### PR TITLE
bgpd: Fix coverity SA issue with copying over prefix data

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5694,12 +5694,12 @@ int bgp_nlri_parse_ip(struct peer *peer, struct attr *attr,
 		}
 
 		/* Defensive coding, double-check the psize fits in a struct
-		 * prefix */
-		if (psize > (ssize_t)sizeof(p.u)) {
+		 * prefix for the v4 and v6 afi's and unicast/multicast */
+		if (psize > (ssize_t)sizeof(p.u.val)) {
 			flog_err(
 				EC_BGP_UPDATE_RCV,
 				"%s [Error] Update packet error (prefix length %d too large for prefix storage %zu)",
-				peer->host, p.prefixlen, sizeof(p.u));
+				peer->host, p.prefixlen, sizeof(p.u.val));
 			return BGP_NLRI_PARSE_ERROR_PACKET_LENGTH;
 		}
 


### PR DESCRIPTION
in bgp_nlri_parse_ip there is a `sanity` check to ensure
that the prefix length as specified by the packet
will fit inside of a `struct prefix` correctly.  The problem
here of course is that this is only v4 / v6 unicast/multicast
parsing and the bytes will never be more than 16, but we are copying
into a part of the struct prefix that is only 16 bytes, but with
this check the length may be up to 47 bytes( but not really possible ).

Limit the size check to at most 16 bytes (since we are only handling
v4 or v6 addresses here )

Signed-off-by: Donald Sharp <sharpd@nvidia.com>