### PR TITLE
zebra: json support for show ip nht

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -305,7 +305,8 @@ the default route.
    indicates that the operator wants to see the multicast rib address resolution
    table.  An alternative form of the command is ``show ip import-check`` and this
    form of the command is deprecated at this point in time.
-   If the ``json`` option is specified, output is displayed in JSON format.
+   User can get that information as JSON string when ``json`` key word
+   at the end of cli is presented.
 
 PBR dataplane programming
 =========================

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -46,7 +46,8 @@ extern void zebra_remove_rnh_client(struct rnh *rnh, struct zserv *client);
 extern void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
 			       const struct prefix *p, safi_t safi);
 extern void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, safi_t safi,
-				  struct vty *vty, const struct prefix *p);
+				  struct vty *vty, const struct prefix *p,
+				  json_object *json);
 
 extern int rnh_resolve_via_default(struct zebra_vrf *zvrf, int family);
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1370,7 +1370,7 @@ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
 
 DEFPY (show_ip_nht,
        show_ip_nht_cmd,
-       "show <ip$ipv4|ipv6$ipv6> <nht|import-check>$type [<A.B.C.D|X:X::X:X>$addr|vrf NAME$vrf_name [<A.B.C.D|X:X::X:X>$addr]|vrf all$vrf_all] [mrib$mrib]",
+       "show <ip$ipv4|ipv6$ipv6> <nht|import-check>$type [<A.B.C.D|X:X::X:X>$addr|vrf NAME$vrf_name [<A.B.C.D|X:X::X:X>$addr]|vrf all$vrf_all] [mrib$mrib] [json]",
        SHOW_STR
        IP_STR
        IP6_STR
@@ -1382,23 +1382,48 @@ DEFPY (show_ip_nht,
        "IPv4 Address\n"
        "IPv6 Address\n"
        VRF_ALL_CMD_HELP_STR
-       "Show Multicast (MRIB) NHT state\n")
+       "Show Multicast (MRIB) NHT state\n"
+       JSON_STR)
 {
 	afi_t afi = ipv4 ? AFI_IP : AFI_IP6;
 	vrf_id_t vrf_id = VRF_DEFAULT;
 	struct prefix prefix, *p = NULL;
 	safi_t safi = mrib ? SAFI_MULTICAST : SAFI_UNICAST;
+	bool uj = use_json(argc, argv);
+	json_object *json = NULL;
+	json_object *json_vrf = NULL;
+	json_object *json_nexthop = NULL;
+
+	if (uj)
+		json = json_object_new_object();
 
 	if (vrf_all) {
 		struct vrf *vrf;
 		struct zebra_vrf *zvrf;
 
-		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
+		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
 			if ((zvrf = vrf->info) != NULL) {
-				vty_out(vty, "\nVRF %s:\n", zvrf_name(zvrf));
+				if (uj) {
+					json_vrf = json_object_new_object();
+					json_nexthop = json_object_new_object();
+					json_object_object_add(json,
+							       zvrf_name(zvrf),
+							       json_vrf);
+					json_object_object_add(json_vrf,
+							       "nexthops",
+							       json_nexthop);
+				} else {
+					vty_out(vty, "\nVRF %s:\n",
+						zvrf_name(zvrf));
+				}
 				zebra_print_rnh_table(zvrf_id(zvrf), afi, safi,
-						      vty, NULL);
+						      vty, NULL, json_nexthop);
 			}
+		}
+
+		if (uj)
+			vty_json(vty, json);
+
 		return CMD_SUCCESS;
 	}
 	if (vrf_name)
@@ -1407,11 +1432,29 @@ DEFPY (show_ip_nht,
 	memset(&prefix, 0, sizeof(prefix));
 	if (addr) {
 		p = sockunion2hostprefix(addr, &prefix);
-		if (!p)
+		if (!p) {
+			if (uj)
+				json_object_free(json);
 			return CMD_WARNING;
+		}
 	}
 
-	zebra_print_rnh_table(vrf_id, afi, safi, vty, p);
+	if (uj) {
+		json_vrf = json_object_new_object();
+		json_nexthop = json_object_new_object();
+		if (vrf_name)
+			json_object_object_add(json, vrf_name, json_vrf);
+		else
+			json_object_object_add(json, "default", json_vrf);
+
+		json_object_object_add(json_vrf, "nexthops", json_nexthop);
+	}
+
+	zebra_print_rnh_table(vrf_id, afi, safi, vty, p, json_nexthop);
+
+	if (uj)
+		vty_json(vty, json);
+
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
show ip/ipv6 nht vrf <all | name> json support added.

**Commands enhanced with JSON:**
------------------------------------
 show ip nht json
 show ip nht <addr> json
 show ipv6 nht json
 show ipv6 nht <addr> json
 show ip nht vrf <name> json
 show ip nht vrf all json
 show ipv6 nht vrf <name> json
 show ipv6 nht vrf all json
 show ip nht vrf default <addr> json
 show ipv6 nht vrf default <addr> json

**Sample JSON output:**
-------------------------

tor-1# **show ip nht vrf default json**
```
{
  "default":{
    "nexthops":{
      "27.0.0.5":{
        "nhtConnected":false,
        "clientList":[
          {
            "protocol":"bgp",
            "socket":70,
            "protocolFiltered":"none"
          }
        ],
        "gates":[
          {
            "ip":"fe80::202:ff:fe00:2b",
            "interface":"uplink_1"
          },
          {
            "ip":"fe80::202:ff:fe00:35",
            "interface":"uplink_2"
          }
        ],
        "resolvedProtocol":"bgp"
      },
      "27.0.0.6":{
        "nhtConnected":false,
        "clientList":[
          {
            "protocol":"bgp",
            "socket":70,
            "protocolFiltered":"none"
          }
        ],
        "gates":[
          {
            "ip":"fe80::202:ff:fe00:2b",
            "interface":"uplink_1"
          },
          {
            "ip":"fe80::202:ff:fe00:35",
            "interface":"uplink_2"
          }
        ],
        "resolvedProtocol":"bgp"
      }
    }
  }
}
```

tor-1# **show ipv6 nht vrf default json**
```
{
  "default": {
    "nexthops": {
      "fe80::202:ff:fe00:25": {
        "nhtConnected": true,
        "clientList": [
          {
            "protocol": "bgp",
            "socket": 45,
            "protocolFiltered": "none"
          }
        ],
        "gates": [
          {
            "interface": "swp1",
            "directlyConnected": true
          }
        ],
        "resolvedProtocol": "connected"
      },
      "fe80::202:ff:fe00:2b": {
        "nhtConnected": true,
        "clientList": [
          {
            "protocol": "bgp",
            "socket": 45,
            "protocolFiltered": "none"
          }
        ],
        "gates": [
          {
            "interface": "swp1",
            "directlyConnected": true
          }
        ],
        "resolvedProtocol": "connected"
      }
    }
  }
}
```

tor-1# **show ipv6 nht vrf all json**
```
{
  "default": {
    "nexthops": {
      "fe80::202:ff:fe00:25": {
        "nhtConnected": true,
        "clientList": [
          {
            "protocol": "bgp",
            "socket": 45,
            "protocolFiltered": "none"
          }
        ],
        "gates": [
          {
            "interface": "swp1",
            "directlyConnected": true
          }
        ],
        "resolvedProtocol": "connected"
      },
      "fe80::202:ff:fe00:2b": {
        "nhtConnected": true,
        "clientList": [
          {
            "protocol": "bgp",
            "socket": 45,
            "protocolFiltered": "none"
          }
        ],
        "gates": [
          {
            "interface": "swp1",
            "directlyConnected": true
          }
        ],
        "resolvedProtocol": "connected"
      }
    }
  },
  "mgmt": {
    "nexthops": {}
  },
  "sym_1": {
    "nexthops": {}
  }
}
```


Testing Done: Unit test completed.

Co-authored-by: Chirag Shah <chirag@nvidia.com>
Signed-off-by: Sindhu Parvathi Gopinathan <sgopinathan@nvidia.com>