### PR TITLE
lib: Correct valgrind errors

### DIFF
--- a/lib/link_state.h
+++ b/lib/link_state.h
@@ -91,7 +91,7 @@ struct ls_node_id {
 			uint8_t level;			/* ISIS Level */
 			uint8_t padding;
 		} iso;
-	} id __attribute__((aligned(8)));
+	} id;
 };
 
 /**


### PR DESCRIPTION
In CSPF topo test, valgrind detects uninitialized bytes when exporting TE
Opaque information through ZEBRA. This is due to C pragma compilation directive
`__attribute__(aligned(8))` in `struct ls_node_id` in `link_state.h`. Valgrind
consideris that struct ls_node_id nid = {} doesn't initialized the padding
bytes introduced by gcc.

This patch simply removes the C pragma compilation directive and also takes
opportunity to remove the transmission of remote node id for vertices and
subnets which is not known. Indeed, remote node id is only pertinent for
edges.

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>