### PR TITLE
Enable pim6d in rpm and debian packages by default

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -27,10 +27,10 @@ else
   CONF_LUA=--enable-scripting
 endif
 
-ifeq ($(filter pkg.frr.pim6d,$(DEB_BUILD_PROFILES)),)
-  CONF_PIM6=--disable-pim6d
-else
+ifeq ($(filter pkg.frr.nopim6d,$(DEB_BUILD_PROFILES)),)
   CONF_PIM6=--enable-pim6d
+else
+  CONF_PIM6=--disable-pim6d
 endif
 
 export PYTHON=python3

--- a/doc/developer/packaging-debian.rst
+++ b/doc/developer/packaging-debian.rst
@@ -66,7 +66,7 @@ buster.)
      +----------------+-------------------+-----------------------------------------+
      | pkg.frr.lua    | pkg.frr.nolua     | builds lua scripting extension          |
      +----------------+-------------------+-----------------------------------------+
-     | pkg.frr.pim6d  | pkg.frr.nopim6d   | builds pim6d (work in progress)         |
+     | pkg.frr.pim6d  | pkg.frr.nopim6d   | builds pim6d (default enabled)          |
      +----------------+-------------------+-----------------------------------------+
 
    * the ``-uc -us`` options to disable signing the packages with your GPG key

--- a/doc/developer/packaging-redhat.rst
+++ b/doc/developer/packaging-redhat.rst
@@ -83,6 +83,7 @@ Tested on CentOS 6, CentOS 7, CentOS 8 and Fedora 24.
       %{!?with_watchfrr:      %global  with_watchfrr      1 }
       %{!?with_bgp_vnc:       %global  with_bgp_vnc       0 }
       %{!?with_pimd:          %global  with_pimd          1 }
+      %{!?with_pim6d:         %global  with_pim6d         1 }
       %{!?with_rpki:          %global  with_rpki          0 }
 
 8. Build the RPM::

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -24,7 +24,7 @@
 %{!?with_pam:           %global  with_pam           0 }
 %{!?with_pbrd:          %global  with_pbrd          1 }
 %{!?with_pimd:          %global  with_pimd          1 }
-%{!?with_pim6d:         %global  with_pim6d         0 }
+%{!?with_pim6d:         %global  with_pim6d         1 }
 %{!?with_vrrpd:         %global  with_vrrpd         1 }
 %{!?with_rtadv:         %global  with_rtadv         1 }
 %{!?with_watchfrr:      %global  with_watchfrr      1 }


### PR DESCRIPTION
Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>