### PR TITLE
bgpd: Do not set bgp_dest to NULL when defering

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3261,8 +3261,7 @@ void bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi)
 
 	/* Process the route list */
 	for (dest = bgp_table_top(bgp->rib[afi][safi]);
-	     dest && bgp->gr_info[afi][safi].gr_deferred != 0 &&
-	     cnt < BGP_MAX_BEST_ROUTE_SELECT;
+	     dest && bgp->gr_info[afi][safi].gr_deferred != 0;
 	     dest = bgp_route_next(dest)) {
 		if (!CHECK_FLAG(dest->flags, BGP_NODE_SELECT_DEFER))
 			continue;
@@ -3271,13 +3270,10 @@ void bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi)
 		bgp->gr_info[afi][safi].gr_deferred--;
 		bgp_process_main_one(bgp, dest, afi, safi);
 		cnt++;
-	}
-	/* If iteration stopped before the entire table was traversed then the
-	 * node needs to be unlocked.
-	 */
-	if (dest) {
-		bgp_dest_unlock_node(dest);
-		dest = NULL;
+		if (cnt >= BGP_MAX_BEST_ROUTE_SELECT) {
+			bgp_dest_unlock_node(dest);
+			break;
+		}
 	}
 
 	/* Send EOR message when all routes are processed */


### PR DESCRIPTION
```
(gdb) bt full
0  0x00007fc197d3ffe1 in raise () from /lib/x86_64-linux-gnu/[libpthread.so](http://libpthread.so/).0
No symbol table info available.
1  0x00007fc197f776cc in core_handler (signo=11, siginfo=0x7ffd6ab650f0, context=<optimized out>)
    at lib/sigevent.c:262
        pc = 0x7fc197f832ee <route_node_match+94>
        sa_default = {__sigaction_handler = {sa_handler = 0x0, sa_sigaction = 0x0}, sa_mask = {__val = {
              0 <repeats 16 times>}}, sa_flags = 0, sa_restorer = 0x0}
        sigset = {__val = {9216, 0 <repeats 15 times>}}
2  <signal handler called>
No symbol table info available.
3  0x00007fc197f832ee in route_node_match (table=table@entry=0x5612f410c0d0, pu=..., pu@entry=...) at lib/table.c:208
        p = 0x7ffd6ab65be0
        node = 0x8c8b61e7
        matched = 0x0
4  0x00007fc197f6c1a0 in route_map_get_index_list (table=0x5612f410c0d0, prefix=0x7ffd6ab65be0,
    rn=<synthetic pointer>) at lib/routemap.c:1778
        tmp_rn = 0x0
        tmp_rn = <optimized out>
5  route_map_get_index (match_ret=<synthetic pointer>, object=0x7ffd6ab65600, prefix=0x7ffd6ab65be0,
    map=0x5612f433e710) at lib/routemap.c:1835
        table = <optimized out>
        ret = <optimized out>
        candidate_rmap_list = <optimized out>
        rn = 0x0
        nn = <optimized out>
        family = <optimized out>
        ln = <optimized out>
        index = <optimized out>
        best_index = 0x0
        head_index = <optimized out>
        ret = <optimized out>
        candidate_rmap_list = <optimized out>
        rn = <optimized out>
        ln = <optimized out>
        nn = <optimized out>
        index = <optimized out>
        best_index = <optimized out>
        head_index = <optimized out>
        table = <optimized out>
        family = <optimized out>
        __func__ = "route_map_get_index"
        _xref = {xref = {xrefdata = 0x0, type = XREFT_ASSERT, line = 1843, file = 0x7fc197fcc964 "lib/routemap.c",
            func = 0x7fc197fcc120 <__func__.38> "route_map_get_index"},
          expr = 0x7fc197fccf60 "((candidate_rmap_list) ? ((candidate_rmap_list)->head) : ((void *)0))", extra = 0x0,
          args = 0x0}
        xref_p_14 = 0x7fc198030320 <_xref.42>
        _xref = {xref = {xrefdata = 0x0, type = XREFT_ASSERT, line = 1843, file = 0x7fc197fcc964 "lib/routemap.c",
            func = 0x7fc197fcc120 <__func__.38> "route_map_get_index"},
          expr = 0x7fc197fccf08 "(((candidate_rmap_list) ? ((candidate_rmap_list)->head) : ((void *)0)))->data != NULL", extra = 0x0, args = 0x0}
        xref_p_15 = 0x7fc1980302e0 <_xref.41>
        _xref = {xref = {xrefdata = 0x0, type = XREFT_ASSERT, line = 1851, file = 0x7fc197fcc964 "lib/routemap.c",
            func = 0x7fc197fcc120 <__func__.38> "route_map_get_index"}, expr = 0x7fc197fb19c0 "ln", extra = 0x0,
          args = 0x0}
        xref_p_16 = 0x7fc1980302a0 <_xref.40>
        _xref = {xref = {xrefdata = 0x0, type = XREFT_ASSERT, line = 1851, file = 0x7fc197fcc964 "lib/routemap.c",
            func = 0x7fc197fcc120 <__func__.38> "route_map_get_index"}, expr = 0x7fc197fb19ad "(ln)->data != NULL",
          extra = 0x0, args = 0x0}
--Type <RET> for more, q to quit, c to continue without paging--
        xref_p_17 = 0x7fc198030260 <_xref.39>
6  route_map_apply_ext (map=0x5612f433e710, prefix=prefix@entry=0x7ffd6ab65be0,
    match_object=match_object@entry=0x7ffd6ab65600, set_object=set_object@entry=0x7ffd6ab65600) at lib/routemap.c:2570
        recursion = 0
        match_ret = <optimized out>
        ret = RMAP_PERMITMATCH
        index = 0x0
        set = 0x0
        skip_match_clause = false
        __func__ = {<optimized out> <repeats 20 times>}
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>