### PR TITLE
bgpd: fix "no match rpki" in route-map

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -1688,7 +1688,7 @@ DEFUN_YANG (no_match_rpki,
 	const char *xpath =
 		"./match-condition[condition='frr-bgp-route-map:rpki']";
 
-	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 	return nb_cli_apply_changes(vty, NULL);
 }
 


### PR DESCRIPTION
With this fix, make `no match rpki` in a route-map actually remove the node in the candidate configuration instead of creating it.

Signed-off-by: Alexander Chernavin <achernavin@netgate.com>