### PR TITLE
bgpd: Warn user only if the LL is not seriously available

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -921,7 +921,7 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
 			memcpy(&nexthop->v6_global, &local->sin6.sin6_addr,
 			       IPV6_MAX_BYTELEN);
 
-			/* If directory connected set link-local address. */
+			/* If directly connected set link-local address. */
 			direct = if_lookup_by_ipv6(&remote->sin6.sin6_addr,
 						   remote->sin6.sin6_scope_id,
 						   peer->bgp->vrf_id);
@@ -934,7 +934,7 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
 			 */
 			if (!v6_ll_avail && if_is_loopback(ifp))
 				v6_ll_avail = true;
-			else {
+			else if (!v6_ll_avail) {
 				flog_warn(
 					EC_BGP_NO_LL_ADDRESS_AVAILABLE,
 					"Interface: %s does not have a v6 LL address associated with it, waiting until one is created for it",


### PR DESCRIPTION
LL address is assigned, but we get a warning, that it's not:

Interface: enp3s0 does not have a v6 LL address associated with it, waiting until one is created for it

```
donatas-pc# sh int enp3s0
Interface enp3s0 is up, line protocol is up
  Link ups:       0    last: (never)
  Link downs:     0    last: (never)
  vrf: default
  index 2 metric 0 mtu 1500 speed 100
  flags: <UP,BROADCAST,RUNNING,MULTICAST>
  v4 Multicast forwarding is on
  v6 Multicast forwarding is on
  Type: Ethernet
  HWaddr: 18:c0:4d:96:fa:3f
  inet 192.168.10.17/24
  inet6 2a02:4780:abc:0:e776:6220:1e21:44b1/64
  inet6 fe80::ca5d:fd0d:cd8:1bb7/64
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>