### PR TITLE
zebra: fix flags used for debug dpdk

### DIFF
--- a/zebra/debug.c
+++ b/zebra/debug.c
@@ -341,7 +341,7 @@ DEFPY(debug_zebra_dplane_dpdk, debug_zebra_dplane_dpdk_cmd,
 		SET_FLAG(zebra_debug_dplane_dpdk, ZEBRA_DEBUG_DPLANE_DPDK);
 
 		if (detail)
-			SET_FLAG(zebra_debug_dplane,
+			SET_FLAG(zebra_debug_dplane_dpdk,
 				 ZEBRA_DEBUG_DPLANE_DPDK_DETAIL);
 	}
 
@@ -740,10 +740,12 @@ static int config_write_debug(struct vty *vty)
 		write++;
 	}
 
-	if (CHECK_FLAG(zebra_debug_dplane, ZEBRA_DEBUG_DPLANE_DPDK_DETAIL)) {
+	if (CHECK_FLAG(zebra_debug_dplane_dpdk,
+		       ZEBRA_DEBUG_DPLANE_DPDK_DETAIL)) {
 		vty_out(vty, "debug zebra dplane dpdk detailed\n");
 		write++;
-	} else if (CHECK_FLAG(zebra_debug_dplane, ZEBRA_DEBUG_DPLANE_DPDK)) {
+	} else if (CHECK_FLAG(zebra_debug_dplane_dpdk,
+			      ZEBRA_DEBUG_DPLANE_DPDK)) {
 		vty_out(vty, "debug zebra dplane dpdk\n");
 		write++;
 	}

--- a/zebra/debug.h
+++ b/zebra/debug.h
@@ -111,9 +111,9 @@ extern "C" {
 	(zebra_debug_dplane & ZEBRA_DEBUG_DPLANE_DETAILED)
 
 #define IS_ZEBRA_DEBUG_DPLANE_DPDK                                             \
-	(zebra_debug_dplane & ZEBRA_DEBUG_DPLANE_DPDK)
+	(zebra_debug_dplane_dpdk & ZEBRA_DEBUG_DPLANE_DPDK)
 #define IS_ZEBRA_DEBUG_DPLANE_DPDK_DETAIL                                      \
-	(zebra_debug_dplane & ZEBRA_DEBUG_DPLANE_DPDK_DETAIL)
+	(zebra_debug_dplane_dpdk & ZEBRA_DEBUG_DPLANE_DPDK_DETAIL)
 
 #define IS_ZEBRA_DEBUG_MLAG (zebra_debug_mlag & ZEBRA_DEBUG_MLAG)
 


### PR DESCRIPTION
Use the correct flags for debug zebra dataplane dpdk options - we were confusing 'debug dataplane' and 'debug dataplane dpdk' in several places.
