### PR TITLE
tests: ospf_gr_helper tests are slow

### DIFF
--- a/tests/topotests/ospf_gr_helper/ospf_gr_helper.json
+++ b/tests/topotests/ospf_gr_helper/ospf_gr_helper.json
@@ -17,7 +17,7 @@
                     "ospf": {
                         "area": "0.0.0.0",
                         "hello_interval": 1,
-                        "dead_interval": 40,
+                        "dead_interval": 4,
                         "priority": 98
                     }
                 },
@@ -26,7 +26,7 @@
                     "ospf": {
                         "area": "0.0.0.0",
                         "hello_interval": 1,
-                        "dead_interval": 40,
+                        "dead_interval": 4,
                         "priority": 99
                     }
                 },
@@ -35,7 +35,7 @@
                     "ospf": {
                         "area": "0.0.0.0",
                         "hello_interval": 1,
-                        "dead_interval": 40,
+                        "dead_interval": 4,
                         "priority": 0
                     }
                 },
@@ -44,7 +44,7 @@
                     "ospf": {
                         "area": "0.0.0.0",
                         "hello_interval": 1,
-                        "dead_interval": 40,
+                        "dead_interval": 4,
                         "priority": 0
                     }
                 }


### PR DESCRIPTION
With a dead interval of 40 seconds, each tests is waiting 40+ seconds for ospf convergence to occurr because the DR is re-elected

Signed-off-by: Donald Sharp <sharpd@nvidia.com>