### PR TITLE
ospfd: fix crash show ip ospf border-routers json

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -11117,7 +11117,8 @@ static int show_ip_ospf_border_routers_common(struct vty *vty,
 			vty_out(vty, "No OSPF routing information exist\n");
 		else {
 			json_object_free(json_router);
-			json_object_free(json_vrf);
+			if (use_vrf)
+				json_object_free(json_vrf);
 		}
 		return CMD_SUCCESS;
 	}


### PR DESCRIPTION
When show ip ospf border-routers json (without vrf) specified, it leads to crash if there no border-routers information.

Fix:
Do not free json object if use_vrf flag (means vrf option is not passed) is not set.


Testing Done:

with fix:
```
l1# show ip ospf border-routers json
{
}
l1# show ip ospf vrf default border-routers json
{
}
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>