### PR TITLE
bgpd: fix vpnv6 nexthop encoding

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -4028,8 +4028,8 @@ size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer, afi_t afi,
 			}
 		} break;
 		case SAFI_MPLS_VPN: {
-			if (attr->mp_nexthop_len
-				   == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL) {
+			if (attr->mp_nexthop_len ==
+			    BGP_ATTR_NHLEN_VPNV6_GLOBAL_AND_LL) {
 				stream_putc(s, 48);
 				stream_putl(s, 0); /* RD = 0, per RFC */
 				stream_putl(s, 0);


### PR DESCRIPTION
In ipv6 vpn, when the global and the local ipv6 address are received, when re-transmitting the bgp ipv6 update, the nexthop attribute length must still be 48 bytes.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>