### PR TITLE
*: clean up various CLI-related bits

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5773,7 +5773,7 @@ ALIAS_HIDDEN(neighbor_remove_private_as_all,
 	     "neighbor <A.B.C.D|X:X::X:X|WORD> remove-private-AS all",
 	     NEIGHBOR_STR NEIGHBOR_ADDR_STR2
 	     "Remove private ASNs in outbound updates\n"
-	     "Apply to all AS numbers")
+	     "Apply to all AS numbers\n")
 
 DEFUN (neighbor_remove_private_as_replace_as,
        neighbor_remove_private_as_replace_as_cmd,

--- a/ldpd/ldp_vty_cmds.c
+++ b/ldpd/ldp_vty_cmds.c
@@ -246,7 +246,7 @@ DEFPY  (ldp_allow_broken_lsps,
 	"[no] install allow-broken-lsps",
 	NO_STR
 	"install lsps\n"
-	"if no remote-label install with imp-null")
+	"if no remote-label install with imp-null\n")
 {
 	return (ldp_vty_allow_broken_lsp(vty, no));
 }

--- a/lib/command.c
+++ b/lib/command.c
@@ -264,8 +264,7 @@ void install_node(struct cmd_node *node)
 	node->cmdgraph = graph_new();
 	node->cmd_vector = vector_init(VECTOR_MIN_SIZE);
 	// add start node
-	struct cmd_token *token =
-		cmd_token_new(START_TKN, CMD_ATTR_NORMAL, NULL, NULL);
+	struct cmd_token *token = cmd_token_new(START_TKN, 0, NULL, NULL);
 	graph_new_node(node->cmdgraph, token,
 		       (void (*)(void *)) & cmd_token_del);
 
@@ -325,7 +324,7 @@ void _install_element(enum node_type ntype, const struct cmd_element *cmd)
 	if (cnode->graph_built || !defer_cli_tree) {
 		struct graph *graph = graph_new();
 		struct cmd_token *token =
-			cmd_token_new(START_TKN, CMD_ATTR_NORMAL, NULL, NULL);
+			cmd_token_new(START_TKN, 0, NULL, NULL);
 		graph_new_node(graph, token,
 			       (void (*)(void *)) & cmd_token_del);
 
@@ -348,8 +347,7 @@ static void cmd_finalize_iter(struct hash_bucket *hb, void *arg)
 	struct cmd_node *cnode = arg;
 	const struct cmd_element *cmd = hb->data;
 	struct graph *graph = graph_new();
-	struct cmd_token *token =
-		cmd_token_new(START_TKN, CMD_ATTR_NORMAL, NULL, NULL);
+	struct cmd_token *token = cmd_token_new(START_TKN, 0, NULL, NULL);
 
 	graph_new_node(graph, token, (void (*)(void *)) & cmd_token_del);
 
@@ -404,7 +402,7 @@ void uninstall_element(enum node_type ntype, const struct cmd_element *cmd)
 	if (cnode->graph_built) {
 		struct graph *graph = graph_new();
 		struct cmd_token *token =
-			cmd_token_new(START_TKN, CMD_ATTR_NORMAL, NULL, NULL);
+			cmd_token_new(START_TKN, 0, NULL, NULL);
 		graph_new_node(graph, token,
 			       (void (*)(void *)) & cmd_token_del);
 
@@ -990,7 +988,7 @@ static int cmd_execute_command_real(vector vline, enum cmd_filter_type filter,
 			 * Perform pending commit (if any) before executing
 			 * non-YANG command.
 			 */
-			if (matched_element->attr != CMD_ATTR_YANG)
+			if (!(matched_element->attr & CMD_ATTR_YANG))
 				(void)nb_cli_pending_commit_check(vty);
 		}
 
@@ -1471,8 +1469,7 @@ static void permute(struct graph_node *start, struct vty *vty)
 	for (unsigned int i = 0; i < vector_active(start->to); i++) {
 		struct graph_node *gn = vector_slot(start->to, i);
 		struct cmd_token *tok = gn->data;
-		if (tok->attr == CMD_ATTR_HIDDEN
-		    || tok->attr == CMD_ATTR_DEPRECATED)
+		if (tok->attr & CMD_ATTR_HIDDEN)
 			continue;
 		else if (tok->type == END_TKN || gn == start) {
 			vty_out(vty, " ");
@@ -1561,9 +1558,8 @@ int cmd_list_cmds(struct vty *vty, int do_permute)
 		const struct cmd_element *element = NULL;
 		for (unsigned int i = 0; i < vector_active(node->cmd_vector);
 		     i++)
-			if ((element = vector_slot(node->cmd_vector, i))
-			    && element->attr != CMD_ATTR_DEPRECATED
-			    && element->attr != CMD_ATTR_HIDDEN) {
+			if ((element = vector_slot(node->cmd_vector, i)) &&
+			    !(element->attr & CMD_ATTR_HIDDEN)) {
 				vty_out(vty, "    ");
 				print_cmd(vty, element->string);
 			}

--- a/lib/command.h
+++ b/lib/command.h
@@ -358,9 +358,13 @@ struct cmd_node {
 	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_HIDDEN, \
 			  0)
 
+/* note: DEPRECATED implies HIDDEN, and other than that there is currently no
+ * difference.  It's purely for expressing intent in the source code - a
+ * DEPRECATED command is supposed to go away, a HIDDEN one is likely to stay.
+ */
 #define ALIAS_DEPRECATED(funcname, cmdname, cmdstr, helpstr)                   \
 	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr,                  \
-			  CMD_ATTR_DEPRECATED, 0)
+			  CMD_ATTR_DEPRECATED | CMD_ATTR_HIDDEN, 0)
 
 #define ALIAS_YANG(funcname, cmdname, cmdstr, helpstr)                         \
 	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_YANG, 0)

--- a/lib/command.h
+++ b/lib/command.h
@@ -280,16 +280,17 @@ struct cmd_node {
 			    int argc __attribute__((unused)),                  \
 			    struct cmd_token *argv[] __attribute__((unused)))
 
-#define DEFPY(funcname, cmdname, cmdstr, helpstr)                              \
-	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, 0, 0)            \
-	funcdecl_##funcname
-
-#define DEFPY_NOSH(funcname, cmdname, cmdstr, helpstr)                         \
-	DEFPY(funcname, cmdname, cmdstr, helpstr)
+/* DEFPY variants */
 
 #define DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr, attr)                   \
 	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, attr, 0)         \
 	funcdecl_##funcname
+
+#define DEFPY(funcname, cmdname, cmdstr, helpstr)                              \
+	DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr, 0)
+
+#define DEFPY_NOSH(funcname, cmdname, cmdstr, helpstr)                         \
+	DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr, 0)
 
 #define DEFPY_HIDDEN(funcname, cmdname, cmdstr, helpstr)                       \
 	DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_HIDDEN)
@@ -298,17 +299,17 @@ struct cmd_node {
 	DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_YANG)
 
 #define DEFPY_YANG_NOSH(funcname, cmdname, cmdstr, helpstr)                    \
-	DEFPY_YANG(funcname, cmdname, cmdstr, helpstr)
+	DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_YANG)
 
-#define DEFUN(funcname, cmdname, cmdstr, helpstr)                              \
-	DEFUN_CMD_FUNC_DECL(funcname)                                          \
-	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, 0, 0)            \
-	DEFUN_CMD_FUNC_TEXT(funcname)
+/* DEFUN variants */
 
 #define DEFUN_ATTR(funcname, cmdname, cmdstr, helpstr, attr)                   \
 	DEFUN_CMD_FUNC_DECL(funcname)                                          \
 	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, attr, 0)         \
 	DEFUN_CMD_FUNC_TEXT(funcname)
+
+#define DEFUN(funcname, cmdname, cmdstr, helpstr)                              \
+	DEFUN_ATTR(funcname, cmdname, cmdstr, helpstr, 0)
 
 #define DEFUN_HIDDEN(funcname, cmdname, cmdstr, helpstr)                       \
 	DEFUN_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_HIDDEN)
@@ -318,56 +319,54 @@ struct cmd_node {
 
 /* DEFUN_NOSH for commands that vtysh should ignore */
 #define DEFUN_NOSH(funcname, cmdname, cmdstr, helpstr)                         \
-	DEFUN(funcname, cmdname, cmdstr, helpstr)
+	DEFUN_ATTR(funcname, cmdname, cmdstr, helpstr, 0)
 
 #define DEFUN_YANG_NOSH(funcname, cmdname, cmdstr, helpstr)                    \
-	DEFUN_YANG(funcname, cmdname, cmdstr, helpstr)
+	DEFUN_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_YANG)
 
 /* DEFSH for vtysh. */
+#define DEFSH_ATTR(daemon, cmdname, cmdstr, helpstr, attr)                     \
+	DEFUN_CMD_ELEMENT(NULL, cmdname, cmdstr, helpstr, attr, daemon)
+
 #define DEFSH(daemon, cmdname, cmdstr, helpstr)                                \
-	DEFUN_CMD_ELEMENT(NULL, cmdname, cmdstr, helpstr, 0, daemon)
+	DEFSH_ATTR(daemon, cmdname, cmdstr, helpstr, 0)
 
 #define DEFSH_HIDDEN(daemon, cmdname, cmdstr, helpstr)                         \
-	DEFUN_CMD_ELEMENT(NULL, cmdname, cmdstr, helpstr, CMD_ATTR_HIDDEN,     \
-			  daemon)
+	DEFSH_ATTR(daemon, cmdname, cmdstr, helpstr, CMD_ATTR_HIDDEN)
 
 /* DEFUN + DEFSH */
-#define DEFUNSH(daemon, funcname, cmdname, cmdstr, helpstr)                    \
-	DEFUN_CMD_FUNC_DECL(funcname)                                          \
-	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, 0, daemon)       \
-	DEFUN_CMD_FUNC_TEXT(funcname)
-
-/* DEFUN + DEFSH with attributes */
 #define DEFUNSH_ATTR(daemon, funcname, cmdname, cmdstr, helpstr, attr)         \
 	DEFUN_CMD_FUNC_DECL(funcname)                                          \
 	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, attr, daemon)    \
 	DEFUN_CMD_FUNC_TEXT(funcname)
+
+#define DEFUNSH(daemon, funcname, cmdname, cmdstr, helpstr)                    \
+	DEFUNSH_ATTR(daemon, funcname, cmdname, cmdstr, helpstr, 0)
 
 #define DEFUNSH_HIDDEN(daemon, funcname, cmdname, cmdstr, helpstr)             \
 	DEFUNSH_ATTR(daemon, funcname, cmdname, cmdstr, helpstr,               \
 		     CMD_ATTR_HIDDEN)
 
 /* ALIAS macro which define existing command's alias. */
-#define ALIAS(funcname, cmdname, cmdstr, helpstr)                              \
-	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, 0, 0)
-
 #define ALIAS_ATTR(funcname, cmdname, cmdstr, helpstr, attr)                   \
 	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, attr, 0)
 
+#define ALIAS(funcname, cmdname, cmdstr, helpstr)                              \
+	ALIAS_ATTR(funcname, cmdname, cmdstr, helpstr, 0)
+
 #define ALIAS_HIDDEN(funcname, cmdname, cmdstr, helpstr)                       \
-	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_HIDDEN, \
-			  0)
+	ALIAS_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_HIDDEN)
 
 /* note: DEPRECATED implies HIDDEN, and other than that there is currently no
  * difference.  It's purely for expressing intent in the source code - a
  * DEPRECATED command is supposed to go away, a HIDDEN one is likely to stay.
  */
 #define ALIAS_DEPRECATED(funcname, cmdname, cmdstr, helpstr)                   \
-	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr,                  \
-			  CMD_ATTR_DEPRECATED | CMD_ATTR_HIDDEN, 0)
+	ALIAS_ATTR(funcname, cmdname, cmdstr, helpstr,                         \
+		   CMD_ATTR_DEPRECATED | CMD_ATTR_HIDDEN)
 
 #define ALIAS_YANG(funcname, cmdname, cmdstr, helpstr)                         \
-	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_YANG, 0)
+	ALIAS_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_YANG)
 
 #endif /* VTYSH_EXTRACT_PL */
 

--- a/lib/command.h
+++ b/lib/command.h
@@ -331,9 +331,6 @@ struct cmd_node {
 	DEFUN_CMD_ELEMENT(NULL, cmdname, cmdstr, helpstr, CMD_ATTR_HIDDEN,     \
 			  daemon)
 
-#define DEFSH_YANG(daemon, cmdname, cmdstr, helpstr)                           \
-	DEFUN_CMD_ELEMENT(NULL, cmdname, cmdstr, helpstr, CMD_ATTR_YANG, daemon)
-
 /* DEFUN + DEFSH */
 #define DEFUNSH(daemon, funcname, cmdname, cmdstr, helpstr)                    \
 	DEFUN_CMD_FUNC_DECL(funcname)                                          \
@@ -349,13 +346,6 @@ struct cmd_node {
 #define DEFUNSH_HIDDEN(daemon, funcname, cmdname, cmdstr, helpstr)             \
 	DEFUNSH_ATTR(daemon, funcname, cmdname, cmdstr, helpstr,               \
 		     CMD_ATTR_HIDDEN)
-
-#define DEFUNSH_DEPRECATED(daemon, funcname, cmdname, cmdstr, helpstr)         \
-	DEFUNSH_ATTR(daemon, funcname, cmdname, cmdstr, helpstr,               \
-		     CMD_ATTR_DEPRECATED)
-
-#define DEFUNSH_YANG(daemon, funcname, cmdname, cmdstr, helpstr)               \
-	DEFUNSH_ATTR(daemon, funcname, cmdname, cmdstr, helpstr, CMD_ATTR_YANG)
 
 /* ALIAS macro which define existing command's alias. */
 #define ALIAS(funcname, cmdname, cmdstr, helpstr)                              \
@@ -374,17 +364,6 @@ struct cmd_node {
 
 #define ALIAS_YANG(funcname, cmdname, cmdstr, helpstr)                         \
 	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_YANG, 0)
-
-#define ALIAS_SH(daemon, funcname, cmdname, cmdstr, helpstr)                   \
-	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, 0, daemon)
-
-#define ALIAS_SH_HIDDEN(daemon, funcname, cmdname, cmdstr, helpstr)            \
-	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_HIDDEN, \
-			  daemon)
-
-#define ALIAS_SH_DEPRECATED(daemon, funcname, cmdname, cmdstr, helpstr)        \
-	DEFUN_CMD_ELEMENT(funcname, cmdname, cmdstr, helpstr,                  \
-			  CMD_ATTR_DEPRECATED, daemon)
 
 #endif /* VTYSH_EXTRACT_PL */
 

--- a/lib/command.h
+++ b/lib/command.h
@@ -290,7 +290,7 @@ struct cmd_node {
 	DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr, 0)
 
 #define DEFPY_NOSH(funcname, cmdname, cmdstr, helpstr)                         \
-	DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr, 0)
+	DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_NOSH)
 
 #define DEFPY_HIDDEN(funcname, cmdname, cmdstr, helpstr)                       \
 	DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_HIDDEN)
@@ -299,7 +299,8 @@ struct cmd_node {
 	DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_YANG)
 
 #define DEFPY_YANG_NOSH(funcname, cmdname, cmdstr, helpstr)                    \
-	DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_YANG)
+	DEFPY_ATTR(funcname, cmdname, cmdstr, helpstr,                         \
+		   CMD_ATTR_YANG | CMD_ATTR_NOSH)
 
 /* DEFUN variants */
 
@@ -319,10 +320,11 @@ struct cmd_node {
 
 /* DEFUN_NOSH for commands that vtysh should ignore */
 #define DEFUN_NOSH(funcname, cmdname, cmdstr, helpstr)                         \
-	DEFUN_ATTR(funcname, cmdname, cmdstr, helpstr, 0)
+	DEFUN_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_NOSH)
 
 #define DEFUN_YANG_NOSH(funcname, cmdname, cmdstr, helpstr)                    \
-	DEFUN_ATTR(funcname, cmdname, cmdstr, helpstr, CMD_ATTR_YANG)
+	DEFUN_ATTR(funcname, cmdname, cmdstr, helpstr,                         \
+		   CMD_ATTR_YANG | CMD_ATTR_NOSH)
 
 /* DEFSH for vtysh. */
 #define DEFSH_ATTR(daemon, cmdname, cmdstr, helpstr, attr)                     \

--- a/lib/command_graph.c
+++ b/lib/command_graph.c
@@ -494,9 +494,10 @@ void cmd_graph_node_print_cb(struct graph_node *gn, struct buffer *buf)
 	snprintf(nbuf, sizeof(nbuf), "<b>%s</b>",
 		 lookup_msg(tokennames, tok->type, NULL));
 	buffer_putstr(buf, nbuf);
-	if (tok->attr == CMD_ATTR_DEPRECATED)
+	if (tok->attr & CMD_ATTR_DEPRECATED)
 		buffer_putstr(buf, " (d)");
-	else if (tok->attr == CMD_ATTR_HIDDEN)
+	/* DEPRECATED implies HIDDEN, don't print both */
+	else if (tok->attr & CMD_ATTR_HIDDEN)
 		buffer_putstr(buf, " (h)");
 	if (tok->text) {
 		if (tok->type == WORD_TKN)

--- a/lib/command_graph.h
+++ b/lib/command_graph.h
@@ -73,10 +73,10 @@ enum cmd_token_type {
 #define IS_VARYING_TOKEN(x) ((x) >= VARIABLE_TKN && (x) < FORK_TKN)
 
 /* Command attributes */
-enum { CMD_ATTR_NORMAL,
-       CMD_ATTR_DEPRECATED,
-       CMD_ATTR_HIDDEN,
-       CMD_ATTR_YANG,
+enum {
+	CMD_ATTR_YANG = (1 << 0),
+	CMD_ATTR_HIDDEN = (1 << 1),
+	CMD_ATTR_DEPRECATED = (1 << 2),
 };
 
 enum varname_src {

--- a/lib/command_graph.h
+++ b/lib/command_graph.h
@@ -77,6 +77,7 @@ enum {
 	CMD_ATTR_YANG = (1 << 0),
 	CMD_ATTR_HIDDEN = (1 << 1),
 	CMD_ATTR_DEPRECATED = (1 << 2),
+	CMD_ATTR_NOSH = (1 << 3),
 };
 
 enum varname_src {

--- a/lib/command_match.c
+++ b/lib/command_match.c
@@ -395,8 +395,7 @@ enum matcher_rv command_complete(struct graph *graph, vector vline,
 		for (ALL_LIST_ELEMENTS_RO(current, node, gstack)) {
 			struct cmd_token *token = gstack[0]->data;
 
-			if (token->attr == CMD_ATTR_HIDDEN
-			    || token->attr == CMD_ATTR_DEPRECATED)
+			if (token->attr & CMD_ATTR_HIDDEN)
 				continue;
 
 			enum match_type minmatch = min_match_level(token->type);

--- a/lib/command_py.c
+++ b/lib/command_py.c
@@ -355,7 +355,8 @@ PyMODINIT_FUNC command_py_init(void)
 
 	if (PyModule_AddIntMacro(pymod, CMD_ATTR_YANG)
 	    || PyModule_AddIntMacro(pymod, CMD_ATTR_HIDDEN)
-	    || PyModule_AddIntMacro(pymod, CMD_ATTR_DEPRECATED))
+	    || PyModule_AddIntMacro(pymod, CMD_ATTR_DEPRECATED)
+	    || PyModule_AddIntMacro(pymod, CMD_ATTR_NOSH))
 		initret(NULL);
 
 	Py_INCREF(&typeobj_graph_node);

--- a/lib/command_py.c
+++ b/lib/command_py.c
@@ -226,8 +226,8 @@ static PyObject *graph_to_pyobj(struct wrap_graph *wgraph,
 			wrap->type = "???";
 		}
 
-		wrap->deprecated = (tok->attr == CMD_ATTR_DEPRECATED);
-		wrap->hidden = (tok->attr == CMD_ATTR_HIDDEN);
+		wrap->deprecated = !!(tok->attr & CMD_ATTR_DEPRECATED);
+		wrap->hidden = !!(tok->attr & CMD_ATTR_HIDDEN);
 		wrap->text = tok->text;
 		wrap->desc = tok->desc;
 		wrap->varname = tok->varname;
@@ -351,6 +351,11 @@ PyMODINIT_FUNC command_py_init(void)
 
 	pymod = modcreate();
 	if (!pymod)
+		initret(NULL);
+
+	if (PyModule_AddIntMacro(pymod, CMD_ATTR_YANG)
+	    || PyModule_AddIntMacro(pymod, CMD_ATTR_HIDDEN)
+	    || PyModule_AddIntMacro(pymod, CMD_ATTR_DEPRECATED))
 		initret(NULL);
 
 	Py_INCREF(&typeobj_graph_node);

--- a/lib/grammar_sandbox.c
+++ b/lib/grammar_sandbox.c
@@ -76,8 +76,7 @@ DEFUN (grammar_test,
 
 	// parse the command and install it into the command graph
 	struct graph *graph = graph_new();
-	struct cmd_token *token =
-		cmd_token_new(START_TKN, CMD_ATTR_NORMAL, NULL, NULL);
+	struct cmd_token *token = cmd_token_new(START_TKN, 0, NULL, NULL);
 	graph_new_node(graph, token, (void (*)(void *)) & cmd_token_del);
 
 	cmd_graph_parse(graph, cmd);

--- a/lib/log_vty.c
+++ b/lib/log_vty.c
@@ -761,8 +761,8 @@ DEFPY (log_immediate_mode,
        log_immediate_mode_cmd,
        "[no] log immediate-mode",
        NO_STR
-       "Logging control"
-       "Output immediately, without buffering")
+       "Logging control\n"
+       "Output immediately, without buffering\n")
 {
 	zlog_set_immediate(!no);
 	return CMD_SUCCESS;

--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -2997,9 +2997,9 @@ DEFPY(gm_debug_show,
       "debug show mld interface IFNAME",
       DEBUG_STR
       SHOW_STR
-      "MLD"
+      MLD_STR
       INTERFACE_STR
-      "interface name")
+      "interface name\n")
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5437,7 +5437,7 @@ DEFPY(no_ip_msdp_mesh_group,
       IP_STR
       CFG_MSDP_STR
       "Delete MSDP mesh-group\n"
-      "Mesh group name")
+      "Mesh group name\n")
 {
 	const char *vrfname;
 	char xpath_value[XPATH_MAXLEN];

--- a/python/clippy/__init__.py
+++ b/python/clippy/__init__.py
@@ -17,8 +17,22 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
 import os, stat
+
+try:
+    from enum import IntFlag as _IntFlag
+except ImportError:
+    # python <3.6
+    from enum import IntEnum as _IntFlag  # type: ignore
+
 import _clippy
-from _clippy import parse, Graph, GraphNode
+from _clippy import (
+    parse,
+    Graph,
+    GraphNode,
+    CMD_ATTR_YANG,
+    CMD_ATTR_HIDDEN,
+    CMD_ATTR_DEPRECATED,
+)
 
 
 frr_top_src = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -78,3 +92,9 @@ def wrdiff(filename, buf, reffiles=[]):
     with open(newname, "w") as out:
         out.write(buf)
     os.rename(newname, filename)
+
+
+class CmdAttr(_IntFlag):
+    YANG = CMD_ATTR_YANG
+    HIDDEN = CMD_ATTR_HIDDEN
+    DEPRECATED = CMD_ATTR_DEPRECATED

--- a/python/clippy/__init__.py
+++ b/python/clippy/__init__.py
@@ -32,6 +32,7 @@ from _clippy import (
     CMD_ATTR_YANG,
     CMD_ATTR_HIDDEN,
     CMD_ATTR_DEPRECATED,
+    CMD_ATTR_NOSH,
 )
 
 
@@ -98,3 +99,4 @@ class CmdAttr(_IntFlag):
     YANG = CMD_ATTR_YANG
     HIDDEN = CMD_ATTR_HIDDEN
     DEPRECATED = CMD_ATTR_DEPRECATED
+    NOSH = CMD_ATTR_NOSH

--- a/python/makefile.py
+++ b/python/makefile.py
@@ -160,6 +160,9 @@ for clippy_file in clippy_scan:
 
 # combine daemon .xref files into frr.xref
 out_lines.append("")
+xref_targets = [
+    target for target in xref_targets if target not in ["tools/ssd", "vtysh/vtysh"]
+]
 out_lines.append(
     "xrefs = %s" % (" ".join(["%s.xref" % target for target in xref_targets]))
 )

--- a/python/xrelfo.py
+++ b/python/xrelfo.py
@@ -21,7 +21,16 @@ import os
 import struct
 import re
 import traceback
-import json
+
+json_dump_args = {}
+
+try:
+    import ujson as json
+
+    json_dump_args["escape_forward_slashes"] = False
+except ImportError:
+    import json
+
 import argparse
 
 from clippy.uidhash import uidhash
@@ -418,12 +427,12 @@ def _main(args):
 
     if args.output:
         with open(args.output + '.tmp', 'w') as fd:
-            json.dump(out, fd, indent=2, sort_keys=True)
+            json.dump(out, fd, indent=2, sort_keys=True, **json_dump_args)
         os.rename(args.output + '.tmp', args.output)
 
     if args.out_by_file:
         with open(args.out_by_file + '.tmp', 'w') as fd:
-            json.dump(outbyfile, fd, indent=2, sort_keys=True)
+            json.dump(outbyfile, fd, indent=2, sort_keys=True, **json_dump_args)
         os.rename(args.out_by_file + '.tmp', args.out_by_file)
 
 if __name__ == '__main__':

--- a/tools/permutations.c
+++ b/tools/permutations.c
@@ -80,8 +80,7 @@ void permute(struct graph_node *start)
 	for (unsigned int i = 0; i < vector_active(start->to); i++) {
 		struct graph_node *gn = vector_slot(start->to, i);
 		struct cmd_token *tok = gn->data;
-		if (tok->attr == CMD_ATTR_HIDDEN
-		    || tok->attr == CMD_ATTR_DEPRECATED)
+		if (tok->attr & CMD_ATTR_HIDDEN)
 			continue;
 		else if (tok->type == END_TKN || gn == start) {
 			fprintf(stdout, " ");

--- a/vrrpd/vrrp_vty.c
+++ b/vrrpd/vrrp_vty.c
@@ -121,7 +121,7 @@ DEFPY_YANG(vrrp_priority,
       VRRP_STR
       VRRP_VRID_STR
       VRRP_PRIORITY_STR
-      "Priority value")
+      "Priority value\n")
 {
 	nb_cli_enqueue_change(vty, "./priority", NB_OP_MODIFY, priority_str);
 
@@ -138,7 +138,7 @@ DEFPY_YANG(no_vrrp_priority,
       VRRP_STR
       VRRP_VRID_STR
       VRRP_PRIORITY_STR
-      "Priority value")
+      "Priority value\n")
 {
 	nb_cli_enqueue_change(vty, "./priority", NB_OP_MODIFY, NULL);
 
@@ -162,7 +162,7 @@ DEFPY_YANG(vrrp_advertisement_interval,
       vrrp_advertisement_interval_cmd,
       "vrrp (1-255)$vrid advertisement-interval (10-40950)",
       VRRP_STR VRRP_VRID_STR VRRP_ADVINT_STR
-      "Advertisement interval in milliseconds; must be multiple of 10")
+      "Advertisement interval in milliseconds; must be multiple of 10\n")
 {
 	char val[20];
 
@@ -183,7 +183,7 @@ DEFPY_YANG(no_vrrp_advertisement_interval,
       no_vrrp_advertisement_interval_cmd,
       "no vrrp (1-255)$vrid advertisement-interval [(10-40950)]",
       NO_STR VRRP_STR VRRP_VRID_STR VRRP_ADVINT_STR
-      "Advertisement interval in milliseconds; must be multiple of 10")
+      "Advertisement interval in milliseconds; must be multiple of 10\n")
 {
 	nb_cli_enqueue_change(vty, "./advertisement-interval", NB_OP_MODIFY,
 			      NULL);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2951,7 +2951,7 @@ DEFUN_HIDDEN (show_config_running,
        show_config_running_cmd,
        "show configuration running\
           [<json|xml> [translate WORD]]\
-          [with-defaults]" DAEMONS_LIST,
+          [with-defaults] " DAEMONS_LIST,
        SHOW_STR
        "Configuration information\n"
        "Running configuration\n"
@@ -2972,7 +2972,7 @@ DEFUN (show_yang_operational_data,
 	   format <json|xml>\
 	   |translate WORD\
 	   |with-config\
-	 }]" DAEMONS_LIST,
+	 }] " DAEMONS_LIST,
        SHOW_STR
        "YANG information\n"
        "Show YANG operational data\n"

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1841,12 +1841,15 @@ DEFUN (clear_zebra_fpm_stats,
 /*
  * update fpm connection information
  */
-DEFUN ( fpm_remote_ip,
+DEFUN (fpm_remote_ip,
        fpm_remote_ip_cmd,
-        "fpm connection ip A.B.C.D port (1-65535)",
-        "fpm connection remote ip and port\n"
-        "Remote fpm server ip A.B.C.D\n"
-        "Enter ip ")
+       "fpm connection ip A.B.C.D port (1-65535)",
+       "Forwarding Path Manager\n"
+       "Configure FPM connection\n"
+       "Connect to IPv4 address\n"
+       "Connect to IPv4 address\n"
+       "TCP port number\n"
+       "TCP port number\n")
 {
 
 	in_addr_t fpm_server;
@@ -1867,13 +1870,16 @@ DEFUN ( fpm_remote_ip,
 	return CMD_SUCCESS;
 }
 
-DEFUN ( no_fpm_remote_ip,
+DEFUN (no_fpm_remote_ip,
        no_fpm_remote_ip_cmd,
-        "no fpm connection ip A.B.C.D port (1-65535)",
-        "fpm connection remote ip and port\n"
-        "Connection\n"
-        "Remote fpm server ip A.B.C.D\n"
-        "Enter ip ")
+       "no fpm connection ip A.B.C.D port (1-65535)",
+       NO_STR
+       "Forwarding Path Manager\n"
+       "Remove configured FPM connection\n"
+       "Connect to IPv4 address\n"
+       "Connect to IPv4 address\n"
+       "TCP port number\n"
+       "TCP port number\n")
 {
 	if (zfpm_g->fpm_server != inet_addr(argv[4]->arg)
 	    || zfpm_g->fpm_port != atoi(argv[6]->arg))


### PR DESCRIPTION
- simplifying / detangling / removing unused `DEFUN` macros
- make `CMD_ATTR_*` a bitmask
- fix a bunch of b0rked CLI docstrings
- fix 2 b0rked CLI command definitions
- exclude vtysh from `frr.xref`
- use faster `ujson` for handling `.xref` files, if it's available

This is all prep work for replacing `vtysh/extract.pl` with extracting the commands from `frr.xref` instead.

NB: some of the python files related to this aren't black-formatted yet. I will do that *AFTER* the `frr.xref` changes (which are already in the oven, so I'd trample over my own changes.)