### PR TITLE
bgpd: Intern attributes before putting into rib-out

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2921,10 +2921,14 @@ void subgroup_process_announce_selected(struct update_subgroup *subgrp,
 			 * in FIB, then it is advertised
 			 */
 			if (advertise) {
-				if (!bgp_check_withdrawal(bgp, dest))
-					bgp_adj_out_set_subgroup(
-						dest, subgrp, &attr, selected);
-				else
+				if (!bgp_check_withdrawal(bgp, dest)) {
+					struct attr *adv_attr =
+						bgp_attr_intern(&attr);
+
+					bgp_adj_out_set_subgroup(dest, subgrp,
+								 adv_attr,
+								 selected);
+				} else
 					bgp_adj_out_unset_subgroup(
 						dest, subgrp, 1, addpath_tx_id);
 			}


### PR DESCRIPTION
```
==21860==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 80 byte(s) in 2 object(s) allocated from:
    0 0x7f8065294d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    1 0x7f8064cfd216 in qcalloc lib/memory.c:105
    2 0x5646b7024073 in ecommunity_dup bgpd/bgp_ecommunity.c:252
    3 0x5646b7153585 in route_set_ecommunity_lb bgpd/bgp_routemap.c:2925
    4 0x7f8064d459be in route_map_apply_ext lib/routemap.c:2675
    5 0x5646b7116584 in subgroup_announce_check bgpd/bgp_route.c:2374
    6 0x5646b711b907 in subgroup_process_announce_selected bgpd/bgp_route.c:2918
    7 0x5646b717ceb8 in group_announce_route_walkcb bgpd/bgp_updgrp_adv.c:184
    8 0x7f8064cc6acd in hash_walk lib/hash.c:270
    9 0x5646b717ae0c in update_group_af_walk bgpd/bgp_updgrp.c:2046
    10 0x5646b7181275 in group_announce_route bgpd/bgp_updgrp_adv.c:1030
    11 0x5646b711a986 in bgp_process_main_one bgpd/bgp_route.c:3303
    12 0x5646b711b5bf in bgp_process_wq bgpd/bgp_route.c:3444
    13 0x7f8064da12d7 in work_queue_run lib/workqueue.c:267
    14 0x7f8064d891fb in thread_call lib/thread.c:1991
    15 0x7f8064cdffcf in frr_run lib/libfrr.c:1185
    16 0x5646b6feca67 in main bgpd/bgp_main.c:505
    17 0x7f8063f96c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 16 byte(s) in 2 object(s) allocated from:
    0 0x7f8065294b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    1 0x7f8064cfcf01 in qmalloc lib/memory.c:100
    2 0x5646b7024151 in ecommunity_dup bgpd/bgp_ecommunity.c:256
    3 0x5646b7153585 in route_set_ecommunity_lb bgpd/bgp_routemap.c:2925
    4 0x7f8064d459be in route_map_apply_ext lib/routemap.c:2675
    5 0x5646b7116584 in subgroup_announce_check bgpd/bgp_route.c:2374
    6 0x5646b711b907 in subgroup_process_announce_selected bgpd/bgp_route.c:2918
    7 0x5646b717ceb8 in group_announce_route_walkcb bgpd/bgp_updgrp_adv.c:184
    8 0x7f8064cc6acd in hash_walk lib/hash.c:270
    9 0x5646b717ae0c in update_group_af_walk bgpd/bgp_updgrp.c:2046
    10 0x5646b7181275 in group_announce_route bgpd/bgp_updgrp_adv.c:1030
    11 0x5646b711a986 in bgp_process_main_one bgpd/bgp_route.c:3303
    12 0x5646b711b5bf in bgp_process_wq bgpd/bgp_route.c:3444
    13 0x7f8064da12d7 in work_queue_run lib/workqueue.c:267
    14 0x7f8064d891fb in thread_call lib/thread.c:1991
    15 0x7f8064cdffcf in frr_run lib/libfrr.c:1185
    16 0x5646b6feca67 in main bgpd/bgp_main.c:505
    17 0x7f8063f96c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)
```