### PR TITLE
bgpd: bgp_update and bgp_withdraw never return failures

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -4429,7 +4429,7 @@ static int process_type2_route(struct peer *peer, afi_t afi, safi_t safi,
 	mpls_label_t label[BGP_MAX_LABELS] = {};
 	uint32_t num_labels = 0;
 	uint32_t eth_tag;
-	int ret;
+	int ret = 0;
 
 	/* Type-2 route should be either 33, 37 or 49 bytes or an
 	 * additional 3 bytes if there is a second label (VNI):
@@ -4522,13 +4522,13 @@ static int process_type2_route(struct peer *peer, afi_t afi, safi_t safi,
 
 	/* Process the route. */
 	if (attr)
-		ret = bgp_update(peer, (struct prefix *)&p, addpath_id, attr,
-				 afi, safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
-				 &prd, &label[0], num_labels, 0, &evpn);
+		bgp_update(peer, (struct prefix *)&p, addpath_id, attr, afi,
+			   safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd,
+			   &label[0], num_labels, 0, &evpn);
 	else
-		ret = bgp_withdraw(peer, (struct prefix *)&p, addpath_id, attr,
-				   afi, safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
-				   &prd, &label[0], num_labels, &evpn);
+		bgp_withdraw(peer, (struct prefix *)&p, addpath_id, attr, afi,
+			     safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd,
+			     &label[0], num_labels, &evpn);
 	goto done;
 
 fail:
@@ -4553,7 +4553,6 @@ static int process_type3_route(struct peer *peer, afi_t afi, safi_t safi,
 	struct prefix_evpn p;
 	uint8_t ipaddr_len;
 	uint32_t eth_tag;
-	int ret;
 
 	/* Type-3 route should be either 17 or 29 bytes: RD (8), Eth Tag (4),
 	 * IP len (1) and IP (4 or 16).
@@ -4614,14 +4613,14 @@ static int process_type3_route(struct peer *peer, afi_t afi, safi_t safi,
 
 	/* Process the route. */
 	if (attr)
-		ret = bgp_update(peer, (struct prefix *)&p, addpath_id, attr,
-				 afi, safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
-				 &prd, NULL, 0, 0, NULL);
+		bgp_update(peer, (struct prefix *)&p, addpath_id, attr, afi,
+			   safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, NULL,
+			   0, 0, NULL);
 	else
-		ret = bgp_withdraw(peer, (struct prefix *)&p, addpath_id, attr,
-				   afi, safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
-				   &prd, NULL, 0, NULL);
-	return ret;
+		bgp_withdraw(peer, (struct prefix *)&p, addpath_id, attr, afi,
+			     safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd,
+			     NULL, 0, NULL);
+	return 0;
 }
 
 /*
@@ -4637,7 +4636,6 @@ static int process_type5_route(struct peer *peer, afi_t afi, safi_t safi,
 	uint8_t ippfx_len;
 	uint32_t eth_tag;
 	mpls_label_t label; /* holds the VNI as in the packet */
-	int ret;
 	bool is_valid_update = true;
 
 	/* Type-5 route should be 34 or 58 bytes:
@@ -4749,9 +4747,9 @@ static int process_type5_route(struct peer *peer, afi_t afi, safi_t safi,
 
 	/* Process the route. */
 	if (attr && is_valid_update)
-		ret = bgp_update(peer, (struct prefix *)&p, addpath_id, attr,
-				 afi, safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
-				 &prd, &label, 1, 0, &evpn);
+		bgp_update(peer, (struct prefix *)&p, addpath_id, attr, afi,
+			   safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd,
+			   &label, 1, 0, &evpn);
 	else {
 		if (!is_valid_update) {
 			char attr_str[BUFSIZ] = {0};
@@ -4762,12 +4760,12 @@ static int process_type5_route(struct peer *peer, afi_t afi, safi_t safi,
 				peer->hostname, peer->bgp->vrf_id, &p,
 				attr_str);
 		}
-		ret = bgp_withdraw(peer, (struct prefix *)&p, addpath_id, attr,
-				   afi, safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
-				   &prd, &label, 1, &evpn);
+		bgp_withdraw(peer, (struct prefix *)&p, addpath_id, attr, afi,
+			     safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd,
+			     &label, 1, &evpn);
 	}
 
-	return ret;
+	return 0;
 }
 
 static void evpn_mpattr_encode_type5(struct stream *s, const struct prefix *p,

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -706,7 +706,6 @@ int bgp_evpn_type4_route_process(struct peer *peer, afi_t afi, safi_t safi,
 		struct attr *attr, uint8_t *pfx, int psize,
 		uint32_t addpath_id)
 {
-	int ret;
 	esi_t esi;
 	uint8_t ipaddr_len;
 	struct in_addr vtep_ip;
@@ -750,15 +749,15 @@ int bgp_evpn_type4_route_process(struct peer *peer, afi_t afi, safi_t safi,
 	build_evpn_type4_prefix(&p, &esi, vtep_ip);
 	/* Process the route. */
 	if (attr) {
-		ret = bgp_update(peer, (struct prefix *)&p, addpath_id, attr,
-				afi, safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
-				&prd, NULL, 0, 0, NULL);
+		bgp_update(peer, (struct prefix *)&p, addpath_id, attr, afi,
+			   safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, NULL,
+			   0, 0, NULL);
 	} else {
-		ret = bgp_withdraw(peer, (struct prefix *)&p, addpath_id, attr,
-				afi, safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
-				&prd, NULL, 0, NULL);
+		bgp_withdraw(peer, (struct prefix *)&p, addpath_id, attr, afi,
+			     safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd,
+			     NULL, 0, NULL);
 	}
-	return ret;
+	return 0;
 }
 
 /* Check if a prefix belongs to the local ES */
@@ -1180,7 +1179,6 @@ int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 		struct attr *attr, uint8_t *pfx, int psize,
 		uint32_t addpath_id)
 {
-	int ret;
 	struct prefix_rd prd;
 	esi_t esi;
 	uint32_t eth_tag;
@@ -1219,15 +1217,15 @@ int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 	build_evpn_type1_prefix(&p, eth_tag, &esi, vtep_ip);
 	/* Process the route. */
 	if (attr) {
-		ret = bgp_update(peer, (struct prefix *)&p, addpath_id, attr,
-				afi, safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
-				&prd, NULL, 0, 0, NULL);
+		bgp_update(peer, (struct prefix *)&p, addpath_id, attr, afi,
+			   safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, NULL,
+			   0, 0, NULL);
 	} else {
-		ret = bgp_withdraw(peer, (struct prefix *)&p, addpath_id, attr,
-				afi, safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
-				&prd, NULL, 0, NULL);
+		bgp_withdraw(peer, (struct prefix *)&p, addpath_id, attr, afi,
+			     safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd,
+			     NULL, 0, NULL);
 	}
-	return ret;
+	return 0;
 }
 
 void bgp_evpn_mh_config_ead_export_rt(struct bgp *bgp,

--- a/bgpd/bgp_flowspec.c
+++ b/bgpd/bgp_flowspec.c
@@ -103,7 +103,6 @@ int bgp_nlri_parse_flowspec(struct peer *peer, struct attr *attr,
 	safi_t safi;
 	int psize = 0;
 	struct prefix p;
-	int ret;
 	void *temp;
 
 	/* Start processing the NLRI - there may be multiple in the MP_REACH */
@@ -190,21 +189,13 @@ int bgp_nlri_parse_flowspec(struct peer *peer, struct attr *attr,
 		}
 		/* Process the route. */
 		if (!withdraw)
-			ret = bgp_update(peer, &p, 0, attr,
-					 afi, safi,
-					 ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
-					 NULL, NULL, 0, 0, NULL);
+			bgp_update(peer, &p, 0, attr, afi, safi,
+				   ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, NULL,
+				   NULL, 0, 0, NULL);
 		else
-			ret = bgp_withdraw(peer, &p, 0, attr,
-					   afi, safi,
-					   ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
-					   NULL, NULL, 0, NULL);
-		if (ret) {
-			flog_err(EC_BGP_FLOWSPEC_INSTALLATION,
-				 "Flowspec NLRI failed to be %s.",
-				 attr ? "added" : "withdrawn");
-			return BGP_NLRI_PARSE_ERROR;
-		}
+			bgp_withdraw(peer, &p, 0, attr, afi, safi,
+				     ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, NULL,
+				     NULL, 0, NULL);
 	}
 	return BGP_NLRI_PARSE_OK;
 }

--- a/bgpd/bgp_mac.c
+++ b/bgpd/bgp_mac.c
@@ -211,16 +211,10 @@ static void bgp_process_mac_rescan_table(struct bgp *bgp, struct peer *peer,
 
 			memcpy(&evpn, bgp_attr_get_evpn_overlay(pi->attr),
 			       sizeof(evpn));
-			int32_t ret = bgp_update(peer, p,
-						 pi->addpath_rx_id,
-						 pi->attr, AFI_L2VPN, SAFI_EVPN,
-						 ZEBRA_ROUTE_BGP,
-						 BGP_ROUTE_NORMAL, &prd,
-						 label_pnt, num_labels,
-						 1, evpn);
-
-			if (ret < 0)
-				bgp_dest_unlock_node(dest);
+			bgp_update(peer, p, pi->addpath_rx_id, pi->attr,
+				   AFI_L2VPN, SAFI_EVPN, ZEBRA_ROUTE_BGP,
+				   BGP_ROUTE_NORMAL, &prd, label_pnt,
+				   num_labels, 1, evpn);
 		}
 	}
 }

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -750,17 +750,17 @@ extern int bgp_static_unset_safi(afi_t afi, safi_t safi, struct vty *,
 				 const char *, const char *, const char *);
 
 /* this is primarily for MPLS-VPN */
-extern int bgp_update(struct peer *peer, const struct prefix *p,
-		      uint32_t addpath_id, struct attr *attr,
-		      afi_t afi, safi_t safi, int type, int sub_type,
-		      struct prefix_rd *prd, mpls_label_t *label,
-		      uint32_t num_labels, int soft_reconfig,
-		      struct bgp_route_evpn *evpn);
-extern int bgp_withdraw(struct peer *peer, const struct prefix *p,
-			uint32_t addpath_id, struct attr *attr, afi_t afi,
-			safi_t safi, int type, int sub_type,
-			struct prefix_rd *prd, mpls_label_t *label,
-			uint32_t num_labels, struct bgp_route_evpn *evpn);
+extern void bgp_update(struct peer *peer, const struct prefix *p,
+		       uint32_t addpath_id, struct attr *attr, afi_t afi,
+		       safi_t safi, int type, int sub_type,
+		       struct prefix_rd *prd, mpls_label_t *label,
+		       uint32_t num_labels, int soft_reconfig,
+		       struct bgp_route_evpn *evpn);
+extern void bgp_withdraw(struct peer *peer, const struct prefix *p,
+			 uint32_t addpath_id, struct attr *attr, afi_t afi,
+			 safi_t safi, int type, int sub_type,
+			 struct prefix_rd *prd, mpls_label_t *label,
+			 uint32_t num_labels, struct bgp_route_evpn *evpn);
 
 /* for bgp_nexthop and bgp_damp */
 extern void bgp_process(struct bgp *, struct bgp_dest *, afi_t, safi_t);


### PR DESCRIPTION
These two functions always return 0.  As such any and all tests against this make no sense.  Remove the return 0 to a void and follow the chain, logically, to remove all the dead code.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>