### PR TITLE
bgpd: Free memory in set_aspath_exclude_access_list

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -6326,6 +6326,7 @@ DEFPY_YANG(set_aspath_exclude_access_list, set_aspath_exclude_access_list_cmd,
 	const char *xpath =
 		"./set-action[action='frr-bgp-route-map:as-path-exclude']";
 	char xpath_value[XPATH_MAXLEN];
+	int ret;
 
 	str = argv_concat(argv, argc, 3);
 
@@ -6335,7 +6336,9 @@ DEFPY_YANG(set_aspath_exclude_access_list, set_aspath_exclude_access_list_cmd,
 		 "%s/rmap-set-action/frr-bgp-route-map:exclude-as-path", xpath);
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, str);
 
-	return nb_cli_apply_changes(vty, NULL);
+	ret = nb_cli_apply_changes(vty, NULL);
+	XFREE(MTYPE_TMP, str);
+	return ret;
 }
 
 DEFPY_YANG(no_set_aspath_exclude_access_list, no_set_aspath_exclude_access_list_cmd,


### PR DESCRIPTION
Properly free the dynamically allocated memory held by `str` after its use. The change also maintains the return value of `nb_cli_apply_changes` by using `ret` variable.

The ASan leak log for reference:

```
Direct leak of 55 byte(s) in 2 object(s) allocated from:
    #0 0x7f16f285f867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f16f23fda11 in qmalloc ../lib/memory.c:100
    #2 0x7f16f23a01a0 in frrstr_join ../lib/frrstr.c:89
    #3 0x7f16f23418c7 in argv_concat ../lib/command.c:183
    #4 0x55aba24731f2 in set_aspath_exclude_access_list_magic ../bgpd/bgp_routemap.c:6327
    #5 0x55aba2455cf4 in set_aspath_exclude_access_list bgpd/bgp_routemap_clippy.c:836
    #6 0x7f16f2345d61 in cmd_execute_command_real ../lib/command.c:993
    #7 0x7f16f23460ee in cmd_execute_command ../lib/command.c:1052
    #8 0x7f16f2346dc0 in cmd_execute ../lib/command.c:1218
    #9 0x7f16f24f7197 in vty_command ../lib/vty.c:591
    #10 0x7f16f24fc07c in vty_execute ../lib/vty.c:1354
    #11 0x7f16f250247a in vtysh_read ../lib/vty.c:2362
    #12 0x7f16f24e72f4 in event_call ../lib/event.c:1979
    #13 0x7f16f23d1828 in frr_run ../lib/libfrr.c:1213
    #14 0x55aba2269e52 in main ../bgpd/bgp_main.c:510
    #15 0x7f16f1dbfd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
```