### PR TITLE
zebra: Free nexthop_group

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -682,6 +682,7 @@ int zebra_add_import_table_entry(struct zebra_vrf *zvrf, struct route_node *rn,
 	copy_nexthops(&ng->nexthop, re->nhe->nhg.nexthop, NULL);
 
 	rib_add_multipath(afi, SAFI_UNICAST, &p, NULL, newre, ng, false);
+	nexthop_group_delete(&ng);
 
 	return 0;
 }


### PR DESCRIPTION
`ng` was not properly freed, leading to a memory leak. The commit calls `nexthop_group_delete` to free memory associated with `ng`.

The ASan leak log for reference:

```
***********************************************************************************
Address Sanitizer Error detected in isis_topo1.test_isis_topo1/r5.asan.zebra.24308

=================================================================
==24308==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7f4f47b43d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f4f4753c0a8 in qcalloc lib/memory.c:105
    #2 0x7f4f47559526 in nexthop_group_new lib/nexthop_group.c:270
    #3 0x562ded6a39d4 in zebra_add_import_table_entry zebra/redistribute.c:681
    #4 0x562ded787c35 in rib_link zebra/zebra_rib.c:3972
    #5 0x562ded787c35 in rib_addnode zebra/zebra_rib.c:3993
    #6 0x562ded787c35 in process_subq_early_route_add zebra/zebra_rib.c:2860
    #7 0x562ded787c35 in process_subq_early_route zebra/zebra_rib.c:3138
    #8 0x562ded787c35 in process_subq zebra/zebra_rib.c:3178
    #9 0x562ded787c35 in meta_queue_process zebra/zebra_rib.c:3228
    #10 0x7f4f475f7118 in work_queue_run lib/workqueue.c:266
    #11 0x7f4f475dc7f2 in event_call lib/event.c:1969
    #12 0x7f4f4751f347 in frr_run lib/libfrr.c:1213
    #13 0x562ded69e818 in main zebra/main.c:486
    #14 0x7f4f468ffc86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 152 byte(s) in 1 object(s) allocated from:
    #0 0x7f4f47b43d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f4f4753c0a8 in qcalloc lib/memory.c:105
    #2 0x7f4f475510ad in nexthop_new lib/nexthop.c:376
    #3 0x7f4f475539c5 in nexthop_dup lib/nexthop.c:914
    #4 0x7f4f4755b27a in copy_nexthops lib/nexthop_group.c:444
    #5 0x562ded6a3a1c in zebra_add_import_table_entry zebra/redistribute.c:682
    #6 0x562ded787c35 in rib_link zebra/zebra_rib.c:3972
    #7 0x562ded787c35 in rib_addnode zebra/zebra_rib.c:3993
    #8 0x562ded787c35 in process_subq_early_route_add zebra/zebra_rib.c:2860
    #9 0x562ded787c35 in process_subq_early_route zebra/zebra_rib.c:3138
    #10 0x562ded787c35 in process_subq zebra/zebra_rib.c:3178
    #11 0x562ded787c35 in meta_queue_process zebra/zebra_rib.c:3228
    #12 0x7f4f475f7118 in work_queue_run lib/workqueue.c:266
    #13 0x7f4f475dc7f2 in event_call lib/event.c:1969
    #14 0x7f4f4751f347 in frr_run lib/libfrr.c:1213
    #15 0x562ded69e818 in main zebra/main.c:486
    #16 0x7f4f468ffc86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 184 byte(s) leaked in 2 allocation(s).
***********************************************************************************
```