### PR TITLE
pimd: Disable handling v3 igmp packets on an interface config'ed for v2

### DIFF
--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -1890,6 +1890,7 @@ int igmp_v3_recv_report(struct gm_sock *igmp, struct in_addr from,
 	uint8_t *group_record;
 	uint8_t *report_pastend = (uint8_t *)igmp_msg + igmp_msg_len;
 	struct interface *ifp = igmp->interface;
+	struct pim_interface *pim_ifp = ifp->info;
 	int i;
 
 	if (igmp->mtrace_only)
@@ -1912,6 +1913,13 @@ int igmp_v3_recv_report(struct gm_sock *igmp, struct in_addr from,
 
 	/* Collecting IGMP Rx stats */
 	igmp->igmp_stats.report_v3++;
+
+	if (pim_ifp->igmp_version == 2) {
+		zlog_warn(
+			"Received Version 3 packet but interface: %s is configured for version 2",
+			ifp->name);
+		return -1;
+	}
 
 	num_groups = ntohs(
 		*(uint16_t *)(igmp_msg + IGMP_V3_REPORT_NUMGROUPS_OFFSET));

--- a/tools/etc/frr/support_bundle_commands.conf
+++ b/tools/etc/frr/support_bundle_commands.conf
@@ -160,6 +160,7 @@ show ip igmp groups
 show ip igmp interface
 show ip igmp join
 show ip igmp sources
+show ip igmp statistics
 show ip pim upstream
 show ip mroute
 show ip pim join


### PR DESCRIPTION
…interfaces

This should not be merged, trying to gather data.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>