### PR TITLE
ospfd: use rib metric as the base for set metric +/-

### DIFF
--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -305,10 +305,18 @@ Route Map Set Command
 
 .. clicmd:: set metric <[+|-](1-4294967295)|rtt|+rtt|-rtt>
 
-   Set the BGP attribute MED to a specific value. Use `+`/`-` to add or subtract
-   the specified value to/from the MED. Use `rtt` to set the MED to the round
-   trip time or `+rtt`/`-rtt` to add/subtract the round trip time to/from the
-   MED.
+   Set the route metric. When used with BGP, set the BGP attribute MED to a
+   specific value. Use `+`/`-` to add or subtract the specified value to/from
+   the existing/MED. Use `rtt` to set the MED to the round trip time or
+   `+rtt`/`-rtt` to add/subtract the round trip time to/from the MED.
+
+.. clicmd:: set min-metric <(0-4294967295)>
+
+   Set the minimum meric for the route.
+
+.. clicmd:: set max-metric <(0-4294967295)>
+
+   Set the maximum meric for the route.
 
 .. clicmd:: set aigp-metric <igp-metric|(1-4294967295)>
 

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -394,6 +394,40 @@ void route_map_no_set_metric_hook(int (*func)(struct route_map_index *index,
 {
 	rmap_match_set_hook.no_set_metric = func;
 }
+/* set min-metric */
+void route_map_set_min_metric_hook(int (*func)(struct route_map_index *index,
+					       const char *command,
+					       const char *arg, char *errmsg,
+					       size_t errmsg_len))
+{
+	rmap_match_set_hook.set_min_metric = func;
+}
+
+/* no set min-metric */
+void route_map_no_set_min_metric_hook(int (*func)(struct route_map_index *index,
+						  const char *command,
+						  const char *arg, char *errmsg,
+						  size_t errmsg_len))
+{
+	rmap_match_set_hook.no_set_min_metric = func;
+}
+/* set max-metric */
+void route_map_set_max_metric_hook(int (*func)(struct route_map_index *index,
+					       const char *command,
+					       const char *arg, char *errmsg,
+					       size_t errmsg_len))
+{
+	rmap_match_set_hook.set_max_metric = func;
+}
+
+/* no set max-metric */
+void route_map_no_set_max_metric_hook(int (*func)(struct route_map_index *index,
+						  const char *command,
+						  const char *arg, char *errmsg,
+						  size_t errmsg_len))
+{
+	rmap_match_set_hook.no_set_max_metric = func;
+}
 
 /* set tag */
 void route_map_set_tag_hook(int (*func)(struct route_map_index *index,

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -312,6 +312,8 @@ DECLARE_QOBJ_TYPE(route_map);
 	(strmatch(A, "frr-route-map:ipv6-next-hop"))
 #define IS_SET_METRIC(A)                                                       \
 	(strmatch(A, "frr-route-map:set-metric"))
+#define IS_SET_MIN_METRIC(A) (strmatch(A, "frr-route-map:set-min-metric"))
+#define IS_SET_MAX_METRIC(A) (strmatch(A, "frr-route-map:set-max-metric"))
 #define IS_SET_TAG(A) (strmatch(A, "frr-route-map:set-tag"))
 #define IS_SET_SR_TE_COLOR(A)                                                  \
 	(strmatch(A, "frr-route-map:set-sr-te-color"))
@@ -684,6 +686,22 @@ extern void route_map_no_set_metric_hook(
 	int (*func)(struct route_map_index *index,
 		    const char *command, const char *arg,
 		    char *errmsg, size_t errmsg_len));
+/* set metric */
+extern void route_map_set_max_metric_hook(
+	int (*func)(struct route_map_index *index, const char *command,
+		    const char *arg, char *errmsg, size_t errmsg_len));
+/* no set metric */
+extern void route_map_no_set_max_metric_hook(
+	int (*func)(struct route_map_index *index, const char *command,
+		    const char *arg, char *errmsg, size_t errmsg_len));
+/* set metric */
+extern void route_map_set_min_metric_hook(
+	int (*func)(struct route_map_index *index, const char *command,
+		    const char *arg, char *errmsg, size_t errmsg_len));
+/* no set metric */
+extern void route_map_no_set_min_metric_hook(
+	int (*func)(struct route_map_index *index, const char *command,
+		    const char *arg, char *errmsg, size_t errmsg_len));
 /* set tag */
 extern void route_map_set_tag_hook(int (*func)(struct route_map_index *index,
 					       const char *command,
@@ -920,6 +938,25 @@ struct route_map_match_set_hooks {
 	int (*no_set_metric)(struct route_map_index *index,
 			     const char *command, const char *arg,
 			     char *errmsg, size_t errmsg_len);
+	/* set min-metric */
+	int (*set_min_metric)(struct route_map_index *index,
+			      const char *command, const char *arg,
+			      char *errmsg, size_t errmsg_len);
+
+	/* no set min-metric */
+	int (*no_set_min_metric)(struct route_map_index *index,
+				 const char *command, const char *arg,
+				 char *errmsg, size_t errmsg_len);
+
+	/* set max-metric */
+	int (*set_max_metric)(struct route_map_index *index,
+			      const char *command, const char *arg,
+			      char *errmsg, size_t errmsg_len);
+
+	/* no set max-metric */
+	int (*no_set_max_metric)(struct route_map_index *index,
+				 const char *command, const char *arg,
+				 char *errmsg, size_t errmsg_len);
 
 	/* set tag */
 	int (*set_tag)(struct route_map_index *index,

--- a/lib/routemap_cli.c
+++ b/lib/routemap_cli.c
@@ -890,6 +890,76 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
+DEFPY_YANG(set_min_metric, set_min_metric_cmd,
+	   "set min-metric <(0-4294967295)$metric>",
+	   SET_STR
+	   "Minimum metric value for destination routing protocol\n"
+	   "Minimum metric value\n")
+{
+	const char *xpath =
+		"./set-action[action='frr-route-map:set-min-metric']";
+	char xpath_value[XPATH_MAXLEN];
+	char value[64];
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+
+	snprintf(xpath_value, sizeof(xpath_value),
+		 "%s/rmap-set-action/min-metric", xpath);
+	snprintf(value, sizeof(value), "%s", metric_str);
+
+	nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, value);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG(no_set_min_metric, no_set_min_metric_cmd,
+	   "no set min-metric [(0-4294967295)]",
+	   NO_STR SET_STR
+	   "Minimum metric value for destination routing protocol\n"
+	   "Minumum metric value\n")
+{
+	const char *xpath =
+		"./set-action[action='frr-route-map:set-min-metric']";
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG(set_max_metric, set_max_metric_cmd,
+	   "set max-metric <(0-4294967295)$metric>",
+	   SET_STR
+	   "Maximum metric value for destination routing protocol\n"
+	   "Miximum metric value\n")
+{
+	const char *xpath =
+		"./set-action[action='frr-route-map:set-max-metric']";
+	char xpath_value[XPATH_MAXLEN];
+	char value[64];
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+
+	snprintf(xpath_value, sizeof(xpath_value),
+		 "%s/rmap-set-action/max-metric", xpath);
+	snprintf(value, sizeof(value), "%s", metric_str);
+
+	nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, value);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG(no_set_max_metric, no_set_max_metric_cmd,
+	   "no set max-metric [(0-4294967295)]",
+	   NO_STR SET_STR
+	   "Maximum Metric value for destination routing protocol\n"
+	   "Maximum metric value\n")
+{
+	const char *xpath =
+		"./set-action[action='frr-route-map:set-max-metric']";
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
 DEFPY_YANG(
 	set_tag, set_tag_cmd,
 	"set tag (1-4294967295)$tag",
@@ -1011,6 +1081,14 @@ void route_map_action_show(struct vty *vty, const struct lyd_node *dnode,
 				yang_dnode_get_string(
 					dnode, "./rmap-set-action/value"));
 		}
+	} else if (IS_SET_MIN_METRIC(action)) {
+		vty_out(vty, " set min-metric %s\n",
+			yang_dnode_get_string(dnode,
+					      "./rmap-set-action/min-metric"));
+	} else if (IS_SET_MAX_METRIC(action)) {
+		vty_out(vty, " set max-metric %s\n",
+			yang_dnode_get_string(dnode,
+					      "./rmap-set-action/max-metric"));
 	} else if (IS_SET_TAG(action)) {
 		vty_out(vty, " set tag %s\n",
 			yang_dnode_get_string(dnode, "./rmap-set-action/tag"));
@@ -1550,6 +1628,12 @@ void route_map_cli_init(void)
 
 	install_element(RMAP_NODE, &set_metric_cmd);
 	install_element(RMAP_NODE, &no_set_metric_cmd);
+
+	install_element(RMAP_NODE, &set_min_metric_cmd);
+	install_element(RMAP_NODE, &no_set_min_metric_cmd);
+
+	install_element(RMAP_NODE, &set_max_metric_cmd);
+	install_element(RMAP_NODE, &no_set_max_metric_cmd);
 
 	install_element(RMAP_NODE, &set_tag_cmd);
 	install_element(RMAP_NODE, &no_set_tag_cmd);

--- a/lib/routemap_northbound.c
+++ b/lib/routemap_northbound.c
@@ -1028,6 +1028,110 @@ lib_route_map_entry_set_action_value_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
+ * XPath: /frr-route-map:lib/route-map/entry/set-action/min-metric
+ */
+static int set_action_min_metric_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource,
+					const char *value, char *errmsg,
+					size_t errmsg_len)
+{
+	struct routemap_hook_context *rhc;
+	int rv;
+
+	if (event != NB_EV_APPLY)
+		return NB_OK;
+
+	/* Check for hook function. */
+	if (rmap_match_set_hook.set_min_metric == NULL)
+		return NB_OK;
+
+	/* Add configuration. */
+	rhc = nb_running_get_entry(dnode, NULL, true);
+
+	/* Set destroy information. */
+	rhc->rhc_shook = rmap_match_set_hook.no_set_min_metric;
+	rhc->rhc_rule = "min-metric";
+
+	rv = rmap_match_set_hook.set_min_metric(rhc->rhc_rmi, "min-metric",
+						value, errmsg, errmsg_len);
+	if (rv != CMD_SUCCESS) {
+		rhc->rhc_shook = NULL;
+		return NB_ERR_INCONSISTENCY;
+	}
+
+	return NB_OK;
+}
+
+static int
+lib_route_map_entry_set_action_min_metric_modify(struct nb_cb_modify_args *args)
+{
+	const char *min_metric = yang_dnode_get_string(args->dnode, NULL);
+
+	return set_action_min_metric_modify(args->event, args->dnode,
+					    args->resource, min_metric,
+					    args->errmsg, args->errmsg_len);
+}
+
+static int lib_route_map_entry_set_action_min_metric_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	return lib_route_map_entry_set_destroy(args);
+}
+
+/*
+ * XPath: /frr-route-map:lib/route-map/entry/set-action/max-metric
+ */
+static int set_action_max_metric_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource,
+					const char *value, char *errmsg,
+					size_t errmsg_len)
+{
+	struct routemap_hook_context *rhc;
+	int rv;
+
+	if (event != NB_EV_APPLY)
+		return NB_OK;
+
+	/* Check for hook function. */
+	if (rmap_match_set_hook.set_max_metric == NULL)
+		return NB_OK;
+
+	/* Add configuration. */
+	rhc = nb_running_get_entry(dnode, NULL, true);
+
+	/* Set destroy information. */
+	rhc->rhc_shook = rmap_match_set_hook.no_set_max_metric;
+	rhc->rhc_rule = "max-metric";
+
+	rv = rmap_match_set_hook.set_max_metric(rhc->rhc_rmi, "max-metric",
+						value, errmsg, errmsg_len);
+	if (rv != CMD_SUCCESS) {
+		rhc->rhc_shook = NULL;
+		return NB_ERR_INCONSISTENCY;
+	}
+
+	return NB_OK;
+}
+
+static int
+lib_route_map_entry_set_action_max_metric_modify(struct nb_cb_modify_args *args)
+{
+	const char *max_metric = yang_dnode_get_string(args->dnode, NULL);
+
+	return set_action_max_metric_modify(args->event, args->dnode,
+					    args->resource, max_metric,
+					    args->errmsg, args->errmsg_len);
+}
+
+static int lib_route_map_entry_set_action_max_metric_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	return lib_route_map_entry_set_destroy(args);
+}
+
+/*
  * XPath: /frr-route-map:lib/route-map/entry/set-action/add-metric
  */
 static int
@@ -1366,6 +1470,20 @@ const struct frr_yang_module_info frr_route_map_info = {
 			.cbs = {
 				.modify = lib_route_map_entry_set_action_value_modify,
 				.destroy = lib_route_map_entry_set_action_value_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/set-action/rmap-set-action/min-metric",
+			.cbs = {
+				.modify = lib_route_map_entry_set_action_min_metric_modify,
+				.destroy = lib_route_map_entry_set_action_min_metric_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/set-action/rmap-set-action/max-metric",
+			.cbs = {
+				.modify = lib_route_map_entry_set_action_max_metric_modify,
+				.destroy = lib_route_map_entry_set_action_max_metric_destroy,
 			}
 		},
 		{

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -132,6 +132,8 @@ ospf_external_info_add(struct ospf *ospf, uint8_t type, unsigned short instance,
 	new->orig_tag = tag;
 	new->aggr_route = NULL;
 	new->metric = metric;
+	new->min_metric = 0;
+	new->max_metric = OSPF_LS_INFINITY;
 
 	/* we don't unlock rn from the get() because we're attaching the info */
 	if (rn)

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -94,7 +94,7 @@ int ospf_route_map_set_compare(struct route_map_set_values *values1,
 struct external_info *
 ospf_external_info_add(struct ospf *ospf, uint8_t type, unsigned short instance,
 		       struct prefix_ipv4 p, ifindex_t ifindex,
-		       struct in_addr nexthop, route_tag_t tag)
+		       struct in_addr nexthop, route_tag_t tag, uint32_t metric)
 {
 	struct external_info *new;
 	struct route_node *rn;
@@ -131,6 +131,7 @@ ospf_external_info_add(struct ospf *ospf, uint8_t type, unsigned short instance,
 	new->tag = tag;
 	new->orig_tag = tag;
 	new->aggr_route = NULL;
+	new->metric = metric;
 
 	/* we don't unlock rn from the get() because we're attaching the info */
 	if (rn)
@@ -138,9 +139,9 @@ ospf_external_info_add(struct ospf *ospf, uint8_t type, unsigned short instance,
 
 	if (IS_DEBUG_OSPF(lsa, LSA_GENERATE)) {
 		zlog_debug(
-			"Redistribute[%s][%u]: %pFX external info created, with NH %pI4",
+			"Redistribute[%s][%u]: %pFX external info created, with NH %pI4, metric:%u",
 			ospf_redist_string(type), ospf->vrf_id, &p,
-			&nexthop.s_addr);
+			&nexthop.s_addr, metric);
 	}
 	return new;
 }

--- a/ospfd/ospf_asbr.h
+++ b/ospfd/ospf_asbr.h
@@ -37,6 +37,8 @@ struct external_info {
 	route_tag_t orig_tag;
 
 	uint32_t metric;
+	uint32_t min_metric;
+	uint32_t max_metric;
 
 	struct route_map_set_values route_map_set;
 #define ROUTEMAP_METRIC(E) (E)->route_map_set.metric

--- a/ospfd/ospf_asbr.h
+++ b/ospfd/ospf_asbr.h
@@ -36,6 +36,8 @@ struct external_info {
 	/* Actual tag received from zebra*/
 	route_tag_t orig_tag;
 
+	uint32_t metric;
+
 	struct route_map_set_values route_map_set;
 #define ROUTEMAP_METRIC(E) (E)->route_map_set.metric
 #define ROUTEMAP_METRIC_TYPE(E) (E)->route_map_set.metric_type
@@ -99,11 +101,10 @@ extern struct external_info *ospf_external_info_new(struct ospf *, uint8_t,
 extern void ospf_reset_route_map_set_values(struct route_map_set_values *);
 extern int ospf_route_map_set_compare(struct route_map_set_values *,
 				      struct route_map_set_values *);
-extern struct external_info *ospf_external_info_add(struct ospf *, uint8_t,
-						    unsigned short,
-						    struct prefix_ipv4,
-						    ifindex_t, struct in_addr,
-						    route_tag_t);
+extern struct external_info *
+ospf_external_info_add(struct ospf *, uint8_t, unsigned short,
+		       struct prefix_ipv4, ifindex_t, struct in_addr,
+		       route_tag_t, uint32_t metric);
 extern void ospf_external_info_delete(struct ospf *, uint8_t, unsigned short,
 				      struct prefix_ipv4);
 extern struct external_info *ospf_external_info_lookup(struct ospf *, uint8_t,

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -159,7 +159,9 @@ ospf_ase_calculate_new_route(struct ospf_lsa *lsa,
 
 	if (!IS_EXTERNAL_METRIC(al->e[0].tos)) {
 		if (IS_DEBUG_OSPF(lsa, LSA))
-			zlog_debug("Route[External]: type-1 created.");
+			zlog_debug(
+				"Route[External]: type-1 created, asbr cost:%d  metric:%d.",
+				asbr_route->cost, metric);
 		new->path_type = OSPF_PATH_TYPE1_EXTERNAL;
 		new->cost = asbr_route->cost + metric; /* X + Y */
 	} else {

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -1975,6 +1975,9 @@ static struct ospf_lsa *ospf_lsa_translated_nssa_new(struct ospf *ospf,
 	ei.nexthop = ext->header.adv_router;
 	ei.route_map_set.metric = -1;
 	ei.route_map_set.metric_type = -1;
+	ei.metric = DEFAULT_DEFAULT_METRIC;
+	ei.max_metric = OSPF_LS_INFINITY;
+	ei.min_metric = 0;
 	ei.tag = 0;
 	ei.instance = 0;
 

--- a/ospfd/ospf_routemap.c
+++ b/ospfd/ospf_routemap.c
@@ -398,7 +398,7 @@ route_set_metric(void *rule, const struct prefix *prefix, void *object)
 	if (!metric->used)
 		return RMAP_OKAY;
 
-	ei->route_map_set.metric = DEFAULT_DEFAULT_METRIC;
+	ei->route_map_set.metric = ei->metric;
 
 	if (metric->type == metric_increment)
 		ei->route_map_set.metric += metric->metric;

--- a/ospfd/ospf_routemap.c
+++ b/ospfd/ospf_routemap.c
@@ -398,17 +398,19 @@ route_set_metric(void *rule, const struct prefix *prefix, void *object)
 	if (!metric->used)
 		return RMAP_OKAY;
 
-	ei->route_map_set.metric = ei->metric;
+	ROUTEMAP_METRIC(ei) = ei->metric;
 
 	if (metric->type == metric_increment)
-		ei->route_map_set.metric += metric->metric;
+		ROUTEMAP_METRIC(ei) += metric->metric;
 	else if (metric->type == metric_decrement)
-		ei->route_map_set.metric -= metric->metric;
+		ROUTEMAP_METRIC(ei) -= metric->metric;
 	else if (metric->type == metric_absolute)
-		ei->route_map_set.metric = metric->metric;
+		ROUTEMAP_METRIC(ei) = metric->metric;
 
-	if (ei->route_map_set.metric > OSPF_LS_INFINITY)
-		ei->route_map_set.metric = OSPF_LS_INFINITY;
+	if ((uint32_t)ROUTEMAP_METRIC(ei) < ei->min_metric)
+		ROUTEMAP_METRIC(ei) = ei->min_metric;
+	if ((uint32_t)ROUTEMAP_METRIC(ei) > ei->max_metric)
+		ROUTEMAP_METRIC(ei) = ei->max_metric;
 
 	return RMAP_OKAY;
 }
@@ -462,6 +464,115 @@ static const struct route_map_rule_cmd route_set_metric_cmd = {
 	route_set_metric_free,
 };
 
+/* `set min-metric METRIC' */
+/* Set min-metric to attribute. */
+static enum route_map_cmd_result_t
+route_set_min_metric(void *rule, const struct prefix *prefix, void *object)
+{
+	uint32_t *min_metric;
+	struct external_info *ei;
+
+	/* Fetch routemap's rule information. */
+	min_metric = rule;
+	ei = object;
+
+	ei->min_metric = *min_metric;
+
+	if (ei->min_metric > OSPF_LS_INFINITY)
+		ei->min_metric = OSPF_LS_INFINITY;
+
+	if ((uint32_t)ROUTEMAP_METRIC(ei) < ei->min_metric)
+		ROUTEMAP_METRIC(ei) = ei->min_metric;
+
+	return RMAP_OKAY;
+}
+
+/* set min-metric compilation. */
+static void *route_set_min_metric_compile(const char *arg)
+{
+
+	uint32_t *min_metric;
+
+	min_metric = XCALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(uint32_t));
+
+	*min_metric = strtoul(arg, NULL, 10);
+
+	if (*min_metric)
+		return min_metric;
+
+	XFREE(MTYPE_ROUTE_MAP_COMPILED, min_metric);
+	return NULL;
+}
+
+/* Free route map's compiled `set min-metric' value. */
+static void route_set_min_metric_free(void *rule)
+{
+	XFREE(MTYPE_ROUTE_MAP_COMPILED, rule);
+}
+
+/* Set metric rule structure. */
+static const struct route_map_rule_cmd route_set_min_metric_cmd = {
+	"min-metric",
+	route_set_min_metric,
+	route_set_min_metric_compile,
+	route_set_min_metric_free,
+};
+
+
+/* `set max-metric METRIC' */
+/* Set max-metric to attribute. */
+static enum route_map_cmd_result_t
+route_set_max_metric(void *rule, const struct prefix *prefix, void *object)
+{
+	uint32_t *max_metric;
+	struct external_info *ei;
+
+	/* Fetch routemap's rule information. */
+	max_metric = rule;
+	ei = object;
+
+	ei->max_metric = *max_metric;
+
+	if (ei->max_metric > OSPF_LS_INFINITY)
+		ei->max_metric = OSPF_LS_INFINITY;
+
+	if ((uint32_t)ROUTEMAP_METRIC(ei) > ei->max_metric)
+		ROUTEMAP_METRIC(ei) = ei->max_metric;
+
+	return RMAP_OKAY;
+}
+
+/* set max-metric compilation. */
+static void *route_set_max_metric_compile(const char *arg)
+{
+
+	uint32_t *max_metric;
+
+	max_metric = XCALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(uint32_t));
+
+	*max_metric = strtoul(arg, NULL, 10);
+
+	if (*max_metric)
+		return max_metric;
+
+	XFREE(MTYPE_ROUTE_MAP_COMPILED, max_metric);
+	return NULL;
+}
+
+/* Free route map's compiled `set max-metric' value. */
+static void route_set_max_metric_free(void *rule)
+{
+	XFREE(MTYPE_ROUTE_MAP_COMPILED, rule);
+}
+
+/* Set metric rule structure. */
+static const struct route_map_rule_cmd route_set_max_metric_cmd = {
+	"max-metric",
+	route_set_max_metric,
+	route_set_max_metric_compile,
+	route_set_max_metric_free,
+};
+
 /* `set metric-type TYPE' */
 /* Set metric-type to attribute. */
 static enum route_map_cmd_result_t
@@ -475,7 +586,7 @@ route_set_metric_type(void *rule, const struct prefix *prefix, void *object)
 	ei = object;
 
 	/* Set metric out value. */
-	ei->route_map_set.metric_type = *metric_type;
+	ROUTEMAP_METRIC_TYPE(ei) = *metric_type;
 
 	return RMAP_OKAY;
 }
@@ -582,9 +693,6 @@ void ospf_route_map_init(void)
 	route_map_delete_hook(ospf_route_map_update);
 	route_map_event_hook(ospf_route_map_event);
 
-	route_map_set_metric_hook(generic_set_add);
-	route_map_no_set_metric_hook(generic_set_delete);
-
 	route_map_match_ip_next_hop_hook(generic_match_add);
 	route_map_no_match_ip_next_hop_hook(generic_match_delete);
 
@@ -609,6 +717,12 @@ void ospf_route_map_init(void)
 	route_map_set_metric_hook(generic_set_add);
 	route_map_no_set_metric_hook(generic_set_delete);
 
+	route_map_set_min_metric_hook(generic_set_add);
+	route_map_no_set_min_metric_hook(generic_set_delete);
+
+	route_map_set_max_metric_hook(generic_set_add);
+	route_map_no_set_max_metric_hook(generic_set_delete);
+
 	route_map_set_tag_hook(generic_set_add);
 	route_map_no_set_tag_hook(generic_set_delete);
 
@@ -621,6 +735,8 @@ void ospf_route_map_init(void)
 	route_map_install_match(&route_match_tag_cmd);
 
 	route_map_install_set(&route_set_metric_cmd);
+	route_map_install_set(&route_set_min_metric_cmd);
+	route_map_install_set(&route_set_max_metric_cmd);
 	route_map_install_set(&route_set_metric_type_cmd);
 	route_map_install_set(&route_set_tag_cmd);
 

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -956,8 +956,8 @@ int ospf_redistribute_default_set(struct ospf *ospf, int originate, int mtype,
 		type_str = "always";
 		ospf->redistribute++;
 		ospf_external_add(ospf, DEFAULT_ROUTE, 0);
-		ospf_external_info_add(ospf, DEFAULT_ROUTE, 0, p, 0, nexthop,
-				       0);
+		ospf_external_info_add(ospf, DEFAULT_ROUTE, 0, p, 0, nexthop, 0,
+				       DEFAULT_DEFAULT_METRIC);
 		break;
 	}
 
@@ -1303,9 +1303,11 @@ static int ospf_zebra_read_route(ZAPI_CALLBACK_ARGS)
 		rt_type = DEFAULT_ROUTE;
 
 	if (IS_DEBUG_OSPF(zebra, ZEBRA_REDISTRIBUTE))
-		zlog_debug("%s: cmd %s from client %s: vrf_id %d, p %pFX",
-			   __func__, zserv_command_string(cmd),
-			   zebra_route_string(api.type), vrf_id, &api.prefix);
+		zlog_debug(
+			"%s: cmd %s from client %s: vrf_id %d, p %pFX, metric %d",
+			__func__, zserv_command_string(cmd),
+			zebra_route_string(api.type), vrf_id, &api.prefix,
+			api.metric);
 
 	if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD) {
 		/* XXX|HACK|TODO|FIXME:
@@ -1332,7 +1334,8 @@ static int ospf_zebra_read_route(ZAPI_CALLBACK_ARGS)
 							  p);
 
 		ei = ospf_external_info_add(ospf, rt_type, api.instance, p,
-					    ifindex, nexthop, api.tag);
+					    ifindex, nexthop, api.tag,
+					    api.metric);
 		if (ei == NULL) {
 			/* Nothing has changed, so nothing to do; return */
 			return 0;

--- a/tests/topotests/ospf_metric_propagation/h1/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/h1/frr.conf
@@ -1,0 +1,10 @@
+!
+hostname h1
+password zebra
+log file /tmp/h1-frr.log
+!
+ip route 0.0.0.0/0 10.0.91.1
+!
+interface h1-eth0
+ ip address 10.0.91.2/24
+!

--- a/tests/topotests/ospf_metric_propagation/h2/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/h2/frr.conf
@@ -1,0 +1,10 @@
+!
+hostname h2
+password zebra
+log file /tmp/h2-frr.log
+!
+ip route 0.0.0.0/0 10.0.94.4
+!
+interface h2-eth0
+ ip address 10.0.94.2/24
+!

--- a/tests/topotests/ospf_metric_propagation/r1/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/r1/frr.conf
@@ -1,0 +1,96 @@
+!
+hostname r1
+password zebra
+log file /tmp/r1-frr.log
+ip forwarding
+!
+interface r1-eth0
+ ip address 10.0.1.1/24
+ ip ospf cost 100
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+interface r1-eth1 vrf blue
+ ip address 10.0.10.1/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+!
+interface r1-eth2 vrf green
+ ip address 10.0.91.1/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+!
+router ospf
+  ospf router-id 10.0.255.1
+  distance 20
+  redistribute bgp route-map costplus
+  network 10.0.1.0/24 area 0
+!
+router ospf vrf blue
+  ospf router-id 10.0.255.1
+  distance 20
+  redistribute bgp route-map costplus
+  network 10.0.10.0/24 area 0
+!
+router ospf vrf green
+  ospf router-id 10.0.255.1
+    distance 20
+  redistribute bgp route-map costplus
+  network 10.0.91.0/24 area 0
+!
+router bgp 99
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf route-map rmap
+    import vrf route-map rmap
+    import vrf blue
+    import vrf green
+  !
+!
+router bgp 99 vrf blue
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf route-map rmap
+    import vrf route-map rmap
+    import vrf default
+    import vrf green
+  !
+router bgp 99 vrf green
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf
+    import vrf route-map rmap
+    import vrf default
+    import vrf blue
+  !
+!
+route-map rmap permit 10
+  set metric-type type-1
+  set metric +1
+  exit
+!
+ip prefix-list min seq 5 permit 10.0.80.0/24
+route-map costmax permit 20
+  set metric-type type-1
+  set metric +1
+  set metric-min 713
+  match ip address prefix-list min
+  exit
+!
+ip prefix-list max seq 10 permit 10.0.70.0/24
+route-map costplus permit 30
+  set metric-type type-1
+  set metric +1
+  set metric-max 13
+  match ip address prefix-list max
+  exit
+!
+route-map costplus permit 40
+  set metric-type type-1
+  set metric +1
+  exit

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-1.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-1.json
@@ -1,0 +1,37 @@
+{
+  "10.0.94.0/24":[
+    {
+      "prefix":"10.0.94.0/24",
+      "prefixLen":24,
+      "protocol":"bgp",
+      "vrfId":9,
+      "vrfName":"green",
+      "selected":true,
+      "destSelected":true,
+      "distance":20,
+      "metric":34,
+      "installed":true,
+      "table":12,
+      "internalStatus":16,
+      "internalFlags":8,
+      "internalNextHopNum":1,
+      "internalNextHopActiveNum":1,
+      "nexthopGroupId":"*",
+      "installedNexthopGroupId":"*",
+      "uptime":"*",
+      "nexthops":[
+        {
+          "flags":3,
+          "fib":true,
+          "ip":"10.0.10.5",
+          "afi":"ipv4",
+          "interfaceIndex":6,
+          "interfaceName":"r1-eth1",
+          "vrf":"blue",
+          "active":true,
+          "weight":1
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-2.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-2.json
@@ -1,0 +1,37 @@
+{
+  "10.0.94.0/24":[
+    {
+      "prefix":"10.0.94.0/24",
+      "prefixLen":24,
+      "protocol":"bgp",
+      "vrfId":9,
+      "vrfName":"green",
+      "selected":true,
+      "destSelected":true,
+      "distance":20,
+      "metric":136,
+      "installed":true,
+      "table":12,
+      "internalStatus":16,
+      "internalFlags":8,
+      "internalNextHopNum":1,
+      "internalNextHopActiveNum":1,
+      "nexthopGroupId":"*",
+      "installedNexthopGroupId":"*",
+      "uptime":"*",
+      "nexthops":[
+        {
+          "flags":3,
+          "fib":true,
+          "ip":"10.0.1.2",
+          "afi":"ipv4",
+          "interfaceIndex":5,
+          "interfaceName":"r1-eth0",
+          "vrf":"default",
+          "active":true,
+          "weight":1
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-3.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-3.json
@@ -1,0 +1,37 @@
+{
+  "10.0.94.0/24":[
+    {
+      "prefix":"10.0.94.0/24",
+      "prefixLen":24,
+      "protocol":"bgp",
+      "vrfId":9,
+      "vrfName":"green",
+      "selected":true,
+      "destSelected":true,
+      "distance":20,
+      "metric":1138,
+      "installed":true,
+      "table":12,
+      "internalStatus":16,
+      "internalFlags":8,
+      "internalNextHopNum":1,
+      "internalNextHopActiveNum":1,
+      "nexthopGroupId":"*",
+      "installedNexthopGroupId":"*",
+      "uptime":"*",
+      "nexthops":[
+        {
+          "flags":3,
+          "fib":true,
+          "ip":"10.0.1.2",
+          "afi":"ipv4",
+          "interfaceIndex":5,
+          "interfaceName":"r1-eth0",
+          "vrf":"default",
+          "active":true,
+          "weight":1
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-4.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-4.json
@@ -1,0 +1,37 @@
+{
+  "10.0.94.0/24":[
+    {
+      "prefix":"10.0.94.0/24",
+      "prefixLen":24,
+      "protocol":"bgp",
+      "vrfId":9,
+      "vrfName":"green",
+      "selected":true,
+      "destSelected":true,
+      "distance":20,
+      "metric":1218,
+      "installed":true,
+      "table":12,
+      "internalStatus":16,
+      "internalFlags":8,
+      "internalNextHopNum":1,
+      "internalNextHopActiveNum":1,
+      "nexthopGroupId":"*",
+      "installedNexthopGroupId":"*",
+      "uptime":"*",
+      "nexthops":[
+        {
+          "flags":3,
+          "fib":true,
+          "ip":"10.0.1.2",
+          "afi":"ipv4",
+          "interfaceIndex":5,
+          "interfaceName":"r1-eth0",
+          "vrf":"default",
+          "active":true,
+          "weight":1
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-5.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-5.json
@@ -1,0 +1,37 @@
+{
+  "10.0.94.0/24":[
+    {
+      "prefix":"10.0.94.0/24",
+      "prefixLen":24,
+      "protocol":"bgp",
+      "vrfId":9,
+      "vrfName":"green",
+      "selected":true,
+      "destSelected":true,
+      "distance":20,
+      "metric":238,
+      "installed":true,
+      "table":12,
+      "internalStatus":16,
+      "internalFlags":8,
+      "internalNextHopNum":1,
+      "internalNextHopActiveNum":1,
+      "nexthopGroupId":"*",
+      "installedNexthopGroupId":"*",
+      "uptime":"*",
+      "nexthops":[
+        {
+          "flags":3,
+          "fib":true,
+          "ip":"10.0.1.2",
+          "afi":"ipv4",
+          "interfaceIndex":5,
+          "interfaceName":"r1-eth0",
+          "vrf":"default",
+          "active":true,
+          "weight":1
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-6.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-6.json
@@ -1,0 +1,37 @@
+{
+  "10.0.94.0/24":[
+    {
+      "prefix":"10.0.94.0/24",
+      "prefixLen":24,
+      "protocol":"bgp",
+      "vrfId":9,
+      "vrfName":"green",
+      "selected":true,
+      "destSelected":true,
+      "distance":20,
+      "metric":136,
+      "installed":true,
+      "table":12,
+      "internalStatus":16,
+      "internalFlags":8,
+      "internalNextHopNum":1,
+      "internalNextHopActiveNum":1,
+      "nexthopGroupId":"*",
+      "installedNexthopGroupId":"*",
+      "uptime":"*",
+      "nexthops":[
+        {
+          "flags":3,
+          "fib":true,
+          "ip":"10.0.10.5",
+          "afi":"ipv4",
+          "interfaceIndex":6,
+          "interfaceName":"r1-eth1",
+          "vrf":"blue",
+          "active":true,
+          "weight":1
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/ospf_metric_propagation/r2/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/r2/frr.conf
@@ -1,0 +1,81 @@
+!
+hostname r2
+password zebra
+log file /tmp/r2-frr.log
+ip forwarding
+!
+interface r2-eth0
+ ip address 10.0.1.2/24
+ ip ospf cost 100
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+interface r2-eth1 vrf blue
+ ip address 10.0.20.2/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+interface r2-eth2 vrf green
+ ip address 10.0.70.2/24
+ ip ospf cost 1000
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+router ospf
+  ospf router-id 10.0.255.2
+  distance 20
+  redistribute bgp route-map costplus
+  network 10.0.1.0/24 area 0
+!
+router ospf vrf blue
+  ospf router-id 10.0.255.2
+  distance 20
+  redistribute bgp route-map costplus
+  network 10.0.20.0/24 area 0
+!
+
+router ospf vrf green
+  ospf router-id 10.0.255.2
+  distance 20
+  redistribute bgp route-map costplus
+  network 10.0.70.0/24 area 0
+!
+
+router bgp 99
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf
+    import vrf route-map rmap
+    import vrf blue
+    import vrf green
+  !
+!
+router bgp 99 vrf blue
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf
+    import vrf route-map rmap
+    import vrf default
+    import vrf green
+  !
+router bgp 99 vrf green
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf
+    import vrf route-map rmap
+    import vrf default
+    import vrf blue
+  !
+!
+route-map rmap permit 10
+  set metric-type type-1
+  set metric +1
+  exit
+!
+route-map costplus permit 1
+  set metric-type type-1
+  set metric +1
+  exit

--- a/tests/topotests/ospf_metric_propagation/r3/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/r3/frr.conf
@@ -1,0 +1,79 @@
+!
+hostname r3
+password zebra
+log file /tmp/r3-frr.log
+ip forwarding
+!
+interface r3-eth0
+ ip address 10.0.3.3/24
+ ip ospf cost 100
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+interface r3-eth1 vrf blue
+ ip address 10.0.30.3/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+interface r3-eth2 vrf green
+ ip address 10.0.80.3/24
+ ip ospf cost 1000
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+router ospf
+  ospf router-id 10.0.255.3
+  distance 20
+  redistribute bgp route-map costplus
+  network 10.0.3.0/24 area 0
+!
+router ospf vrf blue
+  ospf router-id 10.0.255.3
+  distance 20
+  redistribute bgp route-map costplus
+  network 10.0.30.0/24 area 0
+!
+router ospf vrf green
+  ospf router-id 10.0.255.3
+  distance 20
+  redistribute bgp route-map costplus
+  network 10.0.80.0/24 area 0
+!
+router bgp 99
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf
+    import vrf route-map rmap
+    import vrf blue
+    import vrf green
+  !
+!
+router bgp 99 vrf blue
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf
+    import vrf route-map rmap
+    import vrf default
+    import vrf green
+  !
+router bgp 99 vrf green
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf
+    import vrf route-map rmap
+    import vrf default
+    import vrf blue
+  !
+!
+route-map rmap permit 10
+  set metric-type type-1
+  set metric +1
+  exit
+!
+route-map costplus permit 1
+  set metric-type type-1
+  set metric +1
+  exit

--- a/tests/topotests/ospf_metric_propagation/r4/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/r4/frr.conf
@@ -1,0 +1,78 @@
+!
+hostname r4
+password zebra
+log file /tmp/r4-frr.log
+ip forwarding
+!
+interface r4-eth0
+ ip address 10.0.3.4/24
+ ip ospf cost 100
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+interface r4-eth1 vrf blue
+ ip address 10.0.40.4/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+interface r4-eth2 vrf green
+ ip address 10.0.94.4/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+router ospf
+  ospf router-id 10.0.255.4
+  distance 20
+  redistribute bgp route-map costplus
+  network 10.0.3.0/24 area 0
+!
+router ospf vrf blue
+  ospf router-id 10.0.255.4
+  distance 20
+  redistribute bgp route-map costplus
+  network 10.0.40.0/24 area 0
+!
+router ospf vrf green
+  ospf router-id 10.0.255.1
+  distance 20
+  redistribute bgp route-map costplus
+  network 10.0.94.0/24 area 0
+!
+router bgp 99
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf route-map costplus
+    import vrf route-map rmap
+    import vrf blue
+    import vrf green
+  !
+!
+router bgp 99 vrf blue
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf
+    import vrf route-map rmap
+    import vrf default
+    import vrf green
+  !
+router bgp 99 vrf green
+  no bgp ebgp-requires-policy
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute ospf
+    import vrf route-map rmap
+    import vrf default
+    import vrf blue
+  !
+!
+route-map rmap permit 10
+  set metric-type type-1
+  set metric +1
+  exit
+!
+route-map costplus permit 1
+  set metric-type type-1
+  set metric +1
+  exit

--- a/tests/topotests/ospf_metric_propagation/ra/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/ra/frr.conf
@@ -1,0 +1,27 @@
+!
+hostname ra
+password zebra
+log file /tmp/ra-frr.log
+ip forwarding
+!
+interface ra-eth0
+ ip address 10.0.50.5/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+interface ra-eth1
+ ip address 10.0.10.5/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+interface ra-eth2
+ ip address 10.0.20.5/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+router ospf
+  ospf router-id 10.0.255.5
+  network 10.0.10.0/24 area 0
+  network 10.0.20.0/24 area 0
+  network 10.0.50.0/24 area 0
+!

--- a/tests/topotests/ospf_metric_propagation/rb/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/rb/frr.conf
@@ -1,0 +1,27 @@
+!
+hostname rb
+password zebra
+log file /tmp/rb-frr.log
+ip forwarding
+!
+interface rb-eth0
+ ip address 10.0.50.6/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+interface rb-eth1
+ ip address 10.0.30.6/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+interface rb-eth2
+ ip address 10.0.40.6/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+router ospf
+  ospf router-id 10.0.255.6
+  network 10.0.30.0/24 area 0
+  network 10.0.40.0/24 area 0
+  network 10.0.50.0/24 area 0
+!

--- a/tests/topotests/ospf_metric_propagation/rc/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/rc/frr.conf
@@ -1,0 +1,21 @@
+!
+hostname rc
+password zebra
+log file /tmp/rc-frr.log
+ip forwarding
+!
+interface rc-eth0
+ ip address 10.0.70.7/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+interface rc-eth1
+ ip address 10.0.80.7/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 3
+!
+router ospf
+  ospf router-id 10.0.255.7
+  network 10.0.70.0/24 area 0
+  network 10.0.80.0/24 area 0
+!

--- a/tests/topotests/ospf_metric_propagation/test_ospf_metric_propagation.py
+++ b/tests/topotests/ospf_metric_propagation/test_ospf_metric_propagation.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_ospf_metric_propagation.py
+#
+# Copyright (c) 2023 ATCorp
+# Jafar Al-Gharaibeh
+#
+
+import os
+import sys
+import json
+from time import sleep
+from functools import partial
+import pytest
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+
+"""
+test_ospf_metric_propagation.py: Test OSPF/BGP metric propagation
+"""
+
+TOPOLOGY = """
+                                      +-----+                           +-----+
+                                 eth1 |     |           eth0            |     | eth2
+                        +-------------+ rA  +---------------------------+ rB  +---------------+
+                        |          .5 |     | .5                     .6 |     | .6            |
+                        |             +--+--+     10.0.50.0/24          +--+--+ .6            |
+                        |                |.5                               |.6                |
+                        |            eth2|                             eth1|                  |
+                 10.0.10.0/24            |                                 |                  |
+                        |            10.0.20.0/24                   10.0.30.0/24          10.0.40.0/24
+                        |blue            |blue                             |blue              |blue
+                        |                |                                 |                  |
+                    eth1|.1          eth1|.2                           eth1|.3            eth1|.4
+    +-----+          +--+--+          +--+--+           +-----+          +-+---+            +-+---+         +------+
+    |     |eth0  eth2|     |   eth0   |     |eth2   eth1|     |eth2  eth3|     |   eth0     |     |eth2 eth0|      |
+    | h1  +----------+ R1  +----------+ R2  +-----------+ rC  +----------+ R3  +------------+ R4  +---------+ h2   |
+    |     |          |     |          |     |           |     |          |     |            |     |         |      |
+    +-----+.2     .1 +-----+.1      .2+-----+.2      .7 +-----+.7      .3+-----+.3        .4+-----+.4     .2+------+
+                  green                    green                      green                       green
+
+       10.0.91.0/24        10.0.1.0/24      10.0.70.0/24      10.0.80.0/24     10.0.3.0/24        10.0.94.0/24
+"""
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# Required to instantiate the topology builder class.
+
+pytestmark = [pytest.mark.ospfd, pytest.mark.bgpd]
+
+
+def build_topo(tgen):
+    "Build function"
+
+    # Create 4 routers
+    for routern in range(1, 5):
+        tgen.add_router("r{}".format(routern))
+
+    tgen.add_router("ra")
+    tgen.add_router("rb")
+    tgen.add_router("rc")
+    tgen.add_router("h1")
+    tgen.add_router("h2")
+
+
+    # Interconect router 1, 2
+    switch = tgen.add_switch("s1-2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # Interconect router 3, 4
+    switch = tgen.add_switch("s3-4")
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["r4"])
+
+    # Interconect router a, b
+    switch = tgen.add_switch("sa-b")
+    switch.add_link(tgen.gears["ra"])
+    switch.add_link(tgen.gears["rb"])
+
+    # Interconect router 1, a
+    switch = tgen.add_switch("s1-a")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["ra"])
+
+    # Interconect router 2, a
+    switch = tgen.add_switch("s2-a")
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["ra"])
+
+    # Interconect router 3, b
+    switch = tgen.add_switch("s3-b")
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["rb"])
+
+    # Interconect router 4, b
+    switch = tgen.add_switch("s4-b")
+    switch.add_link(tgen.gears["r4"])
+    switch.add_link(tgen.gears["rb"])
+
+    # Interconect router 1, h1
+    switch = tgen.add_switch("s1-h1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["h1"])
+
+    # Interconect router 4, h2
+    switch = tgen.add_switch("s4-h2")
+    switch.add_link(tgen.gears["r4"])
+    switch.add_link(tgen.gears["h2"])
+
+    # Interconect router 2, c
+    switch = tgen.add_switch("s2-c")
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["rc"])
+
+    # Interconect router 3, c
+    switch = tgen.add_switch("s3-c")
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["rc"])
+
+def setup_module(mod):
+    logger.info("OSPF Metric Propagation:\n {}".format(TOPOLOGY))
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    vrf_setup_cmds = [
+        "ip link add name blue type vrf table 11",
+        "ip link set dev blue up",
+        "ip link add name green type vrf table 12",
+        "ip link set dev green up",
+    ]
+
+    # Starting Routers
+    router_list = tgen.routers()
+
+    # Create VRFs and bind to interfaces
+    for routern in range(1, 5):
+        for cmd in vrf_setup_cmds:
+            tgen.net["r{}".format(routern)].cmd(cmd)
+    for routern in range(1, 5):
+        tgen.net["r{}".format(routern)].cmd("ip link set dev r{}-eth1 vrf blue up".format(routern))
+        tgen.net["r{}".format(routern)].cmd("ip link set dev r{}-eth2 vrf green up".format(routern))
+
+    for rname, router in router_list.items():
+        logger.info("Loading router %s" % rname)
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    # Initialize all routers.
+    tgen.start_router()
+    for router in router_list.values():
+        if router.has_version("<", "4.20"):
+            tgen.set_error("unsupported version")
+
+
+def teardown_module(mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_all_links_up():
+    "Test path R1 -> Ra -> Rb -> R4"
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    r1 = tgen.gears["r1"]
+    json_file = "{}/r1/show_ip_route-1.json".format(CWD)
+    expected = json.loads(open(json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route vrf green 10.0.94.2 json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=40, wait=1)
+
+    assertmsg = "r1 JSON output mismatches"
+    assert result is None, assertmsg
+
+
+def test_link_1_down():
+    "Test path R1 -> R2 -> Ra -> Rb -> R4"
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    tgen.net["r1"].cmd("ip link set dev r1-eth1 down")
+    r1 = tgen.gears["r1"]
+
+    json_file = "{}/r1/show_ip_route-2.json".format(CWD)
+    expected = json.loads(open(json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route vrf green 10.0.94.2 json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+
+    assertmsg = "r1 JSON output mismatches"
+    assert result is None, assertmsg
+
+
+def test_link_1_2_down():
+    "Test path R1 -> R2 -> Rc -> R3 -> Rb -> R4"
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    tgen.net["r2"].cmd("ip link set dev r2-eth1 down")
+    r1 = tgen.gears["r1"]
+
+    json_file = "{}/r1/show_ip_route-3.json".format(CWD)
+    expected = json.loads(open(json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route vrf green 10.0.94.2 json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+
+    assertmsg = "r1 JSON output mismatches"
+    assert result is None, assertmsg
+
+
+def test_link_1_2_3_down():
+    "Test path R1 -> R2 -> Rc -> R3  -> R4"
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    tgen.net["r3"].cmd("ip link set dev r3-eth0 down")
+    tgen.net["r3"].cmd("ip link set dev r3-eth1 down")
+    # ospf dead-interval is set to 3 seconds, wait 5 seconds to clear the neighbor
+    sleep(5)
+    tgen.net["r3"].cmd("ip link set dev r3-eth0 up")
+    r1 = tgen.gears["r1"]
+
+    json_file = "{}/r1/show_ip_route-4.json".format(CWD)
+    expected = json.loads(open(json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route vrf green 10.0.94.2 json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+
+    assertmsg = "r1 JSON output mismatches"
+    assert result is None, assertmsg
+
+def test_link_1_2_3_4_down():
+    "Test path R1 -> R2 -> Rc -> R3  -> R4"
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    tgen.net["r4"].cmd("ip link set dev r4-eth1 down")
+    r1 = tgen.gears["r1"]
+
+    json_file = "{}/r1/show_ip_route-4.json".format(CWD)
+    expected = json.loads(open(json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route vrf green 10.0.94.2 json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+
+    assertmsg = "r1 JSON output mismatches"
+    assert result is None, assertmsg
+
+def test_link_1_2_4_down():
+    "Test path R1 -> R2 -> Rc -> R3  -> R4"
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    # bring link 3 back up
+    tgen.net["r3"].cmd("ip link set dev r3-eth1 up")
+    r1 = tgen.gears["r1"]
+
+    json_file = "{}/r1/show_ip_route-4.json".format(CWD)
+    expected = json.loads(open(json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route vrf green 10.0.94.2 json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+
+    assertmsg = "r1 JSON output mismatches"
+    assert result is None, assertmsg
+
+def test_link_1_4_down():
+    "Test path R1 -> R2 -> Ra -> Rb -> R3  -> R4"
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    # bring back link 2 up
+    tgen.net["r2"].cmd("ip link set dev r2-eth1 up")
+    r1 = tgen.gears["r1"]
+
+    json_file = "{}/r1/show_ip_route-5.json".format(CWD)
+    expected = json.loads(open(json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route vrf green 10.0.94.2 json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+
+    assertmsg = "r1 JSON output mismatches"
+    assert result is None, assertmsg
+
+
+def test_link_4_down():
+    "Test path R1 -> Ra -> Rb -> R3  -> R4"
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    # bring back link 1 up
+    tgen.net["r1"].cmd("ip link set dev r1-eth1 up")
+    r1 = tgen.gears["r1"]
+
+    json_file = "{}/r1/show_ip_route-6.json".format(CWD)
+    expected = json.loads(open(json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route vrf green 10.0.94.2 json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+
+    assertmsg = "r1 JSON output mismatches"
+    assert result is None, assertmsg
+
+
+def test_link_1_2_3_4_up():
+    "Test path R1 -> Ra -> Rb -> R4"
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    # bring back link 4 up
+    tgen.net["r4"].cmd("ip link set dev r4-eth1 up")
+    r1 = tgen.gears["r1"]
+
+    json_file = "{}/r1/show_ip_route-1.json".format(CWD)
+    expected = json.loads(open(json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route vrf green 10.0.94.2 json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+
+    assertmsg = "r1 JSON output mismatches"
+    assert result is None, assertmsg
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-route-map.yang
+++ b/yang/frr-route-map.yang
@@ -160,6 +160,18 @@ module frr-route-map {
       "Set prefix/route metric";
   }
 
+  identity set-min-metric {
+    base rmap-set-type;
+    description
+      "Set minimum prefix/route metric";
+  }
+
+    identity set-max-metric {
+    base rmap-set-type;
+    description
+      "Set maximum prefix/route metric";
+  }
+
   identity set-tag {
     base rmap-set-type;
     description
@@ -346,6 +358,39 @@ module frr-route-map {
           }
         }
 
+        case set-min-metric {
+          when "derived-from-or-self(../action, 'set-min-metric')";
+          choice minimun-metric-value {
+            description
+              "Mimimum metric to set or use";
+            case min-metric {
+              leaf min-metric {
+                type uint32 {
+                  range "0..4294967295";
+                }
+                description
+                  "Use the following mimumn metric value";
+              }
+            }
+          }
+        }
+
+        case set-max-metric {
+          when "derived-from-or-self(../action, 'set-max-metric')";
+          choice maximum-metric-value {
+            description
+              "Maximum metric to set or use";
+            case max-metric {
+              leaf max-metric {
+                type uint32 {
+                  range "0..4294967295";
+                }
+                description
+                  "Use the following maximum metric value";
+              }
+            }
+          }
+        }
         case set-tag {
           when "derived-from-or-self(../action, 'set-tag')";
           leaf tag {


### PR DESCRIPTION
When using route maps with external routes in OSPF as follows:
```
   set metric +10
 ```
The current behavior is to use the default ospf metric as the base and then. and add to 10 to it.
The behavior isn't useful as-is and since a value 30 (20, the ospf default metric +10)  can be set
directly instead. the behavior is also not consistent with bgp for example where bgp does use the
rib metric in this case as the base. The current behavior also doesn't allow the metric to accumulate
when crossing different routing domains such as vrfs causing the metric to reset every time the
route enters a new vrf with a new ospf network.

This PR changes the behavior such so that the rib metric is as a base for external routes
when used with route maps set metric -/+

This PR also adds two new route map commands:
```
   set min-metric [0-4294967295]
   set max-metric [0-4294967295]
 ```
to set the minimum and the maximum metric for the route. 

