### PR TITLE
bmp: add source address in connect command

### DIFF
--- a/bgpd/bgp_bmp.h
+++ b/bgpd/bgp_bmp.h
@@ -177,6 +177,8 @@ struct bmp_active {
 	struct bmp *bmp;
 
 	char *hostname;
+
+	union sockunion srcaddr;
 	int port;
 	unsigned minretry, maxretry;
 

--- a/doc/user/bmp.rst
+++ b/doc/user/bmp.rst
@@ -108,13 +108,15 @@ BMP session configuration
 Inside a ``bmp targets`` block, the following commands control session
 establishment:
 
-.. clicmd:: bmp connect HOSTNAME port (1-65535) {min-retry MSEC|max-retry MSEC}
+.. clicmd:: bmp connect HOSTNAME port (1-65535) {min-retry MSEC|max-retry MSEC} [source <X:X::X:X|A.B.C.D>]
 
    Add/remove an active outbound BMP session.  HOSTNAME is resolved via DNS,
    if multiple addresses are returned they are tried in nondeterministic
    order.  Only one connection will be established even if multiple addresses
    are returned.  ``min-retry`` and ``max-retry`` specify (in milliseconds)
-   bounds for exponential backoff.
+   bounds for exponential backoff. ``source `` is used to choice a deterministic
+   source address for the connection. Each connect command will lead to one
+   connection.
 
 .. warning::
 


### PR DESCRIPTION
With current release, it is not possible to force the source ip address to
use when setting up a BMP connection.

The need is to add an extra parameter for the following vty command:

router bgp 65500
bmp targets AAA
bmp connect 2.2.2.2 port 666 min-retry 100 max-retry 700 [source 1.1.1.1]
bmp connect 2:2::2:2 port 666 min-retry 100 max-retry 700 [source 2:2::2:2]

Signed-off-by: Francois Dumontet <francois.dumontet@6wind.com>