### PR TITLE
bgpd: vrf label is configured only when first VPN entry selected

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -312,8 +312,8 @@ void vpn_leak_zebra_vrf_label_update(struct bgp *bgp, afi_t afi)
 
 	if (label == BGP_PREVENT_VRF_2_VRF_LEAK)
 		label = MPLS_LABEL_NONE;
-	zclient_send_vrf_label(zclient, bgp->vrf_id, afi, label, ZEBRA_LSP_BGP);
-	bgp->vpn_policy[afi].tovpn_zebra_vrf_label_last_sent = label;
+	bgp->vpn_policy[afi].tovpn_zebra_vrf_label_to_send = label;
+	SET_FLAG(bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_LABEL_TO_SEND);
 }
 
 /*
@@ -340,7 +340,7 @@ void vpn_leak_zebra_vrf_label_withdraw(struct bgp *bgp, afi_t afi)
 	}
 
 	zclient_send_vrf_label(zclient, bgp->vrf_id, afi, label, ZEBRA_LSP_BGP);
-	bgp->vpn_policy[afi].tovpn_zebra_vrf_label_last_sent = label;
+	bgp->vpn_policy[afi].tovpn_zebra_vrf_label_to_send = label;
 }
 
 /*

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -281,10 +281,8 @@ static inline void vpn_leak_postchange(enum vpn_policy_direction direction,
 		vpn_leak_to_vrf_update_all(bgp_vrf, bgp_vpn, afi);
 	}
 	if (direction == BGP_VPN_POLICY_DIR_TOVPN) {
-
 		if (bgp_vrf->vpn_policy[afi].tovpn_label !=
-			bgp_vrf->vpn_policy[afi]
-			       .tovpn_zebra_vrf_label_last_sent) {
+		    bgp_vrf->vpn_policy[afi].tovpn_zebra_vrf_label_to_send) {
 			vpn_leak_zebra_vrf_label_update(bgp_vrf, afi);
 		}
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3482,9 +3482,8 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 		bgp->vpn_policy[afi].bgp = bgp;
 		bgp->vpn_policy[afi].afi = afi;
 		bgp->vpn_policy[afi].tovpn_label = MPLS_LABEL_NONE;
-		bgp->vpn_policy[afi].tovpn_zebra_vrf_label_last_sent =
+		bgp->vpn_policy[afi].tovpn_zebra_vrf_label_to_send =
 			MPLS_LABEL_NONE;
-
 		bgp->vpn_policy[afi].import_vrf = list_new();
 		bgp->vpn_policy[afi].import_vrf->del =
 			bgp_vrf_string_name_delete;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -219,7 +219,7 @@ struct vpn_policy {
 
 	/* should be mpls_label_t? */
 	uint32_t tovpn_label; /* may be MPLS_LABEL_NONE */
-	uint32_t tovpn_zebra_vrf_label_last_sent;
+	uint32_t tovpn_zebra_vrf_label_to_send;
 	char *tovpn_rd_pretty;
 	struct prefix_rd tovpn_rd;
 	struct prefix tovpn_nexthop; /* unset => set to 0 */
@@ -231,6 +231,7 @@ struct vpn_policy {
 #define BGP_VPN_POLICY_TOVPN_LABEL_PER_NEXTHOP (1 << 4)
 /* Manual label is registered with zebra label manager */
 #define BGP_VPN_POLICY_TOVPN_LABEL_MANUAL_REG (1 << 5)
+#define BGP_VPN_POLICY_TOVPN_LABEL_TO_SEND    (1 << 6)
 
 	/*
 	 * If we are importing another vrf into us keep a list of


### PR DESCRIPTION
This commit addresses an an optimisation issue that consists in delaying the creation of the MPLS entry for return traffic, only when the first BGP update using that label is sent.

Today, MPLS labels are configured when setting up an L3VPN configuration. A BGP instance is configured, and the MPLS label value is chosen (auto or hardset per-vrf value); the label configuration immediately triggers the creation of the MPLS entry for return traffic.

The below configuration depicts the label configuration:

 > router bgp 65500 vrf vrf2
 >  bgp router-id 1.1.1.1
 >   address-family ipv4 unicast
 >    label vpn export 222
 >    rd vpn export 444:444
 >    rt vpn both 53:100
 >    export vpn
 >    import vpn
 >  exit-address-family

The below show command illustrates the MPLS entry output, after having applied the above config.

 >  r1# show bgp vrf vrf2 ipv4
 >   No BGP prefixes displayed, 0 exist
 >  r1# show mpls table
 >   Inbound Label  Type  Nexthop         Outbound Label
 >   -----------------------------------------------------
 >   [..]
 >   222            BGP   vrf2            -

With the above configuration only, the MPLS entry presence is useless. Actually, no BGP VPNvx updates have been sent (either via redistribute or network commands), so no BGP peers are supposed to know how to use the 222 label value. As consequence, there is no incoming traffic to expect with such label value.

The commit proposes to create the MPLS entry, only when the first BGP update that uses that label value is selected in the bgp best selection algorithm.

The commit does not change the time when the MPLS entry is removed.