### PR TITLE
Fix #11178 and various other cleanup

### DIFF
--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -142,14 +142,16 @@ struct bgp_synchronize {
 #define BGP_ADJ_IN_DEL(N, A) BGP_PATH_INFO_DEL(N, A, adj_in)
 
 /* Prototypes.  */
-extern bool bgp_adj_out_lookup(struct peer *, struct bgp_dest *, uint32_t);
-extern void bgp_adj_in_set(struct bgp_dest *, struct peer *, struct attr *,
-			   uint32_t);
-extern bool bgp_adj_in_unset(struct bgp_dest *, struct peer *, uint32_t);
-extern void bgp_adj_in_remove(struct bgp_dest *, struct bgp_adj_in *);
+extern bool bgp_adj_out_lookup(struct peer *peer, struct bgp_dest *dest,
+			       uint32_t addpath_tx_id);
+extern void bgp_adj_in_set(struct bgp_dest *dest, struct peer *peer,
+			   struct attr *attr, uint32_t addpath_id);
+extern bool bgp_adj_in_unset(struct bgp_dest *dest, struct peer *peer,
+			     uint32_t addpath_id);
+extern void bgp_adj_in_remove(struct bgp_dest *dest, struct bgp_adj_in *bai);
 
-extern void bgp_sync_init(struct peer *);
-extern void bgp_sync_delete(struct peer *);
+extern void bgp_sync_init(struct peer *peer);
+extern void bgp_sync_delete(struct peer *peer);
 extern unsigned int baa_hash_key(const void *p);
 extern bool baa_hash_cmp(const void *p1, const void *p2);
 extern void bgp_advertise_add(struct bgp_advertise_attr *baa,

--- a/bgpd/bgp_aspath.h
+++ b/bgpd/bgp_aspath.h
@@ -79,36 +79,40 @@ struct aspath {
 /* Prototypes. */
 extern void aspath_init(void);
 extern void aspath_finish(void);
-extern struct aspath *aspath_parse(struct stream *, size_t, int);
-extern struct aspath *aspath_dup(struct aspath *);
-extern struct aspath *aspath_aggregate(struct aspath *, struct aspath *);
-extern struct aspath *aspath_prepend(struct aspath *, struct aspath *);
-extern struct aspath *aspath_filter_exclude(struct aspath *, struct aspath *);
-extern struct aspath *aspath_add_seq_n(struct aspath *, as_t, unsigned);
-extern struct aspath *aspath_add_seq(struct aspath *, as_t);
-extern struct aspath *aspath_add_confed_seq(struct aspath *, as_t);
+extern struct aspath *aspath_parse(struct stream *s, size_t length,
+				   int use32bit);
+extern struct aspath *aspath_dup(struct aspath *aspath);
+extern struct aspath *aspath_aggregate(struct aspath *as1, struct aspath *as2);
+extern struct aspath *aspath_prepend(struct aspath *as1, struct aspath *as2);
+extern struct aspath *aspath_filter_exclude(struct aspath *source,
+					    struct aspath *exclude_list);
+extern struct aspath *aspath_add_seq_n(struct aspath *aspath, as_t asno,
+				       unsigned num);
+extern struct aspath *aspath_add_seq(struct aspath *aspath, as_t asno);
+extern struct aspath *aspath_add_confed_seq(struct aspath *aspath, as_t asno);
 extern bool aspath_cmp(const void *as1, const void *as2);
-extern bool aspath_cmp_left(const struct aspath *, const struct aspath *);
+extern bool aspath_cmp_left(const struct aspath *aspath1,
+			    const struct aspath *aspath2);
 extern bool aspath_cmp_left_confed(const struct aspath *as1,
-				   const struct aspath *as2xs);
-extern struct aspath *aspath_delete_confed_seq(struct aspath *);
+				   const struct aspath *as2);
+extern struct aspath *aspath_delete_confed_seq(struct aspath *aspath);
 extern struct aspath *aspath_empty(void);
 extern struct aspath *aspath_empty_get(void);
-extern struct aspath *aspath_str2aspath(const char *);
+extern struct aspath *aspath_str2aspath(const char *str);
 extern void aspath_str_update(struct aspath *as, bool make_json);
-extern void aspath_free(struct aspath *);
-extern struct aspath *aspath_intern(struct aspath *);
-extern void aspath_unintern(struct aspath **);
-extern const char *aspath_print(struct aspath *);
-extern void aspath_print_vty(struct vty *, const char *, struct aspath *,
-			     const char *);
-extern void aspath_print_all_vty(struct vty *);
-extern unsigned int aspath_key_make(const void *);
-extern unsigned int aspath_get_first_as(struct aspath *);
-extern unsigned int aspath_get_last_as(struct aspath *);
-extern int aspath_loop_check(struct aspath *, as_t);
-extern bool aspath_private_as_check(struct aspath *);
-extern bool aspath_single_asn_check(struct aspath *, as_t asn);
+extern void aspath_free(struct aspath *aspath);
+extern struct aspath *aspath_intern(struct aspath *aspath);
+extern void aspath_unintern(struct aspath **aspath);
+extern const char *aspath_print(struct aspath *aspath);
+extern void aspath_print_vty(struct vty *vty, const char *format,
+			     struct aspath *aspath, const char *suffix);
+extern void aspath_print_all_vty(struct vty *vty);
+extern unsigned int aspath_key_make(const void *p);
+extern unsigned int aspath_get_first_as(struct aspath *aspath);
+extern unsigned int aspath_get_last_as(struct aspath *aspath);
+extern int aspath_loop_check(struct aspath *aspath, as_t asno);
+extern bool aspath_private_as_check(struct aspath *aspath);
+extern bool aspath_single_asn_check(struct aspath *aspath, as_t asn);
 extern struct aspath *aspath_replace_specific_asn(struct aspath *aspath,
 						  as_t target_asn,
 						  as_t our_asn);
@@ -118,24 +122,25 @@ extern struct aspath *aspath_replace_private_asns(struct aspath *aspath,
 						  as_t asn, as_t peer_asn);
 extern struct aspath *aspath_remove_private_asns(struct aspath *aspath,
 						 as_t peer_asn);
-extern bool aspath_firstas_check(struct aspath *, as_t);
-extern bool aspath_confed_check(struct aspath *);
-extern bool aspath_left_confed_check(struct aspath *);
+extern bool aspath_firstas_check(struct aspath *aspath, as_t asno);
+extern bool aspath_confed_check(struct aspath *aspath);
+extern bool aspath_left_confed_check(struct aspath *aspath);
 extern unsigned long aspath_count(void);
-extern unsigned int aspath_count_hops(const struct aspath *);
+extern unsigned int aspath_count_hops(const struct aspath *aspath);
 extern bool aspath_check_as_sets(struct aspath *aspath);
 extern bool aspath_check_as_zero(struct aspath *aspath);
-extern unsigned int aspath_count_confeds(struct aspath *);
-extern unsigned int aspath_size(struct aspath *);
-extern as_t aspath_highest(struct aspath *);
-extern as_t aspath_leftmost(struct aspath *);
-extern size_t aspath_put(struct stream *, struct aspath *, int);
+extern unsigned int aspath_count_confeds(struct aspath *aspath);
+extern unsigned int aspath_size(struct aspath *aspath);
+extern as_t aspath_highest(struct aspath *aspath);
+extern as_t aspath_leftmost(struct aspath *aspath);
+extern size_t aspath_put(struct stream *s, struct aspath *aspath, int use32bit);
 
-extern struct aspath *aspath_reconcile_as4(struct aspath *, struct aspath *);
-extern bool aspath_has_as4(struct aspath *);
+extern struct aspath *aspath_reconcile_as4(struct aspath *aspath,
+					   struct aspath *as4path);
+extern bool aspath_has_as4(struct aspath *aspath);
 
 /* For SNMP BGP4PATHATTRASPATHSEGMENT, might be useful for debug */
-extern uint8_t *aspath_snmp_pathseg(struct aspath *, size_t *);
+extern uint8_t *aspath_snmp_pathseg(struct aspath *aspath, size_t *varlen);
 
 extern void bgp_compute_aggregate_aspath(struct bgp_aggregate *aggregate,
 					 struct aspath *aspath);

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -386,14 +386,14 @@ struct bpacket_attr_vec_arr;
 /* Prototypes. */
 extern void bgp_attr_init(void);
 extern void bgp_attr_finish(void);
-extern enum bgp_attr_parse_ret bgp_attr_parse(struct peer *, struct attr *,
-					      bgp_size_t, struct bgp_nlri *,
-					      struct bgp_nlri *);
+extern enum bgp_attr_parse_ret
+bgp_attr_parse(struct peer *peer, struct attr *attr, bgp_size_t size,
+	       struct bgp_nlri *mp_update, struct bgp_nlri *mp_withdraw);
 extern struct attr *bgp_attr_intern(struct attr *attr);
-extern void bgp_attr_unintern_sub(struct attr *);
-extern void bgp_attr_unintern(struct attr **);
-extern void bgp_attr_flush(struct attr *);
-extern struct attr *bgp_attr_default_set(struct attr *attr, uint8_t);
+extern void bgp_attr_unintern_sub(struct attr *attr);
+extern void bgp_attr_unintern(struct attr **pattr);
+extern void bgp_attr_flush(struct attr *attr);
+extern struct attr *bgp_attr_default_set(struct attr *attr, uint8_t origin);
 extern struct attr *bgp_attr_aggregate_intern(
 	struct bgp *bgp, uint8_t origin, struct aspath *aspath,
 	struct community *community, struct ecommunity *ecommunity,
@@ -410,13 +410,14 @@ extern bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer,
 extern void bgp_dump_routes_attr(struct stream *s, struct attr *attr,
 				 const struct prefix *p);
 extern bool attrhash_cmp(const void *arg1, const void *arg2);
-extern unsigned int attrhash_key_make(const void *);
-extern void attr_show_all(struct vty *);
+extern unsigned int attrhash_key_make(const void *p);
+extern void attr_show_all(struct vty *vty);
 extern unsigned long int attr_count(void);
 extern unsigned long int attr_unknown_count(void);
 
 /* Cluster list prototypes. */
-extern bool cluster_loop_check(struct cluster_list *, struct in_addr);
+extern bool cluster_loop_check(struct cluster_list *cluster,
+			       struct in_addr originator);
 
 /* Below exported for unit-test purposes only */
 struct bgp_attr_parser_args {
@@ -429,9 +430,9 @@ struct bgp_attr_parser_args {
 	uint8_t *startp;
 };
 extern int bgp_mp_reach_parse(struct bgp_attr_parser_args *args,
-			      struct bgp_nlri *);
+			      struct bgp_nlri *mp_update);
 extern int bgp_mp_unreach_parse(struct bgp_attr_parser_args *args,
-				struct bgp_nlri *);
+				struct bgp_nlri *mp_withdraw);
 extern enum bgp_attr_parse_ret
 bgp_attr_prefix_sid(struct bgp_attr_parser_args *args);
 

--- a/bgpd/bgp_clist.h
+++ b/bgpd/bgp_clist.h
@@ -137,7 +137,7 @@ extern struct community_list_handler *bgp_clist;
 
 /* Prototypes.  */
 extern struct community_list_handler *community_list_init(void);
-extern void community_list_terminate(struct community_list_handler *);
+extern void community_list_terminate(struct community_list_handler *ch);
 
 extern int community_list_set(struct community_list_handler *ch,
 			      const char *name, const char *str,
@@ -160,21 +160,24 @@ extern int lcommunity_list_unset(struct community_list_handler *ch,
 				 const char *seq, int direct, int style);
 
 extern struct community_list_master *
-community_list_master_lookup(struct community_list_handler *, int);
+community_list_master_lookup(struct community_list_handler *ch, int master);
 
 extern struct community_list *
 community_list_lookup(struct community_list_handler *c, const char *name,
 		      uint32_t name_hash, int master);
 
-extern bool community_list_match(struct community *, struct community_list *);
-extern bool ecommunity_list_match(struct ecommunity *, struct community_list *);
-extern bool lcommunity_list_match(struct lcommunity *, struct community_list *);
-extern bool community_list_exact_match(struct community *,
-				       struct community_list *);
+extern bool community_list_match(struct community *com,
+				 struct community_list *list);
+extern bool ecommunity_list_match(struct ecommunity *ecom,
+				  struct community_list *list);
+extern bool lcommunity_list_match(struct lcommunity *lcom,
+				  struct community_list *list);
+extern bool community_list_exact_match(struct community *com,
+				       struct community_list *list);
 extern bool lcommunity_list_exact_match(struct lcommunity *lcom,
 					struct community_list *list);
-extern struct community *community_list_match_delete(struct community *,
-						     struct community_list *);
+extern struct community *
+community_list_match_delete(struct community *com, struct community_list *list);
 extern struct lcommunity *
 lcommunity_list_match_delete(struct lcommunity *lcom,
 			     struct community_list *list);

--- a/bgpd/bgp_community.h
+++ b/bgpd/bgp_community.h
@@ -72,25 +72,26 @@ struct community {
 extern void community_init(void);
 extern void community_finish(void);
 extern void community_free(struct community **comm);
-extern struct community *community_uniq_sort(struct community *);
-extern struct community *community_parse(uint32_t *, unsigned short);
-extern struct community *community_intern(struct community *);
-extern void community_unintern(struct community **);
-extern char *community_str(struct community *, bool make_json,
+extern struct community *community_uniq_sort(struct community *com);
+extern struct community *community_parse(uint32_t *pnt, unsigned short length);
+extern struct community *community_intern(struct community *com);
+extern void community_unintern(struct community **com);
+extern char *community_str(struct community *com, bool make_json,
 			   bool translate_alias);
-extern unsigned int community_hash_make(const struct community *);
-extern struct community *community_str2com(const char *);
-extern bool community_match(const struct community *, const struct community *);
+extern unsigned int community_hash_make(const struct community *com);
+extern struct community *community_str2com(const char *str);
+extern bool community_match(const struct community *com1,
+			    const struct community *com2);
 extern bool community_cmp(const struct community *c1,
 			  const struct community *c2);
-extern struct community *community_merge(struct community *,
-					 struct community *);
-extern struct community *community_delete(struct community *,
-					  struct community *);
-extern struct community *community_dup(struct community *);
-extern bool community_include(struct community *, uint32_t);
+extern struct community *community_merge(struct community *com1,
+					 struct community *com2);
+extern struct community *community_delete(struct community *com1,
+					  struct community *com2);
+extern struct community *community_dup(struct community *com);
+extern bool community_include(struct community *com, uint32_t val);
 extern void community_add_val(struct community *com, uint32_t val);
-extern void community_del_val(struct community *, uint32_t *);
+extern void community_del_val(struct community *com, uint32_t *val);
 extern unsigned long community_count(void);
 extern struct hash *community_hash(void);
 extern uint32_t community_val_get(struct community *com, int i);

--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -132,9 +132,10 @@ struct bgp_damp_config {
 #define REUSE_LIST_SIZE          256
 #define REUSE_ARRAY_SIZE        1024
 
-extern int bgp_damp_enable(struct bgp *, afi_t, safi_t, time_t, unsigned int,
-			   unsigned int, time_t);
-extern int bgp_damp_disable(struct bgp *, afi_t, safi_t);
+extern int bgp_damp_enable(struct bgp *bgp, afi_t afi, safi_t safi, time_t half,
+			   unsigned int reuse, unsigned int suppress,
+			   time_t max);
+extern int bgp_damp_disable(struct bgp *bgp, afi_t afi, safi_t safi);
 extern int bgp_damp_withdraw(struct bgp_path_info *path, struct bgp_dest *dest,
 			     afi_t afi, safi_t safi, int attr_change);
 extern int bgp_damp_update(struct bgp_path_info *path, struct bgp_dest *dest,
@@ -142,8 +143,9 @@ extern int bgp_damp_update(struct bgp_path_info *path, struct bgp_dest *dest,
 extern void bgp_damp_info_free(struct bgp_damp_info *path, int withdraw,
 			       afi_t afi, safi_t safi);
 extern void bgp_damp_info_clean(afi_t afi, safi_t safi);
-extern int bgp_damp_decay(time_t, int, struct bgp_damp_config *damp);
-extern void bgp_config_write_damp(struct vty *, afi_t afi, safi_t safi);
+extern int bgp_damp_decay(time_t tdiff, int penalty,
+			  struct bgp_damp_config *damp);
+extern void bgp_config_write_damp(struct vty *vty, afi_t afi, safi_t safi);
 extern void bgp_damp_info_vty(struct vty *vty, struct bgp_path_info *path,
 			      afi_t afi, safi_t safi, json_object *json_path);
 extern const char *bgp_damp_reuse_time_vty(struct vty *vty,
@@ -151,7 +153,7 @@ extern const char *bgp_damp_reuse_time_vty(struct vty *vty,
 					   char *timebuf, size_t len, afi_t afi,
 					   safi_t safi, bool use_json,
 					   json_object *json);
-extern int bgp_show_dampening_parameters(struct vty *vty, afi_t, safi_t,
-					 uint16_t);
+extern int bgp_show_dampening_parameters(struct vty *vty, afi_t afi,
+					 safi_t safi, uint16_t show_flags);
 
 #endif /* _QUAGGA_BGP_DAMP_H */

--- a/bgpd/bgp_debug.h
+++ b/bgpd/bgp_debug.h
@@ -166,10 +166,10 @@ struct bgp_debug_filter {
 
 extern const char *const bgp_type_str[];
 
-extern bool bgp_dump_attr(struct attr *, char *, size_t);
+extern bool bgp_dump_attr(struct attr *attr, char *buf, size_t size);
 extern bool bgp_debug_peer_updout_enabled(char *host);
-extern const char *bgp_notify_code_str(char);
-extern const char *bgp_notify_subcode_str(char, char);
+extern const char *bgp_notify_code_str(char code);
+extern const char *bgp_notify_subcode_str(char code, char subcode);
 extern void bgp_notify_print(struct peer *peer, struct bgp_notify *bgp_notify,
 			     const char *direct, bool hard_reset);
 

--- a/bgpd/bgp_dump.h
+++ b/bgpd/bgp_dump.h
@@ -59,6 +59,6 @@
 
 extern void bgp_dump_init(void);
 extern void bgp_dump_finish(void);
-extern int bgp_dump_state(struct peer *);
+extern int bgp_dump_state(struct peer *peer);
 
 #endif /* _QUAGGA_BGP_DUMP_H */

--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -46,7 +46,7 @@
  * Record maximum-paths configuration for BGP instance
  */
 int bgp_maximum_paths_set(struct bgp *bgp, afi_t afi, safi_t safi, int peertype,
-			  uint16_t maxpaths, uint16_t options)
+			  uint16_t maxpaths, bool same_clusterlen)
 {
 	if (!bgp || (afi >= AFI_MAX) || (safi >= SAFI_MAX))
 		return -1;
@@ -54,7 +54,7 @@ int bgp_maximum_paths_set(struct bgp *bgp, afi_t afi, safi_t safi, int peertype,
 	switch (peertype) {
 	case BGP_PEER_IBGP:
 		bgp->maxpaths[afi][safi].maxpaths_ibgp = maxpaths;
-		bgp->maxpaths[afi][safi].ibgp_flags |= options;
+		bgp->maxpaths[afi][safi].same_clusterlen = same_clusterlen;
 		break;
 	case BGP_PEER_EBGP:
 		bgp->maxpaths[afi][safi].maxpaths_ebgp = maxpaths;
@@ -80,7 +80,7 @@ int bgp_maximum_paths_unset(struct bgp *bgp, afi_t afi, safi_t safi,
 	switch (peertype) {
 	case BGP_PEER_IBGP:
 		bgp->maxpaths[afi][safi].maxpaths_ibgp = multipath_num;
-		bgp->maxpaths[afi][safi].ibgp_flags = 0;
+		bgp->maxpaths[afi][safi].same_clusterlen = false;
 		break;
 	case BGP_PEER_EBGP:
 		bgp->maxpaths[afi][safi].maxpaths_ebgp = multipath_num;

--- a/bgpd/bgp_mpath.h
+++ b/bgpd/bgp_mpath.h
@@ -51,8 +51,9 @@ struct bgp_path_info_mpath {
 };
 
 /* Functions to support maximum-paths configuration */
-extern int bgp_maximum_paths_set(struct bgp *, afi_t, safi_t, int, uint16_t,
-				 uint16_t);
+extern int bgp_maximum_paths_set(struct bgp *bgp, afi_t afi, safi_t safi,
+				 int peertype, uint16_t maxpaths,
+				 bool clusterlen);
 extern int bgp_maximum_paths_unset(struct bgp *, afi_t, safi_t, int);
 
 /* Functions used by bgp_best_selection to record current

--- a/bgpd/bgp_mpath.h
+++ b/bgpd/bgp_mpath.h
@@ -19,8 +19,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef _QUAGGA_BGP_MPATH_H
-#define _QUAGGA_BGP_MPATH_H
+#ifndef _FRR_BGP_MPATH_H
+#define _FRR_BGP_MPATH_H
 
 /* Supplemental information linked to bgp_path_info for keeping track of
  * multipath selections, lazily allocated to save memory
@@ -54,15 +54,16 @@ struct bgp_path_info_mpath {
 extern int bgp_maximum_paths_set(struct bgp *bgp, afi_t afi, safi_t safi,
 				 int peertype, uint16_t maxpaths,
 				 bool clusterlen);
-extern int bgp_maximum_paths_unset(struct bgp *, afi_t, safi_t, int);
+extern int bgp_maximum_paths_unset(struct bgp *bgp, afi_t afi, safi_t safi,
+				   int peertype);
 
 /* Functions used by bgp_best_selection to record current
  * multipath selections
  */
 extern int bgp_path_info_nexthop_cmp(struct bgp_path_info *bpi1,
 				     struct bgp_path_info *bpi2);
-extern void bgp_mp_list_init(struct list *);
-extern void bgp_mp_list_clear(struct list *);
+extern void bgp_mp_list_init(struct list *mp_list);
+extern void bgp_mp_list_clear(struct list *mp_list);
 extern void bgp_mp_list_add(struct list *mp_list, struct bgp_path_info *mpinfo);
 extern void bgp_mp_dmed_deselect(struct bgp_path_info *dmed_best);
 extern void bgp_path_info_mpath_update(struct bgp *bgp, struct bgp_dest *dest,
@@ -91,4 +92,4 @@ extern bool bgp_path_info_mpath_chkwtd(struct bgp *bgp,
 				       struct bgp_path_info *path);
 extern uint64_t bgp_path_info_mpath_cumbw(struct bgp_path_info *path);
 
-#endif /* _QUAGGA_BGP_MPATH_H */
+#endif /* _FRR_BGP_MPATH_H */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1079,12 +1079,9 @@ static int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 	   pair (newm, existm) with the cluster list length. Prefer the
 	   path with smaller cluster list length.                       */
 	if (newm == existm) {
-		if (peer_sort_lookup(new->peer) == BGP_PEER_IBGP
-		    && peer_sort_lookup(exist->peer) == BGP_PEER_IBGP
-		    && (mpath_cfg == NULL
-			|| CHECK_FLAG(
-				   mpath_cfg->ibgp_flags,
-				   BGP_FLAG_IBGP_MULTIPATH_SAME_CLUSTERLEN))) {
+		if (peer_sort_lookup(new->peer) == BGP_PEER_IBGP &&
+		    peer_sort_lookup(exist->peer) == BGP_PEER_IBGP &&
+		    (mpath_cfg == NULL || mpath_cfg->same_clusterlen)) {
 			newm = BGP_CLUSTER_LIST_LENGTH(new->attr);
 			existm = BGP_CLUSTER_LIST_LENGTH(exist->attr);
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2339,9 +2339,8 @@ DEFUN (bgp_maxpaths_ibgp_cluster,
        "Match the cluster length\n")
 {
 	int idx_number = 2;
-	return bgp_maxpaths_config_vty(
-		vty, BGP_PEER_IBGP, argv[idx_number]->arg,
-		BGP_FLAG_IBGP_MULTIPATH_SAME_CLUSTERLEN, 1);
+	return bgp_maxpaths_config_vty(vty, BGP_PEER_IBGP,
+				       argv[idx_number]->arg, true, 1);
 }
 
 ALIAS_HIDDEN(bgp_maxpaths_ibgp_cluster, bgp_maxpaths_ibgp_cluster_hidden_cmd,
@@ -2399,8 +2398,7 @@ static void bgp_config_write_maxpaths(struct vty *vty, struct bgp *bgp,
 	if (bgp->maxpaths[afi][safi].maxpaths_ibgp != multipath_num) {
 		vty_out(vty, "  maximum-paths ibgp %d",
 			bgp->maxpaths[afi][safi].maxpaths_ibgp);
-		if (CHECK_FLAG(bgp->maxpaths[afi][safi].ibgp_flags,
-			       BGP_FLAG_IBGP_MULTIPATH_SAME_CLUSTERLEN))
+		if (bgp->maxpaths[afi][safi].same_clusterlen)
 			vty_out(vty, " equal-cluster-length");
 		vty_out(vty, "\n");
 	}

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -45,7 +45,7 @@ extern int bgp_if_update_all(void);
 extern void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 			       struct bgp_path_info *path, struct bgp *bgp,
 			       afi_t afi, safi_t safi);
-extern void bgp_zebra_announce_table(struct bgp *, afi_t, safi_t);
+extern void bgp_zebra_announce_table(struct bgp *bgp, afi_t afi, safi_t safi);
 extern void bgp_zebra_withdraw(const struct prefix *p,
 			       struct bgp_path_info *path, struct bgp *bgp,
 			       safi_t safi);
@@ -61,44 +61,54 @@ extern void bgp_zebra_withdraw_table_all_subtypes(struct bgp *bgp, afi_t afi,
 extern void bgp_zebra_initiate_radv(struct bgp *bgp, struct peer *peer);
 extern void bgp_zebra_terminate_radv(struct bgp *bgp, struct peer *peer);
 
-extern void bgp_zebra_instance_register(struct bgp *);
-extern void bgp_zebra_instance_deregister(struct bgp *);
+extern void bgp_zebra_instance_register(struct bgp *bgp);
+extern void bgp_zebra_instance_deregister(struct bgp *bgp);
 
 extern void bgp_redistribute_redo(struct bgp *bgp);
-extern struct bgp_redist *bgp_redist_lookup(struct bgp *, afi_t, uint8_t,
-					    unsigned short);
-extern struct bgp_redist *bgp_redist_add(struct bgp *, afi_t, uint8_t,
-					 unsigned short);
-extern int bgp_redistribute_set(struct bgp *, afi_t, int, unsigned short,
-				bool changed);
-extern int bgp_redistribute_resend(struct bgp *, afi_t, int, unsigned short);
+extern struct bgp_redist *bgp_redist_lookup(struct bgp *bgp, afi_t afi,
+					    uint8_t type,
+					    unsigned short instance);
+extern struct bgp_redist *bgp_redist_add(struct bgp *bgp, afi_t afi,
+					 uint8_t type, unsigned short instance);
+extern int bgp_redistribute_set(struct bgp *bgp, afi_t afi, int type,
+				unsigned short instance, bool changed);
+extern int bgp_redistribute_resend(struct bgp *bgp, afi_t afi, int type,
+				   unsigned short instance);
 extern bool bgp_redistribute_rmap_set(struct bgp_redist *red, const char *name,
 				      struct route_map *route_map);
-extern bool bgp_redistribute_metric_set(struct bgp *, struct bgp_redist *,
-					afi_t, int, uint32_t);
-extern int bgp_redistribute_unset(struct bgp *, afi_t, int, unsigned short);
-extern int bgp_redistribute_unreg(struct bgp *, afi_t, int, unsigned short);
+extern bool bgp_redistribute_metric_set(struct bgp *bgp, struct bgp_redist *red,
+					afi_t afi, int type, uint32_t metric);
+extern int bgp_redistribute_unset(struct bgp *bgp, afi_t afi, int type,
+				  unsigned short instance);
+extern int bgp_redistribute_unreg(struct bgp *bgp, afi_t afi, int type,
+				  unsigned short instance);
 
-extern struct interface *if_lookup_by_ipv4(struct in_addr *, vrf_id_t);
-extern struct interface *if_lookup_by_ipv4_exact(struct in_addr *, vrf_id_t);
-extern struct interface *if_lookup_by_ipv6(struct in6_addr *, ifindex_t,
-					   vrf_id_t);
-extern struct interface *if_lookup_by_ipv6_exact(struct in6_addr *, ifindex_t,
-						 vrf_id_t);
+extern struct interface *if_lookup_by_ipv4(struct in_addr *addr,
+					   vrf_id_t vrf_id);
+extern struct interface *if_lookup_by_ipv4_exact(struct in_addr *addr,
+						 vrf_id_t vrf_id);
+extern struct interface *if_lookup_by_ipv6(struct in6_addr *addr,
+					   ifindex_t ifindex, vrf_id_t vrf_id);
+extern struct interface *if_lookup_by_ipv6_exact(struct in6_addr *addr,
+						 ifindex_t ifindex,
+						 vrf_id_t vrf_id);
 extern int bgp_zebra_advertise_subnet(struct bgp *bgp, int advertise,
 				      vni_t vni);
-extern int bgp_zebra_advertise_gw_macip(struct bgp *, int, vni_t);
+extern int bgp_zebra_advertise_gw_macip(struct bgp *bgp, int advertise,
+					vni_t vni);
 extern int bgp_zebra_advertise_svi_macip(struct bgp *bgp, int advertise,
 					 vni_t vni);
-extern int bgp_zebra_advertise_all_vni(struct bgp *, int);
+extern int bgp_zebra_advertise_all_vni(struct bgp *bgp, int advertise);
 extern int bgp_zebra_dup_addr_detection(struct bgp *bgp);
 extern int bgp_zebra_vxlan_flood_control(struct bgp *bgp,
 					 enum vxlan_flood_control flood_ctrl);
 
 extern int bgp_zebra_num_connects(void);
 
-extern bool bgp_zebra_nexthop_set(union sockunion *, union sockunion *,
-				  struct bgp_nexthop *, struct peer *);
+extern bool bgp_zebra_nexthop_set(union sockunion *local,
+				  union sockunion *remote,
+				  struct bgp_nexthop *nexthop,
+				  struct peer *peer);
 struct bgp_pbr_action;
 struct bgp_pbr_match;
 struct bgp_pbr_rule;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -232,8 +232,17 @@ void bgp_option_norib_set_runtime(void)
 	zlog_info("Disabled BGP route installation to RIB (Zebra)");
 
 	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp)) {
-		FOREACH_AFI_SAFI(afi, safi)
+		FOREACH_AFI_SAFI (afi, safi) {
+			/*
+			 * Stop a crash, more work is needed
+			 * here to properly add/remove these types of
+			 * routes from zebra.
+			 */
+			if (!bgp_fibupd_safi(safi))
+				continue;
+
 			bgp_zebra_withdraw_table_all_subtypes(bgp, afi, safi);
+		}
 	}
 
 	zlog_info("All routes have been withdrawn from RIB (Zebra)");
@@ -255,8 +264,17 @@ void bgp_option_norib_unset_runtime(void)
 	zlog_info("Enabled BGP route installation to RIB (Zebra)");
 
 	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp)) {
-		FOREACH_AFI_SAFI(afi, safi)
+		FOREACH_AFI_SAFI (afi, safi) {
+			/*
+			 * Stop a crash, more work is needed
+			 * here to properly add/remove these types
+			 * of routes from zebra
+			 */
+			if (!bgp_fibupd_safi(safi))
+				continue;
+
 			bgp_zebra_announce_table_all_subtypes(bgp, afi, safi);
+		}
 	}
 
 	zlog_info("All routes have been installed in RIB (Zebra)");

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -620,8 +620,7 @@ struct bgp {
 	struct bgp_maxpaths_cfg {
 		uint16_t maxpaths_ebgp;
 		uint16_t maxpaths_ibgp;
-		uint16_t ibgp_flags;
-#define BGP_FLAG_IBGP_MULTIPATH_SAME_CLUSTERLEN (1 << 0)
+		bool same_clusterlen;
 	} maxpaths[AFI_MAX][SAFI_MAX];
 
 	_Atomic uint32_t wpkt_quanta; // max # packets to write per i/o cycle

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3996,7 +3996,8 @@ the daemons RIB from Zebra and unsetting it will announce all routes in the
 daemons RIB to Zebra. If the option is passed as a command line argument when
 starting the daemon and the configuration gets saved, the option will persist
 unless removed from the configuration with the negating command prior to the
-configuration write operation.
+configuration write operation.  At this point in time non SAFI_UNICAST BGP
+data is not properly withdrawn from zebra when this command is issued.
 
 .. clicmd:: bgp send-extra-data zebra
 


### PR DESCRIPTION
See individual commits

a) Fix #11178 to no longer crash.  There was a conscious decision to not properly handle the non - standard safi's in cleanup or install when this command is issued.  Note this in the documentation

b) Change a uint16_t bit field to a bool since we only had 1 flag

c) A bunch of header cleanup in bgp