### PR TITLE
ospfd: remove deprecated json attrs for neighbor show

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -4414,15 +4414,10 @@ static void show_ip_ospf_neighbour_brief(struct vty *vty,
 		json_neighbor = json_object_new_object();
 
 		ospf_nbr_ism_state_message(nbr, msgbuf, sizeof(msgbuf));
-#if CONFDATE > 20230321
-		CPP_NOTICE(
-			"Remove show_ip_ospf_neighbor_sub() JSON keys: priority, state, deadTimeMsecs, address, retransmitCounter, requestCounter, dbSummaryCounter")
-#endif
-		json_object_int_add(json_neighbor, "priority", nbr->priority);
-		json_object_string_add(json_neighbor, "state", msgbuf);
+		json_object_string_add(json_neighbor, "nbrState", msgbuf);
+
 		json_object_int_add(json_neighbor, "nbrPriority",
 				    nbr->priority);
-		json_object_string_add(json_neighbor, "nbrState", msgbuf);
 
 		json_object_string_add(
 			json_neighbor, "converged",
@@ -4439,8 +4434,6 @@ static void show_ip_ospf_neighbour_brief(struct vty *vty,
 				     1000LL;
 			json_object_int_add(json_neighbor, "upTimeInMsec",
 					    time_val);
-			json_object_int_add(json_neighbor, "deadTimeMsecs",
-					    time_store);
 			json_object_int_add(json_neighbor,
 					    "routerDeadIntervalTimerDueMsec",
 					    time_store);
@@ -4459,24 +4452,16 @@ static void show_ip_ospf_neighbour_brief(struct vty *vty,
 					       "routerDeadIntervalTimerDueMsec",
 					       "inactive");
 		}
-		json_object_string_addf(json_neighbor, "address", "%pI4",
-					&nbr->src);
 		json_object_string_addf(json_neighbor, "ifaceAddress", "%pI4",
 					&nbr->src);
 		json_object_string_add(json_neighbor, "ifaceName",
 				       IF_NAME(nbr->oi));
-		json_object_int_add(json_neighbor, "retransmitCounter",
-				    ospf_ls_retransmit_count(nbr));
 		json_object_int_add(json_neighbor,
 				    "linkStateRetransmissionListCounter",
 				    ospf_ls_retransmit_count(nbr));
-		json_object_int_add(json_neighbor, "requestCounter",
-				    ospf_ls_request_count(nbr));
 		json_object_int_add(json_neighbor,
 				    "linkStateRequestListCounter",
 				    ospf_ls_request_count(nbr));
-		json_object_int_add(json_neighbor, "dbSummaryCounter",
-				    ospf_db_summary_count(nbr));
 		json_object_int_add(json_neighbor, "databaseSummaryListCounter",
 				    ospf_db_summary_count(nbr));
 

--- a/tests/topotests/bgp_features/r1/ospf_neighbor.json
+++ b/tests/topotests/bgp_features/r1/ospf_neighbor.json
@@ -2,13 +2,13 @@
   "neighbors":{
     "192.168.0.2":[
       {
-        "priority":5,
+        "nbrPriority":5,
         "converged":"Full"
       }
     ],
     "192.168.0.3":[
       {
-        "priority":5,
+        "nbrPriority":5,
         "converged":"Full"
       }
     ]

--- a/tests/topotests/bgp_features/r2/ospf_neighbor.json
+++ b/tests/topotests/bgp_features/r2/ospf_neighbor.json
@@ -2,13 +2,13 @@
   "neighbors":{
     "192.168.0.1":[
       {
-        "priority":10,
+        "nbrPriority":10,
         "converged":"Full"
       }
     ],
     "192.168.0.3":[
       {
-        "priority":5,
+        "nbrPriority":5,
         "converged":"Full"
       }
     ]

--- a/tests/topotests/bgp_features/r3/ospf_neighbor.json
+++ b/tests/topotests/bgp_features/r3/ospf_neighbor.json
@@ -2,13 +2,13 @@
   "neighbors":{
     "192.168.0.1":[
       {
-        "priority":10,
+        "nbrPriority":10,
         "converged":"Full"
       }
     ],
     "192.168.0.2":[
       {
-        "priority":10,
+        "nbrPriority":10,
         "converged":"Full"
       }
     ]

--- a/tests/topotests/ldp_oc_acl_topo1/r1/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_oc_acl_topo1/r1/show_ip_ospf_neighbor.json
@@ -2,9 +2,9 @@
   "neighbors":{
     "2.2.2.2":[
       {
-        "priority":2,
+        "nbrPriority":2,
         "converged":"Full",
-        "address":"10.0.1.2",
+        "ifaceAddress":"10.0.1.2",
         "ifaceName":"r1-eth0:10.0.1.1"
       }
     ]

--- a/tests/topotests/ldp_oc_acl_topo1/r2/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_oc_acl_topo1/r2/show_ip_ospf_neighbor.json
@@ -2,25 +2,25 @@
   "neighbors":{
     "1.1.1.1":[
       {
-        "priority":1,
+        "nbrPriority":1,
         "converged":"Full",
-        "address":"10.0.1.1",
+        "ifaceAddress":"10.0.1.1",
         "ifaceName":"r2-eth0:10.0.1.2"
       }
     ],
     "3.3.3.3":[
       {
-        "priority":2,
+        "nbrPriority":2,
         "converged":"Full",
-        "address":"10.0.2.3",
+        "ifaceAddress":"10.0.2.3",
         "ifaceName":"r2-eth1:10.0.2.2"
       }
     ],
     "4.4.4.4":[
       {
-        "priority":3,
+        "nbrPriority":3,
         "converged":"Full",
-        "address":"10.0.2.4",
+        "ifaceAddress":"10.0.2.4",
         "ifaceName":"r2-eth1:10.0.2.2"
       }
     ]

--- a/tests/topotests/ldp_oc_acl_topo1/r3/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_oc_acl_topo1/r3/show_ip_ospf_neighbor.json
@@ -2,17 +2,17 @@
   "neighbors":{
     "2.2.2.2":[
       {
-        "priority":1,
+        "nbrPriority":1,
         "converged":"Full",
-        "address":"10.0.2.2",
+        "ifaceAddress":"10.0.2.2",
         "ifaceName":"r3-eth0:10.0.2.3"
       }
     ],
     "4.4.4.4":[
       {
-        "priority":3,
+        "nbrPriority":3,
         "converged":"Full",
-        "address":"10.0.2.4",
+        "ifaceAddress":"10.0.2.4",
         "ifaceName":"r3-eth0:10.0.2.3"
       }
     ]

--- a/tests/topotests/ldp_oc_acl_topo1/r4/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_oc_acl_topo1/r4/show_ip_ospf_neighbor.json
@@ -3,17 +3,17 @@
   "neighbors":{
     "2.2.2.2":[
       {
-        "priority":1,
+        "nbrPriority":1,
         "converged":"Full",
-        "address":"10.0.2.2",
+        "ifaceAddress":"10.0.2.2",
         "ifaceName":"r4-eth0:10.0.2.4"
       }
     ],
     "3.3.3.3":[
       {
-        "priority":2,
+        "nbrPriority":2,
         "converged":"Full",
-        "address":"10.0.2.3",
+        "ifaceAddress":"10.0.2.3",
         "ifaceName":"r4-eth0:10.0.2.4"
       }
     ]

--- a/tests/topotests/ldp_oc_topo1/r1/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_oc_topo1/r1/show_ip_ospf_neighbor.json
@@ -2,9 +2,9 @@
   "neighbors":{
     "2.2.2.2":[
       {
-        "priority":2,
+        "nbrPriority":2,
         "converged":"Full",
-        "address":"10.0.1.2",
+        "ifaceAddress":"10.0.1.2",
         "ifaceName":"r1-eth0:10.0.1.1"
       }
     ]

--- a/tests/topotests/ldp_oc_topo1/r2/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_oc_topo1/r2/show_ip_ospf_neighbor.json
@@ -2,25 +2,25 @@
   "neighbors":{
     "1.1.1.1":[
       {
-        "priority":1,
+        "nbrPriority":1,
         "converged":"Full",
-        "address":"10.0.1.1",
+        "ifaceAddress":"10.0.1.1",
         "ifaceName":"r2-eth0:10.0.1.2"
       }
     ],
     "3.3.3.3":[
       {
-        "priority":2,
+        "nbrPriority":2,
         "converged":"Full",
-        "address":"10.0.2.3",
+        "ifaceAddress":"10.0.2.3",
         "ifaceName":"r2-eth1:10.0.2.2"
       }
     ],
     "4.4.4.4":[
       {
-        "priority":3,
+        "nbrPriority":3,
         "converged":"Full",
-        "address":"10.0.2.4",
+        "ifaceAddress":"10.0.2.4",
         "ifaceName":"r2-eth1:10.0.2.2"
       }
     ]

--- a/tests/topotests/ldp_oc_topo1/r3/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_oc_topo1/r3/show_ip_ospf_neighbor.json
@@ -2,17 +2,17 @@
   "neighbors":{
     "2.2.2.2":[
       {
-        "priority":1,
+        "nbrPriority":1,
         "converged":"Full",
-        "address":"10.0.2.2",
+        "ifaceAddress":"10.0.2.2",
         "ifaceName":"r3-eth0:10.0.2.3"
       }
     ],
     "4.4.4.4":[
       {
-        "priority":3,
+        "nbrPriority":3,
         "converged":"Full",
-        "address":"10.0.2.4",
+        "ifaceAddress":"10.0.2.4",
         "ifaceName":"r3-eth0:10.0.2.3"
       }
     ]

--- a/tests/topotests/ldp_oc_topo1/r4/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_oc_topo1/r4/show_ip_ospf_neighbor.json
@@ -3,17 +3,17 @@
   "neighbors":{
     "2.2.2.2":[
       {
-        "priority":1,
+        "nbrPriority":1,
         "converged":"Full",
-        "address":"10.0.2.2",
+        "ifaceAddress":"10.0.2.2",
         "ifaceName":"r4-eth0:10.0.2.4"
       }
     ],
     "3.3.3.3":[
       {
-        "priority":2,
+        "nbrPriority":2,
         "converged":"Full",
-        "address":"10.0.2.3",
+        "ifaceAddress":"10.0.2.3",
         "ifaceName":"r4-eth0:10.0.2.4"
       }
     ]

--- a/tests/topotests/ldp_sync_ospf_topo1/r1/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_sync_ospf_topo1/r1/show_ip_ospf_neighbor.json
@@ -2,24 +2,24 @@
   "neighbors": {
     "2.2.2.2": [
       {
-        "dbSummaryCounter": 0,
-        "retransmitCounter": 0,
-        "priority": 1,
+        "databaseSummaryListCounter": 0,
+        "linkStateRetransmissionListCounter": 0,
+        "nbrPriority": 1,
         "converged": "Full",
-        "address": "10.0.1.2",
+        "ifaceAddress": "10.0.1.2",
         "ifaceName": "r1-eth1:10.0.1.1",
-        "requestCounter": 0
+        "linkStateRequestListCounter": 0
       }
     ],
     "3.3.3.3": [
       {
-        "dbSummaryCounter": 0,
-        "retransmitCounter": 0,
-        "priority": 1,
+        "databaseSummaryListCounter": 0,
+        "linkStateRetransmissionListCounter": 0,
+        "nbrPriority": 1,
         "converged": "Full",
-        "address": "10.0.2.3",
+        "ifaceAddress": "10.0.2.3",
         "ifaceName": "r1-eth2:10.0.2.1",
-        "requestCounter": 0
+        "linkStateRequestListCounter": 0
       }
     ]
   }

--- a/tests/topotests/ldp_sync_ospf_topo1/r2/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_sync_ospf_topo1/r2/show_ip_ospf_neighbor.json
@@ -2,24 +2,24 @@
   "neighbors": {
     "1.1.1.1": [
       {
-        "priority":1,
+        "nbrPriority":1,
         "converged":"Full",
-        "address":"10.0.1.1",
+        "ifaceAddress":"10.0.1.1",
         "ifaceName":"r2-eth1:10.0.1.2",
-        "retransmitCounter":0,
-        "requestCounter":0,
-        "dbSummaryCounter":0
+        "linkStateRetransmissionListCounter":0,
+        "linkStateRequestListCounter":0,
+        "databaseSummaryListCounter":0
       }
     ],
     "3.3.3.3": [
       {
-        "priority":1,
+        "nbrPriority":1,
         "converged":"Full",
-        "address":"10.0.3.3",
+        "ifaceAddress":"10.0.3.3",
         "ifaceName":"r2-eth2:10.0.3.2",
-        "retransmitCounter":0,
-        "requestCounter":0,
-        "dbSummaryCounter":0
+        "linkStateRetransmissionListCounter":0,
+        "linkStateRequestListCounter":0,
+        "databaseSummaryListCounter":0
       }
     ]
   }

--- a/tests/topotests/ldp_sync_ospf_topo1/r3/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_sync_ospf_topo1/r3/show_ip_ospf_neighbor.json
@@ -2,24 +2,24 @@
   "neighbors": {
     "1.1.1.1": [
       {
-        "priority":1,
+        "nbrPriority":1,
         "converged":"Full",
-        "address":"10.0.2.1",
+        "ifaceAddress":"10.0.2.1",
         "ifaceName":"r3-eth1:10.0.2.3",
-        "retransmitCounter":0,
-        "requestCounter":0,
-        "dbSummaryCounter":0
+        "linkStateRetransmissionListCounter":0,
+        "linkStateRequestListCounter":0,
+        "databaseSummaryListCounter":0
       }
     ],
     "2.2.2.2": [
       {
-        "priority":1,
+        "nbrPriority":1,
         "converged":"Full",
-        "address":"10.0.3.2",
+        "ifaceAddress":"10.0.3.2",
         "ifaceName":"r3-eth2:10.0.3.3",
-        "retransmitCounter":0,
-        "requestCounter":0,
-        "dbSummaryCounter":0
+        "linkStateRetransmissionListCounter":0,
+        "linkStateRequestListCounter":0,
+        "databaseSummaryListCounter":0
       }
     ]
   }

--- a/tests/topotests/ldp_topo1/r1/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_topo1/r1/show_ip_ospf_neighbor.json
@@ -2,12 +2,12 @@
   "neighbors": {
     "2.2.2.2": [
       {
-        "dbSummaryCounter": 0,
-        "retransmitCounter": 0,
-        "priority": 1,
+        "databaseSummaryListCounter": 0,
+        "linkStateRetransmissionListCounter": 0,
+        "nbrPriority": 1,
         "converged": "Full",
-        "address": "10.0.1.2",
-        "requestCounter": 0
+        "ifaceAddress": "10.0.1.2",
+        "linkStateRequestListCounter": 0
       }
     ]
   }

--- a/tests/topotests/ldp_topo1/r2/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_topo1/r2/show_ip_ospf_neighbor.json
@@ -2,40 +2,40 @@
   "neighbors": {
     "1.1.1.1": [
       {
-        "dbSummaryCounter": 0,
-        "retransmitCounter": 0,
-        "priority": 1,
+        "databaseSummaryListCounter": 0,
+        "linkStateRetransmissionListCounter": 0,
+        "nbrPriority": 1,
         "converged": "Full",
-        "address": "10.0.1.1",
-        "requestCounter": 0
+        "ifaceAddress": "10.0.1.1",
+        "linkStateRequestListCounter": 0
       }
     ],
     "3.3.3.3": [
       {
-        "dbSummaryCounter": 0,
-        "retransmitCounter": 0,
-        "priority": 1,
+        "databaseSummaryListCounter": 0,
+        "linkStateRetransmissionListCounter": 0,
+        "nbrPriority": 1,
         "converged": "Full",
-        "address": "10.0.2.3",
-        "requestCounter": 0
+        "ifaceAddress": "10.0.2.3",
+        "linkStateRequestListCounter": 0
       },
       {
-        "dbSummaryCounter": 0,
-        "retransmitCounter": 0,
-        "priority": 1,
+        "databaseSummaryListCounter": 0,
+        "linkStateRetransmissionListCounter": 0,
+        "nbrPriority": 1,
         "converged": "Full",
-        "address": "10.0.3.3",
-        "requestCounter": 0
+        "ifaceAddress": "10.0.3.3",
+        "linkStateRequestListCounter": 0
       }
     ],
     "4.4.4.4": [
       {
-        "dbSummaryCounter": 0,
-        "retransmitCounter": 0,
-        "priority": 1,
+        "databaseSummaryListCounter": 0,
+        "linkStateRetransmissionListCounter": 0,
+        "nbrPriority": 1,
         "converged": "Full",
-        "address": "10.0.2.4",
-        "requestCounter": 0
+        "ifaceAddress": "10.0.2.4",
+        "linkStateRequestListCounter": 0
       }
     ]
   }

--- a/tests/topotests/ldp_topo1/r3/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_topo1/r3/show_ip_ospf_neighbor.json
@@ -2,30 +2,30 @@
   "neighbors": {
     "2.2.2.2": [
       {
-        "dbSummaryCounter": 0,
-        "retransmitCounter": 0,
-        "priority": 1,
+        "databaseSummaryListCounter": 0,
+        "linkStateRetransmissionListCounter": 0,
+        "nbrPriority": 1,
         "converged": "Full",
-        "address": "10.0.2.2",
-        "requestCounter": 0
+        "ifaceAddress": "10.0.2.2",
+        "linkStateRequestListCounter": 0
       },
       {
-        "dbSummaryCounter": 0,
-        "retransmitCounter": 0,
-        "priority": 1,
+        "databaseSummaryListCounter": 0,
+        "linkStateRetransmissionListCounter": 0,
+        "nbrPriority": 1,
         "converged": "Full",
-        "address": "10.0.3.2",
-        "requestCounter": 0
+        "ifaceAddress": "10.0.3.2",
+        "linkStateRequestListCounter": 0
       }
     ],
     "4.4.4.4": [
       {
-        "dbSummaryCounter": 0,
-        "retransmitCounter": 0,
-        "priority": 1,
+        "databaseSummaryListCounter": 0,
+        "linkStateRetransmissionListCounter": 0,
+        "nbrPriority": 1,
         "converged": "Full",
-        "address": "10.0.2.4",
-        "requestCounter": 0
+        "ifaceAddress": "10.0.2.4",
+        "linkStateRequestListCounter": 0
       }
     ]
   }

--- a/tests/topotests/ldp_topo1/r4/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_topo1/r4/show_ip_ospf_neighbor.json
@@ -2,22 +2,22 @@
   "neighbors": {
     "2.2.2.2": [
       {
-        "dbSummaryCounter": 0,
-        "retransmitCounter": 0,
-        "priority": 1,
+        "databaseSummaryListCounter": 0,
+        "linkStateRetransmissionListCounter": 0,
+        "nbrPriority": 1,
         "converged": "Full",
-        "address": "10.0.2.2",
-        "requestCounter": 0
+        "ifaceAddress": "10.0.2.2",
+        "linkStateRequestListCounter": 0
       }
     ],
     "3.3.3.3": [
       {
-        "dbSummaryCounter": 0,
-        "retransmitCounter": 0,
-        "priority": 1,
+        "databaseSummaryListCounter": 0,
+        "linkStateRetransmissionListCounter": 0,
+        "nbrPriority": 1,
         "converged": "Full",
-        "address": "10.0.2.3",
-        "requestCounter": 0
+        "ifaceAddress": "10.0.2.3",
+        "linkStateRequestListCounter": 0
       }
     ]
   }

--- a/tests/topotests/ldp_vpls_topo1/r1/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_vpls_topo1/r1/show_ip_ospf_neighbor.json
@@ -2,24 +2,24 @@
   "neighbors": {
     "2.2.2.2": [
       {
-        "dbSummaryCounter": 0,
-        "retransmitCounter": 0,
-        "priority": 2,
+        "databaseSummaryListCounter": 0,
+        "linkStateRetransmissionListCounter": 0,
+        "nbrPriority": 2,
         "converged": "Full",
-        "address": "10.0.1.2",
+        "ifaceAddress": "10.0.1.2",
         "ifaceName": "r1-eth1:10.0.1.1",
-        "requestCounter": 0
+        "linkStateRequestListCounter": 0
       }
     ],
     "3.3.3.3": [
       {
-        "dbSummaryCounter": 0,
-        "retransmitCounter": 0,
-        "priority": 2,
+        "databaseSummaryListCounter": 0,
+        "linkStateRetransmissionListCounter": 0,
+        "nbrPriority": 2,
         "converged": "Full",
-        "address": "10.0.2.3",
+        "ifaceAddress": "10.0.2.3",
         "ifaceName": "r1-eth2:10.0.2.1",
-        "requestCounter": 0
+        "linkStateRequestListCounter": 0
       }
     ]
   }

--- a/tests/topotests/ldp_vpls_topo1/r2/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_vpls_topo1/r2/show_ip_ospf_neighbor.json
@@ -2,24 +2,24 @@
   "neighbors": {
     "1.1.1.1": [
       {
-        "priority":1,
+        "nbrPriority":1,
         "converged":"Full",
-        "address":"10.0.1.1",
+        "ifaceAddress":"10.0.1.1",
         "ifaceName":"r2-eth1:10.0.1.2",
-        "retransmitCounter":0,
-        "requestCounter":0,
-        "dbSummaryCounter":0
+        "linkStateRetransmissionListCounter":0,
+        "linkStateRequestListCounter":0,
+        "databaseSummaryListCounter":0
       }
     ],
     "3.3.3.3": [
       {
-        "priority":2,
+        "nbrPriority":2,
         "converged":"Full",
-        "address":"10.0.3.3",
+        "ifaceAddress":"10.0.3.3",
         "ifaceName":"r2-eth2:10.0.3.2",
-        "retransmitCounter":0,
-        "requestCounter":0,
-        "dbSummaryCounter":0
+        "linkStateRetransmissionListCounter":0,
+        "linkStateRequestListCounter":0,
+        "databaseSummaryListCounter":0
       }
     ]
   }

--- a/tests/topotests/ldp_vpls_topo1/r3/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ldp_vpls_topo1/r3/show_ip_ospf_neighbor.json
@@ -2,24 +2,24 @@
   "neighbors": {
     "1.1.1.1": [
       {
-        "priority":1,
+        "nbrPriority":1,
         "converged":"Full",
-        "address":"10.0.2.1",
+        "ifaceAddress":"10.0.2.1",
         "ifaceName":"r3-eth1:10.0.2.3",
-        "retransmitCounter":0,
-        "requestCounter":0,
-        "dbSummaryCounter":0
+        "linkStateRetransmissionListCounter":0,
+        "linkStateRequestListCounter":0,
+        "databaseSummaryListCounter":0
       }
     ],
     "2.2.2.2": [
       {
-        "priority":1,
+        "nbrPriority":1,
         "converged":"Full",
-        "address":"10.0.3.2",
+        "ifaceAddress":"10.0.3.2",
         "ifaceName":"r3-eth2:10.0.3.3",
-        "retransmitCounter":0,
-        "requestCounter":0,
-        "dbSummaryCounter":0
+        "linkStateRetransmissionListCounter":0,
+        "linkStateRequestListCounter":0,
+        "databaseSummaryListCounter":0
       }
     ]
   }

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -577,15 +577,15 @@ def verify_ospf_neighbor(
             "ospf": {
                 "neighbors": {
                     "r1": {
-                        "state": "Full",
+                        "nbrState": "Full",
                         "role": "DR"
                     },
                     "r2": {
-                        "state": "Full",
+                        "nbrState": "Full",
                         "role": "DROther"
                     },
                     "r3": {
-                        "state": "Full",
+                        "nbrState": "Full",
                         "role": "DROther"
                     }
                 }
@@ -642,13 +642,13 @@ def verify_ospf_neighbor(
                 neighbor_ip = neighbor_ip.lower()
                 nbr_rid = data_rid
                 try:
-                    nh_state = show_ospf_json[nbr_rid][0]["state"].split("/")[0]
-                    intf_state = show_ospf_json[nbr_rid][0]["state"].split("/")[1]
+                    nh_state = show_ospf_json[nbr_rid][0]["nbrState"].split("/")[0]
+                    intf_state = show_ospf_json[nbr_rid][0]["nbrState"].split("/")[1]
                 except KeyError:
                     errormsg = "[DUT: {}] OSPF peer {} missing".format(router, nbr_rid)
                     return errormsg
 
-                nbr_state = nbr_data.setdefault("state", None)
+                nbr_state = nbr_data.setdefault("nbrState", None)
                 nbr_role = nbr_data.setdefault("role", None)
 
                 if nbr_state:
@@ -724,8 +724,9 @@ def verify_ospf_neighbor(
                 nh_state = None
                 neighbor_ip = neighbor_ip.lower()
                 nbr_rid = data_rid
+
                 try:
-                    nh_state = show_ospf_json[nbr_rid][0]["state"].split("/")[0]
+                    nh_state = show_ospf_json[nbr_rid][0]["nbrState"].split("/")[0]
                 except KeyError:
                     errormsg = "[DUT: {}] OSPF peer {} missing,from " "{} ".format(
                         router, nbr_rid, ospf_nbr

--- a/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
@@ -165,9 +165,9 @@ def test_ospf_lan_tc1_p0(request):
         "r0": {
             "ospf": {
                 "neighbors": {
-                    "r1": {"state": "Full", "role": "DR"},
-                    "r2": {"state": "Full", "role": "DROther"},
-                    "r3": {"state": "Full", "role": "DROther"},
+                    "r1": {"nbrState": "Full", "role": "DR"},
+                    "r2": {"nbrState": "Full", "role": "DROther"},
+                    "r3": {"nbrState": "Full", "role": "DROther"},
                 }
             }
         }
@@ -185,9 +185,9 @@ def test_ospf_lan_tc1_p0(request):
         "r1": {
             "ospf": {
                 "neighbors": {
-                    "r0": {"state": "Full", "role": "Backup"},
-                    "r2": {"state": "Full", "role": "DROther"},
-                    "r3": {"state": "Full", "role": "DROther"},
+                    "r0": {"nbrState": "Full", "role": "Backup"},
+                    "r2": {"nbrState": "Full", "role": "DROther"},
+                    "r3": {"nbrState": "Full", "role": "DROther"},
                 }
             }
         }
@@ -196,7 +196,8 @@ def test_ospf_lan_tc1_p0(request):
     result = verify_ospf_neighbor(tgen, topo, dut, input_dict, lan=True)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    step("Configure DR pririty 100 on R0 and clear ospf neighbors  on all the routers.")
+    step("Configure DR priority 100 on R0 and clear ospf neighbors "
+         "on all the routers.")
 
     input_dict = {
         "r0": {
@@ -221,9 +222,9 @@ def test_ospf_lan_tc1_p0(request):
         "r0": {
             "ospf": {
                 "neighbors": {
-                    "r1": {"state": "Full", "role": "Backup"},
-                    "r2": {"state": "Full", "role": "DROther"},
-                    "r3": {"state": "Full", "role": "DROther"},
+                    "r1": {"nbrState": "Full", "role": "Backup"},
+                    "r2": {"nbrState": "Full", "role": "DROther"},
+                    "r3": {"nbrState": "Full", "role": "DROther"},
                 }
             }
         }
@@ -232,7 +233,8 @@ def test_ospf_lan_tc1_p0(request):
     result = verify_ospf_neighbor(tgen, topo, dut, input_dict, lan=True)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    step("Configure DR pririty 150 on R0 and clear ospf neighbors  on all the routers.")
+    step("Configure DR priority 150 on R0 and clear ospf neighbors "
+         "on all the routers.")
 
     input_dict = {
         "r0": {
@@ -257,9 +259,9 @@ def test_ospf_lan_tc1_p0(request):
         "r0": {
             "ospf": {
                 "neighbors": {
-                    "r1": {"state": "Full", "role": "Backup"},
-                    "r2": {"state": "Full", "role": "DROther"},
-                    "r3": {"state": "Full", "role": "DROther"},
+                    "r1": {"nbrState": "Full", "role": "Backup"},
+                    "r2": {"nbrState": "Full", "role": "DROther"},
+                    "r3": {"nbrState": "Full", "role": "DROther"},
                 }
             }
         }
@@ -293,9 +295,9 @@ def test_ospf_lan_tc1_p0(request):
         "r0": {
             "ospf": {
                 "neighbors": {
-                    "r1": {"state": "Full", "role": "DR"},
-                    "r2": {"state": "2-Way", "role": "DROther"},
-                    "r3": {"state": "2-Way", "role": "DROther"},
+                    "r1": {"nbrState": "Full", "role": "DR"},
+                    "r2": {"nbrState": "2-Way", "role": "DROther"},
+                    "r3": {"nbrState": "2-Way", "role": "DROther"},
                 }
             }
         }
@@ -332,9 +334,9 @@ def test_ospf_lan_tc1_p0(request):
         "r0": {
             "ospf": {
                 "neighbors": {
-                    "r1": {"state": "Full", "role": "Backup"},
-                    "r2": {"state": "Full", "role": "DROther"},
-                    "r3": {"state": "Full", "role": "DROther"},
+                    "r1": {"nbrState": "Full", "role": "Backup"},
+                    "r2": {"nbrState": "Full", "role": "DROther"},
+                    "r3": {"nbrState": "Full", "role": "DROther"},
                 }
             }
         }
@@ -364,9 +366,9 @@ def test_ospf_lan_tc1_p0(request):
         "r0": {
             "ospf": {
                 "neighbors": {
-                    "r1": {"state": "Full", "role": "DR"},
-                    "r2": {"state": "Full", "role": "DROther"},
-                    "r3": {"state": "Full", "role": "DROther"},
+                    "r1": {"nbrState": "Full", "role": "DR"},
+                    "r2": {"nbrState": "Full", "role": "DROther"},
+                    "r3": {"nbrState": "Full", "role": "DROther"},
                 }
             }
         }
@@ -419,9 +421,9 @@ def test_ospf_lan_tc1_p0(request):
         "r1": {
             "ospf": {
                 "neighbors": {
-                    "r0": {"state": "Full", "role": "Backup"},
-                    "r2": {"state": "Full", "role": "DROther"},
-                    "r3": {"state": "Full", "role": "DROther"},
+                    "r0": {"nbrState": "Full", "role": "Backup"},
+                    "r2": {"nbrState": "Full", "role": "DROther"},
+                    "r3": {"nbrState": "Full", "role": "DROther"},
                 }
             }
         }
@@ -445,9 +447,9 @@ def test_ospf_lan_tc1_p0(request):
         "r1": {
             "ospf": {
                 "neighbors": {
-                    "r0": {"state": "Full", "role": "Backup"},
-                    "r2": {"state": "Full", "role": "DROther"},
-                    "r3": {"state": "Full", "role": "DROther"},
+                    "r0": {"nbrState": "Full", "role": "Backup"},
+                    "r2": {"nbrState": "Full", "role": "DROther"},
+                    "r3": {"nbrState": "Full", "role": "DROther"},
                 }
             }
         }

--- a/tests/topotests/ospf_basic_functionality/test_ospf_p2mp.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_p2mp.py
@@ -411,17 +411,17 @@ def test_ospf_nbrs(tgen):
                 "neighbors": {
                     "100.1.1.1": [
                         {
-                            "state": "Full/DROther",
+                            "nbrState": "Full/DROther",
                         }
                     ],
                     "100.1.1.2": [
                         {
-                            "state": "Full/DROther",
+                            "nbrState": "Full/DROther",
                         }
                     ],
                     "100.1.1.3": [
                         {
-                            "state": "Full/DROther",
+                            "nbrState": "Full/DROther",
                         }
                     ],
                 }
@@ -434,17 +434,17 @@ def test_ospf_nbrs(tgen):
                 "neighbors": {
                     "100.1.1.0": [
                         {
-                            "state": "Full/DROther",
+                            "nbrState": "Full/DROther",
                         }
                     ],
                     "100.1.1.2": [
                         {
-                            "state": "Full/DROther",
+                            "nbrState": "Full/DROther",
                         }
                     ],
                     "100.1.1.3": [
                         {
-                            "state": "Full/DROther",
+                            "nbrState": "Full/DROther",
                         }
                     ],
                 }
@@ -457,17 +457,17 @@ def test_ospf_nbrs(tgen):
                 "neighbors": {
                     "100.1.1.0": [
                         {
-                            "state": "Full/DROther",
+                            "nbrState": "Full/DROther",
                         }
                     ],
                     "100.1.1.1": [
                         {
-                            "state": "Full/DROther",
+                            "nbrState": "Full/DROther",
                         }
                     ],
                     "100.1.1.3": [
                         {
-                            "state": "Full/DROther",
+                            "nbrState": "Full/DROther",
                         }
                     ],
                 }
@@ -480,17 +480,17 @@ def test_ospf_nbrs(tgen):
                 "neighbors": {
                     "100.1.1.0": [
                         {
-                            "state": "Full/DROther",
+                            "nbrState": "Full/DROther",
                         }
                     ],
                     "100.1.1.1": [
                         {
-                            "state": "Full/DROther",
+                            "nbrState": "Full/DROther",
                         }
                     ],
                     "100.1.1.2": [
                         {
-                            "state": "Full/DROther",
+                            "nbrState": "Full/DROther",
                         }
                     ],
                 }

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper2.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper2.py
@@ -189,7 +189,9 @@ def test_ospf_gr_helper_tc3_p1(request):
     assert (
         ospf_covergence is True
     ), "OSPF is not after reset config \n Error:  {}".format(ospf_covergence)
-    step("Configure DR pririty 100 on R0 and clear ospf neighbors  on all the routers.")
+
+    step("Configure DR priority 100 on R0 and clear ospf neighbors "
+         "on all the routers.")
 
     input_dict = {
         "r0": {
@@ -214,9 +216,9 @@ def test_ospf_gr_helper_tc3_p1(request):
         "r0": {
             "ospf": {
                 "neighbors": {
-                    "r1": {"state": "Full", "role": "Backup"},
-                    "r2": {"state": "Full", "role": "DROther"},
-                    "r3": {"state": "Full", "role": "DROther"},
+                    "r1": {"nbrState": "Full", "role": "Backup"},
+                    "r2": {"nbrState": "Full", "role": "DROther"},
+                    "r3": {"nbrState": "Full", "role": "DROther"},
                 }
             }
         }
@@ -281,7 +283,7 @@ def test_ospf_gr_helper_tc4_p1(request):
     assert (
         ospf_covergence is True
     ), "OSPF is not after reset config \n Error:  {}".format(ospf_covergence)
-    step("Configure DR pririty 100 on R0 and clear ospf neighbors  on all the routers.")
+    step("Configure DR priority 0 on R0 and clear ospf neighbors  on all the routers.")
 
     input_dict = {
         "r0": {
@@ -306,9 +308,9 @@ def test_ospf_gr_helper_tc4_p1(request):
         "r0": {
             "ospf": {
                 "neighbors": {
-                    "r1": {"state": "Full", "role": "DR"},
-                    "r2": {"state": "2-Way", "role": "DROther"},
-                    "r3": {"state": "2-Way", "role": "DROther"},
+                    "r1": {"nbrState": "Full", "role": "DR"},
+                    "r2": {"nbrState": "2-Way", "role": "DROther"},
+                    "r3": {"nbrState": "2-Way", "role": "DROther"},
                 }
             }
         }

--- a/tests/topotests/ospf_gr_topo1/rt1/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ospf_gr_topo1/rt1/show_ip_ospf_neighbor.json
@@ -3,7 +3,7 @@
     "2.2.2.2":[
       {
         "converged":"Full",
-        "address":"10.0.1.2",
+        "ifaceAddress":"10.0.1.2",
         "ifaceName":"eth-rt2:10.0.1.1"
       }
     ]

--- a/tests/topotests/ospf_gr_topo1/rt2/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ospf_gr_topo1/rt2/show_ip_ospf_neighbor.json
@@ -3,14 +3,14 @@
     "1.1.1.1":[
       {
         "converged":"Full",
-        "address":"10.0.1.1",
+        "ifaceAddress":"10.0.1.1",
         "ifaceName":"eth-rt1:10.0.1.2"
       }
     ],
     "3.3.3.3":[
       {
         "converged":"Full",
-        "address":"10.0.2.3",
+        "ifaceAddress":"10.0.2.3",
         "ifaceName":"eth-rt3:10.0.2.2"
       }
     ]

--- a/tests/topotests/ospf_gr_topo1/rt3/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ospf_gr_topo1/rt3/show_ip_ospf_neighbor.json
@@ -3,21 +3,21 @@
     "2.2.2.2":[
       {
         "converged":"Full",
-        "address":"10.0.2.2",
+        "ifaceAddress":"10.0.2.2",
         "ifaceName":"eth-rt2:10.0.2.3"
       }
     ],
     "4.4.4.4":[
       {
         "converged":"Full",
-        "address":"10.0.3.4",
+        "ifaceAddress":"10.0.3.4",
         "ifaceName":"eth-rt4:10.0.3.3"
       }
     ],
     "6.6.6.6":[
       {
         "converged":"Full",
-        "address":"10.0.4.6",
+        "ifaceAddress":"10.0.4.6",
         "ifaceName":"eth-rt6:10.0.4.3"
       }
     ]

--- a/tests/topotests/ospf_gr_topo1/rt4/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ospf_gr_topo1/rt4/show_ip_ospf_neighbor.json
@@ -3,14 +3,14 @@
     "3.3.3.3":[
       {
         "converged":"Full",
-        "address":"10.0.3.3",
+        "ifaceAddress":"10.0.3.3",
         "ifaceName":"eth-rt3:10.0.3.4"
       }
     ],
     "5.5.5.5":[
       {
         "converged":"Full",
-        "address":"10.0.5.5",
+        "ifaceAddress":"10.0.5.5",
         "ifaceName":"eth-rt5:10.0.5.4"
       }
     ]

--- a/tests/topotests/ospf_gr_topo1/rt5/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ospf_gr_topo1/rt5/show_ip_ospf_neighbor.json
@@ -3,7 +3,7 @@
     "4.4.4.4":[
       {
         "converged":"Full",
-        "address":"10.0.5.4",
+        "ifaceAddress":"10.0.5.4",
         "ifaceName":"eth-rt4:10.0.5.5"
       }
     ]

--- a/tests/topotests/ospf_gr_topo1/rt6/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ospf_gr_topo1/rt6/show_ip_ospf_neighbor.json
@@ -3,14 +3,14 @@
     "3.3.3.3":[
       {
         "converged":"Full",
-        "address":"10.0.4.3",
+        "ifaceAddress":"10.0.4.3",
         "ifaceName":"eth-rt3:10.0.4.6"
       }
     ],
     "7.7.7.7":[
       {
         "converged":"Full",
-        "address":"10.0.6.7",
+        "ifaceAddress":"10.0.6.7",
         "ifaceName":"eth-rt7:10.0.6.6"
       }
     ]

--- a/tests/topotests/ospf_gr_topo1/rt7/show_ip_ospf_neighbor.json
+++ b/tests/topotests/ospf_gr_topo1/rt7/show_ip_ospf_neighbor.json
@@ -3,7 +3,7 @@
     "6.6.6.6":[
       {
         "converged":"Full",
-        "address":"10.0.6.6",
+        "ifaceAddress":"10.0.6.6",
         "ifaceName":"eth-rt6:10.0.6.7"
       }
     ]

--- a/tests/topotests/pim_acl/r1/ospf_neighbor.json
+++ b/tests/topotests/pim_acl/r1/ospf_neighbor.json
@@ -2,57 +2,57 @@
   "neighbors":{
     "192.168.0.11":[
       {
-        "priority":10,
+        "nbrPriority":10,
         "converged":"Full",
-        "address":"192.168.101.11",
+        "ifaceAddress":"192.168.101.11",
         "ifaceName":"r1-eth1:192.168.101.1",
-        "retransmitCounter":0,
-        "requestCounter":0,
-        "dbSummaryCounter":0
+        "linkStateRetransmissionListCounter":0,
+        "linkStateRequestListCounter":0,
+        "databaseSummaryListCounter":0
       }
     ],
     "192.168.0.12":[
       {
-        "priority":0,
+        "nbrPriority":0,
         "converged":"Full",
-        "address":"192.168.101.12",
+        "ifaceAddress":"192.168.101.12",
         "ifaceName":"r1-eth1:192.168.101.1",
-        "retransmitCounter":0,
-        "requestCounter":0,
-        "dbSummaryCounter":0
+        "linkStateRetransmissionListCounter":0,
+        "linkStateRequestListCounter":0,
+        "databaseSummaryListCounter":0
       }
     ],
     "192.168.0.13":[
       {
-        "priority":0,
+        "nbrPriority":0,
         "converged":"Full",
-        "address":"192.168.101.13",
+        "ifaceAddress":"192.168.101.13",
         "ifaceName":"r1-eth1:192.168.101.1",
-        "retransmitCounter":0,
-        "requestCounter":0,
-        "dbSummaryCounter":0
+        "linkStateRetransmissionListCounter":0,
+        "linkStateRequestListCounter":0,
+        "databaseSummaryListCounter":0
       }
     ],
     "192.168.0.14":[
       {
-        "priority":0,
+        "nbrPriority":0,
         "converged":"Full",
-        "address":"192.168.101.14",
+        "ifaceAddress":"192.168.101.14",
         "ifaceName":"r1-eth1:192.168.101.1",
-        "retransmitCounter":0,
-        "requestCounter":0,
-        "dbSummaryCounter":0
+        "linkStateRetransmissionListCounter":0,
+        "linkStateRequestListCounter":0,
+        "databaseSummaryListCounter":0
       }
     ],
     "192.168.0.15":[
       {
-        "priority":0,
+        "nbrPriority":0,
         "converged":"Full",
-        "address":"192.168.101.15",
+        "ifaceAddress":"192.168.101.15",
         "ifaceName":"r1-eth1:192.168.101.1",
-        "retransmitCounter":0,
-        "requestCounter":0,
-        "dbSummaryCounter":0
+        "linkStateRetransmissionListCounter":0,
+        "linkStateRequestListCounter":0,
+        "databaseSummaryListCounter":0
       }
     ]
   }

--- a/tests/topotests/pim_igmp_vrf/r1/ospf_blue_neighbor.json
+++ b/tests/topotests/pim_igmp_vrf/r1/ospf_blue_neighbor.json
@@ -4,9 +4,9 @@
     "neighbors":{
       "192.168.0.11":[
         {
-          "priority":10,
+          "nbrPriority":10,
           "converged":"Full",
-          "address":"192.168.101.11",
+          "ifaceAddress":"192.168.101.11",
           "ifaceName":"r1-eth1:192.168.101.1"
         }
       ]

--- a/tests/topotests/pim_igmp_vrf/r1/ospf_red_neighbor.json
+++ b/tests/topotests/pim_igmp_vrf/r1/ospf_red_neighbor.json
@@ -4,9 +4,9 @@
     "neighbors":{
       "192.168.0.12":[
         {
-          "priority":10,
+          "nbrPriority":10,
           "converged":"Full",
-          "address":"192.168.101.12",
+          "ifaceAddress":"192.168.101.12",
           "ifaceName":"r1-eth3:192.168.101.1"
         }
       ]


### PR DESCRIPTION
The date for removing some deprecated json attributes from 'show neighbor' has arrived, so remove the attrs (and the CPP_NOTICE block).
