### PR TITLE
pimd: Fix v4-over-v6 nexthop handling

### DIFF
--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -279,7 +279,7 @@ static int zclient_read_nexthop(struct pim_instance *pim,
 			 * secondary
 			 */
 			struct interface *ifp = if_lookup_by_index(
-				nexthop_tab[num_ifindex].ifindex,
+				nh_ifi,
 				nexthop_vrf_id);
 
 			if (!ifp)


### PR DESCRIPTION
In the current code, if_lookup_by_index()
is called for un-initialized ifindex value.
This will break v4-over-v6 nexthop handling feature.

This issue is introduced after #11098 PR.

Signed-off-by: Sarita Patra <saritap@vmware.com>