### PR TITLE
zebra_fpm: Add support for other protocols in fpm:netlink

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -223,7 +223,7 @@ static inline bool is_selfroute(int proto)
 	return false;
 }
 
-static inline int zebra2proto(int proto)
+int zebra2proto(int proto)
 {
 	switch (proto) {
 	case ZEBRA_ROUTE_BABEL:

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -150,6 +150,9 @@ const char *ifa_flags2str(uint32_t flags, char *buf, size_t buflen);
 const char *nh_flags2str(uint32_t flags, char *buf, size_t buflen);
 
 void nl_dump(void *msg, size_t msglen);
+
+extern int zebra2proto(int proto);
+
 #endif /* NETLINK_DEBUG */
 
 #ifdef __cplusplus

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -253,14 +253,7 @@ static int netlink_route_info_add_nh(struct netlink_route_info *ri,
  */
 static uint8_t netlink_proto_from_route_type(int type)
 {
-	switch (type) {
-	case ZEBRA_ROUTE_KERNEL:
-	case ZEBRA_ROUTE_CONNECT:
-		return RTPROT_KERNEL;
-
-	default:
-		return RTPROT_ZEBRA;
-	}
+	return zebra2proto(type);
 }
 
 /*


### PR DESCRIPTION
    fpm:netlink format doesn't indicate the protocol information
    in routes of BGP, OSPF and other protocols. Routes of those
    protocols just indicate protocol as zebra.

    The below route is actually BGP route but 'proto': 11
    indicates that it is zebra.

    {'attrs': [('RTA_DST', 'dummy'),
               ('RTA_PRIORITY', 0),
               ('RTA_GATEWAY', 'dummy'),
               ('RTA_OIF', 2)],
     'dst_len': 32,
     'family': 2,
     'flags': 0,
     'header': {'flags': 1025,
                'length': 60,
                'pid': 3160253895,
                'sequence_number': 0,
                'type': 24},
     'proto': 11,
     'scope': 0,
     'src_len': 0,
     'table': 254,
     'tos': 0,
     'type': 1}

    with this change it is now seen with 'proto': 186
    indicates that it is BGP.

    {'attrs': [('RTA_DST', 'dummy'),
               ('RTA_PRIORITY', 0),
               ('RTA_GATEWAY', 'dummy'),
               ('RTA_OIF', 2)],
     'dst_len': 32,
     'family': 2,
     'flags': 0,
     'header': {'flags': 1025,
                'length': 60,
                'pid': 3160253895,
                'sequence_number': 0,
                'type': 24},
     'proto': 186,
     'scope': 0,
     'src_len': 0,
     'table': 254,
     'tos': 0,
     'type': 1}

Signed-off-by: Spoorthi K <spk@redhat.com>