### PR TITLE
pimd: Remove the api from .h file since there is no definition of it

### DIFF
--- a/pimd/pim_zebra.h
+++ b/pimd/pim_zebra.h
@@ -28,7 +28,6 @@
 void pim_zebra_init(void);
 void pim_zebra_zclient_update(struct vty *vty);
 
-void pim_scan_individual_oil(struct channel_oil *c_oil, int in_vif_index);
 void pim_scan_oil(struct pim_instance *pim_matcher);
 
 void pim_forward_start(struct pim_ifchannel *ch);


### PR DESCRIPTION
Removing the api pim_scan_individual_oil from .h since there is
no definition of it.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>