### PR TITLE
pimd, pim6d: Fix interface deletion problem

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1722,8 +1722,9 @@ static int pim_ifp_destroy(struct interface *ifp)
 			ifp->mtu, if_is_operative(ifp));
 	}
 
-	if (!if_is_operative(ifp))
-		pim_if_addr_del_all(ifp);
+	/* Clear IGMP and PIM, this interface is being destroyed */
+	pim_gm_interface_delete(ifp);
+	pim_pim_interface_delete(ifp);
 
 #if PIM_IPV == 4
 	struct pim_instance *pim;


### PR DESCRIPTION
Fixed interface deletion problem, igmp/mld and pim data structure needs to be deleted when interface is destroyed.

Signed-off-by: Mobashshera Rasool <mrasool@vmware.com>