### PR TITLE
redhat: Drop --enable-systemd from build specification

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -409,9 +409,6 @@ routing state through standard SNMP MIBs.
     --disable-bgp-vnc \
 %endif
     --enable-isisd \
-%if "%{initsystem}" == "systemd"
-    --enable-systemd \
-%endif
     --enable-rpki \
 %if %{with_bfdd}
     --enable-bfdd \


### PR DESCRIPTION
This option no longer exists.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>