### PR TITLE
pim6d: Fix crash in ipv6 pim command

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -81,15 +81,17 @@ static void pim_if_membership_refresh(struct interface *ifp)
 
 	pim_ifp = ifp->info;
 	assert(pim_ifp);
-#if PIM_IPV == 6
-	gm_ifp = pim_ifp->mld;
-#endif
 
 	if (!pim_ifp->pim_enable)
 		return;
 	if (!pim_ifp->gm_enable)
 		return;
 
+#if PIM_IPV == 6
+	gm_ifp = pim_ifp->mld;
+	if (!gm_ifp)
+		return;
+#endif
 	/*
 	 * First clear off membership from all PIM (S,G) entries on the
 	 * interface


### PR DESCRIPTION
Problem:
Execute the below commands, pim6d core happens.
interface ens193
 ip address 69.0.0.2/24
 ipv6 address 8000::1/120
 ipv6 mld
 ipv6 pim
We see crash only if the interface is not configured in kernel, and we are executing PIMV6/MLD commands.

RootCause:
Interface ens193 is not configured in kernel. So, it will have ifindex = 0 and mroute_vif_index = -1.
Currently, we don't enable MLD on an interface if
mroute_vif_index < 0. So, pim_ifp->MLD = NULL.
In the API pim_if_membership_refresh(), we are accessing pim_ifp->MLD NULL pointer which leads to crash.

Fix:
Added NULL check before accessing pim_ifp->MLD pointer in the API pim_if_membership_refresh().

Fixes #13385