### PR TITLE
bgpd: Free memory for BMP listeners when deleting BGP instance

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -136,6 +136,12 @@ static int bmp_listener_cmp(const struct bmp_listener *a,
 DECLARE_SORTLIST_UNIQ(bmp_listeners, struct bmp_listener, bli,
 		      bmp_listener_cmp);
 
+static void bmp_listener_put(struct bmp_listener *bl)
+{
+	bmp_listeners_del(&bl->targets->listeners, bl);
+	XFREE(MTYPE_BMP_LISTENER, bl);
+}
+
 static int bmp_targets_cmp(const struct bmp_targets *a,
 			   const struct bmp_targets *b)
 {
@@ -1541,11 +1547,16 @@ static struct bmp_bgp *bmp_bgp_get(struct bgp *bgp)
 static void bmp_bgp_put(struct bmp_bgp *bmpbgp)
 {
 	struct bmp_targets *bt;
+	struct bmp_listener *bl;
 
 	bmp_bgph_del(&bmp_bgph, bmpbgp);
 
-	frr_each_safe(bmp_targets, &bmpbgp->targets, bt)
+	frr_each_safe (bmp_targets, &bmpbgp->targets, bt) {
+		frr_each_safe (bmp_listeners, &bt->listeners, bl)
+			bmp_listener_put(bl);
+
 		bmp_targets_put(bt);
+	}
 
 	bmp_mirrorq_fini(&bmpbgp->mirrorq);
 	XFREE(MTYPE_BMP, bmpbgp);
@@ -1673,12 +1684,6 @@ static struct bmp_listener *bmp_listener_get(struct bmp_targets *bt,
 
 	bmp_listeners_add(&bt->listeners, bl);
 	return bl;
-}
-
-static void bmp_listener_put(struct bmp_listener *bl)
-{
-	bmp_listeners_del(&bl->targets->listeners, bl);
-	XFREE(MTYPE_BMP_LISTENER, bl);
 }
 
 static void bmp_listener_start(struct bmp_listener *bl)


### PR DESCRIPTION
When using `no router bgp` we MUST free the memory for the listeners too.

Replicate with:
```
router bgp 100
bmp targets server1
bmp listener 0.0.0.0 port 65535
no router bgp
router bgp 100
bmp targets server1
bmp listener 0.0.0.0 port 65535
no router bgp
router bgp 100
bmp targets server1
bmp listener 0.0.0.0 port 65535
no router bgp
```

Before:
```
Type                          : Current#   Size       Total     Max#  MaxBytes
BMP targets                   :        0    240           0        1       248
BMP targets name              :        0      8           0        1        24
BMP listener                  :       12    152        1824       12      1824
BMP instance state            :        0     88           0        1        88
```

After:
```
Type                          : Current#   Size       Total     Max#  MaxBytes
BMP targets                   :        0    240           0        1       248
BMP targets name              :        0      8           0        1        24
BMP listener                  :        0    152           0        1       152
BMP instance state            :        0     88           0        1        88
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>