### PR TITLE
pimd: Fix for FHR mroute taking longer to age out

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -239,10 +239,16 @@ void pim_ifchannel_delete_all(struct interface *ifp)
 
 void delete_on_noinfo(struct pim_ifchannel *ch)
 {
-	if (ch->local_ifmembership == PIM_IFMEMBERSHIP_NOINFO
-	    && ch->ifjoin_state == PIM_IFJOIN_NOINFO
-	    && ch->t_ifjoin_expiry_timer == NULL)
+	struct pim_upstream *up = ch->upstream;
+	/*
+	 * (S,G) with no active traffic, KAT expires, PPT expries,
+	 * channel state is NoInfo
+	 */
+	if (ch->local_ifmembership == PIM_IFMEMBERSHIP_NOINFO &&
+	    ch->ifjoin_state == PIM_IFJOIN_NOINFO &&
+	    (ch->t_ifjoin_expiry_timer == NULL || (up && !pim_upstream_is_kat_running(up)))) {
 		pim_ifchannel_delete(ch);
+	}
 }
 
 void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -312,7 +312,7 @@ static void on_join_timer(struct event *t)
 	}
 
 	/*
-	 * In the case of a HFR we will not ahve anyone to send this to.
+	 * In the case of a FHR we will not ahve anyone to send this to.
 	 */
 	if (PIM_UPSTREAM_FLAG_TEST_FHR(up->flags))
 		return;


### PR DESCRIPTION
Issue:
When there is no traffic for a group, the LHR and RP take the default KAT+Join timer expiry of a maximum of 480 seconds to clear the S,G . However, in the FHR, we update the state from JOINED to NOT Joined, downstream state from PPto NOINFO.  This restarts the ET timer, causing S,G on FHR to take more than 10 minutes to age out.

In other words,
Consider a case where (S,G) is in Join state. When the traffic stops and the KAT (210) expires,
 the Join expiry timer restarts. At this time, if we receive a prune, the expectation is to set
 PPT to 0 (RFC 4601 sec 4.5.2).
 When the PPT expires, we move to the noinfo state and restart the expiry timer one more time. We remove the
 (S,G) entry only after ~10 minutes when there is no active traffic.

Summary:
KAT Join ET 210 + PP ET 210 + NOINFO ET 210.

Solution:
Delete the ifchannel when in noinfo state, and KAT is not running.

Ticket: #13703