### PR TITLE
bgpd: Initialize prd for show_ip_bgp_l2vpn_evpn_rd_neighbor_routes()

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -1571,7 +1571,7 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_routes,
 	int ret;
 	struct peer *peer;
 	char *peerstr = NULL;
-	struct prefix_rd prd;
+	struct prefix_rd prd = {};
 	bool uj = use_json(argc, argv);
 	afi_t afi = AFI_L2VPN;
 	safi_t safi = SAFI_EVPN;


### PR DESCRIPTION
*** CID 1517751:  Uninitialized variables  (UNINIT)
/bgpd/bgp_evpn_vty.c: 1648 in show_ip_bgp_l2vpn_evpn_rd_neighbor_routes()
1642
1643
1644            if (rd_all)
1645                    return bgp_show_ethernet_vpn(vty, NULL, bgp_show_type_neighbor,
1646                                                 peer, SHOW_DISPLAY_STANDARD, uj);
1647            else
>>>     CID 1517751:  Uninitialized variables  (UNINIT)
>>>     Using uninitialized element of array "prd.val" when calling "bgp_show_ethernet_vpn".
1648                    return bgp_show_ethernet_vpn(vty, &prd, bgp_show_type_neighbor,
1649                                                 peer, SHOW_DISPLAY_STANDARD, uj);
1650     }
1651
1652     DEFUN(show_ip_bgp_l2vpn_evpn_neighbor_advertised_routes,
1653           show_ip_bgp_l2vpn_evpn_neighbor_advertised_routes_cmd,

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>