### PR TITLE
zebra: fix assert in process_subq_route

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -185,6 +185,10 @@ struct route_entry {
  *              don't generate routes
  */
 #define MQ_SIZE 11
+
+/* For checking that an object has already queued in some sub-queue */
+#define MQ_BIT_MASK ((1 << MQ_SIZE) - 1)
+
 struct meta_queue {
 	struct list *subq[MQ_SIZE];
 	uint32_t size; /* sum of lengths of all subqueues */


### PR DESCRIPTION
 Bug is reporoduced in case of switching interfaces betwean VRFs.
 ospf6d is enabled and configured in each VRF.

 'dest' can be removed from the route node in the time when the same
 route node waiting processing in another sub-queue.

 A route node must only be in one sub-queue at a time.

 (gdb) bt
 #0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140662163115136) at ./nptl/pthread_kill.c:44
 #1  __pthread_kill_internal (signo=6, threadid=140662163115136) at ./nptl/pthread_kill.c:78
 #2  __GI___pthread_kill (threadid=140662163115136, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
 #3  0x00007fee76753476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
 #4  0x00007fee767397f3 in __GI_abort () at ./stdlib/abort.c:79
 #5  0x00007fee76a420fd in _zlog_assert_failed () from target:/usr/lib/x86_64-linux-gnu/frr/libfrr.so.0
 #6  0x0000562674efe0f0 in process_subq_route (qindex=7 '\a', lnode=0x562675940c60) at zebra/zebra_rib.c:2540
 #7  process_subq (qindex=META_QUEUE_NOTBGP, subq=0x562675574580) at zebra/zebra_rib.c:3055
 #8  meta_queue_process (dummy=<optimized out>, data=0x56267556d430) at zebra/zebra_rib.c:3091
 #9  0x00007fee76a386e8 in work_queue_run () from target:/usr/lib/x86_64-linux-gnu/frr/libfrr.so.0
 #10 0x00007fee76a31c91 in thread_call () from target:/usr/lib/x86_64-linux-gnu/frr/libfrr.so.0
 #11 0x00007fee769ee528 in frr_run () from target:/usr/lib/x86_64-linux-gnu/frr/libfrr.so.0
 #12 0x0000562674e97ec5 in main (argc=5, argv=0x7ffd1e275958) at zebra/main.c:478

 Fixes: d7ac4c4d88 ("zebra: Introduce early route processing on the MetaQ")