### PR TITLE
isisd: Correction of subnets creation in the TED

### DIFF
--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -790,7 +790,7 @@ static int sharp_opaque_handler(ZAPI_CALLBACK_ARGS)
 		   zclient->session_id, info.type);
 
 	if (info.type == LINK_STATE_UPDATE) {
-		lse = ls_stream2ted(sg.ted, s, false);
+		lse = ls_stream2ted(sg.ted, s, true);
 		if (lse) {
 			zlog_debug(" |- Got %s %s from Link State Database",
 				   status2txt[lse->status],


### PR DESCRIPTION
Subnets may be incorrectly created in the IS-IS Traffic Engineering Database (TED).

Indeed, to be usable, the subnets advertised by IS-IS peers must be  adjusted to avoid misinterpretation. For example, consider R1 which is connected to R2 with IP addresses 10.0.0.1/24 (R1) and 10.0.0.2/24 (R2). R1 and R2 will advertise the prefix 10.0.0.0/24. By leaving the subnet with the prefix 10.0.0.0/24 in the TED, it is not possible to determine whether 10.0.0.1 is attached to R1 or R2 or whether 10.0.0.3 exists.

So to avoid this, the subnet prefixes are adjusted with the IP addresses of the local interface. But IS-IS can start to advertise the subnet when not all adjacencies are up, especially when IPv4 and IPv6 are configured on the same interface. This results in an uncorrected prefix, e.g. 10.0.0.0/24, remaining in the TED when it should be removed.

This problem affects some isis-related tests such as the CSPF test (see PR #12924)
    
This patch fixes this bug by removing the uncorrected prefix before adding the corrected version.
    
Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>
