### PR TITLE
ospfd: json support for show ip ospf border-routers

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -831,6 +831,13 @@ Showing Information
    Show the OSPF routing table, as determined by the most recent SPF
    calculation.
 
+.. clicmd:: show ip ospf [vrf <NAME|all>] border-routers [json]
+
+   Show the list of ABR and ASBR border routers summary learnt via
+   OSPFv2 Type-3 (Summary LSA) and Type-4 (Summary ASBR LSA).
+   User can get that information as JSON format when ``json`` keyword
+   at the end of cli is presented.
+
 .. clicmd:: show ip ospf (1-65535) route orr [NAME]
 
 .. clicmd:: show ip ospf [vrf <NAME|all>] route orr [NAME]


### PR DESCRIPTION
show ip ospf border-routers json support added.
commands:
  - show ip ospf vrf default border-routers json
  - show ip ospf vrf all border-routers json
  - show ip ospf border-routers json

Testing Done: Unit testing completed.

rut# show ip ospf vrf all border-routers json
```
{
  "default":{
    "vrfName":"default",
    "vrfId":0,
    "routers":{
      "0.0.0.8":{
        "routeType":"R ",
        "cost":10,
        "area":"0.0.0.1",
        "routerType":"abr",
        "nexthops":[
          {
            "ip":"12.0.0.2",
            "via":"swp1"
          }
        ]
      },
      "0.0.0.9":{
        "routeType":"R ",
        "cost":10,
        "area":"0.0.0.1",
        "routerType":"abr",
        "nexthops":[
          {
            "ip":"12.0.1.2",
            "via":"swp2"
          }
        ]
      }
    }
  }
}

```
rut#
rut# show ip ospf vrf all border-routers json
```
{
  "default":{
        "vrfName":"default",
        "vrfId":0,
        "routers":{
          "0.0.0.15":{
            "routeType":"R ",
            "cost":30,
            "area":"0.0.0.0",
            "routerType":"abr",
            "nexthops":[
                {
                  "ip":"11.0.0.2",
                  "via":"br1"
                }
             ]
          }
      }
  }
}

```
rut# show ip ospf border-routers json
```
{
  "routers":{
    "0.0.0.15":{
      "routeType":"R ",
      "cost":30,
      "area":"0.0.0.0",
      "routerType":"abr",
      "nexthops":[
        {
          "ip":"11.0.0.2",
          "via":"br1"
        }
      ]
   }
 }
}


```


Co-authored-by: Chirag Shah <chirag@nvidia.com>
Signed-off-by: Sindhu Parvathi Gopinathan <sgopinathan@nvidia.com>