### PR TITLE
Netconf work

### DIFF
--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -132,6 +132,9 @@ struct zebra_if {
 	/* Linkdown status */
 	bool linkdown;
 
+	/* Is Multicast Forwarding on? */
+	bool v4mcast_on;
+
 	/* Router advertise configuration. */
 	uint8_t rtadv_enable;
 

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -130,10 +130,10 @@ struct zebra_if {
 	bool mpls;
 
 	/* Linkdown status */
-	bool linkdown;
+	bool linkdown, linkdownv6;
 
 	/* Is Multicast Forwarding on? */
-	bool v4mcast_on;
+	bool v4mcast_on, v6mcast_on;
 
 	/* Router advertise configuration. */
 	uint8_t rtadv_enable;

--- a/zebra/netconf_netlink.c
+++ b/zebra/netconf_netlink.c
@@ -119,23 +119,6 @@ int netlink_netconf_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 
 	ifindex = *(ifindex_t *)RTA_DATA(tb[NETCONFA_IFINDEX]);
 
-	switch (ifindex) {
-	case NETCONFA_IFINDEX_ALL:
-	case NETCONFA_IFINDEX_DEFAULT:
-		/*
-		 * We need the ability to handle netlink messages intended
-		 * for all and default interfaces.  I am not 100% sure
-		 * what that is yet, or where we would store it.
-		 */
-		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug("%s: Ignoring global ifindex %d",
-				   __func__, ifindex);
-
-		return 0;
-	default:
-		break;
-	}
-
 	if (tb[NETCONFA_INPUT]) {
 		ival = *(uint32_t *)RTA_DATA(tb[NETCONFA_INPUT]);
 		if (ival != 0)

--- a/zebra/netconf_netlink.c
+++ b/zebra/netconf_netlink.c
@@ -46,7 +46,7 @@ static struct rtattr *netconf_rta(struct netconfmsg *ncm)
  * context, and enqueue for processing in the main zebra pthread.
  */
 static int
-netlink_netconf_dplane_update(ns_id_t ns_id, ifindex_t ifindex,
+netlink_netconf_dplane_update(ns_id_t ns_id, afi_t afi, ifindex_t ifindex,
 			      enum dplane_netconf_status_e mpls_on,
 			      enum dplane_netconf_status_e mcast_on,
 			      enum dplane_netconf_status_e linkdown_on)
@@ -56,6 +56,7 @@ netlink_netconf_dplane_update(ns_id_t ns_id, ifindex_t ifindex,
 	ctx = dplane_ctx_alloc();
 	dplane_ctx_set_op(ctx, DPLANE_OP_INTF_NETCONFIG);
 	dplane_ctx_set_ns_id(ctx, ns_id);
+	dplane_ctx_set_afi(ctx, afi);
 	dplane_ctx_set_ifindex(ctx, ifindex);
 
 	dplane_ctx_set_netconf_mpls(ctx, mpls_on);
@@ -78,6 +79,7 @@ int netlink_netconf_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	int len;
 	ifindex_t ifindex;
 	uint32_t ival;
+	afi_t afi;
 	enum dplane_netconf_status_e mpls_on = DPLANE_NETCONF_STATUS_UNKNOWN;
 	enum dplane_netconf_status_e mcast_on = DPLANE_NETCONF_STATUS_UNKNOWN;
 	enum dplane_netconf_status_e linkdown_on =
@@ -95,6 +97,18 @@ int netlink_netconf_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	}
 
 	ncm = NLMSG_DATA(h);
+
+	/*
+	 * FRR does not have an internal representation of afi_t for
+	 * the MPLS Address Family that the kernel has.  So let's
+	 * just call it v4.  This is ok because the kernel appears
+	 * to do a good job of not sending data that is mixed/matched
+	 * across families
+	 */
+	if (ncm->ncm_family == AF_MPLS)
+		afi = AFI_IP;
+	else
+		afi = family2afi(ncm->ncm_family);
 
 	netlink_parse_rtattr(tb, NETCONFA_MAX, netconf_rta(ncm), len);
 
@@ -153,7 +167,7 @@ int netlink_netconf_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 			__func__, ifindex, mpls_on, mcast_on, linkdown_on);
 
 	/* Create a dplane context and pass it along for processing */
-	netlink_netconf_dplane_update(ns_id, ifindex, mpls_on, mcast_on,
+	netlink_netconf_dplane_update(ns_id, afi, ifindex, mpls_on, mcast_on,
 				      linkdown_on);
 
 	return 0;

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -220,6 +220,11 @@ struct zebra_router {
 
 	bool supports_nhgs;
 
+	bool all_mc_forwardingv4, default_mc_forwardingv4;
+	bool all_mc_forwardingv6, default_mc_forwardingv6;
+	bool all_linkdownv4, default_linkdownv4;
+	bool all_linkdownv6, default_linkdownv6;
+
 #define ZEBRA_DEFAULT_NHG_KEEP_TIMER 180
 	uint32_t nhg_keep;
 };

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3976,6 +3976,24 @@ DEFUN (show_zebra,
 	ttable_add_row(table, "Kernel NHG|%s",
 		       zrouter.supports_nhgs ? "Available" : "Unavailable");
 
+	ttable_add_row(table, "v4 All LinkDown Routes|%s",
+		       zrouter.all_linkdownv4 ? "On" : "Off");
+	ttable_add_row(table, "v4 Default LinkDown Routes|%s",
+		       zrouter.default_linkdownv4 ? "On" : "Off");
+	ttable_add_row(table, "v6 All LinkDown Routes|%s",
+		       zrouter.all_linkdownv6 ? "On" : "Off");
+	ttable_add_row(table, "v6 Default LinkDown Routes|%s",
+		       zrouter.default_linkdownv6 ? "On" : "Off");
+
+	ttable_add_row(table, "v4 All MC Forwarding|%s",
+		       zrouter.all_mc_forwardingv4 ? "On" : "Off");
+	ttable_add_row(table, "v4 Default MC Forwarding|%s",
+		       zrouter.default_mc_forwardingv4 ? "On" : "Off");
+	ttable_add_row(table, "v6 All MC Forwarding|%s",
+		       zrouter.all_mc_forwardingv6 ? "On" : "Off");
+	ttable_add_row(table, "v6 Default MC Forwarding|%s",
+		       zrouter.default_mc_forwardingv6 ? "On" : "Off");
+
 	out = ttable_dump(table, "\n");
 	vty_out(vty, "%s\n", out);
 	XFREE(MTYPE_TMP, out);


### PR DESCRIPTION
see individual commits:

a) mc_forwarding was being sent but not retrieved per interface, fix
b) Pass the afi received and handle v4 and v6 specific versions of the netconf data
c) Add the ability for the netconf dplane to handle the global ALL and DEFAULT values as passed.