### PR TITLE
tests: fix BGP delayopen timer expiration test

### DIFF
--- a/tests/topotests/bgp_features/test_bgp_features.py
+++ b/tests/topotests/bgp_features/test_bgp_features.py
@@ -1063,7 +1063,7 @@ def test_bgp_delayopen_dual():
 
     delay_stop = int(time.time())
     assertmsg = "BGP peering between r2 and r5 was established before DelayOpenTimer (30sec) on r2 could expire"
-    assert (delay_stop - delay_start) > 30, assertmsg
+    assert (delay_stop - delay_start) >= 30, assertmsg
 
     # 3.8 unset delayopen on R2 and R5
     logger.info("Disabling DelayOpenTimer for neighbor r5 on r2")


### PR DESCRIPTION
The changes allow the test to correctly pass in case the connection between two peers is be established in less than 0.5 seconds after the delayopen timer expires.

This fixes false negatives occurring during tests run on performant platforms (i.e. https://ci1.netdef.org/browse/FRR-PULLREQ2-TOPO3DEB10AMD64-12668/test/case/109021523)