### PR TITLE
test_grpc.cpp Fix Compilation Error and RuntimePath for finding grpc.so

### DIFF
--- a/tests/lib/test_grpc.cpp
+++ b/tests/lib/test_grpc.cpp
@@ -34,8 +34,8 @@
 #include <grpcpp/security/credentials.h>
 #include "grpc/frr-northbound.grpc.pb.h"
 
-DEFINE_HOOK(frr_late_init, (struct event_loop * tm), (tm));
-DEFINE_KOOH(frr_fini, (), ());
+DEFINE_HOOK(test_grpc_late_init, (struct event_loop * tm), (tm));
+DEFINE_KOOH(test_grpc_fini, (), ());
 
 struct vty *vty;
 
@@ -85,7 +85,7 @@ static void static_startup(void)
 	zprivs_init(&static_privs);
 
 	/* Load the server side module -- check libtool path first */
-	std::string modpath = std::string(binpath) + std::string("../../../lib/.libs");
+	std::string modpath = std::string(binpath) + std::string("../../lib/.libs");
 	grpc_module = frrmod_load("grpc:50051", modpath.c_str(), 0, 0);
 	if (!grpc_module) {
 		modpath = std::string(binpath) +  std::string("../../lib");
@@ -127,12 +127,12 @@ static void static_startup(void)
 	frr_pthread_init();
 
 	// frr_config_fork();
-	hook_call(frr_late_init, master);
+	hook_call(test_grpc_late_init, master);
 }
 
 static void static_shutdown(void)
 {
-	hook_call(frr_fini);
+	hook_call(test_grpc_fini);
 	vty_close(vty);
 	vrf_terminate();
 	vty_terminate();


### PR DESCRIPTION

was trying to build test_grpc.cpp for validating some grpc operations and found that it was not compiling in the latest master, on ubuntu 22.04 .

```
Compilation Error:

  CCLD     tests/lib/cli/test_commands
/usr/bin/ld: lib/.libs/libfrr.a(libfrr.o):/root/frr/frr-vanilla/lib/libfrr.c:37: multiple definition of `_hook_frr_late_init'; tests/lib/test_grpc-test_grpc.o:(.data.rel.local+0x0): first defined here
/usr/bin/ld: lib/.libs/libfrr.a(libfrr.o):/root/frr/frr-vanilla/lib/libfrr.c:41: multiple definition of `_hook_frr_fini'; tests/lib/test_grpc-test_grpc.o:(.data.rel.local+0x20): first defined here
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:8929: tests/lib/test_grpc] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/root/frr/frr-vanilla'
```
After fixing the Compilation Error: We then see a runtime error.

```
root@linux-eve:~/frr/frr-vanilla/tests/lib# ./test_grpc
Failed to load grpc module:loader error: dlopen(/root/frr/frr-vanilla/tests/lib/./../../lib/grpc.so): /root/frr/frr-vanilla/tests/lib/./../../lib/grpc.so: cannot open shared object file: No such file or directory
Failed to load grpc module:loader error: dlopen(grpc): grpc: cannot open shared object file: No such file or directory
```

I have made the below patch and have been able to run the test_grpc successfully.