### PR TITLE
pimd, pim6d: Fix RPF check

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1385,7 +1385,7 @@ void pim_show_upstream(struct pim_instance *pim, struct vty *vty,
 
 			nbr = pim_neighbor_find(
 				up->rpf.source_nexthop.interface,
-				up->rpf.rpf_addr);
+				up->rpf.rpf_addr, false);
 			if (nbr)
 				pim_time_timer_to_hhmmss(join_timer,
 							 sizeof(join_timer),

--- a/pimd/pim_hello.c
+++ b/pimd/pim_hello.c
@@ -277,7 +277,7 @@ int pim_hello_recv(struct interface *ifp, pim_addr src_addr, uint8_t *tlv_buf,
 	  New neighbor?
 	*/
 
-	neigh = pim_neighbor_find(ifp, src_addr);
+	neigh = pim_neighbor_find(ifp, src_addr, false);
 	if (!neigh) {
 		/* Add as new neighbor */
 

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -406,7 +406,7 @@ struct pim_neighbor *pim_neighbor_find_by_secondary(struct interface *ifp,
 }
 
 struct pim_neighbor *pim_neighbor_find(struct interface *ifp,
-				       pim_addr source_addr)
+				       pim_addr source_addr, bool secondary)
 {
 	struct pim_interface *pim_ifp;
 	struct listnode *node;
@@ -423,6 +423,13 @@ struct pim_neighbor *pim_neighbor_find(struct interface *ifp,
 		if (!pim_addr_cmp(source_addr, neigh->source_addr)) {
 			return neigh;
 		}
+	}
+
+	if (secondary) {
+		struct prefix p;
+
+		pim_addr_to_prefix(&p, source_addr);
+		return pim_neighbor_find_by_secondary(ifp, &p);
 	}
 
 	return NULL;

--- a/pimd/pim_neighbor.h
+++ b/pimd/pim_neighbor.h
@@ -38,7 +38,7 @@ struct pim_neighbor {
 void pim_neighbor_timer_reset(struct pim_neighbor *neigh, uint16_t holdtime);
 void pim_neighbor_free(struct pim_neighbor *neigh);
 struct pim_neighbor *pim_neighbor_find(struct interface *ifp,
-				       pim_addr source_addr);
+				       pim_addr source_addr, bool secondary);
 struct pim_neighbor *pim_neighbor_find_by_secondary(struct interface *ifp,
 						    struct prefix *src);
 struct pim_neighbor *pim_neighbor_find_if(struct interface *ifp);

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -307,12 +307,11 @@ bool pim_nht_bsr_rpf_check(struct pim_instance *pim, pim_addr bsr_addr,
 			if (if_is_loopback(ifp) && if_is_loopback(src_ifp))
 				return true;
 
-			nbr = pim_neighbor_find(ifp, znh->nexthop_addr);
+			nbr = pim_neighbor_find(ifp, znh->nexthop_addr, true);
 			if (!nbr)
 				continue;
 
-			return znh->ifindex == src_ifp->ifindex &&
-			       (!pim_addr_cmp(znh->nexthop_addr, src_ip));
+			return znh->ifindex == src_ifp->ifindex;
 		}
 		return false;
 	}
@@ -373,12 +372,13 @@ bool pim_nht_bsr_rpf_check(struct pim_instance *pim, pim_addr bsr_addr,
 			return true;
 
 		/* MRIB (IGP) may be pointing at a router where PIM is down */
-		nbr = pim_neighbor_find(ifp, nhaddr);
+
+		nbr = pim_neighbor_find(ifp, nhaddr, true);
+
 		if (!nbr)
 			continue;
 
-		return nh->ifindex == src_ifp->ifindex &&
-		       (!pim_addr_cmp(nhaddr, src_ip));
+		return nh->ifindex == src_ifp->ifindex;
 	}
 	return false;
 }

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -561,7 +561,7 @@ static int pim_ecmp_nexthop_search(struct pim_instance *pim,
 							src)) {
 				nbr = pim_neighbor_find(
 					nexthop->interface,
-					nexthop->mrib_nexthop_addr);
+					nexthop->mrib_nexthop_addr, true);
 				if (!nbr
 				    && !if_is_loopback(nexthop->interface)) {
 					if (PIM_DEBUG_PIM_NHT)
@@ -603,7 +603,7 @@ static int pim_ecmp_nexthop_search(struct pim_instance *pim,
 #else
 			pim_addr nhaddr = nh_node->gate.ipv6;
 #endif
-			nbrs[i] = pim_neighbor_find(ifps[i], nhaddr);
+			nbrs[i] = pim_neighbor_find(ifps[i], nhaddr, true);
 			if (nbrs[i] || pim_if_connected_to_source(ifps[i], src))
 				num_nbrs++;
 		}
@@ -954,7 +954,8 @@ int pim_ecmp_nexthop_lookup(struct pim_instance *pim,
 					     pim->vrf->vrf_id);
 		if (ifps[i]) {
 			nbrs[i] = pim_neighbor_find(
-				ifps[i], nexthop_tab[i].nexthop_addr);
+				ifps[i], nexthop_tab[i].nexthop_addr, true);
+
 			if (nbrs[i] || pim_if_connected_to_source(ifps[i], src))
 				num_nbrs++;
 		}

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -289,7 +289,7 @@ int pim_pim_packet(struct interface *ifp, uint8_t *buf, size_t len,
 					      pim_msg_len - PIM_MSG_HEADER_LEN);
 		break;
 	case PIM_MSG_TYPE_JOIN_PRUNE:
-		neigh = pim_neighbor_find(ifp, sg.src);
+		neigh = pim_neighbor_find(ifp, sg.src, false);
 		if (!neigh) {
 			if (PIM_DEBUG_PIM_PACKETS)
 				zlog_debug(
@@ -304,7 +304,7 @@ int pim_pim_packet(struct interface *ifp, uint8_t *buf, size_t len,
 					  pim_msg_len - PIM_MSG_HEADER_LEN);
 		break;
 	case PIM_MSG_TYPE_ASSERT:
-		neigh = pim_neighbor_find(ifp, sg.src);
+		neigh = pim_neighbor_find(ifp, sg.src, false);
 		if (!neigh) {
 			if (PIM_DEBUG_PIM_PACKETS)
 				zlog_debug(

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -116,8 +116,8 @@ bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
 			i++;
 		} else if (neighbor_needed &&
 			   !pim_if_connected_to_source(ifp, addr)) {
-			nbr = pim_neighbor_find(ifp,
-						nexthop_tab[i].nexthop_addr);
+			nbr = pim_neighbor_find(
+				ifp, nexthop_tab[i].nexthop_addr, true);
 			if (PIM_DEBUG_PIM_TRACE_DETAIL)
 				zlog_debug("ifp name: %s, pim nbr: %p",
 					   ifp->name, nbr);

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -327,7 +327,7 @@ static void join_timer_stop(struct pim_upstream *up)
 
 	if (up->rpf.source_nexthop.interface)
 		nbr = pim_neighbor_find(up->rpf.source_nexthop.interface,
-					up->rpf.rpf_addr);
+					up->rpf.rpf_addr, true);
 
 	if (nbr)
 		pim_jp_agg_remove_group(nbr->upstream_jp_agg, up, nbr);
@@ -341,7 +341,7 @@ void join_timer_start(struct pim_upstream *up)
 
 	if (up->rpf.source_nexthop.interface) {
 		nbr = pim_neighbor_find(up->rpf.source_nexthop.interface,
-					up->rpf.rpf_addr);
+					up->rpf.rpf_addr, true);
 
 		if (PIM_DEBUG_PIM_EVENTS) {
 			zlog_debug(
@@ -433,7 +433,8 @@ void pim_upstream_join_suppress(struct pim_upstream *up, pim_addr rpf,
 	else {
 		/* Remove it from jp agg from the nbr for suppression */
 		nbr = pim_neighbor_find(up->rpf.source_nexthop.interface,
-					up->rpf.rpf_addr);
+					up->rpf.rpf_addr, true);
+
 		if (nbr) {
 			join_timer_remain_msec =
 				pim_time_timer_remain_msec(nbr->jp_timer);
@@ -485,7 +486,8 @@ void pim_upstream_join_timer_decrease_to_t_override(const char *debug_label,
 		struct pim_neighbor *nbr;
 
 		nbr = pim_neighbor_find(up->rpf.source_nexthop.interface,
-					up->rpf.rpf_addr);
+					up->rpf.rpf_addr, true);
+
 		if (nbr)
 			join_timer_remain_msec =
 				pim_time_timer_remain_msec(nbr->jp_timer);

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -257,7 +257,8 @@ void pim_zebra_upstream_rpf_changed(struct pim_instance *pim,
 		struct pim_neighbor *nbr;
 
 		nbr = pim_neighbor_find(old->source_nexthop.interface,
-					old->rpf_addr);
+					old->rpf_addr, true);
+
 		if (nbr)
 			pim_jp_agg_remove_group(nbr->upstream_jp_agg, up, nbr);
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -121,8 +121,6 @@ static int zserv_encode_nexthop(struct stream *s, struct nexthop *nexthop)
 		stream_putl(s, nexthop->ifindex);
 		break;
 	case NEXTHOP_TYPE_IPV6:
-		stream_put(s, &nexthop->gate.ipv6, 16);
-		break;
 	case NEXTHOP_TYPE_IPV6_IFINDEX:
 		stream_put(s, &nexthop->gate.ipv6, 16);
 		stream_putl(s, nexthop->ifindex);


### PR DESCRIPTION
1. Zebra should send ifindex  for nexthop type NEXTHOP_TYPE_IPV6.

2. pim6d should handle nexthop type NEXTHOP_TYPE_IPV6.

3. Fix RPF check,
For a  IPV4/IPV6 route, nexthop can be primary or secondary address.
Whereas PIM hello packet source IP is always primary address.
When there is a difference in the RPF address and PIM neighbour
address for the same interface. RPF check fails.
Fix: 
Check RPF address is either neighbour primary address  or one of the secondary address list.
   
Closes #11957
Closes #11526
Closes #12103
