### PR TITLE
zebra: fix broken evpn

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1033,12 +1033,18 @@ static int netlink_parse_error(const struct nlsock *nl, struct nlmsghdr *h,
 		return 1;
 	}
 
-	/* Deal with errors that occur because of races in link handling. */
-	if (is_cmd
-	    && ((msg_type == RTM_DELROUTE
-		 && (-errnum == ENODEV || -errnum == ESRCH))
-		|| (msg_type == RTM_NEWROUTE
-		    && (-errnum == ENETDOWN || -errnum == EEXIST)))) {
+	/*
+	 * Deal with errors that occur because of races in link handling
+	 * or types are not supported in kernel.
+	 */
+	if (is_cmd &&
+	    ((msg_type == RTM_DELROUTE &&
+	      (-errnum == ENODEV || -errnum == ESRCH)) ||
+	     (msg_type == RTM_NEWROUTE &&
+	      (-errnum == ENETDOWN || -errnum == EEXIST)) ||
+	     ((msg_type == RTM_NEWTUNNEL || msg_type == RTM_DELTUNNEL ||
+	       msg_type == RTM_GETTUNNEL) &&
+	      (-errnum == EOPNOTSUPP)))) {
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug("%s: error: %s type=%s(%u), seq=%u, pid=%u",
 				   nl->name, safe_strerror(-errnum),


### PR DESCRIPTION
To resolve link dependencies of unordered interfaces, the commit                                                                                                             
`520ebf72b27c2462ce8b0dc5a1d4cb83956df69c` has separated assignment of                                                                                                       
`zif->link_ifindex` and `zif->link` from `netlink_interface()` during startup.                                                                                               
The fixup stage of `zebra_if_update_all_links()` goes into the last of                                                                                                       
`interface_lookup_netlink()`, it can't be executed in the case of error in                                                                                                   
above `netlink_parse_info()`s.                                                                                                                                               
                                                                                                                                                                             
`RTM_GETTUNNEL` is not supported in linux kernel until 5.18, so                                                                                                              
`netlink_parse_info()` will throw error with the previous versions.                                                                                                          
                                                                                                                                                                             
If two conditions are met, (it is a common case)                                                                                                                             
1. Interfaces are created before frr restart/start                                                                                                                           
2. Linux kernel version < 5.18                                                                                                                                               
                                                                                                                                                                             
the link dependencies will not be done, then evpn feature will be broken.                                                                                                    
IMO we should just ignore this error.