### PR TITLE
Assert unneeded

### DIFF
--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -1056,26 +1056,22 @@ mgmt_be_client_register_event(struct mgmt_be_client_ctx *client_ctx,
 		event_add_read(client_ctx->tm, mgmt_be_client_read,
 				client_ctx, client_ctx->conn_fd,
 				&client_ctx->conn_read_ev);
-		assert(client_ctx->conn_read_ev);
 		break;
 	case MGMTD_BE_CONN_WRITE:
 		event_add_write(client_ctx->tm, mgmt_be_client_write,
 				 client_ctx, client_ctx->conn_fd,
 				 &client_ctx->conn_write_ev);
-		assert(client_ctx->conn_write_ev);
 		break;
 	case MGMTD_BE_PROC_MSG:
 		tv.tv_usec = MGMTD_BE_MSG_PROC_DELAY_USEC;
 		event_add_timer_tv(client_ctx->tm, mgmt_be_client_proc_msgbufs,
 				    client_ctx, &tv, &client_ctx->msg_proc_ev);
-		assert(client_ctx->msg_proc_ev);
 		break;
 	case MGMTD_BE_CONN_WRITES_ON:
 		event_add_timer_msec(client_ctx->tm,
 				      mgmt_be_client_resume_writes, client_ctx,
 				      MGMTD_BE_MSG_WRITE_DELAY_MSEC,
 				      &client_ctx->conn_writes_on);
-		assert(client_ctx->conn_writes_on);
 		break;
 	case MGMTD_BE_SERVER:
 	case MGMTD_BE_CONN_INIT:

--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -741,27 +741,23 @@ mgmt_fe_client_register_event(struct mgmt_fe_client_ctx *client_ctx,
 		event_add_read(client_ctx->tm, mgmt_fe_client_read,
 				client_ctx, client_ctx->conn_fd,
 				&client_ctx->conn_read_ev);
-		assert(client_ctx->conn_read_ev);
 		break;
 	case MGMTD_FE_CONN_WRITE:
 		event_add_write(client_ctx->tm, mgmt_fe_client_write,
 				 client_ctx, client_ctx->conn_fd,
 				 &client_ctx->conn_write_ev);
-		assert(client_ctx->conn_write_ev);
 		break;
 	case MGMTD_FE_PROC_MSG:
 		tv.tv_usec = MGMTD_FE_MSG_PROC_DELAY_USEC;
 		event_add_timer_tv(client_ctx->tm,
 				    mgmt_fe_client_proc_msgbufs, client_ctx,
 				    &tv, &client_ctx->msg_proc_ev);
-		assert(client_ctx->msg_proc_ev);
 		break;
 	case MGMTD_FE_CONN_WRITES_ON:
 		event_add_timer_msec(
 			client_ctx->tm, mgmt_fe_client_resume_writes,
 			client_ctx, MGMTD_FE_MSG_WRITE_DELAY_MSEC,
 			&client_ctx->conn_writes_on);
-		assert(client_ctx->conn_writes_on);
 		break;
 	case MGMTD_FE_SERVER:
 		assert(!"mgmt_fe_client_ctx_post_event called incorrectly");

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -737,12 +737,10 @@ mgmt_be_adapter_register_event(struct mgmt_be_client_adapter *adapter,
 				      mgmt_be_adapter_conn_init, adapter,
 				      MGMTD_BE_CONN_INIT_DELAY_MSEC,
 				      &adapter->conn_init_ev);
-		assert(adapter->conn_init_ev);
 		break;
 	case MGMTD_BE_CONN_READ:
 		event_add_read(mgmt_be_adapter_tm, mgmt_be_adapter_read,
 				adapter, adapter->conn_fd, &adapter->conn_read_ev);
-		assert(adapter->conn_read_ev);
 		break;
 	case MGMTD_BE_CONN_WRITE:
 		if (adapter->conn_write_ev)
@@ -762,14 +760,12 @@ mgmt_be_adapter_register_event(struct mgmt_be_client_adapter *adapter,
 		event_add_timer_tv(mgmt_be_adapter_tm,
 				    mgmt_be_adapter_proc_msgbufs, adapter, &tv,
 				    &adapter->proc_msg_ev);
-		assert(adapter->proc_msg_ev);
 		break;
 	case MGMTD_BE_CONN_WRITES_ON:
 		event_add_timer_msec(mgmt_be_adapter_tm,
 				      mgmt_be_adapter_resume_writes, adapter,
 				      MGMTD_BE_MSG_WRITE_DELAY_MSEC,
 				      &adapter->conn_writes_on);
-		assert(adapter->conn_writes_on);
 		break;
 	case MGMTD_BE_SERVER:
 	case MGMTD_BE_SCHED_CFG_PREPARE:

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -659,13 +659,11 @@ mgmt_fe_session_register_event(struct mgmt_fe_session_ctx *session,
 		event_add_timer_tv(mgmt_fe_adapter_tm,
 				    mgmt_fe_session_cfg_txn_clnup, session,
 				    &tv, &session->proc_cfg_txn_clnp);
-		assert(session->proc_cfg_txn_clnp);
 		break;
 	case MGMTD_FE_SESSION_SHOW_TXN_CLNUP:
 		event_add_timer_tv(mgmt_fe_adapter_tm,
 				    mgmt_fe_session_show_txn_clnup, session,
 				    &tv, &session->proc_show_txn_clnp);
-		assert(session->proc_show_txn_clnp);
 		break;
 	}
 }
@@ -1497,27 +1495,23 @@ mgmt_fe_adapter_register_event(struct mgmt_fe_client_adapter *adapter,
 	case MGMTD_FE_CONN_READ:
 		event_add_read(mgmt_fe_adapter_tm, mgmt_fe_adapter_read,
 				adapter, adapter->conn_fd, &adapter->conn_read_ev);
-		assert(adapter->conn_read_ev);
 		break;
 	case MGMTD_FE_CONN_WRITE:
 		event_add_write(mgmt_fe_adapter_tm,
 				 mgmt_fe_adapter_write, adapter,
 				 adapter->conn_fd, &adapter->conn_write_ev);
-		assert(adapter->conn_write_ev);
 		break;
 	case MGMTD_FE_PROC_MSG:
 		tv.tv_usec = MGMTD_FE_MSG_PROC_DELAY_USEC;
 		event_add_timer_tv(mgmt_fe_adapter_tm,
 				    mgmt_fe_adapter_proc_msgbufs, adapter,
 				    &tv, &adapter->proc_msg_ev);
-		assert(adapter->proc_msg_ev);
 		break;
 	case MGMTD_FE_CONN_WRITES_ON:
 		event_add_timer_msec(mgmt_fe_adapter_tm,
 				      mgmt_fe_adapter_resume_writes, adapter,
 				      MGMTD_FE_MSG_WRITE_DELAY_MSEC,
 				      &adapter->conn_writes_on);
-		assert(adapter->conn_writes_on);
 		break;
 	case MGMTD_FE_SERVER:
 		assert(!"mgmt_fe_adapter_post_event() called incorrectly");

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -2228,35 +2228,29 @@ static void mgmt_txn_register_event(struct mgmt_txn_ctx *txn,
 	case MGMTD_TXN_PROC_SETCFG:
 		event_add_timer_tv(mgmt_txn_tm, mgmt_txn_process_set_cfg,
 				    txn, &tv, &txn->proc_set_cfg);
-		assert(txn->proc_set_cfg);
 		break;
 	case MGMTD_TXN_PROC_COMMITCFG:
 		event_add_timer_tv(mgmt_txn_tm, mgmt_txn_process_commit_cfg,
 				    txn, &tv, &txn->proc_comm_cfg);
-		assert(txn->proc_comm_cfg);
 		break;
 	case MGMTD_TXN_PROC_GETCFG:
 		event_add_timer_tv(mgmt_txn_tm, mgmt_txn_process_get_cfg,
 				    txn, &tv, &txn->proc_get_cfg);
-		assert(txn->proc_get_cfg);
 		break;
 	case MGMTD_TXN_PROC_GETDATA:
 		event_add_timer_tv(mgmt_txn_tm, mgmt_txn_process_get_data,
 				    txn, &tv, &txn->proc_get_data);
-		assert(txn->proc_get_data);
 		break;
 	case MGMTD_TXN_COMMITCFG_TIMEOUT:
 		event_add_timer_msec(mgmt_txn_tm,
 				      mgmt_txn_cfg_commit_timedout, txn,
 				      MGMTD_TXN_CFG_COMMIT_MAX_DELAY_MSEC,
 				      &txn->comm_cfg_timeout);
-		assert(txn->comm_cfg_timeout);
 		break;
 	case MGMTD_TXN_CLEANUP:
 		tv.tv_usec = MGMTD_TXN_CLEANUP_DELAY_USEC;
 		event_add_timer_tv(mgmt_txn_tm, mgmt_txn_cleanup, txn, &tv,
 				    &txn->clnup);
-		assert(txn->clnup);
 	}
 }
 


### PR DESCRIPTION
See individual commits.  Remove unnecessary asserts *and* this is exactly why I hate cut-n-paste code.  I have to do this in 4+ spots since someone cargo-culted an assert instead of proper abstraction