### PR TITLE
bgpd: fix coverity issue in bgpd

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6610,6 +6610,7 @@ int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
 	}
 
 	if (safi == SAFI_MPLS_VPN || safi == SAFI_EVPN) {
+		memset(&prd, 0, sizeof(prd));
 		ret = str2prefix_rd(rd_str, &prd);
 		if (!ret) {
 			vty_out(vty, "%% Malformed rd\n");


### PR DESCRIPTION
Should address this issue:
** CID 1566843:  Uninitialized variables  (UNINIT) /bgpd/bgp_route.c: 6754 in bgp_static_set()
6748                            bgp_static->backdoor = backdoor;
6749                            bgp_static->valid = 0;
6750                            bgp_static->igpmetric = 0;
6751                            bgp_static->igpnexthop.s_addr = INADDR_ANY;
6752                            bgp_static->label_index = label_index;
6753                            bgp_static->label = label;
>>>     CID 1566843:  Uninitialized variables  (UNINIT)
>>>     Using uninitialized value prd.
6754                            bgp_static->prd = prd;
6755
6756                            if (rmap) {
6757                                    XFREE(MTYPE_ROUTE_MAP_NAME,
6758                                          bgp_static->rmap.name);
6759                                    route_map_counter_decrement(

Testing Done:
 build

Ticket: #NA
Signed-off-by: Rajesh Varatharaj <rvaratharaj@nvidia.com>