### PR TITLE
ospfd: fix missing "ifp->flags"

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -1341,10 +1341,12 @@ static int ospf_ifp_create(struct interface *ifp)
 	oii = ifp->info;
 	oii->curr_mtu = ifp->mtu;
 
-	if (IF_DEF_PARAMS(ifp)
-	    && !OSPF_IF_PARAM_CONFIGURED(IF_DEF_PARAMS(ifp), type)) {
-		SET_IF_PARAM(IF_DEF_PARAMS(ifp), type);
-		IF_DEF_PARAMS(ifp)->type = ospf_default_iftype(ifp);
+	if (!IF_IS_GRE(ifp)) {
+		if (IF_DEF_PARAMS(ifp) &&
+		    !OSPF_IF_PARAM_CONFIGURED(IF_DEF_PARAMS(ifp), type)) {
+			SET_IF_PARAM(IF_DEF_PARAMS(ifp), type);
+			IF_DEF_PARAMS(ifp)->type = ospf_default_iftype(ifp);
+		}
 	}
 
 	ospf = ifp->vrf->info;
@@ -1413,6 +1415,14 @@ static int ospf_ifp_down(struct interface *ifp)
 	if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
 		zlog_debug("Zebra: Interface[%s] state change to down.",
 			   ifp->name);
+
+	if (IF_IS_GRE(ifp)) {
+		if (IF_DEF_PARAMS(ifp) &&
+		    !OSPF_IF_PARAM_CONFIGURED(IF_DEF_PARAMS(ifp), type)) {
+			SET_IF_PARAM(IF_DEF_PARAMS(ifp), type);
+			IF_DEF_PARAMS(ifp)->type = ospf_default_iftype(ifp);
+		}
+	}
 
 	for (node = route_top(IF_OIFS(ifp)); node; node = route_next(node)) {
 		if ((oi = node->info) == NULL)

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -32,6 +32,8 @@
 #define IF_DEF_PARAMS(I) (IF_OSPF_IF_INFO (I)->def_params)
 #define IF_OIFS(I)  (IF_OSPF_IF_INFO (I)->oifs)
 #define IF_OIFS_PARAMS(I) (IF_OSPF_IF_INFO (I)->params)
+#define IF_IS_GRE(I)                                                           \
+	((I)->ll_type == ZEBRA_LLT_IPGRE || (I)->ll_type == ZEBRA_LLT_IP6GRE)
 
 /* Despite the name, this macro probably is for specialist use only */
 #define OSPF_IF_PARAM_CONFIGURED(S, P) ((S) && (S)->P##__config)


### PR DESCRIPTION
One configure line automatically occurs with a new gre tunnel:                                                                          
`ip tunnel add tunnel0 mode gre remote 192.168.1.2 local 192.168.1.1`                                                                   
                                                                                                                                        
```                                                                                                                                     
!                                                                                                                                       
interface tunnel0                                                                                                                       
 ip ospf network broadcast                                                                                                              
!                                                                                                                                       
```                                                                                                                                     
                                                                                                                                        
Triggered by this new interface, two related steps happen:                                                                              
1) `ifp->flags` in `ospf_ifp_create()` got `BROADCAST`. It is a middle status                                                           
for this tunnel, but unfortunately it is permanently saved into `IF_DEF_PARAMS`.                                                        
2) `ifp->flags` in `ospf_ifp_down()` got `POINTOPOINT`. It is final status, but                                                         
too late and makes `ospf_default_iftype(ifp)` to be `POINTOPOINT`.                                                                      
                                                                                                                                        
It is the different `type` between `IF_DEF_PARAMS` and `ospf_default_iftype(ifp)`                                                       
that lead to that boring configure line unexpectedly.                                                                                   
                                                                                                                                        
Unlike other kinds of interfaces, gre tunnle need special process.                                                                      
                                                                                                                                        
Since there is no problem with `zebra` passing `ifp->flags`, just move the                                                              
assignment of `IF_DEF_PARAMS` into `ospf_ifp_down()` for gre tunnel.