### PR TITLE
bgpd: Free nexthop in bgp_mplsvpn_nh_label_bind_free

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -4070,6 +4070,10 @@ void bgp_mplsvpn_nh_label_bind_free(
 	}
 	bgp_mplsvpn_nh_label_bind_cache_del(
 		&bmnc->bgp_vpn->mplsvpn_nh_label_bind, bmnc);
+
+	if (bmnc->nh)
+		nexthop_free(bmnc->nh);
+
 	XFREE(MTYPE_MPLSVPN_NH_LABEL_BIND_CACHE, bmnc);
 }
 


### PR DESCRIPTION
`bmnc->nh` was not properly freed, leading to a memory leak. The commit adds a check to ensure that the `bmnc->nh` member variable is freed if it exists.

The ASan leak log for reference:
```
***********************************************************************************
Address Sanitizer Error detected in bgp_vpnv4_asbr.test_bgp_vpnv4_asbr/r2.asan.bgpd.6382

=================================================================
==6382==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 720 byte(s) in 5 object(s) allocated from:
    #0 0x7f6a80d02d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x55c9afd7c81c in qcalloc lib/memory.c:105
    #2 0x55c9afd9166b in nexthop_new lib/nexthop.c:358
    #3 0x55c9afd93aaa in nexthop_dup lib/nexthop.c:843
    #4 0x55c9afad39bb in bgp_mplsvpn_nh_label_bind_register_local_label bgpd/bgp_mplsvpn.c:4259
    #5 0x55c9afb1c5e9 in bgp_mplsvpn_handle_label_allocation bgpd/bgp_route.c:3239
    #6 0x55c9afb1c5e9 in bgp_process_main_one bgpd/bgp_route.c:3339
    #7 0x55c9afb1d2c1 in bgp_process_wq bgpd/bgp_route.c:3591
    #8 0x55c9afe33df9 in work_queue_run lib/workqueue.c:266
    #9 0x55c9afe198e2 in event_call lib/event.c:1995
    #10 0x55c9afd5fc6f in frr_run lib/libfrr.c:1213
    #11 0x55c9af9f6f00 in main bgpd/bgp_main.c:505
    #12 0x7f6a7f55ec86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 16 byte(s) in 2 object(s) allocated from:
    #0 0x7f6a80d02d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x55c9afd7c81c in qcalloc lib/memory.c:105
    #2 0x55c9afd91ce8 in nexthop_add_labels lib/nexthop.c:536
    #3 0x55c9afd93754 in nexthop_copy_no_recurse lib/nexthop.c:802
    #4 0x55c9afd939fb in nexthop_copy lib/nexthop.c:821
    #5 0x55c9afd93abb in nexthop_dup lib/nexthop.c:845
    #6 0x55c9afad39bb in bgp_mplsvpn_nh_label_bind_register_local_label bgpd/bgp_mplsvpn.c:4259
    #7 0x55c9afb1c5e9 in bgp_mplsvpn_handle_label_allocation bgpd/bgp_route.c:3239
    #8 0x55c9afb1c5e9 in bgp_process_main_one bgpd/bgp_route.c:3339
    #9 0x55c9afb1d2c1 in bgp_process_wq bgpd/bgp_route.c:3591
    #10 0x55c9afe33df9 in work_queue_run lib/workqueue.c:266
    #11 0x55c9afe198e2 in event_call lib/event.c:1995
    #12 0x55c9afd5fc6f in frr_run lib/libfrr.c:1213
    #13 0x55c9af9f6f00 in main bgpd/bgp_main.c:505
    #14 0x7f6a7f55ec86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 736 byte(s) leaked in 7 allocation(s).
***********************************************************************************
```