### PR TITLE
bgpd: explicitly request rd and rt auto change behavior after router-id change

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1724,6 +1724,22 @@ DEFUN (no_bgp_cluster_id,
 	return CMD_SUCCESS;
 }
 
+DEFPY (bgp_auto_rd_rt,
+       bgp_auto_rd_rt_cmd,
+       "[no] bgp auto-rd-rt",
+       NO_STR
+       BGP_STR
+       "Auto-update rd/rt export attributes to <router-id>:XX after a router-id change\n")
+{
+	if (no)
+		bgp_option_unset(BGP_OPT_AUTO_RD_RT);
+	else
+		bgp_option_set(BGP_OPT_AUTO_RD_RT);
+
+	return CMD_SUCCESS;
+}
+
+
 DEFPY (bgp_norib,
        bgp_norib_cmd,
        "bgp no-rib",
@@ -17099,6 +17115,9 @@ int bgp_config_write(struct vty *vty)
 	if (bgp_option_check(BGP_OPT_NO_FIB))
 		vty_out(vty, "bgp no-rib\n");
 
+	if (bgp_option_check(BGP_OPT_AUTO_RD_RT))
+		vty_out(vty, "bgp auto-rd-rt\n");
+
 	if (CHECK_FLAG(bm->flags, BM_FLAG_SEND_EXTRA_DATA_TO_ZEBRA))
 		vty_out(vty, "bgp send-extra-data zebra\n");
 
@@ -17805,6 +17824,9 @@ void bgp_vty_init(void)
 	/* "bgp cluster-id" commands. */
 	install_element(BGP_NODE, &bgp_cluster_id_cmd);
 	install_element(BGP_NODE, &no_bgp_cluster_id_cmd);
+
+	/* "bgp auto-rd-rt" commands. */
+	install_element(CONFIG_NODE, &bgp_auto_rd_rt_cmd);
 
 	/* "bgp no-rib" commands. */
 	install_element(CONFIG_NODE, &bgp_norib_cmd);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -189,6 +189,7 @@ int bgp_option_set(int flag)
 	case BGP_OPT_NO_FIB:
 	case BGP_OPT_NO_LISTEN:
 	case BGP_OPT_NO_ZEBRA:
+	case BGP_OPT_AUTO_RD_RT:
 		SET_FLAG(bm->options, flag);
 		break;
 	default:
@@ -203,6 +204,7 @@ int bgp_option_unset(int flag)
 	/* Fall through.  */
 	case BGP_OPT_NO_ZEBRA:
 	case BGP_OPT_NO_FIB:
+	case BGP_OPT_AUTO_RD_RT:
 		UNSET_FLAG(bm->options, flag);
 		break;
 	default:
@@ -294,7 +296,8 @@ static int bgp_router_id_set(struct bgp *bgp, const struct in_addr *id,
 	if (is_evpn_enabled())
 		bgp_evpn_handle_router_id_update(bgp, true);
 
-	vpn_handle_router_id_update(bgp, true, is_config);
+	if (bgp_option_check(BGP_OPT_AUTO_RD_RT))
+		vpn_handle_router_id_update(bgp, true, is_config);
 
 	IPV4_ADDR_COPY(&bgp->router_id, id);
 
@@ -313,7 +316,8 @@ static int bgp_router_id_set(struct bgp *bgp, const struct in_addr *id,
 	if (is_evpn_enabled())
 		bgp_evpn_handle_router_id_update(bgp, false);
 
-	vpn_handle_router_id_update(bgp, false, is_config);
+	if (bgp_option_check(BGP_OPT_AUTO_RD_RT))
+		vpn_handle_router_id_update(bgp, false, is_config);
 
 	return 0;
 }

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -135,6 +135,7 @@ struct bgp_master {
 #define BGP_OPT_NO_FIB                   (1 << 0)
 #define BGP_OPT_NO_LISTEN                (1 << 1)
 #define BGP_OPT_NO_ZEBRA                 (1 << 2)
+#define BGP_OPT_AUTO_RD_RT               (1 << 3)
 
 	uint64_t updgrp_idspace;
 	uint64_t subgrp_idspace;

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2708,6 +2708,12 @@ address-family:
    extended community values as described in
    :ref:`bgp-extended-communities-attribute`.
 
+.. clicmd:: bgp auto-rd-rt
+
+   Update automatically the ``rd vpn export`` and ``rt vpn export`` attributes
+   after a ``bgp router-id`` modification. Values before the semi-column are
+   replaced automatically by the new router-id.
+
 .. clicmd:: label vpn export (0..1048575)|auto
 
    Enables an MPLS label to be attached to a route exported from the current


### PR DESCRIPTION
636f76088d ("bgpd: router-id change reflect to vpn auto rd rt") has
introduced an automatic configuration change of the `rd vpn export`
and `rt vpn export` attributes after a router-id modification with the
`bgp router-id` command.

For example, run the bgp_l3vpn_to_bgp_vrf topotest:
> python3 -m pytest bgp_l3vpn_to_bgp_vrf -v --pause -s --shell=r1

Configure the following to r1:
> ip link add r1-cust5 type vrf table 100
> ip link set r1-cust5 up
>
> vtysh
> conf t
> router bgp 5227 vrf r1-cust5
>  bgp router-id 192.168.1.1
>  !
>  address-family ipv4 unicast
>   rd vpn export 10:1
>   rt vpn both 52:100
>   export vpn
>   import vpn
>  exit-address-family
> exit

Then change the router-id:
> router bgp 5227 vrf r1-cust5
>  bgp router-id 192.168.1.11

Notice that the change `rd/rt vpn export` attributes:
> r1(config-router)# do sh run bgp
> router bgp 5227 vrf r1-cust5
>  bgp router-id 192.168.1.11
>  !
>  address-family ipv4 unicast
>   rd vpn export 192.168.1.11:3
>   rt vpn import 52:100
>   rt vpn export 192.168.1.11:3
>   export vpn
>   import vpn
>  exit-address-family
>

`rd/rt vpn export` attributes are in the following format:
> r1(config-router-af)# rt vpn export ?
>   RTLIST  Space separated route target list (A.B.C.D:MN|EF:OPQR|GHJK:MN)
> r1(config-router-af)# rd vpn export ?
>  ASN:NN_OR_IP-ADDRESS:NN  Route Distinguisher (<as-number>:<number> | <ip-address>:<number>)

The automatic change of the `rd/rt vpn export` attributes have only a
benefit in the case the attributes are in the `<router-id:number>`
format. It should not be the general case.

Add a `bgp auto-rd-rt` global option to explicitly request the
`rd/rt vpn export` attributes to be automatically replaced by the
`<router-id:number>` format after a `bgp router-id` modification.

Fixes: 636f76088d ("bgpd: router-id change reflect to vpn auto rd rt")
Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>