### PR TITLE
ripd: Fix malformed route-map

### DIFF
--- a/lib/if_rmap.c
+++ b/lib/if_rmap.c
@@ -10,6 +10,7 @@
 #include "memory.h"
 #include "if.h"
 #include "if_rmap.h"
+#include "ripd/ripd.h"
 
 DEFINE_MTYPE_STATIC(LIB, IF_RMAP_CTX, "Interface route map container");
 DEFINE_MTYPE_STATIC(LIB, IF_RMAP_CTX_NAME,
@@ -186,8 +187,13 @@ DEFUN (if_rmap,
 	int idx_in_out = 2;
 	int idx_ifname = 3;
 	enum if_rmap_type type;
-	struct if_rmap_ctx *ctx =
-		(struct if_rmap_ctx *)listnode_head(if_rmap_ctx_list);
+	struct if_rmap_ctx *ctx;
+	const struct lyd_node *dnode;
+	struct rip *rip;
+
+	dnode = yang_dnode_get(running_config->dnode, VTY_CURR_XPATH);
+	rip = nb_running_get_entry(dnode, NULL, true);
+	ctx = rip->if_rmap_ctx;
 
 	if (strncmp(argv[idx_in_out]->text, "in", 1) == 0)
 		type = IF_RMAP_IN;
@@ -289,8 +295,7 @@ struct if_rmap_ctx *if_rmap_ctx_create(const char *name)
 
 	ctx = XCALLOC(MTYPE_IF_RMAP_CTX, sizeof(struct if_rmap_ctx));
 
-	if (ctx->name)
-		ctx->name = XSTRDUP(MTYPE_IF_RMAP_CTX_NAME, name);
+	ctx->name = XSTRDUP(MTYPE_IF_RMAP_CTX_NAME, name);
 	ctx->ifrmaphash = hash_create_size(4, if_rmap_hash_make, if_rmap_hash_cmp,
 					   "Interface Route-Map Hash");
 	if (!if_rmap_ctx_list)


### PR DESCRIPTION
Currently the process of the `route-map` configuration for `per-vrf-rip` is wrong.

There are two problems:
1. `ctx->name` for `if_rmap_ctx`  is not initialized in `if_rmap_ctx_create()`.
2.  The global `if_rmap_ctx_list` is wrongly used for `per-vrf-rip`.

So, two changes for it:
1. Correctly initializes `ctx->name`.
2. Use specific `if_rmap_ctx` for `per-vrf-rip`, not global one.

Note, this related implementation for `route-map` is only for `ripd`.

Before:
```
anlan(config)# route rip vrf vrf1
anlan(config-router)# route-map aa in lan
anlan(config-router)# do show run
!
router rip
 route-map aa in lan
exit
!
```

After:
```
anlan(config)# route rip vrf vrf1
anlan(config-router)# route-map aa in lan
anlan(config-router)# do show run
!
router rip vrf vrf1
 route-map aa in lan
exit
!
```