### PR TITLE
Test bmp loc-rib

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1636,6 +1636,9 @@ static void bmp_close(struct bmp *bmp)
 	while ((bqe = bmp_pull(bmp)))
 		if (!bqe->refcount)
 			XFREE(MTYPE_BMP_QUEUE, bqe);
+	while ((bqe = bmp_pull_locrib(bmp)))
+		if (!bqe->refcount)
+			XFREE(MTYPE_BMP_QUEUE, bqe);
 
 	EVENT_OFF(bmp->t_read);
 	pullwr_del(bmp->pullwr);

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -240,14 +240,20 @@ static void bmp_free(struct bmp *bmp)
 	XFREE(MTYPE_BMP_CONN, bmp);
 }
 
-static uint64_t bmp_get_peer_distinguisher(struct bmp *bmp, afi_t afi)
-{
+#define BMP_PEER_TYPE_GLOBAL_INSTANCE 0
+#define BMP_PEER_TYPE_RD_INSTANCE     1
+#define BMP_PEER_TYPE_LOCAL_INSTANCE  2
+#define BMP_PEER_TYPE_LOC_RIB_INSTANCE 3
 
-	/* legacy : TODO should be turned into an option at some point
-	 * return bmp->targets->bgp->vrf_id;
-	 */
-	struct bgp *bgp = bmp->targets->bgp;
-	struct prefix_rd *prd = &bgp->vpn_policy[afi].tovpn_rd;
+static inline uint64_t bmp_get_peer_distinguisher(struct bmp* bmp, afi_t afi, uint8_t peer_type) {
+
+	/* remove this check when the other peer types get correct peer dist. (RFC7854) impl. */
+	if (peer_type != BMP_PEER_TYPE_LOC_RIB_INSTANCE)
+		return 0;
+
+	/* sending vrf_id or rd could be turned into an option at some point */
+	struct bgp* bgp = bmp->targets->bgp;
+	struct prefix_rd* prd = &bgp->vpn_policy[afi].tovpn_rd;
 	/*
 	 * default vrf => can't have RD => 0
 	 * vrf => has RD?
@@ -272,12 +278,6 @@ static void bmp_per_peer_hdr(struct stream *s, struct bgp* bgp, struct peer *pee
 			     uint64_t peer_distinguisher,
 			     const struct timeval *tv)
 {
-
-#define BMP_PEER_TYPE_GLOBAL_INSTANCE 0
-#define BMP_PEER_TYPE_RD_INSTANCE     1
-#define BMP_PEER_TYPE_LOCAL_INSTANCE  2
-#define BMP_PEER_TYPE_LOC_RIB_INSTANCE 3
-
 #define BMP_PEER_FLAG_V (1 << 7)
 #define BMP_PEER_FLAG_L (1 << 6)
 #define BMP_PEER_FLAG_A (1 << 5)
@@ -854,8 +854,7 @@ static void bmp_eor(struct bmp *bmp, afi_t afi, safi_t safi, uint8_t flags, uint
 		bmp_common_hdr(s2, BMP_VERSION_3,
 				BMP_TYPE_ROUTE_MONITORING);
 
-		uint64_t peerd = peer_type_flag == BMP_PEER_TYPE_LOC_RIB_INSTANCE ? bmp_get_peer_distinguisher(bmp, afi) : 0;
-		bmp_per_peer_hdr(s2, bmp->targets->bgp, peer, flags, peer_type_flag, peerd, NULL);
+		bmp_per_peer_hdr(s2, bmp->targets->bgp, peer, flags, peer_type_flag, bmp_get_peer_distinguisher(bmp, afi, peer_type_flag), NULL);
 
 		stream_putl_at(s2, BMP_LENGTH_POS,
 				stream_get_endp(s) + stream_get_endp(s2));
@@ -960,8 +959,7 @@ static struct stream *bmp_withdraw(const struct prefix *p,
 }
 
 static void bmp_monitor(struct bmp *bmp, struct peer *peer, uint8_t flags,
-			uint8_t peer_type_flags,
-			uint64_t peer_distinguisher_flag,
+			uint8_t peer_type_flag,
 			const struct prefix *p, struct prefix_rd *prd,
 			struct attr *attr, afi_t afi, safi_t safi,
 			time_t uptime)
@@ -978,7 +976,7 @@ static void bmp_monitor(struct bmp *bmp, struct peer *peer, uint8_t flags,
 
 	hdr = stream_new(BGP_MAX_PACKET_SIZE);
 	bmp_common_hdr(hdr, BMP_VERSION_3, BMP_TYPE_ROUTE_MONITORING);
-	bmp_per_peer_hdr(hdr, bmp->targets->bgp, peer, flags, peer_type_flags, peer_distinguisher_flag, &uptime_real);
+	bmp_per_peer_hdr(hdr, bmp->targets->bgp, peer, flags, peer_type_flag, bmp_get_peer_distinguisher(bmp, afi, peer_type_flag), &uptime_real);
 
 	stream_putl_at(hdr, BMP_LENGTH_POS,
 			stream_get_endp(hdr) + stream_get_endp(msg));
@@ -1160,21 +1158,21 @@ afibreak:
 		prd = (struct prefix_rd *)bgp_dest_get_prefix(bmp->syncrdpos);
 
 	if (bpi && CHECK_FLAG(bpi->flags, BGP_PATH_SELECTED) &&
-	    CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_LOC_RIB)) {
-		bmp_monitor(bmp, bpi->peer, 0, BMP_PEER_TYPE_LOC_RIB_INSTANCE,
-			    bmp_get_peer_distinguisher(bmp, afi), bn_p, prd,
+	     CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_LOC_RIB)) {
+		bmp_monitor(bmp, bpi->peer, 0,
+			    BMP_PEER_TYPE_LOC_RIB_INSTANCE, bn_p, prd,
 			    bpi->attr, afi, safi, bpi->rib_uptime);
 	}
 
 	if (bpi && CHECK_FLAG(bpi->flags, BGP_PATH_VALID)
 	    && CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_POSTPOLICY))
 		bmp_monitor(bmp, bpi->peer, BMP_PEER_FLAG_L,
-			    BMP_PEER_TYPE_GLOBAL_INSTANCE, 0, bn_p, prd,
+			    BMP_PEER_TYPE_GLOBAL_INSTANCE, bn_p, prd,
 			    bpi->attr, afi, safi, bpi->uptime);
 
 	if (adjin)
 		bmp_monitor(bmp, adjin->peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE,
-			    0, bn_p, prd, adjin->attr, afi, safi,
+			    bn_p, prd, adjin->attr, afi, safi,
 			    adjin->uptime);
 
 	if (bn)
@@ -1318,9 +1316,8 @@ static bool bmp_wrqueue_locrib(struct bmp *bmp, struct pullwr *pullwr)
 	}
 
 	bmp_monitor(bmp, peer, 0, BMP_PEER_TYPE_LOC_RIB_INSTANCE,
-		    bmp_get_peer_distinguisher(bmp, afi), &bqe->p, prd,
-		    bpi ? bpi->attr : NULL, afi, safi,
-		    bpi ? bpi->rib_uptime : monotime(NULL));
+		    &bqe->p, prd, bpi ? bpi->attr : NULL,
+		    afi, safi, bpi ? bpi->rib_uptime : monotime(NULL));
 	written = true;
 
 out:
@@ -1389,7 +1386,7 @@ static bool bmp_wrqueue(struct bmp *bmp, struct pullwr *pullwr)
 		}
 
 		bmp_monitor(bmp, peer, BMP_PEER_FLAG_L,
-			    BMP_PEER_TYPE_GLOBAL_INSTANCE, 0, &bqe->p, prd,
+			    BMP_PEER_TYPE_GLOBAL_INSTANCE, &bqe->p, prd,
 			    bpi ? bpi->attr : NULL, afi, safi,
 			    bpi ? bpi->uptime : monotime(NULL));
 		written = true;
@@ -1403,7 +1400,7 @@ static bool bmp_wrqueue(struct bmp *bmp, struct pullwr *pullwr)
 			if (adjin->peer == peer)
 				break;
 		}
-		bmp_monitor(bmp, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
+		bmp_monitor(bmp, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE,
 			    &bqe->p, prd, adjin ? adjin->attr : NULL, afi, safi,
 			    adjin ? adjin->uptime : monotime(NULL));
 		written = true;

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1211,7 +1211,7 @@ static inline struct bmp_queue_entry *bmp_pull_locrib(struct bmp *bmp)
 				   &bmp->locrib_queuepos);
 }
 
-/* TODO BMP_MON_LOCRIB  find a way to merge properly this function with
+/* TODO BMP_MON_LOCRIB find a way to merge properly this function with
  * bmp_wrqueue or abstract it if possible
  */
 static bool bmp_wrqueue_locrib(struct bmp *bmp, struct pullwr *pullwr)
@@ -1219,7 +1219,7 @@ static bool bmp_wrqueue_locrib(struct bmp *bmp, struct pullwr *pullwr)
 
 	struct bmp_queue_entry *bqe;
 	struct peer *peer;
-	struct bgp_dest *bn;
+	struct bgp_dest *bn = NULL;
 	bool written = false;
 
 	bqe = bmp_pull_locrib(bmp);
@@ -1272,10 +1272,6 @@ static bool bmp_wrqueue_locrib(struct bmp *bmp, struct pullwr *pullwr)
 				 &bqe->p, prd);
 
 	struct bgp_path_info *bpi;
-
-	struct bgp_path_info *pathinfo = NULL;
-	pathinfo = bgp_dest_get_bgp_path_info(bn);
-
 	for (bpi = bn ? bgp_dest_get_bgp_path_info(bn) : NULL; bpi;
 	     bpi = bpi->next) {
 		if (!CHECK_FLAG(bpi->flags, BGP_PATH_SELECTED))
@@ -1292,6 +1288,10 @@ static bool bmp_wrqueue_locrib(struct bmp *bmp, struct pullwr *pullwr)
 out:
 	if (!bqe->refcount)
 		XFREE(MTYPE_BMP_QUEUE, bqe);
+
+	if (bn)
+		bgp_dest_unlock_node(bn);
+
 	return written;
 }
 

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -852,7 +852,9 @@ static void bmp_eor(struct bmp *bmp, afi_t afi, safi_t safi, uint8_t flags, uint
 
 		bmp_common_hdr(s2, BMP_VERSION_3,
 				BMP_TYPE_ROUTE_MONITORING);
-		bmp_per_peer_hdr(s2, bmp->targets->bgp, peer, flags, peer_type_flag, 0, NULL);
+
+		uint64_t peerd = peer_type_flag == BMP_PEER_TYPE_LOC_RIB_INSTANCE ? bmp_get_peer_distinguisher(bmp, afi) : 0;
+		bmp_per_peer_hdr(s2, bmp->targets->bgp, peer, flags, peer_type_flag, peerd, NULL);
 
 		stream_putl_at(s2, BMP_LENGTH_POS,
 				stream_get_endp(s) + stream_get_endp(s2));

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -243,15 +243,16 @@ static void bmp_free(struct bmp *bmp)
 static uint64_t bmp_get_peer_distinguisher(struct bmp *bmp, afi_t afi)
 {
 
-	// legacy : TODO should be turned into an option at some point
-	// return bmp->targets->bgp->vrf_id;
+	/* legacy : TODO should be turned into an option at some point
+	 * return bmp->targets->bgp->vrf_id;
+	 */
 	struct bgp *bgp = bmp->targets->bgp;
 	struct prefix_rd *prd = &bgp->vpn_policy[afi].tovpn_rd;
 	/*
 	 * default vrf => can't have RD => 0
 	 * vrf => has RD?
-	 * 		if yes => use RD value
-	 * 		else => use vrf_id and convert it so that
+	 *		if yes => use RD value
+	 *		else => use vrf_id and convert it so that
 	 * peer_distinguisher is 0::vrf_id
 	 */
 	return bgp->inst_type == VRF_DEFAULT ? 0
@@ -266,7 +267,7 @@ static void bmp_common_hdr(struct stream *s, uint8_t ver, uint8_t type)
 	stream_putc(s, type);
 }
 
-static void bmp_per_peer_hdr(struct stream *s, struct peer *peer, uint8_t flags,
+static void bmp_per_peer_hdr(struct stream *s, struct bgp* bgp, struct peer *peer, uint8_t flags,
 			     uint8_t peer_type_flag,
 			     uint64_t peer_distinguisher,
 			     const struct timeval *tv)
@@ -280,6 +281,8 @@ static void bmp_per_peer_hdr(struct stream *s, struct peer *peer, uint8_t flags,
 #define BMP_PEER_FLAG_V (1 << 7)
 #define BMP_PEER_FLAG_L (1 << 6)
 #define BMP_PEER_FLAG_A (1 << 5)
+
+	bool is_locrib = peer_type_flag == BMP_PEER_TYPE_LOC_RIB_INSTANCE;
 
 	/* Peer Type */
 	stream_putc(s, peer_type_flag);
@@ -295,25 +298,32 @@ static void bmp_per_peer_hdr(struct stream *s, struct peer *peer, uint8_t flags,
 	stream_put(s, (uint8_t *)&peer_distinguisher, 8);
 
 	/* Peer Address */
-	if (peer->su.sa.sa_family == AF_INET6)
+	/* Set to 0 if it's a LOC-RIB INSTANCE (RFC 9069) or if it's not an IPv4/6 address */
+	if (is_locrib
+	    || (peer->su.sa.sa_family != AF_INET6 && peer->su.sa.sa_family != AF_INET)) {
+		stream_putl(s, 0);
+		stream_putl(s, 0);
+		stream_putl(s, 0);
+		stream_putl(s, 0);
+	} else if (peer->su.sa.sa_family == AF_INET6)
 		stream_put(s, &peer->su.sin6.sin6_addr, 16);
 	else if (peer->su.sa.sa_family == AF_INET) {
 		stream_putl(s, 0);
 		stream_putl(s, 0);
 		stream_putl(s, 0);
 		stream_put_in_addr(s, &peer->su.sin.sin_addr);
-	} else {
-		stream_putl(s, 0);
-		stream_putl(s, 0);
-		stream_putl(s, 0);
-		stream_putl(s, 0);
 	}
 
 	/* Peer AS */
-	stream_putl(s, peer->as);
+	/* set peer ASN but for LOC-RIB INSTANCE (RFC 9069) put the local bgp ASN if available or 0 */
+	as_t asn = !is_locrib ? peer->as : bgp ? bgp->as : 0L;
+	stream_putl(s, asn);
 
 	/* Peer BGP ID */
-	stream_put_in_addr(s, &peer->remote_id);
+	/* set router-id but for LOC-RIB INSTANCE (RFC 9069) put the instance router-id if available or 0 */
+	struct in_addr* bgp_id = !is_locrib ? &peer->remote_id : bgp ? &bgp->router_id : NULL;
+	zlog_info("bmp: per peer header is_locrib=%d, peer->remote_id=%pI4, bgp->router_id=%pI4, selected=%pI4", is_locrib, &peer->remote_id, &bgp->router_id, bgp_id);
+	stream_put_in_addr(s, bgp_id);
 
 	/* Timestamp */
 	if (tv) {
@@ -395,7 +405,7 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 
 		bmp_common_hdr(s, BMP_VERSION_3,
 				BMP_TYPE_PEER_UP_NOTIFICATION);
-		bmp_per_peer_hdr(s, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
+		bmp_per_peer_hdr(s, peer->bgp, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
 				 &uptime_real);
 
 		/* Local Address (16 bytes) */
@@ -449,7 +459,7 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 
 		bmp_common_hdr(s, BMP_VERSION_3,
 				BMP_TYPE_PEER_DOWN_NOTIFICATION);
-		bmp_per_peer_hdr(s, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
+		bmp_per_peer_hdr(s, peer->bgp, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
 				 &uptime_real);
 
 		type_pos = stream_get_endp(s);
@@ -640,7 +650,7 @@ static void bmp_wrmirror_lost(struct bmp *bmp, struct pullwr *pullwr)
 	s = stream_new(BGP_MAX_PACKET_SIZE);
 
 	bmp_common_hdr(s, BMP_VERSION_3, BMP_TYPE_ROUTE_MIRRORING);
-	bmp_per_peer_hdr(s, bmp->targets->bgp->peer_self, 0,
+	bmp_per_peer_hdr(s, bmp->targets->bgp, bmp->targets->bgp->peer_self, 0,
 			 BMP_PEER_TYPE_GLOBAL_INSTANCE, 0, &tv);
 
 	stream_putw(s, BMP_MIRROR_TLV_TYPE_INFO);
@@ -679,7 +689,7 @@ static bool bmp_wrmirror(struct bmp *bmp, struct pullwr *pullwr)
 	s = stream_new(BGP_MAX_PACKET_SIZE);
 
 	bmp_common_hdr(s, BMP_VERSION_3, BMP_TYPE_ROUTE_MIRRORING);
-	bmp_per_peer_hdr(s, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
+	bmp_per_peer_hdr(s, bmp->targets->bgp, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
 			 &bmq->tv);
 
 	/* BMP Mirror TLV. */
@@ -829,7 +839,7 @@ static void bmp_eor(struct bmp *bmp, afi_t afi, safi_t safi, uint8_t flags, uint
 
 		bmp_common_hdr(s2, BMP_VERSION_3,
 				BMP_TYPE_ROUTE_MONITORING);
-		bmp_per_peer_hdr(s2, peer, flags, peer_type_flag, 0, NULL);
+		bmp_per_peer_hdr(s2, bmp->targets->bgp, peer, flags, peer_type_flag, 0, NULL);
 
 		stream_putl_at(s2, BMP_LENGTH_POS,
 				stream_get_endp(s) + stream_get_endp(s2));
@@ -952,7 +962,7 @@ static void bmp_monitor(struct bmp *bmp, struct peer *peer, uint8_t flags,
 
 	hdr = stream_new(BGP_MAX_PACKET_SIZE);
 	bmp_common_hdr(hdr, BMP_VERSION_3, BMP_TYPE_ROUTE_MONITORING);
-	bmp_per_peer_hdr(hdr, peer, flags, peer_type_flags, peer_distinguisher_flag, &uptime_real);
+	bmp_per_peer_hdr(hdr, bmp->targets->bgp, peer, flags, peer_type_flags, peer_distinguisher_flag, &uptime_real);
 
 	stream_putl_at(hdr, BMP_LENGTH_POS,
 			stream_get_endp(hdr) + stream_get_endp(msg));
@@ -1533,7 +1543,7 @@ static void bmp_stats(struct event *thread)
 
 		s = stream_new(BGP_MAX_PACKET_SIZE);
 		bmp_common_hdr(s, BMP_VERSION_3, BMP_TYPE_STATISTICS_REPORT);
-		bmp_per_peer_hdr(s, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
+		bmp_per_peer_hdr(s, bt->bgp, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
 				 &tv);
 
 		count_pos = stream_get_endp(s);

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -245,45 +245,41 @@ static void bmp_free(struct bmp *bmp)
 #define BMP_PEER_TYPE_LOCAL_INSTANCE 2
 #define BMP_PEER_TYPE_LOC_RIB_INSTANCE 3
 
-static inline uint64_t bmp_get_peer_distinguisher(struct bmp *bmp, afi_t afi,
-						  uint8_t peer_type)
+static inline int bmp_get_peer_distinguisher(struct bmp *bmp, afi_t afi,
+					     uint8_t peer_type,
+					     uint64_t *result_ref)
 {
 
 	/* remove this check when the other peer types get correct peer dist.
 	 *(RFC7854) impl.
+	 * for now, always return no error and 0 peer distinguisher as before
 	 */
 	if (peer_type != BMP_PEER_TYPE_LOC_RIB_INSTANCE)
-		return 0;
+		return (*result_ref = 0);
 
 	/* sending vrf_id or rd could be turned into an option at some point */
 	struct bgp *bgp = bmp->targets->bgp;
 
-	/*  default vrf => can't have RD => 0
-	 * vrf => has RD?
-	 *		if yes => use RD value
-	 *		else => use vrf_id
-	 *			vrf_id == VRF_UNKNOWN ?
-	 *				if yes => 0
-	 *				else => convert it so that
-	 *				peer_distinguisher is 0::vrf_id
-	 */
+	/* vrf default => ok, distinguisher 0 */
 	if (bgp->inst_type == VRF_DEFAULT)
-		return 0;
+		return (*result_ref = 0);
 
+	/* use RD if set in VRF config for this AFI */
 	struct prefix_rd *prd = &bgp->vpn_policy[afi].tovpn_rd;
 
 	if (CHECK_FLAG(bgp->vpn_policy[afi].flags,
 		       BGP_VPN_POLICY_TOVPN_RD_SET)) {
-		uint64_t peerd = 0;
-
-		memcpy(&peerd, prd->val, sizeof(prd->val));
-		return peerd;
+		memcpy(result_ref, prd->val, sizeof(prd->val));
+		return 0;
 	}
 
+	/* VRF has no id => error => message should be skipped */
 	if (bgp->vrf_id == VRF_UNKNOWN)
-		return 0;
+		return 1;
 
-	return ((uint64_t)htonl(bgp->vrf_id)) << 32;
+	/* use VRF id converted to ::vrf_id 64bits format */
+	*result_ref = ((uint64_t)htonl(bgp->vrf_id)) << 32;
+	return 0;
 }
 
 static void bmp_common_hdr(struct stream *s, uint8_t ver, uint8_t type)
@@ -391,8 +387,8 @@ bmp_put_vrftablename_info_tlv(struct stream *s, struct bmp *bmp)
 static int bmp_send_initiation(struct bmp *bmp)
 {
 	int len;
-	struct stream *s;
-	s = stream_new(BGP_MAX_PACKET_SIZE);
+	struct stream *s = stream_new(BGP_MAX_PACKET_SIZE);
+
 	bmp_common_hdr(s, BMP_VERSION_3, BMP_TYPE_INITIATION);
 
 #define BMP_INFO_TYPE_SYSDESCR	1
@@ -882,15 +878,22 @@ static void bmp_eor(struct bmp *bmp, afi_t afi, safi_t safi, uint8_t flags,
 		if (!peer->afc_nego[afi][safi])
 			continue;
 
+		uint64_t peer_distinguisher = 0;
+		/* skip this message if peer distinguisher is not available */
+		if (bmp_get_peer_distinguisher(bmp, afi, peer_type_flag,
+					       &peer_distinguisher)) {
+			zlog_debug(
+				"skipping bmp message for reason: can't get peer distinguisher");
+			continue;
+		}
+
 		s2 = stream_new(BGP_MAX_PACKET_SIZE);
 
 		bmp_common_hdr(s2, BMP_VERSION_3,
 				BMP_TYPE_ROUTE_MONITORING);
 
-		bmp_per_peer_hdr(
-			s2, bmp->targets->bgp, peer, flags, peer_type_flag,
-			bmp_get_peer_distinguisher(bmp, afi, peer_type_flag),
-			NULL);
+		bmp_per_peer_hdr(s2, bmp->targets->bgp, peer, flags,
+				 peer_type_flag, peer_distinguisher, NULL);
 
 		stream_putl_at(s2, BMP_LENGTH_POS,
 				stream_get_endp(s) + stream_get_endp(s2));
@@ -1003,6 +1006,15 @@ static void bmp_monitor(struct bmp *bmp, struct peer *peer, uint8_t flags,
 	struct timeval tv = { .tv_sec = uptime, .tv_usec = 0 };
 	struct timeval uptime_real;
 
+	uint64_t peer_distinguisher = 0;
+	/* skip this message if peer distinguisher is not available */
+	if (bmp_get_peer_distinguisher(bmp, afi, peer_type_flag,
+				       &peer_distinguisher)) {
+		zlog_debug(
+			"skipping bmp message for reason: can't get peer distinguisher");
+		return;
+	}
+
 	monotime_to_realtime(&tv, &uptime_real);
 	if (attr)
 		msg = bmp_update(p, prd, peer, attr, afi, safi);
@@ -1012,7 +1024,7 @@ static void bmp_monitor(struct bmp *bmp, struct peer *peer, uint8_t flags,
 	hdr = stream_new(BGP_MAX_PACKET_SIZE);
 	bmp_common_hdr(hdr, BMP_VERSION_3, BMP_TYPE_ROUTE_MONITORING);
 	bmp_per_peer_hdr(hdr, bmp->targets->bgp, peer, flags, peer_type_flag,
-			 bmp_get_peer_distinguisher(bmp, afi, peer_type_flag),
+			 peer_distinguisher,
 			 uptime == (time_t)(-1L) ? NULL : &uptime_real);
 
 	stream_putl_at(hdr, BMP_LENGTH_POS,
@@ -1539,8 +1551,9 @@ static int bmp_process(struct bgp *bgp, afi_t afi, safi_t safi,
 			bmp_process_one(bt, &bt->updhash, &bt->updlist, bgp,
 					afi, safi, bn, peer);
 
-		// if bmp_process_one returns NULL
-		// we don't have anything to do next
+		/* if bmp_process_one returns NULL
+		 * we don't have anything to do next
+		 */
 		if (!last_item)
 			continue;
 
@@ -2809,8 +2822,10 @@ static int bmp_route_update(struct bgp *bgp, afi_t afi, safi_t safi,
 	struct bmp *bmp;
 
 	frr_each (bmp_targets, &bmpbgp->targets, bt) {
-		if ((is_locribmon_enabled |=
-		     (bt->afimon[afi][safi] & BMP_MON_LOC_RIB)))
+		is_locribmon_enabled |=
+			(bt->afimon[afi][safi] & BMP_MON_LOC_RIB);
+
+		if (is_locribmon_enabled)
 			break;
 	}
 
@@ -2836,8 +2851,9 @@ static int bmp_route_update(struct bgp *bgp, afi_t afi, safi_t safi,
 				bt, &bt->locupdhash, &bt->locupdlist, bgp, afi,
 				safi, bn, peer);
 
-			// if bmp_process_one returns NULL
-			// we don't have anything to do next
+			/* if bmp_process_one returns NULL
+			 * we don't have anything to do next
+			 */
 			if (!last_item)
 				continue;
 

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -344,6 +344,19 @@ static void bmp_put_info_tlv(struct stream *s, uint16_t type,
 	stream_put(s, string, len);
 }
 
+static void bmp_put_vrftablename_info_tlv(struct stream *s, struct bmp *bmp)
+{
+
+#define BMP_INFO_TYPE_VRFTABLENAME 3
+	char *vrftablename = "global";
+	if (bmp->targets->bgp->inst_type != BGP_INSTANCE_TYPE_DEFAULT) {
+		struct vrf *vrf = vrf_lookup_by_id(bmp->targets->bgp->vrf_id);
+		vrftablename = vrf ? vrf->name : NULL;
+	}
+	if (vrftablename != NULL)
+		bmp_put_info_tlv(s, BMP_INFO_TYPE_VRFTABLENAME, vrftablename);
+}
+
 static int bmp_send_initiation(struct bmp *bmp)
 {
 	int len;

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -240,6 +240,25 @@ static void bmp_free(struct bmp *bmp)
 	XFREE(MTYPE_BMP_CONN, bmp);
 }
 
+static uint64_t bmp_get_peer_distinguisher(struct bmp *bmp, afi_t afi)
+{
+
+	// legacy : TODO should be turned into an option at some point
+	// return bmp->targets->bgp->vrf_id;
+	struct bgp *bgp = bmp->targets->bgp;
+	struct prefix_rd *prd = &bgp->vpn_policy[afi].tovpn_rd;
+	/*
+	 * default vrf => can't have RD => 0
+	 * vrf => has RD?
+	 * 		if yes => use RD value
+	 * 		else => use vrf_id and convert it so that
+	 * peer_distinguisher is 0::vrf_id
+	 */
+	return bgp->inst_type == VRF_DEFAULT ? 0
+	       : prd			     ? *(uint64_t *)prd->val
+		     : (((uint64_t)htonl(bgp->vrf_id)) << 32);
+}
+
 static void bmp_common_hdr(struct stream *s, uint8_t ver, uint8_t type)
 {
 	stream_putc(s, ver);
@@ -247,8 +266,10 @@ static void bmp_common_hdr(struct stream *s, uint8_t ver, uint8_t type)
 	stream_putc(s, type);
 }
 
-static void bmp_per_peer_hdr(struct stream *s, struct peer *peer,
-		uint8_t flags, uint8_t peer_type_flag, uint8_t *peer_distinguisher, const struct timeval *tv)
+static void bmp_per_peer_hdr(struct stream *s, struct peer *peer, uint8_t flags,
+			     uint8_t peer_type_flag,
+			     uint64_t peer_distinguisher,
+			     const struct timeval *tv)
 {
 
 #define BMP_PEER_TYPE_GLOBAL_INSTANCE 0
@@ -271,9 +292,7 @@ static void bmp_per_peer_hdr(struct stream *s, struct peer *peer,
 	stream_putc(s, flags);
 
 	/* Peer Distinguisher */
-	uint8_t empty_peer_distinguisher[8] = {0};
-	uint64_t peerd = *(uint64_t*)(peer_distinguisher ? peer_distinguisher : empty_peer_distinguisher);
-	stream_putq(s, peerd);
+	stream_put(s, (uint8_t *)&peer_distinguisher, 8);
 
 	/* Peer Address */
 	if (peer->su.sa.sa_family == AF_INET6)
@@ -376,7 +395,8 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 
 		bmp_common_hdr(s, BMP_VERSION_3,
 				BMP_TYPE_PEER_UP_NOTIFICATION);
-		bmp_per_peer_hdr(s, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, NULL, &uptime_real);
+		bmp_per_peer_hdr(s, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
+				 &uptime_real);
 
 		/* Local Address (16 bytes) */
 		if (peer->su_local->sa.sa_family == AF_INET6)
@@ -429,7 +449,8 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 
 		bmp_common_hdr(s, BMP_VERSION_3,
 				BMP_TYPE_PEER_DOWN_NOTIFICATION);
-		bmp_per_peer_hdr(s, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, NULL, &uptime_real);
+		bmp_per_peer_hdr(s, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
+				 &uptime_real);
 
 		type_pos = stream_get_endp(s);
 		stream_putc(s, 0);	/* placeholder for down reason */
@@ -619,7 +640,8 @@ static void bmp_wrmirror_lost(struct bmp *bmp, struct pullwr *pullwr)
 	s = stream_new(BGP_MAX_PACKET_SIZE);
 
 	bmp_common_hdr(s, BMP_VERSION_3, BMP_TYPE_ROUTE_MIRRORING);
-	bmp_per_peer_hdr(s, bmp->targets->bgp->peer_self, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, NULL, &tv);
+	bmp_per_peer_hdr(s, bmp->targets->bgp->peer_self, 0,
+			 BMP_PEER_TYPE_GLOBAL_INSTANCE, 0, &tv);
 
 	stream_putw(s, BMP_MIRROR_TLV_TYPE_INFO);
 	stream_putw(s, 2);
@@ -657,7 +679,8 @@ static bool bmp_wrmirror(struct bmp *bmp, struct pullwr *pullwr)
 	s = stream_new(BGP_MAX_PACKET_SIZE);
 
 	bmp_common_hdr(s, BMP_VERSION_3, BMP_TYPE_ROUTE_MIRRORING);
-	bmp_per_peer_hdr(s, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, NULL, &bmq->tv);
+	bmp_per_peer_hdr(s, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
+			 &bmq->tv);
 
 	/* BMP Mirror TLV. */
 	stream_putw(s, BMP_MIRROR_TLV_TYPE_BGP_MESSAGE);
@@ -806,7 +829,7 @@ static void bmp_eor(struct bmp *bmp, afi_t afi, safi_t safi, uint8_t flags, uint
 
 		bmp_common_hdr(s2, BMP_VERSION_3,
 				BMP_TYPE_ROUTE_MONITORING);
-		bmp_per_peer_hdr(s2, peer, flags, peer_type_flag, NULL, NULL);
+		bmp_per_peer_hdr(s2, peer, flags, peer_type_flag, 0, NULL);
 
 		stream_putl_at(s2, BMP_LENGTH_POS,
 				stream_get_endp(s) + stream_get_endp(s2));
@@ -912,7 +935,7 @@ static struct stream *bmp_withdraw(const struct prefix *p,
 
 static void bmp_monitor(struct bmp *bmp, struct peer *peer, uint8_t flags,
 			uint8_t peer_type_flags,
-			uint8_t *peer_distinguisher_flag,
+			uint64_t peer_distinguisher_flag,
 			const struct prefix *p, struct prefix_rd *prd,
 			struct attr *attr, afi_t afi, safi_t safi,
 			time_t uptime)
@@ -1110,29 +1133,22 @@ afibreak:
 	    (safi == SAFI_MPLS_VPN))
 		prd = (struct prefix_rd *)bgp_dest_get_prefix(bmp->syncrdpos);
 
-	if (bpi && CHECK_FLAG(bpi->flags, BGP_PATH_SELECTED)
-	    && CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_LOC_RIB)) {
-		uint8_t peer_distinguisher[8] = {0};
-		if (bmp->targets->bgp->inst_type != VRF_DEFAULT) {
-			memcpy(peer_distinguisher,
-			       &bmp->targets->bgp->vrf_id,
-			       sizeof(vrf_id_t));
-		}
-
-		bmp_monitor(bmp, bpi->peer, 0,
-			    BMP_PEER_TYPE_LOC_RIB_INSTANCE, peer_distinguisher, bn_p,
-			    prd, bpi->attr, afi, safi, bpi->uptime);
+	if (bpi && CHECK_FLAG(bpi->flags, BGP_PATH_SELECTED) &&
+	    CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_LOC_RIB)) {
+		bmp_monitor(bmp, bpi->peer, 0, BMP_PEER_TYPE_LOC_RIB_INSTANCE,
+			    bmp_get_peer_distinguisher(bmp, afi), bn_p, prd,
+			    bpi->attr, afi, safi, bpi->uptime);
 	}
 
 	if (bpi && CHECK_FLAG(bpi->flags, BGP_PATH_VALID)
 	    && CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_POSTPOLICY))
 		bmp_monitor(bmp, bpi->peer, BMP_PEER_FLAG_L,
-			    BMP_PEER_TYPE_GLOBAL_INSTANCE, NULL, bn_p,
-			    prd, bpi->attr, afi, safi, bpi->uptime);
+			    BMP_PEER_TYPE_GLOBAL_INSTANCE, 0, bn_p, prd,
+			    bpi->attr, afi, safi, bpi->uptime);
 
 	if (adjin)
 		bmp_monitor(bmp, adjin->peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE,
-			    NULL, bn_p, prd, adjin->attr, afi, safi,
+			    0, bn_p, prd, adjin->attr, afi, safi,
 			    adjin->uptime);
 
 	if (bn)
@@ -1275,14 +1291,10 @@ static bool bmp_wrqueue_locrib(struct bmp *bmp, struct pullwr *pullwr)
 			break;
 	}
 
-	uint8_t peer_distinguisher[8] = {0};
-	if (bmp->targets->bgp->inst_type != VRF_DEFAULT) {
-		memcpy(peer_distinguisher, &bmp->targets->bgp->vrf_id, sizeof(vrf_id_t));
-	}
-
-	bmp_monitor(bmp, peer, 0, BMP_PEER_TYPE_LOC_RIB_INSTANCE, peer_distinguisher,
-		    &bqe->p, prd, bpi ? bpi->attr : NULL,
-		    afi, safi, bpi ? bpi->uptime : monotime(NULL));
+	bmp_monitor(bmp, peer, 0, BMP_PEER_TYPE_LOC_RIB_INSTANCE,
+		    bmp_get_peer_distinguisher(bmp, afi), &bqe->p, prd,
+		    bpi ? bpi->attr : NULL, afi, safi,
+		    bpi ? bpi->uptime : monotime(NULL));
 	written = true;
 
 out:
@@ -1351,7 +1363,7 @@ static bool bmp_wrqueue(struct bmp *bmp, struct pullwr *pullwr)
 		}
 
 		bmp_monitor(bmp, peer, BMP_PEER_FLAG_L,
-			    BMP_PEER_TYPE_GLOBAL_INSTANCE, NULL, &bqe->p, prd,
+			    BMP_PEER_TYPE_GLOBAL_INSTANCE, 0, &bqe->p, prd,
 			    bpi ? bpi->attr : NULL, afi, safi,
 			    bpi ? bpi->uptime : monotime(NULL));
 		written = true;
@@ -1365,7 +1377,7 @@ static bool bmp_wrqueue(struct bmp *bmp, struct pullwr *pullwr)
 			if (adjin->peer == peer)
 				break;
 		}
-		bmp_monitor(bmp, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, NULL,
+		bmp_monitor(bmp, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
 			    &bqe->p, prd, adjin ? adjin->attr : NULL, afi, safi,
 			    adjin ? adjin->uptime : monotime(NULL));
 		written = true;
@@ -1521,7 +1533,8 @@ static void bmp_stats(struct event *thread)
 
 		s = stream_new(BGP_MAX_PACKET_SIZE);
 		bmp_common_hdr(s, BMP_VERSION_3, BMP_TYPE_STATISTICS_REPORT);
-		bmp_per_peer_hdr(s, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, NULL, &tv);
+		bmp_per_peer_hdr(s, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
+				 &tv);
 
 		count_pos = stream_get_endp(s);
 		stream_putl(s, 0);

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1163,7 +1163,7 @@ afibreak:
 	    CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_LOC_RIB)) {
 		bmp_monitor(bmp, bpi->peer, 0, BMP_PEER_TYPE_LOC_RIB_INSTANCE,
 			    bmp_get_peer_distinguisher(bmp, afi), bn_p, prd,
-			    bpi->attr, afi, safi, bpi->uptime);
+			    bpi->attr, afi, safi, bpi->rib_uptime);
 	}
 
 	if (bpi && CHECK_FLAG(bpi->flags, BGP_PATH_VALID)
@@ -1320,7 +1320,7 @@ static bool bmp_wrqueue_locrib(struct bmp *bmp, struct pullwr *pullwr)
 	bmp_monitor(bmp, peer, 0, BMP_PEER_TYPE_LOC_RIB_INSTANCE,
 		    bmp_get_peer_distinguisher(bmp, afi), &bqe->p, prd,
 		    bpi ? bpi->attr : NULL, afi, safi,
-		    bpi ? bpi->uptime : monotime(NULL));
+		    bpi ? bpi->rib_uptime : monotime(NULL));
 	written = true;
 
 out:

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -241,19 +241,22 @@ static void bmp_free(struct bmp *bmp)
 }
 
 #define BMP_PEER_TYPE_GLOBAL_INSTANCE 0
-#define BMP_PEER_TYPE_RD_INSTANCE     1
-#define BMP_PEER_TYPE_LOCAL_INSTANCE  2
+#define BMP_PEER_TYPE_RD_INSTANCE 1
+#define BMP_PEER_TYPE_LOCAL_INSTANCE 2
 #define BMP_PEER_TYPE_LOC_RIB_INSTANCE 3
 
-static inline uint64_t bmp_get_peer_distinguisher(struct bmp* bmp, afi_t afi, uint8_t peer_type) {
+static inline uint64_t bmp_get_peer_distinguisher(struct bmp *bmp, afi_t afi,
+						  uint8_t peer_type)
+{
 
-	/* remove this check when the other peer types get correct peer dist. (RFC7854) impl. */
+	/* remove this check when the other peer types get correct peer dist.
+	// (RFC7854) impl. */
 	if (peer_type != BMP_PEER_TYPE_LOC_RIB_INSTANCE)
 		return 0;
 
 	/* sending vrf_id or rd could be turned into an option at some point */
-	struct bgp* bgp = bmp->targets->bgp;
-	struct prefix_rd* prd = &bgp->vpn_policy[afi].tovpn_rd;
+	struct bgp *bgp = bmp->targets->bgp;
+	struct prefix_rd *prd = &bgp->vpn_policy[afi].tovpn_rd;
 	/*
 	 * default vrf => can't have RD => 0
 	 * vrf => has RD?
@@ -261,9 +264,10 @@ static inline uint64_t bmp_get_peer_distinguisher(struct bmp* bmp, afi_t afi, ui
 	 *		else => use vrf_id and convert it so that
 	 * peer_distinguisher is 0::vrf_id
 	 */
-	return bgp->inst_type == VRF_DEFAULT ? 0
-	       : prd			     ? *(uint64_t *)prd->val
-		     : (((uint64_t)htonl(bgp->vrf_id)) << 32);
+	return bgp->inst_type == VRF_DEFAULT
+		       ? 0
+		       : prd ? *(uint64_t *)prd->val
+			     : (((uint64_t)htonl(bgp->vrf_id)) << 32);
 }
 
 static void bmp_common_hdr(struct stream *s, uint8_t ver, uint8_t type)
@@ -273,7 +277,8 @@ static void bmp_common_hdr(struct stream *s, uint8_t ver, uint8_t type)
 	stream_putc(s, type);
 }
 
-static void bmp_per_peer_hdr(struct stream *s, struct bgp* bgp, struct peer *peer, uint8_t flags,
+static void bmp_per_peer_hdr(struct stream *s, struct bgp *bgp,
+			     struct peer *peer, uint8_t flags,
 			     uint8_t peer_type_flag,
 			     uint64_t peer_distinguisher,
 			     const struct timeval *tv)
@@ -298,9 +303,10 @@ static void bmp_per_peer_hdr(struct stream *s, struct bgp* bgp, struct peer *pee
 	stream_put(s, (uint8_t *)&peer_distinguisher, 8);
 
 	/* Peer Address */
-	/* Set to 0 if it's a LOC-RIB INSTANCE (RFC 9069) or if it's not an IPv4/6 address */
-	if (is_locrib
-	    || (peer->su.sa.sa_family != AF_INET6 && peer->su.sa.sa_family != AF_INET)) {
+	/* Set to 0 if it's a LOC-RIB INSTANCE (RFC 9069) or if it's not an
+	 * IPv4/6 address */
+	if (is_locrib || (peer->su.sa.sa_family != AF_INET6 &&
+			  peer->su.sa.sa_family != AF_INET)) {
 		stream_putl(s, 0);
 		stream_putl(s, 0);
 		stream_putl(s, 0);
@@ -315,13 +321,16 @@ static void bmp_per_peer_hdr(struct stream *s, struct bgp* bgp, struct peer *pee
 	}
 
 	/* Peer AS */
-	/* set peer ASN but for LOC-RIB INSTANCE (RFC 9069) put the local bgp ASN if available or 0 */
+	/* set peer ASN but for LOC-RIB INSTANCE (RFC 9069) put the local bgp
+	 * ASN if available or 0 */
 	as_t asn = !is_locrib ? peer->as : bgp ? bgp->as : 0L;
 	stream_putl(s, asn);
 
 	/* Peer BGP ID */
-	/* set router-id but for LOC-RIB INSTANCE (RFC 9069) put the instance router-id if available or 0 */
-	struct in_addr* bgp_id = !is_locrib ? &peer->remote_id : bgp ? &bgp->router_id : NULL;
+	/* set router-id but for LOC-RIB INSTANCE (RFC 9069) put the instance
+	 * router-id if available or 0 */
+	struct in_addr *bgp_id =
+		!is_locrib ? &peer->remote_id : bgp ? &bgp->router_id : NULL;
 	stream_put_in_addr(s, bgp_id);
 
 	/* Timestamp */
@@ -344,11 +353,12 @@ static void bmp_put_info_tlv(struct stream *s, uint16_t type,
 	stream_put(s, string, len);
 }
 
-static void bmp_put_vrftablename_info_tlv(struct stream *s, struct bmp *bmp)
+static void __attribute__((unused))
+bmp_put_vrftablename_info_tlv(struct stream *s, struct bmp *bmp)
 {
 
 #define BMP_INFO_TYPE_VRFTABLENAME 3
-	char *vrftablename = "global";
+	const char *vrftablename = "global";
 	if (bmp->targets->bgp->inst_type != BGP_INSTANCE_TYPE_DEFAULT) {
 		struct vrf *vrf = vrf_lookup_by_id(bmp->targets->bgp->vrf_id);
 		vrftablename = vrf ? vrf->name : NULL;
@@ -418,7 +428,8 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 
 		bmp_common_hdr(s, BMP_VERSION_3,
 				BMP_TYPE_PEER_UP_NOTIFICATION);
-		bmp_per_peer_hdr(s, peer->bgp, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
+		bmp_per_peer_hdr(s, peer->bgp, peer, 0,
+				 BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
 				 &uptime_real);
 
 		/* Local Address (16 bytes) */
@@ -472,7 +483,8 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 
 		bmp_common_hdr(s, BMP_VERSION_3,
 				BMP_TYPE_PEER_DOWN_NOTIFICATION);
-		bmp_per_peer_hdr(s, peer->bgp, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
+		bmp_per_peer_hdr(s, peer->bgp, peer, 0,
+				 BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
 				 &uptime_real);
 
 		type_pos = stream_get_endp(s);
@@ -702,7 +714,8 @@ static bool bmp_wrmirror(struct bmp *bmp, struct pullwr *pullwr)
 	s = stream_new(BGP_MAX_PACKET_SIZE);
 
 	bmp_common_hdr(s, BMP_VERSION_3, BMP_TYPE_ROUTE_MIRRORING);
-	bmp_per_peer_hdr(s, bmp->targets->bgp, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
+	bmp_per_peer_hdr(s, bmp->targets->bgp, peer, 0,
+			 BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
 			 &bmq->tv);
 
 	/* BMP Mirror TLV. */
@@ -808,7 +821,8 @@ static int bmp_peer_backward(struct peer *peer)
 	return 0;
 }
 
-static void bmp_eor(struct bmp *bmp, afi_t afi, safi_t safi, uint8_t flags, uint8_t peer_type_flag)
+static void bmp_eor(struct bmp *bmp, afi_t afi, safi_t safi, uint8_t flags,
+		    uint8_t peer_type_flag)
 {
 	struct peer *peer;
 	struct listnode *node;
@@ -853,7 +867,10 @@ static void bmp_eor(struct bmp *bmp, afi_t afi, safi_t safi, uint8_t flags, uint
 		bmp_common_hdr(s2, BMP_VERSION_3,
 				BMP_TYPE_ROUTE_MONITORING);
 
-		bmp_per_peer_hdr(s2, bmp->targets->bgp, peer, flags, peer_type_flag, bmp_get_peer_distinguisher(bmp, afi, peer_type_flag), NULL);
+		bmp_per_peer_hdr(
+			s2, bmp->targets->bgp, peer, flags, peer_type_flag,
+			bmp_get_peer_distinguisher(bmp, afi, peer_type_flag),
+			NULL);
 
 		stream_putl_at(s2, BMP_LENGTH_POS,
 				stream_get_endp(s) + stream_get_endp(s2));
@@ -958,10 +975,9 @@ static struct stream *bmp_withdraw(const struct prefix *p,
 }
 
 static void bmp_monitor(struct bmp *bmp, struct peer *peer, uint8_t flags,
-			uint8_t peer_type_flag,
-			const struct prefix *p, struct prefix_rd *prd,
-			struct attr *attr, afi_t afi, safi_t safi,
-			time_t uptime)
+			uint8_t peer_type_flag, const struct prefix *p,
+			struct prefix_rd *prd, struct attr *attr, afi_t afi,
+			safi_t safi, time_t uptime)
 {
 	struct stream *hdr, *msg;
 	struct timeval tv = { .tv_sec = uptime, .tv_usec = 0 };
@@ -975,7 +991,9 @@ static void bmp_monitor(struct bmp *bmp, struct peer *peer, uint8_t flags,
 
 	hdr = stream_new(BGP_MAX_PACKET_SIZE);
 	bmp_common_hdr(hdr, BMP_VERSION_3, BMP_TYPE_ROUTE_MONITORING);
-	bmp_per_peer_hdr(hdr, bmp->targets->bgp, peer, flags, peer_type_flag, bmp_get_peer_distinguisher(bmp, afi, peer_type_flag), &uptime_real);
+	bmp_per_peer_hdr(hdr, bmp->targets->bgp, peer, flags, peer_type_flag,
+			 bmp_get_peer_distinguisher(bmp, afi, peer_type_flag),
+			 &uptime_real);
 
 	stream_putl_at(hdr, BMP_LENGTH_POS,
 			stream_get_endp(hdr) + stream_get_endp(msg));
@@ -1087,9 +1105,12 @@ afibreak:
 						bmp->remote, afi2str(afi),
 						safi2str(safi));
 
-				bmp_eor(bmp, afi, safi, BMP_PEER_FLAG_L, BMP_PEER_TYPE_GLOBAL_INSTANCE);
-				bmp_eor(bmp, afi, safi, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE);
-				bmp_eor(bmp, afi, safi, 0, BMP_PEER_TYPE_LOC_RIB_INSTANCE);
+				bmp_eor(bmp, afi, safi, BMP_PEER_FLAG_L,
+					BMP_PEER_TYPE_GLOBAL_INSTANCE);
+				bmp_eor(bmp, afi, safi, 0,
+					BMP_PEER_TYPE_GLOBAL_INSTANCE);
+				bmp_eor(bmp, afi, safi, 0,
+					BMP_PEER_TYPE_LOC_RIB_INSTANCE);
 
 				bmp->afistate[afi][safi] = BMP_AFI_LIVE;
 				bmp->syncafi = AFI_MAX;
@@ -1100,12 +1121,14 @@ afibreak:
 			prefix_copy(&bmp->syncpos, bgp_dest_get_prefix(bn));
 		}
 
-		if (bmp->targets->afimon[afi][safi] & BMP_MON_POSTPOLICY
-		    || bmp->targets->afimon[afi][safi] & BMP_MON_LOC_RIB) {
+		if (bmp->targets->afimon[afi][safi] & BMP_MON_POSTPOLICY ||
+		    bmp->targets->afimon[afi][safi] & BMP_MON_LOC_RIB) {
 			for (bpiter = bgp_dest_get_bgp_path_info(bn); bpiter;
 			     bpiter = bpiter->next) {
-				if (!CHECK_FLAG(bpiter->flags, BGP_PATH_VALID)
-				    && !CHECK_FLAG(bpiter->flags, BGP_PATH_SELECTED))
+				if (!CHECK_FLAG(bpiter->flags,
+						BGP_PATH_VALID) &&
+				    !CHECK_FLAG(bpiter->flags,
+						BGP_PATH_SELECTED))
 					continue;
 				if (bpiter->peer->qobj_node.nid
 				    <= bmp->syncpeerid)
@@ -1156,21 +1179,20 @@ afibreak:
 
 	if (bpi && CHECK_FLAG(bpi->flags, BGP_PATH_SELECTED) &&
 	     CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_LOC_RIB)) {
-		bmp_monitor(bmp, bpi->peer, 0,
-			    BMP_PEER_TYPE_LOC_RIB_INSTANCE, bn_p, prd,
-			    bpi->attr, afi, safi, bpi->rib_uptime);
+		bmp_monitor(bmp, bpi->peer, 0, BMP_PEER_TYPE_LOC_RIB_INSTANCE,
+			    bn_p, prd, bpi->attr, afi, safi, bpi->rib_uptime);
 	}
 
-	if (bpi && CHECK_FLAG(bpi->flags, BGP_PATH_VALID)
-	    && CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_POSTPOLICY))
+	if (bpi && CHECK_FLAG(bpi->flags, BGP_PATH_VALID) &&
+	    CHECK_FLAG(bmp->targets->afimon[afi][safi], BMP_MON_POSTPOLICY))
 		bmp_monitor(bmp, bpi->peer, BMP_PEER_FLAG_L,
 			    BMP_PEER_TYPE_GLOBAL_INSTANCE, bn_p, prd,
-			    bpi->attr, afi, safi, bpi->uptime);
+			    bpi->attr,
+			    afi, safi, bpi->uptime);
 
 	if (adjin)
 		bmp_monitor(bmp, adjin->peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE,
-			    bn_p, prd, adjin->attr, afi, safi,
-			    adjin->uptime);
+			    bn_p, prd, adjin->attr, afi, safi, adjin->uptime);
 
 	if (bn)
 		bgp_dest_unlock_node(bn);
@@ -1280,9 +1302,9 @@ static bool bmp_wrqueue_locrib(struct bmp *bmp, struct pullwr *pullwr)
 			break;
 	}
 
-	bmp_monitor(bmp, peer, 0, BMP_PEER_TYPE_LOC_RIB_INSTANCE,
-		    &bqe->p, prd, bpi ? bpi->attr : NULL,
-		    afi, safi, bpi ? bpi->rib_uptime : monotime(NULL));
+	bmp_monitor(bmp, peer, 0, BMP_PEER_TYPE_LOC_RIB_INSTANCE, &bqe->p, prd,
+		    bpi ? bpi->attr : NULL, afi, safi,
+		    bpi ? bpi->rib_uptime : monotime(NULL));
 	written = true;
 
 out:
@@ -1417,16 +1439,17 @@ static void bmp_wrerr(struct bmp *bmp, struct pullwr *pullwr, bool eof)
 	bmp_free(bmp);
 }
 
-static struct bmp_queue_entry* bmp_process_one(struct bmp_targets *bt, struct bmp_qhash_head* updhash, struct bmp_qlist_head* updlist, struct bgp *bgp, afi_t afi,
-			    safi_t safi, struct bgp_dest *bn, struct peer *peer)
+static struct bmp_queue_entry *
+bmp_process_one(struct bmp_targets *bt, struct bmp_qhash_head *updhash,
+		struct bmp_qlist_head *updlist, struct bgp *bgp, afi_t afi,
+		safi_t safi, struct bgp_dest *bn, struct peer *peer)
 {
-	struct bmp *bmp;
 	struct bmp_queue_entry *bqe, bqeref;
 	size_t refcount;
 
 	refcount = bmp_session_count(&bt->sessions);
 	if (refcount == 0)
-		return;
+		return NULL;
 
 	memset(&bqeref, 0, sizeof(bqeref));
 	prefix_copy(&bqeref.p, bgp_dest_get_prefix(bn));
@@ -1443,7 +1466,7 @@ static struct bmp_queue_entry* bmp_process_one(struct bmp_targets *bt, struct bm
 	if (bqe) {
 		if (bqe->refcount >= refcount)
 			/* nothing to do here */
-			return;
+			return NULL;
 
 		bmp_qlist_del(updlist, bqe);
 	} else {
@@ -1458,7 +1481,8 @@ static struct bmp_queue_entry* bmp_process_one(struct bmp_targets *bt, struct bm
 
 	return bqe;
 
-	/* need to update correct queue pos for all sessions of the target after a call to this function */
+	/* need to update correct queue pos for all sessions of the target after
+	 * a call to this function */
 }
 
 static int bmp_process(struct bgp *bgp, afi_t afi, safi_t safi,
@@ -1480,11 +1504,18 @@ static int bmp_process(struct bgp *bgp, afi_t afi, safi_t safi,
 		return 0;
 
 	frr_each(bmp_targets, &bmpbgp->targets, bt) {
-		/* check if any monitoring is enabled (ignoring loc-rib since it uses another hook & queue */
+		/* check if any monitoring is enabled (ignoring loc-rib since it
+		 * uses another hook & queue */
 		if (!(bt->afimon[afi][safi] & ~BMP_MON_LOC_RIB))
 			continue;
 
-		struct bmp_queue_entry* last_item = bmp_process_one(bt, &bt->updhash, &bt->updlist, bgp, afi, safi, bn, peer);
+		struct bmp_queue_entry *last_item =
+			bmp_process_one(bt, &bt->updhash, &bt->updlist, bgp,
+					afi, safi, bn, peer);
+
+		if (!last_item) // if bmp_process_one returns NULL we don't have
+				// anything to do next
+			continue;
 
 		frr_each(bmp_session, &bt->sessions, bmp) {
 			if (!bmp->queuepos)
@@ -1528,7 +1559,8 @@ static void bmp_stats(struct event *thread)
 
 		s = stream_new(BGP_MAX_PACKET_SIZE);
 		bmp_common_hdr(s, BMP_VERSION_3, BMP_TYPE_STATISTICS_REPORT);
-		bmp_per_peer_hdr(s, bt->bgp, peer, 0, BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
+		bmp_per_peer_hdr(s, bt->bgp, peer, 0,
+				 BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
 				 &tv);
 
 		count_pos = stream_get_endp(s);
@@ -2382,8 +2414,7 @@ DEFPY(bmp_stats_cfg,
 	return CMD_SUCCESS;
 }
 
-DEFPY(bmp_monitor_cfg,
-      bmp_monitor_cmd,
+DEFPY(bmp_monitor_cfg, bmp_monitor_cmd,
       "[no] bmp monitor <ipv4|ipv6|l2vpn> <unicast|multicast|evpn|vpn> <pre-policy|post-policy|loc-rib>$policy",
       NO_STR BMP_STR
       "Send BMP route monitoring messages\n" BGP_AF_STR BGP_AF_STR BGP_AF_STR
@@ -2742,18 +2773,21 @@ static int bmp_route_update(struct bgp *bgp, afi_t afi, safi_t safi,
 			    struct bgp_path_info *updated_route, bool withdraw)
 {
 
-	struct bmp_bgp* bmpbgp = bmp_bgp_get(bgp);
+	struct bmp_bgp *bmpbgp = bmp_bgp_get(bgp);
 	struct peer *peer = updated_route->peer;
-	const struct prefix *prefix = bgp_dest_get_prefix(updated_route->net);
 	struct bmp_targets *bt;
 	struct bmp *bmp;
 
-	afi_t afi_iter;
-	safi_t safi_iter;
-	frr_each(bmp_targets, &bmpbgp->targets, bt) {
+	frr_each (bmp_targets, &bmpbgp->targets, bt) {
 		if (bt->afimon[afi][safi] & BMP_MON_LOC_RIB) {
 
-			struct bmp_queue_entry *last_item = bmp_process_one(bt, &bt->locupdhash, &bt->locupdlist, bgp, afi, safi, bn, peer);
+			struct bmp_queue_entry *last_item = bmp_process_one(
+				bt, &bt->locupdhash, &bt->locupdlist, bgp, afi,
+				safi, bn, peer);
+
+			if (!last_item) // if bmp_process_one returns NULL we
+					// don't have anything to do next
+				continue;
 
 			frr_each (bmp_session, &bt->sessions, bmp) {
 				if (!bmp->locrib_queuepos)

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -326,7 +326,8 @@ static void bmp_per_peer_hdr(struct stream *s, struct bgp* bgp, struct peer *pee
 	stream_put_in_addr(s, bgp_id);
 
 	/* Timestamp */
-	if (tv) {
+	/* set to 0 for LOC-RIB INSTANCE as install uptime is not saved atm */
+	if (!is_locrib && tv) {
 		stream_putl(s, tv->tv_sec);
 		stream_putl(s, tv->tv_usec);
 	} else {

--- a/bgpd/bgp_bmp.h
+++ b/bgpd/bgp_bmp.h
@@ -223,7 +223,7 @@ struct bmp_targets {
 #define BMP_MON_PREPOLICY	(1 << 0)
 #define BMP_MON_POSTPOLICY	(1 << 1)
 
-// TODO define BMP_MON_LOC_RIB flag
+/* TODO define BMP_MON_LOC_RIB flag */
 #define BMP_MON_LOC_RIB (1 << 2)
 	uint8_t afimon[AFI_MAX][SAFI_MAX];
 	bool mirror;

--- a/bgpd/bgp_bmp.h
+++ b/bgpd/bgp_bmp.h
@@ -124,6 +124,7 @@ struct bmp {
 	 * ahead we need to make sure that refcount is decremented.  Also, on
 	 * disconnects we need to walk the queue and drop our reference.
 	 */
+	struct bmp_queue_entry *locrib_queuepos;
 	struct bmp_queue_entry *queuepos;
 	struct bmp_mirrorq *mirrorpos;
 	bool mirror_lost;
@@ -221,6 +222,9 @@ struct bmp_targets {
 	 */
 #define BMP_MON_PREPOLICY	(1 << 0)
 #define BMP_MON_POSTPOLICY	(1 << 1)
+
+// TODO define BMP_MON_LOC_RIB flag
+#define BMP_MON_LOC_RIB (1 << 2)
 	uint8_t afimon[AFI_MAX][SAFI_MAX];
 	bool mirror;
 
@@ -231,6 +235,9 @@ struct bmp_targets {
 
 	struct bmp_qhash_head updhash;
 	struct bmp_qlist_head updlist;
+
+	struct bmp_qhash_head locupdhash;
+	struct bmp_qlist_head locupdlist;
 
 	uint64_t cnt_accept, cnt_aclrefused;
 

--- a/bgpd/bgp_bmp.h
+++ b/bgpd/bgp_bmp.h
@@ -216,15 +216,14 @@ struct bmp_targets {
 	int stat_msec;
 
 	/* only supporting:
-	 * - IPv4 / unicast & multicast
-	 * - IPv6 / unicast & multicast
+	 * - IPv4 / unicast & multicast & VPN
+	 * - IPv6 / unicast & multicast & VPN
 	 * - L2VPN / EVPN
 	 */
 #define BMP_MON_PREPOLICY	(1 << 0)
 #define BMP_MON_POSTPOLICY	(1 << 1)
-
-/* TODO define BMP_MON_LOC_RIB flag */
 #define BMP_MON_LOC_RIB (1 << 2)
+
 	uint8_t afimon[AFI_MAX][SAFI_MAX];
 	bool mirror;
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -85,6 +85,11 @@ DEFINE_HOOK(bgp_rpki_prefix_status,
 	     const struct prefix *prefix),
 	    (peer, attr, prefix));
 
+DEFINE_HOOK(bgp_route_update,
+	    (struct bgp * bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
+	     struct bgp_path_info *updated_route, bool withdraw),
+	    (bgp, afi, safi, bn, updated_route, withdraw));
+
 /* Extern from bgp_dump.c */
 extern const char *bgp_origin_str[];
 extern const char *bgp_origin_long_str[];
@@ -3432,6 +3437,7 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 				&bgp->t_rmap_def_originate_eval);
 	}
 
+	// TODO BMP insert rib update hook
 	if (old_select)
 		bgp_path_info_unset_flag(dest, old_select, BGP_PATH_SELECTED);
 	if (new_select) {
@@ -3443,6 +3449,16 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 		UNSET_FLAG(new_select->flags, BGP_PATH_MULTIPATH_CHG);
 		UNSET_FLAG(new_select->flags, BGP_PATH_LINK_BW_CHG);
 	}
+
+	if (old_select || new_select) {
+		zlog_info("old_select==NULL %s | new_select==NULL %s",
+			  old_select == NULL ? "YES" : "NO",
+			  new_select == NULL ? "YES" : "NO");
+		bool is_withdraw = old_select && !new_select;
+		hook_call(bgp_route_update, bgp, afi, safi, dest,
+			  is_withdraw ? old_select : new_select, is_withdraw);
+	}
+
 
 #ifdef ENABLE_BGP_VNC
 	if ((afi == AFI_IP || afi == AFI_IP6) && (safi == SAFI_UNICAST)) {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -86,7 +86,7 @@ DEFINE_HOOK(bgp_rpki_prefix_status,
 	    (peer, attr, prefix));
 
 DEFINE_HOOK(bgp_route_update,
-	    (struct bgp * bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
+	    (struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
 	     struct bgp_path_info *updated_route, bool withdraw),
 	    (bgp, afi, safi, bn, updated_route, withdraw));
 
@@ -3437,7 +3437,7 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 				&bgp->t_rmap_def_originate_eval);
 	}
 
-	// TODO BMP insert rib update hook
+	/* TODO BMP insert rib update hook */
 	if (old_select)
 		bgp_path_info_unset_flag(dest, old_select, BGP_PATH_SELECTED);
 	if (new_select) {
@@ -3455,6 +3455,7 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 			  old_select == NULL ? "YES" : "NO",
 			  new_select == NULL ? "YES" : "NO");
 		bool is_withdraw = old_select && !new_select;
+
 		hook_call(bgp_route_update, bgp, afi, safi, dest,
 			  is_withdraw ? old_select : new_select, is_withdraw);
 	}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3450,7 +3450,8 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 		UNSET_FLAG(new_select->flags, BGP_PATH_LINK_BW_CHG);
 	}
 
-	/* call bmp hook for loc-rib route update / withdraw after flags were set */
+	/* call bmp hook for loc-rib route update / withdraw after flags were
+	 * set */
 	if (old_select || new_select) {
 
 		if (old_select) /* route is not installed in locrib anymore */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3454,6 +3454,11 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 		zlog_info("old_select==NULL %s | new_select==NULL %s",
 			  old_select == NULL ? "YES" : "NO",
 			  new_select == NULL ? "YES" : "NO");
+
+		if (old_select) /* route is not installed in locrib anymore */
+			old_select->rib_uptime = (time_t)(-1L);
+		if (new_select) /* route is installed in locrib from now on */
+			new_select->rib_uptime = bgp_clock();
 		bool is_withdraw = old_select && !new_select;
 
 		hook_call(bgp_route_update, bgp, afi, safi, dest,
@@ -3986,6 +3991,7 @@ struct bgp_path_info *info_make(int type, int sub_type, unsigned short instance,
 	new->peer = peer;
 	new->attr = attr;
 	new->uptime = monotime(NULL);
+	new->rib_uptime = (time_t)(-1L);
 	new->net = dest;
 	return new;
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3450,10 +3450,8 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 		UNSET_FLAG(new_select->flags, BGP_PATH_LINK_BW_CHG);
 	}
 
+	/* call bmp hook for loc-rib route update / withdraw after flags were set */
 	if (old_select || new_select) {
-		zlog_info("old_select==NULL %s | new_select==NULL %s",
-			  old_select == NULL ? "YES" : "NO",
-			  new_select == NULL ? "YES" : "NO");
 
 		if (old_select) /* route is not installed in locrib anymore */
 			old_select->rib_uptime = (time_t)(-1L);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -87,8 +87,8 @@ DEFINE_HOOK(bgp_rpki_prefix_status,
 
 DEFINE_HOOK(bgp_route_update,
 	    (struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
-	     struct bgp_path_info *updated_route, bool withdraw),
-	    (bgp, afi, safi, bn, updated_route, withdraw));
+	     struct bgp_path_info *old_route, struct bgp_path_info *new_route),
+	    (bgp, afi, safi, bn, old_route, new_route));
 
 /* Extern from bgp_dump.c */
 extern const char *bgp_origin_str[];
@@ -114,8 +114,8 @@ static const struct message bgp_pmsi_tnltype_str[] = {
 
 DEFINE_HOOK(bgp_process,
 	    (struct bgp * bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
-	     struct peer *peer, bool withdraw),
-	    (bgp, afi, safi, bn, peer, withdraw));
+	     struct peer *peer, bool is_locribmon_enabled),
+	    (bgp, afi, safi, bn, peer, is_locribmon_enabled));
 
 /** Test if path is suppressed. */
 static bool bgp_path_suppressed(struct bgp_path_info *pi)
@@ -3451,17 +3451,11 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 	}
 
 	/* call bmp hook for loc-rib route update / withdraw after flags were
-	 * set */
+	 * set
+	 */
 	if (old_select || new_select) {
-
-		if (old_select) /* route is not installed in locrib anymore */
-			old_select->rib_uptime = (time_t)(-1L);
-		if (new_select) /* route is installed in locrib from now on */
-			new_select->rib_uptime = bgp_clock();
-		bool is_withdraw = old_select && !new_select;
-
-		hook_call(bgp_route_update, bgp, afi, safi, dest,
-			  is_withdraw ? old_select : new_select, is_withdraw);
+		hook_call(bgp_route_update, bgp, afi, safi, dest, old_select,
+			  new_select);
 	}
 
 
@@ -3990,7 +3984,6 @@ struct bgp_path_info *info_make(int type, int sub_type, unsigned short instance,
 	new->peer = peer;
 	new->attr = attr;
 	new->uptime = monotime(NULL);
-	new->rib_uptime = (time_t)(-1L);
 	new->net = dest;
 	return new;
 }

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -295,6 +295,7 @@ struct bgp_path_info {
 
 	/* Uptime.  */
 	time_t uptime;
+	time_t rib_uptime;
 
 	/* reference count */
 	int lock;

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -674,6 +674,12 @@ DECLARE_HOOK(bgp_process,
 	      struct peer *peer, bool withdraw),
 	     (bgp, afi, safi, bn, peer, withdraw));
 
+/* called when a route is updated in the rib */
+DECLARE_HOOK(bgp_route_update,
+	     (struct bgp * bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
+	      struct bgp_path_info *updated_route, bool withdraw),
+	     (bgp, afi, safi, bn, updated_route, withdraw));
+
 /* BGP show options */
 #define BGP_SHOW_OPT_JSON (1 << 0)
 #define BGP_SHOW_OPT_WIDE (1 << 1)

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -214,6 +214,9 @@ struct bgp_path_info_extra {
 	/*For EVPN*/
 	struct bgp_path_info_extra_evpn *evpn;
 
+	/* timestamp of the rib installation */
+	time_t bgp_rib_uptime;
+
 #ifdef ENABLE_BGP_VNC
 	union {
 
@@ -289,13 +292,11 @@ struct bgp_path_info {
 	/* Extra information */
 	struct bgp_path_info_extra *extra;
 
+	/* Uptime.  */
+	time_t uptime;
 
 	/* Multipath information */
 	struct bgp_path_info_mpath *mpath;
-
-	/* Uptime.  */
-	time_t uptime;
-	time_t rib_uptime;
 
 	/* reference count */
 	int lock;
@@ -678,8 +679,8 @@ DECLARE_HOOK(bgp_process,
 /* called when a route is updated in the rib */
 DECLARE_HOOK(bgp_route_update,
 	     (struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
-	      struct bgp_path_info *updated_route, bool withdraw),
-	     (bgp, afi, safi, bn, updated_route, withdraw));
+	      struct bgp_path_info *old_route, struct bgp_path_info *new_route),
+	     (bgp, afi, safi, bn, old_route, new_route));
 
 /* BGP show options */
 #define BGP_SHOW_OPT_JSON (1 << 0)

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -670,13 +670,13 @@ static inline bool bgp_check_withdrawal(struct bgp *bgp, struct bgp_dest *dest,
 
 /* called before bgp_process() */
 DECLARE_HOOK(bgp_process,
-	     (struct bgp * bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
+	     (struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
 	      struct peer *peer, bool withdraw),
 	     (bgp, afi, safi, bn, peer, withdraw));
 
 /* called when a route is updated in the rib */
 DECLARE_HOOK(bgp_route_update,
-	     (struct bgp * bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
+	     (struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
 	      struct bgp_path_info *updated_route, bool withdraw),
 	     (bgp, afi, safi, bn, updated_route, withdraw));
 

--- a/bgpd/bgp_trace.h
+++ b/bgpd/bgp_trace.h
@@ -135,11 +135,12 @@ TRACEPOINT_LOGLEVEL(frr_bgp, bmp_mirror_packet, TRACE_INFO)
 TRACEPOINT_EVENT(
 	frr_bgp,
 	bmp_eor,
-	TP_ARGS(afi_t, afi, safi_t, safi, uint8_t, flags),
+	TP_ARGS(afi_t, afi, safi_t, safi, uint8_t, flags, peer_type_flag),
 	TP_FIELDS(
 		ctf_integer(afi_t, afi, afi)
 		ctf_integer(safi_t, safi, safi)
 		ctf_integer(uint8_t, flags, flags)
+		ctf_integer(uint8_t, peer_type_flag, peer_type_flag)
 	)
 )
 

--- a/doc/developer/bmp.rst
+++ b/doc/developer/bmp.rst
@@ -1,0 +1,49 @@
+.. _bmp:
+
+***
+BMP
+***
+
+RFC 7854
+========
+Missing features (non exhaustive):
+  - Per-Peer Header
+
+    - Peer Type Flag
+    - Peer Distingsher
+
+  - Peer Up
+
+    - Reason codes (according to TODO comments in code)
+
+Peer Type Flag and Peer Distinguisher can be implemented easily using RFC 9069's base code.
+
+RFC 9069
+========
+Everything that isn't listed here is implemented and should be working.
+Missing features (should be exhaustive):
+
+- Per-Peer Header
+
+  - Timestamp
+
+    - set to 0
+    - value is now saved `struct bgp_path_info -> locrib_uptime`
+    - needs testing
+
+- Peer Up/Down
+
+  - VRF/Table Name TLV
+
+    - code for TLV exists
+    - need better RFC understanding
+
+- Peer Down Only
+
+  - Reason code (bc not supported in RFC 7854 either)
+
+- Statistics Report
+
+  - Stat Type = 8: (64-bit Gauge) Number of routes in Loc-RIB.
+  - Stat Type = 10: Number of routes in per-AFI/SAFI Loc-RIB. The value is
+    structured as: 2-byte AFI, 1-byte SAFI, followed by a 64-bit Gauge.

--- a/doc/user/bmp.rst
+++ b/doc/user/bmp.rst
@@ -36,8 +36,8 @@ The `BMP` implementation in FRR has the following properties:
   successfully.  OPEN messages for failed sessions cannot currently be
   mirrored.
 
-- **route monitoring** is available for IPv4 and IPv6 AFIs, unicast and
-  multicast SAFIs.  Other SAFIs (VPN, Labeled-Unicast, Flowspec, etc.) are not
+- **route monitoring** is available for IPv4 and IPv6 AFIs, unicast, multicast 
+  EVPN and VPN SAFIs. Other SAFIs (VPN, Labeled-Unicast, Flowspec, etc.) are not
   currently supported.
 
 - monitoring peers that have BGP **add-path** enabled on the session will
@@ -57,6 +57,51 @@ The `BMP` implementation in FRR has the following properties:
 
 - monitoring peers with :rfc:`5549` extended next-hops has not been tested.
 
+RFC 7854
+========
+Unsupported features (non exhaustive):
+  - Per-Peer Header
+    
+    - Peer Type Flag
+    - Peer Distingsher
+  
+  - Peer Up
+  
+    - Reason codes (according to TODO comments in code)
+
+Peer Type Flag and Peer Distinguisher can be implemented easily using RFC 9069's base code.
+    
+RFC 9069
+========
+Everything that isn't listed here is implemented and should be working.
+Unsupported features (should be exhaustive):
+
+- Per-Peer Header
+
+  - Timestamp
+
+    - set to 0
+    - value is now saved `struct bgp_path_info -> locrib_uptime`
+    - needs testing
+
+- Peer Up/Down
+
+  - VRF/Table Name TLV
+  
+    - code for TLV exists
+    - need better RFC understanding
+
+- Peer Down Only
+
+  - Reason code (bc not supported in RFC 7854 either)
+
+- Statistics Report
+
+  - Stat Type = 8: (64-bit Gauge) Number of routes in Loc-RIB.
+  - Stat Type = 10: Number of routes in per-AFI/SAFI Loc-RIB. The value is 
+    structured as: 2-byte AFI, 1-byte SAFI, followed by a 64-bit Gauge.
+ 
+   
 Starting BMP
 ============
 
@@ -146,7 +191,7 @@ associated with a particular ``bmp targets``:
    Send BMP Statistics (counter) messages at the specified interval (in
    milliseconds.)
 
-.. clicmd:: bmp monitor AFI SAFI <pre-policy|post-policy>
+.. clicmd:: bmp monitor AFI SAFI <pre-policy|post-policy|loc-rib>
 
    Perform Route Monitoring for the specified AFI and SAFI.  Only IPv4 and
    IPv6 are currently valid for AFI. SAFI valid values are currently 

--- a/doc/user/bmp.rst
+++ b/doc/user/bmp.rst
@@ -36,7 +36,7 @@ The `BMP` implementation in FRR has the following properties:
   successfully.  OPEN messages for failed sessions cannot currently be
   mirrored.
 
-- **route monitoring** is available for IPv4 and IPv6 AFIs, unicast, multicast 
+- **route monitoring** is available for IPv4 and IPv6 AFIs, unicast, multicast
   EVPN and VPN SAFIs. Other SAFIs (VPN, Labeled-Unicast, Flowspec, etc.) are not
   currently supported.
 
@@ -57,51 +57,6 @@ The `BMP` implementation in FRR has the following properties:
 
 - monitoring peers with :rfc:`5549` extended next-hops has not been tested.
 
-RFC 7854
-========
-Unsupported features (non exhaustive):
-  - Per-Peer Header
-    
-    - Peer Type Flag
-    - Peer Distingsher
-  
-  - Peer Up
-  
-    - Reason codes (according to TODO comments in code)
-
-Peer Type Flag and Peer Distinguisher can be implemented easily using RFC 9069's base code.
-    
-RFC 9069
-========
-Everything that isn't listed here is implemented and should be working.
-Unsupported features (should be exhaustive):
-
-- Per-Peer Header
-
-  - Timestamp
-
-    - set to 0
-    - value is now saved `struct bgp_path_info -> locrib_uptime`
-    - needs testing
-
-- Peer Up/Down
-
-  - VRF/Table Name TLV
-  
-    - code for TLV exists
-    - need better RFC understanding
-
-- Peer Down Only
-
-  - Reason code (bc not supported in RFC 7854 either)
-
-- Statistics Report
-
-  - Stat Type = 8: (64-bit Gauge) Number of routes in Loc-RIB.
-  - Stat Type = 10: Number of routes in per-AFI/SAFI Loc-RIB. The value is 
-    structured as: 2-byte AFI, 1-byte SAFI, followed by a 64-bit Gauge.
- 
-   
 Starting BMP
 ============
 
@@ -194,7 +149,7 @@ associated with a particular ``bmp targets``:
 .. clicmd:: bmp monitor AFI SAFI <pre-policy|post-policy|loc-rib>
 
    Perform Route Monitoring for the specified AFI and SAFI.  Only IPv4 and
-   IPv6 are currently valid for AFI. SAFI valid values are currently 
+   IPv6 are currently valid for AFI. SAFI valid values are currently
    unicast, multicast, evpn and vpn.
    Other AFI/SAFI combinations may be added in the future.
 

--- a/tests/topotests/bgp_bmp/test_bgp_bmp.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp.py
@@ -49,6 +49,7 @@ SEQ = 0
 
 PRE_POLICY = "pre-policy"
 POST_POLICY = "post-policy"
+LOC_RIB = "loc-rib"
 
 
 def build_topo(tgen):
@@ -239,6 +240,8 @@ def test_bmp_bgp_unicast():
     unicast_prefixes(PRE_POLICY)
     logger.info("*** Unicast prefixes post-policy logging ***")
     unicast_prefixes(POST_POLICY)
+    logger.info("*** Unicast prefixes loc-rib logging ***")
+    unicast_prefixes(LOC_RIB)
 
 
 if __name__ == "__main__":

--- a/tests/topotests/bgp_bmp/test_bgp_bmp.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp.py
@@ -120,7 +120,7 @@ def get_bmp_messages():
     return messages
 
 
-def check_for_prefixes(expected_prefixes, bmp_log_type, post_policy):
+def check_for_prefixes(expected_prefixes, bmp_log_type, policy):
     """
     Check for the presence of the given prefixes in the BMP server logs with
     the given message type and the set policy.
@@ -138,7 +138,7 @@ def check_for_prefixes(expected_prefixes, bmp_log_type, post_policy):
         if "ip_prefix" in m.keys()
         and "bmp_log_type" in m.keys()
         and m["bmp_log_type"] == bmp_log_type
-        and m["post_policy"] == post_policy
+        and m["policy"] == policy
     ]
 
     # check for prefixes
@@ -202,7 +202,7 @@ def unicast_prefixes(policy):
 
     logger.info("checking for updated prefixes")
     # check
-    test_func = partial(check_for_prefixes, prefixes, "update", policy == POST_POLICY)
+    test_func = partial(check_for_prefixes, prefixes, "update", policy)
     success, _ = topotest.run_and_expect(test_func, True, wait=0.5)
     assert success, "Checking the updated prefixes has been failed !."
 
@@ -210,7 +210,7 @@ def unicast_prefixes(policy):
     configure_prefixes(tgen, "r2", 65502, "unicast", prefixes, update=False)
     logger.info("checking for withdrawed prefxies")
     # check
-    test_func = partial(check_for_prefixes, prefixes, "withdraw", policy == POST_POLICY)
+    test_func = partial(check_for_prefixes, prefixes, "withdraw", policy)
     success, _ = topotest.run_and_expect(test_func, True, wait=0.5)
     assert success, "Checking the withdrawed prefixes has been failed !."
 

--- a/tests/topotests/lib/bmp_collector/bmp.py
+++ b/tests/topotests/lib/bmp_collector/bmp.py
@@ -252,6 +252,7 @@ class BMPPerPeerMessage:
 
         if peer_type == 0x03:
             msg['is_filtered'] = bool(peer_flags & IS_FILTERED)
+            msg['policy'] = 'loc-rib'
         else:
             # peer_flags = 0x0000 0000
             # ipv6, post-policy, as-path, adj-rib-out, reserverdx4

--- a/tests/topotests/lib/bmp_collector/bmp.py
+++ b/tests/topotests/lib/bmp_collector/bmp.py
@@ -259,7 +259,7 @@ class BMPPerPeerMessage:
             is_as_path = bool(peer_flags & IS_AS_PATH)
             is_post_policy = bool(peer_flags & IS_POST_POLICY)
             is_ipv6 = bool(peer_flags & IS_IPV6)
-            msg['post_policy'] = is_post_policy
+            msg['policy'] = 'post-policy' if is_post_policy else 'pre-policy'
             msg['ipv6'] = is_ipv6
             msg['peer_ip'] = bin2str_ipaddress(peer_address, is_ipv6)
 


### PR DESCRIPTION
@riw777, @mxyns
- Rebased upon [bmp loc-rib implementation](https://github.com/FRRouting/frr/pull/11800)
- Slightly modify the bmp topotest to support bmp loc-rib
- Here is an example of the logged bmp messages [bmp.log](https://github.com/FRRouting/frr/files/12323111/bmp.log)