### PR TITLE
ospf6d: fix uninitialized warnings

### DIFF
--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -87,7 +87,7 @@ static int ospf6_router_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 	char buf[32], name[32], bits[16], options[32];
 	struct ospf6_router_lsa *router_lsa;
 	struct ospf6_router_lsdesc *lsdesc;
-	json_object *json_arr;
+	json_object *json_arr = NULL;
 	json_object *json_loop;
 
 	router_lsa =
@@ -460,7 +460,7 @@ static int ospf6_network_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 	struct ospf6_network_lsa *network_lsa;
 	struct ospf6_network_lsdesc *lsdesc;
 	char buf[128], options[32];
-	json_object *json_arr;
+	json_object *json_arr = NULL;
 
 	network_lsa =
 		(struct ospf6_network_lsa *)((caddr_t)lsa->header


### PR DESCRIPTION
GCC 13.2.0 complains:

```
ospf6d/ospf6_intra.c:139:25: error: ‘json_arr’ may be used uninitialized [-Werror=maybe-uninitialized]
ospf6d/ospf6_intra.c:485:20: error: ‘json_arr’ may be used uninitialized [-Werror=maybe-uninitialized]
```