### PR TITLE
zebra: fix wrong conversion for evpn advertising

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5554,6 +5554,7 @@ void zebra_vxlan_advertise_svi_macip(ZAPI_HANDLER_ARGS)
 		struct zebra_if *zif = NULL;
 		struct zebra_l2info_vxlan zl2_info;
 		struct interface *vlan_if = NULL;
+		int old_advertise;
 
 		zevpn = zebra_evpn_lookup(vni);
 		if (!zevpn)
@@ -5567,13 +5568,14 @@ void zebra_vxlan_advertise_svi_macip(ZAPI_HANDLER_ARGS)
 					? "enabled"
 					: "disabled");
 
-		if (zevpn->advertise_svi_macip == advertise)
-			return;
+		old_advertise = advertise_svi_macip_enabled(zevpn);
 
 		/* Store flag even though SVI is not present.
 		 * Once SVI comes up triggers self MAC-IP route add.
 		 */
 		zevpn->advertise_svi_macip = advertise;
+		if (advertise_svi_macip_enabled(zevpn) == old_advertise)
+			return;
 
 		ifp = zevpn->vxlan_if;
 		if (!ifp)
@@ -5719,6 +5721,7 @@ void zebra_vxlan_advertise_gw_macip(ZAPI_HANDLER_ARGS)
 		struct zebra_l2info_vxlan zl2_info;
 		struct interface *vlan_if = NULL;
 		struct interface *vrr_if = NULL;
+		int old_advertise;
 
 		zevpn = zebra_evpn_lookup(vni);
 		if (!zevpn)
@@ -5731,10 +5734,11 @@ void zebra_vxlan_advertise_gw_macip(ZAPI_HANDLER_ARGS)
 				advertise_gw_macip_enabled(zevpn) ? "enabled"
 								  : "disabled");
 
-		if (zevpn->advertise_gw_macip == advertise)
-			return;
+		old_advertise = advertise_gw_macip_enabled(zevpn);
 
 		zevpn->advertise_gw_macip = advertise;
+		if (advertise_gw_macip_enabled(zevpn) == old_advertise)
+			return;
 
 		ifp = zevpn->vxlan_if;
 		if (!ifp)

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5561,7 +5561,7 @@ void zebra_vxlan_advertise_svi_macip(ZAPI_HANDLER_ARGS)
 
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug(
-				"EVPN SVI macip Adv %s on VNI %d , currently %s",
+				"EVPN SVI macip Adv %s on VNI %d, currently %s",
 				advertise ? "enabled" : "disabled", vni,
 				advertise_svi_macip_enabled(zevpn)
 					? "enabled"
@@ -5637,7 +5637,7 @@ void zebra_vxlan_advertise_subnet(ZAPI_HANDLER_ARGS)
 		return;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug("EVPN subnet Adv %s on VNI %d , currently %s",
+		zlog_debug("EVPN subnet Adv %s on VNI %d, currently %s",
 			   advertise ? "enabled" : "disabled", vni,
 			   zevpn->advertise_subnet ? "enabled" : "disabled");
 
@@ -5726,10 +5726,10 @@ void zebra_vxlan_advertise_gw_macip(ZAPI_HANDLER_ARGS)
 
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug(
-				"EVPN gateway macip Adv %s on VNI %d , currently %s",
+				"EVPN gateway macip Adv %s on VNI %d, currently %s",
 				advertise ? "enabled" : "disabled", vni,
 				advertise_gw_macip_enabled(zevpn) ? "enabled"
-								 : "disabled");
+								  : "disabled");
 
 		if (zevpn->advertise_gw_macip == advertise)
 			return;


### PR DESCRIPTION
## 1. zebra: fix wrong conversion for evpn advertising
The two commands ( `advertise-svi-ip` and `advertise-default-gw` ) can
be set in both `BGP_EVPN_NODE` and `BGP_EVPN_VNI_NODE`. So, when
configuring one of them, need to consider the configuration of the
other.  Configuring it under `BGP_EVPN_NODE`, it does check the other.
However, the conversion is wrong when configured under `BGP_EVPN_VNI_NODE`.

One example:
With the following steps, the evpn routes with `SVI` will be mistakenly
withdrawn.

```
anlan(config-router-af)# advertise-svi-ip
anlan(config-router-af)# vni 100
anlan(config-router-af-vni)# advertise-svi-ip
anlan(config-router-af-vni)# no advertise-svi-ip
```

This commit fixed the conversion under `BGP_EVPN_VNI_NODE` for the
two commands.

## 2. zebra: remove redundant spaces for debug log

Remove redundant spaces for debug log. By the way, adjust one format problem.