### PR TITLE
bgpd: Fix announce SRv6 locally-generated routes to Zebra

### DIFF
--- a/tests/topotests/bgp_srv6l3vpn_route_leak/ce1/zebra.conf
+++ b/tests/topotests/bgp_srv6l3vpn_route_leak/ce1/zebra.conf
@@ -1,0 +1,9 @@
+log file zebra.log
+!
+hostname ce1
+!
+interface eth0
+ ip address 172.16.0.1/24
+!
+line vty
+!

--- a/tests/topotests/bgp_srv6l3vpn_route_leak/pe1/bgpd.conf
+++ b/tests/topotests/bgp_srv6l3vpn_route_leak/pe1/bgpd.conf
@@ -1,0 +1,41 @@
+frr defaults traditional
+!
+hostname pe1
+password zebra
+!
+log stdout notifications
+log monitor notifications
+log commands
+!
+router bgp 65001
+ bgp router-id 192.0.2.1
+ !
+ segment-routing srv6
+  locator default
+ exit
+ !
+!
+router bgp 65001 vrf vrf10
+ bgp router-id 192.0.2.1
+ !
+ address-family ipv4 unicast
+  redistribute connected
+  sid vpn export auto
+  rd vpn export 65001:10
+  rt vpn both 0:10
+  import vpn
+  export vpn
+ exit-address-family
+ !
+!
+router bgp 65001 vrf vrf20
+ bgp router-id 192.0.2.1
+ !
+ address-family ipv4 unicast
+  rd vpn export 65001:20
+  rt vpn both 0:10
+  import vpn
+  export vpn
+ exit-address-family
+ !
+!

--- a/tests/topotests/bgp_srv6l3vpn_route_leak/pe1/results/default_ipv4_vpn.json
+++ b/tests/topotests/bgp_srv6l3vpn_route_leak/pe1/results/default_ipv4_vpn.json
@@ -1,0 +1,31 @@
+{
+    "vrfName": "default",
+    "routerId": "192.0.2.1",
+    "localAS": 65001,
+    "routes": {
+        "routeDistinguishers": {
+            "65001:10": {
+                "172.16.0.0/24": [
+                    {
+                        "valid": true,
+                        "bestpath": true,
+                        "pathFrom": "external",
+                        "prefix": "172.16.0.0",
+                        "prefixLen": 24,
+                        "network": "172.16.0.0\/24",
+                        "origin": "incomplete",
+                        "announceNexthopSelf": true,
+                        "nhVrfName": "vrf10",
+                        "nexthops": [
+                            {
+                                "hostname": "pe1",
+                                "afi": "ipv4",
+                                "used": true
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/tests/topotests/bgp_srv6l3vpn_route_leak/pe1/results/vrf10_ipv4_unicast.json
+++ b/tests/topotests/bgp_srv6l3vpn_route_leak/pe1/results/vrf10_ipv4_unicast.json
@@ -1,0 +1,25 @@
+{
+    "vrfName": "vrf10",
+    "routerId": "192.0.2.1",
+    "localAS": 65001,
+    "routes": {
+        "172.16.0.0/24": [
+            {
+                "valid": true,
+                "bestpath": true,
+                "pathFrom": "external",
+                "prefix": "172.16.0.0",
+                "prefixLen": 24,
+                "network": "172.16.0.0\/24",
+                "origin": "incomplete",
+                "nexthops": [
+                    {
+                        "hostname": "pe1",
+                        "afi": "ipv4",
+                        "used": true
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/topotests/bgp_srv6l3vpn_route_leak/pe1/results/vrf20_ipv4.json
+++ b/tests/topotests/bgp_srv6l3vpn_route_leak/pe1/results/vrf20_ipv4.json
@@ -1,0 +1,22 @@
+{
+    "172.16.0.0\/24": [
+        {
+            "prefix": "172.16.0.0\/24",
+            "prefixLen": 24,
+            "protocol": "bgp",
+            "vrfName": "vrf20",
+            "selected": true,
+            "destSelected": true,
+            "installed": true,
+            "nexthops": [
+                {
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "eth0",
+                    "vrf": "vrf10",
+                    "active": true
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/bgp_srv6l3vpn_route_leak/pe1/results/vrf20_ipv4_unicast.json
+++ b/tests/topotests/bgp_srv6l3vpn_route_leak/pe1/results/vrf20_ipv4_unicast.json
@@ -1,0 +1,27 @@
+{
+    "vrfName": "vrf20",
+    "routerId": "192.0.2.1",
+    "localAS": 65001,
+    "routes": {
+        "172.16.0.0/24": [
+            {
+                "valid": true,
+                "bestpath": true,
+                "pathFrom": "external",
+                "prefix": "172.16.0.0",
+                "prefixLen": 24,
+                "network": "172.16.0.0\/24",
+                "origin": "incomplete",
+                "announceNexthopSelf": true,
+                "nhVrfName": "vrf10",
+                "nexthops": [
+                    {
+                        "hostname": "pe1",
+                        "afi": "ipv4",
+                        "used": true
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/topotests/bgp_srv6l3vpn_route_leak/pe1/zebra.conf
+++ b/tests/topotests/bgp_srv6l3vpn_route_leak/pe1/zebra.conf
@@ -1,0 +1,27 @@
+log file zebra.log
+!
+hostname pe1
+!
+interface lo
+ ip address 10.0.0.1/32
+!
+interface eth0 vrf vrf10
+ ip address 172.16.0.254/24
+!
+line vty
+!
+segment-routing
+ srv6
+  locators
+   locator default
+    prefix 2001:db8:2::/64 block-len 40 node-len 24 func-bits 16
+   exit
+   !
+  exit
+  !
+ exit
+ !
+exit
+!
+end
+!

--- a/tests/topotests/bgp_srv6l3vpn_route_leak/test_bgp_srv6l3vpn_route_leak.py
+++ b/tests/topotests/bgp_srv6l3vpn_route_leak/test_bgp_srv6l3vpn_route_leak.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2022, LINE Corporation
+# Authored by Ryoga Saito <ryoga.saito@linecorp.com>
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+import os
+import re
+import sys
+import json
+import functools
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from lib.common_config import required_linux_kernel_version
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def build_topo(tgen):
+    tgen.add_router("pe1")
+    tgen.add_router("ce1")
+
+    tgen.add_link(tgen.gears["pe1"], tgen.gears["ce1"], "eth0", "eth0")
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    for rname, router in tgen.routers().items():
+        router.load_config(TopoRouter.RD_ZEBRA,
+                           os.path.join(CWD, '{}/zebra.conf'.format(rname)))
+        router.load_config(TopoRouter.RD_BGP,
+                           os.path.join(CWD, '{}/bgpd.conf'.format(rname)))
+
+    tgen.gears["pe1"].run("ip link add vrf10 type vrf table 10")
+    tgen.gears["pe1"].run("ip link set vrf10 up")
+    tgen.gears["pe1"].run("ip link add vrf20 type vrf table 20")
+    tgen.gears["pe1"].run("ip link set vrf20 up")
+    tgen.gears["pe1"].run("ip link set eth0 master vrf10")
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def open_json_file(path):
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except IOError:
+        assert False, "Could not read file {}".format(path)
+    
+
+def check(name, command, checker):
+    tgen = get_topogen()
+    router = tgen.gears[name]
+
+    def _check():
+        try:
+            return checker(router.vtysh_cmd(command))
+        except:
+            return False
+
+    logger.info('[+] check {} "{}"'.format(name, command))
+    _, result = topotest.run_and_expect(_check, None, count=10, wait=0.5)
+    assert result is None, "Failed"
+
+
+def check_vrf10_bgp_rib(output):
+    expected = open_json_file("%s/pe1/results/vrf10_ipv4_unicast.json" % CWD) 
+    actual = json.loads(output)
+    return topotest.json_cmp(actual, expected)
+
+
+def check_default_bgp_vpn_rib(output):
+    expected = open_json_file("%s/pe1/results/default_ipv4_vpn.json" % CWD) 
+    actual = json.loads(output)
+    return topotest.json_cmp(actual, expected)
+
+
+def check_vrf20_bgp_rib(output):
+    expected = open_json_file("%s/pe1/results/vrf20_ipv4_unicast.json" % CWD) 
+    actual = json.loads(output)
+    return topotest.json_cmp(actual, expected)
+
+
+def check_vrf20_rib(output):
+    expected = open_json_file("%s/pe1/results/vrf20_ipv4.json" % CWD) 
+    actual = json.loads(output)
+    return topotest.json_cmp(actual, expected)
+
+
+def test_rib():
+    check("pe1", "show bgp vrf vrf10 ipv4 unicast json", check_vrf10_bgp_rib)
+    check("pe1", "show bgp ipv4 vpn json", check_default_bgp_vpn_rib)
+    check("pe1", "show bgp vrf vrf20 ipv4 unicast json", check_vrf20_bgp_rib)
+    check("pe1", "show ip route vrf vrf20 json", check_vrf20_rib)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Current bgpd can't announce SRv6 locally-generated routes to Zebra correctly because the MPLS label of locally-generated routes is not valid but sid_info->transposition_len is set to a non-zero value. This commit fixes such kinds of issues.

## Before

**pe1**

```
pe1# show bgp vrf vrf20 ipv4 unicast 
BGP table version is 1, local router ID is 192.0.2.1, vrf id 4
Default local pref 100, local AS 65001
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

    Network          Next Hop            Metric LocPrf Weight Path
 *> 172.16.0.0/24    0.0.0.0@2<               0         32768 ?

Displayed  1 routes and 1 total paths

pe1# show ip route vrf vrf20
```

**pe1 - bgpd.log**

```
2022/12/20 18:03:10 BGP: [X11WM-VBA5R] bgp_zebra_announce: p=172.16.0.0/24, bgp_is_valid_label: 0
2022/12/20 18:03:10 BGP: [V15FP-4CPVK] Tx route delete VRF 4 172.16.0.0/24 metric 0 tag 0 count 0 nhg 0
2022/12/20 18:03:10 BGP: [JMVGR-VQ1M1] bgp_zebra_announce: 172.16.0.0/24: announcing to zebra (recursion NOT set)
```


## After

**pe1**

```
pe1# show bgp vrf vrf20 ipv4 unicast 
BGP table version is 1, local router ID is 192.0.2.1, vrf id 4
Default local pref 100, local AS 65001
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

    Network          Next Hop            Metric LocPrf Weight Path
 *> 172.16.0.0/24    0.0.0.0@2<               0         32768 ?

Displayed  1 routes and 1 total paths

pe1# show ip route vrf vrf20
Codes: K - kernel route, C - connected, S - static, B - BGP,
       T - Table, v - VNC, V - VNC-Direct, D - SHARP,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

VRF vrf20:
B>* 172.16.0.0/24 [20/0] is directly connected, eth0 (vrf vrf10), weight 1, 00:00:42
```

**pe1 - bgpd.log**

```
2022/12/20 18:06:35 BGP: [X11WM-VBA5R] bgp_zebra_announce: p=172.16.0.0/24, bgp_is_valid_label: 0
2022/12/20 18:06:35 BGP: [V15FP-4CPVK] Tx route add VRF 4 172.16.0.0/24 metric 0 tag 0 count 1 nhg 0
2022/12/20 18:06:35 BGP: [JQXM8-V0CKB]   nhop [1]:  if 3 VRF 2 wt 0   
2022/12/20 18:06:35 BGP: [JMVGR-VQ1M1] bgp_zebra_announce: 172.16.0.0/24: announcing to zebra (recursion NOT set)
```