### PR TITLE
bgpd: rfapi memleak fixes

### DIFF
--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -51,6 +51,8 @@
 #include <execinfo.h>
 #endif /* HAVE_GLIBC_BACKTRACE */
 
+#define DEBUG_CLEANUP 0
+
 struct ethaddr rfapi_ethaddr0 = {{0}};
 
 #define DEBUG_RFAPI_STR "RF API debugging/testing command\n"
@@ -3677,11 +3679,36 @@ void rfapi_delete(struct bgp *bgp)
 {
 	extern void rfp_clear_vnc_nve_all(void); /* can't fix correctly yet */
 
+#if DEBUG_CLEANUP
+	zlog_debug("%s: bgp %p", __func__, bgp);
+#endif
+
 	/*
 	 * This clears queries and registered routes, and closes nves
 	 */
 	if (bgp->rfapi)
 		rfp_clear_vnc_nve_all();
+
+	/*
+	 * close any remaining descriptors
+	 */
+	struct rfapi *h = bgp->rfapi;
+
+	if (h && h->descriptors.count) {
+		struct listnode *node, *nnode;
+		struct rfapi_descriptor *rfd;
+#if DEBUG_CLEANUP
+		zlog_debug("%s: descriptor count %u", __func__,
+			   h->descriptors.count);
+#endif
+		for (ALL_LIST_ELEMENTS(&h->descriptors, node, nnode, rfd)) {
+#if DEBUG_CLEANUP
+			zlog_debug("%s: closing rfd %p", __func__, rfd);
+#endif
+			(void)rfapi_close(rfd);
+		}
+	}
+
 	bgp_rfapi_cfg_destroy(bgp, bgp->rfapi_cfg);
 	bgp->rfapi_cfg = NULL;
 	bgp_rfapi_destroy(bgp, bgp->rfapi);

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -40,6 +40,7 @@
 #define DEBUG_PENDING_DELETE_ROUTE	0
 #define DEBUG_NHL			0
 #define DEBUG_RIB_SL_RD                 0
+#define DEBUG_CLEANUP 0
 
 /* forward decl */
 #if DEBUG_NHL
@@ -327,6 +328,11 @@ static void rfapiRibStartTimer(struct rfapi_descriptor *rfd,
 		tcb = XCALLOC(MTYPE_RFAPI_RECENT_DELETE,
 			      sizeof(struct rfapi_rib_tcb));
 	}
+#if DEBUG_CLEANUP
+	zlog_debug("%s: rfd %p, rn %p, ri %p, tcb %p", __func__, rfd, rn, ri,
+		   tcb);
+#endif
+
 	tcb->rfd = rfd;
 	tcb->ri = ri;
 	tcb->rn = rn;
@@ -506,6 +512,16 @@ void rfapiRibClear(struct rfapi_descriptor *rfd)
 							    NULL,
 							    (void **)&ri)) {
 
+						if (ri->timer) {
+							struct rfapi_rib_tcb
+								*tcb;
+
+							tcb = EVENT_ARG(
+								ri->timer);
+							EVENT_OFF(ri->timer);
+							XFREE(MTYPE_RFAPI_RECENT_DELETE,
+							      tcb);
+						}
 						rfapi_info_free(ri);
 						skiplist_delete_first(
 							(struct skiplist *)
@@ -555,6 +571,9 @@ void rfapiRibFree(struct rfapi_descriptor *rfd)
 {
 	afi_t afi;
 
+#if DEBUG_CLEANUP
+	zlog_debug("%s: rfd %p", __func__, rfd);
+#endif
 
 	/*
 	 * NB rfd is typically detached from master list, so is not included

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -4888,6 +4888,7 @@ static int vnc_clear_vrf(struct vty *vty, struct bgp *bgp, const char *arg_vrf,
 	clear_vnc_prefix(&cda);
 	vty_out(vty, "Cleared %u out of %d prefixes.\n", cda.pfx_count,
 		start_count);
+	print_cleared_stats(&cda); /* frees lists in cda */
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
More rfapi exit cleanups of memory allocation per #12478