### PR TITLE
vtysh: `service wrap-config`

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -557,6 +557,21 @@ extern int command_config_read_one_line(struct vty *vty,
 					uint32_t line_num, int use_config_node);
 extern int config_from_file(struct vty *, FILE *, unsigned int *line_num);
 extern enum node_type node_parent(enum node_type);
+
+/* shared code between vtysh & lib to safely write config files */
+struct config_save_state {
+	int dirfd;
+
+	char *tmp;
+	char *sav;
+};
+
+extern int config_save_begin(struct vty *vty, struct config_save_state *state,
+			       const char *config_file);
+extern int config_save_commit(struct vty *vty, struct config_save_state *state,
+			      const char *config_file);
+extern void config_save_abort(struct config_save_state *state);
+
 /*
  * Execute command under the given vty context.
  *

--- a/lib/command.h
+++ b/lib/command.h
@@ -567,7 +567,7 @@ struct config_save_state {
 };
 
 extern int config_save_begin(struct vty *vty, struct config_save_state *state,
-			       const char *config_file);
+			       const char *config_file, uid_t uid, gid_t gid);
 extern int config_save_commit(struct vty *vty, struct config_save_state *state,
 			      const char *config_file);
 extern void config_save_abort(struct config_save_state *state);

--- a/tools/subdir.am
+++ b/tools/subdir.am
@@ -66,4 +66,5 @@ EXTRA_DIST += \
 	tools/zc.pl \
 	tools/zebra.el \
 	tools/build-debian-package.sh \
+	tools/wrap_config_pkcs7.sh \
 	# end

--- a/tools/wrap_config_pkcs7.sh
+++ b/tools/wrap_config_pkcs7.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Example script for "service wrap-config".  Uses OpenSSL to do PKCS7.
+#
+# required key & cert creation:
+#   openssl genrsa -out test.key 4096
+#   openssl x509 -new -key test.key -subj '/CN=test' -out test.crt
+
+key="/etc/frr/test.key"
+crt="/etc/frr/test.crt"
+
+case "$1" in
+load)
+	exec openssl smime -decrypt -inform PEM -inkey "$key"
+	;;
+save)
+	exec openssl smime -encrypt -outform PEM "$crt"
+	;;
+esac
+exit 1

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -3563,7 +3563,7 @@ DEFUN (vtysh_copy_to_running,
 	int ret;
 	const char *fname = argv[1]->arg;
 
-	ret = vtysh_apply_config(fname, true, false);
+	ret = vtysh_apply_config(fopen(fname, "r"), fname, true, false);
 
 	/* Return to enable mode - the 'read_config' api leaves us up a level */
 	vtysh_execute_no_pager("enable");

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -73,6 +73,8 @@ enum vtysh_write_integrated {
 
 extern enum vtysh_write_integrated vtysh_write_integrated;
 
+extern char *vtysh_wrap_script;
+
 extern char frr_config[];
 extern char vtydir[];
 extern bool vtysh_loop_exited;
@@ -98,6 +100,7 @@ void config_add_line(struct list *, const char *);
 
 int vtysh_mark_file(const char *filename);
 
+int vtysh_wrap_handle(FILE **config, pid_t *script_pid, bool save);
 int vtysh_apply_config(FILE *config, const char *error_filename, bool dry_run,
 		       bool fork);
 int vtysh_write_config_integrated(void);

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -98,7 +98,8 @@ void config_add_line(struct list *, const char *);
 
 int vtysh_mark_file(const char *filename);
 
-int vtysh_apply_config(const char *config_file_path, bool dry_run, bool fork);
+int vtysh_apply_config(FILE *config, const char *error_filename, bool dry_run,
+		       bool fork);
 int vtysh_write_config_integrated(void);
 
 void vtysh_config_parse_line(void *, const char *);

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -629,19 +629,10 @@ static int vtysh_read_file(FILE *confp, bool dry_run)
 /*
  * Read configuration file and send it to all connected daemons
  */
-static int vtysh_read_config(const char *config_file_path, bool dry_run)
+static int vtysh_read_config(FILE *confp, bool dry_run)
 {
-	FILE *confp = NULL;
 	bool save;
 	int ret;
-
-	confp = fopen(config_file_path, "r");
-	if (confp == NULL) {
-		fprintf(stderr,
-			"%% Can't open configuration file %s due to '%s'.\n",
-			config_file_path, safe_strerror(errno));
-		return CMD_ERR_NO_FILE;
-	}
 
 	save = vtysh_add_timestamp;
 	vtysh_add_timestamp = false;
@@ -654,7 +645,60 @@ static int vtysh_read_config(const char *config_file_path, bool dry_run)
 	return ret;
 }
 
-int vtysh_apply_config(const char *config_file_path, bool dry_run, bool do_fork)
+static int vtysh_forked_feed(FILE *config, const char *error_filename,
+			     FILE *feeds[])
+{
+	int status;
+	int keep_status = 0;
+
+	while (!feof(config)) {
+		char buf[16 * 1024];
+		size_t nread = fread(buf, 1, sizeof(buf), config);
+
+		if (ferror(config)) {
+			fprintf(stderr, "error reading config file (%s): %m\n",
+				error_filename);
+			keep_status = 1;
+			break;
+		}
+
+		for (unsigned int i = 0; i < array_size(vtysh_client); i++) {
+			size_t nwr;
+
+			if (!feeds[i])
+				continue;
+
+			nwr = fwrite(buf, 1, nread, feeds[i]);
+			if (nwr != nread) {
+				fclose(feeds[i]);
+				feeds[i] = NULL;
+			}
+		}
+	}
+
+	for (unsigned int i = 0; i < array_size(vtysh_client); i++)
+		if (feeds[i]) {
+			fclose(feeds[i]);
+			feeds[i] = NULL;
+		}
+
+	fprintf(stdout,
+		"Waiting for children to finish applying config...\n");
+	while (wait(&status) > 0) {
+		if (!keep_status && WEXITSTATUS(status))
+			keep_status = WEXITSTATUS(status);
+	}
+
+	/*
+	 * This will return the first status received
+	 * that failed( if that happens ).  This is
+	 * good enough for the moment
+	 */
+	return keep_status;
+}
+
+int vtysh_apply_config(FILE *config, const char *error_filename, bool dry_run,
+		       bool do_fork)
 {
 	/*
 	 * We need to apply the whole config file to all daemons. Instead of
@@ -662,13 +706,31 @@ int vtysh_apply_config(const char *config_file_path, bool dry_run, bool do_fork)
 	 * child handle one daemon.
 	 */
 	pid_t fork_pid = getpid();
-	int status = 0;
 	int ret;
-	int my_client_type;
+	int my_client_type = 0;
 	char my_client[64];
 
+	if (!config) {
+		fprintf(stderr,
+			"%% Can't open configuration file %s due to '%m'.\n",
+			error_filename);
+		return CMD_ERR_NO_FILE;
+	}
+
 	if (do_fork) {
+		FILE *feeds[array_size(vtysh_client)] = {};
+		int fds[2];
+
 		for (unsigned int i = 0; i < array_size(vtysh_client); i++) {
+			fds[0] = fds[1] = -1;
+
+			if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds)) {
+				fprintf(stderr,
+					"error opening socket for forked child: %m\n");
+				continue;
+			}
+			feeds[i] = fdopen(fds[0], "w");
+
 			/* Store name of client this fork will handle */
 			strlcpy(my_client, vtysh_client[i].name,
 				sizeof(my_client));
@@ -678,26 +740,21 @@ int vtysh_apply_config(const char *config_file_path, bool dry_run, bool do_fork)
 			/* If child, break */
 			if (fork_pid == 0)
 				break;
+			close(fds[1]);
 		}
 
 		/* parent, wait for children */
-		if (fork_pid != 0) {
-			int keep_status = 0;
+		if (fork_pid != 0)
+			return vtysh_forked_feed(config, error_filename, feeds);
 
-			fprintf(stdout,
-				"Waiting for children to finish applying config...\n");
-			while (wait(&status) > 0) {
-				if (!keep_status && WEXITSTATUS(status))
-					keep_status = WEXITSTATUS(status);
+		/* parent duplicates & feeds config */
+		for (unsigned int i = 0; i < array_size(vtysh_client); i++)
+			if (feeds[i]) {
+				fclose(feeds[i]);
+				feeds[i] = NULL;
 			}
 
-			/*
-			 * This will return the first status received
-			 * that failed( if that happens ).  This is
-			 * good enough for the moment
-			 */
-			return keep_status;
-		}
+		config = fdopen(fds[1], "r");
 
 		/*
 		 * children, grow up to be cowboys
@@ -731,17 +788,17 @@ int vtysh_apply_config(const char *config_file_path, bool dry_run, bool do_fork)
 			my_client);
 	}
 
-	ret = vtysh_read_config(config_file_path, dry_run);
+	ret = vtysh_read_config(config, dry_run);
 
 	if (ret) {
 		if (do_fork)
 			fprintf(stderr,
 				"[%d|%s] Configuration file[%s] processing failure: %d\n",
-				getpid(), my_client, frr_config, ret);
+				getpid(), my_client, error_filename, ret);
 		else
 			fprintf(stderr,
 				"Configuration file[%s] processing failure: %d\n",
-				frr_config, ret);
+				error_filename, ret);
 	} else if (do_fork) {
 		fprintf(stderr, "[%d|%s] done\n", getpid(), my_client);
 		exit(0);

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -294,6 +294,8 @@ static void vtysh_unflock_config(void)
 
 void suid_on(void)
 {
+	int prev_errno = errno;
+
 	if (elevuid != realuid && seteuid(elevuid)) {
 		perror("seteuid(on)");
 		exit(1);
@@ -302,10 +304,14 @@ void suid_on(void)
 		perror("setegid(on)");
 		exit(1);
 	}
+
+	errno = prev_errno;
 }
 
 void suid_off(void)
 {
+	int prev_errno = errno;
+
 	if (elevuid != realuid && seteuid(realuid)) {
 		perror("seteuid(off)");
 		exit(1);
@@ -314,6 +320,8 @@ void suid_off(void)
 		perror("setegid(off)");
 		exit(1);
 	}
+
+	errno = prev_errno;
 }
 
 /* VTY shell main routine. */

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -490,13 +490,18 @@ int main(int argc, char **argv, char **env)
 
 	vty_init_vtysh();
 
-	if (!user_mode) {
-		/* Read vtysh configuration file before connecting to daemons.
-		 * (file may not be readable to calling user in SUID mode) */
-		suid_on();
-		vtysh_apply_config(vtysh_config, dryrun, false);
-		suid_off();
-	}
+	/* Read vtysh configuration file before connecting to daemons.
+	 * (file may not be readable to calling user in SUID mode)
+	 *
+	 * This MUST happen before allowing the user to do anything, because
+	 * it may contain additional restrictions.  Currently there is only
+	 * the "anti-PAM" "username WORD nopassword" setting (which relaxes
+	 * rather than restricts things), but the principle still applies.
+	 */
+	suid_on();
+	vtysh_apply_config(vtysh_config, dryrun, false);
+	suid_off();
+
 	/* Error code library system */
 	log_ref_init();
 	lib_error_init();


### PR DESCRIPTION
As noted in commit text:

This allows invoking an external wrapper script with config on stdin/out and frr.conf on stdout/in for saving/loading respectively.
    
Example use cases would be doing a "git commit" on /etc/frr each time the config is saved, pushing the config into some database for backup or history purposes, or interfacing with system security infrastructure (e.g. TPM to keep keys).

---
**TODO** (hence draft):

- improve wrapper script interfacing (some env variables with config path & namespace)
- adjust `frr-reload.py` so it can use the same wrapper script    
- documentation
- some basic test
- double check that forked config load on startup works correctly
- cleanup, style fixes, inevitable CI breakage