### PR TITLE
pimd: removal double inclusion of pim_addr.h

### DIFF
--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -27,8 +27,6 @@
 #include "prefix.h"
 #include "pim_addr.h"
 
-#include "pim_addr.h"
-
 /*
  * Longest possible length of a (S,G) string is 36 bytes
  * 123.123.123.123 = 16 * 2


### PR DESCRIPTION
Removing double inclusion of pim_addr.h from pim_str.h file.

Signed-off-by: Sarita Patra <saritap@vmware.com>