### PR TITLE
bgpd: set ifindex only for v6 nexthops and nexthops that match peer's LL

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -317,11 +317,18 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop,
 			return 1;
 
 		/*
-		 * If path is learnt from an interface based peer,
+		 * If it's a V6 nexthop, path is learnt from a v6 LL peer,
+		 * and if the NH prefix matches peer's LL address then
 		 * set the ifindex to peer's interface index so that
 		 * correct nexthop can be found in nexthop tree.
+		 *
+		 * NH could be set to different v6 LL address (compared to
+		 * peer's LL) using route-map. In such a scenario, do not set
+		 * the ifindex.
 		 */
-		if (pi->peer->conf_if)
+		if (afi == AFI_IP6 &&
+		    IN6_IS_ADDR_LINKLOCAL(&pi->peer->su.sin6.sin6_addr) &&
+		    IPV6_ADDR_SAME(&pi->peer->su.sin6.sin6_addr, &p.u.prefix6))
 			ifindex = pi->peer->su.sin6.sin6_scope_id;
 
 		if (!is_bgp_static_route && orig_prefix

--- a/tests/topotests/bgp_blackhole_community/r4/bgpd.conf
+++ b/tests/topotests/bgp_blackhole_community/r4/bgpd.conf
@@ -4,3 +4,10 @@ router bgp 65002
   no bgp ebgp-requires-policy
   neighbor r4-eth0 interface remote-as internal
 !
+address-family ipv4 unicast
+  neighbor r4-eth0 route-map FOO in
+exit-address-family
+!
+route-map FOO permit 10
+ set ipv6 next-hop local fe80::202:ff:fe00:99
+exit

--- a/tests/topotests/bgp_vpn_5549_route_map/test_bgp_vpn_5549_route_map.py
+++ b/tests/topotests/bgp_vpn_5549_route_map/test_bgp_vpn_5549_route_map.py
@@ -115,9 +115,55 @@ def test_bgp_vpn_5549():
         }
         return topotest.json_cmp(output, expected)
 
+    def _bgp_verify_v4_nexthop_validity():
+        output = json.loads(tgen.gears["cpe1"].vtysh_cmd("show bgp nexthop json"))
+        expected = {
+            "ipv4": {
+                "192.168.1.2": {
+                    "valid": True,
+                    "complete": True,
+                    "igpMetric": 0,
+                    "pathCount": 0,
+                    "nexthops": [{"interfaceName": "cpe1-eth0"}],
+                },
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_verify_v6_global_nexthop_validity():
+        output = json.loads(tgen.gears["pe2"].vtysh_cmd("show bgp nexthop json"))
+        expected = {
+            "ipv6": {
+                "2001:db8::1": {
+                    "valid": True,
+                    "complete": True,
+                    "igpMetric": 0,
+                    "pathCount": 2,
+                    "nexthops": [{"interfaceName": "pe2-eth0"}],
+                },
+                "2001:db8:1::1": {
+                    "valid": True,
+                    "complete": True,
+                    "igpMetric": 20,
+                    "pathCount": 2,
+                    "peer": "2001:db8:1::1",
+                    "nexthops": [{"interfaceName": "pe2-eth0"}],
+                },
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
     test_func = functools.partial(_bgp_vpn_nexthop_changed)
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, "Failed overriding IPv6 next-hop for VPN underlay"
+
+    test_func = functools.partial(_bgp_verify_v4_nexthop_validity)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "IPv4 nexthop is invalid"
+
+    test_func = functools.partial(_bgp_verify_v6_global_nexthop_validity)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "IPv6 nexthop is invalid"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For v4 nexthops, ifindex was being set. Modified the check to set ifindex only for v6 nexthops. Also modified the check to set ifindex only if the v6 nexthop matches peer's LL address.

UT:

Test 1:
```
Without AFI == IPv6 check:
=========================

mlx-3700-19# show bgp nexthop 
Current BGP nexthop cache:
 27.0.0.15 invalid, #paths 32
  Last update: Thu Aug 17 18:05:30 2023----> invalid IPv4 NH was created 

 27.0.0.16 invalid, #paths 31
  Last update: Thu Aug 17 18:05:30 2023

 36.0.0.13 invalid, #paths 72
  Last update: Thu Aug 17 18:05:30 2023

 27.0.0.15 invalid, #paths 32
  Last update: Thu Aug 17 18:05:30 2023

 27.0.0.16 invalid, #paths 31
  Last update: Thu Aug 17 18:05:30 2023

 36.0.0.13 invalid, #paths 72
  Last update: Thu Aug 17 18:05:30 2023

 27.0.0.15 invalid, #paths 32
  Last update: Thu Aug 17 18:05:30 2023

 27.0.0.16 invalid, #paths 31
  Last update: Thu Aug 17 18:05:30 2023

 36.0.0.13 invalid, #paths 72
  Last update: Thu Aug 17 18:05:30 2023

 fe80::202:ff:fe00:11 valid [IGP metric 0], #paths 10, peer uplink-1
  Last update: Thu Aug 17 18:43:55 2023

 fe80::202:ff:fe00:1d valid [IGP metric 0], #paths 10, peer uplink-2
  Last update: Thu Aug 17 18:43:55 2023

 fe80::202:ff:fe00:35 valid [IGP metric 0], #paths 9, peer peerlink-3.4094
  Last update: Thu Aug 17 18:43:54 2023


With AFI == IPv6 check:
=====================
mlx-3700-19# show bgp nexthop --------------> Both ipv4 and ipv6 nexthops are valid
Current BGP nexthop cache:
 27.0.0.15 valid [IGP metric 0], #paths 96. 
  gate fe80::202:ff:fe00:11, if uplink-1
  gate fe80::202:ff:fe00:1d, if uplink-2
  Last update: Thu Aug 17 18:52:56 2023

 27.0.0.16 valid [IGP metric 0], #paths 93
  gate fe80::202:ff:fe00:11, if uplink-1
  gate fe80::202:ff:fe00:1d, if uplink-2
  Last update: Thu Aug 17 18:52:56 2023

 36.0.0.13 valid [IGP metric 0], #paths 216
  gate fe80::202:ff:fe00:11, if uplink-1
  gate fe80::202:ff:fe00:1d, if uplink-2
  Last update: Thu Aug 17 18:52:56 2023

 fe80::202:ff:fe00:11 valid [IGP metric 0], #paths 10, peer uplink-1
  Last update: Thu Aug 17 18:52:55 2023

 fe80::202:ff:fe00:1d valid [IGP metric 0], #paths 10, peer uplink-2
  Last update: Thu Aug 17 18:52:55 2023

 fe80::202:ff:fe00:35 valid [IGP metric 0], #paths 9, peer peerlink-3.4094
  Last update: Thu Aug 17 18:52:53 2023
```


Test 2: Nexthop of prefixes changed to LL address at neighbor in 
=================================================

Before applying route map at neighbor in:

```
r8# show bgp  ipv4 unicast 10.0.0.4/32
BGP routing table entry for 10.0.0.4/32, version 4
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  r1(swp1)
  10 40
    fe80::202:ff:fe00:6 (r1) from r1(swp1) (90.0.0.1)
    (fe80::202:ff:fe00:6) (used)
      Origin IGP, valid, external, bestpath-from-AS 10, best (First path received)
      Last update: Thu Aug 17 23:37:47 2023
```

Apply route map to change NH at neighbor in:

Without fix:
```
router bgp 80
 bgp router-id 10.0.0.8
 no bgp default ipv4-unicast
 neighbor swp1 interface remote-as 10
 neighbor swp1 description r1
 neighbor swp1 advertisement-interval 0
 !
 address-family ipv4 unicast
  network 10.0.0.8/32
  neighbor swp1 activate
  neighbor swp1 soft-reconfiguration inbound
  neighbor swp1 route-map FOO in ----> Route map applied to change NH of prefixes
 exit-address-family
 !
 address-family ipv6 unicast
  network 2001:10::8/128
 exit-address-family
exit
!
route-map FOO permit 10
 set ipv6 next-hop local fe80::202:ff:fe00:99
exit
!
line vty
 exec-timeout 0 0
exit
!
end

r8# show bgp  ipv4 unicast 10.0.0.4/32
BGP routing table entry for 10.0.0.4/32, version 94
Paths: (1 available, no best path)
  Not advertised to any peer
  10 40
    fe80::202:ff:fe00:6 (r1) (inaccessible) from r1(swp1) (90.0.0.1) --> NH is unresolved!!
    (fe80::202:ff:fe00:99) (used)
      Origin IGP, invalid, external
      Last update: Thu Aug 17 23:28:05 2023

r8# show bgp nexthop 
Current BGP nexthop cache:
 fe80::202:ff:fe00:6 valid [IGP metric 0], #paths 0, peer swp1
  Last update: Thu Aug 17 23:27:38 2023

 fe80::202:ff:fe00:99 invalid, #paths 6. ----> NH marked invalid!!
  Must be Connected
  Last update: Thu Aug 17 23:23:34 2023




With fix (I.e ifindex set only if peer's LL matches the nexthop LL):
==================================================


r8# show bgp summary 

IPv4 Unicast Summary (VRF default):
BGP router identifier 10.0.0.8, local AS number 80 vrf-id 0
BGP table version 13
RIB entries 13, using 2496 bytes of memory
Peers 1, using 20 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
r1(swp1)        4         10        37        33        0    0    0 00:00:55            6        7 r1

Total number of neighbors 1

r8# show bgp ipv4 unicast 
BGP table version is 13, local router ID is 10.0.0.8, vrf id 0
Default local pref 100, local AS 80
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          Next Hop            Metric LocPrf Weight Path
*> 10.0.0.2/32      swp1                                   0 10 i
*> 10.0.0.3/32      swp1                                   0 10 i
*> 10.0.0.4/32      swp1                                   0 10 40 i
*> 10.0.0.7/32      swp1                                   0 10 i
*> 10.0.0.8/32      0.0.0.0(r8)              0         32768 i
*> 50.0.0.6/32      swp1                                   0 10 i
*> 90.0.0.1/32      swp1                     0             0 10 i

Displayed  7 routes and 7 total paths


r8# show bgp  ipv4 unicast 10.0.0.4/32
BGP routing table entry for 10.0.0.4/32, version 10
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  r1(swp1)
  10 40
    fe80::202:ff:fe00:6 (r1) from r1(swp1) (90.0.0.1). ---> Path is resolved correctly!
    (fe80::202:ff:fe00:99) (used)
      Origin IGP, valid, external, bestpath-from-AS 10, best (First path received)
      Last update: Thu Aug 17 23:38:36 2023
r8# 
r8# 
r8# show bgp nexthop 
Current BGP nexthop cache:
 fe80::202:ff:fe00:99 valid [IGP metric 0], #paths 6 ---> Nexthop is valid
  if swp1
  Last update: Thu Aug 17 23:38:36 2023

 fe80::202:ff:fe00:6 valid [IGP metric 0], #paths 0, peer swp1
  Last update: Thu Aug 17 23:37:46 2023

r8# 

```