### PR TITLE
ospfd: fix changing ABR type between standard and shortcut

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2058,6 +2058,13 @@ DEFUN (ospf_abr_type,
 	if (ospf->abr_type != abr_type) {
 		ospf->abr_type = abr_type;
 		ospf_schedule_abr_task(ospf);
+
+		/* The ABR task might not initiate SPF recalculation if the
+		 * OSPF flags remain the same. And inter-area routes would not
+		 * be added/deleted according to the new ABR type. So this
+		 * needs to be done here too.
+		 */
+		ospf_spf_calculate_schedule(ospf, SPF_FLAG_ABR_STATUS_CHANGE);
 	}
 
 	return CMD_SUCCESS;


### PR DESCRIPTION
Currently, when changing ABR type on a working router from shortcut/standard to cisco/ibm or vice versa, that will lead to LSA Type 1 update, SPF recalculation, and OSPF RIB update. However, when changing ABR type from standard to shortcut or vice versa, OSPF RIB update will not occur. In other words, changing ABR type between standard and shortcut will not result in inter-area routes addition/deletion.

The problem is that changing ABR type between standard and shortcut doesn't cause ABR/ASBR internal flags to update. And if the flags are unchanged, `ospf_check_abr_status()` will not initiate SPF recalculation.

With this fix, when ABR type is changed between standard and shortcut, the command initiates SPF recalculation.