### PR TITLE
isisd: replace gmtime with gmtime_r

### DIFF
--- a/isisd/isis_misc.c
+++ b/isisd/isis_misc.c
@@ -474,20 +474,20 @@ void log_multiline(int priority, const char *prefix, const char *format, ...)
 
 char *log_uptime(time_t uptime, char *buf, size_t nbuf)
 {
-	struct tm *tm;
+	struct tm tm;
 	time_t difftime = time(NULL);
 	difftime -= uptime;
-	tm = gmtime(&difftime);
+	gmtime_r(&difftime, &tm);
 
 	if (difftime < ONE_DAY_SECOND)
-		snprintf(buf, nbuf, "%02d:%02d:%02d", tm->tm_hour, tm->tm_min,
-			 tm->tm_sec);
+		snprintf(buf, nbuf, "%02d:%02d:%02d", tm.tm_hour, tm.tm_min,
+			 tm.tm_sec);
 	else if (difftime < ONE_WEEK_SECOND)
-		snprintf(buf, nbuf, "%dd%02dh%02dm", tm->tm_yday, tm->tm_hour,
-			 tm->tm_min);
+		snprintf(buf, nbuf, "%dd%02dh%02dm", tm.tm_yday, tm.tm_hour,
+			 tm.tm_min);
 	else
-		snprintf(buf, nbuf, "%02dw%dd%02dh", tm->tm_yday / 7,
-			 tm->tm_yday - ((tm->tm_yday / 7) * 7), tm->tm_hour);
+		snprintf(buf, nbuf, "%02dw%dd%02dh", tm.tm_yday / 7,
+			 tm.tm_yday - ((tm.tm_yday / 7) * 7), tm.tm_hour);
 
 	return buf;
 }


### PR DESCRIPTION
No gmtime() allowed, not thread-safe, use gmtime_r().
