### PR TITLE
bgpd: Drop bgpNoSuchNeighbor in JSON if neighbor does not exist

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -14211,9 +14211,7 @@ static int bgp_show_neighbor_graceful_restart(struct vty *vty, struct bgp *bgp,
 	}
 
 	if (type == show_peer && !find) {
-		if (use_json)
-			json_object_boolean_true_add(json, "bgpNoSuchNeighbor");
-		else
+		if (!use_json)
 			vty_out(vty, "%% No such neighbor\n");
 	}
 	if (use_json) {
@@ -14312,9 +14310,7 @@ static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp,
 
 	if ((type == show_peer || type == show_ipv4_peer ||
 	     type == show_ipv6_peer) && !find) {
-		if (use_json)
-			json_object_boolean_true_add(json, "bgpNoSuchNeighbor");
-		else
+		if (!use_json)
 			vty_out(vty, "%% No such neighbor in this view/vrf\n");
 	}
 


### PR DESCRIPTION
What is the point of this output?

```
donatas-pc# sh ip bgp neighbors 192.168.10.125 json
{
  "bgpNoSuchNeighbor":true
}
```

I think we should just return an empty json `{}`.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>