### PR TITLE
bgpd: fix coverity issue on aspath_filter_exclude_acl

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -1703,7 +1703,7 @@ struct aspath *aspath_filter_exclude_acl(struct aspath *source,
 			if (cur_seg == source->segments)
 				/* first segment */
 				source->segments = cur_seg->next;
-			else
+			else if (prev_seg)
 				prev_seg->next = cur_seg->next;
 			assegment_free(cur_seg);
 		}
@@ -1725,8 +1725,9 @@ struct aspath *aspath_filter_exclude_acl(struct aspath *source,
 			else if (prev_seg)
 				prev_seg->next = new_seg;
 			assegment_free(cur_seg);
-		}
-		prev_seg = cur_seg;
+			prev_seg = new_seg;
+		} else
+			prev_seg = cur_seg;
 		cur_seg = next_seg;
 	}
 


### PR DESCRIPTION
CID 1566378 (#1-4 of 4): Use after free (USE_AFTER_FREE)76.
use_after_free: Using freed pointer cur_seg.

now the prev_seg pointer is set with always existaing values.

Link: https://scan7.scan.coverity.com/reports.htm#v39104/p13747/fileInstanceId=146858993&defectInstanceId=18968273&mergedDefectId=1566378&fileStart=1376&fileEnd=1625
Fixes: 4685db418e3a861205a28f975afeb9869f674337 (bgpd: add set as-path exclude acl-list command)