### PR TITLE
bgpd: cosmetic function address

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -592,7 +592,7 @@ static int bgp_rpki_module_init(void)
 
 	hook_register(bgp_rpki_prefix_status, rpki_validate_prefix);
 	hook_register(frr_late_init, bgp_rpki_init);
-	hook_register(frr_early_fini, &bgp_rpki_fini);
+	hook_register(frr_early_fini, bgp_rpki_fini);
 
 	return 0;
 }


### PR DESCRIPTION
No mistake, just to unify style for the parameter of function address - remove ampersand.  In current code, only this one place of `hook_register()`s needs to be made.