### PR TITLE
isisd: create ext_reachability tlv when necessary

### DIFF
--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -301,8 +301,14 @@ void isis_circuit_add_addr(struct isis_circuit *circuit,
 		listnode_add(circuit->ip_addrs, ipv4);
 
 		/* Update Local IP address parameter if MPLS TE is enable */
-		if (circuit->ext && circuit->area
-		    && IS_MPLS_TE(circuit->area->mta)) {
+		if (circuit->area && connected->ifp && IS_MPLS_TE(circuit->area->mta)) {
+			/* Check if MPLS TE Circuit context has not been already
+			 * created */
+			if (circuit->ext == NULL) {
+				circuit->ext = isis_alloc_ext_subtlvs();
+				te_debug("  |- Allocated new Ext-subTLVs for interface %s",
+					 connected->ifp->name);
+			}
 			circuit->ext->local_addr.s_addr = ipv4->prefix.s_addr;
 			SET_SUBTLV(circuit->ext, EXT_LOCAL_ADDR);
 		}
@@ -340,8 +346,12 @@ void isis_circuit_add_addr(struct isis_circuit *circuit,
 		else {
 			listnode_add(circuit->ipv6_non_link, ipv6);
 			/* Update Local IPv6 address param. if MPLS TE is on */
-			if (circuit->ext && circuit->area
-			    && IS_MPLS_TE(circuit->area->mta)) {
+			if (circuit->area && connected->ifp && IS_MPLS_TE(circuit->area->mta)) {
+				if (circuit->ext == NULL) {
+					circuit->ext = isis_alloc_ext_subtlvs();
+					te_debug("  |- Allocated new Ext-subTLVs for interface %s",
+						 connected->ifp->name);
+				}
 				IPV6_ADDR_COPY(&circuit->ext->local_addr6,
 					       &ipv6->prefix);
 				SET_SUBTLV(circuit->ext, EXT_LOCAL_ADDR6);


### PR DESCRIPTION
This commit addresses the case where the LSP entries of a given device do not contain the local address in the ISIS ext TLV option. The below output shows that the local address is not present in the option:

east-vm# show isis database detail east-vm.00-00
[..]
  Extended Reachability: 0007.e901.1111.00 (Metric: 10)
    Remote Interface IP Address(es): 10.125.0.1
    Adjacency-SID: 30000, Weight: 0, Flags: F:0 B:0, V:1, L:1, S:0, P:0
  Extended Reachability: 0007.e901.3333.00 (Metric: 10)
    Remote Interface IP Address(es): 10.126.0.3
    Adjacency-SID: 30001, Weight: 0, Flags: F:0 B:0, V:1, L:1, S:0, P:0
[..]

The below output shows what is expected:

east-vm# show isis database detail east-vm.00-00
[..]
  Extended Reachability: 0007.e901.1111.00 (Metric: 10)
    Local Interface IP Address(es): 10.125.0.2
    Remote Interface IP Address(es): 10.125.0.1
    Adjacency-SID: 30000, Weight: 0, Flags: F:0 B:0, V:1, L:1, S:0, P:0
  Extended Reachability: 0007.e901.3333.00 (Metric: 10)
    Local Interface IP Address(es): 10.126.0.2
    Remote Interface IP Address(es): 10.126.0.3
    Adjacency-SID: 30001, Weight: 0, Flags: F:0 B:0, V:1, L:1, S:0, P:0

Not having the local address in the LSP results in creating an invalid traffic engineering database. This inconsistency leads to crashes when unconfiguring the isis instance.

The analysis shows the following:
When the configuration is loaded at startup, the interfaces are not always available, and the presence of the interface may be detected after the MPLS-TE activation is done. When the new interface event is triggered, the area is attahed to the new interface circuit, but as the TLV extension has not been initialised on the circuit, it is not possible to populate the local address of the interface.

The proposed commit consists in creating the TLV extension structure if MPLS-TE is enabled. Then the local address is populated.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>