### PR TITLE
bgpd: fix a possible crash issue (code review)

### DIFF
--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -759,9 +759,9 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 					subgrp->update_group->id, subgrp->id);
 
 				/* Flush the FIFO update queue */
-				while (adv)
+				while (adv && adv->adj)
 					adv = bgp_advertise_clean_subgroup(
-						subgrp, adj);
+						subgrp, adv->adj);
 				return NULL;
 			}
 


### PR DESCRIPTION
The variable 'adj' used in this loop is not assigned a new value within the loop, instead it keeps using the same 'adj' assigned earlier, which may cause an exception in the second iteration of the loop.