### PR TITLE
tests: Do not try establishing a connection from r1 to r2

### DIFF
--- a/tests/topotests/bgp_bfd_down_cease_notification/r1/bgpd.conf
+++ b/tests/topotests/bgp_bfd_down_cease_notification/r1/bgpd.conf
@@ -2,7 +2,9 @@ router bgp 65001
  no bgp ebgp-requires-policy
  neighbor 192.168.255.2 remote-as external
  neighbor 192.168.255.2 timers 3 10
+ neighbor 192.168.255.2 timers connect 1
  neighbor 192.168.255.2 bfd
+ neighbor 192.168.255.2 passive
  address-family ipv4
   redistribute connected
  exit-address-family

--- a/tests/topotests/bgp_bfd_down_cease_notification/r2/bgpd.conf
+++ b/tests/topotests/bgp_bfd_down_cease_notification/r2/bgpd.conf
@@ -2,6 +2,7 @@ router bgp 65002
  no bgp ebgp-requires-policy
  neighbor 192.168.255.1 remote-as external
  neighbor 192.168.255.1 timers 3 10
+ neighbor 192.168.255.1 timers connect 1
  neighbor 192.168.255.1 bfd
  address-family ipv4
   redistribute connected

--- a/tests/topotests/bgp_bfd_down_cease_notification/test_bgp_bfd_down_cease_notification.py
+++ b/tests/topotests/bgp_bfd_down_cease_notification/test_bgp_bfd_down_cease_notification.py
@@ -88,13 +88,14 @@ def test_bgp_bfd_down_notification():
         expected = {
             "192.168.255.1": {
                 "lastNotificationReason": "Cease/BFD Down",
+                "lastNotificationHardReset": True,
             }
         }
         return topotest.json_cmp(output, expected)
 
     step("Initial BGP converge")
     test_func = functools.partial(_bgp_converge)
-    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
     assert result is None, "Failed to see BGP convergence on R2"
 
     step("Kill bfdd on R2")
@@ -102,7 +103,7 @@ def test_bgp_bfd_down_notification():
 
     step("Check if we received Cease/BFD Down notification message")
     test_func = functools.partial(_bgp_bfd_down_notification)
-    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
     assert result is None, "Failed to see BGP Cease/BFD Down notification message on R2"
 
 


### PR DESCRIPTION
If r1 becomes the "server" (= local port 179), then it initiates the connection after sending BGP Notification (BFD Down) and r2 resets the last error code.

Telling r1 do not connect to r2, fixes the issue.

Tested with `pytest -s -n 48` at least 20 times - no failures.

Closes https://github.com/FRRouting/frr/issues/13384