### PR TITLE
pimd, pim6d: Don't track nexthop for RP 0.0.0.0 & 0::0

### DIFF
--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -1066,16 +1066,20 @@ struct pim_rpf *pim_rp_g(struct pim_instance *pim, pim_addr group)
 	if (rp_info) {
 		pim_addr nht_p;
 
-		/* Register addr with Zebra NHT */
-		nht_p = rp_info->rp.rpf_addr;
-		if (PIM_DEBUG_PIM_NHT_RP)
-			zlog_debug(
-				"%s: NHT Register RP addr %pPA grp %pFX with Zebra",
-				__func__, &nht_p, &rp_info->group);
-		pim_find_or_track_nexthop(pim, nht_p, NULL, rp_info, NULL);
-		pim_rpf_set_refresh_time(pim);
-		(void)pim_ecmp_nexthop_lookup(pim, &rp_info->rp.source_nexthop,
-					      nht_p, &rp_info->group, 1);
+		if (!pim_addr_is_any(rp_info->rp.rpf_addr)) {
+			/* Register addr with Zebra NHT */
+			nht_p = rp_info->rp.rpf_addr;
+			if (PIM_DEBUG_PIM_NHT_RP)
+				zlog_debug(
+					"%s: NHT Register RP addr %pPA grp %pFX with Zebra",
+					__func__, &nht_p, &rp_info->group);
+			pim_find_or_track_nexthop(pim, nht_p, NULL, rp_info,
+						  NULL);
+			pim_rpf_set_refresh_time(pim);
+			(void)pim_ecmp_nexthop_lookup(
+				pim, &rp_info->rp.source_nexthop, nht_p,
+				&rp_info->group, 1);
+		}
 		return (&rp_info->rp);
 	}
 


### PR DESCRIPTION
Topology:
FHR----Source

Problem:
When FHR receives multicast traffic, there is no RP configured, PIMD does NHT register for RP address 0.0.0.0 and group 224.0.0.0/4 PIM6D does NHT register for RP address 0::0 and group FF00::0/8

frr# show ip pim nexthop
Number of registered addresses: 1
Address         Interface        Nexthop

frr# show ipv6 pim nexthop
Number of registered addresses: 1
Address         Interface        Nexthop


Fix:
Dont track nexthop for RP 0.0.0.0 & 0::0.

issue: #12104

Signed-off-by: Sarita Patra <saritap@vmware.com>