### PR TITLE
tests: ospf_metric_propagation is looking for a specific ifindex

### DIFF
--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-1.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-1.json
@@ -25,7 +25,6 @@
           "fib":true,
           "ip":"10.0.10.5",
           "afi":"ipv4",
-          "interfaceIndex":6,
           "interfaceName":"r1-eth1",
           "vrf":"blue",
           "active":true,

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-2.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-2.json
@@ -25,7 +25,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":5,
           "interfaceName":"r1-eth0",
           "vrf":"default",
           "active":true,

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-3.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-3.json
@@ -25,7 +25,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":5,
           "interfaceName":"r1-eth0",
           "vrf":"default",
           "active":true,

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-4.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-4.json
@@ -25,7 +25,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":5,
           "interfaceName":"r1-eth0",
           "vrf":"default",
           "active":true,

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-5.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-5.json
@@ -25,7 +25,6 @@
           "fib":true,
           "ip":"10.0.1.2",
           "afi":"ipv4",
-          "interfaceIndex":5,
           "interfaceName":"r1-eth0",
           "vrf":"default",
           "active":true,

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-6.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-6.json
@@ -25,7 +25,6 @@
           "fib":true,
           "ip":"10.0.10.5",
           "afi":"ipv4",
-          "interfaceIndex":6,
           "interfaceName":"r1-eth1",
           "vrf":"blue",
           "active":true,


### PR DESCRIPTION
The test ospf_metric_propagation is looking for a specific ifindex this ifindex is not guaranteed to be any particular value by the underlying OS.  So let's remove this test for it.  As a side note I am seeing tests fail in upstream CI because of this.