### PR TITLE
tests: Update join state in verify_upstream_iif API

### DIFF
--- a/tests/topotests/lib/pim.py
+++ b/tests/topotests/lib/pim.py
@@ -1132,7 +1132,7 @@ def verify_upstream_iif(
                                     grp_addr,
                                     in_interface,
                                     group_addr_json[src_address]["inboundInterface"],
-                                    joinState,
+                                    "Joined",
                                     group_addr_json[src_address]["joinState"],
                                 )
                             )


### PR DESCRIPTION
When JoinState is not passed to API it is expected to be in Joined state, 
there was a minor bug in API, where it was printing JoinState as None, 
which is default value in API. Updated value to print Joined when 
verification fails.

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>