### PR TITLE
mgmtd: adjust one unnecessary bool convert

### DIFF
--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -1160,8 +1160,7 @@ int mgmt_fe_send_set_cfg_reply(uint64_t session_id, uint64_t txn_id,
 	}
 
 	return fe_adapter_send_set_cfg_reply(session, ds_id, req_id,
-					     result == MGMTD_SUCCESS ? true
-								     : false,
+					     result == MGMTD_SUCCESS,
 					     error_if_any, implicit_commit);
 }
 

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -1380,8 +1380,7 @@ static int mgmt_txn_send_be_cfg_data(struct mgmt_txn_ctx *txn,
 					     batch->batch_id,
 					     cfg_req.cfgdata_reqs,
 					     cfg_req.num_reqs,
-					     indx == num_batches ? true
-								 : false)) {
+					     indx == num_batches)) {
 			(void)mgmt_txn_send_commit_cfg_reply(
 				txn, MGMTD_INTERNAL_ERROR,
 				"Internal Error! Could not send config data to backend!");


### PR DESCRIPTION
mgmtd: adjust one unnecessary bool convert
    
It is unnecessary to do the bool calculation for expression