### PR TITLE
Ospfv3 shenanigans

### DIFF
--- a/lib/thread.c
+++ b/lib/thread.c
@@ -2143,14 +2143,6 @@ void debug_signals(const sigset_t *sigs)
 	zlog_debug("%s: %s", __func__, buf);
 }
 
-bool thread_is_scheduled(struct thread *thread)
-{
-	if (thread == NULL)
-		return false;
-
-	return true;
-}
-
 static ssize_t printfrr_thread_dbg(struct fbuf *buf, struct printfrr_eargs *ea,
 				   const struct thread *thread)
 {

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -283,7 +283,14 @@ extern pthread_key_t thread_current;
 extern char *thread_timer_to_hhmmss(char *buf, int buf_size,
 		struct thread *t_timer);
 
-extern bool thread_is_scheduled(struct thread *thread);
+static inline bool thread_is_scheduled(struct thread *thread)
+{
+	if (thread)
+		return true;
+
+	return false;
+}
+
 /* Debug signal mask */
 void debug_signals(const sigset_t *sigs);
 

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1121,7 +1121,7 @@ void ospf6_asbr_distribute_list_update(struct ospf6 *ospf6,
 {
 	SET_FLAG(red->flag, OSPF6_IS_RMAP_CHANGED);
 
-	if (ospf6->t_distribute_update)
+	if (thread_is_scheduled(ospf6->t_distribute_update))
 		return;
 
 	if (IS_OSPF6_DEBUG_ASBR)
@@ -3360,7 +3360,7 @@ ospf6_start_asbr_summary_delay_timer(struct ospf6 *ospf6,
 {
 	aggr->action = operation;
 
-	if (ospf6->t_external_aggr) {
+	if (thread_is_scheduled(ospf6->t_external_aggr)) {
 		if (ospf6->aggr_action == OSPF6_ROUTE_AGGR_ADD) {
 
 			if (IS_OSPF6_DEBUG_AGGR)

--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -459,7 +459,6 @@ static void ospf6_gr_grace_period_expired(struct thread *thread)
 {
 	struct ospf6 *ospf6 = THREAD_ARG(thread);
 
-	ospf6->gr_info.t_grace_period = NULL;
 	ospf6_gr_restart_exit(ospf6, "grace period has expired");
 }
 

--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -400,8 +400,7 @@ int ospf6_process_grace_lsa(struct ospf6 *ospf6, struct ospf6_lsa *lsa,
 	}
 
 	if (OSPF6_GR_IS_ACTIVE_HELPER(restarter)) {
-		if (restarter->gr_helper_info.t_grace_timer)
-			THREAD_OFF(restarter->gr_helper_info.t_grace_timer);
+		THREAD_OFF(restarter->gr_helper_info.t_grace_timer);
 
 		if (ospf6->ospf6_helper_cfg.active_restarter_cnt > 0)
 			ospf6->ospf6_helper_cfg.active_restarter_cnt--;

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1152,7 +1152,7 @@ static int ospf6_interface_show(struct vty *vty, struct interface *ifp,
 
 	if (use_json) {
 		timerclear(&res);
-		if (oi->thread_send_lsupdate)
+		if (thread_is_scheduled(oi->thread_send_lsupdate))
 			timersub(&oi->thread_send_lsupdate->u.sands, &now,
 				 &res);
 		timerstring(&res, duration, sizeof(duration));
@@ -1162,7 +1162,9 @@ static int ospf6_interface_show(struct vty *vty, struct interface *ifp,
 				       duration);
 		json_object_string_add(
 			json_obj, "lsUpdateSendThread",
-			(oi->thread_send_lsupdate ? "on" : "off"));
+			(thread_is_scheduled(oi->thread_send_lsupdate)
+				 ? "on"
+				 : "off"));
 
 		json_arr = json_object_new_array();
 		for (ALL_LSDB(oi->lsupdate_list, lsa, lsanext))
@@ -1172,7 +1174,7 @@ static int ospf6_interface_show(struct vty *vty, struct interface *ifp,
 				       json_arr);
 
 		timerclear(&res);
-		if (oi->thread_send_lsack)
+		if (thread_is_scheduled(oi->thread_send_lsack))
 			timersub(&oi->thread_send_lsack->u.sands, &now, &res);
 		timerstring(&res, duration, sizeof(duration));
 
@@ -1180,8 +1182,10 @@ static int ospf6_interface_show(struct vty *vty, struct interface *ifp,
 				    oi->lsack_list->count);
 		json_object_string_add(json_obj, "pendingLsaLsAckTime",
 				       duration);
-		json_object_string_add(json_obj, "lsAckSendThread",
-				       (oi->thread_send_lsack ? "on" : "off"));
+		json_object_string_add(
+			json_obj, "lsAckSendThread",
+			(thread_is_scheduled(oi->thread_send_lsack) ? "on"
+								    : "off"));
 
 		json_arr = json_object_new_array();
 		for (ALL_LSDB(oi->lsack_list, lsa, lsanext))
@@ -1191,25 +1195,28 @@ static int ospf6_interface_show(struct vty *vty, struct interface *ifp,
 
 	} else {
 		timerclear(&res);
-		if (oi->thread_send_lsupdate)
+		if (thread_is_scheduled(oi->thread_send_lsupdate))
 			timersub(&oi->thread_send_lsupdate->u.sands, &now,
 				 &res);
 		timerstring(&res, duration, sizeof(duration));
 		vty_out(vty,
 			"    %d Pending LSAs for LSUpdate in Time %s [thread %s]\n",
 			oi->lsupdate_list->count, duration,
-			(oi->thread_send_lsupdate ? "on" : "off"));
+			(thread_is_scheduled(oi->thread_send_lsupdate)
+				 ? "on"
+				 : "off"));
 		for (ALL_LSDB(oi->lsupdate_list, lsa, lsanext))
 			vty_out(vty, "      %s\n", lsa->name);
 
 		timerclear(&res);
-		if (oi->thread_send_lsack)
+		if (thread_is_scheduled(oi->thread_send_lsack))
 			timersub(&oi->thread_send_lsack->u.sands, &now, &res);
 		timerstring(&res, duration, sizeof(duration));
 		vty_out(vty,
 			"    %d Pending LSAs for LSAck in Time %s [thread %s]\n",
 			oi->lsack_list->count, duration,
-			(oi->thread_send_lsack ? "on" : "off"));
+			(thread_is_scheduled(oi->thread_send_lsack) ? "on"
+								    : "off"));
 		for (ALL_LSDB(oi->lsack_list, lsa, lsanext))
 			vty_out(vty, "      %s\n", lsa->name);
 	}

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -2339,7 +2339,6 @@ void ospf6_dbdesc_send(struct thread *thread)
 	struct ospf6_packet *op;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
-	on->thread_send_dbdesc = (struct thread *)NULL;
 
 	if (on->state < OSPF6_NEIGHBOR_EXSTART) {
 		if (IS_OSPF6_DEBUG_MESSAGE(OSPF6_MESSAGE_TYPE_DBDESC, SEND))
@@ -2505,7 +2504,6 @@ void ospf6_lsreq_send(struct thread *thread)
 	uint16_t length = OSPF6_HEADER_SIZE;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
-	on->thread_send_lsreq = (struct thread *)NULL;
 
 	/* LSReq will be sent only in ExStart or Loading */
 	if (on->state != OSPF6_NEIGHBOR_EXCHANGE
@@ -2685,7 +2683,6 @@ void ospf6_lsupdate_send_neighbor(struct thread *thread)
 	int lsa_cnt = 0;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
-	on->thread_send_lsupdate = (struct thread *)NULL;
 
 	if (IS_OSPF6_DEBUG_MESSAGE(OSPF6_MESSAGE_TYPE_LSUPDATE, SEND_HDR))
 		zlog_debug("LSUpdate to neighbor %s", on->name);
@@ -2821,7 +2818,6 @@ void ospf6_lsupdate_send_interface(struct thread *thread)
 	int lsa_cnt = 0;
 
 	oi = (struct ospf6_interface *)THREAD_ARG(thread);
-	oi->thread_send_lsupdate = (struct thread *)NULL;
 
 	if (oi->state <= OSPF6_INTERFACE_WAITING) {
 		if (IS_OSPF6_DEBUG_MESSAGE(OSPF6_MESSAGE_TYPE_LSUPDATE,
@@ -2862,7 +2858,6 @@ void ospf6_lsack_send_neighbor(struct thread *thread)
 	uint16_t length = OSPF6_HEADER_SIZE;
 
 	on = (struct ospf6_neighbor *)THREAD_ARG(thread);
-	on->thread_send_lsack = (struct thread *)NULL;
 
 	if (on->state < OSPF6_NEIGHBOR_EXCHANGE) {
 		if (IS_OSPF6_DEBUG_MESSAGE(OSPF6_MESSAGE_TYPE_LSACK, SEND_HDR))
@@ -2939,7 +2934,6 @@ void ospf6_lsack_send_interface(struct thread *thread)
 	uint16_t length = OSPF6_HEADER_SIZE;
 
 	oi = (struct ospf6_interface *)THREAD_ARG(thread);
-	oi->thread_send_lsack = (struct thread *)NULL;
 
 	if (oi->state <= OSPF6_INTERFACE_WAITING) {
 		if (IS_OSPF6_DEBUG_MESSAGE(OSPF6_MESSAGE_TYPE_LSACK, SEND_HDR))

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -1007,7 +1007,7 @@ static void ospf6_abr_task_timer(struct thread *thread)
 
 void ospf6_schedule_abr_task(struct ospf6 *ospf6)
 {
-	if (ospf6->t_abr_task) {
+	if (thread_is_scheduled(ospf6->t_abr_task)) {
 		if (IS_OSPF6_DEBUG_ABR)
 			zlog_debug("ABR task already scheduled");
 		return;

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -1372,9 +1372,7 @@ static void ospf6_show(struct vty *vty, struct ospf6 *o, json_object *json,
 		} else
 			json_object_boolean_false_add(json, "spfHasRun");
 
-
-		threadtimer_string(now, o->t_spf_calc, buf, sizeof(buf));
-		if (o->t_spf_calc) {
+		if (thread_is_scheduled(o->t_spf_calc)) {
 			long time_store;
 
 			json_object_boolean_true_add(json, "spfTimerActive");
@@ -1467,7 +1465,9 @@ static void ospf6_show(struct vty *vty, struct ospf6 *o, json_object *json,
 
 		threadtimer_string(now, o->t_spf_calc, buf, sizeof(buf));
 		vty_out(vty, " SPF timer %s%s\n",
-			(o->t_spf_calc ? "due in " : "is "), buf);
+			(thread_is_scheduled(o->t_spf_calc) ? "due in "
+							    : "is "),
+			buf);
 
 		if (CHECK_FLAG(o->flag, OSPF6_STUB_ROUTER))
 			vty_out(vty, " Router Is Stub Router\n");

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -1756,14 +1756,10 @@ DEFUN(show_ipv6_ospf6_route_type_detail, show_ipv6_ospf6_route_type_detail_cmd,
 
 bool ospf6_is_valid_summary_addr(struct vty *vty, struct prefix *p)
 {
-	struct in6_addr addr_zero;
-
-	memset(&addr_zero, 0, sizeof(addr_zero));
-
-	 /* Default prefix validation*/
-	if ((is_default_prefix(p)) ||
-	    (!memcmp(&p->u.prefix6, &addr_zero, sizeof(struct in6_addr)))) {
-		vty_out(vty, "Default address should not be configured as summary address.\n");
+	/* Default prefix validation*/
+	if (is_default_prefix(p)) {
+		vty_out(vty,
+			"Default address should not be configured as summary address.\n");
 		return false;
 	}
 


### PR DESCRIPTION
a) use thread_is_scheduled(), don't set pointer to null in a thread function, trust THREAD_OFF to do the right thing
b) is_default_prefix covers everything already no need to do it again