### PR TITLE
zebra: Cleanup the memory from the hash for MPLS stuff

### DIFF
--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -4005,6 +4005,13 @@ void zebra_mpls_client_cleanup_vrf_label(uint8_t proto)
 	}
 }
 
+static void lsp_table_free(void *p)
+{
+	struct zebra_lsp *lsp = p;
+
+	XFREE(MTYPE_LSP, lsp);
+}
+
 /*
  * Called upon process exiting, need to delete LSP forwarding
  * entries from the kernel.
@@ -4013,9 +4020,9 @@ void zebra_mpls_client_cleanup_vrf_label(uint8_t proto)
 void zebra_mpls_close_tables(struct zebra_vrf *zvrf)
 {
 	hash_iterate(zvrf->lsp_table, lsp_uninstall_from_kernel, NULL);
-	hash_clean(zvrf->lsp_table, NULL);
+	hash_clean(zvrf->lsp_table, lsp_table_free);
 	hash_free(zvrf->lsp_table);
-	hash_clean(zvrf->slsp_table, NULL);
+	hash_clean(zvrf->slsp_table, lsp_table_free);
 	hash_free(zvrf->slsp_table);
 	route_table_finish(zvrf->fec_table[AFI_IP]);
 	route_table_finish(zvrf->fec_table[AFI_IP6]);


### PR DESCRIPTION
Closes https://github.com/FRRouting/frr/issues/11574