### PR TITLE
zebra, ospf6d: Do not check if NULL for XCALLOC()

### DIFF
--- a/ospf6d/ospf6_auth_trailer.c
+++ b/ospf6d/ospf6_auth_trailer.c
@@ -144,8 +144,6 @@ unsigned char *ospf6_hash_message_xor(unsigned char *mes1,
 	uint32_t i;
 
 	result = XCALLOC(MTYPE_OSPF6_AUTH_HASH_XOR, len);
-	if (!result)
-		return NULL;
 
 	for (i = 0; i < len; i++)
 		result[i] = mes1[i] ^ mes2[i];

--- a/zebra/table_manager.c
+++ b/zebra/table_manager.c
@@ -119,8 +119,6 @@ struct table_manager_chunk *assign_table_chunk(uint8_t proto, uint16_t instance,
 	}
 	/* otherwise create a new one */
 	tmc = XCALLOC(MTYPE_TM_CHUNK, sizeof(struct table_manager_chunk));
-	if (!tmc)
-		return NULL;
 
 	if (zvrf->tbl_mgr->start || zvrf->tbl_mgr->end)
 		manual_conf = true;


### PR DESCRIPTION
Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>