### PR TITLE
tests: fix implicit config file and recently added logic error

### DIFF
--- a/tests/topotests/bgp_auth/test_bgp_auth1.py
+++ b/tests/topotests/bgp_auth/test_bgp_auth1.py
@@ -158,8 +158,8 @@ def setup_module(mod):
     # For all registered routers, load the zebra configuration file
     for rname, router in router_list.items():
         router.load_config(TopoRouter.RD_ZEBRA, "zebra.conf")
-        router.load_config(TopoRouter.RD_OSPF)
-        router.load_config(TopoRouter.RD_BGP)
+        router.load_config(TopoRouter.RD_OSPF, "")
+        router.load_config(TopoRouter.RD_BGP, "")
 
     # After copying the configurations, this function loads configured daemons.
     tgen.start_router()

--- a/tests/topotests/bgp_auth/test_bgp_auth2.py
+++ b/tests/topotests/bgp_auth/test_bgp_auth2.py
@@ -158,8 +158,8 @@ def setup_module(mod):
     # For all registered routers, load the zebra configuration file
     for rname, router in router_list.items():
         router.load_config(TopoRouter.RD_ZEBRA, "zebra.conf")
-        router.load_config(TopoRouter.RD_OSPF)
-        router.load_config(TopoRouter.RD_BGP)
+        router.load_config(TopoRouter.RD_OSPF, "")
+        router.load_config(TopoRouter.RD_BGP, "")
 
     # After copying the configurations, this function loads configured daemons.
     tgen.start_router()

--- a/tests/topotests/bgp_auth/test_bgp_auth3.py
+++ b/tests/topotests/bgp_auth/test_bgp_auth3.py
@@ -157,8 +157,8 @@ def setup_module(mod):
     # For all registered routers, load the zebra configuration file
     for rname, router in router_list.items():
         router.load_config(TopoRouter.RD_ZEBRA, "zebra.conf")
-        router.load_config(TopoRouter.RD_OSPF)
-        router.load_config(TopoRouter.RD_BGP)
+        router.load_config(TopoRouter.RD_OSPF, "")
+        router.load_config(TopoRouter.RD_BGP, "")
 
     # After copying the configurations, this function loads configured daemons.
     tgen.start_router()

--- a/tests/topotests/bgp_auth/test_bgp_auth4.py
+++ b/tests/topotests/bgp_auth/test_bgp_auth4.py
@@ -157,8 +157,8 @@ def setup_module(mod):
     # For all registered routers, load the zebra configuration file
     for rname, router in router_list.items():
         router.load_config(TopoRouter.RD_ZEBRA, "zebra.conf")
-        router.load_config(TopoRouter.RD_OSPF)
-        router.load_config(TopoRouter.RD_BGP)
+        router.load_config(TopoRouter.RD_OSPF, "")
+        router.load_config(TopoRouter.RD_BGP, "")
 
     # After copying the configurations, this function loads configured daemons.
     tgen.start_router()

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1527,6 +1527,9 @@ class Router(Node):
         """
 
         # Unfortunately this API allowsfor source to not exist for any and all routers.
+        if source is None:
+            source = f"{daemon}.conf"
+
         if source:
             head, tail = os.path.split(source)
             if not head and not self.path_exists(tail):
@@ -1558,7 +1561,7 @@ class Router(Node):
                     self.cmd_raises("cp {} {}".format(source, conf_file_mgmt))
                 self.cmd_raises("cp {} {}".format(source, conf_file))
 
-            if not self.unified_config or daemon == "frr":
+            if not (self.unified_config or daemon == "frr"):
                 self.cmd_raises("chown {0}:{0} {1}".format(self.routertype, conf_file))
                 self.cmd_raises("chmod 664 {}".format(conf_file))
 
@@ -1952,7 +1955,7 @@ class Router(Node):
                 tail_log_files.append("{}/{}/frr.log".format(self.logdir, self.name))
 
         for tailf in tail_log_files:
-            self.run_in_window("tail -f " + tailf, title=tailf, background=True)
+            self.run_in_window("tail -n10000 -F " + tailf, title=tailf, background=True)
 
         return ""
 

--- a/tests/topotests/pytest.ini
+++ b/tests/topotests/pytest.ini
@@ -1,7 +1,7 @@
 # Skip pytests example directory
 [pytest]
 
-asyncio_mode = auto
+# asyncio_mode = auto
 
 # We always turn this on inside conftest.py, default shown
 # addopts = --junitxml=<rundir>/topotests.xml


### PR DESCRIPTION
- Restore default of looking for a daemon config underneath the router directory if no config file was specified.
- Recent change for adding unified config support had a logic bug, fix