### PR TITLE
bgpd: Don't increment twice notification sent stats counter

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -733,7 +733,6 @@ static void bgp_write_notify(struct peer *peer)
 
 	/* Type should be notify. */
 	atomic_fetch_add_explicit(&peer->notify_out, 1, memory_order_relaxed);
-	peer->notify_out++;
 
 	/* Double start timer. */
 	peer->v_start *= 2;


### PR DESCRIPTION
Before:

```
$ vtysh -c 'clear ip bgp 192.168.10.17'
$ vtysh -c 'show bgp neighbor 192.168.10.17 json' | jq '."192.168.10.17".messageStats.notificationsSent'
2
```

After:

```
$ vtysh -c 'clear ip bgp 192.168.10.17'
$ vtysh -c 'show bgp neighbor 192.168.10.17 json' | jq '."192.168.10.17".messageStats.notificationsSent'
1
```

Closes https://github.com/FRRouting/frr/issues/11257

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>