### PR TITLE
Require libyang >= v2.0.88 to patially fix #11075

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1928,8 +1928,8 @@ AC_SUBST([SNMP_CFLAGS])
 dnl ---------------
 dnl libyang
 dnl ---------------
-PKG_CHECK_MODULES([LIBYANG], [libyang >= 2.0.0], , [
-  AC_MSG_ERROR([libyang (>= 2.0.0) was not found on your system.])
+PKG_CHECK_MODULES([LIBYANG], [libyang >= 2.0.88], , [
+  AC_MSG_ERROR([libyang (>= 2.0.88) was not found on your system.])
 ])
 ac_cflags_save="$CFLAGS"
 CFLAGS="$CFLAGS $LIBYANG_CFLAGS"

--- a/doc/developer/building-libyang.rst
+++ b/doc/developer/building-libyang.rst
@@ -14,7 +14,7 @@ DEB packages are available as CI artifacts `here
 
 .. warning::
 
-   ``libyang`` version 2.0.0 or newer is required to build FRR.
+   ``libyang`` version 2.0.88 or newer is required to build FRR.
 
 .. note::
 
@@ -39,7 +39,7 @@ DEB packages are available as CI artifacts `here
 
    git clone https://github.com/CESNET/libyang.git
    cd libyang
-   git checkout v2.0.0
+   git checkout v2.0.88
    mkdir build; cd build
    cmake -D CMAKE_INSTALL_PREFIX:PATH=/usr \
          -D CMAKE_BUILD_TYPE:String="Release" ..

--- a/docker/ubuntu18-ci/Dockerfile
+++ b/docker/ubuntu18-ci/Dockerfile
@@ -37,7 +37,7 @@ USER frr:frr
 RUN cd && pwd && ls -al && \
     git clone https://github.com/CESNET/libyang.git && \
     cd libyang && \
-    git checkout v2.0.0 && \
+    git checkout v2.0.88 && \
     mkdir build; cd build && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr \
           -DCMAKE_BUILD_TYPE:String="Release" .. && \

--- a/docker/ubuntu20-ci/Dockerfile
+++ b/docker/ubuntu20-ci/Dockerfile
@@ -41,7 +41,7 @@ USER frr:frr
 RUN cd && pwd && ls -al && \
     git clone https://github.com/CESNET/libyang.git && \
     cd libyang && \
-    git checkout v2.0.0 && \
+    git checkout v2.0.88 && \
     mkdir build; cd build && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr \
           -DCMAKE_BUILD_TYPE:String="Release" .. && \


### PR DESCRIPTION
A newer version of libyang is needed to include the bugfix https://github.com/CESNET/libyang/commit/17f7664aa5054d40373a5ab8e4a91233f5c807ce which fixes the handling of nested choices in YANG – specifically, for FRR this corrects the handling of the nested choice for Cisco-style access lists, which was added in https://github.com/FRRouting/frr/commit/de4132bfe509edfe72afcd2b13f6f32e0f553157