### PR TITLE
bgpd: Allow peering via 127.0.0.0/8

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3830,6 +3830,12 @@ bool bgp_update_martian_nexthop(struct bgp *bgp, afi_t afi, safi_t safi,
 		(type == ZEBRA_ROUTE_BGP && stype == BGP_ROUTE_STATIC) ? true
 								       : false;
 
+	/* If `bgp allow-martian-nexthop` is turned on, return next-hop
+	 * as good.
+	 */
+	if (bgp->allow_martian)
+		return false;
+
 	/*
 	 * Only validated for unicast and multicast currently.
 	 * Also valid for EVPN where the nexthop is an IP address.

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -834,6 +834,13 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
 						      peer->bgp->vrf_id);
 	}
 
+	/* Handle peerings via loopbacks. For instance, peer between
+	 * 127.0.0.1 and 127.0.0.2. In short, allow peering with self
+	 * via 127.0.0.0/8.
+	 */
+	if (!ifp && cmd_allow_reserved_ranges_get())
+		ifp = if_get_vrf_loopback(peer->bgp->vrf_id);
+
 	if (!ifp) {
 		/*
 		 * BGP views do not currently get proper data

--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -349,6 +349,10 @@ Basic Config Commands
    Allow using IPv4 reserved (Class E) IP ranges for daemons. E.g.: setting
    IPv4 addresses for interfaces or allowing reserved ranges in BGP next-hops.
 
+   If you need multiple FRR instances (or FRR + any other daemon) running in a
+   single router and peering via 127.0.0.0/8, it's also possible to use this
+   knob if turned on.
+
    Default: off.
 
 .. _sample-config-file:

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1399,7 +1399,7 @@ bool ipv4_unicast_valid(const struct in_addr *addr)
 	if (IPV4_CLASS_D(ip))
 		return false;
 
-	if (IPV4_CLASS_E(ip)) {
+	if (IPV4_NET0(ip) || IPV4_NET127(ip) || IPV4_CLASS_E(ip)) {
 		if (cmd_allow_reserved_ranges_get())
 			return true;
 		else

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -499,11 +499,8 @@ extern int macstr2prefix_evpn(const char *str, struct prefix_evpn *p);
 /* NOTE: This routine expects the address argument in network byte order. */
 static inline bool ipv4_martian(const struct in_addr *addr)
 {
-	in_addr_t ip = ntohl(addr->s_addr);
-
-	if (IPV4_NET0(ip) || IPV4_NET127(ip) || !ipv4_unicast_valid(addr)) {
+	if (!ipv4_unicast_valid(addr))
 		return true;
-	}
 	return false;
 }
 


### PR DESCRIPTION
There are some specific edge-cases when is a need to run FRR and another FRR and/or another BGP implementation on the same box. Relaxing 127.0.0.0/8 for this case might be reasonable.

An example below peering via 127.0.0.0/8 between FRR and GoBGP:

```
% ss -ntlp | grep 179
LISTEN   0         4096              127.0.0.1:179              0.0.0.0:*
LISTEN   0         128               127.0.0.2:179              0.0.0.0:*

% grep 127.0.0.2 /etc/frr/daemons
bgpd_options="   -A 127.0.0.1 -l 127.0.0.2"

% grep local /etc/gobgp/config.toml
    local-address-list = ["127.0.0.1"]

donatas-pc# sh ip bgp summary

IPv4 Unicast Summary (VRF default):
BGP router identifier 192.168.10.17, local AS number 65001 vrf-id 0
BGP table version 0
RIB entries 0, using 0 bytes of memory
Peers 1, using 725 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
127.0.0.1       4      65002         7         7        0    0    0 00:02:02            0        0 N/A

Total number of neighbors 1
donatas-pc#
```
Closes https://github.com/FRRouting/frr/issues/12767