### PR TITLE
pim6d: Implementing "show ipv6 mld groups" CLI

### DIFF
--- a/doc/user/pimv6.rst
+++ b/doc/user/pimv6.rst
@@ -325,6 +325,9 @@ MLD state
    a MLDv2 querier.  MLDv1 joins are recorded as "untracked" and shown in the
    ``NonTrkSeen`` output column.
 
+.. clicmd:: show ipv6 mld [vrf NAME] groups [json]
+
+   Display MLD group information.
 
 General multicast routing state
 -------------------------------

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1129,11 +1129,11 @@ static void igmp_show_groups(struct pim_instance *pim, struct vty *vty, bool uj)
 
 	if (uj) {
 		json = json_object_new_object();
-		json_object_int_add(json, "totalGroups", pim->igmp_group_count);
+		json_object_int_add(json, "totalGroups", pim->gm_group_count);
 		json_object_int_add(json, "watermarkLimit",
 				    pim->gm_watermark_limit);
 	} else {
-		vty_out(vty, "Total IGMP groups: %u\n", pim->igmp_group_count);
+		vty_out(vty, "Total IGMP groups: %u\n", pim->gm_group_count);
 		vty_out(vty, "Watermark warn limit(%s): %u\n",
 			pim->gm_watermark_limit ? "Set" : "Not Set",
 			pim->gm_watermark_limit);

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -1008,12 +1008,11 @@ static void igmp_group_count_incr(struct pim_interface *pim_ifp)
 {
 	uint32_t group_count = listcount(pim_ifp->gm_group_list);
 
-	++pim_ifp->pim->igmp_group_count;
-	if (pim_ifp->pim->igmp_group_count ==
-	    pim_ifp->pim->gm_watermark_limit) {
+	++pim_ifp->pim->gm_group_count;
+	if (pim_ifp->pim->gm_group_count == pim_ifp->pim->gm_watermark_limit) {
 		zlog_warn(
 			"IGMP group count reached watermark limit: %u(vrf: %s)",
-			pim_ifp->pim->igmp_group_count,
+			pim_ifp->pim->gm_group_count,
 			VRF_LOGNAME(pim_ifp->pim->vrf));
 	}
 
@@ -1023,13 +1022,13 @@ static void igmp_group_count_incr(struct pim_interface *pim_ifp)
 
 static void igmp_group_count_decr(struct pim_interface *pim_ifp)
 {
-	if (pim_ifp->pim->igmp_group_count == 0) {
+	if (pim_ifp->pim->gm_group_count == 0) {
 		zlog_warn("Cannot decrement igmp group count below 0(vrf: %s)",
 			  VRF_LOGNAME(pim_ifp->pim->vrf));
 		return;
 	}
 
-	--pim_ifp->pim->igmp_group_count;
+	--pim_ifp->pim->gm_group_count;
 }
 
 void igmp_group_delete(struct gm_group *group)

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -172,7 +172,7 @@ struct pim_instance {
 	int gm_socket;
 	struct thread *t_gm_recv;
 
-	unsigned int igmp_group_count;
+	unsigned int gm_group_count;
 	unsigned int gm_watermark_limit;
 	unsigned int keep_alive_time;
 	unsigned int rp_keep_alive_time;


### PR DESCRIPTION
This helps to display the MLD group information.
Modified the igmp_group_count of struct pim_instance to gm_group_count
to be used for both IGMP and MLD.