### PR TITLE
zebra: Fix build error when FRR is built with the `--disable-bfdd` option

### DIFF
--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -16,6 +16,7 @@
 #include "ptm_lib.h"
 #include "rib.h"
 #include "stream.h"
+#include "lib/version.h"
 #include "vrf.h"
 #include "vty.h"
 #include "lib_errors.h"


### PR DESCRIPTION
When FRR is built with the option `--disable-bfdd`, the build process fails with the following error:

```
zebra/zebra_ptm.c: In function ‘zebra_ptm_init’:
zebra/zebra_ptm.c:119:35: error: ‘FRR_PTM_NAME’ undeclared (first use in this function)
  119 |  snprintf(buf, sizeof(buf), "%s", FRR_PTM_NAME);
      |                                   ^~~~~~~~~~~~
zebra/zebra_ptm.c:119:35: note: each undeclared identifier is reported only once for each function it appears in
make[1]: *** [Makefile:10520: zebra/zebra_ptm.o] Error 1
```

The reason is that `FRR_PTM_NAME` is defined in `version.h` which is not imported.

This PR adds the missing import.