### PR TITLE
vtysh: fix checking empty interface node

### DIFF
--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -548,9 +548,7 @@ static void configvec_dump(vector vec, bool nested)
 				 * are not under the VRF node.
 				 */
 				if (config->index == INTERFACE_NODE
-				    && (listcount(config->line) == 1)
-				    && (line = listnode_head(config->line))
-				    && strmatch(line, "exit")) {
+				    && list_isempty(config->line)) {
 					config_del(config);
 					continue;
 				}


### PR DESCRIPTION
vtysh is not supposed to show empty interface node in running config, however the corresponding check is broken and empty nodes are shown.

P.S. This is broken for 2 years already (since my 4b639f996759eef388c42ca657a520de693ac6fc), so maybe it's better to remove the check completely and keep the current behavior instead of restoring the old one. Looking for comments from the community.