### PR TITLE
 bgpd: aggregate route best path select and other fixes

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1082,9 +1082,6 @@ struct attr *bgp_attr_aggregate_intern(
 		attr.aspath = aspath_empty(bgp->asnotation);
 	attr.flag |= ATTR_FLAG_BIT(BGP_ATTR_AS_PATH);
 
-	/* Next hop attribute.  */
-	attr.flag |= ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
-
 	if (community) {
 		uint32_t gshut = COMMUNITY_GSHUT;
 
@@ -1120,6 +1117,21 @@ struct attr *bgp_attr_aggregate_intern(
 	else
 		attr.aggregator_as = bgp->as;
 	attr.aggregator_addr = bgp->router_id;
+
+	/* Aggregate are done for IPv4/IPv6 so checking ipv4 family,
+	 * This should only be set for IPv4 AFI type
+	 * based on RFC-4760:
+	 * "An UPDATE message that carries no NLRI,
+	 * other than the one encoded in
+	 * the MP_REACH_NLRI attribute,
+	 * SHOULD NOT carry the NEXT_HOP
+	 * attribute"
+	 */
+	if (p->family == AF_INET) {
+		/* Next hop attribute.  */
+		attr.flag |= ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
+		attr.mp_nexthop_len = IPV4_MAX_BYTELEN;
+	}
 
 	/* Apply route-map */
 	if (aggregate->rmap.name) {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7418,7 +7418,7 @@ static bool bgp_aggregate_info_same(struct bgp_path_info *pi, uint8_t origin,
 
 	asnotation = bgp_get_asnotation(NULL);
 
-	if (!ae)
+	if (!aspath)
 		ae = aspath_empty(asnotation);
 
 	if (!pi)

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7477,8 +7477,8 @@ static void bgp_aggregate_install(
 		 * If the aggregate information has not changed
 		 * no need to re-install it again.
 		 */
-		if (bgp_aggregate_info_same(orig, origin, aspath, community,
-					    ecommunity, lcommunity)) {
+		if (pi && bgp_aggregate_info_same(pi, origin, aspath, community,
+						  ecommunity, lcommunity)) {
 			bgp_dest_unlock_node(dest);
 
 			if (aspath)


### PR DESCRIPTION
1. In ebgp+ ibgp deployment aggregate summary-only route selected path should always be locally originated
summary route. When aggregate route summary-only config is removed.
The selected path is iBGP peer as its lower cost upon reconfiguring aggregate route summary-only,
the locally originated is not selected due to always choosing first path attribute and bailing out as no change in route update.

Testing Done:

Config:
 
 ```
    TORC11(config-router)#router bgp
    TORC11(config-router)# address-family ipv4 unicast
    TORC11(config-router-af)# aggregate-address 184.123.0.0/16 summary-only
    TORC11(config-router-af)# no aggregate-address 184.123.0.0/16 summary-only
    TORC11(config-router-af)# aggregate-address 184.123.0.0/16 summary-only
```

Before fix:

 ```
    *> 184.123.0.0/16   ::(TORC11)               0         32768 i
    *                   uplink1                                0 4435 5546 i
    *                   uplink2                                0 4435 5546 i
    * i                 peerlink-3               0    100      0 i
```

After fix:

```
    *> 184.123.0.0/16   ::(TORC11)               0         32768 i
    * i                 peerlink-3               0    100      0 i
    *                   uplink2                                0 4435 5546 i
    *                   uplink1                                0 4435 5546 i
```

2. bgpd: fix aggregate route display

Based on RFC-4760, if NEXT_HOP attribute is not  suppose to be set if MP_REACH_NLRI NLRI is used.
for IPv4 aggregate route only NEXT_HOP attribute with ipv4 prefixlen needs to be set.

Testing Done:

Before fix:

aggregate route:

```
*> 184.123.0.0/16   ::(TORC11)               0         32768 i
```

After fix:

aggregate route:

```
*> 184.123.0.0/16   0.0.0.0(TORC11)          0         32768 i

```


3. bgpd: fix memory leak in aggregate path info

Fix memory leak in aggregate route path info comparison api.


Signed-off-by: Chirag Shah <chirag@nvidia.com>
