### PR TITLE
bgpd: Ensure suppress-fib-pending works with network statements

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1309,6 +1309,14 @@ void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 	uint32_t bos = 0;
 	uint32_t exp = 0;
 
+	/*
+	 * BGP is installing this route and bgp has been configured
+	 * to suppress announcements until the route has been installed
+	 * let's set the fact that we expect this route to be installed
+	 */
+	if (BGP_SUPPRESS_FIB_ENABLED(bgp))
+		SET_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING);
+
 	/* Don't try to install if we're not connected to Zebra or Zebra doesn't
 	 * know of this instance.
 	 */
@@ -1759,6 +1767,12 @@ void bgp_zebra_withdraw(const struct prefix *p, struct bgp_path_info *info,
 {
 	struct zapi_route api;
 	struct peer *peer;
+
+	/*
+	 * If we are withdrawing the route, we don't need to have this
+	 * flag set.  So unset it.
+	 */
+	UNSET_FLAG(info->net->flags, BGP_NODE_FIB_INSTALL_PENDING);
 
 	/* Don't try to install if we're not connected to Zebra or Zebra doesn't
 	 * know of this instance.

--- a/tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py
+++ b/tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py
@@ -217,6 +217,20 @@ def test_bgp_allow_as_in():
     assertmsg = '"r2" 192.168.1.1/32 route should be gone'
     assert result is None, assertmsg
 
+def test_local_vs_non_local():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    output = json.loads(r2.vtysh_cmd("show bgp ipv4 uni 60.0.0.0/24 json"))
+    paths = output["paths"]
+    for i in range(len(paths)):
+        if "fibPending" in paths[i]:
+            assert(False),  "Route 60.0.0.0/24 should not have fibPending"
+
 
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]


### PR DESCRIPTION
The flag for telling BGP that a route is expected to be installed first before notifying a peer was always being set upon receipt of a path that could be accepted as bestpath.  This is not correct: imagine that you have a peer sending you a route and you have a network statement that covers the same route.  Irrelevant if the network statement would win the flag on the dest was being set in bgp_update.  Thus you could get into a situation where the network statement path wins but since the flag is set on the node, it will never be announced to a peer.

Let's just move the setting of the flag into bgp_zebra_announce and _withdraw.  In _announce set the flag to TRUE when suppress-fib is enabled.  In _withdraw just always unset the flag as that a withdrawal does not need to wait for rib removal before announcing.  This will cover the case when a network statement is added after the route has been learned from a peer.