### PR TITLE
tools: revert stop zebra daemon last

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -266,7 +266,7 @@ all_start() {
 }
 
 all_stop() {
-	local pids reversed need_zebra
+	local pids reversed
 
 	daemon_list enabled_daemons disabled_daemons
 	[ "$1" = "--reallyall" ] && enabled_daemons="$enabled_daemons $disabled_daemons"
@@ -276,23 +276,13 @@ all_stop() {
 		reversed="$dmninst $reversed"
 	done
 
-	# Stop zebra last, after trying to stop the other daemons
 	for dmninst in $reversed; do
-		if [ "$dmninst" = "zebra" ]; then
-			need_zebra="yes"
-			continue
-		fi
-
 		daemon_stop "$dmninst" "$1" &
 		pids="$pids $!"
 	done
 	for pid in $pids; do
 		wait $pid
 	done
-
-	if [ -n "$need_zebra" ]; then
-		daemon_stop "zebra"
-	fi
 }
 
 all_status() {


### PR DESCRIPTION
This reverts commit 2000ac4075bbe1a9557ee30286309d3ade72b3a7.

There were concerns that ensuring zebra stopped last led to problems with zebra's "-r" flag, so we'll revert that for the time being and reconsider this area.
