### PR TITLE
pimd, pim6d: fix various smaller issues

### DIFF
--- a/include/linux/mroute6.h
+++ b/include/linux/mroute6.h
@@ -63,7 +63,8 @@ typedef	uint32_t	if_mask;
 #define NIFBITS (sizeof(if_mask) * 8)        /* bits per mask */
 
 typedef struct if_set {
-	if_mask ifs_bits[__KERNEL_DIV_ROUND_UP(IF_SETSIZE, NIFBITS)];
+	/* __KERNEL_DIV_ROUND_UP() */
+	if_mask ifs_bits[(IF_SETSIZE + NIFBITS - 1) / NIFBITS];
 } if_set;
 
 #define IF_SET(n, p)    ((p)->ifs_bits[(n)/NIFBITS] |= (1 << ((n) % NIFBITS)))

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -40,6 +40,7 @@
 #include "pim_nb.h"
 #include "pim_addr.h"
 #include "pim_nht.h"
+#include "pim_bsm.h"
 
 
 #ifndef VTYSH_EXTRACT_PL

--- a/pimd/pim6_mroute_msg.c
+++ b/pimd/pim6_mroute_msg.c
@@ -167,10 +167,12 @@ int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 						       msg);
 		case MRT6MSG_WHOLEPKT:
 			return pim_mroute_msg_wholepkt(pim->mroute_socket, ifp,
-							(const char *)msg);
+						       (const char *)msg,
+						       buf_size);
 		case MRT6MSG_WRMIFWHOLE:
-			return pim_mroute_msg_wrvifwhole(
-				pim->mroute_socket, ifp, (const char *)msg);
+			return pim_mroute_msg_wrvifwhole(pim->mroute_socket,
+							 ifp, (const char *)msg,
+							 buf_size);
 		default:
 			break;
 		}

--- a/pimd/pim6_mroute_msg.c
+++ b/pimd/pim6_mroute_msg.c
@@ -29,6 +29,7 @@
 #include "lib/network.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_mroute.h"
 #include "pim_oil.h"
 #include "pim_str.h"

--- a/pimd/pim6_stubs.c
+++ b/pimd/pim6_stubs.c
@@ -25,6 +25,7 @@
 #include "pim_pim.h"
 #include "pim_register.h"
 #include "pim_cmd.h"
+#include "pim_bsm.h"
 
 /*
  * NH lookup / NHT

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -24,6 +24,7 @@
 #include "if.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_str.h"
 #include "pim_tlv.h"
 #include "pim_msg.h"

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -34,6 +34,7 @@
 #include "lib/linklist.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_vty.h"
 #include "lib/northbound_cli.h"
 #include "pim_errors.h"

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -20,6 +20,12 @@
 #ifndef PIM_CMD_COMMON_H
 #define PIM_CMD_COMMON_H
 
+struct pim_upstream;
+struct pim_instance;
+
+/* duplicated from pim_instance.h - needed to avoid dependency mess */
+struct pim_instance *pim_get_pim_instance(vrf_id_t vrf_id);
+
 const char *pim_cli_get_vrf_name(struct vty *vty);
 int pim_process_join_prune_cmd(struct vty *vty, const char *jpi_str);
 int pim_process_no_join_prune_cmd(struct vty *vty);

--- a/pimd/pim_hello.c
+++ b/pimd/pim_hello.c
@@ -23,6 +23,7 @@
 #include "if.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_pim.h"
 #include "pim_str.h"
 #include "pim_tlv.h"

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -30,7 +30,6 @@
 
 #include "pim_igmp.h"
 #include "pim_upstream.h"
-#include "pim_instance.h"
 #include "bfd.h"
 #include "pim_str.h"
 

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -29,6 +29,7 @@
 #include "prefix.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_str.h"
 #include "pim_iface.h"
 #include "pim_ifchannel.h"

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -27,6 +27,7 @@
 #include "lib_errors.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_igmp.h"
 #include "pim_igmpv2.h"
 #include "pim_igmpv3.h"

--- a/pimd/pim_igmp_mtrace.c
+++ b/pimd/pim_igmp_mtrace.c
@@ -22,6 +22,7 @@
 #include <zebra.h>
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_util.h"
 #include "pim_sock.h"
 #include "pim_rp.h"

--- a/pimd/pim_igmpv2.c
+++ b/pimd/pim_igmpv2.c
@@ -21,6 +21,7 @@
 #include "zebra.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_igmp.h"
 #include "pim_igmpv2.h"
 #include "pim_igmpv3.h"

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -24,6 +24,7 @@
 #include "lib_errors.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_iface.h"
 #include "pim_igmp.h"
 #include "pim_igmpv3.h"

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -25,6 +25,7 @@
 #include "lib_errors.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_ssm.h"
 #include "pim_rpf.h"
 #include "pim_rp.h"

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -28,6 +28,7 @@
 #include "plist.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_str.h"
 #include "pim_tlv.h"
 #include "pim_msg.h"

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -25,6 +25,7 @@
 #include "if.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_msg.h"
 #include "pim_jp_agg.h"
 #include "pim_join.h"

--- a/pimd/pim_jp_agg.h
+++ b/pimd/pim_jp_agg.h
@@ -20,6 +20,8 @@
 #ifndef __PIM_JP_AGG_H__
 #define __PIM_JP_AGG_H__
 
+#include "pim_rpf.h"
+
 struct pim_jp_sources {
 	struct pim_upstream *up;
 	int is_join;

--- a/pimd/pim_macro.c
+++ b/pimd/pim_macro.c
@@ -25,6 +25,7 @@
 #include "plist.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_macro.h"
 #include "pim_iface.h"
 #include "pim_ifchannel.h"

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -137,7 +137,8 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 	return 0;
 }
 
-int pim_mroute_msg_wholepkt(int fd, struct interface *ifp, const char *buf)
+int pim_mroute_msg_wholepkt(int fd, struct interface *ifp, const char *buf,
+			    size_t len)
 {
 	struct pim_interface *pim_ifp;
 	pim_sgaddr sg;
@@ -229,7 +230,7 @@ int pim_mroute_msg_wholepkt(int fd, struct interface *ifp, const char *buf)
 		}
 
 		pim_register_send((uint8_t *)buf + sizeof(ipv_hdr),
-				  ntohs(IPV_LEN(ip_hdr)) - sizeof(ipv_hdr),
+				  len - sizeof(ipv_hdr),
 				  pim_ifp->primary_address, rpg, 0, up);
 	}
 	return 0;
@@ -336,7 +337,8 @@ int pim_mroute_msg_wrongvif(int fd, struct interface *ifp, const kernmsg *msg)
 	return 0;
 }
 
-int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp, const char *buf)
+int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp, const char *buf,
+			      size_t len)
 {
 	const ipv_hdr *ip_hdr = (const ipv_hdr *)buf;
 	struct pim_interface *pim_ifp;
@@ -463,7 +465,7 @@ int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp, const char *buf)
 			pim_upstream_keep_alive_timer_start(
 				up, pim_ifp->pim->keep_alive_time);
 			pim_upstream_inherited_olist(pim_ifp->pim, up);
-			pim_mroute_msg_wholepkt(fd, ifp, buf);
+			pim_mroute_msg_wholepkt(fd, ifp, buf, len);
 		}
 		return 0;
 	}
@@ -490,7 +492,7 @@ int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp, const char *buf)
 			pim_upstream_mroute_add(up->channel_oil, __func__);
 
 		// Send the packet to the RP
-		pim_mroute_msg_wholepkt(fd, ifp, buf);
+		pim_mroute_msg_wholepkt(fd, ifp, buf, len);
 	} else {
 		up = pim_upstream_add(pim_ifp->pim, &sg, ifp,
 				      PIM_UPSTREAM_FLAG_MASK_SRC_NOCACHE,

--- a/pimd/pim_mroute.h
+++ b/pimd/pim_mroute.h
@@ -136,6 +136,7 @@ typedef struct sioc_sg_req6 pim_sioc_sg_req;
 */
 
 struct channel_oil;
+struct pim_instance;
 
 int pim_mroute_socket_enable(struct pim_instance *pim);
 int pim_mroute_socket_disable(struct pim_instance *pim);

--- a/pimd/pim_mroute.h
+++ b/pimd/pim_mroute.h
@@ -158,8 +158,10 @@ bool pim_mroute_allow_iif_in_oil(struct channel_oil *c_oil,
 int pim_mroute_msg(struct pim_instance *pim, const char *buf, size_t buf_size,
 		   ifindex_t ifindex);
 int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg);
-int pim_mroute_msg_wholepkt(int fd, struct interface *ifp, const char *buf);
+int pim_mroute_msg_wholepkt(int fd, struct interface *ifp, const char *buf,
+			    size_t len);
 int pim_mroute_msg_wrongvif(int fd, struct interface *ifp, const kernmsg *msg);
-int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp, const char *buf);
+int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp, const char *buf,
+			      size_t len);
 int pim_mroute_set(struct pim_instance *pim, int enable);
 #endif /* PIM_MROUTE_H */

--- a/pimd/pim_mroute_msg.c
+++ b/pimd/pim_mroute_msg.c
@@ -29,6 +29,7 @@
 #include "lib/network.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_mroute.h"
 #include "pim_oil.h"
 #include "pim_str.h"

--- a/pimd/pim_mroute_msg.c
+++ b/pimd/pim_mroute_msg.c
@@ -226,10 +226,12 @@ int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 						      msg);
 		case IGMPMSG_WHOLEPKT:
 			return pim_mroute_msg_wholepkt(pim->mroute_socket, ifp,
-						       (const char *)msg);
+						       (const char *)msg,
+						       buf_size);
 		case IGMPMSG_WRVIFWHOLE:
-			return pim_mroute_msg_wrvifwhole(
-				pim->mroute_socket, ifp, (const char *)msg);
+			return pim_mroute_msg_wrvifwhole(pim->mroute_socket,
+							 ifp, (const char *)msg,
+							 buf_size);
 		default:
 			break;
 		}

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -32,6 +32,7 @@
 
 #include "pimd.h"
 #include "pim_memory.h"
+#include "pim_instance.h"
 #include "pim_iface.h"
 #include "pim_rp.h"
 #include "pim_str.h"

--- a/pimd/pim_msdp_packet.c
+++ b/pimd/pim_msdp_packet.c
@@ -26,6 +26,7 @@
 #include <lib/lib_errors.h>
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_str.h"
 #include "pim_errors.h"
 

--- a/pimd/pim_msdp_socket.c
+++ b/pimd/pim_msdp_socket.c
@@ -29,6 +29,7 @@
 #include <lib/lib_errors.h>
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_sock.h"
 #include "pim_errors.h"
 

--- a/pimd/pim_msg.c
+++ b/pimd/pim_msg.c
@@ -26,6 +26,7 @@
 #include "plist.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_vty.h"
 #include "pim_pim.h"
 #include "pim_msg.h"

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -28,6 +28,7 @@
 #include "lib_errors.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_neighbor.h"
 #include "pim_time.h"
 #include "pim_str.h"

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -30,6 +30,7 @@
 
 #include "pimd.h"
 #include "pimd/pim_nht.h"
+#include "pim_instance.h"
 #include "log.h"
 #include "pim_time.h"
 #include "pim_oil.h"

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -26,6 +26,7 @@
 #include "network.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_pim.h"
 #include "pim_time.h"
 #include "pim_iface.h"

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -34,6 +34,7 @@
 #include "lib_errors.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_vty.h"
 #include "pim_str.h"
 #include "pim_iface.h"

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -27,6 +27,7 @@
 #include "jhash.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_rpf.h"
 #include "pim_pim.h"
 #include "pim_str.h"

--- a/pimd/pim_rpf.h
+++ b/pimd/pim_rpf.h
@@ -23,6 +23,8 @@
 #include <zebra.h>
 #include "pim_str.h"
 
+struct pim_instance;
+
 /*
   RFC 4601:
 

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -37,6 +37,7 @@
 #include "network.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_mroute.h"
 #include "pim_iface.h"
 #include "pim_sock.h"

--- a/pimd/pim_sock.h
+++ b/pimd/pim_sock.h
@@ -35,6 +35,8 @@
 #define PIM_SOCK_ERR_NAME    (-10) /* Socket name (getsockname) */
 #define PIM_SOCK_ERR_BIND    (-11) /* Can't bind to interface */
 
+struct pim_instance;
+
 int pim_socket_bind(int fd, struct interface *ifp);
 void pim_socket_ip_hdr(int fd);
 int pim_socket_raw(int protocol);

--- a/pimd/pim_ssm.c
+++ b/pimd/pim_ssm.c
@@ -27,6 +27,7 @@
 #include <lib/lib_errors.h>
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_ssm.h"
 #include "pim_igmp.h"
 

--- a/pimd/pim_ssm.h
+++ b/pimd/pim_ssm.h
@@ -21,6 +21,8 @@
 
 #define PIM_SSM_STANDARD_RANGE "232.0.0.0/8"
 
+struct pim_instance;
+
 /* SSM error codes */
 enum pim_ssm_err {
 	PIM_SSM_ERR_NONE = 0,

--- a/pimd/pim_ssmpingd.c
+++ b/pimd/pim_ssmpingd.c
@@ -27,6 +27,7 @@
 #include "lib_errors.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_ssmpingd.h"
 #include "pim_time.h"
 #include "pim_sock.h"

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -26,6 +26,7 @@
 #include "linklist.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_oil.h"
 #include "pim_static.h"
 #include "pim_time.h"

--- a/pimd/pim_static.h
+++ b/pimd/pim_static.h
@@ -22,6 +22,7 @@
 
 #include <zebra.h>
 #include "pim_mroute.h"
+#include "pim_oil.h"
 #include "if.h"
 
 struct static_route {

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -22,6 +22,7 @@
 #include "pim_tib.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_iface.h"
 #include "pim_upstream.h"
 #include "pim_oil.h"

--- a/pimd/pim_tlv.c
+++ b/pimd/pim_tlv.c
@@ -24,6 +24,7 @@
 #include "if.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_int.h"
 #include "pim_tlv.h"
 #include "pim_str.h"

--- a/pimd/pim_vty.h
+++ b/pimd/pim_vty.h
@@ -22,6 +22,8 @@
 
 #include "vty.h"
 
+struct pim_instance;
+
 int pim_debug_config_write(struct vty *vty);
 int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty);
 int pim_interface_config_write(struct vty *vty);

--- a/pimd/pim_vxlan.h
+++ b/pimd/pim_vxlan.h
@@ -22,6 +22,8 @@
 #ifndef PIM_VXLAN_H
 #define PIM_VXLAN_H
 
+#include "pim_instance.h"
+
 /* global timer used for miscellaneous staggered processing */
 #define PIM_VXLAN_WORK_TIME 1
 /* number of SG entries processed at one shot */

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -30,6 +30,7 @@
 #include "lib_errors.h"
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_iface.h"
 #include "pim_neighbor.h"
 #include "pim_pim.h"

--- a/pimd/pim_zlookup.h
+++ b/pimd/pim_zlookup.h
@@ -26,6 +26,8 @@
 
 #define PIM_NEXTHOP_LOOKUP_MAX (3) /* max. recursive route lookup */
 
+struct channel_oil;
+
 struct pim_zlookup_nexthop {
 	vrf_id_t vrf_id;
 	pim_addr nexthop_addr;

--- a/pimd/pim_zpthread.c
+++ b/pimd/pim_zpthread.c
@@ -22,6 +22,7 @@
 #include <lib/lib_errors.h>
 
 #include "pimd.h"
+#include "pim_instance.h"
 #include "pim_mlag.h"
 #include "pim_zebra.h"
 

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -28,7 +28,6 @@
 #include "plist.h"
 
 #include "pim_addr.h"
-#include "pim_instance.h"
 #include "pim_str.h"
 #include "pim_memory.h"
 #include "pim_assert.h"


### PR DESCRIPTION
- (v6 change only) `linux/mroute6.h` was using a kernel macro that wasn't always present
- (v4 + v6 change) register message length was mishandled for IPv6, pass down length
- ~~(v4 + v6 change) accept directly connected BSR~~
- (general/build change) try to un-dependency-entagle `pim_instance.h` (should fix BSD compile errors with pim6)