### PR TITLE
pimd: Display oil_parent as a string name of the interface

### DIFF
--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -1276,10 +1276,15 @@ int pim_mroute_del(struct channel_oil *c_oil, const char *name)
 	if (!c_oil->installed) {
 		if (PIM_DEBUG_MROUTE) {
 			char buf[1000];
-			zlog_debug(
-				"%s %s: vifi %d for route is %s not installed, do not need to send del req. ",
-				__FILE__, __func__, *oil_parent(c_oil),
-				pim_channel_oil_dump(c_oil, buf, sizeof(buf)));
+			struct interface *iifp =
+				pim_if_find_by_vif_index(pim,
+							 *oil_parent(c_oil));
+
+			zlog_debug("%s %s: incoming interface %s for route is %s not installed, do not need to send del req. ",
+				   __FILE__, __func__,
+				   iifp ? iifp->name : "Unknown",
+				   pim_channel_oil_dump(c_oil, buf,
+							sizeof(buf)));
 		}
 		return -2;
 	}

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -286,13 +286,16 @@ int pim_channel_del_oif(struct channel_oil *channel_oil, struct interface *oif,
 	--channel_oil->oil_size;
 
 	if (PIM_DEBUG_MROUTE) {
-		zlog_debug(
-			"%s(%s): (S,G)=(%pPAs,%pPAs): proto_mask=%u IIF:%d OIF=%s vif_index=%d",
-			__func__, caller, oil_origin(channel_oil),
-			oil_mcastgrp(channel_oil),
-			proto_mask,
-			*oil_parent(channel_oil), oif->name,
-			pim_ifp->mroute_vif_index);
+		struct interface *iifp =
+			pim_if_find_by_vif_index(pim_ifp->pim,
+						 *oil_parent(channel_oil));
+
+
+		zlog_debug("%s(%s): (S,G)=(%pPAs,%pPAs): proto_mask=%u IIF:%s OIF=%s vif_index=%d",
+			   __func__, caller, oil_origin(channel_oil),
+			   oil_mcastgrp(channel_oil), proto_mask,
+			   iifp ? iifp->name : "Unknown", oif->name,
+			   pim_ifp->mroute_vif_index);
 	}
 
 	return 0;

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -502,9 +502,9 @@ int pim_zlookup_sg_statistics(struct channel_oil *c_oil)
 	if (PIM_DEBUG_ZEBRA) {
 		more.src = *oil_origin(c_oil);
 		more.grp = *oil_mcastgrp(c_oil);
-		zlog_debug(
-			"Sending Request for New Channel Oil Information%pSG VIIF %d(%s)",
-			&more, *oil_parent(c_oil), c_oil->pim->vrf->name);
+		zlog_debug("Sending Request for New Channel Oil Information%pSG VIIF %d(%s:%s)",
+			   &more, *oil_parent(c_oil),
+			   ifp ? ifp->name : "Unknown", c_oil->pim->vrf->name);
 	}
 
 	if (!ifp)


### PR DESCRIPTION
When debugging and outputting the oil_parent() let's just convert it to a string that is useful for people trying to debug pim