### PR TITLE
pimd, pim6d: Handling SGRPT prune received

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -711,6 +711,8 @@ static void on_ifjoin_prune_pending_timer(struct thread *t)
 			pim_channel_del_oif(
 				ch->upstream->channel_oil, ifp,
 				PIM_OIF_FLAG_PROTO_STAR, __func__);
+			pim_channel_del_oif(ch->upstream->channel_oil, ifp,
+					    PIM_OIF_FLAG_PROTO_PIM, __func__);
 			if (!ch->upstream->channel_oil->installed)
 				pim_upstream_mroute_add(
 					ch->upstream->channel_oil,


### PR DESCRIPTION
pimd: Handling SGRPT prune received

```
Topology:
Receiver----R1----(ens192)R2(ens224)----R3----R4----Source
            -----------------------------
```  
R1=LHR
R2=RP
R4=FHR

Problem:
1. Direct  connected link between R1 and R3 is down initially.
2. So traffic flow path is R4<->R3<->R2<->R1<->Receiver.
3. Mroutes are properly created on all the nodes.
4. Up the direct connected link between R1 and R3.
5. Traffic flows in both the paths.
   R4<->R3<->R2<->R1<->Receiver
   R4<->R3<->R1<->Receiver
6. Duplicate traffic received at the receiver.

Root Cause:
Initially when the direct connected link between R1 and R3 is
down, traffic flows via RP(R2). So in RP (S,G) installed with
IIF as ens224 and OIF as ens192 (reference = 2) with mask
PIM_OIF_FLAG_PROTO_STAR and PIM_OIF_FLAG_PROTO_PIM.

Now when the direct link between R1 and R3 is Up, LHR(R1) sends
SGRPT prune. After prune received, RP(R2) will remove OIF ens224
with mask PIM_OIF_FLAG_PROTO_STAR.
Since OIF ens224 is still present with mask PIM_OIF_FLAG_PROTO_PIM,
RP(R2) will not send prune towards R3.
So traffic continues to flow in the path R4<->R3<->R2<->R1<->Receiver.

Fix:
When SGRpt prune received, remove OIF irrespective of the OIF is
installed with mask "PIM_OIF_FLAG_PROTO_STAR" or "PIM_OIF_FLAG_PROTO_PIM".
Once OIF is removed, RP sends prune towards R3.

Closes #11347

Signed-off-by: Sarita Patra <saritap@vmware.com>