### PR TITLE
nhrpd: Fix nhrpd memory leak

### DIFF
--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -420,6 +420,7 @@ void nhrp_nhs_terminate(void)
 				       &nifp->afi[afi].nhslist_head, nhs)
 				nhrp_nhs_free(nifp, afi, nhs);
 		}
+		nhrp_peer_interface_del(ifp);
 	}
 }
 


### PR DESCRIPTION
Free NHRP peers associated with an interface when NHS is deleted on shutdown