### PR TITLE
pimd, pim6d: changes to pimreg register socket initialization

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1701,6 +1701,12 @@ void pim_if_create_pimreg(struct pim_instance *pim)
 			snprintf(pimreg_name, sizeof(pimreg_name), PIMREG "%u",
 				 pim->vrf->data.l.table_id);
 
+		if (pim_reg_sock_bind(pim)) {
+			zlog_warn(
+				"Could not bind reg_sock to pimreg interface fd=%d; vrf_name=%s vrf_id=%d",
+				pim->reg_sock, pim->vrf->name,
+				pim->vrf->vrf_id);
+		}
 		pim->regiface = if_get_by_name(pimreg_name, pim->vrf->vrf_id,
 					       pim->vrf->name);
 		pim->regiface->ifindex = PIM_OIF_PIM_REGISTER_VIF;

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -939,7 +939,7 @@ static int pim_iface_next_vif_index(struct interface *ifp)
 }
 
 /*
-  pim_if_add_vif() uses ifindex as vif_index
+  pim_if_add_vif() uses ifindex as mroute_vif_index
 
   see also pim_if_find_vifindex_by_ifindex()
  */
@@ -1701,12 +1701,7 @@ void pim_if_create_pimreg(struct pim_instance *pim)
 			snprintf(pimreg_name, sizeof(pimreg_name), PIMREG "%u",
 				 pim->vrf->data.l.table_id);
 
-		if (pim_reg_sock_bind(pim)) {
-			zlog_warn(
-				"Could not bind reg_sock to pimreg interface fd=%d; vrf_name=%s vrf_id=%d",
-				pim->reg_sock, pim->vrf->name,
-				pim->vrf->vrf_id);
-		}
+		pim_reg_sock_bind(pim);
 		pim->regiface = if_get_by_name(pimreg_name, pim->vrf->vrf_id,
 					       pim->vrf->name);
 		pim->regiface->ifindex = PIM_OIF_PIM_REGISTER_VIF;

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -57,7 +57,9 @@ static void pim_instance_terminate(struct pim_instance *pim)
 	pim_msdp_exit(pim);
 #endif /* PIM_IPV == 4 */
 
-	close(pim->reg_sock);
+	if (pim->reg_sock > 0)
+		close(pim->reg_sock);
+	pim->reg_sock = -1;
 
 	pim_mroute_socket_disable(pim);
 

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -740,9 +740,8 @@ int pim_msg_send(int fd, pim_addr src, pim_addr dst, uint8_t *pim_msg,
 		pim_pkt_dump(__func__, pim_msg, pim_msg_size);
 	}
 
-	pim_msg_send_frame(fd, (char *)buffer, sendlen, (struct sockaddr *)&to,
+	return pim_msg_send_frame(fd, (char *)buffer, sendlen, (struct sockaddr *)&to,
 			   tolen, ifp ? ifp->name : "*");
-	return 0;
 
 #else
 	struct iovec iovector[2];
@@ -750,9 +749,8 @@ int pim_msg_send(int fd, pim_addr src, pim_addr dst, uint8_t *pim_msg,
 	iovector[0].iov_base = pim_msg;
 	iovector[0].iov_len = pim_msg_size;
 
-	pim_msg_send_frame(src, dst, ifp ? ifp->ifindex : 0, &iovector[0], fd);
+	return pim_msg_send_frame(src, dst, ifp ? ifp->ifindex : 0, &iovector[0], fd);
 
-	return 0;
 #endif
 }
 

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -449,25 +449,22 @@ int pim_socket_getsockname(int fd, struct sockaddr *name, socklen_t *namelen)
 
 	return PIM_SOCK_ERR_NONE;
 }
-int pim_reg_sock_bind(struct pim_instance *pim)
+void pim_reg_sock_bind(struct pim_instance *pim)
 {
 	if (!pim)
-		return 0;
+		return;
 	if (pim->vrf->vrf_id != VRF_DEFAULT) {
 		struct interface *ifp =
 			if_lookup_by_name(pim->vrf->name, pim->vrf->vrf_id);
 		if (ifp) {
 			if (pim_socket_bind(pim->reg_sock, ifp)) {
 				zlog_warn(
-					"Could not set reg_sock fd: %d for interface: %s to device",
-					pim->reg_sock, ifp->name);
-				return PIM_SOCK_ERR_BIND;
+					"%s: Could not set reg_sock fd: %d for interface: %s to device",
+					__func__, pim->reg_sock, ifp->name);
 			}
 		} else {
 			zlog_warn("%s: vrf interface lookup failed %s id %d",
 				  __func__, pim->vrf->name, pim->vrf->vrf_id);
-			return PIM_SOCK_ERR_SOCKET;
 		}
 	}
-	return PIM_SOCK_ERR_NONE;
 }

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -449,3 +449,25 @@ int pim_socket_getsockname(int fd, struct sockaddr *name, socklen_t *namelen)
 
 	return PIM_SOCK_ERR_NONE;
 }
+int pim_reg_sock_bind(struct pim_instance *pim)
+{
+	if (!pim)
+		return 0;
+	if (pim->vrf->vrf_id != VRF_DEFAULT) {
+		struct interface *ifp =
+			if_lookup_by_name(pim->vrf->name, pim->vrf->vrf_id);
+		if (ifp) {
+			if (pim_socket_bind(pim->reg_sock, ifp)) {
+				zlog_warn(
+					"Could not set reg_sock fd: %d for interface: %s to device",
+					pim->reg_sock, ifp->name);
+				return PIM_SOCK_ERR_BIND;
+			}
+		} else {
+			zlog_warn("%s: vrf interface lookup failed %s id %d",
+				  __func__, pim->vrf->name, pim->vrf->vrf_id);
+			return PIM_SOCK_ERR_SOCKET;
+		}
+	}
+	return PIM_SOCK_ERR_NONE;
+}

--- a/pimd/pim_sock.h
+++ b/pimd/pim_sock.h
@@ -42,5 +42,6 @@ int pim_socket_recvfromto(int fd, uint8_t *buf, size_t len,
 int pim_socket_getsockname(int fd, struct sockaddr *name, socklen_t *namelen);
 
 int pim_reg_sock(void);
+int pim_reg_sock_bind(struct pim_instance *pim);
 
 #endif /* PIM_SOCK_H */

--- a/pimd/pim_sock.h
+++ b/pimd/pim_sock.h
@@ -42,6 +42,6 @@ int pim_socket_recvfromto(int fd, uint8_t *buf, size_t len,
 int pim_socket_getsockname(int fd, struct sockaddr *name, socklen_t *namelen);
 
 int pim_reg_sock(void);
-int pim_reg_sock_bind(struct pim_instance *pim);
+void pim_reg_sock_bind(struct pim_instance *pim);
 
 #endif /* PIM_SOCK_H */


### PR DESCRIPTION
We separated PIM register messages to send out only on the reg_sock socket. This is to handle a case where the FHR is RP: we send out a register message and receive a reg stop in a pim_sock_fd. This is fine, but the problem arises when we are in a multi-VRF setup and FHR is RP. When an pimreg interface moves from one VRF to another, the socket is lost. and, when we create a PIM register interface, this interface is never bound to the non default vrf's reg_sock socket.

With this fix, when FHR is a RP, the non-default VRF reg_sock will now bind to the interface. As a result, the PIM register message will be sent out.

Testing Done:
Verified mroute on RP/FHR and S,G programmed, traffic reaches the receiver

Signed-off-by: Rajesh Varatharaj <rvaratharaj@nvidia.com>