### PR TITLE
doc: configure: add configure option to generate .ccls file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ GSYMS
 GRTAGS
 GPATH
 compile_commands.json
+.ccls
 .ccls-cache
 .dirstamp
 refix

--- a/configure.ac
+++ b/configure.ac
@@ -794,6 +794,9 @@ if test "$ac_cv_lib_json_c_json_object_get" = "no"; then
 fi
 ])
 
+AC_ARG_ENABLE([ccls],
+AS_HELP_STRING([--enable-ccls], [Write .ccls config for this build]))
+
 AC_ARG_ENABLE([dev_build],
     AS_HELP_STRING([--enable-dev-build], [build for development]))
 
@@ -2819,6 +2822,42 @@ AC_CONFIG_FILES([tools/frrinit.sh], [chmod +x tools/frrinit.sh])
 AC_CONFIG_FILES([tools/frrcommon.sh])
 AC_CONFIG_FILES([tools/frr.service])
 AC_CONFIG_FILES([tools/frr@.service])
+
+# dnl write out a ccls file with our compile configuration
+# dnl have to add -Wno-unused-function otherwise foobar_cmd_magic causes
+# dnl all DEFPY(), et al., macros to flag as errors.
+AS_IF([test "$enable_ccls" = "yes"], [
+    AC_CONFIG_COMMANDS([gen-dot-ccls], [
+        cat > "${srcdir}/.ccls" <<EOF
+clang
+-DHAVE_CONFIG_H
+-I.
+-I./include
+-I./lib
+-I./lib/assert
+-DSYSCONFDIR="${ac_frr_sysconfdir}"
+-DCONFDATE=${ac_frr_confdate}
+EOF
+        if test "$ac_abs_top_builddir" != "$ac_abs_top_srcdir"; then
+            echo "-I${ac_abs_top_builddir}" >> "${srcdir}/.ccls"
+        fi
+        if test -n "$FRR_ALL_CCLS_FLAGS"; then
+            echo ${FRR_ALL_CCLS_FLAGS} | tr ' ' '\n' >> "${srcdir}/.ccls"
+        fi
+        if test -n "$FRR_ALL_CCLS_CFLAGS"; then
+            cat >> "${srcdir}/.ccls" <<EOF
+%c $(echo ${FRR_ALL_CCLS_CFLAGS} | sed -e 's/  */\n%c /g')
+%c -Wno-unused-function
+EOF
+fi
+    ], [
+    FRR_ALL_CCLS_FLAGS="$(echo ${LIBYANG_CFLAGS} ${LUA_INCLUDE} ${SQLITE3_CFLAGS} | sed -e 's/  */ /g')"
+    FRR_ALL_CCLS_CFLAGS="$(echo ${CFLAGS} ${WERROR} ${AC_CFLAGS} ${SAN_FLAGS} | sed -e 's/  */ /g')"
+    ac_frr_confdate="${CONFDATE}"
+    ac_frr_sysconfdir="${sysconfdir}/"
+    ])
+])
+
 
 AS_IF([test "$with_pkg_git_version" = "yes"], [
     AC_CONFIG_COMMANDS([lib/gitversion.h], [

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -390,6 +390,18 @@ and the configuration files in :file:`/usr/local/etc`. The :file:`/usr/local/`
 installation prefix and other directories may be changed using the following
 options to the configuration script.
 
+.. option:: --enable-ccls
+
+   Enable the creation of a :file:`.ccls` file in the top level source
+   directory.
+
+   Some development environments (e.g., LSP server within emacs, et al.) can
+   utilize :clicmd:`ccls` to provide highly sophisticated IDE features (e.g.,
+   semantically accurate jump-to definition/reference, and even code
+   refactoring). The `--enable-ccls` causes :file:`configure` to generate a
+   configuration for the :clicmd:`ccls` command, based on the configured
+   FRR build environment.
+
 .. option:: --prefix <prefix>
 
    Install architecture-independent files in `prefix` [/usr/local].


### PR DESCRIPTION
`ccls` needs information from FRR build configuration to work, so allow creation of a custom ccls config during autoconf.

Paraphrasing the doc entry: ccls is a very powerful tool that allows dev environments to provide sophisticated IDE functionality, e.g., semantically aware jumps and code refactoring...