### PR TITLE
zebra: Fix other table inactive when ip import-table is on

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3939,7 +3939,9 @@ static void rib_link(struct route_node *rn, struct route_entry *re, int process)
 
 		rmap_name = zebra_get_import_table_route_map(afi, re->table);
 		zebra_add_import_table_entry(zvrf, rn, re, rmap_name);
-	} else if (process)
+	}
+
+	if (process)
 		rib_queue_add(rn);
 }
 
@@ -4014,11 +4016,9 @@ void rib_delnode(struct route_node *rn, struct route_entry *re)
 			zlog_debug("%s(%u):%pRN: Freeing route rn %p, re %p (%s)",
 				   vrf_id_to_name(re->vrf_id), re->vrf_id, rn,
 				   rn, re, zebra_route_string(re->type));
-
-		rib_unlink(rn, re);
-	} else {
-		rib_queue_add(rn);
 	}
+
+	rib_queue_add(rn);
 }
 
 /*


### PR DESCRIPTION
In `rib_link`, if `is_zebra_import_table_enabled` returns true, `rib_queue_add` will not called, resulting in other table route node never processed. This actually should not be dependent on whether the route is imported.

In `rib_delnode`, if is_zebra_import_table_enabled returns true, it will use `rib_unlink` instead of enqueuing the route node for process. There is no reason that imported route nodes should not be reprocessed. Long ago, the behaviour was dependent on whether the route_entry comes from a table other than main.