### PR TITLE
bgpd: fix flushing fifo when no space in stream

### DIFF
--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -761,7 +761,7 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 				/* Flush the FIFO update queue */
 				while (adv)
 					adv = bgp_advertise_clean_subgroup(
-						subgrp, adj);
+						subgrp, adv->adj);
 				return NULL;
 			}
 


### PR DESCRIPTION
The following crash happen when trying to send BGP Update from a subgroup when the stream is out of spaces:

> ==594613==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000030 (pc 0x56486652f11a bp 0x7ffefaef6140 sp 0x7ffefaef6110 T0)
> ==594613==The signal is caused by a READ memory access.
> ==594613==Hint: address points to the zero page.
>     #0 0x56486652f11a in bgp_advertise_clean_subgroup bgpd/bgp_updgrp_adv.c:449
>     #1 0x564866537019 in subgroup_update_packet bgpd/bgp_updgrp_packet.c:778
>     #2 0x56486646d24c in bgp_generate_updgrp_packets bgpd/bgp_packet.c:439
>     #3 0x7fc00dcb14b0 in thread_call lib/thread.c:1825
>     #4 0x7fc00dbcbf92 in frr_run lib/libfrr.c:1155
>     #5 0x56486634108e in main bgpd/bgp_main.c:570
>     #6 0x7fc00d70bd09 in __libc_start_main ../csu/libc-start.c:308
>     #7 0x56486633d8a9 in _start (/usr/lib/frr/bgpd+0x2a58a9)

Crash at the following line in frame 0 because the 'adv' pointer is NULL:

> baa = adv->baa;

subgroup_update_packet() calls bgp_advertise_clean_subgroup() in a loop and provides adj. In the latter function, adv is get from adj->adv then adj->adv is set to NULL. The next call re-use the same adj and the crash occurs.

Update adj before each call.

Fixes: 3f9c7369f7 ("BGP: Add dynamic update group support")