### PR TITLE
babeld: add AE!=0 check when type is 7 or 10.

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -493,7 +493,7 @@ parse_packet(const unsigned char *from, struct interface *ifp,
             int rc;
             rc = network_address(message[2], message + 4, len - 2,
                                  nh);
-            if(rc < 0) {
+            if(rc <= 0) {
                 have_v4_nh = 0;
                 have_v6_nh = 0;
                 goto fail;
@@ -644,7 +644,7 @@ parse_packet(const unsigned char *from, struct interface *ifp,
             DO_NTOHS(seqno, message + 4);
             rc = network_prefix(message[2], message[3], 0,
                                 message + 16, NULL, len - 14, prefix);
-            if(rc < 0) goto fail;
+            if(rc <= 0) goto fail;
             plen = message[3] + (message[2] == 1 ? 96 : 0);
             debugf(BABEL_DEBUG_COMMON,"Received request (%d) for %s from %s on %s (%s, %d).",
                    message[6],


### PR DESCRIPTION
According to RFC8966:
AE cannot be 0 when type = 7(Next Hop) or 10(Seqno Request).
https://www.rfc-editor.org/rfc/rfc8966.html#name-tlv-format

Signed-off-by: zmw12306 <zmw12306@gmail.com>

Closes https://github.com/FRRouting/frr/issues/13671