### PR TITLE
bgpd: Set attr to NULL when passing NLRI_UPDATE with treat-as-withdraw

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2033,7 +2033,8 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 			break;
 		case NLRI_WITHDRAW:
 		case NLRI_MP_WITHDRAW:
-			nlri_ret = bgp_nlri_parse(peer, &attr, &nlris[i], 1);
+			nlri_ret = bgp_nlri_parse(peer, NLRI_ATTR_ARG,
+						  &nlris[i], 1);
 			break;
 		default:
 			nlri_ret = BGP_NLRI_PARSE_ERROR;


### PR DESCRIPTION
Before this patch, we always passed `struct attr` for NLRI_UPDATE, but if we have a situation with treat-as-withdraw (for example: malformed attribute, or using a command like `neighbor path-attribute treat-as-withdraw`) the route MUST be withdrawn form the BGP table.

Hence, we MUST pass attr as NULL, in this case we already have this check under NLRI_ATTR_ARG() macro, just reuse it properly.

In other words: if we handle the UPDATE as treat-as-withdraw, we SHOULD NOT reset the session with an error, but just withdraw the route.

This commit is the part of https://github.com/FRRouting/frr/pull/12728, but should be for 8.5 release, while #12728 - not.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>