### PR TITLE
tests: Allow cspf_topo1 to function correctly at scale

### DIFF
--- a/tests/topotests/cspf_topo1/reference/sharp-ted.json
+++ b/tests/topotests/cspf_topo1/reference/sharp-ted.json
@@ -269,7 +269,6 @@
         },
         "segment-routing":[
           {
-            "adj-sid":5001,
             "flags":"0xb0",
             "weight":0
           }
@@ -666,7 +665,6 @@
         },
         "segment-routing":[
           {
-            "adj-sid":5000,
             "flags":"0x30",
             "weight":0
           }


### PR DESCRIPTION
The cspf_topo1 test is comparing the adj-sid value that is
assigned dynamically based upon bring up order.  Under very
large scale this order changes causing the test to fail.
Since the adj-sid is dynamically allocated and appears to
be tested elsewhere, let's remove it from the grab all check.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>