### PR TITLE
bgpd: evpn code was not properly unlocking rd_dest

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3757,8 +3757,11 @@ static int install_uninstall_routes_for_vrf(struct bgp *bgp_vrf, int install)
 			     pi = pi->next) {
 				ret = bgp_evpn_route_entry_install_if_vrf_match(
 					bgp_vrf, pi, install);
-				if (ret)
+				if (ret) {
+					bgp_dest_unlock_node(rd_dest);
+					bgp_dest_unlock_node(dest);
 					return ret;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Found some code where bgp was not unlocking the dest and rd_dest when walking the tree attempting to
find something to install.