### PR TITLE
pimd: Querier to non-querier transition to be ignored (ANVL Conformance fix)

### DIFF
--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -585,10 +585,14 @@ static int igmp_recv_query(struct gm_sock *igmp, int query_version,
 		 * time; the same router keeps sending the Group-Specific
 		 * Queries.
 		 */
-		struct gm_group *group;
+		const struct gm_group *group;
+		const struct listnode *grpnode;
 
-		group = find_group_by_addr(igmp, group_addr);
-		if (group && group->t_group_query_retransmit_timer) {
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_group_list, grpnode,
+					  group)) {
+			if (!group->t_group_query_retransmit_timer)
+				continue;
+
 			if (PIM_DEBUG_IGMP_TRACE)
 				zlog_debug(
 					"%s: lower address query packet from %s is ignored when last member query interval timer is running",


### PR DESCRIPTION
Fixing IGMPv2 ANVL Conformance 3.10

As per RFC 2236 section 3, when the leave message is received at a querier,
it starts sending Query messages for "last Member Query Interval*query count"
During this time there should not be any querier to non-querier
transition and the same router needs to send the remaning queries.

Currently the code is handling this scenario only when leave is receive
for a group and the query is received for the same group.
But we need to handle it irrespective of group since the querier
election is based on interface and not group.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>