### PR TITLE
lib, bgpd: bmp was not specifying l2vpn afi

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2498,14 +2498,13 @@ static int bmp_config_write(struct bgp *bgp, struct vty *vty)
 			vty_out(vty, "  bmp mirror\n");
 
 		FOREACH_AFI_SAFI (afi, safi) {
-			const char *afi_str = (afi == AFI_IP) ? "ipv4" : "ipv6";
-
 			if (bt->afimon[afi][safi] & BMP_MON_PREPOLICY)
 				vty_out(vty, "  bmp monitor %s %s pre-policy\n",
-					afi_str, safi2str(safi));
+					afi2str_lower(afi), safi2str(safi));
 			if (bt->afimon[afi][safi] & BMP_MON_POSTPOLICY)
-				vty_out(vty, "  bmp monitor %s %s post-policy\n",
-					afi_str, safi2str(safi));
+				vty_out(vty,
+					"  bmp monitor %s %s post-policy\n",
+					afi2str_lower(afi), safi2str(safi));
 		}
 		frr_each (bmp_listeners, &bt->listeners, bl)
 			vty_out(vty, " \n  bmp listener %pSU port %d\n",

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -123,6 +123,23 @@ afi_t family2afi(int family)
 	return 0;
 }
 
+const char *afi2str_lower(afi_t afi)
+{
+	switch (afi) {
+	case AFI_IP:
+		return "ipv4";
+	case AFI_IP6:
+		return "ipv6";
+	case AFI_L2VPN:
+		return "l2vpn";
+	case AFI_MAX:
+	case AFI_UNSPEC:
+		return "bad-value";
+	}
+
+	assert(!"Reached end of function we should never reach");
+}
+
 const char *afi2str(afi_t afi)
 {
 	switch (afi) {

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -383,6 +383,7 @@ extern afi_t family2afi(int);
 extern const char *family2str(int family);
 extern const char *safi2str(safi_t safi);
 extern const char *afi2str(afi_t afi);
+extern const char *afi2str_lower(afi_t afi);
 
 static inline afi_t prefix_afi(union prefixconstptr pu)
 {


### PR DESCRIPTION
The l2vpn afi was not being properly displayed
when a show run was being issued.  Add a
afi2str_lower function and use it.

Fixes: #12867