### PR TITLE
staticd: When changing the underlying nh ensure it is reinstalled

### DIFF
--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -263,6 +263,7 @@ nexthop_mpls_label_stack_entry_destroy(struct nb_cb_destroy_args *args)
 	struct static_nexthop *nh;
 	uint32_t pos;
 	uint8_t index;
+	uint old_num_labels;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -278,8 +279,12 @@ nexthop_mpls_label_stack_entry_destroy(struct nb_cb_destroy_args *args)
 			return NB_ERR;
 		}
 		index = pos - 1;
+		old_num_labels = nh->snh_label.num_labels;
 		nh->snh_label.label[index] = 0;
 		nh->snh_label.num_labels--;
+
+		if (old_num_labels != nh->snh_label.num_labels)
+			nh->state = STATIC_START;
 		break;
 	}
 
@@ -291,6 +296,7 @@ static int static_nexthop_mpls_label_modify(struct nb_cb_modify_args *args)
 	struct static_nexthop *nh;
 	uint32_t pos;
 	uint8_t index;
+	mpls_label_t old_label;
 
 	nh = nb_running_get_entry(args->dnode, NULL, true);
 	pos = yang_get_list_pos(lyd_parent(args->dnode));
@@ -301,7 +307,12 @@ static int static_nexthop_mpls_label_modify(struct nb_cb_modify_args *args)
 	}
 	/* Mapping to array = list-index -1 */
 	index = pos - 1;
+
+	old_label = nh->snh_label.label[index];
 	nh->snh_label.label[index] = yang_dnode_get_uint32(args->dnode, NULL);
+
+	if (old_label != nh->snh_label.label[index])
+		nh->state = STATIC_START;
 
 	return NB_OK;
 }
@@ -310,6 +321,7 @@ static int static_nexthop_onlink_modify(struct nb_cb_modify_args *args)
 {
 	struct static_nexthop *nh;
 	enum static_nh_type nh_type;
+	bool old_onlink;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -327,7 +339,11 @@ static int static_nexthop_onlink_modify(struct nb_cb_modify_args *args)
 		break;
 	case NB_EV_APPLY:
 		nh = nb_running_get_entry(args->dnode, NULL, true);
+		old_onlink = nh->onlink;
 		nh->onlink = yang_dnode_get_bool(args->dnode, NULL);
+
+		if (old_onlink != nh->onlink)
+			nh->state = STATIC_START;
 		break;
 	}
 
@@ -337,9 +353,14 @@ static int static_nexthop_onlink_modify(struct nb_cb_modify_args *args)
 static int static_nexthop_color_modify(struct nb_cb_modify_args *args)
 {
 	struct static_nexthop *nh;
+	uint32_t old_color;
 
 	nh = nb_running_get_entry(args->dnode, NULL, true);
+	old_color = nh->color;
 	nh->color = yang_dnode_get_uint32(args->dnode, NULL);
+
+	if (old_color != nh->color)
+		nh->state = STATIC_START;
 
 	return NB_OK;
 }
@@ -347,9 +368,14 @@ static int static_nexthop_color_modify(struct nb_cb_modify_args *args)
 static int static_nexthop_color_destroy(struct nb_cb_destroy_args *args)
 {
 	struct static_nexthop *nh;
+	uint32_t old_color;
 
 	nh = nb_running_unset_entry(args->dnode);
+	old_color = nh->color;
 	nh->color = 0;
+
+	if (old_color != nh->color)
+		nh->state = STATIC_START;
 
 	return NB_OK;
 }


### PR DESCRIPTION
There exists some nexthop attributes that are not the unique
part of the nexthop and if you change the static route
with those values then the route is not being updated
in zebra with the new values:

Example of brokenness:

eva# conf
eva(config)# ip route 1.2.3.9/32 192.168.119.1 enp39s0 label 16020
eva(config)# do show ip route 1.2.3.9
Routing entry for 1.2.3.9/32
  Known via "static", distance 1, metric 0, best
  Last update 00:00:05 ago
  * 192.168.119.1, via enp39s0, label 16020, weight 1

eva(config)# ip route 1.2.3.9/32 192.168.119.1 enp39s0 label 16040
eva(config)# do show ip route 1.2.3.9
Routing entry for 1.2.3.9/32
  Known via "static", distance 1, metric 0, best
  Last update 00:00:12 ago
  * 192.168.119.1, via enp39s0, label 16020, weight 1

Fixed behavior:

eva# conf
eva(config)# ip route 1.2.3.10/32 192.168.119.1 enp39s0 label 16020
eva(config)# do show ip route 1.2.3.10
Routing entry for 1.2.3.10/32
  Known via "static", distance 1, metric 0, best
  Last update 00:00:04 ago
  * 192.168.119.1, via enp39s0, label 16020, weight 1

eva(config)# ip route 1.2.3.10/32 192.168.119.1 enp39s0 label 16040
eva(config)# do show ip route 1.2.3.10
Routing entry for 1.2.3.10/32
  Known via "static", distance 1, metric 0, best
  Last update 00:00:01 ago
  * 192.168.119.1, via enp39s0, label 16040, weight 1

I've gone through most of the items in staticd that can change
the nexthop
Signed-off-by: Donald Sharp <sharpd@nvidia.com>