### PR TITLE
zebra: relax if_type check to allow early ES config creation

### DIFF
--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -2759,6 +2759,12 @@ bool zebra_evpn_is_if_es_capable(struct zebra_if *zif)
 	if (zif->zif_type == ZEBRA_IF_BOND)
 		return true;
 
+	/* relax the checks to allow config to be applied in zebra
+	 * before interface is rxed from the kernel
+	 */
+	if (zif->ifp->ifindex == IFINDEX_INTERNAL)
+		return true;
+
 	/* XXX: allow swpX i.e. a regular ethernet port to be an ES link too */
 	return false;
 }


### PR DESCRIPTION
The API for configuring ES in zebra had a strict check for if_type "isBond" that prevented the ES config from being created before the interface.

Ticket: CM-29454

Signed-off-by: Anuradha Karuppiah <anuradhak@cumulusnetworks.com>