### PR TITLE
ospfd: Added missing fields and option to query specific neighbor in VRF

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -794,13 +794,13 @@ Showing Information
 
 .. clicmd:: show ip ospf neighbor [json]
 
-.. clicmd:: show ip ospf neighbor INTERFACE [json]
+.. clicmd:: show ip ospf [vrf <NAME|all>] neighbor INTERFACE [json]
 
 .. clicmd:: show ip ospf neighbor detail [json]
 
-.. clicmd:: show ip ospf neighbor A.B.C.D [detail] [json]
+.. clicmd:: show ip ospf [vrf <NAME|all>] neighbor A.B.C.D [detail] [json]
 
-.. clicmd:: show ip ospf neighbor INTERFACE detail [json]
+.. clicmd:: show ip ospf [vrf <NAME|all>] neighbor INTERFACE detail [json]
 
    Display lsa information of LSDB.
    Json o/p of this command covers base route information

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -312,6 +312,13 @@ int vty_json_no_pretty(struct vty *vty, struct json_object *json)
 	return vty_json_helper(vty, json, JSON_C_TO_STRING_NOSLASHESCAPE);
 }
 
+void vty_json_empty(struct vty *vty)
+{
+	json_object *json = json_object_new_object();
+
+	vty_json(vty, json);
+}
+
 /* Output current time to the vty. */
 void vty_time_print(struct vty *vty, int cr)
 {

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -359,7 +359,7 @@ extern bool vty_set_include(struct vty *vty, const char *regexp);
  */
 extern int vty_json(struct vty *vty, struct json_object *json);
 extern int vty_json_no_pretty(struct vty *vty, struct json_object *json);
-
+extern void vty_json_empty(struct vty *vty);
 /* post fd to be passed to the vtysh client
  * fd is owned by the VTY code after this and will be closed when done
  */


### PR DESCRIPTION
4 Commits:


commit 176900c12be977014b836c2db6b8b23cb297d18a:
    ospfd: Fix "show ip ospf neighbor swp1 detail json" output
    
    1. When OSPF unnumbered neighbor doesn't exist in any VRF,
       OSPFD prints a bunch of empty JSON objects. Fixed it
       by adding an outer JSON object with VRF information in it
    2. Added "vrf" option to this command so that per VRF
       unnumbered OSPF neighbor information can be retrieved
    
    JSON output:
    nl1# show ip ospf neighbor swp1 detail json
        {
          "default":{
          },
          "vrf1012":{
          },
          "vrf1013":{
          },
          "vrf1014":{
          }
        }
    
    nl1# show ip ospf vrf vrf1012 neighbor swp4.2 detail json
        {
          "9.9.12.10":[
            {
              "ifaceAddress":"200.254.2.46",
              "areaId":"0.0.0.0",
              "ifaceName":"swp4.2",
              "localIfaceAddress":"200.254.2.45",
              "nbrPriority":1,
              "nbrState":"Full",
              "role":"DR",
              "stateChangeCounter":6,
              "lastPrgrsvChangeMsec":1462758,
              "routerDesignatedId":"200.254.2.46",
              "routerDesignatedBackupId":"200.254.2.45",
              "optionsCounter":2,
              "optionsList":"*|-|-|-|-|-|E|-",
              "routerDeadIntervalTimerDueMsec":37140,
              "databaseSummaryListCounter":0,
              "linkStateRequestListCounter":0,
              "linkStateRetransmissionListCounter":0,
              "threadInactivityTimer":"on",
              "threadLinkStateRequestRetransmission":"on",
              "threadLinkStateUpdateRetransmission":"on"
            }
          ]
        }
        nl1#
    

commit f12d430e5940981f4f523a7b481b5f7f824502bb:

    ospfd: Option to query specific neighbor in VRF
    
    Added VRF option to
    "show ip ospf [vrf NAME] neighbor X.X.X.X [detail] [json]"
    command so that the user can query information regarding a
    specific neighbor within a VRF.
    
    nl1# show ip ospf vrf vrf1012 neighbor 6.0.0.1
    6.0.0.1           1 Full/DROther      36.521s 200.254.2.1     swp5.2:200.254.2.2                   0     0     0
    
    nl1# show ip ospf vrf vrf1012 neighbor 6.0.0.1 json
        {
          "6.0.0.1":[
            {
              "priority":1,
              "state":"Full\/DROther",
              "nbrPriority":1,
              "nbrState":"Full\/DROther",
              "converged":"Full",
              "role":"DROther",
              "upTimeInMsec":3335207,
              "deadTimeMsecs":34739,
              "routerDeadIntervalTimerDueMsec":34739,
              "upTime":"55m35s",
              "deadTime":"34.739s",
              "address":"200.254.2.1",
              "ifaceAddress":"200.254.2.1",
              "ifaceName":"swp5.2:200.254.2.2",
              "retransmitCounter":0,
              "linkStateRetransmissionListCounter":0,
              "requestCounter":0,
              "linkStateRequestListCounter":0,
              "dbSummaryCounter":0,
              "databaseSummaryListCounter":0
            }
          ]
        }
    nl1# show ip ospf vrf vrf1012 neighbor 6.0.0.1 detail
     Neighbor 6.0.0.1, interface address 200.254.2.1
        In the area 0.0.0.0 via interface swp5.2 local interface IP 200.254.2.2
        Neighbor priority is 1, State is Full, Role is DROther, 5 state changes
        Most recent state change statistics:
          Progressive change 55m38s ago
        DR is 0.0.0.0, BDR is 0.0.0.0
        Options 2 *|-|-|-|-|-|E|-
        Dead timer due in 31.548s
        Database Summary List 0
        Link State Request List 0
        Link State Retransmission List 0
        Thread Inactivity Timer on
        Thread Database Description Retransmision off
        Thread Link State Request Retransmission on
        Thread Link State Update Retransmission on
    
    nl1# show ip ospf vrf vrf1012 neighbor 6.0.0.1 detail json
        {
          "6.0.0.1":[
            {
              "ifaceAddress":"200.254.2.1",
              "areaId":"0.0.0.0",
              "ifaceName":"swp5.2",
              "localIfaceAddress":"200.254.2.2",
              "nbrPriority":1,
              "nbrState":"Full",
              "role":"DROther",
              "stateChangeCounter":5,
              "lastPrgrsvChangeMsec":3340455,
              "routerDesignatedId":"0.0.0.0",
              "routerDesignatedBackupId":"0.0.0.0",
              "optionsCounter":2,
              "optionsList":"*|-|-|-|-|-|E|-",
              "routerDeadIntervalTimerDueMsec":39491,
              "databaseSummaryListCounter":0,
              "linkStateRequestListCounter":0,
              "linkStateRetransmissionListCounter":0,
              "threadInactivityTimer":"on",
              "threadLinkStateRequestRetransmission":"on",
              "threadLinkStateUpdateRetransmission":"on"
            }
          ]
        }
    

commit c0a8be8f90dd1331e2946e97795b3f0d6673cd0b:
    lib: Helper function to print empty JSON
    
    Introduced a helper function to print empty JSON object.
    
    Signed-off-by: Pooja Jagadeesh Doijode <pdoijode@nvidia.com>



commit 5bec85d971a4ab4252c680d5002c64fa8e78c7d9:
    ospfd: Added missing fields to "show ip ospf neighbor detail"
    
    "role" and "local interface address" fields were missing in
    "show ip ospf neighbor detail" command.
    
