### PR TITLE
bgpd: im/explicit-null label management add command in address-family 

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3469,10 +3469,11 @@ need_null_label:
 	if (label == NULL)
 		return true;
 	/* Disable PHP : explicit-null */
-	if (!!CHECK_FLAG(bgp->flags, BGP_FLAG_LU_IPV4_EXPLICIT_NULL) &&
+
+	if (!!CHECK_FLAG(bgp->af_flags[afi][SAFI_LABELED_UNICAST], BGP_LU_EXPLICIT_NULL) &&
 	    afi == AFI_IP)
 		*label = MPLS_LABEL_IPV4_EXPLICIT_NULL;
-	else if (!!CHECK_FLAG(bgp->flags, BGP_FLAG_LU_IPV6_EXPLICIT_NULL) &&
+	else if (!!CHECK_FLAG(bgp->af_flags[afi][SAFI_LABELED_UNICAST], BGP_LU_EXPLICIT_NULL) &&
 		 afi == AFI_IP6)
 		*label = MPLS_LABEL_IPV6_EXPLICIT_NULL;
 	else

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -574,9 +574,9 @@ bool bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 		attr_hash = attrhash_key_make(attr);
 
 	if (!CHECK_FLAG(subgrp->sflags, SUBGRP_STATUS_FORCE_UPDATES) &&
-	    attr_hash && adj->attr_hash == attr_hash &&
-	    bgp_labels_cmp(path->extra ? path->extra->labels : NULL,
-			   adj->labels)) {
+	    !CHECK_FLAG(dest->flags, BGP_NODE_LABEL_CHANGED) && attr_hash &&
+	    adj->attr_hash == attr_hash &&
+	    bgp_labels_cmp(path->extra ? path->extra->labels : NULL, adj->labels)) {
 		if (BGP_DEBUG(update, UPDATE_OUT)) {
 			char attr_str[BUFSIZ] = {0};
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2876,52 +2876,6 @@ DEFPY(bgp_enforce_first_as,
 	return CMD_SUCCESS;
 }
 
-DEFPY(bgp_lu_uses_explicit_null, bgp_lu_uses_explicit_null_cmd,
-      "[no] bgp labeled-unicast <explicit-null|ipv4-explicit-null|ipv6-explicit-null>$value",
-      NO_STR BGP_STR
-      "BGP Labeled-unicast options\n"
-      "Use explicit-null label values for all local prefixes\n"
-      "Use the IPv4 explicit-null label value for IPv4 local prefixes\n"
-      "Use the IPv6 explicit-null label value for IPv6 local prefixes\n")
-{
-	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	safi_t safi = SAFI_LABELED_UNICAST;
-	bool afi4 = false;
-	bool afi6 = false;
-
-
-	if (strmatch(value, "ipv4-explicit-null"))
-		afi4 = true;
-	else if (strmatch(value, "ipv6-explicit-null"))
-		afi6 = true;
-	else {
-		afi4 = true;
-		afi6 = true;
-	}
-
-
-	if (no) {
-		if (afi4 && CHECK_FLAG(bgp->af_flags[AFI_IP][safi], BGP_LU_EXPLICIT_NULL)) {
-			UNSET_FLAG(bgp->af_flags[AFI_IP][safi], BGP_LU_EXPLICIT_NULL);
-			bgp_zebra_label_set_to_imp_null(bgp, AFI_IP);
-		}
-		if (afi6 && CHECK_FLAG(bgp->af_flags[AFI_IP6][safi], BGP_LU_EXPLICIT_NULL)) {
-			UNSET_FLAG(bgp->af_flags[AFI_IP6][safi], BGP_LU_EXPLICIT_NULL);
-			bgp_zebra_label_set_to_imp_null(bgp, AFI_IP6);
-		}
-	} else {
-		if (afi4 && !CHECK_FLAG(bgp->af_flags[AFI_IP][safi], BGP_LU_EXPLICIT_NULL)) {
-			SET_FLAG(bgp->af_flags[AFI_IP][safi], BGP_LU_EXPLICIT_NULL);
-			bgp_zebra_label_set_to_exp_null(bgp, AFI_IP);
-		}
-		if (afi6 && !CHECK_FLAG(bgp->af_flags[AFI_IP6][safi], BGP_LU_EXPLICIT_NULL)) {
-			SET_FLAG(bgp->af_flags[AFI_IP6][safi], BGP_LU_EXPLICIT_NULL);
-			bgp_zebra_label_set_to_exp_null(bgp, AFI_IP6);
-		}
-	}
-	return CMD_SUCCESS;
-}
-
 DEFUN(bgp_suppress_duplicates, bgp_suppress_duplicates_cmd,
       "bgp suppress-duplicates",
       BGP_STR
@@ -20607,9 +20561,6 @@ void bgp_vty_init(void)
 
 	/* bgp enforce-first-as */
 	install_element(BGP_NODE, &bgp_enforce_first_as_cmd);
-
-	/* bgp labeled-unicast explicit-null */
-	install_element(BGP_NODE, &bgp_lu_uses_explicit_null_cmd);
 
 	/* bgp suppress-duplicates */
 	install_element(BGP_NODE, &bgp_suppress_duplicates_cmd);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2894,10 +2894,20 @@ DEFPY(bgp_lu_uses_explicit_null, bgp_lu_uses_explicit_null_cmd,
 	else
 		label_mode = BGP_FLAG_LU_IPV4_EXPLICIT_NULL |
 			     BGP_FLAG_LU_IPV6_EXPLICIT_NULL;
-	if (no)
+
+	if (no) {
 		UNSET_FLAG(bgp->flags, label_mode);
-	else
+		if (CHECK_FLAG(label_mode, BGP_FLAG_LU_IPV4_EXPLICIT_NULL))
+			bgp_zebra_label_set_to_imp_null(bgp, AFI_IP);
+		if (CHECK_FLAG(label_mode, BGP_FLAG_LU_IPV6_EXPLICIT_NULL))
+			bgp_zebra_label_set_to_imp_null(bgp, AFI_IP6);
+	} else {
 		SET_FLAG(bgp->flags, label_mode);
+		if (CHECK_FLAG(label_mode, BGP_FLAG_LU_IPV4_EXPLICIT_NULL))
+			bgp_zebra_label_set_to_exp_null(bgp, AFI_IP);
+		if (CHECK_FLAG(label_mode, BGP_FLAG_LU_IPV6_EXPLICIT_NULL))
+			bgp_zebra_label_set_to_exp_null(bgp, AFI_IP6);
+	}
 	return CMD_SUCCESS;
 }
 

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -34,6 +34,9 @@ extern void bgp_zebra_route_install(struct bgp_dest *dest,
 				    bool is_sync);
 extern void bgp_zebra_announce_table(struct bgp *bgp, afi_t afi, safi_t safi);
 
+extern void bgp_zebra_label_set_to_imp_null(struct bgp *bgp, afi_t afi);
+extern void bgp_zebra_label_set_to_exp_null(struct bgp *bgp, afi_t afi);
+
 /* Announce routes of any bgp subtype of a table to zebra */
 extern void bgp_zebra_announce_table_all_subtypes(struct bgp *bgp, afi_t afi,
 						  safi_t safi);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -542,15 +542,11 @@ struct bgp {
 #define BGP_FLAG_HARD_ADMIN_RESET (1ULL << 31)
 /* Evaluate the AIGP attribute during the best path selection process */
 #define BGP_FLAG_COMPARE_AIGP (1ULL << 32)
-/* For BGP-LU, force IPv4 local prefixes to use ipv4-explicit-null label */
-#define BGP_FLAG_LU_IPV4_EXPLICIT_NULL (1ULL << 33)
-/* For BGP-LU, force IPv6 local prefixes to use ipv6-explicit-null label */
-#define BGP_FLAG_LU_IPV6_EXPLICIT_NULL (1ULL << 34)
-#define BGP_FLAG_SOFT_VERSION_CAPABILITY (1ULL << 35)
-#define BGP_FLAG_ENFORCE_FIRST_AS (1ULL << 36)
-#define BGP_FLAG_DYNAMIC_CAPABILITY (1ULL << 37)
-#define BGP_FLAG_VNI_DOWN		 (1ULL << 38)
-#define BGP_FLAG_INSTANCE_HIDDEN	 (1ULL << 39)
+#define BGP_FLAG_SOFT_VERSION_CAPABILITY (1ULL << 33)
+#define BGP_FLAG_ENFORCE_FIRST_AS	 (1ULL << 34)
+#define BGP_FLAG_DYNAMIC_CAPABILITY	 (1ULL << 35)
+#define BGP_FLAG_VNI_DOWN		 (1ULL << 36)
+#define BGP_FLAG_INSTANCE_HIDDEN	 (1ULL << 37)
 
 	/* BGP default address-families.
 	 * New peers inherit enabled afi/safis from bgp instance.
@@ -587,6 +583,8 @@ struct bgp {
 #define BGP_CONFIG_VRF_TO_VRF_EXPORT (1 << 10)
 /* vpnvx retain flag */
 #define BGP_VPNVX_RETAIN_ROUTE_TARGET_ALL (1 << 11)
+/* for implicit/explicit null label use  */
+#define BGP_LU_EXPLICIT_NULL (1 << 12)
 
 	/* BGP per AF peer count */
 	uint32_t af_peer_count[AFI_MAX][SAFI_MAX];

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3089,16 +3089,27 @@ happened automatically if local-role is set.
    value of his role (by setting local-role on his side). Otherwise, a Role
    Mismatch Notification will be sent.
 
-Labeled unicast
----------------
+Default null label
+-------------------
 
 *bgpd* supports labeled information, as per :rfc:`3107`.
 
-.. clicmd:: bgp labeled-unicast <explicit-null|ipv4-explicit-null|ipv6-explicit-null>
+.. clicmd:: label explicit null
 
 By default, locally advertised prefixes use the `implicit-null` label to
-encode in the outgoing NLRI. The following command uses the `explicit-null`
-label value for all the BGP instances.
+encode in the outgoing NLRI. This command activate the 'explicit-null'
+label value for the related address-family.
+Only labeled-unicast families are accepted.
+
+This configuration example sets up use of "explicit-null" label for
+ipv4 labeled-unicast in the outgoing NLRI that are locally advertised.
+
+.. code-block:: frr
+    router bgp 1
+       address-family ipv4 labeled-unicast
+        label explicit-null
+       exit-address-family
+
 
 .. _bgp-l3vpn-vrfs:
 

--- a/tests/topotests/bgp_lu_explicitnull/r1/bgpd.conf
+++ b/tests/topotests/bgp_lu_explicitnull/r1/bgpd.conf
@@ -1,7 +1,6 @@
 router bgp 65500
  bgp router-id 192.0.2.1
  no bgp ebgp-requires-policy
- bgp labeled-unicast explicit-null
  neighbor 192.0.2.2 remote-as 65501
 !
  address-family ipv4 unicast
@@ -11,5 +10,6 @@ router bgp 65500
  !
  address-family ipv4 labeled-unicast
   neighbor 192.0.2.2 activate
+  label explicit-null
  exit-address-family
 !

--- a/tests/topotests/bgp_lu_explicitnull/r2/bgpd.conf
+++ b/tests/topotests/bgp_lu_explicitnull/r2/bgpd.conf
@@ -1,7 +1,6 @@
 router bgp 65501
  bgp router-id 192.0.2.2
  no bgp ebgp-requires-policy
- bgp labeled-unicast explicit-null
  neighbor 192.0.2.1 remote-as 65500
 !
  address-family ipv4 unicast
@@ -11,5 +10,6 @@ router bgp 65501
  !
  address-family ipv4 labeled-unicast
   neighbor 192.0.2.1 activate
+  label explicit-null
  exit-address-family
 !


### PR DESCRIPTION
currently explicit-null label is managed through
router bgp 65501
 bgp labeled-unicast explicit-null

now this is changed into  the following configuration 

router bgp 65501
address-family ipv4 unicast
  no neighbor 192.0.2.2 activate
  network 192.168.2.1/32
 exit-address-family
 !
 address-family ipv4 labeled-unicast
  neighbor 192.0.2.2 activate
  bgp mls label explicit-null
 exit-address-family

this may be done on ipv4 and ipv6 labeled unicast address families

Signed-off-by: Francois Dumontet <francois.dumontet@6wind.com>
