### PR TITLE
pimd: avoid one EC log

### DIFF
--- a/pimd/pim_igmp_mtrace.c
+++ b/pimd/pim_igmp_mtrace.c
@@ -770,7 +770,8 @@ int igmp_mtrace_recv_qry_req(struct gm_sock *igmp, struct ip *ip_hdr,
 	}
 
 	/* 6.2.2 8. If this router is the Rendez-vous Point */
-	if (pim_rp_i_am_rp(pim, mtracep->grp_addr)) {
+	if (mtracep->grp_addr.s_addr != INADDR_ANY &&
+	    pim_rp_i_am_rp(pim, mtracep->grp_addr)) {
 		mtrace_rsp_set_fwd_code(rspp, MTRACE_FWD_CODE_REACHED_RP);
 		/* 7.7.1. PIM-SM ...RP has not performed source-specific join */
 		if (rspp->src_mask == MTRACE_SRC_MASK_GROUP)


### PR DESCRIPTION
Saw this EC log:

```
PIM: [WX4HZ-FA72S][EC 100663307] pim_rp_find_match_group: BUG We should have found default group information
```

The root cause is group address of "0.0.0.0" is wrongly introduced into `pim_rp_find_match_group()`. So add a check to avoid it.