### PR TITLE
bgpd: cosmetic changes for debug

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2119,10 +2119,11 @@ static int update_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
 		char buf3[ESI_STR_LEN];
 
 		zlog_debug(
-			"VRF %s vni %u type-2 route evp %pFX RMAC %pEA nexthop %pI4 esi %s",
+			"VRF %s vni %u type-%u route evp %pFX RMAC %pEA nexthop %pI4 esi %s",
 			vpn->bgp_vrf ? vrf_id_to_name(vpn->bgp_vrf->vrf_id)
-				     : " ",
-			vpn->vni, p, &attr.rmac, &attr.mp_nexthop_global_in,
+				     : "None",
+			vpn->vni, p->prefix.route_type, p, &attr.rmac,
+			&attr.mp_nexthop_global_in,
 			esi_to_str(esi, buf3, sizeof(buf3)));
 	}
 


### PR DESCRIPTION
Two changes for debug log -
1. Display empty VRF as "None".
2. Correct wrong "type-2" word for type-3 route.

Before:
```
2023/01/17 04:00:30 BGP: [Z5AV7-75RTE] VRF   vni 100 type-2 route evp [3]:[0]:[32]:[88.88.88.88] RMAC 00:00:00:00:00:00 nexthop 88.88.88.88 esi (null)
```

After:
```
2023/01/17 04:05:24 BGP: [M3X4Y-24DVB] VRF None vni 100 type-3 route evp [3]:[0]:[32]:[88.88.88.88] RMAC 00:00:00:00:00:00 nexthop 88.88.88.88 esi (null)
```