### PR TITLE
pimd: adjust the display for debug

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -181,7 +181,7 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 
 	if (PIM_DEBUG_PIM_TRACE)
 		zlog_debug(
-			"%s(%s): Delete %s[%s] ref count: %d , flags: %d c_oil ref count %d (Pre decrement)",
+			"%s(%s): Delete %s[%s] ref count: %d, flags: %d c_oil ref count %d (Pre decrement)",
 			__func__, name, up->sg_str, pim->vrf->name,
 			up->ref_count, up->flags,
 			up->channel_oil->oil_ref_count);
@@ -2056,7 +2056,7 @@ static void pim_upstream_sg_running(void *arg)
 	// No packet can have arrived here if this is the case
 	if (!up->channel_oil->installed) {
 		if (PIM_DEBUG_TRACE)
-			zlog_debug("%s: %s%s is not installed in mroute",
+			zlog_debug("%s: %s[%s] is not installed in mroute",
 				   __func__, up->sg_str, pim->vrf->name);
 		return;
 	}


### PR DESCRIPTION
The vrf name should be separated when it is displayed. And remove unnecessary space after number.

Before:
```
pim_upstream_sg_running: (100.100.1.100,232.100.100.100)x is not installed in mroute
pim_upstream_del(pim_ifchannel_delete): Delete (100.100.1.100,232.100.100.100)[x] ref count: 1 , flags: 1048585 c_oil ref count 2 (Pre decrement)
```

After:
```
pim_upstream_sg_running: (100.100.1.100,232.100.100.100)[x] is not installed in mroute
pim_upstream_del(pim_ifchannel_delete): Delete (100.100.1.100,232.100.100.100)[x] ref count: 1, flags: 1048585 c_oil ref count 2 (Pre decrement)
```