### PR TITLE
isisd: Fix memory leak on shutdown with prefix lists

### DIFF
--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -54,8 +54,6 @@
 #include "isisd/isis_dr.h"
 #include "isisd/isis_zebra.h"
 
-DEFINE_MTYPE_STATIC(ISISD, ISIS_PLIST_NAME, "ISIS prefix-list name");
-
 /*
  * XPath: /frr-isisd:isis/instance
  */

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -90,6 +90,7 @@ DEFINE_MTYPE_STATIC(ISISD, ISIS_NAME, "ISIS process name");
 DEFINE_MTYPE_STATIC(ISISD, ISIS_AREA, "ISIS area");
 DEFINE_MTYPE(ISISD, ISIS_AREA_ADDR,   "ISIS area address");
 DEFINE_MTYPE(ISISD, ISIS_ACL_NAME,    "ISIS access-list name");
+DEFINE_MTYPE(ISISD, ISIS_PLIST_NAME, "ISIS prefix-list name");
 
 DEFINE_QOBJ_TYPE(isis_area);
 
@@ -564,6 +565,11 @@ void isis_area_destroy(struct isis_area *area)
 	free(area->area_tag);
 
 	area_mt_finish(area);
+
+	if (area->rlfa_plist_name[0])
+		XFREE(MTYPE_ISIS_PLIST_NAME, area->rlfa_plist_name[0]);
+	if (area->rlfa_plist_name[1])
+		XFREE(MTYPE_ISIS_PLIST_NAME, area->rlfa_plist_name[1]);
 
 	XFREE(MTYPE_ISIS_AREA, area);
 

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -251,6 +251,7 @@ DECLARE_QOBJ_TYPE(isis_area);
 
 DECLARE_MTYPE(ISIS_ACL_NAME);	/* isis_area->spf_prefix_prioritites */
 DECLARE_MTYPE(ISIS_AREA_ADDR);	/* isis_area->area_addrs */
+DECLARE_MTYPE(ISIS_PLIST_NAME);
 
 DECLARE_HOOK(isis_area_overload_bit_update, (struct isis_area * area), (area));
 


### PR DESCRIPTION
==2623619==
==2623619== 6 bytes in 1 blocks are definitely lost in loss record 3 of 75
==2623619==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==2623619==    by 0x4B55E4A: strdup (strdup.c:42)
==2623619==    by 0x493C992: qstrdup (memory.c:128)
==2623619==    by 0x1A9212: isis_instance_fast_reroute_level_1_remote_lfa_prefix_list_modify (isis_nb_config.c:1599)
==2623619==    by 0x494837C: nb_callback_modify (northbound.c:1083)
==2623619==    by 0x4948C6E: nb_callback_configuration (northbound.c:1352)
==2623619==    by 0x494919D: nb_transaction_process (northbound.c:1473)
==2623619==    by 0x4947DA9: nb_candidate_commit_apply (northbound.c:906)
==2623619==    by 0x4947EBA: nb_candidate_commit (northbound.c:938)
==2623619==    by 0x494EB9E: nb_cli_classic_commit (northbound_cli.c:64)
==2623619==    by 0x494F3DC: nb_cli_apply_changes_internal (northbound_cli.c:250)
==2623619==    by 0x494F4E2: nb_cli_apply_changes (northbound_cli.c:268)
==2623619==    by 0x1BEF0F: isis_frr_remote_lfa_plist_magic (isis_cli.c:1899)
==2623619==    by 0x1B7636: isis_frr_remote_lfa_plist (isis_cli_clippy.c:3406)
==2623619==    by 0x48EBA75: cmd_execute_command_real (command.c:997)
==2623619==    by 0x48EBD4E: cmd_execute_command_strict (command.c:1108)
==2623619==    by 0x48EC1E6: command_config_read_one_line (command.c:1268)
==2623619==    by 0x48EC35B: config_from_file (command.c:1313)
==2623619==    by 0x4999CC1: vty_read_file (vty.c:2347)
==2623619==    by 0x499A4AF: vty_read_config (vty.c:2567)
==2623619==    by 0x4924B12: frr_config_read_in (libfrr.c:984)
==2623619==    by 0x498F5E3: thread_call (thread.c:2008)
==2623619==    by 0x49253DA: frr_run (libfrr.c:1198)
==2623619==    by 0x14FC53: main (isis_main.c:273)

Fix this memory leak

Signed-off-by: Donald Sharp <sharpd@nvidia.com>