### PR TITLE
isisd: Log error when config-end timeout occurs.

### DIFF
--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -170,6 +170,9 @@ static const struct frr_yang_module_info *const isisd_yang_modules[] = {
 /* clang-format on */
 
 
+/* Max wait time for config to load before generating LSPs */
+#define ISIS_PRE_CONFIG_MAX_WAIT_SECONDS 600
+
 static void isis_config_finish(struct event *t)
 {
 	struct listnode *node, *inode;
@@ -182,12 +185,17 @@ static void isis_config_finish(struct event *t)
 	}
 }
 
+static void isis_config_end_timeout(struct event *t)
+{
+	zlog_err("IS-IS configuration end timer expired after %d seconds.",
+		 ISIS_PRE_CONFIG_MAX_WAIT_SECONDS);
+	isis_config_finish(t);
+}
+
 static void isis_config_start(void)
 {
-	/* Max wait time for config to load before generating lsp */
-#define ISIS_PRE_CONFIG_MAX_WAIT_SECONDS 600
 	EVENT_OFF(t_isis_cfg);
-	event_add_timer(im->master, isis_config_finish, NULL,
+	event_add_timer(im->master, isis_config_end_timeout, NULL,
 			ISIS_PRE_CONFIG_MAX_WAIT_SECONDS, &t_isis_cfg);
 }
 


### PR DESCRIPTION
Log an error when the config-end callback is not received for 10 minutes. 