### PR TITLE
pimd, pim6d: Changing IGMP to GM in debug macros.

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -460,7 +460,7 @@ static void gm_sg_update(struct gm_sg *sg, bool has_expired)
 			gm_packet_sg_subs_count(sg->subs_positive),
 			gm_packet_sg_subs_count(sg->subs_negative), grp);
 
-		if (PIM_DEBUG_IGMP_TRACE)
+		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug(log_sg(sg, "dropping"));
 
 		gm_sgs_del(gm_ifp->sgs, sg);
@@ -550,7 +550,7 @@ static void gm_packet_drop(struct gm_packet_state *pkt, bool trace)
 		if (!sg)
 			continue;
 
-		if (trace && PIM_DEBUG_IGMP_TRACE)
+		if (trace && PIM_DEBUG_GM_TRACE)
 			zlog_debug(log_sg(sg, "general-dropping from %pPA"),
 				   &pkt->subscriber->addr);
 		deleted = gm_packet_sg_drop(&pkt->items[i]);
@@ -586,7 +586,7 @@ static void gm_packet_sg_remove_sources(struct gm_if *gm_ifp,
 
 static void gm_sg_expiry_cancel(struct gm_sg *sg)
 {
-	if (sg->t_sg_expire && PIM_DEBUG_IGMP_TRACE)
+	if (sg->t_sg_expire && PIM_DEBUG_GM_TRACE)
 		zlog_debug(log_sg(sg, "alive, cancelling expiry timer"));
 	THREAD_OFF(sg->t_sg_expire);
 	sg->query_sbit = true;
@@ -1102,7 +1102,7 @@ static void gm_handle_q_general(struct gm_if *gm_ifp,
 		 * it's "supersetted" within the preexisting query
 		 */
 
-		if (PIM_DEBUG_IGMP_TRACE_DETAIL)
+		if (PIM_DEBUG_GM_TRACE_DETAIL)
 			zlog_debug(
 				log_ifp("zapping supersetted general timer %pTVMu"),
 				&pend->expiry);
@@ -1121,13 +1121,13 @@ static void gm_handle_q_general(struct gm_if *gm_ifp,
 	pend->expiry = expiry;
 
 	if (!gm_ifp->n_pending++) {
-		if (PIM_DEBUG_IGMP_TRACE)
+		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug(
 				log_ifp("starting general timer @ 0: %pTVMu"),
 				&pend->expiry);
 		thread_add_timer_tv(router->master, gm_t_expire, gm_ifp,
 				    &timers->expire_wait, &gm_ifp->t_expire);
-	} else if (PIM_DEBUG_IGMP_TRACE)
+	} else if (PIM_DEBUG_GM_TRACE)
 		zlog_debug(log_ifp("appending general timer @ %u: %pTVMu"),
 			   gm_ifp->n_pending, &pend->expiry);
 }
@@ -1208,7 +1208,7 @@ static void gm_sg_timer_start(struct gm_if *gm_ifp, struct gm_sg *sg,
 	if (gm_sg_check_recent(gm_ifp, sg, now))
 		return;
 
-	if (PIM_DEBUG_IGMP_TRACE)
+	if (PIM_DEBUG_GM_TRACE)
 		zlog_debug(log_sg(sg, "expiring in %pTVI"), &expire_wait);
 
 	if (sg->t_sg_expire) {
@@ -1305,7 +1305,7 @@ static void gm_handle_q_group(struct gm_if *gm_ifp,
 
 	if (pim_addr_is_any(sg->sgaddr.src)) {
 		/* actually found *,G entry here */
-		if (PIM_DEBUG_IGMP_TRACE)
+		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug(log_ifp("*,%pPAs expiry timer starting"),
 				   &grp);
 		gm_sg_timer_start(gm_ifp, sg, timers->expire_wait);
@@ -1338,7 +1338,7 @@ static void gm_handle_q_group(struct gm_if *gm_ifp,
 	thread_add_timer_tv(router->master, gm_t_grp_expire, pend,
 			    &timers->expire_wait, &pend->t_expire);
 
-	if (PIM_DEBUG_IGMP_TRACE)
+	if (PIM_DEBUG_GM_TRACE)
 		zlog_debug(log_ifp("*,%pPAs S,G timer started: %pTHD"), &grp,
 			   pend->t_expire);
 }
@@ -1463,7 +1463,7 @@ static void gm_handle_query(struct gm_if *gm_ifp,
 
 	gm_expiry_calc(&timers);
 
-	if (PIM_DEBUG_IGMP_TRACE_DETAIL)
+	if (PIM_DEBUG_GM_TRACE_DETAIL)
 		zlog_debug(
 			log_ifp("query timers: QRV=%u max_resp=%ums qqic=%ums expire_wait=%pTVI"),
 			timers.qrv, timers.max_resp_ms, timers.qqic_ms,
@@ -1925,7 +1925,7 @@ static void gm_trigger_specific(struct gm_sg *sg)
 	if (gm_ifp->pim->gm_socket == -1)
 		return;
 
-	if (PIM_DEBUG_IGMP_TRACE)
+	if (PIM_DEBUG_GM_TRACE)
 		zlog_debug(log_sg(sg, "triggered query"));
 
 	if (pim_addr_is_any(sg->sgaddr.src)) {
@@ -2301,7 +2301,7 @@ void gm_ifp_update(struct interface *ifp)
 	}
 
 	if (changed) {
-		if (PIM_DEBUG_IGMP_TRACE)
+		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug(log_ifp(
 				"MLD querier config changed, querying"));
 		gm_bump_querier(gm_ifp);

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -175,7 +175,7 @@ void igmp_source_forward_start(struct pim_instance *pim,
 	sg.src = source->source_addr;
 	sg.grp = source->source_group->group_addr;
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		zlog_debug("%s: (S,G)=%pSG oif=%s fwd=%d", __func__, &sg,
 			   source->source_group->interface->name,
 			   IGMP_SOURCE_TEST_FORWARDING(source->source_flags));
@@ -220,7 +220,7 @@ void igmp_source_forward_stop(struct gm_source *source)
 	sg.src = source->source_addr;
 	sg.grp = source->source_group->group_addr;
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		zlog_debug("%s: (S,G)=%pSG oif=%s fwd=%d", __func__, &sg,
 			   source->source_group->interface->name,
 			   IGMP_SOURCE_TEST_FORWARDING(source->source_flags));
@@ -346,7 +346,7 @@ static void pim_igmp_other_querier_expire(struct thread *t)
 
 	assert(!igmp->t_igmp_query_timer);
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char ifaddr_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
 			       sizeof(ifaddr_str));
@@ -382,7 +382,7 @@ void pim_igmp_other_querier_timer_on(struct gm_sock *igmp)
 		  then reset the other-querier-present timer.
 		*/
 
-		if (PIM_DEBUG_IGMP_TRACE) {
+		if (PIM_DEBUG_GM_TRACE) {
 			char ifaddr_str[INET_ADDRSTRLEN];
 			pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
 				       sizeof(ifaddr_str));
@@ -423,7 +423,7 @@ void pim_igmp_other_querier_timer_on(struct gm_sock *igmp)
 		igmp->querier_robustness_variable, igmp->querier_query_interval,
 		pim_ifp->gm_query_max_response_time_dsec);
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char ifaddr_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
 			       sizeof(ifaddr_str));
@@ -442,7 +442,7 @@ void pim_igmp_other_querier_timer_off(struct gm_sock *igmp)
 {
 	assert(igmp);
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		if (igmp->t_other_querier_timer) {
 			char ifaddr_str[INET_ADDRSTRLEN];
 			pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
@@ -593,14 +593,14 @@ static int igmp_recv_query(struct gm_sock *igmp, int query_version,
 			if (!group->t_group_query_retransmit_timer)
 				continue;
 
-			if (PIM_DEBUG_IGMP_TRACE)
+			if (PIM_DEBUG_GM_TRACE)
 				zlog_debug(
 					"%s: lower address query packet from %s is ignored when last member query interval timer is running",
 					ifp->name, from_str);
 			return 0;
 		}
 
-		if (PIM_DEBUG_IGMP_TRACE) {
+		if (PIM_DEBUG_GM_TRACE) {
 			char ifaddr_str[INET_ADDRSTRLEN];
 			pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
 				       sizeof(ifaddr_str));
@@ -627,7 +627,7 @@ static int igmp_recv_query(struct gm_sock *igmp, int query_version,
 static void on_trace(const char *label, struct interface *ifp,
 		     struct in_addr from)
 {
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char from_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<from?>", from, from_str, sizeof(from_str));
 		zlog_debug("%s: from %s on %s", label, from_str, ifp->name);
@@ -664,7 +664,7 @@ static int igmp_v1_recv_report(struct gm_sock *igmp, struct in_addr from,
 	/* Collecting IGMP Rx stats */
 	igmp->igmp_stats.report_v1++;
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		zlog_warn("%s %s: FIXME WRITEME", __FILE__, __func__);
 	}
 
@@ -862,7 +862,7 @@ void pim_igmp_general_query_on(struct gm_sock *igmp)
 		query_interval = igmp->querier_query_interval;
 	}
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char ifaddr_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
 			       sizeof(ifaddr_str));
@@ -879,7 +879,7 @@ void pim_igmp_general_query_off(struct gm_sock *igmp)
 {
 	assert(igmp);
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		if (igmp->t_igmp_query_timer) {
 			char ifaddr_str[INET_ADDRSTRLEN];
 			pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
@@ -928,7 +928,7 @@ static void pim_igmp_general_query(struct thread *t)
 	dst_addr.s_addr = htonl(INADDR_ALLHOSTS_GROUP);
 	group_addr.s_addr = PIM_NET_INADDR_ANY;
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char querier_str[INET_ADDRSTRLEN];
 		char dst_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<querier?>", igmp->ifaddr, querier_str,
@@ -951,7 +951,7 @@ static void sock_close(struct gm_sock *igmp)
 	pim_igmp_other_querier_timer_off(igmp);
 	pim_igmp_general_query_off(igmp);
 
-	if (PIM_DEBUG_IGMP_TRACE_DETAIL) {
+	if (PIM_DEBUG_GM_TRACE_DETAIL) {
 		if (igmp->t_igmp_read) {
 			zlog_debug(
 				"Cancelling READ event on IGMP socket %pI4 fd=%d on interface %s",
@@ -969,7 +969,7 @@ static void sock_close(struct gm_sock *igmp)
 			igmp->interface->name, errno, safe_strerror(errno));
 	}
 
-	if (PIM_DEBUG_IGMP_TRACE_DETAIL) {
+	if (PIM_DEBUG_GM_TRACE_DETAIL) {
 		zlog_debug("Deleted IGMP socket %pI4 fd=%d on interface %s",
 			   &igmp->ifaddr, igmp->fd,
 			   igmp->interface->name);
@@ -1038,7 +1038,7 @@ void igmp_group_delete(struct gm_group *group)
 	struct gm_source *src;
 	struct pim_interface *pim_ifp = group->interface->info;
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));
@@ -1173,7 +1173,7 @@ static struct gm_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 
 	pim_ifp = ifp->info;
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		zlog_debug(
 			"Creating IGMP socket fd=%d for address %pI4 on interface %s",
 			fd, &ifaddr, ifp->name);
@@ -1245,7 +1245,7 @@ done:
 static void igmp_read_on(struct gm_sock *igmp)
 {
 
-	if (PIM_DEBUG_IGMP_TRACE_DETAIL) {
+	if (PIM_DEBUG_GM_TRACE_DETAIL) {
 		zlog_debug("Scheduling READ event on IGMP socket fd=%d",
 			   igmp->fd);
 	}
@@ -1312,7 +1312,7 @@ static void igmp_group_timer(struct thread *t)
 
 	group = THREAD_ARG(t);
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));
@@ -1347,7 +1347,7 @@ static void group_timer_off(struct gm_group *group)
 	if (!group->t_group_timer)
 		return;
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));
@@ -1414,7 +1414,7 @@ struct gm_group *igmp_add_group_by_addr(struct gm_sock *igmp,
 	}
 
 	if (pim_is_group_224_0_0_0_24(group_addr)) {
-		if (PIM_DEBUG_IGMP_TRACE)
+		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug(
 				"%s: Group specified %pI4 is part of 224.0.0.0/24",
 				__func__, &group_addr);
@@ -1454,7 +1454,7 @@ struct gm_group *igmp_add_group_by_addr(struct gm_sock *igmp,
 	listnode_add(pim_ifp->gm_group_list, group);
 	group = hash_get(pim_ifp->gm_group_hash, group, hash_alloc_intern);
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));
@@ -1527,7 +1527,7 @@ void igmp_send_query_on_intf(struct interface *ifp, int igmp_ver)
 	dst_addr.s_addr = htonl(INADDR_ALLHOSTS_GROUP);
 	group_addr.s_addr = PIM_NET_INADDR_ANY;
 
-	if (PIM_DEBUG_IGMP_TRACE)
+	if (PIM_DEBUG_GM_TRACE)
 		zlog_debug("Issuing general query on request on %s", ifp->name);
 
 	for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, sock_node, igmp)) {

--- a/pimd/pim_igmpv2.c
+++ b/pimd/pim_igmpv2.c
@@ -34,7 +34,7 @@
 static void on_trace(const char *label, struct interface *ifp,
 		     struct in_addr from)
 {
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char from_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<from?>", from, from_str, sizeof(from_str));
 		zlog_debug("%s: from %s on %s", label, from_str, ifp->name);

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -46,7 +46,7 @@ static void on_trace(const char *label, struct interface *ifp,
 		     struct in_addr from, struct in_addr group_addr,
 		     int num_sources, struct in_addr *sources)
 {
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char from_str[INET_ADDRSTRLEN];
 		char group_str[INET_ADDRSTRLEN];
 
@@ -98,7 +98,7 @@ void igmp_group_reset_gmi(struct gm_group *group)
 	*/
 	group_membership_interval_msec = igmp_gmi_msec(group);
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));
@@ -129,7 +129,7 @@ static void igmp_source_timer(struct thread *t)
 
 	group = source->source_group;
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		char source_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
@@ -188,7 +188,7 @@ static void source_timer_off(struct gm_group *group, struct gm_source *source)
 	if (!source->t_source_timer)
 		return;
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		char source_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
@@ -242,7 +242,7 @@ void igmp_source_reset_gmi(struct gm_group *group, struct gm_source *source)
 
 	group_membership_interval_msec = igmp_gmi_msec(group);
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		char source_str[INET_ADDRSTRLEN];
 
@@ -351,7 +351,7 @@ void igmp_source_delete(struct gm_source *source)
 
 	group = source->source_group;
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		char source_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
@@ -452,7 +452,7 @@ struct gm_source *igmp_get_source_by_addr(struct gm_group *group,
 	if (src)
 		return src;
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		char source_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
@@ -1035,7 +1035,7 @@ static void group_retransmit_group(struct gm_group *group)
 	*/
 	s_flag = igmp_group_timer_remain_msec(group) > lmqt_msec;
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));
@@ -1124,7 +1124,7 @@ static int group_retransmit_sources(struct gm_group *group,
 		source_addr2
 		- (struct in_addr *)(query_buf2 + IGMP_V3_SOURCES_OFFSET);
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));
@@ -1221,7 +1221,7 @@ static void igmp_group_retransmit(struct thread *t)
 
 	group = THREAD_ARG(t);
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));
@@ -1284,7 +1284,7 @@ static void group_retransmit_timer_on(struct gm_group *group)
 
 	lmqi_msec = 100 * pim_ifp->gm_specific_query_max_response_time_dsec;
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));
@@ -1513,7 +1513,7 @@ void igmp_group_timer_lower_to_lmqt(struct gm_group *group)
 	lmqt_msec = PIM_IGMP_LMQT_MSEC(
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
 			       sizeof(group_str));
@@ -1548,7 +1548,7 @@ void igmp_source_timer_lower_to_lmqt(struct gm_source *source)
 	lmqt_msec = PIM_IGMP_LMQT_MSEC(
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 
-	if (PIM_DEBUG_IGMP_TRACE) {
+	if (PIM_DEBUG_GM_TRACE) {
 		char group_str[INET_ADDRSTRLEN];
 		char source_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<group?>", group->group_addr, group_str,
@@ -1735,7 +1735,7 @@ void igmp_v3_recv_query(struct gm_sock *igmp, const char *from_str,
 		igmp->querier_query_interval =
 			qqi ? qqi : pim_ifp->gm_default_query_interval;
 
-		if (PIM_DEBUG_IGMP_TRACE) {
+		if (PIM_DEBUG_GM_TRACE) {
 			char ifaddr_str[INET_ADDRSTRLEN];
 			pim_inet4_dump("<ifaddr?>", igmp->ifaddr, ifaddr_str,
 				       sizeof(ifaddr_str));

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -395,7 +395,7 @@ static void igmp_sock_query_interval_reconfig(struct gm_sock *igmp)
 	ifp = igmp->interface;
 	pim_ifp = ifp->info;
 
-	if (PIM_DEBUG_IGMP_TRACE)
+	if (PIM_DEBUG_GM_TRACE)
 		zlog_debug("%s: Querier %pPAs on %s reconfig query_interval=%d",
 			   __func__, &igmp->ifaddr, ifp->name,
 			   pim_ifp->gm_default_query_interval);

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -62,7 +62,7 @@ tib_sg_oil_setup(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif)
 			   __func__, &sg, &vif_source, input_iface_vif_index);
 
 	if (input_iface_vif_index < 1) {
-		if (PIM_DEBUG_IGMP_TRACE)
+		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug(
 				"%s %s: could not find input interface for %pSG",
 				__FILE__, __func__, &sg);
@@ -78,7 +78,7 @@ tib_sg_oil_setup(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif)
 	if ((input_iface_vif_index == pim_oif->mroute_vif_index) &&
 	    !(PIM_I_am_DR(pim_oif))) {
 		/* ignore request for looped MFC entry */
-		if (PIM_DEBUG_IGMP_TRACE)
+		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug(
 				"%s: ignoring request for looped MFC entry (S,G)=%pSG: oif=%s vif_index=%d",
 				__func__, &sg, oif->name,
@@ -96,7 +96,7 @@ bool tib_sg_gm_join(struct pim_instance *pim, pim_sgaddr sg,
 	struct pim_interface *pim_oif = oif->info;
 
 	if (!pim_oif) {
-		if (PIM_DEBUG_IGMP_TRACE)
+		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug("%s: multicast not enabled on oif=%s?",
 				   __func__, oif->name);
 		return false;
@@ -119,7 +119,7 @@ bool tib_sg_gm_join(struct pim_instance *pim, pim_sgaddr sg,
 			return false;
 		}
 	} else {
-		if (PIM_DEBUG_IGMP_TRACE)
+		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug(
 				"%s: %pSG was received on %s interface but we are not DR for that interface",
 				__func__, &sg, oif->name);
@@ -163,7 +163,7 @@ void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg,
 	result = pim_channel_del_oif(*oilp, oif, PIM_OIF_FLAG_PROTO_GM,
 				     __func__);
 	if (result) {
-		if (PIM_DEBUG_IGMP_TRACE)
+		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug(
 				"%s: pim_channel_del_oif() failed with return=%d",
 				__func__, result);

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -66,12 +66,12 @@ int pim_debug_config_write(struct vty *vty)
 		vty_out(vty, "debug igmp packets\n");
 		++writes;
 	}
-	/* PIM_DEBUG_IGMP_TRACE catches _DETAIL too */
+	/* PIM_DEBUG_GM_TRACE catches _DETAIL too */
 	if (router->debugs & PIM_MASK_GM_TRACE) {
 		vty_out(vty, "debug igmp trace\n");
 		++writes;
 	}
-	if (PIM_DEBUG_IGMP_TRACE_DETAIL) {
+	if (PIM_DEBUG_GM_TRACE_DETAIL) {
 		vty_out(vty, "debug igmp trace detail\n");
 		++writes;
 	}

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -162,9 +162,9 @@ extern uint8_t qpim_ecmp_rebalance_enable;
 	(router->debugs & PIM_MASK_PIM_TRACE_DETAIL)
 #define PIM_DEBUG_GM_EVENTS (router->debugs & PIM_MASK_GM_EVENTS)
 #define PIM_DEBUG_GM_PACKETS (router->debugs & PIM_MASK_GM_PACKETS)
-#define PIM_DEBUG_IGMP_TRACE                                                   \
+#define PIM_DEBUG_GM_TRACE                                                     \
 	(router->debugs & (PIM_MASK_GM_TRACE | PIM_MASK_GM_TRACE_DETAIL))
-#define PIM_DEBUG_IGMP_TRACE_DETAIL (router->debugs & PIM_MASK_GM_TRACE_DETAIL)
+#define PIM_DEBUG_GM_TRACE_DETAIL (router->debugs & PIM_MASK_GM_TRACE_DETAIL)
 #define PIM_DEBUG_ZEBRA (router->debugs & PIM_MASK_ZEBRA)
 #define PIM_DEBUG_MLAG (router->debugs & PIM_MASK_MLAG)
 #define PIM_DEBUG_SSMPINGD (router->debugs & PIM_MASK_SSMPINGD)


### PR DESCRIPTION
Changed PIM_DEBUG_IGMP_TRACE to PIM_DEBUG_GM_TRACE and PIM_DEBUG_IGMP_TRACE_DETAIL to PIM_DEBUG_GM_TRACE_DETAIL. Hence, these macros can be used for both v6 and v4.

Issue: #11895

Co-authored-by: Sai Gomathi N <nsaigomathi@vmware.com>
Signed-off-by: Abhishek N R <abnr@vmware.com>