### PR TITLE
zebra: fix nhe refcnt when frr service goes down

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -3635,7 +3635,18 @@ unsigned long zebra_nhg_score_proto(int type)
 		 * This should be the last ref if we remove client routes too,
 		 * and thus should remove and free them.
 		 */
-		zebra_nhg_decrement_ref(nhe);
+		if (!CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_PROTO_RELEASED))
+			zebra_nhg_decrement_ref(nhe);
+		else {
+
+			/* protocol sends explicit delete of nhg, the
+			 * nhe->refcount is decremented in zread_nhg_del()
+			 */
+			if (IS_ZEBRA_DEBUG_RIB_DETAILED)
+				zlog_debug(
+					"%s: nhe %u (%p) refcount %u already decremented in zread_nhg_del",
+					__func__, nhe->id, nhe, nhe->refcnt);
+		}
 	}
 
 	count = iter.found->count;


### PR DESCRIPTION
When frr.service is going down(restart or stop), zebra core can be seen.

Sequence of events leading to crash:
Increments of nhe refcnt:
  - Upper level creates a new nhe(say NHE1) —> nhe->refcnt=1
  - Two RE’s (Say RE1 & RE2) associate with NHE1 —> nhe->refcnt = 3

Decrements of nhe refcnt:
  - BGP sends a zapi msg to zebra to delete NHG. —> nhe->refcnt = 2
  - RE1 is queued for delete in META-Q
  - As zebra is dissociating with its clients, zebra_nhg_score_proto() is invoked -> nhe->refcnt=1
  - RE2 is no more associated with the NHE1 —>nhe->refcnt=0 & hence NHE IS FREED
  - Now RE1 is dequeued from META-Q for processing the re delete. —> At this point re->nhe is pointing to freed pointer. CRASH CRASH!!!!

Fix:
  - When upper client sends a zapi msg to delete nhg(zread_nhg_del), we mark nhe->flags as NEXTHOP_GROUP_PROTO_RELEASED & we decrement the nhe->refcnt
  - When we iterate zebra_nhg_score_proto_entry() to delete the upper proto specific nhe’s,  we need to skip the additional nhe->refcnt decrement in case nhe->flags has NEXTHOP_GROUP_PROTO_RELEASED set.


**Backtraces**

BT-1


```
Program terminated with signal SIGABRT, Aborted.
#0  0x00007fa844b695cb in raise () from /lib/x86_64-linux-gnu/libpthread.so.0
[Current thread is 1 (Thread 0x7fa84404ac80 (LWP 12861))]
(gdb) bt
#0  0x00007fa844b695cb in raise () from /lib/x86_64-linux-gnu/libpthread.so.0
#1  0x00007fa844d07bfc in core_handler (signo=6, siginfo=0x7ffffbdf6130, context=<optimized out>) at lib/sigevent.c:264
#2  <signal handler called>
#3  0x00007fa8449ce8eb in raise () from /lib/x86_64-linux-gnu/libc.so.6
#4  0x00007fa8449b9535 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#5  0x00007fa844d32f86 in _zlog_assert_failed (xref=xref@entry=0x55fa37871040 <_xref.28142>, extra=extra@entry=0x0) at lib/zlog.c:680
#6  0x000055fa3778f770 in rib_re_nhg_free (re=0x55fa39e33770) at zebra/zebra_rib.c:2578
#7  rib_unlink (rn=0x55fa39e27a60, re=0x55fa39e33770) at zebra/zebra_rib.c:3930
#8  0x000055fa3778ff18 in rib_process (rn=0x55fa39e27a60) at zebra/zebra_rib.c:1439
#9  0x000055fa37790b1c in process_subq_route (qindex=8 '\b', lnode=0x55fa39e1c1b0) at zebra/zebra_rib.c:2549
#10 process_subq (qindex=META_QUEUE_BGP, subq=0x55fa3999c580) at zebra/zebra_rib.c:3107
#11 meta_queue_process (dummy=<optimized out>, data=0x55fa3999c480) at zebra/zebra_rib.c:3146
#12 0x00007fa844d232b8 in work_queue_run (thread=0x7ffffbdf6cb0) at lib/workqueue.c:285
#13 0x00007fa844d195fd in thread_call (thread=thread@entry=0x7ffffbdf6cb0) at lib/thread.c:2008
#14 0x00007fa844cd3888 in frr_run (master=0x55fa397b7630) at lib/libfrr.c:1223
#15 0x000055fa3771e294 in main (argc=12, argv=0x7ffffbdf7098) at zebra/main.c:526
```

BT-2

```
(gdb) bt
#0  0x00007f125b0ef5cb in raise () from /lib/x86_64-linux-gnu/libpthread.so.0
#1  0x00007f125b28dc0c in core_handler (signo=6, siginfo=0x7ffc2a73f970, context=<optimized out>) at lib/sigevent.c:264
#2  <signal handler called>
#3  0x00007f125af548eb in raise () from /lib/x86_64-linux-gnu/libc.so.6
#4  0x00007f125af3f535 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#5  0x00007f125b2b8f96 in _zlog_assert_failed (xref=xref@entry=0x7f125b344260 <_xref.18768>, extra=extra@entry=0x0) at lib/zlog.c:680
#6  0x00007f125b268190 in nexthop_copy_no_recurse (copy=copy@entry=0x5606dd726f10, nexthop=nexthop@entry=0x7f125b0d7f90, rparent=<optimized out>) at lib/nexthop.c:806
#7  0x00007f125b2681b2 in nexthop_copy (copy=0x5606dd726f10, nexthop=0x7f125b0d7f90, rparent=<optimized out>) at lib/nexthop.c:836
#8  0x00007f125b268249 in nexthop_dup (nexthop=nexthop@entry=0x7f125b0d7f90, rparent=rparent@entry=0x0) at lib/nexthop.c:860
#9  0x00007f125b26b67b in copy_nexthops (tnh=tnh@entry=0x5606dd9ec748, nh=<optimized out>, rparent=rparent@entry=0x0) at lib/nexthop_group.c:457
#10 0x00007f125b26b6ba in nexthop_group_copy (to=to@entry=0x5606dd9ec748, from=from@entry=0x5606dd9ee9f8) at lib/nexthop_group.c:291
#11 0x00005606db6ec678 in zebra_nhe_copy (orig=0x5606dd9ee9d0, id=id@entry=0) at zebra/zebra_nhg.c:431
#12 0x00005606db6ddc63 in mpls_ftn_uninstall_all (zvrf=zvrf@entry=0x5606dd6e7cd0, afi=afi@entry=2, lsp_type=ZEBRA_LSP_NONE) at zebra/zebra_mpls.c:3410
#13 0x00005606db6de108 in zebra_mpls_cleanup_zclient_labels (client=0x5606dd8e03b0) at ./zebra/zebra_mpls.h:471
#14 0x00005606db73e575 in hook_call_zserv_client_close (client=0x5606dd8e03b0) at zebra/zserv.c:566
#15 zserv_client_free (client=0x5606dd8e03b0) at zebra/zserv.c:585
#16 zserv_close_client (client=0x5606dd8e03b0) at zebra/zserv.c:706
#17 0x00007f125b29f60d in thread_call (thread=thread@entry=0x7ffc2a740290) at lib/thread.c:2008
#18 0x00007f125b259888 in frr_run (master=0x5606dd3b7630) at lib/libfrr.c:1223
#19 0x00005606db68d298 in main (argc=12, argv=0x7ffc2a740678) at zebra/main.c:534
```