### PR TITLE
zebra: Make main routing table (RT_TABLE_MAIN) configurable

### DIFF
--- a/doc/manpages/frr-zebra.rst
+++ b/doc/manpages/frr-zebra.rst
@@ -45,6 +45,11 @@ ROUTES
 
    When the program terminates, do not flush routes installed by zebra from the kernel.
 
+.. option:: -R, --routing-table <tableno>
+
+   Specify which kernel routing table *Zebra* should communicate with.
+   If this option is not specified the default table (RT_TABLE_MAIN) is used.
+
 
 FILES
 =====

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -68,6 +68,12 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
    option and we will use Route Replace Semantics instead of delete
    than add.
 
+.. option:: --routing-table <tableno>
+
+   Specify which kernel routing table *Zebra* should communicate with.
+   If this option is not specified the default table (RT_TABLE_MAIN) is
+   used.
+
 .. option:: --asic-offload=[notify_on_offload|notify_on_ack]
 
    The linux kernel has the ability to use asic-offload ( see switchdev

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1100,11 +1100,11 @@ void rtm_read(struct rt_msghdr *rtm)
 	if (rtm->rtm_type == RTM_GET || rtm->rtm_type == RTM_ADD
 	    || rtm->rtm_type == RTM_CHANGE)
 		rib_add(afi, SAFI_UNICAST, VRF_DEFAULT, proto, 0, zebra_flags,
-			&p, NULL, &nh, 0, RT_TABLE_MAIN, 0, 0, distance, 0,
+			&p, NULL, &nh, 0, rt_table_main_id, 0, 0, distance, 0,
 			false);
 	else
 		rib_delete(afi, SAFI_UNICAST, VRF_DEFAULT, proto, 0,
-			   zebra_flags, &p, NULL, &nh, 0, RT_TABLE_MAIN, 0,
+			   zebra_flags, &p, NULL, &nh, 0, rt_table_main_id, 0,
 			   distance, true);
 }
 

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -69,6 +69,8 @@ uint32_t rcvbufsize = RCVBUFSIZE_MIN;
 uint32_t rcvbufsize = 128 * 1024;
 #endif
 
+uint32_t rt_table_main_id = RT_TABLE_MAIN;
+
 #define OPTION_V6_RR_SEMANTICS 2000
 #define OPTION_ASIC_OFFLOAD    2001
 #define OPTION_V6_WITH_V4_NEXTHOP 2002
@@ -88,6 +90,7 @@ const struct option longopts[] = {
 	{ "nl-bufsize", required_argument, NULL, 's' },
 	{ "v6-rr-semantics", no_argument, NULL, OPTION_V6_RR_SEMANTICS },
 #endif /* HAVE_NETLINK */
+	{"routing-table", optional_argument, NULL, 'R'},
 	{ 0 }
 };
 
@@ -298,7 +301,7 @@ int main(int argc, char **argv)
 
 	frr_preinit(&zebra_di, argc, argv);
 
-	frr_opt_add("baz:e:rK:s:"
+	frr_opt_add("baz:e:rK:s:R:"
 #ifdef HAVE_NETLINK
 		    "n"
 #endif
@@ -319,6 +322,7 @@ int main(int argc, char **argv)
 #else
 		    "  -s,                       Set kernel socket receive buffer size\n"
 #endif /* HAVE_NETLINK */
+		    "  -R, --routing-table       Set kernel routing table\n"
 	);
 
 	while (1) {
@@ -372,6 +376,9 @@ int main(int argc, char **argv)
 				fprintf(stderr,
 					"Rcvbufsize is smaller than recommended value: %d\n",
 					RCVBUFSIZE_MIN);
+			break;
+		case 'R':
+			rt_table_main_id = atoi(optarg);
 			break;
 #ifdef HAVE_NETLINK
 		case 'n':

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -716,7 +716,7 @@ int zebra_import_table(afi_t afi, vrf_id_t vrf_id, uint32_t table_id,
 	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(vrf_id);
 
 	if (!is_zebra_valid_kernel_table(table_id)
-	    || (table_id == RT_TABLE_MAIN))
+	    || (table_id == rt_table_main_id))
 		return -1;
 
 	if (afi >= AFI_MAX)

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -625,6 +625,8 @@ extern pid_t pid;
 
 extern bool v6_rr_semantics;
 
+extern uint32_t rt_table_main_id;
+
 /* Name of hook calls */
 #define ZEBRA_ON_RIB_PROCESS_HOOK_CALL "on_rib_process_dplane_results"
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2476,7 +2476,7 @@ int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *in)
 	 * are trying to give me.  So now we have this little hack.
 	 */
 	if (mroute->family == AF_INET)
-		actual_table = (zvrf->table_id == RT_TABLE_MAIN)
+		actual_table = (zvrf->table_id == rt_table_main_id)
 				       ? RT_TABLE_DEFAULT
 				       : zvrf->table_id;
 	else
@@ -4759,7 +4759,7 @@ ssize_t netlink_mpls_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx,
 	req->n.nlmsg_pid = nl->snl.nl_pid;
 
 	req->r.rtm_family = AF_MPLS;
-	req->r.rtm_table = RT_TABLE_MAIN;
+	req->r.rtm_table = rt_table_main_id;
 	req->r.rtm_dst_len = MPLS_LABEL_LEN_BITS;
 	req->r.rtm_scope = RT_SCOPE_UNIVERSE;
 	req->r.rtm_type = RTN_UNICAST;

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -365,7 +365,7 @@ int is_zebra_valid_kernel_table(uint32_t table_id)
 
 int is_zebra_main_routing_table(uint32_t table_id)
 {
-	if (table_id == RT_TABLE_MAIN)
+	if (table_id == rt_table_main_id)
 		return 1;
 	return 0;
 }

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -371,7 +371,7 @@ struct zebra_vrf *zebra_vrf_alloc(struct vrf *vrf)
 	zebra_vxlan_init_tables(zvrf);
 	zebra_mpls_init_tables(zvrf);
 	zebra_pw_init(zvrf);
-	zvrf->table_id = RT_TABLE_MAIN;
+	zvrf->table_id = rt_table_main_id;
 	/* by default table ID is default one */
 	return zvrf;
 }


### PR DESCRIPTION
Adds a `-R`/`--routing-table` flag to set the main kernel routing table used by zebra.