### PR TITLE
zebra: correct one comment about ethtool ioctl

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -423,7 +423,7 @@ static uint32_t get_iflink_speed(struct interface *interface, int *error)
 	ecmd.cmd = ETHTOOL_GSET; /* ETHTOOL_GLINK */
 	ifdata.ifr_data = (caddr_t)&ecmd;
 
-	/* use ioctl to get IP address of an interface */
+	/* use ioctl to get speed of an interface */
 	frr_with_privs(&zserv_privs) {
 		sd = vrf_socket(PF_INET, SOCK_DGRAM, IPPROTO_IP,
 				interface->vrf->vrf_id, NULL);
@@ -436,7 +436,7 @@ static uint32_t get_iflink_speed(struct interface *interface, int *error)
 				*error = -1;
 			return 0;
 		}
-	/* Get the current link state for the interface */
+		/* Get the current link state for the interface */
 		rc = vrf_ioctl(interface->vrf->vrf_id, sd, SIOCETHTOOL,
 			       (char *)&ifdata);
 	}


### PR DESCRIPTION
`get_iflink_speed()` uses ioctl to get speed, not ip address. Additionally
adjust format for another one comment line.