### PR TITLE
ospfd: Respect loopback's cost that is set and set loopback costs to 0

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -101,6 +101,9 @@ int ospf_if_get_output_cost(struct ospf_interface *oi)
 			cost = 1;
 		else if (cost > 65535)
 			cost = 65535;
+
+		if (if_is_loopback(oi->ifp))
+			cost = 0;
 	}
 
 	return cost;

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -608,7 +608,8 @@ static int lsa_link_loopback_set(struct stream **s, struct ospf_interface *oi)
 
 	mask.s_addr = 0xffffffff;
 	id.s_addr = oi->address->u.prefix4.s_addr;
-	return link_info_set(s, id, mask, LSA_LINK_TYPE_STUB, 0, 0);
+	return link_info_set(s, id, mask, LSA_LINK_TYPE_STUB, 0,
+			     oi->output_cost);
 }
 
 /* Describe Virtual Link. */


### PR DESCRIPTION
When setting an loopback's cost, set the value to 0, unless the operator has assigned a value for the loopback's cost.

RFC states:

If the state of the interface is Loopback, add a Type 3 link (stub network) as long as this is not an interface to an unnumbered point-to-point network. The Link ID should be set to the IP interface address, the Link Data set to the mask 0xffffffff (indicating a host route), and the cost set to 0.

FRR is going to allow this to be overridden if the operator specifically sets a value too.

Fixes: #13472