### PR TITLE
bgpd: Fix memory leak for community stuff

### DIFF
--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -914,8 +914,16 @@ void community_init(void)
 			    "BGP Community Hash");
 }
 
+static void community_hash_free(void *data)
+{
+	struct community *com = data;
+
+	community_free(&com);
+}
+
 void community_finish(void)
 {
+	hash_clean(comhash, community_hash_free);
 	hash_free(comhash);
 	comhash = NULL;
 }


### PR DESCRIPTION
Do not forget to cleanup after we are done:

==395247== 8,268 (32 direct, 8,236 indirect) bytes in 1 blocks are definitely lost in loss record 199 of 205
==395247==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==395247==    by 0x492EB8E: qcalloc (in /usr/local/lib/libfrr.so.0.0.0)
==395247==    by 0x490BB12: hash_get (in /usr/local/lib/libfrr.so.0.0.0)
==395247==    by 0x1FBF63: community_intern (in /usr/lib/frr/bgpd)
==395247==    by 0x1FC0C5: community_parse (in /usr/lib/frr/bgpd)
==395247==    by 0x1F0B66: bgp_attr_community (in /usr/lib/frr/bgpd)
==395247==    by 0x1F4185: bgp_attr_parse (in /usr/lib/frr/bgpd)
==395247==    by 0x26BC29: bgp_update_receive (in /usr/lib/frr/bgpd)
==395247==    by 0x26E887: bgp_process_packet (in /usr/lib/frr/bgpd)
==395247==    by 0x4985380: thread_call (in /usr/local/lib/libfrr.so.0.0.0)
==395247==    by 0x491D521: frr_run (in /usr/local/lib/libfrr.so.0.0.0)
==395247==    by 0x1EBEE8: main (in /usr/lib/frr/bgpd)

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>