### PR TITLE
bgpd: Fix `received-routes detail`

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -14262,7 +14262,6 @@ show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table *table,
 			for (ain = dest->adj_in; ain; ain = ain->next) {
 				if (ain->peer != peer)
 					continue;
-
 				show_adj_route_header(vty, peer, table, header1,
 						      header2, json, json_scode,
 						      json_ocode, wide, detail);
@@ -14313,9 +14312,23 @@ show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table *table,
 					if (use_json)
 						json_net =
 							json_object_new_object();
+
+					struct bgp_path_info bpi;
+					struct bgp_dest buildit = *dest;
+					struct bgp_dest *pass_in;
+
+					if (route_filtered ||
+					    ret == RMAP_DENY) {
+						bpi.attr = &attr;
+						bpi.peer = peer;
+						buildit.info = &bpi;
+
+						pass_in = &buildit;
+					} else
+						pass_in = dest;
 					bgp_show_path_info(
-						NULL /* prefix_rd */, dest, vty,
-						bgp, afi, safi, json_net,
+						NULL, pass_in, vty, bgp, afi,
+						safi, json_net,
 						BGP_PATH_SHOW_ALL, &display,
 						RPKI_NOT_BEING_USED);
 					if (use_json)


### PR DESCRIPTION
The command `show bgp ipv4 uni neigh A.B.C.D received-routes detail` was not displaying anything.

Fix the code to display the received routes from the ones that have been filtered.  In this case we need to fudge up a bgp_dest and a bgp_path_info to make it work.

Old output:

janelle.pinkbelly.org# show bgp ipv4 uni neighbors 192.168.119.224 received-routes detail BGP table version is 1711405, local router ID is 192.168.44.1, vrf id 0 Default local pref 100, local AS 64539

Total number of prefixes 3 (3 filtered)
janelle.pinkbelly.org#

New output:

janelle.pinkbelly.org# show bgp ipv4 uni neighbors 192.168.119.224 received-routes detail BGP table version is 0, local router ID is 192.168.44.1, vrf id 0 Default local pref 100, local AS 64539
BGP routing table entry for 1.2.3.0/24, version 0
Paths: (1 available, no best path)
  Not advertised to any peer
  3291, (aggregated by 3291 192.168.122.1)
    192.168.119.224 (inaccessible, import-check enabled) from 192.168.119.224 (192.168.122.1)
      Origin IGP, metric 0, invalid, external, atomic-aggregate, rpki validation-state: not found
      Community: 55:66
      Last update: Fri Apr 14 08:46:48 2023
BGP routing table entry for 1.2.3.4/32, version 0
Paths: (1 available, no best path)
  Not advertised to any peer
  3291
    192.168.119.224 (inaccessible, import-check enabled) from 192.168.119.224 (192.168.122.1)
      Origin IGP, metric 0, invalid, external, rpki validation-state: not found
      Community: 33:44
      Last update: Fri Apr 14 08:46:48 2023
BGP routing table entry for 1.2.3.5/32, version 0
Paths: (1 available, no best path)
  Not advertised to any peer
  3291
    192.168.119.224 (inaccessible, import-check enabled) from 192.168.119.224 (192.168.122.1)
      Origin IGP, metric 0, invalid, external, rpki validation-state: not found
      Community: 33:44
      Last update: Fri Apr 14 08:46:48 2023

Total number of prefixes 3 (3 filtered)
janelle.pinkbelly.org# show bgp ipv4 uni
No BGP prefixes displayed, 0 exist
janelle.pinkbelly.org#