### PR TITLE
Clang pragman

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -53,7 +53,12 @@ int db_init(const char *path_fmt, ...)
 		return -1;
 
 	va_start(ap, path_fmt);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 	vsnprintf(path, sizeof(path), path_fmt, ap);
+#pragma GCC diagnostic pop
+
 	va_end(ap);
 
 	if (sqlite3_open_v2(path, &dbp,
@@ -312,7 +317,12 @@ int db_execute(const char *stmt_fmt, ...)
 		return -1;
 
 	va_start(ap, stmt_fmt);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 	vsnprintf(stmt, sizeof(stmt), stmt_fmt, ap);
+#pragma GCC diagnostic pop
+
 	va_end(ap);
 
 	if (sqlite3_exec(dbp, stmt, NULL, 0, NULL) != SQLITE_OK) {

--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -604,7 +604,11 @@ void vzlogx(const struct xref_logmsg *xref, int prio,
 #ifdef HAVE_LTTNG
 	va_list copy;
 	va_copy(copy, ap);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 	char *msg = vasprintfrr(MTYPE_LOG_MESSAGE, fmt, copy);
+#pragma GCC diagnostic pop
 
 	switch (prio) {
 	case LOG_ERR:

--- a/tests/bgpd/test_peer_attr.c
+++ b/tests/bgpd/test_peer_attr.c
@@ -221,7 +221,12 @@ static char *str_vprintf(const char *fmt, va_list ap)
 
 	while (1) {
 		va_copy(apc, ap);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 		ret = vsnprintf(buf, buf_size, fmt, apc);
+#pragma GCC diagnostic pop
+
 		va_end(apc);
 
 		if (ret >= 0 && ret < buf_size)

--- a/tests/lib/test_nexthop_iter.c
+++ b/tests/lib/test_nexthop_iter.c
@@ -48,7 +48,12 @@ static void str_appendf(char **buf, const char *format, ...)
 	char *pbuf;
 
 	va_start(ap, format);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 	rv = vasprintf(&pbuf, format, ap);
+#pragma GCC diagnostic pop
+
 	va_end(ap);
 	assert(rv >= 0);
 


### PR DESCRIPTION
fix some missed stuff from David's `-Wformat-literal` addition.  Clearly not all compile options where hit.