### PR TITLE
lib: check hostname in resolver_resolve

### DIFF
--- a/lib/resolver.c
+++ b/lib/resolver.c
@@ -245,6 +245,9 @@ void resolver_resolve(struct resolver_query *query, int af, vrf_id_t vrf_id,
 {
 	int ret;
 
+	if (hostname == NULL)
+		return;
+
 	if (query->callback != NULL) {
 		flog_err(
 			EC_LIB_RESOLVER,


### PR DESCRIPTION
resolver_resolve should check hostname is null or not.

test result:
if ares_gethostbyname() get null hostname string, the hostname string will access a null pointer and crash.
![null](https://user-images.githubusercontent.com/57648884/177684755-978b6ded-706a-40b1-9e10-6a37c19593a6.png)

![log1](https://user-images.githubusercontent.com/57648884/177685295-d5b5c108-6140-4cf9-8d68-a38ff0249104.png)
![log1-1](https://user-images.githubusercontent.com/57648884/177685320-640ece4d-b921-4769-8729-ed9c32672abd.png)
![log2](https://user-images.githubusercontent.com/57648884/177685307-f75b2402-238e-4e80-ac48-56824d15f40c.png)

