### PR TITLE
pim6d: Adding new Debug CLI for MLD

### DIFF
--- a/doc/user/pimv6.rst
+++ b/doc/user/pimv6.rst
@@ -416,6 +416,10 @@ configure CLI mode. If you specify debug commands in the configuration cli
 mode, the debug commands can be persistent across restarts of the FRR pim6d if
 the config was written out.
 
+.. clicmd:: debug mld
+
+   This turns on debugging for MLD protocol activity.
+
 .. clicmd:: debug pimv6 events
 
    This turns on debugging for PIMv6 system events. Especially timers.
@@ -456,3 +460,15 @@ the config was written out.
 .. clicmd:: debug mroute6 detail
 
    This turns on detailed debugging for PIMv6 interaction with kernel MFC cache.
+
+.. clicmd:: debug mld events
+
+   This turns on debugging for MLD system events.
+
+.. clicmd:: debug mld packets
+
+   This turns on information about MLD protocol packets handling.
+
+.. clicmd:: debug mld trace [detail]
+
+   This traces mld code and how it is running. 

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1597,6 +1597,22 @@ DEFPY (debug_mld_events,
 	return CMD_SUCCESS;
 }
 
+DEFPY (debug_mld_packets,
+       debug_mld_packets_cmd,
+       "[no] debug mld packets",
+       NO_STR
+       DEBUG_STR
+       DEBUG_MLD_STR
+       DEBUG_MLD_PACKETS_STR)
+{
+	if (!no)
+		PIM_DO_DEBUG_GM_PACKETS;
+	else
+		PIM_DONT_DEBUG_GM_PACKETS;
+
+	return CMD_SUCCESS;
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -1731,6 +1747,7 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_mroute6_detail_cmd);
 	install_element(ENABLE_NODE, &debug_mld_cmd);
 	install_element(ENABLE_NODE, &debug_mld_events_cmd);
+	install_element(ENABLE_NODE, &debug_mld_packets_cmd);
 
 	install_element(CONFIG_NODE, &debug_pimv6_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_nht_cmd);
@@ -1746,4 +1763,5 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &debug_mroute6_detail_cmd);
 	install_element(CONFIG_NODE, &debug_mld_cmd);
 	install_element(CONFIG_NODE, &debug_mld_events_cmd);
+	install_element(CONFIG_NODE, &debug_mld_packets_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1629,6 +1629,23 @@ DEFPY (debug_mld_trace,
 	return CMD_SUCCESS;
 }
 
+DEFPY (debug_mld_trace_detail,
+       debug_mld_trace_detail_cmd,
+       "[no] debug mld trace detail",
+       NO_STR
+       DEBUG_STR
+       DEBUG_MLD_STR
+       DEBUG_MLD_TRACE_STR
+       "detailed\n")
+{
+	if (!no)
+		PIM_DO_DEBUG_GM_TRACE_DETAIL;
+	else
+		PIM_DONT_DEBUG_GM_TRACE_DETAIL;
+
+	return CMD_SUCCESS;
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -1765,6 +1782,7 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_mld_events_cmd);
 	install_element(ENABLE_NODE, &debug_mld_packets_cmd);
 	install_element(ENABLE_NODE, &debug_mld_trace_cmd);
+	install_element(ENABLE_NODE, &debug_mld_trace_detail_cmd);
 
 	install_element(CONFIG_NODE, &debug_pimv6_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_nht_cmd);
@@ -1782,4 +1800,5 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &debug_mld_events_cmd);
 	install_element(CONFIG_NODE, &debug_mld_packets_cmd);
 	install_element(CONFIG_NODE, &debug_mld_trace_cmd);
+	install_element(CONFIG_NODE, &debug_mld_trace_detail_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1613,6 +1613,22 @@ DEFPY (debug_mld_packets,
 	return CMD_SUCCESS;
 }
 
+DEFPY (debug_mld_trace,
+       debug_mld_trace_cmd,
+       "[no] debug mld trace",
+       NO_STR
+       DEBUG_STR
+       DEBUG_MLD_STR
+       DEBUG_MLD_TRACE_STR)
+{
+	if (!no)
+		PIM_DO_DEBUG_GM_TRACE;
+	else
+		PIM_DONT_DEBUG_GM_TRACE;
+
+	return CMD_SUCCESS;
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -1748,6 +1764,7 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_mld_cmd);
 	install_element(ENABLE_NODE, &debug_mld_events_cmd);
 	install_element(ENABLE_NODE, &debug_mld_packets_cmd);
+	install_element(ENABLE_NODE, &debug_mld_trace_cmd);
 
 	install_element(CONFIG_NODE, &debug_pimv6_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_nht_cmd);
@@ -1764,4 +1781,5 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &debug_mld_cmd);
 	install_element(CONFIG_NODE, &debug_mld_events_cmd);
 	install_element(CONFIG_NODE, &debug_mld_packets_cmd);
+	install_element(CONFIG_NODE, &debug_mld_trace_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1581,6 +1581,22 @@ DEFPY (debug_mld,
 	return CMD_SUCCESS;
 }
 
+DEFPY (debug_mld_events,
+       debug_mld_events_cmd,
+       "[no] debug mld events",
+       NO_STR
+       DEBUG_STR
+       DEBUG_MLD_STR
+       DEBUG_MLD_EVENTS_STR)
+{
+	if (!no)
+		PIM_DO_DEBUG_GM_EVENTS;
+	else
+		PIM_DONT_DEBUG_GM_EVENTS;
+
+	return CMD_SUCCESS;
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -1714,6 +1730,7 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_mroute6_cmd);
 	install_element(ENABLE_NODE, &debug_mroute6_detail_cmd);
 	install_element(ENABLE_NODE, &debug_mld_cmd);
+	install_element(ENABLE_NODE, &debug_mld_events_cmd);
 
 	install_element(CONFIG_NODE, &debug_pimv6_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_nht_cmd);
@@ -1728,4 +1745,5 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &debug_mroute6_cmd);
 	install_element(CONFIG_NODE, &debug_mroute6_detail_cmd);
 	install_element(CONFIG_NODE, &debug_mld_cmd);
+	install_element(CONFIG_NODE, &debug_mld_events_cmd);
 }

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1561,6 +1561,26 @@ DEFUN_NOSH (show_debugging_pimv6,
 	return CMD_SUCCESS;
 }
 
+DEFPY (debug_mld,
+       debug_mld_cmd,
+       "[no] debug mld",
+       NO_STR
+       DEBUG_STR
+       DEBUG_MLD_STR)
+{
+	if (!no) {
+		PIM_DO_DEBUG_GM_EVENTS;
+		PIM_DO_DEBUG_GM_PACKETS;
+		PIM_DO_DEBUG_GM_TRACE;
+	} else {
+		PIM_DONT_DEBUG_GM_EVENTS;
+		PIM_DONT_DEBUG_GM_PACKETS;
+		PIM_DONT_DEBUG_GM_TRACE;
+	}
+
+	return CMD_SUCCESS;
+}
+
 void pim_cmd_init(void)
 {
 	if_cmd_init(pim_interface_config_write);
@@ -1693,6 +1713,7 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &debug_pimv6_zebra_cmd);
 	install_element(ENABLE_NODE, &debug_mroute6_cmd);
 	install_element(ENABLE_NODE, &debug_mroute6_detail_cmd);
+	install_element(ENABLE_NODE, &debug_mld_cmd);
 
 	install_element(CONFIG_NODE, &debug_pimv6_cmd);
 	install_element(CONFIG_NODE, &debug_pimv6_nht_cmd);
@@ -1706,4 +1727,5 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &debug_pimv6_zebra_cmd);
 	install_element(CONFIG_NODE, &debug_mroute6_cmd);
 	install_element(CONFIG_NODE, &debug_mroute6_detail_cmd);
+	install_element(CONFIG_NODE, &debug_mld_cmd);
 }

--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -37,6 +37,7 @@ typedef struct in_addr pim_addr;
 #define PIM_MAX_BITLEN	IPV4_MAX_BITLEN
 #define PIM_AF_NAME     "ip"
 #define PIM_AF_DBG	"pim"
+#define GM_AF_DBG	"igmp"
 #define PIM_MROUTE_DBG  "mroute"
 #define PIMREG          "pimreg"
 #define GM              "IGMP"
@@ -65,6 +66,7 @@ typedef struct in6_addr pim_addr;
 #define PIM_MAX_BITLEN	IPV6_MAX_BITLEN
 #define PIM_AF_NAME     "ipv6"
 #define PIM_AF_DBG	"pimv6"
+#define GM_AF_DBG	"mld"
 #define PIM_MROUTE_DBG  "mroute6"
 #define PIMREG          "pim6reg"
 #define GM              "MLD"

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -59,20 +59,20 @@ int pim_debug_config_write(struct vty *vty)
 		++writes;
 	}
 	if (PIM_DEBUG_GM_EVENTS) {
-		vty_out(vty, "debug igmp events\n");
+		vty_out(vty, "debug " GM_AF_DBG " events\n");
 		++writes;
 	}
 	if (PIM_DEBUG_GM_PACKETS) {
-		vty_out(vty, "debug igmp packets\n");
+		vty_out(vty, "debug " GM_AF_DBG " packets\n");
 		++writes;
 	}
 	/* PIM_DEBUG_GM_TRACE catches _DETAIL too */
 	if (router->debugs & PIM_MASK_GM_TRACE) {
-		vty_out(vty, "debug igmp trace\n");
+		vty_out(vty, "debug " GM_AF_DBG " trace\n");
 		++writes;
 	}
 	if (PIM_DEBUG_GM_TRACE_DETAIL) {
-		vty_out(vty, "debug igmp trace detail\n");
+		vty_out(vty, "debug " GM_AF_DBG " trace detail\n");
 		++writes;
 	}
 


### PR DESCRIPTION
Adding the following debug clis for mld

[no] debug mld
[no] debug mld events
[no] debug mld packets
[no] debug mld trace
[no] debug mld trace detail

Issue: #11895 