### PR TITLE
babeld: fix #11808 to avoid infinite loops

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -422,7 +422,7 @@ parse_packet(const unsigned char *from, struct interface *ifp,
 			debugf(BABEL_DEBUG_COMMON,
 			       "Received Hello from %s on %s that does not have all 0's in the unused section of flags, ignoring",
 			       format_address(from), ifp->name);
-			continue;
+			goto done;
 		}
 
 		/*
@@ -434,7 +434,7 @@ parse_packet(const unsigned char *from, struct interface *ifp,
 			debugf(BABEL_DEBUG_COMMON,
 			       "Received Unicast Hello from %s on %s that FRR is not prepared to understand yet",
 			       format_address(from), ifp->name);
-			continue;
+			goto done;
 		}
 
 		DO_NTOHS(seqno, message + 4);
@@ -452,7 +452,7 @@ parse_packet(const unsigned char *from, struct interface *ifp,
 			debugf(BABEL_DEBUG_COMMON,
 			       "Received hello from %s on %s should be ignored as that this version of FRR does not know how to properly handle interval == 0",
 			       format_address(from), ifp->name);
-			continue;
+			goto done;
 		}
 
 		changed = update_neighbour(neigh, seqno, interval);


### PR DESCRIPTION
Replacing continue in loops to goto done so that index of packet buffer increases.

Closes https://github.com/FRRouting/frr/issues/11808