### PR TITLE
pbrd: add vty support for src/dst ip, src/dst port, DSCP, and ECN

### DIFF
--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -161,15 +161,54 @@ end destination.
    Strip inner vlan tags from matched packets. The Linux Kernel provider does not currently support packet mangling, so this field will be ignored unless another provider is used. It is invalid to specify both a `strip` and `set
    vlan` action.
 
+.. clicmd:: set src-ip [A.B.C.D/M|X:X::X:X/M]
+
+   Change the source IP address of matched packets, possibly using a mask `M`.
+   Note that this action is not currently supported by the Linux kernel
+   provider, so will be ignored unless other providers are used. 
+
+.. clicmd:: set dst-ip [A.B.C.D/M|X:X::X:X/M]
+
+   Change the destination IP address of matched packets, possibly using a mask
+   `M`. Note that this action is not currently supported by the Linux kernel
+   provider, so will be ignored unless other providers are used.
+
+.. clicmd:: set src-port (1-65535)
+
+   Change the source port of matched packets. Note that this action only makes
+   sense with layer 4 protocols that use ports, such as TCP, UDP, and SCTP.
+   This action is not currently supported by the Linux kernel provider, so will 
+   be ignored unless other providers are used.
+
+.. clicmd:: set dst-port (1-65535)
+
+   Change the destination port of matched packets. Note that this action only 
+   makes sense with layer 4 protocols that use ports, such as TCP, UDP, and 
+   SCTP. This action is not currently supported by the Linux kernel provider, 
+   so will be ignored unless other providers are used.
+
+.. clicmd:: set dscp DSCP
+
+   Set the differentiated services code point (DSCP) of matched packets. This
+   action is not currently supported by the Linux kernel provider, so will be
+   ignored unless other providers are used.
+
+.. clicmd:: set ecn (0-3)
+
+   Set the explicit congestion notification (ECN) of matched packets. This
+   action is not currently supported by the Linux kernel provider, so will be
+   ignored unless other providers are used. 
+
 .. clicmd:: set nexthop-group NAME
 
    Use the nexthop-group NAME as the place to forward packets when the match
    commands have matched a packet.
 
-.. clicmd:: set nexthop [A.B.C.D|X:X::X:XX] [interface] [nexthop-vrf NAME]
+.. clicmd:: set nexthop [A.B.C.D|X:X::X:XX|drop] [interface] [nexthop-vrf NAME]
 
    Use this individual nexthop as the place to forward packets when the match
-   commands have matched a packet.
+   commands have matched a packet. If `drop`, packets will be sent to a
+   blackhole route and dropped.
 
 .. clicmd:: set vrf unchanged|NAME
 

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -1047,6 +1047,7 @@ void nexthop_group_write_nexthop_simple(struct vty *vty,
 		vty_out(vty, "%pI6 %s", &nh->gate.ipv6, ifname);
 		break;
 	case NEXTHOP_TYPE_BLACKHOLE:
+        vty_out(vty, "%s", "drop");
 		break;
 	}
 }

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 /* Policy Based Routing (PBR) main header
  * Copyright (C) 2018 6WIND
+ * Portions:
+ *      Copyright (c) 2021 The MITRE Corporation.
  */
 
 #ifndef _PBR_H
@@ -45,7 +47,7 @@ struct pbr_filter {
 	struct prefix src_ip;
 	struct prefix dst_ip;
 
-	/* Source and Destination higher-layer (TCP/UDP) port numbers. */
+	/* Source and Destination layer 4 (TCP, UDP, etc.) port numbers. */
 	uint16_t src_port;
 	uint16_t dst_port;
 
@@ -75,6 +77,17 @@ struct pbr_action {
 	uint16_t vlan_flags;
 
 	uint32_t queue_id;
+    
+    /* Source and Destination IP address with masks. */
+	struct prefix src_ip;
+	struct prefix dst_ip;
+
+	/* Source and Destination layer 4 (tcp, udp, etc.) port numbers. */
+	uint32_t src_port;
+	uint32_t dst_port;
+
+	/* Differentiated Services field  */
+	uint8_t dsfield; /* DSCP (6 bits) & ECN (2 bits) */
 
 	uint32_t table;
 };

--- a/pbrd/pbr_map.h
+++ b/pbrd/pbr_map.h
@@ -3,6 +3,8 @@
  * PBR-map Header
  * Copyright (C) 2018 Cumulus Networks, Inc.
  *               Donald Sharp
+ * Portions:
+ *      Copyright (c) 2021 The MITRE Corporation.
  */
 #ifndef __PBR_MAP_H__
 #define __PBR_MAP_H__
@@ -105,6 +107,20 @@ struct pbr_map_sequence {
 	 * Family of the src/dst.  Needed when deleting since we clear them
 	 */
 	unsigned char family;
+
+    /*
+	 * Actions
+	 */
+	struct prefix *action_src;
+	struct prefix *action_dst;
+
+#define PBR_UNDEFINED_VALUE 0xffffffff
+#define PBR_UNDEFINED_QUEUE_ID 0xff
+
+	uint16_t action_src_port;
+	uint16_t action_dst_port;
+
+	uint8_t action_dsfield;
 
 	/*
 	 * Use interface's vrf.
@@ -222,4 +238,11 @@ extern void pbr_map_check_vrf_nh_group_change(const char *nh_group,
 extern void pbr_map_check_interface_nh_group_change(const char *nh_group,
 						    struct interface *ifp,
 						    ifindex_t oldifindex);
+extern void pbr_set_action_clause_for_dscp(struct pbr_map_sequence *pbrms,
+					   uint8_t dscp_value);
+extern void pbr_reset_action_clause_for_dscp(struct pbr_map_sequence *pbrms);
+
+extern void pbr_set_action_clause_for_ecn(struct pbr_map_sequence *pbrms,
+					  uint8_t ecn_value);
+extern void pbr_reset_action_clause_for_ecn(struct pbr_map_sequence *pbrms);
 #endif

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -5,6 +5,7 @@
  *   Copyright (C) 1997-1999  Kunihiro Ishiguro
  *   Copyright (C) 2015-2018  Cumulus Networks, Inc.
  *   et al.
+ *   Copyright (c) 2021 The MITRE Corporation.
  */
 
 #include <zebra.h>
@@ -3198,18 +3199,32 @@ static inline void zread_rule(ZAPI_HANDLER_ARGS)
 		STREAM_GETL(s, zpr.rule.seq);
 		STREAM_GETL(s, zpr.rule.priority);
 		STREAM_GETL(s, zpr.rule.unique);
-		STREAM_GETC(s, zpr.rule.filter.ip_proto);
 		STREAM_GETC(s, zpr.rule.filter.src_ip.family);
 		STREAM_GETC(s, zpr.rule.filter.src_ip.prefixlen);
 		STREAM_GET(&zpr.rule.filter.src_ip.u.prefix, s,
 			   prefix_blen(&zpr.rule.filter.src_ip));
-		STREAM_GETW(s, zpr.rule.filter.src_port);
 		STREAM_GETC(s, zpr.rule.filter.dst_ip.family);
 		STREAM_GETC(s, zpr.rule.filter.dst_ip.prefixlen);
 		STREAM_GET(&zpr.rule.filter.dst_ip.u.prefix, s,
 			   prefix_blen(&zpr.rule.filter.dst_ip));
+        STREAM_GETC(s, zpr.rule.action.src_ip.family);
+		STREAM_GETC(s, zpr.rule.action.src_ip.prefixlen);
+		STREAM_GET(&zpr.rule.action.src_ip.u.prefix, s,
+			   prefix_blen(&zpr.rule.action.src_ip));
+
+		STREAM_GETC(s, zpr.rule.action.dst_ip.family);
+		STREAM_GETC(s, zpr.rule.action.dst_ip.prefixlen);
+		STREAM_GET(&zpr.rule.action.dst_ip.u.prefix, s,
+			   prefix_blen(&zpr.rule.action.dst_ip));
+
+		STREAM_GETW(s, zpr.rule.filter.src_port);
 		STREAM_GETW(s, zpr.rule.filter.dst_port);
+        STREAM_GETL(s, zpr.rule.action.src_port);
+		STREAM_GETL(s, zpr.rule.action.dst_port);
 		STREAM_GETC(s, zpr.rule.filter.dsfield);
+        STREAM_GETC(s, zpr.rule.action.dsfield);
+
+		STREAM_GETC(s, zpr.rule.filter.ip_proto);
 		STREAM_GETL(s, zpr.rule.filter.fwmark);
 
 		STREAM_GETL(s, zpr.rule.action.queue_id);
@@ -3514,7 +3529,7 @@ static inline void zread_ipset_entry(ZAPI_HANDLER_ARGS)
 		if (zpi.src_port_max != 0)
 			zpi.filter_bm |= PBR_FILTER_SRC_PORT_RANGE;
 		if (zpi.proto != 0)
-			zpi.filter_bm |= PBR_FILTER_PROTO;
+			zpi.filter_bm |= PBR_FILTER_IP_PROTOCOL;
 
 		if (!(zpi.dst.family == AF_INET
 		      || zpi.dst.family == AF_INET6)) {

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -1118,7 +1118,7 @@ static void zebra_pbr_display_port(struct vty *vty, uint32_t filter_bm,
 			    uint16_t port_min, uint16_t port_max,
 			    uint8_t proto)
 {
-	if (!(filter_bm & PBR_FILTER_PROTO)) {
+	if (!(filter_bm & PBR_FILTER_IP_PROTOCOL)) {
 		if (port_max)
 			vty_out(vty, ":udp/tcp:%d-%d",
 				port_min, port_max);


### PR DESCRIPTION
This adds vty support for more action fields besides next hop, including setting src and dst ip, source and destination port, DSCP, and ECN. The default kernel does not currently provide this mangling functionality, but other providers such as netfilter and OpenvSwitch may.
This rebases https://github.com/FRRouting/frr/pull/9729 by Eli Baum, which can no longer be updated in situ. 

Signed-off-by: Josh Werner