### PR TITLE
lib: fix group case-sensitivity while configuring ipv6 address

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2138,7 +2138,7 @@ static void vtysh_read(struct thread *thread)
 		vty_out(vty, "%% Command is too long.\n");
 	} else {
 		for (p = buf; p < buf + nbytes; p++) {
-			vty->buf[vty->length++] = *p;
+			vty->buf[vty->length++] = tolower(*p);
 			if (*p == '\0') {
 				/* Pass this line to parser. */
 				ret = vty_execute(vty);

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -429,7 +429,7 @@ DEFPY (ipv6_pim_rp,
        "ipv6 address of RP\n"
        "Group Address range to cover\n")
 {
-	const char *group_str = (gp_str) ? gp_str : "FF00::0/8";
+	const char *group_str = (gp_str) ? gp_str : "ff00::/8";
 
 	return pim_process_rp_cmd(vty, rp_str, group_str);
 }
@@ -444,7 +444,7 @@ DEFPY (no_ipv6_pim_rp,
        "ipv6 address of RP\n"
        "Group Address range to cover\n")
 {
-	const char *group_str = (gp_str) ? gp_str : "FF00::0/8";
+	const char *group_str = (gp_str) ? gp_str : "ff00::/8";
 
 	return pim_process_no_rp_cmd(vty, rp_str, group_str);
 }


### PR DESCRIPTION
Fixing the below 2 issues: 
Issue: #11810 

Issue 1:

frr(config)# ipv6 pim rp 1080::2 ff00::/8
frr(config)# no ipv6 pim rp 1080::2 FF00::/8
% Unable to find specified RP

Issue 2:
frr(config)# ipv6 pim rp 1080::2

frr(config)# no ipv6 pim rp 1080::2 ff00::/8
% Unable to find specified RP

frr(config)# no ipv6 pim rp 1080::2 FF00::/8
% Unable to find specified RP


Signed-off-by: Sarita Patra <saritap@vmware.com>