### PR TITLE
[WIP] ospfd: opsf_abr.c memory leak fix, free unused range

### DIFF
--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -66,9 +66,11 @@ static void ospf_area_range_add(struct ospf_area *area,
 	apply_mask_ipv4(&p);
 
 	rn = route_node_get(ranges, (struct prefix *)&p);
-	if (rn->info)
+	if (rn->info) {
 		route_unlock_node(rn);
-	else
+		ospf_area_range_free(rn->info);
+		rn->info = range;
+	} else
 		rn->info = range;
 }
 


### PR DESCRIPTION
The new create ```range``` attribute is send to add to ```ranges```, but not use if the prefix already exist in the ```ranges```. The stack trace below show a leak due to creation of new ```range```:

```
Direct leak of 56 byte(s) in 2 object(s) allocated from:
    #0 0x7fa31eae3a37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7fa31e68fae8 in qcalloc ../lib/memory.c:105
    #2 0x55efd93e38ae in ospf_area_range_new ../ospfd/ospf_abr.c:43
    #3 0x55efd93e47aa in ospf_area_range_set ../ospfd/ospf_abr.c:193
    #4 0x55efd936f3e9 in ospf_area_range ../ospfd/ospf_vty.c:628
    #5 0x7fa31e5d88d2 in cmd_execute_command_real ../lib/command.c:988
    #6 0x7fa31e5d8f28 in cmd_execute_command_strict ../lib/command.c:1099
    #7 0x7fa31e5d9acd in command_config_read_one_line ../lib/command.c:1259
    #8 0x7fa31e5d9d92 in config_from_file ../lib/command.c:1304
    #9 0x7fa31e78d552 in vty_read_file ../lib/vty.c:2438
    #10 0x7fa31e78e50e in vty_read_config ../lib/vty.c:2658
    #11 0x7fa31e662143 in frr_config_read_in ../lib/libfrr.c:971
    #12 0x7fa31e77227f in event_call ../lib/event.c:1995
    #13 0x7fa31e663643 in frr_run ../lib/libfrr.c:1185
    #14 0x55efd92889d6 in main ../ospfd/ospf_main.c:220
    #15 0x7fa31e141d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 56 byte(s) leaked in 2 allocation(s).
```