### PR TITLE
lib: hash list add function fix

### DIFF
--- a/lib/typesafe.h
+++ b/lib/typesafe.h
@@ -850,9 +850,12 @@ macro_inline type *prefix ## _add(struct prefix##_head *h, type *item)         \
 	struct thash_item **np = &h->hh.entries[hbits];                        \
 	while (*np && (*np)->hashval < hval)                                   \
 		np = &(*np)->next;                                             \
-	if (*np && cmpfn(container_of(*np, type, field.hi), item) == 0) {      \
-		h->hh.count--;                                                 \
-		return container_of(*np, type, field.hi);                      \
+	while (*np && (*np)->hashval == hval) {                                \
+		if (cmpfn(container_of(*np, type, field.hi), item) == 0) {     \
+			h->hh.count--;                                         \
+			return container_of(*np, type, field.hi);              \
+		}                                                              \
+		np = &(*np)->next;                                             \
 	}                                                                      \
 	item->field.hi.next = *np;                                             \
 	*np = &item->field.hi;                                                 \

--- a/tests/lib/test_typelist.h
+++ b/tests/lib/test_typelist.h
@@ -74,7 +74,7 @@ static uint32_t list_hash(const struct item *a)
 {
 #ifdef SHITTY_HASH
 	/* crappy hash to get some hash collisions */
-	return a->val ^ (a->val << 29) ^ 0x55AA0000U;
+	return (a->val & 0xFF) ^ (a->val << 29) ^ 0x55AA0000U;
 #else
 	return jhash_1word(a->val, 0xdeadbeef);
 #endif


### PR DESCRIPTION
_add function in hash list is not supporting some same hash value case. if we add instance of structure tye a and b different but with same hash value. the _add a, add b, add a sequence lead to have the same object twice in list.

the aim of that fix is to avoid such situation, coding the _add function in a similar manner than the _find one

Signed-off-by: Francois Dumontet <francois.dumontet@6wind.com>