### PR TITLE
bgpd: fix redistributed label value when mpls vpn nexthop changes

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -3583,3 +3583,48 @@ void bgp_vpn_leak_export(struct bgp *from_bgp)
 		}
 	}
 }
+
+mpls_label_t bgp_mplsvpn_adv_label(struct bgp_path_info *pi, struct peer *to,
+				   afi_t afi, safi_t safi)
+{
+	struct peer *from;
+	mpls_label_t remote_label;
+
+	if (!pi || !to || !to->bgp)
+		return MPLS_INVALID_LABEL;
+
+	remote_label = pi->extra ? pi->extra->label[0] : MPLS_INVALID_LABEL;
+	from = pi->peer;
+
+	if (pi->sub_type == BGP_ROUTE_IMPORTED)
+		/* imported route */
+		return remote_label;
+
+	if (from == NULL)
+		/* local route */
+		return remote_label;
+
+	if (from->sort == BGP_PEER_IBGP && to->sort == BGP_PEER_IBGP &&
+	    !CHECK_FLAG(to->af_flags[afi][safi], PEER_FLAG_FORCE_NEXTHOP_SELF))
+		/* nexthop not forced to self in iBGP redistribution */
+		return remote_label;
+
+	if (CHECK_FLAG(to->af_flags[afi][safi], PEER_FLAG_NEXTHOP_UNCHANGED))
+		/* nexthop not changed */
+		return remote_label;
+
+	if (pi->attr && pi->attr->srv6_l3vpn)
+		/* srv6 sid */
+		return remote_label;
+
+	if (pi->attr &&
+	    CHECK_FLAG(pi->attr->flag, ATTR_FLAG_BIT(BGP_ATTR_PREFIX_SID)) &&
+	    pi->attr->label_index != BGP_INVALID_LABEL_INDEX)
+		/* valid prefix_sid attribute */
+		return remote_label;
+
+	/* when next-hop changes, we need a new label value
+	 * TODO: get allocated label for that advertisement
+	 */
+	return MPLS_INVALID_LABEL;
+}

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -324,4 +324,7 @@ extern void vpn_handle_router_id_update(struct bgp *bgp, bool withdraw,
 extern void bgp_vpn_leak_unimport(struct bgp *from_bgp);
 extern void bgp_vpn_leak_export(struct bgp *from_bgp);
 
+extern mpls_label_t bgp_mplsvpn_adv_label(struct bgp_path_info *pi,
+					  struct peer *to, afi_t afi,
+					  safi_t safi);
 #endif /* _QUAGGA_BGP_MPLSVPN_H */

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -789,6 +789,11 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 						      safi);
 				label_pnt = &label;
 				num_labels = 1;
+			} else if (safi == SAFI_MPLS_VPN) {
+				label = bgp_mplsvpn_adv_label(path, peer, afi,
+							      safi);
+				label_pnt = &label;
+				num_labels = 1;
 			} else if (path && path->extra) {
 				label_pnt = &path->extra->label[0];
 				num_labels = path->extra->num_labels;


### PR DESCRIPTION
The current implementation does not change the label value when redistributing mpls vpn route with a modified next-hop.

This behaviour is not compliant with the rfc3107:

> When a BGP speaker redistributes a route, the label(s) assigned
> to that route must not be changed (except by omission), unless
> the speaker changes the value of the Next Hop attribute of the
> route.

This commit detects if the next-hop of the BGP update to advertise is modified; in this case, an MPLS_INVALID_LABEL value will be provided, as mpls vpn update has no mechanism to allocate a new mpls label value. The BGP update will not be advertised.

If the next-hop does not change, the BGP update is advertised with the original update.