### PR TITLE
pim6d: Update last_member_query_interval and last_member_query_count

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2844,6 +2844,9 @@ int lib_interface_gmp_address_family_last_member_query_interval_modify(
 			yang_dnode_get_uint16(args->dnode, NULL);
 		pim_ifp->gm_specific_query_max_response_time_dsec =
 			last_member_query_interval;
+#if PIM_IPV == 6
+		gm_ifp_update(ifp);
+#endif
 
 		break;
 	}
@@ -2872,7 +2875,9 @@ int lib_interface_gmp_address_family_robustness_variable_modify(
 		last_member_query_count =
 			yang_dnode_get_uint8(args->dnode, NULL);
 		pim_ifp->gm_last_member_query_count = last_member_query_count;
-
+#if PIM_IPV == 6
+		gm_ifp_update(ifp);
+#endif
 		break;
 	}
 


### PR DESCRIPTION
When there is update in the configuration of last_member_query_interval
and last_member_query_count, call gm_ifp_update().
This will update cur_query_intv_trig and cur_lmqc of gm_ifp structure.

Issue: #11901

Signed-off-by: Sarita Patra <saritap@vmware.com>