### PR TITLE
lib: mgmtd: remove obfuscating abstraction layer and other cleanup

### DIFF
--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -56,6 +56,9 @@ extern "C" {
 #define MGMTD_DS_OPERATIONAL MGMTD__DATASTORE_ID__OPERATIONAL_DS
 #define MGMTD_DS_MAX_ID MGMTD_DS_OPERATIONAL + 1
 
+struct mgmt_fe_client;
+
+
 /*
  * All the client specific information this library needs to
  * initialize itself, setup connection with MGMTD FrontEnd interface
@@ -66,52 +69,52 @@ extern "C" {
  * to initialize the library (See mgmt_fe_client_lib_init for
  * more details).
  */
-struct mgmt_fe_client_params {
-	char name[MGMTD_CLIENT_NAME_MAX_LEN];
-	uintptr_t user_data;
-	unsigned long conn_retry_intvl_sec;
+struct mgmt_fe_client_cbs {
+	void (*client_connect_notify)(struct mgmt_fe_client *client,
+				      uintptr_t user_data, bool connected);
 
-	void (*client_connect_notify)(uintptr_t lib_hndl,
-				      uintptr_t user_data,
-				      bool connected);
-
-	void (*client_session_notify)(uintptr_t lib_hndl,
-				      uintptr_t user_data,
-				      uint64_t client_id,
+	void (*client_session_notify)(struct mgmt_fe_client *client,
+				      uintptr_t user_data, uint64_t client_id,
 				      bool create, bool success,
 				      uintptr_t session_id,
-				      uintptr_t user_session_ctx);
+				      uintptr_t user_session_client);
 
-	void (*lock_ds_notify)(uintptr_t lib_hndl, uintptr_t user_data,
-			       uint64_t client_id, uintptr_t session_id,
-			       uintptr_t user_session_ctx, uint64_t req_id,
+	void (*lock_ds_notify)(struct mgmt_fe_client *client,
+			       uintptr_t user_data, uint64_t client_id,
+			       uintptr_t session_id,
+			       uintptr_t user_session_client, uint64_t req_id,
 			       bool lock_ds, bool success,
 			       Mgmtd__DatastoreId ds_id, char *errmsg_if_any);
 
-	void (*set_config_notify)(uintptr_t lib_hndl, uintptr_t user_data,
-				  uint64_t client_id, uintptr_t session_id,
-				  uintptr_t user_session_ctx, uint64_t req_id,
-				  bool success, Mgmtd__DatastoreId ds_id,
+	void (*set_config_notify)(struct mgmt_fe_client *client,
+				  uintptr_t user_data, uint64_t client_id,
+				  uintptr_t session_id,
+				  uintptr_t user_session_client,
+				  uint64_t req_id, bool success,
+				  Mgmtd__DatastoreId ds_id,
 				  char *errmsg_if_any);
 
-	void (*commit_config_notify)(
-		uintptr_t lib_hndl, uintptr_t user_data, uint64_t client_id,
-		uintptr_t session_id, uintptr_t user_session_ctx,
-		uint64_t req_id, bool success, Mgmtd__DatastoreId src_ds_id,
-		Mgmtd__DatastoreId dst_ds_id, bool validate_only,
-		char *errmsg_if_any);
+	void (*commit_config_notify)(struct mgmt_fe_client *client,
+				     uintptr_t user_data, uint64_t client_id,
+				     uintptr_t session_id,
+				     uintptr_t user_session_client,
+				     uint64_t req_id, bool success,
+				     Mgmtd__DatastoreId src_ds_id,
+				     Mgmtd__DatastoreId dst_ds_id,
+				     bool validate_only, char *errmsg_if_any);
 
-	enum mgmt_result (*get_data_notify)(
-		uintptr_t lib_hndl, uintptr_t user_data, uint64_t client_id,
-		uintptr_t session_id, uintptr_t user_session_ctx,
-		uint64_t req_id, bool success, Mgmtd__DatastoreId ds_id,
-		Mgmtd__YangData **yang_data, size_t num_data, int next_key,
-		char *errmsg_if_any);
+	int (*get_data_notify)(struct mgmt_fe_client *client,
+			       uintptr_t user_data, uint64_t client_id,
+			       uintptr_t session_id,
+			       uintptr_t user_session_client, uint64_t req_id,
+			       bool success, Mgmtd__DatastoreId ds_id,
+			       Mgmtd__YangData **yang_data, size_t num_data,
+			       int next_key, char *errmsg_if_any);
 
-	enum mgmt_result (*data_notify)(
-		uint64_t client_id, uint64_t session_id, uintptr_t user_data,
-		uint64_t req_id, Mgmtd__DatastoreId ds_id,
-		Mgmtd__YangData **yang_data, size_t num_data);
+	int (*data_notify)(uint64_t client_id, uint64_t session_id,
+			   uintptr_t user_data, uint64_t req_id,
+			   Mgmtd__DatastoreId ds_id,
+			   Mgmtd__YangData **yang_data, size_t num_data);
 };
 
 extern struct debug mgmt_dbg_fe_client;
@@ -139,17 +142,18 @@ extern struct debug mgmt_dbg_fe_client;
  *    Thread master.
  *
  * Returns:
- *    Frontend client lib handler (nothing but address of mgmt_fe_client_ctx)
+ *    Frontend client lib handler (nothing but address of mgmt_fe_client)
  */
-extern uintptr_t mgmt_fe_client_lib_init(struct mgmt_fe_client_params *params,
-					 struct event_loop *master_thread);
+extern struct mgmt_fe_client *
+mgmt_fe_client_create(const char *client_name, struct mgmt_fe_client_cbs *cbs,
+		      uintptr_t user_data, struct event_loop *event_loop);
 
 /*
  * Initialize library vty (adds debug support).
  *
- * This call should be added to your component when enabling other vty code to
- * enable mgmtd client debugs. When adding, one needs to also add a their
- * component in `xref2vtysh.py` as well.
+ * This call should be added to your component when enabling other vty
+ * code to enable mgmtd client debugs. When adding, one needs to also
+ * add a their component in `xref2vtysh.py` as well.
  */
 extern void mgmt_fe_client_lib_vty_init(void);
 
@@ -167,15 +171,15 @@ extern void mgmt_debug_fe_client_show_debug(struct vty *vty);
  * client_id
  *    Unique identifier of client.
  *
- * user_ctx
+ * user_client
  *    Client context.
  *
  * Returns:
  *    MGMTD_SUCCESS on success, MGMTD_* otherwise.
  */
-extern enum mgmt_result mgmt_fe_create_client_session(uintptr_t lib_hndl,
-							  uint64_t client_id,
-							  uintptr_t user_ctx);
+extern enum mgmt_result
+mgmt_fe_create_client_session(struct mgmt_fe_client *client, uint64_t client_id,
+			      uintptr_t user_client);
 
 /*
  * Delete an existing Session for a Frontend Client connection.
@@ -187,10 +191,11 @@ extern enum mgmt_result mgmt_fe_create_client_session(uintptr_t lib_hndl,
  *    Unique identifier of client.
  *
  * Returns:
- *    MGMTD_SUCCESS on success, MGMTD_* otherwise.
+ *    0 on success, otherwise msg_conn_send_msg() return values.
  */
-extern enum mgmt_result mgmt_fe_destroy_client_session(uintptr_t lib_hndl,
-						       uint64_t client_id);
+extern enum mgmt_result
+mgmt_fe_destroy_client_session(struct mgmt_fe_client *client,
+			       uint64_t client_id);
 
 /*
  * Send UN/LOCK_DS_REQ to MGMTD for a specific Datastore DS.
@@ -211,11 +216,11 @@ extern enum mgmt_result mgmt_fe_destroy_client_session(uintptr_t lib_hndl,
  *    TRUE for lock request, FALSE for unlock request.
  *
  * Returns:
- *    MGMTD_SUCCESS on success, MGMTD_* otherwise.
+ *    0 on success, otherwise msg_conn_send_msg() return values.
  */
-extern enum mgmt_result mgmt_fe_lock_ds(uintptr_t lib_hndl, uint64_t session_id,
-					uint64_t req_id,
-					Mgmtd__DatastoreId ds_id, bool lock_ds);
+extern int mgmt_fe_send_lockds_req(struct mgmt_fe_client *client,
+				   uint64_t session_id, uint64_t req_id,
+				   Mgmtd__DatastoreId ds_id, bool lock_ds);
 
 /*
  * Send SET_CONFIG_REQ to MGMTD for one or more config data(s).
@@ -245,13 +250,15 @@ extern enum mgmt_result mgmt_fe_lock_ds(uintptr_t lib_hndl, uint64_t session_id,
  *    Destination Datastore ID where data needs to be set.
  *
  * Returns:
- *    MGMTD_SUCCESS on success, MGMTD_* otherwise.
+ *    0 on success, otherwise msg_conn_send_msg() return values.
  */
-extern enum mgmt_result
-mgmt_fe_set_config_data(uintptr_t lib_hndl, uint64_t session_id,
-			uint64_t req_id, Mgmtd__DatastoreId ds_id,
-			Mgmtd__YangCfgDataReq **config_req, int num_req,
-			bool implicit_commit, Mgmtd__DatastoreId dst_ds_id);
+
+extern int mgmt_fe_send_setcfg_req(struct mgmt_fe_client *client,
+				   uint64_t session_id, uint64_t req_id,
+				   Mgmtd__DatastoreId ds_id,
+				   Mgmtd__YangCfgDataReq **config_req,
+				   int num_req, bool implicit_commit,
+				   Mgmtd__DatastoreId dst_ds_id);
 
 /*
  * Send SET_COMMMIT_REQ to MGMTD for one or more config data(s).
@@ -278,13 +285,13 @@ mgmt_fe_set_config_data(uintptr_t lib_hndl, uint64_t session_id,
  *    TRUE if need to restore Src DS back to Dest DS, FALSE otherwise.
  *
  * Returns:
- *    MGMTD_SUCCESS on success, MGMTD_* otherwise.
+ *    0 on success, otherwise msg_conn_send_msg() return values.
  */
-extern enum mgmt_result
-mgmt_fe_commit_config_data(uintptr_t lib_hndl, uint64_t session_id,
-			   uint64_t req_id, Mgmtd__DatastoreId src_ds_id,
-			   Mgmtd__DatastoreId dst_ds_id, bool validate_only,
-			   bool abort);
+extern int mgmt_fe_send_commitcfg_req(struct mgmt_fe_client *client,
+				      uint64_t session_id, uint64_t req_id,
+				      Mgmtd__DatastoreId src_ds_id,
+				      Mgmtd__DatastoreId dst_ds_id,
+				      bool validate_only, bool abort);
 
 /*
  * Send GET_CONFIG_REQ to MGMTD for one or more config data item(s).
@@ -308,12 +315,13 @@ mgmt_fe_commit_config_data(uintptr_t lib_hndl, uint64_t session_id,
  *    Number of get config requests.
  *
  * Returns:
- *    MGMTD_SUCCESS on success, MGMTD_* otherwise.
+ *    0 on success, otherwise msg_conn_send_msg() return values.
  */
-extern enum mgmt_result
-mgmt_fe_get_config_data(uintptr_t lib_hndl, uint64_t session_id,
-			uint64_t req_id, Mgmtd__DatastoreId ds_id,
-			Mgmtd__YangGetDataReq **data_req, int num_reqs);
+extern int mgmt_fe_send_getcfg_req(struct mgmt_fe_client *client,
+				   uint64_t session_id, uint64_t req_id,
+				   Mgmtd__DatastoreId ds_id,
+				   Mgmtd__YangGetDataReq **data_req,
+				   int num_reqs);
 
 /*
  * Send GET_DATA_REQ to MGMTD for one or more data item(s).
@@ -321,11 +329,11 @@ mgmt_fe_get_config_data(uintptr_t lib_hndl, uint64_t session_id,
  * Similar to get config request but supports getting data
  * from operational ds aka backend clients directly.
  */
-extern enum mgmt_result mgmt_fe_get_data(uintptr_t lib_hndl,
-					 uint64_t session_id, uint64_t req_id,
-					 Mgmtd__DatastoreId ds_id,
-					 Mgmtd__YangGetDataReq **data_req,
-					 int num_reqs);
+extern int mgmt_fe_send_getdata_req(struct mgmt_fe_client *client,
+				    uint64_t session_id, uint64_t req_id,
+				    Mgmtd__DatastoreId ds_id,
+				    Mgmtd__YangGetDataReq **data_req,
+				    int num_reqs);
 
 /*
  * Send NOTIFY_REGISTER_REQ to MGMTD daemon.
@@ -352,23 +360,24 @@ extern enum mgmt_result mgmt_fe_get_data(uintptr_t lib_hndl,
  *    Number of data requests.
  *
  * Returns:
- *    MGMTD_SUCCESS on success, MGMTD_* otherwise.
+ *    0 on success, otherwise msg_conn_send_msg() return values.
  */
-extern enum mgmt_result
-mgmt_fe_register_yang_notify(uintptr_t lib_hndl, uint64_t session_id,
-			     uint64_t req_id, Mgmtd__DatastoreId ds_id,
-			     bool register_req, Mgmtd__YangDataXPath **data_req,
-			     int num_reqs);
+extern int mgmt_fe_send_regnotify_req(struct mgmt_fe_client *client,
+				      uint64_t session_id, uint64_t req_id,
+				      Mgmtd__DatastoreId ds_id,
+				      bool register_req,
+				      Mgmtd__YangDataXPath **data_req,
+				      int num_reqs);
 
 /*
  * Destroy library and cleanup everything.
  */
-extern void mgmt_fe_client_lib_destroy(void);
+extern void mgmt_fe_client_destroy(struct mgmt_fe_client *client);
 
 /*
  * Get count of open sessions.
  */
-extern uint mgmt_fe_client_session_count(uintptr_t lib_hndl);
+extern uint mgmt_fe_client_session_count(struct mgmt_fe_client *client);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Remove an obfuscating abstraction layer whose existence was entirely based on using a uintptr_t rather than a pointer to an declared-only struct.

As the code is no longer using a global FE "client context", and instead create client objects, rename the structure and it's uses to reflect this.