### PR TITLE
bgpd: Intern [l]community that is converted from a string in route-map

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2310,7 +2310,7 @@ static void *route_set_community_compile(const char *arg)
 	}
 
 	rcs = XCALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(struct rmap_com_set));
-	rcs->com = com;
+	rcs->com = community_intern(com);
 	rcs->additive = additive;
 	rcs->none = none;
 
@@ -2421,7 +2421,7 @@ static void *route_set_lcommunity_compile(const char *arg)
 	}
 
 	rcs = XCALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(struct rmap_com_set));
-	rcs->lcom = lcom;
+	rcs->lcom = lcommunity_intern(lcom);
 	rcs->additive = additive;
 	rcs->none = none;
 


### PR DESCRIPTION
This is already done with extended communities, not sure why we are not doing
here the same.

Trying to find a path where we leak the memory.

Don't know yet why in some cases we have something like:

```
Large Community value         : 14082506 variable 5641794208 14082507 5641795000
community val                 :  7047988 variable 184753440  7047989 184753520
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>