### PR TITLE
tests: The bgp_flowspec frequently fails try to gather more data

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -810,8 +810,9 @@ int bgp_getsockname(struct peer *peer)
 				   &peer->nexthop, peer)) {
 		flog_err(
 			EC_BGP_NH_UPD,
-			"%s: nexthop_set failed, resetting connection - intf %s",
-			peer->host,
+			"%s: nexthop_set failed, local: %pSUp remote: %pSUp update_if: %s resetting connection - intf %s",
+			peer->host, peer->su_local, peer->su_remote,
+			peer->update_if ? peer->update_if : "(None)",
 			peer->nexthop.ifp ? peer->nexthop.ifp->name
 					  : "(Unknown)");
 		return -1;

--- a/tests/topotests/bgp_flowspec/test_bgp_flowspec_topo.py
+++ b/tests/topotests/bgp_flowspec/test_bgp_flowspec_topo.py
@@ -51,6 +51,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
+from lib.common_config import generate_support_bundle
 
 # Required to instantiate the topology builder class.
 
@@ -139,7 +140,9 @@ def test_bgp_convergence():
     )
     _, res = topotest.run_and_expect(test_func, None, count=90, wait=0.5)
     assertmsg = "BGP router network did not converge"
-    assert res is None, assertmsg
+    if res is not None:
+        generate_support_bundle()
+        assert res is None, assertmsg
 
 
 def test_bgp_flowspec():

--- a/tests/topotests/bgp_flowspec/test_bgp_flowspec_topo.py
+++ b/tests/topotests/bgp_flowspec/test_bgp_flowspec_topo.py
@@ -186,7 +186,6 @@ def test_bgp_flowspec():
 
 
 if __name__ == "__main__":
-
     args = ["-s"] + sys.argv[1:]
     ret = pytest.main(args)
 


### PR DESCRIPTION
Add a bit of code to allow the bgp_flowspec topotest to gather data when something goes wrong.