### PR TITLE
zebra: Make GR debug logs at least vrf aware

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -2047,7 +2047,7 @@ static int bgp_start_deferral_timer(struct bgp *bgp, afi_t afi, safi_t safi,
 	if (gr_info->af_enabled[afi][safi] == false) {
 		gr_info->af_enabled[afi][safi] = true;
 		/* Send message to RIB */
-		bgp_zebra_update(afi, safi, bgp->vrf_id,
+		bgp_zebra_update(bgp, afi, safi,
 				 ZEBRA_CLIENT_ROUTE_UPDATE_PENDING);
 	}
 	if (BGP_DEBUG(update, UPDATE_OUT))
@@ -2194,7 +2194,7 @@ static enum bgp_fsm_state_progress bgp_establish(struct peer *peer)
 				/* Send route processing complete
 				   message to RIB */
 				bgp_zebra_update(
-					afi, safi, peer->bgp->vrf_id,
+					peer->bgp, afi, safi,
 					ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE);
 		}
 	} else {
@@ -2206,7 +2206,7 @@ static enum bgp_fsm_state_progress bgp_establish(struct peer *peer)
 				/* Send route processing complete
 				   message to RIB */
 				bgp_zebra_update(
-					afi, safi, peer->bgp->vrf_id,
+					peer->bgp, afi, safi,
 					ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE);
 		}
 	}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3405,7 +3405,7 @@ void bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi)
 	if (!bgp->gr_info[afi][safi].gr_deferred) {
 		bgp_send_delayed_eor(bgp);
 		/* Send route processing complete message to RIB */
-		bgp_zebra_update(afi, safi, bgp->vrf_id,
+		bgp_zebra_update(bgp, afi, safi,
 				 ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE);
 		return;
 	}

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3748,16 +3748,22 @@ int bgp_zebra_send_capabilities(struct bgp *bgp, bool disable)
 	struct zapi_cap api;
 	int ret = BGP_GR_SUCCESS;
 
+	if (BGP_DEBUG(zebra, ZEBRA))
+		zlog_debug("%s: Sending %sable for %s", __func__,
+			   disable ? "dis" : "en", bgp->name_pretty);
+
 	if (zclient == NULL) {
 		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_debug("zclient invalid");
+			zlog_debug("%s: %s zclient invalid", __func__,
+				   bgp->name_pretty);
 		return BGP_GR_FAILURE;
 	}
 
 	/* Check if the client is connected */
 	if ((zclient->sock < 0) || (zclient->t_connect)) {
 		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_debug("client not connected");
+			zlog_debug("%s: %s client not connected", __func__,
+				   bgp->name_pretty);
 		return BGP_GR_FAILURE;
 	}
 
@@ -3776,7 +3782,8 @@ int bgp_zebra_send_capabilities(struct bgp *bgp, bool disable)
 
 	if (zclient_capabilities_send(ZEBRA_CLIENT_CAPABILITIES, zclient, &api)
 	    == ZCLIENT_SEND_FAILURE) {
-		zlog_err("error sending capability");
+		zlog_err("%s: %s error sending capability", __func__,
+			 bgp->name_pretty);
 		ret = BGP_GR_FAILURE;
 	} else {
 		if (disable)
@@ -3785,7 +3792,8 @@ int bgp_zebra_send_capabilities(struct bgp *bgp, bool disable)
 			bgp->present_zebra_gr_state = ZEBRA_GR_ENABLE;
 
 		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_debug("send capabilty success");
+			zlog_debug("%s: %s send capabilty success", __func__,
+				   bgp->name_pretty);
 		ret = BGP_GR_SUCCESS;
 	}
 	return ret;
@@ -3794,32 +3802,41 @@ int bgp_zebra_send_capabilities(struct bgp *bgp, bool disable)
 /* Send route update pesding or completed status to RIB for the
  * specific AFI, SAFI
  */
-int bgp_zebra_update(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type)
+int bgp_zebra_update(struct bgp *bgp, afi_t afi, safi_t safi,
+		     enum zserv_client_capabilities type)
 {
 	struct zapi_cap api = {0};
 
+	if (BGP_DEBUG(zebra, ZEBRA))
+		zlog_debug("%s: %s afi: %u safi: %u Command %s", __func__,
+			   bgp->name_pretty, afi, safi,
+			   zserv_gr_client_cap_string(type));
+
 	if (zclient == NULL) {
 		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_debug("zclient == NULL, invalid");
+			zlog_debug("%s: %s zclient == NULL, invalid", __func__,
+				   bgp->name_pretty);
 		return BGP_GR_FAILURE;
 	}
 
 	/* Check if the client is connected */
 	if ((zclient->sock < 0) || (zclient->t_connect)) {
 		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_debug("client not connected");
+			zlog_debug("%s: %s client not connected", __func__,
+				   bgp->name_pretty);
 		return BGP_GR_FAILURE;
 	}
 
 	api.afi = afi;
 	api.safi = safi;
-	api.vrf_id = vrf_id;
+	api.vrf_id = bgp->vrf_id;
 	api.cap = type;
 
 	if (zclient_capabilities_send(ZEBRA_CLIENT_CAPABILITIES, zclient, &api)
 	    == ZCLIENT_SEND_FAILURE) {
 		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_debug("error sending capability");
+			zlog_debug("%s: %s error sending capability", __func__,
+				   bgp->name_pretty);
 		return BGP_GR_FAILURE;
 	}
 	return BGP_GR_SUCCESS;
@@ -3831,6 +3848,10 @@ int bgp_zebra_stale_timer_update(struct bgp *bgp)
 {
 	struct zapi_cap api;
 
+	if (BGP_DEBUG(zebra, ZEBRA))
+		zlog_debug("%s: %s Timer Update to %u", __func__,
+			   bgp->name_pretty, bgp->rib_stale_time);
+
 	if (zclient == NULL) {
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("zclient invalid");
@@ -3840,7 +3861,8 @@ int bgp_zebra_stale_timer_update(struct bgp *bgp)
 	/* Check if the client is connected */
 	if ((zclient->sock < 0) || (zclient->t_connect)) {
 		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_debug("client not connected");
+			zlog_debug("%s: %s client not connected", __func__,
+				   bgp->name_pretty);
 		return BGP_GR_FAILURE;
 	}
 
@@ -3851,11 +3873,11 @@ int bgp_zebra_stale_timer_update(struct bgp *bgp)
 	if (zclient_capabilities_send(ZEBRA_CLIENT_CAPABILITIES, zclient, &api)
 	    == ZCLIENT_SEND_FAILURE) {
 		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_debug("error sending capability");
+			zlog_debug("%s: %s error sending capability", __func__,
+				   bgp->name_pretty);
 		return BGP_GR_FAILURE;
 	}
-	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("send capabilty success");
+
 	return BGP_GR_SUCCESS;
 }
 

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -114,7 +114,8 @@ extern void bgp_send_pbr_iptable(struct bgp_pbr_action *pba,
 extern void bgp_zebra_announce_default(struct bgp *bgp, struct nexthop *nh,
 				afi_t afi, uint32_t table_id, bool announce);
 extern int bgp_zebra_send_capabilities(struct bgp *bgp, bool disable);
-extern int bgp_zebra_update(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type);
+extern int bgp_zebra_update(struct bgp *bgp, afi_t afi, safi_t safi,
+			    enum zserv_client_capabilities);
 extern int bgp_zebra_stale_timer_update(struct bgp *bgp);
 extern int bgp_zebra_srv6_manager_get_locator_chunk(const char *name);
 extern int bgp_zebra_srv6_manager_release_locator_chunk(const char *name);

--- a/lib/log.c
+++ b/lib/log.c
@@ -506,6 +506,26 @@ const char *zserv_command_string(unsigned int command)
 	return command_types[command].string;
 }
 
+#define DESC_ENTRY(T) [(T)] = {(T), (#T), '\0'}
+static const struct zebra_desc_table gr_client_cap_types[] = {
+	DESC_ENTRY(ZEBRA_CLIENT_GR_CAPABILITIES),
+	DESC_ENTRY(ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE),
+	DESC_ENTRY(ZEBRA_CLIENT_ROUTE_UPDATE_PENDING),
+	DESC_ENTRY(ZEBRA_CLIENT_GR_DISABLE),
+	DESC_ENTRY(ZEBRA_CLIENT_RIB_STALE_TIME),
+};
+#undef DESC_ENTRY
+
+const char *zserv_gr_client_cap_string(uint32_t zcc)
+{
+	if (zcc >= array_size(gr_client_cap_types)) {
+		flog_err(EC_LIB_DEVELOPMENT, "unknown zserv command type: %u",
+			 zcc);
+		return unknown.string;
+	}
+	return gr_client_cap_types[zcc].string;
+}
+
 int proto_name2num(const char *s)
 {
 	unsigned i;

--- a/lib/log.h
+++ b/lib/log.h
@@ -113,6 +113,7 @@ extern int proto_name2num(const char *s);
 extern int proto_redistnum(int afi, const char *s);
 
 extern const char *zserv_command_string(unsigned int command);
+extern const char *zserv_gr_client_cap_string(unsigned int zcc);
 
 #define OSPF_LOG(level, cond, fmt, ...)                                        \
 	do {                                                                   \

--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -111,14 +111,17 @@ static struct client_gr_info *zebra_gr_client_info_create(struct zserv *client)
 static void zebra_gr_client_info_delte(struct zserv *client,
 				       struct client_gr_info *info)
 {
+	struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
+
 	TAILQ_REMOVE(&(client->gr_info_queue), info, gr_info);
 
 	THREAD_OFF(info->t_stale_removal);
 
 	XFREE(MTYPE_ZEBRA_GR, info->current_prefix);
 
-	LOG_GR("%s: Instance info is being deleted for client %s", __func__,
-	       zebra_route_string(client->proto));
+	LOG_GR("%s: Instance info is being deleted for client %s vrf %s(%u)",
+	       __func__, zebra_route_string(client->proto), VRF_LOGNAME(vrf),
+	       info->vrf_id);
 
 	/* Delete all the stale routes. */
 	info->do_delete = true;
@@ -154,6 +157,8 @@ int32_t zebra_gr_client_disconnect(struct zserv *client)
 	TAILQ_FOREACH (info, &client->gr_info_queue, gr_info) {
 		if (ZEBRA_CLIENT_GR_ENABLED(info->capabilities)
 		    && (info->t_stale_removal == NULL)) {
+			struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
+
 			thread_add_timer(
 				zrouter.master,
 				zebra_gr_route_stale_delete_timer_expiry, info,
@@ -162,8 +167,9 @@ int32_t zebra_gr_client_disconnect(struct zserv *client)
 			info->current_afi = AFI_IP;
 			info->stale_client_ptr = client;
 			info->stale_client = true;
-			LOG_GR("%s: Client %s Stale timer update to %d",
+			LOG_GR("%s: Client %s vrf %s(%u) Stale timer update to %d",
 			       __func__, zebra_route_string(client->proto),
+			       VRF_LOGNAME(vrf), info->vrf_id,
 			       info->stale_removal_time);
 		}
 	}
@@ -180,6 +186,7 @@ static void zebra_gr_delete_stale_client(struct client_gr_info *info)
 {
 	struct client_gr_info *bgp_info;
 	struct zserv *s_client = NULL;
+	struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
 
 	s_client = info->stale_client_ptr;
 
@@ -204,8 +211,9 @@ static void zebra_gr_delete_stale_client(struct client_gr_info *info)
 			return;
 	}
 
-	LOG_GR("%s: Client %s is being deleted", __func__,
-	       zebra_route_string(s_client->proto));
+	LOG_GR("%s: Client %s vrf %s(%u) is being deleted", __func__,
+	       zebra_route_string(s_client->proto), VRF_LOGNAME(vrf),
+	       info->vrf_id);
 
 	TAILQ_INIT(&(s_client->gr_info_queue));
 	listnode_delete(zrouter.stale_client_list, s_client);
@@ -324,10 +332,13 @@ static void zebra_client_update_info(struct zserv *client, struct zapi_cap *api)
 
 		/* Update other parameters */
 		if (!info->gr_enable) {
+			struct vrf *vrf = vrf_lookup_by_id(api->vrf_id);
+
 			client->gr_instance_count++;
 
-			LOG_GR("%s: Cient %s GR enabled count %d", __func__,
-			       zebra_route_string(client->proto),
+			LOG_GR("%s: Cient %s vrf %s(%u) GR enabled count %d",
+			       __func__, zebra_route_string(client->proto),
+			       VRF_LOGNAME(vrf), api->vrf_id,
 			       client->gr_instance_count);
 
 			info->capabilities = api->cap;
@@ -342,9 +353,11 @@ static void zebra_client_update_info(struct zserv *client, struct zapi_cap *api)
 
 		/* Update the stale removal timer */
 		if (info && info->t_stale_removal == NULL) {
+			struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
 
-			LOG_GR("%s: Stale time: %d is now update to: %d",
-			       __func__, info->stale_removal_time,
+			LOG_GR("%s: vrf %s(%u) Stale time: %d is now update to: %d",
+			       __func__, VRF_LOGNAME(vrf), info->vrf_id,
+			       info->stale_removal_time,
 			       api->stale_removal_time);
 
 			info->stale_removal_time = api->stale_removal_time;
@@ -352,19 +365,35 @@ static void zebra_client_update_info(struct zserv *client, struct zapi_cap *api)
 
 		break;
 	case ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE:
-		LOG_GR(
-		   "%s: Client %s route update complete for AFI %d, SAFI %d",
-		   __func__, zebra_route_string(client->proto), api->afi,
-		   api->safi);
-		if (info)
+		if (!info) {
+			LOG_GR("%s: Client %s route update complete for AFI %d, SAFI %d",
+			       __func__, zebra_route_string(client->proto),
+			       api->afi, api->safi);
+		} else {
+			struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
+
+			LOG_GR("%s: Client %s vrf %s(%u) route update complete for AFI %d, SAFI %d",
+			       __func__, zebra_route_string(client->proto),
+			       VRF_LOGNAME(vrf), info->vrf_id, api->afi,
+			       api->safi);
 			info->route_sync[api->afi][api->safi] = true;
+		}
 		break;
 	case ZEBRA_CLIENT_ROUTE_UPDATE_PENDING:
-		LOG_GR("%s: Client %s route update pending for AFI %d, SAFI %d",
-		       __func__, zebra_route_string(client->proto), api->afi,
-		       api->safi);
-		if (info)
+		if (!info) {
+			LOG_GR("%s: Client %s route update pending for AFI %d, SAFI %d",
+			       __func__, zebra_route_string(client->proto),
+			       api->afi, api->safi);
+		} else {
+			struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
+
+			LOG_GR("%s: Client %s vrf %s(%u) route update pending for AFI %d, SAFI %d",
+			       __func__, zebra_route_string(client->proto),
+			       VRF_LOGNAME(vrf), info->vrf_id, api->afi,
+			       api->safi);
+
 			info->af_enabled[api->afi][api->safi] = true;
+		}
 		break;
 	}
 }
@@ -434,12 +463,11 @@ void zread_client_capabilities(ZAPI_HANDLER_ARGS)
  */
 static void zebra_gr_route_stale_delete_timer_expiry(struct thread *thread)
 {
-	struct client_gr_info *info;
+	struct client_gr_info *info = THREAD_ARG(thread);
 	int32_t cnt = 0;
 	struct zserv *client;
+	struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
 
-	info = THREAD_ARG(thread);
-	info->t_stale_removal = NULL;
 	client = (struct zserv *)info->stale_client_ptr;
 
 	/* Set the flag to indicate all stale route deletion */
@@ -450,8 +478,9 @@ static void zebra_gr_route_stale_delete_timer_expiry(struct thread *thread)
 
 	/* Restart the timer */
 	if (cnt > 0) {
-		LOG_GR("%s: Client %s processed %d routes. Start timer again",
-		       __func__, zebra_route_string(client->proto), cnt);
+		LOG_GR("%s: Client %s vrf %s(%u) processed %d routes. Start timer again",
+		       __func__, zebra_route_string(client->proto),
+		       VRF_LOGNAME(vrf), info->vrf_id, cnt);
 
 		thread_add_timer(zrouter.master,
 				 zebra_gr_route_stale_delete_timer_expiry, info,
@@ -459,8 +488,9 @@ static void zebra_gr_route_stale_delete_timer_expiry(struct thread *thread)
 				 &info->t_stale_removal);
 	} else {
 		/* No routes to delete for the VRF */
-		LOG_GR("%s: Client %s all stale routes processed", __func__,
-		       zebra_route_string(client->proto));
+		LOG_GR("%s: Client %s vrf %s(%u) all stale routes processed",
+		       __func__, zebra_route_string(client->proto),
+		       VRF_LOGNAME(vrf), info->vrf_id);
 
 		XFREE(MTYPE_ZEBRA_GR, info->current_prefix);
 		info->current_afi = 0;
@@ -513,7 +543,8 @@ static int32_t zebra_gr_delete_stale_route(struct client_gr_info *info,
 
 	s_client = info->stale_client_ptr;
 	if (s_client == NULL) {
-		LOG_GR("%s: Stale client not present", __func__);
+		LOG_GR("%s: Stale client %s(%u) not present", __func__,
+		       zvrf->vrf->name, zvrf->vrf->vrf_id);
 		return -1;
 	}
 
@@ -521,8 +552,8 @@ static int32_t zebra_gr_delete_stale_route(struct client_gr_info *info,
 	instance = s_client->instance;
 	curr_afi = info->current_afi;
 
-	LOG_GR("%s: Client %s stale routes are being deleted", __func__,
-	       zebra_route_string(proto));
+	LOG_GR("%s: Client %s %s(%u) stale routes are being deleted", __func__,
+	       zebra_route_string(proto), zvrf->vrf->name, zvrf->vrf->vrf_id);
 
 	/* Process routes for all AFI */
 	for (afi = curr_afi; afi < AFI_MAX; afi++) {
@@ -602,13 +633,13 @@ static int32_t zebra_gr_delete_stale_routes(struct client_gr_info *info)
 	/* Get the current VRF */
 	vrf = vrf_lookup_by_id(info->vrf_id);
 	if (vrf == NULL) {
-		LOG_GR("%s: Invalid VRF %d", __func__, info->vrf_id);
+		LOG_GR("%s: Invalid VRF specified %u", __func__, info->vrf_id);
 		return -1;
 	}
 
 	zvrf = vrf->info;
 	if (zvrf == NULL) {
-		LOG_GR("%s: Invalid VRF entry %d", __func__, info->vrf_id);
+		LOG_GR("%s: Invalid VRF entry %u", __func__, info->vrf_id);
 		return -1;
 	}
 
@@ -639,9 +670,12 @@ static void zebra_gr_process_client_stale_routes(struct zserv *client,
 	FOREACH_AFI_SAFI_NSF (afi, safi) {
 		if (info->af_enabled[afi][safi]) {
 			if (!info->route_sync[afi][safi]) {
-				LOG_GR("%s: Client %s route update not completed for AFI %d, SAFI %d",
+				struct vrf *vrf = vrf_lookup_by_id(vrf_id);
+
+				LOG_GR("%s: Client %s vrf: %s(%u) route update not completed for AFI %d, SAFI %d",
 				       __func__,
-				       zebra_route_string(client->proto), afi,
+				       zebra_route_string(client->proto),
+				       VRF_LOGNAME(vrf), info->vrf_id, afi,
 				       safi);
 				return;
 			}
@@ -653,9 +687,11 @@ static void zebra_gr_process_client_stale_routes(struct zserv *client,
 	 * Cancel the stale timer and process the routes
 	 */
 	if (info->t_stale_removal) {
-		LOG_GR("%s: Client %s canceled stale delete timer vrf %d",
+		struct vrf *vrf = vrf_lookup_by_id(vrf_id);
+
+		LOG_GR("%s: Client %s canceled stale delete timer vrf %s(%d)",
 		       __func__, zebra_route_string(client->proto),
-		       info->vrf_id);
+		       VRF_LOGNAME(vrf), info->vrf_id);
 		THREAD_OFF(info->t_stale_removal);
 		thread_execute(zrouter.master,
 			       zebra_gr_route_stale_delete_timer_expiry, info,


### PR DESCRIPTION
The GR debug logs are doing all sorts of wonderful stuff but they were not actually displaying anything useful to the operator about what vrf we are operating in.