### PR TITLE
zebra: move the checks for l3vni

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5273,10 +5273,6 @@ int zebra_vxlan_process_vrf_vni_cmd(struct zebra_vrf *zvrf, vni_t vni,
 			   add ? "ADD" : "DEL");
 
 	if (add) {
-
-		/* Remove L2VNI if present */
-		zebra_vxlan_handle_vni_transition(zvrf, vni, add);
-
 		/* check if the vni is already present under zvrf */
 		if (zvrf->l3vni) {
 			snprintf(err, err_str_sz,
@@ -5291,6 +5287,9 @@ int zebra_vxlan_process_vrf_vni_cmd(struct zebra_vrf *zvrf, vni_t vni,
 				 "VNI is already configured as L3-VNI");
 			return -1;
 		}
+
+		/* Remove L2VNI if present */
+		zebra_vxlan_handle_vni_transition(zvrf, vni, add);
 
 		/* add the L3-VNI to the global table */
 		zl3vni = zl3vni_add(vni, zvrf_id(zvrf));


### PR DESCRIPTION
The two checks have been already checked in `lib_vrf_zebra_l3vni_id_modify()`
as it should be. So remove them from `zebra_vxlan_process_vrf_vni_cmd()`.

And it is improper that the two checks are put after
`zebra_vxlan_handle_vni_transition()`, which will do real things. It is
too later, but luckily they never got there so no bug, just redundant.

UPDATE:

The two checks for l3vni have been already done in
`lib_vrf_zebra_l3vni_id_modify()` as it should be. And it is improper that
the two checks are put after `zebra_vxlan_handle_vni_transition()`, which
will do real things.

My original fix is to remove them. But NB module can't guarantee many changes,
so we'd better keep them in `zebra_vxlan_process_vrf_vni_cmd()` in APPLY stage
for safe.

Just move them in front of `zebra_vxlan_handle_vni_transition()`.