### PR TITLE
zebra: display seg6local only when specified

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1538,7 +1538,9 @@ void show_route_nexthop_helper(struct vty *vty, const struct route_entry *re,
 				seg6local_action2str(
 					nexthop->nh_srv6->seg6local_action),
 				buf);
-		vty_out(vty, ", seg6 %pI6", &nexthop->nh_srv6->seg6_segs);
+		if (IPV6_ADDR_CMP(&nexthop->nh_srv6->seg6_segs, &in6addr_any))
+			vty_out(vty, ", seg6 %pI6",
+				&nexthop->nh_srv6->seg6_segs);
 	}
 
 	if (nexthop->weight)

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1532,10 +1532,12 @@ void show_route_nexthop_helper(struct vty *vty, const struct route_entry *re,
 		seg6local_context2str(buf, sizeof(buf),
 				      &nexthop->nh_srv6->seg6local_ctx,
 				      nexthop->nh_srv6->seg6local_action);
-		vty_out(vty, ", seg6local %s %s",
-			seg6local_action2str(
-				nexthop->nh_srv6->seg6local_action),
-			buf);
+		if (nexthop->nh_srv6->seg6local_action !=
+		    ZEBRA_SEG6_LOCAL_ACTION_UNSPEC)
+			vty_out(vty, ", seg6local %s %s",
+				seg6local_action2str(
+					nexthop->nh_srv6->seg6local_action),
+				buf);
 		vty_out(vty, ", seg6 %pI6", &nexthop->nh_srv6->seg6_segs);
 	}
 


### PR DESCRIPTION
Srv6 routes which configure encap method, may not have seg6local instructions. Generally speaking, seg6local attributes that are not specified should not be dumped.

Before:
> B>* 10.200.0.0/24 [20/0] via fd00:125::2, ntfp2 (vrf default), label 16, seg6local unspec unknown(seg6local_context2str), seg6 2001:db8:1:1:1::, weight 1, 0\
0:00:17

After:
> B>* 10.200.0.0/24 [20/0] via fd00:125::2, ntfp2 (vrf default), label 16, seg6 2001:db8:1:1:1::, weight 1, 00:00:17