### PR TITLE
ospfd: support configuration of socket buffer sizes

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -310,6 +310,11 @@ To start OSPF process you have to specify the OSPF router.
    of packets to process before returning. The defult value of this parameter
    is 20.
 
+.. clicmd:: socket buffer <send | recv | all> (1-4000000000)
+
+   This command controls the ospf instance's socket buffer sizes. The
+   'no' form resets one or both values to the default.
+   
 .. _ospf-area:
 
 Areas

--- a/ospfd/ospf_network.h
+++ b/ospfd/ospf_network.h
@@ -16,4 +16,14 @@ extern int ospf_if_drop_alldrouters(struct ospf *, struct prefix *, ifindex_t);
 extern int ospf_if_ipmulticast(struct ospf *, struct prefix *, ifindex_t);
 extern int ospf_sock_init(struct ospf *ospf);
 
+enum ospf_sock_type_e {
+	OSPF_SOCK_NONE = 0,
+	OSPF_SOCK_RECV,
+	OSPF_SOCK_SEND,
+	OSPF_SOCK_BOTH
+};
+
+void ospf_sock_bufsize_update(const struct ospf *ospf, int sock,
+			      enum ospf_sock_type_e type);
+
 #endif /* _ZEBRA_OSPF_NETWORK_H */

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -67,6 +67,9 @@
 #define OSPF_LS_REFRESH_SHIFT       (60 * 15)
 #define OSPF_LS_REFRESH_JITTER      60
 
+/* Default socket buffer size */
+#define OSPF_DEFAULT_SOCK_BUFSIZE   (8 * 1024 * 1024)
+
 struct ospf_external {
 	unsigned short instance;
 	struct route_table *external_info;
@@ -423,6 +426,10 @@ struct ospf {
 
 	/* Flood Reduction configuration state */
 	bool fr_configured;
+
+	/* Socket buffer sizes */
+	uint32_t recv_sock_bufsize;
+	uint32_t send_sock_bufsize;
 
 	QOBJ_FIELDS;
 };
@@ -793,6 +800,9 @@ int ospf_area_nssa_no_summary_set(struct ospf *ospf, struct in_addr area_id);
 const char *ospf_get_name(const struct ospf *ospf);
 extern struct ospf_interface *add_ospf_interface(struct connected *co,
 						 struct ospf_area *area);
+/* Update socket bufsize(s), after config change */
+void ospf_update_bufsize(struct ospf *ospf, uint32_t recvsize,
+			 uint32_t sendsize);
 
 extern int p_spaces_compare_func(const struct p_space *a,
 				 const struct p_space *b);


### PR DESCRIPTION
Add configurable socket send and receive buffer sizes, configured at the instance level. The default buffer sizes are ... pretty big, especially for sending.
