### PR TITLE
zebra: cosmetic changes for debug

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -4389,7 +4389,7 @@ static ssize_t netlink_neigh_update_ctx(const struct zebra_dplane_ctx *ctx,
 			"Tx %s family %s IF %s(%u) Neigh %pIA %s %s flags 0x%x state 0x%x %sext_flags 0x%x",
 			nl_msg_type_to_str(cmd), nl_family_to_str(family),
 			dplane_ctx_get_ifname(ctx), dplane_ctx_get_ifindex(ctx),
-			ip, link_ip ? "Link " : "MAC ", buf2, flags, state,
+			ip, link_ip ? "Link" : "MAC", buf2, flags, state,
 			ext ? "ext " : "", ext_flags);
 
 	return netlink_neigh_update_msg_encode(

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -5070,8 +5070,8 @@ neigh_update_internal(enum dplane_op_e op, const struct interface *ifp,
 			ipaddr2str(link_ip, buf1, sizeof(buf1));
 		zlog_debug("init neigh ctx %s: ifp %s, %s %s, ip %pIA",
 			   dplane_op2str(op), ifp->name,
-			   link_family == AF_ETHERNET ? "mac " : "link ",
-			   buf1, ip);
+			   link_family == AF_ETHERNET ? "mac" : "link", buf1,
+			   ip);
 	}
 
 	ctx = dplane_ctx_alloc();


### PR DESCRIPTION
Just remove redundant white spaces in debug information.

Before:
```
2023/01/11 05:04:48 ZEBRA: [W8V7C-6W4DS] init neigh ctx NEIGH_INSTALL: ifp vlan100, mac  9a:68:e9:73:74:88, ip 88.88.88.88
2023/01/11 05:04:48 ZEBRA: [NH6N7-54CD1] Tx RTM_NEWNEIGH family ipv4 IF vlan100(8) Neigh 88.88.88.88 MAC  9a:68:e9:73:74:88 flags 0x10 state 0x40 ext_flags 0x0
```

After:
```
2023/01/11 05:17:26 ZEBRA: [W8V7C-6W4DS] init neigh ctx NEIGH_INSTALL: ifp vlan100, mac 9a:68:e9:73:74:88, ip 88.88.88.88
2023/01/11 05:17:26 ZEBRA: [NH6N7-54CD1] Tx RTM_NEWNEIGH family ipv4 IF vlan100(8) Neigh 88.88.88.88 MAC 9a:68:e9:73:74:88 flags 0x10 state 0x40 ext_flags 0x0
```