### PR TITLE
staticd: fix comparison of nexthop-vrf

### DIFF
--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -1374,6 +1374,7 @@ int static_nexthop_cli_cmp(const struct lyd_node *dnode1,
 {
 	enum static_nh_type nh_type1, nh_type2;
 	struct prefix prefix1, prefix2;
+	const char *vrf1, *vrf2;
 	int ret = 0;
 
 	nh_type1 = yang_dnode_get_enum(dnode1, "./nh-type");
@@ -1413,8 +1414,14 @@ int static_nexthop_cli_cmp(const struct lyd_node *dnode1,
 	if (ret)
 		return ret;
 
-	return if_cmp_name_func(yang_dnode_get_string(dnode1, "./vrf"),
-				yang_dnode_get_string(dnode2, "./vrf"));
+	vrf1 = yang_dnode_get_string(dnode1, "./vrf");
+	if (strmatch(vrf1, "default"))
+		vrf1 = "";
+	vrf2 = yang_dnode_get_string(dnode2, "./vrf");
+	if (strmatch(vrf2, "default"))
+		vrf2 = "";
+
+	return if_cmp_name_func(vrf1, vrf2);
 }
 
 int static_route_list_cli_cmp(const struct lyd_node *dnode1,


### PR DESCRIPTION
When displaying the configuration, the order of nexthop-vrf is wrong, because the default VRF is not displayed, but still compared as the word "default". Therefore it is placed in the middle of the list instead of always being the first one.

Before the fix:
```
ip route 1.1.1.0/24 2.2.2.2 nexthop-vrf ccc
ip route 1.1.1.0/24 2.2.2.2
ip route 1.1.1.0/24 2.2.2.2 nexthop-vrf eee
```

After the fix:
```
ip route 1.1.1.0/24 2.2.2.2
ip route 1.1.1.0/24 2.2.2.2 nexthop-vrf ccc
ip route 1.1.1.0/24 2.2.2.2 nexthop-vrf eee
```