### PR TITLE
bgpd: Add JSON support for `show rpki cache-server`

### DIFF
--- a/doc/user/rpki.rst
+++ b/doc/user/rpki.rst
@@ -216,9 +216,13 @@ Displaying RPKI
    received from the cache servers and stored in the router. Based on this data,
    the router validates BGP Updates.
 
-.. clicmd:: show rpki cache-connection [json]
+.. clicmd:: show rpki cache-server [json]
 
    Display all configured cache servers, whether active or not.
+
+.. clicmd:: show rpki cache-connection [json]
+
+   Display all cache connections, and show which is connected or not.
 
 .. clicmd:: show bgp [afi] [safi] <A.B.C.D|A.B.C.D/M|X:X::X:X|X:X::X:X/M> rpki <valid|invalid|notfound>
 


### PR DESCRIPTION
```
spine1-debian-11# sh rpki cache-server json
{
  "servers":[
    {
      "mode":"tcp",
      "host":"192.168.10.17",
      "port":"8283"
    },
    {
      "mode":"tcp",
      "host":"192.168.10.17",
      "port":"8282"
    }
  ]
}
spine1-debian-11# sh rpki cache-server
host: 192.168.10.17 port: 8283
host: 192.168.10.17 port: 8282
spine1-debian-11#
```

Related: https://github.com/FRRouting/frr/issues/11139

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>