### PR TITLE
bfdd: Some interfaces don't have mac addresses

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -1683,6 +1683,8 @@ void bfd_peer_mac_set(int sd, struct bfd_session *bfd,
 
 	if (CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_MAC_SET))
 		return;
+	if (ifp->flags & IFF_NOARP)
+		return;
 
 	if (peer->sa_sin.sin_family == AF_INET) {
 		/* IPV4 */
@@ -1696,8 +1698,9 @@ void bfd_peer_mac_set(int sd, struct bfd_session *bfd,
 		strlcpy(arpreq_.arp_dev, ifp->name, sizeof(arpreq_.arp_dev));
 
 		if (ioctl(sd, SIOCGARP, &arpreq_) < 0) {
-			zlog_warn("BFD: getting peer's mac failed error %s",
-				  strerror(errno));
+			zlog_warn(
+				"BFD: getting peer's mac on %s failed error %s",
+				ifp->name, strerror(errno));
 			UNSET_FLAG(bfd->flags, BFD_SESS_FLAG_MAC_SET);
 			memset(bfd->peer_hw_addr, 0, sizeof(bfd->peer_hw_addr));
 


### PR DESCRIPTION
When an interface does not have a mac address, don't
try to retrieve the mac address ( for it to just fail ).

Example interface:
sharpd@eva [2]> ip link show tun100
21: tun100@NONE: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1480 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ipip 192.168.119.224 peer 192.168.119.120

Let's just notice that there is a NOARP flag and abort the call.

Fixes: #11733
Signed-off-by: Donald Sharp <sharpd@nvidia.com>