### PR TITLE
ospf6d: ospf6 route installation when changed from nssa to regular area.

### DIFF
--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -1092,7 +1092,25 @@ static void ospf6_check_and_originate_type7_lsa(struct ospf6_area *area)
 			ospf6_nssa_lsa_originate(aggr->route, area, true);
 		}
 	}
+}
 
+static void ospf6_ase_lsa_refresh(struct ospf6 *o)
+{
+	struct ospf6_lsa *old;
+
+	for (struct ospf6_route *route = ospf6_route_head(o->external_table);
+	     route; route = ospf6_route_next(route)) {
+		old = ospf6_lsdb_lookup(htons(OSPF6_LSTYPE_AS_EXTERNAL),
+					route->path.origin.id, o->router_id,
+					o->lsdb);
+		if (old) {
+			THREAD_OFF(old->refresh);
+			thread_add_event(master, ospf6_lsa_refresh, old, 0,
+					 &old->refresh);
+		} else {
+			ospf6_as_external_lsa_originate(route, o);
+		}
+	}
 }
 
 void ospf6_area_nssa_update(struct ospf6_area *area)
@@ -1136,6 +1154,36 @@ void ospf6_area_nssa_update(struct ospf6_area *area)
 		if (IS_OSPF6_DEBUG_NSSA)
 			zlog_debug("Normal area %s", area->name);
 		ospf6_nssa_flush_area(area);
+
+		/* Check if router is ABR */
+		if (ospf6_check_and_set_router_abr(area->ospf6)) {
+			if (IS_OSPF6_DEBUG_NSSA)
+				zlog_debug("Router is ABR area %s", area->name);
+			ospf6_schedule_abr_task(area->ospf6);
+			ospf6_ase_lsa_refresh(area->ospf6);
+		} else {
+			uint16_t type;
+			struct ospf6_lsa *lsa = NULL;
+
+			/*
+			 * Refresh all type-5 LSAs so they get installed
+			 * in the converted ares
+			 */
+			if (IS_OSPF6_DEBUG_NSSA)
+				zlog_debug("Refresh type-5 LSAs, area %s",
+					   area->name);
+
+			type = htons(OSPF6_LSTYPE_AS_EXTERNAL);
+			for (ALL_LSDB_TYPED_ADVRTR(area->ospf6->lsdb, type,
+						   area->ospf6->router_id,
+						   lsa)) {
+				if (IS_OSPF6_DEBUG_NSSA)
+					ospf6_lsa_header_print(lsa);
+				THREAD_OFF(lsa->refresh);
+				thread_add_event(master, ospf6_lsa_refresh, lsa,
+						 0, &lsa->refresh);
+			}
+		}
 	}
 }
 

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa2.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa2.py
@@ -406,6 +406,124 @@ def test_ospfv3_nssa_tc26_p0(request):
     write_test_footer(tc_name)
 
 
+def test_ospfv3_learning_tc15_p0(request):
+    """Verify OSPF can learn different types of LSA and processes them.
+
+    OSPF Learning : Edge learning different types of LSAs.
+    """
+    tc_name = request.node.name
+    write_test_header(tc_name)
+    tgen = get_topogen()
+
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        check_router_status(tgen)
+
+    global topo
+    step("Bring up the base config as per the topology")
+    step("Configure area 1 as NSSA Area")
+
+    reset_config_on_routers(tgen)
+
+    step("Verify that Type 3 summary LSA is originated for the same Area 0")
+    ip = topo["routers"]["r1"]["links"]["r3-link0"]["ipv6"]
+    ip_net = str(ipaddress.ip_interface(u"{}".format(ip)).network)
+
+    input_dict = {
+        "r1": {
+            "static_routes": [
+                {
+                    "network": ip_net,
+                    "no_of_ip": 1,
+                    "routeType": "Network",
+                    "pathtype": "Inter-Area",
+                }
+            ]
+        }
+    }
+
+    dut = "r0"
+    result = verify_ospf6_rib(tgen, dut, input_dict)
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    protocol = "ospf6"
+    result = verify_rib(tgen, "ipv6", dut, input_dict, protocol=protocol)
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    input_dict = {
+        "r2": {
+            "static_routes": [
+                {"network": NETWORK["ipv6"][0], "no_of_ip": 5, "next_hop": "Null0"}
+            ]
+        }
+    }
+    result = create_static_routes(tgen, input_dict)
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step("Redistribute static route in R2 ospf.")
+    dut = "r2"
+    red_static(dut)
+
+    step("Verify that Type 5 LSA is originated by R2.")
+    dut = "r0"
+    protocol = "ospf6"
+    result = verify_rib(tgen, "ipv6", dut, input_dict, protocol=protocol)
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    input_dict = {
+        "r1": {
+            "static_routes": [
+                {"network": NETWORK["ipv6"][0], "no_of_ip": 1, "routeType": "Network"}
+            ]
+        }
+    }
+
+    dut = "r1"
+    result = verify_ospf6_rib(tgen, dut, input_dict)
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    result = verify_rib(tgen, "ipv6", dut, input_dict, protocol=protocol)
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    result = verify_ospf6_neighbor(tgen, topo)
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step("Change area 1 as non nssa area (on the fly changing area" " type on DUT).")
+
+    for rtr in ["r1", "r2", "r3"]:
+        input_dict = {
+            rtr: {
+                "ospf6": {"area": [{"id": "0.0.0.2", "type": "nssa", "delete": True}]}
+            }
+        }
+        result = create_router_ospf(tgen, topo, input_dict)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+    step("Verify that OSPF neighbours are reset after changing area type.")
+    step("Verify that ABR R2 originates type 5 LSA in area 1.")
+    step("Verify that R1 installs type 5 lsa in its database.")
+    step("Verify that route is calculated and installed in R1.")
+
+    input_dict = {
+        "r1": {
+            "static_routes": [
+                {"network": NETWORK["ipv6"][0], "no_of_ip": 1, "routeType": "Network"}
+            ]
+        }
+    }
+
+    dut = "r1"
+    result = verify_ospf6_rib(tgen, dut, input_dict)
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    result = verify_rib(tgen, "ipv6", dut, input_dict, protocol=protocol)
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    write_test_footer(tc_name)
+
+
 # As per internal discussion, this script has to be removed as translator
 # function is not supported, for more details kindly check this PR 2565570
 def ospfv3_nssa_tc27_p0(request):


### PR DESCRIPTION
Problem:
Delay in ospfv3 route installation when area gets converted to regular from NSSA.

RCA:
when area gets converted from NSSA to normal the type-7(NSSA_LSAs) gets flushed from the area, as a result the external routes learnt from these type-7s gets removed. Once the area is moved to nomral the type 5 lsas needs to flooded through the area so that routes are re-learnt. however there is a delay in flooding of these routes until these routes are refreshed. Due to this there is delay installation of these routes.

Fix:
The Fix involves refreshing of the type 5 lsas once the area is changed from nssa to regular area.

Signed-off-by: Manoj Naragund <mnaragund@vmware.com>