### PR TITLE
pimd: Clean up mroute_socket when pim terminates.

### DIFF
--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -70,6 +70,8 @@ static void pim_instance_terminate(struct pim_instance *pim)
 
 	pim_msdp_exit(pim);
 
+	pim_mroute_socket_disable(pim);
+
 	XFREE(MTYPE_PIM_PLIST_NAME, pim->spt.plist);
 	XFREE(MTYPE_PIM_PLIST_NAME, pim->register_plist);
 


### PR DESCRIPTION
pim_mroute_socket_disable api is present but nowhere called.
This should be called when pim instance is terminated.
Fixed it.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>