### PR TITLE
tools: fix ospf area stub summary in frr-reload

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1577,10 +1577,30 @@ def compare_context_objects(newconf, running):
     pcclist_to_del = []
     candidates_to_add = []
     delete_bgpd = False
+    area_stub_no_sum = "area (\S+) stub no-summary"
 
     # Find contexts that are in newconf but not in running
     # Find contexts that are in running but not in newconf
     for (running_ctx_keys, running_ctx) in iteritems(running.contexts):
+
+        if running_ctx_keys in newconf.contexts:
+            newconf_ctx = newconf.contexts[running_ctx_keys]
+
+            for line in running_ctx.lines:
+                # ospf area <> stub no-summary line removal requires
+                # to remoe area <> stub as no form of original
+                # retains the stub form.
+                # lines_to_del will contain:
+                #   no area <x> stub no-summary and
+                #   no area <x> stub
+                if (
+                    running_ctx_keys[0].startswith("router ospf")
+                    and line not in newconf_ctx.dlines
+                ):
+                    re_area_stub_no_sum = re.search(area_stub_no_sum, line)
+                    if re_area_stub_no_sum:
+                        new_del_line = "area %s stub" % re_area_stub_no_sum.group(1)
+                        lines_to_del.append((running_ctx_keys, new_del_line))
 
         if running_ctx_keys not in newconf.contexts:
 


### PR DESCRIPTION
OSPFv2 no area x stub no-summary only resets
'no-summary' config. From frr-reload if the config line 'area x stub no-summary' is removed then
it needs to remove completely. Before this change
it took two frr-roload to remove the config which is inconsistent behavior.
Fix is to frr-reload to add extra line to delete
'no area x stub'.


Testing Done:

Running config:

```
router ospf
 ospf router-id 6.6.6.6
 area 0.0.0.1 stub no-summary
 area 0.0.0.2 stub
exit
!
router ospf vrf sym_1
 area 0.0.1.1 range 24.1.1.0/24
 area 0.0.1.2 stub no-summary
exit
```

changed frr.conf:
```
router ospf
 ospf router-id 6.6.6.6
 area 0.0.0.2 stub
exit
!
router ospf vrf sym_1
 area 0.0.1.1 range 24.1.1.0/24
exit
```
frr-reload action:
```
Lines To Delete
===============
router ospf
 no area 0.0.0.1 stub  <<<< newly added
router ospf vrf sym_1
 no area 0.0.1.2 stub  <<<< newly added
router ospf
 no area 0.0.0.1 stub no-summary
router ospf vrf sym_1
 no area 0.0.1.2 stub no-summary
```

After fix new running-config post reload:
```
router ospf
 ospf router-id 6.6.6.6
 area 0.0.0.2 stub
exit
!
router ospf vrf sym_1
 area 0.0.1.1 range 24.1.1.0/24
exit
```

Before fix running-config post 1st reload:

```
router ospf
 ospf router-id 6.6.6.6
 area 0.0.0.1 stub
 area 0.0.0.2 stub
exit
!
router ospf vrf sym_1
 area 0.0.1.1 range 24.1.1.0/24
 area 0.0.1.2 stub
exit
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>