### PR TITLE
bgpd: Fix aggregated routes are withdrawn abnormally.

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4405,6 +4405,12 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 			 * need to be imported again, so flag accordingly.
 			 */
 			force_evpn_import = true;
+		} else {
+			/* implicit withdraw, decrement aggregate and pcount
+			 * here. only if update is accepted, they'll increment
+			 * below.
+			 */
+			bgp_aggregate_decrement(bgp, p, pi, afi, safi);
 		}
 
 		/* Received Logging. */
@@ -4424,11 +4430,6 @@ int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 
 		/* The attribute is changed. */
 		bgp_path_info_set_flag(dest, pi, BGP_PATH_ATTR_CHANGED);
-
-		/* implicit withdraw, decrement aggregate and pcount here.
-		 * only if update is accepted, they'll increment below.
-		 */
-		bgp_aggregate_decrement(bgp, p, pi, afi, safi);
 
 		/* Update bgp route dampening information.  */
 		if (CHECK_FLAG(bgp->af_flags[afi][safi], BGP_CONFIG_DAMPENING)


### PR DESCRIPTION
The withdraw message and announcement message of a prefix are received continuously within 50ms, which may lead to abnormal aggregation route reference count.

step1:
local config aggregate route 111.0.0.0/24
receive route：111.0.0.1/32 111.0.0.02/32
ref_count:2

step2:
peer withdraw 111.0.0.1/32 and  network 111.0.0.1/32  in 50ms
receive route：111.0.0.1/32 111.0.0.02/32
ref_count:1

step3:
peer withdraw 111.0.0.1/32
receive route：111.0.0.02/32
ref_count:0
aggregate route will be withdrawn abnormally



Signed-off-by: liuze03 <liuze03@baidu.com>