### PR TITLE
pimd, pim6d: re-arrange some code and pimv6 deletion flow fix

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1775,3 +1775,27 @@ static void pim_if_membership_clear(struct interface *ifp)
 
 	pim_ifchannel_membership_clear(ifp);
 }
+
+void pim_pim_interface_delete(struct interface *ifp)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+
+	if (!pim_ifp)
+		return;
+
+	pim_ifp->pim_enable = false;
+
+	pim_if_membership_clear(ifp);
+
+	/*
+	 * pim_sock_delete() removes all neighbors from
+	 * pim_ifp->pim_neighbor_list.
+	 */
+	pim_sock_delete(ifp, "pim unconfigured on interface");
+	pim_upstream_nh_if_update(pim_ifp->pim, ifp);
+
+	if (!pim_ifp->gm_enable) {
+		pim_if_addr_del_all(ifp);
+		pim_if_delete(ifp);
+	}
+}

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1799,3 +1799,24 @@ void pim_pim_interface_delete(struct interface *ifp)
 		pim_if_delete(ifp);
 	}
 }
+
+void pim_gm_interface_delete(struct interface *ifp)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+
+	if (!pim_ifp)
+		return;
+
+	pim_ifp->gm_enable = false;
+
+	pim_if_membership_clear(ifp);
+
+#if PIM_IPV == 4
+	igmp_sock_delete_all(ifp);
+#else
+	gm_ifp_teardown(ifp);
+#endif
+
+	if (!pim_ifp->pim_enable)
+		pim_if_delete(ifp);
+}

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1762,3 +1762,16 @@ void pim_iface_init(void)
 	if_zapi_callbacks(pim_ifp_create, pim_ifp_up, pim_ifp_down,
 			  pim_ifp_destroy);
 }
+
+static void pim_if_membership_clear(struct interface *ifp)
+{
+	struct pim_interface *pim_ifp;
+
+	pim_ifp = ifp->info;
+	assert(pim_ifp);
+
+	if (pim_ifp->pim_enable && pim_ifp->gm_enable)
+		return;
+
+	pim_ifchannel_membership_clear(ifp);
+}

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -244,5 +244,6 @@ int pim_if_ifchannel_count(struct pim_interface *pim_ifp);
 
 void pim_iface_init(void);
 void pim_pim_interface_delete(struct interface *ifp);
+void pim_gm_interface_delete(struct interface *ifp);
 
 #endif /* PIM_IFACE_H */

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -243,5 +243,6 @@ bool pim_if_is_vrf_device(struct interface *ifp);
 int pim_if_ifchannel_count(struct pim_interface *pim_ifp);
 
 void pim_iface_init(void);
+void pim_pim_interface_delete(struct interface *ifp);
 
 #endif /* PIM_IFACE_H */

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -45,20 +45,6 @@ MACRO_REQUIRE_SEMICOLON()
 #define yang_dnode_get_pimaddr yang_dnode_get_ipv4
 #endif /* PIM_IPV != 6 */
 
-static void pim_if_membership_clear(struct interface *ifp)
-{
-	struct pim_interface *pim_ifp;
-
-	pim_ifp = ifp->info;
-	assert(pim_ifp);
-
-	if (pim_ifp->pim_enable && pim_ifp->gm_enable) {
-		return;
-	}
-
-	pim_ifchannel_membership_clear(ifp);
-}
-
 /*
  * When PIM is disabled on interface, IGMPv3 local membership
  * information is not injected into PIM interface state.


### PR DESCRIPTION
1. Move pim_if_membership_clear api from pimd/pim_nb_config.c to pimd/pim_iface.c
2. Rename pim_cmd_interface_delete to pim_pim_interface_delete and move the api to pimd/pim_iface.c
3. Move the mld/igmp deletion common code to api pim_gm_interface_delete Code for IPv6 deletion(gm_ifp_teardown) for MLD was missing in this flow. Making the code common fixes this too.