### PR TITLE
pimd, pim6d: Changing IGMP to GM in debug macros

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -401,7 +401,7 @@ static void gm_sg_update(struct gm_sg *sg, bool has_expired)
 		desired = GM_SG_NOINFO;
 
 	if (desired != sg->state && !gm_ifp->stopping) {
-		if (PIM_DEBUG_IGMP_EVENTS)
+		if (PIM_DEBUG_GM_EVENTS)
 			zlog_debug(log_sg(sg, "%s => %s"), gm_states[sg->state],
 				   gm_states[desired]);
 
@@ -1049,7 +1049,7 @@ static void gm_t_expire(struct thread *t)
 
 		remain_ms = monotime_until(&pend->expiry, &remain);
 		if (remain_ms > 0) {
-			if (PIM_DEBUG_IGMP_EVENTS)
+			if (PIM_DEBUG_GM_EVENTS)
 				zlog_debug(
 					log_ifp("next general expiry in %" PRId64 "ms"),
 					remain_ms / 1000);
@@ -1073,7 +1073,7 @@ static void gm_t_expire(struct thread *t)
 			gm_ifp->n_pending * sizeof(gm_ifp->pending[0]));
 	}
 
-	if (PIM_DEBUG_IGMP_EVENTS)
+	if (PIM_DEBUG_GM_EVENTS)
 		zlog_debug(log_ifp("next general expiry waiting for query"));
 }
 
@@ -1250,7 +1250,7 @@ static void gm_t_grp_expire(struct thread *t)
 	struct gm_if *gm_ifp = pend->iface;
 	struct gm_sg *sg, *sg_start, sg_ref = {};
 
-	if (PIM_DEBUG_IGMP_EVENTS)
+	if (PIM_DEBUG_GM_EVENTS)
 		zlog_debug(log_ifp("*,%pPAs S,G timer expired"), &pend->grp);
 
 	/* gteq lookup - try to find *,G or S,G  (S,G is > *,G)
@@ -1442,7 +1442,7 @@ static void gm_handle_query(struct gm_if *gm_ifp,
 	}
 
 	if (IPV6_ADDR_CMP(&pkt_src->sin6_addr, &gm_ifp->querier) < 0) {
-		if (PIM_DEBUG_IGMP_EVENTS)
+		if (PIM_DEBUG_GM_EVENTS)
 			zlog_debug(
 				log_pkt_src("replacing elected querier %pPA"),
 				&gm_ifp->querier);
@@ -2137,7 +2137,7 @@ void gm_ifp_teardown(struct interface *ifp)
 
 	gm_ifp = pim_ifp->mld;
 	gm_ifp->stopping = true;
-	if (PIM_DEBUG_IGMP_EVENTS)
+	if (PIM_DEBUG_GM_EVENTS)
 		zlog_debug(log_ifp("MLD stop"));
 
 	THREAD_OFF(gm_ifp->t_query);

--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -817,7 +817,7 @@ static void gm_handle_v2_report(struct gm_if *gm_ifp,
 	struct gm_packet_state *pkt;
 
 	if (len < sizeof(*hdr)) {
-		if (PIM_DEBUG_IGMP_PACKETS)
+		if (PIM_DEBUG_GM_PACKETS)
 			zlog_debug(log_pkt_src(
 				"malformed MLDv2 report (truncated header)"));
 		gm_ifp->stats.rx_drop_malformed++;
@@ -923,7 +923,7 @@ static void gm_handle_v1_report(struct gm_if *gm_ifp,
 	size_t max_entries;
 
 	if (len < sizeof(*hdr)) {
-		if (PIM_DEBUG_IGMP_PACKETS)
+		if (PIM_DEBUG_GM_PACKETS)
 			zlog_debug(log_pkt_src(
 				"malformed MLDv1 report (truncated)"));
 		gm_ifp->stats.rx_drop_malformed++;
@@ -989,7 +989,7 @@ static void gm_handle_v1_leave(struct gm_if *gm_ifp,
 	struct gm_packet_sg *old_grp;
 
 	if (len < sizeof(*hdr)) {
-		if (PIM_DEBUG_IGMP_PACKETS)
+		if (PIM_DEBUG_GM_PACKETS)
 			zlog_debug(log_pkt_src(
 				"malformed MLDv1 leave (truncated)"));
 		gm_ifp->stats.rx_drop_malformed++;
@@ -1063,7 +1063,7 @@ static void gm_t_expire(struct thread *t)
 			if (timercmp(&pkt->received, &pend->query, >=))
 				break;
 
-			if (PIM_DEBUG_IGMP_PACKETS)
+			if (PIM_DEBUG_GM_PACKETS)
 				zlog_debug(log_ifp("expire packet %p"), pkt);
 			gm_packet_drop(pkt, true);
 		}
@@ -1802,7 +1802,7 @@ static void gm_send_query(struct gm_if *gm_ifp, pim_addr grp,
 
 	query.hdr.icmp6_cksum = in_cksumv(iov, iov_len);
 
-	if (PIM_DEBUG_IGMP_PACKETS)
+	if (PIM_DEBUG_GM_PACKETS)
 		zlog_debug(
 			log_ifp("MLD query %pPA -> %pI6 (grp=%pPA, %zu srcs)"),
 			&pim_ifp->ll_lowest, &dstaddr.sin6_addr, &grp, n_srcs);

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1345,7 +1345,7 @@ ferr_r pim_if_igmp_join_add(struct interface *ifp, struct in_addr group_addr,
 
 	(void)igmp_join_new(ifp, group_addr, source_addr);
 
-	if (PIM_DEBUG_IGMP_EVENTS) {
+	if (PIM_DEBUG_GM_EVENTS) {
 		char group_str[INET_ADDRSTRLEN];
 		char source_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<grp?>", group_addr, group_str,

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -1362,7 +1362,7 @@ void igmp_group_timer_on(struct gm_group *group, long interval_msec,
 {
 	group_timer_off(group);
 
-	if (PIM_DEBUG_IGMP_EVENTS) {
+	if (PIM_DEBUG_GM_EVENTS) {
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -501,14 +501,14 @@ static int igmp_recv_query(struct gm_sock *igmp, int query_version,
 	}
 
 	if (!pim_if_connected_to_source(ifp, from)) {
-		if (PIM_DEBUG_IGMP_PACKETS)
+		if (PIM_DEBUG_GM_PACKETS)
 			zlog_debug("Recv IGMP query on interface: %s from a non-connected source: %s",
 				   ifp->name, from_str);
 		return 0;
 	}
 
 	if (if_address_is_local(&from, AF_INET, ifp->vrf->vrf_id)) {
-		if (PIM_DEBUG_IGMP_PACKETS)
+		if (PIM_DEBUG_GM_PACKETS)
 			zlog_debug("Recv IGMP query on interface: %s from ourself %s",
 				   ifp->name, from_str);
 		return 0;
@@ -554,7 +554,7 @@ static int igmp_recv_query(struct gm_sock *igmp, int query_version,
 		return 0;
 	}
 
-	if (PIM_DEBUG_IGMP_PACKETS) {
+	if (PIM_DEBUG_GM_PACKETS) {
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group_addr, group_str,
 			       sizeof(group_str));
@@ -750,7 +750,7 @@ int pim_igmp_packet(struct gm_sock *igmp, char *buf, size_t len)
 	pim_inet4_dump("<src?>", ip_hdr->ip_src, from_str, sizeof(from_str));
 	pim_inet4_dump("<dst?>", ip_hdr->ip_dst, to_str, sizeof(to_str));
 
-	if (PIM_DEBUG_IGMP_PACKETS) {
+	if (PIM_DEBUG_GM_PACKETS) {
 		zlog_debug(
 			"Recv IGMP packet from %s to %s on %s: size=%zu ttl=%d msg_type=%d msg_size=%d",
 			from_str, to_str, igmp->interface->name, len, ip_hdr->ip_ttl,

--- a/pimd/pim_igmpv2.c
+++ b/pimd/pim_igmpv2.c
@@ -237,7 +237,7 @@ int igmp_v2_recv_leave(struct gm_sock *igmp, struct ip *ip_hdr,
 	*/
 	if ((ntohl(ip_hdr->ip_dst.s_addr) != INADDR_ALLRTRS_GROUP)
 	    && (ip_hdr->ip_dst.s_addr != group_addr.s_addr)) {
-		if (PIM_DEBUG_IGMP_EVENTS)
+		if (PIM_DEBUG_GM_EVENTS)
 			zlog_debug(
 				"IGMPv2 Leave message is ignored since received on address other than ALL-ROUTERS or Group-address");
 		return -1;

--- a/pimd/pim_igmpv2.c
+++ b/pimd/pim_igmpv2.c
@@ -68,7 +68,7 @@ void igmp_v2_send_query(struct gm_group *group, int fd, const char *ifname,
 	checksum = in_cksum(query_buf, msg_size);
 	*(uint16_t *)(query_buf + IGMP_CHECKSUM_OFFSET) = checksum;
 
-	if (PIM_DEBUG_IGMP_PACKETS) {
+	if (PIM_DEBUG_GM_PACKETS) {
 		char dst_str[INET_ADDRSTRLEN];
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<dst?>", dst_addr, dst_str, sizeof(dst_str));
@@ -121,7 +121,7 @@ int igmp_v2_recv_report(struct gm_sock *igmp, struct in_addr from,
 		return 0;
 
 	if (igmp_msg_len != IGMP_V12_MSG_SIZE) {
-		if (PIM_DEBUG_IGMP_PACKETS)
+		if (PIM_DEBUG_GM_PACKETS)
 			zlog_debug(
 				"Recv IGMPv2 REPORT from %s on %s: size=%d other than correct=%d",
 				from_str, ifp->name, igmp_msg_len,
@@ -140,7 +140,7 @@ int igmp_v2_recv_report(struct gm_sock *igmp, struct in_addr from,
 
 	memcpy(&group_addr, igmp_msg + 4, sizeof(struct in_addr));
 
-	if (PIM_DEBUG_IGMP_PACKETS) {
+	if (PIM_DEBUG_GM_PACKETS) {
 		pim_inet4_dump("<dst?>", group_addr, group_str,
 			       sizeof(group_str));
 		zlog_debug("Recv IGMPv2 REPORT from %s on %s for %s", from_str,
@@ -155,7 +155,7 @@ int igmp_v2_recv_report(struct gm_sock *igmp, struct in_addr from,
 	 * the SSM range.
 	 */
 	if (pim_is_grp_ssm(pim_ifp->pim, group_addr)) {
-		if (PIM_DEBUG_IGMP_PACKETS) {
+		if (PIM_DEBUG_GM_PACKETS) {
 			zlog_debug(
 				"Ignoring IGMPv2 group record %pI4 from %s on %s exclude mode in SSM range",
 				&group_addr.s_addr, from_str, ifp->name);
@@ -196,7 +196,7 @@ int igmp_v2_recv_leave(struct gm_sock *igmp, struct ip *ip_hdr,
 		return 0;
 
 	if (igmp_msg_len != IGMP_V12_MSG_SIZE) {
-		if (PIM_DEBUG_IGMP_PACKETS)
+		if (PIM_DEBUG_GM_PACKETS)
 			zlog_debug(
 				"Recv IGMPv2 LEAVE from %s on %s: size=%d other than correct=%d",
 				from_str, ifp->name, igmp_msg_len,
@@ -213,7 +213,7 @@ int igmp_v2_recv_leave(struct gm_sock *igmp, struct ip *ip_hdr,
 
 	memcpy(&group_addr, igmp_msg + 4, sizeof(struct in_addr));
 
-	if (PIM_DEBUG_IGMP_PACKETS) {
+	if (PIM_DEBUG_GM_PACKETS) {
 		pim_inet4_dump("<dst?>", group_addr, group_str,
 			       sizeof(group_str));
 		zlog_debug("Recv IGMPv2 LEAVE from %s on %s for %s", from_str,

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -209,7 +209,7 @@ static void igmp_source_timer_on(struct gm_group *group,
 	source_timer_off(group, source);
 	struct pim_interface *pim_ifp = group->interface->info;
 
-	if (PIM_DEBUG_IGMP_EVENTS) {
+	if (PIM_DEBUG_GM_EVENTS) {
 		char group_str[INET_ADDRSTRLEN];
 		char source_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -1622,7 +1622,7 @@ void igmp_v3_send_query(struct gm_group *group, int fd, const char *ifname,
 	checksum = in_cksum(query_buf, msg_size);
 	*(uint16_t *)(query_buf + IGMP_CHECKSUM_OFFSET) = checksum;
 
-	if (PIM_DEBUG_IGMP_PACKETS) {
+	if (PIM_DEBUG_GM_PACKETS) {
 		char dst_str[INET_ADDRSTRLEN];
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<dst?>", dst_addr, dst_str, sizeof(dst_str));
@@ -1835,7 +1835,7 @@ static bool igmp_pkt_grp_addr_ok(struct interface *ifp, const char *from_str,
 
 	/* determine filtering status for group */
 	if (pim_is_group_filtered(pim_ifp, &grp)) {
-		if (PIM_DEBUG_IGMP_PACKETS) {
+		if (PIM_DEBUG_GM_PACKETS) {
 			zlog_debug(
 				"Filtering IGMPv3 group record %pI4 from %s on %s per prefix-list %s",
 				&grp.s_addr, from_str, ifp->name,
@@ -1852,7 +1852,7 @@ static bool igmp_pkt_grp_addr_ok(struct interface *ifp, const char *from_str,
 	grp_addr.s_addr = ntohl(grp.s_addr);
 
 	if (pim_is_group_224_0_0_0_24(grp_addr)) {
-		if (PIM_DEBUG_IGMP_PACKETS) {
+		if (PIM_DEBUG_GM_PACKETS) {
 			zlog_debug(
 				"Ignoring IGMPv3 group record %pI4 from %s on %s group range falls in 224.0.0.0/24",
 				&grp.s_addr, from_str, ifp->name);
@@ -1871,7 +1871,7 @@ static bool igmp_pkt_grp_addr_ok(struct interface *ifp, const char *from_str,
 		switch (rec_type) {
 		case IGMP_GRP_REC_TYPE_MODE_IS_EXCLUDE:
 		case IGMP_GRP_REC_TYPE_CHANGE_TO_EXCLUDE_MODE:
-			if (PIM_DEBUG_IGMP_PACKETS) {
+			if (PIM_DEBUG_GM_PACKETS) {
 				zlog_debug(
 					"Ignoring IGMPv3 group record %pI4 from %s on %s exclude mode in SSM range",
 					&grp.s_addr, from_str, ifp->name);
@@ -1930,7 +1930,7 @@ int igmp_v3_recv_report(struct gm_sock *igmp, struct in_addr from,
 		return -1;
 	}
 
-	if (PIM_DEBUG_IGMP_PACKETS) {
+	if (PIM_DEBUG_GM_PACKETS) {
 		zlog_debug(
 			"Recv IGMP report v3 from %s on %s: size=%d groups=%d",
 			from_str, ifp->name, igmp_msg_len, num_groups);
@@ -1967,7 +1967,7 @@ int igmp_v3_recv_report(struct gm_sock *igmp, struct in_addr from,
 		       group_record + IGMP_V3_GROUP_RECORD_GROUP_OFFSET,
 		       sizeof(struct in_addr));
 
-		if (PIM_DEBUG_IGMP_PACKETS) {
+		if (PIM_DEBUG_GM_PACKETS) {
 			zlog_debug(
 				"    Recv IGMP report v3 from %s on %s: record=%d type=%d auxdatalen=%d sources=%d group=%pI4",
 				from_str, ifp->name, i, rec_type,
@@ -1988,7 +1988,7 @@ int igmp_v3_recv_report(struct gm_sock *igmp, struct in_addr from,
 				return -1;
 			}
 
-			if (PIM_DEBUG_IGMP_PACKETS) {
+			if (PIM_DEBUG_GM_PACKETS) {
 				char src_str[200];
 
 				if (!inet_ntop(AF_INET, src, src_str,

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -635,7 +635,7 @@ static int process_igmp_packet(struct pim_instance *pim, const char *buf,
 	connected_src = pim_if_connected_to_source(ifp, ip_hdr->ip_src);
 
 	if (!connected_src) {
-		if (PIM_DEBUG_IGMP_PACKETS) {
+		if (PIM_DEBUG_GM_PACKETS) {
 			zlog_debug(
 				"Recv IGMP packet on interface: %s from a non-connected source: %pI4",
 				ifp->name, &ip_hdr->ip_src);
@@ -647,7 +647,7 @@ static int process_igmp_packet(struct pim_instance *pim, const char *buf,
 	ifaddr = connected_src->u.prefix4;
 	igmp = pim_igmp_sock_lookup_ifaddr(pim_ifp->gm_socket_list, ifaddr);
 
-	if (PIM_DEBUG_IGMP_PACKETS) {
+	if (PIM_DEBUG_GM_PACKETS) {
 		zlog_debug(
 			"%s(%s): igmp kernel upcall on %s(%p) for %pI4 -> %pI4",
 			__func__, pim->vrf->name, ifp->name, igmp,
@@ -655,7 +655,7 @@ static int process_igmp_packet(struct pim_instance *pim, const char *buf,
 	}
 	if (igmp)
 		pim_igmp_packet(igmp, (char *)buf, buf_size);
-	else if (PIM_DEBUG_IGMP_PACKETS) {
+	else if (PIM_DEBUG_GM_PACKETS) {
 		zlog_debug(
 			"No IGMP socket on interface: %s with connected source: %pFX",
 			ifp->name, connected_src);

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -62,7 +62,7 @@ int pim_debug_config_write(struct vty *vty)
 		vty_out(vty, "debug igmp events\n");
 		++writes;
 	}
-	if (PIM_DEBUG_IGMP_PACKETS) {
+	if (PIM_DEBUG_GM_PACKETS) {
 		vty_out(vty, "debug igmp packets\n");
 		++writes;
 	}

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -58,7 +58,7 @@ int pim_debug_config_write(struct vty *vty)
 		vty_out(vty, "debug msdp internal\n");
 		++writes;
 	}
-	if (PIM_DEBUG_IGMP_EVENTS) {
+	if (PIM_DEBUG_GM_EVENTS) {
 		vty_out(vty, "debug igmp events\n");
 		++writes;
 	}

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -160,7 +160,7 @@ extern uint8_t qpim_ecmp_rebalance_enable;
 	(router->debugs & (PIM_MASK_PIM_TRACE | PIM_MASK_PIM_TRACE_DETAIL))
 #define PIM_DEBUG_PIM_TRACE_DETAIL                                             \
 	(router->debugs & PIM_MASK_PIM_TRACE_DETAIL)
-#define PIM_DEBUG_IGMP_EVENTS (router->debugs & PIM_MASK_IGMP_EVENTS)
+#define PIM_DEBUG_GM_EVENTS (router->debugs & PIM_MASK_IGMP_EVENTS)
 #define PIM_DEBUG_IGMP_PACKETS (router->debugs & PIM_MASK_IGMP_PACKETS)
 #define PIM_DEBUG_IGMP_TRACE                                                   \
 	(router->debugs & (PIM_MASK_IGMP_TRACE | PIM_MASK_IGMP_TRACE_DETAIL))

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -161,7 +161,7 @@ extern uint8_t qpim_ecmp_rebalance_enable;
 #define PIM_DEBUG_PIM_TRACE_DETAIL                                             \
 	(router->debugs & PIM_MASK_PIM_TRACE_DETAIL)
 #define PIM_DEBUG_GM_EVENTS (router->debugs & PIM_MASK_IGMP_EVENTS)
-#define PIM_DEBUG_IGMP_PACKETS (router->debugs & PIM_MASK_IGMP_PACKETS)
+#define PIM_DEBUG_GM_PACKETS (router->debugs & PIM_MASK_IGMP_PACKETS)
 #define PIM_DEBUG_IGMP_TRACE                                                   \
 	(router->debugs & (PIM_MASK_IGMP_TRACE | PIM_MASK_IGMP_TRACE_DETAIL))
 #define PIM_DEBUG_IGMP_TRACE_DETAIL                                            \


### PR DESCRIPTION
Changing the below macros to common 
PIM_DEBUG_IGMP_EVENTS to PIM_DEBUG_GM_EVENTS
PIM_DEBUG_IGMP_PACKETS to PIM_DEBUG_GM_PACKETS
so that it can be used for both IGMP and MLD debugs.

Issue: #11895
