### PR TITLE
nhrpd: drop peer references on freeing cache entry

### DIFF
--- a/nhrpd/nhrp_cache.c
+++ b/nhrpd/nhrp_cache.c
@@ -70,6 +70,8 @@ static void nhrp_cache_free(struct nhrp_cache *c)
 	notifier_call(&c->notifier_list, NOTIFY_CACHE_DELETE);
 	assert(!notifier_active(&c->notifier_list));
 	hash_release(nifp->cache_hash, c);
+	nhrp_peer_unref(c->cur.peer);
+	nhrp_peer_unref(c->new.peer);
 	THREAD_OFF(c->t_timeout);
 	THREAD_OFF(c->t_auth);
 	XFREE(MTYPE_NHRP_CACHE, c);


### PR DESCRIPTION
When dropping an interface (e.g. at shutdown) while there are still valid cache entries, the reference held on the cache entries' peer pointers was leaking.

Fixes: #12505