### PR TITLE
tools: Forbid __func__ in logs

### DIFF
--- a/doc/developer/workflow.rst
+++ b/doc/developer/workflow.rst
@@ -1150,6 +1150,9 @@ ways that can be unexpected for the original implementor. As such debugs
 ability to turn on/off debugs from the CLI and it is expected that the
 developer will use this convention to allow control of their debugs.
 
+Do not include the function name (``__func__``) in debug messages.  It is added
+automatically by the logging code.
+
 Custom syntax-like block macros
 -------------------------------
 

--- a/python/xrelfo.py
+++ b/python/xrelfo.py
@@ -189,7 +189,12 @@ class XrefLogmsg(ELFDissectStruct, XrelfoJson):
             "cleanup: replace sockunion2str(...) with %pSU",
             lambda s: True,
         ),
-        #   (re.compile(r'^(\s*__(?:func|FUNCTION|PRETTY_FUNCTION)__\s*)'), 'error: debug message starts with __func__', lambda s: (s.priority & 7 == 7) ),
+        # debug messages should NOT start with "%s: ", __func__
+        (
+            re.compile(r"^(\s*__(?:func|FUNCTION|PRETTY_FUNCTION)__\s*)"),
+            "error: debug message starts with __func__",
+            lambda s: (s.priority & 7 == 7),
+        ),
     ]
 
     def check(self, wopt):


### PR DESCRIPTION
Cherry-picked from https://github.com/FRRouting/frr/pull/10656. 