### PR TITLE
isisd: fix prefix-sid last-hop-behavior

### DIFF
--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -1629,8 +1629,10 @@ DEFPY_YANG (isis_sr_prefix_sid,
 
 		if (strmatch(lh_behavior, "no-php-flag"))
 			value = "no-php";
-		else
+		else if (strmatch(lh_behavior, "explicit-null"))
 			value = "explicit-null";
+		else
+			value = "php";
 
 		nb_cli_enqueue_change(vty, "./last-hop-behavior", NB_OP_MODIFY,
 				      value);


### PR DESCRIPTION
The php value is defined in yang but not properly set.

Fixes: 8f6c893629 ("isisd: add segment-routing CLI commands")
Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>