### PR TITLE
tools: fix list value remove in frr-reload

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1480,12 +1480,17 @@ def ignore_delete_re_add_lines(lines_to_add, lines_to_del):
                         lines_to_add_to_del.append((tmp_ctx_keys, line))
 
     for (ctx_keys, line) in lines_to_del_to_del:
-        if line is not None:
+        try:
             lines_to_del.remove((ctx_keys, line))
+        except ValueError:
+            pass
 
     for (ctx_keys, line) in lines_to_add_to_del:
-        if line is not None:
+        try:
             lines_to_add.remove((ctx_keys, line))
+        except ValueError:
+            pass
+
 
     return (lines_to_add, lines_to_del)
 


### PR DESCRIPTION
There might be a time element(s) from temporary list are removed more than once
which leads to valueError in certain python3 version.

commit-id 1543f58b5 did not handle valueError properly. 
This caused regression where prefix-list config leads to delete followed by add.

The new fix should just pass the exception as
value removal from list_to_add or list_to_del
is best effort.
This allows prefix-list config has no change
then removes the lines from lines_to_del and
lines_to_add properly.


Testing:

Configure prefix-list in frr.conf and perform
multiple frr-reload. After first reload operation subsequent ones should not result in delete
 followed by add of the prefix-list but rather no-op operation.

(Pdb) lines_to_add
[(('ip prefix-list FOO permit 10.2.1.0/24',), None)] (Pdb) lines_to_del
[(('ip prefix-list FOO seq 5 permit 10.2.1.0/24',), None),
 (('ip prefix-list FOO seq 10 permit 10.2.1.0/24',), None)]
(Pdb) lines_to_del_to_del
[(('ip prefix-list FOO seq 5 permit 10.2.1.0/24',), None),
 (('ip prefix-list FOO seq 10 permit 10.2.1.0/24',), None)]
(Pdb) lines_to_add_to_del
[(('ip prefix-list FOO permit 10.2.1.0/24',), None),
 (('ip prefix-list FOO permit 10.2.1.0/24',), None)]
(Pdb) c
> /usr/lib/frr/frr-reload.py(1562)ignore_delete_re_add_lines()
-> return (lines_to_add, lines_to_del)
(Pdb) lines_to_add
[]
(Pdb) lines_to_del
[]