### PR TITLE
pim6d: Clear channel_oil on prune

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -432,6 +432,8 @@ static void gm_sg_update(struct gm_sg *sg, bool has_expired)
 	} else if (sg->tib_joined && !new_join) {
 		tib_sg_gm_prune(gm_ifp->pim, sg->sgaddr, gm_ifp->ifp, &sg->oil);
 
+		/* Detach sg channel oil */
+		pim_channel_oil_del(sg->oil, __func__);
 		sg->oil = NULL;
 		sg->tib_joined = false;
 	}


### PR DESCRIPTION
Setup:
Receiver---LHR---RP

Problem:
In LHR, ipv6 pim state remains after MLD prune received.

Root Cause:
When LHR receives join, it creates (*,G) channel oil with oil_ref_count = 2. The channel_oil is used by gm_sg sg->oil and upstream->channel_oil.

When LHR receives prune, currently upstream->channel_oil is deleted and gm_sg sg->oil still present. Due to this channel_oil is still present with oil_ref_count = 1

Fix:
When LHR receives prune, upstream->channel_oil and pim_sg sg->oil needs to be deleted.

Issue: #11249