### PR TITLE
tools: remove backslash from declare check regex

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -335,7 +335,7 @@ if [ -z "$FRR_PATHSPACE" ]; then
 	load_old_config "/etc/sysconfig/frr"
 fi
 
-if { declare -p watchfrr_options 2>/dev/null || true; } | grep -q '^declare \-a'; then
+if { declare -p watchfrr_options 2>/dev/null || true; } | grep -q '^declare -a'; then
 	log_warning_msg "watchfrr_options contains a bash array value." \
 		"The configured value is intentionally ignored since it is likely wrong." \
 		"Please remove or fix the setting."


### PR DESCRIPTION
The backslash in `grep -q '^declare \-a'` is not needed and
causes `grep: warning: stray \ before -` warning in grep-3.8.