### PR TITLE
ospf6d: Crash backports

### DIFF
--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -2533,7 +2533,8 @@ void ospf6_lsreq_send(struct thread *thread)
 
 	/* schedule loading_done if request list is empty */
 	if (on->request_list->count == 0) {
-		thread_add_event(master, loading_done, on, 0, NULL);
+		thread_add_event(master, loading_done, on, 0,
+				 &on->event_loading_done);
 		return;
 	}
 

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -2576,9 +2576,7 @@ static void ospf6_send_lsupdate(struct ospf6_neighbor *on,
 				struct ospf6_interface *oi,
 				struct ospf6_packet *op)
 {
-
 	if (on) {
-
 		if ((on->ospf6_if->state == OSPF6_INTERFACE_POINTTOPOINT)
 		    || (on->ospf6_if->state == OSPF6_INTERFACE_DR)
 		    || (on->ospf6_if->state == OSPF6_INTERFACE_BDR))
@@ -2595,6 +2593,8 @@ static void ospf6_send_lsupdate(struct ospf6_neighbor *on,
 			op->dst = alldrouters6;
 	}
 	if (oi) {
+		struct ospf6 *ospf6;
+
 		ospf6_fill_hdr_checksum(oi, op);
 		ospf6_packet_add(oi, op);
 		/* If ospf instance is being deleted, send the packet
@@ -2602,12 +2602,27 @@ static void ospf6_send_lsupdate(struct ospf6_neighbor *on,
 		 */
 		if ((oi->area == NULL) || (oi->area->ospf6 == NULL))
 			return;
-		if (oi->area->ospf6->inst_shutdown) {
+
+		ospf6 = oi->area->ospf6;
+		if (ospf6->inst_shutdown) {
 			if (oi->on_write_q == 0) {
-				listnode_add(oi->area->ospf6->oi_write_q, oi);
+				listnode_add(ospf6->oi_write_q, oi);
 				oi->on_write_q = 1;
 			}
-			thread_execute(master, ospf6_write, oi->area->ospf6, 0);
+			/*
+			 * When ospf6d immediately calls event_execute
+			 * for items in the oi_write_q.  The event_execute
+			 * will call ospf6_write and cause the oi_write_q
+			 * to be emptied.  *IF* there is already an event
+			 * scheduled for the oi_write_q by something else
+			 * then when it wakes up in the future and attempts
+			 * to cycle through items in the queue it will
+			 * assert.  Let's stop the t_write event and
+			 * if ospf6_write doesn't finish up the work
+			 * it will schedule itself again.
+			 */
+			thread_cancel(&ospf6->t_write);
+			thread_execute(master, ospf6_write, ospf6, 0);
 		} else
 			OSPF6_MESSAGE_WRITE_ON(oi);
 	}

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -188,6 +188,7 @@ void ospf6_neighbor_delete(struct ospf6_neighbor *on)
 	THREAD_OFF(on->thread_send_lsack);
 	THREAD_OFF(on->thread_exchange_done);
 	THREAD_OFF(on->thread_adj_ok);
+	THREAD_OFF(on->event_loading_done);
 
 	THREAD_OFF(on->gr_helper_info.t_grace_timer);
 
@@ -443,7 +444,8 @@ void ospf6_check_nbr_loading(struct ospf6_neighbor *on)
 	if ((on->state == OSPF6_NEIGHBOR_LOADING)
 	    || (on->state == OSPF6_NEIGHBOR_EXCHANGE)) {
 		if (on->request_list->count == 0)
-			thread_add_event(master, loading_done, on, 0, NULL);
+			thread_add_event(master, loading_done, on, 0,
+					 &on->event_loading_done);
 		else if (on->last_ls_req == NULL) {
 			THREAD_OFF(on->thread_send_lsreq);
 			thread_add_event(master, ospf6_lsreq_send, on, 0,

--- a/ospf6d/ospf6_neighbor.h
+++ b/ospf6d/ospf6_neighbor.h
@@ -138,6 +138,7 @@ struct ospf6_neighbor {
 	struct thread *thread_send_lsack;
 	struct thread *thread_exchange_done;
 	struct thread *thread_adj_ok;
+	struct thread *event_loading_done;
 
 	/* BFD information */
 	struct bfd_session_params *bfd_session;


### PR DESCRIPTION
Manual backports of https://github.com/FRRouting/frr/pull/13908, https://github.com/FRRouting/frr/pull/13911.