### PR TITLE
ospf6d: Free Newly Created LSA when Non-Self-Originated Grace LSA is …

### DIFF
--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -1045,6 +1045,7 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 						zlog_debug(
 							"%s, GraceLSA doesn't exist in lsdb, so discarding GraceLSA",
 							__func__);
+					ospf6_lsa_delete(new);
 					return;
 				}
 			} else {


### PR DESCRIPTION
…Discarded

The newly created LSA `new` is now properly freed to prevent memory leaks when a non-self-originated Grace LSA which is not in LSDB is received.

The ASan leak log for reference:

```
Direct leak of 400 byte(s) in 2 object(s) allocated from:
    #0 0x7f70e984bd28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f70e92481c5 in qcalloc lib/memory.c:105
    #2 0x55b35068c975 in ospf6_lsa_alloc ospf6d/ospf6_lsa.c:710
    #3 0x55b35068c9f9 in ospf6_lsa_create ospf6d/ospf6_lsa.c:725
    #4 0x55b35065ab2c in ospf6_receive_lsa ospf6d/ospf6_flood.c:912
    #5 0x55b3506a1413 in ospf6_lsupdate_recv ospf6d/ospf6_message.c:1621
    #6 0x55b3506a1413 in ospf6_read_helper ospf6d/ospf6_message.c:1896
    #7 0x55b3506a1413 in ospf6_receive ospf6d/ospf6_message.c:1925
    #8 0x7f70e92e6ccb in event_call lib/event.c:1979
    #9 0x7f70e922b488 in frr_run lib/libfrr.c:1213
    #10 0x55b35064345e in main ospf6d/ospf6_main.c:250
    #11 0x7f70e8843c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 72 byte(s) in 2 object(s) allocated from:
    #0 0x7f70e984bb40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f70e9247ee5 in qmalloc lib/memory.c:100
    #2 0x55b35068c987 in ospf6_lsa_alloc ospf6d/ospf6_lsa.c:711
    #3 0x55b35068c9f9 in ospf6_lsa_create ospf6d/ospf6_lsa.c:725
    #4 0x55b35065ab2c in ospf6_receive_lsa ospf6d/ospf6_flood.c:912
    #5 0x55b3506a1413 in ospf6_lsupdate_recv ospf6d/ospf6_message.c:1621
    #6 0x55b3506a1413 in ospf6_read_helper ospf6d/ospf6_message.c:1896
    #7 0x55b3506a1413 in ospf6_receive ospf6d/ospf6_message.c:1925
    #8 0x7f70e92e6ccb in event_call lib/event.c:1979
    #9 0x7f70e922b488 in frr_run lib/libfrr.c:1213
    #10 0x55b35064345e in main ospf6d/ospf6_main.c:250
    #11 0x7f70e8843c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 472 byte(s) leaked in 4 allocation(s).
```