### PR TITLE
bgpd: Fix SRv6 SID index limit in the `sid vpn per-vrf export` VTY command

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -9082,7 +9082,7 @@ DEFPY (af_sid_vpn_export,
 
 DEFPY (bgp_sid_vpn_export,
        bgp_sid_vpn_export_cmd,
-       "[no] sid vpn per-vrf export <(1-255)$sid_idx|auto$sid_auto>",
+       "[no] sid vpn per-vrf export <(1-1048575)$sid_idx|auto$sid_auto>",
        NO_STR
        "sid value for VRF\n"
        "Between current vrf and vpn\n"

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2935,12 +2935,12 @@ General configuration
 Configuration of the SRv6 SID used to advertise a L3VPN for both IPv4 and IPv6
 is accomplished via the following command in the context of a VRF:
 
-.. clicmd:: sid vpn per-vrf export (1..255)|auto
+.. clicmd:: sid vpn per-vrf export (1..1048575)|auto
 
    Enables a SRv6 SID to be attached to a route exported from the current
    unicast VRF to VPN. A single SID is used for both IPv4 and IPv6 address
    families. If you want to set a SID for only IPv4 address family or IPv6
-   address family, you need to use the command ``sid vpn export (1..255)|auto``
+   address family, you need to use the command ``sid vpn export (1..1048575)|auto``
    in the context of an address-family. If the value specified is ``auto``,
    the SID value is automatically assigned from a pool maintained by the Zebra
    daemon. If Zebra is not running, or if this command is not configured, automatic


### PR DESCRIPTION
Previously BGP supported up to 255 SIDs.

The PR https://github.com/FRRouting/frr/pull/11981 extended the transposition computation algorithm in BGP to support more SIDs (up to 1048575 SIDs).

However, the BGP VTY command for allocating an SRv6 per-VRF SID (`sid vpn per-vrf export`) is still limited to 255 SIDs.

This PR extends the SID index in `sid vpn per-vrf export` VTY command to support up to 1048575 SIDs.


Signed-off-by: Carmine Scarpitta [carmine.scarpitta@uniroma2.it](mailto:carmine.scarpitta@uniroma2.it)