### PR TITLE
tests: Increase the dead interval to be longer for neighbor testing

### DIFF
--- a/tests/topotests/ospf_basic_functionality/ospf_lan.json
+++ b/tests/topotests/ospf_basic_functionality/ospf_lan.json
@@ -18,7 +18,7 @@
                     "ospf": {
                         "area": "0.0.0.3",
                         "hello_interval": 1,
-                        "dead_interval": 4,
+                        "dead_interval": 10,
                         "priority": 98
                     }
                 },
@@ -27,7 +27,7 @@
                     "ospf": {
                         "area": "0.0.0.3",
                         "hello_interval": 1,
-                        "dead_interval": 4,
+                        "dead_interval": 10,
                         "priority": 99
                     }
                 },
@@ -36,7 +36,7 @@
                     "ospf": {
                         "area": "0.0.0.3",
                         "hello_interval": 1,
-                        "dead_interval": 4,
+                        "dead_interval": 10,
                         "priority": 0
                     }
                 },
@@ -45,7 +45,7 @@
                     "ospf": {
                         "area": "0.0.0.3",
                         "hello_interval": 1,
-                        "dead_interval": 4,
+                        "dead_interval": 10,
                         "priority": 0
                     }
                 }

--- a/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
@@ -489,7 +489,7 @@ def test_ospf_lan_tc2_p0(request):
                 "s1": {
                     "ospf": {
                         "priority": 98,
-                        "timerDeadSecs": 4,
+                        "timerDeadSecs": 10,
                         "area": "0.0.0.3",
                         "mcastMemberOspfDesignatedRouters": True,
                         "mcastMemberOspfAllRouters": True,

--- a/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
@@ -196,8 +196,10 @@ def test_ospf_lan_tc1_p0(request):
     result = verify_ospf_neighbor(tgen, topo, dut, input_dict, lan=True)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    step("Configure DR priority 100 on R0 and clear ospf neighbors "
-         "on all the routers.")
+    step(
+        "Configure DR priority 100 on R0 and clear ospf neighbors "
+        "on all the routers."
+    )
 
     input_dict = {
         "r0": {
@@ -233,8 +235,10 @@ def test_ospf_lan_tc1_p0(request):
     result = verify_ospf_neighbor(tgen, topo, dut, input_dict, lan=True)
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
-    step("Configure DR priority 150 on R0 and clear ospf neighbors "
-         "on all the routers.")
+    step(
+        "Configure DR priority 150 on R0 and clear ospf neighbors "
+        "on all the routers."
+    )
 
     input_dict = {
         "r0": {


### PR DESCRIPTION
the ospf_basic_functionality/test_ospf_lan.py script is setting up a lan env that will have 4 ospf routers on it and shutting/no shutting interfaces with various priorities to see that ospf is properly choosing roles.  I am consistently seeing the ospf_basic_functionality/test_ospf_lan.py script failing where it is saying a neighbor is not in the correct state.

Upon examination of the logs we are seeing this:

2023/04/24 09:16:42 OSPF: [M7Q4P-46WDR] vty[7]@(config)# interface r0-s1-eth0  <----- This is where we no shut the interface
2023/04/24 09:16:47 OSPF: [M7Q4P-46WDR] vty[7]@> enable
2023/04/24 09:16:47 OSPF: [M7Q4P-46WDR] vty[7]@# show ip ospf neighbor all json
2023/04/24 09:16:53 OSPF: [QH9AB-Y4XMZ][EC 100663314] STARVATION: task ospf_ism_event (556af08a5b4c) ran for 6038ms (cpu time 0ms)
2023/04/24 09:16:53 OSPF: [HKQ2F-8D0MY][EC 100663315] Thread Starvation: {(thread *)0x556af19da020 arg=0x556af19c0dd0 timer  r=-5.086     ospf_ase_calculate_timer() &ospf->t_ase_calc from ospfd/ospf_ase.c:635} was scheduled to pop greater than 4s ago
2023/04/24 09:16:53 OSPF: [M7Q4P-46WDR] vty[18]@> enable
2023/04/24 09:16:53 OSPF: [M7Q4P-46WDR] vty[18]@# show ip ospf neighbor all
2023/04/24 09:16:55 OSPF: [M7Q4P-46WDR] vty[7]@> enable
2023/04/24 09:16:55 OSPF: [M7Q4P-46WDR] vty[7]@# show ip ospf neighbor all json
2023/04/24 09:16:55 OSPF: [M7Q4P-46WDR] vty[7]@> enable

This test is setting the dead interval to 4 seconds, seeing a 6 second delay where the os has gone to town (probably because of the high load on the system ) and not choosing the correct neighbor as the DR.

OSPF when coming up and after seeing the first neighbor, goes into a waiting period before the DR is elected.  If the neighbor does send it's hello packets but they are not processed before the wait timer pops because of the starvation event, then the wrong neighbor will be elected DR.  Let's give this test a bit more time to decide who the DR is in case everything goes a bit south.