### PR TITLE
bgpd, tests: Fix topotests for SRv6 L3VPN and misuse of sid_unregister

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -888,7 +888,7 @@ void delete_vrf_tovpn_sid_per_af(struct bgp *bgp_vpn, struct bgp *bgp_vrf,
 	srv6_locator_chunk_free(&bgp_vrf->vpn_policy[afi].tovpn_sid_locator);
 
 	if (bgp_vrf->vpn_policy[afi].tovpn_sid) {
-		sid_unregister(bgp_vrf, bgp_vrf->vpn_policy[afi].tovpn_sid);
+		sid_unregister(bgp_vpn, bgp_vrf->vpn_policy[afi].tovpn_sid);
 		XFREE(MTYPE_BGP_SRV6_SID, bgp_vrf->vpn_policy[afi].tovpn_sid);
 	}
 	bgp_vrf->vpn_policy[afi].tovpn_sid_transpose_label = 0;
@@ -915,7 +915,7 @@ void delete_vrf_tovpn_sid_per_vrf(struct bgp *bgp_vpn, struct bgp *bgp_vrf)
 	srv6_locator_chunk_free(&bgp_vrf->tovpn_sid_locator);
 
 	if (bgp_vrf->tovpn_sid) {
-		sid_unregister(bgp_vrf, bgp_vrf->tovpn_sid);
+		sid_unregister(bgp_vpn, bgp_vrf->tovpn_sid);
 		XFREE(MTYPE_BGP_SRV6_SID, bgp_vrf->tovpn_sid);
 	}
 	bgp_vrf->tovpn_sid_transpose_label = 0;

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/test_bgp_srv6l3vpn_to_bgp_vrf.py
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/test_bgp_srv6l3vpn_to_bgp_vrf.py
@@ -155,7 +155,7 @@ def check_ping(name, dest_addr, expect_connected):
         if match not in output:
             return "ping fail"
 
-    match = "{} packet loss".format("0%" if expect_connected else "100%")
+    match = ", {} packet loss".format("0%" if expect_connected else "100%")
     logger.info("[+] check {} {} {}".format(name, dest_addr, match))
     tgen = get_topogen()
     func = functools.partial(_check, name, dest_addr, match)

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/test_bgp_srv6l3vpn_to_bgp_vrf2.py
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/test_bgp_srv6l3vpn_to_bgp_vrf2.py
@@ -69,10 +69,12 @@ def setup_module(mod):
     tgen.start_topology()
     for rname, router in tgen.routers().items():
         router.run("/bin/bash {}/{}/setup.sh".format(CWD, rname))
-        router.load_config(TopoRouter.RD_ZEBRA,
-                           os.path.join(CWD, '{}/zebra.conf'.format(rname)))
-        router.load_config(TopoRouter.RD_BGP,
-                           os.path.join(CWD, '{}/bgpd.conf'.format(rname)))
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP, os.path.join(CWD, "{}/bgpd.conf".format(rname))
+        )
 
     tgen.gears["r1"].run("sysctl net.vrf.strict_mode=1")
     tgen.gears["r1"].run("ip link add vrf10 type vrf table 10")
@@ -114,7 +116,7 @@ def check_ping(name, dest_addr, expect_connected):
         logger.info(output)
         assert match in output, "ping fail"
 
-    match = "{} packet loss".format("0%" if expect_connected else "100%")
+    match = ", {} packet loss".format("0%" if expect_connected else "100%")
     logger.info("[+] check {} {} {}".format(name, dest_addr, match))
     tgen = get_topogen()
     func = functools.partial(_check, name, dest_addr, match)
@@ -131,7 +133,7 @@ def check_rib(name, cmd, expected_file):
         expected = open_json_file("{}/{}".format(CWD, expected_file))
         return topotest.json_cmp(output, expected)
 
-    logger.info("[+] check {} \"{}\" {}".format(name, cmd, expected_file))
+    logger.info('[+] check {} "{}" {}'.format(name, cmd, expected_file))
     tgen = get_topogen()
     func = functools.partial(_check, name, cmd, expected_file)
     success, result = topotest.run_and_expect(func, None, count=10, wait=0.5)
@@ -154,16 +156,16 @@ def test_rib():
 
 
 def test_ping():
-    check_ping("ce1", "192.168.2.2", " 0% packet loss")
-    check_ping("ce1", "192.168.3.2", " 0% packet loss")
-    check_ping("ce1", "192.168.4.2", " 100% packet loss")
-    check_ping("ce1", "192.168.5.2", " 100% packet loss")
-    check_ping("ce1", "192.168.6.2", " 100% packet loss")
-    check_ping("ce4", "192.168.1.2", " 100% packet loss")
-    check_ping("ce4", "192.168.2.2", " 100% packet loss")
-    check_ping("ce4", "192.168.3.2", " 100% packet loss")
-    check_ping("ce4", "192.168.5.2", " 0% packet loss")
-    check_ping("ce4", "192.168.6.2", " 0% packet loss")
+    check_ping("ce1", "192.168.2.2", True)
+    check_ping("ce1", "192.168.3.2", True)
+    check_ping("ce1", "192.168.4.2", False)
+    check_ping("ce1", "192.168.5.2", False)
+    check_ping("ce1", "192.168.6.2", False)
+    check_ping("ce4", "192.168.1.2", False)
+    check_ping("ce4", "192.168.2.2", False)
+    check_ping("ce4", "192.168.3.2", False)
+    check_ping("ce4", "192.168.5.2", True)
+    check_ping("ce4", "192.168.6.2", True)
 
 
 if __name__ == "__main__":

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/test_bgp_srv6l3vpn_to_bgp_vrf3.py
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/test_bgp_srv6l3vpn_to_bgp_vrf3.py
@@ -66,10 +66,12 @@ def setup_module(mod):
     tgen.start_topology()
     for rname, router in tgen.routers().items():
         router.run("/bin/bash {}/{}/setup.sh".format(CWD, rname))
-        router.load_config(TopoRouter.RD_ZEBRA,
-                           os.path.join(CWD, '{}/zebra.conf'.format(rname)))
-        router.load_config(TopoRouter.RD_BGP,
-                           os.path.join(CWD, '{}/bgpd.conf'.format(rname)))
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP, os.path.join(CWD, "{}/bgpd.conf".format(rname))
+        )
 
     tgen.gears["r1"].run("sysctl net.vrf.strict_mode=1")
     tgen.gears["r1"].run("ip link add vrf10 type vrf table 10")
@@ -111,7 +113,7 @@ def check_ping4(name, dest_addr, expect_connected):
         logger.info(output)
         assert match in output, "ping fail"
 
-    match = "{} packet loss".format("0%" if expect_connected else "100%")
+    match = ", {} packet loss".format("0%" if expect_connected else "100%")
     logger.info("[+] check {} {} {}".format(name, dest_addr, match))
     tgen = get_topogen()
     func = functools.partial(_check, name, dest_addr, match)
@@ -144,7 +146,7 @@ def check_rib(name, cmd, expected_file):
         expected = open_json_file("{}/{}".format(CWD, expected_file))
         return topotest.json_cmp(output, expected)
 
-    logger.info("[+] check {} \"{}\" {}".format(name, cmd, expected_file))
+    logger.info('[+] check {} "{}" {}'.format(name, cmd, expected_file))
     tgen = get_topogen()
     func = functools.partial(_check, name, cmd, expected_file)
     success, result = topotest.run_and_expect(func, None, count=10, wait=0.5)
@@ -214,10 +216,18 @@ def test_bgp_sid_vpn_export_disable():
            no sid vpn per-vrf export
         """
     )
-    check_rib("r1", "show bgp ipv4 vpn json", "r1/vpnv4_rib_sid_vpn_export_disabled.json")
-    check_rib("r2", "show bgp ipv4 vpn json", "r2/vpnv4_rib_sid_vpn_export_disabled.json")
-    check_rib("r1", "show bgp ipv6 vpn json", "r1/vpnv6_rib_sid_vpn_export_disabled.json")
-    check_rib("r2", "show bgp ipv6 vpn json", "r2/vpnv6_rib_sid_vpn_export_disabled.json")
+    check_rib(
+        "r1", "show bgp ipv4 vpn json", "r1/vpnv4_rib_sid_vpn_export_disabled.json"
+    )
+    check_rib(
+        "r2", "show bgp ipv4 vpn json", "r2/vpnv4_rib_sid_vpn_export_disabled.json"
+    )
+    check_rib(
+        "r1", "show bgp ipv6 vpn json", "r1/vpnv6_rib_sid_vpn_export_disabled.json"
+    )
+    check_rib(
+        "r2", "show bgp ipv6 vpn json", "r2/vpnv6_rib_sid_vpn_export_disabled.json"
+    )
     check_ping4("ce1", "192.168.2.2", False)
     check_ping6("ce1", "2001:2::2", False)
 
@@ -233,10 +243,18 @@ def test_bgp_sid_vpn_export_reenable():
            sid vpn per-vrf export auto
         """
     )
-    check_rib("r1", "show bgp ipv4 vpn json", "r1/vpnv4_rib_sid_vpn_export_reenabled.json")
-    check_rib("r2", "show bgp ipv4 vpn json", "r2/vpnv4_rib_sid_vpn_export_reenabled.json")
-    check_rib("r1", "show bgp ipv6 vpn json", "r1/vpnv6_rib_sid_vpn_export_reenabled.json")
-    check_rib("r2", "show bgp ipv6 vpn json", "r2/vpnv6_rib_sid_vpn_export_reenabled.json")
+    check_rib(
+        "r1", "show bgp ipv4 vpn json", "r1/vpnv4_rib_sid_vpn_export_reenabled.json"
+    )
+    check_rib(
+        "r2", "show bgp ipv4 vpn json", "r2/vpnv4_rib_sid_vpn_export_reenabled.json"
+    )
+    check_rib(
+        "r1", "show bgp ipv6 vpn json", "r1/vpnv6_rib_sid_vpn_export_reenabled.json"
+    )
+    check_rib(
+        "r2", "show bgp ipv6 vpn json", "r2/vpnv6_rib_sid_vpn_export_reenabled.json"
+    )
     check_ping4("ce1", "192.168.2.2", True)
     check_ping6("ce1", "2001:2::2", True)
 


### PR DESCRIPTION
The current SRv6 L3VPN topotests can't test reachability correctly. If we set expect_connected to True, check_ping will pass even if all ping packets are dropped. 

This PR fixes check_ping to check reachability correctly. This PR also updates misuse of sid_unregister in delete_vrf_tovpn_sid_per_{af,vrf} to pass bgp_srv6l3vpn_to_bgp_vrf.