### PR TITLE
pimd: Fix wrong protocol for SSM

### DIFF
--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -106,6 +106,11 @@ bool tib_sg_gm_join(struct pim_instance *pim, pim_sgaddr sg,
 					  __func__, result);
 			return false;
 		}
+
+		if (!pim_addr_is_any(sg.src))
+			(*oilp)->oif_flags[pim_oif->mroute_vif_index] &=
+				~PIM_OIF_FLAG_PROTO_STAR;
+
 	} else {
 		if (PIM_DEBUG_GM_TRACE)
 			zlog_debug(


### PR DESCRIPTION
Consider LHR in `SSM` case, and the `oif` is set to up -> down -> up. When the `oif` is down, the `channel_oil` adds `PIM_OIF_FLAG_PROTO_STAR` for it, but doesn't remove it when `oif` is up.

So, just remove this flag when the `oif` is up.

Fixes #13696