### PR TITLE
pimd: Fix missing deletion of pimreg interface

### DIFF
--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -193,7 +193,22 @@ static int pim_vrf_enable(struct vrf *vrf)
 
 static int pim_vrf_disable(struct vrf *vrf)
 {
-	/* Note: This is a callback, the VRF will be deleted by the caller. */
+	struct interface *ifp;
+	char pimreg_name[INTERFACE_NAMSIZ];
+
+	snprintf(pimreg_name, sizeof(pimreg_name), PIMREG "%u",
+		 vrf->data.l.table_id);
+
+	FOR_ALL_INTERFACES (vrf, ifp) {
+		if (!ifp->info)
+			continue;
+
+		if (strmatch(ifp->name, pimreg_name)) {
+			if_delete(&ifp);
+			break;
+		}
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
When removing vrf, `vrf_delete()` quickly exited without calling `vrf_delete_hook()` of pim instance because there is `pimreg` interface in this vrf at that time.

Since no place to delete `pimreg` interface, delete it in `vrf_disable_hook()` of pim instance.