### PR TITLE
zebra: fix JSON fields for show evpn vni detail

### DIFF
--- a/tests/topotests/bgp_evpn_vxlan_topo1/PE1/evpn.vni.json
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/PE1/evpn.vni.json
@@ -1,13 +1,17 @@
 {
   "vni":101,
   "type":"L2",
-  "vrf":"default",
+  "tenantVrf":"default",
   "vxlanInterface":"vxlan101",
   "vtepIp":"10.10.10.10",
   "mcastGroup":"0.0.0.0",
   "advertiseGatewayMacip":"No",
-  "numRemoteVteps":[
-    "10.30.30.30"
+  "numRemoteVteps":1,
+  "remoteVteps":[
+      {
+        "ip":"10.30.30.30",
+        "flood":"HER"
+      }
   ]
 }
 

--- a/tests/topotests/bgp_evpn_vxlan_topo1/PE2/evpn.vni.json
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/PE2/evpn.vni.json
@@ -1,12 +1,16 @@
 {
   "vni":101,
   "type":"L2",
-  "vrf":"default",
+  "tenantVrf":"default",
   "vxlanInterface":"vxlan101",
   "vtepIp":"10.30.30.30",
   "mcastGroup":"0.0.0.0",
   "advertiseGatewayMacip":"No",
-  "numRemoteVteps":[
-    "10.10.10.10"
-  ]
+  "numRemoteVteps":1,
+  "remoteVteps":[
+      {
+        "ip":"10.10.10.10",
+        "flood":"HER"
+      }
+   ]
 }

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
@@ -144,7 +144,6 @@ def teardown_module(mod):
 
 def show_vni_json_elide_ifindex(pe, vni, expected):
     output_json = pe.vtysh_cmd("show evpn vni {} json".format(vni), isjson=True)
-
     if "ifindex" in output_json:
         output_json.pop("ifindex")
 

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -750,6 +750,12 @@ static void zl3vni_print(struct zebra_l3vni *zl3vni, void **ctx)
 		json_evpn_list = json_object_new_array();
 		json_object_int_add(json, "vni", zl3vni->vni);
 		json_object_string_add(json, "type", "L3");
+#if CONFDATE > 20240210
+CPP_NOTICE("Drop `vrf` from JSON outputs")
+#endif
+		json_object_string_add(json, "vrf", zl3vni_vrf_name(zl3vni));
+		json_object_string_add(json, "tenantVrf",
+				       zl3vni_vrf_name(zl3vni));
 		json_object_string_addf(json, "localVtepIp", "%pI4",
 					&zl3vni->local_vtep_ip);
 		json_object_string_add(json, "vxlanIntf",
@@ -757,7 +763,6 @@ static void zl3vni_print(struct zebra_l3vni *zl3vni, void **ctx)
 		json_object_string_add(json, "sviIntf",
 				       zl3vni_svi_if_name(zl3vni));
 		json_object_string_add(json, "state", zl3vni_state2str(zl3vni));
-		json_object_string_add(json, "vrf", zl3vni_vrf_name(zl3vni));
 		json_object_string_add(
 			json, "sysMac",
 			zl3vni_sysmac2str(zl3vni, buf, sizeof(buf)));


### PR DESCRIPTION
Few of the JSON fields in "show evpn vni detail" command is confusing and does not follow the naming convention used in EVPN deployments. Since this is the detail option, it is better to address it now.

```
primary# show evpn vni detail json
[
  {
    "vni":200,
    "type":"L2",
    "tenantVrf":"default",
    "vxlanInterface":"vni200",
    "vxlanIfindex":19,
    "sviInterface":"br200",
    "sviIfindex":18,
    "vtepIp":"2.2.2.1",
    "mcastGroup":"0.0.0.0",
    "advertiseGatewayMacip":"No",
    "advertiseSviMacip":"No",
    "numMacs":0,
    "numArpNd":0,
    "numRemoteVteps":1,
    "remoteVteps":[
      {
        "ip":"2.2.2.2",
        "flood":"HER"
      }
    ]
  },
  {
    "vni":100,
    "type":"L3",
    "tenantVrf":"default",
    "localVtepIp":"2.2.2.1",
    "vxlanIntf":"vni100",
    "sviIntf":"br100",
    "state":"Up",
    "sysMac":"aa:bb:cc:dd:ee:f1",
    "routerMac":"aa:bb:cc:dd:ee:f1",
    "vniFilter":"none",
    "l2Vnis":[
      20,
      30,
      200
    ]
  }
]
```
Signed-off-by: Pooja Jagadeesh Doijode <pdoijode@nvidia.com>