### PR TITLE
tests: Fix topotest invalid escape sequence in isis_advertise_high_me…

### DIFF
--- a/tests/topotests/isis_advertise_high_metrics/test_isis_advertise_high_metrics.py
+++ b/tests/topotests/isis_advertise_high_metrics/test_isis_advertise_high_metrics.py
@@ -420,9 +420,9 @@ def test_isis_advertise_high_metrics_route():
     Topology:
     
          r2
-        /  \
+       //  \\
       r1   r4
-        \  /
+       \\  //
          r3
     
     Devices are configured with preferred route between r1 and r4:


### PR DESCRIPTION
…trics test

Fixes: #13283 
```
frr@9ae2a2810e48:~/frr/tests/topotests$ sudo -E pytest -s isis_advertise_high_metrics/test_isis_advertise_high_metrics.py::test_isis_advertise_high_metrics_route
sh: 1: /sbin/modprobe: not found
sh: 1: /sbin/modprobe: not found
============================================================================= test session starts ==============================================================================
platform linux -- Python 3.7.5, pytest-7.3.0, pluggy-1.0.0
rootdir: /home/frr/frr/tests/topotests
configfile: pytest.ini
collected 1 item                                                                                                                                                               

isis_advertise_high_metrics/test_isis_advertise_high_metrics.py sh: 1: /sbin/modprobe: not found
.

--------------------------------------------------------------- generated xml file: /tmp/topotests/topotests.xml ---------------------------------------------------------------
======================================================================== 1 passed in 103.89s (0:01:43) =========================================================================
frr@9ae2a2810e48:~/frr/tests/topotests$ 
```