### PR TITLE
isisd: fix area NULL pointer in isis_route_update

### DIFF
--- a/isisd/isis_route.c
+++ b/isisd/isis_route.c
@@ -485,6 +485,9 @@ static void isis_route_update(struct isis_area *area, struct prefix *prefix,
 			      struct prefix_ipv6 *src_p,
 			      struct isis_route_info *route_info)
 {
+	if (area == NULL)
+		return;
+
 	if (CHECK_FLAG(route_info->flag, ISIS_ROUTE_FLAG_ACTIVE)) {
 		if (CHECK_FLAG(route_info->flag, ISIS_ROUTE_FLAG_ZEBRA_SYNCED))
 			return;
@@ -492,9 +495,8 @@ static void isis_route_update(struct isis_area *area, struct prefix *prefix,
 		isis_route_remove_previous_sid(area, prefix, route_info);
 
 		/* Install route. */
-		if (area)
-			isis_zebra_route_add_route(area->isis, prefix, src_p,
-						   route_info);
+		isis_zebra_route_add_route(area->isis, prefix, src_p,
+					   route_info);
 		/* Install/reinstall Prefix-SID label. */
 		if (route_info->sr.present)
 			isis_zebra_prefix_sid_install(area, prefix, route_info,
@@ -509,9 +511,8 @@ static void isis_route_update(struct isis_area *area, struct prefix *prefix,
 			isis_zebra_prefix_sid_uninstall(
 				area, prefix, route_info, &route_info->sr);
 		/* Uninstall route. */
-		if (area)
-			isis_zebra_route_del_route(area->isis, prefix, src_p,
-						   route_info);
+		isis_zebra_route_del_route(area->isis, prefix, src_p,
+					   route_info);
 		hook_call(isis_route_update_hook, area, prefix, route_info);
 
 		UNSET_FLAG(route_info->flag, ISIS_ROUTE_FLAG_ZEBRA_SYNCED);


### PR DESCRIPTION
Fix the case area is NULL.

Fixes: acc0029779 ("isisd: fix potential access to NULL pointer in isis_route_update")
Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>