### PR TITLE
bgpd: Check for IP-format Site-of-Origin

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2418,7 +2418,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 		if (aspath_check_as_sets(attr->aspath))
 			return false;
 
-	/* If neighbor sso is configured, then check if the route has
+	/* If neighbor soo is configured, then check if the route has
 	 * SoO extended community and validate against the configured
 	 * one. If they match, do not announce, to prevent routing
 	 * loops.
@@ -2431,6 +2431,8 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 		if ((ecommunity_lookup(ecomm, ECOMMUNITY_ENCODE_AS,
 				       ECOMMUNITY_SITE_ORIGIN) ||
 		     ecommunity_lookup(ecomm, ECOMMUNITY_ENCODE_AS4,
+				       ECOMMUNITY_SITE_ORIGIN) ||
+		     ecommunity_lookup(ecomm, ECOMMUNITY_ENCODE_IP,
 				       ECOMMUNITY_SITE_ORIGIN)) &&
 		    ecommunity_include(ecomm, ecomm_soo)) {
 			if (bgp_debug_update(NULL, p, subgrp->update_group, 0))


### PR DESCRIPTION
When deciding whether to apply "neighbor soo" filtering towards a peer, we were only looking for SoO ecoms that use either AS or AS4 encoding. This makes sure we also check for IPv4 encoding, since we allow a user to configure that encoding style against the peer.

Config:
```
router bgp 1
 address-family ipv4 unicast
  network 100.64.0.2/32 route-map soo-foo
  neighbor 192.168.122.12 soo 3.3.3.3:20
 exit-address-family
!
route-map soo-foo permit 10
 set extcommunity soo 3.3.3.3:20
exit
```

Before:
```
ub20# show ip bgp neighbors 192.168.122.12 advertised-routes
BGP table version is 5, local router ID is 100.64.0.222, vrf id 0
Default local pref 100, local AS 1
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

    Network          Next Hop            Metric LocPrf Weight Path
*> 2.2.2.2/32       0.0.0.0                  0    100  32768 i
*> 100.64.0.2/32    0.0.0.0                  0    100  32768 i

Total number of prefixes 2
```

After:
```
ub20# show ip bgp neighbors 192.168.122.12 advertised-routes
BGP table version is 5, local router ID is 100.64.0.222, vrf id 0
Default local pref 100, local AS 1
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

    Network          Next Hop            Metric LocPrf Weight Path
*> 2.2.2.2/32       0.0.0.0                  0    100  32768 i

Total number of prefixes 1
```

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>