### PR TITLE
nhrpd: Use nhrp_interface_update_nbma when source vrf was changed

### DIFF
--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -165,8 +165,7 @@ static void nhrp_interface_interface_notifier(struct notifier_block *n,
 
 	switch (cmd) {
 	case NOTIFY_INTERFACE_CHANGED:
-		nhrp_interface_update_mtu(nifp->ifp, AFI_IP);
-		nhrp_interface_update_source(nifp->ifp);
+		nhrp_interface_update_nbma(nifp->ifp, NULL);
 		break;
 	case NOTIFY_INTERFACE_ADDRESS_CHANGED:
 		nifp->nbma = nbmanifp->afi[AFI_IP].addr;


### PR DESCRIPTION
1. Run frr:
interface enp0s8
 ip address 193.168.1.2/24
exit
!
interface gre1
 ip address 10.8.1.2/32
 ip nhrp network-id 1
 ip nhrp nhs dynamic nbma 193.168.1.1
 tunnel source enp0s8
exit

Log:

NHS: Register 10.8.1.2 -> 10.8.1.2 (timeout 2)
Send Registration-Request(3) 10.8.1.2 -> 10.8.1.2
Recv Registration-Reply(4) 10.8.1.1 -> 10.8.1.2

2. Create VRF and move enp0s8 to VRF
ip link set enp0s8 master vrf1

Before patch:
NHS: Waiting link for 193.168.1.1

After patch:
NHS: Register 10.8.1.2 -> 10.8.1.2 (timeout 2)

Signed-off-by: Dmitrii Turlupov <dturlupov@factor-ts.ru>