### PR TITLE
pim6d: Modify "show ipv6 mld join json" o/p

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -2737,7 +2737,7 @@ static void gm_show_joins_one(struct vty *vty, struct gm_if *gm_ifp,
 		}
 
 		js_src = json_object_new_object();
-		json_object_object_addf(js_group, js_src, "%pPA",
+		json_object_object_addf(js_group, js_src, "%pPAs",
 					&sg->sgaddr.src);
 
 		json_object_string_add(js_src, "state", gm_states[sg->state]);
@@ -2800,6 +2800,7 @@ static void gm_show_joins_vrf(struct vty *vty, struct vrf *vrf,
 
 	if (js) {
 		js_vrf = json_object_new_object();
+		json_object_string_add(js_vrf, "vrf", vrf->name);
 		json_object_object_add(js, vrf->name, js_vrf);
 	}
 


### PR DESCRIPTION
Currently "show ipv6 mld join json" o/p is
{
  "default":{
    "ens192":{
      "ff02:2":{
        "::":{
          "state":"JOIN",
          "created":"00:01:50.595",
          "lastSeen":"00:00:38.403",
        }
      }
    }
  }
}

Here, I modified the o/p as below for better understanding. {
{
  "default":{
    "vrf":"default",
    "ens192":{
      "ff02::2":{
        "*":{
          "state":"JOIN",
          "created":"00:00:42.766",
          "lastSeen":"00:00:05.266"
        }
      }
    }
  }
}


Issue: #12755

Signed-off-by: Sarita Patra <saritap@vmware.com>