### PR TITLE
doc: Update /doc/topotests.rst documentation

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -38,6 +38,12 @@ Installing Topotest Requirements
    # To enable the gRPC topotest install:
    python3 -m pip install grpcio grpcio-tools
 
+   # Install Socat tool to run PIMv6 tests,
+   # Socat code can be taken from below url,
+   # which has latest changes done for PIMv6,
+   # join and traffic:
+   https://github.com/opensourcerouting/socat/
+
 
 Enable Coredumps
 """"""""""""""""


### PR DESCRIPTION
Updated /doc/topotests.rst with socat details,
which is needed to run PIMv6 tests. Socat tool
is used to send PIMv6 join and traffic.

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>