### PR TITLE
zebra: Evpn mac vni detail show command

### DIFF
--- a/doc/user/evpn.rst
+++ b/doc/user/evpn.rst
@@ -502,3 +502,11 @@ the creation of the VLAN subinterfaces and directly enslave "eth0" to "br10".
       ip link set eth0 master br10
 
 This completes the necessary configuration for an L2VNI.
+
+Displaying EVPN information
+---------------------------
+
+.. clicmd:: show evpn mac vni (1-16777215) detail [json]
+
+   Display detailed information about MAC addresses for
+   a specified VNI.

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -653,8 +653,13 @@ void zebra_evpn_print_mac(struct zebra_mac *mac, void *ctxt, json_object *json)
 				json_object_int_add(json_mac, "vlan", vid);
 		} else if (CHECK_FLAG(mac->flags, ZEBRA_MAC_REMOTE)) {
 			json_object_string_add(json_mac, "type", "remote");
-			json_object_string_addf(json_mac, "remoteVtep", "%pI4",
-						&mac->fwd_info.r_vtep_ip);
+			if (mac->es)
+				json_object_string_add(json_mac, "remoteEs",
+						       mac->es->esi_str);
+			else
+				json_object_string_addf(
+					json_mac, "remoteVtep", "%pI4",
+					&mac->fwd_info.r_vtep_ip);
 		} else if (CHECK_FLAG(mac->flags, ZEBRA_MAC_AUTO))
 			json_object_string_add(json_mac, "type", "auto");
 
@@ -937,8 +942,13 @@ void zebra_evpn_print_mac_hash(struct hash_bucket *bucket, void *ctxt)
 				"", mac->loc_seq, mac->rem_seq);
 		} else {
 			json_object_string_add(json_mac, "type", "remote");
-			json_object_string_addf(json_mac, "remoteVtep", "%pI4",
-						&mac->fwd_info.r_vtep_ip);
+			if (mac->es)
+				json_object_string_add(json_mac, "remoteEs",
+						       mac->es->esi_str);
+			else
+				json_object_string_addf(
+					json_mac, "remoteVtep", "%pI4",
+					&mac->fwd_info.r_vtep_ip);
 			json_object_object_add(json_mac_hdr, buf1, json_mac);
 			json_object_int_add(json_mac, "localSequence",
 					    mac->loc_seq);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3511,7 +3511,26 @@ DEFUN (show_evpn_mac_vni,
 
 	vni = strtoul(argv[4]->arg, NULL, 10);
 	zvrf = zebra_vrf_get_evpn();
-	zebra_vxlan_print_macs_vni(vty, zvrf, vni, uj);
+	zebra_vxlan_print_macs_vni(vty, zvrf, vni, uj, false);
+	return CMD_SUCCESS;
+}
+
+DEFPY (show_evpn_mac_vni_detail,
+       show_evpn_mac_vni_detail_cmd,
+       "show evpn mac vni " CMD_VNI_RANGE " detail [json]",
+       SHOW_STR
+       "EVPN\n"
+       "MAC addresses\n"
+       "VXLAN Network Identifier\n"
+       "VNI number\n"
+       "Detailed Information On Each VNI MAC\n"
+       JSON_STR)
+{
+	struct zebra_vrf *zvrf;
+	bool uj = use_json(argc, argv);
+
+	zvrf = zebra_vrf_get_evpn();
+	zebra_vxlan_print_macs_vni(vty, zvrf, vni, uj, true);
 	return CMD_SUCCESS;
 }
 
@@ -4819,6 +4838,7 @@ void zebra_vty_init(void)
 	install_element(VIEW_NODE, &show_evpn_mac_vni_cmd);
 	install_element(VIEW_NODE, &show_evpn_mac_vni_all_cmd);
 	install_element(VIEW_NODE, &show_evpn_mac_vni_all_detail_cmd);
+	install_element(VIEW_NODE, &show_evpn_mac_vni_detail_cmd);
 	install_element(VIEW_NODE, &show_evpn_mac_vni_all_vtep_cmd);
 	install_element(VIEW_NODE, &show_evpn_mac_vni_mac_cmd);
 	install_element(VIEW_NODE, &show_evpn_mac_vni_vtep_cmd);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -2869,7 +2869,7 @@ void zebra_vxlan_print_neigh_vni_dad(struct vty *vty,
  * Display MACs for a VNI (VTY command handler).
  */
 void zebra_vxlan_print_macs_vni(struct vty *vty, struct zebra_vrf *zvrf,
-				vni_t vni, bool use_json)
+				vni_t vni, bool use_json, bool detail)
 {
 	struct zebra_evpn *zevpn;
 	uint32_t num_macs;
@@ -2902,17 +2902,28 @@ void zebra_vxlan_print_macs_vni(struct vty *vty, struct zebra_vrf *zvrf,
 	wctx.json = json_mac;
 
 	if (!use_json) {
-		vty_out(vty,
-			"Number of MACs (local and remote) known for this VNI: %u\n",
-			num_macs);
-		vty_out(vty,
-			"Flags: N=sync-neighs, I=local-inactive, P=peer-active, X=peer-proxy\n");
-		vty_out(vty, "%-17s %-6s %-5s %-30s %-5s %s\n", "MAC", "Type",
-			"Flags", "Intf/Remote ES/VTEP", "VLAN", "Seq #'s");
+		if (detail) {
+			vty_out(vty, "\nVNI %u #MACs (local and remote) %u\n\n",
+				zevpn->vni, num_macs);
+		} else {
+			vty_out(vty,
+				"Number of MACs (local and remote) known for this VNI: %u\n",
+				num_macs);
+			vty_out(vty,
+				"Flags: N=sync-neighs, I=local-inactive, P=peer-active, X=peer-proxy\n");
+			vty_out(vty, "%-17s %-6s %-5s %-30s %-5s %s\n", "MAC",
+				"Type", "Flags", "Intf/Remote ES/VTEP", "VLAN",
+				"Seq #'s");
+		}
 	} else
 		json_object_int_add(json, "numMacs", num_macs);
 
-	hash_iterate(zevpn->mac_table, zebra_evpn_print_mac_hash, &wctx);
+	if (detail)
+		hash_iterate(zevpn->mac_table, zebra_evpn_print_mac_hash_detail,
+			     &wctx);
+	else
+		hash_iterate(zevpn->mac_table, zebra_evpn_print_mac_hash,
+			     &wctx);
 
 	if (use_json) {
 		json_object_object_add(json, "macs", json_mac);

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -95,7 +95,7 @@ extern void zebra_vxlan_print_specific_rmac_l3vni(struct vty *vty, vni_t l3vni,
 						  struct ethaddr *rmac,
 						  bool use_json);
 extern void zebra_vxlan_print_macs_vni(struct vty *vty, struct zebra_vrf *zvrf,
-				       vni_t vni, bool use_json);
+				       vni_t vni, bool use_json, bool detail);
 extern void zebra_vxlan_print_macs_all_vni(struct vty *vty,
 					   struct zebra_vrf *zvrf,
 					   bool print_dup,


### PR DESCRIPTION
A new show command "show evpn mac vni xx detail [json]" to display details of all the mac entries for the
requested VNI.

output of show evpn mac vni xx detail json:
```
{
  "numMacs":18,
  "macs":{
    "00:02:00:00:00:0d":{
      "type":"remote",
      "remoteEs":"03:44:38:39:ff:ff:02:00:00:02",
      "localSequence":0,
      "remoteSequence":0,
      "detectionCount":0,
      "isDuplicate":false,
      "syncNeighCount":0,
      "neighbors":{
        "active":[
          "2001:fee1:0:9::d",
          "fe80::202:ff:fe00:d"
        ],
        "inactive":[
        ]
      }
    }
  }
}
```
Also added remoteEs field in the JSON output of
"show evpn mac vni xx json".
output of show evpn mac vni xx json:
```
"00:02:00:00:00:0d":{
      "type":"remote",
      "remoteEs":"03:44:38:39:ff:ff:02:00:00:02",
      "localSequence":0,
      "remoteSequence":0,
      "detectionCount":0,
      "isDuplicate":false
    }
```
Signed-off-by: Pooja Jagadeesh Doijode <pdoijode@nvidia.com>