### PR TITLE
Limit scope

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5679,7 +5679,7 @@ void bgp_evpn_encode_prefix(struct stream *s, const struct prefix *p,
 }
 
 int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
-			struct bgp_nlri *packet, int withdraw)
+			struct bgp_nlri *packet, bool withdraw)
 {
 	uint8_t *pnt;
 	uint8_t *lim;

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -150,7 +150,7 @@ extern void bgp_evpn_encode_prefix(struct stream *s, const struct prefix *p,
 				   struct attr *attr, bool addpath_capable,
 				   uint32_t addpath_tx_id);
 extern int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
-			       struct bgp_nlri *packet, int withdraw);
+			       struct bgp_nlri *packet, bool withdraw);
 extern int bgp_evpn_import_route(struct bgp *bgp, afi_t afi, safi_t safi,
 				 const struct prefix *p,
 				 struct bgp_path_info *ri);

--- a/bgpd/bgp_flowspec.c
+++ b/bgpd/bgp_flowspec.c
@@ -82,7 +82,7 @@ static int bgp_fs_nlri_validate(uint8_t *nlri_content, uint32_t len,
 }
 
 int bgp_nlri_parse_flowspec(struct peer *peer, struct attr *attr,
-			    struct bgp_nlri *packet, int withdraw)
+			    struct bgp_nlri *packet, bool withdraw)
 {
 	uint8_t *pnt;
 	uint8_t *lim;
@@ -103,7 +103,7 @@ int bgp_nlri_parse_flowspec(struct peer *peer, struct attr *attr,
 	 * withdraw.  Flowspec should as well.
 	 */
 	if (!attr)
-		withdraw = 1;
+		withdraw = true;
 
 	if (packet->length >= FLOWSPEC_NLRI_SIZELIMIT_EXTENDED) {
 		flog_err(EC_BGP_FLOWSPEC_PACKET,

--- a/bgpd/bgp_flowspec.c
+++ b/bgpd/bgp_flowspec.c
@@ -98,6 +98,13 @@ int bgp_nlri_parse_flowspec(struct peer *peer, struct attr *attr,
 	afi = packet->afi;
 	safi = packet->safi;
 
+	/*
+	 * All other AFI/SAFI's treat no attribute as a implicit
+	 * withdraw.  Flowspec should as well.
+	 */
+	if (!attr)
+		withdraw = 1;
+
 	if (packet->length >= FLOWSPEC_NLRI_SIZELIMIT_EXTENDED) {
 		flog_err(EC_BGP_FLOWSPEC_PACKET,
 			 "BGP flowspec nlri length maximum reached (%u)",

--- a/bgpd/bgp_flowspec.h
+++ b/bgpd/bgp_flowspec.h
@@ -15,7 +15,7 @@
 #define BGP_FLOWSPEC_NLRI_STRING_MAX 512
 
 extern int bgp_nlri_parse_flowspec(struct peer *peer, struct attr *attr,
-				   struct bgp_nlri *packet, int withdraw);
+				   struct bgp_nlri *packet, bool withdraw);
 
 extern void bgp_flowspec_vty_init(void);
 

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -331,7 +331,7 @@ static void bgp_update_explicit_eors(struct peer *peer)
  * calling safi function and for evpn, passed as parameter
  */
 int bgp_nlri_parse(struct peer *peer, struct attr *attr,
-		   struct bgp_nlri *packet, int mp_withdraw)
+		   struct bgp_nlri *packet, bool mp_withdraw)
 {
 	switch (packet->safi) {
 	case SAFI_UNICAST:

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -42,26 +42,28 @@ DECLARE_HOOK(bgp_packet_send,
 	} while (0)
 
 /* Packet send and receive function prototypes. */
-extern void bgp_keepalive_send(struct peer *);
-extern void bgp_open_send(struct peer *);
-extern void bgp_notify_send(struct peer *, uint8_t, uint8_t);
-extern void bgp_notify_send_with_data(struct peer *, uint8_t, uint8_t,
-				      uint8_t *, size_t);
+extern void bgp_keepalive_send(struct peer *peer);
+extern void bgp_open_send(struct peer *peer);
+extern void bgp_notify_send(struct peer *peer, uint8_t code, uint8_t sub_code);
+extern void bgp_notify_send_with_data(struct peer *peer, uint8_t code,
+				      uint8_t sub_code, uint8_t *data,
+				      size_t datalen);
 void bgp_notify_io_invalid(struct peer *peer, uint8_t code, uint8_t sub_code,
 			   uint8_t *data, size_t datalen);
 extern void bgp_route_refresh_send(struct peer *peer, afi_t afi, safi_t safi,
 				   uint8_t orf_type, uint8_t when_to_refresh,
 				   int remove, uint8_t subtype);
-extern void bgp_capability_send(struct peer *, afi_t, safi_t, int, int);
+extern void bgp_capability_send(struct peer *peer, afi_t afi, safi_t safi,
+				int capabilty_code, int action);
 
-extern int bgp_capability_receive(struct peer *, bgp_size_t);
+extern int bgp_capability_receive(struct peer *peer, bgp_size_t length);
 
-extern int bgp_nlri_parse(struct peer *, struct attr *, struct bgp_nlri *,
-			  int mp_withdraw);
+extern int bgp_nlri_parse(struct peer *peer, struct attr *attr,
+			  struct bgp_nlri *nlri, int mp_withdraw);
 
-extern void bgp_update_restarted_peers(struct peer *);
-extern void bgp_update_implicit_eors(struct peer *);
-extern void bgp_check_update_delay(struct bgp *);
+extern void bgp_update_restarted_peers(struct peer *peer);
+extern void bgp_update_implicit_eors(struct peer *peer);
+extern void bgp_check_update_delay(struct bgp *peer);
 
 extern int bgp_packet_set_marker(struct stream *s, uint8_t type);
 extern void bgp_packet_set_size(struct stream *s);

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -59,7 +59,7 @@ extern void bgp_capability_send(struct peer *peer, afi_t afi, safi_t safi,
 extern int bgp_capability_receive(struct peer *peer, bgp_size_t length);
 
 extern int bgp_nlri_parse(struct peer *peer, struct attr *attr,
-			  struct bgp_nlri *nlri, int mp_withdraw);
+			  struct bgp_nlri *nlri, bool mp_withdraw);
 
 extern void bgp_update_restarted_peers(struct peer *peer);
 extern void bgp_update_implicit_eors(struct peer *peer);

--- a/tests/bgpd/test_mp_attr.c
+++ b/tests/bgpd/test_mp_attr.c
@@ -1042,9 +1042,9 @@ static void parse_test(struct peer *peer, struct test_segment *t, int type)
 
 	if (!parse_ret) {
 		if (type == BGP_ATTR_MP_REACH_NLRI)
-			nlri_ret = bgp_nlri_parse(peer, &attr, &nlri, 0);
+			nlri_ret = bgp_nlri_parse(peer, &attr, &nlri, false);
 		else if (type == BGP_ATTR_MP_UNREACH_NLRI)
-			nlri_ret = bgp_nlri_parse(peer, &attr, &nlri, 1);
+			nlri_ret = bgp_nlri_parse(peer, &attr, &nlri, true);
 	}
 	handle_result(peer, t, parse_ret, nlri_ret);
 }


### PR DESCRIPTION
See individual Commits, two categories:

a) Code cleanup to our standards
b) Prevent a NLRI_MPUPDATE that has a poorly formed bgp nlri( ie it doesn't exist ) from crashing flowspec.