### PR TITLE
bgpd: avoid possible memleak

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -6639,9 +6639,10 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 				char *vni_str = NULL;
 
 				vni_str = strchr(ecom_str, ':');
-
-				if (!vni_str)
-					continue; /* This should never happen */
+				if (!vni_str) {
+					XFREE(MTYPE_ECOMMUNITY_STR, ecom_str);
+					continue;
+				}
 
 				/* Move pointer to vni */
 				vni_str += 1;


### PR DESCRIPTION
~~Since it will never happen without ':' in `ecom_str`, change it into `assert()`. Otherwise, memleak on this `ecom_str` will occur in this case.~~

In the case of without ':' in `ecom_str`, memleak on this `ecom_str` will occur. Just free `ecom_str` for this case.
