### PR TITLE
tests: Ensure that the scale_up.py script tests for actual sharp inst…

### DIFF
--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/scale_up.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/scale_up.py
@@ -62,6 +62,25 @@ else:
         "pass",
         "Adding {} routes".format(num),
     )
+    luCommand(
+        "ce1",
+        'vtysh -c "show ip route summ" | grep "sharp" | cut -d " " -f 33',
+        str(num),
+        "wait",
+        "See all sharp routes in rib on ce1",
+        wait,
+        wait_time=10,
+        )
+    luCommand(
+        "ce2",
+        'vtysh -c "show ip route summ" | grep "sharp" | cut -d " " -f 33',
+        str(num),
+        "wait",
+        "See all sharp routes in rib on ce2",
+        wait,
+        wait_time=10,
+        )
+
     rtrs = ["ce1", "ce2", "ce3"]
     for rtr in rtrs:
         luCommand(


### PR DESCRIPTION
…alled routes first

The scale_up.py script used by several tests installs 50k routes into the rib from sharpd.  It is first looking for the results in the bgp database.  Let's ensure that the routes are actually installed into the rib first before looking in the bgp tables.  This should help situations where the system is under extreme load.