### PR TITLE
mgmt lock simplification

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1333,11 +1333,12 @@ int config_from_file(struct vty *vty, FILE *fp, unsigned int *line_num)
 /* Configuration from terminal */
 DEFUN (config_terminal,
        config_terminal_cmd,
-       "configure [terminal]",
+       "configure [terminal [file-lock]]",
        "Configuration from vty interface\n"
+       "Configuration with locked datastores\n"
        "Configuration terminal\n")
 {
-	return vty_config_enter(vty, false, false);
+	return vty_config_enter(vty, false, false, argc == 3);
 }
 
 /* Enable command */

--- a/lib/mgmt.proto
+++ b/lib/mgmt.proto
@@ -243,7 +243,8 @@ message FeSetConfigReply {
   required DatastoreId ds_id = 2;
   required uint64 req_id = 3;
   required bool success = 4;
-  optional string error_if_any = 5;
+  required bool implicit_commit = 5;
+  optional string error_if_any = 6;
 }
 
 message FeCommitConfigReq {

--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -164,7 +164,7 @@ static int mgmt_fe_send_session_req(struct mgmt_fe_client *client,
 
 int mgmt_fe_send_lockds_req(struct mgmt_fe_client *client, uint64_t session_id,
 			    uint64_t req_id, Mgmtd__DatastoreId ds_id,
-			    bool lock)
+			    bool lock, bool scok)
 {
 	(void)req_id;
 	Mgmtd__FeMessage fe_msg;
@@ -185,7 +185,7 @@ int mgmt_fe_send_lockds_req(struct mgmt_fe_client *client, uint64_t session_id,
 		lock ? "" : "UN", dsid2name(ds_id), session_id);
 
 
-	return mgmt_fe_client_send_msg(client, &fe_msg, false);
+	return mgmt_fe_client_send_msg(client, &fe_msg, scok);
 }
 
 int mgmt_fe_send_setcfg_req(struct mgmt_fe_client *client, uint64_t session_id,

--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -411,6 +411,7 @@ static int mgmt_fe_client_handle_msg(struct mgmt_fe_client *client,
 				session->user_ctx, fe_msg->setcfg_reply->req_id,
 				fe_msg->setcfg_reply->success,
 				fe_msg->setcfg_reply->ds_id,
+				fe_msg->setcfg_reply->implicit_commit,
 				fe_msg->setcfg_reply->error_if_any);
 		break;
 	case MGMTD__FE_MESSAGE__MESSAGE_COMMCFG_REPLY:

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -91,7 +91,7 @@ struct mgmt_fe_client_cbs {
 				  uintptr_t session_id,
 				  uintptr_t user_session_client,
 				  uint64_t req_id, bool success,
-				  Mgmtd__DatastoreId ds_id,
+				  Mgmtd__DatastoreId ds_id, bool implcit_commit,
 				  char *errmsg_if_any);
 
 	void (*commit_config_notify)(struct mgmt_fe_client *client,

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -219,7 +219,8 @@ mgmt_fe_destroy_client_session(struct mgmt_fe_client *client,
  */
 extern int mgmt_fe_send_lockds_req(struct mgmt_fe_client *client,
 				   uint64_t session_id, uint64_t req_id,
-				   Mgmtd__DatastoreId ds_id, bool lock_ds);
+				   Mgmtd__DatastoreId ds_id, bool lock_ds,
+				   bool scok);
 
 /*
  * Send SET_CONFIG_REQ to MGMTD for one or more config data(s).

--- a/lib/mgmt_msg.h
+++ b/lib/mgmt_msg.h
@@ -98,8 +98,8 @@ struct msg_conn {
 			   struct msg_conn *conn);
 	void *user;
 	uint short_circuit_depth;
+	bool is_short_circuit;	/* true when the message being handled is SC */
 	bool is_client;
-	bool is_short_circuit;
 	bool debug;
 };
 

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -763,7 +763,7 @@ DEFUN (config_exclusive,
        "Configuration from vty interface\n"
        "Configure exclusively from this terminal\n")
 {
-	return vty_config_enter(vty, true, true);
+	return vty_config_enter(vty, true, true, false);
 }
 
 /* Configure using a private candidate configuration. */
@@ -773,7 +773,7 @@ DEFUN (config_private,
        "Configuration from vty interface\n"
        "Configure using a private candidate configuration\n")
 {
-	return vty_config_enter(vty, true, false);
+	return vty_config_enter(vty, true, false, false);
 }
 
 DEFPY (config_commit,

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -70,7 +70,6 @@ struct nb_config *vty_mgmt_candidate_config;
 
 static struct mgmt_fe_client *mgmt_fe_client;
 static bool mgmt_fe_connected;
-static bool mgmt_candidate_ds_wr_locked;
 static uint64_t mgmt_client_id_next;
 static uint64_t mgmt_last_req_id = UINT64_MAX;
 
@@ -128,6 +127,35 @@ char const *const mgmt_daemons[] = {
 #endif
 };
 uint mgmt_daemons_count = array_size(mgmt_daemons);
+
+
+static int vty_mgmt_lock_candidate_inline(struct vty *vty)
+{
+	assert(!vty->mgmt_locked_candidate_ds);
+	(void)vty_mgmt_send_lockds_req(vty, MGMTD_DS_CANDIDATE, true, true);
+	return vty->mgmt_locked_candidate_ds ? 0 : -1;
+}
+
+static int vty_mgmt_unlock_candidate_inline(struct vty *vty)
+{
+	assert(vty->mgmt_locked_candidate_ds);
+	(void)vty_mgmt_send_lockds_req(vty, MGMTD_DS_CANDIDATE, false, true);
+	return vty->mgmt_locked_candidate_ds ? -1 : 0;
+}
+
+static int vty_mgmt_lock_running_inline(struct vty *vty)
+{
+	assert(!vty->mgmt_locked_running_ds);
+	(void)vty_mgmt_send_lockds_req(vty, MGMTD_DS_RUNNING, true, true);
+	return vty->mgmt_locked_running_ds ? 0 : -1;
+}
+
+static int vty_mgmt_unlock_running_inline(struct vty *vty)
+{
+	assert(vty->mgmt_locked_running_ds);
+	(void)vty_mgmt_send_lockds_req(vty, MGMTD_DS_RUNNING, false, true);
+	return vty->mgmt_locked_running_ds ? -1 : 0;
+}
 
 void vty_mgmt_resume_response(struct vty *vty, bool success)
 {
@@ -2202,10 +2230,8 @@ bool mgmt_vty_read_configs(void)
 	vty->node = CONFIG_NODE;
 	vty->config = true;
 	vty->pending_allowed = true;
-	vty->candidate_config = vty_shared_candidate_config;
-	vty->mgmt_locked_candidate_ds = true;
-	mgmt_candidate_ds_wr_locked = true;
 
+	vty->candidate_config = vty_shared_candidate_config;
 
 	for (index = 0; index < array_size(mgmt_daemons); index++) {
 		snprintf(path, sizeof(path), "%s/%s.conf", frr_sysconfdir,
@@ -2251,9 +2277,6 @@ bool mgmt_vty_read_configs(void)
 	}
 
 	vty->pending_allowed = false;
-
-	vty->mgmt_locked_candidate_ds = false;
-	mgmt_candidate_ds_wr_locked = false;
 
 	if (!count)
 		vty_close(vty);
@@ -2367,7 +2390,7 @@ static void vtysh_read(struct event *thread)
 				 */
 				if (vty->mgmt_req_pending_cmd) {
 					MGMTD_FE_CLIENT_DBG(
-						"postpone CLI cmd response pending mgmtd %s on vty session-id %" PRIu64,
+						"postpone CLI response pending mgmtd %s on vty session-id %" PRIu64,
 						vty->mgmt_req_pending_cmd,
 						vty->mgmt_session_id);
 					return;
@@ -2453,15 +2476,15 @@ void vty_close(struct vty *vty)
 		MGMTD_FE_CLIENT_ERR(
 			"vty closed, uncommitted config will be lost.");
 
+	/* Drop out of configure / transaction if needed. */
+	vty_config_exit(vty);
+
 	if (mgmt_fe_client && vty->mgmt_session_id) {
 		MGMTD_FE_CLIENT_DBG("closing vty session");
 		mgmt_fe_destroy_client_session(mgmt_fe_client,
 					       vty->mgmt_client_id);
 		vty->mgmt_session_id = 0;
 	}
-
-	/* Drop out of configure / transaction if needed. */
-	vty_config_exit(vty);
 
 	/* Cancel threads.*/
 	EVENT_OFF(vty->t_read);
@@ -2828,21 +2851,26 @@ int vty_config_enter(struct vty *vty, bool private_config, bool exclusive)
 		return CMD_WARNING;
 	}
 
-	if (vty_mgmt_fe_enabled()) {
-		if (!mgmt_candidate_ds_wr_locked) {
-			if (vty_mgmt_send_lockds_req(vty, MGMTD_DS_CANDIDATE,
-						     true) != 0) {
-				vty_out(vty, "Not able to lock candidate DS\n");
-				return CMD_WARNING;
-			}
-		} else {
-			vty_out(vty,
-				"Candidate DS already locked by different session\n");
-			return CMD_WARNING;
-		}
-
+	/*
+	 * We only need to do a lock when reading a config file as we will be
+	 * sending a batch of setcfg changes followed by a single commit
+	 * message. For user interactive mode we are doing implicit commits
+	 * those will obtain the lock (or not) when they try and commit.
+	 */
+	if (vty_mgmt_fe_enabled() && vty->pending_allowed && !private_config) {
+		/*
+		 * lock using short-circuit, we set the locked boolean to true
+		 * here so that it can be flipped to false by our locked_notify
+		 * handler during the synchronous call.
+		 */
 		vty->mgmt_locked_candidate_ds = true;
-		mgmt_candidate_ds_wr_locked = true;
+		if (vty_mgmt_send_lockds_req(vty, MGMTD_DS_CANDIDATE, true,
+					     true) ||
+		    !vty->mgmt_locked_candidate_ds) {
+			vty_out(vty,
+				"%% Can't enter config; candidate datastore locked by another session\n");
+			return CMD_WARNING_CONFIG_FAILED;
+		}
 	}
 
 	vty->node = CONFIG_NODE;
@@ -2855,22 +2883,23 @@ int vty_config_enter(struct vty *vty, bool private_config, bool exclusive)
 		vty->candidate_config_base = nb_config_dup(running_config);
 		vty_out(vty,
 			"Warning: uncommitted changes will be discarded on exit.\n\n");
-	} else {
-		/*
-		 * NOTE: On the MGMTD daemon we point the VTY candidate DS to
-		 * the global MGMTD candidate DS. Else we point to the VTY
-		 * Shared Candidate Config.
-		 */
-		vty->candidate_config = vty_mgmt_candidate_config
-						? vty_mgmt_candidate_config
-						: vty_shared_candidate_config;
-		if (frr_get_cli_mode() == FRR_CLI_TRANSACTIONAL)
-			vty->candidate_config_base =
-				nb_config_dup(running_config);
+		return CMD_SUCCESS;
 	}
+
+	/*
+	 * NOTE: On the MGMTD daemon we point the VTY candidate DS to
+	 * the global MGMTD candidate DS. Else we point to the VTY
+	 * Shared Candidate Config.
+	 */
+	vty->candidate_config = vty_mgmt_candidate_config
+					? vty_mgmt_candidate_config
+					: vty_shared_candidate_config;
+	if (frr_get_cli_mode() == FRR_CLI_TRANSACTIONAL)
+		vty->candidate_config_base = nb_config_dup(running_config);
 
 	return CMD_SUCCESS;
 }
+
 
 void vty_config_exit(struct vty *vty)
 {
@@ -2894,22 +2923,17 @@ void vty_config_exit(struct vty *vty)
 
 int vty_config_node_exit(struct vty *vty)
 {
+	int ret;
+
 	vty->xpath_index = 0;
 
-	/*
-	 * If we are not reading config file and we are mgmtd FE and we are
-	 * locked then unlock.
-	 */
-	if (vty->type != VTY_FILE && vty_mgmt_fe_enabled() &&
-	    mgmt_candidate_ds_wr_locked && vty->mgmt_locked_candidate_ds) {
-		if (vty_mgmt_send_lockds_req(vty, MGMTD_DS_CANDIDATE, false) !=
-		    0) {
-			vty_out(vty, "Not able to unlock candidate DS\n");
-			return CMD_WARNING;
-		}
-
+	if (vty->mgmt_locked_candidate_ds) {
+		assert(vty->type != VTY_FILE);
+		/* use short-circuit call to immediately unlock */
+		ret = vty_mgmt_send_lockds_req(vty, MGMTD_DS_CANDIDATE, false,
+					       true);
+		assert(!ret);
 		vty->mgmt_locked_candidate_ds = false;
-		mgmt_candidate_ds_wr_locked = false;
 	}
 
 	/* Perform any pending commits. */
@@ -3493,17 +3517,21 @@ static void vty_mgmt_ds_lock_notified(struct mgmt_fe_client *client,
 
 	vty = (struct vty *)session_ctx;
 
-	if (!success) {
-		zlog_err("%socking for DS %u failed, Err: '%s'",
-			 lock_ds ? "L" : "Unl", ds_id, errmsg_if_any);
-		vty_out(vty, "ERROR: %socking for DS %u failed, Err: '%s'\n",
-			lock_ds ? "L" : "Unl", ds_id, errmsg_if_any);
-	} else {
+	assert(ds_id == MGMTD_DS_CANDIDATE || ds_id == MGMTD_DS_RUNNING);
+	if (!success)
+		zlog_err("%socking for DS %u failed, Err: '%s' vty %p",
+			 lock_ds ? "L" : "Unl", ds_id, errmsg_if_any, vty);
+	else {
 		MGMTD_FE_CLIENT_DBG("%socked DS %u successfully",
 				    lock_ds ? "L" : "Unl", ds_id);
+		if (ds_id == MGMTD_DS_CANDIDATE)
+			vty->mgmt_locked_candidate_ds = lock_ds;
+		else
+			vty->mgmt_locked_running_ds = lock_ds;
 	}
 
-	vty_mgmt_resume_response(vty, success);
+	if (vty->mgmt_req_pending_cmd)
+		vty_mgmt_resume_response(vty, success);
 }
 
 static void vty_mgmt_set_config_result_notified(
@@ -3632,22 +3660,23 @@ bool vty_mgmt_should_process_cli_apply_changes(struct vty *vty)
 }
 
 int vty_mgmt_send_lockds_req(struct vty *vty, Mgmtd__DatastoreId ds_id,
-			     bool lock)
+			     bool lock, bool scok)
 {
-	if (mgmt_fe_client && vty->mgmt_session_id) {
-		vty->mgmt_req_id++;
-		if (mgmt_fe_send_lockds_req(mgmt_fe_client,
-					    vty->mgmt_session_id,
-					    vty->mgmt_req_id, ds_id, lock)) {
-			zlog_err("Failed sending %sLOCK-DS-REQ req-id %" PRIu64,
-				 lock ? "" : "UN", vty->mgmt_req_id);
-			vty_out(vty, "Failed to send %sLOCK-DS-REQ to MGMTD!\n",
-				lock ? "" : "UN");
-			return -1;
-		}
+	assert(mgmt_fe_client);
+	assert(vty->mgmt_session_id);
 
-		vty->mgmt_req_pending_cmd = "MESSAGE_LOCKDS_REQ";
+	vty->mgmt_req_id++;
+	if (mgmt_fe_send_lockds_req(mgmt_fe_client, vty->mgmt_session_id,
+				    vty->mgmt_req_id, ds_id, lock, scok)) {
+		zlog_err("Failed sending %sLOCK-DS-REQ req-id %" PRIu64,
+			 lock ? "" : "UN", vty->mgmt_req_id);
+		vty_out(vty, "Failed to send %sLOCK-DS-REQ to MGMTD!\n",
+			lock ? "" : "UN");
+		return -1;
 	}
+
+	if (!scok)
+		vty->mgmt_req_pending_cmd = "MESSAGE_LOCKDS_REQ";
 
 	return 0;
 }
@@ -3667,7 +3696,6 @@ int vty_mgmt_send_config_data(struct vty *vty, bool implicit_commit)
 		 * changes until we are done reading the file and have modified
 		 * the local candidate DS.
 		 */
-		assert(vty->mgmt_locked_candidate_ds);
 		/* no-one else should be sending data right now */
 		assert(!vty->mgmt_num_pending_setcfg);
 		return 0;

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -391,7 +391,7 @@ extern void vty_close(struct vty *);
 extern char *vty_get_cwd(void);
 extern void vty_update_xpath(const char *oldpath, const char *newpath);
 extern int vty_config_enter(struct vty *vty, bool private_config,
-			    bool exclusive);
+			    bool exclusive, bool file_lock);
 extern void vty_config_exit(struct vty *);
 extern int vty_config_node_exit(struct vty *);
 extern int vty_shell(struct vty *);

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -230,6 +230,7 @@ struct vty {
 	 * vty user. */
 	const char *mgmt_req_pending_cmd;
 	bool mgmt_locked_candidate_ds;
+	bool mgmt_locked_running_ds;
 };
 
 static inline void vty_push_context(struct vty *vty, int node, uint64_t id)
@@ -416,7 +417,7 @@ extern int vty_mgmt_send_get_config(struct vty *vty,
 extern int vty_mgmt_send_get_data(struct vty *vty, Mgmtd__DatastoreId datastore,
 				  const char **xpath_list, int num_req);
 extern int vty_mgmt_send_lockds_req(struct vty *vty, Mgmtd__DatastoreId ds_id,
-				    bool lock);
+				    bool lock, bool scok);
 extern void vty_mgmt_resume_response(struct vty *vty, bool success);
 
 static inline bool vty_needs_implicit_commit(struct vty *vty)

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -648,8 +648,7 @@ static void mgmt_be_adapter_process_msg(uint8_t version, uint8_t *data,
 	mgmtd__be_message__free_unpacked(be_msg, NULL);
 }
 
-static void mgmt_be_iter_and_get_cfg(struct mgmt_ds_ctx *ds_ctx,
-				     const char *xpath, struct lyd_node *node,
+static void mgmt_be_iter_and_get_cfg(const char *xpath, struct lyd_node *node,
 				     struct nb_node *nb_node, void *ctx)
 {
 	struct mgmt_be_get_adapter_config_params *parms = ctx;
@@ -806,10 +805,10 @@ mgmt_be_get_adapter_by_name(const char *name)
 }
 
 int mgmt_be_get_adapter_config(struct mgmt_be_client_adapter *adapter,
-				  struct mgmt_ds_ctx *ds_ctx,
-				  struct nb_config_cbs **cfg_chgs)
+			       struct nb_config_cbs **cfg_chgs)
 {
 	struct mgmt_be_get_adapter_config_params parms;
+	struct nb_config *cfg_root = mgmt_ds_get_nb_config(mm->running_ds);
 
 	assert(cfg_chgs);
 
@@ -825,8 +824,8 @@ int mgmt_be_get_adapter_config(struct mgmt_be_client_adapter *adapter,
 		parms.cfg_chgs = &adapter->cfg_chgs;
 		parms.seq = 0;
 
-		mgmt_ds_iter_data(ds_ctx, "", mgmt_be_iter_and_get_cfg,
-				  (void *)&parms);
+		mgmt_ds_iter_data(MGMTD_DS_RUNNING, cfg_root, "",
+				  mgmt_be_iter_and_get_cfg, (void *)&parms);
 	}
 
 	*cfg_chgs = &adapter->cfg_chgs;

--- a/mgmtd/mgmt_be_adapter.h
+++ b/mgmtd/mgmt_be_adapter.h
@@ -110,10 +110,8 @@ extern struct mgmt_be_client_adapter *
 mgmt_be_get_adapter_by_id(enum mgmt_be_client_id id);
 
 /* Fetch backend adapter config. */
-extern int
-mgmt_be_get_adapter_config(struct mgmt_be_client_adapter *adapter,
-			      struct mgmt_ds_ctx *ds_ctx,
-			      struct nb_config_cbs **cfg_chgs);
+extern int mgmt_be_get_adapter_config(struct mgmt_be_client_adapter *adapter,
+				      struct nb_config_cbs **cfg_chgs);
 
 /* Create/destroy a transaction. */
 extern int mgmt_be_send_txn_req(struct mgmt_be_client_adapter *adapter,

--- a/mgmtd/mgmt_ds.c
+++ b/mgmtd/mgmt_ds.c
@@ -22,7 +22,9 @@
 
 struct mgmt_ds_ctx {
 	Mgmtd__DatastoreId ds_id;
-	int lock; /* 0 unlocked, >0 read locked < write locked */
+
+	bool locked;
+	uint64_t vty_session_id; /* Owner of the lock or 0 */
 
 	bool config_ds;
 
@@ -244,40 +246,33 @@ bool mgmt_ds_is_config(struct mgmt_ds_ctx *ds_ctx)
 	return ds_ctx->config_ds;
 }
 
-int mgmt_ds_read_lock(struct mgmt_ds_ctx *ds_ctx)
+bool mgmt_ds_is_locked(struct mgmt_ds_ctx *ds_ctx, uint64_t session_id)
 {
-	if (!ds_ctx)
-		return EINVAL;
-	if (ds_ctx->lock < 0)
+	assert(ds_ctx);
+	return (ds_ctx->locked && ds_ctx->vty_session_id == session_id);
+}
+
+int mgmt_ds_lock(struct mgmt_ds_ctx *ds_ctx, uint64_t session_id)
+{
+	assert(ds_ctx);
+
+	if (ds_ctx->locked)
 		return EBUSY;
-	++ds_ctx->lock;
+
+	ds_ctx->locked = true;
+	ds_ctx->vty_session_id = session_id;
 	return 0;
 }
 
-int mgmt_ds_write_lock(struct mgmt_ds_ctx *ds_ctx)
+void mgmt_ds_unlock(struct mgmt_ds_ctx *ds_ctx)
 {
-	if (!ds_ctx)
-		return EINVAL;
-	if (ds_ctx->lock != 0)
-		return EBUSY;
-	ds_ctx->lock = -1;
-	return 0;
-}
-
-int mgmt_ds_unlock(struct mgmt_ds_ctx *ds_ctx)
-{
-	if (!ds_ctx)
-		return EINVAL;
-	if (ds_ctx->lock > 0)
-		--ds_ctx->lock;
-	else if (ds_ctx->lock < 0) {
-		assert(ds_ctx->lock == -1);
-		ds_ctx->lock = 0;
-	} else {
-		assert(ds_ctx->lock != 0);
-		return EINVAL;
-	}
-	return 0;
+	assert(ds_ctx);
+	if (!ds_ctx->locked)
+		zlog_warn(
+			"%s: WARNING: unlock on unlocked in DS:%s last session-id %" PRIu64,
+			__func__, mgmt_ds_id2name(ds_ctx->ds_id),
+			ds_ctx->vty_session_id);
+	ds_ctx->locked = 0;
 }
 
 int mgmt_ds_copy_dss(struct mgmt_ds_ctx *src_ds_ctx,
@@ -314,10 +309,9 @@ struct nb_config *mgmt_ds_get_nb_config(struct mgmt_ds_ctx *ds_ctx)
 }
 
 static int mgmt_walk_ds_nodes(
-	struct mgmt_ds_ctx *ds_ctx, const char *base_xpath,
+	struct nb_config *root, const char *base_xpath,
 	struct lyd_node *base_dnode,
-	void (*mgmt_ds_node_iter_fn)(struct mgmt_ds_ctx *ds_ctx,
-				     const char *xpath, struct lyd_node *node,
+	void (*mgmt_ds_node_iter_fn)(const char *xpath, struct lyd_node *node,
 				     struct nb_node *nb_node, void *ctx),
 	void *ctx)
 {
@@ -336,10 +330,7 @@ static int mgmt_walk_ds_nodes(
 		 * This function only returns the first node of a possible set
 		 * of matches issuing a warning if more than 1 matches
 		 */
-		base_dnode = yang_dnode_get(
-			ds_ctx->config_ds ? ds_ctx->root.cfg_root->dnode
-					   : ds_ctx->root.dnode_root,
-			base_xpath);
+		base_dnode = yang_dnode_get(root->dnode, base_xpath);
 	if (!base_dnode)
 		return -1;
 
@@ -348,7 +339,7 @@ static int mgmt_walk_ds_nodes(
 			       sizeof(xpath)));
 
 	nbnode = (struct nb_node *)base_dnode->schema->priv;
-	(*mgmt_ds_node_iter_fn)(ds_ctx, base_xpath, base_dnode, nbnode, ctx);
+	(*mgmt_ds_node_iter_fn)(base_xpath, base_dnode, nbnode, ctx);
 
 	/*
 	 * If the base_xpath points to a leaf node we can skip the tree walk.
@@ -370,7 +361,7 @@ static int mgmt_walk_ds_nodes(
 
 		MGMTD_DS_DBG(" -- Child xpath: %s", xpath);
 
-		ret = mgmt_walk_ds_nodes(ds_ctx, xpath, dnode,
+		ret = mgmt_walk_ds_nodes(root, xpath, dnode,
 					 mgmt_ds_node_iter_fn, ctx);
 		if (ret != 0)
 			break;
@@ -459,9 +450,9 @@ int mgmt_ds_load_config_from_file(struct mgmt_ds_ctx *dst,
 	return 0;
 }
 
-int mgmt_ds_iter_data(struct mgmt_ds_ctx *ds_ctx, const char *base_xpath,
-		      void (*mgmt_ds_node_iter_fn)(struct mgmt_ds_ctx *ds_ctx,
-						   const char *xpath,
+int mgmt_ds_iter_data(Mgmtd__DatastoreId ds_id, struct nb_config *root,
+		      const char *base_xpath,
+		      void (*mgmt_ds_node_iter_fn)(const char *xpath,
 						   struct lyd_node *node,
 						   struct nb_node *nb_node,
 						   void *ctx),
@@ -472,7 +463,7 @@ int mgmt_ds_iter_data(struct mgmt_ds_ctx *ds_ctx, const char *base_xpath,
 	struct lyd_node *base_dnode = NULL;
 	struct lyd_node *node;
 
-	if (!ds_ctx)
+	if (!root)
 		return -1;
 
 	strlcpy(xpath, base_xpath, sizeof(xpath));
@@ -484,12 +475,11 @@ int mgmt_ds_iter_data(struct mgmt_ds_ctx *ds_ctx, const char *base_xpath,
 	 * Oper-state should be kept in mind though for the prefix walk
 	 */
 
-	MGMTD_DS_DBG(" -- START DS walk for DSid: %d", ds_ctx->ds_id);
+	MGMTD_DS_DBG(" -- START DS walk for DSid: %d", ds_id);
 
 	/* If the base_xpath is empty then crawl the sibblings */
 	if (xpath[0] == 0) {
-		base_dnode = ds_ctx->config_ds ? ds_ctx->root.cfg_root->dnode
-						: ds_ctx->root.dnode_root;
+		base_dnode = root->dnode;
 
 		/* get first top-level sibling */
 		while (base_dnode->parent)
@@ -499,11 +489,11 @@ int mgmt_ds_iter_data(struct mgmt_ds_ctx *ds_ctx, const char *base_xpath,
 			base_dnode = base_dnode->prev;
 
 		LY_LIST_FOR (base_dnode, node) {
-			ret = mgmt_walk_ds_nodes(ds_ctx, xpath, node,
+			ret = mgmt_walk_ds_nodes(root, xpath, node,
 						 mgmt_ds_node_iter_fn, ctx);
 		}
 	} else
-		ret = mgmt_walk_ds_nodes(ds_ctx, xpath, base_dnode,
+		ret = mgmt_walk_ds_nodes(root, xpath, base_dnode,
 					 mgmt_ds_node_iter_fn, ctx);
 
 	return ret;

--- a/mgmtd/mgmt_ds.h
+++ b/mgmtd/mgmt_ds.h
@@ -179,19 +179,19 @@ extern struct mgmt_ds_ctx *mgmt_ds_get_ctx_by_id(struct mgmt_master *mm,
 extern bool mgmt_ds_is_config(struct mgmt_ds_ctx *ds_ctx);
 
 /*
- * Acquire read lock to a ds given a ds_handle
+ * Check if a given datastore is locked by a given session
  */
-extern int mgmt_ds_read_lock(struct mgmt_ds_ctx *ds_ctx);
+extern bool mgmt_ds_is_locked(struct mgmt_ds_ctx *ds_ctx, uint64_t session_id);
 
 /*
  * Acquire write lock to a ds given a ds_handle
  */
-extern int mgmt_ds_write_lock(struct mgmt_ds_ctx *ds_ctx);
+extern int mgmt_ds_lock(struct mgmt_ds_ctx *ds_ctx, uint64_t session_id);
 
 /*
  * Remove a lock from ds given a ds_handle
  */
-extern int mgmt_ds_unlock(struct mgmt_ds_ctx *ds_ctx);
+extern void mgmt_ds_unlock(struct mgmt_ds_ctx *ds_ctx);
 
 /*
  * Copy from source to destination datastore.
@@ -233,8 +233,11 @@ extern int mgmt_ds_delete_data_nodes(struct mgmt_ds_ctx *ds_ctx,
 /*
  * Iterate over datastore data.
  *
- * ds_ctx
- *    Datastore context.
+ * ds_id
+ *    Datastore ID..
+ *
+ * root
+ *    The root of the tree to iterate over.
  *
  * base_xpath
  *    Base YANG xpath from where needs to be iterated.
@@ -252,9 +255,9 @@ extern int mgmt_ds_delete_data_nodes(struct mgmt_ds_ctx *ds_ctx,
  *    0 on success, -1 on failure.
  */
 extern int mgmt_ds_iter_data(
-	struct mgmt_ds_ctx *ds_ctx, const char *base_xpath,
-	void (*mgmt_ds_node_iter_fn)(struct mgmt_ds_ctx *ds_ctx,
-				     const char *xpath, struct lyd_node *node,
+	Mgmtd__DatastoreId ds_id, struct nb_config *root,
+	const char *base_xpath,
+	void (*mgmt_ds_node_iter_fn)(const char *xpath, struct lyd_node *node,
 				     struct nb_node *nb_node, void *ctx),
 	void *ctx);
 

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -389,6 +389,7 @@ static int mgmt_fe_send_lockds_reply(struct mgmt_fe_session_ctx *session,
 {
 	Mgmtd__FeMessage fe_msg;
 	Mgmtd__FeLockDsReply lockds_reply;
+	bool scok = session->adapter->conn->is_short_circuit;
 
 	assert(session->adapter);
 
@@ -406,10 +407,10 @@ static int mgmt_fe_send_lockds_reply(struct mgmt_fe_session_ctx *session,
 	fe_msg.lockds_reply = &lockds_reply;
 
 	MGMTD_FE_ADAPTER_DBG(
-		"Sending LOCK_DS_REPLY message to MGMTD Frontend client '%s'",
-		session->adapter->name);
+		"Sending LOCK_DS_REPLY message to MGMTD Frontend client '%s' scok: %d",
+		session->adapter->name, scok);
 
-	return mgmt_fe_adapter_send_msg(session->adapter, &fe_msg, false);
+	return mgmt_fe_adapter_send_msg(session->adapter, &fe_msg, scok);
 }
 
 static int mgmt_fe_send_setcfg_reply(struct mgmt_fe_session_ctx *session,

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -40,8 +40,7 @@ struct mgmt_fe_session_ctx {
 	uint64_t client_id;
 	uint64_t txn_id;
 	uint64_t cfg_txn_id;
-	uint8_t ds_write_locked[MGMTD_DS_MAX_ID];
-	uint8_t ds_read_locked[MGMTD_DS_MAX_ID];
+	uint8_t ds_locked[MGMTD_DS_MAX_ID];
 	uint8_t ds_locked_implict[MGMTD_DS_MAX_ID];
 	struct event *proc_cfg_txn_clnp;
 	struct event *proc_show_txn_clnp;
@@ -72,8 +71,12 @@ mgmt_fe_session_write_lock_ds(Mgmtd__DatastoreId ds_id,
 				  struct mgmt_ds_ctx *ds_ctx,
 				  struct mgmt_fe_session_ctx *session)
 {
-	if (!session->ds_write_locked[ds_id]) {
-		if (mgmt_ds_write_lock(ds_ctx) != 0) {
+	if (session->ds_locked[ds_id])
+		zlog_warn("multiple lock taken by session-id: %" PRIu64
+			  " on DS:%s",
+			  session->session_id, mgmt_ds_id2name(ds_id));
+	else {
+		if (mgmt_ds_lock(ds_ctx, session->session_id)) {
 			MGMTD_FE_ADAPTER_DBG(
 				"Failed to lock the DS:%s for session-id: %" PRIu64
 				" from %s!",
@@ -82,7 +85,7 @@ mgmt_fe_session_write_lock_ds(Mgmtd__DatastoreId ds_id,
 			return -1;
 		}
 
-		session->ds_write_locked[ds_id] = true;
+		session->ds_locked[ds_id] = true;
 		MGMTD_FE_ADAPTER_DBG(
 			"Write-Locked the DS:%s for session-id: %" PRIu64
 			" from %s",
@@ -93,74 +96,22 @@ mgmt_fe_session_write_lock_ds(Mgmtd__DatastoreId ds_id,
 	return 0;
 }
 
-static int
-mgmt_fe_session_read_lock_ds(Mgmtd__DatastoreId ds_id,
-				 struct mgmt_ds_ctx *ds_ctx,
-				 struct mgmt_fe_session_ctx *session)
+static void mgmt_fe_session_unlock_ds(Mgmtd__DatastoreId ds_id,
+				      struct mgmt_ds_ctx *ds_ctx,
+				      struct mgmt_fe_session_ctx *session)
 {
-	if (!session->ds_read_locked[ds_id]) {
-		if (mgmt_ds_read_lock(ds_ctx) != 0) {
-			MGMTD_FE_ADAPTER_DBG(
-				"Failed to lock the DS:%s for session-is: %" PRIu64
-				" from %s",
-				mgmt_ds_id2name(ds_id), session->session_id,
-				session->adapter->name);
-			return -1;
-		}
+	if (!session->ds_locked[ds_id])
+		zlog_warn("unlock unlocked by session-id: %" PRIu64 " on DS:%s",
+			  session->session_id, mgmt_ds_id2name(ds_id));
 
-		session->ds_read_locked[ds_id] = true;
-		MGMTD_FE_ADAPTER_DBG(
-			"Read-Locked the DS:%s for session-id: %" PRIu64
-			" from %s",
-			mgmt_ds_id2name(ds_id), session->session_id,
-			session->adapter->name);
-	}
-
-	return 0;
-}
-
-static int mgmt_fe_session_unlock_ds(Mgmtd__DatastoreId ds_id,
-					 struct mgmt_ds_ctx *ds_ctx,
-					 struct mgmt_fe_session_ctx *session,
-					 bool unlock_write, bool unlock_read)
-{
-	if (unlock_write && session->ds_write_locked[ds_id]) {
-		session->ds_write_locked[ds_id] = false;
-		session->ds_locked_implict[ds_id] = false;
-		if (mgmt_ds_unlock(ds_ctx) != 0) {
-			MGMTD_FE_ADAPTER_DBG(
-				"Failed to unlock the DS:%s taken earlier by session-id: %" PRIu64
-				" from %s",
-				mgmt_ds_id2name(ds_id), session->session_id,
-				session->adapter->name);
-			return -1;
-		}
-
-		MGMTD_FE_ADAPTER_DBG(
-			"Unlocked DS:%s write-locked earlier by session-id: %" PRIu64
-			" from %s",
-			mgmt_ds_id2name(ds_id), session->session_id,
-			session->adapter->name);
-	} else if (unlock_read && session->ds_read_locked[ds_id]) {
-		session->ds_read_locked[ds_id] = false;
-		session->ds_locked_implict[ds_id] = false;
-		if (mgmt_ds_unlock(ds_ctx) != 0) {
-			MGMTD_FE_ADAPTER_DBG(
-				"Failed to unlock the DS:%s taken earlier by session-id: %" PRIu64
-				" from %s",
-				mgmt_ds_id2name(ds_id), session->session_id,
-				session->adapter->name);
-			return -1;
-		}
-
-		MGMTD_FE_ADAPTER_DBG(
-			"Unlocked DS:%s read-locked earlier by session-id: %" PRIu64
-			" from %s",
-			mgmt_ds_id2name(ds_id), session->session_id,
-			session->adapter->name);
-	}
-
-	return 0;
+	session->ds_locked[ds_id] = false;
+	session->ds_locked_implict[ds_id] = false;
+	mgmt_ds_unlock(ds_ctx);
+	MGMTD_FE_ADAPTER_DBG(
+		"Unlocked DS:%s write-locked earlier by session-id: %" PRIu64
+		" from %s",
+		mgmt_ds_id2name(ds_id), session->session_id,
+		session->adapter->name);
 }
 
 static void
@@ -177,11 +128,8 @@ mgmt_fe_session_cfg_txn_cleanup(struct mgmt_fe_session_ctx *session)
 
 	for (ds_id = 0; ds_id < MGMTD_DS_MAX_ID; ds_id++) {
 		ds_ctx = mgmt_ds_get_ctx_by_id(mm, ds_id);
-		if (ds_ctx) {
-			if (session->ds_locked_implict[ds_id])
-				mgmt_fe_session_unlock_ds(
-					ds_id, ds_ctx, session, true, false);
-		}
+		if (ds_ctx && session->ds_locked_implict[ds_id])
+			mgmt_fe_session_unlock_ds(ds_id, ds_ctx, session);
 	}
 
 	/*
@@ -194,17 +142,6 @@ mgmt_fe_session_cfg_txn_cleanup(struct mgmt_fe_session_ctx *session)
 static void
 mgmt_fe_session_show_txn_cleanup(struct mgmt_fe_session_ctx *session)
 {
-	Mgmtd__DatastoreId ds_id;
-	struct mgmt_ds_ctx *ds_ctx;
-
-	for (ds_id = 0; ds_id < MGMTD_DS_MAX_ID; ds_id++) {
-		ds_ctx = mgmt_ds_get_ctx_by_id(mm, ds_id);
-		if (ds_ctx) {
-			mgmt_fe_session_unlock_ds(ds_id, ds_ctx, session,
-						      false, true);
-		}
-	}
-
 	/*
 	 * Destroy the transaction created recently.
 	 */
@@ -245,25 +182,29 @@ mgmt_fe_session_compute_commit_timers(struct mgmt_commit_stats *cmt_stats)
 	}
 }
 
-static void mgmt_fe_cleanup_session(struct mgmt_fe_session_ctx **session)
+static void mgmt_fe_cleanup_session(struct mgmt_fe_session_ctx **sessionp)
 {
-	if ((*session)->adapter) {
-		mgmt_fe_session_cfg_txn_cleanup((*session));
-		mgmt_fe_session_show_txn_cleanup((*session));
-		mgmt_fe_session_unlock_ds(MGMTD_DS_CANDIDATE, mm->candidate_ds,
-					  *session, true, true);
-		mgmt_fe_session_unlock_ds(MGMTD_DS_RUNNING, mm->running_ds,
-					  *session, true, true);
+	Mgmtd__DatastoreId ds_id;
+	struct mgmt_ds_ctx *ds_ctx;
+	struct mgmt_fe_session_ctx *session = *sessionp;
 
-		mgmt_fe_sessions_del(&(*session)->adapter->fe_sessions,
-				     *session);
-		assert((*session)->adapter->refcount > 1);
-		mgmt_fe_adapter_unlock(&(*session)->adapter);
+	if (session->adapter) {
+		mgmt_fe_session_cfg_txn_cleanup(session);
+		mgmt_fe_session_show_txn_cleanup(session);
+		for (ds_id = 0; ds_id < MGMTD_DS_MAX_ID; ds_id++) {
+			ds_ctx = mgmt_ds_get_ctx_by_id(mm, ds_id);
+			if (ds_ctx && session->ds_locked[ds_id])
+				mgmt_fe_session_unlock_ds(ds_id, ds_ctx,
+							  session);
+		}
+		mgmt_fe_sessions_del(&session->adapter->fe_sessions, session);
+		assert(session->adapter->refcount > 1);
+		mgmt_fe_adapter_unlock(&session->adapter);
 	}
 
-	hash_release(mgmt_fe_sessions, *session);
-	XFREE(MTYPE_MGMTD_FE_SESSION, *session);
-	*session = NULL;
+	hash_release(mgmt_fe_sessions, session);
+	XFREE(MTYPE_MGMTD_FE_SESSION, session);
+	*sessionp = NULL;
 }
 
 static struct mgmt_fe_session_ctx *
@@ -735,7 +676,7 @@ mgmt_fe_session_handle_lockds_req_msg(struct mgmt_fe_session_ctx *session,
 
 		session->ds_locked_implict[lockds_req->ds_id] = false;
 	} else {
-		if (!session->ds_write_locked[lockds_req->ds_id]) {
+		if (!session->ds_locked[lockds_req->ds_id]) {
 			mgmt_fe_send_lockds_reply(
 				session, lockds_req->ds_id, lockds_req->req_id,
 				lockds_req->lock, false,
@@ -743,8 +684,7 @@ mgmt_fe_session_handle_lockds_req_msg(struct mgmt_fe_session_ctx *session,
 			return 0;
 		}
 
-		(void)mgmt_fe_session_unlock_ds(lockds_req->ds_id, ds_ctx,
-						    session, true, false);
+		mgmt_fe_session_unlock_ds(lockds_req->ds_id, ds_ctx, session);
 	}
 
 	if (mgmt_fe_send_lockds_reply(session, lockds_req->ds_id,
@@ -821,7 +761,7 @@ mgmt_fe_session_handle_setcfg_req_msg(struct mgmt_fe_session_ctx *session,
 		/*
 		 * Try taking write-lock on the requested DS (if not already).
 		 */
-		if (!session->ds_write_locked[setcfg_req->ds_id]) {
+		if (!session->ds_locked[setcfg_req->ds_id]) {
 			MGMTD_FE_ADAPTER_ERR(
 				"SETCFG_REQ on session-id: %" PRIu64
 				" without obtaining lock",
@@ -832,7 +772,7 @@ mgmt_fe_session_handle_setcfg_req_msg(struct mgmt_fe_session_ctx *session,
 				mgmt_fe_send_setcfg_reply(
 					session, setcfg_req->ds_id,
 					setcfg_req->req_id, false,
-					"Failed to lock the DS!",
+					"Failed to lock the target DS",
 					setcfg_req->implicit_commit);
 				goto mgmt_fe_sess_handle_setcfg_req_failed;
 			}
@@ -915,9 +855,8 @@ mgmt_fe_sess_handle_setcfg_req_failed:
 	 */
 	if (session->cfg_txn_id != MGMTD_TXN_ID_NONE)
 		mgmt_destroy_txn(&session->cfg_txn_id);
-	if (ds_ctx && session->ds_write_locked[setcfg_req->ds_id])
-		mgmt_fe_session_unlock_ds(setcfg_req->ds_id, ds_ctx, session,
-					      true, false);
+	if (ds_ctx && session->ds_locked[setcfg_req->ds_id])
+		mgmt_fe_session_unlock_ds(setcfg_req->ds_id, ds_ctx, session);
 
 	return 0;
 }
@@ -927,6 +866,7 @@ mgmt_fe_session_handle_getcfg_req_msg(struct mgmt_fe_session_ctx *session,
 					  Mgmtd__FeGetConfigReq *getcfg_req)
 {
 	struct mgmt_ds_ctx *ds_ctx;
+	struct nb_config *cfg_root = NULL;
 
 	/*
 	 * Get the DS handle.
@@ -939,11 +879,7 @@ mgmt_fe_session_handle_getcfg_req_msg(struct mgmt_fe_session_ctx *session,
 		return 0;
 	}
 
-	/*
-	 * Next check first if the GETCFG_REQ is for Candidate DS
-	 * or not. Report failure if its not. MGMTD currently only
-	 * supports editing the Candidate DS.
-	 */
+	/* GETCFG must be on candidate or running DS */
 	if (getcfg_req->ds_id != MGMTD_DS_CANDIDATE
 	    && getcfg_req->ds_id != MGMTD_DS_RUNNING) {
 		mgmt_fe_send_getcfg_reply(
@@ -954,27 +890,6 @@ mgmt_fe_session_handle_getcfg_req_msg(struct mgmt_fe_session_ctx *session,
 	}
 
 	if (session->txn_id == MGMTD_TXN_ID_NONE) {
-		/*
-		 * Try taking read-lock on the requested DS (if not already
-		 * locked). If the DS has already been write-locked by a ongoing
-		 * CONFIG transaction we may allow reading the contents of the
-		 * same DS.
-		 */
-		if (!session->ds_read_locked[getcfg_req->ds_id]
-		    && !session->ds_write_locked[getcfg_req->ds_id]) {
-			if (mgmt_fe_session_read_lock_ds(getcfg_req->ds_id,
-							     ds_ctx, session)
-			    != 0) {
-				mgmt_fe_send_getcfg_reply(
-					session, getcfg_req->ds_id,
-					getcfg_req->req_id, false, NULL,
-					"Failed to lock the DS! Another session might have locked it!");
-				goto mgmt_fe_sess_handle_getcfg_req_failed;
-			}
-
-			session->ds_locked_implict[getcfg_req->ds_id] = true;
-		}
-
 		/*
 		 * Start a SHOW Transaction (if not started already)
 		 */
@@ -992,6 +907,7 @@ mgmt_fe_session_handle_getcfg_req_msg(struct mgmt_fe_session_ctx *session,
 				     " for session-id: %" PRIu64,
 				     session->txn_id, session->session_id);
 	} else {
+		/* XXX chopps: Why would we already have a TXN here? */
 		MGMTD_FE_ADAPTER_DBG("Show txn-id: %" PRIu64
 				     " for session-id: %" PRIu64
 				     " already created",
@@ -999,12 +915,16 @@ mgmt_fe_session_handle_getcfg_req_msg(struct mgmt_fe_session_ctx *session,
 	}
 
 	/*
+	 * Get a copy of the datastore config root, avoids locking.
+	 */
+	cfg_root = nb_config_dup(mgmt_ds_get_nb_config(ds_ctx));
+
+	/*
 	 * Create a GETConfig request under the transaction.
 	 */
-	if (mgmt_txn_send_get_config_req(session->txn_id, getcfg_req->req_id,
-					  getcfg_req->ds_id, ds_ctx,
-					  getcfg_req->data, getcfg_req->n_data)
-	    != 0) {
+	if (mgmt_txn_send_get_config_req(
+		    session->txn_id, getcfg_req->req_id, getcfg_req->ds_id,
+		    cfg_root, getcfg_req->data, getcfg_req->n_data) != 0) {
 		mgmt_fe_send_getcfg_reply(
 			session, getcfg_req->ds_id, getcfg_req->req_id, false,
 			NULL, "Request processing for GET-CONFIG failed!");
@@ -1015,14 +935,13 @@ mgmt_fe_session_handle_getcfg_req_msg(struct mgmt_fe_session_ctx *session,
 
 mgmt_fe_sess_handle_getcfg_req_failed:
 
+	if (cfg_root)
+		nb_config_free(cfg_root);
 	/*
 	 * Destroy the transaction created recently.
 	 */
 	if (session->txn_id != MGMTD_TXN_ID_NONE)
 		mgmt_destroy_txn(&session->txn_id);
-	if (ds_ctx && session->ds_read_locked[getcfg_req->ds_id])
-		mgmt_fe_session_unlock_ds(getcfg_req->ds_id, ds_ctx, session,
-					      false, true);
 
 	return -1;
 }
@@ -1044,28 +963,16 @@ mgmt_fe_session_handle_getdata_req_msg(struct mgmt_fe_session_ctx *session,
 		return 0;
 	}
 
+	/* GETDATA must be on operational DS */
+	if (getdata_req->ds_id != MGMTD_DS_OPERATIONAL) {
+		mgmt_fe_send_getdata_reply(
+			session, getdata_req->ds_id, getdata_req->req_id, false,
+			NULL,
+			"Get-Data on datastore other than Operational DS not permitted!");
+		return 0;
+	}
+
 	if (session->txn_id == MGMTD_TXN_ID_NONE) {
-		/*
-		 * Try taking read-lock on the requested DS (if not already
-		 * locked). If the DS has already been write-locked by a ongoing
-		 * CONFIG transaction we may allow reading the contents of the
-		 * same DS.
-		 */
-		if (!session->ds_read_locked[getdata_req->ds_id]
-		    && !session->ds_write_locked[getdata_req->ds_id]) {
-			if (mgmt_fe_session_read_lock_ds(getdata_req->ds_id,
-							     ds_ctx, session)
-			    != 0) {
-				mgmt_fe_send_getdata_reply(
-					session, getdata_req->ds_id,
-					getdata_req->req_id, false, NULL,
-					"Failed to lock the DS! Another session might have locked it!");
-				goto mgmt_fe_sess_handle_getdata_req_failed;
-			}
-
-			session->ds_locked_implict[getdata_req->ds_id] = true;
-		}
-
 		/*
 		 * Start a SHOW Transaction (if not started already)
 		 */
@@ -1092,9 +999,8 @@ mgmt_fe_session_handle_getdata_req_msg(struct mgmt_fe_session_ctx *session,
 	 * Create a GETData request under the transaction.
 	 */
 	if (mgmt_txn_send_get_data_req(session->txn_id, getdata_req->req_id,
-					getdata_req->ds_id, ds_ctx,
-					getdata_req->data, getdata_req->n_data)
-	    != 0) {
+				       getdata_req->ds_id, getdata_req->data,
+				       getdata_req->n_data) != 0) {
 		mgmt_fe_send_getdata_reply(
 			session, getdata_req->ds_id, getdata_req->req_id, false,
 			NULL, "Request processing for GET-CONFIG failed!");
@@ -1110,10 +1016,6 @@ mgmt_fe_sess_handle_getdata_req_failed:
 	 */
 	if (session->txn_id != MGMTD_TXN_ID_NONE)
 		mgmt_destroy_txn(&session->txn_id);
-
-	if (ds_ctx && session->ds_read_locked[getdata_req->ds_id])
-		mgmt_fe_session_unlock_ds(getdata_req->ds_id, ds_ctx,
-					      session, false, true);
 
 	return -1;
 }
@@ -1192,7 +1094,7 @@ static int mgmt_fe_session_handle_commit_config_req_msg(
 	/*
 	 * Try taking write-lock on the destination DS (if not already).
 	 */
-	if (!session->ds_write_locked[commcfg_req->dst_ds_id]) {
+	if (!session->ds_locked[commcfg_req->dst_ds_id]) {
 		if (mgmt_fe_session_write_lock_ds(commcfg_req->dst_ds_id,
 						      dst_ds_ctx, session)
 		    != 0) {
@@ -1215,8 +1117,7 @@ static int mgmt_fe_session_handle_commit_config_req_msg(
 		    session->cfg_txn_id, commcfg_req->req_id,
 		    commcfg_req->src_ds_id, src_ds_ctx, commcfg_req->dst_ds_id,
 		    dst_ds_ctx, commcfg_req->validate_only, commcfg_req->abort,
-		    false)
-	    != 0) {
+		    false) != 0) {
 		mgmt_fe_send_commitcfg_reply(
 			session, commcfg_req->src_ds_id, commcfg_req->dst_ds_id,
 			commcfg_req->req_id, MGMTD_INTERNAL_ERROR,
@@ -1744,16 +1645,12 @@ void mgmt_fe_adapter_status_write(struct vty *vty, bool detail)
 				session->session_id);
 			vty_out(vty, "        DS-Locks:\n");
 			FOREACH_MGMTD_DS_ID (ds_id) {
-				if (session->ds_write_locked[ds_id]
-				    || session->ds_read_locked[ds_id]) {
+				if (session->ds_locked[ds_id]) {
 					locked = true;
-					vty_out(vty,
-						"          %s\t\t\t%s, %s\n",
+					vty_out(vty, "          %s\t\t\t%s\n",
 						mgmt_ds_id2name(ds_id),
-						session->ds_write_locked[ds_id]
-							? "Write"
-							: "Read",
-						session->ds_locked_implict[ds_id]
+						session->ds_locked_implict
+								[ds_id]
 							? "Implicit"
 							: "Explicit");
 				}

--- a/mgmtd/mgmt_history.c
+++ b/mgmtd/mgmt_history.c
@@ -211,7 +211,7 @@ static int mgmt_history_rollback_to_cmt(struct vty *vty,
 		return -1;
 	}
 
-	ret = mgmt_ds_write_lock(dst_ds_ctx);
+	ret = mgmt_ds_lock(dst_ds_ctx, vty->mgmt_session_id);
 	if (ret != 0) {
 		vty_out(vty,
 			"Failed to lock the DS %u for rollback Reason: %s!\n",
@@ -242,6 +242,8 @@ static int mgmt_history_rollback_to_cmt(struct vty *vty,
 	}
 
 	mgmt_history_dump_cmt_record_index();
+
+	/* XXX chopps when does this get unlocked? */
 
 	/*
 	 * Block the rollback command from returning till the rollback

--- a/mgmtd/mgmt_history.c
+++ b/mgmtd/mgmt_history.c
@@ -196,23 +196,21 @@ static int mgmt_history_rollback_to_cmt(struct vty *vty,
 	}
 
 	src_ds_ctx = mgmt_ds_get_ctx_by_id(mm, MGMTD_DS_CANDIDATE);
-	if (!src_ds_ctx) {
-		vty_out(vty, "ERROR: Couldnot access Candidate datastore!\n");
-		return -1;
-	}
-
-	/*
-	 * Note: Write lock on src_ds is not required. This is already
-	 * taken in 'conf te'.
-	 */
 	dst_ds_ctx = mgmt_ds_get_ctx_by_id(mm, MGMTD_DS_RUNNING);
-	if (!dst_ds_ctx) {
-		vty_out(vty, "ERROR: Couldnot access Running datastore!\n");
+	assert(src_ds_ctx);
+	assert(dst_ds_ctx);
+
+	ret = mgmt_ds_lock(src_ds_ctx, vty->mgmt_session_id);
+	if (ret != 0) {
+		vty_out(vty,
+			"Failed to lock the DS %u for rollback Reason: %s!\n",
+			MGMTD_DS_RUNNING, strerror(ret));
 		return -1;
 	}
 
 	ret = mgmt_ds_lock(dst_ds_ctx, vty->mgmt_session_id);
 	if (ret != 0) {
+		mgmt_ds_unlock(src_ds_ctx);
 		vty_out(vty,
 			"Failed to lock the DS %u for rollback Reason: %s!\n",
 			MGMTD_DS_RUNNING, strerror(ret));
@@ -223,27 +221,28 @@ static int mgmt_history_rollback_to_cmt(struct vty *vty,
 		ret = mgmt_ds_load_config_from_file(
 			src_ds_ctx, cmt_info->cmt_json_file, false);
 		if (ret != 0) {
-			mgmt_ds_unlock(dst_ds_ctx);
 			vty_out(vty,
 				"Error with parsing the file with error code %d\n",
 				ret);
-			return ret;
+			goto failed_unlock;
 		}
 	}
 
 	/* Internally trigger a commit-request. */
 	ret = mgmt_txn_rollback_trigger_cfg_apply(src_ds_ctx, dst_ds_ctx);
 	if (ret != 0) {
-		mgmt_ds_unlock(dst_ds_ctx);
 		vty_out(vty,
 			"Error with creating commit apply txn with error code %d\n",
 			ret);
-		return ret;
+		goto failed_unlock;
 	}
 
 	mgmt_history_dump_cmt_record_index();
 
-	/* XXX chopps when does this get unlocked? */
+	/*
+	 * TODO: Cleanup: the generic TXN code currently checks for rollback
+	 * and does the unlock when it completes.
+	 */
 
 	/*
 	 * Block the rollback command from returning till the rollback
@@ -253,6 +252,11 @@ static int mgmt_history_rollback_to_cmt(struct vty *vty,
 	vty->mgmt_req_pending_cmd = "ROLLBACK";
 	rollback_vty = vty;
 	return 0;
+
+failed_unlock:
+	mgmt_ds_unlock(src_ds_ctx);
+	mgmt_ds_unlock(dst_ds_ctx);
+	return ret;
 }
 
 void mgmt_history_rollback_complete(bool success)

--- a/mgmtd/mgmt_txn.h
+++ b/mgmtd/mgmt_txn.h
@@ -169,12 +169,12 @@ extern int mgmt_txn_send_set_config_req(uint64_t txn_id, uint64_t req_id,
  *    0 on success, -1 on failures.
  */
 extern int mgmt_txn_send_commit_config_req(uint64_t txn_id, uint64_t req_id,
-					    Mgmtd__DatastoreId src_ds_id,
-					    struct mgmt_ds_ctx *dst_ds_ctx,
-					    Mgmtd__DatastoreId dst_ds_id,
-					    struct mgmt_ds_ctx *src_ds_ctx,
-					    bool validate_only, bool abort,
-					    bool implicit);
+					   Mgmtd__DatastoreId src_ds_id,
+					   struct mgmt_ds_ctx *dst_ds_ctx,
+					   Mgmtd__DatastoreId dst_ds_id,
+					   struct mgmt_ds_ctx *src_ds_ctx,
+					   bool validate_only, bool abort,
+					   bool implicit);
 
 /*
  * Send get-config request to be processed later in transaction.
@@ -182,10 +182,10 @@ extern int mgmt_txn_send_commit_config_req(uint64_t txn_id, uint64_t req_id,
  * Similar to set-config request.
  */
 extern int mgmt_txn_send_get_config_req(uint64_t txn_id, uint64_t req_id,
-					 Mgmtd__DatastoreId ds_id,
-					 struct mgmt_ds_ctx *ds_ctx,
-					 Mgmtd__YangGetDataReq **data_req,
-					 size_t num_reqs);
+					Mgmtd__DatastoreId ds_id,
+					struct nb_config *cfg_root,
+					Mgmtd__YangGetDataReq **data_req,
+					size_t num_reqs);
 
 /*
  * Send get-data request to be processed later in transaction.
@@ -194,7 +194,6 @@ extern int mgmt_txn_send_get_config_req(uint64_t txn_id, uint64_t req_id,
  */
 extern int mgmt_txn_send_get_data_req(uint64_t txn_id, uint64_t req_id,
 				       Mgmtd__DatastoreId ds_id,
-				       struct mgmt_ds_ctx *ds_ctx,
 				       Mgmtd__YangGetDataReq **data_req,
 				       size_t num_reqs);
 

--- a/tests/lib/test_grpc.cpp
+++ b/tests/lib/test_grpc.cpp
@@ -114,7 +114,7 @@ static void static_startup(void)
 	// Add a route
 	vty = vty_new();
 	vty->type = vty::VTY_TERM;
-	vty_config_enter(vty, true, false);
+	vty_config_enter(vty, true, false, false);
 
 	auto ret = cmd_execute(vty, "ip route 11.0.0.0/8 Null0", NULL, 0);
 	assert(!ret);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2333,8 +2333,9 @@ DEFUNSH(VTYSH_REALLYALL, vtysh_disable, vtysh_disable_cmd, "disable",
 }
 
 DEFUNSH(VTYSH_REALLYALL, vtysh_config_terminal, vtysh_config_terminal_cmd,
-	"configure [terminal]",
+	"configure [terminal [file-lock]]",
 	"Configuration from vty interface\n"
+	"Configuration with locked datastores\n"
 	"Configuration terminal\n")
 {
 	vty->node = CONFIG_NODE;
@@ -2355,7 +2356,7 @@ static int vtysh_exit(struct vty *vty)
 	if (vty->node == CONFIG_NODE) {
 		/* resync in case one of the daemons is somewhere else */
 		vtysh_execute("end");
-		vtysh_execute("configure");
+		vtysh_execute("configure terminal file-lock");
 	}
 	return CMD_SUCCESS;
 }

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -607,7 +607,7 @@ static int vtysh_read_file(FILE *confp, bool dry_run)
 	vty->node = CONFIG_NODE;
 
 	vtysh_execute_no_pager("enable");
-	vtysh_execute_no_pager("configure terminal");
+	vtysh_execute_no_pager("configure terminal file-lock");
 
 	if (!dry_run)
 		vtysh_execute_no_pager("XFRR_start_configuration");


### PR DESCRIPTION
CLEANUP WRITE LOCKS

Move away from things like "lock if not locked" type code.

New KISS requirements API user must always lock the datastores.

- SET CFG:
  not implicit commit - requires user has locked candidate DS and they
    must unlock after

  implicit commit - requires user has locked candidate and running DS
    both locks will be unlocked on reply to the SETCFG

- COMMIT CFG:
  requires user has locked candidate and running DS and they must unlock
  after

NO READ LOCKS:

Run get-config operation from a snapshot of tree, eliminating need for read locks.

- For get-config operation instead of trying to maintain read and write locking, we take a snapshot of the config and run the operation off that. This allowed us to remove read locking from mgmtd.

- Also use short-circuit path for CLI (frontend) client to obtain locks.