### PR TITLE
old Fpm netlink some cleanups

### DIFF
--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -497,6 +497,11 @@ static inline void zfpm_connect_off(void)
 	EVENT_OFF(zfpm_g->t_connect);
 }
 
+static inline void zfpm_conn_down_off(void)
+{
+	EVENT_OFF(zfpm_g->t_conn_down);
+}
+
 /*
  * zfpm_conn_up_thread_cb
  *
@@ -635,8 +640,6 @@ static void zfpm_conn_down_thread_cb(struct event *thread)
 	while ((mac = TAILQ_FIRST(&zfpm_g->mac_q)) != NULL)
 		zfpm_mac_info_del(mac);
 
-	zfpm_g->t_conn_down = NULL;
-
 	iter = &zfpm_g->t_conn_down_state.iter;
 
 	while ((rnode = zfpm_rnodes_iter_next(iter))) {
@@ -667,7 +670,6 @@ static void zfpm_conn_down_thread_cb(struct event *thread)
 
 		zfpm_g->stats.t_conn_down_yields++;
 		zfpm_rnodes_iter_pause(iter);
-		zfpm_g->t_conn_down = NULL;
 		event_add_timer_msec(zfpm_g->master, zfpm_conn_down_thread_cb,
 				     NULL, 0, &zfpm_g->t_conn_down);
 		return;
@@ -712,7 +714,7 @@ static void zfpm_connection_down(const char *detail)
 	 */
 	assert(!zfpm_g->t_conn_down);
 	zfpm_rnodes_iter_init(&zfpm_g->t_conn_down_state.iter);
-	zfpm_g->t_conn_down = NULL;
+	zfpm_conn_down_off();
 	event_add_timer_msec(zfpm_g->master, zfpm_conn_down_thread_cb, NULL, 0,
 			     &zfpm_g->t_conn_down);
 	zfpm_g->stats.t_conn_down_starts++;
@@ -2042,6 +2044,7 @@ static int zfpm_fini(void)
 	zfpm_write_off();
 	zfpm_read_off();
 	zfpm_connect_off();
+	zfpm_conn_down_off();
 
 	zfpm_stop_stats_timer();
 

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -2049,6 +2049,8 @@ static int zfpm_fini(void)
 	zfpm_stop_stats_timer();
 
 	hook_unregister(rib_update, zfpm_trigger_update);
+	hook_unregister(zebra_rmac_update, zfpm_trigger_rmac_update);
+
 	return 0;
 }
 

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -252,20 +252,15 @@ static int netlink_route_info_fill(struct netlink_route_info *ri, int cmd,
 				   rib_dest_t *dest, struct route_entry *re)
 {
 	struct nexthop *nexthop;
-	struct rib_table_info *table_info =
-		rib_table_info(rib_dest_table(dest));
-	struct zebra_vrf *zvrf = table_info->zvrf;
 
 	memset(ri, 0, sizeof(*ri));
 
 	ri->prefix = rib_dest_prefix(dest);
 	ri->af = rib_dest_af(dest);
 
-	if (zvrf && zvrf->zns)
-		ri->nlmsg_pid = zvrf->zns->netlink_dplane_out.snl.nl_pid;
+	ri->nlmsg_pid = pid;
 
 	ri->nlmsg_type = cmd;
-	ri->rtm_table = table_info->table_id;
 	ri->rtm_protocol = RTPROT_UNSPEC;
 
 	/*
@@ -279,6 +274,8 @@ static int netlink_route_info_fill(struct netlink_route_info *ri, int cmd,
 		zfpm_debug("%s: Expected non-NULL re pointer", __func__);
 		return 0;
 	}
+
+	ri->rtm_table = re->table;
 
 	ri->rtm_protocol = netlink_proto_from_route_type(re->type);
 	ri->rtm_type = RTN_UNICAST;


### PR DESCRIPTION
See individual commits:

a) Cleanup possible use after free of some pointers
b) t_conn_down could create multiple events if we already had one running ( unlikely to happen, but remotely possible )
c) zebra_rmac_updates were not turned off on shutdown.