### PR TITLE
zebra: fix link-params not written in show running-config

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -4853,17 +4853,14 @@ static int ag_iter_cb(const struct lyd_node *dnode, void *arg)
 void cli_show_legacy_admin_group(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults)
 {
-	if (!yang_dnode_exists(dnode, "./legacy-admin-group"))
-		return;
-
 	vty_out(vty, "  admin-group 0x%x\n",
-		yang_dnode_get_uint32(dnode, "./legacy-admin-group"));
+		yang_dnode_get_uint32(dnode, NULL));
 }
 
 void cli_show_affinity_mode(struct vty *vty, const struct lyd_node *dnode,
 			    bool show_defaults)
 {
-	enum affinity_mode affinity_mode = yang_dnode_get_enum(dnode, ".");
+	enum affinity_mode affinity_mode = yang_dnode_get_enum(dnode, NULL);
 
 	if (affinity_mode == AFFINITY_MODE_STANDARD)
 		vty_out(vty, "  affinity-mode standard\n");


### PR DESCRIPTION
Some link-params are not displayed in "show running-config". The leafs have their own cli_show handler, so it is not needed to pass the leaf name as parameter to get the value.