### PR TITLE
bgpd: [8.2] Prevent crash when issuing various forms of `bgp no-rib`

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -232,8 +232,17 @@ void bgp_option_norib_set_runtime(void)
 	zlog_info("Disabled BGP route installation to RIB (Zebra)");
 
 	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp)) {
-		FOREACH_AFI_SAFI(afi, safi)
+		FOREACH_AFI_SAFI (afi, safi) {
+			/*
+			 * Stop a crash, more work is needed
+			 * here to properly add/remove these types of
+			 * routes from zebra.
+			 */
+			if (!bgp_fibupd_safi(safi))
+				continue;
+
 			bgp_zebra_withdraw_table_all_subtypes(bgp, afi, safi);
+		}
 	}
 
 	zlog_info("All routes have been withdrawn from RIB (Zebra)");
@@ -255,8 +264,17 @@ void bgp_option_norib_unset_runtime(void)
 	zlog_info("Enabled BGP route installation to RIB (Zebra)");
 
 	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp)) {
-		FOREACH_AFI_SAFI(afi, safi)
+		FOREACH_AFI_SAFI (afi, safi) {
+			/*
+			 * Stop a crash, more work is needed
+			 * here to properly add/remove these types
+			 * of routes from zebra
+			 */
+			if (!bgp_fibupd_safi(safi))
+				continue;
+
 			bgp_zebra_announce_table_all_subtypes(bgp, afi, safi);
+		}
 	}
 
 	zlog_info("All routes have been installed in RIB (Zebra)");

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3917,7 +3917,8 @@ the daemons RIB from Zebra and unsetting it will announce all routes in the
 daemons RIB to Zebra. If the option is passed as a command line argument when
 starting the daemon and the configuration gets saved, the option will persist
 unless removed from the configuration with the negating command prior to the
-configuration write operation.
+configuration write operation.  At this point in time non SAFI_UNICAST BGP
+data is not properly withdrawn from zebra when this command is issued.
 
 .. clicmd:: bgp send-extra-data zebra
 


### PR DESCRIPTION
The `bgp no-rib` command cycles through all the bgp rib tables
and removes them from zebra.  Modify the code so that FRR notices
that it is attempting to cycle through the safi's that are two level
tables.  In addition these safi's cannot just blindly remove the routes
from the rib as that there are none explicitly.

This code just prevents the crash in bgpd.  It does not properly cycle
through and remove the zebra changes made that are explicit to these afi's.
This should be handled as appropriate by the developers on these safi's when
it becomes important to them.

Fixes: #11178
Signed-off-by: Donald Sharp <sharpd@nvidia.com>