### PR TITLE
ospfd: Fixing Summary origination after range configuration

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -1290,7 +1290,7 @@ static struct ospf_lsa *ospf_handle_summarylsa_lsId_chg(struct ospf_area *area,
 							struct in_addr old_id)
 {
 	struct ospf_lsa *lsa = NULL;
-	struct ospf_lsa *new = NULL;
+	struct ospf_lsa *summary_lsa = NULL;
 	struct summary_lsa *sl = NULL;
 	struct ospf_area *old_area = NULL;
 	struct ospf *ospf = area->ospf;
@@ -1328,19 +1328,19 @@ static struct ospf_lsa *ospf_handle_summarylsa_lsId_chg(struct ospf_area *area,
 
 	if (type == OSPF_SUMMARY_LSA) {
 		/*Refresh the LSA with new LSA*/
-		ospf_summary_lsa_refresh(ospf, lsa);
+		summary_lsa = ospf_summary_lsa_refresh(ospf, lsa);
 
-		new = ospf_summary_lsa_prepare_and_flood(
-			&old_prefix, old_metric, old_area, old_id);
+		ospf_summary_lsa_prepare_and_flood(&old_prefix, old_metric,
+						   old_area, old_id);
 	} else {
 		/*Refresh the LSA with new LSA*/
-		ospf_summary_asbr_lsa_refresh(ospf, lsa);
+		summary_lsa = ospf_summary_asbr_lsa_refresh(ospf, lsa);
 
-		new = ospf_asbr_summary_lsa_prepare_and_flood(
-			&old_prefix, old_metric, old_area, old_id);
+		ospf_asbr_summary_lsa_prepare_and_flood(&old_prefix, old_metric,
+							old_area, old_id);
 	}
 
-	return new;
+	return summary_lsa;
 }
 
 /* Originate Summary-LSA. */


### PR DESCRIPTION
Description:
	After area range config, summary lsas are aggerated to configured
	route but later it was being flushed instead of the actual summary
	lsa. This was seen when prefix-id of the aggregated route is same
	as one of the actual summary route.
	Here, aggregated summary lsa need to be returned to set the flag
	SUMMARY_APPROVE after originating aggregated summary lsa but its not.
	Which is being cleaned up as part of unapproved summary cleanup.
	Corrected this now.

Issue: #13028