### PR TITLE
tools: Enable start of FRR for non-root user

### DIFF
--- a/doc/user/setup.rst
+++ b/doc/user/setup.rst
@@ -116,6 +116,16 @@ allow this to happen.
 
 ::
 
+  FRR_NO_ROOT="yes"
+
+This option allows you to run FRR as a non-root user. Use this option
+only when you know what you are doing since most of the daemons
+in FRR will not be able to run under a regular user. This option
+is useful for example when you run FRR in a container with a designated
+user instead of root.
+
+::
+
    zebra_options=" -s 90000000 --daemon -A 127.0.0.1"
    bgpd_options="   --daemon -A 127.0.0.1"
    ...

--- a/tools/etc/frr/daemons
+++ b/tools/etc/frr/daemons
@@ -91,6 +91,11 @@ pathd_options="  -A 127.0.0.1"
 #
 #MAX_FDS=1024
 
+# Uncomment this option if you want to run FRR as a non-root user. Note that
+# you should know what you are doing since most of the daemons need root
+# to work. This could be useful if you want to run FRR in a container
+# for instance.
+# FRR_NO_ROOT="yes"
 
 # For any daemon, you can specify a "wrap" command to start instead of starting
 # the daemon directly. This will simply be prepended to the daemon invocation.

--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -43,6 +43,10 @@ RELOAD_SCRIPT="$D_PATH/frr-reload.py"
 #
 
 is_user_root () {
+	if [[ ! -z $FRR_NO_ROOT  &&  "${FRR_NO_ROOT}" == "yes" ]]; then
+		return 0
+	fi
+
 	[ "${EUID:-$(id -u)}" -eq 0 ] || {
 		log_failure_msg "Only users having EUID=0 can start/stop daemons"
 		return 1


### PR DESCRIPTION
There might be use cases when this would make sense, for example running FRR in a container as a designated user.

Signed-off-by: Michal Ruprich <mruprich@redhat.com>

Closes https://github.com/FRRouting/frr/issues/12323