### PR TITLE
ldpd: Clarify error situation for different problems

### DIFF
--- a/ldpd/init.c
+++ b/ldpd/init.c
@@ -229,9 +229,11 @@ send_capability(struct nbr *nbr, uint16_t capability, int enable)
 		 * Announcement Parameter in Capability messages sent to
 		 * its peers".
 		 */
-		fallthrough;
+		fatalx("send_capability: An LDP speaker MUST NOT include the Dynamic Capability Announcement Parameter");
+		break;
 	default:
 		fatalx("send_capability: unsupported capability");
+		break;
 	}
 
 	if (err) {


### PR DESCRIPTION
Clarify the fatal error message recorded when an error situation happens.  Disambiguating the default case from the TLV_TYPE_DYNAMIC_CAP case.