### PR TITLE
bgpd: fix bgpd core when unintern attr

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -4682,6 +4682,10 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer,
 		 * there! (JK)
 		 * Folks, talk to me: what is reasonable here!?
 		 */
+
+		/* Make sure dup aspath before the modification */
+		if (aspath == attr->aspath)
+			aspath = aspath_dup(attr->aspath);
 		aspath = aspath_delete_confed_seq(aspath);
 
 		stream_putc(s,


### PR DESCRIPTION
When the remote peer is neither EBGP nor confed, aspath is the shadow copy of attr->aspath in bgp_packet_attribute(). Striping AS4_PATH should not be done on the aspath directly, since that would lead to bgpd core dump when unintern the attr.