### PR TITLE
bgpd: Wrap IPV4_CLASS_DE into ipv4_unicast_valid() helper

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1605,9 +1605,9 @@ enum bgp_attr_parse_ret bgp_attr_nexthop_valid(struct peer *peer,
 	in_addr_t nexthop_h;
 
 	nexthop_h = ntohl(attr->nexthop.s_addr);
-	if ((IPV4_NET0(nexthop_h) || IPV4_NET127(nexthop_h)
-	     || IPV4_CLASS_DE(nexthop_h))
-	    && !BGP_DEBUG(allow_martians, ALLOW_MARTIANS)) {
+	if ((IPV4_NET0(nexthop_h) || IPV4_NET127(nexthop_h) ||
+	     !ipv4_unicast_valid(&attr->nexthop)) &&
+	    !BGP_DEBUG(allow_martians, ALLOW_MARTIANS)) {
 		uint8_t data[7]; /* type(2) + length(1) + nhop(4) */
 		char buf[INET_ADDRSTRLEN];
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3631,9 +3631,9 @@ bool bgp_update_martian_nexthop(struct bgp *bgp, afi_t afi, safi_t safi,
 
 	/* If NEXT_HOP is present, validate it. */
 	if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP)) {
-		if (attr->nexthop.s_addr == INADDR_ANY
-		    || IPV4_CLASS_DE(ntohl(attr->nexthop.s_addr))
-		    || bgp_nexthop_self(bgp, afi, type, stype, attr, dest))
+		if (attr->nexthop.s_addr == INADDR_ANY ||
+		    !ipv4_unicast_valid(&attr->nexthop) ||
+		    bgp_nexthop_self(bgp, afi, type, stype, attr, dest))
 			return true;
 	}
 
@@ -3650,11 +3650,12 @@ bool bgp_update_martian_nexthop(struct bgp *bgp, afi_t afi, safi_t safi,
 		switch (attr->mp_nexthop_len) {
 		case BGP_ATTR_NHLEN_IPV4:
 		case BGP_ATTR_NHLEN_VPNV4:
-			ret = (attr->mp_nexthop_global_in.s_addr == INADDR_ANY
-			       || IPV4_CLASS_DE(
-				       ntohl(attr->mp_nexthop_global_in.s_addr))
-			       || bgp_nexthop_self(bgp, afi, type, stype, attr,
-						   dest));
+			ret = (attr->mp_nexthop_global_in.s_addr ==
+				       INADDR_ANY ||
+			       !ipv4_unicast_valid(
+				       &attr->mp_nexthop_global_in) ||
+			       bgp_nexthop_self(bgp, afi, type, stype, attr,
+						dest));
 			break;
 
 		case BGP_ATTR_NHLEN_IPV6_GLOBAL:

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -4410,8 +4410,8 @@ DEFUN_YANG (set_evpn_gw_ip_ipv4,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	if (su.sin.sin_addr.s_addr == 0
-	    || IPV4_CLASS_DE(ntohl(su.sin.sin_addr.s_addr))) {
+	if (su.sin.sin_addr.s_addr == 0 ||
+	    !ipv4_unicast_valid(&su.sin.sin_addr)) {
 		vty_out(vty,
 			"%% Gateway IP cannot be 0.0.0.0, multicast or reserved\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -4448,8 +4448,8 @@ DEFUN_YANG (no_set_evpn_gw_ip_ipv4,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	if (su.sin.sin_addr.s_addr == 0
-	    || IPV4_CLASS_DE(ntohl(su.sin.sin_addr.s_addr))) {
+	if (su.sin.sin_addr.s_addr == 0 ||
+	    !ipv4_unicast_valid(&su.sin.sin_addr)) {
 		vty_out(vty,
 			"%% Gateway IP cannot be 0.0.0.0, multicast or reserved\n");
 		return CMD_WARNING_CONFIG_FAILED;

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -508,6 +508,17 @@ extern char *esi_to_str(const esi_t *esi, char *buf, int size);
 extern char *evpn_es_df_alg2str(uint8_t df_alg, char *buf, int buf_len);
 extern void prefix_evpn_hexdump(const struct prefix_evpn *p);
 
+static inline bool ipv4_unicast_valid(const struct in_addr *addr)
+{
+
+	in_addr_t ip = ntohl(addr->s_addr);
+
+	if (IPV4_CLASS_DE(ip))
+		return false;
+
+	return true;
+}
+
 static inline int ipv6_martian(const struct in6_addr *addr)
 {
 	struct in6_addr localhost_addr;
@@ -527,7 +538,7 @@ static inline int ipv4_martian(const struct in_addr *addr)
 {
 	in_addr_t ip = ntohl(addr->s_addr);
 
-	if (IPV4_NET0(ip) || IPV4_NET127(ip) || IPV4_CLASS_DE(ip)) {
+	if (IPV4_NET0(ip) || IPV4_NET127(ip) || !ipv4_unicast_valid(addr)) {
 		return 1;
 	}
 	return 0;

--- a/lib/routemap_northbound.c
+++ b/lib/routemap_northbound.c
@@ -887,7 +887,7 @@ static int lib_route_map_entry_set_action_ipv4_address_modify(
 		 * only implemented action.
 		 */
 		yang_dnode_get_ipv4(&ia, args->dnode, NULL);
-		if (ia.s_addr == INADDR_ANY || IPV4_CLASS_DE(ntohl(ia.s_addr)))
+		if (ia.s_addr == INADDR_ANY || !ipv4_unicast_valid(&ia))
 			return NB_ERR_VALIDATION;
 		/* FALLTHROUGH */
 	case NB_EV_PREPARE:


### PR DESCRIPTION
Linux kernel allows (FreeBSD/OpenBSD too) using reserved class E IP ranges.

This is a preparation commit that ease the global switch to allow/deny
class E IP ranges in FRR.

https://datatracker.ietf.org/doc/html/draft-chen-ati-adaptive-ipv4-address-space

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>

Related: https://github.com/FRRouting/frr/pull/11283