### PR TITLE
 pathd: nai adjacency fix query type f for IPV6

### DIFF
--- a/pathd/path_ted.c
+++ b/pathd/path_ted.c
@@ -243,16 +243,16 @@ uint32_t path_ted_query_type_f(struct ipaddr *local, struct ipaddr *remote)
 		}
 		break;
 	case IPADDR_V6:
-		key = (uint64_t)(local->ip._v6_addr.s6_addr32[0] & 0xffffffff)
-		      | ((uint64_t)local->ip._v6_addr.s6_addr32[1] << 32);
+		key = (uint64_t)ntohl(local->ip._v6_addr.s6_addr32[2]) << 32 |
+		      (uint64_t)ntohl(local->ip._v6_addr.s6_addr32[3]);
 		edge = ls_find_edge_by_key(ted_state_g.ted, key);
 		if (edge) {
-			if ((memcmp(&edge->attributes->standard.remote6,
-				    &remote->ip._v6_addr,
-				    sizeof(remote->ip._v6_addr))
-			     && CHECK_FLAG(edge->attributes->flags,
-					   LS_ATTR_ADJ_SID))) {
-				sid = edge->attributes->adj_sid[0]
+			if ((0 == memcmp(&edge->attributes->standard.remote6,
+					 &remote->ip._v6_addr,
+					 sizeof(remote->ip._v6_addr)) &&
+			     CHECK_FLAG(edge->attributes->flags,
+					LS_ATTR_ADJ_SID6))) {
+				sid = edge->attributes->adj_sid[ADJ_PRI_IPV6]
 					      .sid; /* from primary */
 				break;
 			}


### PR DESCRIPTION
This commit is dedicated to fix some issues in path_ted_query_type_f
function. Issues are related to IPv6 implementation.
-key is not based on the pertinent part of IPv6 address.
-test on memcmp return value is mismatch.
-wrong flag value tested (ipv4 against ipv6).
-return adj_sid was the wrong one.

Signed-off-by: Francois Dumontet francois.dumontet@6wind.com