### PR TITLE
pimd: Removal of unused function pim_neighbor_find_prefix

### DIFF
--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -441,15 +441,6 @@ struct pim_neighbor *pim_neighbor_find(struct interface *ifp,
 	return NULL;
 }
 
-struct pim_neighbor *pim_neighbor_find_prefix(struct interface *ifp,
-					      const struct prefix *src_prefix)
-{
-	pim_addr addr;
-
-	addr = pim_addr_from_prefix(src_prefix);
-	return pim_neighbor_find(ifp, addr);
-}
-
 /*
  * Find the *one* interface out
  * this interface.  If more than

--- a/pimd/pim_neighbor.h
+++ b/pimd/pim_neighbor.h
@@ -52,8 +52,6 @@ void pim_neighbor_timer_reset(struct pim_neighbor *neigh, uint16_t holdtime);
 void pim_neighbor_free(struct pim_neighbor *neigh);
 struct pim_neighbor *pim_neighbor_find(struct interface *ifp,
 				       pim_addr source_addr);
-struct pim_neighbor *pim_neighbor_find_prefix(struct interface *ifp,
-					      const struct prefix *src_prefix);
 struct pim_neighbor *pim_neighbor_find_by_secondary(struct interface *ifp,
 						    struct prefix *src);
 struct pim_neighbor *pim_neighbor_find_if(struct interface *ifp);


### PR DESCRIPTION
pim_neighbor_find_prefix function is no more used. Removing it.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>