### PR TITLE
pim6d: "show ipv6 pim state" not displaying when OIL is empty

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1148,13 +1148,18 @@ void pim_show_state(struct pim_instance *pim, struct vty *vty,
 						    "wrongInterface",
 						    c_oil->cc.wrong_if);
 			}
-		}
+		} else
 #if PIM_IPV == 4
-		else
 			vty_out(vty, "%-6d %-15pPAs  %-15pPAs  %-3s  %-16s  ",
 				c_oil->installed, oil_origin(c_oil),
 				oil_mcastgrp(c_oil), isRpt ? "y" : "n",
 				in_ifname);
+#else
+			/* Add a new row for c_oil with no OIF */
+			ttable_add_row(tt, "%d|%pPAs|%pPAs|%s|%s|%c",
+				       c_oil->installed, oil_origin(c_oil),
+				       oil_mcastgrp(c_oil), isRpt ? "y" : "n",
+				       in_ifname, ' ');
 #endif
 
 		for (oif_vif_index = 0; oif_vif_index < MAXVIFS;
@@ -1225,6 +1230,13 @@ void pim_show_state(struct pim_instance *pim, struct vty *vty,
 #if PIM_IPV == 4
 					vty_out(vty, "%s%s", out_ifname, flag);
 #else
+					/* OIF found.
+					 * Delete the existing row for c_oil,
+					 * with no OIF.
+					 * Add a new row for c_oil with OIF and
+					 * flag.
+					 */
+					ttable_del_row(tt, tt->nrows - 1);
 					ttable_add_row(
 						tt, "%d|%pPAs|%pPAs|%s|%s|%s%s",
 						c_oil->installed,


### PR DESCRIPTION
**Problem:**
The cli "show ipv6 pim state" is not displaying when outgoing interface list is empty.
This is fixed now.

**Before Fix:**
`frr# show ipv6 pim state json`
`{`
 ` "ffaa::5":{`
   ` "1100::10":{`
     ` "ens224":{`
  `    },`
    `  "installed":1,`
    `  "isRpt":false,`
    ` "refCount":1,`
    `  "oilListSize":0,`
      `"oilRescan":0,`
      `"lastUsed":0,`
     ` "packetCount":40,`
      `"byteCount":3080,`
    `  "wrongInterface":1`
    `}`
  `}`
`}

`frr# show ipv6 pim state`
`Codes: J -> Pim Join, I -> MLD Report, S -> Source, * -> Inherited from (*,G), V -> VxLAN, M -> Muted`
 `Active  Source  Group  RPT  IIF  OIL`

**After fix:**
Case 1:
- "show ipv6 pim state" output with 1 oil.
`frr# show ipv6 pim state`
`Codes: J -> Pim Join, I -> MLD Report, S -> Source, * -> Inherited from (*,G), V -> VxLAN, M -> Muted`
 `Active  Source    Group    RPT  IIF     OIL`
` 1       1100::10  ffaa::5  n    ens224`

Case 2:
- "show ipv6 pim state" output with multiple oil.
`frr# show ipv6 pim state`
`Codes: J -> Pim Join, I -> MLD Report, S -> Source, * -> Inherited from (*,G), V -> VxLAN, M -> Muted`
`Active  Source    Group    RPT  IIF     OIL`
 `1   1100::10   ffaa::5   n   ens224   ens192( J   )`
                                      ` ens256( J   )`

Case 3:
- "show ipv6 pim state" output with no oil
`frr# show ipv6 pim state`
`Codes: J -> Pim Join, I -> MLD Report, S -> Source, * -> Inherited from (*,G), V -> VxLAN, M -> Muted`
 `Active  Source    Group    RPT  IIF     OIL`
 `1       1100::10  ffaa::5  n    ens224`

Closes #13070