### PR TITLE
ospf6: permit route delete without nexthops

### DIFF
--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -432,9 +432,12 @@ static void ospf6_zebra_route_update(int type, struct ospf6_route *request,
 	}
 
 	/* If removing is the best path and if there's another path,
-	   treat this request as add the secondary path */
-	if (type == REM && ospf6_route_is_best(request) && request->next
-	    && ospf6_route_is_same(request, request->next)) {
+	 * treat this request as add the secondary path - if there are
+	 * nexthops.
+	 */
+	if (type == REM && ospf6_route_is_best(request) && request->next &&
+	    ospf6_route_is_same(request, request->next) &&
+	    ospf6_route_num_nexthops(request->next) > 0) {
 		if (IS_OSPF6_DEBUG_ZEBRA(SEND))
 			zlog_debug(
 				"  Best-path removal resulted Secondary addition");
@@ -452,9 +455,12 @@ static void ospf6_zebra_route_update(int type, struct ospf6_route *request,
 
 	nhcount = ospf6_route_num_nexthops(request);
 	if (nhcount == 0) {
-		if (IS_OSPF6_DEBUG_ZEBRA(SEND))
-			zlog_debug("  No nexthop, ignore");
-		return;
+		if (type == ADD) {
+			if (IS_OSPF6_DEBUG_ZEBRA(SEND))
+				zlog_debug("  No nexthop, ignore");
+			return;
+		} else if (IS_OSPF6_DEBUG_ZEBRA(SEND))
+			zlog_debug("  No nexthop, rem ok");
 	}
 
 	dest = &request->prefix;
@@ -464,17 +470,20 @@ static void ospf6_zebra_route_update(int type, struct ospf6_route *request,
 	api.type = ZEBRA_ROUTE_OSPF6;
 	api.safi = SAFI_UNICAST;
 	api.prefix = *dest;
-	SET_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP);
 
 	if (nhcount > ospf6->max_multipath) {
 		if (IS_OSPF6_DEBUG_ZEBRA(SEND))
 			zlog_debug(
 				"  Nexthop count is greater than configured maximum-path, hence ignore the extra nexthops");
 	}
-	api.nexthop_num = MIN(nhcount, ospf6->max_multipath);
 
-	ospf6_route_zebra_copy_nexthops(request, api.nexthops, api.nexthop_num,
-					api.vrf_id);
+	api.nexthop_num = MIN(nhcount, ospf6->max_multipath);
+	if (api.nexthop_num > 0) {
+		SET_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP);
+		ospf6_route_zebra_copy_nexthops(request, api.nexthops,
+						api.nexthop_num, api.vrf_id);
+	}
+
 	SET_FLAG(api.message, ZAPI_MESSAGE_METRIC);
 	api.metric = (request->path.metric_type == 2 ? request->path.u.cost_e2
 						     : request->path.cost);


### PR DESCRIPTION
It's possible for ospf6 to decide to delete a route after it's removed all of the route's nexthops. It's ok to delete a prefix alone - be a little more forgiving when preparing a route delete.
