### PR TITLE
zebra: adjust one debug info

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -256,12 +256,11 @@ void redistribute_delete(const struct route_node *rn,
 			table = new_re->table;
 		}
 
-		zlog_debug(
-			"%u:%u%pRN: Redist del: re %p (%u:%s), new re %p (%u:%s)",
-			vrfid, table, rn, old_re, old_inst,
-			old_re ? zebra_route_string(old_re->type) : "None",
-			new_re, new_inst,
-			new_re ? zebra_route_string(new_re->type) : "None");
+		zlog_debug("(%u:%u):%pRN: Redist del: re %p (%u:%s), new re %p (%u:%s)",
+			   vrfid, table, rn, old_re, old_inst,
+			   old_re ? zebra_route_string(old_re->type) : "None",
+			   new_re, new_inst,
+			   new_re ? zebra_route_string(new_re->type) : "None");
 	}
 
 	/* Skip invalid (e.g. linklocal) prefix */


### PR DESCRIPTION
zebra: adjust one debug info                                                                                                                                                 
                                                                                    
Adjust one debug info, separate the ip address from it. Just like it is processed
in `redistribute_update()`.                                                         
                                                                                    
Before:                                                                             
```                                                                                 
34:1375.75.75.75/32: Redist del: re 0x55c1112067e0 (0:static), new re 0x55c1112de7c0 (0:static)
```                                                                                 
                                                                                    
After:                                                                              
```                                                                                 
(34:13):75.75.75.75/32: Redist del: re 0x55c1112067e0 (0:static), new re 0x55c1112de7c0 (0:static)