### PR TITLE
pimd, pim6d: Don't track nexthop for RP 0.0.0.0 & 0::0

### DIFF
--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -1066,6 +1066,14 @@ struct pim_rpf *pim_rp_g(struct pim_instance *pim, pim_addr group)
 	if (rp_info) {
 		pim_addr nht_p;
 
+		if (pim_addr_is_any(rp_info->rp.rpf_addr)) {
+			if (PIM_DEBUG_PIM_NHT_RP)
+				zlog_debug(
+					"%s: Skipping NHT Register since RP is not configured for the group %pPA",
+					__func__, &group);
+			return &rp_info->rp;
+		}
+
 		/* Register addr with Zebra NHT */
 		nht_p = rp_info->rp.rpf_addr;
 		if (PIM_DEBUG_PIM_NHT_RP)


### PR DESCRIPTION
Topology:
FHR----Source

Problem:
When FHR receives multicast traffic, there is no RP configured, PIMD does NHT register for RP address 0.0.0.0 and group 224.0.0.0/4 PIM6D does NHT register for RP address 0::0 and group FF00::0/8

frr# show ip pim nexthop
Number of registered addresses: 1
Address         Interface        Nexthop

frr# show ipv6 pim nexthop
Number of registered addresses: 1
Address         Interface        Nexthop

Fix:
Don't track nexthop for RP 0.0.0.0 & 0::0.

frr# show ip pim nexthop
Number of registered addresses: 0

frr# show ipv6 pim nexthop
Number of registered addresses: 0

Closes #12104