### PR TITLE
pimd: Fix (S,G) debug issue

### DIFF
--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -166,8 +166,8 @@ struct channel_oil *pim_channel_oil_del(struct channel_oil *c_oil,
 					const char *name)
 {
 	if (PIM_DEBUG_MROUTE) {
-		pim_sgaddr sg = {.src = *oil_mcastgrp(c_oil),
-				 .grp = *oil_origin(c_oil)};
+		pim_sgaddr sg = {.src = *oil_origin(c_oil),
+				 .grp = *oil_mcastgrp(c_oil)};
 
 		zlog_debug(
 			"%s(%s): Del oil for %pSG, Ref Count: %d (Predecrement)",


### PR DESCRIPTION
Fixing the below debug issue.
```
2022/12/14 04:28:17 PIM: [P4GDD-KHFYX] pim_channel_oil_del(pim_channel_oil_upstream_deref): Del oil for (225.1.1.1,*), Ref Count: 1 (Predecrement)
```

Signed-off-by: Sarita Patra <saritap@vmware.com>