### PR TITLE
pimd: Change in PIM northbound error, when a path to RP is not found …

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -276,7 +276,7 @@ static int pim_rp_cmd_worker(struct pim_instance *pim, pim_addr rp_addr,
 	if (result == PIM_RP_NO_PATH) {
 		snprintfrr(errmsg, errmsg_len,
 			   "No Path to RP address specified: %pPA", &rp_addr);
-		return NB_ERR_INCONSISTENCY;
+		return NB_OK;
 	}
 
 	if (result == PIM_GROUP_OVERLAP) {


### PR DESCRIPTION
…during config apply

Currently, in PIM Northbound, when a path to RP is not found during config apply, we are treating this as a NB_ERR_INCONSISTENCY. However, there are two issues with this approach:

When OSPF or IGP convergence is completed, it is possible that the RPF check will succeed. If we have multiple groups and RPs (e.g. 50 RPs), we will receive 50 logs with inconsistency errors. example:

`2023/05/27 22:57:45 PIM: [G822R-SBMNH] config-from-file# ip pim rp 192.168.100.1 239.100.0.0/28 2023/05/27 22:57:45 PIM: [VAKV3-NMY7B][EC 100663337] error processing configuration change: error [internal inconsistency] event [apply] operation [create] xpath [/frr-routing:routing/control-plane-protocols/control-plane-protocol[type='frr-pim:pimd'] [name='pim'][vrf='default']/frr-pim:pim/address-family[address-family='frr-routing:ipv4']/frr-pim-rp:rp/static-rp/rp-list [rp-address='192.168.100.1']/group-list[.='239.100.0.0/28']] message: No Path to RP address specified: 192.168.100.1`

Fixes: #13620

Signed-off-by: Rajesh Varatharaj <rvaratharaj@nvidia.com>