### PR TITLE
babeld: fix handling retractions for update packets

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -554,7 +554,7 @@ parse_packet(const unsigned char *from, struct interface *ifp,
                 }
                 have_router_id = 1;
             }
-            if(!have_router_id && message[2] != 0) {
+            if(metric < 0xFFFF && !have_router_id && message[2] != 0) {
                 flog_err(EC_BABEL_PACKET,
 			  "Received prefix with no router id.");
                 goto fail;
@@ -574,7 +574,7 @@ parse_packet(const unsigned char *from, struct interface *ifp,
                 retract_neighbour_routes(neigh);
                 goto done;
             } else if(message[2] == 1) {
-                if(!have_v4_nh)
+                if(!have_v4_nh && metric < 0xFFFF)
                     goto fail;
                 nh = v4_nh;
             } else if(have_v6_nh) {

--- a/babeld/route.h
+++ b/babeld/route.h
@@ -64,7 +64,7 @@ route_metric_noninterfering(const struct babel_route *route)
 }
 
 struct babel_route *find_route(const unsigned char *prefix, unsigned char plen,
-                         struct neighbour *neigh, const unsigned char *nexthop);
+                         struct neighbour *neigh);
 struct babel_route *find_installed_route(const unsigned char *prefix,
                                    unsigned char plen);
 int installed_routes_estimate(void);


### PR DESCRIPTION
RFC8966 3.6 and 4.6.9:
if the metric field if 0xFFFF, a retraction happens So it is acceptable for no router_id when metric is 0xFFFF while ae is not 0

https://datatracker.ietf.org/doc/html/rfc8966#section-3.6
https://datatracker.ietf.org/doc/html/rfc8966#section-4.6.9

Signed-off-by: zmw12306 <zmw12306@gmail.com>