### PR TITLE
bgpd: show bgp vrfs per vrf level json support

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -4150,6 +4150,28 @@ structure is extended with :clicmd:`show bgp [afi] [safi]`.
 
 .. clicmd:: show bgp [afi] [safi] [all] [wide|json]
 
+.. clicmd:: show bgp vrfs [<VRFNAME$vrf_name>] [json]
+
+   The command displays all bgp vrf instances basic info like router-id,
+   configured and established neighbors,
+   evpn related basic info like l3vni, router-mac, vxlan-interface.
+   User can get that information as JSON format when ``json`` keyword
+   at the end of cli is presented.
+
+   .. code-block:: frr
+
+      torc-11# show bgp vrfs
+      Type  Id     routerId          #PeersCfg  #PeersEstb  Name
+                   L3-VNI            RouterMAC              Interface
+      DFLT  0      17.0.0.6          3          3           default
+                   0                 00:00:00:00:00:00      unknown
+       VRF  21     17.0.0.6          0          0           sym_1
+                   8888              34:11:12:22:22:01      vlan4034_l3
+       VRF  32     17.0.0.6          0          0           sym_2
+                   8889              34:11:12:22:22:01      vlan4035_l3
+
+      Total number of VRFs (including default): 3
+
 .. clicmd:: show bgp [<ipv4|ipv6> <unicast|multicast|vpn|labeled-unicast|flowspec> | l2vpn evpn]
 
    These commands display BGP routes for the specific routing table indicated by


### PR DESCRIPTION
json support extended for show [ip] bgp vrfs <vrf-name> json

**Before:**
```
tor-2# show ip bgp vrfs default json
% JSON option not yet supported for specific VRF
tor-2#
tor-2# show bgp vrfs sym_1 json
% JSON option not yet supported for specific VRF
tor-2#
```

**After:**
```
tor-1# show ip bgp vrfs default json
{
  "default":{
    "type":"DFLT",
    "vrfId":0,
    "routerId":"27.0.0.7",
    "numConfiguredPeers":2,
    "numEstablishedPeers":2,
    "l3vni":0,
    "rmac":"00:00:00:00:00:00",
    "interface":"unknown"
  }
}
tor-1#
tor-1# show bgp vrfs sym_1 json
{
  "sym_1":{
    "type":"VRF",
    "vrfId":21,
    "routerId":"27.0.0.81",
    "numConfiguredPeers":0,
    "numEstablishedPeers":0,
    "l3vni":8888,
    "rmac":"44:38:39:ff:ff:25",
    "interface":"vlan490_l3"
  }
}


tor-1# show bgp vrfs test json
{
}
tor-1#
```

Ticket:#3314672

Issue:3314672

Testing: UT done

Signed-off-by: Chirag Shah <chirag@nvidia.com>
Signed-off-by: Sindhu Parvathi Gopinathan <sgopinathan@nvidia.com>