### PR TITLE
pim6d: Fix RpAddress in "show ipv6 pim bsm-database"

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -963,7 +963,7 @@ static void pim_show_bsm_db(struct pim_instance *pim, struct vty *vty, bool uj)
 
 				bsm_rpinfo = (struct bsmmsg_rpinfo *)buf;
 				/* unaligned, again */
-				memcpy(&rp_addr, &bsm_rpinfo->rpaddr,
+				memcpy(&rp_addr, &bsm_rpinfo->rpaddr.addr,
 				       sizeof(rp_addr));
 
 				buf += sizeof(struct bsmmsg_rpinfo);


### PR DESCRIPTION
RpAddress is showing wrong value in
"show ipv6 pim bsm-database" cli. This is fixed now.

Issue: #12089

Signed-off-by: Sarita Patra <saritap@vmware.com>