### PR TITLE
ospf,ospf6: fix json key typo supoort

### DIFF
--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -937,8 +937,18 @@ static void show_ospf6_gr_helper_details(struct vty *vty, struct ospf6 *ospf6,
 			(ospf6->ospf6_helper_cfg.strict_lsa_check)
 				? "Enabled"
 				: "Disabled");
+
+#if CONFDATE > 20240401
+		CPP_NOTICE("Remove deprecated json key: restartSupoort")
+#endif
 		json_object_string_add(
 			json, "restartSupoort",
+			(ospf6->ospf6_helper_cfg.only_planned_restart)
+				? "Planned Restart only"
+				: "Planned and Unplanned Restarts");
+
+		json_object_string_add(
+			json, "restartSupport",
 			(ospf6->ospf6_helper_cfg.only_planned_restart)
 				? "Planned Restart only"
 				: "Planned and Unplanned Restarts");

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -10080,8 +10080,17 @@ static int ospf_show_gr_helper_details(struct vty *vty, struct ospf *ospf,
 		json_object_string_add(json_vrf, "strictLsaCheck",
 				       (ospf->strict_lsa_check) ? "Enabled"
 								: "Disabled");
+#if CONFDATE > 20240401
+		CPP_NOTICE("Remove deprecated json key: restartSupoort")
+#endif
 		json_object_string_add(
 			json_vrf, "restartSupoort",
+			(ospf->only_planned_restart)
+				? "Planned Restart only"
+				: "Planned and Unplanned Restarts");
+
+		json_object_string_add(
+			json_vrf, "restartSupport",
 			(ospf->only_planned_restart)
 				? "Planned Restart only"
 				: "Planned and Unplanned Restarts");

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -2477,7 +2477,7 @@ def verify_ospf_gr_helper(tgen, topo, dut, input_dict=None):
     input_dict = {
                     "helperSupport":"Disabled",
                     "strictLsaCheck":"Enabled",
-                    "restartSupoort":"Planned and Unplanned Restarts",
+                    "restartSupport":"Planned and Unplanned Restarts",
                     "supportedGracePeriod":1800
                 }
     result = verify_ospf_gr_helper(tgen, topo, dut, input_dict)

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper1.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper1.py
@@ -188,7 +188,7 @@ def test_ospf_gr_helper_tc1_p0(request):
     input_dict = {
         "helperSupport": "Disabled",
         "strictLsaCheck": "Enabled",
-        "restartSupoort": "Planned and Unplanned Restarts",
+        "restartSupport": "Planned and Unplanned Restarts",
         "supportedGracePeriod": 1800,
     }
     dut = "r0"
@@ -220,7 +220,7 @@ def test_ospf_gr_helper_tc1_p0(request):
     input_dict = {
         "helperSupport": "Enabled",
         "strictLsaCheck": "Enabled",
-        "restartSupoort": "Planned and Unplanned Restarts",
+        "restartSupport": "Planned and Unplanned Restarts",
         "supportedGracePeriod": 1800,
     }
     dut = "r0"


### PR DESCRIPTION
Fix json key 'supoort' -> 'support'; add 1-year deprecation notice; fix topotests to use corrected json key.