### PR TITLE
mgmtd: Revert changes related to local validation.

### DIFF
--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -106,7 +106,9 @@ static int nb_node_new_cb(const struct lysc_node *snode, void *arg)
 {
 	struct nb_node *nb_node;
 	struct lysc_node *sparent, *sparent_list;
+	struct frr_yang_module_info *module;
 
+	module = (struct frr_yang_module_info *)arg;
 	nb_node = XCALLOC(MTYPE_NB_NODE, sizeof(*nb_node));
 	yang_snode_get_path(snode, YANG_PATH_DATA, nb_node->xpath,
 			    sizeof(nb_node->xpath));
@@ -140,6 +142,9 @@ static int nb_node_new_cb(const struct lysc_node *snode, void *arg)
 	nb_node->snode = snode;
 	assert(snode->priv == NULL);
 	((struct lysc_node *)snode)->priv = nb_node;
+
+	if (module && module->ignore_cbs)
+		SET_FLAG(nb_node->flags, F_NB_NODE_IGNORE_CBS);
 
 	return YANG_ITER_CONTINUE;
 }
@@ -242,6 +247,9 @@ static unsigned int nb_node_validate_cbs(const struct nb_node *nb_node)
 
 {
 	unsigned int error = 0;
+
+	if (CHECK_FLAG(nb_node->flags, F_NB_NODE_IGNORE_CBS))
+		return error;
 
 	error += nb_node_validate_cb(nb_node, NB_OP_CREATE,
 				     !!nb_node->cbs.create, false);
@@ -1213,6 +1221,8 @@ static int nb_callback_create(struct nb_context *context,
 	bool unexpected_error = false;
 	int ret;
 
+	assert(!CHECK_FLAG(nb_node->flags, F_NB_NODE_IGNORE_CBS));
+
 	nb_log_config_callback(event, NB_OP_CREATE, dnode);
 
 	args.context = context;
@@ -1261,6 +1271,8 @@ static int nb_callback_modify(struct nb_context *context,
 	struct nb_cb_modify_args args = {};
 	bool unexpected_error = false;
 	int ret;
+
+	assert(!CHECK_FLAG(nb_node->flags, F_NB_NODE_IGNORE_CBS));
 
 	nb_log_config_callback(event, NB_OP_MODIFY, dnode);
 
@@ -1311,6 +1323,8 @@ static int nb_callback_destroy(struct nb_context *context,
 	bool unexpected_error = false;
 	int ret;
 
+	assert(!CHECK_FLAG(nb_node->flags, F_NB_NODE_IGNORE_CBS));
+
 	nb_log_config_callback(event, NB_OP_DESTROY, dnode);
 
 	args.context = context;
@@ -1353,6 +1367,8 @@ static int nb_callback_move(struct nb_context *context,
 	struct nb_cb_move_args args = {};
 	bool unexpected_error = false;
 	int ret;
+
+	assert(!CHECK_FLAG(nb_node->flags, F_NB_NODE_IGNORE_CBS));
 
 	nb_log_config_callback(event, NB_OP_MOVE, dnode);
 
@@ -1397,6 +1413,9 @@ static int nb_callback_pre_validate(struct nb_context *context,
 	bool unexpected_error = false;
 	int ret;
 
+	if (CHECK_FLAG(nb_node->flags, F_NB_NODE_IGNORE_CBS))
+		return 0;
+
 	nb_log_config_callback(NB_EV_VALIDATE, NB_OP_PRE_VALIDATE, dnode);
 
 	args.dnode = dnode;
@@ -1428,6 +1447,9 @@ static void nb_callback_apply_finish(struct nb_context *context,
 {
 	struct nb_cb_apply_finish_args args = {};
 
+	if (CHECK_FLAG(nb_node->flags, F_NB_NODE_IGNORE_CBS))
+		return;
+
 	nb_log_config_callback(NB_EV_APPLY, NB_OP_APPLY_FINISH, dnode);
 
 	args.context = context;
@@ -1442,6 +1464,9 @@ struct yang_data *nb_callback_get_elem(const struct nb_node *nb_node,
 				       const void *list_entry)
 {
 	struct nb_cb_get_elem_args args = {};
+
+	if (CHECK_FLAG(nb_node->flags, F_NB_NODE_IGNORE_CBS))
+		return NULL;
 
 	DEBUGD(&nb_dbg_cbs_state,
 	       "northbound callback (get_elem): xpath [%s] list_entry [%p]",
@@ -1458,6 +1483,9 @@ const void *nb_callback_get_next(const struct nb_node *nb_node,
 {
 	struct nb_cb_get_next_args args = {};
 
+	if (CHECK_FLAG(nb_node->flags, F_NB_NODE_IGNORE_CBS))
+		return NULL;
+
 	DEBUGD(&nb_dbg_cbs_state,
 	       "northbound callback (get_next): node [%s] parent_list_entry [%p] list_entry [%p]",
 	       nb_node->xpath, parent_list_entry, list_entry);
@@ -1471,6 +1499,9 @@ int nb_callback_get_keys(const struct nb_node *nb_node, const void *list_entry,
 			 struct yang_list_keys *keys)
 {
 	struct nb_cb_get_keys_args args = {};
+
+	if (CHECK_FLAG(nb_node->flags, F_NB_NODE_IGNORE_CBS))
+		return 0;
 
 	DEBUGD(&nb_dbg_cbs_state,
 	       "northbound callback (get_keys): node [%s] list_entry [%p]",
@@ -1487,6 +1518,9 @@ const void *nb_callback_lookup_entry(const struct nb_node *nb_node,
 {
 	struct nb_cb_lookup_entry_args args = {};
 
+	if (CHECK_FLAG(nb_node->flags, F_NB_NODE_IGNORE_CBS))
+		return NULL;
+
 	DEBUGD(&nb_dbg_cbs_state,
 	       "northbound callback (lookup_entry): node [%s] parent_list_entry [%p]",
 	       nb_node->xpath, parent_list_entry);
@@ -1501,6 +1535,9 @@ int nb_callback_rpc(const struct nb_node *nb_node, const char *xpath,
 		    size_t errmsg_len)
 {
 	struct nb_cb_rpc_args args = {};
+
+	if (CHECK_FLAG(nb_node->flags, F_NB_NODE_IGNORE_CBS))
+		return 0;
 
 	DEBUGD(&nb_dbg_cbs_rpc, "northbound RPC: %s", xpath);
 
@@ -1527,6 +1564,9 @@ static int nb_callback_configuration(struct nb_context *context,
 	const struct lyd_node *dnode = change->cb.dnode;
 	union nb_resource *resource;
 	int ret = NB_ERR;
+
+	if (CHECK_FLAG(nb_node->flags, F_NB_NODE_IGNORE_CBS))
+		return NB_OK;
 
 	if (event == NB_EV_VALIDATE)
 		resource = NULL;
@@ -1925,7 +1965,7 @@ static int nb_oper_data_iter_list(const struct nb_node *nb_node,
 	/* Iterate over all list entries. */
 	do {
 		const struct lysc_node_leaf *skey;
-		struct yang_list_keys list_keys;
+		struct yang_list_keys list_keys = {};
 		char xpath[XPATH_MAXLEN * 2];
 		int ret;
 
@@ -2585,6 +2625,10 @@ const char *nb_client_name(enum nb_client client)
 
 static void nb_load_callbacks(const struct frr_yang_module_info *module)
 {
+
+	if (module->ignore_cbs)
+		return;
+
 	for (size_t i = 0; module->nodes[i].xpath; i++) {
 		struct nb_node *nb_node;
 		uint32_t priority;
@@ -2658,7 +2702,8 @@ void nb_init(struct thread_master *tm,
 
 	/* Initialize the compiled nodes with northbound data */
 	for (size_t i = 0; i < nmodules; i++) {
-		yang_snodes_iterate(loaded[i]->info, nb_node_new_cb, 0, NULL);
+		yang_snodes_iterate(loaded[i]->info, nb_node_new_cb, 0,
+				    (void *)modules[i]);
 		nb_load_callbacks(modules[i]);
 	}
 

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -610,6 +610,8 @@ struct nb_node {
 #define F_NB_NODE_CONFIG_ONLY 0x01
 /* The YANG list doesn't contain key leafs. */
 #define F_NB_NODE_KEYLESS_LIST 0x02
+/* Ignore callbacks for this node */
+#define F_NB_NODE_IGNORE_CBS 0x04
 
 /*
  * HACK: old gcc versions (< 5.x) have a bug that prevents C99 flexible arrays
@@ -621,6 +623,12 @@ struct nb_node {
 struct frr_yang_module_info {
 	/* YANG module name. */
 	const char *name;
+
+	/*
+	 * Ignore callbacks for this module. Set this to true to
+	 * load module without any callbacks.
+	 */
+	bool ignore_cbs;
 
 	/* Northbound callbacks. */
 	const struct {

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -124,10 +124,24 @@ static struct mgmt_be_adapter_list_head mgmt_be_adapters;
 static struct mgmt_be_client_adapter
 	*mgmt_be_adapters_by_id[MGMTD_BE_CLIENT_ID_MAX];
 
+
+/*
+ * List of YANG modules for every Backend Clients gets added here.
+ * These will typically have to be prototyped in mgmtd_be_adapter.h
+ * and then added under mgmt_yang_modules[] in mgmt_main.c.
+ *
+ * NOTE: The .ignore_cbs for all entries to be set to 'true' to
+ * avoid validating backend northbound callback loading.
+ */
+const struct frr_yang_module_info frr_mgmt_staticd_info = {
+	.name = "frr-staticd",
+	.ignore_cbs = true
+};
+
 /* Forward declarations */
 static void
 mgmt_be_adapter_register_event(struct mgmt_be_client_adapter *adapter,
-				enum mgmt_be_event event);
+			       enum mgmt_be_event event);
 
 static struct mgmt_be_client_adapter *
 mgmt_be_find_adapter_by_fd(int conn_fd)

--- a/mgmtd/mgmt_be_adapter.h
+++ b/mgmtd/mgmt_be_adapter.h
@@ -117,9 +117,15 @@ union mgmt_be_xpath_subscr_info {
 };
 
 struct mgmt_be_client_subscr_info {
-	union mgmt_be_xpath_subscr_info
-		xpath_subscr[MGMTD_BE_CLIENT_ID_MAX];
+	union mgmt_be_xpath_subscr_info xpath_subscr[MGMTD_BE_CLIENT_ID_MAX];
 };
+
+/*
+ * NOTE: List of YANG modules for every Backend Clients gets added here.
+ * These will typically have to be defined in mgmtd_be_adapter.c file
+ * first.
+ */
+extern const struct frr_yang_module_info frr_mgmt_staticd_info;
 
 /* Initialise backend adapter module. */
 extern int mgmt_be_adapter_init(struct thread_master *tm);

--- a/mgmtd/mgmt_main.c
+++ b/mgmtd/mgmt_main.c
@@ -213,7 +213,7 @@ static void mgmt_vrf_terminate(void)
  */
 static const struct frr_yang_module_info *const mgmt_yang_modules[] = {
 	&frr_filter_info,  &frr_interface_info, &frr_route_map_info,
-	&frr_routing_info, &frr_vrf_info,       &frr_staticd_info,
+	&frr_routing_info, &frr_vrf_info,       &frr_mgmt_staticd_info,
 };
 
 FRR_DAEMON_INFO(mgmtd, MGMTD, .vty_port = MGMTD_VTY_PORT,

--- a/mgmtd/subdir.am
+++ b/mgmtd/subdir.am
@@ -24,11 +24,9 @@ lib_LTLIBRARIES += mgmtd/libmgmt_be_nb.la
 nodist_mgmtd_libmgmt_be_nb_la_SOURCES = \
 	yang/frr-staticd.yang.c \
 	staticd/static_vty.c \
-	staticd/static_nb.c \
-	staticd/static_nb_config.c \
 	# end
-mgmtd_libmgmt_be_nb_la_CFLAGS = $(AM_CFLAGS) -DINCLUDE_MGMTD_CMDDEFS_ONLY -DINCLUDE_MGMTD_VALIDATE_ONLY
-mgmtd_libmgmt_be_nb_la_CPPFLAGS = $(AM_CPPFLAGS) -DINCLUDE_MGMTD_CMDDEFS_ONLY -DINCLUDE_MGMTD_VALIDATE_ONLY
+mgmtd_libmgmt_be_nb_la_CFLAGS = $(AM_CFLAGS) -DINCLUDE_MGMTD_CMDDEFS_ONLY
+mgmtd_libmgmt_be_nb_la_CPPFLAGS = $(AM_CPPFLAGS) -DINCLUDE_MGMTD_CMDDEFS_ONLY
 mgmtd_libmgmt_be_nb_la_LDFLAGS = -version-info 0:0:0
 
 noinst_LIBRARIES += mgmtd/libmgmtd.a

--- a/staticd/static_nb.c
+++ b/staticd/static_nb.c
@@ -60,9 +60,7 @@ const struct frr_yang_module_info frr_staticd_info = {
 		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop",
 			.cbs = {
-#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 				.apply_finish = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_apply_finish,
-#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_create,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_destroy,
 				.pre_validate = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_pre_validate,
@@ -143,9 +141,7 @@ const struct frr_yang_module_info frr_staticd_info = {
 		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/src-list/path-list/frr-nexthops/nexthop",
 			.cbs = {
-#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 				.apply_finish = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_apply_finish,
-#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_create,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_destroy,
 				.pre_validate = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_pre_validate,

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -86,8 +86,7 @@ static struct static_nht_hash_head static_nht_hash[1];
 
 /* Zebra structure to hold current status. */
 struct zclient *zclient;
-
-extern uint32_t zebra_ecmp_count;
+uint32_t zebra_ecmp_count = MULTIPATH_NUM;
 
 /* Interface addition message from zebra. */
 static int static_ifp_create(struct interface *ifp)


### PR DESCRIPTION
Was adding static_nb.c and static_nb_config.c as
a library to mgmt. Had put all the local variables
inside ifdefs. As local validation is not used now,
these changes can be reverted now.

Co-authored-by: Pushpasis Sarkar <pushpasis@gmail.com>
Signed-off-by: Yash Ranjan <ranjany@vmware.com>