### PR TITLE
tests: do not use exclude grep

### DIFF
--- a/tests/topotests/bgp_vpnv4_noretain/test_bgp_vpnv4_noretain.py
+++ b/tests/topotests/bgp_vpnv4_noretain/test_bgp_vpnv4_noretain.py
@@ -134,11 +134,20 @@ def teardown_module(_mod):
 
 
 def router_json_cmp_exact_filter(router, cmd, expected):
-    # filter out tableVersion, version and nhVrfID
-    output = router.cmd('vtysh -c "{}" | grep -v ersion | grep -v nhVrfId'.format(cmd))
+    output = router.vtysh_cmd(cmd)
     logger.info("{}: {}\n{}".format(router.name, cmd, output))
 
     json_output = json.loads(output)
+
+    # filter out tableVersion, version and nhVrfID
+    json_output.pop("tableVersion")
+    for rd, data in json_output["routes"]["routeDistinguishers"].items():
+        for prefix, attrs in data.items():
+            for attr in attrs:
+                if "nhVrfId" in attr:
+                    attr.pop("nhVrfId")
+                if "version" in attr:
+                    attr.pop("version")
 
     return topotest.json_cmp(json_output, expected, exact=True)
 


### PR DESCRIPTION
Filter out keys in JSON output with "grep -v" does not work when JSON does not use the pretty format.

Use native python code to filter out keys.

Fixes: 6c13bd5744 ("topotests: fix bgp_vpnv4_noretain")
Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>