### PR TITLE
ospfd: Ensure listnode returns are usable

### DIFF
--- a/ospfd/ospf_ti_lfa.c
+++ b/ospfd/ospf_ti_lfa.c
@@ -64,6 +64,7 @@ ospf_ti_lfa_find_p_node(struct vertex *pc_node, struct p_space *p_space,
 	struct vertex_parent *pc_vertex_parent;
 
 	curr_node = listnode_lookup(q_space->pc_path, pc_node);
+	assert(curr_node);
 	pc_node_parent = listgetdata(curr_node->next);
 
 	q_space->p_node_info->type = OSPF_TI_LFA_UNDEFINED_NODE;
@@ -105,6 +106,7 @@ static void ospf_ti_lfa_find_q_node(struct vertex *pc_node,
 	struct vertex_parent *pc_vertex_parent;
 
 	curr_node = listnode_lookup(q_space->pc_path, pc_node);
+	assert(curr_node);
 	next_node = curr_node->next;
 	pc_node_parent = listgetdata(next_node);
 	pc_vertex_parent =
@@ -219,7 +221,7 @@ static struct list *ospf_ti_lfa_cut_out_pc_path(struct list *pc_vertex_list,
 	current_listnode = listnode_lookup(pc_path, current_vertex);
 
 	/* Note that the post-convergence paths are reversed. */
-	for (;;) {
+	while (current_listnode) {
 		current_vertex = listgetdata(current_listnode);
 		listnode_add(inner_pc_path, current_vertex);
 
@@ -268,6 +270,7 @@ static void ospf_ti_lfa_generate_inner_label_stack(
 	end_label = MPLS_INVALID_LABEL;
 	if (p_node_info->node->id.s_addr == p_space->root->id.s_addr) {
 		pc_p_node = listnode_lookup(q_space->pc_path, p_space->pc_spf);
+		assert(pc_p_node);
 		start_vertex = listgetdata(pc_p_node->prev);
 		start_label = ospf_sr_get_adj_sid_by_id(&p_node_info->node->id,
 							&start_vertex->id);
@@ -275,6 +278,7 @@ static void ospf_ti_lfa_generate_inner_label_stack(
 	if (q_node_info->node->id.s_addr == q_space->root->id.s_addr) {
 		pc_q_node = listnode_lookup(q_space->pc_path,
 					    listnode_head(q_space->pc_path));
+		assert(pc_q_node);
 		end_vertex = listgetdata(pc_q_node->next);
 		end_label = ospf_sr_get_adj_sid_by_id(&end_vertex->id,
 						      &q_node_info->node->id);


### PR DESCRIPTION
Coverity is complaining that listnode can return a NULL value and thus FRR could derefence the returned value. Since this is not crashing we know that this is not happening in the wild.  Let's make this an assert or check that it is legal to use the value.