### PR TITLE
pim6d: Removed PIM_IPV == 4 flag

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -3007,11 +3007,7 @@ void pim_cmd_show_ip_multicast_helper(struct pim_instance *pim, struct vty *vty)
 	vty_out(vty, "\n");
 
 	pim_zebra_zclient_update(vty);
-#if PIM_IPV == 4
 	pim_zlookup_show_ip_multicast(vty);
-#else
-	/* TBD */
-#endif
 
 	vty_out(vty, "\n");
 	vty_out(vty, "Maximum highest VifIndex: %d\n", PIM_MAX_USABLE_VIFS);


### PR DESCRIPTION
PIM_IPV == 4 is removed form function pim_cmd_show_ip_multicast_helper
as pim_zlookup.c is available for pimv6 aswell.

Signed-off-by: Abhishek N R <abnr@vmware.com>