### PR TITLE
pimd: Register stop message sent with mask 32

### DIFF
--- a/pimd/pim_tlv.c
+++ b/pimd/pim_tlv.c
@@ -218,7 +218,7 @@ int pim_encode_addr_group(uint8_t *buf, afi_t afi, int bidir, int scope,
 	*buf++ = PIM_MSG_ADDRESS_FAMILY;
 	*buf++ = 0;
 	*buf++ = flags;
-	*buf++ = sizeof(group) / 8;
+	*buf++ = sizeof(group) * 8;
 	memcpy(buf, &group, sizeof(group));
 	buf += sizeof(group);
 


### PR DESCRIPTION
As per RFC 4601 section 4.9.4, For Register-Stops,
the Mask Len field contains full address length * 8
(e.g. 32 for IPv4 native encoding) (e.g. 128 for IPv6),
if the message is sent for a single group

The issue is seen after #10356, so fixed now.

Signed-off-by: Sarita Patra <saritap@vmware.com>