### PR TITLE
pimd: Prevent crash when pimreg already exists.

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1534,8 +1534,10 @@ void pim_if_create_pimreg(struct pim_instance *pim)
 					       pim->vrf->name);
 		pim->regiface->ifindex = PIM_OIF_PIM_REGISTER_VIF;
 
-		pim_if_new(pim->regiface, false, false, true,
-			false /*vxlan_term*/);
+		if (!pim->regiface->info)
+			pim_if_new(pim->regiface, false, false, true,
+				   false /*vxlan_term*/);
+
 		/*
 		 * On vrf moves we delete the interface if there
 		 * is nothing going on with it.  We cannot have


### PR DESCRIPTION
If the pimreg device exists but it has not been set to the pim->pimreg pointer we can have a crash.  Just prevent the crash since it's some sort of startup / re-org the network issue.

(gdb) bt
0  0x00007f0485b035cb in raise () from /lib/x86_64-linux-gnu/libpthread.so.0 1  0x00007f0485c0fbec in core_handler (signo=6, siginfo=0x7ffdc0198030, context=<optimized out>) at lib/sigevent.c:264 2  <signal handler called>
3  0x00007f04859668eb in raise () from /lib/x86_64-linux-gnu/libc.so.6 4  0x00007f0485951535 in abort () from /lib/x86_64-linux-gnu/libc.so.6 5  0x00007f0485c3af76 in _zlog_assert_failed (xref=xref@entry=0x55692269b940 <_xref.23164>, extra=extra@entry=0x0) at lib/zlog.c:680 6  0x00005569226150d0 in pim_if_new (ifp=0x556922c82900, gm=gm@entry=false, pim=pim@entry=false, ispimreg=ispimreg@entry=true,
    is_vxlan_term=is_vxlan_term@entry=false) at pimd/pim_iface.c:124
7  0x0000556922615140 in pim_if_create_pimreg (pim=pim@entry=0x556922cc11e0) at pimd/pim_iface.c:1549 8  0x0000556922616bc8 in pim_if_create_pimreg (pim=0x556922cc11e0) at pimd/pim_iface.c:1613 9  pim_ifp_create (ifp=0x556922cc0e70) at pimd/pim_iface.c:1641 10 0x00007f0485c32cf9 in zclient_interface_add (cmd=<optimized out>, zclient=<optimized out>, length=<optimized out>, vrf_id=77) at lib/zclient.c:2214 11 0x00007f0485c3346a in zclient_read (thread=<optimized out>) at lib/zclient.c:4003 12 0x00007f0485c215ed in thread_call (thread=thread@entry=0x7ffdc0198880) at lib/thread.c:2008 13 0x00007f0485bdbbc8 in frr_run (master=0x556922a10470) at lib/libfrr.c:1223 14 0x000055692260312b in main (argc=<optimized out>, argv=0x7ffdc0198b98, envp=<optimized out>) at pimd/pim_main.c:176