### PR TITLE
*: use label code to store VNI info

### DIFF
--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -36,27 +36,6 @@ static inline int is_evpn_enabled(void)
 	return bgp ? EVPN_ENABLED(bgp) : 0;
 }
 
-static inline void vni2label(vni_t vni, mpls_label_t *label)
-{
-	uint8_t *tag = (uint8_t *)label;
-
-	tag[0] = (vni >> 16) & 0xFF;
-	tag[1] = (vni >> 8) & 0xFF;
-	tag[2] = vni & 0xFF;
-}
-
-static inline vni_t label2vni(mpls_label_t *label)
-{
-	uint8_t *tag = (uint8_t *)label;
-	vni_t vni;
-
-	vni = ((uint32_t)*tag++ << 16);
-	vni |= (uint32_t)*tag++ << 8;
-	vni |= (uint32_t)(*tag & 0xFF);
-
-	return vni;
-}
-
 static inline int advertise_type5_routes(struct bgp *bgp_vrf,
 					 afi_t afi)
 {

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -2264,7 +2264,8 @@ static void isis_print_route(struct ttable *tt, const struct prefix *prefix,
 
 					label2str(
 						nexthop->label_stack->label[i],
-						buf_label, sizeof(buf_label));
+						0, buf_label,
+						sizeof(buf_label));
 					if (i != 0)
 						strlcat(buf_labels, "/",
 							sizeof(buf_labels));
@@ -2272,7 +2273,7 @@ static void isis_print_route(struct ttable *tt, const struct prefix *prefix,
 						sizeof(buf_labels));
 				}
 			} else if (nexthop->sr.present)
-				label2str(nexthop->sr.label, buf_labels,
+				label2str(nexthop->sr.label, 0, buf_labels,
 					  sizeof(buf_labels));
 			else
 				strlcpy(buf_labels, "-", sizeof(buf_labels));

--- a/lib/mpls.c
+++ b/lib/mpls.c
@@ -80,7 +80,7 @@ int mpls_str2label(const char *label_str, uint8_t *num_labels,
  * Label to string conversion, labels in string separated by '/'.
  */
 char *mpls_label2str(uint8_t num_labels, const mpls_label_t *labels, char *buf,
-		     int len, int pretty)
+		     int len, enum lsp_types_t type, int pretty)
 {
 	char label_buf[BUFSIZ];
 	int i;
@@ -90,9 +90,14 @@ char *mpls_label2str(uint8_t num_labels, const mpls_label_t *labels, char *buf,
 		if (i != 0)
 			strlcat(buf, "/", len);
 		if (pretty)
-			label2str(labels[i], label_buf, sizeof(label_buf));
+			label2str(labels[i], type, label_buf,
+				  sizeof(label_buf));
 		else
-			snprintf(label_buf, sizeof(label_buf), "%u", labels[i]);
+			snprintf(label_buf, sizeof(label_buf), "%u",
+				 ((type == ZEBRA_LSP_EVPN)
+					  ? label2vni(&labels[i])
+					  : labels[i]));
+
 		strlcat(buf, label_buf, len);
 	}
 

--- a/lib/mpls.h
+++ b/lib/mpls.h
@@ -23,6 +23,7 @@
 #define _QUAGGA_MPLS_H
 
 #include <zebra.h>
+#include <vxlan.h>
 #include <arpa/inet.h>
 
 #ifdef __cplusplus
@@ -129,9 +130,31 @@ enum lsp_types_t {
 	ZEBRA_LSP_ISIS_SR = 5,/* IS-IS Segment Routing LSP. */
 	ZEBRA_LSP_SHARP = 6,  /* Identifier for test protocol */
 	ZEBRA_LSP_SRTE = 7,   /* SR-TE LSP */
+	ZEBRA_LSP_EVPN = 8,  /* EVPN VNI Label */
 };
 
 /* Functions for basic label operations. */
+
+static inline void vni2label(vni_t vni, mpls_label_t *label)
+{
+	uint8_t *tag = (uint8_t *)label;
+
+	tag[0] = (vni >> 16) & 0xFF;
+	tag[1] = (vni >> 8) & 0xFF;
+	tag[2] = vni & 0xFF;
+}
+
+static inline vni_t label2vni(const mpls_label_t *label)
+{
+	uint8_t *tag = (uint8_t *)label;
+	vni_t vni;
+
+	vni = ((uint32_t)*tag++ << 16);
+	vni |= (uint32_t)*tag++ << 8;
+	vni |= (uint32_t)(*tag & 0xFF);
+
+	return vni;
+}
 
 /* Encode a label stack entry from fields; convert to network byte-order as
  * the Netlink interface expects MPLS labels to be in this format.
@@ -168,8 +191,14 @@ static inline void mpls_lse_decode(mpls_lse_t lse, mpls_label_t *label,
 #define MPLS_INVALID_LABEL_INDEX   0xFFFFFFFF
 
 /* Printable string for labels (with consideration for reserved values). */
-static inline char *label2str(mpls_label_t label, char *buf, size_t len)
+static inline char *label2str(mpls_label_t label, enum lsp_types_t type,
+			      char *buf, size_t len)
 {
+	if (type == ZEBRA_LSP_EVPN) {
+		snprintf(buf, len, "%u", label2vni(&label));
+		return (buf);
+	}
+
 	switch (label) {
 	case MPLS_LABEL_IPV4_EXPLICIT_NULL:
 		strlcpy(buf, "IPv4 Explicit Null", len);
@@ -217,7 +246,7 @@ int mpls_str2label(const char *label_str, uint8_t *num_labels,
  * Label to string conversion, labels in string separated by '/'.
  */
 char *mpls_label2str(uint8_t num_labels, const mpls_label_t *labels, char *buf,
-		     int len, int pretty);
+		     int len, enum lsp_types_t type, int pretty);
 
 #ifdef __cplusplus
 }

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -1014,9 +1014,8 @@ void nexthop_group_write_nexthop(struct vty *vty, const struct nexthop *nh)
 	if (nh->nh_label && nh->nh_label->num_labels > 0) {
 		char buf[200];
 
-		mpls_label2str(nh->nh_label->num_labels,
-			       nh->nh_label->label,
-			       buf, sizeof(buf), 0);
+		mpls_label2str(nh->nh_label->num_labels, nh->nh_label->label,
+			       buf, sizeof(buf), nh->nh_label_type, 0);
 		vty_out(vty, " label %s", buf);
 	}
 
@@ -1073,7 +1072,7 @@ void nexthop_group_json_nexthop(json_object *j, const struct nexthop *nh)
 		char buf[200];
 
 		mpls_label2str(nh->nh_label->num_labels, nh->nh_label->label,
-			       buf, sizeof(buf), 0);
+			       buf, sizeof(buf), nh->nh_label_type, 0);
 		json_object_string_add(j, "label", buf);
 	}
 

--- a/ospfd/ospf_ti_lfa.c
+++ b/ospfd/ospf_ti_lfa.c
@@ -721,7 +721,7 @@ static void ospf_ti_lfa_generate_q_spaces(struct ospf_area *area,
 	if (q_space->label_stack) {
 		mpls_label2str(q_space->label_stack->num_labels,
 			       q_space->label_stack->label, label_buf,
-			       MPLS_LABEL_STRLEN, true);
+			       MPLS_LABEL_STRLEN, 0, true);
 		zlog_info(
 			"%s: Generated label stack %s for root %pI4 and destination %pI4 for %s",
 			__func__, label_buf, &p_space->root->id,
@@ -1047,7 +1047,7 @@ void ospf_ti_lfa_insert_backup_paths(struct ospf_area *area,
 					path->srni.backup_label_stack
 						->num_labels,
 					path->srni.backup_label_stack->label,
-					label_buf, MPLS_LABEL_STRLEN, true);
+					label_buf, MPLS_LABEL_STRLEN, 0, true);
 				if (IS_DEBUG_OSPF_TI_LFA)
 					zlog_debug(
 						"%s: inserted backup path %s for prefix %pFX, router id %pI4 and nexthop %pI4.",

--- a/tests/ospfd/common.c
+++ b/tests/ospfd/common.c
@@ -74,7 +74,7 @@ void print_route_table(struct vty *vty, struct route_table *rt)
 				label_stack = path->srni.backup_label_stack;
 				mpls_label2str(label_stack->num_labels,
 					       label_stack->label, buf,
-					       MPLS_LABEL_STRLEN, true);
+					       MPLS_LABEL_STRLEN, 0, true);
 				vty_out(vty, " and backup path %s", buf);
 			}
 			vty_out(vty, "\n");

--- a/tests/ospfd/test_ospf_spf.c
+++ b/tests/ospfd/test_ospf_spf.c
@@ -104,7 +104,7 @@ static void test_run_spf(struct vty *vty, struct ospf *ospf,
 						q_space->label_stack
 							->num_labels,
 						q_space->label_stack->label,
-						label_buf, MPLS_LABEL_STRLEN,
+						label_buf, MPLS_LABEL_STRLEN, 0,
 						true);
 					vty_out(vty, "\nLabel stack: %s\n",
 						label_buf);

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -426,6 +426,7 @@ static inline uint8_t lsp_distance(enum lsp_types_t type)
 		return (route_distance(ZEBRA_ROUTE_BGP));
 	case ZEBRA_LSP_NONE:
 	case ZEBRA_LSP_SHARP:
+	case ZEBRA_LSP_EVPN:
 	case ZEBRA_LSP_OSPF_SR:
 	case ZEBRA_LSP_ISIS_SR:
 	case ZEBRA_LSP_SRTE:
@@ -478,6 +479,7 @@ static inline int re_type_from_lsp_type(enum lsp_types_t lsp_type)
 	case ZEBRA_LSP_LDP:
 		return ZEBRA_ROUTE_LDP;
 	case ZEBRA_LSP_BGP:
+	case ZEBRA_LSP_EVPN:
 		return ZEBRA_ROUTE_BGP;
 	case ZEBRA_LSP_OSPF_SR:
 		return ZEBRA_ROUTE_OSPF;
@@ -516,6 +518,8 @@ static inline const char *nhlfe_type2str(enum lsp_types_t lsp_type)
 		return "SR (IS-IS)";
 	case ZEBRA_LSP_SHARP:
 		return "SHARP";
+	case ZEBRA_LSP_EVPN:
+		return "EVPN";
 	case ZEBRA_LSP_SRTE:
 		return "SR-TE";
 	case ZEBRA_LSP_NONE:

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3284,7 +3284,8 @@ static void _route_entry_dump_nh(const struct route_entry *re,
 	if (nexthop->nh_label && nexthop->nh_label->num_labels > 0) {
 		mpls_label2str(nexthop->nh_label->num_labels,
 			       nexthop->nh_label->label, label_str,
-			       sizeof(label_str), 0 /*pretty*/);
+			       sizeof(label_str), nexthop->nh_label_type,
+			       0 /*pretty*/);
 		strlcat(label_str, ", ", sizeof(label_str));
 	}
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -414,7 +414,8 @@ static void show_nexthop_detail_helper(struct vty *vty,
 		vty_out(vty, ", label %s",
 			mpls_label2str(nexthop->nh_label->num_labels,
 				       nexthop->nh_label->label, buf,
-				       sizeof(buf), 1 /*pretty*/));
+				       sizeof(buf), nexthop->nh_label_type,
+				       1 /*pretty*/));
 	}
 
 	if (nexthop->weight)
@@ -690,7 +691,7 @@ static void show_route_nexthop_helper(struct vty *vty,
 		vty_out(vty, ", label %s",
 			mpls_label2str(nexthop->nh_label->num_labels,
 				       nexthop->nh_label->label, buf,
-				       sizeof(buf), 1));
+				       sizeof(buf), nexthop->nh_label_type, 1));
 	}
 
 	if (nexthop->nh_srv6) {
@@ -891,9 +892,14 @@ static void show_nexthop_json_helper(json_object *json_nexthop,
 		     label_index++)
 			json_object_array_add(
 				json_labels,
-				json_object_new_int(
-					nexthop->nh_label->label
-					[label_index]));
+				json_object_new_int((
+					(nexthop->nh_label_type ==
+					 ZEBRA_LSP_EVPN)
+						? label2vni(
+							  &nexthop->nh_label->label
+								   [label_index])
+						: nexthop->nh_label->label
+							  [label_index])));
 
 		json_object_object_add(json_nexthop, "labels",
 				       json_labels);


### PR DESCRIPTION
Use the already existing mpls label code to store VNI
info for vxlan. VNI's are defined as labels just like mpls,
we should be using the same code for both.

This patch is the first part of that. Next we will need to
abstract the label code to not be so mpls specific. Currently
in this, we are just treating VXLAN as a label type and storing
it that way.

Co-developed-by: Chirag Shah <chirag@nvidia.com>
Signed-off-by: Chirag Shah <chirag@nvidia.com>
Signed-off-by: Stephen Worley <sworley@nvidia.com>