### PR TITLE
pimd: Use a better name for oil_parent

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1078,7 +1078,7 @@ void pim_show_state(struct pim_instance *pim, struct vty *vty,
 			   oil_mcastgrp(c_oil));
 		snprintfrr(src_str, sizeof(src_str), "%pPAs",
 			   oil_origin(c_oil));
-		ifp_in = pim_if_find_by_vif_index(pim, *oil_parent(c_oil));
+		ifp_in = pim_if_find_by_vif_index(pim, *oil_incoming_vif(c_oil));
 
 		if (ifp_in)
 			strlcpy(in_ifname, ifp_in->name, sizeof(in_ifname));
@@ -3723,7 +3723,7 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 		if (pim_channel_oil_empty(c_oil))
 			strlcat(state_str, "P", sizeof(state_str));
 
-		ifp_in = pim_if_find_by_vif_index(pim, *oil_parent(c_oil));
+		ifp_in = pim_if_find_by_vif_index(pim, *oil_incoming_vif(c_oil));
 
 		if (ifp_in)
 			strlcpy(in_ifname, ifp_in->name, sizeof(in_ifname));
@@ -3789,7 +3789,7 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 			if (c_oil->oif_flags[oif_vif_index] & PIM_OIF_FLAG_MUTE)
 				continue;
 
-			if (*oil_parent(c_oil) == oif_vif_index &&
+			if (*oil_incoming_vif(c_oil) == oif_vif_index &&
 			    !pim_mroute_allow_iif_in_oil(c_oil, oif_vif_index))
 				continue;
 
@@ -3840,7 +3840,7 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 						       "inboundInterface",
 						       in_ifname);
 				json_object_int_add(json_ifp_out, "iVifI",
-						    *oil_parent(c_oil));
+						    *oil_incoming_vif(c_oil));
 				json_object_string_add(json_ifp_out,
 						       "outboundInterface",
 						       out_ifname);
@@ -3989,9 +3989,9 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 				json_object_string_add(json_ifp_out,
 						       "inboundInterface",
 						       in_ifname);
-				json_object_int_add(
-					json_ifp_out, "iVifI",
-					*oil_parent(&s_route->c_oil));
+				json_object_int_add(json_ifp_out, "iVifI",
+						    *oil_incoming_vif(
+							    &s_route->c_oil));
 				json_object_string_add(json_ifp_out,
 						       "outboundInterface",
 						       out_ifname);

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -253,7 +253,7 @@ int pim_mroute_msg_nocache(int fd, struct interface *ifp, const kernmsg *msg)
 	up->channel_oil->cc.pktcnt++;
 	// resolve mfcc_parent prior to mroute_add in channel_add_oif
 	if (up->rpf.source_nexthop.interface &&
-	    *oil_parent(up->channel_oil) >= MAXVIFS) {
+	    *oil_incoming_vif(up->channel_oil) >= MAXVIFS) {
 		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
 	}
 	pim_register_join(up);
@@ -1042,10 +1042,10 @@ static inline void pim_mroute_copy(struct channel_oil *out,
 
 	*oil_origin(out) = *oil_origin(in);
 	*oil_mcastgrp(out) = *oil_mcastgrp(in);
-	*oil_parent(out) = *oil_parent(in);
+	*oil_incoming_vif(out) = *oil_incoming_vif(in);
 
 	for (i = 0; i < MAXVIFS; ++i) {
-		if (*oil_parent(out) == i &&
+		if (*oil_incoming_vif(out) == i &&
 		    !pim_mroute_allow_iif_in_oil(in, i)) {
 			oil_if_set(out, i, 0);
 			continue;
@@ -1080,7 +1080,7 @@ static int pim_mroute_add(struct channel_oil *c_oil, const char *name)
 	 * in the case of a (*,G).
 	 */
 	if (pim_addr_is_any(*oil_origin(c_oil))) {
-		oil_if_set(tmp_oil, *oil_parent(c_oil), 1);
+		oil_if_set(tmp_oil, *oil_incoming_vif(c_oil), 1);
 	}
 
 	/*
@@ -1090,18 +1090,17 @@ static int pim_mroute_add(struct channel_oil *c_oil, const char *name)
 	 * the packets to be forwarded.  Then set it
 	 * to the correct IIF afterwords.
 	 */
-	if (!c_oil->installed && !pim_addr_is_any(*oil_origin(c_oil))
-	    && *oil_parent(c_oil) != 0) {
-		*oil_parent(tmp_oil) = 0;
+	if (!c_oil->installed && !pim_addr_is_any(*oil_origin(c_oil)) &&
+	    *oil_incoming_vif(c_oil) != 0) {
+		*oil_incoming_vif(tmp_oil) = 0;
 	}
 	/* For IPv6 MRT_ADD_MFC is defined to MRT6_ADD_MFC */
 	err = setsockopt(pim->mroute_socket, PIM_IPPROTO, MRT_ADD_MFC,
 			 &tmp_oil->oil, sizeof(tmp_oil->oil));
 
-	if (!err && !c_oil->installed
-	    && !pim_addr_is_any(*oil_origin(c_oil))
-	    && *oil_parent(c_oil) != 0) {
-		*oil_parent(tmp_oil) = *oil_parent(c_oil);
+	if (!err && !c_oil->installed && !pim_addr_is_any(*oil_origin(c_oil)) &&
+	    *oil_incoming_vif(c_oil) != 0) {
+		*oil_incoming_vif(tmp_oil) = *oil_incoming_vif(c_oil);
 		err = setsockopt(pim->mroute_socket, PIM_IPPROTO, MRT_ADD_MFC,
 				 &tmp_oil->oil, sizeof(tmp_oil->oil));
 	}
@@ -1158,7 +1157,7 @@ static int pim_upstream_mroute_update(struct channel_oil *c_oil,
 {
 	char buf[1000];
 
-	if (*oil_parent(c_oil) >= MAXVIFS) {
+	if (*oil_incoming_vif(c_oil) >= MAXVIFS) {
 		/* the c_oil cannot be installed as a mroute yet */
 		if (PIM_DEBUG_MROUTE)
 			zlog_debug(
@@ -1205,13 +1204,13 @@ int pim_upstream_mroute_add(struct channel_oil *c_oil, const char *name)
 
 	iif = pim_upstream_get_mroute_iif(c_oil, name);
 
-	if (*oil_parent(c_oil) != iif) {
-		*oil_parent(c_oil) = iif;
+	if (*oil_incoming_vif(c_oil) != iif) {
+		*oil_incoming_vif(c_oil) = iif;
 		if (pim_addr_is_any(*oil_origin(c_oil)) &&
 				c_oil->up)
 			pim_upstream_all_sources_iif_update(c_oil->up);
 	} else {
-		*oil_parent(c_oil) = iif;
+		*oil_incoming_vif(c_oil) = iif;
 	}
 
 	return pim_upstream_mroute_update(c_oil, name);
@@ -1226,11 +1225,11 @@ int pim_upstream_mroute_iif_update(struct channel_oil *c_oil, const char *name)
 	char buf[1000];
 
 	iif = pim_upstream_get_mroute_iif(c_oil, name);
-	if (*oil_parent(c_oil) == iif) {
+	if (*oil_incoming_vif(c_oil) == iif) {
 		/* no change */
 		return 0;
 	}
-	*oil_parent(c_oil) = iif;
+	*oil_incoming_vif(c_oil) = iif;
 
 	if (pim_addr_is_any(*oil_origin(c_oil)) &&
 			c_oil->up)
@@ -1255,10 +1254,10 @@ void pim_static_mroute_iif_update(struct channel_oil *c_oil,
 				int input_vif_index,
 				const char *name)
 {
-	if (*oil_parent(c_oil) == input_vif_index)
+	if (*oil_incoming_vif(c_oil) == input_vif_index)
 		return;
 
-	*oil_parent(c_oil) = input_vif_index;
+	*oil_incoming_vif(c_oil) = input_vif_index;
 	if (input_vif_index == MAXVIFS)
 		pim_mroute_del(c_oil, name);
 	else
@@ -1277,8 +1276,8 @@ int pim_mroute_del(struct channel_oil *c_oil, const char *name)
 		if (PIM_DEBUG_MROUTE) {
 			char buf[1000];
 			struct interface *iifp =
-				pim_if_find_by_vif_index(pim,
-							 *oil_parent(c_oil));
+				pim_if_find_by_vif_index(pim, *oil_incoming_vif(
+								      c_oil));
 
 			zlog_debug("%s %s: incoming interface %s for route is %s not installed, do not need to send del req. ",
 				   __FILE__, __func__,

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -31,7 +31,7 @@ char *pim_channel_oil_dump(struct channel_oil *c_oil, char *buf, size_t size)
 
 	sg.src = *oil_origin(c_oil);
 	sg.grp = *oil_mcastgrp(c_oil);
-	ifp = pim_if_find_by_vif_index(c_oil->pim, *oil_parent(c_oil));
+	ifp = pim_if_find_by_vif_index(c_oil->pim, *oil_incoming_vif(c_oil));
 	snprintfrr(buf, size, "%pSG IIF: %s, OIFS: ", &sg,
 		   ifp ? ifp->name : "(?)");
 
@@ -135,7 +135,7 @@ struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
 	*oil_mcastgrp(c_oil) = sg->grp;
 	*oil_origin(c_oil) = sg->src;
 
-	*oil_parent(c_oil) = MAXVIFS;
+	*oil_incoming_vif(c_oil) = MAXVIFS;
 	c_oil->oil_ref_count = 1;
 	c_oil->installed = 0;
 	c_oil->up = pim_upstream_find(pim, sg);
@@ -164,7 +164,7 @@ void pim_clear_nocache_state(struct pim_interface *pim_ifp)
 		    !(PIM_UPSTREAM_FLAG_TEST_SRC_NOCACHE(c_oil->up->flags)))
 			continue;
 
-		if (*oil_parent(c_oil) != pim_ifp->mroute_vif_index)
+		if (*oil_incoming_vif(c_oil) != pim_ifp->mroute_vif_index)
 			continue;
 
 		EVENT_OFF(c_oil->up->t_ka_timer);
@@ -288,8 +288,7 @@ int pim_channel_del_oif(struct channel_oil *channel_oil, struct interface *oif,
 	if (PIM_DEBUG_MROUTE) {
 		struct interface *iifp =
 			pim_if_find_by_vif_index(pim_ifp->pim,
-						 *oil_parent(channel_oil));
-
+						 *oil_incoming_vif(channel_oil));
 
 		zlog_debug("%s(%s): (S,G)=(%pPAs,%pPAs): proto_mask=%u IIF:%s OIF=%s vif_index=%d",
 			   __func__, caller, oil_origin(channel_oil),
@@ -525,7 +524,7 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 	/* channel_oil->oil.mfcc_parent != MAXVIFS indicate this entry is not
 	 * valid to get installed in kernel.
 	 */
-	if (*oil_parent(channel_oil) != MAXVIFS) {
+	if (*oil_incoming_vif(channel_oil) != MAXVIFS) {
 		if (pim_upstream_mroute_add(channel_oil, __func__)) {
 			if (PIM_DEBUG_MROUTE) {
 				zlog_debug(

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -112,7 +112,7 @@ static inline pim_addr *oil_mcastgrp(struct channel_oil *c_oil)
 	return &c_oil->oil.mfcc_mcastgrp;
 }
 
-static inline vifi_t *oil_parent(struct channel_oil *c_oil)
+static inline vifi_t *oil_incoming_vif(struct channel_oil *c_oil)
 {
 	return &c_oil->oil.mfcc_parent;
 }
@@ -143,7 +143,7 @@ static inline pim_addr *oil_mcastgrp(struct channel_oil *c_oil)
 	return &c_oil->oil.mf6cc_mcastgrp.sin6_addr;
 }
 
-static inline mifi_t *oil_parent(struct channel_oil *c_oil)
+static inline mifi_t *oil_incoming_vif(struct channel_oil *c_oil)
 {
 	return &c_oil->oil.mf6cc_parent;
 }

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -44,7 +44,7 @@ static struct static_route *static_route_new(ifindex_t iif, ifindex_t oif,
 	s_route->c_oil.oil_ref_count = 1;
 	*oil_origin(&s_route->c_oil) = source;
 	*oil_mcastgrp(&s_route->c_oil) = group;
-	*oil_parent(&s_route->c_oil) = iif;
+	*oil_incoming_vif(&s_route->c_oil) = iif;
 	oil_if_set(&s_route->c_oil, oif, 1);
 	s_route->c_oil.oif_creation[oif] = pim_time_monotonic_sec();
 

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1977,7 +1977,7 @@ static bool pim_upstream_kat_start_ok(struct pim_upstream *up)
 		return false;
 
 	pim_ifp = ifp->info;
-	if (pim_ifp->mroute_vif_index != *oil_parent(c_oil))
+	if (pim_ifp->mroute_vif_index != *oil_incoming_vif(c_oil))
 		return false;
 
 	if (pim_if_connected_to_source(up->rpf.source_nexthop.interface,

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -497,13 +497,13 @@ int pim_zlookup_sg_statistics(struct channel_oil *c_oil)
 	int ret;
 	pim_sgaddr more = {};
 	struct interface *ifp =
-		pim_if_find_by_vif_index(c_oil->pim, *oil_parent(c_oil));
+		pim_if_find_by_vif_index(c_oil->pim, *oil_incoming_vif(c_oil));
 
 	if (PIM_DEBUG_ZEBRA) {
 		more.src = *oil_origin(c_oil);
 		more.grp = *oil_mcastgrp(c_oil);
 		zlog_debug("Sending Request for New Channel Oil Information%pSG VIIF %d(%s:%s)",
-			   &more, *oil_parent(c_oil),
+			   &more, *oil_incoming_vif(c_oil),
 			   ifp ? ifp->name : "Unknown", c_oil->pim->vrf->name);
 	}
 


### PR DESCRIPTION
Use oil_incoming_vif instead of oil_parent.  I had to go look this up as that I failed to remember that the linux kernel calls this parent for some bizarre reason.