### PR TITLE
zebra: add label chunk range in log when label manager request fails

### DIFF
--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -457,11 +457,19 @@ static int label_manager_get_chunk(struct label_manager_chunk **lmc,
 	*lmc = assign_label_chunk(client->proto, client->instance,
 				  client->session_id, keep, size, base);
 	/* Respond to a get_chunk request */
-	if (!*lmc)
-		flog_err(EC_ZEBRA_LM_CANNOT_ASSIGN_CHUNK,
-			 "Unable to assign Label Chunk to %s instance %u",
-			 zebra_route_string(client->proto), client->instance);
-	else if (IS_ZEBRA_DEBUG_PACKET)
+	if (!*lmc) {
+		if (base == MPLS_LABEL_BASE_ANY)
+			flog_err(EC_ZEBRA_LM_CANNOT_ASSIGN_CHUNK,
+				 "Unable to assign Label Chunk size %u to %s instance %u",
+				 size, zebra_route_string(client->proto),
+				 client->instance);
+		else
+			flog_err(EC_ZEBRA_LM_CANNOT_ASSIGN_CHUNK,
+				 "Unable to assign Label Chunk %u - %u to %s instance %u",
+				 base, base + size - 1,
+				 zebra_route_string(client->proto),
+				 client->instance);
+	} else if (IS_ZEBRA_DEBUG_PACKET)
 		zlog_debug("Assigned Label Chunk %u - %u to %s instance %u",
 			   (*lmc)->start, (*lmc)->end,
 			   zebra_route_string(client->proto), client->instance);

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -456,7 +456,17 @@ static int label_manager_get_chunk(struct label_manager_chunk **lmc,
 {
 	*lmc = assign_label_chunk(client->proto, client->instance,
 				  client->session_id, keep, size, base);
-	return lm_get_chunk_response(*lmc, client, vrf_id);
+	/* Respond to a get_chunk request */
+	if (!*lmc)
+		flog_err(EC_ZEBRA_LM_CANNOT_ASSIGN_CHUNK,
+			 "Unable to assign Label Chunk to %s instance %u",
+			 zebra_route_string(client->proto), client->instance);
+	else if (IS_ZEBRA_DEBUG_PACKET)
+		zlog_debug("Assigned Label Chunk %u - %u to %s instance %u",
+			   (*lmc)->start, (*lmc)->end,
+			   zebra_route_string(client->proto), client->instance);
+
+	return zsend_assign_label_chunk_response(client, vrf_id, *lmc);
 }
 
 /* Respond to a connect request */
@@ -473,22 +483,6 @@ int lm_client_connect_response(uint8_t proto, uint16_t instance,
 		return 1;
 	}
 	return zsend_label_manager_connect_response(client, vrf_id, result);
-}
-
-/* Respond to a get_chunk request */
-int lm_get_chunk_response(struct label_manager_chunk *lmc, struct zserv *client,
-			  vrf_id_t vrf_id)
-{
-	if (!lmc)
-		flog_err(EC_ZEBRA_LM_CANNOT_ASSIGN_CHUNK,
-			 "Unable to assign Label Chunk to %s instance %u",
-			 zebra_route_string(client->proto), client->instance);
-	else if (IS_ZEBRA_DEBUG_PACKET)
-		zlog_debug("Assigned Label Chunk %u - %u to %s instance %u",
-			   lmc->start, lmc->end,
-			   zebra_route_string(client->proto), client->instance);
-
-	return zsend_assign_label_chunk_response(client, vrf_id, lmc);
 }
 
 void label_manager_close(void)

--- a/zebra/label_manager.h
+++ b/zebra/label_manager.h
@@ -78,8 +78,6 @@ void lm_release_chunk_call(struct zserv *client, uint32_t start,
 int lm_client_connect_response(uint8_t proto, uint16_t instance,
 			       uint32_t session_id, vrf_id_t vrf_id,
 			       uint8_t result);
-int lm_get_chunk_response(struct label_manager_chunk *lmc, struct zserv *client,
-			  vrf_id_t vrf_id);
 
 /* convenience function to allocate an lmc to be consumed by the above API */
 struct label_manager_chunk *


### PR DESCRIPTION
When the label manager is unable to provide a label chunk to a routing service, an error message is displayed:

> Oct 11 11:47:27 vsr zebra[163745]: [YMY6E-K9JYD][EC 4043309085] Unable to assign Label Chunk [60;60] to bgp instance 0

There is missing information on the range that was requested. Add this information in the log message.

> Oct 11 11:47:27 vsr zebra[163745]: [YMY6E-K9JYD][EC 4043309085] Unable to assign Label Chunk [60;60] to bgp instance 0