### PR TITLE
pimd, pim6d: Added pimEnabled field in "show ip pim nexthop json" cli

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -2844,6 +2844,8 @@ static int pim_print_json_pnc_cache_walkcb(struct hash_bucket *backet,
 	json_object *json_row = NULL;
 	json_object *json_ifp = NULL;
 	json_object *json_arr = NULL;
+	struct pim_interface *pim_ifp = NULL;
+	bool pim_enable = false;
 
 	for (nh_node = pnc->nexthop; nh_node; nh_node = nh_node->next) {
 		first_ifindex = nh_node->ifindex;
@@ -2863,6 +2865,14 @@ static int pim_print_json_pnc_cache_walkcb(struct hash_bucket *backet,
 		json_ifp = json_object_new_object();
 		json_object_string_add(json_ifp, "interface",
 				       ifp ? ifp->name : "NULL");
+
+		if (ifp)
+			pim_ifp = ifp->info;
+
+		if (pim_ifp && pim_ifp->pim_enable)
+			pim_enable = true;
+
+		json_object_boolean_add(json_ifp, "pimEnabled", pim_enable);
 #if PIM_IPV == 4
 		json_object_string_addf(json_ifp, "nexthop", "%pI4",
 					&nh_node->gate.ipv4);


### PR DESCRIPTION
The cli "show ip pim nexthop json" gives the unicast RPF information. 
However it doesn't give PIM enable status on the nexthop interface.

Added pimEnabled field in this clis,
this will tell if PIM is enabled or not on the nexthop interface.

Example:

frr# show ip pim nexthop
Number of registered addresses: 1
 Address    Interface  Nexthop
 108.0.0.2  ens224     108.0.0.2

frr# show ip pim nexthop json
{
  "108.0.0.2":{
    "address":"108.0.0.2",
    "nexthops":[
      {
        "interface":"ens224",
        "pimEnabled":true,
        "nexthop":"108.0.0.2"
      }
    ]
  }
}

frr# configure terminal
frr(config)# int ens224
frr(config-if)# no ip pim
frr(config-if)# end

frr# show ip pim nexthop json
{
  "108.0.0.2":{
    "address":"108.0.0.2",
    "nexthops":[
      {
        "interface":"ens224",
        "pimEnabled":false,
        "nexthop":"108.0.0.2"
      }
    ]
  }
}

Closes #13441