### PR TITLE
pimd: Fix pim_channel_oil_empty tests

### DIFF
--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -544,27 +544,19 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 
 int pim_channel_oil_empty(struct channel_oil *c_oil)
 {
-#if PIM_IPV == 4
-	static struct mfcctl null_oil;
-#else
-	static struct mf6cctl null_oil;
-#endif
+	static struct channel_oil null_oil;
 
 	if (!c_oil)
 		return 1;
-
 
 	/* exclude pimreg from the OIL when checking if the inherited_oil is
 	 * non-NULL.
 	 * pimreg device (in all vrfs) uses a vifi of
 	 * 0 (PIM_OIF_PIM_REGISTER_VIF) so we simply mfcc_ttls[0] */
-	if (oil_if_has(c_oil, 0)) {
-#if PIM_IPV == 4
-		null_oil.mfcc_ttls[0] = 1;
-#else
-		IF_SET(0, &null_oil.mf6cc_ifset);
-#endif
-	}
+	if (oil_if_has(c_oil, 0))
+		oil_if_set(&null_oil, 0, 1);
+	else
+		oil_if_set(&null_oil, 0, 0);
 
-	return !oil_if_cmp(&c_oil->oil, &null_oil);
+	return !oil_if_cmp(&c_oil->oil, &null_oil.oil);
 }

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -255,7 +255,7 @@ int pim_channel_del_oif(struct channel_oil *channel_oil, struct interface *oif,
 		return 0;
 	}
 
-	oil_if_set(channel_oil, pim_ifp->mroute_vif_index, false);
+	oil_if_set(channel_oil, pim_ifp->mroute_vif_index, 0);
 	/* clear mute; will be re-evaluated when the OIF becomes valid again */
 	channel_oil->oif_flags[pim_ifp->mroute_vif_index] &= ~PIM_OIF_FLAG_MUTE;
 

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -130,9 +130,9 @@ static inline vifi_t *oil_parent(struct channel_oil *c_oil)
 	return &c_oil->oil.mfcc_parent;
 }
 
-static inline uint8_t oil_if_has(struct channel_oil *c_oil, vifi_t ifi)
+static inline bool oil_if_has(struct channel_oil *c_oil, vifi_t ifi)
 {
-	return c_oil->oil.mfcc_ttls[ifi];
+	return !!c_oil->oil.mfcc_ttls[ifi];
 }
 
 static inline void oil_if_set(struct channel_oil *c_oil, vifi_t ifi, uint8_t set)
@@ -166,7 +166,8 @@ static inline bool oil_if_has(struct channel_oil *c_oil, mifi_t ifi)
 	return !!IF_ISSET(ifi, &c_oil->oil.mf6cc_ifset);
 }
 
-static inline void oil_if_set(struct channel_oil *c_oil, mifi_t ifi, bool set)
+static inline void oil_if_set(struct channel_oil *c_oil, mifi_t ifi,
+			      uint8_t set)
 {
 	if (set)
 		IF_SET(ifi, &c_oil->oil.mf6cc_ifset);

--- a/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_static_routes_topo1.py
+++ b/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_static_routes_topo1.py
@@ -720,7 +720,7 @@ def test_pim_source_dr_functionality_while_rebooting_dr_non_dr_nodes_p1(request)
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     step(
-        "R2 is transit router for R3 to reach R4, mroute should have (s, g) mroute with "
+        "R2 is transit router for I1 to reach R4, mroute should have (s, g) mroute with "
         "OIL towards R4, using 'show ip mroute json'"
     )
     step(
@@ -787,7 +787,9 @@ def test_pim_source_dr_functionality_while_rebooting_dr_non_dr_nodes_p1(request)
     step("Reboot R3 node")
     stop_router(tgen, "r3")
 
-    step("After reboot of R3 verify R1 became DR, using 'show ip pim interface json'")
+    step(
+        "After reboot of R3 verify R1 continues to be DR, using 'show ip pim interface json'"
+    )
 
     result = verify_pim_config(tgen, input_dict_dr)
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
@@ -834,7 +836,9 @@ def test_pim_source_dr_functionality_while_rebooting_dr_non_dr_nodes_p1(request)
     step("Reboot R2 node")
     stop_router(tgen, "r2")
 
-    step("After reboot of R2, R1 became DR verify using 'show ip pim interface json'")
+    step(
+        "After reboot of R2, R1 continues to be DR verify using 'show ip pim interface json'"
+    )
 
     result = verify_pim_config(tgen, input_dict_dr)
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
@@ -843,9 +847,9 @@ def test_pim_source_dr_functionality_while_rebooting_dr_non_dr_nodes_p1(request)
         "R3 and R2 should not have any mroute and upstream , verify using "
         "'show ip mroute json' 'show ip pim upstream json'"
     )
-    step("R1 has mroute created with OIL towards R4 , using 'show ip mroute json'")
+    step("R1 has mroute created with empty OIL, using 'show ip mroute json'")
     step(
-        "R1 has upstream with Join Rej Prune , verify using 'show ip pim upstream json'"
+        "R1 has upstream with Not Join, Rej Prune , verify using 'show ip pim upstream json'"
     )
 
     for data in input_dict_r1_r2:


### PR DESCRIPTION
The pim_channel_oil_empty() function was setting
the pimreg if it ever existed for NULL comparison
but of course the pimreg device is never pulled back
out again when it was needed to be when the pimreg
is not present.

Commit: a5fa982256b23d53d5b833f75224fb7f96054b9b
broke this.

Fixes: #11368
Signed-off-by: Donald Sharp <sharpd@nvidia.com>