### PR TITLE
bgpd: Call a hook when as-path filter is replaced

### DIFF
--- a/bgpd/bgp_filter.c
+++ b/bgpd/bgp_filter.c
@@ -189,7 +189,7 @@ static void as_list_filter_add(struct as_list *aslist,
 		replace = bgp_aslist_seq_check(aslist, asfilter->seq);
 		if (replace) {
 			as_filter_entry_replace(aslist, replace, asfilter);
-			return;
+			goto hook;
 		}
 
 		/* Check insert point. */
@@ -218,6 +218,7 @@ static void as_list_filter_add(struct as_list *aslist,
 		aslist->tail = asfilter;
 	}
 
+hook:
 	/* Run hook function. */
 	if (as_list_master.add_hook)
 		(*as_list_master.add_hook)(aslist->name);


### PR DESCRIPTION
Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>