### PR TITLE
pimd: consistently ignore prefix list mask len

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -1217,8 +1217,9 @@ int pim_ifchannel_local_membership_add(struct interface *ifp, pim_sgaddr *sg,
 				struct prefix g;
 
 				pim_addr_to_prefix(&g, up->sg.grp);
-				if (prefix_list_apply(plist, &g)
-				    == PREFIX_DENY) {
+				if (prefix_list_apply_ext(plist, NULL, &g,
+							  true) ==
+				    PREFIX_DENY) {
 					pim_channel_add_oif(
 						up->channel_oil, pim->regiface,
 						PIM_OIF_FLAG_PROTO_GM,

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -628,7 +628,8 @@ int pim_register_recv(struct interface *ifp, pim_addr dest_addr,
 
 			pim_addr_to_prefix(&src, sg.src);
 
-			if (prefix_list_apply(plist, &src) == PREFIX_DENY) {
+			if (prefix_list_apply_ext(plist, NULL, &src, true) ==
+			    PREFIX_DENY) {
 				pim_register_stop_send(ifp, &sg, dest_addr,
 						       src_addr);
 				if (PIM_DEBUG_PIM_PACKETS)

--- a/pimd/pim_ssm.c
+++ b/pimd/pim_ssm.c
@@ -93,7 +93,8 @@ int pim_is_grp_ssm(struct pim_instance *pim, pim_addr group_addr)
 	if (!plist)
 		return 0;
 
-	return (prefix_list_apply(plist, &group) == PREFIX_PERMIT);
+	return (prefix_list_apply_ext(plist, NULL, &group, true) ==
+		PREFIX_PERMIT);
 }
 
 int pim_ssm_range_set(struct pim_instance *pim, vrf_id_t vrf_id,

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -2153,7 +2153,7 @@ void pim_upstream_remove_lhr_star_pimreg(struct pim_instance *pim,
 			continue;
 		}
 		pim_addr_to_prefix(&g, up->sg.grp);
-		apply_new = prefix_list_apply(np, &g);
+		apply_new = prefix_list_apply_ext(np, NULL, &g, true);
 		if (apply_new == PREFIX_DENY)
 			pim_channel_add_oif(up->channel_oil, pim->regiface,
 					    PIM_OIF_FLAG_PROTO_GM, __func__);

--- a/pimd/pim_util.c
+++ b/pimd/pim_util.c
@@ -150,7 +150,9 @@ bool pim_is_group_filtered(struct pim_interface *pim_ifp, pim_addr *grp)
 	pim_addr_to_prefix(&grp_pfx, *grp);
 
 	pl = prefix_list_lookup(PIM_AFI, pim_ifp->boundary_oil_plist);
-	return pl ? prefix_list_apply(pl, &grp_pfx) == PREFIX_DENY : false;
+	return pl ? prefix_list_apply_ext(pl, NULL, &grp_pfx, true) ==
+			       PREFIX_DENY
+		  : false;
 }
 
 


### PR DESCRIPTION
... the prefix length wasn't ignored as expected.  Both S and G are always /32.  But expecting "le 32" in prefix-list config is unexpected & counterintuitive.

---

it's already ignored in most other places.