### PR TITLE
pimd: During prune pending, behave as NOINFO state (conformance issue)

### DIFF
--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -449,7 +449,7 @@ static int pim_update_upstream_nh_helper(struct hash_bucket *bucket, void *arg)
 	 * RPF nbr is now unreachable the MFC has already been updated
 	 * by pim_rpf_clear
 	 */
-	if (rpf_result != PIM_RPF_FAILURE)
+	if (rpf_result != PIM_RPF_CHANGED)
 		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
 
 	if (rpf_result == PIM_RPF_CHANGED ||

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -947,7 +947,16 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 					__func__, up->sg_str);
 		}
 
-		if (up->rpf.source_nexthop.interface) {
+		/* Consider a case where (S,G,rpt) prune is received and this
+		 * upstream is getting created due to that, then as per RFC
+		 * until prune pending time we need to behave same as NOINFO
+		 * state, therefore do not install if OIF is NULL until then
+		 * This is for PIM Conformance PIM-SM 16.3 fix
+		 * When the prune pending timer pop, this mroute will get
+		 * installed with none as OIF */
+		if (up->rpf.source_nexthop.interface &&
+		    !(pim_upstream_empty_inherited_olist(up) && (ch != NULL) &&
+		      PIM_IF_FLAG_TEST_S_G_RPT(ch->flags))) {
 			pim_upstream_mroute_iif_update(up->channel_oil,
 					__func__);
 		}


### PR DESCRIPTION
pimd: During prune pending, behave as NOINFO state

Fixed ANVL Conformance PIM-SM 16.3 test case.

When (S,G,rpt) prune is received, we were installing
the mroute immediately with none as OIF.
This leads to dropping the (S,G) traffic during prune
pending time as well.

Also we should not install the mroute if there is no
change in the rpf update.

These 2 things lead to the failure of the test case.

Fixed it by blocking the installation in this scenario.
When prune pending timer pops, it will take care of
installing the mroute with  none as OIF.

Fixes: https://github.com/FRRouting/frr/issues/11535

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>