### PR TITLE
pim6d: Don't enable mld on pimv6 interface by default

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -654,7 +654,8 @@ void pim_if_addr_add(struct connected *ifc)
 		vxlan_term = pim_vxlan_is_term_dev_cfg(pim_ifp->pim, ifp);
 		pim_if_add_vif(ifp, false, vxlan_term);
 	}
-	gm_ifp_update(ifp);
+	if (pim_ifp->gm_enable)
+		gm_ifp_update(ifp);
 	pim_ifchannel_scan_forward_start(ifp);
 }
 
@@ -767,8 +768,8 @@ void pim_if_addr_del(struct connected *ifc, int force_prim_as_any)
 				"%s: removed link-local %pI6, lowest now %pI6, highest %pI6",
 				ifc->ifp->name, &ifc->address->u.prefix6,
 				&pim_ifp->ll_lowest, &pim_ifp->ll_highest);
-
-		gm_ifp_update(ifp);
+		if (pim_ifp->gm_enable)
+			gm_ifp_update(ifp);
 	}
 #endif
 
@@ -828,7 +829,8 @@ void pim_if_addr_add_all(struct interface *ifp)
 		vxlan_term = pim_vxlan_is_term_dev_cfg(pim_ifp->pim, ifp);
 		pim_if_add_vif(ifp, false, vxlan_term);
 	}
-	gm_ifp_update(ifp);
+	if (pim_ifp->gm_enable)
+		gm_ifp_update(ifp);
 	pim_ifchannel_scan_forward_start(ifp);
 
 	pim_rp_setup(pim_ifp->pim);
@@ -1040,7 +1042,7 @@ int pim_if_add_vif(struct interface *ifp, bool ispimreg, bool is_vxlan_term)
 
 	pim_ifp->pim->iface_vif_index[pim_ifp->mroute_vif_index] = 1;
 
-	if (!ispimreg)
+	if (pim_ifp->gm_enable)
 		gm_ifp_update(ifp);
 
 	/* if the device qualifies as pim_vxlan iif/oif update vxlan entries */


### PR DESCRIPTION
In the current code, mld is getting enabled by default
when ipv6 pim is enabled on the interface.

I will open this PR for review after https://github.com/FRRouting/frr/pull/11485/ is merged

Signed-off-by: Sarita Patra <saritap@vmware.com>