### PR TITLE
zebra: fix deadcodes in tc dplane & netlink

### DIFF
--- a/zebra/tc_netlink.c
+++ b/zebra/tc_netlink.c
@@ -294,7 +294,7 @@ static ssize_t netlink_tclass_msg_encode(int cmd, struct zebra_dplane_ctx *ctx,
 	htb_opt.cbuffer = cbuffer;
 
 	tc_calc_rate_table(&htb_opt.rate, rtab, mtu);
-	tc_calc_rate_table(&htb_opt.ceil, rtab, mtu);
+	tc_calc_rate_table(&htb_opt.ceil, ctab, mtu);
 
 	htb_opt.ceil.mpu = htb_opt.rate.mpu = 0;
 	htb_opt.ceil.overhead = htb_opt.rate.overhead = 0;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2775,14 +2775,13 @@ int dplane_ctx_tc_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op)
 {
 	int ret = EINVAL;
 
-	struct zebra_vrf *zvrf = NULL;
 	struct zebra_ns *zns = NULL;
 
 	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
 
 	/* TODO: init traffic control qdisc */
-	zns = zvrf ? zvrf->zns : zebra_ns_lookup(NS_DEFAULT);
+	zns = zebra_ns_lookup(NS_DEFAULT);
 
 	dplane_ctx_ns_init(ctx, zns, true);
 


### PR DESCRIPTION
zebra: fix deadcodes in tc dplane & netlink