### PR TITLE
lib: fix handle seg6local routes on default vrf

### DIFF
--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -901,7 +901,7 @@ zclient_send_vrf_label(struct zclient *zclient, vrf_id_t vrf_id, afi_t afi,
 
 extern enum zclient_send_status
 zclient_send_localsid(struct zclient *zclient, const struct in6_addr *sid,
-		      ifindex_t oif, enum seg6local_action_t action,
+		      vrf_id_t vrf_id, enum seg6local_action_t action,
 		      const struct seg6local_context *context);
 
 extern void zclient_send_reg_requests(struct zclient *, vrf_id_t);


### PR DESCRIPTION
An L3VPN network can be configured on the main BGP instance, with an SRv6 SID. By declaring a network, a seg6local route is created but remains invalid.

The below BGP VPN configuration the default VRF has been used:
> router bgp 1
>  address-family ipv6 unicast
>   sid vpn export auto
>   rd vpn export 1:30
>   rt vpn both 77:77
>   import vpn
>   export vpn
>   network 2001:7::/64
>  exit-address-family

The below seg6local route has been added:

> # show ipv6 route
> [..]
> B   2001:db8:2:2:300::/128 [20/0] is directly connected, unknown inactive, seg6local End.DT6 table 254, seg6 ::, weight 1, 00:00:07
>

When creating the seg6local route, an interface is used as nexthop. The interface index is obtained from the vrf identifier. This is true when using VRF interfaces, but is wrong when using the lo interface which usually has the '1' ifindex whereas the vrf id for the default VRF is 0.

Get the appropriate index from the vrf identifier. The below seg6local route is visible:

> # show ipv6 route
> [..]
> B>* 2001:db8:1:1:300::/128 [20/0] is directly connected, lo, seg6local End.DT6 table 254, seg6 ::, weight 1, 00:00:15
>