### PR TITLE
zebra: add evpn isDetectionFreeze to json output

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -3819,6 +3819,8 @@ void zebra_vxlan_print_evpn(struct vty *vty, bool uj)
 		json_object_int_add(json, "detectionTime", zvrf->dad_time);
 		json_object_int_add(json, "detectionFreezeTime",
 				    zvrf->dad_freeze_time);
+		json_object_boolean_add(json, "isDetectionFreeze",
+					zvrf->dad_freeze);
 		zebra_evpn_mh_json(json);
 	} else {
 		vty_out(vty, "L2 VNIs: %u\n", num_l2vnis);


### PR DESCRIPTION
Added "isDetectionFreeze" into show evpn json output to identify **freeze** **permanent**. 

Before fix:-
```
tor-2(config)# router bgp 65561
tor-2(config-router)# address-family l2vpn evpn
  <cr>
tor-2(config-router)# address-family l2vpn evpn
tor-2(config-router-af)# dup-addr-detection freeze permanent

tor-2(config-router-af)# do show evpn
L2 VNIs: 21
L3 VNIs: 5
Advertise gateway mac-ip: No
Advertise svi mac-ip: No
Advertise svi mac: No
Duplicate address detection: Enable
  Detection max-moves 5, time 180
  Detection freeze permanent
EVPN MH:
  mac-holdtime: 1080s, neigh-holdtime: 1080s
  startup-delay: 180s, start-delay-timer: --:--:--
  uplink-cfg-cnt: 0, uplink-active-cnt: 0
tor-2(config-router-af)#

tor-2(config-router-af)# do show evpn json
{
  "advertiseGatewayMacip":"No",
  "advertiseSviMacip":"No",
  "advertiseSviMac":"No",
  "numVnis":26,
  "numL2Vnis":21,
  "numL3Vnis":5,
  "isDuplicateAddrDetection":true,
  "maxMoves":5,
  "detectionTime":180,
  "detectionFreezeTime":0,
  "macHoldtime":1080,
  "neighHoldtime":1080,
  "startupDelay":180,
  "startupDelayTimer":"--:--:--",
  "uplinkConfigCount":0,
  "uplinkActiveCount":0
}
tor-2(config-router-af)#
```

After fix:-
```
cumulus@tor-1:mgmt:~$ sudo vtysh -c "show evpn json"
{
  "advertiseGatewayMacip":"No",
  "advertiseSviMacip":"No",
  "advertiseSviMac":"No",
  "numVnis":26,
  "numL2Vnis":21,
  "numL3Vnis":5,
  "isDuplicateAddrDetection":true,
  "maxMoves":5,
  "detectionTime":180,
  "detectionFreezeTime":0,  ==> default case , i.e dad_freeze duration is 0
  "isDetectionFreeze":false, ==> default case, i.e. dad_freeze disabled
  "macHoldtime":1080,
  "neighHoldtime":1080,
  "startupDelay":180,
  "startupDelayTimer":"--:--:--",
  "uplinkConfigCount":0,
  "uplinkActiveCount":0
}
cumulus@tor-1:mgmt:~$

tor-1(config-router-af)# dup-addr-detection freeze permanent
tor-1(config-router-af)# do show evpn json
{
  "advertiseGatewayMacip":"No",
  "advertiseSviMacip":"No",
  "advertiseSviMac":"No",
  "numVnis":26,
  "numL2Vnis":21,
  "numL3Vnis":5,
  "isDuplicateAddrDetection":true,
  "maxMoves":5,
  "detectionTime":180,
  "detectionFreezeTime":0, ==> dad_freeze with duration permanent
  "isDetectionFreeze":true, ==> dad_freeze enabled
  "macHoldtime":1080,
  "neighHoldtime":1080,
  "startupDelay":180,
  "startupDelayTimer":"00:00:08",
  "uplinkConfigCount":0,
  "uplinkActiveCount":0,
  "protodownReasons":[
    "startupDelay"
  ]
}
tor-1(config-router-af)#

tor-1(config-router-af)# dup-addr-detection freeze 400
tor-1(config-router-af)#
tor-1(config-router-af)# do show evpn json
{
  "advertiseGatewayMacip":"No",
  "advertiseSviMacip":"No",
  "advertiseSviMac":"No",
  "numVnis":26,
  "numL2Vnis":21,
  "numL3Vnis":5,
  "isDuplicateAddrDetection":true,
  "maxMoves":5,
  "detectionTime":180,
  "detectionFreezeTime":400, ==> dad_freeze duration with numeric value
  "isDetectionFreeze":true, ==> dad_freeze enabled
  "macHoldtime":1080,
  "neighHoldtime":1080,
  "startupDelay":180,
  "startupDelayTimer":"00:00:47",
  "uplinkConfigCount":0,
  "uplinkActiveCount":0,
  "protodownReasons":[
    "startupDelay"
  ]
}

tor-1(config-router-af)# no dup-addr-detection freeze permanent
tor-1(config-router-af)# do show evpn json
{
  "advertiseGatewayMacip":"No",
  "advertiseSviMacip":"No",
  "advertiseSviMac":"No",
  "numVnis":26,
  "numL2Vnis":21,
  "numL3Vnis":5,
  "isDuplicateAddrDetection":true,
  "maxMoves":5,
  "detectionTime":180,
  "detectionFreezeTime":0, ==> no dad_freeze duration
  "isDetectionFreeze":false, ==> no dad_freeze enabled
  "macHoldtime":1080,
  "neighHoldtime":1080,
  "startupDelay":180,
  "startupDelayTimer":"--:--:--",
  "uplinkConfigCount":0,
  "uplinkActiveCount":0
}
tor-1(config-router-af)#

```

Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>