### PR TITLE
pim6d: Implementing "clear ipv6 pim interface traffic" command.

### DIFF
--- a/doc/user/pimv6.rst
+++ b/doc/user/pimv6.rst
@@ -389,6 +389,11 @@ Clear commands reset various variables.
 
    Reset PIMv6 interfaces.
 
+.. clicmd:: clear ipv6 pim [vrf NAME] interface traffic
+
+   When this command is issued, resets the information about the 
+   number of PIM protocol packets sent/received on an interface.
+
 .. clicmd:: clear ipv6 pim oil
 
    Rescan PIMv6 OIL (output interface list).

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1260,6 +1260,19 @@ DEFPY (clear_ipv6_pim_statistics,
 	return CMD_SUCCESS;
 }
 
+DEFPY (clear_ipv6_pim_interface_traffic,
+       clear_ipv6_pim_interface_traffic_cmd,
+       "clear ipv6 pim [vrf NAME] interface traffic",
+       CLEAR_STR
+       IPV6_STR
+       CLEAR_IP_PIM_STR
+       VRF_CMD_HELP_STR
+       "Reset PIM interfaces\n"
+       "Reset Protocol Packet counters\n")
+{
+	return clear_pim_interface_traffic(vrf, vty);
+}
+
 DEFPY (clear_ipv6_mroute,
        clear_ipv6_mroute_cmd,
        "clear ipv6 mroute [vrf NAME]$name",
@@ -1619,6 +1632,7 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &clear_ipv6_mroute_count_cmd);
 	install_element(ENABLE_NODE, &clear_ipv6_pim_bsr_db_cmd);
 	install_element(ENABLE_NODE, &clear_ipv6_pim_interfaces_cmd);
+	install_element(ENABLE_NODE, &clear_ipv6_pim_interface_traffic_cmd);
 
 	install_element(ENABLE_NODE, &debug_pimv6_cmd);
 	install_element(ENABLE_NODE, &debug_pimv6_nht_cmd);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1678,50 +1678,17 @@ DEFPY (clear_ip_pim_interfaces,
 	return CMD_SUCCESS;
 }
 
-DEFUN (clear_ip_pim_interface_traffic,
+DEFPY (clear_ip_pim_interface_traffic,
        clear_ip_pim_interface_traffic_cmd,
        "clear ip pim [vrf NAME] interface traffic",
-       "Reset functions\n"
-       "IP information\n"
-       "PIM clear commands\n"
+       CLEAR_STR
+       IP_STR
+       CLEAR_IP_PIM_STR
        VRF_CMD_HELP_STR
        "Reset PIM interfaces\n"
        "Reset Protocol Packet counters\n")
 {
-	int idx = 2;
-	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	struct interface *ifp = NULL;
-	struct pim_interface *pim_ifp = NULL;
-
-	if (!vrf)
-		return CMD_WARNING;
-
-	FOR_ALL_INTERFACES (vrf, ifp) {
-		pim_ifp = ifp->info;
-
-		if (!pim_ifp)
-			continue;
-
-		pim_ifp->pim_ifstat_hello_recv = 0;
-		pim_ifp->pim_ifstat_hello_sent = 0;
-		pim_ifp->pim_ifstat_join_recv = 0;
-		pim_ifp->pim_ifstat_join_send = 0;
-		pim_ifp->pim_ifstat_prune_recv = 0;
-		pim_ifp->pim_ifstat_prune_send = 0;
-		pim_ifp->pim_ifstat_reg_recv = 0;
-		pim_ifp->pim_ifstat_reg_send = 0;
-		pim_ifp->pim_ifstat_reg_stop_recv = 0;
-		pim_ifp->pim_ifstat_reg_stop_send = 0;
-		pim_ifp->pim_ifstat_assert_recv = 0;
-		pim_ifp->pim_ifstat_assert_send = 0;
-		pim_ifp->pim_ifstat_bsm_rx = 0;
-		pim_ifp->pim_ifstat_bsm_tx = 0;
-		pim_ifp->igmp_ifstat_joins_sent = 0;
-		pim_ifp->igmp_ifstat_joins_failed = 0;
-		pim_ifp->igmp_peak_group_count = 0;
-	}
-
-	return CMD_SUCCESS;
+	return clear_pim_interface_traffic(vrf, vty);
 }
 
 DEFPY (clear_ip_pim_oil,

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -4023,6 +4023,46 @@ void clear_pim_statistics(struct pim_instance *pim)
 	}
 }
 
+int clear_pim_interface_traffic(const char *vrf, struct vty *vty)
+{
+	struct interface *ifp = NULL;
+	struct pim_interface *pim_ifp = NULL;
+
+	struct vrf *v = pim_cmd_lookup(vty, vrf);
+
+	if (!v)
+		return CMD_WARNING;
+
+	FOR_ALL_INTERFACES (v, ifp) {
+		pim_ifp = ifp->info;
+
+		if (!pim_ifp)
+			continue;
+
+		pim_ifp->pim_ifstat_hello_recv = 0;
+		pim_ifp->pim_ifstat_hello_sent = 0;
+		pim_ifp->pim_ifstat_join_recv = 0;
+		pim_ifp->pim_ifstat_join_send = 0;
+		pim_ifp->pim_ifstat_prune_recv = 0;
+		pim_ifp->pim_ifstat_prune_send = 0;
+		pim_ifp->pim_ifstat_reg_recv = 0;
+		pim_ifp->pim_ifstat_reg_send = 0;
+		pim_ifp->pim_ifstat_reg_stop_recv = 0;
+		pim_ifp->pim_ifstat_reg_stop_send = 0;
+		pim_ifp->pim_ifstat_assert_recv = 0;
+		pim_ifp->pim_ifstat_assert_send = 0;
+		pim_ifp->pim_ifstat_bsm_rx = 0;
+		pim_ifp->pim_ifstat_bsm_tx = 0;
+#if PIM_IPV == 4
+		pim_ifp->igmp_ifstat_joins_sent = 0;
+		pim_ifp->igmp_ifstat_joins_failed = 0;
+		pim_ifp->igmp_peak_group_count = 0;
+#endif
+	}
+
+	return CMD_SUCCESS;
+}
+
 int pim_debug_pim_cmd(void)
 {
 	PIM_DO_DEBUG_PIM_EVENTS;

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -139,6 +139,7 @@ int clear_ip_mroute_count_command(struct vty *vty, const char *name);
 struct vrf *pim_cmd_lookup(struct vty *vty, const char *name);
 void clear_mroute(struct pim_instance *pim);
 void clear_pim_statistics(struct pim_instance *pim);
+int clear_pim_interface_traffic(const char *vrf, struct vty *vty);
 int pim_debug_pim_cmd(void);
 int pim_no_debug_pim_cmd(void);
 int pim_debug_pim_packets_cmd(const char *hello, const char *joins,


### PR DESCRIPTION
clear ipv6 pim [vrf NAME] interface traffic

Signed-off-by: Abhishek N R <abnr@vmware.com>