### PR TITLE
github: Use pull_request_target as a target

### DIFF
--- a/.github/workflows/base-branch-label.yml
+++ b/.github/workflows/base-branch-label.yml
@@ -1,7 +1,7 @@
 name: Add base branch label
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -13,7 +13,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: |


### PR DESCRIPTION
And drop checkout action - not needed.

Due to the dangers inherent to automatic processing of PRs, GitHub’s standard
pull_request workflow trigger by default prevents write permissions and
secrets access to the target repository. However, in some scenarios such
access is needed to properly process the PR.

To this end the pull_request_target workflow trigger was introduced.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>