### PR TITLE
babeld: ignore nonzero flag bits in Hello TLVs

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -414,18 +414,6 @@ parse_packet(const unsigned char *from, struct interface *ifp,
 		DO_NTOHS(flags, message + 2);
 
 		/*
-		 * RFC 8966 4.6.5
-		 * All other bits MUST be sent as a 0 and silently
-		 * ignored on reception
-		 */
-		if (CHECK_FLAG(flags, ~BABEL_UNICAST_HELLO)) {
-			debugf(BABEL_DEBUG_COMMON,
-			       "Received Hello from %s on %s that does not have all 0's in the unused section of flags, ignoring",
-			       format_address(from), ifp->name);
-			goto done;
-		}
-
-		/*
 		 * RFC 8966 Appendix F
 		 * TL;DR -> Please ignore Unicast hellos until FRR's
 		 * BABEL is brought up to date


### PR DESCRIPTION
Ignore all other bits(except U) in Hello TLVs, according to   #@RFC8966

Signed-off-by: zmw12306 <zmw12306@gmail.com>