### PR TITLE
ripd: Use argv_find to avoid buffer overflow when parsing allow-ecmp args

### DIFF
--- a/ripd/rip_cli.c
+++ b/ripd/rip_cli.c
@@ -91,11 +91,11 @@ DEFUN_YANG (rip_allow_ecmp,
        "Allow Equal Cost MultiPath\n"
        "Number of paths\n")
 {
-	int idx_number = 1;
+	int idx_number = 0;
 	char mpaths[3] = {};
 	uint32_t paths = MULTIPATH_NUM;
 
-	if (argv[idx_number])
+	if (argv_find(argv, argc, CMD_RANGE_STR(1, MULTIPATH_NUM), &idx_number))
 		paths = strtol(argv[idx_number]->arg, NULL, 10);
 	snprintf(mpaths, sizeof(mpaths), "%u", paths);
 


### PR DESCRIPTION
```
==13211==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020000af158 at pc 0x55d48c5f1e38 bp 0x7fffd8a713d0 sp 0x7fffd8a713c0 READ of size 8 at 0x6020000af158 thread T0
    #0 0x55d48c5f1e37 in rip_allow_ecmp ripd/rip_cli.c:98
    #1 0x7f2ec125aa0f in cmd_execute_command_real lib/command.c:990
    #2 0x7f2ec125ae90 in cmd_execute_command lib/command.c:1049
    #3 0x7f2ec125b406 in cmd_execute lib/command.c:1217
    #4 0x7f2ec137ca36 in vty_command lib/vty.c:551
    #5 0x7f2ec137ce52 in vty_execute lib/vty.c:1314
    #6 0x7f2ec1384f9e in vtysh_read lib/vty.c:2223
    #7 0x7f2ec137041b in event_call lib/event.c:1995
    #8 0x7f2ec12b54bf in frr_run lib/libfrr.c:1204
    #9 0x55d48c5f0f32 in main ripd/rip_main.c:171
    #10 0x7f2ec0ad9c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)
    #11 0x55d48c5f1349 in _start (/usr/lib/frr/ripd+0x3b349)

0x6020000af158 is located 0 bytes to the right of 8-byte region [0x6020000af150,0x6020000af158) allocated by thread T0 here:
    #0 0x7f2ec18ccb40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f2ec12d2e41 in qmalloc lib/memory.c:100
    #2 0x7f2ec125a815 in cmd_execute_command_real lib/command.c:955
    #3 0x7f2ec125ae90 in cmd_execute_command lib/command.c:1049
    #4 0x7f2ec125b406 in cmd_execute lib/command.c:1217
    #5 0x7f2ec137ca36 in vty_command lib/vty.c:551
    #6 0x7f2ec137ce52 in vty_execute lib/vty.c:1314
    #7 0x7f2ec1384f9e in vtysh_read lib/vty.c:2223
    #8 0x7f2ec137041b in event_call lib/event.c:1995
    #9 0x7f2ec12b54bf in frr_run lib/libfrr.c:1204
    #10 0x55d48c5f0f32 in main ripd/rip_main.c:171
    #11 0x7f2ec0ad9c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: heap-buffer-overflow ripd/rip_cli.c:98 in rip_allow_ecmp Shadow bytes around the buggy address:
  0x0c048000ddd0: fa fa fd fa fa fa fd fa fa fa fd fd fa fa fd fa
  0x0c048000dde0: fa fa fd fa fa fa fd fd fa fa fd fa fa fa fd fd
  0x0c048000ddf0: fa fa fd fa fa fa fd fd fa fa fd fd fa fa fd fd
  0x0c048000de00: fa fa fd fa fa fa fd fd fa fa 00 03 fa fa fd fa
  0x0c048000de10: fa fa fd fa fa fa 00 00 fa fa fd fa fa fa 00 03
=>0x0c048000de20: fa fa 00 03 fa fa fd fa fa fa 00[fa]fa fa fa fa
  0x0c048000de30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048000de40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048000de50: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048000de60: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048000de70: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==13211==ABORTING
```