### PR TITLE
zebra: straighten out nexthop eligibility rules

### DIFF
--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -616,8 +616,8 @@ static int nhlfe_nexthop_active_ipv4(struct zebra_nhlfe *nhlfe,
 
 		for (match_nh = match->nhe->nhg.nexthop; match_nh;
 		     match_nh = match_nh->next) {
-			if (match->type == ZEBRA_ROUTE_CONNECT
-			    || nexthop->ifindex == match_nh->ifindex) {
+			if (rib_nonrecursive_nh_eligible(match) ||
+			    nexthop->ifindex == match_nh->ifindex) {
 				nexthop->ifindex = match_nh->ifindex;
 				return 1;
 			}
@@ -659,9 +659,9 @@ static int nhlfe_nexthop_active_ipv6(struct zebra_nhlfe *nhlfe,
 
 	/* Locate a valid connected route. */
 	RNODE_FOREACH_RE (rn, match) {
-		if ((match->type == ZEBRA_ROUTE_CONNECT)
-		    && !CHECK_FLAG(match->status, ROUTE_ENTRY_REMOVED)
-		    && CHECK_FLAG(match->flags, ZEBRA_FLAG_SELECTED))
+		if (rib_nonrecursive_nh_eligible(match) &&
+		    !CHECK_FLAG(match->status, ROUTE_ENTRY_REMOVED) &&
+		    CHECK_FLAG(match->flags, ZEBRA_FLAG_SELECTED))
 			break;
 	}
 

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2111,7 +2111,7 @@ zebra_nhg_connected_ifindex(struct route_node *rn, struct route_entry *match,
 	 * of those ifindexes match as well.
 	 */
 	RNODE_FOREACH_RE (rn, re) {
-		if (re->type != ZEBRA_ROUTE_CONNECT)
+		if (!rib_nonrecursive_nh_eligible(re))
 			continue;
 
 		if (CHECK_FLAG(re->status, ROUTE_ENTRY_REMOVED))
@@ -2386,8 +2386,7 @@ static int nexthop_active(struct nexthop *nexthop, struct nhg_hash_entry *nhe,
 			continue;
 		}
 
-		if ((match->type == ZEBRA_ROUTE_CONNECT) ||
-		    (RIB_SYSTEM_ROUTE(match) && RSYSTEM_ROUTE(type))) {
+		if (rib_nonrecursive_nh_eligible(match)) {
 			match = zebra_nhg_connected_ifindex(rn, match,
 							    nexthop->ifindex);
 

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -514,23 +514,9 @@ static bool rnh_check_re_nexthops(const struct route_entry *re,
 	}
 
 	/* Some special checks if registration asked for them. */
-	if (CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED)) {
-		if ((re->type == ZEBRA_ROUTE_CONNECT)
-		    || (re->type == ZEBRA_ROUTE_STATIC))
-			ret = true;
-		if (re->type == ZEBRA_ROUTE_NHRP) {
-
-			for (nexthop = re->nhe->nhg.nexthop;
-			     nexthop;
-			     nexthop = nexthop->next)
-				if (nexthop->type == NEXTHOP_TYPE_IFINDEX)
-					break;
-			if (nexthop)
-				ret = true;
-		}
-	} else {
+	if (!CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED) ||
+	    rib_nonrecursive_nh_eligible(re))
 		ret = true;
-	}
 
 done:
 	return ret;


### PR DESCRIPTION
We're using a hodgepodge of checks to determine whether a particular route_entry can be used for a non-recursive nexthop.  For extra fun, being inconsistent here can lead to NHT sending a nexthop to a protocol daemon that then doesn't even work when installed.

Introduce `rib_nonrecursive_nh_eligible()` to get _one_ consistent answer on usability:  everything with an NEXTHOP_TYPE_IFINDEX can be used.