### PR TITLE
bgpd: fix import from a local VRF with no bgp retain

### DIFF
--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -245,8 +245,7 @@ static inline void vpn_leak_postchange(enum vpn_policy_direction direction,
 		if (!CHECK_FLAG(bgp_vpn->af_flags[afi][SAFI_MPLS_VPN],
 				BGP_VPNVX_RETAIN_ROUTE_TARGET_ALL))
 			bgp_clear_soft_in(bgp_vpn, afi, SAFI_MPLS_VPN);
-		else
-			vpn_leak_to_vrf_update_all(bgp_vrf, bgp_vpn, afi);
+		vpn_leak_to_vrf_update_all(bgp_vrf, bgp_vpn, afi);
 	}
 	if (direction == BGP_VPN_POLICY_DIR_TOVPN) {
 

--- a/tests/topotests/bgp_vpnv4_noretain/r1/ipv4_vrf_all_routes_init.json
+++ b/tests/topotests/bgp_vpnv4_noretain/r1/ipv4_vrf_all_routes_init.json
@@ -1,0 +1,156 @@
+{
+  "default": {
+    "vrfName": "default",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.204.0.0/24": [
+        {
+          "pathFrom": "external",
+          "prefix": "10.204.0.0",
+          "prefixLen": 24,
+          "network": "10.204.0.0/24",
+          "metric": 0,
+          "locPrf": 100,
+          "weight": 0,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "default",
+          "nexthops": [
+            {
+              "ip": "10.125.0.2",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf1": {
+    "vrfName": "vrf1",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.101.0.0/24": [
+        {
+          "valid": true,
+          "bestpath": true,
+          "selectionReason": "First path received",
+          "pathFrom": "external",
+          "prefix": "10.101.0.0",
+          "prefixLen": 24,
+          "network": "10.101.0.0/24",
+          "metric": 0,
+          "weight": 32768,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "nexthops": [
+            {
+              "ip": "0.0.0.0",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ],
+      "10.201.0.0/24": [
+        {
+          "pathFrom": "external",
+          "prefix": "10.201.0.0",
+          "prefixLen": 24,
+          "network": "10.201.0.0/24",
+          "metric": 0,
+          "locPrf": 100,
+          "weight": 0,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "default",
+          "nexthops": [
+            {
+              "ip": "10.125.0.2",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf3": {
+    "vrfName": "vrf3",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.103.0.0/24": [
+        {
+          "valid": true,
+          "bestpath": true,
+          "selectionReason": "First path received",
+          "pathFrom": "external",
+          "prefix": "10.103.0.0",
+          "prefixLen": 24,
+          "network": "10.103.0.0/24",
+          "metric": 0,
+          "weight": 32768,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "nexthops": [
+            {
+              "ip": "0.0.0.0",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf4": {
+    "vrfName": "vrf4",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.103.0.0/24": [
+        {
+          "valid": true,
+          "bestpath": true,
+          "selectionReason": "First path received",
+          "pathFrom": "external",
+          "prefix": "10.103.0.0",
+          "prefixLen": 24,
+          "network": "10.103.0.0/24",
+          "metric": 0,
+          "weight": 32768,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "vrf3",
+          "nexthops": [
+            {
+              "ip": "0.0.0.0",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/topotests/bgp_vpnv4_noretain/r1/ipv4_vrf_all_routes_plus_r1_vrf1.json
+++ b/tests/topotests/bgp_vpnv4_noretain/r1/ipv4_vrf_all_routes_plus_r1_vrf1.json
@@ -1,0 +1,190 @@
+{
+  "default": {
+    "vrfName": "default",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.204.0.0/24": [
+        {
+          "pathFrom": "external",
+          "prefix": "10.204.0.0",
+          "prefixLen": 24,
+          "network": "10.204.0.0/24",
+          "metric": 0,
+          "locPrf": 100,
+          "weight": 0,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "default",
+          "nexthops": [
+            {
+              "ip": "10.125.0.2",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf1": {
+    "vrfName": "vrf1",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.101.0.0/24": [
+        {
+          "valid": true,
+          "bestpath": true,
+          "selectionReason": "First path received",
+          "pathFrom": "external",
+          "prefix": "10.101.0.0",
+          "prefixLen": 24,
+          "network": "10.101.0.0/24",
+          "metric": 0,
+          "weight": 32768,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "nexthops": [
+            {
+              "ip": "0.0.0.0",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ],
+      "10.201.0.0/24": [
+        {
+          "pathFrom": "external",
+          "prefix": "10.201.0.0",
+          "prefixLen": 24,
+          "network": "10.201.0.0/24",
+          "metric": 0,
+          "locPrf": 100,
+          "weight": 0,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "default",
+          "nexthops": [
+            {
+              "ip": "10.125.0.2",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf3": {
+    "vrfName": "vrf3",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.103.0.0/24": [
+        {
+          "valid": true,
+          "bestpath": true,
+          "selectionReason": "First path received",
+          "pathFrom": "external",
+          "prefix": "10.103.0.0",
+          "prefixLen": 24,
+          "network": "10.103.0.0/24",
+          "metric": 0,
+          "weight": 32768,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "nexthops": [
+            {
+              "ip": "0.0.0.0",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf4": {
+    "vrfName": "vrf4",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.103.0.0/24": [
+        {
+          "valid": true,
+          "bestpath": true,
+          "selectionReason": "First path received",
+          "pathFrom": "external",
+          "prefix": "10.103.0.0",
+          "prefixLen": 24,
+          "network": "10.103.0.0/24",
+          "metric": 0,
+          "weight": 32768,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "vrf3",
+          "nexthops": [
+            {
+              "ip": "0.0.0.0",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf2": {
+    "vrfName": "vrf2",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.101.0.0/24": [
+        {
+          "valid": true,
+          "bestpath": true,
+          "selectionReason": "First path received",
+          "pathFrom": "external",
+          "prefix": "10.101.0.0",
+          "prefixLen": 24,
+          "network": "10.101.0.0/24",
+          "metric": 0,
+          "weight": 32768,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "vrf1",
+          "nexthops": [
+            {
+              "ip": "0.0.0.0",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/topotests/bgp_vpnv4_noretain/r1/ipv4_vrf_all_routes_plus_r2_vrf2.json
+++ b/tests/topotests/bgp_vpnv4_noretain/r1/ipv4_vrf_all_routes_plus_r2_vrf2.json
@@ -1,0 +1,188 @@
+{
+  "default": {
+    "vrfName": "default",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.204.0.0/24": [
+        {
+          "pathFrom": "external",
+          "prefix": "10.204.0.0",
+          "prefixLen": 24,
+          "network": "10.204.0.0/24",
+          "metric": 0,
+          "locPrf": 100,
+          "weight": 0,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "default",
+          "nexthops": [
+            {
+              "ip": "10.125.0.2",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf1": {
+    "vrfName": "vrf1",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.101.0.0/24": [
+        {
+          "valid": true,
+          "bestpath": true,
+          "selectionReason": "First path received",
+          "pathFrom": "external",
+          "prefix": "10.101.0.0",
+          "prefixLen": 24,
+          "network": "10.101.0.0/24",
+          "metric": 0,
+          "weight": 32768,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "nexthops": [
+            {
+              "ip": "0.0.0.0",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ],
+      "10.201.0.0/24": [
+        {
+          "pathFrom": "external",
+          "prefix": "10.201.0.0",
+          "prefixLen": 24,
+          "network": "10.201.0.0/24",
+          "metric": 0,
+          "locPrf": 100,
+          "weight": 0,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "default",
+          "nexthops": [
+            {
+              "ip": "10.125.0.2",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf3": {
+    "vrfName": "vrf3",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.103.0.0/24": [
+        {
+          "valid": true,
+          "bestpath": true,
+          "selectionReason": "First path received",
+          "pathFrom": "external",
+          "prefix": "10.103.0.0",
+          "prefixLen": 24,
+          "network": "10.103.0.0/24",
+          "metric": 0,
+          "weight": 32768,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "nexthops": [
+            {
+              "ip": "0.0.0.0",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf4": {
+    "vrfName": "vrf4",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.103.0.0/24": [
+        {
+          "valid": true,
+          "bestpath": true,
+          "selectionReason": "First path received",
+          "pathFrom": "external",
+          "prefix": "10.103.0.0",
+          "prefixLen": 24,
+          "network": "10.103.0.0/24",
+          "metric": 0,
+          "weight": 32768,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "vrf3",
+          "nexthops": [
+            {
+              "ip": "0.0.0.0",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf2": {
+    "vrfName": "vrf2",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.202.0.0/24": [
+        {
+          "pathFrom": "external",
+          "prefix": "10.202.0.0",
+          "prefixLen": 24,
+          "network": "10.202.0.0/24",
+          "metric": 0,
+          "locPrf": 100,
+          "weight": 0,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "default",
+          "nexthops": [
+            {
+              "ip": "10.125.0.2",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/topotests/bgp_vpnv4_noretain/r1/ipv4_vrf_all_routes_plus_r2_vrf3.json
+++ b/tests/topotests/bgp_vpnv4_noretain/r1/ipv4_vrf_all_routes_plus_r2_vrf3.json
@@ -1,0 +1,188 @@
+{
+  "default": {
+    "vrfName": "default",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.204.0.0/24": [
+        {
+          "pathFrom": "external",
+          "prefix": "10.204.0.0",
+          "prefixLen": 24,
+          "network": "10.204.0.0/24",
+          "metric": 0,
+          "locPrf": 100,
+          "weight": 0,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "default",
+          "nexthops": [
+            {
+              "ip": "10.125.0.2",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf1": {
+    "vrfName": "vrf1",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.101.0.0/24": [
+        {
+          "valid": true,
+          "bestpath": true,
+          "selectionReason": "First path received",
+          "pathFrom": "external",
+          "prefix": "10.101.0.0",
+          "prefixLen": 24,
+          "network": "10.101.0.0/24",
+          "metric": 0,
+          "weight": 32768,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "nexthops": [
+            {
+              "ip": "0.0.0.0",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ],
+      "10.201.0.0/24": [
+        {
+          "pathFrom": "external",
+          "prefix": "10.201.0.0",
+          "prefixLen": 24,
+          "network": "10.201.0.0/24",
+          "metric": 0,
+          "locPrf": 100,
+          "weight": 0,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "default",
+          "nexthops": [
+            {
+              "ip": "10.125.0.2",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf3": {
+    "vrfName": "vrf3",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.103.0.0/24": [
+        {
+          "valid": true,
+          "bestpath": true,
+          "selectionReason": "First path received",
+          "pathFrom": "external",
+          "prefix": "10.103.0.0",
+          "prefixLen": 24,
+          "network": "10.103.0.0/24",
+          "metric": 0,
+          "weight": 32768,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "nexthops": [
+            {
+              "ip": "0.0.0.0",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf4": {
+    "vrfName": "vrf4",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.103.0.0/24": [
+        {
+          "valid": true,
+          "bestpath": true,
+          "selectionReason": "First path received",
+          "pathFrom": "external",
+          "prefix": "10.103.0.0",
+          "prefixLen": 24,
+          "network": "10.103.0.0/24",
+          "metric": 0,
+          "weight": 32768,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "vrf3",
+          "nexthops": [
+            {
+              "ip": "0.0.0.0",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "vrf2": {
+    "vrfName": "vrf2",
+    "routerId": "192.0.2.1",
+    "defaultLocPrf": 100,
+    "localAS": 65500,
+    "routes": {
+      "10.203.0.0/24": [
+        {
+          "pathFrom": "external",
+          "prefix": "10.203.0.0",
+          "prefixLen": 24,
+          "network": "10.203.0.0/24",
+          "metric": 0,
+          "locPrf": 100,
+          "weight": 0,
+          "peerId": "(unspec)",
+          "path": "",
+          "origin": "incomplete",
+          "announceNexthopSelf": true,
+          "nhVrfName": "default",
+          "nexthops": [
+            {
+              "ip": "10.125.0.2",
+              "hostname": "r1",
+              "afi": "ipv4",
+              "used": true
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/topotests/bgp_vpnv4_noretain/test_bgp_vpnv4_noretain.py
+++ b/tests/topotests/bgp_vpnv4_noretain/test_bgp_vpnv4_noretain.py
@@ -157,6 +157,36 @@ def router_json_cmp_exact_filter(router, cmd, expected):
     return topotest.json_cmp(json_output, expected, exact=True)
 
 
+def router_vrf_json_cmp_exact_filter(router, cmd, expected):
+    output = router.vtysh_cmd(cmd)
+    logger.info("{}: {}\n{}".format(router.name, cmd, output))
+
+    json_output = json.loads(output)
+
+    # filter out tableVersion, version, nhVrfId and vrfId
+    for vrf, data in json_output.items():
+        if "vrfId" in data:
+            data.pop("vrfId")
+        if "tableVersion" in data:
+            data.pop("tableVersion")
+        if "routes" not in data:
+            continue
+        for route, attrs in data["routes"].items():
+            for attr in attrs:
+                if "nhVrfId" in attr:
+                    attr.pop("nhVrfId")
+                if "version" in attr:
+                    attr.pop("version")
+
+    # filter out VRF with no routes
+    json_tmp = deepcopy(json_output)
+    for vrf, data in json_tmp.items():
+        if "routes" not in data or len(data["routes"].keys()) == 0:
+            json_output.pop(vrf)
+
+    return topotest.json_cmp(json_output, expected, exact=True)
+
+
 def check_show_bgp_ipv4_vpn(rname, json_file):
     tgen = get_topogen()
     if tgen.routers_have_failure():
@@ -171,6 +201,27 @@ def check_show_bgp_ipv4_vpn(rname, json_file):
         router_json_cmp_exact_filter,
         router,
         "show bgp ipv4 vpn json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
+    assertmsg = '"{}" JSON output mismatches'.format(router.name)
+    assert result is None, assertmsg
+
+
+def check_show_bgp_vrf_ipv4(rname, json_file):
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    router = tgen.gears[rname]
+
+    logger.info("Checking VRF IPv4 routes for convergence on {}".format(rname))
+
+    json_file = "{}/{}/{}".format(CWD, router.name, json_file)
+    expected = json.loads(open(json_file).read())
+    test_func = partial(
+        router_vrf_json_cmp_exact_filter,
+        router,
+        "show bgp vrf all ipv4 unicast json",
         expected,
     )
     _, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
@@ -211,6 +262,8 @@ def test_bgp_no_retain_step1():
     check_show_bgp_ipv4_vpn(rname, "ipv4_vpn_routes_no_retain_init.json")
     check_show_bgp_ipv4_vpn("r2", "ipv4_vpn_routes_all.json")
 
+    check_show_bgp_vrf_ipv4(rname, "ipv4_vrf_all_routes_init.json")
+
 
 def test_bgp_retain_step2():
     """
@@ -234,6 +287,8 @@ router bgp 65500
     check_show_bgp_ipv4_vpn(rname, "ipv4_vpn_routes_all.json")
     check_show_bgp_ipv4_vpn("r2", "ipv4_vpn_routes_all.json")
 
+    check_show_bgp_vrf_ipv4(rname, "ipv4_vrf_all_routes_init.json")
+
 
 def test_bgp_no_retain_step3():
     """
@@ -253,10 +308,12 @@ def test_bgp_no_retain_step3():
     check_show_bgp_ipv4_vpn(rname, "ipv4_vpn_routes_no_retain_init.json")
     check_show_bgp_ipv4_vpn("r2", "ipv4_vpn_routes_all.json")
 
+    check_show_bgp_vrf_ipv4(rname, "ipv4_vrf_all_routes_init.json")
+
 
 def test_bgp_no_retain_add_vrf2_step4():
     """
-    Add vrf2 on r1 and check bgp vpnv4 table
+    Add vrf2 on r1 and check bgp tables
     """
 
     rname = "r1"
@@ -283,10 +340,12 @@ router bgp 65500 vrf vrf2
     check_show_bgp_ipv4_vpn(rname, "ipv4_vpn_routes_no_retain_init_plus_r2_vrf2.json")
     check_show_bgp_ipv4_vpn("r2", "ipv4_vpn_routes_all.json")
 
+    check_show_bgp_vrf_ipv4(rname, "ipv4_vrf_all_routes_plus_r2_vrf2.json")
+
 
 def test_bgp_no_retain_unimport_vrf2_step5():
     """
-    Unimport to vrf2 on r1 and check bgp vpnv4 table
+    Unimport to vrf2 on r1 and check bgp tables
     """
 
     rname = "r1"
@@ -308,10 +367,12 @@ router bgp 65500 vrf vrf2
     check_show_bgp_ipv4_vpn(rname, "ipv4_vpn_routes_no_retain_init.json")
     check_show_bgp_ipv4_vpn("r2", "ipv4_vpn_routes_all.json")
 
+    check_show_bgp_vrf_ipv4(rname, "ipv4_vrf_all_routes_init.json")
+
 
 def test_bgp_no_retain_import_vrf2_step6():
     """
-    Re-import to vrf2 on r1 and check bgp vpnv4 table
+    Re-import to vrf2 on r1 and check bgp tables
     """
 
     rname = "r1"
@@ -333,10 +394,12 @@ router bgp 65500 vrf vrf2
     check_show_bgp_ipv4_vpn(rname, "ipv4_vpn_routes_no_retain_init_plus_r2_vrf2.json")
     check_show_bgp_ipv4_vpn("r2", "ipv4_vpn_routes_all.json")
 
+    check_show_bgp_vrf_ipv4(rname, "ipv4_vrf_all_routes_plus_r2_vrf2.json")
+
 
 def test_bgp_no_retain_import_vrf1_step7():
     """
-    Import r1 vrf1 into r1 vrf2 and check bgp vpnv4 table
+    Import r1 vrf1 into r1 vrf2 and check bgp tables
     """
 
     rname = "r1"
@@ -358,10 +421,12 @@ router bgp 65500 vrf vrf2
     check_show_bgp_ipv4_vpn(rname, "ipv4_vpn_routes_no_retain_init.json")
     check_show_bgp_ipv4_vpn("r2", "ipv4_vpn_routes_all.json")
 
+    check_show_bgp_vrf_ipv4(rname, "ipv4_vrf_all_routes_plus_r1_vrf1.json")
+
 
 def test_bgp_no_retain_import_vrf3_step8():
     """
-    Import r2 vrf3 into r1 vrf2 and check bgp vpnv4 table
+    Import r2 vrf3 into r1 vrf2 and check bgp tables
     """
 
     rname = "r1"
@@ -383,10 +448,12 @@ router bgp 65500 vrf vrf2
     check_show_bgp_ipv4_vpn(rname, "ipv4_vpn_routes_no_retain_init_plus_r2_vrf3.json")
     check_show_bgp_ipv4_vpn("r2", "ipv4_vpn_routes_all.json")
 
+    check_show_bgp_vrf_ipv4(rname, "ipv4_vrf_all_routes_plus_r2_vrf3.json")
+
 
 def test_bgp_no_retain_unimport_vrf3_step9():
     """
-    Un-import r2 vrf3 into r1 vrf2 and check bgp vpnv4 table
+    Un-import r2 vrf3 into r1 vrf2 and check bgp tables
     """
 
     rname = "r1"
@@ -408,10 +475,12 @@ router bgp 65500 vrf vrf2
     check_show_bgp_ipv4_vpn(rname, "ipv4_vpn_routes_no_retain_init.json")
     check_show_bgp_ipv4_vpn("r2", "ipv4_vpn_routes_all.json")
 
+    check_show_bgp_vrf_ipv4(rname, "ipv4_vrf_all_routes_init.json")
+
 
 def test_bgp_no_retain_import_vrf3_step10():
     """
-    Import r2 vrf3 into r1 vrf2 and check bgp vpnv4 table
+    Import r2 vrf3 into r1 vrf2 and check bgp tables
     """
 
     rname = "r1"
@@ -433,10 +502,12 @@ router bgp 65500 vrf vrf2
     check_show_bgp_ipv4_vpn(rname, "ipv4_vpn_routes_no_retain_init_plus_r2_vrf3.json")
     check_show_bgp_ipv4_vpn("r2", "ipv4_vpn_routes_all.json")
 
+    check_show_bgp_vrf_ipv4(rname, "ipv4_vrf_all_routes_plus_r2_vrf3.json")
+
 
 def test_bgp_no_retain_remove_vrf2_step11():
     """
-    Remove BGP vrf2 on r1 and check bgp vpnv4 table
+    Remove BGP vrf2 on r1 and check bgp tables
     """
 
     rname = "r1"
@@ -454,10 +525,12 @@ no router bgp 65500 vrf vrf2
     check_show_bgp_ipv4_vpn(rname, "ipv4_vpn_routes_no_retain_init.json")
     check_show_bgp_ipv4_vpn("r2", "ipv4_vpn_routes_all.json")
 
+    check_show_bgp_vrf_ipv4(rname, "ipv4_vrf_all_routes_init.json")
+
 
 def test_bgp_retain_step12():
     """
-    Configure retain and check bgp vpnv4 table
+    Configure retain and check bgp tables
     """
 
     rname = "r1"
@@ -476,6 +549,8 @@ router bgp 65500
 
     check_show_bgp_ipv4_vpn(rname, "ipv4_vpn_routes_all.json")
     check_show_bgp_ipv4_vpn("r2", "ipv4_vpn_routes_all.json")
+
+    check_show_bgp_vrf_ipv4(rname, "ipv4_vrf_all_routes_init.json")
 
 
 def test_memory_leak():

--- a/tests/topotests/bgp_vpnv4_noretain/test_bgp_vpnv4_noretain.py
+++ b/tests/topotests/bgp_vpnv4_noretain/test_bgp_vpnv4_noretain.py
@@ -336,7 +336,7 @@ router bgp 65500 vrf vrf2
 
 def test_bgp_no_retain_import_vrf1_step7():
     """
-    Import r2 vrf1 into r1 vrf2 and check bgp vpnv4 table
+    Import r1 vrf1 into r1 vrf2 and check bgp vpnv4 table
     """
 
     rname = "r1"
@@ -436,7 +436,7 @@ router bgp 65500 vrf vrf2
 
 def test_bgp_no_retain_remove_vrf2_step11():
     """
-    Import r2 vrf3 into r1 vrf2 and check bgp vpnv4 table
+    Remove BGP vrf2 on r1 and check bgp vpnv4 table
     """
 
     rname = "r1"


### PR DESCRIPTION
The BGP "no retain" VPN option avoids storing VPN prefixes that are not
imported in the incoming BGP table (aka. Adj RIB in). When a VPN import
policy is changed, BGP does a soft clear so that a prefix refresh is
requested from the peers. However, the import from local VPN prefixes
is never requested.

Fix this issue by requesting a local import refresh.