### PR TITLE
topotests: fix intermittent problem with bgp_l3vpn_to_bgp_vrf

### DIFF
--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_mpls.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_mpls.py
@@ -83,21 +83,28 @@ if ret != False and found != None:
     )
     luCommand(
         "r1",
-        "ip vrf exec r1-cust1 ping 6.0.3.1 -I 10.4.5.6 -c 1",
+        'ip vrf exec r1-cust1 bash -c "ping 6.0.3.1 -I 10.4.5.6 -c 1"',
         " 0. packet loss",
         "wait",
         "R1(r1-cust1)->CE3/4 (loopback) ping",
     )
     luCommand(
         "r1",
-        "ip vrf exec r1-cust1 ping 6.0.3.1 -I 10.4.5.6 -c 1",
+        'ip vrf exec r1-cust1 bash -c "ping 6.0.3.1 -I 10.4.5.6 -c 1"',
         " 0. packet loss",
         "pass",
         "R1(r1-cust1)->CE3/4 (loopback) ping",
     )
     luCommand(
         "r1",
-        "ip vrf exec r1-cust5 ping 6.0.3.1 -I 29.0.0.1 -c 1",
+        'ip vrf exec r1-cust1 bash -c "ping 6.0.3.1 -I 10.4.5.6 -c 1"',
+        " 0. packet loss",
+        "wait",
+        "R1(r1-cust1)->CE3/4 (loopback) ping",
+    )
+    luCommand(
+        "r1",
+        'ip vrf exec r1-cust5 bash -c "ping 6.0.3.1 -I 29.0.0.1 -c 1"',
         " 0. packet loss",
         "pass",
         "R1(r1-cust5)->CE3/4 ( (loopback) ping",

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_vrf.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_vrf.py
@@ -72,52 +72,129 @@ luCommand(
     "wait",
     "CE4->PE4 ping",
 )
-ret = luCommand(
+luCommand(
     "r1",
-    "ip vrf exec r1-cust5 ping 29.0.0.1 -I 29.0.0.1 -c 1",
+    'ip route show table 10 | wc -l',
+    "24",
+    "wait",
+    "Check r1 r1-cust1 routing table",
+    time=60,
+)
+luCommand(
+    "r1",
+    'ip route show table 10 | wc -l',
+    "24",
+    "pass",
+    "Check r1 r1-cust1 routing table",
+)
+luCommand(
+    "r1",
+    'ip route show table 20 | wc -l',
+    "18",
+    "wait",
+    "Check r1 r1-cust3 routing table",
+)
+luCommand(
+    "r1",
+    'ip route show table 20 | wc -l',
+    "18",
+    "pass",
+    "Check r1 r1-cust3 routing table",
+)
+luCommand(
+    "r1",
+    'ip route show table 30 | wc -l',
+    "0",
+    "wait",
+    "Check r1 r1-cust4 routing table",
+)
+luCommand(
+    "r1",
+    'ip route show table 30 | wc -l',
+    "0",
+    "pass",
+    "Check r1 r1-cust4 routing table",
+)
+luCommand(
+    "r1",
+    'ip route show table 40 | wc -l',
+    "19",
+    "wait",
+    "Check r1 r1-cust5 routing table",
+)
+luCommand(
+    "r1",
+    'ip route show table 40 | wc -l',
+    "19",
+    "pass",
+    "Check r1 r1-cust5 routing table",
+)
+luCommand(
+    "r1",
+    'ip vrf exec r1-cust5 bash -c "ping 29.0.0.1 -I 29.0.0.1 -c 1"',
+    " 0. packet loss",
+    "wait",
+    "Ping its own IP.",
+)
+luCommand(
+    "r1",
+    'ip vrf exec r1-cust5 bash -c "ping 29.0.0.1 -I 29.0.0.1 -c 1"',
     " 0. packet loss",
     "pass",
     "Ping its own IP. Check https://bugzilla.kernel.org/show_bug.cgi?id=203483 if it fails",
 )
 luCommand(
     "r1",
-    "ip vrf exec r1-cust5 ping 192.168.1.1 -I 29.0.0.1 -c 1",
+    'ip vrf exec r1-cust5 bash -c "ping 192.168.1.1 -I 29.0.0.1 -c 1"',
+    " 0. packet loss",
+    "wait",
+    "R1(r1-cust5)->R1(r1-cust1 - r1-eth4) ping",
+)
+luCommand(
+    "r1",
+    'ip vrf exec r1-cust5 bash -c "ping 192.168.1.1 -I 29.0.0.1 -c 1"',
     " 0. packet loss",
     "pass",
     "R1(r1-cust5)->R1(r1-cust1 - r1-eth4) ping",
 )
 luCommand(
     "r1",
-    "ip vrf exec r1-cust5 ping 192.168.1.2 -I 29.0.0.1 -c 1",
+    'ip vrf exec r1-cust5 bash -c "ping 192.168.1.2 -I 29.0.0.1 -c 1"',
     " 0. packet loss",
     "wait",
     "R1(r1-cust5)->CE1 ping",
 )
 luCommand(
     "r1",
-    "ip vrf exec r1-cust5 ping 192.168.1.2 -I 29.0.0.1 -c 1",
+    'ip vrf exec r1-cust5 bash -c "ping 192.168.1.2 -I 29.0.0.1 -c 1"',
     " 0. packet loss",
     "pass",
     "R1(r1-cust5)->CE1 ping",
 )
 luCommand(
     "r1",
-    "ip vrf exec r1-cust5 ping 99.0.0.1 -I 29.0.0.1 -c 1",
+    'ip vrf exec r1-cust5 bash -c "ping 99.0.0.1 -I 29.0.0.1 -c 1"',
+    " 0. packet loss",
+    "wait",
+    "R1(r1-cust5)->CE1 (loopback) ping",
+)
+luCommand(
+    "r1",
+    'ip vrf exec r1-cust5 bash -c "ping 99.0.0.1 -I 29.0.0.1 -c 1"',
     " 0. packet loss",
     "pass",
     "R1(r1-cust5)->CE1 (loopback) ping",
 )
 luCommand(
     "r1",
-    "ip vrf exec r1-cust5 ping 5.1.0.1 -I 29.0.0.1 -c 1",
+    'ip vrf exec r1-cust5 bash -c "ping 5.1.0.1 -I 29.0.0.1 -c 1"',
     " 0. packet loss",
     "wait",
     "R1(r1-cust5)->CE1 (loopback) ping",
-    time=30,
 )
 luCommand(
     "r1",
-    "ip vrf exec r1-cust5 ping 5.1.0.1 -I 29.0.0.1 -c 1",
+    'ip vrf exec r1-cust5 bash -c "ping 5.1.0.1 -I 29.0.0.1 -c 1"',
     " 0. packet loss",
     "pass",
     "R1(r1-cust5)->CE1 (loopback) ping",

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_routes.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_routes.py
@@ -726,7 +726,7 @@ bgpribRequireUnicastRoutes(
 luCommand(
     "ce1",
     'vtysh -c "show bgp ipv4 uni"',
-    "18 routes and 19",
+    "18 routes and 18",
     "wait",
     "Local and remote routes",
     10,
@@ -748,7 +748,7 @@ bgpribRequireUnicastRoutes(
 luCommand(
     "ce2",
     'vtysh -c "show bgp ipv4 uni"',
-    "18 routes and 22",
+    "18 routes and 21",
     "wait",
     "Local and remote routes",
     10,


### PR DESCRIPTION
Fix intermittent problem with bgp_l3vpn_to_bgp_vrf. It also fixes bgp_instance_del_test that shares the same code.

Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>