### PR TITLE
zebra: Fix wrong vrf change procedure

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -714,6 +714,11 @@ static void bgp_nht_ifp_table_handle(struct bgp *bgp,
 {
 	struct bgp_nexthop_cache *bnc;
 
+	if (ifp->ifindex == IFINDEX_INTERNAL) {
+		zlog_warn("%s: The interface %s ignored", __func__, ifp->name);
+		return;
+	}
+
 	frr_each (bgp_nexthop_cache, table, bnc) {
 		if (bnc->ifindex != ifp->ifindex)
 			continue;


### PR DESCRIPTION
- zebra: Fix wrong vrf change procedure

Currently the vrf change procedure for the deleted interface is after its deletion, it causes problem for upper daemons.

Here is the problem of `bgp`:

After deletion of one **irrelevant** interface in the same vrf, its `ifindex` is set to 0. And then, the vrf change procedure will send "ZEBRA_INTERFACE_DOWN" to `bgpd`.

Normally, `bgp_nht_ifp_table_handle()` should igore this message for no correlation. However, it wrongly matched `ifindex` of 0, and removed the related routes for the down `bnc`.

Adjust the location of the vrf change procedure to fix this issue.

 
 
- bgpd: Add an assert for nht procedure
    
`bnc->ifindex` should not be with 0 ( IFINDEX_INTERNAL ), so add an
assert to make it safe.