### PR TITLE
zebra: fix fpm crash

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -585,6 +585,7 @@ static inline void rib_tables_iter_cleanup(rib_tables_iter_t *iter)
 
 DECLARE_HOOK(rib_update, (struct route_node * rn, const char *reason),
 	     (rn, reason));
+DECLARE_HOOK(rib_shutdown, (struct route_node * rn), (rn));
 
 /*
  * Access installed/fib nexthops, which may be a subset of the

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -76,6 +76,8 @@ static struct dplane_ctx_q rib_dplane_q;
 
 DEFINE_HOOK(rib_update, (struct route_node * rn, const char *reason),
 	    (rn, reason));
+DEFINE_HOOK(rib_shutdown, (struct route_node * rn), (rn));
+
 
 /* Meta Q's specific names */
 enum meta_queue_indexes {
@@ -943,6 +945,9 @@ void zebra_rtable_node_cleanup(struct route_table *table,
 
 	if (node->info) {
 		rib_dest_t *dest = node->info;
+
+		/* Remove from update queue of FPM module */
+		hook_call(rib_shutdown, node);
 
 		rnh_list_fini(&dest->nht);
 		XFREE(MTYPE_RIB_DEST, node->info);


### PR DESCRIPTION
Fix issue#11996.

When removing VRF ( all routes of this VRF), zebra mistakenly forgot to check whether its routes are in update queue of FPM.  So FPM module will crash during its dealing with these routes, which are already freed.

Add a new HOOK `rib_shutdown()`, `zebra_rtable_node_cleanup()` will use it to remove these routes from update queue of FPM module before freeing them.