### PR TITLE
doc: Fix one syntax error for code block

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -443,7 +443,7 @@ as shown in the examples below.
 
 For each capture a window is opened displaying a live summary of the captured
 packets. Additionally, the entire packet stream is captured in a pcap file in
-the tests log directory e.g.,::
+the tests log directory e.g.,:
 
 .. code:: console
 


### PR DESCRIPTION
The code block doesn't work due to special thing in front of it. So, just make it work.