### PR TITLE
pimd, pim6d: Moving the reusable code to common api for PIM show CLIs

### DIFF
--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1418,16 +1418,7 @@ DEFPY (show_ipv6_pim_nexthop,
        VRF_CMD_HELP_STR
        "PIM cached nexthop rpf information\n")
 {
-	struct vrf *v;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v)
-		return CMD_WARNING;
-
-	pim_show_nexthop(v->info, vty);
-
-	return CMD_SUCCESS;
+	return pim_show_nexthop_cmd_helper(vrf, vty);
 }
 
 DEFPY (show_ipv6_pim_nexthop_lookup,

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1266,33 +1266,8 @@ DEFPY (show_ipv6_pim_interface_vrf_all,
        "interface name\n"
        JSON_STR)
 {
-	bool uj = !!json;
-	struct vrf *v;
-	json_object *json_parent = NULL;
-	json_object *json_vrf = NULL;
-
-	if (uj)
-		json_parent = json_object_new_object();
-
-	RB_FOREACH (v, vrf_name_head, &vrfs_by_name) {
-		if (!uj)
-			vty_out(vty, "VRF: %s\n", v->name);
-		else
-			json_vrf = json_object_new_object();
-
-		if (interface)
-			pim_show_interfaces_single(v->info, vty, interface,
-						   false, json_vrf);
-		else
-			pim_show_interfaces(v->info, vty, false, json_vrf);
-
-		if (uj)
-			json_object_object_add(json_parent, v->name, json_vrf);
-	}
-	if (uj)
-		vty_json(vty, json_parent);
-
-	return CMD_SUCCESS;
+	return pim_show_interface_vrf_all_cmd_helper(vty, !!json, false,
+						     interface);
 }
 
 DEFPY (show_ipv6_pim_join,

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1432,37 +1432,7 @@ DEFPY (show_ipv6_pim_nexthop_lookup,
        "Source/RP address\n"
        "Multicast Group address\n")
 {
-	struct prefix nht_p;
-	int result = 0;
-	pim_addr vif_source;
-	struct prefix grp;
-	struct pim_nexthop nexthop;
-	struct vrf *v;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v)
-		return CMD_WARNING;
-
-	if (!pim_rp_set_upstream_addr(v->info, &vif_source, source, group))
-		return CMD_SUCCESS;
-
-	pim_addr_to_prefix(&nht_p, vif_source);
-	pim_addr_to_prefix(&grp, group);
-	memset(&nexthop, 0, sizeof(nexthop));
-
-	result = pim_ecmp_nexthop_lookup(v->info, &nexthop, &nht_p, &grp, 0);
-
-	if (!result) {
-		vty_out(vty,
-			"Nexthop Lookup failed, no usable routes returned.\n");
-		return CMD_SUCCESS;
-	}
-
-	vty_out(vty, "Group %s --- Nexthop %pPAs Interface %s\n", group_str,
-		&nexthop.mrib_nexthop_addr, nexthop.interface->name);
-
-	return CMD_SUCCESS;
+	return pim_show_nexthop_lookup_cmd_helper(vrf, vty, source, group);
 }
 
 DEFPY (show_ipv6_multicast,

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1406,31 +1406,7 @@ DEFPY (show_ipv6_pim_neighbor_vrf_all,
        "Name of interface or neighbor\n"
        JSON_STR)
 {
-	struct vrf *v;
-	json_object *json_parent = NULL;
-	json_object *json_vrf = NULL;
-
-	if (json)
-		json_parent = json_object_new_object();
-	RB_FOREACH (v, vrf_name_head, &vrfs_by_name) {
-		if (!json)
-			vty_out(vty, "VRF: %s\n", v->name);
-		else
-			json_vrf = json_object_new_object();
-
-		if (interface)
-			pim_show_neighbors_single(v->info, vty, interface,
-						  json_vrf);
-		else
-			pim_show_neighbors(v->info, vty, json_vrf);
-
-		if (json)
-			json_object_object_add(json_parent, v->name, json_vrf);
-	}
-	if (json)
-		vty_json(vty, json_parent);
-
-	return CMD_SUCCESS;
+	return pim_show_neighbors_vrf_all_cmd_helper(vty, json, interface);
 }
 
 DEFPY (show_ipv6_pim_nexthop,

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1363,25 +1363,7 @@ DEFPY (show_ipv6_pim_jp_agg,
        VRF_CMD_HELP_STR
        "join prune aggregation list\n")
 {
-	struct vrf *v;
-	struct pim_instance *pim;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v) {
-		vty_out(vty, "%% Vrf specified: %s does not exist\n", vrf);
-		return CMD_WARNING;
-	}
-	pim = pim_get_pim_instance(v->vrf_id);
-
-	if (!pim) {
-		vty_out(vty, "%% Unable to find pim instance\n");
-		return CMD_WARNING;
-	}
-
-	pim_show_jp_agg_list(pim, vty);
-
-	return CMD_SUCCESS;
+	return pim_show_jp_agg_list_cmd_helper(vrf, vty);
 }
 
 DEFPY (show_ipv6_pim_local_membership,

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1376,17 +1376,7 @@ DEFPY (show_ipv6_pim_local_membership,
        "PIM interface local-membership\n"
        JSON_STR)
 {
-	struct vrf *v;
-	bool uj = !!json;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v)
-		return CMD_WARNING;
-
-	pim_show_membership(v->info, vty, uj);
-
-	return CMD_SUCCESS;
+	return pim_show_membership_cmd_helper(vrf, vty, !!json);
 }
 
 DEFPY (show_ipv6_pim_neighbor,

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1250,28 +1250,8 @@ DEFPY (show_ipv6_pim_interface,
        "interface name\n"
        JSON_STR)
 {
-	struct vrf *v;
-	bool uj = !!json;
-	json_object *json_parent = NULL;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v)
-		return CMD_WARNING;
-
-	if (uj)
-		json_parent = json_object_new_object();
-
-	if (interface)
-		pim_show_interfaces_single(v->info, vty, interface, false,
-					   json_parent);
-	else
-		pim_show_interfaces(v->info, vty, false, json_parent);
-
-	if (uj)
-		vty_json(vty, json_parent);
-
-	return CMD_SUCCESS;
+	return pim_show_interface_cmd_helper(vrf, vty, !!json, false,
+					     interface);
 }
 
 DEFPY (show_ipv6_pim_interface_vrf_all,

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1282,41 +1282,7 @@ DEFPY (show_ipv6_pim_join,
        "The Group\n"
        JSON_STR)
 {
-	pim_sgaddr sg = {};
-	struct vrf *v;
-	struct pim_instance *pim;
-	json_object *json_parent = NULL;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v) {
-		vty_out(vty, "%% Vrf specified: %s does not exist\n", vrf);
-		return CMD_WARNING;
-	}
-	pim = pim_get_pim_instance(v->vrf_id);
-
-	if (!pim) {
-		vty_out(vty, "%% Unable to find pim instance\n");
-		return CMD_WARNING;
-	}
-
-	if (!pim_addr_is_any(s_or_g)) {
-		if (!pim_addr_is_any(g)) {
-			sg.src = s_or_g;
-			sg.grp = g;
-		} else
-			sg.grp = s_or_g;
-	}
-
-	if (json)
-		json_parent = json_object_new_object();
-
-	pim_show_join(pim, vty, &sg, json_parent);
-
-	if (json)
-		vty_json(vty, json_parent);
-
-	return CMD_SUCCESS;
+	return pim_show_join_cmd_helper(vrf, vty, s_or_g, g, json);
 }
 
 DEFPY (show_ipv6_pim_join_vrf_all,
@@ -1329,29 +1295,7 @@ DEFPY (show_ipv6_pim_join_vrf_all,
        "PIM interface join information\n"
        JSON_STR)
 {
-	pim_sgaddr sg = {0};
-	struct vrf *vrf_struct;
-	json_object *json_parent = NULL;
-	json_object *json_vrf = NULL;
-
-	if (json)
-		json_parent = json_object_new_object();
-
-	RB_FOREACH (vrf_struct, vrf_name_head, &vrfs_by_name) {
-		if (!json_parent)
-			vty_out(vty, "VRF: %s\n", vrf_struct->name);
-		else
-			json_vrf = json_object_new_object();
-		pim_show_join(vrf_struct->info, vty, &sg, json_vrf);
-
-		if (json)
-			json_object_object_add(json_parent, vrf_struct->name,
-					       json_vrf);
-	}
-	if (json)
-		vty_json(vty, json_parent);
-
-	return CMD_WARNING;
+	return pim_show_join_vrf_all_cmd_helper(vty, json);
 }
 
 DEFPY (show_ipv6_pim_jp_agg,

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1235,17 +1235,7 @@ DEFPY (show_ipv6_pim_channel,
        "PIM downstream channel info\n"
        JSON_STR)
 {
-	struct vrf *v;
-	bool uj = !!json;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v)
-		return CMD_WARNING;
-
-	pim_show_channel(v->info, vty, uj);
-
-	return CMD_SUCCESS;
+	return pim_show_channel_cmd_helper(vrf, vty, !!json);
 }
 
 DEFPY (show_ipv6_pim_interface,

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1391,26 +1391,7 @@ DEFPY (show_ipv6_pim_neighbor,
        "Name of interface or neighbor\n"
        JSON_STR)
 {
-	struct vrf *v;
-	json_object *json_parent = NULL;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v)
-		return CMD_WARNING;
-
-	if (json)
-		json_parent = json_object_new_object();
-
-	if (interface)
-		pim_show_neighbors_single(v->info, vty, interface, json_parent);
-	else
-		pim_show_neighbors(v->info, vty, json_parent);
-
-	if (json)
-		vty_json(vty, json_parent);
-
-	return CMD_SUCCESS;
+	return pim_show_neighbors_cmd_helper(vrf, vty, json, interface);
 }
 
 DEFPY (show_ipv6_pim_neighbor_vrf_all,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2553,17 +2553,7 @@ DEFPY (show_ip_pim_local_membership,
        "PIM interface local-membership\n"
        JSON_STR)
 {
-	struct vrf *v;
-	bool uj = !!json;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v)
-		return CMD_WARNING;
-
-	pim_show_membership(v->info, vty, uj);
-
-	return CMD_SUCCESS;
+	return pim_show_membership_cmd_helper(vrf, vty, !!json);
 }
 
 static void pim_show_mlag_up_entry_detail(struct vrf *vrf,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3284,16 +3284,7 @@ DEFPY (show_ip_pim_nexthop,
        VRF_CMD_HELP_STR
        "PIM cached nexthop rpf information\n")
 {
-	struct vrf *v;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v)
-		return CMD_WARNING;
-
-	pim_show_nexthop(v->info, vty);
-
-	return CMD_SUCCESS;
+	return pim_show_nexthop_cmd_helper(vrf, vty);
 }
 
 DEFPY (show_ip_pim_nexthop_lookup,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2427,29 +2427,8 @@ DEFPY (show_ip_pim_interface,
        "interface name\n"
        JSON_STR)
 {
-	struct vrf *v;
-	bool uj = !!json;
-	bool is_mlag = !!mlag;
-	json_object *json_parent = NULL;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v)
-		return CMD_WARNING;
-
-	if (uj)
-		json_parent = json_object_new_object();
-
-	if (interface)
-		pim_show_interfaces_single(v->info, vty, interface, is_mlag,
-					   json_parent);
-	else
-		pim_show_interfaces(v->info, vty, is_mlag, json_parent);
-
-	if (uj)
-		vty_json(vty, json_parent);
-
-	return CMD_SUCCESS;
+	return pim_show_interface_cmd_helper(vrf, vty, !!json, !!mlag,
+					     interface);
 }
 
 DEFPY (show_ip_pim_interface_vrf_all,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2444,34 +2444,8 @@ DEFPY (show_ip_pim_interface_vrf_all,
        "interface name\n"
        JSON_STR)
 {
-	bool uj = !!json;
-	bool is_mlag = !!mlag;
-	struct vrf *v;
-	json_object *json_parent = NULL;
-	json_object *json_vrf = NULL;
-
-	if (uj)
-		json_parent = json_object_new_object();
-
-	RB_FOREACH (v, vrf_name_head, &vrfs_by_name) {
-		if (!uj)
-			vty_out(vty, "VRF: %s\n", v->name);
-		else
-			json_vrf = json_object_new_object();
-
-		if (interface)
-			pim_show_interfaces_single(v->info, vty, interface,
-						   is_mlag, json_vrf);
-		else
-			pim_show_interfaces(v->info, vty, is_mlag, json_vrf);
-
-		if (uj)
-			json_object_object_add(json_parent, v->name, json_vrf);
-	}
-	if (uj)
-		vty_json(vty, json_parent);
-
-	return CMD_SUCCESS;
+	return pim_show_interface_vrf_all_cmd_helper(vty, !!json, !!mlag,
+						     interface);
 }
 
 DEFPY (show_ip_pim_join,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2850,31 +2850,7 @@ DEFPY (show_ip_pim_neighbor_vrf_all,
        "Name of interface or neighbor\n"
        JSON_STR)
 {
-	struct vrf *v;
-	json_object *json_parent = NULL;
-	json_object *json_vrf = NULL;
-
-	if (json)
-		json_parent = json_object_new_object();
-	RB_FOREACH (v, vrf_name_head, &vrfs_by_name) {
-		if (!json)
-			vty_out(vty, "VRF: %s\n", v->name);
-		else
-			json_vrf = json_object_new_object();
-
-		if (interface)
-			pim_show_neighbors_single(v->info, vty, interface,
-						  json_vrf);
-		else
-			pim_show_neighbors(v->info, vty, json_vrf);
-
-		if (json)
-			json_object_object_add(json_parent, v->name, json_vrf);
-	}
-	if (json)
-		vty_json(vty, json_parent);
-
-	return CMD_SUCCESS;
+	return pim_show_neighbors_vrf_all_cmd_helper(vty, json, interface);
 }
 
 DEFPY (show_ip_pim_secondary,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2460,41 +2460,7 @@ DEFPY (show_ip_pim_join,
        "The Group\n"
        JSON_STR)
 {
-	pim_sgaddr sg = {0};
-	struct vrf *v;
-	struct pim_instance *pim;
-	json_object *json_parent = NULL;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v) {
-		vty_out(vty, "%% Vrf specified: %s does not exist\n", vrf);
-		return CMD_WARNING;
-	}
-	pim = pim_get_pim_instance(v->vrf_id);
-
-	if (!pim) {
-		vty_out(vty, "%% Unable to find pim instance\n");
-		return CMD_WARNING;
-	}
-
-	if (s_or_g.s_addr != INADDR_ANY) {
-		if (g.s_addr != INADDR_ANY) {
-			sg.src = s_or_g;
-			sg.grp = g;
-		} else
-			sg.grp = s_or_g;
-	}
-
-	if (json)
-		json_parent = json_object_new_object();
-
-	pim_show_join(pim, vty, &sg, json_parent);
-
-	if (json)
-		vty_json(vty, json_parent);
-
-	return CMD_SUCCESS;
+	return pim_show_join_cmd_helper(vrf, vty, s_or_g, g, json);
 }
 
 DEFPY (show_ip_pim_join_vrf_all,
@@ -2507,28 +2473,7 @@ DEFPY (show_ip_pim_join_vrf_all,
        "PIM interface join information\n"
        JSON_STR)
 {
-	pim_sgaddr sg = {0};
-	struct vrf *vrf_struct;
-	json_object *json_parent = NULL;
-	json_object *json_vrf = NULL;
-
-	if (json)
-		json_parent = json_object_new_object();
-	RB_FOREACH (vrf_struct, vrf_name_head, &vrfs_by_name) {
-		if (!json)
-			vty_out(vty, "VRF: %s\n", vrf_struct->name);
-		else
-			json_vrf = json_object_new_object();
-		pim_show_join(vrf_struct->info, vty, &sg, json_vrf);
-
-		if (json)
-			json_object_object_add(json_parent, vrf_struct->name,
-					       json_vrf);
-	}
-	if (json)
-		vty_json(vty, json_parent);
-
-	return CMD_WARNING;
+	return pim_show_join_vrf_all_cmd_helper(vty, json);
 }
 
 DEFPY (show_ip_pim_jp_agg,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2835,26 +2835,7 @@ DEFPY (show_ip_pim_neighbor,
        "Name of interface or neighbor\n"
        JSON_STR)
 {
-	struct vrf *v;
-	json_object *json_parent = NULL;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v)
-		return CMD_WARNING;
-
-	if (json)
-		json_parent = json_object_new_object();
-
-	if (interface)
-		pim_show_neighbors_single(v->info, vty, interface, json_parent);
-	else
-		pim_show_neighbors(v->info, vty, json_parent);
-
-	if (json)
-		vty_json(vty, json_parent);
-
-	return CMD_SUCCESS;
+	return pim_show_neighbors_cmd_helper(vrf, vty, json, interface);
 }
 
 DEFPY (show_ip_pim_neighbor_vrf_all,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3168,17 +3168,7 @@ DEFPY (show_ip_pim_channel,
        "PIM downstream channel info\n"
        JSON_STR)
 {
-	struct vrf *v;
-	bool uj = !!json;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v)
-		return CMD_WARNING;
-
-	pim_show_channel(v->info, vty, uj);
-
-	return CMD_SUCCESS;
+	return pim_show_channel_cmd_helper(vrf, vty, !!json);
 }
 
 DEFPY (show_ip_pim_upstream_join_desired,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2540,25 +2540,7 @@ DEFPY (show_ip_pim_jp_agg,
        VRF_CMD_HELP_STR
        "join prune aggregation list\n")
 {
-	struct vrf *v;
-	struct pim_instance *pim;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v) {
-		vty_out(vty, "%% Vrf specified: %s does not exist\n", vrf);
-		return CMD_WARNING;
-	}
-	pim = pim_get_pim_instance(v->vrf_id);
-
-	if (!pim) {
-		vty_out(vty, "%% Unable to find pim instance\n");
-		return CMD_WARNING;
-	}
-
-	pim_show_jp_agg_list(pim, vty);
-
-	return CMD_SUCCESS;
+	return pim_show_jp_agg_list_cmd_helper(vrf, vty);
 }
 
 DEFPY (show_ip_pim_local_membership,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3298,49 +3298,7 @@ DEFPY (show_ip_pim_nexthop_lookup,
        "Source/RP address\n"
        "Multicast Group address\n")
 {
-	struct prefix nht_p;
-	int result = 0;
-	pim_addr vif_source;
-	struct prefix grp;
-	struct pim_nexthop nexthop;
-	struct vrf *v;
-
-	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
-
-	if (!v)
-		return CMD_WARNING;
-
-	if (pim_is_group_224_4(source)) {
-		vty_out(vty,
-			"Invalid argument. Expected Valid Source Address.\n");
-		return CMD_WARNING;
-	}
-
-	if (!pim_is_group_224_4(group)) {
-		vty_out(vty,
-			"Invalid argument. Expected Valid Multicast Group Address.\n");
-		return CMD_WARNING;
-	}
-
-	if (!pim_rp_set_upstream_addr(v->info, &vif_source, source, group))
-		return CMD_SUCCESS;
-
-	pim_addr_to_prefix(&nht_p, vif_source);
-	pim_addr_to_prefix(&grp, group);
-	memset(&nexthop, 0, sizeof(nexthop));
-
-	result = pim_ecmp_nexthop_lookup(v->info, &nexthop, &nht_p, &grp, 0);
-
-	if (!result) {
-		vty_out(vty,
-			"Nexthop Lookup failed, no usable routes returned.\n");
-		return CMD_SUCCESS;
-	}
-
-	vty_out(vty, "Group %s --- Nexthop %pPAs Interface %s \n", group_str,
-		&nexthop.mrib_nexthop_addr, nexthop.interface->name);
-
-	return CMD_SUCCESS;
+	return pim_show_nexthop_lookup_cmd_helper(vrf, vty, source, group);
 }
 
 DEFUN (show_ip_pim_interface_traffic,

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1959,6 +1959,32 @@ int pim_show_channel_cmd_helper(const char *vrf, struct vty *vty, bool uj)
 	return CMD_SUCCESS;
 }
 
+int pim_show_interface_cmd_helper(const char *vrf, struct vty *vty, bool uj,
+				  bool mlag, const char *interface)
+{
+	struct vrf *v;
+	json_object *json_parent = NULL;
+
+	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
+
+	if (!v)
+		return CMD_WARNING;
+
+	if (uj)
+		json_parent = json_object_new_object();
+
+	if (interface)
+		pim_show_interfaces_single(v->info, vty, interface, mlag,
+					   json_parent);
+	else
+		pim_show_interfaces(v->info, vty, mlag, json_parent);
+
+	if (uj)
+		vty_json(vty, json_parent);
+
+	return CMD_SUCCESS;
+}
+
 void pim_show_interfaces(struct pim_instance *pim, struct vty *vty, bool mlag,
 			 json_object *json)
 {

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1945,6 +1945,20 @@ void pim_show_channel(struct pim_instance *pim, struct vty *vty, bool uj)
 		vty_json(vty, json);
 }
 
+int pim_show_channel_cmd_helper(const char *vrf, struct vty *vty, bool uj)
+{
+	struct vrf *v;
+
+	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
+
+	if (!v)
+		return CMD_WARNING;
+
+	pim_show_channel(v->info, vty, uj);
+
+	return CMD_SUCCESS;
+}
+
 void pim_show_interfaces(struct pim_instance *pim, struct vty *vty, bool mlag,
 			 json_object *json)
 {

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1758,6 +1758,20 @@ void pim_show_jp_agg_list(struct pim_instance *pim, struct vty *vty)
 	}
 }
 
+int pim_show_membership_cmd_helper(const char *vrf, struct vty *vty, bool uj)
+{
+	struct vrf *v;
+
+	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
+
+	if (!v)
+		return CMD_WARNING;
+
+	pim_show_membership(v->info, vty, uj);
+
+	return CMD_SUCCESS;
+}
+
 static void pim_show_membership_helper(struct vty *vty,
 				       struct pim_interface *pim_ifp,
 				       struct pim_ifchannel *ch,

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -2611,6 +2611,31 @@ void pim_show_nexthop(struct pim_instance *pim, struct vty *vty)
 	hash_walk(pim->rpf_hash, pim_print_pnc_cache_walkcb, &cwd);
 }
 
+int pim_show_neighbors_cmd_helper(const char *vrf, struct vty *vty,
+				  const char *json, const char *interface)
+{
+	struct vrf *v;
+	json_object *json_parent = NULL;
+
+	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
+
+	if (!v)
+		return CMD_WARNING;
+
+	if (json)
+		json_parent = json_object_new_object();
+
+	if (interface)
+		pim_show_neighbors_single(v->info, vty, interface, json_parent);
+	else
+		pim_show_neighbors(v->info, vty, json_parent);
+
+	if (json)
+		vty_json(vty, json_parent);
+
+	return CMD_SUCCESS;
+}
+
 void pim_show_neighbors_single(struct pim_instance *pim, struct vty *vty,
 			       const char *neighbor, json_object *json)
 {

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1701,6 +1701,29 @@ static void pim_show_jp_agg_helper(struct vty *vty, struct interface *ifp,
 		is_join ? "J" : "P");
 }
 
+int pim_show_jp_agg_list_cmd_helper(const char *vrf, struct vty *vty)
+{
+	struct vrf *v;
+	struct pim_instance *pim;
+
+	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
+
+	if (!v) {
+		vty_out(vty, "%% Vrf specified: %s does not exist\n", vrf);
+		return CMD_WARNING;
+	}
+	pim = pim_get_pim_instance(v->vrf_id);
+
+	if (!pim) {
+		vty_out(vty, "%% Unable to find pim instance\n");
+		return CMD_WARNING;
+	}
+
+	pim_show_jp_agg_list(pim, vty);
+
+	return CMD_SUCCESS;
+}
+
 void pim_show_jp_agg_list(struct pim_instance *pim, struct vty *vty)
 {
 	struct interface *ifp;

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -2597,6 +2597,20 @@ static int pim_print_pnc_cache_walkcb(struct hash_bucket *bucket, void *arg)
 	return CMD_SUCCESS;
 }
 
+int pim_show_nexthop_cmd_helper(const char *vrf, struct vty *vty)
+{
+	struct vrf *v;
+
+	v = vrf_lookup_by_name(vrf ? vrf : VRF_DEFAULT_NAME);
+
+	if (!v)
+		return CMD_WARNING;
+
+	pim_show_nexthop(v->info, vty);
+
+	return CMD_SUCCESS;
+}
+
 void pim_show_nexthop(struct pim_instance *pim, struct vty *vty)
 {
 	struct pnc_cache_walk_data cwd;

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1985,6 +1985,37 @@ int pim_show_interface_cmd_helper(const char *vrf, struct vty *vty, bool uj,
 	return CMD_SUCCESS;
 }
 
+int pim_show_interface_vrf_all_cmd_helper(struct vty *vty, bool uj, bool mlag,
+					  const char *interface)
+{
+	struct vrf *v;
+	json_object *json_parent = NULL;
+	json_object *json_vrf = NULL;
+
+	if (uj)
+		json_parent = json_object_new_object();
+
+	RB_FOREACH (v, vrf_name_head, &vrfs_by_name) {
+		if (!uj)
+			vty_out(vty, "VRF: %s\n", v->name);
+		else
+			json_vrf = json_object_new_object();
+
+		if (interface)
+			pim_show_interfaces_single(v->info, vty, interface,
+						   mlag, json_vrf);
+		else
+			pim_show_interfaces(v->info, vty, mlag, json_vrf);
+
+		if (uj)
+			json_object_object_add(json_parent, v->name, json_vrf);
+	}
+	if (uj)
+		vty_json(vty, json_parent);
+
+	return CMD_SUCCESS;
+}
+
 void pim_show_interfaces(struct pim_instance *pim, struct vty *vty, bool mlag,
 			 json_object *json)
 {

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -2636,6 +2636,36 @@ int pim_show_neighbors_cmd_helper(const char *vrf, struct vty *vty,
 	return CMD_SUCCESS;
 }
 
+int pim_show_neighbors_vrf_all_cmd_helper(struct vty *vty, const char *json,
+					  const char *interface)
+{
+	struct vrf *v;
+	json_object *json_parent = NULL;
+	json_object *json_vrf = NULL;
+
+	if (json)
+		json_parent = json_object_new_object();
+	RB_FOREACH (v, vrf_name_head, &vrfs_by_name) {
+		if (!json)
+			vty_out(vty, "VRF: %s\n", v->name);
+		else
+			json_vrf = json_object_new_object();
+
+		if (interface)
+			pim_show_neighbors_single(v->info, vty, interface,
+						  json_vrf);
+		else
+			pim_show_neighbors(v->info, vty, json_vrf);
+
+		if (json)
+			json_object_object_add(json_parent, v->name, json_vrf);
+	}
+	if (json)
+		vty_json(vty, json_parent);
+
+	return CMD_SUCCESS;
+}
+
 void pim_show_neighbors_single(struct pim_instance *pim, struct vty *vty,
 			       const char *neighbor, json_object *json)
 {

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -91,6 +91,8 @@ void pim_show_channel(struct pim_instance *pim, struct vty *vty, bool uj);
 int pim_show_channel_cmd_helper(const char *vrf, struct vty *vty, bool uj);
 int pim_show_interface_cmd_helper(const char *vrf, struct vty *vty, bool uj,
 				  bool mlag, const char *interface);
+int pim_show_interface_vrf_all_cmd_helper(struct vty *vty, bool uj, bool mlag,
+					  const char *interface);
 void pim_show_interfaces(struct pim_instance *pim, struct vty *vty, bool mlag,
 			 json_object *json);
 void pim_show_interfaces_single(struct pim_instance *pim, struct vty *vty,

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -102,6 +102,8 @@ void pim_show_interfaces_single(struct pim_instance *pim, struct vty *vty,
 				json_object *json);
 void ip_pim_ssm_show_group_range(struct pim_instance *pim, struct vty *vty,
 				 bool uj);
+int pim_show_nexthop_lookup_cmd_helper(const char *vrf, struct vty *vty,
+				       pim_addr source, pim_addr group);
 int pim_show_nexthop_cmd_helper(const char *vrf, struct vty *vty);
 void pim_show_nexthop(struct pim_instance *pim, struct vty *vty);
 int pim_show_neighbors_cmd_helper(const char *vrf, struct vty *vty,

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -105,6 +105,8 @@ void ip_pim_ssm_show_group_range(struct pim_instance *pim, struct vty *vty,
 void pim_show_nexthop(struct pim_instance *pim, struct vty *vty);
 int pim_show_neighbors_cmd_helper(const char *vrf, struct vty *vty,
 				  const char *json, const char *interface);
+int pim_show_neighbors_vrf_all_cmd_helper(struct vty *vty, const char *json,
+					  const char *interface);
 void pim_show_neighbors_single(struct pim_instance *pim, struct vty *vty,
 			       const char *neighbor, json_object *json);
 void pim_show_neighbors(struct pim_instance *pim, struct vty *vty,

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -88,6 +88,7 @@ void pim_show_join(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 void pim_show_jp_agg_list(struct pim_instance *pim, struct vty *vty);
 void pim_show_membership(struct pim_instance *pim, struct vty *vty, bool uj);
 void pim_show_channel(struct pim_instance *pim, struct vty *vty, bool uj);
+int pim_show_channel_cmd_helper(const char *vrf, struct vty *vty, bool uj);
 void pim_show_interfaces(struct pim_instance *pim, struct vty *vty, bool mlag,
 			 json_object *json);
 void pim_show_interfaces_single(struct pim_instance *pim, struct vty *vty,

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -87,6 +87,7 @@ void pim_show_join(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 		   json_object *json);
 int pim_show_jp_agg_list_cmd_helper(const char *vrf, struct vty *vty);
 void pim_show_jp_agg_list(struct pim_instance *pim, struct vty *vty);
+int pim_show_membership_cmd_helper(const char *vrf, struct vty *vty, bool uj);
 void pim_show_membership(struct pim_instance *pim, struct vty *vty, bool uj);
 void pim_show_channel(struct pim_instance *pim, struct vty *vty, bool uj);
 int pim_show_channel_cmd_helper(const char *vrf, struct vty *vty, bool uj);

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -85,6 +85,7 @@ void pim_print_ifp_flags(struct vty *vty, struct interface *ifp);
 void json_object_pim_upstream_add(json_object *json, struct pim_upstream *up);
 void pim_show_join(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 		   json_object *json);
+int pim_show_jp_agg_list_cmd_helper(const char *vrf, struct vty *vty);
 void pim_show_jp_agg_list(struct pim_instance *pim, struct vty *vty);
 void pim_show_membership(struct pim_instance *pim, struct vty *vty, bool uj);
 void pim_show_channel(struct pim_instance *pim, struct vty *vty, bool uj);

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -83,6 +83,9 @@ bool pim_sgaddr_match(pim_sgaddr item, pim_sgaddr match);
 void json_object_pim_ifp_add(struct json_object *json, struct interface *ifp);
 void pim_print_ifp_flags(struct vty *vty, struct interface *ifp);
 void json_object_pim_upstream_add(json_object *json, struct pim_upstream *up);
+int pim_show_join_cmd_helper(const char *vrf, struct vty *vty, pim_addr s_or_g,
+			     pim_addr g, const char *json);
+int pim_show_join_vrf_all_cmd_helper(struct vty *vty, const char *json);
 void pim_show_join(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 		   json_object *json);
 int pim_show_jp_agg_list_cmd_helper(const char *vrf, struct vty *vty);

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -102,6 +102,7 @@ void pim_show_interfaces_single(struct pim_instance *pim, struct vty *vty,
 				json_object *json);
 void ip_pim_ssm_show_group_range(struct pim_instance *pim, struct vty *vty,
 				 bool uj);
+int pim_show_nexthop_cmd_helper(const char *vrf, struct vty *vty);
 void pim_show_nexthop(struct pim_instance *pim, struct vty *vty);
 int pim_show_neighbors_cmd_helper(const char *vrf, struct vty *vty,
 				  const char *json, const char *interface);

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -89,6 +89,8 @@ void pim_show_jp_agg_list(struct pim_instance *pim, struct vty *vty);
 void pim_show_membership(struct pim_instance *pim, struct vty *vty, bool uj);
 void pim_show_channel(struct pim_instance *pim, struct vty *vty, bool uj);
 int pim_show_channel_cmd_helper(const char *vrf, struct vty *vty, bool uj);
+int pim_show_interface_cmd_helper(const char *vrf, struct vty *vty, bool uj,
+				  bool mlag, const char *interface);
 void pim_show_interfaces(struct pim_instance *pim, struct vty *vty, bool mlag,
 			 json_object *json);
 void pim_show_interfaces_single(struct pim_instance *pim, struct vty *vty,

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -103,6 +103,8 @@ void pim_show_interfaces_single(struct pim_instance *pim, struct vty *vty,
 void ip_pim_ssm_show_group_range(struct pim_instance *pim, struct vty *vty,
 				 bool uj);
 void pim_show_nexthop(struct pim_instance *pim, struct vty *vty);
+int pim_show_neighbors_cmd_helper(const char *vrf, struct vty *vty,
+				  const char *json, const char *interface);
 void pim_show_neighbors_single(struct pim_instance *pim, struct vty *vty,
 			       const char *neighbor, json_object *json);
 void pim_show_neighbors(struct pim_instance *pim, struct vty *vty,


### PR DESCRIPTION
Moving the common lines of code to pim_cmd_common.c file 