### PR TITLE
lib: check hostname in resolver_resolve

### DIFF
--- a/lib/resolver.c
+++ b/lib/resolver.c
@@ -245,6 +245,9 @@ void resolver_resolve(struct resolver_query *query, int af, vrf_id_t vrf_id,
 {
 	int ret;
 
+	if (hostname == NULL)
+		return;
+
 	if (query->callback != NULL) {
 		flog_err(
 			EC_LIB_RESOLVER,


### PR DESCRIPTION
resolver_resolve should check hostname is null or not.

if ares_gethostbyname() get a null hostname string, it will access a null pointer and crash.

**test result:**
![null](https://user-images.githubusercontent.com/57648884/177688845-c56246b7-db83-41d3-82c9-cc86be5b3785.png)

**trace code**
![log1](https://user-images.githubusercontent.com/57648884/177688873-94c3daf4-d938-4186-bef3-74cd59bb5ae2.png)
![log1-1](https://user-images.githubusercontent.com/57648884/177688884-72572f2d-a673-4534-8541-069aebcaa88e.png)


