### PR TITLE
bgpd: The last_reset_cause in the peer structure is too large

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -956,8 +956,9 @@ static void bgp_notify_send_internal(struct peer *peer, uint8_t code,
 	if (use_curr && peer->curr) {
 		size_t packetsize = stream_get_endp(peer->curr);
 		assert(packetsize <= peer->max_packet_size);
-		memcpy(peer->last_reset_cause, peer->curr->data, packetsize);
-		peer->last_reset_cause_size = packetsize;
+		if (peer->last_reset_cause)
+			stream_free(peer->last_reset_cause);
+		peer->last_reset_cause = stream_dup(peer->curr);
 	}
 
 	/* For debug */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -14862,15 +14862,15 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 					    BGP_UPTIME_LEN, 0, NULL));
 
 			bgp_show_peer_reset(vty, p, NULL, false);
-			if (p->last_reset_cause_size) {
-				msg = p->last_reset_cause;
+			if (p->last_reset_cause) {
+				msg = p->last_reset_cause->data;
 				vty_out(vty,
 					"  Message received that caused BGP to send a NOTIFICATION:\n    ");
-				for (i = 1; i <= p->last_reset_cause_size;
+				for (i = 1; i <= p->last_reset_cause->size;
 				     i++) {
 					vty_out(vty, "%02X", *msg++);
 
-					if (i != p->last_reset_cause_size) {
+					if (i != p->last_reset_cause->size) {
 						if (i % 16 == 0) {
 							vty_out(vty, "\n    ");
 						} else if (i % 4 == 0) {

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1189,6 +1189,8 @@ static void peer_free(struct peer *peer)
 
 	bgp_unlock(peer->bgp);
 
+	stream_free(peer->last_reset_cause);
+
 	memset(peer, 0, sizeof(struct peer));
 
 	XFREE(MTYPE_BGP_PEER, peer);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1716,8 +1716,7 @@ struct peer {
 	 * a new value to the last_reset reason
 	 */
 
-	uint16_t last_reset_cause_size;
-	uint8_t last_reset_cause[BGP_MAX_PACKET_SIZE];
+	struct stream *last_reset_cause;
 
 	/* The kind of route-map Flags.*/
 	uint16_t rmap_type;


### PR DESCRIPTION
The last_reset_cause is a plain old BGP_MAX_PACKET_SIZE buffer that is really enlarging the peer data structure.  Let's just copy the stream that failed and only allocate how ever much the packet size actually was.  While it's likely that we have a reset reason, the packet typically is not going to be 65k in size.  Let's save space.