### PR TITLE
pim6d: Fix [no] ipv6 pim drpriority command

### DIFF
--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -270,7 +270,7 @@ DEFPY (interface_ipv6_pim_drprio,
 
 DEFPY (interface_no_ipv6_pim_drprio,
        interface_no_ipv6_pim_drprio_cmd,
-       "no ip pim drpriority [(1-4294967295)]",
+       "no ipv6 pim drpriority [(1-4294967295)]",
        NO_STR
        IPV6_STR
        PIM_STR

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -334,10 +334,10 @@ static bool is_pim_interface(const struct lyd_node *dnode)
 	pim_enable_dnode =
 		yang_dnode_getf(dnode,
 				"%s/frr-pim:pim/address-family[address-family='%s']/pim-enable",
-				if_xpath, "frr-routing:ipv4");
+				if_xpath, FRR_PIM_AF_XPATH_VAL);
 	igmp_enable_dnode = yang_dnode_getf(dnode,
 			"%s/frr-gmp:gmp/address-family[address-family='%s']/enable",
-			if_xpath, "frr-routing:ipv4");
+			if_xpath, FRR_PIM_AF_XPATH_VAL);
 
 	if (((pim_enable_dnode) &&
 	     (yang_dnode_get_bool(pim_enable_dnode, "."))) ||


### PR DESCRIPTION
Fixing the ipv6 pim drpriority issues.

Issue 1 : 
Fixes: https://github.com/FRRouting/frr/issues/11503
R2(config)# interface ens192.4001
R2(config-if)# ipv6 pim drpriority 200
% Configuration failed.

Error type: validation
Error description: Pim not enabled on this interface

Issue 2:
no ipv6 pim drpriority command is not showing.