### PR TITLE
pim6d: Longest possible length of a (S,G) string is 96 bytes

### DIFF
--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -352,7 +352,7 @@ union prefixconstptr {
 #define PREFIX_STRLEN 80
 
 /*
- * Longest possible length of a (S,G) string is 36 bytes
+ * Longest possible length of a (S,G) string is 34 bytes
  * 123.123.123.123 = 15 * 2
  * (,) = 3
  * NULL Character at end = 1

--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -27,6 +27,7 @@
 #include "prefix.h"
 #include "pim_addr.h"
 
+#if PIM_IPV == 4
 /*
  * Longest possible length of a IPV4 (S,G) string is 34 bytes
  * 123.123.123.123 = 16 * 2
@@ -35,6 +36,15 @@
  * (123.123.123.123,123.123.123.123)
  */
 #define PIM_SG_LEN PREFIX_SG_STR_LEN
+#else
+/*
+ * Longest possible length of a IPV6 (S,G) string is 94 bytes
+ * INET6_ADDRSTRLEN * 2 = 46 * 2
+ * (,) = 3
+ * NULL Character at end = 1
+ */
+#define PIM_SG_LEN 96
+#endif
 
 #define pim_inet4_dump prefix_mcast_inet4_dump
 

--- a/pimd/pim_str.h
+++ b/pimd/pim_str.h
@@ -28,13 +28,14 @@
 #include "pim_addr.h"
 
 /*
- * Longest possible length of a (S,G) string is 36 bytes
+ * Longest possible length of a IPV4 (S,G) string is 34 bytes
  * 123.123.123.123 = 16 * 2
  * (,) = 3
  * NULL Character at end = 1
- * (123.123.123.123,123,123,123,123)
+ * (123.123.123.123,123.123.123.123)
  */
 #define PIM_SG_LEN PREFIX_SG_STR_LEN
+
 #define pim_inet4_dump prefix_mcast_inet4_dump
 
 void pim_addr_dump(const char *onfail, struct prefix *p, char *buf,


### PR DESCRIPTION
Longest possible length of a IPV6 (S,G) string is 94 bytes
INET6_ADDRSTRLEN * 2 = 46 * 2
(,) = 1
NULL Character at end = 1

Signed-off-by: Sarita Patra <saritap@vmware.com>