### PR TITLE
bgpd: Add a warning for the operator that keepalive was changed

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -590,7 +590,7 @@ int bgp_get_vty(struct bgp **bgp, as_t *as, const char *name,
 	int ret = bgp_get(bgp, as, name, inst_type, as_pretty, asnotation);
 
 	if (ret == BGP_CREATED) {
-		bgp_timers_set(*bgp, DFLT_BGP_KEEPALIVE, DFLT_BGP_HOLDTIME,
+		bgp_timers_set(NULL, *bgp, DFLT_BGP_KEEPALIVE, DFLT_BGP_HOLDTIME,
 			       DFLT_BGP_CONNECT_RETRY, BGP_DEFAULT_DELAYOPEN);
 
 		if (DFLT_BGP_IMPORT_CHECK)
@@ -2661,7 +2661,7 @@ DEFUN (bgp_timers,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	bgp_timers_set(bgp, keepalive, holdtime, DFLT_BGP_CONNECT_RETRY,
+	bgp_timers_set(vty, bgp, keepalive, holdtime, DFLT_BGP_CONNECT_RETRY,
 		       BGP_DEFAULT_DELAYOPEN);
 
 	return CMD_SUCCESS;
@@ -2677,7 +2677,7 @@ DEFUN (no_bgp_timers,
        "Holdtime\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_timers_set(bgp, DFLT_BGP_KEEPALIVE, DFLT_BGP_HOLDTIME,
+	bgp_timers_set(vty, bgp, DFLT_BGP_KEEPALIVE, DFLT_BGP_HOLDTIME,
 		       DFLT_BGP_CONNECT_RETRY, BGP_DEFAULT_DELAYOPEN);
 
 	return CMD_SUCCESS;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -519,11 +519,22 @@ void bgp_cluster_id_unset(struct bgp *bgp)
 }
 
 /* BGP timer configuration.  */
-void bgp_timers_set(struct bgp *bgp, uint32_t keepalive, uint32_t holdtime,
-		    uint32_t connect_retry, uint32_t delayopen)
+void bgp_timers_set(struct vty *vty, struct bgp *bgp, uint32_t keepalive,
+		    uint32_t holdtime, uint32_t connect_retry,
+		    uint32_t delayopen)
 {
-	bgp->default_keepalive =
-		(keepalive < holdtime / 3 ? keepalive : holdtime / 3);
+	uint32_t default_keepalive = holdtime / 3;
+
+	if (keepalive > default_keepalive) {
+		if (vty)
+			vty_out(vty,
+				"%% keepalive value %u is larger than 1/3 of the holdtime, setting to %u\n",
+				keepalive, default_keepalive);
+	} else {
+		default_keepalive = keepalive;
+	}
+
+	bgp->default_keepalive = default_keepalive;
 	bgp->default_holdtime = holdtime;
 	bgp->default_connect_retry = connect_retry;
 	bgp->default_delayopen = delayopen;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2254,8 +2254,9 @@ extern void bgp_confederation_peers_add(struct bgp *bgp, as_t as,
 					const char *as_str);
 extern void bgp_confederation_peers_remove(struct bgp *bgp, as_t as);
 
-extern void bgp_timers_set(struct bgp *, uint32_t keepalive, uint32_t holdtime,
-			   uint32_t connect_retry, uint32_t delayopen);
+extern void bgp_timers_set(struct vty *vty, struct bgp *, uint32_t keepalive,
+			   uint32_t holdtime, uint32_t connect_retry,
+			   uint32_t delayopen);
 extern void bgp_timers_unset(struct bgp *);
 
 extern void bgp_default_local_preference_set(struct bgp *bgp,


### PR DESCRIPTION
```
donatas-pc(config-router)# timers bgp 8 12
% keepalive value 8 is larger than 1/3 of the holdtime, setting to 4
donatas-pc(config-router)# do sh run | include timers bgp
 timers bgp 4 12
donatas-pc(config-router)#
```

Closes https://github.com/FRRouting/frr/issues/14287