### PR TITLE
pimd: Mroutes in prune state after removing and adding attached nw config

### DIFF
--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -320,10 +320,8 @@ void pim_zebra_upstream_rpf_changed(struct pim_instance *pim,
 		 * We have detected a case where we might need
 		 * to rescan the inherited o_list so do it.
 		 */
-		if (up->channel_oil->oil_inherited_rescan) {
-			pim_upstream_inherited_olist_decide(pim, up);
-			up->channel_oil->oil_inherited_rescan = 0;
-		}
+		pim_upstream_inherited_olist_decide(pim, up);
+		up->channel_oil->oil_inherited_rescan = 0;
 
 		if (up->join_state == PIM_UPSTREAM_JOINED)
 			pim_jp_agg_switch_interface(old, &up->rpf, up);


### PR DESCRIPTION
Problem Statement:
==================
LHR has got the WHOLEPKT event, for (190.190.190.190 226.1.1.1), (190.190.190.190 226.1.1.2) and (190.190.190.190 226.1.1.3) It has created the upstream. But It has not send the join towards RP. Also mroute out interface is not correct.

Fix:
====
If RPF check returns changed, and previous interface was not there in the upstream then recalculate the mroute oil.

Signed-off-by: Vishal dhingra <rac.vishaldhingra@gmail.com>
Commited-by: Abhishek N R <abnr@vmware.com>