### PR TITLE
pimd: Cleaning up IGMP/MLD static joins when gm interface is deleted

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1806,6 +1806,9 @@ void pim_gm_interface_delete(struct interface *ifp)
 
 	pim_if_membership_clear(ifp);
 
+	/* Delete the IGMP/MLD Static joins */
+	pim_if_gm_join_del_all(ifp);
+
 #if PIM_IPV == 4
 	igmp_sock_delete_all(ifp);
 #else


### PR DESCRIPTION
Cleaning up IGMP/MLD static joins when gm interface is deleted.

Signed-off-by: Abhishek N R <abnr@vmware.com>