### PR TITLE
bgpd: Don't check for `NULL` when removing SRv6 SIDs

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -298,7 +298,6 @@ static int bgp_srv6_locator_unset(struct bgp *bgp)
 	struct srv6_locator_chunk *chunk;
 	struct bgp_srv6_function *func;
 	struct bgp *bgp_vrf;
-	struct in6_addr *tovpn_sid;
 
 	/* release chunk notification via ZAPI */
 	ret = bgp_zebra_srv6_manager_release_locator_chunk(
@@ -324,16 +323,12 @@ static int bgp_srv6_locator_unset(struct bgp *bgp)
 			continue;
 
 		/* refresh vpnv4 tovpn_sid */
-		tovpn_sid = bgp_vrf->vpn_policy[AFI_IP].tovpn_sid;
-		if (tovpn_sid)
-			XFREE(MTYPE_BGP_SRV6_SID,
-			      bgp_vrf->vpn_policy[AFI_IP].tovpn_sid);
+		XFREE(MTYPE_BGP_SRV6_SID,
+		      bgp_vrf->vpn_policy[AFI_IP].tovpn_sid);
 
 		/* refresh vpnv6 tovpn_sid */
-		tovpn_sid = bgp_vrf->vpn_policy[AFI_IP6].tovpn_sid;
-		if (tovpn_sid)
-			XFREE(MTYPE_BGP_SRV6_SID,
-			      bgp_vrf->vpn_policy[AFI_IP6].tovpn_sid);
+		XFREE(MTYPE_BGP_SRV6_SID,
+		      bgp_vrf->vpn_policy[AFI_IP6].tovpn_sid);
 	}
 
 	/* update vpn bgp processes */


### PR DESCRIPTION
When an SRv6 locator is unset, all the SRv6 SIDs allocated from the locator are removed. Before freeing the memory allocated for an SRv6 SID, we check if the pointer to the SID is `NULL`.

However, checking for `NULL` before freeing memory is useless.

This PR aims to improve the code's readability by removing the useless `NULL` checks.

Signed-off-by: Carmine Scarpitta <carmine.scarpitta@uniroma2.it>