### PR TITLE
tools: less aggressive settings for clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -169,16 +169,16 @@ ObjCSpaceBeforeProtocolList: true
 ## Lowest Penalty Value wins. Values are used by clang-format to influence
 ## the brak decisions, it's a bit of voodoo magic though.
 ## Originally from linux which was "Taken from git's rules"
-PenaltyBreakAssignment: 10
+PenaltyBreakAssignment: 30
 PenaltyBreakComment: 10
 PenaltyBreakFirstLessLess: 0
 # Don't break a string into multi-string-fragments
-PenaltyBreakString: 200
+PenaltyBreakString: 1000
 # Allow going past the ColumnLimit to keep function arguments aligned
 # with the open parenthesis.
-PenaltyBreakBeforeFirstCallParameter: 200
+PenaltyBreakBeforeFirstCallParameter: 1000
 # Try and stay under ColumnLimit, but not at the cost of incomprehensible code.
-PenaltyExcessCharacter: 5
+PenaltyExcessCharacter: 30
 PenaltyReturnTypeOnItsOwnLine: 60
 
 PointerAlignment: Right


### PR DESCRIPTION
- Reports were that the current settings were choosing to extend beyond 80 columns too often. This change makes that more expensive but still tries very hard to not break before first open parenthesis of function calls.

- Also a break was being inserted after = signs very often, so raise the penalty on that to make it stop.
i.e., dont do this:

```
foo = 
    fucntion(foo, bar, bz);
```