### PR TITLE
bgpd: EVPN MH add correct value into dfAlgorithm json output

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -2458,6 +2458,7 @@ static void bgp_evpn_es_json_vtep_fill(json_object *json_vteps,
 {
 	json_object *json_vtep_entry;
 	json_object *json_flags;
+	char alg_buf[EVPN_DF_ALG_STR_LEN];
 
 	json_vtep_entry = json_object_new_object();
 
@@ -2474,8 +2475,10 @@ static void bgp_evpn_es_json_vtep_fill(json_object *json_vteps,
 		if (es_vtep->flags & BGP_EVPNES_VTEP_ESR) {
 			json_object_int_add(json_vtep_entry, "dfPreference",
 					    es_vtep->df_pref);
-			json_object_int_add(json_vtep_entry, "dfAlgorithm",
-					    es_vtep->df_pref);
+			json_object_string_add(
+				json_vtep_entry, "dfAlgorithm",
+				evpn_es_df_alg2str(es_vtep->df_alg, alg_buf,
+						   sizeof(alg_buf)));
 		}
 	}
 


### PR DESCRIPTION
FRR "show bgp l2 evpn es <esi-id> json" output shows 'dfAlgorithm' same as 'dfPreference' value instead of algorithm.

Modified the code to set the correct DF algorithm value into 'dfAlgorithm' field.
```
torm-11# show bgp l2 evpn es
ES Flags: B - bypass, L local, R remote, I inconsistent VTEP Flags: E ESR/Type-4, A active nexthop
ESI                            Flags RD                    #VNIs
VTEPs
03:44:38:39:ff:ff:01:00:00:01  LR    27.0.0.15:15          10
27.0.0.16(EA),27.0.0.17(EA)
03:44:38:39:ff:ff:01:00:00:02  LR    27.0.0.15:16          10
27.0.0.16(EA),27.0.0.17(EA)
03:44:38:39:ff:ff:01:00:00:03  LR    27.0.0.15:17          10
27.0.0.16(EA),27.0.0.17(EA)
03:44:38:39:ff:ff:02:00:00:01  R     -                     10
27.0.0.18(A),27.0.0.19(A),27.0.0.20(A)
03:44:38:39:ff:ff:02:00:00:02  R     -                     10
27.0.0.18(A),27.0.0.19(A),27.0.0.20(A)
03:44:38:39:ff:ff:02:00:00:03  R     -                     10
27.0.0.18(A),27.0.0.19(A),27.0.0.20(A)
torm-11#
```

**Before Fix:-**
```
torm-11# show bgp l2 evpn es 03:44:38:39:ff:ff:01:00:00:01 json
{
  "esi":"03:44:38:39:ff:ff:01:00:00:01",
  "rd":"27.0.0.15:15",
  "type":[
    "local",
    "remote"
  ],
  "vteps":[
    {
      "vtep_ip":"27.0.0.16",
      "flags":[
        "esr",
        "active"
      ],
      "dfPreference":32767,
      "dfAlgorithm":32767 =====> dfAlgorithm is same as dfPreference
    },
    {
      "vtep_ip":"27.0.0.17",
      "flags":[
        "esr",
        "active"
      ],
      "dfPreference":32767,
      "dfAlgorithm":32767 =====> dfAlgorithm is same as dfPreference
    }
  ],
  "flags":[
    "up",
    "advertiseEVI"
  ],
  "originator_ip":"27.0.0.15",
  "remoteVniCount":10,
  "vrfCount":3,
  "macipPathCount":33,
  "macipGlobalPathCount":264,
  "inconsistentVniVtepCount":0,
  "localEsDfPreference":50000,
  "fragments":[
    {
      "rd":"27.0.0.15:15",
      "eviCount":10
    }
  ]
}
torm-11#
```

**After Fix:-**

```
torm-11# show bgp l2vpn evpn es 03:44:38:39:ff:ff:01:00:00:01 json
{
  "esi":"03:44:38:39:ff:ff:01:00:00:01",
  "rd":"27.0.0.15:4",
  "type":[
    "local",
    "remote"
  ],
  "vteps":[
    {
      "vtep_ip":"27.0.0.16",
      "flags":[
        "esr",
        "active"
      ],
      "dfPreference":32767,
      "dfAlgorithm":"preference" ---- dfAlgorithm shows properly
    },
    {
      "vtep_ip":"27.0.0.17",
      "flags":[
        "esr",
        "active"
      ],
      "dfPreference":32767,
      "dfAlgorithm":"preference" --- dfAlgorithm shows properly
    }
  ],
  "vniCount":10,
  "flags":[
    "up",
    "advertiseEVI"
  ],
  "originator_ip":"27.0.0.15",
  "remoteVniCount":10,
  "vrfCount":3,
  "macipPathCount":33,
  "macipGlobalPathCount":264,
  "inconsistentVniVtepCount":0,
  "localEsDfPreference":50000,
  "fragments":[
    {
      "rd":"27.0.0.15:4",
      "eviCount":10
    }
  ]
}
torm-11#
```

Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>