### PR TITLE
pimd: Show interface traffic even if interface is currently `down`

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -867,8 +867,6 @@ static void pim_show_interface_traffic(struct pim_instance *pim,
 		if (!pim_ifp)
 			continue;
 
-		if (pim_ifp->pim_sock_fd < 0)
-			continue;
 		if (uj) {
 			json_row = json_object_new_object();
 			json_object_pim_ifp_add(json_row, ifp);
@@ -956,9 +954,6 @@ static void pim_show_interface_traffic_single(struct pim_instance *pim,
 		pim_ifp = ifp->info;
 
 		if (!pim_ifp)
-			continue;
-
-		if (pim_ifp->pim_sock_fd < 0)
 			continue;
 
 		found_ifname = 1;


### PR DESCRIPTION
the `show ip pim interface [x] traffic` command was deciding
to skip display of interfaces if they happened to be down at
that moment.  This of course does not make a bunch of sense
to limit the output for a interface that may have sent data
in the past.

This fixes this test crash:
rnode = <lib.topogen.TopoRouter object at 0x7fc755be3880>, dut = 'c1', input_dict = {'c1': {'c1-l1-eth2': ['helloTx', 'helloRx']}}, output_dict = {'c1': {}}

    def show_pim_intf_traffic(rnode, dut, input_dict, output_dict):
        show_pim_intf_traffic_json = run_frr_cmd(
            rnode, "show ip pim interface traffic json", isjson=True
        )

        output_dict[dut] = {}
        for intf, data in input_dict[dut].items():
>           interface_json = show_pim_intf_traffic_json[intf]
E           KeyError: 'c1-l1-eth2'

/home/sharpd/frr8/tests/topotests/lib/pim.py:1496: KeyError

Signed-off-by: Donald Sharp <sharpd@nvidia.com>