### PR TITLE
tests: Fix wrong tgen.stop_topology() calls which got skipped

### DIFF
--- a/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
@@ -143,7 +143,7 @@ def teardown_module():
 
     try:
         # Stop toplogy and Remove tmp files
-        tgen.stop_topology
+        tgen.stop_topology()
 
     except OSError:
         # OSError exception is raised when mininet tries to stop switch

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper1.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper1.py
@@ -153,7 +153,7 @@ def teardown_module():
 
     try:
         # Stop toplogy and Remove tmp files
-        tgen.stop_topology
+        tgen.stop_topology()
 
     except OSError:
         # OSError exception is raised when mininet tries to stop switch

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper2.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper2.py
@@ -153,7 +153,7 @@ def teardown_module():
 
     try:
         # Stop toplogy and Remove tmp files
-        tgen.stop_topology
+        tgen.stop_topology()
 
     except OSError:
         # OSError exception is raised when mininet tries to stop switch

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper3.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper3.py
@@ -153,7 +153,7 @@ def teardown_module():
 
     try:
         # Stop toplogy and Remove tmp files
-        tgen.stop_topology
+        tgen.stop_topology()
 
     except OSError:
         # OSError exception is raised when mininet tries to stop switch


### PR DESCRIPTION
Calls were missing the () and caused the stop_topology() to be skipped

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>