### PR TITLE
pim6d: Clear channel_oil on prune

### DIFF
--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -355,6 +355,7 @@ void igmp_source_delete(struct gm_source *source)
 
 	source_timer_off(group, source);
 	igmp_source_forward_stop(source);
+	source->source_channel_oil = NULL;
 
 	/* sanity check that forwarding has been disabled */
 	if (IGMP_SOURCE_TEST_FORWARDING(source->source_flags)) {
@@ -370,8 +371,6 @@ void igmp_source_delete(struct gm_source *source)
 			group->interface->name);
 		/* warning only */
 	}
-
-	source_channel_oil_detach(source);
 
 	/*
 	  notice that listnode_delete() can't be moved

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -319,14 +319,6 @@ void igmp_source_free(struct gm_source *source)
 	XFREE(MTYPE_PIM_IGMP_GROUP_SOURCE, source);
 }
 
-static void source_channel_oil_detach(struct gm_source *source)
-{
-	if (source->source_channel_oil) {
-		pim_channel_oil_del(source->source_channel_oil, __func__);
-		source->source_channel_oil = NULL;
-	}
-}
-
 /*
   igmp_source_delete:       stop forwarding, and delete the source
   igmp_source_forward_stop: stop forwarding, but keep the source

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -163,4 +163,6 @@ void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg,
 	  per-interface (S,G) state.
 	 */
 	pim_ifchannel_local_membership_del(oif, &sg);
+
+	pim_channel_oil_del(*oilp, __func__);
 }


### PR DESCRIPTION
Setup:
Receiver---LHR---RP

Problem:
In LHR, ipv6 pim state remains after MLD prune received.

Root Cause:
When LHR receives join, it creates (*,G) channel oil with oil_ref_count = 2. The channel_oil is used by gm_sg sg->oil and upstream->channel_oil.

When LHR receives prune, currently upstream->channel_oil is deleted and gm_sg sg->oil still present. Due to this channel_oil is still present with oil_ref_count = 1

Fix:
When LHR receives prune, upstream->channel_oil and pim_sg sg->oil needs to be deleted.

Issue: https://github.com/FRRouting/frr/issues/11249

Signed-off-by: Sarita Patra <saritap@vmware.com>