### PR TITLE
zebra: fix a couple of typos

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2208,7 +2208,7 @@ DEFPY (show_route_detail,
 	 [json$json] [nexthop-group$ng]",
        SHOW_STR
        IP_STR
-       "IPv6 forwarding table\n"
+       "IP forwarding table\n"
        "IP routing table\n"
        VRF_FULL_CMD_HELP_STR
        "Network in the IP routing table to display\n"

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1037,7 +1037,8 @@ static void zebra_show_client_detail(struct vty *vty, struct zserv *client)
 	} else
 		vty_out(vty, "Not registered for Nexthop Updates\n");
 
-	vty_out(vty, "Client will %sbe notified about it's routes status\n",
+	vty_out(vty,
+		"Client will %sbe notified about the status of its routes.\n",
 		client->notify_owner ? "" : "Not ");
 
 	last_read_time = (time_t)atomic_load_explicit(&client->last_read_time,


### PR DESCRIPTION
Fix a couple of typos in zebra vty prompt and output text.
