### PR TITLE
ospf6d: Remove ospf6Enabled from JSON output

### DIFF
--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -966,10 +966,6 @@ static const char *ospf6_iftype_str(uint8_t iftype)
 	return "UNKNOWN";
 }
 
-#if CONFDATE > 20220709
-CPP_NOTICE("Time to remove ospf6Enabled from JSON output")
-#endif
-
 /* show specified interface structure */
 static int ospf6_interface_show(struct vty *vty, struct interface *ifp,
 				json_object *json_obj, bool use_json)
@@ -996,11 +992,8 @@ static int ospf6_interface_show(struct vty *vty, struct interface *ifp,
 				       ospf6_iftype_str(default_iftype));
 		json_object_int_add(json_obj, "interfaceId", ifp->ifindex);
 
-		if (ifp->info == NULL) {
-			json_object_boolean_false_add(json_obj, "ospf6Enabled");
+		if (ifp->info == NULL)
 			return 0;
-		}
-		json_object_boolean_true_add(json_obj, "ospf6Enabled");
 
 		oi = (struct ospf6_interface *)ifp->info;
 

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_single_area.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_single_area.py
@@ -183,7 +183,7 @@ def test_ospfv3_p2p_tc3_p0(request):
     step("Verify that interface is enabled in ospf.")
     step("Verify that config is successful.")
     dut = "r0"
-    input_dict = {"r0": {"links": {"r3": {"ospf6": {"ospf6Enabled": True}}}}}
+    input_dict = {"r0": {"links": {"r3": {"ospf6": {}}}}}
     result = verify_ospf6_interface(tgen, topo, dut=dut, input_dict=input_dict)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
@@ -339,7 +339,7 @@ def test_ospfv3_p2p_tc3_p0(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
     step("Verify that interface is enabled in ospf.")
     dut = "r0"
-    input_dict = {"r0": {"links": {"r3": {"ospf6": {"ospf6Enabled": True}}}}}
+    input_dict = {"r0": {"links": {"r3": {"ospf6": {}}}}}
     result = verify_ospf6_interface(tgen, topo, dut=dut, input_dict=input_dict)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
@@ -374,7 +374,7 @@ def test_ospfv3_p2p_tc3_p0(request):
 
     step("Verify that interface is enabled in ospf.")
     dut = "r0"
-    input_dict = {"r0": {"links": {"r3": {"ospf6": {"ospf6Enabled": True}}}}}
+    input_dict = {"r0": {"links": {"r3": {"ospf6": {}}}}}
     result = verify_ospf6_interface(tgen, topo, dut=dut, input_dict=input_dict)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
@@ -1172,7 +1172,6 @@ def test_ospfv3_show_p1(request):
                     "ospf6": {
                         "status": "up",
                         "type": "BROADCAST",
-                        "ospf6Enabled": True,
                         "attachedToArea": True,
                         "instanceId": 0,
                         "interfaceMtu": 1500,


### PR DESCRIPTION
Time to deprecate it.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>