### PR TITLE
doc: remove BFD label command references

### DIFF
--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -225,12 +225,6 @@ BFD peers and profiles share the same BFD session configuration commands.
 BFD Peer Specific Commands
 --------------------------
 
-.. clicmd:: label WORD
-
-   Labels a peer with the provided word. This word can be referenced
-   later on other daemons to refer to a specific peer.
-
-
 .. clicmd:: profile BFDPROF
 
    Configure peer to use the profile configurations.
@@ -443,7 +437,6 @@ Here is an example of BFD configuration:
 
     bfd
      peer 192.168.0.1
-       label home-peer
        no shutdown
      !
     !
@@ -457,7 +450,7 @@ Here is an example of BFD configuration:
     !
 
 Peers can be identified by its address (use ``multihop`` when you need
-to specify a multi hop peer) or can be specified manually by a label.
+to specify a multi hop peer).
 
 Here are the available peer configurations:
 
@@ -500,7 +493,6 @@ Here are the available peer configurations:
 
     ! configure a peer with every option possible
     peer 192.168.0.4
-     label peer-label
      detect-multiplier 50
      receive-interval 60000
      transmit-interval 3000
@@ -548,7 +540,6 @@ You can inspect the current BFD peer status with the following commands:
                            Echo receive interval: 50ms
 
            peer 192.168.1.1
-                   label: router3-peer
                    ID: 2
                    Remote ID: 2
                    Status: up
@@ -571,7 +562,6 @@ You can inspect the current BFD peer status with the following commands:
    frr# show bfd peer 192.168.1.1
    BFD Peer:
                peer 192.168.1.1
-                   label: router3-peer
                    ID: 2
                    Remote ID: 2
                    Status: up


### PR DESCRIPTION
Fixes #13933 .

`label` command is already gone ( https://github.com/FRRouting/frr/commit/3e4e7405ff2d9373c4e43550fa37c43fd06504d5 ) and now we are going to remove all label references.

---

Further explanation: `label` feature still exists for the control socket, however with new northbound the control socket should be deprecated in favor of gRPC/other yang tools.