### PR TITLE
tools: fix TAB size in checkpatch

### DIFF
--- a/tools/checkpatch.pl
+++ b/tools/checkpatch.pl
@@ -58,6 +58,7 @@ my $codespellfile = "/usr/share/codespell/dictionary.txt";
 my $typedefsfile = "";
 my $color = "auto";
 my $allow_c99_comments = 1;
+my $tabsize = 4;
 
 sub help {
 	my ($exitcode) = @_;
@@ -92,6 +93,7 @@ Options:
   --show-types               show the specific message type in the output
   --max-line-length=n        set the maximum line length, if exceeded, warn
   --min-conf-desc-length=n   set the min description length, if shorter, warn
+  --tab-size=n               set the number of spaces for tab (default $tabsize)
   --root=PATH                PATH to the kernel tree root
   --no-summary               suppress the per-file summary
   --mailback                 only produce a report in case of warnings/errors
@@ -209,6 +211,7 @@ GetOptions(
 	'list-types!'	=> \$list_types,
 	'max-line-length=i' => \$max_line_length,
 	'min-conf-desc-length=i' => \$min_conf_desc_length,
+	'tab-size=i'	=> \$tabsize,
 	'root=s'	=> \$root,
 	'summary!'	=> \$summary,
 	'mailback!'	=> \$mailback,
@@ -260,6 +263,9 @@ if ($color =~ /^[01]$/) {
 } else {
 	die "Invalid color mode: $color\n";
 }
+
+# skip TAB size 1 to avoid additional checks on $tabsize - 1
+die "$P: Invalid TAB size: $tabsize\n" if ($tabsize < 2);
 
 sub hash_save_array_words {
 	my ($hashRef, $arrayRef) = @_;
@@ -1144,7 +1150,7 @@ sub expand_tabs {
 		if ($c eq "\t") {
 			$res .= ' ';
 			$n++;
-			for (; ($n % 8) != 0; $n++) {
+			for (; ($n % $tabsize) != 0; $n++) {
 				$res .= ' ';
 			}
 			next;
@@ -2129,7 +2135,7 @@ sub string_find_replace {
 sub tabify {
 	my ($leading) = @_;
 
-	my $source_indent = 8;
+	my $source_indent = $tabsize;
 	my $max_spaces_before_tab = $source_indent - 1;
 	my $spaces_to_tab = " " x $source_indent;
 
@@ -2965,7 +2971,7 @@ sub process {
 		next if ($realfile !~ /\.(h|c|pl|dtsi|dts)$/);
 
 # at the beginning of a line any tabs must come first and anything
-# more than 8 must use tabs.
+# more than $tabsize must use tabs.
 		if ($rawline =~ /^\+\s* \t\s*\S/ ||
 		    $rawline =~ /^\+\s*        \s*/) {
 			my $herevet = "$here\n" . cat_vet($rawline) . "\n";
@@ -2984,7 +2990,7 @@ sub process {
 				"please, no space before tabs\n" . $herevet) &&
 			    $fix) {
 				while ($fixed[$fixlinenr] =~
-					   s/(^\+.*) {8,8}\t/$1\t\t/) {}
+					   s/(^\+.*) {$tabsize,$tabsize}\t/$1\t\t/) {}
 				while ($fixed[$fixlinenr] =~
 					   s/(^\+.*) +\t/$1\t/) {}
 			}
@@ -3000,11 +3006,11 @@ sub process {
 		if ($^V && $^V ge 5.10.0 &&
 		    $sline =~ /^\+\t+( +)(?:$c90_Keywords\b|\{\s*$|\}\s*(?:else\b|while\b|\s*$))/) {
 			my $indent = length($1);
-			if ($indent % 8) {
+			if ($indent % $tabsize) {
 				if (WARN("TABSTOP",
 					 "Statements should start on a tabstop\n" . $herecurr) &&
 				    $fix) {
-					$fixed[$fixlinenr] =~ s@(^\+\t+) +@$1 . "\t" x ($indent/8)@e;
+					$fixed[$fixlinenr] =~ s@(^\+\t+) +@$1 . "\t" x ($indent/$tabsize)@e;
 				}
 			}
 		}
@@ -3022,8 +3028,8 @@ sub process {
 				my $newindent = $2;
 
 				my $goodtabindent = $oldindent .
-					"\t" x ($pos / 8) .
-					" "  x ($pos % 8);
+					"\t" x ($pos / $tabsize) .
+					" "  x ($pos % $tabsize);
 				my $goodspaceindent = $oldindent . " "  x $pos;
 
 				if ($newindent ne $goodtabindent &&
@@ -3506,11 +3512,11 @@ sub process {
 			#print "line<$line> prevline<$prevline> indent<$indent> sindent<$sindent> check<$check> continuation<$continuation> s<$s> cond_lines<$cond_lines> stat_real<$stat_real> stat<$stat>\n";
 
 			if ($check && $s ne '' &&
-			    (($sindent % 8) != 0 ||
+			    (($sindent % $tabsize) != 0 ||
 			     ($sindent < $indent) ||
 			     ($sindent == $indent &&
 			      ($s !~ /^\s*(?:\}|\{|else\b)/)) ||
-			     ($sindent > $indent + 8))) {
+			     ($sindent > $indent + $tabsize))) {
 				WARN("SUSPECT_CODE_INDENT",
 				     "suspect code indent for conditional statements ($indent, $sindent)\n" . $herecurr . "$stat_real\n");
 			}


### PR DESCRIPTION
FRR has TAB size of 4 characters. checkpatch.pl was imported from linux kernel repository where the TAB size is 8 characters. As result, valid lines are in errors:

> $ tools/checkpatch.pl --no-tree -f lib/affinitymap_northbound.c
> (...)
> WARNING: line over 80 characters
> #112: FILE: lib/affinitymap_northbound.c:112:
> +			.xpath = "/frr-affinity-map:lib/affinity-maps/affinity-map",

The line has 73 characters when replacing tabs with 4 spaces and 85, with 8 spaces.

> $ head -n 112 lib/affinitymap_northbound.c | tail -n 1
> 			.xpath = "/frr-affinity-map:lib/affinity-maps/affinity-map",
> $ head -n 112 lib/affinitymap_northbound.c | tail -n 1 | wc -c
> 64
> $ head -n 112 lib/affinitymap_northbound.c | tail -n 1 | sed -e 's|[\t]|\ \ \ \ |g' | wc -c
> 73
> $ head -n 112 lib/affinitymap_northbound.c | tail -n 1 | sed -e 's|[\t]|\ \ \ \ \ \ \ \ |g' | wc -c
> 85

Backport the patch in Link to allow setting the TAB size in argument and set the default TAB size to 4 characters.

Link: https://github.com/torvalds/linux/commit/713a09de9ca9ac6277cb43d79967e7852238f998
Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>