### PR TITLE
tools/gcc-plugins: make GCC 12 compatible

### DIFF
--- a/tools/gcc-plugins/frr-format.c
+++ b/tools/gcc-plugins/frr-format.c
@@ -1042,7 +1042,7 @@ check_format_info (function_format_info *info, tree params,
   format_ctx.arglocs = arglocs;
 
   check_function_arguments_recurse (check_format_arg, &format_ctx,
-				    format_tree, arg_num);
+				    format_tree, arg_num, OPT_Wformat_);
 
   location_t loc = format_ctx.res->format_string_loc;
 

--- a/tools/gcc-plugins/gcc-common.h
+++ b/tools/gcc-plugins/gcc-common.h
@@ -982,4 +982,9 @@ static inline void debug_gimple_stmt(const_gimple s)
 #define SET_DECL_MODE(decl, mode)	DECL_MODE(decl) = (mode)
 #endif
 
+#if BUILDING_GCC_VERSION < 12000
+#define check_function_arguments_recurse(arg, ctx, tree, num, opt)             \
+	check_function_arguments_recurse(arg, ctx, tree, num)
+#endif
+
 #endif


### PR DESCRIPTION
check_function_arguments_recurse() has received a new function argument in GCC 12.  Fill it in and add a compatibility wrapper.