### PR TITLE
lib: Clear Computed Path Pointer to Destination on Clean

### DIFF
--- a/lib/cspf.c
+++ b/lib/cspf.c
@@ -331,6 +331,8 @@ void cspf_clean(struct cspf *algo)
 	if (processed_count(&algo->processed)) {
 		frr_each_safe (processed, &algo->processed, path) {
 			processed_del(&algo->processed, path);
+			if (path == algo->pdst)
+				algo->pdst = NULL;
 			cpath_del(path);
 		}
 	}
@@ -342,6 +344,9 @@ void cspf_clean(struct cspf *algo)
 			vnode_del(vnode);
 		}
 	}
+
+	if (algo->pdst)
+		cpath_del(algo->pdst);
 
 	memset(&algo->csts, 0, sizeof(struct constraints));
 	algo->path = NULL;


### PR DESCRIPTION
This commit ensures proper cleanup by clearing the `algo->pdst` pointer if it points to a path that is being deleted. It addresses memory leaks by freeing memory held by `algo->pdst` that might not have been released during the cleanup of processed paths.

The ASan leak log for reference:

```
Direct leak of 96 byte(s) in 1 object(s) allocated from:
    #0 0x7fbffcec9a37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7fbffca67a81 in qcalloc ../lib/memory.c:105
    #2 0x7fbffc9d1a54 in cpath_new ../lib/cspf.c:44
    #3 0x7fbffc9d2829 in cspf_init ../lib/cspf.c:256
    #4 0x7fbffc9d295d in cspf_init_v4 ../lib/cspf.c:287
    #5 0x5601dcd34d3f in show_sharp_cspf_magic ../sharpd/sharp_vty.c:1262
    #6 0x5601dcd2c2be in show_sharp_cspf sharpd/sharp_vty_clippy.c:1869
    #7 0x7fbffc9afd61 in cmd_execute_command_real ../lib/command.c:993
    #8 0x7fbffc9b00ee in cmd_execute_command ../lib/command.c:1052
    #9 0x7fbffc9b0dc0 in cmd_execute ../lib/command.c:1218
    #10 0x7fbffcb611c7 in vty_command ../lib/vty.c:591
    #11 0x7fbffcb660ac in vty_execute ../lib/vty.c:1354
    #12 0x7fbffcb6c4aa in vtysh_read ../lib/vty.c:2362
    #13 0x7fbffcb51324 in event_call ../lib/event.c:1979
    #14 0x7fbffca3b872 in frr_run ../lib/libfrr.c:1213
    #15 0x5601dcd11c6f in main ../sharpd/sharp_main.c:177
    #16 0x7fbffc5ffd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Indirect leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7fbffcec9a37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7fbffca67a81 in qcalloc ../lib/memory.c:105
    #2 0x7fbffca3c108 in list_new ../lib/linklist.c:49
    #3 0x7fbffc9d1acc in cpath_new ../lib/cspf.c:47
    #4 0x7fbffc9d2829 in cspf_init ../lib/cspf.c:256
    #5 0x7fbffc9d295d in cspf_init_v4 ../lib/cspf.c:287
    #6 0x5601dcd34d3f in show_sharp_cspf_magic ../sharpd/sharp_vty.c:1262
    #7 0x5601dcd2c2be in show_sharp_cspf sharpd/sharp_vty_clippy.c:1869
    #8 0x7fbffc9afd61 in cmd_execute_command_real ../lib/command.c:993
    #9 0x7fbffc9b00ee in cmd_execute_command ../lib/command.c:1052
    #10 0x7fbffc9b0dc0 in cmd_execute ../lib/command.c:1218
    #11 0x7fbffcb611c7 in vty_command ../lib/vty.c:591
    #12 0x7fbffcb660ac in vty_execute ../lib/vty.c:1354
    #13 0x7fbffcb6c4aa in vtysh_read ../lib/vty.c:2362
    #14 0x7fbffcb51324 in event_call ../lib/event.c:1979
    #15 0x7fbffca3b872 in frr_run ../lib/libfrr.c:1213
    #16 0x5601dcd11c6f in main ../sharpd/sharp_main.c:177
    #17 0x7fbffc5ffd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

```