### PR TITLE
pbrd: show '0' DSCP / ECN-based PBR Match

### DIFF
--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -1291,13 +1291,14 @@ static int pbr_vty_map_config_write_sequence(struct vty *vty,
 		vty_out(vty, " match ip-protocol %s\n", p->p_name);
 	}
 
-	if (pbrms->dsfield & PBR_DSFIELD_DSCP)
-		vty_out(vty, " match dscp %u\n",
-			(pbrms->dsfield & PBR_DSFIELD_DSCP) >> 2);
+	/*  As per RFC 3168 section 5, the ECN field in the IP header has two
+	 *  bits, allowing for four ECN codepoints from '00' to '11'. DSCP/ECN
+	 * with a value of 0 should be treated like any other value and its
+	 * valid. This also applies to  the 6 bits of DSCP in the IP header.*/
+	vty_out(vty, " match dscp %u\n",
+		(pbrms->dsfield & PBR_DSFIELD_DSCP) >> 2);
 
-	if (pbrms->dsfield & PBR_DSFIELD_ECN)
-		vty_out(vty, " match ecn %u\n",
-			pbrms->dsfield & PBR_DSFIELD_ECN);
+	vty_out(vty, " match ecn %u\n", pbrms->dsfield & PBR_DSFIELD_ECN);
 
 	if (pbrms->mark)
 		vty_out(vty, " match mark %u\n", pbrms->mark);


### PR DESCRIPTION
As per RFC rfc3168 section 5, the ECN field in the IP header has two bits,
 allowing for four ECN codepoints from '00' to '11'. DSCP/ECN with a value of 0
 should be treated like any other value. This also applies to the 6 bits of DSCP
 in the IP header.

    For example:

0 1 2 3 4 5 6 7
+-----+-----+-----+-----+-----+-----+-----+-----+
| DS FIELD, DSCP | ECN FIELD |
+-----+-----+-----+-----+-----+-----+-----+-----+
DSCP: differentiated services codepoint
ECN: Explicit Congestion Notification

There are four options of these two ECN bits
00 – Non-ECN Packet ==> still valid (0-3)
01 – ECN capable
10 – ECN capable
11 – Congestion experienced (CE)
Both 10 and 01 are same

Before fix:
pbr-map l3_intf_pbr_map seq 1
 match src-ip 191.1.1.1/24
exit
!

After fix:
pbr-map l3_intf_pbr_map seq 1
 match src-ip 191.1.1.1/24
 match dscp 0
 match ecn 0
exit
!