### PR TITLE
configure: Check for readline() function instead of main

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1372,7 +1372,7 @@ case "${enable_vtysh}" in
   AC_DEFINE([VTYSH], [1], [VTY shell])
 
   prev_libs="$LIBS"
-  AC_CHECK_LIB([readline], [main], [
+  AC_CHECK_LIB([readline], [readline], [
     LIBREADLINE="-lreadline"
   ], [
     dnl readline failed - it might be incorrectly linked and missing its


### PR DESCRIPTION
main is not a function found in libreadline, its better to check for a
function thats provided by it.

Signed-off-by: Khem Raj <raj.khem@gmail.com>