### PR TITLE
bgpd: Fix table manager to use the synchronous client

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1085,7 +1085,7 @@ static void bgp_zebra_tm_connect(struct event *t)
 		}
 		bgp_tm_status_connected = true;
 		if (!bgp_tm_chunk_obtained) {
-			if (bgp_zebra_get_table_range(bgp_tm_chunk_size,
+			if (bgp_zebra_get_table_range(zclient, bgp_tm_chunk_size,
 						      &bgp_tm_min,
 						      &bgp_tm_max) >= 0) {
 				bgp_tm_chunk_obtained = true;
@@ -1129,14 +1129,14 @@ void bgp_zebra_init_tm_connect(struct bgp *bgp)
 			&bgp_tm_thread_connect);
 }
 
-int bgp_zebra_get_table_range(uint32_t chunk_size,
+int bgp_zebra_get_table_range(struct zclient *zc, uint32_t chunk_size,
 			      uint32_t *start, uint32_t *end)
 {
 	int ret;
 
 	if (!bgp_tm_status_connected)
 		return -1;
-	ret = tm_get_table_chunk(zclient, chunk_size, start, end);
+	ret = tm_get_table_chunk(zc, chunk_size, start, end);
 	if (ret < 0) {
 		flog_err(EC_BGP_TABLE_CHUNK,
 			 "BGP: Error getting table chunk %u", chunk_size);

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -24,7 +24,7 @@ extern void bgp_zebra_init_tm_connect(struct bgp *bgp);
 extern uint32_t bgp_zebra_tm_get_id(void);
 extern bool bgp_zebra_tm_chunk_obtained(void);
 extern void bgp_zebra_destroy(void);
-extern int bgp_zebra_get_table_range(uint32_t chunk_size,
+extern int bgp_zebra_get_table_range(struct zclient *zc, uint32_t chunk_size,
 				     uint32_t *start, uint32_t *end);
 extern int bgp_if_update_all(void);
 extern void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,


### PR DESCRIPTION
bgp_zebra_tm_connect calls bgp_zebra_get_table_range which just used the global zclient.  Which of course still had us exposing the global zclient to read and drop important data from zebra.  This fixes commit 787c61e03c760ffdb422bfc44c72d83fb451e0c8