### PR TITLE
pimd, pim6d: Upstream IIF pointing towards PIM and IGMP disabled source conn…

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -157,10 +157,10 @@ static int pim_cmd_interface_delete(struct interface *ifp)
 	 * pim_ifp->pim_neighbor_list.
 	 */
 	pim_sock_delete(ifp, "pim unconfigured on interface");
+	pim_upstream_nh_if_update(pim_ifp->pim, ifp);
 
 	if (!pim_ifp->gm_enable) {
 		pim_if_addr_del_all(ifp);
-		pim_upstream_nh_if_update(pim_ifp->pim, ifp);
 		pim_if_delete(ifp);
 	}
 


### PR DESCRIPTION
pimd, pim6d: Upstream IIF pointing towards PIM and IGMP disabled source connected interface

Topology:
RP---FHR<ens224>---Source

Problem Statement:
Step 1:
Enable PIM and IGMP on source connected interface ens224

Step 2:
Start multicast traffic. (s,g) mroute and upstream will be created as expected.

dev# show ip mroute
IP Multicast Routing Table
Flags: S - Sparse, C - Connected, P - Pruned
       R - SGRpt Pruned, F - Register flag, T - SPT-bit for SSM FHR
 Source    Group      Flags  Proto  Input   Output  TTL  Uptime
 50.0.0.4  225.1.1.1  SF     PIM    ens224  pimreg  1    00:37:55

dev# show ip pim upstream
 Iif     Source    Group      State      Uptime    JoinTimer  RSTimer   KATimer   RefCnt
 ens224  50.0.0.4  225.1.1.1  NotJ,RegJ  00:37:57  --:--:--   --:--:--  00:02:43  1

Step 3:
Disable PIM on source connected interafce ens224

dev# show ip mroute
IP Multicast Routing Table
Flags: S - Sparse, C - Connected, P - Pruned
       R - SGRpt Pruned, F - Register flag, T - SPT-bit for SSM FHR
 Source    Group      Flags  Proto  Input   Output  TTL  Uptime
 50.0.0.4  225.1.1.1  SF     PIM    ens224  pimreg  1    00:38:05

dev# show ip pim upstream
 Iif     Source    Group      State      Uptime    JoinTimer  RSTimer   KATimer   RefCnt
 ens224  50.0.0.4  225.1.1.1  NotJ,RegJ  00:38:08  --:--:--   --:--:--  00:02:32  1

Step 4:
Disable IGMP on source connected interface ens224

dev# show ip pim upstream
 Iif     Source    Group      State      Uptime    JoinTimer  RSTimer   KATimer   RefCnt
 ens224  50.0.0.4  225.1.1.1  NotJ,RegJ  00:38:15  --:--:--   --:--:--  00:03:27  1

dev# show ip mroute
IP Multicast Routing Table
Flags: S - Sparse, C - Connected, P - Pruned
       R - SGRpt Pruned, F - Register flag, T - SPT-bit for SSM FHR
 Source    Group      Flags  Proto  Input   Output  TTL  Uptime
 50.0.0.4  225.1.1.1  SF     PIM    <iif?>  pimreg  1    00:38:18

Pim upstream IIF is still pointing towards the source connected interface which is not pim enabled and not IGMP enabled and Mroute is still present in the kernel and KAT timer is still running on the interface, where ifp->info is already set to NULL. This leads to crash.

Root Cause:
When "no ip pim" commands get executed on source connected interface, we are updating upstream IIF only when IGMP is not enabled on the same interface.

Fix:
When PIM is disabled on source connected interface, update upstream IIF no matter if IGMP is enabled or not on the same interface.

Closes #12848
Closes #10782