### PR TITLE
ospf6d: fix nexthop in NSSA

### DIFF
--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -645,9 +645,8 @@ void ospf6_asbr_lsa_add(struct ospf6_lsa *lsa)
 			}
 
 			/* Find the forwarding entry */
-			asbr_entry = ospf6_route_lookup_bestmatch(
-				&fwd_addr, ospf6->route_table);
-			if (asbr_entry == NULL) {
+			if (!ospf6_route_lookup_bestmatch(&fwd_addr,
+							  ospf6->route_table)) {
 				if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL))
 					zlog_debug(
 						"Fwd address not found: %pFX",

--- a/ospf6d/ospf6_nssa.h
+++ b/ospf6d/ospf6_nssa.h
@@ -70,5 +70,6 @@ int ospf6_redistribute_check(struct ospf6 *ospf6, struct ospf6_route *route,
 extern void ospf6_abr_check_translate_nssa(struct ospf6_area *area,
 					   struct ospf6_lsa *lsa);
 extern void ospf6_abr_nssa_check_status(struct ospf6 *ospf6);
+void ospf6_schedule_nssa_update(struct ospf6 *ospf6);
 extern void config_write_ospf6_debug_nssa(struct vty *vty);
 #endif /* OSPF6_NSSA_H */

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -189,6 +189,7 @@ struct ospf6 {
 	struct thread *t_distribute_update; /* Distirbute update timer. */
 	struct thread *t_ospf6_receive; /* OSPF6 receive timer */
 	struct thread *t_external_aggr; /* OSPF6 aggregation timer */
+	struct thread *t_nssa_update;
 #define OSPF6_WRITE_INTERFACE_COUNT_DEFAULT 20
 	struct thread *t_write;
 

--- a/tests/topotests/ospf6_topo2/test_ospf6_topo2.py
+++ b/tests/topotests/ospf6_topo2/test_ospf6_topo2.py
@@ -334,7 +334,7 @@ def test_nssa_lsa_type7():
     route = {
         "2001:db8:100::/64": {
             "pathType": "E2",
-            "nextHops": [{"nextHop": "::", "interfaceName": "r4-eth0"}],
+            "nextHops": [{"interfaceName": "r4-eth0"}],
         }
     }
 


### PR DESCRIPTION
In a topology like: r1 --- r2 --- r3 (asbr)

where r3 is redistributing statics, r2 (abr) will see the routes announced
by r3 as directly connected
```
r2# sh ipv6 route
Codes: K - kernel route, C - connected, S - static, R - RIPng,
       O - OSPFv3, I - IS-IS, B - BGP, N - NHRP, T - Table,
       v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

O   12::/64 [110/10] is directly connected, r2-r1-eth0, weight 1, 00:00:12
C>* 12::/64 is directly connected, r2-r1-eth0, 00:00:25
O   23::/64 [110/10] is directly connected, r2-r3-eth1, weight 1, 00:00:12
C>* 23::/64 is directly connected, r2-r3-eth1, 00:00:25
O>* 33::33/128 [110/20] is directly connected, r2-r3-eth1, weight 1, 00:00:11   <---  ****
C>* 2001::2:17/128 is directly connected, lo, 00:00:27
C * fe80::/64 is directly connected, r2-r1-eth0, 00:00:25
C * fe80::/64 is directly connected, r2-r3-eth1, 00:00:26
C>* fe80::/64 is directly connected, lo, 00:00:27
```
With this PR we avoid overwriting the `asbr_entry` variable containing the right information. The result is then:
```
r2# sh ipv6 route
Codes: K - kernel route, C - connected, S - static, R - RIPng,
       O - OSPFv3, I - IS-IS, B - BGP, N - NHRP, T - Table,
       v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

O   12::/64 [110/10] is directly connected, r2-r1-eth0, weight 1, 00:00:10
C>* 12::/64 is directly connected, r2-r1-eth0, 00:00:27
O   23::/64 [110/10] is directly connected, r2-r3-eth1, weight 1, 00:00:10
C>* 23::/64 is directly connected, r2-r3-eth1, 00:00:27
O>* 33::33/128 [110/20] via fe80::601d:eaff:fe56:8601, r2-r3-eth1, weight 1, 00:00:09  <--- ****
C>* 2001::2:17/128 is directly connected, lo, 00:00:29
C * fe80::/64 is directly connected, r2-r3-eth1, 00:00:28
C * fe80::/64 is directly connected, r2-r1-eth0, 00:00:28
C>* fe80::/64 is directly connected, lo, 00:00:29
```
This PR should fix #11738