### PR TITLE
pim6d: Fix the todo items in ipv6 watermark limit CLI

### DIFF
--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -686,9 +686,7 @@ DEFPY (ipv6_mld_group_watermark,
        "Group count to generate watermark warning\n")
 {
 	PIM_DECLVAR_CONTEXT_VRF(vrf, pim);
-
-       /* TBD Depends on MLD data structure changes */
-	(void)pim;
+	pim->gm_watermark_limit = limit;
 
 	return CMD_SUCCESS;
 }
@@ -703,9 +701,7 @@ DEFPY (no_ipv6_mld_group_watermark,
        IGNORED_IN_NO_STR)
 {
 	PIM_DECLVAR_CONTEXT_VRF(vrf, pim);
-
-	/* TBD Depends on MLD data structure changes */
-	(void)pim;
+	pim->gm_watermark_limit = 0;
 
 	return CMD_SUCCESS;
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -687,7 +687,7 @@ DEFPY (ipv6_mld_group_watermark,
 {
 	PIM_DECLVAR_CONTEXT_VRF(vrf, pim);
 
-	/* TBD Depends on MLD data structure changes */
+       /* TBD Depends on MLD data structure changes */
 	(void)pim;
 
 	return CMD_SUCCESS;

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1135,12 +1135,12 @@ static void igmp_show_groups(struct pim_instance *pim, struct vty *vty, bool uj)
 		json = json_object_new_object();
 		json_object_int_add(json, "totalGroups", pim->igmp_group_count);
 		json_object_int_add(json, "watermarkLimit",
-				    pim->igmp_watermark_limit);
+				    pim->gm_watermark_limit);
 	} else {
 		vty_out(vty, "Total IGMP groups: %u\n", pim->igmp_group_count);
 		vty_out(vty, "Watermark warn limit(%s): %u\n",
-			pim->igmp_watermark_limit ? "Set" : "Not Set",
-			pim->igmp_watermark_limit);
+			pim->gm_watermark_limit ? "Set" : "Not Set",
+			pim->gm_watermark_limit);
 		vty_out(vty,
 			"Interface        Group           Mode Timer    Srcs V Uptime  \n");
 	}
@@ -3334,7 +3334,7 @@ DEFPY (ip_igmp_group_watermark,
        "Group count to generate watermark warning\n")
 {
 	PIM_DECLVAR_CONTEXT_VRF(vrf, pim);
-	pim->igmp_watermark_limit = limit;
+	pim->gm_watermark_limit = limit;
 
 	return CMD_SUCCESS;
 }
@@ -3349,7 +3349,7 @@ DEFPY (no_ip_igmp_group_watermark,
        IGNORED_IN_NO_STR)
 {
 	PIM_DECLVAR_CONTEXT_VRF(vrf, pim);
-	pim->igmp_watermark_limit = 0;
+	pim->gm_watermark_limit = 0;
 
 	return CMD_SUCCESS;
 }

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -1009,8 +1009,8 @@ static void igmp_group_count_incr(struct pim_interface *pim_ifp)
 	uint32_t group_count = listcount(pim_ifp->gm_group_list);
 
 	++pim_ifp->pim->igmp_group_count;
-	if (pim_ifp->pim->igmp_group_count
-	    == pim_ifp->pim->igmp_watermark_limit) {
+	if (pim_ifp->pim->igmp_group_count ==
+	    pim_ifp->pim->gm_watermark_limit) {
 		zlog_warn(
 			"IGMP group count reached watermark limit: %u(vrf: %s)",
 			pim_ifp->pim->igmp_group_count,

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -173,7 +173,7 @@ struct pim_instance {
 	struct thread *t_gm_recv;
 
 	unsigned int igmp_group_count;
-	unsigned int igmp_watermark_limit;
+	unsigned int gm_watermark_limit;
 	unsigned int keep_alive_time;
 	unsigned int rp_keep_alive_time;
 

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -261,8 +261,13 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 	}
 
 	if (pim->gm_watermark_limit != 0) {
-		vty_out(vty, "%sip igmp watermark-warn %u\n", spaces,
-			pim->gm_watermark_limit);
+#if PIM_IPV == 4
+		vty_out(vty, "%s" PIM_AF_NAME " igmp watermark-warn %u\n",
+			spaces, pim->gm_watermark_limit);
+#else
+		vty_out(vty, "%s" PIM_AF_NAME " mld watermark-warn %u\n",
+			spaces, pim->gm_watermark_limit);
+#endif
 		++writes;
 	}
 

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -260,9 +260,9 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 		++writes;
 	}
 
-	if (pim->igmp_watermark_limit != 0) {
+	if (pim->gm_watermark_limit != 0) {
 		vty_out(vty, "%sip igmp watermark-warn %u\n", spaces,
-			pim->igmp_watermark_limit);
+			pim->gm_watermark_limit);
 		++writes;
 	}
 


### PR DESCRIPTION
Implementing the todo parts of watermark-warn CLI for IPv6 MLD
This command can be use to warn the user
when more than the desired limit of groups gets configured.

Signed-off-by: Sai Gomathi N <nsaigomathi@vmware.com>