### PR TITLE
zebra: fix evpn rmac nh list cmp function

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -194,7 +194,7 @@ static int l3vni_rmac_nh_list_cmp(void *p1, void *p2)
 	const struct ipaddr *vtep_ip1 = p1;
 	const struct ipaddr *vtep_ip2 = p2;
 
-	return !ipaddr_cmp(vtep_ip1, vtep_ip2);
+	return ipaddr_cmp(vtep_ip1, vtep_ip2);
 }
 
 static void l3vni_rmac_nh_free(struct ipaddr *vtep_ip)


### PR DESCRIPTION
EVPN RMAC (Router MAC) nexthop list compare function needs to return all values so
the list element can be compared and added/deleted properly.

Testing Done:
Originate EVPN Type-5 route with PIP IP and MAC as remote nexthops.
Change the PIP IP address which triggers nexthop change.

Before fix:
When PIP IP changes RMAC is deleted from remote VTEPs.

```
TORS1# show evpn next-hops vni 4001 | include 00:02:00:00:00:2d
27.0.0.11       00:02:00:00:00:2d
TORS1# show evpn rmac vni 4001 | include 00:02:00:00:00:2d 
00:02:00:00:00:2d 27.0.0.11
```
----- Remote VTEP change nexthop IP to 172.16.16.16 -----
```
TORS1# show evpn next-hops vni 4001 | include 00:02:00:00:00:2d
172.16.16.16    00:02:00:00:00:2d
TORS1# show evpn rmac vni 4001 | include 00:02:00:00:00:2d
TORS1#
```
After fix:

RMAC is retained as its nexthop list is not empty, thus it is not deleted from remote VTEPs.

```
TORS1# show evpn rmac vni 4001 | include 00:02:00:00:00:2d
00:02:00:00:00:2d 172.16.16.16

Log:
2023/06/27 00:50:36.833474 ZEBRA: [XREH0-ZYMH6] L3VNI 4001 Remote VTEP change(27.0.0.11 -> 172.16.16.16) for RMAC 00:02:00:00:00:2d
```


Signed-off-by: Chirag Shah <chirag@nvidia.com>