### PR TITLE
bgpd: Show the real prefix for `show bgp detail`

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -2821,6 +2821,10 @@ int bgp_show_mpls_vpn(struct vty *vty, afi_t afi, struct prefix_rd *prd,
 {
 	struct bgp *bgp;
 	struct bgp_table *table;
+	uint16_t show_flags = 0;
+
+	if (use_json)
+		SET_FLAG(show_flags, BGP_SHOW_OPT_JSON);
 
 	bgp = bgp_get_default();
 	if (bgp == NULL) {
@@ -2832,7 +2836,7 @@ int bgp_show_mpls_vpn(struct vty *vty, afi_t afi, struct prefix_rd *prd,
 	}
 	table = bgp->rib[afi][SAFI_MPLS_VPN];
 	return bgp_show_table_rd(vty, bgp, SAFI_MPLS_VPN, table, prd, type,
-				 output_arg, use_json);
+				 output_arg, show_flags);
 }
 
 DEFUN (show_bgp_ip_vpn_all_rd,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11248,7 +11248,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 	bool use_json = CHECK_FLAG(show_flags, BGP_SHOW_OPT_JSON);
 	bool wide = CHECK_FLAG(show_flags, BGP_SHOW_OPT_WIDE);
 	bool all = CHECK_FLAG(show_flags, BGP_SHOW_OPT_AFI_ALL);
-	bool detail = CHECK_FLAG(show_flags, BGP_SHOW_OPT_DETAIL);
+	bool detail_json = CHECK_FLAG(show_flags, BGP_SHOW_OPT_JSON_DETAIL);
 
 	if (output_cum && *output_cum != 0)
 		header = false;
@@ -11282,7 +11282,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 	}
 
 	/* Check for 'json detail', where we need header output once per dest */
-	if (use_json && detail && type != bgp_show_type_dampend_paths &&
+	if (use_json && detail_json && type != bgp_show_type_dampend_paths &&
 	    type != bgp_show_type_damp_neighbor &&
 	    type != bgp_show_type_flap_statistics &&
 	    type != bgp_show_type_flap_neighbor)
@@ -11545,7 +11545,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 				vty_out(vty, "Default local pref %u, ",
 					bgp->default_local_pref);
 				vty_out(vty, "local AS %u\n", bgp->as);
-				if (!detail) {
+				if (!detail_json) {
 					vty_out(vty, BGP_SHOW_SCODE_HEADER);
 					vty_out(vty, BGP_SHOW_NCODE_HEADER);
 					vty_out(vty, BGP_SHOW_OCODE_HEADER);
@@ -11557,7 +11557,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 				else if (type == bgp_show_type_flap_statistics
 					 || type == bgp_show_type_flap_neighbor)
 					vty_out(vty, BGP_SHOW_FLAP_HEADER);
-				else if (!detail)
+				else if (!detail_json)
 					vty_out(vty, (wide ? BGP_SHOW_HEADER_WIDE
 							   : BGP_SHOW_HEADER));
 				header = false;
@@ -11600,7 +11600,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 						   AFI_IP, safi, use_json,
 						   json_paths);
 			else {
-				if (detail) {
+				if (detail_json) {
 					const struct prefix_rd *prd;
 
 					prd = bgp_rd_from_dest(dest, safi);
@@ -12666,7 +12666,7 @@ DEFPY(show_ip_bgp, show_ip_bgp_cmd,
           |A.B.C.D/M longer-prefixes\
           |X:X::X:X/M longer-prefixes\
 	  |optimal-route-reflection [WORD$orr_group_name]\
-          ] [json$uj [detail$detail] | wide$wide]",
+          ] [json$uj [detail$detail_json] | wide$wide]",
       SHOW_STR IP_STR BGP_STR BGP_INSTANCE_HELP_STR BGP_AFI_HELP_STR
 	      BGP_SAFI_WITH_LABEL_HELP_STR
       "Display the entries for all address families\n"
@@ -12739,8 +12739,8 @@ DEFPY(show_ip_bgp, show_ip_bgp_cmd,
 		SET_FLAG(show_flags, BGP_SHOW_OPT_JSON);
 	}
 
-	if (detail)
-		SET_FLAG(show_flags, BGP_SHOW_OPT_DETAIL);
+	if (detail_json)
+		SET_FLAG(show_flags, BGP_SHOW_OPT_JSON_DETAIL);
 
 	/* [<ipv4|ipv6> [all]] */
 	if (all) {
@@ -14717,7 +14717,7 @@ DEFUN (show_ip_bgp_flowspec_routes_detailed,
 	struct bgp *bgp = NULL;
 	int idx = 0;
 	bool uj = use_json(argc, argv);
-	uint16_t show_flags = BGP_SHOW_OPT_DETAIL;
+	uint16_t show_flags = BGP_SHOW_OPT_JSON_DETAIL;
 
 	if (uj) {
 		argc--;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11249,6 +11249,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 	bool wide = CHECK_FLAG(show_flags, BGP_SHOW_OPT_WIDE);
 	bool all = CHECK_FLAG(show_flags, BGP_SHOW_OPT_AFI_ALL);
 	bool detail_json = CHECK_FLAG(show_flags, BGP_SHOW_OPT_JSON_DETAIL);
+	bool detail_routes = CHECK_FLAG(show_flags, BGP_SHOW_OPT_ROUTES_DETAIL);
 
 	if (output_cum && *output_cum != 0)
 		header = false;
@@ -11545,7 +11546,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 				vty_out(vty, "Default local pref %u, ",
 					bgp->default_local_pref);
 				vty_out(vty, "local AS %u\n", bgp->as);
-				if (!detail_json) {
+				if (!detail_routes) {
 					vty_out(vty, BGP_SHOW_SCODE_HEADER);
 					vty_out(vty, BGP_SHOW_NCODE_HEADER);
 					vty_out(vty, BGP_SHOW_OCODE_HEADER);
@@ -11557,7 +11558,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 				else if (type == bgp_show_type_flap_statistics
 					 || type == bgp_show_type_flap_neighbor)
 					vty_out(vty, BGP_SHOW_FLAP_HEADER);
-				else if (!detail_json)
+				else if (!detail_routes)
 					vty_out(vty, (wide ? BGP_SHOW_HEADER_WIDE
 							   : BGP_SHOW_HEADER));
 				header = false;
@@ -11600,7 +11601,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 						   AFI_IP, safi, use_json,
 						   json_paths);
 			else {
-				if (detail_json) {
+				if (detail_routes) {
 					const struct prefix_rd *prd;
 
 					prd = bgp_rd_from_dest(dest, safi);
@@ -12666,6 +12667,7 @@ DEFPY(show_ip_bgp, show_ip_bgp_cmd,
           |A.B.C.D/M longer-prefixes\
           |X:X::X:X/M longer-prefixes\
 	  |optimal-route-reflection [WORD$orr_group_name]\
+          |detail-routes$detail_routes\
           ] [json$uj [detail$detail_json] | wide$wide]",
       SHOW_STR IP_STR BGP_STR BGP_INSTANCE_HELP_STR BGP_AFI_HELP_STR
 	      BGP_SAFI_WITH_LABEL_HELP_STR
@@ -12716,6 +12718,7 @@ DEFPY(show_ip_bgp, show_ip_bgp_cmd,
       "Display route and more specific routes\n"
       "Display Optimal Route Reflection RR Clients\n"
       "ORR Group name\n"
+      "Display detailed version of all routes\n"
       JSON_STR
       "Display detailed version of JSON output\n"
       "Increase table width for longer prefixes\n")
@@ -12741,6 +12744,9 @@ DEFPY(show_ip_bgp, show_ip_bgp_cmd,
 
 	if (detail_json)
 		SET_FLAG(show_flags, BGP_SHOW_OPT_JSON_DETAIL);
+
+	if (detail_routes)
+		SET_FLAG(show_flags, BGP_SHOW_OPT_ROUTES_DETAIL);
 
 	/* [<ipv4|ipv6> [all]] */
 	if (all) {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -14723,7 +14723,7 @@ DEFUN (show_ip_bgp_flowspec_routes_detailed,
 	struct bgp *bgp = NULL;
 	int idx = 0;
 	bool uj = use_json(argc, argv);
-	uint16_t show_flags = BGP_SHOW_OPT_JSON_DETAIL;
+	uint16_t show_flags = BGP_SHOW_OPT_ROUTES_DETAIL;
 
 	if (uj) {
 		argc--;

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -665,6 +665,7 @@ DECLARE_HOOK(bgp_process,
 #define BGP_SHOW_OPT_FAILED (1 << 6)
 #define BGP_SHOW_OPT_JSON_DETAIL (1 << 7)
 #define BGP_SHOW_OPT_TERSE (1 << 8)
+#define BGP_SHOW_OPT_ROUTES_DETAIL (1 << 9)
 
 /* Prototypes. */
 extern void bgp_rib_remove(struct bgp_dest *dest, struct bgp_path_info *pi,

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -866,7 +866,7 @@ extern void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 extern int bgp_show_table_rd(struct vty *vty, struct bgp *bgp, safi_t safi,
 			     struct bgp_table *table, struct prefix_rd *prd,
 			     enum bgp_show_type type, void *output_arg,
-			     bool use_json);
+			     uint16_t show_flags);
 extern void bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi);
 extern bool bgp_update_martian_nexthop(struct bgp *bgp, afi_t afi, safi_t safi,
 				       uint8_t type, uint8_t stype,

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -663,7 +663,7 @@ DECLARE_HOOK(bgp_process,
 #define BGP_SHOW_OPT_AFI_IP6 (1 << 4)
 #define BGP_SHOW_OPT_ESTABLISHED (1 << 5)
 #define BGP_SHOW_OPT_FAILED (1 << 6)
-#define BGP_SHOW_OPT_DETAIL (1 << 7)
+#define BGP_SHOW_OPT_JSON_DETAIL (1 << 7)
 #define BGP_SHOW_OPT_TERSE (1 << 8)
 
 /* Prototypes. */

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -4325,6 +4325,17 @@ structure is extended with :clicmd:`show bgp [afi] [safi]`.
 
    If ``json`` option is specified, output is displayed in JSON format.
 
+.. clicmd:: show [ip] bgp [afi] [safi] [all] detail-routes
+
+   Display the detailed version of all routes. The same format as using
+   ``show [ip] bgp [afi] [safi] PREFIX``, but for the whole BGP table.
+
+   If ``all`` option is specified, ``ip`` keyword is ignored and,
+   routes displayed for all AFIs and SAFIs.
+
+   If ``afi`` is specified, with ``all`` option, routes will be displayed for
+   each SAFI in the selected AFI.
+
 .. _bgp-display-routes-by-community:
 
 Displaying Routes by Community Attribute


### PR DESCRIPTION
Absolutely not possible to read the output and even distinguish the prefix we are looking for.

Before:

```
donatas-pc# show ip bgp detail
BGP table version is 12, local router ID is 192.168.10.17, vrf id 0
Default local pref 100, local AS 65002
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

    Network          Next Hop            Metric LocPrf Weight Path
  65001
    2a02:4780:abc::2 from 2a02:4780:abc::2 (200.200.200.202)
    (fe80::a00:27ff:fe5e:d19e) (used)
      Origin incomplete, metric 0, valid, external, multipath
      Last update: Tue Dec 13 22:53:16 2022
  65001
    192.168.10.124 from 192.168.10.124 (200.200.200.202)
      Origin incomplete, metric 0, valid, external, otc 65001, multipath, best (Neighbor IP)
      Last update: Tue Dec 13 22:53:16 2022
  65001
    2a02:4780:abc::2 from 2a02:4780:abc::2 (200.200.200.202)
    (fe80::a00:27ff:fe5e:d19e) (used)
      Origin IGP, metric 0, valid, external, multipath
      Last update: Tue Dec 13 22:53:16 2022
  65001
    192.168.10.124 from 192.168.10.124 (200.200.200.202)
      Origin IGP, metric 0, valid, external, otc 65001, multipath, best (Neighbor IP)
      Last update: Tue Dec 13 22:53:16 2022
```

After:

```
donatas-pc# show ip bgp detail
BGP table version is 12, local router ID is 192.168.10.17, vrf id 0
Default local pref 100, local AS 65002
BGP routing table entry for 10.0.2.0/24, version 1
Paths: (2 available, best #2, table default)
  Advertised to non peer-group peers:
  2a02:4780:abc::2
  65001
    2a02:4780:abc::2 from 2a02:4780:abc::2 (200.200.200.202)
    (fe80::a00:27ff:fe5e:d19e) (used)
      Origin incomplete, metric 0, valid, external, multipath
      Last update: Tue Dec 13 22:47:16 2022
BGP routing table entry for 10.0.2.0/24, version 1
Paths: (2 available, best #2, table default)
  Advertised to non peer-group peers:
  2a02:4780:abc::2
  65001
    192.168.10.124 from 192.168.10.124 (200.200.200.202)
      Origin incomplete, metric 0, valid, external, otc 65001, multipath, best (Neighbor IP)
      Last update: Tue Dec 13 22:47:16 2022
BGP routing table entry for 10.10.100.0/24, version 2
Paths: (2 available, best #2, table default)
  Advertised to non peer-group peers:
  2a02:4780:abc::2
  65001
    2a02:4780:abc::2 from 2a02:4780:abc::2 (200.200.200.202)
    (fe80::a00:27ff:fe5e:d19e) (used)
      Origin IGP, metric 0, valid, external, multipath
      Last update: Tue Dec 13 22:47:16 2022
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>