### PR TITLE
handling obsolete command RIP_POLL in ripd

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -1963,8 +1963,12 @@ static void rip_read(struct event *t)
 		rip_response_process(packet, len, &from, ifc);
 		break;
 	case RIP_REQUEST:
-	case RIP_POLL:
 		rip_request_process(packet, len, &from, ifc);
+		break;
+	case RIP_POLL:
+		zlog_info("Obsolete command %s received",
+			  lookup_msg(rip_msg, packet->command, NULL));
+		rip_peer_bad_packet(rip, &from);
 		break;
 	case RIP_TRACEON:
 	case RIP_TRACEOFF:


### PR DESCRIPTION
It seems that there is no longer use for RIP_POLL any longer according to issue https://github.com/FRRouting/frr/issues/13136.
So I try to deal with it as other obsolete command, thanks.

According to rfc1058: 
<img width="1207" alt="image" src="https://user-images.githubusercontent.com/47736210/228433917-7b8a70f0-780f-45f8-8c1e-0943e1ab232c.png">

https://www.rfc-editor.org/rfc/rfc1058
In FRR project, RIP_POLL is defined as one of the command types, with the value 5.
#define RIP_POLL                         5
https://github.com/FRRouting/frr/blob/5b314d5fc433256a377438e963699592c5e23972/ripd/ripd.c#L1966