### PR TITLE
Bgp outq limit

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -18928,10 +18928,6 @@ void bgp_vty_init(void)
 	install_element(BGP_NODE, &bgp_graceful_restart_rib_stale_time_cmd);
 	install_element(BGP_NODE, &no_bgp_graceful_restart_rib_stale_time_cmd);
 
-	/* "bgp inq-limit command */
-	install_element(BGP_NODE, &bgp_inq_limit_cmd);
-	install_element(BGP_NODE, &no_bgp_inq_limit_cmd);
-
 	/* "bgp graceful-shutdown" commands */
 	install_element(BGP_NODE, &bgp_graceful_shutdown_cmd);
 	install_element(BGP_NODE, &no_bgp_graceful_shutdown_cmd);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -17901,8 +17901,11 @@ int bgp_config_write(struct vty *vty)
 		vty_out(vty, "bgp session-dscp %u\n", bm->tcp_dscp >> 2);
 
 	/* BGP InQ limit */
-	if (bm->inq_limit != BM_DEFAULT_INQ_LIMIT)
+	if (bm->inq_limit != BM_DEFAULT_Q_LIMIT)
 		vty_out(vty, "bgp input-queue-limit %u\n", bm->inq_limit);
+
+	if (bm->outq_limit != BM_DEFAULT_Q_LIMIT)
+		vty_out(vty, "bgp output-queue-limit %u\n", bm->outq_limit);
 
 	/* BGP configuration. */
 	for (ALL_LIST_ELEMENTS(bm->bgp, mnode, mnnode, bgp)) {
@@ -18638,10 +18641,36 @@ DEFPY (no_bgp_inq_limit,
        "Set the BGP Input Queue limit for all peers when message parsing\n"
        "Input-Queue limit\n")
 {
-	bm->inq_limit = BM_DEFAULT_INQ_LIMIT;
+	bm->inq_limit = BM_DEFAULT_Q_LIMIT;
 
 	return CMD_SUCCESS;
 }
+
+DEFPY (bgp_outq_limit,
+       bgp_outq_limit_cmd,
+       "bgp output-queue-limit (1-4294967295)$limit",
+       BGP_STR
+       "Set the BGP Output Queue limit for all peers when message parsing\n"
+       "Output-Queue limit\n")
+{
+	bm->outq_limit = limit;
+
+	return CMD_SUCCESS;
+}
+
+DEFPY (no_bgp_outq_limit,
+       no_bgp_outq_limit_cmd,
+       "no bgp output-queue-limit [(1-4294967295)$limit]",
+       NO_STR
+       BGP_STR
+       "Set the BGP Output Queue limit for all peers when message parsing\n"
+       "Output-Queue limit\n")
+{
+	bm->outq_limit = BM_DEFAULT_Q_LIMIT;
+
+	return CMD_SUCCESS;
+}
+
 
 /* Initialization of BGP interface. */
 static void bgp_vty_if_init(void)
@@ -18695,6 +18724,8 @@ void bgp_vty_init(void)
 	/* "global bgp inq-limit command */
 	install_element(CONFIG_NODE, &bgp_inq_limit_cmd);
 	install_element(CONFIG_NODE, &no_bgp_inq_limit_cmd);
+	install_element(CONFIG_NODE, &bgp_outq_limit_cmd);
+	install_element(CONFIG_NODE, &no_bgp_outq_limit_cmd);
 
 	/* "bgp local-mac" hidden commands. */
 	install_element(CONFIG_NODE, &bgp_local_mac_cmd);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7940,7 +7940,8 @@ void bgp_master_init(struct thread_master *master, const int buffer_size,
 	bm->socket_buffer = buffer_size;
 	bm->wait_for_fib = false;
 	bm->tcp_dscp = IPTOS_PREC_INTERNETCONTROL;
-	bm->inq_limit = BM_DEFAULT_INQ_LIMIT;
+	bm->inq_limit = BM_DEFAULT_Q_LIMIT;
+	bm->outq_limit = BM_DEFAULT_Q_LIMIT;
 
 	bgp_mac_init();
 	/* init the rd id space.

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -177,8 +177,9 @@ struct bgp_master {
 	/* DSCP value for TCP sessions */
 	uint8_t tcp_dscp;
 
-#define BM_DEFAULT_INQ_LIMIT 10000
+#define BM_DEFAULT_Q_LIMIT 10000
 	uint32_t inq_limit;
+	uint32_t outq_limit;
 
 	QOBJ_FIELDS;
 };

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -4065,6 +4065,11 @@ The following command is available in ``config`` mode as well as in the
    Set the BGP Input Queue limit for all peers when messaging parsing. Increase
    this only if you have the memory to handle large queues of messages at once.
 
+.. clicmd:: bgp output-queue-limit (1-4294967295)
+
+   Set the BGP Output Queue limit for all peers when messaging parsing. Increase
+   this only if you have the memory to handle large queues of messages at once.
+
 .. _bgp-displaying-bgp-information:
 
 Displaying BGP Information


### PR DESCRIPTION
Limit the OutputQueue size ala what was done for the input Queue size.