### PR TITLE
doc: fix an incomplete command for ospf

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -782,7 +782,7 @@ Showing Information
 
 .. _show-ip-ospf:
 
-.. clicmd:: show ip ospf [json]
+.. clicmd:: show ip ospf [vrf <NAME|all>] [json]
 
    Show information on a variety of general OSPF and area state and
    configuration information.


### PR DESCRIPTION
The command of "show ip ospf" is incomplete. But "show ipv6 ospf" is fine.

Just complete it with actual parameters.