### PR TITLE
bgpd: Few fixes for Update message error handling of malformed attribute

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3537,48 +3537,66 @@ enum bgp_attr_parse_ret bgp_attr_parse(struct peer *peer, struct attr *attr,
 				"%s: BGP type %d length %d is too large, attribute total length is %d.  attr_endp is %p.  endp is %p",
 				peer->host, type, length, size, attr_endp,
 				endp);
-			/*
-			 * RFC 4271 6.3
-			 * If any recognized attribute has an Attribute
-			 * Length that conflicts with the expected length
-			 * (based on the attribute type code), then the
-			 * Error Subcode MUST be set to Attribute Length
-			 * Error.  The Data field MUST contain the erroneous
-			 * attribute (type, length, and value).
-			 * ----------
-			 * We do not currently have a good way to determine the
-			 * length of the attribute independent of the length
-			 * received in the message. Instead we send the
-			 * minimum between the amount of data we have and the
-			 * amount specified by the attribute length field.
-			 *
-			 * Instead of directly passing in the packet buffer and
-			 * offset we use the stream_get* functions to read into
-			 * a stack buffer, since they perform bounds checking
-			 * and we are working with untrusted data.
-			 */
-			unsigned char ndata[peer->max_packet_size];
-			memset(ndata, 0x00, sizeof(ndata));
-			size_t lfl =
-				CHECK_FLAG(flag, BGP_ATTR_FLAG_EXTLEN) ? 2 : 1;
-			/* Rewind to end of flag field */
-			stream_rewind_getp(BGP_INPUT(peer), (1 + lfl));
-			/* Type */
-			stream_get(&ndata[0], BGP_INPUT(peer), 1);
-			/* Length */
-			stream_get(&ndata[1], BGP_INPUT(peer), lfl);
-			/* Value */
-			size_t atl = attr_endp - startp;
-			size_t ndl = MIN(atl, STREAM_READABLE(BGP_INPUT(peer)));
-			stream_get(&ndata[lfl + 1], BGP_INPUT(peer), ndl);
 
-			bgp_notify_send_with_data(
-				peer, BGP_NOTIFY_UPDATE_ERR,
-				BGP_NOTIFY_UPDATE_ATTR_LENG_ERR, ndata,
-				ndl + lfl + 1);
+			/* Only relax error handling for eBGP peers */
+			if (peer->sort != BGP_PEER_EBGP) {
+				/*
+				 * RFC 4271 6.3
+				 * If any recognized attribute has an Attribute
+				 * Length that conflicts with the expected length
+				 * (based on the attribute type code), then the
+				 * Error Subcode MUST be set to Attribute Length
+				 * Error.  The Data field MUST contain the erroneous
+				 * attribute (type, length, and value).
+				 * ----------
+				 * We do not currently have a good way to determine the
+				 * length of the attribute independent of the length
+				 * received in the message. Instead we send the
+				 * minimum between the amount of data we have and the
+				 * amount specified by the attribute length field.
+				 *
+				 * Instead of directly passing in the packet buffer and
+				 * offset we use the stream_get* functions to read into
+				 * a stack buffer, since they perform bounds checking
+				 * and we are working with untrusted data.
+				 */
+				unsigned char ndata[peer->max_packet_size];
 
-			ret = BGP_ATTR_PARSE_ERROR;
-			goto done;
+				memset(ndata, 0x00, sizeof(ndata));
+				size_t lfl =
+					CHECK_FLAG(flag, BGP_ATTR_FLAG_EXTLEN) ? 2 : 1;
+				/* Rewind to end of flag field */
+				stream_rewind_getp(BGP_INPUT(peer), (1 + lfl));
+				/* Type */
+				stream_get(&ndata[0], BGP_INPUT(peer), 1);
+				/* Length */
+				stream_get(&ndata[1], BGP_INPUT(peer), lfl);
+				/* Value */
+				size_t atl = attr_endp - startp;
+				size_t ndl = MIN(atl, STREAM_READABLE(BGP_INPUT(peer)));
+
+				stream_get(&ndata[lfl + 1], BGP_INPUT(peer), ndl);
+
+				bgp_notify_send_with_data(
+					peer, BGP_NOTIFY_UPDATE_ERR,
+					BGP_NOTIFY_UPDATE_ATTR_LENG_ERR, ndata,
+					ndl + lfl + 1);
+
+				ret = BGP_ATTR_PARSE_ERROR;
+				goto done;
+			} else {
+				/* Handling as per RFC7606 section 4, treat-as-withdraw approach
+				 * must be followed when the total attribute length is in conflict
+				 * with the enclosed path attribute length.
+				 */
+				flog_warn(
+					EC_BGP_ATTRIBUTE_PARSE_WITHDRAW,
+					"%s: Attribute %s, parse error - treating as withdrawal",
+					peer->host, lookup_msg(attr_str, type, NULL));
+				ret = BGP_ATTR_PARSE_WITHDRAW;
+				stream_forward_getp(BGP_INPUT(peer), endp - BGP_INPUT_PNT(peer));
+				goto done;
+			}
 		}
 
 		struct bgp_attr_parser_args attr_args = {


### PR DESCRIPTION
Below two cases of update message error handling have been fixed as part of this commit in conformance to RFC7606.

Issue 1:
As per RFC7606 section 4,
when the total attribute length value is in conflict with the enclosed attribute length, treat-as-withdraw approach must be followed. However, notification is being sent out for this case currently, that leads to session reset.
Fix:
The handling has been updated to conform to treat-as-withdraw approach only for EBGP case. For IBGP, since we are not following treat-as-withdraw approach for any of the error handling cases, the existing behavior is retained for the IBGP.

Issue2:
As per RFC7606 section 3g,
   g.  If the MP_REACH_NLRI attribute or the MP_UNREACH_NLRI [RFC4760]
       attribute appears more than once in the UPDATE message, then a
       NOTIFICATION message MUST be sent with the Error Subcode
       "Malformed Attribute List".  If any other attribute (whether
       recognized or unrecognized) appears more than once in an UPDATE
       message, then all the occurrences of the attribute other than the
       first one SHALL be discarded and the UPDATE message will continue
       to be processed.
However, notification is sent out currently for all the cases. Fix:
For cases other than MP_REACH_NLRI & MP_UNREACH_NLRI, handling has been updated to discard the occurrences other than the first one and proceed with further parsing. Again, the handling is relaxed only for the EBGP case. Also, since in case of error, the attribute is discarded & stream pointer is being adjusted accordingly based on length, the total attribute length sanity check case has been moved up in the function to be checked before this case.


Testing details :
=========================================================================================

**1. Last Attribute length larger than the total attribute length.** 

**EBGP case:** 
BGP neighbor is 24.0.0.4, remote AS 400, local AS 200, external link

**Without fix :**
2023/08/10 00:12:49 BGP: [XW4GT-8RRGC][EC 33554486] 24.0.0.4: BGP type 4 length 5 is too large, attribute total length is 28.  attr_endp is 0x7fe7c8007584.  endp is 0x7fe7c8007583
2023/08/10 00:12:49 BGP: [HZN6M-XRM1G] %NOTIFICATION: sent to neighbor 24.0.0.4 3/5 (UPDATE Message Error/Attribute Length Error) 10 bytes 04 05 00 
2023/08/10 00:12:49 BGP: [GW152-RVASS][EC 33554455] bgp_process_packet: BGP UPDATE receipt failed for peer: 24.0.0.4
2023/08/10 00:12:49 BGP: [ZWCSR-M7FG9] 24.0.0.4 [FSM] BGP_Stop (Established->Clearing), fd 30

**With Fix:**
2023/08/09 02:03:59 BGP: [PGS8W-47EHJ][EC 33554485] 24.0.0.4: BGP type 4 length 5 is too large, attribute total length is 28.  attr_endp is 0x7fcd64007234.  endp is 0x7fcd64007233
2023/08/09 02:03:59 BGP: [P7TRR-4J6XT][EC 33554487] 24.0.0.4: Attribute MULTI_EXIT_DISC, parse error - treating as withdrawal
2023/08/09 02:03:59 BGP: [G2Z1P-1H5F3][EC 33554454] 24.0.0.4(frr) rcvd UPDATE with errors in attr(s)!! Withdrawing route.
2023/08/09 02:03:59 BGP: [T5AAP-5GA85] 24.0.0.4(frr) rcvd UPDATE w/ attr: nexthop 24.0.0.4, origin ?, path 400
2023/08/09 02:03:59 BGP: [PCFFM-WMARW] 24.0.0.4(frr) rcvd UPDATE wlen 0 attrlen 28 alen 8
2023/08/09 02:03:59 BGP: [PAPP6-VDAWM] 24.0.0.4(frr) rcvd UPDATE about 8.8.8.0/24 IPv4 unicast -- withdrawn
2023/08/09 02:03:59 BGP: [PC71A-4RFD8] 24.0.0.4 Can't find the route 8.8.8.0/24 IPv4 unicast
2023/08/09 02:03:59 BGP: [PAPP6-VDAWM] 24.0.0.4(frr) rcvd UPDATE about 9.9.9.0/24 IPv4 unicast -- withdrawn
2023/08/09 02:03:59 BGP: [PC71A-4RFD8] 24.0.0.4 Can't find the route 9.9.9.0/24 IPv4 unicast

============================================================================================
**2. Multiple instances of same attribute:** 

Simulated Update message Packet attributes for testing,
ORIGIN 
ORIGIN
NEXT_HOP 
MED - 100
MED - 200

**EBGP case:** 

**Without Fix:** 
2023/08/10 00:42:00 BGP: [MZ33J-MDD6J][EC 33554485] 24.0.0.4: error BGP attribute type 1 appears twice in a message
2023/08/10 00:42:00 BGP: [HZN6M-XRM1G] %NOTIFICATION: sent to neighbor 24.0.0.4 3/1 (UPDATE Message Error/Malformed Attribute List) 0 bytes 
2023/08/10 00:42:00 BGP: [GW152-RVASS][EC 33554455] bgp_process_packet: BGP UPDATE receipt failed for peer: 24.0.0.4
2023/08/10 00:42:00 BGP: [ZWCSR-M7FG9] 24.0.0.4 [FSM] BGP_Stop (Established->Clearing), fd 30

**Withfix:** With fix, the second occurance is discarded & first occurance is considered. 
2023/08/09 01:46:06 BGP: [QBY45-DNHAP][EC 33554484] 24.0.0.4: error BGP attribute type 1 appears twice in a message - discard attribute
2023/08/09 01:46:06 BGP: [QBY45-DNHAP][EC 33554484] 24.0.0.4: error BGP attribute type 4 appears twice in a message - discard attribute
2023/08/09 01:46:06 BGP: [T5AAP-5GA85] 24.0.0.4(frr) rcvd UPDATE w/ attr: nexthop 24.0.0.4, origin i, metric 100, path 400
2023/08/09 01:46:06 BGP: [PCFFM-WMARW] 24.0.0.4(frr) rcvd UPDATE wlen 0 attrlen 39 alen 8
2023/08/09 01:46:06 BGP: [YCKEM-GB33T] 24.0.0.4(frr) rcvd 8.8.8.0/24 IPv4 unicast
2023/08/09 01:46:06 BGP: [YCKEM-GB33T] 24.0.0.4(frr) rcvd 9.9.9.0/24 IPv4 unicast

