### PR TITLE
zebra: null-check client pointer during GR processing

### DIFF
--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -651,6 +651,9 @@ void zebra_gr_process_client(afi_t afi, vrf_id_t vrf_id, uint8_t proto,
 	struct client_gr_info *info = NULL;
 	struct zebra_gr_afi_clean *gac;
 
+	if (client == NULL)
+		return;
+
 	TAILQ_FOREACH (info, &client->gr_info_queue, gr_info) {
 		if (info->vrf_id == vrf_id)
 			break;


### PR DESCRIPTION
Add a null check - should fix coverity CID 1537086.
