### PR TITLE
memory desciprtion shortening

### DIFF
--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -28,8 +28,8 @@
  * FRR related code.
  */
 DEFINE_MGROUP(BFDD, "Bidirectional Forwarding Detection Daemon");
-DEFINE_MTYPE(BFDD, BFDD_CONTROL, "long-lived control socket memory");
-DEFINE_MTYPE(BFDD, BFDD_NOTIFICATION, "short-lived control notification data");
+DEFINE_MTYPE(BFDD, BFDD_CONTROL, "control socket memory");
+DEFINE_MTYPE(BFDD, BFDD_NOTIFICATION, "control notification data");
 
 /* Master of threads. */
 struct event_loop *master;

--- a/lib/grammar_sandbox.c
+++ b/lib/grammar_sandbox.c
@@ -19,7 +19,7 @@
 
 #define GRAMMAR_STR "CLI grammar sandbox\n"
 
-DEFINE_MTYPE_STATIC(LIB, CMD_TOKENS, "Command desc");
+DEFINE_MTYPE_STATIC(LIB, CMD_DESCRIPTIONS, "Command desc");
 
 /** headers **/
 void grammar_sandbox_init(void);
@@ -53,7 +53,7 @@ DEFUN (grammar_test,
 
 	// create cmd_element for parser
 	struct cmd_element *cmd =
-		XCALLOC(MTYPE_CMD_TOKENS, sizeof(struct cmd_element));
+		XCALLOC(MTYPE_CMD_DESCRIPTIONS, sizeof(struct cmd_element));
 	cmd->string = command;
 	cmd->doc =
 		"0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n";
@@ -207,11 +207,11 @@ DEFUN (grammar_test_doc,
 
 	// create cmd_element with docstring
 	struct cmd_element *cmd =
-		XCALLOC(MTYPE_CMD_TOKENS, sizeof(struct cmd_element));
+		XCALLOC(MTYPE_CMD_DESCRIPTIONS, sizeof(struct cmd_element));
 	cmd->string = XSTRDUP(
-		MTYPE_CMD_TOKENS,
+		MTYPE_CMD_DESCRIPTIONS,
 		"test docstring <example|selector follow> (1-255) end VARIABLE [OPTION|set lol] . VARARG");
-	cmd->doc = XSTRDUP(MTYPE_CMD_TOKENS,
+	cmd->doc = XSTRDUP(MTYPE_CMD_DESCRIPTIONS,
 			   "Test stuff\n"
 			   "docstring thing\n"
 			   "first example\n"

--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -26,9 +26,8 @@
 #define MGMTD_DBG_BE_CLIENT_CHECK()                                            \
 	DEBUG_MODE_CHECK(&mgmt_dbg_be_client, DEBUG_MODE_ALL)
 
-DEFINE_MTYPE_STATIC(LIB, MGMTD_BE_BATCH,
-		    "MGMTD backend transaction batch data");
-DEFINE_MTYPE_STATIC(LIB, MGMTD_BE_TXN, "MGMTD backend transaction data");
+DEFINE_MTYPE_STATIC(LIB, MGMTD_BE_BATCH, "backend transaction batch data");
+DEFINE_MTYPE_STATIC(LIB, MGMTD_BE_TXN, "backend transaction data");
 
 enum mgmt_be_txn_event {
 	MGMTD_BE_TXN_PROC_SETCFG = 1,

--- a/mgmtd/mgmt_memory.c
+++ b/mgmtd/mgmt_memory.c
@@ -18,19 +18,15 @@
  */
 
 DEFINE_MGROUP(MGMTD, "mgmt");
-DEFINE_MTYPE(MGMTD, MGMTD, "MGMTD instance");
-DEFINE_MTYPE(MGMTD, MGMTD_BE_ADPATER, "MGMTD backend adapter");
-DEFINE_MTYPE(MGMTD, MGMTD_FE_ADPATER, "MGMTD Frontend adapter");
-DEFINE_MTYPE(MGMTD, MGMTD_FE_SESSION, "MGMTD Frontend Client Session");
-DEFINE_MTYPE(MGMTD, MGMTD_TXN, "MGMTD Transaction");
-DEFINE_MTYPE(MGMTD, MGMTD_TXN_REQ, "MGMTD Transaction Requests");
-DEFINE_MTYPE(MGMTD, MGMTD_TXN_SETCFG_REQ,
-	     "MGMTD Transaction Set-Config Requests");
-DEFINE_MTYPE(MGMTD, MGMTD_TXN_COMMCFG_REQ,
-	     "MGMTD Transaction Commit-Config Requests");
-DEFINE_MTYPE(MGMTD, MGMTD_TXN_GETDATA_REQ,
-	     "MGMTD Transaction Get-Data Requests");
-DEFINE_MTYPE(MGMTD, MGMTD_TXN_GETDATA_REPLY,
-	     "MGMTD Transaction Get-Data Replies");
-DEFINE_MTYPE(MGMTD, MGMTD_TXN_CFG_BATCH, "MGMTD Transaction Gonfig Batches");
-DEFINE_MTYPE(MGMTD, MGMTD_CMT_INFO, "MGMTD commit info for tracking commits");
+DEFINE_MTYPE(MGMTD, MGMTD, "instance");
+DEFINE_MTYPE(MGMTD, MGMTD_BE_ADPATER, "backend adapter");
+DEFINE_MTYPE(MGMTD, MGMTD_FE_ADPATER, "Frontend adapter");
+DEFINE_MTYPE(MGMTD, MGMTD_FE_SESSION, "Frontend Client Session");
+DEFINE_MTYPE(MGMTD, MGMTD_TXN, "Trnsction");
+DEFINE_MTYPE(MGMTD, MGMTD_TXN_REQ, "Trnsction Requests");
+DEFINE_MTYPE(MGMTD, MGMTD_TXN_SETCFG_REQ, "Trnsction Set-Config Requests");
+DEFINE_MTYPE(MGMTD, MGMTD_TXN_COMMCFG_REQ, "Trnsction Commit-Config Requests");
+DEFINE_MTYPE(MGMTD, MGMTD_TXN_GETDATA_REQ, "Trnsction Get-Data Requests");
+DEFINE_MTYPE(MGMTD, MGMTD_TXN_GETDATA_REPLY, "Trnsction Get-Data Replies");
+DEFINE_MTYPE(MGMTD, MGMTD_TXN_CFG_BATCH, "Trnsction Gonfig Batches");
+DEFINE_MTYPE(MGMTD, MGMTD_CMT_INFO, "info for tracking commits");

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -1185,7 +1185,7 @@ struct ptm_process {
 TAILQ_HEAD(ppqueue, ptm_process) ppqueue;
 
 DEFINE_MTYPE_STATIC(ZEBRA, ZEBRA_PTM_BFD_PROCESS,
-		    "PTM BFD process registration table.");
+		    "PTM BFD process reg table");
 
 /*
  * Prototypes.


### PR DESCRIPTION
See individual commits but make the 'show memory` command work so that we are not clipping the table.