### PR TITLE
zebra: vrf-id support for show vrf vni json cmd

### DIFF
--- a/doc/user/evpn.rst
+++ b/doc/user/evpn.rst
@@ -510,3 +510,21 @@ Displaying EVPN information
 
    Display detailed information about MAC addresses for
    a specified VNI.
+
+.. clicmd:: show vrf [<NAME$vrf_name|all$vrf_all>] vni [json]
+
+   Displays VRF to L3VNI mapping. It also displays L3VNI associated
+   router-mac, svi interface and vxlan interface.
+   User can get that information as JSON format when ``json`` keyword
+   at the end of cli is presented.
+
+   .. code-block:: frr
+
+      tor2# show vrf vni
+      VRF                                   VNI        VxLAN IF             L3-SVI               State Rmac
+      sym_1                                 9288       vxlan21              vlan210_l3           Up    21:31:36:ff:ff:20
+      sym_2                                 9289       vxlan21              vlan210_l3           Up    21:31:36:ff:ff:20
+      sym_3                                 9290       vxlan21              vlan210_l3           Up    21:31:36:ff:ff:20
+      tor2# show vrf sym_1 vni
+      VRF                                   VNI        VxLAN IF             L3-SVI               State Rmac
+      sym_1                                 9288       vxlan21              vlan210_l3           Up    44:38:36:ff:ff:20


### PR DESCRIPTION
cli & json support extended for show vrf vrf-id vni

commands:

	 - show vrf <vrf-name> vni
	 - show vrf all vni
	 - show vrf <vrf-name> vni json
	 - show vrf all vni json

Before:
```
tor-1# show vrf vni
VRF                                   VNI        VxLAN IF
L3-SVI               State Rmac
default                               100        None
None                 Down  None
sym_1                                 8888       vxlan99
vlan490_l3           Up    44:38:39:ff:ff:25
sym_2                                 8889       vxlan99
vlan491_l3           Up    44:38:39:ff:ff:25
sym_3                                 8890       vxlan99
vlan492_l3           Up    44:38:39:ff:ff:25
sym_4                                 8891       vxlan99
vlan493_l3           Up    44:38:39:ff:ff:25
sym_5                                 8892       vxlan99
vlan494_l3           Up    44:38:39:ff:ff:25
```

After:
```
tor-1# show vrf default vni json
{
  "vrfs":[
    {
      "vrf":"default",
      "vni":100,
      "vxlanIntf":"None",
      "sviIntf":"None",
      "state":"Down",
      "routerMac":"None"
    }
  ]
}

tor-1# show vrf default vni
VRF                                   VNI        VxLAN IF
L3-SVI               State Rmac
default                               100        None
None                 Down  None
tor-1#

tor-1# show vrf all vni
VRF                                   VNI        VxLAN IF
L3-SVI               State Rmac
default                               100        None
None                 Down  None
sym_1                                 8888       vxlan99
vlan490_l3           Up    44:38:39:ff:ff:25
sym_2                                 8889       vxlan99
vlan491_l3           Up    44:38:39:ff:ff:25
sym_3                                 8890       vxlan99
vlan492_l3           Up    44:38:39:ff:ff:25
sym_4                                 8891       vxlan99
vlan493_l3           Up    44:38:39:ff:ff:25
sym_5                                 8892       vxlan99
vlan494_l3           Up    44:38:39:ff:ff:25
tor-1#

tor-1# show vrf all vni json
{
  "vrfs":[
    {
      "vrf":"default",
      "vni":100,
      "vxlanIntf":"None",
      "sviIntf":"None",
      "state":"Down",
      "routerMac":"None"
    },
    {
      "vrf":"sym_1",
      "vni":8888,
      "vxlanIntf":"vxlan99",
      "sviIntf":"vlan490_l3",
      "state":"Up",
      "routerMac":"44:38:39:ff:ff:25"
    },
    {
      "vrf":"sym_2",
      "vni":8889,
      "vxlanIntf":"vxlan99",
      "sviIntf":"vlan491_l3",
      "state":"Up",
      "routerMac":"44:38:39:ff:ff:25"
    },
    {
      "vrf":"sym_3",
      "vni":8890,
      "vxlanIntf":"vxlan99",
      "sviIntf":"vlan492_l3",
      "state":"Up",
      "routerMac":"44:38:39:ff:ff:25"
    },
    {
      "vrf":"sym_4",
      "vni":8891,
      "vxlanIntf":"vxlan99",
      "sviIntf":"vlan493_l3",
      "state":"Up",
      "routerMac":"44:38:39:ff:ff:25"
    },
    {
      "vrf":"sym_5",
      "vni":8892,
      "vxlanIntf":"vxlan99",
      "sviIntf":"vlan494_l3",
      "state":"Up",
      "routerMac":"44:38:39:ff:ff:25"
    }
  ]
}
```

Signed-off-by: Sindhu Parvathi Gopinathan <sgopinathan@nvidia.com>