### PR TITLE
pim6d: Fixing coverity issues for pim6_mld.c

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -1609,7 +1609,7 @@ static void gm_t_recv(struct thread *t)
 	char rxbuf[2048];
 	struct msghdr mh[1] = {};
 	struct iovec iov[1];
-	struct sockaddr_in6 pkt_src[1];
+	struct sockaddr_in6 pkt_src[1] = {};
 	ssize_t nread;
 	size_t pktlen;
 


### PR DESCRIPTION
CID 1519843 (#2 of 2): Uninitialized scalar variable (UNINIT)
43. uninit_use_in_call: Using uninitialized value pkt_src->sin6_addr when calling gm_rx_process

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>