### PR TITLE
bgpd: Ensure peer data structure is accessed only when BGPD is not te…

### DIFF
--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -225,7 +225,7 @@ static void bgp_process_reads(struct event *thread)
 
 	peer = EVENT_ARG(thread);
 
-	if (peer->fd < 0 || bm->terminating)
+	if (bm->terminating || peer->fd < 0)
 		return;
 
 	struct frr_pthread *fpt = bgp_pth_io;


### PR DESCRIPTION
Ensure peer data structure is accessed only when BGPD is not terminating.

With these changes,
the code ensures that the peer data-structures are accessed only after it knows that BGPD is not terminating.

Authored-by: Naveen Thanikachalam <nthanikachal@vmware.com>
Signed-off-by: Iqra Siddiqui <imujeebsiddi@vmware.com>