### PR TITLE
tests: fix sporadic failures in the ldp_topo1 topotest

### DIFF
--- a/tests/topotests/ldp_topo1/r1/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_topo1/r1/show_ip_ospf_neighbor.json
@@ -1,0 +1,14 @@
+{
+  "neighbors": {
+    "2.2.2.2": [
+      {
+        "dbSummaryCounter": 0,
+        "retransmitCounter": 0,
+        "priority": 1,
+        "converged": "Full",
+        "address": "10.0.1.2",
+        "requestCounter": 0
+      }
+    ]
+  }
+}

--- a/tests/topotests/ldp_topo1/r2/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_topo1/r2/show_ip_ospf_neighbor.json
@@ -1,0 +1,42 @@
+{
+  "neighbors": {
+    "1.1.1.1": [
+      {
+        "dbSummaryCounter": 0,
+        "retransmitCounter": 0,
+        "priority": 1,
+        "converged": "Full",
+        "address": "10.0.1.1",
+        "requestCounter": 0
+      }
+    ],
+    "3.3.3.3": [
+      {
+        "dbSummaryCounter": 0,
+        "retransmitCounter": 0,
+        "priority": 1,
+        "converged": "Full",
+        "address": "10.0.2.3",
+        "requestCounter": 0
+      },
+      {
+        "dbSummaryCounter": 0,
+        "retransmitCounter": 0,
+        "priority": 1,
+        "converged": "Full",
+        "address": "10.0.3.3",
+        "requestCounter": 0
+      }
+    ],
+    "4.4.4.4": [
+      {
+        "dbSummaryCounter": 0,
+        "retransmitCounter": 0,
+        "priority": 1,
+        "converged": "Full",
+        "address": "10.0.2.4",
+        "requestCounter": 0
+      }
+    ]
+  }
+}

--- a/tests/topotests/ldp_topo1/r3/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_topo1/r3/show_ip_ospf_neighbor.json
@@ -1,0 +1,32 @@
+{
+  "neighbors": {
+    "2.2.2.2": [
+      {
+        "dbSummaryCounter": 0,
+        "retransmitCounter": 0,
+        "priority": 1,
+        "converged": "Full",
+        "address": "10.0.2.2",
+        "requestCounter": 0
+      },
+      {
+        "dbSummaryCounter": 0,
+        "retransmitCounter": 0,
+        "priority": 1,
+        "converged": "Full",
+        "address": "10.0.3.2",
+        "requestCounter": 0
+      }
+    ],
+    "4.4.4.4": [
+      {
+        "dbSummaryCounter": 0,
+        "retransmitCounter": 0,
+        "priority": 1,
+        "converged": "Full",
+        "address": "10.0.2.4",
+        "requestCounter": 0
+      }
+    ]
+  }
+}

--- a/tests/topotests/ldp_topo1/r4/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_topo1/r4/show_ip_ospf_neighbor.json
@@ -1,0 +1,24 @@
+{
+  "neighbors": {
+    "2.2.2.2": [
+      {
+        "dbSummaryCounter": 0,
+        "retransmitCounter": 0,
+        "priority": 1,
+        "converged": "Full",
+        "address": "10.0.2.2",
+        "requestCounter": 0
+      }
+    ],
+    "3.3.3.3": [
+      {
+        "dbSummaryCounter": 0,
+        "retransmitCounter": 0,
+        "priority": 1,
+        "converged": "Full",
+        "address": "10.0.2.3",
+        "requestCounter": 0
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The sporadic failures were happening because, under heavy load,
the r4 router could form an OSPF adjacency with r3 a few seconds
before doing the same with r2. In that interim, LDP could establish
a neighborship with r2 going through r3 (instead of connecting
directly). That would cause all label mappings received from r3
to be ignored since they can't be mapped to the routes' nexthops
received from zebra, causing all sorts of test failures. None of
this is erroneous behavior as LDP simply follows the IGP.

The fix consists of updating the test to ensure all expected OSPF
adjacencies fully converged before proceeding to the LDP checks.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>