### PR TITLE
isisd:change ngh lvl when int circuit type setted

### DIFF
--- a/tests/topotests/isis_lsp_bits_topo1/rt6/step1/show_yang_interface_isis_adjacencies.ref
+++ b/tests/topotests/isis_lsp_bits_topo1/rt6/step1/show_yang_interface_isis_adjacencies.ref
@@ -9,7 +9,7 @@
             "adjacencies": {
               "adjacency": [
                 {
-                  "neighbor-sys-type": "level-1-2",
+                  "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0004",
                   "hold-timer": 10,
                   "neighbor-priority": 0,
@@ -28,7 +28,7 @@
             "adjacencies": {
               "adjacency": [
                 {
-                  "neighbor-sys-type": "level-1-2",
+                  "neighbor-sys-type": "level-1",
                   "neighbor-sysid": "0000.0000.0005",
                   "hold-timer": 10,
                   "neighbor-priority": 0,


### PR DESCRIPTION
I added a new variable to calculate the required level of neighborhood,
as well as checking if the interfaces are in the same area,
in accordance with cisco

Signed-off-by: Sososhas <1248756005hfh@gmail.com>