### PR TITLE
pbrd: fix coverity issue in pbr_map_match_vlan_tag

### DIFF
--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -73,7 +73,7 @@ DEFPY(pbr_map_match_vlan_id, pbr_map_match_vlan_id_cmd,
 
 /* clang-format off */
 DEFPY(pbr_map_match_vlan_tag, pbr_map_match_vlan_tag_cmd,
-      "[no] match vlan [<tagged|untagged|untagged-or-zero>$tag_type]",
+      "[no] match vlan ![<tagged|untagged|untagged-or-zero>$tag_type]",
       NO_STR
       "Match the rest of the command\n"
       "Match based on VLAN tagging\n"
@@ -88,6 +88,7 @@ DEFPY(pbr_map_match_vlan_tag, pbr_map_match_vlan_tag_cmd,
 		return CMD_WARNING;
 
 	if (!no) {
+		assert(tag_type);
 		if (strmatch(tag_type, "tagged")) {
 			pbr_set_match_clause_for_vlan(pbrms, 0,
 						      PBR_VLAN_FLAGS_TAGGED);


### PR DESCRIPTION
Should address this issue:

```
*** CID 1566396:  Null pointer dereferences  (FORWARD_NULL)
/pbrd/pbr_vty_clippy.c: 163 in pbr_map_match_vlan_tag()
157     #if 0 /* anything that can fail? */
158             if (_failcnt)
159                     return CMD_WARNING;
160     #endif
161     #endif
162
>>>     CID 1566396:  Null pointer dereferences  (FORWARD_NULL)
>>>     Passing null pointer "tag_type" to "pbr_map_match_vlan_tag_magic",
which dereferences it.
163             return pbr_map_match_vlan_tag_magic(self, vty, argc, argv,
no, tag_type);
164     }
```
