### PR TITLE
yang: Fix "aggregator-asn" to support asdot

### DIFF
--- a/yang/frr-bgp-route-map.yang
+++ b/yang/frr-bgp-route-map.yang
@@ -474,6 +474,24 @@ module frr-bgp-route-map {
       "ext-community link bandwidth types.";
   }
 
+  typedef asn-type {
+          type string {
+            pattern
+              '((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+            +     '6[0-4][0-9]{3}|'
+            +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0).'
+            +  '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+            +     '6[0-4][0-9]{3}|'
+            +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)|'
+            +     '(429496729[0-5]|42949672[0-8][0-9]|'
+            +     '4294967[01][0-9]{2}|'
+            +     '429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|'
+            +     '4294[0-8][0-9]{5}|'
+            +     '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[01][0-9]{8}|'
+            +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0))';
+          }
+  }
+
   augment "/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:rmap-match-condition/frr-route-map:match-condition" {
     case local-preference {
       when "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:condition, 'frr-bgp-route-map:match-local-preference')";
@@ -1004,16 +1022,12 @@ module frr-bgp-route-map {
       when "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:set-action/frr-route-map:action, 'frr-bgp-route-map:aggregator')";
       container aggregator {
         leaf aggregator-asn {
-          type uint32 {
-            range "1..4294967295";
-          }
+          type asn-type;
           description
             "ASN of the aggregator";
         }
 
         leaf aggregator-address {
-          when "../aggregator-asn > 0 or "
-             + "../aggregator-asn <= 4294967295";
           type inet:ipv4-address;
           description
             "IPv4 address of the aggregator";


### PR DESCRIPTION
```
(routemap)  set aggregator as ASNUM A.B.C.D
```

Since "aggregator-asn" has already supported asdot, fixed it with new yang type.