### PR TITLE
bgpd: fix show bgp all with evpn

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3192,6 +3192,21 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 	}
 }
 
+int bgp_evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
+			     bool use_json, int detail)
+{
+	json_object *json = NULL;
+
+	if (use_json)
+		json = json_object_new_object();
+
+	evpn_show_all_routes(vty, bgp, type, json, detail);
+
+	if (use_json)
+		vty_json(vty, json);
+	return CMD_SUCCESS;
+}
+
 /*
  * Display specified VNI (vty handler)
  */

--- a/bgpd/bgp_evpn_vty.h
+++ b/bgpd/bgp_evpn_vty.h
@@ -42,4 +42,7 @@ extern int argv_find_and_parse_oly_idx(struct cmd_token **argv, int argc,
 extern int bgp_evpn_cli_parse_type(int *type, struct cmd_token **argv,
 				   int argc);
 
+extern int bgp_evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
+				    bool use_json, int detail);
+
 #endif /* _QUAGGA_BGP_EVPN_VTY_H */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11811,6 +11811,9 @@ static int bgp_show(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 					       1, NULL, NULL);
 	}
 
+	if (safi == SAFI_EVPN)
+		return bgp_evpn_show_all_routes(vty, bgp, type, use_json, 0);
+
 	return bgp_show_table(vty, bgp, safi, table, type, output_arg, NULL, 1,
 			      NULL, NULL, &json_header_depth, show_flags,
 			      rpki_target_state);


### PR DESCRIPTION
Fix crash on "show bgp all" when BGP EVPN is set.

> #0  raise (sig=11) at ../sysdeps/unix/sysv/linux/raise.c:50
> #1  0x00007fdfe03cf53c in core_handler (signo=11, siginfo=0x7ffdebbffe30, context=0x7ffdebbffd00) at lib/sigevent.c:261
> #2  <signal handler called>
> #3  0x00000000004d4fec in bgp_attr_get_community (attr=0x41) at bgpd/bgp_attr.h:553
> #4  0x00000000004eee84 in bgp_show_table (vty=0x1a790d0, bgp=0x19d0a00, safi=SAFI_EVPN, table=0x19f6010, type=bgp_show_type_normal, output_arg=0x0, rd=0x0, is_last=1, output_cum=0x0,
>     total_cum=0x0, json_header_depth=0x7ffdebc00bf8, show_flags=4, rpki_target_state=RPKI_NOT_BEING_USED) at bgpd/bgp_route.c:11329
> #5  0x00000000004f7765 in bgp_show (vty=0x1a790d0, bgp=0x19d0a00, afi=AFI_L2VPN, safi=SAFI_EVPN, type=bgp_show_type_normal, output_arg=0x0, show_flags=4,
>     rpki_target_state=RPKI_NOT_BEING_USED) at bgpd/bgp_route.c:11814
> #6  0x00000000004fb53b in show_ip_bgp_magic (self=0x6752b0 <show_ip_bgp_cmd>, vty=0x1a790d0, argc=3, argv=0x19cb050, viewvrfname=0x0, all=0x1395390 "all", aa_nn=0x0, community_list=0,
>     community_list_str=0x0, community_list_name=0x0, as_path_filter_name=0x0, prefix_list=0x0, accesslist_name=0x0, rmap_name=0x0, version=0, version_str=0x0, alias_name=0x0,
>     orr_group_name=0x0, detail_routes=0x0, uj=0x0, detail_json=0x0, wide=0x0) at bgpd/bgp_route.c:13040
> #7  0x00000000004fa322 in show_ip_bgp (self=0x6752b0 <show_ip_bgp_cmd>, vty=0x1a790d0, argc=3, argv=0x19cb050) at ./bgpd/bgp_route_clippy.c:519
> #8  0x00007fdfe033ccc8 in cmd_execute_command_real (vline=0x19c9300, filter=FILTER_RELAXED, vty=0x1a790d0, cmd=0x0, up_level=0) at lib/command.c:996
> #9  0x00007fdfe033c739 in cmd_execute_command (vline=0x19c9300, vty=0x1a790d0, cmd=0x0, vtysh=0) at lib/command.c:1056
> #10 0x00007fdfe033cdf5 in cmd_execute (vty=0x1a790d0, cmd=0x19c9eb0 "show bgp all", matched=0x0, vtysh=0) at lib/command.c:1223
> #11 0x00007fdfe03f65c6 in vty_command (vty=0x1a790d0, buf=0x19c9eb0 "show bgp all") at lib/vty.c:486
> #12 0x00007fdfe03f603b in vty_execute (vty=0x1a790d0) at lib/vty.c:1249
> #13 0x00007fdfe03f533b in vtysh_read (thread=0x7ffdebc03838) at lib/vty.c:2148
> #14 0x00007fdfe03e815d in thread_call (thread=0x7ffdebc03838) at lib/thread.c:2006
> #15 0x00007fdfe0379b54 in frr_run (master=0x1246880) at lib/libfrr.c:1198
> #16 0x000000000042b2a8 in main (argc=7, argv=0x7ffdebc03af8) at bgpd/bgp_main.c:520

Closes https://github.com/FRRouting/frr/issues/12576
Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>