### PR TITLE
bgpd: Fix coverity FORWARD_NULL for v->namelen in SNMP code

### DIFF
--- a/bgpd/bgp_snmp_bgp4v2.c
+++ b/bgpd/bgp_snmp_bgp4v2.c
@@ -440,11 +440,11 @@ bgp4v2PathAttrLookup(struct variable *v, oid name[], size_t *length,
 	sockunion_init(&su);
 
 	if (exact) {
-		if (*length - v->namelen != BGP_NLRI_ENTRY_OFFSET)
+		if (*length - namelen != BGP_NLRI_ENTRY_OFFSET)
 			return NULL;
 
 		/* Set OID offset for prefix */
-		offset = name + v->namelen;
+		offset = name + namelen;
 		if (family == AF_INET)
 			oid2in_addr(offset, afi_len, &addr->u.prefix4);
 		else
@@ -477,8 +477,8 @@ bgp4v2PathAttrLookup(struct variable *v, oid name[], size_t *length,
 		return NULL;
 	}
 
-	offset = name + v->namelen;
-	offsetlen = *length - v->namelen;
+	offset = name + namelen;
+	offsetlen = *length - namelen;
 	len = offsetlen;
 
 	if (offsetlen == 0) {
@@ -560,9 +560,9 @@ bgp4v2PathAttrLookup(struct variable *v, oid name[], size_t *length,
 		if (min) {
 			const struct prefix *rn_p = bgp_dest_get_prefix(dest);
 
-			*length = v->namelen + BGP_NLRI_ENTRY_OFFSET;
+			*length = namelen + BGP_NLRI_ENTRY_OFFSET;
 
-			offset = name + v->namelen;
+			offset = name + namelen;
 
 			if (family == AF_INET)
 				oid_copy_in_addr(offset, &rn_p->u.prefix4);


### PR DESCRIPTION
```
*** CID 1529864:    (FORWARD_NULL)
/bgpd/bgp_snmp_bgp4v2.c: 443 in bgp4v2PathAttrLookup()
437
438     #define BGP_NLRI_ENTRY_OFFSET (afi_len + 1 + afi_len)
439
440             sockunion_init(&su);
441
442             if (exact) {
>>>     CID 1529864:    (FORWARD_NULL)
>>>     Dereferencing null pointer "v".
443                     if (*length - v->namelen != BGP_NLRI_ENTRY_OFFSET)
444                             return NULL;
445
446                     /* Set OID offset for prefix */
447                     offset = name + v->namelen;
448                     if (family == AF_INET)
/bgpd/bgp_snmp_bgp4v2.c: 480 in bgp4v2PathAttrLookup()
474                             bgp_dest_unlock_node(dest);
475                     }
476
477                     return NULL;
478             }
479
>>>     CID 1529864:    (FORWARD_NULL)
>>>     Dereferencing null pointer "v".
480             offset = name + v->namelen;
481             offsetlen = *length - v->namelen;
482             len = offsetlen;
483
484             if (offsetlen == 0) {
485                     dest = bgp_table_top(bgp->rib[afi][SAFI_UNICAST]);
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>