### PR TITLE
babeld: Install route to RIB if parse_update_subtlv() is false

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -636,7 +636,7 @@ parse_packet(const unsigned char *from, struct interface *ifp,
 						    len - parsed_len, channels);
 	    }
 
-	    if (ignore_update)
+	    if (!ignore_update)
 		    update_route(router_id, prefix, plen, seqno, metric,
 				 interval, neigh, nh, channels,
 				 channels_len(channels));


### PR DESCRIPTION
We installed the route only if the type was SUBTLV_MANDATORY.

Fixes https://github.com/FRRouting/frr/issues/11555

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>