### PR TITLE
zebra: Use `mpls enable`, not `mpls` when generating a config

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -4646,7 +4646,7 @@ static int if_config_write(struct vty *vty)
 							? ""
 							: "no ");
 				if (if_data->mpls == IF_ZEBRA_DATA_ON)
-					vty_out(vty, " mpls\n");
+					vty_out(vty, " mpls enable\n");
 			}
 
 			hook_call(zebra_if_config_wr, vty, ifp);


### PR DESCRIPTION
Closes https://github.com/FRRouting/frr/issues/12406