### PR TITLE
isisd: Correct Valgrind errors

### DIFF
--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -217,6 +217,11 @@ void isis_circuit_del(struct isis_circuit *circuit)
 	list_delete(&circuit->ipv6_link);
 	list_delete(&circuit->ipv6_non_link);
 
+	if (circuit->ext) {
+		isis_del_ext_subtlvs(circuit->ext);
+		circuit->ext = NULL;
+	}
+
 	XFREE(MTYPE_TMP, circuit->bfd_config.profile);
 	XFREE(MTYPE_ISIS_CIRCUIT, circuit->tag);
 

--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -1253,6 +1253,9 @@ void isis_sr_area_term(struct isis_area *area)
 	if (area->srdb.enabled)
 		isis_sr_stop(area);
 
+	/* Free Adjacency SID list */
+	list_delete(&srdb->adj_sids);
+
 	/* Clear Prefix-SID configuration. */
 	while (srdb_prefix_cfg_count(&srdb->config.prefix_sids) > 0) {
 		struct sr_prefix_cfg *pcfg;

--- a/isisd/isis_te.h
+++ b/isisd/isis_te.h
@@ -123,6 +123,9 @@ enum lsp_event { LSP_UNKNOWN, LSP_ADD, LSP_UPD, LSP_DEL, LSP_INC, LSP_TICK };
 
 /* Prototypes. */
 void isis_mpls_te_init(void);
+void isis_mpls_te_create(struct isis_area *area);
+void isis_mpls_te_disable(struct isis_area *area);
+void isis_mpls_te_term(struct isis_area *area);
 void isis_link_params_update(struct isis_circuit *, struct interface *);
 int isis_mpls_te_update(struct interface *);
 void isis_te_lsp_event(struct isis_lsp *lsp, enum lsp_event event);

--- a/isisd/isis_tlvs.h
+++ b/isisd/isis_tlvs.h
@@ -597,6 +597,7 @@ void isis_tlvs_add_ipv6_dstsrc_reach(struct isis_tlvs *tlvs, uint16_t mtid,
 				     struct prefix_ipv6 *src,
 				     uint32_t metric);
 struct isis_ext_subtlvs *isis_alloc_ext_subtlvs(void);
+void isis_del_ext_subtlvs(struct isis_ext_subtlvs *ext);
 void isis_tlvs_add_adj_sid(struct isis_ext_subtlvs *exts,
 			   struct isis_adj_sid *adj);
 void isis_tlvs_del_adj_sid(struct isis_ext_subtlvs *exts,


### PR DESCRIPTION
Running most of isisd tests with --valgrind-memleaks give many memory errors.
This is due to the way isisd is stopped: performing a "no router isis XXX"
through CLI solves most of them. Indeed, `isis_finish()` doesn't call
`isis_area_destroy()` leaving many allocated memory not freed.

This patch adds call to appropriate delete functions or XFREE() when necessary
to properly free all allocated memory before terminating isisd.

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>