### PR TITLE
bgpd: Add support for flowspec prefixes in bgp_packet_mpattr_prefix_size

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3986,6 +3986,8 @@ size_t bgp_packet_mpattr_prefix_size(afi_t afi, safi_t safi,
 	else if (afi == AFI_L2VPN && safi == SAFI_EVPN)
 		size += 232; // TODO: Maximum possible for type-2, type-3 and
 			     // type-5
+	else if (safi == SAFI_FLOWSPEC)
+		size = ((struct prefix_fs *)p)->prefix.prefixlen;
 	return size;
 }
 


### PR DESCRIPTION
Currently, bgp_packet_mpattr_prefix_size (bgpd/bgp_attr.c:3978) always returns zero for Flowspec prefixes. This is because, for flowspec prefixes, the prefixlen attribute of the prefix struct is always set to 0, and the actual length in bytes is set inside the flowspec_prefix struct instead (see lib/prefix.h:293 and lib/prefix.h:178). Because of this, with a large number of flowspec NLRIs, bgpd ends up building update messages that exceed the maximum size and cause the peer to drop the connection (bgpd/bgp_updgrp_packet.c:L719). The proposed change allows the bgp_packet_mpattr_prefix_size to return correct result for flowspec prefixes.

Fixes #12529

Signed-off-by: Stephane Poignant <stephane.poignant@proton.ch>