### PR TITLE
github: Add base branch label to every PR to distinguish easily

### DIFF
--- a/.github/workflows/base-branch-label.yml
+++ b/.github/workflows/base-branch-label.yml
@@ -1,0 +1,17 @@
+name: Add base branch label
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: |
+            ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
Faster notice and filter backports by labels per release.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>