### PR TITLE
pimd, pim6d: Add return in case of failure in api pim_mroute_set

### DIFF
--- a/pimd/pim6_mroute_msg.c
+++ b/pimd/pim6_mroute_msg.c
@@ -104,6 +104,7 @@ int pim_mroute_set(struct pim_instance *pim, int enable)
 			"Could not set non blocking on socket fd=%d: errno=%d: %s",
 			pim->mroute_socket, errno,
 			safe_strerror(errno));
+		return -1;
 	}
 
 	if (enable) {

--- a/pimd/pim_mroute_msg.c
+++ b/pimd/pim_mroute_msg.c
@@ -107,6 +107,7 @@ int pim_mroute_set(struct pim_instance *pim, int enable)
 			"Could not set non blocking on socket fd=%d: errno=%d: %s",
 			pim->mroute_socket, errno,
 			safe_strerror(errno));
+		return -1;
 	}
 
 	if (enable) {


### PR DESCRIPTION
pimd, pim6d: Add return in case of failure in api pim_mroute_set

PR #10661 has removed the return in case of failure which is wrong. Added it back.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>