### PR TITLE
bgpd: include 0 in configured hold/keepalive

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -12720,12 +12720,14 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 		/* Configured timer values. */
 		json_object_int_add(json_neigh,
 				    "bgpTimerConfiguredHoldTimeMsecs",
-				    p->holdtime ? p->holdtime * 1000
-						: bgp->default_holdtime * 1000);
-		json_object_int_add(
-			json_neigh, "bgpTimerConfiguredKeepAliveIntervalMsecs",
-			p->keepalive ? p->keepalive * 1000
-				     : bgp->default_keepalive * 1000);
+				    CHECK_FLAG(p->flags, PEER_FLAG_TIMER)
+					    ? p->holdtime * 1000
+					    : bgp->default_holdtime * 1000);
+		json_object_int_add(json_neigh,
+				    "bgpTimerConfiguredKeepAliveIntervalMsecs",
+				    CHECK_FLAG(p->flags, PEER_FLAG_TIMER)
+					    ? p->keepalive * 1000
+					    : bgp->default_keepalive * 1000);
 		json_object_int_add(json_neigh, "bgpTimerHoldTimeMsecs",
 				    p->v_holdtime * 1000);
 		json_object_int_add(json_neigh,
@@ -12812,12 +12814,16 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 
 		/* Configured timer values. */
 		vty_out(vty,
-			"  Hold time is %d, keepalive interval is %d seconds\n",
+			"  Hold time is %d seconds, keepalive interval is %d seconds\n",
 			p->v_holdtime, p->v_keepalive);
-		vty_out(vty, "  Configured hold time is %d",
-			p->holdtime ? p->holdtime : bgp->default_holdtime);
+		vty_out(vty, "  Configured hold time is %d seconds",
+			CHECK_FLAG(p->flags, PEER_FLAG_TIMER)
+				? p->holdtime
+				: bgp->default_holdtime);
 		vty_out(vty, ", keepalive interval is %d seconds\n",
-			p->keepalive ? p->keepalive : bgp->default_keepalive);
+			CHECK_FLAG(p->flags, PEER_FLAG_TIMER)
+				? p->keepalive
+				: bgp->default_keepalive);
 		if (CHECK_FLAG(p->flags, PEER_FLAG_TIMER_DELAYOPEN))
 			vty_out(vty,
 				"  Configured DelayOpenTime is %d seconds\n",


### PR DESCRIPTION
The default keepalive/hold timers are always exposed via this commit:
```
commit 9b1b96233d7204263d409ea6c504b316af9e533f (origin/bgp_timer_always_on)
Author: Trey Aspelund <taspelund@nvidia.com>
Date:   Mon Jun 27 23:20:33 2022 +0000

    bgpd: always display keepalive/hold intervals

    `show bgp neighbors <peer> [json]` was only displaying the configured
    keepalive and holdtime intervals when they differed from the default
    values.  Since default config is still config, let's make sure these
    values are always displayed.

    Signed-off-by: Trey Aspelund <taspelund@nvidia.com>
```

However it mistakenly changed the logic to only display the peer's
timers if the configured value was non-zero.  This updates the logic to
check PEER_FLAG_TIMER to determine if the values were configured,
given 0 is a valid value (to disable keepalives).

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>