### PR TITLE
ospfd: Fix RFC conformance test cases 25.19 and 27.6

### DIFF
--- a/lib/libospf.h
+++ b/lib/libospf.h
@@ -52,6 +52,7 @@ extern "C" {
 #define OSPF_DEFAULT_DESTINATION        0x00000000      /* 0.0.0.0 */
 #define OSPF_INITIAL_SEQUENCE_NUMBER    0x80000001U
 #define OSPF_MAX_SEQUENCE_NUMBER        0x7fffffffU
+#define OSPF_INVALID_SEQUENCE_NUMBER 0x80000000U
 
 /* OSPF Interface Types */
 #define OSPF_IFTYPE_NONE		0

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -3648,6 +3648,7 @@ void ospf_flush_self_originated_lsas_now(struct ospf *ospf)
 	struct ospf_interface *oi;
 	struct ospf_lsa *lsa;
 	struct route_node *rn;
+	struct ospf_if_params *oip;
 	int need_to_flush_ase = 0;
 
 	ospf->inst_shutdown = 1;
@@ -3680,6 +3681,12 @@ void ospf_flush_self_originated_lsas_now(struct ospf *ospf)
 				ospf_lsa_flush_area(oi->network_lsa_self, area);
 				ospf_lsa_unlock(&oi->network_lsa_self);
 				oi->network_lsa_self = NULL;
+
+				oip = ospf_lookup_if_params(
+					oi->ifp, oi->address->u.prefix4);
+				if (oip)
+					oip->network_lsa_seqnum = htonl(
+						OSPF_INVALID_SEQUENCE_NUMBER);
 			}
 
 			if (oi->type != OSPF_IFTYPE_VIRTUALLINK


### PR DESCRIPTION
**Steps to reproduce:**
1. ANVL: Establish full adjacency with DUT for neighbor Rtr-0-A on DIface-0 with DUT as DR.
2. ANVL: Listen (for up to 2 * <RxmtInterval> seconds) on DIface-0.
3. DUT: Send <OSPF-LSU> packet.
4. ANVL: Verify that the received <OSPF-LSU> packet contains a Network- LSA for network N1 originated by DUT, and the LS Sequence Number is set to <InitialSequenceNumber>.
5. ANVL: Establish full adjacency with DUT for neighbor Rtr-0-B on DIface-0 with DUT as DR.
6. ANVL: Listen (for up to 2 * <RxmtInterval> seconds) on DIface-0.
7. DUT: Send <OSPF-LSU> packet.
8. ANVL: Verify that the received <OSPF-LSU> packet contains a new instance of the Network-LSA for network N1 originated by DUT, and the LS Sequence Number is set to (<InitialSequenceNumber> + 1).

Both the test cases were failing while verifying the initial sequence number for network LSA.

This is because currently OSPF does not reset its LSA sequence number when it is going down.

To locally reproduce this issue. just form ospf neighbor and then execute "no router ospf" command and then reconfigure ospf. Network LSA is not originated with the initial sequence number.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>