### PR TITLE
bgpd: Add JSON output for `show rpki cache-connection`

### DIFF
--- a/doc/user/rpki.rst
+++ b/doc/user/rpki.rst
@@ -216,7 +216,7 @@ Displaying RPKI
    received from the cache servers and stored in the router. Based on this data,
    the router validates BGP Updates.
 
-.. clicmd:: show rpki cache-connection
+.. clicmd:: show rpki cache-connection [json]
 
    Display all configured cache servers, whether active or not.
 


### PR DESCRIPTION
```
spine1-debian-11# sh rpki cache-connection
Connected to group 1
rpki tcp cache 192.168.10.17 8283 pref 1 (connected)
rpki tcp cache 192.168.10.17 8282 pref 2
spine1-debian-11# sh rpki cache-connection json
{
  "connectedGroup":1,
  "connections":[
    {
      "mode":"tcp",
      "host":"192.168.10.17",
      "port":"8283",
      "preference":1,
      "state":"connected"
    },
    {
      "mode":"tcp",
      "host":"192.168.10.17",
      "port":"8282",
      "preference":2,
      "state":"disconnected"
    }
  ]
}
```

Related: https://github.com/FRRouting/frr/issues/11139

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>