### PR TITLE
bgpd: Free memory in set_aspath_replace_access_list

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -6163,6 +6163,7 @@ DEFPY_YANG(
 	char xpath_value[XPATH_MAXLEN];
 	as_t as_configured_value;
 	char replace_value[ASN_STRING_MAX_SIZE * 2];
+	int ret;
 
 	if (configured_asn_str &&
 	    !asn_str2asn(configured_asn_str, &as_configured_value)) {
@@ -6181,7 +6182,9 @@ DEFPY_YANG(
 		 "%s/rmap-set-action/frr-bgp-route-map:replace-as-path", xpath);
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, str);
 
-	return nb_cli_apply_changes(vty, NULL);
+	ret = nb_cli_apply_changes(vty, NULL);
+	XFREE(MTYPE_TMP, str);
+	return ret;
 }
 
 DEFPY_YANG(


### PR DESCRIPTION
Properly free the dynamically allocated memory held by `str` after its use. The change also maintains the return value of `nb_cli_apply_changes` by using `ret` variable.

The ASan leak log for reference:

```
***********************************************************************************
Address Sanitizer Error detected in bgp_set_aspath_replace.test_bgp_set_aspath_replace/r1.asan.bgpd.11586

=================================================================
==11586==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 92 byte(s) in 3 object(s) allocated from:
    #0 0x7f4e2951db40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f4e28f19ea2 in qmalloc lib/memory.c:100
    #2 0x7f4e28edbb08 in frrstr_join lib/frrstr.c:89
    #3 0x7f4e28e9a601 in argv_concat lib/command.c:183
    #4 0x56519adf8413 in set_aspath_replace_access_list_magic bgpd/bgp_routemap.c:6174
    #5 0x56519adf8942 in set_aspath_replace_access_list bgpd/bgp_routemap_clippy.c:683
    #6 0x7f4e28e9d548 in cmd_execute_command_real lib/command.c:993
    #7 0x7f4e28e9da0c in cmd_execute_command lib/command.c:1051
    #8 0x7f4e28e9de8b in cmd_execute lib/command.c:1218
    #9 0x7f4e28fc4f1c in vty_command lib/vty.c:591
    #10 0x7f4e28fc53c7 in vty_execute lib/vty.c:1354
    #11 0x7f4e28fcdc8d in vtysh_read lib/vty.c:2362
    #12 0x7f4e28fb8c8b in event_call lib/event.c:1979
    #13 0x7f4e28efd445 in frr_run lib/libfrr.c:1213
    #14 0x56519ac85d81 in main bgpd/bgp_main.c:510
    #15 0x7f4e27f40c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 92 byte(s) leaked in 3 allocation(s).
***********************************************************************************

***********************************************************************************
Address Sanitizer Error detected in bgp_set_aspath_exclude.test_bgp_set_aspath_exclude/r1.asan.bgpd.10385

=================================================================
==10385==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 55 byte(s) in 2 object(s) allocated from:
    #0 0x7f6814fdab40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f68149d6ea2 in qmalloc lib/memory.c:100
    #2 0x7f6814998b08 in frrstr_join lib/frrstr.c:89
    #3 0x7f6814957601 in argv_concat lib/command.c:183
    #4 0x5570e05117a1 in set_aspath_exclude_access_list_magic bgpd/bgp_routemap.c:6327
    #5 0x5570e05119da in set_aspath_exclude_access_list bgpd/bgp_routemap_clippy.c:836
    #6 0x7f681495a548 in cmd_execute_command_real lib/command.c:993
    #7 0x7f681495aa0c in cmd_execute_command lib/command.c:1051
    #8 0x7f681495ae8b in cmd_execute lib/command.c:1218
    #9 0x7f6814a81f1c in vty_command lib/vty.c:591
    #10 0x7f6814a823c7 in vty_execute lib/vty.c:1354
    #11 0x7f6814a8ac8d in vtysh_read lib/vty.c:2362
    #12 0x7f6814a75c8b in event_call lib/event.c:1979
    #13 0x7f68149ba445 in frr_run lib/libfrr.c:1213
    #14 0x5570e03a0d81 in main bgpd/bgp_main.c:510
    #15 0x7f68139fdc86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 55 byte(s) leaked in 2 allocation(s).
***********************************************************************************
```