### PR TITLE
bgpd: Use interface name instead of pointer value

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -805,9 +805,12 @@ int bgp_getsockname(struct peer *peer)
 
 	if (!bgp_zebra_nexthop_set(peer->su_local, peer->su_remote,
 				   &peer->nexthop, peer)) {
-		flog_err(EC_BGP_NH_UPD,
-			 "%s: nexthop_set failed, resetting connection - intf %p",
-			 peer->host, peer->nexthop.ifp);
+		flog_err(
+			EC_BGP_NH_UPD,
+			"%s: nexthop_set failed, resetting connection - intf %s",
+			peer->host,
+			peer->nexthop.ifp ? peer->nexthop.ifp->name
+					  : "(Unknown)");
 		return -1;
 	}
 	return 0;


### PR DESCRIPTION
Log message is borked in a manner that makes it unusable: bgpd[52]: [VX6SM-8YE5W][EC 33554460] 2000:31:0:53::2: nexthop_set failed, resetting connection - intf 0x561eb9005a30

Let's print out the interface name instead.