### PR TITLE
bgpd: evpn route detail json display non prett

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -4807,8 +4807,15 @@ DEFUN(show_bgp_l2vpn_evpn_route,
 
 	evpn_show_all_routes(vty, bgp, type, json, detail);
 
-	if (uj)
-		vty_json(vty, json);
+	if (uj) {
+		if (detail) {
+			vty_out(vty, "%s\n", json_object_to_json_string(json));
+			json_object_free(json);
+		} else {
+			vty_json(vty, json);
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
For BGP evpn route table detail JSON to use non pretty form of display.

Problem:

In scaled EVPN route table detail JSON dump occupies high resources (CPU + memory) of the system. 
In high scale EVPN route dump using pretty form
hogs CPU for a while which can trigger watchfrr
to kill bgpd.

Solution:
Avoid pretty JSON print for detail version dump



Signed-off-by: Chirag Shah <chirag@nvidia.com>