### PR TITLE
zebra: Prevent crash because nl is NULL on shutdown

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -206,11 +206,16 @@ void zebra_finalize(struct event *dummy)
 
 	vrf_terminate();
 
+	/*
+	 * Stop dplane thread and finish any cleanup
+	 * This is before the zebra_ns_early_shutdown call
+	 * because sockets that the dplane depends on are closed
+	 * in those functions
+	 */
+	zebra_dplane_shutdown();
+
 	ns_walk_func(zebra_ns_early_shutdown, NULL, NULL);
 	zebra_ns_notify_close();
-
-	/* Stop dplane thread and finish any cleanup */
-	zebra_dplane_shutdown();
 
 	/* Final shutdown of ns resources */
 	ns_walk_func(zebra_ns_final_shutdown, NULL, NULL);


### PR DESCRIPTION
When shutting down the main pthread was first closing the sockets associated with the dplane pthread and then telling it to shutdown the pthread at a later point in time.  This caused the dplane to crash because the nl data has been freed already.  Change the shutdown order to stop the dplane pthread *and* then close the sockets.