### PR TITLE
build: unconditionally enable format checks

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -469,11 +469,7 @@ am__v_XRELFO_ = $(am__v_XRELFO_$(AM_DEFAULT_VERBOSITY))
 am__v_XRELFO_0 = @echo "  XRELFO  " $@;
 am__v_XRELFO_1 =
 
-if DEV_BUILD
 XRELFO_FLAGS = -Wlog-format -Wlog-args
-else
-XRELFO_FLAGS =
-endif
 
 SUFFIXES += .xref
 %.xref: % $(CLIPPY)


### PR DESCRIPTION
The format message checks done by clippy/xrelfo were still guarded behind `--enable-dev-build`.  They've been clean and reliable, so it's time to enable them unconditionally.

Fixes: #11680