### PR TITLE
bgpd: conditional adv fixes

### DIFF
--- a/bgpd/bgp_conditional_adv.c
+++ b/bgpd/bgp_conditional_adv.c
@@ -258,6 +258,25 @@ static void bgp_conditional_adv_timer(struct thread *t)
 						? UPDATE_TYPE_WITHDRAW
 						: UPDATE_TYPE_ADVERTISE;
 
+			/*
+			 * Update condadv update type so
+			 * subgroup_announce_check() can properly apply
+			 * outbound policy according to advertisement state
+			 */
+			paf = peer_af_find(peer, afi, safi);
+			if (paf && (SUBGRP_PEER(PAF_SUBGRP(paf))
+					    ->filter[afi][safi]
+					    .advmap.update_type !=
+				    filter->advmap.update_type)) {
+				/* Handle change to peer advmap */
+				if (BGP_DEBUG(update, UPDATE_OUT))
+					zlog_debug(
+						"%s: advmap.update_type changed for peer %s, adjusting update_group.",
+						__func__, peer->host);
+
+				update_group_adjust_peer(paf);
+			}
+
 			/* Send regular update as per the existing policy.
 			 * There is a change in route-map, match-rule, ACLs,
 			 * or route-map filter configuration on the same peer.
@@ -270,11 +289,10 @@ static void bgp_conditional_adv_timer(struct thread *t)
 						__func__, peer->host,
 						get_afi_safi_str(afi, safi,
 								 false));
-
-				paf = peer_af_find(peer, afi, safi);
 				if (paf) {
 					update_subgroup_split_peer(paf, NULL);
 					subgrp = paf->subgroup;
+
 					if (subgrp && subgrp->update_group)
 						subgroup_announce_table(
 							paf->subgroup, NULL);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2212,6 +2212,32 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 	bgp_peer_remove_private_as(bgp, afi, safi, peer, attr);
 	bgp_peer_as_override(bgp, afi, safi, peer, attr);
 
+	if (filter->advmap.update_type == UPDATE_TYPE_WITHDRAW &&
+	    filter->advmap.aname &&
+	    route_map_lookup_by_name(filter->advmap.aname)) {
+		struct bgp_path_info rmap_path = {0};
+		struct bgp_path_info_extra dummy_rmap_path_extra = {0};
+		struct attr dummy_attr = *attr;
+
+		/* Fill temp path_info */
+		prep_for_rmap_apply(&rmap_path, &dummy_rmap_path_extra, dest,
+				    pi, peer, &dummy_attr);
+
+		struct route_map *amap =
+			route_map_lookup_by_name(filter->advmap.aname);
+
+		ret = route_map_apply(amap, p, &rmap_path);
+
+		bgp_attr_flush(&dummy_attr);
+
+		/*
+		 * The conditional advertisement mode is Withdraw and this
+		 * prefix is a conditional prefix. Don't advertise it
+		 */
+		if (ret == RMAP_PERMITMATCH)
+			return false;
+	}
+
 	/* Route map & unsuppress-map apply. */
 	if (!post_attr &&
 	    (ROUTE_MAP_OUT_NAME(filter) || bgp_path_suppressed(pi))) {

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -218,6 +218,8 @@ static void conf_copy(struct peer *dst, struct peer *src, afi_t afi,
 			MTYPE_BGP_FILTER_NAME, CONDITION_MAP_NAME(srcfilter));
 		CONDITION_MAP(dstfilter) = CONDITION_MAP(srcfilter);
 	}
+
+	dstfilter->advmap.update_type = srcfilter->advmap.update_type;
 }
 
 /**
@@ -388,6 +390,9 @@ static unsigned int updgrp_hash_key_make(const void *p)
 		key = jhash_1word(jhash(filter->advmap.aname,
 					strlen(filter->advmap.aname), SEED1),
 				  key);
+
+	if (filter->advmap.update_type)
+		key = jhash_1word(filter->advmap.update_type, key);
 
 	if (peer->default_rmap[afi][safi].name)
 		key = jhash_1word(
@@ -586,6 +591,9 @@ static bool updgrp_hash_cmp(const void *p1, const void *p2)
 	    || (!fl1->advmap.aname && fl2->advmap.aname)
 	    || (fl1->advmap.aname && fl2->advmap.aname
 		&& strcmp(fl1->advmap.aname, fl2->advmap.aname)))
+		return false;
+
+	if (fl1->advmap.update_type != fl2->advmap.update_type)
 		return false;
 
 	if ((pe1->default_rmap[afi][safi].name


### PR DESCRIPTION
A couple of fixes for bgp conditional advertisement, mostly authored by Quentin:

- The new outbound filter to apply conditional advertisement policy was not working properly due to complications with update groups. The two routemaps were properly copied into the update group peer filter but not the conditional advertisement state. If the adv state changes, that will change the update_group's hash, so ensure that the peer/update_group/subgroup relationships are updated.
- If we have conditional advertisement enabled, and conditionally withdrew some prefixes, and then we do a 'clear bgp', those routes were getting advertised again, and then withdrawn the next time the conditional advertisement scanner executed. When we go to advertise check the prefix against the conditional advertisement status so we don't do that.

This is an update of #9668 