### PR TITLE
isis: switch to time_t to avoid truncation issues

### DIFF
--- a/isisd/isis_nb.h
+++ b/isisd/isis_nb.h
@@ -727,7 +727,7 @@ void isis_notif_lsp_received(const struct isis_circuit *circuit,
 			     const uint8_t *lsp_id, uint32_t seqno,
 			     uint32_t timestamp, const char *sys_id);
 void isis_notif_lsp_gen(const struct isis_area *area, const uint8_t *lsp_id,
-			uint32_t seqno, uint32_t timestamp);
+			uint32_t seqno, time_t timestamp);
 void isis_notif_id_len_mismatch(const struct isis_circuit *circuit,
 				uint8_t rcv_id_len, const char *raw_pdu,
 				size_t raw_pdu_len);

--- a/isisd/isis_nb_notifications.c
+++ b/isisd/isis_nb_notifications.c
@@ -411,7 +411,7 @@ void isis_notif_lsp_received(const struct isis_circuit *circuit,
 	data = yang_data_new_uint32(xpath_arg, seqno);
 	listnode_add(arguments, data);
 	snprintf(xpath_arg, sizeof(xpath_arg), "%s/received-timestamp", xpath);
-	data = yang_data_new_uint32(xpath_arg, timestamp);
+	data = yang_data_new_uint32(xpath_arg, (uint32_t)timestamp);
 	listnode_add(arguments, data);
 	snprintf(xpath_arg, sizeof(xpath_arg), "%s/neighbor-system-id", xpath);
 	data = yang_data_new_string(xpath_arg, sys_id);
@@ -424,7 +424,7 @@ void isis_notif_lsp_received(const struct isis_circuit *circuit,
  * XPath: /frr-isisd:lsp-generation
  */
 void isis_notif_lsp_gen(const struct isis_area *area, const uint8_t *lsp_id,
-			uint32_t seqno, uint32_t timestamp)
+			uint32_t seqno, time_t timestamp)
 {
 	const char *xpath = "/frr-isisd:lsp-generation";
 	struct list *arguments = yang_data_list_new();
@@ -441,7 +441,7 @@ void isis_notif_lsp_gen(const struct isis_area *area, const uint8_t *lsp_id,
 	data = yang_data_new_uint32(xpath_arg, seqno);
 	listnode_add(arguments, data);
 	snprintf(xpath_arg, sizeof(xpath_arg), "%s/send-timestamp", xpath);
-	data = yang_data_new_uint32(xpath_arg, timestamp);
+	data = yang_data_new_uint32(xpath_arg, (uint32_t)timestamp);
 	listnode_add(arguments, data);
 
 	nb_notification_send(xpath, arguments);


### PR DESCRIPTION
CID1519822: switch to time_t to avoid truncation issues.