### PR TITLE
staticd: Add metric for static routes

### DIFF
--- a/doc/user/static.rst
+++ b/doc/user/static.rst
@@ -35,21 +35,21 @@ Static Route Commands
 Static routing is a very fundamental feature of routing technology. It defines
 a static prefix and gateway, with several possible forms.
 
-.. clicmd:: ip route NETWORK GATEWAY [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK GATEWAY [DISTANCE] [metric METRIC] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ip route NETWORK IFNAME [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK IFNAME [DISTANCE] [metric METRIC] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ip route NETWORK GATEWAY IFNAME [DISTANCE] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK GATEWAY IFNAME [DISTANCE] [metric METRIC] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ip route NETWORK (Null0|blackhole|reject) [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK (Null0|blackhole|reject) [DISTANCE] [metric METRIC] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY [DISTANCE] [metric METRIC] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] IFNAME [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] IFNAME [DISTANCE] [metric METRIC] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY IFNAME [DISTANCE] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY IFNAME [DISTANCE] [metric METRIC] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] (Null0|blackhole|reject) [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] (Null0|blackhole|reject) [DISTANCE] [metric METRIC] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
    NETWORK is destination prefix with a valid v4 or v6 network based upon
    initial form of the command.

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -539,6 +539,12 @@ struct zapi_route {
  * offload situation.
  */
 #define ZEBRA_FLAG_OFFLOAD_FAILED     0x200
+/*
+ * This flag tells Zebra that it should treat the metric passed
+ * down as an additional discriminator for route selection of the
+ * route entry.  This mainly is used for backup static routes.
+ */
+#define ZEBRA_FLAG_RR_USE_METRIC      0x400
 
 	/* The older XXX_MESSAGE flags live here */
 	uint32_t message;

--- a/staticd/static_nb.h
+++ b/staticd/static_nb.h
@@ -126,7 +126,7 @@ int routing_control_plane_protocols_name_validate(
 	"/frr-routing:routing/control-plane-protocols/"                        \
 	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"              \
 	"frr-staticd:staticd/route-list[prefix='%s'][afi-safi='%s']/"          \
-	"path-list[table-id='%u'][distance='%u']"
+	"path-list[table-id='%u'][distance='%u'][metric='%u']"
 
 #define FRR_STATIC_ROUTE_INFO_KEY_NO_DISTANCE_XPATH                            \
 	"/frr-routing:routing/control-plane-protocols/"                        \
@@ -157,7 +157,8 @@ int routing_control_plane_protocols_name_validate(
 	"/frr-routing:routing/control-plane-protocols/"                        \
 	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"              \
 	"frr-staticd:staticd/route-list[prefix='%s'][afi-safi='%s']/"          \
-	"src-list[src-prefix='%s']/path-list[table-id='%u'][distance='%u']"
+	"src-list[src-prefix='%s']/"                                           \
+	"path-list[table-id='%u'][distance='%u'][metric='%u']"
 
 #define FRR_S_ROUTE_SRC_INFO_KEY_NO_DISTANCE_XPATH                             \
 	"/frr-routing:routing/control-plane-protocols/"                        \

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -40,6 +40,7 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 	const struct lyd_node *vrf_dnode;
 	const char *vrf;
 	uint8_t distance;
+	uint32_t metric;
 	uint32_t table_id;
 
 	switch (args->event) {
@@ -69,8 +70,9 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 	case NB_EV_APPLY:
 		rn = nb_running_get_entry(args->dnode, NULL, true);
 		distance = yang_dnode_get_uint8(args->dnode, "./distance");
+		metric = yang_dnode_get_uint32(args->dnode, "./metric");
 		table_id = yang_dnode_get_uint32(args->dnode, "./table-id");
-		pn = static_add_path(rn, table_id, distance);
+		pn = static_add_path(rn, table_id, distance, metric);
 		nb_running_set_entry(args->dnode, pn);
 	}
 

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -217,7 +217,7 @@ bool static_add_nexthop_validate(const char *nh_vrf_name,
 }
 
 struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
-				    uint8_t distance)
+				    uint8_t distance, uint32_t metric)
 {
 	struct static_path *pn;
 	struct static_route_info *si;
@@ -229,6 +229,7 @@ struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
 
 	pn->rn = rn;
 	pn->distance = distance;
+	pn->metric = metric;
 	pn->table_id = table_id;
 	static_nexthop_list_init(&(pn->nexthop_list));
 

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -95,6 +95,8 @@ struct static_path {
 	struct static_path_list_item list;
 	/* Administrative distance. */
 	uint8_t distance;
+	/* Metric. */
+	uint32_t metric;
 	/* Tag */
 	route_tag_t tag;
 	/* Table-id */
@@ -192,7 +194,8 @@ extern struct route_node *static_add_route(afi_t afi, safi_t safi,
 extern void static_del_route(struct route_node *rn);
 
 extern struct static_path *static_add_path(struct route_node *rn,
-					   uint32_t table_id, uint8_t distance);
+					   uint32_t table_id, uint8_t distance,
+					   uint32_t metric);
 extern void static_del_path(struct static_path *pn);
 
 extern void static_get_nh_type(enum static_nh_type stype, char *type,

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -418,11 +418,16 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
 		memcpy(&api.src_prefix, src_pp, sizeof(api.src_prefix));
 	}
 	SET_FLAG(api.flags, ZEBRA_FLAG_RR_USE_DISTANCE);
+	SET_FLAG(api.flags, ZEBRA_FLAG_RR_USE_METRIC);
 	SET_FLAG(api.flags, ZEBRA_FLAG_ALLOW_RECURSION);
 	SET_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP);
 	if (pn->distance) {
 		SET_FLAG(api.message, ZAPI_MESSAGE_DISTANCE);
 		api.distance = pn->distance;
+	}
+	if (pn->metric) {
+		SET_FLAG(api.message, ZAPI_MESSAGE_METRIC);
+		api.metric = pn->metric;
 	}
 	if (pn->tag) {
 		SET_FLAG(api.message, ZAPI_MESSAGE_TAG);

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/ce1/ipv6_rib.json
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/ce1/ipv6_rib.json
@@ -12,7 +12,7 @@
       "installed": true,
       "table": 254,
       "internalStatus": 16,
-      "internalFlags": 73,
+      "internalFlags": 1097,
       "internalNextHopNum": 1,
       "internalNextHopActiveNum": 1,
       "nexthops": [

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/ce2/ipv6_rib.json
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/ce2/ipv6_rib.json
@@ -12,7 +12,7 @@
       "installed": true,
       "table": 254,
       "internalStatus": 16,
-      "internalFlags": 73,
+      "internalFlags": 1097,
       "internalNextHopNum": 1,
       "internalNextHopActiveNum": 1,
       "nexthops": [

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/ce3/ipv6_rib.json
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/ce3/ipv6_rib.json
@@ -12,7 +12,7 @@
       "installed": true,
       "table": 254,
       "internalStatus": 16,
-      "internalFlags": 73,
+      "internalFlags": 1097,
       "internalNextHopNum": 1,
       "internalNextHopActiveNum": 1,
       "nexthops": [

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/ce4/ipv6_rib.json
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/ce4/ipv6_rib.json
@@ -12,7 +12,7 @@
       "installed": true,
       "table": 254,
       "internalStatus": 16,
-      "internalFlags": 73,
+      "internalFlags": 1097,
       "internalNextHopNum": 1,
       "internalNextHopActiveNum": 1,
       "nexthops": [

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/ce5/ipv6_rib.json
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/ce5/ipv6_rib.json
@@ -12,7 +12,7 @@
       "installed": true,
       "table": 254,
       "internalStatus": 16,
-      "internalFlags": 73,
+      "internalFlags": 1097,
       "internalNextHopNum": 1,
       "internalNextHopActiveNum": 1,
       "nexthops": [

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/ce6/ipv6_rib.json
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/ce6/ipv6_rib.json
@@ -12,7 +12,7 @@
       "installed": true,
       "table": 254,
       "internalStatus": 16,
-      "internalFlags": 73,
+      "internalFlags": 1097,
       "internalNextHopNum": 1,
       "internalNextHopActiveNum": 1,
       "nexthops": [

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/ce1/ip_rib.json
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/ce1/ip_rib.json
@@ -12,7 +12,7 @@
       "installed": true,
       "table": 254,
       "internalStatus": 16,
-      "internalFlags": 73,
+      "internalFlags": 1097,
       "internalNextHopNum": 1,
       "internalNextHopActiveNum": 1,
       "nexthops": [

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/ce2/ip_rib.json
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/ce2/ip_rib.json
@@ -12,7 +12,7 @@
       "installed": true,
       "table": 254,
       "internalStatus": 16,
-      "internalFlags": 73,
+      "internalFlags": 1097,
       "internalNextHopNum": 1,
       "internalNextHopActiveNum": 1,
       "nexthops": [

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/ce3/ip_rib.json
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/ce3/ip_rib.json
@@ -12,7 +12,7 @@
       "installed": true,
       "table": 254,
       "internalStatus": 16,
-      "internalFlags": 73,
+      "internalFlags": 1097,
       "internalNextHopNum": 1,
       "internalNextHopActiveNum": 1,
       "nexthops": [

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/ce4/ip_rib.json
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/ce4/ip_rib.json
@@ -12,7 +12,7 @@
       "installed": true,
       "table": 254,
       "internalStatus": 16,
-      "internalFlags": 73,
+      "internalFlags": 1097,
       "internalNextHopNum": 1,
       "internalNextHopActiveNum": 1,
       "nexthops": [

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/ce5/ip_rib.json
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/ce5/ip_rib.json
@@ -12,7 +12,7 @@
       "installed": true,
       "table": 254,
       "internalStatus": 16,
-      "internalFlags": 73,
+      "internalFlags": 1097,
       "internalNextHopNum": 1,
       "internalNextHopActiveNum": 1,
       "nexthops": [

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/ce6/ip_rib.json
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/ce6/ip_rib.json
@@ -12,7 +12,7 @@
       "installed": true,
       "table": 254,
       "internalStatus": 16,
-      "internalFlags": 73,
+      "internalFlags": 1097,
       "internalNextHopNum": 1,
       "internalNextHopActiveNum": 1,
       "nexthops": [

--- a/tests/topotests/static_metric/r1/routes_1.json
+++ b/tests/topotests/static_metric/r1/routes_1.json
@@ -1,0 +1,81 @@
+{
+    "10.0.0.0/8": [
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "selected": true,
+            "destSelected": true,
+            "distance": 1,
+            "metric": 0,
+            "nexthops": [
+                {
+                    "ip": "192.168.1.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "distance": 1,
+            "metric": 10,
+            "nexthops": [
+                {
+                    "ip": "192.168.1.3",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                },
+                {
+                    "ip": "192.168.1.4",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "distance": 1,
+            "metric": 20,
+            "nexthops": [
+                {
+                    "ip": "192.168.1.6",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "distance": 1,
+            "metric": 30,
+            "nexthops": [
+                {
+                    "ip": "192.168.1.5",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "distance": 1,
+            "metric": 40,
+            "nexthops": [
+                {
+                    "unreachable": true,
+                    "blackhole": true,
+                    "active": true
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/static_metric/r1/routes_2.json
+++ b/tests/topotests/static_metric/r1/routes_2.json
@@ -1,0 +1,67 @@
+{
+    "10.0.0.0/8": [
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "selected": true,
+            "destSelected": true,
+            "distance": 1,
+            "metric": 10,
+            "nexthops": [
+                {
+                    "ip": "192.168.1.3",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                },
+                {
+                    "ip": "192.168.1.4",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "distance": 1,
+            "metric": 20,
+            "nexthops": [
+                {
+                    "ip": "192.168.1.6",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "distance": 1,
+            "metric": 30,
+            "nexthops": [
+                {
+                    "ip": "192.168.1.5",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "distance": 1,
+            "metric": 40,
+            "nexthops": [
+                {
+                    "unreachable": true,
+                    "blackhole": true,
+                    "active": true
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/static_metric/r1/routes_3.json
+++ b/tests/topotests/static_metric/r1/routes_3.json
@@ -1,0 +1,61 @@
+{
+    "10.0.0.0/8": [
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "selected": true,
+            "destSelected": true,
+            "distance": 1,
+            "metric": 10,
+            "nexthops": [
+                {
+                    "ip": "192.168.1.4",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "distance": 1,
+            "metric": 20,
+            "nexthops": [
+                {
+                    "ip": "192.168.1.6",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "distance": 1,
+            "metric": 30,
+            "nexthops": [
+                {
+                    "ip": "192.168.1.5",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "distance": 1,
+            "metric": 40,
+            "nexthops": [
+                {
+                    "unreachable": true,
+                    "blackhole": true,
+                    "active": true
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/static_metric/r1/routes_4.json
+++ b/tests/topotests/static_metric/r1/routes_4.json
@@ -1,0 +1,47 @@
+{
+    "10.0.0.0/8": [
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "selected": true,
+            "destSelected": true,
+            "distance": 1,
+            "metric": 20,
+            "nexthops": [
+                {
+                    "ip": "192.168.1.6",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "distance": 1,
+            "metric": 30,
+            "nexthops": [
+                {
+                    "ip": "192.168.1.5",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "distance": 1,
+            "metric": 40,
+            "nexthops": [
+                {
+                    "unreachable": true,
+                    "blackhole": true,
+                    "active": true
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/static_metric/r1/routes_5.json
+++ b/tests/topotests/static_metric/r1/routes_5.json
@@ -1,0 +1,33 @@
+{
+    "10.0.0.0/8": [
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "selected": true,
+            "destSelected": true,
+            "distance": 1,
+            "metric": 20,
+            "nexthops": [
+                {
+                    "ip": "192.168.1.6",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "distance": 1,
+            "metric": 40,
+            "nexthops": [
+                {
+                    "unreachable": true,
+                    "blackhole": true,
+                    "active": true
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/static_metric/r1/routes_6.json
+++ b/tests/topotests/static_metric/r1/routes_6.json
@@ -1,0 +1,19 @@
+{
+    "10.0.0.0/8": [
+        {
+            "prefix": "10.0.0.0/8",
+            "protocol": "static",
+            "selected": true,
+            "destSelected": true,
+            "distance": 1,
+            "metric": 40,
+            "nexthops": [
+                {
+                    "unreachable": true,
+                    "blackhole": true,
+                    "active": true
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/static_metric/r1/staticd.conf
+++ b/tests/topotests/static_metric/r1/staticd.conf
@@ -1,0 +1,6 @@
+ip route 10.0.0.0/8 192.168.1.2
+ip route 10.0.0.0/8 192.168.1.3 metric 10
+ip route 10.0.0.0/8 192.168.1.4 metric 10
+ip route 10.0.0.0/8 192.168.1.6 metric 20
+ip route 10.0.0.0/8 192.168.1.5 metric 30
+ip route 10.0.0.0/8 blackhole metric 40

--- a/tests/topotests/static_metric/r1/zebra.conf
+++ b/tests/topotests/static_metric/r1/zebra.conf
@@ -1,0 +1,2 @@
+interface r1-eth0
+  ip address 192.168.1.1/24

--- a/tests/topotests/static_metric/test_static_metric.py
+++ b/tests/topotests/static_metric/test_static_metric.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+#
+# Copyright (c) 2022
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+import os
+import sys
+import functools
+import pytest
+import json
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from lib.common_config import apply_raw_config
+
+def setup_module(mod):
+    topodef = {"s1": "r1"}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_config(TopoRouter.RD_ZEBRA, "zebra.conf")
+        router.load_config(TopoRouter.RD_STATIC, "staticd.conf")
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_static_metric():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def remove_route(nh):
+        cmd = "no ip route 10.0.0.0/8 {}".format(nh)
+        apply_raw_config(tgen, {"r1": {"raw_config": [cmd]}})
+
+    def test_func(n):
+        with open("{}/r1/routes_{}.json".format(CWD, n)) as f:
+            expected = json.load(f)
+        return functools.partial(
+            topotest.router_json_cmp,
+            r1,
+            "show ip route 10.0.0.0/8 json",
+            expected
+        )
+
+    _, result = topotest.run_and_expect(test_func(1), None, count=20, wait=0.5)
+    assert result is None, "static route mismatches"
+
+    for i in range(2, 7):
+        remove_route("192.168.1.{}".format(i))
+        _, result = topotest.run_and_expect(test_func(i), None, count=20,
+                                            wait=0.5)
+        assert result is None, "static route mismatches"
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-staticd.yang
+++ b/yang/frr-staticd.yang
@@ -63,7 +63,7 @@ module frr-staticd {
 
   grouping staticd-prefix-attributes {
     list path-list {
-      key "table-id distance";
+      key "table-id distance metric";
       leaf table-id {
         type uint32;
         description
@@ -74,6 +74,14 @@ module frr-staticd {
         type frr-rt:administrative-distance;
         description
           "Admin distance associated with this route.";
+      }
+
+      leaf metric{
+        type uint32 {
+          range "0..4294967295";
+        }
+        description
+          "Route metric.";
       }
 
       leaf tag {

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1558,7 +1558,9 @@ static bool rib_compare_routes(const struct route_entry *re1,
 	if (re1->instance != re2->instance)
 		return false;
 
-	if (re1->type == ZEBRA_ROUTE_KERNEL && re1->metric != re2->metric)
+	if ((CHECK_FLAG(re1->flags, ZEBRA_FLAG_RR_USE_METRIC) ||
+	     re1->type == ZEBRA_ROUTE_KERNEL) &&
+	    re1->metric != re2->metric)
 		return false;
 
 	if (CHECK_FLAG(re1->flags, ZEBRA_FLAG_RR_USE_DISTANCE) &&
@@ -2847,7 +2849,8 @@ static void process_subq_early_route_delete(struct zebra_early_route *ere)
 		    ere->re->distance != re->distance)
 			continue;
 
-		if (re->type == ZEBRA_ROUTE_KERNEL &&
+		if ((CHECK_FLAG(re->flags, ZEBRA_FLAG_RR_USE_METRIC) ||
+		     re->type == ZEBRA_ROUTE_KERNEL) &&
 		    re->metric != ere->re->metric)
 			continue;
 		if (re->type == ZEBRA_ROUTE_CONNECT && (rtnh = nh) &&


### PR DESCRIPTION
Add metric for static routes so that backup routes don't interfere with other routing protocols, as distance is mainly used by inter-protocol route selection.
For example, static routes with distance greater than 20 will lose to EBGP. If this is not desired, use metric instead.