### PR TITLE
Fix thread cancel issue, make list, thread ptr to NULL

### DIFF
--- a/lib/thread.c
+++ b/lib/thread.c
@@ -1391,8 +1391,10 @@ static void do_thread_cancel(struct thread_master *master)
 
 		if (list) {
 			thread_list_del(list, thread);
+			list = NULL;
 		} else if (thread_array) {
 			thread_array[thread->u.fd] = NULL;
+			thread_array = NULL;
 		}
 
 		if (thread->ref)


### PR DESCRIPTION
-What I did
thread_cancel will lead to core dump, make thread pointer to NULL while deleting it.

-How I did it
make pointer list and thr in `do_thread_cancel()` to NULL

-How to verify it
check list and thread_array is NULL