### PR TITLE
lib: Fix `show route-map NAME json` command and memory leak

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1059,7 +1059,6 @@ static int vty_show_route_map(struct vty *vty, const char *name, bool use_json)
 
 		if (map) {
 			vty_show_route_map_entry(vty, map, json_proto);
-			return CMD_SUCCESS;
 		} else if (!use_json) {
 			vty_out(vty, "%s: 'route-map %s' not found\n",
 				frr_protonameinst, name);


### PR DESCRIPTION
JSON object was generated, but not printed, because the function returned immediatelly, even without freeing the memory.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>