### PR TITLE
Grab bag of fixes from upgrading system

### DIFF
--- a/lib/printf/glue.c
+++ b/lib/printf/glue.c
@@ -273,6 +273,7 @@ static ssize_t printfrr_va(struct fbuf *buf, struct printfrr_eargs *ea,
 {
 	const struct va_format *vaf = ptr;
 	va_list ap;
+	ssize_t s;
 
 	if (!vaf || !vaf->fmt || !vaf->va)
 		return bputs(buf, "NULL");
@@ -285,6 +286,9 @@ static ssize_t printfrr_va(struct fbuf *buf, struct printfrr_eargs *ea,
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 	/* can't format check this */
-	return vbprintfrr(buf, vaf->fmt, ap);
+	s = vbprintfrr(buf, vaf->fmt, ap);
 #pragma GCC diagnostic pop
+	va_end(ap);
+
+	return s;
 }

--- a/tests/topotests/bgp_default_originate/test_bgp_default_originate_2links.py
+++ b/tests/topotests/bgp_default_originate/test_bgp_default_originate_2links.py
@@ -19,6 +19,7 @@ import pytest
 import datetime
 from copy import deepcopy
 from lib.topolog import logger
+from time import sleep
 
 # pylint: disable=C0413
 # Import topogen and topotest helpers
@@ -592,6 +593,7 @@ def test_verify_bgp_default_originate_with_default_static_route_p1(request):
     step("Taking uptime snapshot before configuring default - originate")
     uptime_before_ipv4 = get_rib_route_uptime(tgen, "ipv4", "r2", ipv4_uptime_dict)
     uptime_before_ipv6 = get_rib_route_uptime(tgen, "ipv6", "r2", ipv6_uptime_dict)
+    sleep(1)
 
     step(
         "Configure default-originate on R1 link-1 again for IPv4 and IPv6 address family"
@@ -1031,6 +1033,7 @@ def test_verify_bgp_default_originate_with_default_static_route_p1(request):
     step("Taking uptime snapshot before  removing   redisctribute static ")
     uptime_before_ipv4 = get_rib_route_uptime(tgen, "ipv4", "r2", ipv4_uptime_dict)
     uptime_before_ipv6 = get_rib_route_uptime(tgen, "ipv6", "r2", ipv6_uptime_dict)
+    sleep(1)
 
     step("Remove redistribute static from IPv4 and IPv6 address family ")
     input_dict_1 = {

--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -529,6 +529,7 @@ def __create_bgp_unicast_neighbor(
 
             config_data.extend(neigh_addr_data)
 
+    config_data.append("exit")
     logger.debug("Exiting lib API: {}".format(sys._getframe().f_code.co_name))
     return config_data
 

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -2186,6 +2186,7 @@ def create_interfaces_cfg(tgen, topo, build=False):
                     interface_data += _create_interfaces_ospf_cfg(
                         "ospf6", c_data, data, ospf_keywords + ["area"]
                     )
+                interface_data.append("exit")
             if interface_data:
                 interface_data_dict[c_router] = interface_data
 

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -337,6 +337,7 @@ def __create_ospf_global(tgen, input_dict, router, build, load_config, ospf):
                 cmd = "no {}".format(cmd)
             config_data.append(cmd)
 
+    config_data.append("exit")
     logger.debug("Exiting lib API: create_ospf_global()")
 
     return config_data

--- a/tests/topotests/lib/topojson.py
+++ b/tests/topotests/lib/topojson.py
@@ -340,7 +340,7 @@ def build_config_from_json(tgen, topo=None, save_bkup=True):
     result = load_config_to_routers(tgen, routers, save_bkup)
     if not result:
         logger.info("build_config_from_json: failed to configure topology")
-        pytest.exit(1)
+        assert False
 
     logger.info(
         "Built config now clearing ospf neighbors as that router-id might not be what is used"

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3799,8 +3799,7 @@ tc_qdisc_update_internal(enum dplane_op_e op,
 	} else {
 		atomic_fetch_add_explicit(&zdplane_info.dg_tcs_errors, 1,
 					  memory_order_relaxed);
-		if (ctx)
-			dplane_ctx_free(&ctx);
+		dplane_ctx_free(&ctx);
 	}
 
 	return result;
@@ -3830,8 +3829,7 @@ tc_class_update_internal(enum dplane_op_e op, struct zebra_tc_class *class)
 	} else {
 		atomic_fetch_add_explicit(&zdplane_info.dg_tcs_errors, 1,
 					  memory_order_relaxed);
-		if (ctx)
-			dplane_ctx_free(&ctx);
+		dplane_ctx_free(&ctx);
 	}
 
 	return result;
@@ -3861,8 +3859,7 @@ tc_filter_update_internal(enum dplane_op_e op, struct zebra_tc_filter *filter)
 	} else {
 		atomic_fetch_add_explicit(&zdplane_info.dg_tcs_errors, 1,
 					  memory_order_relaxed);
-		if (ctx)
-			dplane_ctx_free(&ctx);
+		dplane_ctx_free(&ctx);
 	}
 
 	return result;
@@ -4230,8 +4227,7 @@ done:
 	else {
 		atomic_fetch_add_explicit(&zdplane_info.dg_lsp_errors, 1,
 					  memory_order_relaxed);
-		if (ctx)
-			dplane_ctx_free(&ctx);
+		dplane_ctx_free(&ctx);
 	}
 	return result;
 }


### PR DESCRIPTION
1) Tests that look for second changes in time but complete in under a second will fail
2) Tests should not stop the entire run of the topotests if an error is found on configuring a single test
3) Do not free a hash until we are done
4) Do not test for ctx being null when it cannot be
5) va_end must be called