### PR TITLE
ospfd: check for NULLs in ldp-igp sync json code

### DIFF
--- a/ospfd/ospf_ldp_sync.c
+++ b/ospfd/ospf_ldp_sync.c
@@ -637,6 +637,9 @@ static int show_ip_ospf_mpls_ldp_interface_common(struct vty *vty,
 			     rn = route_next(rn)) {
 				oi = rn->info;
 
+				if (oi == NULL)
+					continue;
+
 				if (use_json) {
 					json_interface_sub =
 						json_object_new_object();
@@ -671,6 +674,9 @@ static int show_ip_ospf_mpls_ldp_interface_common(struct vty *vty,
 			for (rn = route_top(IF_OIFS(ifp)); rn;
 			     rn = route_next(rn)) {
 				oi = rn->info;
+
+				if (oi == NULL)
+					continue;
 
 				if (use_json)
 					json_interface_sub =

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -4301,6 +4301,9 @@ static int show_ip_ospf_interface_traffic_common(
 			     rn = route_next(rn)) {
 				oi = rn->info;
 
+				if (oi == NULL)
+					continue;
+
 				if (use_json) {
 					json_interface_sub =
 						json_object_new_object();


### PR DESCRIPTION
There were a couple of cli paths that NULL-checked in the vtysh output path, but not in the json path.
