### PR TITLE
bgpd: fix 'json detail' output structure

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2485,7 +2485,7 @@ static void evpn_show_route_vni_multicast(struct vty *vty, struct bgp *bgp,
 
 	/* Prefix and num paths displayed once per prefix. */
 	route_vty_out_detail_header(vty, bgp, dest, bgp_dest_get_prefix(dest),
-				    NULL, afi, safi, json);
+				    NULL, afi, safi, json, false);
 
 	/* Display each path for this prefix. */
 	for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next) {
@@ -2587,7 +2587,7 @@ static void evpn_show_route_vni_macip(struct vty *vty, struct bgp *bgp,
 
 	/* Prefix and num paths displayed once per prefix. */
 	route_vty_out_detail_header(vty, bgp, dest, (struct prefix *)&p, NULL,
-				    afi, safi, json);
+				    afi, safi, json, false);
 
 	evp = (const struct prefix_evpn *)bgp_dest_get_prefix(dest);
 
@@ -2722,7 +2722,7 @@ static void evpn_show_route_rd_macip(struct vty *vty, struct bgp *bgp,
 
 	/* Prefix and num paths displayed once per prefix. */
 	route_vty_out_detail_header(vty, bgp, dest, bgp_dest_get_prefix(dest),
-				    prd, afi, safi, json);
+				    prd, afi, safi, json, false);
 
 	if (json)
 		json_paths = json_object_new_array();
@@ -2830,7 +2830,7 @@ static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
 			/* Prefix and num paths displayed once per prefix. */
 			route_vty_out_detail_header(
 				vty, bgp, dest, bgp_dest_get_prefix(dest), prd,
-				afi, safi, json_prefix);
+				afi, safi, json_prefix, false);
 
 			prefix_cnt++;
 		}
@@ -2965,7 +2965,7 @@ static void evpn_show_route_rd_all_macip(struct vty *vty, struct bgp *bgp,
 			/* Prefix and num paths displayed once per prefix. */
 			route_vty_out_detail_header(
 				vty, bgp, dest, p, (struct prefix_rd *)rd_destp,
-				AFI_L2VPN, SAFI_EVPN, json_prefix);
+				AFI_L2VPN, SAFI_EVPN, json_prefix, false);
 
 		/* For EVPN, the prefix is displayed for each path (to
 		 * fit in with code that already exists).
@@ -3119,7 +3119,7 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 					vty, bgp, dest,
 					bgp_dest_get_prefix(dest),
 					(struct prefix_rd *)rd_destp, AFI_L2VPN,
-					SAFI_EVPN, json_prefix);
+					SAFI_EVPN, json_prefix, false);
 
 			/* For EVPN, the prefix is displayed for each path (to
 			 * fit in

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -857,7 +857,8 @@ extern void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 					struct bgp_dest *dest,
 					const struct prefix *p,
 					const struct prefix_rd *prd, afi_t afi,
-					safi_t safi, json_object *json);
+					safi_t safi, json_object *json,
+					bool incremental_print);
 extern void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 				 struct bgp_dest *bn, const struct prefix *p,
 				 struct bgp_path_info *path, afi_t afi,

--- a/tests/topotests/bgp_aigp/test_bgp_aigp.py
+++ b/tests/topotests/bgp_aigp/test_bgp_aigp.py
@@ -151,30 +151,34 @@ def test_bgp_aigp():
         )
         expected = {
             "routes": {
-                "10.0.0.71/32": [
-                    {
-                        "aigpMetric": 101,
-                        "valid": True,
-                    },
-                    {
-                        "aigpMetric": 91,
-                        "valid": True,
-                        "bestpath": {"selectionReason": "AIGP"},
-                        "nexthops": [{"hostname": "r3", "accessible": True}],
-                    },
-                ],
-                "10.0.0.72/32": [
-                    {
-                        "aigpMetric": 102,
-                        "valid": True,
-                    },
-                    {
-                        "aigpMetric": 92,
-                        "valid": True,
-                        "bestpath": {"selectionReason": "AIGP"},
-                        "nexthops": [{"hostname": "r3", "accessible": True}],
-                    },
-                ],
+                "10.0.0.71/32": {
+                    "paths": [
+                        {
+                            "aigpMetric": 101,
+                            "valid": True,
+                        },
+                        {
+                            "aigpMetric": 91,
+                            "valid": True,
+                            "bestpath": {"selectionReason": "AIGP"},
+                            "nexthops": [{"hostname": "r3", "accessible": True}],
+                        },
+                    ],
+                },
+                "10.0.0.72/32": {
+                    "paths": [
+                        {
+                            "aigpMetric": 102,
+                            "valid": True,
+                        },
+                        {
+                            "aigpMetric": 92,
+                            "valid": True,
+                            "bestpath": {"selectionReason": "AIGP"},
+                            "nexthops": [{"hostname": "r3", "accessible": True}],
+                        },
+                    ],
+                },
             }
         }
         return topotest.json_cmp(output, expected)

--- a/tests/topotests/bgp_community_alias/test_bgp-community-alias.py
+++ b/tests/topotests/bgp_community_alias/test_bgp-community-alias.py
@@ -118,12 +118,16 @@ def test_bgp_community_alias():
         )
         expected = {
             "routes": {
-                "172.16.16.1/32": [
-                    {
-                        "community": {"string": "community-r2-1 65001:2"},
-                        "largeCommunity": {"string": "large-community-r2-1 65001:1:2"},
-                    }
-                ]
+                "172.16.16.1/32": {
+                    "paths": [
+                        {
+                            "community": {"string": "community-r2-1 65001:2"},
+                            "largeCommunity": {
+                                "string": "large-community-r2-1 65001:1:2"
+                            },
+                        }
+                    ]
+                }
             }
         }
         return topotest.json_cmp(output, expected)

--- a/tests/topotests/bgp_path_attribute_discard/test_bgp_path_attribute_discard.py
+++ b/tests/topotests/bgp_path_attribute_discard/test_bgp_path_attribute_discard.py
@@ -81,24 +81,28 @@ def test_bgp_path_attribute_discard():
         output = json.loads(r1.vtysh_cmd("show bgp ipv4 unicast json detail"))
         expected = {
             "routes": {
-                "192.168.100.101/32": [
-                    {
-                        "valid": True,
-                        "atomicAggregate": True,
-                        "community": {
-                            "string": "65001:101",
-                        },
-                    }
-                ],
-                "192.168.100.102/32": [
-                    {
-                        "valid": True,
-                        "originatorId": "10.0.0.2",
-                        "community": {
-                            "string": "65001:102",
-                        },
-                    }
-                ],
+                "192.168.100.101/32": {
+                    "paths": [
+                        {
+                            "valid": True,
+                            "atomicAggregate": True,
+                            "community": {
+                                "string": "65001:101",
+                            },
+                        }
+                    ],
+                },
+                "192.168.100.102/32": {
+                    "paths": [
+                        {
+                            "valid": True,
+                            "originatorId": "10.0.0.2",
+                            "community": {
+                                "string": "65001:102",
+                            },
+                        }
+                    ],
+                },
             }
         }
         return topotest.json_cmp(output, expected)
@@ -120,20 +124,24 @@ def test_bgp_path_attribute_discard():
         output = json.loads(r1.vtysh_cmd("show bgp ipv4 unicast json detail"))
         expected = {
             "routes": {
-                "192.168.100.101/32": [
-                    {
-                        "valid": True,
-                        "atomicAggregate": None,
-                        "community": None,
-                    }
-                ],
-                "192.168.100.102/32": [
-                    {
-                        "valid": True,
-                        "originatorId": None,
-                        "community": None,
-                    }
-                ],
+                "192.168.100.101/32": {
+                    "paths": [
+                        {
+                            "valid": True,
+                            "atomicAggregate": None,
+                            "community": None,
+                        }
+                    ],
+                },
+                "192.168.100.102/32": {
+                    "paths": [
+                        {
+                            "valid": True,
+                            "originatorId": None,
+                            "community": None,
+                        }
+                    ],
+                },
             }
         }
         return topotest.json_cmp(output, expected)

--- a/tests/topotests/bgp_path_attribute_treat_as_withdraw/test_bgp_path_attribute_treat_as_withdraw.py
+++ b/tests/topotests/bgp_path_attribute_treat_as_withdraw/test_bgp_path_attribute_treat_as_withdraw.py
@@ -82,17 +82,21 @@ def test_bgp_path_attribute_treat_as_withdraw():
         output = json.loads(r2.vtysh_cmd("show bgp ipv4 unicast json detail"))
         expected = {
             "routes": {
-                "10.10.10.10/32": [
-                    {
-                        "valid": True,
-                        "atomicAggregate": True,
-                    }
-                ],
-                "10.10.10.20/32": [
-                    {
-                        "valid": True,
-                    }
-                ],
+                "10.10.10.10/32": {
+                    "paths": [
+                        {
+                            "valid": True,
+                            "atomicAggregate": True,
+                        }
+                    ],
+                },
+                "10.10.10.20/32": {
+                    "paths": [
+                        {
+                            "valid": True,
+                        }
+                    ],
+                },
             }
         }
         return topotest.json_cmp(output, expected)
@@ -115,11 +119,13 @@ def test_bgp_path_attribute_treat_as_withdraw():
         expected = {
             "routes": {
                 "10.10.10.10/32": None,
-                "10.10.10.20/32": [
-                    {
-                        "valid": True,
-                    }
-                ],
+                "10.10.10.20/32": {
+                    "paths": [
+                        {
+                            "valid": True,
+                        }
+                    ],
+                },
             }
         }
         return topotest.json_cmp(output, expected)


### PR DESCRIPTION
"show bgp <afi> <safi> json detail" was incorrectly displaying header information from route_vty_out_detail_header() as an element of the "paths" array. This corrects the behavior for 'json detail' so that a route holds a dictionary with keys for "paths" and header info, which aligns with how we structure the output for a specific prefix, e.g. "show bgp <afi> <safi> <prefix> json".

Before:
```
ub20# show ip bgp json detail
{
 "vrfId": 0,
 "vrfName": "default",
 "tableVersion": 3,
 "routerId": "100.64.0.222",
 "defaultLocPrf": 100,
 "localAS": 1,
 "routes": { "2.2.2.2/32": [
  {                           <<<<<<<<<  should be outside the array
    "prefix":"2.2.2.2/32",
    "version":1,
    "advertisedTo":{
      "192.168.122.12":{
        "hostname":"ub20-2"
      }
    }
  },
  {
    "aspath":{
      "string":"Local",
      "segments":[
      ],
      "length":0
    },
<snip>
```

After:
```
ub20# show ip bgp json detail
{
 "vrfId": 0,
 "vrfName": "default",
 "tableVersion": 3,
 "routerId": "100.64.0.222",
 "defaultLocPrf": 100,
 "localAS": 1,
 "routes": { "2.2.2.2/32": {
"prefix": "2.2.2.2/32",
"version": "1",
"advertisedTo": {
  "192.168.122.12":{
    "hostname":"ub20-2"
  }
}
,"paths": [
  {
    "aspath":{
      "string":"Local",
      "segments":[
      ],
      "length":0
    },
```

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>