### PR TITLE
pimd: Allow v6 to do non-integrated configuration

### DIFF
--- a/pimd/pim6_main.c
+++ b/pimd/pim6_main.c
@@ -120,8 +120,6 @@ static const struct frr_yang_module_info *const pim6d_yang_modules[] = {
 /* clang-format off */
 FRR_DAEMON_INFO(pim6d, PIM6,
 	.vty_port = 0,
-	.flags = FRR_NO_SPLIT_CONFIG,
-
 	.proghelp = "Protocol Independent Multicast (RFC7761) for IPv6",
 
 	.signals = pim6d_signals,

--- a/pimd/pim6_main.c
+++ b/pimd/pim6_main.c
@@ -119,7 +119,7 @@ static const struct frr_yang_module_info *const pim6d_yang_modules[] = {
 
 /* clang-format off */
 FRR_DAEMON_INFO(pim6d, PIM6,
-	.vty_port = 0,
+	.vty_port = PIM6D_VTY_PORT,
 	.proghelp = "Protocol Independent Multicast (RFC7761) for IPv6",
 
 	.signals = pim6d_signals,

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -35,6 +35,7 @@
 #define PIMD_PROGNAME       "pimd"
 #define PIMD_DEFAULT_CONFIG "pimd.conf"
 #define PIMD_VTY_PORT       2611
+#define PIM6D_VTY_PORT      2622
 
 #define PIM_IP_PROTO_IGMP             (2)
 #define PIM_IP_PROTO_PIM              (103)

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -32,8 +32,6 @@
 #include "pim_memory.h"
 #include "pim_assert.h"
 
-#define PIMD_PROGNAME       "pimd"
-#define PIMD_DEFAULT_CONFIG "pimd.conf"
 #define PIMD_VTY_PORT       2611
 #define PIM6D_VTY_PORT      2622
 


### PR DESCRIPTION
Proof:
eva# conf
eva(config)# no service integrated-vtysh-config
eva(config)# end
eva# wr mem
Note: this version of vtysh never writes vtysh.conf Building Configuration...
Configuration saved to /etc/frr/zebra.conf
Configuration saved to /etc/frr/ripd.conf
Configuration saved to /etc/frr/ripngd.conf
Configuration saved to /etc/frr/ospfd.conf
Configuration saved to /etc/frr/ospf6d.conf
Configuration saved to /etc/frr/bgpd.conf
Configuration saved to /etc/frr/isisd.conf
Configuration saved to /etc/frr/pimd.conf
Configuration saved to /etc/frr/nhrpd.conf
Configuration saved to /etc/frr/eigrpd.conf
Configuration saved to /etc/frr/babeld.conf
Configuration saved to /etc/frr/sharpd.conf
Configuration saved to /etc/frr/fabricd.conf
Configuration saved to /etc/frr/pbrd.conf
Configuration saved to /etc/frr/staticd.conf
Configuration saved to /etc/frr/bfdd.conf
Configuration saved to /etc/frr/vrrpd.conf
Configuration saved to /etc/frr/pim6d.conf
eva#

Fixes: #12011
Signed-off-by: Donald Sharp <sharpd@nvidia.com>