### PR TITLE
gdb: Add a macro to walk memory allocations

### DIFF
--- a/gdb/lib.txt
+++ b/gdb/lib.txt
@@ -293,3 +293,25 @@ Arguments:
 1st: A (struct route_node *) to the top of the route table.
 2nd: The (struct route_node *) to walk up from
 end
+
+define mq_walk
+  set $mg = (struct memgroup *)$arg0
+
+  while ($mg)
+     printf "showing active allocations in memory group %s\n", $mg->name
+     set $mt = (struct memtype *)$mg->types
+     while ($mt)
+         printf "memstats: %s:%zu\n", $mt->name, $mt->n_alloc
+         set $mt = $mt->next
+     end
+     set $mg = $mg->next
+  end
+
+document mg_walk
+Walk the memory data structures to show what is holding memory.
+
+Arguments:
+1st: A (struct memgroup *) where to start the walk.  If you are not
+     sure where to start pass it mg_first, which is a global DS for
+     all memory allocated in FRR
+end


### PR DESCRIPTION
Add a macro to walk all memory allocations in a core file.

load the file in gdb:
source /path/to/frr/gdb/lib.txt
mg_walk mg_first
(gdb) mq_walk mg_first
showing active allocations in memory group libfrr
memstats: BFD info:0
memstats: Buffer:5
memstats: Buffer data:0
memstats: Host config:6
memstats: Completion item:0
memstats: Command Tokens:2585
memstats: Command Token Text:1951
memstats: Command Token Help:1951
memstats: Command Argument:0
memstats: Command Argument Name:575
memstats: Command Match Stack:0
memstats: Lexer token (temporary):0
memstats: Path Computation Algorithms:0
memstats: Distribute ctx:0
memstats: Distribute list:0
memstats: Dist-list ifname:0
memstats: Dist-list name:0
memstats: error information:0
memstats: Access List:0
memstats: Access List Str:0
memstats: Access Filter:0
memstats: RCU thread:0
<snip>

Signed-off-by: Donald Sharp <sharpd@nvidia.com>