### PR TITLE
eigrp: use correct memory pool on interface deletion

### DIFF
--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -43,8 +43,7 @@
 #include "eigrpd/eigrp_types.h"
 #include "eigrpd/eigrp_metric.h"
 
-DEFINE_MTYPE_STATIC(EIGRPD, EIGRP_IF,      "EIGRP interface");
-DEFINE_MTYPE_STATIC(EIGRPD, EIGRP_IF_INFO, "EIGRP Interface Information");
+DEFINE_MTYPE_STATIC(EIGRPD, EIGRP_IF, "EIGRP interface");
 
 struct eigrp_interface *eigrp_if_new(struct eigrp *eigrp, struct interface *ifp,
 				     struct prefix *p)
@@ -110,7 +109,7 @@ int eigrp_if_delete_hook(struct interface *ifp)
 
 	eigrp_fifo_free(ei->obuf);
 
-	XFREE(MTYPE_EIGRP_IF_INFO, ifp->info);
+	XFREE(MTYPE_EIGRP_IF, ifp->info);
 
 	return 0;
 }


### PR DESCRIPTION
Trying to delete an interface during the test `test_eigrp_topo1.py` triggers a crash.
```
2023/10/10 19:12:25.299840 EIGRP: [T6888-VVP0Y] Zebra: Interface[r1-eth0] state change to down.
2023/10/10 19:12:25.301524 EIGRP: [ZNQW6-A3MDH] Zebra: interface delete r1-eth0 index 2 flags 1002 metric 0 mtu 1500
2023/10/10 19:12:25.301529 EIGRP: lib/memory.c:73: mt_count_free(): assertion (mt->n_alloc) failed
EIGRP: Received signal 6 at 1696954345 (si_addr 0x840006315b, PC 0x7f246ad7200b); aborting...
EIGRP: zlog_signal+0x1b1                  7f246b04004b     7ffff0df59b0 /usr/lib//frr/libfrr.so.0 (mapped at 0x7f246af74000)
EIGRP: core_handler+0xfc                  7f246b08fc33     7ffff0df5ae0 /usr/lib//frr/libfrr.so.0 (mapped at 0x7f246af74000)
EIGRP: funlockfile+0x60                   7f246af35420     7ffff0df5c40 /lib/x86_64-linux-gnu/libpthread.so.0 (mapped at 0x7f246af21000)
EIGRP:     ---- signal ----
EIGRP: gsignal+0xcb                       7f246ad7200b     7ffff0df6810 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7f246ad2f000)
EIGRP: abort+0x12b                        7f246ad51859     7ffff0df6930 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7f246ad2f000)
EIGRP: _zlog_assert_failed+0x18c          7f246b0d2bbd     7ffff0df6a60 /usr/lib//frr/libfrr.so.0 (mapped at 0x7f246af74000)
EIGRP: mt_count_free+0x56                 7f246b0461a7     7ffff0df6b60 /usr/lib//frr/libfrr.so.0 (mapped at 0x7f246af74000)
EIGRP: qfree+0x2e                         7f246b0463f5     7ffff0df6ba0 /usr/lib//frr/libfrr.so.0 (mapped at 0x7f246af74000)
EIGRP: eigrp_if_delete_hook+0x8c          55fd2d095aee     7ffff0df6bc0 /usr/lib/frr/eigrpd (mapped at 0x55fd2d074000)
EIGRP: hook_call_if_del+0x5f              7f246b024214     7ffff0df6bf0 /usr/lib//frr/libfrr.so.0 (mapped at 0x7f246af74000)
EIGRP: if_delete_retain+0x1c              7f246b024947     7ffff0df6c30 /usr/lib//frr/libfrr.so.0 (mapped at 0x7f246af74000)
EIGRP: if_delete+0xfb                     7f246b024a7d     7ffff0df6c50 /usr/lib//frr/libfrr.so.0 (mapped at 0x7f246af74000)
EIGRP: if_destroy_via_zapi+0x69           7f246b024698     7ffff0df6c90 /usr/lib//frr/libfrr.so.0 (mapped at 0x7f246af74000)
EIGRP: zclient_interface_delete+0x57      7f246b0cb543     7ffff0df6cb0 /usr/lib//frr/libfrr.so.0 (mapped at 0x7f246af74000)
EIGRP: zclient_read+0x3d0                 7f246b0cfcbd     7ffff0df6cf0 /usr/lib//frr/libfrr.so.0 (mapped at 0x7f246af74000)
EIGRP: event_call+0xd8                    7f246b0aa2aa     7ffff0df6d50 /usr/lib//frr/libfrr.so.0 (mapped at 0x7f246af74000)
EIGRP: frr_run+0x271                      7f246b034012     7ffff0df6e10 /usr/lib//frr/libfrr.so.0 (mapped at 0x7f246af74000)
EIGRP: main+0x14b                         55fd2d0970d6     7ffff0df6f30 /usr/lib/frr/eigrpd (mapped at 0x55fd2d074000)
EIGRP: __libc_start_main+0xf3             7f246ad53083     7ffff0df6f80 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7f246ad2f000)
EIGRP: _start+0x2e                        55fd2d08996e     7ffff0df7050 /usr/lib/frr/eigrpd (mapped at 0x55fd2d074000)
EIGRP: in thread zclient_read scheduled from lib/zclient.c:4514 zclient_event()
```