### PR TITLE
build: fix missing YANG model embedding

### DIFF
--- a/mgmtd/subdir.am
+++ b/mgmtd/subdir.am
@@ -57,12 +57,16 @@ sbin_PROGRAMS += mgmtd/mgmtd
 mgmtd_mgmtd_SOURCES = \
 	mgmtd/mgmt_main.c \
 	# end
+nodist_mgmtd_mgmtd_SOURCES = \
+	# nothing
 mgmtd_mgmtd_CFLAGS = $(AM_CFLAGS) -I ./
 mgmtd_mgmtd_LDADD = mgmtd/libmgmtd.a lib/libfrr.la $(LIBCAP) $(LIBM) $(LIBYANG_LIBS) $(UST_LIBS)
 mgmtd_mgmtd_LDADD += mgmtd/libmgmt_be_nb.la
 
 if STATICD
-$(mgmtd_mgmtd_OBJECTS): yang/frr-staticd.yang.c
-CLEANFILES += yang/frr-staticd.yang.c
+nodist_mgmtd_mgmtd_SOURCES += \
+	yang/frr-staticd.yang.c \
+	yang/frr-bfdd.yang.c \
+	# end
 nodist_mgmtd_libmgmt_be_nb_la_SOURCES += staticd/static_vty.c
 endif

--- a/ripd/subdir.am
+++ b/ripd/subdir.am
@@ -48,6 +48,7 @@ noinst_HEADERS += \
 ripd_ripd_LDADD = lib/libfrr.la $(LIBCAP)
 nodist_ripd_ripd_SOURCES = \
 	yang/frr-ripd.yang.c \
+	yang/frr-bfdd.yang.c \
 	# end
 
 ripd_ripd_snmp_la_SOURCES = ripd/rip_snmp.c


### PR DESCRIPTION
- mgmtd wasn't embedding `frr-staticd.yang` & `frr-bfdd.yang` (dependency), the Makefile-fu was a bit off
- ripd needs `frr-bfdd.yang` since the RIP model depends on it