### PR TITLE
bgpd: Don't read the first byte of ORF header if we are ahead of stream

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2471,7 +2471,8 @@ static int bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 				 * and 7 bytes of ORF Address-filter entry from
 				 * the stream
 				 */
-				if (*p_pnt & ORF_COMMON_PART_REMOVE_ALL) {
+				if (p_pnt < p_end &&
+				    *p_pnt & ORF_COMMON_PART_REMOVE_ALL) {
 					if (bgp_debug_neighbor_events(peer))
 						zlog_debug(
 							"%pBP rcvd Remove-All pfxlist ORF request",


### PR DESCRIPTION
Reported-by: Iggy Frankovic iggyfran@amazon.com