### PR TITLE
tests: restart bgpd to avoid warnings in follow on tests

### DIFF
--- a/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-3.py
+++ b/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-3.py
@@ -2142,6 +2142,9 @@ def test_BGP_GR_TC_43_p1(request):
             tc_name, result
         )
 
+    # restart the daemon or we get warnings in the follow-on tests
+    start_router_daemons(tgen, "r1", ["bgpd"])
+
     write_test_footer(tc_name)
 
 
@@ -2431,6 +2434,9 @@ def test_BGP_GR_TC_44_p1(request):
         assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
         result = verify_rib(tgen, addr_type, dut, input_topo, next_hop, protocol)
         assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+
+    # restart the daemon or we get warnings in the follow-on tests
+    start_router_daemons(tgen, "r2", ["bgpd"])
 
     write_test_footer(tc_name)
 
@@ -2726,6 +2732,9 @@ def test_BGP_GR_TC_45_p1(request):
         assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
         result = verify_rib(tgen, addr_type, dut, input_topo, next_hop, protocol)
         assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+
+    # restart the daemon or we get warnings in the follow-on tests
+    start_router_daemons(tgen, "r1", ["bgpd"])
 
     write_test_footer(tc_name)
 

--- a/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-4.py
+++ b/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-4.py
@@ -763,6 +763,9 @@ def test_BGP_GR_TC_46_p1(request):
             tc_name, result
         )
 
+    # restart the daemon or we get warnings in the follow-on tests
+    start_router_daemons(tgen, "r1", ["bgpd"])
+
     write_test_footer(tc_name)
 
 
@@ -1022,6 +1025,9 @@ def test_BGP_GR_TC_47_p1(request):
         ), "Testcase {} :Failed \n Routes are still present \n Error {}".format(
             tc_name, result
         )
+
+    # restart the daemon or we get warnings in the follow-on tests
+    start_router_daemons(tgen, "r1", ["bgpd"])
 
     write_test_footer(tc_name)
 
@@ -1299,6 +1305,9 @@ def test_BGP_GR_TC_48_p1(request):
         ), "Testcase {} :Failed \n Routes are still present \n Error {}".format(
             tc_name, result
         )
+
+    # restart the daemon or we get warnings in the follow-on tests
+    start_router_daemons(tgen, "r1", ["bgpd"])
 
     write_test_footer(tc_name)
 


### PR DESCRIPTION
The tests are killing bgpd and then ending, the next test is checking for all daemons running and spewing warnings to stderr. Restart the daemons before ending the test (like other tests in this same module) to avoid this.