### PR TITLE
debian: Don't install sample dplane plugin

### DIFF
--- a/debian/not-installed
+++ b/debian/not-installed
@@ -1,3 +1,4 @@
 usr/include
 usr/lib/frr/ospfclient
 usr/lib/frr/rfptest
+usr/lib/*/frr/modules/dplane_sample_plugin.so


### PR DESCRIPTION
Without this, the Debian package build fails because dplane_sample_plugin.so gets compiled but not installed.