### PR TITLE
tests: Use inequality operator for strings

### DIFF
--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -2816,7 +2816,7 @@ def get_ospf_database(tgen, topo, dut, input_dict, vrf=None, lsatype=None, rid=N
                                 result = True
                                 break
                             if (
-                                _age is not "get"
+                                _age != "get"
                                 and lsa["lsaAge"]
                                 == show_ospf_json["routerLinkStates"][rtrlsa][
                                     ospf_area


### PR DESCRIPTION
tests/topotests/lib/ospf.py:2819: SyntaxWarning: "is not" with a literal. Did you mean "!="?
    _age is not "get"

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html