### PR TITLE
isisd: Delay lsp generation to after non-integrated config processing is complete

### DIFF
--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -202,6 +202,18 @@ static void isis_config_end(void)
 	isis_config_finish(t_isis_cfg);
 }
 
+static int isis_config_fork_start(struct event_loop *tm)
+{
+	isis_config_start();
+	return 0;
+}
+
+static int isis_config_fork_end(struct event_loop *tm)
+{
+	isis_config_end();
+	return 0;
+}
+
 #ifdef FABRICD
 FRR_DAEMON_INFO(fabricd, OPEN_FABRIC, .vty_port = FABRICD_VTY_PORT,
 
@@ -266,6 +278,8 @@ int main(int argc, char **argv, char **envp)
 	 *  initializations
 	 */
 	cmd_init_config_callbacks(isis_config_start, isis_config_end);
+	hook_register(frr_config_pre, isis_config_fork_start);
+	hook_register(frr_config_post, isis_config_fork_end);
 	isis_error_init();
 	access_list_init();
 	access_list_add_hook(isis_filter_update);


### PR DESCRIPTION
(Reopen of #12924)
Before:
isisd generates its initial lsp before fully processing the written non-integrated config.

Ex: lsp_generate() is called in isis_instance_area_address_create(), before other configs that may affect the lsp are loaded in, like set-overload-bit.

After:
isisd generates its initial lsp as soon as the config is fully processed. This was done by passing isisd's existing config callbacks into the existing frr_config_pre/frr_config_post hooks so they can be called before and after the non-integrated config is processed.