### PR TITLE
pimd,pim6d: Change the show running commands based on address family

### DIFF
--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -35,6 +35,7 @@ typedef struct in_addr pim_addr;
 #define ipaddr_pim	ipaddr_v4
 #define PIM_MAX_BITLEN	IPV4_MAX_BITLEN
 #define PIM_AF_NAME     "ip"
+#define PIM_AF_DBG	"pim"
 #define PIMREG          "pimreg"
 
 #define PIM_ADDR_FUNCNAME(name) ipv4_##name
@@ -59,6 +60,7 @@ typedef struct in6_addr pim_addr;
 #define ipaddr_pim	ipaddr_v6
 #define PIM_MAX_BITLEN	IPV6_MAX_BITLEN
 #define PIM_AF_NAME     "ipv6"
+#define PIM_AF_DBG	"pimv6"
 #define PIMREG          "pim6reg"
 
 #define PIM_ADDR_FUNCNAME(name) ipv6_##name

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -92,34 +92,34 @@ int pim_debug_config_write(struct vty *vty)
 	}
 
 	if (PIM_DEBUG_PIM_EVENTS) {
-		vty_out(vty, "debug pim events\n");
+		vty_out(vty, "debug " PIM_AF_DBG " events\n");
 		++writes;
 	}
 	if (PIM_DEBUG_PIM_PACKETS) {
-		vty_out(vty, "debug pim packets\n");
+		vty_out(vty, "debug " PIM_AF_DBG " packets\n");
 		++writes;
 	}
 	if (PIM_DEBUG_PIM_PACKETDUMP_SEND) {
-		vty_out(vty, "debug pim packet-dump send\n");
+		vty_out(vty, "debug " PIM_AF_DBG " packet-dump send\n");
 		++writes;
 	}
 	if (PIM_DEBUG_PIM_PACKETDUMP_RECV) {
-		vty_out(vty, "debug pim packet-dump receive\n");
+		vty_out(vty, "debug " PIM_AF_DBG " packet-dump receive\n");
 		++writes;
 	}
 
 	/* PIM_DEBUG_PIM_TRACE catches _DETAIL too */
 	if (router->debugs & PIM_MASK_PIM_TRACE) {
-		vty_out(vty, "debug pim trace\n");
+		vty_out(vty, "debug " PIM_AF_DBG " trace\n");
 		++writes;
 	}
 	if (PIM_DEBUG_PIM_TRACE_DETAIL) {
-		vty_out(vty, "debug pim trace detail\n");
+		vty_out(vty, "debug " PIM_AF_DBG " trace detail\n");
 		++writes;
 	}
 
 	if (PIM_DEBUG_ZEBRA) {
-		vty_out(vty, "debug pim zebra\n");
+		vty_out(vty, "debug " PIM_AF_DBG " zebra\n");
 		++writes;
 	}
 
@@ -144,17 +144,17 @@ int pim_debug_config_write(struct vty *vty)
 	}
 
 	if (PIM_DEBUG_PIM_HELLO) {
-		vty_out(vty, "debug pim packets hello\n");
+		vty_out(vty, "debug " PIM_AF_DBG " packets hello\n");
 		++writes;
 	}
 
 	if (PIM_DEBUG_PIM_J_P) {
-		vty_out(vty, "debug pim packets joins\n");
+		vty_out(vty, "debug " PIM_AF_DBG " packets joins\n");
 		++writes;
 	}
 
 	if (PIM_DEBUG_PIM_REG) {
-		vty_out(vty, "debug pim packets register\n");
+		vty_out(vty, "debug " PIM_AF_DBG " packets register\n");
 		++writes;
 	}
 
@@ -164,7 +164,7 @@ int pim_debug_config_write(struct vty *vty)
 	}
 
 	if (PIM_DEBUG_PIM_NHT) {
-		vty_out(vty, "debug pim nht\n");
+		vty_out(vty, "debug " PIM_AF_DBG " nht\n");
 		++writes;
 	}
 
@@ -174,7 +174,7 @@ int pim_debug_config_write(struct vty *vty)
 	}
 
 	if (PIM_DEBUG_PIM_NHT_DETAIL) {
-		vty_out(vty, "debug pim nht detail\n");
+		vty_out(vty, "debug " PIM_AF_DBG " nht detail\n");
 		++writes;
 	}
 


### PR DESCRIPTION
Change the show running commands for pimv4 and pimv6 debug commands
based on the address family.

Signed-off-by: Sai Gomathi N <nsaigomathi@vmware.com>