### PR TITLE
ospf6d: Fix for memory leak issues in ospf6.

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -39,6 +39,8 @@
 #include "ospf6_spf.h"
 #include "ospf6_top.h"
 #include "ospf6_area.h"
+#include "ospf6_message.h"
+#include "ospf6_neighbor.h"
 #include "ospf6_interface.h"
 #include "ospf6_intra.h"
 #include "ospf6_abr.h"
@@ -348,8 +350,16 @@ void ospf6_area_delete(struct ospf6_area *oa)
 	 * deleting an area.
 	 * So just detach the interface from the area and
 	 * keep it around. */
-	for (ALL_LIST_ELEMENTS_RO(oa->if_list, n, oi))
+	for (ALL_LIST_ELEMENTS_RO(oa->if_list, n, oi)) {
 		oi->area = NULL;
+
+		struct listnode *node;
+		struct listnode *nnode;
+		struct ospf6_neighbor *on;
+
+		for (ALL_LIST_ELEMENTS(oi->neighbor_list, node, nnode, on))
+			ospf6_neighbor_delete(on);
+	}
 
 	list_delete(&oa->if_list);
 

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -3169,6 +3169,14 @@ void ospf6_external_aggregator_free(struct ospf6_external_aggr_rt *aggr)
 		hash_clean(aggr->match_extnl_hash,
 			ospf6_aggr_unlink_external_info);
 
+	if (aggr->route) {
+		if (aggr->route->route_option)
+			XFREE(MTYPE_OSPF6_EXTERNAL_INFO,
+			      aggr->route->route_option);
+
+		ospf6_route_delete(aggr->route);
+	}
+
 	if (IS_OSPF6_DEBUG_AGGR)
 		zlog_debug("%s: Release the aggregator Address(%pFX)",
 						__func__,


### PR DESCRIPTION
Problem:
Multiple memory leaks in ospf6.

 260 ==6637== 32 bytes in 1 blocks are definitely lost in loss record 5 of 24
 261 ==6637==    at 0x4C31FAC: calloc (vg_replace_malloc.c:762)
 262 ==6637==    by 0x4E8A1BF: qcalloc (memory.c:111)
 263 ==6637==    by 0x11EE27: ospf6_summary_add_aggr_route_and_blackhole (ospf6_asbr.c:2779)
 264 ==6637==    by 0x11EEBA: ospf6_originate_new_aggr_lsa (ospf6_asbr.c:2811)
 265 ==6637==    by 0x4E7C6A7: hash_clean (hash.c:325)
 266 ==6637==    by 0x11FA93: ospf6_handle_external_aggr_update (ospf6_asbr.c:3164)
 267 ==6637==    by 0x11FA93: ospf6_asbr_summary_process (ospf6_asbr.c:3386)
 268 ==6637==    by 0x4EB739B: thread_call (thread.c:1692)
 269 ==6637==    by 0x4E85B17: frr_run (libfrr.c:1068)
 270 ==6637==    by 0x119535: main (ospf6_main.c:228)

 356 ==6637== 240 bytes in 12 blocks are indirectly lost in loss record 13 of 24
 357 ==6637==    at 0x4C2FE96: malloc (vg_replace_malloc.c:309)
 358 ==6637==    by 0x4E8A0DA: qmalloc (memory.c:106)
 359 ==6637==    by 0x13545C: ospf6_lsa_alloc (ospf6_lsa.c:724)
 360 ==6637==    by 0x1354E3: ospf6_lsa_create_headeronly (ospf6_lsa.c:756)
 361 ==6637==    by 0x1355F2: ospf6_lsa_copy (ospf6_lsa.c:790)
 362 ==6637==    by 0x13B58B: ospf6_dbdesc_recv_slave (ospf6_message.c:976)
 363 ==6637==    by 0x13B58B: ospf6_dbdesc_recv (ospf6_message.c:1038)
 364 ==6637==    by 0x13B58B: ospf6_read_helper (ospf6_message.c:1838)
 365 ==6637==    by 0x13B58B: ospf6_receive (ospf6_message.c:1875)
 366 ==6637==    by 0x4EB739B: thread_call (thread.c:1692)
 367 ==6637==    by 0x4E85B17: frr_run (libfrr.c:1068)
 368 ==6637==    by 0x119535: main (ospf6_main.c:228)

RCA:
1. when the ospf6 area is being deleted, the neighbor related information was not being cleaned up.
2. when aggr route gets deleted from rt_aggr_tbl the corrsponding summary route attched to the aggr route was not being deleted.

Fix:
Added the ospf6_neighbor_delete in ospf6_area_delete to free the neighbor related information and added ospf6_route_delete while freeing external aggr route to free the summary route.

Signed-off-by: Manoj Naragund <mnaragund@vmware.com>