### PR TITLE
zebra: Add link_nsid to zebra interface

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -137,6 +137,8 @@ static int if_zebra_new_hook(struct interface *ifp)
 	zebra_if->multicast = IF_ZEBRA_DATA_UNSPEC;
 	zebra_if->shutdown = IF_ZEBRA_DATA_OFF;
 
+	zebra_if->link_nsid = NS_UNKNOWN;
+
 	zebra_if_nhg_dependents_init(zebra_if);
 
 	zebra_ptm_if_init(zebra_if);
@@ -303,6 +305,14 @@ struct interface *if_lookup_by_name_per_ns(struct zebra_ns *ns,
 	}
 
 	return NULL;
+}
+
+struct interface *if_lookup_by_index_per_nsid(ns_id_t ns_id, uint32_t ifindex)
+{
+	struct zebra_ns *zns;
+
+	zns = zebra_ns_lookup(ns_id);
+	return zns ? if_lookup_by_index_per_ns(zns, ifindex) : NULL;
 }
 
 const char *ifindex2ifname_per_ns(struct zebra_ns *zns, unsigned int ifindex)
@@ -991,7 +1001,6 @@ void if_up(struct interface *ifp, bool install_connected)
 {
 	struct zebra_if *zif;
 	struct interface *link_if;
-	struct zebra_vrf *zvrf = ifp->vrf->info;
 
 	zif = ifp->info;
 	zif->up_count++;
@@ -1024,8 +1033,7 @@ void if_up(struct interface *ifp, bool install_connected)
 		link_if = ifp;
 		zebra_vxlan_svi_up(ifp, link_if);
 	} else if (IS_ZEBRA_IF_VLAN(ifp)) {
-		link_if = if_lookup_by_index_per_ns(zvrf->zns,
-						    zif->link_ifindex);
+		link_if = zif->link;
 		if (link_if)
 			zebra_vxlan_svi_up(ifp, link_if);
 	} else if (IS_ZEBRA_IF_MACVLAN(ifp)) {
@@ -1049,7 +1057,6 @@ void if_down(struct interface *ifp)
 {
 	struct zebra_if *zif;
 	struct interface *link_if;
-	struct zebra_vrf *zvrf = ifp->vrf->info;
 
 	zif = ifp->info;
 	zif->down_count++;
@@ -1068,8 +1075,7 @@ void if_down(struct interface *ifp)
 		link_if = ifp;
 		zebra_vxlan_svi_down(ifp, link_if);
 	} else if (IS_ZEBRA_IF_VLAN(ifp)) {
-		link_if = if_lookup_by_index_per_ns(zvrf->zns,
-						    zif->link_ifindex);
+		link_if = zif->link;
 		if (link_if)
 			zebra_vxlan_svi_down(ifp, link_if);
 	} else if (IS_ZEBRA_IF_MACVLAN(ifp)) {
@@ -1109,6 +1115,7 @@ void zebra_if_update_link(struct interface *ifp, ifindex_t link_ifindex,
 	if (IS_ZEBRA_IF_VETH(ifp))
 		return;
 	zif = (struct zebra_if *)ifp->info;
+	zif->link_nsid = ns_id;
 	zif->link_ifindex = link_ifindex;
 	zif->link = if_lookup_by_index_per_ns(zebra_ns_lookup(ns_id),
 					      link_ifindex);
@@ -1145,8 +1152,8 @@ void zebra_if_update_all_links(struct zebra_ns *zns)
 
 		/* update SVI linkages */
 		if ((zif->link_ifindex != IFINDEX_INTERNAL) && !zif->link) {
-			zif->link = if_lookup_by_index_per_ns(
-				zns, zif->link_ifindex);
+			zif->link = if_lookup_by_index_per_nsid(
+				zif->link_nsid, zif->link_ifindex);
 			if (IS_ZEBRA_DEBUG_KERNEL)
 				zlog_debug("interface %s/%d's lower fixup to %s/%d",
 						ifp->name, ifp->ifindex,

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -195,6 +195,7 @@ struct zebra_if {
 	struct list *mac_list;
 
 	/* Link fields - for sub-interfaces. */
+	ns_id_t link_nsid;
 	ifindex_t link_ifindex;
 	struct interface *link;
 
@@ -259,6 +260,8 @@ extern struct interface *if_lookup_by_index_per_ns(struct zebra_ns *, uint32_t);
 extern struct interface *if_lookup_by_name_per_ns(struct zebra_ns *,
 						  const char *);
 extern struct interface *if_link_per_ns(struct zebra_ns *, struct interface *);
+extern struct interface *if_lookup_by_index_per_nsid(ns_id_t nsid,
+						     uint32_t ifindex);
 extern const char *ifindex2ifname_per_ns(struct zebra_ns *, unsigned int);
 
 extern void if_unlink_per_ns(struct interface *);


### PR DESCRIPTION
Add link_nsid to zebra interface, so that the <link_nsid, link_ifindex> pair can uniquely identify the link interface. And VLAN interface is not necessary in the same netns of its parent.