### PR TITLE
bgpd: Fix missing deletion of evpn routes

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3271,6 +3271,9 @@ static int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 	bgp_aggregate_decrement(bgp_vrf, bgp_dest_get_prefix(dest), pi, afi,
 				safi);
 
+	/* Force deletion */
+	SET_FLAG(dest->flags, BGP_NODE_PROCESS_CLEAR);
+
 	/* Mark entry for deletion */
 	bgp_path_info_delete(dest, pi);
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3227,10 +3227,11 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 	/* If best route remains the same and this is not due to user-initiated
 	 * clear, see exactly what needs to be done.
 	 */
-	if (old_select && old_select == new_select
-	    && !CHECK_FLAG(dest->flags, BGP_NODE_USER_CLEAR)
-	    && !CHECK_FLAG(old_select->flags, BGP_PATH_ATTR_CHANGED)
-	    && !bgp_addpath_is_addpath_used(&bgp->tx_addpath, afi, safi)) {
+	if (old_select && old_select == new_select &&
+	    !CHECK_FLAG(dest->flags, BGP_NODE_USER_CLEAR) &&
+	    !CHECK_FLAG(dest->flags, BGP_NODE_PROCESS_CLEAR) &&
+	    !CHECK_FLAG(old_select->flags, BGP_PATH_ATTR_CHANGED) &&
+	    !bgp_addpath_is_addpath_used(&bgp->tx_addpath, afi, safi)) {
 		if (bgp_zebra_has_route_changed(old_select)) {
 #ifdef ENABLE_BGP_VNC
 			vnc_import_bgp_add_route(bgp, p, old_select);
@@ -3283,6 +3284,10 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 	/* If the user did "clear ip bgp prefix x.x.x.x" this flag will be set
 	 */
 	UNSET_FLAG(dest->flags, BGP_NODE_USER_CLEAR);
+
+	/* If the process wants to force deletion this flag will be set
+	 */
+	UNSET_FLAG(dest->flags, BGP_NODE_PROCESS_CLEAR);
 
 	/* bestpath has changed; bump version */
 	if (old_select || new_select) {

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -100,6 +100,7 @@ struct bgp_node {
 #define BGP_NODE_FIB_INSTALLED          (1 << 6)
 #define BGP_NODE_LABEL_REQUESTED        (1 << 7)
 #define BGP_NODE_SOFT_RECONFIG (1 << 8)
+#define BGP_NODE_PROCESS_CLEAR (1 << 9)
 
 	struct bgp_addpath_node_data tx_addpath;
 


### PR DESCRIPTION
Consider the scenario of anycast gateways with one ES group in evpn multihoming, the remote ( not ES group ) has already learn everything about that ES group.

When removing one of ES peers, `show evpn rmac vni all` kept no change sometimes, it means the rmac of the removed peer is still there. This error display depends on which member of peers is to be removed.

The root cause is that the best path selection for Type-2/5 routes maybe keep no change and the best path is not to the removed peer, so `bgpd` wrongly doesn't tell `zebra` to remove ( withdraw ) the Type-2/5 routes owned by the removed peer. Finally, the rmac display from `zebra` kept no change.

So, force the deletion.

----

It is updated, please check commit log.