### PR TITLE
pimd, pim6d: Fix description for clear ip[v6] mroute command

### DIFF
--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1265,7 +1265,7 @@ DEFPY (clear_ipv6_mroute,
        "clear ipv6 mroute [vrf NAME]$name",
        CLEAR_STR
        IPV6_STR
-       "Reset multicast routes\n"
+       MROUTE_STR
        VRF_CMD_HELP_STR)
 {
 	struct vrf *v = pim_cmd_lookup(vty, name);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1662,7 +1662,7 @@ DEFPY (clear_ip_mroute,
        "clear ip mroute [vrf NAME]$name",
        CLEAR_STR
        IP_STR
-       "Reset multicast routes\n"
+       MROUTE_STR
        VRF_CMD_HELP_STR)
 {
 	struct vrf *v = pim_cmd_lookup(vty, name);


### PR DESCRIPTION
The code is mismatching with the display. So fixing this.

frr# clear ip 
  mroute       IP multicast routing table
