### PR TITLE
bgpd: Prevent Null pointer deref when outputting data

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -2564,7 +2564,8 @@ static void bgp_evpn_es_show_entry(struct vty *vty,
 		bgp_evpn_es_vteps_str(vtep_str, es, sizeof(vtep_str));
 
 		vty_out(vty, "%-30s %-5s %-21pRDP %-8d %s\n", es->esi_str,
-			type_str, &es->es_base_frag->prd,
+			type_str,
+			es->es_base_frag ? &es->es_base_frag->prd : NULL,
 			listcount(es->es_evi_list), vtep_str);
 	}
 }
@@ -2640,7 +2641,8 @@ static void bgp_evpn_es_show_entry_detail(struct vty *vty,
 
 		vty_out(vty, "ESI: %s\n", es->esi_str);
 		vty_out(vty, " Type: %s\n", type_str);
-		vty_out(vty, " RD: %pRDP\n", &es->es_base_frag->prd);
+		vty_out(vty, " RD: %pRDP\n",
+			es->es_base_frag ? &es->es_base_frag->prd : NULL);
 		vty_out(vty, " Originator-IP: %pI4\n", &es->originator_ip);
 		if (es->flags & BGP_EVPNES_LOCAL)
 			vty_out(vty, " Local ES DF preference: %u\n",


### PR DESCRIPTION
Crash:

(gdb) bt
0  0x00007fee27de15cb in raise () from /lib/x86_64-linux-gnu/libpthread.so.0 1  0x00007fee280ecd9c in core_handler (signo=11, siginfo=0x7ffe56001bb0, context=<optimized out>) at lib/sigevent.c:264 2  <signal handler called>
3  0x0000555e321c41b2 in prefix_rd2str (prd=0x10, buf=buf@entry=0x7ffe56002080 "27.0.0.R\340\373\062\062^U", size=size@entry=28) at bgpd/bgp_rd.c:168 4  0x0000555e321c431a in printfrr_prd (buf=0x7ffe560021a0, ea=<optimized out>, ptr=<optimized out>) at bgpd/bgp_rd.c:224 5  0x00007fee2812069b in vbprintfrr (cb_in=cb_in@entry=0x7ffe56002330, fmt0=fmt0@entry=0x555e3229a3ad " RD: %pRD\n", ap=ap@entry=0x7ffe560023d8) at lib/printf/vfprintf.c:564 6  0x00007fee28122ef7 in vasnprintfrr (mt=mt@entry=0x7fee281cb5e0 <MTYPE_VTY_OUT_BUF>, out=out@entry=0x7ffe560023f0 " RD: : R\n", outsz=outsz@entry=1024, fmt=fmt@entry=0x555e3229a3ad " RD: %pRD\n", ap=ap@entry=0x7ffe560023d8) at lib/printf/glue.c:103 7  0x00007fee28103504 in vty_out (vty=vty@entry=0x555e33f82d10, format=format@entry=0x555e3229a3ad " RD: %pRD\n") at lib/vty.c:190 8  0x0000555e32185156 in bgp_evpn_es_show_entry_detail (vty=0x555e33f82d10, es=0x555e33c38420, json=<optimized out>) at bgpd/bgp_evpn_mh.c:2655 9  0x0000555e32188fe5 in bgp_evpn_es_show (vty=vty@entry=0x555e33f82d10, uj=false, detail=true) at bgpd/bgp_evpn_mh.c:2721 notice prd=0x10 in #3.  This is because in bgp_evpn_mh.c we are sending &es->es_base_frag->prd.

There is one spot in the code where during output the es->es_base_frag is checked for non nullness Let's just make sure it's right in all the places.