### PR TITLE
bgpd: flowspec SAFI is never used with AFI_L2VPN

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3951,11 +3951,10 @@ size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer, afi_t afi,
 		}
 		break;
 	case AFI_L2VPN:
-		if (safi != SAFI_FLOWSPEC)
-			flog_err(
-				EC_BGP_ATTR_NH_SEND_LEN,
-				"Bad nexthop when sending to %s, AFI %u SAFI %u nhlen %d",
-				peer->host, afi, safi, attr->mp_nexthop_len);
+		flog_err(
+			 EC_BGP_ATTR_NH_SEND_LEN,
+			 "Bad nexthop when sending to %s, AFI %u SAFI %u nhlen %d",
+			 peer->host, afi, safi, attr->mp_nexthop_len);
 		break;
 	case AFI_UNSPEC:
 	case AFI_MAX:


### PR DESCRIPTION
Remove code check about SAFI_FLOWSPEC when AFI is L2VPN, as this case can never happen.

Fixes: 722e8011e1e8 ("Use switch statements without default for safi_t and afi_t enum's")

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>