### PR TITLE
github: Show less information in PR status in Github for freeze label check

### DIFF
--- a/.github/workflows/freeze.yml
+++ b/.github/workflows/freeze.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   freeze_warning:
     if: ${{ contains(github.event.*.labels.*.name, 'freeze') }}
-    name: Warn before merging if a "freeze" label exists
+    name: freeze
     runs-on: ubuntu-latest
     steps:
       - name: Check for "freeze" label


### PR DESCRIPTION
Instead:

```
Warn before merging if a "freeze" label exists / Warn before merging if a "freeze" label exists
```

Do:

```
Warn before merging if a "freeze" label exists / freeze
```

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>