### PR TITLE
isisd: fix warning of compilation

### DIFF
--- a/isisd/isis_snmp.c
+++ b/isisd/isis_snmp.c
@@ -35,6 +35,7 @@
 #include "command.h"
 #include "memory.h"
 #include "smux.h"
+#include "zclient.h"
 #include "libfrr.h"
 #include "lib/version.h"
 #include "lib/zclient.h"


### PR DESCRIPTION
The following warning can be seen when compiling with snmp:

./isisd/isis_te.h:132:29: warning: ‘struct zapi_opaque_reg_info’ declared inside parameter list will not be visible outside of this definition or declaration
  132 | int isis_te_sync_ted(struct zapi_opaque_reg_info dst);
      |                             ^~~~~~~~~~~~~~~~~~~~
  CCLD     isisd/isisd_snmp.la

Include the appropriate header file to avoid the warning.

Fixes: ("8310af27f0d1") isisd: Add Link State Traffic Engineering support

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>