### PR TITLE
zebra: Fix crash in shutdown w/ pw thread still running

### DIFF
--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -101,13 +101,15 @@ void zebra_pw_del(struct zebra_vrf *zvrf, struct zebra_pw *pw)
 	if (pw->status == PW_FORWARDING) {
 		hook_call(pw_uninstall, pw);
 		dplane_pw_uninstall(pw);
-	} else if (pw->install_retry_timer)
-		THREAD_OFF(pw->install_retry_timer);
+	}
+
+	THREAD_OFF(pw->install_retry_timer);
 
 	/* unlink and release memory */
 	RB_REMOVE(zebra_pw_head, &zvrf->pseudowires, pw);
 	if (pw->protocol == ZEBRA_ROUTE_STATIC)
 		RB_REMOVE(zebra_static_pw_head, &zvrf->static_pseudowires, pw);
+
 	XFREE(MTYPE_PW, pw);
 }
 
@@ -230,7 +232,6 @@ static void zebra_pw_install_retry(struct thread *thread)
 {
 	struct zebra_pw *pw = THREAD_ARG(thread);
 
-	pw->install_retry_timer = NULL;
 	zebra_pw_install(pw);
 }
 


### PR DESCRIPTION
I am seeing the zebra_pw_install_retry timer thread crashing
on shutdown

The shutdown of the timer is only in an
if () {
   ...
} else if

Let's just always shut it down.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>