### PR TITLE
ospfd: correctly update outbound filter-list once prefix-list is updated

### DIFF
--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1787,7 +1787,7 @@ static void ospf_prefix_list_update(struct prefix_list *plist)
 			    && strcmp(PREFIX_NAME_OUT(area),
 				      prefix_list_name(plist))
 				       == 0) {
-				PREFIX_LIST_IN(area) = prefix_list_lookup(
+				PREFIX_LIST_OUT(area) = prefix_list_lookup(
 					AFI_IP, PREFIX_NAME_OUT(area));
 				abr_inv++;
 			}


### PR DESCRIPTION
Fix obvious bug where the wrong area filter-lists were being updated in response to a prefix-list update.