### PR TITLE
pim6d: clear interface stats on interface shutdown

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1768,9 +1768,7 @@ static int pim_ifp_down(struct interface *ifp)
 
 	if (ifp->info) {
 		pim_if_del_vif(ifp);
-#if PIM_IPV == 4
 		pim_ifstat_reset(ifp);
-#endif
 	}
 
 	return 0;


### PR DESCRIPTION
The clear was happening only for PIMv4. Removed the PIMv4
check.

Fixes: #11628

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>