### PR TITLE
redhat: Change libyang dependency to libyang > 2

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -184,7 +184,7 @@ BuildRequires:  make
 BuildRequires:  ncurses-devel
 BuildRequires:  readline-devel
 BuildRequires:  texinfo
-BuildRequires:  libyang2-devel
+BuildRequires:  libyang-devel >= 2
 %if 0%{?rhel} && 0%{?rhel} < 7
 #python27-devel is available from ius community repo for RedHat/CentOS 6
 BuildRequires:  python27-devel


### PR DESCRIPTION
Not using libyang2 anymore to match RedHat name change of the libyang library.
Newer versions of libyang 2.1 use the libyang instead of libyang2 package name.
