### PR TITLE
tools: Don't complain about missing PID files when stopping all damons

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -194,10 +194,14 @@ daemon_stop() {
 
 	is_user_root || exit 1
 
+	all=false
+	[ "$1" = "--all" ] && { all=true; shift; }
+
 	pidfile="$V_PATH/$daemon${inst:+-$inst}.pid"
 	vtyfile="$V_PATH/$daemon${inst:+-$inst}.vty"
 
 	[ -r "$pidfile" ] || fail="pid file not found"
+	$all && [ -n "$fail" ] && return 0
 	[ -z "$fail" ] && pid="`cat \"$pidfile\"`"
 	[ -z "$fail" -a -z "$pid" ] && fail="pid file is empty"
 	[ -n "$fail" ] || kill -0 "$pid" 2>/dev/null || fail="pid $pid not running"
@@ -273,7 +277,7 @@ all_stop() {
 	done
 
 	for dmninst in $reversed; do
-		daemon_stop "$dmninst" "$1" &
+		daemon_stop --all "$dmninst" "$1" &
 		pids="$pids $!"
 	done
 	for pid in $pids; do


### PR DESCRIPTION
Since 1686b1d4864384ee508b58418f20970f2dff2587, we try to stop all daemons,
even those which are not (no longer) enabled in /etc/frr/daemons. But we
shouldn't complain about missing PID files for daemons which have never been
started and just silently ignore those.

Signed-off-by: Martin Buck <mb-tmp-tvguho.pbz@gromit.dyndns.org>