### PR TITLE
pbrd: add advisory flag PBR_ACTION_DROP

### DIFF
--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -99,6 +99,7 @@ struct pbr_action {
 #define PBR_ACTION_DST_PORT		(1 << 8)
 #define PBR_ACTION_DSCP			(1 << 9)
 #define PBR_ACTION_ECN			(1 << 10)
+#define PBR_ACTION_DROP			(1 << 11) /* nexthop == blackhole */
 
 	uint32_t table;
 	uint32_t queue_id;

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -1105,6 +1105,9 @@ static void pbrms_clear_set_config(struct pbr_map_sequence *pbrms)
 	pbrms->nhs_installed = false;
 
 	pbrms->forwarding_type = PBR_FT_UNSPEC;
+
+	/* clear advisory flag indicating nexthop == blackhole */
+	UNSET_FLAG(pbrms->action_bm, PBR_ACTION_DROP);
 }
 
 
@@ -1263,6 +1266,8 @@ DEFPY  (pbr_map_nexthop,
 		}
 	} else if (bh) {
 		nhop.type = NEXTHOP_TYPE_BLACKHOLE;
+		/* advisory flag for non-linux dataplanes */
+		SET_FLAG(pbrms->action_bm, PBR_ACTION_DROP);
 	} else {
 		nhop.type = NEXTHOP_TYPE_IFINDEX;
 	}


### PR DESCRIPTION
    PBR configuration may specify "set nexthop blackhole" which,
    for linux dataplanes, is implemented as a table with a blackhole
    route.

    Other dataplanes might implement this action as an explicit
    packet-filtering "drop" action instead of a route. This new flag
    PBR_ACTION_DROP is now set when a rule has "set nexthop blackhole"
    as an aid to other dataplanes.