### PR TITLE
bgpd: Add ability to match `match peer <PEERGROUPNAME>`

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -263,10 +263,14 @@ route_match_peer(void *rule, const struct prefix *prefix, void *object)
 	peer = ((struct bgp_path_info *)object)->peer;
 
 	if (pc->interface) {
-		if (!peer->conf_if)
+		if (!peer->conf_if || !peer->group)
 			return RMAP_NOMATCH;
 
-		if (strcmp(peer->conf_if, pc->interface) == 0)
+		if (peer->conf_if && strcmp(peer->conf_if, pc->interface) == 0)
+			return RMAP_MATCH;
+
+		if (peer->group &&
+		    strcmp(peer->group->name, pc->interface) == 0)
 			return RMAP_MATCH;
 
 		return RMAP_NOMATCH;
@@ -4567,7 +4571,7 @@ DEFPY_YANG (match_peer,
        "Match peer address\n"
        "IP address of peer\n"
        "IPv6 address of peer\n"
-       "Interface name of peer\n")
+       "Interface name of peer or peer group name\n")
 {
 	const char *xpath =
 		"./match-condition[condition='frr-bgp-route-map:peer']";

--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -205,6 +205,11 @@ Route Map Match Command
   interface name specified if the neighbor was specified
   in this manner.
 
+.. clicmd:: match peer PEER_GROUP_NAME
+
+  This is a BGP specific match command. Matches the peer
+  group name specified for the peer in question.
+
 .. clicmd:: match source-protocol PROTOCOL_NAME
 
   This is a ZEBRA specific match command.  Matches the


### PR DESCRIPTION
Allow the end operator to match `match peer <PEERGROUPNAME>`
in a route-map.  If the end operator defines interface
based peers and peer-groups that have names that overlap
the interface based peer will match first.

Fixes: #11316
Signed-off-by: Donald Sharp <sharpd@nvidia.com>