### PR TITLE
bgpd: Fix for session reset issue caused by malformed core attributes  in update message

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3357,6 +3357,7 @@ enum bgp_attr_parse_ret bgp_attr_parse(struct peer *peer, struct attr *attr,
 				attr_args.total);
 			if (ret == BGP_ATTR_PARSE_PROCEED)
 				continue;
+			stream_forward_getp(BGP_INPUT(peer), endp - BGP_INPUT_PNT(peer));
 			goto done;
 		}
 
@@ -3458,6 +3459,7 @@ enum bgp_attr_parse_ret bgp_attr_parse(struct peer *peer, struct attr *attr,
 				EC_BGP_ATTRIBUTE_PARSE_WITHDRAW,
 				"%s: Attribute %s, parse error - treating as withdrawal",
 				peer->host, lookup_msg(attr_str, type, NULL));
+			stream_forward_getp(BGP_INPUT(peer), endp - BGP_INPUT_PNT(peer));
 			goto done;
 		}
 


### PR DESCRIPTION
Problem:
Few of the Update message error handling methods in RFC 4271 are updated with RFC 7606.
According to the RFC 7606, the error handling for the core attributes
has been relaxed to follow 'treat-as-withdraw' approach than session resets.
However, BGP session resets on encountering any malformed core attribute.

RCA:
On encountering any attribute error for core attributes in update message, the error handling is set to 'treat as withdraw' and further parsing of the remaining attributes is skipped. But the stream pointer is not being correctly adjusted to point to the next NLRI field skipping the rest of the attributes. This leads to incorrect parsing of the NLRI field, which causes BGP session to reset.

Fix:
The stream pointer offset is rightly adjusted to point to the NLRI field correctly when the malformed attribute is encountered and remaining attribute parsing is skipped.


Testing details with & without fix:
---------------------------------

1. Update message attribute flag error :  handled with treat-as-withdraw approach

Without fix: session resets

2023/08/01 22:27:51 BGP: [M59KS-A3ZXZ] bgp_update_receive: rcvd End-of-RIB for IPv4 Unicast from 24.0.0.4 in vrf default
2023/08/01 22:27:55 BGP: [NYD0B-A3BTB][EC 33554433] ORIGIN attribute must be flagged as "Optional"
2023/08/01 22:27:55 BGP: [SM0KX-WXMGK] bgp_attr_malformed: attributes: 
2023/08/01 22:27:55 BGP: [G2Z1P-1H5F3][EC 33554454] 24.0.0.4(frr) rcvd UPDATE with errors in attr(s)!! Withdrawing route.
2023/08/01 22:27:55 BGP: [PCFFM-WMARW] 24.0.0.4(frr) rcvd UPDATE wlen 0 attrlen 28 alen 28
2023/08/01 22:27:55 BGP: [QMZ79-K2DH7][EC 33554454] 24.0.0.4 [Error] Update packet error (wrong prefix length 80 for afi 1)
2023/08/01 22:27:55 BGP: [P9SYB-54XRZ][EC 33554454] 24.0.0.4 [Error] Error parsing NLRI
2023/08/01 22:27:55 BGP: [HZN6M-XRM1G] %NOTIFICATION: sent to neighbor 24.0.0.4 3/10 (UPDATE Message Error/Invalid Network Field) 0 bytes 


With Fix: no session reset

2023/08/01 22:26:27 BGP: [NYD0B-A3BTB][EC 33554433] ORIGIN attribute must be flagged as "Optional"
2023/08/01 22:26:27 BGP: [SM0KX-WXMGK] bgp_attr_malformed: attributes: 
2023/08/01 22:26:27 BGP: [G2Z1P-1H5F3][EC 33554454] 24.0.0.4(frr) rcvd UPDATE with errors in attr(s)!! Withdrawing route.
2023/08/01 22:26:27 BGP: [PCFFM-WMARW] 24.0.0.4(frr) rcvd UPDATE wlen 0 attrlen 28 alen 4
2023/08/01 22:26:27 BGP: [PAPP6-VDAWM] 24.0.0.4(frr) rcvd UPDATE about 9.9.9.0/24 IPv4 unicast -- withdrawn
2023/08/01 22:26:27 BGP: [PC71A-4RFD8] 24.0.0.4 Can't find the route 9.9.9.0/24 IPv4 unicast
2023/08/01 22:26:27 BGP: [P8XN0-33WQ6] 24.0.0.4 [FSM] Timer (keepalive timer expire)
2023/08/01 22:26:27 BGP: [HRDT0-0DPQ7] 24.0.0.4 sending KEEPALIVE
2023/08/01 22:26:27 BGP: [X61A3-E95TJ] 24.0.0.4 KEEPALIVE rcvd

====================================================================

2. Update message attribute length error : treat-as-withdraw approach

Without fix: the session resets

2023/08/01 22:16:16 BGP: [RB8T5-WW10B][EC 33554434] Origin attribute length is not one 0
2023/08/01 22:16:16 BGP: [SM0KX-WXMGK] bgp_attr_malformed: attributes: 
2023/08/01 22:16:16 BGP: [P7TRR-4J6XT][EC 33554487] 24.0.0.4: Attribute ORIGIN, parse error - treating as withdrawal
2023/08/01 22:16:16 BGP: [G2Z1P-1H5F3][EC 33554454] 24.0.0.4(frr) rcvd UPDATE with errors in attr(s)!! Withdrawing route.
2023/08/01 22:16:16 BGP: [PCFFM-WMARW] 24.0.0.4(frr) rcvd UPDATE wlen 0 attrlen 28 alen 29
2023/08/01 22:16:16 BGP: [PAPP6-VDAWM] 24.0.0.4(frr) rcvd UPDATE about 80.0.0.0/2 IPv4 unicast -- withdrawn
2023/08/01 22:16:16 BGP: [PC71A-4RFD8] 24.0.0.4 Can't find the route 80.0.0.0/2 IPv4 unicast
2023/08/01 22:16:16 BGP: [PAPP6-VDAWM] 24.0.0.4(frr) rcvd UPDATE about 0.0.0.0/2 IPv4 unicast -- withdrawn
2023/08/01 22:16:16 BGP: [PC71A-4RFD8] 24.0.0.4 Can't find the route 0.0.0.0/2 IPv4 unicast
2023/08/01 22:16:16 BGP: [PAPP6-VDAWM] 24.0.0.4(frr) rcvd UPDATE about 144.0.0.0/1 IPv4 unicast -- withdrawn
2023/08/01 22:16:16 BGP: [PC71A-4RFD8] 24.0.0.4 Can't find the route 144.0.0.0/1 IPv4 unicast
2023/08/01 22:16:16 BGP: [QMZ79-K2DH7][EC 33554454] 24.0.0.4 [Error] Update packet error (wrong prefix length 64 for afi 1)
2023/08/01 22:16:16 BGP: [P9SYB-54XRZ][EC 33554454] 24.0.0.4 [Error] Error parsing NLRI
2023/08/01 22:16:16 BGP: [HZN6M-XRM1G] %NOTIFICATION: sent to neighbor 24.0.0.4 3/10 (UPDATE Message Error/Invalid Network Field) 0 bytes  

With Fix: no session reset

2023/08/01 22:20:50 BGP: [RB8T5-WW10B][EC 33554434] Origin attribute length is not one 0
2023/08/01 22:20:50 BGP: [SM0KX-WXMGK] bgp_attr_malformed: attributes: 
2023/08/01 22:20:50 BGP: [P7TRR-4J6XT][EC 33554487] 24.0.0.4: Attribute ORIGIN, parse error - treating as withdrawal
2023/08/01 22:20:50 BGP: [G2Z1P-1H5F3][EC 33554454] 24.0.0.4(frr) rcvd UPDATE with errors in attr(s)!! Withdrawing route.
2023/08/01 22:20:50 BGP: [PCFFM-WMARW] 24.0.0.4(frr) rcvd UPDATE wlen 0 attrlen 28 alen 4
2023/08/01 22:20:50 BGP: [PAPP6-VDAWM] 24.0.0.4(frr) rcvd UPDATE about 9.9.9.0/24 IPv4 unicast -- withdrawn
2023/08/01 22:20:50 BGP: [PC71A-4RFD8] 24.0.0.4 Can't find the route 9.9.9.0/24 IPv4 unicast
2023/08/01 22:20:50 BGP: [P8XN0-33WQ6] 24.0.0.4 [FSM] Timer (keepalive timer expire)
2023/08/01 22:20:50 BGP: [HRDT0-0DPQ7] 24.0.0.4 sending KEEPALIVE
2023/08/01 22:20:50 BGP: [X61A3-E95TJ] 24.0.0.4 KEEPALIVE rcvd




