### PR TITLE
bgpd: release rcu lock in bgp keepalive pthread

### DIFF
--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -175,6 +175,15 @@ void *bgp_keepalives_start(void *arg)
 	struct timeval next_update = {0, 0};
 	struct timespec next_update_ts = {0, 0};
 
+	/*
+	 * The RCU mechanism for each pthread is initialized in a "locked"
+	 * state. That's ok for pthreads using the frr_pthread,
+	 * thread_fetch event loop, because that event loop unlocks regularly.
+	 * For foreign pthreads, the lock needs to be unlocked so that the
+	 * background rcu pthread can run.
+	 */
+	rcu_read_unlock();
+
 	peerhash_mtx = XCALLOC(MTYPE_TMP, sizeof(pthread_mutex_t));
 	peerhash_cond = XCALLOC(MTYPE_TMP, sizeof(pthread_cond_t));
 


### PR DESCRIPTION
If logging to files is enabled, the RCU sweeper background pthread is responsible for closing old files' fds after log-rotation. Pthreads that don't run in the libfrr event loop, like the bgp keepalive pthread, are holding their per-pthread rcu lock, preventing that rcu pthread from closing old files. Don't hold the rcu lock in the bgp keepalive pthread: it blocks the rcu pthread and prevents log-file deletion.
