### PR TITLE
pim6d: Register message getting dropped in source node, mroute stuck in RegJ

### DIFF
--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -185,7 +185,7 @@ int pim_reg_sock(void)
 	long flags;
 
 	frr_with_privs (&pimd_privs) {
-		fd = socket(AF_INET, SOCK_RAW, IPPROTO_RAW);
+		fd = socket(PIM_AF, SOCK_RAW, IPPROTO_RAW);
 	}
 
 	if (fd < 0) {


### PR DESCRIPTION
The socket created for pimv6 was created using AF_INET for PIMV6
too.
Since the api pim_reg_sock is common to both PIMv4 and PIMv6,
need to use PIM_AF instead of AF_INET.

Fixes: #11815

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>