### PR TITLE
bgpd: Fix memory leak

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -344,6 +344,7 @@ static void bgp_vrf_init(void)
 
 static void bgp_vrf_terminate(void)
 {
+	free_bgp_srv6_resources();
 	vrf_terminate();
 }
 

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -3866,3 +3866,19 @@ void bgp_vpn_leak_export(struct bgp *from_bgp)
 		}
 	}
 }
+
+void free_bgp_srv6_resources(void)
+{
+	struct listnode *next;
+	struct bgp *bgp;
+	struct bgp *bgp_default = bgp_get_default();
+
+	assert(bgp_default);
+
+	for (ALL_LIST_ELEMENTS_RO(bm->bgp, next, bgp)) {
+		if (bgp->inst_type != BGP_INSTANCE_TYPE_VRF)
+			continue;
+
+		delete_vrf_tovpn_sid(bgp_default, bgp, AFI_IP6);
+	}
+}

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -325,4 +325,6 @@ extern void vpn_handle_router_id_update(struct bgp *bgp, bool withdraw,
 extern void bgp_vpn_leak_unimport(struct bgp *from_bgp);
 extern void bgp_vpn_leak_export(struct bgp *from_bgp);
 
+extern void free_bgp_srv6_resources(void);
+
 #endif /* _QUAGGA_BGP_MPLSVPN_H */


### PR DESCRIPTION
Free VRF to VPN SID resources on BGP VRF shutdown

This PR resolves the following memory leaks detected by ASan:

```
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144:Direct leak of 592 byte(s) in 2 object(s) allocated from:
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #0 0x7f49ab936037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #1 0x7f49ab4dc1ee in qcalloc lib/memory.c:105
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #2 0x7f49ab4ef696 in srv6_locator_chunk_alloc lib/srv6.c:135
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #3 0x55673b2dc11b in ensure_vrf_tovpn_sid_per_af bgpd/bgp_mplsvpn.c:752
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #4 0x55673b2dcaad in ensure_vrf_tovpn_sid bgpd/bgp_mplsvpn.c:846
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #5 0x55673b2d7180 in vpn_leak_postchange bgpd/bgp_mplsvpn.h:259
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #6 0x55673b2ea87e in vpn_leak_postchange_all bgpd/bgp_mplsvpn.c:3397
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #7 0x55673b488e57 in bgp_zebra_process_srv6_locator_chunk bgpd/bgp_zebra.c:3259
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #8 0x7f49ab609c22 in zclient_read lib/zclient.c:4134
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #9 0x7f49ab5b6bf7 in event_call lib/event.c:1995
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #10 0x7f49ab49f99d in frr_run lib/libfrr.c:1185
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #11 0x55673b1ce59d in main bgpd/bgp_main.c:505
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #12 0x7f49aae86d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144:Direct leak of 32 byte(s) in 2 object(s) allocated from:
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #0 0x7f49ab936037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #1 0x7f49ab4dc1ee in qcalloc lib/memory.c:105
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #2 0x55673b2d9bdb in vpn_leak_zebra_vrf_sid_update_per_af bgpd/bgp_mplsvpn.c:386
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #3 0x55673b2da50b in vpn_leak_zebra_vrf_sid_update bgpd/bgp_mplsvpn.c:448
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #4 0x55673b2d73d3 in vpn_leak_postchange bgpd/bgp_mplsvpn.h:271
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #5 0x55673b2ea87e in vpn_leak_postchange_all bgpd/bgp_mplsvpn.c:3397
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #6 0x55673b488e57 in bgp_zebra_process_srv6_locator_chunk bgpd/bgp_zebra.c:3259
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #7 0x7f49ab609c22 in zclient_read lib/zclient.c:4134
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #8 0x7f49ab5b6bf7 in event_call lib/event.c:1995
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #9 0x7f49ab49f99d in frr_run lib/libfrr.c:1185
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #10 0x55673b1ce59d in main bgpd/bgp_main.c:505
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #11 0x7f49aae86d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144:Direct leak of 32 byte(s) in 2 object(s) allocated from:
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #0 0x7f49ab936037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #1 0x7f49ab4dc1ee in qcalloc lib/memory.c:105
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #2 0x55673b2dc153 in ensure_vrf_tovpn_sid_per_af bgpd/bgp_mplsvpn.c:753
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #3 0x55673b2dcaad in ensure_vrf_tovpn_sid bgpd/bgp_mplsvpn.c:846
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #4 0x55673b2d7180 in vpn_leak_postchange bgpd/bgp_mplsvpn.h:259
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #5 0x55673b2ea87e in vpn_leak_postchange_all bgpd/bgp_mplsvpn.c:3397
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #6 0x55673b488e57 in bgp_zebra_process_srv6_locator_chunk bgpd/bgp_zebra.c:3259
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #7 0x7f49ab609c22 in zclient_read lib/zclient.c:4134
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #8 0x7f49ab5b6bf7 in event_call lib/event.c:1995
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #9 0x7f49ab49f99d in frr_run lib/libfrr.c:1185
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #10 0x55673b1ce59d in main bgpd/bgp_main.c:505
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-    #11 0x7f49aae86d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-
./bgp_srv6l3vpn_to_bgp_vrf.test_bgp_srv6l3vpn_to_bgp_vrf/r2.bgpd.asan.1083144-SUMMARY: AddressSanitizer: 656 byte(s) leaked in 6 allocation(s).

```

```
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770:Direct leak of 296 byte(s) in 1 object(s) allocated from:
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #0 0x7f1d6a6d7037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #1 0x7f1d6a27d1ee in qcalloc lib/memory.c:105
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #2 0x7f1d6a290696 in srv6_locator_chunk_alloc lib/srv6.c:135
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #3 0x55bcb2a7511b in ensure_vrf_tovpn_sid_per_af bgpd/bgp_mplsvpn.c:752
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #4 0x55bcb2a75aad in ensure_vrf_tovpn_sid bgpd/bgp_mplsvpn.c:846
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #5 0x55bcb2a70180 in vpn_leak_postchange bgpd/bgp_mplsvpn.h:259
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #6 0x55bcb2a83861 in vpn_leak_postchange_all bgpd/bgp_mplsvpn.c:3391
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #7 0x55bcb2c21e57 in bgp_zebra_process_srv6_locator_chunk bgpd/bgp_zebra.c:3259
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #8 0x7f1d6a3aac22 in zclient_read lib/zclient.c:4134
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #9 0x7f1d6a357bf7 in event_call lib/event.c:1995
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #10 0x7f1d6a24099d in frr_run lib/libfrr.c:1185
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #11 0x55bcb296759d in main bgpd/bgp_main.c:505
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #12 0x7f1d69c27d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770:Direct leak of 16 byte(s) in 1 object(s) allocated from:
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #0 0x7f1d6a6d7037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #1 0x7f1d6a27d1ee in qcalloc lib/memory.c:105
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #2 0x55bcb2a72bdb in vpn_leak_zebra_vrf_sid_update_per_af bgpd/bgp_mplsvpn.c:386
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #3 0x55bcb2a7350b in vpn_leak_zebra_vrf_sid_update bgpd/bgp_mplsvpn.c:448
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #4 0x55bcb2a703d3 in vpn_leak_postchange bgpd/bgp_mplsvpn.h:271
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #5 0x55bcb2a83861 in vpn_leak_postchange_all bgpd/bgp_mplsvpn.c:3391
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #6 0x55bcb2c21e57 in bgp_zebra_process_srv6_locator_chunk bgpd/bgp_zebra.c:3259
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #7 0x7f1d6a3aac22 in zclient_read lib/zclient.c:4134
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #8 0x7f1d6a357bf7 in event_call lib/event.c:1995
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #9 0x7f1d6a24099d in frr_run lib/libfrr.c:1185
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #10 0x55bcb296759d in main bgpd/bgp_main.c:505
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #11 0x7f1d69c27d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770:Direct leak of 16 byte(s) in 1 object(s) allocated from:
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #0 0x7f1d6a6d7037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #1 0x7f1d6a27d1ee in qcalloc lib/memory.c:105
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #2 0x55bcb2a75153 in ensure_vrf_tovpn_sid_per_af bgpd/bgp_mplsvpn.c:753
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #3 0x55bcb2a75aad in ensure_vrf_tovpn_sid bgpd/bgp_mplsvpn.c:846
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #4 0x55bcb2a70180 in vpn_leak_postchange bgpd/bgp_mplsvpn.h:259
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #5 0x55bcb2a83861 in vpn_leak_postchange_all bgpd/bgp_mplsvpn.c:3391
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #6 0x55bcb2c21e57 in bgp_zebra_process_srv6_locator_chunk bgpd/bgp_zebra.c:3259
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #7 0x7f1d6a3aac22 in zclient_read lib/zclient.c:4134
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #8 0x7f1d6a357bf7 in event_call lib/event.c:1995
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #9 0x7f1d6a24099d in frr_run lib/libfrr.c:1185
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #10 0x55bcb296759d in main bgpd/bgp_main.c:505
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-    #11 0x7f1d69c27d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-
./bgp_srv6l3vpn_route_leak.test_bgp_srv6l3vpn_route_leak/pe1.bgpd.asan.1066770-SUMMARY: AddressSanitizer: 328 byte(s) leaked in 3 allocation(s).
```