### PR TITLE
vtysh: free memory given to us by readline

### DIFF
--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -111,6 +111,8 @@ static void vtysh_rl_callback(char *line_read)
 
 	if (!vtysh_loop_exited)
 		rl_callback_handler_install(vtysh_prompt(), vtysh_rl_callback);
+
+	free(line_read);
 }
 
 /* SIGTSTP handler.  This function care user's ^Z input. */


### PR DESCRIPTION
The rl_callback_handler_install function manual says this:

Set up the terminal for Readline I/O and display the initial expanded value of prompt. Save the value of lhandler to use as a handler function to call when a complete line of input has been entered. The handler function receives the text of the line as an argument. As with readline(), the handler function should free the line when it is finished with it.

Adding a free removes this memory leak that I am seeing with address sanitizer enabled;

SUMMARY: AddressSanitizer: 99 byte(s) leaked in 5 allocation(s).: 2022-12-05 07:50:57,231 INFO: topolog.r7: vtysh result:
	Hello, this is FRRouting (version 8.5-dev).
	Copyright 1996-2005 Kunihiro Ishiguro, et al.

	r7# clear log cmdline-targets
	r7# conf t
	r7(config)# log file staticd.log debug
	r7(config)# log commands
	r7(config)# log timestamp precision 3
	r7(config)#

	=================================================================
	==976989==ERROR: LeakSanitizer: detected memory leaks

	Direct leak of 99 byte(s) in 5 object(s) allocated from:
	    #0 0x49cadd in malloc (/usr/bin/vtysh+0x49cadd)
	    #1 0x7fc57135d8e8 in xmalloc build/shlib/./xmalloc.c:59:10

	SUMMARY: AddressSanitizer: 99 byte(s) leaked in 5 allocation(s).

Signed-off-by: Donald Sharp <sharpd@nvidia.com>