### PR TITLE
pbrd: add vty support for vlan filtering and send to zebra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@
 /libtool.orig
 /test-driver
 /test-suite.log
+/changelog-auto
+/m4/ac
+/pathd/
+/pceplib/
 
 /Makefile
 /Makefile.in
@@ -114,6 +118,6 @@ refix
 .kitchen
 .emacs.desktop*
 
-/test-suite.log
 pceplib/test/*.log
 pceplib/test/*.trs
+*.xref

--- a/.gitignore
+++ b/.gitignore
@@ -30,10 +30,6 @@
 /libtool.orig
 /test-driver
 /test-suite.log
-/changelog-auto
-/m4/ac
-/pathd/
-/pceplib/
 
 /Makefile
 /Makefile.in
@@ -120,4 +116,3 @@ refix
 
 pceplib/test/*.log
 pceplib/test/*.trs
-*.xref

--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -5,7 +5,7 @@ PBR
 ***
 
 :abbr:`PBR` is Policy Based Routing.  This implementation supports a very simple
-interface to allow admins to influence routing on their router.  At this point in 
+interface to allow admins to influence routing on their router.  At this point in
 time, this implementation will only work on Linux. Note that some
 functionality (VLAN matching, packet mangling) is not supported by the default
 Linux kernel provider.
@@ -114,8 +114,8 @@ end destination.
 
    When a incoming packet matches the specified ip protocol, take the
    packet and forward according to the nexthops specified. Protocols are
-   queried from the protocols database (`/etc/protocols`; see `man 5
-   protocols`).
+   queried from the protocols database (``/etc/protocols``; see ``man 5
+   protocols``).
 
 .. clicmd:: match mark (1-4294967295)
 

--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -5,9 +5,10 @@ PBR
 ***
 
 :abbr:`PBR` is Policy Based Routing.  This implementation supports a very simple
-interface to allow admins to influence routing on their router.  At this time
-you can only match on destination and source prefixes for an incoming interface.
-At this point in time, this implementation will only work on Linux.
+interface to allow admins to influence routing on their router.  At this point in 
+time, this implementation will only work on Linux. Note that some
+functionality (VLAN matching, packet mangling) is not supported by the default
+Linux kernel provider.
 
 .. _starting-pbr:
 
@@ -109,10 +110,12 @@ end destination.
    When a incoming packet matches the destination port specified, take the
    packet and forward according to the nexthops specified.
 
-.. clicmd:: match ip-protocol [tcp|udp]
+.. clicmd:: match ip-protocol PROTOCOL
 
    When a incoming packet matches the specified ip protocol, take the
-   packet and forward according to the nexthops specified.
+   packet and forward according to the nexthops specified. Protocols are
+   queried from the protocols database (`/etc/protocols`; see `man 5
+   protocols`).
 
 .. clicmd:: match mark (1-4294967295)
 
@@ -135,7 +138,6 @@ end destination.
    Match packets according to the specified explicit congestion notification
    (ECN) field in the IP header; if this value matches then forward the packet
    according to the nexthop(s) specified.
-
 
 .. clicmd:: set queue-id (1-65535)
 
@@ -160,6 +162,28 @@ end destination.
 
    Strip inner vlan tags from matched packets. The Linux Kernel provider does not currently support packet mangling, so this field will be ignored unless another provider is used. It is invalid to specify both a `strip` and `set
    vlan` action.
+
+.. clicmd:: match pcp (0-7)
+
+   Match packets according to the 802.1Q Priority Code Point. Zero is the
+   default (nominally, "best effort"). Note that the Linux kernel provider
+   does not support matching PCPs, so this field will be ignored unless other
+   providers are used.
+
+.. clicmd:: match vlan (1-4094)
+
+   Match packets according to their VLAN (802.1Q) identifier. Note that VLAN
+   IDs 0 and 4095 are reserved. The Linux kernel provider does not provide
+   VLAN-matching facilities, so this field will be ignored unless other
+   providers are used.
+
+.. clicmd:: match vlan (tagged|untagged|untagged-or-zero)
+
+   Match packets according to whether or not they have a VLAN tag. Use
+   `untagged-or-zero` to also match packets with the reserved VLAN ID of 0
+   (indicating an untagged frame which includes other 802.1Q fields). The
+   Linux kernel provider does not provide VLAN-matching facilities, so this
+   field will be ignored unless other providers are used.
 
 .. clicmd:: set nexthop-group NAME
 
@@ -227,7 +251,7 @@ end destination.
    | nexthopGroup    | This policy's nexthop group (if relevant) | Object  |
    +-----------------+-------------------------------------------+---------+
 
-   Finally, the ``nexthopGroup`` object above cotains information we know
+   Finally, the ``nexthopGroup`` object above contains information we know
    about the configured nexthop for this policy:
 
    +---------------------+--------------------------------------+---------+

--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -148,7 +148,7 @@ end destination.
 .. clicmd:: set pcp (0-7)
 
    Set the 802.1Q priority code point (PCP) for matched packets. A PCP of zero
-   is the defaul (nominally, "best effort"). The Linux Kernel provider does not 
+   is the default (nominally, "best effort"). The Linux Kernel provider does not 
    currently support packet mangling, so this field will be ignored unless 
    another provider is used.
 

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -44,7 +44,7 @@ struct pbr_filter {
 
 #define PBR_DSFIELD_DSCP (0xfc) /* Upper 6 bits of DS field: DSCP */
 #define PBR_DSFIELD_ECN (0x03)	/* Lower 2 bits of DS field: BCN */
-#define PBR_PCP (0x07)	        /* 3-bit value 0..7 for prioritization*/
+#define PBR_PCP (0x07)		/* 3-bit value 0..7 for prioritization*/
 
 	/* Source and Destination IP address with masks */
 	struct prefix src_ip;
@@ -54,7 +54,7 @@ struct pbr_filter {
 	uint16_t src_port;
 	uint16_t dst_port;
 
-    /* Filter by VLAN and prioritization */
+	/* Filter by VLAN and prioritization */
 	uint8_t pcp;
 	uint16_t vlan_id;
 	uint16_t vlan_flags;

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 /* Policy Based Routing (PBR) main header
  * Copyright (C) 2018 6WIND
+ * Portions:
+ *      Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+ *		    Approved for Public Release; Distribution Unlimited 21-1402
  */
 
 #ifndef _PBR_H
@@ -25,29 +28,37 @@ extern "C" {
  * specified.
  */
 struct pbr_filter {
-	uint32_t filter_bm; /* not encoded by zapi
-			     */
-#define PBR_FILTER_SRC_IP		(1 << 0)
-#define PBR_FILTER_DST_IP		(1 << 1)
-#define PBR_FILTER_SRC_PORT		(1 << 2)
-#define PBR_FILTER_DST_PORT		(1 << 3)
-#define PBR_FILTER_FWMARK		(1 << 4)
-#define PBR_FILTER_PROTO		(1 << 5)
+	uint32_t filter_bm; /* not encoded by zapi */
+#define PBR_FILTER_SRC_IP		    (1 << 0)
+#define PBR_FILTER_DST_IP		    (1 << 1)
+#define PBR_FILTER_SRC_PORT		    (1 << 2)
+#define PBR_FILTER_DST_PORT		    (1 << 3)
+#define PBR_FILTER_FWMARK		    (1 << 4)
+#define PBR_FILTER_PROTO		    (1 << 5)
 #define PBR_FILTER_SRC_PORT_RANGE	(1 << 6)
 #define PBR_FILTER_DST_PORT_RANGE	(1 << 7)
-#define PBR_FILTER_DSFIELD		(1 << 8)
-#define PBR_FILTER_IP_PROTOCOL	(1 << 9)
+#define PBR_FILTER_DSFIELD          (1 << 8)
+#define PBR_FILTER_IP_PROTOCOL      (1 << 9)
+#define PBR_FILTER_PCP              (1 << 10)
+#define PBR_FILTER_VLAN_FLAGS       (1 << 11)
+#define PBR_FILTER_VLAN_ID          (1 << 12)
 
 #define PBR_DSFIELD_DSCP (0xfc) /* Upper 6 bits of DS field: DSCP */
 #define PBR_DSFIELD_ECN (0x03)	/* Lower 2 bits of DS field: BCN */
+#define PBR_PCP (0x07)	        /* 3-bit value 0..7 for prioritization*/
 
-	/* Source and Destination IP address with masks. */
+	/* Source and Destination IP address with masks */
 	struct prefix src_ip;
 	struct prefix dst_ip;
 
-	/* Source and Destination higher-layer (TCP/UDP) port numbers. */
+	/* Source and Destination higher-layer (TCP/UDP) port numbers */
 	uint16_t src_port;
 	uint16_t dst_port;
+
+    /* Filter by VLAN and prioritization */
+	uint8_t pcp;
+	uint16_t vlan_id;
+	uint16_t vlan_flags;
 
 	/* Filter by Differentiated Services field  */
 	uint8_t dsfield; /* DSCP (6 bits) & ECN (2 bits) */

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -2,8 +2,7 @@
 /* Policy Based Routing (PBR) main header
  * Copyright (C) 2018 6WIND
  * Portions:
- *      Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
- *		    Approved for Public Release; Distribution Unlimited 21-1402
+ *      Copyright (c) 2021 The MITRE Corporation.
  */
 
 #ifndef _PBR_H
@@ -29,19 +28,19 @@ extern "C" {
  */
 struct pbr_filter {
 	uint32_t filter_bm; /* not encoded by zapi */
-#define PBR_FILTER_SRC_IP		    (1 << 0)
-#define PBR_FILTER_DST_IP		    (1 << 1)
-#define PBR_FILTER_SRC_PORT		    (1 << 2)
-#define PBR_FILTER_DST_PORT		    (1 << 3)
-#define PBR_FILTER_FWMARK		    (1 << 4)
-#define PBR_FILTER_PROTO		    (1 << 5)
-#define PBR_FILTER_SRC_PORT_RANGE	(1 << 6)
-#define PBR_FILTER_DST_PORT_RANGE	(1 << 7)
-#define PBR_FILTER_DSFIELD          (1 << 8)
-#define PBR_FILTER_IP_PROTOCOL      (1 << 9)
-#define PBR_FILTER_PCP              (1 << 10)
-#define PBR_FILTER_VLAN_FLAGS       (1 << 11)
-#define PBR_FILTER_VLAN_ID          (1 << 12)
+#define PBR_FILTER_SRC_IP (1 << 0)
+#define PBR_FILTER_DST_IP (1 << 1)
+#define PBR_FILTER_SRC_PORT (1 << 2)
+#define PBR_FILTER_DST_PORT (1 << 3)
+#define PBR_FILTER_FWMARK (1 << 4)
+#define PBR_FILTER_PROTO (1 << 5)
+#define PBR_FILTER_SRC_PORT_RANGE (1 << 6)
+#define PBR_FILTER_DST_PORT_RANGE (1 << 7)
+#define PBR_FILTER_DSFIELD (1 << 8)
+#define PBR_FILTER_IP_PROTOCOL (1 << 9)
+#define PBR_FILTER_PCP (1 << 10)
+#define PBR_FILTER_VLAN_FLAGS (1 << 11)
+#define PBR_FILTER_VLAN_ID (1 << 12)
 
 #define PBR_DSFIELD_DSCP (0xfc) /* Upper 6 bits of DS field: DSCP */
 #define PBR_DSFIELD_ECN (0x03)	/* Lower 2 bits of DS field: BCN */

--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -314,7 +314,7 @@ static void pbrms_vrf_update(struct pbr_map_sequence *pbrms,
 		DEBUGD(&pbr_dbg_map, "    Seq %u uses vrf %s (%u), updating map",
 		       pbrms->seqno, vrf_name, pbr_vrf_id(pbr_vrf));
 
-        pbr_map_check(pbrms, false);
+		pbr_map_check(pbrms, false);
 	}
 }
 
@@ -506,7 +506,7 @@ uint8_t pbr_map_decode_dscp_enum(const char *name)
 
 struct pbr_map_sequence *pbrms_get(const char *name, uint32_t seqno)
 {
-    struct pbr_map *pbrm = NULL;
+	struct pbr_map *pbrm = NULL;
 	struct pbr_map_sequence *pbrms = NULL;
 	struct listnode *node = NULL;
 
@@ -545,10 +545,10 @@ struct pbr_map_sequence *pbrms_get(const char *name, uint32_t seqno)
 		pbrms->seqno = seqno;
 		pbrms->ruleno = pbr_nht_get_next_rule(seqno);
 		pbrms->parent = pbrm;
-        
+
 		pbrms->match_vlan_id = 0;
 		pbrms->match_vlan_flags = 0;
-        pbrms->match_pcp = 0;
+		pbrms->match_pcp = 0;
 
 		pbrms->action_vlan_id = 0;
 		pbrms->action_vlan_flags = 0;
@@ -618,11 +618,11 @@ pbr_map_sequence_check_nexthops_valid(struct pbr_map_sequence *pbrms)
 
 static void pbr_map_sequence_check_not_empty(struct pbr_map_sequence *pbrms)
 {
-	if (!pbrms->src && !pbrms->dst && !pbrms->mark && !pbrms->dsfield
-        && !pbrms->match_pcp && !pbrms->action_pcp && !pbrms->match_vlan_id
-	    && !pbrms->match_vlan_flags && !pbrms->action_vlan_id
-	    && !pbrms->action_vlan_flags
-        && pbrms->action_queue_id == PBR_MAP_UNDEFINED_QUEUE_ID)
+	if (!pbrms->src && !pbrms->dst && !pbrms->mark && !pbrms->dsfield &&
+	    !pbrms->match_pcp && !pbrms->action_pcp && !pbrms->match_vlan_id &&
+	    !pbrms->match_vlan_flags && !pbrms->action_vlan_id &&
+	    !pbrms->action_vlan_flags &&
+	    pbrms->action_queue_id == PBR_MAP_UNDEFINED_QUEUE_ID)
 		pbrms->reason |= PBR_MAP_INVALID_EMPTY;
 }
 

--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -548,7 +548,7 @@ struct pbr_map_sequence *pbrms_get(const char *name, uint32_t seqno)
 
 		pbrms->match_vlan_id = 0;
 		pbrms->match_vlan_flags = 0;
-		pbrms->match_pcp = 0;
+		pbrms->match_pcp = PBR_MAP_IGNORE_PCP;
 
 		pbrms->action_vlan_id = 0;
 		pbrms->action_vlan_flags = 0;

--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -4,8 +4,7 @@
  * Copyright (C) 2018 Cumulus Networks, Inc.
  *               Donald Sharp
  * Portions:
- *		Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
- *			Approved for Public Release; Distribution Unlimited 21-1402
+ *		Copyright (c) 2021 The MITRE Corporation.
  */
 #include <zebra.h>
 
@@ -108,8 +107,6 @@ void pbr_set_match_clause_for_pcp(struct pbr_map_sequence *pbrms, uint8_t pcp)
 {
 	if (pbrms) {
 		pbrms->match_pcp = pcp;
-		zlog_info("setting pbrms->match_pcp = %u ", pbrms->match_pcp);
-
 		pbr_map_check(pbrms, true);
 	}
 }
@@ -317,7 +314,7 @@ static void pbrms_vrf_update(struct pbr_map_sequence *pbrms,
 		DEBUGD(&pbr_dbg_map, "    Seq %u uses vrf %s (%u), updating map",
 		       pbrms->seqno, vrf_name, pbr_vrf_id(pbr_vrf));
 
-		pbr_map_check(pbrms, false);
+        pbr_map_check(pbrms, false);
 	}
 }
 
@@ -551,7 +548,7 @@ struct pbr_map_sequence *pbrms_get(const char *name, uint32_t seqno)
         
 		pbrms->match_vlan_id = 0;
 		pbrms->match_vlan_flags = 0;
-		pbrms->match_pcp = 0;
+        pbrms->match_pcp = 0;
 
 		pbrms->action_vlan_id = 0;
 		pbrms->action_vlan_flags = 0;
@@ -625,7 +622,7 @@ static void pbr_map_sequence_check_not_empty(struct pbr_map_sequence *pbrms)
         && !pbrms->match_pcp && !pbrms->action_pcp && !pbrms->match_vlan_id
 	    && !pbrms->match_vlan_flags && !pbrms->action_vlan_id
 	    && !pbrms->action_vlan_flags
-	    && pbrms->action_queue_id == PBR_MAP_UNDEFINED_QUEUE_ID)
+        && pbrms->action_queue_id == PBR_MAP_UNDEFINED_QUEUE_ID)
 		pbrms->reason |= PBR_MAP_INVALID_EMPTY;
 }
 

--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -3,6 +3,9 @@
  * PBR-map Code
  * Copyright (C) 2018 Cumulus Networks, Inc.
  *               Donald Sharp
+ * Portions:
+ *		Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+ *			Approved for Public Release; Distribution Unlimited 21-1402
  */
 #include <zebra.h>
 
@@ -99,6 +102,26 @@ static bool pbrms_is_installed(const struct pbr_map_sequence *pbrms,
 		return true;
 
 	return false;
+}
+
+void pbr_set_match_clause_for_pcp(struct pbr_map_sequence *pbrms, uint8_t pcp)
+{
+	if (pbrms) {
+		pbrms->match_pcp = pcp;
+		zlog_info("setting pbrms->match_pcp = %u ", pbrms->match_pcp);
+
+		pbr_map_check(pbrms, true);
+	}
+}
+
+void pbr_set_match_clause_for_vlan(struct pbr_map_sequence *pbrms,
+				   uint16_t vlan_id, uint16_t vlan_flags)
+{
+	if (pbrms) {
+		pbrms->match_vlan_id = vlan_id;
+		pbrms->match_vlan_flags = vlan_flags;
+		pbr_map_check(pbrms, true);
+	}
 }
 
 /* If any sequence is installed on the interface, assume installed */
@@ -486,9 +509,9 @@ uint8_t pbr_map_decode_dscp_enum(const char *name)
 
 struct pbr_map_sequence *pbrms_get(const char *name, uint32_t seqno)
 {
-	struct pbr_map *pbrm;
-	struct pbr_map_sequence *pbrms;
-	struct listnode *node;
+    struct pbr_map *pbrm = NULL;
+	struct pbr_map_sequence *pbrms = NULL;
+	struct listnode *node = NULL;
 
 	pbrm = pbrm_find(name);
 	if (!pbrm) {
@@ -525,6 +548,10 @@ struct pbr_map_sequence *pbrms_get(const char *name, uint32_t seqno)
 		pbrms->seqno = seqno;
 		pbrms->ruleno = pbr_nht_get_next_rule(seqno);
 		pbrms->parent = pbrm;
+        
+		pbrms->match_vlan_id = 0;
+		pbrms->match_vlan_flags = 0;
+		pbrms->match_pcp = 0;
 
 		pbrms->action_vlan_id = 0;
 		pbrms->action_vlan_flags = 0;
@@ -595,8 +622,9 @@ pbr_map_sequence_check_nexthops_valid(struct pbr_map_sequence *pbrms)
 static void pbr_map_sequence_check_not_empty(struct pbr_map_sequence *pbrms)
 {
 	if (!pbrms->src && !pbrms->dst && !pbrms->mark && !pbrms->dsfield
-	    && !pbrms->action_vlan_id && !pbrms->action_vlan_flags
-	    && !pbrms->action_pcp
+        && !pbrms->match_pcp && !pbrms->action_pcp && !pbrms->match_vlan_id
+	    && !pbrms->match_vlan_flags && !pbrms->action_vlan_id
+	    && !pbrms->action_vlan_flags
 	    && pbrms->action_queue_id == PBR_MAP_UNDEFINED_QUEUE_ID)
 		pbrms->reason |= PBR_MAP_INVALID_EMPTY;
 }
@@ -733,7 +761,6 @@ void pbr_map_policy_delete(struct pbr_map *pbrm, struct pbr_map_interface *pmi)
 	struct listnode *node;
 	struct pbr_map_sequence *pbrms;
 	bool sent = false;
-
 
 	for (ALL_LIST_ELEMENTS_RO(pbrm->seqnumbers, node, pbrms))
 		if (pbr_send_pbr_map(pbrms, pmi, false, true))

--- a/pbrd/pbr_map.h
+++ b/pbrd/pbr_map.h
@@ -113,6 +113,7 @@ struct pbr_map_sequence {
 #define PBR_MAP_VLAN_TAGGED (1 << 0)
 #define PBR_MAP_VLAN_UNTAGGED (1 << 1)
 #define PBR_MAP_VLAN_UNTAGGED_0 (1 << 2)
+#define PBR_MAP_IGNORE_PCP 8
 
 	uint16_t match_vlan_flags;
 

--- a/pbrd/pbr_map.h
+++ b/pbrd/pbr_map.h
@@ -106,6 +106,16 @@ struct pbr_map_sequence {
 	 */
 	unsigned char family;
 
+	uint8_t match_pcp;
+	uint16_t match_vlan_id;
+
+#define PBR_MAP_VLAN_NO_WILD 0
+#define PBR_MAP_VLAN_TAGGED (1 << 0)
+#define PBR_MAP_VLAN_UNTAGGED (1 << 1)
+#define PBR_MAP_VLAN_UNTAGGED_0 (1 << 2)
+
+	uint16_t match_vlan_flags;
+
 	/*
 	 * Use interface's vrf.
 	 */
@@ -222,4 +232,9 @@ extern void pbr_map_check_vrf_nh_group_change(const char *nh_group,
 extern void pbr_map_check_interface_nh_group_change(const char *nh_group,
 						    struct interface *ifp,
 						    ifindex_t oldifindex);
+extern void pbr_set_match_clause_for_vlan(struct pbr_map_sequence *pbrms,
+					  uint16_t vlan_id,
+					  uint16_t vlan_flags);
+extern void pbr_set_match_clause_for_pcp(struct pbr_map_sequence *pbrms,
+					 uint8_t pcp);
 #endif

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -38,7 +38,7 @@ DEFPY(pbr_map_match_pcp, pbr_map_match_pcp_cmd, "[no] match pcp <(0-7)$pcp>",
 		if (!no)
 			pbr_set_match_clause_for_pcp(pbrms, pcp);
 		else if (pcp == pbrms->match_pcp)
-			pbr_set_match_clause_for_pcp(pbrms, 0);
+			pbr_set_match_clause_for_pcp(pbrms, PBR_MAP_IGNORE_PCP);
 	}
 	return CMD_SUCCESS;
 }
@@ -981,7 +981,7 @@ static void vty_show_pbrms(struct vty *vty,
 			pbrms->dsfield & PBR_DSFIELD_ECN);
 	if (pbrms->mark)
 		vty_out(vty, "        MARK Match: %u\n", pbrms->mark);
-	if (pbrms->match_pcp != 0)
+	if (pbrms->match_pcp != PBR_MAP_IGNORE_PCP)
 		vty_out(vty, "        PCP Match: %d\n", pbrms->match_pcp);
 
 	if (pbrms->match_vlan_id != 0)

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -3,6 +3,9 @@
  * PBR - vty code
  * Copyright (C) 2018 Cumulus Networks, Inc.
  *               Donald Sharp
+ * Portions:
+ *		Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+ *		    Approved for Public Release; Distribution Unlimited 21-1402
  */
 #include <zebra.h>
 
@@ -24,6 +27,80 @@
 #include "pbrd/pbr_vty.h"
 #include "pbrd/pbr_debug.h"
 #include "pbrd/pbr_vty_clippy.c"
+
+DEFPY(pbr_map_match_pcp, pbr_map_match_pcp_cmd, "[no] match pcp <(0-7)$pcp>",
+      NO_STR
+      "match the rest of the command\n"
+      "match based on 802.1p Priority Code Point (PCP) value\n"
+      "a valid value in range 0..7 \n")
+{
+	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
+
+	if (pbrms) {
+		if (!no)
+			pbr_set_match_clause_for_pcp(pbrms, pcp);
+		else if (pcp == pbrms->match_pcp)
+			pbr_set_match_clause_for_pcp(pbrms, 0);
+	}
+	return CMD_SUCCESS;
+}
+
+DEFPY(pbr_map_match_vlan_id, pbr_map_match_vlan_id_cmd,
+      "[no] match vlan <(1-4094)$vlan_id>",
+      NO_STR
+      "match the rest of the command\n"
+      "match based on VLAN ID\n"
+      "a valid value in range 1..4094\n")
+{
+	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
+
+	if (pbrms) {
+		if (!no) {
+			pbr_set_match_clause_for_vlan(pbrms, vlan_id, 0);
+		} else {
+			/* if the user previously set a vlan_id value */
+			if (pbrms->match_vlan_id != 0) {
+				if (vlan_id == pbrms->match_vlan_id) {
+					pbr_set_match_clause_for_vlan(pbrms, 0,
+								      0);
+				}
+			}
+		}
+	}
+	return CMD_SUCCESS;
+}
+
+DEFPY(pbr_map_match_vlan_tag, pbr_map_match_vlan_tag_cmd,
+      "[no] match vlan ![<tagged|untagged|untagged-or-zero>$tag_type]",
+      NO_STR
+      "match the rest of the command\n"
+      "match based on VLAN tagging\n"
+      "match all tagged frames\n"
+      "match all untagged frames\n"
+      "match untagged frames, or tagged frames with id zero\n")
+{
+	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
+
+	if (!pbrms)
+		return CMD_WARNING;
+
+	if (!no) {
+		if (strcmp(tag_type, "tagged") == 0) {
+			pbr_set_match_clause_for_vlan(pbrms, 0,
+						      PBR_MAP_VLAN_TAGGED);
+		} else if (strcmp(tag_type, "untagged") == 0) {
+			pbr_set_match_clause_for_vlan(pbrms, 0,
+						      PBR_MAP_VLAN_UNTAGGED);
+		} else if (strcmp(tag_type, "untagged-or-zero") == 0) {
+			pbr_set_match_clause_for_vlan(pbrms, 0,
+						      PBR_MAP_VLAN_UNTAGGED_0);
+		}
+	} else {
+		pbr_set_match_clause_for_vlan(pbrms, 0, PBR_MAP_VLAN_NO_WILD);
+	}
+
+	return CMD_SUCCESS;
+}
 
 DEFUN_NOSH(pbr_map, pbr_map_cmd, "pbr-map PBRMAP seq (1-700)",
 	   "Create pbr-map or enter pbr-map command mode\n"
@@ -185,12 +262,11 @@ DEFPY(pbr_map_match_dst, pbr_map_match_dst_cmd,
 }
 
 DEFPY(pbr_map_match_ip_proto, pbr_map_match_ip_proto_cmd,
-      "[no] match ip-protocol [tcp|udp]$ip_proto",
+      "[no] match ip-protocol PROTO$ip_proto",
       NO_STR
       "Match the rest of the command\n"
       "Choose an ip-protocol\n"
-      "Match on tcp flows\n"
-      "Match on udp flows\n")
+      "Protocol name\n")
 {
 	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
 	struct protoent *p;
@@ -562,9 +638,9 @@ DEFPY(no_pbr_map_nexthop_group, no_pbr_map_nexthop_group_cmd,
 DEFPY(pbr_map_nexthop, pbr_map_nexthop_cmd,
       "set nexthop\
         <\
-	  <A.B.C.D|X:X::X:X>$addr [INTERFACE$intf]\
-	  |INTERFACE$intf\
-	>\
+		    <A.B.C.D|X:X::X:X>$addr [INTERFACE$intf]\
+			|INTERFACE$intf\
+		>\
         [nexthop-vrf NAME$vrf_name]",
       "Set for the PBR-MAP\n"
       "Specify one of the nexthops in this map\n"
@@ -689,9 +765,9 @@ done:
 DEFPY(no_pbr_map_nexthop, no_pbr_map_nexthop_cmd,
       "no set nexthop\
         [<\
-	  <A.B.C.D|X:X::X:X>$addr [INTERFACE$intf]\
-	  |INTERFACE$intf\
-	>\
+		    <A.B.C.D|X:X::X:X>$addr [INTERFACE$intf]\
+			|INTERFACE$intf\
+		>\
         [nexthop-vrf NAME$vrf_name]]",
       NO_STR
       "Set for the PBR-MAP\n"
@@ -884,6 +960,12 @@ static void vty_show_pbrms(struct vty *vty,
 			pbrms->installed ? "yes" : "no",
 			pbrms->reason ? rbuf : "Valid");
 
+    /* match clauses first */
+
+	if (pbrms->dsfield & PBR_DSFIELD_DSCP)
+		vty_out(vty, "        Match DSCP %u\n",
+			(pbrms->dsfield & PBR_DSFIELD_DSCP) >> 2);
+
 	if (pbrms->ip_proto) {
 		struct protoent *p;
 
@@ -899,17 +981,26 @@ static void vty_show_pbrms(struct vty *vty,
 		vty_out(vty, "        SRC Port Match: %u\n", pbrms->src_prt);
 	if (pbrms->dst_prt)
 		vty_out(vty, "        DST Port Match: %u\n", pbrms->dst_prt);
-	if (pbrms->dsfield & PBR_DSFIELD_DSCP)
-		vty_out(vty, "        DSCP Match: %u\n",
-			(pbrms->dsfield & PBR_DSFIELD_DSCP) >> 2);
 	if (pbrms->dsfield & PBR_DSFIELD_ECN)
 		vty_out(vty, "        ECN Match: %u\n",
 			pbrms->dsfield & PBR_DSFIELD_ECN);
 	if (pbrms->mark)
-		vty_out(vty, "        MARK Match: %u\n", pbrms->mark);
+	    vty_out(vty, "        MARK Match: %u\n", pbrms->mark);
+	if (pbrms->match_pcp != 0)
+		vty_out(vty, "        PCP Match: %d\n", pbrms->match_pcp);
+
+	if (pbrms->match_vlan_id != 0)
+		vty_out(vty, "        Match VLAN ID: %u\n",
+			pbrms->match_vlan_id);
+	if (pbrms->match_vlan_flags == PBR_MAP_VLAN_TAGGED)
+		vty_out(vty, "        Match VLAN tagged frames\n");
+	if (pbrms->match_vlan_flags == PBR_MAP_VLAN_UNTAGGED)
+		vty_out(vty, "        Match VLAN untagged frames\n");
+	if (pbrms->match_vlan_flags == PBR_MAP_VLAN_UNTAGGED_0)
+		vty_out(vty, "        Match VLAN untagged or ID 0\n");
 
 	if (pbrms->action_queue_id != PBR_MAP_UNDEFINED_QUEUE_ID)
-		vty_out(vty, "        Set Queue ID %u\n",
+		vty_out(vty, "        Set Queue ID: %u\n",
 			pbrms->action_queue_id);
 
 	if (pbrms->action_vlan_id != 0)
@@ -1306,7 +1397,18 @@ static int pbr_vty_map_config_write_sequence(struct vty *vty,
 
 	if (pbrms->mark)
 		vty_out(vty, " match mark %u\n", pbrms->mark);
+    if (pbrms->match_pcp)
+		vty_out(vty, " match pcp %d\n", pbrms->match_pcp);
 
+	if ((pbrms->match_vlan_id)
+	    && (pbrms->match_vlan_flags == PBR_MAP_VLAN_NO_WILD))
+		vty_out(vty, " match vlan %u\n", pbrms->match_vlan_id);
+	if (pbrms->match_vlan_flags == PBR_MAP_VLAN_TAGGED)
+		vty_out(vty, " match vlan tagged\n");
+	if (pbrms->match_vlan_flags == PBR_MAP_VLAN_UNTAGGED)
+		vty_out(vty, " match vlan untagged\n");
+	if (pbrms->match_vlan_flags == PBR_MAP_VLAN_UNTAGGED_0)
+		vty_out(vty, " match vlan untagged-or-zero\n");
 
 	if (pbrms->action_queue_id != PBR_MAP_UNDEFINED_QUEUE_ID)
 		vty_out(vty, " set queue-id %d\n", pbrms->action_queue_id);
@@ -1406,6 +1508,9 @@ void pbr_vty_init(void)
 	install_element(PBRMAP_NODE, &pbr_map_match_dst_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_match_dscp_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_match_ecn_cmd);
+    install_element(PBRMAP_NODE, &pbr_map_match_vlan_id_cmd);
+	install_element(PBRMAP_NODE, &pbr_map_match_vlan_tag_cmd);
+	install_element(PBRMAP_NODE, &pbr_map_match_pcp_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_match_mark_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_action_queue_id_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_action_strip_vlan_cmd);

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -4,8 +4,7 @@
  * Copyright (C) 2018 Cumulus Networks, Inc.
  *               Donald Sharp
  * Portions:
- *		Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
- *		    Approved for Public Release; Distribution Unlimited 21-1402
+ *		Copyright (c) 2021 The MITRE Corporation.
  */
 #include <zebra.h>
 
@@ -30,9 +29,8 @@
 
 DEFPY(pbr_map_match_pcp, pbr_map_match_pcp_cmd, "[no] match pcp <(0-7)$pcp>",
       NO_STR
-      "match the rest of the command\n"
-      "match based on 802.1p Priority Code Point (PCP) value\n"
-      "a valid value in range 0..7 \n")
+      "Match the rest of the command\n"
+      "Match based on 802.1p Priority Code Point (PCP) value\n")
 {
 	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
 
@@ -48,9 +46,8 @@ DEFPY(pbr_map_match_pcp, pbr_map_match_pcp_cmd, "[no] match pcp <(0-7)$pcp>",
 DEFPY(pbr_map_match_vlan_id, pbr_map_match_vlan_id_cmd,
       "[no] match vlan <(1-4094)$vlan_id>",
       NO_STR
-      "match the rest of the command\n"
-      "match based on VLAN ID\n"
-      "a valid value in range 1..4094\n")
+      "Match the rest of the command\n"
+      "Match based on VLAN ID\n")
 {
 	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
 
@@ -71,27 +68,27 @@ DEFPY(pbr_map_match_vlan_id, pbr_map_match_vlan_id_cmd,
 }
 
 DEFPY(pbr_map_match_vlan_tag, pbr_map_match_vlan_tag_cmd,
-      "[no] match vlan ![<tagged|untagged|untagged-or-zero>$tag_type]",
+      "[no] match vlan [<tagged|untagged|untagged-or-zero>$tag_type]",
       NO_STR
-      "match the rest of the command\n"
-      "match based on VLAN tagging\n"
-      "match all tagged frames\n"
-      "match all untagged frames\n"
-      "match untagged frames, or tagged frames with id zero\n")
+      "Match the rest of the command\n"
+      "Match based on VLAN tagging\n"
+      "Match all tagged frames\n"
+      "Match all untagged frames\n"
+      "Match untagged frames, or tagged frames with id zero\n")
 {
 	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
 
 	if (!pbrms)
 		return CMD_WARNING;
 
-	if (!no) {
-		if (strcmp(tag_type, "tagged") == 0) {
+    if (!no) {
+        if (strmatch(tag_type, "tagged")) {
 			pbr_set_match_clause_for_vlan(pbrms, 0,
 						      PBR_MAP_VLAN_TAGGED);
-		} else if (strcmp(tag_type, "untagged") == 0) {
+        } else if (strmatch(tag_type, "untagged")) {
 			pbr_set_match_clause_for_vlan(pbrms, 0,
 						      PBR_MAP_VLAN_UNTAGGED);
-		} else if (strcmp(tag_type, "untagged-or-zero") == 0) {
+        } else if (strmatch(tag_type, "untagged-or-zero")) {
 			pbr_set_match_clause_for_vlan(pbrms, 0,
 						      PBR_MAP_VLAN_UNTAGGED_0);
 		}
@@ -638,9 +635,9 @@ DEFPY(no_pbr_map_nexthop_group, no_pbr_map_nexthop_group_cmd,
 DEFPY(pbr_map_nexthop, pbr_map_nexthop_cmd,
       "set nexthop\
         <\
-		    <A.B.C.D|X:X::X:X>$addr [INTERFACE$intf]\
-			|INTERFACE$intf\
-		>\
+	  <A.B.C.D|X:X::X:X>$addr [INTERFACE$intf]\
+	  |INTERFACE$intf\
+	>\
         [nexthop-vrf NAME$vrf_name]",
       "Set for the PBR-MAP\n"
       "Specify one of the nexthops in this map\n"
@@ -765,9 +762,9 @@ done:
 DEFPY(no_pbr_map_nexthop, no_pbr_map_nexthop_cmd,
       "no set nexthop\
         [<\
-		    <A.B.C.D|X:X::X:X>$addr [INTERFACE$intf]\
-			|INTERFACE$intf\
-		>\
+	  <A.B.C.D|X:X::X:X>$addr [INTERFACE$intf]\
+	  |INTERFACE$intf\
+	>\
         [nexthop-vrf NAME$vrf_name]]",
       NO_STR
       "Set for the PBR-MAP\n"
@@ -960,12 +957,6 @@ static void vty_show_pbrms(struct vty *vty,
 			pbrms->installed ? "yes" : "no",
 			pbrms->reason ? rbuf : "Valid");
 
-    /* match clauses first */
-
-	if (pbrms->dsfield & PBR_DSFIELD_DSCP)
-		vty_out(vty, "        Match DSCP %u\n",
-			(pbrms->dsfield & PBR_DSFIELD_DSCP) >> 2);
-
 	if (pbrms->ip_proto) {
 		struct protoent *p;
 
@@ -981,6 +972,10 @@ static void vty_show_pbrms(struct vty *vty,
 		vty_out(vty, "        SRC Port Match: %u\n", pbrms->src_prt);
 	if (pbrms->dst_prt)
 		vty_out(vty, "        DST Port Match: %u\n", pbrms->dst_prt);
+
+	if (pbrms->dsfield & PBR_DSFIELD_DSCP)
+		vty_out(vty, "        Match DSCP %u\n",
+			(pbrms->dsfield & PBR_DSFIELD_DSCP) >> 2);
 	if (pbrms->dsfield & PBR_DSFIELD_ECN)
 		vty_out(vty, "        ECN Match: %u\n",
 			pbrms->dsfield & PBR_DSFIELD_ECN);
@@ -988,8 +983,8 @@ static void vty_show_pbrms(struct vty *vty,
 	    vty_out(vty, "        MARK Match: %u\n", pbrms->mark);
 	if (pbrms->match_pcp != 0)
 		vty_out(vty, "        PCP Match: %d\n", pbrms->match_pcp);
-
-	if (pbrms->match_vlan_id != 0)
+    
+    if (pbrms->match_vlan_id != 0)
 		vty_out(vty, "        Match VLAN ID: %u\n",
 			pbrms->match_vlan_id);
 	if (pbrms->match_vlan_flags == PBR_MAP_VLAN_TAGGED)
@@ -1402,7 +1397,7 @@ static int pbr_vty_map_config_write_sequence(struct vty *vty,
 
 	if ((pbrms->match_vlan_id)
 	    && (pbrms->match_vlan_flags == PBR_MAP_VLAN_NO_WILD))
-		vty_out(vty, " match vlan %u\n", pbrms->match_vlan_id);
+	    vty_out(vty, " match vlan %u\n", pbrms->match_vlan_id);
 	if (pbrms->match_vlan_flags == PBR_MAP_VLAN_TAGGED)
 		vty_out(vty, " match vlan tagged\n");
 	if (pbrms->match_vlan_flags == PBR_MAP_VLAN_UNTAGGED)
@@ -1513,7 +1508,7 @@ void pbr_vty_init(void)
 	install_element(PBRMAP_NODE, &pbr_map_match_pcp_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_match_mark_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_action_queue_id_cmd);
-	install_element(PBRMAP_NODE, &pbr_map_action_strip_vlan_cmd);
+    install_element(PBRMAP_NODE, &pbr_map_action_strip_vlan_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_action_vlan_id_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_action_pcp_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_nexthop_group_cmd);

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -81,14 +81,14 @@ DEFPY(pbr_map_match_vlan_tag, pbr_map_match_vlan_tag_cmd,
 	if (!pbrms)
 		return CMD_WARNING;
 
-    if (!no) {
-        if (strmatch(tag_type, "tagged")) {
+	if (!no) {
+		if (strmatch(tag_type, "tagged")) {
 			pbr_set_match_clause_for_vlan(pbrms, 0,
 						      PBR_MAP_VLAN_TAGGED);
-        } else if (strmatch(tag_type, "untagged")) {
+		} else if (strmatch(tag_type, "untagged")) {
 			pbr_set_match_clause_for_vlan(pbrms, 0,
 						      PBR_MAP_VLAN_UNTAGGED);
-        } else if (strmatch(tag_type, "untagged-or-zero")) {
+		} else if (strmatch(tag_type, "untagged-or-zero")) {
 			pbr_set_match_clause_for_vlan(pbrms, 0,
 						      PBR_MAP_VLAN_UNTAGGED_0);
 		}
@@ -980,11 +980,11 @@ static void vty_show_pbrms(struct vty *vty,
 		vty_out(vty, "        ECN Match: %u\n",
 			pbrms->dsfield & PBR_DSFIELD_ECN);
 	if (pbrms->mark)
-	    vty_out(vty, "        MARK Match: %u\n", pbrms->mark);
+		vty_out(vty, "        MARK Match: %u\n", pbrms->mark);
 	if (pbrms->match_pcp != 0)
 		vty_out(vty, "        PCP Match: %d\n", pbrms->match_pcp);
-    
-    if (pbrms->match_vlan_id != 0)
+
+	if (pbrms->match_vlan_id != 0)
 		vty_out(vty, "        Match VLAN ID: %u\n",
 			pbrms->match_vlan_id);
 	if (pbrms->match_vlan_flags == PBR_MAP_VLAN_TAGGED)
@@ -1392,12 +1392,12 @@ static int pbr_vty_map_config_write_sequence(struct vty *vty,
 
 	if (pbrms->mark)
 		vty_out(vty, " match mark %u\n", pbrms->mark);
-    if (pbrms->match_pcp)
+	if (pbrms->match_pcp)
 		vty_out(vty, " match pcp %d\n", pbrms->match_pcp);
 
-	if ((pbrms->match_vlan_id)
-	    && (pbrms->match_vlan_flags == PBR_MAP_VLAN_NO_WILD))
-	    vty_out(vty, " match vlan %u\n", pbrms->match_vlan_id);
+	if ((pbrms->match_vlan_id) &&
+	    (pbrms->match_vlan_flags == PBR_MAP_VLAN_NO_WILD))
+		vty_out(vty, " match vlan %u\n", pbrms->match_vlan_id);
 	if (pbrms->match_vlan_flags == PBR_MAP_VLAN_TAGGED)
 		vty_out(vty, " match vlan tagged\n");
 	if (pbrms->match_vlan_flags == PBR_MAP_VLAN_UNTAGGED)
@@ -1503,12 +1503,12 @@ void pbr_vty_init(void)
 	install_element(PBRMAP_NODE, &pbr_map_match_dst_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_match_dscp_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_match_ecn_cmd);
-    install_element(PBRMAP_NODE, &pbr_map_match_vlan_id_cmd);
+	install_element(PBRMAP_NODE, &pbr_map_match_vlan_id_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_match_vlan_tag_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_match_pcp_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_match_mark_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_action_queue_id_cmd);
-    install_element(PBRMAP_NODE, &pbr_map_action_strip_vlan_cmd);
+	install_element(PBRMAP_NODE, &pbr_map_action_strip_vlan_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_action_vlan_id_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_action_pcp_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_nexthop_group_cmd);

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -3,6 +3,9 @@
  * Zebra connect code.
  * Copyright (C) 2018 Cumulus Networks, Inc.
  *               Donald Sharp
+ * Portions:
+ *		Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+ *		    Approved for Public Release; Distribution Unlimited 21-1402
  */
 #include <zebra.h>
 
@@ -536,13 +539,22 @@ static bool pbr_encode_pbr_map_sequence(struct stream *s,
 	stream_putw(s, pbrms->dst_prt);
 	stream_putc(s, pbrms->dsfield);
 	stream_putl(s, pbrms->mark);
-
-	stream_putl(s, pbrms->action_queue_id);
+    /* PCP */
+	stream_putc(s, pbrms->match_pcp);
+	stream_putw(s, pbrms->action_pcp);
+	/* VLAN */
+	stream_putw(s, pbrms->match_vlan_id);
+	stream_putw(s, pbrms->match_vlan_flags);
 
 	stream_putw(s, pbrms->action_vlan_id);
 	stream_putw(s, pbrms->action_vlan_flags);
-	stream_putw(s, pbrms->action_pcp);
+    stream_putl(s, pbrms->action_queue_id);
 
+    /* if the user does not use the command "set vrf name |unchanged"
+	 * then pbr_encode_pbr_map_sequence_vrf will not be called
+	 */
+
+	/* these statement get a table id */
 	if (pbrms->vrf_unchanged || pbrms->vrf_lookup)
 		pbr_encode_pbr_map_sequence_vrf(s, pbrms, ifp);
 	else if (pbrms->nhgrp_name)
@@ -567,9 +579,6 @@ bool pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 	uint64_t is_installed = (uint64_t)1 << pmi->install_bit;
 
 	is_installed &= pbrms->installed;
-
-	DEBUGD(&pbr_dbg_zebra, "%s: for %s %d(%" PRIu64 ")", __func__,
-	       pbrm->name, install, is_installed);
 
 	/*
 	 * If we are installed and asked to do so again and the config

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -4,8 +4,7 @@
  * Copyright (C) 2018 Cumulus Networks, Inc.
  *               Donald Sharp
  * Portions:
- *		Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
- *		    Approved for Public Release; Distribution Unlimited 21-1402
+ *		Copyright (c) 2021 The MITRE Corporation.
  */
 #include <zebra.h>
 

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -538,7 +538,7 @@ static bool pbr_encode_pbr_map_sequence(struct stream *s,
 	stream_putw(s, pbrms->dst_prt);
 	stream_putc(s, pbrms->dsfield);
 	stream_putl(s, pbrms->mark);
-    /* PCP */
+	/* PCP */
 	stream_putc(s, pbrms->match_pcp);
 	stream_putw(s, pbrms->action_pcp);
 	/* VLAN */
@@ -547,9 +547,9 @@ static bool pbr_encode_pbr_map_sequence(struct stream *s,
 
 	stream_putw(s, pbrms->action_vlan_id);
 	stream_putw(s, pbrms->action_vlan_flags);
-    stream_putl(s, pbrms->action_queue_id);
+	stream_putl(s, pbrms->action_queue_id);
 
-    /* if the user does not use the command "set vrf name |unchanged"
+	/* if the user does not use the command "set vrf name |unchanged"
 	 * then pbr_encode_pbr_map_sequence_vrf will not be called
 	 */
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -5,6 +5,8 @@
  *   Copyright (C) 1997-1999  Kunihiro Ishiguro
  *   Copyright (C) 2015-2018  Cumulus Networks, Inc.
  *   et al.
+ *   Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+ *	    Approved for Public Release; Distribution Unlimited 21-1402
  */
 
 #include <zebra.h>
@@ -3212,10 +3214,13 @@ static inline void zread_rule(ZAPI_HANDLER_ARGS)
 		STREAM_GETC(s, zpr.rule.filter.dsfield);
 		STREAM_GETL(s, zpr.rule.filter.fwmark);
 
-		STREAM_GETL(s, zpr.rule.action.queue_id);
+	    STREAM_GETC(s, zpr.rule.filter.pcp);
+		STREAM_GETW(s, zpr.rule.action.pcp);
+		STREAM_GETW(s, zpr.rule.filter.vlan_id);
+		STREAM_GETW(s, zpr.rule.filter.vlan_flags);
 		STREAM_GETW(s, zpr.rule.action.vlan_id);
 		STREAM_GETW(s, zpr.rule.action.vlan_flags);
-		STREAM_GETW(s, zpr.rule.action.pcp);
+	    STREAM_GETL(s, zpr.rule.action.queue_id);
 
 		STREAM_GETL(s, zpr.rule.action.table);
 		STREAM_GET(ifname, s, INTERFACE_NAMSIZ);
@@ -3243,6 +3248,15 @@ static inline void zread_rule(ZAPI_HANDLER_ARGS)
 
 		if (zpr.rule.filter.fwmark)
 			zpr.rule.filter.filter_bm |= PBR_FILTER_FWMARK;
+
+		if (zpr.rule.filter.pcp)
+			zpr.rule.filter.filter_bm |= PBR_FILTER_PCP;
+
+		if (zpr.rule.filter.vlan_flags)
+			zpr.rule.filter.filter_bm |= PBR_FILTER_VLAN_FLAGS;
+
+		if (zpr.rule.filter.vlan_id)
+			zpr.rule.filter.filter_bm |= PBR_FILTER_VLAN_ID;
 
 		if (!(zpr.rule.filter.src_ip.family == AF_INET
 		      || zpr.rule.filter.src_ip.family == AF_INET6)) {
@@ -3514,7 +3528,7 @@ static inline void zread_ipset_entry(ZAPI_HANDLER_ARGS)
 		if (zpi.src_port_max != 0)
 			zpi.filter_bm |= PBR_FILTER_SRC_PORT_RANGE;
 		if (zpi.proto != 0)
-			zpi.filter_bm |= PBR_FILTER_PROTO;
+			zpi.filter_bm |= PBR_FILTER_IP_PROTOCOL;
 
 		if (!(zpi.dst.family == AF_INET
 		      || zpi.dst.family == AF_INET6)) {

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -5,8 +5,7 @@
  *   Copyright (C) 1997-1999  Kunihiro Ishiguro
  *   Copyright (C) 2015-2018  Cumulus Networks, Inc.
  *   et al.
- *   Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
- *	    Approved for Public Release; Distribution Unlimited 21-1402
+ *   Copyright (c) 2021 The MITRE Corporation.
  */
 
 #include <zebra.h>

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -3213,13 +3213,13 @@ static inline void zread_rule(ZAPI_HANDLER_ARGS)
 		STREAM_GETC(s, zpr.rule.filter.dsfield);
 		STREAM_GETL(s, zpr.rule.filter.fwmark);
 
-	    STREAM_GETC(s, zpr.rule.filter.pcp);
+		STREAM_GETC(s, zpr.rule.filter.pcp);
 		STREAM_GETW(s, zpr.rule.action.pcp);
 		STREAM_GETW(s, zpr.rule.filter.vlan_id);
 		STREAM_GETW(s, zpr.rule.filter.vlan_flags);
 		STREAM_GETW(s, zpr.rule.action.vlan_id);
 		STREAM_GETW(s, zpr.rule.action.vlan_flags);
-	    STREAM_GETL(s, zpr.rule.action.queue_id);
+		STREAM_GETL(s, zpr.rule.action.queue_id);
 
 		STREAM_GETL(s, zpr.rule.action.table);
 		STREAM_GET(ifname, s, INTERFACE_NAMSIZ);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3,8 +3,7 @@
  * Zebra dataplane layer.
  * Copyright (c) 2018 Volta Networks, Inc.
  * Portions:
- *		Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
- *		Approved for Public Release; Distribution Unlimited 21-1402
+ *		Copyright (c) 2021 The MITRE Corporation.
  */
 
 #ifdef HAVE_CONFIG_H
@@ -249,7 +248,7 @@ struct dplane_neigh_table {
  */
 struct dplane_ctx_rule {
     uint32_t seq;
-	uint32_t priority;
+    uint32_t priority;
 	uint32_t unique;
 
 	/* The route table pointed by this rule */
@@ -272,7 +271,7 @@ struct dplane_ctx_rule {
 	uint32_t action_queue_id;
 
     uint8_t filter_pcp;
-	uint16_t filter_vlan_id;
+    uint16_t filter_vlan_id;
 	uint16_t filter_vlan_flags;
 
 	char ifname[INTERFACE_NAMSIZ + 1];
@@ -3433,7 +3432,7 @@ static void dplane_ctx_rule_init_single(struct dplane_ctx_rule *dplane_rule,
 	dplane_rule->src_port = rule->rule.filter.src_port;
 	dplane_rule->dst_port = rule->rule.filter.dst_port;
     dplane_rule->filter_pcp = rule->rule.filter.pcp;
-	dplane_rule->filter_vlan_id = rule->rule.filter.vlan_id;
+    dplane_rule->filter_vlan_id = rule->rule.filter.vlan_id;
 	dplane_rule->filter_vlan_flags = rule->rule.filter.vlan_flags;
 	prefix_copy(&(dplane_rule->dst_ip), &rule->rule.filter.dst_ip);
 	prefix_copy(&(dplane_rule->src_ip), &rule->rule.filter.src_ip);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2,6 +2,9 @@
 /*
  * Zebra dataplane layer.
  * Copyright (c) 2018 Volta Networks, Inc.
+ * Portions:
+ *		Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+ *		Approved for Public Release; Distribution Unlimited 21-1402
  */
 
 #ifdef HAVE_CONFIG_H
@@ -245,7 +248,9 @@ struct dplane_neigh_table {
  * Policy based routing rule info for the dataplane
  */
 struct dplane_ctx_rule {
+    uint32_t seq;
 	uint32_t priority;
+	uint32_t unique;
 
 	/* The route table pointed by this rule */
 	uint32_t table;
@@ -265,6 +270,10 @@ struct dplane_ctx_rule {
 	uint16_t action_vlan_flags;
 
 	uint32_t action_queue_id;
+
+    uint8_t filter_pcp;
+	uint16_t filter_vlan_id;
+	uint16_t filter_vlan_flags;
 
 	char ifname[INTERFACE_NAMSIZ + 1];
 	struct ethaddr smac;
@@ -3423,6 +3432,9 @@ static void dplane_ctx_rule_init_single(struct dplane_ctx_rule *dplane_rule,
 	dplane_rule->ip_proto = rule->rule.filter.ip_proto;
 	dplane_rule->src_port = rule->rule.filter.src_port;
 	dplane_rule->dst_port = rule->rule.filter.dst_port;
+    dplane_rule->filter_pcp = rule->rule.filter.pcp;
+	dplane_rule->filter_vlan_id = rule->rule.filter.vlan_id;
+	dplane_rule->filter_vlan_flags = rule->rule.filter.vlan_flags;
 	prefix_copy(&(dplane_rule->dst_ip), &rule->rule.filter.dst_ip);
 	prefix_copy(&(dplane_rule->src_ip), &rule->rule.filter.src_ip);
 

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -247,8 +247,8 @@ struct dplane_neigh_table {
  * Policy based routing rule info for the dataplane
  */
 struct dplane_ctx_rule {
-    uint32_t seq;
-    uint32_t priority;
+	uint32_t seq;
+	uint32_t priority;
 	uint32_t unique;
 
 	/* The route table pointed by this rule */
@@ -270,8 +270,8 @@ struct dplane_ctx_rule {
 
 	uint32_t action_queue_id;
 
-    uint8_t filter_pcp;
-    uint16_t filter_vlan_id;
+	uint8_t filter_pcp;
+	uint16_t filter_vlan_id;
 	uint16_t filter_vlan_flags;
 
 	char ifname[INTERFACE_NAMSIZ + 1];
@@ -3431,8 +3431,8 @@ static void dplane_ctx_rule_init_single(struct dplane_ctx_rule *dplane_rule,
 	dplane_rule->ip_proto = rule->rule.filter.ip_proto;
 	dplane_rule->src_port = rule->rule.filter.src_port;
 	dplane_rule->dst_port = rule->rule.filter.dst_port;
-    dplane_rule->filter_pcp = rule->rule.filter.pcp;
-    dplane_rule->filter_vlan_id = rule->rule.filter.vlan_id;
+	dplane_rule->filter_pcp = rule->rule.filter.pcp;
+	dplane_rule->filter_vlan_id = rule->rule.filter.vlan_id;
 	dplane_rule->filter_vlan_flags = rule->rule.filter.vlan_flags;
 	prefix_copy(&(dplane_rule->dst_ip), &rule->rule.filter.dst_ip);
 	prefix_copy(&(dplane_rule->src_ip), &rule->rule.filter.src_ip);

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -160,22 +160,21 @@ uint32_t zebra_pbr_rules_hash_key(const void *arg)
 
 	rule = arg;
 	key = jhash_3words(rule->rule.seq, rule->rule.priority,
-	            rule->rule.action.table,
-	            prefix_hash_key(&rule->rule.filter.src_ip));
+			   rule->rule.action.table,
+			   prefix_hash_key(&rule->rule.filter.src_ip));
 
 	key = jhash_3words(rule->rule.filter.fwmark, rule->vrf_id,
-	            rule->rule.filter.ip_proto, key);
+			   rule->rule.filter.ip_proto, key);
 
 	key = jhash(rule->ifname, strlen(rule->ifname), key);
 
-    key = jhash_3words(rule->rule.filter.pcp,
-                rule->rule.filter.vlan_id,
-                rule->rule.filter.vlan_flags, key);
+	key = jhash_3words(rule->rule.filter.pcp, rule->rule.filter.vlan_id,
+			   rule->rule.filter.vlan_flags, key);
 
 	return jhash_3words(rule->rule.filter.src_port,
 			    rule->rule.filter.dst_port,
 			    prefix_hash_key(&rule->rule.filter.dst_ip),
-                jhash_1word(rule->rule.unique, key));
+			    jhash_1word(rule->rule.unique, key));
 }
 
 bool zebra_pbr_rules_hash_equal(const void *arg1, const void *arg2)

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -2,8 +2,7 @@
 /* Zebra Policy Based Routing (PBR) main handling.
  * Copyright (C) 2018  Cumulus Networks, Inc.
  * Portions:
- *		Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
- *		    Approved for Public Release; Distribution Unlimited 21-1402
+ *		Copyright (c) 2021 The MITRE Corporation.
  */
 
 #include <zebra.h>
@@ -161,22 +160,22 @@ uint32_t zebra_pbr_rules_hash_key(const void *arg)
 
 	rule = arg;
 	key = jhash_3words(rule->rule.seq, rule->rule.priority,
-			   rule->rule.action.table,
-			   prefix_hash_key(&rule->rule.filter.src_ip));
+	            rule->rule.action.table,
+	            prefix_hash_key(&rule->rule.filter.src_ip));
 
 	key = jhash_3words(rule->rule.filter.fwmark, rule->vrf_id,
-			   rule->rule.filter.ip_proto, key);
+	            rule->rule.filter.ip_proto, key);
 
 	key = jhash(rule->ifname, strlen(rule->ifname), key);
 
-    key = jhash_3words(rule->rule.filter.pcp, 
-               rule->rule.filter.vlan_id,
-               rule->rule.filter.vlan_flags, key);
+    key = jhash_3words(rule->rule.filter.pcp,
+                rule->rule.filter.vlan_id,
+                rule->rule.filter.vlan_flags, key);
 
 	return jhash_3words(rule->rule.filter.src_port,
 			    rule->rule.filter.dst_port,
 			    prefix_hash_key(&rule->rule.filter.dst_ip),
-			    jhash_1word(rule->rule.unique, key));
+                jhash_1word(rule->rule.unique, key));
 }
 
 bool zebra_pbr_rules_hash_equal(const void *arg1, const void *arg2)

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 /* Zebra Policy Based Routing (PBR) main handling.
  * Copyright (C) 2018  Cumulus Networks, Inc.
+ * Portions:
+ *		Copyright (c) 2021 The MITRE Corporation. All Rights Reserved.
+ *		    Approved for Public Release; Distribution Unlimited 21-1402
  */
 
 #include <zebra.h>
@@ -165,6 +168,10 @@ uint32_t zebra_pbr_rules_hash_key(const void *arg)
 			   rule->rule.filter.ip_proto, key);
 
 	key = jhash(rule->ifname, strlen(rule->ifname), key);
+
+    key = jhash_3words(rule->rule.filter.pcp, 
+               rule->rule.filter.vlan_id,
+               rule->rule.filter.vlan_flags, key);
 
 	return jhash_3words(rule->rule.filter.src_port,
 			    rule->rule.filter.dst_port,
@@ -1118,7 +1125,7 @@ static void zebra_pbr_display_port(struct vty *vty, uint32_t filter_bm,
 			    uint16_t port_min, uint16_t port_max,
 			    uint8_t proto)
 {
-	if (!(filter_bm & PBR_FILTER_PROTO)) {
+	if (!(filter_bm & PBR_FILTER_IP_PROTOCOL)) {
 		if (port_max)
 			vty_out(vty, ":udp/tcp:%d-%d",
 				port_min, port_max);


### PR DESCRIPTION
This adds VTY and initial Zebra support for VLAN filters. Since the kernel PBR facilities do not provide any way of matching on VLAN fields, another provider may be required (i.e. netfilter). This rebases the previous pull request by Eli Baum [PR 9705](https://github.com/FRRouting/frr/pull/9705), now closed, on master since the previous fork can no longer be updated in situ.

Signed-off-by: Josh Werner [joshuawerner@mitre.org](mailto:joshuawerner@mitre.org)