### PR TITLE
pimd: Use macro for pimreg interface

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -979,13 +979,13 @@ int pim_if_add_vif(struct interface *ifp, bool ispimreg, bool is_vxlan_term)
 	}
 
 	if (ifp->ifindex < 0) {
-		zlog_warn("%s: ifindex=%d < 1 on interface %s", __func__,
+		zlog_warn("%s: ifindex=%d < 0 on interface %s", __func__,
 			  ifp->ifindex, ifp->name);
 		return -2;
-	} else if ((ifp->ifindex == 0) &&
+	} else if ((ifp->ifindex == PIM_OIF_PIM_REGISTER_VIF) &&
 		   ((strncmp(ifp->name, "pimreg", 6)) &&
 		    (strncmp(ifp->name, "pim6reg", 7)))) {
-		zlog_warn("%s: ifindex=%d == 0 on interface %s", __func__,
+		zlog_warn("%s: ifindex=%d on interface %s", __func__,
 			  ifp->ifindex, ifp->name);
 		return -2;
 	}


### PR DESCRIPTION
Some interfaces are special, they have the same `ifindex` with pimreg.