### PR TITLE
bgpd: add set as-path exclude acl-list command

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -21,6 +21,7 @@
 #include "bgpd/bgp_debug.h"
 #include "bgpd/bgp_attr.h"
 #include "bgpd/bgp_errors.h"
+#include "bgpd/bgp_filter.h"
 
 /* Attr. Flags and Attr. Type Code. */
 #define AS_HEADER_SIZE 2
@@ -1615,6 +1616,92 @@ struct aspath *aspath_filter_exclude_all(struct aspath *source)
 	aspath_free(source);
 	return newpath;
 }
+
+struct aspath *aspath_filter_exclude_acl(struct aspath *source,
+					 struct as_list *acl_list)
+{
+	struct assegment *cur_seg, *new_seg, *prev_seg, *next_seg;
+	struct as_list *cur_as_list;
+	struct as_filter *cur_as_filter;
+	char str_buf[ASPATH_STR_DEFAULT_LEN];
+	uint32_t nb_as_del;
+	uint32_t i, j;
+
+	cur_seg = source->segments;
+	prev_seg = NULL;
+	/* segments from source aspath */
+	while (cur_seg) {
+		next_seg = cur_seg->next;
+		cur_as_list = acl_list;
+		nb_as_del = 0;
+		/* aspath filter list from acl_list */
+		while (cur_as_list) {
+			cur_as_filter = cur_as_list->head;
+			while (cur_as_filter) {
+				for (i = 0; i < cur_seg->length; i++) {
+					if (cur_seg->as[i] == 0)
+						continue;
+
+					snprintfrr(str_buf,
+						   ASPATH_STR_DEFAULT_LEN,
+						   ASN_FORMAT(source->asnotation),
+						   &cur_seg->as[i]);
+					if (!regexec(cur_as_filter->reg,
+						     str_buf, 0, NULL, 0)) {
+						cur_seg->as[i] = 0;
+						nb_as_del++;
+					}
+				}
+
+				cur_as_filter = cur_as_filter->next;
+			}
+
+			cur_as_list = cur_as_list->next;
+		}
+		/* full segment is excluded remove it */
+		if (nb_as_del == cur_seg->length) {
+			if (cur_seg == source->segments)
+				/* first segment */
+				source->segments = cur_seg->next;
+			else
+				prev_seg->next = cur_seg->next;
+			assegment_free(cur_seg);
+		}
+		/* change in segment size -> new allocation and replace segment*/
+		else if (nb_as_del) {
+			new_seg = assegment_new(cur_seg->type,
+						cur_seg->length - nb_as_del);
+			j = 0;
+			for (i = 0; i < cur_seg->length; i++) {
+				if (cur_seg->as[i] == 0)
+					continue;
+				new_seg->as[j] = cur_seg->as[i];
+				j++;
+			}
+			new_seg->next = next_seg;
+			if (cur_seg == source->segments)
+				/* first segment */
+				source->segments = new_seg;
+			else if (prev_seg)
+				prev_seg->next = new_seg;
+			assegment_free(cur_seg);
+		}
+		prev_seg = cur_seg;
+		cur_seg = next_seg;
+	}
+
+
+	aspath_str_update(source, false);
+	/* We are happy returning even an empty AS_PATH, because the
+	 * administrator
+	 * might expect this very behaviour. There's a mean to avoid this, if
+	 * necessary,
+	 * by having a match rule against certain AS_PATH regexps in the
+	 * route-map index.
+	 */
+	return source;
+}
+
 
 /* Add specified AS to the leftmost of aspath. */
 static struct aspath *aspath_add_asns(struct aspath *aspath, as_t asno,

--- a/bgpd/bgp_aspath.h
+++ b/bgpd/bgp_aspath.h
@@ -8,6 +8,7 @@
 
 #include "lib/json.h"
 #include "bgpd/bgp_route.h"
+#include "bgpd/bgp_filter.h"
 
 /* AS path segment type.  */
 #define AS_SET                       1
@@ -77,6 +78,8 @@ extern struct aspath *aspath_prepend(struct aspath *as1, struct aspath *as2);
 extern struct aspath *aspath_filter_exclude(struct aspath *source,
 					    struct aspath *exclude_list);
 extern struct aspath *aspath_filter_exclude_all(struct aspath *source);
+extern struct aspath *aspath_filter_exclude_acl(struct aspath *source,
+						struct as_list *acl_list);
 extern struct aspath *aspath_add_seq_n(struct aspath *aspath, as_t asno,
 				       unsigned num);
 extern struct aspath *aspath_add_seq(struct aspath *aspath, as_t asno);

--- a/bgpd/bgp_filter.c
+++ b/bgpd/bgp_filter.c
@@ -15,7 +15,6 @@
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_aspath.h"
 #include "bgpd/bgp_regex.h"
-#include "bgpd/bgp_filter.h"
 
 /* List of AS filter list. */
 struct as_list_list {
@@ -35,30 +34,6 @@ struct as_list_master {
 	void (*delete_hook)(const char *);
 };
 
-/* Element of AS path filter. */
-struct as_filter {
-	struct as_filter *next;
-	struct as_filter *prev;
-
-	enum as_filter_type type;
-
-	regex_t *reg;
-	char *reg_str;
-
-	/* Sequence number. */
-	int64_t seq;
-};
-
-/* AS path filter list. */
-struct as_list {
-	char *name;
-
-	struct as_list *next;
-	struct as_list *prev;
-
-	struct as_filter *head;
-	struct as_filter *tail;
-};
 
 
 /* Calculate new sequential number. */
@@ -220,7 +195,6 @@ struct as_list *as_list_lookup(const char *name)
 	for (aslist = as_list_master.str.head; aslist; aslist = aslist->next)
 		if (strcmp(aslist->name, name) == 0)
 			return aslist;
-
 	return NULL;
 }
 

--- a/bgpd/bgp_filter.h
+++ b/bgpd/bgp_filter.h
@@ -10,6 +10,33 @@
 
 enum as_filter_type { AS_FILTER_DENY, AS_FILTER_PERMIT };
 
+
+/* Element of AS path filter. */
+struct as_filter {
+	struct as_filter *next;
+	struct as_filter *prev;
+
+	enum as_filter_type type;
+
+	regex_t *reg;
+	char *reg_str;
+
+	/* Sequence number. */
+	int64_t seq;
+};
+
+/* AS path filter list. */
+struct as_list {
+	char *name;
+
+	struct as_list *next;
+	struct as_list *prev;
+
+	struct as_filter *head;
+	struct as_filter *tail;
+};
+
+
 extern void bgp_filter_init(void);
 extern void bgp_filter_reset(void);
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2138,6 +2138,13 @@ Using AS Path in Route Map
    Remove all AS numbers from the AS_PATH of the BGP path's NLRI. The no form of
    this command removes this set operation from the route-map.
 
+.. clicmd:: set as-path exclude as-path-access-list WORD
+
+   Remove some AS numbers from the AS_PATH of the BGP path's NLRI. Removed AS
+   numbers are conformant with the regex defined in as-path access-list  WORD.
+   The no form of this command removes this set operation from the route-map.
+   
+   
 .. _bgp-communities-attribute:
 
 Communities Attribute


### PR DESCRIPTION

A route-map applied on incoming BGP updates is not able
to exclude the unwanted as segments, based on an AS path
access-list.

The below configuration illustrates the case:

router bgp 65001

 address-family ipv4 unicast
  neighbor 192.168.1.2 route-map rule_2 in
 exit-address-family

bgp as-path access-list RULE permit ^65

route-map rule_2 permit 10
 set as-path exclude as-path-access-list RULE

```
BGP routing table entry for 10.10.10.10/32, version 13
Paths: (1 available, best https://github.com/FRRouting/frr/pull/1, table default)
  Advertised to non peer-group peers:
  192.168.10.65
  65000 1 2 3 123
    192.168.10.65 from 192.168.10.65 (10.10.10.11)
      Origin IGP, metric 0, valid, external, best (First path received)
      Last update: Mon Apr 25 10:39:50 2022
```

After:

```
do show ip bgp 10.10.10.10/32
BGP routing table entry for 10.10.10.10/32, version 15
Paths: (1 available, best https://github.com/FRRouting/frr/pull/1, table default)
  Advertised to non peer-group peers:
  192.168.10.65
  2 3 123
    192.168.10.65 from 192.168.10.65 (10.10.10.11)
      Origin IGP, metric 0, valid, external, best (First path received)
      Last update: Mon Apr 25 10:40:16 2022
```

Signed-off-by: Francois Dumontet <francois.dumontet@6wind.com>