### PR TITLE
pathd: add a zebra stop handler

### DIFF
--- a/pathd/path_zebra.c
+++ b/pathd/path_zebra.c
@@ -352,3 +352,9 @@ void path_zebra_init(struct thread_master *master)
 	/* Connect to the LM. */
 	path_zebra_label_manager_connect();
 }
+
+void path_zebra_stop(void)
+{
+	zclient_stop(zclient);
+	zclient_free(zclient);
+}

--- a/pathd/path_zebra.h
+++ b/pathd/path_zebra.h
@@ -30,5 +30,6 @@ void path_zebra_delete_sr_policy(struct srte_policy *policy);
 int path_zebra_request_label(mpls_label_t label);
 void path_zebra_release_label(mpls_label_t label);
 void path_zebra_init(struct thread_master *master);
+void path_zebra_stop(void);
 
 #endif /* _FRR_PATH_MPLS_H_ */

--- a/pathd/pathd.c
+++ b/pathd/pathd.c
@@ -510,6 +510,8 @@ void srte_clean_zebra(void)
 
 	RB_FOREACH_SAFE (policy, srte_policy_head, &srte_policies, safe_pol)
 		srte_policy_del(policy);
+
+	path_zebra_stop();
 }
 
 /**


### PR DESCRIPTION
This handler code is used to stop zebra related contexts.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>