### PR TITLE
bgpd: fix crash in *bgpv2PeerErrorsTable"

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -498,6 +498,7 @@ const char *bgp_notify_subcode_str(char code, char subcode)
 const char *bgp_notify_admin_message(char *buf, size_t bufsz, uint8_t *data,
 				     size_t datalen)
 {
+	memset(buf, 0, bufsz);
 	if (!data || datalen < 1)
 		return buf;
 

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -499,11 +499,11 @@ const char *bgp_notify_admin_message(char *buf, size_t bufsz, uint8_t *data,
 				     size_t datalen)
 {
 	if (!data || datalen < 1)
-		return NULL;
+		return buf;
 
 	uint8_t len = data[0];
 	if (!len || len > datalen - 1)
-		return NULL;
+		return buf;
 
 	return zlog_sanitize(buf, bufsz, data + 1, len);
 }

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -11202,11 +11202,9 @@ static void bgp_show_peer_reset(struct vty * vty, struct peer *peer,
 					     msgbuf, sizeof(msgbuf),
 					     (uint8_t *)peer->notify.data,
 					     peer->notify.length);
-				if (msg_str)
-					json_object_string_add(
-					   json_peer,
-					   "lastShutdownDescription",
-					   msg_str);
+				json_object_string_add(json_peer,
+				   "lastShutdownDescription",
+				   msg_str);
 			}
 
 		}


### PR DESCRIPTION
following crash occurs:
    at ./nptl/pthread_kill.c:44
    at ./nptl/pthread_kill.c:78
    at ./nptl/pthread_kill.c:89
    context=0x7ffd06d3d300)
    at /build/make-pkg/output/_packages/cp-routing/src/lib/sigevent.c:246
    length=0x7ffd06d3da88, exact=1, var_len=0x7ffd06d3da90, write_method=<optimized out>)
    at /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_snmp_bgp4v2.c:364
    vp=vp@entry=0x7f7c88b584c0 <bgpv2_variables>, vp_len=vp_len@entry=102,
    ename=ename@entry=0x7f7c88b58440 <bgpv2_trap_oid>, enamelen=enamelen@entry=8,
    name=name@entry=0x7f7c88b58480 <bgpv2_oid>, namelen=namelen@entry=7,
    iname=0x7ffd06d3e7b0, index_len=1, trapobj=0x7f7c88b53b80 <bgpv2TrapBackListv6>,
    trapobjlen=6, sptrap=2 '\002')
    at /build/make-pkg/output/_packages/cp-routing/src/lib/agentx.c:382
    vp_len=vp_len@entry=102, ename=ename@entry=0x7f7c88b58440 <bgpv2_trap_oid>,
    enamelen=enamelen@entry=8, name=name@entry=0x7f7c88b58480 <bgpv2_oid>,
    namelen=namelen@entry=7, iname=0x7ffd06d3ec30, inamelen=16,
    trapobj=0x7f7c88b53b80 <bgpv2TrapBackListv6>, trapobjlen=6, sptrap=2 '\002')
    at /build/make-pkg/output/_packages/cp-routing/src/lib/agentx.c:298
    at /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_snmp_bgp4v2.c:1496
    at /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_fsm.c:48
    at /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_fsm.c:1314
    event=Receive_NOTIFICATION_message)
    at /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_fsm.c:2665
    at /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_packet.c:3129
    at /build/make-pkg/output/_packages/cp-routing/src/lib/event.c:1979
    at /build/make-pkg/output/_packages/cp-routing/src/lib/libfrr.c:1213
    at /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_main.c:510

it's due to function bgpv2PeerErrorsTable returning return SNMP_STRING(msg_str);
with msg_str NULL rather the string ""

ALSO

 fix wrong type values  provided to snmp clients
 fix invalid address type values in index
 fix invalid bgp instance value in index