### PR TITLE
lib: fix the default TE bandwidth

### DIFF
--- a/lib/if.h
+++ b/lib/if.h
@@ -143,9 +143,13 @@ struct if_stats {
 #define TE_EXT_MASK             0x0FFFFFFF
 #define TE_EXT_ANORMAL          0x80000000
 #define LOSS_PRECISION          0.000003
+/* TE_MEGA_BIT and TE_BYTE are utilized to convert TE bandwidth */
 #define TE_MEGA_BIT             1000000
 #define TE_BYTE                 8
-#define DEFAULT_BANDWIDTH       10000
+/* Default TE bandwidth when no value in config.
+ * The value is in Mbps (will be multiplied by TE_BYTE)
+ */
+#define DEFAULT_BANDWIDTH 10
 #define MAX_CLASS_TYPE          8
 #define MAX_PKT_LOSS            50.331642
 

--- a/tests/topotests/cspf_topo1/r1/zebra.conf
+++ b/tests/topotests/cspf_topo1/r1/zebra.conf
@@ -10,6 +10,7 @@ interface r1-eth0
  link-params
   metric 20
   delay 10000
+  max-bw 10e+10
   ava-bw 1.25e+08
   enable
   exit-link-params

--- a/tests/topotests/cspf_topo1/r2/zebra.conf
+++ b/tests/topotests/cspf_topo1/r2/zebra.conf
@@ -37,6 +37,7 @@ interface r2-eth3
  link-params
   metric 25
   delay 25000
+  max-bw 10e+10
   use-bw 1.25e+8
   enable
   exit-link-params

--- a/tests/topotests/cspf_topo1/reference/sharp-ted.json
+++ b/tests/topotests/cspf_topo1/reference/sharp-ted.json
@@ -64,32 +64,32 @@
           "te-metric":10,
           "local-address-v6":"2001:db8:1::1:1",
           "remote-address-v6":"2001:db8:1::1:2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":20000
@@ -107,32 +107,32 @@
           "te-metric":10,
           "local-address-v6":"2001:db8:1::1:2",
           "remote-address-v6":"2001:db8:1::1:1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":20000
@@ -150,32 +150,32 @@
           "te-metric":40,
           "local-address-v6":"2001:db8:3::3:2",
           "remote-address-v6":"2001:db8:3::3:3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":40000
@@ -194,32 +194,32 @@
           "admin-group":32,
           "local-address-v6":"2001:db8:3::3:3",
           "remote-address-v6":"2001:db8:3::3:2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000
@@ -237,32 +237,32 @@
           "te-metric":10,
           "local-address-v6":"2001:db8:5::3:4",
           "remote-address-v6":"2001:db8:5::4:3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000
@@ -286,32 +286,32 @@
           "te-metric":10,
           "local-address-v6":"2001:db8:5::4:3",
           "remote-address-v6":"2001:db8:5::3:4",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000
@@ -329,32 +329,32 @@
           "te-metric":20,
           "local-address":"10.0.0.1",
           "remote-address":"10.0.0.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -373,32 +373,32 @@
           "te-metric":20,
           "local-address":"10.0.0.2",
           "remote-address":"10.0.0.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000
@@ -416,32 +416,32 @@
           "te-metric":10,
           "local-address":"10.0.1.1",
           "remote-address":"10.0.1.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":20000
@@ -459,32 +459,32 @@
           "te-metric":10,
           "local-address":"10.0.1.2",
           "remote-address":"10.0.1.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":20000
@@ -502,32 +502,32 @@
           "te-metric":40,
           "local-address":"10.0.3.2",
           "remote-address":"10.0.3.3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":40000
@@ -546,32 +546,32 @@
           "admin-group":32,
           "local-address":"10.0.3.3",
           "remote-address":"10.0.3.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000
@@ -589,32 +589,32 @@
           "te-metric":25,
           "local-address":"10.0.4.2",
           "remote-address":"10.0.4.4",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000,
@@ -633,32 +633,32 @@
           "te-metric":40,
           "local-address":"10.0.4.4",
           "remote-address":"10.0.4.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":40000

--- a/tests/topotests/cspf_topo1/test_cspf_topo1.py
+++ b/tests/topotests/cspf_topo1/test_cspf_topo1.py
@@ -169,13 +169,19 @@ def compare_cspf_output(tgen, rname, fileref, src, dst, cost, bw=""):
 
     filename = "{}/reference/{}".format(CWD, fileref)
     expected = open(filename).read()
-    command = "show sharp cspf source {} destination {} {} {}".format(src, dst, cost, bw)
+    command = "show sharp cspf source {} destination {} {} {}".format(
+        src, dst, cost, bw
+    )
 
     # Run test function until we get an result. Wait at most 60 seconds.
-    test_func = partial(topotest.router_output_cmp, tgen.gears[rname], command, expected)
+    test_func = partial(
+        topotest.router_output_cmp, tgen.gears[rname], command, expected
+    )
     result, diff = topotest.run_and_expect(test_func, "", count=2, wait=2)
-    assert result, "CSPF output mismatches the expected result on {}:\n{}".format(rname, diff)
-    
+    assert result, "CSPF output mismatches the expected result on {}:\n{}".format(
+        rname, diff
+    )
+
 
 def setup_testcase(msg):
     "Setup test case"
@@ -207,10 +213,24 @@ def test_step2():
 
     tgen = setup_testcase("Step2: CSPF(r1, r4, IPv4)")
 
-    compare_cspf_output(tgen, "r1", "cspf-ipv4-metric.txt", "10.0.0.1", "10.0.255.4", "metric 50")
-    compare_cspf_output(tgen, "r1", "cspf-ipv4-te-metric.txt", "10.0.255.1", "10.0.4.4", "te-metric 50")
-    compare_cspf_output(tgen, "r1", "cspf-ipv4-delay.txt", "10.0.255.1", "10.0.255.4", "delay 50000")
-    compare_cspf_output(tgen, "r1", "cspf-ipv4-delay.txt", "10.0.255.1", "10.0.255.4", "delay 50000", "rsv 7 100000000")
+    compare_cspf_output(
+        tgen, "r1", "cspf-ipv4-metric.txt", "10.0.0.1", "10.0.255.4", "metric 50"
+    )
+    compare_cspf_output(
+        tgen, "r1", "cspf-ipv4-te-metric.txt", "10.0.255.1", "10.0.4.4", "te-metric 50"
+    )
+    compare_cspf_output(
+        tgen, "r1", "cspf-ipv4-delay.txt", "10.0.255.1", "10.0.255.4", "delay 50000"
+    )
+    compare_cspf_output(
+        tgen,
+        "r1",
+        "cspf-ipv4-delay.txt",
+        "10.0.255.1",
+        "10.0.255.4",
+        "delay 50000",
+        "rsv 7 1000000",
+    )
 
 
 def test_step3():
@@ -218,10 +238,34 @@ def test_step3():
 
     tgen = setup_testcase("Step2: CSPF(r1, r4, IPv6)")
 
-    compare_cspf_output(tgen, "r1", "cspf-ipv6-metric.txt", "2001:db8:1::1:1", "2001:db8::4", "metric 50")
-    compare_cspf_output(tgen, "r1", "cspf-ipv6-te-metric.txt", "2001:db8::1", "2001:db8:5::3:4", "te-metric 80")
-    compare_cspf_output(tgen, "r1", "cspf-ipv6-delay.txt", "2001:db8::1", "2001:db8::4", "delay 80000")
-    compare_cspf_output(tgen, "r1", "cspf-ipv6-delay.txt", "2001:db8::1", "2001:db8::4", "delay 80000", "rsv 7 100000000")
+    compare_cspf_output(
+        tgen,
+        "r1",
+        "cspf-ipv6-metric.txt",
+        "2001:db8:1::1:1",
+        "2001:db8::4",
+        "metric 50",
+    )
+    compare_cspf_output(
+        tgen,
+        "r1",
+        "cspf-ipv6-te-metric.txt",
+        "2001:db8::1",
+        "2001:db8:5::3:4",
+        "te-metric 80",
+    )
+    compare_cspf_output(
+        tgen, "r1", "cspf-ipv6-delay.txt", "2001:db8::1", "2001:db8::4", "delay 80000"
+    )
+    compare_cspf_output(
+        tgen,
+        "r1",
+        "cspf-ipv6-delay.txt",
+        "2001:db8::1",
+        "2001:db8::4",
+        "delay 80000",
+        "rsv 7 1000000",
+    )
 
 
 def test_step4():
@@ -229,13 +273,33 @@ def test_step4():
 
     tgen = setup_testcase("Step2: CSPF(r1, r4, failure)")
 
-    compare_cspf_output(tgen, "r1", "cspf-failed.txt", "10.0.255.1", "10.0.255.4", "metric 10")
-    compare_cspf_output(tgen, "r1", "cspf-failed.txt", "2001:db8::1", "2001:db8::4", "te-metric 50")
-    compare_cspf_output(tgen, "r1", "cspf-failed.txt", "10.0.255.1", "10.0.255.4", "delay 5000")
-    compare_cspf_output(tgen, "r1", "cspf-failed.txt", "2001:db8::1", "2001:db8::4", "delay 80000", "rsv 7 1000000000")
-    compare_cspf_output(tgen, "r1", "cspf-failed-src.txt", "10.0.0.3", "10.0.255.4", "metric 10")
-    compare_cspf_output(tgen, "r1", "cspf-failed-dst.txt", "10.0.0.1", "10.0.4.40", "metric 10")
-    compare_cspf_output(tgen, "r1", "cspf-failed-same.txt", "10.0.0.1", "10.0.0.1", "metric 10")
+    compare_cspf_output(
+        tgen, "r1", "cspf-failed.txt", "10.0.255.1", "10.0.255.4", "metric 10"
+    )
+    compare_cspf_output(
+        tgen, "r1", "cspf-failed.txt", "2001:db8::1", "2001:db8::4", "te-metric 50"
+    )
+    compare_cspf_output(
+        tgen, "r1", "cspf-failed.txt", "10.0.255.1", "10.0.255.4", "delay 5000"
+    )
+    compare_cspf_output(
+        tgen,
+        "r1",
+        "cspf-failed.txt",
+        "2001:db8::1",
+        "2001:db8::4",
+        "delay 80000",
+        "rsv 7 10000000",
+    )
+    compare_cspf_output(
+        tgen, "r1", "cspf-failed-src.txt", "10.0.0.3", "10.0.255.4", "metric 10"
+    )
+    compare_cspf_output(
+        tgen, "r1", "cspf-failed-dst.txt", "10.0.0.1", "10.0.4.40", "metric 10"
+    )
+    compare_cspf_output(
+        tgen, "r1", "cspf-failed-same.txt", "10.0.0.1", "10.0.0.1", "metric 10"
+    )
 
 
 def test_memory_leak():

--- a/tests/topotests/isis_te_topo1/r1/zebra.conf
+++ b/tests/topotests/isis_te_topo1/r1/zebra.conf
@@ -10,6 +10,7 @@ interface r1-eth0
  link-params
   metric 20
   delay 10000
+  max-bw 10e+10
   ava-bw 1.25e+08
   enable
   exit-link-params

--- a/tests/topotests/isis_te_topo1/r2/zebra.conf
+++ b/tests/topotests/isis_te_topo1/r2/zebra.conf
@@ -31,6 +31,7 @@ interface r2-eth3
  link-params
   metric 30
   delay 25000
+  max-bw 10e+10
   use-bw 1.25e+8
   enable
   exit-link-params

--- a/tests/topotests/isis_te_topo1/reference/ted_step1.json
+++ b/tests/topotests/isis_te_topo1/reference/ted_step1.json
@@ -60,32 +60,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:1::1:1",
           "remote-address-v6":"2001:db8:1::1:2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -101,32 +101,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:1::1:2",
           "remote-address-v6":"2001:db8:1::1:1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -142,32 +142,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:3::3:2",
           "remote-address-v6":"2001:db8:3::3:3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -184,32 +184,32 @@
           "admin-group":32,
           "local-address-v6":"2001:db8:3::3:3",
           "remote-address-v6":"2001:db8:3::3:2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -225,32 +225,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:5::3:4",
           "remote-address-v6":"2001:db8:5::4:3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -274,32 +274,32 @@
           "te-metric":10,
           "local-address-v6":"2001:db8:5::4:3",
           "remote-address-v6":"2001:db8:5::3:4",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":50000
@@ -317,32 +317,32 @@
           "te-metric":20,
           "local-address":"10.0.0.1",
           "remote-address":"10.0.0.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -360,32 +360,32 @@
         "edge-attributes":{
           "local-address":"10.0.0.2",
           "remote-address":"10.0.0.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -401,32 +401,32 @@
         "edge-attributes":{
           "local-address":"10.0.1.1",
           "remote-address":"10.0.1.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -442,32 +442,32 @@
         "edge-attributes":{
           "local-address":"10.0.1.2",
           "remote-address":"10.0.1.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -483,32 +483,32 @@
         "edge-attributes":{
           "local-address":"10.0.3.2",
           "remote-address":"10.0.3.3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -525,32 +525,32 @@
           "admin-group":32,
           "local-address":"10.0.3.3",
           "remote-address":"10.0.3.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -567,32 +567,32 @@
           "te-metric":30,
           "local-address":"10.0.4.2",
           "remote-address":"10.0.4.4",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000,
@@ -610,32 +610,32 @@
         "edge-attributes":{
           "local-address":"10.0.4.4",
           "remote-address":"10.0.4.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },

--- a/tests/topotests/isis_te_topo1/reference/ted_step2.json
+++ b/tests/topotests/isis_te_topo1/reference/ted_step2.json
@@ -60,32 +60,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:3::3:2",
           "remote-address-v6":"2001:db8:3::3:3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -102,32 +102,32 @@
           "admin-group":32,
           "local-address-v6":"2001:db8:3::3:3",
           "remote-address-v6":"2001:db8:3::3:2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -143,32 +143,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:5::3:4",
           "remote-address-v6":"2001:db8:5::4:3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -192,32 +192,32 @@
           "te-metric":10,
           "local-address-v6":"2001:db8:5::4:3",
           "remote-address-v6":"2001:db8:5::3:4",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":50000
@@ -235,32 +235,32 @@
           "te-metric":20,
           "local-address":"10.0.0.1",
           "remote-address":"10.0.0.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -278,32 +278,32 @@
         "edge-attributes":{
           "local-address":"10.0.0.2",
           "remote-address":"10.0.0.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -319,32 +319,32 @@
         "edge-attributes":{
           "local-address":"10.0.3.2",
           "remote-address":"10.0.3.3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -361,32 +361,32 @@
           "admin-group":32,
           "local-address":"10.0.3.3",
           "remote-address":"10.0.3.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -403,32 +403,32 @@
           "te-metric":30,
           "local-address":"10.0.4.2",
           "remote-address":"10.0.4.4",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000,
@@ -446,32 +446,32 @@
         "edge-attributes":{
           "local-address":"10.0.4.4",
           "remote-address":"10.0.4.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },

--- a/tests/topotests/isis_te_topo1/reference/ted_step3.json
+++ b/tests/topotests/isis_te_topo1/reference/ted_step3.json
@@ -61,32 +61,32 @@
           "te-metric":20,
           "local-address-v6":"2001:db8::1",
           "remote-address-v6":"2001:db8::2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -103,32 +103,32 @@
         "metric":10,
         "edge-attributes":{
           "local-address-v6":"2001:db8::2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -144,32 +144,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:3::3:2",
           "remote-address-v6":"2001:db8:3::3:3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -186,32 +186,32 @@
           "admin-group":32,
           "local-address-v6":"2001:db8:3::3:3",
           "remote-address-v6":"2001:db8:3::3:2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -227,32 +227,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:5::3:4",
           "remote-address-v6":"2001:db8:5::4:3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -276,32 +276,32 @@
           "te-metric":10,
           "local-address-v6":"2001:db8:5::4:3",
           "remote-address-v6":"2001:db8:5::3:4",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":50000
@@ -319,32 +319,32 @@
           "te-metric":20,
           "local-address":"10.0.0.1",
           "remote-address":"10.0.0.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -362,32 +362,32 @@
         "edge-attributes":{
           "local-address":"10.0.0.2",
           "remote-address":"10.0.0.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -403,32 +403,32 @@
         "edge-attributes":{
           "local-address":"10.0.3.2",
           "remote-address":"10.0.3.3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -445,32 +445,32 @@
           "admin-group":32,
           "local-address":"10.0.3.3",
           "remote-address":"10.0.3.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -487,32 +487,32 @@
           "te-metric":30,
           "local-address":"10.0.4.2",
           "remote-address":"10.0.4.4",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000,
@@ -530,32 +530,32 @@
         "edge-attributes":{
           "local-address":"10.0.4.4",
           "remote-address":"10.0.4.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },

--- a/tests/topotests/isis_te_topo1/reference/ted_step4.json
+++ b/tests/topotests/isis_te_topo1/reference/ted_step4.json
@@ -61,32 +61,32 @@
           "te-metric":20,
           "local-address-v6":"2001:db8::1",
           "remote-address-v6":"2001:db8::2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -103,32 +103,32 @@
         "metric":10,
         "edge-attributes":{
           "local-address-v6":"2001:db8::2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -144,32 +144,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:3::3:2",
           "remote-address-v6":"2001:db8:3::3:3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -186,32 +186,32 @@
           "admin-group":32,
           "local-address-v6":"2001:db8:3::3:3",
           "remote-address-v6":"2001:db8:3::3:2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -227,32 +227,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:5::3:4",
           "remote-address-v6":"2001:db8:5::4:3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -276,32 +276,32 @@
           "te-metric":10,
           "local-address-v6":"2001:db8:5::4:3",
           "remote-address-v6":"2001:db8:5::3:4",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":50000
@@ -319,32 +319,32 @@
           "te-metric":20,
           "local-address":"10.0.0.1",
           "remote-address":"10.0.0.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -362,32 +362,32 @@
         "edge-attributes":{
           "local-address":"10.0.0.2",
           "remote-address":"10.0.0.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -403,32 +403,32 @@
         "edge-attributes":{
           "local-address":"10.0.3.2",
           "remote-address":"10.0.3.3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -445,32 +445,32 @@
           "admin-group":32,
           "local-address":"10.0.3.3",
           "remote-address":"10.0.3.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -487,32 +487,32 @@
           "te-metric":30,
           "local-address":"10.0.4.2",
           "remote-address":"10.0.4.4",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000,
@@ -530,32 +530,32 @@
         "edge-attributes":{
           "local-address":"10.0.4.4",
           "remote-address":"10.0.4.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },

--- a/tests/topotests/isis_te_topo1/reference/ted_step5.json
+++ b/tests/topotests/isis_te_topo1/reference/ted_step5.json
@@ -61,32 +61,32 @@
           "te-metric":20,
           "local-address-v6":"2001:db8::1",
           "remote-address-v6":"2001:db8::2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -103,32 +103,32 @@
         "metric":10,
         "edge-attributes":{
           "local-address-v6":"2001:db8::2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -144,32 +144,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:1::1:1",
           "remote-address-v6":"2001:db8:1::1:2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -185,32 +185,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:1::1:2",
           "remote-address-v6":"2001:db8:1::1:1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -226,32 +226,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:3::3:2",
           "remote-address-v6":"2001:db8:3::3:3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -268,32 +268,32 @@
           "admin-group":32,
           "local-address-v6":"2001:db8:3::3:3",
           "remote-address-v6":"2001:db8:3::3:2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -309,32 +309,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:5::3:4",
           "remote-address-v6":"2001:db8:5::4:3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -358,32 +358,32 @@
           "te-metric":10,
           "local-address-v6":"2001:db8:5::4:3",
           "remote-address-v6":"2001:db8:5::3:4",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":50000
@@ -401,32 +401,32 @@
           "te-metric":20,
           "local-address":"10.0.0.1",
           "remote-address":"10.0.0.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -444,32 +444,32 @@
         "edge-attributes":{
           "local-address":"10.0.0.2",
           "remote-address":"10.0.0.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -485,32 +485,32 @@
         "edge-attributes":{
           "local-address":"10.0.1.1",
           "remote-address":"10.0.1.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -526,32 +526,32 @@
         "edge-attributes":{
           "local-address":"10.0.1.2",
           "remote-address":"10.0.1.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -567,32 +567,32 @@
         "edge-attributes":{
           "local-address":"10.0.3.2",
           "remote-address":"10.0.3.3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -609,32 +609,32 @@
           "admin-group":32,
           "local-address":"10.0.3.3",
           "remote-address":"10.0.3.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -651,32 +651,32 @@
           "te-metric":30,
           "local-address":"10.0.4.2",
           "remote-address":"10.0.4.4",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000,
@@ -694,32 +694,32 @@
         "edge-attributes":{
           "local-address":"10.0.4.4",
           "remote-address":"10.0.4.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },

--- a/tests/topotests/isis_te_topo1/reference/ted_step6.json
+++ b/tests/topotests/isis_te_topo1/reference/ted_step6.json
@@ -61,32 +61,32 @@
           "te-metric":20,
           "local-address-v6":"2001:db8::1",
           "remote-address-v6":"2001:db8::2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -103,32 +103,32 @@
         "metric":10,
         "edge-attributes":{
           "local-address-v6":"2001:db8::2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -144,32 +144,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:1::1:1",
           "remote-address-v6":"2001:db8:1::1:2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -185,32 +185,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:1::1:2",
           "remote-address-v6":"2001:db8:1::1:1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -226,32 +226,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:3::3:2",
           "remote-address-v6":"2001:db8:3::3:3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -268,32 +268,32 @@
           "admin-group":32,
           "local-address-v6":"2001:db8:3::3:3",
           "remote-address-v6":"2001:db8:3::3:2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -309,32 +309,32 @@
         "edge-attributes":{
           "local-address-v6":"2001:db8:5::3:4",
           "remote-address-v6":"2001:db8:5::4:3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -358,32 +358,32 @@
           "te-metric":10,
           "local-address-v6":"2001:db8:5::4:3",
           "remote-address-v6":"2001:db8:5::3:4",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":50000
@@ -401,32 +401,32 @@
           "te-metric":20,
           "local-address":"10.0.0.1",
           "remote-address":"10.0.0.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -444,32 +444,32 @@
         "edge-attributes":{
           "local-address":"10.0.0.2",
           "remote-address":"10.0.0.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -485,32 +485,32 @@
         "edge-attributes":{
           "local-address":"10.0.1.1",
           "remote-address":"10.0.1.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -526,32 +526,32 @@
         "edge-attributes":{
           "local-address":"10.0.1.2",
           "remote-address":"10.0.1.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -567,32 +567,32 @@
         "edge-attributes":{
           "local-address":"10.0.3.2",
           "remote-address":"10.0.3.3",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -609,32 +609,32 @@
           "admin-group":32,
           "local-address":"10.0.3.3",
           "remote-address":"10.0.3.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -651,32 +651,32 @@
           "te-metric":30,
           "local-address":"10.0.4.2",
           "remote-address":"10.0.4.4",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000
@@ -693,32 +693,32 @@
         "edge-attributes":{
           "local-address":"10.0.4.4",
           "remote-address":"10.0.4.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":20000,

--- a/tests/topotests/ospf_te_topo1/r1/zebra.conf
+++ b/tests/topotests/ospf_te_topo1/r1/zebra.conf
@@ -7,6 +7,7 @@ interface r1-eth0
  link-params
   metric 20
   delay 10000
+  max-bw 10e+10
   ava-bw 1.25e+08
   enable
   exit-link-params

--- a/tests/topotests/ospf_te_topo1/r2/zebra.conf
+++ b/tests/topotests/ospf_te_topo1/r2/zebra.conf
@@ -25,6 +25,7 @@ interface r2-eth3
  link-params
   metric 30
   delay 25000
+  max-bw 10e+10
   use-bw 1.25e+8
   enable
   exit-link-params

--- a/tests/topotests/ospf_te_topo1/reference/ted_step1.json
+++ b/tests/topotests/ospf_te_topo1/reference/ted_step1.json
@@ -68,32 +68,32 @@
           "te-metric":20,
           "local-address":"10.0.0.1",
           "remote-address":"10.0.0.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -111,32 +111,32 @@
         "edge-attributes":{
           "local-address":"10.0.0.2",
           "remote-address":"10.0.0.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -152,32 +152,32 @@
         "edge-attributes":{
           "local-address":"10.0.1.1",
           "remote-address":"10.0.1.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -193,32 +193,32 @@
         "edge-attributes":{
           "local-address":"10.0.1.2",
           "remote-address":"10.0.1.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -235,32 +235,32 @@
           "admin-group":32,
           "local-address":"10.0.3.1",
           "remote-address":"10.0.3.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -276,32 +276,32 @@
         "edge-attributes":{
           "local-address":"10.0.3.2",
           "remote-address":"10.0.3.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -317,32 +317,32 @@
         "edge-attributes":{
           "local-address":"10.0.4.1",
           "remote-address":"10.0.4.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -371,32 +371,32 @@
           "te-metric":30,
           "local-address":"10.0.4.2",
           "remote-address":"10.0.4.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000,
@@ -414,32 +414,32 @@
         "edge-attributes":{
           "te-metric":10,
           "local-address":"10.0.5.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "remote-asn":65535,

--- a/tests/topotests/ospf_te_topo1/reference/ted_step2.json
+++ b/tests/topotests/ospf_te_topo1/reference/ted_step2.json
@@ -68,32 +68,32 @@
           "te-metric":20,
           "local-address":"10.0.0.1",
           "remote-address":"10.0.0.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -111,32 +111,32 @@
         "edge-attributes":{
           "local-address":"10.0.0.2",
           "remote-address":"10.0.0.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -153,32 +153,32 @@
           "admin-group":32,
           "local-address":"10.0.3.1",
           "remote-address":"10.0.3.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -194,32 +194,32 @@
         "edge-attributes":{
           "local-address":"10.0.3.2",
           "remote-address":"10.0.3.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -235,32 +235,32 @@
         "edge-attributes":{
           "local-address":"10.0.4.1",
           "remote-address":"10.0.4.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -289,32 +289,32 @@
           "te-metric":30,
           "local-address":"10.0.4.2",
           "remote-address":"10.0.4.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000,
@@ -332,32 +332,32 @@
         "edge-attributes":{
           "te-metric":10,
           "local-address":"10.0.5.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "remote-asn":65535,

--- a/tests/topotests/ospf_te_topo1/reference/ted_step3.json
+++ b/tests/topotests/ospf_te_topo1/reference/ted_step3.json
@@ -60,32 +60,32 @@
           "te-metric":20,
           "local-address":"10.0.0.1",
           "remote-address":"10.0.0.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -103,32 +103,32 @@
         "edge-attributes":{
           "local-address":"10.0.0.2",
           "remote-address":"10.0.0.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -145,32 +145,32 @@
           "admin-group":32,
           "local-address":"10.0.3.1",
           "remote-address":"10.0.3.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -186,32 +186,32 @@
         "edge-attributes":{
           "local-address":"10.0.3.2",
           "remote-address":"10.0.3.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -227,32 +227,32 @@
         "edge-attributes":{
           "local-address":"10.0.4.1",
           "remote-address":"10.0.4.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -281,32 +281,32 @@
           "te-metric":30,
           "local-address":"10.0.4.2",
           "remote-address":"10.0.4.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000,

--- a/tests/topotests/ospf_te_topo1/reference/ted_step4.json
+++ b/tests/topotests/ospf_te_topo1/reference/ted_step4.json
@@ -83,32 +83,32 @@
           "te-metric":20,
           "local-address":"10.0.0.1",
           "remote-address":"10.0.0.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -138,32 +138,32 @@
         "edge-attributes":{
           "local-address":"10.0.0.2",
           "remote-address":"10.0.0.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -192,32 +192,32 @@
           "admin-group":32,
           "local-address":"10.0.3.1",
           "remote-address":"10.0.3.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -233,32 +233,32 @@
         "edge-attributes":{
           "local-address":"10.0.3.2",
           "remote-address":"10.0.3.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -286,32 +286,32 @@
         "edge-attributes":{
           "local-address":"10.0.4.1",
           "remote-address":"10.0.4.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -340,32 +340,32 @@
           "te-metric":30,
           "local-address":"10.0.4.2",
           "remote-address":"10.0.4.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000,

--- a/tests/topotests/ospf_te_topo1/reference/ted_step5.json
+++ b/tests/topotests/ospf_te_topo1/reference/ted_step5.json
@@ -83,32 +83,32 @@
           "te-metric":20,
           "local-address":"10.0.0.1",
           "remote-address":"10.0.0.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -138,32 +138,32 @@
         "edge-attributes":{
           "local-address":"10.0.0.2",
           "remote-address":"10.0.0.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -191,32 +191,32 @@
         "edge-attributes":{
           "local-address":"10.0.1.1",
           "remote-address":"10.0.1.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -244,32 +244,32 @@
         "edge-attributes":{
           "local-address":"10.0.1.2",
           "remote-address":"10.0.1.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -298,32 +298,32 @@
           "admin-group":32,
           "local-address":"10.0.3.1",
           "remote-address":"10.0.3.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -339,32 +339,32 @@
         "edge-attributes":{
           "local-address":"10.0.3.2",
           "remote-address":"10.0.3.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -392,32 +392,32 @@
         "edge-attributes":{
           "local-address":"10.0.4.1",
           "remote-address":"10.0.4.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -446,32 +446,32 @@
           "te-metric":30,
           "local-address":"10.0.4.2",
           "remote-address":"10.0.4.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000,

--- a/tests/topotests/ospf_te_topo1/reference/ted_step6.json
+++ b/tests/topotests/ospf_te_topo1/reference/ted_step6.json
@@ -83,32 +83,32 @@
           "te-metric":20,
           "local-address":"10.0.0.1",
           "remote-address":"10.0.0.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -138,32 +138,32 @@
         "edge-attributes":{
           "local-address":"10.0.0.2",
           "remote-address":"10.0.0.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -191,32 +191,32 @@
         "edge-attributes":{
           "local-address":"10.0.1.1",
           "remote-address":"10.0.1.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -244,32 +244,32 @@
         "edge-attributes":{
           "local-address":"10.0.1.2",
           "remote-address":"10.0.1.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -298,32 +298,32 @@
           "admin-group":32,
           "local-address":"10.0.3.1",
           "remote-address":"10.0.3.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -339,32 +339,32 @@
         "edge-attributes":{
           "local-address":"10.0.3.2",
           "remote-address":"10.0.3.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -392,32 +392,32 @@
         "edge-attributes":{
           "local-address":"10.0.4.1",
           "remote-address":"10.0.4.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":20000,
@@ -448,32 +448,32 @@
           "te-metric":30,
           "local-address":"10.0.4.2",
           "remote-address":"10.0.4.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":25000

--- a/tests/topotests/ospf_te_topo1/reference/ted_step7.json
+++ b/tests/topotests/ospf_te_topo1/reference/ted_step7.json
@@ -64,32 +64,32 @@
           "te-metric":20,
           "local-address":"10.0.0.1",
           "remote-address":"10.0.0.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":99999997952,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ],
           "delay":10000,
@@ -119,32 +119,32 @@
         "edge-attributes":{
           "local-address":"10.0.0.2",
           "remote-address":"10.0.0.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -172,32 +172,32 @@
         "edge-attributes":{
           "local-address":"10.0.1.1",
           "remote-address":"10.0.1.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -225,32 +225,32 @@
         "edge-attributes":{
           "local-address":"10.0.1.2",
           "remote-address":"10.0.1.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },
@@ -279,32 +279,32 @@
           "admin-group":32,
           "local-address":"10.0.3.1",
           "remote-address":"10.0.3.2",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         }
@@ -320,32 +320,32 @@
         "edge-attributes":{
           "local-address":"10.0.3.2",
           "remote-address":"10.0.3.1",
-          "max-link-bandwidth":176258176.0,
-          "max-resv-link-bandwidth":176258176.0,
+          "max-link-bandwidth":1250000,
+          "max-resv-link-bandwidth":1250000,
           "unreserved-bandwidth":[
             {
-              "class-type-0":176258176.0
+              "class-type-0":1250000
             },
             {
-              "class-type-1":176258176.0
+              "class-type-1":1250000
             },
             {
-              "class-type-2":176258176.0
+              "class-type-2":1250000
             },
             {
-              "class-type-3":176258176.0
+              "class-type-3":1250000
             },
             {
-              "class-type-4":176258176.0
+              "class-type-4":1250000
             },
             {
-              "class-type-5":176258176.0
+              "class-type-5":1250000
             },
             {
-              "class-type-6":176258176.0
+              "class-type-6":1250000
             },
             {
-              "class-type-7":176258176.0
+              "class-type-7":1250000
             }
           ]
         },


### PR DESCRIPTION
When enabling the interface link-params, a default bandwidth is assigned to the Max, Reservable and Unreserved Bandwidth variables. If the bandwidth is set at in the interface context, this value is used. Otherwise, a default bandwidth value of 10 Gbps is set.

Revert the default value to 10 Mbps as it was intended in the initial commit. 10 Mbps is a low value so that the link will not be prioritized when computing the paths.

Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>