### PR TITLE
pimd: Cleanup rpf lookup debug to help us figure out what is going on

### DIFF
--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -267,10 +267,15 @@ struct rp_info *pim_rp_find_match_group(struct pim_instance *pim,
 	}
 
 	rp_info = rn->info;
-	if (PIM_DEBUG_PIM_TRACE)
-		zlog_debug("Lookedup: %p for rp_info: %p(%pFX) Lock: %d", rn,
-			   rp_info, &rp_info->group,
-			   route_node_get_lock_count(rn));
+	if (PIM_DEBUG_PIM_TRACE) {
+		if (best)
+			zlog_debug(
+				"Lookedup(%pFX): prefix_list match %s, rn %p found: %pFX",
+				group, best->plist, rn, &rp_info->group);
+		else
+			zlog_debug("Lookedup(%pFX): rn %p found:%pFX", group,
+				   rn, &rp_info->group);
+	}
 
 	route_unlock_node(rn);
 


### PR DESCRIPTION
The rpf lookup debug was not taking into account the fact that a prefix-list
might be applied and also we might need to make a choice between the two.
So let's give ourselves a bit more data.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>