### PR TITLE
Fix for "Debugs For RFC 5549 Neighbor Creation #5884"

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2021,6 +2021,25 @@ static int netlink_neigh_update(int cmd, int ifindex, void *addr, char *lla,
 	if (lla)
 		nl_attr_put(&req.n, sizeof(req), NDA_LLADDR, lla, llalen);
 
+	if (IS_ZEBRA_DEBUG_KERNEL) {
+		char ip_str[INET6_ADDRSTRLEN + 8];
+		struct interface *ifp = if_lookup_by_index_per_ns(
+			zebra_ns_lookup(ns_id), ifindex);
+		if (ifp) {
+			if (family == AF_INET6)
+				snprintfrr(ip_str, sizeof(ip_str), "ipv6 %pI6",
+					   (struct in6_addr *)addr);
+			else
+				snprintfrr(ip_str, sizeof(ip_str), "ipv4 %pI4",
+					   (in_addr_t *)addr);
+			zlog_debug(
+				"%s: %s ifname %s ifindex %u addr %s mac %pEA vrf %s(%u)",
+				__func__, nl_msg_type_to_str(cmd), ifp->name,
+				ifindex, ip_str, (struct ethaddr *)lla,
+				vrf_id_to_name(ifp->vrf->vrf_id),
+				ifp->vrf->vrf_id);
+		}
+	}
 	return netlink_talk(netlink_talk_filter, &req.n, &zns->netlink_cmd, zns,
 			    false);
 }


### PR DESCRIPTION
Added Debugs For RFC 5549 Neighbor Creation

 This commit is to add debug log as discussed in below link
    https://github.com/FRRouting/frr/issues/5884

Added debug log in netlink_neigh_update(), log contains
    ifindex, ifname, ip address and mac address

 Output from zebra logs running in netns of frr after adding the fix
 
```
    netlink_neigh_update:
    RTM_DELNEIGH
    ifname veth0 ifindex 5 addr ipv4 169.254.0.1 mac b2:99:a1:ac:d3:e5
    netlink_neigh_update:
    RTM_NEWNEIGH
    ifname veth0 ifindex 5 addr ipv4 169.254.0.1 mac b2:99:a1:ac:d3:e5
```

    Signed-off-by: Kavitha <kavirhene@gmail.com>