### PR TITLE
bgpd: Set the TTL for the correct socket

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -588,12 +588,6 @@ static void bgp_accept(struct event *thread)
 		peer_delete(peer1->doppelganger);
 	}
 
-	if (bgp_set_socket_ttl(peer1->connection) < 0)
-		if (bgp_debug_neighbor_events(peer1))
-			zlog_debug(
-				"[Event] Unable to set min/max TTL on peer %s, Continuing",
-				peer1->host);
-
 	peer = peer_create(&su, peer1->conf_if, peer1->bgp, peer1->local_as,
 			   peer1->as, peer1->as_type, NULL, false, NULL);
 
@@ -617,6 +611,12 @@ static void bgp_accept(struct event *thread)
 	peer->doppelganger = peer1;
 	peer1->doppelganger = peer;
 	connection->fd = bgp_sock;
+
+	if (bgp_set_socket_ttl(connection) < 0)
+		if (bgp_debug_neighbor_events(peer))
+			zlog_debug("[Event] Unable to set min/max TTL on peer %s, Continuing",
+				   peer->host);
+
 	frr_with_privs(&bgpd_privs) {
 		vrf_bind(peer->bgp->vrf_id, bgp_sock,
 			 bgp_get_bound_name(peer->connection));


### PR DESCRIPTION
When we accept a connection, we try to set TTL for the socket, but the socket is not yet created and we are trying to set it on the wrong socket fd.

```
[Event] connection from 127.0.0.1 fd 25, active peer status 3 fd -1
can't set sockopt IP_TTL 255 to socket -1
bgp_set_socket_ttl: Can't set TxTTL on peer (rtrid 0.0.0.0) socket, err = 9
Unable to set min/max TTL on peer 127.0.0.1, Continuing
```