### PR TITLE
ospf6d: Fixing memory leak in ospf6_summary_add_aggr_route_and_blackh…

### DIFF
--- a/ospf6d/ospf6_asbr.h
+++ b/ospf6d/ospf6_asbr.h
@@ -182,4 +182,6 @@ void ospf6_external_aggregator_free(struct ospf6_external_aggr_rt *aggr);
 void ospf6_unset_all_aggr_flag(struct ospf6 *ospf6);
 void ospf6_fill_aggr_route_details(struct ospf6 *ospf6,
 				   struct ospf6_external_aggr_rt *aggr);
+void ospf6_asbr_summary_config_delete(struct ospf6 *ospf6,
+				      struct route_node *rn);
 #endif /* OSPF6_ASBR_H */

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -498,6 +498,7 @@ void ospf6_delete(struct ospf6 *o)
 	struct route_node *rn = NULL;
 	struct ospf6_area *oa;
 	struct vrf *vrf;
+	struct ospf6_external_aggr_rt *aggr;
 
 	QOBJ_UNREG(o);
 
@@ -536,8 +537,11 @@ void ospf6_delete(struct ospf6 *o)
 	}
 
 	for (rn = route_top(o->rt_aggr_tbl); rn; rn = route_next(rn))
-		if (rn->info)
-			ospf6_external_aggregator_free(rn->info);
+		if (rn->info) {
+			aggr = rn->info;
+			ospf6_asbr_summary_config_delete(o, rn);
+			ospf6_external_aggregator_free(aggr);
+		}
 	route_table_finish(o->rt_aggr_tbl);
 
 	XFREE(MTYPE_OSPF6_TOP, o->name);


### PR DESCRIPTION
…ole.

Problem Statement:
=================
Memory leak in ospf6d.
2022-11-15 02:15:11,569 - ERROR: ==30108== 440 (280 direct, 160 indirect) bytes in 1 blocks are definitely lost in loss record 15 of 17
2022-11-15 02:15:11,569 - ERROR: ==30108==    at 0x4C31FAC: calloc (vg_replace_malloc.c:762)
2022-11-15 02:15:11,569 - ERROR: ==30108==    by 0x4E8A1BF: qcalloc (memory.c:111)
2022-11-15 02:15:11,569 - ERROR: ==30108==    by 0x14337A: ospf6_route_create (ospf6_route.c:462)
2022-11-15 02:15:11,569 - ERROR: ==30108==    by 0x11EE27: ospf6_summary_add_aggr_route_and_blackhole (ospf6_asbr.c:2779)
2022-11-15 02:15:11,569 - ERROR: ==30108==    by 0x11EEDA: ospf6_originate_new_aggr_lsa (ospf6_asbr.c:2816)
2022-11-15 02:15:11,569 - ERROR: ==30108==    by 0x120053: ospf6_handle_external_lsa_origination (ospf6_asbr.c:3659)
2022-11-15 02:15:11,569 - ERROR: ==30108==    by 0x12041E: ospf6_asbr_redistribute_add (ospf6_asbr.c:1547)
2022-11-15 02:15:11,569 - ERROR: ==30108==    by 0x14F3CC: ospf6_zebra_read_route (ospf6_zebra.c:253)
2022-11-15 02:15:11,569 - ERROR: ==30108==    by 0x4EC9B73: zclient_read (zclient.c:2727)
2022-11-15 02:15:11,569 - ERROR: ==30108==    by 0x4EB741B: thread_call (thread.c:1692)
2022-11-15 02:15:11,569 - ERROR: ==30108==    by 0x4E85B17: frr_run (libfrr.c:1068)
2022-11-15 02:15:11,569 - ERROR: ==30108==    by 0x119585: main (ospf6_main.c:228)
2022-11-15 02:15:11,569 - ERROR: ==30108==

RCA:
====
blackhole route was not freed before adding a new one.

Fix:
====
Added a check before allocating new route, to free the old one. Also, added ospf6_asbr_summary_config_delete in ospf6_delet before freeing the aggregate route.

Signed-off-by: Manoj Naragund <mnaragund@vmware.com>