### PR TITLE
zebra: Skip the VRF interfaces when switching VRF

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -797,7 +797,8 @@ void if_delete_update(struct interface **pifp)
 	 * occur with this implementation whereas it is not possible with
 	 * vrf-lite).
 	 */
-	if (ifp->vrf->vrf_id && !vrf_is_backend_netns())
+	if (ifp->vrf->vrf_id && !vrf_is_backend_netns() &&
+	    !IS_ZEBRA_IF_VRF(ifp))
 		if_handle_vrf_change(ifp, VRF_DEFAULT);
 
 	/* Reset some zebra interface params to default values. */


### PR DESCRIPTION
After removed one VRF, saw this VRF interface in 'show run':

```
interface vrf666
exit
```

But "vrf666" is a VRF created by 'ip link add vrf666 type vrf ...'.

`if_handle_vrf_change()` will notify all daemons this added interface. 
Add `!IS_ZEBRA_IF_VRF(ifp)` check to avoid VRF interfaces wrongly moved to default VRF as normal interfaces.