### PR TITLE
tests: improve bgp test determinism

### DIFF
--- a/tests/topotests/bgp_features/test_bgp_features.py
+++ b/tests/topotests/bgp_features/test_bgp_features.py
@@ -176,6 +176,19 @@ def test_bgp_convergence():
     # tgen.mininet_cli()
 
 
+def get_shut_msg_count(tgen):
+    shuts = {}
+    for rtrNum in [2, 4]:
+        shutmsg = tgen.net["r{}".format(rtrNum)].cmd_nostatus(
+            'grep -c "NOTIFICATION.*Cease/Administrative Shutdown" bgpd.log', warn=False
+        )
+        try:
+            shuts[rtrNum] = int(shutmsg.strip())
+        except ValueError:
+            shuts[rtrNum] = 0
+    return shuts
+
+
 def test_bgp_shutdown():
     "Test BGP instance shutdown"
 
@@ -184,6 +197,8 @@ def test_bgp_shutdown():
     # Skip if previous fatal error condition is raised
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
+
+    shuts_before = get_shut_msg_count(tgen)
 
     tgen.net["r1"].cmd(
         'vtysh -c "conf t" -c "router bgp 65000" -c "bgp shutdown message ABCDabcd"'
@@ -208,6 +223,11 @@ def test_bgp_shutdown():
         )
         assert res is None, assertmsg
 
+    shuts_after = get_shut_msg_count(tgen)
+
+    for k in shuts_before:
+        assert shuts_before[k] + 1 == shuts_after[k]
+
 
 def test_bgp_shutdown_message():
     "Test BGP Peer Shutdown Message"
@@ -222,17 +242,10 @@ def test_bgp_shutdown_message():
         logger.info("Checking BGP shutdown received on router r{}".format(rtrNum))
 
         shut_message = tgen.net["r{}".format(rtrNum)].cmd(
-            'tail bgpd.log | grep "NOTIFICATION.*Cease/Administrative Shutdown"'
+            'grep -e "NOTIFICATION.*Cease/Administrative Shutdown.*ABCDabcd" bgpd.log'
         )
         assertmsg = "BGP shutdown message not received on router R{}".format(rtrNum)
         assert shut_message != "", assertmsg
-
-        assertmsg = "Incorrect BGP shutdown message received on router R{}".format(
-            rtrNum
-        )
-        assert "ABCDabcd" in shut_message, assertmsg
-
-    # tgen.mininet_cli()
 
 
 def test_bgp_no_shutdown():


### PR DESCRIPTION
don't grep the tail of a log file after running a previous test, there could be (and have been) other items added to the log in between.

add before and after count of shutdown messages to very the actual message shows up as the test intended, and keep the search for the shutdown message.