### PR TITLE
zebra: prevent multiple up notifications to zclients

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1032,7 +1032,9 @@ void if_up(struct interface *ifp, bool install_connected)
 			  __func__, ifp->name);
 		return;
 	}
-	zebra_interface_up_update(ifp);
+
+	if (install_connected)
+		zebra_interface_up_update(ifp);
 
 	if_nbr_ipv6ll_to_ipv4ll_neigh_add_all(ifp);
 


### PR DESCRIPTION
When using tcpdump over an interface, the interface raises, then unraises the promiscuous mode to that interface. The zebra daemon systematically considers this change as an up event, and all the zebra clients are triggered.

Fix this by avoiding sending multiple up notifications if at last notification, the status of the interface was already up.