### PR TITLE
tests: Fix DeprecationWarning in SRv6 L3VPN topotest

### DIFF
--- a/tests/topotests/bgp_srv6l3vpn_sid/test_bgp_srv6l3vpn_sid.py
+++ b/tests/topotests/bgp_srv6l3vpn_sid/test_bgp_srv6l3vpn_sid.py
@@ -39,7 +39,7 @@ from lib.checkping import check_ping
 
 
 def build_topo(tgen):
-    """
+    r"""
      CE1     CE3      CE5
     (eth0)  (eth0)   (eth0)
       :2      :2      :2


### PR DESCRIPTION
Fix the following warning:

```
tests/topotests/bgp_srv6l3vpn_sid/test_bgp_srv6l3vpn_sid.py:42
  /media/SharedUTM/workspace/frr/tests/topotests/bgp_srv6l3vpn_sid/test_bgp_srv6l3vpn_sid.py:42: DeprecationWarning: invalid escape sequence '\ '
```

In test_bgp_srv6l3vpn_sid.py we have a comment containing some '\\' characters. Python mistakenly tries to interpret such '\\' characters as escape sequences, which leads to the above warning.

Let's tell Python to treat the comment as a raw string, so that it simply treats backslashes as literal characters rather than escape sequences.