### PR TITLE
bgpd: Put ssh_config->port as integer, not as string in RPKI code

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -1413,8 +1413,8 @@ DEFPY (show_rpki_cache_connection,
 						       "ssh");
 				json_object_string_add(json_conn, "host",
 						       ssh_config->host);
-				json_object_string_add(json_conn, "port",
-						       ssh_config->port);
+				json_object_int_add(json_conn, "port",
+						    ssh_config->port);
 				json_object_int_add(json_conn, "preference",
 						    cache->preference);
 				json_object_string_add(


### PR DESCRIPTION
tcp_host->port is a string, ssh_config->port is an integer...

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>