### PR TITLE
FUZZER: Certain types of fuzzing requires a default ospf instance

### DIFF
--- a/ospfd/ospf_main.c
+++ b/ospfd/ospf_main.c
@@ -173,11 +173,12 @@ static struct ospf *FuzzingCreateOspf(void)
 {
 	struct prefix p;
 	struct interface *ifp = if_get_by_name("fuzziface", 0, "default");
+	struct vrf *vrf = vrf_get(VRF_DEFAULT, VRF_DEFAULT_NAME);
 	ifp->mtu = 68;
 	str2prefix("11.0.2.0/24", &p);
 
 	bool created;
-	struct ospf *o = ospf_get(0, "omgwtfbbq", &created);
+	struct ospf *o = ospf_get(0, VRF_DEFAULT_NAME, &created);
 	o->fd = 69;
 
 	struct in_addr in;


### PR DESCRIPTION
Crash found in the fuzzer is because the ospf pointer looked up for the default vrf instance returns NULL, which immediately crashes.  Normal OSPF code, to even get here, requires a default instance of ospf.  As such the fuzzing code violated a tenant of the main ospf code.  Let's just fix the ospf fuzzing code to create a default vrf and then associate the ospf code with it.