### PR TITLE
zebra: remove ZEBRA_IF_BOND_SLAVE interface type

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -279,8 +279,6 @@ static void netlink_determine_zebra_iftype(const char *kind,
 		*zif_type = ZEBRA_IF_VETH;
 	else if (strcmp(kind, "bond") == 0)
 		*zif_type = ZEBRA_IF_BOND;
-	else if (strcmp(kind, "bond_slave") == 0)
-		*zif_type = ZEBRA_IF_BOND_SLAVE;
 	else if (strcmp(kind, "gre") == 0)
 		*zif_type = ZEBRA_IF_GRE;
 }
@@ -1120,10 +1118,7 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		if (linkinfo[IFLA_INFO_SLAVE_KIND])
 			slave_kind = RTA_DATA(linkinfo[IFLA_INFO_SLAVE_KIND]);
 
-		if ((slave_kind != NULL) && strcmp(slave_kind, "bond") == 0)
-			netlink_determine_zebra_iftype("bond_slave", &zif_type);
-		else
-			netlink_determine_zebra_iftype(kind, &zif_type);
+		netlink_determine_zebra_iftype(kind, &zif_type);
 	}
 
 	/* If VRF, create the VRF structure itself. */

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1697,9 +1697,6 @@ static const char *zebra_ziftype_2str(enum zebra_iftype zif_type)
 	case ZEBRA_IF_BOND:
 		return "bond";
 
-	case ZEBRA_IF_BOND_SLAVE:
-		return "bond_slave";
-
 	case ZEBRA_IF_MACVLAN:
 		return "macvlan";
 

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -39,7 +39,6 @@ enum zebra_iftype {
 	ZEBRA_IF_MACVLAN,   /* MAC VLAN interface*/
 	ZEBRA_IF_VETH,      /* VETH interface*/
 	ZEBRA_IF_BOND,	    /* Bond */
-	ZEBRA_IF_BOND_SLAVE,	    /* Bond */
 	ZEBRA_IF_GRE,      /* GRE interface */
 };
 


### PR DESCRIPTION
It is never actually used in the code.

Closes #13532.