### PR TITLE
 pimd: Fixing invalid memory access

### DIFF
--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -238,5 +238,20 @@ void pim_vrf_init(void)
 
 void pim_vrf_terminate(void)
 {
+	struct vrf *vrf;
+
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+		struct pim_instance *pim;
+
+		pim = vrf->info;
+		if (!pim)
+			continue;
+
+		pim_ssmpingd_destroy(pim);
+		pim_instance_terminate(pim);
+
+		vrf->info = NULL;
+	}
+
 	vrf_terminate();
 }


### PR DESCRIPTION
Fixing below valgrind issues.

==16837== Invalid read of size 8
==16837==    at 0x17971C: pim_neighbor_find (pim_neighbor.c:431)
==16837==    by 0x186439: join_timer_stop (pim_upstream.c:348)
==16837==    by 0x186794: pim_upstream_del (pim_upstream.c:231)
==16837==    by 0x189A66: pim_upstream_terminate (pim_upstream.c:1951)
==16837==    by 0x17111B: pim_instance_terminate (pim_instance.c:54)
==16837==    by 0x17111B: pim_vrf_delete (pim_instance.c:172)
==16837==    by 0x4F1D6C8: vrf_delete (vrf.c:264)
==16837==    by 0x19006F: pim_terminate (pimd.c:160)
==16837==    by 0x1B2E4D: pim_sigterm (pim_signals.c:51)
==16837==    by 0x4F08FA2: frr_sigevent_process (sigevent.c:130)
==16837==    by 0x4F1A2CC: thread_fetch (thread.c:1771)
==16837==    by 0x4ED4F92: frr_run (libfrr.c:1197)
==16837==    by 0x15D81A: main (pim_main.c:176)
==16837==  Address 0x83a8b48 is 200 bytes inside a block of size 272 free'd
==16837==    at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==16837==    by 0x4ECE1C2: if_delete (if.c:295)
==16837==    by 0x4ECE327: if_terminate (if.c:1033)
==16837==    by 0x4F1DA43: vrf_terminate_single (vrf.c:532)
==16837==    by 0x4F1DA43: vrf_terminate (vrf.c:561)
==16837==    by 0x19006F: pim_terminate (pimd.c:160)
==16837==    by 0x1B2E4D: pim_sigterm (pim_signals.c:51)
==16837==    by 0x4F08FA2: frr_sigevent_process (sigevent.c:130)
==16837==    by 0x4F1A2CC: thread_fetch (thread.c:1771)
==16837==    by 0x4ED4F92: frr_run (libfrr.c:1197)
==16837==    by 0x15D81A: main (pim_main.c:176)
==16837==  Block was alloc'd at
==16837==    at 0x4C31B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==16837==    by 0x4EE087F: qcalloc (memory.c:116)
==16837==    by 0x4ECCAE7: if_new (if.c:176)
==16837==    by 0x4ECCAE7: if_create_name (if.c:230)
==16837==    by 0x4ECCAE7: if_get_by_name (if.c:615)
==16837==    by 0x4F2BEB2: zclient_interface_add (zclient.c:2200)
==16837==    by 0x4F2C645: zclient_read (zclient.c:3987)
==16837==    by 0x4F1A71C: thread_call (thread.c:2002)
==16837==    by 0x4ED4F87: frr_run (libfrr.c:1198)
==16837==    by 0x15D81A: main (pim_main.c:176)
==16837==
==16837== Invalid read of size 8
==16837==    at 0x18638C: pim_upstream_timers_stop (pim_upstream.c:183)
==16837==    by 0x189A6E: pim_upstream_terminate (pim_upstream.c:1952)
==16837==    by 0x17111B: pim_instance_terminate (pim_instance.c:54)
==16837==    by 0x17111B: pim_vrf_delete (pim_instance.c:172)
==16837==    by 0x4F1D6C8: vrf_delete (vrf.c:264)
==16837==    by 0x19006F: pim_terminate (pimd.c:160)
==16837==    by 0x1B2E4D: pim_sigterm (pim_signals.c:51)
==16837==    by 0x4F08FA2: frr_sigevent_process (sigevent.c:130)
==16837==    by 0x4F1A2CC: thread_fetch (thread.c:1771)
==16837==    by 0x4ED4F92: frr_run (libfrr.c:1197)
==16837==    by 0x15D81A: main (pim_main.c:176)
==16837==  Address 0x8cce378 is 280 bytes inside a block of size 304 free'd
==16837==    at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==16837==    by 0x1869C5: pim_upstream_del (pim_upstream.c:278)
==16837==    by 0x189A66: pim_upstream_terminate (pim_upstream.c:1951)
==16837==    by 0x17111B: pim_instance_terminate (pim_instance.c:54)
==16837==    by 0x17111B: pim_vrf_delete (pim_instance.c:172)
==16837==    by 0x4F1D6C8: vrf_delete (vrf.c:264)
==16837==    by 0x19006F: pim_terminate (pimd.c:160)
==16837==    by 0x1B2E4D: pim_sigterm (pim_signals.c:51)
==16837==    by 0x4F08FA2: frr_sigevent_process (sigevent.c:130)
==16837==    by 0x4F1A2CC: thread_fetch (thread.c:1771)
==16837==    by 0x4ED4F92: frr_run (libfrr.c:1197)
==16837==    by 0x15D81A: main (pim_main.c:176)
==16837==  Block was alloc'd at
==16837==    at 0x4C31B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==16837==    by 0x4EE087F: qcalloc (memory.c:116)
==16837==    by 0x188C98: pim_upstream_new (pim_upstream.c:860)
==16837==    by 0x188C98: pim_upstream_add (pim_upstream.c:1068)
==16837==    by 0x18FD39: pim_register_recv (pim_register.c:623)
==16837==    by 0x17DAF5: pim_pim_packet (pim_pim.c:295)
==16837==    by 0x17DEEF: pim_sock_read (pim_pim.c:410)
==16837==    by 0x4F1A71C: thread_call (thread.c:2002)
==16837==    by 0x4ED4F87: frr_run (libfrr.c:1198)
==16837==    by 0x15D81A: main (pim_main.c:176)
