### PR TITLE
lib: Fix memory leaks in LS Update Functions

### DIFF
--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -523,7 +523,9 @@ struct ls_vertex *ls_vertex_update(struct ls_ted *ted, struct ls_node *node)
 		if (!ls_node_same(old->node, node)) {
 			ls_node_del(old->node);
 			old->node = node;
-		}
+		} else
+			ls_node_del(node);
+
 		old->status = UPDATE;
 		return old;
 	}
@@ -805,7 +807,9 @@ struct ls_edge *ls_edge_update(struct ls_ted *ted,
 		if (!ls_attributes_same(old->attributes, attributes)) {
 			ls_attributes_del(old->attributes);
 			old->attributes = attributes;
-		}
+		} else
+			ls_attributes_del(attributes);
+
 		old->status = UPDATE;
 		return old;
 	}
@@ -902,7 +906,9 @@ struct ls_subnet *ls_subnet_update(struct ls_ted *ted, struct ls_prefix *pref)
 		if (!ls_prefix_same(old->ls_pref, pref)) {
 			ls_prefix_del(old->ls_pref);
 			old->ls_pref = pref;
-		}
+		} else
+			ls_prefix_del(pref);
+
 		old->status = UPDATE;
 		return old;
 	}


### PR DESCRIPTION
Previously when updating vertices, edges and subnets, when no update was required due to existing value matching the new one, memory associated with the new object was not being freed leading to memory leaks. This commit fixes memory leak by freeing memory associated with new object when update is unnecessary.

The ASan leak log for reference:

```
Direct leak of 312 byte(s) in 3 object(s) allocated from:
    #0 0x7faf3afbfa37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7faf3ab5dbcf in qcalloc ../lib/memory.c:105
    #2 0x7faf3ab42e00 in ls_parse_prefix ../lib/link_state.c:1323
    #3 0x7faf3ab43c87 in ls_parse_msg ../lib/link_state.c:1373
    #4 0x7faf3ab476a5 in ls_stream2ted ../lib/link_state.c:1885
    #5 0x564e045046aa in sharp_opaque_handler ../sharpd/sharp_zebra.c:792
    #6 0x7faf3aca35a9 in zclient_read ../lib/zclient.c:4410
    #7 0x7faf3ac47474 in event_call ../lib/event.c:1979
    #8 0x7faf3ab318b4 in frr_run ../lib/libfrr.c:1213
    #9 0x564e044fdc6f in main ../sharpd/sharp_main.c:177
    #10 0x7faf3a6f4d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 312 byte(s) leaked in 3 allocation(s).
```