### PR TITLE
*: Drop explicit NULL assignment after hash_free()

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -2082,7 +2082,6 @@ void aspath_finish(void)
 {
 	hash_clean(ashash, (void (*)(void *))aspath_free);
 	hash_free(ashash);
-	ashash = NULL;
 
 	if (snmp_stream)
 		stream_free(snmp_stream);

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -202,7 +202,6 @@ static void cluster_finish(void)
 {
 	hash_clean(cluster_hash, (void (*)(void *))cluster_free);
 	hash_free(cluster_hash);
-	cluster_hash = NULL;
 }
 
 static struct hash *encap_hash = NULL;
@@ -388,11 +387,9 @@ static void encap_finish(void)
 {
 	hash_clean(encap_hash, (void (*)(void *))encap_free);
 	hash_free(encap_hash);
-	encap_hash = NULL;
 #ifdef ENABLE_BGP_VNC
 	hash_clean(vnc_hash, (void (*)(void *))encap_free);
 	hash_free(vnc_hash);
-	vnc_hash = NULL;
 #endif
 }
 
@@ -606,10 +603,8 @@ static void srv6_finish(void)
 {
 	hash_clean(srv6_l3vpn_hash, (void (*)(void *))srv6_l3vpn_free);
 	hash_free(srv6_l3vpn_hash);
-	srv6_l3vpn_hash = NULL;
 	hash_clean(srv6_vpn_hash, (void (*)(void *))srv6_vpn_free);
 	hash_free(srv6_vpn_hash);
-	srv6_vpn_hash = NULL;
 }
 
 static unsigned int transit_hash_key_make(const void *p)
@@ -638,7 +633,6 @@ static void transit_finish(void)
 {
 	hash_clean(transit_hash, (void (*)(void *))transit_free);
 	hash_free(transit_hash);
-	transit_hash = NULL;
 }
 
 /* Attribute hash routines. */
@@ -790,7 +784,6 @@ static void attrhash_finish(void)
 {
 	hash_clean(attrhash, attr_vfree);
 	hash_free(attrhash);
-	attrhash = NULL;
 }
 
 static void attr_show_all_iterator(struct hash_bucket *bucket, struct vty *vty)

--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -925,7 +925,6 @@ void community_finish(void)
 {
 	hash_clean(comhash, community_hash_free);
 	hash_free(comhash);
-	comhash = NULL;
 }
 
 static struct community *bgp_aggr_community_lookup(

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -381,7 +381,6 @@ void ecommunity_finish(void)
 {
 	hash_clean(ecomhash, (void (*)(void *))ecommunity_hash_free);
 	hash_free(ecomhash);
-	ecomhash = NULL;
 }
 
 /* Extended Communities token enum. */

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5962,15 +5962,9 @@ void bgp_evpn_cleanup(struct bgp *bgp)
 		     bgp);
 
 	hash_free(bgp->import_rt_hash);
-	bgp->import_rt_hash = NULL;
-
 	hash_free(bgp->vrf_import_rt_hash);
-	bgp->vrf_import_rt_hash = NULL;
-
 	hash_free(bgp->vni_svi_hash);
-	bgp->vni_svi_hash = NULL;
 	hash_free(bgp->vnihash);
-	bgp->vnihash = NULL;
 
 	list_delete(&bgp->vrf_import_rtl);
 	list_delete(&bgp->vrf_export_rtl);
@@ -6151,7 +6145,6 @@ static void bgp_evpn_remote_ip_hash_destroy(struct bgpevpn *vpn)
 	vpn);
 
 	hash_free(vpn->remote_ip_hash);
-	vpn->remote_ip_hash = NULL;
 }
 
 /* Add a remote MAC/IP route to hash table */

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -4613,7 +4613,6 @@ void bgp_evpn_nh_finish(struct bgp *bgp_vrf)
 		(void (*)(struct hash_bucket *, void *))bgp_evpn_nh_flush_cb,
 		NULL);
 	hash_free(bgp_vrf->evpn_nh_table);
-	bgp_vrf->evpn_nh_table = NULL;
 }
 
 static void bgp_evpn_nh_update_ref_pi(struct bgp_evpn_nh *nh)

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -350,7 +350,6 @@ void lcommunity_finish(void)
 {
 	hash_clean(lcomhash, (void (*)(void *))lcommunity_hash_free);
 	hash_free(lcomhash);
-	lcomhash = NULL;
 }
 
 /* Get next Large Communities token from the string.

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -189,7 +189,6 @@ void bgp_tip_hash_destroy(struct bgp *bgp)
 		return;
 	hash_clean(bgp->tip_hash, bgp_tip_hash_free);
 	hash_free(bgp->tip_hash);
-	bgp->tip_hash = NULL;
 }
 
 void bgp_tip_add(struct bgp *bgp, struct in_addr *tip)
@@ -313,7 +312,6 @@ void bgp_address_destroy(struct bgp *bgp)
 		return;
 	hash_clean(bgp->address_hash, bgp_address_hash_free);
 	hash_free(bgp->address_hash);
-	bgp->address_hash = NULL;
 }
 
 static void bgp_address_add(struct bgp *bgp, struct connected *ifc,

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1402,17 +1402,14 @@ void bgp_pbr_cleanup(struct bgp *bgp)
 	if (bgp->pbr_match_hash) {
 		hash_clean(bgp->pbr_match_hash, bgp_pbr_match_free);
 		hash_free(bgp->pbr_match_hash);
-		bgp->pbr_match_hash = NULL;
 	}
 	if (bgp->pbr_rule_hash) {
 		hash_clean(bgp->pbr_rule_hash, bgp_pbr_rule_free);
 		hash_free(bgp->pbr_rule_hash);
-		bgp->pbr_rule_hash = NULL;
 	}
 	if (bgp->pbr_action_hash) {
 		hash_clean(bgp->pbr_action_hash, bgp_pbr_action_free);
 		hash_free(bgp->pbr_action_hash);
-		bgp->pbr_action_hash = NULL;
 	}
 	if (bgp->bgp_pbr_cfg == NULL)
 		return;

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1672,10 +1672,8 @@ void update_bgp_group_free(struct bgp *bgp)
 	int afid;
 
 	AF_FOREACH (afid) {
-		if (bgp->update_groups[afid]) {
+		if (bgp->update_groups[afid])
 			hash_free(bgp->update_groups[afid]);
-			bgp->update_groups[afid] = NULL;
-		}
 	}
 }
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3787,10 +3787,8 @@ void bgp_free(struct bgp *bgp)
 	list_delete(&bgp->group);
 	list_delete(&bgp->peer);
 
-	if (bgp->peerhash) {
+	if (bgp->peerhash)
 		hash_free(bgp->peerhash);
-		bgp->peerhash = NULL;
-	}
 
 	FOREACH_AFI_SAFI (afi, safi) {
 		/* Special handling for 2-level routing tables. */

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -257,7 +257,6 @@ void isis_vertex_del(struct isis_vertex *vertex)
 	if (vertex->firsthops) {
 		hash_clean(vertex->firsthops, NULL);
 		hash_free(vertex->firsthops);
-		vertex->firsthops = NULL;
 	}
 
 	memset(vertex, 0, sizeof(struct isis_vertex));

--- a/isisd/isis_spf_private.h
+++ b/isisd/isis_spf_private.h
@@ -216,7 +216,6 @@ static void isis_vertex_queue_free(struct isis_vertex_queue *queue)
 	isis_vertex_queue_clear(queue);
 
 	hash_free(queue->hash);
-	queue->hash = NULL;
 
 	if (queue->insert_counter) {
 		skiplist_free(queue->l.slist);

--- a/lib/command.c
+++ b/lib/command.c
@@ -2604,7 +2604,6 @@ void cmd_terminate(void)
 				vector_free(cmd_node->cmd_vector);
 				hash_clean(cmd_node->cmd_hash, NULL);
 				hash_free(cmd_node->cmd_hash);
-				cmd_node->cmd_hash = NULL;
 			}
 
 		vector_free(cmdvec);

--- a/lib/ferr.c
+++ b/lib/ferr.c
@@ -193,7 +193,6 @@ void log_ref_fini(void)
 	frr_with_mutex (&refs_mtx) {
 		hash_clean(refs, NULL);
 		hash_free(refs);
-		refs = NULL;
 	}
 }
 

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -3251,13 +3251,10 @@ void route_map_finish(void)
 		route_map_delete(map);
 	}
 
-	for (i = 1; i < ROUTE_MAP_DEP_MAX; i++) {
+	for (i = 1; i < ROUTE_MAP_DEP_MAX; i++)
 		hash_free(route_map_dep_hash[i]);
-		route_map_dep_hash[i] = NULL;
-	}
 
 	hash_free(route_map_master_hash);
-	route_map_master_hash = NULL;
 }
 
 /* Increment the use_count counter while attaching the route map */

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -743,7 +743,6 @@ void thread_master_free(struct thread_master *m)
 
 	hash_clean(m->cpu_record, cpu_record_hash_free);
 	hash_free(m->cpu_record);
-	m->cpu_record = NULL;
 
 	XFREE(MTYPE_THREAD_MASTER, m->name);
 	XFREE(MTYPE_THREAD_MASTER, m->handler.pfds);

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -208,7 +208,6 @@ void nhrp_peer_interface_del(struct interface *ifp)
 		hash_clean(nifp->peer_hash, do_peer_hash_free);
 		assert(nifp->peer_hash->count == 0);
 		hash_free(nifp->peer_hash);
-		nifp->peer_hash = NULL;
 	}
 }
 

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -3175,7 +3175,6 @@ void ospf6_external_aggregator_free(struct ospf6_external_aggr_rt *aggr)
 						&aggr->p);
 
 	hash_free(aggr->match_extnl_hash);
-	aggr->match_extnl_hash = NULL;
 
 	XFREE(MTYPE_OSPF6_EXTERNAL_RT_AGGR, aggr);
 }

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -473,7 +473,6 @@ void ospf_external_aggregator_free(struct ospf_external_aggr_rt *aggr)
 		zlog_debug("%s: Release the aggregator Address(%pI4/%d)",
 			   __func__, &aggr->p.prefix, aggr->p.prefixlen);
 	hash_free(aggr->match_extnl_hash);
-	aggr->match_extnl_hash = NULL;
 
 	XFREE(MTYPE_OSPF_EXTERNAL_RT_AGGR, aggr);
 }

--- a/ospfd/ospf_gr_helper.c
+++ b/ospfd/ospf_gr_helper.c
@@ -116,7 +116,6 @@ static void ospf_enable_rtr_hash_destroy(struct ospf *ospf)
 
 	hash_clean(ospf->enable_rtr_list, ospf_disable_rtr_hash_free);
 	hash_free(ospf->enable_rtr_list);
-	ospf->enable_rtr_list = NULL;
 }
 
 /*

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -61,7 +61,6 @@ static void pim_instance_terminate(struct pim_instance *pim)
 	if (pim->rpf_hash) {
 		hash_clean(pim->rpf_hash, (void *)pim_rp_list_hash_clean);
 		hash_free(pim->rpf_hash);
-		pim->rpf_hash = NULL;
 	}
 
 	pim_if_terminate(pim);

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -1383,7 +1383,6 @@ void pim_msdp_exit(struct pim_instance *pim)
 	if (pim->msdp.peer_hash) {
 		hash_clean(pim->msdp.peer_hash, NULL);
 		hash_free(pim->msdp.peer_hash);
-		pim->msdp.peer_hash = NULL;
 	}
 
 	if (pim->msdp.peer_list) {
@@ -1393,7 +1392,6 @@ void pim_msdp_exit(struct pim_instance *pim)
 	if (pim->msdp.sa_hash) {
 		hash_clean(pim->msdp.sa_hash, NULL);
 		hash_free(pim->msdp.sa_hash);
-		pim->msdp.sa_hash = NULL;
 	}
 
 	if (pim->msdp.sa_list) {

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -61,7 +61,6 @@ void pim_rp_list_hash_clean(void *data)
 
 	hash_clean(pnc->upstream_hash, NULL);
 	hash_free(pnc->upstream_hash);
-	pnc->upstream_hash = NULL;
 	if (pnc->nexthop)
 		nexthops_free(pnc->nexthop);
 

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -1191,7 +1191,6 @@ void pim_vxlan_exit(struct pim_instance *pim)
 		hash_clean(pim->vxlan.sg_hash,
 			   (void (*)(void *))pim_vxlan_sg_del_item);
 		hash_free(pim->vxlan.sg_hash);
-		pim->vxlan.sg_hash = NULL;
 	}
 }
 

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1937,7 +1937,6 @@ void kernel_router_terminate(void)
 	pthread_mutex_destroy(&nlsock_mutex);
 
 	hash_free(nlsock_hash);
-	nlsock_hash = NULL;
 }
 
 #endif /* HAVE_NETLINK */

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -1049,11 +1049,9 @@ int zebra_evpn_del(struct zebra_evpn *zevpn)
 
 	/* Free the neighbor hash table. */
 	hash_free(zevpn->neigh_table);
-	zevpn->neigh_table = NULL;
 
 	/* Free the MAC hash table. */
 	hash_free(zevpn->mac_table);
-	zevpn->mac_table = NULL;
 
 	/* Remove references to the zevpn in the MH databases */
 	if (zevpn->vxlan_if)

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1717,11 +1717,9 @@ static int zl3vni_del(struct zebra_l3vni *zl3vni)
 
 	/* Free the rmac table */
 	hash_free(zl3vni->rmac_table);
-	zl3vni->rmac_table = NULL;
 
 	/* Free the nh table */
 	hash_free(zl3vni->nh_table);
-	zl3vni->nh_table = NULL;
 
 	/* Free the VNI hash entry and allocated memory. */
 	tmp_zl3vni = hash_release(zrouter.l3vni_table, zl3vni);
@@ -5888,7 +5886,6 @@ void zebra_vxlan_close_tables(struct zebra_vrf *zvrf)
 	if (zvrf->vxlan_sg_table) {
 		zebra_vxlan_cleanup_sg_table(zvrf);
 		hash_free(zvrf->vxlan_sg_table);
-		zvrf->vxlan_sg_table = NULL;
 	}
 }
 


### PR DESCRIPTION
hash_free() -> XFREE() does the same.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>