### PR TITLE
ospf6d: Don't remove summary route if it is a range

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -488,7 +488,12 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 				zlog_debug(
 					"Suppressed by range %pFX of area %s",
 					&range->prefix, route_area->name);
-			ospf6_abr_delete_route(summary, summary_table, old);
+			/* The existing summary route could be a range, don't
+			 * remove it in this case
+			 */
+			if (summary && summary->type != OSPF6_DEST_TYPE_RANGE)
+				ospf6_abr_delete_route(summary, summary_table,
+						       old);
 			return 0;
 		}
 	}


### PR DESCRIPTION
Fix issue #11839.

When the user defines a range in an area other than the backbone area, the
summary route will be announced to the backbone area as an inter-area LSA.
However, if the prefix defined in the range is the same prefix as a connected
route in that area, the LSA won't be announced to the backbone area.

This is because when ospf6d is originating the summary route for the
intra-area route, it finds the range configured by the user and tries to
suppress the route by deleting the existing summary route, which happens to be
the one created by the range.

Although the range definition is not necessary in this case, it should not
fail this use case. So let's just keep the summary route there if it is
created from the user defined range.