### PR TITLE
tests: fix ldp_vpls_topo1 to work as expected

### DIFF
--- a/doc/user/ldpd.rst
+++ b/doc/user/ldpd.rst
@@ -128,6 +128,21 @@ LDP Configuration
    the IPv4 or IPv6 transport-address used by the LDP protocol to talk on this
    interface.
 
+.. clicmd:: ttl-security disable
+
+   Located under the LDP address-family node, use this command to disable the
+   GTSM procedures described in RFC 6720 (for the IPv4 address-family) and
+   RFC 7552 (for the IPv6 address-family).
+
+   Since GTSM is mandatory for LDPv6, the only effect of disabling GTSM for the
+   IPv6 address-family is that *ldpd* will not discard packets with a hop limit
+   below 255. This may be necessary to interoperate with older implementations.
+   Outgoing packets will still be sent using a hop limit of 255 for maximum
+   compatibility.
+
+   If GTSM is enabled, multi-hop neighbors should have either GTSM disabled
+   individually or configured with an appropriate ttl-security hops distance.
+
 .. clicmd:: neighbor A.B.C.D password PASSWORD
 
    The following command located under MPLS router node configures the router
@@ -142,6 +157,19 @@ LDP Configuration
    mechanism. That value can be configured between 15 and 65535 seconds. After
    this time of non response, the LDP established session will be considered as
    set to down. By default, no holdtime is configured for the LDP devices.
+
+.. clicmd:: neighbor A.B.C.D ttl-security disable
+
+   Located under the MPLS LDP node, use this command to override the global
+   configuration and enable/disable GTSM for the specified neighbor.
+
+.. clicmd:: neighbor A.B.C.D ttl-security hops (1-254)
+
+   Located under the MPLS LDP node, use this command to set the maximum number
+   of hops the specified neighbor may be away. When GTSM is enabled for this
+   neighbor, incoming packets are required to have a TTL/hop limit of 256
+   minus this value, ensuring they have not passed through more than the
+   expected number of hops. The default value is 1.
 
 .. clicmd:: discovery hello holdtime HOLDTIME
 

--- a/tests/topotests/ldp_vpls_topo1/r1/ldpd.conf
+++ b/tests/topotests/ldp_vpls_topo1/r1/ldpd.conf
@@ -14,6 +14,7 @@ mpls ldp
  !
  address-family ipv4
   discovery transport-address 1.1.1.1
+  ttl-security disable
   label local allocate host-routes
   !
   interface r1-eth1

--- a/tests/topotests/ldp_vpls_topo1/r2/ldpd.conf
+++ b/tests/topotests/ldp_vpls_topo1/r2/ldpd.conf
@@ -14,6 +14,7 @@ mpls ldp
  !
  address-family ipv4
   discovery transport-address 2.2.2.2
+  ttl-security disable
   label local allocate host-routes
   !
   interface r2-eth1

--- a/tests/topotests/ldp_vpls_topo1/r3/ldpd.conf
+++ b/tests/topotests/ldp_vpls_topo1/r3/ldpd.conf
@@ -14,6 +14,7 @@ mpls ldp
  !
  address-family ipv4
   discovery transport-address 3.3.3.3
+  ttl-security disable
   label local allocate host-routes
   !
   interface r3-eth1


### PR DESCRIPTION
In the last step of this test, r1's link to r2 is shut down but
both routers stay connected through a multi-hop LDP session. That
happens because r1 and r2 have a targeted adjacency created by
the pseudowire.  The test then checks whether the pseudowire is
still up, using an alternate path for nexthop resolution.

Everything's fine except for the fact that LDP GTSM (aka
ttl-security) is enabled by default. This means that messages sent
over a multi-hop session are not delivered. In the case of this
test, it can prevent PW-Status notifications from being delivered,
which in turn can prevent the pseudowire from coming back up.

Fix the test by disabling GTSM so that LDP multi-hop sessions can
work normally. This is in accordance with RFC6720 which mentions
that GTSM should be disabled (statically or dynamically) for
multi-hop sessions.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>