### PR TITLE
mgmt: delete candidate scratch buffer

### DIFF
--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -703,7 +703,6 @@ struct nb_transaction {
 struct nb_config {
 	struct lyd_node *dnode;
 	uint32_t version;
-	struct nb_config_cbs cfg_chgs;
 };
 
 /* Callback function used by nb_oper_data_iterate(). */

--- a/mgmtd/mgmt_ds.c
+++ b/mgmtd/mgmt_ds.c
@@ -93,14 +93,6 @@ static int mgmt_ds_replace_dst_with_src_ds(struct mgmt_ds_ctx *src,
 		dst->root.dnode_root = yang_dnode_dup(src->root.dnode_root);
 	}
 
-	if (src->ds_id == MGMTD_DS_CANDIDATE) {
-		/*
-		 * Drop the changes in scratch-buffer.
-		 */
-		MGMTD_DS_DBG("Emptying Candidate Scratch buffer!");
-		nb_config_diff_del_changes(&src->root.cfg_root->cfg_chgs);
-	}
-
 	return 0;
 }
 
@@ -124,14 +116,6 @@ static int mgmt_ds_merge_src_with_dst_ds(struct mgmt_ds_ctx *src,
 	if (ret != 0) {
 		MGMTD_DS_ERR("merge failed with err: %d", ret);
 		return ret;
-	}
-
-	if (src->ds_id == MGMTD_DS_CANDIDATE) {
-		/*
-		 * Drop the changes in scratch-buffer.
-		 */
-		MGMTD_DS_DBG("Emptying Candidate Scratch buffer!");
-		nb_config_diff_del_changes(&src->root.cfg_root->cfg_chgs);
 	}
 
 	return 0;

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -1193,25 +1193,11 @@ static int mgmt_txn_prepare_config(struct mgmt_txn_ctx *txn)
 		goto mgmt_txn_prepare_config_done;
 	}
 
-	/*
-	 * Check for diffs from scratch buffer. If found empty
-	 * get the diff from Candidate DS itself.
-	 */
-	cfg_chgs = &nb_config->cfg_chgs;
-	if (RB_EMPTY(nb_config_cbs, cfg_chgs)) {
-		/*
-		 * This could be the case when the config is directly
-		 * loaded onto the candidate DS from a file. Get the
-		 * diff from a full comparison of the candidate and
-		 * running DSs.
-		 */
-		nb_config_diff(mgmt_ds_get_nb_config(
-				       txn->commit_cfg_req->req.commit_cfg
-					       .dst_ds_ctx),
-			       nb_config, &changes);
-		cfg_chgs = &changes;
-		del_cfg_chgs = true;
-	}
+	nb_config_diff(mgmt_ds_get_nb_config(txn->commit_cfg_req->req.commit_cfg
+					     .dst_ds_ctx),
+		       nb_config, &changes);
+	cfg_chgs = &changes;
+	del_cfg_chgs = true;
 
 	if (RB_EMPTY(nb_config_cbs, cfg_chgs)) {
 		/*


### PR DESCRIPTION
The code doesn't work at all. It tries to use libyang operation metadata in a regular (not diff) data tree, and regular data trees don't provide this data. Also, for destroy operations, it searches for nodes in the running config, which may not have the deleted nodes if we're not using implicit commits.

@pushpasis @choppsv1 I'm adding a `do not merge` label in case I am missing something. Please, take a look before I remove the label.