### PR TITLE
pim6d: "show ipv6 mld interface" command

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -2495,13 +2495,13 @@ static void gm_show_if(struct vty *vty, struct vrf *vrf, const char *ifname,
 
 DEFPY(gm_show_interface,
       gm_show_interface_cmd,
-      "show ipv6 mld [vrf <VRF|all>$vrf_str] interface [IFNAME] [detail$detail|json$json]",
-      DEBUG_STR
+      "show ipv6 mld [vrf <VRF|all>$vrf_str] interface [IFNAME | detail$detail] [json$json]",
       SHOW_STR
       IPV6_STR
       MLD_STR
       VRF_FULL_CMD_HELP_STR
       "MLD interface information\n"
+      "Interface name\n"
       "Detailed output\n"
       JSON_STR)
 {


### PR DESCRIPTION
Issue:
frr# show ipv6 mld 
  interface   All VRFs

Fix:
frr# show ipv6 mld
  interface   MLD interface information

Keeping "show ipv6 mld interface" cmd similar as "show ip igmp interface" cmd.

Signed-off-by: Sarita Patra <saritap@vmware.com>