### PR TITLE
doc: fix ospf's max-metric command

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -195,7 +195,7 @@ To start OSPF process you have to specify the OSPF router.
    This command supersedes the *timers spf* command in previous FRR
    releases.
 
-.. clicmd:: max-metric router-lsa [on-startup|on-shutdown] (5-86400)
+.. clicmd:: max-metric router-lsa [on-startup (5-86400)|on-shutdown (5-100)]
 
 .. clicmd:: max-metric router-lsa administrative
 


### PR DESCRIPTION
"on-shutdown" and "on-startup" have the different timeout range.

Correct the timeout range for "on-shutdown" based on the current code:

```
(ospf)  max-metric router-lsa on-shutdown (5-100)
```