### PR TITLE
minor topotest cleanup

### DIFF
--- a/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
+++ b/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
@@ -288,6 +288,17 @@ def test_converge_protocols():
 
     thisDir = os.path.dirname(os.path.realpath(__file__))
 
+    # We need loopback to have a link local so it always is the
+    # "selected" router for fe80::/64 when we static compare below.
+    print("Adding link-local to loopback for stable results")
+    cmd = (
+        "mac=`cat /sys/class/net/lo/address`; echo lo: $mac;"
+        " [ -z \"$mac\" ] && continue; IFS=':'; set $mac; unset IFS;"
+        " ip address add dev lo scope link"
+        " fe80::$(printf %02x $((0x$1 ^ 2)))$2:${3}ff:fe$4:$5$6/64"
+    )
+    net["r1"].cmd_raises(cmd)
+
     print("\n\n** Waiting for protocols convergence")
     print("******************************************\n")
 

--- a/tests/topotests/lib/micronet_compat.py
+++ b/tests/topotests/lib/micronet_compat.py
@@ -161,12 +161,10 @@ class Mininet(Micronet):
 
     g_mnet_inst = None
 
-    def __init__(self, controller=None):
+    def __init__(self):
         """
         Create a Micronet.
         """
-        assert not controller
-
         if Mininet.g_mnet_inst is not None:
             Mininet.g_mnet_inst.stop()
         Mininet.g_mnet_inst = self

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -802,7 +802,7 @@ class TopoRouter(TopoGear):
                     grep_cmd = "grep 'ip {}' {}".format(daemonstr, source)
                 else:
                     grep_cmd = "grep 'router {}' {}".format(daemonstr, source)
-                result = self.run(grep_cmd).strip()
+                result = self.run(grep_cmd, warn=False).strip()
                 if result:
                     self.load_config(daemon)
         else:

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -212,7 +212,7 @@ class Topogen(object):
         # Mininet(Micronet) to build the actual topology.
         assert not inspect.isclass(topodef)
 
-        self.net = Mininet(controller=None)
+        self.net = Mininet()
 
         # New direct way: Either a dictionary defines the topology or a build function
         # is supplied, or a json filename all of which build the topology by calling

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -214,6 +214,9 @@ class Topogen(object):
 
         self.net = Mininet()
 
+        # Adjust the parent namespace
+        topotest.fix_netns_limits(self.net)
+
         # New direct way: Either a dictionary defines the topology or a build function
         # is supplied, or a json filename all of which build the topology by calling
         # Topogen methods which call Mininet(Micronet) methods to create the actual

--- a/tests/topotests/zebra_rib/test_zebra_rib.py
+++ b/tests/topotests/zebra_rib/test_zebra_rib.py
@@ -51,7 +51,8 @@ def config_macvlan(tgen, r_str, device, macvlan):
 
 def setup_module(mod):
     "Sets up the pytest environment"
-    topodef = {"s1": ("r1", "r1", "r1", "r1", "r1", "r1", "r1", "r1")}
+    # 8 links to 8 switches on r1
+    topodef = {"s{}".format(x): ("r1",) for x in range(1, 9)}
     tgen = Topogen(topodef, mod.__name__)
     tgen.start_topology()
 


### PR DESCRIPTION
tests: don't flush ipv6 addresses
tests: create 8 link, switch pairs, not 8 links on one switch
tests: initialize parent test namespace too

