### PR TITLE
lib: Fix elf_py.c for coverity

### DIFF
--- a/lib/elf_py.c
+++ b/lib/elf_py.c
@@ -1140,7 +1140,7 @@ static PyObject *elffile_load(PyTypeObject *type, PyObject *args,
 	fd = open(filename, O_RDONLY | O_NOCTTY);
 	if (fd < 0 || fstat(fd, &st)) {
 		PyErr_SetFromErrnoWithFilename(PyExc_OSError, filename);
-		if (fd > 0)
+		if (fd >= 0)
 			close(fd);
 		goto out;
 	}


### PR DESCRIPTION
David rightly pointed out that having a test for fd > 0 would technically not be right, but not wrong for this portion of the code since we know that we would never get a fd = 0 in this section. In any event let's make coverity happy and move on with our life.