### PR TITLE
zebra/netconf_netlink.c: fix build without AF_MPLS

### DIFF
--- a/zebra/netconf_netlink.c
+++ b/zebra/netconf_netlink.c
@@ -106,9 +106,11 @@ int netlink_netconf_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	 * to do a good job of not sending data that is mixed/matched
 	 * across families
 	 */
+#ifdef AF_MPLS
 	if (ncm->ncm_family == AF_MPLS)
 		afi = AFI_IP;
 	else
+#endif /* AF_MPLS */
 		afi = family2afi(ncm->ncm_family);
 
 	netlink_parse_rtattr(tb, NETCONFA_MAX, netconf_rta(ncm), len);


### PR DESCRIPTION
Fix the following build failure raised since version 8.4 and https://github.com/FRRouting/frr/commit/d53dc9bd8164ba40242e2013d382fb01eb0b96ed:

```
zebra/netconf_netlink.c: In function 'netlink_netconf_change': zebra/netconf_netlink.c:109:32: error: 'AF_MPLS' undeclared (first use in this function)
  109 |         if (ncm->ncm_family == AF_MPLS)
      |                                ^~~~~~~
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>