### PR TITLE
tests: Actually loop if ping fails

### DIFF
--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/test_bgp_srv6l3vpn_to_bgp_vrf3.py
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/test_bgp_srv6l3vpn_to_bgp_vrf3.py
@@ -98,7 +98,8 @@ def check_ping4(name, dest_addr, expect_connected):
         tgen = get_topogen()
         output = tgen.gears[name].run("ping {} -c 1 -w 1".format(dest_addr))
         logger.info(output)
-        assert match in output, "ping fail"
+        if match not in output:
+            return "ping fail"
 
     match = ", {} packet loss".format("0%" if expect_connected else "100%")
     logger.info("[+] check {} {} {}".format(name, dest_addr, match))


### PR DESCRIPTION
The usage of run_and_expect doesn't work if the function being called as the run part asserts.