### PR TITLE
lib, zebra: Use real mtypes instead of MTYPE_TMP

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -38,6 +38,7 @@
 #include "lib/if_clippy.c"
 
 DEFINE_MTYPE_STATIC(LIB, IF, "Interface");
+DEFINE_MTYPE_STATIC(LIB, IFDESC, "Intf Desc");
 DEFINE_MTYPE_STATIC(LIB, CONNECTED, "Connected");
 DEFINE_MTYPE_STATIC(LIB, NBR_CONNECTED, "Neighbor Connected");
 DEFINE_MTYPE(LIB, CONNECTED_LABEL, "Connected interface label");
@@ -288,7 +289,7 @@ void if_delete(struct interface **ifp)
 
 	if_link_params_free(ptr);
 
-	XFREE(MTYPE_TMP, ptr->desc);
+	XFREE(MTYPE_IFDESC, ptr->desc);
 
 	XFREE(MTYPE_IF, ptr);
 	*ifp = NULL;
@@ -1612,9 +1613,9 @@ static int lib_interface_description_modify(struct nb_cb_modify_args *args)
 		return NB_OK;
 
 	ifp = nb_running_get_entry(args->dnode, NULL, true);
-	XFREE(MTYPE_TMP, ifp->desc);
+	XFREE(MTYPE_IFDESC, ifp->desc);
 	description = yang_dnode_get_string(args->dnode, NULL);
-	ifp->desc = XSTRDUP(MTYPE_TMP, description);
+	ifp->desc = XSTRDUP(MTYPE_IFDESC, description);
 
 	return NB_OK;
 }
@@ -1627,7 +1628,7 @@ static int lib_interface_description_destroy(struct nb_cb_destroy_args *args)
 		return NB_OK;
 
 	ifp = nb_running_get_entry(args->dnode, NULL, true);
-	XFREE(MTYPE_TMP, ifp->desc);
+	XFREE(MTYPE_IFDESC, ifp->desc);
 
 	return NB_OK;
 }

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1081,8 +1081,8 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	zif->link_ifindex = link_ifindex;
 
 	if (desc) {
-		XFREE(MTYPE_TMP, zif->desc);
-		zif->desc = XSTRDUP(MTYPE_TMP, desc);
+		XFREE(MTYPE_ZIF_DESC, zif->desc);
+		zif->desc = XSTRDUP(MTYPE_ZIF_DESC, desc);
 	}
 
 	/* Hardware type and address. */
@@ -2136,9 +2136,9 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 
 		zif = ifp->info;
 		if (zif) {
-			XFREE(MTYPE_TMP, zif->desc);
+			XFREE(MTYPE_ZIF_DESC, zif->desc);
 			if (desc)
-				zif->desc = XSTRDUP(MTYPE_TMP, desc);
+				zif->desc = XSTRDUP(MTYPE_ZIF_DESC, desc);
 		}
 	} else {
 		/* Delete interface notification from kernel */

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -61,6 +61,7 @@ DEFINE_HOOK(zebra_if_extra_info, (struct vty * vty, struct interface *ifp),
 DEFINE_HOOK(zebra_if_config_wr, (struct vty * vty, struct interface *ifp),
 	    (vty, ifp));
 
+DEFINE_MTYPE(ZEBRA, ZIF_DESC, "Intf desc");
 
 static void if_down_del_nbr_connected(struct interface *ifp);
 
@@ -233,7 +234,7 @@ static int if_zebra_delete_hook(struct interface *ifp)
 		if_nhg_dependents_release(ifp);
 		zebra_if_nhg_dependents_free(zebra_if);
 
-		XFREE(MTYPE_TMP, zebra_if->desc);
+		XFREE(MTYPE_ZIF_DESC, zebra_if->desc);
 
 		THREAD_OFF(zebra_if->speed_update);
 

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -109,6 +109,9 @@ enum zebra_if_flags {
 #define ZEBRA_IF_IS_PROTODOWN_ONLY_EXTERNAL(zif)                               \
 	((zif)->protodown_rc == ZEBRA_PROTODOWN_EXTERNAL)
 
+/* Mem type for zif desc */
+DECLARE_MTYPE(ZIF_DESC);
+
 /* `zebra' daemon local interface structure. */
 struct zebra_if {
 	/* back pointer to the interface */

--- a/zebra/irdp_interface.c
+++ b/zebra/irdp_interface.c
@@ -200,12 +200,12 @@ static void if_set_defaults(struct irdp_interface *irdp)
 
 static struct Adv *Adv_new(void)
 {
-	return XCALLOC(MTYPE_TMP, sizeof(struct Adv));
+	return XCALLOC(MTYPE_IRDP_IF, sizeof(struct Adv));
 }
 
 static void Adv_free(struct Adv *adv)
 {
-	XFREE(MTYPE_TMP, adv);
+	XFREE(MTYPE_IRDP_IF, adv);
 }
 
 static void irdp_if_start(struct interface *ifp, int multicast,

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -3698,7 +3698,7 @@ static inline void zebra_neigh_ip_del(ZAPI_HANDLER_ARGS)
 static inline void zread_iptable(ZAPI_HANDLER_ARGS)
 {
 	struct zebra_pbr_iptable *zpi =
-		XCALLOC(MTYPE_TMP, sizeof(struct zebra_pbr_iptable));
+		XCALLOC(MTYPE_PBR_OBJ, sizeof(struct zebra_pbr_iptable));
 	struct stream *s;
 
 	s = msg;

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -36,6 +36,7 @@
 
 /* definitions */
 DEFINE_MTYPE_STATIC(ZEBRA, PBR_IPTABLE_IFNAME, "PBR interface list");
+DEFINE_MTYPE(ZEBRA, PBR_OBJ, "PBR");
 
 /* definitions */
 static const struct message ipset_type_msg[] = {
@@ -163,7 +164,7 @@ void zebra_pbr_rules_free(void *arg)
 	rule = (struct zebra_pbr_rule *)arg;
 
 	(void)dplane_pbr_rule_delete(rule);
-	XFREE(MTYPE_TMP, rule);
+	XFREE(MTYPE_PBR_OBJ, rule);
 }
 
 uint32_t zebra_pbr_rules_hash_key(const void *arg)
@@ -275,7 +276,7 @@ void zebra_pbr_ipset_free(void *arg)
 
 	ipset = (struct zebra_pbr_ipset *)arg;
 	hook_call(zebra_pbr_ipset_update, 0, ipset);
-	XFREE(MTYPE_TMP, ipset);
+	XFREE(MTYPE_PBR_OBJ, ipset);
 }
 
 uint32_t zebra_pbr_ipset_hash_key(const void *arg)
@@ -319,7 +320,7 @@ void zebra_pbr_ipset_entry_free(void *arg)
 
 	hook_call(zebra_pbr_ipset_entry_update, 0, ipset);
 
-	XFREE(MTYPE_TMP, ipset);
+	XFREE(MTYPE_PBR_OBJ, ipset);
 }
 
 uint32_t zebra_pbr_ipset_entry_hash_key(const void *arg)
@@ -396,7 +397,7 @@ static void _zebra_pbr_iptable_free_all(void *arg, bool all)
 		}
 		list_delete(&iptable->interface_name_list);
 	}
-	XFREE(MTYPE_TMP, iptable);
+	XFREE(MTYPE_PBR_OBJ, iptable);
 }
 
 void zebra_pbr_iptable_free(void *arg)
@@ -478,7 +479,7 @@ static void *pbr_rule_alloc_intern(void *arg)
 
 	zpr = (struct zebra_pbr_rule *)arg;
 
-	new = XCALLOC(MTYPE_TMP, sizeof(*new));
+	new = XCALLOC(MTYPE_PBR_OBJ, sizeof(*new));
 
 	memcpy(new, zpr, sizeof(*zpr));
 
@@ -492,7 +493,7 @@ static struct zebra_pbr_rule *pbr_rule_free(struct zebra_pbr_rule *hash_data,
 		zebra_neigh_deref(hash_data);
 	hash_release(zrouter.rules_hash, hash_data);
 	if (free_data) {
-		XFREE(MTYPE_TMP, hash_data);
+		XFREE(MTYPE_PBR_OBJ, hash_data);
 		return NULL;
 	}
 
@@ -688,7 +689,7 @@ void zebra_pbr_add_rule(struct zebra_pbr_rule *rule)
 		(void)dplane_pbr_rule_update(found, new);
 		/* release the old hash data */
 		if (old)
-			XFREE(MTYPE_TMP, old);
+			XFREE(MTYPE_PBR_OBJ, old);
 	} else {
 		if (IS_ZEBRA_DEBUG_PBR)
 			zlog_debug(
@@ -856,7 +857,7 @@ static void *pbr_ipset_alloc_intern(void *arg)
 
 	zpi = (struct zebra_pbr_ipset *)arg;
 
-	new = XCALLOC(MTYPE_TMP, sizeof(struct zebra_pbr_ipset));
+	new = XCALLOC(MTYPE_PBR_OBJ, sizeof(struct zebra_pbr_ipset));
 
 	memcpy(new, zpi, sizeof(*zpi));
 
@@ -877,7 +878,7 @@ void zebra_pbr_destroy_ipset(struct zebra_pbr_ipset *ipset)
 	(void)dplane_pbr_ipset_delete(ipset);
 	if (lookup) {
 		hash_release(zrouter.ipset_hash, lookup);
-		XFREE(MTYPE_TMP, lookup);
+		XFREE(MTYPE_PBR_OBJ, lookup);
 	} else
 		zlog_debug(
 			"%s: IPSet Entry being deleted we know nothing about",
@@ -930,7 +931,7 @@ static void *pbr_ipset_entry_alloc_intern(void *arg)
 
 	zpi = (struct zebra_pbr_ipset_entry *)arg;
 
-	new = XCALLOC(MTYPE_TMP, sizeof(struct zebra_pbr_ipset_entry));
+	new = XCALLOC(MTYPE_PBR_OBJ, sizeof(struct zebra_pbr_ipset_entry));
 
 	memcpy(new, zpi, sizeof(*zpi));
 
@@ -952,7 +953,7 @@ void zebra_pbr_del_ipset_entry(struct zebra_pbr_ipset_entry *ipset)
 	(void)dplane_pbr_ipset_entry_delete(ipset);
 	if (lookup) {
 		hash_release(zrouter.ipset_entry_hash, lookup);
-		XFREE(MTYPE_TMP, lookup);
+		XFREE(MTYPE_PBR_OBJ, lookup);
 	} else
 		zlog_debug("%s: IPSet being deleted we know nothing about",
 			   __func__);
@@ -967,7 +968,7 @@ static void *pbr_iptable_alloc_intern(void *arg)
 
 	zpi = (struct zebra_pbr_iptable *)arg;
 
-	new = XCALLOC(MTYPE_TMP, sizeof(struct zebra_pbr_iptable));
+	new = XCALLOC(MTYPE_PBR_OBJ, sizeof(struct zebra_pbr_iptable));
 
 	/* Deep structure copy */
 	memcpy(new, zpi, sizeof(*zpi));
@@ -1009,7 +1010,7 @@ void zebra_pbr_del_iptable(struct zebra_pbr_iptable *iptable)
 					 node);
 		}
 		list_delete(&iptable->interface_name_list);
-		XFREE(MTYPE_TMP, lookup);
+		XFREE(MTYPE_PBR_OBJ, lookup);
 	} else
 		zlog_debug("%s: IPTable being deleted we know nothing about",
 			   __func__);

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -36,6 +36,9 @@
 extern "C" {
 #endif
 
+/* Memory type for PBR objects. */
+DECLARE_MTYPE(PBR_OBJ);
+
 struct zebra_pbr_action {
 	afi_t afi;
 

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -78,6 +78,8 @@ static struct zserv *find_client_internal(uint8_t proto,
 					  unsigned short instance,
 					  uint32_t session_id);
 
+/* Mem type for zclients. */
+DEFINE_MTYPE_STATIC(ZEBRA, ZSERV_CLIENT, "ZClients");
 
 /*
  * Client thread events.
@@ -144,6 +146,14 @@ static void zserv_event(struct zserv *client, enum zserv_event event);
 
 
 /* Client thread lifecycle -------------------------------------------------- */
+
+/*
+ * Free a zserv client object.
+ */
+void zserv_client_delete(struct zserv *client)
+{
+	XFREE(MTYPE_ZSERV_CLIENT, client);
+}
 
 /*
  * Log zapi message to zlog.
@@ -644,7 +654,7 @@ static void zserv_client_free(struct zserv *client)
 		if (IS_ZEBRA_DEBUG_EVENT)
 			zlog_debug("%s: Deleting client %s", __func__,
 				   zebra_route_string(client->proto));
-		XFREE(MTYPE_TMP, client);
+		zserv_client_delete(client);
 	} else {
 		/* Handle cases where client has GR instance. */
 		if (IS_ZEBRA_DEBUG_EVENT)
@@ -733,7 +743,7 @@ static struct zserv *zserv_client_create(int sock)
 	int i;
 	afi_t afi;
 
-	client = XCALLOC(MTYPE_TMP, sizeof(struct zserv));
+	client = XCALLOC(MTYPE_ZSERV_CLIENT, sizeof(struct zserv));
 
 	/* Make client input/output buffer. */
 	client->sock = sock;

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -364,6 +364,13 @@ extern void zserv_release_client(struct zserv *client);
 extern void zserv_close_client(struct zserv *client);
 
 /*
+ * Free memory for a zserv client object - note that this does not
+ * clean up the internal allocations associated with the zserv client,
+ * this just free the struct's memory.
+ */
+void zserv_client_delete(struct zserv *client);
+
+/*
  * Log a ZAPI message hexdump.
  *
  * errmsg


### PR DESCRIPTION
Add several MTYPEs for various objects and use those instead of MTYPE_TMP. This makes it easier to debug mem leaks, for example.