### PR TITLE
tools: Null0 nexthops should be treated as blackholes, in sync with k…

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -422,7 +422,9 @@ class Config(object):
             for line in lines:
                 if line.startswith("ip route ") or line.startswith("ipv6 route "):
                     if "null0" in line:
-                        line = re.sub(r"\s+null0(\s*$)", " Null0", line)
+                        line = re.sub(r"\s+null0(\s*$)", " blackhole", line)
+                    elif "Null0" in line:
+                        line = re.sub(r"\s+Null0(\s*$)", " blackhole", line)
                     newlines.append(line)
                 else:
                     newlines.append(line)


### PR DESCRIPTION
…ernel 'ip route show'

Currently, when Null0 nexthops are configured,
they are displayed as 'Null0' instead of 'blackhole'. However, the 'nexthop' is displayed as 'blackhole' in 'show ip route' or 'ip route show' (kernel).

When 'frr reload' occurs, the Null0 nexthops should be programmed as 'blackhole'.

Before fix:
=========
vrf S3-C01-01
 ip route 10.230.0.0/16 Null0
exit-vrf

S>* 10.240.0.0/16 [1/0] unreachable (blackhole), weight 1, 01:42:00

After fix:
=========
vrf S3-C01-01
 ip route 10.230.0.0/16 blackhole
exit-vrf

S>* 10.240.0.0/16 [1/0] unreachable (blackhole), weight 1, 01:42:00

root@r0:mgmt:/var/log/frr# ip route show
blackhole 10.240.0.0/16 proto static metric 20