### PR TITLE
zebra: fix various multicast routing netlink API bits

### DIFF
--- a/zebra/debug_nl.c
+++ b/zebra/debug_nl.c
@@ -543,6 +543,8 @@ const char *rtm_rta2str(int type)
 		return "MFC_STATS";
 	case RTA_NH_ID:
 		return "NH_ID";
+	case RTA_EXPIRES:
+		return "EXPIRES";
 	default:
 		return "UNKNOWN";
 	}
@@ -1070,9 +1072,11 @@ next_rta:
 
 static void nlroute_dump(struct rtmsg *rtm, size_t msglen)
 {
+	struct rta_mfc_stats *mfc_stats;
 	struct rtattr *rta;
 	size_t plen;
 	uint32_t u32v;
+	uint64_t u64v;
 
 	/* Get the first attribute and go from there. */
 	rta = RTM_RTA(rtm);
@@ -1095,6 +1099,11 @@ next_rta:
 		zlog_debug("      %u", u32v);
 		break;
 
+	case RTA_EXPIRES:
+		u64v = *(uint64_t *)RTA_DATA(rta);
+		zlog_debug("      %" PRIu64, u64v);
+		break;
+
 	case RTA_GATEWAY:
 	case RTA_DST:
 	case RTA_SRC:
@@ -1111,6 +1120,14 @@ next_rta:
 		default:
 			break;
 		}
+		break;
+
+	case RTA_MFC_STATS:
+		mfc_stats = (struct rta_mfc_stats *)RTA_DATA(rta);
+		zlog_debug("      pkts=%ju bytes=%ju wrong_if=%ju",
+			   (uintmax_t)mfc_stats->mfcs_packets,
+			   (uintmax_t)mfc_stats->mfcs_bytes,
+			   (uintmax_t)mfc_stats->mfcs_wrong_if);
 		break;
 
 	default:

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2333,7 +2333,7 @@ int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *in)
 	struct mcast_route_data *mr = (struct mcast_route_data *)in;
 	struct {
 		struct nlmsghdr n;
-		struct ndmsg ndm;
+		struct rtmsg rtm;
 		char buf[256];
 	} req;
 
@@ -2343,7 +2343,7 @@ int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *in)
 	zns = zvrf->zns;
 	memset(&req, 0, sizeof(req));
 
-	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg));
+	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg));
 	req.n.nlmsg_flags = NLM_F_REQUEST;
 	req.n.nlmsg_pid = zns->netlink_cmd.snl.nl_pid;
 
@@ -2353,7 +2353,7 @@ int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *in)
 	nl_attr_put32(&req.n, sizeof(req), RTA_OIF, mroute->ifindex);
 
 	if (mroute->family == AF_INET) {
-		req.ndm.ndm_family = RTNL_FAMILY_IPMR;
+		req.rtm.rtm_family = RTNL_FAMILY_IPMR;
 		nl_attr_put(&req.n, sizeof(req), RTA_SRC,
 			    &mroute->src.ipaddr_v4,
 			    sizeof(mroute->src.ipaddr_v4));
@@ -2361,7 +2361,7 @@ int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *in)
 			    &mroute->grp.ipaddr_v4,
 			    sizeof(mroute->grp.ipaddr_v4));
 	} else {
-		req.ndm.ndm_family = RTNL_FAMILY_IP6MR;
+		req.rtm.rtm_family = RTNL_FAMILY_IP6MR;
 		nl_attr_put(&req.n, sizeof(req), RTA_SRC,
 			    &mroute->src.ipaddr_v6,
 			    sizeof(mroute->src.ipaddr_v6));

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2349,9 +2349,6 @@ int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *in)
 
 	req.n.nlmsg_type = RTM_GETROUTE;
 
-	nl_attr_put32(&req.n, sizeof(req), RTA_IIF, mroute->ifindex);
-	nl_attr_put32(&req.n, sizeof(req), RTA_OIF, mroute->ifindex);
-
 	if (mroute->family == AF_INET) {
 		req.rtm.rtm_family = RTNL_FAMILY_IPMR;
 		nl_attr_put(&req.n, sizeof(req), RTA_SRC,


### PR DESCRIPTION
- fix #11533 by properly ignoring irrelevant notifications
- fix header type in RTM_GETROUTE
- drop unneeded IIF/OIF attributes
- set src/dst len correctly
- make table ID hack IPv4 specific
- add debug decodes for RTA_EXPIRES and RTA_MFC_STATS