### PR TITLE
pimd: add the support of (s,g,rpt) entry

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -1210,6 +1210,7 @@ int pim_ifchannel_local_membership_add(struct interface *ifp, pim_sgaddr *sg,
 			}
 		}
 
+#ifndef PIM_SUPPORT_SG_RPT
 		if (pim->spt.switchover == PIM_SPT_INFINITY) {
 			if (pim->spt.plist) {
 				struct prefix_list *plist = prefix_list_lookup(
@@ -1226,6 +1227,7 @@ int pim_ifchannel_local_membership_add(struct interface *ifp, pim_sgaddr *sg,
 				}
 			}
 		} else
+#endif
 			pim_channel_add_oif(up->channel_oil, pim->regiface,
 					    PIM_OIF_FLAG_PROTO_GM, __func__);
 	}

--- a/pimd/pim_msg.c
+++ b/pimd/pim_msg.c
@@ -285,6 +285,10 @@ size_t pim_msg_build_jp_groups(struct pim_jp_groups *grp,
 				up = source->up;
 		} else {
 			bits = PIM_ENCODE_SPARSE_BIT;
+#ifdef PIM_SUPPORT_SG_RPT
+			if (PIM_UPSTREAM_FLAG_TEST_USE_RPT(source->up->flags))
+				bits |= PIM_ENCODE_RPT_BIT;
+#endif
 			stosend = source->up->sg.src;
 		}
 

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -42,6 +42,12 @@
 
 #define PIM_ENFORCE_LOOPFREE_MFC
 
+/* create (s,g,rpt) entry if suitable,
+ * RFC7761 inherited_olist(S,G,rpt),
+ * making both forward(rpt/spt) based on 64bit match(S+G)
+ */
+#define PIM_SUPPORT_SG_RPT
+
 /*
  * PIM MSG Header Format
  *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1


### PR DESCRIPTION
1.This PR adds the support of (S,G,RPT) entry.
It only apply to ASIC forwarding devices, no need on X86. It is not a necessary feature.

2.What is the difference?
preset:
(1). topology:  Source -- R1 -- R2 (RP) -- R3 -- Host 
(2). config 'ip pim spt-switchover infinity-and-beyond' on R3
(3). other usual configs, make pim-sm works, forwarding correctly.
check the last hop router(R3) :
before the PR: created (\*,G) enry, without pimreg as out-interface, no (S,G).
after the PR: created (\*,G) enry with pimreg as one of the out-interfaces; 
                     created (S,G) with in-interface determined by RPT, after received the first traffic-packet.

3.What is the reason?
(1).comply with rfc7761, as it says:
   "inherited_olist(S,G,rpt) is the outgoing interface list for packets forwarded on (\*,G) state"
(2).for ASIC forwarding devices,like layer3 switcher, ASIC works for forwarding, traffic only gets into CPU shortly.
	So after the PR, the first traffic packet gets into CPU through (\*,G) entry, then a (S,G,RPT) entry is created in ASIC.
       Then all subsequent traffic will forwarded by ASIC and not get into CPU.
