### PR TITLE
lib: fix display cputime-warning and walltime-warning

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -502,7 +502,7 @@ static int config_write_host(struct vty *vty)
 		else if (cputime_threshold != 5000000)
 #endif
 			vty_out(vty, "service cputime-warning %lu\n",
-				cputime_threshold);
+				cputime_threshold / 1000);
 
 		if (!walltime_threshold)
 			vty_out(vty, "no service walltime-warning\n");
@@ -512,7 +512,7 @@ static int config_write_host(struct vty *vty)
 		else if (walltime_threshold != 5000000)
 #endif
 			vty_out(vty, "service walltime-warning %lu\n",
-				walltime_threshold);
+				walltime_threshold / 1000);
 
 		if (host.advanced)
 			vty_out(vty, "service advanced-vty\n");


### PR DESCRIPTION
Before patch:
```
# vtysh -c "c t" -c "service cputime-warning 1" -c "service walltime-warning 2"
# vtysh  -c "show run" | grep warn
service cputime-warning 1000
service walltime-warning 2000
```

After patch:
```
# vtysh -c "c t" -c "service cputime-warning 1" -c "service walltime-warning 2"
# vtysh  -c "show run" | grep warn
service cputime-warning 1
service walltime-warning 2
```

Signed-off-by: Dmitrii Turlupov <dturlupov@factor-ts.ru>