### PR TITLE
Update Alpine packaging foo + change docker images back over to Alpine-provided libyang

### DIFF
--- a/alpine/APKBUILD.in
+++ b/alpine/APKBUILD.in
@@ -18,7 +18,7 @@ makedepends="ncurses-dev net-snmp-dev gawk texinfo perl
     ncurses-libs ncurses-terminfo ncurses-terminfo-base patch pax-utils pcre
     perl pkgconf python3 python3-dev readline readline-dev sqlite-libs
     squashfs-tools sudo tar texinfo xorriso xz-libs py-pip rtrlib rtrlib-dev
-    py3-sphinx elfutils elfutils-dev"
+    py3-sphinx elfutils elfutils-dev libyang-dev"
 checkdepends="pytest py-setuptools"
 install="$pkgname.pre-install $pkgname.pre-deinstall $pkgname.post-deinstall"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-dbg"

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -15,11 +15,12 @@ RUN adduser -D -G abuild builder && su builder -c 'abuild-keygen -a -n'
 # This stage builds a libyang APK from source
 FROM alpine-builder as libyang-builder
 RUN mkdir -p /libyang && chown -R builder /pkgs /libyang
-COPY docker/alpine/libyang/ /libyang
-USER builder
-RUN cd /libyang \
-	&& abuild checksum \
-	&& abuild -r -P /pkgs/apk
+# -- Not currently needed - libyang currently available in Alpine upstream
+# COPY docker/alpine/libyang/ /libyang
+# USER builder
+# RUN cd /libyang \
+# 	&& abuild checksum \
+# 	&& abuild -r -P /pkgs/apk
 
 # This stage builds a dist tarball from the source
 FROM alpine:3.15 as source-builder
@@ -37,10 +38,11 @@ RUN source /src/alpine/APKBUILD.in \
 	&& pip install pytest
 
 RUN mkdir -p /pkgs/apk
-COPY --from=libyang-builder /pkgs/apk/ /pkgs/apk/
-RUN apk add \
-		--no-cache \
-		--allow-untrusted /pkgs/apk/*/*.apk
+# -- Not needed while libyang is not built
+# COPY --from=libyang-builder /pkgs/apk/ /pkgs/apk/
+# RUN apk add \
+# 		--no-cache \
+# 		--allow-untrusted /pkgs/apk/*/*.apk \
 
 COPY . /src
 ARG PKGVER
@@ -53,12 +55,13 @@ RUN cd /src \
 
 # This stage builds an APK from the dist tarball
 FROM alpine-builder as frr-apk-builder
-COPY --from=libyang-builder /pkgs/apk/ /pkgs/apk/
+# -- Not needed while libyang is not built
+# COPY --from=libyang-builder /pkgs/apk/ /pkgs/apk/
+# RUN apk add \
+# 		--no-cache \
+# 		--allow-untrusted /pkgs/apk/*/*.apk
 COPY --from=source-builder /src/frr-*.tar.gz /src/alpine/* /dist/
 RUN find /pkgs/apk -type f -name APKINDEX.tar.gz -delete
-RUN apk add \
-		--no-cache \
-		--allow-untrusted /pkgs/apk/*/*.apk
 RUN chown -R builder /dist /pkgs
 USER builder
 RUN cd /dist \

--- a/docker/alpine/libyang/APKBUILD
+++ b/docker/alpine/libyang/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Christian Franke <nobody@nowhere.ws>
 pkgname=libyang
-pkgver=2.0.7
+pkgver=2.0.194
 pkgrel=0
 pkgdesc="YANG data modelling language parser and toolkit"
 url="https://github.com/CESNET/libyang"
@@ -10,9 +10,7 @@ license="BSD-3-Clause-Clear"
 makedepends="bison cmake cmocka-dev flex pcre2-dev"
 checkdepends="expect grep shunit2"
 subpackages="$pkgname-dev $pkgname-doc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/CESNET/libyang/archive/v$pkgver.tar.gz
-	10-remove-non-standard-headers.patch
-	11-utest-dont-parse-dlerror.patch"
+source="$pkgname-$pkgver.tar.gz::https://github.com/CESNET/libyang/archive/v$pkgver.tar.gz"
 
 # secfixes:
 #   1.0.215-r1:
@@ -40,7 +38,3 @@ build() {
 package() {
 	make -C build DESTDIR="$pkgdir" install
 }
-
-sha512sums="edb1d8d372b25ed820fa312e0dc96d4af7c8cd5ddeb785964de73f64774062ea7a5586bb27e2039ad24189d4a2ba04268921ca86e82423fc48647d1d10a2a0a7  libyang-2.0.7.tar.gz
-385008c715e6b0dc9e8f33c9cb550b3af7ee16f056f35d09a4ba01b9e00ddb88940915f93fc608fedd30b4f9a6a1503df414ae0be64b1263681b0ee18e6f4db8  10-remove-non-standard-headers.patch
-b16881d301a6aec68fbe6bfb7ba53a8fcdb4b9eead3b03573e0e2a4a8c3c3d6962db623be14d29c023b5a7ad0f685da1f6033dd9985f7a2914ad2f4da07e60cb  11-utest-dont-parse-dlerror.patch"


### PR DESCRIPTION
We were using a locally built copy of libyang because it wasn't present in Alpine's repos for a while, but someone added it back in May, so we can use that again.