### PR TITLE
bgpd: Remove unnecessary check for pi and setting type and sub-type

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3854,8 +3854,6 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	int do_loop_check = 1;
 	int has_valid_label = 0;
 	afi_t nh_afi;
-	uint8_t pi_type = 0;
-	uint8_t pi_sub_type = 0;
 	bool force_evpn_import = false;
 	safi_t orig_safi = safi;
 	bool leak_success = true;
@@ -4059,15 +4057,10 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 			bgp_attr_add_gshut_community(&new_attr);
 	}
 
-	if (pi) {
-		pi_type = pi->type;
-		pi_sub_type = pi->sub_type;
-	}
-
 	/* next hop check.  */
-	if (!CHECK_FLAG(peer->flags, PEER_FLAG_IS_RFAPI_HD)
-	    && bgp_update_martian_nexthop(bgp, afi, safi, pi_type, pi_sub_type,
-					  &new_attr, dest)) {
+	if (!CHECK_FLAG(peer->flags, PEER_FLAG_IS_RFAPI_HD) &&
+	    bgp_update_martian_nexthop(bgp, afi, safi, type, sub_type,
+				       &new_attr, dest)) {
 		peer->stat_pfx_nh_invalid++;
 		reason = "martian or self next-hop;";
 		bgp_attr_flush(&new_attr);


### PR DESCRIPTION
There is code that sets the pi based upon matching it against the same peer.  In this code the type and sub-type are also compared to the passed in type and sub-type.  Let's just use type and sub-type as that if we have a pi we know type and sub-type are already correct.  This should also make the first iteration work correctly when the pi has not been created yet when we call the martian_update function.bgpd: Remove unnecessary check for pi and setting type and sub-type

There is code that sets the pi based upon matching it against the same peer.  In this code the type and sub-type are also compared to the passed in type and sub-type.  Let's just use type and sub-type as that if we have a pi we know type and sub-type are already correct.  This should also make the first iteration work correctly when the pi has not been created yet when we call the martian_update function.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>