### PR TITLE
bgpd: fix using bgp lu remote label when sending to ibgp peer

### DIFF
--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -94,9 +94,10 @@ mpls_label_t bgp_adv_label(struct bgp_dest *dest, struct bgp_path_info *pi,
 	reflect =
 		((from->sort == BGP_PEER_IBGP) && (to->sort == BGP_PEER_IBGP));
 
-	if (reflect
-	    && !CHECK_FLAG(to->af_flags[afi][safi],
-			   PEER_FLAG_FORCE_NEXTHOP_SELF))
+	if (reflect &&
+	    !CHECK_FLAG(to->af_flags[afi][safi],
+			PEER_FLAG_FORCE_NEXTHOP_SELF) &&
+	    !CHECK_FLAG(to->af_flags[afi][safi], PEER_FLAG_NEXTHOP_SELF))
 		return remote_label;
 
 	if (CHECK_FLAG(to->af_flags[afi][safi], PEER_FLAG_NEXTHOP_UNCHANGED))


### PR DESCRIPTION
When redistributing an advertisement from an EBGP peer to an IBGP peer, and the next-hop is kept unchanged, then the remote label should be used.

Fix this by not extending the route reflector case to the ebgp to ibgp redistribution.
Fixes: cd1964ff38bd ("bgpd: labeled unicast processing")