### PR TITLE
isisd: fix a flex algo race condition and a minor fix

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1191,8 +1191,11 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 					rcap_fad = NULL;
 
 				if (!isis_flex_algo_elected_supported_local_fad(
-					    fa->algorithm, area, &rcap_fad))
+					    fa->algorithm, area, &rcap_fad)) {
+					fa->state = false;
 					continue;
+				}
+				fa->state = true;
 				lsp_debug("ISIS (%s):   SR Algorithm %u",
 					  area->area_tag, fa->algorithm);
 				rcap->algo[fa->algorithm] = fa->algorithm;

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1886,8 +1886,8 @@ void isis_run_spf(struct isis_spftree *spftree)
 	 * Flexible-Algorithm.
 	 */
 	if (flex_algo_id_valid(spftree->algorithm) &&
-	    !isis_flex_algo_elected_supported(spftree->algorithm,
-					      spftree->area)) {
+	    !flex_algo_get_state(spftree->area->flex_algos,
+				 spftree->algorithm)) {
 		if (!CHECK_FLAG(spftree->flags, F_SPFTREE_DISABLED)) {
 			isis_spftree_clear(spftree);
 			SET_FLAG(spftree->flags, F_SPFTREE_DISABLED);

--- a/lib/flex_algo.c
+++ b/lib/flex_algo.c
@@ -140,3 +140,24 @@ char *flex_algo_metric_type_print(char *type_str, size_t sz,
 	}
 	return type_str;
 }
+
+bool flex_algo_get_state(struct flex_algos *flex_algos, uint8_t algorithm)
+{
+	struct flex_algo *fa = flex_algo_lookup(flex_algos, algorithm);
+
+	if (!fa)
+		return false;
+
+	return fa->state;
+}
+
+void flex_algo_set_state(struct flex_algos *flex_algos, uint8_t algorithm,
+			 bool state)
+{
+	struct flex_algo *fa = flex_algo_lookup(flex_algos, algorithm);
+
+	if (!fa)
+		return;
+
+	fa->state = state;
+}

--- a/lib/flex_algo.c
+++ b/lib/flex_algo.c
@@ -79,6 +79,12 @@ bool flex_algo_definition_cmp(struct flex_algo *fa1, struct flex_algo *fa2)
 		return false;
 	if (fa1->metric_type != fa2->metric_type)
 		return false;
+	if (fa1->exclude_srlg != fa2->exclude_srlg)
+		return false;
+	if (fa1->flags != fa2->flags)
+		return false;
+	if (fa1->unsupported_subtlv != fa2->unsupported_subtlv)
+		return false;
 
 	if (!admin_group_cmp(&fa1->admin_group_exclude_any,
 			     &fa2->admin_group_exclude_any))

--- a/lib/flex_algo.h
+++ b/lib/flex_algo.h
@@ -83,6 +83,11 @@ struct flex_algo {
 #define FLEX_ALGO_IP 0x04
 	uint8_t dataplanes;
 
+	/* True if the Algorithm is locally enabled (ie. a definition has been
+	 * found and is supported).
+	 */
+	bool state;
+
 	/*
 	 * This property can be freely extended among different routing
 	 * protocols. Since Flex-Algo is an IGP protocol agnostic, both IS-IS
@@ -118,4 +123,8 @@ bool flex_algo_id_valid(uint16_t algorithm);
 char *flex_algo_metric_type_print(char *type_str, size_t sz,
 				  enum flex_algo_metric_type metric_type);
 
+bool flex_algo_get_state(struct flex_algos *flex_algos, uint8_t algorithm);
+
+void flex_algo_set_state(struct flex_algos *flex_algos, uint8_t algorithm,
+			 bool state);
 #endif /* _FRR_FLEX_ALGO_H */


### PR DESCRIPTION
A particular flex-algo algorithm may remain in disabled state after
configuring it if its flex-algo definition is being spread in the area.

It happens sometimes that, in isis_sr_flex_algo_topo1 topotest, r3
flex-algo 203 is disabled on test8. It depends on the following
sequence on r3:
 1. a LSP containing the flex-algo 203 definition is received from
    either r1 or r2 (or both).
 2. the local LSP is rebuilt by lsp_build() because of the flex-algo 203
    configuration
 3. isis_run_spf() recomputes the algo 203 SPF tree

A 1. 2. 3. sequence results in a working test whereas 2. 1. 3. is not
working. The second case issue is because of an inconsistent flex-algo
definition state between the following:
 - in lsp_build(), isis_flex_algo_elected_supported_local_fad() returns
   false because no flex-algo definition is known.
 - in isis_run_spf(), isis_flex_algo_elected_supported() returns true
   because a flex-algo definition is found.

Set a flex-algo state lsp_build() depending on flex-algo definition
existence that is used later in isis_run_spf().