### PR TITLE
Fixing show bgp all json format and convert evpn to no pretty output

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3217,7 +3217,14 @@ int bgp_evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 	evpn_show_all_routes(vty, bgp, type, json, detail, false);
 
 	if (use_json)
-		vty_json(vty, json);
+		/*
+		 * We are using no_pretty here because under extremely high
+		 * settings (lots of routes with many different paths) this can
+		 * save several minutes of output when FRR is run on older cpu's
+		 * or more underperforming routers out there. So for route
+		 * scale, we need to use no_pretty json.
+		 */
+		vty_json_no_pretty(vty, json);
 	return CMD_SUCCESS;
 }
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13068,6 +13068,15 @@ DEFPY(show_ip_bgp, show_ip_bgp_cmd,
 							get_afi_safi_str(afi,
 									 safi,
 									 true));
+
+						/* Adding 'routes' key to make
+						 * the json output format valid
+						 * for evpn
+						 */
+						if (safi == SAFI_EVPN)
+							vty_out(vty,
+								"\"routes\":");
+
 					} else
 						vty_out(vty,
 							"\nFor address family: %s\n",


### PR DESCRIPTION
The following are the changes made to show bgp all json

- Make the json output of 'show bgp all json' into a valid format
- Using no pretty json output for evpn routes

valid Json format:
```
    Before Fix:
    torm-11# sh bgp all json
    {
    <SNIP>....................
    "l2VpnEvpn":{
    {
      "27.0.0.15:2":{
        "rd":"27.0.0.15:2",
        "[4]:[03:44:38:39:ff:ff:01:00:00:01]:[32]:[27.0.0.15]":{
          "prefix":"[4]:[03:44:38:39:ff:ff:01:00:00:01]:[32]:[27.0.0.15]",
          "prefixLen":352,
          "paths":[
    <SNIP>....................

    After Fix:
    torm-11# sh bgp all json
    {
    <SNIP>....................
    "l2VpnEvpn":{
    "routes":{
      "27.0.0.15:2":{
        "rd":"27.0.0.15:2",
        "[1]:[0]:[03:44:38:39:ff:ff:01:00:00:01]:[128]:[::]:[0]":{
          "prefix":"[1]:[0]:[03:44:38:39:ff:ff:01:00:00:01]:[128]:[::]:[0]",
          "prefixLen":352,
          "paths":[
    <SNIP>....................
```

No pretty output for evpn routes
```
    Before fix:
    torm-11# sh bgp all json
    {
    "ipv4Unicast":{
     "vrfId": 0,
     "vrfName": "default",
     "tableVersion": 1,
     "routerId": "27.0.0.15",
     "defaultLocPrf": 100,
     "localAS": 65000,
     "routes": { } }
    ,
    "l2VpnEvpn":{
    "routes":{
      "27.0.0.15:2":{
        "rd":"27.0.0.15:2",
        "[1]:[0]:[03:44:38:39:ff:ff:01:00:00:01]:[128]:[::]:[0]":{
          "prefix":"[1]:[0]:[03:44:38:39:ff:ff:01:00:00:01]:[128]:[::]:[0]",
          "prefixLen":352,
          "paths":[
    <SNIP>.............

    After fix:
    torm-11# sh bgp all json
    {
    "ipv4Unicast":{
     "vrfId": 0,
     "vrfName": "default",
     "tableVersion": 1,
     "routerId": "27.0.0.15",
     "defaultLocPrf": 100,
     "localAS": 65000,
     "routes": { } }
    ,
    "l2VpnEvpn":{
    "routes":{"27.0.0.15:2":{"rd":"27.0.0.15:2","[1]:[0]:[03:44:38:39:ff:ff:01:00:00:01]:[128]:[::]:[0]":{"prefix":"[1]:[0]:[03:44:38:39:ff:ff:01:00:00:01]:[128]:[::]:[0]","prefixLen":352,"paths":[[{"valid":true,"bestpath":true,"selectionReason":"First path received","pathFrom":"external","routeType":1,"weight":32768,"peerId":"(unspec)","path":"","origin":"IGP","extendedCommunity"
    <SNIP>.............

```



Signed-off-by: Rajasekar Raja [rajasekarr@nvidia.com](mailto:rajasekarr@nvidia.com)

