### PR TITLE
pathd: 'no mpls-te on' command was not working

### DIFF
--- a/pathd/path_ted.c
+++ b/pathd/path_ted.c
@@ -385,7 +385,7 @@ DEFUN (no_path_ted,
        "Disable the TE Database functionality\n")
 /* clang-format on */
 {
-	if (ted_state_g.enabled) {
+	if (!ted_state_g.enabled) {
 		PATH_TED_DEBUG("%s: PATHD-TED: OFF -> OFF", __func__);
 		return CMD_SUCCESS;
 	}


### PR DESCRIPTION
Fix the 'no mpls-te on' command.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>