### PR TITLE
ospf6d: unlock lsa

### DIFF
--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -293,8 +293,10 @@ static int ospf6_router_lsa_contains_adj(struct ospf6_area *area,
 			if (lsdesc->type != OSPF6_ROUTER_LSDESC_POINTTOPOINT)
 				continue;
 
-			if (lsdesc->neighbor_router_id == neighbor_router_id)
+			if (lsdesc->neighbor_router_id == neighbor_router_id) {
+				ospf6_lsa_unlock(lsa);
 				return RTR_LSA_ADJ_FOUND;
+			}
 		}
 	}
 
@@ -511,8 +513,10 @@ static bool ospf6_gr_check_adjs(struct ospf6 *ospf6)
 		for (ALL_LSDB_TYPED_ADVRTR(area->lsdb, type, router,
 					   lsa_self)) {
 			found = true;
-			if (!ospf6_gr_check_adjs_lsa(area, lsa_self))
+			if (!ospf6_gr_check_adjs_lsa(area, lsa_self)) {
+				ospf6_lsa_unlock(lsa_self);
 				return false;
+			}
 		}
 		if (!found)
 			return false;

--- a/ospf6d/ospf6_lsdb.c
+++ b/ospf6d/ospf6_lsdb.c
@@ -236,8 +236,10 @@ struct ospf6_lsa *ospf6_find_inter_prefix_lsa(struct ospf6 *ospf6,
 		prefix.prefixlen = prefix_lsa->prefix.prefix_length;
 		ospf6_prefix_in6_addr(&prefix.u.prefix6, prefix_lsa,
 				      &prefix_lsa->prefix);
-		if (prefix_same(p, &prefix))
+		if (prefix_same(p, &prefix)) {
+			ospf6_lsa_unlock(lsa);
 			return lsa;
+		}
 	}
 
 	return NULL;


### PR DESCRIPTION
The function ospf6_router_lsa_contains_adj(), ospf6_gr_check_adjs() and ospf6_find_interf_prefix_lsa() iterate through LSDB and lock each LSA. During testing, it was discovered that the lock count did not reach zero upon termination. The stack trace below indicates the leak. To resolve this issue, it was found that unlocking the LSA before returning from the functions solves the problem. This suggests that there was a missing unlock that caused the lock count to remain nonzero.

```
================================================================= ==22565==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 400 byte(s) in 2 object(s) allocated from:
    #0 0x7fa744ccea37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7fa744867562 in qcalloc ../lib/memory.c:105
    #2 0x555cdbb37506 in ospf6_lsa_alloc ../ospf6d/ospf6_lsa.c:710
    #3 0x555cdbb375d6 in ospf6_lsa_create ../ospf6d/ospf6_lsa.c:725
    #4 0x555cdbaf1008 in ospf6_receive_lsa ../ospf6d/ospf6_flood.c:912
    #5 0x555cdbb48ceb in ospf6_lsupdate_recv ../ospf6d/ospf6_message.c:1621
    #6 0x555cdbb4ac90 in ospf6_read_helper ../ospf6d/ospf6_message.c:1896
    #7 0x555cdbb4aecc in ospf6_receive ../ospf6d/ospf6_message.c:1925
    #8 0x7fa744950c33 in event_call ../lib/event.c:1995
    #9 0x7fa74483b34a in frr_run ../lib/libfrr.c:1213
    #10 0x555cdbacf1eb in main ../ospf6d/ospf6_main.c:250
    #11 0x7fa7443f9d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Objects leaked above:
0x6110000606c0 (200 bytes)
0x611000060940 (200 bytes)

Indirect leak of 80 byte(s) in 2 object(s) allocated from:
    #0 0x7fa744cce867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7fa744867525 in qmalloc ../lib/memory.c:100
    #2 0x555cdbb37520 in ospf6_lsa_alloc ../ospf6d/ospf6_lsa.c:711
    #3 0x555cdbb375d6 in ospf6_lsa_create ../ospf6d/ospf6_lsa.c:725
    #4 0x555cdbaf1008 in ospf6_receive_lsa ../ospf6d/ospf6_flood.c:912
    #5 0x555cdbb48ceb in ospf6_lsupdate_recv ../ospf6d/ospf6_message.c:1621
    #6 0x555cdbb4ac90 in ospf6_read_helper ../ospf6d/ospf6_message.c:1896
    #7 0x555cdbb4aecc in ospf6_receive ../ospf6d/ospf6_message.c:1925
    #8 0x7fa744950c33 in event_call ../lib/event.c:1995
    #9 0x7fa74483b34a in frr_run ../lib/libfrr.c:1213
    #10 0x555cdbacf1eb in main ../ospf6d/ospf6_main.c:250
    #11 0x7fa7443f9d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Objects leaked above:
0x6040000325d0 (40 bytes)
0x604000032650 (40 bytes)

SUMMARY: AddressSanitizer: 480 byte(s) leaked in 4 allocation(s).

=================================================================
==5483==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 2000 byte(s) in 10 object(s) allocated from:
    #0 0x7f2c3faeea37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7f2c3f68a6d9 in qcalloc ../lib/memory.c:105
    #2 0x56431b83633d in ospf6_lsa_alloc ../ospf6d/ospf6_lsa.c:710
    #3 0x56431b83640d in ospf6_lsa_create ../ospf6d/ospf6_lsa.c:725
    #4 0x56431b7efe13 in ospf6_receive_lsa ../ospf6d/ospf6_flood.c:912
    #5 0x56431b847b31 in ospf6_lsupdate_recv ../ospf6d/ospf6_message.c:1621
    #6 0x56431b849ad6 in ospf6_read_helper ../ospf6d/ospf6_message.c:1896
    #7 0x56431b849d12 in ospf6_receive ../ospf6d/ospf6_message.c:1925
    #8 0x7f2c3f773c62 in event_call ../lib/event.c:1995
    #9 0x7f2c3f65e2de in frr_run ../lib/libfrr.c:1213
    #10 0x56431b7cdff6 in main ../ospf6d/ospf6_main.c:221
    #11 0x7f2c3f21dd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Objects leaked above:
0x611000060800 (200 bytes)
0x611000060a80 (200 bytes)
0x611000060d00 (200 bytes)
0x611000060f80 (200 bytes)
0x611000061200 (200 bytes)
0x611000061480 (200 bytes)
0x611000061840 (200 bytes)
0x611000061ac0 (200 bytes)
0x61100006c740 (200 bytes)
0x61100006d500 (200 bytes)

Indirect leak of 460 byte(s) in 10 object(s) allocated from:
    #0 0x7f2c3faee867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f2c3f68a69c in qmalloc ../lib/memory.c:100
    #2 0x56431b836357 in ospf6_lsa_alloc ../ospf6d/ospf6_lsa.c:711
    #3 0x56431b83640d in ospf6_lsa_create ../ospf6d/ospf6_lsa.c:725
    #4 0x56431b7efe13 in ospf6_receive_lsa ../ospf6d/ospf6_flood.c:912
    #5 0x56431b847b31 in ospf6_lsupdate_recv ../ospf6d/ospf6_message.c:1621
    #6 0x56431b849ad6 in ospf6_read_helper ../ospf6d/ospf6_message.c:1896
    #7 0x56431b849d12 in ospf6_receive ../ospf6d/ospf6_message.c:1925
    #8 0x7f2c3f773c62 in event_call ../lib/event.c:1995
    #9 0x7f2c3f65e2de in frr_run ../lib/libfrr.c:1213
    #10 0x56431b7cdff6 in main ../ospf6d/ospf6_main.c:221
    #11 0x7f2c3f21dd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Objects leaked above:
0x604000033110 (40 bytes)
0x604000033190 (40 bytes)
0x604000033210 (44 bytes)
0x604000033290 (44 bytes)
0x604000033310 (44 bytes)
0x604000033390 (44 bytes)
0x604000033410 (44 bytes)
0x604000033490 (44 bytes)
0x604000034c90 (44 bytes)
0x6070000d3830 (72 bytes)

SUMMARY: AddressSanitizer: 2460 byte(s) leaked in 20 allocation(s).
```