### PR TITLE
Add ability for dplane_fpm_nl to receive RTM_NEWROUTE netlink messages that signal route handling in the asic

### DIFF
--- a/doc/developer/fpm.rst
+++ b/doc/developer/fpm.rst
@@ -101,3 +101,19 @@ Data
 ^^^^
 
 The netlink or protobuf message payload.
+
+
+Route Status Notification from ASIC
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The dplane_fpm_nl has the ability to read route netlink messages
+from the underlying fpm implementation that can tell zebra
+whether or not the route has been Offloaded/Failed or Trapped.
+The end developer must send the data up the same socket that has
+been created to listen for FPM messages from Zebra.  The data sent
+must have a Frame Header with Version set to 1, Message Type set to 1
+and an appropriate message Length.  The message data must contain
+a RTM_NEWROUTE netlink message that sends the prefix and nexthops
+associated with the route.  Finally rtm_flags must contain
+RTM_F_OFFLOAD, RTM_F_TRAP and or RTM_F_OFFLOAD_FAILED to signify
+what has happened to the route in the ASIC.

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -122,6 +122,10 @@ netlink_put_lsp_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx);
 extern enum netlink_msg_status
 netlink_put_pw_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx);
 
+int netlink_route_change_read_unicast_internal(struct nlmsghdr *h,
+					       ns_id_t ns_id, int startup,
+					       struct zebra_dplane_ctx *ctx);
+
 #ifdef NETLINK_DEBUG
 const char *nlmsg_type2str(uint16_t type);
 const char *af_type2str(int type);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -135,6 +135,8 @@ struct dplane_route_info {
 	uint32_t zd_mtu;
 	uint32_t zd_nexthop_mtu;
 
+	uint32_t zd_flags;
+
 	/* Nexthop hash entry info */
 	struct dplane_nexthop_info nhe;
 
@@ -1428,6 +1430,20 @@ uint16_t dplane_ctx_get_old_instance(const struct zebra_dplane_ctx *ctx)
 	DPLANE_CTX_VALID(ctx);
 
 	return ctx->u.rinfo.zd_old_instance;
+}
+
+uint32_t dplane_ctx_get_flags(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.rinfo.zd_flags;
+}
+
+void dplane_ctx_set_flags(struct zebra_dplane_ctx *ctx, uint32_t flags)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	ctx->u.rinfo.zd_flags = flags;
 }
 
 uint32_t dplane_ctx_get_metric(const struct zebra_dplane_ctx *ctx)
@@ -2806,6 +2822,7 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 
 	ctx->zd_table_id = re->table;
 
+	ctx->u.rinfo.zd_flags = re->flags;
 	ctx->u.rinfo.zd_metric = re->metric;
 	ctx->u.rinfo.zd_old_metric = re->metric;
 	ctx->zd_vrf_id = re->vrf_id;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2784,7 +2784,7 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	struct dplane_intf_extra *if_extra;
 
 	if (!ctx || !rn || !re)
-		goto done;
+		return ret;
 
 	TAILQ_INIT(&ctx->u.rinfo.intf_extra_q);
 
@@ -2875,8 +2875,7 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	/* Don't need some info when capturing a system notification */
 	if (op == DPLANE_OP_SYS_ROUTE_ADD ||
 	    op == DPLANE_OP_SYS_ROUTE_DELETE) {
-		ret = AOK;
-		goto done;
+		return AOK;
 	}
 
 	/* Extract ns info - can't use pointers to 'core' structs */
@@ -2897,14 +2896,12 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 		 * If its a delete we only use the prefix anyway, so this only
 		 * matters for INSTALL/UPDATE.
 		 */
-		if (zebra_nhg_kernel_nexthops_enabled()
-		    && (((op == DPLANE_OP_ROUTE_INSTALL)
-			 || (op == DPLANE_OP_ROUTE_UPDATE))
-			&& !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED)
-			&& !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED))) {
-			ret = ENOENT;
-			goto done;
-		}
+		if (zebra_nhg_kernel_nexthops_enabled() &&
+		    (((op == DPLANE_OP_ROUTE_INSTALL) ||
+		      (op == DPLANE_OP_ROUTE_UPDATE)) &&
+		     !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) &&
+		     !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)))
+			return ENOENT;
 
 		re->nhe_installed_id = nhe->id;
 	}
@@ -2916,10 +2913,7 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	re->dplane_sequence = zebra_router_get_next_sequence();
 	ctx->zd_seq = re->dplane_sequence;
 
-	ret = AOK;
-
-done:
-	return ret;
+	return AOK;
 }
 
 static int dplane_ctx_tc_qdisc_init(struct zebra_dplane_ctx *ctx,
@@ -3031,7 +3025,7 @@ int dplane_ctx_nexthop_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	int ret = EINVAL;
 
 	if (!ctx || !nhe)
-		goto done;
+		return ret;
 
 	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
@@ -3066,7 +3060,6 @@ int dplane_ctx_nexthop_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 
 	ret = AOK;
 
-done:
 	return ret;
 }
 
@@ -3088,7 +3081,7 @@ int dplane_ctx_intf_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	bool set_pdown, unset_pdown;
 
 	if (!ctx || !ifp)
-		goto done;
+		return ret;
 
 	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
@@ -3133,7 +3126,6 @@ int dplane_ctx_intf_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 
 	ret = AOK;
 
-done:
 	return ret;
 }
 
@@ -3161,10 +3153,8 @@ int dplane_ctx_lsp_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	/* This may be called to create/init a dplane context, not necessarily
 	 * to copy an lsp object.
 	 */
-	if (lsp == NULL) {
-		ret = AOK;
-		goto done;
-	}
+	if (lsp == NULL)
+		return ret;
 
 	if (IS_ZEBRA_DEBUG_DPLANE_DETAIL)
 		zlog_debug("init dplane ctx %s: in-label %u ecmp# %d",
@@ -3207,7 +3197,7 @@ int dplane_ctx_lsp_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	}
 
 	if (ret != AOK)
-		goto done;
+		return ret;
 
 	/* Capture backup nhlfes/nexthops */
 	frr_each(nhlfe_list, &lsp->backup_nhlfe_list, nhlfe) {
@@ -3227,11 +3217,6 @@ int dplane_ctx_lsp_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 		new_nhlfe->flags = nhlfe->flags;
 		new_nhlfe->nexthop->flags = nhlfe->nexthop->flags;
 	}
-
-	/* On error the ctx will be cleaned-up, so we don't need to
-	 * deal with any allocated nhlfe or nexthop structs here.
-	 */
-done:
 
 	return ret;
 }
@@ -3293,11 +3278,11 @@ static int dplane_ctx_pw_init(struct zebra_dplane_ctx *ctx,
 	afi = (pw->af == AF_INET) ? AFI_IP : AFI_IP6;
 	table = zebra_vrf_table(afi, SAFI_UNICAST, pw->vrf_id);
 	if (table == NULL)
-		goto done;
+		return ret;
 
 	rn = route_node_match(table, &p);
 	if (rn == NULL)
-		goto done;
+		return ret;
 
 	re = NULL;
 	RNODE_FOREACH_RE(rn, re) {
@@ -3365,10 +3350,7 @@ static int dplane_ctx_pw_init(struct zebra_dplane_ctx *ctx,
 	}
 	route_unlock_node(rn);
 
-	ret = AOK;
-
-done:
-	return ret;
+	return AOK;
 }
 
 /**
@@ -3943,12 +3925,11 @@ enum zebra_dplane_result dplane_route_add(struct route_node *rn,
 	enum zebra_dplane_result ret = ZEBRA_DPLANE_REQUEST_FAILURE;
 
 	if (rn == NULL || re == NULL)
-		goto done;
+		return ret;
 
 	ret = dplane_route_update_internal(rn, re, NULL,
 					   DPLANE_OP_ROUTE_INSTALL);
 
-done:
 	return ret;
 }
 
@@ -3962,11 +3943,11 @@ enum zebra_dplane_result dplane_route_update(struct route_node *rn,
 	enum zebra_dplane_result ret = ZEBRA_DPLANE_REQUEST_FAILURE;
 
 	if (rn == NULL || re == NULL)
-		goto done;
+		return ret;
 
 	ret = dplane_route_update_internal(rn, re, old_re,
 					   DPLANE_OP_ROUTE_UPDATE);
-done:
+
 	return ret;
 }
 
@@ -3979,12 +3960,11 @@ enum zebra_dplane_result dplane_route_delete(struct route_node *rn,
 	enum zebra_dplane_result ret = ZEBRA_DPLANE_REQUEST_FAILURE;
 
 	if (rn == NULL || re == NULL)
-		goto done;
+		return ret;
 
 	ret = dplane_route_update_internal(rn, re, NULL,
 					   DPLANE_OP_ROUTE_DELETE);
 
-done:
 	return ret;
 }
 
@@ -3997,18 +3977,16 @@ enum zebra_dplane_result dplane_sys_route_add(struct route_node *rn,
 	enum zebra_dplane_result ret = ZEBRA_DPLANE_REQUEST_FAILURE;
 
 	/* Ignore this event unless a provider plugin has requested it. */
-	if (!zdplane_info.dg_sys_route_notifs) {
-		ret = ZEBRA_DPLANE_REQUEST_SUCCESS;
-		goto done;
-	}
+	if (!zdplane_info.dg_sys_route_notifs)
+		return ZEBRA_DPLANE_REQUEST_SUCCESS;
+
 
 	if (rn == NULL || re == NULL)
-		goto done;
+		return ret;
 
 	ret = dplane_route_update_internal(rn, re, NULL,
 					   DPLANE_OP_SYS_ROUTE_ADD);
 
-done:
 	return ret;
 }
 
@@ -4021,18 +3999,15 @@ enum zebra_dplane_result dplane_sys_route_del(struct route_node *rn,
 	enum zebra_dplane_result ret = ZEBRA_DPLANE_REQUEST_FAILURE;
 
 	/* Ignore this event unless a provider plugin has requested it. */
-	if (!zdplane_info.dg_sys_route_notifs) {
-		ret = ZEBRA_DPLANE_REQUEST_SUCCESS;
-		goto done;
-	}
+	if (!zdplane_info.dg_sys_route_notifs)
+		return ZEBRA_DPLANE_REQUEST_SUCCESS;
 
 	if (rn == NULL || re == NULL)
-		goto done;
+		return ret;
 
 	ret = dplane_route_update_internal(rn, re, NULL,
 					   DPLANE_OP_SYS_ROUTE_DELETE);
 
-done:
 	return ret;
 }
 
@@ -6463,7 +6438,7 @@ int dplane_clean_ctx_queue(bool (*context_cb)(struct zebra_dplane_ctx *ctx,
 	TAILQ_INIT(&work_list);
 
 	if (context_cb == NULL)
-		goto done;
+		return AOK;
 
 	/* Walk the pending context queue under the dplane lock. */
 	DPLANE_LOCK();
@@ -6487,9 +6462,7 @@ int dplane_clean_ctx_queue(bool (*context_cb)(struct zebra_dplane_ctx *ctx,
 		dplane_ctx_fini(&ctx);
 	}
 
-done:
-
-	return 0;
+	return AOK;
 }
 
 /* Indicates zebra shutdown/exit is in progress. Some operations may be
@@ -6553,10 +6526,8 @@ static bool dplane_work_pending(void)
 	}
 	DPLANE_UNLOCK();
 
-	if (ctx != NULL) {
-		ret = true;
-		goto done;
-	}
+	if (ctx != NULL)
+		return true;
 
 	while (prov) {
 
@@ -6579,7 +6550,6 @@ static bool dplane_work_pending(void)
 	if (ctx != NULL)
 		ret = true;
 
-done:
 	return ret;
 }
 

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -6301,6 +6301,17 @@ kernel_dplane_process_ipset_entry(struct zebra_dplane_provider *prov,
 	dplane_provider_enqueue_out_ctx(prov, ctx);
 }
 
+void dplane_rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
+			      struct prefix_ipv6 *src_p, struct route_entry *re,
+			      struct nexthop_group *ng, int startup,
+			      struct zebra_dplane_ctx *ctx)
+{
+	if (!ctx)
+		rib_add_multipath(afi, safi, p, src_p, re, ng, startup);
+	else {
+	}
+}
+
 /*
  * Kernel provider callback
  */

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2785,7 +2785,7 @@ static int dplane_ctx_ns_init(struct zebra_dplane_ctx *ctx,
 int dplane_ctx_route_init_basic(struct zebra_dplane_ctx *ctx,
 				enum dplane_op_e op, struct route_entry *re,
 				const struct prefix *p,
-				const struct prefix *src_p, afi_t afi,
+				const struct prefix_ipv6 *src_p, afi_t afi,
 				safi_t safi)
 {
 	int ret = EINVAL;
@@ -2836,7 +2836,8 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	int ret = EINVAL;
 	const struct route_table *table = NULL;
 	const struct rib_table_info *info;
-	const struct prefix *p, *src_p;
+	const struct prefix *p;
+	const struct prefix_ipv6 *src_p;
 	struct zebra_ns *zns;
 	struct zebra_vrf *zvrf;
 	struct nexthop *nexthop;
@@ -2853,7 +2854,7 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	 */
 
 	/* Prefixes: dest, and optional source */
-	srcdest_rnode_prefixes(rn, &p, &src_p);
+	srcdest_rnode_prefixes(rn, &p, (const struct prefix **)&src_p);
 	table = srcdest_rnode_table(rn);
 	info = table->info;
 
@@ -6309,6 +6310,9 @@ void dplane_rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
 	if (!ctx)
 		rib_add_multipath(afi, safi, p, src_p, re, ng, startup);
 	else {
+		dplane_ctx_route_init_basic(ctx, dplane_ctx_get_op(ctx), re, p,
+					    src_p, afi, safi);
+		dplane_provider_enqueue_to_zebra(ctx);
 	}
 }
 

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -910,6 +910,12 @@ dplane_pbr_ipset_entry_delete(struct zebra_pbr_ipset_entry *ipset);
 int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 			  struct route_node *rn, struct route_entry *re);
 
+int dplane_ctx_route_init_basic(struct zebra_dplane_ctx *ctx,
+				enum dplane_op_e op, struct route_entry *re,
+				const struct prefix *p,
+				const struct prefix *src_p, afi_t afi,
+				safi_t safi);
+
 /* Encode next hop information into data plane context. */
 int dplane_ctx_nexthop_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 			    struct nhg_hash_entry *nhe);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -913,7 +913,7 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 int dplane_ctx_route_init_basic(struct zebra_dplane_ctx *ctx,
 				enum dplane_op_e op, struct route_entry *re,
 				const struct prefix *p,
-				const struct prefix *src_p, afi_t afi,
+				const struct prefix_ipv6 *src_p, afi_t afi,
 				safi_t safi);
 
 /* Encode next hop information into data plane context. */

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -380,6 +380,8 @@ route_tag_t dplane_ctx_get_old_tag(const struct zebra_dplane_ctx *ctx);
 uint16_t dplane_ctx_get_instance(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_instance(struct zebra_dplane_ctx *ctx, uint16_t instance);
 uint16_t dplane_ctx_get_old_instance(const struct zebra_dplane_ctx *ctx);
+uint32_t dplane_ctx_get_flags(const struct zebra_dplane_ctx *ctx);
+void dplane_ctx_set_flags(struct zebra_dplane_ctx *ctx, uint32_t flags);
 uint32_t dplane_ctx_get_metric(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_get_old_metric(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_get_mtu(const struct zebra_dplane_ctx *ctx);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -1081,6 +1081,16 @@ void zebra_dplane_pre_finish(void);
 void zebra_dplane_finish(void);
 void zebra_dplane_shutdown(void);
 
+/*
+ * decision point for sending a routing update through the old
+ * straight to zebra master pthread or through the dplane to
+ * the master pthread for handling
+ */
+void dplane_rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
+			      struct prefix_ipv6 *src_p, struct route_entry *re,
+			      struct nexthop_group *ng, int startup,
+			      struct zebra_dplane_ctx *ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1523,8 +1523,7 @@ static bool rib_route_match_ctx(const struct route_entry *re,
 	}
 
 done:
-
-	return (result);
+	return result;
 }
 
 static void zebra_rib_fixup_system(struct route_node *rn)

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2339,55 +2339,70 @@ static void rib_process_dplane_notify(struct zebra_dplane_ctx *ctx)
 	/* Various fib transitions: changed nexthops; from installed to
 	 * not-installed; or not-installed to installed.
 	 */
-	if (start_count > 0 && end_count > 0) {
-		if (debug_p)
-			zlog_debug(
-				"%s(%u:%u):%pRN applied nexthop changes from dplane notification",
-				VRF_LOGNAME(vrf), dplane_ctx_get_vrf(ctx),
-				dplane_ctx_get_table(ctx), rn);
+	if (zrouter.asic_notification_nexthop_control) {
+		if (start_count > 0 && end_count > 0) {
+			if (debug_p)
+				zlog_debug(
+					"%s(%u:%u):%pRN applied nexthop changes from dplane notification",
+					VRF_LOGNAME(vrf),
+					dplane_ctx_get_vrf(ctx),
+					dplane_ctx_get_table(ctx), rn);
 
-		/* Changed nexthops - update kernel/others */
-		dplane_route_notif_update(rn, re,
-					  DPLANE_OP_ROUTE_UPDATE, ctx);
+			/* Changed nexthops - update kernel/others */
+			dplane_route_notif_update(rn, re,
+						  DPLANE_OP_ROUTE_UPDATE, ctx);
 
-	} else if (start_count == 0 && end_count > 0) {
-		if (debug_p)
-			zlog_debug(
-				"%s(%u:%u):%pRN installed transition from dplane notification",
-				VRF_LOGNAME(vrf), dplane_ctx_get_vrf(ctx),
-				dplane_ctx_get_table(ctx), rn);
+		} else if (start_count == 0 && end_count > 0) {
+			if (debug_p)
+				zlog_debug(
+					"%s(%u:%u):%pRN installed transition from dplane notification",
+					VRF_LOGNAME(vrf),
+					dplane_ctx_get_vrf(ctx),
+					dplane_ctx_get_table(ctx), rn);
 
-		/* We expect this to be the selected route, so we want
-		 * to tell others about this transition.
-		 */
-		SET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
+			/* We expect this to be the selected route, so we want
+			 * to tell others about this transition.
+			 */
+			SET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
 
-		/* Changed nexthops - update kernel/others */
-		dplane_route_notif_update(rn, re, DPLANE_OP_ROUTE_UPDATE, ctx);
+			/* Changed nexthops - update kernel/others */
+			dplane_route_notif_update(rn, re,
+						  DPLANE_OP_ROUTE_UPDATE, ctx);
 
-		/* Redistribute, lsp, and nht update */
-		redistribute_update(rn, re, NULL);
+			/* Redistribute, lsp, and nht update */
+			redistribute_update(rn, re, NULL);
 
-	} else if (start_count > 0 && end_count == 0) {
-		if (debug_p)
-			zlog_debug(
-				"%s(%u:%u):%pRN un-installed transition from dplane notification",
-				VRF_LOGNAME(vrf), dplane_ctx_get_vrf(ctx),
-				dplane_ctx_get_table(ctx), rn);
+		} else if (start_count > 0 && end_count == 0) {
+			if (debug_p)
+				zlog_debug(
+					"%s(%u:%u):%pRN un-installed transition from dplane notification",
+					VRF_LOGNAME(vrf),
+					dplane_ctx_get_vrf(ctx),
+					dplane_ctx_get_table(ctx), rn);
 
-		/* Transition from _something_ installed to _nothing_
-		 * installed.
-		 */
-		/* We expect this to be the selected route, so we want
-		 * to tell others about this transistion.
-		 */
-		UNSET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
+			/* Transition from _something_ installed to _nothing_
+			 * installed.
+			 */
+			/* We expect this to be the selected route, so we want
+			 * to tell others about this transistion.
+			 */
+			UNSET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
 
-		/* Changed nexthops - update kernel/others */
-		dplane_route_notif_update(rn, re, DPLANE_OP_ROUTE_DELETE, ctx);
+			/* Changed nexthops - update kernel/others */
+			dplane_route_notif_update(rn, re,
+						  DPLANE_OP_ROUTE_DELETE, ctx);
 
-		/* Redistribute, lsp, and nht update */
-		redistribute_delete(rn, re, NULL);
+			/* Redistribute, lsp, and nht update */
+			redistribute_delete(rn, re, NULL);
+		}
+	}
+
+	if (!zebra_router_notify_on_ack()) {
+		if (CHECK_FLAG(re->flags, ZEBRA_FLAG_OFFLOADED))
+			zsend_route_notify_owner_ctx(ctx, ZAPI_ROUTE_INSTALLED);
+		if (CHECK_FLAG(re->flags, ZEBRA_FLAG_OFFLOAD_FAILED))
+			zsend_route_notify_owner_ctx(ctx,
+						     ZAPI_ROUTE_FAIL_INSTALL);
 	}
 
 	/* Make any changes visible for lsp and nexthop-tracking processing */

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -330,6 +330,17 @@ void zebra_router_init(bool asic_offload, bool notify_on_ack)
 	zrouter.asic_offloaded = asic_offload;
 	zrouter.notify_on_ack = notify_on_ack;
 
+	/*
+	 * If you start using asic_notification_nexthop_control
+	 * come talk to the FRR community about what you are doing
+	 * We would like to know.
+	 */
+#if CONFDATE > 20251231
+	CPP_NOTICE(
+		"Remove zrouter.asic_notification_nexthop_control as that it's not being maintained or used");
+#endif
+	zrouter.asic_notification_nexthop_control = false;
+
 #ifdef HAVE_SCRIPTING
 	zebra_script_init();
 #endif

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -224,6 +224,14 @@ struct zebra_router {
 	bool asic_offloaded;
 	bool notify_on_ack;
 
+	/*
+	 * If the asic is notifying us about successful nexthop
+	 * allocation/control.  Some developers have made their
+	 * asic take control of how many nexthops/ecmp they can
+	 * have and will report what is successfull or not
+	 */
+	bool asic_notification_nexthop_control;
+
 	bool supports_nhgs;
 
 	bool all_mc_forwardingv4, default_mc_forwardingv4;

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -4073,6 +4073,15 @@ DEFUN (show_zebra,
 	ttable_add_row(table, "ASIC offload|%s",
 		       zrouter.asic_offloaded ? "Used" : "Unavailable");
 
+	/*
+	 * Do not display this unless someone is actually using it
+	 *
+	 * Why this distinction?  I think this is effectively dead code
+	 * and should not be exposed.  Maybe someone proves me wrong.
+	 */
+	if (zrouter.asic_notification_nexthop_control)
+		ttable_add_row(table, "ASIC offload and nexthop control|Used");
+
 	ttable_add_row(table, "RA|%s",
 		       rtadv_compiled_in() ? "Compiled in" : "Not Compiled in");
 	ttable_add_row(table, "RFC 5549|%s",


### PR DESCRIPTION
See the various commits.  But effectively modify the dplane_fpm_nl to receive a RTM_NEWROUTE netlink message to allow the underlying asic to signal to zebra if the route was successfully offloaded/Failed to offload or Trapped.  This message is read then converted to a context to pass up through the dplane to zebra for processing.