### PR TITLE
zebra: fix race during shutdown

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -6500,10 +6500,6 @@ void zebra_dplane_shutdown(void)
 
 	zdplane_info.dg_run = false;
 
-	if (zdplane_info.dg_t_update)
-		thread_cancel_async(zdplane_info.dg_t_update->master,
-				    &zdplane_info.dg_t_update, NULL);
-
 	frr_pthread_stop(zdplane_info.dg_pthread, NULL);
 
 	/* Destroy pthread */


### PR DESCRIPTION
During shutdown, the main pthread stops the dplane pthread before exiting. Don't try to clean up any events scheduled to the dplane pthread at that point - just let the thread exit and clean up. This is the 8.4 version of #13213 