### PR TITLE
build: fix some corners for LLVM analysis tools

### DIFF
--- a/python/makefile.py
+++ b/python/makefile.py
@@ -32,7 +32,12 @@ for clippy_file in clippy_scan:
     assert clippy_file.endswith(".c")
 
 xref_targets = []
-for varname in ["bin_PROGRAMS", "sbin_PROGRAMS", "lib_LTLIBRARIES", "module_LTLIBRARIES"]:
+for varname in [
+    "bin_PROGRAMS",
+    "sbin_PROGRAMS",
+    "lib_LTLIBRARIES",
+    "module_LTLIBRARIES",
+]:
     xref_targets.extend(mv[varname].strip().split())
 
 # check for files using clippy but not listed in clippy_scan
@@ -120,11 +125,11 @@ while lines:
     target, dep = m.group(1), m.group(2)
 
     filename = os.path.basename(target)
-    if '-' in filename:
+    if "-" in filename:
         # dashes in output filename = building same .c with different CFLAGS
-        am_name, _ = filename.split('-', 1)
+        am_name, _ = filename.split("-", 1)
         am_name = os.path.join(os.path.dirname(target), am_name)
-        am_name = am_name.replace('/', '_')
+        am_name = am_name.replace("/", "_")
         extraflags = " $(%s_CFLAGS)" % (am_name,)
     else:
         # this path isn't really triggered because automake is using a generic
@@ -135,7 +140,10 @@ while lines:
         if not dep.endswith(".h"):
             # LLVM bitcode targets for analysis tools
             bcdeps.append("%s.bc: %s" % (target, target))
-            bcdeps.append("\t$(AM_V_LLVM_BC)$(COMPILE)%s -emit-llvm -c -o $@ %s" % (extraflags, dep))
+            bcdeps.append(
+                "\t$(AM_V_LLVM_BC)$(COMPILE)%s -emit-llvm -c -o $@ %s"
+                % (extraflags, dep)
+            )
     if m.group(2) in clippy_scan:
         # again - this is only hit for targets with custom CFLAGS, because
         # automake uses a generic .c -> .o rule for standard CFLAGS
@@ -152,13 +160,15 @@ for clippy_file in clippy_scan:
 
 # combine daemon .xref files into frr.xref
 out_lines.append("")
-out_lines.append("xrefs = %s" % (" ".join(["%s.xref" % target for target in xref_targets])))
+out_lines.append(
+    "xrefs = %s" % (" ".join(["%s.xref" % target for target in xref_targets]))
+)
 out_lines.append("frr.xref: $(xrefs)")
 out_lines.append("")
 
 # analog but slower way to get the same frr.xref
-#frr.xref: $(bin_PROGRAMS) $(sbin_PROGRAMS) $(lib_LTLIBRARIES) $(module_LTLIBRARIES)
-#	$(AM_V_XRELFO) $(CLIPPY) $(top_srcdir)/python/xrelfo.py -o $@ $^
+# frr.xref: $(bin_PROGRAMS) $(sbin_PROGRAMS) $(lib_LTLIBRARIES) $(module_LTLIBRARIES)
+# 	$(AM_V_XRELFO) $(CLIPPY) $(top_srcdir)/python/xrelfo.py -o $@ $^
 
 # LLVM bitcode link targets creating a .bc file for whole daemon or lib
 out_lines.append("")

--- a/python/makefile.py
+++ b/python/makefile.py
@@ -113,10 +113,19 @@ while lines:
 
     target, dep = m.group(1), m.group(2)
 
+    filename = os.path.basename(target)
+    if '-' in filename:
+        am_name, _ = filename.split('-', 1)
+        am_name = os.path.join(os.path.dirname(target), am_name)
+        am_name = am_name.replace('/', '_')
+        extraflags = " $(%s_CFLAGS)" % (am_name,)
+    else:
+        extraflags = ""
+
     if target.endswith(".lo") or target.endswith(".o"):
         if not dep.endswith(".h"):
             bcdeps.append("%s.bc: %s" % (target, target))
-            bcdeps.append("\t$(AM_V_LLVM_BC)$(COMPILE) -emit-llvm -c -o $@ %s" % (dep))
+            bcdeps.append("\t$(AM_V_LLVM_BC)$(COMPILE)%s -emit-llvm -c -o $@ %s" % (extraflags, dep))
     if m.group(2) in clippy_scan:
         out_lines.append(
             clippyauxdep.substitute(target=m.group(1), clippybase=m.group(2)[:-2])

--- a/tools/frr-llvm-cg.c
+++ b/tools/frr-llvm-cg.c
@@ -561,7 +561,6 @@ static void process_call(struct json_object *js_calls,
 	unsigned n_args = LLVMGetNumArgOperands(instr);
 
 	bool is_external = LLVMIsDeclaration(called);
-	enum called_fn called_type = FN_GENERIC;
 
 	js_call = json_object_new_object();
 	json_object_array_add(js_calls, js_call);
@@ -570,7 +569,6 @@ static void process_call(struct json_object *js_calls,
 			       json_object_new_boolean(is_external));
 
 	if (!called_name || called_len == 0) {
-		called_type = FN_NONAME;
 		json_object_object_add(js_call, "type",
 				       json_object_new_string("indirect"));
 
@@ -653,8 +651,6 @@ static void process_call(struct json_object *js_calls,
 		}
 #ifdef FRR_SPECIFIC
 	} else if (!strcmp(called_name, "_install_element")) {
-		called_type = FN_INSTALL_ELEMENT;
-
 		LLVMValueRef param0 = LLVMGetOperand(instr, 0);
 		if (!LLVMIsAConstantInt(param0))
 			goto out_nonconst;
@@ -694,8 +690,6 @@ static void process_call(struct json_object *js_calls,
 			json_object_new_string("install_element"));
 		return;
 	} else if (is_thread_sched(called_name, called_len)) {
-		called_type = FN_THREAD_ADD;
-
 		json_object_object_add(js_call, "type",
 				       json_object_new_string("thread_sched"));
 		json_object_object_add(


### PR DESCRIPTION
Minor fixes to LLVM build tooling / analysis setup.

- use correct CFLAGS to build LLVM bitcode files
- document `makefile.py`
- remove unused variable in callgraph tool

(This should be in the "fixes for release"/stable category.)