### PR TITLE
tools: fix missing remote-as configuration when reload

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -788,6 +788,8 @@ def bgp_delete_nbr_remote_as_line(lines_to_add):
     # remote-as config.
 
     pg_dict = dict()
+    found_pg_cmd = False
+
     # Find all peer-group commands; create dict of each peer-group
     # to store assoicated neighbor as value
     for ctx_keys, line in lines_to_add:
@@ -808,6 +810,10 @@ def bgp_delete_nbr_remote_as_line(lines_to_add):
                     "remoteas": False,
                 }
                 found_pg_cmd = True
+
+    # Do nothing if there is no any "peer-group"
+    if found_pg_cmd is False:
+        return
 
     # Find peer-group with remote-as command, also search neighbor
     # associated to peer-group and store into peer-group dict

--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -850,7 +850,7 @@ def bgp_delete_nbr_remote_as_line(lines_to_add):
                 for pg in pg_dict[ctx_keys[0]]:
                     if pg_dict[ctx_keys[0]][pg]["remoteas"] == True:
                         for nbr in pg_dict[ctx_keys[0]][pg]["nbr"]:
-                            if re_nbr_rmtas.group(1) in nbr:
+                            if re_nbr_rmtas.group(1) == nbr:
                                 lines_to_del_from_add.append((ctx_keys, line))
 
     for ctx_keys, line in lines_to_del_from_add:


### PR DESCRIPTION
From commit `411d1a2`, `bgp_delete_nbr_remote_as_line()` is added to remove some specific bgp neighbors.  But, when reloading the following configuration, it will wrongly remove some good ones: `neighbor 66.66.66.6 remote-as internal`:

```
router bgp 66
 bgp router-id 172.16.204.6
 neighbor ANLAN peer-group
 neighbor ANLAN remote-as internal
 neighbor 66.66.66.6 remote-as internal <- LOST
 neighbor 66.66.66.60 peer-group ANLAN
```

The reason is that "66.66.66.6" is included in "66.66.66.60" literally, then it is mistakenly thought to be a match.  Just fix it with excat match.

Additionally, the flag of `found_pg_cmd` is already there, but not used. Let this flag work.