### PR TITLE
* : include event ptr in event_execute api

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13502,7 +13502,7 @@ static int bgp_table_stats_single(struct vty *vty, struct bgp *bgp, afi_t afi,
 
 	memset(&ts, 0, sizeof(ts));
 	ts.table = bgp->rib[afi][safi];
-	event_execute(bm->master, bgp_table_stats_walker, &ts, 0);
+	event_execute(bm->master, bgp_table_stats_walker, &ts, 0, NULL);
 
 	for (i = 0; i < BGP_STATS_MAX; i++) {
 		if ((!json && !table_stats_strs[i][TABLE_STATS_IDX_VTY])
@@ -13859,7 +13859,7 @@ static int bgp_peer_counts(struct vty *vty, struct peer *peer, afi_t afi,
 	 * stats for the thread-walk (i.e. ensure this can't be blamed on
 	 * on just vty_read()).
 	 */
-	event_execute(bm->master, bgp_peer_count_walker, &pcounts, 0);
+	event_execute(bm->master, bgp_peer_count_walker, &pcounts, 0, NULL);
 
 	if (use_json) {
 		json_object_string_add(json, "prefixCountsFor", peer->host);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7588,7 +7588,7 @@ DEFUN (bgp_set_route_map_delay_timer,
 		if (!rmap_delay_timer && bm->t_rmap_update) {
 			EVENT_OFF(bm->t_rmap_update);
 			event_execute(bm->master, bgp_route_map_update_timer,
-				      NULL, 0);
+				      NULL, 0, NULL);
 		}
 		return CMD_SUCCESS;
 	} else {

--- a/eigrpd/eigrp_hello.c
+++ b/eigrpd/eigrp_hello.c
@@ -772,7 +772,7 @@ void eigrp_hello_send(struct eigrp_interface *ei, uint8_t flags,
 		if (ei->eigrp->t_write == NULL) {
 			if (flags & EIGRP_HELLO_GRACEFUL_SHUTDOWN) {
 				event_execute(master, eigrp_write, ei->eigrp,
-					      ei->eigrp->fd);
+					      ei->eigrp->fd, NULL);
 			} else {
 				event_add_write(master, eigrp_write, ei->eigrp,
 						ei->eigrp->fd,

--- a/eigrpd/eigrp_update.c
+++ b/eigrpd/eigrp_update.c
@@ -913,7 +913,7 @@ void eigrp_update_send_GR_thread(struct event *thread)
 
 	/* if it wasn't last chunk, schedule this thread again */
 	if (nbr->nbr_gr_packet_type != EIGRP_PACKET_PART_LAST) {
-		event_execute(master, eigrp_update_send_GR_thread, nbr, 0);
+		event_execute(master, eigrp_update_send_GR_thread, nbr, 0, NULL);
 	}
 }
 
@@ -979,7 +979,7 @@ void eigrp_update_send_GR(struct eigrp_neighbor *nbr, enum GR_type gr_type,
 	/* indicate, that this is first GR Update packet chunk */
 	nbr->nbr_gr_packet_type = EIGRP_PACKET_PART_FIRST;
 	/* execute packet sending in thread */
-	event_execute(master, eigrp_update_send_GR_thread, nbr, 0);
+	event_execute(master, eigrp_update_send_GR_thread, nbr, 0, NULL);
 }
 
 /**

--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -541,7 +541,7 @@ static void _bfd_sess_remove(struct bfd_session_params *bsp)
 
 	/* Send request to remove any session. */
 	bsp->lastev = BSE_UNINSTALL;
-	event_execute(bsglobal.tm, _bfd_sess_send, bsp, 0);
+	event_execute(bsglobal.tm, _bfd_sess_send, bsp, 0, NULL);
 }
 
 void bfd_sess_free(struct bfd_session_params **bsp)
@@ -894,7 +894,7 @@ int zclient_bfd_session_replay(ZAPI_CALLBACK_ARGS)
 
 		/* Ask for installation. */
 		bsp->lastev = BSE_INSTALL;
-		event_execute(bsglobal.tm, _bfd_sess_send, bsp, 0);
+		event_execute(bsglobal.tm, _bfd_sess_send, bsp, 0, NULL);
 	}
 
 	return 0;

--- a/lib/event.c
+++ b/lib/event.c
@@ -1491,9 +1491,9 @@ void event_cancel(struct event **thread)
 		cr->thread = *thread;
 		listnode_add(master->cancel_req, cr);
 		do_event_cancel(master);
-	}
 
-	*thread = NULL;
+		*thread = NULL;
+	}
 }
 
 /**
@@ -2066,9 +2066,14 @@ void event_call(struct event *thread)
 
 /* Execute thread */
 void _event_execute(const struct xref_eventsched *xref, struct event_loop *m,
-		    void (*func)(struct event *), void *arg, int val)
+		    void (*func)(struct event *), void *arg, int val,
+		    struct event **eref)
 {
 	struct event *thread;
+
+	/* Cancel existing scheduled task TODO -- nice to do in 1 lock cycle */
+	if (eref)
+		event_cancel(eref);
 
 	/* Get or allocate new thread to execute. */
 	frr_with_mutex (&m->mtx) {

--- a/lib/frrevent.h
+++ b/lib/frrevent.h
@@ -195,7 +195,7 @@ struct cpu_event_history {
 	_xref_t_a(timer_tv, TIMER, m, f, a, v, t)
 #define event_add_event(m, f, a, v, t) _xref_t_a(event, EVENT, m, f, a, v, t)
 
-#define event_execute(m, f, a, v)                                              \
+#define event_execute(m, f, a, v, p)                                           \
 	({                                                                     \
 		static const struct xref_eventsched _xref __attribute__(       \
 			(used)) = {                                            \
@@ -205,7 +205,7 @@ struct cpu_event_history {
 			.event_type = EVENT_EXECUTE,                           \
 		};                                                             \
 		XREF_LINK(_xref.xref);                                         \
-		_event_execute(&_xref, m, f, a, v);                            \
+		_event_execute(&_xref, m, f, a, v, p);                         \
 	}) /* end */
 
 /* Prototypes. */
@@ -241,7 +241,8 @@ extern void _event_add_event(const struct xref_eventsched *xref,
 
 extern void _event_execute(const struct xref_eventsched *xref,
 			   struct event_loop *master,
-			   void (*fn)(struct event *), void *arg, int val);
+			   void (*fn)(struct event *), void *arg, int val,
+			   struct event **eref);
 
 extern void event_cancel(struct event **event);
 extern void event_cancel_async(struct event_loop *m, struct event **eptr,

--- a/lib/wheel.c
+++ b/lib/wheel.c
@@ -57,7 +57,7 @@ static void wheel_timer_thread(struct event *t)
 
 	wheel = EVENT_ARG(t);
 
-	event_execute(wheel->master, wheel_timer_thread_helper, wheel, 0);
+	event_execute(wheel->master, wheel_timer_thread_helper, wheel, 0, NULL);
 }
 
 struct timer_wheel *wheel_init(struct event_loop *master, int period,

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -309,7 +309,7 @@ void ospf6_interface_disable(struct ospf6_interface *oi)
 {
 	SET_FLAG(oi->flag, OSPF6_INTERFACE_DISABLE);
 
-	event_execute(master, interface_down, oi, 0);
+	event_execute(master, interface_down, oi, 0, NULL);
 
 	ospf6_lsdb_remove_all(oi->lsdb);
 	ospf6_lsdb_remove_all(oi->lsdb_self);
@@ -387,9 +387,9 @@ void ospf6_interface_state_update(struct interface *ifp)
 	if (if_is_operative(ifp)
 	    && (ospf6_interface_get_linklocal_address(oi->interface)
 		|| if_is_loopback(oi->interface)))
-		event_execute(master, interface_up, oi, 0);
+		event_execute(master, interface_up, oi, 0, NULL);
 	else
-		event_execute(master, interface_down, oi, 0);
+		event_execute(master, interface_down, oi, 0, NULL);
 
 	return;
 }
@@ -2584,8 +2584,8 @@ DEFUN (ipv6_ospf6_network,
 	}
 
 	/* Reset the interface */
-	event_execute(master, interface_down, oi, 0);
-	event_execute(master, interface_up, oi, 0);
+	event_execute(master, interface_down, oi, 0, NULL);
+	event_execute(master, interface_up, oi, 0, NULL);
 
 	return CMD_SUCCESS;
 }
@@ -2620,8 +2620,8 @@ DEFUN (no_ipv6_ospf6_network,
 	oi->type = type;
 
 	/* Reset the interface */
-	event_execute(master, interface_down, oi, 0);
-	event_execute(master, interface_up, oi, 0);
+	event_execute(master, interface_down, oi, 0, NULL);
+	event_execute(master, interface_up, oi, 0, NULL);
 
 	return CMD_SUCCESS;
 }
@@ -2844,8 +2844,8 @@ void ospf6_interface_clear(struct interface *ifp)
 		zlog_debug("Interface %s: clear by reset", ifp->name);
 
 	/* Reset the interface */
-	event_execute(master, interface_down, oi, 0);
-	event_execute(master, interface_up, oi, 0);
+	event_execute(master, interface_down, oi, 0, NULL);
+	event_execute(master, interface_up, oi, 0, NULL);
 }
 
 /* Clear interface */

--- a/ospf6d/ospf6_intra.h
+++ b/ospf6d/ospf6_intra.h
@@ -181,20 +181,21 @@ struct ospf6_intra_prefix_lsa {
 	do {                                                                   \
 		if (CHECK_FLAG((oa)->flag, OSPF6_AREA_ENABLE))                 \
 			event_execute(master, ospf6_router_lsa_originate, oa,  \
-				      0);                                      \
+				      0, NULL);                                \
 	} while (0)
 
 #define OSPF6_NETWORK_LSA_EXECUTE(oi)                                          \
 	do {                                                                   \
 		EVENT_OFF((oi)->thread_network_lsa);                           \
-		event_execute(master, ospf6_network_lsa_originate, oi, 0);     \
+		event_execute(master, ospf6_network_lsa_originate, oi, 0,      \
+			      NULL);                                           \
 	} while (0)
 
 #define OSPF6_LINK_LSA_EXECUTE(oi)                                             \
 	do {                                                                   \
 		if (!CHECK_FLAG((oi)->flag, OSPF6_INTERFACE_DISABLE))          \
 			event_execute(master, ospf6_link_lsa_originate, oi,    \
-				      0);                                      \
+				      0, NULL);                                \
 	} while (0)
 
 #define OSPF6_INTRA_PREFIX_LSA_EXECUTE_TRANSIT(oi)                             \
@@ -202,13 +203,13 @@ struct ospf6_intra_prefix_lsa {
 		EVENT_OFF((oi)->thread_intra_prefix_lsa);                      \
 		event_execute(master,                                          \
 			      ospf6_intra_prefix_lsa_originate_transit, oi,    \
-			      0);                                              \
+			      0, NULL);                                        \
 	} while (0)
 
 #define OSPF6_AS_EXTERN_LSA_EXECUTE(oi)                                        \
 	do {                                                                   \
 		EVENT_OFF((oi)->thread_as_extern_lsa);                         \
-		event_execute(master, ospf6_orig_as_external_lsa, oi, 0);      \
+		event_execute(master, ospf6_orig_as_external_lsa, oi, 0, NULL);\
 	} while (0)
 
 /* Function Prototypes */

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -333,7 +333,7 @@ void ospf6_lsa_premature_aging(struct ospf6_lsa *lsa)
 	ospf6_flood_clear(lsa);
 
 	lsa->header->age = htons(OSPF_LSA_MAXAGE);
-	event_execute(master, ospf6_lsa_expire, lsa, 0);
+	event_execute(master, ospf6_lsa_expire, lsa, 0, NULL);
 }
 
 /* check which is more recent. if a is more recent, return -1;

--- a/ospf6d/ospf6_lsdb.c
+++ b/ospf6d/ospf6_lsdb.c
@@ -398,7 +398,7 @@ int ospf6_lsdb_maxage_remover(struct ospf6_lsdb *lsdb)
 			ospf6_lsa_checksum(lsa->header);
 
 			EVENT_OFF(lsa->refresh);
-			event_execute(master, ospf6_lsa_refresh, lsa, 0);
+			event_execute(master, ospf6_lsa_refresh, lsa, 0, NULL);
 		} else {
 			zlog_debug("calling ospf6_lsdb_remove %s", lsa->name);
 			ospf6_lsdb_remove(lsa, lsdb);

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -535,9 +535,9 @@ static void ospf6_hello_recv(struct in6_addr *src, struct in6_addr *dst,
 	oi->hello_in++;
 
 	/* Execute neighbor events */
-	event_execute(master, hello_received, on, 0);
+	event_execute(master, hello_received, on, 0, NULL);
 	if (twoway)
-		event_execute(master, twoway_received, on, 0);
+		event_execute(master, twoway_received, on, 0, NULL);
 	else {
 		if (OSPF6_GR_IS_ACTIVE_HELPER(on)) {
 			if (IS_DEBUG_OSPF6_GR)
@@ -553,7 +553,7 @@ static void ospf6_hello_recv(struct in6_addr *src, struct in6_addr *dst,
 			 * receives one_way hellow when it acts as HELPER for
 			 * that specific neighbor.
 			 */
-			event_execute(master, oneway_received, on, 0);
+			event_execute(master, oneway_received, on, 0, NULL);
 		}
 	}
 
@@ -624,7 +624,7 @@ static void ospf6_dbdesc_recv_master(struct ospf6_header *oh,
 		return;
 
 	case OSPF6_NEIGHBOR_INIT:
-		event_execute(master, twoway_received, on, 0);
+		event_execute(master, twoway_received, on, 0, NULL);
 		if (on->state != OSPF6_NEIGHBOR_EXSTART) {
 			if (IS_OSPF6_DEBUG_MESSAGE(oh->type, RECV_HDR))
 				zlog_debug(
@@ -640,7 +640,7 @@ static void ospf6_dbdesc_recv_master(struct ospf6_header *oh,
 		    && !CHECK_FLAG(dbdesc->bits, OSPF6_DBDESC_IBIT)
 		    && ntohl(dbdesc->seqnum) == on->dbdesc_seqnum) {
 			/* execute NegotiationDone */
-			event_execute(master, negotiation_done, on, 0);
+			event_execute(master, negotiation_done, on, 0, NULL);
 
 			/* Record neighbor options */
 			memcpy(on->options, dbdesc->options,
@@ -828,7 +828,7 @@ static void ospf6_dbdesc_recv_slave(struct ospf6_header *oh,
 		return;
 
 	case OSPF6_NEIGHBOR_INIT:
-		event_execute(master, twoway_received, on, 0);
+		event_execute(master, twoway_received, on, 0, NULL);
 		if (on->state != OSPF6_NEIGHBOR_EXSTART) {
 			if (IS_OSPF6_DEBUG_MESSAGE(oh->type, RECV_HDR))
 				zlog_debug(
@@ -855,7 +855,7 @@ static void ospf6_dbdesc_recv_slave(struct ospf6_header *oh,
 			on->dbdesc_seqnum = ntohl(dbdesc->seqnum);
 
 			/* schedule NegotiationDone */
-			event_execute(master, negotiation_done, on, 0);
+			event_execute(master, negotiation_done, on, 0, NULL);
 
 			/* Record neighbor options */
 			memcpy(on->options, dbdesc->options,
@@ -2436,7 +2436,7 @@ void ospf6_dbdesc_send_newone(struct event *thread)
 		event_add_event(master, exchange_done, on, 0,
 				&on->thread_exchange_done);
 
-	event_execute(master, ospf6_dbdesc_send, on, 0);
+	event_execute(master, ospf6_dbdesc_send, on, 0, NULL);
 }
 
 static uint16_t ospf6_make_lsreq(struct ospf6_neighbor *on, struct stream *s)
@@ -2623,7 +2623,7 @@ static void ospf6_send_lsupdate(struct ospf6_neighbor *on,
 			 * it will schedule itself again.
 			 */
 			event_cancel(&ospf6->t_write);
-			event_execute(master, ospf6_write, ospf6, 0);
+			event_execute(master, ospf6_write, ospf6, 0, NULL);
 		} else
 			OSPF6_MESSAGE_WRITE_ON(oi);
 	}

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -1436,7 +1436,7 @@ DEFPY (no_area_nssa_range,
 		SET_FLAG(range->flag, OSPF6_ROUTE_REMOVE);
 
 		/* Redo summaries if required */
-		event_execute(master, ospf6_abr_task_timer, ospf6, 0);
+		event_execute(master, ospf6_abr_task_timer, ospf6, 0, NULL);
 	}
 
 	ospf6_route_remove(range, oa->nssa_range_table);

--- a/ospfd/ospf_ism.h
+++ b/ospfd/ospf_ism.h
@@ -69,7 +69,7 @@
 
 /* Macro for OSPF execute event. */
 #define OSPF_ISM_EVENT_EXECUTE(I, E)                                           \
-	event_execute(master, ospf_ism_event, (I), (E))
+	event_execute(master, ospf_ism_event, (I), (E), NULL)
 
 /* Prototypes. */
 extern void ospf_ism_event(struct event *thread);

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -3780,7 +3780,7 @@ void ospf_flush_self_originated_lsas_now(struct ospf *ospf)
 	 */
 	if (ospf->t_maxage != NULL) {
 		EVENT_OFF(ospf->t_maxage);
-		event_execute(master, ospf_maxage_lsa_remover, ospf, 0);
+		event_execute(master, ospf_maxage_lsa_remover, ospf, 0, NULL);
 	}
 
 	return;

--- a/ospfd/ospf_nsm.h
+++ b/ospfd/ospf_nsm.h
@@ -49,7 +49,7 @@
 
 /* Macro for OSPF NSM execute event. */
 #define OSPF_NSM_EVENT_EXECUTE(N, E)                                           \
-	event_execute(master, ospf_nsm_event, (N), (E))
+	event_execute(master, ospf_nsm_event, (N), (E), NULL)
 
 /* Prototypes. */
 extern void ospf_nsm_event(struct event *e);

--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -1367,7 +1367,7 @@ static void gm_bump_querier(struct gm_if *gm_ifp)
 
 	gm_ifp->n_startup = gm_ifp->cur_qrv;
 
-	event_execute(router->master, gm_t_query, gm_ifp, 0);
+	event_execute(router->master, gm_t_query, gm_ifp, 0, NULL);
 }
 
 static void gm_t_other_querier(struct event *t)
@@ -1380,7 +1380,7 @@ static void gm_t_other_querier(struct event *t)
 	gm_ifp->querier = pim_ifp->ll_lowest;
 	gm_ifp->n_startup = gm_ifp->cur_qrv;
 
-	event_execute(router->master, gm_t_query, gm_ifp, 0);
+	event_execute(router->master, gm_t_query, gm_ifp, 0, NULL);
 }
 
 static void gm_handle_query(struct gm_if *gm_ifp,
@@ -2267,7 +2267,7 @@ static void gm_update_ll(struct interface *ifp)
 		return;
 
 	gm_ifp->n_startup = gm_ifp->cur_qrv;
-	event_execute(router->master, gm_t_query, gm_ifp, 0);
+	event_execute(router->master, gm_t_query, gm_ifp, 0, NULL);
 }
 
 void gm_ifp_update(struct interface *ifp)

--- a/tests/lib/test_segv.c
+++ b/tests/lib/test_segv.c
@@ -61,7 +61,7 @@ int main(void)
 
 	zlog_aux_init("NONE: ", LOG_DEBUG);
 
-	event_execute(master, threadfunc, 0, 0);
+	event_execute(master, threadfunc, 0, 0, NULL);
 
 	exit(0);
 }

--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -80,13 +80,12 @@ void zebra_gr_stale_client_cleanup(struct list *client_list)
 			/* Cancel the stale timer */
 			if (info->t_stale_removal != NULL) {
 				EVENT_OFF(info->t_stale_removal);
-				info->t_stale_removal = NULL;
 				info->do_delete = true;
 				/* Process the stale routes */
 				event_execute(
 					zrouter.master,
 					zebra_gr_route_stale_delete_timer_expiry,
-					info, 0);
+					info, 0, NULL);
 			}
 		}
 	}


### PR DESCRIPTION
This is a proposal to include an event ptr-to-ptr in the event_execute() api call, like the various schedule api calls. This would allow the execute() api to cancel an existing scheduled task if that task is being executed inline. If there's agreement that this is a reasonable change, I'll continue implementing the 'cancel' code (and add a test).
At this point, I'm not proposing examining all of the code paths that use 'execute' - other than to add the argument and compile. I'd like to make the lib change first, and then over time we can review the various daemons' use of the apis and decide what changes to make.