### PR TITLE
vtysh: Ignore `end` when parsing frr.conf

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -886,9 +886,22 @@ int vtysh_config_from_file(struct vty *vty, FILE *fp)
 	int lineno = 0;
 	/* once we have an error, we remember & return that */
 	int retcode = CMD_SUCCESS;
+	char *vty_buf_copy = XCALLOC(MTYPE_VTYSH_CMD, VTY_BUFSIZ);
+	char *vty_buf_trimmed = NULL;
 
 	while (fgets(vty->buf, VTY_BUFSIZ, fp)) {
 		lineno++;
+
+		strlcpy(vty_buf_copy, vty->buf, VTY_BUFSIZ);
+		vty_buf_trimmed = trim(vty_buf_copy);
+
+		/*
+		 * Ignore the "end" lines, we will generate these where
+		 * appropriate, otherwise we never execute
+		 * XFRR_end_configuration, and start/end markers do not work.
+		 */
+		if (strmatch(vty_buf_trimmed, "end"))
+			continue;
 
 		ret = command_config_read_one_line(vty, &cmd, lineno, 1);
 
@@ -955,6 +968,8 @@ int vtysh_config_from_file(struct vty *vty, FILE *fp)
 		}
 		}
 	}
+
+	XFREE(MTYPE_VTYSH_CMD, vty_buf_copy);
 
 	return (retcode);
 }


### PR DESCRIPTION
If we have `end` at the end of the frr.conf, then we never execute
XFRR_end_configuration command, and start/end markers do not work.

This leads to for example waiting BGP configuration parsing thread to hang,
and the peers are in shutdown state until the timer expires.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>