### PR TITLE
bgpd: Fix the order of SRv6 locator parameters

### DIFF
--- a/tests/topotests/srv6_locator_custom_bits_length/test_srv6_locator.py
+++ b/tests/topotests/srv6_locator_custom_bits_length/test_srv6_locator.py
@@ -124,7 +124,7 @@ def test_srv6():
           srv6
            locators
             locator loc3
-             prefix 2001:db8:3::/48 func-bits 16 block-len 32 node-len 16
+             prefix 2001:db8:3::/48 block-len 32 node-len 16 func-bits 16
         """
     )
     check_srv6_locator(router, "expected_locators4.json")

--- a/tests/topotests/srv6_locator_usid/r1/zebra.conf
+++ b/tests/topotests/srv6_locator_usid/r1/zebra.conf
@@ -12,7 +12,7 @@ segment-routing
  srv6
   locators
    locator loc1
-    prefix fc00:0:1::/48 func-bits 16 block-len 32 node-len 16
+    prefix fc00:0:1::/48 block-len 32 node-len 16 func-bits 16
     behavior usid
    !
   !

--- a/tests/topotests/srv6_locator_usid/test_srv6_locator_usid.py
+++ b/tests/topotests/srv6_locator_usid/test_srv6_locator_usid.py
@@ -54,12 +54,10 @@ def setup_module(mod):
     for rname, router in tgen.routers().items():
         router.run("/bin/bash {}/{}/setup.sh".format(CWD, rname))
         router.load_config(
-            TopoRouter.RD_ZEBRA, os.path.join(
-                CWD, "{}/zebra.conf".format(rname))
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )
         router.load_config(
-            TopoRouter.RD_SHARP, os.path.join(
-                CWD, "{}/sharpd.conf".format(rname))
+            TopoRouter.RD_SHARP, os.path.join(CWD, "{}/sharpd.conf".format(rname))
         )
     tgen.start_router()
 
@@ -71,18 +69,14 @@ def teardown_module(mod):
 
 def _check_srv6_locator(router, expected_locator_file):
     logger.info("checking zebra locator status")
-    output = json.loads(
-        router.vtysh_cmd("show segment-routing srv6 locator json")
-    )
+    output = json.loads(router.vtysh_cmd("show segment-routing srv6 locator json"))
     expected = open_json_file("{}/{}".format(CWD, expected_locator_file))
     return topotest.json_cmp(output, expected)
 
 
 def _check_sharpd_chunk(router, expected_chunk_file):
     logger.info("checking sharpd locator chunk status")
-    output = json.loads(
-        router.vtysh_cmd("show sharp segment-routing srv6 json")
-    )
+    output = json.loads(router.vtysh_cmd("show sharp segment-routing srv6 json"))
     expected = open_json_file("{}/{}".format(CWD, expected_chunk_file))
     return topotest.json_cmp(output, expected)
 
@@ -164,7 +158,7 @@ def test_srv6_usid_locator_create_locator():
           srv6
            locators
             locator loc2
-             prefix fc00:0:2::/48 func-bits 16 block-len 32 node-len 16
+             prefix fc00:0:2::/48 block-len 32 node-len 16 func-bits 16
         """
     )
     check_srv6_locator(router, "expected_locators_4.json")
@@ -181,9 +175,7 @@ def test_srv6_usid_locator_set_behavior_usid():
     # If you want to stop some specific line and start interactive shell,
     # please use tgen.mininet_cli() to start it.
 
-    logger.info(
-        "Specify the SRv6 Locator loc2 as a Micro-segment (uSID) Locator"
-    )
+    logger.info("Specify the SRv6 Locator loc2 as a Micro-segment (uSID) Locator")
     router.vtysh_cmd(
         """
         configure terminal

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -276,16 +276,16 @@ DEFUN (no_srv6_locator,
 
 DEFPY (locator_prefix,
        locator_prefix_cmd,
-       "prefix X:X::X:X/M$prefix [func-bits (0-64)$func_bit_len] \
-	       [block-len (16-64)$block_bit_len] [node-len (16-64)$node_bit_len]",
+       "prefix X:X::X:X/M$prefix [block-len (16-64)$block_bit_len]  \
+	        [node-len (16-64)$node_bit_len] [func-bits (0-64)$func_bit_len]",
        "Configure SRv6 locator prefix\n"
        "Specify SRv6 locator prefix\n"
-       "Configure SRv6 locator function length in bits\n"
-       "Specify SRv6 locator function length in bits\n"
        "Configure SRv6 locator block length in bits\n"
        "Specify SRv6 locator block length in bits\n"
        "Configure SRv6 locator node length in bits\n"
-       "Specify SRv6 locator node length in bits\n")
+       "Specify SRv6 locator node length in bits\n"
+       "Configure SRv6 locator function length in bits\n"
+       "Specify SRv6 locator function length in bits\n")
 {
 	VTY_DECLVAR_CONTEXT(srv6_locator, locator);
 	struct srv6_locator_chunk *chunk = NULL;


### PR DESCRIPTION
The latest FRR's frr-reload.py is broken and we can't reload FRR gracefully with segment routing locator configuration (if we execute frr-reload.py, FRR will stop suddenly) because block-len and node-len introduced by https://github.com/FRRouting/frr/pull/11673 are something wrong.

The root cause of this issue is very simple. FRR will display the current configuration like this (the below is the result of "show running-configuration").

```
segment-routing
 srv6
  locators
   locator default
    prefix fd00:1:0:1::/64 block-len 40 node-len 24 func-bits 16
   exit
   !
  exit
  !
 exit
 !
exit
```

However, FRR doesn't accept segment routing locator parameters if we specify block-len and node-len earlier than func-bits.

```
HV101(config)# segment-routing
HV101(config-sr)# srv6
HV101(config-srv6)# locators
HV101(config-srv6-locators)# locator default
HV101(config-srv6-locator)# prefix fd00:1:0:1::/64 block-len 40 node-len 24
  <cr>
HV101(config-srv6-locator)# prefix fd00:1:0:1::/64 block-len 40 node-len 24 
```

This difference will cause this issue.

```
frr@HV101:/$ /usr/lib/frr/frr-reload.py --test /etc/frr/frr.conf
2022-11-18 01:50:29,852  INFO: Called via "Namespace(bindir='/usr/bin', confdir='/etc/frr', daemon='', debug=False, filename='/etc/frr/frr.conf', input=None, log_level='info', overwrite=False, pathspace=None, reload=False, rundir='/var/run/frr', stdout=False, test=True, test_reset=False, vty_socket=None)"
2022-11-18 01:50:29,852  INFO: Loading Config object from file /etc/frr/frr.conf
2022-11-18 01:50:29,894  INFO: Loading Config object from vtysh show running
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
line 140: % Unknown command:     prefix fd00:1:0:1::/64 block-len 40 node-len 24 func-bits 16Traceback (most recent call last):
  File "/usr/lib/frr/frr-reload.py", line 1979, in <module>
    running.load_from_show_running(args.daemon)
  File "/usr/lib/frr/frr-reload.py", line 308, in load_from_show_running
    config_text = self.vtysh.mark_show_run(daemon)
  File "/usr/lib/frr/frr-reload.py", line 167, in mark_show_run
    raise VtyshException(
__main__.VtyshException: vtysh (mark running-config) exited with status 2 
```

I thought the order of the result `show running-configuration` sounds good (block-len -> node-len -> func-bits). So, this PR correct the order of command arguments.

Signed-off-by: Ryoga Saito <ryoga.saito@linecorp.com>