### PR TITLE
tools: Replace pull_request_target to pull_request for commitlint action

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,7 +1,7 @@
 name: commitlint
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -14,6 +14,7 @@ jobs:
     if: github.repository == 'frrouting/frr'
     permissions:
       contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Tested locally, and it works. So it seems that, pull_request_target is not working properly, let's check.

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>