### PR TITLE
bgpd: Fix typo in debug message

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -547,7 +547,7 @@ static void bgp_process_nexthop_update(struct bgp_nexthop_cache *bnc,
 		char bnc_buf[BNC_FLAG_DUMP_SIZE];
 
 		zlog_debug(
-			"%s(%u): Rcvd NH update %pFX(%u)%u) - metric %d/%d #nhops %d/%d flags %s",
+			"%s(%u): Rcvd NH update %pFX(%u)(%u) - metric %d/%d #nhops %d/%d flags %s",
 			bnc->bgp->name_pretty, bnc->bgp->vrf_id, &nhr->prefix,
 			bnc->ifindex, bnc->srte_color, nhr->metric, bnc->metric,
 			nhr->nexthop_num, bnc->nexthop_num,
@@ -849,7 +849,7 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 	if (!bnc_nhc) {
 		if (BGP_DEBUG(nht, NHT))
 			zlog_debug(
-				"parse nexthop update(%pFX(%u)(%s)): bnc info not found for nexthop cache",
+				"parse nexthop update %pFX(%u)(%s): bnc info not found for nexthop cache",
 				&nhr.prefix, nhr.srte_color, bgp->name_pretty);
 	} else
 		bgp_process_nexthop_update(bnc_nhc, &nhr, false);
@@ -860,7 +860,7 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 	if (!bnc_import) {
 		if (BGP_DEBUG(nht, NHT))
 			zlog_debug(
-				"parse nexthop update(%pFX(%u)(%s)): bnc info not found for import check",
+				"parse nexthop update %pFX(%u)(%s): bnc info not found for import check",
 				&nhr.prefix, nhr.srte_color, bgp->name_pretty);
 	} else
 		bgp_process_nexthop_update(bnc_import, &nhr, true);


### PR DESCRIPTION
Cosmetic change for the debug messages, mainly on the parentheses.

Before:
```
[ZJYCS-KQYD6] VRF vrf-debug(140): Rcvd NH update 50.50.50.0/24(0)0) - metric 300/300 #nhops 2/1 flags Valid Reg Static Static Exact
[VZJVD-D7GXM] parse nexthop update(50.50.50.0/24(0)(VRF vrf-debug)): bnc info not found for nexthop cache
[NSWTE-81HEK] parse nexthop update(50.50.201.0/31(0)(VRF vrf-debug)): bnc info not found for import check
```

After:
```
[ZJYCS-KQYD6] VRF vrf-debug(140): Rcvd NH update 50.50.50.0/24(0)(0) - metric 300/300 #nhops 2/1 flags Valid Reg Static Static Exact
[VZJVD-D7GXM] parse nexthop update 50.50.50.0/24(0)(VRF vrf-debug): bnc info not found for nexthop cache
[NSWTE-81HEK] parse nexthop update 50.50.201.0/31(0)(VRF vrf-debug): bnc info not found for import check
```