### PR TITLE
ripd: Align show ip rip status output for sources

### DIFF
--- a/ripd/rip_peer.c
+++ b/ripd/rip_peer.c
@@ -136,7 +136,7 @@ void rip_peer_display(struct vty *vty, struct rip *rip)
 	char timebuf[RIP_UPTIME_LEN];
 
 	for (ALL_LIST_ELEMENTS(rip->peer_list, node, nnode, peer)) {
-		vty_out(vty, "    %-16pI4 %9d %9d %9d   %s\n",
+		vty_out(vty, "    %-17pI4 %9d %9d %9d %11s\n",
 			&peer->addr, peer->recv_badpackets,
 			peer->recv_badroutes, ZEBRA_RIP_DISTANCE_DEFAULT,
 			rip_peer_uptime(peer, timebuf, RIP_UPTIME_LEN));

--- a/tests/topotests/rip_topo1/r1/rip_status.ref
+++ b/tests/topotests/rip_topo1/r1/rip_status.ref
@@ -18,5 +18,5 @@ Routing Protocol is "rip"
     r1-eth3
   Routing Information Sources:
     Gateway          BadPackets BadRoutes  Distance Last Update
-    193.1.1.2                0         0       120   XX:XX:XX
+    193.1.1.2                 0         0       120    XX:XX:XX
   Distance: (default is 120)

--- a/tests/topotests/rip_topo1/r2/rip_status.ref
+++ b/tests/topotests/rip_topo1/r2/rip_status.ref
@@ -14,6 +14,6 @@ Routing Protocol is "rip"
     193.1.2.0/24
   Routing Information Sources:
     Gateway          BadPackets BadRoutes  Distance Last Update
-    193.1.1.1                0         0       120   XX:XX:XX
-    193.1.2.2                0         0       120   XX:XX:XX
+    193.1.1.1                 0         0       120    XX:XX:XX
+    193.1.2.2                 0         0       120    XX:XX:XX
   Distance: (default is 120)

--- a/tests/topotests/rip_topo1/r3/rip_status.ref
+++ b/tests/topotests/rip_topo1/r3/rip_status.ref
@@ -12,5 +12,5 @@ Routing Protocol is "rip"
     193.1.2.0/24
   Routing Information Sources:
     Gateway          BadPackets BadRoutes  Distance Last Update
-    193.1.2.1                0         0       120   XX:XX:XX
+    193.1.2.1                 0         0       120    XX:XX:XX
   Distance: (default is 120)


### PR DESCRIPTION
Before:
```
Routing Protocol is "rip"
  Sending updates every 5 seconds with +/-50%, next due in 0 seconds
  Timeout after 15 seconds, garbage collect after 10 seconds
  Outgoing update filter list for all interface is not set
  Incoming update filter list for all interface is not set
  Default redistribution metric is 1
  Redistributing:
  Default version control: send version 2, receive any version
    Interface        Send  Recv   Key-chain
    r1-eth0          2     1 2
  Routing for Networks:
    192.168.1.0/24
  Routing Information Sources:
    Gateway          BadPackets BadRoutes  Distance Last Update
    192.168.1.2              0         0       120   00:00:05
    192.168.1.3              0         0       120   00:00:04
  Distance: (default is 120)
```

After:
```
Routing Protocol is "rip"
  Sending updates every 5 seconds with +/-50%, next due in 4 seconds
  Timeout after 15 seconds, garbage collect after 10 seconds
  Outgoing update filter list for all interface is not set
  Incoming update filter list for all interface is not set
  Default redistribution metric is 1
  Redistributing:
  Default version control: send version 2, receive any version
    Interface        Send  Recv   Key-chain
    r1-eth0          2     1 2
  Routing for Networks:
    192.168.1.0/24
  Routing Information Sources:
    Gateway          BadPackets BadRoutes  Distance Last Update
    192.168.1.2               0         0       120    00:00:00
    192.168.1.3               0         0       120    00:00:04
  Distance: (default is 120)
```