### PR TITLE
tests: Fix `bgp_srv6l3vpn_to_bgp_vrf3` topotest

### DIFF
--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/r2/bgpd.conf
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/r2/bgpd.conf
@@ -1,6 +1,6 @@
 frr defaults traditional
 !
-!bgp send-extra-data zebra
+bgp send-extra-data zebra
 !
 hostname r2
 password zebra


### PR DESCRIPTION
The `bgp_srv6l3vpn_to_bgp_vrf3` topotest locally fails all the time.

```
>       assert result is None, "Failed"
E       AssertionError: Failed
E       assert Generated JSON diff error report:
E         
E         > $->192.168.1.0/24: d2 has the following element at index 0 which is not present in d1: 
E         
E         	{
E         	    "prefix": "192.168.1.0/24",

[...]

E         	> $->192.168.1.0/24[0]: d2 has key 'asPath' which is not present in d1

[...]

bgp_srv6l3vpn_to_bgp_vrf3/test_bgp_srv6l3vpn_to_bgp_vrf3.py:140: AssertionError
```

The reason CI doesn't catch the error is that this topotest is skipped on older kernels that don't support the SRv6 feature under test.



The `bgp_srv6l3vpn_to_bgp_vrf3` topotest verifies the SRv6 L3VPN functionality. It applies the appropriate configuration in `bgpd` and `zebra`, and then checks that the RIB is updated correctly.

The topotest expects to find the AS-Path in the RIB, which is only present if the `bgp send-extra-data zebra` option is enabled in the `bgpd` configuration.

The `bgp send-extra-data zebra` option has been accidentally commented out in commit https://github.com/FRRouting/frr/commit/2007e2dbd0d5c42d9fe6cbe92b34be10654834ef.

This commit fixes the `bgp_srv6l3vpn_to_bgp_vrf3` topotest by re-adding the missing `bgp send-extra-data zebra` option.

Signed-off-by: Carmine Scarpitta <carmine.scarpitta@uniroma2.it>