### PR TITLE
doc: use real wording for the show isis segment-routing node command

### DIFF
--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -411,7 +411,7 @@ Known limitations:
    clear the Node flag that is set by default for Prefix-SIDs associated to
    loopback addresses. This option is necessary to configure Anycast-SIDs.
 
-.. clicmd:: show isis segment-routing nodes
+.. clicmd:: show isis segment-routing node
 
    Show detailed information about all learned Segment Routing Nodes.
 


### PR DESCRIPTION
The node keyword does not take 's' at the end.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>