### PR TITLE
lib: fix vtysh core when handling questionmark

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -735,9 +735,13 @@ char *cmd_variable_comp2str(vector comps, unsigned short cols)
 		char *item = vector_slot(comps, j);
 		itemlen = strlen(item);
 
-		if (cs + itemlen + AUTOCOMP_INDENT + 3 >= bsz)
-			buf = XREALLOC(MTYPE_TMP, buf, (bsz *= 2));
+		size_t next_sz = cs + itemlen + AUTOCOMP_INDENT + 3;
 
+		if (next_sz > bsz) {
+			/* Make sure the buf size is large enough */
+			bsz = next_sz;
+			buf = XREALLOC(MTYPE_TMP, buf, bsz);
+		}
 		if (lc + itemlen + 1 >= cols) {
 			cs += snprintf(&buf[cs], bsz - cs, "\n%*s",
 				       AUTOCOMP_INDENT, "");


### PR DESCRIPTION
When issue vtysh command with ?, the initial buf size for the element is 16. Then it would loop through each element in the cmd output vector. If the required size for printing out the next element is larger than the current buf size, realloc the buf memory by doubling the current buf size regardless of the actual size that's needed. This would cause vtysh core when the doubled size is not enough for the next element.