### PR TITLE
lib, staticd: return values even after an assert

### DIFF
--- a/lib/zlog_targets.c
+++ b/lib/zlog_targets.c
@@ -257,6 +257,7 @@ bool zlog_file_set_filename(struct zlog_cfg_file *zcf, const char *filename)
 		return zlog_file_cycle(zcf);
 	}
 	assert(0);
+	return false;
 }
 
 bool zlog_file_set_fd(struct zlog_cfg_file *zcf, int fd)
@@ -271,6 +272,7 @@ bool zlog_file_set_fd(struct zlog_cfg_file *zcf, int fd)
 		return zlog_file_cycle(zcf);
 	}
 	assert(0);
+	return false;
 }
 
 struct rcu_close_rotate {
@@ -544,6 +546,7 @@ int zlog_syslog_get_facility(void)
 		return syslog_facility;
 	}
 	assert(0);
+	return 0;
 }
 
 void zlog_syslog_set_prio_min(int prio_min)
@@ -581,4 +584,5 @@ int zlog_syslog_get_prio_min(void)
 		return syslog_prio_min;
 	}
 	assert(0);
+	return 0;
 }

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -313,6 +313,7 @@ static bool static_zebra_nht_get_prefix(const struct static_nexthop *nh,
 	}
 
 	assertf(0, "BUG: someone forgot to add nexthop type %u", nh->type);
+	return false;
 }
 
 void static_zebra_nht_register(struct static_nexthop *nh, bool reg)


### PR DESCRIPTION
When compiling with -fsanitize=thread.  I started getting this error:

staticd/static_zebra.c: In function ‘static_zebra_nht_get_prefix’: staticd/static_zebra.c:316:1: error: control reaches end of non-void function [-Werror=return-type]
  316 | }
      | ^

Just to make future efforts still work, let's just make the compiler happy.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>