### PR TITLE
lib, vtysh: calculate the number of lines for better vtysh pagering.

### DIFF
--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -481,3 +481,16 @@ buffer_status_t buffer_write(struct buffer *b, int fd, const void *p,
 	}
 	return b->head ? BUFFER_PENDING : BUFFER_EMPTY;
 }
+
+buffer_status_t buffer_fprintf_all(FILE *fp, struct buffer *b)
+{
+	struct buffer_data *data, *next;
+
+	for (data = b->head; data; data = next) {
+		next = data->next;
+		fprintf(fp, "%s", data->data);
+	}
+	buffer_reset(b);
+	fflush(fp);
+	return BUFFER_EMPTY;
+}

--- a/lib/buffer.h
+++ b/lib/buffer.h
@@ -88,6 +88,8 @@ extern buffer_status_t buffer_flush_all(struct buffer *, int fd);
 extern buffer_status_t buffer_flush_window(struct buffer *, int fd, int width,
 					   int height, int erase, int no_more);
 
+extern buffer_status_t buffer_fprintf_all(FILE *fp, struct buffer *b);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -235,6 +235,8 @@ struct vty {
 	 * workaround
 	 */
 	bool vtysh_file_locked;
+
+	int vtysh_lines;
 };
 
 static inline void vty_push_context(struct vty *vty, int node, uint64_t id)
@@ -365,7 +367,9 @@ extern struct vty *vty_stdio(void (*atclose)(int isexit));
  * - vty_endframe() clears the buffer without printing it, and prints an
  *   extra string if the buffer was empty before (for context-end markers)
  */
+extern int vty_out_old_pager(struct vty *vty, const char *format, ...) PRINTFRR(2, 3);
 extern int vty_out(struct vty *, const char *, ...) PRINTFRR(2, 3);
+extern int vty_out_flush_vtysh_pager(struct vty *vty);
 extern void vty_frame(struct vty *, const char *, ...) PRINTFRR(2, 3);
 extern void vty_endframe(struct vty *, const char *);
 extern bool vty_set_include(struct vty *vty, const char *regexp);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -511,6 +511,12 @@ static int vtysh_execute_func(const char *line, int pager)
 	const struct cmd_element *cmd;
 	int tried = 0;
 	int saved_ret, saved_node;
+	struct winsize winsize;
+
+	ioctl(STDOUT_FILENO, TIOCGWINSZ, &winsize);
+	vty->width = winsize.ws_col;
+	vty->height = winsize.ws_row;
+	//vty_out(vty, "vty width: %d height: %d\n", vty->width, vty->height);
 
 	/* Split readline string up into the vector. */
 	vline = cmd_make_strvec(line);
@@ -551,7 +557,7 @@ static int vtysh_execute_func(const char *line, int pager)
 	if (ret == CMD_SUCCESS || ret == CMD_SUCCESS_DAEMON
 	    || ret == CMD_WARNING) {
 		while (tried-- > 0)
-			vtysh_execute("exit");
+			vtysh_execute_no_pager("exit");
 	}
 	/*
 	 * If command didn't succeed in any node, continue with return value
@@ -580,14 +586,6 @@ static int vtysh_execute_func(const char *line, int pager)
 		vty_out(vty, "%% Command incomplete: %s\n", line);
 		break;
 	case CMD_SUCCESS_DAEMON: {
-		/*
-		 * FIXME: Don't open pager for exit commands. popen() causes
-		 * problems if exited from vtysh at all. This hack shouldn't
-		 * cause any problem but is really ugly.
-		 */
-		if (pager && strncmp(line, "exit", 4))
-			vty_open_pager(vty);
-
 		if (!strcmp(cmd->string, "configure")) {
 			for (i = 0; i < array_size(vtysh_client); i++) {
 				cmd_stat = vtysh_client_execute(
@@ -599,7 +597,6 @@ static int vtysh_execute_func(const char *line, int pager)
 			if (cmd_stat) {
 				line = "end";
 				vline = cmd_make_strvec(line);
-
 
 				if (vline == NULL) {
 					if (vty->is_paged)
@@ -656,6 +653,12 @@ static int vtysh_execute_func(const char *line, int pager)
 			(*cmd->func)(cmd, vty, 0, NULL);
 	}
 	}
+
+	if (pager && vty->vtysh_lines > vty->height)
+		vty_open_pager(vty);
+
+	vty_out_flush_vtysh_pager(vty);
+
 	if (vty->is_paged)
 		vty_close_pager(vty);
 
@@ -1044,6 +1047,19 @@ static int vtysh_process_questionmark(const char *input, int input_len)
 
 	cmd_free_strvec(vline);
 	vector_free(describe);
+
+	/* if you don't want pager for help descriptions,
+	 * change the "pager" to 0.
+	 */
+	int pager = 1;
+
+	if (pager && vty->vtysh_lines > vty->height)
+		vty_open_pager(vty);
+
+	vty_out_flush_vtysh_pager(vty);
+
+	if (vty->is_paged)
+		vty_close_pager(vty);
 
 	return 0;
 }
@@ -2355,13 +2371,13 @@ static int vtysh_exit(struct vty *vty)
 
 	if (vty->node == CONFIG_NODE) {
 		/* resync in case one of the daemons is somewhere else */
-		vtysh_execute("end");
+		vtysh_execute_no_pager("end");
 		/* NOTE: a rather expensive thing to do, can we avoid it? */
 
 		if (vty->vtysh_file_locked)
-			vtysh_execute("configure terminal file-lock");
+			vtysh_execute_no_pager("configure terminal file-lock");
 		else
-			vtysh_execute("configure terminal");
+			vtysh_execute_no_pager("configure terminal");
 	}
 
 	return CMD_SUCCESS;
@@ -3305,10 +3321,8 @@ DEFUN (vtysh_write_terminal,
 			vtysh_client_config(&vtysh_client[i], line);
 
 	/* Integrate vtysh specific configuration. */
-	vty_open_pager(vty);
 	vtysh_config_write();
 	vtysh_config_dump();
-	vty_close_pager(vty);
 	vty_out(vty, "end\n");
 
 	return CMD_SUCCESS;


### PR DESCRIPTION
It checks the lines of the output of the vty_out()s by buffering, and compare it with the terminal length before invoking the pager. Previously, the pager is always invoked regardless of the number of output lines when "terminal pager" is enabled. This is problematic if 1) "less" is invoked without "-F", or 2) "more" is used, in that the unnecessary paging lock occured even when there's no output. I imagine this is the reason why we can't enable terminal pager by default.

This patch replaces vty_out() (older is saved by the name: vty_out_old_pager()) and flushing the buffer is postponed to the vty_output_flush_vtysh_pager(), and when it is being flushed, the number of lines is calculated and used to decide whether the pager should be called. Also by this architecture change, we can remove FIXME about "exit" cmd, it enables better behaviors for "more" and "less" without "-F", and we might even make the "terminal pager" by default. Additionally, the pager is applied when help messages by "?" is longer than the screen.