### PR TITLE
zebra: Prevent protodown_rc from going Bzonkas

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1195,6 +1195,12 @@ static bool if_ignore_set_protodown(const struct interface *ifp, bool new_down,
 
 	zif = ifp->info;
 
+	/*
+	 * FRR does not have enough data to make this request
+	 */
+	if (ifp->ifindex == IFINDEX_INTERNAL)
+		return true;
+
 	/* Current state as we know it */
 	old_down = !!(ZEBRA_IF_IS_PROTODOWN(zif));
 	old_set_down = !!CHECK_FLAG(zif->flags, ZIF_FLAG_SET_PROTODOWN);


### PR DESCRIPTION
The code that handles the protodown_rc setting for VRRP interfaces in zebra is sending a interface
to be set into a protodown state *before* the
interface has been learned by the kernel.  Resulting in crashes when the data plane sends the ctx back
to us saying hey man you are uncool.

Additionally change the protodown code to refuse
to send any protodown_rc codes *until* the interface has actually been learned about from the kernel.

Ticket: 3582375