### PR TITLE
tools: fix boot config load in watchfrr

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -73,7 +73,7 @@ chownfrr() {
 
 vtysh_b () {
 	[ "$1" = "watchfrr" ] && return 0
-	if [ -r "$C_PATH/frr.conf" ]; then
+	if [ ! -r "$C_PATH/frr.conf" ]; then
 		log_warning_msg "$C_PATH/frr.conf does not exist; skipping config apply"
 		return 0
 	fi


### PR DESCRIPTION
2469a37f reversed the logic of the existence check for
/etc/frr/frr.conf breaking boot config loading, fix it.

Signed-off-by: Christian Hopps <chopps@labn.net>