### PR TITLE
doc: include affinity-maps into index

### DIFF
--- a/doc/user/index.rst
+++ b/doc/user/index.rst
@@ -27,6 +27,7 @@ Basics
    grpc
    filter
    routemap
+   affinitymap
    ipv6
    kernel
    snmp


### PR DESCRIPTION
Include affinity-maps documentation into index under "basics".