### PR TITLE
bgpd: Fix memory leak

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2292,6 +2292,9 @@ static void evpn_configure_vrf_rd(struct bgp *bgp_vrf, struct prefix_rd *rd,
 	 */
 	bgp_evpn_handle_vrf_rd_change(bgp_vrf, 1);
 
+	if (bgp_vrf->vrf_prd_pretty)
+		XFREE(MTYPE_BGP, bgp_vrf->vrf_prd_pretty);
+
 	/* update RD */
 	memcpy(&bgp_vrf->vrf_prd, rd, sizeof(struct prefix_rd));
 	bgp_vrf->vrf_prd_pretty = XSTRDUP(MTYPE_BGP, rd_pretty);


### PR DESCRIPTION
The `bgp_vrf->vrf_prd_pretty` string was not properly freed, leading to a memory leak. This commit resolves the memory leak by freeing the memory allocated for `bgp_vrf->vrf_prd_pretty` before returning from the function.

The ASan leak log for reference:
```
***********************************************************************************
Address Sanitizer Error detected in evpn_type5_test_topo1.test_evpn_type5_topo1/e1.asan.bgpd.17689

=================================================================
==17689==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 15 byte(s) in 1 object(s) allocated from:
    #0 0x7fdd94fc0538 in strdup (/usr/lib/x86_64-linux-gnu/libasan.so.4+0x77538)
    #1 0x55e28d9c4c6c in qstrdup lib/memory.c:117
    #2 0x55e28d6c0d27 in evpn_configure_vrf_rd bgpd/bgp_evpn_vty.c:2297
    #3 0x55e28d6c0d27 in bgp_evpn_vrf_rd bgpd/bgp_evpn_vty.c:6271
    #4 0x55e28d94c155 in cmd_execute_command_real lib/command.c:994
    #5 0x55e28d94c622 in cmd_execute_command lib/command.c:1053
    #6 0x55e28d94ca99 in cmd_execute lib/command.c:1221
    #7 0x55e28da6d7d4 in vty_command lib/vty.c:591
    #8 0x55e28da6dc6e in vty_execute lib/vty.c:1354
    #9 0x55e28da7644d in vtysh_read lib/vty.c:2362
    #10 0x55e28da616e2 in event_call lib/event.c:1995
    #11 0x55e28d9a7a65 in frr_run lib/libfrr.c:1213
    #12 0x55e28d63ef00 in main bgpd/bgp_main.c:505
    #13 0x7fdd93883c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 15 byte(s) leaked in 1 allocation(s).
***********************************************************************************
```