### PR TITLE
bgpd: Print hostname for peer as well when marking as stale for route-refresh

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5620,8 +5620,8 @@ void bgp_set_stale_route(struct peer *peer, afi_t afi, safi_t safi)
 						if (bgp_debug_neighbor_events(
 							    peer))
 							zlog_debug(
-								"%s: route-refresh for %s/%s, marking prefix %pFX as stale",
-								peer->host,
+								"%pBP route-refresh for %s/%s, marking prefix %pFX as stale",
+								peer,
 								afi2str(afi),
 								safi2str(safi),
 								bgp_dest_get_prefix(
@@ -5649,9 +5649,8 @@ void bgp_set_stale_route(struct peer *peer, afi_t afi, safi_t safi)
 						   BGP_PATH_UNUSEABLE)) {
 					if (bgp_debug_neighbor_events(peer))
 						zlog_debug(
-							"%s: route-refresh for %s/%s, marking prefix %pFX as stale",
-							peer->host,
-							afi2str(afi),
+							"%pBP route-refresh for %s/%s, marking prefix %pFX as stale",
+							peer, afi2str(afi),
 							safi2str(safi),
 							bgp_dest_get_prefix(
 								dest));


### PR DESCRIPTION
Before:

```
2022/09/26 10:13:35.261 BGP: [QCZ1W-VKS36] 192.168.0.1(r0) sending REFRESH_REQ for afi/safi: IPv4/unicast
2022/09/26 10:13:35.262 BGP: [VF3QY-FP1PP] 192.168.0.1: route-refresh for IPv4/unicast, marking prefix 172.16.1.1/32 as stale
2022/09/26 10:13:35.262 BGP: [VF3QY-FP1PP] 192.168.0.1: route-refresh for IPv4/unicast, marking prefix 192.168.0.0/24 as stale
2022/09/26 10:13:35.262 BGP: [SDZS7-XVC4W] 192.168.0.1(r0) rcvd route-refresh (BoRR) for IPv4/unicast, triggering timer for 360 seconds
2022/09/26 10:13:35.362 BGP: [Y6XKR-PF89P] 192.168.0.1(r0) rcvd route-refresh (EoRR) for IPv4/unicast, stopping BoRR timer
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>