### PR TITLE
Crash fix and test fix and some cleanup

### DIFF
--- a/isisd/fabricd.c
+++ b/isisd/fabricd.c
@@ -728,7 +728,7 @@ void fabricd_trigger_csnp(struct isis_area *area, bool circuit_scoped)
 
 struct list *fabricd_ip_addrs(struct isis_circuit *circuit)
 {
-	if (circuit->ip_addrs && listcount(circuit->ip_addrs))
+	if (listcount(circuit->ip_addrs))
 		return circuit->ip_addrs;
 
 	if (!fabricd || !circuit->area || !circuit->area->circuit_list)
@@ -741,7 +741,7 @@ struct list *fabricd_ip_addrs(struct isis_circuit *circuit)
 		if (c->circ_type != CIRCUIT_T_LOOPBACK)
 			continue;
 
-		if (!c->ip_addrs || !listcount(c->ip_addrs))
+		if (!listcount(c->ip_addrs))
 			return NULL;
 
 		return c->ip_addrs;

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -97,7 +97,7 @@ static void bfd_handle_adj_up(struct isis_adjacency *adj)
 		family = AF_INET6;
 		dst_ip.ipv6 = adj->ll_ipv6_addrs[0];
 		local_ips = circuit->ipv6_link;
-		if (!local_ips || list_isempty(local_ips)) {
+		if (list_isempty(local_ips)) {
 			if (IS_DEBUG_BFD)
 				zlog_debug(
 					"ISIS-BFD: skipping BFD initialization: IPv6 enabled and no local IPv6 addresses");

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1171,8 +1171,7 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 					  ? circuit->metric[level - 1]
 					  : circuit->te_metric[level - 1];
 
-		if (circuit->ip_router && circuit->ip_addrs
-		    && circuit->ip_addrs->count > 0) {
+		if (circuit->ip_router && circuit->ip_addrs->count > 0) {
 			lsp_debug(
 				"ISIS (%s): Circuit has IPv4 active, adding respective TLVs.",
 				area->area_tag);
@@ -1206,8 +1205,7 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 			}
 		}
 
-		if (circuit->ipv6_router && circuit->ipv6_non_link
-		    && circuit->ipv6_non_link->count > 0) {
+		if (circuit->ipv6_router && circuit->ipv6_non_link->count > 0) {
 			struct listnode *ipnode;
 			struct prefix_ipv6 *ipv6;
 

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -778,8 +778,8 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 	iih.v4_usable = (fabricd_ip_addrs(circuit)
 			 && iih.tlvs->ipv4_address.count);
 
-	iih.v6_usable = (circuit->ipv6_link && listcount(circuit->ipv6_link)
-			 && iih.tlvs->ipv6_address.count);
+	iih.v6_usable =
+		(listcount(circuit->ipv6_link) && iih.tlvs->ipv6_address.count);
 
 	if (!iih.v4_usable && !iih.v6_usable) {
 		if (IS_DEBUG_ADJ_PACKETS) {
@@ -1969,11 +1969,11 @@ int send_hello(struct isis_circuit *circuit, int level)
 			isis_tlvs_add_ipv4_addresses(tlvs, circuit_ip_addrs);
 	}
 
-	if (circuit->ipv6_router && circuit->ipv6_link)
+	if (circuit->ipv6_router)
 		isis_tlvs_add_ipv6_addresses(tlvs, circuit->ipv6_link);
 
 	/* RFC6119 section 4 define TLV 233 to provide Global IPv6 address */
-	if (circuit->ipv6_router && circuit->ipv6_non_link)
+	if (circuit->ipv6_router)
 		isis_tlvs_add_global_ipv6_addresses(tlvs,
 						    circuit->ipv6_non_link);
 

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -108,8 +108,7 @@ void isis_link_params_update(struct isis_circuit *circuit,
 			UNSET_SUBTLV(ext, EXT_ADM_GRP);
 
 		/* If known, register local IPv4 addr from ip_addr list */
-		if (circuit->ip_addrs != NULL
-		    && listcount(circuit->ip_addrs) != 0) {
+		if (listcount(circuit->ip_addrs) != 0) {
 			addr = (struct prefix_ipv4 *)listgetdata(
 				(struct listnode *)listhead(circuit->ip_addrs));
 			IPV4_ADDR_COPY(&ext->local_addr, &addr->prefix);
@@ -118,8 +117,7 @@ void isis_link_params_update(struct isis_circuit *circuit,
 			UNSET_SUBTLV(ext, EXT_LOCAL_ADDR);
 
 		/* If known, register local IPv6 addr from ip_addr list */
-		if (circuit->ipv6_non_link != NULL
-		    && listcount(circuit->ipv6_non_link) != 0) {
+		if (listcount(circuit->ipv6_non_link) != 0) {
 			addr6 = (struct prefix_ipv6 *)listgetdata(
 				(struct listnode *)listhead(
 					circuit->ipv6_non_link));

--- a/tests/topotests/bgp_multiview_topo1/test_bgp_multiview_topo1.py
+++ b/tests/topotests/bgp_multiview_topo1/test_bgp_multiview_topo1.py
@@ -169,7 +169,7 @@ def test_bgp_converge():
         for i in range(1, 2):
             for view in range(1, 4):
                 notConverged = tgen.net["r%s" % i].cmd(
-                    'vtysh -c "show ip bgp view %s summary" 2> /dev/null | grep ^[0-9] | grep -vP " 11\s+(\d+)"'
+                    r'vtysh -c "show ip bgp view %s summary" 2> /dev/null | grep ^[0-9] | grep -vP " 11\s+(\d+)"'
                     % view
                 )
                 if notConverged:

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/test_bgp_srv6l3vpn_to_bgp_vrf.py
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/test_bgp_srv6l3vpn_to_bgp_vrf.py
@@ -41,7 +41,7 @@ pytestmark = [pytest.mark.bgpd]
 
 
 def build_topo(tgen):
-    """
+    r"""
       CE1     CE3      CE5
     (eth0)  (eth0)   (eth0)
       :2      :2      :2

--- a/tests/topotests/ospf6_ecmp_inter_area/test_ospf6_ecmp_inter_area.py
+++ b/tests/topotests/ospf6_ecmp_inter_area/test_ospf6_ecmp_inter_area.py
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE.
 #
 
-"""
+r"""
 test_ospf6_ecmp_inter_area.py: Test OSPFv3 ECMP inter-area nexthop update
 
 Check proper removal of ECMP nexthops after a path used by one nexthop

--- a/tests/topotests/route_scale/scale_test_common.py
+++ b/tests/topotests/route_scale/scale_test_common.py
@@ -158,7 +158,7 @@ def route_install_helper(iter):
 
     # Avoid top ecmp case for runs with < 4G memory
     output = tgen.net.cmd_raises("free")
-    m = re.search("Mem:\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)", output)
+    m = re.search(r"Mem:\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)", output)
     total_mem = int(m.group(2))
     if total_mem < 4000000 and iter == 5:
         logger.info(

--- a/tests/topotests/zebra_seg6local_route/test_zebra_seg6local_route.py
+++ b/tests/topotests/zebra_seg6local_route/test_zebra_seg6local_route.py
@@ -104,7 +104,7 @@ def test_zebra_seg6local_routes():
             dest,
             manifest["out"],
         )
-        success, result = topotest.run_and_expect(test_func, None, count=5, wait=1)
+        success, result = topotest.run_and_expect(test_func, None, count=25, wait=1)
         assert result is None, "Failed"
 
 


### PR DESCRIPTION
See individual commits
a) Crash in isis because we were not allocating lists to save space and missed at least 1 code path where we didn't allocate first
b) Fix a test not running to completion because a route was still queued and we gave up too early
c) Fix some regex usage issues