### PR TITLE
pim6d: Removing the temporary enabled debugs.

### DIFF
--- a/pimd/pim6_main.c
+++ b/pimd/pim6_main.c
@@ -161,8 +161,6 @@ int main(int argc, char **argv, char **envp)
 	}
 
 	pim_router_init();
-	/* TODO PIM6: temporary enable all debugs, remove later in PIMv6 work */
-	router->debugs = ~0U;
 
 	access_list_init();
 	prefix_list_init();


### PR DESCRIPTION
Debug pimv6 cli's are implemented.
Therefore removing this.

Signed-off-by: Abhishek N R <abnr@vmware.com>