### PR TITLE
lib: fix SA warning in typesafe code

### DIFF
--- a/lib/typesafe.h
+++ b/lib/typesafe.h
@@ -309,7 +309,8 @@ static inline void typesafe_dlist_add(struct dlist_head *head,
 		struct dlist_item *prev, struct dlist_item *item)
 {
 	item->next = prev->next;
-	item->next->prev = item;
+	if (item->next)
+		item->next->prev = item;
 	item->prev = prev;
 	prev->next = item;
 	head->count++;


### PR DESCRIPTION
There's a nagging SA warning, at least with the scan-build version we use in the FRR CI.
