### PR TITLE
ripd: add non-zero check for RIPv1 reserved field

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -1171,6 +1171,12 @@ static void rip_response_process(struct rip_packet *packet, int size,
 			continue;
 		}
 
+		if (packet->version == RIPv1 && rte->tag != 0) {
+			zlog_warn("RIPv1 reserved field is nonzero: %d",
+				  ntohs(rte->tag));
+			continue;
+		}
+
 		/* - is the destination address valid (e.g., unicast; not net 0
 		   or 127) */
 		if (!rip_destination_check(rte->prefix)) {


### PR DESCRIPTION
According to RFC2453 3.6, the tag of a RIP-1 entry should be zero
<img width="923" alt="截屏2023-04-23 下午11 14 49" src="https://user-images.githubusercontent.com/47736210/233892275-98dbfa03-f4dc-40e5-893b-7131575034e3.png">

https://datatracker.ietf.org/doc/html/rfc2453#section-3.6
Signed-off-by: zmw12306 <zmw12306@gmail.com>