### PR TITLE
bgpd: avoid using bgp mplsvpn with no label configured

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -4050,6 +4050,32 @@ bool bgp_mplsvpn_path_uses_valid_mpls_label(struct bgp_path_info *pi)
 	return true;
 }
 
+/* Called to check if the incoming l3vpn path entry
+ * has mpls label information
+ */
+bool bgp_mplsvpn_path_can_be_advertised(struct bgp_path_info *pi)
+{
+	if (pi->attr && pi->attr->srv6_l3vpn)
+		/* srv6 sid */
+		return true;
+
+	if (pi->attr &&
+	    CHECK_FLAG(pi->attr->flag, ATTR_FLAG_BIT(BGP_ATTR_PREFIX_SID)) &&
+	    pi->attr->label_index != BGP_INVALID_LABEL_INDEX)
+		/* prefix_sid attribute */
+		return true;
+
+	if (!pi->extra || !bgp_is_valid_label(&pi->extra->label[0]))
+		/* invalid MPLS label */
+		return false;
+
+	if (pi->extra->label[0] == MPLS_LABEL_NONE)
+		/* none label */
+		return false;
+
+	return true;
+}
+
 mpls_label_t bgp_mplsvpn_nh_label_bind_get_label(struct bgp_path_info *pi)
 {
 	mpls_label_t label;

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -339,6 +339,7 @@ extern void bgp_mplsvpn_path_nh_label_bind_unlink(struct bgp_path_info *pi);
 extern void bgp_mplsvpn_nh_label_bind_register_local_label(
 	struct bgp *bgp, struct bgp_dest *dest, struct bgp_path_info *pi);
 mpls_label_t bgp_mplsvpn_nh_label_bind_get_label(struct bgp_path_info *pi);
+bool bgp_mplsvpn_path_can_be_advertised(struct bgp_path_info *pi);
 
 /* used to bind a local label to the (label, nexthop) values
  * from an incoming BGP mplsvpn update

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2150,6 +2150,13 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 					   p);
 			return false;
 		}
+	} else if (safi == SAFI_MPLS_VPN &&
+		   !bgp_mplsvpn_path_can_be_advertised(pi)) {
+		if (bgp_debug_update(NULL, p, subgrp->update_group, 0))
+			zlog_debug("u%" PRIu64 ":s%" PRIu64
+				   " %pFX is filtered - no valid label",
+				   subgrp->update_group->id, subgrp->id, p);
+		return false;
 	}
 
 	/* Do not send back route to sender. */


### PR DESCRIPTION
The following configuration is inconsistent because there is no valid label value for exported prefixes.

> router bgp 1 vrf vrf10
>  bgp router-id 1.1.1.1
>  no bgp ebgp-requires-policy
>  no bgp default ipv4-unicast
>  !
>  address-family ipv6 unicast
>   rd vpn export 1:10
>   rt vpn both 99:99
>   import vpn
>   export vpn
>   redistribute connected
>  exit-address-family

As consequence, the remote peer can see and install the following BGP route:

> # show ipv6 route vrf vrf10
> [..]
> B>* 2001:1::/64 [20/0] via fe80::1444:d2ff:fe56:e4f1, eth0 (vrf default), label implicit-null, weight 1, 00:03:55

The implicit-null label value should not be implicitly used, when no label value is specified in the configuration.

Instead, do return if there is no valid MPLS value to fill in instead.