### PR TITLE
zebra: avoid pbr iptable added twice when used with flowspec

### DIFF
--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -812,8 +812,11 @@ static void *pbr_iptable_alloc_intern(void *arg)
 
 void zebra_pbr_add_iptable(struct zebra_pbr_iptable *iptable)
 {
-	(void)hash_get(zrouter.iptable_hash, iptable, pbr_iptable_alloc_intern);
-	(void)dplane_pbr_iptable_add(iptable);
+	struct zebra_pbr_iptable *ipt_hash;
+
+	ipt_hash = hash_get(zrouter.iptable_hash, iptable,
+			    pbr_iptable_alloc_intern);
+	(void)dplane_pbr_iptable_add(ipt_hash);
 }
 
 void zebra_pbr_del_iptable(struct zebra_pbr_iptable *iptable)

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -171,6 +171,9 @@ struct zebra_pbr_iptable {
 
 	struct list *interface_name_list;
 
+#define IPTABLE_INSTALL_QUEUED 1 << 1
+#define IPTABLE_UNINSTALL_QUEUED 1 << 2
+	uint8_t internal_flags;
 	char ipset_name[ZEBRA_IPSET_NAME_SIZE];
 };
 


### PR DESCRIPTION
The usage of zebra dplane makes the job asyncronous which implies
that a given job will try to add an iptable, while the second job
will not know that its iptable is the same as the former one.

The below exabgp rules stand for two bgp flowspec rules sent to
the bgp device:

flow {
route {match {
source 185.228.172.73/32;
destination 0.0.0.0/0;
source-port >=49156&<=49159;
}then {redirect 213.242.114.113;}}
route {match {
source 185.228.172.73/32;
destination 0.0.0.0/0;
source-port >=49160&<=49163;
}then {redirect 213.242.114.113;}}
}

This rule creates a single iptable, but in fact, the same iptable
name is appended twice. This results in duplicated entries in the
iptables context. This also results in contexts not flushed, when
BGP session or 'flush' operation is performed.

iptables-save:
[..]
-A PREROUTING -m set --match-set match0x55baf4c25cb0 src,src -g match0x55baf4c25cb0
-A PREROUTING -m set --match-set match0x55baf4c25cb0 src,src -g match0x55baf4c25cb0
-A match0x55baf4c25cb0 -j MARK --set-xmark 0x100/0xffffffff
-A match0x55baf4c25cb0 -j ACCEPT
-A match0x55baf4c25cb0 -j MARK --set-xmark 0x100/0xffffffff
-A match0x55baf4c25cb0 -j ACCEPT
[..]

This commit addresses this issue, by checking that an iptable
context is not already being processed. A flag is added in the
original iptable context, and a check is done if the iptable
context is not already being processed for install or uinstall.

PR=79480
Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>