### PR TITLE
bgpd: ecommunity_token_rt6 is not handled

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -699,6 +699,7 @@ static struct ecommunity *ecommunity_str2com_internal(const char *str, int type,
 	while ((str = ecommunity_gettoken(str, (void *)&eval, &token))) {
 		switch (token) {
 		case ecommunity_token_rt:
+		case ecommunity_token_rt6:
 		case ecommunity_token_soo:
 			if (!keyword_included || keyword) {
 				if (ecom)
@@ -746,7 +747,6 @@ static struct ecommunity *ecommunity_str2com_internal(const char *str, int type,
 						    ecom->unit_size);
 			break;
 		case ecommunity_token_unknown:
-		default:
 			if (ecom)
 				ecommunity_free(&ecom);
 			return NULL;


### PR DESCRIPTION
The function ecommunity_str2com_internal appears to want to handle the ecommunity_token_rt6 enum but skips over it.  Commit 9a659715dfcb6c0b1e3ef8004b6c9d14c55f2081 tried to add this but I really don't see how this is going to behave correctly.  Add the ecommunity_token_rt6 case to the switch statement so it is handled appropriately?

Signed-off-by: Donald Sharp <sharpd@nvidia.com>