### PR TITLE
zebra: Add ipv6 import-table command

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3787,36 +3787,17 @@ static int zebra_ip_config(struct vty *vty)
 	return write;
 }
 
-DEFUN (ip_zebra_import_table_distance,
-       ip_zebra_import_table_distance_cmd,
-       "ip import-table (1-252) [distance (1-255)] [route-map RMAP_NAME]",
-       IP_STR
-       "import routes from non-main kernel table\n"
-       "kernel routing table id\n"
-       "Distance for imported routes\n"
-       "Default distance value\n"
-       "route-map for filtering\n"
-       "route-map name\n")
+static int import_table_set(struct vty *vty, int afi, uint32_t table_id,
+			    const char *distance_str, const char *route_map)
 {
-	uint32_t table_id = 0;
-
-	table_id = strtoul(argv[2]->arg, NULL, 10);
 	int distance = ZEBRA_TABLE_DISTANCE_DEFAULT;
-	char *rmap =
-		strmatch(argv[argc - 2]->text, "route-map")
-			? XSTRDUP(MTYPE_ROUTE_MAP_NAME, argv[argc - 1]->arg)
-			: NULL;
-	int ret;
-
-	if (argc == 7 || (argc == 5 && !rmap))
-		distance = strtoul(argv[4]->arg, NULL, 10);
+	if (distance_str)
+		distance = strtoul(distance_str, NULL, 10);
 
 	if (!is_zebra_valid_kernel_table(table_id)) {
 		vty_out(vty,
 			"Invalid routing table ID, %d. Must be in range 1-252\n",
 			table_id);
-		if (rmap)
-			XFREE(MTYPE_ROUTE_MAP_NAME, rmap);
 		return CMD_WARNING;
 	}
 
@@ -3824,17 +3805,39 @@ DEFUN (ip_zebra_import_table_distance,
 		vty_out(vty,
 			"Invalid routing table ID, %d. Must be non-default table\n",
 			table_id);
-		if (rmap)
-			XFREE(MTYPE_ROUTE_MAP_NAME, rmap);
 		return CMD_WARNING;
 	}
 
-	ret = zebra_import_table(AFI_IP, VRF_DEFAULT, table_id,
-				 distance, rmap, 1);
-	if (rmap)
-		XFREE(MTYPE_ROUTE_MAP_NAME, rmap);
+	return zebra_import_table(afi, VRF_DEFAULT, table_id, distance,
+				  route_map, 1);
+}
 
-	return ret;
+DEFPY(ip_zebra_import_table_distance, ip_zebra_import_table_distance_cmd,
+      "ip import-table (1-252)$table "
+      "[distance (1-255)$distance] [route-map RMAP_NAME$rmap]",
+      IP_STR
+      "import routes from non-main kernel table\n"
+      "kernel routing table id\n"
+      "Distance for imported routes\n"
+      "Default distance value\n"
+      "route-map for filtering\n"
+      "route-map name\n")
+{
+	return import_table_set(vty, AFI_IP, table, distance_str, rmap);
+}
+
+DEFPY(ipv6_zebra_import_table_distance, ipv6_zebra_import_table_distance_cmd,
+      "ipv6 import-table (1-252)$table "
+      "[distance (1-255)$distance] [route-map RMAP_NAME$rmap]",
+      IPV6_STR
+      "import routes from non-main kernel table\n"
+      "kernel routing table id\n"
+      "Distance for imported routes\n"
+      "Default distance value\n"
+      "route-map for filtering\n"
+      "route-map name\n")
+{
+	return import_table_set(vty, AFI_IP6, table, distance_str, rmap);
 }
 
 DEFUN_HIDDEN (zebra_packet_process,
@@ -3893,20 +3896,9 @@ DEFUN_HIDDEN (no_zebra_workqueue_timer,
 	return CMD_SUCCESS;
 }
 
-DEFUN (no_ip_zebra_import_table,
-       no_ip_zebra_import_table_cmd,
-       "no ip import-table (1-252) [distance (1-255)] [route-map NAME]",
-       NO_STR
-       IP_STR
-       "import routes from non-main kernel table\n"
-       "kernel routing table id\n"
-       "Distance for imported routes\n"
-       "Default distance value\n"
-       "route-map for filtering\n"
-       "route-map name\n")
+static int import_table_unset(struct vty *vty, int afi, const char *table_str)
 {
-	uint32_t table_id = 0;
-	table_id = strtoul(argv[3]->arg, NULL, 10);
+	uint32_t table_id = strtoul(table_str, NULL, 10);
 
 	if (!is_zebra_valid_kernel_table(table_id)) {
 		vty_out(vty,
@@ -3921,10 +3913,36 @@ DEFUN (no_ip_zebra_import_table,
 		return CMD_WARNING;
 	}
 
-	if (!is_zebra_import_table_enabled(AFI_IP, VRF_DEFAULT, table_id))
+	if (!is_zebra_import_table_enabled(afi, VRF_DEFAULT, table_id))
 		return CMD_SUCCESS;
 
-	return (zebra_import_table(AFI_IP, VRF_DEFAULT, table_id, 0, NULL, 0));
+	return (zebra_import_table(afi, VRF_DEFAULT, table_id, 0, NULL, 0));
+}
+
+DEFUN(no_ip_zebra_import_table, no_ip_zebra_import_table_cmd,
+      "no ip import-table (1-252) [distance (1-255)] [route-map NAME]",
+      NO_STR IP_STR
+      "import routes from non-main kernel table\n"
+      "kernel routing table id\n"
+      "Distance for imported routes\n"
+      "Default distance value\n"
+      "route-map for filtering\n"
+      "route-map name\n")
+{
+	return import_table_unset(vty, AFI_IP, argv[3]->arg);
+}
+
+DEFUN(no_ipv6_zebra_import_table, no_ipv6_zebra_import_table_cmd,
+      "no ipv6 import-table (1-252) [distance (1-255)] [route-map NAME]",
+      NO_STR IPV6_STR
+      "import routes from non-main kernel table\n"
+      "kernel routing table id\n"
+      "Distance for imported routes\n"
+      "Default distance value\n"
+      "route-map for filtering\n"
+      "route-map name\n")
+{
+	return import_table_unset(vty, AFI_IP6, argv[3]->arg);
 }
 
 DEFPY (zebra_nexthop_group_keep,
@@ -4570,6 +4588,8 @@ void zebra_vty_init(void)
 	install_element(CONFIG_NODE, &zebra_nexthop_group_keep_cmd);
 	install_element(CONFIG_NODE, &ip_zebra_import_table_distance_cmd);
 	install_element(CONFIG_NODE, &no_ip_zebra_import_table_cmd);
+	install_element(CONFIG_NODE, &ipv6_zebra_import_table_distance_cmd);
+	install_element(CONFIG_NODE, &no_ipv6_zebra_import_table_cmd);
 	install_element(CONFIG_NODE, &zebra_workqueue_timer_cmd);
 	install_element(CONFIG_NODE, &no_zebra_workqueue_timer_cmd);
 	install_element(CONFIG_NODE, &zebra_packet_process_cmd);


### PR DESCRIPTION
Add the command to enable import from other tables for IPv6, just like what `ip import-table` do.

Test result:

```
devbox-debian(config)# ipv6 import-table 10
devbox-debian(config)# ip import-table 15 distance 2
devbox-debian(config)# do show running-config 
Building configuration...

Current configuration:
!
frr version 9.0-dev
frr defaults traditional
hostname devbox-debian
ip import-table 15 distance 2
ipv6 import-table 10
!
end
```

Route can be imported correctly:

```
root@devbox-debian:/home/zyxwvu/src/frr# ip route replace 1::2/128 dev ens33 table 10
root@devbox-debian:/home/zyxwvu/src/frr# vtysh/vtysh -c "show ipv6 route"
% Can't open configuration file /usr/local/etc/vtysh.conf due to 'No such file or directory'.
Codes: K - kernel route, C - connected, S - static, R - RIPng,
       B - BGP, T - Table, v - VNC, V - VNC-Direct, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

T[10]>* 1::2/128 [15/1024] is directly connected, ens33, 00:00:02
C>* fe80::/64 is directly connected, ens33, 00:09:32
```