### PR TITLE
zebra: Fix use-after-free crash on srte cleanup

### DIFF
--- a/zebra/zebra_srte.c
+++ b/zebra/zebra_srte.c
@@ -387,13 +387,13 @@ int zebra_sr_policy_label_update(mpls_label_t label,
 static int zebra_srte_client_close_cleanup(struct zserv *client)
 {
 	int sock = client->sock;
-	struct zebra_sr_policy *policy;
+	struct zebra_sr_policy *policy, *policy_temp;
 
 	if (!sock)
 		return 0;
 
-	RB_FOREACH (policy, zebra_sr_policy_instance_head,
-		    &zebra_sr_policy_instances) {
+	RB_FOREACH_SAFE (policy, zebra_sr_policy_instance_head,
+			 &zebra_sr_policy_instances, policy_temp) {
 		if (policy->sock == sock)
 			zebra_sr_policy_del(policy);
 	}


### PR DESCRIPTION
This PR solves the following issue:

```
________________________________________________________________________________________________________
*** CID 1527358:  Memory - illegal accesses  (USE_AFTER_FREE)
/zebra/zebra_srte.c: 395 in zebra_srte_client_close_cleanup()
389             int sock = client->sock;
390             struct zebra_sr_policy *policy;
391     
392             if (!sock)
393                     return 0;
394     
>>>     CID 1527358:  Memory - illegal accesses  (USE_AFTER_FREE)
>>>     Passing freed pointer "policy" as an argument to "zebra_sr_policy_instance_head_RB_NEXT".
395             RB_FOREACH (policy, zebra_sr_policy_instance_head,
396                         &zebra_sr_policy_instances) {
397                     if (policy->sock == sock)
398                             zebra_sr_policy_del(policy);
399             }
400             return 1;
```

Currently, in `zebra_srte_client_close_cleanup()` we use the `RB_FOREACH` macro to traverse the SR policies tree. We remove the SR policies within the loop. Removing elements from the tree and freeing them is not safe and causes a use-after-free crash whenever the `zebra_srte_client_close_cleanup()` is called to perform cleanup.

This PR replaces the `RB_FOREACH` macro with its variant `RB_FOREACH_SAFE`. As explained in the documentation (reported below), unlike `RB_FOREACH`, `RB_FOREACH_SAFE` permits both the removal of tree elements as well as freeing them from within the loop safely.

>   The macros RB_FOREACH_SAFE() and RB_FOREACH_REVERSE_SAFE()	traverse the
     tree referenced by	head in	a forward or reverse direction respectively,
     assigning each element in turn to np.  However, unlike their unsafe coun-
     terparts, they permit both	the removal of np as well as freeing it	from
     within the	loop safely without interfering	with the traversal.

(from https://www.freebsd.org/cgi/man.cgi?query=tree&sektion=3&format=html)

Signed-off-by: Carmine Scarpitta <carmine.scarpitta@uniroma2.it>