### PR TITLE
Rib match multicast

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -974,7 +974,7 @@ unicast topology!
    Unreachable routes do not receive special treatment and do not cause
    fallback to a second lookup.
 
-.. clicmd:: show ip rpf ADDR
+.. clicmd:: show [ip|ipv6] rpf ADDR
 
    Performs a Multicast RPF lookup, as configured with ``ip multicast
    rpf-lookup-mode MODE``. ADDR specifies the multicast source address to look
@@ -984,7 +984,6 @@ unicast topology!
 
       > show ip rpf 192.0.2.1
       Routing entry for 192.0.2.0/24 using Unicast RIB
-
       Known via "kernel", distance 0, metric 0, best
       * 198.51.100.1, via eth0
 
@@ -992,7 +991,7 @@ unicast topology!
    Indicates that a multicast source lookup for 192.0.2.1 would use an
    Unicast RIB entry for 192.0.2.0/24 with a gateway of 198.51.100.1.
 
-.. clicmd:: show ip rpf
+.. clicmd:: show [ip|ipv6] rpf
 
    Prints the entire Multicast RIB. Note that this is independent of the
    configured RPF lookup mode, the Multicast RIB may be printed yet not

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -407,12 +407,9 @@ extern void rib_delete(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 extern struct route_entry *rib_match(afi_t afi, safi_t safi, vrf_id_t vrf_id,
 				     const union g_addr *addr,
 				     struct route_node **rn_out);
-extern struct route_entry *rib_match_ipv4_multicast(vrf_id_t vrf_id,
-						    struct in_addr addr,
-						    struct route_node **rn_out);
-extern struct route_entry *rib_match_ipv6_multicast(vrf_id_t vrf_id,
-						    struct in6_addr addr,
-						    struct route_node **rn_out);
+extern struct route_entry *rib_match_multicast(afi_t afi, vrf_id_t vrf_id,
+					       union g_addr *gaddr,
+					       struct route_node **rn_out);
 
 extern struct route_entry *rib_lookup_ipv4(struct prefix_ipv4 *p,
 					   vrf_id_t vrf_id);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2249,17 +2249,18 @@ static void zread_nexthop_lookup_mrib(ZAPI_HANDLER_ARGS)
 {
 	struct ipaddr addr;
 	struct route_entry *re = NULL;
+	union g_addr gaddr;
 
 	STREAM_GET_IPADDR(msg, &addr);
 
 	switch (addr.ipa_type) {
 	case IPADDR_V4:
-		re = rib_match_ipv4_multicast(zvrf_id(zvrf), addr.ipaddr_v4,
-					      NULL);
+		gaddr.ipv4 = addr.ipaddr_v4;
+		re = rib_match_multicast(AFI_IP, zvrf_id(zvrf), &gaddr, NULL);
 		break;
 	case IPADDR_V6:
-		re = rib_match_ipv6_multicast(zvrf_id(zvrf), addr.ipaddr_v6,
-					      NULL);
+		gaddr.ipv6 = addr.ipaddr_v6;
+		re = rib_match_multicast(AFI_IP6, zvrf_id(zvrf), &gaddr, NULL);
 		break;
 	case IPADDR_NONE:
 		/* ??? */

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -524,31 +524,28 @@ struct route_entry *rib_match(afi_t afi, safi_t safi, vrf_id_t vrf_id,
 	return NULL;
 }
 
-struct route_entry *rib_match_ipv4_multicast(vrf_id_t vrf_id,
-					     struct in_addr addr,
-					     struct route_node **rn_out)
+struct route_entry *rib_match_multicast(afi_t afi, vrf_id_t vrf_id,
+					union g_addr *gaddr,
+					struct route_node **rn_out)
 {
 	struct route_entry *re = NULL, *mre = NULL, *ure = NULL;
 	struct route_node *m_rn = NULL, *u_rn = NULL;
-	union g_addr gaddr = {.ipv4 = addr};
 
 	switch (zrouter.ipv4_multicast_mode) {
 	case MCAST_MRIB_ONLY:
-		return rib_match(AFI_IP, SAFI_MULTICAST, vrf_id, &gaddr,
-				 rn_out);
+		return rib_match(afi, SAFI_MULTICAST, vrf_id, gaddr, rn_out);
 	case MCAST_URIB_ONLY:
-		return rib_match(AFI_IP, SAFI_UNICAST, vrf_id, &gaddr, rn_out);
+		return rib_match(afi, SAFI_UNICAST, vrf_id, gaddr, rn_out);
 	case MCAST_NO_CONFIG:
 	case MCAST_MIX_MRIB_FIRST:
-		re = mre = rib_match(AFI_IP, SAFI_MULTICAST, vrf_id, &gaddr,
-				     &m_rn);
+		re = mre = rib_match(afi, SAFI_MULTICAST, vrf_id, gaddr, &m_rn);
 		if (!mre)
-			re = ure = rib_match(AFI_IP, SAFI_UNICAST, vrf_id,
-					     &gaddr, &u_rn);
+			re = ure = rib_match(afi, SAFI_UNICAST, vrf_id, gaddr,
+					     &u_rn);
 		break;
 	case MCAST_MIX_DISTANCE:
-		mre = rib_match(AFI_IP, SAFI_MULTICAST, vrf_id, &gaddr, &m_rn);
-		ure = rib_match(AFI_IP, SAFI_UNICAST, vrf_id, &gaddr, &u_rn);
+		mre = rib_match(afi, SAFI_MULTICAST, vrf_id, gaddr, &m_rn);
+		ure = rib_match(afi, SAFI_UNICAST, vrf_id, gaddr, &u_rn);
 		if (mre && ure)
 			re = ure->distance < mre->distance ? ure : mre;
 		else if (mre)
@@ -557,8 +554,8 @@ struct route_entry *rib_match_ipv4_multicast(vrf_id_t vrf_id,
 			re = ure;
 		break;
 	case MCAST_MIX_PFXLEN:
-		mre = rib_match(AFI_IP, SAFI_MULTICAST, vrf_id, &gaddr, &m_rn);
-		ure = rib_match(AFI_IP, SAFI_UNICAST, vrf_id, &gaddr, &u_rn);
+		mre = rib_match(afi, SAFI_MULTICAST, vrf_id, gaddr, &m_rn);
+		ure = rib_match(afi, SAFI_UNICAST, vrf_id, gaddr, &u_rn);
 		if (mre && ure)
 			re = u_rn->p.prefixlen > m_rn->p.prefixlen ? ure : mre;
 		else if (mre)
@@ -573,70 +570,16 @@ struct route_entry *rib_match_ipv4_multicast(vrf_id_t vrf_id,
 
 	if (IS_ZEBRA_DEBUG_RIB) {
 		char buf[BUFSIZ];
-		inet_ntop(AF_INET, &addr, buf, BUFSIZ);
+		inet_ntop(afi == AFI_IP ? AF_INET : AF_INET6, gaddr, buf,
+			  BUFSIZ);
 
-		zlog_debug("%s: %s: vrf: %s(%u) found %s, using %s", __func__,
-			   buf, vrf_id_to_name(vrf_id), vrf_id,
+		zlog_debug("%s: %s: %pRN vrf: %s(%u) found %s, using %s",
+			   __func__, buf, (re == mre) ? m_rn : u_rn,
+			   vrf_id_to_name(vrf_id), vrf_id,
 			   mre ? (ure ? "MRIB+URIB" : "MRIB")
 			       : ure ? "URIB" : "nothing",
 			   re == ure ? "URIB" : re == mre ? "MRIB" : "none");
 	}
-	return re;
-}
-
-struct route_entry *rib_match_ipv6_multicast(vrf_id_t vrf_id,
-					     struct in6_addr addr,
-					     struct route_node **rn_out)
-{
-	struct route_entry *re = NULL, *mre = NULL, *ure = NULL;
-	struct route_node *m_rn = NULL, *u_rn = NULL;
-	union g_addr gaddr = {.ipv6 = addr};
-
-	switch (zrouter.ipv4_multicast_mode) {
-	case MCAST_MRIB_ONLY:
-		return rib_match(AFI_IP6, SAFI_MULTICAST, vrf_id, &gaddr,
-				 rn_out);
-	case MCAST_URIB_ONLY:
-		return rib_match(AFI_IP6, SAFI_UNICAST, vrf_id, &gaddr, rn_out);
-	case MCAST_NO_CONFIG:
-	case MCAST_MIX_MRIB_FIRST:
-		re = mre = rib_match(AFI_IP6, SAFI_MULTICAST, vrf_id, &gaddr,
-				     &m_rn);
-		if (!mre)
-			re = ure = rib_match(AFI_IP6, SAFI_UNICAST, vrf_id,
-					     &gaddr, &u_rn);
-		break;
-	case MCAST_MIX_DISTANCE:
-		mre = rib_match(AFI_IP6, SAFI_MULTICAST, vrf_id, &gaddr, &m_rn);
-		ure = rib_match(AFI_IP6, SAFI_UNICAST, vrf_id, &gaddr, &u_rn);
-		if (mre && ure)
-			re = ure->distance < mre->distance ? ure : mre;
-		else if (mre)
-			re = mre;
-		else if (ure)
-			re = ure;
-		break;
-	case MCAST_MIX_PFXLEN:
-		mre = rib_match(AFI_IP6, SAFI_MULTICAST, vrf_id, &gaddr, &m_rn);
-		ure = rib_match(AFI_IP6, SAFI_UNICAST, vrf_id, &gaddr, &u_rn);
-		if (mre && ure)
-			re = u_rn->p.prefixlen > m_rn->p.prefixlen ? ure : mre;
-		else if (mre)
-			re = mre;
-		else if (ure)
-			re = ure;
-		break;
-	}
-
-	if (rn_out)
-		*rn_out = (re == mre) ? m_rn : u_rn;
-
-	if (IS_ZEBRA_DEBUG_RIB)
-		zlog_debug("%s: %pI6: vrf: %s(%u) found %s, using %s", __func__,
-			   &addr, vrf_id_to_name(vrf_id), vrf_id,
-			   mre ? (ure ? "MRIB+URIB" : "MRIB")
-			       : ure ? "URIB" : "nothing",
-			   re == ure ? "URIB" : re == mre ? "MRIB" : "none");
 	return re;
 }
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -164,27 +164,19 @@ DEFUN (show_ip_rpf,
 				&ctx);
 }
 
-DEFUN (show_ip_rpf_addr,
+DEFPY (show_ip_rpf_addr,
        show_ip_rpf_addr_cmd,
-       "show ip rpf A.B.C.D",
+       "show ip rpf A.B.C.D$address",
        SHOW_STR
        IP_STR
        "Display RPF information for multicast source\n"
        "IP multicast source address (e.g. 10.0.0.0)\n")
 {
-	int idx_ipv4 = 3;
-	struct in_addr addr;
 	struct route_node *rn;
 	struct route_entry *re;
-	int ret;
 
-	ret = inet_aton(argv[idx_ipv4]->arg, &addr);
-	if (ret == 0) {
-		vty_out(vty, "%% Malformed address\n");
-		return CMD_WARNING;
-	}
-
-	re = rib_match_ipv4_multicast(VRF_DEFAULT, addr, &rn);
+	re = rib_match_multicast(AFI_IP, VRF_DEFAULT, (union g_addr *)&address,
+				 &rn);
 
 	if (re)
 		vty_show_ip_route_detail(vty, rn, 1, false, false);


### PR DESCRIPTION
a) Cleanup the cut-n-paste code that rib_match_ipv[4|6]_multicast
b) Cleanup doc and add `show ipv6 rpf X:X::X:X` as well as `show ipv6 rpf`