### PR TITLE
isisd: Fix a bunch of coverity issues in IS-IS

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -2751,7 +2751,7 @@ static int unpack_item_srv6_end_sid(uint16_t mtid, uint8_t len,
 				    void *dest, int indent)
 {
 	struct isis_subtlvs *subtlvs = dest;
-	struct isis_srv6_end_sid_subtlv *sid;
+	struct isis_srv6_end_sid_subtlv *sid = NULL;
 	size_t consume;
 	uint8_t subsubtlv_len;
 
@@ -2763,7 +2763,7 @@ static int unpack_item_srv6_end_sid(uint16_t mtid, uint8_t len,
 			log, indent,
 			"Not enough data left. (expected 19 or more bytes, got %hhu)\n",
 			len);
-		return 1;
+		goto out;
 	}
 
 	sid = XCALLOC(MTYPE_ISIS_SUBTLV, sizeof(*sid));

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -1136,6 +1136,9 @@ static int isis_zebra_process_srv6_locator_chunk(ZAPI_CALLBACK_ARGS)
 	enum srv6_endpoint_behavior_codepoint behavior;
 	bool allocated = false;
 
+	if (!isis)
+		return -1;
+
 	/* Decode the received zebra message */
 	s = zclient->ibuf;
 	if (zapi_srv6_locator_chunk_decode(s, chunk) < 0)

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -1017,11 +1017,14 @@ void isis_zebra_srv6_adj_sid_install(struct srv6_adjacency *sra)
 	struct seg6local_context ctx = {};
 	uint16_t prefixlen = IPV6_MAX_BITLEN;
 	struct interface *ifp;
-	struct isis_circuit *circuit = sra->adj->circuit;
-	struct isis_area *area = circuit->area;
+	struct isis_circuit *circuit;
+	struct isis_area *area;
 
 	if (!sra)
 		return;
+
+	circuit = sra->adj->circuit;
+	area = circuit->area;
 
 	sr_debug("ISIS-SRv6 (%s): setting adjacency SID %pI6", area->area_tag,
 		 &sra->sid);

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -1074,11 +1074,14 @@ void isis_zebra_srv6_adj_sid_uninstall(struct srv6_adjacency *sra)
 	enum seg6local_action_t action = ZEBRA_SEG6_LOCAL_ACTION_UNSPEC;
 	struct interface *ifp;
 	uint16_t prefixlen = IPV6_MAX_BITLEN;
-	struct isis_circuit *circuit = sra->adj->circuit;
-	struct isis_area *area = circuit->area;
+	struct isis_circuit *circuit;
+	struct isis_area *area;
 
 	if (!sra)
 		return;
+
+	circuit = sra->adj->circuit;
+	area = circuit->area;
 
 	switch (sra->behavior) {
 	case SRV6_ENDPOINT_BEHAVIOR_END_X:


### PR DESCRIPTION
Fix a bunch of coverity issues.

```
*** CID 1568129:  Null pointer dereferences  (REVERSE_INULL)
/isisd/isis_tlvs.c: 2813 in unpack_item_srv6_end_sid()
2807                    sid->subsubtlvs = NULL;
2808            }
2809
2810            append_item(&subtlvs->srv6_end_sids, (struct isis_item *)sid);
2811            return 0;
2812     out:
>>>     CID 1568129:  Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "sid" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
2813            if (sid)
2814                    free_item_srv6_end_sid((struct isis_item *)sid);
2815            return 1;
2816     }
2817
2818     /* Functions related to TLVs 1 Area Addresses */
```

---

```
*** CID 1568132:  Null pointer dereferences  (REVERSE_INULL)
/isisd/isis_zebra.c: 1023 in isis_zebra_srv6_adj_sid_install()
1017            struct seg6local_context ctx = {};
1018            uint16_t prefixlen = IPV6_MAX_BITLEN;
1019            struct interface *ifp;
1020            struct isis_circuit *circuit = sra->adj->circuit;
1021            struct isis_area *area = circuit->area;
1022
>>>     CID 1568132:  Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "sra" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
1023            if (!sra)
1024                    return;
1025
1026            sr_debug("ISIS-SRv6 (%s): setting adjacency SID %pI6", area->area_tag,
1027                     &sra->sid);
1028
```

---

```
*** CID 1568133:  Null pointer dereferences  (REVERSE_INULL)
/isisd/isis_zebra.c: 1077 in isis_zebra_srv6_adj_sid_uninstall()
1071            enum seg6local_action_t action = ZEBRA_SEG6_LOCAL_ACTION_UNSPEC;
1072            struct interface *ifp;
1073            uint16_t prefixlen = IPV6_MAX_BITLEN;
1074            struct isis_circuit *circuit = sra->adj->circuit;
1075            struct isis_area *area = circuit->area;
1076
>>>     CID 1568133:  Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "sra" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
1077            if (!sra)
1078                    return;
1079
1080            switch (sra->behavior) {
1081            case SRV6_ENDPOINT_BEHAVIOR_END_X:
1082                    prefixlen = IPV6_MAX_BITLEN;
```

---

```
*** CID 1568134:  Null pointer dereferences  (NULL_RETURNS)
/isisd/isis_zebra.c: 1146 in isis_zebra_process_srv6_locator_chunk()
1140                    "prefix %pFX, block_len %u, node_len %u, func_len %u, arg_len %u",
1141                    chunk->locator_name, &chunk->prefix, chunk->block_bits_length,
1142                    chunk->node_bits_length, chunk->function_bits_length,
1143                    chunk->argument_bits_length);
1144
1145            /* Walk through all areas of the ISIS instance */
>>>     CID 1568134:  Null pointer dereferences  (NULL_RETURNS)
>>>     Dereferencing "isis", which is known to be "NULL".
1146            for (ALL_LIST_ELEMENTS_RO(isis->area_list, node, area)) {
1147                    if (strncmp(area->srv6db.config.srv6_locator_name,
1148                                chunk->locator_name,
1149                                sizeof(area->srv6db.config.srv6_locator_name)) != 0)
1150                            continue;
1151
```
