### PR TITLE
tests: Fix `bgp_srv6l3vpn_to_bgp_vrf2` topotest failures

### DIFF
--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/r1/bgpd.conf
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/r1/bgpd.conf
@@ -1,5 +1,7 @@
 frr defaults traditional
 !
+bgp send-extra-data zebra
+!
 hostname r1
 password zebra
 !

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/r2/bgpd.conf
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/r2/bgpd.conf
@@ -1,5 +1,7 @@
 frr defaults traditional
 !
+bgp send-extra-data zebra
+!
 hostname r2
 password zebra
 !


### PR DESCRIPTION
The `bgp_srv6l3vpn_to_bgp_vrf2` topotest tests the SRv6 IPv4 L3VPN functionality. It applies the appropriate configuration in `bgpd` and `zebra`, and then checks that the RIB is updated correctly.

The topotest expects to find the AS-Path in the RIB, which is only present if the `bgp send-extra-data zebra` option is enabled in the `bgpd` configuration.

When this topotest was created, the `bgp send-extra-data zebra` option was enabled by default and the topotest worked fine.

However, the PR https://github.com/FRRouting/frr/pull/10408 changed the default behavior of bgp. Now the `bgp send-extra-data zebra` option is unset by default, which always causes the topotest to fail (because AS-Path is missing in the RIB):

![Schermata da 2022-11-30 23-10-15](https://user-images.githubusercontent.com/15899501/204919247-17cf0751-ef42-4f0c-9404-72f235d6a3e3.png)

This PR fixes the `bgp_srv6l3vpn_to_bgp_vrf2` topotest by enabling the `bgp send-extra-data zebra` option in the bgpd configuration for both routers `r1` and `r2`.

Signed-off-by: Carmine Scarpitta <carmine.scarpitta@uniroma2.it>