### PR TITLE
tests: fix some broken logging

### DIFF
--- a/tests/topotests/lib/micronet_compat.py
+++ b/tests/topotests/lib/micronet_compat.py
@@ -121,7 +121,7 @@ class Mininet(BaseMunet):
 
     g_mnet_inst = None
 
-    def __init__(self, rundir=None, pytestconfig=None):
+    def __init__(self, rundir=None, pytestconfig=None, logger=None):
         """
         Create a Micronet.
         """
@@ -140,7 +140,7 @@ class Mininet(BaseMunet):
         # os.umask(0)
 
         super(Mininet, self).__init__(
-            pid=False, rundir=rundir, pytestconfig=pytestconfig
+            pid=False, rundir=rundir, pytestconfig=pytestconfig, logger=logger
         )
 
         # From munet/munet/native.py

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -84,7 +84,7 @@ def get_exabgp_cmd(commander=None):
     """Return the command to use for ExaBGP version < 4."""
 
     if commander is None:
-        commander = Commander("topogen")
+        commander = Commander("exabgp", logger=logging.getLogger("exabgp"))
 
     def exacmd_version_ok(exacmd):
         logger.debug("checking %s for exabgp < version 4", exacmd)
@@ -107,7 +107,7 @@ def get_exabgp_cmd(commander=None):
         exacmd = py2_path + " -m exabgp"
         if exacmd_version_ok(exacmd):
             return exacmd
-    py2_path = commander.get_exec_path("python")
+        py2_path = commander.get_exec_path("python")
     if py2_path:
         exacmd = py2_path + " -m exabgp"
         if exacmd_version_ok(exacmd):
@@ -209,7 +209,11 @@ class Topogen(object):
         # Mininet(Micronet) to build the actual topology.
         assert not inspect.isclass(topodef)
 
-        self.net = Mininet(rundir=self.logdir, pytestconfig=topotest.g_pytest_config)
+        self.net = Mininet(
+            rundir=self.logdir,
+            pytestconfig=topotest.g_pytest_config,
+            logger=topolog.get_logger("mu", log_level="debug"),
+        )
 
         # Adjust the parent namespace
         topotest.fix_netns_limits(self.net)
@@ -1090,8 +1094,9 @@ class TopoSwitch(TopoGear):
     # pylint: disable=too-few-public-methods
 
     def __init__(self, tgen, name, **params):
+        logger = topolog.get_logger(name, log_level="debug")
         super(TopoSwitch, self).__init__(tgen, name, **params)
-        tgen.net.add_switch(name)
+        tgen.net.add_switch(name, logger=logger)
 
     def __str__(self):
         gear = super(TopoSwitch, self).__str__()

--- a/tests/topotests/lib/topolog.py
+++ b/tests/topotests/lib/topolog.py
@@ -15,13 +15,6 @@ This file defines our logging abstraction.
 
 import logging
 import os
-import subprocess
-import sys
-
-if sys.version_info[0] > 2:
-    pass
-else:
-    pass
 
 try:
     from xdist import is_xdist_controller
@@ -30,8 +23,6 @@ except ImportError:
     def is_xdist_controller():
         return False
 
-
-BASENAME = "topolog"
 
 # Helper dictionary to convert Topogen logging levels to Python's logging.
 DEBUG_TOPO2LOGGING = {
@@ -42,13 +33,43 @@ DEBUG_TOPO2LOGGING = {
     "error": logging.ERROR,
     "critical": logging.CRITICAL,
 }
-FORMAT = "%(asctime)s.%(msecs)03d %(levelname)s: %(name)s: %(message)s"
+FORMAT = "%(asctime)s %(levelname)s: %(name)s: %(message)s"
 
 handlers = {}
-logger = logging.getLogger("topolog")
+logger = logging.getLogger("topo")
 
 
-def set_handler(l, target=None):
+# Remove this and use munet version when we move to pytest_asyncio
+def get_test_logdir(nodeid=None, module=False):
+    """Get log directory relative pathname."""
+    xdist_worker = os.getenv("PYTEST_XDIST_WORKER", "")
+    mode = os.getenv("PYTEST_XDIST_MODE", "no")
+
+    # nodeid: all_protocol_startup/test_all_protocol_startup.py::test_router_running
+    # may be missing "::testname" if module is True
+    if not nodeid:
+        nodeid = os.environ["PYTEST_CURRENT_TEST"].split(" ")[0]
+
+    cur_test = nodeid.replace("[", "_").replace("]", "_")
+    if module:
+        idx = cur_test.rfind("::")
+        path = cur_test if idx == -1 else cur_test[:idx]
+        testname = ""
+    else:
+        path, testname = cur_test.split("::")
+        testname = testname.replace("/", ".")
+    path = path[:-3].replace("/", ".")
+
+    # We use different logdir paths based on how xdist is running.
+    if mode == "each":
+        if module:
+            return os.path.join(path, "worker-logs", xdist_worker)
+        return os.path.join(path, testname, xdist_worker)
+    assert mode in ("no", "load", "loadfile", "loadscope"), f"Unknown dist mode {mode}"
+    return path if module else os.path.join(path, testname)
+
+
+def set_handler(lg, target=None):
     if target is None:
         h = logging.NullHandler()
     else:
@@ -59,106 +80,81 @@ def set_handler(l, target=None):
         h.setFormatter(logging.Formatter(fmt=FORMAT))
     # Don't filter anything at the handler level
     h.setLevel(logging.DEBUG)
-    l.addHandler(h)
+    lg.addHandler(h)
     return h
 
 
-def set_log_level(l, level):
+def set_log_level(lg, level):
     "Set the logging level."
     # Messages sent to this logger only are created if this level or above.
     log_level = DEBUG_TOPO2LOGGING.get(level, level)
-    l.setLevel(log_level)
+    lg.setLevel(log_level)
 
 
-def get_logger(name, log_level=None, target=None):
-    l = logging.getLogger("{}.{}".format(BASENAME, name))
+def reset_logger(lg):
+    while lg.handlers:
+        x = lg.handlers.pop()
+        x.close()
+        lg.removeHandler(x)
+
+
+def get_logger(name, log_level=None, target=None, reset=True):
+    lg = logging.getLogger(name)
+
+    if reset:
+        reset_logger(lg)
 
     if log_level is not None:
-        set_log_level(l, log_level)
+        set_log_level(lg, log_level)
 
     if target is not None:
-        set_handler(l, target)
+        set_handler(lg, target)
 
-    return l
-
-
-# nodeid: all_protocol_startup/test_all_protocol_startup.py::test_router_running
+    return lg
 
 
-def get_test_logdir(nodeid=None):
-    """Get log directory relative pathname."""
-    xdist_worker = os.getenv("PYTEST_XDIST_WORKER", "")
-    mode = os.getenv("PYTEST_XDIST_MODE", "no")
-
-    if not nodeid:
-        nodeid = os.environ["PYTEST_CURRENT_TEST"].split(" ")[0]
-
-    cur_test = nodeid.replace("[", "_").replace("]", "_")
-    path, testname = cur_test.split("::")
-    path = path[:-3].replace("/", ".")
-
-    # We use different logdir paths based on how xdist is running.
-    if mode == "each":
-        return os.path.join(path, testname, xdist_worker)
-    elif mode == "load":
-        return os.path.join(path, testname)
-    else:
-        assert (
-            mode == "no" or mode == "loadfile" or mode == "loadscope"
-        ), "Unknown dist mode {}".format(mode)
-
-        return path
-
-
-def logstart(nodeid, location, rundir):
+def logstart(nodeid, logpath):
     """Called from pytest before module setup."""
-
-    mode = os.getenv("PYTEST_XDIST_MODE", "no")
     worker = os.getenv("PYTEST_TOPOTEST_WORKER", "")
-
-    # We only per-test log in the workers (or non-dist)
-    if not worker and mode != "no":
-        return
-
+    wstr = f" on worker {worker}" if worker else ""
     handler_id = nodeid + worker
-    assert handler_id not in handlers
+    logpath = logpath.absolute()
 
-    rel_log_dir = get_test_logdir(nodeid)
-    exec_log_dir = os.path.join(rundir, rel_log_dir)
-    subprocess.check_call(
-        "mkdir -p {0} && chmod 1777 {0}".format(exec_log_dir), shell=True
-    )
-    exec_log_path = os.path.join(exec_log_dir, "exec.log")
+    logging.debug("logstart: adding logging for %s%s at %s", nodeid, wstr, logpath)
+    root_logger = logging.getLogger()
+    handler = logging.FileHandler(logpath, mode="w")
+    handler.setFormatter(logging.Formatter(FORMAT))
 
-    # Add test based exec log handler
-    h = set_handler(logger, exec_log_path)
-    handlers[handler_id] = h
+    root_logger.addHandler(handler)
+    handlers[handler_id] = handler
 
-    if worker:
-        logger.info(
-            "Logging on worker %s for %s into %s", worker, handler_id, exec_log_path
-        )
-    else:
-        logger.info("Logging for %s into %s", handler_id, exec_log_path)
+    logging.debug("logstart: added logging for %s%s at %s", nodeid, wstr, logpath)
+    return handler
 
 
-def logfinish(nodeid, location):
+def logfinish(nodeid, logpath):
     """Called from pytest after module teardown."""
-    # This function may not be called if pytest is interrupted.
-
     worker = os.getenv("PYTEST_TOPOTEST_WORKER", "")
+    wstr = f" on worker {worker}" if worker else ""
+
+    root_logger = logging.getLogger()
+
     handler_id = nodeid + worker
 
-    if handler_id in handlers:
-        # Remove test based exec log handler
-        if worker:
-            logger.info("Closing logs for %s", handler_id)
-
+    if handler_id not in handlers:
+        logging.critical("can't find log handler to remove")
+    else:
+        logging.debug(
+            "logfinish: removing logging for %s%s at %s", nodeid, wstr, logpath
+        )
         h = handlers[handler_id]
-        logger.removeHandler(handlers[handler_id])
+        root_logger.removeHandler(h)
         h.flush()
         h.close()
         del handlers[handler_id]
+        logging.debug(
+            "logfinish: removed logging for %s%s at %s", nodeid, wstr, logpath
+        )
 
 
 console_handler = set_handler(logger, None)

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import logging
 from collections.abc import Mapping
 from copy import deepcopy
 
@@ -38,7 +39,7 @@ g_pytest_config = None
 
 
 def get_logs_path(rundir):
-    logspath = topolog.get_test_logdir()
+    logspath = topolog.get_test_logdir(module=True)
     return os.path.join(rundir, logspath)
 
 
@@ -1137,7 +1138,9 @@ def _sysctl_assure(commander, variable, value):
 def sysctl_atleast(commander, variable, min_value, raises=False):
     try:
         if commander is None:
-            commander = micronet.Commander("topotest")
+            logger = logging.getLogger("topotest")
+            commander = micronet.Commander("sysctl", logger=logger)
+
         return _sysctl_atleast(commander, variable, min_value)
     except subprocess.CalledProcessError as error:
         logger.warning(
@@ -1153,7 +1156,8 @@ def sysctl_atleast(commander, variable, min_value, raises=False):
 def sysctl_assure(commander, variable, value, raises=False):
     try:
         if commander is None:
-            commander = micronet.Commander("topotest")
+            logger = logging.getLogger("topotest")
+            commander = micronet.Commander("sysctl", logger=logger)
         return _sysctl_assure(commander, variable, value)
     except subprocess.CalledProcessError as error:
         logger.warning(


### PR DESCRIPTION
- test module level exec.log no longer truncated to last test case output
- keep separate exec logs for each pytest worker when running in distributed mode
- cleanup the log names, and make sure they are present in all exec logs
- add per test case exec logs