### PR TITLE
pimd: Fix possible null of pim instance

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -2471,6 +2471,19 @@ static void gm_show_if_vrf(struct vty *vty, struct vrf *vrf, const char *ifname,
 
 		if (js) {
 			js_if = json_object_new_object();
+			/*
+			 * If we have js as true and detail as false
+			 * and if Coverity thinks that js_if is NULL
+			 * because of a failed call to new then
+			 * when we call gm_show_if_one below
+			 * the tt can be deref'ed and as such
+			 * FRR will crash.  But since we know
+			 * that json_object_new_object never fails
+			 * then let's tell Coverity that this assumption
+			 * is true.  I'm not worried about fast path
+			 * here at all.
+			 */
+			assert(js_if);
 			json_object_object_add(js_vrf, ifp->name, js_if);
 		}
 

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -68,6 +68,8 @@ static int pim_zebra_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 			   vrf_id, new_vrf_id);
 
 	pim = pim_get_pim_instance(new_vrf_id);
+	if (!pim)
+		return 0;
 
 	if_update_to_new_vrf(ifp, new_vrf_id);
 


### PR DESCRIPTION
Coverity shows a path where the pim instance may
be null.  In this code path if we have no pim
vrf there is nothing to do anyway so just return