### PR TITLE
tools: Set correct directory of vtysh for frr-reload.py

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2693,6 +2693,7 @@ AC_SUBST([vtysh_bin])
 
 CFG_SYSCONF="$sysconfdir"
 CFG_SBIN="$sbindir"
+CFG_BIN="$bindir"
 CFG_STATE="$frr_statedir"
 CFG_MODULE="$moduledir"
 CFG_YANGMODELS="$yangmodelsdir"
@@ -2700,6 +2701,7 @@ CFG_SCRIPT="$scriptdir"
 for I in 1 2 3 4 5 6 7 8 9 10; do
 	eval CFG_SYSCONF="\"$CFG_SYSCONF\""
 	eval CFG_SBIN="\"$CFG_SBIN\""
+	eval CFG_BIN="\"$CFG_BIN\""
 	eval CFG_STATE="\"$CFG_STATE\""
 	eval CFG_MODULE="\"$CFG_MODULE\""
 	eval CFG_YANGMODELS="\"$CFG_YANGMODELS\""
@@ -2707,6 +2709,7 @@ for I in 1 2 3 4 5 6 7 8 9 10; do
 done
 AC_SUBST([CFG_SYSCONF])
 AC_SUBST([CFG_SBIN])
+AC_SUBST([CFG_BIN])
 AC_SUBST([CFG_STATE])
 AC_SUBST([CFG_MODULE])
 AC_SUBST([CFG_SCRIPT])

--- a/tools/frr.in
+++ b/tools/frr.in
@@ -17,6 +17,7 @@ PATH=/bin:/usr/bin:/sbin:/usr/sbin
 D_PATH="@CFG_SBIN@" # /usr/lib/frr
 C_PATH="@CFG_SYSCONF@" # /etc/frr
 V_PATH="@CFG_STATE@" # /var/run/frr
+B_PATH="@CFG_BIN@"
 VTYSH="@vtysh_bin@" # /usr/bin/vtysh
 FRR_USER="@enable_user@" # frr
 FRR_GROUP="@enable_group@" # frr
@@ -582,7 +583,7 @@ case "$1" in
 		NEW_CONFIG_FILE="${2:-$C_PATH/frr.conf}"
 		[ ! -r $NEW_CONFIG_FILE ] && echo "Unable to read new configuration file $NEW_CONFIG_FILE" && exit 1
 		echo "Applying only incremental changes to running configuration from frr.conf"
-		"$RELOAD_SCRIPT" --reload --bindir "$D_PATH" --confdir "$C_PATH" --rundir "$V_PATH" "$C_PATH/frr.conf"
+		"$RELOAD_SCRIPT" --reload --bindir "$B_PATH" --confdir "$C_PATH" --rundir "$V_PATH" "$C_PATH/frr.conf"
 		exit $?
 		;;
 

--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -24,6 +24,7 @@ PATH=/bin:/usr/bin:/sbin:/usr/sbin
 D_PATH="@CFG_SBIN@" # /usr/lib/frr
 C_PATH="@CFG_SYSCONF@${suffix}" # /etc/frr
 V_PATH="@CFG_STATE@${suffix}" # /var/run/frr
+B_PATH="@CFG_BIN@"
 VTYSH="@vtysh_bin@" # /usr/bin/vtysh
 FRR_USER="@enable_user@" # frr
 FRR_GROUP="@enable_group@" # frr

--- a/tools/frrinit.sh.in
+++ b/tools/frrinit.sh.in
@@ -122,7 +122,7 @@ reload)
 
 	NEW_CONFIG_FILE="${2:-$C_PATH/frr.conf}"
 	[ ! -r $NEW_CONFIG_FILE ] && log_failure_msg "Unable to read new configuration file $NEW_CONFIG_FILE" && exit 1
-	"$RELOAD_SCRIPT" --reload --bindir "$D_PATH" --confdir "$C_PATH" --rundir "$V_PATH" "$NEW_CONFIG_FILE" `echo $nsopt`
+	"$RELOAD_SCRIPT" --reload --bindir "$B_PATH" --confdir "$C_PATH" --rundir "$V_PATH" "$NEW_CONFIG_FILE" `echo $nsopt`
 	exit $?
 	;;
 


### PR DESCRIPTION
Before it was setting SDIR, which is /usr/lib/frr, but the vtysh binary is put under bindir (which is /usr/local by default). And running `/usr/lib/frr/frr reload` failed.