### PR TITLE
tests: Debugging test_multicast_pim_uplink_topo1 test failure[Do not review]

### DIFF
--- a/tests/topotests/multicast_pim_uplink_topo1/test_multicast_pim_uplink_topo1.py
+++ b/tests/topotests/multicast_pim_uplink_topo1/test_multicast_pim_uplink_topo1.py
@@ -65,6 +65,7 @@ from lib.common_config import (
     create_static_routes,
     required_linux_kernel_version,
     topo_daemons,
+    create_debug_log_config
 )
 from lib.bgp import create_router_bgp
 from lib.pim import (
@@ -3081,6 +3082,13 @@ def test_mroutes_after_restart_frr_services_p2(request):
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
+
+    input_dict = {
+            "r4": {"debug": {"log_file": "r4_debug.log", "enable": ["pimd"]}},
+            "r2": {"debug": {"log_file": "r2_debug.log", "enable": ["pimd"]}},
+            "r1": {"debug": {"log_file": "r1_debug.log", "enable": ["pimd"]}},
+    }
+    result = create_debug_log_config(tgen, input_dict)
 
     step("Enable IGMP on DUT and R4 interface")
     intf_r1_i1 = topo["routers"]["r1"]["links"]["i1"]["interface"]


### PR DESCRIPTION
One of the tests for multicast uplink topo1 is
failing intermittently. There was some timing
issue in (*, G) and (S, G) verification. (*, G)s
were verified followed by (S, G)s. Now it is
verified together.

Ci(Micronet CI also) was verified multiple times
before getting approval and merged. 

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>