### PR TITLE
zebra: Unlock the route node when sending route notifications

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -465,6 +465,13 @@ extern uint8_t route_distance(int type);
 extern void zebra_rib_evaluate_rn_nexthops(struct route_node *rn, uint32_t seq,
 					   bool rt_delete);
 
+/*
+ * rib_find_rn_from_ctx
+ *
+ * Returns a lock increased route_node for the appropriate
+ * table and prefix specified by the context.  Developer
+ * should unlock the node when done.
+ */
 extern struct route_node *
 rib_find_rn_from_ctx(const struct zebra_dplane_ctx *ctx);
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -801,11 +801,17 @@ int zsend_route_notify_owner(const struct route_node *rn,
 int zsend_route_notify_owner_ctx(const struct zebra_dplane_ctx *ctx,
 				 enum zapi_route_notify_owner note)
 {
-	return (route_notify_internal(
-		rib_find_rn_from_ctx(ctx), dplane_ctx_get_type(ctx),
-		dplane_ctx_get_instance(ctx), dplane_ctx_get_vrf(ctx),
-		dplane_ctx_get_table(ctx), note, dplane_ctx_get_afi(ctx),
-		dplane_ctx_get_safi(ctx)));
+	int result;
+	struct route_node *rn = rib_find_rn_from_ctx(ctx);
+
+	result = route_notify_internal(
+		rn, dplane_ctx_get_type(ctx), dplane_ctx_get_instance(ctx),
+		dplane_ctx_get_vrf(ctx), dplane_ctx_get_table(ctx), note,
+		dplane_ctx_get_afi(ctx), dplane_ctx_get_safi(ctx));
+
+	route_unlock_node(rn);
+
+	return result;
 }
 
 static void zread_route_notify_request(ZAPI_HANDLER_ARGS)


### PR DESCRIPTION
When using a context to send route notifications to upper level protocols, the code was using a locking function to get the route node.  There is no need for this to be locked as such FRR should free it up.