### PR TITLE
tests: [Topojson] Enhance CLI logging

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -225,17 +225,9 @@ def run_frr_cmd(rnode, cmd, isjson=False):
     if cmd:
         ret_data = rnode.vtysh_cmd(cmd, isjson=isjson)
 
-        if True:
-            if isjson:
-                print_data = json.dumps(ret_data)
-            else:
-                print_data = ret_data
-            logger.info(
-                "Output for command [%s] on router %s:\n%s",
-                cmd,
-                rnode.name,
-                print_data,
-            )
+        if isjson:
+            rnode.vtysh_cmd(cmd.rstrip("json"), isjson=False)
+
         return ret_data
 
     else:


### PR DESCRIPTION
As of now we are logging only JSON output of CLIs
in topotests(topojson) executions and same o/p is
getting printed twice. CLI logging is already taken 
care by topogen.py inside vtysh_cmd() API.

Enhanced code to show both plain and JSON output
of CLIs and remove duplicate logging.

It will help in reducing execution logs and in
verification, if sometimes there is mis-match
in CLI plain and JSON outputs.

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>