### PR TITLE
pimd: pim_addr_cmp returns 0 for same not -1 or 1

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1989,8 +1989,8 @@ void pim_show_interfaces(struct pim_instance *pim, struct vty *vty, bool mlag,
 		json_object_string_addf(json_row, "pimDesignatedRouter",
 					"%pPAs", &pim_ifp->pim_dr_addr);
 
-		if (pim_addr_cmp(pim_ifp->pim_dr_addr,
-				 pim_ifp->primary_address))
+		if (!pim_addr_cmp(pim_ifp->pim_dr_addr,
+				  pim_ifp->primary_address))
 			json_object_boolean_true_add(
 				json_row, "pimDesignatedRouterLocal");
 


### PR DESCRIPTION
The test for setting pimDesignatedRouterLocal was comparing
the result of pim_addr_cmp to non zero to say that the
pim_dr_addr and primary_address are the same.  This is
not correct in that pim_addr_cmp returns 0 for being the
same, so the correct test is !pim_addr_cmp

Signed-off-by: Donald Sharp <sharpd@nvidia.com>