### PR TITLE
vtysh: Do not leak memory

### DIFF
--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -348,9 +348,13 @@ void vtysh_config_parse_line(void *arg, const char *line)
 		break;
 	default:
 		if (strncmp(line, "exit", strlen("exit")) == 0) {
-			if (config)
+			if (config) {
+				if (config->exit)
+					XFREE(MTYPE_VTYSH_CONFIG_LINE,
+					      config->exit);
 				config->exit =
 					XSTRDUP(MTYPE_VTYSH_CONFIG_LINE, line);
+			}
 		} else if (strncmp(line, "interface", strlen("interface")) == 0)
 			config = config_get(INTERFACE_NODE, line);
 		else if (strncmp(line, "pseudowire", strlen("pseudowire")) == 0)


### PR DESCRIPTION
config->exit may already be non-NULL and a simple
`vtysh -c "show run"` with address sanitizer built in shows the memory leak is gone now.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>