### PR TITLE
zebra: upon vrf deletion, no need to perform l3vni transition

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5430,16 +5430,13 @@ int zebra_vxlan_vrf_disable(struct zebra_vrf *zvrf)
 int zebra_vxlan_vrf_delete(struct zebra_vrf *zvrf)
 {
 	struct zebra_l3vni *zl3vni = NULL;
-	vni_t vni;
 
 	if (zvrf->l3vni)
 		zl3vni = zl3vni_lookup(zvrf->l3vni);
 	if (!zl3vni)
 		return 0;
 
-	vni = zl3vni->vni;
 	zl3vni_del(zl3vni);
-	zebra_vxlan_handle_vni_transition(zvrf, vni, 0);
 
 	return 0;
 }


### PR DESCRIPTION
The l3vni to l2vni transition on a given VNI belonging to a given VRF supposes that the evpn contexts for that VRF are still present. This is not the case here, as vrf_disable is already called, and zvrf->evpn_table is freed. Do not call the function 'zebra_vxlan_handle_vni_transition()' on that case, to avoid the following crashlog:

     Thread 1 (Thread 0x7fc2eb121e40 (LWP 11516)):
     #0  raise (sig=<optimized out>) at ../sysdeps/unix/sysv/linux/raise.c:50
     #1  0x00007fc2eb774a04 in core_handler (signo=11, siginfo=0x7fff26102830, context=0x7fff26102700) at /build/tools-build-framew
     #2  <signal handler called>
     #3  0x00007fc2eb716ffb in hash_get (hash=0x55af78ece860, data=0x7fff26102be0, alloc_func=0x55af76f52f60 <zebra_evpn_alloc>) at
     #4  0x000055af76f530f8 in zebra_evpn_add (vni=101) at /build/tools-build-framework/output/_packages/cp-routing/src/zebra/zebra
     #5  0x000055af76fb64c5 in zebra_vxlan_handle_vni_transition (zvrf=0x55af78ed0220, vni=101, add=0) at /build/tools-build-framew
     #6  0x000055af76fbd94f in zebra_vxlan_vrf_delete (zvrf=0x55af78ed0220) at /build/tools-build-framework/output/_packages/cp-rou
            zl3vni = 0x55af78fffb20
            vni = 101
     #7  0x000055af76fa13bb in zebra_vrf_delete (vrf=0x55af78ed0140) at /build/tools-build-framework/output/_packages/cp-routing/sr
     #8  0x00007fc2eb791330 in vrf_delete (vrf=0x55af78ed0140) at /build/tools-build-framework/output/_packages/cp-routing/src/lib/
     #9  0x00007fc2eb791b55 in vrf_terminate_single (vrf=0x55af78ed0140) at /build/tools-build-framework/output/_packages/cp-routin
     #10 0x00007fc2eb791c41 in vrf_terminate () at /build/tools-build-framework/output/_packages/cp-routing/src/lib/vrf.c:624
     #11 0x000055af76f1c8a6 in sigint () at /build/tools-build-framework/output/_packages/cp-routing/src/zebra/main.c:191
     #12 0x00007fc2eb774757 in quagga_sigevent_process () at /build/tools-build-framework/output/_packages/cp-routing/src/lib/sigev
     #13 0x00007fc2eb78cf9b in thread_fetch (m=0x55af78ccc3f0, fetch=0x7fff26102f20) at /build/tools-build-framework/output/_packag
     #14 0x00007fc2eb728e8c in frr_run (master=0x55af78ccc3f0) at /build/tools-build-framework/output/_packages/cp-routing/src/lib/
     #15 0x000055af76f1ce36 in main (argc=6, argv=0x7fff261031e8) at /build/tools-build-framework/output/_packages/cp-routing/src/z

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>