### PR TITLE
bgpd: Ensure we are not using AFI_MAX

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3855,6 +3855,11 @@ DEFPY(bgp_default_afi_safi, bgp_default_afi_safi_cmd,
 	afi_t afi = bgp_vty_afi_from_str(afi_str);
 	safi_t safi;
 
+	/*
+	 * Impossible situation but making coverity happy
+	 */
+	assert(afi != AFI_MAX);
+
 	if (strmatch(safi_str, "labeled"))
 		safi = bgp_vty_safi_from_str("labeled-unicast");
 	else


### PR DESCRIPTION
When using bgp_vty_afi_from_str it can
return AFI_MAX( but in practice never will with
our cli ).  In bgp_default_afi_safi_cmd the code
directly references:
	bgp->default_afi[afi][safi] = TRUE;

and if afi is AFI_MAX FRRR would be accessing
memory where it should not be.

Let's just provide some assurances for coverity
that this never happens.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>