### PR TITLE
zebra: Send nht resolved entry up to concerned protocols in all cases

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1788,9 +1788,12 @@ no_nexthops:
 			ctxnhg->nexthop != NULL ? "" : " (empty)");
 
 	/* Set the flag about the dedicated fib list */
-	SET_FLAG(re->status, ROUTE_ENTRY_USE_FIB_NHG);
-	if (ctxnhg->nexthop)
-		copy_nexthops(&(re->fib_ng.nexthop), ctxnhg->nexthop, NULL);
+	if (zrouter.asic_notification_nexthop_control) {
+		SET_FLAG(re->status, ROUTE_ENTRY_USE_FIB_NHG);
+		if (ctxnhg->nexthop)
+			copy_nexthops(&(re->fib_ng.nexthop), ctxnhg->nexthop,
+				      NULL);
+	}
 
 check_backups:
 


### PR DESCRIPTION
There existed the idea, from Volta, that a nexthop group would not have the same nexthops installed -vs- what FRR actually sent down.  The dplane would notify you.

With the addition of 06525c4f99d4dcafdf448565f7e11bd70993697d the code was put behind a bit of a wall controlled the usage of it.

The flag ROUTE_ENTRY_USE_FIB_NHG flag was being used to control which set was being sent up to concerned parties in nexthop tracking.  Put this flag behind the wall and do not necessarily set it when we receive a data plane notification about a route being installed or not.

Fixes: #12706
Signed-off-by: Donald Sharp <sharpd@nvidia.com>