### PR TITLE
vrrpd: add priority field into interface json

### DIFF
--- a/vrrpd/vrrp_vty.c
+++ b/vrrpd/vrrp_vty.c
@@ -398,6 +398,7 @@ static struct json_object *vrrp_build_json(struct vrrp_vrouter *vr)
 	json_object_string_add(j, "interface", vr->ifp->name);
 	json_object_int_add(j, "advertisementInterval",
 			    vr->advertisement_interval * CS2MS);
+	json_object_int_add(j, "priority", vr->priority);
 	/* v4 */
 	json_object_string_add(v4, "interface",
 			       vr->v4->mvl_ifp ? vr->v4->mvl_ifp->name : "");


### PR DESCRIPTION
'Priority' attribute is missing in "show vrrp interface <intf> json" output. Whereas it is there in non-json output.

It has been added now in show vrrp interface json output.

Before Fix:

```
vrrp1# show vrrp interface swp5.101 json
[
  {
    "vrid":2,
    "version":3,
    "autoconfigured":false,
    "shutdown":false,
    "preemptMode":true,
    "acceptMode":true,
    "interface":"swp5.101",
    "advertisementInterval":1000,
    "v4":{
      "interface":"vrrp4-11-2",
      "vmac":"00:00:5e:00:01:02",
      "primaryAddress":"50.0.0.2",
      "status":"Master",
      "effectivePriority":110,
      "masterAdverInterval":1000,
      "skewTime":570,
      "masterDownInterval":3570,
      "stats":{
        "adverTx":248456,
        "adverRx":1,
        "garpTx":1,
        "transitions":2
      },
      "addresses":[
        "50.0.0.1"
      ]
    },
    "v6":{
      "interface":"vrrp6-11-2",
      "vmac":"00:00:5e:00:02:02",
      "primaryAddress":"fe80::7f1:49e7:768c:aa73",
      "status":"Master",
      "effectivePriority":110,
      "masterAdverInterval":1000,
      "skewTime":570,
      "masterDownInterval":3570,
      "stats":{
        "adverTx":248455,
        "adverRx":1,
        "neighborAdverTx":1,
        "transitions":2
      },
      "addresses":[
        "2001:50::1"
      ]
    }
  }
]
vrrp1#
```

After Fix:

```
vrrp1# show vrrp interface swp5.101 json
[
  {
    "vrid":2,
    "version":3,
    "autoconfigured":false,
    "shutdown":false,
    "preemptMode":true,
    "acceptMode":true,
    "interface":"swp5.101",
    "advertisementInterval":1000,
    "priority":110, ====> priority added into json output
    "v4":{
      "interface":"vrrp4-11-2",
      "vmac":"00:00:5e:00:01:02",
      "primaryAddress":"50.0.0.2",
      "status":"Master",
      "effectivePriority":110,
      "masterAdverInterval":1000,
      "skewTime":570,
      "masterDownInterval":3570,
      "stats":{
        "adverTx":15,
        "adverRx":4,
        "garpTx":1,
        "transitions":2
      },
      "addresses":[
        "50.0.0.1"
      ]
    },
    "v6":{
      "interface":"vrrp6-11-2",
      "vmac":"00:00:5e:00:02:02",
      "primaryAddress":"fe80::7f1:49e7:768c:aa73",
      "status":"Master",
      "effectivePriority":110,
      "masterAdverInterval":1000,
      "skewTime":570,
      "masterDownInterval":3570,
      "stats":{
        "adverTx":13,
        "adverRx":5,
        "neighborAdverTx":1,
        "transitions":2
      },
      "addresses":[
        "2001:50::1"
      ]
    }
  }
]
```

Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>