### PR TITLE
ospfd: fix default-metric change if external LSAs already sent

### DIFF
--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -265,17 +265,17 @@ void ospf_asbr_status_update(struct ospf *ospf, uint8_t status)
 }
 
 /* If there's redistribution configured, we need to refresh external
- * LSAs in order to install Type-7 and flood to all NSSA Areas
+ * LSAs (e.g. when default-metric changes or NSSA settings change).
  */
-static void ospf_asbr_nssa_redist_update_timer(struct event *thread)
+static void ospf_asbr_redist_update_timer(struct event *thread)
 {
 	struct ospf *ospf = EVENT_ARG(thread);
 	int type;
 
-	ospf->t_asbr_nssa_redist_update = NULL;
+	ospf->t_asbr_redist_update = NULL;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("Running ASBR NSSA redistribution update on timer");
+		zlog_debug("Running ASBR redistribution update on timer");
 
 	for (type = 0; type < ZEBRA_ROUTE_MAX; type++) {
 		struct list *red_list;
@@ -295,14 +295,14 @@ static void ospf_asbr_nssa_redist_update_timer(struct event *thread)
 	ospf_external_lsa_refresh_default(ospf);
 }
 
-void ospf_schedule_asbr_nssa_redist_update(struct ospf *ospf)
+void ospf_schedule_asbr_redist_update(struct ospf *ospf)
 {
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("Scheduling ASBR NSSA redistribution update");
+		zlog_debug("Scheduling ASBR redistribution update");
 
-	event_add_timer(master, ospf_asbr_nssa_redist_update_timer, ospf,
-			OSPF_ASBR_NSSA_REDIST_UPDATE_DELAY,
-			&ospf->t_asbr_nssa_redist_update);
+	event_add_timer(master, ospf_asbr_redist_update_timer, ospf,
+			OSPF_ASBR_REDIST_UPDATE_DELAY,
+			&ospf->t_asbr_redist_update);
 }
 
 void ospf_redistribute_withdraw(struct ospf *ospf, uint8_t type,

--- a/ospfd/ospf_asbr.h
+++ b/ospfd/ospf_asbr.h
@@ -95,7 +95,7 @@ struct ospf_external_aggr_rt {
 };
 
 #define OSPF_ASBR_CHECK_DELAY 30
-#define OSPF_ASBR_NSSA_REDIST_UPDATE_DELAY 9
+#define OSPF_ASBR_REDIST_UPDATE_DELAY 9
 
 extern void ospf_external_route_remove(struct ospf *, struct prefix_ipv4 *);
 extern struct external_info *ospf_external_info_new(struct ospf *, uint8_t,
@@ -113,7 +113,7 @@ extern struct external_info *ospf_external_info_lookup(struct ospf *, uint8_t,
 						       unsigned short,
 						       struct prefix_ipv4 *);
 extern void ospf_asbr_status_update(struct ospf *, uint8_t);
-extern void ospf_schedule_asbr_nssa_redist_update(struct ospf *ospf);
+extern void ospf_schedule_asbr_redist_update(struct ospf *ospf);
 
 extern void ospf_redistribute_withdraw(struct ospf *, uint8_t, unsigned short);
 extern void ospf_asbr_check(void);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -1529,7 +1529,7 @@ DEFPY (ospf_area_nssa,
 	/* Flush the external LSA for the specified area */
 	ospf_flush_lsa_from_area(ospf, area_id, OSPF_AS_EXTERNAL_LSA);
 	ospf_schedule_abr_task(ospf);
-	ospf_schedule_asbr_nssa_redist_update(ospf);
+	ospf_schedule_asbr_redist_update(ospf);
 
 	return CMD_SUCCESS;
 }
@@ -9619,6 +9619,8 @@ DEFUN (ospf_default_metric,
 
 	ospf->default_metric = metric;
 
+	ospf_schedule_asbr_redist_update(ospf);
+
 	return CMD_SUCCESS;
 }
 
@@ -9632,6 +9634,8 @@ DEFUN (no_ospf_default_metric,
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 
 	ospf->default_metric = -1;
+
+	ospf_schedule_asbr_redist_update(ospf);
 
 	return CMD_SUCCESS;
 }

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -816,7 +816,7 @@ static void ospf_finish_final(struct ospf *ospf)
 	EVENT_OFF(ospf->t_abr_task);
 	EVENT_OFF(ospf->t_abr_fr);
 	EVENT_OFF(ospf->t_asbr_check);
-	EVENT_OFF(ospf->t_asbr_nssa_redist_update);
+	EVENT_OFF(ospf->t_asbr_redist_update);
 	EVENT_OFF(ospf->t_distribute_update);
 	EVENT_OFF(ospf->t_lsa_refresher);
 	EVENT_OFF(ospf->t_opaque_lsa_self);

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -268,8 +268,8 @@ struct ospf {
 	struct event *t_abr_task;		 /* ABR task timer. */
 	struct event *t_abr_fr;			 /* ABR FR timer. */
 	struct event *t_asbr_check;		 /* ASBR check timer. */
-	struct event *t_asbr_nssa_redist_update; /* ASBR NSSA redistribution
-						     update timer. */
+	struct event *t_asbr_redist_update; /* ASBR redistribution update
+					       timer. */
 	struct event *t_distribute_update; /* Distirbute list update timer. */
 	struct event *t_spf_calc;	   /* SPF calculation timer. */
 	struct event *t_ase_calc;	   /* ASE calculation timer. */


### PR DESCRIPTION
Currently, when redistribution of routes was configured, external LSAs were already advertised to peers, and then default-metric is changed, external LSAs refresh will not occur. In other words, the peers will not receive the refreshed external LSAs with the new metric.

With this fix, changing default-metric will cause external LSAs to be refreshed and flooded.

There is a similar task to refresh external LSAs when NSSA settings are changed. And there is a function that accomplishes it - `ospf_schedule_asbr_nssa_redist_update()`. Since the function does the general work of refreshing external LSAs and is not specific to NSSA settings, the idea is to give it a more general name and call it when default-metric changes in order to fix the problem.