### PR TITLE
Fixes for `file-lock` mode of configuration node

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1331,8 +1331,8 @@ DEFUN (config_terminal,
        config_terminal_cmd,
        "configure [terminal [file-lock]]",
        "Configuration from vty interface\n"
-       "Configuration with locked datastores\n"
-       "Configuration terminal\n")
+       "Configuration terminal\n"
+       "Configuration with locked datastores\n")
 {
 	return vty_config_enter(vty, false, false, argc == 3);
 }

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2890,6 +2890,12 @@ int vty_config_enter(struct vty *vty, bool private_config, bool exclusive,
 		}
 		assert(vty->mgmt_locked_candidate_ds);
 		assert(vty->mgmt_locked_running_ds);
+
+		/*
+		 * As datastores are locked explicitly, we don't need implicit
+		 * commits and should allow pending changes.
+		 */
+		vty->pending_allowed = true;
 	}
 
 	vty->node = CONFIG_NODE;
@@ -2945,6 +2951,8 @@ int vty_config_node_exit(struct vty *vty)
 	vty->xpath_index = 0;
 
 	/* TODO: could we check for un-commited changes here? */
+
+	vty->pending_allowed = false;
 
 	if (vty->mgmt_locked_running_ds)
 		vty_mgmt_unlock_running_inline(vty);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2381,8 +2381,8 @@ DEFUNSH(VTYSH_REALLYALL, vtysh_disable, vtysh_disable_cmd, "disable",
 DEFUNSH(VTYSH_REALLYALL, vtysh_config_terminal, vtysh_config_terminal_cmd,
 	"configure [terminal [file-lock]]",
 	"Configuration from vty interface\n"
-	"Configuration with locked datastores\n"
-	"Configuration terminal\n")
+	"Configuration terminal\n"
+	"Configuration with locked datastores\n")
 {
 	vty->node = CONFIG_NODE;
 	return CMD_SUCCESS;

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2379,12 +2379,23 @@ DEFUNSH(VTYSH_REALLYALL, vtysh_disable, vtysh_disable_cmd, "disable",
 }
 
 DEFUNSH(VTYSH_REALLYALL, vtysh_config_terminal, vtysh_config_terminal_cmd,
-	"configure [terminal [file-lock]]",
+	"configure [terminal]",
+	"Configuration from vty interface\n"
+	"Configuration terminal\n")
+{
+	vty->node = CONFIG_NODE;
+	return CMD_SUCCESS;
+}
+
+DEFUNSH(VTYSH_REALLYALL, vtysh_config_terminal_file_lock,
+	vtysh_config_terminal_file_lock_cmd,
+	"configure terminal file-lock",
 	"Configuration from vty interface\n"
 	"Configuration terminal\n"
 	"Configuration with locked datastores\n")
 {
 	vty->node = CONFIG_NODE;
+	vty->vtysh_file_locked = true;
 	return CMD_SUCCESS;
 }
 
@@ -5021,6 +5032,7 @@ void vtysh_init_vty(void)
 	if (!user_mode)
 		install_element(VIEW_NODE, &vtysh_enable_cmd);
 	install_element(ENABLE_NODE, &vtysh_config_terminal_cmd);
+	install_element(ENABLE_NODE, &vtysh_config_terminal_file_lock_cmd);
 	install_element(ENABLE_NODE, &vtysh_disable_cmd);
 
 	/* "exit" command. */


### PR DESCRIPTION
```
    vty: fix configure terminal argument descriptions

    "terminal" and "file-lock" description are mixed up.
```
```
    vty: fix working in file-lock mode

    When the configuration node is entered in file-lock mode, candidate
    and running datastores are locked. Any configuration change is followed
    by an implicit commit which leads to a crash of mgmtd, because double
    lock is prohibited by an assert. When working in file-lock mode, we
    shouldn't do implicit commits which is disabled by allowing pending
    configuration changes.
```
```
    vtysh: fix entering configuration node in file-lock mode

    When the config node is entered in file-lock mode, we should actually
    remember it to correctly apply the workaround in `vtysh_exit`.
    Otherwise, the file-lock mode is dropped once we exit any node one level
    below the config node.
```