### PR TITLE
ospfd: fix bug where acks were not be generated to incoming P2P/P2MP peers

### DIFF
--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -818,6 +818,11 @@ int ospf_flood_through(struct ospf *ospf, struct ospf_neighbor *inbr,
 		break;
 	}
 
+	/* always need to send ack when incoming intf is PTP or P2MP */
+	if (inbr != NULL && (inbr->oi->type == OSPF_IFTYPE_POINTOMULTIPOINT ||
+			     inbr->oi->type == OSPF_IFTYPE_POINTOPOINT))
+		lsa_ack_flag = 1;
+
 	return (lsa_ack_flag);
 }
 


### PR DESCRIPTION
This looks like an original but - the recent P2MP optimization made it more obvious.