### PR TITLE
tests: Turn off debug logging

### DIFF
--- a/tests/topotests/all_protocol_startup/r1/ospf6d.conf-pre-v4
+++ b/tests/topotests/all_protocol_startup/r1/ospf6d.conf-pre-v4
@@ -1,9 +1,9 @@
 log file ospf6d.log
 !
-debug ospf6 lsa unknown
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
+!debug ospf6 lsa unknown
+!debug ospf6 zebra
+!debug ospf6 interface
+!debug ospf6 neighbor
 !
 interface r1-eth4
 !

--- a/tests/topotests/bfd_topo3/r5/bfdd.conf
+++ b/tests/topotests/bfd_topo3/r5/bfdd.conf
@@ -1,6 +1,6 @@
-debug bfd network
-debug bfd peer
-debug bfd zebra
+!debug bfd network
+!debug bfd peer
+!debug bfd zebra
 !
 bfd
  profile slow-tx

--- a/tests/topotests/bfd_topo3/r6/bfdd.conf
+++ b/tests/topotests/bfd_topo3/r6/bfdd.conf
@@ -1,6 +1,6 @@
-debug bfd network
-debug bfd peer
-debug bfd zebra
+!debug bfd network
+!debug bfd peer
+!debug bfd zebra
 !
 bfd
  profile slow-tx

--- a/tests/topotests/bgp_accept_own/ce1/bgpd.conf
+++ b/tests/topotests/bgp_accept_own/ce1/bgpd.conf
@@ -1,5 +1,5 @@
 !
-debug bgp updates
+!debug bgp updates
 !
 router bgp 65010
  no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_accept_own/ce2/bgpd.conf
+++ b/tests/topotests/bgp_accept_own/ce2/bgpd.conf
@@ -1,5 +1,5 @@
 !
-debug bgp updates
+!debug bgp updates
 !
 router bgp 65020
  no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_accept_own/pe1/bgpd.conf
+++ b/tests/topotests/bgp_accept_own/pe1/bgpd.conf
@@ -1,8 +1,8 @@
 !
-debug bgp updates
-debug bgp vpn leak-from-vrf
-debug bgp vpn leak-to-vrf
-debug bgp nht
+!debug bgp updates
+!debug bgp vpn leak-from-vrf
+!debug bgp vpn leak-to-vrf
+!debug bgp nht
 !
 router bgp 65001
  bgp router-id 10.10.10.10

--- a/tests/topotests/bgp_accept_own/rr1/bgpd.conf
+++ b/tests/topotests/bgp_accept_own/rr1/bgpd.conf
@@ -1,5 +1,5 @@
 !
-debug bgp updates
+!debug bgp updates
 !
 router bgp 65001
  bgp router-id 10.10.10.101

--- a/tests/topotests/bgp_comm_list_match/r2/bgpd.conf
+++ b/tests/topotests/bgp_comm_list_match/r2/bgpd.conf
@@ -1,5 +1,5 @@
 !
-debug bgp updates
+!debug bgp updates
 !
 router bgp 65002
  no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_confed1/r1/bgpd.conf
+++ b/tests/topotests/bgp_confed1/r1/bgpd.conf
@@ -1,7 +1,7 @@
-debug bgp neighbor-events
-debug bgp nht
-debug bgp updates in
-debug bgp updates out
+!debug bgp neighbor-events
+!debug bgp nht
+!debug bgp updates in
+!debug bgp updates out
 !
 router bgp 100
  no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_confed1/r2/bgpd.conf
+++ b/tests/topotests/bgp_confed1/r2/bgpd.conf
@@ -1,7 +1,7 @@
-debug bgp neighbor-events
-debug bgp nht
-debug bgp updates in
-debug bgp updates out
+!debug bgp neighbor-events
+!debug bgp nht
+!debug bgp updates in
+!debug bgp updates out
 !
 router bgp 200
  no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_confed1/r3/bgpd.conf
+++ b/tests/topotests/bgp_confed1/r3/bgpd.conf
@@ -1,7 +1,7 @@
-debug bgp neighbor-events
-debug bgp nht
-debug bgp updates in
-debug bgp updates out
+!debug bgp neighbor-events
+!debug bgp nht
+!debug bgp updates in
+!debug bgp updates out
 !
 router bgp 300
  no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_confed1/r4/bgpd.conf
+++ b/tests/topotests/bgp_confed1/r4/bgpd.conf
@@ -1,7 +1,7 @@
-debug bgp neighbor-events
-debug bgp nht
-debug bgp updates in
-debug bgp updates out
+!debug bgp neighbor-events
+!debug bgp nht
+!debug bgp updates in
+!debug bgp updates out
 !
 router bgp 400
  no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_dont_capability_negotiate/r1/bgpd.conf
+++ b/tests/topotests/bgp_dont_capability_negotiate/r1/bgpd.conf
@@ -1,5 +1,5 @@
 !
-debug bgp neighbor
+!debug bgp neighbor
 !
 router bgp 65001
  no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
+++ b/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
@@ -463,8 +463,8 @@ def test_ip_pe1_learn():
     host1 = tgen.gears["host1"]
     pe1 = tgen.gears["PE1"]
     pe2 = tgen.gears["PE2"]
-    pe2.vtysh_cmd("debug zebra vxlan")
-    pe2.vtysh_cmd("debug zebra kernel")
+    #pe2.vtysh_cmd("debug zebra vxlan")
+    #pe2.vtysh_cmd("debug zebra kernel")
     # lets populate that arp cache
     host1.run("ping -c1 10.10.1.1")
     ip_learn_test(tgen, host1, pe1, pe2, "10.10.1.55")
@@ -482,8 +482,8 @@ def test_ip_pe2_learn():
     host2 = tgen.gears["host2"]
     pe1 = tgen.gears["PE1"]
     pe2 = tgen.gears["PE2"]
-    pe1.vtysh_cmd("debug zebra vxlan")
-    pe1.vtysh_cmd("debug zebra kernel")
+    #pe1.vtysh_cmd("debug zebra vxlan")
+    #pe1.vtysh_cmd("debug zebra kernel")
     # lets populate that arp cache
     host2.run("ping -c1 10.10.1.3")
     ip_learn_test(tgen, host2, pe2, pe1, "10.10.1.56")

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
@@ -385,8 +385,8 @@ def test_ip_pe1_learn():
     host1 = tgen.gears["host1"]
     pe1 = tgen.gears["PE1"]
     pe2 = tgen.gears["PE2"]
-    pe2.vtysh_cmd("debug zebra vxlan")
-    pe2.vtysh_cmd("debug zebra kernel")
+    #pe2.vtysh_cmd("debug zebra vxlan")
+    #pe2.vtysh_cmd("debug zebra kernel")
     # lets populate that arp cache
     host1.run("ping -c1 10.10.1.1")
     ip_learn_test(tgen, host1, pe1, pe2, "10.10.1.55")
@@ -404,8 +404,8 @@ def test_ip_pe2_learn():
     host2 = tgen.gears["host2"]
     pe1 = tgen.gears["PE1"]
     pe2 = tgen.gears["PE2"]
-    pe1.vtysh_cmd("debug zebra vxlan")
-    pe1.vtysh_cmd("debug zebra kernel")
+    #pe1.vtysh_cmd("debug zebra vxlan")
+    #pe1.vtysh_cmd("debug zebra kernel")
     # lets populate that arp cache
     host2.run("ping -c1 10.10.1.3")
     ip_learn_test(tgen, host2, pe2, pe1, "10.10.1.56")

--- a/tests/topotests/bgp_prefix_list_any/r2/bgpd.conf
+++ b/tests/topotests/bgp_prefix_list_any/r2/bgpd.conf
@@ -1,5 +1,5 @@
 !
-debug bgp updates
+!debug bgp updates
 !
 router bgp 65002
  no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_route_map_delay_timer/r1/bgpd.conf
+++ b/tests/topotests/bgp_route_map_delay_timer/r1/bgpd.conf
@@ -1,6 +1,6 @@
 !
-debug bgp updates
-debug bgp neighbor
+!debug bgp updates
+!debug bgp neighbor
 !
 bgp route-map delay-timer 5
 !

--- a/tests/topotests/bgp_route_map_vpn_import/r1/bgpd.conf
+++ b/tests/topotests/bgp_route_map_vpn_import/r1/bgpd.conf
@@ -1,9 +1,9 @@
 !
-debug bgp updates
-debug bgp vpn leak-from-vrf
-debug bgp vpn leak-to-vrf
-debug bgp nht
-debug route-map
+!debug bgp updates
+!debug bgp vpn leak-from-vrf
+!debug bgp vpn leak-to-vrf
+!debug bgp nht
+!debug route-map
 !
 router bgp 65001
  bgp router-id 10.10.10.10

--- a/tests/topotests/bgp_snmp_bgp4v2mib/r2/bgpd.conf
+++ b/tests/topotests/bgp_snmp_bgp4v2mib/r2/bgpd.conf
@@ -1,5 +1,5 @@
 !
-debug bgp updates
+!debug bgp updates
 !
 router bgp 65002
  no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/r1/zebra.conf
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/r1/zebra.conf
@@ -7,9 +7,9 @@ log stdout notifications
 log monitor notifications
 log commands
 !
-debug zebra packet
-debug zebra dplane
-debug zebra kernel
+!debug zebra packet
+!debug zebra dplane
+!debug zebra kernel
 !
 interface eth0
  ipv6 address 2001::1/64

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/r2/zebra.conf
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/r2/zebra.conf
@@ -7,9 +7,9 @@ log stdout notifications
 log monitor notifications
 log commands
 !
-debug zebra packet
-debug zebra dplane
-debug zebra kernel
+!debug zebra packet
+!debug zebra dplane
+!debug zebra kernel
 !
 interface eth0
  ipv6 address 2001::2/64

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/r1/zebra.conf
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/r1/zebra.conf
@@ -7,9 +7,9 @@ log stdout notifications
 log monitor notifications
 log commands
 !
-debug zebra packet
-debug zebra dplane
-debug zebra kernel
+!debug zebra packet
+!debug zebra dplane
+!debug zebra kernel
 !
 interface eth0
  ipv6 address 2001::1/64

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/r2/bgpd.conf
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/r2/bgpd.conf
@@ -1,6 +1,6 @@
 frr defaults traditional
 !
-bgp send-extra-data zebra
+!bgp send-extra-data zebra
 !
 hostname r2
 password zebra

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/r2/zebra.conf
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/r2/zebra.conf
@@ -7,9 +7,9 @@ log stdout notifications
 log monitor notifications
 log commands
 !
-debug zebra packet
-debug zebra dplane
-debug zebra kernel
+!debug zebra packet
+!debug zebra dplane
+!debug zebra kernel
 !
 interface eth0
  ipv6 address 2001::2/64

--- a/tests/topotests/bgp_suppress_fib/r2/bgpd.allowas_in.conf
+++ b/tests/topotests/bgp_suppress_fib/r2/bgpd.allowas_in.conf
@@ -2,12 +2,12 @@ access-list access seq 10 permit 192.168.1.1/32
 !
 ip route 192.168.1.1/32 10.0.0.10
 !
-debug bgp bestpath
-debug bgp nht
-debug bgp updates
-debug bgp update-groups
-debug bgp zebra
-debug zebra rib detail
+!debug bgp bestpath
+!debug bgp nht
+!debug bgp updates
+!debug bgp update-groups
+!debug bgp zebra
+!debug zebra rib detail
 !
 router bgp 2
   address-family ipv4 uni

--- a/tests/topotests/bgp_suppress_fib/r2/bgpd.conf
+++ b/tests/topotests/bgp_suppress_fib/r2/bgpd.conf
@@ -1,6 +1,6 @@
-debug bgp updates
-debug bgp bestpath 40.0.0.0/8
-debug bgp zebra
+!debug bgp updates
+!debug bgp bestpath 40.0.0.0/8
+!debug bgp zebra
 !
 router bgp 2
   no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_vrf_md5_peering/r1/bgpd.conf
+++ b/tests/topotests/bgp_vrf_md5_peering/r1/bgpd.conf
@@ -1,5 +1,5 @@
 !
-debug bgp neighbor
+!debug bgp neighbor
 !
 router bgp 65534 vrf public
  bgp router-id 10.0.0.1

--- a/tests/topotests/isis_snmp/r5/ldpdconf
+++ b/tests/topotests/isis_snmp/r5/ldpdconf
@@ -1,10 +1,10 @@
 hostname r5
 log file ldpd.log
 !
-debug mpls ldp zebra
-debug mpls ldp event
-debug mpls ldp errors
-debug mpls ldp sync
+!debug mpls ldp zebra
+!debug mpls ldp event
+!debug mpls ldp errors
+!debug mpls ldp sync
 !
 mpls ldp
  router-id 3.3.3.3

--- a/tests/topotests/ospf6_ecmp_inter_area/r1/ospf6d.conf
+++ b/tests/topotests/ospf6_ecmp_inter_area/r1/ospf6d.conf
@@ -1,35 +1,35 @@
-debug ospf6 lsa all
-debug ospf6 message all
-debug ospf6 route all
-debug ospf6 spf time
-debug ospf6 spf database
-debug ospf6 zebra send
-debug ospf6 zebra recv
-
-debug ospf6 lsa router
-debug ospf6 lsa router originate
-debug ospf6 lsa router examine
-debug ospf6 lsa router flooding
-debug ospf6 lsa as-external
-debug ospf6 lsa as-external originate
-debug ospf6 lsa as-external examine
-debug ospf6 lsa as-external flooding
-debug ospf6 lsa intra-prefix
-debug ospf6 lsa intra-prefix originate
-debug ospf6 lsa intra-prefix examine
-debug ospf6 lsa intra-prefix flooding
-debug ospf6 border-routers
-debug ospf6 zebra
-debug ospf6 interface
-debug ospf6 neighbor
-debug ospf6 flooding
-debug ospf6 gr helper
-debug ospf6 spf process
-debug ospf6 route intra-area
-debug ospf6 route inter-area
-debug ospf6 abr
-debug ospf6 asbr
-debug ospf6 nssa
+!debug ospf6 lsa all
+!debug ospf6 message all
+!debug ospf6 route all
+!debug ospf6 spf time
+!debug ospf6 spf database
+!debug ospf6 zebra send
+!debug ospf6 zebra recv
+!
+!debug ospf6 lsa router
+!debug ospf6 lsa router originate
+!debug ospf6 lsa router examine
+!debug ospf6 lsa router flooding
+!debug ospf6 lsa as-external
+!debug ospf6 lsa as-external originate
+!debug ospf6 lsa as-external examine
+!debug ospf6 lsa as-external flooding
+!debug ospf6 lsa intra-prefix
+!debug ospf6 lsa intra-prefix originate
+!debug ospf6 lsa intra-prefix examine
+!debug ospf6 lsa intra-prefix flooding
+!debug ospf6 border-routers
+!debug ospf6 zebra
+!debug ospf6 interface
+!debug ospf6 neighbor
+!debug ospf6 flooding
+!debug ospf6 gr helper
+!debug ospf6 spf process
+!debug ospf6 route intra-area
+!debug ospf6 route inter-area
+!debug ospf6 abr
+!debug ospf6 asbr
+!debug ospf6 nssa
 !
 interface r1-eth0
  ipv6 ospf6 area 0

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_single_area.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_single_area.py
@@ -1079,53 +1079,6 @@ def test_ospfv3_show_p1(request):
 
     result = create_debug_log_config(tgen, input_dict)
 
-    # Code coverage steps #Do Not upstream
-    input_dict_config = {
-        "r1": {
-            "raw_config": [
-                "end",
-                "debug ospf6 event",
-                "debug ospf6 gr helper",
-                "debug ospf6 ism events",
-                "debug ospf6 ism status",
-                "debug ospf6 ism timers",
-                "debug ospf6 nsm events",
-                "debug ospf6 nsm status",
-                "debug ospf6 nsm timers ",
-                "debug ospf6 nssa",
-                "debug ospf6 lsa aggregate",
-                "debug ospf6 lsa flooding ",
-                "debug ospf6 lsa generate",
-                "debug ospf6 lsa install ",
-                "debug ospf6 lsa refresh",
-                "debug ospf6 packet all detail",
-                "debug ospf6 packet all recv",
-                "debug ospf6 packet all send",
-                "debug ospf6 packet dd detail",
-                "debug ospf6 packet dd recv",
-                "debug ospf6 packet dd send ",
-                "debug ospf6 packet hello detail",
-                "debug ospf6 packet hello recv",
-                "debug ospf6 packet hello send",
-                "debug ospf6 packet ls-ack detail",
-                "debug ospf6 packet ls-ack recv",
-                "debug ospf6 packet ls-ack send",
-                "debug ospf6 packet ls-request detail",
-                "debug ospf6 packet ls-request recv",
-                "debug ospf6 packet ls-request send",
-                "debug ospf6 packet ls-update detail",
-                "debug ospf6 packet ls-update recv",
-                "debug ospf6 packet ls-update send",
-                "debug ospf6 sr",
-                "debug ospf6 te ",
-                "debug ospf6 zebra interface",
-                "debug ospf6 zebra redistribute",
-            ]
-        }
-    }
-
-    apply_raw_config(tgen, input_dict_config)
-
     for rtr in topo["routers"]:
         clear_ospf(tgen, rtr, ospf="ospf6")
 


### PR DESCRIPTION
Tests are taking up too much space, turn off debug logging for normal runs.