### PR TITLE
ldpd: Check if the thread is scheduled before calling for remained time

### DIFF
--- a/ldpd/adjacency.c
+++ b/ldpd/adjacency.c
@@ -386,7 +386,9 @@ adj_to_ctl(struct adj *adj)
 	}
 	actl.holdtime = adj->holdtime;
 	actl.holdtime_remaining =
-	    thread_timer_remain_second(adj->inactivity_timer);
+		thread_is_scheduled(adj->inactivity_timer)
+			? thread_timer_remain_second(adj->inactivity_timer)
+			: 0;
 	actl.trans_addr = adj->trans_addr;
 	actl.ds_tlv = adj->ds_tlv;
 


### PR DESCRIPTION
LDPD crashes when hold time is configured to 65535:
(gdb) bt
0  0x00007f8c3fc224bb in raise () from /lib64/libpthread.so.0
1  0x00007f8c4138a3dd in core_handler () from /lib64/libfrr.so.0
2  <signal handler called>
3  0x00007f8c3fc1ccc0 in pthread_mutex_lock () from /lib64/libpthread.so.0
4  0x00007f8c4139914b in thread_timer_remain_msec () from /lib64/libfrr.so.0
5  0x00007f8c41399209 in thread_timer_remain_second () from /lib64/libfrr.so.0
6  0x000000000040eb19 in adj_to_ctl ()
7  0x0000000000427b38 in ldpe_nbr_ctl ()
8  0x000000000042fd68 in control_dispatch_imsg ()
9  0x00007f8c4139a628 in thread_call () from /lib64/libfrr.so.0
10 0x00000000004265fc in ldpe ()
11 0x000000000040a68f in main ()

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>