### PR TITLE
bgpd: upon monitor configuration change, refresh the rib

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2268,9 +2268,11 @@ DEFPY(bmp_monitor_cfg,
 			bmp->afistate[afi][safi] = BMP_AFI_INACTIVE;
 			continue;
 		}
-
 		bmp->afistate[afi][safi] = BMP_AFI_NEEDSYNC;
 	}
+
+	frr_each(bmp_session, &bt->sessions, bmp)
+		pullwr_bump(bmp->pullwr);
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
BMP monitors all incoming prefixes from the BGP RIB. When pre-policy or post-policy is configured, when a new prefix is received, then the BMP server receives the prefix. The BMP server also receives messages that have not been previously sent.

This commit addresses the case where an administrator changes the BMP monitor configuration, and wants the BMP server to get the new RIB entries, without waiting for a next update to perform the completion.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>