### PR TITLE
bfdd: fix IPv4 socket source selection

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -1397,8 +1397,6 @@ int bp_peer_socket(const struct bfd_session *bs)
 	sin.sin_len = sizeof(sin);
 #endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 	memcpy(&sin.sin_addr, &bs->key.local, sizeof(sin.sin_addr));
-	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH) == 0)
-		sin.sin_addr.s_addr = INADDR_ANY;
 
 	pcount = 0;
 	do {


### PR DESCRIPTION
The imported BFD code ([link](https://github.com/FRRouting/frr/commit/e9e2c950d7423071e8577a12c072a5309f02f8c1#diff-40710a42a0d79917913e2f2311ff7df6d5b1a20b7f8b56a4108e1adebfd48297R1301)) had some logic to ignore the source address when using single hop IPv4. The BFD peer socket function should allow the source to be selected so we can:
1. Select the source address in the outgoing packets
2. Only receive packets from that specific source

> **NOTE** IPv6 was never affected by this.