### PR TITLE
tests: Fix wrong interface name in `bgp_srv6l3vpn_route_leak` topotest

### DIFF
--- a/tests/topotests/bgp_srv6l3vpn_route_leak/pe1/results/vrf20_ipv4.json
+++ b/tests/topotests/bgp_srv6l3vpn_route_leak/pe1/results/vrf20_ipv4.json
@@ -12,7 +12,7 @@
                 {
                     "fib": true,
                     "directlyConnected": true,
-                    "interfaceName": "eth0",
+                    "interfaceName": "vrf10",
                     "vrf": "vrf10",
                     "active": true
                 }


### PR DESCRIPTION
Previously, routes leaked from one VRF to another VRF were associated with the original nexthop interface.

Commit 14aabc0 replaced the nexthop interface with the index of incoming VRF interface.
Due to this change, the `bgp_srv6l3vpn_route_leak` topotest always fails because it still expects the nexthop interface.

This commit fixes the expected interface name in the `bgp_srv6l3vpn_route_leak` topotest.

Signed-off-by: Carmine Scarpitta <carmine.scarpitta@uniroma2.it>