### PR TITLE
bgpd: fixed misaligned columns in BGP routes table

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9035,6 +9035,8 @@ static void route_vty_short_status_out(struct vty *vty,
 		vty_out(vty, "I");
 	else if (rpki_state == RPKI_NOTFOUND)
 		vty_out(vty, "N");
+	else
+		vty_out(vty, " ");
 
 	/* Route status display. */
 	if (CHECK_FLAG(path->flags, BGP_PATH_REMOVED))

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -80,7 +80,7 @@ enum bgp_show_adj_route_type {
 #define BGP_SHOW_NCODE_HEADER "Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self\n"
 #define BGP_SHOW_RPKI_HEADER                                                   \
 	"RPKI validation codes: V valid, I invalid, N Not found\n\n"
-#define BGP_SHOW_HEADER "   Network          Next Hop            Metric LocPrf Weight Path\n"
+#define BGP_SHOW_HEADER "    Network          Next Hop            Metric LocPrf Weight Path\n"
 #define BGP_SHOW_HEADER_WIDE "   Network                                      Next Hop                                  Metric LocPrf Weight Path\n"
 
 /* Maximum number of labels we can process or send with a prefix. We

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post4.1.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post4.1.ref
@@ -5,5 +5,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-   Network          Next Hop            Metric LocPrf Weight Path
-*> 192.168.0.0      0.0.0.0                  0         32768 i
+    Network          Next Hop            Metric LocPrf Weight Path
+ *> 192.168.0.0      0.0.0.0                  0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post5.0.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post5.0.ref
@@ -5,5 +5,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-   Network          Next Hop            Metric LocPrf Weight Path
-*> 192.168.0.0/24   0.0.0.0                  0         32768 i
+    Network          Next Hop            Metric LocPrf Weight Path
+ *> 192.168.0.0/24   0.0.0.0                  0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post6.1.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post6.1.ref
@@ -6,5 +6,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-   Network          Next Hop            Metric LocPrf Weight Path
-*> 192.168.0.0/24   0.0.0.0                  0         32768 i
+    Network          Next Hop            Metric LocPrf Weight Path
+ *> 192.168.0.0/24   0.0.0.0                  0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4.ref
@@ -3,5 +3,5 @@ Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
 Origin codes: i - IGP, e - EGP, ? - incomplete
 
-   Network          Next Hop            Metric LocPrf Weight Path
-*> 192.168.0.0      0.0.0.0                  0         32768 i
+    Network          Next Hop            Metric LocPrf Weight Path
+ *> 192.168.0.0      0.0.0.0                  0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6-post4.1.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6-post4.1.ref
@@ -5,5 +5,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-   Network          Next Hop            Metric LocPrf Weight Path
-*> fc00::/64        ::                       0         32768 i
+    Network          Next Hop            Metric LocPrf Weight Path
+ *> fc00::/64        ::                       0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6.ref
@@ -3,5 +3,5 @@ Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
 Origin codes: i - IGP, e - EGP, ? - incomplete
 
-   Network          Next Hop            Metric LocPrf Weight Path
-*> fc00::/64        ::                       0         32768 i
+    Network          Next Hop            Metric LocPrf Weight Path
+ *> fc00::/64        ::                       0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6_post6.1.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6_post6.1.ref
@@ -6,5 +6,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-   Network          Next Hop            Metric LocPrf Weight Path
-*> fc00::/64        ::                       0         32768 i
+    Network          Next Hop            Metric LocPrf Weight Path
+ *> fc00::/64        ::                       0         32768 i


### PR DESCRIPTION
Column headers in BGP routes table are not aligned with data when RPKI status is available.  This was fixed to insert a space at the beginning of the header and at the beginning of lines that do not have RPKI status.

This fix requires that several testing templates be adjusted to match the new output.

Signed-off-by: Wayne Morrison <wmorrison@netgate.com>