### PR TITLE
pimd: Fix wrong protocol for SSM

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -135,7 +135,7 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 		 * being inherited.  So let's figure out what
 		 * needs to be done here
 		 */
-		if (!pim_addr_is_any(ch->sg.src) &&
+		if (!pim_addr_is_any(ch->sg.src) && ch->parent &&
 		    pim_upstream_evaluate_join_desired_interface(
 			    ch->upstream, ch, ch->parent))
 			pim_channel_add_oif(ch->upstream->channel_oil,


### PR DESCRIPTION
Consider LHR in `SSM` case, and its `oif` goes from up to down. As the `oif` changes down, the `channel_oil` is still wrongly reserved with `PIM_OIF_FLAG_PROTO_STAR` protocol.

The mechanism of adding `STAR` protocol for <S,G> entry without `oif` is introduced by commit `2164ed5`/`71056a6`, which should be only used for ASM.

PR #13699 wants to clean this `STAR` protocol after the `oif` becomes up again. That case is for SSM, as the `oif` changes down, the `channel_oil` should be removed, so the fix of that PR is wrong.

In `pim_ifchannel_delete()` we should check the `ch->parent` before that mechanism of adding `STAR` protocol. If `ch->parent` is NULL, we should skip that mechanism with SSM.

Fixes #13696