### PR TITLE
L3VPN exportation by using 'route-map vpn export' command instead of 'rt vpn export' command

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -1042,6 +1042,34 @@ static int ecommunity_lb_str(char *buf, size_t bufsz, const uint8_t *pnt,
 	return len;
 }
 
+bool ecommunity_has_route_target(struct ecommunity *ecom)
+{
+	uint32_t i;
+	uint8_t *pnt;
+	uint8_t type = 0;
+	uint8_t sub_type = 0;
+
+	if (!ecom)
+		return false;
+	for (i = 0; i < ecom->size; i++) {
+		/* Retrieve value field */
+		pnt = ecom->val + (i * ecom->unit_size);
+
+		/* High-order octet is the type */
+		type = *pnt++;
+
+		if (type == ECOMMUNITY_ENCODE_AS ||
+		    type == ECOMMUNITY_ENCODE_IP ||
+		    type == ECOMMUNITY_ENCODE_AS4) {
+			/* Low-order octet of type. */
+			sub_type = *pnt++;
+			if (sub_type == ECOMMUNITY_ROUTE_TARGET)
+				return true;
+		}
+	}
+	return false;
+}
+
 /* Convert extended community attribute to string.
  * Due to historical reason of industry standard implementation, there
  * are three types of format:

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -341,6 +341,7 @@ extern struct ecommunity *ecommunity_str2com(const char *, int, int);
 extern struct ecommunity *ecommunity_str2com_ipv6(const char *str, int type,
 						  int keyword_included);
 extern char *ecommunity_ecom2str(struct ecommunity *, int, int);
+extern bool ecommunity_has_route_target(struct ecommunity *ecom);
 extern void ecommunity_strfree(char **s);
 extern bool ecommunity_include(struct ecommunity *e1, struct ecommunity *e2);
 extern bool ecommunity_match(const struct ecommunity *,

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1904,14 +1904,14 @@ void vpn_leak_from_vrf_withdraw(struct bgp *to_bgp,		/* to */
 		return;
 	}
 
-	if (debug)
-		zlog_debug("%s: withdrawing (path_vrf=%p)", __func__, path_vrf);
-
-	bn = bgp_afi_node_get(to_bgp->rib[afi][safi], afi, safi, p,
-			      &(from_bgp->vpn_policy[afi].tovpn_rd));
+	bn = bgp_safi_node_lookup(to_bgp->rib[afi][safi], safi, p,
+				  &(from_bgp->vpn_policy[afi].tovpn_rd));
 
 	if (!bn)
 		return;
+	if (debug)
+		zlog_debug("%s: withdrawing (path_vrf=%p)", __func__, path_vrf);
+
 	/*
 	 * vrf -> vpn
 	 * match original bpi imported from

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -113,7 +113,8 @@ static inline bool is_bgp_vrf_mplsvpn(struct bgp *bgp)
 }
 
 static inline int vpn_leak_to_vpn_active(struct bgp *bgp_vrf, afi_t afi,
-					 const char **pmsg)
+					 const char **pmsg,
+					 bool ignore_export_rt_list)
 {
 	if (bgp_vrf->inst_type != BGP_INSTANCE_TYPE_VRF
 		&& bgp_vrf->inst_type != BGP_INSTANCE_TYPE_DEFAULT) {
@@ -133,8 +134,21 @@ static inline int vpn_leak_to_vpn_active(struct bgp *bgp_vrf, afi_t afi,
 		return 0;
 	}
 
-	/* Is there an RT list set? */
-	if (!bgp_vrf->vpn_policy[afi].rtlist[BGP_VPN_POLICY_DIR_TOVPN]) {
+	/* Before performing withdrawal, VPN activation is checked; however,
+	 * when the route-map modifies the export route-target (RT) list, it
+	 * becomes challenging to determine if VPN prefixes were previously
+	 * present, or not. The 'ignore_export_rt_list' parameter will be
+	 * used to force the withdraw operation by not checking the possible
+	 * route-map changes.
+	 * Of the 'ignore_export_rt_list' is set to false, check the following:
+	 * - Is there an RT list set?
+	 * - Is there a route-map that sets RT communities
+	 */
+	if (!ignore_export_rt_list &&
+	    !bgp_vrf->vpn_policy[afi].rtlist[BGP_VPN_POLICY_DIR_TOVPN] &&
+	    (!bgp_vrf->vpn_policy[afi].rmap[BGP_VPN_POLICY_DIR_TOVPN] ||
+	     !bgp_route_map_has_extcommunity_rt(
+		     bgp_vrf->vpn_policy[afi].rmap[BGP_VPN_POLICY_DIR_TOVPN]))) {
 		if (pmsg)
 			*pmsg = "rtlist tovpn not defined";
 		return 0;
@@ -246,8 +260,7 @@ static inline void vpn_leak_prechange(enum vpn_policy_direction direction,
 		vpn_leak_to_vrf_withdraw_all(bgp_vrf, afi);
 	}
 	if ((direction == BGP_VPN_POLICY_DIR_TOVPN) &&
-		vpn_leak_to_vpn_active(bgp_vrf, afi, NULL)) {
-
+	    vpn_leak_to_vpn_active(bgp_vrf, afi, NULL, true)) {
 		vpn_leak_from_vrf_withdraw_all(bgp_vpn, bgp_vrf, afi);
 	}
 }

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -4743,6 +4743,24 @@ static void bgp_route_map_delete(const char *rmap_name)
 	route_map_notify_dependencies(rmap_name, RMAP_EVENT_MATCH_DELETED);
 }
 
+bool bgp_route_map_has_extcommunity_rt(const struct route_map *map)
+{
+	struct route_map_index *index = NULL;
+	struct route_map_rule *set = NULL;
+
+	assert(map);
+
+	for (index = map->head; index; index = index->next) {
+		for (set = index->set_list.head; set; set = set->next) {
+			if (set->cmd && set->cmd->str &&
+			    (strmatch(set->cmd->str, "extcommunity rt") ||
+			     strmatch(set->cmd->str, "extended-comm-list")))
+				return true;
+		}
+	}
+	return false;
+}
+
 static void bgp_route_map_event(const char *rmap_name)
 {
 	if (route_map_mark_updated(rmap_name) == 0)

--- a/bgpd/bgp_routemap_nb_config.c
+++ b/bgpd/bgp_routemap_nb_config.c
@@ -1450,7 +1450,7 @@ int lib_route_map_entry_set_action_rmap_set_action_distance_destroy(
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		return lib_route_map_entry_match_destroy(args);
+		return lib_route_map_entry_set_destroy(args);
 	}
 
 	return NB_OK;
@@ -1504,7 +1504,7 @@ lib_route_map_entry_set_action_rmap_set_action_extcommunity_rt_destroy(
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		return lib_route_map_entry_match_destroy(args);
+		return lib_route_map_entry_set_destroy(args);
 	}
 
 	return NB_OK;
@@ -1556,7 +1556,7 @@ int lib_route_map_entry_set_action_rmap_set_action_extcommunity_nt_destroy(
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		return lib_route_map_entry_match_destroy(args);
+		return lib_route_map_entry_set_destroy(args);
 	}
 
 	return NB_OK;
@@ -1611,7 +1611,7 @@ lib_route_map_entry_set_action_rmap_set_action_extcommunity_soo_destroy(
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		return lib_route_map_entry_match_destroy(args);
+		return lib_route_map_entry_set_destroy(args);
 	}
 
 	return NB_OK;
@@ -3043,7 +3043,7 @@ int lib_route_map_entry_set_action_rmap_set_action_extcommunity_color_destroy(
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		return lib_route_map_entry_match_destroy(args);
+		return lib_route_map_entry_set_destroy(args);
 	}
 
 	return NB_OK;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2446,6 +2446,8 @@ extern enum asnotation_mode bgp_get_asnotation(struct bgp *bgp);
 
 extern void bgp_route_map_terminate(void);
 
+extern bool bgp_route_map_has_extcommunity_rt(const struct route_map *map);
+
 extern int peer_cmp(struct peer *p1, struct peer *p2);
 
 extern int bgp_map_afi_safi_iana2int(iana_afi_t pkt_afi, iana_safi_t pkt_safi,

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3048,7 +3048,33 @@ address-family:
 
    Specifies the route-target list to be attached to a route (export) or the
    route-target list to match against (import) when exporting/importing between
-   the current unicast VRF and VPN.
+   the current unicast VRF and VPN. The `rt vpn export RTLIST` command is not
+   mandatory and can be replaced or completed by the `set extcommunity rt`
+   command in the route-map attached with the `route-map vpn export`. The below
+   configuration illustrates how the route target is selected based on the
+   prefixes, and not solely on vrf criterium:
+
+   .. code-block:: frr
+
+      access-list acl1 permit 192.0.2.0/24
+      access-list acl2 permit 192.0.3.0/24
+      route-map rmap permit 10
+       match address acl1
+       set extcommunity ty 65001:10
+      !
+      route-map rmap permit 20
+       match address acl1
+       set extcommunity ty 65001:20
+      !
+      router bgp 65001 vrf vrf1
+       !
+       address-family ipv4 unicast
+        rd vpn export 65001:1
+        import vpn
+        export vpn
+        rt vpn import 65001:1
+        route-map vpn export rmap
+
 
    The RTLIST is a space-separated list of route-targets, which are BGP
    extended community values as described in

--- a/tests/topotests/bgp_vpnv4_ebgp/r1/bgpd.conf
+++ b/tests/topotests/bgp_vpnv4_ebgp/r1/bgpd.conf
@@ -1,3 +1,4 @@
+bgp route-map delay-timer 1
 router bgp 65500
  bgp router-id 192.0.2.1
  no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_vpnv4_ebgp/test_bgp_vpnv4_ebgp.py
+++ b/tests/topotests/bgp_vpnv4_ebgp/test_bgp_vpnv4_ebgp.py
@@ -25,6 +25,10 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
+from lib.bgpcheck import (
+    check_show_bgp_vpn_prefix_found,
+    check_show_bgp_vpn_prefix_not_found,
+)
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
@@ -212,6 +216,87 @@ def test_protocols_convergence():
     _, result = topotest.run_and_expect(test_func, None, count=40, wait=2)
     assertmsg = '"{}" JSON output mismatches'.format(router.name)
     assert result is None, assertmsg
+
+
+def test_export_route_target_empty():
+    """
+    Check that when removing 'rt vpn export' command, exported prefix is removed
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    router = tgen.gears["r1"]
+    logger.info("r1, Remove 'rt vpn export 52:100' command")
+    router.vtysh_cmd(
+        "configure terminal\nrouter bgp 65500 vrf vrf1\naddress-family ipv4 unicast\nno rt vpn export 52:100\n"
+    )
+
+    prefix = "172.31.0.1/32"
+    logger.info("r1, check that exported prefix {} is removed".format(prefix))
+    test_func = partial(
+        check_show_bgp_vpn_prefix_not_found,
+        router,
+        "ipv4",
+        prefix,
+        "444:1",
+    )
+    success, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
+    assert success, "{}, vpnv4 update {} still present".format(router.name, prefix)
+
+
+def test_export_route_target_with_routemap_with_export_route_target():
+    """
+    Check that when removing 'rt vpn export' command, exported prefix is added back
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    router = tgen.gears["r1"]
+    logger.info("r1, configuring route target with route-map with export route target")
+    router.vtysh_cmd(
+        "configure terminal\nrouter bgp 65500 vrf vrf1\naddress-family ipv4 unicast\nroute-map vpn export rmap\n"
+    )
+    router.vtysh_cmd(
+        "configure terminal\nroute-map rmap permit 1\nset extcommunity rt 52:100\n"
+    )
+
+    prefix = "172.31.0.1/32"
+    logger.info("r1, check that exported prefix {} is added back".format(prefix))
+    test_func = partial(
+        check_show_bgp_vpn_prefix_found,
+        router,
+        "ipv4",
+        prefix,
+        "444:1",
+    )
+    success, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
+    assert success, "{}, vpnv4 update {} still not present".format(router.name, prefix)
+
+
+def test_export_route_target_with_routemap_without_export_route_target():
+    """
+    Check that when removing 'set extcommunity rt' command, prefix is removed
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    router = tgen.gears["r1"]
+    logger.info("r1, removing 'set extcommunity rt 52:100.")
+    router.vtysh_cmd(
+        "configure terminal\nroute-map rmap permit 1\nno set extcommunity rt\n"
+    )
+
+    prefix = "172.31.0.1/32"
+    logger.info("r1, check that exported prefix {} is removed".format(prefix))
+    test_func = partial(
+        check_show_bgp_vpn_prefix_not_found,
+        router,
+        "ipv4",
+        prefix,
+        "444:1",
+    )
+    success, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
+    assert success, "{}, vpnv4 update {} still present".format(router.name, prefix)
 
 
 def test_memory_leak():

--- a/tests/topotests/lib/bgpcheck.py
+++ b/tests/topotests/lib/bgpcheck.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Copyright 2023, 6wind
+import json
+
+from lib import topotest
+
+
+def check_show_bgp_vpn_prefix_not_found(router, ipversion, prefix, rd, label=None):
+    """
+    Check if a given vpn prefix is not present in the BGP RIB
+    * 'router': the router to check BGP VPN RIB
+    * 'ipversion': The ip version to check: ipv4 or ipv6
+    * 'prefix': the IP prefix to check
+    * 'rd': the route distinguisher to check
+    * 'label: the label to check
+    """
+    output = json.loads(
+        router.vtysh_cmd("show bgp {} vpn {} json".format(ipversion, prefix))
+    )
+    if label:
+        expected = {rd: {"prefix": prefix, "paths": [{"remoteLabel": label}]}}
+    else:
+        expected = {rd: {"prefix": prefix}}
+    ret = topotest.json_cmp(output, expected)
+    if ret is None:
+        return "not good"
+    return None
+
+
+def check_show_bgp_vpn_prefix_found(
+    router, ipversion, prefix, rd, label=None, nexthop=None
+):
+    """
+    Check if a given vpn prefix is present in the BGP RIB
+    * 'router': the router to check BGP VPN RIB
+    * 'ipversion': The ip version to check: ipv4 or ipv6
+    * 'prefix': the IP prefix to check
+    * 'rd': the route distinguisher to check
+    * 'label: the label to check
+    """
+    output = json.loads(
+        router.vtysh_cmd("show bgp {} vpn {} json".format(ipversion, prefix))
+    )
+    if label:
+        if nexthop:
+            expected = {
+                rd: {
+                    "prefix": prefix,
+                    "paths": [{"remoteLabel": label, "nexthops": [{"ip": nexthop}]}],
+                }
+            }
+        else:
+            expected = {rd: {"prefix": prefix, "paths": [{"remoteLabel": label}]}}
+    else:
+        if nexthop:
+            expected = {
+                rd: {"prefix": prefix, "paths": [{"nexthops": [{"ip": nexthop}]}]}
+            }
+        else:
+            expected = {rd: {"prefix": prefix}}
+    return topotest.json_cmp(output, expected)


### PR DESCRIPTION
This pull request introduces a few fixes related to route-map and l3vpn usage.
This pull request also proposes to facilitate the L3VPN prefixes exportation by not solely relying on the 'rt vpn export ' command. That is to say that a route-map usage can also be used.
