### PR TITLE
pimd: fix pim interface deletion flow

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -213,8 +213,8 @@ void pim_if_delete(struct interface *ifp)
 #if PIM_IPV == 4
 	igmp_sock_delete_all(ifp);
 #endif
-
-	pim_neighbor_delete_all(ifp, "Interface removed from configuration");
+	if (pim_ifp->pim_sock_fd >= 0)
+		pim_sock_delete(ifp, "Interface removed from configuration");
 
 	pim_if_del_vif(ifp);
 


### PR DESCRIPTION
Deletion of pim interface(pim_if_delete) should
do the below things before cleanup.
1. Send a hello message with zero hold time.
2. Delete all the neighbors.
3. Close the pim socket.

This is fixed now.

Signed-off-by: Sarita Patra <saritap@vmware.com>