### PR TITLE
lib/if: fix interface name comparison

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -77,57 +77,7 @@ static struct interface_master{
  */
 int if_cmp_name_func(const char *p1, const char *p2)
 {
-	unsigned int l1, l2;
-	long int x1, x2;
-	int res;
-
-	while (*p1 && *p2) {
-		/* look up to any number */
-		l1 = strcspn(p1, "0123456789");
-		l2 = strcspn(p2, "0123456789");
-
-		/* name lengths are different -> compare names */
-		if (l1 != l2)
-			return (strcmp(p1, p2));
-
-		/* Note that this relies on all numbers being less than all
-		 * letters, so
-		 * that de0 < del0.
-		 */
-		res = strncmp(p1, p2, l1);
-
-		/* names are different -> compare them */
-		if (res)
-			return res;
-
-		/* with identical name part, go to numeric part */
-		p1 += l1;
-		p2 += l1;
-
-		if (!*p1 && !*p2)
-			return 0;
-		if (!*p1)
-			return -1;
-		if (!*p2)
-			return 1;
-
-		x1 = strtol(p1, (char **)&p1, 10);
-		x2 = strtol(p2, (char **)&p2, 10);
-
-		/* let's compare numbers now */
-		if (x1 < x2)
-			return -1;
-		if (x1 > x2)
-			return 1;
-
-		/* numbers were equal, lets do it again..
-		(it happens with name like "eth123.456:789") */
-	}
-	if (*p1)
-		return 1;
-	if (*p2)
-		return -1;
-	return 0;
+	return strverscmp(p1, p2);
 }
 
 static int if_cmp_func(const struct interface *ifp1,

--- a/lib/strverscmp.c
+++ b/lib/strverscmp.c
@@ -1,0 +1,63 @@
+/* Compare strings while treating digits characters numerically.
+ * musl as a whole is licensed under the following standard MIT license:
+ * ----------------------------------------------------------------------
+ * Copyright © 2005-2020 Rich Felker, et al.
+
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * ----------------------------------------------------------------------
+ */
+#include "zebra.h"
+
+#if defined(OPEN_BSD) || defined(__NetBSD__) || defined(__FreeBSD__)
+#include <ctype.h>
+#include <string.h>
+
+int strverscmp(const char *l0, const char *r0)
+{
+	const unsigned char *l = (const void *)l0;
+	const unsigned char *r = (const void *)r0;
+	size_t i, dp, j;
+	int z = 1;
+
+	/* Find maximal matching prefix and track its maximal digit
+	 * suffix and whether those digits are all zeros. */
+	for (dp=i=0; l[i]==r[i]; i++) {
+		int c = l[i];
+		if (!c) return 0;
+		if (!isdigit(c)) dp=i+1, z=1;
+		else if (c!='0') z=0;
+	}
+
+	if (l[dp]!='0' && r[dp]!='0') {
+		/* If we're not looking at a digit sequence that began
+		 * with a zero, longest digit string is greater. */
+		for (j=i; isdigit(l[j]); j++)
+			if (!isdigit(r[j])) return 1;
+		if (isdigit(r[j])) return -1;
+	} else if (z && dp<i && (isdigit(l[i]) || isdigit(r[i]))) {
+		/* Otherwise, if common prefix of digit sequence is
+		 * all zeros, digits order less than non-digits. */
+		return (unsigned char)(l[i]-'0') - (unsigned char)(r[i]-'0');
+	}
+
+	return l[i] - r[i];
+}
+
+#endif

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -95,6 +95,7 @@ lib_libfrr_la_SOURCES = \
 	lib/strformat.c \
 	lib/strlcat.c \
 	lib/strlcpy.c \
+	lib/strverscmp.c \
 	lib/systemd.c \
 	lib/table.c \
 	lib/termtable.c \

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -230,6 +230,8 @@ size_t strlcpy(char *__restrict dest,
 	       const char *__restrict src, size_t destsize);
 #endif
 
+int strverscmp(const char *s1, const char *s2);
+
 #if !defined(HAVE_STRUCT_MMSGHDR_MSG_HDR) || !defined(HAVE_SENDMMSG)
 /* avoid conflicts in case we have partial support */
 #define mmsghdr frr_mmsghdr


### PR DESCRIPTION
Using strtol() to compare two strings is a bad idea.
Before the patch, if_cmp_name_func() may confuse foo001 and foo1.

Let's use frr_version_cmp(), which classify foo2 before foo10, as expected.

Fixes: 106d2fd ("2003-08-01 Cougar <cougar@random.ee>")
Signed-off-by: Nicolas Dichtel <nicolas.dichtel@6wind.com>
Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>