### PR TITLE
bgpd: Free temporary memory after using argv_concat()

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -8795,7 +8795,7 @@ DEFPY(neighbor_path_attribute_discard,
 {
 	struct peer *peer;
 	int idx = 0;
-	const char *discard_attrs = NULL;
+	char *discard_attrs = NULL;
 
 	peer = peer_and_group_lookup_vty(vty, neighbor);
 	if (!peer)
@@ -8806,6 +8806,8 @@ DEFPY(neighbor_path_attribute_discard,
 		discard_attrs = argv_concat(argv, argc, idx);
 
 	bgp_path_attribute_discard_vty(vty, peer, discard_attrs, true);
+
+	XFREE(MTYPE_TMP, discard_attrs);
 
 	return CMD_SUCCESS;
 }
@@ -8822,7 +8824,7 @@ DEFPY(no_neighbor_path_attribute_discard,
 {
 	struct peer *peer;
 	int idx = 0;
-	const char *discard_attrs = NULL;
+	char *discard_attrs = NULL;
 
 	peer = peer_and_group_lookup_vty(vty, neighbor);
 	if (!peer)
@@ -8833,6 +8835,8 @@ DEFPY(no_neighbor_path_attribute_discard,
 		discard_attrs = argv[idx]->arg;
 
 	bgp_path_attribute_discard_vty(vty, peer, discard_attrs, false);
+
+	XFREE(MTYPE_TMP, discard_attrs);
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
Closes https://github.com/FRRouting/frr/issues/13988