### PR TITLE
pimd, pim6d: Send register msg via reg socket, solve FHR/RP same node issue

### DIFF
--- a/lib/sockunion.c
+++ b/lib/sockunion.c
@@ -290,8 +290,10 @@ int sockopt_reuseaddr(int sock)
 	ret = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void *)&on,
 			 sizeof(on));
 	if (ret < 0) {
-		flog_err(EC_LIB_SOCKET,
-			 "can't set sockopt SO_REUSEADDR to socket %d", sock);
+		flog_err(
+			EC_LIB_SOCKET,
+			"can't set sockopt SO_REUSEADDR to socket %d errno=%d: %s",
+			sock, errno, safe_strerror(errno));
 		return -1;
 	}
 	return 0;

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -3352,6 +3352,8 @@ void pim_cmd_show_ip_multicast_helper(struct pim_instance *pim, struct vty *vty)
 	vty_out(vty, "Mroute socket descriptor:");
 
 	vty_out(vty, " %d(%s)\n", pim->mroute_socket, vrf->name);
+	vty_out(vty, "PIM Register socket descriptor:");
+	vty_out(vty, " %d(%s)\n", pim->reg_sock, vrf->name);
 
 	pim_time_uptime(uptime, sizeof(uptime),
 			now - pim->mroute_socket_creation);

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -36,6 +36,7 @@
 #include "pim_vty.h"
 #include "pim_bsm.h"
 #include "pim_mlag.h"
+#include "pim_sock.h"
 
 static void pim_instance_terminate(struct pim_instance *pim)
 {
@@ -69,6 +70,8 @@ static void pim_instance_terminate(struct pim_instance *pim)
 	pim_oil_terminate(pim);
 
 	pim_msdp_exit(pim);
+
+	close(pim->reg_sock);
 
 	pim_mroute_socket_disable(pim);
 
@@ -130,6 +133,10 @@ static struct pim_instance *pim_instance_init(struct vrf *vrf)
 	pim_instance_mlag_init(pim);
 
 	pim->last_route_change_time = -1;
+
+	pim->reg_sock = pim_reg_sock();
+	if (pim->reg_sock < 0)
+		assert(0);
 
 	/* MSDP global timer defaults. */
 	pim->msdp.hold_time = PIM_MSDP_PEER_HOLD_TIME;

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -136,6 +136,7 @@ struct pim_instance {
 
 	struct thread *thread;
 	int mroute_socket;
+	int reg_sock; /* Socket to send register msg */
 	int64_t mroute_socket_creation;
 	int64_t mroute_add_events;
 	int64_t mroute_add_last;

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -331,7 +331,7 @@ void pim_register_send(const uint8_t *buf, int buf_size, pim_addr src,
 	if (!pinfo->pim_passive_enable)
 		++pinfo->pim_ifstat_reg_send;
 
-	if (pim_msg_send(pinfo->pim_sock_fd, src, rpg->rpf_addr, buffer,
+	if (pim_msg_send(pinfo->pim->reg_sock, src, rpg->rpf_addr, buffer,
 			 buf_size + PIM_MSG_REGISTER_LEN, ifp)) {
 		if (PIM_DEBUG_PIM_TRACE) {
 			zlog_debug(

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -179,6 +179,46 @@ static inline int pim_setsockopt(int protocol, int fd, struct interface *ifp)
 }
 #endif
 
+int pim_reg_sock(void)
+{
+	int fd;
+	long flags;
+
+	frr_with_privs (&pimd_privs) {
+		fd = socket(AF_INET, SOCK_RAW, IPPROTO_RAW);
+	}
+
+	if (fd < 0) {
+		zlog_warn("Could not create raw socket: errno=%d: %s", errno,
+			  safe_strerror(errno));
+		return PIM_SOCK_ERR_SOCKET;
+	}
+
+	if (sockopt_reuseaddr(fd)) {
+		close(fd);
+		return PIM_SOCK_ERR_REUSE;
+	}
+
+	flags = fcntl(fd, F_GETFL, 0);
+	if (flags < 0) {
+		zlog_warn(
+			"Could not get fcntl(F_GETFL,O_NONBLOCK) on socket fd=%d: errno=%d: %s",
+			fd, errno, safe_strerror(errno));
+		close(fd);
+		return PIM_SOCK_ERR_NONBLOCK_GETFL;
+	}
+
+	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK)) {
+		zlog_warn(
+			"Could not set fcntl(F_SETFL,O_NONBLOCK) on socket fd=%d: errno=%d: %s",
+			fd, errno, safe_strerror(errno));
+		close(fd);
+		return PIM_SOCK_ERR_NONBLOCK_SETFL;
+	}
+
+	return fd;
+}
+
 int pim_socket_mcast(int protocol, pim_addr ifaddr, struct interface *ifp,
 		     uint8_t loop)
 {

--- a/pimd/pim_sock.h
+++ b/pimd/pim_sock.h
@@ -51,4 +51,6 @@ int pim_socket_recvfromto(int fd, uint8_t *buf, size_t len,
 
 int pim_socket_getsockname(int fd, struct sockaddr *name, socklen_t *namelen);
 
+int pim_reg_sock(void);
+
 #endif /* PIM_SOCK_H */


### PR DESCRIPTION
The problem here is when the same node is FHR as well as RP,
then the node keeps on sending the register packet.
Register-stop is not sent as well.

This problem has occurred because the RP is the same node
and there is no socket created on loopback interface, so the
packet is never sent out and never received back on the same
node, so register recv could not be processed on the node and
hence no register-stop is sent.

Since register packets are unicast packets, its better to handle
the send of register packet via a separate register socket.
This fixes the problem mentioned above as well.

Fixes: #11331
Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>