### PR TITLE
vrrpd: add IPv4 pseudoheader option for VRRPv3

### DIFF
--- a/doc/user/vrrp.rst
+++ b/doc/user/vrrp.rst
@@ -393,6 +393,11 @@ All interface configuration commands are documented below.
    higher priority to take over Master status from the existing Master. Enabled
    by default.
 
+.. clicmd:: vrrp (1-255) checksum-with-ipv4-pseudoheader
+
+   Specify whether VRRPv3 checksum should involve IPv4 pseudoheader. This
+   command should not affect VRRPv2 and IPv6. Enabled by default.
+
 .. clicmd:: vrrp (1-255) priority (1-254)
 
    Set the router priority. The router with the highest priority is elected as
@@ -448,7 +453,7 @@ Show commands, global defaults and debugging configuration commands.
    zebra
       Logs communications with Zebra.
 
-.. clicmd:: vrrp default <advertisement-interval (1-4096)|preempt|priority (1-254)|shutdown>
+.. clicmd:: vrrp default <advertisement-interval (1-4096)|preempt|priority (1-254)|checksum-with-ipv4-pseudoheader|shutdown>
 
    Configure defaults for new VRRP routers. These values will not affect
    already configured VRRP routers, but will be applied to newly configured
@@ -550,3 +555,19 @@ feature instead, explained `here
 <https://www.virtuallyghetto.com/2018/04/native-mac-learning-in-vsphere-6-7-removes-the-need-for-promiscuous-mode-for-nested-esxi.html>`_.
 
 Issue reference: https://github.com/FRRouting/frr/issues/5386
+
+
+My router cannot interoperate with branded routers / L3 switches
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+FRR includes a pseudoheader when calculating VRRPv3 checksums by default,
+regardless of whether it's IPv4 or IPv6.
+
+Some vendors have different interpretations of `VRRPv3 RFC 5798 #5.2.8
+<https://www.rfc-editor.org/rfc/rfc5798.html#section-5.2.8>`_. In such cases,
+their checksums are calculated with a pseudoheader only when it comes to IPv6.
+
+You need to disable ``checksum-with-ipv4-pseudoheader`` so that FRR computes and
+accepts such checksums.
+
+Issue reference: https://github.com/FRRouting/frr/issues/9951

--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -647,6 +647,8 @@ struct vrrp_vrouter *vrrp_vrouter_create(struct interface *ifp, uint8_t vrid,
 	vr->priority = vd.priority;
 	vr->preempt_mode = vd.preempt_mode;
 	vr->accept_mode = vd.accept_mode;
+	vr->checksum_with_ipv4_pseudoheader =
+		vd.checksum_with_ipv4_pseudoheader;
 	vr->shutdown = vd.shutdown;
 
 	vr->v4 = vrrp_router_create(vr, AF_INET);
@@ -789,7 +791,8 @@ static void vrrp_send_advertisement(struct vrrp_router *r)
 
 	pktsz = vrrp_pkt_adver_build(&pkt, &r->src, r->vr->version, r->vr->vrid,
 				     r->priority, r->vr->advertisement_interval,
-				     r->addrs->count, (struct ipaddr **)&addrs);
+				     r->addrs->count, (struct ipaddr **)&addrs,
+				     r->vr->checksum_with_ipv4_pseudoheader);
 
 	if (DEBUG_MODE_CHECK(&vrrp_dbg_pkt, DEBUG_MODE_ALL))
 		zlog_hexdump(pkt, (size_t)pktsz);
@@ -1027,8 +1030,10 @@ static void vrrp_read(struct thread *thread)
 		zlog_hexdump(r->ibuf, nbytes);
 	}
 
-	pktsize = vrrp_pkt_parse_datagram(r->family, r->vr->version, &m, nbytes,
-					  &src, &pkt, errbuf, sizeof(errbuf));
+	pktsize = vrrp_pkt_parse_datagram(
+		r->family, r->vr->version,
+		r->vr->checksum_with_ipv4_pseudoheader, &m, nbytes, &src, &pkt,
+		errbuf, sizeof(errbuf));
 
 	if (pktsize < 0)
 		DEBUGD(&vrrp_dbg_pkt,
@@ -2347,6 +2352,12 @@ int vrrp_config_write_global(struct vty *vty)
 		vty_out(vty, "%svrrp default accept\n",
 			!vd.accept_mode ? "no " : "");
 
+	if (vd.checksum_with_ipv4_pseudoheader !=
+		    VRRP_DEFAULT_CHECKSUM_WITH_IPV4_PSEUDOHEADER &&
+	    ++writes)
+		vty_out(vty, "%svrrp default checksum-with-ipv4-pseudoheader\n",
+			!vd.checksum_with_ipv4_pseudoheader ? "no " : "");
+
 	if (vd.shutdown != VRRP_DEFAULT_SHUTDOWN && ++writes)
 		vty_out(vty, "%svrrp default shutdown\n",
 			!vd.shutdown ? "no " : "");
@@ -2387,6 +2398,8 @@ void vrrp_init(void)
 	vd.preempt_mode = yang_get_default_bool("%s/preempt", VRRP_XPATH_FULL);
 	vd.accept_mode =
 		yang_get_default_bool("%s/accept-mode", VRRP_XPATH_FULL);
+	vd.checksum_with_ipv4_pseudoheader = yang_get_default_bool(
+		"%s/checksum-with-ipv4-pseudoheader", VRRP_XPATH_FULL);
 	vd.shutdown = VRRP_DEFAULT_SHUTDOWN;
 
 	vrrp_autoconfig_version = 3;

--- a/vrrpd/vrrp.h
+++ b/vrrpd/vrrp.h
@@ -53,6 +53,7 @@
 #define VRRP_DEFAULT_ADVINT 100
 #define VRRP_DEFAULT_PREEMPT true
 #define VRRP_DEFAULT_ACCEPT true
+#define VRRP_DEFAULT_CHECKSUM_WITH_IPV4_PSEUDOHEADER true
 #define VRRP_DEFAULT_SHUTDOWN false
 
 /* User compatibility constant */
@@ -70,6 +71,7 @@ struct vrrp_defaults {
 	uint16_t advertisement_interval;
 	bool preempt_mode;
 	bool accept_mode;
+	bool checksum_with_ipv4_pseudoheader;
 	bool shutdown;
 };
 
@@ -265,6 +267,14 @@ struct vrrp_vrouter {
 	 * it is not the IPvX address owner. The default is False.
 	 */
 	bool accept_mode;
+
+	/*
+	 * Indicates whether this router computes and accepts VRRPv3 checksums
+	 * without pseudoheader, for device interoperability.
+	 *
+	 * This option should only affect IPv4 virtual routers.
+	 */
+	bool checksum_with_ipv4_pseudoheader;
 
 	struct vrrp_router *v4;
 	struct vrrp_router *v6;

--- a/vrrpd/vrrp_northbound.c
+++ b/vrrpd/vrrp_northbound.c
@@ -602,6 +602,26 @@ lib_interface_vrrp_vrrp_group_shutdown_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
+/*
+ * XPath: /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/checksum-with-
+ *        ipv4-pseudoheader
+ */
+static int lib_interface_vrrp_vrrp_group_checksum_with_ipv4_pseudoheader_modify(
+	struct nb_cb_modify_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	struct vrrp_vrouter *vr;
+	bool checksum_with_ipv4_ph;
+
+	vr = nb_running_get_entry(args->dnode, NULL, true);
+	checksum_with_ipv4_ph = yang_dnode_get_bool(args->dnode, NULL);
+	vr->checksum_with_ipv4_pseudoheader = checksum_with_ipv4_ph;
+
+	return NB_OK;
+}
+
 /* clang-format off */
 const struct frr_yang_module_info frr_vrrpd_info = {
 	.name = "frr-vrrpd",
@@ -641,6 +661,13 @@ const struct frr_yang_module_info frr_vrrpd_info = {
 			.xpath = "/frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/accept-mode",
 			.cbs = {
 				.modify = lib_interface_vrrp_vrrp_group_accept_mode_modify,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/checksum-with-ipv4-pseudoheader",
+			.cbs = {
+				.modify = lib_interface_vrrp_vrrp_group_checksum_with_ipv4_pseudoheader_modify,
+				.cli_show = cli_show_checksum_with_ipv4_pseudoheader,
 			}
 		},
 		{

--- a/vrrpd/vrrp_packet.h
+++ b/vrrpd/vrrp_packet.h
@@ -131,7 +131,7 @@ struct vrrp_pkt {
 ssize_t vrrp_pkt_adver_build(struct vrrp_pkt **pkt, struct ipaddr *src,
 			     uint8_t version, uint8_t vrid, uint8_t prio,
 			     uint16_t max_adver_int, uint8_t numip,
-			     struct ipaddr **ips);
+			     struct ipaddr **ips, bool ipv4_ph);
 
 /* free memory allocated by vrrp_pkt_adver_build's pkt arg */
 void vrrp_pkt_free(struct vrrp_pkt *pkt);
@@ -195,9 +195,9 @@ size_t vrrp_pkt_adver_dump(char *buf, size_t buflen, struct vrrp_pkt *pkt);
  * Returns:
  *    Size of VRRP packet, or -1 upon error
  */
-ssize_t vrrp_pkt_parse_datagram(int family, int version, struct msghdr *m,
-				size_t read, struct ipaddr *src,
-				struct vrrp_pkt **pkt, char *errmsg,
-				size_t errmsg_len);
+ssize_t vrrp_pkt_parse_datagram(int family, int version, bool ipv4_ph,
+				struct msghdr *m, size_t read,
+				struct ipaddr *src, struct vrrp_pkt **pkt,
+				char *errmsg, size_t errmsg_len);
 
 #endif /* __VRRP_PACKET_H__ */

--- a/vrrpd/vrrp_vty.c
+++ b/vrrpd/vrrp_vty.c
@@ -281,6 +281,35 @@ void cli_show_preempt(struct vty *vty, const struct lyd_node *dnode,
 	vty_out(vty, " %svrrp %s preempt\n", pre ? "" : "no ", vrid);
 }
 
+/*
+ * XPath: /frr-interface:lib/interface/frr-vrrpd:vrrp/vrrp-group/checksum-with-
+ *        ipv4-pseudoheader
+ */
+DEFPY_YANG(vrrp_checksum_with_ipv4_pseudoheader,
+      vrrp_checksum_with_ipv4_pseudoheader_cmd,
+      "[no] vrrp (1-255)$vrid checksum-with-ipv4-pseudoheader",
+      NO_STR
+      VRRP_STR
+      VRRP_VRID_STR
+      "Checksum mode in VRRPv3\n")
+{
+	nb_cli_enqueue_change(vty, "./checksum-with-ipv4-pseudoheader",
+			      NB_OP_MODIFY, no ? "false" : "true");
+
+	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
+}
+
+void cli_show_checksum_with_ipv4_pseudoheader(struct vty *vty,
+					      const struct lyd_node *dnode,
+					      bool show_defaults)
+{
+	const char *vrid = yang_dnode_get_string(dnode, "../virtual-router-id");
+	const bool pre = yang_dnode_get_bool(dnode, NULL);
+
+	vty_out(vty, " %svrrp %s checksum-with-ipv4-pseudoheader\n",
+		pre ? "" : "no ", vrid);
+}
+
 /* XXX: yang conversion */
 DEFPY_YANG(vrrp_autoconfigure,
       vrrp_autoconfigure_cmd,
@@ -304,7 +333,7 @@ DEFPY_YANG(vrrp_autoconfigure,
 /* XXX: yang conversion */
 DEFPY_YANG(vrrp_default,
       vrrp_default_cmd,
-      "[no] vrrp default <advertisement-interval$adv (10-40950)$advint|preempt$p|priority$prio (1-254)$prioval|shutdown$s>",
+      "[no] vrrp default <advertisement-interval$adv (10-40950)$advint|preempt$p|priority$prio (1-254)$prioval|checksum-with-ipv4-pseudoheader$ipv4ph|shutdown$s>",
       NO_STR
       VRRP_STR
       "Configure defaults for new VRRP instances\n"
@@ -313,6 +342,7 @@ DEFPY_YANG(vrrp_default,
       "Preempt mode\n"
       VRRP_PRIORITY_STR
       "Priority value\n"
+      "Checksum mode in VRRPv3\n"
       "Force VRRP router into administrative shutdown\n")
 {
 	if (adv) {
@@ -329,6 +359,8 @@ DEFPY_YANG(vrrp_default,
 		vd.preempt_mode = !no;
 	if (prio)
 		vd.priority = no ? VRRP_DEFAULT_PRIORITY : prioval;
+	if (ipv4ph)
+		vd.checksum_with_ipv4_pseudoheader = !no;
 	if (s)
 		vd.shutdown = !no;
 
@@ -374,6 +406,8 @@ static struct json_object *vrrp_build_json(struct vrrp_vrouter *vr)
 	json_object_boolean_add(j, "shutdown", vr->shutdown);
 	json_object_boolean_add(j, "preemptMode", vr->preempt_mode);
 	json_object_boolean_add(j, "acceptMode", vr->accept_mode);
+	json_object_boolean_add(j, "checksumWithIpv4Pseudoheader",
+				vr->checksum_with_ipv4_pseudoheader);
 	json_object_string_add(j, "interface", vr->ifp->name);
 	json_object_int_add(j, "advertisementInterval",
 			    vr->advertisement_interval * CS2MS);
@@ -499,6 +533,8 @@ static void vrrp_show(struct vty *vty, struct vrrp_vrouter *vr)
 		       vr->preempt_mode ? "Yes" : "No");
 	ttable_add_row(tt, "%s|%s", "Accept Mode",
 		       vr->accept_mode ? "Yes" : "No");
+	ttable_add_row(tt, "%s|%s", "Checksum with IPv4 Pseudoheader",
+		       vr->checksum_with_ipv4_pseudoheader ? "Yes" : "No");
 	ttable_add_row(tt, "%s|%d ms", "Advertisement Interval",
 		       vr->advertisement_interval * CS2MS);
 	ttable_add_row(tt, "%s|%d ms (stale)",
@@ -752,4 +788,6 @@ void vrrp_vty_init(void)
 	install_element(INTERFACE_NODE, &vrrp_ip_cmd);
 	install_element(INTERFACE_NODE, &vrrp_ip6_cmd);
 	install_element(INTERFACE_NODE, &vrrp_preempt_cmd);
+	install_element(INTERFACE_NODE,
+			&vrrp_checksum_with_ipv4_pseudoheader_cmd);
 }

--- a/vrrpd/vrrp_vty.h
+++ b/vrrpd/vrrp_vty.h
@@ -40,5 +40,8 @@ void cli_show_ipv6(struct vty *vty, const struct lyd_node *dnode,
 		   bool show_defaults);
 void cli_show_preempt(struct vty *vty, const struct lyd_node *dnode,
 		      bool show_defaults);
+void cli_show_checksum_with_ipv4_pseudoheader(struct vty *vty,
+					      const struct lyd_node *dnode,
+					      bool show_defaults);
 
 #endif /* __VRRP_VTY_H__ */

--- a/yang/frr-vrrpd.yang
+++ b/yang/frr-vrrpd.yang
@@ -110,6 +110,13 @@ module frr-vrrpd {
          address is not owned by the router interface";
     }
 
+    leaf checksum-with-ipv4-pseudoheader {
+      type boolean;
+      default "true";
+      description
+        "Enabled if VRRPv3 checksum for IPv4 involves pseudoheader";
+    }
+
     leaf advertisement-interval {
       type uint16 {
         range "1..4095";


### PR DESCRIPTION
This commit adds a new option to control whether a VRRPv3 group accepts / computes its checksum with a prepended IPv4 pseudoheader. This should improve interoperability with other devices.

Signed-off-by: Siger Yang <siger.yang@outlook.com>

Due to text ambiguity, vendors have different explanations for IPv4 scenarios in [RFC 5798 #5.2.8](https://www.rfc-editor.org/rfc/rfc5798.html#section-5.2.8), so this PR should solve #9951.
