### PR TITLE
zebra: Actually free up memory associated with the mq list

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3766,6 +3766,9 @@ static void rib_meta_queue_gr_run_free(struct meta_queue *mq, struct list *l,
 			continue;
 
 		XFREE(MTYPE_WQ_WRAPPER, gr_run);
+		node->data = NULL;
+		list_delete_node(l, node);
+		mq->size--;
 	}
 }
 


### PR DESCRIPTION
Free up the link list data structures as well as properly account for data sizes.