### PR TITLE
pimd: Handle receive of (*,G) register stop with src addr as 0

### DIFF
--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -175,7 +175,12 @@ int pim_register_stop_recv(struct interface *ifp, uint8_t *buf, int buf_size)
 	rp = RP(pim_ifp->pim, sg.grp);
 	if (rp) {
 		rpf_addr = pim_addr_from_prefix(&rp->rpf_addr);
-		if (pim_addr_cmp(sg.src, rpf_addr) == 0) {
+		/* As per RFC 7761, Section 4.9.4:
+		 * A special wildcard value consisting of an address field of
+		 * all zeros can be used to indicate any source.
+		 */
+		if ((pim_addr_cmp(sg.src, rpf_addr) == 0) ||
+		    pim_addr_is_any(sg.src)) {
 			handling_star = true;
 			sg.src = PIMADDR_ANY;
 		}


### PR DESCRIPTION
PIM conformance test case 11.12 sends a register stop msg with
source address as 0. This should trigger a register stop for
all the upstreams. It is not happening as such because we are not
considering 0.0.0.0 source address for starg_handling.

Fixed it.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>