### PR TITLE
bgpd: fix redistribute table command after bgp restarts

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -16974,7 +16974,8 @@ DEFUN (no_bgp_redistribute_ipv4_ospf,
 		protocol = ZEBRA_ROUTE_TABLE;
 
 	instance = strtoul(argv[idx_number]->arg, NULL, 10);
-	return bgp_redistribute_unset(bgp, AFI_IP, protocol, instance);
+	bgp_redistribute_unset(bgp, AFI_IP, protocol, instance);
+	return CMD_SUCCESS;
 }
 
 ALIAS_HIDDEN(
@@ -17010,7 +17011,8 @@ DEFUN (no_bgp_redistribute_ipv4,
 		vty_out(vty, "%% Invalid route type\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
-	return bgp_redistribute_unset(bgp, AFI_IP, type, 0);
+	bgp_redistribute_unset(bgp, AFI_IP, type, 0);
+	return CMD_SUCCESS;
 }
 
 ALIAS_HIDDEN(
@@ -17194,7 +17196,8 @@ DEFUN (no_bgp_redistribute_ipv6,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	return bgp_redistribute_unset(bgp, AFI_IP6, type, 0);
+	bgp_redistribute_unset(bgp, AFI_IP6, type, 0);
+	return CMD_SUCCESS;
 }
 
 /* Neighbor update tcp-mss. */

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -64,8 +64,8 @@ extern bool bgp_redistribute_rmap_set(struct bgp_redist *red, const char *name,
 				      struct route_map *route_map);
 extern bool bgp_redistribute_metric_set(struct bgp *bgp, struct bgp_redist *red,
 					afi_t afi, int type, uint32_t metric);
-extern int bgp_redistribute_unset(struct bgp *bgp, afi_t afi, int type,
-				  unsigned short instance);
+extern void bgp_redistribute_unset(struct bgp *bgp, afi_t afi, int type,
+				   unsigned short instance);
 extern int bgp_redistribute_unreg(struct bgp *bgp, afi_t afi, int type,
 				  unsigned short instance);
 


### PR DESCRIPTION
When the BGP 'redistribute table' command is used for a given route table, and BGP configuration is flushed and rebuilt, the redistribution does not work.

Actually, when flushing the BGP configuration, the BGP redistribute entries are flushed only when the redistribute is not related to table identifier.
Fix this by adding some code to flush all the redistribute table instances.

Fixes: 7c8ff89e9346 ("Multi-Instance OSPF  Summary")