### PR TITLE
bgpd: keep interface index on bgp nexthop tracking

### DIFF
--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -908,27 +908,37 @@ static void bgp_show_nexthops_detail(struct vty *vty, struct bgp *bgp,
 		}
 		switch (nexthop->type) {
 		case NEXTHOP_TYPE_IPV6:
-			vty_out(vty, "  gate %pI6\n", &nexthop->gate.ipv6);
-			break;
 		case NEXTHOP_TYPE_IPV6_IFINDEX:
-			vty_out(vty, "  gate %pI6, if %s\n",
-				&nexthop->gate.ipv6,
-				ifindex2ifname(bnc->ifindex ? bnc->ifindex
-							    : nexthop->ifindex,
-					       bgp->vrf_id));
+			vty_out(vty, "  gate %pI6", &nexthop->gate.ipv6);
+			if (nexthop->type == NEXTHOP_TYPE_IPV6_IFINDEX &&
+			    bnc->ifindex)
+				vty_out(vty, ", if %s\n",
+					ifindex2ifname(bnc->ifindex,
+						       bgp->vrf_id));
+			else if (nexthop->ifindex)
+				vty_out(vty, ", if %s\n",
+					ifindex2ifname(nexthop->ifindex,
+						       bgp->vrf_id));
+			else
+				vty_out(vty, "\n");
 			break;
 		case NEXTHOP_TYPE_IPV4:
-			vty_out(vty, "  gate %pI4\n", &nexthop->gate.ipv4);
+		case NEXTHOP_TYPE_IPV4_IFINDEX:
+			vty_out(vty, "  gate %pI4", &nexthop->gate.ipv4);
+			if (nexthop->type == NEXTHOP_TYPE_IPV4_IFINDEX &&
+			    bnc->ifindex)
+				vty_out(vty, ", if %s\n",
+					ifindex2ifname(bnc->ifindex,
+						       bgp->vrf_id));
+			else if (nexthop->ifindex)
+				vty_out(vty, ", if %s\n",
+					ifindex2ifname(nexthop->ifindex,
+						       bgp->vrf_id));
+			else
+				vty_out(vty, "\n");
 			break;
 		case NEXTHOP_TYPE_IFINDEX:
 			vty_out(vty, "  if %s\n",
-				ifindex2ifname(bnc->ifindex ? bnc->ifindex
-							    : nexthop->ifindex,
-					       bgp->vrf_id));
-			break;
-		case NEXTHOP_TYPE_IPV4_IFINDEX:
-			vty_out(vty, "  gate %pI4, if %s\n",
-				&nexthop->gate.ipv4,
 				ifindex2ifname(bnc->ifindex ? bnc->ifindex
 							    : nexthop->ifindex,
 					       bgp->vrf_id));


### PR DESCRIPTION
The following BGP configuration does not show that the resolved next-hop to 192.0.2.1 has a defined interface.

> router bgp 65500
>  bgp router-id 192.0.2.2
>  neighbor 192.0.2.1 remote-as 65500
>  neighbor 192.0.2.1 update-source loop1
>  neighbor 192.168.0.1 remote-as 65500
>  !
>  address-family ipv4 unicast
>   network 192.0.2.2/32
>   no neighbor 192.168.0.1 activate
>  exit-address-family
>  !
>  address-family ipv4 labeled-unicast
>   neighbor 192.168.0.1 activate
>  exit-address-family
>  !
>  address-family ipv4 vpn
>   neighbor 192.0.2.1 activate
>  exit-address-family

The 'show bgp nexthop' dump does not output the interface whereas the zebra rnh has the information.

> dut-vm# show bgp nexthop
> [..]
> Current BGP nexthop cache:
>  192.0.2.1 valid [IGP metric 0], #paths 1, peer 192.0.2.1
>   gate 192.168.0.1
>   Last update: Mon Apr 24 22:10:07 2023
>
> dut-vm# show ip nht
> 192.0.2.1
>  resolved via bgp
>  via 192.168.0.1, r2-eth0
>  Client list: bgp(fd 33)

Modify the display of BGP nexthop tracking to also dump the interface used:

> dut-vm# show bgp nexthop
> [..]
> Current BGP nexthop cache:
>  192.0.2.1 valid [IGP metric 0], #paths 1, peer 192.0.2.1
>   gate 192.168.0.1, r2-eth0
>   Last update: Mon Apr 24 22:10:07 2023