### PR TITLE
pim6d: Do not use interfaces with ifindex as 0

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -982,6 +982,12 @@ int pim_if_add_vif(struct interface *ifp, bool ispimreg, bool is_vxlan_term)
 		zlog_warn("%s: ifindex=%d < 1 on interface %s", __func__,
 			  ifp->ifindex, ifp->name);
 		return -2;
+	} else if ((ifp->ifindex == 0) &&
+		   ((strncmp(ifp->name, "pimreg", 6)) &&
+		    (strncmp(ifp->name, "pim6reg", 7)))) {
+		zlog_warn("%s: ifindex=%d == 0 on interface %s", __func__,
+			  ifp->ifindex, ifp->name);
+		return -2;
 	}
 
 	ifaddr = pim_ifp->primary_address;


### PR DESCRIPTION
After restarting pim6d, in some cases the ifindex is 0 for the interfaces,
so the vif index is also assigned as 0. This causes the interface name to be pim6reg.

Fix:
If the ifindex is 0 and the interface name is not "pimreg" or "pim6reg",
the function will return without assigning vifindex with an error message.

Issue: #12744 