### PR TITLE
github: Add `conflicts`/`no_conflicts` labels for PRs

### DIFF
--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -1,0 +1,21 @@
+name: Add a conflict label is PR needs to rebase
+
+on:
+  push:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  conflicts:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check if PRs need a rebase (have some conflicts)
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: "conflicts"
+          removeOnDirtyLabel: "no_conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."


### PR DESCRIPTION
Just to quickly identify which PRs needs attention on rebasing.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>