### PR TITLE
ospfd: Fixing "show ip ospf neighbour <nbrid>" command

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -798,6 +798,8 @@ Showing Information
 
 .. clicmd:: show ip ospf neighbor detail [json]
 
+.. clicmd:: show ip ospf neighbor A.B.C.D [detail] [json]
+
 .. clicmd:: show ip ospf neighbor INTERFACE detail [json]
 
    Display lsa information of LSDB.


### PR DESCRIPTION
Description:
	"show ip ospf neighbour [nbrid] [json]" is expected to give brief output
	of the specific neighbour. But it gives the detailed output without
	the detail keyword.
	"show ip ospf neighbour [nbrid] [deatil] [json]" command is failed to
	fetch the expected o/p. Corrected it.

	Ex o/p:
	frr(config-if)# do show ip ospf  neighbor

	Neighbor ID     Pri State           Up Time         Dead Time Address         Interface                        RXmtL RqstL DBsmL
	8.8.8.8           1 Full/DR         17m03s            31.192s 20.1.1.194      ens192:20.1.1.220                    0     0     0
	30.1.1.100        1 Full/DR         56.229s           32.000s 30.1.1.100      ens224:30.1.1.220                    0     0     0

	frr(config-if)#
	frr(config-if)#
	frr(config-if)# do show ip ospf  neighbor 8.8.8.8
	Neighbor 8.8.8.8, interface address 20.1.1.194
	In the area 0.0.0.0 via interface ens192
	Neighbor priority is 1, State is Full/DR, 6 state changes
	Most recent state change statistics:
	  Progressive change 17m18s ago
	DR is 20.1.1.194, BDR is 20.1.1.220
	Options 2 *|-|-|-|-|-|E|-
	Dead timer due in 35.833s
	Database Summary List 0
	Link State Request List 0
	Link State Retransmission List 0
	Thread Inactivity Timer on
	Thread Database Description Retransmision off
	Thread Link State Request Retransmission on
	Thread Link State Update Retransmission on

	Graceful restart Helper info:
	  Graceful Restart HELPER Status : None

	frr(config-if)# do show ip ospf  neighbor 8.8.8.8 detail
	No such interface.
	frr(config-if)# do show ip ospf  neighbor 8.8.8.8 detail json
	{}
	frr(config-if)#

Signed-off-by: Rajesh Girada <rgirada@vmware.com>