### PR TITLE
bgpd: Remove unnecessary all_digit() call

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1403,10 +1403,6 @@ static void *route_match_local_pref_compile(const char *arg)
 	char *endptr = NULL;
 	unsigned long tmpval;
 
-	/* Locpref value shoud be integer. */
-	if (!all_digit(arg))
-		return NULL;
-
 	errno = 0;
 	tmpval = strtoul(arg, &endptr, 10);
 	if (*endptr != '\0' || errno || tmpval > UINT32_MAX)


### PR DESCRIPTION
The call for all_digit is unnecessary as that the local preference must be entered as a digit.  In other words you cannot get to this point without the string being all digits.  This check is unnecessary.