### PR TITLE
isisd: duplicate 'isis bfd' command when forging show running-config

### DIFF
--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1424,10 +1424,6 @@ static int isis_interface_config_write(struct vty *vty)
 					circuit->passwd.passwd);
 				write++;
 			}
-			if (circuit->bfd_config.enabled) {
-				vty_out(vty, " " PROTO_NAME " bfd\n");
-				write++;
-			}
 			write += hook_call(isis_circuit_config_write,
 					   circuit, vty);
 		} while (0);


### PR DESCRIPTION
The show running-configuration is simplified, as now the BFD contexts
are forged with yang hook.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>