### PR TITLE
topotests: ignore env for pytest --collect-only

### DIFF
--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -232,6 +232,9 @@ def pytest_configure(config):
     Assert that the environment is correctly configured, and get extra config.
     """
 
+    if config.getoption("--collect-only"):
+        return
+
     if "PYTEST_XDIST_WORKER" not in os.environ:
         os.environ["PYTEST_XDIST_MODE"] = config.getoption("dist", "no")
         os.environ["PYTEST_TOPOTEST_WORKER"] = ""


### PR DESCRIPTION
`--collect-only` does not run any tests, so bypass env checks for it.

---
`python3 -m pytest --collect-only` is useful to get a list of all the tests.