### PR TITLE
docker,alpine: Remove isl from dependencies

### DIFF
--- a/alpine/APKBUILD.in
+++ b/alpine/APKBUILD.in
@@ -10,7 +10,7 @@ depends="json-c c-ares iproute2 python3 bash"
 makedepends="ncurses-dev net-snmp-dev gawk texinfo perl
     acct autoconf automake bash binutils bison bsd-compat-headers build-base
     c-ares c-ares-dev ca-certificates cryptsetup-libs curl device-mapper-libs
-    expat fakeroot flex fortify-headers gdbm git gmp isl json-c-dev kmod
+    expat fakeroot flex fortify-headers gdbm git gmp json-c-dev kmod
     lddtree libacl libatomic libattr libblkid libburn libbz2 libc-dev
     libcap-dev libcurl libedit libffi libgcc libgomp libisoburn libisofs
     libltdl libressl libssh2 libstdc++ libtool libuuid


### PR DESCRIPTION
As the title says, replace `isl` package with `isl-dev` package in Alpine Docker build. The Alpine upstream changed the package name, and it caused a build failure.