### PR TITLE
bgpd: fix one wrong debug log for evpn

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1626,9 +1626,8 @@ void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 		zlog_debug(
 			"Tx route %s VRF %u %pFX metric %u tag %" ROUTE_TAG_PRI
 			" count %d nhg %d",
-			valid_nh_count ? "add" : "delete", bgp->vrf_id,
-			&api.prefix, api.metric, api.tag, api.nexthop_num,
-			nhg_id);
+			is_add ? "add" : "delete", bgp->vrf_id, &api.prefix,
+			api.metric, api.tag, api.nexthop_num, nhg_id);
 		for (i = 0; i < api.nexthop_num; i++) {
 			api_nh = &api.nexthops[i];
 


### PR DESCRIPTION
Take it into consideration for one debug log:
EVPN MAC-IP routes with a L3 NHG id, has no nexthops.

Not "delete", but "add".

Before:
```
Tx route delete VRF 21 192.168.30.253/32 metric 0 tag 0 count 0 nhg 72580649
```

After:
```
Tx route add VRF 21 192.168.30.253/32 metric 0 tag 0 count 0 nhg 72580649
```