### PR TITLE
pim6d: Changing igmp_enable to gm_enable.

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -155,7 +155,7 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 	pim_ifp->pim_enable = pim;
 	pim_ifp->pim_passive_enable = false;
 #if PIM_IPV == 4
-	pim_ifp->igmp_enable = igmp;
+	pim_ifp->gm_enable = igmp;
 #endif
 
 	pim_ifp->gm_join_list = NULL;
@@ -542,7 +542,7 @@ void pim_if_addr_add(struct connected *ifc)
 #if PIM_IPV == 4
 	struct in_addr ifaddr = ifc->address->u.prefix4;
 
-	if (pim_ifp->igmp_enable) {
+	if (pim_ifp->gm_enable) {
 		struct gm_sock *igmp;
 
 		/* lookup IGMP socket */

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -75,7 +75,7 @@ struct pim_interface {
 	bool pim_can_disable_join_suppression : 1;
 	bool pim_passive_enable : 1;
 
-	bool igmp_enable : 1;
+	bool gm_enable : 1;
 
 	ifindex_t mroute_vif_index;
 	struct pim_instance *pim;

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -64,7 +64,7 @@ static void pim_if_membership_clear(struct interface *ifp)
 	pim_ifp = ifp->info;
 	assert(pim_ifp);
 
-	if (pim_ifp->pim_enable && pim_ifp->igmp_enable) {
+	if (pim_ifp->pim_enable && pim_ifp->gm_enable) {
 		return;
 	}
 
@@ -92,7 +92,7 @@ static void pim_if_membership_refresh(struct interface *ifp)
 
 	if (!pim_ifp->pim_enable)
 		return;
-	if (!pim_ifp->igmp_enable)
+	if (!pim_ifp->gm_enable)
 		return;
 
 	/*
@@ -169,7 +169,7 @@ static int pim_cmd_interface_delete(struct interface *ifp)
 	 */
 	pim_sock_delete(ifp, "pim unconfigured on interface");
 
-	if (!pim_ifp->igmp_enable) {
+	if (!pim_ifp->gm_enable) {
 		pim_if_addr_del_all(ifp);
 		pim_if_delete(ifp);
 	}
@@ -360,8 +360,8 @@ static int pim_cmd_igmp_start(struct interface *ifp)
 		pim_ifp = pim_if_new(ifp, true, false, false, false);
 		need_startup = 1;
 	} else {
-		if (!pim_ifp->igmp_enable) {
-			pim_ifp->igmp_enable = true;
+		if (!pim_ifp->gm_enable) {
+			pim_ifp->gm_enable = true;
 			need_startup = 1;
 		}
 	}
@@ -2565,7 +2565,7 @@ int lib_interface_gmp_address_family_destroy(struct nb_cb_destroy_args *args)
 		if (!pim_ifp)
 			return NB_OK;
 
-		pim_ifp->igmp_enable = false;
+		pim_ifp->gm_enable = false;
 
 		pim_if_membership_clear(ifp);
 
@@ -2586,7 +2586,7 @@ int lib_interface_gmp_address_family_enable_modify(
 {
 #if PIM_IPV == 4
 	struct interface *ifp;
-	bool igmp_enable;
+	bool gm_enable;
 	struct pim_interface *pim_ifp;
 	int mcast_if_count;
 	const char *ifp_name;
@@ -2611,9 +2611,9 @@ int lib_interface_gmp_address_family_enable_modify(
 		break;
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
-		igmp_enable = yang_dnode_get_bool(args->dnode, NULL);
+		gm_enable = yang_dnode_get_bool(args->dnode, NULL);
 
-		if (igmp_enable)
+		if (gm_enable)
 			return pim_cmd_igmp_start(ifp);
 
 		else {
@@ -2622,7 +2622,7 @@ int lib_interface_gmp_address_family_enable_modify(
 			if (!pim_ifp)
 				return NB_ERR_INCONSISTENCY;
 
-			pim_ifp->igmp_enable = false;
+			pim_ifp->gm_enable = false;
 
 			pim_if_membership_clear(ifp);
 

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -296,7 +296,7 @@ static int gm_config_write(struct vty *vty, int writes,
 			   struct pim_interface *pim_ifp)
 {
 	/* IF ip igmp */
-	if (pim_ifp->igmp_enable) {
+	if (pim_ifp->gm_enable) {
 		vty_out(vty, " ip igmp\n");
 		++writes;
 	}

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -1172,7 +1172,7 @@ void pim_vxlan_del_term_dev(struct pim_instance *pim)
 	pim_ifp = (struct pim_interface *)ifp->info;
 	if (pim_ifp) {
 		pim_ifp->pim_enable = false;
-		if (!pim_ifp->igmp_enable)
+		if (!pim_ifp->gm_enable)
 			pim_if_delete(ifp);
 	}
 }


### PR DESCRIPTION
Modified variable name so that it can be reused in mld.

Signed-off-by: Abhishek N R <abnr@vmware.com>