### PR TITLE
bgpd: fix the issue of connected tag error when BGP subscribes to NHT…

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1543,6 +1543,7 @@ void peer_xfer_config(struct peer *peer_dst, struct peer *peer_src)
 		peer_dst->ifname =
 			XSTRDUP(MTYPE_BGP_PEER_IFNAME, peer_src->ifname);
 	}
+	peer_dst->ttl = peer_src->ttl;
 }
 
 static int bgp_peer_conf_if_to_su_update_v4(struct peer *peer,


### PR DESCRIPTION
Imagine the following scenario:
1.Create a multihop ebgp peer and config the ttl as 254 for both side.
2.Call bgp_start and start an active connection.
  Bgp will send a nht register with non-connected flag.
3.The function bgp_accept be called by remote connection.
  Bgp will create a accept peer as a passive connection with default ttl(1). And then will send a nht register again with connected flag. This register result will cover the first one.
4.The active connection come to establish first. In funciton "peer_xfer_conn", check for "PEER_FLAG_CONFIG_NODE" flag of "from_peer->doppelganger" will not be pass, so we can not repair the nht register error forever.
Then the bgp nexthop will be like this:
 2000::60 invalid, #paths 0, peer 2000::60
  Must be Connected
  Last update: Thu May  4 09:35:14 2023
  
The route from this peer can not be treat with a vaild nexthop forever.
This change will fix this error.