### PR TITLE
vtysh: Remove shell access code

### DIFF
--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -314,7 +314,8 @@ options from the list below.
 
    Turn on the ability of FRR to access some shell options( telnet/ssh/bash/etc. )
    from vtysh itself.  This option is considered extremely unsecure and should only
-   be considered for usage if you really really know what you are doing.
+   be considered for usage if you really really know what you are doing.  This
+   option is deprecated and will be removed on Feb 1, 2024.
 
 .. option:: --enable-gcov
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -4014,6 +4014,9 @@ DEFUN (vtysh_traceroute6,
 	return CMD_SUCCESS;
 }
 
+#if CONFDATE > 20240201
+CPP_NOTICE("Remove HAVE_SHELL_ACCESS and it's documentation");
+#endif
 #if defined(HAVE_SHELL_ACCESS)
 DEFUN (vtysh_telnet,
        vtysh_telnet_cmd,


### PR DESCRIPTION
The shell access code has been hidden behind a configure option now for 5+ years.  Frankly I don't think FRR should be carrying such code that easily allows you to shoot yourself in the foot from a security perspective.  If someone really needs this they can carry this as a private patch.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>