### PR TITLE
tests: Fix for test_pim_dr_nondr_with_ospf_topo2 test failure

### DIFF
--- a/tests/topotests/lib/pim.py
+++ b/tests/topotests/lib/pim.py
@@ -273,18 +273,20 @@ def create_igmp_config(tgen, topo, input_dict=None, build=False):
                 config_data.append(cmd)
                 protocol = "igmp"
                 del_action = intf_data[intf_name]["igmp"].setdefault("delete", False)
+                del_attr = intf_data[intf_name]["igmp"].setdefault("delete_attr", False)
                 cmd = "ip igmp"
                 if del_action:
                     cmd = "no {}".format(cmd)
-                config_data.append(cmd)
+                if not del_attr:
+                    config_data.append(cmd)
 
-                del_attr = intf_data[intf_name]["igmp"].setdefault("delete_attr", False)
                 for attribute, data in intf_data[intf_name]["igmp"].items():
                     if attribute == "version":
                         cmd = "ip {} {} {}".format(protocol, attribute, data)
                         if del_action:
                             cmd = "no {}".format(cmd)
-                        config_data.append(cmd)
+                        if not del_attr:
+                            config_data.append(cmd)
 
                     if attribute == "join":
                         for group in data:

--- a/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_ospf_topo2.py
+++ b/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_ospf_topo2.py
@@ -894,36 +894,36 @@ def test_configuring_igmp_local_join_on_reciever_dr_non_dr_nodes_p1(request):
         assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     step("Delete local join from DR node")
-    input_dict = {
-        "r1": {
-            "igmp": {
-                "interfaces": {
-                    vlan_intf_r1_s1: {
-                        "igmp": {
-                            "version": "2",
-                            "join": IGMP_JOIN_RANGE_3,
-                            "delete_attr": True,
+    for _join in IGMP_JOIN_RANGE_3:
+        input_dict = {
+            "r1": {
+                "igmp": {
+                    "interfaces": {
+                        vlan_intf_r1_s1: {
+                            "igmp": {
+                                "join": [_join],
+                                "delete_attr": True,
+                            }
                         }
                     }
                 }
             }
         }
-    }
 
-    result = create_igmp_config(tgen, topo, input_dict)
-    assert result is True, "Testcase {}: Failed Error: {}".format(tc_name, result)
+        result = create_igmp_config(tgen, topo, input_dict)
+        assert result is True, "Testcase {}: Failed Error: {}".format(tc_name, result)
 
-    step(
-        "After removing local join 227.1.1.1 group removed from IGMP join "
-        "of R1, R2 node , using 'show ip igmp groups json'"
-    )
-
-    for dut, intf in zip(["r1", "r2"], [intf_r1_s1, intf_r2_s1]):
-        result = verify_igmp_groups(tgen, dut, intf, IGMP_JOIN_RANGE_3, expected=False)
-        assert result is not True, (
-            "Testcase {} : Failed \n "
-            "IGMP groups are still present \n Error: {}".format(tc_name, result)
+        step(
+            "After removing local join 227.1.1.1 group removed from IGMP join "
+            "of R1, R2 node , using 'show ip igmp groups json'"
         )
+
+        for dut, intf in zip(["r1", "r2"], [intf_r1_s1, intf_r2_s1]):
+            result = verify_igmp_groups(tgen, dut, intf, IGMP_JOIN_RANGE_3, expected=False)
+            assert result is not True, (
+                "Testcase {} : Failed \n "
+                "IGMP groups are still present \n Error: {}".format(tc_name, result)
+            )
 
     step("(*,G) mroute for 227.1.1.1 group removed from R1 node")
     step(


### PR DESCRIPTION
This test is failing intermittently because sometimes igmp
local join is not getting deleted. I did following changes:
1. I did split the joins means trying to delete igmp local joins 
    one by one. 
2. Running join delete command only, previously it was run 
    along with ip igmp and ip igmp version 2 command.

I tried running tests multiple times and it seems to be working fine with
current changes.

There was an issue found during debugging this test failure,
issue was raised already:
Issue# https://github.com/FRRouting/frr/issues/11105

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>