### PR TITLE
tests: Topotests daemon start as per feature test

### DIFF
--- a/tests/topotests/bgp_as_allow_in/test_bgp_as_allow_in.py
+++ b/tests/topotests/bgp_as_allow_in/test_bgp_as_allow_in.py
@@ -76,27 +76,11 @@ from lib.topojson import build_topo_from_json, build_config_from_json
 
 pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
 
-
-# Reading the data from JSON File for topology creation
-jsonFile = "{}/bgp_as_allow_in.json".format(CWD)
-try:
-    with open(jsonFile, "r") as topoJson:
-        topo = json.load(topoJson)
-except IOError:
-    assert False, "Could not read file {}".format(jsonFile)
-
 # Global variables
 BGP_CONVERGENCE = False
 ADDR_TYPES = check_address_types()
 NETWORK = {"ipv4": "2.2.2.2/32", "ipv6": "22:22::2/128"}
 NEXT_HOP_IP = {"ipv4": "Null0", "ipv6": "Null0"}
-
-
-def build_topo(tgen):
-    """Build function"""
-
-    # Building topology from json file
-    build_topo_from_json(tgen, topo)
 
 
 def setup_module(mod):
@@ -118,7 +102,11 @@ def setup_module(mod):
     logger.info("Running setup_module to create topology")
 
     # This function initiates the topology build with Topogen...
-    tgen = Topogen(build_topo, mod.__name__)
+    json_file = "{}/bgp_as_allow_in.json".format(CWD)
+    tgen = Topogen(json_file, mod.__name__)
+    global topo
+    topo = tgen.json_topo
+
     # ... and here it calls Mininet initialization functions.
 
     # Starting topology, create tmp files which are loaded to routers

--- a/tests/topotests/bgp_ecmp_topo3/test_ibgp_ecmp_topo3.py
+++ b/tests/topotests/bgp_ecmp_topo3/test_ibgp_ecmp_topo3.py
@@ -39,8 +39,7 @@ sys.path.append(os.path.join(CWD, "../../"))
 
 # pylint: disable=C0413
 # Import topogen and topotest helpers
-from lib.topogen import get_topogen
-from lib import topojson
+from lib.topogen import Topogen, get_topogen
 
 from lib.common_config import (
     write_test_header,
@@ -51,10 +50,11 @@ from lib.common_config import (
     reset_config_on_routers,
     shutdown_bringup_interface,
     apply_raw_config,
+    start_topology,
 )
 from lib.topolog import logger
+from lib.topojson import build_config_from_json
 from lib.bgp import create_router_bgp, verify_bgp_convergence
-
 
 pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
 
@@ -78,8 +78,18 @@ def setup_module(mod):
     logger.info("Testsuite start time: {}".format(testsuite_run_time))
     logger.info("=" * 40)
 
-    tgen = topojson.setup_module_from_json(mod.__file__)
+    # This function initiates the topology build with Topogen...
+    json_file = "{}/ibgp_ecmp_topo3.json".format(CWD)
+    tgen = Topogen(json_file, mod.__name__)
+    global topo
     topo = tgen.json_topo
+
+    # Starting topology, create tmp files which are loaded to routers
+    #  to start daemons and then start routers
+    start_topology(tgen)
+
+    # Creating configuration from JSON
+    build_config_from_json(tgen, topo)
 
     # Don't run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/bgp_vrf_dynamic_route_leak/test_bgp_vrf_dynamic_route_leak_topo2.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak/test_bgp_vrf_dynamic_route_leak_topo2.py
@@ -75,28 +75,12 @@ from lib.topojson import build_topo_from_json, build_config_from_json
 
 pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
 
-
-# Reading the data from JSON File for topology creation
-jsonFile = "{}/bgp_vrf_dynamic_route_leak_topo2.json".format(CWD)
-try:
-    with open(jsonFile, "r") as topoJson:
-        topo = json.load(topoJson)
-except IOError:
-    assert False, "Could not read file {}".format(jsonFile)
-
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}
 NETWORK3_3 = {"ipv4": "50.50.50.5/32", "ipv6": "50:50::5/128"}
 NETWORK3_4 = {"ipv4": "50.50.50.50/32", "ipv6": "50:50::50/128"}
 
 PREFERRED_NEXT_HOP = "global"
-
-
-def build_topo(tgen):
-    """Build function"""
-
-    # Building topology from json file
-    build_topo_from_json(tgen, topo)
 
 
 def setup_module(mod):
@@ -114,7 +98,9 @@ def setup_module(mod):
     logger.info("Running setup_module to create topology")
 
     # This function initiates the topology build with Topogen...
-    tgen = Topogen(build_topo, mod.__name__)
+    json_file = "{}/bgp_vrf_dynamic_route_leak_topo2.json".format(CWD)
+    tgen = Topogen(json_file, mod.__name__)
+    topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
     # Starting topology, create tmp files which are loaded to routers

--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
@@ -71,7 +71,7 @@ from lib.common_config import (
     configure_brctl,
     create_interface_in_kernel,
     kill_router_daemons,
-    start_router_daemons
+    start_router_daemons,
 )
 
 from lib.topolog import logger
@@ -1765,34 +1765,41 @@ def test_evpn_address_family_with_graceful_restart_p0(request):
     for addr_type in ADDR_TYPES:
         input_dict_1 = {
             "r3": {
-                "static_routes": [{
-                    "network": NETWORK1_2[addr_type],
-                    "next_hop": NEXT_HOP_IP[addr_type],
-                    "vrf": "RED"
-                }]
+                "static_routes": [
+                    {
+                        "network": NETWORK1_2[addr_type],
+                        "next_hop": NEXT_HOP_IP[addr_type],
+                        "vrf": "RED",
+                    }
+                ]
             },
-            "r4":{
-                "static_routes": [{
-                    "network": NETWORK1_3[addr_type],
-                    "next_hop": NEXT_HOP_IP[addr_type],
-                    "vrf": "BLUE"
-                },
-                {
-                    "network": NETWORK1_4[addr_type],
-                    "next_hop": NEXT_HOP_IP[addr_type],
-                    "vrf": "GREEN"
-                }]
-            }
+            "r4": {
+                "static_routes": [
+                    {
+                        "network": NETWORK1_3[addr_type],
+                        "next_hop": NEXT_HOP_IP[addr_type],
+                        "vrf": "BLUE",
+                    },
+                    {
+                        "network": NETWORK1_4[addr_type],
+                        "next_hop": NEXT_HOP_IP[addr_type],
+                        "vrf": "GREEN",
+                    },
+                ]
+            },
         }
 
         result = create_static_routes(tgen, input_dict_1)
-        assert result is True, 'Testcase {} : Failed \n Error: {}'.format(
-            tc_name, result)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
 
-    step("Redistribute static in (IPv4 and IPv6) address-family "
-        "on Edge-1 for all VRFs.")
+    step(
+        "Redistribute static in (IPv4 and IPv6) address-family "
+        "on Edge-1 for all VRFs."
+    )
 
-    input_dict_2={}
+    input_dict_2 = {}
     for dut in ["r3", "r4"]:
         temp = {dut: {"bgp": []}}
         input_dict_2.update(temp)
@@ -1811,108 +1818,116 @@ def test_evpn_address_family_with_graceful_restart_p0(request):
                     "vrf": vrf,
                     "address_family": {
                         "ipv4": {
-                            "unicast": {
-                                "redistribute": [{
-                                    "redist_type": "static"
-                                }]
-                            }
+                            "unicast": {"redistribute": [{"redist_type": "static"}]}
                         },
                         "ipv6": {
-                            "unicast": {
-                                "redistribute": [{
-                                    "redist_type": "static"
-                                }]
-                            }
-                        }
-                    }
-                })
+                            "unicast": {"redistribute": [{"redist_type": "static"}]}
+                        },
+                    },
+                }
+            )
 
     result = create_router_bgp(tgen, topo, input_dict_2)
-    assert result is True, "Testcase {} :Failed \n Error: {}". \
-        format(tc_name, result)
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify on router Edge-1 that EVPN routes corresponding to "
-        "all VRFs are received from both routers DCG-1 and DCG-2")
+    step(
+        "Verify on router Edge-1 that EVPN routes corresponding to "
+        "all VRFs are received from both routers DCG-1 and DCG-2"
+    )
 
     for addr_type in ADDR_TYPES:
         input_routes = {
             "r3": {
-                "static_routes": [{
-                    "network": NETWORK1_2[addr_type],
-                    "next_hop": NEXT_HOP_IP[addr_type],
-                    "vrf": "RED"
-                }]
+                "static_routes": [
+                    {
+                        "network": NETWORK1_2[addr_type],
+                        "next_hop": NEXT_HOP_IP[addr_type],
+                        "vrf": "RED",
+                    }
+                ]
             },
-            "r4":{
-                "static_routes": [{
-                    "network": NETWORK1_3[addr_type],
-                    "next_hop": NEXT_HOP_IP[addr_type],
-                    "vrf": "BLUE"
-                },
-                {
-                    "network": NETWORK1_4[addr_type],
-                    "next_hop": NEXT_HOP_IP[addr_type],
-                    "vrf": "GREEN"
-                }]
-            }
+            "r4": {
+                "static_routes": [
+                    {
+                        "network": NETWORK1_3[addr_type],
+                        "next_hop": NEXT_HOP_IP[addr_type],
+                        "vrf": "BLUE",
+                    },
+                    {
+                        "network": NETWORK1_4[addr_type],
+                        "next_hop": NEXT_HOP_IP[addr_type],
+                        "vrf": "GREEN",
+                    },
+                ]
+            },
         }
 
         result = verify_rib(tgen, addr_type, "e1", input_routes)
-        assert result is True, "Testcase {} :Failed \n Error: {}". \
-            format(tc_name, result)
+        assert result is True, "Testcase {} :Failed \n Error: {}".format(
+            tc_name, result
+        )
 
-    step("Configure DCG-2 as GR restarting node for EVPN session between"
+    step(
+        "Configure DCG-2 as GR restarting node for EVPN session between"
         " DCG-2 and EDGE-1, following by a session reset using 'clear bgp *'"
-        " command.")
+        " command."
+    )
 
     input_dict_gr = {
         "d2": {
-            "bgp":
-            [
+            "bgp": [
                 {
                     "local_as": "200",
                     "graceful-restart": {
                         "graceful-restart": True,
-                    }
+                    },
                 }
             ]
         }
     }
 
     result = create_router_bgp(tgen, topo, input_dict_gr)
-    assert result is True, "Testcase {} : Failed \n Error: {}".format(
-        tc_name, result)
+    assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify that DCG-2 changes it's role to GR-restarting router "
-        "and EDGE-1 becomes the GR-helper.")
+    step(
+        "Verify that DCG-2 changes it's role to GR-restarting router "
+        "and EDGE-1 becomes the GR-helper."
+    )
 
     step("Kill BGPd daemon on DCG-2.")
     kill_router_daemons(tgen, "d2", ["bgpd"])
 
-    step("Verify that EDGE-1 keep stale entries for EVPN RT-5 routes "
-        "received from DCG-2 before the restart.")
+    step(
+        "Verify that EDGE-1 keep stale entries for EVPN RT-5 routes "
+        "received from DCG-2 before the restart."
+    )
 
     for addr_type in ADDR_TYPES:
         input_routes = {
-            "r4":{
-                "static_routes": [{
-                    "network": NETWORK1_3[addr_type],
-                    "next_hop": NEXT_HOP_IP[addr_type],
-                    "vrf": "BLUE"
-                },
-                {
-                    "network": NETWORK1_4[addr_type],
-                    "next_hop": NEXT_HOP_IP[addr_type],
-                    "vrf": "GREEN"
-                }]
+            "r4": {
+                "static_routes": [
+                    {
+                        "network": NETWORK1_3[addr_type],
+                        "next_hop": NEXT_HOP_IP[addr_type],
+                        "vrf": "BLUE",
+                    },
+                    {
+                        "network": NETWORK1_4[addr_type],
+                        "next_hop": NEXT_HOP_IP[addr_type],
+                        "vrf": "GREEN",
+                    },
+                ]
             }
         }
         result = verify_evpn_routes(tgen, topo, "e1", input_routes)
-        assert result is True, "Testcase {} :Failed \n Error: {}". \
-            format(tc_name, result)
+        assert result is True, "Testcase {} :Failed \n Error: {}".format(
+            tc_name, result
+        )
 
-    step("Verify that DCG-2 keeps BGP routes in Zebra until BGPd "
-        "comes up or end of 'rib-stale-time'")
+    step(
+        "Verify that DCG-2 keeps BGP routes in Zebra until BGPd "
+        "comes up or end of 'rib-stale-time'"
+    )
 
     step("Start BGPd daemon on DCG-2.")
     start_router_daemons(tgen, "d2", ["bgpd"])
@@ -1920,44 +1935,52 @@ def test_evpn_address_family_with_graceful_restart_p0(request):
     step("Verify that EDGE-1 removed all the stale entries.")
     for addr_type in ADDR_TYPES:
         input_routes = {
-            "r4":{
-                "static_routes": [{
-                    "network": NETWORK1_3[addr_type],
-                    "next_hop": NEXT_HOP_IP[addr_type],
-                    "vrf": "BLUE"
-                },
-                {
-                    "network": NETWORK1_4[addr_type],
-                    "next_hop": NEXT_HOP_IP[addr_type],
-                    "vrf": "GREEN"
-                }]
+            "r4": {
+                "static_routes": [
+                    {
+                        "network": NETWORK1_3[addr_type],
+                        "next_hop": NEXT_HOP_IP[addr_type],
+                        "vrf": "BLUE",
+                    },
+                    {
+                        "network": NETWORK1_4[addr_type],
+                        "next_hop": NEXT_HOP_IP[addr_type],
+                        "vrf": "GREEN",
+                    },
+                ]
             }
         }
         result = verify_evpn_routes(tgen, topo, "e1", input_routes)
-        assert result is True, "Testcase {} :Failed \n Error: {}". \
-            format(tc_name, result)
+        assert result is True, "Testcase {} :Failed \n Error: {}".format(
+            tc_name, result
+        )
 
-    step("Verify that DCG-2 refresh zebra with EVPN routes. "
-        "(no significance of 'rib-stale-time'")
+    step(
+        "Verify that DCG-2 refresh zebra with EVPN routes. "
+        "(no significance of 'rib-stale-time'"
+    )
 
     for addr_type in ADDR_TYPES:
         input_routes = {
-            "r4":{
-                "static_routes": [{
-                    "network": NETWORK1_3[addr_type],
-                    "next_hop": NEXT_HOP_IP[addr_type],
-                    "vrf": "BLUE"
-                },
-                {
-                    "network": NETWORK1_4[addr_type],
-                    "next_hop": NEXT_HOP_IP[addr_type],
-                    "vrf": "GREEN"
-                }]
+            "r4": {
+                "static_routes": [
+                    {
+                        "network": NETWORK1_3[addr_type],
+                        "next_hop": NEXT_HOP_IP[addr_type],
+                        "vrf": "BLUE",
+                    },
+                    {
+                        "network": NETWORK1_4[addr_type],
+                        "next_hop": NEXT_HOP_IP[addr_type],
+                        "vrf": "GREEN",
+                    },
+                ]
             }
         }
         result = verify_rib(tgen, addr_type, "d2", input_routes)
-        assert result is True, "Testcase {} :Failed \n Error: {}". \
-            format(tc_name, result)
+        assert result is True, "Testcase {} :Failed \n Error: {}".format(
+            tc_name, result
+        )
 
     write_test_footer(tc_name)
 

--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
@@ -86,15 +86,6 @@ from lib.topojson import build_topo_from_json, build_config_from_json
 
 pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
 
-
-# Reading the data from JSON File for topology creation
-jsonFile = "{}/evpn_type5_topo1.json".format(CWD)
-try:
-    with open(jsonFile, "r") as topoJson:
-        topo = json.load(topoJson)
-except IOError:
-    assert False, "Could not read file {}".format(jsonFile)
-
 # Global variables
 NETWORK1_1 = {"ipv4": "10.1.1.1/32", "ipv6": "10::1/128"}
 NETWORK1_2 = {"ipv4": "40.1.1.1/32", "ipv6": "40::1/128"}
@@ -135,10 +126,6 @@ BRCTL = {
 }
 
 
-def build_topo(tgen):
-    build_topo_from_json(tgen, topo)
-
-
 def setup_module(mod):
     """
     Sets up the pytest environment
@@ -154,7 +141,10 @@ def setup_module(mod):
     logger.info("Running setup_module to create topology")
 
     # This function initiates the topology build with Topogen...
-    tgen = Topogen(build_topo, mod.__name__)
+    json_file = "{}/evpn_type5_topo1.json".format(CWD)
+    tgen = Topogen(json_file, mod.__name__)
+    topo = tgen.json_topo
+
     # ... and here it calls Mininet initialization functions.
 
     # Starting topology, create tmp files which are loaded to routers

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -1009,38 +1009,70 @@ def start_topology(tgen, daemon=None):
         except IOError as err:
             logger.error("I/O error({0}): {1}".format(err.errno, err.strerror))
 
-        # Loading empty zebra.conf file to router, to start the zebra daemon
+        topo = tgen.json_topo
+        feature = set()
+
+        if "feature" in topo:
+            feature.update(topo["feature"])
+
+        if rname in topo["routers"]:
+            for key in topo["routers"][rname].keys():
+                feature.add(key)
+
+            for val in topo["routers"][rname]["links"].values():
+                if "pim" in val:
+                    feature.add("pim")
+                    break
+            for val in topo["routers"][rname]["links"].values():
+                if "pim6" in val:
+                    feature.add("pim6")
+                    break
+            for val in topo["routers"][rname]["links"].values():
+                if "ospf6" in val:
+                    feature.add("ospf6")
+                    break
+        if "switches" in topo and rname in topo["switches"]:
+            for val in topo["switches"][rname]["links"].values():
+                if "ospf" in val:
+                    feature.add("ospf")
+                    break
+                if "ospf6" in val:
+                    feature.add("ospf6")
+                    break
+
+        # Loading empty zebra.conf file to router, to start the zebra deamon
         router.load_config(
             TopoRouter.RD_ZEBRA, "{}/{}/zebra.conf".format(tgen.logdir, rname)
         )
 
-        # Loading empty bgpd.conf file to router, to start the bgp daemon
-        router.load_config(
-            TopoRouter.RD_BGP, "{}/{}/bgpd.conf".format(tgen.logdir, rname)
-        )
-
-        if daemon and "ospfd" in daemon:
-            # Loading empty ospf.conf file to router, to start the bgp daemon
+        # Loading empty bgpd.conf file to router, to start the bgp deamon
+        if "bgp" in feature:
             router.load_config(
-                TopoRouter.RD_OSPF, "{}/{}/ospfd.conf".format(tgen.logdir, rname)
+                TopoRouter.RD_BGP, "{}/{}/bgpd.conf".format(tgen.logdir, rname)
             )
 
-        if daemon and "ospf6d" in daemon:
-            # Loading empty ospf.conf file to router, to start the bgp daemon
-            router.load_config(
-                TopoRouter.RD_OSPF6, "{}/{}/ospf6d.conf".format(tgen.logdir, rname)
-            )
-
-        if daemon and "pimd" in daemon:
-            # Loading empty pimd.conf file to router, to start the pim deamon
+        # Loading empty pimd.conf file to router, to start the pim deamon
+        if "pim" in feature:
             router.load_config(
                 TopoRouter.RD_PIM, "{}/{}/pimd.conf".format(tgen.logdir, rname)
             )
 
-        if daemon and "pim6d" in daemon:
-            # Loading empty pimd.conf file to router, to start the pim6d deamon
+        # Loading empty pimd.conf file to router, to start the pim deamon
+        if "pim6" in feature:
             router.load_config(
                 TopoRouter.RD_PIM6, "{}/{}/pim6d.conf".format(tgen.logdir, rname)
+            )
+
+        if "ospf" in feature:
+            # Loading empty ospf.conf file to router, to start the ospf deamon
+            router.load_config(
+                TopoRouter.RD_OSPF, "{}/{}/ospfd.conf".format(tgen.logdir, rname)
+            )
+
+        if "ospf6" in feature:
+            # Loading empty ospf.conf file to router, to start the ospf deamon
+            router.load_config(
+                TopoRouter.RD_OSPF6, "{}/{}/ospf6d.conf".format(tgen.logdir, rname)
             )
 
     # Starting routers

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -961,7 +961,7 @@ def generate_support_bundle():
     return True
 
 
-def start_topology(tgen, daemon=None):
+def start_topology(tgen):
     """
     Starting topology, create tmp files which are loaded to routers
     to start daemons and then start routers

--- a/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp1.py
+++ b/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp1.py
@@ -86,7 +86,6 @@ from lib.common_config import (
     socat_send_mld_join,
     socat_send_pim6_traffic,
     kill_socat,
-    topo_daemons,
 )
 from lib.pim import (
     create_pim_config,
@@ -162,12 +161,9 @@ def setup_module(mod):
 
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, TOPO)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp1.py
+++ b/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp1.py
@@ -280,8 +280,9 @@ def test_pim6_add_delete_static_RP_p0(request):
         shutdown_bringup_interface(tgen, "r1", intf, ifaceaction=False)
 
     step("Enable PIM6 between r1 and r2")
-    step("Enable MLD on r1 interface and send MLD " "join {} to r1".\
-         format(GROUP_RANGE_1))
+    step(
+        "Enable MLD on r1 interface and send MLD " "join {} to r1".format(GROUP_RANGE_1)
+    )
     step("Configure r2 loopback interface as RP")
     input_dict = {
         "r2": {
@@ -484,8 +485,11 @@ def test_pim6_SPT_RPT_path_same_p1(request):
         shutdown_bringup_interface(tgen, "r3", intf, ifaceaction=False)
 
     step("Enable the PIM6 on all the interfaces of r1, r2, r3 and r4 routers")
-    step("Configure RP on r2 (loopback interface) for the group range {}".\
-        format(GROUP_ADDRESS_1))
+    step(
+        "Configure RP on r2 (loopback interface) for the group range {}".format(
+            GROUP_ADDRESS_1
+        )
+    )
     input_dict = {
         "r2": {
             "pim6": {
@@ -503,7 +507,9 @@ def test_pim6_SPT_RPT_path_same_p1(request):
     result = create_pim_config(tgen, TOPO, input_dict)
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
-    step("Enable MLD on r1 interface and send MLD join {} to R1".format(GROUP_ADDRESS_1))
+    step(
+        "Enable MLD on r1 interface and send MLD join {} to R1".format(GROUP_ADDRESS_1)
+    )
     intf = TOPO["routers"]["r0"]["links"]["r1"]["interface"]
     intf_ip = TOPO["routers"]["r0"]["links"]["r1"]["ipv6"].split("/")[0]
     result = socat_send_mld_join(
@@ -1084,8 +1090,11 @@ def test_pim6_send_join_on_higher_preffered_rp_p1(request):
 
     step("Enable MLD on r1 interface")
     step("Enable the PIM66 on all the interfaces of r1, r2, r3 and r4 routers")
-    step("Configure RP on r2 (loopback interface) for the group range {}".\
-        format(GROUP_RANGE_4))
+    step(
+        "Configure RP on r2 (loopback interface) for the group range {}".format(
+            GROUP_RANGE_4
+        )
+    )
     input_dict = {
         "r2": {
             "pim6": {
@@ -1255,9 +1264,9 @@ def test_pim6_send_join_on_higher_preffered_rp_p1(request):
     )
     assert result is not True, (
         "Testcase {} : Failed \n "
-        "r1: rp-info is present for group {} \n Error: {}".format(tc_name,
-                                                                  GROUP_RANGE_4,
-                                                                  result)
+        "r1: rp-info is present for group {} \n Error: {}".format(
+            tc_name, GROUP_RANGE_4, result
+        )
     )
 
     step(

--- a/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp2.py
+++ b/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp2.py
@@ -247,6 +247,7 @@ def verify_state_incremented(state_before, state_after):
 #
 #####################################################
 
+
 def test_pim6_multiple_groups_same_RP_address_p2(request):
     """
     Configure multiple  groups (10 grps) with same RP address

--- a/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp2.py
+++ b/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp2.py
@@ -75,7 +75,6 @@ from lib.common_config import (
     socat_send_mld_join,
     socat_send_pim6_traffic,
     kill_socat,
-    topo_daemons,
 )
 from lib.pim import (
     create_pim_config,
@@ -165,12 +164,9 @@ def setup_module(mod):
 
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, TOPO)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim_bsm_topo1/test_mcast_pim_bsmp_01.py
+++ b/tests/topotests/multicast_pim_bsm_topo1/test_mcast_pim_bsmp_01.py
@@ -83,7 +83,6 @@ from lib.common_config import (
     apply_raw_config,
     run_frr_cmd,
     required_linux_kernel_version,
-    topo_daemons,
     verify_rib,
 )
 
@@ -168,12 +167,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim_bsm_topo2/test_mcast_pim_bsmp_02.py
+++ b/tests/topotests/multicast_pim_bsm_topo2/test_mcast_pim_bsmp_02.py
@@ -67,7 +67,6 @@ from lib.common_config import (
     reset_config_on_routers,
     run_frr_cmd,
     required_linux_kernel_version,
-    topo_daemons,
     verify_rib,
 )
 
@@ -148,12 +147,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_ospf_topo2.py
+++ b/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_ospf_topo2.py
@@ -166,12 +166,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, tgen.json_topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start deamons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_ospf_topo2.py
+++ b/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_ospf_topo2.py
@@ -916,7 +916,9 @@ def test_configuring_igmp_local_join_on_reciever_dr_non_dr_nodes_p1(request):
         )
 
         for dut, intf in zip(["r1", "r2"], [intf_r1_s1, intf_r2_s1]):
-            result = verify_igmp_groups(tgen, dut, intf, IGMP_JOIN_RANGE_3, expected=False)
+            result = verify_igmp_groups(
+                tgen, dut, intf, IGMP_JOIN_RANGE_3, expected=False
+            )
             assert result is not True, (
                 "Testcase {} : Failed \n "
                 "IGMP groups are still present \n Error: {}".format(tc_name, result)

--- a/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_static_routes_topo1.py
+++ b/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_static_routes_topo1.py
@@ -180,12 +180,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, tgen.json_topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start deamons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_transit_router_topo3.py
+++ b/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_transit_router_topo3.py
@@ -185,12 +185,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, tgen.json_topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start deamons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim_sm_topo1/test_multicast_pim_sm_topo1.py
+++ b/tests/topotests/multicast_pim_sm_topo1/test_multicast_pim_sm_topo1.py
@@ -175,12 +175,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, tgen.json_topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim_sm_topo2/test_multicast_pim_sm_topo2.py
+++ b/tests/topotests/multicast_pim_sm_topo2/test_multicast_pim_sm_topo2.py
@@ -172,12 +172,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
+++ b/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
@@ -186,12 +186,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo4.py
+++ b/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo4.py
@@ -151,12 +151,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp.py
@@ -223,12 +223,9 @@ def setup_module(mod):
 
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, TOPO)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp1.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp1.py
@@ -1413,8 +1413,6 @@ def test_clear_pim_configuration_p1(request):
     write_test_footer(tc_name)
 
 
-
-
 if __name__ == "__main__":
     ARGS = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(ARGS))

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp1.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp1.py
@@ -128,7 +128,6 @@ from lib.common_config import (
     kill_router_daemons,
     start_router_daemons,
     create_static_routes,
-    topo_daemons,
 )
 from lib.pim import (
     create_pim_config,
@@ -223,12 +222,9 @@ def setup_module(mod):
 
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, TOPO)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp2.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp2.py
@@ -128,7 +128,6 @@ from lib.common_config import (
     kill_router_daemons,
     start_router_daemons,
     create_static_routes,
-    topo_daemons,
 )
 from lib.pim import (
     create_pim_config,
@@ -223,12 +222,9 @@ def setup_module(mod):
 
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, TOPO)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim_uplink_topo1/test_multicast_pim_uplink_topo1.py
+++ b/tests/topotests/multicast_pim_uplink_topo1/test_multicast_pim_uplink_topo1.py
@@ -64,7 +64,6 @@ from lib.common_config import (
     stop_router,
     create_static_routes,
     required_linux_kernel_version,
-    topo_daemons,
 )
 from lib.bgp import create_router_bgp
 from lib.pim import (
@@ -148,12 +147,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, tgen.json_topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start deamons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Don"t run this test if we have any failure.
     if tgen.routers_have_failure():

--- a/tests/topotests/multicast_pim_uplink_topo1/test_multicast_pim_uplink_topo1.py
+++ b/tests/topotests/multicast_pim_uplink_topo1/test_multicast_pim_uplink_topo1.py
@@ -345,8 +345,9 @@ def configure_static_routes_for_rp_reachability(tgen, topo):
         }
 
         result = create_static_routes(tgen, static_routes)
-        assert result is True, "API {} : Failed Error: {}".\
-            format(sys._getframe().f_code.co_name, result)
+        assert result is True, "API {} : Failed Error: {}".format(
+            sys._getframe().f_code.co_name, result
+        )
 
 
 def verify_state_incremented(state_before, state_after):
@@ -1662,9 +1663,10 @@ def test_mroutes_updated_correctly_after_source_interface_shut_noshut_p1(request
             data["oil"],
             expected=False,
         )
-        assert result is not True, (
-            "Testcase {} : Failed "
-            "Mroute IIF and OIF are same \n Error: {}".format(tc_name, result)
+        assert (
+            result is not True
+        ), "Testcase {} : Failed " "Mroute IIF and OIF are same \n Error: {}".format(
+            tc_name, result
         )
 
     step("Shut and No shut source interface multiple time")
@@ -2335,9 +2337,10 @@ def test_mroutes_updated_after_sending_IGMP_prune_and_join_p1(request):
             data["oil"],
             expected=False,
         )
-        assert result is not True, (
-            "Testcase {} : Failed "
-            " mroute are still present \n Error: {}".format(tc_name, result)
+        assert (
+            result is not True
+        ), "Testcase {} : Failed " " mroute are still present \n Error: {}".format(
+            tc_name, result
         )
 
     for data in input_dict_sg:
@@ -2350,9 +2353,10 @@ def test_mroutes_updated_after_sending_IGMP_prune_and_join_p1(request):
             data["oil"],
             expected=False,
         )
-        assert result is not True, (
-            "Testcase {} : Failed "
-            " mroute are still present \n Error: {}".format(tc_name, result)
+        assert (
+            result is not True
+        ), "Testcase {} : Failed " " mroute are still present \n Error: {}".format(
+            tc_name, result
         )
 
     step(
@@ -2791,10 +2795,11 @@ def test_mroutes_updated_after_changing_rp_config_p1(request):
     intf_traffic = topo["routers"]["r4"]["links"]["r3-link1"]["interface"]
     state_dict = {"r4": {intf_traffic: ["registerStopRx"]}}
     state_before = verify_pim_interface_traffic(tgen, state_dict)
-    assert  isinstance(state_before, dict), \
-    ("Testcase{} : Failed \n state_before is not dictionary \n "
-    "Error: {}".\
-        format(tc_name, result))
+    assert isinstance(
+        state_before, dict
+    ), "Testcase{} : Failed \n state_before is not dictionary \n " "Error: {}".format(
+        tc_name, result
+    )
 
     step("Change the RP to R3 loopback for same group range (225.1.1.1-5)")
 
@@ -2884,10 +2889,11 @@ def test_mroutes_updated_after_changing_rp_config_p1(request):
     step("Verify pim interface traffic after changing RP")
 
     state_after = verify_pim_interface_traffic(tgen, state_dict)
-    assert  isinstance(state_before, dict), \
-    ("Testcase{} : Failed \n state_before is not dictionary \n "
-    "Error: {}".\
-        format(tc_name, result))
+    assert isinstance(
+        state_before, dict
+    ), "Testcase{} : Failed \n state_before is not dictionary \n " "Error: {}".format(
+        tc_name, result
+    )
 
     result = verify_state_incremented(state_before, state_after)
     assert result is True, "Testcase{} : Failed Error: {}".format(tc_name, result)
@@ -3281,9 +3287,10 @@ def test_mroutes_after_restart_frr_services_p2(request):
                 data["oil"],
                 expected=False,
             )
-            assert result is not True, (
-                "Testcase {}: Failed "
-                "mroutes are still present \n Error: {}".format(tc_name, result)
+            assert (
+                result is not True
+            ), "Testcase {}: Failed " "mroutes are still present \n Error: {}".format(
+                tc_name, result
             )
 
     step("Stop FRR on R4 node")
@@ -3306,9 +3313,10 @@ def test_mroutes_after_restart_frr_services_p2(request):
             data["oil"],
             expected=False,
         )
-        assert result is not True, (
-            "Testcase {} : Failed "
-            " Mroutes are still present \n Error: {}".format(tc_name, result)
+        assert (
+            result is not True
+        ), "Testcase {} : Failed " " Mroutes are still present \n Error: {}".format(
+            tc_name, result
         )
 
     step("Start FRR on R4 node")

--- a/tests/topotests/ospf_basic_functionality/ospf_rte_calc.json
+++ b/tests/topotests/ospf_basic_functionality/ospf_rte_calc.json
@@ -1,5 +1,5 @@
 {
-
+    "feature": ["bgp"],
     "ipv4base": "10.0.0.0",
     "ipv4mask": 24,
     "link_ip_start": {

--- a/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_topo1.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_topo1.py
@@ -53,7 +53,6 @@ from lib.common_config import (
     start_router_daemons,
     create_route_maps,
     shutdown_bringup_interface,
-    topo_daemons,
     create_prefix_lists,
     create_route_maps,
     create_interfaces_cfg,
@@ -142,12 +141,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_type7_lsa.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_type7_lsa.py
@@ -46,7 +46,6 @@ from lib.common_config import (
     verify_rib,
     create_static_routes,
     step,
-    topo_daemons,
 )
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
@@ -134,12 +133,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_basic_functionality/test_ospf_authentication.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_authentication.py
@@ -47,7 +47,6 @@ from lib.common_config import (
     reset_config_on_routers,
     step,
     shutdown_bringup_interface,
-    topo_daemons,
 )
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
@@ -102,12 +101,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_basic_functionality/test_ospf_chaos.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_chaos.py
@@ -43,7 +43,6 @@ from lib.common_config import (
     write_test_footer,
     reset_config_on_routers,
     step,
-    topo_daemons,
     verify_rib,
     stop_router,
     start_router,
@@ -113,12 +112,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
@@ -47,7 +47,6 @@ from lib.common_config import (
     create_static_routes,
     step,
     shutdown_bringup_interface,
-    topo_daemons,
 )
 from lib.topolog import logger
 
@@ -116,12 +115,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp_lan.py
@@ -45,7 +45,6 @@ from lib.common_config import (
     verify_rib,
     create_static_routes,
     step,
-    topo_daemons,
 )
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
@@ -117,12 +116,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
@@ -49,7 +49,6 @@ from lib.common_config import (
     shutdown_bringup_interface,
     stop_router,
     start_router,
-    topo_daemons,
 )
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
@@ -116,12 +115,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
@@ -39,7 +39,6 @@ from lib.common_config import (
     verify_rib,
     create_static_routes,
     step,
-    topo_daemons,
 )
 from lib.topogen import Topogen, get_topogen
 import os
@@ -114,12 +113,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_basic_functionality/test_ospf_p2mp.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_p2mp.py
@@ -46,7 +46,6 @@ from lib.common_config import (
     reset_config_on_routers,
     step,
     create_interfaces_cfg,
-    topo_daemons,
     retry,
     run_frr_cmd,
 )
@@ -105,12 +104,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
@@ -48,7 +48,6 @@ from lib.common_config import (
     step,
     create_route_maps,
     verify_prefix_lists,
-    topo_daemons,
 )
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
@@ -129,12 +128,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
@@ -48,7 +48,6 @@ from lib.common_config import (
     create_static_routes,
     step,
     shutdown_bringup_interface,
-    topo_daemons,
 )
 from lib.bgp import verify_bgp_convergence, create_router_bgp
 from lib.topolog import logger
@@ -125,12 +124,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_basic_functionality/test_ospf_single_area.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_single_area.py
@@ -48,7 +48,6 @@ from lib.common_config import (
     reset_config_on_routers,
     step,
     create_interfaces_cfg,
-    topo_daemons,
 )
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
@@ -110,12 +109,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_dual_stack/test_ospf_dual_stack.py
+++ b/tests/topotests/ospf_dual_stack/test_ospf_dual_stack.py
@@ -17,7 +17,6 @@ from lib.common_config import (
     write_test_footer,
     reset_config_on_routers,
     step,
-    topo_daemons,
 )
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
@@ -48,12 +47,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper1.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper1.py
@@ -43,7 +43,6 @@ from lib.common_config import (
     reset_config_on_routers,
     step,
     create_interfaces_cfg,
-    topo_daemons,
     scapy_send_raw_packet,
 )
 
@@ -121,12 +120,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper2.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper2.py
@@ -43,7 +43,6 @@ from lib.common_config import (
     reset_config_on_routers,
     step,
     create_interfaces_cfg,
-    topo_daemons,
     scapy_send_raw_packet,
 )
 
@@ -121,12 +120,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper3.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper3.py
@@ -43,7 +43,6 @@ from lib.common_config import (
     reset_config_on_routers,
     step,
     create_interfaces_cfg,
-    topo_daemons,
     scapy_send_raw_packet,
 )
 
@@ -121,12 +120,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_asbr_summary_topo1.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_asbr_summary_topo1.py
@@ -55,7 +55,6 @@ from lib.common_config import (
     shutdown_bringup_interface,
     create_prefix_lists,
     create_route_maps,
-    topo_daemons,
     create_interfaces_cfg,
 )
 from lib.topolog import logger
@@ -158,12 +157,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_authentication.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_authentication.py
@@ -50,7 +50,6 @@ from lib.common_config import (
     reset_config_on_routers,
     step,
     shutdown_bringup_interface,
-    topo_daemons,
 )
 from lib.topolog import logger
 from lib.topojson import build_topo_from_json, build_config_from_json
@@ -112,12 +111,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_authentication.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_authentication.py
@@ -93,6 +93,7 @@ TESTCASES =
 
  """
 
+
 def setup_module(mod):
     """
     Sets up the pytest environment
@@ -152,6 +153,7 @@ def teardown_module(mod):
 # ##################################
 # Test cases start here.
 # ##################################
+
 
 def test_ospf6_auth_trailer_tc1_md5(request):
     """
@@ -229,9 +231,7 @@ def test_ospf6_auth_trailer_tc1_md5(request):
         tc_name, ospf6_covergence
     )
 
-    step(
-        "Disable authentication on R2 "
-    )
+    step("Disable authentication on R2 ")
 
     r2_ospf6_auth = {
         "r2": {
@@ -241,7 +241,7 @@ def test_ospf6_auth_trailer_tc1_md5(request):
                         "hash-algo": "md5",
                         "key": "ospf6",
                         "key-id": "10",
-                        "del_action": True
+                        "del_action": True,
                     }
                 }
             }
@@ -397,9 +397,7 @@ def test_ospf6_auth_trailer_tc2_sha256(request):
         tc_name, ospf6_covergence
     )
 
-    step(
-        "Disable authentication on R2 "
-    )
+    step("Disable authentication on R2 ")
 
     r2_ospf6_auth = {
         "r2": {
@@ -409,7 +407,7 @@ def test_ospf6_auth_trailer_tc2_sha256(request):
                         "hash-algo": "hmac-sha-256",
                         "key": "ospf6",
                         "key-id": "10",
-                        "del_action": True
+                        "del_action": True,
                     }
                 }
             }
@@ -487,6 +485,7 @@ def test_ospf6_auth_trailer_tc2_sha256(request):
     )
 
     write_test_footer(tc_name)
+
 
 def test_ospf6_auth_trailer_tc3_keychain_md5(request):
     """
@@ -579,21 +578,10 @@ def test_ospf6_auth_trailer_tc3_keychain_md5(request):
         tc_name, ospf6_covergence
     )
 
-    step(
-        "Disable authentication on R2 "
-    )
+    step("Disable authentication on R2 ")
 
     r2_ospf6_auth = {
-        "r2": {
-            "links": {
-                "r1": {
-                    "ospf6": {
-                        "keychain": "auth",
-                        "del_action": True
-                    }
-                }
-            }
-        }
+        "r2": {"links": {"r1": {"ospf6": {"keychain": "auth", "del_action": True}}}}
     }
     result = config_ospf6_interface(tgen, topo, r2_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
@@ -665,6 +653,7 @@ def test_ospf6_auth_trailer_tc3_keychain_md5(request):
     )
 
     write_test_footer(tc_name)
+
 
 def test_ospf6_auth_trailer_tc4_keychain_sha256(request):
     """
@@ -757,21 +746,10 @@ def test_ospf6_auth_trailer_tc4_keychain_sha256(request):
         tc_name, ospf6_covergence
     )
 
-    step(
-        "Disable authentication on R2 "
-    )
+    step("Disable authentication on R2 ")
 
     r2_ospf6_auth = {
-        "r2": {
-            "links": {
-                "r1": {
-                    "ospf6": {
-                        "keychain": "auth",
-                        "del_action": True
-                    }
-                }
-            }
-        }
+        "r2": {"links": {"r1": {"ospf6": {"keychain": "auth", "del_action": True}}}}
     }
     result = config_ospf6_interface(tgen, topo, r2_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
@@ -843,6 +821,7 @@ def test_ospf6_auth_trailer_tc4_keychain_sha256(request):
     )
 
     write_test_footer(tc_name)
+
 
 def test_ospf6_auth_trailer_tc5_md5_keymissmatch(request):
     """
@@ -959,6 +938,7 @@ def test_ospf6_auth_trailer_tc5_md5_keymissmatch(request):
 
     write_test_footer(tc_name)
 
+
 def test_ospf6_auth_trailer_tc6_sha256_mismatch(request):
     """
     OSPFv3 Authentication Trailer - Verify ospfv3 authentication trailer
@@ -1068,6 +1048,7 @@ def test_ospf6_auth_trailer_tc6_sha256_mismatch(request):
     )
 
     write_test_footer(tc_name)
+
 
 def test_ospf6_auth_trailer_tc7_keychain_md5_missmatch(request):
     """
@@ -1200,6 +1181,7 @@ def test_ospf6_auth_trailer_tc7_keychain_md5_missmatch(request):
 
     write_test_footer(tc_name)
 
+
 def test_ospf6_auth_trailer_tc8_keychain_sha256_missmatch(request):
     """
     OSPFv3 Authentication Trailer - Verify ospfv3 authentication trailer
@@ -1331,6 +1313,7 @@ def test_ospf6_auth_trailer_tc8_keychain_sha256_missmatch(request):
 
     write_test_footer(tc_name)
 
+
 def test_ospf6_auth_trailer_tc9_keychain_not_configured(request):
     """
     OSPFv3 Neighborship without Authentication Trailer -
@@ -1408,6 +1391,7 @@ def test_ospf6_auth_trailer_tc9_keychain_not_configured(request):
 
     write_test_footer(tc_name)
 
+
 def test_ospf6_auth_trailer_tc10_no_auth_trailer(request):
     """
     OSPFv3 Neighborship without Authentication Trailer -
@@ -1436,6 +1420,7 @@ def test_ospf6_auth_trailer_tc10_no_auth_trailer(request):
     )
 
     write_test_footer(tc_name)
+
 
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp.py
@@ -46,7 +46,6 @@ from lib.common_config import (
     create_static_routes,
     step,
     shutdown_bringup_interface,
-    topo_daemons,
     get_frr_ipv6_linklocal,
 )
 from lib.topolog import logger
@@ -117,12 +116,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp_lan.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp_lan.py
@@ -53,7 +53,6 @@ from lib.common_config import (
     create_route_maps,
     shutdown_bringup_interface,
     create_interfaces_cfg,
-    topo_daemons,
     get_frr_ipv6_linklocal,
 )
 from lib.topolog import logger
@@ -130,12 +129,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa.py
@@ -7,7 +7,6 @@ from lib.common_config import (
     write_test_footer,
     reset_config_on_routers,
     step,
-    topo_daemons,
 )
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
@@ -62,12 +61,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa2.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa2.py
@@ -57,7 +57,6 @@ from lib.common_config import (
     verify_rib,
     create_static_routes,
     step,
-    topo_daemons,
     create_route_maps,
     shutdown_bringup_interface,
     create_interfaces_cfg,
@@ -139,12 +138,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_routemaps.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_routemaps.py
@@ -48,7 +48,6 @@ from lib.common_config import (
     step,
     create_route_maps,
     verify_prefix_lists,
-    topo_daemons,
 )
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
@@ -131,12 +130,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_rte_calc.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_rte_calc.py
@@ -46,7 +46,6 @@ from lib.common_config import (
     step,
     shutdown_bringup_interface,
     create_interfaces_cfg,
-    topo_daemons,
     get_frr_ipv6_linklocal,
     check_router_status,
     create_static_routes,
@@ -122,12 +121,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_single_area.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_single_area.py
@@ -48,7 +48,6 @@ from lib.common_config import (
     reset_config_on_routers,
     step,
     create_interfaces_cfg,
-    topo_daemons,
     create_debug_log_config,
     apply_raw_config,
 )
@@ -116,12 +115,9 @@ def setup_module(mod):
     topo = tgen.json_topo
     # ... and here it calls Mininet initialization functions.
 
-    # get list of daemons needs to be started for this suite.
-    daemons = topo_daemons(tgen, topo)
-
     # Starting topology, create tmp files which are loaded to routers
     #  to start daemons and then start routers
-    start_topology(tgen, daemons)
+    start_topology(tgen)
 
     # Creating configuration from JSON
     build_config_from_json(tgen, topo)


### PR DESCRIPTION
Currently topotests starts all daemons by default, 
made changes to f/w so only needed daemons can
be started, daemons which are needed to tests
particular test suite.

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>