### PR TITLE
fix missed passing pytestconfig arg.

### DIFF
--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -15,13 +15,14 @@ import time
 
 import lib.fixtures
 import pytest
-from lib.micronet_compat import ConfigOptionsProxy, Mininet
+from lib.micronet_compat import Mininet
 from lib.topogen import diagnose_env, get_topogen
 from lib.topolog import get_test_logdir, logger
 from lib.topotest import json_cmp_result
 from munet import cli
 from munet.base import Commander, proc_error
 from munet.cleanup import cleanup_current, cleanup_previous
+from munet.config import ConfigOptionsProxy
 from munet.testing.util import pause_test
 
 from lib import topolog, topotest

--- a/tests/topotests/lib/micronet_compat.py
+++ b/tests/topotests/lib/micronet_compat.py
@@ -12,49 +12,6 @@ from munet import cli
 from munet.base import BaseMunet, LinuxNamespace
 
 
-def cli_opt_list(option_list):
-    if not option_list:
-        return []
-    if isinstance(option_list, str):
-        return [x for x in option_list.split(",") if x]
-    return [x for x in option_list if x]
-
-
-def name_in_cli_opt_str(name, option_list):
-    ol = cli_opt_list(option_list)
-    return name in ol or "all" in ol
-
-
-class ConfigOptionsProxy:
-    def __init__(self, pytestconfig=None):
-        if isinstance(pytestconfig, ConfigOptionsProxy):
-            self.config = pytestconfig.config
-        else:
-            self.config = pytestconfig
-        self.option = self.config.option
-
-    def getoption(self, opt, defval=None):
-        if not self.config:
-            return defval
-
-        value = self.config.getoption(opt)
-        if value is None:
-            return defval
-
-        return value
-
-    def get_option(self, opt, defval=None):
-        return self.getoption(opt, defval)
-
-    def get_option_list(self, opt):
-        value = self.get_option(opt, "")
-        return cli_opt_list(value)
-
-    def name_in_option_list(self, name, opt):
-        optlist = self.get_option_list(opt)
-        return "all" in optlist or name in optlist
-
-
 class Node(LinuxNamespace):
     """Node (mininet compat)."""
 
@@ -182,7 +139,9 @@ class Mininet(BaseMunet):
         # to set permissions to root:frr 770 to make this unneeded in that case
         # os.umask(0)
 
-        super(Mininet, self).__init__(pid=False, rundir=rundir)
+        super(Mininet, self).__init__(
+            pid=False, rundir=rundir, pytestconfig=pytestconfig
+        )
 
         # From munet/munet/native.py
         with open(os.path.join(self.rundir, "nspid"), "w", encoding="ascii") as f:

--- a/tests/topotests/munet/config.py
+++ b/tests/topotests/munet/config.py
@@ -191,17 +191,18 @@ class ConfigOptionsProxy:
         else:
             self.option = ConfigOptionsProxy.DefNoneObject()
 
-    def getoption(self, opt, defval=None):
+    def getoption(self, opt, default=None):
         if not self.config:
-            return defval
+            return default
 
         try:
-            return self.config.getoption(opt, default=defval)
+            value = self.config.getoption(opt)
+            return value if value is not None else default
         except ValueError:
-            return defval
+            return default
 
-    def get_option(self, opt, defval=None):
-        return self.getoption(opt, defval)
+    def get_option(self, opt, default=None):
+        return self.getoption(opt, default)
 
     def get_option_list(self, opt):
         value = self.get_option(opt, "")


### PR DESCRIPTION
Also, acutally remove the local ConfigOptionProxy
import munet 0.13.2 - fixed ConfigOptionsProxy bug