### PR TITLE
bgpd: bmp fix peer-up ports byte order

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -389,13 +389,13 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 
 		/* Local Port, Remote Port */
 		if (peer->su_local->sa.sa_family == AF_INET6)
-			stream_putw(s, peer->su_local->sin6.sin6_port);
+			stream_putw(s, htons(peer->su_local->sin6.sin6_port));
 		else if (peer->su_local->sa.sa_family == AF_INET)
-			stream_putw(s, peer->su_local->sin.sin_port);
+			stream_putw(s, htons(peer->su_local->sin.sin_port));
 		if (peer->su_remote->sa.sa_family == AF_INET6)
-			stream_putw(s, peer->su_remote->sin6.sin6_port);
+			stream_putw(s, htons(peer->su_remote->sin6.sin6_port));
 		else if (peer->su_remote->sa.sa_family == AF_INET)
-			stream_putw(s, peer->su_remote->sin.sin_port);
+			stream_putw(s, htons(peer->su_remote->sin.sin_port));
 
 		static const uint8_t dummy_open[] = {
 			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,


### PR DESCRIPTION
according to the wireshark dissector the ports in the bmp peer-up messages are in the wrong byte order. 
for example, dissected port 179 of bgp is read as 0xb300 (base10 = 45824) instead of 0x00b3 (base10 = 179)

this PR adds a htons call to the port values put in the bmp message packet for the peer-up message in ordre to fix this byte order problem