### PR TITLE
bgpd: increase buffer size used for dumping BGP to MRT files

### DIFF
--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -845,8 +845,7 @@ void bgp_dump_init(void)
 	memset(&bgp_dump_routes, 0, sizeof(bgp_dump_routes));
 
 	bgp_dump_obuf =
-		stream_new((BGP_STANDARD_MESSAGE_MAX_PACKET_SIZE * 2)
-			   + BGP_DUMP_MSG_HEADER + BGP_DUMP_HEADER_SIZE);
+		stream_new(BGP_MAX_PACKET_SIZE + BGP_MAX_PACKET_SIZE_OVERFLOW);
 
 	install_node(&bgp_dump_node);
 


### PR DESCRIPTION
This PR fixes [issue 13151](https://github.com/FRRouting/frr/issues/13151) where BGP messages larger than 8192 could be truncated in the dumped MRT files.

The fix is to use a larger buffer sized with BGP_MAX_PACKET_SIZE (65535) plus some overhead BGP_MAX_PACKET_SIZE_OVERFLOW (1024).