### PR TITLE
snapcraft: Add pim6 daemon for PIM IPv6 to snap package

### DIFF
--- a/snapcraft/README.snap_build.md
+++ b/snapcraft/README.snap_build.md
@@ -87,11 +87,11 @@ All the commands are prefixed with frr.
     frr.ospf6d-debug
     frr.ospfd-debug
     frr.pimd-debug
+    frr.pim6d-debug
     frr.ripd-debug
     frr.ripngd-debug
     frr.ldp-debug
     frr.zebra-debug
-    frr.pimd-debug
     frr.nhrpd-debug
     frr.babeld-debug
     frr.eigrpd-debug

--- a/snapcraft/README.usage.md
+++ b/snapcraft/README.usage.md
@@ -18,8 +18,8 @@ ie for `ospf6d` (OSPFv3):
     systemctl enable snap.frr.ospf6d.service
 
 The daemons are: `ripd`, `ripngd`, `ospfd`, `ospf6d`, `isisd`, `bgpd`, 
-`pimd`, `ldpd`, `eigrpd`, `babeld`, `nhrpd`, `bfdd`, `vrrpd`, `pbrd`,
-`pathd`, `fabricd`, `staticd`, `zebra`
+`pimd`, `pim6d`, `ldpd`, `eigrpd`, `babeld`, `nhrpd`, `bfdd`, `vrrpd`,
+`pbrd`, `pathd`, `fabricd`, `staticd`, `zebra`
 
 Commands defined by this snap
 -----------------------------
@@ -53,6 +53,8 @@ depend on them). These are mainly intended to debug the Snap
 	Starts bgpd daemon in foreground
 - `frr.pimd-debug`:
 	Starts pimd daemon in foreground
+- `frr.pim6d-debug`:
+        Starts pim6d daemon in foreground
 - `frr.ldpd-debug`:
         Starts ldpd daemon in foreground
 - `frr.nhrpd-debug`:

--- a/snapcraft/scripts/Makefile
+++ b/snapcraft/scripts/Makefile
@@ -10,6 +10,7 @@ install:
 	install -D -m 0755 ripngd-service $(DESTDIR)/bin/
 	install -D -m 0755 isisd-service $(DESTDIR)/bin/
 	install -D -m 0755 pimd-service $(DESTDIR)/bin/
+	install -D -m 0755 pim6d-service $(DESTDIR)/bin/
 	install -D -m 0755 ldpd-service $(DESTDIR)/bin/
 	install -D -m 0755 nhrpd-service $(DESTDIR)/bin/
 	install -D -m 0755 babeld-service $(DESTDIR)/bin/
@@ -22,4 +23,3 @@ install:
 	install -D -m 0755 pathd-service $(DESTDIR)/bin/
 	install -D -m 0755 set-options $(DESTDIR)/bin/
 	install -D -m 0755 show_version $(DESTDIR)/bin/
-

--- a/snapcraft/scripts/pim6d-service
+++ b/snapcraft/scripts/pim6d-service
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e -x
+
+if ! [ -e $SNAP_DATA/pim6d.conf ]; then
+    cp $SNAP/etc/frr/pim6d.conf.default $SNAP_DATA/pim6d.conf
+fi
+exec $SNAP/sbin/pim6d \
+    -f $SNAP_DATA/pim6d.conf \
+    --pid_file $SNAP_DATA/pim6d.pid \
+    --socket $SNAP_DATA/zsock \
+    --vty_socket $SNAP_DATA

--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -79,6 +79,13 @@ apps:
             - network
             - network-bind
             - network-control
+    pim6d:
+        command: bin/pim6d-service
+        daemon: simple
+        plugs:
+            - network
+            - network-bind
+            - network-control
     ldpd:
         command: bin/ldpd-service
         daemon: simple
@@ -195,6 +202,12 @@ apps:
             - network-control
     pimd-debug:
         command: sbin/pimd -f $SNAP_DATA/pimd.conf --pid_file $SNAP_DATA/pimd.pid --socket $SNAP_DATA/zsock --vty_socket $SNAP_DATA
+        plugs:
+            - network
+            - network-bind
+            - network-control
+    pim6d-debug:
+        command: sbin/pim6d -f $SNAP_DATA/pim6d.conf --pid_file $SNAP_DATA/pim6d.pid --socket $SNAP_DATA/zsock --vty_socket $SNAP_DATA
         plugs:
             - network
             - network-bind
@@ -360,6 +373,7 @@ parts:
             - --enable-user=root
             - --enable-group=root
             - --enable-pimd
+            - --enable-pim6d
             - --enable-ldpd
             - --enable-fpm
             - --enable-protobuf
@@ -382,6 +396,7 @@ parts:
             ospf6d.conf.default: etc/frr/ospf6d.conf.default
             ospfd.conf.default: etc/frr/ospfd.conf.default
             pimd.conf.default: etc/frr/pimd.conf.default
+            pim6d.conf.default: etc/frr/pim6d.conf.default
             ripd.conf.default: etc/frr/ripd.conf.default
             ripngd.conf.default: etc/frr/ripngd.conf.default
             ldpd.conf.default: etc/frr/ldpd.conf.default
@@ -417,4 +432,3 @@ parts:
             README.usage.md: doc/README.usage.md
             README.snap_build.md: doc/README.snap_build.md
             extra_version_info.txt: doc/extra_version_info.txt
-


### PR DESCRIPTION
Adding PIM6d to snap package

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>