### PR TITLE
zebra: rtnetlink: flow attr per gateway attr in multipath updates

### DIFF
--- a/zebra/debug_nl.c
+++ b/zebra/debug_nl.c
@@ -1083,8 +1083,9 @@ next_rta:
 
 	plen = RTA_PAYLOAD(rta);
 	zlog_debug("    rta [len=%d (payload=%zu) type=(%d) %s]", rta->rta_len,
-		   plen, rta->rta_type, rtm_rta2str(rta->rta_type));
-	switch (rta->rta_type) {
+		   plen, rta->rta_type & NLA_TYPE_MASK,
+		   rtm_rta2str(rta->rta_type & NLA_TYPE_MASK));
+	switch (rta->rta_type & NLA_TYPE_MASK) {
 	case RTA_IIF:
 	case RTA_OIF:
 	case RTA_PRIORITY:


### PR DESCRIPTION
Idea for https://github.com/FRRouting/frr/issues/11451  
We think adding multipath route with a Linux realm (using rt tag mapping) needs a flow attribute per gateway attribute within a multipath rtnl attribute.  

rtnl msg multipath attr dump

```
3400 0900 len 52 RTA_MULTIPATH (9)
1800 0000 len 24
0a00 0000 10: if index
0800 0500 len 8 GATEWAY (5)
0a0a 0a0f 10.10.10.15
0800 0b00 len 8 FLOW (11)
1500 0000 realm 21
1800 0000 len 24
0a00 0000 10: if index
0800 0500 len 8 GATEWAY (5)
0a0a 0a10 10.10.10.16
0800 0b00 len 8 FLOW (11)
1500 0000 realm 21 
```  

Thanks for the help

Signed-off-by: Ricardo <rbarroetavena@anura.com.ar>