### PR TITLE
pimd: Avoid accessing freed memory

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1948,8 +1948,8 @@ void pim_upstream_terminate(struct pim_instance *pim)
 	struct pim_upstream *up;
 
 	while ((up = rb_pim_upstream_first(&pim->upstream_head))) {
-		pim_upstream_del(pim, up, __func__);
-		pim_upstream_timers_stop(up);
+		if (pim_upstream_del(pim, up, __func__))
+			pim_upstream_timers_stop(up);
 	}
 
 	rb_pim_upstream_fini(&pim->upstream_head);


### PR DESCRIPTION
If the upstream is freed in pim_upstream_del, then trying to
call pim_upstream_timers_stop will lead to accessing freed memory.

Fix:
Change the order of the function call.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>