### PR TITLE
bfdd: remove redundant nb destroy callbacks

### DIFF
--- a/bfdd/bfdd_nb.c
+++ b/bfdd/bfdd_nb.c
@@ -74,7 +74,6 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			.xpath = "/frr-bfdd:bfdd/bfd/profile/minimum-ttl",
 			.cbs = {
 				.modify = bfdd_bfd_profile_minimum_ttl_modify,
-				.destroy = bfdd_bfd_profile_minimum_ttl_destroy,
 				.cli_show = bfd_cli_show_minimum_ttl,
 			}
 		},
@@ -361,7 +360,6 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/minimum-ttl",
 			.cbs = {
 				.modify = bfdd_bfd_sessions_multi_hop_minimum_ttl_modify,
-				.destroy = bfdd_bfd_sessions_multi_hop_minimum_ttl_destroy,
 				.cli_show = bfd_cli_show_minimum_ttl,
 			}
 		},

--- a/bfdd/bfdd_nb.h
+++ b/bfdd/bfdd_nb.h
@@ -25,7 +25,6 @@ int bfdd_bfd_profile_required_receive_interval_modify(
 int bfdd_bfd_profile_administrative_down_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_passive_mode_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_minimum_ttl_modify(struct nb_cb_modify_args *args);
-int bfdd_bfd_profile_minimum_ttl_destroy(struct nb_cb_destroy_args *args);
 int bfdd_bfd_profile_echo_mode_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_desired_echo_transmission_interval_modify(
 	struct nb_cb_modify_args *args);
@@ -128,8 +127,6 @@ int bfdd_bfd_sessions_multi_hop_administrative_down_modify(
 	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_multi_hop_minimum_ttl_modify(
 	struct nb_cb_modify_args *args);
-int bfdd_bfd_sessions_multi_hop_minimum_ttl_destroy(
-	struct nb_cb_destroy_args *args);
 struct yang_data *
 bfdd_bfd_sessions_multi_hop_stats_local_discriminator_get_elem(
 	struct nb_cb_get_elem_args *args);

--- a/bfdd/bfdd_nb_config.c
+++ b/bfdd/bfdd_nb_config.c
@@ -423,20 +423,6 @@ int bfdd_bfd_profile_minimum_ttl_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
-int bfdd_bfd_profile_minimum_ttl_destroy(struct nb_cb_destroy_args *args)
-{
-	struct bfd_profile *bp;
-
-	if (args->event != NB_EV_APPLY)
-		return NB_OK;
-
-	bp = nb_running_get_entry(args->dnode, NULL, true);
-	bp->minimum_ttl = BFD_DEF_MHOP_TTL;
-	bfd_profile_update(bp);
-
-	return NB_OK;
-}
-
 /*
  * XPath: /frr-bfdd:bfdd/bfd/profile/echo-mode
  */
@@ -855,30 +841,6 @@ int bfdd_bfd_sessions_multi_hop_minimum_ttl_modify(
 
 	bs = nb_running_get_entry(args->dnode, NULL, true);
 	bs->peer_profile.minimum_ttl = yang_dnode_get_uint8(args->dnode, NULL);
-	bfd_session_apply(bs);
-
-	return NB_OK;
-}
-
-int bfdd_bfd_sessions_multi_hop_minimum_ttl_destroy(
-	struct nb_cb_destroy_args *args)
-{
-	struct bfd_session *bs;
-
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-		return NB_OK;
-
-	case NB_EV_APPLY:
-		break;
-
-	case NB_EV_ABORT:
-		return NB_OK;
-	}
-
-	bs = nb_running_get_entry(args->dnode, NULL, true);
-	bs->peer_profile.minimum_ttl = BFD_DEF_MHOP_TTL;
 	bfd_session_apply(bs);
 
 	return NB_OK;


### PR DESCRIPTION
Fixes warning logs:
```
2023/05/29 20:11:50 BFD: [ZKB8W-3S2Q4][EC 100663330] unneeded 'destroy' callback for '/frr-bfdd:bfdd/bfd/profile/minimum-ttl'
2023/05/29 20:11:50 BFD: [ZKB8W-3S2Q4][EC 100663330] unneeded 'destroy' callback for '/frr-bfdd:bfdd/bfd/sessions/multi-hop/minimum-ttl'
```