### PR TITLE
pimd: fixing some coverity issues

### DIFF
--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -495,11 +495,12 @@ static int pim_ecmp_nexthop_search(struct pim_instance *pim,
 	uint32_t hash_val = 0, mod_val = 0;
 	uint8_t nh_iter = 0, found = 0;
 	uint32_t i, num_nbrs = 0;
-	pim_addr nh_addr = nexthop->mrib_nexthop_addr;
-	pim_addr grp_addr = pim_addr_from_prefix(grp);
 
 	if (!pnc || !pnc->nexthop_num || !nexthop)
 		return 0;
+
+	pim_addr nh_addr = nexthop->mrib_nexthop_addr;
+	pim_addr grp_addr = pim_addr_from_prefix(grp);
 
 	memset(&nbrs, 0, sizeof(nbrs));
 	memset(&ifps, 0, sizeof(ifps));

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -49,7 +49,8 @@ tib_sg_oil_setup(struct pim_instance *pim, pim_sgaddr sg, struct interface *oif)
 	if (up) {
 		memcpy(&nexthop, &up->rpf.source_nexthop,
 		       sizeof(struct pim_nexthop));
-		pim_ecmp_nexthop_lookup(pim, &nexthop, vif_source, &grp, 0);
+		(void)pim_ecmp_nexthop_lookup(pim, &nexthop, vif_source, &grp,
+					      0);
 		if (nexthop.interface)
 			input_iface_vif_index = pim_if_find_vifindex_by_ifindex(
 				pim, nexthop.interface->ifindex);


### PR DESCRIPTION
Fixing the coverity issues
Unchecked return value (CID 1519816) and 
Dereference before null check (CID 1519749)

Check commits for more details.