### PR TITLE
github: Mark issues with no activity in 180 days as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: Mark stale issues
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Comment or remove the `autoclose` label in order to avoid having this issue closed.'
+        stale-issue-label: autoclose
+        days-before-stale: 180
+        days-before-close: -1
+        days-before-pr-stale: -1
+        days-before-pr-close: -1


### PR DESCRIPTION
Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>