### PR TITLE
build: enable pim6d by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -636,7 +636,7 @@ AC_ARG_ENABLE([isisd],
 AC_ARG_ENABLE([pimd],
   AS_HELP_STRING([--disable-pimd], [do not build pimd]))
 AC_ARG_ENABLE([pim6d],
-  AS_HELP_STRING([--enable-pim6d], [build pim6d]))
+  AS_HELP_STRING([--disable-pim6d], [do not build pim6d]))
 AC_ARG_ENABLE([pbrd],
   AS_HELP_STRING([--disable-pbrd], [do not build pbrd]))
 AC_ARG_ENABLE([sharpd],
@@ -1765,7 +1765,7 @@ AS_IF([test "$enable_pimd" != "no"], [
   AC_DEFINE([HAVE_PIMD], [1], [pimd])
 ])
 
-AS_IF([test "$enable_pim6d" = "yes"], [
+AS_IF([test "$enable_pim6d" != "no"], [
   AC_DEFINE([HAVE_PIM6D], [1], [pim6d])
 ])
 
@@ -2078,7 +2078,7 @@ if test "$enable_rpki" = "yes"; then
 fi
 
 dnl ------------------------------------
-dnl pimd is not supported on OpenBSD and MacOS
+dnl pimd and pim6d not supported on OpenBSD and MacOS
 dnl ------------------------------------
 if test "$enable_pimd" != "no"; then
 AC_MSG_CHECKING([for pimd OS support])
@@ -2090,6 +2090,23 @@ case "$host_os" in
   openbsd*)
     AC_MSG_RESULT([no])
     enable_pimd="no"
+    ;;
+  *)
+    AC_MSG_RESULT([yes])
+    ;;
+esac
+fi
+
+if test "$enable_pim6d" != "no"; then
+AC_MSG_CHECKING([for pim6d OS support])
+case "$host_os" in
+  darwin*)
+    AC_MSG_RESULT([no])
+    enable_pim6d="no"
+    ;;
+  openbsd*)
+    AC_MSG_RESULT([no])
+    enable_pim6d="no"
     ;;
   *)
     AC_MSG_RESULT([yes])
@@ -2730,7 +2747,7 @@ AM_CONDITIONAL([BABELD], [test "$enable_babeld" != "no"])
 AM_CONDITIONAL([OSPF6D], [test "$enable_ospf6d" != "no"])
 AM_CONDITIONAL([ISISD], [test "$enable_isisd" != "no"])
 AM_CONDITIONAL([PIMD], [test "$enable_pimd" != "no"])
-AM_CONDITIONAL([PIM6D], [test "$enable_pim6d" = "yes"])
+AM_CONDITIONAL([PIM6D], [test "$enable_pim6d" != "no"])
 AM_CONDITIONAL([PBRD], [test "$enable_pbrd" != "no"])
 AM_CONDITIONAL([SHARPD], [test "$enable_sharpd" = "yes"])
 AM_CONDITIONAL([STATICD], [test "$enable_staticd" != "no"])


### PR DESCRIPTION
Change configure.ac so that pim6d is enabled by default; a command-line option can disable it. There was a platform test for pimd - I duplicated that for pim6d too.
