### PR TITLE
lib: Fix skip of every other plist deletion

### DIFF
--- a/lib/plist.c
+++ b/lib/plist.c
@@ -1570,7 +1570,6 @@ static void prefix_list_reset_afi(afi_t afi, int orf)
 
 	while ((plist = plist_first(&master->str))) {
 		prefix_list_delete(plist);
-		plist_pop(&master->str);
 	}
 
 	master->recent = NULL;


### PR DESCRIPTION
When bulk deleting prefix lists on shutdown the code was calling plist_delete, which removed the item
from the master->str list, and then popping the next item on the list and just dropping it on the floor. The pop is not needed.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>