### PR TITLE
zebra: Extend the FPM module to push the missing SRv6 nexthop information

### DIFF
--- a/lib/srv6.h
+++ b/lib/srv6.h
@@ -92,6 +92,8 @@ struct srv6_locator {
 	bool status_up;
 	struct list *chunks;
 
+	uint8_t flags;
+
 	QOBJ_FIELDS;
 };
 DECLARE_QOBJ_TYPE(srv6_locator);
@@ -116,6 +118,8 @@ struct srv6_locator_chunk {
 	uint8_t proto;
 	uint16_t instance;
 	uint32_t session_id;
+
+	uint8_t flags;
 };
 
 struct nexthop_srv6 {

--- a/lib/srv6.h
+++ b/lib/srv6.h
@@ -93,6 +93,7 @@ struct srv6_locator {
 	struct list *chunks;
 
 	uint8_t flags;
+#define SRV6_LOCATOR_USID (1 << 0) /* The SRv6 Locator is a uSID Locator */
 
 	QOBJ_FIELDS;
 };

--- a/zebra/zebra_srv6.h
+++ b/zebra/zebra_srv6.h
@@ -32,6 +32,9 @@
 /* SRv6 instance structure. */
 struct zebra_srv6 {
 	struct list *locators;
+
+	/* Source address for SRv6 encapsulation */
+	struct in6_addr encap_src_addr;
 };
 
 /* declare hooks for the basic API, so that it can be specialized or served


### PR DESCRIPTION
SRv6 is supported in SONiC (https://github.com/sonic-net/sonic-swss/pull/1964) as part of release 202211 (~Nov 2021). Zebra’s FPM module allows SONiC to learn the forwarding information computed by the FRR routing suite. Currently, the information exported by FRR does not include the SRv6 nexthops.

We already have two open PRs to support two functionalities required for the integration of FRR and SONiC: https://github.com/FRRouting/frr/pull/12219 adds the support for SRv6 uSID behaviors to FRR; https://github.com/FRRouting/frr/pull/12261 adds the missing source address parameter for the SRv6 encapsulation.

This PR completes the integration work of FRR and SONiC by extending the FPM module to push the missing SRv6 nexthop information to SONiC.

Signed-off-by: Carmine Scarpitta [carmine.scarpitta@uniroma2.it](mailto:carmine.scarpitta@uniroma2.it)