### PR TITLE
ospfd: Add config callbacks and suppress hello during config load.

### DIFF
--- a/ospfd/ospf_main.c
+++ b/ospfd/ospf_main.c
@@ -134,6 +134,32 @@ FRR_DAEMON_INFO(ospfd, OSPF, .vty_port = OSPF_VTY_PORT,
 		.n_yang_modules = array_size(ospfd_yang_modules),
 );
 
+/** Max wait time for config to load before accepting hellos */
+#define OSPF_PRE_CONFIG_MAX_WAIT_SECONDS 600
+
+static void ospf_config_finish(struct event *t)
+{
+	zlog_err("OSPF configuration end timer expired after %d seconds.",
+		 OSPF_PRE_CONFIG_MAX_WAIT_SECONDS);
+}
+
+static void ospf_config_start(void)
+{
+	EVENT_OFF(t_ospf_cfg);
+	if (IS_DEBUG_OSPF_EVENT)
+		zlog_debug("ospfd config start callback received.");
+	event_add_timer(master, ospf_config_finish, NULL,
+			OSPF_PRE_CONFIG_MAX_WAIT_SECONDS, &t_ospf_cfg);
+}
+
+static void ospf_config_end(void)
+{
+	if (IS_DEBUG_OSPF_EVENT)
+		zlog_debug("ospfd config end callback received.");
+
+	EVENT_OFF(t_ospf_cfg);
+}
+
 /* OSPFd main routine. */
 int main(int argc, char **argv)
 {
@@ -192,6 +218,9 @@ int main(int argc, char **argv)
 
 	access_list_init();
 	prefix_list_init();
+
+	/* Configuration processing callback initialization. */
+	cmd_init_config_callbacks(ospf_config_start, ospf_config_end);
 
 	/* OSPFd inits. */
 	ospf_if_init();

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -3682,6 +3682,16 @@ static void ospf_hello_send_sub(struct ospf_interface *oi, in_addr_t addr)
 	struct ospf_packet *op;
 	uint16_t length = OSPF_HEADER_SIZE;
 
+	/* Check if config is still being processed */
+	if (event_is_scheduled(t_ospf_cfg)) {
+		if (IS_DEBUG_OSPF_PACKET(0, SEND))
+			zlog_debug(
+				"Suppressing hello to %pI4 on %s during config load",
+				&(addr), IF_NAME(oi));
+
+		return;
+	}
+
 	op = ospf_packet_new(oi->ifp->mtu);
 
 	/* Prepare OSPF common header. */

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -61,6 +61,8 @@ unsigned short ospf_instance;
 
 extern struct zclient *zclient;
 
+/* OSPF config processing timer thread */
+struct event *t_ospf_cfg;
 
 static void ospf_remove_vls_through_area(struct ospf *, struct ospf_area *);
 static void ospf_network_free(struct ospf *, struct ospf_network *);

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -70,6 +70,9 @@
 /* Default socket buffer size */
 #define OSPF_DEFAULT_SOCK_BUFSIZE   (8 * 1024 * 1024)
 
+/* OSPF config processing timer thread */
+extern struct event *t_ospf_cfg;
+
 struct ospf_external {
 	unsigned short instance;
 	struct route_table *external_info;


### PR DESCRIPTION
Added configuration callbacks to prevent ospfd from sending hellos during config load. 
Tried similar change in ospf6d but it resulted in topotest failures - more investigation needed. 

Closes https://github.com/FRRouting/frr/issues/13542