### PR TITLE
pimd, doc: remove dead import check references

### DIFF
--- a/doc/developer/zebra.rst
+++ b/doc/developer/zebra.rst
@@ -218,8 +218,6 @@ Zebra Protocol Commands
 +------------------------------------+-------+
 | ZEBRA_IMPORT_ROUTE_UNREGISTER      | 27    |
 +------------------------------------+-------+
-| ZEBRA_IMPORT_CHECK_UPDATE          | 28    |
-+------------------------------------+-------+
 | ZEBRA_BFD_DEST_REGISTER            | 29    |
 +------------------------------------+-------+
 | ZEBRA_BFD_DEST_DEREGISTER          | 30    |

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -724,20 +724,13 @@ int pim_parse_nexthop_update(ZAPI_CALLBACK_ARGS)
 		return 0;
 	}
 
-	if (cmd == ZEBRA_NEXTHOP_UPDATE) {
-		rpf.rpf_addr = pim_addr_from_prefix(&match);
-		pnc = pim_nexthop_cache_find(pim, &rpf);
-		if (!pnc) {
-			if (PIM_DEBUG_PIM_NHT)
-				zlog_debug(
-					"%s: Skipping NHT update, addr %pPA is not in local cached DB.",
-					__func__, &rpf.rpf_addr);
-			return 0;
-		}
-	} else {
-		/*
-		 * We do not currently handle ZEBRA_IMPORT_CHECK_UPDATE
-		 */
+	rpf.rpf_addr = pim_addr_from_prefix(&match);
+	pnc = pim_nexthop_cache_find(pim, &rpf);
+	if (!pnc) {
+		if (PIM_DEBUG_PIM_NHT)
+			zlog_debug(
+				"%s: Skipping NHT update, addr %pPA is not in local cached DB.",
+				__func__, &rpf.rpf_addr);
 		return 0;
 	}
 


### PR DESCRIPTION
`ZEBRA_IMPORT_CHECK_UPDATE` has been gone for more than a year; remove some leftover dead references to it.