### PR TITLE
vtysh: Account validity should be verified when authenticating users with PAM

### DIFF
--- a/vtysh/vtysh_user.c
+++ b/vtysh/vtysh_user.c
@@ -71,6 +71,10 @@ static int vtysh_pam(const char *user)
 		fprintf(stderr, "vtysh_pam: Failure to initialize pam: %s(%d)",
 			pam_strerror(pamh, ret), ret);
 
+	if (pam_acct_mgmt(pamh, 0) != PAM_SUCCESS)
+		fprintf(stderr, "%s: Failed in account validation: %s(%d)",
+			__func__, pam_strerror(pamh, ret), ret);
+
 	/* close Linux-PAM */
 	if (pam_end(pamh, ret) != PAM_SUCCESS) {
 		pamh = NULL;


### PR DESCRIPTION

Description:
	SonarQube detects the following behaviour as a vulanarability.
	When authenticating users using PAM, it is strongly recommended to
	check the validity of the account (not locked, not expired ...),
	otherwise it leads to unauthorized access to resources.

	pam_acct_mgmt() should be called for account validity after
	calling pam_authenticate().

Signed-off-by: Rajesh Girada <rgirada@vmware.com>