### PR TITLE
bgpd: Warn user about mixed order of commands executed

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -521,10 +521,8 @@ DEFUN (neighbor_bfd_check_controlplane_failure,
 	else
 		idx_peer = 1;
 	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
-	if (!peer) {
-		vty_out(vty, "%% Specify remote-as or peer-group commands first\n");
+	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
-	}
 
 	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
 		bgp_group_configure_bfd(peer);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -819,6 +819,9 @@ struct peer *peer_and_group_lookup_vty(struct vty *vty, const char *peer_str)
 
 	if (peer) {
 		if (peer_dynamic_neighbor(peer)) {
+			zlog_warn(
+				"%pBP: Operation not allowed on a dynamic neighbor",
+				peer);
 			vty_out(vty,
 				"%% Operation not allowed on a dynamic neighbor\n");
 			return NULL;
@@ -830,6 +833,8 @@ struct peer *peer_and_group_lookup_vty(struct vty *vty, const char *peer_str)
 	if (group)
 		return group->conf;
 
+	zlog_warn("Specify remote-as or peer-group commands first before: %s",
+		  vty->buf);
 	vty_out(vty, "%% Specify remote-as or peer-group commands first\n");
 
 	return NULL;


### PR DESCRIPTION
Related: https://github.com/FRRouting/frr/issues/12625