### PR TITLE
bgpd: Fix for ain->attr corruption during path update

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4065,17 +4065,24 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	if (has_valid_label)
 		assert(label != NULL);
 
-	/* Update overlay index of the attribute */
-	if (afi == AFI_L2VPN && evpn)
-		memcpy(&attr->evpn_overlay, evpn,
-		       sizeof(struct bgp_route_evpn));
 
 	/* When peer's soft reconfiguration enabled.  Record input packet in
 	   Adj-RIBs-In.  */
-	if (!soft_reconfig
-	    && CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG)
-	    && peer != bgp->peer_self)
+	if (!soft_reconfig &&
+	    CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG) &&
+	    peer != bgp->peer_self) {
+		/*
+		 * If the trigger is not from soft_reconfig and if
+		 * PEER_FLAG_SOFT_RECONFIG is enabled for the peer, then attr
+		 * will not be interned. In which case, it is ok to update the
+		 * attr->evpn_overlay, so that, this can be stored in adj_in.
+		 */
+		if ((afi == AFI_L2VPN) && evpn) {
+			memcpy(&attr->evpn_overlay, evpn,
+			       sizeof(struct bgp_route_evpn));
+		}
 		bgp_adj_in_set(dest, peer, attr, addpath_id);
+	}
 
 	/* Update permitted loop count */
 	if (CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_ALLOWAS_IN))
@@ -4203,6 +4210,15 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 		}
 
 	new_attr = *attr;
+	/*
+	 * If bgp_update is called with soft_reconfig set then
+	 * attr is interned. In this case, do not overwrite the
+	 * attr->evpn_overlay with evpn directly. Instead memcpy
+	 * evpn to new_atr.evpn_overlay before it is interned.
+	 */
+	if (soft_reconfig && (afi == AFI_L2VPN) && evpn)
+		memcpy(&new_attr.evpn_overlay, evpn,
+		       sizeof(struct bgp_route_evpn));
 
 	/* Apply incoming route-map.
 	 * NB: new_attr may now contain newly allocated values from route-map


### PR DESCRIPTION
1. Consider a established L2VPN EVPN BGP peer with soft-reconfiguartion inbound configured

2. When the interface of this directly connected BGP peer is shutdown, bgp_soft_reconfig_table_update() is called, which memsets the evpn buffer and calls bgp_update() with received attributes stored in ain table(ain->attr). In bgp_update(), evpn_overlay attribute in ain->attr (which is an interned attr) was modified by doing a memcpy

3. Above action causes 2 attributes in the attrhash (which were previously different) to match!

4. Later during fsm change event of the peer, bgp_adj_in_remove() is called to clean up the ain->attr. But, because 2 attrs in attrhash match, it causes BGP to assert in bgp_attr_unintern()



BGP Crash decode:
```
#0  0x00007f623b39f5cb in raise () from /lib/x86_64-linux-gnu/libpthread.so.0
[Current thread is 1 (Thread 0x7f623aa07240 (LWP 26667))]
(gdb) bt
#0  0x00007f623b39f5cb in raise () from /lib/x86_64-linux-gnu/libpthread.so.0
#1  0x00007f623b6b17ac in core_handler (signo=6, siginfo=0x7fff6df9cfb0, context=<optimized out>) at lib/sigevent.c:264
#2  <signal handler called>
#3  0x00007f623b2048eb in raise () from /lib/x86_64-linux-gnu/libc.so.6
#4  0x00007f623b1ef535 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#5  0x00007f623b6dd276 in _zlog_assert_failed (xref=xref@entry=0x56038d43c0c0 <_xref.26537>, extra=extra@entry=0x0) at lib/zlog.c:680
#6  0x000056038d288f6e in bgp_attr_unintern (pattr=pattr@entry=0x56038ea95168) at bgpd/bgp_attr.c:1329
#7  0x000056038d370776 in bgp_adj_in_remove (dest=0x56038e88ef70, bai=0x56038ea95150) at bgpd/bgp_advertise.c:208
#8  0x000056038d2ef3e9 in bgp_clear_route_table (peer=peer@entry=0x7f62310e2010, afi=afi@entry=AFI_L2VPN, safi=safi@entry=SAFI_EVPN, table=<optimized out>)
    at bgpd/bgp_route.c:5439
#9  0x000056038d2f5aa7 in bgp_clear_route (peer=peer@entry=0x7f62310e2010, afi=afi@entry=AFI_L2VPN, safi=safi@entry=SAFI_EVPN) at bgpd/bgp_route.c:5506
#10 0x000056038d2f5bc0 in bgp_clear_route_all (peer=peer@entry=0x7f62310e2010) at bgpd/bgp_route.c:5520
#11 0x000056038d2c783e in bgp_fsm_change_status (peer=peer@entry=0x7f62310e2010, status=status@entry=7) at bgpd/bgp_fsm.c:1545
#12 0x000056038d2c920b in bgp_event_update (peer=peer@entry=0x7f62310e2010, event=event@entry=BGP_Stop) at bgpd/bgp_fsm.c:2772
#13 0x000056038d2c9249 in bgp_event (thread=<optimized out>) at bgpd/bgp_fsm.c:2725
#14 0x00007f623b6c37e3 in thread_call (thread=thread@entry=0x7fff6df9fa60) at lib/thread.c:2008
#15 0x00007f623b67aa58 in frr_run (master=0x56038e0ef890) at lib/libfrr.c:1223
#16 0x000056038d28342c in main (argc=<optimized out>, argv=<optimized out>) at bgpd/bgp_main.c:550
(gdb) f 6
#6  0x000056038d288f6e in bgp_attr_unintern (pattr=pattr@entry=0x56038ea95168) at bgpd/bgp_attr.c:1329
1329	bgpd/bgp_attr.c: No such file or directory.
(gdb) p *attr
$1 = {aspath = 0x56038ea3f490, community = 0x0, refcnt = 0, flag = 40963, nexthop = {s_addr = 218103814}, med = 0, local_pref = 0, nh_ifindex = 0, 
  origin = 2 '\002', pmsi_tnl_type = PMSI_TNLTYPE_NO_INFO, rmap_change_flags = 0, mp_nexthop_global = {__in6_u = {__u6_addr8 = '\000' <repeats 15 times>, 
      __u6_addr16 = {0, 0, 0, 0, 0, 0, 0, 0}, __u6_addr32 = {0, 0, 0, 0}}}, mp_nexthop_local = {__in6_u = {__u6_addr8 = '\000' <repeats 15 times>, 
      __u6_addr16 = {0, 0, 0, 0, 0, 0, 0, 0}, __u6_addr32 = {0, 0, 0, 0}}}, nh_lla_ifindex = 0, ecommunity = 0x56038e88e300, ipv6_ecommunity = 0x0, 
  lcommunity = 0x0, cluster1 = 0x0, transit = 0x0, mp_nexthop_global_in = {s_addr = 218103814}, aggregator_addr = {s_addr = 0}, originator_id = {
    s_addr = 0}, weight = 0, aggregator_as = 0, mp_nexthop_len = 4 '\004', mp_nexthop_prefer_global = 0 '\000', sticky = 0 '\000', default_gw = 0 '\000', 
  router_flag = 0 '\000', es_flags = 0 '\000', tag = 0, label_index = 4294967295, label = 4294836223, srv6_vpn = 0x0, srv6_l3vpn = 0x0, 
  encap_tunneltype = 8, encap_subtlvs = 0x0, evpn_overlay = {type = OVERLAY_INDEX_TYPE_NONE, eth_s_id = {val = "\000\000\000\000\000\000\000\000\000"}, 
    gw_ip = {ipa_type = IPADDR_NONE, ip = {addr = 0 '\000', _v4_addr = {s_addr = 0}, _v6_addr = {__in6_u = {__u6_addr8 = '\000' <repeats 15 times>, 
            __u6_addr16 = {0, 0, 0, 0, 0, 0, 0, 0}, __u6_addr32 = {0, 0, 0, 0}}}}}}, mm_seqnum = 0, mm_sync_seqnum = 0, rmac = {
    octet = "\000\002\000\000\000'"}, distance = 0 '\000', rmap_table_id = 0, link_bw = 0, esi = {val = "\000\000\000\000\000\000\000\000\000"}, 
  srte_color = 0, df_pref = 0, df_alg = 0 '\000', nh_type = 0, bh_type = BLACKHOLE_UNSPEC, otc = 0}
(gdb) p *attr->evpn_overlay 
Structure has no component named operator*.
(gdb) p attr->evpn_overlay 
$2 = {type = OVERLAY_INDEX_TYPE_NONE, eth_s_id = {val = "\000\000\000\000\000\000\000\000\000"}, gw_ip = {ipa_type = IPADDR_NONE, ip = {addr = 0 '\000', 
      _v4_addr = {s_addr = 0}, _v6_addr = {__in6_u = {__u6_addr8 = '\000' <repeats 15 times>, __u6_addr16 = {0, 0, 0, 0, 0, 0, 0, 0}, __u6_addr32 = {0, 0, 
            0, 0}}}}}}
```


