### PR TITLE
*: Fix several memory leaks in SRv6 implementation

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -306,8 +306,10 @@ static int bgp_srv6_locator_unset(struct bgp *bgp)
 		return -1;
 
 	/* refresh chunks */
-	for (ALL_LIST_ELEMENTS(bgp->srv6_locator_chunks, node, nnode, chunk))
+	for (ALL_LIST_ELEMENTS(bgp->srv6_locator_chunks, node, nnode, chunk)) {
 		listnode_delete(bgp->srv6_locator_chunks, chunk);
+		srv6_locator_chunk_free(chunk);
+	}
 
 	/* refresh functions */
 	for (ALL_LIST_ELEMENTS(bgp->srv6_functions, node, nnode, func))

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -312,8 +312,10 @@ static int bgp_srv6_locator_unset(struct bgp *bgp)
 	}
 
 	/* refresh functions */
-	for (ALL_LIST_ELEMENTS(bgp->srv6_functions, node, nnode, func))
+	for (ALL_LIST_ELEMENTS(bgp->srv6_functions, node, nnode, func)) {
 		listnode_delete(bgp->srv6_functions, func);
+		XFREE(MTYPE_BGP_SRV6_FUNCTION, func);
+	}
 
 	/* refresh tovpn_sid */
 	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp_vrf)) {

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -338,6 +338,20 @@ static int bgp_srv6_locator_unset(struct bgp *bgp)
 	/* update vpn bgp processes */
 	vpn_leak_postchange_all();
 
+	/* refresh tovpn_sid_locator */
+	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp_vrf)) {
+		if (bgp_vrf->inst_type != BGP_INSTANCE_TYPE_VRF)
+			continue;
+
+		/* refresh vpnv4 tovpn_sid_locator */
+		XFREE(MTYPE_BGP_SRV6_SID,
+		      bgp_vrf->vpn_policy[AFI_IP].tovpn_sid_locator);
+
+		/* refresh vpnv6 tovpn_sid_locator */
+		XFREE(MTYPE_BGP_SRV6_SID,
+		      bgp_vrf->vpn_policy[AFI_IP6].tovpn_sid_locator);
+	}
+
 	/* clear locator name */
 	memset(bgp->srv6_locator_name, 0, sizeof(bgp->srv6_locator_name));
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3218,8 +3218,10 @@ static int bgp_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 	// refresh chunks
 	for (ALL_LIST_ELEMENTS(bgp->srv6_locator_chunks, node, nnode, chunk))
 		if (prefix_match((struct prefix *)&loc.prefix,
-				 (struct prefix *)&chunk->prefix))
+				 (struct prefix *)&chunk->prefix)) {
 			listnode_delete(bgp->srv6_locator_chunks, chunk);
+			srv6_locator_chunk_free(chunk);
+		}
 
 	// refresh functions
 	for (ALL_LIST_ELEMENTS(bgp->srv6_functions, node, nnode, func)) {

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3209,7 +3209,7 @@ static int bgp_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 	struct srv6_locator_chunk *chunk;
 	struct bgp_srv6_function *func;
 	struct bgp *bgp_vrf;
-	struct in6_addr *tovpn_sid;
+	struct in6_addr *tovpn_sid, *tovpn_sid_locator;
 	struct prefix_ipv6 tmp_prefi;
 
 	if (zapi_srv6_locator_decode(zclient->ibuf, &loc) < 0)
@@ -3266,6 +3266,37 @@ static int bgp_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 	}
 
 	vpn_leak_postchange_all();
+
+	/* refresh tovpn_sid_locator */
+	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp_vrf)) {
+		if (bgp_vrf->inst_type != BGP_INSTANCE_TYPE_VRF)
+			continue;
+
+		/* refresh vpnv4 tovpn_sid_locator */
+		tovpn_sid_locator =
+			bgp_vrf->vpn_policy[AFI_IP].tovpn_sid_locator;
+		if (tovpn_sid_locator) {
+			tmp_prefi.family = AF_INET6;
+			tmp_prefi.prefixlen = IPV6_MAX_BITLEN;
+			tmp_prefi.prefix = *tovpn_sid_locator;
+			if (prefix_match((struct prefix *)&loc.prefix,
+					 (struct prefix *)&tmp_prefi))
+				XFREE(MTYPE_BGP_SRV6_SID, tovpn_sid_locator);
+		}
+
+		/* refresh vpnv6 tovpn_sid_locator */
+		tovpn_sid_locator =
+			bgp_vrf->vpn_policy[AFI_IP6].tovpn_sid_locator;
+		if (tovpn_sid_locator) {
+			tmp_prefi.family = AF_INET6;
+			tmp_prefi.prefixlen = IPV6_MAX_BITLEN;
+			tmp_prefi.prefix = *tovpn_sid_locator;
+			if (prefix_match((struct prefix *)&loc.prefix,
+					 (struct prefix *)&tmp_prefi))
+				XFREE(MTYPE_BGP_SRV6_SID, tovpn_sid_locator);
+		}
+	}
+
 	return 0;
 }
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3229,8 +3229,10 @@ static int bgp_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 		tmp_prefi.prefixlen = 128;
 		tmp_prefi.prefix = func->sid;
 		if (prefix_match((struct prefix *)&loc.prefix,
-				 (struct prefix *)&tmp_prefi))
+				 (struct prefix *)&tmp_prefi)) {
 			listnode_delete(bgp->srv6_functions, func);
+			XFREE(MTYPE_BGP_SRV6_FUNCTION, func);
+		}
 	}
 
 	// refresh tovpn_sid

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -924,6 +924,11 @@ DEFPY (import_te,
 	return CMD_SUCCESS;
 }
 
+static void sharp_srv6_locator_chunk_free(struct prefix_ipv6 *chunk)
+{
+	prefix_ipv6_free((struct prefix_ipv6 **)&chunk);
+}
+
 DEFPY (sharp_srv6_manager_get_locator_chunk,
        sharp_srv6_manager_get_locator_chunk_cmd,
        "sharp srv6-manager get-locator-chunk NAME$locator_name",
@@ -947,6 +952,8 @@ DEFPY (sharp_srv6_manager_get_locator_chunk,
 		loc = XCALLOC(MTYPE_SRV6_LOCATOR,
 			      sizeof(struct sharp_srv6_locator));
 		loc->chunks = list_new();
+		loc->chunks->del =
+			(void (*)(void *))sharp_srv6_locator_chunk_free;
 		snprintf(loc->name, SRV6_LOCNAME_SIZE, "%s", locator_name);
 		listnode_add(sg.srv6_locators, loc);
 	}

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -234,6 +234,8 @@ DEFPY (install_routes,
 
 	memset(&prefix, 0, sizeof(prefix));
 	memset(&sg.r.orig_prefix, 0, sizeof(sg.r.orig_prefix));
+	nexthop_del_srv6_seg6local(&sg.r.nhop);
+	nexthop_del_srv6_seg6(&sg.r.nhop);
 	memset(&sg.r.nhop, 0, sizeof(sg.r.nhop));
 	memset(&sg.r.nhop_group, 0, sizeof(sg.r.nhop_group));
 	memset(&sg.r.backup_nhop, 0, sizeof(sg.r.nhop));
@@ -376,6 +378,8 @@ DEFPY (install_seg6_routes,
 
 	memset(&prefix, 0, sizeof(prefix));
 	memset(&sg.r.orig_prefix, 0, sizeof(sg.r.orig_prefix));
+	nexthop_del_srv6_seg6local(&sg.r.nhop);
+	nexthop_del_srv6_seg6(&sg.r.nhop);
 	memset(&sg.r.nhop, 0, sizeof(sg.r.nhop));
 	memset(&sg.r.nhop_group, 0, sizeof(sg.r.nhop_group));
 	memset(&sg.r.backup_nhop, 0, sizeof(sg.r.nhop));
@@ -467,6 +471,8 @@ DEFPY (install_seg6local_routes,
 		sg.r.repeat = 0;
 
 	memset(&sg.r.orig_prefix, 0, sizeof(sg.r.orig_prefix));
+	nexthop_del_srv6_seg6local(&sg.r.nhop);
+	nexthop_del_srv6_seg6(&sg.r.nhop);
 	memset(&sg.r.nhop, 0, sizeof(sg.r.nhop));
 	memset(&sg.r.nhop_group, 0, sizeof(sg.r.nhop_group));
 	memset(&sg.r.backup_nhop, 0, sizeof(sg.r.nhop));

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -1096,6 +1096,7 @@ DEFPY (sharp_srv6_manager_release_locator_chunk,
 			list_delete_all_node(loc->chunks);
 			list_delete(&loc->chunks);
 			listnode_delete(sg.srv6_locators, loc);
+			XFREE(MTYPE_SRV6_LOCATOR, loc);
 			break;
 		}
 	}

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -162,6 +162,7 @@ void zebra_srv6_locator_delete(struct srv6_locator *locator)
 	}
 
 	listnode_delete(srv6->locators, locator);
+	srv6_locator_free(locator);
 }
 
 struct srv6_locator *zebra_srv6_locator_lookup(const char *name)


### PR DESCRIPTION
Running `srv6_locator`, `zebra_seg6local_route`, `bgp_srv6l3vpn_to_bgp_vrf` and `bgp_srv6l3vpn_to_bgp_vrf2` topotests with `--valgrind-memleaks` gives many memory leak errors (reported below).

This patch fixes several memory leaks related to the SRv6 implementation. Details of the memory leaks and how they were fixed are provided in the commit messages.

```
==270435== 96 bytes in 6 blocks are definitely lost in loss record 112 of 207
==270435==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==270435==    by 0x48F34A3: qcalloc (memory.c:116)
==270435==    by 0x236740: ensure_vrf_tovpn_sid (bgp_mplsvpn.c:611)
==270435==    by 0x23AE2F: vpn_leak_postchange (bgp_mplsvpn.h:252)
==270435==    by 0x23AE2F: vpn_leak_postchange (bgp_mplsvpn.h:227)
==270435==    by 0x23AE2F: vpn_leak_postchange_all (bgp_mplsvpn.c:2977)
==270435==    by 0x2AF010: bgp_zebra_process_srv6_locator_chunk (bgp_zebra.c:3182)
==270435==    by 0x4940A7C: zclient_read (zclient.c:3992)
==270435==    by 0x492E440: thread_call (thread.c:2005)
==270435==    by 0x48E7AA7: frr_run (libfrr.c:1198)
==270435==    by 0x1EC787: main (bgp_main.c:518)

==270435== 352 bytes in 8 blocks are definitely lost in loss record 158 of 207
==270435==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==270435==    by 0x48F34A3: qcalloc (memory.c:116)
==270435==    by 0x48F5E5C: nexthop_add_srv6_seg6local (nexthop.c:574)
==270435==    by 0x48F5E5C: nexthop_add_srv6_seg6local (nexthop.c:567)
==270435==    by 0x494386B: zclient_send_localsid (zclient.c:471)
==270435==    by 0x23645B: vpn_leak_zebra_vrf_sid_update (bgp_mplsvpn.c:401)
==270435==    by 0x23ADF5: vpn_leak_postchange (bgp_mplsvpn.h:261)
==270435==    by 0x23ADF5: vpn_leak_postchange (bgp_mplsvpn.h:227)
==270435==    by 0x23ADF5: vpn_leak_postchange_all (bgp_mplsvpn.c:2977)
==270435==    by 0x2AF010: bgp_zebra_process_srv6_locator_chunk (bgp_zebra.c:3182)
==270435==    by 0x4940A7C: zclient_read (zclient.c:3992)
==270435==    by 0x492E440: thread_call (thread.c:2005)
==270435==    by 0x48E7AA7: frr_run (libfrr.c:1198)
==270435==    by 0x1EC787: main (bgp_main.c:518)

==270435== 888 bytes in 3 blocks are definitely lost in loss record 169 of 207
==270435==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==270435==    by 0x48F34A3: qcalloc (memory.c:116)
==270435==    by 0x2AEF3E: bgp_zebra_process_srv6_locator_chunk (bgp_zebra.c:3162)
==270435==    by 0x4940A7C: zclient_read (zclient.c:3992)
==270435==    by 0x492E440: thread_call (thread.c:2005)
==270435==    by 0x48E7AA7: frr_run (libfrr.c:1198)
==270435==    by 0x1EC787: main (bgp_main.c:518)

==270435== 1,632 bytes in 6 blocks are definitely lost in loss record 180 of 207
==270435==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==270435==    by 0x48F34A3: qcalloc (memory.c:116)
==270435==    by 0x2368F6: sid_register (bgp_mplsvpn.c:499)
==270435==    by 0x2368F6: alloc_new_sid (bgp_mplsvpn.c:568)
==270435==    by 0x2368F6: ensure_vrf_tovpn_sid (bgp_mplsvpn.c:614)
==270435==    by 0x23AE2F: vpn_leak_postchange (bgp_mplsvpn.h:252)
==270435==    by 0x23AE2F: vpn_leak_postchange (bgp_mplsvpn.h:227)
==270435==    by 0x23AE2F: vpn_leak_postchange_all (bgp_mplsvpn.c:2977)
==270435==    by 0x2AF010: bgp_zebra_process_srv6_locator_chunk (bgp_zebra.c:3182)
==270435==    by 0x4940A7C: zclient_read (zclient.c:3992)
==270435==    by 0x492E440: thread_call (thread.c:2005)
==270435==    by 0x48E7AA7: frr_run (libfrr.c:1198)
==270435==    by 0x1EC787: main (bgp_main.c:518)

==268813== 132 bytes in 3 blocks are definitely lost in loss record 24 of 37
==268813==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==268813==    by 0x48F34A3: qcalloc (memory.c:116)
==268813==    by 0x48F5E5C: nexthop_add_srv6_seg6local (nexthop.c:574)
==268813==    by 0x48F5E5C: nexthop_add_srv6_seg6local (nexthop.c:567)
==268813==    by 0x116D4B: install_seg6local_routes_magic (sharp_vty.c:513)
==268813==    by 0x116D4B: install_seg6local_routes (sharp_vty_clippy.c:684)
==268813==    by 0x48C26AD: cmd_execute_command_real.isra.0 (command.c:997)
==268813==    by 0x48C2850: cmd_execute_command (command.c:1057)
==268813==    by 0x48C29EF: cmd_execute (command.c:1224)
==268813==    by 0x4933A9D: vty_command (vty.c:482)
==268813==    by 0x4933CDC: vty_execute (vty.c:1245)
==268813==    by 0x4936A6F: vtysh_read (vty.c:2144)
==268813==    by 0x492E440: thread_call (thread.c:2005)
==268813==    by 0x48E7AA7: frr_run (libfrr.c:1198)
==268813==    by 0x1113FB: main (sharp_main.c:192)

==269307== 264 bytes in 1 blocks are definitely lost in loss record 27 of 38
==269307==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==269307==    by 0x48F34A3: qcalloc (memory.c:116)
==269307==    by 0x118EF0: sharp_srv6_manager_get_locator_chunk_magic (sharp_vty.c:947)
==269307==    by 0x118EF0: sharp_srv6_manager_get_locator_chunk (sharp_vty_clippy.c:1604)
==269307==    by 0x48C26AD: cmd_execute_command_real.isra.0 (command.c:997)
==269307==    by 0x48C2850: cmd_execute_command (command.c:1057)
==269307==    by 0x48C29EF: cmd_execute (command.c:1224)
==269307==    by 0x4933A9D: vty_command (vty.c:482)
==269307==    by 0x4933CDC: vty_execute (vty.c:1245)
==269307==    by 0x4936A6F: vtysh_read (vty.c:2144)
==269307==    by 0x492E440: thread_call (thread.c:2005)
==269307==    by 0x48E7AA7: frr_run (libfrr.c:1198)
==269307==    by 0x1113FB: main (sharp_main.c:192)

==269281== 704 (344 direct, 360 indirect) bytes in 1 blocks are definitely lost in loss record 26 of 30
==269281==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==269281==    by 0x48F34A3: qcalloc (memory.c:116)
==269281==    by 0x48F4F7F: srv6_locator_alloc (srv6.c:129)
==269281==    by 0x1DA61C: srv6_locator (zebra_srv6_vty.c:243)
==269281==    by 0x1DA61C: srv6_locator (zebra_srv6_vty.c:228)
==269281==    by 0x48C26AD: cmd_execute_command_real.isra.0 (command.c:997)
==269281==    by 0x48C2AE9: command_config_read_one_line (command.c:1268)
==269281==    by 0x48C2D24: config_from_file (command.c:1313)
==269281==    by 0x49371CC: vty_read_file (vty.c:2347)
==269281==    by 0x49371CC: vty_read_config (vty.c:2567)
==269281==    by 0x48E7600: frr_config_read_in (libfrr.c:984)
==269281==    by 0x492E440: thread_call (thread.c:2005)
==269281==    by 0x48E7AA7: frr_run (libfrr.c:1198)
==269281==    by 0x18926D: main (main.c:475)
```

Signed-off-by: Carmine Scarpitta carmine.scarpitta@uniroma2.it