### PR TITLE
bgp: add set BGP extended community for deletion command

### DIFF
--- a/bgpd/bgp_clist.h
+++ b/bgpd/bgp_clist.h
@@ -163,6 +163,9 @@ community_list_match_delete(struct community *com, struct community_list *list);
 extern struct lcommunity *
 lcommunity_list_match_delete(struct lcommunity *lcom,
 			     struct community_list *list);
+extern struct ecommunity *
+ecommunity_list_match_delete(struct ecommunity *ecom,
+			     struct community_list *list);
 
 static inline uint32_t bgp_clist_hash_key(char *name)
 {

--- a/bgpd/bgp_routemap_nb_config.c
+++ b/bgpd/bgp_routemap_nb_config.c
@@ -2835,6 +2835,8 @@ int lib_route_map_entry_set_action_rmap_set_action_comm_list_name_modify(
 				"../../frr-route-map:action");
 		if (IS_SET_COMM_LIST_DEL(action))
 			rhc->rhc_rule = "comm-list";
+		else if (IS_SET_EXTCOMM_LIST_DEL(action))
+			rhc->rhc_rule = "extended-comm-list";
 		else
 			rhc->rhc_rule = "large-comm-list";
 

--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -335,6 +335,10 @@ Route Map Set Command
 
    Set the BGP community attribute.
 
+.. clicmd:: set extended-comm-list <EXTCOMMUNITY_LIST_NAME> delete
+
+   Set BGP extended community list for deletion.
+
 .. clicmd:: set ipv6 next-hop local IPV6_ADDRESS
 
    Set the BGP-4+ link local IPv6 nexthop address.

--- a/lib/command.h
+++ b/lib/command.h
@@ -416,6 +416,10 @@ struct cmd_node {
 #define COMMUNITY_AANN_STR "Community number where AA and NN are (0-65535)\n"
 #define COMMUNITY_VAL_STR                                                      \
 	"Community number in AA:NN format (where AA and NN are (0-65535)) or local-AS|no-advertise|no-export|internet|graceful-shutdown|accept-own-nexthop|accept-own|route-filter-translated-v4|route-filter-v4|route-filter-translated-v6|route-filter-v6|llgr-stale|no-llgr|blackhole|no-peer or additive\n"
+#define EXTCOMM_LIST_CMD_STR "<(1-99)|(100-500)|EXTCOMMUNITY_LIST_NAME>"
+#define EXTCOMM_STD_LIST_NUM_STR "Extended community-list number (standard)\n"
+#define EXTCOMM_EXP_LIST_NUM_STR "Extended community-list number (expanded)\n"
+#define EXTCOMM_LIST_NAME_STR "Extended community-list name\n"
 #define MPLS_TE_STR "MPLS-TE specific commands\n"
 #define LINK_PARAMS_STR "Configure interface link parameters\n"
 #define OSPF_RI_STR "OSPF Router Information specific commands\n"

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -348,6 +348,8 @@ DECLARE_QOBJ_TYPE(route_map);
 	(strmatch(A, "frr-bgp-route-map:comm-list-delete"))
 #define IS_SET_LCOMM_LIST_DEL(A)                                               \
 	(strmatch(A, "frr-bgp-route-map:large-comm-list-delete"))
+#define IS_SET_EXTCOMM_LIST_DEL(A)                                                \
+	(strmatch(A, "frr-bgp-route-map:extended-comm-list-delete"))
 #define IS_SET_LCOMMUNITY(A)                                                   \
 	(strmatch(A, "frr-bgp-route-map:set-large-community"))
 #define IS_SET_COMMUNITY(A)                                                    \

--- a/lib/routemap_cli.c
+++ b/lib/routemap_cli.c
@@ -1186,6 +1186,16 @@ void route_map_action_show(struct vty *vty, const struct lyd_node *dnode,
 		assert(acl);
 
 		vty_out(vty, " set large-comm-list %s delete\n", acl);
+	} else if (IS_SET_EXTCOMM_LIST_DEL(action)) {
+		acl = NULL;
+		ln = yang_dnode_get(dnode, "./rmap-set-action/frr-bgp-route-map:comm-list-name");
+
+		if (ln)
+			acl = yang_dnode_get_string(ln, NULL);
+
+		assert(acl);
+
+		vty_out(vty, " set extended-comm-list %s delete\n", acl);
 	} else if (IS_SET_LCOMMUNITY(action)) {
 		if (yang_dnode_exists(
 			    dnode,

--- a/tests/topotests/bgp_extcomm_list_delete/r1/bgpd.conf
+++ b/tests/topotests/bgp_extcomm_list_delete/r1/bgpd.conf
@@ -1,0 +1,20 @@
+router bgp 65000
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  neighbor 192.168.255.2 remote-as 65001
+  address-family ipv4 unicast
+    network 10.10.10.1/32 route-map r2-out-rt
+    network 10.10.10.2/32 route-map r2-out-soo
+    network 10.10.10.3/32 route-map r2-out-nt
+    redistribute connected
+  exit-address-family
+!
+route-map r2-out-rt permit 10
+ set extcommunity rt 1.1.1.1:1 2.2.2.2:2 3.3.3.3:3 4.4.4.4:4
+!
+route-map r2-out-soo permit 20
+ set extcommunity soo 1.1.1.1:1 2.2.2.2:2 3.3.3.3:3 4.4.4.4:4
+!
+route-map r2-out-nt permit 30
+ set extcommunity nt 192.168.255.2:0 2.2.2.2:0 3.3.3.3:0 4.4.4.4:0
+!

--- a/tests/topotests/bgp_extcomm_list_delete/r1/zebra.conf
+++ b/tests/topotests/bgp_extcomm_list_delete/r1/zebra.conf
@@ -1,0 +1,6 @@
+!
+interface r1-eth0
+ ip address 192.168.255.1/24
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_extcomm_list_delete/r2/bgpd.conf
+++ b/tests/topotests/bgp_extcomm_list_delete/r2/bgpd.conf
@@ -1,0 +1,10 @@
+router bgp 65001
+  no bgp ebgp-requires-policy
+  neighbor 192.168.255.1 remote-as 65000
+  neighbor 192.168.255.1 timers 3 10
+  address-family ipv4
+    neighbor 192.168.255.1 route-map r1-in in
+  exit-address-family
+!
+route-map r1-in permit 10
+!

--- a/tests/topotests/bgp_extcomm_list_delete/r2/zebra.conf
+++ b/tests/topotests/bgp_extcomm_list_delete/r2/zebra.conf
@@ -1,0 +1,6 @@
+!
+interface r2-eth0
+ ip address 192.168.255.2/24
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_extcomm_list_delete/test_bgp_extcomm-list_delete.py
+++ b/tests/topotests/bgp_extcomm_list_delete/test_bgp_extcomm-list_delete.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# Copyright 2023 6WIND S.A.
+# Authored by Farid Mihoub <farid.mihoub@6wind.com>
+#
+
+"""
+bgp_extcomm_list-delete.py:
+
+Test the following commands:
+route-map test permit 10
+  set extended-comm-list <arg> delete
+"""
+
+import functools
+import json
+import os
+import pytest
+import re
+import sys
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from lib import topotest
+
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def build_topo(tgen):
+    for routern in range(1, 3):
+        tgen.add_router("r{}".format(routern))
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for i, (rname, router) in enumerate(router_list.items(), 1):
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP, os.path.join(CWD, "{}/bgpd.conf".format(rname))
+        )
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_convergence():
+    tgen = get_topogen()
+    r2 = tgen.gears["r2"]
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _bgp_converge():
+        output = json.loads(r2.vtysh_cmd("show ip bgp neighbor 192.168.255.1 json"))
+        expected = {
+            "192.168.255.1": {
+                "bgpState": "Established",
+                "addressFamilyInfo": {
+                    "ipv4Unicast": {
+                        "acceptedPrefixCounter": 4,
+                    }
+                },
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_converge)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Can't converge initially"
+
+
+def _set_extcomm_list(gear, ecom_t, ecom):
+    "Set the extended community for deletion."
+    cmd = [
+        "con t\n",
+        f"bgp extcommunity-list standard r1-{ecom_t} permit {ecom_t} {ecom}\n",
+        f"route-map r1-in permit 10\n",
+        f"set extended-comm-list r1-{ecom_t} delete\n",
+    ]
+    gear.vtysh_cmd("".join(cmd))
+
+
+def _bgp_extcomm_list_del_check(gear, prefix, ecom):
+    """
+    Check the non-presense of the extended community for the given prefix.
+    """
+    # get the extended community list attribute for the given prefix
+    output = json.loads(gear.vtysh_cmd(f"show ip bgp {prefix} json"))
+    ecoms = output.get("paths", [])[0].get("extendedCommunity", {})
+    ecoms = ecoms.get("string")
+
+    # ecoms might be None at the first time
+    if not ecoms:
+        return False
+    return re.search(ecom, ecoms) is None
+
+
+def test_rt_extcomm_list_delete():
+    tgen = get_topogen()
+    r2 = tgen.gears["r2"]
+
+    # set the extended community for deletion
+    _set_extcomm_list(r2, "rt", "1.1.1.1:1")
+
+    # check for the deletion of the extended community
+    test_func = functools.partial(
+            _bgp_extcomm_list_del_check, r2, "10.10.10.1/32", r"1.1.1.1:1")
+    _, result = topotest.run_and_expect(test_func, True, count=60, wait=0.5)
+    assert result, "RT extended community 1.1.1.1:1 was not stripped."
+
+
+def test_soo_extcomm_list_delete():
+    tgen = get_topogen()
+    r2 = tgen.gears["r2"]
+
+    # set the extended community for deletion
+    _set_extcomm_list(r2, "soo", "2.2.2.2:2")
+
+    # check for the deletion of the extended community
+    test_func = functools.partial(
+            _bgp_extcomm_list_del_check, r2, "10.10.10.2/32", r"2.2.2.2:2")
+    _, result = topotest.run_and_expect(test_func, True, count=60, wait=0.5)
+    assert result, "SoO extended community 2.2.2.2:2 was not stripped."
+
+
+def test_nt_extcomm_list_delete():
+    tgen = get_topogen()
+    r2 = tgen.gears["r2"]
+
+    # set the extended community for deletion
+    _set_extcomm_list(r2, "nt", "3.3.3.3:0")
+
+    # check for the deletion of the extended community
+    test_func = functools.partial(
+            _bgp_extcomm_list_del_check, r2, "10.10.10.3/32", r"3.3.3.3")
+    _, result = topotest.run_and_expect(test_func, True, count=60, wait=0.5)
+    assert result, "NT extended community 3.3.3.3:0 was not stripped."
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-bgp-route-map.yang
+++ b/yang/frr-bgp-route-map.yang
@@ -352,6 +352,12 @@ identity set-extcommunity-color {
       "Set BGP large community list (for deletion)";
   }
 
+  identity extended-comm-list-delete {
+    base frr-route-map:rmap-set-type;
+    description
+      "Set BGP extended community list (for deletion)";
+  }
+
   identity set-evpn-gateway-ip-ipv4 {
     base frr-route-map:rmap-set-type;
     description
@@ -1109,7 +1115,9 @@ identity set-extcommunity-color {
 
     case comm-list-name {
       when "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:set-action/frr-route-map:action, 'frr-bgp-route-map:comm-list-delete') or "
-        + "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:set-action/frr-route-map:action, 'frr-bgp-route-map:large-comm-list-delete')";
+        + "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:set-action/frr-route-map:action, 'frr-bgp-route-map:large-comm-list-delete') or "
+        + "derived-from-or-self(/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:set-action/frr-route-map:action,
+'frr-bgp-route-map:extended-comm-list-delete')";
       leaf comm-list-name {
         type bgp-filter:bgp-list-name;
       }


### PR DESCRIPTION
Add a **"set extended-comm-list <EXTCOMM_LIST_NAME> delete"** command to **strip** BGP extended communities.