### PR TITLE
pam: declare root as sufficient frr pam account

### DIFF
--- a/debian/frr.pam
+++ b/debian/frr.pam
@@ -1,3 +1,4 @@
 # Any user may call vtysh but only those belonging to the group frrvty can
 # actually connect to the socket and use the program.
 auth	sufficient	pam_permit.so
+account	sufficient	pam_rootok.so

--- a/redhat/frr.pam
+++ b/redhat/frr.pam
@@ -5,6 +5,7 @@
 # Only allow root (and possibly wheel) to use this because enable access
 # is unrestricted.
 auth       sufficient   pam_rootok.so
+account    sufficient   pam_rootok.so
 
 # Uncomment the following line to implicitly trust users in the "wheel" group.
 #auth       sufficient   pam_wheel.so trust use_uid


### PR DESCRIPTION
https://github.com/FRRouting/frr/pull/11465 enabled account verification, but the pam config declares rootok as sufficient in authentication only and not in account verification, what causes warning in the log:

```
vtysh[3747]: pam_warn(frr:account): function=[pam_sm_acct_mgmt] flags=0 service=[frr] terminal=[<unknown>] user=[root] ruser=[<unknown>] rhost=[<unknown>]
```