### PR TITLE
OSPF: allow for zero length opaque LSAs

### DIFF
--- a/ospfclient/ospfclient.py
+++ b/ospfclient/ospfclient.py
@@ -1099,6 +1099,12 @@ async def async_main(args):
             for action in args.actions:
                 _s = action.split(",")
                 what = _s.pop(False)
+                if what.casefold() == "wait":
+                    stime = int(_s.pop(False))
+                    logging.info("waiting %s seconds", stime)
+                    await asyncio.sleep(stime)
+                    logging.info("wait complete: %s seconds", stime)
+                    continue
                 ltype = int(_s.pop(False))
                 if ltype == 11:
                     addr = ip(0)

--- a/ospfd/ospf_opaque.h
+++ b/ospfd/ospf_opaque.h
@@ -77,7 +77,7 @@
 
 #define OPAQUE_TYPE_RANGE_RESERVED(type) (127 < (type) && (type) <= 255)
 
-#define OSPF_OPAQUE_LSA_MIN_SIZE 4U
+#define OSPF_OPAQUE_LSA_MIN_SIZE 0 /* RFC5250 imposes no minimum */
 
 #define VALID_OPAQUE_INFO_LEN(lsahdr)                                          \
 	((ntohs((lsahdr)->length) >= sizeof(struct lsa_header))                \


### PR DESCRIPTION

This issue was first introduced in release 8.2 (8.1 passes zero len opaque LSAs)

Also improve related topotest