### PR TITLE
snmp and peer down issues

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1237,7 +1237,7 @@ static void bgp_update_delay_process_status_change(struct peer *peer)
 
 /* Called after event occurred, this function change status and reset
    read/write and timer thread. */
-void bgp_fsm_change_status(struct peer *peer, int status)
+void bgp_fsm_change_status(struct peer *peer, enum bgp_fsm_status status)
 {
 	struct bgp *bgp;
 	uint32_t peer_count;

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -125,7 +125,8 @@ extern int bgp_event_update(struct peer *, enum bgp_fsm_events event);
 extern int bgp_stop(struct peer *peer);
 extern void bgp_timer_set(struct peer *);
 extern void bgp_routeadv_timer(struct thread *);
-extern void bgp_fsm_change_status(struct peer *peer, int status);
+extern void bgp_fsm_change_status(struct peer *peer,
+				  enum bgp_fsm_status status);
 extern const char *const peer_down_str[];
 extern void bgp_update_delay_end(struct bgp *);
 extern void bgp_maxmed_update(struct bgp *);

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -82,6 +82,8 @@ static const struct option longopts[] = {
 	{"socket_size", required_argument, NULL, 's'},
 	{0}};
 
+DEFINE_HOOK(bgp_snmp_shutdown, (), ());
+
 /* signal definitions */
 void sighup(void);
 void sigint(void);
@@ -194,6 +196,11 @@ static __attribute__((__noreturn__)) void bgp_exit(int status)
 	assert(status == 0);
 
 	frr_early_fini();
+
+	/*
+	 * Let's intentionally just turn snmp off.
+	 */
+	hook_call(bgp_snmp_shutdown);
 
 	bgp_close();
 

--- a/bgpd/bgp_snmp.c
+++ b/bgpd/bgp_snmp.c
@@ -925,11 +925,19 @@ static int bgp_snmp_init(struct thread_master *tm)
 	return 0;
 }
 
+static int bgp_snmp_shutdown(void)
+{
+	smux_disable();
+
+	return 0;
+}
+
 static int bgp_snmp_module_init(void)
 {
 	hook_register(peer_status_changed, bgpTrapEstablished);
 	hook_register(peer_backward_transition, bgpTrapBackwardTransition);
 	hook_register(frr_late_init, bgp_snmp_init);
+	hook_register(bgp_snmp_shutdown, bgp_snmp_shutdown);
 	return 0;
 }
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2444,6 +2444,7 @@ int peer_delete(struct peer *peer)
 	bgp_keepalives_off(peer);
 	bgp_reads_off(peer);
 	bgp_writes_off(peer);
+	THREAD_OFF(peer->t_down_event);
 	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON));
 	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_READS_ON));
 	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_KEEPALIVES_ON));

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1558,6 +1558,7 @@ struct peer {
 	struct thread *t_process_packet;
 	struct thread *t_process_packet_error;
 	struct thread *t_refresh_stalepath;
+	struct thread *t_down_event;
 
 	/* Thread flags. */
 	_Atomic uint32_t thread_flags;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2653,7 +2653,7 @@ DECLARE_HOOK(bgp_rpki_prefix_status,
 	     (struct peer * peer, struct attr *attr,
 	      const struct prefix *prefix),
 	     (peer, attr, prefix));
-
+DECLARE_HOOK(bgp_snmp_shutdown, (), ());
 void peer_nsf_stop(struct peer *peer);
 
 void peer_tcp_mss_set(struct peer *peer, uint32_t tcp_mss);

--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -245,6 +245,11 @@ DEFUN (no_agentx,
 	return CMD_WARNING_CONFIG_FAILED;
 }
 
+void smux_disable(void)
+{
+	agentx_enabled = false;
+}
+
 bool smux_enabled(void)
 {
 	return agentx_enabled;

--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -398,7 +398,8 @@ int smux_trap_multi_index(struct variable *vp, size_t vp_len, const oid *ename,
 
 void smux_events_update(void)
 {
-	agentx_events_update();
+	if (agentx_enabled)
+		agentx_events_update();
 }
 
 #endif /* SNMP_AGENTX */

--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -38,7 +38,7 @@ XREF_SETUP();
 
 DEFINE_HOOK(agentx_enabled, (), ());
 
-static int agentx_enabled = 0;
+static bool agentx_enabled = false;
 
 static struct thread_master *agentx_tm;
 static struct thread *timeout_thr = NULL;
@@ -226,7 +226,7 @@ DEFUN (agentx_enable,
 		init_snmp(FRR_SMUX_NAME);
 		events = list_new();
 		agentx_events_update();
-		agentx_enabled = 1;
+		agentx_enabled = true;
 		hook_call(agentx_enabled);
 	}
 
@@ -245,7 +245,7 @@ DEFUN (no_agentx,
 	return CMD_WARNING_CONFIG_FAILED;
 }
 
-int smux_enabled(void)
+bool smux_enabled(void)
 {
 	return agentx_enabled;
 }
@@ -272,7 +272,7 @@ void smux_agentx_enable(void)
 		init_snmp(FRR_SMUX_NAME);
 		events = list_new();
 		agentx_events_update();
-		agentx_enabled = 1;
+		agentx_enabled = true;
 	}
 }
 

--- a/lib/smux.h
+++ b/lib/smux.h
@@ -103,7 +103,15 @@ struct index_oid {
 
 #define SNMP_IP6ADDRESS(V) (*var_len = sizeof(struct in6_addr), (uint8_t *)&V)
 
+/*
+ * Check to see if snmp is enabled or not
+ */
 extern bool smux_enabled(void);
+
+/*
+ * On shutdown turn off updates to the snmp subsystem
+ */
+extern void smux_disable(void);
 
 extern void smux_init(struct thread_master *tm);
 extern void smux_agentx_enable(void);

--- a/lib/smux.h
+++ b/lib/smux.h
@@ -103,7 +103,7 @@ struct index_oid {
 
 #define SNMP_IP6ADDRESS(V) (*var_len = sizeof(struct in6_addr), (uint8_t *)&V)
 
-extern int smux_enabled(void);
+extern bool smux_enabled(void);
 
 extern void smux_init(struct thread_master *tm);
 extern void smux_agentx_enable(void);


### PR DESCRIPTION
See individual commits

a) use the enum luke
b) snmp traps can block.  Ensure that proper processing is done
c) Large numbers of peers on an interface can take up signficant cpu time shutting down, break it up