### PR TITLE
bgpd,lib,zebra: fix and reinstall out-of-sync routes

### DIFF
--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -52,7 +52,7 @@ struct bgp_nexthop_cache {
 #define BGP_STATIC_ROUTE              (1 << 4)
 #define BGP_STATIC_ROUTE_EXACT_MATCH  (1 << 5)
 #define BGP_NEXTHOP_LABELED_VALID     (1 << 6)
-
+#define BGP_FORCED_CACHE_UPDATE	      (1 << 7)
 /*
  * This flag is added for EVPN gateway IP nexthops.
  * If the nexthop is RIB reachable, but a MAC/IP is not yet

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3030,9 +3030,10 @@ bool bgp_zebra_has_route_changed(struct bgp_path_info *selected)
 	 * we handle the case of BGP nexthop change. This is the behavior
 	 * when the best path has an attribute change anyway.
 	 */
-	if (CHECK_FLAG(selected->flags, BGP_PATH_IGP_CHANGED)
-	    || CHECK_FLAG(selected->flags, BGP_PATH_MULTIPATH_CHG)
-	    || CHECK_FLAG(selected->flags, BGP_PATH_LINK_BW_CHG))
+	if (CHECK_FLAG(selected->flags, BGP_PATH_IGP_CHANGED) ||
+	    CHECK_FLAG(selected->flags, BGP_PATH_MULTIPATH_CHG) ||
+	    CHECK_FLAG(selected->flags, BGP_PATH_LINK_BW_CHG) ||
+	    CHECK_FLAG(selected->flags, BGP_PATH_RECURSIVE_PATH_UPDATE))
 		return true;
 
 	/*
@@ -3350,11 +3351,49 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 	    !CHECK_FLAG(dest->flags, BGP_NODE_PROCESS_CLEAR) &&
 	    !CHECK_FLAG(old_select->flags, BGP_PATH_ATTR_CHANGED) &&
 	    !bgp_addpath_is_addpath_used(&bgp->tx_addpath, afi, safi)) {
-		if (bgp_zebra_has_route_changed(old_select)) {
+		if (bgp_zebra_has_route_changed(old_select) ||
+		    CHECK_FLAG(dest->flags,
+			       BGP_NODE_USED_AS_RECURSIVE_ONLINK_NEXTHOP)) {
 #ifdef ENABLE_BGP_VNC
 			vnc_import_bgp_add_route(bgp, p, old_select);
 			vnc_import_bgp_exterior_add_route(bgp, p, old_select);
 #endif
+			if (CHECK_FLAG(dest->flags,
+				       BGP_NODE_USED_AS_RECURSIVE_ONLINK_NEXTHOP)) {
+				if (debug) {
+					zlog_debug("Route %pBD is used as recursive nexthop - will be updated",
+						   dest);
+				}
+			}
+
+			UNSET_FLAG(dest->flags,
+				   BGP_NODE_USED_AS_RECURSIVE_ONLINK_NEXTHOP);
+			if (CHECK_FLAG(old_select->flags,
+				       BGP_PATH_RECURSIVE_PATH_UPDATE)) {
+				UNSET_FLAG(old_select->flags,
+					   BGP_PATH_RECURSIVE_PATH_UPDATE);
+				if (bgp->rib) {
+					struct bgp_table *table =
+						bgp->rib[afi][safi];
+					if (old_select->nexthop) {
+						struct bgp_dest *ddest =
+							bgp_node_get(table,
+								     &old_select
+									      ->nexthop
+									      ->prefix);
+						if (ddest) {
+							if (debug) {
+								zlog_debug("Route %pBD set to be updated, setting nexthop %pBD to be updated",
+									   dest,
+									   ddest);
+							}
+							SET_FLAG(ddest->flags,
+								 BGP_NODE_USED_AS_RECURSIVE_ONLINK_NEXTHOP);
+						}
+					}
+				}
+			}
+
 			if (bgp_fibupd_safi(safi)
 			    && !bgp_option_check(BGP_OPT_NO_FIB)) {
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -316,6 +316,7 @@ struct bgp_path_info {
 #define BGP_PATH_ACCEPT_OWN (1 << 16)
 #define BGP_PATH_MPLSVPN_LABEL_NH (1 << 17)
 #define BGP_PATH_MPLSVPN_NH_LABEL_BIND (1 << 18)
+#define BGP_PATH_RECURSIVE_PATH_UPDATE (1 << 19)
 
 	/* BGP route type.  This can be static, RIP, OSPF, BGP etc.  */
 	uint8_t type;

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -101,6 +101,7 @@ struct bgp_node {
 #define BGP_NODE_LABEL_REQUESTED        (1 << 7)
 #define BGP_NODE_SOFT_RECONFIG (1 << 8)
 #define BGP_NODE_PROCESS_CLEAR (1 << 9)
+#define BGP_NODE_USED_AS_RECURSIVE_ONLINK_NEXTHOP (1 << 10)
 
 	struct bgp_addpath_node_data tx_addpath;
 

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -81,6 +81,7 @@ struct nexthop {
 #define NEXTHOP_FLAG_SRTE       (1 << 7) /* SR-TE color used for BGP traffic */
 #define NEXTHOP_FLAG_EVPN       (1 << 8) /* nexthop is EVPN */
 #define NEXTHOP_FLAG_LINKDOWN   (1 << 9) /* is not removed on link down */
+#define NEXTHOP_FLAG_RNH_UPDATE	   (1 << 10) /* forced recursive nexthop update  */
 
 #define NEXTHOP_IS_ACTIVE(flags)                                               \
 	(CHECK_FLAG(flags, NEXTHOP_FLAG_ACTIVE)                                \

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2021,6 +2021,9 @@ int zapi_nexthop_from_nexthop(struct zapi_nexthop *znh,
 	znh->ifindex = nh->ifindex;
 	znh->gate = nh->gate;
 
+	if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_RNH_UPDATE))
+		SET_FLAG(znh->flags, ZAPI_NEXTHOP_RNH_UPDATE);
+
 	if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_ONLINK))
 		SET_FLAG(znh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
 
@@ -2171,6 +2174,9 @@ bool zapi_nexthop_update_decode(struct stream *s, struct prefix *match,
 	for (i = 0; i < nhr->nexthop_num; i++) {
 		if (zapi_nexthop_decode(s, &(nhr->nexthops[i]), 0, 0) != 0)
 			return false;
+		if (CHECK_FLAG(nhr->nexthops[i].flags, ZAPI_NEXTHOP_RNH_UPDATE)) {
+			SET_FLAG(nhr->flags, ZEBRA_FLAG_RNH_UPDATE);
+		}
 	}
 
 	return true;

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -453,6 +453,7 @@ struct zapi_nexthop {
 #define ZAPI_NEXTHOP_FLAG_SEG6		0x10
 #define ZAPI_NEXTHOP_FLAG_SEG6LOCAL	0x20
 #define ZAPI_NEXTHOP_FLAG_EVPN		0x40
+#define ZAPI_NEXTHOP_RNH_UPDATE		0x80
 
 /*
  * ZAPI Nexthop Group. For use with protocol creation of nexthop groups.
@@ -546,6 +547,14 @@ struct zapi_route {
  * kernel (NLM_F_APPEND at the very least )
  */
 #define ZEBRA_FLAG_OUTOFSYNC          0x400
+
+	/*
+ * This flag tells Zebra to update route even if state seems to be the same
+ * because is used as recursive onlink nexthop and might be out-of-sync
+ * after bgp session changes.
+*/
+
+#define ZEBRA_FLAG_RNH_UPDATE 0x800
 
 	/* The older XXX_MESSAGE flags live here */
 	uint32_t message;

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -336,6 +336,9 @@ int route_entry_update_nhe(struct route_entry *re,
 void rib_handle_nhg_replace(struct nhg_hash_entry *old_entry,
 			    struct nhg_hash_entry *new_entry);
 
+/* NHG got lost, reinstall failed routes */
+void rib_handle_nhg_reinstall(struct nhg_hash_entry *entry);
+
 #define route_entry_dump(prefix, src, re) _route_entry_dump(__func__, prefix, src, re)
 extern void _route_entry_dump(const char *func, union prefixconstptr pp,
 			      union prefixconstptr src_pp,

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -457,6 +457,39 @@ void rib_handle_nhg_replace(struct nhg_hash_entry *old_entry,
 	}
 }
 
+void rib_handle_nhg_reinstall(struct nhg_hash_entry *nhe)
+{
+	struct zebra_router_table *zrt;
+	struct route_node *rn;
+	struct route_entry *re, *next;
+
+	if (IS_ZEBRA_DEBUG_RIB_DETAILED || IS_ZEBRA_DEBUG_NHG_DETAIL)
+		zlog_debug("%s: reinstalling routes nhe (%u) %p", __func__,
+			   nhe->id, nhe);
+
+	/* We have to do them ALL */
+	RB_FOREACH (zrt, zebra_router_table_head, &zrouter.tables) {
+		for (rn = route_top(zrt->table); rn;
+		     rn = srcdest_route_next(rn)) {
+			RNODE_FOREACH_RE_SAFE (rn, re, next) {
+				if ((re->nhe && re->nhe == nhe) ||
+				    (re->nhe_installed_id &&
+				     re->nhe_installed_id == nhe->id)) {
+					if (CHECK_FLAG(re->status,
+						       ROUTE_ENTRY_FAILED)) {
+						if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+							zlog_debug("%s: reinstalling route for nhe (%u) %pRN",
+								   __func__,
+								   nhe->id, rn);
+
+						rib_install_kernel(rn, re, NULL);
+					}
+				}
+			}
+		}
+	}
+}
+
 struct route_entry *rib_match(afi_t afi, safi_t safi, vrf_id_t vrf_id,
 			      const union g_addr *addr,
 			      struct route_node **rn_out)


### PR DESCRIPTION
PR fixes two issues:
Issue A.  Route will not be reinstalled when failed to install due to carrier state DOWN (will not be updated when state becomes UP).
Re-adding route when carrier state is up is fixing problem.

How to reproduce:
0. Add route when carrier state of interface is DOWN

=======================
Issue B. Route becomes inactive due to out-of-sync of bestpath-routes selection. Multiple bgp neighbors are announcing the same nexthop and bgp session with neighbor selected as bestpath-routes provider goes down. Then after choosing next bgp neighbor as bestpath-routes provider, issued route will not be updated. Route has to have recursive onlink nexthop to reproduce issue.

How to reproduce:

0. Route that will be corrupted:

```
host1# show ip route

B>  33.33.33.33/32 [20/0] via 2600:cccc:32:1::2 (recursive), weight 1, 00:47:55
  *                         via ::ffff:a14:2, br3 onlink, weight 1, 00:47:55
```


0. Neighbor which is propagating bestpath-routes
```
host1 show bgp neighbors 2600:3c0f:51:ff34:1::1 bestpath-routes

 *> 2600:cccc:32:1::2/128
                    ::ffff:a14:2          1024             0 4250134000 4250100002 ?
```

0. Route server aka neighbor
```
host1# show bgp neighbors rs1001

BGP neighbor is 2600:3c0f:51:ff34:1::1, remote AS 4250134000, local AS 4250100001, external link
  Local Role: undefined
  Remote Role: undefined
Hostname: rs1001
```

1. clear session with bgp neighbour which is announcing bestpaths-routes (and is selected)
```
host1# clear bgp rs1001
```

2. route becomes inactive
```
host1# show ip route

B   33.33.33.33/32 [20/0] via 2600:cccc:32:1::2 inactive, weight 1, 00:00:20
```

but nexthop path 2600:cccc:32:1::2 is also announced from another route server (is reachable)
```
host1# show bgp neighbors 2600:3c0f:51:ff34:1::2 bestpath-routes

 *> 2600:cccc:32:1::2/128
                    ::ffff:a14:2          1024             0 4250134000 4250100002 ? 
```

