### PR TITLE
pim6d, pimd: RFC conformance - Discard join/prune msg when WC bit is set but RPT bit is unset

### DIFF
--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -140,8 +140,21 @@ static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 
 	++pim_ifp->pim_ifstat_prune_recv;
 
-	if ((source_flags & PIM_RPT_BIT_MASK)
-	    && (source_flags & PIM_WILDCARD_BIT_MASK)) {
+	if (CHECK_FLAG(source_flags, PIM_WILDCARD_BIT_MASK)) {
+		/* As per RFC 7761 Section 4.9.1:
+		 * The RPT (or Rendezvous Point Tree) bit is a 1-bit value for
+		 * use with PIM Join/Prune messages (see Section 4.9.5.1). If
+		 * the WC bit is 1, the RPT bit MUST be 1.
+		 */
+		if (!CHECK_FLAG(source_flags, PIM_RPT_BIT_MASK)) {
+			if (PIM_DEBUG_PIM_J_P)
+				zlog_debug(
+					"Discarding (*,G)=%pSG prune since WC bit is set but RPT bit is unset",
+					sg);
+
+			return;
+		}
+
 		/*
 		 * RFC 4601 Section 4.5.2:
 		 * Received Prune(*,G) messages are processed even if the

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -72,8 +72,21 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 	 * If the RPT and WC are set it's a (*,G)
 	 * and the source is the RP
 	 */
-	if ((source_flags & PIM_RPT_BIT_MASK)
-	    && (source_flags & PIM_WILDCARD_BIT_MASK)) {
+	if (CHECK_FLAG(source_flags, PIM_WILDCARD_BIT_MASK)) {
+		/* As per RFC 7761 Section 4.9.1:
+		 * The RPT (or Rendezvous Point Tree) bit is a 1-bit value for
+		 * use with PIM Join/Prune messages (see Section 4.9.5.1). If
+		 * the WC bit is 1, the RPT bit MUST be 1.
+		 */
+		if (!CHECK_FLAG(source_flags, PIM_RPT_BIT_MASK)) {
+			if (PIM_DEBUG_PIM_J_P)
+				zlog_debug(
+					"Discarding (*,G)=%pSG join since WC bit is set but RPT bit is unset",
+					sg);
+
+			return;
+		}
+
 		struct pim_rpf *rp = RP(pim_ifp->pim, sg->grp);
 		pim_addr rpf_addr;
 


### PR DESCRIPTION
pim6d, pimd: Discard (*,G) join/prune if WC bit is set but RPT bit is unset.
    
As per RFC 7761, Section 4.9.1
The RPT (or Rendezvous Point Tree) bit is a 1-bit value for use
with PIM Join/Prune messages (see Section 4.9.5.1). If the
WC bit is 1, the RPT bit MUST be 1.

ANVL conformance test case is trying to verify this and is failing because we are accepting the packet
and forwarding it towards RP.
    
Issue: #12354
Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>