### PR TITLE
bgpd: bgp_best_path_select_defer never returns negative

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2006,10 +2006,8 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 					gr_info->eor_required = 0;
 					gr_info->eor_received = 0;
 					/* Best path selection */
-					if (bgp_best_path_select_defer(
-						    peer->bgp, afi, safi)
-					    < 0)
-						return BGP_Stop;
+					bgp_best_path_select_defer(peer->bgp,
+								   afi, safi);
 				}
 			}
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3191,7 +3191,7 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 }
 
 /* Process the routes with the flag BGP_NODE_SELECT_DEFER set */
-int bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi)
+void bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi)
 {
 	struct bgp_dest *dest;
 	int cnt = 0;
@@ -3238,7 +3238,7 @@ int bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi)
 		/* Send route processing complete message to RIB */
 		bgp_zebra_update(afi, safi, bgp->vrf_id,
 				 ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE);
-		return 0;
+		return;
 	}
 
 	thread_info = XMALLOC(MTYPE_TMP, sizeof(struct afi_safi_info));
@@ -3253,7 +3253,6 @@ int bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi)
 	thread_add_timer(bm->master, bgp_route_select_timer_expire, thread_info,
 			BGP_ROUTE_SELECT_DELAY,
 			&bgp->gr_info[afi][safi].t_route_select);
-	return 0;
 }
 
 static wq_item_status bgp_process_wq(struct work_queue *wq, void *data)

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -828,7 +828,7 @@ extern int bgp_show_table_rd(struct vty *vty, struct bgp *bgp, safi_t safi,
 			     struct bgp_table *table, struct prefix_rd *prd,
 			     enum bgp_show_type type, void *output_arg,
 			     bool use_json);
-extern int bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi);
+extern void bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi);
 extern bool bgp_update_martian_nexthop(struct bgp *bgp, afi_t afi, safi_t safi,
 				       uint8_t type, uint8_t stype,
 				       struct attr *attr, struct bgp_dest *dest);


### PR DESCRIPTION
Just drop the test and convert to void.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>