### PR TITLE
tests: Use a correct syntax for defining keepalive/hold timers

### DIFF
--- a/tests/topotests/bgp_addpath_best_selected/r5/bgpd.conf
+++ b/tests/topotests/bgp_addpath_best_selected/r5/bgpd.conf
@@ -1,5 +1,5 @@
 router bgp 65005
- timers 3 10
+ timers bgp 3 10
  no bgp ebgp-requires-policy
  neighbor 192.168.2.2 remote-as external
  neighbor 192.168.2.2 timers connect 5

--- a/tests/topotests/bgp_addpath_best_selected/r6/bgpd.conf
+++ b/tests/topotests/bgp_addpath_best_selected/r6/bgpd.conf
@@ -1,5 +1,5 @@
 router bgp 65006
- timers 3 10
+ timers bgp 3 10
  no bgp ebgp-requires-policy
  neighbor 192.168.2.2 remote-as external
  neighbor 192.168.2.2 timers connect 5

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/PE1/bgpd.conf
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/PE1/bgpd.conf
@@ -1,5 +1,5 @@
 router bgp 65000
- timers 3 9
+ timers bgp 3 9
  bgp router-id 10.10.10.10
  no bgp default ipv4-unicast
  neighbor 10.30.30.30 remote-as 65000

--- a/tests/topotests/bgp_evpn_vxlan_svd_topo1/PE1/bgpd.conf
+++ b/tests/topotests/bgp_evpn_vxlan_svd_topo1/PE1/bgpd.conf
@@ -1,5 +1,5 @@
 router bgp 65000
- timers 3 9
+ timers bgp 3 9
  bgp router-id 10.10.10.10
  no bgp default ipv4-unicast
  neighbor 10.30.30.30 remote-as 65000

--- a/tests/topotests/bgp_evpn_vxlan_topo1/PE1/bgpd.conf
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/PE1/bgpd.conf
@@ -1,5 +1,5 @@
 router bgp 65000
- timers 3 9
+ timers bgp 3 9
  bgp router-id 10.10.10.10
  no bgp default ipv4-unicast
  neighbor 10.30.30.30 remote-as 65000


### PR DESCRIPTION
BGP: [SHWNK-NWT5S][EC 100663304] No such command on config line 2:  timers 3 10