### PR TITLE
mgmtd: assert an assertion for coverity

### DIFF
--- a/mgmtd/mgmt_history.h
+++ b/mgmtd/mgmt_history.h
@@ -74,9 +74,11 @@ mgmt_time_to_string(struct timespec *tv, bool long_fmt, char *buffer, size_t sz)
 
 	if (long_fmt) {
 		n = strftime(buffer, sz, MGMT_LONG_TIME_FMT, &tm);
+		assert(n < sz);
 		snprintf(&buffer[n], sz - n, ",%09lu", tv->tv_nsec);
 	} else {
 		n = strftime(buffer, sz, MGMT_SHORT_TIME_FMT, &tm);
+		assert(n < sz);
 		snprintf(&buffer[n], sz - n, "%09lu", tv->tv_nsec);
 	}
 


### PR DESCRIPTION
I believe coverity can't tell the length of the return value from strftime based on the format string (like we can), so it allows `n` to be larger than it could be which then allows `sz - n` to be negative which is size_t positive and very large so it thinks an overrun is possible.

CID#1563211