### PR TITLE
pimd, pim6d: Update upstream IIF when pim disabled and enabled on an interface

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -689,7 +689,7 @@ static void pim_if_addr_del_pim(struct connected *ifc)
 {
 	struct pim_interface *pim_ifp = ifc->ifp->info;
 
-	if (ifc->address->family != AF_INET) {
+	if (ifc->address->family != PIM_AF) {
 		/* non-IPv4 address */
 		return;
 	}
@@ -843,7 +843,7 @@ void pim_if_addr_del_all(struct interface *ifp)
 	for (ALL_LIST_ELEMENTS(ifp->connected, node, nextnode, ifc)) {
 		struct prefix *p = ifc->address;
 
-		if (p->family != AF_INET)
+		if (p->family != PIM_AF)
 			continue;
 
 		pim_if_addr_del(ifc, 1 /* force_prim_as_any=true */);

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -24,6 +24,7 @@
 #include "lib/northbound_cli.h"
 #include "pim_igmpv3.h"
 #include "pim_neighbor.h"
+#include "pim_nht.h"
 #include "pim_pim.h"
 #include "pim_mlag.h"
 #include "pim_bfd.h"
@@ -146,6 +147,7 @@ static int pim_cmd_interface_add(struct interface *ifp)
 		pim_ifp->pim_enable = true;
 
 	pim_if_addr_add_all(ifp);
+	pim_upstream_nh_if_update(pim_ifp->pim, ifp);
 	pim_if_membership_refresh(ifp);
 
 	pim_if_create_pimreg(pim_ifp->pim);
@@ -171,6 +173,7 @@ static int pim_cmd_interface_delete(struct interface *ifp)
 
 	if (!pim_ifp->gm_enable) {
 		pim_if_addr_del_all(ifp);
+		pim_upstream_nh_if_update(pim_ifp->pim, ifp);
 		pim_if_delete(ifp);
 	}
 

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -529,6 +529,7 @@ static int pim_ecmp_nexthop_search(struct pim_instance *pim,
 	uint32_t hash_val = 0, mod_val = 0;
 	uint8_t nh_iter = 0, found = 0;
 	uint32_t i, num_nbrs = 0;
+	struct pim_interface *pim_ifp;
 
 	if (!pnc || !pnc->nexthop_num || !nexthop)
 		return 0;
@@ -645,10 +646,13 @@ static int pim_ecmp_nexthop_search(struct pim_instance *pim,
 			nh_iter++;
 			continue;
 		}
-		if (!ifp->info) {
+
+		pim_ifp = ifp->info;
+
+		if (!pim_ifp || !pim_ifp->pim_enable) {
 			if (PIM_DEBUG_PIM_NHT)
 				zlog_debug(
-					"%s: multicast not enabled on input interface %s(%s) (ifindex=%d, RPF for source %pPA)",
+					"%s: pim not enabled on input interface %s(%s) (ifindex=%d, RPF for source %pPA)",
 					__func__, ifp->name, pim->vrf->name,
 					first_ifindex, &src);
 			if (nh_iter == mod_val)
@@ -916,6 +920,7 @@ int pim_ecmp_nexthop_lookup(struct pim_instance *pim,
 	uint8_t i = 0;
 	uint32_t hash_val = 0, mod_val = 0;
 	uint32_t num_nbrs = 0;
+	struct pim_interface *pim_ifp;
 
 	if (PIM_DEBUG_PIM_NHT_DETAIL)
 		zlog_debug("%s: Looking up: %pPA(%s), last lookup time: %lld",
@@ -998,10 +1003,12 @@ int pim_ecmp_nexthop_lookup(struct pim_instance *pim,
 			continue;
 		}
 
-		if (!ifp->info) {
+		pim_ifp = ifp->info;
+
+		if (!pim_ifp || !pim_ifp->pim_enable) {
 			if (PIM_DEBUG_PIM_NHT)
 				zlog_debug(
-					"%s: multicast not enabled on input interface %s(%s) (ifindex=%d, RPF for source %pPA)",
+					"%s: pim not enabled on input interface %s(%s) (ifindex=%d, RPF for source %pPA)",
 					__func__, ifp->name, pim->vrf->name,
 					first_ifindex, &src);
 			if (i == mod_val)

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -82,5 +82,5 @@ void pim_nht_bsr_del(struct pim_instance *pim, pim_addr bsr_addr);
 /* RPF(bsr_addr) == src_ip%src_ifp? */
 bool pim_nht_bsr_rpf_check(struct pim_instance *pim, pim_addr bsr_addr,
 			   struct interface *src_ifp, pim_addr src_ip);
-
+void pim_upstream_nh_if_update(struct pim_instance *pim, struct interface *ifp);
 #endif

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -53,6 +53,11 @@ struct pim_nexthop_cache {
 	uint32_t bsr_count;
 };
 
+struct pnc_hash_walk_data {
+	struct pim_instance *pim;
+	struct interface *ifp;
+};
+
 int pim_parse_nexthop_update(ZAPI_CALLBACK_ARGS);
 int pim_find_or_track_nexthop(struct pim_instance *pim, pim_addr addr,
 			      struct pim_upstream *up, struct rp_info *rp,

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -61,6 +61,7 @@ bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
 	ifindex_t first_ifindex = 0;
 	int found = 0;
 	int i = 0;
+	struct pim_interface *pim_ifp;
 
 #if PIM_IPV == 4
 	/*
@@ -118,15 +119,16 @@ bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
 			continue;
 		}
 
-		if (!ifp->info) {
+		pim_ifp = ifp->info;
+		if (!pim_ifp || !pim_ifp->pim_enable) {
 			if (PIM_DEBUG_ZEBRA)
 				zlog_debug(
-					"%s: multicast not enabled on input interface %s (ifindex=%d, RPF for source %pPAs)",
+					"%s: pim not enabled on input interface %s (ifindex=%d, RPF for source %pPAs)",
 					__func__, ifp->name, first_ifindex,
 					&addr);
 			i++;
-		} else if (neighbor_needed
-			   && !pim_if_connected_to_source(ifp, addr)) {
+		} else if (neighbor_needed &&
+			   !pim_if_connected_to_source(ifp, addr)) {
 			nbr = pim_neighbor_find(ifp,
 						nexthop_tab[i].nexthop_addr);
 			if (PIM_DEBUG_PIM_TRACE_DETAIL)


### PR DESCRIPTION
Commit 1:
    Handle IPV6 for "no ipv6 pim" code flow.

Commit 2:
    When “no ip pim” command gets executed on source connected interface, then clear upstream RPF information.
    Closes #10782
    Closes #11931