### PR TITLE
zebra: Add missing json attributes for show evpn

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -3511,6 +3511,12 @@ void zebra_vxlan_print_evpn(struct vty *vty, bool uj)
 		json = json_object_new_object();
 		json_object_string_add(json, "advertiseGatewayMacip",
 				       zvrf->advertise_gw_macip ? "Yes" : "No");
+		json_object_string_add(json, "advertiseSviMacip",
+				       zvrf->advertise_svi_macip ? "Yes"
+								 : "No");
+		json_object_string_add(json, "advertiseSviMac",
+				       zebra_evpn_mh_do_adv_svi_mac() ? "Yes"
+								      : "No");
 		json_object_int_add(json, "numVnis", num_vnis);
 		json_object_int_add(json, "numL2Vnis", num_l2vnis);
 		json_object_int_add(json, "numL3Vnis", num_l3vnis);


### PR DESCRIPTION
Missing json attributes added for show evpn json

Before:
```
tor-1# show evpn json
{
  "advertiseGatewayMacip":"No",
  "numVnis":26,
  "numL2Vnis":21,
  "numL3Vnis":5,
  "isDuplicateAddrDetection":true,
  "maxMoves":5,
  "detectionTime":180,
  "detectionFreezeTime":0,
  "macHoldtime":1080,
  "neighHoldtime":1080,
  "startupDelay":180,
  "startupDelayTimer":"--:--:--",
  "uplinkConfigCount":0,
  "uplinkActiveCount":0
}
tor-1#
```

After:
```
tor-1# show evpn json
{
  "advertiseGatewayMacip":"No",
  "advertiseSviMacip":"No",
  "advertiseSviMac":"No",
  "numVnis":26,
  "numL2Vnis":21,
  "numL3Vnis":5,
  "isDuplicateAddrDetection":true,
  "maxMoves":5,
  "detectionTime":180,
  "detectionFreezeTime":0,
  "macHoldtime":1080,
  "neighHoldtime":1080,
  "startupDelay":180,
  "startupDelayTimer":"--:--:--",
  "uplinkConfigCount":0,
  "uplinkActiveCount":0
}
tor-1#
```


Testing: UT done

Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>