### PR TITLE
bgpd: fix bug in a place about label validation

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9672,9 +9672,8 @@ void route_vty_out_tag(struct vty *vty, const struct prefix *p,
 		}
 	}
 
-	label = decode_label(&path->extra->label[0]);
-
-	if (bgp_is_valid_label(&label)) {
+	if (bgp_is_valid_label(&path->extra->label[0])) {
+		label = decode_label(&path->extra->label[0]);
 		if (json) {
 			json_object_int_add(json_out, "notag", label);
 			json_object_array_add(json, json_out);


### PR DESCRIPTION
Shouldn't validate the label after 'decode_label'. If we validate the label after 'decode_label', even the 'MPLS_INVALID_LABEL' will be valid then.