### PR TITLE
tools: Ignore errors for frr reload stuff

### DIFF
--- a/tools/frrinit.sh.in
+++ b/tools/frrinit.sh.in
@@ -123,7 +123,7 @@ reload)
 	NEW_CONFIG_FILE="${2:-$C_PATH/frr.conf}"
 	[ ! -r $NEW_CONFIG_FILE ] && log_failure_msg "Unable to read new configuration file $NEW_CONFIG_FILE" && exit 1
 	"$RELOAD_SCRIPT" --reload --bindir "$B_PATH" --confdir "$C_PATH" --rundir "$V_PATH" "$NEW_CONFIG_FILE" `echo $nsopt`
-	exit $?
+	exit 0
 	;;
 
 *)


### PR DESCRIPTION
When we pass an unknown/wrong command and do `systemctl reload frr`, all processes are killed, and not started up.

Like doing with frr-reload.py, all good:

```
$ /usr/lib/frr/frr-reload.py --reload /etc/frr/frr.conf
vtysh failed to process new configuration: vtysh (mark file) exited with status 2:
b'line 20: % Unknown command:  neighbor 192.168.10.123 bfd 300 300\n\n'
```

Closes https://github.com/FRRouting/frr/issues/13888