### PR TITLE
zebra:add df flag into evpn esi json output

### DIFF
--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3157,6 +3157,9 @@ static void zebra_evpn_es_show_entry_detail(struct vty *vty,
 				json_array_string_add(json_flags, "local");
 			if (es->flags & ZEBRA_EVPNES_REMOTE)
 				json_array_string_add(json_flags, "remote");
+			if (es->flags & ZEBRA_EVPNES_LOCAL &&
+			    !(es->flags & ZEBRA_EVPNES_NON_DF))
+				json_array_string_add(json_flags, "df");
 			if (es->flags & ZEBRA_EVPNES_NON_DF)
 				json_array_string_add(json_flags, "nonDF");
 			if (es->flags & ZEBRA_EVPNES_BYPASS)


### PR DESCRIPTION
FRR "show evpn es 'esi-id' json" output dont have the 'df' flag.

Modified the code to add the 'df' flag into json output.

Before Fix:

```
torm-11# show evpn es 03:44:38:39:ff:ff:01:00:00:01 json
{
  "esi":"03:44:38:39:ff:ff:01:00:00:01",
  "accessPort":"hostbond1",
  "flags":[
    "local",
    "remote",
    "readyForBgp",
    "bridgePort",
    "operUp",
    "nexthopGroupActive"
	 ====================> df is missing
  ],
  "vniCount":10,
  "macCount":13,
  "dfPreference":50000,
  "nexthopGroup":536870913,
  "vteps":[
    {
      "vtep":"27.0.0.16",
      "dfAlgorithm":"preference",
      "dfPreference":32767,
      "nexthopId":268435460
    },
    {
      "vtep":"27.0.0.17",
      "dfAlgorithm":"preference",
      "dfPreference":32767,
      "nexthopId":268435461
    }
  ]
}
torm-11#
```

After Fix:-

```
torm-11# show evpn es 03:44:38:39:ff:ff:01:00:00:01 json
{
  "esi":"03:44:38:39:ff:ff:01:00:00:01",
  "accessPort":"hostbond1",
  "flags":[
    "local",
    "remote",
    "readyForBgp",
    "bridgePort",
    "operUp",
    "nexthopGroupActive",
    "df" ========================> designated-forward flag added
  ],
  "vniCount":10,
  "macCount":13,
  "dfPreference":50000,
  "nexthopGroup":536870913,
  "vteps":[
    {
      "vtep":"27.0.0.16",
      "dfAlgorithm":"preference",
      "dfPreference":32767,
      "nexthopId":268435460
    },
    {
      "vtep":"27.0.0.17",
      "dfAlgorithm":"preference",
      "dfPreference":32767,
      "nexthopId":268435461
    }
  ]
}
torm-11#

```

 Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>
 Signed-off-by: Chirag Shah <chirag@nvidia.com>
