### PR TITLE
bgpd: non pretty json output for neighbor routes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -14639,8 +14639,12 @@ CPP_NOTICE("Drop `bgpOriginCodes` from JSON outputs")
 			json_object_free(json_ocode);
 		}
 
-		vty_json(vty, json);
-	} else if (output_count > 0) {
+                /*
+                 * This is an extremely expensive operation at scale
+                 * and non-pretty reduces memory footprint significantly.
+                 */
+                vty_json_no_pretty(vty, json);
+        } else if (output_count > 0) {
 		if (!match && filtered_count > 0)
 			vty_out(vty,
 				"\nTotal number of prefixes %ld (%ld filtered)\n",


### PR DESCRIPTION
Currently, json output of show BGP commands are no pretty format.

This is an extremely expensive operation for huge scale (lots of routes with lots of paths).

BGP json non-pretty commands support added:

```
show bgp neighbors <nbr-id> advertised-routes json
show bgp neighbors <nbr-id> received-routes json
show bgp neighbors <nbr-id> advertised-routes detail json
show bgp neighbors <nbr-id> received-routes detail json
```

Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>