### PR TITLE
ospfd: Support OSPF Refresh and Flooding Reduction RFC4136.

### DIFF
--- a/lib/log.h
+++ b/lib/log.h
@@ -129,6 +129,21 @@ extern int proto_redistnum(int afi, const char *s);
 
 extern const char *zserv_command_string(unsigned int command);
 
+#define OSPF_LOG(level, cond, fmt, ...)                                        \
+	do {                                                                   \
+		if (cond)                                                      \
+			zlog_##level(fmt, ##__VA_ARGS__);                      \
+	} while (0)
+
+#define OSPF_LOG_ERR(fmt, ...) OSPF_LOG(err, true, fmt, ##__VA_ARGS__)
+
+#define OSPF_LOG_WARN(fmt, ...) OSPF_LOG(warn, true, fmt, ##__VA_ARGS__)
+
+#define OSPF_LOG_INFO(fmt, ...) OSPF_LOG(info, true, fmt, ##__VA_ARGS__)
+
+#define OSPF_LOG_DEBUG(cond, fmt, ...) OSPF_LOG(debug, cond, fmt, ##__VA_ARGS__)
+
+#define OSPF_LOG_NOTICE(fmt, ...) OSPF_LOG(notice, true, fmt, ##__VA_ARGS__)
 
 /* structure useful for avoiding repeated rendering of the same timestamp */
 struct timestamp_control {

--- a/ospfd/ospf_abr.h
+++ b/ospfd/ospf_abr.h
@@ -23,6 +23,11 @@
 #define _ZEBRA_OSPF_ABR_H
 
 #define OSPF_ABR_TASK_DELAY 	5
+#define OSPF_ABR_DNA_TIMER 10
+/* Delay in announceing Non-DNA routers
+ * so that LSAs are completely synced
+ * before generating indication LSAs.
+ */
 
 #define OSPF_AREA_RANGE_ADVERTISE	(1 << 0)
 #define OSPF_AREA_RANGE_SUBSTITUTE	(1 << 1)
@@ -84,4 +89,20 @@ extern void ospf_schedule_abr_task(struct ospf *);
 extern void ospf_abr_announce_network_to_area(struct prefix_ipv4 *, uint32_t,
 					      struct ospf_area *);
 extern void ospf_abr_nssa_check_status(struct ospf *ospf);
+extern void ospf_abr_generate_indication_lsa(struct ospf *ospf,
+					     const struct ospf_area *area);
+extern void ospf_flush_indication_lsas(struct ospf *ospf);
+extern void ospf_generate_indication_lsa(struct ospf *ospf,
+					 struct ospf_area *area);
+extern bool ospf_check_fr_enabled_all(struct ospf *ospf);
+extern void ospf_recv_indication_lsa_flush(struct ospf_lsa *lsa);
+
+/** @brief Static inline functions.
+ *  @param Area pointer.
+ *  @return area Flood Reduction status.
+ */
+static inline bool ospf_check_area_fr_enabled(const struct ospf_area *area)
+{
+	return area->fr_info.enabled ? true : false;
+}
 #endif /* _ZEBRA_OSPF_ABR_H */

--- a/ospfd/ospf_flood.h
+++ b/ospfd/ospf_flood.h
@@ -68,5 +68,7 @@ extern struct external_info *ospf_external_info_check(struct ospf *,
 						      struct ospf_lsa *);
 
 extern void ospf_lsdb_init(struct ospf_lsdb *);
+extern void ospf_area_update_fr_state(struct ospf_area *area);
+extern void ospf_refresh_dna_type5_and_type7_lsas(struct ospf *ospf);
 
 #endif /* _ZEBRA_OSPF_FLOOD_H */

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -60,6 +60,7 @@
 /* OSPF LSA header. */
 struct lsa_header {
 	uint16_t ls_age;
+#define DO_NOT_AGE 0x8000
 	uint8_t options;
 	uint8_t type;
 	struct in_addr id;
@@ -233,6 +234,9 @@ enum lsid_status { LSID_AVAILABLE = 0, LSID_CHANGE, LSID_NOT_AVAILABLE };
 	 || (type == OSPF_SUMMARY_LSA) || (type == OSPF_ASBR_SUMMARY_LSA)      \
 	 || (type == OSPF_AS_EXTERNAL_LSA) || (type == OSPF_AS_NSSA_LSA))
 
+#define OSPF_FR_CONFIG(o, a)                                                   \
+	(o->fr_configured || ((a != NULL) ? a->fr_info.configured : 0))
+
 /* Prototypes. */
 /* XXX: Eek, time functions, similar are in lib/thread.c */
 extern struct timeval int2tv(int);
@@ -358,4 +362,24 @@ extern void ospf_check_and_gen_init_seq_lsa(struct ospf_interface *oi,
 extern void ospf_flush_lsa_from_area(struct ospf *ospf, struct in_addr area_id,
 				     int type);
 extern void ospf_maxage_lsa_remover(struct thread *thread);
+extern bool ospf_check_dna_lsa(const struct ospf_lsa *lsa);
+extern void ospf_refresh_area_self_lsas(struct ospf_area *area);
+
+/** @brief Check if the LSA is an indication LSA.
+ *  @param lsa pointer.
+ *  @return true or false based on lsa info.
+ */
+static inline bool ospf_check_indication_lsa(struct ospf_lsa *lsa)
+{
+	struct summary_lsa *sl = NULL;
+
+	if (lsa->data->type == OSPF_ASBR_SUMMARY_LSA) {
+		sl = (struct summary_lsa *)lsa->data;
+		if ((GET_METRIC(sl->metric) == OSPF_LS_INFINITY) &&
+		    !CHECK_FLAG(lsa->data->options, OSPF_OPTION_DC))
+			return true;
+	}
+
+	return false;
+}
 #endif /* _ZEBRA_OSPF_LSA_H */

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -986,6 +986,16 @@ void ospf_prune_unreachable_routers(struct route_table *rtrs)
 						&or->u.std.area_id);
 				}
 
+				/* Unset the DNA flag on lsa, if the router
+				 * which generated this lsa is no longer
+				 * reachabele.
+				 */
+				(CHECK_FLAG(or->u.std.origin->ls_age,
+					    DO_NOT_AGE))
+					? UNSET_FLAG(or->u.std.origin->ls_age,
+						     DO_NOT_AGE)
+					: 0;
+
 				listnode_delete(paths, or);
 				ospf_route_free(or);
 			}

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -467,6 +467,8 @@ static struct ospf *ospf_new(unsigned short instance, const char *name)
 	 */
 	ospf_gr_nvm_read(new);
 
+	new->fr_configured = false;
+
 	return new;
 }
 
@@ -817,6 +819,7 @@ static void ospf_finish_final(struct ospf *ospf)
 	THREAD_OFF(ospf->t_maxage);
 	THREAD_OFF(ospf->t_maxage_walker);
 	THREAD_OFF(ospf->t_abr_task);
+	THREAD_OFF(ospf->t_abr_fr);
 	THREAD_OFF(ospf->t_asbr_check);
 	THREAD_OFF(ospf->t_asbr_nssa_redist_update);
 	THREAD_OFF(ospf->t_distribute_update);
@@ -961,6 +964,15 @@ struct ospf_area *ospf_area_new(struct ospf *ospf, struct in_addr area_id)
 
 	/* Self-originated LSAs initialize. */
 	new->router_lsa_self = NULL;
+
+	/* Initialize FR field */
+	new->fr_info.enabled = false;
+	new->fr_info.configured = false;
+	new->fr_info.state_changed = false;
+	new->fr_info.router_lsas_recv_dc_bit = 0;
+	new->fr_info.indication_lsa_self = NULL;
+	new->fr_info.area_ind_lsa_recvd = false;
+	new->fr_info.area_dc_clear = false;
 
 	ospf_opaque_type10_lsa_init(new);
 

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -116,7 +116,25 @@ struct ospf_redist {
 		struct route_map *map;
 	} route_map; /* +1 is for default-information */
 #define ROUTEMAP_NAME(R)   (R->route_map.name)
-#define ROUTEMAP(R)        (R->route_map.map)
+#define ROUTEMAP(R) (R->route_map.map)
+};
+
+/* OSPF area flood reduction info */
+struct ospf_area_fr_info {
+	bool enabled;       /* Area support for Flood Reduction */
+	bool configured;    /* Flood Reduction configured per area knob */
+	bool state_changed; /* flood reduction state change info */
+	int router_lsas_recv_dc_bit; /* Number of unique router lsas
+				      * received with DC bit set.
+				      * (excluding self)
+				      */
+	bool area_ind_lsa_recvd;     /* Indication lsa received in this area */
+	bool area_dc_clear;	  /* Area has atleast one lsa with dc bit 0(
+				      * excluding indication lsa)
+				      */
+	struct ospf_lsa *indication_lsa_self; /* Indication LSA generated
+					       * in the area.
+					       */
 };
 
 /* ospf->config */
@@ -255,6 +273,7 @@ struct ospf {
 
 	/* Threads. */
 	struct thread *t_abr_task;	  /* ABR task timer. */
+	struct thread *t_abr_fr;	  /* ABR FR timer. */
 	struct thread *t_asbr_check;	/* ASBR check timer. */
 	struct thread *t_asbr_nssa_redist_update; /* ASBR NSSA redistribution
 						     update timer. */
@@ -405,6 +424,9 @@ struct ospf {
 	/* TI-LFA support for all interfaces. */
 	bool ti_lfa_enabled;
 	enum protection_type ti_lfa_protection_type;
+
+	/* Flood Reduction configuration state */
+	bool fr_configured;
 
 	QOBJ_FIELDS;
 };
@@ -591,6 +613,8 @@ struct ospf_area {
 	uint32_t act_ints;  /* Active interfaces. */
 	uint32_t full_nbrs; /* Fully adjacent neighbors. */
 	uint32_t full_vls;  /* Fully adjacent virtual neighbors. */
+
+	struct ospf_area_fr_info fr_info; /* Flood reduction info. */
 };
 
 /* OSPF config network structure. */

--- a/tests/topotests/ospf_basic_functionality/ospf_flood_reduction.json
+++ b/tests/topotests/ospf_basic_functionality/ospf_flood_reduction.json
@@ -1,0 +1,214 @@
+{
+
+    "ipv4base": "10.0.0.0",
+    "ipv4mask": 24,
+    "link_ip_start": {
+        "ipv4": "10.0.0.0",
+        "v4mask": 24
+    },
+    "lo_prefix": {
+        "ipv4": "1.0.",
+        "v4mask": 32
+    },
+    "routers": {
+        "r0": {
+            "links": {
+                "lo": {
+                    "ipv4": "auto",
+                    "type": "loopback"
+                },
+                "r1": {
+                    "ipv4": "auto",
+                    "ospf": {
+                        "area": "0.0.0.0",
+                        "hello_interval": 1,
+                        "dead_interval": 4
+                    }
+                },
+                "r2": {
+                    "ipv4": "auto",
+                    "ospf": {
+                        "area": "0.0.0.0",
+                        "hello_interval": 1,
+                        "dead_interval": 4
+                    }
+                },
+                "r3": {
+                    "ipv4": "auto",
+                    "ospf": {
+                        "area": "0.0.0.0",
+                        "hello_interval": 1,
+                        "dead_interval": 4,
+                        "network": "point-to-point"
+                    }
+                }
+            },
+            "ospf": {
+                "router_id": "100.1.1.0",
+                "neighbors": {
+                    "r1": {},
+                    "r2": {},
+                    "r3": {}
+                },
+                "graceful-restart": {
+                    "helper-only": []
+                }
+            }
+        },
+        "r1": {
+            "links": {
+                "lo": {
+                    "ipv4": "auto",
+                    "type": "loopback"
+                },
+                "r0": {
+                    "ipv4": "auto",
+                    "ospf": {
+                        "area": "0.0.0.0",
+                        "hello_interval": 1,
+                        "dead_interval": 4
+                    }
+                },
+                "r2": {
+                    "ipv4": "auto",
+                    "ospf": {
+                        "area": "0.0.0.1",
+                        "hello_interval": 1,
+                        "dead_interval": 4
+                    }
+                },
+                "r3": {
+                    "ipv4": "auto",
+                    "ospf": {
+                        "area": "0.0.0.0",
+                        "hello_interval": 1,
+                        "dead_interval": 4
+                    }
+                },
+                "r3-link0": {
+                    "ipv4": "auto",
+                    "description": "DummyIntftoR3"
+                }
+            },
+            "ospf": {
+                "router_id": "100.1.1.1",
+                "neighbors": {
+                    "r0": {},
+                    "r2": {},
+                    "r3": {}
+                },
+                "graceful-restart": {
+                    "helper-only": []
+                }
+            }
+        },
+        "r2": {
+            "links": {
+                "lo": {
+                    "ipv4": "auto",
+                    "type": "loopback"
+                },
+                "r0": {
+                    "ipv4": "auto",
+                    "ospf": {
+                        "area": "0.0.0.0",
+                        "hello_interval": 1,
+                        "dead_interval": 4
+                    }
+                },
+                "r1": {
+                    "ipv4": "auto",
+                    "ospf": {
+                        "area": "0.0.0.1",
+                        "hello_interval": 1,
+                        "dead_interval": 4
+                    }
+                },
+                "r3": {
+                    "ipv4": "auto",
+                    "ospf": {
+                        "area": "0.0.0.2",
+                        "hello_interval": 1,
+                        "dead_interval": 4,
+                        "network": "broadcast"
+                    }
+                }
+            },
+            "ospf": {
+                "router_id": "100.1.1.2",
+                "area": [
+                    {
+                        "id": "0.0.0.2",
+                        "type": "nssa"
+                    }
+                ],
+                "neighbors": {
+                    "r1": {},
+                    "r0": {},
+                    "r3": {}
+                },
+                "graceful-restart": {
+                    "helper-only": []
+                }
+            }
+        },
+        "r3": {
+            "links": {
+                "lo": {
+                    "ipv4": "auto",
+                    "type": "loopback"
+                },
+                "r0": {
+                    "ipv4": "auto",
+                    "ospf": {
+                        "area": "0.0.0.0",
+                        "hello_interval": 1,
+                        "dead_interval": 4,
+                        "network": "point-to-point"
+                    }
+                },
+                "r1": {
+                    "ipv4": "auto",
+                    "ospf": {
+                        "area": "0.0.0.0",
+                        "hello_interval": 1,
+                        "dead_interval": 4
+                    }
+                },
+                "r2": {
+                    "ipv4": "auto",
+                    "ospf": {
+                        "area": "0.0.0.2",
+                        "hello_interval": 1,
+                        "dead_interval": 4,
+                        "network": "broadcast"
+                    }
+                },
+                "r1-link0": {
+                    "ipv4": "auto",
+                    "description": "DummyIntftoR1",
+                    "ospf": {
+                        "area": "0.0.0.0"
+                    }
+                }
+            },
+            "ospf": {
+                "router_id": "100.1.1.3",
+                "area": [
+                    {
+                        "id": "0.0.0.2",
+                        "type": "nssa"
+                    }
+                ],
+                "neighbors": {
+                    "r0": {},
+                    "r1": {},
+                    "r2": {}
+                },
+                "graceful-restart": {
+                    "helper-only": []
+                }
+            }
+        }
+    }
+}

--- a/tests/topotests/ospf_basic_functionality/test_ospf_flood_reduction.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_flood_reduction.py
@@ -1,0 +1,1066 @@
+#!/usr/bin/python
+
+#
+# Copyright (c) 2022 by VMware, Inc. ("VMware")
+# Used Copyright (c) 2018 by Network Device Education Foundation, Inc.
+# ("NetDEF") in this file.
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND VMWARE DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL VMWARE BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+
+"""OSPF Basic Functionality Automation."""
+import os
+import sys
+import time
+import pytest
+from time import sleep
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+sys.path.append(os.path.join(CWD, "../lib/"))
+
+pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+# Global variables
+topo = None
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib.topolog import logger
+from lib.topojson import build_config_from_json
+
+# Import topoJson from lib, to create topology and initial configuration
+from lib.common_config import (
+    start_topology,
+    write_test_header,
+    write_test_footer,
+    reset_config_on_routers,
+    create_static_routes,
+    step,
+    topo_daemons,
+    shutdown_bringup_interface,
+    check_router_status,
+    start_topology,
+    write_test_header,
+    write_test_footer,
+    reset_config_on_routers,
+    create_static_routes,
+    step,
+    shutdown_bringup_interface,
+    check_router_status,
+    start_topology,
+    write_test_header,
+    write_test_footer,
+    reset_config_on_routers,
+    stop_router,
+    start_router,
+    step,
+    create_static_routes,
+    kill_router_daemons,
+    check_router_status,
+    start_router_daemons,
+)
+from lib.topolog import logger
+from lib.topogen import Topogen, get_topogen
+
+from lib.topojson import build_config_from_json
+from lib.ospf import (
+    verify_ospf_neighbor,
+    clear_ospf,
+    create_router_ospf,
+    verify_ospf_database,
+    get_ospf_database,
+)
+
+# Global variables
+topo = None
+NETWORK = {
+    "ipv4": [
+        "11.0.20.1/32",
+        "11.0.20.2/32",
+        "11.0.20.3/32",
+        "11.0.20.4/32",
+        "11.0.20.5/32",
+    ]
+}
+"""
+TOPOOLOGY =
+      Please view in a fixed-width font such as Courier.
+      +---+  A1       +---+
+      +R1 +------------+R2 |
+      +-+-+-           +--++
+        |  --        --  |
+        |    -- A0 --    |
+      A0|      ----      |
+        |      ----      | A2
+        |    --    --    |
+        |  --        --  |
+      +-+-+-            +-+-+
+      +R0 +-------------+R3 |
+      +---+     A3     +---+
+
+TESTCASES =
+1. Verify OSPF Flood reduction functionality with ospf enabled on process level.
+2. Verify OSPF Flood reduction functionality with ospf enabled on area level.
+3. Verify OSPF Flood reduction functionality between different area's.
+4. Verify OSPF Flood reduction functionality with ospf enabled on process level with default lsa refresh timer.
+5. Chaos - Verify OSPF TTL GTSM and flood  reduction functionality in chaos scenarios.
+"""
+
+
+def setup_module(mod):
+    """
+    Sets up the pytest environment
+
+    * `mod`: module name
+    """
+    global topo
+    testsuite_run_time = time.asctime(time.localtime(time.time()))
+    logger.info("Testsuite start time: {}".format(testsuite_run_time))
+    logger.info("=" * 40)
+
+    logger.info("Running setup_module to create topology")
+
+    # This function initiates the topology build with Topogen...
+    json_file = "{}/ospf_flood_reduction.json".format(CWD)
+    tgen = Topogen(json_file, mod.__name__)
+    global topo
+    topo = tgen.json_topo
+    # ... and here it calls Mininet initialization functions.
+
+    # get list of daemons needs to be started for this suite.
+    daemons = topo_daemons(tgen)
+
+    # Starting topology, create tmp files which are loaded to routers
+    #  to start daemons and then start routers
+    start_topology(tgen)
+
+    # Creating configuration from JSON
+    build_config_from_json(tgen, topo)
+
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    # Api call verify whether OSPF is converged
+    ospf_covergence = verify_ospf_neighbor(tgen, topo)
+    assert ospf_covergence is True, "setup_module :Failed \n Error:" " {}".format(
+        ospf_covergence
+    )
+
+    logger.info("Running setup_module() done")
+
+
+def teardown_module(mod):
+    """
+    Teardown the pytest environment.
+
+    * `mod`: module name
+    """
+
+    logger.info("Running teardown_module to delete topology")
+
+    tgen = get_topogen()
+
+    # Stop toplogy and Remove tmp files
+    tgen.stop_topology()
+
+    logger.info(
+        "Testsuite end time: {}".format(time.asctime(time.localtime(time.time())))
+    )
+    logger.info("=" * 40)
+
+
+
+def red_static(dut, config=True):
+    """Local def for Redstribute static routes inside ospf."""
+    global topo
+    tgen = get_topogen()
+    if config:
+        ospf_red = {dut: {"ospf": {"redistribute": [{"redist_type": "static"}]}}}
+    else:
+        ospf_red = {
+            dut: {
+                "ospf": {
+                    "redistribute": [{"redist_type": "static", "del_action": True}]
+                }
+            }
+        }
+    result = create_router_ospf(tgen, topo, ospf_red)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+
+# ##################################
+# Test cases start here.
+# ##################################
+def test_ospf_flood_red_tc1_p0(request):
+    """Verify OSPF Flood reduction functionality with ospf enabled on process level."""
+    tc_name = request.node.name
+    write_test_header(tc_name)
+    tgen = get_topogen()
+
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        check_router_status(tgen)
+
+    global topo
+
+    step("Bring up the base config as per the topology")
+    reset_config_on_routers(tgen)
+    red_static("r0")
+    step("Base config should be up, verify using OSPF convergence on all the routers")
+
+    ospf_covergence = verify_ospf_neighbor(tgen, topo)
+    assert ospf_covergence is True, "Testcase :Failed \n Error:" " {}".format(
+        ospf_covergence
+    )
+
+    input_dict = {
+        "r0": {
+            "static_routes": [
+                {
+                    "network": NETWORK["ipv4"][0],
+                    "no_of_ip": 5,
+                    "next_hop": "Null0",
+                }
+            ]
+        }
+    }
+    result = create_static_routes(tgen, input_dict)
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step("Enable flood reduction in process level on R0")
+    ospf_flood = {"r0": {"ospf": {"flood-reduction": True}}}
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    step("Verify that ospf lsa's are set with dc bit 1.")
+    dut = "r0"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {
+                        "lsaId": "100.1.1.0",
+                        "options": "*|-|DC|-|-|-|E|-",
+                    },
+                ]
+            }
+        },
+    }
+    result = verify_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step("Configure the custom refresh timer")
+    ospf_flood = {"r0": {"ospf": {"lsa-refresh": 120}}}
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    step("Enable flood. reduction in all the routers of the topology.")
+    for rtr in topo["routers"].keys():
+        ospf_flood = {rtr: {"ospf": {"lsa-refresh": 120, "flood-reduction": True}}}
+        result = create_router_ospf(tgen, topo, ospf_flood)
+        assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    for rtr in topo["routers"]:
+        clear_ospf(tgen, rtr)
+
+    ospf_covergence = verify_ospf_neighbor(tgen, topo)
+    assert ospf_covergence is True, "Testcase :Failed \n Error:" " {}".format(
+        ospf_covergence
+    )
+
+    step("Verify that ospf lsa's are set with dc bit 1.")
+    for rtr in topo["routers"]:
+        dut = rtr
+        lsid = "{}".format(topo["routers"][rtr]["ospf"]["router_id"])
+        input_dict_db = {
+            "routerId": lsid,
+            "areas": {
+                "0.0.0.0": {
+                    "routerLinkStates": [
+                        {
+                            "lsaId": lsid,
+                            "options": "*|-|DC|-|-|-|E|-",
+                        },
+                    ]
+                }
+            },
+        }
+        result = verify_ospf_database(
+            tgen, topo, dut, input_dict_db, lsatype="router", rid=lsid
+        )
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+    step("Wait for 120 secs and verify that LSA's are not refreshed. ")
+    # get LSA age
+    dut = "r1"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {"lsaId": "100.1.1.0", "lsaAge": "get"},
+                ]
+            }
+        },
+    }
+    sleep(10)
+
+    result1 = get_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+    # this wait is put so that we wait for 5secs to check if lsa is refreshed.
+    sleep(5)
+    result2 = get_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+
+    assert (result1 == result2) is True, "Testcase {} : Failed \n Error: {}".format(
+        tc_name, result
+    )
+
+    step("Disable flood reduction in R0.")
+    ospf_flood = {
+        "r0": {"ospf": {"flood-reduction": True, "del_flood_reduction": True}}
+    }
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    clear_ospf(tgen, "r0")
+
+    ospf_covergence = verify_ospf_neighbor(tgen, topo)
+    assert ospf_covergence is True, "Testcase :Failed \n Error:" " {}".format(
+        ospf_covergence
+    )
+
+    step("Verify that ospf lea's are not set with dc bit 1.")
+    dut = "r0"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {
+                        "lsaId": "100.1.1.0",
+                        "options": "*|-|DC|-|-|-|E|-",
+                    },
+                ]
+            }
+        },
+    }
+    result = verify_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0", expected=False
+    )
+    assert result is not True, (
+        "Testcase {} : Failed \n "
+        "Expected: OSPF LSA should not be set with DC bit in {} \n "
+        "Found: {}".format(tc_name, dut, result)
+    )
+    step("Wait for 120 secs and verify that LSA's are not refreshed. ")
+    # get LSA age
+    dut = "r1"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {"lsaId": "100.1.1.0", "lsaAge": "get"},
+                ]
+            }
+        },
+    }
+    sleep(10)
+
+    result1 = get_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+    sleep(5)
+    result2 = get_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+
+    if result2 is not result1:
+        result = True
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step(
+        "Enable flood reduction on each router with 10 secs delay of between each router."
+    )
+    for rtr in topo["routers"].keys():
+        ospf_flood = {rtr: {"ospf": {"lsa-refresh": 120, "flood-reduction": True}}}
+        sleep(10)
+        result = create_router_ospf(tgen, topo, ospf_flood)
+        assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    for rtr in topo["routers"]:
+        clear_ospf(tgen, rtr)
+
+    step("Verify that LSA's are not refreshed. Do not age bit should be set to 1.")
+    dut = "r0"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {
+                        "lsaId": "100.1.1.0",
+                        "options": "*|-|DC|-|-|-|E|-",
+                    },
+                ]
+            }
+        },
+    }
+    result = verify_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step(
+        "Verify OSPF neighborship when OSPF flood reduction  is configured and ospf process is restarted"
+    )
+
+    step("Kill OSPFd daemon on R0.")
+    kill_router_daemons(tgen, "r0", ["ospfd"])
+    start_router_daemons(tgen, "r0", ["ospfd"])
+
+    ospf_covergence = verify_ospf_neighbor(tgen, topo)
+    assert ospf_covergence is True, "Testcase :Failed \n Error:" " {}".format(
+        ospf_covergence
+    )
+
+    step("Verify that LSA's are not refreshed. Do not age bit should be set to 1.")
+    dut = "r0"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {
+                        "lsaId": "100.1.1.0",
+                        "options": "*|-|DC|-|-|-|E|-",
+                    },
+                ]
+            }
+        },
+    }
+    result = verify_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    write_test_footer(tc_name)
+
+
+def test_ospf_flood_red_tc2_p0(request):
+    """Verify OSPF Flood reduction functionality with ospf enabled on area level."""
+    tc_name = request.node.name
+    write_test_header(tc_name)
+    tgen = get_topogen()
+
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        check_router_status(tgen)
+
+    global topo
+
+    step("Bring up the base config as per the topology")
+    reset_config_on_routers(tgen)
+    red_static("r0")
+    step("Base config should be up, verify using OSPF convergence on all the routers")
+
+    ospf_covergence = verify_ospf_neighbor(tgen, topo)
+    assert ospf_covergence is True, "Testcase :Failed \n Error:" " {}".format(
+        ospf_covergence
+    )
+
+    input_dict = {
+        "r0": {
+            "static_routes": [
+                {
+                    "network": NETWORK["ipv4"][0],
+                    "no_of_ip": 5,
+                    "next_hop": "Null0",
+                }
+            ]
+        }
+    }
+    result = create_static_routes(tgen, input_dict)
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step("Enable flood reduction in area level on R0 in area 0")
+    ospf_flood = {
+        "r0": {"ospf": {"area": [{"id": "0.0.0.0", "flood-reduction": True}]}}
+    }
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    step("Verify that ospf lsa's are set with dc bit 1.")
+    dut = "r0"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {
+                        "lsaId": "100.1.1.0",
+                        "options": "*|-|DC|-|-|-|E|-",
+                    },
+                ]
+            }
+        },
+    }
+    result = verify_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step("Configure the custom refresh timer")
+    ospf_flood = {"r0": {"ospf": {"lsa-refresh": 120}}}
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    step("Enable flood. reduction in all the routers of the topology.")
+    for rtr in topo["routers"].keys():
+        ospf_flood = {
+            rtr: {"ospf": {"area": [{"id": "0.0.0.0", "flood-reduction": True}]}}
+        }
+        result = create_router_ospf(tgen, topo, ospf_flood)
+        assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    for rtr in topo["routers"]:
+        clear_ospf(tgen, rtr)
+
+    ospf_covergence = verify_ospf_neighbor(tgen, topo)
+    assert ospf_covergence is True, "Testcase :Failed \n Error:" " {}".format(
+        ospf_covergence
+    )
+
+    step("Verify that ospf lsa's are set with dc bit 1.")
+    for rtr in topo["routers"]:
+        dut = rtr
+        lsid = "{}".format(topo["routers"][rtr]["ospf"]["router_id"])
+        input_dict_db = {
+            "routerId": lsid,
+            "areas": {
+                "0.0.0.0": {
+                    "routerLinkStates": [
+                        {
+                            "lsaId": lsid,
+                            "options": "*|-|DC|-|-|-|E|-",
+                        },
+                    ]
+                }
+            },
+        }
+        result = verify_ospf_database(
+            tgen, topo, dut, input_dict_db, lsatype="router", rid=lsid
+        )
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step("Wait for 120 secs and verify that LSA's are not refreshed. ")
+    # get LSA age
+    dut = "r1"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {"lsaId": "100.1.1.0", "lsaAge": "get"},
+                ]
+            }
+        },
+    }
+    sleep(10)
+
+    result1 = get_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+    sleep(5)
+    result2 = get_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+
+    assert (result1 == result2) is True, "Testcase {} : Failed \n Error: {}".format(
+        tc_name, result
+    )
+
+    step("Disable flood reduction in R0.")
+    ospf_flood = {
+        "r0": {
+            "ospf": {
+                "area": [{"id": "0.0.0.0", "flood-reduction": True, "delete": True}]
+            }
+        }
+    }
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    clear_ospf(tgen, "r0")
+
+    ospf_covergence = verify_ospf_neighbor(tgen, topo)
+    assert ospf_covergence is True, "Testcase :Failed \n Error:" " {}".format(
+        ospf_covergence
+    )
+
+    step("Verify that ospf lea's are not set with dc bit 1.")
+    dut = "r0"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {
+                        "lsaId": "100.1.1.0",
+                        "options": "*|-|DC|-|-|-|E|-",
+                    },
+                ]
+            }
+        },
+    }
+    result = verify_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0", expected=False
+    )
+    assert result is not True, (
+        "Testcase {} : Failed \n "
+        "Expected: OSPF LSA should not be set with DC bit in {} \n "
+        "Found: {}".format(tc_name, dut, result)
+    )
+    step("Wait for 120 secs and verify that LSA's are not refreshed. ")
+    # get LSA age
+    dut = "r1"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {"lsaId": "100.1.1.0", "lsaAge": "get"},
+                ]
+            }
+        },
+    }
+    sleep(10)
+
+    result1 = get_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+    sleep(5)
+    result2 = get_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+
+    if result2 is not result1:
+        result = True
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step(
+        "Enable flood reduction on each router with 10 secs delay of between each router."
+    )
+    for rtr in topo["routers"].keys():
+        ospf_flood = {
+            rtr: {"ospf": {"area": [{"id": "0.0.0.0", "flood-reduction": True}]}}
+        }
+        sleep(10)
+        result = create_router_ospf(tgen, topo, ospf_flood)
+        assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    for rtr in topo["routers"]:
+        clear_ospf(tgen, rtr)
+
+    step("Verify that LSA's are not refreshed. Do not age bit should be set to 1.")
+    dut = "r0"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {
+                        "lsaId": "100.1.1.0",
+                        "options": "*|-|DC|-|-|-|E|-",
+                    },
+                ]
+            }
+        },
+    }
+    result = verify_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    write_test_footer(tc_name)
+
+
+def test_ospf_flood_red_tc3_p0(request):
+    """Verify OSPF Flood reduction functionality between different area's"""
+    tc_name = request.node.name
+    write_test_header(tc_name)
+    tgen = get_topogen()
+
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        check_router_status(tgen)
+
+    global topo
+
+    step("Bring up the base config as per the topology")
+    reset_config_on_routers(tgen)
+    red_static("r0")
+    step("Base config should be up, verify using OSPF convergence on all the routers")
+
+    ospf_covergence = verify_ospf_neighbor(tgen, topo)
+    assert ospf_covergence is True, "Testcase :Failed \n Error:" " {}".format(
+        ospf_covergence
+    )
+
+    input_dict = {
+        "r0": {
+            "static_routes": [
+                {
+                    "network": NETWORK["ipv4"][0],
+                    "no_of_ip": 5,
+                    "next_hop": "Null0",
+                }
+            ]
+        }
+    }
+    result = create_static_routes(tgen, input_dict)
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step("Enable flood reduction in area level on R0 in area 0")
+    ospf_flood = {
+        "r0": {"ospf": {"area": [{"id": "0.0.0.0", "flood-reduction": True}]}}
+    }
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    step("Verify that ospf lsa's are set with dc bit 1.")
+    dut = "r0"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {
+                        "lsaId": "100.1.1.0",
+                        "options": "*|-|DC|-|-|-|E|-",
+                    },
+                ]
+            }
+        },
+    }
+    result = verify_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step("Configure the custom refresh timer")
+    ospf_flood = {"r0": {"ospf": {"lsa-refresh": 120}}}
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    step(
+        "Enable flood. reduction in all the routers of the topology in area 0. Redistribute static route in area 0 R1 and area1 in R2."
+    )
+    for rtr in topo["routers"].keys():
+        ospf_flood = {
+            rtr: {"ospf": {"area": [{"id": "0.0.0.0", "flood-reduction": True}]}}
+        }
+        result = create_router_ospf(tgen, topo, ospf_flood)
+        assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    sleep(10)
+
+    for rtr in topo["routers"]:
+        clear_ospf(tgen, rtr)
+
+    ospf_covergence = verify_ospf_neighbor(tgen, topo)
+    assert ospf_covergence is True, "Testcase :Failed \n Error:" " {}".format(
+        ospf_covergence
+    )
+
+    step("Verify that ospf lsa's are set with dc bit 1.")
+    for rtr in topo["routers"]:
+        dut = rtr
+        lsid = "{}".format(topo["routers"][rtr]["ospf"]["router_id"])
+        input_dict_db = {
+            "routerId": lsid,
+            "areas": {
+                "0.0.0.0": {
+                    "routerLinkStates": [
+                        {
+                            "lsaId": lsid,
+                            "options": "*|-|DC|-|-|-|E|-",
+                        },
+                    ]
+                }
+            },
+        }
+        result = verify_ospf_database(
+            tgen, topo, dut, input_dict_db, lsatype="router", rid=lsid
+        )
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step("Wait for 120 secs and verify that LSA's are not refreshed. ")
+    # get LSA age
+    dut = "r1"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {"lsaId": "100.1.1.0", "lsaAge": "get"},
+                ]
+            }
+        },
+    }
+    sleep(10)
+
+    result1 = get_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+    sleep(5)
+    result2 = get_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+
+    assert (result1 == result2) is True, "Testcase {} : Failed \n Error: {}".format(
+        tc_name, result
+    )
+
+    step("Enable flood reduction in area 1.")
+
+    ospf_flood = {
+        "r0": {"ospf": {"area": [{"id": "0.0.0.0", "flood-reduction": True}]}}
+    }
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    ospf_flood = {
+        "r1": {
+            "ospf": {
+                "area": [
+                    {"id": "0.0.0.0", "flood-reduction": True},
+                    {"id": "0.0.0.1", "flood-reduction": True},
+                ]
+            }
+        }
+    }
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    ospf_flood = {
+        "r2": {
+            "ospf": {
+                "area": [
+                    {"id": "0.0.0.0", "flood-reduction": True},
+                    {"id": "0.0.0.1", "flood-reduction": True},
+                    {"id": "0.0.0.2", "flood-reduction": True},
+                ]
+            }
+        }
+    }
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    ospf_flood = {
+        "r3": {
+            "ospf": {
+                "area": [
+                    {"id": "0.0.0.0", "flood-reduction": True},
+                    {"id": "0.0.0.2", "flood-reduction": True},
+                ]
+            }
+        }
+    }
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    for rtr in topo["routers"]:
+        clear_ospf(tgen, rtr)
+
+    ospf_covergence = verify_ospf_neighbor(tgen, topo)
+    assert ospf_covergence is True, "Testcase :Failed \n Error:" " {}".format(
+        ospf_covergence
+    )
+
+    step("Verify that ospf lea's are  set with dc bit 1.")
+    dut = "r1"
+    input_dict_db = {
+        "routerId": "100.1.1.1",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {
+                        "lsaId": "100.1.1.1",
+                        "options": "*|-|DC|-|-|-|E|-",
+                    },
+                ]
+            }
+        },
+    }
+    result = verify_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.1"
+    )
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step("Wait for 120 secs and verify that LSA's are not refreshed. ")
+    # get LSA age
+    dut = "r1"
+    input_dict_db = {
+        "routerId": "100.1.1.1",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {"lsaId": "100.1.1.1", "lsaAge": "get"},
+                ]
+            }
+        },
+    }
+    sleep(10)
+
+    result1 = get_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.1"
+    )
+    sleep(5)
+    result2 = get_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.1"
+    )
+
+    if result2 is result1:
+        result = True
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    step("Disable flood reduction in R0.")
+
+    ospf_flood = {
+        "r0": {
+            "ospf": {
+                "area": [{"id": "0.0.0.0", "flood-reduction": True, "delete": True}]
+            }
+        }
+    }
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    ospf_flood = {
+        "r1": {
+            "ospf": {
+                "area": [
+                    {"id": "0.0.0.0", "flood-reduction": True, "delete": True},
+                    {"id": "0.0.0.1", "flood-reduction": True, "delete": True},
+                ]
+            }
+        }
+    }
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    ospf_flood = {
+        "r2": {
+            "ospf": {
+                "area": [
+                    {"id": "0.0.0.0", "flood-reduction": True, "delete": True},
+                    {"id": "0.0.0.1", "flood-reduction": True, "delete": True},
+                    {"id": "0.0.0.2", "flood-reduction": True, "delete": True},
+                ]
+            }
+        }
+    }
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    ospf_flood = {
+        "r3": {
+            "ospf": {
+                "area": [
+                    {"id": "0.0.0.0", "flood-reduction": True, "delete": True},
+                    {"id": "0.0.0.2", "flood-reduction": True, "delete": True},
+                ]
+            }
+        }
+    }
+    result = create_router_ospf(tgen, topo, ospf_flood)
+    assert result is True, "Testcase : Failed \n Error: {}".format(result)
+
+    clear_ospf(tgen, "r0")
+
+    ospf_covergence = verify_ospf_neighbor(tgen, topo)
+    assert ospf_covergence is True, "Testcase :Failed \n Error:" " {}".format(
+        ospf_covergence
+    )
+
+    step("Verify that ospf lea's are not set with dc bit 1.")
+    dut = "r0"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {
+                        "lsaId": "100.1.1.0",
+                        "options": "*|-|DC|-|-|-|E|-",
+                    },
+                ]
+            }
+        },
+    }
+    result = verify_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0", expected=False
+    )
+
+    assert result is not True, (
+        "Testcase {} : Failed \n "
+        "Expected: OSPF LSA should not be set with DC bit in {} \n "
+        "Found: {}".format(tc_name, dut, result)
+    )
+
+    step("Wait for 120 secs and verify that LSA's are not refreshed. ")
+    # get LSA age
+    dut = "r1"
+    input_dict_db = {
+        "routerId": "100.1.1.0",
+        "areas": {
+            "0.0.0.0": {
+                "routerLinkStates": [
+                    {"lsaId": "100.1.1.0", "lsaAge": "get"},
+                ]
+            }
+        },
+    }
+    sleep(10)
+
+    result1 = get_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+    sleep(5)
+    result2 = get_ospf_database(
+        tgen, topo, dut, input_dict_db, lsatype="router", rid="100.1.1.0"
+    )
+
+    if result2 is not result1:
+        result = True
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
+
+    write_test_footer(tc_name)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
As of now OSPF requires every LSA to be refreshed every 1800 seconds or else they will expire when they reach 
3600 seconds. This rfc proposes to overcome the LSA expiration by generalising the use of DoNotAge LSAs.
This technique will facilitate OSPF scaling by reducing OSPF traffic overhead in stable topologies.

This implementation handles CLIs, logic to flood DNA LSAs,  preventing LSAs from ageing,
generation and handling of Indication LSAs.

rfc link : https://datatracker.ietf.org/doc/html/rfc4136.

Below CLIs are added as part of this feature support.

Process/vrf level:
frr(config-router)# flood-reduction : Enables FR for all the areas.

frr(config-router)# no flood-reduction : Disables FR for all the areas.

Area level:
frr(config-router)# area [A.B.C.D$addr] flood-reduction : Enables FR for particular area.

frr(config-router)# no area [A.B.C.D$addr] flood-reduction : Disables FR for particular area.

Signed-off-by: Manoj Naragund <mnaragund@vmware.com>
Co-authored-by: nguggarigoud <nguggarigoud@vmware.com>