### PR TITLE
zebra: Continue fpm_read when we decide a netlink message is not needed

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -604,7 +604,10 @@ static void fpm_read(struct thread *t)
 				    hdr, 0, false, ctx) != 1) {
 				dplane_ctx_fini(&ctx);
 				stream_pulldown(fnc->ibuf);
-				return;
+				/*
+				 * Let's continue to read other messages
+				 * Even if we ignore this one.
+				 */
 			}
 			break;
 		default:


### PR DESCRIPTION
When FRR receives a netlink message that it decides to stop parsing it returns a 0 ( instead of a -1 ).  Just make the dplane continue reading other data instead of aborting the read.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>