### PR TITLE
bgpd: Fix memory leak for community alias

### DIFF
--- a/bgpd/bgp_community_alias.c
+++ b/bgpd/bgp_community_alias.c
@@ -81,9 +81,16 @@ void bgp_community_alias_init(void)
 			    "BGP community alias (alias)");
 }
 
+static void bgp_ca_free(void *ca)
+{
+	XFREE(MTYPE_COMMUNITY_ALIAS, ca);
+}
+
 void bgp_community_alias_finish(void)
 {
+	hash_clean(bgp_ca_community_hash, bgp_ca_free);
 	hash_free(bgp_ca_community_hash);
+	hash_clean(bgp_ca_alias_hash, bgp_ca_free);
 	hash_free(bgp_ca_alias_hash);
 }
 


### PR DESCRIPTION
==361630== 24,780 (96 direct, 24,684 indirect) bytes in 3 blocks are definitely lost in loss record 94 of 97
==361630==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==361630==    by 0x492EB8E: qcalloc (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x490BB12: hash_get (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x1FD3CC: bgp_ca_alias_insert (in /usr/lib/frr/bgpd)
==361630==    by 0x2CF8E5: bgp_community_alias_magic (in /usr/lib/frr/bgpd)
==361630==    by 0x2C980B: bgp_community_alias (in /usr/lib/frr/bgpd)
==361630==    by 0x48E3556: cmd_execute_command_real (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x48E384B: cmd_execute_command_strict (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x48E3D41: command_config_read_one_line (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x48E3EBA: config_from_file (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x499065C: vty_read_file (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x4990FF4: vty_read_config (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x491CB95: frr_config_read_in (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x4985380: thread_call (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x491D521: frr_run (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x1EBEE8: main (in /usr/lib/frr/bgpd)
==361630==
==361630== 24,780 (96 direct, 24,684 indirect) bytes in 3 blocks are definitely lost in loss record 95 of 97
==361630==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==361630==    by 0x492EB8E: qcalloc (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x490BB12: hash_get (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x1FD39C: bgp_ca_community_insert (in /usr/lib/frr/bgpd)
==361630==    by 0x2CF8F4: bgp_community_alias_magic (in /usr/lib/frr/bgpd)
==361630==    by 0x2C980B: bgp_community_alias (in /usr/lib/frr/bgpd)
==361630==    by 0x48E3556: cmd_execute_command_real (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x48E384B: cmd_execute_command_strict (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x48E3D41: command_config_read_one_line (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x48E3EBA: config_from_file (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x499065C: vty_read_file (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x4990FF4: vty_read_config (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x491CB95: frr_config_read_in (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x4985380: thread_call (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x491D521: frr_run (in /usr/local/lib/libfrr.so.0.0.0)
==361630==    by 0x1EBEE8: main (in /usr/lib/frr/bgpd)

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>