### PR TITLE
zebra: non pretty json format for rib and evpn operational commands

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -962,8 +962,12 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 		}
 	}
 
+	/*
+	 * This is an extremely expensive operation at scale
+	 * and non-pretty reduces memory footprint significantly.
+	 */
 	if (use_json)
-		vty_json(vty, json);
+		vty_json_no_pretty(vty, json);
 }
 
 static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf,

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -3229,7 +3229,11 @@ void zebra_vxlan_print_macs_vni(struct vty *vty, struct zebra_vrf *zvrf,
 
 	if (use_json) {
 		json_object_object_add(json, "macs", json_mac);
-		vty_json(vty, json);
+		/*
+		 * This is an extremely expensive operation at scale
+		 * and non-pretty reduces memory footprint significantly.
+		 */
+		vty_json_no_pretty(vty, json);
 	}
 }
 
@@ -4014,8 +4018,12 @@ void zebra_vxlan_print_vnis_detail(struct vty *vty, struct zebra_vrf *zvrf,
 			       void *))zl3vni_print_hash_detail,
 		     &zes);
 
+	/*
+	 * This is an extremely expensive operation at scale
+	 * and non-pretty reduces memory footprint significantly.
+	 */
 	if (use_json)
-		vty_json(vty, json_array);
+		vty_json_no_pretty(vty, json_array);
 }
 
 /*


### PR DESCRIPTION
1) zebra:non pretty json output for evpn route

Currently, json output of evpn route command are no pretty format.
This is an extremely expensive operation at high VNI scale

EVPN json non-pretty command support added:

    ```
    show evpn mac vni <vni-id> detail json
    show evpn vni detail json
    ```

Currently, json output of show ip route command are no pretty format.
This is an extremely expensive operation at high scale (with high number of routes with many paths).

2) Zebra json non-pretty command support added:

    ```
    show ip route json
    ```

Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>