### PR TITLE
    bgpd: Fix some bugs of set tcp-mss on listen socket.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,5 +117,3 @@ refix
 /test-suite.log
 pceplib/test/*.log
 pceplib/test/*.trs
-*.si4project*
-*gitignore*

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ refix
 /test-suite.log
 pceplib/test/*.log
 pceplib/test/*.trs
+*.si4project*
+*gitignore*

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -5784,7 +5784,7 @@ void peer_tcp_mss_set(struct peer *peer, uint32_t tcp_mss)
 	SET_FLAG(peer->flags, PEER_FLAG_TCP_MSS);
 
 	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
-		for (ALL_LIST_ELEMENTS_RO(peer->group->peer, node, p)) {
+		for (ALL_LIST_ELEMENTS(peer->group->peer, node, p)) {
 			p->tcp_mss = tcp_mss;
 			SET_FLAG(p->flags, PEER_FLAG_TCP_MSS);
 		}
@@ -5806,7 +5806,7 @@ void peer_tcp_mss_unset(struct peer *peer)
 	peer->tcp_mss = 0;
 
 	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
-		for (ALL_LIST_ELEMENTS_RO(peer->group->peer, node, p)) {
+		for (ALL_LIST_ELEMENTS(peer->group->peer, node, p)) {
 			UNSET_FLAG(p->flags, PEER_FLAG_TCP_MSS);
 			p->tcp_mss = 0;
 		}

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -5777,8 +5777,19 @@ void peer_port_unset(struct peer *peer)
  */
 void peer_tcp_mss_set(struct peer *peer, uint32_t tcp_mss)
 {
+	struct listnode *node;
+	struct peer *p;
+
 	peer->tcp_mss = tcp_mss;
 	SET_FLAG(peer->flags, PEER_FLAG_TCP_MSS);
+
+	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
+		for (ALL_LIST_ELEMENTS_RO(peer->group->peer, node, p)) {
+			p->tcp_mss = tcp_mss;
+			SET_FLAG(p->flags, PEER_FLAG_TCP_MSS);
+		}
+	}
+
 	bgp_tcp_mss_set(peer);
 }
 
@@ -5788,8 +5799,19 @@ void peer_tcp_mss_set(struct peer *peer, uint32_t tcp_mss)
  */
 void peer_tcp_mss_unset(struct peer *peer)
 {
+	struct listnode *node;
+	struct peer *p;
+
 	UNSET_FLAG(peer->flags, PEER_FLAG_TCP_MSS);
 	peer->tcp_mss = 0;
+
+	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
+		for (ALL_LIST_ELEMENTS_RO(peer->group->peer, node, p)) {
+			UNSET_FLAG(p->flags, PEER_FLAG_TCP_MSS);
+			p->tcp_mss = 0;
+		}
+	}
+
 	bgp_tcp_mss_set(peer);
 }
 


### PR DESCRIPTION
    1.Tcp-mss not just for bgp neighbor, but also for bgp neighbor group.
    2.Set tcp-mss for listhen socket even no neighbor config passive mode.
    3.Config tcp-mss on neighbor group sync to all the neighbor in that group.
