### PR TITLE
Interface duplication linux

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -2277,7 +2277,6 @@ DEFUN_NOSH (show_debugging_bgp,
 	if (BGP_DEBUG(bfd, BFD_LIB))
 		vty_out(vty, "  BGP BFD library debugging is on\n");
 
-	vty_out(vty, "\n");
 	return CMD_SUCCESS;
 }
 

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -1850,8 +1850,6 @@ static int show_debugging_ospf_common(struct vty *vty)
 	if (IS_DEBUG_OSPF(client_api, CLIENT_API) == OSPF_DEBUG_CLIENT_API)
 		vty_out(vty, "  OSPF client-api debugging is on\n");
 
-	vty_out(vty, "\n");
-
 	return CMD_SUCCESS;
 }
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1119,7 +1119,9 @@ void if_down(struct interface *ifp)
 
 void if_refresh(struct interface *ifp)
 {
+#ifndef GNU_LINUX
 	if_get_flags(ifp);
+#endif
 }
 
 void zebra_if_update_link(struct interface *ifp, ifindex_t link_ifindex,

--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -160,7 +160,8 @@ void if_get_mtu(struct interface *ifp)
 
 #if defined(SIOCGIFMTU)
 	if (vrf_if_ioctl(SIOCGIFMTU, (caddr_t)&ifreq, ifp->vrf->vrf_id) < 0) {
-		zlog_info("Can't lookup mtu by ioctl(SIOCGIFMTU)");
+		zlog_info("Can't lookup mtu by ioctl(SIOCGIFMTU) for %s(%u)",
+			  ifp->name, ifp->vrf->vrf_id);
 		ifp->mtu6 = ifp->mtu = -1;
 		return;
 	}
@@ -171,7 +172,8 @@ void if_get_mtu(struct interface *ifp)
 	zebra_interface_up_update(ifp);
 
 #else
-	zlog_info("Can't lookup mtu on this system");
+	zlog_info("Can't lookup mtu on this system for %s(%u)", ifp->name,
+		  ifp->vrf->vrf_id);
 	ifp->mtu6 = ifp->mtu = -1;
 #endif
 }
@@ -512,7 +514,8 @@ int if_set_flags(struct interface *ifp, uint64_t flags)
 	ret = vrf_if_ioctl(SIOCSIFFLAGS, (caddr_t)&ifreq, ifp->vrf->vrf_id);
 
 	if (ret < 0) {
-		zlog_info("can't set interface flags");
+		zlog_info("can't set interface %s(%u) flags %" PRIu64,
+			  ifp->name, ifp->vrf->vrf_id, flags);
 		return ret;
 	}
 	return 0;
@@ -533,7 +536,8 @@ int if_unset_flags(struct interface *ifp, uint64_t flags)
 	ret = vrf_if_ioctl(SIOCSIFFLAGS, (caddr_t)&ifreq, ifp->vrf->vrf_id);
 
 	if (ret < 0) {
-		zlog_info("can't unset interface flags");
+		zlog_warn("can't unset interface %s(%u) flags %" PRIu64,
+			  ifp->name, ifp->vrf->vrf_id, flags);
 		return ret;
 	}
 	return 0;


### PR DESCRIPTION
See individual commits:

a) bgpd/ospfd -> had extra whitespace when showing `show debugging`.  Just noticed this in passing and added a quick cleanup

b) Make ioctl.c's log messaging a bit better informed.

c) <this is the meat of the matter> On linux do not ask the ioctl for interface updates via if_refresh as that it all comes in through netlink messaging.  This removal reduces some of the duplication of effort being seen on shut/no shut events for interfaces