### PR TITLE
bgpd: remove one EC log

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -6436,14 +6436,8 @@ int bgp_evpn_local_vni_del(struct bgp *bgp, vni_t vni)
 
 	/* Locate VNI hash */
 	vpn = bgp_evpn_lookup_vni(bgp, vni);
-	if (!vpn) {
-		if (bgp_debug_zebra(NULL))
-			flog_warn(
-				EC_BGP_EVPN_VPN_VNI,
-				"%u: VNI hash entry for VNI %u not found at DEL",
-				bgp->vrf_id, vni);
+	if (!vpn)
 		return 0;
-	}
 
 	/* Remove all local EVPN routes and schedule for processing (to
 	 * withdraw from peers).


### PR DESCRIPTION
When creating one interface "vxlan66" ( ip link add vxlan66 type vxlan ... ), which initially maintains down status, saw one unexpected EC log:

```
zebra[37906]: [ZAG0W-VSNSD] interface vxlan66 vrf default(0) index 35 becomes active.
zebra[37906]: [HPWGA-Y527W] IFLA_VXLAN_LINK missing from VXLAN IF message
...
zebra[37906]: [W6BZR-YZPAB] RTM_NEWLINK update for vxlan66(35) sl_type 0 master 0 flags 0x1002
zebra[37906]: [MR3ZF-ATDBY] Intf vxlan66(35) has gone DOWN
zebra[37906]: [T44X9-FFNVB] Intf vxlan66(35) L2-VNI 66 is DOWN
zebra[37906]: [KEGYY-K8XVV] Send EVPN_DEL 66 to bgp
zebra[37906]: [HPWGA-Y527W] IFLA_VXLAN_LINK missing from VXLAN IF message
bgpd[37911]: [TV0XP-3WR0A] Rx VNI del VRF default VNI 66 tenant-vrf default SVI ifindex 0
bgpd[37911]: [MDW89-YAXJG][EC 33554497] 0: VNI hash entry for VNI 66 not found at DEL
```

Since commit `6f908ded80eeba40a850e8d1f6246fb3ed31e648` support interfaces from down to down, and bgpd doesn't know "VNI 66" at all. So, remove this EC log.