### PR TITLE
ospfd, ospf6d: fix time_t truncation

### DIFF
--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -239,7 +239,8 @@ static void ospf6_gr_restart_exit(struct ospf6 *ospf6, const char *reason)
 
 /* Enter the Graceful Restart mode. */
 void ospf6_gr_restart_enter(struct ospf6 *ospf6,
-			    enum ospf6_gr_restart_reason reason, int timestamp)
+			    enum ospf6_gr_restart_reason reason,
+			    time_t timestamp)
 {
 	unsigned long remaining_time;
 

--- a/ospf6d/ospf6_gr.h
+++ b/ospf6d/ospf6_gr.h
@@ -158,7 +158,7 @@ extern int config_write_ospf6_debug_gr_helper(struct vty *vty);
 extern void ospf6_gr_iface_send_grace_lsa(struct event *thread);
 extern void ospf6_gr_restart_enter(struct ospf6 *ospf6,
 				   enum ospf6_gr_restart_reason reason,
-				   int timestamp);
+				   time_t timestamp);
 extern void ospf6_gr_check_lsdb_consistency(struct ospf6 *ospf,
 					    struct ospf6_area *area);
 extern void ospf6_gr_nvm_read(struct ospf6 *ospf);

--- a/ospfd/ospf_gr.c
+++ b/ospfd/ospf_gr.c
@@ -282,7 +282,7 @@ static void ospf_gr_restart_exit(struct ospf *ospf, const char *reason)
 
 /* Enter the Graceful Restart mode. */
 void ospf_gr_restart_enter(struct ospf *ospf,
-			   enum ospf_gr_restart_reason reason, int timestamp)
+			   enum ospf_gr_restart_reason reason, time_t timestamp)
 {
 	unsigned long remaining_time;
 

--- a/ospfd/ospf_gr.h
+++ b/ospfd/ospf_gr.h
@@ -169,7 +169,7 @@ extern void ospf_gr_helper_set_supported_planned_only_restart(struct ospf *ospf,
 extern void ospf_gr_iface_send_grace_lsa(struct event *thread);
 extern void ospf_gr_restart_enter(struct ospf *ospf,
 				  enum ospf_gr_restart_reason reason,
-				  int timestamp);
+				  time_t timestamp);
 extern void ospf_gr_check_lsdb_consistency(struct ospf *ospf,
 						  struct ospf_area *area);
 extern void ospf_gr_check_adjs(struct ospf *ospf);


### PR DESCRIPTION
Change timestamp parameter from int to time_t to avoid truncation.

Found by Coverity Scan (CID 1563226 and 1563222)