### PR TITLE
bgpd: peer with link-local address

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -301,7 +301,7 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop,
 						"%s: Unable to locate ifindex, waiting till we have one",
 						peer->conf_if);
 				}
-				return 0;
+				// return 0;
 			}
 		}
 


### PR DESCRIPTION
When BGP is established with a link-local address, it is unestablished.