### PR TITLE
lib: Batch config in vty_read_file()

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -585,6 +585,7 @@ extern int cmd_execute_command_strict(vector, struct vty *,
 extern void cmd_init(int terminal);
 extern void cmd_init_config_callbacks(void (*start_config_cb)(void),
 				      void (*end_config_cb)(void));
+extern int cmd_xfrr_end_config(struct vty *vty);
 extern void cmd_terminate(void);
 extern void cmd_exit(struct vty *vty);
 extern int cmd_list_cmds(struct vty *vty, int do_permute);

--- a/lib/lib_vty.c
+++ b/lib/lib_vty.c
@@ -225,12 +225,14 @@ DEFUN_NOSH(start_config, start_config_cmd, "XFRR_start_configuration",
 	return CMD_SUCCESS;
 }
 
-DEFUN_NOSH(end_config, end_config_cmd, "XFRR_end_configuration",
-	   "The End of Configuration\n")
+int cmd_xfrr_end_config(struct vty *vty)
 {
 	time_t readin_time;
 	char readin_time_str[MONOTIME_STRLEN];
 	int ret;
+
+	if (!vty->pending_allowed)
+		return CMD_SUCCESS;
 
 	readin_time = monotime(NULL);
 	readin_time -= callback.readin_time;
@@ -258,6 +260,12 @@ DEFUN_NOSH(end_config, end_config_cmd, "XFRR_end_configuration",
 		(*callback.end_config)();
 
 	return ret;
+}
+
+DEFUN_NOSH(end_config, end_config_cmd, "XFRR_end_configuration",
+	   "The End of Configuration\n")
+{
+	return cmd_xfrr_end_config(vty);
 }
 
 void cmd_init_config_callbacks(void (*start_config_cb)(void),

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2427,8 +2427,12 @@ static void vty_read_file(struct nb_config *config, FILE *confp)
 		vty->candidate_config = nb_config_new(NULL);
 	}
 
+	cmd_execute(vty, "XFRR_start_configuration", NULL, 0);
+
 	/* Execute configuration file */
 	ret = config_from_file(vty, confp, &line_num);
+
+	cmd_execute(vty, "XFRR_end_configuration", NULL, 0);
 
 	/* Flush any previous errors before printing messages below */
 	buffer_flush_all(vty->obuf, vty->wfd);

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2761,6 +2761,8 @@ int vty_config_node_exit(struct vty *vty)
 {
 	vty->xpath_index = 0;
 
+	cmd_xfrr_end_config(vty);
+
 	if (vty_mgmt_fe_enabled() && mgmt_candidate_ds_wr_locked &&
 	    vty->mgmt_locked_candidate_ds) {
 		if (vty_mgmt_send_lockds_req(vty, MGMTD_DS_CANDIDATE, false) !=

--- a/tests/topotests/bgp_default_originate/test_bgp_default_originate_topo1_3.py
+++ b/tests/topotests/bgp_default_originate/test_bgp_default_originate_topo1_3.py
@@ -54,6 +54,7 @@ from lib.common_config import (
     reset_config_on_routers,
     create_static_routes,
     check_router_status,
+    apply_raw_config,
 )
 
 pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
@@ -892,6 +893,12 @@ def test_verify_default_originate_after_BGP_and_FRR_restart_p2(request):
 
     step(" BGP Daemon restart operation")
     routers = ["r1", "r2"]
+
+    # set route-map delay timer to reduce convergence time.
+    apply_raw_config(
+        tgen, {r: {"raw_config": ["bgp route-map delay-timer 1"]} for r in routers}
+    )
+
     for dut in routers:
         step(
             "Restart BGPD process on {}, when all the processes are running use watchfrr ".format(
@@ -909,6 +916,7 @@ def test_verify_default_originate_after_BGP_and_FRR_restart_p2(request):
             dut="r2",
             routes=DEFAULT_ROUTES,
             expected_nexthop=DEFAULT_ROUTE_NXT_HOP_R3,
+            expect_both=False,
             expected=False,
         )
         assert (
@@ -940,7 +948,7 @@ def test_verify_default_originate_after_BGP_and_FRR_restart_p2(request):
             dut="r2",
             routes=DEFAULT_ROUTES,
             expected_nexthop=DEFAULT_ROUTE_NXT_HOP_R1,
-            expected=False,
+            expected=True,
         )
         assert result is True, "Testcase {} : Failed \n Error: {}".format(
             tc_name, result

--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -5197,7 +5197,9 @@ def verify_rib_default_route(
 
 
 @retry(retry_timeout=5)
-def verify_fib_default_route(tgen, topo, dut, routes, expected_nexthop):
+def verify_fib_default_route(
+    tgen, topo, dut, routes, expected_nexthop, expect_both=True
+):
     """
     API to verify the the 'Default route" in FIB
 
@@ -5271,13 +5273,15 @@ def verify_fib_default_route(tgen, topo, dut, routes, expected_nexthop):
             )
             return False
 
-    if is_ipv4_default_route_found and is_ipv6_default_route_found:
-        return True
+    if expect_both:
+        if is_ipv4_default_route_found and is_ipv6_default_route_found:
+            return True
     else:
-        logger.error(
-            "Default Route for ipv4 and ipv6 address family is not found in FIB "
-        )
-        return False
+        if is_ipv4_default_route_found or is_ipv6_default_route_found:
+            return True
+
+    logger.error("Default Route for ipv4 and ipv6 address family is not found in FIB ")
+    return False
 
 
 @retry(retry_timeout=5)

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -872,22 +872,9 @@ int vtysh_config_from_file(struct vty *vty, FILE *fp)
 	int lineno = 0;
 	/* once we have an error, we remember & return that */
 	int retcode = CMD_SUCCESS;
-	char *vty_buf_copy = XCALLOC(MTYPE_VTYSH_CMD, VTY_BUFSIZ);
-	char *vty_buf_trimmed = NULL;
 
 	while (fgets(vty->buf, VTY_BUFSIZ, fp)) {
 		lineno++;
-
-		strlcpy(vty_buf_copy, vty->buf, VTY_BUFSIZ);
-		vty_buf_trimmed = trim(vty_buf_copy);
-
-		/*
-		 * Ignore the "end" lines, we will generate these where
-		 * appropriate, otherwise we never execute
-		 * XFRR_end_configuration, and start/end markers do not work.
-		 */
-		if (strmatch(vty_buf_trimmed, "end"))
-			continue;
 
 		ret = command_config_read_one_line(vty, &cmd, lineno, 1);
 
@@ -954,8 +941,6 @@ int vtysh_config_from_file(struct vty *vty, FILE *fp)
 		}
 		}
 	}
-
-	XFREE(MTYPE_VTYSH_CMD, vty_buf_copy);
 
 	return (retcode);
 }

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -614,9 +614,7 @@ static int vtysh_read_file(FILE *confp, bool dry_run)
 	/* Execute configuration file. */
 	ret = vtysh_config_from_file(vty, confp);
 
-	if (!dry_run)
-		vtysh_execute_no_pager("XFRR_end_configuration");
-
+	/* Will execute "XFRR_end_configuration" if necessary. */
 	vtysh_execute_no_pager("end");
 	vtysh_execute_no_pager("disable");
 


### PR DESCRIPTION
Add "XFRR_{start,end}_configuration" in vty_read_file() to batch configs and reduce startup time in individual config file mode. This has been done for integrated config in vtysh_read_file().

With staticd.conf of 3k routes, it takes roughly 4 seconds versus 3 minutes to startup with and without batching.