### PR TITLE
ospfd: show ospf database info using formatted json

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -7183,10 +7183,8 @@ DEFUN (show_ip_ospf_database_max,
 						   use_vrf, json, uj);
 	}
 
-	if (uj) {
-		vty_out(vty, "%s\n", json_object_to_json_string(json));
-		json_object_free(json);
-	}
+	if (uj)
+		vty_json(vty, json);
 
 	return ret;
 }


### PR DESCRIPTION
Signed-off-by: Rei Shimizu <rshimizu@apache.org>

This PR enables to show ospfd database info using formatted json. As result, we can see such a result as following format.

```
R1# show ip ospf database json
{
  "routerId":"1.1.1.1",
  "areas":{
    "0.0.0.0":{
      "routerLinkStates":[
        {
          "lsId":"1.1.1.1",
          "advertisedRouter":"1.1.1.1",
          "lsaAge":460,
          "sequenceNumber":"80000006",
          "checksum":"95f4",
          "numOfRouterLinks":3
        },
        ...
}
```