### PR TITLE
bmp: add a interface source to bmp connect command

### DIFF
--- a/bgpd/bgp_bmp.h
+++ b/bgpd/bgp_bmp.h
@@ -179,6 +179,8 @@ struct bmp_active {
 	char *hostname;
 	int port;
 	unsigned minretry, maxretry;
+	char *ifsrc;
+	union sockunion addrsrc;
 
 	struct resolver_query resq;
 

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -632,7 +632,7 @@ static char *bgp_get_bound_name(struct peer *peer)
 	return peer->bgp->name;
 }
 
-static int bgp_update_address(struct interface *ifp, const union sockunion *dst,
+int bgp_update_address(struct interface *ifp, const union sockunion *dst,
 			      union sockunion *addr)
 {
 	struct prefix *p, *sel, d;

--- a/bgpd/bgp_network.h
+++ b/bgpd/bgp_network.h
@@ -45,5 +45,7 @@ extern int bgp_md5_unset_prefix(struct bgp *bgp, struct prefix *p);
 extern int bgp_md5_set(struct peer *);
 extern int bgp_md5_unset(struct peer *);
 extern int bgp_set_socket_ttl(struct peer *, int fd);
+extern int bgp_update_address(struct interface *ifp, const union sockunion *dst,
+			      union sockunion *addr);
 
 #endif /* _QUAGGA_BGP_NETWORK_H */

--- a/doc/user/bmp.rst
+++ b/doc/user/bmp.rst
@@ -108,13 +108,15 @@ BMP session configuration
 Inside a ``bmp targets`` block, the following commands control session
 establishment:
 
-.. clicmd:: bmp connect HOSTNAME port (1-65535) {min-retry MSEC|max-retry MSEC}
+
+.. clicmd:: bmp connect HOSTNAME port (1-65535) {min-retry MSEC|max-retry MSEC} [source-interface WORD]
 
    Add/remove an active outbound BMP session.  HOSTNAME is resolved via DNS,
    if multiple addresses are returned they are tried in nondeterministic
    order.  Only one connection will be established even if multiple addresses
    are returned.  ``min-retry`` and ``max-retry`` specify (in milliseconds)
-   bounds for exponential backoff.
+   bounds for exponential backoff. ``source-interface`` is the local interface on
+   which the connection has to bind.
 
 .. warning::
 


### PR DESCRIPTION
With current release, forcin the source ip address when setting up a BMP
connection is not possible.

The need is to add an extra parameter for the following vty command:

router bgp 65500
bmp targets AAA
bmp connect 2.2.2.2 port 666 min-retry 100 max-retry 700
bmp connect 2:2::2:2 port 666 min-retry 100 max-retry 700 [source-interface lo1]

Signed-off-by: Francois Dumontet <francois.dumontet@6wind.com>