### PR TITLE
zebra: use typesafe lib lists in zebra dplane

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -89,7 +89,7 @@ struct fpm_nl_ctx {
 	 * When a FPM server connection becomes a bottleneck, we must keep the
 	 * data plane contexts until we get a chance to process them.
 	 */
-	struct dplane_ctx_q ctxqueue;
+	struct dplane_ctx_list_head ctxqueue;
 	pthread_mutex_t ctxqueue_mutex;
 
 	/* data plane events. */
@@ -1473,7 +1473,7 @@ static int fpm_nl_start(struct zebra_dplane_provider *prov)
 	fnc->socket = -1;
 	fnc->disabled = true;
 	fnc->prov = prov;
-	TAILQ_INIT(&fnc->ctxqueue);
+	dplane_ctx_q_init(&fnc->ctxqueue);
 	pthread_mutex_init(&fnc->ctxqueue_mutex, NULL);
 
 	/* Set default values. */

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1516,13 +1516,13 @@ int kernel_dplane_read(struct zebra_dplane_info *info)
 	return 0;
 }
 
-void kernel_update_multi(struct dplane_ctx_q *ctx_list)
+void kernel_update_multi(struct dplane_ctx_list_head *ctx_list)
 {
 	struct zebra_dplane_ctx *ctx;
-	struct dplane_ctx_q handled_list;
+	struct dplane_ctx_list_head handled_list;
 	enum zebra_dplane_result res = ZEBRA_DPLANE_REQUEST_SUCCESS;
 
-	TAILQ_INIT(&handled_list);
+	dplane_ctx_q_init(&handled_list);
 
 	while (true) {
 		ctx = dplane_ctx_dequeue(ctx_list);
@@ -1642,7 +1642,7 @@ void kernel_update_multi(struct dplane_ctx_q *ctx_list)
 		dplane_ctx_enqueue_tail(&handled_list, ctx);
 	}
 
-	TAILQ_INIT(ctx_list);
+	dplane_ctx_q_init(ctx_list);
 	dplane_ctx_list_append(ctx_list, &handled_list);
 }
 

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -121,7 +121,7 @@ extern int kernel_del_mac_nhg(uint32_t nhg_id);
 /*
  * Message batching interface.
  */
-extern void kernel_update_multi(struct dplane_ctx_q *ctx_list);
+extern void kernel_update_multi(struct dplane_ctx_list_head *ctx_list);
 
 /*
  * Called by the dplane pthread to read incoming OS messages and dispatch them.


### PR DESCRIPTION
Replace some of the old queue/DLIST macros with lib/typesafe dlists. This cleans up some SA reports (we think).
