### PR TITLE
isisd: Add PDU drop counter to "show isis summary"

### DIFF
--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -2503,6 +2503,9 @@ static void common_isis_summary_vty(struct vty *vty, struct isis *isis)
 		vty_out(vty, "  RX counters per PDU type:\n");
 		pdu_counter_print(vty, "    ", area->pdu_rx_counters);
 
+		vty_out(vty, "  Drop counters per PDU type:\n");
+		pdu_counter_print(vty, "    ", area->pdu_drop_counters);
+
 		vty_out(vty, "  Advertise high metrics: %s\n",
 			area->advertise_high_metrics ? "Enabled" : "Disabled");
 

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -232,6 +232,7 @@ struct isis_area {
 
 	pdu_counter_t pdu_tx_counters;
 	pdu_counter_t pdu_rx_counters;
+	pdu_counter_t pdu_drop_counters;
 	uint64_t lsp_rxmt_count;
 
 	/* Area counters */


### PR DESCRIPTION
Adding a new drop counters section to "show isis summary".

In isis_handle_pdu(), I increment the drop counter for each PDU that isn't successfully processed. 

New output:
```
Drop counters per PDU type:
  P2P IIH: X
  L2 LSP: X
  L2 CSNP: X
  L2 PSNP: X
  ...
```

Before:
```
r1# show isis summary
vrf             : default
Process Id      : 972
System Id       : 0000.0000.0001
Up time         : 00:00:48 ago
Number of areas : 1
Area TE:
  Net: 49.0000.0000.0000.0001.00
  TX counters per PDU type:
    P2P IIH: 36
     L2 LSP: 8
    L2 CSNP: 12
    L2 PSNP: 11
  RX counters per PDU type:
    P2P IIH: 37
     L2 LSP: 17
    L2 CSNP: 12
    L2 PSNP: 6
Advertise high metrics: Disabled
...
```
After:
```
r1# show isis summary
vrf             : default
Process Id      : 972
System Id       : 0000.0000.0001
Up time         : 00:00:19 ago
Number of areas : 1
Area TE:
  Net: 49.0000.0000.0000.0001.00
  TX counters per PDU type:
    P2P IIH: 16
     L2 LSP: 2
    L2 CSNP: 4
    L2 PSNP: 6
   LSP RXMT: 0
  RX counters per PDU type:
    P2P IIH: 16
     L2 LSP: 5
    L2 CSNP: 4
    L2 PSNP: 2
  Drop counters per PDU type:
    P2P IIH: 2
  Advertise high metrics: Disabled
...
```