### PR TITLE
frr.postinst: egrep is deprecated

### DIFF
--- a/debian/frr.postinst
+++ b/debian/frr.postinst
@@ -40,7 +40,7 @@ find \
 	# don't chown anything that has ACLs (but don't fail if we don't
 	# have getfacl)
 	if { getfacl -c "$filename" 2>/dev/null || true; } \
-		| egrep -q -v '^((user|group|other)::|$)'; then
+		| grep -E -q -v '^((user|group|other)::|$)'; then
 		:
 	else
 		chown frr: "$filename"


### PR DESCRIPTION
egrep is deprecated, please see
https://git.savannah.gnu.org/cgit/grep.git/commit/?id=a9515624709865d480e3142fd959bccd1c9372d1