### PR TITLE
vtysh: Show allow-reserved-ranges once in config

### DIFF
--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -483,6 +483,8 @@ void vtysh_config_parse_line(void *arg, const char *line)
 				    0 ||
 			    strncmp(line, "domainname", strlen("domainname")) ==
 				    0 ||
+			    strncmp(line, "allow-reserved-ranges",
+				    strlen("allow-reserved-ranges")) == 0 ||
 			    strncmp(line, "frr", strlen("frr")) == 0 ||
 			    strncmp(line, "agentx", strlen("agentx")) == 0 ||
 			    strncmp(line, "no log", strlen("no log")) == 0 ||


### PR DESCRIPTION
Before:

```
donatas-pc# sh run | include allow-reserved-ranges
allow-reserved-ranges
allow-reserved-ranges
allow-reserved-ranges
allow-reserved-ranges
allow-reserved-ranges
allow-reserved-ranges
donatas-pc#
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>