### PR TITLE
tools/gcc-plugins: fix for GCC 13

### DIFF
--- a/tools/gcc-plugins/Makefile
+++ b/tools/gcc-plugins/Makefile
@@ -5,11 +5,15 @@ CXX=g++-9
 PLUGBASE=`$(CXX) -print-file-name=plugin`
 CPPFLAGS=-I$(PLUGBASE)/include -I$(PLUGBASE)/include/c-family
 
+# NB: compiler flags must match those used to build gcc, otherwise inlining
+# behavior is different and linker errors will result due to missing symbols
+# (which should in fact be inlined)
+
 frr-format.so: frr-format.o
-	$(CXX) -g -shared -o $@ $^
+	$(CXX) -fno-rtti -fno-exceptions -fasynchronous-unwind-tables -ggdb -shared -o $@ $^
 
 frr-format.o: frr-format.c gcc-common.h
-	$(CXX) -g $(CPPFLAGS) -fPIC -Wall -Wextra -Wno-unused-parameter -c -o $@ $<
+	$(CXX) -fno-rtti -fno-exceptions -fasynchronous-unwind-tables -ggdb $(CPPFLAGS) -fPIC -Wall -Wextra -Wno-unused-parameter -c -o $@ $<
 
 install:
 	install -d $(DESTDIR)$(PLUGBASE)

--- a/tools/gcc-plugins/gcc-common.h
+++ b/tools/gcc-plugins/gcc-common.h
@@ -111,6 +111,10 @@
 #include "varasm.h"
 #include "stor-layout.h"
 #include "internal-fn.h"
+#if BUILDING_GCC_VERSION >= 13000
+#include "gimple.h"
+#include "gimple-iterator.h"
+#endif
 #include "gimple-expr.h"
 #include "gimple-fold.h"
 #include "context.h"


### PR DESCRIPTION
As usual, new GCC version, new small random changes in the API.