### PR TITLE
zebra: Fix crashes in interface change

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -635,8 +635,10 @@ static int netlink_bridge_vxlan_update(struct zebra_dplane_ctx *ctx,
 	struct bridge_vlan_info *vinfo;
 	struct zebra_dplane_bridge_vlan_info bvinfo;
 
-	if (!af_spec)
+	if (!af_spec) {
+		dplane_ctx_set_ifp_no_afspec(ctx);
 		return 0;
+	}
 
 	netlink_bridge_vxlan_vlan_vni_map_update(ctx, af_spec);
 
@@ -644,8 +646,10 @@ static int netlink_bridge_vxlan_update(struct zebra_dplane_ctx *ctx,
 	 * only 1 access VLAN is accepted.
 	 */
 	netlink_parse_rtattr_nested(aftb, IFLA_BRIDGE_MAX, af_spec);
-	if (!aftb[IFLA_BRIDGE_VLAN_INFO])
+	if (!aftb[IFLA_BRIDGE_VLAN_INFO]) {
+		dplane_ctx_set_ifp_no_bridge_vlan_info(ctx);
 		return 0;
+	}
 
 	vinfo = RTA_DATA(aftb[IFLA_BRIDGE_VLAN_INFO]);
 	bvinfo.flags = vinfo->flags;

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1848,8 +1848,14 @@ static void interface_bridge_vxlan_update(struct zebra_dplane_ctx *ctx,
 	struct zebra_if *zif = ifp->info;
 	const struct zebra_dplane_bridge_vlan_info *bvinfo;
 
+	if (dplane_ctx_get_ifp_no_afspec(ctx))
+		return;
+
 	if (IS_ZEBRA_VXLAN_IF_SVD(zif))
 		interface_bridge_vxlan_vlan_vni_map_update(ctx, ifp);
+
+	if (dplane_ctx_get_ifp_no_bridge_vlan_info(ctx))
+		return;
 
 	bvinfo = dplane_ctx_get_ifp_bridge_vlan_info(ctx);
 

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -197,6 +197,8 @@ struct dplane_intf_info {
 	bool startup;
 	uint8_t family;
 	struct zebra_vxlan_vni_array *vniarray;
+	bool no_bvinfo_avail;
+	bool no_afspec_avail;
 	struct zebra_dplane_bridge_vlan_info bvinfo;
 	struct zebra_dplane_bridge_vlan_info_array *bvarray;
 
@@ -1353,6 +1355,34 @@ dplane_ctx_get_ifp_vxlan_vni_array(const struct zebra_dplane_ctx *ctx)
 	DPLANE_CTX_VALID(ctx);
 
 	return ctx->u.intf.vniarray;
+}
+
+void dplane_ctx_set_ifp_no_afspec(struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	ctx->u.intf.no_afspec_avail = true;
+}
+
+bool dplane_ctx_get_ifp_no_afspec(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.intf.no_afspec_avail;
+}
+
+void dplane_ctx_set_ifp_no_bridge_vlan_info(struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	ctx->u.intf.no_bvinfo_avail = true;
+}
+
+bool dplane_ctx_get_ifp_no_bridge_vlan_info(struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.intf.no_bvinfo_avail;
 }
 
 void dplane_ctx_set_ifp_bridge_vlan_info(

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -429,6 +429,10 @@ struct zebra_dplane_bridge_vlan_info {
 	uint16_t flags;
 	uint16_t vid;
 };
+void dplane_ctx_set_ifp_no_afspec(struct zebra_dplane_ctx *ctx);
+bool dplane_ctx_get_ifp_no_afspec(const struct zebra_dplane_ctx *ctx);
+void dplane_ctx_set_ifp_no_bridge_vlan_info(struct zebra_dplane_ctx *ctx);
+bool dplane_ctx_get_ifp_no_bridge_vlan_info(struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_ifp_bridge_vlan_info(
 	struct zebra_dplane_ctx *ctx,
 	struct zebra_dplane_bridge_vlan_info *bvinfo);

--- a/zebra/zebra_l2.c
+++ b/zebra/zebra_l2.c
@@ -383,7 +383,8 @@ void zebra_l2_vxlanif_update_access_vlan(struct interface *ifp,
 	assert(zif);
 
 	/* This would be called only in non svd case */
-	assert(IS_ZEBRA_VXLAN_IF_VNI(zif));
+	if (!IS_ZEBRA_VXLAN_IF_VNI(zif))
+		return;
 
 	old_access_vlan = zif->l2info.vxl.vni_info.vni.access_vlan;
 	;


### PR DESCRIPTION
Upon some internal testing some crashes were found.  This fixes the several crashes and normalizes the code to be closer in it's execution pre and post changes to use the data plane.