### PR TITLE
isisd, ospfd: fix opaque zapi source parsing

### DIFF
--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -772,9 +772,9 @@ static int isis_opaque_msg_handler(ZAPI_CALLBACK_ARGS)
 
 	switch (info.type) {
 	case LINK_STATE_SYNC:
-		STREAM_GETC(s, dst.proto);
-		STREAM_GETW(s, dst.instance);
-		STREAM_GETL(s, dst.session_id);
+		dst.proto = info.src_proto;
+		dst.instance = info.src_instance;
+		dst.session_id = info.src_session_id;
 		dst.type = LINK_STATE_SYNC;
 		ret = isis_te_sync_ted(dst);
 		break;

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -2161,9 +2161,9 @@ static int ospf_opaque_msg_handler(ZAPI_CALLBACK_ARGS)
 
 	switch (info.type) {
 	case LINK_STATE_SYNC:
-		STREAM_GETC(s, dst.proto);
-		STREAM_GETW(s, dst.instance);
-		STREAM_GETL(s, dst.session_id);
+		dst.proto = info.src_proto;
+		dst.instance = info.src_instance;
+		dst.session_id = info.src_session_id;
 		dst.type = LINK_STATE_SYNC;
 		ret = ospf_te_sync_ted(dst);
 		break;


### PR DESCRIPTION
Opaque zapi messages carry the sender's zclient tuple now, daemons shouldn't try to parse those bits directly. This should fix the recent report of zapi parsing errors after some recent opaque message changes.