### PR TITLE
ospfd: crash when router acts as GR helper upon a topo change

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2865,10 +2865,11 @@ struct ospf_lsa *ospf_lsa_install(struct ospf *ospf, struct ospf_interface *oi,
 		 * So, router should be aborted from HELPER role
 		 * if it is detected as TOPO  change.
 		 */
-		if (ospf->active_restarter_cnt
-		    && CHECK_LSA_TYPE_1_TO_5_OR_7(lsa->data->type)
-		    && ospf_lsa_different(old, lsa, true))
-			ospf_helper_handle_topo_chg(ospf, lsa);
+		if (ospf->active_restarter_cnt &&
+		    CHECK_LSA_TYPE_1_TO_5_OR_7(lsa->data->type)) {
+			if (old == NULL || ospf_lsa_different(old, lsa, true))
+				ospf_helper_handle_topo_chg(ospf, lsa);
+		}
 
 		rt_recalc = 1;
 	}


### PR DESCRIPTION
Description:
	ospf process is crashing when  the current router acts
	as GR helper and it received a new lsa.

	Here, ospf_lsa_different() is being called without checking
	'old' pointer. It is asserted in ospf_lsa_different() api
	if the 'old' pointer is NULL.

	corrected this by validaing old pointer before calling
	ospf_lsa_different() api.

	back tarce:
	Program terminated with signal SIGABRT, Aborted.
	0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
	[Current thread is 1 (Thread 0x6b84348827c0 (LWP 3155))]
	0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
	1  0x00006b8433aa4801 in __GI_abort () at abort.c:79
	2  0x00006b8433a9439a in __assert_fail_base (fmt=0x6b8433c1b7d8 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=assertion@entry=0x162ffc0630bc "l1", file=file@entry=0x162ffc062ff7 "ospfd/ospf_lsa.c", line=line@entry=3520, function=function@entry=0x162ffc0646f0 <__PRETTY_FUNCTION__.18732> "ospf_lsa_different") at assert.c:92
	3  0x00006b8433a94412 in __GI___assert_fail (assertion=assertion@entry=0x162ffc0630bc "l1", file=file@entry=0x162ffc062ff7 "ospfd/ospf_lsa.c", line=line@entry=3520, function=function@entry=0x162ffc0646f0 <__PRETTY_FUNCTION__.18732> "ospf_lsa_different") at assert.c:101
	4  0x0000162ffc008c25 in ospf_lsa_different (l1=l1@entry=0x0, l2=l2@entry=0x162ffe535c60, ignore_rcvd_flag=ignore_rcvd_flag@entry=true) at ospfd/ospf_lsa.c:3520
	5  0x0000162ffc00a8e8 in ospf_lsa_install (ospf=ospf@entry=0x162ffe513650, oi=oi@entry=0x162ffe531c30, lsa=lsa@entry=0x162ffe535c60) at ospfd/ospf_lsa.c:2892
	6  0x0000162ffc059d16 in ospf_flood (ospf=0x162ffe513650, nbr=nbr@entry=0x162ffe52cc90, current=current@entry=0x0, new=new@entry=0x162ffe535c60) at ospfd/ospf_flood.c:429
	7  0x0000162ffc01838f in ospf_ls_upd (size=<optimized out>, oi=0x162ffe531c30, s=<optimized out>, ospfh=<optimized out>, iph=<optimized out>, ospf=<optimized out>) at ospfd/ospf_packet.c:2162
	8  ospf_read_helper (ospf=<optimized out>) at ospfd/ospf_packet.c:3241
	9  ospf_read (thread=<optimized out>) at ospfd/ospf_packet.c:3272
	10 0x00006b843450139c in thread_call (thread=thread@entry=0x7780f42c7480) at lib/thread.c:1692
	11 0x00006b84344cfb18 in frr_run (master=0x162ffe34d130) at lib/libfrr.c:1068

Signed-off-by: Rajesh Girada <rgirada@vmware.com>