### PR TITLE
zebra: Reuse netinet/if_ether.h to avoid redefinition of struct ethhdr

### DIFF
--- a/zebra/tc_netlink.c
+++ b/zebra/tc_netlink.c
@@ -25,7 +25,7 @@
 
 #ifdef HAVE_NETLINK
 
-#include <linux/if_ether.h>
+#include <netinet/if_ether.h>
 #include <sys/socket.h>
 
 #include "if.h"


### PR DESCRIPTION
In file included from /usr/include/net/ethernet.h:10,
                 from ./lib/prefix.h:26,
                 from zebra/tc_netlink.c:32:
/usr/include/netinet/if_ether.h:115:8: error: redefinition of 'struct ethhdr'
  115 | struct ethhdr {
      |        ^~~~~~
In file included from zebra/tc_netlink.c:28:
/usr/include/linux/if_ether.h:169:8: note: originally defined here
  169 | struct ethhdr {
      |        ^~~~~~

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>