### PR TITLE
bgpd: Checking if bfd is enabled before setting other commands

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -526,6 +526,11 @@ DEFUN (neighbor_bfd_check_controlplane_failure,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
+	if (!peer->bfd_config) {
+		vty_out(vty, "%% Enable bfd for this neighbor first\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
 	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
 		bgp_group_configure_bfd(peer);
 	else
@@ -585,6 +590,11 @@ DEFUN(neighbor_bfd_profile, neighbor_bfd_profile_cmd,
 	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
+
+	if (!peer->bfd_config) {
+		vty_out(vty, "%% Enable bfd for this neighbor first\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 
 	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
 		bgp_group_configure_bfd(peer);

--- a/tests/topotests/bfd_profiles_topo1/r2/bgpd.conf
+++ b/tests/topotests/bfd_profiles_topo1/r2/bgpd.conf
@@ -9,6 +9,7 @@ router bgp 100
  neighbor 2001:db8:2::2 remote-as 200
  neighbor 2001:db8:2::2 timers 3 10
  neighbor 2001:db8:2::2 ebgp-multihop 2
+ neighbor 2001:db8:2::2 bfd
  neighbor 2001:db8:2::2 bfd profile slowtx
  address-family ipv4 unicast
   redistribute connected

--- a/tests/topotests/bfd_topo3/r1/bgpd.conf
+++ b/tests/topotests/bfd_topo3/r1/bgpd.conf
@@ -10,6 +10,7 @@ router bgp 100
  neighbor 2001:db8:3::1 remote-as external
  neighbor 2001:db8:3::1 timers 3 10
  neighbor 2001:db8:3::1 ebgp-multihop 3
+ neighbor 2001:db8:3::1 bfd
  neighbor 2001:db8:3::1 bfd profile slow-tx
  address-family ipv4 unicast
   redistribute connected


### PR DESCRIPTION
When using 'bfd profile' or 'bfd check-control-plane-failure' for a neighbor, make sure that bfd is enabled first for this neighbor.

Signed-off-by: Michal Ruprich <mruprich@redhat.com>