### PR TITLE
pimd, pim6d: Don't start KAT timer when traffic received on PIM disabled interface

### DIFF
--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -154,11 +154,15 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 	sg.src = msg->msg_im_src;
 	sg.grp = msg->msg_im_dst;
 
-	if (!pim_ifp) {
+
+	if (!pim_ifp || !pim_ifp->pim_enable) {
 		if (PIM_DEBUG_MROUTE)
 			zlog_debug(
-				"%s: PIM not enabled on interface, dropping packet to %pSG",
-				ifp->name, &sg);
+				"%s: %s on interface, dropping packet to %pSG",
+				ifp->name,
+				!pim_ifp ? "Multicast not enabled"
+					 : "PIM not enabled",
+				&sg);
 		return 0;
 	}
 


### PR DESCRIPTION
pimd, pim6d: Don't start KAT timer when traffic received on PIM disabled interface

Topology:
RP---FHR---Source

Problem Statement:
1. In FHR, Enable PIM and IGMP on source connected interface
2. Start multicast traffic. (s,g) mroute and upstream will be created as expected.
3. Disable PIM on source connected interface.
4. Disable IGMP on source connected interface.
5. Stop the traffic.

Mroute will never get timeout.

Root Cause:
In FHR, when PIMD receive multicast data packet on source connected interface which is IGMP enabled, but PIM not enabled. PIMD process the packet, install the
mroute and start the KAT timer.

Fix:
Don't process multicast data packet received on PIM disabled