### PR TITLE
pimd: Set pimreg interface with one master

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1674,7 +1674,9 @@ static int pim_ifp_up(struct interface *ifp)
 						__func__, vrf->name);
 					return 0;
 				}
+
 				pim_zebra_interface_set_master(master, ifp);
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
Add break for loop, `pimreg` interface should be with one master.