### PR TITLE
build: fix frr-if-rmap.yang model embedding

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -138,6 +138,7 @@ lib_libfrr_la_SOURCES = \
 nodist_lib_libfrr_la_SOURCES = \
 	yang/frr-affinity-map.yang.c \
 	yang/frr-filter.yang.c \
+	yang/frr-if-rmap.yang.c \
 	yang/frr-interface.yang.c \
 	yang/frr-route-map.yang.c \
 	yang/frr-route-types.yang.c \


### PR DESCRIPTION
This was missed somewhere along the line, causing ripd to not start:

```
2023/04/24 16:44:01 RIP: libyang: Data model "frr-if-rmap" not found in local searchdirs.
2023/04/24 16:44:01 RIP: libyang: Loading "frr-if-rmap" module failed.
2023/04/24 16:44:01 RIP: libyang: Parsing module "frr-ripd" failed.
2023/04/24 16:44:01 RIP: libyang: Data model "frr-ripd" not found in local searchdirs.
2023/04/24 16:44:01 RIP: libyang: Loading "frr-ripd" module failed.
2023/04/24 16:44:01 RIP: [XAR87-H157X][EC 100663321] yang_module_load: failed to load data model: frr-ripd
```