### PR TITLE
lib: Ensure two threads cannot be raised privs at the same time.

### DIFF
--- a/lib/privs.c
+++ b/lib/privs.c
@@ -16,6 +16,11 @@
 DEFINE_MTYPE_STATIC(LIB, PRIVS, "Privilege information");
 
 /*
+ * Mutex used to avoid race conditions in multi-threaded processes.
+ */
+pthread_mutex_t zprivs_mutex;
+
+/*
  * Different capabilities/privileges apis have different characteristics: some
  * are process-wide, and some are per-thread.
  */
@@ -481,26 +486,26 @@ struct zebra_privs_t *_zprivs_raise(struct zebra_privs_t *privs,
 	int save_errno = errno;
 	struct zebra_privs_refs_t *refs;
 
-	if (!privs)
-		return NULL;
-
 	/*
 	 * Serialize 'raise' operations; particularly important for
 	 * OSes where privs are process-wide.
 	 */
-	frr_with_mutex (&(privs->mutex)) {
-		/* Locate ref-counting object to use */
-		refs = get_privs_refs(privs);
+	pthread_mutex_lock(&zprivs_mutex);
+	if (!privs)
+		return NULL;
+	;
 
-		if (++(refs->refcount) == 1) {
-			errno = 0;
-			if (privs->change(ZPRIVS_RAISE)) {
-				zlog_err("%s: Failed to raise privileges (%s)",
-					 funcname, safe_strerror(errno));
-			}
-			errno = save_errno;
-			refs->raised_in_funcname = funcname;
+	/* Locate ref-counting object to use */
+	refs = get_privs_refs(privs);
+
+	if (++(refs->refcount) == 1) {
+		errno = 0;
+		if (privs->change(ZPRIVS_RAISE)) {
+			zlog_err("%s: Failed to raise privileges (%s)",
+				 funcname, safe_strerror(errno));
 		}
+		errno = save_errno;
+		refs->raised_in_funcname = funcname;
 	}
 
 	return privs;
@@ -511,13 +516,11 @@ void _zprivs_lower(struct zebra_privs_t **privs)
 	int save_errno = errno;
 	struct zebra_privs_refs_t *refs;
 
-	if (!*privs)
-		return;
-
 	/* Serialize 'lower privs' operation - particularly important
 	 * when OS privs are process-wide.
 	 */
-	frr_with_mutex (&(*privs)->mutex) {
+	if (*privs) {
+
 		refs = get_privs_refs(*privs);
 
 		if (--(refs->refcount) == 0) {
@@ -530,22 +533,26 @@ void _zprivs_lower(struct zebra_privs_t **privs)
 			errno = save_errno;
 			refs->raised_in_funcname = NULL;
 		}
-	}
 
 	*privs = NULL;
+	}
+	pthread_mutex_unlock(&zprivs_mutex);
 }
 
 void zprivs_preinit(struct zebra_privs_t *zprivs)
 {
 	struct passwd *pwentry = NULL;
 	struct group *grentry = NULL;
+	pthread_mutexattr_t ma;
 
 	if (!zprivs) {
 		fprintf(stderr, "zprivs_init: called with NULL arg!\n");
 		exit(1);
 	}
 
-	pthread_mutex_init(&(zprivs->mutex), NULL);
+	pthread_mutexattr_init(&ma);
+	pthread_mutexattr_settype(&ma, PTHREAD_MUTEX_RECURSIVE);
+	pthread_mutex_init(&zprivs_mutex, &ma);
 	zprivs->process_refs.refcount = 0;
 	zprivs->process_refs.raised_in_funcname = NULL;
 	STAILQ_INIT(&zprivs->thread_refs);

--- a/lib/privs.h
+++ b/lib/privs.h
@@ -58,13 +58,12 @@ struct zebra_privs_t {
 	int cap_num_p;		      /* number of caps in arrays */
 	int cap_num_i;
 
-	/* Mutex and counter used to avoid race conditions in multi-threaded
+	/* counter used to avoid race conditions in multi-threaded
 	 * processes. If privs status is process-wide, we need to
 	 * control changes to the privilege status among threads.
 	 * If privs changes are per-thread, we need to be able to
 	 * manage that too.
 	 */
-	pthread_mutex_t mutex;
 	struct zebra_privs_refs_t process_refs;
 
 	STAILQ_HEAD(thread_refs_q, zebra_privs_refs_t) thread_refs;


### PR DESCRIPTION
Currently the privs code allows the developer to specify a critical section where priviledges need to be raised.  This currently suffers from the problem where two pthreads who need different priviledges raised could accidently override one another and one pthread gets higher priviliedges than intended.  Example

pthread's A and B.  A only needs CAP_NET_RAW while B needs CAP_SYS_ADMIN A runs first and raises priv's but is task swapped.  B runs then raises it's privs( even higher ) and then task swaps.  A now runs with both SYS_ADMIN and NET_RAW, lowers it's privs and continues.  B now wakes up finishes it's work and lowers it's privs.

This is especially a problem if the operator who compiled FRR does the compilation without lib_cap and raising priv's causes the program to become root.  Files can have wrong permissions then.

So let's wrap the entire critical section of raise/lowering with a global privs mutex.  So that if A and B are both trying to run at the same time one will complete before the other.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>