### PR TITLE
bgpd: Print out useful information about peer

### DIFF
--- a/bgpd/bgp_addpath.c
+++ b/bgpd/bgp_addpath.c
@@ -406,9 +406,9 @@ void bgp_addpath_set_peer_type(struct peer *peer, afi_t afi, safi_t safi,
 		}
 	}
 
-	zlog_info("Resetting peer %s%s due to change in addpath config",
+	zlog_info("Resetting peer %s%pBP due to change in addpath config",
 		  CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP) ? "group " : "",
-		  peer->host);
+		  peer);
 
 	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
 		group = peer->group;


### PR DESCRIPTION
I am seeing this output:
2022/12/16 09:16:00.206 BGP: [MNE5N-K0G4Z] Resetting peer (null) due to change in addpath config

Switch over to %pBP

Signed-off-by: Donald Sharp <sharpd@nvidia.com>