### PR TITLE
mgmtd, tests: Disable auto-saving of running config to startup config.

### DIFF
--- a/doc/user/mgmtd.rst
+++ b/doc/user/mgmtd.rst
@@ -305,6 +305,20 @@ MGMT Configuration commands
     This command dumps the DB specified in the db-name into the file in JSON
     format. This command in not supported for the Operational DB.
 
+.. clicmd:: mgmt copy-config running startup
+
+    This command saves a copy of the running datastore to the startup datastore
+    such that on restart of MGMT daemon (or the entire FRR) the same can be
+    restored and loaded back onto the running datastore.
+
+.. clicmd:: [no] mgmt auto-copy-config running startup
+
+    With this configuration command the contents of the running dtatstore
+    shall be automatically saved onto the startup datastore everytime any
+    configuration change is committed to it. To disable the automatic saving
+    of contents of running datastore to startup datastore the command
+    'no mgmt auto-copy-config running startup' can be used.
+
 .. clicmd:: mgmt commit abort
 
     This command will abort any configuration present on the Candidate but not

--- a/lib/command.h
+++ b/lib/command.h
@@ -171,6 +171,7 @@ enum node_type {
 	OPENFABRIC_NODE,	/* OpenFabric router configuration node */
 	VRRP_NODE,		 /* VRRP node */
 	BMP_NODE,		/* BMP config under router bgp */
+	MGMT_NODE,		/* Management Daemon Config */
 	NODE_TYPE_MAX, /* maximum */
 };
 /* clang-format on */

--- a/mgmtd/mgmt.c
+++ b/mgmtd/mgmt.c
@@ -36,6 +36,7 @@ void mgmt_master_init(struct event_loop *master, const int buffer_size)
 	mm->terminating = false;
 	mm->socket_buffer = buffer_size;
 	mm->perf_stats_en = true;
+	mm->auto_save_config_to_startup = false;
 }
 
 void mgmt_init(void)
@@ -69,7 +70,7 @@ void mgmt_init(void)
 	mgmt_fe_server_init(mm->master);
 
 	/* MGMTD VTY commands installation. */
-	mgmt_vty_init();
+	mgmt_vty_init(mm);
 }
 
 void mgmt_terminate(void)

--- a/mgmtd/mgmt.h
+++ b/mgmtd/mgmt.h
@@ -53,6 +53,7 @@ struct mgmt_master {
 	struct mgmt_ds_ctx *running_ds;
 	struct mgmt_ds_ctx *candidate_ds;
 	struct mgmt_ds_ctx *oper_ds;
+	bool auto_save_config_to_startup;
 
 	bool terminating;   /* global flag that sigint terminate seen */
 	bool perf_stats_en; /* to enable performance stats measurement */
@@ -100,7 +101,7 @@ extern int mgmt_config_write(struct vty *vty);
 extern void mgmt_master_init(struct event_loop *master, const int buffer_size);
 
 extern void mgmt_init(void);
-extern void mgmt_vty_init(void);
+extern void mgmt_vty_init(struct mgmt_master *mm);
 
 static inline char *mgmt_realtime_to_string(struct timeval *tv, char *buf,
 					    size_t sz)

--- a/mgmtd/mgmt_ds.c
+++ b/mgmtd/mgmt_ds.c
@@ -87,6 +87,7 @@ static int mgmt_ds_replace_dst_with_src_ds(struct mgmt_ds_ctx *src,
 					   struct mgmt_ds_ctx *dst)
 {
 	struct lyd_node *dst_dnode, *src_dnode;
+	struct ly_out *out;
 
 	if (!src || !dst)
 		return -1;
@@ -116,6 +117,14 @@ static int mgmt_ds_replace_dst_with_src_ds(struct mgmt_ds_ctx *src,
 		nb_config_diff_del_changes(&src->root.cfg_root->cfg_chgs);
 	}
 
+	if (dst->ds_id == MGMTD_DS_RUNNING &&
+	    mgmt_ds_mm->auto_save_config_to_startup) {
+		if (ly_out_new_filepath(MGMTD_STARTUP_DS_FILE_PATH, &out) ==
+		    LY_SUCCESS)
+			mgmt_ds_dump_in_memory(dst, "", LYD_JSON, out);
+		ly_out_free(out, NULL, 0);
+	}
+
 	/* TODO: Update the versions if nb_config present */
 
 	return 0;
@@ -126,6 +135,7 @@ static int mgmt_ds_merge_src_with_dst_ds(struct mgmt_ds_ctx *src,
 {
 	int ret;
 	struct lyd_node **dst_dnode, *src_dnode;
+	struct ly_out *out;
 
 	if (!src || !dst)
 		return -1;
@@ -148,6 +158,14 @@ static int mgmt_ds_merge_src_with_dst_ds(struct mgmt_ds_ctx *src,
 		 */
 		MGMTD_DS_DBG("Emptying Candidate Scratch buffer!");
 		nb_config_diff_del_changes(&src->root.cfg_root->cfg_chgs);
+	}
+
+	if (dst->ds_id == MGMTD_DS_RUNNING &&
+	    mgmt_ds_mm->auto_save_config_to_startup) {
+		if (ly_out_new_filepath(MGMTD_STARTUP_DS_FILE_PATH, &out) ==
+		    LY_SUCCESS)
+			mgmt_ds_dump_in_memory(dst, "", LYD_JSON, out);
+		ly_out_free(out, NULL, 0);
 	}
 
 	return 0;

--- a/mgmtd/mgmt_ds.h
+++ b/mgmtd/mgmt_ds.h
@@ -31,6 +31,8 @@
 #define MGMTD_MD5_HASH_LEN 16
 #define MGMTD_MD5_HASH_STR_HEX_LEN 33
 
+#define MGMTD_STARTUP_DS_FILE_PATH DAEMON_DB_DIR "/frr_startup.json"
+
 #define MGMTD_COMMIT_FILE_PATH DAEMON_DB_DIR "/commit-%s.json"
 #define MGMTD_COMMIT_INDEX_FILE_NAME DAEMON_DB_DIR "/commit-index.dat"
 #define MGMTD_COMMIT_TIME_STR_LEN 100

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -1129,7 +1129,8 @@ def start_router(tgen, router):
     try:
         router_list = tgen.routers()
 
-        # Ensure that configs from staticd are always loaded onto mgmtd
+        # Ensure that configs from zebra and staticd are always loaded onto mgmtd
+        # tgen.net[router].loadConf("mgmtd", "/etc/frr/zebra.conf")
         tgen.net[router].loadConf("mgmtd", "/etc/frr/staticd.conf")
 
         # Router and its daemons would be started and config would

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -1095,7 +1095,7 @@ def start_topology(tgen):
     tgen.start_router()
 
 
-def stop_router(tgen, router):
+def stop_router(tgen, router, save_config=True):
     """
     Router"s current config would be saved to /tmp/topotest/<suite>/<router> for each daemon
     and router and its daemons would be stopped.
@@ -1108,7 +1108,8 @@ def stop_router(tgen, router):
 
     # Saving router config to /etc/frr, which will be loaded to router
     # when it starts
-    router_list[router].vtysh_cmd("write memory")
+    if save_config:
+        router_list[router].vtysh_cmd("write memory")
 
     # Stop router
     router_list[router].stop()
@@ -1127,6 +1128,9 @@ def start_router(tgen, router):
 
     try:
         router_list = tgen.routers()
+
+        # Ensure that configs from staticd are always loaded onto mgmtd
+        tgen.net[router].loadConf("mgmtd", "/etc/frr/staticd.conf")
 
         # Router and its daemons would be started and config would
         #  be loaded to router for each daemon from /etc/frr

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1564,6 +1564,9 @@ class Router(Node):
                         "using router relative configuration: {}".format(source)
                     )
 
+        logger.info("loadConf: daemon:{}, source:{}".format(daemon, source))
+        if source is not None and not os.path.exists(source):
+            self.logger.info("loadConf: {} does not exists".format(source))
         # print "Daemons before:", self.daemons
         if daemon in self.daemons.keys() or daemon == "frr":
             if daemon == "frr":
@@ -1581,8 +1584,12 @@ class Router(Node):
                 # copy zebra.conf to mgmtd folder, which can be used during startup
                 if daemon == "zebra":
                     conf_file_mgmt = "/etc/{}/{}.conf".format(self.routertype, "mgmtd")
-                    self.cmd_raises("cp {} {}".format(source, conf_file_mgmt))
-                self.cmd_raises("cp {} {}".format(source, conf_file))
+                    cmd = "cp {} {}".format(source, conf_file_mgmt)
+                    self.logger.info("Daemon: {}, {}".format(daemon, cmd))
+                    self.cmd_raises(cmd)
+                cmd = "cp {} {}".format(source, conf_file)
+                self.logger.info("Daemon: {}, {}".format(daemon, cmd))
+                self.cmd_raises(cmd)
 
             if not self.unified_config or daemon == "frr":
                 self.cmd_raises("chown {0}:{0} {1}".format(self.routertype, conf_file))

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo2_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo2_ebgp.py
@@ -1392,6 +1392,7 @@ def test_static_route_8nh_diff_AD_bgp_ecmp_p1_tc10_ebgp(request):
             result is True
         ), "Testcase {} : Failed \n Error: Routes are missing in RIB".format(tc_name)
 
+    router = tgen.gears["r2"]
     step("Remove random static route with all the nexthop")
     for addr_type in ADDR_TYPES:
         # delete static routes
@@ -1468,6 +1469,8 @@ def test_static_route_8nh_diff_AD_bgp_ecmp_p1_tc10_ebgp(request):
 
             start_router(tgen, "r2")
 
+            router.vtysh_cmd("show running-config")
+            router.vtysh_cmd("show mgmt get-config running /")
             step("After reloading, verify that routes are still present in R2.")
             result = verify_rib(
                 tgen,

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo2_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo2_ibgp.py
@@ -1619,6 +1619,7 @@ def test_static_route_8nh_diff_AD_bgp_ecmp_p1_tc10_ibgp(request):
             result is True
         ), "Testcase {} : Failed \n Error: Routes are missing in RIB".format(tc_name)
 
+    router = tgen.gears["r2"]
     step("Remove random static route with all the nexthop")
     for addr_type in ADDR_TYPES:
         # delete static routes
@@ -1695,6 +1696,8 @@ def test_static_route_8nh_diff_AD_bgp_ecmp_p1_tc10_ibgp(request):
 
             start_router(tgen, "r2")
 
+            router.vtysh_cmd("show running-config")
+            router.vtysh_cmd("show mgmt get-config running /")
             step("After reloading, verify that routes are still present in R2.")
             result = verify_rib(
                 tgen,


### PR DESCRIPTION
Currently in mgmtd, after every config commands (applicable to configs for components that has been migrated to MGMT infra), has been validated, applied onto the component backend daemon, the config are added to running datastore on MGMT. And then whenever there's a change in the contents of the running datastore a copy of the running datastore is automatically stored into the on-disk startup datastore file (usually to be found at /var/run/frr/frr_startup.json). The motive was to re-read the contents of the startup datastore file (in case mgmtd crahsed/restarted/reloaded)and then populate the running/candidate datastore with it (to restore them back to its previous incarnation form).

But it has been brought to notice this seems to be departure from the pre-MGMTd behaviour, where config is explicitly backed up using 'write memory' command and not automatically backed up.

This PR alters the behaviour of MGMTd by disabling automatic backup of running datastore to startup by default. Instead it provides the following commands to have the same functionality (if required).
- Run 'mgmt copy-config running startup' as and when user wants to copy the current contents of the running datastore to the startup datastore. This is similar to 'write memory' command.
- Run 'mgmt copy-config running startup always' to enable auto saving contents of running datastore to startup after each successful change to the running datastore. This command is also reflected in the 'show running' and can be made permanent through another 'write memory' command right after.

So now by default, configs fed through the MGMT infra will not be stored in the startup datastore unless specified to do so using the above commands.

Signed-off-by: Pushpasis Sarkar <pushpasis@gmail.com>

