### PR TITLE
bgpd: Handle software version capability dynamicaly

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1261,6 +1261,19 @@ void bgp_capability_send(struct peer *peer, afi_t afi, safi_t safi,
 								: "Removing",
 				iana_afi2str(pkt_afi), iana_safi2str(pkt_safi));
 		break;
+	case CAPABILITY_CODE_REFRESH:
+	case CAPABILITY_CODE_ORF:
+	case CAPABILITY_CODE_RESTART:
+	case CAPABILITY_CODE_AS4:
+	case CAPABILITY_CODE_DYNAMIC:
+	case CAPABILITY_CODE_ADDPATH:
+	case CAPABILITY_CODE_ENHANCED_RR:
+	case CAPABILITY_CODE_LLGR:
+	case CAPABILITY_CODE_FQDN:
+	case CAPABILITY_CODE_ENHE:
+	case CAPABILITY_CODE_EXT_MESSAGE:
+	case CAPABILITY_CODE_ROLE:
+		break;
 	default:
 		break;
 	}
@@ -2851,6 +2864,19 @@ static int bgp_capability_msg_parse(struct peer *peer, uint8_t *pnt,
 				else
 					return BGP_Stop;
 			}
+			break;
+		case CAPABILITY_CODE_REFRESH:
+		case CAPABILITY_CODE_ORF:
+		case CAPABILITY_CODE_RESTART:
+		case CAPABILITY_CODE_AS4:
+		case CAPABILITY_CODE_DYNAMIC:
+		case CAPABILITY_CODE_ADDPATH:
+		case CAPABILITY_CODE_ENHANCED_RR:
+		case CAPABILITY_CODE_LLGR:
+		case CAPABILITY_CODE_FQDN:
+		case CAPABILITY_CODE_ENHE:
+		case CAPABILITY_CODE_EXT_MESSAGE:
+		case CAPABILITY_CODE_ROLE:
 			break;
 		default:
 			flog_warn(

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5728,8 +5728,8 @@ DEFPY(neighbor_capability_software_version,
 	int ret;
 
 	peer = peer_and_group_lookup_vty(vty, neighbor);
-	if (peer && peer->conf_if)
-		return CMD_SUCCESS;
+	if (!peer)
+		return CMD_WARNING_CONFIG_FAILED;
 
 	if (no)
 		ret = peer_flag_unset_vty(vty, neighbor,

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4449,7 +4449,7 @@ static const struct peer_flag_action peer_flag_action_list[] = {
 	{PEER_FLAG_PORT, 0, peer_change_reset},
 	{PEER_FLAG_AIGP, 0, peer_change_none},
 	{PEER_FLAG_GRACEFUL_SHUTDOWN, 0, peer_change_none},
-	{PEER_FLAG_CAPABILITY_SOFT_VERSION, 0, peer_change_reset},
+	{PEER_FLAG_CAPABILITY_SOFT_VERSION, 0, peer_change_none},
 	{0, 0, 0}};
 
 static const struct peer_flag_action peer_af_flag_action_list[] = {

--- a/tests/topotests/bgp_dynamic_capability/r1/bgpd.conf
+++ b/tests/topotests/bgp_dynamic_capability/r1/bgpd.conf
@@ -1,0 +1,10 @@
+!
+!debug bgp neighbor
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ neighbor 192.168.1.2 remote-as external
+ neighbor 192.168.1.2 timers 1 3
+ neighbor 192.168.1.2 timers connect 1
+ neighbor 192.168.1.2 capability dynamic
+!

--- a/tests/topotests/bgp_dynamic_capability/r1/zebra.conf
+++ b/tests/topotests/bgp_dynamic_capability/r1/zebra.conf
@@ -1,0 +1,4 @@
+!
+int r1-eth0
+ ip address 192.168.1.1/24
+!

--- a/tests/topotests/bgp_dynamic_capability/r2/bgpd.conf
+++ b/tests/topotests/bgp_dynamic_capability/r2/bgpd.conf
@@ -1,0 +1,10 @@
+!
+!debug bgp neighbor
+!
+router bgp 65002
+ no bgp ebgp-requires-policy
+ neighbor 192.168.1.1 remote-as external
+ neighbor 192.168.1.1 timers 1 3
+ neighbor 192.168.1.1 timers connect 1
+ neighbor 192.168.1.1 capability dynamic
+!

--- a/tests/topotests/bgp_dynamic_capability/r2/zebra.conf
+++ b/tests/topotests/bgp_dynamic_capability/r2/zebra.conf
@@ -1,0 +1,4 @@
+!
+int r2-eth0
+ ip address 192.168.1.2/24
+!

--- a/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_software_version.py
+++ b/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_software_version.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2023 by
+# Donatas Abraitis <donatas@opensourcerouting.org>
+#
+
+"""
+Test if software version capability is exchanged dynamically.
+"""
+
+import os
+import re
+import sys
+import json
+import pytest
+import functools
+
+pytestmark = pytest.mark.bgpd
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.common_config import step
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1", "r2")}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for i, (rname, router) in enumerate(router_list.items(), 1):
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP, os.path.join(CWD, "{}/bgpd.conf".format(rname))
+        )
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_dynamic_capability():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    def _bgp_converge():
+        output = json.loads(r1.vtysh_cmd("show bgp neighbor json"))
+        expected = {
+            "192.168.1.2": {
+                "bgpState": "Established",
+                "neighborCapabilities": {
+                    "dynamic": "advertisedAndReceived",
+                    "softwareVersion": {
+                        "advertisedSoftwareVersion": None,
+                        "receivedSoftwareVersion": None,
+                    },
+                },
+                "connectionsEstablished": 1,
+                "connectionsDropped": 0,
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(
+        _bgp_converge,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "Can't converge"
+
+    step("Enable software version capability and check if it's exchanged dynamically")
+
+    r1.vtysh_cmd(
+        """
+    configure terminal
+    router bgp
+      neighbor 192.168.1.2 capability software-version
+    """
+    )
+
+    r2.vtysh_cmd(
+        """
+    configure terminal
+    router bgp
+      neighbor 192.168.1.1 capability software-version
+    """
+    )
+
+    def _bgp_check_if_session_not_reset():
+        def _bgp_software_version():
+            try:
+                versions = output["192.168.1.2"]["neighborCapabilities"][
+                    "softwareVersion"
+                ]
+                adv = versions["advertisedSoftwareVersion"]
+                rcv = versions["receivedSoftwareVersion"]
+
+                if not adv and not rcv:
+                    return ""
+
+                pattern = "FRRouting/\\d.+"
+                if re.search(pattern, adv) and re.search(pattern, rcv):
+                    return adv, rcv
+            except:
+                return ""
+
+        output = json.loads(r1.vtysh_cmd("show bgp neighbor json"))
+        adv, rcv = _bgp_software_version()
+        expected = {
+            "192.168.1.2": {
+                "bgpState": "Established",
+                "neighborCapabilities": {
+                    "dynamic": "advertisedAndReceived",
+                    "softwareVersion": {
+                        "advertisedSoftwareVersion": adv,
+                        "receivedSoftwareVersion": rcv,
+                    },
+                },
+                "connectionsEstablished": 1,
+                "connectionsDropped": 0,
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(
+        _bgp_check_if_session_not_reset,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert (
+        result is None
+    ), "Session was reset after enabling software version capability"
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
This is the first PR of the series to be handled with upcoming PRs for dynamic capability. We have to cover all of the supported or at least crucial ones (graceful restart, addpath) dynamically.