### PR TITLE
pimd: Fix wrong creating order for pimreg

### DIFF
--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -178,6 +178,8 @@ static int pim_vrf_enable(struct vrf *vrf)
 
 	zlog_debug("%s: for %s %u", __func__, vrf->name, vrf->vrf_id);
 
+	pim_mroute_socket_enable(pim);
+
 	FOR_ALL_INTERFACES (vrf, ifp) {
 		if (!ifp->info)
 			continue;
@@ -185,8 +187,6 @@ static int pim_vrf_enable(struct vrf *vrf)
 		pim_if_create_pimreg(pim);
 		break;
 	}
-
-	pim_mroute_socket_enable(pim);
 
 	return 0;
 }


### PR DESCRIPTION
`pim_if_create_pimreg()` need use the `mroute_socket`, so adjust the order. First call `pim_mroute_socket_enable()`, then call `pim_if_create_pimreg()`.