### PR TITLE
ospfd: Added clis to change default timers for LSA refresh and maxage remove delay.

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -3020,7 +3020,7 @@ int ospf_check_nbr_status(struct ospf *ospf)
 }
 
 
-static void ospf_maxage_lsa_remover(struct thread *thread)
+void ospf_maxage_lsa_remover(struct thread *thread)
 {
 	struct ospf *ospf = THREAD_ARG(thread);
 	struct ospf_lsa *lsa, *old;
@@ -3898,8 +3898,9 @@ void ospf_refresher_register_lsa(struct ospf *ospf, struct ospf_lsa *lsa)
 	if (lsa->refresh_list < 0) {
 		int delay;
 		int min_delay =
-			OSPF_LS_REFRESH_TIME - (2 * OSPF_LS_REFRESH_JITTER);
-		int max_delay = OSPF_LS_REFRESH_TIME - OSPF_LS_REFRESH_JITTER;
+			ospf->lsa_refresh_timer - (2 * OSPF_LS_REFRESH_JITTER);
+		int max_delay =
+			ospf->lsa_refresh_timer - OSPF_LS_REFRESH_JITTER;
 
 		/* We want to refresh the LSA within OSPF_LS_REFRESH_TIME which
 		 * is

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -354,4 +354,5 @@ extern void ospf_check_and_gen_init_seq_lsa(struct ospf_interface *oi,
 					    struct ospf_lsa *lsa);
 extern void ospf_flush_lsa_from_area(struct ospf *ospf, struct in_addr area_id,
 				     int type);
+extern void ospf_maxage_lsa_remover(struct thread *thread);
 #endif /* _ZEBRA_OSPF_LSA_H */

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -12952,6 +12952,42 @@ DEFUN (clear_ip_ospf_interface,
 	return CMD_SUCCESS;
 }
 
+DEFPY_HIDDEN(ospf_lsa_refresh_timer, ospf_lsa_refresh_timer_cmd,
+	     "[no$no] ospf lsa-refresh [(120-1800)]$value",
+	     NO_STR OSPF_STR
+	     "OSPF lsa refresh timer\n"
+	     "timer value in seconds\n")
+{
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf)
+
+	if (no)
+		ospf->lsa_refresh_timer = OSPF_LS_REFRESH_TIME;
+	else
+		ospf->lsa_refresh_timer = value;
+
+	return CMD_SUCCESS;
+}
+
+DEFPY_HIDDEN(ospf_maxage_delay_timer, ospf_maxage_delay_timer_cmd,
+	     "[no$no] ospf maxage-delay [(0-60)]$value",
+	     NO_STR OSPF_STR
+	     "OSPF lsa maxage delay timer\n"
+	     "timer value in seconds\n")
+{
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf)
+
+	if (no)
+		ospf->maxage_delay = OSPF_LSA_MAXAGE_REMOVE_DELAY_DEFAULT;
+	else
+		ospf->maxage_delay = value;
+
+	THREAD_OFF(ospf->t_maxage);
+	OSPF_TIMER_ON(ospf->t_maxage, ospf_maxage_lsa_remover,
+		      ospf->maxage_delay);
+
+	return CMD_SUCCESS;
+}
+
 void ospf_vty_clear_init(void)
 {
 	install_element(ENABLE_NODE, &clear_ip_ospf_interface_cmd);
@@ -13108,6 +13144,9 @@ void ospf_vty_init(void)
 	install_element(OSPF_NODE, &no_ospf_max_multipath_cmd);
 
 	vrf_cmd_init(NULL);
+
+	install_element(OSPF_NODE, &ospf_lsa_refresh_timer_cmd);
+	install_element(OSPF_NODE, &ospf_maxage_delay_timer_cmd);
 
 	/* Init interface related vty commands. */
 	ospf_vty_if_init();

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -392,6 +392,7 @@ struct ospf *ospf_new_alloc(unsigned short instance, const char *name)
 
 	new->lsa_refresh_queue.index = 0;
 	new->lsa_refresh_interval = OSPF_LSA_REFRESH_INTERVAL_DEFAULT;
+	new->lsa_refresh_timer = OSPF_LS_REFRESH_TIME;
 	new->t_lsa_refresher = NULL;
 	thread_add_timer(master, ospf_lsa_refresh_walker, new,
 			 new->lsa_refresh_interval, &new->t_lsa_refresher);

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -313,6 +313,7 @@ struct ospf {
 	time_t lsa_refresher_started;
 #define OSPF_LSA_REFRESH_INTERVAL_DEFAULT 10
 	uint16_t lsa_refresh_interval;
+	uint16_t lsa_refresh_timer;
 
 	/* Distance parameter. */
 	uint8_t distance_all;


### PR DESCRIPTION
Description:
Added hidden clis that will allow you to reset the default timers
for LSA refresh and LSA maxage remove delay, these will help in testing
LSA refresh scenarios in upcoming OSPFv2 Flood reduction feature(rfc4136).

IETF Link : https://datatracker.ietf.org/doc/html/rfc4136

Signed-off-by: Manoj Naragund  <mnaragund@vmware.com>