### PR TITLE
tests: Ensure routes are not queued when calling verify_rib

### DIFF
--- a/tests/topotests/bfd_topo1/test_bfd_topo1.py
+++ b/tests/topotests/bfd_topo1/test_bfd_topo1.py
@@ -100,7 +100,7 @@ def test_bfd_connection():
         test_func = partial(
             topotest.router_json_cmp, router, "show bfd peers json", expected
         )
-        _, result = topotest.run_and_expect(test_func, None, count=8, wait=0.5)
+        _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
         assertmsg = '"{}" JSON output mismatches'.format(router.name)
         assert result is None, assertmsg
 

--- a/tests/topotests/bfd_topo2/test_bfd_topo2.py
+++ b/tests/topotests/bfd_topo2/test_bfd_topo2.py
@@ -144,7 +144,7 @@ def test_bfd_connection():
         test_func = partial(
             topotest.router_json_cmp, router, "show bfd peers json", expected
         )
-        _, result = topotest.run_and_expect(test_func, None, count=8, wait=0.5)
+        _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
         assertmsg = '"{}" JSON output mismatches'.format(router.name)
         assert result is None, assertmsg
 

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -3245,7 +3245,7 @@ def configure_interface_mac(tgen, input_dict):
 #############################################
 # Verification APIs
 #############################################
-@retry(retry_timeout=12)
+@retry(retry_timeout=40)
 def verify_rib(
     tgen,
     addr_type,

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -3383,6 +3383,10 @@ def verify_rib(
                             st_found = True
                             found_routes.append(st_rt)
 
+                            if "queued" in rib_routes_json[st_rt][0]:
+                                errormsg = "Route {} is queued\n".format(st_rt)
+                                return errormsg
+
                             if fib and next_hop:
                                 if type(next_hop) is not list:
                                     next_hop = [next_hop]
@@ -3606,6 +3610,10 @@ def verify_rib(
                     if st_rt in rib_routes_json:
                         st_found = True
                         found_routes.append(st_rt)
+
+                        if "queued" in rib_routes_json[st_rt][0]:
+                            errormsg = "Route {} is queued\n".format(st_rt)
+                            return errormsg
 
                         if next_hop:
                             if type(next_hop) is not list:


### PR DESCRIPTION
Lots of tests call verify_rib that takes a list of routes that
need to be verified in some fashion.  This verify_rib functionality
will try up to 12 seconds before failing the check that zebra
has the route and has installed it.

Unfortunately the verify_rib code was not looking to see if
the route was queued for installation and was then allowing
tests to immediately do subsuquent steps that depended on
that route actually being installed sometimes causing tests
to fail.

Write a bit of additional code that looks at the queued
status and allows the test to wait a bit longer for zebra
to finish processing before allowing the test to move on
to the next bit.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>