### PR TITLE
pim6d: Fix the Code for MLD in the show pim state command

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1038,7 +1038,7 @@ void pim_show_state(struct pim_instance *pim, struct vty *vty,
 
 	if (!json) {
 		vty_out(vty,
-			"Codes: J -> Pim Join, I -> IGMP Report, S -> Source, * -> Inherited from (*,G), V -> VxLAN, M -> Muted");
+			"Codes: J -> Pim Join, I -> " GM " Report, S -> Source, * -> Inherited from (*,G), V -> VxLAN, M -> Muted");
 		vty_out(vty,
 			"\nActive Source           Group            RPT  IIF               OIL\n");
 	}


### PR DESCRIPTION
show ip pim state should show IGMP Report while
show ipv6 pim state should show MLD Report.

Output After Fix:
frr# do sh ip pim state
Codes: J -> Pim Join, I -> IGMP Report, S -> Source, * -> Inherited from (*,G), V -> VxLAN, M -> Muted
Active Source           Group            RPT  IIF               OIL

frr# do sh ipv6 pim state
Codes: J -> Pim Join, I -> MLD Report, S -> Source, * -> Inherited from (*,G), V -> VxLAN, M -> Muted
Active Source           Group            RPT  IIF               OIL

frr#

Issue: #11249

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>