### PR TITLE
tests: Log as error if some of the daemons are missing

### DIFF
--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -363,7 +363,7 @@ def pytest_configure(config):
 
     # Check environment now that we have config
     if not diagnose_env(rundir):
-        pytest.exit("environment has errors, please read the logs")
+        pytest.exit("environment has errors, please read the logs in %s" % rundir)
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -1293,7 +1293,7 @@ def diagnose_env_linux(rundir):
                     )
                     continue
 
-                logger.warning("could not find {} in {}".format(fname, frrdir))
+                logger.error("could not find {} in {}".format(fname, frrdir))
                 ret = False
             else:
                 if fname != "zebra":


### PR DESCRIPTION
Also print runtime directory for topotests if the error occurs.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>