### PR TITLE
pimd, pim6d: send secondary address in PIM hello packet

### DIFF
--- a/pimd/pim_hello.c
+++ b/pimd/pim_hello.c
@@ -389,8 +389,10 @@ int pim_hello_build_tlv(struct interface *ifp, uint8_t *tlv_buf,
 	uint8_t *curr = tlv_buf;
 	uint8_t *pastend = tlv_buf + tlv_buf_size;
 	uint8_t *tmp;
+#if PIM_IPV == 4
 	struct pim_interface *pim_ifp = ifp->info;
 	struct pim_instance *pim = pim_ifp->pim;
+#endif
 
 	/*
 	 * Append options
@@ -452,19 +454,20 @@ int pim_hello_build_tlv(struct interface *ifp, uint8_t *tlv_buf,
 
 	/* Secondary Address List */
 	if (ifp->connected->count) {
-		curr = pim_tlv_append_addrlist_ucast(curr, pastend,
-						     ifp->connected, AF_INET);
+		curr = pim_tlv_append_addrlist_ucast(curr, pastend, ifp,
+						     PIM_AF);
 		if (!curr) {
 			if (PIM_DEBUG_PIM_HELLO) {
 				zlog_debug(
-					"%s: could not set PIM hello v4 Secondary Address List option for interface %s",
-					__func__, ifp->name);
+					"%s: could not set PIM hello %s Secondary Address List option for interface %s",
+					__func__, PIM_AF_NAME, ifp->name);
 			}
 			return -4;
 		}
+#if PIM_IPV == 4
 		if (pim->send_v6_secondary) {
-			curr = pim_tlv_append_addrlist_ucast(
-				curr, pastend, ifp->connected, AF_INET6);
+			curr = pim_tlv_append_addrlist_ucast(curr, pastend, ifp,
+							     AF_INET6);
 			if (!curr) {
 				if (PIM_DEBUG_PIM_HELLO) {
 					zlog_debug(
@@ -474,6 +477,7 @@ int pim_hello_build_tlv(struct interface *ifp, uint8_t *tlv_buf,
 				return -4;
 			}
 		}
+#endif
 	}
 
 	return curr - tlv_buf;

--- a/pimd/pim_tlv.h
+++ b/pimd/pim_tlv.h
@@ -82,7 +82,7 @@ uint8_t *pim_tlv_append_2uint16(uint8_t *buf, const uint8_t *buf_pastend,
 uint8_t *pim_tlv_append_uint32(uint8_t *buf, const uint8_t *buf_pastend,
 			       uint16_t option_type, uint32_t option_value);
 uint8_t *pim_tlv_append_addrlist_ucast(uint8_t *buf, const uint8_t *buf_pastend,
-				       struct list *ifconnected, int family);
+				       struct interface *ifp, int family);
 
 int pim_tlv_parse_holdtime(const char *ifname, pim_addr src_addr,
 			   pim_hello_options *hello_options,


### PR DESCRIPTION
Fixed as per rfc7761 section 4.3.1.
"""
Sending Hello Messages
The Address List option advertises all the secondary addresses associated with the source interface of the router originating the message.  The option MUST be included in all Hello messages if there are secondary addresses associated with the source interface and MAY be omitted if no secondary addresses exist.
"""

Issue: #12015

Signed-off-by: Sarita Patra <saritap@vmware.com>