### PR TITLE
ospfd: Adding per neighbour json details to GR helper detail command

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -10118,6 +10118,21 @@ static int ospf_print_vty_helper_dis_rtr_walkcb(struct hash_bucket *bucket,
 	return HASHWALK_CONTINUE;
 }
 
+static int ospf_print_json_helper_enabled_rtr_walkcb(struct hash_bucket *bucket,
+						     void *arg)
+{
+	struct advRtr *rtr = bucket->data;
+	struct json_object *json_rid_array = arg;
+	struct json_object *json_rid;
+
+	json_rid = json_object_new_object();
+
+	json_object_string_addf(json_rid, "routerId", "%pI4", &rtr->advRtrAddr);
+	json_object_array_add(json_rid_array, json_rid);
+
+	return HASHWALK_CONTINUE;
+}
+
 static int ospf_show_gr_helper_details(struct vty *vty, struct ospf *ospf,
 				       uint8_t use_vrf, json_object *json,
 				       bool uj, bool detail)
@@ -10237,6 +10252,18 @@ CPP_NOTICE("Remove JSON object commands with keys starting with capital")
 		if (ospf->active_restarter_cnt)
 			json_object_int_add(json_vrf, "activeRestarterCnt",
 					    ospf->active_restarter_cnt);
+
+		if (OSPF_HELPER_ENABLE_RTR_COUNT(ospf)) {
+			struct json_object *json_rid_array =
+				json_object_new_array();
+
+			json_object_object_add(json_vrf, "enabledRouterIds",
+					       json_rid_array);
+
+			hash_walk(ospf->enable_rtr_list,
+				  ospf_print_json_helper_enabled_rtr_walkcb,
+				  json_rid_array);
+		}
 	}
 
 


### PR DESCRIPTION
Description:
	Per neighbor GR enabled information is  missing from json
	output in "show ip ospf gr helper details json" command.

      Example config:

	frr(config-router)# graceful-restart helper enable 2.2.2.2
	frr(config-router)#
	frr(config-router)# do show ip ospf  graceful-restart helper  detail

       OSPF Router with ID (10.112.156.220)

	Graceful restart helper support disabled.
	Strict LSA check is enabled.
	Helper supported for Planned and Unplanned Restarts.
	Supported Graceful restart interval: 1800(in seconds).
	Enable Router list:
		2.2.2.2,

	frr(config-router)# do show ip ospf  graceful-restart helper  detail json
	{
	 "routerId":"10.112.156.220",
	 "helperSupport":"Disabled",
	 "strictLsaCheck":"Enabled",
	 "restartSupoort":"Planned and Unplanned Restarts",
	 "supportedGracePeriod":1800,
                              -------------------------------> Per  Neighbour helper details are missing 

	}
	frr(config-router)#

Signed-off-by: Rajesh Girada <rgirada@vmware.com>