### PR TITLE
pim6d: custom error-message for non-multicast groups

### DIFF
--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -539,6 +539,14 @@ DEFPY (interface_ipv6_mld_join,
        "Source address\n")
 {
 	char xpath[XPATH_MAXLEN];
+	struct ipaddr group_addr = {0};
+
+	(void)str2ipaddr(group_str, &group_addr);
+
+	if (!IN6_IS_ADDR_MULTICAST(&group_addr)) {
+		vty_out(vty, "Invalid Multicast Address\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 
 	if (source_str) {
 		if (IPV6_ADDR_SAME(&source, &in6addr_any)) {


### PR DESCRIPTION
While configuring global or non-multicast address
for ipv6 mld join command, displaying a custom error-message
"Invalid Multicast Address"

Closes #12822 