### PR TITLE
lib: remove deadcode when reading "link_params"

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2387,15 +2387,13 @@ struct interface *zebra_interface_link_params_read(struct stream *s,
 	if (changed == NULL)
 		return ifp;
 
-	if (iflp_prev_set && iflp) {
+	if (iflp_prev_set) {
 		if (memcmp(&iflp_prev, iflp, sizeof(iflp_prev)))
 			*changed = true;
 		else
 			*changed = false;
-	} else if (!iflp_prev_set && !iflp)
+	} else
 		*changed = false;
-	else
-		*changed = true;
 
 	return ifp;
 


### PR DESCRIPTION
Fix CID#1526738: DEADCODE

During `zebra_interface_link_params_read()`'s checking link params change or not, `iflp_prev_set` is enough.  `iflp` is unnecessary, so remove the part of it.