### PR TITLE
zebra: Reconfiguring netns for vrf is not a failure

### DIFF
--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -595,7 +595,7 @@ int zebra_vrf_netns_handler_create(struct vty *vty, struct vrf *vrf,
 				zlog_info(
 					"VRF %u already configured with NETNS %s",
 					vrf->vrf_id, ns->name);
-			return CMD_WARNING_CONFIG_FAILED;
+			return CMD_WARNING;
 		}
 	}
 	ns = ns_lookup_name(pathname);


### PR DESCRIPTION
When using namespace VRF backend, and frr.conf contains:

    vrf test
      netns /run/netns/test
    exit-vrf

FRR fails to start:

    line 11: Failure to communicate[13] to zebra, line:  netns /run/netns/test

Fix this by returning CMD_WARNING rather than CMD_WARNING_CONFIG_FAILED when the same netns path is configured.