### PR TITLE
BFDD: Add RTT to BFD IPV4 Echo packet processing

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -381,6 +381,9 @@ int bfd_session_enable(struct bfd_session *bs)
 		ptm_bfd_start_xmt_timer(bs, false);
 	}
 
+	/* initialize RTT */
+	bfd_rtt_init(bs);
+
 	return 0;
 }
 
@@ -574,6 +577,9 @@ void ptm_bfd_sess_dn(struct bfd_session *bfd, uint8_t diag)
 	memset(bfd->peer_hw_addr, 0, sizeof(bfd->peer_hw_addr));
 	/* reset local address ,it might has been be changed after bfd is up*/
 	memset(&bfd->local_address, 0, sizeof(bfd->local_address));
+
+	/* reset RTT */
+	bfd_rtt_init(bfd);
 }
 
 static struct bfd_session *bfd_find_disc(struct sockaddr_any *sa,
@@ -2064,4 +2070,15 @@ struct bfd_vrf_global *bfd_vrf_look_by_session(struct bfd_session *bfd)
 unsigned long bfd_get_session_count(void)
 {
 	return bfd_key_hash->count;
+}
+
+void bfd_rtt_init(struct bfd_session *bfd)
+{
+	uint8_t i;
+
+	/* initialize RTT */
+	bfd->rtt_valid = 0;
+	bfd->rtt_index = 0;
+	for (i = 0; i < BFD_RTT_SAMPLE; i++)
+		bfd->rtt[i] = 0;
 }

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -86,7 +86,8 @@ struct bfd_echo_pkt {
 		};
 	};
 	uint32_t my_discr;
-	uint8_t pad[16];
+	uint64_t time_sent_sec;
+	uint64_t time_sent_usec;
 };
 
 
@@ -249,6 +250,8 @@ struct bfd_config_timers {
 	uint32_t required_min_echo_rx;
 };
 
+#define BFD_RTT_SAMPLE 8
+
 /*
  * Session state information
  */
@@ -311,6 +314,10 @@ struct bfd_session {
 	struct bfd_timers remote_timers;
 
 	uint64_t refcount; /* number of pointers referencing this. */
+
+	uint8_t rtt_valid;	    /* number of valid samples */
+	uint8_t rtt_index;	    /* last index added */
+	uint64_t rtt[BFD_RTT_SAMPLE]; /* RRT in usec for echo to be looped */
 };
 
 struct peer_label {
@@ -635,6 +642,7 @@ const struct bfd_session *bfd_session_next(const struct bfd_session *bs,
 					   bool mhop);
 void bfd_sessions_remove_manual(void);
 void bfd_profiles_remove(void);
+void bfd_rtt_init(struct bfd_session *bfd);
 
 /**
  * Set the BFD session echo state.

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -55,8 +55,8 @@ ssize_t bfd_recv_ipv6(int sd, uint8_t *msgbuf, size_t msgbuflen, uint8_t *ttl,
 		      struct sockaddr_any *peer);
 int bp_udp_send(int sd, uint8_t ttl, uint8_t *data, size_t datalen,
 		struct sockaddr *to, socklen_t tolen);
-int bp_bfd_echo_in(struct bfd_vrf_global *bvrf, int sd,
-		   uint8_t *ttl, uint32_t *my_discr);
+int bp_bfd_echo_in(struct bfd_vrf_global *bvrf, int sd, uint8_t *ttl,
+		   uint32_t *my_discr, uint64_t *my_rtt);
 #ifdef BFD_LINUX
 ssize_t bfd_recv_ipv4_fp(int sd, uint8_t *msgbuf, size_t msgbuflen,
 			 uint8_t *ttl, ifindex_t *ifindex,
@@ -207,6 +207,7 @@ void ptm_bfd_echo_fp_snd(struct bfd_session *bfd)
 	struct iphdr *iph;
 	struct bfd_echo_pkt *beph;
 	static char sendbuff[100];
+	struct timeval time_sent;
 
 	if (!bvrf)
 		return;
@@ -258,6 +259,11 @@ void ptm_bfd_echo_fp_snd(struct bfd_session *bfd)
 	beph->ver = BFD_ECHO_VERSION;
 	beph->len = BFD_ECHO_PKT_LEN;
 	beph->my_discr = htonl(bfd->discrs.my_discr);
+
+	/* RTT calculation: add starting time in packet */
+	monotime(&time_sent);
+	beph->time_sent_sec = htobe64(time_sent.tv_sec);
+	beph->time_sent_usec = htobe64(time_sent.tv_usec);
 
 	total_len += sizeof(struct bfd_echo_pkt);
 	uh->len =
@@ -338,10 +344,11 @@ static int ptm_bfd_process_echo_pkt(struct bfd_vrf_global *bvrf, int s)
 {
 	struct bfd_session *bfd;
 	uint32_t my_discr = 0;
+	uint64_t my_rtt = 0;
 	uint8_t ttl = 0;
 
 	/* Receive and parse echo packet. */
-	if (bp_bfd_echo_in(bvrf, s, &ttl, &my_discr) == -1)
+	if (bp_bfd_echo_in(bvrf, s, &ttl, &my_discr, &my_rtt) == -1)
 		return 0;
 
 	/* Your discriminator not zero - use it to find session */
@@ -358,6 +365,16 @@ static int ptm_bfd_process_echo_pkt(struct bfd_vrf_global *bvrf, int s)
 			zlog_debug("echo-packet: echo disabled [%s] (id:%u)",
 				   bs_to_string(bfd), my_discr);
 		return -1;
+	}
+
+	/* RTT Calculation: add current RTT to samples */
+	if (my_rtt != 0) {
+		bfd->rtt[bfd->rtt_index] = my_rtt;
+		bfd->rtt_index++;
+		if (bfd->rtt_index >= BFD_RTT_SAMPLE)
+			bfd->rtt_index = 0;
+		if (bfd->rtt_valid < BFD_RTT_SAMPLE)
+			bfd->rtt_valid++;
 	}
 
 	bfd->stats.rx_echo_pkt++;
@@ -995,8 +1012,8 @@ void bfd_recv_cb(struct thread *t)
  *
  * Returns -1 on error or loopback or 0 on success.
  */
-int bp_bfd_echo_in(struct bfd_vrf_global *bvrf, int sd,
-		   uint8_t *ttl, uint32_t *my_discr)
+int bp_bfd_echo_in(struct bfd_vrf_global *bvrf, int sd, uint8_t *ttl,
+		   uint32_t *my_discr, uint64_t *my_rtt)
 {
 	struct bfd_echo_pkt *bep;
 	ssize_t rlen;
@@ -1054,6 +1071,17 @@ int bp_bfd_echo_in(struct bfd_vrf_global *bvrf, int sd,
 		return -1;
 	}
 
+#ifdef BFD_LINUX
+	/* RTT Calculation: determine RTT time of IPv4 echo pkt */
+	if (sd == bvrf->bg_echo) {
+		struct timeval time_sent = {0, 0};
+
+		time_sent.tv_sec = be64toh(bep->time_sent_sec);
+		time_sent.tv_usec = be64toh(bep->time_sent_usec);
+		*my_rtt = monotime_since(&time_sent, NULL);
+	}
+#endif
+
 	return 0;
 }
 
@@ -1066,11 +1094,10 @@ int bp_udp_send_fp(int sd, uint8_t *data, size_t datalen,
 		   struct bfd_session *bfd)
 {
 	ssize_t wlen;
-	struct msghdr msg;
+	struct msghdr msg = {0};
 	struct iovec iov[1];
 	uint8_t msgctl[255];
-	struct sockaddr_ll sadr_ll;
-
+	struct sockaddr_ll sadr_ll = {0};
 
 	sadr_ll.sll_ifindex = bfd->ifp->ifindex;
 	sadr_ll.sll_halen = ETH_ALEN;
@@ -1081,7 +1108,6 @@ int bp_udp_send_fp(int sd, uint8_t *data, size_t datalen,
 	iov[0].iov_base = data;
 	iov[0].iov_len = datalen;
 
-	memset(&msg, 0, sizeof(msg));
 	memset(msgctl, 0, sizeof(msgctl));
 	msg.msg_name = &sadr_ll;
 	msg.msg_namelen = sizeof(sadr_ll);
@@ -1560,7 +1586,7 @@ int bp_echo_socket(const struct vrf *vrf)
 		zlog_fatal("echo-socket: socket: %s", strerror(errno));
 
 	struct sock_fprog pf;
-	struct sockaddr_ll sll;
+	struct sockaddr_ll sll = {0};
 
 	/* adjust filter for socket to only receive ECHO packets */
 	pf.filter = my_filterudp;

--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -518,6 +518,10 @@ You can inspect the current BFD peer status with the following commands:
    frr# show bfd peer 192.168.0.1 json
    {"multihop":false,"peer":"192.168.0.1","id":1,"remote-id":1,"status":"up","uptime":161,"diagnostic":"ok","remote-diagnostic":"ok","receive-interval":300,"transmit-interval":300,"echo-receive-interval":50,"echo-transmit-interval":0,"detect-multiplier":3,"remote-receive-interval":300,"remote-transmit-interval":300,"remote-echo-receive-interval":50,"remote-detect-multiplier":3,"peer-type":"dynamic"}
 
+If you are running IPV4 BFD Echo, on a Linux platform, we also
+calculate round trip time for the packets.  We display minimum,
+average and maximum time it took to receive the looped Echo packets
+in the RTT fields.
 
 You can inspect the current BFD peer status in brief with the following commands:
 


### PR DESCRIPTION
Add a send time into the BFD Echo packet.  When the BFD Echo
packet is received back store time it took in usec.   When
user issues a show bfd peer(s) command calculate and display
minimum, average, and max time it took for the BFD Echo packet
to be looped back.

Signed-off-by: Lynne Morrison <lynne.morrison@ibm.com>