### PR TITLE
update nexthop num counter to uint32 to prevent counter reverse

### DIFF
--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -70,10 +70,10 @@ static struct nexthop *nexthop_group_tail(const struct nexthop_group *nhg)
 	return nexthop;
 }
 
-uint8_t nexthop_group_nexthop_num(const struct nexthop_group *nhg)
+uint32_t nexthop_group_nexthop_num(const struct nexthop_group *nhg)
 {
 	struct nexthop *nhop;
-	uint8_t num = 0;
+	uint32_t num = 0;
 
 	for (ALL_NEXTHOPS_PTR(nhg, nhop))
 		num++;
@@ -81,10 +81,10 @@ uint8_t nexthop_group_nexthop_num(const struct nexthop_group *nhg)
 	return num;
 }
 
-uint8_t nexthop_group_nexthop_num_no_recurse(const struct nexthop_group *nhg)
+uint32_t nexthop_group_nexthop_num_no_recurse(const struct nexthop_group *nhg)
 {
 	struct nexthop *nhop;
-	uint8_t num = 0;
+	uint32_t num = 0;
 
 	for (nhop = nhg->nexthop; nhop; nhop = nhop->next)
 		num++;
@@ -92,10 +92,10 @@ uint8_t nexthop_group_nexthop_num_no_recurse(const struct nexthop_group *nhg)
 	return num;
 }
 
-uint8_t nexthop_group_active_nexthop_num(const struct nexthop_group *nhg)
+uint32_t nexthop_group_active_nexthop_num(const struct nexthop_group *nhg)
 {
 	struct nexthop *nhop;
-	uint8_t num = 0;
+	uint32_t num = 0;
 
 	for (ALL_NEXTHOPS_PTR(nhg, nhop)) {
 		if (CHECK_FLAG(nhop->flags, NEXTHOP_FLAG_ACTIVE))
@@ -105,11 +105,11 @@ uint8_t nexthop_group_active_nexthop_num(const struct nexthop_group *nhg)
 	return num;
 }
 
-uint8_t
+uint32_t
 nexthop_group_active_nexthop_num_no_recurse(const struct nexthop_group *nhg)
 {
 	struct nexthop *nhop;
-	uint8_t num = 0;
+	uint32_t num = 0;
 
 	for (nhop = nhg->nexthop; nhop; nhop = nhop->next) {
 		if (CHECK_FLAG(nhop->flags, NEXTHOP_FLAG_ACTIVE))
@@ -200,7 +200,7 @@ static struct nexthop *nhg_nh_find(const struct nexthop_group *nhg,
 static bool
 nexthop_group_equal_common(const struct nexthop_group *nhg1,
 			   const struct nexthop_group *nhg2,
-			   uint8_t (*nexthop_group_nexthop_num_func)(
+			   uint32_t (*nexthop_group_nexthop_num_func)(
 				   const struct nexthop_group *nhg))
 {
 	if (nhg1 && !nhg2)

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -149,12 +149,12 @@ extern void nexthop_group_json_nexthop(json_object *j,
 				       const struct nexthop *nh);
 
 /* Return the number of nexthops in this nhg */
-extern uint8_t nexthop_group_nexthop_num(const struct nexthop_group *nhg);
-extern uint8_t
+extern uint32_t nexthop_group_nexthop_num(const struct nexthop_group *nhg);
+extern uint32_t
 nexthop_group_nexthop_num_no_recurse(const struct nexthop_group *nhg);
-extern uint8_t
+extern uint32_t
 nexthop_group_active_nexthop_num(const struct nexthop_group *nhg);
-extern uint8_t
+extern uint32_t
 nexthop_group_active_nexthop_num_no_recurse(const struct nexthop_group *nhg);
 
 extern bool nexthop_group_has_label(const struct nexthop_group *nhg);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -687,7 +687,7 @@ static uint8_t parse_multipath_nexthops_unicast(ns_id_t ns_id,
 		rtnh = RTNH_NEXT(rtnh);
 	}
 
-	uint8_t nhop_num = nexthop_group_nexthop_num(ng);
+	uint32_t nhop_num = nexthop_group_nexthop_num(ng);
 
 	return nhop_num;
 }


### PR DESCRIPTION
When there is a route that has 256 nexthops,  the counter of type uint8 will revert to zero.  For example, In rib_process_update_fib and rib_process_add_fib, it relies on nexthop_group_active_nexthop_num to decide if this nexthop is active or not. Then, a route with 256 nexthop will cause nexthop inactive, subsequently, it leads to route withdraw from kernel and fpm.