### PR TITLE
Use switch statements without default for safi_t and afi_t enum's

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3876,7 +3876,10 @@ size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer, afi_t afi,
 				stream_putc(s, attr->mp_nexthop_len);
 				stream_put_ipv4(s, attr->nexthop.s_addr);
 			}
-		default:
+			break;
+		case SAFI_UNSPEC:
+		case SAFI_MAX:
+			assert(!"SAFI's UNSPEC or MAX being specified are a DEV ESCAPE");
 			break;
 		}
 		break;
@@ -3927,16 +3930,23 @@ size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer, afi_t afi,
 			break;
 		case SAFI_FLOWSPEC:
 			stream_putc(s, 0); /* no nexthop for flowspec */
-		default:
+			break;
+		case SAFI_UNSPEC:
+		case SAFI_MAX:
+			assert(!"SAFI's UNSPEC or MAX being specified are a DEV ESCAPE");
 			break;
 		}
 		break;
-	default:
+	case AFI_L2VPN:
 		if (safi != SAFI_FLOWSPEC)
 			flog_err(
 				EC_BGP_ATTR_NH_SEND_LEN,
 				"Bad nexthop when sending to %s, AFI %u SAFI %u nhlen %d",
 				peer->host, afi, safi, attr->mp_nexthop_len);
+		break;
+	case AFI_UNSPEC:
+	case AFI_MAX:
+		assert(!"DEV ESCAPE: AFI_UNSPEC or AFI_MAX should not be used here");
 		break;
 	}
 


### PR DESCRIPTION
See individual commits but effectively we had a recent commit where flowspec wasn't being properly encoded because an if statement was hiding the flowspec safi being properly encoded because the code was using if statements.  Make it easier for future people to not have bugs when new encodings are needed.