### PR TITLE
bgpd: SAFI_MPLS_VPN can do nexthop tracking for its path

### DIFF
--- a/tests/topotests/bgp_prefix_sid2/r1/zebra.conf
+++ b/tests/topotests/bgp_prefix_sid2/r1/zebra.conf
@@ -1,6 +1,7 @@
 hostname r1
 !
 interface r1-eth0
+ ipv6 address 2001::1/64
  ip address 10.0.0.1/24
  no shutdown
 !


### PR DESCRIPTION
Perform nexthop tracking for mpls-vpn updates.
Getting to know the reachability for MPLS-VPN updates is a must, before BGP is able to establish LSPs like option 10B recommends it.