### PR TITLE
bgpd: fix wrong vrf name for debug

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3576,7 +3576,7 @@ int bgp_get(struct bgp **bgp_val, as_t *as, const char *name,
 	if (IS_BGP_INST_KNOWN_TO_ZEBRA(bgp)) {
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("%s: Registering BGP instance %s to zebra",
-				   __func__, name);
+				   __func__, bgp->name_pretty);
 		bgp_zebra_instance_register(bgp);
 	}
 


### PR DESCRIPTION
For vrf name in debug, use `bgp->name_pretty` instead of `bgp->name`.

Before:
```
2023/01/15 05:04:19 BGP: [P4GAZ-JHRM3] evpn vrf VRF default nh init
2023/01/15 05:04:19 BGP: [ZZKY3-FX5JH] bgp_get: Registering BGP instance (null) to zebra <-
2023/01/15 05:04:19 BGP: [TNK7N-FJF7K] Registering VRF 0
```

After:
```
2023/01/15 21:38:16 BGP: [P4GAZ-JHRM3] evpn vrf VRF default nh init
2023/01/15 21:38:16 BGP: [ZZKY3-FX5JH] bgp_get: Registering BGP instance VRF default to zebra <-
2023/01/15 21:38:16 BGP: [TNK7N-FJF7K] Registering VRF 0
```
