### PR TITLE
Cputime stats

### DIFF
--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -493,7 +493,9 @@ void vtysh_config_parse_line(void *arg, const char *line)
 			    strncmp(line, "service cputime-stats",
 				    strlen("service cputime-stats")) == 0 ||
 			    strncmp(line, "no service cputime-stats",
-				    strlen("no service cputime-stats")) == 0)
+				    strlen("no service cputime-stats")) == 0 ||
+			    strncmp(line, "service cputime-warning",
+				    strlen("service cputime-warning")) == 0)
 				config_add_line_uniq(config_top, line);
 			else
 				config_add_line(config_top, line);

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -489,7 +489,11 @@ void vtysh_config_parse_line(void *arg, const char *line)
 			    strncmp(line, "no ip prefix-list",
 				    strlen("no ip prefix-list")) == 0 ||
 			    strncmp(line, "no ipv6 prefix-list",
-				    strlen("no ipv6 prefix-list")) == 0)
+				    strlen("no ipv6 prefix-list")) == 0 ||
+			    strncmp(line, "service cputime-stats",
+				    strlen("service cputime-stats")) == 0 ||
+			    strncmp(line, "no service cputime-stats",
+				    strlen("no service cputime-stats")) == 0)
 				config_add_line_uniq(config_top, line);
 			else
 				config_add_line(config_top, line);


### PR DESCRIPTION
vtysh was not properly handling the `service cputime-XXX` commands in output when multiple daemons are running.