### PR TITLE
ospfd: Fixing a memleak.

### DIFF
--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -89,6 +89,25 @@ static int ospf_network_match_iface(const struct connected *,
 				    const struct prefix *);
 static void ospf_finish_final(struct ospf *);
 
+/* API to clean refresh queues and LSAs */
+static void ospf_free_refresh_queue(struct ospf *ospf)
+{
+	for (int i = 0; i < OSPF_LSA_REFRESHER_SLOTS; i++) {
+		struct list *list = ospf->lsa_refresh_queue.qs[i];
+		struct listnode *node, *nnode;
+		struct ospf_lsa *lsa;
+
+		if (list) {
+			for (ALL_LIST_ELEMENTS(list, node, nnode, lsa)) {
+				listnode_delete(list, lsa);
+				lsa->refresh_list = -1;
+				ospf_lsa_unlock(&lsa);
+			}
+			list_delete(&list);
+			ospf->lsa_refresh_queue.qs[i] = NULL;
+		}
+	}
+}
 #define OSPF_EXTERNAL_LSA_ORIGINATE_DELAY 1
 
 int p_spaces_compare_func(const struct p_space *a, const struct p_space *b)
@@ -894,6 +913,8 @@ static void ospf_finish_final(struct ospf *ospf)
 
 	route_table_finish(ospf->rt_aggr_tbl);
 
+
+	ospf_free_refresh_queue(ospf);
 
 	list_delete(&ospf->areas);
 	list_delete(&ospf->oi_write_q);


### PR DESCRIPTION
Description:
	As part of signal handler ospf_finish_final(),  lsas are originated
	and added to refresh queues are not freed.

	One such leak is :
	==2869285== 432 (40 direct, 392 indirect) bytes in 1 blocks are definitely lost in loss record 159 of 221
	==2869285==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
	==2869285==    by 0x4910EC3: qcalloc (memory.c:116)
	==2869285==    by 0x199024: ospf_refresher_register_lsa (ospf_lsa.c:4017)
	==2869285==    by 0x199024: ospf_refresher_register_lsa (ospf_lsa.c:3979)
	==2869285==    by 0x19A37F: ospf_network_lsa_install (ospf_lsa.c:2680)
	==2869285==    by 0x19A37F: ospf_lsa_install (ospf_lsa.c:2941)
	==2869285==    by 0x19C18F: ospf_network_lsa_update (ospf_lsa.c:1099)
	==2869285==    by 0x1931ED: ism_change_state (ospf_ism.c:556)
	==2869285==    by 0x1931ED: ospf_ism_event (ospf_ism.c:596)
	==2869285==    by 0x494E0B0: thread_call (thread.c:2006)
	==2869285==    by 0x494E395: _thread_execute (thread.c:2098)
	==2869285==    by 0x19FBC6: nsm_change_state (ospf_nsm.c:695)
	==2869285==    by 0x19FBC6: ospf_nsm_event (ospf_nsm.c:861)
	==2869285==    by 0x494E0B0: thread_call (thread.c:2006)
	==2869285==    by 0x494E395: _thread_execute (thread.c:2098)
	==2869285==    by 0x19020B: ospf_if_cleanup (ospf_interface.c:322)
	==2869285==    by 0x192D0C: ism_interface_down (ospf_ism.c:393)
	==2869285==    by 0x193028: ospf_ism_event (ospf_ism.c:584)
	==2869285==    by 0x494E0B0: thread_call (thread.c:2006)
	==2869285==    by 0x494E395: _thread_execute (thread.c:2098)
	==2869285==    by 0x190F10: ospf_if_down (ospf_interface.c:851)
	==2869285==    by 0x1911D6: ospf_if_free (ospf_interface.c:341)
	==2869285==    by 0x1E6E98: ospf_finish_final (ospfd.c:748)
	==2869285==    by 0x1E6E98: ospf_deferred_shutdown_finish (ospfd.c:578)
	==2869285==    by 0x1E7727: ospf_finish (ospfd.c:682)
	==2869285==    by 0x1E7727: ospf_terminate (ospfd.c:652)
	==2869285==    by 0x18852B: sigint (ospf_main.c:105)
	==2869285==    by 0x493BE12: frr_sigevent_process (sigevent.c:130)
	==2869285==    by 0x494DCD4: thread_fetch (thread.c:1775)
	==2869285==    by 0x4905022: frr_run (libfrr.c:1197)
	==2869285==    by 0x187891: main (ospf_main.c:235)

	Added a fix to cleanup all these queue pointers and corresponing lsas in it.

Signed-off-by: Rajesh Girada <rgirada@vmware.com>