### PR TITLE
lib: Suppress HOB/STARVATION warnings when running in vtysh

### DIFF
--- a/lib/event.c
+++ b/lib/event.c
@@ -1946,6 +1946,7 @@ void event_getrusage(RUSAGE_T *r)
 void event_call(struct event *thread)
 {
 	RUSAGE_T before, after;
+	bool suppress_warnings = EVENT_ARG(thread);
 
 	/* if the thread being called is the CLI, it may change cputime_enabled
 	 * ("service cputime-stats" command), which can result in nonsensical
@@ -2005,6 +2006,9 @@ void event_call(struct event *thread)
 				  memory_order_seq_cst);
 	atomic_fetch_or_explicit(&thread->hist->types, 1 << thread->add_type,
 				 memory_order_seq_cst);
+
+	if (suppress_warnings)
+		return;
 
 	if (cputime_enabled_here && cputime_enabled && cputime_threshold
 	    && cputime > cputime_threshold) {

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -221,7 +221,9 @@ static struct event *vtysh_rl_read_thread;
 
 static void vtysh_rl_read(struct event *thread)
 {
-	event_add_read(master, vtysh_rl_read, NULL, STDIN_FILENO,
+	bool *suppress_warnings = EVENT_ARG(thread);
+
+	event_add_read(master, vtysh_rl_read, suppress_warnings, STDIN_FILENO,
 		       &vtysh_rl_read_thread);
 	rl_callback_read_char();
 }
@@ -230,11 +232,12 @@ static void vtysh_rl_read(struct event *thread)
 static void vtysh_rl_run(void)
 {
 	struct event thread;
+	bool suppress_warnings = true;
 
 	master = event_master_create(NULL);
 
 	rl_callback_handler_install(vtysh_prompt(), vtysh_rl_callback);
-	event_add_read(master, vtysh_rl_read, NULL, STDIN_FILENO,
+	event_add_read(master, vtysh_rl_read, &suppress_warnings, STDIN_FILENO,
 		       &vtysh_rl_read_thread);
 
 	while (!vtysh_loop_exited && event_fetch(master, &thread))


### PR DESCRIPTION
Running ping/traceroute/etc. (any kind of commands that use execute_command() suffer with this kind of warnings.

Related: https://github.com/FRRouting/frr/issues/14412