### PR TITLE
pim6d: IPv6 PIM state remain even after MLD groups prune

### DIFF
--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -175,4 +175,7 @@ void tib_sg_gm_prune(struct pim_instance *pim, pim_sgaddr sg,
 	  per-interface (S,G) state.
 	 */
 	pim_ifchannel_local_membership_del(oif, &sg);
+
+	if(*oilp)
+		*oilp = pim_channel_oil_del(*oilp, __func__);
 }


### PR DESCRIPTION
Channel oil's refcount is incremented via 2 flows, first when when mld join is received via tib_sg_oil_setup and then when upstream is created.
But the refcount is not decremented when mld
prune is received via the prune flow.
Therefore the pim state is still shown.
Hence deleting the channel oil when prune is received.

Issue: #11249

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>