### PR TITLE
zebra: Reduce creation and fix memory leak of frrscripting pointers

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4614,6 +4614,21 @@ static void rib_process_dplane_results(struct thread *thread)
 	struct dplane_ctx_list_head ctxlist;
 	bool shut_p = false;
 
+#ifdef HAVE_SCRIPTING
+	char *script_name =
+		frrscript_names_get_script_name(ZEBRA_ON_RIB_PROCESS_HOOK_CALL);
+
+	int ret = 1;
+	struct frrscript *fs = NULL;
+
+	if (script_name) {
+		fs = frrscript_new(script_name);
+		if (fs)
+			ret = frrscript_load(fs, ZEBRA_ON_RIB_PROCESS_HOOK_CALL,
+					     NULL);
+	}
+#endif /* HAVE_SCRIPTING */
+
 	/* Dequeue a list of completed updates with one lock/unlock cycle */
 
 	do {
@@ -4647,24 +4662,7 @@ static void rib_process_dplane_results(struct thread *thread)
 			continue;
 		}
 
-#ifdef HAVE_SCRIPTING
-		char *script_name = frrscript_names_get_script_name(
-			ZEBRA_ON_RIB_PROCESS_HOOK_CALL);
-
-		int ret = 1;
-		struct frrscript *fs;
-
-		if (script_name) {
-			fs = frrscript_new(script_name);
-			if (fs)
-				ret = frrscript_load(
-					fs, ZEBRA_ON_RIB_PROCESS_HOOK_CALL,
-					NULL);
-		}
-#endif /* HAVE_SCRIPTING */
-
 		while (ctx) {
-
 #ifdef HAVE_SCRIPTING
 			if (ret == 0)
 				frrscript_call(fs,
@@ -4779,6 +4777,11 @@ static void rib_process_dplane_results(struct thread *thread)
 		}
 
 	} while (1);
+
+#ifdef HAVE_SCRIPTING
+	if (fs)
+		frrscript_delete(fs);
+#endif
 }
 
 /*


### PR DESCRIPTION
There are two issues being addressed:

a) The ZEBRA_ON_RIB_PROCESS_HOOK_CALL script point was creating a fs pointer per dplane ctx in
rib_process_dplane_results().

b) The fs pointer was not being deleted and directly leaked.

For (a) Move the creation of the fs to outside
the do while loop.

For (b) At function end ensure that the pointer
is actually deleted.