### PR TITLE
snapcraft: fix staging libssh on non-x86 arches

### DIFF
--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -272,7 +272,7 @@ parts:
            - zlib1g
         prime:
            - lib/librtr.so*
-           - usr/lib/x86_64-linux-gnu/libssh.so*
+           - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libssh.so*
         source: https://github.com/rtrlib/rtrlib.git
         source-type: git
         source-tag: v0.8.0


### PR DESCRIPTION
It looks like frr gets built and published to snapcraft.io for a bunch of different architectures, but unfortunately on those other than x86, libssh.so doesn't get primed effectively, so on arm64, for instance, you end up with errors like 

`frr.bgpd[59989]: frr_init: loader error: dlopen(/snap/frr/x1/lib/frr/modules/bgpd_rpki.so): libssh.so.4: cannot open shared object file: No such file or directory` 

This tweak should make sure the .so file gets included on all architectures.