### PR TITLE
zebra: Prefixlen is 16-bit, it should use stream_putw

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -776,7 +776,7 @@ enum zclient_send_status zclient_send_rnh(struct zclient *zclient, int command,
 	stream_putc(s, (resolve_via_def) ? 1 : 0);
 	stream_putw(s, safi);
 	stream_putw(s, PREFIX_FAMILY(p));
-	stream_putc(s, p->prefixlen);
+	stream_putw(s, p->prefixlen);
 	switch (PREFIX_FAMILY(p)) {
 	case AF_INET:
 		stream_put_in_addr(s, &p->u.prefix4);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1197,8 +1197,8 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 		STREAM_GETC(s, resolve_via_default);
 		STREAM_GETW(s, safi);
 		STREAM_GETW(s, p.family);
-		STREAM_GETC(s, p.prefixlen);
-		l += 7;
+		STREAM_GETW(s, p.prefixlen);
+		l += 8;
 		if (p.family == AF_INET) {
 			client->v4_nh_watch_add_cnt++;
 			if (p.prefixlen > IPV4_MAX_BITLEN) {
@@ -1284,8 +1284,8 @@ static void zread_rnh_unregister(ZAPI_HANDLER_ARGS)
 
 		STREAM_GETW(s, safi);
 		STREAM_GETW(s, p.family);
-		STREAM_GETC(s, p.prefixlen);
-		l += 7;
+		STREAM_GETW(s, p.prefixlen);
+		l += 8;
 		if (p.family == AF_INET) {
 			client->v4_nh_watch_rem_cnt++;
 			if (p.prefixlen > IPV4_MAX_BITLEN) {


### PR DESCRIPTION
Prefixlen is 16-bit, Stream_putw should be used instead of stream_putc.