### PR TITLE
pimd: update state before evaluating join (when pruning)

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -355,6 +355,13 @@ void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,
 				   ch->sg_str, ch->interface->name);
 		}
 
+		/* pim_upstream_update_join_desired looks at up->channel_oil,
+		 * but that's updated from pim_forward_stop().  Need this here
+		 * so we correctly determine join_desired right below.
+		 */
+		if (new_state == PIM_IFJOIN_NOINFO)
+			pim_forward_stop(ch);
+
 		/*
 		  Record uptime of state transition to/from NOINFO
 		*/
@@ -632,7 +639,6 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp, pim_sgaddr *sg,
 static void ifjoin_to_noinfo(struct pim_ifchannel *ch)
 {
 	pim_ifchannel_ifjoin_switch(__func__, ch, PIM_IFJOIN_NOINFO);
-	pim_forward_stop(ch);
 
 	PIM_UPSTREAM_FLAG_UNSET_SRC_PIM(ch->upstream->flags);
 


### PR DESCRIPTION
join_desired looks at whether up->channel_oil is empty.  up->channel_oil is updated from pim_forward_stop(), calling pim_channel_del_oif().  But that was being called *after* updating join_desired, so join_desired saw a non-empty OIL.  Pull up the pim_forward_stop() call to before updating join_desired.

---
This fixes significant hop-by-hop delay in processing prunes.