### PR TITLE
build: unconditionally enable format checks

### DIFF
--- a/lib/sockopt.c
+++ b/lib/sockopt.c
@@ -306,12 +306,9 @@ int setsockopt_ipv4_multicast(int sock, int optname, struct in_addr if_addr,
 	    && (errno == EADDRINUSE)) {
 		/* see above: handle possible problem when interface comes back
 		 * up */
-		char buf[1][INET_ADDRSTRLEN];
 		zlog_info(
-			"setsockopt_ipv4_multicast attempting to drop and re-add (fd %d, mcast %s, ifindex %u)",
-			sock, inet_ntop(AF_INET, &mreq.imr_multiaddr, buf[0],
-					sizeof(buf[0])),
-			ifindex);
+			"setsockopt_ipv4_multicast attempting to drop and re-add (fd %d, mcast %pI4, ifindex %u)",
+			sock, &mreq.imr_multiaddr, ifindex);
 		setsockopt(sock, IPPROTO_IP, IP_DROP_MEMBERSHIP, (void *)&mreq,
 			   sizeof(mreq));
 		ret = setsockopt(sock, IPPROTO_IP, IP_ADD_MEMBERSHIP,

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -469,11 +469,7 @@ am__v_XRELFO_ = $(am__v_XRELFO_$(AM_DEFAULT_VERBOSITY))
 am__v_XRELFO_0 = @echo "  XRELFO  " $@;
 am__v_XRELFO_1 =
 
-if DEV_BUILD
 XRELFO_FLAGS = -Wlog-format -Wlog-args
-else
-XRELFO_FLAGS =
-endif
 
 SUFFIXES += .xref
 %.xref: % $(CLIPPY)


### PR DESCRIPTION
The format message checks done by clippy/xrelfo were still guarded
behind `--enable-dev-build`.  They've been clean and reliable, so it's
time to enable them unconditionally.

Fixes: #11680
Signed-off-by: David Lamparter <equinox@opensourcerouting.org>