### PR TITLE
ospfd: fix ospfd memory leak

### DIFF
--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -686,7 +686,7 @@ void ospf_intra_add_stub(struct route_table *rt, struct router_lsa_link *link,
 	}
 	if (rn->info)
 		ospf_route_free(rn->info);
-	
+
 	rn->info = or ;
 
 	if (IS_DEBUG_OSPF_EVENT)

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -684,7 +684,9 @@ void ospf_intra_add_stub(struct route_table *rt, struct router_lsa_link *link,
 					   __func__);
 		}
 	}
-
+	if(rn->info) {
+		ospf_route_free(rn->info);
+	}
 	rn->info = or ;
 
 	if (IS_DEBUG_OSPF_EVENT)

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -684,9 +684,9 @@ void ospf_intra_add_stub(struct route_table *rt, struct router_lsa_link *link,
 					   __func__);
 		}
 	}
-	if(rn->info) {
+	if (rn->info)
 		ospf_route_free(rn->info);
-	}
+	
 	rn->info = or ;
 
 	if (IS_DEBUG_OSPF_EVENT)


### PR DESCRIPTION
The ```rn``` variable has its ```info``` attribute being replaced with a new ospf route before being freed properly.
the stack below present the error:
```
Indirect leak of 960 byte(s) in 8 object(s) allocated from:
    #0 0x7fd686bd4a37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7fd686780d81 in qcalloc ../lib/memory.c:105
    #2 0x7fd68684bc56 in route_node_create ../lib/table.c:481
    #3 0x7fd686849398 in route_node_new ../lib/table.c:52
    #4 0x7fd68684af54 in route_node_get ../lib/table.c:305
    #5 0x56220b40e009 in ospf_intra_add_stub ../ospfd/ospf_route.c:557
    #6 0x56220b30bd40 in ospf_spf_process_stubs ../ospfd/ospf_spf.c:1624
    #7 0x56220b30bea8 in ospf_spf_process_stubs ../ospfd/ospf_spf.c:1647
    #8 0x56220b30caeb in ospf_spf_calculate ../ospfd/ospf_spf.c:1787
    #9 0x56220b31373c in ospf_ti_lfa_generate_q_spaces ../ospfd/ospf_ti_lfa.c:669
    #10 0x56220b31408f in ospf_ti_lfa_generate_q_spaces ../ospfd/ospf_ti_lfa.c:731
    #11 0x56220b314581 in ospf_ti_lfa_generate_p_space ../ospfd/ospf_ti_lfa.c:807
    #12 0x56220b314fd0 in ospf_ti_lfa_generate_p_spaces ../ospfd/ospf_ti_lfa.c:918
    #13 0x56220b3166df in ospf_ti_lfa_compute ../ospfd/ospf_ti_lfa.c:1095
    #14 0x56220b30ce80 in ospf_spf_calculate_area ../ospfd/ospf_spf.c:1811
    #15 0x56220b30d1ab in ospf_spf_calculate_areas ../ospfd/ospf_spf.c:1840
    #16 0x56220b30d3e8 in ospf_spf_calculate_schedule_worker ../ospfd/ospf_spf.c:1871
    #17 0x7fd68686322e in event_call ../lib/event.c:1995
    #18 0x7fd686755643 in frr_run ../lib/libfrr.c:1185
    #19 0x56220b2719d6 in main ../ospfd/ospf_main.c:220
    #20 0x7fd686234d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
```