### PR TITLE
tools: make --quiet actually suppress output

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -207,8 +207,8 @@ daemon_stop() {
 	[ -z "$fail" -a -z "$pid" ] && fail="pid file is empty"
 	[ -n "$fail" ] || kill -0 "$pid" 2>/dev/null || fail="pid $pid not running"
 
-	if [ -n "$fail" ] && [ "$2" != "--quiet" ]; then
-		log_failure_msg "Cannot stop $dmninst: $fail"
+	if [ -n "$fail" ]; then
+		[ "$2" = "--quiet" ] || log_failure_msg "Cannot stop $dmninst: $fail"
 		return 1
 	fi
 
@@ -220,11 +220,11 @@ daemon_stop() {
 		[ $(( cnt -= 1 )) -gt 0 ] || break
 	done
 	if kill -0 "$pid" 2>/dev/null; then
-		log_failure_msg "Failed to stop $dmninst, pid $pid still running"
+		[ "$2" = "--quiet" ] || log_failure_msg "Failed to stop $dmninst, pid $pid still running"
 		still_running=1
 		return 1
 	else
-		log_success_msg "Stopped $dmninst"
+		[ "$2" = "--quiet" ] || log_success_msg "Stopped $dmninst"
 		rm -f "$pidfile"
 		return 0
 	fi


### PR DESCRIPTION
When calling daemon_stop() with --quiet and e.g. the pidfile is empty, it won't return early since while "$fail" is set, "$2" is "--quiet", so the if condition isn't met and it will continue executing, resulting in error messages in the log:

```
Sep 14 14:48:33 localhost watchfrr[2085]: [YFT0P-5Q5YX] Forked background command [pid 2086]: /usr/lib/frr/watchfrr.sh restart all
Sep 14 14:48:33 localhost frrinit.sh[2075]: /usr/lib/frr/frrcommon.sh: line 216: kill: `': not a pid or valid job spec
Sep 14 14:48:33 localhost frrinit.sh[2075]: /usr/lib/frr/frrcommon.sh: line 216: kill: `': not a pid or valid job spec
Sep 14 14:48:33 localhost frrinit.sh[2075]: /usr/lib/frr/frrcommon.sh: line 216: kill: `': not a pid or valid job spec
```

Fix this by moving the --quiet check into the block to log\_failure\_msg(), and also add the check to all other invocations of log_*_msg to make --quiet properly suppress output.

Fixes: 19a99d89f088 ("tools: suppress unuseful warnings during restarting frr")