### PR TITLE
lib: Lower precedence for ASNUM_TKN when using together with IPV4/IPV6_TKN

### DIFF
--- a/lib/command_match.c
+++ b/lib/command_match.c
@@ -566,9 +566,9 @@ static int score_precedence(enum cmd_token_type type)
 	case IPV6_PREFIX_TKN:
 	case MAC_TKN:
 	case MAC_PREFIX_TKN:
-	case ASNUM_TKN:
 	case RANGE_TKN:
 		return 2;
+	case ASNUM_TKN:
 	case WORD_TKN:
 		return 3;
 	case VARIABLE_TKN:


### PR DESCRIPTION
Closes https://github.com/FRRouting/frr/issues/14200