### PR TITLE
ospfd: Ensure `show ip ospf interface` json code is guarded

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -424,7 +424,7 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 		}
 		vty_out(vty, "  Advertise-gw-macip : %s\n", "n/a");
 		vty_out(vty, "  Advertise-svi-macip : %s\n", "n/a");
-		if (bgp_vrf && bgp_vrf->evpn_info) {
+		if (bgp_vrf->evpn_info) {
 			vty_out(vty, "  Advertise-pip: %s\n",
 				bgp_vrf->evpn_info->advertise_pip ? "Yes"
 								  : "No");

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3690,7 +3690,8 @@ static void show_ip_ospf_interface_sub(struct vty *vty, struct ospf *ospf,
 			"Use all fields following ospfEnabled from interfaceIp hierarchy")
 #endif
 
-		json_oi = json_object_new_object();
+		if (use_json)
+			json_oi = json_object_new_object();
 
 		if (CHECK_FLAG(oi->connected->flags, ZEBRA_IFA_UNNUMBERED)) {
 			if (use_json) {


### PR DESCRIPTION
When not using json, do not allocate json memory.

Closes https://github.com/FRRouting/frr/issues/13919