### PR TITLE
bgpd: add 'set as-path replace' with a configured ASN

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2105,10 +2105,11 @@ Using AS Path in Route Map
    Prepend the existing last AS number (the leftmost ASN) to the AS_PATH.
    The no form of this command removes this set operation from the route-map.
 
-.. clicmd:: set as-path replace <any|ASN>
+.. clicmd:: set as-path replace <any|ASN> [<ASN>]
 
-   Replace a specific AS number to local AS number. ``any`` replaces each
-   AS number in the AS-PATH with the local AS number.
+   Replace a specific AS number to local AS number or a configured AS number.
+   ``any`` replaces each AS number in the AS-PATH with either the local AS
+   number or the configured AS number.
 
 .. clicmd:: set as-path exclude all
 

--- a/tests/topotests/bgp_set_aspath_replace/r1/bgpd.conf
+++ b/tests/topotests/bgp_set_aspath_replace/r1/bgpd.conf
@@ -9,6 +9,7 @@ router bgp 65001
 !
 ip prefix-list p1 seq 5 permit 172.16.255.31/32
 !
+bgp route-map delay-timer 1
 route-map r2 permit 10
  match ip address prefix-list p1
  set as-path replace 65003

--- a/tests/topotests/bgp_set_aspath_replace/test_bgp_set_aspath_replace.py
+++ b/tests/topotests/bgp_set_aspath_replace/test_bgp_set_aspath_replace.py
@@ -24,6 +24,7 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
 
 pytestmark = [pytest.mark.bgpd]
 
@@ -63,7 +64,7 @@ def teardown_module(mod):
     tgen.stop_topology()
 
 
-def test_bgp_maximum_prefix_out():
+def test_bgp_set_aspath_replace_test1():
     tgen = get_topogen()
 
     if tgen.routers_have_failure():
@@ -83,6 +84,40 @@ def test_bgp_maximum_prefix_out():
     _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
 
     assert result is None, "Failed overriding incoming AS-PATH with route-map"
+
+
+def test_bgp_set_aspath_replace_test2():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    logger.info("Configuring r1 to replace the matching AS with a configured ASN")
+    router = tgen.gears["r1"]
+    router.vtysh_cmd(
+        "configure terminal\nroute-map r2 permit 10\nset as-path replace 65003 65500\n",
+        isjson=False,
+    )
+    router.vtysh_cmd(
+        "configure terminal\nroute-map r2 permit 20\nset as-path replace any 65501\n",
+        isjson=False,
+    )
+
+    def _bgp_converge(router):
+        output = json.loads(router.vtysh_cmd("show bgp ipv4 unicast json"))
+        expected = {
+            "routes": {
+                "172.16.255.31/32": [{"path": "65002 65500"}],
+                "172.16.255.32/32": [{"path": "65501 65501"}],
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_converge, router)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+
+    assert (
+        result is None
+    ), "Failed overriding incoming AS-PATH with route-map replace with configured ASN"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There is no route-map set action to replace any ASN, or a part of an ASN, with a configured ASN.

The current commit adds a new command to use a configured ASN as replacement, instead of using the local as number.

> set as-path replace any 65500

Update the 'bgp_set_aspath_replace' test.