### PR TITLE
bgpd: fixed misaligned columns in BGP routes table

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9035,6 +9035,8 @@ static void route_vty_short_status_out(struct vty *vty,
 		vty_out(vty, "I");
 	else if (rpki_state == RPKI_NOTFOUND)
 		vty_out(vty, "N");
+	else
+		vty_out(vty, " ");
 
 	/* Route status display. */
 	if (CHECK_FLAG(path->flags, BGP_PATH_REMOVED))

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -80,7 +80,7 @@ enum bgp_show_adj_route_type {
 #define BGP_SHOW_NCODE_HEADER "Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self\n"
 #define BGP_SHOW_RPKI_HEADER                                                   \
 	"RPKI validation codes: V valid, I invalid, N Not found\n\n"
-#define BGP_SHOW_HEADER "   Network          Next Hop            Metric LocPrf Weight Path\n"
+#define BGP_SHOW_HEADER "    Network          Next Hop            Metric LocPrf Weight Path\n"
 #define BGP_SHOW_HEADER_WIDE "   Network                                      Next Hop                                  Metric LocPrf Weight Path\n"
 
 /* Maximum number of labels we can process or send with a prefix. We


### PR DESCRIPTION
Column headers in BGP routes table are not aligned with data when      
RPKI status is available.  This was fixed to insert a space at the          
beginning of the header and at the beginning of lines that do not                  
have RPKI status.

Signed-off-by: Wayne Morrison <wmorrison@netgate.com>