### PR TITLE
[DRAFT] zebra: only send NL messages when the session is valid.

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1223,6 +1223,14 @@ static int netlink_talk_info(int (*filter)(struct nlmsghdr *, ns_id_t,
 {
 	struct nlsock *nl;
 
+	/* Don't try to lookup already closed session */
+	if (dp_info->sock < 0) {
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug(
+				"netlink_talk_info: invalid sock fd %d , sendmsg failed",
+				dp_info->sock);
+		return -1;
+	}
 	nl = kernel_netlink_nlsock_lookup(dp_info->sock);
 	n->nlmsg_seq = dp_info->seq;
 	n->nlmsg_pid = nl->snl.nl_pid;


### PR DESCRIPTION
If the session has already been cleared,
there is no point in using the invalid socket to
send out a netlink message.
In this case, the NL socket lookup will be NULL.

Testing Done:
evpn_mh_test