### PR TITLE
Realm fix nexthop groups

### DIFF
--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -231,7 +231,8 @@ options from the list below.
 
    Enable the support of Linux Realms. Convert tag values from 1-255 into a
    realm value when inserting into the Linux kernel. Then routing policy can be
-   assigned to the realm. See the tc man page.
+   assigned to the realm. See the tc man page.  This option is currently not
+   compatible with the usage of nexthop groups in the linux kernel itself.
 
 .. option:: --disable-irdp
 

--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -244,7 +244,9 @@ Route Map Set Command
    Set a tag on the matched route. This tag value can be from (1-4294967295).
    Additionally if you have compiled with the :option:`--enable-realms`
    configure option. Tag values from (1-255) are sent to the Linux kernel as a
-   realm value. Then route policy can be applied. See the tc man page.
+   realm value. Then route policy can be applied. See the tc man page.  As
+   a note realms cannot currently be used with the installation of nexthops
+   as nexthop groups in the linux kernel.
 
 .. clicmd:: set ip next-hop IPV4_ADDRESS
 


### PR DESCRIPTION
realms require that the RTA_FLOW attribute be passed down per nexthop when encoding routes.  Make the code work with this.