### PR TITLE
bgpd: fix vni_str NULL check in evpn rt show run

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -6625,10 +6625,13 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 			if (CHECK_FLAG(l3rt->flags, BGP_VRF_RT_WILD)) {
 				char *vni_str = NULL;
 
-				vni_str = strchr(ecom_str, ':') + 1;
+				vni_str = strchr(ecom_str, ':');
 
 				if (!vni_str)
 					continue; /* This should never happen */
+
+				/* Move pointer to vni */
+				vni_str += 1;
 
 				vty_out(vty, "  route-target import *:%s\n",
 					vni_str);


### PR DESCRIPTION
Fix the vni_str NULL check for wildcard route-targets in evpn show run. This will never be NULL if we add 1 here. Though it should also never be NULL since ":" should always exist. Better to be safe than sorry.

Signed-off-by: Stephen Worley <sworley@nvidia.com>