### PR TITLE
zebra: Replace TC definitions for dplane

### DIFF
--- a/zebra/zebra_script.c
+++ b/zebra/zebra_script.c
@@ -417,9 +417,14 @@ void lua_pushzebra_dplane_ctx(lua_State *L, const struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_INTF_INSTALL:
 	case DPLANE_OP_INTF_UPDATE:
 	case DPLANE_OP_INTF_DELETE:
-	case DPLANE_OP_TC_INSTALL:
-	case DPLANE_OP_TC_UPDATE:
-	case DPLANE_OP_TC_DELETE:
+	case DPLANE_OP_TC_QDISC_INSTALL:
+	case DPLANE_OP_TC_QDISC_UNINSTALL:
+	case DPLANE_OP_TC_CLASS_ADD:
+	case DPLANE_OP_TC_CLASS_DELETE:
+	case DPLANE_OP_TC_CLASS_UPDATE:
+	case DPLANE_OP_TC_FILTER_ADD:
+	case DPLANE_OP_TC_FILTER_DELETE:
+	case DPLANE_OP_TC_FILTER_UPDATE:
 		/* Not currently handled */
 	case DPLANE_OP_INTF_NETCONFIG: /*NYI*/
 	case DPLANE_OP_NONE:


### PR DESCRIPTION
There's a switch statement in the lua extension code that doesn't include all of the values of a dataplane enum - so it fails to build. Add those values in...