### PR TITLE
ospfd: set/unset bfd profile

### DIFF
--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -266,8 +266,12 @@ DEFUN (ip_ospf_bfd_prof,
 	struct ospf_if_params *params;
 	int idx_prof = 4;
 
-	ospf_interface_enable_bfd(ifp);
 	params = IF_DEF_PARAMS(ifp);
+	if (!params->bfd_config) {
+		vty_out(vty, "ip ospf bfd has not been set\n");
+		return CMD_WARNING;
+	}
+
 	strlcpy(params->bfd_config->profile, argv[idx_prof]->arg,
 		sizeof(params->bfd_config->profile));
 	ospf_interface_bfd_apply(ifp);
@@ -288,8 +292,10 @@ DEFUN (no_ip_ospf_bfd_prof,
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct ospf_if_params *params;
 
-	ospf_interface_enable_bfd(ifp);
 	params = IF_DEF_PARAMS(ifp);
+	if (!params->bfd_config)
+		return CMD_SUCCESS;
+
 	params->bfd_config->profile[0] = 0;
 	ospf_interface_bfd_apply(ifp);
 

--- a/tests/topotests/bfd_profiles_topo1/r1/ospfd.conf
+++ b/tests/topotests/bfd_profiles_topo1/r1/ospfd.conf
@@ -2,6 +2,7 @@ interface r1-eth1
  ip ospf area 0
  ip ospf hello-interval 2
  ip ospf dead-interval 10
+ ip ospf bfd
  ip ospf bfd profile slowtx
 !
 router ospf


### PR DESCRIPTION
Before this patch we can enable 'ip ospf bfd' via '[no] ip ospf bfd profile ...' commads.
After patch '[no] ip ospf bfd profile ...' actual only if 'ip ospf bfd' is set.

Signed-off-by: Dmitrii Turlupov <dturlupov@factor-ts.ru>