### PR TITLE
zebra: clean up coverity warning in opaque api

### DIFF
--- a/zebra/zebra_opaque.c
+++ b/zebra/zebra_opaque.c
@@ -546,7 +546,6 @@ static void opq_send_notifications(const struct opq_msg_reg *reg,
 					      client->session_id, msg)) {
 				/* Error - need to free the message */
 				stream_free(msg);
-				msg = NULL;
 			}
 		}
 	}


### PR DESCRIPTION
Seems a bit fussy of coverity, but ... don't NULL a variable unnecessarily.
