### PR TITLE
Use tab of boolean to store algorithm list

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1077,8 +1077,8 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 			cap.srgb.range_size = range_size;
 			cap.srgb.lower_bound = srdb->config.srgb_lower_bound;
 			/* Then Algorithm */
-			cap.algo[0] = SR_ALGORITHM_SPF;
-			cap.algo[1] = SR_ALGORITHM_UNSET;
+			cap.algo[SR_ALGORITHM_SPF] = true;
+			cap.algo[SR_ALGORITHM_STRICT_SPF] = false;
 			/* SRLB */
 			cap.srlb.flags = 0;
 			range_size = srdb->config.srlb_upper_bound
@@ -1087,12 +1087,7 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 			cap.srlb.lower_bound = srdb->config.srlb_lower_bound;
 			/* And finally MSD */
 			cap.msd = srdb->config.msd;
-		} else {
-			/* Disable SR Algorithm */
-			cap.algo[0] = SR_ALGORITHM_UNSET;
-			cap.algo[1] = SR_ALGORITHM_UNSET;
 		}
-
 		isis_tlvs_set_router_capability(lsp->tlvs, &cap);
 		lsp_debug("ISIS (%s): Adding Router Capabilities information",
 			  area->area_tag);

--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -1041,7 +1041,7 @@ static void show_node(struct vty *vty, struct isis_area *area, int level)
 			cap->srgb.lower_bound + cap->srgb.range_size - 1,
 			cap->srlb.lower_bound,
 			cap->srlb.lower_bound + cap->srlb.range_size - 1,
-			cap->algo[0] == SR_ALGORITHM_SPF ? "SPF" : "S-SPF",
+			"SPF",
 			cap->msd);
 	}
 

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -449,12 +449,8 @@ static struct ls_vertex *lsp_to_vertex(struct ls_ted *ted, struct isis_lsp *lsp)
 				lnode.srgb.flag = cap->srgb.flags;
 				lnode.srgb.lower_bound = cap->srgb.lower_bound;
 				lnode.srgb.range_size = cap->srgb.range_size;
-				for (int i = 0; i < SR_ALGORITHM_COUNT; i++) {
-					if (cap->algo[i])
-						lnode.algo[i] = i;
-					else
-						lnode.algo[i] = SR_ALGORITHM_UNSET;
-				}
+				for (int i = 0; i < SR_ALGORITHM_COUNT; i++)
+					lnode.algo[i] = cap->algo[i];
 			}
 
 			if (cap->srlb.lower_bound != 0

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -449,8 +449,12 @@ static struct ls_vertex *lsp_to_vertex(struct ls_ted *ted, struct isis_lsp *lsp)
 				lnode.srgb.flag = cap->srgb.flags;
 				lnode.srgb.lower_bound = cap->srgb.lower_bound;
 				lnode.srgb.range_size = cap->srgb.range_size;
-				for (int i = 0; i < SR_ALGORITHM_COUNT; i++)
-					lnode.algo[i] = cap->algo[i];
+				for (int i = 0; i < SR_ALGORITHM_COUNT; i++) {
+					if (cap->algo[i])
+						lnode.algo[i] = i;
+					else
+						lnode.algo[i] = SR_ALGORITHM_UNSET;
+				}
 			}
 
 			if (cap->srlb.lower_bound != 0

--- a/isisd/isis_tlvs.h
+++ b/isisd/isis_tlvs.h
@@ -201,7 +201,6 @@ struct isis_lan_adj_sid {
 #define SR_ALGORITHM_COUNT	2
 #define SR_ALGORITHM_SPF	0
 #define SR_ALGORITHM_STRICT_SPF	1
-#define SR_ALGORITHM_UNSET	255
 
 #define MSD_TYPE_BASE_MPLS_IMPOSITION  0x01
 #define MSD_TLV_SIZE            2

--- a/isisd/isis_tlvs.h
+++ b/isisd/isis_tlvs.h
@@ -213,7 +213,7 @@ struct isis_router_cap {
 	/* RFC 8667 section #3 */
 	struct isis_sr_block srgb;
 	struct isis_sr_block srlb;
-	uint8_t algo[SR_ALGORITHM_COUNT];
+	bool algo[SR_ALGORITHM_COUNT];
 	/* RFC 8491 */
 	uint8_t msd;
 };

--- a/lib/link_state.h
+++ b/lib/link_state.h
@@ -61,6 +61,8 @@ struct zclient;
 #define MAX_NAME_LENGTH		256
 #define ISO_SYS_ID_LEN		6
 
+#define SR_ALGORITHM_COUNT	2
+
 /* Type of Node */
 enum ls_node_type {
 	NONE = 0,	/* Unknown */
@@ -135,7 +137,7 @@ struct ls_node {
 		uint32_t lower_bound;		/* MPLS label lower bound */
 		uint32_t range_size;		/* MPLS label range size */
 	} srlb;
-	uint8_t algo[2];		/* Segment Routing Algorithms */
+	bool algo[SR_ALGORITHM_COUNT];		/* Segment Routing Algorithms */
 	uint8_t msd;			/* Maximum Stack Depth */
 };
 

--- a/ospfd/ospf_sr.h
+++ b/ospfd/ospf_sr.h
@@ -242,7 +242,7 @@ struct ospf_sr_db {
 	/* Local SR info announced in Router Info LSA */
 
 	/* Algorithms supported by the node */
-	uint8_t algo[ALGORITHM_COUNT];
+	bool algo[ALGORITHM_COUNT];
 	/*
 	 * Segment Routing Global Block i.e. label range
 	 * Only one range supported in this code
@@ -265,7 +265,7 @@ struct sr_node {
 	/* 24-bit Opaque-ID field value according to RFC 7684 specification */
 	uint32_t instance;
 
-	uint8_t algo[ALGORITHM_COUNT]; /* Algorithms supported by the node */
+	bool algo[ALGORITHM_COUNT]; /* Algorithms supported by the node */
 	struct sr_block srgb;          /* Segment Routing Global Block */
 	struct sr_block srlb;          /* Segment Routing Local Block */
 	uint8_t msd;                   /* Maximum SID Depth */

--- a/tests/isisd/test_common.c
+++ b/tests/isisd/test_common.c
@@ -196,8 +196,8 @@ static void lsp_add_router_capability(struct isis_lsp *lsp,
 		cap.srgb.range_size = tnode->srgb.range_size
 					      ? tnode->srgb.range_size
 					      : SRGB_DFTL_RANGE_SIZE;
-		cap.algo[0] = SR_ALGORITHM_SPF;
-		cap.algo[1] = SR_ALGORITHM_UNSET;
+		cap.algo[SR_ALGORITHM_SPF] = true;
+		cap.algo[SR_ALGORITHM_STRICT_SPF] = false;
 	}
 
 	isis_tlvs_set_router_capability(lsp->tlvs, &cap);


### PR DESCRIPTION
Will be useful for flex-algo.

Tab algos are stored in the code as follows:

> struct XX {
>       uint8_t algo[ALGORITHM_COUNT];
> }

A SR_ALGORITHM_UNSET value in the tab at the idx index means that
algo[idx] is unused. When an algorithm ID should be added in the
SR-Algorithm Sub-TLV, the algo ID replaces the first occurrence of the
SR_ALGORITHM_UNSET in the tab.

This is source of bug as the value of tab are usually set to zero at the
tab initialization but SR_ALGORITHM_UNSET is not zero.

Use a bool type for algo[] instead of the uint8_t type. The algo ID is
now set in index. Boolean value at the algo ID index means that the algo
ID is enabled if true.

Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>

