### PR TITLE
zebra: fix fpm netlink encode out of bounds read

### DIFF
--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -511,7 +511,7 @@ static int netlink_route_info_encode(struct netlink_route_info *ri,
 done:
 
 	if (ri->pref_src) {
-		nl_attr_put(&req->n, in_buf_len, RTA_PREFSRC, &ri->pref_src,
+		nl_attr_put(&req->n, in_buf_len, RTA_PREFSRC, ri->pref_src,
 			    bytelen);
 	}
 


### PR DESCRIPTION
Don't attempt to encode the pointer address instead pass the pointer directly so the real contents can be accessed.

(`ri->pref_src` type is `union g_addr *`)

Found by Coverity Scan (CID 1482162)