### PR TITLE
*: fix time truncation in many places

### DIFF
--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -327,7 +327,8 @@ void bgp_damp_info_free(struct bgp_damp_info *bdi, int withdraw, afi_t afi,
 	XFREE(MTYPE_BGP_DAMP_INFO, bdi);
 }
 
-static void bgp_damp_parameter_set(int hlife, int reuse, int sup, int maxsup,
+static void bgp_damp_parameter_set(time_t hlife, unsigned int reuse,
+				   unsigned int sup, time_t maxsup,
 				   struct bgp_damp_config *bdc)
 {
 	double reuse_max_ratio;

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -37,6 +37,7 @@
 #include "if.h"
 #include "table.h"
 #include "memory.h"
+#include "network.h"
 #include "command.h"
 #include "stream.h"
 #include "log.h"
@@ -83,7 +84,7 @@ struct eigrp_interface *eigrp_if_new(struct eigrp *eigrp, struct interface *ifp,
 	/* Initialize neighbor list. */
 	ei->nbrs = list_new();
 
-	ei->crypt_seqnum = time(NULL);
+	ei->crypt_seqnum = frr_sequence32_next();
 
 	/* Initialize lists */
 	for (i = 0; i < EIGRP_FILTER_MAX; i++) {

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -2714,12 +2714,14 @@ void isis_spf_init(void)
 
 void isis_spf_print(struct isis_spftree *spftree, struct vty *vty)
 {
+	uint64_t last_run_duration = spftree->last_run_duration;
+
 	vty_out(vty, "      last run elapsed  : ");
 	vty_out_timestr(vty, spftree->last_run_timestamp);
 	vty_out(vty, "\n");
 
-	vty_out(vty, "      last run duration : %u usec\n",
-		(uint32_t)spftree->last_run_duration);
+	vty_out(vty, "      last run duration : %" PRIu64 " usec\n",
+		last_run_duration);
 
 	vty_out(vty, "      run count         : %u\n", spftree->runcount);
 }

--- a/ldpd/logmsg.c
+++ b/ldpd/logmsg.c
@@ -137,7 +137,7 @@ log_time(time_t t)
 	char		*buf;
 	static char	 tfbuf[TF_BUFS][TF_LEN];	/* ring buffer */
 	static int	 idx = 0;
-	unsigned int	 sec, min, hrs, day, week;
+	uint64_t	 sec, min, hrs, day, week;
 
 	buf = tfbuf[idx++];
 	if (idx == TF_BUFS)
@@ -155,11 +155,17 @@ log_time(time_t t)
 	week /= 7;
 
 	if (week > 0)
-		snprintf(buf, TF_LEN, "%02uw%01ud%02uh", week, day, hrs);
+		snprintfrr(buf, TF_LEN,
+			   "%02" PRIu64 "w%01" PRIu64 "d%02" PRIu64 "h", week,
+			   day, hrs);
 	else if (day > 0)
-		snprintf(buf, TF_LEN, "%01ud%02uh%02um", day, hrs, min);
+		snprintfrr(buf, TF_LEN,
+			   "%01" PRIu64 "d%02" PRIu64 "h%02" PRIu64 "m", day,
+			   hrs, min);
 	else
-		snprintf(buf, TF_LEN, "%02u:%02u:%02u", hrs, min, sec);
+		snprintfrr(buf, TF_LEN,
+			   "%02" PRIu64 ":%02" PRIu64 ":%02" PRIu64, hrs, min,
+			   sec);
 
 	return (buf);
 }

--- a/lib/network.c
+++ b/lib/network.c
@@ -122,3 +122,24 @@ float ntohf(float net)
 {
 	return htonf(net);
 }
+
+uint64_t frr_sequence_next(void)
+{
+	static uint64_t last_sequence;
+	struct timespec ts;
+
+	(void)clock_gettime(CLOCK_MONOTONIC, &ts);
+	if (last_sequence == (uint64_t)ts.tv_sec) {
+		last_sequence++;
+		return last_sequence;
+	}
+
+	last_sequence = ts.tv_sec;
+	return last_sequence;
+}
+
+uint32_t frr_sequence32_next(void)
+{
+	/* coverity[Y2K38_SAFETY] */
+	return (uint32_t)frr_sequence_next();
+}

--- a/lib/network.h
+++ b/lib/network.h
@@ -82,6 +82,24 @@ extern float ntohf(float);
 #endif
 
 /**
+ * Generate a sequence number using monotonic clock with a same second call
+ * protection to help guarantee a unique incremental sequence number that never
+ * goes back (except when wrapping/overflow).
+ *
+ * **NOTE** this function is not thread safe since it uses `static` variable.
+ *
+ * This function and `frr_sequence32_next` should be used to initialize
+ * sequence numbers without directly calling other `time_t` returning
+ * functions because of `time_t` truncation warnings.
+ *
+ * \returns `uint64_t` number based on the monotonic clock.
+ */
+extern uint64_t frr_sequence_next(void);
+
+/** Same as `frr_sequence_next` but returns truncated number. */
+extern uint32_t frr_sequence32_next(void);
+
+/**
  * Helper function that returns a random long value. The main purpose of
  * this function is to hide a `random()` call that gets flagged by coverity
  * scan and put it into one place.

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -28,6 +28,7 @@
 #include "linklist.h"
 #include "lib_errors.h"
 #include "checksum.h"
+#include "network.h"
 
 #include "ospf6_proto.h"
 #include "ospf6_lsa.h"
@@ -2300,7 +2301,7 @@ static uint16_t ospf6_make_dbdesc(struct ospf6_neighbor *on, struct stream *s)
 	/* if this is initial one, initialize sequence number for DbDesc */
 	if (CHECK_FLAG(on->dbdesc_bits, OSPF6_DBDESC_IBIT)
 	    && (on->dbdesc_seqnum == 0)) {
-		on->dbdesc_seqnum = monotime(NULL);
+		on->dbdesc_seqnum = frr_sequence32_next();
 	}
 
 	/* reserved */

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -30,6 +30,7 @@
 #include "command.h"
 #include "stream.h"
 #include "log.h"
+#include "network.h"
 #include "zclient.h"
 #include "bfd.h"
 #include "ldp_sync.h"
@@ -274,7 +275,7 @@ struct ospf_interface *ospf_if_new(struct ospf *ospf, struct interface *ifp,
 	oi->t_ls_upd_event = NULL;
 	oi->t_ls_ack_direct = NULL;
 
-	oi->crypt_seqnum = time(NULL);
+	oi->crypt_seqnum = frr_sequence32_next();
 
 	ospf_opaque_type9_lsa_init(oi);
 

--- a/pimd/mtracebis_netlink.c
+++ b/pimd/mtracebis_netlink.c
@@ -92,7 +92,7 @@ int rtnl_open_byproto(struct rtnl_handle *rth, unsigned subscriptions,
 			rth->local.nl_family);
 		return -1;
 	}
-	rth->seq = (uint32_t)time(NULL);
+	rth->seq = getpid();
 	return 0;
 }
 

--- a/zebra/zebra_netns_id.c
+++ b/zebra/zebra_netns_id.c
@@ -23,6 +23,7 @@
 #include "vrf.h"
 #include "log.h"
 #include "lib_errors.h"
+#include "network.h"
 
 #include "zebra/rib.h"
 #include "zebra/zebra_dplane.h"
@@ -73,7 +74,7 @@ static struct nlmsghdr *initiate_nlh(char *buf, unsigned int *seq, int type)
 	nlh->nlmsg_flags = NLM_F_REQUEST;
 	if (type == RTM_NEWNSID)
 		nlh->nlmsg_flags |= NLM_F_ACK;
-	nlh->nlmsg_seq = *seq = time(NULL);
+	nlh->nlmsg_seq = *seq = frr_sequence32_next();
 	return nlh;
 }
 


### PR DESCRIPTION
Changes:
- Introduce new function for generating sequence numbers (clears up coverity scan warnings about time truncation)
  - CIDs 1519812, 1519786, 1519783 and 1519772
- Replace PIM's tool mtracebis `time(NULL)` sequence seed with `getpid()`
  - CID 1519828
- Increase `ldpd` log function variables storage for `time_t`
  - CID 1519735
- Fix BGP dampening function prototype to avoid time truncation
  - CID 1519802
- Fix IS-IS SPF show command time truncation
  - CID 1519793

Please read individual commits for more information.