### PR TITLE
lib: typesafe shenanigans

### DIFF
--- a/lib/typesafe.c
+++ b/lib/typesafe.c
@@ -85,6 +85,15 @@ void typesafe_hash_grow(struct thash_head *head)
 	uint32_t newsize = head->count, i, j;
 	uint8_t newshift, delta;
 
+	/* note hash_grow is called after head->count++, so newsize is
+	 * guaranteed to be >= 1.  So the minimum argument to builtin_ctz
+	 * below is 2, which returns 1, and that makes newshift >= 2.
+	 *
+	 * Calling hash_grow with a zero head->count would result in a
+	 * malformed hash table that has tabshift == 1.
+	 */
+	assert(head->count > 0);
+
 	hash_consistency_check(head);
 
 	newsize |= newsize >> 1;

--- a/lib/typesafe.h
+++ b/lib/typesafe.h
@@ -948,6 +948,8 @@ macro_pure size_t prefix ## _count(const struct prefix##_head *h)              \
 macro_pure bool prefix ## _member(const struct prefix##_head *h,               \
 				  const type *item)                            \
 {                                                                              \
+	if (!h->hh.tabshift)                                                   \
+		return NULL;                                                   \
 	uint32_t hval = item->field.hi.hashval, hbits = HASH_KEY(h->hh, hval); \
 	const struct thash_item *hitem = h->hh.entries[hbits];                 \
 	while (hitem && hitem->hashval < hval)                                 \

--- a/tests/lib/test_typelist.h
+++ b/tests/lib/test_typelist.h
@@ -171,6 +171,11 @@ static void concat(test_, TYPE)(void)
 
 	ts_hash("init", "df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119");
 
+#if !IS_ATOMIC(REALTYPE)
+	assert(!list_member(&head, &itm[0]));
+	assert(!list_member(&head, &itm[1]));
+#endif
+
 #if IS_SORTED(REALTYPE)
 	prng = prng_new(0);
 	k = 0;


### PR DESCRIPTION
Coverity sent me on a chase to understand my own code, so the first commit here is just additional breadcrumbs to understand how `tabshift` works.

However, while looking over the constraints regarding `tabshift`, I noticed the typesafe hash `_member()` is actually missing a check and will crash if used on an empty hash table. Oops.

(We have no code using `_member` on a hash, it's only used on an RB tree in lib/cspf.c.)