### PR TITLE
bgpd: fix display bgp large-community exact-match

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12196,8 +12196,10 @@ DEFUN (show_ip_bgp_large_community,
 		return CMD_WARNING;
 
 	if (argv_find(argv, argc, "AA:BB:CC", &idx)) {
-		if (argv_find(argv, argc, "exact-match", &idx))
+		if (argv_find(argv, argc, "exact-match", &idx)) {
+			argc--;
 			exact_match = 1;
+		}
 		return bgp_show_lcommunity(vty, bgp, argc, argv,
 					exact_match, afi, safi, uj);
 	} else


### PR DESCRIPTION
Before patch:
frr# show bgp large-community 1:1:1 exact-match
% Large-community malformed

After patch:
frr# show bgp large-community 1:1:1 exact-match

Signed-off-by: Dmitrii Turlupov <dturlupov@factor-ts.ru>