### PR TITLE
pimd: Dont not process invalid msdp peer address

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -1227,6 +1227,12 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ms
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
+		yang_dnode_get_ip(&peer_ip, args->dnode, "./peer-ip");
+		if (!pim_is_valid_ipddress(&peer_ip)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "Invalid peer ip address");
+			return NB_ERR_VALIDATION;
+		}
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;

--- a/pimd/pim_util.c
+++ b/pimd/pim_util.c
@@ -167,3 +167,20 @@ bool pim_addr_is_multicast(pim_addr addr)
 #endif
 	return false;
 }
+/*ip address with -1, or 0 */
+bool pim_is_valid_ipddress(const struct ipaddr *ip)
+{
+	if (ip->ipa_type == IPADDR_V4) {
+		return (ip->ip._v4_addr.s_addr == 0 ||
+			ip->ip._v4_addr.s_addr == 0xFFFFFFFF);
+	} else if (ip->ipa_type == IPADDR_V6) {
+		/*
+		 * In this case,check the IPv6 address if needed,
+		 * assuming its valid all the time
+		 */
+		return false;
+	} else {
+		/* Invalid IP address type */
+		return true;
+	}
+}

--- a/pimd/pim_util.h
+++ b/pimd/pim_util.h
@@ -25,4 +25,5 @@ int pim_is_group_224_4(struct in_addr group_addr);
 bool pim_is_group_filtered(struct pim_interface *pim_ifp, pim_addr *grp);
 int pim_get_all_mcast_group(struct prefix *prefix);
 bool pim_addr_is_multicast(pim_addr addr);
+bool pim_is_valid_ipddress(const struct ipaddr *ip);
 #endif /* PIM_UTIL_H */


### PR DESCRIPTION
The issue occurs when a new peer is created with an invalid peer
 address, which can cause the peer database to become corrupted.
 This can lead to various issues during shutdown, such as the example below:

(gdb) p/x *peer
 = {s_addr = 0x7fd5}

In other words, the peer hash key is based on the peer.s_addr value. When an invalid peer address is passed, it can break the entire peer cache logic like lookup, add, delete .

To fix this issue, return an error to Northbound validate
 and bail out if the source address is invalid.

Ticket:

Signed-off-by: Rajesh Varatharaj <rvaratharaj@nvidia.com>