### PR TITLE
babeld: add parse_request_subtlv into parse_packet

### DIFF
--- a/babeld/message.h
+++ b/babeld/message.h
@@ -34,6 +34,7 @@ Copyright (c) 2007, 2008 by Juliusz Chroboczek
 #define SUBTLV_PADN 1
 #define SUBTLV_DIVERSITY 2 /* Also known as babelz. */
 #define SUBTLV_TIMESTAMP 3 /* Used to compute RTT. */
+#define SUBTLV_SOURCE_PREFIX 128 /* Source-specific routing. */
 #define SUBTLV_MANDATORY 0x80
 
 extern unsigned short myseqno;

--- a/babeld/util.h
+++ b/babeld/util.h
@@ -104,6 +104,12 @@ void uchar_to_in6addr(struct in6_addr *dest, const unsigned char *src);
 int daemonise(void);
 extern const unsigned char v4prefix[16];
 
+static inline bool
+is_default(const unsigned char *prefix, int plen)
+{
+    return plen == 0 || (plen == 96 && v4mapped(prefix));
+}
+
 /* If debugging is disabled, we want to avoid calling format_address
    for every omitted debugging message.  So debug is a macro.  But
    vararg macros are not portable. */


### PR DESCRIPTION
According to rfc8966
https://www.rfc-editor.org/rfc/rfc8966#name-compatibility-with-previous
https://datatracker.ietf.org/doc/html/draft-ietf-babel-source-specific-07#section-4.4
1. when type is MESSAGE_REQUEST, babel should be able to handle sub_tlvs
2. a wildcard request with a source prefix MUST be ignored

Signed-off-by: zmw12306 <zmw12306@gmail.com>