### PR TITLE
pimd,pim6d: Query-interval should be greater than query max response time

### DIFF
--- a/yang/frr-gmp.yang
+++ b/yang/frr-gmp.yang
@@ -107,7 +107,7 @@ module frr-gmp {
         range "1..max";
       }
       units seconds;
-      must ". * 10 >= ../query-max-response-time";
+      must ". * 10 > ../query-max-response-time";
       default "125";
       description
         "The Query Interval is the interval between General Queries


### PR DESCRIPTION
According to RFC 2236 Section 8.3
The number of seconds represented by the [Query Response Interval] must be less than the [Query Interval].

As Maximum Response Delay refers to the maximum time interval within which an IGMP or MLD router should respond to a query message. If both are equal, then both may expire at the same time. 
So Query Interval must be greater than the query max response time.