### PR TITLE
lib,zebra: add tx queuelen to interface struct

### DIFF
--- a/lib/if.h
+++ b/lib/if.h
@@ -252,6 +252,9 @@ struct interface {
 	/* Interface Speed in Mb/s */
 	uint32_t speed;
 
+	/* TX queue len */
+	uint32_t txqlen;
+
 	/* Interface MTU. */
 	unsigned int mtu; /* IPv4 MTU */
 	unsigned int

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2761,6 +2761,7 @@ static void zebra_interface_if_set_value(struct stream *s,
 	STREAM_GETC(s, ifp->ptm_status);
 	STREAM_GETL(s, ifp->metric);
 	STREAM_GETL(s, ifp->speed);
+	STREAM_GETL(s, ifp->txqlen);
 	STREAM_GETL(s, ifp->mtu);
 	STREAM_GETL(s, ifp->mtu6);
 	STREAM_GETL(s, ifp->bandwidth);

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1508,6 +1508,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	ns_id_t link_nsid = ns_id;
 	ifindex_t master_infindex = IFINDEX_INTERNAL;
 	uint8_t bypass = 0;
+	uint32_t txqlen = 0;
 
 	frrtrace(3, frr_zebra, netlink_interface, h, ns_id, startup);
 
@@ -1586,6 +1587,9 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		link_nsid = ns_id_get_absolute(ns_id, link_nsid);
 	}
 
+	if (tb[IFLA_TXQLEN])
+		txqlen = *(uint32_t *)RTA_DATA(tb[IFLA_TXQLEN]);
+
 	struct zebra_dplane_ctx *ctx = dplane_ctx_alloc();
 	dplane_ctx_set_ns_id(ctx, ns_id);
 	dplane_ctx_set_ifp_link_nsid(ctx, link_nsid);
@@ -1594,6 +1598,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	dplane_ctx_set_ifname(ctx, name);
 	dplane_ctx_set_ifp_startup(ctx, startup);
 	dplane_ctx_set_ifp_family(ctx, ifi->ifi_family);
+	dplane_ctx_set_intf_txqlen(ctx, txqlen);
 
 	/* We are interested in some AF_BRIDGE notifications. */
 #ifndef AF_BRIDGE

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -2060,6 +2060,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 			ifp->metric = 0;
 			ifp->speed = kernel_get_speed(ifp, NULL);
 			ifp->ptm_status = ZEBRA_PTM_STATUS_UNKNOWN;
+			ifp->txqlen = dplane_ctx_get_intf_txqlen(ctx);
 
 			/* Set interface type */
 			zebra_if_set_ziftype(ifp, zif_type, zif_slave_type);
@@ -2142,6 +2143,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 			set_ifindex(ifp, ifindex, zns);
 			ifp->mtu6 = ifp->mtu = mtu;
 			ifp->metric = 0;
+			ifp->txqlen = dplane_ctx_get_intf_txqlen(ctx);
 
 			/*
 			 * Update interface type - NOTE: Only slave_type can
@@ -2786,8 +2788,8 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 		return;
 	}
 
-	vty_out(vty, "  index %d metric %d mtu %d speed %u ", ifp->ifindex,
-		ifp->metric, ifp->mtu, ifp->speed);
+	vty_out(vty, "  index %d metric %d mtu %d speed %u txqlen %u",
+		ifp->ifindex, ifp->metric, ifp->mtu, ifp->speed, ifp->txqlen);
 	if (ifp->mtu6 != ifp->mtu)
 		vty_out(vty, "mtu6 %d ", ifp->mtu6);
 	vty_out(vty, "\n  flags: %s\n", if_flag_dump(ifp->flags));
@@ -3174,6 +3176,7 @@ static void if_dump_vty_json(struct vty *vty, struct interface *ifp,
 	if (ifp->mtu6 != ifp->mtu)
 		json_object_int_add(json_if, "mtu6", ifp->mtu6);
 	json_object_int_add(json_if, "speed", ifp->speed);
+	json_object_int_add(json_if, "txqlen", ifp->txqlen);
 	json_object_string_add(json_if, "flags", if_flag_dump(ifp->flags));
 
 	/* Hardware address. */

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -71,6 +71,7 @@ static void zserv_encode_interface(struct stream *s, struct interface *ifp)
 	stream_putc(s, ifp->ptm_status);
 	stream_putl(s, ifp->metric);
 	stream_putl(s, ifp->speed);
+	stream_putl(s, ifp->txqlen);
 	stream_putl(s, ifp->mtu);
 	stream_putl(s, ifp->mtu6);
 	stream_putl(s, ifp->bandwidth);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -216,6 +216,8 @@ struct dplane_intf_info {
 
 	uint32_t rc_bitfield;
 
+	uint32_t txqlen;
+
 	uint32_t metric;
 	uint32_t flags;
 
@@ -2654,6 +2656,20 @@ void dplane_ctx_set_intf_label(struct zebra_dplane_ctx *ctx, const char *label)
 	} else {
 		ctx->u.intf.flags &= ~DPLANE_INTF_HAS_LABEL;
 	}
+}
+
+void dplane_ctx_set_intf_txqlen(struct zebra_dplane_ctx *ctx, uint32_t txqlen)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	ctx->u.intf.txqlen = txqlen;
+}
+
+uint32_t dplane_ctx_get_intf_txqlen(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.intf.txqlen;
 }
 
 /* Accessors for MAC information */

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -672,6 +672,8 @@ void dplane_ctx_set_intf_dest(struct zebra_dplane_ctx *ctx,
 bool dplane_ctx_intf_has_label(const struct zebra_dplane_ctx *ctx);
 const char *dplane_ctx_get_intf_label(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_intf_label(struct zebra_dplane_ctx *ctx, const char *label);
+void dplane_ctx_set_intf_txqlen(struct zebra_dplane_ctx *ctx, uint32_t txqlen);
+uint32_t dplane_ctx_get_intf_txqlen(const struct zebra_dplane_ctx *ctx);
 
 /* Accessors for MAC information */
 vlanid_t dplane_ctx_mac_get_vlan(const struct zebra_dplane_ctx *ctx);


### PR DESCRIPTION
Add a txqlen attribute to the common interface struct. This captures the value in zebra, add it to the existing 'show' output, and distributes it through the interface lib module's zapi messaging.
