### PR TITLE
bgpd: fix return of local from ctime_r

### DIFF
--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -734,7 +734,8 @@ static int update_group_show_walkcb(struct update_group *updgrp, void *arg)
 				       safi2str(updgrp->safi));
 	} else {
 		vty_out(vty, "Update-group %" PRIu64 ":\n", updgrp->id);
-		vty_out(vty, "  Created: %s", timestamp_string(updgrp->uptime));
+		vty_out(vty, "  Created: %s",
+			timestamp_string(updgrp->uptime, timebuf));
 	}
 
 	filter = &updgrp->conf->filter[updgrp->afi][updgrp->safi];
@@ -803,7 +804,7 @@ static int update_group_show_walkcb(struct update_group *updgrp, void *arg)
 			vty_out(vty, "  Update-subgroup %" PRIu64 ":\n",
 				subgrp->id);
 			vty_out(vty, "    Created: %s",
-				timestamp_string(subgrp->uptime));
+				timestamp_string(subgrp->uptime, timebuf));
 		}
 
 		if (subgrp->split_from.update_group_id

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2595,10 +2595,9 @@ static inline int peer_group_af_configured(struct peer_group *group)
 	return 0;
 }
 
-static inline char *timestamp_string(time_t ts)
+static inline char *timestamp_string(time_t ts, char *timebuf)
 {
 	time_t tbuf;
-	char timebuf[32];
 
 	tbuf = time(NULL) - (monotime(NULL) - ts);
 	return ctime_r(&tbuf, timebuf);


### PR DESCRIPTION
Don't return a local - caller needs to pass in a buffer.
This should fix recent coverity CID 1568217.