### PR TITLE
pim6d: mroute stuck in register state, multicast traffic getting drops

### DIFF
--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -31,6 +31,7 @@ typedef struct in_addr pim_addr;
 #define PIM_ADDRSTRLEN	INET_ADDRSTRLEN
 #define PIM_AF		AF_INET
 #define PIM_AFI		AFI_IP
+#define PIM_PROTO_REG   IPPROTO_RAW
 #define PIM_IPADDR	IPADDR_V4
 #define ipaddr_pim	ipaddr_v4
 #define PIM_MAX_BITLEN	IPV4_MAX_BITLEN
@@ -58,6 +59,7 @@ typedef struct in6_addr pim_addr;
 #define PIM_ADDRSTRLEN	INET6_ADDRSTRLEN
 #define PIM_AF		AF_INET6
 #define PIM_AFI		AFI_IP6
+#define PIM_PROTO_REG   IPPROTO_PIM
 #define PIM_IPADDR	IPADDR_V6
 #define ipaddr_pim	ipaddr_v6
 #define PIM_MAX_BITLEN	IPV6_MAX_BITLEN

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -185,7 +185,7 @@ int pim_reg_sock(void)
 	long flags;
 
 	frr_with_privs (&pimd_privs) {
-		fd = socket(PIM_AF, SOCK_RAW, IPPROTO_RAW);
+		fd = socket(PIM_AF, SOCK_RAW, PIM_PROTO_REG);
 	}
 
 	if (fd < 0) {


### PR DESCRIPTION
IPv4 and IPv6 behaves a little bit differently with the socket
options.
IPPROTO_RAW socket option is only for IPv4.
Therefore the register packet was not properly getting encapculated
for PIMv6 and was working fine for PIMv4.

So have used IPPROTO_PIM for PIMv6.

Fixes: #11846

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>