### PR TITLE
pimd: Fix the setting of oif_flags in channel oil

### DIFF
--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -429,6 +429,8 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 	/* Prevent single protocol from subscribing same interface to
 	   channel (S,G) multiple times */
 	if (channel_oil->oif_flags[pim_ifp->mroute_vif_index] & proto_mask) {
+		channel_oil->oif_flags[pim_ifp->mroute_vif_index] |= proto_mask;
+
 		if (PIM_DEBUG_MROUTE) {
 			zlog_debug(
 				"%s %s: existing protocol mask %u requested OIF %s (vif_index=%d, min_ttl=%d) for channel (S,G)=(%pPAs,%pPAs)",


### PR DESCRIPTION
When pim_upstream_inherited_olist_decide calls the api
pim_channel_add_oif, it can pass PIM_OIF_FLAG_PROTO_GM,
PIM_OIF_FLAG_PROTO_PIM and/or PIM_OIF_FLAG_PROTO_STAR.
Now a consider a case where PIM flag was already set
but STAR flag was not set and this api tries to set
both STAR + PIM and passes the same. The api pim_channel_add_oif
returns since it sees that PIM is already set without
setting the STAR flag.

So basically this will lead to issues in scenarios where for the
same OIF multiple flags(IGMP, PIM, STAR) needs to be set.

Fixing it for all combinations.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>