### PR TITLE
bfdd: add additional parameters to json command

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -1742,9 +1742,10 @@ void bfd_peer_mac_set(int sd, struct bfd_session *bfd,
 		strlcpy(arpreq_.arp_dev, ifp->name, sizeof(arpreq_.arp_dev));
 
 		if (ioctl(sd, SIOCGARP, &arpreq_) < 0) {
-			zlog_warn(
-				"BFD: getting peer's mac on %s failed error %s",
-				ifp->name, strerror(errno));
+			if (bglobal.debug_network)
+				zlog_debug(
+					"BFD: getting peer's mac on %s failed error %s",
+					ifp->name, strerror(errno));
 			UNSET_FLAG(bfd->flags, BFD_SESS_FLAG_MAC_SET);
 			memset(bfd->peer_hw_addr, 0, sizeof(bfd->peer_hw_addr));
 

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -213,6 +213,8 @@ static struct json_object *__display_peer_json(struct bfd_session *bs)
 	uint32_t avg = 0;
 	uint32_t max = 0;
 
+	if (bs->key.ifname[0])
+		json_object_string_add(jo, "interface", bs->key.ifname);
 	json_object_int_add(jo, "id", bs->discrs.my_discr);
 	json_object_int_add(jo, "remote-id", bs->discrs.remote_discr);
 	json_object_boolean_add(jo, "passive-mode",
@@ -246,6 +248,10 @@ static struct json_object *__display_peer_json(struct bfd_session *bs)
 	json_object_string_add(jo, "diagnostic", diag2str(bs->local_diag));
 	json_object_string_add(jo, "remote-diagnostic",
 			       diag2str(bs->remote_diag));
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG))
+		json_object_string_add(jo, "type", "configured");
+	else
+		json_object_string_add(jo, "type", "dynamic");
 
 	json_object_int_add(jo, "receive-interval",
 			    bs->timers.required_min_rx / 1000);


### PR DESCRIPTION
Add parameters to the "show bfd peers json" command to display interface and type of BFD session.
Add BFD debug flag around log.

Signed-off-by:Lynne Morrison <lynne.morrison@ibm.com>