### PR TITLE
ospfd: Fix for memory leak issue in ospf related to flood_reduction tests.

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -4099,11 +4099,11 @@ void ospf_lsa_refresh_walker(struct thread *t)
 		dna_lsa = ospf_check_dna_lsa(lsa);
 		if (!dna_lsa) { /* refresh only non-DNA LSAs */
 			ospf_lsa_refresh(ospf, lsa);
-			assert(lsa->lock > 0);
-			ospf_lsa_unlock(&lsa); /* lsa_refresh_queue & temp for
-						* lsa_to_refresh.
-						*/
 		}
+		assert(lsa->lock > 0);
+		ospf_lsa_unlock(&lsa); /* lsa_refresh_queue & temp for
+					* lsa_to_refresh.
+					*/
 	}
 
 	list_delete(&lsa_to_refresh);


### PR DESCRIPTION
Problem:
Multiple memory leaks after pr12366

RCA:
ospf_lsa_unlock was not happening for the few of the LSAs in ospf_lsa_refresh_walker after pr12366 due to which
memory related to lsas was leaking.

Fix:
Moved the ospf_lsa_unlock outside if check.

Signed-off-by: Manoj Naragund <mnaragund@vmware.com>