### PR TITLE
Zebra routemap cleanup

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -647,8 +647,7 @@ int zebra_add_import_table_entry(struct zebra_vrf *zvrf, struct route_node *rn,
 
 	afi = family2afi(rn->p.family);
 	if (rmap_name)
-		ret = zebra_import_table_route_map_check(afi, re, re->instance,
-							 &rn->p,
+		ret = zebra_import_table_route_map_check(afi, re, &rn->p,
 							 re->nhe->nhg.nexthop,
 							 re->tag, rmap_name);
 

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -649,7 +649,7 @@ int zebra_add_import_table_entry(struct zebra_vrf *zvrf, struct route_node *rn,
 	if (rmap_name)
 		ret = zebra_import_table_route_map_check(afi, re, &rn->p,
 							 re->nhe->nhg.nexthop,
-							 re->tag, rmap_name);
+							 rmap_name);
 
 	if (ret != RMAP_PERMITMATCH) {
 		UNSET_FLAG(re->flags, ZEBRA_FLAG_SELECTED);

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -647,10 +647,10 @@ int zebra_add_import_table_entry(struct zebra_vrf *zvrf, struct route_node *rn,
 
 	afi = family2afi(rn->p.family);
 	if (rmap_name)
-		ret = zebra_import_table_route_map_check(
-			afi, re->type, re->instance, &rn->p,
-			re->nhe->nhg.nexthop,
-			zvrf->vrf->vrf_id, re->tag, rmap_name);
+		ret = zebra_import_table_route_map_check(afi, re->type,
+							 re->instance, &rn->p,
+							 re->nhe->nhg.nexthop,
+							 re->tag, rmap_name);
 
 	if (ret != RMAP_PERMITMATCH) {
 		UNSET_FLAG(re->flags, ZEBRA_FLAG_SELECTED);

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -647,8 +647,8 @@ int zebra_add_import_table_entry(struct zebra_vrf *zvrf, struct route_node *rn,
 
 	afi = family2afi(rn->p.family);
 	if (rmap_name)
-		ret = zebra_import_table_route_map_check(afi, re->type,
-							 re->instance, &rn->p,
+		ret = zebra_import_table_route_map_check(afi, re, re->instance,
+							 &rn->p,
 							 re->nhe->nhg.nexthop,
 							 re->tag, rmap_name);
 

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2703,8 +2703,8 @@ skip_check:
 	}
 
 	/* It'll get set if required inside */
-	ret = zebra_route_map_check(family, re->type, re->instance, p, nexthop,
-				    zvrf, re->tag);
+	ret = zebra_route_map_check(family, re, re->instance, p, nexthop, zvrf,
+				    re->tag);
 	if (ret == RMAP_DENYMATCH) {
 		if (IS_ZEBRA_DEBUG_RIB) {
 			zlog_debug(

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2703,7 +2703,7 @@ skip_check:
 	}
 
 	/* It'll get set if required inside */
-	ret = zebra_route_map_check(family, re, p, nexthop, zvrf, re->tag);
+	ret = zebra_route_map_check(family, re, p, nexthop, zvrf);
 	if (ret == RMAP_DENYMATCH) {
 		if (IS_ZEBRA_DEBUG_RIB) {
 			zlog_debug(

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2703,8 +2703,7 @@ skip_check:
 	}
 
 	/* It'll get set if required inside */
-	ret = zebra_route_map_check(family, re, re->instance, p, nexthop, zvrf,
-				    re->tag);
+	ret = zebra_route_map_check(family, re, p, nexthop, zvrf, re->tag);
 	if (ret == RMAP_DENYMATCH) {
 		if (IS_ZEBRA_DEBUG_RIB) {
 			zlog_debug(

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -34,7 +34,6 @@ char *zebra_import_table_routemap[AFI_MAX][ZEBRA_KERNEL_TABLE_MAX];
 struct zebra_rmap_obj {
 	struct nexthop *nexthop;
 	struct route_entry *re;
-	uint8_t instance;
 	int metric;
 	route_tag_t tag;
 };
@@ -1477,7 +1476,7 @@ route_match_source_instance(void *rule, const struct prefix *p, void *object)
 	if (!rm_data)
 		return RMAP_NOMATCH;
 
-	return (rm_data->instance == *instance) ? RMAP_MATCH : RMAP_NOMATCH;
+	return (rm_data->re->instance == *instance) ? RMAP_MATCH : RMAP_NOMATCH;
 }
 
 static void *route_match_source_instance_compile(const char *arg)
@@ -1759,10 +1758,10 @@ void zebra_routemap_finish(void)
 	route_map_finish();
 }
 
-route_map_result_t
-zebra_route_map_check(afi_t family, struct route_entry *re, uint8_t instance,
-		      const struct prefix *p, struct nexthop *nexthop,
-		      struct zebra_vrf *zvrf, route_tag_t tag)
+route_map_result_t zebra_route_map_check(afi_t family, struct route_entry *re,
+					 const struct prefix *p,
+					 struct nexthop *nexthop,
+					 struct zebra_vrf *zvrf, route_tag_t tag)
 {
 	struct route_map *rmap = NULL;
 	char *rm_name;
@@ -1771,7 +1770,6 @@ zebra_route_map_check(afi_t family, struct route_entry *re, uint8_t instance,
 
 	rm_obj.nexthop = nexthop;
 	rm_obj.re = re;
-	rm_obj.instance = instance;
 	rm_obj.metric = 0;
 	rm_obj.tag = tag;
 
@@ -1813,11 +1811,9 @@ void zebra_del_import_table_route_map(afi_t afi, uint32_t table)
 	XFREE(MTYPE_ROUTE_MAP_NAME, zebra_import_table_routemap[afi][table]);
 }
 
-route_map_result_t
-zebra_import_table_route_map_check(int family, struct route_entry *re,
-				   uint8_t instance, const struct prefix *p,
-				   struct nexthop *nexthop, route_tag_t tag,
-				   const char *rmap_name)
+route_map_result_t zebra_import_table_route_map_check(
+	int family, struct route_entry *re, const struct prefix *p,
+	struct nexthop *nexthop, route_tag_t tag, const char *rmap_name)
 {
 	struct route_map *rmap = NULL;
 	route_map_result_t ret = RMAP_DENYMATCH;
@@ -1825,7 +1821,6 @@ zebra_import_table_route_map_check(int family, struct route_entry *re,
 
 	rm_obj.nexthop = nexthop;
 	rm_obj.re = re;
-	rm_obj.instance = instance;
 	rm_obj.metric = 0;
 	rm_obj.tag = tag;
 
@@ -1850,7 +1845,6 @@ route_map_result_t zebra_nht_route_map_check(afi_t afi, int client_proto,
 
 	rm_obj.nexthop = nexthop;
 	rm_obj.re = re;
-	rm_obj.instance = re->instance;
 	rm_obj.metric = re->metric;
 	rm_obj.tag = re->tag;
 

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -31,7 +31,7 @@ static uint32_t zebra_rmap_update_timer = ZEBRA_RMAP_DEFAULT_UPDATE_TIMER;
 static struct event *zebra_t_rmap_update = NULL;
 char *zebra_import_table_routemap[AFI_MAX][ZEBRA_KERNEL_TABLE_MAX];
 
-struct nh_rmap_obj {
+struct zebra_rmap_obj {
 	struct nexthop *nexthop;
 	vrf_id_t vrf_id;
 	uint32_t source_protocol;
@@ -49,12 +49,12 @@ static enum route_map_cmd_result_t
 route_match_tag(void *rule, const struct prefix *prefix, void *object)
 {
 	route_tag_t *tag;
-	struct nh_rmap_obj *nh_data;
+	struct zebra_rmap_obj *rm_data;
 
 	tag = rule;
-	nh_data = object;
+	rm_data = object;
 
-	if (nh_data->tag == *tag)
+	if (rm_data->tag == *tag)
 		return RMAP_MATCH;
 
 	return RMAP_NOMATCH;
@@ -74,19 +74,19 @@ static const struct route_map_rule_cmd route_match_tag_cmd = {
 static enum route_map_cmd_result_t
 route_match_interface(void *rule, const struct prefix *prefix, void *object)
 {
-	struct nh_rmap_obj *nh_data;
+	struct zebra_rmap_obj *rm_data;
 	char *ifname = rule;
 	ifindex_t ifindex;
 
 	if (strcasecmp(ifname, "any") == 0)
 		return RMAP_MATCH;
-	nh_data = object;
-	if (!nh_data || !nh_data->nexthop)
+	rm_data = object;
+	if (!rm_data || !rm_data->nexthop)
 		return RMAP_NOMATCH;
-	ifindex = ifname2ifindex(ifname, nh_data->vrf_id);
+	ifindex = ifname2ifindex(ifname, rm_data->vrf_id);
 	if (ifindex == 0)
 		return RMAP_NOMATCH;
-	if (nh_data->nexthop->ifindex == ifindex)
+	if (rm_data->nexthop->ifindex == ifindex)
 		return RMAP_MATCH;
 
 	return RMAP_NOMATCH;
@@ -1017,21 +1017,21 @@ static enum route_map_cmd_result_t
 route_match_ip_next_hop(void *rule, const struct prefix *prefix, void *object)
 {
 	struct access_list *alist;
-	struct nh_rmap_obj *nh_data;
+	struct zebra_rmap_obj *rm_data;
 	struct prefix_ipv4 p;
 
-	nh_data = object;
-	if (!nh_data)
+	rm_data = object;
+	if (!rm_data)
 		return RMAP_NOMATCH;
 
-	switch (nh_data->nexthop->type) {
+	switch (rm_data->nexthop->type) {
 	case NEXTHOP_TYPE_IFINDEX:
 		/* Interface routes can't match ip next-hop */
 		return RMAP_NOMATCH;
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
 	case NEXTHOP_TYPE_IPV4:
 		p.family = AF_INET;
-		p.prefix = nh_data->nexthop->gate.ipv4;
+		p.prefix = rm_data->nexthop->gate.ipv4;
 		p.prefixlen = IPV4_MAX_BITLEN;
 		break;
 	case NEXTHOP_TYPE_IPV6:
@@ -1080,21 +1080,21 @@ route_match_ip_next_hop_prefix_list(void *rule, const struct prefix *prefix,
 				    void *object)
 {
 	struct prefix_list *plist;
-	struct nh_rmap_obj *nh_data;
+	struct zebra_rmap_obj *rm_data;
 	struct prefix_ipv4 p;
 
-	nh_data = (struct nh_rmap_obj *)object;
-	if (!nh_data)
+	rm_data = (struct zebra_rmap_obj *)object;
+	if (!rm_data)
 		return RMAP_NOMATCH;
 
-	switch (nh_data->nexthop->type) {
+	switch (rm_data->nexthop->type) {
 	case NEXTHOP_TYPE_IFINDEX:
 		/* Interface routes can't match ip next-hop */
 		return RMAP_NOMATCH;
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
 	case NEXTHOP_TYPE_IPV4:
 		p.family = AF_INET;
-		p.prefix = nh_data->nexthop->gate.ipv4;
+		p.prefix = rm_data->nexthop->gate.ipv4;
 		p.prefixlen = IPV4_MAX_BITLEN;
 		break;
 	case NEXTHOP_TYPE_IPV6:
@@ -1264,14 +1264,14 @@ static enum route_map_cmd_result_t
 route_match_ipv6_next_hop_type(void *rule, const struct prefix *prefix,
 			       void *object)
 {
-	struct nh_rmap_obj *nh_data;
+	struct zebra_rmap_obj *rm_data;
 
 	if (prefix->family == AF_INET6) {
-		nh_data = (struct nh_rmap_obj *)object;
-		if (!nh_data)
+		rm_data = (struct zebra_rmap_obj *)object;
+		if (!rm_data)
 			return RMAP_NOMATCH;
 
-		if (nh_data->nexthop->type == NEXTHOP_TYPE_BLACKHOLE)
+		if (rm_data->nexthop->type == NEXTHOP_TYPE_BLACKHOLE)
 			return RMAP_MATCH;
 	}
 
@@ -1356,21 +1356,21 @@ route_match_ip_nexthop_prefix_len(void *rule, const struct prefix *prefix,
 				  void *object)
 {
 	uint32_t *prefixlen = (uint32_t *)rule;
-	struct nh_rmap_obj *nh_data;
+	struct zebra_rmap_obj *rm_data;
 	struct prefix_ipv4 p;
 
-	nh_data = (struct nh_rmap_obj *)object;
-	if (!nh_data || !nh_data->nexthop)
+	rm_data = (struct zebra_rmap_obj *)object;
+	if (!rm_data || !rm_data->nexthop)
 		return RMAP_NOMATCH;
 
-	switch (nh_data->nexthop->type) {
+	switch (rm_data->nexthop->type) {
 	case NEXTHOP_TYPE_IFINDEX:
 		/* Interface routes can't match ip next-hop */
 		return RMAP_NOMATCH;
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
 	case NEXTHOP_TYPE_IPV4:
 		p.family = AF_INET;
-		p.prefix = nh_data->nexthop->gate.ipv4;
+		p.prefix = rm_data->nexthop->gate.ipv4;
 		p.prefixlen = IPV4_MAX_BITLEN;
 		break;
 	case NEXTHOP_TYPE_IPV6:
@@ -1395,14 +1395,14 @@ static enum route_map_cmd_result_t
 route_match_ip_next_hop_type(void *rule, const struct prefix *prefix,
 			     void *object)
 {
-	struct nh_rmap_obj *nh_data;
+	struct zebra_rmap_obj *rm_data;
 
 	if (prefix->family == AF_INET) {
-		nh_data = (struct nh_rmap_obj *)object;
-		if (!nh_data)
+		rm_data = (struct zebra_rmap_obj *)object;
+		if (!rm_data)
 			return RMAP_NOMATCH;
 
-		if (nh_data->nexthop->type == NEXTHOP_TYPE_BLACKHOLE)
+		if (rm_data->nexthop->type == NEXTHOP_TYPE_BLACKHOLE)
 			return RMAP_MATCH;
 	}
 
@@ -1433,13 +1433,13 @@ static enum route_map_cmd_result_t
 route_match_source_protocol(void *rule, const struct prefix *p, void *object)
 {
 	uint32_t *rib_type = (uint32_t *)rule;
-	struct nh_rmap_obj *nh_data;
+	struct zebra_rmap_obj *rm_data;
 
-	nh_data = (struct nh_rmap_obj *)object;
-	if (!nh_data)
+	rm_data = (struct zebra_rmap_obj *)object;
+	if (!rm_data)
 		return RMAP_NOMATCH;
 
-	return ((nh_data->source_protocol == *rib_type) ? RMAP_MATCH
+	return ((rm_data->source_protocol == *rib_type) ? RMAP_MATCH
 							: RMAP_NOMATCH);
 }
 
@@ -1473,13 +1473,13 @@ static enum route_map_cmd_result_t
 route_match_source_instance(void *rule, const struct prefix *p, void *object)
 {
 	uint8_t *instance = (uint8_t *)rule;
-	struct nh_rmap_obj *nh_data;
+	struct zebra_rmap_obj *rm_data;
 
-	nh_data = (struct nh_rmap_obj *)object;
-	if (!nh_data)
+	rm_data = (struct zebra_rmap_obj *)object;
+	if (!rm_data)
 		return RMAP_NOMATCH;
 
-	return (nh_data->instance == *instance) ? RMAP_MATCH : RMAP_NOMATCH;
+	return (rm_data->instance == *instance) ? RMAP_MATCH : RMAP_NOMATCH;
 }
 
 static void *route_match_source_instance_compile(const char *arg)
@@ -1513,10 +1513,10 @@ static const struct route_map_rule_cmd route_match_source_instance_cmd = {
 static enum route_map_cmd_result_t
 route_set_src(void *rule, const struct prefix *prefix, void *object)
 {
-	struct nh_rmap_obj *nh_data;
+	struct zebra_rmap_obj *rm_data;
 
-	nh_data = (struct nh_rmap_obj *)object;
-	nh_data->nexthop->rmap_src = *(union g_addr *)rule;
+	rm_data = (struct zebra_rmap_obj *)object;
+	rm_data->nexthop->rmap_src = *(union g_addr *)rule;
 
 	return RMAP_OKAY;
 }
@@ -1769,14 +1769,14 @@ zebra_route_map_check(afi_t family, int rib_type, uint8_t instance,
 	struct route_map *rmap = NULL;
 	char *rm_name;
 	route_map_result_t ret = RMAP_PERMITMATCH;
-	struct nh_rmap_obj nh_obj;
+	struct zebra_rmap_obj rm_obj;
 
-	nh_obj.nexthop = nexthop;
-	nh_obj.vrf_id = nexthop->vrf_id;
-	nh_obj.source_protocol = rib_type;
-	nh_obj.instance = instance;
-	nh_obj.metric = 0;
-	nh_obj.tag = tag;
+	rm_obj.nexthop = nexthop;
+	rm_obj.vrf_id = nexthop->vrf_id;
+	rm_obj.source_protocol = rib_type;
+	rm_obj.instance = instance;
+	rm_obj.metric = 0;
+	rm_obj.tag = tag;
 
 	if (rib_type >= 0 && rib_type < ZEBRA_ROUTE_MAX) {
 		rm_name = PROTO_RM_NAME(zvrf, family, rib_type);
@@ -1793,7 +1793,7 @@ zebra_route_map_check(afi_t family, int rib_type, uint8_t instance,
 			return RMAP_DENYMATCH;
 	}
 	if (rmap) {
-		ret = route_map_apply(rmap, p, &nh_obj);
+		ret = route_map_apply(rmap, p, &rm_obj);
 	}
 
 	return (ret);
@@ -1825,19 +1825,19 @@ zebra_import_table_route_map_check(int family, int re_type, uint8_t instance,
 {
 	struct route_map *rmap = NULL;
 	route_map_result_t ret = RMAP_DENYMATCH;
-	struct nh_rmap_obj nh_obj;
+	struct zebra_rmap_obj rm_obj;
 
-	nh_obj.nexthop = nexthop;
-	nh_obj.vrf_id = vrf_id;
-	nh_obj.source_protocol = re_type;
-	nh_obj.instance = instance;
-	nh_obj.metric = 0;
-	nh_obj.tag = tag;
+	rm_obj.nexthop = nexthop;
+	rm_obj.vrf_id = vrf_id;
+	rm_obj.source_protocol = re_type;
+	rm_obj.instance = instance;
+	rm_obj.metric = 0;
+	rm_obj.tag = tag;
 
 	if (re_type >= 0 && re_type < ZEBRA_ROUTE_MAX)
 		rmap = route_map_lookup_by_name(rmap_name);
 	if (rmap) {
-		ret = route_map_apply(rmap, p, &nh_obj);
+		ret = route_map_apply(rmap, p, &rm_obj);
 	}
 
 	return (ret);
@@ -1851,21 +1851,21 @@ route_map_result_t zebra_nht_route_map_check(afi_t afi, int client_proto,
 {
 	struct route_map *rmap = NULL;
 	route_map_result_t ret = RMAP_PERMITMATCH;
-	struct nh_rmap_obj nh_obj;
+	struct zebra_rmap_obj rm_obj;
 
-	nh_obj.nexthop = nexthop;
-	nh_obj.vrf_id = nexthop->vrf_id;
-	nh_obj.source_protocol = re->type;
-	nh_obj.instance = re->instance;
-	nh_obj.metric = re->metric;
-	nh_obj.tag = re->tag;
+	rm_obj.nexthop = nexthop;
+	rm_obj.vrf_id = nexthop->vrf_id;
+	rm_obj.source_protocol = re->type;
+	rm_obj.instance = re->instance;
+	rm_obj.metric = re->metric;
+	rm_obj.tag = re->tag;
 
 	if (client_proto >= 0 && client_proto < ZEBRA_ROUTE_MAX)
 		rmap = NHT_RM_MAP(zvrf, afi, client_proto);
 	if (!rmap && NHT_RM_MAP(zvrf, afi, ZEBRA_ROUTE_MAX))
 		rmap = NHT_RM_MAP(zvrf, afi, ZEBRA_ROUTE_MAX);
 	if (rmap)
-		ret = route_map_apply(rmap, p, &nh_obj);
+		ret = route_map_apply(rmap, p, &rm_obj);
 
 	return ret;
 }

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1816,19 +1816,16 @@ void zebra_del_import_table_route_map(afi_t afi, uint32_t table)
 	XFREE(MTYPE_ROUTE_MAP_NAME, zebra_import_table_routemap[afi][table]);
 }
 
-route_map_result_t
-zebra_import_table_route_map_check(int family, int re_type, uint8_t instance,
-				   const struct prefix *p,
-				   struct nexthop *nexthop,
-				   vrf_id_t vrf_id, route_tag_t tag,
-				   const char *rmap_name)
+route_map_result_t zebra_import_table_route_map_check(
+	int family, int re_type, uint8_t instance, const struct prefix *p,
+	struct nexthop *nexthop, route_tag_t tag, const char *rmap_name)
 {
 	struct route_map *rmap = NULL;
 	route_map_result_t ret = RMAP_DENYMATCH;
 	struct zebra_rmap_obj rm_obj;
 
 	rm_obj.nexthop = nexthop;
-	rm_obj.vrf_id = vrf_id;
+	rm_obj.vrf_id = nexthop->vrf_id;
 	rm_obj.source_protocol = re_type;
 	rm_obj.instance = instance;
 	rm_obj.metric = 0;

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -33,7 +33,6 @@ char *zebra_import_table_routemap[AFI_MAX][ZEBRA_KERNEL_TABLE_MAX];
 
 struct zebra_rmap_obj {
 	struct nexthop *nexthop;
-	vrf_id_t vrf_id;
 	uint32_t source_protocol;
 	uint8_t instance;
 	int metric;
@@ -83,7 +82,7 @@ route_match_interface(void *rule, const struct prefix *prefix, void *object)
 	rm_data = object;
 	if (!rm_data || !rm_data->nexthop)
 		return RMAP_NOMATCH;
-	ifindex = ifname2ifindex(ifname, rm_data->vrf_id);
+	ifindex = ifname2ifindex(ifname, rm_data->nexthop->vrf_id);
 	if (ifindex == 0)
 		return RMAP_NOMATCH;
 	if (rm_data->nexthop->ifindex == ifindex)
@@ -1772,7 +1771,6 @@ zebra_route_map_check(afi_t family, int rib_type, uint8_t instance,
 	struct zebra_rmap_obj rm_obj;
 
 	rm_obj.nexthop = nexthop;
-	rm_obj.vrf_id = nexthop->vrf_id;
 	rm_obj.source_protocol = rib_type;
 	rm_obj.instance = instance;
 	rm_obj.metric = 0;
@@ -1825,7 +1823,6 @@ route_map_result_t zebra_import_table_route_map_check(
 	struct zebra_rmap_obj rm_obj;
 
 	rm_obj.nexthop = nexthop;
-	rm_obj.vrf_id = nexthop->vrf_id;
 	rm_obj.source_protocol = re_type;
 	rm_obj.instance = instance;
 	rm_obj.metric = 0;
@@ -1851,7 +1848,6 @@ route_map_result_t zebra_nht_route_map_check(afi_t afi, int client_proto,
 	struct zebra_rmap_obj rm_obj;
 
 	rm_obj.nexthop = nexthop;
-	rm_obj.vrf_id = nexthop->vrf_id;
 	rm_obj.source_protocol = re->type;
 	rm_obj.instance = re->instance;
 	rm_obj.metric = re->metric;

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -34,7 +34,6 @@ char *zebra_import_table_routemap[AFI_MAX][ZEBRA_KERNEL_TABLE_MAX];
 struct zebra_rmap_obj {
 	struct nexthop *nexthop;
 	struct route_entry *re;
-	int metric;
 	route_tag_t tag;
 };
 
@@ -1770,7 +1769,6 @@ route_map_result_t zebra_route_map_check(afi_t family, struct route_entry *re,
 
 	rm_obj.nexthop = nexthop;
 	rm_obj.re = re;
-	rm_obj.metric = 0;
 	rm_obj.tag = tag;
 
 	if (re->type >= 0 && re->type < ZEBRA_ROUTE_MAX) {
@@ -1821,7 +1819,6 @@ route_map_result_t zebra_import_table_route_map_check(
 
 	rm_obj.nexthop = nexthop;
 	rm_obj.re = re;
-	rm_obj.metric = 0;
 	rm_obj.tag = tag;
 
 	if (re->type >= 0 && re->type < ZEBRA_ROUTE_MAX)
@@ -1845,7 +1842,6 @@ route_map_result_t zebra_nht_route_map_check(afi_t afi, int client_proto,
 
 	rm_obj.nexthop = nexthop;
 	rm_obj.re = re;
-	rm_obj.metric = re->metric;
 	rm_obj.tag = re->tag;
 
 	if (client_proto >= 0 && client_proto < ZEBRA_ROUTE_MAX)

--- a/zebra/zebra_routemap.h
+++ b/zebra/zebra_routemap.h
@@ -21,17 +21,20 @@ extern void zebra_add_import_table_route_map(afi_t afi, const char *rmap_name,
 					     uint32_t table);
 extern void zebra_del_import_table_route_map(afi_t afi, uint32_t table);
 
-extern route_map_result_t zebra_import_table_route_map_check(
-	int family, int rib_type, uint8_t instance, const struct prefix *p,
-	struct nexthop *nexthop, route_tag_t tag, const char *rmap_name);
 extern route_map_result_t
-zebra_route_map_check(afi_t family, int rib_type, uint8_t instance,
+zebra_import_table_route_map_check(int family, struct route_entry *re,
+				   uint8_t instance, const struct prefix *p,
+				   struct nexthop *nexthop, route_tag_t tag,
+				   const char *rmap_name);
+extern route_map_result_t
+zebra_route_map_check(afi_t family, struct route_entry *re, uint8_t instance,
 		      const struct prefix *p, struct nexthop *nexthop,
 		      struct zebra_vrf *zvrf, route_tag_t tag);
-extern route_map_result_t
-zebra_nht_route_map_check(afi_t afi, int client_proto, const struct prefix *p,
-			  struct zebra_vrf *zvrf, struct route_entry *,
-			  struct nexthop *nexthop);
+extern route_map_result_t zebra_nht_route_map_check(afi_t afi, int client_proto,
+						    const struct prefix *p,
+						    struct zebra_vrf *zvrf,
+						    struct route_entry *re,
+						    struct nexthop *nexthop);
 
 extern void zebra_routemap_vrf_delete(struct zebra_vrf *zvrf);
 

--- a/zebra/zebra_routemap.h
+++ b/zebra/zebra_routemap.h
@@ -21,13 +21,11 @@ extern void zebra_add_import_table_route_map(afi_t afi, const char *rmap_name,
 					     uint32_t table);
 extern void zebra_del_import_table_route_map(afi_t afi, uint32_t table);
 
+extern route_map_result_t zebra_import_table_route_map_check(
+	int family, struct route_entry *re, const struct prefix *p,
+	struct nexthop *nexthop, route_tag_t tag, const char *rmap_name);
 extern route_map_result_t
-zebra_import_table_route_map_check(int family, struct route_entry *re,
-				   uint8_t instance, const struct prefix *p,
-				   struct nexthop *nexthop, route_tag_t tag,
-				   const char *rmap_name);
-extern route_map_result_t
-zebra_route_map_check(afi_t family, struct route_entry *re, uint8_t instance,
+zebra_route_map_check(afi_t family, struct route_entry *re,
 		      const struct prefix *p, struct nexthop *nexthop,
 		      struct zebra_vrf *zvrf, route_tag_t tag);
 extern route_map_result_t zebra_nht_route_map_check(afi_t afi, int client_proto,

--- a/zebra/zebra_routemap.h
+++ b/zebra/zebra_routemap.h
@@ -21,11 +21,9 @@ extern void zebra_add_import_table_route_map(afi_t afi, const char *rmap_name,
 					     uint32_t table);
 extern void zebra_del_import_table_route_map(afi_t afi, uint32_t table);
 
-extern route_map_result_t
-zebra_import_table_route_map_check(int family, int rib_type, uint8_t instance,
-				   const struct prefix *p,
-				   struct nexthop *nexthop, vrf_id_t vrf_id,
-				   route_tag_t tag, const char *rmap_name);
+extern route_map_result_t zebra_import_table_route_map_check(
+	int family, int rib_type, uint8_t instance, const struct prefix *p,
+	struct nexthop *nexthop, route_tag_t tag, const char *rmap_name);
 extern route_map_result_t
 zebra_route_map_check(afi_t family, int rib_type, uint8_t instance,
 		      const struct prefix *p, struct nexthop *nexthop,

--- a/zebra/zebra_routemap.h
+++ b/zebra/zebra_routemap.h
@@ -23,11 +23,12 @@ extern void zebra_del_import_table_route_map(afi_t afi, uint32_t table);
 
 extern route_map_result_t zebra_import_table_route_map_check(
 	int family, struct route_entry *re, const struct prefix *p,
-	struct nexthop *nexthop, route_tag_t tag, const char *rmap_name);
-extern route_map_result_t
-zebra_route_map_check(afi_t family, struct route_entry *re,
-		      const struct prefix *p, struct nexthop *nexthop,
-		      struct zebra_vrf *zvrf, route_tag_t tag);
+	struct nexthop *nexthop, const char *rmap_name);
+extern route_map_result_t zebra_route_map_check(afi_t family,
+						struct route_entry *re,
+						const struct prefix *p,
+						struct nexthop *nexthop,
+						struct zebra_vrf *zvrf);
 extern route_map_result_t zebra_nht_route_map_check(afi_t afi, int client_proto,
 						    const struct prefix *p,
 						    struct zebra_vrf *zvrf,


### PR DESCRIPTION
The `struct nh_rmap_obj` in zebra being used for routemaps was copying lots of individual fields.  Let's just cut to the chase and store and use the re instead.

Found a couple of bugs:
a) import table was using the vrf of the route -vs- the vrf of the nexthop and as such a import table with a cross vrf nexthop would never be imported.
b) metric was being ignored and as such in some cases zebra would never match on a metric if we passed it in to use.  Let's just allow zebra to match on the metric.

This also sets up a future changes to allow other match requirements against the re( see the routemap work that ali-baba is doing to not install into the kernel.  This should be foundational for their work.