### PR TITLE
zebra: remove duplicated nexthops when sending fpm msg

### DIFF
--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -287,6 +287,8 @@ static int netlink_route_info_fill(struct netlink_route_info *ri, int cmd,
 
 		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
 			continue;
+		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
+			continue;
 
 		if (nexthop->type == NEXTHOP_TYPE_BLACKHOLE) {
 			switch (nexthop->bh_type) {


### PR DESCRIPTION
For now, when zebra send msg to fpm client, it doesn't handle duplicated nexthops especially, which means if zebra has a route with NUM1 recursive nexthops, each resolved to the same NUM2 connected nexthops, it will send to fpm client a route with NUM1*NUM2 nexthops. But actually there are only NUM2 useful nexthops, the left NUM1*NUM2-NUM2 nexthops are all  duplicated nexthops. By the way, zebra has duplicated nexthop remove logic when sending msg to kernel.
    Add duplicated nexthop remove logic to zebra when sending msg to fpm client.