### PR TITLE
pimd: Fix missing pimreg interface

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1495,9 +1495,16 @@ void pim_if_create_pimreg(struct pim_instance *pim)
 					       pim->vrf->name);
 		pim->regiface->ifindex = PIM_OIF_PIM_REGISTER_VIF;
 
-		if (!pim->regiface->info)
-			pim_if_new(pim->regiface, false, false, true,
-				   false /*vxlan_term*/);
+		/*
+		 * The pimreg interface might has been removed from
+		 * kerenl with the VRF's deletion.  It must be
+		 * recreated, so delete the old one first.
+		 */
+		if (pim->regiface->info)
+			pim_if_delete(pim->regiface);
+
+		pim_if_new(pim->regiface, false, false, true,
+			   false /*vxlan_term*/);
 
 		/*
 		 * On vrf moves we delete the interface if there


### PR DESCRIPTION
`pimregX` of specific vrf can be deleted from kernel after this vrf                                                                                                          
is deleted.  However, then `pimdregX` will never come back to                    
kernel after adding it ( the same vrf ) back.  That is to say, it exists            
only in daemon, but not in kernel.                                               
                                                                                 
The root cause is this `pimregX` is not really deleted for its special              
usage, and `pim_if_create_pimreg()` wants reusing it.                            
                                                                                 
I have tried 4 solutions:                                                        
1. Remove the `configured` flag of `pimregX`, allow its deletion.                
A few timers still use `pimregX` after its deletion.  So, not adopted.              
2. Remove `pimregX` by vrf hook in `pim_instance_terminate()`.                   
It has no vrf id there, (and it maybe already is moved to default VRF).  So, not adopted.                                        
3. Reuse `pimregX` in `pim_if_create_pimreg()`.                                  
If `pim->regiface->info` is true, then reuse old `pimregX` and only call            
`pim_if_add_vif()` to install it into kernel.  But at that time, it maybe           
is in default VRF.  The `pim_zebra_interface_set_master()` doesn't work             
at that time because it shouldn't wait there for its changing into               
correct VRF.  So, not adopted.                                                   
4. Not reuse it.                                                                 
If `pim->regiface->info` is true, there must have been pim instance with            
VRF deleted and created before.  Actually delele old one in                      
`pim_if_create_pimreg()`, then recreate new one.                                 
                                                                                 
Finally, this PR adopted the fourth solution.                                    
                                                                                 
Fixes #13454