### PR TITLE
bgpd: configure explicit-null for local paths per address family

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3087,10 +3087,13 @@ static bool bgp_lu_need_null_label(struct bgp *bgp,
 need_null_label:
 	if (label == NULL)
 		return true;
-	if (!!CHECK_FLAG(bgp->flags, BGP_FLAG_LU_EXPLICIT_NULL))
-		/* Disable PHP : explicit-null */
-		*label = afi == AFI_IP ? MPLS_LABEL_IPV4_EXPLICIT_NULL
-				       : MPLS_LABEL_IPV6_EXPLICIT_NULL;
+	/* Disable PHP : explicit-null */
+	if (!!CHECK_FLAG(bgp->flags, BGP_FLAG_LU_IPV4_EXPLICIT_NULL) &&
+	    afi == AFI_IP)
+		*label = MPLS_LABEL_IPV4_EXPLICIT_NULL;
+	else if (!!CHECK_FLAG(bgp->flags, BGP_FLAG_LU_IPV6_EXPLICIT_NULL) &&
+		 afi == AFI_IP6)
+		*label = MPLS_LABEL_IPV6_EXPLICIT_NULL;
 	else
 		/* Enforced PHP popping: implicit-null */
 		*label = MPLS_LABEL_IMPLICIT_NULL;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -500,8 +500,10 @@ struct bgp {
 #define BGP_FLAG_HARD_ADMIN_RESET (1ULL << 31)
 /* Evaluate the AIGP attribute during the best path selection process */
 #define BGP_FLAG_COMPARE_AIGP (1ULL << 32)
-/* For BGP-LU, force local prefixes to use explicit-null label */
-#define BGP_FLAG_LU_EXPLICIT_NULL (1ULL << 33)
+/* For BGP-LU, force IPv4 local prefixes to use ipv4-explicit-null label */
+#define BGP_FLAG_LU_IPV4_EXPLICIT_NULL (1ULL << 33)
+/* For BGP-LU, force IPv6 local prefixes to use ipv6-explicit-null label */
+#define BGP_FLAG_LU_IPV6_EXPLICIT_NULL (1ULL << 34)
 
 	/* BGP default address-families.
 	 * New peers inherit enabled afi/safis from bgp instance.

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2780,7 +2780,7 @@ Labeled unicast
 
 *bgpd* supports labeled information, as per :rfc:`3107`.
 
-.. clicmd:: bgp labeled-unicast explicit-null
+.. clicmd:: bgp labeled-unicast <explicit-null|ipv4-explicit-null|ipv6-explicit-null>
 
 By default, locally advertised prefixes use the `implicit-null` label to
 encode in the outgoing NLRI. The following command uses the `explicit-null`


### PR DESCRIPTION
Until now, the bgp local paths were using the default null label defined. It was not possible to select the null label for the ipv4 or the ipv6 address families.

This commit addresses this issues by adding two extra-parameters to the BGP labeled-unicast command.