### PR TITLE
RA logging improvements

### DIFF
--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -664,8 +664,9 @@ static void rtadv_process_advert(uint8_t *msg, unsigned int len,
 	     zif->rtadv.lastadvcurhoplimit.tv_sec == 0)) {
 		flog_warn(
 			EC_ZEBRA_RA_PARAM_MISMATCH,
-			"%s(%u): Rx RA - our AdvCurHopLimit doesn't agree with %s",
-			ifp->name, ifp->ifindex, addr_str);
+			"%s(%u): Rx RA - our AdvCurHopLimit (%u) doesn't agree with %s (%u)",
+			ifp->name, ifp->ifindex, zif->rtadv.AdvCurHopLimit,
+			addr_str, radvert->nd_ra_curhoplimit);
 		monotime(&zif->rtadv.lastadvcurhoplimit);
 	}
 
@@ -676,8 +677,11 @@ static void rtadv_process_advert(uint8_t *msg, unsigned int len,
 	     zif->rtadv.lastadvmanagedflag.tv_sec == 0)) {
 		flog_warn(
 			EC_ZEBRA_RA_PARAM_MISMATCH,
-			"%s(%u): Rx RA - our AdvManagedFlag doesn't agree with %s",
-			ifp->name, ifp->ifindex, addr_str);
+			"%s(%u): Rx RA - our AdvManagedFlag (%u) doesn't agree with %s (%u)",
+			ifp->name, ifp->ifindex, zif->rtadv.AdvManagedFlag,
+			addr_str,
+			!!CHECK_FLAG(radvert->nd_ra_flags_reserved,
+				     ND_RA_FLAG_MANAGED));
 		monotime(&zif->rtadv.lastadvmanagedflag);
 	}
 
@@ -688,8 +692,11 @@ static void rtadv_process_advert(uint8_t *msg, unsigned int len,
 	     zif->rtadv.lastadvotherconfigflag.tv_sec == 0)) {
 		flog_warn(
 			EC_ZEBRA_RA_PARAM_MISMATCH,
-			"%s(%u): Rx RA - our AdvOtherConfigFlag doesn't agree with %s",
-			ifp->name, ifp->ifindex, addr_str);
+			"%s(%u): Rx RA - our AdvOtherConfigFlag (%u) doesn't agree with %s (%u)",
+			ifp->name, ifp->ifindex, zif->rtadv.AdvOtherConfigFlag,
+			addr_str,
+			!!CHECK_FLAG(radvert->nd_ra_flags_reserved,
+				     ND_RA_FLAG_OTHER));
 		monotime(&zif->rtadv.lastadvotherconfigflag);
 	}
 
@@ -700,8 +707,9 @@ static void rtadv_process_advert(uint8_t *msg, unsigned int len,
 	     zif->rtadv.lastadvreachabletime.tv_sec == 0)) {
 		flog_warn(
 			EC_ZEBRA_RA_PARAM_MISMATCH,
-			"%s(%u): Rx RA - our AdvReachableTime doesn't agree with %s",
-			ifp->name, ifp->ifindex, addr_str);
+			"%s(%u): Rx RA - our AdvReachableTime (%u) doesn't agree with %s (%u)",
+			ifp->name, ifp->ifindex, zif->rtadv.AdvReachableTime,
+			addr_str, ntohl(radvert->nd_ra_reachable));
 		monotime(&zif->rtadv.lastadvreachabletime);
 	}
 
@@ -712,8 +720,9 @@ static void rtadv_process_advert(uint8_t *msg, unsigned int len,
 	     zif->rtadv.lastadvretranstimer.tv_sec == 0)) {
 		flog_warn(
 			EC_ZEBRA_RA_PARAM_MISMATCH,
-			"%s(%u): Rx RA - our AdvRetransTimer doesn't agree with %s",
-			ifp->name, ifp->ifindex, addr_str);
+			"%s(%u): Rx RA - our AdvRetransTimer (%u) doesn't agree with %s (%u)",
+			ifp->name, ifp->ifindex, zif->rtadv.AdvRetransTimer,
+			addr_str, ntohl(radvert->nd_ra_retransmit));
 		monotime(&zif->rtadv.lastadvretranstimer);
 	}
 

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -713,7 +713,8 @@ static void rtadv_process_advert(uint8_t *msg, unsigned int len,
 		monotime(&zif->rtadv.lastadvreachabletime);
 	}
 
-	if ((ntohl(radvert->nd_ra_retransmit) !=
+	if ((radvert->nd_ra_retransmit && zif->rtadv.AdvRetransTimer) &&
+	    (ntohl(radvert->nd_ra_retransmit) !=
 	     (unsigned int)zif->rtadv.AdvRetransTimer) &&
 	    (monotime_since(&zif->rtadv.lastadvretranstimer, NULL) >
 		     SIXHOUR2USEC ||


### PR DESCRIPTION
Couple commits here to improve our logging of RAs.
1) When we detect a mismatch in local/received values, include those values in the log
2) Exclude Retrans Timer inconsistencies from system logging if one of the values is 0 per RFC 4861