### PR TITLE
pimd,pim6d: Correct the socket to send reg-stop msg

### DIFF
--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -85,7 +85,7 @@ void pim_register_stop_send(struct interface *ifp, pim_sgaddr *sg, pim_addr src,
 			zlog_debug("%s: No pinfo!", __func__);
 		return;
 	}
-	if (pim_msg_send(pinfo->pim_sock_fd, src, originator, buffer,
+	if (pim_msg_send(pinfo->pim->reg_sock, src, originator, buffer,
 			 b1length + PIM_MSG_REGISTER_STOP_LEN, ifp)) {
 		if (PIM_DEBUG_PIM_TRACE) {
 			zlog_debug(


### PR DESCRIPTION
We were using the pim interface socket to send the register stop msg, it works fine in cases where the interface on which register msg is received and the interface on which the register-stop msg is supposed to be sent is the same.
But when the interfaces are different, msg send fails because the outgoing interface is not right.

Fixes: #13774