### PR TITLE
pim, pim6d: pimreg interface is not getting added in a certain scenario

### DIFF
--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -745,6 +745,7 @@ void pim_reg_del_on_couldreg_fail(struct interface *ifp)
 					    PIM_OIF_FLAG_PROTO_PIM, __func__);
 			EVENT_OFF(up->t_rs_timer);
 			up->reg_state = PIM_REG_NOINFO;
+			PIM_UPSTREAM_FLAG_UNSET_FHR(up->flags);
 		}
 	}
 }

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1713,6 +1713,7 @@ static void pim_upstream_register_stop_timer(struct event *t)
 				zlog_debug("%s: up %s RPF is not present",
 					   __func__, up->sg_str);
 			up->reg_state = PIM_REG_NOINFO;
+			PIM_UPSTREAM_FLAG_UNSET_FHR(up->flags);
 			return;
 		}
 


### PR DESCRIPTION
Problem:
When ipv6 pim configuration is removed from the IIF on FHR node, if we wait for RST timer to expire and then add the ipv6 pim configuration on the IIF again, it is seen that pimreg is not getting added due to which null register wont be sent, the register flag state also remains NO_INFO forever instead of RegPrune. The reason for this is, when RST timer expires and IIF is unknown for the (S,G) upstream, the FHR state is not reset due to which when the RP becomes reachable, upstream state changes from NotJoined to Join but the register suppress timer could not be started since we see there is no change in FHR state.

Fix:
When the Register Timer expires and the reg state is set to PIM_REG_NOINFO,reset the FHR flag, so that when the RP becomes reachable can be because of config change or RP not reachable, it is able to resume its duty.

Closes #12396 