### PR TITLE
pim6d: Correcting the help string

### DIFF
--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -743,7 +743,7 @@ DEFPY (interface_ipv6_mld_query_max_response_time,
        IPV6_STR
        IFACE_MLD_STR
        IFACE_MLD_QUERY_MAX_RESPONSE_TIME_STR
-       "Query response value in milliseconds\n")
+       "Query response value in deci-seconds\n")
 {
 	return gm_process_query_max_response_time_cmd(vty, qmrt_str);
 }


### PR DESCRIPTION
Max response time in the code is being used as decisecond but the user input is taken in millisecond. 
Also yang expects the field to be in decisecond.
The below condition in yang is failing due to the mismatch in units.

```
units deciseconds;
must ". <= ../query-interval * 10";
```

Issue: #11892