### PR TITLE
bgpd: expose comms, ext-comms, large-comms to lua

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -403,10 +403,23 @@ route_match_script(void *rule, const struct prefix *prefix, void *object)
 		zlog_debug("Updating attribute based on script's values");
 
 		uint32_t locpref = 0;
+		uint32_t med = 0;
 
-		path->attr->med = newattr.med;
+		if (CHECK_FLAG(path->attr->flag,
+			       ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC)))
+			med = path->attr->med;
+		if (med != newattr.med) {
+			path->attr->med = newattr.med;
+			SET_FLAG(path->attr->flag,
+				 ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC));
+		}
 
-		if (path->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF))
+		path->attr->aspath = newattr.aspath;
+
+		path->attr->nh_ifindex = newattr.nh_ifindex;
+
+		if (CHECK_FLAG(path->attr->flag,
+			       ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)))
 			locpref = path->attr->local_pref;
 		if (locpref != newattr.local_pref) {
 			SET_FLAG(path->attr->flag,

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -426,6 +426,18 @@ route_match_script(void *rule, const struct prefix *prefix, void *object)
 				 ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF));
 			path->attr->local_pref = newattr.local_pref;
 		}
+
+		if (CHECK_FLAG(newattr.flag,
+			       ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES)))
+			bgp_attr_set_community(path->attr, newattr.community);
+
+		if (CHECK_FLAG(newattr.flag,
+			       ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES)))
+			bgp_attr_set_ecommunity(path->attr, newattr.ecommunity);
+
+		if (CHECK_FLAG(newattr.flag,
+			       ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES)))
+			bgp_attr_set_lcommunity(path->attr, newattr.lcommunity);
 		break;
 	case LUA_RM_MATCH:
 		status = RMAP_MATCH;

--- a/bgpd/bgp_script.c
+++ b/bgpd/bgp_script.c
@@ -12,6 +12,10 @@
 #include "bgp_script.h"
 #include "bgp_debug.h"
 #include "bgp_aspath.h"
+#include "bgp_attr.h"
+#include "bgp_community.h"
+#include "bgp_ecommunity.h"
+#include "bgp_lcommunity.h"
 #include "frratomic.h"
 #include "frrscript.h"
 
@@ -138,16 +142,34 @@ void lua_pushattr(lua_State *L, const struct attr *attr)
 	lua_setfield(L, -2, "aspath");
 	lua_pushinteger(L, attr->local_pref);
 	lua_setfield(L, -2, "localpref");
+	lua_pushstring(L, (attr->community && attr->community->str)
+				  ? attr->community->str
+				  : "");
+	lua_setfield(L, -2, "community");
+	lua_pushstring(L, (attr->ecommunity && attr->ecommunity->str)
+				  ? attr->ecommunity->str
+				  : "");
+	lua_setfield(L, -2, "extended-community");
+	lua_pushstring(L, (attr->lcommunity && attr->lcommunity->str)
+				  ? attr->lcommunity->str
+				  : "");
+	lua_setfield(L, -2, "large-community");
 }
 
 void lua_decode_attr(lua_State *L, int idx, struct attr *attr)
 {
+	struct community *comm_new;
+	struct ecommunity *ecomm_new;
+	struct lcommunity *lcomm_new;
+
 	lua_getfield(L, idx, "metric");
 	attr->med = lua_tointeger(L, -1);
 	lua_pop(L, 1);
+
 	lua_getfield(L, idx, "ifindex");
 	attr->nh_ifindex = lua_tointeger(L, -1);
 	lua_pop(L, 1);
+
 	lua_getfield(L, idx, "aspath");
 	attr->aspath = aspath_str2aspath(lua_tostring(L, -1),
 					 bgp_get_asnotation(NULL));
@@ -155,6 +177,32 @@ void lua_decode_attr(lua_State *L, int idx, struct attr *attr)
 	lua_getfield(L, idx, "localpref");
 	attr->local_pref = lua_tointeger(L, -1);
 	lua_pop(L, 1);
+
+	lua_getfield(L, idx, "community");
+	comm_new = community_str2com(lua_tostring(L, -1));
+	if (comm_new) {
+		community_str(attr->community, false, false);
+		bgp_attr_set_community(attr, comm_new);
+	}
+	lua_pop(L, 1);
+
+	lua_getfield(L, idx, "extended-community");
+	ecomm_new = ecommunity_str2com(lua_tostring(L, -1), 0 /* type */,
+				       1 /* keyword included */);
+	if (ecomm_new) {
+		ecommunity_str(ecomm_new);
+		bgp_attr_set_ecommunity(attr, ecomm_new);
+	}
+	lua_pop(L, 1);
+
+	lua_getfield(L, idx, "large-community");
+	lcomm_new = lcommunity_str2com(lua_tostring(L, -1));
+	if (lcomm_new) {
+		lcommunity_str(lcomm_new, false, false);
+		bgp_attr_set_lcommunity(attr, lcomm_new);
+	}
+	lua_pop(L, 1);
+
 	lua_pop(L, 1);
 }
 


### PR DESCRIPTION
Expose "community", "extended-community", and "large-community" strings
to lua for use in scripting.

Example:
```
[21:00:14] root@GRTicker:~/frr scripting_comms✔
 # cat /etc/frr/scripts/comm_log.lua
function route_match(prefix, attributes, peer,
        RM_FAILURE, RM_NOMATCH, RM_MATCH, RM_MATCH_AND_CHANGE)

        route_string = prefix.network

        for attr, val in pairs(attributes) do
                if ((attr == "community" or
                     attr == "extended-community" or
                     attr == "large-community") and
                     (val ~= 0 and val ~= nil)) then
                        route_string = route_string .. " " .. attr .. "(" .. val .. ")"
                end
        end

        log.info("Evaluating route " .. route_string .. " from " .. peer.remote_id.string)

        attributes["community"] = "1111:2222"
        log.info("new comm: " .. attributes["community"])

        attributes["extended-community"] = "rt 1:1"
        log.info("new ext-comm: " .. attributes["extended-community"])

        attributes["large-community"] = "1111:2222:3333"
        log.info("new large-comm: " .. attributes["large-community"])

        return {
                action = RM_MATCH_AND_CHANGE,
                attributes = attributes
        }
 end

[21:00:19] root@GRTicker:~/frr scripting_comms✔
 # grep -A3 Evaluating /var/log/frr/trey.log | tail -4
2023/06/04 21:00:20 BGP: [JZMNV-MDH8J] Evaluating route 209.239.224.0/20 large-community(19625:53610:1) community(2914:410 2914:1005 2914:2000 2914:3000 3356:3 3356:22 3356:86 3356:575 3356:666 3356:903 3356:2059 53610:3356) extended-community() from 208.64.92.14
2023/06/04 21:00:20 BGP: [JZMNV-MDH8J] new comm: 1111:2222
2023/06/04 21:00:20 BGP: [JZMNV-MDH8J] new ext-comm: rt 1:1
2023/06/04 21:00:20 BGP: [JZMNV-MDH8J] new large-comm: 1111:2222:3333

[21:00:21] root@GRTicker:~/frr scripting_comms✔
 # vtysh -c 'show ip bgp 209.239.224.0/20'
BGP routing table entry for 209.239.224.0/20, version 65808
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  19625 53610 3356 2914 5033
    2602:fc59:e:c02::1 from 2602:fc59:e:c02::1 (208.64.92.14)
    (fe80::5cce:6fff:fe43:eb70) (used)
      Origin IGP, valid, external, best (First path received)
      Community: 1111:2222
      Extended Community: RT:1:1
      Large Community: 1111:2222:3333
      Last update: Sun Jun  4 21:00:21 2023
```

Signed-off-by: Trey Aspelund <taspelund@nvidia.com>