### PR TITLE
bgpd: Avoid double aspath_dup() for confederation when remote-as != AS_SPECIFIED

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -4312,7 +4312,6 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer,
 			 * if the peer belongs to us.
 			 */
 			if (bgp_confederation_peers_check(bgp, peer->as)) {
-				aspath = aspath_dup(attr->aspath);
 				aspath = aspath_add_confed_seq(aspath,
 							       peer->local_as);
 			} else {


### PR DESCRIPTION
Just was blind when not seing it's already dup'ed above:

```	if (peer->sort == BGP_PEER_EBGP
	    && (!CHECK_FLAG(peer->af_flags[afi][safi],
			    PEER_FLAG_AS_PATH_UNCHANGED)
		|| attr->aspath->segments == NULL)
	    && (!CHECK_FLAG(peer->af_flags[afi][safi],
			    PEER_FLAG_RSERVER_CLIENT))) {
		aspath = aspath_dup(attr->aspath); <<<<<<<<<<<<<<<
```