### PR TITLE
pim6d: mroutes not created after disabling and enabling PIMv6.

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -99,7 +99,7 @@ static inline uint8_t in6_multicast_scope(const pim_addr *addr)
 	return addr->s6_addr[1] & 0xf;
 }
 
-static inline bool in6_multicast_nofwd(const pim_addr *addr)
+bool in6_multicast_nofwd(const pim_addr *addr)
 {
 	return in6_multicast_scope(addr) <= IPV6_MULTICAST_SCOPE_LINK;
 }
@@ -182,12 +182,10 @@ DECLARE_HASH(gm_gsq_pends, struct gm_gsq_pending, itm, gm_gsq_pending_cmp,
  * interface -> (S,G)
  */
 
-static int gm_sg_cmp(const struct gm_sg *a, const struct gm_sg *b)
+int gm_sg_cmp(const struct gm_sg *a, const struct gm_sg *b)
 {
 	return pim_sgaddr_cmp(a->sgaddr, b->sgaddr);
 }
-
-DECLARE_RBTREE_UNIQ(gm_sgs, struct gm_sg, itm, gm_sg_cmp);
 
 static struct gm_sg *gm_sg_find(struct gm_if *gm_ifp, pim_addr grp,
 				pim_addr src)

--- a/pimd/pim6_mld.h
+++ b/pimd/pim6_mld.h
@@ -113,6 +113,8 @@ struct gm_sg {
 	 */
 	struct gm_packet_sg *most_recent;
 };
+int gm_sg_cmp(const struct gm_sg *a, const struct gm_sg *b);
+DECLARE_RBTREE_UNIQ(gm_sgs, struct gm_sg, itm, gm_sg_cmp);
 
 /* host tracking entry.  addr will be one of:
  *
@@ -352,5 +354,6 @@ static inline void gm_ifp_teardown(struct interface *ifp)
 #endif
 
 extern void gm_cli_init(void);
+bool in6_multicast_nofwd(const pim_addr *addr);
 
 #endif /* PIM6_MLD_H */


### PR DESCRIPTION
After doing "no ipv6 pim" and "ipv6 pim" on receiver interface in LHR, mroutes were not created.

When we enable pim after disabling it, we refresh the membership on interface. First we clear the membership on the interface, then we add it back. For PIMv6 we were only clearing it, membership was not added back. So mroutes were not created.

Now added code to fetch all the local membership information into PIM.

Fixes: #12005, #12820