### PR TITLE
zebra: fix mpls config on ifaces created post frr

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -610,6 +610,11 @@ void if_add_update(struct interface *ifp)
 
 		if_addr_wakeup(ifp);
 
+		if (if_data->mpls_config == IF_ZEBRA_DATA_ON)
+			dplane_intf_mpls_modify_state(ifp, true);
+		else if (if_data->mpls_config == IF_ZEBRA_DATA_OFF)
+			dplane_intf_mpls_modify_state(ifp, false);
+
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug(
 				"interface %s vrf %s(%u) index %d becomes active.",


### PR DESCRIPTION
The mpls configuration does not work when an interface is created after having applied the frr configuration. The below scenario illustrates:

> root@dut:~# modprobe mpls
> root@dut:~# zebra &
> [..]
> dut(config)# interface ifacenotcreated
> dut(config-if)# mpls enable
> dut(config-if)# Ctrl-D
> root@dut:~# ip li show ifacenotcreated
> Device "ifacenotcreated" does not exist.
> root@dut:~# ip li add ifacenotcreated type dummy
> 0

Fix this by forcing the mpls flag when the interface is detected.

> root@dut:~# cat /proc/sys/net/mpls/conf/ifacenotcreated/input
> 1