### PR TITLE
Echo exclusion

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -447,7 +447,8 @@ static int vty_command(struct vty *vty, char *buf)
 	/*
 	 * Log non empty command lines
 	 */
-	if (do_log_commands)
+	if (do_log_commands &&
+	    strncmp(buf, "echo PING", strlen("echo PING")) != 0)
 		cp = buf;
 	if (cp != NULL) {
 		/* Skip white spaces. */

--- a/zebra/zebra_trace.h
+++ b/zebra/zebra_trace.h
@@ -123,6 +123,49 @@ TRACEPOINT_EVENT(
 		)
 	)
 
+TRACEPOINT_EVENT(
+	frr_zebra,
+	netlink_tc_qdisc_change,
+	TP_ARGS(
+		struct nlmsghdr *, header,
+		ns_id_t, ns_id,
+		int, startup),
+	TP_FIELDS(
+		ctf_integer_hex(intptr_t, header, header)
+		ctf_integer(uint32_t, ns_id, ns_id)
+		ctf_integer(uint32_t, startup, startup)
+		)
+	)
+
+TRACEPOINT_EVENT(
+	frr_zebra,
+	netlink_tc_class_change,
+	TP_ARGS(
+		struct nlmsghdr *, header,
+		ns_id_t, ns_id,
+		int, startup),
+	TP_FIELDS(
+		ctf_integer_hex(intptr_t, header, header)
+		ctf_integer(uint32_t, ns_id, ns_id)
+		ctf_integer(uint32_t, startup, startup)
+		)
+	)
+
+
+TRACEPOINT_EVENT(
+	frr_zebra,
+	netlink_tc_filter_change,
+	TP_ARGS(
+		struct nlmsghdr *, header,
+		ns_id_t, ns_id,
+		int, startup),
+	TP_FIELDS(
+		ctf_integer_hex(intptr_t, header, header)
+		ctf_integer(uint32_t, ns_id, ns_id)
+		ctf_integer(uint32_t, startup, startup)
+		)
+	)
+
 #include <lttng/tracepoint-event.h>
 
 #endif /* HAVE_LTTNG */


### PR DESCRIPTION
1) do not log `ping ECHO` commands from watchfrr when `log commands` is turned on.
2) fix the lttng issue introduced recently