### PR TITLE
tests: [topojson] multicast pimv6 socat cleanup

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -3357,7 +3357,19 @@ def socat_send_mld_join(
 
         # Run socat command to send IGMP join
         logger.info("[DUT: {}]: Running command: [{}]".format(server, socat_cmd))
-        output = rnode.run("set +m; {} sleep 0.5".format(socat_cmd))
+        output = rnode.run("set +m; {} echo $!".format(socat_cmd))
+
+        # Check if socat join process is running
+        if output:
+            pid = output.split()[0]
+            rnode.run("touch /var/run/frr/socat_join.pid")
+            rnode.run("echo %s >> /var/run/frr/socat_join.pid" % pid)
+        else:
+            errormsg = "Socat join is not sent for {}. Error {}".format(
+                mld_group, output
+            )
+            logger.error(output)
+            return errormsg
 
     logger.debug("Exiting lib API: {}".format(sys._getframe().f_code.co_name))
     return True
@@ -3415,7 +3427,7 @@ def socat_send_pim6_traffic(
         if multicast_hops:
             socat_cmd += "multicast-hops=255'"
 
-        socat_cmd += " &>{}/socat.logs &".format(tgen.logdir)
+        socat_cmd += " >{}/socat.logs &".format(tgen.logdir)
 
         # Run socat command to send pim6 traffic
         logger.info(
@@ -3435,7 +3447,20 @@ def socat_send_pim6_traffic(
             )
 
         rnode.run("chmod 755 {}".format(traffic_shell_script))
-        output = rnode.run("{} &> /dev/null".format(traffic_shell_script))
+        output = rnode.run("{} &>/dev/null & echo $!".format(traffic_shell_script))
+
+        # Check if socat traffic process is running
+        if output:
+            pid = output.split()[0]
+            rnode.run("touch /var/run/frr/socat_traffic.pid")
+            rnode.run("echo %s >> /var/run/frr/socat_traffic.pid" % pid)
+
+        else:
+            errormsg = "Socat traffic is not sent for {}. Error {}".format(
+                mld_group, output
+            )
+            logger.error(output)
+            return errormsg
 
     logger.debug("Exiting lib API: {}".format(sys._getframe().f_code.co_name))
     return True
@@ -3465,18 +3490,30 @@ def kill_socat(tgen, dut=None, action=None):
         if dut is not None and router != dut:
             continue
 
+        traffic_shell_script = "{}/{}/traffic.sh".format(tgen.logdir, router)
+        pid_socat_join = rnode.run("cat /var/run/frr/socat_join.pid")
+        pid_socat_traffic = rnode.run("cat /var/run/frr/socat_traffic.pid")
         if action == "remove_mld_join":
-            cmd = "ps -ef | grep socat | grep UDP6-RECV | grep {}".format(router)
+            pids = pid_socat_join
         elif action == "remove_mld_traffic":
-            cmd = "ps -ef | grep socat | grep UDP6-SEND | grep {}".format(router)
+            pids = pid_socat_traffic
         else:
-            cmd = "ps -ef | grep socat".format(router)
+            pids = "\n".join([pid_socat_join, pid_socat_traffic])
 
-        awk_cmd = "awk -F' ' '{print $2}' | xargs kill -9 &>/dev/null &"
-        cmd = "{} | {}".format(cmd, awk_cmd)
+        if os.path.exists(traffic_shell_script):
+            cmd = (
+                "ps -ef | grep %s | awk -F' ' '{print $2}' | xargs kill -9"
+                % traffic_shell_script
+            )
+            logger.debug("[DUT: {}]: Running command: [{}]".format(router, cmd))
+            rnode.run(cmd)
 
-        logger.debug("[DUT: {}]: Running command: [{}]".format(router, cmd))
-        rnode.run(cmd)
+        for pid in pids.split("\n"):
+            pid = pid.strip()
+            if pid.isdigit():
+                cmd = "set +m; kill -9 %s &> /dev/null" % pid
+                logger.debug("[DUT: {}]: Running command: [{}]".format(router, cmd))
+                rnode.run(cmd)
 
     logger.debug("Exiting lib API: {}".format(sys._getframe().f_code.co_name))
 

--- a/tests/topotests/multicast_pim6_sm_topo1/test_multicast_pim6_sm1.py
+++ b/tests/topotests/multicast_pim6_sm_topo1/test_multicast_pim6_sm1.py
@@ -62,6 +62,7 @@ from lib.common_config import (
     socat_send_mld_join,
     socat_send_pim6_traffic,
     get_frr_ipv6_linklocal,
+    kill_socat,
 )
 from lib.bgp import create_router_bgp
 from lib.pim import (
@@ -158,10 +159,6 @@ def setup_module(mod):
     # Creating configuration from JSON
     build_config_from_json(tgen, tgen.json_topo)
 
-    # XXX Replace this using "with McastTesterHelper()... " in each test if possible.
-    global app_helper
-    app_helper = McastTesterHelper(tgen)
-
     logger.info("Running setup_module() done")
 
 
@@ -172,7 +169,8 @@ def teardown_module():
 
     tgen = get_topogen()
 
-    app_helper.cleanup()
+    # Clean up socat
+    kill_socat(tgen)
 
     # Stop toplogy and Remove tmp files
     tgen.stop_topology()

--- a/tests/topotests/multicast_pim6_sm_topo1/test_multicast_pim6_sm2.py
+++ b/tests/topotests/multicast_pim6_sm_topo1/test_multicast_pim6_sm2.py
@@ -53,6 +53,7 @@ from lib.common_config import (
     socat_send_mld_join,
     socat_send_pim6_traffic,
     get_frr_ipv6_linklocal,
+    kill_socat,
 )
 from lib.bgp import create_router_bgp
 from lib.pim import (
@@ -149,10 +150,6 @@ def setup_module(mod):
     # Creating configuration from JSON
     build_config_from_json(tgen, tgen.json_topo)
 
-    # XXX Replace this using "with McastTesterHelper()... " in each test if possible.
-    global app_helper
-    app_helper = McastTesterHelper(tgen)
-
     logger.info("Running setup_module() done")
 
 
@@ -163,7 +160,8 @@ def teardown_module():
 
     tgen = get_topogen()
 
-    app_helper.cleanup()
+    # Clean up socat
+    kill_socat(tgen)
 
     # Stop toplogy and Remove tmp files
     tgen.stop_topology()

--- a/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp1.py
+++ b/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp1.py
@@ -172,6 +172,9 @@ def teardown_module():
     logger.info("Running teardown_module to delete topology")
     tgen = get_topogen()
 
+    # Clean up socat
+    kill_socat(tgen)
+
     # Stop toplogy and Remove tmp files
     tgen.stop_topology()
 

--- a/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp2.py
+++ b/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp2.py
@@ -176,6 +176,9 @@ def teardown_module():
     logger.info("Running teardown_module to delete topology")
     tgen = get_topogen()
 
+    # Clean up socat
+    kill_socat(tgen)
+
     # Stop toplogy and Remove tmp files
     tgen.stop_topology()
 


### PR DESCRIPTION
For multicast pimv6 join and traffic, socat is
used, which was not cleaned up post tests executions, 
enhanced kill_socat() API to kill socat join and
traffic specific PIDs during teardown module.

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>