### PR TITLE
bgpd: Show the real table version for a decent peer subgroup

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -11620,8 +11620,11 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 					&peer->ibuf->count,
 					memory_order_relaxed);
 
-				json_object_int_add(json_peer, "tableVersion",
-						    peer->version[afi][safi]);
+				json_object_int_add(
+					json_peer, "tableVersion",
+					(paf && PAF_SUBGRP(paf))
+						? paf->subgroup->version
+						: 0);
 				json_object_int_add(json_peer, "outq",
 						    outq_count);
 				json_object_int_add(json_peer, "inq",
@@ -11799,8 +11802,10 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 					" %9u %9u %8" PRIu64 " %4zu %4zu %8s",
 					PEER_TOTAL_RX(peer),
 					PEER_TOTAL_TX(peer),
-					peer->version[afi][safi], inq_count,
-					outq_count,
+					(paf && PAF_SUBGRP(paf))
+						? paf->subgroup->version
+						: 0,
+					inq_count, outq_count,
 					peer_uptime(peer->uptime, timebuf,
 						    BGP_UPTIME_LEN, 0, NULL));
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1119,7 +1119,6 @@ struct peer {
 
 	/* BGP peer group.  */
 	struct peer_group *group;
-	uint64_t version[AFI_MAX][SAFI_MAX];
 
 	/* BGP peer_af structures, per configured AF on this peer */
 	struct peer_af *peer_af_array[BGP_AF_MAX];

--- a/tests/topotests/evpn_pim_1/spine/bgp.summ.json
+++ b/tests/topotests/evpn_pim_1/spine/bgp.summ.json
@@ -8,7 +8,6 @@
     "192.168.1.2":{
       "remoteAs":65002,
       "version":4,
-      "tableVersion":0,
       "outq":0,
       "inq":0,
       "pfxRcd":3,
@@ -21,7 +20,6 @@
     "192.168.2.3":{
       "remoteAs":65003,
       "version":4,
-      "tableVersion":0,
       "outq":0,
       "inq":0,
       "pfxRcd":3,


### PR DESCRIPTION
Closes https://github.com/FRRouting/frr/issues/13525