### PR TITLE
bgpd: BGP troubleshooting - Add a keyword self-originate to display o…

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11458,6 +11458,10 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 				    || CHECK_FLAG(pi->flags, BGP_PATH_HISTORY))
 					continue;
 			}
+			if (type == bgp_show_type_self_originated) {
+				if (pi->peer != bgp->peer_self)
+					continue;
+			}
 
 			if (!use_json && header) {
 				vty_out(vty,
@@ -12610,6 +12614,7 @@ DEFPY(show_ip_bgp, show_ip_bgp_cmd,
           |alias ALIAS_NAME\
           |A.B.C.D/M longer-prefixes\
           |X:X::X:X/M longer-prefixes\
+          |"BGP_SELF_ORIG_CMD_STR"\
           |detail-routes$detail_routes\
           ] [json$uj [detail$detail_json] | wide$wide]",
       SHOW_STR IP_STR BGP_STR BGP_INSTANCE_HELP_STR BGP_AFI_HELP_STR
@@ -12659,6 +12664,7 @@ DEFPY(show_ip_bgp, show_ip_bgp_cmd,
       "Display route and more specific routes\n"
       "IPv6 prefix\n"
       "Display route and more specific routes\n"
+      BGP_SELF_ORIG_HELP_STR
       "Display detailed version of all routes\n"
       JSON_STR
       "Display detailed version of JSON output\n"
@@ -12852,6 +12858,10 @@ DEFPY(show_ip_bgp, show_ip_bgp_cmd,
 		sh_type = bgp_show_type_prefix_longer;
 		output_arg = &p;
 	}
+
+	/* self originated only */
+	if (argv_find(argv, argc, BGP_SELF_ORIG_CMD_STR, &idx))
+		sh_type = bgp_show_type_self_originated;
 
 	if (!all) {
 		/* show bgp: AFI_IP6, show ip bgp: AFI_IP */

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -61,6 +61,7 @@ enum bgp_show_type {
 	bgp_show_type_detail,
 	bgp_show_type_rpki,
 	bgp_show_type_prefix_version,
+	bgp_show_type_self_originated,
 };
 
 enum bgp_show_adj_route_type {

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -43,6 +43,9 @@ struct bgp;
 	BGP_AF_MODIFIER_STR BGP_AF_MODIFIER_STR BGP_AF_MODIFIER_STR            \
 		BGP_AF_MODIFIER_STR BGP_AF_MODIFIER_STR
 
+#define BGP_SELF_ORIG_CMD_STR       "self-originate"
+#define BGP_SELF_ORIG_HELP_STR      "Display only self-originated routes\n"
+
 #define SHOW_GR_HEADER \
 	"Codes: GR - Graceful Restart," \
 	" * -  Inheriting Global GR Config,\n" \

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3887,6 +3887,10 @@ structure is extended with :clicmd:`show bgp [afi] [safi]`.
 
    EVPN prefixes can also be filtered by EVPN route type.
 
+.. clicmd:: show bgp l2vpn evpn route [detail] [type <ead|1|macip|2|multicast|3|es|4|prefix|5>] self-originate [json]
+
+   Display self-originated EVPN prefixes which can also be filtered by EVPN route type.
+
 .. clicmd:: show bgp vni <all|VNI> [vtep VTEP] [type <ead|1|macip|2|multicast|3>] [<detail|json>]
 
    Display per-VNI EVPN routing table in bgp. Filter route-type, vtep, or VNI.
@@ -4037,6 +4041,15 @@ structure is extended with :clicmd:`show bgp [afi] [safi]`.
 .. clicmd:: show [ip] bgp [afi] [safi] [all] <A.B.C.D/M|X:X::X:X/M> longer-prefixes [wide|json]
 
    Displays the specified route and all more specific routes.
+
+   If ``wide`` option is specified, then the prefix table's width is increased
+   to fully display the prefix and the nexthop.
+
+   If the ``json`` option is specified, output is displayed in JSON format.
+
+.. clicmd:: show [ip] bgp [afi] [safi] [all] self-originate [wide|json]
+
+   Display self-originated routes.
 
    If ``wide`` option is specified, then the prefix table's width is increased
    to fully display the prefix and the nexthop.


### PR DESCRIPTION
…nly self-originated prefixes when looking at the BGP table for a given address-family

Add a keyword self-originate" to extend current CLI commands to filter out self-originated routes only

a\) CLI to show ipv4/ipv6 self-originated routes
    "show [ip] bgp [<view|vrf> VIEWVRFNAME] [<ipv4|ipv6> [<unicast|multicast|vpn|labeled-unicast|flowspec>]] [all] self-originate [json [detail] | wide]"

b\) CLI to show evpn self-originated routes
    "show bgp l2vpn evpn route [detail] [type <ead|macip|multicast|es|prefix|1|2|3|4|5>] self-originate [json]"

Signed-off-by: Karl Quan <kquan@nvidia.com>