### PR TITLE
topotests: fix bgp_vpnv4_noretain

### DIFF
--- a/tests/topotests/bgp_vpnv4_noretain/r1/ipv4_vpn_routes.json
+++ b/tests/topotests/bgp_vpnv4_noretain/r1/ipv4_vpn_routes.json
@@ -1,7 +1,6 @@
 {
    "vrfId":0,
    "vrfName":"default",
-   "tableVersion":1,
    "routerId":"1.1.1.1",
    "defaultLocPrf":100,
    "localAS":65500,
@@ -17,7 +16,6 @@
                   "prefix":"10.201.0.0",
                   "prefixLen":24,
                   "network":"10.201.0.0\/24",
-                  "version":1,
                   "metric":0,
                   "weight":32768,
                   "peerId":"(unspec)",
@@ -28,6 +26,7 @@
                   "nexthops":[
                      {
                         "ip":"0.0.0.0",
+                        "hostname":"r1",
                         "afi":"ipv4",
                         "used":true
                      }
@@ -45,7 +44,6 @@
                   "prefix":"10.200.0.0",
                   "prefixLen":24,
                   "network":"10.200.0.0\/24",
-                  "version":1,
                   "metric":0,
                   "locPrf":100,
                   "weight":0,
@@ -55,6 +53,7 @@
                   "nexthops":[
                      {
                         "ip":"10.125.0.2",
+                        "hostname":"r2",
                         "afi":"ipv4",
                         "used":true
                      }

--- a/tests/topotests/bgp_vpnv4_noretain/r1/ipv4_vpn_routes_unfiltered.json
+++ b/tests/topotests/bgp_vpnv4_noretain/r1/ipv4_vpn_routes_unfiltered.json
@@ -1,7 +1,6 @@
 {
    "vrfId":0,
    "vrfName":"default",
-   "tableVersion":1,
    "routerId":"1.1.1.1",
    "defaultLocPrf":100,
    "localAS":65500,
@@ -17,7 +16,6 @@
                   "prefix":"10.201.0.0",
                   "prefixLen":24,
                   "network":"10.201.0.0\/24",
-                  "version":1,
                   "metric":0,
                   "weight":32768,
                   "peerId":"(unspec)",
@@ -28,6 +26,7 @@
                   "nexthops":[
                      {
                         "ip":"0.0.0.0",
+                        "hostname":"r1",
                         "afi":"ipv4",
                         "used":true
                      }
@@ -45,7 +44,6 @@
                   "prefix":"10.200.0.0",
                   "prefixLen":24,
                   "network":"10.200.0.0\/24",
-                  "version":1,
                   "metric":0,
                   "locPrf":100,
                   "weight":0,
@@ -55,6 +53,7 @@
                   "nexthops":[
                      {
                         "ip":"10.125.0.2",
+                        "hostname":"r2",
                         "afi":"ipv4",
                         "used":true
                      }
@@ -72,7 +71,6 @@
                   "prefix":"10.210.0.0",
                   "prefixLen":24,
                   "network":"10.210.0.0\/24",
-                  "version":1,
                   "metric":0,
                   "locPrf":100,
                   "weight":0,
@@ -82,6 +80,7 @@
                   "nexthops":[
                      {
                         "ip":"10.125.0.2",
+                        "hostname":"r2",
                         "afi":"ipv4",
                         "used":true
                      }


### PR DESCRIPTION
Fix the following issues:
- two tests are done in one function. Dispatch the tests in two functions to help the test debug.
- the first test passes even if a third prefix is not filtered. Match the exact to avoid false positive.
- the expected values contains variable like version. Do no check variable values.

Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>