### PR TITLE
pim, pimv6: Removing upstreams and mroutes when pim configs removed on receiver connected interface.

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -2151,6 +2151,15 @@ static void gm_start(struct interface *ifp)
 	}
 }
 
+void pim_gm_if_reset(struct interface *ifp)
+{
+	struct pim_interface *pim_ifp = ifp->info;
+	struct gm_if *gm_ifp = pim_ifp->mld;
+
+	if (gm_ifp)
+		gm_group_delete(gm_ifp);
+}
+
 void gm_group_delete(struct gm_if *gm_ifp)
 {
 	struct gm_sg *sg;

--- a/pimd/pim6_mld.h
+++ b/pimd/pim6_mld.h
@@ -357,6 +357,7 @@ struct gm_if {
 #if PIM_IPV == 6
 extern void gm_ifp_update(struct interface *ifp);
 extern void gm_ifp_teardown(struct interface *ifp);
+extern void pim_gm_if_reset(struct interface *ifp);
 extern void gm_group_delete(struct gm_if *gm_ifp);
 #else
 static inline void gm_ifp_update(struct interface *ifp)

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1808,6 +1808,9 @@ void pim_pim_interface_delete(struct interface *ifp)
 	pim_sock_delete(ifp, "pim unconfigured on interface");
 	pim_upstream_nh_if_update(pim_ifp->pim, ifp);
 
+	if (pim_ifp->gm_enable)
+		pim_gm_if_reset(ifp);
+
 	if (!pim_ifp->gm_enable) {
 		pim_if_addr_del_all(ifp);
 		pim_if_delete(ifp);

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -201,7 +201,7 @@ void pim_if_delete(struct interface *ifp)
 
 	pim_if_del_vif(ifp);
 
-	pim_igmp_if_fini(pim_ifp);
+	pim_igmp_if_fini(ifp);
 
 	list_delete(&pim_ifp->pim_neighbor_list);
 	list_delete(&pim_ifp->upstream_switch_list);

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -1232,8 +1232,6 @@ void pim_ifchannel_local_membership_del(struct interface *ifp, pim_sgaddr *sg)
 	pim_ifp = ifp->info;
 	if (!pim_ifp)
 		return;
-	if (!pim_ifp->pim_enable)
-		return;
 
 	orig = ch = pim_ifchannel_find(ifp, sg);
 	if (!ch)

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -1146,8 +1146,9 @@ void pim_igmp_if_reset(struct pim_interface *pim_ifp)
 	}
 }
 
-void pim_igmp_if_fini(struct pim_interface *pim_ifp)
+void pim_igmp_if_fini(struct interface *ifp)
 {
+	struct pim_interface *pim_ifp = ifp->info;
 	pim_igmp_if_reset(pim_ifp);
 
 	assert(pim_ifp->gm_group_list);

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -1074,10 +1074,12 @@ void igmp_sock_free(struct gm_sock *igmp)
 
 void igmp_sock_delete(struct gm_sock *igmp)
 {
+	struct interface *ifp;
 	struct pim_interface *pim_ifp;
 
 	sock_close(igmp);
 
+	ifp = igmp->interface;
 	pim_ifp = igmp->interface->info;
 
 	listnode_delete(pim_ifp->gm_socket_list, igmp);
@@ -1085,7 +1087,7 @@ void igmp_sock_delete(struct gm_sock *igmp)
 	igmp_sock_free(igmp);
 
 	if (!listcount(pim_ifp->gm_socket_list))
-		pim_igmp_if_reset(pim_ifp);
+		pim_gm_if_reset(ifp);
 }
 
 void igmp_sock_delete_all(struct interface *ifp)
@@ -1135,8 +1137,9 @@ void pim_igmp_if_init(struct pim_interface *pim_ifp, struct interface *ifp)
 					     igmp_group_hash_equal, hash_name);
 }
 
-void pim_igmp_if_reset(struct pim_interface *pim_ifp)
+void pim_gm_if_reset(struct interface *ifp)
 {
+	struct pim_interface *pim_ifp = ifp->info;
 	struct listnode *grp_node, *grp_nextnode;
 	struct gm_group *grp;
 
@@ -1149,7 +1152,8 @@ void pim_igmp_if_reset(struct pim_interface *pim_ifp)
 void pim_igmp_if_fini(struct interface *ifp)
 {
 	struct pim_interface *pim_ifp = ifp->info;
-	pim_igmp_if_reset(pim_ifp);
+
+	pim_gm_if_reset(ifp);
 
 	assert(pim_ifp->gm_group_list);
 	assert(!listcount(pim_ifp->gm_group_list));

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -83,7 +83,7 @@ struct pim_interface;
 #if PIM_IPV == 4
 void pim_igmp_if_init(struct pim_interface *pim_ifp, struct interface *ifp);
 void pim_igmp_if_reset(struct pim_interface *pim_ifp);
-void pim_igmp_if_fini(struct pim_interface *pim_ifp);
+void pim_igmp_if_fini(struct interface *ifp);
 
 struct gm_sock *pim_igmp_sock_lookup_ifaddr(struct list *igmp_sock_list,
 					    struct in_addr ifaddr);
@@ -108,7 +108,7 @@ static inline void pim_igmp_if_init(struct pim_interface *pim_ifp,
 {
 }
 
-static inline void pim_igmp_if_fini(struct pim_interface *pim_ifp)
+static inline void pim_igmp_if_fini(struct interface *ifp)
 {
 }
 

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -82,7 +82,7 @@ struct pim_interface;
 
 #if PIM_IPV == 4
 void pim_igmp_if_init(struct pim_interface *pim_ifp, struct interface *ifp);
-void pim_igmp_if_reset(struct pim_interface *pim_ifp);
+void pim_gm_if_reset(struct interface *ifp);
 void pim_igmp_if_fini(struct interface *ifp);
 
 struct gm_sock *pim_igmp_sock_lookup_ifaddr(struct list *igmp_sock_list,


### PR DESCRIPTION
When the (no ip pim/no ipv6 pim) pim/pimv6 configuration is removed from the receiver-connected interface in LHR, we observe inconsistent behavior in following scenarios.

1) When there is no pim/pimv6 configuration at the beginning and the traffic is initiated, no multicast routes are formed, and there is no available upstream 

```
frr# show ip pim upstream
 Iif  Source  Group  State  Uptime  JoinTimer  RSTimer  KATimer  RefCnt

frr# show ip mroute
IP Multicast Routing Table
Flags: S - Sparse, C - Connected, P - Pruned
       R - SGRpt Pruned, F - Register flag, T - SPT-bit set
 Source  Group  Flags  Proto  Input  Output  TTL  Uptime
```

2) When the traffic is flowing and we remove the pim/pimv6 config in between, the (*,G) upstream transitions into the NotJ state, yet the mroutes remain intact.

```
frr# show ip mroute
IP Multicast Routing Table
Flags: S - Sparse, C - Connected, P - Pruned
       R - SGRpt Pruned, F - Register flag, T - SPT-bit set
 Source  Group      Flags  Proto  Input   Output  TTL  Uptime
 *       226.1.1.1  SC     IGMP   ens224  pimreg  1    00:00:56
                           IGMP           ens192  1

frr# show ip pim upstream
 Iif     Source  Group      State  Uptime    JoinTimer  RSTimer   KATimer   RefCnt
 ens224  *       226.1.1.1  NotJ   00:00:13  00:00:55   --:--:--  --:--:--  1

```
Hence, to make the behaviour consistent, we remove both the upstream entries for (*,G) and the corresponding mroutes using the 'pim_igmp_if_reset' API call when dealing with the receiver-connected interface. The 'pim_ifchannel_local_membership_del' is returned when no ip pim/pimv6 config is applied due to 'pim_ifp->pim_enable' check. Therefore, removing this check in order to proceed with the deletion when the pim/pimv6 configurations are removed.

Closes #13890 