### PR TITLE
lib: use XREALLOC over realloc avoid coverity warning

### DIFF
--- a/lib/darr.c
+++ b/lib/darr.c
@@ -7,8 +7,9 @@
  */
 #include <zebra.h>
 #include "darr.h"
+#include "memory.h"
 
-void __dar_resize(void **a, uint count, size_t esize);
+DEFINE_MTYPE_STATIC(LIB, DARR, "Dynamic Array");
 
 static uint _msb(uint count)
 {
@@ -56,15 +57,12 @@ void *__darr_resize(void *a, uint count, size_t esize)
 	uint ncount = darr_next_count(count, esize);
 	size_t osz = (a == NULL) ? 0 : darr_size(darr_cap(a), esize);
 	size_t sz = darr_size(ncount, esize);
-	struct darr_metadata *dm = realloc(a ? _darr_meta(a) : NULL, sz);
-	/* do *not* use a */
+	struct darr_metadata *dm = XREALLOC(MTYPE_DARR,
+					    a ? _darr_meta(a) : NULL, sz);
 
-	assert(dm);
 	if (sz > osz)
 		memset((char *)dm + osz, 0, sz - osz);
-
 	dm->cap = ncount;
-
 	return (void *)(dm + 1);
 }
 


### PR DESCRIPTION
I believe coverity is complaining that the current code does not handle the realloc fail case, in which case the original pointer is not freed, but NULL is returned. The code assert()s it's not failed but that is not strong enough it needs to abort which XREALLOC does and is a better integration into FRR-inrfa anyway.