### PR TITLE
tests: nhid is interfering with pattern match

### DIFF
--- a/tests/topotests/bgp_gr_restart_retain_routes/r2/zebra.conf
+++ b/tests/topotests/bgp_gr_restart_retain_routes/r2/zebra.conf
@@ -1,3 +1,4 @@
+no zebra nexthop kernel enable
 !
 interface r2-eth0
  ip address 192.168.255.2/24


### PR DESCRIPTION
The bgp_gr_restart_retain_routes test is looking for specific output that does not include the routes nexthop id:

    def _bgp_check_kernel_retained_routes():
        output = (
            r2.cmd("ip route show 172.16.255.1/32 proto bgp dev r2-eth0")
            .replace("\n", "")
            .rstrip()
        )
        expected = "172.16.255.1 via 192.168.255.1 metric 20"
        diff = topotest.get_textdiff(
            output, expected, "Actual IP Routing Table", "Expected IP RoutingTable"
        )
        if diff:
            return False
        return True

While the output includes nexthop group id's now:

root@r2:# ip route show 172.16.255.1 proto bgp dev r2-eth0 172.16.255.1 nhid 8 via 192.168.255.1 metric 20

Let's just mark r2 as not to use nexthop groups for installation and this test issue will go away.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>