### PR TITLE
pimd, pim6d: Fix rp-info OIF having PIM disabled interface

### DIFF
--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -950,10 +950,12 @@ void pim_rp_setup(struct pim_instance *pim)
 
 		pim_find_or_track_nexthop(pim, nht_p, NULL, rp_info, NULL);
 		if (!pim_ecmp_nexthop_lookup(pim, &rp_info->rp.source_nexthop,
-					     nht_p, &rp_info->group, 1))
+					     nht_p, &rp_info->group, 1)) {
 			if (PIM_DEBUG_PIM_NHT_RP)
 				zlog_debug(
 					"Unable to lookup nexthop for rp specified");
+			pim_rp_nexthop_del(rp_info);
+		}
 	}
 }
 


### PR DESCRIPTION
Problem:
```
frr(config)# show ip pim rp-info
RP address group/prefix-list OIF I am RP Source Group-Type 109.0.0.3 224.0.0.0/4 ens192 no Static ASM

frr(config)# int ens192
frr(config-if)# no ip pim

frr(config) show ip pim rp-info
RP address group/prefix-list OIF I am RP Source Group-Type 109.0.0.3 224.0.0.0/4 ens192 no Static ASM
```
rp-info OIF is still having ens192 which is PIM disabled. Fixing this as part of this PR.

Issue: #12044

Signed-off-by: Sarita Patra <saritap@vmware.com>