### PR TITLE
bgpd: fix null pointer dereference

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2537,6 +2537,7 @@ static void evpn_show_route_vni_macip(struct vty *vty, struct bgp *bgp,
 	safi_t safi;
 	json_object *json_paths = NULL;
 	struct ethaddr empty_mac = {};
+	struct ipaddr empty_ip = {};
 	const struct prefix_evpn *evp;
 
 	afi = AFI_L2VPN;
@@ -2550,7 +2551,8 @@ static void evpn_show_route_vni_macip(struct vty *vty, struct bgp *bgp,
 		return;
 	}
 
-	build_evpn_type2_prefix(&p, mac ? mac : &empty_mac, ip);
+	build_evpn_type2_prefix(&p, mac ? mac : &empty_mac,
+				ip ? ip : &empty_ip);
 
 	/* See if route exists. Look for both non-sticky and sticky. */
 	dest = bgp_evpn_vni_node_lookup(vpn, &p, NULL);


### PR DESCRIPTION
It is possible there is no ip address in type2 prefix, that leads to crash in `build_evpn_type2_prefix()`.