### PR TITLE
ospfd: Fix  ospf_ti_lfa memory leak

### DIFF
--- a/ospfd/ospf_ti_lfa.c
+++ b/ospfd/ospf_ti_lfa.c
@@ -1078,6 +1078,7 @@ void ospf_ti_lfa_free_p_spaces(struct ospf_area *area)
 
 		q_spaces_fini(p_space->q_spaces);
 		XFREE(MTYPE_OSPF_Q_SPACE, p_space->q_spaces);
+		XFREE(MTYPE_OSPF_P_SPACE, p_space);
 	}
 
 	p_spaces_fini(area->p_spaces);


### PR DESCRIPTION
This PR resolves a memory leak detected by ASan by freeing the P spaces.

```
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739:Direct leak of 320 byte(s) in 4 object(s) allocated from:
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #0 0x7f78e0d25037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #1 0x7f78e08cb1ee in qcalloc lib/memory.c:105
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #2 0x5586ead59567 in ospf_ti_lfa_generate_p_space ospfd/ospf_ti_lfa.c:778
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #3 0x5586ead5a1e9 in ospf_ti_lfa_generate_p_spaces ospfd/ospf_ti_lfa.c:918
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #4 0x5586ead5b857 in ospf_ti_lfa_compute ospfd/ospf_ti_lfa.c:1095
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #5 0x5586ead52346 in ospf_spf_calculate_area ospfd/ospf_spf.c:1811
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #6 0x5586ead52667 in ospf_spf_calculate_areas ospfd/ospf_spf.c:1840
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #7 0x5586ead5288b in ospf_spf_calculate_schedule_worker ospfd/ospf_spf.c:1871
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #8 0x7f78e09a5bf7 in event_call lib/event.c:1995
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #9 0x7f78e088e99d in frr_run lib/libfrr.c:1185
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #10 0x5586eacbcfb8 in main ospfd/ospf_main.c:220
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #11 0x7f78e047dd09 in __libc_start_main ../csu/libc-start.c:308
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739:Direct leak of 160 byte(s) in 2 object(s) allocated from:
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #0 0x7f78e0d25037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #1 0x7f78e08cb1ee in qcalloc lib/memory.c:105
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #2 0x5586ead59567 in ospf_ti_lfa_generate_p_space ospfd/ospf_ti_lfa.c:778
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #3 0x5586ead59dc6 in ospf_ti_lfa_generate_p_spaces ospfd/ospf_ti_lfa.c:869
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #4 0x5586ead5b857 in ospf_ti_lfa_compute ospfd/ospf_ti_lfa.c:1095
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #5 0x5586ead52346 in ospf_spf_calculate_area ospfd/ospf_spf.c:1811
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #6 0x5586ead52667 in ospf_spf_calculate_areas ospfd/ospf_spf.c:1840
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #7 0x5586ead5288b in ospf_spf_calculate_schedule_worker ospfd/ospf_spf.c:1871
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #8 0x7f78e09a5bf7 in event_call lib/event.c:1995
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #9 0x7f78e088e99d in frr_run lib/libfrr.c:1185
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #10 0x5586eacbcfb8 in main ospfd/ospf_main.c:220
./ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.ospfd.asan.1698739-    #11 0x7f78e047dd09 in __libc_start_main ../csu/libc-start.c:308

```