### PR TITLE
zebra: remove unnecessary check for default vrf

### DIFF
--- a/zebra/table_manager.c
+++ b/zebra/table_manager.c
@@ -63,8 +63,7 @@ void table_manager_enable(struct zebra_vrf *zvrf)
 	    && strcmp(zvrf_name(zvrf), VRF_DEFAULT_NAME)) {
 		struct zebra_vrf *def = zebra_vrf_lookup_by_id(VRF_DEFAULT);
 
-		if (def)
-			zvrf->tbl_mgr = def->tbl_mgr;
+		zvrf->tbl_mgr = def->tbl_mgr;
 		return;
 	}
 	zvrf->tbl_mgr = XCALLOC(MTYPE_TM_TABLE, sizeof(struct table_manager));

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1337,8 +1337,6 @@ static void zread_fec_register(ZAPI_HANDLER_ARGS)
 
 	s = msg;
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf)
-		return;
 
 	/*
 	 * The minimum amount of data that can be sent for one fec
@@ -1400,8 +1398,6 @@ static void zread_fec_unregister(ZAPI_HANDLER_ARGS)
 
 	s = msg;
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf)
-		return;
 
 	/*
 	 * The minimum amount of data that can be sent for one

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -1029,8 +1029,6 @@ static void lsp_processq_del(struct work_queue *wq, void *data)
 		return;
 
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	assert(zvrf);
-
 	lsp_table = zvrf->lsp_table;
 	if (!lsp_table) // unexpected
 		return;
@@ -1776,9 +1774,6 @@ void zebra_mpls_lsp_dplane_result(struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_LSP_UPDATE:
 		/* Look for zebra LSP object */
 		zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-		if (zvrf == NULL)
-			break;
-
 		lsp_table = zvrf->lsp_table;
 
 		tmp_ile.in_label = label;
@@ -2093,9 +2088,6 @@ void zebra_mpls_process_dplane_notify(struct zebra_dplane_ctx *ctx)
 
 	/* Look for zebra LSP object */
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (zvrf == NULL)
-		return;
-
 	lsp_table = zvrf->lsp_table;
 
 	tmp_ile.in_label = dplane_ctx_get_in_label(ctx);

--- a/zebra/zebra_mpls_vty.c
+++ b/zebra/zebra_mpls_vty.c
@@ -42,10 +42,6 @@ static int zebra_mpls_transit_lsp(struct vty *vty, int add_cmd,
 	}
 
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf) {
-		vty_out(vty, "%% Default VRF does not exist\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
 
 	if (!inlabel_str) {
 		vty_out(vty, "%% No Label Information\n");
@@ -186,10 +182,6 @@ static int zebra_mpls_bind(struct vty *vty, int add_cmd, const char *prefix,
 	int ret;
 
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf) {
-		vty_out(vty, "%% Default VRF does not exist\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
 
 	memset(&p, 0, sizeof(p));
 	ret = str2prefix(prefix, &p);
@@ -274,8 +266,6 @@ static int zebra_mpls_config(struct vty *vty)
 	struct zebra_vrf *zvrf;
 
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf)
-		return 0;
 
 	write += zebra_mpls_write_lsp_config(vty, zvrf);
 	write += zebra_mpls_write_fec_config(vty, zvrf);
@@ -297,8 +287,6 @@ DEFUN (show_mpls_fec,
 	int ret;
 
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf)
-		return 0;
 
 	if (argc == 3)
 		zebra_mpls_print_fec_table(vty, zvrf);
@@ -373,10 +361,6 @@ static int zebra_mpls_global_block(struct vty *vty, int add_cmd,
 	struct zebra_vrf *zvrf;
 
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf) {
-		vty_out(vty, "%% Default VRF does not exist\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
 
 	if (add_cmd) {
 		if (!start_label_str || !end_label_str) {

--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -408,8 +408,6 @@ DEFUN_NOSH (pseudowire_if,
 	int idx = 0;
 
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf)
-		return CMD_WARNING;
 
 	argv_find(argv, argc, "IFNAME", &idx);
 	ifname = argv[idx]->arg;
@@ -440,8 +438,6 @@ DEFUN (no_pseudowire_if,
 	int idx = 0;
 
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf)
-		return CMD_WARNING;
 
 	argv_find(argv, argc, "IFNAME", &idx);
 	ifname = argv[idx]->arg;
@@ -564,8 +560,6 @@ DEFUN (show_pseudowires,
 	struct zebra_pw *pw;
 
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf)
-		return 0;
 
 	vty_out(vty, "%-16s %-24s %-12s %-8s %-10s\n", "Interface", "Neighbor",
 		"Labels", "Protocol", "Status");
@@ -603,8 +597,6 @@ static void vty_show_mpls_pseudowire_detail(struct vty *vty)
 	struct nexthop_group *nhg;
 
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf)
-		return;
 
 	RB_FOREACH (pw, zebra_pw_head, &zvrf->pseudowires) {
 		char buf_nbr[INET6_ADDRSTRLEN];
@@ -759,8 +751,6 @@ static void vty_show_mpls_pseudowire_detail_json(struct vty *vty)
 	struct zebra_pw *pw;
 
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf)
-		return;
 
 	json = json_object_new_object();
 	json_pws = json_object_new_array();
@@ -795,8 +785,6 @@ static int zebra_pw_config(struct vty *vty)
 	struct zebra_pw *pw;
 
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf)
-		return 0;
 
 	RB_FOREACH (pw, zebra_static_pw_head, &zvrf->static_pseudowires) {
 		vty_out(vty, "pseudowire %s\n", pw->ifname);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2703,12 +2703,7 @@ DEFUN (default_vrf_vni_mapping,
        "Prefix routes only \n")
 {
 	char xpath[XPATH_MAXLEN];
-	struct zebra_vrf *zvrf = NULL;
 	int filter = 0;
-
-	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf)
-		return CMD_WARNING;
 
 	if (argc == 3)
 		filter = 1;
@@ -2746,8 +2741,6 @@ DEFUN (no_default_vrf_vni_mapping,
 	struct zebra_vrf *zvrf = NULL;
 
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
-	if (!zvrf)
-		return CMD_WARNING;
 
 	if (argc == 4)
 		filter = 1;

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5937,8 +5937,6 @@ static void zebra_vxlan_sg_del(struct zebra_vxlan_sg *vxlan_sg)
 	struct zebra_vrf *zvrf;
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
-	if (!zvrf)
-		return;
 
 	/* On SG entry deletion remove the reference to its parent XG
 	 * entry
@@ -6008,8 +6006,6 @@ void zebra_vxlan_sg_deref(struct in_addr local_vtep_ip,
 		return;
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
-	if (!zvrf)
-		return;
 
 	zebra_vxlan_sg_do_deref(zvrf, local_vtep_ip, mcast_grp);
 }
@@ -6023,8 +6019,7 @@ void zebra_vxlan_sg_ref(struct in_addr local_vtep_ip, struct in_addr mcast_grp)
 		return;
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
-	if (!zvrf)
-		return;
+
 	zebra_vxlan_sg_do_ref(zvrf, local_vtep_ip, mcast_grp);
 }
 


### PR DESCRIPTION
Though default vrf must be non-NULL, there are some places to use unnecessary
check or assert. Let them unify the form - remove the redundant things.