### PR TITLE
tools,watchfrr: coordinate timeout when restarting a daemon

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -207,13 +207,39 @@ daemon_stop() {
 		return 1
 	fi
 
-	debug "kill -2 $pid"
-	kill -2 "$pid"
 	cnt=1200
+
+	#
+	# Allow calling program to convey the timeout it may be using
+	#
+	if [ -n "$FRR_WATCHFRR_TIMEOUT" ] ; then
+		$(( cnt = "$FRR_WATCHFRR_TIMEOUT" - 5 ))
+		$(( cnt *= 10 ))
+	fi
+
+	debug "kill -2 $pid, cnt $cnt"
+	log_success_msg "Stopping $dmninst, pid $pid ..."
+	kill -2 "$pid"
 	while kill -0 "$pid" 2>/dev/null; do
 		sleep .1
 		[ $(( cnt -= 1 )) -gt 0 ] || break
 	done
+
+	# Really kill the daemon if it didn't react to SIGINT
+	if kill -0 "$pid" 2>/dev/null; then
+		debug "kill -9 $dmninst, pid $pid"
+		log_success_msg "Failed to stop $dmninst, killing pid $pid ..."
+
+		kill -9 "$pid"
+
+		# And wait a bit for the kill to take effect
+		cnt=5
+		while kill -0 "$pid" 2>/dev/null; do
+			sleep .1
+			[ $(( cnt -= 1 )) -gt 0 ] || break
+		done
+	fi
+
 	if kill -0 "$pid" 2>/dev/null; then
 		log_failure_msg "Failed to stop $dmninst, pid $pid still running"
 		still_running=1

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -512,7 +512,16 @@ static int run_job(struct restart_info *restart, const char *cmdtype,
 	restart->kills = 0;
 	{
 		char cmd[strlen(command) + strlen(restart->name) + 1];
+		char tbuf[30];
+
 		snprintf(cmd, sizeof(cmd), command, restart->name);
+
+		/* Allow the restart script to see the timeout watchfrr will
+		 * be using.
+		 */
+		snprintf(tbuf, sizeof(tbuf), "%ld", gs.restart_timeout);
+		setenv("FRR_WATCHFRR_TIMEOUT", tbuf, 1);
+
 		if ((restart->pid = run_background(cmd)) > 0) {
 			thread_add_timer(master, restart_kill, restart,
 					 gs.restart_timeout, &restart->t_kill);


### PR DESCRIPTION
When watchfrr restarts a hung or failed daemon, convey the timeout that it's going to use to the shell script that's actually doing the work. If the two timeouts are different, watchfrr may terminate the shell script prematurely.

Also add a "kill" step to frrcommon's daemon_stop(): if a daemon is hung or deadlocked, it may not be able to react to SIGINT, and SIGKILL may be necessary.
