### PR TITLE
bfd:fix version bits check

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -79,7 +79,7 @@ struct bfd_echo_pkt {
 
 
 /* Macros for manipulating control packets */
-#define BFD_VERMASK 0x03
+#define BFD_VERMASK 0x07
 #define BFD_DIAGMASK 0x1F
 #define BFD_GETVER(diag) ((diag >> 5) & BFD_VERMASK)
 #define BFD_SETVER(diag, val) ((diag) |= (val & BFD_VERMASK) << 5)


### PR DESCRIPTION
https://github.com/FRRouting/frr/blob/ff82184faebac4f7de68018c54f0f55da2ebcf37/bfdd/bfd_packet.c#L848-L852
BFD_GETVER: since the version of bad packet is represented by 3 bits in B[0], BFD_VERMASK should be 0x07, instead of 0x03.
https://github.com/FRRouting/frr/blob/ff82184faebac4f7de68018c54f0f55da2ebcf37/bfdd/bfd.h#L82-L84

Fixes https://github.com/FRRouting/frr/issues/13673