### PR TITLE
ospf6d: Add config callbacks to suppress hellos during config load.

### DIFF
--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -2248,6 +2248,17 @@ void ospf6_hello_send(struct event *thread)
 	if (oi->gr.hello_delay.t_grace_send)
 		return;
 
+	/* Check if config is still being processed */
+	if (event_is_scheduled(t_ospf6_cfg)) {
+		if (IS_OSPF6_DEBUG_MESSAGE(OSPF6_MESSAGE_TYPE_HELLO, SEND))
+			zlog_debug(
+				"Suppressing Hello on interface %s during config load",
+				oi->interface->name);
+		event_add_timer(master, ospf6_hello_send, oi,
+				oi->hello_interval, &oi->thread_send_hello);
+		return;
+	}
+
 	if (oi->state <= OSPF6_INTERFACE_DOWN) {
 		if (IS_OSPF6_DEBUG_MESSAGE(OSPF6_MESSAGE_TYPE_HELLO, SEND_HDR))
 			zlog_debug("Unable to send Hello on down interface %s",

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -34,8 +34,15 @@
 #include "lib/json.h"
 #include "ospf6_nssa.h"
 #include "ospf6_auth_trailer.h"
+#include "ospf6d/ospf6d_clippy.c"
 
 DEFINE_MGROUP(OSPF6D, "ospf6d");
+
+/* OSPF6 config processing timer thread */
+struct event *t_ospf6_cfg;
+
+/* OSPF6 debug event state */
+unsigned char conf_debug_ospf6_event;
 
 struct route_node *route_prev(struct route_node *node)
 {
@@ -62,6 +69,7 @@ struct route_node *route_prev(struct route_node *node)
 }
 
 static int config_write_ospf6_debug(struct vty *vty);
+static int config_write_ospf6_debug_event(struct vty *vty);
 static struct cmd_node debug_node = {
 	.name = "debug",
 	.node = DEBUG_NODE,
@@ -85,6 +93,7 @@ static int config_write_ospf6_debug(struct vty *vty)
 	config_write_ospf6_debug_nssa(vty);
 	config_write_ospf6_debug_gr_helper(vty);
 	config_write_ospf6_debug_auth(vty);
+	config_write_ospf6_debug_event(vty);
 
 	return 0;
 }
@@ -1374,6 +1383,29 @@ DEFUN(show_ipv6_ospf6_linkstate_detail, show_ipv6_ospf6_linkstate_detail_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY(debug_ospf6_event, debug_ospf6_event_cmd, "[no] debug ospf6 event",
+      NO_STR DEBUG_STR OSPF6_STR "Debug OSPFv3 event function\n")
+{
+	if (!no)
+		OSPF6_DEBUG_EVENT_ON();
+	else
+		OSPF6_DEBUG_EVENT_OFF();
+	return CMD_SUCCESS;
+}
+
+static int config_write_ospf6_debug_event(struct vty *vty)
+{
+	if (IS_OSPF6_DEBUG_EVENT)
+		vty_out(vty, "debug ospf6 event\n");
+	return 0;
+}
+
+static void install_element_ospf6_debug_event(void)
+{
+	install_element(ENABLE_NODE, &debug_ospf6_event_cmd);
+	install_element(CONFIG_NODE, &debug_ospf6_event_cmd);
+}
+
 /* Install ospf related commands. */
 void ospf6_init(struct event_loop *master)
 {
@@ -1447,6 +1479,7 @@ void ospf6_init(struct event_loop *master)
 		VIEW_NODE,
 		&show_ipv6_ospf6_database_type_self_originated_linkstate_id_cmd);
 	install_element(VIEW_NODE, &show_ipv6_ospf6_database_aggr_router_cmd);
+	install_element_ospf6_debug_event();
 	install_element_ospf6_debug_auth();
 	ospf6_interface_auth_trailer_cmd_init();
 	install_element_ospf6_clear_intf_auth();

--- a/ospf6d/ospf6d.h
+++ b/ospf6d/ospf6d.h
@@ -15,6 +15,9 @@ DECLARE_MGROUP(OSPF6D);
 /* global variables */
 extern struct event_loop *master;
 
+/* OSPF config processing timer thread */
+extern struct event *t_ospf6_cfg;
+
 /* Historical for KAME.  */
 #ifndef IPV6_JOIN_GROUP
 #ifdef IPV6_ADD_MEMBERSHIP
@@ -104,6 +107,12 @@ extern struct event_loop *master;
 #define OSPF6_INVALID -1
 
 extern struct zebra_privs_t ospf6d_privs;
+
+/* Event Debug option */
+extern unsigned char conf_debug_ospf6_event;
+#define OSPF6_DEBUG_EVENT_ON() (conf_debug_ospf6_event = 1)
+#define OSPF6_DEBUG_EVENT_OFF() (conf_debug_ospf6_event = 0)
+#define IS_OSPF6_DEBUG_EVENT (conf_debug_ospf6_event)
 
 /* Function Prototypes */
 extern struct route_node *route_prev(struct route_node *node);

--- a/ospf6d/subdir.am
+++ b/ospf6d/subdir.am
@@ -75,6 +75,7 @@ ospf6d_ospf6d_snmp_la_LDFLAGS = $(MODULE_LDFLAGS)
 ospf6d_ospf6d_snmp_la_LIBADD = lib/libfrrsnmp.la
 
 clippy_scan += \
+	ospf6d/ospf6d.c \
 	ospf6d/ospf6_top.c \
 	ospf6d/ospf6_area.c \
 	ospf6d/ospf6_asbr.c \


### PR DESCRIPTION
Add config-callbacks to ospf6d to suppress sending hellos during config load. Also, add "debug ospf6 event". 

Tested with ospf6 and ospfv3 topo tests. 