### PR TITLE
tools: stop zebra daemon last

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -272,7 +272,7 @@ all_start() {
 }
 
 all_stop() {
-	local pids reversed
+	local pids reversed need_zebra
 
 	daemon_list enabled_daemons disabled_daemons
 	[ "$1" = "--reallyall" ] && enabled_daemons="$enabled_daemons $disabled_daemons"
@@ -282,13 +282,23 @@ all_stop() {
 		reversed="$dmninst $reversed"
 	done
 
+	# Stop zebra last, after trying to stop the other daemons
 	for dmninst in $reversed; do
+		if [ "$dmninst" = "zebra" ]; then
+			need_zebra="yes"
+			continue
+		fi
+
 		daemon_stop "$dmninst" "$1" &
 		pids="$pids $!"
 	done
 	for pid in $pids; do
 		wait $pid
 	done
+
+	if [ -n "$need_zebra" ]; then
+		daemon_stop "zebra"
+	fi
 }
 
 all_status() {


### PR DESCRIPTION
When stopping the FRR daemons, stop zebra last, after trying to stop the other daemons.
