### PR TITLE
WIP: Record `no bgp no-rib` override of implicit `-n` when using `-l`

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -17400,6 +17400,8 @@ int bgp_config_write(struct vty *vty)
 	/* No-RIB (Zebra) option flag configuration */
 	if (bgp_option_check(BGP_OPT_NO_FIB))
 		vty_out(vty, "bgp no-rib\n");
+	else if (!list_isempty(bm->addresses))
+		vty_out(vty, "no bgp no-rib\n");
 
 	if (CHECK_FLAG(bm->flags, BM_FLAG_SEND_EXTRA_DATA_TO_ZEBRA))
 		vty_out(vty, "bgp send-extra-data zebra\n");


### PR DESCRIPTION
We are running the `bgpd` daemon with `-l BIND_IP` options but we don't want the implicit `-n` behaviour.

Whenever we make a change and `write memory` the config it will lose the required `no bgp no-rib` command.

This is probably not the correct answer to the problem but it works for us.