### PR TITLE
zebra: add several fields for debug

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -932,6 +932,8 @@ ssize_t printfrr_nhs(struct fbuf *buf, const struct nexthop *nexthop)
 		ret += bputs(buf, "blackhole");
 		break;
 	}
+
+	ret += bprintfrr(buf, " vrfid %u", nexthop->vrf_id);
 	return ret;
 }
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4170,10 +4170,10 @@ static int rib_meta_queue_early_route_add(struct meta_queue *mq, void *data)
 	mq->size++;
 
 	if (IS_ZEBRA_DEBUG_RIB_DETAILED)
-		zlog_debug(
-			"Route %pFX(%u) queued for processing into sub-queue %s",
-			&ere->p, ere->re->vrf_id,
-			subqueue2str(META_QUEUE_EARLY_ROUTE));
+		zlog_debug("Route %pFX(%u) (%s) queued for processing into sub-queue %s",
+			   &ere->p, ere->re->vrf_id,
+			   ere->deletion ? "delete" : "add",
+			   subqueue2str(META_QUEUE_EARLY_ROUTE));
 
 	return 0;
 }


### PR DESCRIPTION
Two changes for debug:
1. Add a field to indicate its vrf for nexthop.  When the interface changes vrf, we can't easily know the vrf of this nexthop according to current log.
2. Add a field to indicate operation type.  We can't know whether to add or remove route according to current log.

Before:
```
zebra_nhg_increment_ref: nhe 0x555623eb82c0 (76[if 6]) 0 => 1
zebra_interface_nhg_reinstall install nhe 75[77.75.1.75 if 6] nh type 3 flags 0x1
Route 77.75.1.0/24(8) queued for processing into sub-queue Early Route Processing
Route 77.75.1.0/24(8) queued for processing into sub-queue Early Route Processing
```

After:
```
zebra_nhg_increment_ref: nhe 0x555623eb82c0 (76[if 6 vrfid 9]) 0 => 1
zebra_interface_nhg_reinstall install nhe 75[77.75.1.75 if 6 vrfid 8] nh type 3 flags 0x1
Route 77.75.1.0/24(8) (add) queued for processing into sub-queue Early Route Processing
Route 77.75.1.0/24(8) (delete) queued for processing into sub-queue Early Route Processing
```