### PR TITLE
tests: Fix timing windows to not be so tight

### DIFF
--- a/tests/topotests/isis_lfa_topo1/test_isis_lfa_topo1.py
+++ b/tests/topotests/isis_lfa_topo1/test_isis_lfa_topo1.py
@@ -676,8 +676,8 @@ def test_rib_ipv6_step15():
             rname,
             "show ipv6 route isis json",
             outputs[rname][15]["show_ipv6_route.ref"],
-            count=2,
-            wait=0.05,
+            count=10,
+            wait=0.5,
         )
 
 
@@ -791,8 +791,8 @@ def test_rib_ipv6_step18():
         rname,
         "show ipv6 route isis json",
         outputs[rname][15]["show_ipv6_route.ref"],
-        count=2,
-        wait=0.05,
+        count=20,
+        wait=0.5,
     )
 
 
@@ -887,8 +887,8 @@ def test_rib_ipv6_step21():
         rname,
         "show ipv6 route isis json",
         outputs[rname][15]["show_ipv6_route.ref"],
-        count=2,
-        wait=0.05,
+        count=20,
+        wait=0.5,
     )
 
 
@@ -985,14 +985,14 @@ def test_rib_ipv6_step24():
         "show bfd peers json",
         expect,
         count=40,
-        wait=0.05,
+        wait=0.5,
     )
 
     router_compare_json_output(
         rname,
         "show ipv6 route isis json",
         outputs[rname][15]["show_ipv6_route.ref"],
-        count=4,
+        count=10,
     )
 
 

--- a/tests/topotests/isis_tilfa_topo1/test_isis_tilfa_topo1.py
+++ b/tests/topotests/isis_tilfa_topo1/test_isis_tilfa_topo1.py
@@ -831,19 +831,19 @@ def test_rt6_step11():
         rname,
         "show ip route isis json",
         outputs[rname][11]["show_ip_route.ref"],
-        count=1,
+        count=10,
     )
     router_compare_json_output(
         rname,
         "show ipv6 route isis json",
         outputs[rname][11]["show_ipv6_route.ref"],
-        count=1,
+        count=10,
     )
     router_compare_json_output(
         rname,
         "show mpls table json",
         outputs[rname][11]["show_mpls_table.ref"],
-        count=1,
+        count=10,
     )
 
 


### PR DESCRIPTION
Under system load the isis_tilfa_topo1 and
isis_lfa_topo1 tests are implementing too tight
of a testing window.  Relax so that the tests
do not fail so much.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>