### PR TITLE
zebra: Add startup message and display netlink buffer size.

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -79,8 +79,9 @@ int graceful_restart;
 bool v6_rr_semantics = false;
 
 /* Receive buffer size for kernel control sockets */
+#define RCVBUFSIZE_MIN 4194304
 #ifdef HAVE_NETLINK
-uint32_t rcvbufsize = 4194304;
+uint32_t rcvbufsize = RCVBUFSIZE_MIN;
 #else
 uint32_t rcvbufsize = 128 * 1024;
 #endif
@@ -365,6 +366,10 @@ int main(int argc, char **argv)
 			break;
 		case 's':
 			rcvbufsize = atoi(optarg);
+			if (rcvbufsize < RCVBUFSIZE_MIN)
+				fprintf(stderr,
+					"Rcvbufsize is smaller than recommended value: %d\n",
+					RCVBUFSIZE_MIN);
 			break;
 #ifdef HAVE_NETLINK
 		case 'n':

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3914,6 +3914,7 @@ DEFUN (show_zebra,
 		       ipforward_ipv6() ? "On" : "Off");
 	ttable_add_row(table, "MPLS|%s", mpls_enabled ? "On" : "Off");
 	ttable_add_row(table, "EVPN|%s", is_evpn_enabled() ? "On" : "Off");
+	ttable_add_row(table, "Kernel socket buffer size|%d", rcvbufsize);
 
 
 #ifdef GNU_LINUX


### PR DESCRIPTION
Add startup message and display netlink buffer size.

Signed-off-by: Loganaden Velvindron <logan@cyberstorm.mu>