### PR TITLE
pim6d: (*,G) mroutes not learnt after pim6d daemon restart

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -883,7 +883,7 @@ pim_addr pim_find_primary_addr(struct interface *ifp)
 		return pim_ifp->update_source;
 
 #if PIM_IPV == 6
-	if (pim_ifp)
+	if (pim_ifp && !pim_addr_is_any(pim_ifp->ll_highest))
 		return pim_ifp->ll_highest;
 
 	pim_addr best_addr = PIMADDR_ANY;


### PR DESCRIPTION
After restart pim dr address was zero due to which pim (*,G) join could not get propagated towards RP.

While trying to find primary address ll_highest will be zero initially, since we have not received address from zebra yet.

So we can get the best address at this point and use it as primary address whenever ll_highest is zero.

Fixes: #11925

Signed-off-by: Abhishek N R <abnr@vmware.com>