### PR TITLE
pimd: don't try to check RPF for incoming SSM data

### DIFF
--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -148,18 +148,34 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 	struct pim_rpf *rpg;
 	pim_sgaddr sg;
 
-	rpg = pim_ifp ? RP(pim_ifp->pim, msg->msg_im_dst) : NULL;
+	memset(&sg, 0, sizeof(sg));
+	sg.src = msg->msg_im_src;
+	sg.grp = msg->msg_im_dst;
+
+	if (!pim_ifp) {
+		if (PIM_DEBUG_MROUTE)
+			zlog_debug(
+				"%s: PIM not enabled on interface, dropping packet to %pSG",
+				ifp->name, &sg);
+		return 0;
+	}
+
+	rpg = RP(pim_ifp->pim, msg->msg_im_dst);
 	/*
 	 * If the incoming interface is unknown OR
 	 * the Interface type is SSM we don't need to
 	 * do anything here
 	 */
-	if (!rpg || pim_rpf_addr_is_inaddr_any(rpg)) {
-		if (PIM_DEBUG_MROUTE_DETAIL)
-			zlog_debug(
-				"%s: Interface is not configured correctly to handle incoming packet: Could be !pim_ifp, !SM, !RP",
-				__func__);
-
+	if (!rpg) {
+		if (PIM_DEBUG_MROUTE)
+			zlog_debug("%s: no RPF for packet to %pSG", ifp->name,
+				   &sg);
+		return 0;
+	}
+	if (pim_rpf_addr_is_inaddr_any(rpg)) {
+		if (PIM_DEBUG_MROUTE)
+			zlog_debug("%s: null RPF for packet to %pSG", ifp->name,
+				   &sg);
 		return 0;
 	}
 
@@ -168,22 +184,21 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 	 * us
 	 */
 	if (!pim_if_connected_to_source(ifp, msg->msg_im_src)) {
-		if (PIM_DEBUG_MROUTE_DETAIL)
+		if (PIM_DEBUG_MROUTE)
 			zlog_debug(
-				"%s: Received incoming packet that doesn't originate on our seg",
-				__func__);
+				"%s: incoming packet to %pSG from non-connected source",
+				ifp->name, &sg);
 		return 0;
 	}
 
-	memset(&sg, 0, sizeof(sg));
-	sg.src = msg->msg_im_src;
-	sg.grp = msg->msg_im_dst;
-
 	if (!(PIM_I_am_DR(pim_ifp))) {
+		/* unlike the other debug messages, this one is further in the
+		 * "normal operation" category and thus under _DETAIL
+		 */
 		if (PIM_DEBUG_MROUTE_DETAIL)
 			zlog_debug(
-				"%s: Interface is not the DR blackholing incoming traffic for %pSG",
-				__func__, &sg);
+				"%s: not DR on interface, not forwarding traffic for %pSG",
+				ifp->name, &sg);
 
 		/*
 		 * We are not the DR, but we are still receiving packets


### PR DESCRIPTION
For incoming no-receiver SSM traffic, there isn't going to be a RP, much less a RPF.  We should install an MFC entry with empty oif regardless, so we don't get swamped with further notifications.

---
This is on top of #12878.

TBH while our behavior here for ASM can be argued to be correct, I'm not sure it's particularly useful — it results in the kernel spamming us with NOCACHE notifications if we have no RP config for the groups in question.
