### PR TITLE
lib: disable vrf before terminating interfaces

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -528,6 +528,7 @@ void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
 static void vrf_terminate_single(struct vrf *vrf)
 {
 	/* Clear configured flag and invoke delete. */
+	vrf_disable(vrf);
 	UNSET_FLAG(vrf->status, VRF_CONFIGURED);
 	if_terminate(vrf);
 	vrf_delete(vrf);


### PR DESCRIPTION
We must disable the vrf before we start terminating interfaces.

On termination, we free the 'zebra_if' struct from the interface ->info pointer. We rely on that for subsystems like vxlan for cleanup when shutting down.

'''
==497406== Invalid read of size 8
==497406==    at 0x47E70A: zebra_evpn_del (zebra_evpn.c:1103)
==497406==    by 0x47F004: zebra_evpn_cleanup_all (zebra_evpn.c:1363)
==497406==    by 0x4F2404: zebra_evpn_vxlan_cleanup_all (zebra_vxlan.c:1158)
==497406==    by 0x4917041: hash_iterate (hash.c:267)
==497406==    by 0x4F25E2: zebra_vxlan_cleanup_tables (zebra_vxlan.c:5676)
==497406==    by 0x4D52EC: zebra_vrf_disable (zebra_vrf.c:209)
==497406==    by 0x49A247F: vrf_disable (vrf.c:340)
==497406==    by 0x49A2521: vrf_delete (vrf.c:245)
==497406==    by 0x49A2E2B: vrf_terminate_single (vrf.c:533)
==497406==    by 0x49A2D8F: vrf_terminate (vrf.c:561)
==497406==    by 0x441240: sigint (main.c:192)
==497406==    by 0x4981F6D: frr_sigevent_process (sigevent.c:130)
==497406==  Address 0x6d68c68 is 200 bytes inside a block of size 272 free'd
==497406==    at 0x48470E4: free (vg_replace_malloc.c:872)
==497406==    by 0x4942CF0: qfree (memory.c:141)
==497406==    by 0x49196A9: if_delete (if.c:293)
==497406==    by 0x491C54C: if_terminate (if.c:1031)
==497406==    by 0x49A2E22: vrf_terminate_single (vrf.c:532)
==497406==    by 0x49A2D8F: vrf_terminate (vrf.c:561)
==497406==    by 0x441240: sigint (main.c:192)
==497406==    by 0x4981F6D: frr_sigevent_process (sigevent.c:130)
==497406==    by 0x499A5F0: thread_fetch (thread.c:1775)
==497406==    by 0x492850E: frr_run (libfrr.c:1197)
==497406==    by 0x441746: main (main.c:476)
==497406==  Block was alloc'd at
==497406==    at 0x4849464: calloc (vg_replace_malloc.c:1328)
==497406==    by 0x49429A5: qcalloc (memory.c:116)
==497406==    by 0x491D971: if_new (if.c:174)
==497406==    by 0x491ACC8: if_create_name (if.c:228)
==497406==    by 0x491ABEB: if_get_by_name (if.c:613)
==497406==    by 0x427052: netlink_interface (if_netlink.c:1178)
==497406==    by 0x43BC18: netlink_parse_info (kernel_netlink.c:1188)
==497406==    by 0x4266D7: interface_lookup_netlink (if_netlink.c:1288)
==497406==    by 0x42B634: interface_list (if_netlink.c:2368)
==497406==    by 0x4ABF83: zebra_ns_enable (zebra_ns.c:127)
==497406==    by 0x4AC17E: zebra_ns_init (zebra_ns.c:216)
==497406==    by 0x44166C: main (main.c:408)
'''

Signed-off-by: Stephen Worley <sworley@nvidia.com>