### PR TITLE
bgpd: add support of traps for bgp4-mibv2 

### DIFF
--- a/bgpd/bgp_snmp.c
+++ b/bgpd/bgp_snmp.c
@@ -59,9 +59,31 @@ static void bgp_snmp_traps_init(void)
 
 int bgp_cli_snmp_traps_config_write(struct vty *vty)
 {
-	if (CHECK_FLAG(bgp_snmp_traps_flags, BGP_SNMP_TRAPS_RFC4273_ENABLED))
-		return 0;
-	vty_out(vty, "traps rfc4273 disable\n");
+	int write = 0;
+
+	if (!CHECK_FLAG(bm->options, BGP_OPT_TRAPS_RFC4273)) {
+		vty_out(vty, "no bgp snmp traps rfc4273\n");
+		write++;
+	}
+	if (CHECK_FLAG(bm->options, BGP_OPT_TRAPS_BGP4MIBV2)) {
+		vty_out(vty, "bgp snmp traps bgp4-mibv2\n");
+		write++;
+	}
+
+	return write;
+}
+
+int bgpTrapEstablished(struct peer *peer)
+{
+	bgp4TrapEstablished(peer);
+	bgpv2TrapEstablished(peer);
+	return 0;
+}
+
+int bgpTrapBackwardTransition(struct peer *peer)
+{
+	bgp4TrapBackwardTransition(peer);
+	bgpv2TrapBackwardTransition(peer);
 	return 0;
 }
 

--- a/bgpd/bgp_snmp.c
+++ b/bgpd/bgp_snmp.c
@@ -38,9 +38,9 @@ static int bgp_cli_snmp_traps_config_write(struct vty *vty);
 DEFPY(bgp_snmp_traps_rfc4273, bgp_snmp_traps_rfc4273_cmd,
       "[no$no] bgp snmp traps rfc4273",
       NO_STR BGP_STR
-              "Configure BGP SNMP\n"
-	      "Configure SNMP traps for BGP\n"
-	      "Configure use of rfc4273 SNMP traps for BGP\n")
+      "Configure BGP SNMP\n"
+      "Configure SNMP traps for BGP\n"
+      "Configure use of rfc4273 SNMP traps for BGP\n")
 {
 	if (no) {
 		UNSET_FLAG(bm->options, BGP_OPT_TRAPS_RFC4273);
@@ -53,9 +53,9 @@ DEFPY(bgp_snmp_traps_rfc4273, bgp_snmp_traps_rfc4273_cmd,
 DEFPY(bgp_snmp_traps_bgp4_mibv2, bgp_snmp_traps_bgp4_mibv2_cmd,
       "[no$no] bgp snmp traps bgp4-mibv2",
       NO_STR BGP_STR
-              "Configure BGP SNMP\n"
-	      "Configure SNMP traps for BGP\n"
-	      "Configure use of BGP4-MIBv2 SNMP traps for BGP\n")
+      "Configure BGP SNMP\n"
+      "Configure SNMP traps for BGP\n"
+      "Configure use of BGP4-MIBv2 SNMP traps for BGP\n")
 {
 	if (no) {
 		UNSET_FLAG(bm->options, BGP_OPT_TRAPS_BGP4MIBV2);

--- a/bgpd/bgp_snmp.h
+++ b/bgpd/bgp_snmp.h
@@ -19,4 +19,7 @@ extern uint32_t bgp_snmp_traps_flags;
 
 #define BGP_SNMP_TRAPS_RFC4273_ENABLED (1 << 0)
 
+extern int bgpTrapEstablished(struct peer *peer);
+extern int bgpTrapBackwardTransition(struct peer *peer);
+
 #endif /* _FRR_BGP_SNMP_H_ */

--- a/bgpd/bgp_snmp.h
+++ b/bgpd/bgp_snmp.h
@@ -15,4 +15,8 @@
 #define IPADDRESS ASN_IPADDRESS
 #define GAUGE32 ASN_UNSIGNED
 
+extern uint32_t bgp_snmp_traps_flags;
+
+#define BGP_SNMP_TRAPS_RFC4273_ENABLED (1 << 0)
+
 #endif /* _FRR_BGP_SNMP_H_ */

--- a/bgpd/bgp_snmp.h
+++ b/bgpd/bgp_snmp.h
@@ -15,10 +15,6 @@
 #define IPADDRESS ASN_IPADDRESS
 #define GAUGE32 ASN_UNSIGNED
 
-extern uint32_t bgp_snmp_traps_flags;
-
-#define BGP_SNMP_TRAPS_RFC4273_ENABLED (1 << 0)
-
 extern int bgpTrapEstablished(struct peer *peer);
 extern int bgpTrapBackwardTransition(struct peer *peer);
 

--- a/bgpd/bgp_snmp_bgp4.c
+++ b/bgpd/bgp_snmp_bgp4.c
@@ -764,9 +764,6 @@ int bgp4TrapEstablished(struct peer *peer)
 	oid index[sizeof(oid) * IN_ADDR_SIZE];
 	struct peer_connection *connection = peer->connection;
 
-	if (!CHECK_FLAG(bgp_snmp_traps_flags, BGP_SNMP_TRAPS_RFC4273_ENABLED))
-		return 0;
-
 	/* Check if this peer just went to Established */
 	if ((connection->ostatus != OpenConfirm) ||
 	    !(peer_established(connection)))
@@ -790,9 +787,6 @@ int bgp4TrapBackwardTransition(struct peer *peer)
 	int ret;
 	struct in_addr addr;
 	oid index[sizeof(oid) * IN_ADDR_SIZE];
-
-	if (!CHECK_FLAG(bgp_snmp_traps_flags, BGP_SNMP_TRAPS_RFC4273_ENABLED))
-		return 0;
 
 	ret = inet_aton(peer->host, &addr);
 	if (ret == 0)

--- a/bgpd/bgp_snmp_bgp4.c
+++ b/bgpd/bgp_snmp_bgp4.c
@@ -757,7 +757,7 @@ static struct variable bgp_variables[] = {
 	 {6, 1, 14}},
 };
 
-int bgpTrapEstablished(struct peer *peer)
+int bgp4TrapEstablished(struct peer *peer)
 {
 	int ret;
 	struct in_addr addr;
@@ -785,7 +785,7 @@ int bgpTrapEstablished(struct peer *peer)
 	return 0;
 }
 
-int bgpTrapBackwardTransition(struct peer *peer)
+int bgp4TrapBackwardTransition(struct peer *peer)
 {
 	int ret;
 	struct in_addr addr;

--- a/bgpd/bgp_snmp_bgp4.c
+++ b/bgpd/bgp_snmp_bgp4.c
@@ -764,6 +764,9 @@ int bgpTrapEstablished(struct peer *peer)
 	oid index[sizeof(oid) * IN_ADDR_SIZE];
 	struct peer_connection *connection = peer->connection;
 
+	if (!CHECK_FLAG(bgp_snmp_traps_flags, BGP_SNMP_TRAPS_RFC4273_ENABLED))
+		return 0;
+
 	/* Check if this peer just went to Established */
 	if ((connection->ostatus != OpenConfirm) ||
 	    !(peer_established(connection)))
@@ -787,6 +790,9 @@ int bgpTrapBackwardTransition(struct peer *peer)
 	int ret;
 	struct in_addr addr;
 	oid index[sizeof(oid) * IN_ADDR_SIZE];
+
+	if (!CHECK_FLAG(bgp_snmp_traps_flags, BGP_SNMP_TRAPS_RFC4273_ENABLED))
+		return 0;
 
 	ret = inet_aton(peer->host, &addr);
 	if (ret == 0)

--- a/bgpd/bgp_snmp_bgp4.h
+++ b/bgpd/bgp_snmp_bgp4.h
@@ -69,8 +69,8 @@
 #define BGP4PATHATTRBEST 13
 #define BGP4PATHATTRUNKNOWN 14
 
-extern int bgpTrapEstablished(struct peer *peer);
-extern int bgpTrapBackwardTransition(struct peer *peer);
+extern int bgp4TrapEstablished(struct peer *peer);
+extern int bgp4TrapBackwardTransition(struct peer *peer);
 extern int bgp_snmp_bgp4_init(struct event_loop *tm);
 
 #endif /* _FRR_BGP_SNMP_BGP4_H_ */

--- a/bgpd/bgp_snmp_bgp4v2.c
+++ b/bgpd/bgp_snmp_bgp4v2.c
@@ -825,7 +825,6 @@ static struct trap_object bgpv2TrapBackListv6[] = {
 	{ 6, { 1, 3, 1, BGP4V2_PEER_LAST_ERROR_RECEIVED_TEXT, 1, 2 } }
 };
 
-
 static struct variable bgpv2_variables[] = {
 	/* bgp4V2PeerEntry */
 	{BGP4V2_PEER_INSTANCE,
@@ -1450,6 +1449,9 @@ int bgpv2TrapEstablished(struct peer *peer)
 	oid index[sizeof(oid) * IN6_ADDR_SIZE];
 	size_t length;
 
+	if (!CHECK_FLAG(bm->options, BGP_OPT_TRAPS_BGP4MIBV2))
+		return 0;
+
 	/* Check if this peer just went to Established */
 	if ((peer->connection->ostatus != OpenConfirm) ||
 	    !(peer_established(peer->connection)))
@@ -1475,8 +1477,7 @@ int bgpv2TrapEstablished(struct peer *peer)
 			  BGP4V2ESTABLISHED);
 		break;
 	default:
-		return 0;
-		;
+		break;
 	}
 
 	return 0;
@@ -1486,6 +1487,9 @@ int bgpv2TrapBackwardTransition(struct peer *peer)
 {
 	oid index[sizeof(oid) * IN6_ADDR_SIZE];
 	size_t length;
+
+	if (!CHECK_FLAG(bm->options, BGP_OPT_TRAPS_BGP4MIBV2))
+		return 0;
 
 	switch (sockunion_family(&peer->connection->su)) {
 	case AF_INET:
@@ -1507,13 +1511,11 @@ int bgpv2TrapBackwardTransition(struct peer *peer)
 			  BGP4V2BACKWARDTRANSITION);
 		break;
 	default:
-		return 0;
-		;
+		break;
 	}
 
 	return 0;
 }
-
 
 int bgp_snmp_bgp4v2_init(struct event_loop *tm)
 {

--- a/bgpd/bgp_snmp_bgp4v2.h
+++ b/bgpd/bgp_snmp_bgp4v2.h
@@ -16,6 +16,14 @@
  * offset 1.3.6.1.3.5.1.1.2.1.x.(1|2).(4|16) = 13
  * offset 1.3.6.1.4.1.7336.3.2.1.1.2.1.x.1.(1|2) = 16
  */
+
+
+/* bgpTraps */
+#define BGP4V2ESTABLISHED	 1
+#define BGP4V2BACKWARDTRANSITION 2
+
+/* bgpPeerTable */
+
 #define BGP4V2_PEER_ENTRY_OFFSET 13
 #define BGP4V2_PEER_INSTANCE 1
 #define BGP4V2_PEER_LOCAL_ADDR_TYPE 2
@@ -84,5 +92,7 @@
 #define BGP4V2_BACKWARD_TRANSITION_NOTIFICATION 2
 
 extern int bgp_snmp_bgp4v2_init(struct event_loop *tm);
+extern int bgpv2TrapEstablished(struct peer *peer);
+extern int bgpv2TrapBackwardTransition(struct peer *peer);
 
 #endif /* _FRR_BGP_SNMP_BGP4V2_H_ */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -128,6 +128,7 @@ DEFINE_HOOK(bgp_inst_config_write,
 		(bgp, vty));
 DEFINE_HOOK(bgp_snmp_update_last_changed, (struct bgp *bgp), (bgp));
 DEFINE_HOOK(bgp_snmp_init_stats, (struct bgp *bgp), (bgp));
+DEFINE_HOOK(bgp_snmp_traps_config_write, (struct vty * vty), (vty));
 
 static struct peer_group *listen_range_exists(struct bgp *bgp,
 					      struct prefix *range, int exact);
@@ -18476,6 +18477,8 @@ int bgp_config_write(struct vty *vty)
 	afi_t afi;
 	safi_t safi;
 	uint32_t tovpn_sid_index = 0;
+
+	hook_call(bgp_snmp_traps_config_write, vty);
 
 	if (bm->rmap_update_timer != RMAP_DEFAULT_UPDATE_TIMER)
 		vty_out(vty, "bgp route-map delay-timer %u\n",

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -121,6 +121,8 @@ struct bgp_master {
 #define BGP_OPT_NO_FIB                   (1 << 0)
 #define BGP_OPT_NO_LISTEN                (1 << 1)
 #define BGP_OPT_NO_ZEBRA                 (1 << 2)
+#define BGP_OPT_TRAPS_RFC4273            (1 << 3)
+#define BGP_OPT_TRAPS_BGP4MIBV2          (1 << 4)
 
 	uint64_t updgrp_idspace;
 	uint64_t subgrp_idspace;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -834,7 +834,7 @@ DECLARE_HOOK(bgp_inst_delete, (struct bgp *bgp), (bgp));
 DECLARE_HOOK(bgp_inst_config_write,
 		(struct bgp *bgp, struct vty *vty),
 		(bgp, vty));
-DECLARE_HOOK(bgp_snmp_traps_config_write, (struct vty * vty), (vty));
+DECLARE_HOOK(bgp_snmp_traps_config_write, (struct vty *vty), (vty));
 DECLARE_HOOK(bgp_config_end, (struct bgp *bgp), (bgp));
 
 /* Thread callback information */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -832,6 +832,7 @@ DECLARE_HOOK(bgp_inst_delete, (struct bgp *bgp), (bgp));
 DECLARE_HOOK(bgp_inst_config_write,
 		(struct bgp *bgp, struct vty *vty),
 		(bgp, vty));
+DECLARE_HOOK(bgp_snmp_traps_config_write, (struct vty * vty), (vty));
 DECLARE_HOOK(bgp_config_end, (struct bgp *bgp), (bgp));
 
 /* Thread callback information */

--- a/bgpd/subdir.am
+++ b/bgpd/subdir.am
@@ -214,6 +214,7 @@ clippy_scan += \
 	bgpd/bgp_rpki.c \
 	bgpd/bgp_vty.c \
         bgpd/bgp_nexthop.c \
+	bgpd/bgp_snmp.c \
 	# end
 
 nodist_bgpd_bgpd_SOURCES = \

--- a/doc/user/snmptrap.rst
+++ b/doc/user/snmptrap.rst
@@ -4,8 +4,9 @@ Handling SNMP Traps
 To handle snmp traps make sure your snmp setup of frr works correctly as
 described in the frr documentation in :ref:`snmp-support`.
 
-The BGP4 mib will send traps on peer up/down events. These should be visible in
-your snmp logs with a message similar to:
+BGP handles both :rfc:`4273` and [Draft-IETF-idr-bgp4-mibv2-11]_ MIBs.
+The BGP4 MIBs will send traps on peer up/down events. These should be
+visible in your snmp logs with a message similar to:
 
 ::
 
@@ -199,3 +200,18 @@ a siren, have your display flash, etc., be creative ;).
 
    # mail the notification
    echo "$MAIL" | mail -s "$SUBJECT" $EMAILADDR
+
+.. _traps-mib-selection:
+
+Traps Mib Selection in BGP
+--------------------------
+
+Both :rfc:`4273` and [Draft-IETF-idr-bgp4-mibv2-11]_ MIBs define traps for
+dealing with up/down events and state transition. The user has the
+possibility to select the MIB he wants to receive traps from:
+
+.. clicmd:: bgp snmp traps <rfc4273|bgp4-mibv2>
+
+By default, only rfc4273 traps are enabled and sent.
+
+.. [Draft-IETF-idr-bgp4-mibv2-11] <https://tools.ietf.org/id/draft-ietf-idr-bgp4-mibv2-11.txt>

--- a/tests/topotests/bgp_snmp_bgp4v2mib/r2/snmpd.conf
+++ b/tests/topotests/bgp_snmp_bgp4v2mib/r2/snmpd.conf
@@ -6,6 +6,15 @@ access public_group "" any noauth prefix all all none
 
 rocommunity public default
 
+trapsess -v2c -c public 127.0.0.1
+
+notificationEvent  linkUpTrap    linkUp   ifIndex ifAdminStatus ifOperStatus
+notificationEvent  linkDownTrap  linkDown ifIndex ifAdminStatus ifOperStatus
+
+monitor  -r 2 -e linkUpTrap   "Generate linkUp" ifOperStatus != 2
+monitor  -r 2 -e linkDownTrap "Generate linkDown" ifOperStatus == 2
+
+
 view all included .1
 
 iquerySecName frr

--- a/tests/topotests/bgp_snmp_bgp4v2mib/r2/snmptrapd.conf
+++ b/tests/topotests/bgp_snmp_bgp4v2mib/r2/snmptrapd.conf
@@ -1,0 +1,2 @@
+authCommunity net,log public
+disableAuthorization yes

--- a/tests/topotests/bgp_snmp_bgp4v2mib/test_bgp_snmp_bgp4v2mib.py
+++ b/tests/topotests/bgp_snmp_bgp4v2mib/test_bgp_snmp_bgp4v2mib.py
@@ -205,7 +205,7 @@ def test_bgp_snmp_bgp4v2():
         }
 
         # bgp4V2NlriOrigin
-        tgen.mininet_cli()
+        # tgen.mininet_cli()
         output, _ = snmp.walk(".1.3.6.1.3.5.1.1.9.1.9")
         logger.info(output)
         return output == expected
@@ -248,19 +248,15 @@ def test_bgp_snmp_bgp4v2():
         output = snmp.trap(outputfile)
         return output == expected
 
-
-
     # skip tests is SNMP not installed
     if not os.path.isfile("/usr/sbin/snmptrapd"):
         error_msg = "SNMP not installed - skipping"
         pytest.skip(error_msg)
 
-
     snmptrapfile = "{}/{}/snmptrapd.log".format(r2.logdir, r2.name)
     trap_file = open(snmptrapfile, "w")
     trap_file.truncate(0)
     trap_file.close()
-    topotest.sleep(1)
     r1.vtysh_cmd("clear bgp *")
     _, result = topotest.run_and_expect(_snmptrap_ipv4, True, count=2, wait=10)
     assertmsg = "Can't fetch SNMP trap for ipv4"
@@ -293,12 +289,17 @@ def test_bgp_snmp_bgp4v2():
         snmptrapfile = "{}/{}/snmptrapd.log".format(r2.logdir, r2.name)
         outputfile = open(snmptrapfile).read()
         output = snmp.trap(outputfile)
-        logger.info(output)
         return output == expected
 
+    snmptrapfile = "{}/{}/snmptrapd.log".format(r2.logdir, r2.name)
+    trap_file = open(snmptrapfile, "w")
+    trap_file.truncate(0)
+    trap_file.close()
+    r2.vtysh_cmd("conf\nbgp snmp traps bgp4-mibv2")
+    r2.vtysh_cmd("conf\nno bgp snmp traps rfc4273")
     r1.vtysh_cmd("clear bgp *")
-    _, result = topotest.run_and_expect(_snmptrap_ipv4, True, count=15, wait=2)
-    assertmsg = "Can't fetch SNMP trap for ipv4"
+    _, result = topotest.run_and_expect(_snmptrap_ipv6, True, count=2, wait=10)
+    assertmsg = "Can't fetch SNMP trap for ipv6"
     assert result, assertmsg
 
 

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -744,6 +744,7 @@ class TopoRouter(TopoGear):
     RD_SNMP = 18
     RD_PIM6 = 19
     RD_MGMTD = 20
+    RD_TRAP = 21
     RD = {
         RD_FRR: "frr",
         RD_ZEBRA: "zebra",
@@ -766,6 +767,7 @@ class TopoRouter(TopoGear):
         RD_PATH: "pathd",
         RD_SNMP: "snmpd",
         RD_MGMTD: "mgmtd",
+        RD_TRAP: "snmptrapd",
     }
 
     def __init__(self, tgen, cls, name, **params):
@@ -842,7 +844,7 @@ class TopoRouter(TopoGear):
         TopoRouter.RD_RIPNG, TopoRouter.RD_OSPF, TopoRouter.RD_OSPF6,
         TopoRouter.RD_ISIS, TopoRouter.RD_BGP, TopoRouter.RD_LDP,
         TopoRouter.RD_PIM, TopoRouter.RD_PIM6, TopoRouter.RD_PBR,
-        TopoRouter.RD_SNMP, TopoRouter.RD_MGMTD.
+        TopoRouter.RD_SNMP, TopoRouter.RD_MGMTD, TopoRouter.RD_TRAP.
 
         Possible `source` values are `None` for an empty config file, a path name which is
         used directly, or a file name with no path components which is first looked for
@@ -880,7 +882,7 @@ class TopoRouter(TopoGear):
         # Enable all daemon command logging, logging files
         # and set them to the start dir.
         for daemon, enabled in nrouter.daemons.items():
-            if enabled and daemon != "snmpd":
+            if enabled and daemon != "snmpd" and daemon != "snmptrapd":
                 self.vtysh_cmd(
                     "\n".join(
                         [


### PR DESCRIPTION
this pull request add the support of traps for bgp4-mibv2. It is
conformant to draft-ietf-idr-bgp4-mibv2-11.
bgp4V2EstablishedNotification and bgp4V2BackwardTransitionNotification.

since the MIB bgp4-mibv2 notification are  redundant with MIB RFC4273
we added a  2 commands for avoiding conflicts.
bgp snmp traps rfc4273<enable|disable>
bgp snmp traps bgp4-mibv2<enable|disable>