### PR TITLE
bgpd: Show extended communities memory consumption

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10173,9 +10173,11 @@ DEFUN (show_bgp_memory,
 			count, mtype_memstr(memstrbuf, sizeof(memstrbuf),
 					    count * sizeof(struct community)));
 	if ((count = mtype_stats_alloc(MTYPE_ECOMMUNITY)))
-		vty_out(vty, "%ld BGP community entries, using %s of memory\n",
-			count, mtype_memstr(memstrbuf, sizeof(memstrbuf),
-					    count * sizeof(struct ecommunity)));
+		vty_out(vty,
+			"%ld BGP ext-community entries, using %s of memory\n",
+			count,
+			mtype_memstr(memstrbuf, sizeof(memstrbuf),
+				     count * sizeof(struct ecommunity)));
 	if ((count = mtype_stats_alloc(MTYPE_LCOMMUNITY)))
 		vty_out(vty,
 			"%ld BGP large-community entries, using %s of memory\n",


### PR DESCRIPTION
Just fix the description because it's wrong.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>