### PR TITLE
Linkdown

### DIFF
--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -81,7 +81,7 @@ struct nexthop {
 
 	enum nexthop_types_t type;
 
-	uint8_t flags;
+	uint16_t flags;
 #define NEXTHOP_FLAG_ACTIVE     (1 << 0) /* This nexthop is alive. */
 #define NEXTHOP_FLAG_FIB        (1 << 1) /* FIB nexthop. */
 #define NEXTHOP_FLAG_RECURSIVE  (1 << 2) /* Recursive nexthop. */

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -95,6 +95,7 @@ struct nexthop {
 #define NEXTHOP_FLAG_HAS_BACKUP (1 << 6)    /* Backup nexthop index is set */
 #define NEXTHOP_FLAG_SRTE       (1 << 7) /* SR-TE color used for BGP traffic */
 #define NEXTHOP_FLAG_EVPN       (1 << 8) /* nexthop is EVPN */
+#define NEXTHOP_FLAG_LINKDOWN   (1 << 9) /* is not removed on link down */
 
 #define NEXTHOP_IS_ACTIVE(flags)                                               \
 	(CHECK_FLAG(flags, NEXTHOP_FLAG_ACTIVE)                                \

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -129,6 +129,9 @@ struct zebra_if {
 	/* MPLS status. */
 	bool mpls;
 
+	/* Linkdown status */
+	bool linkdown;
+
 	/* Router advertise configuration. */
 	uint8_t rtadv_enable;
 

--- a/zebra/netconf_netlink.c
+++ b/zebra/netconf_netlink.c
@@ -53,8 +53,8 @@ static int netlink_netconf_dplane_update(ns_id_t ns_id, ifindex_t ifindex,
 
 	ctx = dplane_ctx_alloc();
 	dplane_ctx_set_op(ctx, DPLANE_OP_INTF_NETCONFIG);
-	dplane_ctx_set_netconf_ns_id(ctx, ns_id);
-	dplane_ctx_set_netconf_ifindex(ctx, ifindex);
+	dplane_ctx_set_ns_id(ctx, ns_id);
+	dplane_ctx_set_ifindex(ctx, ifindex);
 
 	dplane_ctx_set_netconf_mpls(ctx, mpls_on);
 	dplane_ctx_set_netconf_mcast(ctx, mcast_on);

--- a/zebra/netconf_netlink.c
+++ b/zebra/netconf_netlink.c
@@ -45,9 +45,11 @@ static struct rtattr *netconf_rta(struct netconfmsg *ncm)
  * Handle netconf update about a single interface: create dplane
  * context, and enqueue for processing in the main zebra pthread.
  */
-static int netlink_netconf_dplane_update(ns_id_t ns_id, ifindex_t ifindex,
-					 enum dplane_netconf_status_e mpls_on,
-					 enum dplane_netconf_status_e mcast_on)
+static int
+netlink_netconf_dplane_update(ns_id_t ns_id, ifindex_t ifindex,
+			      enum dplane_netconf_status_e mpls_on,
+			      enum dplane_netconf_status_e mcast_on,
+			      enum dplane_netconf_status_e linkdown_on)
 {
 	struct zebra_dplane_ctx *ctx;
 
@@ -58,6 +60,7 @@ static int netlink_netconf_dplane_update(ns_id_t ns_id, ifindex_t ifindex,
 
 	dplane_ctx_set_netconf_mpls(ctx, mpls_on);
 	dplane_ctx_set_netconf_mcast(ctx, mcast_on);
+	dplane_ctx_set_netconf_linkdown(ctx, linkdown_on);
 
 	/* Enqueue ctx for main pthread to process */
 	dplane_provider_enqueue_to_zebra(ctx);
@@ -77,6 +80,8 @@ int netlink_netconf_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	uint32_t ival;
 	enum dplane_netconf_status_e mpls_on = DPLANE_NETCONF_STATUS_UNKNOWN;
 	enum dplane_netconf_status_e mcast_on = DPLANE_NETCONF_STATUS_UNKNOWN;
+	enum dplane_netconf_status_e linkdown_on =
+		DPLANE_NETCONF_STATUS_UNKNOWN;
 
 	if (h->nlmsg_type != RTM_NEWNETCONF && h->nlmsg_type != RTM_DELNETCONF)
 		return 0;
@@ -133,12 +138,23 @@ int netlink_netconf_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 			mcast_on = DPLANE_NETCONF_STATUS_DISABLED;
 	}
 
+	if (tb[NETCONFA_IGNORE_ROUTES_WITH_LINKDOWN]) {
+		ival = *(uint32_t *)RTA_DATA(
+			tb[NETCONFA_IGNORE_ROUTES_WITH_LINKDOWN]);
+		if (ival != 0)
+			linkdown_on = DPLANE_NETCONF_STATUS_ENABLED;
+		else
+			linkdown_on = DPLANE_NETCONF_STATUS_DISABLED;
+	}
+
 	if (IS_ZEBRA_DEBUG_KERNEL)
-		zlog_debug("%s: interface %u is mpls on: %d multicast on: %d",
-			   __func__, ifindex, mpls_on, mcast_on);
+		zlog_debug(
+			"%s: interface %u is mpls on: %d multicast on: %d linkdown: %d",
+			__func__, ifindex, mpls_on, mcast_on, linkdown_on);
 
 	/* Create a dplane context and pass it along for processing */
-	netlink_netconf_dplane_update(ns_id, ifindex, mpls_on, mcast_on);
+	netlink_netconf_dplane_update(ns_id, ifindex, mpls_on, mcast_on,
+				      linkdown_on);
 
 	return 0;
 }

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -535,6 +535,9 @@ parse_nexthop_unicast(ns_id_t ns_id, struct rtmsg *rtm, struct rtattr **tb,
 	if (rtm->rtm_flags & RTNH_F_ONLINK)
 		SET_FLAG(nh.flags, NEXTHOP_FLAG_ONLINK);
 
+	if (rtm->rtm_flags & RTNH_F_LINKDOWN)
+		SET_FLAG(nh.flags, NEXTHOP_FLAG_LINKDOWN);
+
 	if (num_labels)
 		nexthop_add_labels(&nh, ZEBRA_LSP_STATIC, num_labels, labels);
 

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -301,8 +301,6 @@ struct dplane_gre_ctx {
  * info. The flags values are public, in the dplane.h file...
  */
 struct dplane_netconf_info {
-	ns_id_t ns_id;
-	ifindex_t ifindex;
 	enum dplane_netconf_status_e mpls_val;
 	enum dplane_netconf_status_e mcast_val;
 };
@@ -2332,35 +2330,6 @@ dplane_ctx_neightable_get_mcast_probes(const struct zebra_dplane_ctx *ctx)
 	DPLANE_CTX_VALID(ctx);
 
 	return ctx->u.neightable.mcast_probes;
-}
-
-ifindex_t dplane_ctx_get_netconf_ifindex(const struct zebra_dplane_ctx *ctx)
-{
-	DPLANE_CTX_VALID(ctx);
-
-	return ctx->u.netconf.ifindex;
-}
-
-ns_id_t dplane_ctx_get_netconf_ns_id(const struct zebra_dplane_ctx *ctx)
-{
-	DPLANE_CTX_VALID(ctx);
-
-	return ctx->u.netconf.ns_id;
-}
-
-void dplane_ctx_set_netconf_ifindex(struct zebra_dplane_ctx *ctx,
-				    ifindex_t ifindex)
-{
-	DPLANE_CTX_VALID(ctx);
-
-	ctx->u.netconf.ifindex = ifindex;
-}
-
-void dplane_ctx_set_netconf_ns_id(struct zebra_dplane_ctx *ctx, ns_id_t ns_id)
-{
-	DPLANE_CTX_VALID(ctx);
-
-	ctx->u.netconf.ns_id = ns_id;
 }
 
 enum dplane_netconf_status_e
@@ -5439,7 +5408,7 @@ static void kernel_dplane_log_detail(struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_INTF_NETCONFIG:
 		zlog_debug("%s: ifindex %d, mpls %d, mcast %d",
 			   dplane_op2str(dplane_ctx_get_op(ctx)),
-			   dplane_ctx_get_netconf_ifindex(ctx),
+			   dplane_ctx_get_ifindex(ctx),
 			   dplane_ctx_get_netconf_mpls(ctx),
 			   dplane_ctx_get_netconf_mcast(ctx));
 		break;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -303,6 +303,7 @@ struct dplane_gre_ctx {
 struct dplane_netconf_info {
 	enum dplane_netconf_status_e mpls_val;
 	enum dplane_netconf_status_e mcast_val;
+	enum dplane_netconf_status_e linkdown_val;
 };
 
 /*
@@ -2348,6 +2349,14 @@ dplane_ctx_get_netconf_mcast(const struct zebra_dplane_ctx *ctx)
 	return ctx->u.netconf.mcast_val;
 }
 
+enum dplane_netconf_status_e
+dplane_ctx_get_netconf_linkdown(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.netconf.linkdown_val;
+}
+
 void dplane_ctx_set_netconf_mpls(struct zebra_dplane_ctx *ctx,
 				 enum dplane_netconf_status_e val)
 {
@@ -2363,6 +2372,15 @@ void dplane_ctx_set_netconf_mcast(struct zebra_dplane_ctx *ctx,
 
 	ctx->u.netconf.mcast_val = val;
 }
+
+void dplane_ctx_set_netconf_linkdown(struct zebra_dplane_ctx *ctx,
+				     enum dplane_netconf_status_e val)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	ctx->u.netconf.linkdown_val = val;
+}
+
 
 /*
  * Retrieve the limit on the number of pending, unprocessed updates.

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -592,11 +592,6 @@ const struct zebra_l2info_gre *
 dplane_ctx_gre_get_info(const struct zebra_dplane_ctx *ctx);
 
 /* Interface netconf info */
-ifindex_t dplane_ctx_get_netconf_ifindex(const struct zebra_dplane_ctx *ctx);
-ns_id_t dplane_ctx_get_netconf_ns_id(const struct zebra_dplane_ctx *ctx);
-void dplane_ctx_set_netconf_ifindex(struct zebra_dplane_ctx *ctx,
-				    ifindex_t ifindex);
-void dplane_ctx_set_netconf_ns_id(struct zebra_dplane_ctx *ctx, ns_id_t ns_id);
 enum dplane_netconf_status_e
 dplane_ctx_get_netconf_mpls(const struct zebra_dplane_ctx *ctx);
 enum dplane_netconf_status_e

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -596,10 +596,15 @@ enum dplane_netconf_status_e
 dplane_ctx_get_netconf_mpls(const struct zebra_dplane_ctx *ctx);
 enum dplane_netconf_status_e
 dplane_ctx_get_netconf_mcast(const struct zebra_dplane_ctx *ctx);
+enum dplane_netconf_status_e
+dplane_ctx_get_netconf_linkdown(const struct zebra_dplane_ctx *ctx);
+
 void dplane_ctx_set_netconf_mpls(struct zebra_dplane_ctx *ctx,
 				 enum dplane_netconf_status_e val);
 void dplane_ctx_set_netconf_mcast(struct zebra_dplane_ctx *ctx,
 				  enum dplane_netconf_status_e val);
+void dplane_ctx_set_netconf_linkdown(struct zebra_dplane_ctx *ctx,
+				     enum dplane_netconf_status_e val);
 
 /* Namespace fd info - esp. for netlink communication */
 const struct zebra_dplane_info *dplane_ctx_get_ns(

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -376,6 +376,9 @@ static void show_nexthop_detail_helper(struct vty *vty,
 	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK))
 		vty_out(vty, " onlink");
 
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_LINKDOWN))
+		vty_out(vty, " linkdown");
+
 	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
 		vty_out(vty, " (recursive)");
 
@@ -657,6 +660,9 @@ static void show_route_nexthop_helper(struct vty *vty,
 	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK))
 		vty_out(vty, " onlink");
 
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_LINKDOWN))
+		vty_out(vty, " linkdown");
+
 	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
 		vty_out(vty, " (recursive)");
 
@@ -836,6 +842,9 @@ static void show_nexthop_json_helper(json_object *json_nexthop,
 	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK))
 		json_object_boolean_true_add(json_nexthop,
 					     "onLink");
+
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_LINKDOWN))
+		json_object_boolean_true_add(json_nexthop, "linkDown");
 
 	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
 		json_object_boolean_true_add(json_nexthop,


### PR DESCRIPTION
See individual commits

a) dplane netconf handling was broken in that a change in the middle of zebra running would be dropped on the floor due to a misscommunication about the ns_id and the ifindex
b) The nexthop->flags size was 8 bits but there were 9 flags (ouch!)
c) Notice when a nexthop has the linkdown flag
d) Add the abilty to read the linkdown status on an interface

All of this is setup for the `better` handling of interface events and routes.  As that there exists possibilities that a interface can be in a carrier down state and the route will keep the nexthops.  Unfortunately FRR does not play this game very well at the moment.

I figured, I believe(ha!), out what is going on.  Interface down events trigger a rescan of all kernel/system routes to see if they are sane.  There exists state where a interface is not up enough to have a connected route in the zebra rib, but a kernel route can still be there that would be covered by that connected route.  On rescan the kernel routes are resolving to non-connected routes and being removed because there is nothing covering them.  Modify the code to just ensure that the interface the nexthop is on is in an operational enough state that the route should be kept.