### PR TITLE
pimd, pim6d: Changing IGMP to GM in few macro's.

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -131,13 +131,13 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool gm, bool pim,
 	pim_ifp->igmp_version = IGMP_DEFAULT_VERSION;
 	pim_ifp->mld_version = MLD_DEFAULT_VERSION;
 	pim_ifp->gm_default_robustness_variable =
-		IGMP_DEFAULT_ROBUSTNESS_VARIABLE;
-	pim_ifp->gm_default_query_interval = IGMP_GENERAL_QUERY_INTERVAL;
+		GM_DEFAULT_ROBUSTNESS_VARIABLE;
+	pim_ifp->gm_default_query_interval = GM_GENERAL_QUERY_INTERVAL;
 	pim_ifp->gm_query_max_response_time_dsec =
-		IGMP_QUERY_MAX_RESPONSE_TIME_DSEC;
+		GM_QUERY_MAX_RESPONSE_TIME_DSEC;
 	pim_ifp->gm_specific_query_max_response_time_dsec =
-		IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC;
-	pim_ifp->gm_last_member_query_count = IGMP_DEFAULT_ROBUSTNESS_VARIABLE;
+		GM_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC;
+	pim_ifp->gm_last_member_query_count = GM_DEFAULT_ROBUSTNESS_VARIABLE;
 
 	/* BSM config on interface: true by default */
 	pim_ifp->bsm_enable = true;

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -56,18 +56,6 @@
 #define IGMP_V3_GROUP_RECORD_SOURCE_OFFSET     (8)
 #define IGMP_CHECKSUM_OFFSET                   (2)
 
-/* RFC 3376: 8.1. Robustness Variable - Default: 2 */
-#define IGMP_DEFAULT_ROBUSTNESS_VARIABLE           (2)
-
-/* RFC 3376: 8.2. Query Interval - Default: 125 seconds */
-#define IGMP_GENERAL_QUERY_INTERVAL                (125)
-
-/* RFC 3376: 8.3. Query Response Interval - Default: 100 deciseconds */
-#define IGMP_QUERY_MAX_RESPONSE_TIME_DSEC          (100)
-
-/* RFC 3376: 8.8. Last Member Query Interval - Default: 10 deciseconds */
-#define IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC (10)
-
 #define IGMP_DEFAULT_VERSION (3)
 
 #define IGMP_GET_INT16(ptr, output)                                            \

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -314,14 +314,14 @@ static int gm_config_write(struct vty *vty, int writes,
 
 	/* IF ip igmp query-max-response-time */
 	if (pim_ifp->gm_query_max_response_time_dsec !=
-	    IGMP_QUERY_MAX_RESPONSE_TIME_DSEC) {
+	    GM_QUERY_MAX_RESPONSE_TIME_DSEC) {
 		vty_out(vty, " ip igmp query-max-response-time %d\n",
 			pim_ifp->gm_query_max_response_time_dsec);
 		++writes;
 	}
 
 	/* IF ip igmp query-interval */
-	if (pim_ifp->gm_default_query_interval != IGMP_GENERAL_QUERY_INTERVAL) {
+	if (pim_ifp->gm_default_query_interval != GM_GENERAL_QUERY_INTERVAL) {
 		vty_out(vty, " ip igmp query-interval %d\n",
 			pim_ifp->gm_default_query_interval);
 		++writes;
@@ -329,7 +329,7 @@ static int gm_config_write(struct vty *vty, int writes,
 
 	/* IF ip igmp last-member_query-count */
 	if (pim_ifp->gm_last_member_query_count !=
-	    IGMP_DEFAULT_ROBUSTNESS_VARIABLE) {
+	    GM_DEFAULT_ROBUSTNESS_VARIABLE) {
 		vty_out(vty, " ip igmp last-member-query-count %d\n",
 			pim_ifp->gm_last_member_query_count);
 		++writes;
@@ -337,7 +337,7 @@ static int gm_config_write(struct vty *vty, int writes,
 
 	/* IF ip igmp last-member_query-interval */
 	if (pim_ifp->gm_specific_query_max_response_time_dsec !=
-	    IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC) {
+	    GM_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC) {
 		vty_out(vty, " ip igmp last-member-query-interval %d\n",
 			pim_ifp->gm_specific_query_max_response_time_dsec);
 		++writes;
@@ -381,23 +381,23 @@ static int gm_config_write(struct vty *vty, int writes,
 
 	/* IF ipv6 mld query-max-response-time */
 	if (pim_ifp->gm_query_max_response_time_dsec !=
-	    IGMP_QUERY_MAX_RESPONSE_TIME_DSEC)
+	    GM_QUERY_MAX_RESPONSE_TIME_DSEC)
 		vty_out(vty, " ipv6 mld query-max-response-time %d\n",
 			pim_ifp->gm_query_max_response_time_dsec);
 
-	if (pim_ifp->gm_default_query_interval != IGMP_GENERAL_QUERY_INTERVAL)
+	if (pim_ifp->gm_default_query_interval != GM_GENERAL_QUERY_INTERVAL)
 		vty_out(vty, " ipv6 mld query-interval %d\n",
 			pim_ifp->gm_default_query_interval);
 
 	/* IF ipv6 mld last-member_query-count */
 	if (pim_ifp->gm_last_member_query_count !=
-	    IGMP_DEFAULT_ROBUSTNESS_VARIABLE)
+	    GM_DEFAULT_ROBUSTNESS_VARIABLE)
 		vty_out(vty, " ipv6 mld last-member-query-count %d\n",
 			pim_ifp->gm_last_member_query_count);
 
 	/* IF ipv6 mld last-member_query-interval */
 	if (pim_ifp->gm_specific_query_max_response_time_dsec !=
-	    IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC)
+	    GM_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC)
 		vty_out(vty, " ipv6 mld last-member-query-interval %d\n",
 			pim_ifp->gm_specific_query_max_response_time_dsec);
 

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -261,6 +261,24 @@ extern uint8_t qpim_ecmp_rebalance_enable;
 #define PIM_DONT_DEBUG_VXLAN (router->debugs &= ~PIM_MASK_VXLAN)
 #define PIM_DONT_DEBUG_BSM (router->debugs &= ~PIM_MASK_BSM_PROC)
 
+/* RFC 3376: 8.1. Robustness Variable - Default: 2 for IGMP */
+/* RFC 2710: 7.1. Robustness Variable - Default: 2 for MLD */
+#define GM_DEFAULT_ROBUSTNESS_VARIABLE 2
+
+/* RFC 3376: 8.2. Query Interval - Default: 125 seconds for IGMP */
+/* RFC 2710: 7.2. Query Interval - Default: 125 seconds for MLD */
+#define GM_GENERAL_QUERY_INTERVAL 125
+
+/* RFC 3376: 8.3. Query Response Interval - Default: 100 deciseconds for IGMP */
+/* RFC 2710: 7.3. Query Response Interval - Default: 100 deciseconds for MLD */
+#define GM_QUERY_MAX_RESPONSE_TIME_DSEC 100
+
+/* RFC 3376: 8.8. Last Member Query Interval - Default: 10 deciseconds for IGMP
+ */
+/* RFC 2710: 7.8. Last Listener Query Interval - Default: 10 deciseconds for MLD
+ */
+#define GM_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC 10
+
 void pim_router_init(void);
 void pim_router_terminate(void);
 


### PR DESCRIPTION
Changing
IGMP_DEFAULT_ROBUSTNESS_VARIABLE to GM_DEFAULT_ROBUSTNESS_VARIABLE,
IGMP_GENERAL_QUERY_INTERVAL to GM_GENERAL_QUERY_INTERVAL,
IGMP_QUERY_MAX_RESPONSE_TIME_DSEC to GM_QUERY_MAX_RESPONSE_TIME_DSEC and
IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC to GM_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC
to accomodate both igmp and mld.

Signed-off-by: Abhishek N R <abnr@vmware.com>