### PR TITLE
tools: Add pim6d support bundle commands

### DIFF
--- a/tools/etc/frr/support_bundle_commands.conf
+++ b/tools/etc/frr/support_bundle_commands.conf
@@ -208,3 +208,34 @@ show ipv6 ospf6 vrf all spf tree
 show ipv6 ospf6 vrf all summary-address detail
 show ipv6 ospf6 zebra
 CMD_LIST_END
+
+#PIMv6 Support Bundle Command List
+PROC_NAME:pim6
+CMD_LIST_START
+show ipv6 pim channel
+show ipv6 pim interface
+show ipv6 pim interface traffic
+show ipv6 pim join
+show ipv6 jp-agg
+show ipv6 pim nexthop
+show ipv6 pim nexthop-lookup
+show ipv6 pim neighbor
+show ipv6 pim local-membership
+show ipv6 pim rp-info
+show ipv6 pim rpf
+show ipv6 pim secondary
+show ipv6 pim state
+show ipv6 pim statistics
+show ipv6 pim upstream
+show ipv6 pim upstream-join-desired
+show ipv6 pim upstream-rpf
+show ipv6 mld interface
+show ipv6 mld statistics
+show ipv6 mld joins
+show ipv6 mld groups
+show ipv6 multicast
+show ipv6 mroute
+show ipv6 pim bsr
+show ipv6 pim bsrp-info
+show ipv6 pim bsm-databases
+CMD_LIST_END


### PR DESCRIPTION
PIMv6 Support Bundle commands are added in support_bundle_commands.conf file.
This will help in debugging PIMv6 test Failures.

Issue: #12279 

Signed-off-by: Sai Gomathi <nsaigomathi@vmware.com>