### PR TITLE
pimd: fix crash by wheel timer when del a vif

### DIFF
--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -655,6 +655,10 @@ void pim_neighbor_delete_all(struct interface *ifp, const char *delete_message)
 			       neigh_nextnode, neigh)) {
 		pim_neighbor_delete(ifp, neigh, delete_message);
 	}
+
+	/* the neighbor who has no hello interactive(stream-source) */
+	if (listcount(pim_ifp->pim_neighbor_list) == 0)
+		sched_rpf_cache_refresh(pim_ifp->pim);
 }
 
 struct prefix *pim_neighbor_find_secondary(struct pim_neighbor *neigh,

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -705,14 +705,14 @@ void pim_upstream_switch(struct pim_instance *pim, struct pim_upstream *up,
 
 	if (pim_addr_is_any(up->upstream_addr)) {
 		if (PIM_DEBUG_PIM_EVENTS)
-			zlog_debug("%s: RPF not configured for %s", __func__,
+			zlog_debug("%s: RP not configured for %s", __func__,
 				   up->sg_str);
 		return;
 	}
 
 	if (!up->rpf.source_nexthop.interface)  {
 		if (PIM_DEBUG_PIM_EVENTS)
-			zlog_debug("%s: RP not reachable for %s", __func__,
+			zlog_debug("%s: RPF not reachable for %s", __func__,
 				   up->sg_str);
 		return;
 	}
@@ -2017,7 +2017,7 @@ static bool pim_upstream_sg_running_proc(struct pim_upstream *up)
 	    && (up->channel_oil->cc.lastused / 100 > 30)) {
 		if (PIM_DEBUG_PIM_TRACE) {
 			zlog_debug(
-				"%s[%s]: %s old packet count is equal or lastused is greater than 30, (%ld,%ld,%lld)",
+				"%s[%s]: %s old packet count is equal and lastused is greater than 30, (%ld,%ld,%lld)",
 				__func__, up->sg_str, pim->vrf->name,
 				up->channel_oil->cc.oldpktcnt,
 				up->channel_oil->cc.pktcnt,


### PR DESCRIPTION
pimd: fix crash by wheel timer when del a vif

reproduce (4 steps):
1. topology:  R1 -- Host
  one router with a interface ens38, connected to one host (just for make it simple).

2. enable pim sm on ens38; config ens38 as RP; send a traffic packet from host to router.
    so there will be an (S, G) entry.  state as follows:

ron-virtual-machine# 
ron-virtual-machine# show ip mroute 
IP Multicast Routing Table
Flags: S - Sparse, C - Connected, P - Pruned
       R - SGRpt Pruned, F - Register flag, T - SPT-bit set
 Source         Group            Flags  Proto  Input  Output  TTL  Uptime    
 192.168.7.100  239.255.255.250  SFTP   none   ens38  none    0    --:--:--  

ron-virtual-machine# show ip pim upstream
 Iif    Source         Group            State      Uptime    JoinTimer  RSTimer   KATimer   RefCnt  
 ens38  192.168.7.100  239.255.255.250  NotJ,RegP  00:21:49  --:--:--   00:00:09  00:02:45  1       

ron-virtual-machine# 
ron-virtual-machine# show ip pim interface 
 Interface  State  Address        PIM Nbrs  PIM DR  FHR  IfChannels  
 ens38      up     192.168.7.101  0         local   0    0           
 pimreg     up     0.0.0.0        0         local   0    0           

ron-virtual-machine# show ip pim rp-info 
 RP address     group/prefix-list  OIF    I am RP  Source  Group-Type  
 192.168.7.101  224.0.0.0/4        ens38  yes      Static  ASM     

3. del the vif of ens38 with 'no ip pim sm'.  state as follows:

ron-virtual-machine(config)# interface ens38
ron-virtual-machine(config-if)# no ip pim sm
ron-virtual-machine(config-if)# end
ron-virtual-machine# show ip pim interface 
 Interface  State  Address  PIM Nbrs  PIM DR  FHR  IfChannels  
 pimreg     up     0.0.0.0  0         local   0    0           

ron-virtual-machine# show ip mroute 
IP Multicast Routing Table
Flags: S - Sparse, C - Connected, P - Pruned
       R - SGRpt Pruned, F - Register flag, T - SPT-bit set
 Source         Group            Flags  Proto  Input   Output  TTL  Uptime    
 192.168.7.100  239.255.255.250  SFTP   none   <iif?>  none    0    --:--:--  

ron-virtual-machine# show ip pim upstream
 Iif    Source         Group            State      Uptime    JoinTimer  RSTimer   KATimer   RefCnt  
 ens38  192.168.7.100  239.255.255.250  NotJ,RegP  00:23:03  --:--:--   00:00:14  00:02:32  1       

4. waiting for wheel timer coming, then crashed

Program received signal SIGSEGV, Segmentation fault.
0x0000558852140ac4 in pim_upstream_kat_start_ok (up=0x55885286d560) at pimd/pim_oil.h:130
130             return &c_oil->oil.mfcc_parent;
(gdb) info frame
Stack level 0, frame at 0x7ffeb4b5e130:
 rip = 0x558852140ac4 in pim_upstream_kat_start_ok (pimd/pim_oil.h:130); saved rip = 0x7f50c960ad8f
 inlined into frame 1
 source language c.
 Arglist at unknown address.
 Locals at unknown address, Previous frame's sp in rsp
(gdb) backtrace 
#0  0x0000558852140ac4 in pim_upstream_kat_start_ok (up=0x55885286d560) at pimd/pim_oil.h:130
#1  pim_upstream_sg_running_proc (up=0x55885286d560) at pimd/pim_upstream.c:2029
#2  0x00007f50c960ad8f in wheel_timer_thread_helper (t=<optimized out>) at lib/wheel.c:55
#3  0x00007f50c9601431 in thread_call (thread=0x558852733690) at lib/thread.c:2008
#4  0x00007f50c9601709 in _thread_execute (xref=0x7f50c96b5e80 <_xref.11032>, m=0x558852601c80, func=<optimized out>, arg=0x55885272f060, val=0)
    at lib/thread.c:2100
#5  0x00007f50c9601431 in thread_call (thread=thread@entry=0x7ffeb4b5e300) at lib/thread.c:2008
#6  0x00007f50c95baab8 in frr_run (master=0x558852601c80) at lib/libfrr.c:1198
#7  0x00005588521116c3 in main (argc=8, argv=<optimized out>, envp=<optimized out>) at pimd/pim_main.c:176