### PR TITLE
pimd,pim6d: Set RP to true if the address matches, ignore prefix-length

### DIFF
--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -339,9 +339,7 @@ static int pim_rp_check_interface_addrs(struct rp_info *rp_info,
 {
 	struct listnode *node;
 	struct pim_secondary_addr *sec_addr;
-	struct prefix rpf_addr;
-
-	pim_addr_to_prefix(&rpf_addr, rp_info->rp.rpf_addr);
+	pim_addr sec_paddr;
 
 	if (!pim_addr_cmp(pim_ifp->primary_address, rp_info->rp.rpf_addr))
 		return 1;
@@ -351,9 +349,11 @@ static int pim_rp_check_interface_addrs(struct rp_info *rp_info,
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(pim_ifp->sec_addr_list, node, sec_addr)) {
-		if (prefix_same(&sec_addr->addr, &rpf_addr)) {
+		sec_paddr = pim_addr_from_prefix(&sec_addr->addr);
+		/* If an RP-address is self, It should be enough to say
+		 * I am RP the prefix-length should not matter here */
+		if (!pim_addr_cmp(sec_paddr, rp_info->rp.rpf_addr))
 			return 1;
-		}
 	}
 
 	return 0;


### PR DESCRIPTION
~~I would like to discuss on this before moving further. Have raised it temporarily to ease the discussion.~~

~~Either~~
1. We can fix both PIMv4 and PIMv6 by only matching the configured RP address with the interface address and not the prefix-length since it does not matter
**OR**
~~2. Make this fix only specific to PIMv6 as done in this PR.~~

The API pim_rp_check_interface_addrs checks if the RP address matches
with the primary address then it returns true.
In case of PIMv4 this condition is true, therefore the router becomes RP.
But in case of PIMv6, this condition does not pass because primary address
for PIMv6 is link-local address.

Also PIMv4 allows secondary addresses to be used as RP
if it is a host route in case primary does not match.
This behaviour is same for PIMv6.

Fixing it by only checking the configured RP address with the interface
address and ignoring the prefix length since it does not matter.

Fixes: #11335

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>