### PR TITLE
ospfd: fix interface param type update

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -1346,18 +1346,28 @@ static int ospf_ifp_create(struct interface *ifp)
 
 	if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
 		zlog_debug(
-			"Zebra: interface add %s vrf %s[%u] index %d flags %llx metric %d mtu %d speed %u",
+			"Zebra: interface add %s vrf %s[%u] index %d flags %llx metric %d mtu %d speed %u status 0x%x",
 			ifp->name, ifp->vrf->name, ifp->vrf->vrf_id,
 			ifp->ifindex, (unsigned long long)ifp->flags,
-			ifp->metric, ifp->mtu, ifp->speed);
+			ifp->metric, ifp->mtu, ifp->speed, ifp->status);
 
 	assert(ifp->info);
 
 	oii = ifp->info;
 	oii->curr_mtu = ifp->mtu;
 
-	if (IF_DEF_PARAMS(ifp)
-	    && !OSPF_IF_PARAM_CONFIGURED(IF_DEF_PARAMS(ifp), type)) {
+	/* Change ospf type param based on following
+	 * condition:
+	 * ospf type params is not set (first creation),
+	 * OR ospf param type is changed based on
+	 * link event, currently only handle for
+	 * loopback interface type, for other ospf interface,
+	 * type can be set from user config which needs to be
+	 * preserved.
+	 */
+	if (IF_DEF_PARAMS(ifp) &&
+	    (!OSPF_IF_PARAM_CONFIGURED(IF_DEF_PARAMS(ifp), type) ||
+	     if_is_loopback(ifp))) {
 		SET_IF_PARAM(IF_DEF_PARAMS(ifp), type);
 		IF_DEF_PARAMS(ifp)->type = ospf_default_iftype(ifp);
 	}


### PR DESCRIPTION
interface link update event needs to be handle properly in ospf interface cache.

Example:
When vrf (interface) is created its default type would be set to BROADCAST because ifp->status
is not set to VRF. Subsequent link event sets ifp->status to vrf,
ospf interface update need to compare current type to new default type which would be VRF (OSPF_IFTYPE_LOOPBACK). Since ospf type param was created in first add event, ifp vrf link event didn't update ospf type param which leads to treat vrf as non loopback interface.


**Testing Done:**

Running config suppose to bypass rendering default network broadcast for loopback/vrf types.

Before fix:

vrf vrf1
 vni 4001
exit-vrf
!
interface vrf1
 ip ospf network broadcast
exit

After fix: (interface vrf1 is not displayed).

vrf vrf1
 vni 4001
exit-vrf