### PR TITLE
lib,zebra,ospf: link-params are not flushed after "no enable"

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -1095,13 +1095,15 @@ const char *if_link_type_str(enum zebra_link_type llt)
 
 struct if_link_params *if_link_params_get(struct interface *ifp)
 {
+	return ifp->link_params;
+}
+
+struct if_link_params *if_link_params_enable(struct interface *ifp)
+{
+	struct if_link_params *iflp;
 	int i;
 
-	if (ifp->link_params != NULL)
-		return ifp->link_params;
-
-	struct if_link_params *iflp =
-		XCALLOC(MTYPE_IF_LINK_PARAMS, sizeof(struct if_link_params));
+	iflp = if_link_params_init(ifp);
 
 	/* Compute default bandwidth based on interface */
 	iflp->default_bw =
@@ -1124,6 +1126,20 @@ struct if_link_params *if_link_params_get(struct interface *ifp)
 	}
 
 	/* Finally attach newly created Link Parameters */
+	ifp->link_params = iflp;
+
+	return iflp;
+}
+
+struct if_link_params *if_link_params_init(struct interface *ifp)
+{
+	struct if_link_params *iflp = if_link_params_get(ifp);
+
+	if (iflp)
+		return iflp;
+
+	iflp = XCALLOC(MTYPE_IF_LINK_PARAMS, sizeof(struct if_link_params));
+
 	ifp->link_params = iflp;
 
 	return iflp;

--- a/lib/if.h
+++ b/lib/if.h
@@ -588,6 +588,8 @@ struct connected *connected_get_linklocal(struct interface *ifp);
 
 /* link parameters */
 struct if_link_params *if_link_params_get(struct interface *);
+struct if_link_params *if_link_params_enable(struct interface *ifp);
+struct if_link_params *if_link_params_init(struct interface *ifp);
 void if_link_params_free(struct interface *);
 
 /* Northbound. */

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -3279,14 +3279,8 @@ DEFUN (link_params_enable,
 			"Link-params: enable TE link parameters on interface %s",
 			ifp->name);
 
-	if (!if_link_params_get(ifp)) {
-		if (IS_ZEBRA_DEBUG_EVENT || IS_ZEBRA_DEBUG_MPLS)
-			zlog_debug(
-				"Link-params: failed to init TE link parameters  %s",
-				ifp->name);
-
-		return CMD_WARNING_CONFIG_FAILED;
-	}
+	if (!if_link_params_get(ifp))
+		if_link_params_enable(ifp);
 
 	/* force protocols to update LINK STATE due to parameters change */
 	if (if_is_operative(ifp))
@@ -3330,6 +3324,9 @@ DEFUN (link_params_metric,
 
 	metric = strtoul(argv[idx_number]->arg, NULL, 10);
 
+	if (!iflp)
+		iflp = if_link_params_enable(ifp);
+
 	/* Update TE metric if needed */
 	link_param_cmd_set_uint32(ifp, &iflp->te_metric, LP_TE_METRIC, metric);
 
@@ -3370,16 +3367,19 @@ DEFUN (link_params_maxbw,
 
 	/* Check that Maximum bandwidth is not lower than other bandwidth
 	 * parameters */
-	if ((bw <= iflp->max_rsv_bw) || (bw <= iflp->unrsv_bw[0])
-	    || (bw <= iflp->unrsv_bw[1]) || (bw <= iflp->unrsv_bw[2])
-	    || (bw <= iflp->unrsv_bw[3]) || (bw <= iflp->unrsv_bw[4])
-	    || (bw <= iflp->unrsv_bw[5]) || (bw <= iflp->unrsv_bw[6])
-	    || (bw <= iflp->unrsv_bw[7]) || (bw <= iflp->ava_bw)
-	    || (bw <= iflp->res_bw) || (bw <= iflp->use_bw)) {
+	if (iflp && ((bw <= iflp->max_rsv_bw) || (bw <= iflp->unrsv_bw[0]) ||
+		     (bw <= iflp->unrsv_bw[1]) || (bw <= iflp->unrsv_bw[2]) ||
+		     (bw <= iflp->unrsv_bw[3]) || (bw <= iflp->unrsv_bw[4]) ||
+		     (bw <= iflp->unrsv_bw[5]) || (bw <= iflp->unrsv_bw[6]) ||
+		     (bw <= iflp->unrsv_bw[7]) || (bw <= iflp->ava_bw) ||
+		     (bw <= iflp->res_bw) || (bw <= iflp->use_bw))) {
 		vty_out(vty,
 			"Maximum Bandwidth could not be lower than others bandwidth\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
+
+	if (!iflp)
+		iflp = if_link_params_enable(ifp);
 
 	/* Update Maximum Bandwidth if needed */
 	link_param_cmd_set_float(ifp, &iflp->max_bw, LP_MAX_BW, bw);
@@ -3406,12 +3406,15 @@ DEFUN (link_params_max_rsv_bw,
 
 	/* Check that bandwidth is not greater than maximum bandwidth parameter
 	 */
-	if (bw > iflp->max_bw) {
+	if (iflp && bw > iflp->max_bw) {
 		vty_out(vty,
 			"Maximum Reservable Bandwidth could not be greater than Maximum Bandwidth (%g)\n",
 			iflp->max_bw);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
+
+	if (!iflp)
+		iflp = if_link_params_enable(ifp);
 
 	/* Update Maximum Reservable Bandwidth if needed */
 	link_param_cmd_set_float(ifp, &iflp->max_rsv_bw, LP_MAX_RSV_BW, bw);
@@ -3448,12 +3451,15 @@ DEFUN (link_params_unrsv_bw,
 
 	/* Check that bandwidth is not greater than maximum bandwidth parameter
 	 */
-	if (bw > iflp->max_bw) {
+	if (iflp && bw > iflp->max_bw) {
 		vty_out(vty,
 			"UnReserved Bandwidth could not be greater than Maximum Bandwidth (%g)\n",
 			iflp->max_bw);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
+
+	if (!iflp)
+		iflp = if_link_params_enable(ifp);
 
 	/* Update Unreserved Bandwidth if needed */
 	link_param_cmd_set_float(ifp, &iflp->unrsv_bw[priority], LP_UNRSV_BW,
@@ -3478,6 +3484,9 @@ DEFUN (link_params_admin_grp,
 			safe_strerror(errno));
 		return CMD_WARNING_CONFIG_FAILED;
 	}
+
+	if (!iflp)
+		iflp = if_link_params_enable(ifp);
 
 	/* Update Administrative Group if needed */
 	link_param_cmd_set_uint32(ifp, &iflp->admin_grp, LP_ADM_GRP, value);
@@ -3521,6 +3530,9 @@ DEFUN (link_params_inter_as,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
+	if (!iflp)
+		iflp = if_link_params_enable(ifp);
+
 	as = strtoul(argv[idx_number]->arg, NULL, 10);
 
 	/* Update Remote IP and Remote AS fields if needed */
@@ -3547,6 +3559,9 @@ DEFUN (no_link_params_inter_as,
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct if_link_params *iflp = if_link_params_get(ifp);
+
+	if (!iflp)
+		return CMD_SUCCESS;
 
 	/* Reset Remote IP and AS neighbor */
 	iflp->rmt_as = 0;
@@ -3595,13 +3610,17 @@ DEFUN (link_params_delay,
 		 * Therefore, it is also allowed that the average
 		 * delay be equal to the min delay or max delay.
 		 */
-		if (IS_PARAM_SET(iflp, LP_MM_DELAY)
-		    && (delay < iflp->min_delay || delay > iflp->max_delay)) {
+		if (iflp && IS_PARAM_SET(iflp, LP_MM_DELAY) &&
+		    (delay < iflp->min_delay || delay > iflp->max_delay)) {
 			vty_out(vty,
 				"Average delay should be in range Min (%d) - Max (%d) delay\n",
 				iflp->min_delay, iflp->max_delay);
 			return CMD_WARNING_CONFIG_FAILED;
 		}
+
+		if (!iflp)
+			iflp = if_link_params_enable(ifp);
+
 		/* Update delay if value is not set or change */
 		if (IS_PARAM_UNSET(iflp, LP_DELAY) || iflp->av_delay != delay) {
 			iflp->av_delay = delay;
@@ -3626,6 +3645,10 @@ DEFUN (link_params_delay,
 				low, high);
 			return CMD_WARNING_CONFIG_FAILED;
 		}
+
+		if (!iflp)
+			iflp = if_link_params_enable(ifp);
+
 		/* Update Delays if needed */
 		if (IS_PARAM_UNSET(iflp, LP_DELAY)
 		    || IS_PARAM_UNSET(iflp, LP_MM_DELAY)
@@ -3656,6 +3679,9 @@ DEFUN (no_link_params_delay,
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct if_link_params *iflp = if_link_params_get(ifp);
 
+	if (!iflp)
+		return CMD_SUCCESS;
+
 	/* Unset Delays */
 	iflp->av_delay = 0;
 	UNSET_PARAM(iflp, LP_DELAY);
@@ -3682,6 +3708,9 @@ DEFUN (link_params_delay_var,
 	uint32_t value;
 
 	value = strtoul(argv[idx_number]->arg, NULL, 10);
+
+	if (!iflp)
+		iflp = if_link_params_enable(ifp);
 
 	/* Update Delay Variation if needed */
 	link_param_cmd_set_uint32(ifp, &iflp->delay_var, LP_DELAY_VAR, value);
@@ -3723,6 +3752,9 @@ DEFUN (link_params_pkt_loss,
 	if (fval > MAX_PKT_LOSS)
 		fval = MAX_PKT_LOSS;
 
+	if (!iflp)
+		iflp = if_link_params_enable(ifp);
+
 	/* Update Packet Loss if needed */
 	link_param_cmd_set_float(ifp, &iflp->pkt_loss, LP_PKT_LOSS, fval);
 
@@ -3762,12 +3794,15 @@ DEFUN (link_params_res_bw,
 
 	/* Check that bandwidth is not greater than maximum bandwidth parameter
 	 */
-	if (bw > iflp->max_bw) {
+	if (iflp && bw > iflp->max_bw) {
 		vty_out(vty,
 			"Residual Bandwidth could not be greater than Maximum Bandwidth (%g)\n",
 			iflp->max_bw);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
+
+	if (!iflp)
+		iflp = if_link_params_enable(ifp);
 
 	/* Update Residual Bandwidth if needed */
 	link_param_cmd_set_float(ifp, &iflp->res_bw, LP_RES_BW, bw);
@@ -3808,12 +3843,15 @@ DEFUN (link_params_ava_bw,
 
 	/* Check that bandwidth is not greater than maximum bandwidth parameter
 	 */
-	if (bw > iflp->max_bw) {
+	if (iflp && bw > iflp->max_bw) {
 		vty_out(vty,
 			"Available Bandwidth could not be greater than Maximum Bandwidth (%g)\n",
 			iflp->max_bw);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
+
+	if (!iflp)
+		iflp = if_link_params_enable(ifp);
 
 	/* Update Residual Bandwidth if needed */
 	link_param_cmd_set_float(ifp, &iflp->ava_bw, LP_AVA_BW, bw);
@@ -3854,12 +3892,15 @@ DEFUN (link_params_use_bw,
 
 	/* Check that bandwidth is not greater than maximum bandwidth parameter
 	 */
-	if (bw > iflp->max_bw) {
+	if (iflp && bw > iflp->max_bw) {
 		vty_out(vty,
 			"Utilised Bandwidth could not be greater than Maximum Bandwidth (%g)\n",
 			iflp->max_bw);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
+
+	if (!iflp)
+		iflp = if_link_params_enable(ifp);
 
 	/* Update Utilized Bandwidth if needed */
 	link_param_cmd_set_float(ifp, &iflp->use_bw, LP_USE_BW, bw);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -232,11 +232,6 @@ int zsend_interface_link_params(struct zserv *client, struct interface *ifp)
 {
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
-	if (!ifp->link_params) {
-		stream_free(s);
-		return 0;
-	}
-
 	zclient_create_header(s, ZEBRA_INTERFACE_LINK_PARAMS, ifp->vrf->vrf_id);
 
 	/* Add Interface Index */


### PR DESCRIPTION
Daemons like isisd continue to use the previous after they are unset
from zebra.

For example,
>r0# sh run zebra
> (...)
> interface eth-rt1
>  link-params
>   enable
>   metric 100
>  exit-link-params
> r0# conf
> r0(config)# interface eth-rt1
> r0(config-if)#  link-params
> r0(config-link-params)#   no enable

After "no enable", "sh run zebra" displays no more link-params context.

The "no enable" causes the release of the "link_params" pointer within
the "interface" structure. The zebra function to update daemons with
a ZEBRA_INTERFACE_LINK_PARAMS zapi message is called but the function
returns without doing anything because the "link_params" pointer is
NULL.

"enable" means that the traffic engineering parameters are set. Daemons
consider "enable" is set when the "link_params" pointer is set.
Protocols can do some traffic engineering specific actions when only
the "enable" option is set in the "link-params" section. Note that
setting another option like "metric" sets the "link_params" pointer and
then implicitly set the "enable" option.

Remove the faulty return that avoids sending the
ZEBRA_INTERFACE_LINK_PARAMS message to daemons. If the pointer is null,
send only null value in the zapi so that the daemons can reset all the
link_params value. Add a "enabled" boolean and update the
HAS_LINK_PARAMS macro to distinct the case where "link-params" has
only the "enable" option from the case where "link-params" is not
present ("no enable").

Fixes: 16f1b9ee29 ("Update Traffic Engineering Support for OSPFD")
Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>