### PR TITLE
Revert "lib: add a frr_each_const macro"

### DIFF
--- a/isisd/isis_flex_algo.c
+++ b/isisd/isis_flex_algo.c
@@ -127,10 +127,7 @@ _isis_flex_algo_elected(int algorithm, const struct isis_area *area,
 	 * Perform FAD comparison. First, compare the priority, and if they are
 	 * the same, compare the sys-id.
 	 */
-	/* clang-format off */
-	frr_each_const(lspdb, &area->lspdb[ISIS_LEVEL1 - 1], lsp) {
-		/* clang-format on */
-
+	frr_each (lspdb_const, &area->lspdb[ISIS_LEVEL1 - 1], lsp) {
 		if (!lsp->tlvs || !lsp->tlvs->router_cap)
 			continue;
 

--- a/lib/typesafe.h
+++ b/lib/typesafe.h
@@ -20,9 +20,6 @@ extern "C" {
 #define frr_each(prefix, head, item)                                           \
 	for (item = prefix##_first(head); item;                                \
 			item = prefix##_next(head, item))
-#define frr_each_const(prefix, head, item)                                     \
-	for (item = prefix##_const_first(head); item;                          \
-	     item = prefix##_const_next(head, item))
 #define frr_each_safe(prefix, head, item)                                      \
 	for (typeof(prefix##_next_safe(head, NULL)) prefix##_safe =            \
 			prefix##_next_safe(head,                               \

--- a/lib/typesafe.h
+++ b/lib/typesafe.h
@@ -17,6 +17,11 @@ extern "C" {
 
 /* generic macros for all list-like types */
 
+/* to iterate using the const variants of the functions, append "_const" to
+ * the name of the container, e.g. "frr_each (my_list, head, item)" becomes
+ * "frr_each (my_list_const, head, item)"
+ */
+
 #define frr_each(prefix, head, item)                                           \
 	for (item = prefix##_first(head); item;                                \
 			item = prefix##_next(head, item))


### PR DESCRIPTION
This reverts commit 72eae2c3cb771b7010f3f07b6c638e9ae078bbdf.

`frr_each_const(X, ...)` is not needed since it is the same as `frr_each(X_const, ...)`.

The fact that it wasn't properly set up for clang-format, and that then work-arounded with "clang-format off" is all the more reason to not do this.