### PR TITLE
lib: fix ls_prefix memory allocation

### DIFF
--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -346,7 +346,7 @@ struct ls_prefix *ls_prefix_new(struct ls_node_id adv, struct prefix p)
 	if (adv.origin == UNKNOWN)
 		return NULL;
 
-	new = XCALLOC(MTYPE_LS_DB, sizeof(struct ls_attributes));
+	new = XCALLOC(MTYPE_LS_DB, sizeof(struct ls_prefix));
 	new->adv = adv;
 	new->pref = p;
 


### PR DESCRIPTION
The wrong size is allocated for struct ls_prefix memory.

Fix ls_prefix memory allocation.

Fixes: b0c0b43348 ("lib: Update Link State Database")
Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>