### PR TITLE
debian: add lua _binary_ to build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,6 +30,7 @@ Build-Depends: bison,
                python3-pytest <!nocheck>,
                python3-sphinx,
                texinfo (>= 4.7),
+               lua5.3 <pkg.frr.lua>,
                liblua5.3-dev <pkg.frr.lua>
 Standards-Version: 4.5.0.3
 Homepage: https://www.frrouting.org/


### PR DESCRIPTION
FRR only needs lua library (package libluaX.Y-dev) to be compiled and
linked, but its `configure` script makes use of lua interpreter to
perform its checks. Therefore, `luaX.Y` package is a requisite
build-dependency for debian packaging.

This commit adds the debian package with the lua interpreter to the
build dependencies.

Closes: #11834
Signed-off-by: Eugene Crosser <crosser@average.org>