### PR TITLE
zebra: Delete the 'mbr_zifs' list in the if_zebra_delete_hook function 

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -200,6 +200,7 @@ static void if_nhg_dependents_release(const struct interface *ifp)
 static int if_zebra_delete_hook(struct interface *ifp)
 {
 	struct zebra_if *zebra_if;
+	struct zebra_l2info_bond *bond;
 
 	if (ifp->info) {
 		zebra_if = ifp->info;
@@ -216,6 +217,10 @@ static int if_zebra_delete_hook(struct interface *ifp)
 			route_table_finish(zebra_if->ipv4_subnets);
 
 		rtadv_if_fini(zebra_if);
+
+		bond = &zebra_if->bond_info;
+		if (bond && bond->mbr_zifs)
+			list_delete(&bond->mbr_zifs);
 
 		zebra_l2_bridge_if_cleanup(ifp);
 		zebra_evpn_if_cleanup(zebra_if);


### PR DESCRIPTION
This commit addresses a memory leak issue detected by ASan associated with the member lists (mbr_zifs) of bond interfaces.
Previously, the member lists were not properly deleted during interface deletion, leading to memory leaks.
A call to list_delete() is made when interface is deleted.

The ASan leak log for reference:

```
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047:Direct leak of 80 byte(s) in 2 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    #0 0x7fe7a5b9d037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/pull/1 0x7fe7a57431ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/issues/2 0x7fe7a571833c in list_new lib/linklist.c:49
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/issues/3 0x55c1b87a7525 in zebra_l2if_update_bond zebra/zebra_l2.c:223
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/issues/4 0x55c1b86e044d in netlink_interface zebra/if_netlink.c:1203
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/pull/5 0x55c1b870fbcf in netlink_parse_info zebra/kernel_netlink.c:1183
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/pull/6 0x55c1b86e0cc1 in interface_lookup_netlink zebra/if_netlink.c:1273
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/pull/7 0x55c1b86e8b27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/pull/8 0x55c1b8817a77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/issues/9 0x55c1b8817e76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/pull/10 0x55c1b8717b38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/issues/11 0x7fe7a5231d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047:Indirect leak of 48 byte(s) in 2 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    #0 0x7fe7a5b9d037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/pull/1 0x7fe7a57431ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/issues/2 0x7fe7a571843d in listnode_new lib/linklist.c:71
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/issues/3 0x7fe7a5718780 in listnode_add lib/linklist.c:92
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/issues/4 0x55c1b87a6fdf in zebra_l2_map_slave_to_bond zebra/zebra_l2.c:168
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/pull/5 0x55c1b86f177d in zebra_if_update_all_links zebra/interface.c:1150
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/pull/6 0x55c1b86e0d51 in interface_lookup_netlink zebra/if_netlink.c:1303
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/pull/7 0x55c1b86e8b27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/pull/8 0x55c1b8817a77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/issues/9 0x55c1b8817e76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/pull/10 0x55c1b8717b38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-    https://github.com/FRRouting/frr/issues/11 0x7fe7a5231d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-
./bgp_evpn_mh.test_evpn_mh/torm12.zebra.asan.662047-SUMMARY: AddressSanitizer: 128 byte(s) leaked in 4 allocation(s).
--
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918:Direct leak of 80 byte(s) in 2 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    #0 0x7fd8c357f037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/pull/1 0x7fd8c31251ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/issues/2 0x7fd8c30fa33c in list_new lib/linklist.c:49
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/issues/3 0x56101df23525 in zebra_l2if_update_bond zebra/zebra_l2.c:223
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/issues/4 0x56101de5c44d in netlink_interface zebra/if_netlink.c:1203
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/pull/5 0x56101de8bbcf in netlink_parse_info zebra/kernel_netlink.c:1183
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/pull/6 0x56101de5ccc1 in interface_lookup_netlink zebra/if_netlink.c:1273
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/pull/7 0x56101de64b27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/pull/8 0x56101df93a77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/issues/9 0x56101df93e76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/pull/10 0x56101de93b38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/issues/11 0x7fd8c2c13d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918:Indirect leak of 48 byte(s) in 2 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    #0 0x7fd8c357f037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/pull/1 0x7fd8c31251ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/issues/2 0x7fd8c30fa43d in listnode_new lib/linklist.c:71
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/issues/3 0x7fd8c30fa780 in listnode_add lib/linklist.c:92
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/issues/4 0x56101df22fdf in zebra_l2_map_slave_to_bond zebra/zebra_l2.c:168
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/pull/5 0x56101de6d77d in zebra_if_update_all_links zebra/interface.c:1150
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/pull/6 0x56101de5cd51 in interface_lookup_netlink zebra/if_netlink.c:1303
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/pull/7 0x56101de64b27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/pull/8 0x56101df93a77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/issues/9 0x56101df93e76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/pull/10 0x56101de93b38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-    https://github.com/FRRouting/frr/issues/11 0x7fd8c2c13d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-
./bgp_evpn_mh.test_evpn_mh/torm21.zebra.asan.663918-SUMMARY: AddressSanitizer: 128 byte(s) leaked in 4 allocation(s).
--
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815:Direct leak of 80 byte(s) in 2 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    #0 0x7ff74228b037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/pull/1 0x7ff741e311ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/issues/2 0x7ff741e0633c in list_new lib/linklist.c:49
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/issues/3 0x56535dceb525 in zebra_l2if_update_bond zebra/zebra_l2.c:223
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/issues/4 0x56535dc2444d in netlink_interface zebra/if_netlink.c:1203
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/pull/5 0x56535dc53bcf in netlink_parse_info zebra/kernel_netlink.c:1183
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/pull/6 0x56535dc24cc1 in interface_lookup_netlink zebra/if_netlink.c:1273
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/pull/7 0x56535dc2cb27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/pull/8 0x56535dd5ba77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/issues/9 0x56535dd5be76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/pull/10 0x56535dc5bb38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/issues/11 0x7ff74191fd09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815:Indirect leak of 48 byte(s) in 2 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    #0 0x7ff74228b037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/pull/1 0x7ff741e311ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/issues/2 0x7ff741e0643d in listnode_new lib/linklist.c:71
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/issues/3 0x7ff741e06780 in listnode_add lib/linklist.c:92
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/issues/4 0x56535dceafdf in zebra_l2_map_slave_to_bond zebra/zebra_l2.c:168
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/pull/5 0x56535dc3577d in zebra_if_update_all_links zebra/interface.c:1150
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/pull/6 0x56535dc24d51 in interface_lookup_netlink zebra/if_netlink.c:1303
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/pull/7 0x56535dc2cb27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/pull/8 0x56535dd5ba77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/issues/9 0x56535dd5be76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/pull/10 0x56535dc5bb38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-    https://github.com/FRRouting/frr/issues/11 0x7ff74191fd09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-
./bgp_evpn_mh.test_evpn_mh/torm11.zebra.asan.660815-SUMMARY: AddressSanitizer: 128 byte(s) leaked in 4 allocation(s).
--
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685:Direct leak of 40 byte(s) in 1 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    #0 0x7fb3bf09f037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/pull/1 0x7fb3bec451ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/issues/2 0x7fb3bec1a33c in list_new lib/linklist.c:49
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/issues/3 0x559e90ee6525 in zebra_l2if_update_bond zebra/zebra_l2.c:223
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/issues/4 0x559e90e1f44d in netlink_interface zebra/if_netlink.c:1203
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/pull/5 0x559e90e4ebcf in netlink_parse_info zebra/kernel_netlink.c:1183
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/pull/6 0x559e90e1fcc1 in interface_lookup_netlink zebra/if_netlink.c:1273
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/pull/7 0x559e90e27b27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/pull/8 0x559e90f56a77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/issues/9 0x559e90f56e76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/pull/10 0x559e90e56b38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/issues/11 0x7fb3be733d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685:Indirect leak of 48 byte(s) in 2 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    #0 0x7fb3bf09f037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/pull/1 0x7fb3bec451ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/issues/2 0x7fb3bec1a43d in listnode_new lib/linklist.c:71
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/issues/3 0x7fb3bec1a780 in listnode_add lib/linklist.c:92
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/issues/4 0x559e90ee5fdf in zebra_l2_map_slave_to_bond zebra/zebra_l2.c:168
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/pull/5 0x559e90e3077d in zebra_if_update_all_links zebra/interface.c:1150
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/pull/6 0x559e90e1fd51 in interface_lookup_netlink zebra/if_netlink.c:1303
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/pull/7 0x559e90e27b27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/pull/8 0x559e90f56a77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/issues/9 0x559e90f56e76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/pull/10 0x559e90e56b38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-    https://github.com/FRRouting/frr/issues/11 0x7fb3be733d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-
./bgp_evpn_mh.test_evpn_mh/hostd12.zebra.asan.667685-SUMMARY: AddressSanitizer: 88 byte(s) leaked in 3 allocation(s).
--
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560:Direct leak of 40 byte(s) in 1 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    #0 0x7faab58d4037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/pull/1 0x7faab547a1ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/issues/2 0x7faab544f33c in list_new lib/linklist.c:49
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/issues/3 0x5599ef7e5525 in zebra_l2if_update_bond zebra/zebra_l2.c:223
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/issues/4 0x5599ef71e44d in netlink_interface zebra/if_netlink.c:1203
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/pull/5 0x5599ef74dbcf in netlink_parse_info zebra/kernel_netlink.c:1183
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/pull/6 0x5599ef71ecc1 in interface_lookup_netlink zebra/if_netlink.c:1273
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/pull/7 0x5599ef726b27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/pull/8 0x5599ef855a77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/issues/9 0x5599ef855e76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/pull/10 0x5599ef755b38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/issues/11 0x7faab4f68d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560:Indirect leak of 48 byte(s) in 2 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    #0 0x7faab58d4037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/pull/1 0x7faab547a1ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/issues/2 0x7faab544f43d in listnode_new lib/linklist.c:71
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/issues/3 0x7faab544f780 in listnode_add lib/linklist.c:92
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/issues/4 0x5599ef7e4fdf in zebra_l2_map_slave_to_bond zebra/zebra_l2.c:168
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/pull/5 0x5599ef72f77d in zebra_if_update_all_links zebra/interface.c:1150
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/pull/6 0x5599ef71ed51 in interface_lookup_netlink zebra/if_netlink.c:1303
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/pull/7 0x5599ef726b27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/pull/8 0x5599ef855a77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/issues/9 0x5599ef855e76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/pull/10 0x5599ef755b38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-    https://github.com/FRRouting/frr/issues/11 0x7faab4f68d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-
./bgp_evpn_mh.test_evpn_mh/hostd22.zebra.asan.670560-SUMMARY: AddressSanitizer: 88 byte(s) leaked in 3 allocation(s).
--
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413:Direct leak of 80 byte(s) in 2 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    #0 0x7fc5e175f037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/pull/1 0x7fc5e13051ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/issues/2 0x7fc5e12da33c in list_new lib/linklist.c:49
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/issues/3 0x55e090b90525 in zebra_l2if_update_bond zebra/zebra_l2.c:223
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/issues/4 0x55e090ac944d in netlink_interface zebra/if_netlink.c:1203
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/pull/5 0x55e090af8bcf in netlink_parse_info zebra/kernel_netlink.c:1183
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/pull/6 0x55e090ac9cc1 in interface_lookup_netlink zebra/if_netlink.c:1273
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/pull/7 0x55e090ad1b27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/pull/8 0x55e090c00a77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/issues/9 0x55e090c00e76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/pull/10 0x55e090b00b38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/issues/11 0x7fc5e0df3d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413:Indirect leak of 48 byte(s) in 2 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    #0 0x7fc5e175f037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/pull/1 0x7fc5e13051ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/issues/2 0x7fc5e12da43d in listnode_new lib/linklist.c:71
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/issues/3 0x7fc5e12da780 in listnode_add lib/linklist.c:92
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/issues/4 0x55e090b8ffdf in zebra_l2_map_slave_to_bond zebra/zebra_l2.c:168
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/pull/5 0x55e090ada77d in zebra_if_update_all_links zebra/interface.c:1150
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/pull/6 0x55e090ac9d51 in interface_lookup_netlink zebra/if_netlink.c:1303
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/pull/7 0x55e090ad1b27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/pull/8 0x55e090c00a77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/issues/9 0x55e090c00e76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/pull/10 0x55e090b00b38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-    https://github.com/FRRouting/frr/issues/11 0x7fc5e0df3d09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-
./bgp_evpn_mh.test_evpn_mh/torm22.zebra.asan.665413-SUMMARY: AddressSanitizer: 128 byte(s) leaked in 4 allocation(s).
--
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024:Direct leak of 40 byte(s) in 1 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    #0 0x7fe5c2019037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/pull/1 0x7fe5c1bbf1ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/issues/2 0x7fe5c1b9433c in list_new lib/linklist.c:49
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/issues/3 0x557ad92d0525 in zebra_l2if_update_bond zebra/zebra_l2.c:223
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/issues/4 0x557ad920944d in netlink_interface zebra/if_netlink.c:1203
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/pull/5 0x557ad9238bcf in netlink_parse_info zebra/kernel_netlink.c:1183
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/pull/6 0x557ad9209cc1 in interface_lookup_netlink zebra/if_netlink.c:1273
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/pull/7 0x557ad9211b27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/pull/8 0x557ad9340a77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/issues/9 0x557ad9340e76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/pull/10 0x557ad9240b38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/issues/11 0x7fe5c16add09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024:Indirect leak of 48 byte(s) in 2 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    #0 0x7fe5c2019037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/pull/1 0x7fe5c1bbf1ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/issues/2 0x7fe5c1b9443d in listnode_new lib/linklist.c:71
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/issues/3 0x7fe5c1b94780 in listnode_add lib/linklist.c:92
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/issues/4 0x557ad92cffdf in zebra_l2_map_slave_to_bond zebra/zebra_l2.c:168
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/pull/5 0x557ad921a77d in zebra_if_update_all_links zebra/interface.c:1150
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/pull/6 0x557ad9209d51 in interface_lookup_netlink zebra/if_netlink.c:1303
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/pull/7 0x557ad9211b27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/pull/8 0x557ad9340a77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/issues/9 0x557ad9340e76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/pull/10 0x557ad9240b38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-    https://github.com/FRRouting/frr/issues/11 0x7fe5c16add09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-
./bgp_evpn_mh.test_evpn_mh/hostd21.zebra.asan.669024-SUMMARY: AddressSanitizer: 88 byte(s) leaked in 3 allocation(s).
--
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551:Direct leak of 40 byte(s) in 1 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    #0 0x7f1fc2399037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/pull/1 0x7f1fc1f3f1ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/issues/2 0x7f1fc1f1433c in list_new lib/linklist.c:49
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/issues/3 0x559cd8f0b525 in zebra_l2if_update_bond zebra/zebra_l2.c:223
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/issues/4 0x559cd8e4444d in netlink_interface zebra/if_netlink.c:1203
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/pull/5 0x559cd8e73bcf in netlink_parse_info zebra/kernel_netlink.c:1183
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/pull/6 0x559cd8e44cc1 in interface_lookup_netlink zebra/if_netlink.c:1273
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/pull/7 0x559cd8e4cb27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/pull/8 0x559cd8f7ba77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/issues/9 0x559cd8f7be76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/pull/10 0x559cd8e7bb38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/issues/11 0x7f1fc1a2dd09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551:Indirect leak of 48 byte(s) in 2 object(s) allocated from:
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    #0 0x7f1fc2399037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/pull/1 0x7f1fc1f3f1ee in qcalloc lib/memory.c:105
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/issues/2 0x7f1fc1f1443d in listnode_new lib/linklist.c:71
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/issues/3 0x7f1fc1f14780 in listnode_add lib/linklist.c:92
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/issues/4 0x559cd8f0afdf in zebra_l2_map_slave_to_bond zebra/zebra_l2.c:168
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/pull/5 0x559cd8e5577d in zebra_if_update_all_links zebra/interface.c:1150
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/pull/6 0x559cd8e44d51 in interface_lookup_netlink zebra/if_netlink.c:1303
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/pull/7 0x559cd8e4cb27 in interface_list zebra/if_netlink.c:2419
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/pull/8 0x559cd8f7ba77 in zebra_ns_enable zebra/zebra_ns.c:113
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/issues/9 0x559cd8f7be76 in zebra_ns_init zebra/zebra_ns.c:205
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/pull/10 0x559cd8e7bb38 in main zebra/main.c:399
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-    https://github.com/FRRouting/frr/issues/11 0x7f1fc1a2dd09 in __libc_start_main ../csu/libc-start.c:308
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-
./bgp_evpn_mh.test_evpn_mh/hostd11.zebra.asan.666551-SUMMARY: AddressSanitizer: 88 byte(s) leaked in 3 allocation(s).
```