### PR TITLE
bgpd: Fixup pbr rule changes that were missed

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2683,6 +2683,11 @@ static void bgp_encode_pbr_rule_action(struct stream *s,
 	else
 		stream_putl(s, pbra->fwmark);  /* fwmark */
 
+	stream_putl(s, 0); /* queue id */
+	stream_putw(s, 0); /* vlan_id */
+	stream_putw(s, 0); /* vlan_flags */
+	stream_putw(s, 0); /* pcp */
+
 	stream_putl(s, pbra->table_id);
 
 	memset(ifname, 0, sizeof(ifname));


### PR DESCRIPTION
In commit: d70a31a3ef2b60d978b336d5cc9ee5e1ec079dfc

the Zapi ZEBRA_RULE_ADD message was modified but
the bgp version was not updated appropriately and
when zebra received the message it did not properly
read it.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>