### PR TITLE
tools: frr-reload fix list value not present

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1474,10 +1474,12 @@ def ignore_delete_re_add_lines(lines_to_add, lines_to_del):
                         lines_to_add_to_del.append((tmp_ctx_keys, line))
 
     for (ctx_keys, line) in lines_to_del_to_del:
-        lines_to_del.remove((ctx_keys, line))
+        if line is not None:
+            lines_to_del.remove((ctx_keys, line))
 
     for (ctx_keys, line) in lines_to_add_to_del:
-        lines_to_add.remove((ctx_keys, line))
+        if line is not None:
+            lines_to_add.remove((ctx_keys, line))
 
     return (lines_to_add, lines_to_del)
 


### PR DESCRIPTION
Check for value present in list before removing
as in certain python3 ValueError traceback is observed.

```
Traceback (most recent call last):
  File "/usr/lib/frr/frr-reload.py",
		line 2278, in <module>
    (lines_to_add, lines_to_del, restart_frr)
	= compare_context_objects(newconf, running)
  File "/usr/lib/frr/frr-reload.py",
		line 1933, in compare_context_objects
    lines_to_add, lines_to_del
  File "/usr/lib/frr/frr-reload.py",
		line 1549, in ignore_delete_re_add_lines
    lines_to_del.remove((ctx_keys, line))
ValueError: list.remove(x): x not in list
```

Testing Done:
With fix perform frr-relaod on frr.conf config where earlier traceback was seen.

Signed-off-by: Donald Sharp <sharpd@nvidia.com>
Signed-off-by: Chirag Shah <chirag@nvidia.com>