### PR TITLE
lib: Speedup prefix-list readin by a large factor

### DIFF
--- a/lib/filter_cli.c
+++ b/lib/filter_cli.c
@@ -1272,9 +1272,6 @@ DEFPY_YANG(
 		pda.any = true;
 	}
 
-	if (plist_is_dup(vty->candidate_config->dnode, &pda))
-		return CMD_SUCCESS;
-
 	/*
 	 * Create the prefix-list first, so we can generate sequence if
 	 * none given (backward compatibility).
@@ -1475,9 +1472,6 @@ DEFPY_YANG(
 	} else {
 		pda.any = true;
 	}
-
-	if (plist_is_dup(vty->candidate_config->dnode, &pda))
-		return CMD_SUCCESS;
 
 	/*
 	 * Create the prefix-list first, so we can generate sequence if

--- a/lib/filter_nb.c
+++ b/lib/filter_nb.c
@@ -456,24 +456,6 @@ bool plist_is_dup(const struct lyd_node *dnode, struct plist_dup_args *pda)
 	return pda->pda_found;
 }
 
-static bool plist_is_dup_nb(const struct lyd_node *dnode)
-{
-	const struct lyd_node *entry_dnode =
-		yang_dnode_get_parent(dnode, "entry");
-	struct plist_dup_args pda = {};
-
-	/* Initialize. */
-	pda.pda_type = yang_dnode_get_string(entry_dnode, "../type");
-	pda.pda_name = yang_dnode_get_string(entry_dnode, "../name");
-	pda.pda_action = yang_dnode_get_string(entry_dnode, "action");
-	pda.pda_entry_dnode = entry_dnode;
-
-	plist_dnode_to_prefix(entry_dnode, &pda.any, &pda.prefix, &pda.ge,
-			      &pda.le);
-
-	return plist_is_dup(entry_dnode, &pda);
-}
-
 /*
  * XPath: /frr-filter:lib/access-list
  */
@@ -1331,13 +1313,6 @@ lib_prefix_list_entry_ipv4_prefix_modify(struct nb_cb_modify_args *args)
 		const struct lyd_node *plist_dnode =
 			yang_dnode_get_parent(args->dnode, "prefix-list");
 
-		if (plist_is_dup_nb(args->dnode)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "duplicated prefix list value: %s",
-				 yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
-
 		return prefix_list_nb_validate_v4_af_type(
 			plist_dnode, args->errmsg, args->errmsg_len);
 	}
@@ -1365,13 +1340,6 @@ lib_prefix_list_entry_ipv6_prefix_modify(struct nb_cb_modify_args *args)
 	if (args->event == NB_EV_VALIDATE) {
 		const struct lyd_node *plist_dnode =
 			yang_dnode_get_parent(args->dnode, "prefix-list");
-
-		if (plist_is_dup_nb(args->dnode)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "duplicated prefix list value: %s",
-				 yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
 
 		return prefix_list_nb_validate_v6_af_type(
 			plist_dnode, args->errmsg, args->errmsg_len);
@@ -1403,13 +1371,6 @@ static int lib_prefix_list_entry_ipv4_prefix_length_greater_or_equal_modify(
 	if (args->event == NB_EV_VALIDATE) {
 		const struct lyd_node *plist_dnode =
 			yang_dnode_get_parent(args->dnode, "prefix-list");
-
-		if (plist_is_dup_nb(args->dnode)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "duplicated prefix list value: %s",
-				 yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
 
 		return prefix_list_nb_validate_v4_af_type(
 			plist_dnode, args->errmsg, args->errmsg_len);
@@ -1448,13 +1409,6 @@ static int lib_prefix_list_entry_ipv4_prefix_length_lesser_or_equal_modify(
 		const struct lyd_node *plist_dnode =
 			yang_dnode_get_parent(args->dnode, "prefix-list");
 
-		if (plist_is_dup_nb(args->dnode)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "duplicated prefix list value: %s",
-				 yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
-
 		return prefix_list_nb_validate_v4_af_type(
 			plist_dnode, args->errmsg, args->errmsg_len);
 	}
@@ -1491,13 +1445,6 @@ static int lib_prefix_list_entry_ipv6_prefix_length_greater_or_equal_modify(
 	if (args->event == NB_EV_VALIDATE) {
 		const struct lyd_node *plist_dnode =
 			yang_dnode_get_parent(args->dnode, "prefix-list");
-
-		if (plist_is_dup_nb(args->dnode)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "duplicated prefix list value: %s",
-				 yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
 
 		return prefix_list_nb_validate_v6_af_type(
 			plist_dnode, args->errmsg, args->errmsg_len);
@@ -1536,13 +1483,6 @@ static int lib_prefix_list_entry_ipv6_prefix_length_lesser_or_equal_modify(
 		const struct lyd_node *plist_dnode =
 			yang_dnode_get_parent(args->dnode, "prefix-list");
 
-		if (plist_is_dup_nb(args->dnode)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "duplicated prefix list value: %s",
-				 yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
-
 		return prefix_list_nb_validate_v6_af_type(
 			plist_dnode, args->errmsg, args->errmsg_len);
 	}
@@ -1574,16 +1514,11 @@ static int lib_prefix_list_entry_any_create(struct nb_cb_create_args *args)
 	struct prefix_list_entry *ple;
 	int type;
 
-	if (args->event == NB_EV_VALIDATE) {
-		if (plist_is_dup_nb(args->dnode)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "duplicated prefix list value: %s",
-				 yang_dnode_get_string(args->dnode, NULL));
-			return NB_ERR_VALIDATION;
-		}
-
+	/*
+	 * If we have gotten to this point, it's legal
+	 */
+	if (args->event == NB_EV_VALIDATE)
 		return NB_OK;
-	}
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;


### PR DESCRIPTION
Reading in prefix-lists is reading in the specified prefix list and validating that the prefix is unique 2 times.  This makes no sense.  Relax the requirement that a prefix list can limit this as well as completely remove this check.  Validation then just becomes
does this prefix-list specified actually make sense and that is taken care of by the the cli code.

Reading in prefix-lists was looking for duplicate prefixes 2 times instead of doing it just one time.  Let's just not do it at all.

By doing this change, The code changes from never
completing for a 27k long prefix-list to taking
just under 30 seconds, with 4 daemons processing
this data.