### PR TITLE
bgpd: Flowspec overflow issue

### DIFF
--- a/bgpd/bgp_flowspec.c
+++ b/bgpd/bgp_flowspec.c
@@ -127,6 +127,13 @@ int bgp_nlri_parse_flowspec(struct peer *peer, struct attr *attr,
 				psize);
 			return BGP_NLRI_PARSE_ERROR_PACKET_OVERFLOW;
 		}
+
+		if (psize == 0) {
+			flog_err(EC_BGP_FLOWSPEC_PACKET,
+				 "Flowspec NLRI length 0 which makes no sense");
+			return BGP_NLRI_PARSE_ERROR_PACKET_OVERFLOW;
+		}
+
 		if (bgp_fs_nlri_validate(pnt, psize, afi) < 0) {
 			flog_err(
 				EC_BGP_FLOWSPEC_PACKET,


### PR DESCRIPTION
According to the flowspec RFC 8955 a flowspec nlri is <length, <nlri data>> Specifying 0 as a length makes BGP get all warm on the inside.  Which in this case is not a good thing at all.  Prevent warmth, stay cold on the inside.

Reported-by: Iggy Frankovic <iggyfran@amazon.com>