### PR TITLE
doc: add .readthedocs.yaml configs

### DIFF
--- a/doc/developer/.readthedocs.yaml
+++ b/doc/developer/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/developer/conf.py
+
+python:
+  install:
+    - requirements: doc/requirements.txt

--- a/doc/user/.readthedocs.yaml
+++ b/doc/user/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/user/conf.py
+
+python:
+  install:
+    - requirements: doc/requirements.txt


### PR DESCRIPTION
As of Sep 25 2023, RTD projects require config files to build. This patch is necessary for docs to continue to build.