### PR TITLE
bgpd: Convert the bgp_advertise_attr->adv to a fifo

### DIFF
--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -36,6 +36,8 @@ struct bgp_advertise_attr *bgp_advertise_attr_new(void)
 
 void bgp_advertise_attr_free(struct bgp_advertise_attr *baa)
 {
+	bgp_advertise_attr_fifo_fini(&baa->fifo);
+
 	XFREE(MTYPE_BGP_ADVERTISE_ATTR, baa);
 }
 
@@ -46,6 +48,9 @@ static void *bgp_advertise_attr_hash_alloc(void *p)
 
 	baa = bgp_advertise_attr_new();
 	baa->attr = ref->attr;
+
+	bgp_advertise_attr_fifo_init(&baa->fifo);
+
 	return baa;
 }
 
@@ -83,36 +88,13 @@ void bgp_advertise_free(struct bgp_advertise *adv)
 void bgp_advertise_add(struct bgp_advertise_attr *baa,
 		       struct bgp_advertise *adv)
 {
-	struct bgp_advertise *spot, *prev = NULL;
-
-	spot = baa->adv;
-
-	while (spot) {
-		prev = spot;
-		spot = spot->next;
-	}
-
-	if (prev) {
-		prev->next = adv;
-		adv->prev = prev;
-	} else
-		adv->prev = NULL;
-
-	adv->next = NULL;
-
-	if (!baa->adv)
-		baa->adv = adv;
+	bgp_advertise_attr_fifo_add_tail(&baa->fifo, adv);
 }
 
 void bgp_advertise_delete(struct bgp_advertise_attr *baa,
 			  struct bgp_advertise *adv)
 {
-	if (adv->next)
-		adv->next->prev = adv->prev;
-	if (adv->prev)
-		adv->prev->next = adv->next;
-	else
-		baa->adv = adv->next;
+	bgp_advertise_attr_fifo_del(&baa->fifo, adv);
 }
 
 struct bgp_advertise_attr *bgp_advertise_attr_intern(struct hash *hash,

--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -11,26 +11,19 @@
 PREDECL_DLIST(bgp_adv_fifo);
 
 struct update_subgroup;
+struct bgp_advertise;
+
+PREDECL_DLIST(bgp_advertise_attr_fifo);
+
+struct bgp_advertise_attr;
 
 /* BGP advertise attribute.  */
-struct bgp_advertise_attr {
-	/* Head of advertisement pointer. */
-	struct bgp_advertise *adv;
-
-	/* Reference counter.  */
-	unsigned long refcnt;
-
-	/* Attribute pointer to be announced.  */
-	struct attr *attr;
-};
-
 struct bgp_advertise {
 	/* FIFO for advertisement.  */
 	struct bgp_adv_fifo_item fifo;
 
-	/* Link list for same attribute advertise.  */
-	struct bgp_advertise *next;
-	struct bgp_advertise *prev;
+	/* FIFO for this item in the bgp_advertise_attr fifo */
+	struct bgp_advertise_attr_fifo_item item;
 
 	/* Prefix information.  */
 	struct bgp_dest *dest;
@@ -45,7 +38,20 @@ struct bgp_advertise {
 	struct bgp_path_info *pathi;
 };
 
+DECLARE_DLIST(bgp_advertise_attr_fifo, struct bgp_advertise, item);
 DECLARE_DLIST(bgp_adv_fifo, struct bgp_advertise, fifo);
+
+/* BGP advertise attribute.  */
+struct bgp_advertise_attr {
+	/* Head of advertisement pointer. */
+	struct bgp_advertise_attr_fifo_head fifo;
+
+	/* Reference counter.  */
+	unsigned long refcnt;
+
+	/* Attribute pointer to be announced.  */
+	struct attr *attr;
+};
 
 /* BGP adjacency out.  */
 struct bgp_adj_out {

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -479,7 +479,7 @@ bgp_advertise_clean_subgroup(struct update_subgroup *subgrp,
 		bgp_advertise_delete(baa, adv);
 
 		/* Fetch next advertise candidate. */
-		next = baa->adv;
+		next = bgp_advertise_attr_fifo_first(&baa->fifo);
 
 		/* Unintern BGP advertise attribute.  */
 		bgp_advertise_attr_unintern(subgrp->hash, baa);


### PR DESCRIPTION
BGP is storing outgoing updates in a couple of different fifo's.  This is to ensure proper packet packing of all bgp_dests that happen to use the same attribute.

How it's all put together currently:  On initial update BGP walks through all the bgp_dest's in a table.  For each path being sent a bgp_advertise is created.  This bgp_advertise is placed in fifo order on the bgp_synchronize->update queue. The bgp_advertise has a pointer to the bgp_advertise_attr which is associated iwth the actual attribute that is being sent to it's peer.  In turn this bgp_advertise is placed in a fifo off of the bgp_advertise_attr structure.  As such as we have paths that share an attribute, the path/dest is placed on the bgp_syncrhonize->update fifo as well as being placed on the fifo associated with the advertised attribute.

On actual creation of a packet.  The first item in the bgp_synchronize->update fifo is popped.  The bgp_advertise_attr pointer is grabbed, we fill out the nlri part of the bgp packet and then walk the bgp_advertise_attr fifo to place paths/dests in the packet.  As each path/dest is placed in the packet it is removed from both the bgp_synchronize->update fifo and the bgp_advertise_attr fifo.

The whole point of this change is to switch the *next, *prev pointers in the bgp_advertise structure with a typesafe data structure.