### PR TITLE
lib, bgpd: Add ability to specify that some json output should not be…

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -4807,14 +4807,13 @@ DEFUN(show_bgp_l2vpn_evpn_route,
 
 	evpn_show_all_routes(vty, bgp, type, json, detail);
 
-	if (uj) {
-		if (detail) {
-			vty_out(vty, "%s\n", json_object_to_json_string(json));
-			json_object_free(json);
-		} else {
-			vty_json(vty, json);
-		}
-	}
+	/*
+	 * This is an extremely expensive operation at scale
+	 * and as such we need to save as much time as is
+	 * possible.
+	 */
+	if (uj)
+		vty_json_no_pretty(vty, json);
 
 	return CMD_SUCCESS;
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11588,7 +11588,16 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 				else
 					vty_out(vty, ",\"%pFX\": ", dest_p);
 			}
-			vty_json(vty, json_paths);
+			/*
+			 * We are using no_pretty here because under
+			 * extremely high settings( say lots and lots of
+			 * routes with lots and lots of ways to reach
+			 * that route via different paths ) this can
+			 * save several minutes of output when FRR
+			 * is run on older cpu's or more underperforming
+			 * routers out there
+			 */
+			vty_json_no_pretty(vty, json_paths);
 			json_paths = NULL;
 			first = 0;
 		} else

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -284,7 +284,8 @@ done:
 	return len;
 }
 
-int vty_json(struct vty *vty, struct json_object *json)
+static int vty_json_helper(struct vty *vty, struct json_object *json,
+			   uint32_t options)
 {
 	const char *text;
 
@@ -297,6 +298,18 @@ int vty_json(struct vty *vty, struct json_object *json)
 	json_object_free(json);
 
 	return CMD_SUCCESS;
+}
+
+int vty_json(struct vty *vty, struct json_object *json)
+{
+	return vty_json_helper(vty, json,
+			       JSON_C_TO_STRING_PRETTY |
+				       JSON_C_TO_STRING_NOSLASHESCAPE);
+}
+
+int vty_json_no_pretty(struct vty *vty, struct json_object *json)
+{
+	return vty_json_helper(vty, json, JSON_C_TO_STRING_NOSLASHESCAPE);
 }
 
 /* Output current time to the vty. */

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -353,8 +353,12 @@ extern void vty_endframe(struct vty *, const char *);
 extern bool vty_set_include(struct vty *vty, const char *regexp);
 /* returns CMD_SUCCESS so you can do a one-line "return vty_json(...)"
  * NULL check and json_object_free() is included.
+ *
+ * _no_pretty means do not add a bunch of newlines and dump the output
+ * as densely as possible.
  */
 extern int vty_json(struct vty *vty, struct json_object *json);
+extern int vty_json_no_pretty(struct vty *vty, struct json_object *json);
 
 /* post fd to be passed to the vtysh client
  * fd is owned by the VTY code after this and will be closed when done


### PR DESCRIPTION
… pretty

Initial commit: 23b2a7ef524c9fe083b217c7f6ebaec0effc8f52 changed the json output of `show bgp <afi> <safi> json` to not have pretty print because when under a situation where there are a bunch of routes with a large scale ecmp show output was taking forever and this commit cut 2 minutes out of vtysh run time.

Subusequent commit: f4ec52f7cc99f709756d9030623a20c98a086125 changed this back.

When upgrading to latest version the long run time was noticed due to testing.  Let's add back this functionality such that FRR can have reduced run times with vtysh when it's really needed.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>