### PR TITLE
bgpd: Cleanup subgroup hash when we delete/merge a subgroup

### DIFF
--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -49,7 +49,7 @@ struct bgp_advertise_attr *baa_new(void)
 		       sizeof(struct bgp_advertise_attr));
 }
 
-static void baa_free(struct bgp_advertise_attr *baa)
+void baa_free(struct bgp_advertise_attr *baa)
 {
 	XFREE(MTYPE_BGP_ADVERTISE_ATTR, baa);
 }

--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -43,35 +43,35 @@
 /* BGP advertise attribute is used for pack same attribute update into
    one packet.  To do that we maintain attribute hash in struct
    peer.  */
-struct bgp_advertise_attr *baa_new(void)
+struct bgp_advertise_attr *bgp_advertise_attr_new(void)
 {
 	return XCALLOC(MTYPE_BGP_ADVERTISE_ATTR,
 		       sizeof(struct bgp_advertise_attr));
 }
 
-void baa_free(struct bgp_advertise_attr *baa)
+void bgp_advertise_attr_free(struct bgp_advertise_attr *baa)
 {
 	XFREE(MTYPE_BGP_ADVERTISE_ATTR, baa);
 }
 
-static void *baa_hash_alloc(void *p)
+static void *bgp_advertise_attr_hash_alloc(void *p)
 {
 	struct bgp_advertise_attr *ref = (struct bgp_advertise_attr *)p;
 	struct bgp_advertise_attr *baa;
 
-	baa = baa_new();
+	baa = bgp_advertise_attr_new();
 	baa->attr = ref->attr;
 	return baa;
 }
 
-unsigned int baa_hash_key(const void *p)
+unsigned int bgp_advertise_attr_hash_key(const void *p)
 {
 	const struct bgp_advertise_attr *baa = p;
 
 	return attrhash_key_make(baa->attr);
 }
 
-bool baa_hash_cmp(const void *p1, const void *p2)
+bool bgp_advertise_attr_hash_cmp(const void *p1, const void *p2)
 {
 	const struct bgp_advertise_attr *baa1 = p1;
 	const struct bgp_advertise_attr *baa2 = p2;
@@ -115,20 +115,22 @@ void bgp_advertise_delete(struct bgp_advertise_attr *baa,
 		baa->adv = adv->next;
 }
 
-struct bgp_advertise_attr *bgp_advertise_intern(struct hash *hash,
-						struct attr *attr)
+struct bgp_advertise_attr *bgp_advertise_attr_intern(struct hash *hash,
+						     struct attr *attr)
 {
 	struct bgp_advertise_attr ref;
 	struct bgp_advertise_attr *baa;
 
 	ref.attr = bgp_attr_intern(attr);
-	baa = (struct bgp_advertise_attr *)hash_get(hash, &ref, baa_hash_alloc);
+	baa = (struct bgp_advertise_attr *)hash_get(
+		hash, &ref, bgp_advertise_attr_hash_alloc);
 	baa->refcnt++;
 
 	return baa;
 }
 
-void bgp_advertise_unintern(struct hash *hash, struct bgp_advertise_attr *baa)
+void bgp_advertise_attr_unintern(struct hash *hash,
+				 struct bgp_advertise_attr *baa)
 {
 	if (baa->refcnt)
 		baa->refcnt--;
@@ -140,7 +142,7 @@ void bgp_advertise_unintern(struct hash *hash, struct bgp_advertise_attr *baa)
 			hash_release(hash, baa);
 			bgp_attr_unintern(&baa->attr);
 		}
-		baa_free(baa);
+		bgp_advertise_attr_free(baa);
 	}
 }
 

--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -152,19 +152,19 @@ extern void bgp_adj_in_remove(struct bgp_dest *dest, struct bgp_adj_in *bai);
 
 extern void bgp_sync_init(struct peer *peer);
 extern void bgp_sync_delete(struct peer *peer);
-extern unsigned int baa_hash_key(const void *p);
-extern bool baa_hash_cmp(const void *p1, const void *p2);
+extern unsigned int bgp_advertise_attr_hash_key(const void *p);
+extern bool bgp_advertise_attr_hash_cmp(const void *p1, const void *p2);
 extern void bgp_advertise_add(struct bgp_advertise_attr *baa,
 			      struct bgp_advertise *adv);
 extern struct bgp_advertise *bgp_advertise_new(void);
 extern void bgp_advertise_free(struct bgp_advertise *adv);
-extern struct bgp_advertise_attr *bgp_advertise_intern(struct hash *hash,
-						       struct attr *attr);
-extern struct bgp_advertise_attr *baa_new(void);
+extern struct bgp_advertise_attr *bgp_advertise_attr_intern(struct hash *hash,
+							    struct attr *attr);
+extern struct bgp_advertise_attr *bgp_advertise_attr_new(void);
 extern void bgp_advertise_delete(struct bgp_advertise_attr *baa,
 				 struct bgp_advertise *adv);
-extern void bgp_advertise_unintern(struct hash *hash,
-				   struct bgp_advertise_attr *baa);
-extern void baa_free(struct bgp_advertise_attr *baa);
+extern void bgp_advertise_attr_unintern(struct hash *hash,
+					struct bgp_advertise_attr *baa);
+extern void bgp_advertise_attr_free(struct bgp_advertise_attr *baa);
 
 #endif /* _QUAGGA_BGP_ADVERTISE_H */

--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -165,5 +165,6 @@ extern void bgp_advertise_delete(struct bgp_advertise_attr *baa,
 				 struct bgp_advertise *adv);
 extern void bgp_advertise_unintern(struct hash *hash,
 				   struct bgp_advertise_attr *baa);
+extern void baa_free(struct bgp_advertise_attr *baa);
 
 #endif /* _QUAGGA_BGP_ADVERTISE_H */

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -91,7 +91,8 @@ static void sync_init(struct update_subgroup *subgrp,
 	bgp_adv_fifo_init(&subgrp->sync->withdraw);
 	bgp_adv_fifo_init(&subgrp->sync->withdraw_low);
 	subgrp->hash =
-		hash_create(baa_hash_key, baa_hash_cmp, "BGP SubGroup Hash");
+		hash_create(bgp_advertise_attr_hash_key,
+			    bgp_advertise_attr_hash_cmp, "BGP SubGroup Hash");
 
 	/* We use a larger buffer for subgrp->work in the event that:
 	 * - We RX a BGP_UPDATE where the attributes alone are just
@@ -116,7 +117,8 @@ static void sync_delete(struct update_subgroup *subgrp)
 {
 	XFREE(MTYPE_BGP_SYNCHRONISE, subgrp->sync);
 	if (subgrp->hash) {
-		hash_clean(subgrp->hash, (void (*)(void *))baa_free);
+		hash_clean(subgrp->hash,
+			   (void (*)(void *))bgp_advertise_attr_free);
 		hash_free(subgrp->hash);
 	}
 	subgrp->hash = NULL;

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -115,8 +115,10 @@ static void sync_init(struct update_subgroup *subgrp,
 static void sync_delete(struct update_subgroup *subgrp)
 {
 	XFREE(MTYPE_BGP_SYNCHRONISE, subgrp->sync);
-	if (subgrp->hash)
+	if (subgrp->hash) {
+		hash_clean(subgrp->hash, (void (*)(void *))baa_free);
 		hash_free(subgrp->hash);
+	}
 	subgrp->hash = NULL;
 	if (subgrp->work)
 		stream_free(subgrp->work);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -437,7 +437,7 @@ bgp_advertise_clean_subgroup(struct update_subgroup *subgrp,
 		next = baa->adv;
 
 		/* Unintern BGP advertise attribute.  */
-		bgp_advertise_unintern(subgrp->hash, baa);
+		bgp_advertise_attr_unintern(subgrp->hash, baa);
 	} else
 		fhead = &subgrp->sync->withdraw;
 
@@ -523,7 +523,7 @@ void bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 	/* bgp_path_info adj_out reference */
 	adv->pathi = bgp_path_info_lock(path);
 
-	adv->baa = bgp_advertise_intern(subgrp->hash, attr);
+	adv->baa = bgp_advertise_attr_intern(subgrp->hash, attr);
 	adv->adj = adj;
 	adj->attr_hash = attr_hash;
 


### PR DESCRIPTION
Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>