### PR TITLE
Bgp rpki takes too long

### DIFF
--- a/bgpd/bgp_mac.c
+++ b/bgpd/bgp_mac.c
@@ -242,19 +242,18 @@ static void bgp_mac_rescan_evpn_table(struct bgp *bgp, struct ethaddr *macaddr)
 		if (!peer_established(peer))
 			continue;
 
-		if (CHECK_FLAG(peer->af_flags[afi][safi],
-			       PEER_FLAG_SOFT_RECONFIG)) {
-			if (bgp_debug_update(peer, NULL, NULL, 1))
-				zlog_debug("Processing EVPN MAC interface change on peer %s (inbound, soft-reconfig)",
-					   peer->host);
+		if (bgp_debug_update(peer, NULL, NULL, 1))
+			zlog_debug(
+				"Processing EVPN MAC interface change on peer %s %s",
+				peer->host,
+				CHECK_FLAG(peer->af_flags[afi][safi],
+					   PEER_FLAG_SOFT_RECONFIG)
+					? "(inbound, soft-reconfig)"
+					: "");
 
-			bgp_soft_reconfig_in(peer, afi, safi);
-		} else {
+		if (!bgp_soft_reconfig_in(peer, afi, safi)) {
 			struct bgp_table *table = bgp->rib[afi][safi];
 
-			if (bgp_debug_update(peer, NULL, NULL, 1))
-				zlog_debug("Processing EVPN MAC interface change on peer %s",
-					   peer->host);
 			bgp_process_mac_rescan_table(bgp, peer, table, macaddr);
 		}
 	}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5342,7 +5342,10 @@ void bgp_soft_reconfig_table_task_cancel(const struct bgp *bgp,
 	}
 }
 
-void bgp_soft_reconfig_in(struct peer *peer, afi_t afi, safi_t safi)
+/*
+ * Returns false if the peer is not configured for soft reconfig in
+ */
+bool bgp_soft_reconfig_in(struct peer *peer, afi_t afi, safi_t safi)
 {
 	struct bgp_dest *dest;
 	struct bgp_table *table;
@@ -5350,14 +5353,14 @@ void bgp_soft_reconfig_in(struct peer *peer, afi_t afi, safi_t safi)
 	struct peer *npeer;
 	struct peer_af *paf;
 
-	if (!peer_established(peer))
-		return;
+	if (!CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG))
+		return false;
 
 	if ((safi != SAFI_MPLS_VPN) && (safi != SAFI_ENCAP)
 	    && (safi != SAFI_EVPN)) {
 		table = peer->bgp->rib[afi][safi];
 		if (!table)
-			return;
+			return true;
 
 		table->soft_reconfig_init = true;
 
@@ -5417,6 +5420,8 @@ void bgp_soft_reconfig_in(struct peer *peer, afi_t afi, safi_t safi)
 
 			bgp_soft_reconfig_table(peer, afi, safi, table, &prd);
 		}
+
+	return true;
 }
 
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -676,7 +676,12 @@ extern void bgp_default_originate(struct peer *, afi_t, safi_t, int);
 extern void bgp_soft_reconfig_table_task_cancel(const struct bgp *bgp,
 						const struct bgp_table *table,
 						const struct peer *peer);
-extern void bgp_soft_reconfig_in(struct peer *, afi_t, safi_t);
+
+/*
+ * If this peer is configured for soft reconfig in then do the work
+ * and return true.  If it is not return false; and do nothing
+ */
+extern bool bgp_soft_reconfig_in(struct peer *peer, afi_t afi, safi_t safi);
 extern void bgp_clear_route(struct peer *, afi_t, safi_t);
 extern void bgp_clear_route_all(struct peer *);
 extern void bgp_clear_adj_in(struct peer *, afi_t, safi_t);

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -401,6 +401,7 @@ static void rpki_revalidate_prefix(struct thread *thread)
 
 	match = bgp_table_subtree_lookup(rrp->bgp->rib[rrp->afi][rrp->safi],
 					 &rrp->prefix);
+
 	node = match;
 
 	while (node) {
@@ -410,9 +411,6 @@ static void rpki_revalidate_prefix(struct thread *thread)
 
 		node = bgp_route_next_until(node, match);
 	}
-
-	if (match)
-		bgp_dest_unlock_node(match);
 
 	XFREE(MTYPE_BGP_RPKI_REVALIDATE, rrp);
 }

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -487,7 +487,7 @@ static void revalidate_all_routes(void)
 			safi_t safi;
 
 			FOREACH_AFI_SAFI (afi, safi) {
-				if (!peer->bgp->rib[afi][safi])
+				if (!bgp->rib[afi][safi])
 					continue;
 
 				if (!peer_established(peer))

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -483,18 +483,14 @@ static void revalidate_all_routes(void)
 		struct listnode *peer_listnode;
 
 		for (ALL_LIST_ELEMENTS_RO(bgp->peer, peer_listnode, peer)) {
+			afi_t afi;
+			safi_t safi;
 
-			for (size_t i = 0; i < 2; i++) {
-				safi_t safi;
-				afi_t afi = (i == 0) ? AFI_IP : AFI_IP6;
+			FOREACH_AFI_SAFI (afi, safi) {
+				if (!peer->bgp->rib[afi][safi])
+					continue;
 
-				for (safi = SAFI_UNICAST; safi < SAFI_MAX;
-				     safi++) {
-					if (!peer->bgp->rib[afi][safi])
-						continue;
-
-					bgp_soft_reconfig_in(peer, afi, safi);
-				}
+				bgp_soft_reconfig_in(peer, afi, safi);
 			}
 		}
 	}

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -490,6 +490,8 @@ static void revalidate_all_routes(void)
 				if (!peer->bgp->rib[afi][safi])
 					continue;
 
+				if (!peer_established(peer))
+					continue;
 				bgp_soft_reconfig_in(peer, afi, safi);
 			}
 		}

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -5517,11 +5517,11 @@ void peer_on_policy_change(struct peer *peer, afi_t afi, safi_t safi,
 		if (!peer_established(peer))
 			return;
 
-		if (CHECK_FLAG(peer->af_flags[afi][safi],
-			       PEER_FLAG_SOFT_RECONFIG)) {
-			bgp_soft_reconfig_in(peer, afi, safi);
-		} else if (CHECK_FLAG(peer->cap, PEER_CAP_REFRESH_OLD_RCV) ||
-			   CHECK_FLAG(peer->cap, PEER_CAP_REFRESH_NEW_RCV)) {
+		if (bgp_soft_reconfig_in(peer, afi, safi))
+			return;
+
+		if (CHECK_FLAG(peer->cap, PEER_CAP_REFRESH_OLD_RCV) ||
+		    CHECK_FLAG(peer->cap, PEER_CAP_REFRESH_NEW_RCV)) {
 			if (CHECK_FLAG(peer->af_cap[afi][safi],
 				       PEER_CAP_ORF_PREFIX_SM_ADV) &&
 			    (CHECK_FLAG(peer->af_cap[afi][safi],
@@ -7777,10 +7777,7 @@ int peer_clear_soft(struct peer *peer, afi_t afi, safi_t safi,
 	    || stype == BGP_CLEAR_SOFT_IN_ORF_PREFIX) {
 		/* If neighbor has soft reconfiguration inbound flag.
 		   Use Adj-RIB-In database. */
-		if (CHECK_FLAG(peer->af_flags[afi][safi],
-			       PEER_FLAG_SOFT_RECONFIG))
-			bgp_soft_reconfig_in(peer, afi, safi);
-		else {
+		if (!bgp_soft_reconfig_in(peer, afi, safi)) {
 			/* If neighbor has route refresh capability, send route
 			   refresh
 			   message to the peer. */

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1127,6 +1127,8 @@ static void peer_free(struct peer *peer)
 	bgp_timer_set(peer);
 	bgp_reads_off(peer);
 	bgp_writes_off(peer);
+	FOREACH_AFI_SAFI (afi, safi)
+		THREAD_OFF(peer->t_revalidate_all[afi][safi]);
 	assert(!peer->t_write);
 	assert(!peer->t_read);
 	BGP_EVENT_FLUSH(peer);
@@ -2444,6 +2446,8 @@ int peer_delete(struct peer *peer)
 	bgp_keepalives_off(peer);
 	bgp_reads_off(peer);
 	bgp_writes_off(peer);
+	FOREACH_AFI_SAFI (afi, safi)
+		THREAD_OFF(peer->t_revalidate_all[afi][safi]);
 	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON));
 	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_READS_ON));
 	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_KEEPALIVES_ON));

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3645,6 +3645,9 @@ int bgp_delete(struct bgp *bgp)
 
 	hook_call(bgp_inst_delete, bgp);
 
+	FOREACH_AFI_SAFI (afi, safi)
+		THREAD_OFF(bgp->t_revalidate[afi][safi]);
+
 	THREAD_OFF(bgp->t_condition_check);
 	THREAD_OFF(bgp->t_startup);
 	THREAD_OFF(bgp->t_maxmed_onstartup);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1554,6 +1554,7 @@ struct peer {
 	struct thread *t_gr_restart;
 	struct thread *t_gr_stale;
 	struct thread *t_llgr_stale[AFI_MAX][SAFI_MAX];
+	struct thread *t_revalidate_all[AFI_MAX][SAFI_MAX];
 	struct thread *t_generate_updgrp_packets;
 	struct thread *t_process_packet;
 	struct thread *t_process_packet_error;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -470,6 +470,8 @@ struct bgp {
 	/* BGP update delay on startup */
 	struct thread *t_update_delay;
 	struct thread *t_establish_wait;
+	struct thread *t_revalidate[AFI_MAX][SAFI_MAX];
+
 	uint8_t update_delay_over;
 	uint8_t main_zebra_update_hold;
 	uint8_t main_peers_update_hold;


### PR DESCRIPTION
issue #12264 points at several issues with RPKI.  Mainly that when changes are made rpki can take some extraordinary amount of time to converge.

This PR attempts to mitigate some of those issues by breaking up work done into a bunch of different events.  Additionally some code refactoring was done to improve FRR and finally an additional lock decrement was found by the re-arrangement that would not have been easily exposed ( but is also probably already causing crashes in the field )