### PR TITLE
ospf6d: Increment sequence number correctly in Authentication Trailer

### DIFF
--- a/ospf6d/ospf6_auth_trailer.c
+++ b/ospf6d/ospf6_auth_trailer.c
@@ -604,20 +604,19 @@ void ospf6_auth_digest_send(struct in6_addr *src, struct ospf6_interface *oi,
 	else
 		return;
 
-	ospf6->seqnum_l++;
 	if (ospf6->seqnum_l == 0xFFFFFFFF) {
-		ospf6->seqnum_h++;
-		ospf6->seqnum_l = 0;
+		if (ospf6->seqnum_h == 0xFFFFFFFF) {
+			/* Key must be reset, which is not handled as of now. */
+			zlog_err("Sequence number wrapped; key must be reset.");
+			ospf6->seqnum_h = 0;
+		} else {
+			ospf6->seqnum_h++;
+		}
 		ospf6_auth_seqno_nvm_update(ospf6);
-	}
 
-	/* Key must be reset. which is not handled as of now. */
-	if ((ospf6->seqnum_l == 0xFFFFFFFF)
-	    && (ospf6->seqnum_h == 0xFFFFFFFF)) {
 		ospf6->seqnum_l = 0;
-		ospf6->seqnum_h = 0;
-		zlog_err(
-			"Both Higher and Lower sequence number has wrapped. Need to reset the key");
+	} else {
+		ospf6->seqnum_l++;
 	}
 
 	memset(apad, 0, sizeof(apad));


### PR DESCRIPTION
According to RFC 7166, the sequence number should be treated as an unsigned 64-bit value, although it is stored as two 32-bit values.

When incrementing it, the code caused the lower-order 32-bit value to skip from 0xFFFFFFFE to 0. As a side effect, an error was never produced if the full 64-bit sequence number wrapped.

Fixes: #13805