### PR TITLE
ospfd: Cleanup some memory leaks on shutdown in ospf_apiserver.c

### DIFF
--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -166,9 +166,14 @@ void ospf_apiserver_term(void)
 	 * Free all client instances.  ospf_apiserver_free removes the node
 	 * from the list, so we examine the head of the list anew each time.
 	 */
-	while (apiserver_list
-	       && (apiserv = listgetdata(listhead(apiserver_list))) != NULL)
+	if (!apiserver_list)
+		return;
+
+	while (listcount(apiserver_list)) {
+		apiserv = listgetdata(listhead(apiserver_list));
+
 		ospf_apiserver_free(apiserv);
+	}
 
 	/* Free client list itself */
 	if (apiserver_list)
@@ -323,6 +328,7 @@ void ospf_apiserver_free(struct ospf_apiserver *apiserv)
 		ospf_apiserver_unregister_opaque_type(
 			apiserv, regtype->lsa_type, regtype->opaque_type);
 	}
+	list_delete(&apiserv->opaque_types);
 
 	/* Close connections to OSPFd. */
 	if (apiserv->fd_sync > 0) {
@@ -343,6 +349,8 @@ void ospf_apiserver_free(struct ospf_apiserver *apiserv)
 
 	/* Remove from the list of active clients. */
 	listnode_delete(apiserver_list, apiserv);
+
+	XFREE(MTYPE_APISERVER_MSGFILTER, apiserv->filter);
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("API: Delete apiserv(%p), total#(%d)",
@@ -889,6 +897,7 @@ int ospf_apiserver_unregister_opaque_type(struct ospf_apiserver *apiserv,
 			/* Remove from list of registered opaque types */
 			listnode_delete(apiserv->opaque_types, regtype);
 
+			XFREE(MTYPE_APISERVER, regtype);
 			if (IS_DEBUG_OSPF_EVENT)
 				zlog_debug(
 					"API: Del LSA-type(%d)/Opaque-type(%d) from apiserv(%p), total#(%d)",

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -117,6 +117,10 @@ void ospf_opaque_finish(void)
 
 	ospf_ext_finish();
 
+#ifdef SUPPORT_OSPF_API
+	ospf_apiserver_term();
+#endif
+
 	ospf_sr_finish();
 }
 


### PR DESCRIPTION
Clean up some memory leaks found in ospf_apiserver.c  Also a crash in the original implementation.