### PR TITLE
[WIP] ospfd: memory leak fix

### DIFF
--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -57,8 +57,6 @@ static void ospf_spf_set_reason(ospf_spf_reason_t reason)
 	spf_reason_flags |= 1 << reason;
 }
 
-static void ospf_vertex_free(void *);
-
 /*
  * Heap related functions, for the managment of the candidates, to
  * be used with pqueue.
@@ -207,7 +205,7 @@ static struct vertex *ospf_vertex_new(struct ospf_area *area,
 	return new;
 }
 
-static void ospf_vertex_free(void *data)
+void ospf_vertex_free(void *data)
 {
 	struct vertex *v = data;
 

--- a/ospfd/ospf_spf.h
+++ b/ospfd/ospf_spf.h
@@ -73,6 +73,7 @@ extern void ospf_spf_calculate_areas(struct ospf *ospf,
 				     struct route_table *all_rtrs,
 				     struct route_table *new_rtrs);
 extern void ospf_rtrs_free(struct route_table *);
+extern void ospf_vertex_free(void *data);
 extern void ospf_spf_cleanup(struct vertex *spf, struct list *vertex_list);
 extern void ospf_spf_copy(struct vertex *vertex, struct list *vertex_list);
 extern void ospf_spf_remove_resource(struct vertex *vertex,

--- a/ospfd/ospf_ti_lfa.c
+++ b/ospfd/ospf_ti_lfa.c
@@ -782,6 +782,7 @@ ospf_ti_lfa_generate_p_space(struct ospf_area *area, struct vertex *child,
 
 	p_space = XCALLOC(MTYPE_OSPF_P_SPACE, sizeof(struct p_space));
 	vertex_list = list_new();
+	vertex_list->del = ospf_vertex_free;
 
 	/* The P-space will get its own SPF tree, so copy the old one */
 	ospf_spf_copy(area->spf, vertex_list);


### PR DESCRIPTION
this fix the memory leak due to vertex copy, Need some more fix to solve the leak due to ```ospf_spf_vertex_parent_copy```.
The leak fix can be found below:
```
Indirect leak of 320 byte(s) in 4 object(s) allocated from:
    #0 0x7f7d1e909a57 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7f7d1e4a79ce in qcalloc ../lib/memory.c:105
    #2 0x5604c03c9351 in ospf_spf_vertex_copy ../ospfd/ospf_spf.c:332
    #3 0x5604c03c9af2 in ospf_spf_copy ../ospfd/ospf_spf.c:400
    #4 0x5604c03c9e09 in ospf_spf_copy ../ospfd/ospf_spf.c:408
    #5 0x5604c03d8ffe in ospf_ti_lfa_generate_p_space ../ospfd/ospf_ti_lfa.c:786
    #6 0x5604c03d9c63 in ospf_ti_lfa_generate_p_spaces ../ospfd/ospf_ti_lfa.c:922
    #7 0x5604c03db390 in ospf_ti_lfa_compute ../ospfd/ospf_ti_lfa.c:1100
    #8 0x5604c03d1a48 in ospf_spf_calculate_area ../ospfd/ospf_spf.c:1811
    #9 0x5604c03d1d73 in ospf_spf_calculate_areas ../ospfd/ospf_spf.c:1840
    #10 0x5604c03d1fb0 in ospf_spf_calculate_schedule_worker ../ospfd/ospf_spf.c:1871
    #11 0x7f7d1e59111c in event_call ../lib/event.c:1979
    #12 0x7f7d1e47b7ca in frr_run ../lib/libfrr.c:1213
    #13 0x5604c0333b6d in main ../ospfd/ospf_main.c:249
    #14 0x7f7d1df58d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Indirect leak of 160 byte(s) in 4 object(s) allocated from:
    #0 0x7f7d1e909a57 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7f7d1e4a79ce in qcalloc ../lib/memory.c:105
    #2 0x7f7d1e47c055 in list_new ../lib/linklist.c:49
    #3 0x5604c03c940c in ospf_spf_vertex_copy ../ospfd/ospf_spf.c:338
    #4 0x5604c03c9af2 in ospf_spf_copy ../ospfd/ospf_spf.c:400
    #5 0x5604c03c9e09 in ospf_spf_copy ../ospfd/ospf_spf.c:408
    #6 0x5604c03d8ffe in ospf_ti_lfa_generate_p_space ../ospfd/ospf_ti_lfa.c:786
    #7 0x5604c03d9c63 in ospf_ti_lfa_generate_p_spaces ../ospfd/ospf_ti_lfa.c:922
    #8 0x5604c03db390 in ospf_ti_lfa_compute ../ospfd/ospf_ti_lfa.c:1100
    #9 0x5604c03d1a48 in ospf_spf_calculate_area ../ospfd/ospf_spf.c:1811
    #10 0x5604c03d1d73 in ospf_spf_calculate_areas ../ospfd/ospf_spf.c:1840
    #11 0x5604c03d1fb0 in ospf_spf_calculate_schedule_worker ../ospfd/ospf_spf.c:1871
    #12 0x7f7d1e59111c in event_call ../lib/event.c:1979
    #13 0x7f7d1e47b7ca in frr_run ../lib/libfrr.c:1213
    #14 0x5604c0333b6d in main ../ospfd/ospf_main.c:249
    #15 0x7f7d1df58d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Indirect leak of 96 byte(s) in 4 object(s) allocated from:
    #0 0x7f7d1e909a57 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7f7d1e4a79ce in qcalloc ../lib/memory.c:105
    #2 0x7f7d1e47c164 in listnode_new ../lib/linklist.c:71
    #3 0x7f7d1e47c273 in listnode_add ../lib/linklist.c:92
    #4 0x5604c03c991e in ospf_spf_copy ../ospfd/ospf_spf.c:393
    #5 0x5604c03c9e09 in ospf_spf_copy ../ospfd/ospf_spf.c:408
    #6 0x5604c03c9e09 in ospf_spf_copy ../ospfd/ospf_spf.c:408
    #7 0x5604c03d8ffe in ospf_ti_lfa_generate_p_space ../ospfd/ospf_ti_lfa.c:786
    #8 0x5604c03d9c63 in ospf_ti_lfa_generate_p_spaces ../ospfd/ospf_ti_lfa.c:922
    #9 0x5604c03db390 in ospf_ti_lfa_compute ../ospfd/ospf_ti_lfa.c:1100
    #10 0x5604c03d1a48 in ospf_spf_calculate_area ../ospfd/ospf_spf.c:1811
    #11 0x5604c03d1d73 in ospf_spf_calculate_areas ../ospfd/ospf_spf.c:1840
    #12 0x5604c03d1fb0 in ospf_spf_calculate_schedule_worker ../ospfd/ospf_spf.c:1871
    #13 0x7f7d1e59111c in event_call ../lib/event.c:1979
    #14 0x7f7d1e47b7ca in frr_run ../lib/libfrr.c:1213
    #15 0x5604c0333b6d in main ../ospfd/ospf_main.c:249
    #16 0x7f7d1df58d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58"
```