### PR TITLE
ospfd: fix missing max-metric in show running config

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -10532,22 +10532,15 @@ DEFUN (no_ospf_route_aggregation_timer,
 
 static void config_write_stub_router(struct vty *vty, struct ospf *ospf)
 {
-	struct listnode *ln;
-	struct ospf_area *area;
-
 	if (ospf->stub_router_startup_time != OSPF_STUB_ROUTER_UNCONFIGURED)
 		vty_out(vty, " max-metric router-lsa on-startup %u\n",
 			ospf->stub_router_startup_time);
 	if (ospf->stub_router_shutdown_time != OSPF_STUB_ROUTER_UNCONFIGURED)
 		vty_out(vty, " max-metric router-lsa on-shutdown %u\n",
 			ospf->stub_router_shutdown_time);
-	for (ALL_LIST_ELEMENTS_RO(ospf->areas, ln, area)) {
-		if (CHECK_FLAG(area->stub_router_state,
-			       OSPF_AREA_ADMIN_STUB_ROUTED)) {
-			vty_out(vty, " max-metric router-lsa administrative\n");
-			break;
-		}
-	}
+	if (ospf->stub_router_admin_set == OSPF_STUB_ROUTER_ADMINISTRATIVE_SET)
+		vty_out(vty, " max-metric router-lsa administrative\n");
+
 	return;
 }
 


### PR DESCRIPTION
Just add the missing running config for this command:

```
(ospf)  max-metric router-lsa administrative
```
