### PR TITLE
bgpd: fix NULL argument warning

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -2817,7 +2817,7 @@ const char *print_peer_gr_cmd(enum peer_gr_command pr_gr_cmd)
 
 const char *print_global_gr_mode(enum global_mode gl_mode)
 {
-	const char *global_gr_mode = NULL;
+	const char *global_gr_mode = "???";
 
 	switch (gl_mode) {
 	case GLOBAL_HELPER:


### PR DESCRIPTION
gcc 12.2.0 complains `error: ‘%s’ directive argument is null`, even though all enum values are covered with a string.  Let's just go with a `???` default.

---

Honestly the warning is bogus, but broken build is broken build.

```
bgpd/bgp_fsm.c: In function ‘bgp_gr_update_all’:
./lib/zlog.h:109:34: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  109 |                 zlog_ref(&_xref, (msg), ##__VA_ARGS__);                        \
      |                                  ^~~~~
./lib/zlog.h:116:26: note: in expansion of macro ‘_zlog_ecref’
  116 | #define zlog_debug(...)  _zlog_ecref(0, LOG_DEBUG, __VA_ARGS__)
      |                          ^~~~~~~~~~~
bgpd/bgp_fsm.c:2730:17: note: in expansion of macro ‘zlog_debug’
 2730 |                 zlog_debug("[BGP_GR] global_old_gr_state :%s:",
      |                 ^~~~~~~~~~
./lib/zlog.h:109:34: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  109 |                 zlog_ref(&_xref, (msg), ##__VA_ARGS__);                        \
      |                                  ^~~~~
./lib/zlog.h:116:26: note: in expansion of macro ‘_zlog_ecref’
  116 | #define zlog_debug(...)  _zlog_ecref(0, LOG_DEBUG, __VA_ARGS__)
      |                          ^~~~~~~~~~~
bgpd/bgp_fsm.c:2738:25: note: in expansion of macro ‘zlog_debug’
 2738 |                         zlog_debug("[BGP_GR] global_new_gr_state :%s:",
      |                         ^~~~~~~~~~
```
