### PR TITLE
bgpd: Fix one dependency of evpn commands

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1698,6 +1698,7 @@ DEFUN (no_router_bgp,
 								[SAFI_UNICAST],
 					       BGP_CONFIG_VRF_TO_VRF_EXPORT) ||
 				    (bgp == bgp_get_evpn() &&
+				     bgp->advertise_all_vni &&
 				     (CHECK_FLAG(
 					      tmp_bgp->af_flags[AFI_L2VPN]
 							       [SAFI_EVPN],


### PR DESCRIPTION
```
anlan(config)# router bgp 8 vrf vrf1
anlan(config-router)# address-family l2vpn evpn
anlan(config-router-af)# advertise ipv4 unicast
anlan(config)# router bgp 8
anlan(config-router)# exit
anlan(config)# no router bgp 8
% Cannot delete default BGP instance. Dependent VRF instances exist
```

Since there is no `advertise-all-vni` in "router bgp 8", it should be able to be removed.

With this commit, the `bgp_evpn` without `advertise-all-vni` can be removed.