### PR TITLE
*: Use a `struct prefix *p` instead of a `struct prefix` in functions

### DIFF
--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -1077,7 +1077,7 @@ static int lsp_to_subnet_cb(const struct prefix *prefix, uint32_t metric,
 		prefix_copy(&p, prefix);
 	else {
 		/* Remove old subnet if any before prefix adjustment */
-		subnet = ls_find_subnet(args->ted, *prefix);
+		subnet = ls_find_subnet(args->ted, prefix);
 		if (subnet) {
 			if (args->export) {
 				subnet->status = DELETE;
@@ -1092,10 +1092,10 @@ static int lsp_to_subnet_cb(const struct prefix *prefix, uint32_t metric,
 	}
 
 	/* Search existing Subnet in TED ... */
-	subnet = ls_find_subnet(args->ted, p);
+	subnet = ls_find_subnet(args->ted, &p);
 	/* ... and create a new Subnet if not found */
 	if (!subnet) {
-		ls_pref = ls_prefix_new(vertex->node->adv, p);
+		ls_pref = ls_prefix_new(vertex->node->adv, &p);
 		subnet = ls_subnet_add(args->ted, ls_pref);
 		/* Stop processing if we are unable to create a new subnet */
 		if (!subnet)
@@ -1835,7 +1835,7 @@ static int show_ted(struct vty *vty, struct cmd_token *argv[], int argc,
 				return CMD_WARNING_CONFIG_FAILED;
 			}
 			/* Get the Subnet from the Link State Database */
-			subnet = ls_find_subnet(ted, pref);
+			subnet = ls_find_subnet(ted, &pref);
 			if (!subnet) {
 				vty_out(vty, "No subnet found for ID %pFX\n",
 					&pref);
@@ -1848,7 +1848,7 @@ static int show_ted(struct vty *vty, struct cmd_token *argv[], int argc,
 				return CMD_WARNING_CONFIG_FAILED;
 			}
 			/* Get the Subnet from the Link State Database */
-			subnet = ls_find_subnet(ted, pref);
+			subnet = ls_find_subnet(ted, &pref);
 			if (!subnet) {
 				vty_out(vty, "No subnet found for ID %pFX\n",
 					&pref);

--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -333,7 +333,7 @@ int ls_attributes_same(struct ls_attributes *l1, struct ls_attributes *l2)
 /**
  *  Link State prefix management functions
  */
-struct ls_prefix *ls_prefix_new(struct ls_node_id adv, struct prefix p)
+struct ls_prefix *ls_prefix_new(struct ls_node_id adv, struct prefix *p)
 {
 	struct ls_prefix *new;
 
@@ -342,7 +342,7 @@ struct ls_prefix *ls_prefix_new(struct ls_node_id adv, struct prefix p)
 
 	new = XCALLOC(MTYPE_LS_DB, sizeof(struct ls_prefix));
 	new->adv = adv;
-	new->pref = p;
+	new->pref = *p;
 
 	return new;
 }
@@ -889,7 +889,7 @@ struct ls_subnet *ls_subnet_update(struct ls_ted *ted, struct ls_prefix *pref)
 	if (pref == NULL)
 		return NULL;
 
-	old = ls_find_subnet(ted, pref->pref);
+	old = ls_find_subnet(ted, &pref->pref);
 	if (old) {
 		if (!ls_prefix_same(old->ls_pref, pref)) {
 			ls_prefix_del(old->ls_pref);
@@ -942,11 +942,12 @@ void ls_subnet_del_all(struct ls_ted *ted, struct ls_subnet *subnet)
 	ls_subnet_del(ted, subnet);
 }
 
-struct ls_subnet *ls_find_subnet(struct ls_ted *ted, const struct prefix prefix)
+struct ls_subnet *ls_find_subnet(struct ls_ted *ted,
+				 const struct prefix *prefix)
 {
 	struct ls_subnet subnet = {};
 
-	subnet.key = prefix;
+	subnet.key = *prefix;
 	return subnets_find(&ted->subnets, &subnet);
 }
 
@@ -1846,7 +1847,7 @@ struct ls_subnet *ls_msg2subnet(struct ls_ted *ted, struct ls_message *msg,
 			subnet->status = UPDATE;
 		break;
 	case LS_MSG_EVENT_DELETE:
-		subnet = ls_find_subnet(ted, pref->pref);
+		subnet = ls_find_subnet(ted, &pref->pref);
 		if (subnet) {
 			if (delete)
 				ls_subnet_del_all(ted, subnet);

--- a/lib/link_state.h
+++ b/lib/link_state.h
@@ -314,7 +314,7 @@ extern int ls_attributes_same(struct ls_attributes *a1,
  *
  * @return	New Link State Prefix
  */
-extern struct ls_prefix *ls_prefix_new(struct ls_node_id adv, struct prefix p);
+extern struct ls_prefix *ls_prefix_new(struct ls_node_id adv, struct prefix *p);
 
 /**
  * Remove Link State Prefix. Data Structure is freed.
@@ -709,7 +709,7 @@ extern void ls_subnet_del_all(struct ls_ted *ted, struct ls_subnet *subnet);
  * @return		Subnet if found, NULL otherwise
  */
 extern struct ls_subnet *ls_find_subnet(struct ls_ted *ted,
-					const struct prefix prefix);
+					const struct prefix *prefix);
 
 /**
  * Create a new Link State Data Base.

--- a/pathd/path_ted.c
+++ b/pathd/path_ted.c
@@ -268,7 +268,7 @@ uint32_t path_ted_query_type_c(struct prefix *prefix, uint8_t algo)
 	switch (prefix->family) {
 	case AF_INET:
 	case AF_INET6:
-		subnet = ls_find_subnet(ted_state_g.ted, *prefix);
+		subnet = ls_find_subnet(ted_state_g.ted, prefix);
 		if (subnet) {
 			if ((CHECK_FLAG(subnet->ls_pref->flags, LS_PREF_SR))
 			    && (subnet->ls_pref->sr.algo == algo))
@@ -298,7 +298,7 @@ uint32_t path_ted_query_type_e(struct prefix *prefix, uint32_t iface_id)
 	switch (prefix->family) {
 	case AF_INET:
 	case AF_INET6:
-		subnet = ls_find_subnet(ted_state_g.ted, *prefix);
+		subnet = ls_find_subnet(ted_state_g.ted, prefix);
 		if (subnet && subnet->vertex
 		    && subnet->vertex->outgoing_edges) {
 			/* from the vertex linked in subnet */

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -1059,7 +1059,7 @@ DEFUN (show_sharp_ted,
 				return CMD_WARNING_CONFIG_FAILED;
 			}
 			/* Get the Subnet from the Link State Database */
-			subnet = ls_find_subnet(sg.ted, pref);
+			subnet = ls_find_subnet(sg.ted, &pref);
 			if (!subnet) {
 				vty_out(vty, "No subnet found for ID %pFX\n",
 					&pref);


### PR DESCRIPTION
When passing a prefix into a function let's pass by address instead of pass by value.  Let's save our stack space.