### PR TITLE
configure.ac: fix protobuf config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1385,7 +1385,9 @@ if test "$enable_protobuf3" = "yes"; then
                   [PROTO3=false && AC_MSG_FAILURE([protobuf3 requested but protobuf-c.h not found.  Install protobuf-c.])])
 fi
 
-AC_DEFINE([HAVE_PROTOBUF], [1], [protobuf])
+if test "$enable_protobuf" != "no"; then
+  AC_DEFINE([HAVE_PROTOBUF], [1], [protobuf])
+fi
 #
 # End of logic for protobuf support.
 #


### PR DESCRIPTION
Bug report:
```
root@adf01781b1eb:~/persist/frr-build/tests/topotests# /usr/lib/frr/zebra -M fpm
frr_init: loader error: dlopen(/usr/lib/frr/modules/zebra_fpm.so): /usr/lib/frr/modules/zebra_fpm.so: undefined symbol: zfpm_protobuf_encode_route
frr_init: loader error: dlopen(/usr/lib/frr/modules/fpm.so): /usr/lib/frr/modules/fpm.so: cannot open shared object file: No such file or directory
frr_init: loader error: dlopen(fpm): fpm: cannot open shared object file: No such file or directory
```

Bug trigger condition ( CI have this set ): 
```
./configure --enable-protobuf=no --enable-fpm=yes
/usr/lib/frr/zebra -M fpm
```

Explain:
Macro `HAVE_PROTOBUF` and compile condition variable `HAVE_PROTOBUF`  in `configure.ac ` is not consistent. 
When configure `disable-protobuf`, compile condition variable `HAVE_PROTOBUF` is 0, but macro is 1. It leads to zebra load protobuf module, but protobuf module is not in symbol table.
![image](https://github.com/FRRouting/frr/assets/43382319/9d83cfac-37bb-4f30-abb8-cc8bd6a98806)
