### PR TITLE
bgpd: [8.2] Fix memory leak when setting [l]community at egress

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2212,7 +2212,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 					"%s [Update:SEND] %pFX is filtered by route-map '%s'",
 					peer->host, p,
 					ROUTE_MAP_OUT_NAME(filter));
-
+			bgp_attr_flush(rmap_path.attr);
 			return false;
 		}
 	}


### PR DESCRIPTION
```
==2209758== 7,791,480 (399,840 direct, 7,391,640 indirect) bytes in 9,996 blocks are definitely lost in loss record 102 of 103
==2209758==    at 0x4C33B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2209758==    by 0x4EE264F: qcalloc (memory.c:116)
==2209758==    by 0x22E62A: lcommunity_new (bgp_lcommunity.c:42)
==2209758==    by 0x22E62A: lcommunity_dup (bgp_lcommunity.c:155)
==2209758==    by 0x26F28F: route_set_lcommunity (bgp_routemap.c:2382)
==2209758==    by 0x4EFF7EF: route_map_apply_ext (routemap.c:2663)
==2209758==    by 0x250B3D: subgroup_announce_check (bgp_route.c:2202)
==2209758==    by 0x27A195: subgroup_announce_table (bgp_updgrp_adv.c:690)
==2209758==    by 0x27A509: subgroup_coalesce_timer (bgp_updgrp_adv.c:332)
==2209758==    by 0x4F1C3FC: thread_call (thread.c:2002)
==2209758==    by 0x4ED6D67: frr_run (libfrr.c:1196)
==2209758==    by 0x1E921B: main (bgp_main.c:519)
```

To reproduce it's enough to have something like applied at egress:

```
route-map test permit 10
 on-match goto 15
 set large-community 20717:0:0 20717:1:1820 20717:1:3303 20717:1:4788 20717:1:5416 20717:1:5713 20717:1:6774 20717:1:8309 20717:1:8529 20717:1:8697 20717:1:8966 20717:1:9038 20717:1:9119 20717:1:9304 20717:1:9498 20717:1:12779 20717:1:12883 20717:1:13113 20717:1:14340 20717:1:14907 20717:1:15802 20717:1:16347 20717:1:16637 20717:1:18403 20717:1:20717 20717:1:20928 20717:1:21245 20717:1:25818 20717:1:28917 20717:1:30844 20717:1:30990 20717:1:31133 20717:1:35297 20717:1:35320 20717:1:35432 20717:1:35819 20717:1:35838 20717:1:36994 20717:1:37100 20717:1:37558 20717:1:37662 20717:1:39180 20717:1:39405 20717:1:41095 20717:1:43996 20717:1:45489 20717:1:45903 20717:1:47794 20717:1:51185 20717:1:51254 20717:1:58715 20717:1:59605 20717:1:60427 20717:1:62955 20717:1:63008 20717:1:63927 20717:1:64049 20717:1:132602 20717:1:198435 20717:1:205988 20717:1:208278 20717:1:327700
exit
!
route-map test deny 15
exit
!
```

On the other side doing:
```
spine1-debian-11# sharp install routes 100.100.100.1 nexthop 192.168.10.65 30
spine1-debian-11# sharp remove routes 100.100.100.1 30
spine1-debian-11# sharp install routes 100.100.100.1 nexthop 192.168.10.65 30
```

Before:

```
Large Community               :       66     40        2816       66      2816
Large Community value         :       66 variable     29728       66     29728
Large Community               :       96     40        4096       96      4096
Large Community value         :       96 variable     52048       96     52048
```

After:
```
Large Community               :       28     40        1152       29      1192
Large Community value         :       28 variable      1456       29      2200
Large Community               :       28     40        1152       29      1192
Large Community value         :       28 variable      1456       29      2200
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>