### PR TITLE
lib: pim6d: Use IPv6 global unicast address to send PIMv6 register packet

### DIFF
--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -594,6 +594,15 @@ static inline int is_default_host_route(const struct prefix *p)
 	return 0;
 }
 
+static inline bool is_ipv6_global_unicast(const struct in6_addr *p)
+{
+	if (IN6_IS_ADDR_UNSPECIFIED(p) || IN6_IS_ADDR_LOOPBACK(p) ||
+	    IN6_IS_ADDR_LINKLOCAL(p) || IN6_IS_ADDR_MULTICAST(p))
+		return false;
+
+	return true;
+}
+
 /* IPv6 scope values, usable for IPv4 too (cf. below) */
 /* clang-format off */
 enum {

--- a/pimd/pim_register.h
+++ b/pimd/pim_register.h
@@ -34,7 +34,9 @@ int pim_register_stop_recv(struct interface *ifp, uint8_t *buf, int buf_size);
 
 int pim_register_recv(struct interface *ifp, pim_addr dest_addr,
 		      pim_addr src_addr, uint8_t *tlv_buf, int tlv_buf_size);
-
+#if PIM_IPV == 6
+struct in6_addr pim_register_get_unicast_v6_addr(struct pim_interface *p_ifp);
+#endif
 void pim_register_send(const uint8_t *buf, int buf_size, pim_addr src,
 		       struct pim_rpf *rpg, int null_register,
 		       struct pim_upstream *up);


### PR DESCRIPTION
Right now, PIMv6 uses link-local addresses for all the communications with the neighbors but
for register packet, it does not work.
So added an api to check if an address is global ipv6 address unicast address or not.
Added an api in pim6d to select a global address from the secondary address list and use
it to send the register msg.

Fixes: #11235
    
Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>