### PR TITLE
build: clean up mgmtd lib protobuf make syntax

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -165,13 +165,10 @@ am__v_PROTOC_C_ = $(am__v_PROTOC_C_$(AM_DEFAULT_VERBOSITY))
 am__v_PROTOC_C_0 = @echo "  PROTOC_C" $@;
 am__v_PROTOC_C_1 =
 
-.proto.pb-c.c:
+%.pb-c.c %.pb-c.h : %.proto
 	$(AM_V_PROTOC_C)$(PROTOC_C) -I$(top_srcdir) --c_out=$(top_builddir) $^
 	$(AM_V_GEN)$(SED) -i -e '1i\
 	#include "config.h"' $@
-
-.pb-c.c.pb-c.h:
-	@echo "  GEN     " $@
 
 include doc/subdir.am
 include doc/user/subdir.am


### PR DESCRIPTION
Fix the makefile rules for the new mgmtd lib module that's generated from a protobuf spec file.
The existing rule a) emits output every time you 'make', and b) doesn't have a dependency for the .h file that needs to be generated, so if that file isn't present the compile just fails.