### PR TITLE
bgpd: Free ->raw_data from Hard Notification message after we use it

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -780,7 +780,7 @@ struct bgp_notify bgp_notify_decapsulate_hard_reset(struct bgp_notify *notify)
 	bn.subcode = notify->raw_data[1];
 	bn.length = notify->length - 2;
 
-	bn.raw_data = XCALLOC(MTYPE_BGP_NOTIFICATION, bn.length);
+	bn.raw_data = XMALLOC(MTYPE_BGP_NOTIFICATION, bn.length);
 	memcpy(bn.raw_data, notify->raw_data + 2, bn.length);
 
 	return bn;
@@ -2114,6 +2114,8 @@ static int bgp_notify_receive(struct peer *peer, bgp_size_t size)
 		}
 
 		bgp_notify_print(peer, &inner, "received", hard_reset);
+		XFREE(MTYPE_BGP_NOTIFICATION, inner.raw_data);
+
 		if (inner.length) {
 			XFREE(MTYPE_BGP_NOTIFICATION, inner.data);
 			inner.length = 0;


### PR DESCRIPTION
==175785== 0 bytes in 1 blocks are definitely lost in loss record 1 of 88
==175785==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==175785==    by 0x492EB8E: qcalloc (in /usr/local/lib/libfrr.so.0.0.0)
==175785==    by 0x269823: bgp_notify_decapsulate_hard_reset (in /usr/lib/frr/bgpd)
==175785==    by 0x26C85D: bgp_notify_receive (in /usr/lib/frr/bgpd)
==175785==    by 0x26E94E: bgp_process_packet (in /usr/lib/frr/bgpd)
==175785==    by 0x4985349: thread_call (in /usr/local/lib/libfrr.so.0.0.0)
==175785==    by 0x491D521: frr_run (in /usr/local/lib/libfrr.so.0.0.0)
==175785==    by 0x1EBEE8: main (in /usr/lib/frr/bgpd)
==175785==

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>