### PR TITLE
mgmtd: Fixing invalid memory writes

### DIFF
--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -183,14 +183,14 @@ extern enum mgmt_result mgmt_fe_create_client_session(uintptr_t lib_hndl,
  * lib_hndl
  *    Client library handler.
  *
- * session_id
- *    Client session ID.
+ * client_id
+ *    Unique identifier of client.
  *
  * Returns:
  *    MGMTD_SUCCESS on success, MGMTD_* otherwise.
  */
-extern enum mgmt_result
-mgmt_fe_destroy_client_session(uintptr_t lib_hndl, uintptr_t session_id);
+extern enum mgmt_result mgmt_fe_destroy_client_session(uintptr_t lib_hndl,
+						       uint64_t client_id);
 
 /*
  * Send UN/LOCK_DB_REQ to MGMTD for a specific Datastore DB.

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2292,7 +2292,7 @@ void vty_close(struct vty *vty)
 
 	if (mgmt_lib_hndl) {
 		mgmt_fe_destroy_client_session(mgmt_lib_hndl,
-						   vty->mgmt_session_id);
+					       vty->mgmt_client_id);
 		vty->mgmt_session_id = 0;
 	}
 


### PR DESCRIPTION
Description:
            Have observed an inavalid memory access during the following scenario.
            when "write memory" command issued, it will create a vty pointer and
            collect all configurations , write to a file and then close the vty
            pointer.
            Here when vty pointer created, mgmt session is created by updating the mgmtd
            session with vty pointer and send the session request to mgmtd fe_adapter.
            Session_id details will be updated to the session structure once ack received
            from frontend adapter.
            As part of vty_close, the correspodning mgmt session should be destroyed before
            cleaning up the client pointer.i.e here vty.
            Here, before even receiving the ack from adapter, this vty_close called and vty freeed.
            Anyhow, session is not be distroyed because it is relayed on session_id which
            is expected to be updated once after receiving the ACK.
            But here, vty pointed is freed and still it is back pointed in mgmtd session.
            So this is leading to a invalid write when this vty pointer accessed upon
            receivng ACK from adapter.
            Corrected this by fetching mgmt session using client_id instead of session_id in
            mgmt session destroy.

Signed-off-by: Rajesh Girada <rgirada@vmware.com>