### PR TITLE
vrrpd: give null when using null ifp to lookup vr

### DIFF
--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -671,6 +671,9 @@ void vrrp_vrouter_destroy(struct vrrp_vrouter *vr)
 
 struct vrrp_vrouter *vrrp_lookup(const struct interface *ifp, uint8_t vrid)
 {
+	if (!ifp)
+		return NULL;
+
 	struct vrrp_vrouter vr;
 
 	vr.vrid = vrid;


### PR DESCRIPTION
This is still causing crashes somehow.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>