### PR TITLE
pimd: Process no-forward BSM packet

### DIFF
--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -156,7 +156,6 @@ static void pim_on_bs_timer(struct event *t)
 
 	pim_nht_bsr_del(scope->pim, scope->current_bsr);
 	/* Reset scope zone data */
-	scope->accept_nofwd_bsm = false;
 	scope->state = ACCEPT_ANY;
 	scope->current_bsr = PIMADDR_ANY;
 	scope->current_bsr_prio = 0;
@@ -1363,6 +1362,10 @@ int pim_bsm_process(struct interface *ifp, pim_sgaddr *sg, uint8_t *buf,
 			return -1;
 		}
 	}
+
+	/* BSM packet is seen, so resetting accept_nofwd_bsm to false */
+	if (pim->global_scope.accept_nofwd_bsm)
+		pim->global_scope.accept_nofwd_bsm = false;
 
 	if (!pim_addr_cmp(sg->grp, qpim_all_pim_routers_addr)) {
 		/* Multicast BSMs are only accepted if source interface & IP


### PR DESCRIPTION
Topology Used:
Cisco---FRR4----FRR2

Initially PIM nbr is down between FRR4----FRR2 from FRR2 side Cisco is sending BSR packet to FRR4.

Problem Statement:
No shutdown the PIM neighbor on FRR2 towards FRR4. FRR2, receives BSR packet immediately as the new neighbor comes up. This BSR packet is having no-forward bit set. FRR2 is not able to process the BSR packet, and drop the BSR packet.

Root Cause:
When PIMD comes up, we start BSM timer for 60 seconds. Here, the value accept_nofwd_bsm is setting to false.

FRR2, when receives no-forward BSR packet, it is getting accept_nofwd_bsm value as false.

So, it drops, the no-forward BSM packet.

Fix:
Set accept_nofwd_bsm as false after first BSM packet received.