### PR TITLE
bgpd: Fix memory leak by moving allocation of json object

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13836,10 +13836,10 @@ static int bgp_table_stats_single(struct vty *vty, struct bgp *bgp, afi_t afi,
 		json_bitlen = json_object_new_array();
 
 		for (i = 0; i <= bitlen; i++) {
-			struct json_object *ind_bit = json_object_new_object();
-
 			if (!ts.prefix_len_count[i])
 				continue;
+
+			struct json_object *ind_bit = json_object_new_object();
 
 			snprintf(temp_buf, sizeof(temp_buf), "%u", i);
 			json_object_int_add(ind_bit, temp_buf,


### PR DESCRIPTION
Fixes #13982. Currently the function `bgp_table_stats_single` leaks memory because the `json_object` won't get freed in the if condition. I moved the allocation after the if and Valgrind does not report a memory leak anymore.