### PR TITLE
lib: another attempt at Coverity false positives

### DIFF
--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -122,6 +122,14 @@ extern "C" {
 #define assume(x)
 #endif
 
+#ifdef __COVERITY__
+/* __coverity_panic__() is named a bit poorly, it's essentially the same as
+ * __builtin_unreachable().  Used to eliminate false positives.
+ */
+#undef assume
+#define assume(x) do { if (!(x)) __coverity_panic__(); } while (0)
+#endif
+
 /* for helper functions defined inside macros */
 #define macro_inline	static inline __attribute__((unused))
 #define macro_pure	static inline __attribute__((unused, pure))


### PR DESCRIPTION
Typesafe hash tables do this:

```
	assume((tabshift) >= 2 && (tabshift) <= 33);
	(val) >> (33 - (tabshift));
```

Sadly, Coverity currently ignores assume() and says:
> [...] right shifting by more than 31 bits has undefined behavior.
> The shift amount, "33 - h->hh.tabshift", is 33.

Let's see if Coverity understands this can't happen...