### PR TITLE
*: Rearrange vrf_bitmap_X api to reduce memory footprint

### DIFF
--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -108,14 +108,14 @@ babel_config_write (struct vty *vty)
     /* list redistributed protocols */
     for (afi = AFI_IP; afi <= AFI_IP6; afi++) {
         for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
-            if (i != zclient->redist_default &&
-                vrf_bitmap_check (zclient->redist[afi][i], VRF_DEFAULT)) {
-                vty_out (vty, " redistribute %s %s\n",
-                         (afi == AFI_IP) ? "ipv4" : "ipv6",
-                         zebra_route_string(i));
-                lines++;
-            }
-        }
+		if (i != zclient->redist_default &&
+		    vrf_bitmap_check(&zclient->redist[afi][i], VRF_DEFAULT)) {
+			vty_out(vty, " redistribute %s %s\n",
+				(afi == AFI_IP) ? "ipv4" : "ipv6",
+				zebra_route_string(i));
+			lines++;
+		}
+	}
     }
 
     lines += config_write_distribute (vty, babel_routing_process->distribute_ctx);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1911,7 +1911,7 @@ int bgp_redistribute_set(struct bgp *bgp, afi_t afi, int type,
 
 		redist_add_instance(&zclient->mi_redist[afi][type], instance);
 	} else {
-		if (vrf_bitmap_check(zclient->redist[afi][type], bgp->vrf_id))
+		if (vrf_bitmap_check(&zclient->redist[afi][type], bgp->vrf_id))
 			return CMD_WARNING;
 
 #ifdef ENABLE_BGP_VNC
@@ -1921,7 +1921,7 @@ int bgp_redistribute_set(struct bgp *bgp, afi_t afi, int type,
 		}
 #endif
 
-		vrf_bitmap_set(zclient->redist[afi][type], bgp->vrf_id);
+		vrf_bitmap_set(&zclient->redist[afi][type], bgp->vrf_id);
 	}
 
 	/*
@@ -2042,9 +2042,9 @@ int bgp_redistribute_unreg(struct bgp *bgp, afi_t afi, int type,
 			return CMD_WARNING;
 		redist_del_instance(&zclient->mi_redist[afi][type], instance);
 	} else {
-		if (!vrf_bitmap_check(zclient->redist[afi][type], bgp->vrf_id))
+		if (!vrf_bitmap_check(&zclient->redist[afi][type], bgp->vrf_id))
 			return CMD_WARNING;
-		vrf_bitmap_unset(zclient->redist[afi][type], bgp->vrf_id);
+		vrf_bitmap_unset(&zclient->redist[afi][type], bgp->vrf_id);
 	}
 
 	if (bgp_install_info_to_zebra(bgp)) {

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3654,9 +3654,9 @@ static void bgp_zclient_set_redist(afi_t afi, int type, unsigned short instance,
 					    instance);
 	} else {
 		if (set)
-			vrf_bitmap_set(zclient->redist[afi][type], vrf_id);
+			vrf_bitmap_set(&zclient->redist[afi][type], vrf_id);
 		else
-			vrf_bitmap_unset(zclient->redist[afi][type], vrf_id);
+			vrf_bitmap_unset(&zclient->redist[afi][type], vrf_id);
 	}
 }
 

--- a/bgpd/rfapi/vnc_zebra.c
+++ b/bgpd/rfapi/vnc_zebra.c
@@ -560,9 +560,9 @@ static void vnc_zebra_add_del_prefix(struct bgp *bgp,
 		return;
 	}
 
-	if (!vrf_bitmap_check(
-		    zclient_vnc->redist[family2afi(p->family)][ZEBRA_ROUTE_VNC],
-		    VRF_DEFAULT))
+	if (!vrf_bitmap_check(&zclient_vnc->redist[family2afi(p->family)]
+						  [ZEBRA_ROUTE_VNC],
+			      VRF_DEFAULT))
 		return;
 
 	if (!bgp->rfapi_cfg) {
@@ -622,7 +622,7 @@ static void vnc_zebra_add_del_nve(struct bgp *bgp, struct rfapi_descriptor *rfd,
 	if (zclient_vnc->sock < 0)
 		return;
 
-	if (!vrf_bitmap_check(zclient_vnc->redist[afi][ZEBRA_ROUTE_VNC],
+	if (!vrf_bitmap_check(&zclient_vnc->redist[afi][ZEBRA_ROUTE_VNC],
 			      VRF_DEFAULT))
 		return;
 
@@ -819,12 +819,12 @@ int vnc_redistribute_set(struct bgp *bgp, afi_t afi, int type)
 	//  bgp->redist[afi][type] = 1;
 
 	/* Return if already redistribute flag is set. */
-	if (vrf_bitmap_check(zclient_vnc->redist[afi][type], VRF_DEFAULT))
+	if (vrf_bitmap_check(&zclient_vnc->redist[afi][type], VRF_DEFAULT))
 		return CMD_WARNING_CONFIG_FAILED;
 
-	vrf_bitmap_set(zclient_vnc->redist[afi][type], VRF_DEFAULT);
+	vrf_bitmap_set(&zclient_vnc->redist[afi][type], VRF_DEFAULT);
 
-	// vrf_bitmap_set(zclient_vnc->redist[afi][type], VRF_DEFAULT);
+	// vrf_bitmap_set(&zclient_vnc->redist[afi][type], VRF_DEFAULT);
 
 	/* Return if zebra connection is not established. */
 	if (zclient_vnc->sock < 0)
@@ -855,9 +855,9 @@ int vnc_redistribute_unset(struct bgp *bgp, afi_t afi, int type)
 	bgp->rfapi_cfg->redist[afi][type] = 0;
 
 	/* Return if zebra connection is disabled. */
-	if (!vrf_bitmap_check(zclient_vnc->redist[afi][type], VRF_DEFAULT))
+	if (!vrf_bitmap_check(&zclient_vnc->redist[afi][type], VRF_DEFAULT))
 		return CMD_WARNING_CONFIG_FAILED;
-	vrf_bitmap_unset(zclient_vnc->redist[afi][type], VRF_DEFAULT);
+	vrf_bitmap_unset(&zclient_vnc->redist[afi][type], VRF_DEFAULT);
 
 	if (bgp->rfapi_cfg->redist[AFI_IP][type] == 0
 	    && bgp->rfapi_cfg->redist[AFI_IP6][type] == 0

--- a/eigrpd/eigrp_northbound.c
+++ b/eigrpd/eigrp_northbound.c
@@ -724,7 +724,7 @@ static int eigrpd_instance_redistribute_create(struct nb_cb_create_args *args)
 		else
 			vrfid = VRF_DEFAULT;
 
-		if (vrf_bitmap_check(zclient->redist[AFI_IP][proto], vrfid))
+		if (vrf_bitmap_check(&zclient->redist[AFI_IP][proto], vrfid))
 			return NB_ERR_INCONSISTENCY;
 		break;
 	case NB_EV_PREPARE:

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -249,9 +249,9 @@ void eigrp_zebra_route_delete(struct eigrp *eigrp, struct prefix *p)
 static int eigrp_is_type_redistributed(int type, vrf_id_t vrf_id)
 {
 	return ((DEFAULT_ROUTE_TYPE(type))
-			? vrf_bitmap_check(zclient->default_information[AFI_IP],
-					   vrf_id)
-			: vrf_bitmap_check(zclient->redist[AFI_IP][type],
+			? vrf_bitmap_check(
+				  &zclient->default_information[AFI_IP], vrf_id)
+			: vrf_bitmap_check(&zclient->redist[AFI_IP][type],
 					   vrf_id));
 }
 

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -638,22 +638,22 @@ static void isis_set_redist_vrf_bitmaps(struct isis *isis, bool set)
 			if (type == DEFAULT_ROUTE) {
 				if (set)
 					vrf_bitmap_set(
-						zclient->default_information
-							[afi],
+						&zclient->default_information
+							 [afi],
 						isis->vrf_id);
 				else
 					vrf_bitmap_unset(
-						zclient->default_information
-							[afi],
+						&zclient->default_information
+							 [afi],
 						isis->vrf_id);
 			} else {
 				if (set)
 					vrf_bitmap_set(
-						zclient->redist[afi][type],
+						&zclient->redist[afi][type],
 						isis->vrf_id);
 				else
 					vrf_bitmap_unset(
-						zclient->redist[afi][type],
+						&zclient->redist[afi][type],
 						isis->vrf_id);
 			}
 		}

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -167,15 +167,14 @@ extern void *vrf_info_lookup(vrf_id_t);
 /*
  * VRF bit-map: maintaining flags, one bit per VRF ID
  */
-
 typedef void *vrf_bitmap_t;
 #define VRF_BITMAP_NULL     NULL
 
-extern vrf_bitmap_t vrf_bitmap_init(void);
-extern void vrf_bitmap_free(vrf_bitmap_t);
-extern void vrf_bitmap_set(vrf_bitmap_t, vrf_id_t);
-extern void vrf_bitmap_unset(vrf_bitmap_t, vrf_id_t);
-extern int vrf_bitmap_check(vrf_bitmap_t, vrf_id_t);
+extern void vrf_bitmap_init(vrf_bitmap_t *pbmap);
+extern void vrf_bitmap_free(vrf_bitmap_t *pbmap);
+extern void vrf_bitmap_set(vrf_bitmap_t *pbmap, vrf_id_t vrf_id);
+extern void vrf_bitmap_unset(vrf_bitmap_t *pbmap, vrf_id_t vrf_id);
+extern int vrf_bitmap_check(vrf_bitmap_t *pbmap, vrf_id_t vrf_id);
 
 /*
  * VRF initializer/destructor

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -140,20 +140,20 @@ static void ospf6_set_redist_vrf_bitmaps(struct ospf6 *ospf6, bool set)
 				"%s: setting redist vrf %d bitmap for type %d",
 				__func__, ospf6->vrf_id, type);
 		if (set)
-			vrf_bitmap_set(zclient->redist[AFI_IP6][type],
+			vrf_bitmap_set(&zclient->redist[AFI_IP6][type],
 				       ospf6->vrf_id);
 		else
-			vrf_bitmap_unset(zclient->redist[AFI_IP6][type],
+			vrf_bitmap_unset(&zclient->redist[AFI_IP6][type],
 					 ospf6->vrf_id);
 	}
 
 	red_list = ospf6->redist[DEFAULT_ROUTE];
 	if (red_list) {
 		if (set)
-			vrf_bitmap_set(zclient->default_information[AFI_IP6],
+			vrf_bitmap_set(&zclient->default_information[AFI_IP6],
 				       ospf6->vrf_id);
 		else
-			vrf_bitmap_unset(zclient->default_information[AFI_IP6],
+			vrf_bitmap_unset(&zclient->default_information[AFI_IP6],
 					 ospf6->vrf_id);
 	}
 }

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -97,9 +97,9 @@ static int ospf6_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 /* redistribute function */
 void ospf6_zebra_redistribute(int type, vrf_id_t vrf_id)
 {
-	if (vrf_bitmap_check(zclient->redist[AFI_IP6][type], vrf_id))
+	if (vrf_bitmap_check(&zclient->redist[AFI_IP6][type], vrf_id))
 		return;
-	vrf_bitmap_set(zclient->redist[AFI_IP6][type], vrf_id);
+	vrf_bitmap_set(&zclient->redist[AFI_IP6][type], vrf_id);
 
 	if (zclient->sock > 0)
 		zebra_redistribute_send(ZEBRA_REDISTRIBUTE_ADD, zclient,
@@ -108,9 +108,9 @@ void ospf6_zebra_redistribute(int type, vrf_id_t vrf_id)
 
 void ospf6_zebra_no_redistribute(int type, vrf_id_t vrf_id)
 {
-	if (!vrf_bitmap_check(zclient->redist[AFI_IP6][type], vrf_id))
+	if (!vrf_bitmap_check(&zclient->redist[AFI_IP6][type], vrf_id))
 		return;
-	vrf_bitmap_unset(zclient->redist[AFI_IP6][type], vrf_id);
+	vrf_bitmap_unset(&zclient->redist[AFI_IP6][type], vrf_id);
 	if (zclient->sock > 0)
 		zebra_redistribute_send(ZEBRA_REDISTRIBUTE_DELETE, zclient,
 					AFI_IP6, type, 0, vrf_id);
@@ -333,10 +333,10 @@ DEFUN(show_zebra,
 		json_object_int_add(json_zebra, "fail", zclient->fail);
 		json_object_int_add(
 			json_zebra, "redistributeDefault",
-			vrf_bitmap_check(zclient->default_information[AFI_IP6],
+			vrf_bitmap_check(&zclient->default_information[AFI_IP6],
 					 VRF_DEFAULT));
 		for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
-			if (vrf_bitmap_check(zclient->redist[AFI_IP6][i],
+			if (vrf_bitmap_check(&zclient->redist[AFI_IP6][i],
 					     VRF_DEFAULT))
 				json_object_array_add(
 					json_array,
@@ -351,11 +351,11 @@ DEFUN(show_zebra,
 		vty_out(vty, "Zebra Information\n");
 		vty_out(vty, "  fail: %d\n", zclient->fail);
 		vty_out(vty, "  redistribute default: %d\n",
-			vrf_bitmap_check(zclient->default_information[AFI_IP6],
+			vrf_bitmap_check(&zclient->default_information[AFI_IP6],
 					 VRF_DEFAULT));
 		vty_out(vty, "  redistribute:");
 		for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
-			if (vrf_bitmap_check(zclient->redist[AFI_IP6][i],
+			if (vrf_bitmap_check(&zclient->redist[AFI_IP6][i],
 					     VRF_DEFAULT))
 				vty_out(vty, " %s", zebra_route_string(i));
 		}

--- a/ospf6d/ospf6_zebra.h
+++ b/ospf6d/ospf6_zebra.h
@@ -38,7 +38,7 @@ extern void ospf6_zebra_route_update_remove(struct ospf6_route *request,
 extern void ospf6_zebra_redistribute(int, vrf_id_t vrf_id);
 extern void ospf6_zebra_no_redistribute(int, vrf_id_t vrf_id);
 #define ospf6_zebra_is_redistribute(type, vrf_id)                              \
-	vrf_bitmap_check(zclient->redist[AFI_IP6][type], vrf_id)
+	vrf_bitmap_check(&zclient->redist[AFI_IP6][type], vrf_id)
 extern void ospf6_zebra_init(struct event_loop *tm);
 extern void ospf6_zebra_import_default_route(struct ospf6 *ospf6, bool unreg);
 extern void ospf6_zebra_add_discard(struct ospf6_route *request,

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -154,11 +154,11 @@ struct external_info *ospf_external_info_check(struct ospf *ospf,
 		redist_on =
 			is_default_prefix4(&p)
 				? vrf_bitmap_check(
-					zclient->default_information[AFI_IP],
-					ospf->vrf_id)
-				: (zclient->mi_redist[AFI_IP][type].enabled
-				   || vrf_bitmap_check(
-					   zclient->redist[AFI_IP][type],
+					  &zclient->default_information[AFI_IP],
+					  ospf->vrf_id)
+				: (zclient->mi_redist[AFI_IP][type].enabled ||
+				   vrf_bitmap_check(
+					   &zclient->redist[AFI_IP][type],
 					   ospf->vrf_id));
 		// Pending: check for MI above.
 		if (redist_on) {

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -814,16 +814,16 @@ int ospf_is_type_redistributed(struct ospf *ospf, int type,
 			       unsigned short instance)
 {
 	return (DEFAULT_ROUTE_TYPE(type)
-			? vrf_bitmap_check(zclient->default_information[AFI_IP],
-					   ospf->vrf_id)
-			: ((instance
-			    && redist_check_instance(
+			? vrf_bitmap_check(
+				  &zclient->default_information[AFI_IP],
+				  ospf->vrf_id)
+			: ((instance &&
+			    redist_check_instance(
 				    &zclient->mi_redist[AFI_IP][type],
-				    instance))
-			   || (!instance
-			       && vrf_bitmap_check(
-				       zclient->redist[AFI_IP][type],
-				       ospf->vrf_id))));
+				    instance)) ||
+			   (!instance &&
+			    vrf_bitmap_check(&zclient->redist[AFI_IP][type],
+					     ospf->vrf_id))));
 }
 
 int ospf_redistribute_update(struct ospf *ospf, struct ospf_redist *red,

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -2284,20 +2284,20 @@ static void ospf_set_redist_vrf_bitmaps(struct ospf *ospf, bool set)
 				"%s: setting redist vrf %d bitmap for type %d",
 				__func__, ospf->vrf_id, type);
 		if (set)
-			vrf_bitmap_set(zclient->redist[AFI_IP][type],
+			vrf_bitmap_set(&zclient->redist[AFI_IP][type],
 				       ospf->vrf_id);
 		else
-			vrf_bitmap_unset(zclient->redist[AFI_IP][type],
+			vrf_bitmap_unset(&zclient->redist[AFI_IP][type],
 					 ospf->vrf_id);
 	}
 
 	red_list = ospf->redist[DEFAULT_ROUTE];
 	if (red_list) {
 		if (set)
-			vrf_bitmap_set(zclient->default_information[AFI_IP],
+			vrf_bitmap_set(&zclient->default_information[AFI_IP],
 				       ospf->vrf_id);
 		else
-			vrf_bitmap_unset(zclient->default_information[AFI_IP],
+			vrf_bitmap_unset(&zclient->default_information[AFI_IP],
 					 ospf->vrf_id);
 	}
 }

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -60,7 +60,7 @@ static void zebra_redistribute_default(struct zserv *client, vrf_id_t vrf_id)
 
 	for (afi = AFI_IP; afi <= AFI_IP6; afi++) {
 
-		if (!vrf_bitmap_check(client->redist_default[afi], vrf_id))
+		if (!vrf_bitmap_check(&client->redist_default[afi], vrf_id))
 			continue;
 
 		/* Lookup table.  */
@@ -151,11 +151,11 @@ static bool zebra_redistribute_check(const struct route_node *rn,
 
 	/* If default route and redistributed */
 	if (is_default_prefix(&rn->p) &&
-	    vrf_bitmap_check(client->redist_default[afi], re->vrf_id))
+	    vrf_bitmap_check(&client->redist_default[afi], re->vrf_id))
 		return true;
 
 	/* If redistribute in enabled for zebra route all */
-	if (vrf_bitmap_check(client->redist[afi][ZEBRA_ROUTE_ALL], re->vrf_id))
+	if (vrf_bitmap_check(&client->redist[afi][ZEBRA_ROUTE_ALL], re->vrf_id))
 		return true;
 
 	/*
@@ -171,7 +171,7 @@ static bool zebra_redistribute_check(const struct route_node *rn,
 	}
 
 	/* If redistribution is enabled for give route type. */
-	if (vrf_bitmap_check(client->redist[afi][re->type], re->vrf_id))
+	if (vrf_bitmap_check(&client->redist[afi][re->type], re->vrf_id))
 		return true;
 
 	return false;
@@ -331,14 +331,14 @@ void zebra_redistribute_add(ZAPI_HANDLER_ARGS)
 					   zvrf_id(zvrf), afi);
 		}
 	} else {
-		if (!vrf_bitmap_check(client->redist[afi][type],
+		if (!vrf_bitmap_check(&client->redist[afi][type],
 				      zvrf_id(zvrf))) {
 			if (IS_ZEBRA_DEBUG_EVENT)
 				zlog_debug(
 					"%s: setting vrf %s(%u) redist bitmap",
 					__func__, VRF_LOGNAME(zvrf->vrf),
 					zvrf_id(zvrf));
-			vrf_bitmap_set(client->redist[afi][type],
+			vrf_bitmap_set(&client->redist[afi][type],
 				       zvrf_id(zvrf));
 			zebra_redistribute(client, type, 0, zvrf_id(zvrf), afi);
 		}
@@ -387,7 +387,7 @@ void zebra_redistribute_delete(ZAPI_HANDLER_ARGS)
 	if (instance)
 		redist_del_instance(&client->mi_redist[afi][type], instance);
 	else
-		vrf_bitmap_unset(client->redist[afi][type], zvrf_id(zvrf));
+		vrf_bitmap_unset(&client->redist[afi][type], zvrf_id(zvrf));
 
 stream_failure:
 	return;
@@ -405,7 +405,7 @@ void zebra_redistribute_default_add(ZAPI_HANDLER_ARGS)
 		return;
 	}
 
-	vrf_bitmap_set(client->redist_default[afi], zvrf_id(zvrf));
+	vrf_bitmap_set(&client->redist_default[afi], zvrf_id(zvrf));
 	zebra_redistribute_default(client, zvrf_id(zvrf));
 
 stream_failure:
@@ -424,7 +424,7 @@ void zebra_redistribute_default_delete(ZAPI_HANDLER_ARGS)
 		return;
 	}
 
-	vrf_bitmap_unset(client->redist_default[afi], zvrf_id(zvrf));
+	vrf_bitmap_unset(&client->redist_default[afi], zvrf_id(zvrf));
 
 stream_failure:
 	return;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -995,7 +995,7 @@ void zsend_nhrp_neighbor_notify(int cmd, struct interface *ifp,
 	       family2addrsize(sockunion_family(&ip)));
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
-		if (!vrf_bitmap_check(client->nhrp_neighinfo[afi],
+		if (!vrf_bitmap_check(&client->nhrp_neighinfo[afi],
 				      ifp->vrf->vrf_id))
 			continue;
 
@@ -1016,7 +1016,7 @@ int zsend_router_id_update(struct zserv *client, afi_t afi, struct prefix *p,
 	struct stream *s;
 
 	/* Check this client need interface information. */
-	if (!vrf_bitmap_check(client->ridinfo[afi], vrf_id))
+	if (!vrf_bitmap_check(&client->ridinfo[afi], vrf_id))
 		return 0;
 
 	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
@@ -2281,7 +2281,7 @@ static void zread_router_id_add(ZAPI_HANDLER_ARGS)
 	}
 
 	/* Router-id information is needed. */
-	vrf_bitmap_set(client->ridinfo[afi], zvrf_id(zvrf));
+	vrf_bitmap_set(&client->ridinfo[afi], zvrf_id(zvrf));
 
 	router_id_get(afi, &p, zvrf);
 
@@ -2317,7 +2317,7 @@ static void zread_router_id_delete(ZAPI_HANDLER_ARGS)
 		goto stream_failure;
 	}
 
-	vrf_bitmap_unset(client->ridinfo[afi], zvrf_id(zvrf));
+	vrf_bitmap_unset(&client->ridinfo[afi], zvrf_id(zvrf));
 
 stream_failure:
 	return;
@@ -2407,10 +2407,11 @@ static void zread_vrf_unregister(ZAPI_HANDLER_ARGS)
 
 	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
 		for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
-			vrf_bitmap_unset(client->redist[afi][i], zvrf_id(zvrf));
-		vrf_bitmap_unset(client->redist_default[afi], zvrf_id(zvrf));
-		vrf_bitmap_unset(client->ridinfo[afi], zvrf_id(zvrf));
-		vrf_bitmap_unset(client->nhrp_neighinfo[afi], zvrf_id(zvrf));
+			vrf_bitmap_unset(&client->redist[afi][i],
+					 zvrf_id(zvrf));
+		vrf_bitmap_unset(&client->redist_default[afi], zvrf_id(zvrf));
+		vrf_bitmap_unset(&client->ridinfo[afi], zvrf_id(zvrf));
+		vrf_bitmap_unset(&client->nhrp_neighinfo[afi], zvrf_id(zvrf));
 	}
 }
 
@@ -3563,7 +3564,7 @@ static inline void zebra_neigh_register(ZAPI_HANDLER_ARGS)
 			afi);
 		goto stream_failure;
 	}
-	vrf_bitmap_set(client->nhrp_neighinfo[afi], zvrf_id(zvrf));
+	vrf_bitmap_set(&client->nhrp_neighinfo[afi], zvrf_id(zvrf));
 stream_failure:
 	return;
 }
@@ -3579,7 +3580,7 @@ static inline void zebra_neigh_unregister(ZAPI_HANDLER_ARGS)
 			afi);
 		goto stream_failure;
 	}
-	vrf_bitmap_unset(client->nhrp_neighinfo[afi], zvrf_id(zvrf));
+	vrf_bitmap_unset(&client->nhrp_neighinfo[afi], zvrf_id(zvrf));
 stream_failure:
 	return;
 }

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -634,13 +634,13 @@ static void zserv_client_free(struct zserv *client)
 	/* Free bitmaps. */
 	for (afi_t afi = AFI_IP; afi < AFI_MAX; afi++) {
 		for (int i = 0; i < ZEBRA_ROUTE_MAX; i++) {
-			vrf_bitmap_free(client->redist[afi][i]);
+			vrf_bitmap_free(&client->redist[afi][i]);
 			redist_del_all_instances(&client->mi_redist[afi][i]);
 		}
 
-		vrf_bitmap_free(client->redist_default[afi]);
-		vrf_bitmap_free(client->ridinfo[afi]);
-		vrf_bitmap_free(client->nhrp_neighinfo[afi]);
+		vrf_bitmap_free(&client->redist_default[afi]);
+		vrf_bitmap_free(&client->ridinfo[afi]);
+		vrf_bitmap_free(&client->nhrp_neighinfo[afi]);
 	}
 
 	/*
@@ -758,10 +758,10 @@ static struct zserv *zserv_client_create(int sock)
 	/* Initialize flags */
 	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
 		for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
-			client->redist[afi][i] = vrf_bitmap_init();
-		client->redist_default[afi] = vrf_bitmap_init();
-		client->ridinfo[afi] = vrf_bitmap_init();
-		client->nhrp_neighinfo[afi] = vrf_bitmap_init();
+			vrf_bitmap_init(&client->redist[afi][i]);
+		vrf_bitmap_init(&client->redist_default[afi]);
+		vrf_bitmap_init(&client->ridinfo[afi]);
+		vrf_bitmap_init(&client->nhrp_neighinfo[afi]);
 	}
 
 	/* Add this client to linked list. */


### PR DESCRIPTION
When running all daemons with config for most of them, FRR has sharpd@janelle:~/frr$ vtysh -c "show debug hashtable"  | grep "VRF BIT HASH" | wc -l 3570

3570 hashes for bitmaps associated with the vrf.  This is a very large number of hashes.  Let's do two things:

a) Reduce the created size of the actually created hashes to 2 instead of 32.

b) Delay generation of the hash *until* a set operation happens. As that no hash directly implies a unset value if/when checked.

This reduces the number of hashes to 61 in my setup for normal operation.