### PR TITLE
lib: cleanup red-herring memleaks in parent of daemonizing fork

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -963,6 +963,8 @@ static void frr_daemonize(void)
 	}
 
 	close(fds[1]);
+	nb_terminate();
+	yang_terminate();
 	frr_daemon_wait(fds[0]);
 }
 


### PR DESCRIPTION
- The parent of the daemonizing fork reports memleaks for the early
northbound allocations (libyang). If these were real memleaks these
would show up in the child as well; however, ignoring all memleaks in
the parent of the fork is too hard a sale. Instead, spend some CPU
cycles cleaning up the allocations in the parent after the fork and
immeidatley prior to exiting the parent after the daemonizing fork.