### PR TITLE
tests: [PIMv6] Added APIs for multicast PIMv6 config

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -449,6 +449,8 @@ def check_router_status(tgen):
                     daemons.append("zebra")
                 if "pimd" in result:
                     daemons.append("pimd")
+                if "pim6d" in result:
+                    daemons.append("pim6d")
                 if "ospfd" in result:
                     daemons.append("ospfd")
                 if "ospf6d" in result:
@@ -1035,6 +1037,12 @@ def start_topology(tgen, daemon=None):
                 TopoRouter.RD_PIM, "{}/{}/pimd.conf".format(tgen.logdir, rname)
             )
 
+        if daemon and "pim6d" in daemon:
+            # Loading empty pimd.conf file to router, to start the pim6d deamon
+            router.load_config(
+                TopoRouter.RD_PIM6, "{}/{}/pim6d.conf".format(tgen.logdir, rname)
+            )
+
     # Starting routers
     logger.info("Starting all routers once topology is created")
     tgen.start_router()
@@ -1131,6 +1139,8 @@ def topo_daemons(tgen, topo=None):
         for val in topo["routers"][rtr]["links"].values():
             if "pim" in val and "pimd" not in daemon_list:
                 daemon_list.append("pimd")
+            if "pim6" in val and "pim6d" not in daemon_list:
+                daemon_list.append("pim6d")
             if "ospf" in val and "ospfd" not in daemon_list:
                 daemon_list.append("ospfd")
             if "ospf6" in val and "ospf6d" not in daemon_list:
@@ -3231,6 +3241,86 @@ def configure_interface_mac(tgen, input_dict):
                 logger.error(errormsg)
                 return errormsg
 
+    return True
+
+
+def socat_send_igmp_join_traffic(
+    tgen,
+    server,
+    protocol_option,
+    igmp_groups,
+    send_from_intf,
+    send_from_intf_ip=None,
+    port=12345,
+    reuseaddr=True,
+    join=False,
+    traffic=False,
+):
+    """
+    API to send IGMP join using SOCAT tool
+
+    Parameters:
+    -----------
+    * `tgen`  : Topogen object
+    * `server`: iperf server, from where IGMP join would be sent
+    * `protocol_option`: Protocol options, ex: UDP6-RECV
+    * `igmp_groups`: IGMP group for which join has to be sent
+    * `send_from_intf`: Interface from which join would be sent
+    * `send_from_intf_ip`: Interface IP, default is None
+    * `port`: Port to be used, default is 12345
+    * `reuseaddr`: True|False, bydefault True
+    * `join`: If join needs to be sent
+    * `traffic`: If traffic needs to be sent
+
+    returns:
+    --------
+    errormsg or True
+    """
+
+    logger.debug("Entering lib API: {}".format(sys._getframe().f_code.co_name))
+
+    rnode = tgen.routers()[server]
+    socat_cmd = "socat -u "
+
+    # UDP4/TCP4/UDP6/UDP6-RECV
+    if protocol_option:
+        socat_cmd += "{}".format(protocol_option)
+
+    if port:
+        socat_cmd += ":{},".format(port)
+
+    if reuseaddr:
+        socat_cmd += "{},".format("reuseaddr")
+
+    # Group address range to cover
+    if igmp_groups:
+        if not isinstance(igmp_groups, list):
+            igmp_groups = [igmp_groups]
+
+    for igmp_group in igmp_groups:
+        if join:
+            join_traffic_option = "ipv6-join-group"
+        elif traffic:
+            join_traffic_option = "ipv6-join-group-source"
+
+        if send_from_intf and not send_from_intf_ip:
+            socat_cmd += "{}='[{}]:{}'".format(
+                join_traffic_option, igmp_group, send_from_intf
+            )
+        else:
+            socat_cmd += "{}='[{}]:{}:[{}]'".format(
+                join_traffic_option, igmp_group, send_from_intf, send_from_intf_ip
+            )
+
+        socat_cmd += " STDOUT"
+
+        socat_cmd += " &>{}/socat.logs &".format(tgen.logdir)
+
+        # Run socat command to send IGMP join
+        logger.info("[DUT: {}]: Running command: [{}]".format(server, socat_cmd))
+        output = rnode.run("set +m; {} sleep 0.5".format(socat_cmd))
+
+    logger.debug("Exiting lib API: {}".format(sys._getframe().f_code.co_name))
     return True
 
 

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -725,6 +725,7 @@ class TopoRouter(TopoGear):
     RD_PBRD = 16
     RD_PATH = 17
     RD_SNMP = 18
+    RD_PIM6 = 19
     RD = {
         RD_FRR: "frr",
         RD_ZEBRA: "zebra",
@@ -735,6 +736,7 @@ class TopoRouter(TopoGear):
         RD_ISIS: "isisd",
         RD_BGP: "bgpd",
         RD_PIM: "pimd",
+        RD_PIM6: "pim6d",
         RD_LDP: "ldpd",
         RD_EIGRP: "eigrpd",
         RD_NHRP: "nhrpd",
@@ -820,7 +822,8 @@ class TopoRouter(TopoGear):
         Possible daemon values are: TopoRouter.RD_ZEBRA, TopoRouter.RD_RIP,
         TopoRouter.RD_RIPNG, TopoRouter.RD_OSPF, TopoRouter.RD_OSPF6,
         TopoRouter.RD_ISIS, TopoRouter.RD_BGP, TopoRouter.RD_LDP,
-        TopoRouter.RD_PIM, TopoRouter.RD_PBR, TopoRouter.RD_SNMP.
+        TopoRouter.RD_PIM, TopoRouter.RD_PIM6, TopoRouter.RD_PBR,
+        TopoRouter.RD_SNMP.
 
         Possible `source` values are `None` for an empty config file, a path name which is
         used directly, or a file name with no path components which is first looked for
@@ -1276,6 +1279,7 @@ def diagnose_env_linux(rundir):
             "ripngd",
             "isisd",
             "pimd",
+            "pim6d",
             "ldpd",
             "pbrd",
         ]:

--- a/tests/topotests/lib/topojson.py
+++ b/tests/topotests/lib/topojson.py
@@ -41,7 +41,11 @@ from lib.common_config import (
     number_to_column,
 )
 from lib.ospf import create_router_ospf
-from lib.pim import create_igmp_config, create_pim_config
+from lib.pim import (
+    create_igmp_config,
+    create_pim_config,
+    create_mld_config,
+)
 from lib.topolog import logger
 
 
@@ -332,6 +336,7 @@ def build_config_from_json(tgen, topo=None, save_bkup=True):
             ("route_maps", create_route_maps),
             ("pim", create_pim_config),
             ("igmp", create_igmp_config),
+            ("mld", create_mld_config),
             ("bgp", create_router_bgp),
             ("ospf", create_router_ospf),
         ]
@@ -352,7 +357,9 @@ def build_config_from_json(tgen, topo=None, save_bkup=True):
         logger.info("build_config_from_json: failed to configure topology")
         pytest.exit(1)
 
-    logger.info("Built config now clearing ospf neighbors as that router-id might not be what is used")
+    logger.info(
+        "Built config now clearing ospf neighbors as that router-id might not be what is used"
+    )
     for ospf in ["ospf", "ospf6"]:
         for router in data:
             if ospf not in data[router]:

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1330,6 +1330,7 @@ class Router(Node):
             "isisd": 0,
             "bgpd": 0,
             "pimd": 0,
+            "pim6d": 0,
             "ldpd": 0,
             "eigrpd": 0,
             "nhrpd": 0,

--- a/tests/topotests/multicast_pim_static_rp_topo1/multicast_pimv6_static_rp.json
+++ b/tests/topotests/multicast_pim_static_rp_topo1/multicast_pimv6_static_rp.json
@@ -1,0 +1,197 @@
+{
+    "address_types": ["ipv6"],
+    "ipv6base": "fd00::",
+    "ipv6mask": 64,
+    "link_ip_start": {
+        "ipv6": "fd00::",
+        "v6mask": 64
+    },
+    "lo_prefix": {
+        "ipv6": "2001:db8:f::",
+        "v6mask": 128
+    },
+    "routers": {
+        "r0": {
+            "links": {
+                "r1": {"ipv6": "auto"}
+            }
+        },
+        "r1": {
+            "links": {
+                "lo": {"ipv6": "auto", "type": "loopback", "pim6": "enable",
+                "ospf6": {
+                    "area": "0.0.0.0",
+                    "hello_interval": 1,
+                    "dead_interval": 4
+                }},
+                "r0": {"ipv6": "auto", "pim6": "enable"},
+                "r2": {"ipv6": "auto", "pim6": "enable",
+                "ospf6": {
+                    "area": "0.0.0.0",
+                    "hello_interval": 1,
+                    "dead_interval": 4
+                }},
+                "r3": {"ipv6": "auto", "pim6": "enable",
+                "ospf6": {
+                    "area": "0.0.0.0",
+                    "hello_interval": 1,
+                    "dead_interval": 4
+                }},
+                "r4": {"ipv6": "auto", "pim6": "enable",
+                "ospf6": {
+                    "area": "0.0.0.0",
+                    "hello_interval": 1,
+                    "dead_interval": 4
+                }}
+            },
+            "ospf6": {
+                "router_id": "100.1.1.0",
+                "neighbors": {
+                    "r2": {},
+                    "r3": {},
+                    "r4": {}
+                },
+                "redistribute": [
+                    {
+                        "redist_type": "static"
+                    },
+                    {
+                        "redist_type": "connected"
+                    }
+                ]
+            },
+            "mld": {
+                "interfaces": {
+                    "r1-r0-eth0" :{
+                        "mld":{
+                        }
+                    }
+                }
+            }
+        },
+        "r2": {
+            "links": {
+                "lo": {"ipv6": "auto", "type": "loopback", "pim6": "enable",
+                "ospf6": {
+                    "area": "0.0.0.0",
+                    "hello_interval": 1,
+                    "dead_interval": 4
+                }},
+                "r1": {"ipv6": "auto", "pim6": "enable",
+                "ospf6": {
+                    "area": "0.0.0.0",
+                    "hello_interval": 1,
+                    "dead_interval": 4
+                }},
+                "r3": {"ipv6": "auto", "pim6": "enable",
+                "ospf6": {
+                    "area": "0.0.0.0",
+                    "hello_interval": 1,
+                    "dead_interval": 4
+                }}
+            },
+            "ospf6": {
+                "router_id": "100.1.1.1",
+                "neighbors": {
+                    "r1": {},
+                    "r3": {}
+                },
+                "redistribute": [
+                    {
+                        "redist_type": "static"
+                    },
+                    {
+                        "redist_type": "connected"
+                    }
+                ]
+            }
+        },
+        "r3": {
+            "links": {
+                "lo": {"ipv6": "auto", "type": "loopback", "pim6": "enable",
+                "ospf6": {
+                    "area": "0.0.0.0",
+                    "hello_interval": 1,
+                    "dead_interval": 4
+                }},
+                "r1": {"ipv6": "auto", "pim6": "enable",
+                "ospf6": {
+                    "area": "0.0.0.0",
+                    "hello_interval": 1,
+                    "dead_interval": 4
+                }},
+                "r2": {"ipv6": "auto", "pim6": "enable",
+                "ospf6": {
+                    "area": "0.0.0.0",
+                    "hello_interval": 1,
+                    "dead_interval": 4
+                }},
+                "r4": {"ipv6": "auto", "pim6": "enable",
+                "ospf6": {
+                    "area": "0.0.0.0",
+                    "hello_interval": 1,
+                    "dead_interval": 4
+                }},
+                "r5": {"ipv6": "auto", "pim6": "enable"}
+            },
+            "ospf6": {
+                "router_id": "100.1.1.2",
+                "neighbors": {
+                    "r1": {},
+                    "r2": {},
+                    "r4": {}
+                },
+                "redistribute": [
+                    {
+                        "redist_type": "static"
+                    },
+                    {
+                        "redist_type": "connected"
+                    }
+                ]
+            }
+        },
+        "r4": {
+            "links": {
+                "lo": {"ipv6": "auto", "type": "loopback", "pim6": "enable",
+                "ospf6": {
+                    "area": "0.0.0.0",
+                    "hello_interval": 1,
+                    "dead_interval": 4
+                }},
+                "r1": {"ipv6": "auto", "pim6": "enable",
+                "ospf6": {
+                    "area": "0.0.0.0",
+                    "hello_interval": 1,
+                    "dead_interval": 4
+                }},
+                "r3": {"ipv6": "auto", "pim6": "enable",
+                "ospf6": {
+                    "area": "0.0.0.0",
+                    "hello_interval": 1,
+                    "dead_interval": 4
+                }}
+            },
+            "ospf6": {
+                "router_id": "100.1.1.3",
+                "neighbors": {
+                    "r1": {},
+                    "r3": {}
+                },
+                "redistribute": [
+                    {
+                        "redist_type": "static"
+                    },
+                    {
+                        "redist_type": "connected"
+                    }
+                ]
+            }
+        },
+        "r5": {
+            "links": {
+                "r3": {"ipv6": "auto"}
+            }
+        }
+    }
+}

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pimv6_static_rp.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pimv6_static_rp.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python
+
+#
+# Copyright (c) 2022 by VMware, Inc. ("VMware")
+# Used Copyright (c) 2018 by Network Device Education Foundation,
+# Inc. ("NetDEF") in this file.
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND VMWARE DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL VMWARE BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+Following tests are covered to test Multicast basic functionality:
+
+Topology:
+
+                 _______r2_____
+                |             |
+      iperf     |             |     iperf
+        r0-----r1-------------r3-----r5
+                |             |
+                |_____________|
+                        r4
+
+Test steps
+- Create topology (setup module)
+- Bring up topology
+
+TC_1 : Verify upstream interfaces(IIF) and join state are updated properly
+       after adding and deleting the static RP
+TC_2 : Verify IIF and OIL in "show ip pim state" updated properly after
+       adding and deleting the static RP
+TC_3: (*, G) Mroute entry are cleared when static RP gets deleted
+TC_4: Verify (*,G) prune is send towards the RP after deleting the static RP
+TC_24 : Verify (*,G) and (S,G) populated correctly when SPT and RPT share the
+        same path
+"""
+
+import os
+import sys
+import json
+import time
+import pytest
+from time import sleep
+import datetime
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+sys.path.append(os.path.join(CWD, "../lib/"))
+
+# Required to instantiate the topology builder class.
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib.topogen import Topogen, get_topogen
+
+from lib.common_config import (
+    start_topology,
+    write_test_header,
+    write_test_footer,
+    reset_config_on_routers,
+    step,
+    shutdown_bringup_interface,
+    kill_router_daemons,
+    start_router_daemons,
+    create_static_routes,
+    check_router_status,
+    socat_send_igmp_join_traffic,
+    topo_daemons
+)
+from lib.pim import (
+    create_pim_config,
+    verify_igmp_groups,
+    verify_upstream_iif,
+    verify_join_state_and_timer,
+    verify_mroutes,
+    verify_pim_neighbors,
+    verify_pim_interface_traffic,
+    verify_pim_rp_info,
+    verify_pim_state,
+    clear_pim_interface_traffic,
+    clear_igmp_interfaces,
+    clear_pim_interfaces,
+    clear_mroute,
+    clear_mroute_verify,
+)
+from lib.topolog import logger
+from lib.topojson import build_topo_from_json, build_config_from_json
+
+# Global variables
+GROUP_RANGE_V6 = "ff08::/64"
+IGMP_JOIN_V6 = "ff08::1"
+STAR = "*"
+SOURCE = "Static"
+
+pytestmark = [pytest.mark.pimd]
+
+
+def build_topo(tgen):
+    """Build function"""
+
+    # Building topology from json file
+    build_topo_from_json(tgen, TOPO)
+
+
+def setup_module(mod):
+    """
+    Sets up the pytest environment
+
+    * `mod`: module name
+    """
+
+    testsuite_run_time = time.asctime(time.localtime(time.time()))
+    logger.info("Testsuite start time: %s", testsuite_run_time)
+    logger.info("=" * 40)
+
+    topology = """
+
+                 _______r2_____
+                |             |
+      iperf     |             |     iperf
+        r0-----r1-------------r3-----r5
+                |             |
+                |_____________|
+                        r4
+
+    """
+    logger.info("Master Topology: \n %s", topology)
+
+    logger.info("Running setup_module to create topology")
+
+    # This function initiates the topology build with Topogen...
+    json_file = "{}/multicast_pimv6_static_rp.json".format(CWD)
+    tgen = Topogen(json_file, mod.__name__)
+    global TOPO
+    TOPO = tgen.json_topo
+
+    # ... and here it calls Mininet initialization functions.
+
+    # get list of daemons needs to be started for this suite.
+    daemons = topo_daemons(tgen, TOPO)
+
+    # Starting topology, create tmp files which are loaded to routers
+    #  to start daemons and then start routers
+    start_topology(tgen, daemons)
+
+    # Don"t run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Creating configuration from JSON
+    build_config_from_json(tgen, TOPO)
+
+    # Verify PIM neighbors
+    result = verify_pim_neighbors(tgen, TOPO)
+    assert result is True, "setup_module :Failed \n Error:" " {}".format(result)
+
+    logger.info("Running setup_module() done")
+
+
+def teardown_module():
+    """Teardown the pytest environment"""
+
+    logger.info("Running teardown_module to delete topology")
+    tgen = get_topogen()
+
+    # Stop toplogy and Remove tmp files
+    tgen.stop_topology()
+
+    logger.info("Testsuite end time: %s", time.asctime(time.localtime(time.time())))
+    logger.info("=" * 40)
+
+
+#####################################################
+#
+#   Testcases
+#
+#####################################################
+
+
+def verify_state_incremented(state_before, state_after):
+    """
+    API to compare interface traffic state incrementing
+
+    Parameters
+    ----------
+    * `state_before` : State dictionary for any particular instance
+    * `state_after` : State dictionary for any particular instance
+    """
+
+    for router, state_data in state_before.items():
+        for state, value in state_data.items():
+            if state_before[router][state] >= state_after[router][state]:
+                errormsg = (
+                    "[DUT: %s]: state %s value has not"
+                    " incremented, Initial value: %s, "
+                    "Current value: %s [FAILED!!]"
+                    % (
+                        router,
+                        state,
+                        state_before[router][state],
+                        state_after[router][state],
+                    )
+                )
+                return errormsg
+
+            logger.info(
+                "[DUT: %s]: State %s value is "
+                "incremented, Initial value: %s, Current value: %s"
+                " [PASSED!!]",
+                router,
+                state,
+                state_before[router][state],
+                state_after[router][state],
+            )
+
+    return True
+
+
+#####################################################
+
+def test_pimv6_add_delete_static_RP_p0(request):
+    """
+    TC_1: Verify upstream interfaces(IIF) and join state are updated
+        properly after adding and deleting the static RP
+    TC_2: Verify IIF and OIL in "show ip pim state" updated properly
+        after adding and deleting the static RP
+    TC_3: (*, G) Mroute entry are cleared when static RP gets deleted
+    TC_4: Verify (*,G) prune is send towards the RP after deleting the
+        static RP
+
+    TOPOlogy used:
+         r0------r1-----r2
+       iperf    DUT     RP
+    """
+
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    # Don"t run this test if we have any failure.
+    if tgen.routers_have_failure():
+        check_router_status(tgen)
+
+    step("Shut link b/w R1 and R3")
+    intf = TOPO["routers"]["r1"]["links"]["r3"]["interface"]
+    shutdown_bringup_interface(tgen, "r1", intf, ifaceaction=False)
+
+    step("Enable PIM between r1 and r2")
+    step("Enable MLD on r1 interface and send IGMP " "join (FF08::1) to r1")
+    step("Configure r2 loopback interface as RP")
+    input_dict = {
+        "r2": {
+            "pim6": {
+                "rp": [
+                    {
+                        "rp_addr": TOPO["routers"]["r2"]["links"]["lo"]["ipv6"].split(
+                            "/"
+                        )[0],
+                        "group_addr_range": GROUP_RANGE_V6,
+                    }
+                ]
+            }
+        }
+    }
+
+    result = create_pim_config(tgen, TOPO, input_dict)
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    step("Verify show ip pim interface traffic without any mld join")
+    state_dict = {
+        "r1": {TOPO["routers"]["r1"]["links"]["r2"]["interface"]: ["pruneTx"]}
+    }
+
+    state_before = verify_pim_interface_traffic(tgen, state_dict, addr_type="ipv6")
+    assert isinstance(
+        state_before, dict
+    ), "Testcase{} : Failed \n state_before is not dictionary \n " "Error: {}".format(
+        tc_name, result
+    )
+
+    step("send mld join (FF08::1) to R1")
+    intf = TOPO["routers"]["r0"]["links"]["r1"]["interface"]
+    intf_ip = TOPO["routers"]["r0"]["links"]["r1"]["ipv6"].split("/")[0]
+    result = socat_send_igmp_join_traffic(
+        tgen, "r0", "UDP6-RECV", IGMP_JOIN_V6, intf, intf_ip, join=True
+    )
+    assert result is True, "Testcase {}: Failed Error: {}".format(tc_name, result)
+
+    step("r1: Verify RP info")
+    dut = "r1"
+    oif = TOPO["routers"]["r1"]["links"]["r2"]["interface"]
+    iif = TOPO["routers"]["r1"]["links"]["r0"]["interface"]
+    rp_address = TOPO["routers"]["r2"]["links"]["lo"]["ipv6"].split("/")[0]
+    result = verify_pim_rp_info(
+        tgen, TOPO, dut, GROUP_RANGE_V6, oif, rp_address, SOURCE
+    )
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    step("r1: Verify upstream IIF interface")
+    result = verify_upstream_iif(tgen, dut, oif, STAR, IGMP_JOIN_V6)
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    step("r1: Verify upstream join state and join timer")
+    result = verify_join_state_and_timer(tgen, dut, oif, STAR, IGMP_JOIN_V6)
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    step("r1: Verify PIM state")
+    result = verify_pim_state(tgen, dut, oif, iif, IGMP_JOIN_V6)
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    step("r1: Verify ip mroutes")
+    result = verify_mroutes(tgen, dut, STAR, IGMP_JOIN_V6, oif, iif)
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    step("r1: Delete RP configuration")
+    input_dict = {
+        "r2": {
+            "pim6": {
+                "rp": [
+                    {
+                        "rp_addr": TOPO["routers"]["r2"]["links"]["lo"]["ipv6"].split(
+                            "/"
+                        )[0],
+                        "group_addr_range": GROUP_RANGE_V6,
+                        "delete": True,
+                    }
+                ]
+            }
+        }
+    }
+
+    result = create_pim_config(tgen, TOPO, input_dict)
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    step("r1: Verify RP info")
+    result = verify_pim_rp_info(
+        tgen, TOPO, dut, GROUP_RANGE_V6, oif, rp_address, SOURCE, expected=False
+    )
+    assert (
+        result is not True
+    ), "Testcase {} :Failed \n " "RP: {} info is still present \n Error: {}".format(
+        tc_name, rp_address, result
+    )
+
+    step("r1: Verify upstream IIF interface")
+    result = verify_upstream_iif(tgen, dut, oif, STAR, IGMP_JOIN_V6, expected=False)
+    assert result is not True, (
+        "Testcase {} :Failed \n "
+        "Upstream ({}, {}) is still in join state \n Error: {}".format(
+            tc_name, STAR, IGMP_JOIN_V6, result
+        )
+    )
+
+    step("r1: Verify upstream join state and join timer")
+    result = verify_join_state_and_timer(
+        tgen, dut, oif, STAR, IGMP_JOIN_V6, expected=False
+    )
+    assert result is not True, (
+        "Testcase {} :Failed \n "
+        "Upstream ({}, {}) timer is still running \n Error: {}".format(
+            tc_name, STAR, IGMP_JOIN_V6, result
+        )
+    )
+
+    step("r1: Verify PIM state")
+    result = verify_pim_state(tgen, dut, oif, iif, IGMP_JOIN_V6, expected=False)
+    assert result is not True, (
+        "Testcase {} :Failed \n "
+        "PIM state for group: {} is still Active \n Error: {}".format(
+            tc_name, IGMP_JOIN_V6, result
+        )
+    )
+
+    step("r1: Verify ip mroutes")
+    result = verify_mroutes(tgen, dut, STAR, IGMP_JOIN_V6, oif, iif, expected=False)
+    assert result is not True, (
+        "Testcase {} :Failed \n "
+        "mroute ({}, {}) is still present \n Error: {}".format(
+            tc_name, STAR, IGMP_JOIN_V6, result
+        )
+    )
+
+    step("r1: Verify show ip pim interface traffic without any IGMP join")
+    state_after = verify_pim_interface_traffic(tgen, state_dict, addr_type="ipv6")
+    assert isinstance(
+        state_after, dict
+    ), "Testcase{} : Failed \n state_before is not dictionary \n " "Error: {}".format(
+        tc_name, result
+    )
+
+    result = verify_state_incremented(state_before, state_after)
+    assert result is True, "Testcase{} : Failed Error: {}".format(tc_name, result)
+
+    write_test_footer(tc_name)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Enhanced few exsiting PIM APIs to support both
IPv4 and IPv6 configuration. Added few new APIs
for PIMv6. Tested all existing tests with new
API changes.

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>