### PR TITLE
bgpd: Fix crash for `set ipv4/ipv6 vpn next-hop` command

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -6847,9 +6847,9 @@ DEFUN_YANG (no_set_vpn_nexthop,
 }
 #endif /* KEEP_OLD_VPN_COMMANDS */
 
-DEFUN_YANG (set_ipx_vpn_nexthop,
+DEFPY_YANG (set_ipx_vpn_nexthop,
 	    set_ipx_vpn_nexthop_cmd,
-	    "set <ipv4|ipv6> vpn next-hop <A.B.C.D|X:X::X:X>",
+	    "set <ipv4|ipv6> vpn next-hop <A.B.C.D$addrv4|X:X::X:X$addrv6>",
 	    SET_STR
 	    "IPv4 information\n"
 	    "IPv6 information\n"
@@ -6865,6 +6865,11 @@ DEFUN_YANG (set_ipx_vpn_nexthop,
 
 	if (argv_find_and_parse_afi(argv, argc, &idx, &afi)) {
 		if (afi == AFI_IP) {
+			if (addrv6_str) {
+				vty_out(vty, "%% IPv4 next-hop expected\n");
+				return CMD_WARNING_CONFIG_FAILED;
+			}
+
 			const char *xpath =
 				"./set-action[action='frr-bgp-route-map:ipv4-vpn-address']";
 
@@ -6874,6 +6879,11 @@ DEFUN_YANG (set_ipx_vpn_nexthop,
 				"%s/rmap-set-action/frr-bgp-route-map:ipv4-address",
 				xpath);
 		} else {
+			if (addrv4_str) {
+				vty_out(vty, "%% IPv6 next-hop expected\n");
+				return CMD_WARNING_CONFIG_FAILED;
+			}
+
 			const char *xpath =
 				"./set-action[action='frr-bgp-route-map:ipv6-vpn-address']";
 


### PR DESCRIPTION
Crash when using for example:

```
route-map test permit 10
 set ipv6 vpn next-hop 10.10.10.10
```

```
bgpd[30843]: libyang: Unsatisfied pattern - "1.1.1.1" does not conform to "((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\p{N}\p{L}]+)?". (Schema location /frr-route-map:lib/route-map/entry/set-action/rmap-set-action/set-action/frr-bgp-route-map:ipv6-address/ipv6-address.)
bgpd[30843]: [JEA2K-29RPH][EC 100663345] nb_candidate_edit: lyd_new_path(/frr-route-map:lib/route-map[name='belekas']/entry[sequence='109']/set-action[action='frr-bgp-route-map:ipv6-vpn-address']/rmap-set-action/frr-bgp-route-map:ipv6-address) failed: 7
bgpd[30843]: [ZDEA9-V1X7W][EC 100663341] nb_cli_apply_changes_internal: failed to edit candidate configuration: operation [modify] xpath [/frr-route-map:lib/route-map[name='belekas']/entry[sequence='109']/set-action[action='frr-bgp-route-map:ipv6-vpn-address']/rmap-set-action/frr-bgp-route-map:ipv6-address]
bgpd[30843]: [SZNR8-V24R3][EC 100663326] yang_dnode_xpath_get_canon: couldn't find ./rmap-set-action/frr-bgp-route-map:ipv6-address
bgpd[30843]: Backtrace for 20 stack frames:
bgpd[30843]: [bt 0] /usr/local/lib/libfrr.so.0(zlog_backtrace+0x3a) [0x7f539c87c95a]
bgpd[30843]: [bt 1] /usr/local/lib/libfrr.so.0(+0xed022) [0x7f539c8c8022]
bgpd[30843]: [bt 2] /usr/local/lib/libfrr.so.0(yang_dnode_get_string+0x96) [0x7f539c8c9ea6]
bgpd[30843]: [bt 3] /usr/local/lib/libfrr.so.0(route_map_action_show+0xc40) [0x7f539c8a4540]
bgpd[30843]: [bt 4] /usr/local/lib/libfrr.so.0(nb_cli_show_dnode_cmds+0x5c) [0x7f539c88fa8c]
bgpd[30843]: [bt 5] /usr/local/lib/libfrr.so.0(nb_cli_show_dnode_cmds+0x159) [0x7f539c88fb89]
bgpd[30843]: [bt 6] /usr/local/lib/libfrr.so.0(nb_cli_show_dnode_cmds+0x1a3) [0x7f539c88fbd3]
bgpd[30843]: [bt 7] /usr/local/lib/libfrr.so.0(nb_cli_show_dnode_cmds+0x159) [0x7f539c88fb89]
bgpd[30843]: [bt 8] /usr/local/lib/libfrr.so.0(+0xc4d47) [0x7f539c89fd47]
bgpd[30843]: [bt 9] /usr/local/lib/libfrr.so.0(+0x7274a) [0x7f539c84d74a]
bgpd[30843]: [bt 10] /usr/local/lib/libfrr.so.0(+0x72cb0) [0x7f539c84dcb0]
bgpd[30843]: [bt 11] /usr/local/lib/libfrr.so.0(+0x74c40) [0x7f539c84fc40]
bgpd[30843]: [bt 12] /usr/local/lib/libfrr.so.0(cmd_execute_command+0xa4) [0x7f539c84fd74]
bgpd[30843]: [bt 13] /usr/local/lib/libfrr.so.0(cmd_execute+0x142) [0x7f539c84ffe2]
bgpd[30843]: [bt 14] /usr/local/lib/libfrr.so.0(+0xe51b7) [0x7f539c8c01b7]
bgpd[30843]: [bt 15] /usr/local/lib/libfrr.so.0(+0xe53f0) [0x7f539c8c03f0]
bgpd[30843]: [bt 16] /usr/local/lib/libfrr.so.0(+0xe8078) [0x7f539c8c3078]
bgpd[30843]: [bt 17] /usr/local/lib/libfrr.so.0(thread_call+0x7d) [0x7f539c8bacbd]
bgpd[30843]: [bt 18] /usr/local/lib/libfrr.so.0(frr_run+0xe8) [0x7f539c8749b8]
bgpd[30843]: [bt 19] /usr/lib/frr/bgpd(main+0x3f1) [0x55f887e97d71]
BGP[30843]: Received signal 6 at 1669121170 (si_addr 0x7f0000787b, PC 0x7f539ba58e87); aborting...
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>