### PR TITLE
tests: snmp tests sometimes fail with `Unable to bind`

### DIFF
--- a/tests/topotests/bgp_snmp_mplsl3vpn/ce1/snmpd.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/ce1/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:10.5.5.5:161
+agentAddress udp:161
 
 com2sec public localhost public
 

--- a/tests/topotests/bgp_snmp_mplsl3vpn/ce2/snmpd.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/ce2/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:10.6.6.6:161
+agentAddress udp:161
 
 com2sec public localhost public
 

--- a/tests/topotests/bgp_snmp_mplsl3vpn/ce3/snmpd.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/ce3/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:10.5.5.5:161
+agentAddress udp:161
 
 com2sec public localhost public
 

--- a/tests/topotests/bgp_snmp_mplsl3vpn/ce4/snmpd.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/ce4/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:10.5.5.5:161
+agentAddress udp:161
 
 com2sec public localhost public
 

--- a/tests/topotests/bgp_snmp_mplsl3vpn/r1/snmpd.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/r1/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:10.1.1.1:161
+agentAddress udp:161
 
 com2sec public 10.1.1.1 public
 

--- a/tests/topotests/bgp_snmp_mplsl3vpn/r2/snmpd.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/r2/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:10.2.2.2:161
+agentAddress udp:161
 
 com2sec public localhost public
 

--- a/tests/topotests/bgp_snmp_mplsl3vpn/r3/snmpd.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/r3/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:10.3.3.3:161
+agentAddress udp:161
 
 com2sec public localhost public
 

--- a/tests/topotests/bgp_snmp_mplsl3vpn/r4/snmpd.conf
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/r4/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:10.4.4.4:161
+agentAddress udp:161
 
 com2sec public localhost public
 

--- a/tests/topotests/isis_snmp/r1/snmpd.conf
+++ b/tests/topotests/isis_snmp/r1/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:1.1.1.1:161
+agentAddress udp:161
 
 com2sec public 1.1.1.1 public
 

--- a/tests/topotests/isis_snmp/r2/snmpd.conf
+++ b/tests/topotests/isis_snmp/r2/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:2.2.2.2:161
+agentAddress udp::161
 
 com2sec public 2.2.2.2 public
 

--- a/tests/topotests/isis_snmp/r3/snmpd.conf
+++ b/tests/topotests/isis_snmp/r3/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:3.3.3.3:161
+agentAddress udp:161
 
 com2sec public 3.3.3.3 public
 

--- a/tests/topotests/isis_snmp/r4/snmpd.conf
+++ b/tests/topotests/isis_snmp/r4/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:4.4.4.4:161
+agentAddress udp:161
 
 com2sec public 4.4.4.4 public
 

--- a/tests/topotests/isis_snmp/r5/snmpd.conf
+++ b/tests/topotests/isis_snmp/r5/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:5.5.5.5:161
+agentAddress udp::161
 
 com2sec public 5.5.5.5 public
 

--- a/tests/topotests/ldp_snmp/r1/snmpd.conf
+++ b/tests/topotests/ldp_snmp/r1/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:1.1.1.1:161
+agentAddress udp:161
 
 com2sec public 1.1.1.1 public
 

--- a/tests/topotests/ldp_snmp/r2/snmpd.conf
+++ b/tests/topotests/ldp_snmp/r2/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:2.2.2.2:161
+agentAddress udp:161
 
 com2sec public 2.2.2.2 public
 

--- a/tests/topotests/simple_snmp_test/r1/snmpd.conf
+++ b/tests/topotests/simple_snmp_test/r1/snmpd.conf
@@ -1,4 +1,4 @@
-agentAddress udp:1.1.1.1:161
+agentAddress udp:161
 
 com2sec public 1.1.1.1 public
 


### PR DESCRIPTION
the snmp tests are using zebra.conf to setup the
address that they are binding to and immediately
after that they are starting snmpd.  If snmpd
starts up *before* zebra has installed the address the bind on the address will fail.  Causing the entire test to fail.  Modify the snmpd.conf for all our
snmp tests to bind to all addresses.  Things still work and we no longer have an issue.