### PR TITLE
pimd: stop t_sg_expire in MLD NOINFO transition

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -438,6 +438,13 @@ static void gm_sg_update(struct gm_sg *sg, bool has_expired)
 	}
 
 	if (desired == GM_SG_NOINFO) {
+		/* multiple paths can lead to the last state going away;
+		 * t_sg_expire can still be running if we're arriving from
+		 * another path.
+		 */
+		if (has_expired)
+			THREAD_OFF(sg->t_sg_expire);
+
 		assertf((!sg->t_sg_expire &&
 			 !gm_packet_sg_subs_count(sg->subs_positive) &&
 			 !gm_packet_sg_subs_count(sg->subs_negative)),


### PR DESCRIPTION
When hitting gm_sg_update from the S,G expiry timer, t_sg_expire will already be cancelled.  But when arriving there from e.g. the MLD packet getting cleared out, it'll still be running.

Clear out the timer if we arrive with `has_expired == true`.

Fixes: #12441

---
cf. discussion in #13013 