### PR TITLE
pim6d: Don't process multicast packet with global IPv6 source address

### DIFF
--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -139,6 +139,21 @@ void pim_sock_delete(struct interface *ifp, const char *delete_message)
 	sock_close(ifp);
 }
 
+#if PIM_IPV == 6
+/* Check src address for hello, assrt, join/prune and Bootstrap is link-local */
+static bool pim_pkt_src_addr_ok(enum pim_msg_type type, pim_addr addr)
+{
+	if ((type == PIM_MSG_TYPE_HELLO) || (type == PIM_MSG_TYPE_ASSERT) ||
+	    (type == PIM_MSG_TYPE_JOIN_PRUNE) ||
+	    (type == PIM_MSG_TYPE_BOOTSTRAP)) {
+		if (!IN6_IS_ADDR_LINKLOCAL(&addr))
+			return false;
+	}
+
+	return true;
+}
+#endif
+
 /* For now check dst address for hello, assrt and join/prune is all pim rtr */
 static bool pim_pkt_dst_addr_ok(enum pim_msg_type type, pim_addr addr)
 {
@@ -278,6 +293,15 @@ int pim_pim_packet(struct interface *ifp, uint8_t *buf, size_t len,
 		if (PIM_DEBUG_PIM_PACKETDUMP_RECV)
 			pim_pkt_dump(__func__, pim_msg, pim_msg_len);
 	}
+
+#if PIM_IPV == 6
+	if (!pim_pkt_src_addr_ok(header->type, sg.src)) {
+		zlog_warn(
+			"%s: Ignoring Pkt. Unexpected IP source %pPA for %s (Expected: Link-local)",
+			__func__, &sg.src, pim_pim_msgtype2str(header->type));
+		return -1;
+	}
+#endif
 
 	if (!pim_pkt_dst_addr_ok(header->type, sg.grp)) {
 		zlog_warn(


### PR DESCRIPTION
As per rfc7761 section 4.9,
   PIM messages are either unicast (e.g., Registers and Register-Stop)
   or multicast with TTL 1 to the 'ALL-PIM-ROUTERS' group (e.g.,
   Join/Prune, Asserts).  The source address used for unicast messages
   is a domain-wide reachable address; the source address used for
   multicast messages is the link-local address of the interface on
   which the message is being sent.

As per rfc5059 section 4,
 The IP source address used for Bootstrap messages
 (regardless of whether they are being originated
 or forwarded) is the link-local address of the
 interface on which the message is being sent.
 we should process or drop multicast packet with global address. So closed the PR as of now.

PIMV6 hello packet should be accepted from LL address.
PIMV6 Join/Prune, Assert and BSM packets should be accepted from primary LL address. (Source address of the PIMV6 hello packet)

Only Register and Candidate-RP messages use Global address , so these are excluded from the check.

Signed-off-by: Sarita Patra <saritap@vmware.com>