### PR TITLE
vtysh freezed on ospf 'no network' command when there are multiple networks and interfaces

### DIFF
--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -1257,7 +1257,7 @@ int ospf_network_unset(struct ospf *ospf, struct prefix_ipv4 *p,
 {
 	struct route_node *rn;
 	struct ospf_network *network;
-	struct listnode *node, *nnode;
+	struct listnode *node;
 	struct ospf_interface *oi;
 	struct list *ospf_oiflist = NULL;
 


### PR DESCRIPTION
Issue: https://github.com/FRRouting/frr/issues/14004

Fixing infinite loop when listing OSPF interfaces
