### PR TITLE
bgpd: trim long neighbor description with no whitespace

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -11036,10 +11036,10 @@ static char *bgp_peer_description_stripped(char *desc, uint32_t size)
 {
 	static char stripped[BUFSIZ];
 	uint32_t i = 0;
-	uint32_t last_space = 0;
+	uint32_t last_space = size;
 
 	while (i < size) {
-		if (*(desc + i) == 0) {
+		if (*(desc + i) == '\0') {
 			stripped[i] = '\0';
 			return stripped;
 		}
@@ -11049,10 +11049,7 @@ static char *bgp_peer_description_stripped(char *desc, uint32_t size)
 		i++;
 	}
 
-	if (last_space > size)
-		stripped[size + 1] = '\0';
-	else
-		stripped[last_space] = '\0';
+	stripped[last_space] = '\0';
 
 	return stripped;
 }


### PR DESCRIPTION
We use neighbor descriptions with len > 20 and usually no whitespaces.
But since 64541ffa8f33404e32336d1905b73f89a7d26610, `sh ip bgp summary` shows nothing because `last_space` == 0.
It'd be helpful trimming configured neighbor description instead of showing blank if its len > 20 and contains no whitespaces. Same stands if description len goes above 64 using wide mode.

Thanks for the help