### PR TITLE
babeld: Fix --terminal option

### DIFF
--- a/babeld/babel_main.c
+++ b/babeld/babel_main.c
@@ -50,7 +50,6 @@ THE SOFTWARE.
 
 static void babel_fail(void);
 static void babel_init_random(void);
-static void babel_replace_by_null(int fd);
 static void babel_exit_properly(void);
 static void babel_save_state_file(void);
 
@@ -199,8 +198,6 @@ main(int argc, char **argv)
     resend_delay = BABEL_DEFAULT_RESEND_DELAY;
     change_smoothing_half_life(BABEL_DEFAULT_SMOOTHING_HALF_LIFE);
 
-    babel_replace_by_null(STDIN_FILENO);
-
     /* init some quagga's dependencies, and babeld's commands */
     if_zapi_callbacks(babel_ifp_create, babel_ifp_up,
 		      babel_ifp_down, babel_ifp_destroy);
@@ -245,32 +242,6 @@ babel_init_random(void)
 
     seed ^= (babel_now.tv_sec ^ babel_now.tv_usec);
     srandom(seed);
-}
-
-/*
- close fd, and replace it by "/dev/null"
- exit if error
- */
-static void
-babel_replace_by_null(int fd)
-{
-    int fd_null;
-    int rc;
-
-    fd_null = open("/dev/null", O_RDONLY);
-    if(fd_null < 0) {
-        flog_err_sys(EC_LIB_SYSTEM_CALL, "open(null): %s", safe_strerror(errno));
-        exit(1);
-    }
-
-    rc = dup2(fd_null, fd);
-    if(rc < 0) {
-        flog_err_sys(EC_LIB_SYSTEM_CALL, "dup2(null, 0): %s",
-		  safe_strerror(errno));
-        exit(1);
-    }
-
-    close(fd_null);
 }
 
 /*


### PR DESCRIPTION
babeld's `--terminal` option doesn't work because it replaces `stdin` with `/dev/null`. It seems to me this function can be removed as `frr_run` handles that in daemon mode.

Signed-off-by: Yuxiang Zhu <vfreex@gmail.com>