### PR TITLE
*: add uptime's epoch time to json outputs

### DIFF
--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -809,6 +809,7 @@ void bfd_sess_show(struct vty *vty, struct json_object *json,
 {
 	json_object *json_bfd = NULL;
 	char time_buf[64];
+	time_t epoch_tbuf;
 
 	if (!bsp)
 		return;
@@ -840,10 +841,14 @@ void bfd_sess_show(struct vty *vty, struct json_object *json,
 	}
 
 	bfd_last_update(bsp->bss.last_event, time_buf, sizeof(time_buf));
+	epoch_tbuf = time(NULL) - (monotime(NULL) - bsp->bss.last_event);
 	if (json) {
 		json_object_string_add(json_bfd, "status",
 				       bfd_get_status_str(bsp->bss.state));
 		json_object_string_add(json_bfd, "lastUpdate", time_buf);
+		json_object_int_add(json_bfd, "bfdLastUpdateEpoch", epoch_tbuf);
+		json_object_string_add(json_bfd, "bfdLastUpdateEpochStr",
+				       ctime(&epoch_tbuf));
 	} else
 		vty_out(vty, "  Status: %s, Last update: %s\n",
 			bfd_get_status_str(bsp->bss.state), time_buf);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -4630,10 +4630,15 @@ static void show_ip_ospf_neighbour_brief(struct vty *vty,
 	struct timeval res = {.tv_sec = 0, .tv_usec = 0};
 	long time_val = 0;
 	char uptime[OSPF_TIME_DUMP_SIZE];
+	time_t epoch_tbuf = 0;
 
 	if (nbr->ts_last_progress.tv_sec || nbr->ts_last_progress.tv_usec)
 		time_val =
 			monotime_since(&nbr->ts_last_progress, &res) / 1000LL;
+
+	if (nbr->ts_last_progress.tv_sec)
+		epoch_tbuf = time(NULL) -
+			     (monotime(NULL) - (nbr->ts_last_progress.tv_sec));
 
 	if (use_json) {
 		char neigh_str[INET_ADDRSTRLEN];
@@ -4692,6 +4697,11 @@ static void show_ip_ospf_neighbour_brief(struct vty *vty,
 				json_neighbor, "deadTime",
 				ospf_timer_dump(nbr->t_inactivity, timebuf,
 						sizeof(timebuf)));
+			json_object_int_add(json_neighbor,
+					    "ospfNeighUptimeEpoch", epoch_tbuf);
+			json_object_string_add(json_neighbor,
+					       "ospfNeighUptimeEpochStr",
+					       ctime(&epoch_tbuf));
 		} else {
 			json_object_string_add(json_neighbor, "deadTimeMsecs",
 					       "inactive");

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -828,19 +828,26 @@ static void igmp_show_statistics(struct pim_instance *pim, struct vty *vty,
 
 static void igmp_source_json_helper(struct gm_source *src,
 				    json_object *json_sources, char *source_str,
-				    char *mmss, char *uptime)
+				    char *mmss, char *uptime,
+				    time_t source_creation)
 {
 	json_object *json_source = NULL;
+	time_t epoch_tbuf;
 
 	json_source = json_object_new_object();
 	if (!json_source)
 		return;
 
+	epoch_tbuf =
+		time(NULL) - (monotime(NULL) - (UPTIMESECS(source_creation)));
 	json_object_string_add(json_source, "source", source_str);
 	json_object_string_add(json_source, "timer", mmss);
 	json_object_boolean_add(json_source, "forwarded",
 				IGMP_SOURCE_TEST_FORWARDING(src->source_flags));
 	json_object_string_add(json_source, "uptime", uptime);
+	json_object_int_add(json_source, "grpUptimeEpoch", epoch_tbuf);
+	json_object_string_add(json_source, "grpUptimeEpochStr",
+			       ctime(&epoch_tbuf));
 	json_object_array_add(json_sources, json_source);
 }
 
@@ -854,11 +861,14 @@ static void igmp_group_print(struct interface *ifp, struct vty *vty, bool uj,
 	char group_str[INET_ADDRSTRLEN];
 	char hhmmss[PIM_TIME_STRLEN];
 	char uptime[PIM_TIME_STRLEN];
+	time_t epoch_tbuf;
 
 	pim_inet4_dump("<group?>", grp->group_addr, group_str,
 		       sizeof(group_str));
 	pim_time_timer_to_hhmmss(hhmmss, sizeof(hhmmss), grp->t_group_timer);
 	pim_time_uptime(uptime, sizeof(uptime), now - grp->group_creation);
+	epoch_tbuf = time(NULL) -
+		     (monotime(NULL) - (UPTIMESECS(grp->group_creation)));
 
 	if (uj) {
 		json_object_object_get_ex(json, ifp->name, &json_iface);
@@ -898,6 +908,11 @@ static void igmp_group_print(struct interface *ifp, struct vty *vty, bool uj,
 			json_object_int_add(json_group, "version",
 					    grp->igmp_version);
 			json_object_string_add(json_group, "uptime", uptime);
+			json_object_int_add(json_group, "igmpGrpUptimeEpoch",
+					    epoch_tbuf);
+			json_object_string_add(json_group,
+					       "igmpGrpUptimeEpochStr",
+					       ctime(&epoch_tbuf));
 			json_object_array_add(json_groups, json_group);
 
 			if (detail) {
@@ -931,7 +946,8 @@ static void igmp_group_print(struct interface *ifp, struct vty *vty, bool uj,
 
 					igmp_source_json_helper(
 						src, json_sources, source_str,
-						mmss, src_uptime);
+						mmss, src_uptime,
+						src->source_creation);
 				}
 			}
 		}
@@ -1221,7 +1237,8 @@ static void igmp_sources_print(struct interface *ifp, char *group_str,
 		json_object_object_get_ex(json_group, "sources", &json_sources);
 		if (json_sources)
 			igmp_source_json_helper(src, json_sources, source_str,
-						mmss, uptime);
+						mmss, uptime,
+						src->source_creation);
 	} else {
 		vty_out(vty, "%-16s %-15s %-15s %5s %3s %8s\n", ifp->name,
 			group_str, source_str, mmss,

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1206,9 +1206,10 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 	json_object *json = NULL;
 	json_object *json_backup_nexthop_array = NULL;
 	json_object *json_backup_nexthops = NULL;
-
+	time_t epoch_tbuf;
 
 	uptime2str(nhe->uptime, up_str, sizeof(up_str));
+	epoch_tbuf = time(NULL) - (monotime(NULL) - (UPTIMESECS(nhe->uptime)));
 
 	if (json_nhe_hdr)
 		json = json_object_new_object();
@@ -1224,6 +1225,10 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 						      sizeof(time_left),
 						      nhe->timer));
 		json_object_string_add(json, "uptime", up_str);
+		json_object_int_add(json, "nhGrpUptimeEstablishedEpoch",
+				    epoch_tbuf);
+		json_object_string_add(json, "nhGrpUptimeEstablishedEpochStr",
+				       ctime(&epoch_tbuf));
 		json_object_string_add(json, "vrf",
 				       vrf_id_to_name(nhe->vrf_id));
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -618,8 +618,10 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 	char up_str[MONOTIME_STRLEN];
 	bool first_p = true;
 	bool nhg_from_backup = false;
+	time_t epoch_tbuf;
 
 	uptime2str(re->uptime, up_str, sizeof(up_str));
+	epoch_tbuf = time(NULL) - (monotime(NULL) - (UPTIMESECS(re->uptime)));
 
 	/* If showing fib information, use the fib view of the
 	 * nexthops.
@@ -699,6 +701,11 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 					    re->nhe_installed_id);
 
 		json_object_string_add(json_route, "uptime", up_str);
+		json_object_int_add(json_route, "routeUptimeEstablishedEpoch",
+				    epoch_tbuf);
+		json_object_string_add(json_route,
+				       "routeUptimeEstablishedEpochStr",
+				       ctime(&epoch_tbuf));
 
 		for (ALL_NEXTHOPS_PTR(nhg, nexthop)) {
 			json_nexthop = json_object_new_object();


### PR DESCRIPTION
zebra: show ip[v6] route , nexthop-group, ospfv2 neighbor, ospfv2 neighbor bfd and igmp groups.

commits:
```
pimd: convert uptime to epoch for igmp vrf groups
lib: convert lastUpdate to epoch for ospf neigh bfd json
ospfd: convert uptime to epoch for ip ospf neigh
zebra: convert uptime to epoch for show nexthop-group rib
zebra: convert uptime to epoch for show ip/ipv6 route
```


sample outputs:
```
    tor-12# show ip igmp vrf red groups detail json
    {"totalGroups":5,"watermarkLimit":0,"swp3":
    {"name":"swp3","state":"up","address":"20.20.20.2","index":5,"flagMulticast":true,"flagBroadcast":true,"flagAllMulticast":true,"lanDelayEnabled":true,"groups":[{"group":"225.1.101.5","mode":"EXCLUDE","timer":"00:05:34","sourcesCount":1,"version":3,"uptime":"00:00:55","sources":[{"source":"*","timer":"05:34","forwarded":true,"uptime":"00:00:55","grpUptimeEpoch":1691123525,"grpUptimeEpochStr":"Fri
    Aug  4 04:32:05
    2023\n"}]},{"group":"225.1.101.4","mode":"EXCLUDE","timer":"00:05:34","sourcesCount":1,"version":3,"uptime":"00:00:55","sources":[{"source":"*","timer":"05:34","forwarded":true,"uptime":"00:00:55","grpUptimeEpoch":1691123525,"grpUptimeEpochStr":"Fri
    Aug  4 04:32:05
    2023\n"}]},{"group":"225.1.101.3","mode":"EXCLUDE","timer":"00:05:34","sourcesCount":1,"version":3,"uptime":"00:00:55","sources":[{"source":"*","timer":"05:34","forwarded":true,"uptime":"00:00:55","grpUptimeEpoch":1691123525,"grpUptimeEpochStr":"Fri
    Aug  4 04:32:05
    2023\n"}]},{"group":"225.1.101.2","mode":"EXCLUDE","timer":"00:05:34","sourcesCount":1,"version":3,"uptime":"00:00:55","sources":[{"source":"*","timer":"05:34","forwarded":true,"uptime":"00:00:55","grpUptimeEpoch":1691123525,"grpUptimeEpochStr":"Fri
    Aug  4 04:32:05
    2023\n"}]},{"group":"225.1.101.1","mode":"EXCLUDE","timer":"00:05:34","sourcesCount":1,"version":3,"uptime":"00:00:55","sources":[{"source":"*","timer":"05:34","forwarded":true,"uptime":"00:00:55","grpUptimeEpoch":1691123525,"grpUptimeEpochStr":"Fri
    Aug  4 04:32:05 2023\n"}]}]}}
 ```
 
 ```
     TORC11# show ip route 27.0.0.16/32 json
    {
      "27.0.0.16\/32":[
        {
          "prefix":"27.0.0.16\/32",
          "prefixLen":32,
              .....
              .....

          "uptime":"00:00:19",
          "routeUptimeEstablishedEpoch":1690969152,
          "routeUptimeEstablishedEpochStr":"Wed Aug  2 09:39:12 2023\n",
          "nexthops":[
            {
              "flags":3,
              "fib":true,
              "ip":"fe80::202:ff:fe00:11",
              "afi":"ipv6",
              "interfaceIndex":12,
              "interfaceName":"uplink-1",
              "active":true,
              "weight":1
            },
            {
              "flags":3,
              "fib":true,
              "ip":"fe80::202:ff:fe00:1d",
              "afi":"ipv6",
              "interfaceIndex":13,
              "interfaceName":"uplink-2",
              "active":true,
              "weight":1
            }
```

```
    TORC11# show ipv6 route 2001:c15c:d06:f00d::9/128 json
    {
      "2001:c15c:d06:f00d::9\/128":[
        {
          "prefix":"2001:c15c:d06:f00d::9\/128",
          "prefixLen":128,
          "protocol":"bgp",
          "vrfId":0,
          "vrfName":"default",
          "selected":true,
          "destSelected":true,
          "distance":20,
          "metric":0,
          "installed":true,
          "table":254,
          "internalStatus":16,
          "internalFlags":8,
          "internalNextHopNum":1,
          "internalNextHopActiveNum":1,
          "nexthopGroupId":94,
          "installedNexthopGroupId":94,
          "uptime":"00:03:16",
          "routeUptimeEstablishedEpoch":1690969152,
          "routeUptimeEstablishedEpochStr":"Wed Aug  2 09:39:12 2023\n",
          "nexthops":[
          ..
```

Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>