### PR TITLE
topotests: Remove typo (extra dot on the IP)

### DIFF
--- a/tests/topotests/bgp_default_route_route_map_match_set/r1/zebra.conf
+++ b/tests/topotests/bgp_default_route_route_map_match_set/r1/zebra.conf
@@ -5,7 +5,5 @@ interface lo
 interface r1-eth0
  ip address 192.168.255.1/24
 !
-ip route 192.168.13.0./24 Null0
-!
 ip forwarding
 !


### PR DESCRIPTION
Remove an extra dot on an IP in r1 zebra config for topotest bgp_default_route_route_map_match_set