### PR TITLE
bgpd: EVPN-MH ESI is not active suppress EAD-ES Type-1 route

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -1071,7 +1071,8 @@ void update_type1_routes_for_evi(struct bgp *bgp, struct bgpevpn *vpn)
 			continue;
 
 		/* Update EAD-ES */
-		bgp_evpn_ead_es_route_update(bgp, es);
+		if (bgp_evpn_local_es_is_active(es))
+			bgp_evpn_ead_es_route_update(bgp, es);
 
 		/* Update EAD-EVI */
 		if (CHECK_FLAG(es->flags, BGP_EVPNES_ADV_EVI)) {


### PR DESCRIPTION
`update_type1_routes_for_evi()` is called from L3VNI/L2VNI up event, if ESI is not UP at this point then
do not advertise EAD-ES Type-1 route.
Just like from multiple places EAD-ES route origination checks for its operational status.


Signed-off-by: Trey Aspelund <taspelund@nvidia.com>
Signed-off-by: Chirag Shah <chirag@nvidia.com>
