### PR TITLE
pim6d: Fixing Mld crash while running conformance.

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -537,6 +537,8 @@ static void gm_packet_drop(struct gm_packet_state *pkt, bool trace)
 		if (!sg)
 			continue;
 
+		THREAD_OFF(sg->t_sg_expire);
+
 		if (trace && PIM_DEBUG_GM_TRACE)
 			zlog_debug(log_sg(sg, "general-dropping from %pPA"),
 				   &pkt->subscriber->addr);


### PR DESCRIPTION
t_sg_expire thread was not turned off, so was crashing in assert. Turned off thread to fix the issue.

Issue: #12441