### PR TITLE
isisd: remove redundant northbound destroy callbacks

### DIFF
--- a/isisd/isis_nb.c
+++ b/isisd/isis_nb.c
@@ -879,28 +879,24 @@ const struct frr_yang_module_info frr_isisd_info = {
 			.xpath = "/frr-isisd:isis/instance/segment-routing-srv6/msd/node-msd/max-segs-left",
 			.cbs = {
 				.modify = isis_instance_segment_routing_srv6_msd_node_msd_max_segs_left_modify,
-				.destroy = isis_instance_segment_routing_srv6_msd_node_msd_max_segs_left_destroy,
 			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/segment-routing-srv6/msd/node-msd/max-end-pop",
 			.cbs = {
 				.modify = isis_instance_segment_routing_srv6_msd_node_msd_max_end_pop_modify,
-				.destroy = isis_instance_segment_routing_srv6_msd_node_msd_max_end_pop_destroy,
 			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/segment-routing-srv6/msd/node-msd/max-h-encaps",
 			.cbs = {
 				.modify = isis_instance_segment_routing_srv6_msd_node_msd_max_h_encaps_modify,
-				.destroy = isis_instance_segment_routing_srv6_msd_node_msd_max_h_encaps_destroy,
 			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/segment-routing-srv6/msd/node-msd/max-end-d",
 			.cbs = {
 				.modify = isis_instance_segment_routing_srv6_msd_node_msd_max_end_d_modify,
-				.destroy = isis_instance_segment_routing_srv6_msd_node_msd_max_end_d_destroy,
 			},
 		},
 		{

--- a/isisd/isis_nb.h
+++ b/isisd/isis_nb.h
@@ -334,20 +334,12 @@ void cli_show_isis_srv6_locator(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults);
 int isis_instance_segment_routing_srv6_msd_node_msd_max_segs_left_modify(
 	struct nb_cb_modify_args *args);
-int isis_instance_segment_routing_srv6_msd_node_msd_max_segs_left_destroy(
-	struct nb_cb_destroy_args *args);
 int isis_instance_segment_routing_srv6_msd_node_msd_max_end_pop_modify(
 	struct nb_cb_modify_args *args);
-int isis_instance_segment_routing_srv6_msd_node_msd_max_end_pop_destroy(
-	struct nb_cb_destroy_args *args);
 int isis_instance_segment_routing_srv6_msd_node_msd_max_h_encaps_modify(
 	struct nb_cb_modify_args *args);
-int isis_instance_segment_routing_srv6_msd_node_msd_max_h_encaps_destroy(
-	struct nb_cb_destroy_args *args);
 int isis_instance_segment_routing_srv6_msd_node_msd_max_end_d_modify(
 	struct nb_cb_modify_args *args);
-int isis_instance_segment_routing_srv6_msd_node_msd_max_end_d_destroy(
-	struct nb_cb_destroy_args *args);
 void cli_show_isis_srv6_node_msd(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults);
 int isis_instance_segment_routing_srv6_interface_modify(

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -3583,24 +3583,6 @@ int isis_instance_segment_routing_srv6_msd_node_msd_max_segs_left_modify(
 	return NB_OK;
 }
 
-int isis_instance_segment_routing_srv6_msd_node_msd_max_segs_left_destroy(
-	struct nb_cb_destroy_args *args)
-{
-	struct isis_area *area;
-
-	if (args->event != NB_EV_APPLY)
-		return NB_OK;
-
-	area = nb_running_get_entry(args->dnode, NULL, true);
-	area->srv6db.config.max_seg_left_msd =
-		yang_get_default_uint8("./msd/node-msd/max-segs-left");
-
-	/* Update and regenerate LSP */
-	lsp_regenerate_schedule(area, area->is_type, 0);
-
-	return NB_OK;
-}
-
 /*
  * XPath: /frr-isisd:isis/instance/segment-routing-srv6/msd/node-msd/max-end-pop
  */
@@ -3615,24 +3597,6 @@ int isis_instance_segment_routing_srv6_msd_node_msd_max_end_pop_modify(
 	area = nb_running_get_entry(args->dnode, NULL, true);
 	area->srv6db.config.max_end_pop_msd = yang_dnode_get_uint8(args->dnode,
 								   NULL);
-
-	/* Update and regenerate LSP */
-	lsp_regenerate_schedule(area, area->is_type, 0);
-
-	return NB_OK;
-}
-
-int isis_instance_segment_routing_srv6_msd_node_msd_max_end_pop_destroy(
-	struct nb_cb_destroy_args *args)
-{
-	struct isis_area *area;
-
-	if (args->event != NB_EV_APPLY)
-		return NB_OK;
-
-	area = nb_running_get_entry(args->dnode, NULL, true);
-	area->srv6db.config.max_end_pop_msd =
-		yang_get_default_uint8("./msd/node-msd/max-end-pop");
 
 	/* Update and regenerate LSP */
 	lsp_regenerate_schedule(area, area->is_type, 0);
@@ -3661,24 +3625,6 @@ int isis_instance_segment_routing_srv6_msd_node_msd_max_h_encaps_modify(
 	return NB_OK;
 }
 
-int isis_instance_segment_routing_srv6_msd_node_msd_max_h_encaps_destroy(
-	struct nb_cb_destroy_args *args)
-{
-	struct isis_area *area;
-
-	if (args->event != NB_EV_APPLY)
-		return NB_OK;
-
-	area = nb_running_get_entry(args->dnode, NULL, true);
-	area->srv6db.config.max_h_encaps_msd =
-		yang_get_default_uint8("./msd/node-msd/max-h-encaps");
-
-	/* Update and regenerate LSP */
-	lsp_regenerate_schedule(area, area->is_type, 0);
-
-	return NB_OK;
-}
-
 /*
  * XPath: /frr-isisd:isis/instance/segment-routing-srv6/msd/node-msd/max-end-d
  */
@@ -3693,24 +3639,6 @@ int isis_instance_segment_routing_srv6_msd_node_msd_max_end_d_modify(
 	area = nb_running_get_entry(args->dnode, NULL, true);
 	area->srv6db.config.max_end_d_msd = yang_dnode_get_uint8(args->dnode,
 								 NULL);
-
-	/* Update and regenerate LSP */
-	lsp_regenerate_schedule(area, area->is_type, 0);
-
-	return NB_OK;
-}
-
-int isis_instance_segment_routing_srv6_msd_node_msd_max_end_d_destroy(
-	struct nb_cb_destroy_args *args)
-{
-	struct isis_area *area;
-
-	if (args->event != NB_EV_APPLY)
-		return NB_OK;
-
-	area = nb_running_get_entry(args->dnode, NULL, true);
-	area->srv6db.config.max_end_d_msd =
-		yang_get_default_uint8("./msd/node-msd/max-end-d");
 
 	/* Update and regenerate LSP */
 	lsp_regenerate_schedule(area, area->is_type, 0);


### PR DESCRIPTION
Fixes startup warnings:
```
ISIS: [ZKB8W-3S2Q4][EC 100663330] unneeded 'destroy' callback for '/frr-isisd:isis/instance/segment-routing-srv6/msd/node-msd/max-segs-left'
ISIS: [ZKB8W-3S2Q4][EC 100663330] unneeded 'destroy' callback for '/frr-isisd:isis/instance/segment-routing-srv6/msd/node-msd/max-end-pop'
ISIS: [ZKB8W-3S2Q4][EC 100663330] unneeded 'destroy' callback for '/frr-isisd:isis/instance/segment-routing-srv6/msd/node-msd/max-h-encaps'
ISIS: [ZKB8W-3S2Q4][EC 100663330] unneeded 'destroy' callback for '/frr-isisd:isis/instance/segment-routing-srv6/msd/node-msd/max-end-d'
```