### PR TITLE
tests: route_scale tests are failing on micronet

### DIFF
--- a/tests/topotests/route_scale/scale_test_common.py
+++ b/tests/topotests/route_scale/scale_test_common.py
@@ -178,7 +178,7 @@ def route_install_helper(iter):
 
     # Table of defaults, used for timeout values and 'expected' objects
     scale_defaults = dict(
-        zip(scale_keys, [None, None, 7, 30, expected_installed, expected_removed])
+        zip(scale_keys, [None, None, 10, 50, expected_installed, expected_removed])
     )
 
     # List of params for each step in the test; note extra time given


### PR DESCRIPTION
I'm seeing test failures after in micronet runs in CI after 7 seconds * 30 attempts at seeing if it succeeds. Let's see if another 60 seconds of attempts allows this to work properly.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>