### PR TITLE
bgpd: multiple memory leak issue fixes

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -1383,7 +1383,7 @@ bool ecommunity_del_val(struct ecommunity *ecom, struct ecommunity_val *eval)
 		XFREE(MTYPE_ECOMMUNITY_VAL, ecom->val);
 		ecom->val = p;
 	} else
-		ecom->val = NULL;
+		XFREE(MTYPE_ECOMMUNITY_VAL, ecom->val);
 
 	return true;
 }

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1464,6 +1464,11 @@ int bgp_stop(struct peer *peer)
 
 				/* There is no pending EOR message */
 				if (gr_info->eor_required == 0) {
+					if (gr_info->t_select_deferral) {
+						void *info = THREAD_ARG(
+							gr_info->t_select_deferral);
+						XFREE(MTYPE_TMP, info);
+					}
 					THREAD_OFF(gr_info->t_select_deferral);
 					gr_info->eor_received = 0;
 				}

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1988,9 +1988,15 @@ void vpn_handle_router_id_update(struct bgp *bgp, bool withdraw,
 			bgp->vpn_policy[afi].tovpn_rd = bgp->vrf_prd_auto;
 			prefix_rd2str(&bgp->vpn_policy[afi].tovpn_rd, buf,
 				      sizeof(buf));
-			bgp->vpn_policy[afi].rtlist[edir] =
-				ecommunity_str2com(buf,
-						   ECOMMUNITY_ROUTE_TARGET, 0);
+
+			/* free up pre-existing memory if any and allocate
+			 *  the ecommunity attribute with new RD/RT
+			 */
+			if (bgp->vpn_policy[afi].rtlist[edir])
+				ecommunity_free(
+					&bgp->vpn_policy[afi].rtlist[edir]);
+			bgp->vpn_policy[afi].rtlist[edir] = ecommunity_str2com(
+				buf, ECOMMUNITY_ROUTE_TARGET, 0);
 
 			/* Update import_vrf rt_list */
 			ecom = bgp->vpn_policy[afi].rtlist[edir];

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2054,6 +2054,11 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 							gr_info->eor_required,
 							"EOR RCV",
 							gr_info->eor_received);
+					if (gr_info->t_select_deferral) {
+						void *info = THREAD_ARG(
+							gr_info->t_select_deferral);
+						XFREE(MTYPE_TMP, info);
+					}
 					THREAD_OFF(gr_info->t_select_deferral);
 					gr_info->eor_required = 0;
 					gr_info->eor_received = 0;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3630,7 +3630,12 @@ int bgp_delete(struct bgp *bgp)
 		gr_info = &bgp->gr_info[afi][safi];
 		if (!gr_info)
 			continue;
+		t = gr_info->t_select_deferral;
+		if (t) {
+			void *info = THREAD_ARG(t);
 
+			XFREE(MTYPE_TMP, info);
+		}
 		THREAD_OFF(gr_info->t_select_deferral);
 
 		t = gr_info->t_route_select;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3713,6 +3713,17 @@ int bgp_delete(struct bgp *bgp)
 		bgp->vpn_policy[afi].import_redirect_rtlist = NULL;
 	}
 
+	/* Free any memory allocated to holding routemap references */
+	for (afi = 0; afi < AFI_MAX; ++afi) {
+		for (enum vpn_policy_direction dir = 0;
+		     dir < BGP_VPN_POLICY_DIR_MAX; ++dir) {
+			if (bgp->vpn_policy[afi].rmap_name[dir])
+				XFREE(MTYPE_ROUTE_MAP_NAME,
+				      bgp->vpn_policy[afi].rmap_name[dir]);
+			bgp->vpn_policy[afi].rmap[dir] = NULL;
+		}
+	}
+
 	/* Deregister from Zebra, if needed */
 	if (IS_BGP_INST_KNOWN_TO_ZEBRA(bgp)) {
 		if (BGP_DEBUG(zebra, ZEBRA))


### PR DESCRIPTION
1) In ecommunity_del_val(), ecommunity was not being freed
     when the last value in the ecommunity was being deleted.
2) Memory allocated when 'import vrf route maps <>' is configured,
     wasn't being deleted when the entire bgp config was deleted through 'no router bgp'.
3) When router id is changed through config, new RD is auto generated.
     However new export RT was being assigned without freeing
     the older RT from VRF.

Signed-off-by: Samanvitha B Bhargav <bsmanvitha@vmware.com>