### PR TITLE
bgpd: remove unncessary check for evpn

### DIFF
--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -450,8 +450,7 @@ static inline void build_evpn_type2_prefix(struct prefix_evpn *p,
 	p->prefix.route_type = BGP_EVPN_MAC_IP_ROUTE;
 	memcpy(&p->prefix.macip_addr.mac.octet, mac->octet, ETH_ALEN);
 	p->prefix.macip_addr.ip.ipa_type = IPADDR_NONE;
-	if (ip)
-		memcpy(&p->prefix.macip_addr.ip, ip, sizeof(*ip));
+	memcpy(&p->prefix.macip_addr.ip, ip, sizeof(*ip));
 }
 
 static inline void


### PR DESCRIPTION
In current code, `build_evpn_type2_prefix()` doesn't distinguish ARP
or not according to the `ip` parameter. The `ip` parameter from caller
is always non-NULL.
    
Be consistent and not confused, just remove the unnecessary check.
