### PR TITLE
build: consistently mkdir -p output for redirect

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -567,6 +567,7 @@ rt_enabled += --enabled zebra
 endif
 
 lib/route_types.h: $(top_srcdir)/lib/route_types.txt $(top_srcdir)/lib/route_types.pl
+	@$(MKDIR_P) lib
 	$(PERL) $(top_srcdir)/lib/route_types.pl $(rt_enabled) < $(top_srcdir)/lib/route_types.txt > $@
 DISTCLEANFILES += lib/route_types.h
 
@@ -581,6 +582,7 @@ PHONY_GITVERSION=lib/gitversion.h.tmp
 .SILENT: lib/gitversion.h lib/gitversion.h.tmp
 GITH=lib/gitversion.h
 lib/gitversion.h.tmp: $(top_srcdir)/.git
+	@$(MKDIR_P) lib
 	$(PERL) $(top_srcdir)/lib/gitversion.pl $(top_srcdir) > ${GITH}.tmp
 lib/gitversion.h: lib/gitversion.h.tmp
 	{ test -f ${GITH} && diff -s -q ${GITH}.tmp ${GITH}; } || cp ${GITH}.tmp ${GITH}

--- a/tests/isisd/subdir.am
+++ b/tests/isisd/subdir.am
@@ -21,7 +21,7 @@ EXTRA_DIST += \
 	# end
 
 tests/isisd/test_fuzz_isis_tlv_tests.h: $(top_srcdir)/tests/isisd/test_fuzz_isis_tlv_tests.h.gz
-	@mkdir -p tests/isisd
+	@$(MKDIR_P) tests/isisd
 	$(AM_V_GEN)gzip -d < $(top_srcdir)/tests/isisd/test_fuzz_isis_tlv_tests.h.gz > "$@"
 CLEANFILES += tests/isisd/test_fuzz_isis_tlv_tests.h
 

--- a/tests/lib/subdir.am
+++ b/tests/lib/subdir.am
@@ -93,7 +93,7 @@ tests_lib_cli_test_commands_LDADD = $(ALL_TESTS_LDADD)
 nodist_tests_lib_cli_test_commands_SOURCES = tests/lib/cli/test_commands_defun.c
 tests_lib_cli_test_commands_SOURCES = tests/lib/cli/test_commands.c tests/helpers/c/prng.c
 tests/lib/cli/test_commands_defun.c: vtysh/vtysh_cmd.c
-	@mkdir -p tests/lib/cli
+	@$(MKDIR_P) tests/lib/cli
 	$(AM_V_GEN)sed \
 		-e 's%"vtysh/vtysh\.h"%"tests/helpers/c/tests.h"%' \
 		-e 's/vtysh_init_cmd/test_init_cmd/' \

--- a/vtysh/subdir.am
+++ b/vtysh/subdir.am
@@ -37,5 +37,5 @@ $(vtysh_vtysh_OBJECTS): vtysh/vtysh_daemons.h
 
 CLEANFILES += vtysh/vtysh_daemons.h
 vtysh/vtysh_daemons.h:
-	mkdir -p vtysh
+	@$(MKDIR_P) vtysh
 	$(PERL) $(top_srcdir)/vtysh/daemons.pl $(vtysh_daemons) > vtysh/vtysh_daemons.h

--- a/yang/embedmodel.py
+++ b/yang/embedmodel.py
@@ -12,8 +12,10 @@ inname = sys.argv[1]
 outname = sys.argv[2]
 
 outdir = os.path.dirname(os.path.abspath(outname))
-if not os.path.isdir(outdir):
+try:
     os.makedirs(outdir)
+except FileExistsError:
+    pass
 
 # these are regexes to avoid a compile-time/host dependency on yang-tools
 # or python-yang.  Cross-compiling FRR is already somewhat involved, no need


### PR DESCRIPTION
When running the build in a separate build directory, redirecting output into a file can error out if the directory does not exist yet.  Some places already had `mkdir -p` calls, but not all.

Make all occurences of this consistently use `@$(MKDIR_P)`.

(Extension of PR #12575 to catch more places.)