### PR TITLE
bgpd: Unset role when receiving UNSET action for dynamic capability

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2917,6 +2917,7 @@ static int bgp_capability_msg_parse(struct peer *peer, uint8_t *pnt,
 				peer->remote_role = role;
 			} else {
 				UNSET_FLAG(peer->cap, PEER_CAP_ROLE_RCV);
+				peer->remote_role = ROLE_UNDEFINED;
 			}
 			break;
 		default:


### PR DESCRIPTION
Capability was unset, but forgot to unset the role.

Fixes: 5ad080d37a26d72b56ecd0b796593bb7fc3aa6ad ("bgpd: Handle Role capability via dynamic capabilities for SET/UNSET properly")