### PR TITLE
zebra: remove unnecessary check for "zevpn_vrf"

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -4493,8 +4493,6 @@ static int netlink_fdb_nh_update(uint32_t nh_id, struct in_addr vtep_ip)
 	struct zebra_ns *zns;
 
 	zvrf = zebra_vrf_get_evpn();
-	if (!zvrf)
-		return -1;
 	zns = zvrf->zns;
 
 	memset(&req, 0, sizeof(req));
@@ -4534,8 +4532,6 @@ static int netlink_fdb_nh_del(uint32_t nh_id)
 	struct zebra_ns *zns;
 
 	zvrf = zebra_vrf_get_evpn();
-	if (!zvrf)
-		return -1;
 	zns = zvrf->zns;
 
 	memset(&req, 0, sizeof(req));
@@ -4572,8 +4568,6 @@ static int netlink_fdb_nhg_update(uint32_t nhg_id, uint32_t nh_cnt,
 	uint32_t i;
 
 	zvrf = zebra_vrf_get_evpn();
-	if (!zvrf)
-		return -1;
 	zns = zvrf->zns;
 
 	memset(&req, 0, sizeof(req));

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -73,7 +73,7 @@ int advertise_gw_macip_enabled(struct zebra_evpn *zevpn)
 	struct zebra_vrf *zvrf;
 
 	zvrf = zebra_vrf_get_evpn();
-	if (zvrf && zvrf->advertise_gw_macip)
+	if (zvrf->advertise_gw_macip)
 		return 1;
 
 	if (zevpn && zevpn->advertise_gw_macip)
@@ -87,7 +87,7 @@ int advertise_svi_macip_enabled(struct zebra_evpn *zevpn)
 	struct zebra_vrf *zvrf;
 
 	zvrf = zebra_vrf_get_evpn();
-	if (zvrf && zvrf->advertise_svi_macip)
+	if (zvrf->advertise_svi_macip)
 		return 1;
 
 	if (zevpn && zevpn->advertise_svi_macip)
@@ -999,7 +999,6 @@ struct zebra_evpn *zebra_evpn_lookup(vni_t vni)
 	struct zebra_evpn *zevpn = NULL;
 
 	zvrf = zebra_vrf_get_evpn();
-	assert(zvrf);
 	memset(&tmp_vni, 0, sizeof(tmp_vni));
 	tmp_vni.vni = vni;
 	zevpn = hash_lookup(zvrf->evpn_table, &tmp_vni);
@@ -1018,7 +1017,6 @@ struct zebra_evpn *zebra_evpn_add(vni_t vni)
 	struct zebra_evpn *zevpn = NULL;
 
 	zvrf = zebra_vrf_get_evpn();
-	assert(zvrf);
 	memset(&tmp_zevpn, 0, sizeof(tmp_zevpn));
 	tmp_zevpn.vni = vni;
 	zevpn = hash_get(zvrf->evpn_table, &tmp_zevpn, zebra_evpn_alloc);
@@ -1046,7 +1044,6 @@ int zebra_evpn_del(struct zebra_evpn *zevpn)
 	struct zebra_evpn *tmp_zevpn;
 
 	zvrf = zebra_vrf_get_evpn();
-	assert(zvrf);
 
 	zevpn->svi_if = NULL;
 
@@ -1454,10 +1451,6 @@ void zebra_evpn_rem_macip_add(vni_t vni, const struct ethaddr *macaddr,
 	}
 
 	zvrf = zebra_vrf_get_evpn();
-	if (!zvrf)
-		return;
-
-
 	if (zebra_evpn_mac_remote_macip_add(zevpn, zvrf, macaddr, ipa_len,
 					    ipaddr, &mac, vtep_ip, flags, seq,
 					    esi)

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -625,9 +625,6 @@ void zebra_evpn_print_mac(struct zebra_mac *mac, void *ctxt, json_object *json)
 	char up_str[MONOTIME_STRLEN];
 
 	zvrf = zebra_vrf_get_evpn();
-	if (!zvrf)
-		return;
-
 	vty = (struct vty *)ctxt;
 	prefix_mac2str(&mac->macaddr, buf1, sizeof(buf1));
 

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -2066,11 +2066,6 @@ static void zebra_evpn_mh_dup_addr_detect_off(void)
 		return;
 
 	zvrf = zebra_vrf_get_evpn();
-	if (!zvrf) {
-		zmh_info->flags |= ZEBRA_EVPN_MH_DUP_ADDR_DETECT_OFF;
-		return;
-	}
-
 	old_detect = zebra_evpn_do_dup_addr_detect(zvrf);
 	zmh_info->flags |= ZEBRA_EVPN_MH_DUP_ADDR_DETECT_OFF;
 	new_detect = zebra_evpn_do_dup_addr_detect(zvrf);

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -1718,9 +1718,6 @@ void zebra_evpn_print_neigh(struct zebra_neigh *n, void *ctxt,
 	char up_str[MONOTIME_STRLEN];
 
 	zvrf = zebra_vrf_get_evpn();
-	if (!zvrf)
-		return;
-
 	uptime = monotime(NULL);
 	uptime -= n->uptime;
 

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -1148,7 +1148,6 @@ int lib_vrf_zebra_l3vni_id_modify(struct nb_cb_modify_args *args)
 	struct zebra_vrf *zvrf;
 	vni_t vni = 0;
 	struct zebra_l3vni *zl3vni = NULL;
-	struct zebra_vrf *zvrf_evpn = NULL;
 	char err[ERR_STR_SZ];
 	bool pfx_only = false;
 	const struct lyd_node *pn_dnode;
@@ -1159,12 +1158,6 @@ int lib_vrf_zebra_l3vni_id_modify(struct nb_cb_modify_args *args)
 	case NB_EV_ABORT:
 		return NB_OK;
 	case NB_EV_VALIDATE:
-		zvrf_evpn = zebra_vrf_get_evpn();
-		if (!zvrf_evpn) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "evpn vrf is not present.");
-			return NB_ERR_VALIDATION;
-		}
 		vni = yang_dnode_get_uint32(args->dnode, NULL);
 		/* Get vrf info from parent node, reject configuration
 		 * if zebra vrf already mapped to different vni id.

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -928,9 +928,6 @@ static int zevpn_build_hash_table_zns(struct ns *ns,
 
 	zvrf = zebra_vrf_get_evpn();
 
-	if (!zvrf)
-		return NS_WALK_STOP;
-
 	/* Walk VxLAN interfaces and create EVPN hash. */
 	for (rn = route_top(zns->if_table); rn; rn = route_next(rn)) {
 		vni_t vni;
@@ -1744,9 +1741,6 @@ static int zl3vni_map_to_vxlan_if_ns(struct ns *ns,
 	struct zebra_vrf *zvrf;
 
 	zvrf = zebra_vrf_get_evpn();
-
-	if (!zvrf)
-		return NS_WALK_STOP;
 
 	assert(_pifp);
 
@@ -3496,8 +3490,6 @@ void zebra_vxlan_print_evpn(struct vty *vty, bool uj)
 		return;
 
 	zvrf = zebra_vrf_get_evpn();
-	if (!zvrf)
-		return;
 
 	num_l3vnis = hashcount(zrouter.l3vni_table);
 	num_l2vnis = hashcount(zvrf->evpn_table);
@@ -4199,12 +4191,6 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 	}
 
 	zvrf = zebra_vrf_get_evpn();
-	if (!zvrf) {
-		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug("        No Evpn Global Vrf found");
-		return -1;
-	}
-
 	return zebra_evpn_add_update_local_mac(zvrf, zevpn, ifp, macaddr, vid,
 					       sticky, local_inactive,
 					       dp_static, NULL);
@@ -5275,8 +5261,6 @@ int zebra_vxlan_process_vrf_vni_cmd(struct zebra_vrf *zvrf, vni_t vni,
 	struct zebra_vrf *zvrf_evpn = NULL;
 
 	zvrf_evpn = zebra_vrf_get_evpn();
-	if (!zvrf_evpn)
-		return -1;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
 		zlog_debug("vrf %s vni %u %s", zvrf_name(zvrf), vni,
@@ -5873,8 +5857,6 @@ void zebra_vxlan_cleanup_tables(struct zebra_vrf *zvrf)
 {
 	struct zebra_vrf *evpn_zvrf = zebra_vrf_get_evpn();
 
-	if (!zvrf)
-		return;
 	hash_iterate(zvrf->evpn_table, zebra_evpn_vxlan_cleanup_all, zvrf);
 	zebra_vxlan_cleanup_sg_table(zvrf);
 
@@ -6252,7 +6234,7 @@ static int zebra_evpn_pim_cfg_clean_up(struct zserv *client)
 {
 	struct zebra_vrf *zvrf = zebra_vrf_get_evpn();
 
-	if (zvrf && CHECK_FLAG(zvrf->flags, ZEBRA_PIM_SEND_VXLAN_SG)) {
+	if (CHECK_FLAG(zvrf->flags, ZEBRA_PIM_SEND_VXLAN_SG)) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug("VxLAN SG updates to PIM, stop");
 		UNSET_FLAG(zvrf->flags, ZEBRA_PIM_SEND_VXLAN_SG);

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -45,18 +45,13 @@ extern "C" {
 #define EVPN_ENABLED(zvrf)  (zvrf)->advertise_all_vni
 static inline int is_evpn_enabled(void)
 {
-	struct zebra_vrf *zvrf = NULL;
-	zvrf = zebra_vrf_get_evpn();
-	return zvrf ? EVPN_ENABLED(zvrf) : 0;
+	return EVPN_ENABLED(zebra_vrf_get_evpn());
 }
 
 static inline int
 is_vxlan_flooding_head_end(void)
 {
 	struct zebra_vrf *zvrf = zebra_vrf_get_evpn();
-
-	if (!zvrf)
-		return 0;
 	return (zvrf->vxlan_flood_ctrl == VXLAN_FLOOD_HEAD_END_REPL);
 }
 


### PR DESCRIPTION
The global vrf in zebra is always non-NULL. In general, it is bound to
default vrf by `zebra_vrf_init()`, at other times bound to some specific
vrf. Anyway, non-NULL.
    
So remove all redundant checkings for the returned value of
`zebra_vrf_get_evpn()`.
    
Additionally, remove the unnecessary check for `zvrf` in
`zebra_vxlan_cleanup_tables()`.