### PR TITLE
libs: use XREALLOC in bitfield lib module

### DIFF
--- a/lib/bitfield.h
+++ b/lib/bitfield.h
@@ -114,7 +114,8 @@ DECLARE_MTYPE(BITFIELD);
 		(v).n += ((v).data[w] == WORD_MAX);                            \
 		if ((v).n == (v).m) {                                          \
 			(v).m = (v).m + 1;                                     \
-			(v).data = realloc((v).data, (v).m * sizeof(word_t));  \
+			(v).data = XREALLOC(MTYPE_BITFIELD, (v).data,          \
+					    (v).m * sizeof(word_t));           \
 		}                                                              \
 	} while (0)
 
@@ -188,7 +189,8 @@ bf_find_next_clear_bit_wrap(bitfield_t *v, word_t start_index, word_t max_index)
 		 * will allocate additional space.
 		 */
 		v->m += 1;
-		v->data = (word_t *)realloc(v->data, v->m * sizeof(word_t));
+		v->data = (word_t *)XREALLOC(MTYPE_BITFIELD, v->data,
+					     v->m * sizeof(word_t));
 		v->data[v->m - 1] = 0;
 		return v->m * WORD_SIZE;
 	}


### PR DESCRIPTION
Use FRR mem api instead of raw realloc() in bitfield module.
