### PR TITLE
bgpd: fix arg order in bgp_redistribute_add() call

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -592,7 +592,7 @@ static int zebra_read_route(ZAPI_CALLBACK_ARGS)
 
 		/* Now perform the add/update. */
 		bgp_redistribute_add(bgp, &api.prefix, &nexthop, ifindex,
-				     nhtype, bhtype, api.distance, api.metric,
+				     nhtype, api.distance, bhtype, api.metric,
 				     api.type, api.instance, api.tag);
 	} else {
 		bgp_redistribute_delete(bgp, &api.prefix, api.type,


### PR DESCRIPTION
Fixes a call to bgp_redistribute_add() that mixed up the position of args bhtype (blackhole type, enum) and api.distance (RIB admin distance, uint8_t).