### PR TITLE
tools: config clang-format to allow aligned macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,6 +11,7 @@ AllowShortFunctionsOnASingleLine: false
 IndentCaseLabels: false
 AlignEscapedNewlinesLeft: false
 AlignTrailingComments: true
+AlignConsecutiveMacros: AcrossComments
 AllowAllParametersOfDeclarationOnNextLine: false
 AlignAfterOpenBracket: true
 SpaceAfterCStyleCast: false


### PR DESCRIPTION
Add an AlignConsecutiveMacros config for clang-format. Instead of un-aligning a list of macros, like flags bits:

```
-#define ZEBRA_NHT_CONNECTED           0x1
-#define ZEBRA_NHT_DELETED             0x2
+#define ZEBRA_NHT_CONNECTED 0x1
+#define ZEBRA_NHT_DELETED 0x2
 #define ZEBRA_NHT_RESOLVE_VIA_DEFAULT 0x4
```

this will allow a little more readable format:
 
```
-#define ZEBRA_NHT_CONNECTED           0x1
-#define ZEBRA_NHT_DELETED             0x2
+#define ZEBRA_NHT_CONNECTED          0x1
+#define ZEBRA_NHT_DELETED            0x2
 #define ZEBRA_NHT_RESOLVE_VIA_DEFAULT 0x4
 ```

It's still not really great, but it won't make false-reports that we ignore any more frequent, and it will make the output for folks who blindly apply the clang-format diff better for the rest of us.
