### PR TITLE
*: more format string fixing

### DIFF
--- a/bgpd/rfapi/rfapi_vty.h
+++ b/bgpd/rfapi/rfapi_vty.h
@@ -62,7 +62,8 @@ extern int rfapiStr2EthAddr(const char *str, struct ethaddr *ea);
 extern const char *rfapi_ntop(int af, const void *src, char *buf,
 			      socklen_t size);
 
-extern int rfapiDebugPrintf(void *dummy, const char *format, ...);
+extern int rfapiDebugPrintf(void *dummy, const char *format, ...)
+	PRINTFRR(2, 3);
 
 extern int rfapiStream2Vty(void *stream,			  /* input */
 			   int (**fp)(void *, const char *, ...), /* output */

--- a/lib/db.h
+++ b/lib/db.h
@@ -36,21 +36,24 @@
 #define _FRR_DB_H_
 #ifdef HAVE_SQLITE3
 
+#include "compiler.h"
 #include <sqlite3.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern int db_init(const char *path_fmt, ...);
+extern int db_init(const char *path_fmt, ...) PRINTFRR(1, 2);
 extern int db_close(void);
+/* WARNING: sqlite format string! not printf compatible! */
 extern int db_bindf(struct sqlite3_stmt *ss, const char *fmt, ...);
 extern struct sqlite3_stmt *db_prepare_len(const char *stmt, int stmtlen);
 extern struct sqlite3_stmt *db_prepare(const char *stmt);
 extern int db_run(struct sqlite3_stmt *ss);
+/* WARNING: sqlite format string! not scanf compatible! */
 extern int db_loadf(struct sqlite3_stmt *ss, const char *fmt, ...);
 extern void db_finalize(struct sqlite3_stmt **ss);
-extern int db_execute(const char *stmt_fmt, ...);
+extern int db_execute(const char *stmt_fmt, ...) PRINTFRR(1, 2);
 
 #ifdef __cplusplus
 }

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -789,7 +789,7 @@ struct thread_master *frr_init(void)
 #ifdef HAVE_SQLITE3
 	if (!di->db_file)
 		di->db_file = dbfile_default;
-	db_init(di->db_file);
+	db_init("%s", di->db_file);
 #endif
 
 	if (di->flags & FRR_LIMITED_CLI)

--- a/lib/zlog.h
+++ b/lib/zlog.h
@@ -71,8 +71,8 @@ struct xrefdata_logmsg {
  * determine whether something is a log message or something else.
  */
 
-extern void vzlogx(const struct xref_logmsg *xref, int prio,
-		   const char *fmt, va_list ap);
+extern void vzlogx(const struct xref_logmsg *xref, int prio, const char *fmt,
+		   va_list ap) PRINTFRR(3, 0);
 #define vzlog(prio, ...) vzlogx(NULL, prio, __VA_ARGS__)
 
 PRINTFRR(2, 3)

--- a/tests/lib/test_nexthop_iter.c
+++ b/tests/lib/test_nexthop_iter.c
@@ -41,6 +41,7 @@ static void str_append(char **buf, const char *repr)
 	}
 }
 
+PRINTFRR(2, 3)
 static void str_appendf(char **buf, const char *format, ...)
 {
 	va_list ap;


### PR DESCRIPTION
cf. individual subjects/commits, just a bunch more format string attributes

also stripped a duplicate of `asprintfrr` from `tests/`