### PR TITLE
github: Add permissions for labeler action

### DIFF
--- a/.github/workflows/base-branch-label.yml
+++ b/.github/workflows/base-branch-label.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   label:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-add-labels@v1


### PR DESCRIPTION
Should solve this:

```
Error: HttpError: Resource not accessible by integration
Error: Resource not accessible by integration
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>