### PR TITLE
fix crashes in rip and ripng

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3597,17 +3597,9 @@ static int rip_vrf_new(struct vrf *vrf)
 
 static int rip_vrf_delete(struct vrf *vrf)
 {
-	struct rip *rip;
-
 	if (IS_RIP_DEBUG_EVENT)
 		zlog_debug("%s: VRF deleted: %s(%u)", __func__, vrf->name,
 			   vrf->vrf_id);
-
-	rip = rip_lookup_by_vrf_name(vrf->name);
-	if (!rip)
-		return 0;
-
-	rip_clean(rip);
 
 	return 0;
 }

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2624,17 +2624,10 @@ static int ripng_vrf_new(struct vrf *vrf)
 
 static int ripng_vrf_delete(struct vrf *vrf)
 {
-	struct ripng *ripng;
-
 	if (IS_RIPNG_DEBUG_EVENT)
 		zlog_debug("%s: VRF deleted: %s(%u)", __func__, vrf->name,
 			   vrf->vrf_id);
 
-	ripng = ripng_lookup_by_vrf_name(vrf->name);
-	if (!ripng)
-		return 0;
-
-	ripng_clean(ripng);
 	return 0;
 }
 


### PR DESCRIPTION
Revert a couple of faulty commits.

To reproduce in ripd:
```
frr# conf t
frr(config)# vrf vrf1
frr(config-vrf)# exit
frr(config)# router rip vrf vrf1
frr(config-router)# exit
frr(config)# no vrf vrf1
frr(config)# no router rip vrf vrf1
vtysh: error reading from ripd: Resource temporarily unavailable (11)Warning: closing connection to ripd because of an I/O error!
frr(config)#
```

Same thing with ripngd.