### PR TITLE
tests: pytest does not like return True from a test

### DIFF
--- a/tests/topotests/bgp_remove_private_as/test_bgp_remove_private_as.py
+++ b/tests/topotests/bgp_remove_private_as/test_bgp_remove_private_as.py
@@ -409,8 +409,6 @@ def test_bgp_remove_private_as():
         # the old flag after each iteration so we only test the flags we expect.
         _change_remove_type(rmv_type, "del")
 
-    return True
-
 
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]


### PR DESCRIPTION
From running the test:
bgp_remove_private_as/test_bgp_remove_private_as.py::test_bgp_remove_private_as
  /home/sharpd/.local/lib/python3.10/site-packages/_pytest/python.py:198: PytestReturnNotNoneWarning: Expected None, but bgp_remove_private_as/test_bgp_remove_private_as.py::test_bgp_remove_private_as returned True, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html