### PR TITLE
bgpd: remove one unnecessary parameter for evpn-mh

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3686,8 +3686,8 @@ static int update_advertise_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
 
 			es = bgp_evpn_es_find(&evp->prefix.ead_addr.esi);
 			bgp_evpn_mh_route_update(bgp, es, vpn, afi, safi,
-						 global_dest, attr, 1,
-						 &global_pi, &route_changed);
+						 global_dest, attr, &global_pi,
+						 &route_changed);
 		}
 
 		/* Schedule for processing and unlock node. */

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -351,7 +351,7 @@ static void bgp_evpn_es_route_del_all(struct bgp *bgp, struct bgp_evpn_es *es)
  */
 int bgp_evpn_mh_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
 			     struct bgpevpn *vpn, afi_t afi, safi_t safi,
-			     struct bgp_dest *dest, struct attr *attr, int add,
+			     struct bgp_dest *dest, struct attr *attr,
 			     struct bgp_path_info **ri, int *route_changed)
 {
 	struct bgp_path_info *tmp_pi = NULL;
@@ -389,9 +389,6 @@ int bgp_evpn_mh_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
 			es ? &es->originator_ip : NULL);
 		return -1;
 	}
-
-	if (!local_pi && !add)
-		return 0;
 
 	/* create or update the entry */
 	if (!local_pi) {
@@ -652,7 +649,7 @@ static int bgp_evpn_type4_route_update(struct bgp *bgp,
 	dest = bgp_node_get(es->route_table, (struct prefix *)p);
 
 	/* Create or update route entry. */
-	ret = bgp_evpn_mh_route_update(bgp, es, NULL, afi, safi, dest, &attr, 1,
+	ret = bgp_evpn_mh_route_update(bgp, es, NULL, afi, safi, dest, &attr,
 				       &pi, &route_changed);
 	if (ret != 0)
 		flog_err(
@@ -681,8 +678,7 @@ static int bgp_evpn_type4_route_update(struct bgp *bgp,
 		dest = bgp_global_evpn_node_get(bgp->rib[afi][safi], afi, safi,
 						p, &es->es_base_frag->prd);
 		bgp_evpn_mh_route_update(bgp, es, NULL, afi, safi, dest,
-					 attr_new, 1, &global_pi,
-					 &route_changed);
+					 attr_new, &global_pi, &route_changed);
 
 		/* Schedule for processing and unlock node. */
 		bgp_process(bgp, dest, afi, safi);
@@ -968,7 +964,7 @@ static int bgp_evpn_type1_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
 
 		/* Create or update route entry. */
 		ret = bgp_evpn_mh_route_update(bgp, es, vpn, afi, safi, dest,
-					       &attr, 1, &pi, &route_changed);
+					       &attr, &pi, &route_changed);
 		if (ret != 0)
 			flog_err(
 				EC_BGP_ES_INVALID,
@@ -990,7 +986,7 @@ static int bgp_evpn_type1_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
 
 		/* Create or update route entry. */
 		ret = bgp_evpn_mh_route_update(bgp, es, vpn, afi, safi, dest,
-					       &attr, 1, &pi, &route_changed);
+					       &attr, &pi, &route_changed);
 		if (ret != 0) {
 			flog_err(
 				EC_BGP_ES_INVALID,
@@ -1022,8 +1018,7 @@ static int bgp_evpn_type1_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
 		dest = bgp_global_evpn_node_get(bgp->rib[afi][safi], afi, safi,
 						p, global_rd);
 		bgp_evpn_mh_route_update(bgp, es, vpn, afi, safi, dest,
-					 attr_new, 1, &global_pi,
-					 &route_changed);
+					 attr_new, &global_pi, &route_changed);
 
 		/* Schedule for processing and unlock node. */
 		bgp_process(bgp, dest, afi, safi);

--- a/bgpd/bgp_evpn_mh.h
+++ b/bgpd/bgp_evpn_mh.h
@@ -420,7 +420,7 @@ extern int delete_global_ead_evi_routes(struct bgp *bgp, struct bgpevpn *vpn);
 extern int bgp_evpn_mh_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
 				    struct bgpevpn *vpn, afi_t afi, safi_t safi,
 				    struct bgp_dest *dest, struct attr *attr,
-				    int add, struct bgp_path_info **ri,
+				    struct bgp_path_info **ri,
 				    int *route_changed);
 int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 		struct attr *attr, uint8_t *pfx, int psize,


### PR DESCRIPTION
The "add" parameter of `bgp_evpn_mh_route_update()` makes no sense.
Just remove it to clarify this function, and remove the relevant check
with "add" as well.