### PR TITLE
*: Prevent double string formatting

### DIFF
--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -74,6 +74,8 @@ DEFPY_YANG(no_router_isis, no_router_isis_cmd,
 	   "ISO IS-IS\n"
 	   "ISO Routing area tag\n" VRF_CMD_HELP_STR)
 {
+	char xpath[XPATH_MAXLEN];
+
 	if (!vrf_name)
 		vrf_name = VRF_DEFAULT_NAME;
 
@@ -87,9 +89,11 @@ DEFPY_YANG(no_router_isis, no_router_isis_cmd,
 
 	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes_clear_pending(
-		vty, "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']", tag,
-		vrf_name);
+	snprintf(xpath, sizeof(xpath),
+		 "/frr-isisd:isis/instance[area-tag='%s'][vrf='%s']", tag,
+		 vrf_name);
+
+	return nb_cli_apply_changes_clear_pending(vty, xpath);
 }
 
 void cli_show_router_isis(struct vty *vty, const struct lyd_node *dnode,
@@ -616,9 +620,12 @@ DEFPY_YANG(no_area_passwd, no_area_passwd_cmd,
       "Configure the authentication password for an area\n"
       "Set the authentication password for a routing domain\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./%s", cmd);
+	snprintf(xpath, sizeof(xpath), "./%s", cmd);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_isis_domain_pwd(struct vty *vty, const struct lyd_node *dnode,
@@ -1254,6 +1261,8 @@ DEFPY_YANG(isis_default_originate, isis_default_originate_cmd,
       "Route map reference\n"
       "Pointer to route-map entries\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	if (no)
 		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 	else {
@@ -1273,9 +1282,9 @@ DEFPY_YANG(isis_default_originate, isis_default_originate_cmd,
 		}
 	}
 
-	return nb_cli_apply_changes(
-		vty, "./default-information-originate/%s[level='%s']", ip,
-		level);
+	snprintf(xpath, sizeof(xpath),
+		 "./default-information-originate/%s[level='%s']", ip, level);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 static void vty_print_def_origin(struct vty *vty, const struct lyd_node *dnode,
@@ -1333,6 +1342,8 @@ DEFPY_YANG(isis_redistribute, isis_redistribute_cmd,
       "Route map reference\n"
       "Pointer to route-map entries\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	if (no)
 		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 	else {
@@ -1344,9 +1355,10 @@ DEFPY_YANG(isis_redistribute, isis_redistribute_cmd,
 				      metric_str ? metric_str : NULL);
 	}
 
-	return nb_cli_apply_changes(
-		vty, "./redistribute/%s[protocol='%s'][level='%s']", ip, proto,
-		level);
+	snprintf(xpath, sizeof(xpath),
+		 "./redistribute/%s[protocol='%s'][level='%s']", ip, proto,
+		 level);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 static void vty_print_redistribute(struct vty *vty,
@@ -1655,6 +1667,8 @@ DEFPY_YANG (isis_sr_prefix_sid,
        "Upstream neighbor must replace prefix-sid with explicit null label\n"
        "Not a node SID\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
 	nb_cli_enqueue_change(vty, "./sid-value-type", NB_OP_MODIFY, sid_type);
 	nb_cli_enqueue_change(vty, "./sid-value", NB_OP_MODIFY, sid_value_str);
@@ -1676,9 +1690,11 @@ DEFPY_YANG (isis_sr_prefix_sid,
 	nb_cli_enqueue_change(vty, "./n-flag-clear", NB_OP_MODIFY,
 			      n_flag_clear ? "true" : "false");
 
-	return nb_cli_apply_changes(
-		vty, "./segment-routing/prefix-sid-map/prefix-sid[prefix='%s']",
-		prefix_str);
+	snprintf(xpath, sizeof(xpath),
+		 "./segment-routing/prefix-sid-map/prefix-sid[prefix='%s']",
+		 prefix_str);
+
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFPY_YANG (no_isis_sr_prefix_sid,
@@ -1699,11 +1715,15 @@ DEFPY_YANG (no_isis_sr_prefix_sid,
        "Upstream neighbor must replace prefix-sid with explicit null label\n"
        "Not a node SID\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(
-		vty, "./segment-routing/prefix-sid-map/prefix-sid[prefix='%s']",
-		prefix_str);
+	snprintf(xpath, sizeof(xpath),
+		 "./segment-routing/prefix-sid-map/prefix-sid[prefix='%s']",
+		 prefix_str);
+
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_isis_prefix_sid(struct vty *vty, const struct lyd_node *dnode,
@@ -2386,6 +2406,8 @@ DEFPY_YANG(circuit_topology, circuit_topology_cmd,
       "IPv6 management topology\n"
       "IPv6 dst-src topology\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, ".", NB_OP_MODIFY, no ? "false" : "true");
 
 	if (strmatch(topology, "ipv4-mgmt"))
@@ -2397,9 +2419,12 @@ DEFPY_YANG(circuit_topology, circuit_topology_cmd,
 	if (strmatch(topology, "ipv4-unicast"))
 		return nb_cli_apply_changes(
 			vty, "./frr-isisd:isis/multi-topology/standard");
-	else
-		return nb_cli_apply_changes(
-			vty, "./frr-isisd:isis/multi-topology/%s", topology);
+	else {
+		snprintf(xpath, sizeof(xpath),
+			 "./frr-isisd:isis/multi-topology/%s", topology);
+
+		return nb_cli_apply_changes(vty, xpath);
+	}
 }
 
 void cli_show_ip_isis_mt_standard(struct vty *vty, const struct lyd_node *dnode,

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -251,34 +251,13 @@ static int nb_cli_apply_changes_internal(struct vty *vty,
 	return CMD_SUCCESS;
 }
 
-int nb_cli_apply_changes(struct vty *vty, const char *xpath_base_fmt, ...)
+int nb_cli_apply_changes(struct vty *vty, const char *xpath_base)
 {
-	char xpath_base[XPATH_MAXLEN] = {};
-
-	/* Parse the base XPath format string. */
-	if (xpath_base_fmt) {
-		va_list ap;
-
-		va_start(ap, xpath_base_fmt);
-		vsnprintf(xpath_base, sizeof(xpath_base), xpath_base_fmt, ap);
-		va_end(ap);
-	}
 	return nb_cli_apply_changes_internal(vty, xpath_base, false);
 }
 
-int nb_cli_apply_changes_clear_pending(struct vty *vty,
-				       const char *xpath_base_fmt, ...)
+int nb_cli_apply_changes_clear_pending(struct vty *vty, const char *xpath_base)
 {
-	char xpath_base[XPATH_MAXLEN] = {};
-
-	/* Parse the base XPath format string. */
-	if (xpath_base_fmt) {
-		va_list ap;
-
-		va_start(ap, xpath_base_fmt);
-		vsnprintf(xpath_base, sizeof(xpath_base), xpath_base_fmt, ap);
-		va_end(ap);
-	}
 	return nb_cli_apply_changes_internal(vty, xpath_base, true);
 }
 

--- a/lib/northbound_cli.h
+++ b/lib/northbound_cli.h
@@ -71,7 +71,7 @@ extern void nb_cli_enqueue_change(struct vty *vty, const char *xpath,
  *    CMD_SUCCESS on success, CMD_WARNING_CONFIG_FAILED otherwise.
  */
 extern int nb_cli_apply_changes_clear_pending(struct vty *vty,
-					      const char *xpath_base_fmt, ...);
+					      const char *xpath_base_fmt);
 
 /*
  * Apply enqueued changes to the candidate configuration, this function
@@ -88,8 +88,7 @@ extern int nb_cli_apply_changes_clear_pending(struct vty *vty,
  * Returns:
  *    CMD_SUCCESS on success, CMD_WARNING_CONFIG_FAILED otherwise.
  */
-extern int nb_cli_apply_changes(struct vty *vty, const char *xpath_base_fmt,
-				...);
+extern int nb_cli_apply_changes(struct vty *vty, const char *xpath_base_fmt);
 
 /*
  * Execute a YANG RPC or Action.

--- a/pathd/path_cli.c
+++ b/pathd/path_cli.c
@@ -762,6 +762,8 @@ DEFPY(srte_policy_candidate_exp,
       "List of SIDs\n"
       "Name of the Segment List\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, preference_str);
 	nb_cli_enqueue_change(vty, "./name", NB_OP_MODIFY, name);
 	nb_cli_enqueue_change(vty, "./protocol-origin", NB_OP_MODIFY, "local");
@@ -769,8 +771,10 @@ DEFPY(srte_policy_candidate_exp,
 	nb_cli_enqueue_change(vty, "./type", NB_OP_MODIFY, "explicit");
 	nb_cli_enqueue_change(vty, "./segment-list-name", NB_OP_MODIFY,
 			      list_name);
-	return nb_cli_apply_changes(vty, "./candidate-path[preference='%s']",
-				    preference_str);
+
+	snprintf(xpath, sizeof(xpath), "./candidate-path[preference='%s']",
+		 preference_str);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFPY_NOSH(
@@ -785,6 +789,7 @@ DEFPY_NOSH(
 	"Dynamic Path\n")
 {
 	char xpath[XPATH_MAXLEN + XPATH_CANDIDATE_BASELEN];
+	char xpath2[XPATH_MAXLEN];
 	int ret;
 
 	snprintf(xpath, sizeof(xpath), "%s/candidate-path[preference='%s']",
@@ -795,8 +800,10 @@ DEFPY_NOSH(
 	nb_cli_enqueue_change(vty, "./protocol-origin", NB_OP_MODIFY, "local");
 	nb_cli_enqueue_change(vty, "./originator", NB_OP_MODIFY, "config");
 	nb_cli_enqueue_change(vty, "./type", NB_OP_MODIFY, "dynamic");
-	ret = nb_cli_apply_changes(vty, "./candidate-path[preference='%s']",
-				   preference_str);
+
+	snprintf(xpath2, sizeof(xpath2), "./candidate-path[preference='%s']",
+		 preference_str);
+	ret = nb_cli_apply_changes(vty, xpath2);
 
 	if (ret == CMD_SUCCESS)
 		VTY_PUSH_XPATH(SR_CANDIDATE_DYN_NODE, xpath);
@@ -972,10 +979,13 @@ DEFPY(srte_policy_no_candidate,
       "Name of the Segment List\n"
       "Dynamic Path\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./candidate-path[preference='%s']",
-				    preference_str);
+	snprintf(xpath, sizeof(xpath), "./candidate-path[preference='%s']",
+		 preference_str);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFPY(srte_candidate_objfun,

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -603,10 +603,13 @@ DEFPY (interface_ipv6_mld,
        IPV6_STR
        IFACE_MLD_STR)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv6");
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 "frr-routing:ipv6");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFPY (interface_no_ipv6_mld,
@@ -618,6 +621,7 @@ DEFPY (interface_no_ipv6_mld,
 {
 	const struct lyd_node *pim_enable_dnode;
 	char pim_if_xpath[XPATH_MAXLEN + 64];
+	char xpath[XPATH_MAXLEN];
 
 	snprintf(pim_if_xpath, sizeof(pim_if_xpath),
 		 "%s/frr-pim:pim/address-family[address-family='%s']",
@@ -639,8 +643,9 @@ DEFPY (interface_no_ipv6_mld,
 					      "false");
 	}
 
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv6");
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 "frr-routing:ipv6");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFPY (interface_ipv6_mld_version,
@@ -651,11 +656,14 @@ DEFPY (interface_ipv6_mld_version,
        "MLD version\n"
        "MLD version number\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY, "true");
 	nb_cli_enqueue_change(vty, "./mld-version", NB_OP_MODIFY, version_str);
 
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv6");
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 "frr-routing:ipv6");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFPY (interface_no_ipv6_mld_version,
@@ -667,10 +675,13 @@ DEFPY (interface_no_ipv6_mld_version,
        "MLD version\n"
        "MLD version number\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./mld-version", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv6");
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 "frr-routing:ipv6");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFPY (interface_ipv6_mld_query_interval,
@@ -682,6 +693,7 @@ DEFPY (interface_ipv6_mld_query_interval,
        "Query interval in seconds\n")
 {
 	const struct lyd_node *pim_enable_dnode;
+	char xpath[XPATH_MAXLEN];
 
 	pim_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
 					   FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
@@ -697,8 +709,9 @@ DEFPY (interface_ipv6_mld_query_interval,
 	nb_cli_enqueue_change(vty, "./query-interval", NB_OP_MODIFY,
 			      q_interval_str);
 
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv6");
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 "frr-routing:ipv6");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFPY (interface_no_ipv6_mld_query_interval,
@@ -710,10 +723,13 @@ DEFPY (interface_no_ipv6_mld_query_interval,
       IFACE_MLD_QUERY_INTERVAL_STR
       IGNORED_IN_NO_STR)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./query-interval", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv6");
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 "frr-routing:ipv6");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFPY (ipv6_mld_group_watermark,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3367,10 +3367,13 @@ DEFUN (interface_ip_igmp,
        IP_STR
        IFACE_IGMP_STR)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFUN (interface_no_ip_igmp,
@@ -3382,7 +3385,7 @@ DEFUN (interface_no_ip_igmp,
 {
 	const struct lyd_node *pim_enable_dnode;
 	char pim_if_xpath[XPATH_MAXLEN];
-
+	char xpath[XPATH_MAXLEN];
 	int printed =
 		snprintf(pim_if_xpath, sizeof(pim_if_xpath),
 			 "%s/frr-pim:pim/address-family[address-family='%s']",
@@ -3410,8 +3413,9 @@ DEFUN (interface_no_ip_igmp,
 					      NB_OP_MODIFY, "false");
 	}
 
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFUN (interface_ip_igmp_join,
@@ -3490,6 +3494,7 @@ DEFUN (interface_ip_igmp_query_interval,
        "Query interval in seconds\n")
 {
 	const struct lyd_node *pim_enable_dnode;
+	char xpath[XPATH_MAXLEN];
 
 	pim_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
@@ -3507,8 +3512,9 @@ DEFUN (interface_ip_igmp_query_interval,
 	nb_cli_enqueue_change(vty, "./query-interval", NB_OP_MODIFY,
 			      argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFUN (interface_no_ip_igmp_query_interval,
@@ -3520,10 +3526,13 @@ DEFUN (interface_no_ip_igmp_query_interval,
        IFACE_IGMP_QUERY_INTERVAL_STR
        IGNORED_IN_NO_STR)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./query-interval", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFUN (interface_ip_igmp_version,
@@ -3534,13 +3543,16 @@ DEFUN (interface_ip_igmp_version,
        "IGMP version\n"
        "IGMP version number\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY,
 			      "true");
 	nb_cli_enqueue_change(vty, "./igmp-version", NB_OP_MODIFY,
 			      argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFUN (interface_no_ip_igmp_version,
@@ -3552,10 +3564,14 @@ DEFUN (interface_no_ip_igmp_version,
        "IGMP version\n"
        "IGMP version number\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./igmp-version", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	snprintf(xpath, XPATH_MAXLEN, FRR_GMP_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFPY (interface_ip_igmp_query_max_response_time,
@@ -3590,6 +3606,7 @@ DEFUN_HIDDEN (interface_ip_igmp_query_max_response_time_dsec,
 	      "Query response value in deciseconds\n")
 {
 	const struct lyd_node *pim_enable_dnode;
+	char xpath[XPATH_MAXLEN];
 
 	pim_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
@@ -3607,8 +3624,9 @@ DEFUN_HIDDEN (interface_ip_igmp_query_max_response_time_dsec,
 	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_MODIFY,
 			      argv[3]->arg);
 
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFUN_HIDDEN (interface_no_ip_igmp_query_max_response_time_dsec,
@@ -3620,11 +3638,15 @@ DEFUN_HIDDEN (interface_no_ip_igmp_query_max_response_time_dsec,
 	      IFACE_IGMP_QUERY_MAX_RESPONSE_TIME_DSEC_STR
 	      IGNORED_IN_NO_STR)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_DESTROY,
 			      NULL);
 
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFPY (interface_ip_igmp_last_member_query_count,
@@ -4541,11 +4563,13 @@ DEFUN (interface_pim_use_source,
        "Configure primary IP address\n"
        "source ip address\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./use-source", NB_OP_MODIFY, argv[3]->arg);
 
-	return nb_cli_apply_changes(vty,
-				    FRR_PIM_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFUN (interface_no_pim_use_source,
@@ -4557,11 +4581,13 @@ DEFUN (interface_no_pim_use_source,
        "Delete source IP address\n"
        "source ip address\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./use-source", NB_OP_MODIFY, "0.0.0.0");
 
-	return nb_cli_apply_changes(vty,
-				    FRR_PIM_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFPY (ip_pim_bfd,
@@ -4574,6 +4600,7 @@ DEFPY (ip_pim_bfd,
        "Use BFD profile name\n")
 {
 	const struct lyd_node *igmp_enable_dnode;
+	char xpath[XPATH_MAXLEN];
 
 	igmp_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
@@ -4592,9 +4619,9 @@ DEFPY (ip_pim_bfd,
 	if (prof)
 		nb_cli_enqueue_change(vty, "./bfd/profile", NB_OP_MODIFY, prof);
 
-	return nb_cli_apply_changes(vty,
-				    FRR_PIM_INTERFACE_XPATH,
-				    "frr-routing:ipv4");
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFPY(no_ip_pim_bfd_profile, no_ip_pim_bfd_profile_cmd,
@@ -4606,11 +4633,13 @@ DEFPY(no_ip_pim_bfd_profile, no_ip_pim_bfd_profile_cmd,
       "Disable BFD profile\n"
       "BFD Profile name\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./bfd/profile", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty,
-			FRR_PIM_INTERFACE_XPATH,
-			"frr-routing:ipv4");
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFUN (no_ip_pim_bfd,
@@ -4621,11 +4650,14 @@ DEFUN (no_ip_pim_bfd,
        PIM_STR
        "Disables BFD support\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./bfd", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty,
-			FRR_PIM_INTERFACE_XPATH,
-			"frr-routing:ipv4");
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFUN (ip_pim_bsm,
@@ -4697,6 +4729,7 @@ DEFUN_HIDDEN (
 	int idx_number_2 = 4;
 	int idx_number_3 = 5;
 	const struct lyd_node *igmp_enable_dnode;
+	char xpath[XPATH_MAXLEN];
 
 	igmp_enable_dnode =
 		yang_dnode_getf(vty->candidate_config->dnode,
@@ -4719,8 +4752,9 @@ DEFUN_HIDDEN (
 	nb_cli_enqueue_change(vty, "./bfd/detect_mult", NB_OP_MODIFY,
 			      argv[idx_number]->arg);
 
-	return nb_cli_apply_changes(vty,
-			FRR_PIM_INTERFACE_XPATH, "frr-routing:ipv4");
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 #if HAVE_BFDD == 0
@@ -4747,6 +4781,7 @@ DEFPY(ip_msdp_peer, ip_msdp_peer_cmd,
 	const char *vrfname;
 	char temp_xpath[XPATH_MAXLEN];
 	char msdp_peer_source_xpath[XPATH_MAXLEN];
+	char xpath[XPATH_MAXLEN];
 
 	vrfname = pim_cli_get_vrf_name(vty);
 	if (vrfname == NULL)
@@ -4763,8 +4798,10 @@ DEFPY(ip_msdp_peer, ip_msdp_peer_cmd,
 	nb_cli_enqueue_change(vty, msdp_peer_source_xpath, NB_OP_MODIFY,
 			      source_str);
 
-	return nb_cli_apply_changes(vty,
-			FRR_PIM_INTERFACE_XPATH, "frr-routing:ipv4");
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 "frr-routing:ipv4");
+
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 DEFPY(ip_msdp_timers, ip_msdp_timers_cmd,

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -350,14 +350,19 @@ int pim_process_no_register_suppress_cmd(struct vty *vty)
 
 int pim_process_ip_pim_cmd(struct vty *vty)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./pim-enable", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_ip_pim_passive_cmd(struct vty *vty, bool enable)
 {
+	char xpath[XPATH_MAXLEN];
+
 	if (enable)
 		nb_cli_enqueue_change(vty, "./pim-passive-enable", NB_OP_MODIFY,
 				      "true");
@@ -365,14 +370,16 @@ int pim_process_ip_pim_passive_cmd(struct vty *vty, bool enable)
 		nb_cli_enqueue_change(vty, "./pim-passive-enable", NB_OP_MODIFY,
 				      "false");
 
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_no_ip_pim_cmd(struct vty *vty)
 {
 	const struct lyd_node *mld_enable_dnode;
 	char mld_if_xpath[XPATH_MAXLEN];
+	char xpath[XPATH_MAXLEN];
 
 	int printed =
 		snprintf(mld_if_xpath, sizeof(mld_if_xpath),
@@ -402,31 +409,39 @@ int pim_process_no_ip_pim_cmd(struct vty *vty)
 					      "false");
 	}
 
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_ip_pim_drprio_cmd(struct vty *vty, const char *drpriority_str)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./dr-priority", NB_OP_MODIFY,
 			      drpriority_str);
 
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_no_ip_pim_drprio_cmd(struct vty *vty)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./dr-priority", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_ip_pim_hello_cmd(struct vty *vty, const char *hello_str,
 				 const char *hold_str)
 {
 	const struct lyd_node *mld_enable_dnode;
+	char xpath[XPATH_MAXLEN];
 
 	mld_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
 					   FRR_GMP_ENABLE_XPATH, VTY_CURR_XPATH,
@@ -447,21 +462,27 @@ int pim_process_ip_pim_hello_cmd(struct vty *vty, const char *hello_str,
 		nb_cli_enqueue_change(vty, "./hello-holdtime", NB_OP_MODIFY,
 				      hold_str);
 
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_no_ip_pim_hello_cmd(struct vty *vty)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./hello-interval", NB_OP_DESTROY, NULL);
 	nb_cli_enqueue_change(vty, "./hello-holdtime", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_ip_pim_activeactive_cmd(struct vty *vty, const char *no)
 {
+	char xpath[XPATH_MAXLEN];
+
 	if (no)
 		nb_cli_enqueue_change(vty, "./active-active", NB_OP_MODIFY,
 				      "false");
@@ -473,64 +494,77 @@ int pim_process_ip_pim_activeactive_cmd(struct vty *vty, const char *no)
 				      "true");
 	}
 
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_ip_pim_boundary_oil_cmd(struct vty *vty, const char *oil)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./multicast-boundary-oil", NB_OP_MODIFY,
 			      oil);
 
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_no_ip_pim_boundary_oil_cmd(struct vty *vty)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./multicast-boundary-oil", NB_OP_DESTROY,
 			      NULL);
 
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_ip_mroute_cmd(struct vty *vty, const char *interface,
 			      const char *group_str, const char *source_str)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./oif", NB_OP_MODIFY, interface);
 
 	if (!source_str) {
 		char buf[SRCDEST2STR_BUFFER];
 
 		inet_ntop(AF_INET6, &in6addr_any, buf, sizeof(buf));
-		return nb_cli_apply_changes(vty, FRR_PIM_MROUTE_XPATH,
-					    FRR_PIM_AF_XPATH_VAL, buf,
-					    group_str);
+
+		snprintf(xpath, sizeof(xpath), FRR_PIM_MROUTE_XPATH,
+			 FRR_PIM_AF_XPATH_VAL, buf, group_str);
+		return nb_cli_apply_changes(vty, xpath);
 	}
 
-	return nb_cli_apply_changes(vty, FRR_PIM_MROUTE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL, source_str,
-				    group_str);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_MROUTE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL, source_str, group_str);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_no_ip_mroute_cmd(struct vty *vty, const char *interface,
 				 const char *group_str, const char *source_str)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
 	if (!source_str) {
 		char buf[SRCDEST2STR_BUFFER];
 
 		inet_ntop(AF_INET6, &in6addr_any, buf, sizeof(buf));
-		return nb_cli_apply_changes(vty, FRR_PIM_MROUTE_XPATH,
-					    FRR_PIM_AF_XPATH_VAL, buf,
-					    group_str);
+
+		snprintf(xpath, sizeof(xpath), FRR_PIM_MROUTE_XPATH,
+			 FRR_PIM_AF_XPATH_VAL, buf, group_str);
+		return nb_cli_apply_changes(vty, xpath);
 	}
 
-	return nb_cli_apply_changes(vty, FRR_PIM_MROUTE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL, source_str,
-				    group_str);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_MROUTE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL, source_str, group_str);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_rp_cmd(struct vty *vty, const char *rp_str,
@@ -3332,6 +3366,7 @@ int gm_process_query_max_response_time_cmd(struct vty *vty,
 					   const char *qmrt_str)
 {
 	const struct lyd_node *pim_enable_dnode;
+	char xpath[XPATH_MAXLEN];
 
 	pim_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
 					   FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
@@ -3347,22 +3382,28 @@ int gm_process_query_max_response_time_cmd(struct vty *vty,
 
 	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_MODIFY,
 			      qmrt_str);
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int gm_process_no_query_max_response_time_cmd(struct vty *vty)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./query-max-response-time", NB_OP_DESTROY,
 			      NULL);
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int gm_process_last_member_query_count_cmd(struct vty *vty,
 					   const char *lmqc_str)
 {
 	const struct lyd_node *pim_enable_dnode;
+	char xpath[XPATH_MAXLEN];
 
 	pim_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
 					   FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
@@ -3377,22 +3418,29 @@ int gm_process_last_member_query_count_cmd(struct vty *vty,
 
 	nb_cli_enqueue_change(vty, "./robustness-variable", NB_OP_MODIFY,
 			      lmqc_str);
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int gm_process_no_last_member_query_count_cmd(struct vty *vty)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./robustness-variable", NB_OP_DESTROY,
 			      NULL);
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int gm_process_last_member_query_interval_cmd(struct vty *vty,
 					      const char *lmqi_str)
 {
 	const struct lyd_node *pim_enable_dnode;
+	char xpath[XPATH_MAXLEN];
 
 	pim_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
 					   FRR_PIM_ENABLE_XPATH, VTY_CURR_XPATH,
@@ -3407,16 +3455,22 @@ int gm_process_last_member_query_interval_cmd(struct vty *vty,
 
 	nb_cli_enqueue_change(vty, "./last-member-query-interval", NB_OP_MODIFY,
 			      lmqi_str);
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int gm_process_no_last_member_query_interval_cmd(struct vty *vty)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./last-member-query-interval",
 			      NB_OP_DESTROY, NULL);
-	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+
+	snprintf(xpath, sizeof(xpath), FRR_GMP_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_ssmpingd_cmd(struct vty *vty, enum nb_operation operation,
@@ -3443,6 +3497,7 @@ int pim_process_ssmpingd_cmd(struct vty *vty, enum nb_operation operation,
 int pim_process_bsm_cmd(struct vty *vty)
 {
 	const struct lyd_node *gm_enable_dnode;
+	char xpath[XPATH_MAXLEN];
 
 	gm_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
 					  FRR_GMP_ENABLE_XPATH, VTY_CURR_XPATH,
@@ -3458,21 +3513,25 @@ int pim_process_bsm_cmd(struct vty *vty)
 
 	nb_cli_enqueue_change(vty, "./bsm", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_no_bsm_cmd(struct vty *vty)
 {
+	char xpath[XPATH_MAXLEN];
 	nb_cli_enqueue_change(vty, "./bsm", NB_OP_MODIFY, "false");
 
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_unicast_bsm_cmd(struct vty *vty)
 {
 	const struct lyd_node *gm_enable_dnode;
+	char xpath[XPATH_MAXLEN];
 
 	gm_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode,
 					  FRR_GMP_ENABLE_XPATH, VTY_CURR_XPATH,
@@ -3488,16 +3547,20 @@ int pim_process_unicast_bsm_cmd(struct vty *vty)
 
 	nb_cli_enqueue_change(vty, "./unicast-bsm", NB_OP_MODIFY, "true");
 
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 int pim_process_no_unicast_bsm_cmd(struct vty *vty)
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./unicast-bsm", NB_OP_MODIFY, "false");
 
-	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH,
-				    FRR_PIM_AF_XPATH_VAL);
+	snprintf(xpath, sizeof(xpath), FRR_PIM_INTERFACE_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 static void show_scan_oil_stats(struct pim_instance *pim, struct vty *vty,

--- a/ripd/rip_cli.c
+++ b/ripd/rip_cli.c
@@ -228,6 +228,8 @@ DEFPY_YANG (rip_distance_source,
        "IP source prefix\n"
        "Access list name\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	if (!no) {
 		nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
 		nb_cli_enqueue_change(vty, "./distance", NB_OP_MODIFY,
@@ -237,8 +239,9 @@ DEFPY_YANG (rip_distance_source,
 	} else
 		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./distance/source[prefix='%s']",
-				    prefix_str);
+	snprintf(xpath, sizeof(xpath), "./distance/source[prefix='%s']",
+		 prefix_str);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_rip_distance_source(struct vty *vty, const struct lyd_node *dnode,
@@ -334,6 +337,8 @@ DEFPY_YANG (rip_offset_list,
        "Metric value\n"
        "Interface to match\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	if (!no) {
 		nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
 		nb_cli_enqueue_change(vty, "./access-list", NB_OP_MODIFY, acl);
@@ -342,9 +347,11 @@ DEFPY_YANG (rip_offset_list,
 	} else
 		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(
-		vty, "./offset-list[interface='%s'][direction='%s']",
-		ifname ? ifname : "*", direction);
+	snprintf(xpath, sizeof(xpath),
+		 "./offset-list[interface='%s'][direction='%s']",
+		 ifname ? ifname : "*", direction);
+
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_rip_offset_list(struct vty *vty, const struct lyd_node *dnode,
@@ -446,6 +453,8 @@ DEFPY_YANG (rip_redistribute,
        "Route map reference\n"
        "Pointer to route-map entries\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	if (!no) {
 		nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
 		nb_cli_enqueue_change(vty, "./route-map",
@@ -457,8 +466,9 @@ DEFPY_YANG (rip_redistribute,
 	} else
 		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./redistribute[protocol='%s']",
-				    protocol);
+	snprintf(xpath, sizeof(xpath), "./redistribute[protocol='%s']",
+		 protocol);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_rip_redistribute(struct vty *vty, const struct lyd_node *dnode,

--- a/ripngd/ripng_cli.c
+++ b/ripngd/ripng_cli.c
@@ -240,6 +240,8 @@ DEFPY_YANG (ripng_offset_list,
        "Metric value\n"
        "Interface to match\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	if (!no) {
 		nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
 		nb_cli_enqueue_change(vty, "./access-list", NB_OP_MODIFY, acl);
@@ -248,9 +250,10 @@ DEFPY_YANG (ripng_offset_list,
 	} else
 		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(
-		vty, "./offset-list[interface='%s'][direction='%s']",
-		ifname ? ifname : "*", direction);
+	snprintf(xpath, sizeof(xpath),
+		 "./offset-list[interface='%s'][direction='%s']",
+		 ifname ? ifname : "*", direction);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_ripng_offset_list(struct vty *vty, const struct lyd_node *dnode,
@@ -307,6 +310,8 @@ DEFPY_YANG (ripng_redistribute,
        "Route map reference\n"
        "Pointer to route-map entries\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	if (!no) {
 		nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
 		nb_cli_enqueue_change(vty, "./route-map",
@@ -318,8 +323,9 @@ DEFPY_YANG (ripng_redistribute,
 	} else
 		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
-	return nb_cli_apply_changes(vty, "./redistribute[protocol='%s']",
-				    protocol);
+	snprintf(xpath, sizeof(xpath), "./redistribute[protocol='%s']",
+		 protocol);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_ripng_redistribute(struct vty *vty, const struct lyd_node *dnode,

--- a/vrrpd/vrrp_vty.c
+++ b/vrrpd/vrrp_vty.c
@@ -60,6 +60,7 @@ DEFPY_YANG(vrrp_vrid,
       VRRP_VERSION_STR)
 {
 	char valbuf[20];
+	char xpath[XPATH_MAXLEN];
 
 	snprintf(valbuf, sizeof(valbuf), "%ld", version ? version : vd.version);
 
@@ -70,7 +71,8 @@ DEFPY_YANG(vrrp_vrid,
 		nb_cli_enqueue_change(vty, "./version", NB_OP_MODIFY, valbuf);
 	}
 
-	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
+	snprintf(xpath, sizeof(xpath), VRRP_XPATH_ENTRY, vrid);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_vrrp(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
@@ -95,10 +97,13 @@ DEFPY_YANG(vrrp_shutdown,
       VRRP_VRID_STR
       "Force VRRP router into administrative shutdown\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./shutdown", NB_OP_MODIFY,
 			      no ? "false" : "true");
 
-	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
+	snprintf(xpath, sizeof(xpath), VRRP_XPATH_ENTRY, vrid);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_shutdown(struct vty *vty, const struct lyd_node *dnode,
@@ -121,9 +126,13 @@ DEFPY_YANG(vrrp_priority,
       VRRP_PRIORITY_STR
       "Priority value\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./priority", NB_OP_MODIFY, priority_str);
 
-	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
+	snprintf(xpath, sizeof(xpath),  VRRP_XPATH_ENTRY, vrid);
+
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 /*
@@ -138,9 +147,12 @@ DEFPY_YANG(no_vrrp_priority,
       VRRP_PRIORITY_STR
       "Priority value\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./priority", NB_OP_MODIFY, NULL);
 
-	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
+	snprintf(xpath, sizeof(xpath),  VRRP_XPATH_ENTRY, vrid);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_priority(struct vty *vty, const struct lyd_node *dnode,
@@ -163,6 +175,7 @@ DEFPY_YANG(vrrp_advertisement_interval,
       "Advertisement interval in milliseconds; must be multiple of 10\n")
 {
 	char val[20];
+	char xpath[XPATH_MAXLEN];
 
 	/* all internal computations are in centiseconds */
 	advertisement_interval /= CS2MS;
@@ -170,7 +183,8 @@ DEFPY_YANG(vrrp_advertisement_interval,
 	nb_cli_enqueue_change(vty, "./advertisement-interval", NB_OP_MODIFY,
 			      val);
 
-	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
+	snprintf(xpath, sizeof(xpath),  VRRP_XPATH_ENTRY, vrid);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 /*
@@ -183,10 +197,14 @@ DEFPY_YANG(no_vrrp_advertisement_interval,
       NO_STR VRRP_STR VRRP_VRID_STR VRRP_ADVINT_STR
       "Advertisement interval in milliseconds; must be multiple of 10\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./advertisement-interval", NB_OP_MODIFY,
 			      NULL);
 
-	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
+	snprintf(xpath, sizeof(xpath), VRRP_XPATH_ENTRY, vrid);
+
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_advertisement_interval(struct vty *vty, const struct lyd_node *dnode,
@@ -212,10 +230,13 @@ DEFPY_YANG(vrrp_ip,
       "Add IPv4 address\n"
       VRRP_IP_STR)
 {
+	char xpath[XPATH_MAXLEN];
 	int op = no ? NB_OP_DESTROY : NB_OP_CREATE;
+
 	nb_cli_enqueue_change(vty, "./v4/virtual-address", op, ip_str);
 
-	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
+	snprintf(xpath, sizeof(xpath),  VRRP_XPATH_ENTRY, vrid);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_ip(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
@@ -241,9 +262,12 @@ DEFPY_YANG(vrrp_ip6,
       VRRP_IP_STR)
 {
 	int op = no ? NB_OP_DESTROY : NB_OP_CREATE;
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./v6/virtual-address", op, ipv6_str);
 
-	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
+	snprintf(xpath, sizeof(xpath),  VRRP_XPATH_ENTRY, vrid);
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_ipv6(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
@@ -266,10 +290,14 @@ DEFPY_YANG(vrrp_preempt,
       VRRP_VRID_STR
       "Preempt mode\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./preempt", NB_OP_MODIFY,
 			      no ? "false" : "true");
 
-	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
+	snprintf(xpath, sizeof(xpath),  VRRP_XPATH_ENTRY, vrid);
+
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_preempt(struct vty *vty, const struct lyd_node *dnode,
@@ -293,10 +321,14 @@ DEFPY_YANG(vrrp_checksum_with_ipv4_pseudoheader,
       VRRP_VRID_STR
       "Checksum mode in VRRPv3\n")
 {
+	char xpath[XPATH_MAXLEN];
+
 	nb_cli_enqueue_change(vty, "./checksum-with-ipv4-pseudoheader",
 			      NB_OP_MODIFY, no ? "false" : "true");
 
-	return nb_cli_apply_changes(vty, VRRP_XPATH_ENTRY, vrid);
+	snprintf(xpath, sizeof(xpath),  VRRP_XPATH_ENTRY, vrid);
+
+	return nb_cli_apply_changes(vty, xpath);
 }
 
 void cli_show_checksum_with_ipv4_pseudoheader(struct vty *vty,


### PR DESCRIPTION
The call to nb_cli_apply_changes takes a variable list of arguments that are string formated via the va_arg calls.  The problem with this is that in interface_magic string formatting is already done and passed in.  If the user passes a `%n`( or really any string formatter as part of the interface name ) the double format allows stack overwrites of the string.  This is a problem because the nb_cli_apply_changes call was sometimes being used to format the strings and sometimes it wasn't leading to the ability to have a double string formatting allowing bad semantics to happen because of the string replacement.  Fix this problem by changing the api of the nb_cli_apply_changes and nb_cli_apply_changes_clear_pending to not allow a possibility of this happening.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>