### PR TITLE
Explain first occurrence of DR/BDR

### DIFF
--- a/doc/user/ospf_fundamentals.rst
+++ b/doc/user/ospf_fundamentals.rst
@@ -86,7 +86,7 @@ OSPF also uses the Hello protocol to propagate certain state between routers
 sharing a link, for example:
 
 - Hello protocol configured state, such as the dead-interval.
-- Router priority, for DR/BDR election.
+- Router priority, for :abbr:`DR (Designated Router)`/:abbr:`BDR (Backup Designated Router)` election.
 - DR/BDR election results.
 - Any optional capabilities supported by each router.
 


### PR DESCRIPTION
In https://docs.frrouting.org/en/latest/ospfd.html the abbreviations DR or BDR are not explained at all. I see that in `master` an 
explanation has been added, but it should still be the first occurrence of an abbreviation that is explained.

Hopefully the format of `:abbr:` is correct, I copied it over from further down.