### PR TITLE
pathd: change the vty output, when no ted is enabled on pathd

### DIFF
--- a/pathd/path_ted.c
+++ b/pathd/path_ted.c
@@ -462,7 +462,7 @@ DEFPY (show_pathd_ted_db,
 	json_object *json = NULL;
 
 	if (!ted_state_g.enabled) {
-		vty_out(vty, "PATHD TED database is not enabled\n");
+		vty_out(vty, "Traffic Engineering database is not enabled\n");
 		return CMD_WARNING;
 	}
 	if (strcmp(ver_json, "json") == 0) {


### PR DESCRIPTION
Change the vty output, in case ted is not enabled.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>