### PR TITLE
lib: link-state protection against edge with same key

### DIFF
--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -731,6 +731,11 @@ struct ls_edge *ls_edge_add(struct ls_ted *ted,
 	key = get_edge_key(attributes, false);
 	if (key == 0)
 		return NULL;
+	if(ls_find_edge_by_key(ted,key)){
+		zlog_debug(" %s try to use an already used key",
+			   __func__);
+		return NULL;
+	}
 
 	/* Create Edge and add it to the TED */
 	new = XCALLOC(MTYPE_LS_DB, sizeof(struct ls_edge));


### PR DESCRIPTION
Current version of TE database is based on point to point links between interfaces. Thus in this case each interface is represented by a vertex, and point to point link by an edge between 2 vertices. This edge is bidirectional (supporting different properties on each direction).

The TE database is build from external LSPs when TE is enabled. Illegaly formated LSPs or LSPs that contain a multipoint description may be received leading to a TE database corruption and a crash risk.

Since each edge is identified by a key based on the source address, a multipoint interface may cause trying to add several edges with the same key.

Current IPv6 keys computation may also easily leads to one key for different address.

Abort creating a vertex with an existing key. In point-to-multipoint links, only one edge will be created. This is a workaround to avoid crashes until a support of point-to-multipoint links will be added to the TE library, and a better IPv6 key managment will be provided.

Signed-off-by: Francois Dumontet <francois.dumontet@6wind.com>