### PR TITLE
ospfd: Fix External Aggregator Leak

### DIFF
--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -987,6 +987,7 @@ static void ospf_handle_external_aggr_update(struct ospf *ospf)
 				&aggr->match_extnl_hash,
 				(void *)ospf_aggr_handle_external_info);
 
+			ospf_external_aggregator_free(aggr);
 		} else if (aggr->action == OSPF_ROUTE_AGGR_MODIFY) {
 
 			aggr->action = OSPF_ROUTE_AGGR_NONE;


### PR DESCRIPTION
Fixes a memory leak in ospfd where the external aggregator was not released after its associated route node is deleted.

The ASan leak log for reference:

```
***********************************************************************************
Address Sanitizer Error detected in ospf_basic_functionality.test_ospf_asbr_summary_topo1/r0.asan.ospfd.31502

=================================================================
==31502==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 200 byte(s) in 5 object(s) allocated from:
    #0 0x7fdb30665d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7fdb300620da in qcalloc lib/memory.c:105
    #2 0x55e53c2da5fa in ospf_external_aggregator_new ospfd/ospf_asbr.c:396
    #3 0x55e53c2dead3 in ospf_asbr_external_aggregator_set ospfd/ospf_asbr.c:1123
    #4 0x55e53c27c921 in ospf_external_route_aggregation ospfd/ospf_vty.c:10264
    #5 0x7fdb2ffe5428 in cmd_execute_command_real lib/command.c:993
    #6 0x7fdb2ffe58ec in cmd_execute_command lib/command.c:1051
    #7 0x7fdb2ffe5d6b in cmd_execute lib/command.c:1218
    #8 0x7fdb3010ce2a in vty_command lib/vty.c:591
    #9 0x7fdb3010d2d5 in vty_execute lib/vty.c:1354
    #10 0x7fdb30115b9b in vtysh_read lib/vty.c:2362
    #11 0x7fdb30100b99 in event_call lib/event.c:1979
    #12 0x7fdb30045379 in frr_run lib/libfrr.c:1213
    #13 0x55e53c1ccab4 in main ospfd/ospf_main.c:249
    #14 0x7fdb2f65dc86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7fdb30665d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7fdb300620da in qcalloc lib/memory.c:105
    #2 0x55e53c2da5fa in ospf_external_aggregator_new ospfd/ospf_asbr.c:396
    #3 0x55e53c2dedd3 in ospf_asbr_external_rt_no_advertise ospfd/ospf_asbr.c:1182
    #4 0x55e53c27cf10 in ospf_external_route_aggregation_no_adrvertise ospfd/ospf_vty.c:10626
    #5 0x7fdb2ffe5428 in cmd_execute_command_real lib/command.c:993
    #6 0x7fdb2ffe58ec in cmd_execute_command lib/command.c:1051
    #7 0x7fdb2ffe5d6b in cmd_execute lib/command.c:1218
    #8 0x7fdb3010ce2a in vty_command lib/vty.c:591
    #9 0x7fdb3010d2d5 in vty_execute lib/vty.c:1354
    #10 0x7fdb30115b9b in vtysh_read lib/vty.c:2362
    #11 0x7fdb30100b99 in event_call lib/event.c:1979
    #12 0x7fdb30045379 in frr_run lib/libfrr.c:1213
    #13 0x55e53c1ccab4 in main ospfd/ospf_main.c:249
    #14 0x7fdb2f65dc86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 240 byte(s) leaked in 6 allocation(s).
***********************************************************************************
```