### PR TITLE
doc: Add Ubuntu 22.04 to list of builds

### DIFF
--- a/doc/developer/building.rst
+++ b/doc/developer/building.rst
@@ -9,13 +9,13 @@ Building FRR
 
    static-linking
    building-frr-for-alpine
+   building-frr-for-archlinux
    building-frr-for-centos6
    building-frr-for-centos7
    building-frr-for-centos8
    building-frr-for-debian8
    building-frr-for-debian9
    building-frr-for-fedora
-   building-frr-for-opensuse
    building-frr-for-freebsd9
    building-frr-for-freebsd10
    building-frr-for-freebsd11
@@ -23,11 +23,12 @@ Building FRR
    building-frr-for-netbsd6
    building-frr-for-netbsd7
    building-frr-for-openbsd6
+   building-frr-for-opensuse
    building-frr-for-openwrt
    building-frr-for-ubuntu1404
    building-frr-for-ubuntu1604
    building-frr-for-ubuntu1804
    building-frr-for-ubuntu2004
-   building-frr-for-archlinux
+   building-frr-for-ubuntu2204
    building-docker
    cross-compiling

--- a/doc/developer/subdir.am
+++ b/doc/developer/subdir.am
@@ -6,12 +6,12 @@ dev_RSTFILES = \
 	doc/developer/bgp-typecodes.rst \
 	doc/developer/bgpd.rst \
 	doc/developer/building-frr-for-alpine.rst \
+	doc/developer/building-frr-for-archlinux.rst \
 	doc/developer/building-frr-for-centos6.rst \
 	doc/developer/building-frr-for-centos7.rst \
 	doc/developer/building-frr-for-debian8.rst \
 	doc/developer/building-frr-for-debian9.rst \
 	doc/developer/building-frr-for-fedora.rst \
-	doc/developer/building-frr-for-opensuse.rst \
 	doc/developer/building-frr-for-freebsd10.rst \
 	doc/developer/building-frr-for-freebsd11.rst \
 	doc/developer/building-frr-for-freebsd13.rst \
@@ -19,11 +19,13 @@ dev_RSTFILES = \
 	doc/developer/building-frr-for-netbsd6.rst \
 	doc/developer/building-frr-for-netbsd7.rst \
 	doc/developer/building-frr-for-openbsd6.rst \
+	doc/developer/building-frr-for-opensuse.rst \
 	doc/developer/building-frr-for-openwrt.rst \
 	doc/developer/building-frr-for-ubuntu1404.rst \
 	doc/developer/building-frr-for-ubuntu1604.rst \
 	doc/developer/building-frr-for-ubuntu1804.rst \
 	doc/developer/building-frr-for-ubuntu2004.rst \
+	doc/developer/building-frr-for-ubuntu2204.rst \
 	doc/developer/building-libunwind-note.rst \
 	doc/developer/building-libyang.rst \
 	doc/developer/building.rst \


### PR DESCRIPTION
Add Ubuntu 22.04 build instructions to list.
Sort list into alphabetic order.