### PR TITLE
mgmtd: improvements in logging and commentary

### DIFF
--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -20,14 +20,6 @@
 
 #include "lib/mgmt_be_client_clippy.c"
 
-#define MGMTD_BE_CLIENT_DBG(fmt, ...)                                          \
-	DEBUGD(&mgmt_dbg_be_client, "BE-CLIENT: %s: " fmt, __func__,           \
-	       ##__VA_ARGS__)
-#define MGMTD_BE_CLIENT_ERR(fmt, ...)                                          \
-	zlog_err("BE-CLIENT: %s: ERROR: " fmt, __func__, ##__VA_ARGS__)
-#define MGMTD_DBG_BE_CLIENT_CHECK()                                            \
-	DEBUG_MODE_CHECK(&mgmt_dbg_be_client, DEBUG_MODE_ALL)
-
 DEFINE_MTYPE_STATIC(LIB, MGMTD_BE_CLIENT, "backend client");
 DEFINE_MTYPE_STATIC(LIB, MGMTD_BE_CLIENT_NAME, "backend client name");
 DEFINE_MTYPE_STATIC(LIB, MGMTD_BE_BATCH, "backend transaction batch data");

--- a/lib/mgmt_be_client.h
+++ b/lib/mgmt_be_client.h
@@ -131,9 +131,19 @@ mgmt_be_client_name2id(const char *name)
 	return MGMTD_BE_CLIENT_ID_MAX;
 }
 
+extern struct debug mgmt_dbg_be_client;
+
 /***************************************************************
  * API prototypes
  ***************************************************************/
+
+#define MGMTD_BE_CLIENT_DBG(fmt, ...)                                          \
+	DEBUGD(&mgmt_dbg_be_client, "BE-CLIENT: %s: " fmt, __func__,           \
+	       ##__VA_ARGS__)
+#define MGMTD_BE_CLIENT_ERR(fmt, ...)                                          \
+	zlog_err("BE-CLIENT: %s: ERROR: " fmt, __func__, ##__VA_ARGS__)
+#define MGMTD_DBG_BE_CLIENT_CHECK()                                            \
+	DEBUG_MODE_CHECK(&mgmt_dbg_be_client, DEBUG_MODE_ALL)
 
 /**
  * Create backend client and connect to MGMTD.

--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -50,6 +50,22 @@ struct mgmt_fe_client {
 struct debug mgmt_dbg_fe_client = {0, "Management frontend client operations"};
 
 
+static inline const char *dsid2name(Mgmtd__DatastoreId id)
+{
+	switch ((int)id) {
+	case MGMTD_DS_NONE:
+		return "none";
+	case MGMTD_DS_RUNNING:
+		return "running";
+	case MGMTD_DS_CANDIDATE:
+		return "candidate";
+	case MGMTD_DS_OPERATIONAL:
+		return "operational";
+	default:
+		return "unknown-datastore-id";
+	}
+}
+
 static struct mgmt_fe_client_session *
 mgmt_fe_find_session_by_client_id(struct mgmt_fe_client *client,
 				  uint64_t client_id)
@@ -165,8 +181,9 @@ int mgmt_fe_send_lockds_req(struct mgmt_fe_client *client, uint64_t session_id,
 	fe_msg.lockds_req = &lockds_req;
 
 	MGMTD_FE_CLIENT_DBG(
-		"Sending %sLOCK_REQ message for Ds:%d session-id %" PRIu64,
-		lock ? "" : "UN", ds_id, session_id);
+		"Sending LOCKDS_REQ (%sLOCK) message for DS:%s session-id %" PRIu64,
+		lock ? "" : "UN", dsid2name(ds_id), session_id);
+
 
 	return mgmt_fe_client_send_msg(client, &fe_msg, false);
 }
@@ -194,9 +211,9 @@ int mgmt_fe_send_setcfg_req(struct mgmt_fe_client *client, uint64_t session_id,
 	fe_msg.setcfg_req = &setcfg_req;
 
 	MGMTD_FE_CLIENT_DBG(
-		"Sending SET_CONFIG_REQ message for Ds:%d session-id %" PRIu64
+		"Sending SET_CONFIG_REQ message for DS:%s session-id %" PRIu64
 		" (#xpaths:%d)",
-		ds_id, session_id, num_data_reqs);
+		dsid2name(ds_id), session_id, num_data_reqs);
 
 	return mgmt_fe_client_send_msg(client, &fe_msg, false);
 }
@@ -224,8 +241,8 @@ int mgmt_fe_send_commitcfg_req(struct mgmt_fe_client *client,
 	fe_msg.commcfg_req = &commitcfg_req;
 
 	MGMTD_FE_CLIENT_DBG(
-		"Sending COMMIT_CONFIG_REQ message for Src-Ds:%d, Dst-Ds:%d session-id %" PRIu64,
-		src_ds_id, dest_ds_id, session_id);
+		"Sending COMMIT_CONFIG_REQ message for Src-DS:%s, Dst-DS:%s session-id %" PRIu64,
+		dsid2name(src_ds_id), dsid2name(dest_ds_id), session_id);
 
 	return mgmt_fe_client_send_msg(client, &fe_msg, false);
 }
@@ -251,9 +268,9 @@ int mgmt_fe_send_getcfg_req(struct mgmt_fe_client *client, uint64_t session_id,
 	fe_msg.getcfg_req = &getcfg_req;
 
 	MGMTD_FE_CLIENT_DBG(
-		"Sending GET_CONFIG_REQ message for Ds:%d session-id %" PRIu64
+		"Sending GET_CONFIG_REQ message for DS:%s session-id %" PRIu64
 		" (#xpaths:%d)",
-		ds_id, session_id, num_data_reqs);
+		dsid2name(ds_id), session_id, num_data_reqs);
 
 	return mgmt_fe_client_send_msg(client, &fe_msg, false);
 }
@@ -279,9 +296,9 @@ int mgmt_fe_send_getdata_req(struct mgmt_fe_client *client, uint64_t session_id,
 	fe_msg.getdata_req = &getdata_req;
 
 	MGMTD_FE_CLIENT_DBG(
-		"Sending GET_CONFIG_REQ message for Ds:%d session-id %" PRIu64
+		"Sending GET_CONFIG_REQ message for DS:%s session-id %" PRIu64
 		" (#xpaths:%d)",
-		ds_id, session_id, num_data_reqs);
+		dsid2name(ds_id), session_id, num_data_reqs);
 
 	return mgmt_fe_client_send_msg(client, &fe_msg, false);
 }

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -119,6 +119,10 @@ struct mgmt_fe_client_cbs {
 
 extern struct debug mgmt_dbg_fe_client;
 
+/***************************************************************
+ * API prototypes
+ ***************************************************************/
+
 #define MGMTD_FE_CLIENT_DBG(fmt, ...)                                          \
 	DEBUGD(&mgmt_dbg_fe_client, "FE-CLIENT: %s: " fmt, __func__,           \
 	       ##__VA_ARGS__)
@@ -126,11 +130,6 @@ extern struct debug mgmt_dbg_fe_client;
 	zlog_err("FE-CLIENT: %s: ERROR: " fmt, __func__, ##__VA_ARGS__)
 #define MGMTD_DBG_FE_CLIENT_CHECK()                                            \
 	DEBUG_MODE_CHECK(&mgmt_dbg_fe_client, DEBUG_MODE_ALL)
-
-
-/***************************************************************
- * API prototypes
- ***************************************************************/
 
 /*
  * Initialize library and try connecting with MGMTD FrontEnd interface.

--- a/lib/mgmt_msg.c
+++ b/lib/mgmt_msg.c
@@ -59,11 +59,12 @@ enum mgmt_msg_rsched mgmt_msg_read(struct mgmt_msg_state *ms, int fd,
 	 */
 	while (avail > sizeof(struct mgmt_msg_hdr)) {
 		n = stream_read_try(ms->ins, fd, avail);
-		MGMT_MSG_DBG(dbgtag, "got %zd bytes", n);
 
 		/* -2 is normal nothing read, and to retry */
-		if (n == -2)
+		if (n == -2) {
+			MGMT_MSG_DBG(dbgtag, "nothing more to read");
 			break;
+		}
 		if (n <= 0) {
 			if (n == 0)
 				MGMT_MSG_ERR(ms, "got EOF/disconnect");
@@ -73,6 +74,7 @@ enum mgmt_msg_rsched mgmt_msg_read(struct mgmt_msg_state *ms, int fd,
 					     safe_strerror(errno));
 			return MSR_DISCONNECT;
 		}
+		MGMT_MSG_DBG(dbgtag, "read %zd bytes", n);
 		ms->nrxb += n;
 		avail -= n;
 	}

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -229,7 +229,7 @@ struct vty {
 	/* set when we have sent mgmtd a *REQ command in response to some vty
 	 * CLI command and we are waiting on the reply so we can respond to the
 	 * vty user. */
-	bool mgmt_req_pending;
+	const char *mgmt_req_pending_cmd;
 	bool mgmt_locked_candidate_ds;
 };
 

--- a/mgmtd/mgmt_ds.c
+++ b/mgmtd/mgmt_ds.c
@@ -80,7 +80,9 @@ static int mgmt_ds_replace_dst_with_src_ds(struct mgmt_ds_ctx *src,
 
 	if (!src || !dst)
 		return -1;
-	MGMTD_DS_DBG("Replacing %d with %d", dst->ds_id, src->ds_id);
+
+	MGMTD_DS_DBG("Replacing %s with %s", mgmt_ds_id2name(dst->ds_id),
+		     mgmt_ds_id2name(src->ds_id));
 
 	src_dnode = src->config_ds ? src->root.cfg_root->dnode
 				   : dst->root.dnode_root;

--- a/mgmtd/mgmt_history.c
+++ b/mgmtd/mgmt_history.c
@@ -248,7 +248,7 @@ static int mgmt_history_rollback_to_cmt(struct vty *vty,
 	 * is completed. On rollback completion mgmt_history_rollback_complete()
 	 * shall be called to resume the rollback command return to VTYSH.
 	 */
-	vty->mgmt_req_pending = true;
+	vty->mgmt_req_pending_cmd = "ROLLBACK";
 	rollback_vty = vty;
 	return 0;
 }


### PR DESCRIPTION
Only the last commit is new as this PR also contains PR #13763 

- log names of datastores not numbers
- improve logging for mgmt_msg_read
- Rather than use a bool, instead store the const string name of the pending command being run that has postponed the CLI. This adds some nice information to the logging when enabled.

