### PR TITLE
bgpd: Do not try to redistribute routes if we are shutting down

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8800,6 +8800,10 @@ void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 	route_map_result_t ret;
 	struct bgp_redist *red;
 
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS) ||
+	    bgp->peer_self == NULL)
+		return;
+
 	/* Make default attribute. */
 	bgp_attr_default_set(&attr, bgp, BGP_ORIGIN_INCOMPLETE);
 	/*


### PR DESCRIPTION
When switching `router bgp`, `no router bgp` and doing redistributions, we should ignore this action, otherwise memory leak happens:

```
Indirect leak of 400 byte(s) in 2 object(s) allocated from:
    0 0x7f81b36b3a06 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:153
    1 0x7f81b327bd2e in qcalloc lib/memory.c:105
    2 0x55f301d28628 in bgp_node_create bgpd/bgp_table.c:92
    3 0x7f81b3309d0b in route_node_new lib/table.c:52
    4 0x7f81b3309d0b in route_node_set lib/table.c:61
    5 0x7f81b330be0a in route_node_get lib/table.c:319
    6 0x55f301ce89df in bgp_redistribute_add bgpd/bgp_route.c:8907
    7 0x55f301dac182 in zebra_read_route bgpd/bgp_zebra.c:593
    8 0x7f81b334dcd7 in zclient_read lib/zclient.c:4179
    9 0x7f81b331d702 in event_call lib/event.c:1995
    10 0x7f81b325d597 in frr_run lib/libfrr.c:1213
    11 0x55f301b94b12 in main bgpd/bgp_main.c:505
    12 0x7f81b2b57082 in __libc_start_main ../csu/libc-start.c:308
```
Closes https://github.com/FRRouting/frr/issues/13984