### PR TITLE
bgpd: Set ifindex to find the correct nexthop

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -316,6 +316,14 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop,
 		if (make_prefix(afi, pi, &p) < 0)
 			return 1;
 
+		/*
+		 * If path is learnt from an interface based peer,
+		 * set the ifindex to peer's interface index so that
+		 * correct nexthop can be found in nexthop tree.
+		 */
+		if (pi->peer->conf_if)
+			ifindex = pi->peer->su.sin6.sin6_scope_id;
+
 		if (!is_bgp_static_route && orig_prefix
 		    && prefix_same(&p, orig_prefix)) {
 			if (BGP_DEBUG(nht, NHT)) {


### PR DESCRIPTION
Problem:
    On GR helper, paths learnt from an interface based peer were linked
    to bnc with ifindex=0. During restart of GR peer, BGP (unnumbered)
    session (with GR restarter peer) goes down on GR helper but the routes
    are retained. Later, when BGP receives an interface up event, it
    will process all the paths associated with BNC whose ifindex matches the
    ifindex of the interface for which UP event is received. However, paths
    associated with bnc that has ifindex=0 were not being reinstalled since
    ifindex=0 doesn't match ifindex of any interfaces. This results in
    BGP routes not being reinstalled in zebra and kernel.

Fix:
    For paths learnt from an interface based peer, set the
    ifindex to peer's interface ifindex so that correct
    peer based nexthop can be found and linked to the path.

Signed-off-by: Donald Sharp sharpd@nvidia.com