### PR TITLE
zebra: EVPN handle duplicate detected local mac delete event

### DIFF
--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -1038,12 +1038,11 @@ int zebra_evpn_macip_send_msg_to_client(vni_t vni,
 		char flag_buf[MACIP_BUF_SIZE];
 
 		zlog_debug(
-			"Send MACIP %s f %s MAC %pEA IP %pIA seq %u L2-VNI %u ESI %s to %s",
+			"Send MACIP %s f %s state %u MAC %pEA IP %pIA seq %u L2-VNI %u ESI %s to %s",
 			(cmd == ZEBRA_MACIP_ADD) ? "Add" : "Del",
 			zclient_evpn_dump_macip_flags(flags, flag_buf,
 						      sizeof(flag_buf)),
-			macaddr, ip, seq, vni,
-			es ? es->esi_str : "-",
+			state, macaddr, ip, seq, vni, es ? es->esi_str : "-",
 			zebra_route_string(client->proto));
 	}
 
@@ -2445,7 +2444,7 @@ int zebra_evpn_del_local_mac(struct zebra_evpn *zevpn, struct zebra_mac *mac,
 
 	/* Remove MAC from BGP. */
 	zebra_evpn_mac_send_del_to_client(zevpn->vni, &mac->macaddr, mac->flags,
-					  false /* force */);
+					  clear_static /* force */);
 
 	zebra_evpn_es_mac_deref_entry(mac);
 


### PR DESCRIPTION
In EVPN, duplicate detected local MAC is deleted from dplane/kernel, trigger BGP to re sync remote MAC to zebra. 

If MAC is detected duplicate and froze in Zebra then BGP won't be aware of the local learnt event, BGP has remotely learnt entry. Upon deletion of local MAC event, BGP to resync remote MAC so it can install properly in dplane/kernel.


Commit 1:
```
    zebra: evpn handle del event for dup detected mac

    Upon receiving local mobility event for MAC + NEIGH,
    both are detected as duplicate upon hitting DAD threshold.

    Duplicated detected ( Frozen) MAC + NEIGH are not known to bgpd.

    If locally learnt MAC + NEIGH are deleted in kernel,
    the MAC is marked as AUTO after sending delete event     to bgpd.

    Bgpd only re-installs best route for MAC_IP route (NEIGH)
    but not for MAC event.
    This puts a situation where MAC is AUTO state and
    associated neigh as remote.

    Fix:
    DUPLICATE + LOCAL MAC deletion, set MAC delete request
    as reinstall from bgpd.
```
2. commit 2:

```
    zebra:fix evpn dup detected local mac del event

    The current local mac delete event send to flag with force
    always which breaks the duplicate detected MACs where
    it requires to be resynced from bgpd to earlier state.
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>
