### PR TITLE
pbrd: Free Memory in pbr_map_delete

### DIFF
--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -357,6 +357,11 @@ extern void pbr_map_delete(struct pbr_map_sequence *pbrms)
 	if (pbrms->nhg)
 		pbr_nht_delete_individual_nexthop(pbrms);
 
+	if (pbrms->nhgrp_name)
+		XFREE(MTYPE_TMP, pbrms->nhgrp_name);
+
+	prefix_free(&pbrms->dst);
+
 	listnode_delete(pbrm->seqnumbers, pbrms);
 
 	if (pbrm->seqnumbers->count == 0) {


### PR DESCRIPTION
This commit frees dynamically allocated memory associated with `pbrms->nhgrp_name` and `pbrms->dst` which were causing memory leaks.

The ASan leak log for reference:

```
=================================================================
==107458==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7f87d644ca37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7f87d5feaa37 in qcalloc ../lib/memory.c:105
    #2 0x7f87d6054ffd in prefix_new ../lib/prefix.c:1180
    #3 0x55722f3c2885 in pbr_map_match_dst_magic ../pbrd/pbr_vty.c:302
    #4 0x55722f3b5c24 in pbr_map_match_dst pbrd/pbr_vty_clippy.c:228
    #5 0x7f87d5f32d61 in cmd_execute_command_real ../lib/command.c:993
    #6 0x7f87d5f330ee in cmd_execute_command ../lib/command.c:1052
    #7 0x7f87d5f33dc0 in cmd_execute ../lib/command.c:1218
    #8 0x7f87d60e4177 in vty_command ../lib/vty.c:591
    #9 0x7f87d60e905c in vty_execute ../lib/vty.c:1354
    #10 0x7f87d60ef45a in vtysh_read ../lib/vty.c:2362
    #11 0x7f87d60d42d4 in event_call ../lib/event.c:1979
    #12 0x7f87d5fbe828 in frr_run ../lib/libfrr.c:1213
    #13 0x55722f3ac795 in main ../pbrd/pbr_main.c:168
    #14 0x7f87d5b82d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Direct leak of 2 byte(s) in 1 object(s) allocated from:
    #0 0x7f87d63f39a7 in __interceptor_strdup ../../../../src/libsanitizer/asan/asan_interceptors.cpp:454
    #1 0x7f87d5feaafc in qstrdup ../lib/memory.c:117
    #2 0x55722f3da139 in pbr_nht_set_seq_nhg ../pbrd/pbr_nht.c:551
    #3 0x55722f3c693f in pbr_map_nexthop_group_magic ../pbrd/pbr_vty.c:1140
    #4 0x55722f3bdaae in pbr_map_nexthop_group pbrd/pbr_vty_clippy.c:1284
    #5 0x7f87d5f32d61 in cmd_execute_command_real ../lib/command.c:993
    #6 0x7f87d5f330ee in cmd_execute_command ../lib/command.c:1052
    #7 0x7f87d5f33dc0 in cmd_execute ../lib/command.c:1218
    #8 0x7f87d60e4177 in vty_command ../lib/vty.c:591
    #9 0x7f87d60e905c in vty_execute ../lib/vty.c:1354
    #10 0x7f87d60ef45a in vtysh_read ../lib/vty.c:2362
    #11 0x7f87d60d42d4 in event_call ../lib/event.c:1979
    #12 0x7f87d5fbe828 in frr_run ../lib/libfrr.c:1213
    #13 0x55722f3ac795 in main ../pbrd/pbr_main.c:168
    #14 0x7f87d5b82d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 58 byte(s) leaked in 2 allocation(s).
```