### PR TITLE
ospfd: Delete `q_space->vertex_list` on No Backup Path

### DIFF
--- a/ospfd/ospf_ti_lfa.c
+++ b/ospfd/ospf_ti_lfa.c
@@ -694,6 +694,7 @@ static void ospf_ti_lfa_generate_q_spaces(struct ospf_area *area,
 			__func__, &p_space->root->id, &q_space->root->id,
 			res_buf);
 
+		list_delete(&q_space->vertex_list);
 		XFREE(MTYPE_OSPF_Q_SPACE, q_space->p_node_info);
 		XFREE(MTYPE_OSPF_Q_SPACE, q_space->q_node_info);
 		XFREE(MTYPE_OSPF_Q_SPACE, q_space);


### PR DESCRIPTION
In scenarios where no backup paths are available, ensure proper memory management by deleting `q_space->vertex_list`. This prevents memory leaks.

The ASan leak log for reference:

```
Direct leak of 80 byte(s) in 2 object(s) allocated from:
    #0 0x7fcf8c70aa37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7fcf8c2a8a45 in qcalloc ../lib/memory.c:105
    #2 0x7fcf8c27d0cc in list_new ../lib/linklist.c:49
    #3 0x55d6e8385e35 in ospf_spf_init ../ospfd/ospf_spf.c:540
    #4 0x55d6e838c30d in ospf_spf_calculate ../ospfd/ospf_spf.c:1736
    #5 0x55d6e83933cf in ospf_ti_lfa_generate_q_spaces ../ospfd/ospf_ti_lfa.c:673
    #6 0x55d6e8394214 in ospf_ti_lfa_generate_p_space ../ospfd/ospf_ti_lfa.c:812
    #7 0x55d6e8394c63 in ospf_ti_lfa_generate_p_spaces ../ospfd/ospf_ti_lfa.c:923
    #8 0x55d6e8396390 in ospf_ti_lfa_compute ../ospfd/ospf_ti_lfa.c:1101
    #9 0x55d6e838ca48 in ospf_spf_calculate_area ../ospfd/ospf_spf.c:1811
    #10 0x55d6e838cd73 in ospf_spf_calculate_areas ../ospfd/ospf_spf.c:1840
    #11 0x55d6e838cfb0 in ospf_spf_calculate_schedule_worker ../ospfd/ospf_spf.c:1871
    #12 0x7fcf8c3922e4 in event_call ../lib/event.c:1979
    #13 0x7fcf8c27c828 in frr_run ../lib/libfrr.c:1213
    #14 0x55d6e82eeb6d in main ../ospfd/ospf_main.c:249
    #15 0x7fcf8bd59d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

```