### PR TITLE
tests: Add delay to "While True" loops

### DIFF
--- a/tests/topotests/bgp_comm_list_delete/test_bgp_comm-list_delete.py
+++ b/tests/topotests/bgp_comm_list_delete/test_bgp_comm-list_delete.py
@@ -40,6 +40,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # pylint: disable=C0413
 from lib.topogen import Topogen, TopoRouter, get_topogen
+from time import sleep
 
 pytestmark = [pytest.mark.bgpd]
 
@@ -82,7 +83,10 @@ def test_bgp_maximum_prefix_invalid():
         pytest.skip(tgen.errors)
 
     def _bgp_converge(router):
-        while True:
+        count = 0
+        while count<20 :
+            count +=1
+            sleep(1)
             output = json.loads(
                 tgen.gears[router].vtysh_cmd("show ip bgp neighbor 192.168.255.1 json")
             )
@@ -94,6 +98,7 @@ def test_bgp_maximum_prefix_invalid():
                     == 2
                 ):
                     return True
+        return False
 
     def _bgp_comm_list_delete(router):
         output = json.loads(

--- a/tests/topotests/bgp_local_as_private_remove/test_bgp_local_as_private_remove.py
+++ b/tests/topotests/bgp_local_as_private_remove/test_bgp_local_as_private_remove.py
@@ -85,13 +85,17 @@ def test_bgp_remove_private_as():
         pytest.skip(tgen.errors)
 
     def _bgp_converge(router):
-        while True:
+        count = 0
+        while count<20 :
+            count +=1
+            time.sleep(1)
             output = json.loads(
                 tgen.gears[router].vtysh_cmd("show ip bgp neighbor 192.168.255.1 json")
             )
             if output["192.168.255.1"]["bgpState"] == "Established":
                 time.sleep(1)
                 return True
+        return False
 
     def _bgp_as_path(router):
         output = json.loads(

--- a/tests/topotests/bgp_maximum_prefix_invalid_update/test_bgp_maximum_prefix_invalid_update.py
+++ b/tests/topotests/bgp_maximum_prefix_invalid_update/test_bgp_maximum_prefix_invalid_update.py
@@ -42,6 +42,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # pylint: disable=C0413
 from lib.topogen import Topogen, TopoRouter, get_topogen
+from time import sleep
 
 pytestmark = [pytest.mark.bgpd]
 
@@ -84,12 +85,16 @@ def test_bgp_maximum_prefix_invalid():
         pytest.skip(tgen.errors)
 
     def _bgp_converge(router):
-        while True:
+        count = 0
+        while count<20 :
+            count +=1
+            sleep(1)
             output = json.loads(
                 tgen.gears[router].vtysh_cmd("show ip bgp neighbor 192.168.255.1 json")
             )
             if output["192.168.255.1"]["connectionsEstablished"] > 0:
                 return True
+        return False
 
     def _bgp_parsing_nlri(router):
         cmd_max_exceeded = (


### PR DESCRIPTION
While loops ran without delays and caused multiple GB's of logs for simple tests. Need to wait a little between each run to throttle output.

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>