### PR TITLE
pbrd: Correct Handling of Sequence Deletion

### DIFF
--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -62,7 +62,7 @@ static int pbr_map_sequence_compare(const struct pbr_map_sequence *pbrms1,
 	return 1;
 }
 
-static void pbr_map_sequence_delete(struct pbr_map_sequence *pbrms)
+void pbr_map_sequence_delete(struct pbr_map_sequence *pbrms)
 {
 	XFREE(MTYPE_TMP, pbrms->internal_nhg_name);
 

--- a/pbrd/pbr_map.h
+++ b/pbrd/pbr_map.h
@@ -251,6 +251,8 @@ extern void pbr_map_policy_install(const char *name);
 extern void pbr_map_policy_delete(struct pbr_map *pbrm,
 				  struct pbr_map_interface *pmi);
 
+extern void pbr_map_sequence_delete(struct pbr_map_sequence *pbrms);
+
 extern void pbr_map_check_vrf_nh_group_change(const char *nh_group,
 					      struct pbr_vrf *pbr_vrf,
 					      uint32_t old_vrf_id);

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -123,6 +123,7 @@ DEFUN_NOSH(no_pbr_map,
 			continue;
 
 		pbr_map_delete(pbrms);
+		pbr_map_sequence_delete(pbrms);
 	}
 
 	return CMD_SUCCESS;


### PR DESCRIPTION
This commit ensures that sequence data and associated structures are correctly deleted to prevent memory leaks

The ASan leak log for reference:
```
Direct leak of 432 byte(s) in 1 object(s) allocated from:
    #0 0x7f911ebaba37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7f911e749a4e in qcalloc ../lib/memory.c:105
    #2 0x564fd444b2d3 in pbrms_get ../pbrd/pbr_map.c:527
    #3 0x564fd443a82d in pbr_map ../pbrd/pbr_vty.c:90
    #4 0x7f911e691d61 in cmd_execute_command_real ../lib/command.c:993
    #5 0x7f911e6920ee in cmd_execute_command ../lib/command.c:1052
    #6 0x7f911e692dc0 in cmd_execute ../lib/command.c:1218
    #7 0x7f911e843197 in vty_command ../lib/vty.c:591
    #8 0x7f911e84807c in vty_execute ../lib/vty.c:1354
    #9 0x7f911e84e47a in vtysh_read ../lib/vty.c:2362
    #10 0x7f911e8332f4 in event_call ../lib/event.c:1979
    #11 0x7f911e71d828 in frr_run ../lib/libfrr.c:1213
    #12 0x564fd4425795 in main ../pbrd/pbr_main.c:168
    #13 0x7f911e2e1d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

```