### PR TITLE
lib: handle visual studio code C/C++ extension

### DIFF
--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -72,6 +72,16 @@ extern "C" {
 #endif
 #endif
 
+#ifdef __INTELLISENSE__
+/*
+ * Fix Visual Studio Code error: attribute "constructor" does not take
+ * arguments.
+ *
+ * Caused by the macro `DEFINE_MTYPE_ATTR` in `lib/memory.h`.
+ */
+#pragma diag_suppress 1094
+#endif /* __INTELISENSE__ */
+
 #if __has_attribute(hot)
 #  define _OPTIMIZE_HOT __attribute__((hot))
 #else
@@ -410,6 +420,35 @@ _Static_assert(sizeof(_uint64_t) == 8 && sizeof(_int64_t) == 8,
 
 #endif /* !__cplusplus */
 #endif /* !_FRR_ATTRIBUTE_PRINTFRR */
+
+/* helper to get type safety/avoid casts on calls
+ * (w/o this, functions accepting all prefix types need casts on the caller
+ * side, which strips type safety since the cast will accept any pointer
+ * type.)
+ */
+#ifndef __cplusplus
+#define prefixtype(uname, typename, fieldname) typename *fieldname;
+#define TRANSPARENT_UNION __attribute__((transparent_union))
+#else
+#define prefixtype(uname, typename, fieldname)                                 \
+	typename *fieldname;                                                   \
+	uname(typename *x)                                                     \
+	{                                                                      \
+		this->fieldname = x;                                           \
+	}
+#define TRANSPARENT_UNION
+#endif
+
+#ifdef __INTELLISENSE__
+/*
+ * Fix Visual Studio Code error: argument of type "struct prefix *" is
+ * incompatible with parameter of type "union prefixptr".
+ *
+ * This is caused by all functions having the transparent unions in the
+ * prototype. Example: `prefixptr` and `prefixconstptr` from `lib/prefix.h`.
+ */
+#pragma diag_suppress 167
+#endif /* __INTELISENSE__ */
 
 #ifdef __cplusplus
 }

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -301,22 +301,6 @@ struct prefix_sg {
 	struct in_addr grp;
 };
 
-/* helper to get type safety/avoid casts on calls
- * (w/o this, functions accepting all prefix types need casts on the caller
- * side, which strips type safety since the cast will accept any pointer
- * type.)
- */
-#ifndef __cplusplus
-#define prefixtype(uname, typename, fieldname) \
-	typename *fieldname;
-#define TRANSPARENT_UNION __attribute__((transparent_union))
-#else
-#define prefixtype(uname, typename, fieldname) \
-	typename *fieldname; \
-	uname(typename *x) { this->fieldname = x; }
-#define TRANSPARENT_UNION
-#endif
-
 union prefixptr {
 	prefixtype(prefixptr, struct prefix,      p)
 	prefixtype(prefixptr, struct prefix_ipv4, p4)


### PR DESCRIPTION
Add some `pragma`s to handle errors that the C/C++ extension is not able to understand.

See [discussion](https://github.com/FRRouting/frr/discussions/12398) for more details.