### PR TITLE
tests: Expand minimum run_and_expect to 5 seconds

### DIFF
--- a/tests/topotests/bfd_topo1/test_bfd_topo1.py
+++ b/tests/topotests/bfd_topo1/test_bfd_topo1.py
@@ -207,7 +207,7 @@ def test_bgp_fast_reconvergence():
         test_func = partial(
             topotest.router_json_cmp, router, "show ip bgp json", expected
         )
-        _, res = topotest.run_and_expect(test_func, None, count=3, wait=1)
+        _, res = topotest.run_and_expect(test_func, None, count=5, wait=1)
         assertmsg = "{}: bgp did not converge".format(router.name)
         assert res is None, assertmsg
 

--- a/tests/topotests/bgp_features/test_bgp_features.py
+++ b/tests/topotests/bgp_features/test_bgp_features.py
@@ -785,7 +785,7 @@ def test_bgp_delayopen_without():
         test_func = functools.partial(
             topotest.router_json_cmp, router, "show ip bgp summary json", expected
         )
-        _, res = topotest.run_and_expect(test_func, None, count=3, wait=1)
+        _, res = topotest.run_and_expect(test_func, None, count=5, wait=1)
         assertmsg = "BGP session on r{} did not shut down peer".format(router_num)
         assert res is None, assertmsg
 
@@ -862,7 +862,7 @@ def test_bgp_delayopen_singular():
         test_func = functools.partial(
             topotest.router_json_cmp, router, "show ip bgp summary json", expected
         )
-        _, res = topotest.run_and_expect(test_func, None, count=3, wait=1)
+        _, res = topotest.run_and_expect(test_func, None, count=5, wait=1)
         assertmsg = "BGP session on r{} did not shut down peer".format(router_num)
         assert res is None, assertmsg
 
@@ -880,7 +880,7 @@ def test_bgp_delayopen_singular():
     test_func = functools.partial(
         topotest.router_json_cmp, router, "show bgp neighbors json", expected
     )
-    _, res = topotest.run_and_expect(test_func, None, count=3, wait=1)
+    _, res = topotest.run_and_expect(test_func, None, count=5, wait=1)
     assertmsg = "BGP session on r1 failed to set DelayOpenTime for r4"
     assert res is None, assertmsg
 
@@ -974,7 +974,7 @@ def test_bgp_delayopen_dual():
         test_func = functools.partial(
             topotest.router_json_cmp, router, "show ip bgp summary json", expected
         )
-        _, res = topotest.run_and_expect(test_func, None, count=3, wait=1)
+        _, res = topotest.run_and_expect(test_func, None, count=5, wait=1)
         assertmsg = "BGP session on r{} did not shut down peer".format(router_num)
         assert res is None, assertmsg
 
@@ -1003,7 +1003,7 @@ def test_bgp_delayopen_dual():
         test_func = functools.partial(
             topotest.router_json_cmp, router, "show bgp neighbors json", expected
         )
-        _, res = topotest.run_and_expect(test_func, None, count=3, wait=1)
+        _, res = topotest.run_and_expect(test_func, None, count=5, wait=1)
         assertmsg = "BGP session on r{} failed to set DelayOpenTime".format(router_num)
         assert res is None, assertmsg
 
@@ -1032,7 +1032,7 @@ def test_bgp_delayopen_dual():
         test_func = functools.partial(
             topotest.router_json_cmp, router, "show ip bgp summary json", expected
         )
-        _, res = topotest.run_and_expect(test_func, None, count=3, wait=1)
+        _, res = topotest.run_and_expect(test_func, None, count=5, wait=1)
         assertmsg = "BGP session on r{} did not enter Connect state with peer".format(
             router_num
         )

--- a/tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py
+++ b/tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py
@@ -106,7 +106,7 @@ def test_bgp_route():
         "show ip route 50.0.0.0 json",
         expected,
     )
-    _, result = topotest.run_and_expect(test_func, None, count=3, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
     assertmsg = '"r3" JSON output mismatches'
     assert result is None, assertmsg
 
@@ -118,8 +118,9 @@ def test_bgp_route():
         r3,
         "show ip route 10.0.0.3 json",
         expected,
-        )
-    _, result = topotest.run_and_expect(test_func, None, count=3, wait=0.5)
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
+
 
 def test_bgp_better_admin_won():
     "A better Admin distance protocol may come along and knock us out"

--- a/tests/topotests/bgp_tcp_mss/test_bgp_tcp_mss.py
+++ b/tests/topotests/bgp_tcp_mss/test_bgp_tcp_mss.py
@@ -153,7 +153,7 @@ def test_bgp_tcp_mss():
         "Verify if TCP MSS value is synced with neighbor in {}".format(router1.name)
     )
     test_func = functools.partial(_bgp_check_neighbor_tcp_mss, router1, "192.168.255.2")
-    success, result = topotest.run_and_expect(test_func, None, count=3, wait=0.5)
+    success, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
     assert (
         result is None
     ), 'Failed to sync TCP MSS value over BGP session in "{}"'.format(router1.name)
@@ -163,7 +163,7 @@ def test_bgp_tcp_mss():
         "Verify if TCP MSS value is synced with neighbor in {}".format(router2.name)
     )
     test_func = functools.partial(_bgp_check_neighbor_tcp_mss, router2, "192.168.255.1")
-    success, result = topotest.run_and_expect(test_func, None, count=3, wait=0.5)
+    success, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
     assert (
         result is None
     ), 'Failed to sync TCP MSS value over BGP session in "{}"'.format(router2.name)

--- a/tests/topotests/cspf_topo1/test_cspf_topo1.py
+++ b/tests/topotests/cspf_topo1/test_cspf_topo1.py
@@ -177,7 +177,7 @@ def compare_cspf_output(tgen, rname, fileref, src, dst, cost, bw=""):
     test_func = partial(
         topotest.router_output_cmp, tgen.gears[rname], command, expected
     )
-    result, diff = topotest.run_and_expect(test_func, "", count=2, wait=2)
+    result, diff = topotest.run_and_expect(test_func, "", count=5, wait=2)
     assert result, "CSPF output mismatches the expected result on {}:\n{}".format(
         rname, diff
     )

--- a/tests/topotests/isis_lfa_topo1/test_isis_lfa_topo1.py
+++ b/tests/topotests/isis_lfa_topo1/test_isis_lfa_topo1.py
@@ -676,8 +676,8 @@ def test_rib_ipv6_step15():
             rname,
             "show ipv6 route isis json",
             outputs[rname][15]["show_ipv6_route.ref"],
-            count=2,
-            wait=0.05,
+            count=10,
+            wait=0.5,
         )
 
 
@@ -852,8 +852,8 @@ def test_rib_ipv6_step18():
         rname,
         "show ipv6 route isis json",
         outputs[rname][15]["show_ipv6_route.ref"],
-        count=2,
-        wait=0.05,
+        count=10,
+        wait=0.5,
     )
 
 
@@ -948,8 +948,8 @@ def test_rib_ipv6_step21():
         rname,
         "show ipv6 route isis json",
         outputs[rname][15]["show_ipv6_route.ref"],
-        count=2,
-        wait=0.05,
+        count=10,
+        wait=0.5,
     )
 
 
@@ -1047,14 +1047,14 @@ def test_rib_ipv6_step24():
     rname = "rt1"
     router = tgen.gears[rname]
     test_func = partial(_bfd_down, router)
-    success, result = topotest.run_and_expect(test_func, None, count=30, wait=0.05)
+    success, result = topotest.run_and_expect(test_func, None, count=30, wait=0.3)
     assert result is None, 'BFD session is still up on "{}"'.format(router)
 
     router_compare_json_output(
         rname,
         "show ipv6 route isis json",
         outputs[rname][15]["show_ipv6_route.ref"],
-        count=4,
+        count=5,
     )
 
 

--- a/tests/topotests/isis_tilfa_topo1/test_isis_tilfa_topo1.py
+++ b/tests/topotests/isis_tilfa_topo1/test_isis_tilfa_topo1.py
@@ -831,19 +831,19 @@ def test_rt6_step11():
         rname,
         "show ip route isis json",
         outputs[rname][11]["show_ip_route.ref"],
-        count=1,
+        count=5,
     )
     router_compare_json_output(
         rname,
         "show ipv6 route isis json",
         outputs[rname][11]["show_ipv6_route.ref"],
-        count=1,
+        count=5,
     )
     router_compare_json_output(
         rname,
         "show mpls table json",
         outputs[rname][11]["show_mpls_table.ref"],
-        count=1,
+        count=5,
     )
 
 
@@ -1021,26 +1021,26 @@ def test_rt6_step14():
         "show bfd peers json",
         expect,
         count=40,
-        wait=0.05,
+        wait=0.5,
     )
 
     router_compare_json_output(
         rname,
         "show ip route isis json",
         outputs[rname][11]["show_ip_route.ref"],
-        count=4,
+        count=5,
     )
     router_compare_json_output(
         rname,
         "show ipv6 route isis json",
         outputs[rname][11]["show_ipv6_route.ref"],
-        count=4,
+        count=5,
     )
     router_compare_json_output(
         rname,
         "show mpls table json",
         outputs[rname][11]["show_mpls_table.ref"],
-        count=4,
+        count=5,
     )
 
 


### PR DESCRIPTION
Ensure that the minimum time spent run and expecting is 5 seconds.  Heavy load is not a reason to fail a test.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>