### PR TITLE
pimd: Fix old commit that got in

### DIFF
--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -167,7 +167,7 @@ void pim_clear_nocache_state(struct pim_interface *pim_ifp)
 		if (*oil_parent(c_oil) != pim_ifp->mroute_vif_index)
 			continue;
 
-		THREAD_OFF(c_oil->up->t_ka_timer);
+		EVENT_OFF(c_oil->up->t_ka_timer);
 		PIM_UPSTREAM_FLAG_UNSET_SRC_NOCACHE(c_oil->up->flags);
 		PIM_UPSTREAM_FLAG_UNSET_SRC_STREAM(c_oil->up->flags);
 		pim_upstream_del(pim_ifp->pim, c_oil->up, __func__);


### PR DESCRIPTION
An old fix that used THREAD_OFF was pushed in, should have used EVENT_OFF instead.