### PR TITLE
ospfd: Adding SUPPORT_OSPF_API define in ospf_spf.c

### DIFF
--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -48,7 +48,10 @@
 #include "ospfd/ospf_sr.h"
 #include "ospfd/ospf_ti_lfa.h"
 #include "ospfd/ospf_errors.h"
+
+#ifdef SUPPORT_OSPF_API
 #include "ospfd/ospf_apiserver.h"
+#endif
 
 /* Variables to ensure a SPF scheduled log message is printed only once */
 
@@ -1895,7 +1898,9 @@ static void ospf_spf_calculate_schedule_worker(struct thread *thread)
 	/* Update all routers routing table */
 	ospf->oall_rtrs = ospf->all_rtrs;
 	ospf->all_rtrs = all_rtrs;
+#ifdef SUPPORT_OSPF_API
 	ospf_apiserver_notify_reachable(ospf->oall_rtrs, ospf->all_rtrs);
+#endif
 
 	/* Free old ABR/ASBR routing table */
 	if (ospf->old_rtrs)


### PR DESCRIPTION
It is not possible to build ospf_spf.c file with --disable-ospfapi because
ospf_apiserver.c has SUPPORT_OSPF_API around all function definitions and
that results in an undefined reference to the ospf_apiserver_notify_reachable
function error while building.

Signed-off-by: Michal Ruprich <mruprich@redhat.com>