### PR TITLE
doc: Prohibit usage of `system()` calls in FRR

### DIFF
--- a/doc/developer/workflow.rst
+++ b/doc/developer/workflow.rst
@@ -761,6 +761,13 @@ following requirements have achieved consensus:
   tools can catch uninitialized value use that would otherwise be suppressed by
   the (incorrect) zero initialization.
 
+- Usage of ``system()`` or other c library routines that cause signals to
+  possibly be ignored are not allowed.  This includes the ``fork()`` and
+  ``execXX`` call patterns, which is actually what system() does underneath
+  the covers.  This pattern causes the system shutdown to never work properly
+  as the SIGINT sent is never received.  It is better to just prohibit code
+  that does this instead of having to debug shutdown issues again.
+
 Other than these specific rules, coding practices from the Linux kernel as
 well as CERT or MISRA C guidelines may provide useful input on safe C code.
 However, these rules are not applied as-is;  some of them expressly collide


### PR DESCRIPTION
See the documentation update, but system() calls and it's ilk block the processing of SIGINT and they are not properly handled as a result leading to shutdown issues where one or more daemons never stop.

See aa530b627de8d1d8c11e4455f3e97a8c2e045281 as an example of system call usage removed from the system.