### PR TITLE
ospfd: fix SPF table memory leak

### DIFF
--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1956,9 +1956,10 @@ static void ospf_spf_calculate_schedule_worker(struct thread *thread)
 	rt_time = monotime_since(&start_time, NULL);
 
 	/* Free old all routers routing table */
-	if (ospf->oall_rtrs)
-		/* ospf_route_delete (ospf->old_rtrs); */
+	if (ospf->oall_rtrs) {
 		ospf_rtrs_free(ospf->oall_rtrs);
+		ospf->oall_rtrs = NULL;
+	}
 
 	/* Update all routers routing table */
 	ospf->oall_rtrs = ospf->all_rtrs;
@@ -1967,9 +1968,10 @@ static void ospf_spf_calculate_schedule_worker(struct thread *thread)
 	ospf_apiserver_notify_reachable(ospf->oall_rtrs, ospf->all_rtrs);
 #endif
 	/* Free old ABR/ASBR routing table */
-	if (ospf->old_rtrs)
-		/* ospf_route_delete (ospf->old_rtrs); */
+	if (ospf->old_rtrs) {
 		ospf_rtrs_free(ospf->old_rtrs);
+		ospf->old_rtrs = NULL;
+	}
 
 	/* Update ABR/ASBR routing table */
 	ospf->old_rtrs = ospf->new_rtrs;

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -852,6 +852,10 @@ static void ospf_finish_final(struct ospf *ospf)
 			ospf_route_delete(ospf, ospf->new_table);
 		ospf_route_table_free(ospf->new_table);
 	}
+	if (ospf->oall_rtrs)
+		ospf_rtrs_free(ospf->oall_rtrs);
+	if (ospf->all_rtrs)
+		ospf_rtrs_free(ospf->all_rtrs);
 	if (ospf->old_rtrs)
 		ospf_rtrs_free(ospf->old_rtrs);
 	if (ospf->new_rtrs)


### PR DESCRIPTION
Fixes #12500 .

Fix a memory leak that happens on OSPF instance removal.