### PR TITLE
Changes for inclusive language and other cleanup

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -87,6 +87,8 @@ ForEachMacros:
   # ospfd outliers:
   - 'LSDB_LOOP'
   # first git grep
+  - 'darr_foreach_p'
+  - 'darr_foreach_i'
   - 'frr_each'
   - 'frr_each_safe'
   - 'frr_each_from'

--- a/lib/darr.c
+++ b/lib/darr.c
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * June 23 2023, Christian Hopps <chopps@labn.net>
+ *
+ * Copyright (c) 2023, LabN Consulting, L.L.C.
+ *
+ */
+#include <zebra.h>
+#include "darr.h"
+
+void __dar_resize(void **a, uint count, size_t esize);
+
+static uint _msb(uint count)
+{
+	uint bit = 0;
+	int msb = 0;
+
+	while (count) {
+		if (count & 1)
+			msb = bit;
+		count >>= 1;
+		bit += 1;
+	}
+	return msb;
+}
+
+static uint darr_next_count(uint count, size_t esize)
+{
+	uint ncount;
+
+	if (esize > sizeof(long long) && count == 1)
+		/* treat like a pointer */
+		ncount = 1;
+	else {
+		uint msb = _msb(count);
+
+		ncount = 1ull << msb;
+		/* if the users count wasn't a pow2 make it the next pow2. */
+		if (ncount != count) {
+			assert(ncount < count);
+			ncount <<= 1;
+			if (esize < sizeof(long long) && ncount < 8)
+				ncount = 8;
+		}
+	}
+	return ncount;
+}
+
+static size_t darr_size(uint count, size_t esize)
+{
+	return count * esize + sizeof(struct darr_metadata);
+}
+
+void *__darr_resize(void *a, uint count, size_t esize)
+{
+	uint ncount = darr_next_count(count, esize);
+	size_t osz = (a == NULL) ? 0 : darr_size(darr_cap(a), esize);
+	size_t sz = darr_size(ncount, esize);
+	struct darr_metadata *dm = realloc(a ? _darr_meta(a) : NULL, sz);
+	/* do *not* use a */
+
+	assert(dm);
+	if (sz > osz)
+		memset((char *)dm + osz, 0, sz - osz);
+
+	dm->cap = ncount;
+
+	return (void *)(dm + 1);
+}
+
+
+void *__darr_insert_n(void *a, uint at, uint count, size_t esize, bool zero)
+{
+
+	struct darr_metadata *dm;
+	uint olen, nlen;
+
+	if (!a)
+		a = __darr_resize(NULL, at + count, esize);
+	dm = (struct darr_metadata *)a - 1;
+	olen = dm->len;
+
+	// at == 1
+	// count == 100
+	// olen == 2
+
+	/* see if the user is expanding first using `at` */
+	if (at >= olen)
+		nlen = at + count;
+	else
+		nlen = olen + count;
+
+	if (nlen > dm->cap) {
+		a = __darr_resize(a, nlen, esize);
+		dm = (struct darr_metadata *)a - 1;
+	}
+
+#define _a_at(i) ((char *)a + ((i)*esize))
+	if (at < olen)
+		memmove(_a_at(at + count), _a_at(at), esize * (olen - at));
+
+	dm->len = nlen;
+
+	if (zero) {
+		if (at >= olen) {
+			at -= olen;
+			count += olen;
+		}
+		memset(_a_at(at), 0, esize * count);
+	}
+
+	return (void *)a;
+#undef _a_at
+}

--- a/lib/darr.h
+++ b/lib/darr.h
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * June 23 2023, Christian Hopps <chopps@labn.net>
+ *
+ * Copyright (c) 2023, LabN Consulting, L.L.C.
+ *
+ * API functions:
+ * ==============
+ *  - darr_append
+ *  - darr_append_n
+ *  - darr_append_nz
+ *  - darr_cap
+ *  - darr_ensure_cap
+ *  - darr_ensure_i
+ *  - darr_foreach_i
+ *  - darr_foreach_p
+ *  - darr_free
+ *  - darr_insert
+ *  - darr_insertz
+ *  - darr_insert_n
+ *  - darr_insert_nz
+ *  - darr_len
+ *  - darr_maxi
+ *  - darr_pop
+ *  - darr_push
+ *  - darr_pushz
+ *  - darr_remove
+ *  - darr_remove_n
+ *  - darr_reset
+ *  - darr_setlen
+ */
+/*
+ * A few assured items
+ *
+ * - DAs will never have capacity 0 unless they are NULL pointers.
+ */
+#include <zebra.h>
+
+struct darr_metadata {
+	uint len;
+	uint cap;
+};
+void *__darr_insert_n(void *a, uint at, uint count, size_t esize, bool zero);
+void *__darr_resize(void *a, uint count, size_t esize);
+
+#define _darr_esize(A)	   sizeof((A)[0])
+#define darr_esize(A)	   sizeof((A)[0])
+#define _darr_len(A)	   _darr_meta(A)->len
+#define _darr_meta(A)	   (((struct darr_metadata *)(A)) - 1)
+#define _darr_resize(A, C) ({ (A) = __darr_resize((A), C, _darr_esize(A)); })
+
+/* Get the current capacity of the array */
+#define darr_cap(A) (((A) == NULL) ? 0 : _darr_meta(A)->cap)
+
+/* Get the largest possible index one can `darr_ensure_i` w/o resizing */
+#define darr_maxi(A) ((int)darr_cap(A) - 1)
+
+/**
+ * Get the current length of the array.
+ *
+ * As long as `A` is non-NULL, this macro may be used as an L-value to modify
+ * the length of the array.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ *
+ * Return:
+ *      The current length of the array.
+ */
+#define darr_len(A) (((A) == NULL) ? 0 : _darr_meta(A)->len)
+
+/**
+ * Set the current length of the array `A` to 0.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ */
+#define darr_reset(A)                                                          \
+	do {                                                                   \
+		if ((A))                                                       \
+			_darr_len(A) = 0;                                      \
+	} while (0)
+
+/**
+ * Set the current length of the array `A` to `L`.
+ *
+ * This function does *not* guarantee the memory is valid to L,
+ * use `darr_ensure` or `darr_ensure_cap` for that.
+ *
+ * Args:
+ *	A: The dynamic array, can only be NULL if (L) == 0.
+ *      L: The new length of the array.
+ */
+#define darr_setlen(A, L)                                                      \
+	do {                                                                   \
+		assert((A) || !(L));                                           \
+		if ((A)) {                                                     \
+			/* have to cast to avoid compiler warning for "0" */   \
+			assert((long long)darr_cap(A) >= (L));                 \
+			_darr_len(A) = (L);                                    \
+		}                                                              \
+	} while (0)
+
+/**
+ * Free memory allocated for the dynamic array `A`
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ */
+
+#define darr_free(A)                                                           \
+	do {                                                                   \
+		if ((A)) {                                                     \
+			free(_darr_meta(A));                                   \
+			(A) = NULL;                                            \
+		}                                                              \
+	} while (0)
+
+/**
+ * Make sure that there is room in the dynamic array `A` for `C` elements.
+ *
+ * The value `A` may be changed as a result of this call in which case any
+ * pointers into the previous memory block are no longer valid. The `A` value
+ * is guaranteed not to change if there is sufficient capacity in the array.
+ *
+ * Args:
+ *	A: (IN/OUT) the dynamic array, can be NULL.
+ *	I: the index to guarantee memory exists for
+ *
+ * Return:
+ *      A pointer to the (possibly moved) array.
+ */
+#define darr_ensure_cap(A, C)                                                  \
+	({                                                                     \
+		if (darr_cap(A) < (C))                                         \
+			_darr_resize((A), (C));                                \
+		(A);                                                           \
+	})
+
+/**
+ * Return a pointer to the (I)th element of array `A`, making sure there is
+ * room for the element.
+ *
+ * If the array length is less than `I + 1` then the length is set to `I + 1`.
+ *
+ * The value `A` may be changed as a result of this call in which case any
+ * pointers into the previous memory block are no longer valid. The `A` value
+ * is guaranteed not to change if there is sufficient capacity in the array.
+ *
+ * Args:
+ *
+ *	A: (IN/OUT) the dynamic array, can be NULL.
+ *	I: the index to guarantee memory exists for
+ *
+ * Return:
+ *      A pointer to the (I)th element in `A`
+ */
+#define darr_ensure_i(A, I)                                                    \
+	({                                                                     \
+		if ((int)(I) > darr_maxi(A))                                   \
+			_darr_resize((A), (I) + 1);                            \
+		if ((I) + 1 > _darr_len(A))                                    \
+			_darr_len(A) = (I) + 1;                                \
+		&(A)[I];                                                       \
+	})
+
+#define _darr_insert_n(A, I, N, Z)                                             \
+	({                                                                     \
+		(A) = __darr_insert_n(A, I, N, _darr_esize(A), Z);             \
+		&(A)[I];                                                       \
+	})
+/**
+ * Insert N uninitialized elements in the array at index `I`.
+ *
+ * Previous elements from `I` are shifted right by `N`. Array length is
+ * increased by `N`.
+ *
+ * The value `A` may be changed as a result of this call in which case any
+ * pointers into the previous memory block are no longer valid. The `A` value
+ * is guaranteed not to change if there is sufficient capacity in the array.
+ *
+ * The `z` variant zeros new elements.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ *
+ * Return:
+ *      A pointer to the first inserted element in the array.
+ */
+#define darr_insert_n(A, I, N)	_darr_insert_n(A, I, N, false)
+#define darr_insert_nz(A, I, N) _darr_insert_n(A, I, N, true)
+
+/**
+ * Insert an uninitialized element in the array at index `I`.
+ *
+ * Previous elements from `I` are shifted right by 1. Array length is
+ * increased by 1.
+ *
+ * The value `A` may be changed as a result of this call in which case any
+ * pointers into the previous memory block are no longer valid. The `A` value
+ * is guaranteed not to change if there is sufficient capacity in the array.
+ *
+ * The `z` variant zeros the new element.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ *
+ * Return:
+ *      A pointer to the element in the array.
+ */
+#define darr_insert(A, I)  _darr_insert_n(A, I, 1, false)
+#define darr_insertz(A, I) _darr_insert_n(A, I, 1, true)
+
+/**
+ * Remove `N` elements from the array starting at index `I`.
+ *
+ * Elements from `I` + `N` are shifted left by `N`. Array length is reduced by
+ * `N`.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ */
+#define darr_remove_n(A, I, N)                                                 \
+	do {                                                                   \
+		uint __i = (I);                                                \
+		uint __n = (N);                                                \
+		uint __len = darr_len(A);                                      \
+		if (!__len)                                                    \
+			break;                                                 \
+		else if (__i + __n < __len) {                                  \
+			memmove(&(A)[__i], &(A)[__i + __n],                    \
+				_darr_esize(A) * (__len - (__i + __n)));       \
+			_darr_len(A) = __len - __n;                            \
+		} else                                                         \
+			_darr_len(A) = __i;                                    \
+	} while (0)
+
+/**
+ * Remove the `I`th element from the array.
+ *
+ * Previous elements from `I` + 1 are shifted left by 1, Array length is reduced
+ * by 1.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ */
+#define darr_remove(A, I) darr_remove_n(A, I, 1)
+
+
+#define _darr_append_n(A, N, Z)                                                \
+	({                                                                     \
+		uint __len = darr_len(A);                                      \
+		darr_ensure_cap(A, __len + (N));                               \
+		_darr_len(A) = __len + (N);                                    \
+		if (Z)                                                         \
+			memset(&(A)[__len], 0, (N)*_darr_esize(A));            \
+		&(A)[__len];                                                   \
+	})
+/**
+ * Extending the array's length by N.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ *
+ * The `z` variant zeros new elements.
+ *
+ * Return:
+ *	A pointer to the first of the added elements at the end of the array.
+ */
+#define darr_append_n(A, N)  _darr_append_n(A, N, false)
+#define darr_append_nz(A, N) _darr_append_n(A, N, true)
+
+/**
+ * Extending the array's length by 1.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ *
+ * The `z` variant zeros the new element.
+ *
+ * Return:
+ *	A pointer to the new element at the end of the array.
+ */
+#define darr_append(A)	_darr_append_n(A, 1, false)
+#define darr_appendz(A) _darr_append_n(A, 1, true)
+
+/**
+ * Append an element `E` onto the array `A`, extending it's length by 1.
+ *
+ * The `z` variant zeros the new element.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ *
+ * Return:
+ *	A pointer to the element in the array.
+ */
+#define darr_push(A, E) (*darr_append(A) = (E))
+#define darr_pushz(A)	(darr_appendz(A))
+
+
+/**
+ * Pop the last `N` elements from the array decrementing the length by `N`.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ */
+#define darr_pop_n(A, N)                                                       \
+	do {                                                                   \
+		if ((A) && (N) >= _darr_len(A))                                \
+			darr_reset(A);                                         \
+		else                                                           \
+			_darr_len(A) -= (N);                                   \
+	} while (0)
+
+
+/**
+ * Pop the last element from the array decrementing the length by 1.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ *
+ * Return:
+ *      The element just popped.
+ */
+#define darr_pop(A)                                                            \
+	({                                                                     \
+		uint __len = _darr_len(A);                                     \
+		assert(__len);                                                 \
+		darr_remove(A, __len - 1);                                     \
+		/* count on fact that we don't resize */                       \
+		(A)[__len - 1];                                                \
+	})
+
+/**
+ * Return the address at the end of the array -- useful for iterating
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ *
+ * Return:
+ *	The address of the end of the array (past the last elment) or NULL
+ *	if `A` is NULL.
+ */
+#define darr_end(A) ((A) + darr_len(A))
+
+/**
+ * Iterate over array `A` using a pointer to each element in `P`.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ *	P: A variable with the same type as A used as the iterator.
+ */
+#define darr_foreach_p(A, P) for ((P) = (A); (P) < darr_end(A); (P)++)
+
+/**
+ * Iterate over array `A`s indices.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ *	I: A uint variable to store the current element index in.
+ */
+#define darr_foreach_i(A, I) for ((I) = 0; (I) < darr_len(A); (I)++)

--- a/lib/mgmt.proto
+++ b/lib/mgmt.proto
@@ -267,36 +267,22 @@ message FeCommitConfigReply {
   optional string error_if_any = 8;
 }
 
-message FeGetConfigReq {
+message FeGetReq {
   required uint64 session_id = 1;
-  required DatastoreId ds_id = 2;
-  required uint64 req_id = 3;
-  repeated YangGetDataReq data = 4;
+  required bool config = 2;
+  required DatastoreId ds_id = 3;
+  required uint64 req_id = 4;
+  repeated YangGetDataReq data = 5;
 }
 
-message FeGetConfigReply {
+message FeGetReply {
   required uint64 session_id = 1;
-  required DatastoreId ds_id = 2;
-  required uint64 req_id = 3;
-  required bool success = 4;
-  optional string error_if_any = 5;
-  optional YangDataReply data = 6;
-}
-
-message FeGetDataReq {
-  required uint64 session_id = 1;
-  required DatastoreId ds_id = 2;
-  required uint64 req_id = 3;
-  repeated YangGetDataReq data = 4;
-}
-
-message FeGetDataReply {
-  required uint64 session_id = 1;
-  required DatastoreId ds_id = 2;
-  required uint64 req_id = 3;
-  required bool success = 4;
-  optional string error_if_any = 5;
-  optional YangDataReply data = 6;
+  required bool config = 2;
+  required DatastoreId ds_id = 3;
+  required uint64 req_id = 4;
+  required bool success = 5;
+  optional string error_if_any = 6;
+  optional YangDataReply data = 7;
 }
 
 message FeNotifyDataReq {
@@ -322,10 +308,8 @@ message FeMessage {
     FeSetConfigReply setcfg_reply = 8;
     FeCommitConfigReq commcfg_req = 9;
     FeCommitConfigReply commcfg_reply = 10;
-    FeGetConfigReq getcfg_req = 11;
-    FeGetConfigReply getcfg_reply = 12;
-    FeGetDataReq getdata_req = 13;
-    FeGetDataReply getdata_reply = 14;
+    FeGetReq get_req = 11;
+    FeGetReply get_reply = 12;
     FeNotifyDataReq notify_data_req = 15;
     FeRegisterNotifyReq regnotify_req = 16;
   }

--- a/lib/mgmt.proto
+++ b/lib/mgmt.proto
@@ -136,28 +136,6 @@ message BeOperDataGetReply {
   optional YangDataReply data = 5;
 }
 
-message BeOperDataNotify {
-  required YangDataReply data = 5;
-}
-
-message BeConfigCmdReq {
-  required string cmd = 1;
-}
-
-message BeConfigCmdReply {
-  required bool success = 1;
-  required string error_if_any = 2;
-}
-
-message BeShowCmdReq {
-  required string cmd = 1;
-}
-
-message BeShowCmdReply {
-  required bool success = 1;
-  required string cmd_ouput = 2;
-}
-
 //
 // Any message on the MGMTD Backend Interface.
 //
@@ -173,11 +151,6 @@ message BeMessage {
     BeCfgDataApplyReply cfg_apply_reply = 9;
     BeOperDataGetReq get_req = 10;
     BeOperDataGetReply get_reply = 11;
-    BeOperDataNotify notify_data = 12;
-    BeConfigCmdReq cfg_cmd_req = 13;
-    BeConfigCmdReply cfg_cmd_reply = 14;
-    BeShowCmdReq show_cmd_req = 15;
-    BeShowCmdReply show_cmd_reply = 16;
   }
 }
 

--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -768,9 +768,6 @@ static int mgmt_be_client_handle_msg(struct mgmt_be_client *client_ctx,
 			client_ctx, (uint64_t)be_msg->cfg_apply_req->txn_id);
 		break;
 	case MGMTD__BE_MESSAGE__MESSAGE_GET_REQ:
-	case MGMTD__BE_MESSAGE__MESSAGE_SUBSCR_REQ:
-	case MGMTD__BE_MESSAGE__MESSAGE_CFG_CMD_REQ:
-	case MGMTD__BE_MESSAGE__MESSAGE_SHOW_CMD_REQ:
 		MGMTD_BE_CLIENT_ERR("Got unhandled message type %u",
 				    be_msg->message_case);
 		/*
@@ -781,13 +778,11 @@ static int mgmt_be_client_handle_msg(struct mgmt_be_client *client_ctx,
 	 * NOTE: The following messages are always sent from Backend
 	 * clients to MGMTd only and/or need not be handled here.
 	 */
+	case MGMTD__BE_MESSAGE__MESSAGE_SUBSCR_REQ:
 	case MGMTD__BE_MESSAGE__MESSAGE_GET_REPLY:
 	case MGMTD__BE_MESSAGE__MESSAGE_TXN_REPLY:
 	case MGMTD__BE_MESSAGE__MESSAGE_CFG_DATA_REPLY:
 	case MGMTD__BE_MESSAGE__MESSAGE_CFG_APPLY_REPLY:
-	case MGMTD__BE_MESSAGE__MESSAGE_CFG_CMD_REPLY:
-	case MGMTD__BE_MESSAGE__MESSAGE_SHOW_CMD_REPLY:
-	case MGMTD__BE_MESSAGE__MESSAGE_NOTIFY_DATA:
 	case MGMTD__BE_MESSAGE__MESSAGE__NOT_SET:
 	default:
 		/*

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -294,13 +294,19 @@ extern int mgmt_fe_send_commitcfg_req(struct mgmt_fe_client *client,
 				      bool validate_only, bool abort);
 
 /*
- * Send GET_CONFIG_REQ to MGMTD for one or more config data item(s).
+ * Send GET_REQ to MGMTD for one or more config data item(s).
+ *
+ * If is_config is true gets config from the MGMTD datastore, otherwise
+ * operational state is queried from the backend clients.
  *
  * lib_hndl
  *    Client library handler.
  *
  * session_id
  *    Client session ID.
+ *
+ * is_config
+ *    True if get-config else get-data.
  *
  * req_id
  *    Client request ID.
@@ -309,31 +315,19 @@ extern int mgmt_fe_send_commitcfg_req(struct mgmt_fe_client *client,
  *    Datastore ID (Running/Candidate)
  *
  * data_req
- *    Get config requested.
+ *    Get xpaths requested.
  *
  * num_req
- *    Number of get config requests.
+ *    Number of get xpath requests.
  *
  * Returns:
  *    0 on success, otherwise msg_conn_send_msg() return values.
  */
-extern int mgmt_fe_send_getcfg_req(struct mgmt_fe_client *client,
-				   uint64_t session_id, uint64_t req_id,
-				   Mgmtd__DatastoreId ds_id,
-				   Mgmtd__YangGetDataReq **data_req,
-				   int num_reqs);
+extern int mgmt_fe_send_get_req(struct mgmt_fe_client *client,
+				uint64_t session_id, uint64_t req_id,
+				bool is_config, Mgmtd__DatastoreId ds_id,
+				Mgmtd__YangGetDataReq **data_req, int num_reqs);
 
-/*
- * Send GET_DATA_REQ to MGMTD for one or more data item(s).
- *
- * Similar to get config request but supports getting data
- * from operational ds aka backend clients directly.
- */
-extern int mgmt_fe_send_getdata_req(struct mgmt_fe_client *client,
-				    uint64_t session_id, uint64_t req_id,
-				    Mgmtd__DatastoreId ds_id,
-				    Mgmtd__YangGetDataReq **data_req,
-				    int num_reqs);
 
 /*
  * Send NOTIFY_REGISTER_REQ to MGMTD daemon.

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -25,6 +25,7 @@ lib_libfrr_la_SOURCES = \
 	lib/command_parse.y \
 	lib/cspf.c \
 	lib/csv.c \
+	lib/darr.c \
 	lib/debug.c \
 	lib/defaults.c \
 	lib/distribute.c \
@@ -209,6 +210,7 @@ pkginclude_HEADERS += \
 	lib/compiler.h \
 	lib/cspf.h \
 	lib/csv.h \
+	lib/darr.h \
 	lib/db.h \
 	lib/debug.h \
 	lib/defaults.h \

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -411,11 +411,9 @@ extern bool mgmt_vty_read_configs(void);
 extern int vty_mgmt_send_config_data(struct vty *vty, bool implicit_commit);
 extern int vty_mgmt_send_commit_config(struct vty *vty, bool validate_only,
 				       bool abort);
-extern int vty_mgmt_send_get_config(struct vty *vty,
-				    Mgmtd__DatastoreId datastore,
-				    const char **xpath_list, int num_req);
-extern int vty_mgmt_send_get_data(struct vty *vty, Mgmtd__DatastoreId datastore,
-				  const char **xpath_list, int num_req);
+extern int vty_mgmt_send_get_req(struct vty *vty, bool is_config,
+				 Mgmtd__DatastoreId datastore,
+				 const char **xpath_list, int num_req);
 extern int vty_mgmt_send_lockds_req(struct vty *vty, Mgmtd__DatastoreId ds_id,
 				    bool lock, bool scok);
 extern void vty_mgmt_resume_response(struct vty *vty, bool success);

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -532,9 +532,6 @@ mgmt_be_adapter_handle_msg(struct mgmt_be_client_adapter *adapter,
 			be_msg->cfg_apply_reply->error_if_any, adapter);
 		break;
 	case MGMTD__BE_MESSAGE__MESSAGE_GET_REPLY:
-	case MGMTD__BE_MESSAGE__MESSAGE_CFG_CMD_REPLY:
-	case MGMTD__BE_MESSAGE__MESSAGE_SHOW_CMD_REPLY:
-	case MGMTD__BE_MESSAGE__MESSAGE_NOTIFY_DATA:
 		/*
 		 * TODO: Add handling code in future.
 		 */
@@ -548,8 +545,6 @@ mgmt_be_adapter_handle_msg(struct mgmt_be_client_adapter *adapter,
 	case MGMTD__BE_MESSAGE__MESSAGE_TXN_REQ:
 	case MGMTD__BE_MESSAGE__MESSAGE_CFG_DATA_REQ:
 	case MGMTD__BE_MESSAGE__MESSAGE_CFG_APPLY_REQ:
-	case MGMTD__BE_MESSAGE__MESSAGE_CFG_CMD_REQ:
-	case MGMTD__BE_MESSAGE__MESSAGE_SHOW_CMD_REQ:
 	case MGMTD__BE_MESSAGE__MESSAGE__NOT_SET:
 	default:
 		/*

--- a/mgmtd/mgmt_fe_adapter.h
+++ b/mgmtd/mgmt_fe_adapter.h
@@ -87,10 +87,6 @@ mgmt_fe_adapter_unlock(struct mgmt_fe_client_adapter **adapter);
 extern struct msg_conn *mgmt_fe_create_adapter(int conn_fd,
 					       union sockunion *su);
 
-/* Fetch frontend adapter given a name */
-extern struct mgmt_fe_client_adapter *
-mgmt_fe_get_adapter(const char *name);
-
 /*
  * Send set-config reply to the frontend client.
  *
@@ -134,29 +130,13 @@ extern int mgmt_fe_send_commit_cfg_reply(
 	enum mgmt_result result, const char *error_if_any);
 
 /*
- * Send get-config reply to the frontend client.
+ * Send get-config/get-data reply to the frontend client.
  */
-extern int mgmt_fe_send_get_cfg_reply(uint64_t session_id, uint64_t txn_id,
-					  Mgmtd__DatastoreId ds_id,
-					  uint64_t req_id,
-					  enum mgmt_result result,
-					  Mgmtd__YangDataReply *data_resp,
-					  const char *error_if_any);
-
-/*
- * Send get-data reply to the frontend client.
- */
-extern int mgmt_fe_send_get_data_reply(
-	uint64_t session_id, uint64_t txn_id, Mgmtd__DatastoreId ds_id,
-	uint64_t req_id, enum mgmt_result result,
-	Mgmtd__YangDataReply *data_resp, const char *error_if_any);
-
-/*
- * Send data notify to the frontend client.
- */
-extern int mgmt_fe_send_data_notify(Mgmtd__DatastoreId ds_id,
-					Mgmtd__YangData * data_resp[],
-					int num_data);
+extern int mgmt_fe_send_get_reply(uint64_t session_id, uint64_t txn_id,
+				  Mgmtd__DatastoreId ds_id, uint64_t req_id,
+				  enum mgmt_result result,
+				  Mgmtd__YangDataReply *data_resp,
+				  const char *error_if_any);
 
 /* Fetch frontend client session set-config stats */
 extern struct mgmt_setcfg_stats *

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -19,7 +19,7 @@
 #define MGMTD_TXN_ERR(fmt, ...)                                                \
 	zlog_err("%s: ERROR: " fmt, __func__, ##__VA_ARGS__)
 
-#define MGMTD_TXN_LOCK(txn) mgmt_txn_lock(txn, __FILE__, __LINE__)
+#define MGMTD_TXN_LOCK(txn)   mgmt_txn_lock(txn, __FILE__, __LINE__)
 #define MGMTD_TXN_UNLOCK(txn) mgmt_txn_unlock(txn, __FILE__, __LINE__)
 
 enum mgmt_txn_event {
@@ -53,8 +53,7 @@ enum mgmt_commit_phase {
 	MGMTD_COMMIT_PHASE_MAX
 };
 
-static inline const char *
-mgmt_commit_phase2str(enum mgmt_commit_phase cmt_phase)
+static inline const char *mgmt_commit_phase2str(enum mgmt_commit_phase cmt_phase)
 {
 	switch (cmt_phase) {
 	case MGMTD_COMMIT_PHASE_PREPARE_CFG:
@@ -83,7 +82,7 @@ struct mgmt_txn_be_cfg_batch {
 	struct mgmt_be_client_adapter *be_adapter;
 	uint xp_subscr[MGMTD_MAX_CFG_CHANGES_IN_BATCH];
 	Mgmtd__YangCfgDataReq cfg_data[MGMTD_MAX_CFG_CHANGES_IN_BATCH];
-	Mgmtd__YangCfgDataReq * cfg_datap[MGMTD_MAX_CFG_CHANGES_IN_BATCH];
+	Mgmtd__YangCfgDataReq *cfg_datap[MGMTD_MAX_CFG_CHANGES_IN_BATCH];
 	Mgmtd__YangData data[MGMTD_MAX_CFG_CHANGES_IN_BATCH];
 	Mgmtd__YangDataValue value[MGMTD_MAX_CFG_CHANGES_IN_BATCH];
 	size_t num_cfg_data;
@@ -143,8 +142,7 @@ struct mgmt_commit_cfg_req {
 	 * The last batch added for any backend client. This is always on
 	 * 'curr_batches'
 	 */
-	struct mgmt_txn_be_cfg_batch
-		*last_be_cfg_batch[MGMTD_BE_CLIENT_ID_MAX];
+	struct mgmt_txn_be_cfg_batch *last_be_cfg_batch[MGMTD_BE_CLIENT_ID_MAX];
 	struct hash *batches;
 	uint64_t next_batch_id;
 
@@ -157,7 +155,7 @@ struct mgmt_get_data_reply {
 	int last_batch;
 	Mgmtd__YangDataReply data_reply;
 	Mgmtd__YangData reply_data[MGMTD_MAX_NUM_DATA_REPLY_IN_BATCH];
-	Mgmtd__YangData * reply_datap[MGMTD_MAX_NUM_DATA_REPLY_IN_BATCH];
+	Mgmtd__YangData *reply_datap[MGMTD_MAX_NUM_DATA_REPLY_IN_BATCH];
 	Mgmtd__YangDataValue reply_value[MGMTD_MAX_NUM_DATA_REPLY_IN_BATCH];
 	char *reply_xpathp[MGMTD_MAX_NUM_DATA_REPLY_IN_BATCH];
 };
@@ -256,8 +254,8 @@ static int mgmt_txn_send_commit_cfg_reply(struct mgmt_txn_ctx *txn,
 					  enum mgmt_result result,
 					  const char *error_if_any);
 
-static inline const char *
-mgmt_txn_commit_phase_str(struct mgmt_txn_ctx *txn, bool curr)
+static inline const char *mgmt_txn_commit_phase_str(struct mgmt_txn_ctx *txn,
+						    bool curr)
 {
 	if (!txn->commit_cfg_req)
 		return "None";
@@ -267,99 +265,90 @@ mgmt_txn_commit_phase_str(struct mgmt_txn_ctx *txn, bool curr)
 		     : txn->commit_cfg_req->req.commit_cfg.next_phase));
 }
 
-static void mgmt_txn_lock(struct mgmt_txn_ctx *txn, const char *file,
-			   int line);
+static void mgmt_txn_lock(struct mgmt_txn_ctx *txn, const char *file, int line);
 static void mgmt_txn_unlock(struct mgmt_txn_ctx **txn, const char *file,
-			     int line);
-static int
-mgmt_txn_send_be_txn_delete(struct mgmt_txn_ctx *txn,
-				 struct mgmt_be_client_adapter *adapter);
+			    int line);
+static int mgmt_txn_send_be_txn_delete(struct mgmt_txn_ctx *txn,
+				       struct mgmt_be_client_adapter *adapter);
 
 static struct event_loop *mgmt_txn_tm;
 static struct mgmt_master *mgmt_txn_mm;
 
 static void mgmt_txn_register_event(struct mgmt_txn_ctx *txn,
-				     enum mgmt_txn_event event);
+				    enum mgmt_txn_event event);
 
 static int
 mgmt_move_be_commit_to_next_phase(struct mgmt_txn_ctx *txn,
-				     struct mgmt_be_client_adapter *adapter);
+				  struct mgmt_be_client_adapter *adapter);
 
 static struct mgmt_txn_be_cfg_batch *
-mgmt_txn_cfg_batch_alloc(struct mgmt_txn_ctx *txn,
-			  enum mgmt_be_client_id id,
-			  struct mgmt_be_client_adapter *be_adapter)
+mgmt_txn_cfg_batch_alloc(struct mgmt_txn_ctx *txn, enum mgmt_be_client_id id,
+			 struct mgmt_be_client_adapter *be_adapter)
 {
-	struct mgmt_txn_be_cfg_batch *cfg_btch;
+	struct mgmt_txn_be_cfg_batch *batch;
 
-	cfg_btch = XCALLOC(MTYPE_MGMTD_TXN_CFG_BATCH,
-			   sizeof(struct mgmt_txn_be_cfg_batch));
-	assert(cfg_btch);
-	cfg_btch->be_id = id;
+	batch = XCALLOC(MTYPE_MGMTD_TXN_CFG_BATCH,
+			sizeof(struct mgmt_txn_be_cfg_batch));
+	assert(batch);
+	batch->be_id = id;
 
-	cfg_btch->txn = txn;
+	batch->txn = txn;
 	MGMTD_TXN_LOCK(txn);
 	assert(txn->commit_cfg_req);
-	mgmt_txn_batches_add_tail(
-		&txn->commit_cfg_req->req.commit_cfg.curr_batches[id],
-		cfg_btch);
-	cfg_btch->be_adapter = be_adapter;
-	cfg_btch->buf_space_left = MGMTD_BE_CFGDATA_MAX_MSG_LEN;
+	mgmt_txn_batches_add_tail(&txn->commit_cfg_req->req.commit_cfg
+					   .curr_batches[id],
+				  batch);
+	batch->be_adapter = be_adapter;
+	batch->buf_space_left = MGMTD_BE_CFGDATA_MAX_MSG_LEN;
 	if (be_adapter)
 		mgmt_be_adapter_lock(be_adapter);
 
-	txn->commit_cfg_req->req.commit_cfg.last_be_cfg_batch[id] =
-		cfg_btch;
+	txn->commit_cfg_req->req.commit_cfg.last_be_cfg_batch[id] = batch;
 	if (!txn->commit_cfg_req->req.commit_cfg.next_batch_id)
 		txn->commit_cfg_req->req.commit_cfg.next_batch_id++;
-	cfg_btch->batch_id =
-		txn->commit_cfg_req->req.commit_cfg.next_batch_id++;
-	hash_get(txn->commit_cfg_req->req.commit_cfg.batches, cfg_btch,
+	batch->batch_id = txn->commit_cfg_req->req.commit_cfg.next_batch_id++;
+	hash_get(txn->commit_cfg_req->req.commit_cfg.batches, batch,
 		 hash_alloc_intern);
 
-	return cfg_btch;
+	return batch;
 }
 
-static void
-mgmt_txn_cfg_batch_free(struct mgmt_txn_be_cfg_batch **cfg_btch)
+static void mgmt_txn_cfg_batch_free(struct mgmt_txn_be_cfg_batch **batch)
 {
 	size_t indx;
 	struct mgmt_commit_cfg_req *cmtcfg_req;
 
 	MGMTD_TXN_DBG(" freeing batch-id: %" PRIu64 " txn-id %" PRIu64,
-		      (*cfg_btch)->batch_id, (*cfg_btch)->txn->txn_id);
+		      (*batch)->batch_id, (*batch)->txn->txn_id);
 
-	assert((*cfg_btch)->txn
-	       && (*cfg_btch)->txn->type == MGMTD_TXN_TYPE_CONFIG);
+	assert((*batch)->txn && (*batch)->txn->type == MGMTD_TXN_TYPE_CONFIG);
 
-	cmtcfg_req = &(*cfg_btch)->txn->commit_cfg_req->req.commit_cfg;
-	hash_release(cmtcfg_req->batches, *cfg_btch);
-	mgmt_txn_batches_del(&cmtcfg_req->curr_batches[(*cfg_btch)->be_id],
-			     *cfg_btch);
-	mgmt_txn_batches_del(&cmtcfg_req->next_batches[(*cfg_btch)->be_id],
-			     *cfg_btch);
+	cmtcfg_req = &(*batch)->txn->commit_cfg_req->req.commit_cfg;
+	hash_release(cmtcfg_req->batches, *batch);
+	mgmt_txn_batches_del(&cmtcfg_req->curr_batches[(*batch)->be_id], *batch);
+	mgmt_txn_batches_del(&cmtcfg_req->next_batches[(*batch)->be_id], *batch);
 
-	if ((*cfg_btch)->be_adapter)
-		mgmt_be_adapter_unlock(&(*cfg_btch)->be_adapter);
+	if ((*batch)->be_adapter)
+		mgmt_be_adapter_unlock(&(*batch)->be_adapter);
 
-	for (indx = 0; indx < (*cfg_btch)->num_cfg_data; indx++) {
-		if ((*cfg_btch)->data[indx].xpath) {
-			free((*cfg_btch)->data[indx].xpath);
-			(*cfg_btch)->data[indx].xpath = NULL;
+	for (indx = 0; indx < (*batch)->num_cfg_data; indx++) {
+		if ((*batch)->data[indx].xpath) {
+			free((*batch)->data[indx].xpath);
+			(*batch)->data[indx].xpath = NULL;
 		}
 	}
 
-	MGMTD_TXN_UNLOCK(&(*cfg_btch)->txn);
+	MGMTD_TXN_UNLOCK(&(*batch)->txn);
 
-	XFREE(MTYPE_MGMTD_TXN_CFG_BATCH, *cfg_btch);
-	*cfg_btch = NULL;
+	XFREE(MTYPE_MGMTD_TXN_CFG_BATCH, *batch);
+	*batch = NULL;
 }
 
 static unsigned int mgmt_txn_cfgbatch_hash_key(const void *data)
 {
 	const struct mgmt_txn_be_cfg_batch *batch = data;
 
-	return jhash2((uint32_t *) &batch->batch_id,
+	return jhash2((uint32_t *)&batch->batch_id,
 		      sizeof(batch->batch_id) / sizeof(uint32_t), 0);
 }
 
@@ -381,15 +370,14 @@ static void mgmt_txn_cfgbatch_hash_free(void *data)
 static inline struct mgmt_txn_be_cfg_batch *
 mgmt_txn_cfgbatch_id2ctx(struct mgmt_txn_ctx *txn, uint64_t batch_id)
 {
-	struct mgmt_txn_be_cfg_batch key = {0};
+	struct mgmt_txn_be_cfg_batch key = { 0 };
 	struct mgmt_txn_be_cfg_batch *batch;
 
 	if (!txn->commit_cfg_req)
 		return NULL;
 
 	key.batch_id = batch_id;
-	batch = hash_lookup(txn->commit_cfg_req->req.commit_cfg.batches,
-			    &key);
+	batch = hash_lookup(txn->commit_cfg_req->req.commit_cfg.batches, &key);
 
 	return batch;
 }
@@ -397,18 +385,18 @@ mgmt_txn_cfgbatch_id2ctx(struct mgmt_txn_ctx *txn, uint64_t batch_id)
 static void mgmt_txn_cleanup_be_cfg_batches(struct mgmt_txn_ctx *txn,
 					    enum mgmt_be_client_id id)
 {
-	struct mgmt_txn_be_cfg_batch *cfg_btch;
+	struct mgmt_txn_be_cfg_batch *batch;
 	struct mgmt_txn_batches_head *list;
 
 	list = &txn->commit_cfg_req->req.commit_cfg.curr_batches[id];
-	FOREACH_TXN_CFG_BATCH_IN_LIST (list, cfg_btch)
-		mgmt_txn_cfg_batch_free(&cfg_btch);
+	FOREACH_TXN_CFG_BATCH_IN_LIST (list, batch)
+		mgmt_txn_cfg_batch_free(&batch);
 
 	mgmt_txn_batches_fini(list);
 
 	list = &txn->commit_cfg_req->req.commit_cfg.next_batches[id];
-	FOREACH_TXN_CFG_BATCH_IN_LIST (list, cfg_btch)
-		mgmt_txn_cfg_batch_free(&cfg_btch);
+	FOREACH_TXN_CFG_BATCH_IN_LIST (list, batch)
+		mgmt_txn_cfg_batch_free(&batch);
 
 	mgmt_txn_batches_fini(list);
 
@@ -416,8 +404,8 @@ static void mgmt_txn_cleanup_be_cfg_batches(struct mgmt_txn_ctx *txn,
 }
 
 static struct mgmt_txn_req *mgmt_txn_req_alloc(struct mgmt_txn_ctx *txn,
-						 uint64_t req_id,
-						 enum mgmt_txn_event req_event)
+					       uint64_t req_id,
+					       enum mgmt_txn_event req_event)
 {
 	struct mgmt_txn_req *txn_req;
 	enum mgmt_be_client_id id;
@@ -502,17 +490,19 @@ static void mgmt_txn_req_free(struct mgmt_txn_req **txn_req)
 		for (indx = 0; indx < (*txn_req)->req.set_cfg->num_cfg_changes;
 		     indx++) {
 			if ((*txn_req)->req.set_cfg->cfg_changes[indx].value) {
-				MGMTD_TXN_DBG(
-					"Freeing value for %s at %p ==> '%s'",
-					(*txn_req)
-						->req.set_cfg->cfg_changes[indx]
-						.xpath,
-					(*txn_req)
-						->req.set_cfg->cfg_changes[indx]
-						.value,
-					(*txn_req)
-						->req.set_cfg->cfg_changes[indx]
-						.value);
+				MGMTD_TXN_DBG("Freeing value for %s at %p ==> '%s'",
+					      (*txn_req)
+						      ->req.set_cfg
+						      ->cfg_changes[indx]
+						      .xpath,
+					      (*txn_req)
+						      ->req.set_cfg
+						      ->cfg_changes[indx]
+						      .value,
+					      (*txn_req)
+						      ->req.set_cfg
+						      ->cfg_changes[indx]
+						      .value);
 				free((void *)(*txn_req)
 					     ->req.set_cfg->cfg_changes[indx]
 					     .value);
@@ -614,8 +604,7 @@ static void mgmt_txn_req_free(struct mgmt_txn_req **txn_req)
 		mgmt_txn_reqs_del(req_list, *txn_req);
 		MGMTD_TXN_DBG("Removed req-id: %" PRIu64
 			      " from request-list (left:%zu)",
-			      (*txn_req)->req_id,
-			      mgmt_txn_reqs_count(req_list));
+			      (*txn_req)->req_id, mgmt_txn_reqs_count(req_list));
 	}
 
 	(*txn_req)->pending_be_proc = false;
@@ -650,36 +639,42 @@ static void mgmt_txn_process_set_cfg(struct event *thread)
 		assert(txn_req->req_event == MGMTD_TXN_PROC_SETCFG);
 		ds_ctx = txn_req->req.set_cfg->ds_ctx;
 		if (!ds_ctx) {
-			mgmt_fe_send_set_cfg_reply(
-				txn->session_id, txn->txn_id,
-				txn_req->req.set_cfg->ds_id, txn_req->req_id,
-				MGMTD_INTERNAL_ERROR, "No such datastore!",
-				txn_req->req.set_cfg->implicit_commit);
+			mgmt_fe_send_set_cfg_reply(txn->session_id, txn->txn_id,
+						   txn_req->req.set_cfg->ds_id,
+						   txn_req->req_id,
+						   MGMTD_INTERNAL_ERROR,
+						   "No such datastore!",
+						   txn_req->req.set_cfg
+							   ->implicit_commit);
 			goto mgmt_txn_process_set_cfg_done;
 		}
 
 		nb_config = mgmt_ds_get_nb_config(ds_ctx);
 		if (!nb_config) {
-			mgmt_fe_send_set_cfg_reply(
-				txn->session_id, txn->txn_id,
-				txn_req->req.set_cfg->ds_id, txn_req->req_id,
-				MGMTD_INTERNAL_ERROR,
-				"Unable to retrieve DS Config Tree!",
-				txn_req->req.set_cfg->implicit_commit);
+			mgmt_fe_send_set_cfg_reply(txn->session_id, txn->txn_id,
+						   txn_req->req.set_cfg->ds_id,
+						   txn_req->req_id,
+						   MGMTD_INTERNAL_ERROR,
+						   "Unable to retrieve DS Config Tree!",
+						   txn_req->req.set_cfg
+							   ->implicit_commit);
 			goto mgmt_txn_process_set_cfg_done;
 		}
 
 		error = false;
-		nb_candidate_edit_config_changes(
-			nb_config, txn_req->req.set_cfg->cfg_changes,
-			(size_t)txn_req->req.set_cfg->num_cfg_changes, NULL,
-			NULL, 0, err_buf, sizeof(err_buf), &error);
+		nb_candidate_edit_config_changes(nb_config,
+						 txn_req->req.set_cfg->cfg_changes,
+						 (size_t)txn_req->req.set_cfg
+							 ->num_cfg_changes,
+						 NULL, NULL, 0, err_buf,
+						 sizeof(err_buf), &error);
 		if (error) {
-			mgmt_fe_send_set_cfg_reply(
-				txn->session_id, txn->txn_id,
-				txn_req->req.set_cfg->ds_id, txn_req->req_id,
-				MGMTD_INTERNAL_ERROR, err_buf,
-				txn_req->req.set_cfg->implicit_commit);
+			mgmt_fe_send_set_cfg_reply(txn->session_id, txn->txn_id,
+						   txn_req->req.set_cfg->ds_id,
+						   txn_req->req_id,
+						   MGMTD_INTERNAL_ERROR, err_buf,
+						   txn_req->req.set_cfg
+							   ->implicit_commit);
 			goto mgmt_txn_process_set_cfg_done;
 		}
 
@@ -690,41 +685,44 @@ static void mgmt_txn_process_set_cfg(struct event *thread)
 			/* We expect the user to have locked the DST DS */
 			if (!mgmt_ds_is_locked(txn_req->req.set_cfg->dst_ds_ctx,
 					       txn->session_id)) {
-				MGMTD_TXN_ERR(
-					"DS %u not locked for implicit commit txn-id: %" PRIu64
-					" session-id: %" PRIu64 " err: %s",
-					txn_req->req.set_cfg->dst_ds_id,
-					txn->txn_id, txn->session_id,
-					strerror(ret));
+				MGMTD_TXN_ERR("DS %u not locked for implicit commit txn-id: %" PRIu64
+					      " session-id: %" PRIu64 " err: %s",
+					      txn_req->req.set_cfg->dst_ds_id,
+					      txn->txn_id, txn->session_id,
+					      strerror(ret));
 				mgmt_txn_send_commit_cfg_reply(
 					txn, MGMTD_DS_LOCK_FAILED,
 					"running DS not locked for implicit commit");
 				goto mgmt_txn_process_set_cfg_done;
 			}
 
-			mgmt_txn_send_commit_config_req(
-				txn->txn_id, txn_req->req_id,
-				txn_req->req.set_cfg->ds_id,
-				txn_req->req.set_cfg->ds_ctx,
-				txn_req->req.set_cfg->dst_ds_id,
-				txn_req->req.set_cfg->dst_ds_ctx, false, false,
-				true);
+			mgmt_txn_send_commit_config_req(txn->txn_id,
+							txn_req->req_id,
+							txn_req->req.set_cfg
+								->ds_id,
+							txn_req->req.set_cfg
+								->ds_ctx,
+							txn_req->req.set_cfg
+								->dst_ds_id,
+							txn_req->req.set_cfg
+								->dst_ds_ctx,
+							false, false, true);
 
 			if (mm->perf_stats_en)
 				gettimeofday(&cmt_stats->last_start, NULL);
 			cmt_stats->commit_cnt++;
-		} else if (mgmt_fe_send_set_cfg_reply(
-				   txn->session_id, txn->txn_id,
-				   txn_req->req.set_cfg->ds_id,
-				   txn_req->req_id, MGMTD_SUCCESS, NULL, false)
-			   != 0) {
-			MGMTD_TXN_ERR(
-				"Failed to send SET_CONFIG_REPLY txn-id %" PRIu64
-				" session-id: %" PRIu64,
-				txn->txn_id, txn->session_id);
+		} else if (mgmt_fe_send_set_cfg_reply(txn->session_id,
+						      txn->txn_id,
+						      txn_req->req.set_cfg->ds_id,
+						      txn_req->req_id,
+						      MGMTD_SUCCESS, NULL,
+						      false) != 0) {
+			MGMTD_TXN_ERR("Failed to send SET_CONFIG_REPLY txn-id %" PRIu64
+				      " session-id: %" PRIu64,
+				      txn->txn_id, txn->session_id);
 		}
 
-	mgmt_txn_process_set_cfg_done:
+mgmt_txn_process_set_cfg_done:
 
 		/*
 		 * Note: The following will remove it from the list as well.
@@ -738,17 +736,16 @@ static void mgmt_txn_process_set_cfg(struct event *thread)
 
 	left = mgmt_txn_reqs_count(&txn->set_cfg_reqs);
 	if (left) {
-		MGMTD_TXN_DBG(
-			"Processed maximum number of Set-Config requests (%d/%d/%d). Rescheduling for rest.",
-			num_processed, MGMTD_TXN_MAX_NUM_SETCFG_PROC,
-			(int)left);
+		MGMTD_TXN_DBG("Processed maximum number of Set-Config requests (%d/%d/%d). Rescheduling for rest.",
+			      num_processed, MGMTD_TXN_MAX_NUM_SETCFG_PROC,
+			      (int)left);
 		mgmt_txn_register_event(txn, MGMTD_TXN_PROC_SETCFG);
 	}
 }
 
 static int mgmt_txn_send_commit_cfg_reply(struct mgmt_txn_ctx *txn,
-					   enum mgmt_result result,
-					   const char *error_if_any)
+					  enum mgmt_result result,
+					  const char *error_if_any)
 {
 	bool success, create_cmt_info_rec;
 
@@ -761,31 +758,31 @@ static int mgmt_txn_send_commit_cfg_reply(struct mgmt_txn_ctx *txn,
 	 * b/c right now that is special cased.. that special casing should be
 	 * removed; however...
 	 */
-	if (!txn->commit_cfg_req->req.commit_cfg.implicit && txn->session_id
-	    && !txn->commit_cfg_req->req.commit_cfg.rollback
-	    && mgmt_fe_send_commit_cfg_reply(
-		       txn->session_id, txn->txn_id,
-		       txn->commit_cfg_req->req.commit_cfg.src_ds_id,
-		       txn->commit_cfg_req->req.commit_cfg.dst_ds_id,
-		       txn->commit_cfg_req->req_id,
-		       txn->commit_cfg_req->req.commit_cfg.validate_only,
-		       result, error_if_any)
-		       != 0) {
-		MGMTD_TXN_ERR(
-			"Failed to send COMMIT-CONFIG-REPLY txn-id: %" PRIu64
-			" session-id: %" PRIu64,
-			txn->txn_id, txn->session_id);
+	if (!txn->commit_cfg_req->req.commit_cfg.implicit && txn->session_id &&
+	    !txn->commit_cfg_req->req.commit_cfg.rollback &&
+	    mgmt_fe_send_commit_cfg_reply(txn->session_id, txn->txn_id,
+					  txn->commit_cfg_req->req.commit_cfg
+						  .src_ds_id,
+					  txn->commit_cfg_req->req.commit_cfg
+						  .dst_ds_id,
+					  txn->commit_cfg_req->req_id,
+					  txn->commit_cfg_req->req.commit_cfg
+						  .validate_only,
+					  result, error_if_any) != 0) {
+		MGMTD_TXN_ERR("Failed to send COMMIT-CONFIG-REPLY txn-id: %" PRIu64
+			      " session-id: %" PRIu64,
+			      txn->txn_id, txn->session_id);
 	}
 
-	if (txn->commit_cfg_req->req.commit_cfg.implicit && txn->session_id
-	    && !txn->commit_cfg_req->req.commit_cfg.rollback
-	    && mgmt_fe_send_set_cfg_reply(
-		       txn->session_id, txn->txn_id,
-		       txn->commit_cfg_req->req.commit_cfg.src_ds_id,
-		       txn->commit_cfg_req->req_id,
-		       success ? MGMTD_SUCCESS : MGMTD_INTERNAL_ERROR,
-		       error_if_any, true)
-		       != 0) {
+	if (txn->commit_cfg_req->req.commit_cfg.implicit && txn->session_id &&
+	    !txn->commit_cfg_req->req.commit_cfg.rollback &&
+	    mgmt_fe_send_set_cfg_reply(txn->session_id, txn->txn_id,
+				       txn->commit_cfg_req->req.commit_cfg
+					       .src_ds_id,
+				       txn->commit_cfg_req->req_id,
+				       success ? MGMTD_SUCCESS
+					       : MGMTD_INTERNAL_ERROR,
+				       error_if_any, true) != 0) {
 		MGMTD_TXN_ERR("Failed to send SET-CONFIG-REPLY txn-id: %" PRIu64
 			      " session-id: %" PRIu64,
 			      txn->txn_id, txn->session_id);
@@ -804,10 +801,10 @@ static int mgmt_txn_send_commit_cfg_reply(struct mgmt_txn_ctx *txn,
 		 * Successful commit: Merge Src DS into Dst DS if and only if
 		 * this was not a validate-only or abort request.
 		 */
-		if ((txn->session_id
-		     && !txn->commit_cfg_req->req.commit_cfg.validate_only
-		     && !txn->commit_cfg_req->req.commit_cfg.abort)
-		    || txn->commit_cfg_req->req.commit_cfg.rollback) {
+		if ((txn->session_id &&
+		     !txn->commit_cfg_req->req.commit_cfg.validate_only &&
+		     !txn->commit_cfg_req->req.commit_cfg.abort) ||
+		    txn->commit_cfg_req->req.commit_cfg.rollback) {
 			mgmt_ds_copy_dss(txn->commit_cfg_req->req.commit_cfg
 						 .src_ds_ctx,
 					 txn->commit_cfg_req->req.commit_cfg
@@ -819,8 +816,7 @@ static int mgmt_txn_send_commit_cfg_reply(struct mgmt_txn_ctx *txn,
 		 * Restore Src DS back to Dest DS only through a commit abort
 		 * request.
 		 */
-		if (txn->session_id
-		    && txn->commit_cfg_req->req.commit_cfg.abort)
+		if (txn->session_id && txn->commit_cfg_req->req.commit_cfg.abort)
 			mgmt_ds_copy_dss(txn->commit_cfg_req->req.commit_cfg
 						 .dst_ds_ctx,
 					 txn->commit_cfg_req->req.commit_cfg
@@ -868,24 +864,24 @@ static int mgmt_txn_send_commit_cfg_reply(struct mgmt_txn_ctx *txn,
 
 static void
 mgmt_move_txn_cfg_batch_to_next(struct mgmt_commit_cfg_req *cmtcfg_req,
-				struct mgmt_txn_be_cfg_batch *cfg_btch,
+				struct mgmt_txn_be_cfg_batch *batch,
 				struct mgmt_txn_batches_head *src_list,
 				struct mgmt_txn_batches_head *dst_list,
 				bool update_commit_phase,
 				enum mgmt_commit_phase to_phase)
 {
-	mgmt_txn_batches_del(src_list, cfg_btch);
+	mgmt_txn_batches_del(src_list, batch);
 
 	if (update_commit_phase) {
 		MGMTD_TXN_DBG("Move txn-id %" PRIu64 " batch-id: %" PRIu64
 			      " from '%s' --> '%s'",
-			      cfg_btch->txn->txn_id, cfg_btch->batch_id,
-			      mgmt_commit_phase2str(cfg_btch->comm_phase),
-			      mgmt_txn_commit_phase_str(cfg_btch->txn, false));
-		cfg_btch->comm_phase = to_phase;
+			      batch->txn->txn_id, batch->batch_id,
+			      mgmt_commit_phase2str(batch->comm_phase),
+			      mgmt_txn_commit_phase_str(batch->txn, false));
+		batch->comm_phase = to_phase;
 	}
 
-	mgmt_txn_batches_add_tail(dst_list, cfg_btch);
+	mgmt_txn_batches_add_tail(dst_list, batch);
 }
 
 static void mgmt_move_txn_cfg_batches(struct mgmt_txn_ctx *txn,
@@ -895,12 +891,12 @@ static void mgmt_move_txn_cfg_batches(struct mgmt_txn_ctx *txn,
 				      bool update_commit_phase,
 				      enum mgmt_commit_phase to_phase)
 {
-	struct mgmt_txn_be_cfg_batch *cfg_btch;
+	struct mgmt_txn_be_cfg_batch *batch;
 
-	FOREACH_TXN_CFG_BATCH_IN_LIST (src_list, cfg_btch) {
-		mgmt_move_txn_cfg_batch_to_next(cmtcfg_req, cfg_btch, src_list,
-						 dst_list, update_commit_phase,
-						 to_phase);
+	FOREACH_TXN_CFG_BATCH_IN_LIST (src_list, batch) {
+		mgmt_move_txn_cfg_batch_to_next(cmtcfg_req, batch, src_list,
+						dst_list, update_commit_phase,
+						to_phase);
 	}
 }
 
@@ -949,8 +945,8 @@ mgmt_try_move_commit_to_next_phase(struct mgmt_txn_ctx *txn,
 	FOREACH_MGMTD_BE_CLIENT_ID (id) {
 		curr_list = &cmtcfg_req->curr_batches[id];
 		next_list = &cmtcfg_req->next_batches[id];
-		mgmt_move_txn_cfg_batches(txn, cmtcfg_req, next_list,
-					   curr_list, false, 0);
+		mgmt_move_txn_cfg_batches(txn, cmtcfg_req, next_list, curr_list,
+					  false, 0);
 	}
 
 	mgmt_txn_register_event(txn, MGMTD_TXN_PROC_COMMITCFG);
@@ -976,13 +972,12 @@ mgmt_move_be_commit_to_next_phase(struct mgmt_txn_ctx *txn,
 		      mgmt_txn_commit_phase_str(txn, true),
 		      mgmt_txn_commit_phase_str(txn, false));
 
-	MGMTD_TXN_DBG(
-		"Move all config batches for '%s' from current to next list",
-		adapter->name);
+	MGMTD_TXN_DBG("Move all config batches for '%s' from current to next list",
+		      adapter->name);
 	curr_list = &cmtcfg_req->curr_batches[adapter->id];
 	next_list = &cmtcfg_req->next_batches[adapter->id];
 	mgmt_move_txn_cfg_batches(txn, cmtcfg_req, curr_list, next_list, true,
-				   cmtcfg_req->next_phase);
+				  cmtcfg_req->next_phase);
 
 	MGMTD_TXN_DBG("txn-id: %" PRIu64 ", Phase(current:'%s' next:'%s')",
 		      txn->txn_id, mgmt_txn_commit_phase_str(txn, true),
@@ -997,11 +992,11 @@ mgmt_move_be_commit_to_next_phase(struct mgmt_txn_ctx *txn,
 }
 
 static int mgmt_txn_create_config_batches(struct mgmt_txn_req *txn_req,
-					   struct nb_config_cbs *changes)
+					  struct nb_config_cbs *changes)
 {
 	struct nb_config_cb *cb, *nxt;
 	struct nb_config_change *chg;
-	struct mgmt_txn_be_cfg_batch *cfg_btch;
+	struct mgmt_txn_be_cfg_batch *batch;
 	struct mgmt_be_client_subscr_info subscr_info;
 	char *xpath = NULL, *value = NULL;
 	char err_buf[1024];
@@ -1035,7 +1030,7 @@ static int mgmt_txn_create_config_batches(struct mgmt_txn_req *txn_req,
 			value = (char *)MGMTD_BE_CONTAINER_NODE_VAL;
 
 		MGMTD_TXN_DBG("XPATH: %s, Value: '%s'", xpath,
-			       value ? value : "NIL");
+			      value ? value : "NIL");
 
 		mgmt_be_get_subscr_info_for_xpath(xpath, &subscr_info);
 
@@ -1052,51 +1047,46 @@ static int mgmt_txn_create_config_batches(struct mgmt_txn_req *txn_req,
 			if (!adapter)
 				continue;
 
-			cfg_btch = cmtcfg_req->last_be_cfg_batch[id];
-			if (!cfg_btch
-			    || (cfg_btch->num_cfg_data
-				== MGMTD_MAX_CFG_CHANGES_IN_BATCH)
-			    || (cfg_btch->buf_space_left
-				< (xpath_len + value_len))) {
+			batch = cmtcfg_req->last_be_cfg_batch[id];
+			if (!batch ||
+			    (batch->num_cfg_data ==
+			     MGMTD_MAX_CFG_CHANGES_IN_BATCH) ||
+			    (batch->buf_space_left < (xpath_len + value_len))) {
 				/* Allocate a new config batch */
-				cfg_btch = mgmt_txn_cfg_batch_alloc(
-					txn_req->txn, id, adapter);
+				batch = mgmt_txn_cfg_batch_alloc(txn_req->txn,
+								 id, adapter);
 			}
 
-			cfg_btch->buf_space_left -= (xpath_len + value_len);
-			memcpy(&cfg_btch->xp_subscr[cfg_btch->num_cfg_data],
+			batch->buf_space_left -= (xpath_len + value_len);
+			memcpy(&batch->xp_subscr[batch->num_cfg_data],
 			       &subscr_info.xpath_subscr[id],
-			       sizeof(cfg_btch->xp_subscr[0]));
+			       sizeof(batch->xp_subscr[0]));
 
 			mgmt_yang_cfg_data_req_init(
-				&cfg_btch->cfg_data[cfg_btch->num_cfg_data]);
-			cfg_btch->cfg_datap[cfg_btch->num_cfg_data] =
-				&cfg_btch->cfg_data[cfg_btch->num_cfg_data];
+				&batch->cfg_data[batch->num_cfg_data]);
+			batch->cfg_datap[batch->num_cfg_data] =
+				&batch->cfg_data[batch->num_cfg_data];
 
 			if (chg->cb.operation == NB_OP_DESTROY)
-				cfg_btch->cfg_data[cfg_btch->num_cfg_data]
-					.req_type =
+				batch->cfg_data[batch->num_cfg_data].req_type =
 					MGMTD__CFG_DATA_REQ_TYPE__DELETE_DATA;
 			else
-				cfg_btch->cfg_data[cfg_btch->num_cfg_data]
-					.req_type =
+				batch->cfg_data[batch->num_cfg_data].req_type =
 					MGMTD__CFG_DATA_REQ_TYPE__SET_DATA;
 
-			mgmt_yang_data_init(
-				&cfg_btch->data[cfg_btch->num_cfg_data]);
-			cfg_btch->cfg_data[cfg_btch->num_cfg_data].data =
-				&cfg_btch->data[cfg_btch->num_cfg_data];
-			cfg_btch->data[cfg_btch->num_cfg_data].xpath =
-				strdup(xpath);
+			mgmt_yang_data_init(&batch->data[batch->num_cfg_data]);
+			batch->cfg_data[batch->num_cfg_data].data =
+				&batch->data[batch->num_cfg_data];
+			batch->data[batch->num_cfg_data].xpath = strdup(xpath);
 
 			mgmt_yang_data_value_init(
-				&cfg_btch->value[cfg_btch->num_cfg_data]);
-			cfg_btch->data[cfg_btch->num_cfg_data].value =
-				&cfg_btch->value[cfg_btch->num_cfg_data];
-			cfg_btch->value[cfg_btch->num_cfg_data].value_case =
+				&batch->value[batch->num_cfg_data]);
+			batch->data[batch->num_cfg_data].value =
+				&batch->value[batch->num_cfg_data];
+			batch->value[batch->num_cfg_data].value_case =
 				MGMTD__YANG_DATA_VALUE__VALUE_ENCODED_STR_VAL;
-			cfg_btch->value[cfg_btch->num_cfg_data]
-				.encoded_str_val = value;
+			batch->value[batch->num_cfg_data].encoded_str_val =
+				value;
 			value = NULL;
 
 			if (subscr_info.xpath_subscr[id] &
@@ -1105,17 +1095,11 @@ static int mgmt_txn_create_config_batches(struct mgmt_txn_req *txn_req,
 
 			cmtcfg_req->subscr_info.xpath_subscr[id] |=
 				subscr_info.xpath_subscr[id];
-			MGMTD_TXN_DBG(" -- %s, {V:%d, N:%d}, batch-id: %" PRIu64
-				      " item:%d",
-				      adapter->name,
-				      (subscr_info.xpath_subscr[id] &
-				       MGMT_SUBSCR_VALIDATE_CFG) != 0,
-				      (subscr_info.xpath_subscr[id] &
-				       MGMT_SUBSCR_NOTIFY_CFG) != 0,
-				      cfg_btch->batch_id,
-				      (int)cfg_btch->num_cfg_data);
+			MGMTD_TXN_DBG(" -- %s, batch-id: %" PRIu64 " item:%d",
+				      adapter->name, batch->batch_id,
+				      (int)batch->num_cfg_data);
 
-			cfg_btch->num_cfg_data++;
+			batch->num_cfg_data++;
 			num_chgs++;
 		}
 
@@ -1131,9 +1115,9 @@ static int mgmt_txn_create_config_batches(struct mgmt_txn_req *txn_req,
 
 	cmtcfg_req->cmt_stats->last_batch_cnt = num_chgs;
 	if (!num_chgs) {
-		(void)mgmt_txn_send_commit_cfg_reply(
-			txn_req->txn, MGMTD_NO_CFG_CHANGES,
-			"No changes found to commit!");
+		(void)mgmt_txn_send_commit_cfg_reply(txn_req->txn,
+						     MGMTD_NO_CFG_CHANGES,
+						     "No changes found to commit!");
 		return -1;
 	}
 
@@ -1159,8 +1143,7 @@ static int mgmt_txn_prepare_config(struct mgmt_txn_ctx *txn)
 		goto mgmt_txn_prep_config_validation_done;
 	}
 
-	if (txn->commit_cfg_req->req.commit_cfg.src_ds_id
-	    != MGMTD_DS_CANDIDATE) {
+	if (txn->commit_cfg_req->req.commit_cfg.src_ds_id != MGMTD_DS_CANDIDATE) {
 		(void)mgmt_txn_send_commit_cfg_reply(
 			txn, MGMTD_INVALID_PARAM,
 			"Source DS cannot be any other than CANDIDATE!");
@@ -1168,8 +1151,7 @@ static int mgmt_txn_prepare_config(struct mgmt_txn_ctx *txn)
 		goto mgmt_txn_prepare_config_done;
 	}
 
-	if (txn->commit_cfg_req->req.commit_cfg.dst_ds_id
-	    != MGMTD_DS_RUNNING) {
+	if (txn->commit_cfg_req->req.commit_cfg.dst_ds_id != MGMTD_DS_RUNNING) {
 		(void)mgmt_txn_send_commit_cfg_reply(
 			txn, MGMTD_INVALID_PARAM,
 			"Destination DS cannot be any other than RUNNING!");
@@ -1178,16 +1160,15 @@ static int mgmt_txn_prepare_config(struct mgmt_txn_ctx *txn)
 	}
 
 	if (!txn->commit_cfg_req->req.commit_cfg.src_ds_ctx) {
-		(void)mgmt_txn_send_commit_cfg_reply(
-			txn, MGMTD_INVALID_PARAM, "No such source datastore!");
+		(void)mgmt_txn_send_commit_cfg_reply(txn, MGMTD_INVALID_PARAM,
+						     "No such source datastore!");
 		ret = -1;
 		goto mgmt_txn_prepare_config_done;
 	}
 
 	if (!txn->commit_cfg_req->req.commit_cfg.dst_ds_ctx) {
-		(void)mgmt_txn_send_commit_cfg_reply(
-			txn, MGMTD_INVALID_PARAM,
-			"No such destination datastore!");
+		(void)mgmt_txn_send_commit_cfg_reply(txn, MGMTD_INVALID_PARAM,
+						     "No such destination datastore!");
 		ret = -1;
 		goto mgmt_txn_prepare_config_done;
 	}
@@ -1198,8 +1179,7 @@ static int mgmt_txn_prepare_config(struct mgmt_txn_ctx *txn)
 		 * That should trigger a restore of Candidate datastore to
 		 * Running.
 		 */
-		(void)mgmt_txn_send_commit_cfg_reply(txn, MGMTD_SUCCESS,
-						      NULL);
+		(void)mgmt_txn_send_commit_cfg_reply(txn, MGMTD_SUCCESS, NULL);
 		goto mgmt_txn_prepare_config_done;
 	}
 
@@ -1225,10 +1205,10 @@ static int mgmt_txn_prepare_config(struct mgmt_txn_ctx *txn)
 		 * diff from a full comparison of the candidate and
 		 * running DSs.
 		 */
-		nb_config_diff(
-			mgmt_ds_get_nb_config(txn->commit_cfg_req->req
-						      .commit_cfg.dst_ds_ctx),
-			nb_config, &changes);
+		nb_config_diff(mgmt_ds_get_nb_config(
+				       txn->commit_cfg_req->req.commit_cfg
+					       .dst_ds_ctx),
+			       nb_config, &changes);
 		cfg_chgs = &changes;
 		del_cfg_chgs = true;
 	}
@@ -1238,9 +1218,8 @@ static int mgmt_txn_prepare_config(struct mgmt_txn_ctx *txn)
 		 * This means there's no changes to commit whatsoever
 		 * is the source of the changes in config.
 		 */
-		(void)mgmt_txn_send_commit_cfg_reply(
-			txn, MGMTD_NO_CFG_CHANGES,
-			"No changes found to be committed!");
+		(void)mgmt_txn_send_commit_cfg_reply(txn, MGMTD_NO_CFG_CHANGES,
+						     "No changes found to be committed!");
 		ret = -1;
 		goto mgmt_txn_prepare_config_done;
 	}
@@ -1254,7 +1233,7 @@ static int mgmt_txn_prepare_config(struct mgmt_txn_ctx *txn)
 	 * Validate YANG contents of the source DS and get the diff
 	 * between source and destination DS contents.
 	 */
-	char err_buf[1024] = {0};
+	char err_buf[1024] = { 0 };
 	nb_ctx.client = NB_CLIENT_MGMTD_SERVER;
 	nb_ctx.user = (void *)txn;
 
@@ -1264,7 +1243,7 @@ static int mgmt_txn_prepare_config(struct mgmt_txn_ctx *txn)
 		if (strncmp(err_buf, " ", strlen(err_buf)) == 0)
 			strlcpy(err_buf, "Validation failed", sizeof(err_buf));
 		(void)mgmt_txn_send_commit_cfg_reply(txn, MGMTD_INVALID_PARAM,
-						      err_buf);
+						     err_buf);
 		ret = -1;
 		goto mgmt_txn_prepare_config_done;
 	}
@@ -1279,7 +1258,7 @@ static int mgmt_txn_prepare_config(struct mgmt_txn_ctx *txn)
 		if (strncmp(err_buf, " ", strlen(err_buf)) == 0)
 			strlcpy(err_buf, "Validation failed", sizeof(err_buf));
 		(void)mgmt_txn_send_commit_cfg_reply(txn, MGMTD_INVALID_PARAM,
-						      err_buf);
+						     err_buf);
 		ret = -1;
 		goto mgmt_txn_prepare_config_done;
 	}
@@ -1288,8 +1267,7 @@ static int mgmt_txn_prepare_config(struct mgmt_txn_ctx *txn)
 		/*
 		 * This was a validate-only COMMIT request return success.
 		 */
-		(void)mgmt_txn_send_commit_cfg_reply(txn, MGMTD_SUCCESS,
-						      NULL);
+		(void)mgmt_txn_send_commit_cfg_reply(txn, MGMTD_SUCCESS, NULL);
 		goto mgmt_txn_prepare_config_done;
 	}
 #endif /* ifdef MGMTD_LOCAL_VALIDATIONS_ENABLED */
@@ -1334,7 +1312,7 @@ static int mgmt_txn_send_be_txn_create(struct mgmt_txn_ctx *txn)
 	enum mgmt_be_client_id id;
 	struct mgmt_be_client_adapter *adapter;
 	struct mgmt_commit_cfg_req *cmtcfg_req;
-	struct mgmt_txn_be_cfg_batch *cfg_btch;
+	struct mgmt_txn_be_cfg_batch *batch;
 
 	assert(txn->type == MGMTD_TXN_TYPE_CONFIG && txn->commit_cfg_req);
 
@@ -1349,11 +1327,11 @@ static int mgmt_txn_send_be_txn_create(struct mgmt_txn_ctx *txn)
 				return -1;
 			}
 
-			FOREACH_TXN_CFG_BATCH_IN_LIST (
-				&txn->commit_cfg_req->req.commit_cfg
-					 .curr_batches[id],
-				cfg_btch)
-				cfg_btch->comm_phase =
+			FOREACH_TXN_CFG_BATCH_IN_LIST (&txn->commit_cfg_req->req
+								.commit_cfg
+								.curr_batches[id],
+						       batch)
+				batch->comm_phase =
 					MGMTD_COMMIT_PHASE_TXN_CREATE;
 		}
 	}
@@ -1379,8 +1357,8 @@ static int mgmt_txn_send_be_cfg_data(struct mgmt_txn_ctx *txn,
 				     struct mgmt_be_client_adapter *adapter)
 {
 	struct mgmt_commit_cfg_req *cmtcfg_req;
-	struct mgmt_txn_be_cfg_batch *cfg_btch;
-	struct mgmt_be_cfgreq cfg_req = {0};
+	struct mgmt_txn_be_cfg_batch *batch;
+	struct mgmt_be_cfgreq cfg_req = { 0 };
 	size_t num_batches, indx;
 
 	assert(txn->type == MGMTD_TXN_TYPE_CONFIG && txn->commit_cfg_req);
@@ -1392,29 +1370,31 @@ static int mgmt_txn_send_be_cfg_data(struct mgmt_txn_ctx *txn,
 	num_batches =
 		mgmt_txn_batches_count(&cmtcfg_req->curr_batches[adapter->id]);
 	FOREACH_TXN_CFG_BATCH_IN_LIST (&cmtcfg_req->curr_batches[adapter->id],
-				       cfg_btch) {
+				       batch) {
 		assert(cmtcfg_req->next_phase == MGMTD_COMMIT_PHASE_SEND_CFG);
 
-		cfg_req.cfgdata_reqs = cfg_btch->cfg_datap;
-		cfg_req.num_reqs = cfg_btch->num_cfg_data;
+		cfg_req.cfgdata_reqs = batch->cfg_datap;
+		cfg_req.num_reqs = batch->num_cfg_data;
 		indx++;
-		if (mgmt_be_send_cfgdata_req(
-			    adapter, txn->txn_id, cfg_btch->batch_id,
-			    cfg_req.cfgdata_reqs, cfg_req.num_reqs,
-			    indx == num_batches ? true : false)) {
+		if (mgmt_be_send_cfgdata_req(adapter, txn->txn_id,
+					     batch->batch_id,
+					     cfg_req.cfgdata_reqs,
+					     cfg_req.num_reqs,
+					     indx == num_batches ? true
+								 : false)) {
 			(void)mgmt_txn_send_commit_cfg_reply(
 				txn, MGMTD_INTERNAL_ERROR,
 				"Internal Error! Could not send config data to backend!");
-			MGMTD_TXN_ERR(
-				"Could not send CFGDATA_CREATE txn-id: %" PRIu64
-				" batch-id: %" PRIu64 " to client '%s",
-				txn->txn_id, cfg_btch->batch_id, adapter->name);
+			MGMTD_TXN_ERR("Could not send CFGDATA_CREATE txn-id: %" PRIu64
+				      " batch-id: %" PRIu64 " to client '%s",
+				      txn->txn_id, batch->batch_id,
+				      adapter->name);
 			return -1;
 		}
 
 		cmtcfg_req->cmt_stats->last_num_cfgdata_reqs++;
 		mgmt_move_txn_cfg_batch_to_next(
-			cmtcfg_req, cfg_btch,
+			cmtcfg_req, batch,
 			&cmtcfg_req->curr_batches[adapter->id],
 			&cmtcfg_req->next_batches[adapter->id], true,
 			MGMTD_COMMIT_PHASE_SEND_CFG);
@@ -1429,9 +1409,8 @@ static int mgmt_txn_send_be_cfg_data(struct mgmt_txn_ctx *txn,
 	return 0;
 }
 
-static int
-mgmt_txn_send_be_txn_delete(struct mgmt_txn_ctx *txn,
-				 struct mgmt_be_client_adapter *adapter)
+static int mgmt_txn_send_be_txn_delete(struct mgmt_txn_ctx *txn,
+				       struct mgmt_be_client_adapter *adapter)
 {
 	struct mgmt_commit_cfg_req *cmtcfg_req =
 		&txn->commit_cfg_req->req.commit_cfg;
@@ -1483,8 +1462,8 @@ static int mgmt_txn_send_be_cfg_apply(struct mgmt_txn_ctx *txn)
 	enum mgmt_be_client_id id;
 	struct mgmt_be_client_adapter *adapter;
 	struct mgmt_commit_cfg_req *cmtcfg_req;
-	struct mgmt_txn_batches_head *btch_list;
-	struct mgmt_txn_be_cfg_batch *cfg_btch;
+	struct mgmt_txn_batches_head *batch_list;
+	struct mgmt_txn_be_cfg_batch *batch;
 
 	assert(txn->type == MGMTD_TXN_TYPE_CONFIG && txn->commit_cfg_req);
 
@@ -1493,8 +1472,7 @@ static int mgmt_txn_send_be_cfg_apply(struct mgmt_txn_ctx *txn)
 		/*
 		 * If this was a validate-only COMMIT request return success.
 		 */
-		(void)mgmt_txn_send_commit_cfg_reply(txn, MGMTD_SUCCESS,
-						      NULL);
+		(void)mgmt_txn_send_commit_cfg_reply(txn, MGMTD_SUCCESS, NULL);
 		return 0;
 	}
 
@@ -1505,7 +1483,7 @@ static int mgmt_txn_send_be_cfg_apply(struct mgmt_txn_ctx *txn)
 			if (!adapter)
 				return -1;
 
-			btch_list = &cmtcfg_req->curr_batches[id];
+			batch_list = &cmtcfg_req->curr_batches[id];
 			if (mgmt_be_send_cfgapply_req(adapter, txn->txn_id)) {
 				(void)mgmt_txn_send_commit_cfg_reply(
 					txn, MGMTD_INTERNAL_ERROR,
@@ -1517,9 +1495,8 @@ static int mgmt_txn_send_be_cfg_apply(struct mgmt_txn_ctx *txn)
 			UNSET_FLAG(adapter->flags,
 				   MGMTD_BE_ADAPTER_FLAGS_CFG_SYNCED);
 
-			FOREACH_TXN_CFG_BATCH_IN_LIST (btch_list, cfg_btch)
-				cfg_btch->comm_phase =
-					MGMTD_COMMIT_PHASE_APPLY_CFG;
+			FOREACH_TXN_CFG_BATCH_IN_LIST (batch_list, batch)
+				batch->comm_phase = MGMTD_COMMIT_PHASE_APPLY_CFG;
 		}
 	}
 
@@ -1543,8 +1520,7 @@ static void mgmt_txn_process_commit_cfg(struct event *thread)
 	assert(txn);
 
 	MGMTD_TXN_DBG("Processing COMMIT_CONFIG for txn-id: %" PRIu64
-		      " session-id: %" PRIu64
-		      " Phase(Current:'%s', Next: '%s')",
+		      " session-id: %" PRIu64 " Phase(Current:'%s', Next: '%s')",
 		      txn->txn_id, txn->session_id,
 		      mgmt_txn_commit_phase_str(txn, true),
 		      mgmt_txn_commit_phase_str(txn, false));
@@ -1574,16 +1550,14 @@ static void mgmt_txn_process_commit_cfg(struct event *thread)
 			 */
 #ifndef MGMTD_LOCAL_VALIDATIONS_ENABLED
 		assert(cmtcfg_req->next_phase == MGMTD_COMMIT_PHASE_APPLY_CFG);
-		MGMTD_TXN_DBG(
-			"txn-id: %" PRIu64 " session-id: %" PRIu64
-			" trigger sending CFG_VALIDATE_REQ to all backend clients",
-			txn->txn_id, txn->session_id);
+		MGMTD_TXN_DBG("txn-id: %" PRIu64 " session-id: %" PRIu64
+			      " trigger sending CFG_VALIDATE_REQ to all backend clients",
+			      txn->txn_id, txn->session_id);
 #else  /* ifndef MGMTD_LOCAL_VALIDATIONS_ENABLED */
 		assert(cmtcfg_req->next_phase == MGMTD_COMMIT_PHASE_APPLY_CFG);
-		MGMTD_TXN_DBG(
-			"txn-id: %" PRIu64 " session-id: %" PRIu64
-			" trigger sending CFG_APPLY_REQ to all backend clients",
-			txn->txn_id, txn->session_id);
+		MGMTD_TXN_DBG("txn-id: %" PRIu64 " session-id: %" PRIu64
+			      " trigger sending CFG_APPLY_REQ to all backend clients",
+			      txn->txn_id, txn->session_id);
 #endif /* ifndef MGMTD_LOCAL_VALIDATIONS_ENABLED */
 		break;
 	case MGMTD_COMMIT_PHASE_APPLY_CFG:
@@ -1664,7 +1638,7 @@ static void mgmt_reset_get_data_reply_buf(struct mgmt_get_data_req *get_data)
 }
 
 static void mgmt_txn_send_getcfg_reply_data(struct mgmt_txn_req *txn_req,
-					     struct mgmt_get_data_req *get_req)
+					    struct mgmt_get_data_req *get_req)
 {
 	struct mgmt_get_data_reply *get_reply;
 	Mgmtd__YangDataReply *data_reply;
@@ -1677,45 +1651,44 @@ static void mgmt_txn_send_getcfg_reply_data(struct mgmt_txn_req *txn_req,
 	mgmt_yang_data_reply_init(data_reply);
 	data_reply->n_data = get_reply->num_reply;
 	data_reply->data = get_reply->reply_datap;
-	data_reply->next_indx =
-		(!get_reply->last_batch ? get_req->total_reply : -1);
+	data_reply->next_indx = (!get_reply->last_batch ? get_req->total_reply
+							: -1);
 
 	MGMTD_TXN_DBG("Sending %zu Get-Config/Data replies next-index:%" PRId64,
 		      data_reply->n_data, data_reply->next_indx);
 
 	switch (txn_req->req_event) {
 	case MGMTD_TXN_PROC_GETCFG:
-		if (mgmt_fe_send_get_cfg_reply(
-			    txn_req->txn->session_id, txn_req->txn->txn_id,
-			    get_req->ds_id, txn_req->req_id, MGMTD_SUCCESS,
-			    data_reply, NULL)
-		    != 0) {
-			MGMTD_TXN_ERR(
-				"Failed to send GET-CONFIG-REPLY txn-id: %" PRIu64
-				" session-id: %" PRIu64 " req-id: %" PRIu64,
-				txn_req->txn->txn_id, txn_req->txn->session_id,
-				txn_req->req_id);
+		if (mgmt_fe_send_get_cfg_reply(txn_req->txn->session_id,
+					       txn_req->txn->txn_id,
+					       get_req->ds_id, txn_req->req_id,
+					       MGMTD_SUCCESS, data_reply,
+					       NULL) != 0) {
+			MGMTD_TXN_ERR("Failed to send GET-CONFIG-REPLY txn-id: %" PRIu64
+				      " session-id: %" PRIu64
+				      " req-id: %" PRIu64,
+				      txn_req->txn->txn_id,
+				      txn_req->txn->session_id, txn_req->req_id);
 		}
 		break;
 	case MGMTD_TXN_PROC_GETDATA:
-		if (mgmt_fe_send_get_data_reply(
-			    txn_req->txn->session_id, txn_req->txn->txn_id,
-			    get_req->ds_id, txn_req->req_id, MGMTD_SUCCESS,
-			    data_reply, NULL)
-		    != 0) {
-			MGMTD_TXN_ERR(
-				"Failed to send GET-DATA-REPLY txn-id: %" PRIu64
-				" session-id: %" PRIu64 " req-id: %" PRIu64,
-				txn_req->txn->txn_id, txn_req->txn->session_id,
-				txn_req->req_id);
+		if (mgmt_fe_send_get_data_reply(txn_req->txn->session_id,
+						txn_req->txn->txn_id,
+						get_req->ds_id, txn_req->req_id,
+						MGMTD_SUCCESS, data_reply,
+						NULL) != 0) {
+			MGMTD_TXN_ERR("Failed to send GET-DATA-REPLY txn-id: %" PRIu64
+				      " session-id: %" PRIu64
+				      " req-id: %" PRIu64,
+				      txn_req->txn->txn_id,
+				      txn_req->txn->session_id, txn_req->req_id);
 		}
 		break;
 	case MGMTD_TXN_PROC_SETCFG:
 	case MGMTD_TXN_PROC_COMMITCFG:
 	case MGMTD_TXN_COMMITCFG_TIMEOUT:
 	case MGMTD_TXN_CLEANUP:
-		MGMTD_TXN_ERR("Invalid Txn-Req-Event %u",
-			       txn_req->req_event);
+		MGMTD_TXN_ERR("Invalid Txn-Req-Event %u", txn_req->req_event);
 		break;
 	}
 
@@ -1743,8 +1716,8 @@ static void mgmt_txn_iter_and_send_get_cfg_reply(const char *xpath,
 	if (!(node->schema->nodetype & LYD_NODE_TERM))
 		return;
 
-	assert(txn_req->req_event == MGMTD_TXN_PROC_GETCFG
-	       || txn_req->req_event == MGMTD_TXN_PROC_GETDATA);
+	assert(txn_req->req_event == MGMTD_TXN_PROC_GETCFG ||
+	       txn_req->req_event == MGMTD_TXN_PROC_GETDATA);
 
 	get_req = txn_req->req.get_data;
 	assert(get_req);
@@ -1762,7 +1735,7 @@ static void mgmt_txn_iter_and_send_get_cfg_reply(const char *xpath,
 	get_reply->num_reply++;
 	get_req->total_reply++;
 	MGMTD_TXN_DBG(" [%d] XPATH: '%s', Value: '%s'", get_req->total_reply,
-		       data->xpath, data_value->encoded_str_val);
+		      data->xpath, data_value->encoded_str_val);
 
 	if (get_reply->num_reply == MGMTD_MAX_NUM_DATA_REPLY_IN_BATCH)
 		mgmt_txn_send_getcfg_reply_data(txn_req, get_req);
@@ -1783,9 +1756,8 @@ static int mgmt_txn_get_config(struct mgmt_txn_ctx *txn,
 					  sizeof(struct mgmt_get_data_reply));
 		if (!get_data->reply) {
 			mgmt_fe_send_get_cfg_reply(
-				txn->session_id, txn->txn_id,
-				get_data->ds_id, txn_req->req_id,
-				MGMTD_INTERNAL_ERROR, NULL,
+				txn->session_id, txn->txn_id, get_data->ds_id,
+				txn_req->req_id, MGMTD_INTERNAL_ERROR, NULL,
 				"Internal error: Unable to allocate reply buffers!");
 			goto mgmt_txn_get_config_failed;
 		}
@@ -1798,7 +1770,7 @@ static int mgmt_txn_get_config(struct mgmt_txn_ctx *txn,
 	get_reply = get_data->reply;
 	for (indx = 0; indx < get_data->num_xpaths; indx++) {
 		MGMTD_TXN_DBG("Trying to get all data under '%s'",
-			       get_data->xpaths[indx]);
+			      get_data->xpaths[indx]);
 		mgmt_init_get_data_reply(get_reply);
 		/*
 		 * mgmt_ds_iter_data works on path prefixes, but the user may
@@ -1810,15 +1782,16 @@ static int mgmt_txn_get_config(struct mgmt_txn_ctx *txn,
 				      mgmt_txn_iter_and_send_get_cfg_reply,
 				      (void *)txn_req) == -1) {
 			MGMTD_TXN_DBG("Invalid Xpath '%s",
-				       get_data->xpaths[indx]);
-			mgmt_fe_send_get_cfg_reply(
-				txn->session_id, txn->txn_id,
-				get_data->ds_id, txn_req->req_id,
-				MGMTD_INTERNAL_ERROR, NULL, "Invalid xpath");
+				      get_data->xpaths[indx]);
+			mgmt_fe_send_get_cfg_reply(txn->session_id, txn->txn_id,
+						   get_data->ds_id,
+						   txn_req->req_id,
+						   MGMTD_INTERNAL_ERROR, NULL,
+						   "Invalid xpath");
 			goto mgmt_txn_get_config_failed;
 		}
 		MGMTD_TXN_DBG("Got %d remaining data-replies for xpath '%s'",
-			       get_reply->num_reply, get_data->xpaths[indx]);
+			      get_reply->num_reply, get_data->xpaths[indx]);
 		get_reply->last_batch = true;
 		mgmt_txn_send_getcfg_reply_data(txn_req, get_data);
 	}
@@ -1857,11 +1830,11 @@ static void mgmt_txn_process_get_cfg(struct event *thread)
 		assert(cfg_root);
 
 		if (mgmt_txn_get_config(txn, txn_req, cfg_root) != 0) {
-			MGMTD_TXN_ERR(
-				"Unable to retrieve config from DS %d txn-id: %" PRIu64
-				" session-id: %" PRIu64 " req-id: %" PRIu64,
-				txn_req->req.get_data->ds_id, txn->txn_id,
-				txn->session_id, txn_req->req_id);
+			MGMTD_TXN_ERR("Unable to retrieve config from DS %d txn-id: %" PRIu64
+				      " session-id: %" PRIu64
+				      " req-id: %" PRIu64,
+				      txn_req->req.get_data->ds_id, txn->txn_id,
+				      txn->session_id, txn_req->req_id);
 			error = true;
 		}
 
@@ -1884,9 +1857,8 @@ static void mgmt_txn_process_get_cfg(struct event *thread)
 	}
 
 	if (mgmt_txn_reqs_count(&txn->get_cfg_reqs)) {
-		MGMTD_TXN_DBG(
-			"Processed maximum number of Get-Config requests (%d/%d). Rescheduling for rest.",
-			num_processed, MGMTD_TXN_MAX_NUM_GETCFG_PROC);
+		MGMTD_TXN_DBG("Processed maximum number of Get-Config requests (%d/%d). Rescheduling for rest.",
+			      num_processed, MGMTD_TXN_MAX_NUM_GETCFG_PROC);
 		mgmt_txn_register_event(txn, MGMTD_TXN_PROC_GETCFG);
 	}
 }
@@ -1912,11 +1884,11 @@ static void mgmt_txn_process_get_data(struct event *thread)
 		 * TODO: Trigger GET procedures for Backend
 		 * For now return back error.
 		 */
-		mgmt_fe_send_get_data_reply(
-			txn->session_id, txn->txn_id,
-			txn_req->req.get_data->ds_id, txn_req->req_id,
-			MGMTD_INTERNAL_ERROR, NULL,
-			"GET-DATA on Oper DS is not supported yet!");
+		mgmt_fe_send_get_data_reply(txn->session_id, txn->txn_id,
+					    txn_req->req.get_data->ds_id,
+					    txn_req->req_id,
+					    MGMTD_INTERNAL_ERROR, NULL,
+					    "GET-DATA on Oper DS is not supported yet!");
 		/*
 		 * Delete the txn request.
 		 * Note: The following will remove it from the list
@@ -1934,16 +1906,15 @@ static void mgmt_txn_process_get_data(struct event *thread)
 	}
 
 	if (mgmt_txn_reqs_count(&txn->get_data_reqs)) {
-		MGMTD_TXN_DBG(
-			"Processed maximum number of Get-Data requests (%d/%d). Rescheduling for rest.",
-			num_processed, MGMTD_TXN_MAX_NUM_GETDATA_PROC);
+		MGMTD_TXN_DBG("Processed maximum number of Get-Data requests (%d/%d). Rescheduling for rest.",
+			      num_processed, MGMTD_TXN_MAX_NUM_GETDATA_PROC);
 		mgmt_txn_register_event(txn, MGMTD_TXN_PROC_GETDATA);
 	}
 }
 
 static struct mgmt_txn_ctx *
 mgmt_fe_find_txn_by_session_id(struct mgmt_master *cm, uint64_t session_id,
-				    enum mgmt_txn_type type)
+			       enum mgmt_txn_type type)
 {
 	struct mgmt_txn_ctx *txn;
 
@@ -1956,7 +1927,7 @@ mgmt_fe_find_txn_by_session_id(struct mgmt_master *cm, uint64_t session_id,
 }
 
 static struct mgmt_txn_ctx *mgmt_txn_create_new(uint64_t session_id,
-						   enum mgmt_txn_type type)
+						enum mgmt_txn_type type)
 {
 	struct mgmt_txn_ctx *txn = NULL;
 
@@ -1970,8 +1941,7 @@ static struct mgmt_txn_ctx *mgmt_txn_create_new(uint64_t session_id,
 		goto mgmt_create_txn_done;
 	}
 
-	txn = mgmt_fe_find_txn_by_session_id(mgmt_txn_mm, session_id,
-						   type);
+	txn = mgmt_fe_find_txn_by_session_id(mgmt_txn_mm, session_id, type);
 	if (!txn) {
 		txn = XCALLOC(MTYPE_MGMTD_TXN, sizeof(struct mgmt_txn_ctx));
 		assert(txn);
@@ -2012,7 +1982,7 @@ static unsigned int mgmt_txn_hash_key(const void *data)
 {
 	const struct mgmt_txn_ctx *txn = data;
 
-	return jhash2((uint32_t *) &txn->txn_id,
+	return jhash2((uint32_t *)&txn->txn_id,
 		      sizeof(txn->txn_id) / sizeof(uint32_t), 0);
 }
 
@@ -2036,9 +2006,8 @@ static void mgmt_txn_hash_init(void)
 	if (!mgmt_txn_mm || mgmt_txn_mm->txn_hash)
 		return;
 
-	mgmt_txn_mm->txn_hash = hash_create(mgmt_txn_hash_key,
-					      mgmt_txn_hash_cmp,
-					      "MGMT Transactions");
+	mgmt_txn_mm->txn_hash = hash_create(mgmt_txn_hash_key, mgmt_txn_hash_cmp,
+					    "MGMT Transactions");
 }
 
 static void mgmt_txn_hash_destroy(void)
@@ -2046,16 +2015,14 @@ static void mgmt_txn_hash_destroy(void)
 	if (!mgmt_txn_mm || !mgmt_txn_mm->txn_hash)
 		return;
 
-	hash_clean(mgmt_txn_mm->txn_hash,
-		   mgmt_txn_hash_free);
+	hash_clean(mgmt_txn_mm->txn_hash, mgmt_txn_hash_free);
 	hash_free(mgmt_txn_mm->txn_hash);
 	mgmt_txn_mm->txn_hash = NULL;
 }
 
-static inline struct mgmt_txn_ctx *
-mgmt_txn_id2ctx(uint64_t txn_id)
+static inline struct mgmt_txn_ctx *mgmt_txn_id2ctx(uint64_t txn_id)
 {
-	struct mgmt_txn_ctx key = {0};
+	struct mgmt_txn_ctx key = { 0 };
 	struct mgmt_txn_ctx *txn;
 
 	if (!mgmt_txn_mm || !mgmt_txn_mm->txn_hash)
@@ -2067,8 +2034,7 @@ mgmt_txn_id2ctx(uint64_t txn_id)
 	return txn;
 }
 
-static void mgmt_txn_lock(struct mgmt_txn_ctx *txn, const char *file,
-			   int line)
+static void mgmt_txn_lock(struct mgmt_txn_ctx *txn, const char *file, int line)
 {
 	txn->refcount++;
 	MGMTD_TXN_DBG("%s:%d --> Lock %s txn-id: %" PRIu64 " refcnt: %d", file,
@@ -2077,7 +2043,7 @@ static void mgmt_txn_lock(struct mgmt_txn_ctx *txn, const char *file,
 }
 
 static void mgmt_txn_unlock(struct mgmt_txn_ctx **txn, const char *file,
-			     int line)
+			    int line)
 {
 	assert(*txn && (*txn)->refcount);
 
@@ -2114,8 +2080,7 @@ static void mgmt_txn_cleanup_txn(struct mgmt_txn_ctx **txn)
 	mgmt_txn_delete(txn);
 }
 
-static void
-mgmt_txn_cleanup_all_txns(void)
+static void mgmt_txn_cleanup_all_txns(void)
 {
 	struct mgmt_txn_ctx *txn;
 
@@ -2137,40 +2102,39 @@ static void mgmt_txn_cleanup(struct event *thread)
 }
 
 static void mgmt_txn_register_event(struct mgmt_txn_ctx *txn,
-				     enum mgmt_txn_event event)
+				    enum mgmt_txn_event event)
 {
-	struct timeval tv = {.tv_sec = 0,
-			     .tv_usec = MGMTD_TXN_PROC_DELAY_USEC};
+	struct timeval tv = { .tv_sec = 0,
+			      .tv_usec = MGMTD_TXN_PROC_DELAY_USEC };
 
 	assert(mgmt_txn_mm && mgmt_txn_tm);
 
 	switch (event) {
 	case MGMTD_TXN_PROC_SETCFG:
-		event_add_timer_tv(mgmt_txn_tm, mgmt_txn_process_set_cfg,
-				    txn, &tv, &txn->proc_set_cfg);
+		event_add_timer_tv(mgmt_txn_tm, mgmt_txn_process_set_cfg, txn,
+				   &tv, &txn->proc_set_cfg);
 		break;
 	case MGMTD_TXN_PROC_COMMITCFG:
 		event_add_timer_tv(mgmt_txn_tm, mgmt_txn_process_commit_cfg,
-				    txn, &tv, &txn->proc_comm_cfg);
+				   txn, &tv, &txn->proc_comm_cfg);
 		break;
 	case MGMTD_TXN_PROC_GETCFG:
-		event_add_timer_tv(mgmt_txn_tm, mgmt_txn_process_get_cfg,
-				    txn, &tv, &txn->proc_get_cfg);
+		event_add_timer_tv(mgmt_txn_tm, mgmt_txn_process_get_cfg, txn,
+				   &tv, &txn->proc_get_cfg);
 		break;
 	case MGMTD_TXN_PROC_GETDATA:
-		event_add_timer_tv(mgmt_txn_tm, mgmt_txn_process_get_data,
-				    txn, &tv, &txn->proc_get_data);
+		event_add_timer_tv(mgmt_txn_tm, mgmt_txn_process_get_data, txn,
+				   &tv, &txn->proc_get_data);
 		break;
 	case MGMTD_TXN_COMMITCFG_TIMEOUT:
-		event_add_timer_msec(mgmt_txn_tm,
-				      mgmt_txn_cfg_commit_timedout, txn,
-				      MGMTD_TXN_CFG_COMMIT_MAX_DELAY_MSEC,
-				      &txn->comm_cfg_timeout);
+		event_add_timer_msec(mgmt_txn_tm, mgmt_txn_cfg_commit_timedout,
+				     txn, MGMTD_TXN_CFG_COMMIT_MAX_DELAY_MSEC,
+				     &txn->comm_cfg_timeout);
 		break;
 	case MGMTD_TXN_CLEANUP:
 		tv.tv_usec = MGMTD_TXN_CLEANUP_DELAY_USEC;
 		event_add_timer_tv(mgmt_txn_tm, mgmt_txn_cleanup, txn, &tv,
-				    &txn->clnup);
+				   &txn->clnup);
 	}
 }
 
@@ -2224,12 +2188,12 @@ void mgmt_destroy_txn(uint64_t *txn_id)
 }
 
 int mgmt_txn_send_set_config_req(uint64_t txn_id, uint64_t req_id,
-				  Mgmtd__DatastoreId ds_id,
-				  struct mgmt_ds_ctx *ds_ctx,
-				  Mgmtd__YangCfgDataReq **cfg_req,
-				  size_t num_req, bool implicit_commit,
-				  Mgmtd__DatastoreId dst_ds_id,
-				  struct mgmt_ds_ctx *dst_ds_ctx)
+				 Mgmtd__DatastoreId ds_id,
+				 struct mgmt_ds_ctx *ds_ctx,
+				 Mgmtd__YangCfgDataReq **cfg_req,
+				 size_t num_req, bool implicit_commit,
+				 Mgmtd__DatastoreId dst_ds_id,
+				 struct mgmt_ds_ctx *dst_ds_ctx)
 {
 	struct mgmt_txn_ctx *txn;
 	struct mgmt_txn_req *txn_req;
@@ -2254,40 +2218,38 @@ int mgmt_txn_send_set_config_req(uint64_t txn_id, uint64_t req_id,
 	for (indx = 0; indx < num_req; indx++) {
 		cfg_chg = &txn_req->req.set_cfg->cfg_changes[*num_chgs];
 
-		if (cfg_req[indx]->req_type
-		    == MGMTD__CFG_DATA_REQ_TYPE__DELETE_DATA)
+		if (cfg_req[indx]->req_type ==
+		    MGMTD__CFG_DATA_REQ_TYPE__DELETE_DATA)
 			cfg_chg->operation = NB_OP_DESTROY;
-		else if (cfg_req[indx]->req_type
-			 == MGMTD__CFG_DATA_REQ_TYPE__SET_DATA)
+		else if (cfg_req[indx]->req_type ==
+			 MGMTD__CFG_DATA_REQ_TYPE__SET_DATA)
 			cfg_chg->operation =
-				mgmt_ds_find_data_node_by_xpath(
-					ds_ctx, cfg_req[indx]->data->xpath)
+				mgmt_ds_find_data_node_by_xpath(ds_ctx,
+								cfg_req[indx]
+									->data
+									->xpath)
 					? NB_OP_MODIFY
 					: NB_OP_CREATE;
 		else
 			continue;
 
-		MGMTD_TXN_DBG(
-			"XPath: '%s', Value: '%s'", cfg_req[indx]->data->xpath,
-			(cfg_req[indx]->data->value
-					 && cfg_req[indx]
-						    ->data->value
-						    ->encoded_str_val
-				 ? cfg_req[indx]->data->value->encoded_str_val
-				 : "NULL"));
+		MGMTD_TXN_DBG("XPath: '%s', Value: '%s'",
+			      cfg_req[indx]->data->xpath,
+			      (cfg_req[indx]->data->value &&
+					       cfg_req[indx]->data->value->encoded_str_val
+				       ? cfg_req[indx]->data->value->encoded_str_val
+				       : "NULL"));
 		strlcpy(cfg_chg->xpath, cfg_req[indx]->data->xpath,
 			sizeof(cfg_chg->xpath));
-		cfg_chg->value = (cfg_req[indx]->data->value
-						  && cfg_req[indx]
-							     ->data->value
-							     ->encoded_str_val
-					  ? strdup(cfg_req[indx]
-							   ->data->value
-							   ->encoded_str_val)
-					  : NULL);
+		cfg_chg->value =
+			(cfg_req[indx]->data->value &&
+					 cfg_req[indx]->data->value->encoded_str_val
+				 ? strdup(cfg_req[indx]
+						  ->data->value->encoded_str_val)
+				 : NULL);
 		if (cfg_chg->value)
 			MGMTD_TXN_DBG("Allocated value at %p ==> '%s'",
-				       cfg_chg->value, cfg_chg->value);
+				      cfg_chg->value, cfg_chg->value);
 
 		(*num_chgs)++;
 	}
@@ -2342,7 +2304,7 @@ int mgmt_txn_send_commit_config_req(uint64_t txn_id, uint64_t req_id,
 }
 
 int mgmt_txn_notify_be_adapter_conn(struct mgmt_be_client_adapter *adapter,
-					bool connect)
+				    bool connect)
 {
 	struct mgmt_txn_ctx *txn;
 	struct mgmt_txn_req *txn_req;
@@ -2367,9 +2329,8 @@ int mgmt_txn_notify_be_adapter_conn(struct mgmt_be_client_adapter *adapter,
 		 */
 		txn = mgmt_txn_create_new(0, MGMTD_TXN_TYPE_CONFIG);
 		if (!txn) {
-			MGMTD_TXN_ERR(
-				"Failed to create CONFIG Transaction for downloading CONFIGs for client '%s'",
-				adapter->name);
+			MGMTD_TXN_ERR("Failed to create CONFIG Transaction for downloading CONFIGs for client '%s'",
+				      adapter->name);
 			return -1;
 		}
 
@@ -2380,8 +2341,7 @@ int mgmt_txn_notify_be_adapter_conn(struct mgmt_be_client_adapter *adapter,
 		 * Set the changeset for transaction to commit and trigger the
 		 * commit request.
 		 */
-		txn_req =
-			mgmt_txn_req_alloc(txn, 0, MGMTD_TXN_PROC_COMMITCFG);
+		txn_req = mgmt_txn_req_alloc(txn, 0, MGMTD_TXN_PROC_COMMITCFG);
 		txn_req->req.commit_cfg.src_ds_id = MGMTD_DS_NONE;
 		txn_req->req.commit_cfg.src_ds_ctx = 0;
 		txn_req->req.commit_cfg.dst_ds_id = MGMTD_DS_NONE;
@@ -2407,8 +2367,8 @@ int mgmt_txn_notify_be_adapter_conn(struct mgmt_be_client_adapter *adapter,
 			 * completed */
 			if (txn->type == MGMTD_TXN_TYPE_CONFIG) {
 				cmtcfg_req = txn->commit_cfg_req
-						     ? &txn->commit_cfg_req
-								->req.commit_cfg
+						     ? &txn->commit_cfg_req->req
+								.commit_cfg
 						     : NULL;
 				if (cmtcfg_req &&
 				    cmtcfg_req->subscr_info
@@ -2424,9 +2384,8 @@ int mgmt_txn_notify_be_adapter_conn(struct mgmt_be_client_adapter *adapter,
 	return 0;
 }
 
-int mgmt_txn_notify_be_txn_reply(uint64_t txn_id, bool create,
-				      bool success,
-				      struct mgmt_be_client_adapter *adapter)
+int mgmt_txn_notify_be_txn_reply(uint64_t txn_id, bool create, bool success,
+				 struct mgmt_be_client_adapter *adapter)
 {
 	struct mgmt_txn_ctx *txn;
 	struct mgmt_commit_cfg_req *cmtcfg_req = NULL;
@@ -2446,8 +2405,8 @@ int mgmt_txn_notify_be_txn_reply(uint64_t txn_id, bool create,
 			 * Done with TXN_CREATE. Move the backend client to
 			 * next phase.
 			 */
-			assert(cmtcfg_req->curr_phase
-			       == MGMTD_COMMIT_PHASE_TXN_CREATE);
+			assert(cmtcfg_req->curr_phase ==
+			       MGMTD_COMMIT_PHASE_TXN_CREATE);
 
 			/*
 			 * Send CFGDATA_CREATE-REQs to the backend immediately.
@@ -2469,12 +2428,12 @@ int mgmt_txn_notify_be_txn_reply(uint64_t txn_id, bool create,
 	return 0;
 }
 
-int mgmt_txn_notify_be_cfgdata_reply(
-	uint64_t txn_id, uint64_t batch_id, bool success, char *error_if_any,
-	struct mgmt_be_client_adapter *adapter)
+int mgmt_txn_notify_be_cfgdata_reply(uint64_t txn_id, uint64_t batch_id,
+				     bool success, char *error_if_any,
+				     struct mgmt_be_client_adapter *adapter)
 {
 	struct mgmt_txn_ctx *txn;
-	struct mgmt_txn_be_cfg_batch *cfg_btch;
+	struct mgmt_txn_be_cfg_batch *batch;
 	struct mgmt_commit_cfg_req *cmtcfg_req;
 
 	txn = mgmt_txn_id2ctx(txn_id);
@@ -2485,32 +2444,31 @@ int mgmt_txn_notify_be_cfgdata_reply(
 		return -1;
 	cmtcfg_req = &txn->commit_cfg_req->req.commit_cfg;
 
-	cfg_btch = mgmt_txn_cfgbatch_id2ctx(txn, batch_id);
-	if (!cfg_btch || cfg_btch->txn != txn)
+	batch = mgmt_txn_cfgbatch_id2ctx(txn, batch_id);
+	if (!batch || batch->txn != txn)
 		return -1;
 
 	if (!success) {
-		MGMTD_TXN_ERR(
-			"CFGDATA_CREATE_REQ sent to '%s' failed txn-id: %" PRIu64
-			" batch-id %" PRIu64 " err: %s",
-			adapter->name, txn->txn_id, cfg_btch->batch_id,
-			error_if_any ? error_if_any : "None");
+		MGMTD_TXN_ERR("CFGDATA_CREATE_REQ sent to '%s' failed txn-id: %" PRIu64
+			      " batch-id %" PRIu64 " err: %s",
+			      adapter->name, txn->txn_id, batch->batch_id,
+			      error_if_any ? error_if_any : "None");
 		mgmt_txn_send_commit_cfg_reply(
 			txn, MGMTD_INTERNAL_ERROR,
-			error_if_any ? error_if_any :
-			"Internal error! Failed to download config data to backend!");
+			error_if_any
+				? error_if_any
+				: "Internal error! Failed to download config data to backend!");
 		return 0;
 	}
 
-	MGMTD_TXN_DBG(
-		"CFGDATA_CREATE_REQ sent to '%s' was successful txn-id: %" PRIu64
-		" batch-id %" PRIu64 " err: %s",
-		adapter->name, txn->txn_id, cfg_btch->batch_id,
-		error_if_any ? error_if_any : "None");
-	mgmt_move_txn_cfg_batch_to_next(
-		cmtcfg_req, cfg_btch, &cmtcfg_req->curr_batches[adapter->id],
-		&cmtcfg_req->next_batches[adapter->id], true,
-		MGMTD_COMMIT_PHASE_APPLY_CFG);
+	MGMTD_TXN_DBG("CFGDATA_CREATE_REQ sent to '%s' was successful txn-id: %" PRIu64
+		      " batch-id %" PRIu64 " err: %s",
+		      adapter->name, txn->txn_id, batch->batch_id,
+		      error_if_any ? error_if_any : "None");
+	mgmt_move_txn_cfg_batch_to_next(cmtcfg_req, batch,
+					&cmtcfg_req->curr_batches[adapter->id],
+					&cmtcfg_req->next_batches[adapter->id],
+					true, MGMTD_COMMIT_PHASE_APPLY_CFG);
 
 	mgmt_try_move_commit_to_next_phase(txn, cmtcfg_req);
 
@@ -2523,37 +2481,36 @@ int mgmt_txn_notify_be_cfg_apply_reply(uint64_t txn_id, bool success,
 				       struct mgmt_be_client_adapter *adapter)
 {
 	struct mgmt_txn_ctx *txn;
-	struct mgmt_txn_be_cfg_batch *cfg_btch;
+	struct mgmt_txn_be_cfg_batch *batch;
 	struct mgmt_commit_cfg_req *cmtcfg_req = NULL;
 	size_t indx;
 
 	txn = mgmt_txn_id2ctx(txn_id);
-	if (!txn || txn->type != MGMTD_TXN_TYPE_CONFIG
-	    || !txn->commit_cfg_req)
+	if (!txn || txn->type != MGMTD_TXN_TYPE_CONFIG || !txn->commit_cfg_req)
 		return -1;
 
 	cmtcfg_req = &txn->commit_cfg_req->req.commit_cfg;
 
 	if (!success) {
-		MGMTD_TXN_ERR(
-			"CFGDATA_APPLY_REQ sent to '%s' failed txn-id: %" PRIu64
-			" batch ids %" PRIu64 " - %" PRIu64 " err: %s",
-			adapter->name, txn->txn_id, batch_ids[0],
-			batch_ids[num_batch_ids - 1],
-			error_if_any ? error_if_any : "None");
+		MGMTD_TXN_ERR("CFGDATA_APPLY_REQ sent to '%s' failed txn-id: %" PRIu64
+			      " batch ids %" PRIu64 " - %" PRIu64 " err: %s",
+			      adapter->name, txn->txn_id, batch_ids[0],
+			      batch_ids[num_batch_ids - 1],
+			      error_if_any ? error_if_any : "None");
 		mgmt_txn_send_commit_cfg_reply(
 			txn, MGMTD_INTERNAL_ERROR,
-			error_if_any ? error_if_any :
-			"Internal error! Failed to apply config data on backend!");
+			error_if_any
+				? error_if_any
+				: "Internal error! Failed to apply config data on backend!");
 		return 0;
 	}
 
 	for (indx = 0; indx < num_batch_ids; indx++) {
-		cfg_btch = mgmt_txn_cfgbatch_id2ctx(txn, batch_ids[indx]);
-		if (cfg_btch->txn != txn)
+		batch = mgmt_txn_cfgbatch_id2ctx(txn, batch_ids[indx]);
+		if (batch->txn != txn)
 			return -1;
 		mgmt_move_txn_cfg_batch_to_next(
-			cmtcfg_req, cfg_btch,
+			cmtcfg_req, batch,
 			&cmtcfg_req->curr_batches[adapter->id],
 			&cmtcfg_req->next_batches[adapter->id], true,
 			MGMTD_COMMIT_PHASE_TXN_DELETE);
@@ -2608,8 +2565,7 @@ int mgmt_txn_send_get_config_req(uint64_t txn_id, uint64_t req_id,
 
 int mgmt_txn_send_get_data_req(uint64_t txn_id, uint64_t req_id,
 			       Mgmtd__DatastoreId ds_id,
-			       Mgmtd__YangGetDataReq **data_req,
-			       size_t num_reqs)
+			       Mgmtd__YangGetDataReq **data_req, size_t num_reqs)
 {
 	struct mgmt_txn_ctx *txn;
 	struct mgmt_txn_req *txn_req;

--- a/mgmtd/mgmt_txn.h
+++ b/mgmtd/mgmt_txn.h
@@ -177,25 +177,16 @@ extern int mgmt_txn_send_commit_config_req(uint64_t txn_id, uint64_t req_id,
 					   bool implicit);
 
 /*
- * Send get-config request to be processed later in transaction.
+ * Send get-{cfg,data} request to be processed later in transaction.
  *
- * Similar to set-config request.
+ * Is get-config if cfg_root is provided and the config is gathered locally,
+ * otherwise it's get-data and data is fetched from backedn clients.
  */
-extern int mgmt_txn_send_get_config_req(uint64_t txn_id, uint64_t req_id,
-					Mgmtd__DatastoreId ds_id,
-					struct nb_config *cfg_root,
-					Mgmtd__YangGetDataReq **data_req,
-					size_t num_reqs);
-
-/*
- * Send get-data request to be processed later in transaction.
- *
- * Similar to get-config request, but here data is fetched from backedn client.
- */
-extern int mgmt_txn_send_get_data_req(uint64_t txn_id, uint64_t req_id,
-				       Mgmtd__DatastoreId ds_id,
-				       Mgmtd__YangGetDataReq **data_req,
-				       size_t num_reqs);
+extern int mgmt_txn_send_get_req(uint64_t txn_id, uint64_t req_id,
+				 Mgmtd__DatastoreId ds_id,
+				 struct nb_config *cfg_root,
+				 Mgmtd__YangGetDataReq **data_req,
+				 size_t num_reqs);
 
 /*
  * Notifiy backend adapter on connection.

--- a/mgmtd/mgmt_vty.c
+++ b/mgmtd/mgmt_vty.c
@@ -194,7 +194,7 @@ DEFPY(show_mgmt_get_config, show_mgmt_get_config_cmd,
 		datastore = mgmt_ds_name2id(dsname);
 
 	xpath_list[0] = path;
-	vty_mgmt_send_get_config(vty, datastore, xpath_list, 1);
+	vty_mgmt_send_get_req(vty, true, datastore, xpath_list, 1);
 	return CMD_SUCCESS;
 }
 
@@ -214,7 +214,7 @@ DEFPY(show_mgmt_get_data, show_mgmt_get_data_cmd,
 		datastore = mgmt_ds_name2id(dsname);
 
 	xpath_list[0] = path;
-	vty_mgmt_send_get_data(vty, datastore, xpath_list, 1);
+	vty_mgmt_send_get_req(vty, false, datastore, xpath_list, 1);
 	return CMD_SUCCESS;
 }
 

--- a/tests/lib/subdir.am
+++ b/tests/lib/subdir.am
@@ -157,6 +157,13 @@ tests_lib_test_checksum_LDADD = $(ALL_TESTS_LDADD)
 tests_lib_test_checksum_SOURCES = tests/lib/test_checksum.c tests/helpers/c/prng.c
 
 
+check_PROGRAMS += tests/lib/test_darr
+tests_lib_test_darr_CFLAGS = $(TESTS_CFLAGS)
+tests_lib_test_darr_CPPFLAGS = $(TESTS_CPPFLAGS)
+tests_lib_test_darr_LDADD = $(ALL_TESTS_LDADD)
+tests_lib_test_darr_SOURCES = tests/lib/test_darr.c
+
+
 check_PROGRAMS += tests/lib/test_graph
 tests_lib_test_graph_CFLAGS = $(TESTS_CFLAGS)
 tests_lib_test_graph_CPPFLAGS = $(TESTS_CPPFLAGS)

--- a/tests/lib/test_darr.c
+++ b/tests/lib/test_darr.c
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * June 23 2023, Christian Hopps <chopps@labn.net>
+ *
+ * Copyright (c) 2023, LabN Consulting, L.L.C.
+ *
+ */
+#include <zebra.h>
+#include "darr.h"
+
+/*
+ * Public functions to test:
+ * [x] - darr_append
+ * [x] - darr_append_n
+ * [x] - darr_append_nz
+ * [x] - darr_cap
+ * [-] - darr_ensure_cap
+ * [x] - darr_ensure_i
+ * [x] - darr_foreach_i
+ * [x] - darr_foreach_p
+ * [x] - darr_free
+ * [x] - darr_insert
+ * [ ] - darr_insertz
+ * [x] - darr_insert_n
+ * [x] - darr_insert_nz
+ * [x] - darr_maxi
+ * [x] - darr_pop
+ * [x] - darr_push
+ * [ ] - darr_pushz
+ * [x] - darr_remove
+ * [x] - darr_remove_n
+ * [x] - darr_reset
+ * [x] - darr_setlen
+ */
+
+static void test_int(void)
+{
+	int z105[105] = {0};
+	int a1[] = {0, 1, 2, 3, 4};
+	int a2[] = {4, 3, 2, 1, 0};
+	int *da1 = NULL;
+	int *da2 = NULL;
+	int *dap;
+	uint i;
+
+	darr_ensure_i(da1, 0);
+	da1[0] = 0;
+	assert(darr_len(da1) == 1);
+	assert(darr_cap(da1) == 1);
+
+	*darr_ensure_i(da1, 1) = 1;
+	assert(darr_len(da1) == 2);
+	assert(darr_cap(da1) == 2);
+
+	darr_ensure_i(da1, 4);
+	darr_foreach_i (da1, i)
+		da1[i] = i;
+
+	assert(darr_len(da1) == 5);
+	/* minimum non-pow2 array size for long long and smaller */
+	assert(darr_cap(da1) == 8);
+	assert(!memcmp(da1, a1, sizeof(a1)));
+
+	/* reverse the numbers */
+	darr_foreach_p (da1, dap)
+		*dap = darr_end(da1) - dap - 1;
+	assert(!memcmp(da1, a2, sizeof(a2)));
+
+	darr_append_n(da1, 100);
+	darr_foreach_p (da1, dap)
+		*dap = darr_end(da1) - dap - 1;
+
+	darr_pop_n(da1, 100);
+	darr_append_nz(da1, 100);
+	assert(!memcmp(&da1[5], z105, _darr_esize(da1) * 100));
+
+	assert(darr_len(da1) == 105);
+	assert(darr_maxi(da1) == 127);
+	assert(darr_cap(da1) == 128);
+
+	darr_setlen(da1, 102);
+	assert(darr_len(da1) == 102);
+	assert(darr_maxi(da1) == 127);
+
+	int a3[] = { 0xdeadbeaf, 0x12345678 };
+
+	da1[0] = a3[0];
+	da1[101] = a3[1];
+	darr_remove_n(da1, 1, 100);
+	assert(darr_len(da1) == array_size(a3));
+	assert(!memcmp(da1, a3, sizeof(a3)));
+
+	da1[0] = a3[1];
+	da1[1] = a3[0];
+
+	darr_insert_n(da1, 1, 100);
+	assert(darr_len(da1) == 102);
+	assert(da1[0] == a3[1]);
+	assert(da1[101] == a3[0]);
+
+	darr_reset(da1);
+	assert(darr_len(da1) == 0);
+	assert(darr_maxi(da1) == 127);
+	assert(darr_cap(da1) == 128);
+
+	/* we touch the length field of the freed block here somehow */
+	darr_insert_n(da1, 100, 300);
+	assert(darr_len(da1) == 400);
+	assert(darr_cap(da1) == 512);
+
+	da1[400 - 1] = 0x0BAD;
+	*darr_insert(da1, 0) = 0xF00D;
+	assert(da1[0] == 0xF00D);
+	assert(da1[400] == 0x0BAD);
+	assert(darr_len(da1) == 401);
+	assert(darr_cap(da1) == 512);
+
+	darr_free(da1);
+	assert(da1 == NULL);
+	assert(darr_len(da1) == 0);
+	darr_setlen(da1, 0);
+	darr_reset(da1);
+	darr_free(da1);
+
+	*darr_append(da2) = 0;
+	*darr_append(da2) = 1;
+	darr_push(da2, 2);
+	darr_push(da2, 3);
+	darr_push(da2, 4);
+
+	assert(!memcmp(da2, a1, sizeof(a1)));
+
+	assert(darr_pop(da2) == 4);
+	assert(darr_pop(da2) == 3);
+	assert(darr_pop(da2) == 2);
+	assert(darr_len(da2) == 2);
+	assert(darr_pop(da2) == 1);
+	assert(darr_pop(da2) == 0);
+	assert(darr_len(da2) == 0);
+
+	darr_free(da2);
+}
+
+static void test_struct(void)
+{
+	/*
+	 *uwould like to use different sizes with padding but memcmp can't be
+	 *used then.
+	 */
+	struct st {
+		long long a;
+		long long b;
+	};
+	struct st z102[102] = {{0, 0}};
+	struct st *da1 = NULL;
+	struct st *da2 = NULL;
+	struct st a1[] = {
+		{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4},
+	};
+	uint i;
+
+	darr_ensure_i(da1, 0);
+	da1[0].a = 0;
+	da1[0].b = 0;
+	assert(darr_len(da1) == 1);
+	assert(darr_cap(da1) == 1);
+
+	darr_ensure_i(da1, 1)->a = 1;
+	darr_ensure_i(da1, 1)->b = 1;
+	assert(darr_len(da1) == 2);
+	assert(darr_cap(da1) == 2);
+
+	darr_ensure_i(da1, 4);
+	da1[2].a = 2;
+	da1[2].b = 2;
+
+	da1[3].a = 3;
+	da1[3].b = 3;
+
+	da1[4].a = 4;
+	da1[4].b = 4;
+
+	assert(darr_len(da1) == 5);
+	/* minimum non-pow2 array size for long long and smaller */
+	assert(darr_cap(da1) == 8);
+	assert(!memcmp(da1, a1, sizeof(a1)));
+
+	darr_append_n(da1, 100);
+
+	assert(darr_len(da1) == 105);
+	assert(darr_maxi(da1) == 127);
+	assert(darr_cap(da1) == 128);
+
+	darr_setlen(da1, 102);
+	assert(darr_len(da1) == 102);
+	assert(darr_maxi(da1) == 127);
+
+	struct st a2[] = {
+		{0xdeadbeaf, 0xdeadbeaf},
+		{0x12345678, 0x12345678},
+	};
+	da1[0] = a2[0];
+	da1[101] = a2[1];
+	darr_remove_n(da1, 1, 100);
+	assert(darr_len(da1) == array_size(a2));
+	assert(!memcmp(da1, a2, sizeof(a2)));
+
+	da1[0] = a2[1];
+	da1[1] = a2[0];
+
+	darr_insert_n(da1, 1, 100);
+	assert(darr_len(da1) == 102);
+	darr_foreach_i (da1, i) {
+		da1[i].a = i;
+		da1[i].b = i;
+	}
+	darr_remove_n(da1, 1, 100);
+	assert(darr_len(da1) == 2);
+	darr_insert_nz(da1, 1, 100);
+	assert(!memcmp(&da1[1], z102, 100 * sizeof(da1[0])));
+	/* assert(da1[0] == a2[1]); */
+	/* assert(da1[101] == a2[0]); */
+
+	darr_reset(da1);
+	assert(darr_len(da1) == 0);
+	assert(darr_maxi(da1) == 127);
+	assert(darr_cap(da1) == 128);
+
+	/* we touch the length field of the freed block here somehow */
+	darr_insert_n(da1, 100, 300);
+
+	assert(darr_len(da1) == 400);
+	assert(darr_cap(da1) == 512);
+
+	darr_free(da1);
+	assert(da1 == NULL);
+
+	assert(darr_len(da1) == 0);
+	darr_setlen(da1, 0);
+	darr_reset(da1);
+
+	darr_free(da1);
+
+	struct st i0 = {0, 0};
+	struct st i1 = {1, 1};
+	struct st i2 = {2, 2};
+	struct st i3 = {3, 3};
+	struct st i4 = {4, 4};
+
+	*darr_append(da2) = i0;
+	*darr_append(da2) = i1;
+	darr_push(da2, i2);
+	darr_push(da2, i3);
+	darr_push(da2, i4);
+
+	assert(!memcmp(da2, a1, sizeof(a1)));
+
+	struct st p0, p1, p2, p3, p4;
+
+	p4 = darr_pop(da2);
+	p3 = darr_pop(da2);
+	p2 = darr_pop(da2);
+	p1 = darr_pop(da2);
+	p0 = darr_pop(da2);
+	assert(darr_len(da2) == 0);
+	assert(p4.a == i4.a && p4.b == i4.b);
+	assert(p3.a == i3.a && p3.b == i3.b);
+	assert(p2.a == i2.a && p2.b == i2.b);
+	assert(p1.a == i1.a && p1.b == i1.b);
+	assert(p0.a == i0.a && p0.b == i0.b);
+
+	darr_free(da2);
+}
+
+int main(int argc, char **argv)
+{
+	test_int();
+	test_struct();
+}


### PR DESCRIPTION
- rename a variable abbrev to avoid possible misreading
- remove unimplemented message types
- consolidate 2 getmsg types to 1 removing copy/paste code.
- move from static array to dynamic for xpath registries