### PR TITLE
zebra: Fix missing newline character in the of SRv6 config write function

### DIFF
--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -434,9 +434,9 @@ static int zebra_sr_config(struct vty *vty)
 			if (locator->argument_bits_length)
 				vty_out(vty, " arg-len %u",
 					locator->argument_bits_length);
-			if (CHECK_FLAG(locator->flags, SRV6_LOCATOR_USID))
-				vty_out(vty, "    behavior usid");
 			vty_out(vty, "\n");
+			if (CHECK_FLAG(locator->flags, SRV6_LOCATOR_USID))
+				vty_out(vty, "    behavior usid\n");
 			vty_out(vty, "   exit\n");
 			vty_out(vty, "   !\n");
 		}


### PR DESCRIPTION
The `behavior usid` command is installed under the SRv6 Locator node in the zebra VTY. However, in the SRv6 config write function this command is wrongly put on the same line as the `prefix X:X::X:X/M` command. This causes a failure when an SRv6 uSID locator is configured in zebra and `frr-reload.py` is used to reload the FRR configuration.

This PR prepends a newline character to the `behavior usid` command in the SRv6 config write function. The output of `show running-config` before and after this PR is shown below.

Before:

```
Building configuration...

Current configuration:
!
frr version 8.5-dev
!
segment-routing
 srv6
  locators
   locator loc1
    prefix fc00:0:1::/48 block-len 32 node-len 16    behavior usid
   exit
   !
  exit
  !
 exit
 !
exit
!
end
```

After:

```
Building configuration...

Current configuration:
!
segment-routing
 srv6
  locators
   locator loc1
    prefix fc00:0:1::/48 block-len 32 node-len 16
    behavior usid
   exit
   !
  exit
  !
 exit
 !
exit
!
end
```

Signed-off-by: Carmine Scarpitta <carmine.scarpitta@uniroma2.it>