### PR TITLE
doc: Fix one syntax error for code block

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -453,7 +453,7 @@ the tests log directory e.g.,::
    -rw------- 1 root root 45172 Apr 19 05:30 capture-r2-r2-eth0.pcap
    -rw------- 1 root root 48412 Apr 19 05:30 capture-sw1.pcap
    ...
--
+
 Viewing Live Daemon Logs
 """"""""""""""""""""""""
 


### PR DESCRIPTION
The code block doesn't work because blank line is missing. So, just make it work.