### PR TITLE
lib: log commands read from config file

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1303,6 +1303,14 @@ int config_from_file(struct vty *vty, FILE *fp, unsigned int *line_num)
 	while (fgets(vty->buf, VTY_BUFSIZ, fp)) {
 		++(*line_num);
 
+		if (vty_log_commands) {
+			int len = strlen(vty->buf);
+
+			/* now log the command */
+			zlog_notice("config-from-file# %.*s", len ? len - 1 : 0,
+				    vty->buf);
+		}
+
 		ret = command_config_read_one_line(vty, NULL, *line_num, 0);
 
 		if (ret != CMD_SUCCESS && ret != CMD_WARNING

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -125,8 +125,8 @@ static int no_password_check = 0;
 /* Integrated configuration file path */
 static char integrate_default[] = SYSCONFDIR INTEGRATE_DEFAULT_CONFIG;
 
-static bool do_log_commands;
-static bool do_log_commands_perm;
+bool vty_log_commands;
+static bool vty_log_commands_perm;
 
 void vty_mgmt_resume_response(struct vty *vty, bool success)
 {
@@ -508,7 +508,7 @@ static int vty_command(struct vty *vty, char *buf)
 	/*
 	 * Log non empty command lines
 	 */
-	if (do_log_commands &&
+	if (vty_log_commands &&
 	    strncmp(buf, "echo PING", strlen("echo PING")) != 0)
 		cp = buf;
 	if (cp != NULL) {
@@ -3160,15 +3160,15 @@ DEFPY (log_commands,
        "Log all commands\n")
 {
 	if (no) {
-		if (do_log_commands_perm) {
+		if (vty_log_commands_perm) {
 			vty_out(vty,
 				"Daemon started with permanent logging turned on for commands, ignoring\n");
 			return CMD_WARNING;
 		}
 
-		do_log_commands = false;
+		vty_log_commands = false;
 	} else
-		do_log_commands = true;
+		vty_log_commands = true;
 
 	return CMD_SUCCESS;
 }
@@ -3196,7 +3196,7 @@ static int vty_config_write(struct vty *vty)
 
 	vty_endframe(vty, "exit\n");
 
-	if (do_log_commands)
+	if (vty_log_commands)
 		vty_out(vty, "log commands\n");
 
 	vty_out(vty, "!\n");
@@ -3677,8 +3677,8 @@ void vty_init(struct event_loop *master_thread, bool do_command_logging)
 	install_element(CONFIG_NODE, &log_commands_cmd);
 
 	if (do_command_logging) {
-		do_log_commands = true;
-		do_log_commands_perm = true;
+		vty_log_commands = true;
+		vty_log_commands_perm = true;
 	}
 
 	install_element(ENABLE_NODE, &terminal_monitor_cmd);

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -335,6 +335,7 @@ struct vty_arg {
 #endif
 
 extern struct nb_config *vty_mgmt_candidate_config;
+extern bool vty_log_commands;
 
 /* Prototypes. */
 extern void vty_init(struct event_loop *m, bool do_command_logging);


### PR DESCRIPTION
When the user specifies `--command-log-always` in CLI arguments then also log commands executed from loading the config file.