### PR TITLE
bgpd: Unlock dest if we return earlier for aggregate install

### DIFF
--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -766,7 +766,7 @@ extern void bgp_config_write_distance(struct vty *, struct bgp *, afi_t,
 extern void bgp_aggregate_delete(struct bgp *bgp, const struct prefix *p,
 				 afi_t afi, safi_t safi,
 				 struct bgp_aggregate *aggregate);
-extern void bgp_aggregate_route(struct bgp *bgp, const struct prefix *p,
+extern bool bgp_aggregate_route(struct bgp *bgp, const struct prefix *p,
 				afi_t afi, safi_t safi,
 				struct bgp_aggregate *aggregate);
 extern void bgp_aggregate_increment(struct bgp *bgp, const struct prefix *p,
@@ -876,6 +876,7 @@ extern void bgp_path_info_free_with_caller(const char *caller,
 extern void bgp_path_info_add_with_caller(const char *caller,
 					  struct bgp_dest *dest,
 					  struct bgp_path_info *pi);
+extern void bgp_aggregate_free(struct bgp_aggregate *aggregate);
 #define bgp_path_info_add(A, B)                                                \
 	bgp_path_info_add_with_caller(__func__, (A), (B))
 #define bgp_path_info_free(B) bgp_path_info_free_with_caller(__func__, (B))

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -4266,8 +4266,9 @@ static void bgp_route_map_process_update(struct bgp *bgp, const char *rmap_name,
 						inet_ntop(bn_p->family,
 							  &bn_p->u.prefix, buf,
 							  sizeof(buf)));
-				bgp_aggregate_route(bgp, bn_p, afi, safi,
-						    aggregate);
+				if (!bgp_aggregate_route(bgp, bn_p, afi, safi,
+							 aggregate))
+					bgp_aggregate_free(aggregate);
 			}
 		}
 	}


### PR DESCRIPTION
If the bgp is in shutdown state or so, do not forget to unlock the dest node.

Also, fix memory leak:

```
Direct leak of 152 byte(s) in 1 object(s) allocated from:
    0 0x7f63dfcd5d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    1 0x7f63df8984df in qcalloc lib/memory.c:105
    2 0x55d54b586eb7 in bgp_aggregate_new bgpd/bgp_route.c:7244
    3 0x55d54b586eb7 in bgp_aggregate_set bgpd/bgp_route.c:8451
    4 0x55d54b587f0a in aggregate_addressv4_magic bgpd/bgp_route.c:8570
    5 0x55d54b587f0a in aggregate_addressv4 bgpd/bgp_route_clippy.c:255
    6 0x7f63df86299f in cmd_execute_command_real lib/command.c:988
    7 0x7f63df862e20 in cmd_execute_command lib/command.c:1047
    8 0x7f63df863396 in cmd_execute lib/command.c:1215
    9 0x7f63df8e1c46 in vty_command lib/vty.c:505
    10 0x7f63df8e2062 in vty_execute lib/vty.c:1268
    11 0x7f63df8e9a67 in vtysh_read lib/vty.c:2167
    12 0x7f63df8da60c in thread_call lib/thread.c:1991
    13 0x7f63df88c26f in frr_run lib/libfrr.c:1185
    14 0x55d54b4fc6d7 in main bgpd/bgp_main.c:505
    15 0x7f63dec2dc86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 152 byte(s) in 1 object(s) allocated from:
    0 0x7f63dfcd5d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    1 0x7f63df8984df in qcalloc lib/memory.c:105
    2 0x55d54b586eb7 in bgp_aggregate_new bgpd/bgp_route.c:7244
    3 0x55d54b586eb7 in bgp_aggregate_set bgpd/bgp_route.c:8451
    4 0x55d54b588988 in aggregate_addressv6_magic bgpd/bgp_route.c:8619
    5 0x55d54b588988 in aggregate_addressv6 bgpd/bgp_route_clippy.c:341
    6 0x7f63df86299f in cmd_execute_command_real lib/command.c:988
    7 0x7f63df862e20 in cmd_execute_command lib/command.c:1047
    8 0x7f63df863396 in cmd_execute lib/command.c:1215
    9 0x7f63df8e1c46 in vty_command lib/vty.c:505
    10 0x7f63df8e2062 in vty_execute lib/vty.c:1268
    11 0x7f63df8e9a67 in vtysh_read lib/vty.c:2167
    12 0x7f63df8da60c in thread_call lib/thread.c:1991
    13 0x7f63df88c26f in frr_run lib/libfrr.c:1185
    14 0x55d54b4fc6d7 in main bgpd/bgp_main.c:505
    15 0x7f63dec2dc86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)
```