### PR TITLE
bgpd,lib: rework BGP Link-State and Flowspec raw NLRI data pointer

### DIFF
--- a/bgpd/bgp_flowspec.c
+++ b/bgpd/bgp_flowspec.c
@@ -90,7 +90,6 @@ int bgp_nlri_parse_flowspec(struct peer *peer, struct attr *attr,
 	safi_t safi;
 	int psize = 0;
 	struct prefix p;
-	void *temp;
 
 	/* Start processing the NLRI - there may be multiple in the MP_REACH */
 	pnt = packet->nlri;
@@ -152,9 +151,7 @@ int bgp_nlri_parse_flowspec(struct peer *peer, struct attr *attr,
 		/* Flowspec encoding is in bytes */
 		p.u.prefix_flowspec.prefixlen = psize;
 		p.u.prefix_flowspec.family = afi2family(afi);
-		temp = XCALLOC(MTYPE_TMP, psize);
-		memcpy(temp, pnt, psize);
-		p.u.prefix_flowspec.ptr = (uintptr_t) temp;
+		p.u.prefix_flowspec.ptr = bgp_flowspec_ptr_new(pnt, psize);
 
 		if (BGP_DEBUG(flowspec, FLOWSPEC)) {
 			char return_string[BGP_FLOWSPEC_NLRI_STRING_MAX];
@@ -197,8 +194,6 @@ int bgp_nlri_parse_flowspec(struct peer *peer, struct attr *attr,
 			bgp_withdraw(peer, &p, 0, afi, safi, ZEBRA_ROUTE_BGP,
 				     BGP_ROUTE_NORMAL, NULL, NULL, 0, NULL);
 		}
-
-		XFREE(MTYPE_TMP, temp);
 	}
 	return BGP_NLRI_PARSE_OK;
 }

--- a/bgpd/bgp_flowspec_util.c
+++ b/bgpd/bgp_flowspec_util.c
@@ -19,6 +19,26 @@
 #include "bgp_pbr.h"
 #include "bgp_errors.h"
 
+DEFINE_MTYPE_STATIC(BGPD, PTR_FLOWSPEC, "FLOWSPEC Prefix Pointer");
+
+uintptr_t bgp_flowspec_ptr_new(uint8_t *pnt, uint16_t length)
+{
+	void *ptr = XCALLOC(MTYPE_PTR_FLOWSPEC, length);
+
+	memcpy(ptr, pnt, length);
+
+	return (uintptr_t)ptr;
+}
+
+void bgp_flowspec_ptr_free(uintptr_t ptr)
+{
+	void *tmp;
+
+	tmp = (void *)ptr;
+
+	XFREE(MTYPE_PTR_FLOWSPEC, tmp);
+}
+
 static void hex2bin(uint8_t *hex, int *bin)
 {
 	int remainder = *hex;

--- a/bgpd/bgp_flowspec_util.h
+++ b/bgpd/bgp_flowspec_util.h
@@ -17,6 +17,8 @@ enum bgp_flowspec_util_nlri_t {
 	BGP_FLOWSPEC_RETURN_JSON = 3,
 };
 
+extern uintptr_t bgp_flowspec_ptr_new(uint8_t *pnt, uint16_t length);
+extern void bgp_flowspec_ptr_free(uintptr_t ptr);
 
 extern int bgp_flowspec_op_decode(enum bgp_flowspec_util_nlri_t type,
 				  uint8_t *nlri_ptr,

--- a/bgpd/bgp_linkstate.c
+++ b/bgpd/bgp_linkstate.c
@@ -15,6 +15,27 @@
 #include "bgpd/bgp_linkstate.h"
 #include "bgpd/bgp_linkstate_tlv.h"
 
+
+DEFINE_MTYPE_STATIC(BGPD, PTR_LINKSTATE, "Link-State Prefix Pointer");
+
+uintptr_t bgp_linkstate_ptr_new(uint8_t *pnt, uint16_t length)
+{
+	void *ptr = XCALLOC(MTYPE_PTR_LINKSTATE, length);
+
+	memcpy(ptr, pnt, length);
+
+	return (uintptr_t)ptr;
+}
+
+void bgp_linkstate_ptr_free(uintptr_t ptr)
+{
+	void *tmp;
+
+	tmp = (void *)ptr;
+
+	XFREE(MTYPE_PTR_LINKSTATE, tmp);
+}
+
 void bgp_linkstate_init(void)
 {
 	prefix_set_linkstate_display_hook(bgp_linkstate_nlri_prefix_display);

--- a/bgpd/bgp_linkstate.h
+++ b/bgpd/bgp_linkstate.h
@@ -6,5 +6,8 @@
 #ifndef _FRR_BGP_LINKSTATE_H
 #define _FRR_BGP_LINKSTATE_H
 
+uintptr_t bgp_linkstate_ptr_new(uint8_t *pnt, uint16_t length);
+void bgp_linkstate_ptr_free(uintptr_t ptr);
+
 void bgp_linkstate_init(void);
 #endif /* _FRR_BGP_LINKSTATE_H */

--- a/bgpd/bgp_linkstate_tlv.c
+++ b/bgpd/bgp_linkstate_tlv.c
@@ -274,7 +274,7 @@ int bgp_nlri_parse_linkstate(struct peer *peer, struct attr *attr,
 		}
 		p.family = AF_LINKSTATE;
 
-		p.u.prefix_linkstate.ptr = (uintptr_t)pnt;
+		p.u.prefix_linkstate.ptr = bgp_linkstate_ptr_new(pnt, length);
 		p.prefixlen = length;
 
 		if (BGP_DEBUG(linkstate, LINKSTATE)) {

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -119,6 +119,8 @@ static void bgp_node_destroy(route_table_delegate_t *delegate,
 
 	if (node->p.family == AF_LINKSTATE)
 		bgp_linkstate_ptr_free(node->p.u.prefix_linkstate.ptr);
+	else if (node->p.family == AF_FLOWSPEC)
+		bgp_flowspec_ptr_free(node->p.u.prefix_flowspec.ptr);
 
 	XFREE(MTYPE_ROUTE_NODE, node);
 }

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -117,7 +117,7 @@ static void bgp_node_destroy(route_table_delegate_t *delegate,
 		node->info = NULL;
 	}
 
-	if (family2afi(node->p.family) == AFI_LINKSTATE)
+	if (node->p.family == AF_LINKSTATE)
 		bgp_linkstate_ptr_free(node->p.u.prefix_linkstate.ptr);
 
 	XFREE(MTYPE_ROUTE_NODE, node);

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -118,7 +118,7 @@ static void bgp_node_destroy(route_table_delegate_t *delegate,
 	}
 
 	if (family2afi(node->p.family) == AFI_LINKSTATE)
-		prefix_linkstate_ptr_free(&node->p);
+		bgp_linkstate_ptr_free(node->p.u.prefix_linkstate.ptr);
 
 	XFREE(MTYPE_ROUTE_NODE, node);
 }

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -241,8 +241,8 @@ static inline struct bgp_dest *bgp_node_get(struct bgp_table *const table,
 
 	rn = route_node_get(table->route_table, p);
 
-	if (rn->p.family == AF_LINKSTATE && table->route_table->count == count) {
-		/* ptr pointer has not referenced in a new route_node, free it. */
+	if (table->afi == AFI_LINKSTATE && table->route_table->count == count) {
+		/* ptr pointer has not been referenced in a new route_node, free it. */
 		prefix_copy(&p2, p);
 		bgp_linkstate_ptr_free(p2.u.prefix_linkstate.ptr);
 	}

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -245,6 +245,11 @@ static inline struct bgp_dest *bgp_node_get(struct bgp_table *const table,
 		/* ptr pointer has not been referenced in a new route_node, free it. */
 		prefix_copy(&p2, p);
 		bgp_linkstate_ptr_free(p2.u.prefix_linkstate.ptr);
+	} else if (table->safi == SAFI_FLOWSPEC &&
+		   table->route_table->count == count) {
+		prefix_copy(&p2, p);
+		/* ptr pointer has not been referenced in a new route_node, free it. */
+		bgp_flowspec_ptr_free(p2.u.prefix_flowspec.ptr);
 	}
 
 	if (!rn->info) {

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -223,32 +223,13 @@ int prefix_match(union prefixconstptr unet, union prefixconstptr upfx)
 	if (n->prefixlen > p->prefixlen)
 		return 0;
 
-	if (n->family == AF_FLOWSPEC) {
-		/* prefixlen is unused. look at fs prefix len */
-		if (n->u.prefix_flowspec.family !=
-		    p->u.prefix_flowspec.family)
-			return 0;
-
-		if (n->u.prefix_flowspec.prefixlen >
-		    p->u.prefix_flowspec.prefixlen)
-			return 0;
-
-		/* Set both prefix's head pointer. */
-		np = (const uint8_t *)&n->u.prefix_flowspec.ptr;
-		pp = (const uint8_t *)&p->u.prefix_flowspec.ptr;
-
-		offset = n->u.prefix_flowspec.prefixlen;
-
-		while (offset--)
-			if (np[offset] != pp[offset])
-				return 0;
-		return 1;
-	} else if (n->family == AF_LINKSTATE)
-		/* BGP Link-State prefixes are pseudo-prefixes that contain information
-		 * about IGP Link-State. The length of prefixes is used for compatibility
-		 * purposes and does not indicate the length of a real range. Checking
-		 * whether a BGP-LS prefix n is a sub-range of range p is not is not
-		 * relevant.
+	if (n->family == AF_FLOWSPEC || n->family == AF_LINKSTATE)
+		/* BGP Flowspec and Link-State prefixes are pseudo prefixes that
+		 * carries respectively traffic flow specification and IGP Link-State
+		 * information. Their prefix length are used for compatibility and do
+		 * not indicate the length of a range.
+		 * Checking whether a Flowspec or Link-State prefix n is a sub-range of
+		 * p range is not relevant.
 		 * Compare the prefixes instead.
 		 */
 		return prefix_same(n, p);

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -358,7 +358,6 @@ void prefix_copy(union prefixptr udest, union prefixconstptr usrc)
 			src->u.prefix_flowspec.prefixlen;
 		dest->u.prefix_flowspec.family =
 			src->u.prefix_flowspec.family;
-		dest->family = src->family;
 		temp = XCALLOC(MTYPE_PREFIX_FLOWSPEC, len);
 		dest->u.prefix_flowspec.ptr = (uintptr_t)temp;
 		memcpy((void *)dest->u.prefix_flowspec.ptr,

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -244,22 +244,15 @@ int prefix_match(union prefixconstptr unet, union prefixconstptr upfx)
 			if (np[offset] != pp[offset])
 				return 0;
 		return 1;
-	} else if (n->family == AF_LINKSTATE) {
-		if (n->u.prefix_linkstate.nlri_type !=
-		    p->u.prefix_linkstate.nlri_type)
-			return 0;
-
-		/* Set both prefix's head pointer. */
-		np = (const uint8_t *)&n->u.prefix_linkstate.ptr;
-		pp = (const uint8_t *)&p->u.prefix_linkstate.ptr;
-
-		offset = n->prefixlen; /* length is checked above */
-
-		while (offset--)
-			if (np[offset] != pp[offset])
-				return 0;
-		return 1;
-	}
+	} else if (n->family == AF_LINKSTATE)
+		/* BGP Link-State prefixes are pseudo-prefixes that contain information
+		 * about IGP Link-State. The length of prefixes is used for compatibility
+		 * purposes and does not indicate the length of a real range. Checking
+		 * whether a BGP-LS prefix n is a sub-range of range p is not is not
+		 * relevant.
+		 * Compare the prefixes instead.
+		 */
+		return prefix_same(n, p);
 
 	/* Set both prefix's head pointer. */
 	np = n->u.val;

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -491,8 +491,9 @@ int prefix_same(union prefixconstptr up1, union prefixconstptr up2)
 			if (p1->u.prefix_linkstate.nlri_type !=
 			    p2->u.prefix_linkstate.nlri_type)
 				return 0;
-			if (!memcmp(&p1->u.prefix_linkstate.ptr,
-				    &p2->u.prefix_linkstate.ptr, p2->prefixlen))
+			if (!memcmp((const void *)p1->u.prefix_linkstate.ptr,
+				    (const void *)p1->u.prefix_linkstate.ptr,
+				    p2->prefixlen))
 				return 1;
 		}
 	}

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -470,8 +470,8 @@ int prefix_same(union prefixconstptr up1, union prefixconstptr up2)
 			if (p1->u.prefix_flowspec.prefixlen !=
 			    p2->u.prefix_flowspec.prefixlen)
 				return 0;
-			if (!memcmp(&p1->u.prefix_flowspec.ptr,
-				    &p2->u.prefix_flowspec.ptr,
+			if (!memcmp((const void *)p1->u.prefix_flowspec.ptr,
+				    (const void *)p2->u.prefix_flowspec.ptr,
 				    p2->u.prefix_flowspec.prefixlen))
 				return 1;
 		}

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -320,6 +320,7 @@ union prefixptr {
 	prefixtype(prefixptr, struct prefix_evpn, evp)
 	prefixtype(prefixptr, struct prefix_fs,   fs)
 	prefixtype(prefixptr, struct prefix_rd,   rd)
+	prefixtype(prefixptr, struct prefix_bgpls, ls)
 } TRANSPARENT_UNION;
 
 union prefixconstptr {
@@ -329,6 +330,7 @@ union prefixconstptr {
 	prefixtype(prefixconstptr, const struct prefix_evpn, evp)
 	prefixtype(prefixconstptr, const struct prefix_fs,   fs)
 	prefixtype(prefixconstptr, const struct prefix_rd,   rd)
+	prefixtype(prefixconstptr, const struct prefix_bgpls, ls)
 } TRANSPARENT_UNION;
 
 #ifndef INET_ADDRSTRLEN

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -439,8 +439,6 @@ static inline afi_t prefix_afi(union prefixconstptr pu)
  */
 extern unsigned int prefix_bit(const uint8_t *prefix, const uint16_t bit_index);
 
-extern void prefix_linkstate_ptr_free(struct prefix *p);
-
 extern struct prefix *prefix_new(void);
 extern void prefix_free(struct prefix **p);
 /*

--- a/lib/table.c
+++ b/lib/table.c
@@ -281,22 +281,15 @@ struct route_node *route_node_get(struct route_table *table,
 	const uint8_t *prefix = &p->u.prefix;
 
 	node = rn_hash_node_find(&table->hash, &search);
-	if (node && node->info) {
-		if (family2afi(p->family) == AFI_LINKSTATE)
-			prefix_linkstate_ptr_free(p);
-
+	if (node && node->info)
 		return route_lock_node(node);
-	}
 
 	match = NULL;
 	node = table->top;
 	while (node && node->p.prefixlen <= prefixlen
 	       && prefix_match(&node->p, p)) {
-		if (node->p.prefixlen == prefixlen) {
-			if (family2afi(p->family) == AFI_LINKSTATE)
-				prefix_linkstate_ptr_free(p);
+		if (node->p.prefixlen == prefixlen)
 			return route_lock_node(node);
-		}
 
 		match = node;
 		node = node->link[prefix_bit(prefix, node->p.prefixlen)];
@@ -330,9 +323,6 @@ struct route_node *route_node_get(struct route_table *table,
 	}
 	table->count++;
 	route_lock_node(new);
-
-	if (family2afi(p->family) == AFI_LINKSTATE)
-		prefix_linkstate_ptr_free(p);
 
 	return new;
 }


### PR DESCRIPTION
BGP-Link-State and FlowSpec (BGP-LS and BGP-FS) utilize the 'ptr' pointer within the lib to store
a raw copy of their NLRI as seen in the structure definitions:

> struct linkstate_prefix {
>         uint16_t nlri_type;
>         uintptr_t ptr;
> };
>
> struct flowspec_prefix {
>         [...]
>         uintptr_t ptr;
> };
>
> /* FRR generic prefix structure. */
> struct prefix {
>         uint8_t family;
>         uint16_t prefixlen;
>         union {
>                 uint8_t prefix;
>                 [...]
>                 struct linkstate_prefix prefix_flowspec; /* AF_FLOWSPEC */
>                 struct linkstate_prefix prefix_linkstate; /* AF_LINKSTATE */
>         } u __attribute__((aligned(8)));
> };

When copying such prefixes with prefix_copy(), memory is allocated for
a new 'ptr' pointer in the copy. If a 'struct prefix' for BGP-FS or BGP-LS is
declared on the stack and filled using prefix_copy(), this new pointer
must be freed before the function exits. Releasing this pointer is not
obvious. Forgetting to do so might would lead to memory leaks. For example,
in route_node_get(), the flowspec 'ptr' release is missing. It is done for link-state
using prefix_linkstate_ptr_free().

Deal with BGP-FS and BGP-LS 'ptr' pointer memory in bgpd itself.