### PR TITLE
lib,zebra: fix null dereference and remove dead code

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -1000,8 +1000,7 @@ lib_vrf_state_active_get_elem(struct nb_cb_get_elem_args *args)
 	struct vrf *vrfp = (struct vrf *)args->list_entry;
 
 	if (vrfp->status == VRF_ACTIVE)
-		return yang_data_new_bool(
-			args->xpath, vrfp->status == VRF_ACTIVE ? true : false);
+		return yang_data_new_bool(args->xpath, true);
 
 	return NULL;
 }

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1436,7 +1436,8 @@ static void zebra_if_netconf_update_ctx(struct zebra_dplane_ctx *ctx,
 			if (IS_ZEBRA_DEBUG_KERNEL)
 				zlog_debug(
 					"%s: if %s(%u) zebra info pointer is NULL",
-					__func__, ifp->name, ifp->ifindex);
+					__func__, ifp ? ifp->name : "(null)",
+					ifp ? ifp->ifindex : ifindex);
 			return;
 		}
 		if (afi == AFI_IP) {


### PR DESCRIPTION
Fix two coverity scan issues:
- 1519776: Possible null dereference
- 1519760: Remove dead code logic

See commit messages for more information.