### PR TITLE
Revert "bgpd: Add peers back to peer hash when peer_xfer_conn fails"

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -2146,17 +2146,6 @@ bgp_establish(struct peer_connection *connection)
 	peer = peer_xfer_conn(peer);
 	if (!peer) {
 		flog_err(EC_BGP_CONNECT, "%%Neighbor failed in xfer_conn");
-
-		/*
-		 * A failure of peer_xfer_conn but not putting the peers
-		 * back in the hash ends up with a situation where incoming
-		 * connections are rejected, as that the peer is not found
-		 * when a lookup is done
-		 */
-		(void)hash_get(peer->bgp->peerhash, peer, hash_alloc_intern);
-		if (other)
-			(void)hash_get(other->bgp->peerhash, other,
-				       hash_alloc_intern);
 		return BGP_FSM_FAILURE;
 	}
 


### PR DESCRIPTION
peer is NULL, but we pass it to hash_get().

This reverts commit 6f8c927b03c454aa309b84cefccc4faa31e0c03f.