### PR TITLE
zebra: fix broken netlink

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1136,7 +1136,9 @@ int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 					if (!(h->nlmsg_flags & NLM_F_MULTI))
 						return 0;
 					continue;
-				} else
+				} else if (err == 0)
+					continue;
+				else
 					return err;
 			}
 


### PR DESCRIPTION
Problem:
========
After all needed interfaces ( include some vxlan interfaces ) are ready and up, restart/start frr service. Daemons are abnormal, peers/neighbors can't be set up successfully.

Root Cause:
===========
`netlink-cmd` sock should read all the netlink messsages of one request at once, otherwise it will be out of order.

The log with this problem:
```
Sep 22 04:59:30 zebra[1196]: [TJ327-ET8HE] netlink_send_msg: >> netlink message dump [sent]
Sep 22 04:59:30 zebra[1196]: [JAS4D-NCWGP] nlmsghdr [len=32 type=(22) GETADDR flags=(0x0301)
{REQUEST,DUMP,(ROOT|REPLACE|CAPPED),(MATCH|EXCLUDE|ACK_TLVS)} seq=7 pid=3805483542] <- send seq is 7
Sep 22 04:59:30 zebra[1196]: [XS99C-X3KS5] netlink-cmd (NS 0): error: Operation not supported
type=RTM_GETTUNNEL(122), seq=5, pid=3805483542 <- rcv seq is 5
```

`interface_lookup_netlink()` requests "RTM_GETTUNNEL" of all vxlan interfaces, linux kernel with version < 5.18 will return more than one error messages. But it only deals with this first one, the left are wrongly handled by the following functions.

Fix:
====
All the netlink messages which can be ignored, need to be fully read at once.