### PR TITLE
Rework of Various Handling in EVPN for Extended Mac Mobility

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2906,11 +2906,15 @@ static int install_evpn_route_entry_in_vni_common(
 
 		new_local_es = bgp_evpn_attr_is_local_es(pi->attr);
 	} else {
-		if (attrhash_cmp(pi->attr, parent_pi->attr)
-		    && !CHECK_FLAG(pi->flags, BGP_PATH_REMOVED)) {
-			bgp_dest_unlock_node(dest);
+		/* Return early if attributes haven't changed
+		 * and dest isn't flagged for removal.
+		 * dest will be unlocked by either
+		 * install_evpn_route_entry_in_vni_mac() or
+		 * install_evpn_route_entry_in_vni_ip()
+		 */
+		if (attrhash_cmp(pi->attr, parent_pi->attr) &&
+		    !CHECK_FLAG(pi->flags, BGP_PATH_REMOVED))
 			return 0;
-		}
 		/* The attribute has changed. */
 		/* Add (or update) attribute to hash. */
 		attr_new = bgp_attr_intern(parent_pi->attr);

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -552,10 +552,14 @@ static void evpn_convert_nexthop_to_ipv6(struct attr *attr)
 	attr->mp_nexthop_len = IPV6_MAX_BYTELEN;
 }
 
-struct bgp_dest *bgp_global_evpn_node_get(struct bgp_table *table, afi_t afi,
+/*
+ * Wrapper for node get in global table.
+ */
+struct bgp_dest *bgp_evpn_global_node_get(struct bgp_table *table, afi_t afi,
 					  safi_t safi,
 					  const struct prefix_evpn *evp,
-					  struct prefix_rd *prd)
+					  struct prefix_rd *prd,
+					  const struct bgp_path_info *local_pi)
 {
 	struct prefix_evpn global_p;
 
@@ -564,15 +568,29 @@ struct bgp_dest *bgp_global_evpn_node_get(struct bgp_table *table, afi_t afi,
 		 * we need to create a different copy of the prefix
 		 */
 		evpn_type1_prefix_global_copy(&global_p, evp);
+		evp = &global_p;
+	} else if (evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE &&
+		   local_pi) {
+		/*
+		 * prefix in the global table needs MAC, ensure it's present,
+		 * using one from local table's path_info.
+		 */
+		evpn_type2_prefix_global_copy(
+			&global_p, evp,
+			*evpn_type2_path_info_get_mac(local_pi));
 		evp = &global_p;
 	}
 	return bgp_afi_node_get(table, afi, safi, (struct prefix *)evp, prd);
 }
 
-struct bgp_dest *bgp_global_evpn_node_lookup(struct bgp_table *table, afi_t afi,
-					     safi_t safi,
-					     const struct prefix_evpn *evp,
-					     struct prefix_rd *prd)
+/*
+ * Wrapper for node lookup in global table.
+ */
+struct bgp_dest *
+bgp_evpn_global_node_lookup(struct bgp_table *table, afi_t afi, safi_t safi,
+			    const struct prefix_evpn *evp,
+			    struct prefix_rd *prd,
+			    const struct bgp_path_info *local_pi)
 {
 	struct prefix_evpn global_p;
 
@@ -582,8 +600,78 @@ struct bgp_dest *bgp_global_evpn_node_lookup(struct bgp_table *table, afi_t afi,
 		 */
 		evpn_type1_prefix_global_copy(&global_p, evp);
 		evp = &global_p;
+	} else if (evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE &&
+		   local_pi) {
+		/*
+		 * prefix in the global table needs MAC, ensure it's present,
+		 * using one from local table's path_info.
+		 */
+		evpn_type2_prefix_global_copy(
+			&global_p, evp,
+			*evpn_type2_path_info_get_mac(local_pi));
+		evp = &global_p;
 	}
 	return bgp_afi_node_lookup(table, afi, safi, (struct prefix *)evp, prd);
+}
+
+/*
+ * Wrapper for node get in VNI table.
+ */
+struct bgp_dest *bgp_evpn_vni_node_get(struct bgp_table *const table,
+				       const struct prefix_evpn *evp,
+				       const struct bgp_path_info *parent_pi)
+{
+	struct prefix_evpn vni_p;
+
+	if (evp->prefix.route_type == BGP_EVPN_AD_ROUTE && parent_pi) {
+		/* prefix in the global table doesn't include the VTEP-IP so
+		 * we need to create a different copy for the VNI
+		 */
+		evpn_type1_prefix_vni_copy(&vni_p, evp,
+					   parent_pi->attr->nexthop);
+		evp = &vni_p;
+	} else if (evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE &&
+		   !is_evpn_prefix_ipaddr_none(evp)) {
+		/*
+		 * IP prefix in the vni table doesn't include MAC so
+		 * we need to create a different copy of the prefix.
+		 *
+		 * However, if it's MAC-only, keep it.
+		 */
+		evpn_type2_prefix_vni_copy(&vni_p, evp);
+		evp = &vni_p;
+	}
+	return bgp_node_get(table, (struct prefix *)evp);
+}
+
+/*
+ * Wrapper for node lookup in VNI table.
+ */
+struct bgp_dest *bgp_evpn_vni_node_lookup(const struct bgp_table *const table,
+					  const struct prefix_evpn *evp,
+					  const struct bgp_path_info *parent_pi)
+{
+	struct prefix_evpn vni_p;
+
+	if (evp->prefix.route_type == BGP_EVPN_AD_ROUTE && parent_pi) {
+		/* prefix in the global table doesn't include the VTEP-IP so
+		 * we need to create a different copy for the VNI
+		 */
+		evpn_type1_prefix_vni_copy(&vni_p, evp,
+					   parent_pi->attr->nexthop);
+		evp = &vni_p;
+	} else if (evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE &&
+		   !is_evpn_prefix_ipaddr_none(evp)) {
+		/*
+		 * IP prefix in the vni table doesn't include MAC so
+		 * we need to create a different copy of the prefix.
+		 *
+		 * However, if it's MAC-only, keep it.
+		 */
+		evpn_type2_prefix_vni_copy(&vni_p, evp);
+		evp = &vni_p;
+	}
+	return bgp_node_lookup(table, (struct prefix *)evp);
 }
 
 /*
@@ -591,6 +679,7 @@ struct bgp_dest *bgp_global_evpn_node_lookup(struct bgp_table *table, afi_t afi,
  */
 static int bgp_zebra_send_remote_macip(struct bgp *bgp, struct bgpevpn *vpn,
 				       const struct prefix_evpn *p,
+				       const struct ethaddr *mac,
 				       struct in_addr remote_vtep_ip, int add,
 				       uint8_t flags, uint32_t seq, esi_t *esi)
 {
@@ -620,7 +709,12 @@ static int bgp_zebra_send_remote_macip(struct bgp *bgp, struct bgpevpn *vpn,
 		s, add ? ZEBRA_REMOTE_MACIP_ADD : ZEBRA_REMOTE_MACIP_DEL,
 		bgp->vrf_id);
 	stream_putl(s, vpn->vni);
-	stream_put(s, &p->prefix.macip_addr.mac.octet, ETH_ALEN); /* Mac Addr */
+
+	if (mac) /* Mac Addr */
+		stream_put(s, &mac->octet, ETH_ALEN);
+	else
+		stream_put(s, &p->prefix.macip_addr.mac.octet, ETH_ALEN);
+
 	/* IP address length and IP address, if any. */
 	if (is_evpn_prefix_ipaddr_none(p))
 		stream_putw(s, 0);
@@ -985,8 +1079,9 @@ static int evpn_zebra_install(struct bgp *bgp, struct bgpevpn *vpn,
 		}
 
 		ret = bgp_zebra_send_remote_macip(
-				bgp, vpn, p, pi->attr->nexthop, 1, flags,
-				seq, bgp_evpn_attr_get_esi(pi->attr));
+			bgp, vpn, p, evpn_type2_path_info_get_mac(pi),
+			pi->attr->nexthop, 1, flags, seq,
+			bgp_evpn_attr_get_esi(pi->attr));
 	} else if (p->prefix.route_type == BGP_EVPN_AD_ROUTE) {
 		ret = bgp_evpn_remote_es_evi_add(bgp, vpn, p);
 	} else {
@@ -1012,13 +1107,15 @@ static int evpn_zebra_install(struct bgp *bgp, struct bgpevpn *vpn,
 /* Uninstall EVPN route from zebra. */
 static int evpn_zebra_uninstall(struct bgp *bgp, struct bgpevpn *vpn,
 				const struct prefix_evpn *p,
-				struct in_addr remote_vtep_ip)
+				struct bgp_path_info *pi, bool is_sync)
 {
 	int ret;
 
 	if (p->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE)
-		ret = bgp_zebra_send_remote_macip(bgp, vpn, p, remote_vtep_ip,
-						0, 0, 0, NULL);
+		ret = bgp_zebra_send_remote_macip(
+			bgp, vpn, p, evpn_type2_path_info_get_mac(pi),
+			(is_sync ? zero_vtep_ip : pi->attr->nexthop), 0, 0, 0,
+			NULL);
 	else if (p->prefix.route_type == BGP_EVPN_AD_ROUTE)
 		ret = bgp_evpn_remote_es_evi_del(bgp, vpn, p);
 	else
@@ -1061,9 +1158,10 @@ static void evpn_delete_old_local_route(struct bgp *bgp, struct bgpevpn *vpn,
 	 * this table is a 2-level tree (RD-level + Prefix-level) similar to
 	 * L3VPN routes.
 	 */
-	global_dest = bgp_global_evpn_node_lookup(bgp->rib[afi][safi], afi, safi,
-			(const struct prefix_evpn *)bgp_dest_get_prefix(dest),
-			&vpn->prd);
+	global_dest = bgp_evpn_global_node_lookup(
+		bgp->rib[afi][safi], afi, safi,
+		(const struct prefix_evpn *)bgp_dest_get_prefix(dest),
+		&vpn->prd, old_local);
 	if (global_dest) {
 		/* Delete route entry in the global EVPN table. */
 		delete_evpn_route_entry(bgp, afi, safi, global_dest, &pi);
@@ -1176,7 +1274,7 @@ int evpn_route_select_install(struct bgp *bgp, struct bgpevpn *vpn,
 				bgp, vpn,
 				(const struct prefix_evpn *)bgp_dest_get_prefix(
 					dest),
-				old_select->attr->nexthop);
+				old_select, false);
 	}
 
 	/* Clear any route change flags. */
@@ -1362,9 +1460,8 @@ static int update_evpn_type5_route(struct bgp *bgp_vrf, struct prefix_evpn *evp,
 	build_evpn_type5_route_extcomm(bgp_vrf, &attr);
 
 	/* get the route node in global table */
-	dest = bgp_global_evpn_node_get(bgp_evpn->rib[afi][safi], afi, safi,
-			(const struct prefix_evpn *)evp,
-			&bgp_vrf->vrf_prd);
+	dest = bgp_evpn_global_node_get(bgp_evpn->rib[afi][safi], afi, safi,
+					evp, &bgp_vrf->vrf_prd, NULL);
 	assert(dest);
 
 	/* create or update the route entry within the route node */
@@ -1515,9 +1612,9 @@ static void update_evpn_route_entry_sync_info(struct bgp *bgp,
 static int update_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 				   afi_t afi, safi_t safi,
 				   struct bgp_dest *dest, struct attr *attr,
-				   int add, struct bgp_path_info **pi,
-				   uint8_t flags, uint32_t seq, bool vpn_rt,
-				   bool *old_is_sync)
+				   const struct ethaddr *mac, int add,
+				   struct bgp_path_info **pi, uint8_t flags,
+				   uint32_t seq, bool vpn_rt, bool *old_is_sync)
 {
 	struct bgp_path_info *tmp_pi;
 	struct bgp_path_info *local_pi;
@@ -1589,6 +1686,11 @@ static int update_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 
 		memcpy(&tmp_pi->extra->label, label, sizeof(label));
 		tmp_pi->extra->num_labels = num_labels;
+
+		if (evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE && mac)
+			evpn_type2_path_info_set_mac(tmp_pi, *mac);
+
+
 		/* Mark route as self type-2 route */
 		if (flags && CHECK_FLAG(flags, ZEBRA_MACIP_TYPE_SVI_IP))
 			tmp_pi->extra->af_flags = BGP_EVPN_MACIP_TYPE_SVI_IP;
@@ -1617,6 +1719,10 @@ static int update_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 			}
 			memcpy(&tmp_pi->extra->label, label, sizeof(label));
 			tmp_pi->extra->num_labels = num_labels;
+
+			if (evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE &&
+			    mac)
+				evpn_type2_path_info_set_mac(tmp_pi, *mac);
 
 			/* The attribute has changed. */
 			/* Add (or update) attribute to hash. */
@@ -1798,12 +1904,12 @@ static int update_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
 
 	/* First, create (or fetch) route node within the VNI. */
 	/* NOTE: There is no RD here. */
-	dest = bgp_node_get(vpn->route_table, (struct prefix *)p);
+	dest = bgp_evpn_vni_node_get(vpn->route_table, p, NULL);
 
 	/* Create or update route entry. */
-	route_change = update_evpn_route_entry(bgp, vpn, afi, safi, dest, &attr,
-			1, &pi, flags, seq,
-			true /* setup_sync */, &old_is_sync);
+	route_change = update_evpn_route_entry(
+		bgp, vpn, afi, safi, dest, &attr, &p->prefix.macip_addr.mac, 1,
+		&pi, flags, seq, true /* setup_sync */, &old_is_sync);
 	assert(pi);
 	attr_new = pi->attr;
 
@@ -1841,7 +1947,7 @@ static int update_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
 			 */
 			new_is_sync = bgp_evpn_attr_is_sync(pi->attr);
 			if (!new_is_sync && old_is_sync)
-				evpn_zebra_uninstall(bgp, vpn, p, zero_vtep_ip);
+				evpn_zebra_uninstall(bgp, vpn, p, pi, true);
 		}
 	}
 	bgp_path_info_unlock(pi);
@@ -1856,12 +1962,12 @@ static int update_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
 	if (route_change) {
 		struct bgp_path_info *global_pi;
 
-		dest = bgp_global_evpn_node_get(bgp->rib[afi][safi], afi, safi,
-				(const struct prefix_evpn *)p,
-				&vpn->prd);
-		update_evpn_route_entry(bgp, vpn, afi, safi, dest, attr_new, 1,
-				&global_pi, flags, seq,
-				false /* setup_sync */, NULL /* old_is_sync */);
+		dest = bgp_evpn_global_node_get(bgp->rib[afi][safi], afi, safi,
+						p, &vpn->prd, NULL);
+		update_evpn_route_entry(bgp, vpn, afi, safi, dest, attr_new,
+					NULL /* mac */, 1, &global_pi, flags,
+					seq, false /* setup_sync */,
+					NULL /* old_is_sync */);
 
 		/* Schedule for processing and unlock node. */
 		bgp_process(bgp, dest, afi, safi);
@@ -1915,8 +2021,8 @@ static int delete_evpn_type5_route(struct bgp *bgp_vrf, struct prefix_evpn *evp)
 		return 0;
 
 	/* locate the global route entry for this type-5 prefix */
-	dest = bgp_global_evpn_node_lookup(bgp_evpn->rib[afi][safi], afi, safi,
-			(const struct prefix_evpn *)evp, &bgp_vrf->vrf_prd);
+	dest = bgp_evpn_global_node_lookup(bgp_evpn->rib[afi][safi], afi, safi,
+					   evp, &bgp_vrf->vrf_prd, NULL);
 	if (!dest)
 		return 0;
 
@@ -1944,7 +2050,7 @@ static int delete_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
 	 * is nothing further to do.
 	 */
 	/* NOTE: There is no RD here. */
-	dest = bgp_node_lookup(vpn->route_table, (struct prefix *)p);
+	dest = bgp_evpn_vni_node_lookup(vpn->route_table, p, NULL);
 	if (!dest)
 		return 0;
 
@@ -1952,8 +2058,8 @@ static int delete_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
 	 * this table is a 2-level tree (RD-level + Prefix-level) similar to
 	 * L3VPN routes.
 	 */
-	global_dest = bgp_global_evpn_node_lookup(bgp->rib[afi][safi], afi, safi,
-			(const struct prefix_evpn *)p, &vpn->prd);
+	global_dest = bgp_evpn_global_node_lookup(bgp->rib[afi][safi], afi,
+						  safi, p, &vpn->prd, NULL);
 	if (global_dest) {
 		/* Delete route entry in the global EVPN table. */
 		delete_evpn_route_entry(bgp, afi, safi, global_dest, &pi);
@@ -1992,13 +2098,19 @@ void bgp_evpn_update_type2_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 	int add_l3_ecomm = 0;
 	struct bgp_dest *global_dest;
 	struct bgp_path_info *global_pi;
-	struct prefix_evpn *evp =
-		(struct prefix_evpn *)bgp_dest_get_prefix(dest);
+	struct prefix_evpn evp;
 	int route_change;
 	bool old_is_sync = false;
 
 	if (CHECK_FLAG(local_pi->flags, BGP_PATH_REMOVED))
 		return;
+
+	/*
+	 * VNI table MAC-IP prefixes don't have MAC so make sure it's set from
+	 * path info here.
+	 */
+	evpn_type2_prefix_global_copy(&evp, (struct prefix_evpn *)&dest->p,
+				      *evpn_type2_path_info_get_mac(local_pi));
 
 	/*
 	 * Build attribute per local route as the MAC mobility and
@@ -2014,18 +2126,17 @@ void bgp_evpn_update_type2_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 	attr.es_flags = local_pi->attr->es_flags;
 	if (local_pi->attr->default_gw) {
 		attr.default_gw = 1;
-		if (is_evpn_prefix_ipaddr_v6(evp))
+		if (is_evpn_prefix_ipaddr_v6(&evp))
 			attr.router_flag = 1;
 	}
 	memcpy(&attr.esi, &local_pi->attr->esi, sizeof(esi_t));
-	bgp_evpn_get_rmac_nexthop(vpn, evp, &attr,
-			local_pi->extra->af_flags);
+	bgp_evpn_get_rmac_nexthop(vpn, &evp, &attr, local_pi->extra->af_flags);
 	vni2label(vpn->vni, &(attr.label));
 	/* Add L3 VNI RTs and RMAC for non IPv6 link-local if
 	 * using L3 VNI for type-2 routes also.
 	 */
 	add_l3_ecomm = bgp_evpn_route_add_l3_ecomm_ok(
-		vpn, evp,
+		vpn, &evp,
 		(attr.es_flags & ATTR_ES_IS_LOCAL) ? &attr.esi : NULL);
 
 	/* Set up extended community. */
@@ -2039,15 +2150,15 @@ void bgp_evpn_update_type2_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 			"VRF %s vni %u evp %pFX RMAC %pEA nexthop %pI4 esi %s esf 0x%x from %s",
 			vpn->bgp_vrf ? vrf_id_to_name(vpn->bgp_vrf->vrf_id)
 				     : " ",
-			vpn->vni, evp, &attr.rmac, &attr.mp_nexthop_global_in,
+			vpn->vni, &evp, &attr.rmac, &attr.mp_nexthop_global_in,
 			esi_to_str(&attr.esi, buf3, sizeof(buf3)),
 			attr.es_flags, caller);
 	}
 
 	/* Update the route entry. */
 	route_change = update_evpn_route_entry(
-		bgp, vpn, afi, safi, dest, &attr, 0, &pi, 0, seq,
-		true /* setup_sync */, &old_is_sync);
+		bgp, vpn, afi, safi, dest, &attr, NULL /* mac */, 0, &pi, 0,
+		seq, true /* setup_sync */, &old_is_sync);
 
 	assert(pi);
 	attr_new = pi->attr;
@@ -2082,8 +2193,7 @@ void bgp_evpn_update_type2_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 			 */
 			new_is_sync = bgp_evpn_attr_is_sync(pi->attr);
 			if (!new_is_sync && old_is_sync)
-				evpn_zebra_uninstall(bgp, vpn,
-						evp, zero_vtep_ip);
+				evpn_zebra_uninstall(bgp, vpn, &evp, pi, true);
 		}
 	}
 
@@ -2093,13 +2203,14 @@ void bgp_evpn_update_type2_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 
 	if (route_change) {
 		/* Update route in global routing table. */
-		global_dest = bgp_global_evpn_node_get(bgp->rib[afi][safi], afi,
-						       safi, evp, &vpn->prd);
+		global_dest = bgp_evpn_global_node_get(
+			bgp->rib[afi][safi], afi, safi, &evp, &vpn->prd, NULL);
 		assert(global_dest);
-		update_evpn_route_entry(
-			bgp, vpn, afi, safi, global_dest, attr_new, 0,
-			&global_pi, 0, mac_mobility_seqnum(attr_new),
-			false /* setup_sync */, NULL /* old_is_sync */);
+		update_evpn_route_entry(bgp, vpn, afi, safi, global_dest,
+					attr_new, NULL /* mac */, 0, &global_pi,
+					0, mac_mobility_seqnum(attr_new),
+					false /* setup_sync */,
+					NULL /* old_is_sync */);
 
 		/* Schedule for processing and unlock node. */
 		bgp_process(bgp, global_dest, afi, safi);
@@ -2400,6 +2511,7 @@ bgp_create_evpn_bgp_path_info(struct bgp_path_info *parent_pi,
 		pi->extra->num_labels = parent_pi->extra->num_labels;
 		pi->extra->igpmetric = parent_pi->extra->igpmetric;
 	}
+
 	bgp_path_info_add(dest, pi);
 
 	return pi;
@@ -2589,20 +2701,12 @@ static int install_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 	struct bgp_path_info *local_pi;
 	struct attr *attr_new;
 	int ret;
-	struct prefix_evpn ad_evp;
 	bool old_local_es = false;
 	bool new_local_es;
 
-	/* EAD prefix in the global table doesn't include the VTEP-IP so
-	 * we need to create a different copy for the VNI
-	 */
-	if (p->prefix.route_type == BGP_EVPN_AD_ROUTE)
-		p = evpn_type1_prefix_vni_copy(&ad_evp, p,
-				parent_pi->attr->nexthop);
-
 	/* Create (or fetch) route within the VNI. */
 	/* NOTE: There is no RD here. */
-	dest = bgp_node_get(vpn->route_table, (struct prefix *)p);
+	dest = bgp_evpn_vni_node_get(vpn->route_table, p, parent_pi);
 
 	/* Check if route entry is already present. */
 	for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next)
@@ -2614,6 +2718,11 @@ static int install_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 		/* Create an info */
 		pi = bgp_create_evpn_bgp_path_info(parent_pi, dest,
 						    parent_pi->attr);
+
+		if (p->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE)
+			evpn_type2_path_info_set_mac(pi,
+						     p->prefix.macip_addr.mac);
+
 		new_local_es = bgp_evpn_attr_is_local_es(pi->attr);
 	} else {
 		if (attrhash_cmp(pi->attr, parent_pi->attr)
@@ -2765,18 +2874,10 @@ static int uninstall_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 	struct bgp_path_info *pi;
 	struct bgp_path_info *local_pi;
 	int ret;
-	struct prefix_evpn ad_evp;
-
-	/* EAD prefix in the global table doesn't include the VTEP-IP so
-	 * we need to create a different copy for the VNI
-	 */
-	if (p->prefix.route_type == BGP_EVPN_AD_ROUTE)
-		p = evpn_type1_prefix_vni_copy(&ad_evp, p,
-				parent_pi->attr->nexthop);
 
 	/* Locate route within the VNI. */
 	/* NOTE: There is no RD here. */
-	dest = bgp_node_lookup(vpn->route_table, (struct prefix *)p);
+	dest = bgp_evpn_vni_node_lookup(vpn->route_table, p, parent_pi);
 	if (!dest)
 		return 0;
 
@@ -3623,7 +3724,7 @@ static int update_advertise_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
 	if (bgp_evpn_vni_flood_mode_get(bgp, vpn)
 				== VXLAN_FLOOD_HEAD_END_REPL) {
 		build_evpn_type3_prefix(&p, vpn->originator_ip);
-		dest = bgp_node_lookup(vpn->route_table, (struct prefix *)&p);
+		dest = bgp_evpn_vni_node_lookup(vpn->route_table, &p, NULL);
 		if (!dest) /* unexpected */
 			return 0;
 		for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next)
@@ -3637,11 +3738,12 @@ static int update_advertise_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
 		}
 		attr = pi->attr;
 
-		global_dest = bgp_global_evpn_node_get(bgp->rib[afi][safi],
-				afi, safi, &p, &vpn->prd);
-		update_evpn_route_entry(bgp, vpn, afi, safi, global_dest, attr,
-				1, &pi, 0, mac_mobility_seqnum(attr),
-				false /* setup_sync */, NULL /* old_is_sync */);
+		global_dest = bgp_evpn_global_node_get(
+			bgp->rib[afi][safi], afi, safi, &p, &vpn->prd, NULL);
+		update_evpn_route_entry(
+			bgp, vpn, afi, safi, global_dest, attr, NULL /* mac */,
+			1, &pi, 0, mac_mobility_seqnum(attr),
+			false /* setup_sync */, NULL /* old_is_sync */);
 
 		/* Schedule for processing and unlock node. */
 		bgp_process(bgp, global_dest, afi, safi);
@@ -3653,6 +3755,7 @@ static int update_advertise_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
 	 */
 	for (dest = bgp_table_top(vpn->route_table); dest;
 	     dest = bgp_route_next(dest)) {
+		struct prefix_evpn tmp_evp;
 		const struct prefix_evpn *evp =
 			(const struct prefix_evpn *)bgp_dest_get_prefix(dest);
 
@@ -3672,19 +3775,28 @@ static int update_advertise_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
 		if (!pi)
 			continue;
 
+		/*
+		 * VNI table MAC-IP prefixes don't have MAC so make sure it's
+		 * set from path info here.
+		 */
+		evpn_type2_prefix_global_copy(
+			&tmp_evp, evp, *evpn_type2_path_info_get_mac(pi));
+
 		/* Create route in global routing table using this route entry's
 		 * attribute.
 		 */
 		attr = pi->attr;
-		global_dest = bgp_global_evpn_node_get(bgp->rib[afi][safi], afi, safi,
-					     evp, &vpn->prd);
+		global_dest =
+			bgp_evpn_global_node_get(bgp->rib[afi][safi], afi, safi,
+						 &tmp_evp, &vpn->prd, NULL);
 		assert(global_dest);
 
 		if (evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE) {
 			/* Type-2 route */
 			update_evpn_route_entry(
-				bgp, vpn, afi, safi, global_dest, attr, 1,
-				&global_pi, 0, mac_mobility_seqnum(attr),
+				bgp, vpn, afi, safi, global_dest, attr,
+				NULL /* mac */, 1, &global_pi, 0,
+				mac_mobility_seqnum(attr),
 				false /* setup_sync */, NULL /* old_is_sync */);
 		} else {
 			/* Type-1 route */
@@ -3724,8 +3836,8 @@ static int delete_withdraw_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
 
 	/* Remove type-3 route for this VNI from global table. */
 	build_evpn_type3_prefix(&p, vpn->originator_ip);
-	global_dest = bgp_global_evpn_node_lookup(bgp->rib[afi][safi], afi, safi,
-			(const struct prefix_evpn *)&p, &vpn->prd);
+	global_dest = bgp_evpn_global_node_lookup(bgp->rib[afi][safi], afi,
+						  safi, &p, &vpn->prd, NULL);
 	if (global_dest) {
 		/* Delete route entry in the global EVPN table. */
 		delete_evpn_route_entry(bgp, afi, safi, global_dest, &pi);
@@ -5482,7 +5594,7 @@ int bgp_evpn_local_macip_del(struct bgp *bgp, vni_t vni, struct ethaddr *mac,
 		delete_evpn_route(bgp, vpn, &p);
 	} else {
 		/* Re-instate the current remote best path if any */
-		dest = bgp_node_lookup(vpn->route_table, (struct prefix *)&p);
+		dest = bgp_evpn_vni_node_lookup(vpn->route_table, &p, NULL);
 		if (dest) {
 			evpn_zebra_reinstall_best_route(bgp, vpn, dest);
 			bgp_dest_unlock_node(dest);

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -471,7 +471,7 @@ static int bgp_evpn_mh_route_delete(struct bgp *bgp, struct bgp_evpn_es *es,
 	struct prefix_rd *prd;
 
 	if (vpn) {
-		rt_table = vpn->route_table;
+		rt_table = vpn->ip_table;
 		prd = &vpn->prd;
 	} else {
 		rt_table = es->route_table;
@@ -960,7 +960,7 @@ static int bgp_evpn_type1_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
 		bgp_evpn_type1_evi_route_extcomm_build(es, vpn, &attr);
 
 		/* First, create (or fetch) route node within the VNI. */
-		dest = bgp_node_get(vpn->route_table, (struct prefix *)p);
+		dest = bgp_node_get(vpn->ip_table, (struct prefix *)p);
 
 		/* Create or update route entry. */
 		ret = bgp_evpn_mh_route_update(bgp, es, vpn, afi, safi, dest,

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -498,9 +498,8 @@ static int bgp_evpn_mh_route_delete(struct bgp *bgp, struct bgp_evpn_es *es,
 	/* Next, locate route node in the global EVPN routing table.
 	 * Note that this table is a 2-level tree (RD-level + Prefix-level)
 	 */
-	global_dest =
-		bgp_global_evpn_node_lookup(bgp->rib[afi][safi], afi, safi,
-					    (const struct prefix_evpn *)p, prd);
+	global_dest = bgp_evpn_global_node_lookup(bgp->rib[afi][safi], afi,
+						  safi, p, prd, NULL);
 	if (global_dest) {
 
 		/* Delete route entry in the global EVPN table. */
@@ -675,8 +674,9 @@ static int bgp_evpn_type4_route_update(struct bgp *bgp,
 	if (route_changed) {
 		struct bgp_path_info *global_pi;
 
-		dest = bgp_global_evpn_node_get(bgp->rib[afi][safi], afi, safi,
-						p, &es->es_base_frag->prd);
+		dest = bgp_evpn_global_node_get(bgp->rib[afi][safi], afi, safi,
+						p, &es->es_base_frag->prd,
+						NULL);
 		bgp_evpn_mh_route_update(bgp, es, NULL, afi, safi, dest,
 					 attr_new, &global_pi, &route_changed);
 
@@ -1015,8 +1015,8 @@ static int bgp_evpn_type1_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
 	if (route_changed) {
 		struct bgp_path_info *global_pi;
 
-		dest = bgp_global_evpn_node_get(bgp->rib[afi][safi], afi, safi,
-						p, global_rd);
+		dest = bgp_evpn_global_node_get(bgp->rib[afi][safi], afi, safi,
+						p, global_rd, NULL);
 		bgp_evpn_mh_route_update(bgp, es, vpn, afi, safi, dest,
 					 attr_new, &global_pi, &route_changed);
 

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -735,7 +735,8 @@ static void bgp_evpn_show_routes_mac_ip_es(struct vty *vty, esi_t *esi,
 
 			if (detail)
 				route_vty_out_detail(
-					vty, bgp, rn, pi, AFI_L2VPN, SAFI_EVPN,
+					vty, bgp, rn, bgp_dest_get_prefix(rn),
+					pi, AFI_L2VPN, SAFI_EVPN,
 					RPKI_NOT_BEING_USED, json_path);
 			else
 				route_vty_out(vty, &rn->p, pi, 0, SAFI_EVPN,
@@ -818,6 +819,7 @@ static void show_vni_routes(struct bgp *bgp, struct bgpevpn *vpn, int type,
 		 * with code that already exists).
 		 */
 		for (; pi; pi = pi->next) {
+			struct prefix tmp_p;
 			json_object *json_path = NULL;
 
 			if (vtep_ip.s_addr != INADDR_ANY
@@ -825,16 +827,30 @@ static void show_vni_routes(struct bgp *bgp, struct bgpevpn *vpn, int type,
 					       &(pi->attr->nexthop)))
 				continue;
 
+			if (evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE) {
+				/*
+				 * VNI table MAC-IP prefixes don't have MAC so
+				 * make sure it's set from path info
+				 * here.
+				 */
+				evpn_type2_prefix_global_copy(
+					(struct prefix_evpn *)&tmp_p,
+					(struct prefix_evpn *)p,
+					*evpn_type2_path_info_get_mac(pi));
+			} else
+				memcpy(&tmp_p, p, sizeof(tmp_p));
+
+
 			if (json)
 				json_path = json_object_new_array();
 
 			if (detail)
-				route_vty_out_detail(vty, bgp, dest, pi,
+				route_vty_out_detail(vty, bgp, dest, &tmp_p, pi,
 						     AFI_L2VPN, SAFI_EVPN,
 						     RPKI_NOT_BEING_USED,
 						     json_path);
 			else
-				route_vty_out(vty, p, pi, 0, SAFI_EVPN,
+				route_vty_out(vty, &tmp_p, pi, 0, SAFI_EVPN,
 					      json_path, false);
 
 			if (json)
@@ -846,6 +862,19 @@ static void show_vni_routes(struct bgp *bgp, struct bgpevpn *vpn, int type,
 
 		if (json) {
 			if (add_prefix_to_json) {
+				struct prefix tmp_p;
+
+				if (evp->prefix.route_type ==
+				    BGP_EVPN_MAC_IP_ROUTE) {
+					pi = bgp_dest_get_bgp_path_info(dest);
+					evpn_type2_prefix_global_copy(
+						(struct prefix_evpn *)&tmp_p,
+						(struct prefix_evpn *)p,
+						*evpn_type2_path_info_get_mac(
+							pi));
+				} else
+					memcpy(&tmp_p, p, sizeof(tmp_p));
+
 				json_object_string_addf(json_prefix, "prefix",
 							"%pFX", p);
 				json_object_int_add(json_prefix, "prefixLen",
@@ -2371,7 +2400,7 @@ static void evpn_show_route_vni_multicast(struct vty *vty, struct bgp *bgp,
 
 	/* See if route exists. */
 	build_evpn_type3_prefix(&p, orig_ip);
-	dest = bgp_node_lookup(vpn->route_table, (struct prefix *)&p);
+	dest = bgp_evpn_vni_node_lookup(vpn->route_table, &p, NULL);
 	if (!dest || !bgp_dest_has_bgp_path_info_data(dest)) {
 		if (!json)
 			vty_out(vty, "%% Network not in table\n");
@@ -2386,7 +2415,8 @@ static void evpn_show_route_vni_multicast(struct vty *vty, struct bgp *bgp,
 		json_paths = json_object_new_array();
 
 	/* Prefix and num paths displayed once per prefix. */
-	route_vty_out_detail_header(vty, bgp, dest, NULL, afi, safi, json);
+	route_vty_out_detail_header(vty, bgp, dest, bgp_dest_get_prefix(dest),
+				    NULL, afi, safi, json);
 
 	/* Display each path for this prefix. */
 	for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next) {
@@ -2395,8 +2425,9 @@ static void evpn_show_route_vni_multicast(struct vty *vty, struct bgp *bgp,
 		if (json)
 			json_path = json_object_new_array();
 
-		route_vty_out_detail(vty, bgp, dest, pi, afi, safi,
-				     RPKI_NOT_BEING_USED, json_path);
+		route_vty_out_detail(vty, bgp, dest, bgp_dest_get_prefix(dest),
+				     pi, afi, safi, RPKI_NOT_BEING_USED,
+				     json_path);
 
 		if (json)
 			json_object_array_add(json_paths, json_path);
@@ -2427,6 +2458,7 @@ static void evpn_show_route_vni_macip(struct vty *vty, struct bgp *bgp,
 {
 	struct bgpevpn *vpn;
 	struct prefix_evpn p;
+	struct prefix_evpn tmp_p;
 	struct bgp_dest *dest;
 	struct bgp_path_info *pi;
 	uint32_t path_cnt = 0;
@@ -2447,7 +2479,7 @@ static void evpn_show_route_vni_macip(struct vty *vty, struct bgp *bgp,
 
 	/* See if route exists. Look for both non-sticky and sticky. */
 	build_evpn_type2_prefix(&p, mac, ip);
-	dest = bgp_node_lookup(vpn->route_table, (struct prefix *)&p);
+	dest = bgp_evpn_vni_node_lookup(vpn->route_table, &p, NULL);
 	if (!dest || !bgp_dest_has_bgp_path_info_data(dest)) {
 		if (!json)
 			vty_out(vty, "%% Network not in table\n");
@@ -2458,21 +2490,54 @@ static void evpn_show_route_vni_macip(struct vty *vty, struct bgp *bgp,
 		return;
 	}
 
+	/*
+	 * MAC is per-path, we have to walk the path_info's and look for it
+	 * first here.
+	 */
+	for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next) {
+		if (memcmp(mac, evpn_type2_path_info_get_mac(pi),
+			   sizeof(*mac)) == 0)
+			break;
+	}
+
+	if (!pi) {
+		if (!json)
+			vty_out(vty, "%% Network not in table\n");
+		return;
+	}
+
 	if (json)
 		json_paths = json_object_new_array();
 
 	/* Prefix and num paths displayed once per prefix. */
-	route_vty_out_detail_header(vty, bgp, dest, NULL, afi, safi, json);
+	route_vty_out_detail_header(vty, bgp, dest, (struct prefix *)&p, NULL,
+				    afi, safi, json);
 
 	/* Display each path for this prefix. */
 	for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next) {
 		json_object *json_path = NULL;
 
+		/* skip non-matching MACs */
+		if (memcmp(mac, evpn_type2_path_info_get_mac(pi),
+			   sizeof(*mac)) != 0)
+			continue;
+
 		if (json)
 			json_path = json_object_new_array();
 
-		route_vty_out_detail(vty, bgp, dest, pi, afi, safi,
-				     RPKI_NOT_BEING_USED, json_path);
+		/*
+		 * VNI table MAC-IP prefixes don't have MAC so
+		 * make sure it's set from path info
+		 * here.
+		 */
+		evpn_type2_prefix_global_copy(
+			(struct prefix_evpn *)&tmp_p,
+			(struct prefix_evpn *)bgp_dest_get_prefix(dest),
+			*evpn_type2_path_info_get_mac(pi));
+
+		route_vty_out_detail(vty, bgp, dest, (struct prefix *)&tmp_p,
+				     pi, afi, safi, RPKI_NOT_BEING_USED,
+				     json_path);
 
 		if (json)
 			json_object_array_add(json_paths, json_path);
@@ -2568,7 +2633,8 @@ static void evpn_show_route_rd_macip(struct vty *vty, struct bgp *bgp,
 	}
 
 	/* Prefix and num paths displayed once per prefix. */
-	route_vty_out_detail_header(vty, bgp, dest, prd, afi, safi, json);
+	route_vty_out_detail_header(vty, bgp, dest, bgp_dest_get_prefix(dest),
+				    prd, afi, safi, json);
 
 	if (json)
 		json_paths = json_object_new_array();
@@ -2580,8 +2646,9 @@ static void evpn_show_route_rd_macip(struct vty *vty, struct bgp *bgp,
 		if (json)
 			json_path = json_object_new_array();
 
-		route_vty_out_detail(vty, bgp, dest, pi, afi, safi,
-				     RPKI_NOT_BEING_USED, json_path);
+		route_vty_out_detail(vty, bgp, dest, bgp_dest_get_prefix(dest),
+				     pi, afi, safi, RPKI_NOT_BEING_USED,
+				     json_path);
 
 		if (json)
 			json_object_array_add(json_paths, json_path);
@@ -2673,8 +2740,9 @@ static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
 			}
 
 			/* Prefix and num paths displayed once per prefix. */
-			route_vty_out_detail_header(vty, bgp, dest, prd, afi,
-						    safi, json_prefix);
+			route_vty_out_detail_header(
+				vty, bgp, dest, bgp_dest_get_prefix(dest), prd,
+				afi, safi, json_prefix);
 
 			prefix_cnt++;
 		}
@@ -2689,8 +2757,9 @@ static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
 			if (json)
 				json_path = json_object_new_array();
 
-			route_vty_out_detail(vty, bgp, dest, pi, afi, safi,
-					     RPKI_NOT_BEING_USED, json_path);
+			route_vty_out_detail(
+				vty, bgp, dest, bgp_dest_get_prefix(dest), pi,
+				afi, safi, RPKI_NOT_BEING_USED, json_path);
 
 			if (json)
 				json_object_array_add(json_paths, json_path);
@@ -2807,7 +2876,7 @@ static void evpn_show_route_rd_all_macip(struct vty *vty, struct bgp *bgp,
 		} else
 			/* Prefix and num paths displayed once per prefix. */
 			route_vty_out_detail_header(
-				vty, bgp, dest, (struct prefix_rd *)rd_destp,
+				vty, bgp, dest, p, (struct prefix_rd *)rd_destp,
 				AFI_L2VPN, SAFI_EVPN, json_prefix);
 
 		/* For EVPN, the prefix is displayed for each path (to
@@ -2822,7 +2891,7 @@ static void evpn_show_route_rd_all_macip(struct vty *vty, struct bgp *bgp,
 			if (json)
 				json_path = json_object_new_array();
 
-			route_vty_out_detail(vty, bgp, dest, pi, AFI_L2VPN,
+			route_vty_out_detail(vty, bgp, dest, p, pi, AFI_L2VPN,
 					     SAFI_EVPN, RPKI_NOT_BEING_USED,
 					     json_path);
 
@@ -2960,6 +3029,7 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 			if (detail)
 				route_vty_out_detail_header(
 					vty, bgp, dest,
+					bgp_dest_get_prefix(dest),
 					(struct prefix_rd *)rd_destp, AFI_L2VPN,
 					SAFI_EVPN, json_prefix);
 
@@ -2979,9 +3049,10 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 
 				if (detail) {
 					route_vty_out_detail(
-						vty, bgp, dest, pi, AFI_L2VPN,
-						SAFI_EVPN, RPKI_NOT_BEING_USED,
-						json_path);
+						vty, bgp, dest,
+						bgp_dest_get_prefix(dest), pi,
+						AFI_L2VPN, SAFI_EVPN,
+						RPKI_NOT_BEING_USED, json_path);
 				} else
 					route_vty_out(vty, p, pi, 0, SAFI_EVPN,
 						      json_path, false);

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -519,7 +519,7 @@ static void display_vni(struct vty *vty, struct bgpevpn *vpn, json_object *json)
 			json, "sviInterface",
 			ifindex2ifname(vpn->svi_ifindex, vpn->tenant_vrf_id));
 	} else {
-		vty_out(vty, "VNI: %d", vpn->vni);
+		vty_out(vty, "VNI: %u", vpn->vni);
 		if (is_vni_live(vpn))
 			vty_out(vty, " (known to the kernel)");
 		vty_out(vty, "\n");
@@ -923,12 +923,12 @@ static void show_vni_routes_hash(struct hash_bucket *bucket, void *arg)
 	json_object *json_vni = NULL;
 	char vni_str[VNI_STR_LEN];
 
-	snprintf(vni_str, sizeof(vni_str), "%d", vpn->vni);
+	snprintf(vni_str, sizeof(vni_str), "%u", vpn->vni);
 	if (json) {
 		json_vni = json_object_new_object();
 		json_object_int_add(json_vni, "vni", vpn->vni);
 	} else {
-		vty_out(vty, "\nVNI: %d\n\n", vpn->vni);
+		vty_out(vty, "\nVNI: %u\n\n", vpn->vni);
 	}
 
 	show_vni_routes(wctx->bgp, vpn, wctx->vty, wctx->type, wctx->mac_table,
@@ -948,12 +948,12 @@ static void show_vni_routes_all_hash(struct hash_bucket *bucket, void *arg)
 	json_object *json_vni_mac = NULL;
 	char vni_str[VNI_STR_LEN];
 
-	snprintf(vni_str, sizeof(vni_str), "%d", vpn->vni);
+	snprintf(vni_str, sizeof(vni_str), "%u", vpn->vni);
 	if (json) {
 		json_vni = json_object_new_object();
 		json_object_int_add(json_vni, "vni", vpn->vni);
 	} else {
-		vty_out(vty, "\nVNI: %d\n\n", vpn->vni);
+		vty_out(vty, "\nVNI: %u\n\n", vpn->vni);
 	}
 
 	show_vni_routes(wctx->bgp, vpn, wctx->vty, 0, false, wctx->vtep_ip,
@@ -965,7 +965,7 @@ static void show_vni_routes_all_hash(struct hash_bucket *bucket, void *arg)
 	if (json)
 		json_vni_mac = json_object_new_object();
 	else
-		vty_out(vty, "\nVNI: %d MAC Table\n\n", vpn->vni);
+		vty_out(vty, "\nVNI: %u MAC Table\n\n", vpn->vni);
 
 	show_vni_routes(wctx->bgp, vpn, wctx->vty, 0, true, wctx->vtep_ip,
 			json_vni_mac, wctx->detail);
@@ -3456,7 +3456,7 @@ static void write_vni_config(struct vty *vty, struct bgpevpn *vpn)
 	struct ecommunity *ecom;
 
 	if (is_vni_configured(vpn)) {
-		vty_out(vty, "  vni %d\n", vpn->vni);
+		vty_out(vty, "  vni %u\n", vpn->vni);
 		if (is_rd_configured(vpn))
 			vty_out(vty, "   rd %pRD\n", &vpn->prd);
 

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -5264,12 +5264,8 @@ DEFPY(show_bgp_vni_all,
 
 	evpn_show_routes_vni_all_type_all(vty, bgp, addr, json, !!detail);
 
-	if (uj) {
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
-	}
+	if (uj)
+		vty_json(vty, json);
 
 	return CMD_SUCCESS;
 }
@@ -5306,12 +5302,8 @@ DEFPY(show_bgp_vni_all_ead,
 	evpn_show_routes_vni_all(vty, bgp, BGP_EVPN_AD_ROUTE, false, addr, json,
 				 !!detail);
 
-	if (uj) {
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
-	}
+	if (uj)
+		vty_json(vty, json);
 
 	return CMD_SUCCESS;
 }
@@ -5349,12 +5341,8 @@ DEFPY(show_bgp_vni_all_macip_mac,
 	evpn_show_routes_vni_all(vty, bgp, BGP_EVPN_MAC_IP_ROUTE, true, addr,
 				 json, !!detail);
 
-	if (uj) {
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
-	}
+	if (uj)
+		vty_json(vty, json);
 
 	return CMD_SUCCESS;
 }
@@ -5392,12 +5380,8 @@ DEFPY(show_bgp_vni_all_macip_ip,
 	evpn_show_routes_vni_all(vty, bgp, BGP_EVPN_MAC_IP_ROUTE, false, addr,
 				 json, !!detail);
 
-	if (uj) {
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
-	}
+	if (uj)
+		vty_json(vty, json);
 
 	return CMD_SUCCESS;
 }
@@ -5434,12 +5418,8 @@ DEFPY(show_bgp_vni_all_imet,
 	evpn_show_routes_vni_all(vty, bgp, BGP_EVPN_IMET_ROUTE, false, addr,
 				 json, !!detail);
 
-	if (uj) {
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
-	}
+	if (uj)
+		vty_json(vty, json);
 
 	return CMD_SUCCESS;
 }
@@ -5481,10 +5461,7 @@ DEFPY(show_bgp_vni,
 
 	if (uj) {
 		json_object_object_add(json, "macTable", json_mac);
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
+		vty_json(vty, json);
 	}
 
 	return CMD_SUCCESS;
@@ -5521,12 +5498,8 @@ DEFPY(show_bgp_vni_ead,
 	evpn_show_routes_vni(vty, bgp, vni, BGP_EVPN_AD_ROUTE, false, addr,
 			     json);
 
-	if (uj) {
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
-	}
+	if (uj)
+		vty_json(vty, json);
 
 	return CMD_SUCCESS;
 }
@@ -5563,12 +5536,8 @@ DEFPY(show_bgp_vni_macip_mac,
 	evpn_show_routes_vni(vty, bgp, vni, BGP_EVPN_MAC_IP_ROUTE, true, addr,
 			     json);
 
-	if (uj) {
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
-	}
+	if (uj)
+		vty_json(vty, json);
 
 	return CMD_SUCCESS;
 }
@@ -5605,12 +5574,8 @@ DEFPY(show_bgp_vni_macip_ip,
 	evpn_show_routes_vni(vty, bgp, vni, BGP_EVPN_MAC_IP_ROUTE, false, addr,
 			     json);
 
-	if (uj) {
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
-	}
+	if (uj)
+		vty_json(vty, json);
 
 	return CMD_SUCCESS;
 }
@@ -5646,12 +5611,8 @@ DEFPY(show_bgp_vni_imet,
 	evpn_show_routes_vni(vty, bgp, vni, BGP_EVPN_IMET_ROUTE, false, addr,
 			     json);
 
-	if (uj) {
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
-	}
+	if (uj)
+		vty_json(vty, json);
 
 	return CMD_SUCCESS;
 }
@@ -5686,12 +5647,8 @@ DEFPY(show_bgp_vni_macip_mac_addr,
 
 	evpn_show_route_vni_macip(vty, bgp, vni, &mac->eth_addr, NULL, json);
 
-	if (uj) {
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
-	}
+	if (uj)
+		vty_json(vty, json);
 
 	return CMD_SUCCESS;
 }
@@ -5728,12 +5685,8 @@ DEFPY(show_bgp_vni_macip_ip_addr, show_bgp_vni_macip_ip_addr_cmd,
 	}
 	evpn_show_route_vni_macip(vty, bgp, vni, NULL, &ip_addr, json);
 
-	if (uj) {
-		vty_out(vty, "%s\n",
-			json_object_to_json_string_ext(
-				json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
-	}
+	if (uj)
+		vty_json(vty, json);
 
 	return CMD_SUCCESS;
 }

--- a/bgpd/bgp_evpn_vty.h
+++ b/bgpd/bgp_evpn_vty.h
@@ -27,6 +27,12 @@ extern void bgp_ethernetvpn_init(void);
 
 #define L2VPN_HELP_STR        "Layer 2 Virtual Private Network\n"
 #define EVPN_HELP_STR        "Ethernet Virtual Private Network\n"
+#define VNI_HELP_STR "VXLAN Network Identifier\n"
+#define VNI_NUM_HELP_STR "VNI number\n"
+#define VNI_ALL_HELP_STR "All VNIs\n"
+#define DETAIL_HELP_STR "Print Detailed Output\n"
+#define VTEP_HELP_STR "Remote VTEP\n"
+#define VTEP_IP_HELP_STR "Remote VTEP IP address\n"
 
 extern int argv_find_and_parse_oly_idx(struct cmd_token **argv, int argc,
 				       int *oly_idx,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10109,10 +10109,11 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 					(struct prefix_evpn *)
 						bgp_dest_get_prefix(dest),
 					tag_buf);
-				if (attr->es_flags & ATTR_ES_L3_NHG)
+				if (CHECK_FLAG(attr->es_flags, ATTR_ES_L3_NHG))
 					vty_out(vty, ", L3NHG %s",
-						(attr->es_flags &
-						 ATTR_ES_L3_NHG_ACTIVE)
+						CHECK_FLAG(
+							attr->es_flags,
+							ATTR_ES_L3_NHG_ACTIVE)
 							? "active"
 							: "inactive");
 				vty_out(vty, "\n");

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -214,9 +214,11 @@ struct bgp_path_info_extra {
 	} vnc;
 #endif
 
-	/* For imported routes into a VNI (or VRF), this points to the parent.
+	/*
+	 * For imported routes into a VNI (or VRF)
 	 */
-	void *parent;
+	void *parent;	    /* parent from global table */
+	struct ethaddr mac; /* MAC set here for VNI table */
 
 	/*
 	 * Some tunnelish parameters follow. Maybe consolidate into an
@@ -827,10 +829,11 @@ extern bool bgp_zebra_has_route_changed(struct bgp_path_info *selected);
 
 extern void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 					struct bgp_dest *dest,
+					const struct prefix *p,
 					const struct prefix_rd *prd, afi_t afi,
 					safi_t safi, json_object *json);
 extern void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
-				 struct bgp_dest *bn,
+				 struct bgp_dest *bn, const struct prefix *p,
 				 struct bgp_path_info *path, afi_t afi,
 				 safi_t safi, enum rpki_states,
 				 json_object *json_paths);

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -218,7 +218,10 @@ struct bgp_path_info_extra {
 	 * For imported routes into a VNI (or VRF)
 	 */
 	void *parent;	    /* parent from global table */
-	struct ethaddr mac; /* MAC set here for VNI table */
+	union {
+		struct ethaddr mac; /* MAC set here for VNI IP table */
+		struct ipaddr ip;   /* IP set here for VNI MAC table */
+	} vni_info;
 
 	/*
 	 * Some tunnelish parameters follow. Maybe consolidate into an

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3750,6 +3750,10 @@ structure is extended with :clicmd:`show bgp [afi] [safi]`.
 
    EVPN prefixes can also be filtered by EVPN route type.
 
+.. clicmd:: show bgp vni <all|VNI> [vtep VTEP] [type <ead|1|macip|2|multicast|3>] [<detail|json>]
+
+   Display per-VNI EVPN routing table in bgp. Filter route-type, vtep, or VNI.
+
 .. clicmd:: show bgp [afi] [safi] [all] summary [json]
 
    Show a bgp peer summary for the specified address family, and subsequent

--- a/lib/command.h
+++ b/lib/command.h
@@ -404,6 +404,8 @@ struct cmd_node {
 #define SHOW_STR "Show running system information\n"
 #define IP_STR "IP information\n"
 #define IPV6_STR "IPv6 information\n"
+#define IP_ADDR_STR "IPv4 Address\n"
+#define IP6_ADDR_STR "IPv6 Address\n"
 #define SRTE_STR "SR-TE information\n"
 #define SRTE_COLOR_STR "SR-TE Color information\n"
 #define NO_STR "Negate a command or set its defaults\n"

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -1327,11 +1327,11 @@ static void zebra_evpn_process_sync_macip_add(struct zebra_evpn *zevpn,
 					      uint8_t flags, uint32_t seq,
 					      const esi_t *esi)
 {
-	struct sync_mac_ip_ctx ctx;
 	char ipbuf[INET6_ADDRSTRLEN];
 	bool sticky;
 	bool remote_gw;
 	struct zebra_neigh *n = NULL;
+	struct zebra_mac *mac = NULL;
 
 	sticky = !!CHECK_FLAG(flags, ZEBRA_MACIP_TYPE_STICKY);
 	remote_gw = !!CHECK_FLAG(flags, ZEBRA_MACIP_TYPE_GW);
@@ -1352,22 +1352,30 @@ static void zebra_evpn_process_sync_macip_add(struct zebra_evpn *zevpn,
 		return;
 	}
 
-	if (ipa_len) {
+	if (!ipa_len) {
+		/* MAC update */
+		(void)zebra_evpn_proc_sync_mac_update(zevpn, macaddr, ipa_len,
+						      ipaddr, flags, seq, esi);
+	} else {
+		/* MAC-IP update */
+		mac = zebra_evpn_mac_lookup(zevpn, macaddr);
+		if (!mac) {
+			mac = zebra_evpn_proc_sync_mac_update(zevpn, macaddr,
+							      ipa_len, ipaddr,
+							      flags, seq, esi);
+		}
+		if (!mac)
+			return;
+
 		n = zebra_evpn_neigh_lookup(zevpn, ipaddr);
 		if (n
 		    && !zebra_evpn_neigh_is_bgp_seq_ok(zevpn, n, macaddr, seq,
 						       true))
 			return;
+
+		zebra_evpn_proc_sync_neigh_update(zevpn, n, ipa_len, ipaddr,
+						  flags, seq, esi, mac);
 	}
-
-	memset(&ctx, 0, sizeof(ctx));
-	ctx.mac = zebra_evpn_proc_sync_mac_update(
-		zevpn, macaddr, ipa_len, ipaddr, flags, seq, esi, &ctx);
-	if (ctx.ignore_macip || !ctx.mac || !ipa_len)
-		return;
-
-	zebra_evpn_proc_sync_neigh_update(zevpn, n, ipa_len, ipaddr, flags, seq,
-					  esi, &ctx);
 }
 
 /************************** remote mac-ip handling **************************/
@@ -1452,14 +1460,30 @@ void zebra_evpn_rem_macip_add(vni_t vni, const struct ethaddr *macaddr,
 	}
 
 	zvrf = zebra_vrf_get_evpn();
-	if (zebra_evpn_mac_remote_macip_add(zevpn, zvrf, macaddr, ipa_len,
-					    ipaddr, &mac, vtep_ip, flags, seq,
-					    esi)
-	    != 0)
+	if (!zvrf)
 		return;
 
-	zebra_evpn_neigh_remote_macip_add(zevpn, zvrf, ipaddr, mac, vtep_ip,
-					  flags, seq);
+	if (!ipa_len) {
+		/* MAC update */
+		zebra_evpn_mac_remote_macip_add(zevpn, zvrf, macaddr, vtep_ip,
+						flags, seq, esi);
+	} else {
+		/* MAC-IP update
+		 * Add auto MAC if it doesn't exist.
+		 */
+		mac = zebra_evpn_mac_lookup(zevpn, macaddr);
+		if (!mac) {
+			mac = zebra_evpn_mac_add_auto(zevpn, macaddr);
+
+			if (IS_ZEBRA_DEBUG_VXLAN)
+				zlog_debug(
+					"Neigh %pIA: MAC %pEA not found, Auto MAC created",
+					ipaddr, macaddr);
+		}
+
+		zebra_evpn_neigh_remote_macip_add(zevpn, zvrf, ipaddr, mac,
+						  vtep_ip, flags, seq);
+	}
 }
 
 /* Process a remote MACIP delete from BGP. */

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -1528,7 +1528,7 @@ void zebra_evpn_rem_macip_del(vni_t vni, const struct ethaddr *macaddr,
 
 	if (n && !mac) {
 		zlog_warn(
-			"Failed to locate MAC %pEA for neigh %pIA VNI %u upon remote MACIP DEL",
+			"Failed to locate MAC %pEA for Neigh %pIA VNI %u upon remote MACIP DEL",
 			macaddr, ipaddr, vni);
 		return;
 	}
@@ -1536,8 +1536,13 @@ void zebra_evpn_rem_macip_del(vni_t vni, const struct ethaddr *macaddr,
 	/* If the remote mac or neighbor doesn't exist there is nothing
 	 * more to do. Otherwise, uninstall the entry and then remove it.
 	 */
-	if (!mac && !n)
+	if (!mac && !n) {
+		if (IS_ZEBRA_DEBUG_VXLAN)
+			zlog_debug(
+				"Failed to locate MAC %pEA & Neigh %pIA VNI %u upon remote MACIP DEL",
+				macaddr, ipaddr, vni);
 		return;
+	}
 
 	zvrf = zevpn->vxlan_if->vrf->info;
 

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -1642,7 +1642,7 @@ static inline bool zebra_evpn_mac_is_bgp_seq_ok(struct zebra_evpn *zevpn,
 		/* if the mac was never advertised to bgp we must accept
 		 * whatever sequence number bgp sends
 		 */
-		if (!is_local && zebra_vxlan_accept_bgp_seq()) {
+		if (!is_local && zebra_vxlan_get_accept_bgp_seq()) {
 			if (IS_ZEBRA_DEBUG_EVPN_MH_MAC ||
 			    IS_ZEBRA_DEBUG_VXLAN) {
 				zlog_debug(

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -1179,6 +1179,25 @@ int zebra_evpn_mac_del(struct zebra_evpn *zevpn, struct zebra_mac *mac)
 	return 0;
 }
 
+/*
+ * Add Auto MAC entry.
+ */
+struct zebra_mac *zebra_evpn_mac_add_auto(struct zebra_evpn *zevpn,
+					  const struct ethaddr *macaddr)
+{
+	struct zebra_mac *mac;
+
+	mac = zebra_evpn_mac_add(zevpn, macaddr);
+	if (!mac)
+		return NULL;
+
+	zebra_evpn_mac_clear_fwd_info(mac);
+	memset(&mac->flags, 0, sizeof(uint32_t));
+	SET_FLAG(mac->flags, ZEBRA_MAC_AUTO);
+
+	return mac;
+}
+
 static bool zebra_evpn_check_mac_del_from_db(struct mac_walk_ctx *wctx,
 					     struct zebra_mac *mac)
 {
@@ -1592,11 +1611,8 @@ void zebra_evpn_sync_mac_del(struct zebra_mac *mac)
 
 static inline bool zebra_evpn_mac_is_bgp_seq_ok(struct zebra_evpn *zevpn,
 						struct zebra_mac *mac,
-						uint32_t seq, uint16_t ipa_len,
-						const struct ipaddr *ipaddr,
-						bool sync)
+						uint32_t seq, bool sync)
 {
-	char ipbuf[INET6_ADDRSTRLEN];
 	char mac_buf[MAC_BUF_SIZE];
 	uint32_t tmp_seq;
 	const char *n_type;
@@ -1630,14 +1646,9 @@ static inline bool zebra_evpn_mac_is_bgp_seq_ok(struct zebra_evpn *zevpn,
 			if (IS_ZEBRA_DEBUG_EVPN_MH_MAC ||
 			    IS_ZEBRA_DEBUG_VXLAN) {
 				zlog_debug(
-					"%s-macip accept vni %u %s-mac %pEA%s%s lower seq %u f %s",
+					"%s-macip accept vni %u %s-mac %pEA lower seq %u f %s",
 					sync ? "sync" : "rem", zevpn->vni,
-					n_type, &mac->macaddr,
-					ipa_len ? " IP " : "",
-					ipa_len ? ipaddr2str(ipaddr, ipbuf,
-							     sizeof(ipbuf))
-						: "",
-					tmp_seq,
+					n_type, &mac->macaddr, tmp_seq,
 					zebra_evpn_zebra_mac_flag_dump(
 						mac, mac_buf, sizeof(mac_buf)));
 			}
@@ -1647,14 +1658,9 @@ static inline bool zebra_evpn_mac_is_bgp_seq_ok(struct zebra_evpn *zevpn,
 
 		if (IS_ZEBRA_DEBUG_EVPN_MH_MAC || IS_ZEBRA_DEBUG_VXLAN) {
 			zlog_debug(
-				"%s-macip ignore vni %u %s-mac %pEA%s%s as existing has higher seq %u f %s",
+				"%s-macip ignore vni %u %s-mac %pEA as existing has higher seq %u f %s",
 				sync ? "sync" : "rem", zevpn->vni, n_type,
-				&mac->macaddr,
-				ipa_len ? " IP " : "",
-				ipa_len ? ipaddr2str(ipaddr, ipbuf,
-						     sizeof(ipbuf))
-					: "",
-				tmp_seq,
+				&mac->macaddr, tmp_seq,
 				zebra_evpn_zebra_mac_flag_dump(
 					mac, mac_buf, sizeof(mac_buf)));
 		}
@@ -1665,10 +1671,12 @@ static inline bool zebra_evpn_mac_is_bgp_seq_ok(struct zebra_evpn *zevpn,
 	return true;
 }
 
-struct zebra_mac *zebra_evpn_proc_sync_mac_update(
-	struct zebra_evpn *zevpn, const struct ethaddr *macaddr,
-	uint16_t ipa_len, const struct ipaddr *ipaddr, uint8_t flags,
-	uint32_t seq, const esi_t *esi, struct sync_mac_ip_ctx *ctx)
+struct zebra_mac *zebra_evpn_proc_sync_mac_update(struct zebra_evpn *zevpn,
+						  const struct ethaddr *macaddr,
+						  uint16_t ipa_len,
+						  const struct ipaddr *ipaddr,
+						  uint8_t flags, uint32_t seq,
+						  const esi_t *esi)
 {
 	struct zebra_mac *mac;
 	bool inform_bgp = false;
@@ -1680,6 +1688,7 @@ struct zebra_mac *zebra_evpn_proc_sync_mac_update(
 	bool old_local = false;
 	bool old_bgp_ready;
 	bool new_bgp_ready;
+	bool created = false;
 
 	mac = zebra_evpn_mac_lookup(zevpn, macaddr);
 	if (!mac) {
@@ -1688,8 +1697,6 @@ struct zebra_mac *zebra_evpn_proc_sync_mac_update(
 		 */
 		inform_bgp = true;
 		inform_dataplane = true;
-		ctx->mac_created = true;
-		ctx->mac_inactive = true;
 
 		/* create the MAC and associate it with the dest ES */
 		mac = zebra_evpn_mac_add(zevpn, macaddr);
@@ -1707,6 +1714,7 @@ struct zebra_mac *zebra_evpn_proc_sync_mac_update(
 		SET_FLAG(mac->flags, ZEBRA_MAC_LOCAL_INACTIVE);
 		old_bgp_ready = false;
 		new_bgp_ready = zebra_evpn_mac_is_ready_for_bgp(mac->flags);
+		created = true;
 	} else {
 		uint32_t old_flags;
 		uint32_t new_flags;
@@ -1731,14 +1739,10 @@ struct zebra_mac *zebra_evpn_proc_sync_mac_update(
 						: "",
 					sticky ? " sticky" : "",
 					remote_gw ? " remote_gw" : "");
-			ctx->ignore_macip = true;
 			return NULL;
 		}
-		if (!zebra_evpn_mac_is_bgp_seq_ok(zevpn, mac, seq, ipa_len,
-						  ipaddr, true)) {
-			ctx->ignore_macip = true;
+		if (!zebra_evpn_mac_is_bgp_seq_ok(zevpn, mac, seq, true))
 			return NULL;
-		}
 
 		old_local = !!CHECK_FLAG(old_flags, ZEBRA_MAC_LOCAL);
 		old_static = zebra_evpn_mac_is_static(mac);
@@ -1747,12 +1751,11 @@ struct zebra_mac *zebra_evpn_proc_sync_mac_update(
 		new_flags = 0;
 		SET_FLAG(new_flags, ZEBRA_MAC_LOCAL);
 		/* retain old local activity flag */
-		if (old_flags & ZEBRA_MAC_LOCAL) {
+		if (old_flags & ZEBRA_MAC_LOCAL)
 			new_flags |= (old_flags & ZEBRA_MAC_LOCAL_INACTIVE);
-		} else {
+		else
 			new_flags |= ZEBRA_MAC_LOCAL_INACTIVE;
-			ctx->mac_inactive = true;
-		}
+
 		if (ipa_len) {
 			/* if mac-ip route do NOT update the peer flags
 			 * i.e. retain only flags as is
@@ -1805,7 +1808,6 @@ struct zebra_mac *zebra_evpn_proc_sync_mac_update(
 		if (es_change) {
 			inform_bgp = true;
 			inform_dataplane = true;
-			ctx->mac_inactive = true;
 		}
 
 		/* if peer-flag is being set notify dataplane that the
@@ -1836,8 +1838,7 @@ struct zebra_mac *zebra_evpn_proc_sync_mac_update(
 		char mac_buf[MAC_BUF_SIZE];
 
 		zlog_debug("sync-mac %s vni %u mac %pEA es %s seq %d f %s%s%s",
-			   ctx->mac_created ? "created" : "updated",
-			   zevpn->vni, macaddr,
+			   created ? "created" : "updated", zevpn->vni, macaddr,
 			   mac->es ? mac->es->esi_str : "-", mac->loc_seq,
 			   zebra_evpn_zebra_mac_flag_dump(mac, mac_buf,
 							  sizeof(mac_buf)),
@@ -1856,22 +1857,15 @@ struct zebra_mac *zebra_evpn_proc_sync_mac_update(
 		zebra_evpn_process_neigh_on_local_mac_change(
 			zevpn, mac, seq_change, es_change);
 
-	if (inform_dataplane) {
-		if (ipa_len)
-			/* if the mac is being created as a part of MAC-IP
-			 * route wait for the neigh to be updated or
-			 * created before programming the mac
-			 */
-			ctx->mac_dp_update_deferred = true;
-		else
-			/* program the local mac in the kernel. when the ES
-			 * change we need to force the dataplane to reset
-			 * the activity as we are yet to establish activity
-			 * locally
-			 */
-			zebra_evpn_sync_mac_dp_install(
-				mac, ctx->mac_inactive,
-				false /* force_clear_static */, __func__);
+	if (inform_dataplane && !ipa_len) {
+		/* program the local mac in the kernel. when the ES
+		 * change we need to force the dataplane to reset
+		 * the activity as we are yet to establish activity
+		 * locally
+		 */
+		zebra_evpn_sync_mac_dp_install(mac, false /* set_inactive */,
+					       false /* force_clear_static */,
+					       __func__);
 	}
 
 	return mac;
@@ -1995,13 +1989,12 @@ void zebra_evpn_print_dad_mac_hash_detail(struct hash_bucket *bucket,
 		zebra_evpn_print_mac_hash_detail(bucket, ctxt);
 }
 
-int zebra_evpn_mac_remote_macip_add(
-	struct zebra_evpn *zevpn, struct zebra_vrf *zvrf,
-	const struct ethaddr *macaddr, uint16_t ipa_len,
-	const struct ipaddr *ipaddr, struct zebra_mac **macp,
-	struct in_addr vtep_ip, uint8_t flags, uint32_t seq, const esi_t *esi)
+int zebra_evpn_mac_remote_macip_add(struct zebra_evpn *zevpn,
+				    struct zebra_vrf *zvrf,
+				    const struct ethaddr *macaddr,
+				    struct in_addr vtep_ip, uint8_t flags,
+				    uint32_t seq, const esi_t *esi)
 {
-	char buf1[INET6_ADDRSTRLEN];
 	bool sticky;
 	bool remote_gw;
 	int update_mac = 0;
@@ -2023,11 +2016,8 @@ int zebra_evpn_mac_remote_macip_add(
 	    && CHECK_FLAG(flags, ZEBRA_MACIP_TYPE_GW)) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug(
-				"Ignore remote MACIP ADD VNI %u MAC %pEA%s%s as MAC is already configured as gateway MAC",
-				zevpn->vni, macaddr,
-				ipa_len ? " IP " : "",
-				ipa_len ? ipaddr2str(ipaddr, buf1, sizeof(buf1))
-					: "");
+				"Ignore remote MACIP ADD VNI %u MAC %pEA as MAC is already configured as gateway MAC",
+				zevpn->vni, macaddr);
 		return -1;
 	}
 
@@ -2048,10 +2038,6 @@ int zebra_evpn_mac_remote_macip_add(
 		if (!mac) {
 			mac = zebra_evpn_mac_add(zevpn, macaddr);
 			zebra_evpn_es_mac_ref(mac, esi);
-
-			/* Is this MAC created for a MACIP? */
-			if (ipa_len)
-				SET_FLAG(mac->flags, ZEBRA_MAC_AUTO);
 		} else {
 			/* When host moves but changes its (MAC,IP)
 			 * binding, BGP may install a MACIP entry that
@@ -2061,8 +2047,8 @@ int zebra_evpn_mac_remote_macip_add(
 			 * the sequence number and ignore this update
 			 * if appropriate.
 			 */
-			if (!zebra_evpn_mac_is_bgp_seq_ok(
-				    zevpn, mac, seq, ipa_len, ipaddr, false))
+			if (!zebra_evpn_mac_is_bgp_seq_ok(zevpn, mac, seq,
+							  false))
 				return -1;
 
 			old_es_present = !!mac->es;
@@ -2146,12 +2132,7 @@ int zebra_evpn_mac_remote_macip_add(
 	/* Update seq number. */
 	mac->rem_seq = seq;
 
-	/* If there is no IP, return after clearing AUTO flag of MAC. */
-	if (!ipa_len) {
-		UNSET_FLAG(mac->flags, ZEBRA_MAC_AUTO);
-		return -1;
-	}
-	*macp = mac;
+	UNSET_FLAG(mac->flags, ZEBRA_MAC_AUTO);
 	return 0;
 }
 

--- a/zebra/zebra_evpn_mac.h
+++ b/zebra/zebra_evpn_mac.h
@@ -176,17 +176,6 @@ struct rmac_walk_ctx {
 	struct json_object *json;
 };
 
-/* temporary datastruct to pass info between the mac-update and
- * neigh-update while handling mac-ip routes
- */
-struct sync_mac_ip_ctx {
-	bool ignore_macip;
-	bool mac_created;
-	bool mac_inactive;
-	bool mac_dp_update_deferred;
-	struct zebra_mac *mac;
-};
-
 /**************************** SYNC MAC handling *****************************/
 /* if the mac has been added of a mac-route from the peer
  * or if it is being referenced by a neigh added by the
@@ -232,6 +221,8 @@ struct zebra_mac *zebra_evpn_mac_lookup(struct zebra_evpn *zevi,
 					const struct ethaddr *mac);
 struct zebra_mac *zebra_evpn_mac_add(struct zebra_evpn *zevi,
 				     const struct ethaddr *macaddr);
+struct zebra_mac *zebra_evpn_mac_add_auto(struct zebra_evpn *zevi,
+					  const struct ethaddr *macaddr);
 int zebra_evpn_mac_del(struct zebra_evpn *zevi, struct zebra_mac *mac);
 int zebra_evpn_macip_send_msg_to_client(uint32_t id,
 					const struct ethaddr *macaddr,
@@ -255,20 +246,22 @@ int zebra_evpn_mac_send_add_to_client(vni_t vni, const struct ethaddr *macaddr,
 int zebra_evpn_mac_send_del_to_client(vni_t vni, const struct ethaddr *macaddr,
 				      uint32_t flags, bool force);
 void zebra_evpn_send_mac_list_to_client(struct zebra_evpn *zevi);
-struct zebra_mac *zebra_evpn_proc_sync_mac_update(
-	struct zebra_evpn *zevi, const struct ethaddr *macaddr,
-	uint16_t ipa_len, const struct ipaddr *ipaddr, uint8_t flags,
-	uint32_t seq, const esi_t *esi, struct sync_mac_ip_ctx *ctx);
+struct zebra_mac *zebra_evpn_proc_sync_mac_update(struct zebra_evpn *zevi,
+						  const struct ethaddr *macaddr,
+						  uint16_t ipa_len,
+						  const struct ipaddr *ipaddr,
+						  uint8_t flags, uint32_t seq,
+						  const esi_t *esi);
 void zebra_evpn_sync_mac_del(struct zebra_mac *mac);
 void zebra_evpn_rem_mac_del(struct zebra_evpn *zevi, struct zebra_mac *mac);
 void zebra_evpn_print_dad_mac_hash(struct hash_bucket *bucket, void *ctxt);
 void zebra_evpn_print_dad_mac_hash_detail(struct hash_bucket *bucket,
 					  void *ctxt);
-int zebra_evpn_mac_remote_macip_add(
-	struct zebra_evpn *zevpn, struct zebra_vrf *zvrf,
-	const struct ethaddr *macaddr, uint16_t ipa_len,
-	const struct ipaddr *ipaddr, struct zebra_mac **macp,
-	struct in_addr vtep_ip, uint8_t flags, uint32_t seq, const esi_t *esi);
+int zebra_evpn_mac_remote_macip_add(struct zebra_evpn *zevpn,
+				    struct zebra_vrf *zvrf,
+				    const struct ethaddr *macaddr,
+				    struct in_addr vtep_ip, uint8_t flags,
+				    uint32_t seq, const esi_t *esi);
 
 int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf,
 				    struct zebra_evpn *zevpn,

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -527,7 +527,7 @@ bool zebra_evpn_neigh_is_bgp_seq_ok(struct zebra_evpn *zevpn,
 		/* if the neigh was never advertised to bgp we must accept
 		 * whatever sequence number bgp sends
 		 */
-		if (!is_local && zebra_vxlan_accept_bgp_seq()) {
+		if (!is_local && zebra_vxlan_get_accept_bgp_seq()) {
 			if (IS_ZEBRA_DEBUG_EVPN_MH_NEIGH
 			    || IS_ZEBRA_DEBUG_VXLAN)
 				zlog_debug(

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -513,10 +513,8 @@ bool zebra_evpn_neigh_is_bgp_seq_ok(struct zebra_evpn *zevpn,
 	if (seq < tmp_seq) {
 		/* if the neigh was never advertised to bgp we must accept
 		 * whatever sequence number bgp sends
-		 * XXX - check with Vivek
 		 */
-		if (CHECK_FLAG(n->flags, ZEBRA_NEIGH_LOCAL)
-		    && !zebra_evpn_neigh_is_ready_for_bgp(n)) {
+		if (zebra_vxlan_accept_bgp_seq()) {
 			if (IS_ZEBRA_DEBUG_EVPN_MH_NEIGH
 			    || IS_ZEBRA_DEBUG_VXLAN)
 				zlog_debug(

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -2245,6 +2245,12 @@ void zebra_evpn_neigh_remote_uninstall(struct zebra_evpn *zevpn,
 			zebra_evpn_neigh_del(zevpn, n);
 			zebra_evpn_deref_ip2mac(zevpn, mac);
 		}
+	} else {
+		if (IS_ZEBRA_DEBUG_VXLAN)
+			zlog_debug(
+				"%s: IP %pIA MAC %pEA (flags 0x%x) found doesn't match MAC %pEA, ignoring Neigh DEL",
+				__func__, ipaddr, &n->emac, n->flags,
+				&mac->macaddr);
 	}
 }
 

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -626,11 +626,10 @@ void zebra_evpn_sync_neigh_del(struct zebra_neigh *n)
 struct zebra_neigh *zebra_evpn_proc_sync_neigh_update(
 	struct zebra_evpn *zevpn, struct zebra_neigh *n, uint16_t ipa_len,
 	const struct ipaddr *ipaddr, uint8_t flags, uint32_t seq,
-	const esi_t *esi, struct sync_mac_ip_ctx *ctx)
+	const esi_t *esi, struct zebra_mac *mac)
 {
 	struct interface *ifp = NULL;
 	bool is_router;
-	struct zebra_mac *mac = ctx->mac;
 	uint32_t tmp_seq;
 	bool old_router = false;
 	bool old_bgp_ready = false;
@@ -791,8 +790,8 @@ struct zebra_neigh *zebra_evpn_proc_sync_neigh_update(
 		inform_bgp = true;
 
 	new_mac_static = zebra_evpn_mac_is_static(mac);
-	if ((old_mac_static != new_mac_static) || ctx->mac_dp_update_deferred)
-		zebra_evpn_sync_mac_dp_install(mac, ctx->mac_inactive,
+	if (old_mac_static != new_mac_static)
+		zebra_evpn_sync_mac_dp_install(mac, false /* set_inactive */,
 					       false /* force_clear_static */,
 					       __func__);
 
@@ -1286,10 +1285,12 @@ int zebra_evpn_local_neigh_update(struct zebra_evpn *zevpn,
 			zlog_debug("AUTO MAC %pEA created for neigh %pIA on VNI %u",
 				   macaddr, ip, zevpn->vni);
 
-		zmac = zebra_evpn_mac_add(zevpn, macaddr);
-		zebra_evpn_mac_clear_fwd_info(zmac);
-		memset(&zmac->flags, 0, sizeof(uint32_t));
-		SET_FLAG(zmac->flags, ZEBRA_MAC_AUTO);
+		zmac = zebra_evpn_mac_add_auto(zevpn, macaddr);
+		if (!zmac) {
+			zlog_debug("Failed to add MAC %pEA VNI %u", macaddr,
+				   zevpn->vni);
+			return -1;
+		}
 	} else {
 		if (CHECK_FLAG(zmac->flags, ZEBRA_MAC_REMOTE)) {
 			/*

--- a/zebra/zebra_evpn_neigh.h
+++ b/zebra/zebra_evpn_neigh.h
@@ -231,7 +231,7 @@ void zebra_evpn_sync_neigh_del(struct zebra_neigh *n);
 struct zebra_neigh *zebra_evpn_proc_sync_neigh_update(
 	struct zebra_evpn *zevpn, struct zebra_neigh *n, uint16_t ipa_len,
 	const struct ipaddr *ipaddr, uint8_t flags, uint32_t seq,
-	const esi_t *esi, struct sync_mac_ip_ctx *ctx);
+	const esi_t *esi, struct zebra_mac *mac);
 void zebra_evpn_neigh_del_all(struct zebra_evpn *zevpn, int uninstall,
 			      int upd_client, uint32_t flags);
 struct zebra_neigh *zebra_evpn_neigh_lookup(struct zebra_evpn *zevpn,

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3966,7 +3966,7 @@ static int config_write_protocol(struct vty *vty)
 
 	zebra_pbr_config_write(vty);
 
-	if (!zebra_vxlan_accept_bgp_seq())
+	if (!zebra_vxlan_get_accept_bgp_seq())
 		vty_out(vty, "no evpn accept-bgp-seq\n");
 
 	/* Include nexthop-group config */

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3740,6 +3740,27 @@ DEFPY (clear_evpn_dup_addr,
 	return ret;
 }
 
+DEFPY_HIDDEN (evpn_accept_bgp_seq,
+              evpn_accept_bgp_seq_cmd,
+              "evpn accept-bgp-seq",
+              "EVPN\n"
+	      "Accept all sequence numbers from BGP\n")
+{
+	zebra_vxlan_set_accept_bgp_seq(true);
+	return CMD_SUCCESS;
+}
+
+DEFPY_HIDDEN (no_evpn_accept_bgp_seq,
+              no_evpn_accept_bgp_seq_cmd,
+              "no evpn accept-bgp-seq",
+              NO_STR
+              "EVPN\n"
+	      "Accept all sequence numbers from BGP\n")
+{
+	zebra_vxlan_set_accept_bgp_seq(false);
+	return CMD_SUCCESS;
+}
+
 /* Static ip route configuration write function. */
 static int zebra_ip_config(struct vty *vty)
 {
@@ -3944,6 +3965,9 @@ static int config_write_protocol(struct vty *vty)
 	zebra_evpn_mh_config_write(vty);
 
 	zebra_pbr_config_write(vty);
+
+	if (!zebra_vxlan_accept_bgp_seq())
+		vty_out(vty, "no evpn accept-bgp-seq\n");
 
 	/* Include nexthop-group config */
 	if (!zebra_nhg_kernel_nexthops_enabled())
@@ -4582,6 +4606,8 @@ void zebra_vty_init(void)
 	install_element(VIEW_NODE, &show_evpn_neigh_vni_dad_cmd);
 	install_element(VIEW_NODE, &show_evpn_neigh_vni_all_dad_cmd);
 	install_element(ENABLE_NODE, &clear_evpn_dup_addr_cmd);
+	install_element(CONFIG_NODE, &evpn_accept_bgp_seq_cmd);
+	install_element(CONFIG_NODE, &no_evpn_accept_bgp_seq_cmd);
 
 	install_element(VIEW_NODE, &show_neigh_cmd);
 

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -69,6 +69,9 @@ DEFINE_HOOK(zebra_rmac_update,
 	     const char *reason),
 	    (rmac, zl3vni, delete, reason));
 
+/* config knobs */
+static bool accept_bgp_seq = true;
+
 /* static function declarations */
 static void zevpn_print_neigh_hash_all_evpn(struct hash_bucket *bucket,
 					    void **args);
@@ -6282,6 +6285,17 @@ static int zebra_evpn_cfg_clean_up(struct zserv *client)
 extern void zebra_vxlan_handle_result(struct zebra_dplane_ctx *ctx)
 {
 	return;
+}
+
+/* Config knob for accepting lower sequence numbers */
+void zebra_vxlan_set_accept_bgp_seq(bool set)
+{
+	accept_bgp_seq = set;
+}
+
+bool zebra_vxlan_accept_bgp_seq(void)
+{
+	return accept_bgp_seq;
 }
 
 /* Cleanup BGP EVPN configuration upon client disconnect */

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -6293,7 +6293,7 @@ void zebra_vxlan_set_accept_bgp_seq(bool set)
 	accept_bgp_seq = set;
 }
 
-bool zebra_vxlan_accept_bgp_seq(void)
+bool zebra_vxlan_get_accept_bgp_seq(void)
 {
 	return accept_bgp_seq;
 }

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -226,7 +226,7 @@ extern int zebra_vxlan_dp_network_mac_del(struct interface *ifp,
 					  vlanid_t vid);
 
 extern void zebra_vxlan_set_accept_bgp_seq(bool set);
-extern bool zebra_vxlan_accept_bgp_seq(void);
+extern bool zebra_vxlan_get_accept_bgp_seq(void);
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -225,6 +225,9 @@ extern int zebra_vxlan_dp_network_mac_del(struct interface *ifp,
 					  struct ethaddr *macaddr,
 					  vlanid_t vid);
 
+extern void zebra_vxlan_set_accept_bgp_seq(bool set);
+extern bool zebra_vxlan_accept_bgp_seq(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Changes here are to address various issues seen in Extended Mac Mobility handling.

The brunt of the changes were reworking the BGP VNI table into two separate tables for type2 routes so that MAC and IP info can be deterministically determined. 

By separating the two we are able to run path selection across multiple MACs and IPs to more appropriately handle EMM events. A lot of code also changed around handling of various events now that these are in different tables.

Also, change zebra to always accept whatever it was handed by BGP for neigh/mac even if the seq is lower. During a mobility event is entirely possible to transition back to a lower seq number and we have to handle that. Zebra should not be making decisions on whether to install entries or not, that is a BGP decision and, with the rework, BGP can handle this.

Reference on how the MAC/IPs go into each table:



| Route Type | VNI IP-Route Table | VNI MAC-Route Table |
|------------|--------------------|---------------------|
| Remote MAC-IP | Yes | Yes |
| Remote MAC | No | Yes |
| Local MAC-IP | Yes | No |
| Local MAC | No | Yes |



The distinction for Local MAC-IP not going into the MAC table is necessary because we should not allow a local neigh to have multiple MACs, doesn't make sense.


New commands were added to cleanup the old command cli and support querying both tables:

```
show bgp vni ALL type ...
show bgp vni VNI type ...
```

The old (undocumented) command `show bgp l2vpn evpn route vni` will be deprecated later.

Fixes #9327, Fixes #10468