### PR TITLE
pim6d: Fix RpAddress in "show ipv6 pim bsm-database"

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -5610,7 +5610,7 @@ static void pim_show_bsm_db(struct pim_instance *pim, struct vty *vty, bool uj)
 
 				bsm_rpinfo = (struct bsmmsg_rpinfo *)buf;
 				/* unaligned, again */
-				memcpy(&rp_addr, &bsm_rpinfo->rpaddr,
+				memcpy(&rp_addr, &bsm_rpinfo->rpaddr.addr,
 				       sizeof(rp_addr));
 
 				buf += sizeof(struct bsmmsg_rpinfo);


### PR DESCRIPTION
The fix for issue #12089 was reverted while resolving conflict for PR https://github.com/FRRouting/frr/pull/11600/.

Signed-off-by: Sarita Patra <saritap@vmware.com>