### PR TITLE
doc: Fix typo in previous Coverity workflow doc commit.

### DIFF
--- a/doc/developer/workflow.rst
+++ b/doc/developer/workflow.rst
@@ -1345,12 +1345,12 @@ Coverity static analysis errors prior to submission using the
 ``scan-build`` command. To use this command, the ``clang-tools`` package must
 be installed. For example, this can be accomplished on Ubuntu with the
 ``sudo apt-get install clang-tools`` command.  Then, touch the files you want scanned and
-invoke the ``scan-file`` command. For example::
+invoke the ``scan-build`` command. For example::
   
   cd ~/GitHub/frr
   touch ospfd/ospf_flood.c ospfd/ospf_vty.c ospfd/ospf_opaque.c
   cd build
-  scan-file make -j32
+  scan-build make -j32
      
 The results of the scan including any static analysis errors will appear inline.
 Additionally, there will a directory in the /tmp containing the Coverity


### PR DESCRIPTION
Previous commit contained typo repeated in two places where "scan-file" was
used instead of "scan-build". I discovered this error when following my own
instructions. 