### PR TITLE
isisd: fix show isis database [detail] json

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -746,6 +746,10 @@ void lsp_print_common(struct isis_lsp *lsp, struct vty *vty, struct json_object 
 	}
 }
 
+#if CONFDATE > 20240916
+CPP_NOTICE("Remove JSON in '-' format")
+#endif
+
 void lsp_print_json(struct isis_lsp *lsp, struct json_object *json,
 	       char dynhost, struct isis *isis)
 {
@@ -759,10 +763,20 @@ void lsp_print_json(struct isis_lsp *lsp, struct json_object *json,
 	own_json = json_object_new_object();
 	json_object_object_add(json, "lsp", own_json);
 	json_object_string_add(own_json, "id", LSPid);
+#if CONFDATE > 20240916
+	CPP_NOTICE("remove own key")
+#endif
 	json_object_string_add(own_json, "own", lsp->own_lsp ? "*" : " ");
+	if (lsp->own_lsp)
+		json_object_boolean_add(own_json, "ownLSP", true);
 	json_object_int_add(json, "pdu-len", lsp->hdr.pdu_len);
+	json_object_int_add(json, "pduLen", lsp->hdr.pdu_len);
 	snprintfrr(buf, sizeof(buf), "0x%08x", lsp->hdr.seqno);
+#if CONFDATE > 20240916
+	CPP_NOTICE("remove seq-number key")
+#endif
 	json_object_string_add(json, "seq-number", buf);
+	json_object_string_add(json, "seqNumber", buf);
 	snprintfrr(buf, sizeof(buf), "0x%04hx", lsp->hdr.checksum);
 	json_object_string_add(json, "chksum", buf);
 	if (lsp->hdr.rem_lifetime == 0) {
@@ -772,8 +786,13 @@ void lsp_print_json(struct isis_lsp *lsp, struct json_object *json,
 	} else {
 		json_object_int_add(json, "holdtime", lsp->hdr.rem_lifetime);
 	}
+#if CONFDATE > 20240916
+	CPP_NOTICE("remove att-p-ol key")
+#endif
 	json_object_string_add(
 		json, "att-p-ol", lsp_bits2string(lsp->hdr.lsp_bits, b, sizeof(b)));
+	json_object_string_add(json, "attPOl",
+			       lsp_bits2string(lsp->hdr.lsp_bits, b, sizeof(b)));
 }
 
 void lsp_print_vty(struct isis_lsp *lsp, struct vty *vty,

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -492,8 +492,23 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 
 	if (IS_SUBTLV(exts, EXT_EXTEND_ADM_GRP) &&
 	    admin_group_nb_words(&exts->ext_admin_group) != 0) {
-		if (!json) {
-			/* TODO json after fix show database detail json */
+		if (json) {
+			struct json_object *ext_adm_grp_json;
+			size_t i;
+			ext_adm_grp_json = json_object_new_object();
+			json_object_object_add(json, "extendedAdminGroup",
+					       ext_adm_grp_json);
+			for (i = 0;
+			     i < admin_group_nb_words(&exts->ext_admin_group);
+			     i++) {
+				snprintfrr(cnt_buf, sizeof(cnt_buf), "%lu",
+					   (unsigned long)i);
+				json_object_string_addf(ext_adm_grp_json,
+							cnt_buf, "0x%x",
+							exts->ext_admin_group
+								.bitmap.data[i]);
+			}
+		} else {
 			sbuf_push(buf, indent, "Ext Admin Group: %s\n",
 				  admin_group_string(
 					  admin_group_buf,

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -3202,7 +3202,7 @@ static void format_item_extended_reach(uint16_t mtid, struct isis_item *i,
 					       isis_mtid2str(mtid));
 
 		if (r->subtlvs)
-			format_item_ext_subtlvs(r->subtlvs, NULL, json,
+			format_item_ext_subtlvs(r->subtlvs, NULL, reach_json,
 						indent + 2, mtid);
 	} else {
 		sbuf_push(buf, indent, "%s Reachability: %s (Metric: %u)",
@@ -3906,21 +3906,22 @@ static void format_item_extended_ip_reach(uint16_t mtid, struct isis_item *i,
 			json_object_object_add(json, "ext-ip-reach", array_json);
 		}
 		json_object_array_add(array_json, ext_json);
-		json_object_string_add(
-			json, "mt-id",
-			(mtid == ISIS_MT_IPV4_UNICAST) ? "Extended" : "MT");
-		json_object_string_add(
-			json, "ip-reach",
-			prefix2str(&r->prefix, prefixbuf, sizeof(prefixbuf)));
-		json_object_int_add(json, "ip-reach-metric", r->metric);
-		json_object_string_add(json, "down", r->down ? "yes" : "");
+		json_object_string_add(ext_json, "mt-id",
+				       (mtid == ISIS_MT_IPV4_UNICAST)
+					       ? "Extended"
+					       : "MT");
+		json_object_string_add(ext_json, "ip-reach",
+				       prefix2str(&r->prefix, prefixbuf,
+						  sizeof(prefixbuf)));
+		json_object_int_add(ext_json, "ip-reach-metric", r->metric);
+		json_object_string_add(ext_json, "down", r->down ? "yes" : "");
 		if (mtid != ISIS_MT_IPV4_UNICAST)
-			json_object_string_add(json, "mt-name",
+			json_object_string_add(ext_json, "mt-name",
 					       isis_mtid2str(mtid));
 		if (r->subtlvs) {
 			struct json_object *subtlv_json;
 			subtlv_json = json_object_new_object();
-			json_object_object_add(json, "subtlvs", subtlv_json);
+			json_object_object_add(ext_json, "subtlvs", subtlv_json);
 			format_subtlvs(r->subtlvs, NULL, subtlv_json, 0);
 		}
 	} else {
@@ -4559,7 +4560,8 @@ static void format_item_ipv6_reach(uint16_t mtid, struct isis_item *i,
 		if (r->subtlvs) {
 			struct json_object *subtlvs_json;
 			subtlvs_json = json_object_new_object();
-			json_object_object_add(json, "subtlvs", subtlvs_json);
+			json_object_object_add(reach_json, "subtlvs",
+					       subtlvs_json);
 			format_subtlvs(r->subtlvs, NULL, subtlvs_json, 0);
 		}
 	} else {

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -955,7 +955,8 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 				json_object_array_add(arr_adj_json, flags_json);
 				if (adj->subsubtlvs)
 					isis_format_subsubtlvs(adj->subsubtlvs,
-							       NULL, json,
+							       NULL,
+							       arr_adj_json,
 							       indent + 4);
 			}
 		} else
@@ -1031,7 +1032,8 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 				json_object_array_add(arr_adj_json, flags_json);
 				if (lan->subsubtlvs)
 					isis_format_subsubtlvs(lan->subsubtlvs,
-							       NULL, json,
+							       NULL,
+							       arr_adj_json,
 							       indent + 4);
 			}
 		} else

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -454,6 +454,10 @@ static void format_item_asla_subtlvs(struct isis_asla_subtlvs *asla,
 			  asla->use_bw);
 }
 
+#if CONFDATE > 20240916
+CPP_NOTICE("Remove JSON in '-' format")
+#endif
+
 /* mtid parameter is used to manage multi-topology i.e. IPv4 / IPv6 */
 static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 				    struct sbuf *buf, struct json_object *json,
@@ -470,7 +474,11 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 		if (json) {
 			snprintfrr(aux_buf, sizeof(aux_buf), "0x%x",
 				   exts->adm_group);
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_string_add(json, "adm-group", aux_buf);
+			json_object_string_add(json, "admGroup", aux_buf);
 		} else {
 			sbuf_push(buf, indent, "Admin Group: 0x%08x\n",
 				  exts->adm_group);
@@ -505,9 +513,16 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 	}
 	if (IS_SUBTLV(exts, EXT_LLRI)) {
 		if (json) {
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_int_add(json, "link-local-id",
 					    exts->local_llri);
 			json_object_int_add(json, "link-remote-id",
+					    exts->remote_llri);
+			json_object_int_add(json, "linkLocalId",
+					    exts->local_llri);
+			json_object_int_add(json, "linkRemoteId",
 					    exts->remote_llri);
 		} else {
 			sbuf_push(buf, indent, "Link Local  ID: %u\n",
@@ -520,7 +535,11 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 		if (json) {
 			inet_ntop(AF_INET, &exts->local_addr, aux_buf,
 				  sizeof(aux_buf));
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_string_add(json, "local-iface-ip", aux_buf);
+			json_object_string_add(json, "localIfaceIp", aux_buf);
 		} else
 			sbuf_push(buf, indent,
 				  "Local Interface IP Address(es): %pI4\n",
@@ -530,8 +549,12 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 		if (json) {
 			inet_ntop(AF_INET, &exts->neigh_addr, aux_buf,
 				  sizeof(aux_buf));
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_string_add(json, "remote-iface-ip",
 					       aux_buf);
+			json_object_string_add(json, "remoteIfaceIp", aux_buf);
 		} else
 			sbuf_push(buf, indent,
 				  "Remote Interface IP Address(es): %pI4\n",
@@ -541,8 +564,12 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 		if (json) {
 			inet_ntop(AF_INET6, &exts->local_addr6, aux_buf,
 				  sizeof(aux_buf));
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_string_add(json, "local-iface-ipv6",
 					       aux_buf);
+			json_object_string_add(json, "localIfaceIpv6", aux_buf);
 		} else
 			sbuf_push(buf, indent,
 				  "Local Interface IPv6 Address(es): %pI6\n",
@@ -552,8 +579,12 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 		if (json) {
 			inet_ntop(AF_INET6, &exts->neigh_addr6, aux_buf,
 				  sizeof(aux_buf));
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_string_add(json, "remote-iface-ipv6",
 					       aux_buf);
+			json_object_string_add(json, "remoteIfaceIpv6", aux_buf);
 		} else
 			sbuf_push(buf, indent,
 				  "Remote Interface IPv6 Address(es): %pI6\n",
@@ -563,7 +594,12 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 		if (json) {
 			snprintfrr(aux_buf, sizeof(aux_buf), "%g",
 				   exts->max_bw);
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_string_add(json, "max-bandwith-bytes-sec",
+					       aux_buf);
+			json_object_string_add(json, "maxBandwithBytesSec",
 					       aux_buf);
 		} else
 			sbuf_push(buf, indent,
@@ -574,8 +610,13 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 		if (json) {
 			snprintfrr(aux_buf, sizeof(aux_buf), "%g",
 				   exts->max_rsv_bw);
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_string_add(
 				json, "max-res-bandwith-bytes-sec", aux_buf);
+			json_object_string_add(json, "maxResBandwithBytesSec",
+					       aux_buf);
 		} else
 			sbuf_push(
 				buf, indent,
@@ -585,6 +626,22 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 	if (IS_SUBTLV(exts, EXT_UNRSV_BW)) {
 		if (json) {
 			struct json_object *unrsv_json;
+
+			unrsv_json = json_object_new_object();
+			json_object_object_add(json, "unrsvBandwithBytesSec",
+					       unrsv_json);
+			for (int j = 0; j < MAX_CLASS_TYPE; j += 1) {
+				snprintfrr(cnt_buf, sizeof(cnt_buf), "%d", j);
+				snprintfrr(aux_buf, sizeof(aux_buf), "%g",
+					   exts->unrsv_bw[j]);
+				json_object_string_add(unrsv_json, cnt_buf,
+						       aux_buf);
+			}
+
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
+			/* old deprecated key format */
 			unrsv_json = json_object_new_object();
 			json_object_object_add(json, "unrsv-bandwith-bytes-sec",
 					       unrsv_json);
@@ -595,6 +652,7 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 				json_object_string_add(unrsv_json, cnt_buf,
 						       aux_buf);
 			}
+			/* end old deprecated key format */
 		} else {
 			sbuf_push(buf, indent, "Unreserved Bandwidth:\n");
 			for (int j = 0; j < MAX_CLASS_TYPE; j += 2) {
@@ -608,7 +666,11 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 	}
 	if (IS_SUBTLV(exts, EXT_TE_METRIC)) {
 		if (json) {
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_int_add(json, "te-metric", exts->te_metric);
+			json_object_int_add(json, "teMetric", exts->te_metric);
 		} else
 			sbuf_push(buf, indent,
 				  "Traffic Engineering Metric: %u\n",
@@ -616,7 +678,12 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 	}
 	if (IS_SUBTLV(exts, EXT_RMT_AS)) {
 		if (json) {
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_int_add(json, "inter-as-te-remote-as",
+					    exts->remote_as);
+			json_object_int_add(json, "interAsTeRemoteAs",
 					    exts->remote_as);
 		} else
 			sbuf_push(buf, indent,
@@ -627,8 +694,13 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 		if (json) {
 			inet_ntop(AF_INET6, &exts->remote_ip, aux_buf,
 				  sizeof(aux_buf));
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_string_add(
 				json, "inter-as-te-remote-asbr-ip", aux_buf);
+			json_object_string_add(json, "interAsTeRemoteAsbrIp",
+					       aux_buf);
 		} else
 			sbuf_push(buf, indent,
 				  "Inter-AS TE Remote ASBR IP address: %pI4\n",
@@ -639,12 +711,23 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 		if (json) {
 			struct json_object *avg_json;
 			avg_json = json_object_new_object();
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_object_add(json, "avg-delay", avg_json);
 			json_object_string_add(avg_json, "delay",
 					       IS_ANORMAL(exts->delay)
 						       ? "Anomalous"
 						       : "Normal");
 			json_object_int_add(avg_json, "micro-sec", exts->delay);
+
+			avg_json = json_object_new_object();
+			json_object_object_add(json, "avgDelay", avg_json);
+			json_object_string_add(avg_json, "delay",
+					       IS_ANORMAL(exts->delay)
+						       ? "Anomalous"
+						       : "Normal");
+			json_object_int_add(avg_json, "microSec", exts->delay);
 		} else
 			sbuf_push(buf, indent,
 				  "%s Average Link Delay: %u (micro-sec)\n",
@@ -656,6 +739,9 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 		if (json) {
 			struct json_object *avg_json;
 			avg_json = json_object_new_object();
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_object_add(json, "max-min-delay", avg_json);
 			json_object_string_add(avg_json, "delay",
 					       IS_ANORMAL(exts->min_delay)
@@ -665,6 +751,17 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 				   exts->min_delay & TE_EXT_MASK,
 				   exts->max_delay & TE_EXT_MASK);
 			json_object_string_add(avg_json, "micro-sec", aux_buf);
+
+			avg_json = json_object_new_object();
+			json_object_object_add(json, "maxMinDelay", avg_json);
+			json_object_string_add(avg_json, "delay",
+					       IS_ANORMAL(exts->min_delay)
+						       ? "Anomalous"
+						       : "Normal");
+			snprintfrr(aux_buf, sizeof(aux_buf), "%u / %u",
+				   exts->min_delay & TE_EXT_MASK,
+				   exts->max_delay & TE_EXT_MASK);
+			json_object_string_add(avg_json, "microSec", aux_buf);
 
 		} else
 			sbuf_push(
@@ -677,7 +774,12 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 	}
 	if (IS_SUBTLV(exts, EXT_DELAY_VAR)) {
 		if (json) {
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_int_add(json, "delay-variation-micro-sec",
+					    exts->delay_var & TE_EXT_MASK);
+			json_object_int_add(json, "delayVariationMicroSec",
 					    exts->delay_var & TE_EXT_MASK);
 		} else
 			sbuf_push(buf, indent,
@@ -690,6 +792,10 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 				   (float)((exts->pkt_loss & TE_EXT_MASK) *
 					   LOSS_PRECISION));
 			struct json_object *link_json;
+
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			link_json = json_object_new_object();
 			json_object_object_add(json, "link-packet-loss",
 					       link_json);
@@ -697,8 +803,18 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 					       IS_ANORMAL(exts->pkt_loss)
 						       ? "Anomalous"
 						       : "Normal");
+			/* typo */
 			json_object_string_add(link_json, "percentaje",
 					       aux_buf);
+
+			link_json = json_object_new_object();
+			json_object_object_add(json, "linkPacketLoss",
+					       link_json);
+			json_object_string_add(link_json, "loss",
+					       IS_ANORMAL(exts->pkt_loss)
+						       ? "Anomalous"
+						       : "Normal");
+			json_object_string_add(link_json, "percentage", aux_buf);
 		} else
 			sbuf_push(buf, indent, "%s Link Packet Loss: %g (%%)\n",
 				  IS_ANORMAL(exts->pkt_loss) ? "Anomalous"
@@ -710,8 +826,14 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 		if (json) {
 			snprintfrr(aux_buf, sizeof(aux_buf), "%g",
 				   (exts->res_bw));
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_string_add(json,
 					       "unidir-residual-band-bytes-sec",
+					       aux_buf);
+			json_object_string_add(json,
+					       "unidirResidualBandBytesSec",
 					       aux_buf);
 		} else
 			sbuf_push(
@@ -723,9 +845,15 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 		if (json) {
 			snprintfrr(aux_buf, sizeof(aux_buf), "%g",
 				   (exts->ava_bw));
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_string_add(
 				json, "unidir-available-band-bytes-sec",
 				aux_buf);
+			json_object_string_add(json,
+					       "unidirAvailableBandBytesSec",
+					       aux_buf);
 		} else
 			sbuf_push(
 				buf, indent,
@@ -739,6 +867,12 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 			json_object_string_add(json,
 					       "unidir-utilized-band-bytes-sec",
 					       aux_buf);
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
+			json_object_string_add(json,
+					       "unidirUtilizedBandBytesSec",
+					       aux_buf);
 		} else
 			sbuf_push(
 				buf, indent,
@@ -751,6 +885,11 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 
 		if (json) {
 			struct json_object *arr_adj_json, *flags_json;
+
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
+			/* old deprecated key format */
 			arr_adj_json = json_object_new_array();
 			json_object_object_add(json, "adj-sid", arr_adj_json);
 			for (adj = (struct isis_adj_sid *)exts->adj_sid.head;
@@ -794,6 +933,44 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 						: "0");
 				json_object_array_add(arr_adj_json, flags_json);
 			}
+			/* end old deprecated key format */
+
+			arr_adj_json = json_object_new_array();
+			json_object_object_add(json, "adjSid", arr_adj_json);
+			for (adj = (struct isis_adj_sid *)exts->adj_sid.head;
+			     adj; adj = adj->next) {
+				snprintfrr(cnt_buf, sizeof(cnt_buf), "%d",
+					   adj->sid);
+				flags_json = json_object_new_object();
+				json_object_int_add(flags_json, "sid", adj->sid);
+				json_object_int_add(flags_json, "weight",
+						    adj->weight);
+				json_object_boolean_add(flags_json, "flagF",
+							adj->flags & EXT_SUBTLV_LINK_ADJ_SID_FFLG
+								? true
+								: false);
+				json_object_boolean_add(flags_json, "flagB",
+							adj->flags & EXT_SUBTLV_LINK_ADJ_SID_BFLG
+								? true
+								: false);
+				json_object_boolean_add(flags_json, "flagV",
+							adj->flags & EXT_SUBTLV_LINK_ADJ_SID_VFLG
+								? true
+								: false);
+				json_object_boolean_add(flags_json, "flagL",
+							adj->flags & EXT_SUBTLV_LINK_ADJ_SID_LFLG
+								? true
+								: false);
+				json_object_boolean_add(flags_json, "flagS",
+							adj->flags & EXT_SUBTLV_LINK_ADJ_SID_SFLG
+								? true
+								: false);
+				json_object_boolean_add(flags_json, "flagP",
+							adj->flags & EXT_SUBTLV_LINK_ADJ_SID_PFLG
+								? true
+								: false);
+				json_object_array_add(arr_adj_json, flags_json);
+			}
 		} else
 			for (adj = (struct isis_adj_sid *)exts->adj_sid.head;
 			     adj; adj = adj->next) {
@@ -826,6 +1003,11 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 		struct isis_lan_adj_sid *lan;
 		if (json) {
 			struct json_object *arr_adj_json, *flags_json;
+
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
+			/* old deprecated key format */
 			arr_adj_json = json_object_new_array();
 			json_object_object_add(json, "lan-adj-sid",
 					       arr_adj_json);
@@ -876,6 +1058,49 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 						: "0");
 				json_object_array_add(arr_adj_json, flags_json);
 			}
+			/* end old deprecated key format */
+
+			arr_adj_json = json_object_new_array();
+			json_object_object_add(json, "lanAdjSid", arr_adj_json);
+			for (lan = (struct isis_lan_adj_sid *)exts->adj_sid.head;
+			     lan; lan = lan->next) {
+				if (((mtid == ISIS_MT_IPV4_UNICAST) &&
+				     (lan->family != AF_INET)) ||
+				    ((mtid == ISIS_MT_IPV6_UNICAST) &&
+				     (lan->family != AF_INET6)))
+					continue;
+				snprintfrr(cnt_buf, sizeof(cnt_buf), "%d",
+					   lan->sid);
+				flags_json = json_object_new_object();
+				json_object_int_add(flags_json, "sid", lan->sid);
+				json_object_int_add(flags_json, "weight",
+						    lan->weight);
+				json_object_boolean_add(flags_json, "flagF",
+							lan->flags & EXT_SUBTLV_LINK_ADJ_SID_FFLG
+								? true
+								: false);
+				json_object_boolean_add(flags_json, "flagB",
+							lan->flags & EXT_SUBTLV_LINK_ADJ_SID_BFLG
+								? true
+								: false);
+				json_object_boolean_add(flags_json, "flagV",
+							lan->flags & EXT_SUBTLV_LINK_ADJ_SID_VFLG
+								? true
+								: false);
+				json_object_boolean_add(flags_json, "flagL",
+							lan->flags & EXT_SUBTLV_LINK_ADJ_SID_LFLG
+								? true
+								: false);
+				json_object_boolean_add(flags_json, "flagS",
+							lan->flags & EXT_SUBTLV_LINK_ADJ_SID_SFLG
+								? true
+								: false);
+				json_object_boolean_add(flags_json, "flagP",
+							lan->flags & EXT_SUBTLV_LINK_ADJ_SID_PFLG
+								? true
+								: false);
+				json_object_array_add(arr_adj_json, flags_json);
+			}
 		} else
 
 			for (lan = (struct isis_lan_adj_sid *)
@@ -918,6 +1143,11 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 
 		if (json) {
 			struct json_object *arr_adj_json, *flags_json;
+
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
+			/* old deprecated key format */
 			arr_adj_json = json_object_new_array();
 			json_object_object_add(json, "srv6-endx-sid",
 					       arr_adj_json);
@@ -959,6 +1189,45 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 							       arr_adj_json,
 							       indent + 4);
 			}
+			/* end old deprecated key format */
+
+			arr_adj_json = json_object_new_array();
+			json_object_object_add(json, "srv6EndSID", arr_adj_json);
+			for (adj = (struct isis_srv6_endx_sid_subtlv *)
+					   exts->srv6_endx_sid.head;
+			     adj; adj = adj->next) {
+				snprintfrr(cnt_buf, sizeof(cnt_buf), "%pI6",
+					   &adj->sid);
+				flags_json = json_object_new_object();
+				json_object_string_addf(flags_json, "sid",
+							"%pI6", &adj->sid);
+				json_object_string_add(flags_json, "algorithm",
+						       sr_algorithm_string(
+							       adj->algorithm));
+				json_object_int_add(flags_json, "weight",
+						    adj->weight);
+				json_object_string_add(flags_json, "behavior",
+						       seg6local_action2str(
+							       adj->behavior));
+				json_object_boolean_add(
+					flags_json, "flagB",
+					!!(adj->flags &
+					   EXT_SUBTLV_LINK_SRV6_ENDX_SID_BFLG));
+				json_object_boolean_add(
+					flags_json, "flagS",
+					!!(adj->flags &
+					   EXT_SUBTLV_LINK_SRV6_ENDX_SID_SFLG));
+				json_object_boolean_add(
+					flags_json, "flagP",
+					!!(adj->flags &
+					   EXT_SUBTLV_LINK_SRV6_ENDX_SID_PFLG));
+				json_object_array_add(arr_adj_json, flags_json);
+				if (adj->subsubtlvs)
+					isis_format_subsubtlvs(adj->subsubtlvs,
+							       NULL,
+							       arr_adj_json,
+							       indent + 4);
+			}
 		} else
 			for (adj = (struct isis_srv6_endx_sid_subtlv *)
 					   exts->srv6_endx_sid.head;
@@ -990,6 +1259,11 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 		struct isis_srv6_lan_endx_sid_subtlv *lan;
 		if (json) {
 			struct json_object *arr_adj_json, *flags_json;
+
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
+			/* old deprecated key format */
 			arr_adj_json = json_object_new_array();
 			json_object_object_add(json, "srv6-lan-endx-sid",
 					       arr_adj_json);
@@ -1026,6 +1300,51 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 					lan->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_PFLG
 						? "1"
 						: "0");
+				json_object_string_addf(flags_json,
+							"neighbor-id", "%pSY",
+							lan->neighbor_id);
+				json_object_array_add(arr_adj_json, flags_json);
+				if (lan->subsubtlvs)
+					isis_format_subsubtlvs(lan->subsubtlvs,
+							       NULL,
+							       arr_adj_json,
+							       indent + 4);
+			}
+			/* end old deprecated key format */
+
+			arr_adj_json = json_object_new_array();
+			json_object_object_add(json, "srv6LanEndxSID",
+					       arr_adj_json);
+			for (lan = (struct isis_srv6_lan_endx_sid_subtlv *)
+					   exts->srv6_lan_endx_sid.head;
+			     lan; lan = lan->next) {
+				snprintfrr(cnt_buf, sizeof(cnt_buf), "%pI6",
+					   &lan->sid);
+				flags_json = json_object_new_object();
+				json_object_string_addf(flags_json, "sid",
+							"%pI6", &lan->sid);
+				json_object_int_add(flags_json, "weight",
+						    lan->weight);
+				json_object_string_add(flags_json, "algorithm",
+						       sr_algorithm_string(
+							       lan->algorithm));
+				json_object_int_add(flags_json, "weight",
+						    lan->weight);
+				json_object_string_add(flags_json, "behavior",
+						       seg6local_action2str(
+							       lan->behavior));
+				json_object_boolean_add(
+					flags_json, "flagB",
+					!!(lan->flags &
+					   EXT_SUBTLV_LINK_SRV6_ENDX_SID_BFLG));
+				json_object_boolean_add(
+					flags_json, "flagS",
+					!!(lan->flags &
+					   EXT_SUBTLV_LINK_SRV6_ENDX_SID_SFLG));
+				json_object_boolean_add(
+					flags_json, "flagP",
+					!!(lan->flags &
+					   EXT_SUBTLV_LINK_SRV6_ENDX_SID_PFLG));
 				json_object_string_addf(flags_json,
 							"neighbor-id", "%pSY",
 							lan->neighbor_id);
@@ -2130,6 +2449,7 @@ static void format_item_prefix_sid(uint16_t mtid, struct isis_item *i,
 
 	if (json) {
 		struct json_object *sr_json, *array_json;
+
 		sr_json = json_object_new_object();
 		json_object_object_get_ex(json, "sr", &array_json);
 		if (!array_json) {
@@ -2143,6 +2463,11 @@ static void format_item_prefix_sid(uint16_t mtid, struct isis_item *i,
 			json_object_int_add(sr_json, "index", sid->value);
 		}
 		json_object_int_add(sr_json, "alg", sid->algorithm);
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated non boolean json")
+#endif
+		/* old deprecated keys (no booleans) */
 		json_object_string_add(
 			sr_json, "readvertised",
 			((sid->flags & ISIS_PREFIX_SID_READVERTISED) ? "yes"
@@ -2164,6 +2489,27 @@ static void format_item_prefix_sid(uint16_t mtid, struct isis_item *i,
 		json_object_string_add(
 			sr_json, "local",
 			((sid->flags & ISIS_PREFIX_SID_LOCAL) ? "yes" : ""));
+		/* end deprecated keys (no booleans) */
+
+		struct json_object *flags_json;
+
+		flags_json = json_object_new_object();
+		json_object_object_add(sr_json, "flags", flags_json);
+
+		json_object_boolean_add(flags_json, "readvertised",
+					!!(sid->flags &
+					   ISIS_PREFIX_SID_READVERTISED));
+		json_object_boolean_add(flags_json, "node",
+					!!(sid->flags & ISIS_PREFIX_SID_NODE));
+		json_object_boolean_add(flags_json, "noPHP",
+					!!(sid->flags & ISIS_PREFIX_SID_NO_PHP));
+		json_object_boolean_add(flags_json, "explicitNull",
+					!!(sid->flags &
+					   ISIS_PREFIX_SID_EXPLICIT_NULL));
+		json_object_boolean_add(flags_json, "value",
+					!!(sid->flags & ISIS_PREFIX_SID_VALUE));
+		json_object_boolean_add(flags_json, "local",
+					!!(sid->flags & ISIS_PREFIX_SID_LOCAL));
 
 	} else {
 		sbuf_push(buf, indent, "SR Prefix-SID ");
@@ -2293,7 +2639,11 @@ static void format_subtlv_ipv6_source_prefix(struct prefix_ipv6 *p,
 	char prefixbuf[PREFIX2STR_BUFFER];
 	if (json) {
 		prefix2str(p, prefixbuf, sizeof(prefixbuf));
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
 		json_object_string_add(json, "ipv6-src-prefix", prefixbuf);
+		json_object_string_add(json, "ipv6SrcPrefix", prefixbuf);
 	} else {
 		sbuf_push(buf, indent, "IPv6 Source Prefix: %s\n",
 			  prefix2str(p, prefixbuf, sizeof(prefixbuf)));
@@ -2395,6 +2745,11 @@ static void format_subsubtlv_srv6_sid_structure(
 
 	if (json) {
 		struct json_object *sid_struct_json;
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* old deprecated key format */
 		sid_struct_json = json_object_new_object();
 		json_object_object_add(json, "srv6-sid-structure",
 				       sid_struct_json);
@@ -2405,6 +2760,19 @@ static void format_subsubtlv_srv6_sid_structure(
 		json_object_int_add(sid_struct_json, "func-len",
 				    sid_struct->func_len);
 		json_object_int_add(sid_struct_json, "arg-len",
+				    sid_struct->arg_len);
+		/* end old deprecated key format */
+
+		sid_struct_json = json_object_new_object();
+		json_object_object_add(json, "srv6SidStructure",
+				       sid_struct_json);
+		json_object_int_add(sid_struct_json, "locBlockLen",
+				    sid_struct->loc_block_len);
+		json_object_int_add(sid_struct_json, "locNodeLen",
+				    sid_struct->loc_node_len);
+		json_object_int_add(sid_struct_json, "funcLen",
+				    sid_struct->func_len);
+		json_object_int_add(sid_struct_json, "argLen",
 				    sid_struct->arg_len);
 	} else {
 		sbuf_push(buf, indent, "SRv6 SID Structure ");
@@ -2687,12 +3055,32 @@ static void format_item_srv6_end_sid(uint16_t mtid, struct isis_item *i,
 
 	if (json) {
 		struct json_object *sid_json;
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* old deprecated key format */
 		sid_json = json_object_new_object();
 		json_object_object_add(json, "srv6-end-sid", sid_json);
 		json_object_string_add(sid_json, "endpoint-behavior",
 				       seg6local_action2str(sid->behavior));
 		json_object_string_addf(sid_json, "sid-value", "%pI6",
 					&sid->sid);
+		if (sid->subsubtlvs) {
+			struct json_object *subtlvs_json;
+			subtlvs_json = json_object_new_object();
+			json_object_object_add(sid_json, "subsubtlvs",
+					       subtlvs_json);
+			isis_format_subsubtlvs(sid->subsubtlvs, NULL,
+					       subtlvs_json, 0);
+		}
+		/* end old deprecated key format */
+
+		sid_json = json_object_new_object();
+		json_object_object_add(json, "srv6EndSid", sid_json);
+		json_object_string_add(sid_json, "endpointBehavior",
+				       seg6local_action2str(sid->behavior));
+		json_object_string_addf(sid_json, "sidValue", "%pI6", &sid->sid);
 		if (sid->subsubtlvs) {
 			struct json_object *subtlvs_json;
 			subtlvs_json = json_object_new_object();
@@ -2848,9 +3236,13 @@ static void format_item_area_address(uint16_t mtid, struct isis_item *i,
 
 	memcpy(iso_addr.area_addr, addr->addr, ISO_ADDR_SIZE);
 	iso_addr.addr_len = addr->len;
-	if (json)
+	if (json) {
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
 		json_object_string_addf(json, "area-addr", "%pIS", &iso_addr);
-	else
+		json_object_string_addf(json, "areaAddr", "%pIS", &iso_addr);
+	} else
 		sbuf_push(buf, indent, "Area Address: %pIS\n", &iso_addr);
 }
 
@@ -2937,6 +3329,11 @@ static void format_item_oldstyle_reach(uint16_t mtid, struct isis_item *i,
 	snprintfrr(sys_id, ISO_SYSID_STRLEN, "%pPN", r->id);
 	if (json) {
 		struct json_object *old_json, *array_json;
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* old deprecated key format */
 		old_json = json_object_new_object();
 		json_object_object_get_ex(json, "old-reach-style", &array_json);
 		if (!array_json) {
@@ -2946,6 +3343,18 @@ static void format_item_oldstyle_reach(uint16_t mtid, struct isis_item *i,
 		}
 		json_object_array_add(array_json, old_json);
 		json_object_string_add(old_json, "is-reach", sys_id);
+		json_object_int_add(old_json, "metric", r->metric);
+		/* end old deprecated key format */
+
+		old_json = json_object_new_object();
+		json_object_object_get_ex(json, "oldReachStyle", &array_json);
+		if (!array_json) {
+			array_json = json_object_new_array();
+			json_object_object_add(json, "oldReachStyle",
+					       array_json);
+		}
+		json_object_array_add(array_json, old_json);
+		json_object_string_add(old_json, "isReach", sys_id);
 		json_object_int_add(old_json, "metric", r->metric);
 	} else
 		sbuf_push(buf, indent, "IS Reachability: %s (Metric: %hhu)\n",
@@ -3024,9 +3433,13 @@ static void format_item_lan_neighbor(uint16_t mtid, struct isis_item *i,
 	char sys_id[ISO_SYSID_STRLEN];
 
 	snprintfrr(sys_id, ISO_SYSID_STRLEN, "%pSY", n->mac);
-	if (json)
+	if (json) {
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
 		json_object_string_add(json, "lan-neighbor", sys_id);
-	else
+		json_object_string_add(json, "lanNeighbor", sys_id);
+	} else
 		sbuf_push(buf, indent, "LAN Neighbor: %s\n", sys_id);
 }
 
@@ -3099,11 +3512,23 @@ static void format_item_lsp_entry(uint16_t mtid, struct isis_item *i,
 		char buf[255];
 		struct json_object *lsp_json;
 		lsp_json = json_object_new_object();
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
 		json_object_object_add(json, "lsp-entry", lsp_json);
 		json_object_string_add(lsp_json, "id", sys_id);
 		snprintfrr(buf,sizeof(buf),"0x%08x",e->seqno);
 		json_object_string_add(lsp_json, "seq", buf);
 		snprintfrr(buf,sizeof(buf),"0x%04hx",e->checksum);
+		json_object_string_add(lsp_json, "chksum", buf);
+		json_object_int_add(lsp_json, "lifetime", e->checksum);
+
+		lsp_json = json_object_new_object();
+		json_object_object_add(json, "lspEntry", lsp_json);
+		json_object_string_add(lsp_json, "id", sys_id);
+		snprintfrr(buf, sizeof(buf), "0x%08x", e->seqno);
+		json_object_string_add(lsp_json, "seq", buf);
+		snprintfrr(buf, sizeof(buf), "0x%04hx", e->checksum);
 		json_object_string_add(lsp_json, "chksum", buf);
 		json_object_int_add(lsp_json, "lifetime", e->checksum);
 	} else
@@ -3187,6 +3612,11 @@ static void format_item_extended_reach(uint16_t mtid, struct isis_item *i,
 	snprintfrr(sys_id, ISO_SYSID_STRLEN, "%pPN", r->id);
 	if (json) {
 		struct json_object *reach_json, *array_json;
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* old deprecated key format */
 		reach_json = json_object_new_object();
 		json_object_object_get_ex(json, "ext-reach", &array_json);
 		if (!array_json) {
@@ -3201,6 +3631,28 @@ static void format_item_extended_reach(uint16_t mtid, struct isis_item *i,
 		json_object_int_add(reach_json, "metric", r->metric);
 		if (mtid != ISIS_MT_IPV4_UNICAST)
 			json_object_string_add(reach_json, "mt-name",
+					       isis_mtid2str(mtid));
+
+		if (r->subtlvs)
+			format_item_ext_subtlvs(r->subtlvs, NULL, reach_json,
+						indent + 2, mtid);
+		/* end old deprecated key format */
+
+		reach_json = json_object_new_object();
+		json_object_object_get_ex(json, "extReach", &array_json);
+		if (!array_json) {
+			array_json = json_object_new_array();
+			json_object_object_add(json, "extReach", array_json);
+		}
+		json_object_array_add(array_json, reach_json);
+		json_object_string_add(reach_json, "mtId",
+				       (mtid == ISIS_MT_IPV4_UNICAST)
+					       ? "Extended"
+					       : "MT");
+		json_object_string_add(reach_json, "id", sys_id);
+		json_object_int_add(reach_json, "metric", r->metric);
+		if (mtid != ISIS_MT_IPV4_UNICAST)
+			json_object_string_add(reach_json, "mtName",
 					       isis_mtid2str(mtid));
 
 		if (r->subtlvs)
@@ -3333,6 +3785,11 @@ static void format_item_oldstyle_ip_reach(uint16_t mtid, struct isis_item *i,
 
 	if (json) {
 		struct json_object *old_json, *array_json;
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* old deprecated key format */
 		old_json = json_object_new_object();
 		json_object_object_get_ex(json, "old-ip-reach-style",
 					  &array_json);
@@ -3344,6 +3801,20 @@ static void format_item_oldstyle_ip_reach(uint16_t mtid, struct isis_item *i,
 		json_object_array_add(array_json, old_json);
 		json_object_string_add(old_json, "prefix",
 				       prefix2str(&r->prefix, prefixbuf, sizeof(prefixbuf)));
+		json_object_int_add(old_json, "metric", r->metric);
+		/* end old deprecated key format */
+
+		old_json = json_object_new_object();
+		json_object_object_get_ex(json, "oldIpReachStyle", &array_json);
+		if (!array_json) {
+			array_json = json_object_new_array();
+			json_object_object_add(json, "oldIpReachStyle",
+					       old_json);
+		}
+		json_object_array_add(array_json, old_json);
+		json_object_string_add(old_json, "prefix",
+				       prefix2str(&r->prefix, prefixbuf,
+						  sizeof(prefixbuf)));
 		json_object_int_add(old_json, "metric", r->metric);
 		return;
 	}
@@ -3438,6 +3909,10 @@ static void format_tlv_protocols_supported(struct isis_protocols_supported *p,
 		struct json_object *protocol_json;
 		char buf[255];
 
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* old deprecated key format */
 		protocol_json = json_object_new_object();
 		json_object_object_add(json, "protocols-supported",
 				       protocol_json);
@@ -3446,6 +3921,16 @@ static void format_tlv_protocols_supported(struct isis_protocols_supported *p,
 			json_object_string_add(protocol_json, buf,
 					       nlpid2str(p->protocols[i]));
 		}
+
+		protocol_json = json_object_new_object();
+		json_object_object_add(json, "supportedProtocols",
+				       protocol_json);
+		for (uint8_t i = 0; i < p->count; i++) {
+			snprintfrr(buf, sizeof(buf), "%d", i);
+			json_object_string_add(protocol_json, buf,
+					       nlpid2str(p->protocols[i]));
+		}
+		/* end old deprecated key format */
 	} else {
 		sbuf_push(buf, indent, "Protocols Supported: ");
 		for (uint8_t i = 0; i < p->count; i++) {
@@ -3661,9 +4146,13 @@ static void format_item_global_ipv6_address(uint16_t mtid, struct isis_item *i,
 	char addrbuf[INET6_ADDRSTRLEN];
 
 	inet_ntop(AF_INET6, &a->addr, addrbuf, sizeof(addrbuf));
-	if (json)
+	if (json) {
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
 		json_object_string_add(json, "global-ipv6", addrbuf);
-	else
+		json_object_string_add(json, "globalIpv6", addrbuf);
+	} else
 		sbuf_push(buf, indent, "Global IPv6 Interface Address: %s\n",
 			  addrbuf);
 }
@@ -3742,8 +4231,19 @@ static void format_item_mt_router_info(uint16_t mtid, struct isis_item *i,
 		json_object_int_add(mt_json, "mtid", info->mtid);
 		json_object_string_add(mt_json, "mt-description",
 				       isis_mtid2str_fake(info->mtid));
+		json_object_string_add(mt_json, "mtDescription",
+				       isis_mtid2str(mtid));
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated non boolean format")
+#endif
 		json_object_string_add(mt_json, "overload", info->overload?"true":"false");
 		json_object_string_add(mt_json, "attached", info->attached?"true":"false");
+
+		json_object_boolean_add(mt_json, "overloadBit",
+					!!info->overload);
+		json_object_boolean_add(mt_json, "attachedbit",
+					!!info->attached);
 	} else
 		sbuf_push(buf, indent, "MT Router Info: %s%s%s\n",
 			  isis_mtid2str_fake(info->mtid),
@@ -3826,9 +4326,13 @@ static void format_tlv_te_router_id(const struct in_addr *id, struct sbuf *buf,
 
 	char addrbuf[INET_ADDRSTRLEN];
 	inet_ntop(AF_INET, id, addrbuf, sizeof(addrbuf));
-	if (json)
+	if (json) {
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
 		json_object_string_add(json, "te-router-id", addrbuf);
-	else
+		json_object_string_add(json, "teRouterId", addrbuf);
+	} else
 		sbuf_push(buf, indent, "TE Router ID: %s\n", addrbuf);
 }
 
@@ -3903,6 +4407,10 @@ static void format_item_extended_ip_reach(uint16_t mtid, struct isis_item *i,
 	char prefixbuf[PREFIX2STR_BUFFER];
 
 	if (json) {
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* old deprecated key format */
 		ext_json = json_object_new_object();
 		json_object_object_get_ex(json, "ext-ip-reach", &array_json);
 		if (!array_json) {
@@ -3921,6 +4429,33 @@ static void format_item_extended_ip_reach(uint16_t mtid, struct isis_item *i,
 		json_object_string_add(ext_json, "down", r->down ? "yes" : "");
 		if (mtid != ISIS_MT_IPV4_UNICAST)
 			json_object_string_add(ext_json, "mt-name",
+					       isis_mtid2str(mtid));
+		if (r->subtlvs) {
+			struct json_object *subtlv_json;
+			subtlv_json = json_object_new_object();
+			json_object_object_add(ext_json, "subtlvs", subtlv_json);
+			format_subtlvs(r->subtlvs, NULL, subtlv_json, 0);
+		}
+		/* end old deprecated key format */
+
+		ext_json = json_object_new_object();
+		json_object_object_get_ex(json, "extIpReach", &array_json);
+		if (!array_json) {
+			array_json = json_object_new_array();
+			json_object_object_add(json, "extIpReach", array_json);
+		}
+		json_object_array_add(array_json, ext_json);
+		json_object_string_add(ext_json, "mtId",
+				       (mtid == ISIS_MT_IPV4_UNICAST)
+					       ? "Extended"
+					       : "MT");
+		json_object_string_add(ext_json, "ipReach",
+				       prefix2str(&r->prefix, prefixbuf,
+						  sizeof(prefixbuf)));
+		json_object_int_add(ext_json, "ipReachMetric", r->metric);
+		json_object_boolean_add(ext_json, "down", !!r->down);
+		if (mtid != ISIS_MT_IPV4_UNICAST)
+			json_object_string_add(ext_json, "mtName",
 					       isis_mtid2str(mtid));
 		if (r->subtlvs) {
 			struct json_object *subtlv_json;
@@ -4185,9 +4720,13 @@ static void format_tlv_te_router_id_ipv6(const struct in6_addr *id,
 
 	char addrbuf[INET6_ADDRSTRLEN];
 	inet_ntop(AF_INET6, id, addrbuf, sizeof(addrbuf));
-	if (json)
+	if (json) {
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
 		json_object_string_add(json, "ipv6-te-router-id", addrbuf);
-	else
+		json_object_string_add(json, "ipv6TeRouterId", addrbuf);
+	} else
 		sbuf_push(buf, indent, "IPv6 TE Router ID: %s\n", addrbuf);
 }
 
@@ -4264,6 +4803,11 @@ static void format_tlv_spine_leaf(const struct isis_spine_leaf *spine_leaf,
 
 	if (json) {
 		struct json_object *spine_json;
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* old deprecated format */
 		spine_json = json_object_new_object();
 		json_object_object_add(json, "spine-leaf-extension",
 				       spine_json);
@@ -4282,6 +4826,25 @@ static void format_tlv_spine_leaf(const struct isis_spine_leaf *spine_leaf,
 				       spine_leaf->is_spine ? "yes" : "");
 		json_object_string_add(spine_json, "flag-backup",
 				       spine_leaf->is_backup ? "yes" : "");
+		/* end old deprecated format */
+
+		spine_json = json_object_new_object();
+		json_object_object_add(json, "spineLeafExtension", spine_json);
+		if (spine_leaf->has_tier) {
+			snprintfrr(aux_buf, sizeof(aux_buf), "%hhu",
+				   spine_leaf->tier);
+			json_object_string_add(spine_json, "tier",
+					       (spine_leaf->tier ==
+						ISIS_TIER_UNDEFINED)
+						       ? "undefined"
+						       : aux_buf);
+		}
+		json_object_boolean_add(spine_json, "flagLeaf",
+					spine_leaf->is_leaf ? true : false);
+		json_object_boolean_add(spine_json, "flagSpine",
+					spine_leaf->is_spine ? true : false);
+		json_object_boolean_add(spine_json, "flagBackup",
+					spine_leaf->is_backup ? true : false);
 	} else {
 		sbuf_push(buf, indent, "Spine-Leaf-Extension:\n");
 		if (spine_leaf->has_tier) {
@@ -4423,6 +4986,11 @@ format_tlv_threeway_adj(const struct isis_threeway_adj *threeway_adj,
 	snprintfrr(sys_id, ISO_SYSID_STRLEN, "%pSY", threeway_adj->neighbor_id);
 	if (json) {
 		struct json_object *three_json;
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* old deprecated key format */
 		three_json = json_object_new_object();
 		json_object_object_add(json, "p2p-three-way-adj", three_json);
 		json_object_string_add(
@@ -4431,11 +4999,28 @@ format_tlv_threeway_adj(const struct isis_threeway_adj *threeway_adj,
 		json_object_int_add(three_json, "state", threeway_adj->state);
 		json_object_int_add(three_json, "ext-local-circuit-id",
 				    threeway_adj->local_circuit_id);
-		if (!threeway_adj->neighbor_set)
-			return;
-		json_object_string_add(three_json, "neigh-system-id", sys_id);
-		json_object_int_add(three_json, "neigh-ext-circuit-id",
-				    threeway_adj->neighbor_circuit_id);
+		if (threeway_adj->neighbor_set) {
+			json_object_string_add(three_json, "neigh-system-id",
+					       sys_id);
+			json_object_int_add(three_json, "neigh-ext-circuit-id",
+					    threeway_adj->neighbor_circuit_id);
+		}
+		/* end old deprecated key format */
+
+		three_json = json_object_new_object();
+		json_object_object_add(json, "p2pThreeWayAdj", three_json);
+		json_object_string_add(three_json, "stateName",
+				       isis_threeway_state_name(
+					       threeway_adj->state));
+		json_object_int_add(three_json, "state", threeway_adj->state);
+		json_object_int_add(three_json, "extLocalCircuitId",
+				    threeway_adj->local_circuit_id);
+		if (threeway_adj->neighbor_set) {
+			json_object_string_add(three_json, "neighSystemId",
+					       sys_id);
+			json_object_int_add(three_json, "neighExtCircuitId",
+					    threeway_adj->neighbor_circuit_id);
+		}
 	} else {
 		sbuf_push(buf, indent, "P2P Three-Way Adjacency:\n");
 		sbuf_push(buf, indent, "  State: %s (%d)\n",
@@ -4540,6 +5125,43 @@ static void format_item_ipv6_reach(uint16_t mtid, struct isis_item *i,
 
 	if (json) {
 		struct json_object *reach_json, *array_json;
+
+		reach_json = json_object_new_object();
+		json_object_object_get_ex(json, "ipv6Reach", &array_json);
+		if (!array_json) {
+			array_json = json_object_new_array();
+			json_object_object_add(json, "ipv6Reach", array_json);
+		}
+		json_object_array_add(array_json, reach_json);
+		json_object_string_add(reach_json, "mtId",
+				       (mtid == ISIS_MT_IPV4_UNICAST) ? ""
+								      : "mt");
+		json_object_string_add(reach_json, "prefix",
+				       prefix2str(&r->prefix, prefixbuf,
+						  sizeof(prefixbuf)));
+		json_object_int_add(reach_json, "metric", r->metric);
+		json_object_boolean_add(reach_json, "down",
+					r->down ? true : false);
+		json_object_boolean_add(reach_json, "external",
+					r->external ? true : false);
+		if (mtid != ISIS_MT_IPV4_UNICAST) {
+			json_object_string_add(reach_json, "mt-name",
+					       isis_mtid2str(mtid));
+			json_object_string_add(reach_json, "mtName",
+					       isis_mtid2str(mtid));
+		}
+		if (r->subtlvs) {
+			struct json_object *subtlvs_json;
+			subtlvs_json = json_object_new_object();
+			json_object_object_add(reach_json, "subtlvs",
+					       subtlvs_json);
+			format_subtlvs(r->subtlvs, NULL, subtlvs_json, 0);
+		}
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* old deprecated JSON key format */
 		reach_json = json_object_new_object();
 		json_object_object_get_ex(json, "ipv6-reach", &array_json);
 		if (!array_json) {
@@ -4568,6 +5190,7 @@ static void format_item_ipv6_reach(uint16_t mtid, struct isis_item *i,
 					       subtlvs_json);
 			format_subtlvs(r->subtlvs, NULL, subtlvs_json, 0);
 		}
+		/* end deprecated key format */
 	} else {
 		sbuf_push(buf, indent,
 			  "%sIPv6 Reachability: %s (Metric: %u)%s%s",
@@ -4779,6 +5402,11 @@ static void format_tlv_router_cap_json(const struct isis_router_cap *router_cap,
 
 	/* Router ID and Flags */
 	struct json_object *cap_json;
+
+#if CONFDATE > 20240916
+	CPP_NOTICE("remove deprecated key format with -")
+#endif
+	/* deprecated JSON key format */
 	cap_json = json_object_new_object();
 	json_object_object_add(json, "router-capability", cap_json);
 	inet_ntop(AF_INET, &router_cap->router_id, addrbuf, sizeof(addrbuf));
@@ -4789,10 +5417,26 @@ static void format_tlv_router_cap_json(const struct isis_router_cap *router_cap,
 	json_object_string_add(
 		cap_json, "flag-s",
 		router_cap->flags & ISIS_ROUTER_CAP_FLAG_S ? "1" : "0");
+	/* end deprecated JSON key format */
+
+	cap_json = json_object_new_object();
+	json_object_object_add(json, "routerCapability", cap_json);
+	inet_ntop(AF_INET, &router_cap->router_id, addrbuf, sizeof(addrbuf));
+	json_object_string_add(cap_json, "id", addrbuf);
+	json_object_boolean_add(cap_json, "flagD",
+				!!(router_cap->flags & ISIS_ROUTER_CAP_FLAG_D));
+	json_object_boolean_add(cap_json, "flagS",
+				!!(router_cap->flags & ISIS_ROUTER_CAP_FLAG_S));
+
 
 	/* Segment Routing Global Block as per RFC8667 section #3.1 */
 	if (router_cap->srgb.range_size != 0) {
 		struct json_object *gb_json;
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* deprecated old key format */
 		gb_json = json_object_new_object();
 		json_object_object_add(json, "segment-routing-gb", gb_json);
 		json_object_string_add(gb_json, "ipv4",
@@ -4805,16 +5449,40 @@ static void format_tlv_router_cap_json(const struct isis_router_cap *router_cap,
 				    router_cap->srgb.lower_bound);
 		json_object_int_add(gb_json, "global-block-range",
 				    router_cap->srgb.range_size);
+
+		gb_json = json_object_new_object();
+		json_object_object_add(json, "segmentRoutingGb", gb_json);
+		json_object_boolean_add(gb_json, "ipv4",
+					!!IS_SR_IPV4(&router_cap->srgb));
+		json_object_boolean_add(gb_json, "ipv6",
+					!!IS_SR_IPV6(&router_cap->srgb));
+		json_object_int_add(gb_json, "globalBlockBase",
+				    router_cap->srgb.lower_bound);
+		json_object_int_add(gb_json, "globalBlockRange",
+				    router_cap->srgb.range_size);
 	}
 
 	/* Segment Routing Local Block as per RFC8667 section #3.3 */
 	if (router_cap->srlb.range_size != 0) {
 		struct json_object *lb_json;
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* old deprecated key format */
 		lb_json = json_object_new_object();
 		json_object_object_add(json, "segment-routing-lb", lb_json);
 		json_object_int_add(lb_json, "global-block-base",
 				    router_cap->srlb.lower_bound);
 		json_object_int_add(lb_json, "global-block-range",
+				    router_cap->srlb.range_size);
+		/* end old deprecated key format */
+
+		lb_json = json_object_new_object();
+		json_object_object_add(json, "segmentRoutingLb", lb_json);
+		json_object_int_add(lb_json, "globalBlockBase",
+				    router_cap->srlb.lower_bound);
+		json_object_int_add(lb_json, "globalBlockRange",
 				    router_cap->srlb.range_size);
 	}
 
@@ -4822,6 +5490,11 @@ static void format_tlv_router_cap_json(const struct isis_router_cap *router_cap,
 	if (router_cap->algo[0] != SR_ALGORITHM_UNSET) {
 		char buf[255];
 		struct json_object *alg_json;
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* old deprecated key format */
 		alg_json = json_object_new_object();
 		json_object_object_add(json, "segment-routing-algorithm",
 				       alg_json);
@@ -4833,6 +5506,20 @@ static void format_tlv_router_cap_json(const struct isis_router_cap *router_cap,
 							       ? "SPF"
 							       : "Strict SPF");
 			}
+		/* end old deprecated key format */
+
+		alg_json = json_object_new_object();
+		json_object_object_add(json, "segmentRoutingAlgorithm",
+				       alg_json);
+		for (int i = 0; i < SR_ALGORITHM_COUNT; i++) {
+			if (router_cap->algo[i] != SR_ALGORITHM_UNSET) {
+				snprintfrr(buf, sizeof(buf), "%d", i);
+				json_object_string_add(alg_json, buf,
+						       router_cap->algo[i] == 0
+							       ? "SPF"
+							       : "Strict SPF");
+			}
+		}
 	}
 
 	/* Segment Routing Node MSD as per RFC8491 section #2 */
@@ -5676,16 +6363,24 @@ static void format_item_auth(uint16_t mtid, struct isis_item *i,
 	struct isis_auth *auth = (struct isis_auth *)i;
 	char obuf[768];
 
-	if (json)
+	if (json) {
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
 		json_object_string_add(json, "test-auth", "ok");
-	else
+		json_object_string_add(json, "testAuth", "ok");
+	} else
 		sbuf_push(buf, indent, "Authentication:\n");
 	switch (auth->type) {
 	case ISIS_PASSWD_TYPE_CLEARTXT:
 		zlog_sanitize(obuf, sizeof(obuf), auth->value, auth->length);
-		if (json)
+		if (json) {
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_string_add(json, "auth-pass", obuf);
-		else
+			json_object_string_add(json, "authPass", obuf);
+		} else
 			sbuf_push(buf, indent, "  Password: %s\n", obuf);
 		break;
 	case ISIS_PASSWD_TYPE_HMAC_MD5:
@@ -5693,15 +6388,23 @@ static void format_item_auth(uint16_t mtid, struct isis_item *i,
 			snprintf(obuf + 2 * j, sizeof(obuf) - 2 * j, "%02hhx",
 				 auth->value[j]);
 		}
-		if (json)
+		if (json) {
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_string_add(json, "auth-hmac-md5", obuf);
-		else
+			json_object_string_add(json, "authHmacMd5", obuf);
+		} else
 			sbuf_push(buf, indent, "  HMAC-MD5: %s\n", obuf);
 		break;
 	default:
-		if (json)
+		if (json) {
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_int_add(json, "auth-unknown", auth->type);
-		else
+			json_object_int_add(json, "authUnknown", auth->type);
+		} else
 			sbuf_push(buf, indent, "  Unknown (%hhu)\n",
 				  auth->type);
 		break;
@@ -5816,12 +6519,25 @@ static void format_tlv_purge_originator(struct isis_purge_originator *poi,
 
 	if (json) {
 		struct json_object *purge_json;
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* old deprecated key format */
 		purge_json = json_object_new_object();
 		json_object_object_add(json, "purge_originator", purge_json);
 
 		json_object_string_add(purge_json, "id", gen_id);
 		if (poi->sender_set)
 			json_object_string_add(purge_json, "rec-from", sen_id);
+		/* end old deprecated key format */
+
+		purge_json = json_object_new_object();
+		json_object_object_add(json, "purgeOriginator", purge_json);
+
+		json_object_string_add(purge_json, "id", gen_id);
+		if (poi->sender_set)
+			json_object_string_add(purge_json, "recFrom", sen_id);
 	} else {
 		sbuf_push(buf, indent, "Purge Originator Identification:\n");
 		sbuf_push(buf, indent, "  Generator: %s\n", gen_id);
@@ -6364,6 +7080,11 @@ static void format_item_srv6_locator(uint16_t mtid, struct isis_item *i,
 
 	if (json) {
 		struct json_object *loc_json;
+
+#if CONFDATE > 20240916
+		CPP_NOTICE("remove deprecated key format with -")
+#endif
+		/* old json key format */
 		loc_json = json_object_new_object();
 		json_object_object_add(json, "srv6-locator", loc_json);
 		json_object_int_add(loc_json, "mt-id", mtid);
@@ -6378,6 +7099,26 @@ static void format_item_srv6_locator(uint16_t mtid, struct isis_item *i,
 		json_object_int_add(loc_json, "algorithm", loc->algorithm);
 		json_object_string_add(loc_json, "mt-name",
 				       isis_mtid2str(mtid));
+		if (loc->subtlvs) {
+			struct json_object *subtlvs_json;
+			subtlvs_json = json_object_new_object();
+			json_object_object_add(loc_json, "subtlvs",
+					       subtlvs_json);
+			format_subtlvs(loc->subtlvs, NULL, subtlvs_json, 0);
+		}
+		/* old deprecated key format */
+
+		loc_json = json_object_new_object();
+		json_object_object_add(json, "srv6Locator", loc_json);
+		json_object_int_add(loc_json, "mtId", mtid);
+		json_object_string_addf(loc_json, "prefix", "%pFX",
+					&loc->prefix);
+		json_object_int_add(loc_json, "metric", loc->metric);
+		json_object_boolean_add(loc_json, "flagD",
+					!!CHECK_FLAG(loc->flags,
+						     ISIS_TLV_SRV6_LOCATOR_FLAG_D));
+		json_object_int_add(loc_json, "algorithm", loc->algorithm);
+		json_object_string_add(loc_json, "MTName", isis_mtid2str(mtid));
 		if (loc->subtlvs) {
 			struct json_object *subtlvs_json;
 			subtlvs_json = json_object_new_object();
@@ -6668,9 +7409,13 @@ static void format_tlvs(struct isis_tlvs *tlvs, struct sbuf *buf, struct json_ob
 		     &tlvs->area_addresses, buf, json, indent);
 
 	if (tlvs->mt_router_info_empty) {
-		if (json)
+		if (json) {
+#if CONFDATE > 20240916
+			CPP_NOTICE("remove deprecated key format with -")
+#endif
 			json_object_string_add(json, "mt-router-info", "none");
-		else
+			json_object_object_add(json, "mtRouterInfo", NULL);
+		} else
 			sbuf_push(buf, indent, "MT Router Info: None\n");
 	} else {
 		format_items(ISIS_CONTEXT_LSP, ISIS_TLV_MT_ROUTER_INFO,

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -3738,6 +3738,8 @@ static void format_item_mt_router_info(uint16_t mtid, struct isis_item *i,
 		}
 		json_object_array_add(array_json, mt_json);
 		json_object_int_add(mt_json, "mtid", info->mtid);
+		json_object_string_add(mt_json, "mt-description",
+				       isis_mtid2str_fake(info->mtid));
 		json_object_string_add(mt_json, "overload", info->overload?"true":"false");
 		json_object_string_add(mt_json, "attached", info->attached?"true":"false");
 	} else

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -2127,9 +2127,14 @@ static void format_item_prefix_sid(uint16_t mtid, struct isis_item *i,
 	struct isis_prefix_sid *sid = (struct isis_prefix_sid *)i;
 
 	if (json) {
-		struct json_object *sr_json;
+		struct json_object *sr_json, *array_json;
 		sr_json = json_object_new_object();
-		json_object_object_add(json, "sr", sr_json);
+		json_object_object_get_ex(json, "sr", &array_json);
+		if (!array_json) {
+			array_json = json_object_new_array();
+			json_object_object_add(json, "sr", array_json);
+		}
+		json_object_array_add(array_json, sr_json);
 		if (sid->flags & ISIS_PREFIX_SID_VALUE) {
 			json_object_int_add(sr_json, "label", sid->value);
 		} else {
@@ -2929,9 +2934,15 @@ static void format_item_oldstyle_reach(uint16_t mtid, struct isis_item *i,
 
 	snprintfrr(sys_id, ISO_SYSID_STRLEN, "%pPN", r->id);
 	if (json) {
-		struct json_object *old_json;
+		struct json_object *old_json, *array_json;
 		old_json = json_object_new_object();
-		json_object_object_add(json, "old-reach-style", old_json);
+		json_object_object_get_ex(json, "old-reach-style", &array_json);
+		if (!array_json) {
+			array_json = json_object_new_array();
+			json_object_object_add(json, "old-reach-style",
+					       array_json);
+		}
+		json_object_array_add(array_json, old_json);
 		json_object_string_add(old_json, "is-reach", sys_id);
 		json_object_int_add(old_json, "metric", r->metric);
 	} else
@@ -3173,9 +3184,14 @@ static void format_item_extended_reach(uint16_t mtid, struct isis_item *i,
 
 	snprintfrr(sys_id, ISO_SYSID_STRLEN, "%pPN", r->id);
 	if (json) {
-		struct json_object *reach_json;
+		struct json_object *reach_json, *array_json;
 		reach_json = json_object_new_object();
-		json_object_object_add(json, "ext-reach", reach_json);
+		json_object_object_get_ex(json, "ext-reach", &array_json);
+		if (!array_json) {
+			array_json = json_object_new_array();
+			json_object_object_add(json, "ext-reach", array_json);
+		}
+		json_object_array_add(array_json, reach_json);
 		json_object_string_add(
 			reach_json, "mt-id",
 			(mtid == ISIS_MT_IPV4_UNICAST) ? "Extended" : "MT");
@@ -3314,13 +3330,21 @@ static void format_item_oldstyle_ip_reach(uint16_t mtid, struct isis_item *i,
 	char prefixbuf[PREFIX2STR_BUFFER];
 
 	if (json) {
-		struct json_object *old_json;
+		struct json_object *old_json, *array_json;
 		old_json = json_object_new_object();
-		json_object_object_add(json, "old-ip-reach-style", old_json);
+		json_object_object_get_ex(json, "old-ip-reach-style",
+					  &array_json);
+		if (!array_json) {
+			array_json = json_object_new_array();
+			json_object_object_add(json, "old-ip-reach-style",
+					       old_json);
+		}
+		json_object_array_add(array_json, old_json);
 		json_object_string_add(old_json, "prefix",
 				       prefix2str(&r->prefix, prefixbuf, sizeof(prefixbuf)));
 		json_object_int_add(old_json, "metric", r->metric);
-	} else
+		return;
+	}
 	sbuf_push(buf, indent, "IP Reachability: %s (Metric: %hhu)\n",
 		  prefix2str(&r->prefix, prefixbuf, sizeof(prefixbuf)),
 		  r->metric);
@@ -3705,9 +3729,14 @@ static void format_item_mt_router_info(uint16_t mtid, struct isis_item *i,
 	struct isis_mt_router_info *info = (struct isis_mt_router_info *)i;
 
 	if (json) {
-		struct json_object *mt_json;
+		struct json_object *mt_json, *array_json;
 		mt_json = json_object_new_object();
-		json_object_object_add(json, "mt", mt_json);
+		json_object_object_get_ex(json, "mt", &array_json);
+		if (!array_json) {
+			array_json = json_object_new_array();
+			json_object_object_add(json, "mt", array_json);
+		}
+		json_object_array_add(array_json, mt_json);
 		json_object_int_add(mt_json, "mtid", info->mtid);
 		json_object_string_add(mt_json, "overload", info->overload?"true":"false");
 		json_object_string_add(mt_json, "attached", info->attached?"true":"false");
@@ -3866,12 +3895,17 @@ static void format_item_extended_ip_reach(uint16_t mtid, struct isis_item *i,
 					  struct json_object *json, int indent)
 {
 	struct isis_extended_ip_reach *r = (struct isis_extended_ip_reach *)i;
+	struct json_object *ext_json, *array_json;
 	char prefixbuf[PREFIX2STR_BUFFER];
 
 	if (json) {
-		struct json_object *ext_json;
 		ext_json = json_object_new_object();
-		json_object_object_add(json, "ext-ip-reach", ext_json);
+		json_object_object_get_ex(json, "ext-ip-reach", &array_json);
+		if (!array_json) {
+			array_json = json_object_new_array();
+			json_object_object_add(json, "ext-ip-reach", array_json);
+		}
+		json_object_array_add(array_json, ext_json);
 		json_object_string_add(
 			json, "mt-id",
 			(mtid == ISIS_MT_IPV4_UNICAST) ? "Extended" : "MT");
@@ -4500,9 +4534,14 @@ static void format_item_ipv6_reach(uint16_t mtid, struct isis_item *i,
 	char prefixbuf[PREFIX2STR_BUFFER];
 
 	if (json) {
-		struct json_object *reach_json;
+		struct json_object *reach_json, *array_json;
 		reach_json = json_object_new_object();
-		json_object_object_add(json, "ipv6-reach", reach_json);
+		json_object_object_get_ex(json, "ipv6-reach", &array_json);
+		if (!array_json) {
+			array_json = json_object_new_array();
+			json_object_object_add(json, "ipv6-reach", array_json);
+		}
+		json_object_array_add(array_json, reach_json);
 		json_object_string_add(reach_json, "mt-id",
 				       (mtid == ISIS_MT_IPV4_UNICAST) ? ""
 								      : "mt");

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -2649,6 +2649,7 @@ void show_isis_database_lspdb_json(struct json_object *json,
 				   struct lspdb_head *lspdb,
 				   const char *sysid_str, int ui_level)
 {
+	struct json_object *array_json, *lsp_json;
 	struct isis_lsp *lsp;
 	int lsp_count;
 	struct json_object *lsp_arr_json;
@@ -2661,11 +2662,19 @@ void show_isis_database_lspdb_json(struct json_object *json,
 		}
 
 		if (lsp) {
+			json_object_object_get_ex(json, "lsps", &array_json);
+			if (!array_json) {
+				array_json = json_object_new_array();
+				json_object_object_add(json, "lsps", array_json);
+			}
+			lsp_json = json_object_new_object();
+			json_object_array_add(array_json, lsp_json);
+
 			if (ui_level == ISIS_UI_LEVEL_DETAIL)
-				lsp_print_detail(lsp, NULL, json,
+				lsp_print_detail(lsp, NULL, lsp_json,
 						 area->dynhostname, area->isis);
 			else
-				lsp_print_json(lsp, json, area->dynhostname,
+				lsp_print_json(lsp, lsp_json, area->dynhostname,
 					       area->isis);
 		} else if (sysid_str == NULL) {
 			lsp_arr_json = json_object_new_array();

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -2748,6 +2748,8 @@ static void show_isis_database_json(struct json_object *json, const char *sysid_
 		json_object_object_add(area_json,"area",tag_area_json);
 		json_object_object_add(area_json,"levels",arr_json);
 		for (level = 0; level < ISIS_LEVELS; level++) {
+			if (lspdb_count(&area->lspdb[level]) == 0)
+				continue;
 			lsp_json = json_object_new_object();
 			show_isis_database_lspdb_json(lsp_json, area, level,
 						      &area->lspdb[level],

--- a/tests/topotests/isis_topo1/test_isis_topo1.py
+++ b/tests/topotests/isis_topo1/test_isis_topo1.py
@@ -685,7 +685,7 @@ def _check_lsp_overload_bit(router, overloaded_router_lsp, att_p_ol_expected):
     )
 
     database_json = json.loads(isis_database_output)
-    att_p_ol = database_json["areas"][0]["levels"][1]["att-p-ol"]
+    att_p_ol = database_json["areas"][0]["levels"][1]["lsps"][0]["attPOl"]
     if att_p_ol == att_p_ol_expected:
         return True
     return "{} peer with expected att_p_ol {} got {} ".format(


### PR DESCRIPTION
Fixes for show isis database [detail] json
- Clean JSON format.
- Display multiple values into array. They were mixed together in the same dict.