### PR TITLE
Bgp ringbuf cleanup

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1414,7 +1414,7 @@ struct peer *peer_new(struct bgp *bgp)
 	pthread_mutex_init(&peer->io_mtx, NULL);
 
 	peer->ibuf_work =
-		ringbuf_new(BGP_MAX_PACKET_SIZE * BGP_READ_PACKET_MAX);
+		ringbuf_new(BGP_MAX_PACKET_SIZE + BGP_MAX_PACKET_SIZE/2);
 
 	/* Get service port number.  */
 	sp = getservbyname("bgp", "tcp");


### PR DESCRIPTION
a) Prevent a possible crash when the ringbuf is full and we receive a bunch of very large packets
b) Reduce the size of the peer ringbuf as that it's just too large