### PR TITLE
tools, watchfrr: allow user to change signal sent after watchfrr timeout

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -190,13 +190,19 @@ daemon_start() {
 }
 
 daemon_stop() {
-	local dmninst daemon inst pidfile vtyfile pid cnt fail
+	local dmninst daemon inst pidfile vtyfile pid cnt fail sig
 	daemon_inst "$1"
 
 	is_user_root || exit 1
 
 	all=false
 	[ "$2" = "--reallyall" ] && all=true
+
+        if [ -z "$3" ]; then
+                sig="INT"
+        else
+                sig="$3"
+        fi
 
 	pidfile="$V_PATH/$daemon${inst:+-$inst}.pid"
 	vtyfile="$V_PATH/$daemon${inst:+-$inst}.vty"
@@ -212,8 +218,8 @@ daemon_stop() {
 		return 1
 	fi
 
-	debug "kill -2 $pid"
-	kill -2 "$pid"
+	debug "kill -$sig $pid"
+	kill -$sig "$pid"
 	cnt=1200
 	while kill -0 "$pid" 2>/dev/null; do
 		sleep .1
@@ -267,10 +273,11 @@ all_start() {
 }
 
 all_stop() {
-	local pids reversed
+	local pids reversed sig
 
 	daemon_list enabled_daemons disabled_daemons
 	[ "$1" = "--reallyall" ] && enabled_daemons="$enabled_daemons $disabled_daemons"
+        [ -n "$2" ] && sig="$2"
 
 	reversed=""
 	for dmninst in $enabled_daemons; do
@@ -278,7 +285,7 @@ all_stop() {
 	done
 
 	for dmninst in $reversed; do
-		daemon_stop "$dmninst" "$1" &
+		daemon_stop "$dmninst" "$1" "$sig" &
 		pids="$pids $!"
 	done
 	for pid in $pids; do
@@ -354,15 +361,24 @@ test -n "$frr_profile" && frr_global_options="$frr_global_options -F $frr_profil
 #
 
 frrcommon_main() {
-	local cmd
+	local cmd sig
 
 	debug "frrcommon_main" "$@"
 
 	cmd="$1"
 	shift
 
+	if [ "$cmd" = "signal" ]; then
+		sig="$1"
+		shift
+	fi
+
 	if [ "$1" = "all" ] || [ -z "$1" ]; then
 		case "$cmd" in
+		signal)
+			all_stop $sig
+			all_start
+			;;
 		start)	all_start;;
 		stop)	all_stop;;
 		restart)
@@ -373,6 +389,10 @@ frrcommon_main() {
 		esac
 	else
 		case "$cmd" in
+		signal)
+			daemon_stop "$@" $sig
+			daemon_start "$@"
+			;;
 		start)	daemon_start "$@";;
 		stop)	daemon_stop "$@";;
 		restart)

--- a/tools/frrinit.sh.in
+++ b/tools/frrinit.sh.in
@@ -31,7 +31,11 @@ else
 fi
 
 # "/usr/lib/frr/frrinit.sh start somenamespace"
-FRR_PATHSPACE="$2"
+if [ "$1" = "signal" ]; then
+        FRR_PATHSPACE="$3"
+else
+        FRR_PATHSPACE="$2"
+fi
 
 self="`dirname $0`"
 if [ -r "$self/frrcommon.sh" ]; then
@@ -53,6 +57,16 @@ stop)
 	;;
 
 restart|force-reload)
+	daemon_stop watchfrr
+	all_stop --reallyall
+
+	daemon_list daemons
+	watchfrr_options="$watchfrr_options $daemons"
+	daemon_start watchfrr
+	;;
+
+signal)
+	sig="$2"
 	daemon_stop watchfrr
 	all_stop --reallyall
 

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -47,6 +47,8 @@
 #define DEFAULT_START_CMD	WATCHFRR_SH_PATH " start %s"
 #define DEFAULT_STOP_CMD	WATCHFRR_SH_PATH " stop %s"
 
+#define ABORT_RESTART_CMD WATCHFRR_SH_PATH " signal SIGABRT %s"
+
 #define PING_TOKEN	"PING"
 
 DEFINE_MGROUP(WATCHFRR, "watchfrr");
@@ -218,6 +220,18 @@ void watchfrr_set_ignore_daemon(struct vty *vty, const char *dname, bool ignore)
 	} else
 		vty_out(vty, "%s is not configured for running at the moment",
 			dname);
+}
+
+void watchfrr_set_restart_sig(struct vty *vty, const char *sigstr)
+{
+	/* 'interrupt' */
+	if (strncmp(sigstr, "i", 1) == 0)
+		gs.restart_command = DEFAULT_RESTART_CMD;
+	/* 'abort' */
+	else if (strncmp(sigstr, "a", 1) == 0)
+		gs.restart_command = ABORT_RESTART_CMD;
+	else
+		vty_out(vty, "invalid or unsupported restart-signal\n");
 }
 
 static void printhelp(FILE *target)
@@ -1078,6 +1092,9 @@ void watchfrr_status(struct vty *vty)
 					- (intmax_t)delay.tv_sec,
 				(intmax_t)dmn->restart.interval);
 	}
+	vty_out(vty, "watchfrr restart-signal: %s\n",
+		strmatch(gs.restart_command, ABORT_RESTART_CMD) ? "abort"
+								: "interrupt");
 }
 
 static void sigint(void)

--- a/watchfrr/watchfrr.h
+++ b/watchfrr/watchfrr.h
@@ -36,4 +36,5 @@ extern bool check_all_up(void);
 
 extern void watchfrr_set_ignore_daemon(struct vty *vty, const char *dname,
 				       bool ignore);
+extern void watchfrr_set_restart_sig(struct vty *vty, const char *sigstr);
 #endif /* FRR_WATCHFRR_H */

--- a/watchfrr/watchfrr_vty.c
+++ b/watchfrr/watchfrr_vty.c
@@ -155,6 +155,18 @@ DEFPY (watchfrr_ignore_daemon,
 	return CMD_SUCCESS;
 }
 
+DEFPY(watchfrr_restart_sig, watchfrr_restart_sig_cmd,
+      "watchfrr restart-signal <interrupt|abort>$sig",
+      "Watchfrr Specific sub-command\n"
+      "Send the specified signal to a daemon when it does not respond to echo request\n"
+      "SIGINT - attempts to terminates daemon gracefully via interrupt signal\n"
+      "SIGABRT - forcefully terminates daemon via abort signal, generating a core file\n")
+{
+	watchfrr_set_restart_sig(vty, sig);
+
+	return CMD_SUCCESS;
+}
+
 void integrated_write_sigchld(int status)
 {
 	uint8_t reply[4] = {0, 0, 0, CMD_WARNING};
@@ -191,6 +203,7 @@ void watchfrr_vty_init(void)
 	install_element(ENABLE_NODE, &show_debugging_watchfrr_cmd);
 
 	install_element(ENABLE_NODE, &watchfrr_ignore_daemon_cmd);
+	install_element(ENABLE_NODE, &watchfrr_restart_sig_cmd);
 
 	install_element(CONFIG_NODE, &show_debugging_watchfrr_cmd);
 	install_element(VIEW_NODE, &show_watchfrr_cmd);


### PR DESCRIPTION
2 commits (tools + watchfrr) that allow the frr init script to send arbitrary signals to an FRR daemon, and add plumbing for watchfrr to use this to send `SIGABRT`.

The goal here is to allow some flexibility in the actions taken upon a watchfrr timeout, e.g. send a SIGABRT so you have a core dump to debug instead of just logs.