### PR TITLE
zebra: Fix crash when `dplane_fpm_nl` fails to process received routes

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -587,7 +587,8 @@ static void fpm_read(struct event *t)
 		switch (hdr->nlmsg_type) {
 		case RTM_NEWROUTE:
 			ctx = dplane_ctx_alloc();
-			dplane_ctx_set_op(ctx, DPLANE_OP_ROUTE_NOTIFY);
+			dplane_ctx_route_init(ctx, DPLANE_OP_ROUTE_NOTIFY, NULL,
+					      NULL);
 			if (netlink_route_change_read_unicast_internal(
 				    hdr, 0, false, ctx) != 1) {
 				dplane_ctx_fini(&ctx);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3257,13 +3257,20 @@ int dplane_ctx_route_init_basic(struct zebra_dplane_ctx *ctx,
 {
 	int ret = EINVAL;
 
-	if (!ctx || !re)
+	if (!ctx)
 		return ret;
 
 	dplane_intf_extra_list_init(&ctx->u.rinfo.intf_extra_list);
 
 	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
+
+	/* This function may be called to create/init a dplane context, not
+	 * necessarily to copy a route object. Let's return if there is no route
+	 * object to copy.
+	 */
+	if (!re)
+		return AOK;
 
 	ctx->u.rinfo.zd_type = re->type;
 	ctx->u.rinfo.zd_old_type = re->type;
@@ -3296,6 +3303,8 @@ int dplane_ctx_route_init_basic(struct zebra_dplane_ctx *ctx,
 
 /*
  * Initialize a context block for a route update from zebra data structs.
+ * If the `rn` or `re` parameters are NULL, this function only initializes the
+ * dplane context without copying a route object into it.
  */
 int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 			  struct route_node *rn, struct route_entry *re)
@@ -3312,8 +3321,16 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	const struct interface *ifp;
 	struct dplane_intf_extra *if_extra;
 
-	if (!ctx || !rn || !re)
+	if (!ctx)
 		return ret;
+
+	/*
+	 * Initialize the dplane context and return, if there is no route
+	 * object to copy
+	 */
+	if (!re || !rn)
+		return dplane_ctx_route_init_basic(ctx, op, NULL, NULL, NULL,
+						   AFI_UNSPEC, SAFI_UNSPEC);
 
 	/*
 	 * Let's grab the data from the route_node


### PR DESCRIPTION
This PR fixes #13754.

In `dplane_fpm_nl`, `fpm_read` allocates a dplane route context and calls `netlink_route_change_read_unicast_internal` to populate the dplane context with the received route. When `netlink_route_change_read_unicast_internal` fails to process the route information, we call `dplane_ctx_fini` to free the dplane context. However, this causes a crash because `dplane_ctx_fini` attempts to access the `intf_extra_list` which is not initialized.

To solve this issue, we need to initialize the `intf_extra_list` properly after allocating the dplane route context.

Signed-off-by: Carmine Scarpitta [carmine.scarpitta.94@gmail.com](mailto:carmine.scarpitta.94@gmail.com)