### PR TITLE
pimd: Update mroute IIF based on Nexthop received from Zebra

### DIFF
--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -436,7 +436,7 @@ static int pim_update_upstream_nh_helper(struct hash_bucket *bucket, void *arg)
 	 * RPF nbr is now unreachable the MFC has already been updated
 	 * by pim_rpf_clear
 	 */
-	if (rpf_result != PIM_RPF_CHANGED)
+	if (rpf_result == PIM_RPF_CHANGED)
 		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
 
 	if (rpf_result == PIM_RPF_CHANGED ||


### PR DESCRIPTION
Topology:
R1(LHR) ---- R2 ----R4(FHR)
        ---- R3 ----

R2 = RP

Steps to reproduce:
1. R1(LHR) sends IGMP join, R4(FHR) sends multicast traffic.
   Verify traffic is flowing from FHR to LHR.
2. Restart R1(LHR).
3. Below sequence of events are happening after FRR restart in R1(LHR).
4. R1(LHR) Register RP address to Zebra.
5. R1(LHR) Receive update from Zebra that R2(RP) is reachable via R3.
6. R1(LHR) Receive IGMP join for group 225.1.1.1, will create pim upstream
   and (*,G) mroute with IIF towards R3.
7. R1(LHR) Receive update from Zebra that RP is reachable via R2(RP).
8. R1(LHR) Update the PIM upstream IIF, but not updating the (*,G) IIF
   even there is RPF change.
9. R1(LHR) receives IGMP join for group 225.1.1.2, will create (*,G) with
   IIF towards R2(RP), both upstream and (,G) created with IIF towards R2(RP).

Root Cause:
Mroute IIF is not getting updated when better route update
received. It is still pointing to the older nexthop.

Fix:
Update the mroute IIF when there is change in nexthop.

Fixing Issue https://github.com/FRRouting/frr/issues/11675

Signed-off-by: Sarita Patra <saritap@vmware.com>