### PR TITLE
tests: fix strncpy warning

### DIFF
--- a/tests/lib/test_nexthop_iter.c
+++ b/tests/lib/test_nexthop_iter.c
@@ -19,9 +19,10 @@ static int verbose;
 static void str_append(char **buf, const char *repr)
 {
 	if (*buf) {
-		*buf = realloc(*buf, strlen(*buf) + strlen(repr) + 1);
+		size_t new_size = strlen(*buf) + strlen(repr) + 1;
+		*buf = realloc(*buf, new_size);
 		assert(*buf);
-		strncpy((*buf) + strlen(*buf), repr, strlen(repr) + 1);
+		(void)strlcat(*buf, repr, new_size);
 	} else {
 		*buf = strdup(repr);
 		assert(*buf);


### PR DESCRIPTION
GCC/clang warns about using `strncpy` in such a way that it does not copy the null byte of a string; as implemented it was fine, but to fix the warning, just use `strlcat` which was purpose made for the task being accomplished here.

Fixes #6817