### PR TITLE
Do not look into pim's eyes, pim gets mad

### DIFF
--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -461,15 +461,15 @@ static int pim_update_upstream_nh_helper(struct hash_bucket *bucket, void *arg)
 	}
 
 	if (PIM_DEBUG_PIM_NHT) {
-		zlog_debug(
-			"%s: NHT upstream %s(%s) old ifp %s new ifp %s",
-			__func__, up->sg_str, pim->vrf->name,
-			old.source_nexthop.interface ? old.source_nexthop
-							       .interface->name
-						     : "Unknown",
-			up->rpf.source_nexthop.interface ? up->rpf.source_nexthop
-								   .interface->name
-							 : "Unknown");
+		zlog_debug("%s: NHT upstream %s(%s) old ifp %s new ifp %s rpf_result: %d",
+			   __func__, up->sg_str, pim->vrf->name,
+			   old.source_nexthop.interface ? old.source_nexthop
+								  .interface->name
+							: "Unknown",
+			   up->rpf.source_nexthop.interface ? up->rpf.source_nexthop
+								      .interface->name
+							    : "Unknown",
+			   rpf_result);
 	}
 
 	return HASHWALK_CONTINUE;

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -31,6 +31,8 @@
 #include "pim_zlookup.h"
 #include "pim_rp.h"
 #include "pim_addr.h"
+#include "pim_register.h"
+#include "pim_vxlan.h"
 
 /**
  * pim_sendmsg_zebra_rnh -- Format and send a nexthop register/Unregister
@@ -399,17 +401,28 @@ static void pim_update_rp_nh(struct pim_instance *pim,
 {
 	struct listnode *node = NULL;
 	struct rp_info *rp_info = NULL;
+	struct interface *ifp;
 
 	/*Traverse RP list and update each RP Nexthop info */
 	for (ALL_LIST_ELEMENTS_RO(pnc->rp_list, node, rp_info)) {
 		if (pim_rpf_addr_is_inaddr_any(&rp_info->rp))
 			continue;
 
+		ifp = rp_info->rp.source_nexthop.interface;
 		// Compute PIM RPF using cached nexthop
 		if (!pim_ecmp_nexthop_lookup(pim, &rp_info->rp.source_nexthop,
 					     rp_info->rp.rpf_addr,
 					     &rp_info->group, 1))
 			pim_rp_nexthop_del(rp_info);
+
+		/*
+		 * If we transition from no path to a path
+		 * we need to search through all the vxlan's
+		 * that use this rp and send NULL registers
+		 * for all the vxlan S,G streams
+		 */
+		if (!ifp && rp_info->rp.source_nexthop.interface)
+			pim_vxlan_rp_info_is_alive(pim, &rp_info->rp);
 	}
 }
 
@@ -436,6 +449,16 @@ static int pim_update_upstream_nh_helper(struct hash_bucket *bucket, void *arg)
 		(rpf_result == PIM_RPF_FAILURE && old.source_nexthop.interface))
 		pim_zebra_upstream_rpf_changed(pim, up, &old);
 
+	/*
+	 * If we are a VXLAN source and we are transitioning from not
+	 * having an outgoing interface to having an outgoing interface
+	 * let's immediately send the null pim register
+	 */
+	if (!old.source_nexthop.interface && up->rpf.source_nexthop.interface &&
+	    PIM_UPSTREAM_FLAG_TEST_SRC_VXLAN_ORIG(up->flags) &&
+	    (up->reg_state == PIM_REG_NOINFO || up->reg_state == PIM_REG_JOIN)) {
+		pim_null_register_send(up);
+	}
 
 	if (PIM_DEBUG_PIM_NHT) {
 		zlog_debug(

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -912,6 +912,7 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 				false /*update_mroute*/);
 		rpf_result = pim_rpf_update(pim, up, NULL, __func__);
 		if (rpf_result == PIM_RPF_FAILURE) {
+			up->channel_oil->oil_inherited_rescan = 1;
 			if (PIM_DEBUG_PIM_TRACE)
 				zlog_debug(
 					"%s: Attempting to create upstream(%s), Unable to RPF for source",

--- a/pimd/pim_vxlan.h
+++ b/pimd/pim_vxlan.h
@@ -135,6 +135,9 @@ extern bool pim_vxlan_do_mlag_reg(void);
 extern void pim_vxlan_inherit_mlag_flags(struct pim_instance *pim,
 		struct pim_upstream *up, bool inherit);
 
+extern void pim_vxlan_rp_info_is_alive(struct pim_instance *pim,
+				       struct pim_rpf *rpg_changed);
+
 /* Shutdown of PIM stop the thread */
 extern void pim_vxlan_terminate(void);
 #endif /* PIM_VXLAN_H */

--- a/tests/topotests/bgp_evpn_mh/leaf1/evpn.conf
+++ b/tests/topotests/bgp_evpn_mh/leaf1/evpn.conf
@@ -1,0 +1,21 @@
+frr defaults datacenter
+!
+router bgp 65101
+  bgp router-id 192.168.100.13
+  no bgp ebgp-requires-policy
+  neighbor 192.168.50.1 remote-as external
+  neighbor 192.168.51.1 remote-as external
+  neighbor 192.168.1.2 remote-as external
+  neighbor 192.168.2.2 remote-as external
+  neighbor 192.168.3.2 remote-as external
+  neighbor 192.168.4.2 remote-as external
+  redistribute connected
+  address-family l2vpn evpn
+    neighbor 192.168.50.1 activate
+    neighbor 192.168.51.1 activate
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.2.2 activate
+    neighbor 192.168.3.2 activate
+    neighbor 192.168.4.2 activate
+  exit-address-family
+!

--- a/tests/topotests/bgp_evpn_mh/leaf1/pim.conf
+++ b/tests/topotests/bgp_evpn_mh/leaf1/pim.conf
@@ -1,0 +1,26 @@
+#debug pim packet
+#debug pim packet register
+#debug pim event
+#debug pim trace
+ip pim ecmp
+ip pim rp 192.168.100.13
+ip pim spt-switchover infinity-and-beyond
+!
+int leaf1-eth0
+  ip pim
+!
+int leaf1-eth1
+  ip pim
+!
+int leaf1-eth2
+  ip pim
+!
+int leaf1-eth3
+  ip pim
+!
+int leaf1-eth4
+  ip pim
+!
+int leaf1-eth5
+  ip pim
+!

--- a/tests/topotests/bgp_evpn_mh/leaf1/zebra.conf
+++ b/tests/topotests/bgp_evpn_mh/leaf1/zebra.conf
@@ -1,0 +1,30 @@
+# spine 1 connection
+int leaf1-eth0
+  description spine1 connection
+  ip addr 192.168.50.2/24
+
+#spine 2 connection
+int leaf1-eth1
+  description spine2 connection
+  ip addr 192.168.51.2/24
+
+#torm11 connection
+int leaf1-eth2
+  description torm11 connection
+  ip addr 192.168.1.1/24
+!
+#torm12 connection
+int leaf1-eth3
+  description torm12 connection
+  ip addr 192.168.2.1/24
+!
+#torm21 connection
+int leaf1-eth4
+  description torm21 connection
+  ip addr 192.168.3.1/24
+!
+#torm22 connection
+int leaf1-eth5
+  descriptoin torm22 connection
+  ip addr 192.168.4.1/24
+!

--- a/tests/topotests/bgp_evpn_mh/leaf2/evpn.conf
+++ b/tests/topotests/bgp_evpn_mh/leaf2/evpn.conf
@@ -1,0 +1,21 @@
+frr defaults datacenter
+!
+router bgp 65101
+  bgp router-id 192.168.100.14
+  no bgp ebgp-requires-policy
+  neighbor 192.168.61.1 remote-as external
+  neighbor 192.168.51.1 remote-as external
+  neighbor 192.168.5.2 remote-as external
+  neighbor 192.168.6.2 remote-as external
+  neighbor 192.168.7.2 remote-as external
+  neighbor 192.168.8.2 remote-as external
+  redistribute connected
+  address-family l2vpn evpn
+    neighbor 192.168.61.1 activate
+    neighbor 192.168.51.1 activate
+    neighbor 192.168.5.2 activate
+    neighbor 192.168.6.2 activate
+    neighbor 192.168.7.2 activate
+    neighbor 192.168.8.2 activate
+  exit-address-family
+!

--- a/tests/topotests/bgp_evpn_mh/leaf2/pim.conf
+++ b/tests/topotests/bgp_evpn_mh/leaf2/pim.conf
@@ -1,18 +1,20 @@
-ip pim ecmp
-ip pim rp 192.168.100.13
-#debug pim packets
 #debug pim packet register
+#debug pim packet
 #debug pim event
 #debug pim trace
-#debug pim vxlan
+ip pim ecmp
+ip pim rp 192.168.100.13
 ip pim spt-switchover infinity-and-beyond
 !
-int lo
+int leaf2-eth0
   ip pim
 !
-int spine1-eth0
+int leaf2-eth1
   ip pim
 !
-int spine1-eth1
+int leaf2-eth2
+  ip pim
+!
+int leaf2-eth3
   ip pim
 !

--- a/tests/topotests/bgp_evpn_mh/leaf2/zebra.conf
+++ b/tests/topotests/bgp_evpn_mh/leaf2/zebra.conf
@@ -1,0 +1,24 @@
+# spine1 connection
+int leaf2-eth0
+  ip addr 192.168.51.2/24
+!
+# spine2 connection
+int leaf2-eth1
+  ip addr 192.168.61.2/24
+!
+#torm11 connection
+int leaf2-eth2
+  ip addr 192.168.5.1/24
+!
+#torm12 connection
+int leaf2-eth3
+  ip addr 192.168.6.1/24
+!
+#torm21 connection
+int leaf2-eth4
+  ip addr 192.168.7.1/24
+!
+#torm22 connection
+int leaf2-eth5
+  ip addr 192.168.8.1/24
+!

--- a/tests/topotests/bgp_evpn_mh/spine1/evpn.conf
+++ b/tests/topotests/bgp_evpn_mh/spine1/evpn.conf
@@ -3,15 +3,11 @@ frr defaults datacenter
 router bgp 65001
   bgp router-id 192.168.100.13
   no bgp ebgp-requires-policy
-  neighbor 192.168.1.2 remote-as external
-  neighbor 192.168.2.2 remote-as external
-  neighbor 192.168.3.2 remote-as external
-  neighbor 192.168.4.2 remote-as external
+  neighbor 192.168.50.2 remote-as external
+  neighbor 192.168.51.2 remote-as external
   redistribute connected
   address-family l2vpn evpn
-    neighbor 192.168.1.2 activate
-    neighbor 192.168.2.2 activate
-    neighbor 192.168.3.2 activate
-    neighbor 192.168.4.2 activate
+    neighbor 192.168.50.2 activate
+    neighbor 192.168.51.2 activate
   exit-address-family
 !

--- a/tests/topotests/bgp_evpn_mh/spine1/zebra.conf
+++ b/tests/topotests/bgp_evpn_mh/spine1/zebra.conf
@@ -1,14 +1,10 @@
+# leaf1 connection
 int spine1-eth0
-  ip addr 192.168.1.1/24
+  ip addr 192.168.50.1/24
 !
+# leaf2 connection
 int spine1-eth1
-  ip addr 192.168.2.1/24
-!
-int spine1-eth2
-  ip addr 192.168.3.1/24
-!
-int spine1-eth3
-  ip addr 192.168.4.1/24
+  ip addr 192.168.51.1/24
 !
 int lo
   ip addr 192.168.100.13/32

--- a/tests/topotests/bgp_evpn_mh/spine2/evpn.conf
+++ b/tests/topotests/bgp_evpn_mh/spine2/evpn.conf
@@ -3,15 +3,11 @@ frr defaults datacenter
 router bgp 65001
   bgp router-id 192.168.100.14
   no bgp ebgp-requires-policy
-  neighbor 192.168.5.2 remote-as external
-  neighbor 192.168.6.2 remote-as external
-  neighbor 192.168.7.2 remote-as external
-  neighbor 192.168.8.2 remote-as external
+  neighbor 192.168.60.2 remote-as external
+  neighbor 192.168.61.2 remote-as external
   redistribute connected
   address-family l2vpn evpn
-    neighbor 192.168.5.2 activate
-    neighbor 192.168.6.2 activate
-    neighbor 192.168.7.2 activate
-    neighbor 192.168.8.2 activate
+    neighbor 192.168.60.2 activate
+    neighbor 192.168.61.2 activate
   exit-address-family
 !

--- a/tests/topotests/bgp_evpn_mh/spine2/pim.conf
+++ b/tests/topotests/bgp_evpn_mh/spine2/pim.conf
@@ -1,3 +1,4 @@
+ip pim ecmp
 ip pim rp 192.168.100.13
 ip pim spt-switchover infinity-and-beyond
 !
@@ -8,11 +9,5 @@ int spine2-eth0
   ip pim
 !
 int spine2-eth1
-  ip pim
-!
-int spine2-eth2
-  ip pim
-!
-int spine2-eth3
   ip pim
 !

--- a/tests/topotests/bgp_evpn_mh/spine2/zebra.conf
+++ b/tests/topotests/bgp_evpn_mh/spine2/zebra.conf
@@ -1,14 +1,12 @@
+# leaf1 connection
 int spine2-eth0
-  ip addr 192.168.5.1/24
+  description leaf1 connection
+  ip addr 192.168.60.1/24
 !
+# leaf2 connection
 int spine2-eth1
-  ip addr 192.168.6.1/24
-!
-int spine2-eth2
-  ip addr 192.168.7.1/24
-!
-int spine2-eth3
-  ip addr 192.168.8.1/24
+  description leaf2 connection
+  ip addr 192.168.61.1/24
 !
 int lo
   ip addr 192.168.100.14/32

--- a/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
+++ b/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
@@ -58,6 +58,8 @@ def build_topo(tgen):
 
     tgen.add_router("spine1")
     tgen.add_router("spine2")
+    tgen.add_router("leaf1")
+    tgen.add_router("leaf2")
     tgen.add_router("torm11")
     tgen.add_router("torm12")
     tgen.add_router("torm21")
@@ -71,88 +73,109 @@ def build_topo(tgen):
     # First switch is for a dummy interface (for local network)
 
     ##################### spine1 ########################
-    # spine1-eth0 is connected to torm11-eth0
+    # spine1-eth0 is connected to leaf1-eth0
     switch = tgen.add_switch("sw1")
     switch.add_link(tgen.gears["spine1"])
-    switch.add_link(tgen.gears["torm11"])
+    switch.add_link(tgen.gears["leaf1"])
 
-    # spine1-eth1 is connected to torm12-eth0
+    # spine1-eth1 is connected to leaf2-eth0
     switch = tgen.add_switch("sw2")
     switch.add_link(tgen.gears["spine1"])
-    switch.add_link(tgen.gears["torm12"])
+    switch.add_link(tgen.gears["leaf2"])
 
-    # spine1-eth2 is connected to torm21-eth0
+    # spine2-eth0 is connected to leaf1-eth1
     switch = tgen.add_switch("sw3")
-    switch.add_link(tgen.gears["spine1"])
-    switch.add_link(tgen.gears["torm21"])
-
-    # spine1-eth3 is connected to torm22-eth0
-    switch = tgen.add_switch("sw4")
-    switch.add_link(tgen.gears["spine1"])
-    switch.add_link(tgen.gears["torm22"])
-
-    ##################### spine2 ########################
-    # spine2-eth0 is connected to torm11-eth1
-    switch = tgen.add_switch("sw5")
     switch.add_link(tgen.gears["spine2"])
+    switch.add_link(tgen.gears["leaf1"])
+
+    # spine2-eth1 is connected to leaf2-eth1
+    switch = tgen.add_switch("sw4")
+    switch.add_link(tgen.gears["spine2"])
+    switch.add_link(tgen.gears["leaf2"])
+
+    ################## leaf1 ##########################
+    # leaf1-eth2 is connected to torm11-eth0
+    switch = tgen.add_switch("sw5")
+    switch.add_link(tgen.gears["leaf1"])
     switch.add_link(tgen.gears["torm11"])
 
-    # spine2-eth1 is connected to torm12-eth1
+    # leaf1-eth3 is connected to torm12-eth0
     switch = tgen.add_switch("sw6")
-    switch.add_link(tgen.gears["spine2"])
+    switch.add_link(tgen.gears["leaf1"])
     switch.add_link(tgen.gears["torm12"])
 
-    # spine2-eth2 is connected to torm21-eth1
+    # leaf1-eth4 is connected to torm21-eth0
     switch = tgen.add_switch("sw7")
-    switch.add_link(tgen.gears["spine2"])
+    switch.add_link(tgen.gears["leaf1"])
     switch.add_link(tgen.gears["torm21"])
 
-    # spine2-eth3 is connected to torm22-eth1
+    # leaf1-eth5 is connected to torm22-eth0
     switch = tgen.add_switch("sw8")
-    switch.add_link(tgen.gears["spine2"])
+    switch.add_link(tgen.gears["leaf1"])
+    switch.add_link(tgen.gears["torm22"])
+
+    ##################### leaf2 ########################
+    # leaf2-eth2 is connected to torm11-eth1
+    switch = tgen.add_switch("sw9")
+    switch.add_link(tgen.gears["leaf2"])
+    switch.add_link(tgen.gears["torm11"])
+
+    # leaf2-eth3 is connected to torm12-eth1
+    switch = tgen.add_switch("sw10")
+    switch.add_link(tgen.gears["leaf2"])
+    switch.add_link(tgen.gears["torm12"])
+
+    # leaf2-eth4 is connected to torm21-eth1
+    switch = tgen.add_switch("sw11")
+    switch.add_link(tgen.gears["leaf2"])
+    switch.add_link(tgen.gears["torm21"])
+
+    # leaf2-eth5 is connected to torm22-eth1
+    switch = tgen.add_switch("sw12")
+    switch.add_link(tgen.gears["leaf2"])
     switch.add_link(tgen.gears["torm22"])
 
     ##################### torm11 ########################
     # torm11-eth2 is connected to hostd11-eth0
-    switch = tgen.add_switch("sw9")
+    switch = tgen.add_switch("sw13")
     switch.add_link(tgen.gears["torm11"])
     switch.add_link(tgen.gears["hostd11"])
 
     # torm11-eth3 is connected to hostd12-eth0
-    switch = tgen.add_switch("sw10")
+    switch = tgen.add_switch("sw14")
     switch.add_link(tgen.gears["torm11"])
     switch.add_link(tgen.gears["hostd12"])
 
     ##################### torm12 ########################
     # torm12-eth2 is connected to hostd11-eth1
-    switch = tgen.add_switch("sw11")
+    switch = tgen.add_switch("sw15")
     switch.add_link(tgen.gears["torm12"])
     switch.add_link(tgen.gears["hostd11"])
 
     # torm12-eth3 is connected to hostd12-eth1
-    switch = tgen.add_switch("sw12")
+    switch = tgen.add_switch("sw16")
     switch.add_link(tgen.gears["torm12"])
     switch.add_link(tgen.gears["hostd12"])
 
     ##################### torm21 ########################
     # torm21-eth2 is connected to hostd21-eth0
-    switch = tgen.add_switch("sw13")
+    switch = tgen.add_switch("sw17")
     switch.add_link(tgen.gears["torm21"])
     switch.add_link(tgen.gears["hostd21"])
 
     # torm21-eth3 is connected to hostd22-eth0
-    switch = tgen.add_switch("sw14")
+    switch = tgen.add_switch("sw18")
     switch.add_link(tgen.gears["torm21"])
     switch.add_link(tgen.gears["hostd22"])
 
     ##################### torm22 ########################
     # torm22-eth2 is connected to hostd21-eth1
-    switch = tgen.add_switch("sw15")
+    switch = tgen.add_switch("sw19")
     switch.add_link(tgen.gears["torm22"])
     switch.add_link(tgen.gears["hostd21"])
 
     # torm22-eth3 is connected to hostd22-eth1
-    switch = tgen.add_switch("sw16")
+    switch = tgen.add_switch("sw20")
     switch.add_link(tgen.gears["torm22"])
     switch.add_link(tgen.gears["hostd22"])
 
@@ -591,7 +614,7 @@ def ping_anycast_gw(tgen):
         "--interface=" + intf,
         'Ether(dst="ff:ff:ff:ff:ff:ff")/ARP(pdst="{}")'.format(ipaddr),
     ]
-    for name in ("hostd11", "hostd21"):
+    for name in ("hostd11", "hostd21", "hostd12", "hostd22"):
         host = tgen.net.hosts[name]
         _, stdout, _ = host.cmd_status(ping_cmd, warn=False, stderr=subprocess.STDOUT)
         stdout = stdout.strip()

--- a/tests/topotests/bgp_evpn_mh/torm11/pim.conf
+++ b/tests/topotests/bgp_evpn_mh/torm11/pim.conf
@@ -1,4 +1,10 @@
 !
+#debug pim packet
+#debug pim packet register
+#debug pim trace
+#debug pim event
+#debug pim vxlan
+ip pim ecmp
 ip pim rp 192.168.100.13 239.1.1.0/24
 ip pim spt-switchover infinity-and-beyond
 !

--- a/tests/topotests/bgp_evpn_mh/torm12/pim.conf
+++ b/tests/topotests/bgp_evpn_mh/torm12/pim.conf
@@ -1,4 +1,10 @@
+#debug pim packet
+#debug pim packet register
+#debug pim trace
+#debug pim event
+#debug pim vxlan
 !
+ip pim ecmp
 ip pim rp 192.168.100.13 239.1.1.0/24
 ip pim spt-switchover infinity-and-beyond
 !

--- a/tests/topotests/bgp_evpn_mh/torm21/pim.conf
+++ b/tests/topotests/bgp_evpn_mh/torm21/pim.conf
@@ -1,4 +1,10 @@
+#debug pim packet
+#debug pim packet register
+#debug pim trace
+#debug pim event
+#debug pim vxlan
 !
+ip pim ecmp
 ip pim rp 192.168.100.13 239.1.1.0/24
 ip pim spt-switchover infinity-and-beyond
 !

--- a/tests/topotests/bgp_evpn_mh/torm22/pim.conf
+++ b/tests/topotests/bgp_evpn_mh/torm22/pim.conf
@@ -1,4 +1,10 @@
+#debug pim packet
+#debug pim packet register
+#debug pim trace
+#debug pim event
+#debug pim vxlan
 !
+ip pim ecmp
 ip pim rp 192.168.100.13 239.1.1.0/24
 ip pim spt-switchover infinity-and-beyond
 !


### PR DESCRIPTION
1)  Make the bgp_evpn_mh test a 3 level clos to more realistically see flows setup
2) Prevent a S,G RPT prune being sent in some cases when a pim vxlan S,G is being used
3) Send immediate Null Registers when pim vxlan is being setup when routing for the RP becomes available if after vxlan S,G creation.
4) Intentionally rescan oil when RPF fails at S,G creation time.  Else it never gets rescanned and 
5) Add some more debugs