### PR TITLE
ospf6d: Give time left in hello timer for `show ipv6 ospf6 int`

### DIFF
--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -827,7 +827,7 @@ void interface_up(struct thread *thread)
 	/* Schedule Hello */
 	if (!CHECK_FLAG(oi->flag, OSPF6_INTERFACE_PASSIVE)
 	    && !if_is_loopback(oi->interface)) {
-		thread_add_event(master, ospf6_hello_send, oi, 0,
+		thread_add_timer(master, ospf6_hello_send, oi, 0,
 				 &oi->thread_send_hello);
 	}
 
@@ -2102,6 +2102,16 @@ DEFUN (ipv6_ospf6_hellointerval,
 	oi->hello_interval = strmatch(argv[0]->text, "no")
 				     ? OSPF_HELLO_INTERVAL_DEFAULT
 				     : strtoul(argv[idx_number]->arg, NULL, 10);
+
+	/*
+	 * If the thread is scheduled, send the new hello now.
+	 */
+	if (thread_is_scheduled(oi->thread_send_hello)) {
+		THREAD_OFF(oi->thread_send_hello);
+
+		thread_add_timer(master, ospf6_hello_send, oi, 0,
+				 &oi->thread_send_hello);
+	}
 	return CMD_SUCCESS;
 }
 
@@ -2348,7 +2358,7 @@ DEFUN (no_ipv6_ospf6_passive,
 
 	/* don't send hellos over loopback interface */
 	if (!if_is_loopback(oi->interface))
-		thread_add_event(master, ospf6_hello_send, oi, 0,
+		thread_add_timer(master, ospf6_hello_send, oi, 0,
 				 &oi->thread_send_hello);
 
 	return CMD_SUCCESS;

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1130,9 +1130,9 @@ static int ospf6_interface_show(struct vty *vty, struct interface *ifp,
 			ospf6_interface_state_str[oi->state], oi->transdelay,
 			oi->priority);
 		vty_out(vty, "  Timer intervals configured:\n");
-		vty_out(vty, "   Hello %d, Dead %d, Retransmit %d\n",
-			oi->hello_interval, oi->dead_interval,
-			oi->rxmt_interval);
+		vty_out(vty, "   Hello %d(%pTHd), Dead %d, Retransmit %d\n",
+			oi->hello_interval, oi->thread_send_hello,
+			oi->dead_interval, oi->rxmt_interval);
 	}
 
 	inet_ntop(AF_INET, &oi->drouter, drouter, sizeof(drouter));

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -2242,7 +2242,6 @@ void ospf6_hello_send(struct thread *thread)
 	uint16_t length = OSPF6_HEADER_SIZE;
 
 	oi = (struct ospf6_interface *)THREAD_ARG(thread);
-	oi->thread_send_hello = (struct thread *)NULL;
 
 	if (oi->state <= OSPF6_INTERFACE_DOWN) {
 		if (IS_OSPF6_DEBUG_MESSAGE(OSPF6_MESSAGE_TYPE_HELLO, SEND_HDR))


### PR DESCRIPTION
When running `show ipv6 ospf6 interface` the hello timer period
is shown, but there is no indication on how much time is left
on the timer.  Add a clue:

sharpd@eva ~/frr5 (master)> vtysh -c "show ipv6 ospf6 int"
enp39s0 is up, type BROADCAST
  Interface ID: 2
  Internet Address:
    inet : 192.168.119.224/24
    inet6: 2603:6080:602:509e:9a14:998:b154:9e9/64
  Instance ID 0, Interface MTU 1500 (autodetect: 1500)
  MTU mismatch detection: enabled
  Area ID 0.0.0.0, Cost 1000
  State DR, Transmit Delay 1 sec, Priority 1
  Timer intervals configured:
   Hello 10(2.652), Dead 40, Retransmit 5
  DR: 192.168.122.1 BDR: 0.0.0.0
  Number of I/F scoped LSAs is 1
    0 Pending LSAs for LSUpdate in Time 00:00:00 [thread off]
    0 Pending LSAs for LSAck in Time 00:00:00 [thread off]
  Authentication Trailer is disabled

Signed-off-by: Donald Sharp <sharpd@nvidia.com>