### PR TITLE
lib, vtysh: calculate the number of lines for better vtysh pagering.

### DIFF
--- a/lib/buffer.h
+++ b/lib/buffer.h
@@ -25,8 +25,10 @@ extern void buffer_free(struct buffer *);
 
 /* Add the given data to the end of the buffer. */
 extern void buffer_put(struct buffer *, const void *, size_t);
+/* Add the given data to the end of the buffer, terminate with NUL. */
+extern void buffer_put_strnul(struct buffer *b, const void *p, size_t size);
 /* Add a single character to the end of the buffer. */
-extern void buffer_putc(struct buffer *, uint8_t);
+extern void buffer_putc(struct buffer *b, uint8_t c);
 /* Add a NUL-terminated string to the end of the buffer. */
 extern void buffer_putstr(struct buffer *, const char *);
 /* Add given data, inline-expanding \n to \r\n */
@@ -87,6 +89,8 @@ extern buffer_status_t buffer_flush_all(struct buffer *, int fd);
 */
 extern buffer_status_t buffer_flush_window(struct buffer *, int fd, int width,
 					   int height, int erase, int no_more);
+
+extern buffer_status_t buffer_fprintf_all(FILE *fp, struct buffer *b);
 
 #ifdef __cplusplus
 }

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -244,7 +244,7 @@ bool vty_set_include(struct vty *vty, const char *regexp)
 }
 
 /* VTY standard output function. */
-int vty_out(struct vty *vty, const char *format, ...)
+int vty_out_old_pager(struct vty *vty, const char *format, ...)
 {
 	va_list args;
 	ssize_t len;
@@ -353,6 +353,150 @@ done:
 		XFREE(MTYPE_VTY_OUT_BUF, p);
 
 	return len;
+}
+
+/* Everything in VTY_SHELL should be aware of pagering. */
+int vty_out(struct vty *vty, const char *format, ...)
+{
+	va_list args;
+	ssize_t len;
+	char buf[1024];
+	char *p = NULL;
+	char *filtered;
+	/* format string may contain %m, keep errno intact for printfrr */
+	int saved_errno = errno;
+	vector lines = NULL;
+	char *firstline, *bstr;
+	int nlines;
+
+	if (vty->frame_pos) {
+		vty->frame_pos = 0;
+		vty_out(vty, "%s", vty->frame);
+	}
+
+	va_start(args, format);
+	errno = saved_errno;
+	p = vasnprintfrr(MTYPE_VTY_OUT_BUF, buf, sizeof(buf), format, args);
+	va_end(args);
+
+	len = strlen(p);
+
+	/* filter buffer */
+	if (vty->filter) {
+		lines = frrstr_split_vec(p, "\n");
+
+		/* Place first value in the cache */
+		firstline = vector_slot(lines, 0);
+		buffer_put(vty->lbuf, (uint8_t *)firstline, strlen(firstline));
+
+		/* If our split returned more than one entry, time to filter */
+		if (vector_active(lines) > 1) {
+			/*
+			 * returned string is MTYPE_TMP so it matches the MTYPE
+			 * of everything else in the vector
+			 */
+			bstr = buffer_getstr(vty->lbuf);
+			buffer_reset(vty->lbuf);
+			XFREE(MTYPE_TMP, lines->index[0]);
+			vector_set_index(lines, 0, bstr);
+			frrstr_filter_vec(lines, &vty->include);
+			vector_compact(lines);
+			/*
+			 * Consider the string "foo\n". If the regex is an empty string
+			 * and the line ended with a newline, then the vector will look
+			 * like:
+			 *
+			 * [0]: 'foo'
+			 * [1]: ''
+			 *
+			 * If the regex isn't empty, the vector will look like:
+			 *
+			 * [0]: 'foo'
+			 *
+			 * In this case we'd like to preserve the newline, so we add
+			 * the empty string [1] as in the first example.
+			 */
+			if (p[strlen(p) - 1] == '\n' &&
+			    vector_active(lines) > 0 &&
+			    strlen(vector_slot(lines, vector_active(lines) - 1)))
+				vector_set(lines, XSTRDUP(MTYPE_TMP, ""));
+
+			filtered = frrstr_join_vec(lines, "\n");
+		} else {
+			filtered = NULL;
+		}
+
+	} else {
+		lines = frrstr_split_vec(p, "\n");
+		filtered = p;
+	}
+
+	if (!filtered)
+		goto done;
+
+	switch (vty->type) {
+	case VTY_TERM:
+		/* print with crlf replacement */
+		buffer_put_crlf(vty->obuf, (uint8_t *)filtered,
+				strlen(filtered));
+		break;
+	case VTY_SHELL:
+		/* accumulate the number of lines, and
+		 * just save the output messages in the obuf, for now.
+		 * They will be flushed in vty_out_flush_vtysh_pager().
+		 */
+		if (lines) {
+			nlines = vector_active(lines);
+			if (nlines > 0 &&
+			    !strlen(vector_slot(lines, nlines - 1)))
+				nlines--;
+			vty->vtysh_lines += nlines;
+		}
+		buffer_put_strnul(vty->obuf, (uint8_t *)filtered, strlen(filtered));
+		break;
+	case VTY_SHELL_SERV:
+	case VTY_FILE:
+	default:
+		/* print without crlf replacement */
+		buffer_put(vty->obuf, (uint8_t *)filtered, strlen(filtered));
+		break;
+	}
+
+done:
+	if (lines)
+		frrstr_strvec_free(lines);
+
+	if (vty->filter && filtered)
+		XFREE(MTYPE_TMP, filtered);
+
+	/* If p is not different with buf, it is allocated buffer.  */
+	if (p != buf)
+		XFREE(MTYPE_VTY_OUT_BUF, p);
+
+	return len;
+}
+
+int vty_out_flush_vtysh_pager(struct vty *vty)
+{
+	buffer_putc(vty->obuf, '\0');
+
+	switch (vty->type) {
+	case VTY_TERM:
+		break;
+	case VTY_SHELL:
+		if (vty->of)
+			buffer_fprintf_all(vty->of, vty->obuf);
+		else if (vty->of_saved)
+			buffer_fprintf_all(vty->of_saved, vty->obuf);
+		vty->vtysh_lines = 0;
+		break;
+	case VTY_SHELL_SERV:
+	case VTY_FILE:
+	default:
+		break;
+	}
+
+	return 0;
 }
 
 static int vty_json_helper(struct vty *vty, struct json_object *json,

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -235,6 +235,8 @@ struct vty {
 	 * workaround
 	 */
 	bool vtysh_file_locked;
+
+	int vtysh_lines;
 };
 
 static inline void vty_push_context(struct vty *vty, int node, uint64_t id)
@@ -365,7 +367,9 @@ extern struct vty *vty_stdio(void (*atclose)(int isexit));
  * - vty_endframe() clears the buffer without printing it, and prints an
  *   extra string if the buffer was empty before (for context-end markers)
  */
+extern int vty_out_old_pager(struct vty *vty, const char *format, ...) PRINTFRR(2, 3);
 extern int vty_out(struct vty *, const char *, ...) PRINTFRR(2, 3);
+extern int vty_out_flush_vtysh_pager(struct vty *vty);
 extern void vty_frame(struct vty *, const char *, ...) PRINTFRR(2, 3);
 extern void vty_endframe(struct vty *, const char *);
 extern bool vty_set_include(struct vty *vty, const char *regexp);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -511,6 +511,12 @@ static int vtysh_execute_func(const char *line, int pager)
 	const struct cmd_element *cmd;
 	int tried = 0;
 	int saved_ret, saved_node;
+	struct winsize winsize;
+
+	ioctl(STDOUT_FILENO, TIOCGWINSZ, &winsize);
+	vty->width = winsize.ws_col;
+	vty->height = winsize.ws_row;
+	//vty_out(vty, "vty width: %d height: %d\n", vty->width, vty->height);
 
 	/* Split readline string up into the vector. */
 	vline = cmd_make_strvec(line);
@@ -551,7 +557,7 @@ static int vtysh_execute_func(const char *line, int pager)
 	if (ret == CMD_SUCCESS || ret == CMD_SUCCESS_DAEMON
 	    || ret == CMD_WARNING) {
 		while (tried-- > 0)
-			vtysh_execute("exit");
+			vtysh_execute_no_pager("exit");
 	}
 	/*
 	 * If command didn't succeed in any node, continue with return value
@@ -580,14 +586,6 @@ static int vtysh_execute_func(const char *line, int pager)
 		vty_out(vty, "%% Command incomplete: %s\n", line);
 		break;
 	case CMD_SUCCESS_DAEMON: {
-		/*
-		 * FIXME: Don't open pager for exit commands. popen() causes
-		 * problems if exited from vtysh at all. This hack shouldn't
-		 * cause any problem but is really ugly.
-		 */
-		if (pager && strncmp(line, "exit", 4))
-			vty_open_pager(vty);
-
 		if (!strcmp(cmd->string, "configure")) {
 			for (i = 0; i < array_size(vtysh_client); i++) {
 				cmd_stat = vtysh_client_execute(
@@ -599,7 +597,6 @@ static int vtysh_execute_func(const char *line, int pager)
 			if (cmd_stat) {
 				line = "end";
 				vline = cmd_make_strvec(line);
-
 
 				if (vline == NULL) {
 					if (vty->is_paged)
@@ -656,6 +653,12 @@ static int vtysh_execute_func(const char *line, int pager)
 			(*cmd->func)(cmd, vty, 0, NULL);
 	}
 	}
+
+	if (pager && vty->vtysh_lines > vty->height)
+		vty_open_pager(vty);
+
+	vty_out_flush_vtysh_pager(vty);
+
 	if (vty->is_paged)
 		vty_close_pager(vty);
 
@@ -1044,6 +1047,19 @@ static int vtysh_process_questionmark(const char *input, int input_len)
 
 	cmd_free_strvec(vline);
 	vector_free(describe);
+
+	/* if you don't want pager for help descriptions,
+	 * change the "pager" to 0.
+	 */
+	int pager = 0;
+
+	if (pager && vty->vtysh_lines > vty->height)
+		vty_open_pager(vty);
+
+	vty_out_flush_vtysh_pager(vty);
+
+	if (vty->is_paged)
+		vty_close_pager(vty);
 
 	return 0;
 }
@@ -2397,13 +2413,13 @@ static int vtysh_exit(struct vty *vty)
 
 	if (vty->node == CONFIG_NODE) {
 		/* resync in case one of the daemons is somewhere else */
-		vtysh_execute("end");
+		vtysh_execute_no_pager("end");
 		/* NOTE: a rather expensive thing to do, can we avoid it? */
 
 		if (vty->vtysh_file_locked)
-			vtysh_execute("configure terminal file-lock");
+			vtysh_execute_no_pager("configure terminal file-lock");
 		else
-			vtysh_execute("configure terminal");
+			vtysh_execute_no_pager("configure terminal");
 	}
 
 	return CMD_SUCCESS;
@@ -3371,10 +3387,8 @@ DEFUN (vtysh_write_terminal,
 			vtysh_client_config(&vtysh_client[i], line);
 
 	/* Integrate vtysh specific configuration. */
-	vty_open_pager(vty);
 	vtysh_config_write();
 	vtysh_config_dump();
-	vty_close_pager(vty);
 	vty_out(vty, "end\n");
 
 	return CMD_SUCCESS;


### PR DESCRIPTION
It checks the lines of the output of the vty_out()s by buffering, and compare it with the terminal length before invoking the pager. Previously, the pager is always invoked regardless of the number of output lines when "terminal pager" is enabled. This is problematic if 1) "less" is invoked without "-F", or 2) "more" is used, in that the unnecessary paging lock occured even when there's no output. I imagine this is the reason why we can't enable terminal pager by default.

This patch replaces vty_out() (older is saved by the name: vty_out_old_pager()) and flushing the buffer is postponed to the vty_output_flush_vtysh_pager(), and when it is being flushed, the number of lines is calculated and used to decide whether the pager should be called. Also by this architecture change, we can remove FIXME about "exit" cmd, it enables better behaviors for "more" and "less" without "-F", and we might even make the "terminal pager" by default. Additionally, the pager is applied when help messages by "?" is longer than the screen.