### PR TITLE
bgpd: Enhance the `srv6_locator_chunk_free()` API by automatically setting the pointer to the freed memory to `NULL`

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -892,7 +892,6 @@ void delete_vrf_tovpn_sid_per_af(struct bgp *bgp_vpn, struct bgp *bgp_vrf,
 		return;
 
 	srv6_locator_chunk_free(&bgp_vrf->vpn_policy[afi].tovpn_sid_locator);
-	bgp_vrf->vpn_policy[afi].tovpn_sid_locator = NULL;
 
 	if (bgp_vrf->vpn_policy[afi].tovpn_sid) {
 		sid_unregister(bgp_vrf, bgp_vrf->vpn_policy[afi].tovpn_sid);
@@ -920,7 +919,6 @@ void delete_vrf_tovpn_sid_per_vrf(struct bgp *bgp_vpn, struct bgp *bgp_vrf)
 		return;
 
 	srv6_locator_chunk_free(&bgp_vrf->tovpn_sid_locator);
-	bgp_vrf->tovpn_sid_locator = NULL;
 
 	if (bgp_vrf->tovpn_sid) {
 		sid_unregister(bgp_vrf, bgp_vrf->tovpn_sid);

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -779,7 +779,7 @@ void ensure_vrf_tovpn_sid_per_af(struct bgp *bgp_vpn, struct bgp *bgp_vrf,
 			zlog_debug(
 				"%s: not allocated new sid for vrf %s: afi %s",
 				__func__, bgp_vrf->name_pretty, afi2str(afi));
-		srv6_locator_chunk_free(tovpn_sid_locator);
+		srv6_locator_chunk_free(&tovpn_sid_locator);
 		XFREE(MTYPE_BGP_SRV6_SID, tovpn_sid);
 		return;
 	}
@@ -844,7 +844,7 @@ void ensure_vrf_tovpn_sid_per_vrf(struct bgp *bgp_vpn, struct bgp *bgp_vrf)
 		if (debug)
 			zlog_debug("%s: not allocated new sid for vrf %s",
 				   __func__, bgp_vrf->name_pretty);
-		srv6_locator_chunk_free(tovpn_sid_locator);
+		srv6_locator_chunk_free(&tovpn_sid_locator);
 		XFREE(MTYPE_BGP_SRV6_SID, tovpn_sid);
 		return;
 	}
@@ -891,7 +891,7 @@ void delete_vrf_tovpn_sid_per_af(struct bgp *bgp_vpn, struct bgp *bgp_vrf,
 	if (tovpn_sid_index != 0 || tovpn_sid_auto)
 		return;
 
-	srv6_locator_chunk_free(bgp_vrf->vpn_policy[afi].tovpn_sid_locator);
+	srv6_locator_chunk_free(&bgp_vrf->vpn_policy[afi].tovpn_sid_locator);
 	bgp_vrf->vpn_policy[afi].tovpn_sid_locator = NULL;
 
 	if (bgp_vrf->vpn_policy[afi].tovpn_sid) {
@@ -919,7 +919,7 @@ void delete_vrf_tovpn_sid_per_vrf(struct bgp *bgp_vpn, struct bgp *bgp_vrf)
 	if (tovpn_sid_index != 0 || tovpn_sid_auto)
 		return;
 
-	srv6_locator_chunk_free(bgp_vrf->tovpn_sid_locator);
+	srv6_locator_chunk_free(&bgp_vrf->tovpn_sid_locator);
 	bgp_vrf->tovpn_sid_locator = NULL;
 
 	if (bgp_vrf->tovpn_sid) {

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -347,20 +347,16 @@ static int bgp_srv6_locator_unset(struct bgp *bgp)
 		/* refresh vpnv4 tovpn_sid_locator */
 		tovpn_sid_locator =
 			bgp_vrf->vpn_policy[AFI_IP].tovpn_sid_locator;
-		if (tovpn_sid_locator) {
+		if (tovpn_sid_locator)
 			srv6_locator_chunk_free(
 				&bgp_vrf->vpn_policy[AFI_IP].tovpn_sid_locator);
-			bgp_vrf->vpn_policy[AFI_IP].tovpn_sid_locator = NULL;
-		}
 
 		/* refresh vpnv6 tovpn_sid_locator */
 		tovpn_sid_locator =
 			bgp_vrf->vpn_policy[AFI_IP6].tovpn_sid_locator;
-		if (tovpn_sid_locator) {
+		if (tovpn_sid_locator)
 			srv6_locator_chunk_free(&bgp_vrf->vpn_policy[AFI_IP6]
 							 .tovpn_sid_locator);
-			bgp_vrf->vpn_policy[AFI_IP6].tovpn_sid_locator = NULL;
-		}
 
 		/* refresh per-vrf tovpn_sid_locator */
 		srv6_locator_chunk_free(&bgp_vrf->tovpn_sid_locator);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -297,7 +297,7 @@ static int bgp_srv6_locator_unset(struct bgp *bgp)
 {
 	int ret;
 	struct listnode *node, *nnode;
-	struct srv6_locator_chunk *chunk, *tovpn_sid_locator;
+	struct srv6_locator_chunk *chunk;
 	struct bgp_srv6_function *func;
 	struct bgp *bgp_vrf;
 
@@ -345,18 +345,12 @@ static int bgp_srv6_locator_unset(struct bgp *bgp)
 			continue;
 
 		/* refresh vpnv4 tovpn_sid_locator */
-		tovpn_sid_locator =
-			bgp_vrf->vpn_policy[AFI_IP].tovpn_sid_locator;
-		if (tovpn_sid_locator)
-			srv6_locator_chunk_free(
-				&bgp_vrf->vpn_policy[AFI_IP].tovpn_sid_locator);
+		srv6_locator_chunk_free(
+			&bgp_vrf->vpn_policy[AFI_IP].tovpn_sid_locator);
 
 		/* refresh vpnv6 tovpn_sid_locator */
-		tovpn_sid_locator =
-			bgp_vrf->vpn_policy[AFI_IP6].tovpn_sid_locator;
-		if (tovpn_sid_locator)
-			srv6_locator_chunk_free(&bgp_vrf->vpn_policy[AFI_IP6]
-							 .tovpn_sid_locator);
+		srv6_locator_chunk_free(
+			&bgp_vrf->vpn_policy[AFI_IP6].tovpn_sid_locator);
 
 		/* refresh per-vrf tovpn_sid_locator */
 		srv6_locator_chunk_free(&bgp_vrf->tovpn_sid_locator);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -310,7 +310,7 @@ static int bgp_srv6_locator_unset(struct bgp *bgp)
 	/* refresh chunks */
 	for (ALL_LIST_ELEMENTS(bgp->srv6_locator_chunks, node, nnode, chunk)) {
 		listnode_delete(bgp->srv6_locator_chunks, chunk);
-		srv6_locator_chunk_free(chunk);
+		srv6_locator_chunk_free(&chunk);
 	}
 
 	/* refresh functions */
@@ -348,7 +348,8 @@ static int bgp_srv6_locator_unset(struct bgp *bgp)
 		tovpn_sid_locator =
 			bgp_vrf->vpn_policy[AFI_IP].tovpn_sid_locator;
 		if (tovpn_sid_locator) {
-			srv6_locator_chunk_free(tovpn_sid_locator);
+			srv6_locator_chunk_free(
+				&bgp_vrf->vpn_policy[AFI_IP].tovpn_sid_locator);
 			bgp_vrf->vpn_policy[AFI_IP].tovpn_sid_locator = NULL;
 		}
 
@@ -356,12 +357,13 @@ static int bgp_srv6_locator_unset(struct bgp *bgp)
 		tovpn_sid_locator =
 			bgp_vrf->vpn_policy[AFI_IP6].tovpn_sid_locator;
 		if (tovpn_sid_locator) {
-			srv6_locator_chunk_free(tovpn_sid_locator);
+			srv6_locator_chunk_free(&bgp_vrf->vpn_policy[AFI_IP6]
+							 .tovpn_sid_locator);
 			bgp_vrf->vpn_policy[AFI_IP6].tovpn_sid_locator = NULL;
 		}
 
 		/* refresh per-vrf tovpn_sid_locator */
-		srv6_locator_chunk_free(bgp_vrf->tovpn_sid_locator);
+		srv6_locator_chunk_free(&bgp_vrf->tovpn_sid_locator);
 	}
 
 	/* clear locator name */

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3343,13 +3343,10 @@ static int bgp_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 			tmp_prefi.prefixlen = IPV6_MAX_BITLEN;
 			tmp_prefi.prefix = tovpn_sid_locator->prefix.prefix;
 			if (prefix_match((struct prefix *)&loc.prefix,
-					 (struct prefix *)&tmp_prefi)) {
+					 (struct prefix *)&tmp_prefi))
 				srv6_locator_chunk_free(
 					&bgp_vrf->vpn_policy[AFI_IP]
 						 .tovpn_sid_locator);
-				bgp_vrf->vpn_policy[AFI_IP].tovpn_sid_locator =
-					NULL;
-			}
 		}
 
 		/* refresh vpnv6 tovpn_sid_locator */
@@ -3360,13 +3357,10 @@ static int bgp_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 			tmp_prefi.prefixlen = IPV6_MAX_BITLEN;
 			tmp_prefi.prefix = tovpn_sid_locator->prefix.prefix;
 			if (prefix_match((struct prefix *)&loc.prefix,
-					 (struct prefix *)&tmp_prefi)) {
+					 (struct prefix *)&tmp_prefi))
 				srv6_locator_chunk_free(
 					&bgp_vrf->vpn_policy[AFI_IP6]
 						 .tovpn_sid_locator);
-				bgp_vrf->vpn_policy[AFI_IP6].tovpn_sid_locator =
-					NULL;
-			}
 		}
 
 		/* refresh per-vrf tovpn_sid_locator */

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3219,13 +3219,13 @@ static int bgp_zebra_process_srv6_locator_chunk(ZAPI_CALLBACK_ARGS)
 	if (strcmp(bgp->srv6_locator_name, chunk->locator_name) != 0) {
 		zlog_err("%s: Locator name unmatch %s:%s", __func__,
 			 bgp->srv6_locator_name, chunk->locator_name);
-		srv6_locator_chunk_free(chunk);
+		srv6_locator_chunk_free(&chunk);
 		return 0;
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(bgp->srv6_locator_chunks, node, c)) {
 		if (!prefix_cmp(&c->prefix, &chunk->prefix)) {
-			srv6_locator_chunk_free(chunk);
+			srv6_locator_chunk_free(&chunk);
 			return 0;
 		}
 	}
@@ -3272,7 +3272,7 @@ static int bgp_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 		if (prefix_match((struct prefix *)&loc.prefix,
 				 (struct prefix *)&chunk->prefix)) {
 			listnode_delete(bgp->srv6_locator_chunks, chunk);
-			srv6_locator_chunk_free(chunk);
+			srv6_locator_chunk_free(&chunk);
 		}
 
 	// refresh functions
@@ -3344,7 +3344,9 @@ static int bgp_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 			tmp_prefi.prefix = tovpn_sid_locator->prefix.prefix;
 			if (prefix_match((struct prefix *)&loc.prefix,
 					 (struct prefix *)&tmp_prefi)) {
-				srv6_locator_chunk_free(tovpn_sid_locator);
+				srv6_locator_chunk_free(
+					&bgp_vrf->vpn_policy[AFI_IP]
+						 .tovpn_sid_locator);
 				bgp_vrf->vpn_policy[AFI_IP].tovpn_sid_locator =
 					NULL;
 			}
@@ -3359,7 +3361,9 @@ static int bgp_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 			tmp_prefi.prefix = tovpn_sid_locator->prefix.prefix;
 			if (prefix_match((struct prefix *)&loc.prefix,
 					 (struct prefix *)&tmp_prefi)) {
-				srv6_locator_chunk_free(tovpn_sid_locator);
+				srv6_locator_chunk_free(
+					&bgp_vrf->vpn_policy[AFI_IP6]
+						 .tovpn_sid_locator);
 				bgp_vrf->vpn_policy[AFI_IP6].tovpn_sid_locator =
 					NULL;
 			}
@@ -3373,7 +3377,8 @@ static int bgp_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 			tmp_prefi.prefix = tovpn_sid_locator->prefix.prefix;
 			if (prefix_match((struct prefix *)&loc.prefix,
 					 (struct prefix *)&tmp_prefi))
-				srv6_locator_chunk_free(tovpn_sid_locator);
+				srv6_locator_chunk_free(
+					&bgp_vrf->tovpn_sid_locator);
 		}
 	}
 

--- a/lib/srv6.c
+++ b/lib/srv6.c
@@ -157,9 +157,9 @@ void srv6_locator_free(struct srv6_locator *locator)
 	}
 }
 
-void srv6_locator_chunk_free(struct srv6_locator_chunk *chunk)
+void srv6_locator_chunk_free(struct srv6_locator_chunk **chunk)
 {
-	XFREE(MTYPE_SRV6_LOCATOR_CHUNK, chunk);
+	XFREE(MTYPE_SRV6_LOCATOR_CHUNK, *chunk);
 }
 
 json_object *srv6_locator_chunk_json(const struct srv6_locator_chunk *chunk)

--- a/lib/srv6.h
+++ b/lib/srv6.h
@@ -187,7 +187,7 @@ int snprintf_seg6_segs(char *str,
 extern struct srv6_locator *srv6_locator_alloc(const char *name);
 extern struct srv6_locator_chunk *srv6_locator_chunk_alloc(void);
 extern void srv6_locator_free(struct srv6_locator *locator);
-extern void srv6_locator_chunk_free(struct srv6_locator_chunk *chunk);
+extern void srv6_locator_chunk_free(struct srv6_locator_chunk **chunk);
 json_object *srv6_locator_chunk_json(const struct srv6_locator_chunk *chunk);
 json_object *srv6_locator_json(const struct srv6_locator *loc);
 json_object *srv6_locator_detailed_json(const struct srv6_locator *loc);


### PR DESCRIPTION
A programmer can use the `srv6_locator_chunk_free()` function to free the memory allocated for a `struct srv6_locator_chunk`.

The programmer invokes `srv6_locator_chunk_free()` by passing a single pointer to the `struct srv6_locator_chunk` to be freed. `srv6_locator_chunk_free()` uses `XFREE()` to free the memory. It is the responsibility of the programmer to set the
`struct srv6_locator_chunk` pointer to NULL after freeing memory with `srv6_locator_chunk_free()`.

This PR modifies the `srv6_locator_chunk_free()` function to take a double pointer instead of a single pointer. In this way, setting the `struct srv6_locator_chunk` pointer to NULL is no longer the programmer's responsibility but is the responsibility of
`srv6_locator_chunk_free()`. This prevents programmers from making mistakes such as forgetting to set the pointer to NULL after invoking `srv6_locator_chunk_free()`.

Signed-off-by: Carmine Scarpitta <carmine.scarpitta@uniroma2.it>