### PR TITLE
ospfd client api bugfix and refinements

### DIFF
--- a/ospfclient/ospfclient.py
+++ b/ospfclient/ospfclient.py
@@ -604,14 +604,6 @@ class OspfOpaqueClient(OspfApiClient):
             mp = struct.pack(msg_fmt[mt], lsa_type, otype)
             await self.msg_send_raises(mt, mp)
 
-    async def _assure_opaque_ready(self, lsa_type, otype):
-        async with self.ready_lock:
-            if self.ready_cond[lsa_type].get(otype) is True:
-                return
-
-        await self._register_opaque_data(lsa_type, otype)
-        await self.wait_opaque_ready(lsa_type, otype)
-
     async def _handle_msg_loop(self):
         try:
             logging.debug("entering async msg handling loop")
@@ -812,6 +804,7 @@ class OspfOpaqueClient(OspfApiClient):
         Raises:
             See `msg_send_raises`
         """
+        assert self.ready_cond.get(lsa_type, {}).get(otype) is True, "Not Registered!"
 
         if lsa_type == LSA_TYPE_OPAQUE_LINK:
             ifaddr, aid = int(addr), 0
@@ -829,7 +822,6 @@ class OspfOpaqueClient(OspfApiClient):
             *OspfOpaqueClient._opaque_args(lsa_type, otype, oid, data),
         )
         msg += data
-        await self._assure_opaque_ready(lsa_type, otype)
         await self.msg_send_raises(mt, msg)
 
     async def delete_opaque_data(self, addr, lsa_type, otype, oid, flags=0):
@@ -841,20 +833,30 @@ class OspfOpaqueClient(OspfApiClient):
         Args:
             addr: depends on lsa_type, LINK => ifaddr, AREA => area ID, AS => ignored
             lsa_type: LSA_TYPE_OPAQUE_{LINK,AREA,AS}
-            otype: (octet) opaque type. Note: the type will be registered if the user
-                has not explicity done that yet with `register_opaque_data`.
+            otype: (octet) opaque type.
             oid: (3 octets) ID of this opaque data
             flags: (octet) optional flags (e.g., OSPF_API_DEL_ZERO_LEN_LSA, defaults to no flags)
         Raises:
             See `msg_send_raises`
         """
-        if (lsa_type, otype) in self.opaque_change_cb:
-            del self.opaque_change_cb[(lsa_type, otype)]
+        assert self.ready_cond.get(lsa_type, {}).get(otype) is True, "Not Registered!"
 
         mt = MSG_DELETE_REQUEST
-        await self._assure_opaque_ready(lsa_type, otype)
         mp = struct.pack(msg_fmt[mt], int(addr), lsa_type, otype, flags, oid)
         await self.msg_send_raises(mt, mp)
+
+    async def is_registered(self, lsa_type, otype):
+        """Determine if an (lsa_type, otype) tuple has been registered with FRR
+
+        This determines if the type has been registered, but not necessarily if it is
+        ready, if that is required use the `wait_opaque_ready` metheod.
+
+        Args:
+            lsa_type: LSA_TYPE_OPAQUE_{LINK,AREA,AS}
+            otype: (octet) opaque type.
+        """
+        async with self.ready_lock:
+            return self.ready_cond.get(lsa_type, {}).get(otype) is not None
 
     async def register_opaque_data(self, lsa_type, otype, callback=None):
         """Register intent to advertise opaque data.
@@ -865,8 +867,7 @@ class OspfOpaqueClient(OspfApiClient):
 
         Args:
             lsa_type: LSA_TYPE_OPAQUE_{LINK,AREA,AS}
-            otype: (octet) opaque type. Note: the type will be registered if the user
-                has not explicity done that yet with `register_opaque_data`.
+            otype: (octet) opaque type.
             callback: if given, callback will be called when changes are received for
                 LSA of the given (lsa_type, otype). The callbacks signature is:
 
@@ -882,6 +883,10 @@ class OspfOpaqueClient(OspfApiClient):
         Raises:
             See `msg_send_raises`
         """
+        assert not await self.is_registered(
+            lsa_type, otype
+        ), "Registering registered type"
+
         if callback:
             self.opaque_change_cb[(lsa_type, otype)] = callback
         elif (lsa_type, otype) in self.opaque_change_cb:
@@ -920,8 +925,7 @@ class OspfOpaqueClient(OspfApiClient):
 
         Args:
             lsa_type: LSA_TYPE_OPAQUE_{LINK,AREA,AS}
-            otype: (octet) opaque type. Note: the type will be registered if the user
-                has not explicity done that yet with `register_opaque_data`.
+            otype: (octet) opaque type.
             callback: if given, callback will be called when changes are received for
                 LSA of the given (lsa_type, otype). The callbacks signature is:
 
@@ -938,17 +942,8 @@ class OspfOpaqueClient(OspfApiClient):
 
             See `msg_send_raises`
         """
-        if callback:
-            self.opaque_change_cb[(lsa_type, otype)] = callback
-        elif (lsa_type, otype) in self.opaque_change_cb:
-            logging.warning(
-                "OSPFCLIENT: register: removing callback for %s opaque-type %s",
-                lsa_typename(lsa_type),
-                otype,
-            )
-            del self.opaque_change_cb[(lsa_type, otype)]
-
-        return await self._assure_opaque_ready(lsa_type, otype)
+        await self.register_opaque_data(lsa_type, otype, callback)
+        await self.wait_opaque_ready(lsa_type, otype)
 
     async def unregister_opaque_data(self, lsa_type, otype):
         """Unregister intent to advertise opaque data.
@@ -958,11 +953,13 @@ class OspfOpaqueClient(OspfApiClient):
 
         Args:
             lsa_type: LSA_TYPE_OPAQUE_{LINK,AREA,AS}
-            otype: (octet) opaque type. Note: the type will be registered if the user
-                has not explicity done that yet with `register_opaque_data`.
+            otype: (octet) opaque type.
         Raises:
             See `msg_send_raises`
         """
+        assert await self.is_registered(
+            lsa_type, otype
+        ), "Unregistering unregistered type"
 
         if (lsa_type, otype) in self.opaque_change_cb:
             del self.opaque_change_cb[(lsa_type, otype)]
@@ -1106,6 +1103,10 @@ async def async_main(args):
                     except ValueError:
                         addr = ip(aval)
                 oargs = [addr, ltype, int(_s.pop(False)), int(_s.pop(False))]
+
+                if not await c.is_registered(oargs[1], oargs[2]):
+                    await c.register_opaque_data_wait(oargs[1], oargs[2])
+
                 if what.casefold() == "add":
                     try:
                         b = bytes.fromhex(_s.pop(False))

--- a/ospfclient/ospfclient.py
+++ b/ospfclient/ospfclient.py
@@ -242,6 +242,16 @@ def nsm_name(state):
     return names.get(state, str(state))
 
 
+class WithNothing:
+    "An object that does nothing when used with `with` statement."
+
+    async def __aenter__(self):
+        return
+
+    async def __aexit__(self, *args, **kwargs):
+        return
+
+
 # --------------
 # Client Classes
 # --------------
@@ -547,15 +557,17 @@ class OspfOpaqueClient(OspfApiClient):
 
     Args:
         server: hostname or IP address of server default is "localhost"
+        wait_ready: if True then wait for OSPF to signal ready, in newer versions
+            FRR ospfd is always ready so this overhead can be skipped.
+            default is False.
 
     Raises:
         Will raise exceptions for failures with various `socket` modules
         functions such as `socket.socket`, `socket.setsockopt`, `socket.bind`.
     """
 
-    def __init__(self, server="localhost"):
+    def __init__(self, server="localhost", wait_ready=False):
         handlers = {
-            MSG_READY_NOTIFY: self._ready_msg,
             MSG_LSA_UPDATE_NOTIFY: self._lsa_change_msg,
             MSG_LSA_DELETE_NOTIFY: self._lsa_change_msg,
             MSG_NEW_IF: self._if_msg,
@@ -565,9 +577,13 @@ class OspfOpaqueClient(OspfApiClient):
             MSG_REACHABLE_CHANGE: self._reachable_msg,
             MSG_ROUTER_ID_CHANGE: self._router_id_msg,
         }
+        if wait_ready:
+            handlers[MSG_READY_NOTIFY] = self._ready_msg
+
         super().__init__(server, handlers)
 
-        self.ready_lock = Lock()
+        self.wait_ready = wait_ready
+        self.ready_lock = Lock() if wait_ready else WithNothing()
         self.ready_cond = {
             LSA_TYPE_OPAQUE_LINK: {},
             LSA_TYPE_OPAQUE_AREA: {},
@@ -604,6 +620,10 @@ class OspfOpaqueClient(OspfApiClient):
             mp = struct.pack(msg_fmt[mt], lsa_type, otype)
             await self.msg_send_raises(mt, mp)
 
+            # If we are not waiting, mark ready for register check
+            if not self.wait_ready:
+                self.ready_cond[lsa_type][otype] = True
+
     async def _handle_msg_loop(self):
         try:
             logging.debug("entering async msg handling loop")
@@ -635,6 +655,8 @@ class OspfOpaqueClient(OspfApiClient):
         return lsa
 
     async def _ready_msg(self, mt, msg, extra, lsa_type, otype, addr):
+        assert self.wait_ready
+
         if lsa_type == LSA_TYPE_OPAQUE_LINK:
             e = "ifaddr {}".format(ip(addr))
         elif lsa_type == LSA_TYPE_OPAQUE_AREA:
@@ -905,6 +927,8 @@ class OspfOpaqueClient(OspfApiClient):
             if cond is True:
                 return
 
+            assert self.wait_ready
+
             logging.debug(
                 "waiting for ready %s opaque-type %s", lsa_typename(lsa_type), otype
             )
@@ -1065,6 +1089,17 @@ class OspfOpaqueClient(OspfApiClient):
 # ================
 # CLI/Script Usage
 # ================
+def next_action(action_list=None):
+    "Get next action from list or STDIN"
+    if action_list:
+        for action in action_list:
+            yield action
+    else:
+        while True:
+            action = input("")
+            if not action:
+                break
+            yield action.strip()
 
 
 async def async_main(args):
@@ -1083,54 +1118,53 @@ async def async_main(args):
         await c.req_ism_states()
         await c.req_nsm_states()
 
-        if args.actions:
-            for action in args.actions:
-                _s = action.split(",")
-                what = _s.pop(False)
-                if what.casefold() == "wait":
-                    stime = int(_s.pop(False))
-                    logging.info("waiting %s seconds", stime)
-                    await asyncio.sleep(stime)
-                    logging.info("wait complete: %s seconds", stime)
-                    continue
-                ltype = int(_s.pop(False))
-                if ltype == 11:
-                    addr = ip(0)
-                else:
-                    aval = _s.pop(False)
-                    try:
-                        addr = ip(int(aval))
-                    except ValueError:
-                        addr = ip(aval)
-                oargs = [addr, ltype, int(_s.pop(False)), int(_s.pop(False))]
+        for action in next_action(args.actions):
+            _s = action.split(",")
+            what = _s.pop(False)
+            if what.casefold() == "wait":
+                stime = int(_s.pop(False))
+                logging.info("waiting %s seconds", stime)
+                await asyncio.sleep(stime)
+                logging.info("wait complete: %s seconds", stime)
+                continue
+            ltype = int(_s.pop(False))
+            if ltype == 11:
+                addr = ip(0)
+            else:
+                aval = _s.pop(False)
+                try:
+                    addr = ip(int(aval))
+                except ValueError:
+                    addr = ip(aval)
+            oargs = [addr, ltype, int(_s.pop(False)), int(_s.pop(False))]
 
-                if not await c.is_registered(oargs[1], oargs[2]):
-                    await c.register_opaque_data_wait(oargs[1], oargs[2])
+            if not await c.is_registered(oargs[1], oargs[2]):
+                await c.register_opaque_data_wait(oargs[1], oargs[2])
 
-                if what.casefold() == "add":
+            if what.casefold() == "add":
+                try:
+                    b = bytes.fromhex(_s.pop(False))
+                except IndexError:
+                    b = b""
+                logging.info("opaque data is %s octets", len(b))
+                # Needs to be multiple of 4 in length
+                mod = len(b) % 4
+                if mod:
+                    b += b"\x00" * (4 - mod)
+                    logging.info("opaque padding to %s octets", len(b))
+
+                await c.add_opaque_data(*oargs, b)
+            else:
+                assert what.casefold().startswith("del")
+                f = 0
+                if len(_s) >= 1:
                     try:
-                        b = bytes.fromhex(_s.pop(False))
+                        f = int(_s.pop(False))
                     except IndexError:
-                        b = b""
-                    logging.info("opaque data is %s octets", len(b))
-                    # Needs to be multiple of 4 in length
-                    mod = len(b) % 4
-                    if mod:
-                        b += b"\x00" * (4 - mod)
-                        logging.info("opaque padding to %s octets", len(b))
-
-                    await c.add_opaque_data(*oargs, b)
-                else:
-                    assert what.casefold().startswith("del")
-                    f = 0
-                    if len(_s) >= 1:
-                        try:
-                            f = int(_s.pop(False))
-                        except IndexError:
-                            f = 0
-                    await c.delete_opaque_data(*oargs, f)
-            if args.exit:
-                return 0
+                        f = 0
+                await c.delete_opaque_data(*oargs, f)
+        if not args.actions or args.exit:
+            return 0
     except Exception as error:
         logging.error("async_main: unexpected error: %s", error, exc_info=True)
         return 2
@@ -1146,19 +1180,23 @@ async def async_main(args):
 
 def main(*args):
     ap = argparse.ArgumentParser(args)
+    ap.add_argument("--logtag", default="CLIENT", help="tag to identify log messages")
     ap.add_argument("--exit", action="store_true", help="Exit after commands")
     ap.add_argument("--server", default="localhost", help="OSPF API server")
     ap.add_argument("-v", "--verbose", action="store_true", help="be verbose")
     ap.add_argument(
         "actions",
         nargs="*",
-        help="(ADD|DEL),LSATYPE,[ADDR,],OTYPE,OID,[HEXDATA|DEL_FLAG]",
+        help="WAIT,SEC|(ADD|DEL),LSATYPE,[ADDR,],OTYPE,OID,[HEXDATA|DEL_FLAG]",
     )
     args = ap.parse_args()
 
     level = logging.DEBUG if args.verbose else logging.INFO
     logging.basicConfig(
-        level=level, format="%(asctime)s %(levelname)s: CLIENT: %(name)s %(message)s"
+        level=level,
+        format="%(asctime)s %(levelname)s: {}: %(name)s %(message)s".format(
+            args.logtag
+        ),
     )
 
     logging.info("ospfclient: starting")

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -2578,9 +2578,12 @@ static inline int cmp_route_nodes(struct route_node *orn,
 		return 1;
 	else if (!nrn)
 		return -1;
-	else if (orn->p.u.prefix4.s_addr < nrn->p.u.prefix4.s_addr)
+
+	uint32_t opn = ntohl(orn->p.u.prefix4.s_addr);
+	uint32_t npn = ntohl(nrn->p.u.prefix4.s_addr);
+	if (opn < npn)
 		return -1;
-	else if (orn->p.u.prefix4.s_addr > nrn->p.u.prefix4.s_addr)
+	else if (opn > npn)
 		return 1;
 	else
 		return 0;

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -19,6 +19,7 @@
 #include "thread.h"
 #include "hash.h"
 #include "sockunion.h" /* for inet_aton() */
+#include "printfrr.h"
 
 #include "ospfd/ospfd.h"
 #include "ospfd/ospf_interface.h"
@@ -1147,11 +1148,13 @@ void ospf_opaque_config_write_debug(struct vty *vty)
 void show_opaque_info_detail(struct vty *vty, struct ospf_lsa *lsa,
 			     json_object *json)
 {
+	char buf[128], *bp;
 	struct lsa_header *lsah = lsa->data;
 	uint32_t lsid = ntohl(lsah->id.s_addr);
 	uint8_t opaque_type = GET_OPAQUE_TYPE(lsid);
 	uint32_t opaque_id = GET_OPAQUE_ID(lsid);
 	struct ospf_opaque_functab *functab;
+	int len, lenValid;
 
 	/* Switch output functionality by vty address. */
 	if (vty != NULL) {
@@ -1170,11 +1173,19 @@ void show_opaque_info_detail(struct vty *vty, struct ospf_lsa *lsa,
 				json, "opaqueType",
 				ospf_opaque_type_name(opaque_type));
 			json_object_int_add(json, "opaqueId", opaque_id);
-			json_object_int_add(json, "opaqueDataLength",
-					    ntohs(lsah->length)
-						    - OSPF_LSA_HEADER_SIZE);
+			len = ntohs(lsah->length) - OSPF_LSA_HEADER_SIZE;
+			json_object_int_add(json, "opaqueDataLength", len);
+			lenValid = VALID_OPAQUE_INFO_LEN(lsah);
 			json_object_boolean_add(json, "opaqueDataLengthValid",
-						VALID_OPAQUE_INFO_LEN(lsah));
+						lenValid);
+			if (lenValid) {
+				bp = asnprintfrr(MTYPE_TMP, buf, sizeof(buf),
+						 "%*pHXn", (int)len,
+						 (lsah + 1));
+				json_object_string_add(json, "opaqueData", buf);
+				if (bp != buf)
+					XFREE(MTYPE_TMP, bp);
+			}
 		}
 	} else {
 		zlog_debug("    Opaque-Type %u (%s)", opaque_type,

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -348,44 +348,49 @@ void ospf_route_install(struct ospf *ospf, struct route_table *rt)
 
 /* RFC2328 16.1. (4). For "router". */
 void ospf_intra_add_router(struct route_table *rt, struct vertex *v,
-			   struct ospf_area *area, bool add_all)
+			   struct ospf_area *area, bool add_only)
 {
 	struct route_node *rn;
 	struct ospf_route * or ;
 	struct prefix_ipv4 p;
 	struct router_lsa *lsa;
 
-	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("%s: Start", __func__);
-
+	if (IS_DEBUG_OSPF_EVENT) {
+		if (!add_only)
+			zlog_debug("%s: Start", __func__);
+		else
+			zlog_debug("%s: REACHRUN: Start", __func__);
+	}
 	lsa = (struct router_lsa *)v->lsa;
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("%s: LS ID: %pI4", __func__, &lsa->header.id);
 
-	if (!OSPF_IS_AREA_BACKBONE(area))
-		ospf_vl_up_check(area, lsa->header.id, v);
+	if (!add_only) {
+		if (!OSPF_IS_AREA_BACKBONE(area))
+			ospf_vl_up_check(area, lsa->header.id, v);
 
-	if (!CHECK_FLAG(lsa->flags, ROUTER_LSA_SHORTCUT))
-		area->shortcut_capability = 0;
+		if (!CHECK_FLAG(lsa->flags, ROUTER_LSA_SHORTCUT))
+			area->shortcut_capability = 0;
 
-	/* If the newly added vertex is an area border router or AS boundary
-	   router, a routing table entry is added whose destination type is
-	   "router". */
-	if (!add_all && !IS_ROUTER_LSA_BORDER(lsa) &&
-	    !IS_ROUTER_LSA_EXTERNAL(lsa)) {
-		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug(
-				"%s: this router is neither ASBR nor ABR, skipping it",
-				__func__);
-		return;
+		/* If the newly added vertex is an area border router or AS
+		   boundary router, a routing table entry is added whose
+		   destination type is "router". */
+		if (!IS_ROUTER_LSA_BORDER(lsa) &&
+		    !IS_ROUTER_LSA_EXTERNAL(lsa)) {
+			if (IS_DEBUG_OSPF_EVENT)
+				zlog_debug(
+					"%s: this router is neither ASBR nor ABR, skipping it",
+					__func__);
+			return;
+		}
+
+		/* Update ABR and ASBR count in this area. */
+		if (IS_ROUTER_LSA_BORDER(lsa))
+			area->abr_count++;
+		if (IS_ROUTER_LSA_EXTERNAL(lsa))
+			area->asbr_count++;
 	}
-
-	/* Update ABR and ASBR count in this area. */
-	if (IS_ROUTER_LSA_BORDER(lsa))
-		area->abr_count++;
-	if (IS_ROUTER_LSA_EXTERNAL(lsa))
-		area->asbr_count++;
 
 	/* The Options field found in the associated router-LSA is copied
 	   into the routing table entry's Optional capabilities field. Call
@@ -433,8 +438,12 @@ void ospf_intra_add_router(struct route_table *rt, struct vertex *v,
 
 	listnode_add(rn->info, or);
 
-	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("%s: Stop", __func__);
+	if (IS_DEBUG_OSPF_EVENT) {
+		if (!add_only)
+			zlog_debug("%s: Stop", __func__);
+		else
+			zlog_debug("%s: REACHRUN: Stop", __func__);
+	}
 }
 
 /* RFC2328 16.1. (4).  For transit network. */

--- a/tests/topotests/ospfapi/r1/ospfd.conf
+++ b/tests/topotests/ospfapi/r1/ospfd.conf
@@ -4,7 +4,12 @@ interface r1-eth0
   ip ospf dead-interval 10
   ip ospf area 1.2.3.4
 !
+interface r1-eth1
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
+  ip ospf area 1.2.3.4
+!
 router ospf
-  ospf router-id 192.168.0.1
+  ospf router-id 1.0.0.0
   capability opaque
 !

--- a/tests/topotests/ospfapi/r1/zebra.conf
+++ b/tests/topotests/ospfapi/r1/zebra.conf
@@ -2,3 +2,5 @@
 interface r1-eth0
  ip address 10.0.1.1/24
 !
+interface r1-eth1
+ ip address 10.0.4.1/24

--- a/tests/topotests/ospfapi/r2/ospfd.conf
+++ b/tests/topotests/ospfapi/r2/ospfd.conf
@@ -10,6 +10,6 @@ interface r2-eth1
   ip ospf area 1.2.3.4
 !
 router ospf
-  ospf router-id 192.168.0.2
+  ospf router-id 2.0.0.0
   capability opaque
 !

--- a/tests/topotests/ospfapi/r3/ospfd.conf
+++ b/tests/topotests/ospfapi/r3/ospfd.conf
@@ -10,6 +10,6 @@ interface r3-eth1
   ip ospf area 1.2.3.4
 !
 router ospf
-  ospf router-id 192.168.0.3
+  ospf router-id 3.0.0.0
   capability opaque
 !

--- a/tests/topotests/ospfapi/r4/ospfd.conf
+++ b/tests/topotests/ospfapi/r4/ospfd.conf
@@ -4,7 +4,12 @@ interface r4-eth0
   ip ospf dead-interval 10
   ip ospf area 1.2.3.4
 !
+interface r4-eth1
+  ip ospf hello-interval 2
+  ip ospf dead-interval 10
+  ip ospf area 1.2.3.4
+!
 router ospf
-  ospf router-id 192.168.0.4
+  ospf router-id 4.0.0.0
   capability opaque
 !

--- a/tests/topotests/ospfapi/r4/zebra.conf
+++ b/tests/topotests/ospfapi/r4/zebra.conf
@@ -2,3 +2,5 @@
 interface r4-eth0
  ip address 10.0.3.4/24
 !
+interface r4-eth1
+ ip address 10.0.4.4/24


### PR DESCRIPTION
- Add opaque data to the `detail json` show command output
- Bugfix with router reachability counts
- Bugfix with API reachability sorting order
- simplify ospfclient by removing implicit opaque type registration
- Add ability to enter API commands from over stdin
- Improve the topotest to adding a 4 router ring topology