### PR TITLE
bgpd: Limit snmp trap for backwards state movement from established

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1304,7 +1304,7 @@ void bgp_fsm_change_status(struct peer *peer, int status)
 	peer->rtt_keepalive_rcv = 0;
 
 	/* Fire backward transition hook if that's the case */
-	if (peer->ostatus > peer->status)
+	if (peer->ostatus == Established && peer->status != Established)
 		hook_call(peer_backward_transition, peer);
 
 	/* Save event that caused status change. */


### PR DESCRIPTION
Currently the bgp mib specifies two traps:

a) Into established state
b) transition backwards from a state

b) really is an interesting case.  It means transitioning from say established to starting over.  It can also mean when bgp is trying to connect and that fails and the state transitions backwards.

Now let's imagine 500 peers with tight timers (say a data center) and there is network trauma you have just created an inordinately large number of traps for each peer.

Let's limit FRR to changing from the old status as Established to something else.  This will greatly limit the trap but it will also be something end operators are actually interested in.

I actually had several operators say they had to write special code to ignore all the backward state transitions that they didn't care about.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>