### PR TITLE
bgpd: Fix the condition whether nexthop is changed

### DIFF
--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -527,7 +527,7 @@ struct stream *bpacket_reformat_for_peer(struct bpacket *pkt,
 			   && !CHECK_FLAG(vec->flags,
 					  BPKT_ATTRVEC_FLAGS_RMAP_NH_UNCHANGED)
 			   && !peer_af_flag_check(
-				   peer, nhafi, paf->safi,
+				   peer, paf->afi, paf->safi,
 				   PEER_FLAG_NEXTHOP_UNCHANGED)) {
 			/* NOTE: not handling case where NH has new AFI
 			 */


### PR DESCRIPTION
Given that the following topology, route server MUST not modify NEXT_HOP attribute because route server isn't in the actual routing path. This behavior is required to comply RFC7947:

RFC7947 says as follows:

> As the route server does not participate in the actual routing of
> traffic, the NEXT_HOP attribute MUST be passed unmodified to the route
> server clients, similar to the "third-party" next-hop
> feature described in Section 5.1.3. of [RFC4271].

However, current FRR is violating RFC7947 in some cases. If routers and route server established BGP peer over IPv6 connection and routers advertise ipv4-vpn routes through route server, route server will modify NEXT_HOP attribute in these advertisements.

This is because the condition to check whether NEXT_HOP attribute should be changed or not is wrong. We should use (afi, safi) as the key to check, but (nhafi, safi) is actually used. This causes the RFC7947 violation.

Signed-off-by: Ryoga Saito <ryoga.saito@linecorp.com>

## The actual behavior

<img width="403" alt="topology" src="https://user-images.githubusercontent.com/18246032/198170347-7558aa9b-d660-4a9f-ad0c-efc9a3c38c66.png">

**sv02**

```
sv02# show bgp ipv4 vpn
BGP table version is 173, local router ID is 10.254.10.6, vrf id 0
Default local pref 100, local AS 4216648710
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 0:395108
*= 0.0.0.0/0        fd00:0:0:3::1          200             0 4216648711 ?
*>                  fd00:0:0:4::1          200             0 4216648712 ?
*> 10.254.201.2/32  fd00:0:0:3::1            0             0 4216648711 ?
*                   fd00:0:0:4::1                          0 4216648712 4216648712 ?
*  10.254.201.4/32  fd00:0:0:3::1                          0 4216648711 4216648711 ?
*>                  fd00:0:0:4::1            0             0 4216648712 ?

Displayed  3 routes and 6 total paths
```

**sv03**

```
sv03# show bgp ipv4 vpn
BGP table version is 14, local router ID is 10.254.10.7, vrf id 0
Default local pref 100, local AS 4216648711
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 0:395108
*  0.0.0.0/0        fd00:0:0:2::1          200             0 4216648712 ?
                    fd00:0:0:3::1@9          0             0 65000 i
*>                  fd00:0:0:3::1@9        200         32768 ?
*> 10.254.201.2/32  fd00:0:0:3::1@9          0         32768 ?
*> 10.254.201.4/32  fd00:0:0:2::1            0             0 4216648712 ?

Displayed  3 routes and 5 total paths
```

**sv04**

```
sv04# show bgp ipv4 vpn
BGP table version is 4, local router ID is 10.254.10.8, vrf id 0
Default local pref 100, local AS 4216648712
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 0:395108
*> 0.0.0.0/0        fd00:0:0:4::1@19
                                           200         32768 ?
*> 10.254.201.2/32  fd00:0:0:2::1            0             0 4216648711 ?
*> 10.254.201.4/32  fd00:0:0:4::1@19
                                             0         32768 ?

Displayed  3 routes and 3 total paths
```