### PR TITLE
zebra: fix use after free on RIB processing

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1306,6 +1306,7 @@ static void rib_process(struct route_node *rn)
 									vrf),
 								vrf_id, rn);
 						rib_unlink(rn, re);
+						continue;
 					} else
 						SET_FLAG(re->status,
 							 ROUTE_ENTRY_REMOVED);


### PR DESCRIPTION
After calling `rib_unlink` the variable `re` will point to `free()`d memory, so don't attempt to use it after this point.

Found by Coverity Scan (Coverity ID 1519784)

---

```c
static void rib_process(struct route_node *rn) {
	/* ... */
	RNODE_FOREACH_RE_SAFE (rn, re, next) {
		/* ... */
		if (CHECK_FLAG(re->status, ROUTE_ENTRY_CHANGED)) {
			if (!nexthop_active_update(rn, re)) {
				if (re->type == ZEBRA_ROUTE_TABLE) {
					if (re != old_selected) {
						/* ... */
						rib_unlink(rn, re);
						/* `re` now points to `free()`d memory */
					} else
						SET_FLAG(re->status,
							 ROUTE_ENTRY_REMOVED);
				}

				/* ... */
				/* `re` is used after `free()` in `zsend_route_notify_owner` */
				zsend_route_notify_owner(
					rn, re, ZAPI_ROUTE_FAIL_INSTALL,
					info->afi, info->safi);
				continue;
			}
		} else {
			/* ... */
		}
		/* ... */
}
```