### PR TITLE
lib: Add two places we were not counting route-map applied

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -2554,6 +2554,9 @@ route_map_result_t route_map_apply_ext(struct route_map *map,
 	struct prefix conv;
 
 	if (recursion > RMAP_RECURSION_LIMIT) {
+		if (map)
+			map->applied++;
+
 		flog_warn(
 			EC_LIB_RMAP_RECURSION_LIMIT,
 			"route-map recursion limit (%d) reached, discarding route",
@@ -2563,6 +2566,8 @@ route_map_result_t route_map_apply_ext(struct route_map *map,
 	}
 
 	if (map == NULL || map->head == NULL) {
+		if (map)
+			map->applied++;
 		ret = RMAP_DENYMATCH;
 		goto route_map_apply_end;
 	}


### PR DESCRIPTION
There were a couple of places where it was possible a route-map was applied( and DENIED ) but the count for the number of times the application happen was not incremented.