### PR TITLE
bgpd: fix bgp evpn cli memory leaks.

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -6973,6 +6973,8 @@ DEFUN(bgp_evpn_ead_es_rt, bgp_evpn_ead_es_rt_cmd,
 	if (!bgp_evpn_rt_matches_existing(bgp_mh_info->ead_es_export_rtl,
 					  ecomadd))
 		bgp_evpn_mh_config_ead_export_rt(bgp, ecomadd, false);
+	else
+		ecommunity_free(&ecomadd);
 
 	return CMD_SUCCESS;
 }
@@ -7010,6 +7012,7 @@ DEFUN(no_bgp_evpn_ead_es_rt, no_bgp_evpn_ead_es_rt_cmd,
 	}
 	bgp_evpn_mh_config_ead_export_rt(bgp, ecomdel, true);
 
+	ecommunity_free(&ecomdel);
 	return CMD_SUCCESS;
 }
 
@@ -7061,6 +7064,8 @@ DEFUN (bgp_evpn_vni_rt,
 		/* Do nothing if we already have this import route-target */
 		if (!bgp_evpn_rt_matches_existing(vpn->import_rtl, ecomadd))
 			evpn_configure_import_rt(bgp, vpn, ecomadd);
+		else
+			ecommunity_free(&ecomadd);
 	}
 
 	/* Add/update the export route-target */
@@ -7077,6 +7082,8 @@ DEFUN (bgp_evpn_vni_rt,
 		/* Do nothing if we already have this export route-target */
 		if (!bgp_evpn_rt_matches_existing(vpn->export_rtl, ecomadd))
 			evpn_configure_export_rt(bgp, vpn, ecomadd);
+		else
+			ecommunity_free(&ecomadd);
 	}
 
 	return CMD_SUCCESS;
@@ -7184,6 +7191,7 @@ DEFUN (no_bgp_evpn_vni_rt,
 		}
 	}
 
+	ecommunity_free(&ecomdel);
 	return CMD_SUCCESS;
 }
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -8587,6 +8587,8 @@ DEFPY (neighbor_soo,
 		ecommunity_free(&peer->soo[afi][safi]);
 		peer->soo[afi][safi] = ecomm_soo;
 		peer_af_flag_unset(peer, afi, safi, PEER_FLAG_SOO);
+	} else {
+		ecommunity_free(&ecomm_soo);
 	}
 
 	return bgp_vty_return(vty,


### PR DESCRIPTION
problem:
In CLI config codeflow there are memory leaks in failure scenario

Fix:
Code changes are done to free ecommunity