### PR TITLE
bgpd: Send Hard Reset Notification for BGP_NOTIFY_CEASE_ADMIN_RESET

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2009,6 +2009,7 @@ static int bgp_notify_receive(struct peer *peer, bgp_size_t size)
 	if (peer->notify.data) {
 		XFREE(MTYPE_BGP_NOTIFICATION, peer->notify.data);
 		peer->notify.length = 0;
+		peer->notify.hard_reset = false;
 	}
 
 	outer.code = stream_getc(peer->curr);

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -88,7 +88,9 @@ extern void bgp_send_delayed_eor(struct bgp *bgp);
 void bgp_packet_process_error(struct thread *thread);
 extern struct bgp_notify
 bgp_notify_decapsulate_hard_reset(struct bgp_notify *notify);
-extern bool bgp_notify_is_hard_reset(struct peer *peer, uint8_t code,
-				     uint8_t subcode);
+extern bool bgp_notify_send_hard_reset(struct peer *peer, uint8_t code,
+				       uint8_t subcode);
+extern bool bgp_notify_received_hard_reset(struct peer *peer, uint8_t code,
+					   uint8_t subcode);
 
 #endif /* _QUAGGA_BGP_PACKET_H */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -490,6 +490,8 @@ struct bgp {
 #define BGP_FLAG_PEERTYPE_MULTIPATH_RELAX (1 << 29)
 /* Indicate Graceful Restart support for BGP NOTIFICATION messages */
 #define BGP_FLAG_GRACEFUL_NOTIFICATION (1 << 30)
+/* Send Hard Reset CEASE Notification for 'Administrative Reset' */
+#define BGP_FLAG_HARD_ADMIN_RESET (1 << 31)
 
 	/* BGP default address-families.
 	 * New peers inherit enabled afi/safis from bgp instance.

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -501,6 +501,19 @@ Suppress duplicate updates
    Suppress duplicate updates if the route actually not changed.
    Default: enabled.
 
+Send Hard Reset CEASE Notification for Administrative Reset
+-----------------------------------------------------------
+
+.. clicmd:: bgp hard-administrative-reset
+
+   Send Hard Reset CEASE Notification for 'Administrative Reset' events.
+
+   When disabled, and Graceful Restart Notification capability is exchanged
+   between the peers, Graceful Restart procedures apply, and routes will be
+   retained.
+
+   Enabled by default.
+
 Disable checking if nexthop is connected on EBGP sessions
 ---------------------------------------------------------
 


### PR DESCRIPTION
`clear bgp neighbor` should send Hard Reset and graceful restart should be
activated. Let's make this adjustable.

https://datatracker.ietf.org/doc/html/rfc8538#section-5.1

   +-------+------------------------------------+----------------------+
   | Value |                Name                |  Suggested Behavior  |
   +-------+------------------------------------+----------------------+
   |   1   | Maximum Number of Prefixes Reached |      Hard Reset      |
   |   2   |      Administrative Shutdown       |      Hard Reset      |
   |   3   |         Peer De-configured         |      Hard Reset      |
   |   4   |        Administrative Reset        | Provide user control |
   |   5   |        Connection Rejected         |    Graceful Cease    |
   |   6   |     Other Configuration Change     |    Graceful Cease    |
   |   7   |  Connection Collision Resolution   |    Graceful Cease    |
   |   8   |          Out of Resources          |    Graceful Cease    |
   |   9   |             Hard Reset             |      Hard Reset      |
   +-------+------------------------------------+----------------------+

Enabled by default.

Co-authored-by: Biswajit Sadhu <biswajit.sadhu@gmail.com>
Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>