### PR TITLE
zebra: Fix connected route deletion when multiple entry exists

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2907,8 +2907,8 @@ static void process_subq_early_route_delete(struct zebra_early_route *ere)
 
 	struct nexthop *nh = NULL;
 
-	if (ere->re->nhe)
-		nh = ere->re->nhe->nhg.nexthop;
+	if (ere->re_nhe)
+		nh = ere->re_nhe->nhg.nexthop;
 
 	/* Lookup same type route. */
 	RNODE_FOREACH_RE (rn, re) {
@@ -2926,7 +2926,8 @@ static void process_subq_early_route_delete(struct zebra_early_route *ere)
 		if (re->type == ZEBRA_ROUTE_KERNEL &&
 		    re->metric != ere->re->metric)
 			continue;
-		if (re->type == ZEBRA_ROUTE_CONNECT && (rtnh = nh) &&
+		if (re->type == ZEBRA_ROUTE_CONNECT &&
+		    (rtnh = re->nhe->nhg.nexthop) &&
 		    rtnh->type == NEXTHOP_TYPE_IFINDEX && nh) {
 			if (rtnh->ifindex != nh->ifindex)
 				continue;


### PR DESCRIPTION
When multiple interfaces have addresses in the same network, deleting one of them may cause the wrong connected route being deleted. For example:

    ip link add veth1 type veth peer veth2
    ip link set veth1 up
    ip link set veth2 up
    ip addr add dev veth1 192.168.0.1/24
    ip addr add dev veth2 192.168.0.2/24
    ip addr flush dev veth1

Zebra deletes the route of interface veth2 rather than veth1.

Should match nexthop against ere->re_nhe instead of ere->re->nhe.