### PR TITLE
zebra: add error check condition to sock option

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -309,9 +309,16 @@ static int netlink_socket(struct nlsock *nl, unsigned long groups,
 		snl.nl_groups = groups;
 
 #if defined SOL_NETLINK
-		if (ext_groups)
-			setsockopt(sock, SOL_NETLINK, NETLINK_ADD_MEMBERSHIP,
-				   &ext_groups, sizeof(ext_groups));
+		if (ext_groups) {
+			ret = setsockopt(sock, SOL_NETLINK,
+					 NETLINK_ADD_MEMBERSHIP, &ext_groups,
+					 sizeof(ext_groups));
+			if (ret < 0) {
+				zlog_notice(
+					"can't setsockopt NETLINK_ADD_MEMBERSHIP: %s(%d)",
+					safe_strerror(errno), errno);
+			}
+		}
 #endif
 
 		/* Bind the socket to the netlink structure for anything. */


### PR DESCRIPTION
Adding error checking condition which was missed in PR-11216.

```
*** CID 1517953:  Error handling issues  (CHECKED_RETURN)
/zebra/kernel_netlink.c: 313 in netlink_socket()
307                     memset(&snl, 0, sizeof(snl));
308                     snl.nl_family = AF_NETLINK;
309                     snl.nl_groups = groups;
310
311     #if defined SOL_NETLINK
312                     if (ext_groups)
>>>     CID 1517953:  Error handling issues  (CHECKED_RETURN)
>>>     Calling "setsockopt(sock, 270, 1, &ext_groups, 8U)" without checking return value. This library function may fail and return an error code.
313                             setsockopt(sock, SOL_NETLINK, NETLINK_ADD_MEMBERSHIP,
314                                        &ext_groups, sizeof(ext_groups));
315     #endif
316
317                     /* Bind the socket to the netlink structure for anything. */
318                     ret = bind(sock, (struct sockaddr *)&snl, sizeof(snl));
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>