### PR TITLE
pimd,pim6d: Resolving the YANG datatype Inconsistency for PIM Hello Interval

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -1633,7 +1633,7 @@ int lib_interface_pim_address_family_hello_interval_modify(
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
 		pim_ifp->pim_hello_period =
-			yang_dnode_get_uint8(args->dnode, NULL);
+			yang_dnode_get_uint16(args->dnode, NULL);
 		pim_ifp->pim_default_holdtime = -1;
 		break;
 	}

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -343,7 +343,7 @@ module frr-pim {
     }
 
     leaf hello-interval {
-      type uint8 {
+      type uint16 {
         range "1..max";
       }
       default "30";


### PR DESCRIPTION
The YANG specification currently designates a uint8 data type for the hello interval, despite the CLI documentation (ip pim hello (1-65535) [(1-65535)]) indicating a maximum value of 65535.
To address this inconsistency, updating the data type to uint16 allowing for a maximum value for hello intervals.

Closes #14286 