### PR TITLE
lib: fix clear route-map command

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -3101,27 +3101,24 @@ static void clear_route_map_helper(struct route_map *map)
 		index->applied_clear = index->applied;
 }
 
-DEFUN (rmap_clear_counters,
+DEFPY (rmap_clear_counters,
        rmap_clear_counters_cmd,
-       "clear route-map counters [WORD]",
+       "clear route-map counters [RMAP_NAME$rmapname]",
        CLEAR_STR
        "route-map information\n"
        "counters associated with the specified route-map\n"
        "route-map name\n")
 {
-	int idx_word = 2;
 	struct route_map *map;
 
-	const char *name = (argc == 3 ) ? argv[idx_word]->arg : NULL;
-
-	if (name) {
-		map = route_map_lookup_by_name(name);
+	if (rmapname) {
+		map = route_map_lookup_by_name(rmapname);
 
 		if (map)
 			clear_route_map_helper(map);
 		else {
 			vty_out(vty, "%s: 'route-map %s' not found\n",
-				frr_protonameinst, name);
+				frr_protonameinst, rmapname);
 			return CMD_SUCCESS;
 		}
 	} else {


### PR DESCRIPTION
1. clear route-map command parsing had incorrect index to parse route-map name which corrected using DEFPY
  
    tor-21# clear route-map counters SET_SRC_LO
    tor-21#

    **Before:**
    ```
    TORC11# clear route-map counters
      <cr>
      WORD  route-map name
    ```
    
   **After:**
   ```
    TORC11# clear route-map counters
      <cr>
      RMAP_NAME  route-map name
         my-as
    ```
    
    tor-21# show route-map
    ZEBRA:
    route-map: ALLOW_LO Invoked: 0 Optimization: disabled Processed Change:
    false
     permit, sequence 10 **Invoked 0**
      Match clauses:
        interface lo
      Set clauses:
      Call clause:
      Action:
        Exit routemap


    
    Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>
    Signed-off-by: Chirag Shah <chirag@nvidia.com>
