### PR TITLE
pbrd, zebra: fix zapi and netlink rule encoding

### DIFF
--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -516,7 +516,7 @@ pbr_encode_pbr_map_sequence_vrf(struct stream *s,
 	stream_putl(s, pbr_vrf->vrf->data.l.table_id);
 }
 
-static void pbr_encode_pbr_map_sequence(struct stream *s,
+static bool pbr_encode_pbr_map_sequence(struct stream *s,
 					struct pbr_map_sequence *pbrms,
 					struct interface *ifp)
 {
@@ -549,7 +549,14 @@ static void pbr_encode_pbr_map_sequence(struct stream *s,
 		stream_putl(s, pbr_nht_get_table(pbrms->nhgrp_name));
 	else if (pbrms->nhg)
 		stream_putl(s, pbr_nht_get_table(pbrms->internal_nhg_name));
+	else {
+		/* Not valid for install without table */
+		return false;
+	}
+
 	stream_put(s, ifp->name, INTERFACE_NAMSIZ);
+
+	return true;
 }
 
 bool pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
@@ -593,11 +600,13 @@ bool pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 	       install ? "Installing" : "Deleting", pbrm->name, pbrms->seqno,
 	       install, pmi->ifp->name, pmi->delete);
 
-	pbr_encode_pbr_map_sequence(s, pbrms, pmi->ifp);
-
-	stream_putw_at(s, 0, stream_get_endp(s));
-
-	zclient_send_message(zclient);
+	if (pbr_encode_pbr_map_sequence(s, pbrms, pmi->ifp)) {
+		stream_putw_at(s, 0, stream_get_endp(s));
+		zclient_send_message(zclient);
+	} else {
+		DEBUGD(&pbr_dbg_zebra, "%s: %s seq %u encode failed, skipped",
+		       __func__, pbrm->name, pbrms->seqno);
+	}
 
 	return true;
 }

--- a/zebra/rule_netlink.c
+++ b/zebra/rule_netlink.c
@@ -116,9 +116,9 @@ static ssize_t netlink_rule_msg_encode(
 			return 0;
 	}
 
-	/* dsfield, if specified */
+	/* dsfield, if specified; mask off the ECN bits */
 	if (filter_bm & PBR_FILTER_DSFIELD)
-		req->frh.tos = dsfield;
+		req->frh.tos = dsfield & 0xfc;
 
 	/* protocol to match on */
 	if (filter_bm & PBR_FILTER_IP_PROTOCOL)


### PR DESCRIPTION
In pbrd, don't encode a rule without a table. There are cases where the zapi encoding was incorrect because the 4-octet table id was missing. In zebra, mask off the ECN bits in the TOS byte when encoding an iprule to match netlink's expectation.

Fixes: #13550 