### PR TITLE
ospfd: fixing few coverity issue in 'show_ip_ospf_neighbour_brief'

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -4343,7 +4343,7 @@ static void show_ip_ospf_neighbour_brief(struct vty *vty,
 	char msgbuf[16];
 	char timebuf[OSPF_TIME_DUMP_SIZE];
 	json_object *json_neighbor = NULL, *json_neigh_array = NULL;
-	struct timeval res;
+	struct timeval res = {.tv_sec = 0, .tv_usec = 0};
 	long time_val = 0;
 	char uptime[OSPF_TIME_DUMP_SIZE];
 


### PR DESCRIPTION
Description:
	timerval data structure is being used without initialization.
	Using these uninitialized parameters can lead unexpected results
	so initializing before using it.

Signed-off-by: Rajesh Girada <rgirada@vmware.com>