### PR TITLE
zebra: Update advertise-svi-ip MACIPs w/ new MAC

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -4676,6 +4676,12 @@ int zebra_vxlan_svi_up(struct interface *ifp, struct interface *link_if)
 
 		/* Link the SVI from the access VLAN */
 		zebra_evpn_acc_bd_svi_set(ifp->info, link_if->info, true);
+
+		/* Update MACIP routes created by advertise-svi-ip */
+		if (advertise_svi_macip_enabled(zevpn)) {
+			zebra_evpn_del_macip_for_intf(ifp, zevpn);
+			zebra_evpn_add_macip_for_intf(ifp, zevpn);
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
When the kernel was sending an RTM_NEWLINK updating the MAC of a known
SVI, Type-2 routes created by advertise-svi-ip were not getting updated
with the new address.
This adds removal of any old Type-2 routes (with old MAC) and creation
of new Type-2 routes (with new MAC) into RTM_NEWLINK processing.

Fixes: #11174

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>