### PR TITLE
zebra: bugfix dplane priority sorting

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -5546,7 +5546,7 @@ int dplane_provider_register(const char *name,
 			     struct zebra_dplane_provider **prov_p)
 {
 	int ret = 0;
-	struct zebra_dplane_provider *p = NULL, *last;
+	struct zebra_dplane_provider *p = NULL, *last, *prev = NULL;
 
 	/* Validate */
 	if (fp == NULL) {
@@ -5589,10 +5589,11 @@ int dplane_provider_register(const char *name,
 	frr_each (dplane_prov_list, &zdplane_info.dg_providers, last) {
 		if (last->dp_priority > p->dp_priority)
 			break;
+		prev = last;
 	}
 
 	if (last)
-		dplane_prov_list_add_after(&zdplane_info.dg_providers, last, p);
+		dplane_prov_list_add_after(&zdplane_info.dg_providers, prev, p);
 	else
 		dplane_prov_list_add_tail(&zdplane_info.dg_providers, p);
 


### PR DESCRIPTION
dplane_provider_register() maintains a list of providers which are sorted according to priority. Fix to insert before first node of higher priority rather than after. 