### PR TITLE
tools: frr-reload add exit post router blob

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -196,6 +196,7 @@ class Context(object):
             self.dlines[ligne] = True
 
 
+
 def get_normalized_es_id(line):
     """
     The es-id or es-sys-mac need to be converted to lower case
@@ -217,6 +218,7 @@ def get_normalized_mac_ip_line(line):
         return get_normalized_ipv6_line(line)
 
     return line
+
 
 
 class Config(object):
@@ -713,6 +715,7 @@ def line_exist(lines, target_ctx_keys, target_line, exact_match=True):
                 if line.startswith(target_line):
                     return True
     return False
+
 
 
 def check_for_exit_vrf(lines_to_add, lines_to_del):


### PR DESCRIPTION
frr-reload.py add explicit exit post router blob. Current patch checks for
router ospf6 as interface command context is not switched due to hidden deprecated command under
router ospf6 context. The error is thrown as incomplete command.

vtysh current behavior:

```
r2(config-ospf6)# interface swp1.10 area 0.0.0.0
This command is deprecated, because it is not VRF-aware.
Please, use "ipv6 ospf6 area" on an interface instead.
```

FRR reload command executions"

Before fix:

```
router ospf6
 redistribute connected
interface swp1.10   <<<<<< throws error as deprecated command expected area
interface swp1.10
 ipv6 ospf6 area 0.0.0.0
interface swp1.10
 ipv6 ospf6 network point-to-point
```

After fix:

```
router ospf6
 redistribute connected
router ospf6
 exit
interface swp1.10
interface swp1.10
 ipv6 ospf6 area 0.0.0.0
interface swp1.10
 ipv6 ospf6 network point-to-point
```


Signed-off-by: Chirag Shah <chirag@nvidia.com>
