### PR TITLE
tests: Fix verify_rib such that it will look at the selected route

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -3384,6 +3384,9 @@ def verify_rib(
                                     next_hop = [next_hop]
 
                                 for mnh in range(0, len(rib_routes_json[st_rt])):
+                                    if not "selected" in rib_routes_json[st_rt][mnh]:
+                                        continue
+
                                     if (
                                         "fib"
                                         in rib_routes_json[st_rt][mnh]["nexthops"][0]


### PR DESCRIPTION
When you have a static route with multiple different admin
distances there exists a chance that route will have been
installed multiple times due to system load when inserted
at about the same time.  If this is the case then the
verify_rib function can and will select the wrong route
that happens to have a nexthop group that is still installed.

Modify verify_rib to ensure that the route that is going to
be looked at for nexthop correctness is the actual installed
route, not a previous version of it.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>