### PR TITLE
tools: Really fix all daemon shutdown without complaining about PID files

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -195,7 +195,7 @@ daemon_stop() {
 	is_user_root || exit 1
 
 	all=false
-	[ "$1" = "--all" ] && { all=true; shift; }
+	[ "$2" = "--reallyall" ] && all=true
 
 	pidfile="$V_PATH/$daemon${inst:+-$inst}.pid"
 	vtyfile="$V_PATH/$daemon${inst:+-$inst}.vty"
@@ -277,7 +277,7 @@ all_stop() {
 	done
 
 	for dmninst in $reversed; do
-		daemon_stop --all "$dmninst" "$1" &
+		daemon_stop "$dmninst" "$1" &
 		pids="$pids $!"
 	done
 	for pid in $pids; do


### PR DESCRIPTION
#11315 (just merged) was actually pretty broken. This one really should fix it.

Fix daemon shutdown broken by f0cccaa6bf7dda71d0e1ad1b0406a9b453a84bb3. Now
we still don't complain about missing PID files but actually stop the
running daemons.

The previous fix was broken because it passed a new "--all" option to
daemon_stop which wasn't handled properly (it assumed $1 contains the
daemon name when at that time it acutally contained the "--all" option).
Plus, "--all" wasn't actually necessary, because we already passed
"--reallyall" from all_stop to daemon_stop after the daemon name.

So remove "--all" again and simply check for "--reallyall" in $2. This
should *really* fix #11317.

Signed-off-by: Martin Buck <mb-tmp-tvguho.pbz@gromit.dyndns.org>