### PR TITLE
zebra: Turn on `nht resolve-via-default` by default for traditional profile

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -328,10 +328,14 @@ the default route.
    Allow IPv4 nexthop tracking to resolve via the default route. This parameter
    is configured per-VRF, so the command is also available in the VRF subnode.
 
+   This is enabled by default for a traditional profile.
+
 .. clicmd:: ipv6 nht resolve-via-default
 
    Allow IPv6 nexthop tracking to resolve via the default route. This parameter
    is configured per-VRF, so the command is also available in the VRF subnode.
+
+   This is enabled by default for a traditional profile.
 
 .. clicmd:: show ip nht [vrf NAME] [A.B.C.D|X:X::X:X] [mrib] [json]
 

--- a/tests/topotests/all_protocol_startup/r1/ip_nht.ref
+++ b/tests/topotests/all_protocol_startup/r1/ip_nht.ref
@@ -1,3 +1,5 @@
+VRF default:
+ Resolve via default: on
 1.1.1.1
  resolved via static
  is directly connected, r1-eth1 (vrf default), weight 1

--- a/tests/topotests/all_protocol_startup/r1/ipv6_nht.ref
+++ b/tests/topotests/all_protocol_startup/r1/ipv6_nht.ref
@@ -1,3 +1,5 @@
+VRF default:
+ Resolve via default: on
 fc00::2
  resolved via connected
  is directly connected, r1-eth0 (vrf default)
@@ -10,4 +12,4 @@ fc00:0:0:8::2000(Connected)
  resolved via connected
  is directly connected, r1-eth8 (vrf default)
  Client list: bgp(fd XX)
- 
+

--- a/tests/topotests/bgp_features/r1/zebra.conf
+++ b/tests/topotests/bgp_features/r1/zebra.conf
@@ -26,3 +26,4 @@ interface r1-eth3
  ip address 192.168.101.1/24
  ipv6 address fc00:100:0:1::1/64
 !
+no ip nht resolve-via-default

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -373,6 +373,12 @@ struct zebra_vrf *zebra_vrf_alloc(struct vrf *vrf)
 	zebra_pw_init(zvrf);
 	zvrf->table_id = RT_TABLE_MAIN;
 	/* by default table ID is default one */
+
+	if (DFLT_ZEBRA_IP_NHT_RESOLVE_VIA_DEFAULT) {
+		zvrf->zebra_rnh_ip_default_route = true;
+		zvrf->zebra_rnh_ipv6_default_route = true;
+	}
+
 	return zvrf;
 }
 
@@ -456,11 +462,20 @@ static int vrf_config_write(struct vty *vty)
 						zvrf->l3vni)
 						? " prefix-routes-only"
 						: "");
-			if (zvrf->zebra_rnh_ip_default_route)
-				vty_out(vty, "ip nht resolve-via-default\n");
 
-			if (zvrf->zebra_rnh_ipv6_default_route)
-				vty_out(vty, "ipv6 nht resolve-via-default\n");
+			if (zvrf->zebra_rnh_ip_default_route !=
+			    SAVE_ZEBRA_IP_NHT_RESOLVE_VIA_DEFAULT)
+				vty_out(vty, "%sip nht resolve-via-default\n",
+					zvrf->zebra_rnh_ip_default_route
+						? ""
+						: "no ");
+
+			if (zvrf->zebra_rnh_ipv6_default_route !=
+			    SAVE_ZEBRA_IP_NHT_RESOLVE_VIA_DEFAULT)
+				vty_out(vty, "%sipv6 nht resolve-via-default\n",
+					zvrf->zebra_rnh_ipv6_default_route
+						? ""
+						: "no ");
 
 			if (zvrf->tbl_mgr
 			    && (zvrf->tbl_mgr->start || zvrf->tbl_mgr->end))
@@ -476,11 +491,19 @@ static int vrf_config_write(struct vty *vty)
 						? " prefix-routes-only"
 						: "");
 			zebra_ns_config_write(vty, (struct ns *)vrf->ns_ctxt);
-			if (zvrf->zebra_rnh_ip_default_route)
-				vty_out(vty, " ip nht resolve-via-default\n");
+			if (zvrf->zebra_rnh_ip_default_route !=
+			    SAVE_ZEBRA_IP_NHT_RESOLVE_VIA_DEFAULT)
+				vty_out(vty, " %sip nht resolve-via-default\n",
+					zvrf->zebra_rnh_ip_default_route
+						? ""
+						: "no ");
 
-			if (zvrf->zebra_rnh_ipv6_default_route)
-				vty_out(vty, " ipv6 nht resolve-via-default\n");
+			if (zvrf->zebra_rnh_ipv6_default_route !=
+			    SAVE_ZEBRA_IP_NHT_RESOLVE_VIA_DEFAULT)
+				vty_out(vty, " %sipv6 nht resolve-via-default\n",
+					zvrf->zebra_rnh_ipv6_default_route
+						? ""
+						: "no ");
 
 			if (zvrf->tbl_mgr && vrf_is_backend_netns()
 			    && (zvrf->tbl_mgr->start || zvrf->tbl_mgr->end))

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -13,10 +13,16 @@
 #include <zebra/zebra_pw.h>
 #include <zebra/rtadv.h>
 #include <lib/vxlan.h>
+#include "defaults.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+FRR_CFG_DEFAULT_BOOL(ZEBRA_IP_NHT_RESOLVE_VIA_DEFAULT,
+	{ .val_bool = true, .match_profile = "traditional", },
+	{ .val_bool = false },
+);
 
 /* MPLS (Segment Routing) global block */
 struct mpls_srgb {


### PR DESCRIPTION
As discussed in the Slack, turning `nht resolve-via-default` for a traditional profile by default.