### PR TITLE
ripd: Fix memory leak for ripd's route-map

### DIFF
--- a/lib/if_rmap.c
+++ b/lib/if_rmap.c
@@ -284,7 +284,7 @@ void if_rmap_ctx_delete(struct if_rmap_ctx *ctx)
 	listnode_delete(if_rmap_ctx_list, ctx);
 	hash_clean_and_free(&ctx->ifrmaphash, (void (*)(void *))if_rmap_free);
 	if (ctx->name)
-		XFREE(MTYPE_IF_RMAP_CTX_NAME, ctx);
+		XFREE(MTYPE_IF_RMAP_CTX_NAME, ctx->name);
 	XFREE(MTYPE_IF_RMAP_CTX, ctx);
 }
 


### PR DESCRIPTION
When cleaning `ripd`, it should free `ctx->name` of `struct if_rmap_ctx`, not `ctx` itself.  Otherwise, it will lead to memory leak.