### PR TITLE
lib: constrain hash table "tabshift" both ways

### DIFF
--- a/lib/typesafe.h
+++ b/lib/typesafe.h
@@ -795,13 +795,16 @@ struct thash_head {
 	uint8_t minshift, maxshift;
 };
 
-#define _HASH_SIZE(tabshift) \
-	((1U << (tabshift)) >> 1)
+#define _HASH_SIZE(tabshift)                                                   \
+	({                                                                     \
+		assume((tabshift) <= 31);                                      \
+		(1U << (tabshift)) >> 1;                                       \
+	})
 #define HASH_SIZE(head) \
 	_HASH_SIZE((head).tabshift)
 #define _HASH_KEY(tabshift, val)                                               \
 	({                                                                     \
-		assume((tabshift) >= 2 && (tabshift) <= 33);                   \
+		assume((tabshift) >= 2 && (tabshift) <= 31);                   \
 		(val) >> (33 - (tabshift));                                    \
 	})
 #define HASH_KEY(head, val) \


### PR DESCRIPTION
The previous change to assume() did address the coverity warning about one direction of the shift in HASH_KEY, let's constrain the other in HASH_SIZE as well.

To be fair, the hash table *will* break at 1G entries, but at that point we have other problems RAM-wise.  (Could bump the thing to 64-bit, but then we need better item hash functions too on every single user.)

---
this should *finally* get rid of all hash table related coverity warnings