### PR TITLE
pimd: IN_MULTICAST needs host order

### DIFF
--- a/pimd/pim_util.c
+++ b/pimd/pim_util.c
@@ -159,7 +159,7 @@ int pim_get_all_mcast_group(struct prefix *prefix)
 bool pim_addr_is_multicast(pim_addr addr)
 {
 #if PIM_IPV == 4
-	if (IN_MULTICAST(addr.s_addr))
+	if (IN_MULTICAST(ntohl(addr.s_addr)))
 		return true;
 #else
 	if (IN6_IS_ADDR_MULTICAST(&addr))


### PR DESCRIPTION
New correct behavior:

eva# conf
eva(config)# ip pim rp 192.168.1.224 224.0.0.0/24
No Path to RP address specified: 192.168.1.224
eva(config)# ip pim rp 224.1.2.3 224.0.0.0/24
% Bad RP address specified: 224.1.2.3
eva(config)#

Fixes: #12970