### PR TITLE
zebra: fix missing tenant vrf change notification

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5148,10 +5148,9 @@ int zebra_vxlan_if_update(struct interface *ifp, uint16_t chgflags)
 			return 0;
 
 		/* Inform BGP, if there is a change of interest. */
-		if (chgflags
-			& (ZEBRA_VXLIF_MASTER_CHANGE |
-			   ZEBRA_VXLIF_LOCAL_IP_CHANGE |
-			   ZEBRA_VXLIF_MCAST_GRP_CHANGE))
+		if (chgflags &
+		    (ZEBRA_VXLIF_MASTER_CHANGE | ZEBRA_VXLIF_LOCAL_IP_CHANGE |
+		     ZEBRA_VXLIF_MCAST_GRP_CHANGE | ZEBRA_VXLIF_VLAN_CHANGE))
 			zebra_evpn_send_add_to_client(zevpn);
 
 		/* If there is a valid new master or a VLAN mapping change,


### PR DESCRIPTION
zebra can change l2vni's tenant vrf with new `vid`, and then notify bgpd
to change also. But this notification is wrongly missed, so bgpd knows
nothing about it. It affects evpn routes, which are related to tenant vrf.
Need to notify bgpd of the `vid` change.

Changes l2vni 100 of vxlan's `vid` so as to change its svi interface from
default to vrf1, then check bgp's vni status.

Before: (Ignored irrelevent columns)
```
host#show bgp l2vpn evpn vni
  VNI      Type RD                    Tenant VRF
* 100      L2   66.66.66.66:2         default <- No change
```

After:(Ignored irrelevent columns)
```
host#show bgp l2vpn evpn vni
  VNI      Type RD                   Tenant VRF
* 100      L2   66.66.66.66:2        vrf1 <- Updated
```