### PR TITLE
bgpd: Fix `show bgp nexthop A.B.C.D`

### DIFF
--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -919,7 +919,7 @@ static int show_ip_bgp_nexthop_table(struct vty *vty, const char *name,
 		}
 		tree = import_table ? &bgp->import_check_table
 				    : &bgp->nexthop_cache_table;
-		bnc = bnc_find(tree[family2afi(nhop.family)], &nhop, 0, 0);
+		bnc = bnc_find(&(*tree)[family2afi(nhop.family)], &nhop, 0, 0);
 		if (!bnc) {
 			vty_out(vty, "specified nexthop does not have entry\n");
 			return CMD_SUCCESS;


### PR DESCRIPTION
The issuing of `show bgp nexthop A.B.C.D` fails even if that nexthop exists:

eva# show bgp nexthop 192.168.119.120
specified nexthop does not have entry

Fixed:

eva# show bgp nexthop 192.168.119.120
 192.168.119.120 valid [IGP metric 0], #paths 0, peer 192.168.119.120
  if enp39s0
  Last update: Fri Sep 30 14:55:13 2022

  Paths:

Signed-off-by: Donald Sharp <sharpd@nvidia.com>