### PR TITLE
pimd, pim6d: Don't configure link-local, Multicast, Unspecified address as RP

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -566,6 +566,18 @@ int pim_process_rp_cmd(struct vty *vty, const char *rp_str,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
+	if (pim_addr_is_any(rp_addr) || pim_addr_is_multicast(rp_addr)) {
+		vty_out(vty, "%% Bad RP address specified: %s\n", rp_str);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+#if PIM_IPV == 6
+	if (IN6_IS_ADDR_LINKLOCAL(&rp_addr)) {
+		vty_out(vty, "%% Bad RP address specified: %s\n", rp_str);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+#endif
+
 	vrfname = pim_cli_get_vrf_name(vty);
 	if (vrfname == NULL)
 		return CMD_WARNING_CONFIG_FAILED;

--- a/pimd/pim_util.c
+++ b/pimd/pim_util.c
@@ -166,3 +166,15 @@ int pim_get_all_mcast_group(struct prefix *prefix)
 #endif
 	return 1;
 }
+
+bool pim_addr_is_multicast(pim_addr addr)
+{
+#if PIM_IPV == 4
+	if (IN_MULTICAST(addr.s_addr))
+		return true;
+#else
+	if (IN6_IS_ADDR_MULTICAST(&addr))
+		return true;
+#endif
+	return false;
+}

--- a/pimd/pim_util.h
+++ b/pimd/pim_util.h
@@ -37,4 +37,5 @@ int pim_is_group_224_0_0_0_24(struct in_addr group_addr);
 int pim_is_group_224_4(struct in_addr group_addr);
 bool pim_is_group_filtered(struct pim_interface *pim_ifp, pim_addr *grp);
 int pim_get_all_mcast_group(struct prefix *prefix);
+bool pim_addr_is_multicast(pim_addr addr);
 #endif /* PIM_UTIL_H */


### PR DESCRIPTION
pimd, pim6d: Don't configure link-local, Multicast, Unspecified address as RP

Problem:

frr(config)# do show ipv6 pim interface
 Interface  State  Address                   PIM Nbrs  PIM DR  FHR  IfChannels
 ens192     up     fe80::250:56ff:feb7:3619  0         local   0    1

Configure ens192 interface link-local address as RP.
frr(config)# ipv6 pim rp fe80::250:56ff:feb7:3619
No Path to RP address specified: fe80::250:56ff:feb7:3619

frr(config)# do show ipv6 pim rp-info
 RP address                group/prefix-list  OIF      I am RP  Source  Group-Type
 fe80::250:56ff:feb7:3619  ff00::/8           Unknown  yes      Static  ASM

Fix:

RP should not be link-local, multicast and unspecified address.

Fixes: #12095 

Signed-off-by: Sarita Patra <saritap@vmware.com>