### PR TITLE
ospfd: write socket per interface

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -315,6 +315,13 @@ To start OSPF process you have to specify the OSPF router.
    This command controls the ospf instance's socket buffer sizes. The
    'no' form resets one or both values to the default.
    
+.. clicmd:: no socket-per-interface
+
+   Ordinarily, ospfd uses a socket per interface for sending
+   packets. This command disables those per-interface sockets, and
+   causes ospfd to use a single socket per ospf instance for sending
+   and receiving packets.
+
 .. _ospf-area:
 
 Areas

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -651,6 +651,8 @@ int ospf_if_new_hook(struct interface *ifp)
 
 	ifp->info = XCALLOC(MTYPE_OSPF_IF_INFO, sizeof(struct ospf_if_info));
 
+	IF_OSPF_IF_INFO(ifp)->oii_fd = -1;
+
 	IF_OIFS(ifp) = route_table_init();
 	IF_OIFS_PARAMS(ifp) = route_table_init();
 
@@ -691,6 +693,8 @@ static int ospf_if_delete_hook(struct interface *ifp)
 {
 	int rc = 0;
 	struct route_node *rn;
+	struct ospf_if_info *oii;
+
 	rc = ospf_opaque_del_if(ifp);
 
 	/*
@@ -706,6 +710,13 @@ static int ospf_if_delete_hook(struct interface *ifp)
 
 	route_table_finish(IF_OIFS(ifp));
 	route_table_finish(IF_OIFS_PARAMS(ifp));
+
+	/* Close per-interface socket */
+	oii = ifp->info;
+	if (oii && oii->oii_fd > 0) {
+		close(oii->oii_fd);
+		oii->oii_fd = -1;
+	}
 
 	XFREE(MTYPE_OSPF_IF_INFO, ifp->info);
 
@@ -1367,6 +1378,16 @@ static int ospf_ifp_up(struct interface *ifp)
 	struct ospf_interface *oi;
 	struct route_node *rn;
 	struct ospf_if_info *oii = ifp->info;
+	struct ospf *ospf;
+
+	if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
+		zlog_debug("Zebra: Interface[%s] state change to up.",
+			   ifp->name);
+
+	/* Open per-intf write socket if configured */
+	ospf = ifp->vrf->info;
+	if (ospf && ospf->intf_socket_enabled)
+		ospf_ifp_sock_init(ifp);
 
 	ospf_if_recalculate_output_cost(ifp);
 
@@ -1383,10 +1404,6 @@ static int ospf_ifp_up(struct interface *ifp)
 
 		return 0;
 	}
-
-	if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
-		zlog_debug("Zebra: Interface[%s] state change to up.",
-			   ifp->name);
 
 	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
 		if ((oi = rn->info) == NULL)
@@ -1415,6 +1432,9 @@ static int ospf_ifp_down(struct interface *ifp)
 			continue;
 		ospf_if_down(oi);
 	}
+
+	/* Close per-interface write socket if configured */
+	ospf_ifp_sock_close(ifp);
 
 	return 0;
 }

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -121,6 +121,9 @@ struct ospf_if_info {
 		membership_counts[MEMBER_MAX]; /* multicast group refcnts */
 
 	uint32_t curr_mtu;
+
+	/* Per-interface write socket, configured via 'ospf' object */
+	int oii_fd;
 };
 
 struct ospf_interface;

--- a/ospfd/ospf_network.h
+++ b/ospfd/ospf_network.h
@@ -13,8 +13,11 @@ extern int ospf_if_drop_allspfrouters(struct ospf *, struct prefix *,
 				      ifindex_t);
 extern int ospf_if_add_alldrouters(struct ospf *, struct prefix *, ifindex_t);
 extern int ospf_if_drop_alldrouters(struct ospf *, struct prefix *, ifindex_t);
-extern int ospf_if_ipmulticast(struct ospf *, struct prefix *, ifindex_t);
+extern int ospf_if_ipmulticast(int fd, struct prefix *, ifindex_t);
 extern int ospf_sock_init(struct ospf *ospf);
+/* Open, close per-interface write socket */
+int ospf_ifp_sock_init(struct interface *ifp);
+int ospf_ifp_sock_close(struct interface *ifp);
 
 enum ospf_sock_type_e {
 	OSPF_SOCK_NONE = 0,

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -419,6 +419,7 @@ struct ospf *ospf_new_alloc(unsigned short instance, const char *name)
 	QOBJ_REG(new, ospf);
 
 	new->fd = -1;
+	new->intf_socket_enabled = true;
 
 	new->recv_sock_bufsize = OSPF_DEFAULT_SOCK_BUFSIZE;
 	new->send_sock_bufsize = OSPF_DEFAULT_SOCK_BUFSIZE;

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -431,6 +431,9 @@ struct ospf {
 	uint32_t recv_sock_bufsize;
 	uint32_t send_sock_bufsize;
 
+	/* Per-interface write socket */
+	bool intf_socket_enabled;
+
 	QOBJ_FIELDS;
 };
 DECLARE_QOBJ_TYPE(ospf);


### PR DESCRIPTION
Modify ospfd to use a write socket per interface, instead of the current socket-per-instance. When multiple interfaces with different characteristics share a single socket (and its buffers), it's possible for slow or poor-performing destinations to block packets destined for other, better-performing destinations. With a socket per interface, fewer neighbors share fate.

This is enabled by default, on a per-instance basis. A new cli is available to revert to the original, socket - per - instance behavior if necessary.

I haven't added a specific test, since ... it's enabled all the time.