### PR TITLE
bgpd: BGP_ATTR_MAX can be 255, allow using it for path attr

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -5145,7 +5145,7 @@ void bgp_path_attribute_discard_vty(struct vty *vty, struct peer *peer,
 	 * then flush all.
 	 */
 	if (!discard_attrs) {
-		for (i = 0; i < BGP_ATTR_MAX; i++)
+		for (i = 1; i <= BGP_ATTR_MAX; i++)
 			peer->discard_attrs[i] = false;
 		goto discard_soft_clear;
 	}
@@ -5154,7 +5154,7 @@ void bgp_path_attribute_discard_vty(struct vty *vty, struct peer *peer,
 		frrstr_split(discard_attrs, " ", &attributes, &num_attributes);
 
 		if (set)
-			for (i = 0; i < BGP_ATTR_MAX; i++)
+			for (i = 1; i <= BGP_ATTR_MAX; i++)
 				peer->discard_attrs[i] = false;
 
 		for (i = 0; i < num_attributes; i++) {
@@ -5214,7 +5214,7 @@ void bgp_path_attribute_withdraw_vty(struct vty *vty, struct peer *peer,
 	 * then flush all.
 	 */
 	if (!withdraw_attrs) {
-		for (i = 0; i < BGP_ATTR_MAX; i++)
+		for (i = 1; i <= BGP_ATTR_MAX; i++)
 			peer->withdraw_attrs[i] = false;
 		goto withdraw_soft_clear;
 	}
@@ -5223,7 +5223,7 @@ void bgp_path_attribute_withdraw_vty(struct vty *vty, struct peer *peer,
 		frrstr_split(withdraw_attrs, " ", &attributes, &num_attributes);
 
 		if (set)
-			for (i = 0; i < BGP_ATTR_MAX; i++)
+			for (i = 1; i <= BGP_ATTR_MAX; i++)
 				peer->withdraw_attrs[i] = false;
 
 		for (i = 0; i < num_attributes; i++) {

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4325,7 +4325,7 @@ bool bgp_path_attribute_discard(struct peer *peer, char *buf, size_t size)
 
 	buf[0] = '\0';
 
-	for (unsigned int i = 0; i < BGP_ATTR_MAX; i++) {
+	for (unsigned int i = 1; i <= BGP_ATTR_MAX; i++) {
 		if (peer->discard_attrs[i])
 			snprintf(buf + strlen(buf), size - strlen(buf), "%s%d",
 				 (strlen(buf) > 0) ? " " : "", i);
@@ -4345,7 +4345,7 @@ bool bgp_path_attribute_treat_as_withdraw(struct peer *peer, char *buf,
 
 	buf[0] = '\0';
 
-	for (unsigned int i = 0; i < BGP_ATTR_MAX; i++) {
+	for (unsigned int i = 1; i <= BGP_ATTR_MAX; i++) {
 		if (peer->withdraw_attrs[i])
 			snprintf(buf + strlen(buf), size - strlen(buf), "%s%d",
 				 (strlen(buf) > 0) ? " " : "", i);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1802,10 +1802,10 @@ struct peer {
 
 #define BGP_ATTR_MAX 255
 	/* Path attributes discard */
-	bool discard_attrs[BGP_ATTR_MAX];
+	bool discard_attrs[BGP_ATTR_MAX + 1];
 
 	/* Path attributes treat-as-withdraw */
-	bool withdraw_attrs[BGP_ATTR_MAX];
+	bool withdraw_attrs[BGP_ATTR_MAX + 1];
 
 	/* BGP Software Version Capability */
 #define BGP_MAX_SOFT_VERSION 64


### PR DESCRIPTION
allow 255 in path attr  discard/withdraw cmds

https://www.rfc-editor.org/rfc/rfc2042.html

says: 255 reserved for development

In FRR, 255 is kinda used too BGP_ATTR_VNC, even more we allow setting 255 in CLI.