### PR TITLE
Revert "tools: config clang-format to allow aligned macros"

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,6 @@ AllowShortFunctionsOnASingleLine: false
 IndentCaseLabels: false
 AlignEscapedNewlinesLeft: false
 AlignTrailingComments: true
-AlignConsecutiveMacros: AcrossComments
 AllowAllParametersOfDeclarationOnNextLine: false
 AlignAfterOpenBracket: true
 SpaceAfterCStyleCast: false


### PR DESCRIPTION
This reverts commit 25314d5d878bbcc5ff63ebe76db9b2143b3e04ab.

This causes errors on clang-formatter for versions <= 10.

```
% git clang-format bgpd
YAML:14:25: error: invalid boolean
AlignConsecutiveMacros: AcrossComments
                        ^~~~~~~~~~~~~~
error: `clang-format -lines=11624:11624 -lines=11802:11802 bgpd/bgp_vty.c` failed
```