### PR TITLE
bgpd: Adding BGP neighbor JSON output for neighbors never established a BGP adjacency

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -13010,9 +13010,8 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 
 	if (p->hostname) {
 		if (use_json) {
-			if (p->hostname)
-				json_object_string_add(json_neigh, "hostname",
-						       p->hostname);
+			json_object_string_add(json_neigh, "hostname",
+					       p->hostname);
 
 			if (p->domainname)
 				json_object_string_add(json_neigh, "domainname",
@@ -13024,6 +13023,10 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 			else
 				vty_out(vty, "Hostname: %s\n", p->hostname);
 		}
+	} else {
+		if (use_json)
+			json_object_string_add(json_neigh, "hostname",
+					       "Unknown");
 	}
 
 	/* Peer-group */
@@ -14584,6 +14587,17 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 			vty_out(vty, "BGP connection: %s\n",
 				p->shared_network ? "shared network"
 						  : "non shared network");
+		}
+	} else {
+		if (use_json) {
+			json_object_string_add(json_neigh, "nexthop",
+					       "Unknown");
+			json_object_string_add(json_neigh, "nexthopGlobal",
+					       "Unknown");
+			json_object_string_add(json_neigh, "nexthopLocal",
+					       "Unknown");
+			json_object_string_add(json_neigh, "bgpConnection",
+					       "Unknown");
 		}
 	}
 


### PR DESCRIPTION
Some keys are only present in the JSON data of BGP neighbors are only present if the peer is, or has previously been established. While they are not present if the peer has never come up.

To keep the data structure aligned, the below keys are added also to the neighbors that BGP adjacency has never been established. Besides, the values of the keys are all set to Unknown
    "hostname":Unknown,
    "nexthop":Unknown,
    "nexthopGlobal":Unknown,
    "nexthopLocal":Unknown,
    "bgpConnection":Unknown,

Signed-off-by: Karl Quan <kquan@nvidia.com>