### PR TITLE
zebra: Fix dp_out_queued counter to actually reflect real life

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -5736,6 +5736,21 @@ void dplane_provider_enqueue_out_ctx(struct zebra_dplane_provider *prov,
 				  memory_order_relaxed);
 }
 
+static struct zebra_dplane_ctx *
+dplane_provider_dequeue_out_ctx(struct zebra_dplane_provider *prov)
+{
+	struct zebra_dplane_ctx *ctx;
+
+	ctx = dplane_ctx_list_pop(&(prov->dp_ctx_out_list));
+	if (!ctx)
+		return NULL;
+
+	atomic_fetch_sub_explicit(&(prov->dp_out_queued), 1,
+				  memory_order_relaxed);
+
+	return ctx;
+}
+
 /*
  * Accessor for provider object
  */
@@ -6763,7 +6778,7 @@ static void dplane_thread_loop(struct event *event)
 		dplane_provider_lock(prov);
 
 		while (counter < limit) {
-			ctx = dplane_ctx_list_pop(&(prov->dp_ctx_out_list));
+			ctx = dplane_provider_dequeue_out_ctx(prov);
 			if (ctx) {
 				dplane_ctx_list_add_tail(&work_list, ctx);
 				counter++;


### PR DESCRIPTION
The prov->dp_out_queued counter was never being decremented when a ctx was pulled off of the list.  Let's change it to accurately reflect real life.

Broken:
janelle.pinkbelly.org# show zebra dplane providers detailed Zebra dataplane providers:
Kernel (1): in: 330872, q: 0, q_max: 100, out: 330872, q: 330872, q_max: 330872 janelle.pinkbelly.org#

Fixed:
sharpd@janelle:/tmp/topotests$ vtysh -c "show zebra dplane providers detailed" Zebra dataplane providers:
Kernel (1): in: 221495, q: 0, q_max: 100, out: 221495, q: 0, q_max: 100 sharpd@janelle:/tmp/topotests$