### PR TITLE
bgpd: fix static analyzer warning

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -51,6 +51,8 @@
 #include "bgpd/bgp_flowspec.h"
 #include "bgpd/bgp_packet.h"
 
+#include "bgpd/bgp_debug_clippy.c"
+
 unsigned long conf_bgp_debug_as4;
 unsigned long conf_bgp_debug_neighbor_events;
 unsigned long conf_bgp_debug_events;
@@ -324,7 +326,7 @@ static void bgp_debug_list_add_entry(struct list *list, const char *host,
 }
 
 static bool bgp_debug_list_remove_entry(struct list *list, const char *host,
-					struct prefix *p)
+					const struct prefix *p)
 {
 	struct bgp_debug_filter *filter;
 	struct listnode *node, *nnode;
@@ -1020,48 +1022,42 @@ DEFUN (no_debug_bgp_keepalive_peer,
 }
 
 /* debug bgp bestpath */
-DEFUN (debug_bgp_bestpath_prefix,
+DEFPY (debug_bgp_bestpath_prefix,
        debug_bgp_bestpath_prefix_cmd,
-       "debug bgp bestpath <A.B.C.D/M|X:X::X:X/M>",
+       "debug bgp bestpath <A.B.C.D/M|X:X::X:X/M>$prefix",
        DEBUG_STR
        BGP_STR
        "BGP bestpath\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n")
 {
-	struct prefix argv_p;
-	int idx_ipv4_ipv6_prefixlen = 3;
-
-	(void)str2prefix(argv[idx_ipv4_ipv6_prefixlen]->arg, &argv_p);
-	apply_mask(&argv_p);
-
 	if (!bgp_debug_bestpath_prefixes)
 		bgp_debug_bestpath_prefixes = list_new();
 
 	if (bgp_debug_list_has_entry(bgp_debug_bestpath_prefixes, NULL,
-				     &argv_p)) {
+				     prefix)) {
 		vty_out(vty,
 			"BGP bestpath debugging is already enabled for %s\n",
-			argv[idx_ipv4_ipv6_prefixlen]->arg);
+			prefix_str);
 		return CMD_SUCCESS;
 	}
 
-	bgp_debug_list_add_entry(bgp_debug_bestpath_prefixes, NULL, &argv_p);
+	bgp_debug_list_add_entry(bgp_debug_bestpath_prefixes, NULL, prefix);
 
 	if (vty->node == CONFIG_NODE) {
 		DEBUG_ON(bestpath, BESTPATH);
 	} else {
 		TERM_DEBUG_ON(bestpath, BESTPATH);
 		vty_out(vty, "BGP bestpath debugging is on for %s\n",
-			argv[idx_ipv4_ipv6_prefixlen]->arg);
+			prefix_str);
 	}
 
 	return CMD_SUCCESS;
 }
 
-DEFUN (no_debug_bgp_bestpath_prefix,
+DEFPY (no_debug_bgp_bestpath_prefix,
        no_debug_bgp_bestpath_prefix_cmd,
-       "no debug bgp bestpath <A.B.C.D/M|X:X::X:X/M>",
+       "no debug bgp bestpath <A.B.C.D/M|X:X::X:X/M>$prefix",
        NO_STR
        DEBUG_STR
        BGP_STR
@@ -1069,18 +1065,12 @@ DEFUN (no_debug_bgp_bestpath_prefix,
        "IPv4 prefix\n"
        "IPv6 prefix\n")
 {
-	int idx_ipv4_ipv6_prefixlen = 4;
-	struct prefix *argv_p;
-	int found_prefix = 0;
-
-	argv_p = prefix_new();
-	(void)str2prefix(argv[idx_ipv4_ipv6_prefixlen]->arg, argv_p);
-	apply_mask(argv_p);
+	bool found_prefix = false;
 
 	if (bgp_debug_bestpath_prefixes
 	    && !list_isempty(bgp_debug_bestpath_prefixes)) {
 		found_prefix = bgp_debug_list_remove_entry(
-			bgp_debug_bestpath_prefixes, NULL, argv_p);
+			bgp_debug_bestpath_prefixes, NULL, prefix);
 
 		if (list_isempty(bgp_debug_bestpath_prefixes)) {
 			if (vty->node == CONFIG_NODE) {
@@ -1095,10 +1085,10 @@ DEFUN (no_debug_bgp_bestpath_prefix,
 
 	if (found_prefix)
 		vty_out(vty, "BGP bestpath debugging is off for %s\n",
-			argv[idx_ipv4_ipv6_prefixlen]->arg);
+			prefix_str);
 	else
 		vty_out(vty, "BGP bestpath debugging was not enabled for %s\n",
-			argv[idx_ipv4_ipv6_prefixlen]->arg);
+			prefix_str);
 
 	return CMD_SUCCESS;
 }
@@ -1406,8 +1396,6 @@ DEFUN (no_debug_bgp_update_direct_peer,
 	return CMD_SUCCESS;
 }
 
-#include "bgpd/bgp_debug_clippy.c"
-
 DEFPY (debug_bgp_update_prefix_afi_safi,
        debug_bgp_update_prefix_afi_safi_cmd,
        "debug bgp updates prefix l2vpn$afi evpn$safi type <<macip|2> mac <X:X:X:X:X:X|X:X:X:X:X:X/M> [ip <A.B.C.D|X:X::X:X>]|<multicast|3> ip <A.B.C.D|X:X::X:X>|<prefix|5> ip <A.B.C.D/M|X:X::X:X/M>>",
@@ -1528,9 +1516,9 @@ DEFPY (no_debug_bgp_update_prefix_afi_safi,
 }
 
 
-DEFUN (debug_bgp_update_prefix,
+DEFPY (debug_bgp_update_prefix,
        debug_bgp_update_prefix_cmd,
-       "debug bgp updates prefix <A.B.C.D/M|X:X::X:X/M>",
+       "debug bgp updates prefix <A.B.C.D/M|X:X::X:X/M>$prefix",
        DEBUG_STR
        BGP_STR
        "BGP updates\n"
@@ -1538,39 +1526,32 @@ DEFUN (debug_bgp_update_prefix,
        "IPv4 prefix\n"
        "IPv6 prefix\n")
 {
-	int idx_ipv4_ipv6_prefixlen = 4;
-	struct prefix argv_p;
-
-	(void)str2prefix(argv[idx_ipv4_ipv6_prefixlen]->arg, &argv_p);
-	apply_mask(&argv_p);
-
 	if (!bgp_debug_update_prefixes)
 		bgp_debug_update_prefixes = list_new();
 
-	if (bgp_debug_list_has_entry(bgp_debug_update_prefixes, NULL,
-				     &argv_p)) {
+	if (bgp_debug_list_has_entry(bgp_debug_update_prefixes, NULL, prefix)) {
 		vty_out(vty,
 			"BGP updates debugging is already enabled for %s\n",
-			argv[idx_ipv4_ipv6_prefixlen]->arg);
+			prefix_str);
 		return CMD_SUCCESS;
 	}
 
-	bgp_debug_list_add_entry(bgp_debug_update_prefixes, NULL, &argv_p);
+	bgp_debug_list_add_entry(bgp_debug_update_prefixes, NULL, prefix);
 
 	if (vty->node == CONFIG_NODE) {
 		DEBUG_ON(update, UPDATE_PREFIX);
 	} else {
 		TERM_DEBUG_ON(update, UPDATE_PREFIX);
 		vty_out(vty, "BGP updates debugging is on for %s\n",
-			argv[idx_ipv4_ipv6_prefixlen]->arg);
+			prefix_str);
 	}
 
 	return CMD_SUCCESS;
 }
 
-DEFUN (no_debug_bgp_update_prefix,
+DEFPY (no_debug_bgp_update_prefix,
        no_debug_bgp_update_prefix_cmd,
-       "no debug bgp updates prefix <A.B.C.D/M|X:X::X:X/M>",
+       "no debug bgp updates prefix <A.B.C.D/M|X:X::X:X/M>$prefix",
        NO_STR
        DEBUG_STR
        BGP_STR
@@ -1579,18 +1560,12 @@ DEFUN (no_debug_bgp_update_prefix,
        "IPv4 prefix\n"
        "IPv6 prefix\n")
 {
-	int idx_ipv4_ipv6_prefixlen = 5;
-	struct prefix *argv_p;
-	int found_prefix = 0;
-
-	argv_p = prefix_new();
-	(void)str2prefix(argv[idx_ipv4_ipv6_prefixlen]->arg, argv_p);
-	apply_mask(argv_p);
+	bool found_prefix = false;
 
 	if (bgp_debug_update_prefixes
 	    && !list_isempty(bgp_debug_update_prefixes)) {
 		found_prefix = bgp_debug_list_remove_entry(
-			bgp_debug_update_prefixes, NULL, argv_p);
+			bgp_debug_update_prefixes, NULL, prefix);
 
 		if (list_isempty(bgp_debug_update_prefixes)) {
 			if (vty->node == CONFIG_NODE) {
@@ -1605,10 +1580,10 @@ DEFUN (no_debug_bgp_update_prefix,
 
 	if (found_prefix)
 		vty_out(vty, "BGP updates debugging is off for %s\n",
-			argv[idx_ipv4_ipv6_prefixlen]->arg);
+			prefix_str);
 	else
 		vty_out(vty, "BGP updates debugging was not enabled for %s\n",
-			argv[idx_ipv4_ipv6_prefixlen]->arg);
+			prefix_str);
 
 	return CMD_SUCCESS;
 }
@@ -1678,9 +1653,9 @@ DEFUN (debug_bgp_graceful_restart,
 }
 
 
-DEFUN (debug_bgp_zebra_prefix,
+DEFPY (debug_bgp_zebra_prefix,
        debug_bgp_zebra_prefix_cmd,
-       "debug bgp zebra prefix <A.B.C.D/M|X:X::X:X/M>",
+       "debug bgp zebra prefix <A.B.C.D/M|X:X::X:X/M>$prefix",
        DEBUG_STR
        BGP_STR
        "BGP Zebra messages\n"
@@ -1688,29 +1663,22 @@ DEFUN (debug_bgp_zebra_prefix,
        "IPv4 prefix\n"
        "IPv6 prefix\n")
 {
-	int idx_ipv4_ipv6_prefixlen = 4;
-	struct prefix argv_p;
-
-	(void)str2prefix(argv[idx_ipv4_ipv6_prefixlen]->arg, &argv_p);
-	apply_mask(&argv_p);
-
 	if (!bgp_debug_zebra_prefixes)
 		bgp_debug_zebra_prefixes = list_new();
 
-	if (bgp_debug_list_has_entry(bgp_debug_zebra_prefixes, NULL, &argv_p)) {
+	if (bgp_debug_list_has_entry(bgp_debug_zebra_prefixes, NULL, prefix)) {
 		vty_out(vty, "BGP zebra debugging is already enabled for %s\n",
-			argv[idx_ipv4_ipv6_prefixlen]->arg);
+			prefix_str);
 		return CMD_SUCCESS;
 	}
 
-	bgp_debug_list_add_entry(bgp_debug_zebra_prefixes, NULL, &argv_p);
+	bgp_debug_list_add_entry(bgp_debug_zebra_prefixes, NULL, prefix);
 
 	if (vty->node == CONFIG_NODE)
 		DEBUG_ON(zebra, ZEBRA);
 	else {
 		TERM_DEBUG_ON(zebra, ZEBRA);
-		vty_out(vty, "BGP zebra debugging is on for %s\n",
-			argv[idx_ipv4_ipv6_prefixlen]->arg);
+		vty_out(vty, "BGP zebra debugging is on for %s\n", prefix_str);
 	}
 
 	return CMD_SUCCESS;
@@ -1752,9 +1720,9 @@ DEFUN (no_debug_bgp_graceful_restart,
 	return CMD_SUCCESS;
 }
 
-DEFUN (no_debug_bgp_zebra_prefix,
+DEFPY (no_debug_bgp_zebra_prefix,
        no_debug_bgp_zebra_prefix_cmd,
-       "no debug bgp zebra prefix <A.B.C.D/M|X:X::X:X/M>",
+       "no debug bgp zebra prefix <A.B.C.D/M|X:X::X:X/M>$prefix",
        NO_STR
        DEBUG_STR
        BGP_STR
@@ -1763,17 +1731,12 @@ DEFUN (no_debug_bgp_zebra_prefix,
        "IPv4 prefix\n"
        "IPv6 prefix\n")
 {
-	int idx_ipv4_ipv6_prefixlen = 5;
-	struct prefix argv_p;
-	int found_prefix = 0;
-
-	(void)str2prefix(argv[idx_ipv4_ipv6_prefixlen]->arg, &argv_p);
-	apply_mask(&argv_p);
+	bool found_prefix = false;
 
 	if (bgp_debug_zebra_prefixes
 	    && !list_isempty(bgp_debug_zebra_prefixes)) {
 		found_prefix = bgp_debug_list_remove_entry(
-			bgp_debug_zebra_prefixes, NULL, &argv_p);
+			bgp_debug_zebra_prefixes, NULL, prefix);
 
 		if (list_isempty(bgp_debug_zebra_prefixes)) {
 			if (vty->node == CONFIG_NODE)
@@ -1786,11 +1749,10 @@ DEFUN (no_debug_bgp_zebra_prefix,
 	}
 
 	if (found_prefix)
-		vty_out(vty, "BGP zebra debugging is off for %s\n",
-			argv[idx_ipv4_ipv6_prefixlen]->arg);
+		vty_out(vty, "BGP zebra debugging is off for %s\n", prefix_str);
 	else
 		vty_out(vty, "BGP zebra debugging was not enabled for %s\n",
-			argv[idx_ipv4_ipv6_prefixlen]->arg);
+			prefix_str);
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
Fixes static analyzer warnings introduced here:
https://github.com/FRRouting/frr/pull/12539#issuecomment-1359594833

Always initialize stack variables so static analyzer doesn't complain about garbage values.

NOTE: it is unlikely or impossible that it is not initialized because the DEFUN parameters are always validated and all the cases get a valid prefix.