### PR TITLE
zebra: delete label chunk upon release

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -783,6 +783,19 @@ presence of the entry.
    21     Static       10.125.0.2  IPv4 Explicit Null
 
 
+Allocated label chunks table can be dumped using the command
+
+.. clicmd:: show debugging label-table
+
+::
+
+   zebra# show debugging label-table
+   Proto ospf: [300/350]
+   Proto srte: [500/500]
+   Proto isis: [1200/1300]
+   Proto ospf: [20000/21000]
+   Proto isis: [22000/23000]
+
 .. _zebra-srv6:
 
 Segment-Routing IPv6

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -98,7 +98,7 @@ void delete_label_chunk(void *val)
  */
 int release_daemon_label_chunks(struct zserv *client)
 {
-	struct listnode *node;
+	struct listnode *node, *nnode;
 	struct label_manager_chunk *lmc;
 	int count = 0;
 	int ret;
@@ -108,7 +108,7 @@ int release_daemon_label_chunks(struct zserv *client)
 			   __func__, zebra_route_string(client->proto),
 			   client->instance, client->session_id);
 
-	for (ALL_LIST_ELEMENTS_RO(lbl_mgr.lc_list, node, lmc)) {
+	for (ALL_LIST_ELEMENTS(lbl_mgr.lc_list, node, nnode, lmc)) {
 		if (lmc->proto == client->proto &&
 		    lmc->instance == client->instance &&
 		    lmc->session_id == client->session_id && lmc->keep == 0) {
@@ -419,13 +419,14 @@ int release_label_chunk(uint8_t proto, unsigned short instance,
 				 "%s: Daemon mismatch!!", __func__);
 			continue;
 		}
-		lmc->proto = NO_PROTO;
-		lmc->instance = 0;
-		lmc->session_id = 0;
-		lmc->keep = 0;
 		ret = 0;
 		break;
 	}
+	if (lmc) {
+		list_delete_node(lbl_mgr.lc_list, node);
+		delete_label_chunk(lmc);
+	}
+
 	if (ret != 0)
 		flog_err(EC_ZEBRA_LM_UNRELEASED_CHUNK,
 			 "%s: Label chunk not released!!", __func__);

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -28,6 +28,8 @@
 #include "zebra/zapi_msg.h"
 #include "zebra/debug.h"
 
+#include "zebra/label_manager_clippy.c"
+
 #define CONNECTION_DELAY 5
 
 struct label_manager lbl_mgr;
@@ -145,6 +147,22 @@ void lm_hooks_unregister(void)
 	hook_unregister(lm_release_chunk, label_manager_release_label_chunk);
 }
 
+DEFPY(show_label_table, show_label_table_cmd, "show debugging label-table",
+      SHOW_STR
+      DEBUG_STR
+      "Display allocated label chunks\n")
+{
+	struct label_manager_chunk *lmc;
+	struct listnode *node;
+
+	for (ALL_LIST_ELEMENTS_RO(lbl_mgr.lc_list, node, lmc)) {
+		vty_out(vty, "Proto %s: [%u/%u]\n",
+			zebra_route_string(lmc->proto), lmc->start, lmc->end);
+	}
+
+	return CMD_SUCCESS;
+}
+
 /**
  * Init label manager (or proxy to an external one)
  */
@@ -159,6 +177,8 @@ void label_manager_init(void)
 
 	/* notify any external module that we are done */
 	hook_call(lm_cbs_inited);
+
+	install_element(VIEW_NODE, &show_label_table_cmd);
 }
 
 /* alloc and fill a label chunk */

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -124,6 +124,7 @@ clippy_scan += \
 	zebra/zebra_srv6_vty.c \
 	zebra/zebra_vrf.c \
 	zebra/dpdk/zebra_dplane_dpdk_vty.c \
+	zebra/label_manager.c \
 	# end
 
 noinst_HEADERS += \


### PR DESCRIPTION
In zebra/label_manager.c the releasing of the label chunk is done by disowning the chunk to the system. The presence of this system label chunk will cause label assignment to fail for this use case example:

label chunk ospf: 300-320
label chunk system: 510-520
label chunk isis: 1200-1300

Then we try to allocate the chunk 500-530, we get this error:
  "Allocation of mpls label chunk [500/530] failed"

The error is raised when the below condition is true:
    /* if chunk is used, cannot honor request */
      if (lmc->proto != NO_PROTO)
	      return NULL;

Delete the label chunk instead of disowning it when the label releasing is done.

Signed-off-by: Farid MIHOUB <farid.mihoub@6wind.com>