### PR TITLE
ospfd: remove asster on zero length LSA - which is permitted by spec

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -3596,7 +3596,8 @@ int ospf_lsa_different(struct ospf_lsa *l1, struct ospf_lsa *l2,
 	    && CHECK_FLAG((l1->flags ^ l2->flags), OSPF_LSA_RECEIVED))
 		return 1; /* May be a stale LSA in the LSBD */
 
-	assert(l1->size > OSPF_LSA_HEADER_SIZE);
+	if (l1->size == OSPF_LSA_HEADER_SIZE)
+		return 0; /* nothing to compare */
 
 	p1 = (char *)l1->data;
 	p2 = (char *)l2->data;

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -1716,6 +1716,12 @@ static struct list *ospf_ls_upd_list_lsa(struct ospf_neighbor *nbr,
 			break;
 		}
 
+		if (length < OSPF_LSA_HEADER_SIZE) {
+			flog_warn(EC_OSPF_PACKET,
+				  "Link State Update: LSA length too small.");
+			break;
+		}
+
 		/* Validate the LSA's LS checksum. */
 		sum = lsah->checksum;
 		if (!ospf_lsa_checksum_valid(lsah)) {


### PR DESCRIPTION
removing incorrect assert