### PR TITLE
bgpd: fix no set as_path replace command

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -5938,7 +5938,6 @@ DEFPY_YANG(no_set_aspath_replace_asn, no_set_aspath_replace_asn_cmd,
 	   "Replace AS number to local or configured AS number\n"
 	   "Replace any AS number to local or configured AS number\n"
 	   "Replace a specific AS number to local or configured AS number\n"
-	   "Replace AS number with a configured AS number\n"
 	   "Define the configured AS number\n")
 {
 	const char *xpath =


### PR DESCRIPTION
fix to avoid "Excessive docstring" message

sharpd@eva ~/frr (tests_need_to_be_stricter)> sudo /usr/lib/frr/bgpd --log stdout --log-level debug --daemon
2023/06/30 09:47:25 BGP: [K2CCG-5Y7ZJ] Excessive docstring while parsing 'no set as-path replace [<any|ASNUM>]
[<ASNUM>$configured_asn]'
2023/06/30 09:47:25.361807 BGP: [K2CCG-5Y7ZJ] Excessive docstring while parsing 'no set as-path replace [<any|ASNUM>] [<ASNUM>$configured_asn]'
2023/06/30 09:47:25 BGP: [W7ENN-K2SVA] ----------
2023/06/30 09:47:25.361839 BGP: [W7ENN-K2SVA] ---------- 2023/06/30 09:47:25 BGP: [WCW75-6TZPF] Define the configured AS number 2023/06/30 09:47:25.361842 BGP: [WCW75-6TZPF] Define the configured AS number
2023/06/30 09:47:25 BGP: [W7ENN-K2SVA] ----------
2023/06/30 09:47:25.361844 BGP: [W7ENN-K2SVA] ---------- 2023/06/30 09:47:25.382835 BGP: [T83RR-8SM5G] bgpd 9.1-dev starting: vty@2605, bgp@<all>:179