### PR TITLE
bgpd: ecommunity_dup memory leak fix

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1729,6 +1729,7 @@ void vpn_leak_from_vrf_update(struct bgp *to_bgp,	     /* to */
 			zlog_debug(
 				"%s: %s skipping: waiting for a valid per-label nexthop.",
 				__func__, from_bgp->name_pretty);
+		bgp_attr_flush(&static_attr);
 		return;
 	}
 	if (label_val == MPLS_LABEL_NONE)


### PR DESCRIPTION
The shallow copy of attr wasn't freed when there was no valid label for the moment and the function return therefore creating leaks. The leak below are solved by flushing the shallow copy of attr.

```Address Sanitizer Error detected in bgp_vpnv6_per_nexthop_label.test_bgp_vpnv6_per_nexthop_label/r1.asan.bgpd.13409 ================================================================= ==13409==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 280 byte(s) in 7 object(s) allocated from:
    #0 0x7f62cd0c9d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f62ccac21c3 in qcalloc lib/memory.c:105
    #2 0x5623b8810dc8 in ecommunity_dup bgpd/bgp_ecommunity.c:252
    #3 0x5623b88be8eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x5623b88c13b3 in vpn_leak_from_vrf_update_all bgpd/bgp_mplsvpn.c:2005
    #5 0x5623b89beabc in vpn_leak_postchange bgpd/bgp_mplsvpn.h:287
    #6 0x5623b89beabc in af_label_vpn_export_allocation_mode_magic bgpd/bgp_vty.c:9464
    #7 0x5623b89beabc in af_label_vpn_export_allocation_mode bgpd/bgp_vty_clippy.c:2809
    #8 0x7f62cca45511 in cmd_execute_command_real lib/command.c:978
    #9 0x7f62cca459d5 in cmd_execute_command lib/command.c:1036
    #10 0x7f62cca45e54 in cmd_execute lib/command.c:1203
    #11 0x7f62ccb6ee20 in vty_command lib/vty.c:591
    #12 0x7f62ccb6f2cb in vty_execute lib/vty.c:1354
    #13 0x7f62ccb77b95 in vtysh_read lib/vty.c:2362
    #14 0x7f62ccb62b8f in event_call lib/event.c:1969
    #15 0x7f62ccaa5462 in frr_run lib/libfrr.c:1213
    #16 0x5623b87e054b in main bgpd/bgp_main.c:510
    #17 0x7f62cbae7c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 280 byte(s) in 7 object(s) allocated from:
    #0 0x7f62cd0c9d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f62ccac21c3 in qcalloc lib/memory.c:105
    #2 0x5623b8810dc8 in ecommunity_dup bgpd/bgp_ecommunity.c:252
    #3 0x5623b88be8eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x5623b892e86d in bgp_update bgpd/bgp_route.c:4969
    #5 0x5623b893134d in bgp_nlri_parse_ip bgpd/bgp_route.c:6213
    #6 0x5623b88e2a0e in bgp_nlri_parse bgpd/bgp_packet.c:341
    #7 0x5623b88e4f7c in bgp_update_receive bgpd/bgp_packet.c:2220
    #8 0x5623b88f0474 in bgp_process_packet bgpd/bgp_packet.c:3386
    #9 0x7f62ccb62b8f in event_call lib/event.c:1969
    #10 0x7f62ccaa5462 in frr_run lib/libfrr.c:1213
    #11 0x5623b87e054b in main bgpd/bgp_main.c:510
    #12 0x7f62cbae7c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 280 byte(s) in 7 object(s) allocated from:
    #0 0x7f62cd0c9d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f62ccac21c3 in qcalloc lib/memory.c:105
    #2 0x5623b8810dc8 in ecommunity_dup bgpd/bgp_ecommunity.c:252
    #3 0x5623b88be8eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x5623b88c13b3 in vpn_leak_from_vrf_update_all bgpd/bgp_mplsvpn.c:2005
    #5 0x5623b89bdebb in vpn_leak_postchange bgpd/bgp_mplsvpn.h:287
    #6 0x5623b89bdebb in af_label_vpn_export_magic bgpd/bgp_vty.c:9547
    #7 0x5623b89bdebb in af_label_vpn_export bgpd/bgp_vty_clippy.c:2868
    #8 0x7f62cca45511 in cmd_execute_command_real lib/command.c:978
    #9 0x7f62cca459d5 in cmd_execute_command lib/command.c:1036
    #10 0x7f62cca45e54 in cmd_execute lib/command.c:1203
    #11 0x7f62ccb6ee20 in vty_command lib/vty.c:591
    #12 0x7f62ccb6f2cb in vty_execute lib/vty.c:1354
    #13 0x7f62ccb77b95 in vtysh_read lib/vty.c:2362
    #14 0x7f62ccb62b8f in event_call lib/event.c:1969
    #15 0x7f62ccaa5462 in frr_run lib/libfrr.c:1213
    #16 0x5623b87e054b in main bgpd/bgp_main.c:510
    #17 0x7f62cbae7c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 240 byte(s) in 6 object(s) allocated from:
    #0 0x7f62cd0c9d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f62ccac21c3 in qcalloc lib/memory.c:105
    #2 0x5623b8810dc8 in ecommunity_dup bgpd/bgp_ecommunity.c:252
    #3 0x5623b88be8eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x5623b88dc289 in evaluate_paths bgpd/bgp_nht.c:1384
    #5 0x5623b88ddb0b in bgp_process_nexthop_update bgpd/bgp_nht.c:733
    #6 0x5623b88de027 in bgp_parse_nexthop_update bgpd/bgp_nht.c:934
    #7 0x5623b8a03163 in bgp_read_nexthop_update bgpd/bgp_zebra.c:104
    #8 0x7f62ccb92d8a in zclient_read lib/zclient.c:4425
    #9 0x7f62ccb62b8f in event_call lib/event.c:1969
    #10 0x7f62ccaa5462 in frr_run lib/libfrr.c:1213
    #11 0x5623b87e054b in main bgpd/bgp_main.c:510
    #12 0x7f62cbae7c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 120 byte(s) in 3 object(s) allocated from:
    #0 0x7f62cd0c9d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f62ccac21c3 in qcalloc lib/memory.c:105
    #2 0x5623b8810dc8 in ecommunity_dup bgpd/bgp_ecommunity.c:252
    #3 0x5623b88be8eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x5623b893a406 in bgp_redistribute_add bgpd/bgp_route.c:8692
    #5 0x5623b8a02b3b in zebra_read_route bgpd/bgp_zebra.c:595
    #6 0x7f62ccb92d8a in zclient_read lib/zclient.c:4425
    #7 0x7f62ccb62b8f in event_call lib/event.c:1969
    #8 0x7f62ccaa5462 in frr_run lib/libfrr.c:1213
    #9 0x5623b87e054b in main bgpd/bgp_main.c:510
    #10 0x7f62cbae7c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 80 byte(s) in 2 object(s) allocated from:
    #0 0x7f62cd0c9d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f62ccac21c3 in qcalloc lib/memory.c:105
    #2 0x5623b8810dc8 in ecommunity_dup bgpd/bgp_ecommunity.c:252
    #3 0x5623b88be8eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x5623b88dc188 in evaluate_paths bgpd/bgp_nht.c:1348
    #5 0x5623b88ddb0b in bgp_process_nexthop_update bgpd/bgp_nht.c:733
    #6 0x5623b88de027 in bgp_parse_nexthop_update bgpd/bgp_nht.c:934
    #7 0x5623b8a03163 in bgp_read_nexthop_update bgpd/bgp_zebra.c:104
    #8 0x7f62ccb92d8a in zclient_read lib/zclient.c:4425
    #9 0x7f62ccb62b8f in event_call lib/event.c:1969
    #10 0x7f62ccaa5462 in frr_run lib/libfrr.c:1213
    #11 0x5623b87e054b in main bgpd/bgp_main.c:510
    #12 0x7f62cbae7c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 56 byte(s) in 7 object(s) allocated from:
    #0 0x7f62cd0c9b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f62ccac1ee3 in qmalloc lib/memory.c:100
    #2 0x5623b8810eb8 in ecommunity_dup bgpd/bgp_ecommunity.c:256
    #3 0x5623b88be8eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x5623b88c13b3 in vpn_leak_from_vrf_update_all bgpd/bgp_mplsvpn.c:2005
    #5 0x5623b89beabc in vpn_leak_postchange bgpd/bgp_mplsvpn.h:287
    #6 0x5623b89beabc in af_label_vpn_export_allocation_mode_magic bgpd/bgp_vty.c:9464
    #7 0x5623b89beabc in af_label_vpn_export_allocation_mode bgpd/bgp_vty_clippy.c:2809
    #8 0x7f62cca45511 in cmd_execute_command_real lib/command.c:978
    #9 0x7f62cca459d5 in cmd_execute_command lib/command.c:1036
    #10 0x7f62cca45e54 in cmd_execute lib/command.c:1203
    #11 0x7f62ccb6ee20 in vty_command lib/vty.c:591
    #12 0x7f62ccb6f2cb in vty_execute lib/vty.c:1354
    #13 0x7f62ccb77b95 in vtysh_read lib/vty.c:2362
    #14 0x7f62ccb62b8f in event_call lib/event.c:1969
    #15 0x7f62ccaa5462 in frr_run lib/libfrr.c:1213
    #16 0x5623b87e054b in main bgpd/bgp_main.c:510
    #17 0x7f62cbae7c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 56 byte(s) in 7 object(s) allocated from:
    #0 0x7f62cd0c9b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f62ccac1ee3 in qmalloc lib/memory.c:100
    #2 0x5623b8810eb8 in ecommunity_dup bgpd/bgp_ecommunity.c:256
    #3 0x5623b88be8eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x5623b892e86d in bgp_update bgpd/bgp_route.c:4969
    #5 0x5623b893134d in bgp_nlri_parse_ip bgpd/bgp_route.c:6213
    #6 0x5623b88e2a0e in bgp_nlri_parse bgpd/bgp_packet.c:341
    #7 0x5623b88e4f7c in bgp_update_receive bgpd/bgp_packet.c:2220
    #8 0x5623b88f0474 in bgp_process_packet bgpd/bgp_packet.c:3386
    #9 0x7f62ccb62b8f in event_call lib/event.c:1969
    #10 0x7f62ccaa5462 in frr_run lib/libfrr.c:1213
    #11 0x5623b87e054b in main bgpd/bgp_main.c:510
    #12 0x7f62cbae7c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 56 byte(s) in 7 object(s) allocated from:
    #0 0x7f62cd0c9b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f62ccac1ee3 in qmalloc lib/memory.c:100
    #2 0x5623b8810eb8 in ecommunity_dup bgpd/bgp_ecommunity.c:256
    #3 0x5623b88be8eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x5623b88c13b3 in vpn_leak_from_vrf_update_all bgpd/bgp_mplsvpn.c:2005
    #5 0x5623b89bdebb in vpn_leak_postchange bgpd/bgp_mplsvpn.h:287
    #6 0x5623b89bdebb in af_label_vpn_export_magic bgpd/bgp_vty.c:9547
    #7 0x5623b89bdebb in af_label_vpn_export bgpd/bgp_vty_clippy.c:2868
    #8 0x7f62cca45511 in cmd_execute_command_real lib/command.c:978
    #9 0x7f62cca459d5 in cmd_execute_command lib/command.c:1036
    #10 0x7f62cca45e54 in cmd_execute lib/command.c:1203
    #11 0x7f62ccb6ee20 in vty_command lib/vty.c:591
    #12 0x7f62ccb6f2cb in vty_execute lib/vty.c:1354
    #13 0x7f62ccb77b95 in vtysh_read lib/vty.c:2362
    #14 0x7f62ccb62b8f in event_call lib/event.c:1969
    #15 0x7f62ccaa5462 in frr_run lib/libfrr.c:1213
    #16 0x5623b87e054b in main bgpd/bgp_main.c:510
    #17 0x7f62cbae7c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 48 byte(s) in 6 object(s) allocated from:
    #0 0x7f62cd0c9b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f62ccac1ee3 in qmalloc lib/memory.c:100
    #2 0x5623b8810eb8 in ecommunity_dup bgpd/bgp_ecommunity.c:256
    #3 0x5623b88be8eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x5623b88dc289 in evaluate_paths bgpd/bgp_nht.c:1384
    #5 0x5623b88ddb0b in bgp_process_nexthop_update bgpd/bgp_nht.c:733
    #6 0x5623b88de027 in bgp_parse_nexthop_update bgpd/bgp_nht.c:934
    #7 0x5623b8a03163 in bgp_read_nexthop_update bgpd/bgp_zebra.c:104
    #8 0x7f62ccb92d8a in zclient_read lib/zclient.c:4425
    #9 0x7f62ccb62b8f in event_call lib/event.c:1969
    #10 0x7f62ccaa5462 in frr_run lib/libfrr.c:1213
    #11 0x5623b87e054b in main bgpd/bgp_main.c:510
    #12 0x7f62cbae7c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 24 byte(s) in 3 object(s) allocated from:
    #0 0x7f62cd0c9b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f62ccac1ee3 in qmalloc lib/memory.c:100
    #2 0x5623b8810eb8 in ecommunity_dup bgpd/bgp_ecommunity.c:256
    #3 0x5623b88be8eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x5623b893a406 in bgp_redistribute_add bgpd/bgp_route.c:8692
    #5 0x5623b8a02b3b in zebra_read_route bgpd/bgp_zebra.c:595
    #6 0x7f62ccb92d8a in zclient_read lib/zclient.c:4425
    #7 0x7f62ccb62b8f in event_call lib/event.c:1969
    #8 0x7f62ccaa5462 in frr_run lib/libfrr.c:1213
    #9 0x5623b87e054b in main bgpd/bgp_main.c:510
    #10 0x7f62cbae7c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 16 byte(s) in 2 object(s) allocated from:
    #0 0x7f62cd0c9b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f62ccac1ee3 in qmalloc lib/memory.c:100
    #2 0x5623b8810eb8 in ecommunity_dup bgpd/bgp_ecommunity.c:256
    #3 0x5623b88be8eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x5623b88dc188 in evaluate_paths bgpd/bgp_nht.c:1348
    #5 0x5623b88ddb0b in bgp_process_nexthop_update bgpd/bgp_nht.c:733
    #6 0x5623b88de027 in bgp_parse_nexthop_update bgpd/bgp_nht.c:934
    #7 0x5623b8a03163 in bgp_read_nexthop_update bgpd/bgp_zebra.c:104
    #8 0x7f62ccb92d8a in zclient_read lib/zclient.c:4425
    #9 0x7f62ccb62b8f in event_call lib/event.c:1969
    #10 0x7f62ccaa5462 in frr_run lib/libfrr.c:1213
    #11 0x5623b87e054b in main bgpd/bgp_main.c:510
    #12 0x7f62cbae7c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 1536 byte(s) leaked in 64 allocation(s). ***********************************************************************************

Address Sanitizer Error detected in bgp_vpnv4_per_nexthop_label.test_bgp_vpnv4_per_nexthop_label/r1.asan.bgpd.10610

================================================================= ==10610==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 280 byte(s) in 7 object(s) allocated from:
    #0 0x7f81fc562d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f81fbf5b1c3 in qcalloc lib/memory.c:105
    #2 0x55cdc9b28dc8 in ecommunity_dup bgpd/bgp_ecommunity.c:252
    #3 0x55cdc9bd68eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x55cdc9c4686d in bgp_update bgpd/bgp_route.c:4969
    #5 0x55cdc9c4934d in bgp_nlri_parse_ip bgpd/bgp_route.c:6213
    #6 0x55cdc9bfaa0e in bgp_nlri_parse bgpd/bgp_packet.c:341
    #7 0x55cdc9bfcf7c in bgp_update_receive bgpd/bgp_packet.c:2220
    #8 0x55cdc9c08474 in bgp_process_packet bgpd/bgp_packet.c:3386
    #9 0x7f81fbffbb8f in event_call lib/event.c:1969
    #10 0x7f81fbf3e462 in frr_run lib/libfrr.c:1213
    #11 0x55cdc9af854b in main bgpd/bgp_main.c:510
    #12 0x7f81faf80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 280 byte(s) in 7 object(s) allocated from:
    #0 0x7f81fc562d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f81fbf5b1c3 in qcalloc lib/memory.c:105
    #2 0x55cdc9b28dc8 in ecommunity_dup bgpd/bgp_ecommunity.c:252
    #3 0x55cdc9bd68eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x55cdc9bd93b3 in vpn_leak_from_vrf_update_all bgpd/bgp_mplsvpn.c:2005
    #5 0x55cdc9cd6abc in vpn_leak_postchange bgpd/bgp_mplsvpn.h:287
    #6 0x55cdc9cd6abc in af_label_vpn_export_allocation_mode_magic bgpd/bgp_vty.c:9464
    #7 0x55cdc9cd6abc in af_label_vpn_export_allocation_mode bgpd/bgp_vty_clippy.c:2809
    #8 0x7f81fbede511 in cmd_execute_command_real lib/command.c:978
    #9 0x7f81fbede9d5 in cmd_execute_command lib/command.c:1036
    #10 0x7f81fbedee54 in cmd_execute lib/command.c:1203
    #11 0x7f81fc007e20 in vty_command lib/vty.c:591
    #12 0x7f81fc0082cb in vty_execute lib/vty.c:1354
    #13 0x7f81fc010b95 in vtysh_read lib/vty.c:2362
    #14 0x7f81fbffbb8f in event_call lib/event.c:1969
    #15 0x7f81fbf3e462 in frr_run lib/libfrr.c:1213
    #16 0x55cdc9af854b in main bgpd/bgp_main.c:510
    #17 0x7f81faf80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 280 byte(s) in 7 object(s) allocated from:
    #0 0x7f81fc562d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f81fbf5b1c3 in qcalloc lib/memory.c:105
    #2 0x55cdc9b28dc8 in ecommunity_dup bgpd/bgp_ecommunity.c:252
    #3 0x55cdc9bd68eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x55cdc9bd93b3 in vpn_leak_from_vrf_update_all bgpd/bgp_mplsvpn.c:2005
    #5 0x55cdc9cd5ebb in vpn_leak_postchange bgpd/bgp_mplsvpn.h:287
    #6 0x55cdc9cd5ebb in af_label_vpn_export_magic bgpd/bgp_vty.c:9547
    #7 0x55cdc9cd5ebb in af_label_vpn_export bgpd/bgp_vty_clippy.c:2868
    #8 0x7f81fbede511 in cmd_execute_command_real lib/command.c:978
    #9 0x7f81fbede9d5 in cmd_execute_command lib/command.c:1036
    #10 0x7f81fbedee54 in cmd_execute lib/command.c:1203
    #11 0x7f81fc007e20 in vty_command lib/vty.c:591
    #12 0x7f81fc0082cb in vty_execute lib/vty.c:1354
    #13 0x7f81fc010b95 in vtysh_read lib/vty.c:2362
    #14 0x7f81fbffbb8f in event_call lib/event.c:1969
    #15 0x7f81fbf3e462 in frr_run lib/libfrr.c:1213
    #16 0x55cdc9af854b in main bgpd/bgp_main.c:510
    #17 0x7f81faf80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 240 byte(s) in 6 object(s) allocated from:
    #0 0x7f81fc562d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f81fbf5b1c3 in qcalloc lib/memory.c:105
    #2 0x55cdc9b28dc8 in ecommunity_dup bgpd/bgp_ecommunity.c:252
    #3 0x55cdc9bd68eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x55cdc9bf4289 in evaluate_paths bgpd/bgp_nht.c:1384
    #5 0x55cdc9bf5b0b in bgp_process_nexthop_update bgpd/bgp_nht.c:733
    #6 0x55cdc9bf6027 in bgp_parse_nexthop_update bgpd/bgp_nht.c:934
    #7 0x55cdc9d1b163 in bgp_read_nexthop_update bgpd/bgp_zebra.c:104
    #8 0x7f81fc02bd8a in zclient_read lib/zclient.c:4425
    #9 0x7f81fbffbb8f in event_call lib/event.c:1969
    #10 0x7f81fbf3e462 in frr_run lib/libfrr.c:1213
    #11 0x55cdc9af854b in main bgpd/bgp_main.c:510
    #12 0x7f81faf80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 80 byte(s) in 2 object(s) allocated from:
    #0 0x7f81fc562d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f81fbf5b1c3 in qcalloc lib/memory.c:105
    #2 0x55cdc9b28dc8 in ecommunity_dup bgpd/bgp_ecommunity.c:252
    #3 0x55cdc9bd68eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x55cdc9bf4188 in evaluate_paths bgpd/bgp_nht.c:1348
    #5 0x55cdc9bf5b0b in bgp_process_nexthop_update bgpd/bgp_nht.c:733
    #6 0x55cdc9bf6027 in bgp_parse_nexthop_update bgpd/bgp_nht.c:934
    #7 0x55cdc9d1b163 in bgp_read_nexthop_update bgpd/bgp_zebra.c:104
    #8 0x7f81fc02bd8a in zclient_read lib/zclient.c:4425
    #9 0x7f81fbffbb8f in event_call lib/event.c:1969
    #10 0x7f81fbf3e462 in frr_run lib/libfrr.c:1213
    #11 0x55cdc9af854b in main bgpd/bgp_main.c:510
    #12 0x7f81faf80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 80 byte(s) in 2 object(s) allocated from:
    #0 0x7f81fc562d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f81fbf5b1c3 in qcalloc lib/memory.c:105
    #2 0x55cdc9b28dc8 in ecommunity_dup bgpd/bgp_ecommunity.c:252
    #3 0x55cdc9bd68eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x55cdc9bd93b3 in vpn_leak_from_vrf_update_all bgpd/bgp_mplsvpn.c:2005
    #5 0x55cdc9bdafd5 in vpn_leak_postchange bgpd/bgp_mplsvpn.h:287
    #6 0x55cdc9bdafd5 in vpn_leak_label_callback bgpd/bgp_mplsvpn.c:581
    #7 0x55cdc9bb2606 in lp_cbq_docallback bgpd/bgp_labelpool.c:118
    #8 0x7f81fc0164b5 in work_queue_run lib/workqueue.c:266
    #9 0x7f81fbffbb8f in event_call lib/event.c:1969
    #10 0x7f81fbf3e462 in frr_run lib/libfrr.c:1213
    #11 0x55cdc9af854b in main bgpd/bgp_main.c:510
    #12 0x7f81faf80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7f81fc562d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f81fbf5b1c3 in qcalloc lib/memory.c:105
    #2 0x55cdc9b28dc8 in ecommunity_dup bgpd/bgp_ecommunity.c:252
    #3 0x55cdc9bd68eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x55cdc9c52406 in bgp_redistribute_add bgpd/bgp_route.c:8692
    #5 0x55cdc9d1ab3b in zebra_read_route bgpd/bgp_zebra.c:595
    #6 0x7f81fc02bd8a in zclient_read lib/zclient.c:4425
    #7 0x7f81fbffbb8f in event_call lib/event.c:1969
    #8 0x7f81fbf3e462 in frr_run lib/libfrr.c:1213
    #9 0x55cdc9af854b in main bgpd/bgp_main.c:510
    #10 0x7f81faf80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 56 byte(s) in 7 object(s) allocated from:
    #0 0x7f81fc562b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f81fbf5aee3 in qmalloc lib/memory.c:100
    #2 0x55cdc9b28eb8 in ecommunity_dup bgpd/bgp_ecommunity.c:256
    #3 0x55cdc9bd68eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x55cdc9bd93b3 in vpn_leak_from_vrf_update_all bgpd/bgp_mplsvpn.c:2005
    #5 0x55cdc9cd6abc in vpn_leak_postchange bgpd/bgp_mplsvpn.h:287
    #6 0x55cdc9cd6abc in af_label_vpn_export_allocation_mode_magic bgpd/bgp_vty.c:9464
    #7 0x55cdc9cd6abc in af_label_vpn_export_allocation_mode bgpd/bgp_vty_clippy.c:2809
    #8 0x7f81fbede511 in cmd_execute_command_real lib/command.c:978
    #9 0x7f81fbede9d5 in cmd_execute_command lib/command.c:1036
    #10 0x7f81fbedee54 in cmd_execute lib/command.c:1203
    #11 0x7f81fc007e20 in vty_command lib/vty.c:591
    #12 0x7f81fc0082cb in vty_execute lib/vty.c:1354
    #13 0x7f81fc010b95 in vtysh_read lib/vty.c:2362
    #14 0x7f81fbffbb8f in event_call lib/event.c:1969
    #15 0x7f81fbf3e462 in frr_run lib/libfrr.c:1213
    #16 0x55cdc9af854b in main bgpd/bgp_main.c:510
    #17 0x7f81faf80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 56 byte(s) in 7 object(s) allocated from:
    #0 0x7f81fc562b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f81fbf5aee3 in qmalloc lib/memory.c:100
    #2 0x55cdc9b28eb8 in ecommunity_dup bgpd/bgp_ecommunity.c:256
    #3 0x55cdc9bd68eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x55cdc9bd93b3 in vpn_leak_from_vrf_update_all bgpd/bgp_mplsvpn.c:2005
    #5 0x55cdc9cd5ebb in vpn_leak_postchange bgpd/bgp_mplsvpn.h:287
    #6 0x55cdc9cd5ebb in af_label_vpn_export_magic bgpd/bgp_vty.c:9547
    #7 0x55cdc9cd5ebb in af_label_vpn_export bgpd/bgp_vty_clippy.c:2868
    #8 0x7f81fbede511 in cmd_execute_command_real lib/command.c:978
    #9 0x7f81fbede9d5 in cmd_execute_command lib/command.c:1036
    #10 0x7f81fbedee54 in cmd_execute lib/command.c:1203
    #11 0x7f81fc007e20 in vty_command lib/vty.c:591
    #12 0x7f81fc0082cb in vty_execute lib/vty.c:1354
    #13 0x7f81fc010b95 in vtysh_read lib/vty.c:2362
    #14 0x7f81fbffbb8f in event_call lib/event.c:1969
    #15 0x7f81fbf3e462 in frr_run lib/libfrr.c:1213
    #16 0x55cdc9af854b in main bgpd/bgp_main.c:510
    #17 0x7f81faf80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 56 byte(s) in 7 object(s) allocated from:
    #0 0x7f81fc562b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f81fbf5aee3 in qmalloc lib/memory.c:100
    #2 0x55cdc9b28eb8 in ecommunity_dup bgpd/bgp_ecommunity.c:256
    #3 0x55cdc9bd68eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x55cdc9c4686d in bgp_update bgpd/bgp_route.c:4969
    #5 0x55cdc9c4934d in bgp_nlri_parse_ip bgpd/bgp_route.c:6213
    #6 0x55cdc9bfaa0e in bgp_nlri_parse bgpd/bgp_packet.c:341
    #7 0x55cdc9bfcf7c in bgp_update_receive bgpd/bgp_packet.c:2220
    #8 0x55cdc9c08474 in bgp_process_packet bgpd/bgp_packet.c:3386
    #9 0x7f81fbffbb8f in event_call lib/event.c:1969
    #10 0x7f81fbf3e462 in frr_run lib/libfrr.c:1213
    #11 0x55cdc9af854b in main bgpd/bgp_main.c:510
    #12 0x7f81faf80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 48 byte(s) in 6 object(s) allocated from:
    #0 0x7f81fc562b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f81fbf5aee3 in qmalloc lib/memory.c:100
    #2 0x55cdc9b28eb8 in ecommunity_dup bgpd/bgp_ecommunity.c:256
    #3 0x55cdc9bd68eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x55cdc9bf4289 in evaluate_paths bgpd/bgp_nht.c:1384
    #5 0x55cdc9bf5b0b in bgp_process_nexthop_update bgpd/bgp_nht.c:733
    #6 0x55cdc9bf6027 in bgp_parse_nexthop_update bgpd/bgp_nht.c:934
    #7 0x55cdc9d1b163 in bgp_read_nexthop_update bgpd/bgp_zebra.c:104
    #8 0x7f81fc02bd8a in zclient_read lib/zclient.c:4425
    #9 0x7f81fbffbb8f in event_call lib/event.c:1969
    #10 0x7f81fbf3e462 in frr_run lib/libfrr.c:1213
    #11 0x55cdc9af854b in main bgpd/bgp_main.c:510
    #12 0x7f81faf80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 16 byte(s) in 2 object(s) allocated from:
    #0 0x7f81fc562b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f81fbf5aee3 in qmalloc lib/memory.c:100
    #2 0x55cdc9b28eb8 in ecommunity_dup bgpd/bgp_ecommunity.c:256
    #3 0x55cdc9bd68eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x55cdc9bf4188 in evaluate_paths bgpd/bgp_nht.c:1348
    #5 0x55cdc9bf5b0b in bgp_process_nexthop_update bgpd/bgp_nht.c:733
    #6 0x55cdc9bf6027 in bgp_parse_nexthop_update bgpd/bgp_nht.c:934
    #7 0x55cdc9d1b163 in bgp_read_nexthop_update bgpd/bgp_zebra.c:104
    #8 0x7f81fc02bd8a in zclient_read lib/zclient.c:4425
    #9 0x7f81fbffbb8f in event_call lib/event.c:1969
    #10 0x7f81fbf3e462 in frr_run lib/libfrr.c:1213
    #11 0x55cdc9af854b in main bgpd/bgp_main.c:510
    #12 0x7f81faf80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 16 byte(s) in 2 object(s) allocated from:
    #0 0x7f81fc562b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f81fbf5aee3 in qmalloc lib/memory.c:100
    #2 0x55cdc9b28eb8 in ecommunity_dup bgpd/bgp_ecommunity.c:256
    #3 0x55cdc9bd68eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x55cdc9bd93b3 in vpn_leak_from_vrf_update_all bgpd/bgp_mplsvpn.c:2005
    #5 0x55cdc9bdafd5 in vpn_leak_postchange bgpd/bgp_mplsvpn.h:287
    #6 0x55cdc9bdafd5 in vpn_leak_label_callback bgpd/bgp_mplsvpn.c:581
    #7 0x55cdc9bb2606 in lp_cbq_docallback bgpd/bgp_labelpool.c:118
    #8 0x7f81fc0164b5 in work_queue_run lib/workqueue.c:266
    #9 0x7f81fbffbb8f in event_call lib/event.c:1969
    #10 0x7f81fbf3e462 in frr_run lib/libfrr.c:1213
    #11 0x55cdc9af854b in main bgpd/bgp_main.c:510
    #12 0x7f81faf80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f81fc562b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f81fbf5aee3 in qmalloc lib/memory.c:100
    #2 0x55cdc9b28eb8 in ecommunity_dup bgpd/bgp_ecommunity.c:256
    #3 0x55cdc9bd68eb in vpn_leak_from_vrf_update bgpd/bgp_mplsvpn.c:1628
    #4 0x55cdc9c52406 in bgp_redistribute_add bgpd/bgp_route.c:8692
    #5 0x55cdc9d1ab3b in zebra_read_route bgpd/bgp_zebra.c:595
    #6 0x7f81fc02bd8a in zclient_read lib/zclient.c:4425
    #7 0x7f81fbffbb8f in event_call lib/event.c:1969
    #8 0x7f81fbf3e462 in frr_run lib/libfrr.c:1213
    #9 0x55cdc9af854b in main bgpd/bgp_main.c:510
    #10 0x7f81faf80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 1536 byte(s) leaked in 64 allocation(s). ***********************************************************************************```