### PR TITLE
bgpd: Set `tovpn_sid_locator` to NULL after freeing memory

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -362,6 +362,7 @@ static int bgp_srv6_locator_unset(struct bgp *bgp)
 
 		/* refresh per-vrf tovpn_sid_locator */
 		srv6_locator_chunk_free(bgp_vrf->tovpn_sid_locator);
+		bgp_vrf->tovpn_sid_locator = NULL;
 	}
 
 	/* clear locator name */

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3372,8 +3372,10 @@ static int bgp_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 			tmp_prefi.prefixlen = IPV6_MAX_BITLEN;
 			tmp_prefi.prefix = tovpn_sid_locator->prefix.prefix;
 			if (prefix_match((struct prefix *)&loc.prefix,
-					 (struct prefix *)&tmp_prefi))
+					 (struct prefix *)&tmp_prefi)) {
 				srv6_locator_chunk_free(tovpn_sid_locator);
+				bgp_vrf->tovpn_sid_locator = NULL;
+			}
 		}
 	}
 


### PR DESCRIPTION
After freeing the memory of the `tovpn_sid_locator`, we need to set the pointer to `NULL`. Failure to set the pointer to `NULL` could result in other functions treating the pointer as valid despite the memory being freed.

This PR ensures that the pointer to `tovpn_sid_locator` is set to NULL after freeing the memory in `bgp_zebra_process_srv6_locator_delete()` and `bgp_srv6_locator_unset()`.

Signed-off-by: Carmine Scarpitta <carmine.scarpitta@uniroma2.it>