### PR TITLE
zebra: Ensure memory is not freed that dplane depends on in shutdown

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -221,11 +221,11 @@ void zebra_finalize(struct thread *dummy)
 {
 	zlog_info("Zebra final shutdown");
 
-	/* Final shutdown of ns resources */
-	ns_walk_func(zebra_ns_final_shutdown, NULL, NULL);
-
 	/* Stop dplane thread and finish any cleanup */
 	zebra_dplane_shutdown();
+
+	/* Final shutdown of ns resources */
+	ns_walk_func(zebra_ns_final_shutdown, NULL, NULL);
 
 	zebra_router_terminate();
 


### PR DESCRIPTION
Zebra has a shutdown setup where it asks the dplane to shutdown but can still be processing data.  This is especially true if something the dplane is listening on receives data that will be processed by the main dplane thread
from netlink.   When zebra_finalize is called it is possible that a bit
of data comes in before the zebra_dplane_shutdown() function is called
and the memory freed in ns_walk_func() causes the main dplane event
to crash when it cannot find the ns data anymore.

Reverse the order, stop the zebra dplane pthread and then free the memory associated with the namespaces.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>