### PR TITLE
pimd: remove redundant closing socket

### DIFF
--- a/pimd/pim_ssmpingd.c
+++ b/pimd/pim_ssmpingd.c
@@ -185,7 +185,6 @@ static int ssmpingd_socket(pim_addr addr, int port, int mttl)
 	ret = ssmpingd_setsockopt(fd, addr, mttl);
 	if (ret) {
 		zlog_warn("ssmpingd_setsockopt failed");
-		close(fd);
 		return -1;
 	}
 


### PR DESCRIPTION
The socket has been closed in `ssmpingd_setsockopt()` in the wrong cases, so remove the redundant closing socket from outer layer.