### PR TITLE
bgpd: work around GCC/plugin shortcomings

### DIFF
--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -421,10 +421,9 @@ static unsigned int updgrp_hash_key_make(const void *p)
 
 	if (bgp_debug_neighbor_events(peer)) {
 		zlog_debug(
-			"%pBP Update Group Hash: sort: %d UpdGrpFlags: %" PRIu64
-			" UpdGrpAFFlags: %u",
+			"%pBP Update Group Hash: sort: %d UpdGrpFlags: %ju UpdGrpAFFlags: %u",
 			peer, peer->sort,
-			(uint64_t)(peer->flags & PEER_UPDGRP_FLAGS),
+			(intmax_t)(peer->flags & PEER_UPDGRP_FLAGS),
 			flags & PEER_UPDGRP_AF_FLAGS);
 		zlog_debug(
 			"%pBP Update Group Hash: addpath: %u UpdGrpCapFlag: %u UpdGrpCapAFFlag: %u route_adv: %u change local as: %u",
@@ -464,10 +463,8 @@ static unsigned int updgrp_hash_key_make(const void *p)
 			peer->shared_network &&
 				peer_afi_active_nego(peer, AFI_IP6));
 		zlog_debug(
-			"%pBP Update Group Hash: Lonesoul: %" PRIu64
-			" ORF prefix: %u ORF old: %u max prefix out: %u",
-			peer,
-			(uint64_t)CHECK_FLAG(peer->flags, PEER_FLAG_LONESOUL),
+			"%pBP Update Group Hash: Lonesoul: %d ORF prefix: %u ORF old: %u max prefix out: %u",
+			peer, !!CHECK_FLAG(peer->flags, PEER_FLAG_LONESOUL),
 			CHECK_FLAG(peer->af_cap[afi][safi],
 				   PEER_CAP_ORF_PREFIX_SM_RCV),
 			CHECK_FLAG(peer->af_cap[afi][safi],


### PR DESCRIPTION
The GCC extended printf format checking plugin runs into some GCC shortcomings regarding casts on printf function parameters.  While this can be fixed with a small GCC patch, patching GCC is "nontrivial" to say the least.  Luckily, it happens that this is /almost/ not an issue for the FRR source base.

Since we fix SA "misunderstandings" too, let's just fix places where the format checking plugin runs into this limitation to keep things working extra smoothly.

(It's not a huge effort either, these two spots in bgpd are the only places that trigger the plugin limitation, and it's been "clean" before that for more than a year if my memory is right.)

---

To build with the plugin, run `make -C tools/gcc-plugins CXX=g++-$GCCVER` **before** `./configure` (it will autodetect the plugin). `$GCCVER` must be the version of GCC used for building later. You also need to have the GCC plugin support package installed, e.g. `apt-get install gcc-11-plugin-dev`. Refer to https://github.com/FRRouting/frr/tree/master/tools/gcc-plugins for docs.