### PR TITLE
pim6d: Enable/disable pim6d daemons on different platforms based on flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -635,6 +635,8 @@ AC_ARG_ENABLE([isisd],
   AS_HELP_STRING([--disable-isisd], [do not build isisd]))
 AC_ARG_ENABLE([pimd],
   AS_HELP_STRING([--disable-pimd], [do not build pimd]))
+AC_ARG_ENABLE([pim6d],
+  AS_HELP_STRING([--enable-pim6d], [build pim6d]))
 AC_ARG_ENABLE([pbrd],
   AS_HELP_STRING([--disable-pbrd], [do not build pbrd]))
 AC_ARG_ENABLE([sharpd],
@@ -1751,6 +1753,10 @@ AS_IF([test "$enable_pimd" != "no"], [
   AC_DEFINE([HAVE_PIMD], [1], [pimd])
 ])
 
+AS_IF([test "$enable_pim6d" = "yes"], [
+  AC_DEFINE([HAVE_PIM6D], [1], [pim6d])
+])
+
 AS_IF([test "$enable_pbrd" != "no"], [
   AC_DEFINE([HAVE_PBRD], [1], [pbrd])
 ])
@@ -2711,6 +2717,7 @@ AM_CONDITIONAL([BABELD], [test "$enable_babeld" != "no"])
 AM_CONDITIONAL([OSPF6D], [test "$enable_ospf6d" != "no"])
 AM_CONDITIONAL([ISISD], [test "$enable_isisd" != "no"])
 AM_CONDITIONAL([PIMD], [test "$enable_pimd" != "no"])
+AM_CONDITIONAL([PIM6D], [test "$enable_pim6d" = "yes"])
 AM_CONDITIONAL([PBRD], [test "$enable_pbrd" != "no"])
 AM_CONDITIONAL([SHARPD], [test "$enable_sharpd" = "yes"])
 AM_CONDITIONAL([STATICD], [test "$enable_staticd" != "no"])

--- a/debian/rules
+++ b/debian/rules
@@ -27,6 +27,12 @@ else
   CONF_LUA=--enable-scripting
 endif
 
+ifeq ($(filter pkg.frr.pim6d,$(DEB_BUILD_PROFILES)),)
+  CONF_PIM6=--disable-pim6d
+else
+  CONF_PIM6=--enable-pim6d
+endif
+
 export PYTHON=python3
 
 %:
@@ -46,6 +52,7 @@ override_dh_auto_configure:
 		\
 		$(CONF_RPKI) \
 		$(CONF_LUA) \
+		$(CONF_PIM6) \
 		--with-libpam \
 		--enable-doc \
 		--enable-doc-html \

--- a/doc/developer/packaging-debian.rst
+++ b/doc/developer/packaging-debian.rst
@@ -64,6 +64,10 @@ buster.)
      +================+===================+=========================================+
      | pkg.frr.rtrlib | pkg.frr.nortrlib  | builds frr-rpki-rtrlib package (or not) |
      +----------------+-------------------+-----------------------------------------+
+     | pkg.frr.lua    | pkg.frr.nolua     | builds lua scripting extension          |
+     +----------------+-------------------+-----------------------------------------+
+     | pkg.frr.pim6d  | pkg.frr.nopim6d   | builds pim6d (work in progress)         |
+     +----------------+-------------------+-----------------------------------------+
 
    * the ``-uc -us`` options to disable signing the packages with your GPG key
 

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -171,16 +171,10 @@ clippy_scan += \
 pimd_pimd_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=4
 pimd_pimd_LDADD = lib/libfrr.la $(LIBCAP)
 
-if PIMD
-if DEV_BUILD
-#
-# pim6d is only enabled for --enable-dev-build, and NOT installed currently
-# (change noinst_ to sbin_ below to install it.)
-#
-noinst_PROGRAMS += pimd/pim6d
+if PIM6D
+sbin_PROGRAMS += pimd/pim6d
 pimd_pim6d_CFLAGS = $(AM_CFLAGS) -DPIM_IPV=6
 pimd_pim6d_LDADD = lib/libfrr.la $(LIBCAP)
-endif
 endif
 
 pimd_test_igmpv3_join_LDADD = lib/libfrr.la

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -24,6 +24,7 @@
 %{!?with_pam:           %global  with_pam           0 }
 %{!?with_pbrd:          %global  with_pbrd          1 }
 %{!?with_pimd:          %global  with_pimd          1 }
+%{!?with_pim6d:         %global  with_pim6d         0 }
 %{!?with_vrrpd:         %global  with_vrrpd         1 }
 %{!?with_rtadv:         %global  with_rtadv         1 }
 %{!?with_watchfrr:      %global  with_watchfrr      1 }
@@ -81,6 +82,7 @@
 # if CentOS / RedHat and version < 7, then disable PIMd (too old, won't work)
 %if 0%{?rhel} && 0%{?rhel} < 7
     %global  with_pimd  0
+    %global  with_pim6d 0
 %endif
 
 # misc internal defines
@@ -100,6 +102,12 @@
     %define daemon_pimd pimd
 %else
     %define daemon_pimd ""
+%endif
+
+%if %{with_pim6d}
+    %define daemon_pim6d pim6d
+%else
+    %define daemon_pim6d ""
 %endif
 
 %if %{with_pbrd}
@@ -150,7 +158,7 @@
     %define daemon_pathd ""
 %endif
 
-%define all_daemons %{daemon_list} %{daemon_ldpd} %{daemon_pimd} %{daemon_nhrpd} %{daemon_eigrpd} %{daemon_babeld} %{daemon_watchfrr} %{daemon_pbrd} %{daemon_bfdd} %{daemon_vrrpd} %{daemon_pathd}
+%define all_daemons %{daemon_list} %{daemon_ldpd} %{daemon_pimd} %{daemon_pim6d} %{daemon_nhrpd} %{daemon_eigrpd} %{daemon_babeld} %{daemon_watchfrr} %{daemon_pbrd} %{daemon_bfdd} %{daemon_vrrpd} %{daemon_pathd}
 
 #release sub-revision (the two digits after the CONFDATE)
 %{!?release_rev:        %global  release_rev        01 }
@@ -341,6 +349,11 @@ routing state through standard SNMP MIBs.
     --enable-pimd \
 %else
     --disable-pimd \
+%endif
+%if %{with_pim6d}
+    --enable-pim6d \
+%else
+    --disable-pim6d \
 %endif
 %if %{with_pbrd}
     --enable-pbrd \
@@ -665,6 +678,9 @@ fi
 %{_sbindir}/ospf6d
 %if %{with_pimd}
     %{_sbindir}/pimd
+%endif
+%if %{with_pim6d}
+    %{_sbindir}/pim6d
 %endif
 %if %{with_pbrd}
     %{_sbindir}/pbrd


### PR DESCRIPTION
By default pim6d will be disabled on all the systems.
Use --enable-pim6d flag in configure option for running pim6d daemon.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>