### PR TITLE
pimd, pim6d: deleting the memory malloced for json.

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -2035,6 +2035,7 @@ void pim_show_interfaces(struct pim_instance *pim, struct vty *vty, bool mlag,
 						  &json_tmp);
 			vty_out(vty, "%9d\n", json_object_get_int(json_tmp));
 		}
+		json_object_free(json);
 	}
 }
 


### PR DESCRIPTION
Problem Statement:
=================
2022-08-18 04:57:32,376 - ERROR: Found memory leak in daemon pimd
2022-08-18 04:57:32,377 - ERROR: ==12100== 18,978 (144 direct, 18,834 indirect) bytes in 2 blocks are definitely lost in loss record 45 of 45
2022-08-18 04:57:32,377 - ERROR: ==12100==    at 0x4C31FAC: calloc (vg_replace_malloc.c:762)
2022-08-18 04:57:32,377 - ERROR: ==12100==    by 0x532F51F: json_object_new_object (in /lib/x86_64-linux-gnu/libjson-c.so.3.0.1)
2022-08-18 04:57:32,377 - ERROR: ==12100==    by 0x128B5C: pim_show_interfaces (pim_cmd_common.c:3395)
2022-08-18 04:57:32,377 - ERROR: ==12100==    by 0x15A86B: show_ip_pim_interface_magic (pim_cmd.c:3127)
2022-08-18 04:57:32,377 - ERROR: ==12100==    by 0x15A86B: show_ip_pim_interface (pim_cmd_clippy.c:324)
2022-08-18 04:57:32,377 - ERROR: ==12100==    by 0x4E672B2: cmd_execute_command_real.isra.2 (command.c:1005)
2022-08-18 04:57:32,377 - ERROR: ==12100==    by 0x4E696FE: cmd_execute_command (command.c:1064)
2022-08-18 04:57:32,377 - ERROR: ==12100==    by 0x4E698F1: cmd_execute (command.c:1227)
2022-08-18 04:57:32,377 - ERROR: ==12100==    by 0x4EBC814: vty_command (vty.c:530)
2022-08-18 04:57:32,377 - ERROR: ==12100==    by 0x4EBC9EF: vty_execute (vty.c:1295)
2022-08-18 04:57:32,377 - ERROR: ==12100==    by 0x4EBF1F7: vtysh_read (vty.c:2142)
2022-08-18 04:57:32,377 - ERROR: ==12100==    by 0x4EB739B: thread_call (thread.c:1692)
2022-08-18 04:57:32,377 - ERROR: ==12100==    by 0x4E85B17: frr_run (libfrr.c:1068)
2022-08-18 04:57:32,377 - ERROR: ==12100==

Signed-off-by: Abhishek N R <abnr@vmware.com>