### PR TITLE
lib: Allow unsetting walltime-warning and cpu-warning

### DIFF
--- a/lib/thread.c
+++ b/lib/thread.c
@@ -370,7 +370,7 @@ DEFPY (service_cputime_stats,
 
 DEFPY (service_cputime_warning,
        service_cputime_warning_cmd,
-       "[no] service cputime-warning (1-4294967295)",
+       "[no] service cputime-warning ![(1-4294967295)]",
        NO_STR
        "Set up miscellaneous service\n"
        "Warn for tasks exceeding CPU usage threshold\n"
@@ -383,16 +383,9 @@ DEFPY (service_cputime_warning,
 	return CMD_SUCCESS;
 }
 
-ALIAS (service_cputime_warning,
-       no_service_cputime_warning_cmd,
-       "no service cputime-warning",
-       NO_STR
-       "Set up miscellaneous service\n"
-       "Warn for tasks exceeding CPU usage threshold\n")
-
 DEFPY (service_walltime_warning,
        service_walltime_warning_cmd,
-       "[no] service walltime-warning (1-4294967295)",
+       "[no] service walltime-warning ![(1-4294967295)]",
        NO_STR
        "Set up miscellaneous service\n"
        "Warn for tasks exceeding total wallclock threshold\n"
@@ -404,13 +397,6 @@ DEFPY (service_walltime_warning,
 		walltime_threshold = walltime_warning * 1000;
 	return CMD_SUCCESS;
 }
-
-ALIAS (service_walltime_warning,
-       no_service_walltime_warning_cmd,
-       "no service walltime-warning",
-       NO_STR
-       "Set up miscellaneous service\n"
-       "Warn for tasks exceeding total wallclock threshold\n")
 
 static void show_thread_poll_helper(struct vty *vty, struct thread_master *m)
 {
@@ -541,9 +527,7 @@ void thread_cmd_init(void)
 
 	install_element(CONFIG_NODE, &service_cputime_stats_cmd);
 	install_element(CONFIG_NODE, &service_cputime_warning_cmd);
-	install_element(CONFIG_NODE, &no_service_cputime_warning_cmd);
 	install_element(CONFIG_NODE, &service_walltime_warning_cmd);
-	install_element(CONFIG_NODE, &no_service_walltime_warning_cmd);
 
 	install_element(VIEW_NODE, &show_thread_timers_cmd);
 }

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -492,12 +492,10 @@ void vtysh_config_parse_line(void *arg, const char *line)
 				    strlen("no ip prefix-list")) == 0 ||
 			    strncmp(line, "no ipv6 prefix-list",
 				    strlen("no ipv6 prefix-list")) == 0 ||
-			    strncmp(line, "service cputime-stats",
-				    strlen("service cputime-stats")) == 0 ||
-			    strncmp(line, "no service cputime-stats",
-				    strlen("no service cputime-stats")) == 0 ||
-			    strncmp(line, "service cputime-warning",
-				    strlen("service cputime-warning")) == 0)
+			    strncmp(line, "service ", strlen("service ")) ==
+				    0 ||
+			    strncmp(line, "no service ",
+				    strlen("no service ")) == 0)
 				config_add_line_uniq(config_top, line);
 			else
 				config_add_line(config_top, line);


### PR DESCRIPTION
Manual backport, replacing https://github.com/FRRouting/frr/pull/14208.