### PR TITLE
zebra: Mark connected route as installed after interface flap event

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3745,6 +3745,11 @@ dplane_route_update_internal(struct route_node *rn,
 						 NEXTHOP_FLAG_FIB);
 			}
 
+			if ((op == DPLANE_OP_ROUTE_UPDATE) && old_re && re &&
+			    (old_re != re) &&
+			    !CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED))
+				SET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
+
 			dplane_ctx_free(&ctx);
 			return ZEBRA_DPLANE_REQUEST_SUCCESS;
 		}


### PR DESCRIPTION
Issue:
After vlan flap, zebra was not marking the selected/best route as installed.

As a result, when a static route was configured with nexthop as directly connected interface's(vlan) IP, the static route was not being installed in the kernel since its nexthop was unresolved. The nexthop was marked unresolved because zebra failed to mark the best route as installed after interface flap.

This was happening because, in dplane_route_update_internal() if the old and new context type, and nexthop group id are the same, then zebra doesn't send down a route replace request to kernel. But, the installed (ROUTE_ENTRY_INSTALLED) flag is set when zebra receives a response from kernel. Since the request to kernel was being skipped for the route entry, installed flag was not being set

Fix:
In dplane_route_update_internal() if the old and new context type, and nexthop group id are the same, then before returning, installed flag will be set on the route-entry if it's not set already.