### PR TITLE
ospfd: fix lsa leak

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2007,7 +2007,6 @@ static struct ospf_lsa *ospf_lsa_translated_nssa_new(struct ospf *ospf,
 
 	/* add translated flag, checksum and lock new lsa */
 	SET_FLAG(new->flags, OSPF_LSA_LOCAL_XLT); /* Translated from 7  */
-	new = ospf_lsa_lock(new);
 
 	return new;
 }


### PR DESCRIPTION
In the function ```ospf_lsa_translated_nssa_new``` the newly created lsa is lock however, the return lsa from ```ospf_lsa_new``` already has a lock. Therefore removing the addition lock resolve the leak below.
```
ospf_basic_functionality.test_ospf_nssa#r3.asan.ospfd.5456

================================================================= ==5456==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 640 byte(s) in 5 object(s) allocated from:
    #0 0x7f294f354a37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7f294eeed562 in qcalloc ../lib/memory.c:105
    #2 0x561a16004f60 in ospf_lsa_new ../ospfd/ospf_lsa.c:186
    #3 0x561a160051a1 in ospf_lsa_new_and_data ../ospfd/ospf_lsa.c:205
    #4 0x561a1600f21d in ospf_exnl_lsa_prepare_and_flood ../ospfd/ospf_lsa.c:1762
    #5 0x561a1600fd71 in ospf_external_lsa_new ../ospfd/ospf_lsa.c:1863
    #6 0x561a160107d7 in ospf_lsa_translated_nssa_new ../ospfd/ospf_lsa.c:1985
    #7 0x561a16011cfb in ospf_translated_nssa_refresh ../ospfd/ospf_lsa.c:2152
    #8 0x561a16014bb2 in ospf_external_lsa_install ../ospfd/ospf_lsa.c:2871
    #9 0x561a1601596b in ospf_lsa_install ../ospfd/ospf_lsa.c:3076
    #10 0x561a16168b3c in ospf_flood ../ospfd/ospf_flood.c:482
    #11 0x561a160462f8 in ospf_ls_upd ../ospfd/ospf_packet.c:2115
    #12 0x561a1604c66c in ospf_read_helper ../ospfd/ospf_packet.c:3198
    #13 0x561a1604c88e in ospf_read ../ospfd/ospf_packet.c:3229
    #14 0x7f294efd6c33 in event_call ../lib/event.c:1995
    #15 0x7f294eec134a in frr_run ../lib/libfrr.c:1213
    #16 0x561a15fd3b6d in main ../ospfd/ospf_main.c:249
    #17 0x7f294e998d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Objects leaked above:
0x60c000062800 (128 bytes)
0x60c000062c80 (128 bytes)
0x60c0000631c0 (128 bytes)
0x60c000063700 (128 bytes)
0x60c000063d00 (128 bytes)

Direct leak of 640 byte(s) in 5 object(s) allocated from:
    #0 0x7f294f354a37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7f294eeed562 in qcalloc ../lib/memory.c:105
    #2 0x561a16004f60 in ospf_lsa_new ../ospfd/ospf_lsa.c:186
    #3 0x561a160051a1 in ospf_lsa_new_and_data ../ospfd/ospf_lsa.c:205
    #4 0x561a1600f21d in ospf_exnl_lsa_prepare_and_flood ../ospfd/ospf_lsa.c:1762
    #5 0x561a1600fd71 in ospf_external_lsa_new ../ospfd/ospf_lsa.c:1863
    #6 0x561a160107d7 in ospf_lsa_translated_nssa_new ../ospfd/ospf_lsa.c:1985
    #7 0x561a16010e10 in ospf_translated_nssa_originate ../ospfd/ospf_lsa.c:2034
    #8 0x561a16136559 in ospf_abr_translate_nssa ../ospfd/ospf_abr.c:668
    #9 0x561a161383da in ospf_abr_process_nssa_translates ../ospfd/ospf_abr.c:968
    #10 0x561a1613f9b8 in ospf_abr_nssa_task ../ospfd/ospf_abr.c:2054
    #11 0x561a161402e5 in ospf_abr_task_timer ../ospfd/ospf_abr.c:2168
    #12 0x7f294efd6c33 in event_call ../lib/event.c:1995
    #13 0x7f294eec134a in frr_run ../lib/libfrr.c:1213
    #14 0x561a15fd3b6d in main ../ospfd/ospf_main.c:249
    #15 0x7f294e998d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Objects leaked above:
0x60c00003e380 (128 bytes)
0x60c00003e740 (128 bytes)
0x60c00003eb00 (128 bytes)
0x60c00005fd40 (128 bytes)
0x60c00005ff80 (128 bytes)

Indirect leak of 180 byte(s) in 5 object(s) allocated from:
    #0 0x7f294f354a37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7f294eeed562 in qcalloc ../lib/memory.c:105
    #2 0x561a16005a43 in ospf_lsa_data_new ../ospfd/ospf_lsa.c:296
    #3 0x561a160051b1 in ospf_lsa_new_and_data ../ospfd/ospf_lsa.c:206
    #4 0x561a1600f21d in ospf_exnl_lsa_prepare_and_flood ../ospfd/ospf_lsa.c:1762
    #5 0x561a1600fd71 in ospf_external_lsa_new ../ospfd/ospf_lsa.c:1863
    #6 0x561a160107d7 in ospf_lsa_translated_nssa_new ../ospfd/ospf_lsa.c:1985
    #7 0x561a16011cfb in ospf_translated_nssa_refresh ../ospfd/ospf_lsa.c:2152
    #8 0x561a16014bb2 in ospf_external_lsa_install ../ospfd/ospf_lsa.c:2871
    #9 0x561a1601596b in ospf_lsa_install ../ospfd/ospf_lsa.c:3076
    #10 0x561a16168b3c in ospf_flood ../ospfd/ospf_flood.c:482
    #11 0x561a160462f8 in ospf_ls_upd ../ospfd/ospf_packet.c:2115
    #12 0x561a1604c66c in ospf_read_helper ../ospfd/ospf_packet.c:3198
   #13 0x561a1604c88e in ospf_read ../ospfd/ospf_packet.c:3229
    #14 0x7f294efd6c33 in event_call ../lib/event.c:1995
    #15 0x7f294eec134a in frr_run ../lib/libfrr.c:1213
    #16 0x561a15fd3b6d in main ../ospfd/ospf_main.c:249
    #17 0x7f294e998d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Objects leaked above:
0x60400003f890 (36 bytes)
0x60400003f990 (36 bytes)
0x60400003fa50 (36 bytes)
0x60400003fb10 (36 bytes)
0x60400003fbd0 (36 bytes)

Indirect leak of 180 byte(s) in 5 object(s) allocated from:
    #0 0x7f294f354a37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7f294eeed562 in qcalloc ../lib/memory.c:105
    #2 0x561a16005a43 in ospf_lsa_data_new ../ospfd/ospf_lsa.c:296
    #3 0x561a160051b1 in ospf_lsa_new_and_data ../ospfd/ospf_lsa.c:206
    #4 0x561a1600f21d in ospf_exnl_lsa_prepare_and_flood ../ospfd/ospf_lsa.c:1762
    #5 0x561a1600fd71 in ospf_external_lsa_new ../ospfd/ospf_lsa.c:1863
    #6 0x561a160107d7 in ospf_lsa_translated_nssa_new ../ospfd/ospf_lsa.c:1985
    #7 0x561a16010e10 in ospf_translated_nssa_originate ../ospfd/ospf_lsa.c:2034
    #8 0x561a16136559 in ospf_abr_translate_nssa ../ospfd/ospf_abr.c:668
    #9 0x561a161383da in ospf_abr_process_nssa_translates ../ospfd/ospf_abr.c:968
    #10 0x561a1613f9b8 in ospf_abr_nssa_task ../ospfd/ospf_abr.c:2054
    #11 0x561a161402e5 in ospf_abr_task_timer ../ospfd/ospf_abr.c:2168
    #12 0x7f294efd6c33 in event_call ../lib/event.c:1995
    #13 0x7f294eec134a in frr_run ../lib/libfrr.c:1213
    #14 0x561a15fd3b6d in main ../ospfd/ospf_main.c:249
    #15 0x7f294e998d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Objects leaked above:
0x60400003c6d0 (36 bytes)
0x60400003c790 (36 bytes)
0x60400003c810 (36 bytes)
0x60400003c890 (36 bytes)
0x60400003c910 (36 bytes)

SUMMARY: AddressSanitizer: 1640 byte(s) leaked in 20 allocation(s).
```