### PR TITLE
isisd: fix crash when configuring srv6 locator without isis instance

### DIFF
--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -1225,6 +1225,9 @@ static int isis_zebra_process_srv6_locator_add(ZAPI_CALLBACK_ARGS)
 	struct listnode *node;
 	struct isis_area *area;
 
+	if (!isis)
+		return -1;
+
 	/* Decode the SRv6 locator */
 	if (zapi_srv6_locator_decode(zclient->ibuf, &loc) < 0)
 		return -1;
@@ -1273,6 +1276,9 @@ static int isis_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 	struct srv6_locator_chunk *chunk;
 	struct isis_srv6_sid *sid;
 	struct srv6_adjacency *sra;
+
+	if (!isis)
+		return -1;
 
 	/* Decode the received zebra message */
 	if (zapi_srv6_locator_decode(zclient->ibuf, &loc) < 0)


### PR DESCRIPTION
After the ISIS daemon is launched, the configuration of an srv6 locator in zebra triggers a crash:

> #4  0x00007f1f0ea980f3 in core_handler (signo=11, siginfo=0x7ffdb750de70, context=0x7ffdb750dd40)
>     at /build/make-pkg/output/_packages/cp-routing/src/lib/sigevent.c:262
> #5  <signal handler called>
> #6  0x00005651a05783ef in isis_zebra_process_srv6_locator_add (cmd=117, zclient=0x5651a21d9bd0, length=25, vrf_id=0)
>     at /build/make-pkg/output/_packages/cp-routing/src/isisd/isis_zebra.c:1258
> #7  0x00007f1f0ead5ac9 in zclient_read (thread=0x7ffdb750e750) at /build/make-pkg/output/_packages/cp-routing/src/lib/zclient.c:4246
> #8  0x00007f1f0eab19d4 in thread_call (thread=0x7ffdb750e750) at /build/make-pkg/output/_packages/cp-routing/src/lib/thread.c:1825
> #9  0x00007f1f0ea4862e in frr_run (master=0x5651a1f65a40) at /build/make-pkg/output/_packages/cp-routing/src/lib/libfrr.c:1155
> #10 0x00005651a051131a in main (argc=5, argv=0x7ffdb750e998, envp=0x7ffdb750e9c8)
>     at /build/make-pkg/output/_packages/cp-routing/src/isisd/isis_main.c:282
> (gdb) f 6
> #6  0x00005651a05783ef in isis_zebra_process_srv6_locator_add (cmd=117, zclient=0x5651a21d9bd0, length=25, vrf_id=0)
>     at /build/make-pkg/output/_packages/cp-routing/src/isisd/isis_zebra.c:1258
> (gdb) print isis
> $1 = (struct isis *) 0x0
> (gdb) print isis->area_list
> Cannot access memory at address 0x28

The isis pointer is NULL, because no instances have already been configured on the ISIS instance.
Fix this by checking that there is any isis instance available when zebra hooks related to srv6 are received.