### PR TITLE
zebra: Clean up one comment

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1974,7 +1974,6 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	zns = zebra_ns_lookup(ns_id);
 	ifi = NLMSG_DATA(h);
 
-	/* assume if not default zns, then new VRF */
 	if (!(h->nlmsg_type == RTM_NEWLINK || h->nlmsg_type == RTM_DELLINK)) {
 		/* If this is not link add/delete message so print warning. */
 		zlog_debug("%s: wrong kernel message %s", __func__,


### PR DESCRIPTION
The location of this comment is very inappropriate. The comment is for very late `RTM_NEWLINK` and `RTM_DELLINK` processing.

Since unnecessary, remove it.