### PR TITLE
BMP fix invalid bmp POST POLICY flag

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1189,7 +1189,7 @@ static bool bmp_wrqueue(struct bmp *bmp, struct pullwr *pullwr)
 			if (adjin->peer == peer)
 				break;
 		}
-		bmp_monitor(bmp, peer, BMP_PEER_FLAG_L, &bqe->p, prd,
+		bmp_monitor(bmp, peer, 0, &bqe->p, prd,
 			    adjin ? adjin->attr : NULL, afi, safi,
 			    adjin ? adjin->uptime : monotime(NULL));
 		written = true;


### PR DESCRIPTION
description:
BMP Per Peer Headers of Route Monitoring messages with UPDATE and
WITHDRAW notificatiosn ( not the sync ones at Initiation) are
all typed as POST POLICY.

fix:
notify Pre policy UPDATES AND WITHDRAWS with  Per Peer Header type set
to PRE POLICY (0)

Signed-off-by: Francois Dumontet <francois.dumontet@6wind.com>