### PR TITLE
Improve and fix zebra GR

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -4294,6 +4294,8 @@ int32_t zapi_capabilities_decode(struct stream *s, struct zapi_cap *api)
 
 	memset(api, 0, sizeof(*api));
 
+	api->safi = SAFI_UNICAST;
+
 	STREAM_GETL(s, api->cap);
 	switch (api->cap) {
 	case ZEBRA_CLIENT_GR_CAPABILITIES:

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -180,7 +180,7 @@ struct route_entry {
  * sub-queue 9: any other origin (if any) typically those that
  *              don't generate routes
  */
-#define MQ_SIZE 10
+#define MQ_SIZE 11
 struct meta_queue {
 	struct list *subq[MQ_SIZE];
 	uint32_t size; /* sum of lengths of all subqueues */
@@ -600,6 +600,12 @@ static inline struct nexthop_group *rib_get_fib_backup_nhg(
 {
 	return &(re->fib_backup_ng);
 }
+
+extern void zebra_gr_process_client(afi_t afi, vrf_id_t vrf_id, uint8_t proto,
+				    uint8_t instance);
+
+extern int rib_add_gr_run(afi_t afi, vrf_id_t vrf_id, uint8_t proto,
+			  uint8_t instance);
 
 extern void zebra_vty_init(void);
 

--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -42,7 +42,7 @@ static struct zserv *zebra_gr_find_stale_client(struct zserv *client);
 static void zebra_gr_route_stale_delete_timer_expiry(struct event *thread);
 static int32_t zebra_gr_delete_stale_routes(struct client_gr_info *info);
 static void zebra_gr_process_client_stale_routes(struct zserv *client,
-						 vrf_id_t vrf_id);
+						 struct client_gr_info *info);
 
 /*
  * Debug macros.
@@ -290,17 +290,43 @@ void zebra_gr_client_reconnect(struct zserv *client)
  */
 
 /*
- * Update the graceful restart information
- * for the client instance.
- * This function handles all the capabilities that are received.
+ * Function to decode and call appropriate functions
+ * to handle client capabilities.
  */
-static void zebra_client_update_info(struct zserv *client, struct zapi_cap *api)
+void zread_client_capabilities(ZAPI_HANDLER_ARGS)
 {
+	struct zapi_cap api;
 	struct client_gr_info *info = NULL;
+	struct stream *s;
+	struct vrf *vrf;
+
+	s = msg;
+
+	if (zapi_capabilities_decode(s, &api)) {
+		LOG_GR("%s: Error in reading capabilities for client %s",
+		       __func__, zebra_route_string(client->proto));
+		return;
+	}
+
+	vrf = vrf_lookup_by_id(api.vrf_id);
+
+	/*
+	 * If this ever matters uncomment and add safi to the
+	 * arrays as needed to track
+	 */
+	if (api.safi != SAFI_UNICAST)
+		return;
+
+	/* GR only for dynamic clients */
+	if (client->proto <= ZEBRA_ROUTE_CONNECT) {
+		LOG_GR("%s: GR capabilities for client %s not supported",
+		       __func__, zebra_route_string(client->proto));
+		return;
+	}
 
 	/* Find the bgp information for the specified vrf id */
 	TAILQ_FOREACH (info, &client->gr_info_queue, gr_info) {
-		if (info->vrf_id == api->vrf_id)
+		if (info->vrf_id == api.vrf_id)
 			break;
 	}
 
@@ -308,7 +334,7 @@ static void zebra_client_update_info(struct zserv *client, struct zapi_cap *api)
 	 * If the command is delete, then cancel the stale timer and
 	 * delete the bgp info
 	 */
-	switch (api->cap) {
+	switch (api.cap) {
 	case ZEBRA_CLIENT_GR_DISABLE:
 		if (!info)
 			return;
@@ -329,18 +355,16 @@ static void zebra_client_update_info(struct zserv *client, struct zapi_cap *api)
 
 		/* Update other parameters */
 		if (!info->gr_enable) {
-			struct vrf *vrf = vrf_lookup_by_id(api->vrf_id);
-
 			client->gr_instance_count++;
 
 			LOG_GR("%s: Cient %s vrf %s(%u) GR enabled count %d",
 			       __func__, zebra_route_string(client->proto),
-			       VRF_LOGNAME(vrf), api->vrf_id,
+			       VRF_LOGNAME(vrf), api.vrf_id,
 			       client->gr_instance_count);
 
-			info->capabilities = api->cap;
-			info->stale_removal_time = api->stale_removal_time;
-			info->vrf_id = api->vrf_id;
+			info->capabilities = api.cap;
+			info->stale_removal_time = api.stale_removal_time;
+			info->vrf_id = api.vrf_id;
 			info->gr_enable = true;
 		}
 		break;
@@ -350,14 +374,13 @@ static void zebra_client_update_info(struct zserv *client, struct zapi_cap *api)
 
 		/* Update the stale removal timer */
 		if (info && info->t_stale_removal == NULL) {
-			struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
 
 			LOG_GR("%s: vrf %s(%u) Stale time: %d is now update to: %d",
 			       __func__, VRF_LOGNAME(vrf), info->vrf_id,
 			       info->stale_removal_time,
-			       api->stale_removal_time);
+			       api.stale_removal_time);
 
-			info->stale_removal_time = api->stale_removal_time;
+			info->stale_removal_time = api.stale_removal_time;
 		}
 
 		break;
@@ -365,85 +388,32 @@ static void zebra_client_update_info(struct zserv *client, struct zapi_cap *api)
 		if (!info) {
 			LOG_GR("%s: Client %s route update complete for AFI %d, SAFI %d",
 			       __func__, zebra_route_string(client->proto),
-			       api->afi, api->safi);
+			       api.afi, api.safi);
 		} else {
-			struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
-
 			LOG_GR("%s: Client %s vrf %s(%u) route update complete for AFI %d, SAFI %d",
 			       __func__, zebra_route_string(client->proto),
-			       VRF_LOGNAME(vrf), info->vrf_id, api->afi,
-			       api->safi);
-			info->route_sync[api->afi] = true;
+			       VRF_LOGNAME(vrf), info->vrf_id, api.afi,
+			       api.safi);
+			info->route_sync[api.afi] = true;
 		}
+		zebra_gr_process_client_stale_routes(client, info);
 		break;
 	case ZEBRA_CLIENT_ROUTE_UPDATE_PENDING:
 		if (!info) {
 			LOG_GR("%s: Client %s route update pending for AFI %d, SAFI %d",
 			       __func__, zebra_route_string(client->proto),
-			       api->afi, api->safi);
+			       api.afi, api.safi);
 		} else {
-			struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
-
 			LOG_GR("%s: Client %s vrf %s(%u) route update pending for AFI %d, SAFI %d",
 			       __func__, zebra_route_string(client->proto),
-			       VRF_LOGNAME(vrf), info->vrf_id, api->afi,
-			       api->safi);
+			       VRF_LOGNAME(vrf), info->vrf_id, api.afi,
+			       api.safi);
 
-			info->af_enabled[api->afi] = true;
+			info->af_enabled[api.afi] = true;
 		}
 		break;
 	}
 }
-
-/*
- * Function to decode and call appropriate functions
- * to handle client capabilities.
- */
-void zread_client_capabilities(ZAPI_HANDLER_ARGS)
-{
-	struct zapi_cap api;
-	struct stream *s;
-
-	s = msg;
-
-	if (zapi_capabilities_decode(s, &api)) {
-		LOG_GR("%s: Error in reading capabilities for client %s",
-		       __func__, zebra_route_string(client->proto));
-		return;
-	}
-
-	if (api.safi != SAFI_UNICAST)
-		return;
-
-	/* GR only for dynamic clients */
-	if (client->proto <= ZEBRA_ROUTE_CONNECT) {
-		LOG_GR("%s: GR capabilities for client %s not supported",
-		       __func__, zebra_route_string(client->proto));
-		return;
-	}
-
-	/* Call the capabilities handler */
-	switch (api.cap) {
-	case ZEBRA_CLIENT_GR_CAPABILITIES:
-	case ZEBRA_CLIENT_ROUTE_UPDATE_PENDING:
-	case ZEBRA_CLIENT_GR_DISABLE:
-	case ZEBRA_CLIENT_RIB_STALE_TIME:
-		/*
-		 * For all the cases we need to update the client info.
-		 */
-		zebra_client_update_info(client, &api);
-		break;
-	case ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE:
-		/*
-		 * After client info has been updated delete all
-		 * stale routes
-		 */
-		zebra_client_update_info(client, &api);
-		zebra_gr_process_client_stale_routes(client, api.vrf_id);
-		break;
-	}
-}
-
 
 /*
  * Stale route handling
@@ -613,31 +583,22 @@ static int32_t zebra_gr_delete_stale_routes(struct client_gr_info *info)
  * and cancels the stale timer
  */
 static void zebra_gr_process_client_stale_routes(struct zserv *client,
-						 vrf_id_t vrf_id)
+						 struct client_gr_info *info)
 {
-	struct client_gr_info *info = NULL;
 	afi_t afi;
-
-	TAILQ_FOREACH (info, &client->gr_info_queue, gr_info) {
-		if (info->vrf_id == vrf_id)
-			break;
-	}
 
 	if (info == NULL)
 		return;
 
 	/* Check if route update completed for all AFI, SAFI */
 	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
-		if (info->af_enabled[afi]) {
-			if (!info->route_sync[afi]) {
-				struct vrf *vrf = vrf_lookup_by_id(vrf_id);
+		if (info->af_enabled[afi] && !info->route_sync[afi]) {
+			struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
 
-				LOG_GR("%s: Client %s vrf: %s(%u) route update not completed for AFI %d",
-				       __func__,
-				       zebra_route_string(client->proto),
-				       VRF_LOGNAME(vrf), info->vrf_id, afi);
-				return;
-			}
+			LOG_GR("%s: Client %s vrf: %s(%u) route update not completed for AFI %d",
+			       __func__, zebra_route_string(client->proto),
+			       VRF_LOGNAME(vrf), info->vrf_id, afi);
+			return;
 		}
 	}
 
@@ -646,7 +607,7 @@ static void zebra_gr_process_client_stale_routes(struct zserv *client,
 	 * Cancel the stale timer and process the routes
 	 */
 	if (info->t_stale_removal) {
-		struct vrf *vrf = vrf_lookup_by_id(vrf_id);
+		struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
 
 		LOG_GR("%s: Client %s canceled stale delete timer vrf %s(%d)",
 		       __func__, zebra_route_string(client->proto),

--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -164,7 +164,6 @@ int32_t zebra_gr_client_disconnect(struct zserv *client)
 				zebra_gr_route_stale_delete_timer_expiry, info,
 				info->stale_removal_time,
 				&info->t_stale_removal);
-			info->current_afi = AFI_IP;
 			info->stale_client_ptr = client;
 			info->stale_client = true;
 			LOG_GR("%s: Client %s vrf %s(%u) Stale timer update to %d",
@@ -475,7 +474,6 @@ static void zebra_gr_route_stale_delete_timer_expiry(struct event *thread)
 		       __func__, zebra_route_string(client->proto),
 		       VRF_LOGNAME(vrf), info->vrf_id);
 
-		info->current_afi = 0;
 		zebra_gr_delete_stale_client(info);
 	}
 }
@@ -565,7 +563,7 @@ done:
 static int32_t zebra_gr_delete_stale_route(struct client_gr_info *info,
 					   struct zebra_vrf *zvrf)
 {
-	afi_t afi, curr_afi;
+	afi_t afi;
 	uint8_t proto;
 	uint16_t instance;
 	struct zserv *s_client;
@@ -579,13 +577,12 @@ static int32_t zebra_gr_delete_stale_route(struct client_gr_info *info,
 
 	proto = s_client->proto;
 	instance = s_client->instance;
-	curr_afi = info->current_afi;
 
 	LOG_GR("%s: Client %s %s(%u) stale routes are being deleted", __func__,
 	       zebra_route_string(proto), zvrf->vrf->name, zvrf->vrf->vrf_id);
 
 	/* Process routes for all AFI */
-	for (afi = curr_afi; afi < AFI_MAX; afi++) {
+	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
 		struct zebra_gr_afi_clean *gac =
 			XCALLOC(MTYPE_ZEBRA_GR, sizeof(*gac));
 

--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -535,9 +535,6 @@ static int32_t zebra_gr_delete_stale_route(struct client_gr_info *info,
 	uint16_t instance;
 	struct zserv *s_client;
 
-	if ((info == NULL) || (zvrf == NULL))
-		return -1;
-
 	s_client = info->stale_client_ptr;
 	if (s_client == NULL) {
 		LOG_GR("%s: Stale client %s(%u) not present", __func__,

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -64,7 +64,12 @@ DEFINE_HOOK(rib_update, (struct route_node * rn, const char *reason),
 DEFINE_HOOK(rib_shutdown, (struct route_node * rn), (rn));
 
 
-/* Meta Q's specific names */
+/*
+ * Meta Q's specific names
+ *
+ * If you add something here ensure that you
+ * change MQ_SIZE as well over in rib.h
+ */
 enum meta_queue_indexes {
 	META_QUEUE_NHG,
 	META_QUEUE_EVPN,
@@ -76,6 +81,7 @@ enum meta_queue_indexes {
 	META_QUEUE_NOTBGP,
 	META_QUEUE_BGP,
 	META_QUEUE_OTHER,
+	META_QUEUE_GR_RUN,
 };
 
 /* Each route type's string and default distance value. */
@@ -250,6 +256,8 @@ static const char *subqueue2str(enum meta_queue_indexes index)
 		return "BGP Routes";
 	case META_QUEUE_OTHER:
 		return "Other Routes";
+	case META_QUEUE_GR_RUN:
+		return "Graceful Restart";
 	}
 
 	return "Unknown";
@@ -3089,6 +3097,23 @@ static void process_subq_early_route(struct listnode *lnode)
 		process_subq_early_route_add(ere);
 }
 
+struct meta_q_gr_run {
+	afi_t afi;
+	vrf_id_t vrf_id;
+	uint8_t proto;
+	uint8_t instance;
+};
+
+static void process_subq_gr_run(struct listnode *lnode)
+{
+	struct meta_q_gr_run *gr_run = listgetdata(lnode);
+
+	zebra_gr_process_client(gr_run->afi, gr_run->vrf_id, gr_run->proto,
+				gr_run->instance);
+
+	XFREE(MTYPE_WQ_WRAPPER, gr_run);
+}
+
 /*
  * Examine the specified subqueue; process one entry and return 1 if
  * there is a node, return 0 otherwise.
@@ -3121,6 +3146,9 @@ static unsigned int process_subq(struct list *subq,
 	case META_QUEUE_BGP:
 	case META_QUEUE_OTHER:
 		process_subq_route(lnode, qindex);
+		break;
+	case META_QUEUE_GR_RUN:
+		process_subq_gr_run(lnode);
 		break;
 	}
 
@@ -3727,6 +3755,20 @@ static void early_route_meta_queue_free(struct meta_queue *mq, struct list *l,
 	}
 }
 
+static void rib_meta_queue_gr_run_free(struct meta_queue *mq, struct list *l,
+				       struct zebra_vrf *zvrf)
+{
+	struct meta_q_gr_run *gr_run;
+	struct listnode *node, *nnode;
+
+	for (ALL_LIST_ELEMENTS(l, node, nnode, gr_run)) {
+		if (zvrf && zvrf->vrf->vrf_id != gr_run->vrf_id)
+			continue;
+
+		XFREE(MTYPE_WQ_WRAPPER, gr_run);
+	}
+}
+
 void meta_queue_free(struct meta_queue *mq, struct zebra_vrf *zvrf)
 {
 	enum meta_queue_indexes i;
@@ -3753,6 +3795,9 @@ void meta_queue_free(struct meta_queue *mq, struct zebra_vrf *zvrf)
 		case META_QUEUE_BGP:
 		case META_QUEUE_OTHER:
 			rib_meta_queue_free(mq, mq->subq[i], zvrf);
+			break;
+		case META_QUEUE_GR_RUN:
+			rib_meta_queue_gr_run_free(mq, mq->subq[i], zvrf);
 			break;
 		}
 		if (!zvrf)
@@ -4094,6 +4139,17 @@ void _route_entry_dump(const char *func, union prefixconstptr pp,
 	zlog_debug("%s: dump complete", straddr);
 }
 
+static int rib_meta_queue_gr_run_add(struct meta_queue *mq, void *data)
+{
+	listnode_add(mq->subq[META_QUEUE_GR_RUN], data);
+	mq->size++;
+
+	if (IS_ZEBRA_DEBUG_RIB_DETAILED)
+		zlog_debug("Graceful Run adding");
+
+	return 0;
+}
+
 static int rib_meta_queue_early_route_add(struct meta_queue *mq, void *data)
 {
 	struct zebra_early_route *ere = data;
@@ -4108,6 +4164,20 @@ static int rib_meta_queue_early_route_add(struct meta_queue *mq, void *data)
 			subqueue2str(META_QUEUE_EARLY_ROUTE));
 
 	return 0;
+}
+
+int rib_add_gr_run(afi_t afi, vrf_id_t vrf_id, uint8_t proto, uint8_t instance)
+{
+	struct meta_q_gr_run *gr_run;
+
+	gr_run = XCALLOC(MTYPE_WQ_WRAPPER, sizeof(*gr_run));
+
+	gr_run->afi = afi;
+	gr_run->proto = proto;
+	gr_run->vrf_id = vrf_id;
+	gr_run->instance = instance;
+
+	return mq_add_handler(gr_run, rib_meta_queue_gr_run_add);
 }
 
 struct route_entry *zebra_rib_route_entry_new(vrf_id_t vrf_id, int type,

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1152,7 +1152,6 @@ static void zebra_show_stale_client_detail(struct vty *vty,
 							info->t_stale_removal));
 				}
 			}
-			vty_out(vty, "Current AFI : %d\n", info->current_afi);
 		}
 	}
 	vty_out(vty, "\n");

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1153,9 +1153,6 @@ static void zebra_show_stale_client_detail(struct vty *vty,
 				}
 			}
 			vty_out(vty, "Current AFI : %d\n", info->current_afi);
-			if (info->current_prefix)
-				vty_out(vty, "Current prefix : %pFX\n",
-					info->current_prefix);
 		}
 	}
 	vty_out(vty, "\n");

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -68,7 +68,6 @@ struct client_gr_info {
 	bool route_sync[AFI_MAX][SAFI_MAX];
 
 	/* Book keeping */
-	struct prefix *current_prefix;
 	void *stale_client_ptr;
 	struct event *t_stale_removal;
 

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -64,8 +64,8 @@ struct client_gr_info {
 	bool stale_client;
 
 	/* Route sync and enable flags for AFI/SAFI */
-	bool af_enabled[AFI_MAX][SAFI_MAX];
-	bool route_sync[AFI_MAX][SAFI_MAX];
+	bool af_enabled[AFI_MAX];
+	bool route_sync[AFI_MAX];
 
 	/* Book keeping */
 	void *stale_client_ptr;

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -51,9 +51,6 @@ struct client_gr_info {
 	/* VRF for which GR enabled */
 	vrf_id_t vrf_id;
 
-	/* AFI */
-	afi_t current_afi;
-
 	/* Stale time and GR cap */
 	uint32_t stale_removal_time;
 	enum zserv_client_capabilities capabilities;


### PR DESCRIPTION
See individual commits but the high points:

a) Zebra was storing afi/safi data for GR but only acting on AFI/SAFI_UNICAST.  Remove the redundancy
b) Fix GR code to not accidently stop iterating when a node goes away
c) Fix GR code to process the AFI when it receives the notification that the afi is done
d) Fix GR code to run after anything in Meta-Q since we have a race condition
