### PR TITLE
tests: removing un used loopback interface from bgp admin dist.

### DIFF
--- a/tests/topotests/bgp_distance_change/bgp_admin_dist_vrf.json
+++ b/tests/topotests/bgp_distance_change/bgp_admin_dist_vrf.json
@@ -22,12 +22,7 @@
    "routers": {
       "r1": {
          "links": {
-            "lo": {
-               "ipv4": "auto",
-               "ipv6": "auto",
-               "type": "loopback",
-               "vrf": "RED"
-            },
+
             "r2": {
                "ipv4": "auto",
                "ipv6": "auto",
@@ -129,12 +124,7 @@
       },
       "r2": {
          "links": {
-            "lo": {
-               "ipv4": "auto",
-               "ipv6": "auto",
-               "type": "loopback",
-               "vrf": "RED"
-            },
+
             "r1": {
                "ipv4": "auto",
                "ipv6": "auto",
@@ -193,12 +183,7 @@
       },
       "r3": {
          "links": {
-            "lo": {
-               "ipv4": "auto",
-               "ipv6": "auto",
-               "type": "loopback",
-               "vrf": "RED"
-            },
+
             "r1": {
                "ipv4": "auto",
                "ipv6": "auto",
@@ -287,12 +272,7 @@
       },
       "r4": {
          "links": {
-            "lo": {
-               "ipv4": "auto",
-               "ipv6": "auto",
-               "type": "loopback",
-               "vrf": "RED"
-            },
+
             "r3": {
                "ipv4": "auto",
                "ipv6": "auto",
@@ -336,12 +316,7 @@
       },
       "r5": {
          "links": {
-            "lo": {
-               "ipv4": "auto",
-               "ipv6": "auto",
-               "type": "loopback",
-               "vrf": "RED"
-            },
+
             "r3": {
                "ipv4": "auto",
                "ipv6": "auto",


### PR DESCRIPTION
Loopback interfaces which were not used in scripts have been removed.

Signed-off-by: nguggarigoud [nguggarigoud@vmware.com](mailto:nguggarigoud@vmware.com)