### PR TITLE
ospfd: Fix for vitual-link crash in signal handler

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -977,7 +977,6 @@ static void ospf_vl_if_delete(struct ospf_vl_data *vl_data)
 	if_delete(&ifp);
 	if (!vrf_is_enabled(vrf))
 		vrf_delete(vrf);
-	vlink_count--;
 }
 
 /* for a defined area, count the number of configured vl


### PR DESCRIPTION
OSPF crash:
```
#0  0x00007f74dfd195cb in raise () from /lib/x86_64-linux-gnu/libpthread.so.0
#1  0x00007f74dffa7a9c in core_handler (signo=11, siginfo=0x7ffd70494b30, context=<optimized out>) at lib/sigevent.c:264
#2  <signal handler called>
#3  0x00005623aba3a2fb in ospf_vl_shutdown (vl_data=<optimized out>) at ospfd/ospf_interface.c:1054
#4  0x00005623aba3bf5b in ospf_vl_delete (ospf=ospf@entry=0x5623ac8fe6c0, vl_data=0x5623ac910e00) at ospfd/ospf_interface.c:1070
#5  0x00005623aba8cc1b in ospf_remove_vls_through_area (area=0x5623ac912250, ospf=0x5623ac8fe6c0) at ospfd/ospfd.c:1487
#6  ospf_finish_final (ospf=0x5623ac8fe6c0) at ospfd/ospfd.c:754
#7  ospf_deferred_shutdown_finish (ospf=0x5623ac8fe6c0) at ospfd/ospfd.c:597
#8  0x00005623aba8d5d0 in ospf_finish (ospf=<optimized out>) at ospfd/ospfd.c:701
#9  ospf_terminate () at ospfd/ospfd.c:671
#10 0x00005623aba33b58 in sigint () at ospfd/ospf_main.c:105
#11 0x00007f74dffa7c23 in frr_sigevent_process () at lib/sigevent.c:133
#12 0x00007f74dffb90a5 in thread_fetch (m=m@entry=0x5623ac6526f0, fetch=fetch@entry=0x7ffd70495110) at lib/thread.c:1777
#13 0x00007f74dff738e3 in frr_run (master=0x5623ac6526f0) at lib/libfrr.c:1223
#14 0x00005623aba33132 in main (argc=8, argv=0x7ffd70495418) at ospfd/ospf_main.c:235
(gdb) f 4
#4  0x00005623aba3bf5b in ospf_vl_delete (ospf=ospf@entry=0x5623ac8fe6c0, vl_data=0x5623ac910e00) at ospfd/ospf_interface.c:1070
1070	in ospfd/ospf_interface.c
(gdb) p *vl_data
$9 = {vl_peer = {s_addr = 16843028}, vl_area_id = {s_addr = 4294967295}, vl_area_id_fmt = 2, vl_oi = 0x5623ac9141c0, nexthop = {router = {s_addr = 0}, 
    lsa_pos = 0}, peer_addr = {s_addr = 0}, flags = 0 '\000'}
(gdb) f 5 
```

Whenever a OSPF virtual-link is created, a virtual interface is associated with it. Name of the virtual interface is derived by combining "VLINK" string with the value of vlink_count (in ospf_vl_new), which is a global variable.

Problem:
Consider a scenario where 2 virtual links A and B are created in OSPF with virtual interfaces VLINK0 and VLINK1 respectively. When virtual-link A is unconfigured and reconfigured, the new interface name derived for it will be VLINK1, which is already associated with virtual-link B. Due to this, both virtual-links A and B will point to the same virtual interface, VLINK1.

During FRR restart when signal handler is called, OSPF goes through all the virtual links(within each area) and deletes the interface(oi) associated with it. During the deletion of interface for virtual-link B, it accesses the interface which was deleted already(deleted during deletion of virual-link A) and whose fields were set to NULL. This leads to OSPF crash.

Fix:
Fixed it by not decrementing vlink_count during unconfig/deletion for virtual-link.


Steps to reproduce the crash:

```
r1# show running-config 
Building configuration...

Current configuration:
!
frr version 8.4.3
frr defaults datacenter
hostname r1
log file /var/log/frr/bgpd.log
log timestamp precision 6
service integrated-vtysh-config
!
debug ospf ism
debug ospf zebra
debug ospf event
!
password cn321
enable password cn321
!
interface swp1
 description swp1 -> r2's swp1
exit
!
interface swp2
 description swp2 -> r3's swp1
exit
!
interface swp3
 description swp3 -> r4's swp1
exit
!
router ospf vrf vrf1005
exit
!
line vty
 exec-timeout 0 0
exit
!
end
r1# configure 

r1(config)# router ospf vrf vrf1005
r1(config-router)# area 4294967295 virtual-link 20.1.1.1 hello-interval 10 retransmit-interval 65535 transmit-delay 65535 dead-interval 65535 
r1(config-router)# area 1.1.1.1 virtual-link 20.1.1.1 hello-interval 10 retransmit-interval 65535 transmit-delay 65535 dead-interval 65535 
r1(config-router)# no area 4294967295 virtual-link 20.1.1.1 
r1(config-router)# area 4294967295 virtual-link 20.1.1.1 hello-interval 10 retransmit-interval 65535 transmit-delay 65535 dead-interval 65535 
r1(config-router)# exit
r1(config)# end
r1# 
sudo systemctl restart frr
```

Note: Crash is NOT specific to OSPF in VRF



Before Fix:
```
r1# configure 
r1(config)# router ospf vrf vrf1005
r1(config-router)# area 4294967295 virtual-link 20.1.1.1 hello-interval 10 retransmit-interval 65535 transmit-delay 65535 dead-interval 65535 
r1(config-router)# area 1.1.1.1 virtual-link 20.1.1.1 hello-interval 10 retransmit-interval 65535 transmit-delay 65535 dead-interval 65535 
r1(config-router)# no area 4294967295 virtual-link 20.1.1.1 
r1(config-router)# area 4294967295 virtual-link 20.1.1.1 hello-interval 10 retransmit-interval 65535 transmit-delay 65535 dead-interval 65535 
r1(config-router)# end
r1# exit
cumulus@r1:mgmt:~$ sudo systemctl restart frr
                                                                               
Broadcast message from root@r1 (somewhere) (Mon Mar 27 19:23:28 2023):         
                                                                               
cumulus-core: Running cl-support for core files "ospfd.3605.1679945008.core"
                                                                               
cumulus@r1:mgmt:~$ 

root@r1:mgmt:/home/cumulus# gdb /usr/lib/frr/ospfd ospfd.3605.1679945008.core
GNU gdb (Debian 8.2.1-2+b3) 8.2.1
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /usr/lib/frr/ospfd...Reading symbols from /usr/lib/debug/.build-id/5b/9c160b2175ea63cede14c2e18f617702e4557b.debug...done.
done.
[New LWP 3605]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `/usr/lib/frr/ospfd -d -F datacenter -M snmp -A 127.0.0.1'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f95d274b5cb in raise () from /lib/x86_64-linux-gnu/libpthread.so.0
(gdb) bt
#0  0x00007f95d274b5cb in raise () from /lib/x86_64-linux-gnu/libpthread.so.0
#1  0x00007f95d29d9a4c in core_handler (signo=11, siginfo=0x7ffd3fc50570, context=<optimized out>) at lib/sigevent.c:264
#2  <signal handler called>
#3  0x00005643c159e138 in ospf_vl_shutdown (vl_data=vl_data@entry=0x5643c377d410) at ospfd/ospf_interface.c:1066
#4  0x00005643c15a003a in ospf_vl_delete (ospf=ospf@entry=0x5643c3767f20, vl_data=0x5643c377d410) at ospfd/ospf_interface.c:1082
#5  0x00005643c15f0dd4 in ospf_remove_vls_through_area (area=0x5643c375da00, ospf=0x5643c3767f20) at ospfd/ospfd.c:1495
#6  ospf_finish_final (ospf=0x5643c3767f20) at ospfd/ospfd.c:754
#7  ospf_deferred_shutdown_finish (ospf=0x5643c3767f20) at ospfd/ospfd.c:597
#8  0x00005643c15f1800 in ospf_finish (ospf=<optimized out>) at ospfd/ospfd.c:701
#9  ospf_terminate () at ospfd/ospfd.c:671
#10 0x00005643c1597b58 in sigint () at ospfd/ospf_main.c:105
#11 0x00007f95d29d9bd3 in frr_sigevent_process () at lib/sigevent.c:133
#12 0x00007f95d29eb055 in thread_fetch (m=m@entry=0x5643c34b46f0, fetch=fetch@entry=0x7ffd3fc50b50) at lib/thread.c:1777
#13 0x00007f95d29a5893 in frr_run (master=0x5643c34b46f0) at lib/libfrr.c:1223
#14 0x00005643c1597132 in main (argc=8, argv=0x7ffd3fc50e58) at ospfd/ospf_main.c:235
(gdb) f 3
#3  0x00005643c159e138 in ospf_vl_shutdown (vl_data=vl_data@entry=0x5643c377d410) at ospfd/ospf_interface.c:1066
1066	ospfd/ospf_interface.c: No such file or directory.
(gdb) f 4
#4  0x00005643c15a003a in ospf_vl_delete (ospf=ospf@entry=0x5643c3767f20, vl_data=0x5643c377d410) at ospfd/ospf_interface.c:1082
1082	in ospfd/ospf_interface.c
(gdb) p vl_data
$1 = (struct ospf_vl_data *) 0x5643c377d410
(gdb) p *vl_data
$2 = {vl_peer = {s_addr = 16843028}, vl_area_id = {s_addr = 4294967295}, vl_area_id_fmt = 2, vl_oi = 0x5643c377e240, nexthop = {router = {s_addr = 0}, 
    lsa_pos = 0}, peer_addr = {s_addr = 0}, flags = 0 '\000'}
(gdb) 
```


With Fix:
```
root@r1:mgmt:/home/cumulus# sudo vtysh

Hello, this is FRRouting (version 8.4.3).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# configure 
r1(config)# router ospf vrf vrf1005
r1(config-router)# area 4294967295 virtual-link 20.1.1.1 hello-interval 10 retransmit-interval 65535 transmit-delay 65535 dead-interval 65535
r1(config-router)# area 1.1.1.1 virtual-link 20.1.1.1 hello-interval 10 retransmit-interval 65535 transmit-delay 65535 dead-interval 65535
r1(config-router)# no area 4294967295 virtual-link 20.1.1.1 
r1(config-router)# area 4294967295 virtual-link 20.1.1.1 hello-interval 10 retransmit-interval 65535 transmit-delay 65535 dead-interval 65535

logs:
2023/03/27 20:36:16.464622 OSPF: [X416G-S48EA] ospf_vl_lookup: Looking for 20.1.1.1
2023/03/27 20:36:16.464636 OSPF: [TDDNH-RDPX1] ospf_vl_lookup: in area 255.255.255.255
2023/03/27 20:36:16.464640 OSPF: [P9S8A-W1FZX] ospf_vl_lookup: VL VLINK1, peer 20.1.1.1
2023/03/27 20:36:16.464648 OSPF: [KN82R-MA9BA] ospf_vl_new: (vrf1005): Start
2023/03/27 20:36:16.464650 OSPF: [TYNSV-53KQ5] ospf_vl_new: creating pseudo zebra interface vrf id 7
2023/03/27 20:36:16.464749 OSPF: [Y6C8B-E12XX] ospf_if_new: ospf interface VLINK2 vrf vrf1005 id 7 created --> Virtual interface VLINK2 has been created and associated with peer 20.1.1.1 in area 4294967295.
2023/03/27 20:36:16.464751 OSPF: [MJ7C4-154MH] ospf_vl_new: Created name: VLINK2 set if->name to VLINK2
2023/03/27 20:36:16.464752 OSPF: [KJHCP-380VB] ospf_vl_new: set associated area to the backbone
2023/03/27 20:36:16.464762 OSPF: [X2FW0-2TK0E] ospf_vl_new: Stop

r1(config-router)# end
r1# exit
root@r1:mgmt:/home/cumulus# sudo systemctl restart frr
root@r1:mgmt:/home/cumulus# 
```

