### PR TITLE
bgpd: Fixing the show bgp <vrf> <afi> <safi> detail command

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -4109,6 +4109,122 @@ structure is extended with :clicmd:`show bgp [afi] [safi]`.
    If ``afi`` is specified, with ``all`` option, routes will be displayed for
    each SAFI in the selected AFI.
 
+.. clicmd:: show [ip] bgp [<view|vrf> VIEWVRFNAME] [afi] [safi] detail [json]
+
+   Display the detailed version of all routes from the specified bgp vrf table
+   for a given afi + safi.
+
+   If no vrf is specified, then it is assumed as a default vrf and routes
+   are displayed from default vrf table.
+
+   If ``all`` option is specified as vrf name, then all bgp vrf tables routes
+   from a given afi+safi are displayed in the detailed output of routes.
+
+   If ``json`` option is specified, detailed output is displayed in JSON format.
+
+   Following are sample output for few examples of how to use this command.
+
+.. code-block:: frr
+
+   torm-23# sh bgp ipv4 unicast detail (OR) sh bgp vrf default ipv4 unicast detail
+
+   !--- Output suppressed.
+
+   BGP routing table entry for 172.16.16.1/32
+   Paths: (1 available, best #1, table default)
+     Not advertised to any peer
+     Local, (Received from a RR-client)
+       172.16.16.1 (metric 20) from torm-22(172.16.16.1) (192.168.0.10)
+         Origin IGP, metric 0, localpref 100, valid, internal
+         Last update: Fri May  8 12:54:05 2023
+   BGP routing table entry for 172.16.16.2/32
+   Paths: (1 available, best #1, table default)
+     Not advertised to any peer
+     Local
+       0.0.0.0 from 0.0.0.0 (172.16.16.2)
+         Origin incomplete, metric 0, weight 32768, valid, sourced, bestpath-from-AS Local, best (First path received)
+         Last update: Wed May  8 12:54:41 2023
+
+   Displayed  2 routes and 2 total paths
+
+.. code-block:: frr
+
+   torm-23# sh bgp vrf all detail
+
+   Instance default:
+
+   !--- Output suppressed.
+
+   BGP routing table entry for 172.16.16.1/32
+   Paths: (1 available, best #1, table default)
+     Not advertised to any peer
+     Local, (Received from a RR-client)
+       172.16.16.1 (metric 20) from torm-22(172.16.16.1) (192.168.0.10)
+         Origin IGP, metric 0, localpref 100, valid, internal
+         Last update: Fri May  8 12:44:05 2023
+   BGP routing table entry for 172.16.16.2/32
+   Paths: (1 available, best #1, table default)
+     Not advertised to any peer
+     Local
+       0.0.0.0 from 0.0.0.0 (172.16.16.2)
+         Origin incomplete, metric 0, weight 32768, valid, sourced, bestpath-from-AS Local, best (First path received)
+         Last update: Wed May  8 12:45:01 2023
+
+   Displayed  2 routes and 2 total paths
+
+   Instance vrf3:
+
+   !--- Output suppressed.
+
+   BGP routing table entry for 192.168.0.2/32
+   Paths: (1 available, best #1, vrf vrf3)
+     Not advertised to any peer
+     Imported from 172.16.16.1:12:[2]:[0]:[48]:[00:02:00:00:00:58]:[32]:[192.168.0.2], VNI 1008/4003
+     Local
+       172.16.16.1 from torm-22(172.16.16.1) (172.16.16.1) announce-nh-self
+         Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
+         Extended Community: RT:65000:1008 ET:8 Rmac:00:02:00:00:00:58
+         Last update: Fri May  8 02:41:55 2023
+   BGP routing table entry for 192.168.1.2/32
+   Paths: (1 available, best #1, vrf vrf3)
+     Not advertised to any peer
+     Imported from 172.16.16.1:13:[2]:[0]:[48]:[00:02:00:00:00:58]:[32]:[192.168.1.2], VNI 1009/4003
+     Local
+       172.16.16.1 from torm-22(172.16.16.1) (172.16.16.1) announce-nh-self
+         Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
+         Extended Community: RT:65000:1009 ET:8 Rmac:00:02:00:00:00:58
+         Last update: Fri May  8 02:41:55 2023
+
+   Displayed  2 routes and 2 total paths
+
+
+.. code-block:: frr
+
+   torm-23# sh bgp vrf vrf3 ipv4 unicast detail
+
+   !--- Output suppressed.
+
+   BGP routing table entry for 192.168.0.2/32
+   Paths: (1 available, best #1, vrf vrf3)
+     Not advertised to any peer
+     Imported from 172.16.16.1:12:[2]:[0]:[48]:[00:02:00:00:00:58]:[32]:[192.168.0.2], VNI 1008/4003
+     Local
+       172.16.16.1 from torm-22(172.16.16.1) (172.16.16.1) announce-nh-self
+         Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
+         Extended Community: RT:65000:1008 ET:8 Rmac:00:02:00:00:00:58
+         Last update: Fri May  8 02:23:35 2023
+   BGP routing table entry for 192.168.1.2/32
+   Paths: (1 available, best #1, vrf vrf3)
+     Not advertised to any peer
+     Imported from 172.16.16.1:13:[2]:[0]:[48]:[00:02:00:00:00:58]:[32]:[192.168.1.2], VNI 1009/4003
+     Local
+       172.16.16.1 from torm-22(172.16.16.1) (172.16.16.1) announce-nh-self
+         Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
+         Extended Community: RT:65000:1009 ET:8 Rmac:00:02:00:00:00:58
+         Last update: Fri May  8 02:23:55 2023
+
+   Displayed  2 routes and 2 total paths
+
 .. _bgp-display-routes-by-community:
 
 Displaying Routes by Community Attribute


### PR DESCRIPTION
The following are the changes made to the show cmds involving "detail" keyword
```

- Before this fix, there was only `show bgp <ipv4|ipv6> flowspec detail` command. 
  After the fix, we support `show bgp <ipv4|ipv6> <unicast|multicast|vpn|labeled-unicast|flowspec> detail`.

- Before this fix, there was only support for `sh bgp vrf <vrf_name|all> <ipv4|ipv6> flowspec detail` command.
  After the fix, we support `sh bgp vrf <vrf name|all> <ipv4|ipv6> <unicast|multicast|vpn|labeled-unicast|flowspec> detail`.

- Before this fix, `show bgp vrf all detail` only displays vrf default entries and does not iterate all vrfs.
  After the fix, we iterate all vrfs including the default vrf.

```

Adding support to show cmds like  show bgp vrf all detail, show bgp <afi> <safi> detail & show bgp <vrf> <afi> <safi> detail
Test Results:
Before & After: (Vrf all)
BEFORE:
```
torm-23# sh bgp vrf all detail
<snip>………………
   Network          Next Hop            Metric LocPrf Weight Path
BGP routing table entry for 27.0.0.19/32
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    27.0.0.19 (metric 20) from torm-22(27.0.0.19) (27.0.0.19)
      Origin incomplete, metric 0, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Last update: Fri May  5 03:07:35 2023
BGP routing table entry for 27.0.0.20/32
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  torm-22(27.0.0.19)
  Local
    0.0.0.0 from 0.0.0.0 (27.0.0.20)
      Origin incomplete, metric 0, weight 32768, valid, sourced, bestpath-from-AS Local, best (First path received)
      Last update: Fri May  5 03:07:27 2023

Displayed  2 routes and 2 total paths
```
AFTER:
```
torm-23# sh bgp vrf all detail
Instance default:
<snip>………………

   Network          Next Hop            Metric LocPrf Weight Path
BGP routing table entry for 27.0.0.19/32
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    27.0.0.19 (metric 20) from torm-22(27.0.0.19) (27.0.0.19)
      Origin incomplete, metric 0, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Last update: Fri May  5 02:44:55 2023
BGP routing table entry for 27.0.0.20/32
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  torm-22(27.0.0.19)
  Local
    0.0.0.0 from 0.0.0.0 (27.0.0.20)
      Origin incomplete, metric 0, weight 32768, valid, sourced, bestpath-from-AS Local, best (First path received)
      Last update: Wed May  3 23:00:41 2023

Displayed  2 routes and 2 total paths

Instance vrf3:
<snip>………………

   Network          Next Hop            Metric LocPrf Weight Path
BGP routing table entry for 45.0.8.17/32
Paths: (1 available, best #1, vrf vrf3)
  Not advertised to any peer
  Imported from 27.0.0.19:12:[2]:[0]:[48]:[00:02:00:00:00:58]:[32]:[45.0.8.17], VNI 1008/4003
  Local
    27.0.0.19 from torm-22(27.0.0.19) (27.0.0.19) announce-nh-self
      Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Extended Community: RT:65000:1008 RT:65000:4003 ET:8 Rmac:00:02:00:00:00:58
      Last update: Fri May  5 02:44:55 2023
BGP routing table entry for 45.0.9.17/32
Paths: (1 available, best #1, vrf vrf3)
  Not advertised to any peer
  Imported from 27.0.0.19:13:[2]:[0]:[48]:[00:02:00:00:00:58]:[32]:[45.0.9.17], VNI 1009/4003
  Local
    27.0.0.19 from torm-22(27.0.0.19) (27.0.0.19) announce-nh-self
      Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Extended Community: RT:65000:1009 RT:65000:4003 ET:8 Rmac:00:02:00:00:00:58
      Last update: Fri May  5 02:44:55 2023

Displayed  2 routes and 2 total paths

Instance vrf2:
<snip>………………

BGP routing table entry for 45.0.4.17/32
Paths: (1 available, best #1, vrf vrf2)
  Not advertised to any peer
  Imported from 27.0.0.19:6:[2]:[0]:[48]:[00:02:00:00:00:58]:[32]:[45.0.4.17], VNI 1004/4002
  Local
    27.0.0.19 from torm-22(27.0.0.19) (27.0.0.19) announce-nh-self
      Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Extended Community: RT:65000:1004 RT:65000:4002 ET:8 Rmac:00:02:00:00:00:58
      Last update: Fri May  5 02:44:55 2023
BGP routing table entry for 45.0.5.17/32
Paths: (1 available, best #1, vrf vrf2)
  Not advertised to any peer
  Imported from 27.0.0.19:17:[2]:[0]:[48]:[00:02:00:00:00:58]:[32]:[45.0.5.17], VNI 1005/4002
  Local
    27.0.0.19 from torm-22(27.0.0.19) (27.0.0.19) announce-nh-self
      Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Extended Community: RT:65000:1005 RT:65000:4002 ET:8 Rmac:00:02:00:00:00:58
      Last update: Fri May  5 02:44:55 2023
<snip>………………

Displayed  4 routes and 4 total paths

Instance vrf1:
<snip>………………

   Network          Next Hop            Metric LocPrf Weight Path
BGP routing table entry for 45.0.0.16/32
Paths: (1 available, best #1, vrf vrf1)
  Not advertised to any peer
  Imported from 27.0.0.19:14:[2]:[0]:[48]:[00:02:00:00:00:16]:[32]:[45.0.0.16], VNI 1000/4001
  Local
    27.0.0.19 from torm-22(27.0.0.19) (27.0.0.19) announce-nh-self
      Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Extended Community: RT:65000:1000 RT:65000:4001 ET:8 Rmac:00:02:00:00:00:58
      Last update: Fri May  5 02:44:55 2023
BGP routing table entry for 45.0.0.17/32
Paths: (1 available, best #1, vrf vrf1)
  Not advertised to any peer
  Imported from 27.0.0.19:14:[2]:[0]:[48]:[00:02:00:00:00:58]:[32]:[45.0.0.17], VNI 1000/4001
  Local
    27.0.0.19 from torm-22(27.0.0.19) (27.0.0.19) announce-nh-self
      Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Extended Community: RT:65000:1000 RT:65000:4001 ET:8 Rmac:00:02:00:00:00:58
      Last update: Fri May  5 02:44:55 2023
BGP routing table entry for 45.0.1.17/32
<snip>………………

Displayed  5 routes and 5 total paths
```


New commands:

1. torm-23# sh bgp ipv4 unicast detail (OR) sh bgp vrf default ipv4 unicast detail

```
<snip>………………
   Network          Next Hop            Metric LocPrf Weight Path
BGP routing table entry for 27.0.0.19/32
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    27.0.0.19 (metric 20) from torm-22(27.0.0.19) (27.0.0.19)
      Origin incomplete, metric 0, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Last update: Fri May  5 02:44:55 2023
BGP routing table entry for 27.0.0.20/32
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  torm-22(27.0.0.19)
  Local
    0.0.0.0 from 0.0.0.0 (27.0.0.20)
      Origin incomplete, metric 0, weight 32768, valid, sourced, bestpath-from-AS Local, best (First path received)
      Last update: Wed May  3 23:00:41 2023

Displayed  2 routes and 2 total paths
```

2. torm-23# sh bgp vrf vrf3 ipv4 unicast detail

```
<snip>………………
   Network          Next Hop            Metric LocPrf Weight Path
BGP routing table entry for 45.0.8.17/32
Paths: (1 available, best #1, vrf vrf3)
  Not advertised to any peer
  Imported from 27.0.0.19:12:[2]:[0]:[48]:[00:02:00:00:00:58]:[32]:[45.0.8.17], VNI 1008/4003
  Local
    27.0.0.19 from torm-22(27.0.0.19) (27.0.0.19) announce-nh-self
      Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Extended Community: RT:65000:1008 RT:65000:4003 ET:8 Rmac:00:02:00:00:00:58
      Last update: Fri May  5 02:44:55 2023
BGP routing table entry for 45.0.9.17/32
Paths: (1 available, best #1, vrf vrf3)
  Not advertised to any peer
  Imported from 27.0.0.19:13:[2]:[0]:[48]:[00:02:00:00:00:58]:[32]:[45.0.9.17], VNI 1009/4003
  Local
    27.0.0.19 from torm-22(27.0.0.19) (27.0.0.19) announce-nh-self
      Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Extended Community: RT:65000:1009 RT:65000:4003 ET:8 Rmac:00:02:00:00:00:58
      Last update: Fri May  5 02:44:55 2023

Displayed  2 routes and 2 total paths
```

3. torm-23# sh bgp vrf vrf3 ipv6 unicast detail
```
<snip>………………
   Network          Next Hop            Metric LocPrf Weight Path
BGP routing table entry for 2001:fee1:0:8::10/128
Paths: (1 available, best #1, vrf vrf3)
  Not advertised to any peer
  Imported from 27.0.0.19:12:[2]:[0]:[48]:[00:02:00:00:00:16]:[128]:[2001:fee1:0:8::10], VNI 1008/4003
  Local
    ::ffff:1b00:13 from torm-22(27.0.0.19) (27.0.0.19) announce-nh-self
      Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Extended Community: RT:65000:1008 RT:65000:4003 ET:8 Rmac:00:02:00:00:00:58 ND:Router Flag
      Last update: Fri May  5 02:44:55 2023
BGP routing table entry for 2001:fee1:0:8::11/128
Paths: (1 available, best #1, vrf vrf3)
  Not advertised to any peer
  Imported from 27.0.0.19:12:[2]:[0]:[48]:[00:02:00:00:00:58]:[128]:[2001:fee1:0:8::11], VNI 1008/4003
  Local
    ::ffff:1b00:13 from torm-22(27.0.0.19) (27.0.0.19) announce-nh-self
      Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Extended Community: RT:65000:1008 RT:65000:4003 ET:8 Rmac:00:02:00:00:00:58
      Last update: Fri May  5 02:44:55 2023
BGP routing table entry for 2001:fee1:0:9::10/128
<snip>………………

Displayed  4 routes and 4 total paths
```

Json Output Example for few commands

torm-22(config-router)# do sh bgp vrf all detail json
```
{
"default":{
 "vrfId": 0,
 "vrfName": "default",
 "tableVersion": 18,
 "routerId": "27.0.0.19",
 "defaultLocPrf": 100,
 "localAS": 65000,
 "routes": { "27.0.0.19/32": {
"prefix": "27.0.0.19/32",
"advertisedTo": {
  "27.0.0.20":{
    "hostname":"torm-23"
  }
}
,"paths": [{"aspath":{"string":"Local","segments":[],"length":0},"origin":"incomplete","metric":0,"weight":32768,"valid":true,"sourced":true,"bestpath":{"bestpathFromAs":0,"overall":true,"selectionReason":"First path received"},"lastUpdate":{"epoch":1683154842,"string":"Wed May  3 23:00:42 2023\n"},"nexthops":[{"ip":"0.0.0.0","hostname":"torm-22","afi":"ipv4","metric":0,"accessible":true,"used":true}],"peer":{"peerId":"0.0.0.0","routerId":"27.0.0.19"}}]
} ,"27.0.0.20/32": {
"prefix": "27.0.0.20/32",

"paths": [{"aspath":{"string":"Local","segments":[],"length":0},"origin":"incomplete","metric":0,"locPrf":100,"valid":true,"bestpath":{"bestpathFromAs":0,"overall":true,"selectionReason":"First path received"},"lastUpdate":{"epoch":1683256055,"string":"Fri May  5 03:07:35 2023\n"},"nexthops":[{"ip":"27.0.0.20","hostname":"torm-23","afi":"ipv4","metric":20,"accessible":true,"used":true}],"peer":{"peerId":"27.0.0.20","routerId":"27.0.0.20","hostname":"torm-23","type":"internal"}}]
}  }  }
,
"vrf1":{
 "vrfId": 32,
 "vrfName": "vrf1",
 "tableVersion": 107,
 "routerId": "45.0.3.17",
 "defaultLocPrf": 100,
 "localAS": 65000,
 "routes": { "45.0.0.18/32": {
"prefix": "45.0.0.18/32",

"paths": [{"aspath":{"string":"Local","segments":[],"length":0},"announceNexthopSelf":true,"origin":"IGP","locPrf":100,"valid":true,"bestpath":{"bestpathFromAs":0,"overall":true,"selectionReason":"First path received"},"extendedCommunity":{"string":"RT:65000:1000 RT:65000:4001 ET:8 Rmac:00:02:00:00:00:60"},"lastUpdate":{"epoch":1683256055,"string":"Fri May  5 03:07:35 2023\n"},"nexthops":[{"ip":"27.0.0.20","hostname":"torm-23","afi":"ipv4","metric":0,"accessible":true,"used":true}],"peer":{"peerId":"27.0.0.20","routerId":"27.0.0.20","hostname":"torm-23","type":"internal"}}]
} ,"45.0.0.19/32": {
"prefix": "45.0.0.19/32",

"paths": [{"aspath":{"string":"Local","segments":[],"length":0},"announceNexthopSelf":true,"origin":"IGP","locPrf":100,"valid":true,"bestpath":{"bestpathFromAs":0,"overall":true,"selectionReason":"First path received"},"extendedCommunity":{"string":"RT:65000:1000 RT:65000:4001 ET:8 Rmac:00:02:00:00:00:60"},"lastUpdate":{"epoch":1683256055,"string":"Fri May  5 03:07:35 2023\n"},"nexthops":[{"ip":"27.0.0.20","hostname":"torm-23","afi":"ipv4","metric":0,"accessible":true,"used":true}],"peer":{"peerId":"27.0.0.20","routerId":"27.0.0.20","hostname":"torm-23","type":"internal"}}]
} ,"45.0.1.19/32": {
"prefix": "45.0.1.19/32",
<snip>………………

}  }  }
,
"vrf2":{
 "vrfId": 42,
 "vrfName": "vrf2",
 "tableVersion": 68,
 "routerId": "45.0.7.17",
 "defaultLocPrf": 100,
 "localAS": 65000,
 "routes": { "45.0.4.19/32": {
"prefix": "45.0.4.19/32",

"paths": [{"aspath":{"string":"Local","segments":[],"length":0},"announceNexthopSelf":true,"origin":"IGP","locPrf":100,"valid":true,"bestpath":{"bestpathFromAs":0,"overall":true,"selectionReason":"First path received"},"extendedCommunity":{"string":"RT:65000:1004 RT:65000:4002 ET:8 Rmac:00:02:00:00:00:60"},"lastUpdate":{"epoch":1683256055,"string":"Fri May  5 03:07:35 2023\n"},"nexthops":[{"ip":"27.0.0.20","hostname":"torm-23","afi":"ipv4","metric":0,"accessible":true,"used":true}],"peer":{"peerId":"27.0.0.20","routerId":"27.0.0.20","hostname":"torm-23","type":"internal"}}]
} ,"45.0.5.19/32": {
"prefix": "45.0.5.19/32",

"paths": [{"aspath":{"string":"Local","segments":[],"length":0},"announceNexthopSelf":true,"origin":"IGP","locPrf":100,"valid":true,"bestpath":{"bestpathFromAs":0,"overall":true,"selectionReason":"First path received"},"extendedCommunity":{"string":"RT:65000:1005 RT:65000:4002 ET:8 Rmac:00:02:00:00:00:60"},"lastUpdate":{"epoch":1683256055,"string":"Fri May  5 03:07:35 2023\n"},"nexthops":[{"ip":"27.0.0.20","hostname":"torm-23","afi":"ipv4","metric":0,"accessible":true,"used":true}],"peer":{"peerId":"27.0.0.20","routerId":"27.0.0.20","hostname":"torm-23","type":"internal"}}]
} ,"45.0.6.19/32": {
"prefix": "45.0.6.19/32",
<snip>………………

}  }  }
,
"vrf3":{
 "vrfId": 52,
 "vrfName": "vrf3",
 "tableVersion": 34,
 "routerId": "45.0.9.17",
 "defaultLocPrf": 100,
 "localAS": 65000,
 "routes": { "45.0.8.19/32": {
"prefix": "45.0.8.19/32",

"paths": [{"aspath":{"string":"Local","segments":[],"length":0},"announceNexthopSelf":true,"origin":"IGP","locPrf":100,"valid":true,"bestpath":{"bestpathFromAs":0,"overall":true,"selectionReason":"First path received"},"extendedCommunity":{"string":"RT:65000:1008 RT:65000:4003 ET:8 Rmac:00:02:00:00:00:60"},"lastUpdate":{"epoch":1683256055,"string":"Fri May  5 03:07:35 2023\n"},"nexthops":[{"ip":"27.0.0.20","hostname":"torm-23","afi":"ipv4","metric":0,"accessible":true,"used":true}],"peer":{"peerId":"27.0.0.20","routerId":"27.0.0.20","hostname":"torm-23","type":"internal"}}]
} ,"45.0.9.19/32": {
"prefix": "45.0.9.19/32",

"paths": [{"aspath":{"string":"Local","segments":[],"length":0},"announceNexthopSelf":true,"origin":"IGP","locPrf":100,"valid":true,"bestpath":{"bestpathFromAs":0,"overall":true,"selectionReason":"First path received"},"extendedCommunity":{"string":"RT:65000:1009 RT:65000:4003 ET:8 Rmac:00:02:00:00:00:60"},"lastUpdate":{"epoch":1683256055,"string":"Fri May  5 03:07:35 2023\n"},"nexthops":[{"ip":"27.0.0.20","hostname":"torm-23","afi":"ipv4","metric":0,"accessible":true,"used":true}],"peer":{"peerId":"27.0.0.20","routerId":"27.0.0.20","hostname":"torm-23","type":"internal"}}]
}  }  }
}
```

torm-22(config-router)# do sh bgp ipv4 unicast detail  json
```
{
 "vrfId": 0,
 "vrfName": "default",
 "tableVersion": 18,
 "routerId": "27.0.0.19",
 "defaultLocPrf": 100,
 "localAS": 65000,
 "routes": { "27.0.0.19/32": {
"prefix": "27.0.0.19/32",
"advertisedTo": {
  "27.0.0.20":{
    "hostname":"torm-23"
  }
}
,"paths": [{"aspath":{"string":"Local","segments":[],"length":0},"origin":"incomplete","metric":0,"weight":32768,"valid":true,"sourced":true,"bestpath":{"bestpathFromAs":0,"overall":true,"selectionReason":"First path received"},"lastUpdate":{"epoch":1683154842,"string":"Wed May  3 23:00:42 2023\n"},"nexthops":[{"ip":"0.0.0.0","hostname":"torm-22","afi":"ipv4","metric":0,"accessible":true,"used":true}],"peer":{"peerId":"0.0.0.0","routerId":"27.0.0.19"}}]
} ,"27.0.0.20/32": {
"prefix": "27.0.0.20/32",

"paths": [{"aspath":{"string":"Local","segments":[],"length":0},"origin":"incomplete","metric":0,"locPrf":100,"valid":true,"bestpath":{"bestpathFromAs":0,"overall":true,"selectionReason":"First path received"},"lastUpdate":{"epoch":1683256055,"string":"Fri May  5 03:07:35 2023\n"},"nexthops":[{"ip":"27.0.0.20","hostname":"torm-23","afi":"ipv4","metric":20,"accessible":true,"used":true}],"peer":{"peerId":"27.0.0.20","routerId":"27.0.0.20","hostname":"torm-23","type":"internal"}}]
}  }  }
```

Older show bgp vrf <vrf_name> remains same as before
```
torm-23# sh bgp vrf vrf3 detail
BGP table version is 38, local router ID is 45.0.9.19, vrf id 52
Default local pref 100, local AS 65000
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
BGP routing table entry for 45.0.8.17/32
Paths: (1 available, best #1, vrf vrf3)
  Not advertised to any peer
  Imported from 27.0.0.19:12:[2]:[0]:[48]:[00:02:00:00:00:58]:[32]:[45.0.8.17], VNI 1008/4003
  Local
    27.0.0.19 from torm-22(27.0.0.19) (27.0.0.19) announce-nh-self
      Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Extended Community: RT:65000:1008 RT:65000:4003 ET:8 Rmac:00:02:00:00:00:58
      Last update: Fri May  5 02:44:55 2023
BGP routing table entry for 45.0.9.17/32
Paths: (1 available, best #1, vrf vrf3)
  Not advertised to any peer
  Imported from 27.0.0.19:13:[2]:[0]:[48]:[00:02:00:00:00:58]:[32]:[45.0.9.17], VNI 1009/4003
  Local
    27.0.0.19 from torm-22(27.0.0.19) (27.0.0.19) announce-nh-self
      Origin IGP, localpref 100, valid, internal, bestpath-from-AS Local, best (First path received)
      Extended Community: RT:65000:1009 RT:65000:4003 ET:8 Rmac:00:02:00:00:00:58
      Last update: Fri May  5 02:44:55 2023

Displayed  2 routes and 2 total paths
```
Signed-off-by: Rajasekar Raja <rajasekarr@nvidia.com>
