### PR TITLE
doc: Use full URL for FRR keyword highlight

### DIFF
--- a/doc/user/overview.rst
+++ b/doc/user/overview.rst
@@ -519,7 +519,7 @@ Bug Reports
 
 For information on reporting bugs, please see :ref:`bug-reports`.
 
-.. _frr: |PACKAGE_URL|
+.. _frr: https://frrouting.org
 .. _github: https://github.com/frrouting/frr/
 .. _github issues: https://github.com/frrouting/frr/issues
 .. _slack: https://frrouting.org/community


### PR DESCRIPTION
Seems replacement is not working when referenced, only when used directly
in the text |PACKAGE_URL|.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>