### PR TITLE
[WIP] lib, mgmtd: Fix the Scratch Buffer usage in Northbound code

### DIFF
--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -433,7 +433,7 @@ static int mgmt_be_txn_cfg_prepare(struct mgmt_be_txn_ctx *txn)
 				client_ctx->candidate_config,
 				txn_req->req.set_cfg.cfg_changes,
 				(size_t)txn_req->req.set_cfg.num_cfg_changes,
-				NULL, NULL, 0, err_buf, sizeof(err_buf),
+				NULL, NULL, 0, false, err_buf, sizeof(err_buf),
 				&error);
 			if (error) {
 				err_buf[sizeof(err_buf) - 1] = 0;

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -923,6 +923,10 @@ extern bool nb_candidate_needs_update(const struct nb_config *candidate);
  * xpath_index
  *    Index of xpath being processed.
  *
+ * update_scratchbuf
+ *    Update the scratch buffer associated with candidate data tree
+ *    as well.
+ *
  * err_buf
  *    Buffer to store human-readable error message in case of error.
  *
@@ -935,7 +939,8 @@ extern bool nb_candidate_needs_update(const struct nb_config *candidate);
 extern void nb_candidate_edit_config_changes(
 	struct nb_config *candidate_config, struct nb_cfg_change cfg_changes[],
 	size_t num_cfg_changes, const char *xpath_base, const char *curr_xpath,
-	int xpath_index, char *err_buf, int err_bufsize, bool *error);
+	int xpath_index, bool update_scratchbuf, char *err_buf,
+	int err_bufsize, bool *error);
 
 /*
  * Delete candidate configuration changes.

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -147,8 +147,8 @@ static int nb_cli_apply_changes_internal(struct vty *vty,
 
 	nb_candidate_edit_config_changes(
 		vty->candidate_config, vty->cfg_changes, vty->num_cfg_changes,
-		xpath_base, VTY_CURR_XPATH, vty->xpath_index, buf, sizeof(buf),
-		&error);
+		xpath_base, VTY_CURR_XPATH, vty->xpath_index, false, buf,
+		sizeof(buf), &error);
 	if (error) {
 		/*
 		 * Failure to edit the candidate configuration should never

--- a/mgmtd/mgmt_ds.c
+++ b/mgmtd/mgmt_ds.c
@@ -101,6 +101,14 @@ static int mgmt_ds_replace_dst_with_src_ds(struct mgmt_ds_ctx *src,
 		nb_config_diff_del_changes(&src->root.cfg_root->cfg_chgs);
 	}
 
+	if (dst->ds_id == MGMTD_DS_CANDIDATE) {
+		/*
+		 * Drop the changes in scratch-buffer.
+		 */
+		MGMTD_DS_DBG("Emptying Candidate Scratch buffer!");
+		nb_config_diff_del_changes(&dst->root.cfg_root->cfg_chgs);
+	}
+
 	return 0;
 }
 
@@ -132,6 +140,14 @@ static int mgmt_ds_merge_src_with_dst_ds(struct mgmt_ds_ctx *src,
 		 */
 		MGMTD_DS_DBG("Emptying Candidate Scratch buffer!");
 		nb_config_diff_del_changes(&src->root.cfg_root->cfg_chgs);
+	}
+
+	if (dst->ds_id == MGMTD_DS_CANDIDATE) {
+		/*
+		 * Drop the changes in scratch-buffer.
+		 */
+		MGMTD_DS_DBG("Emptying Candidate Scratch buffer!");
+		nb_config_diff_del_changes(&dst->root.cfg_root->cfg_chgs);
 	}
 
 	return 0;


### PR DESCRIPTION
The changes to the candidate data trees were not getting added to the scratch-buffer since lyd_diff_get_op was returning nothing ('n') as no 'operational' metadata associated with the data items in the YANG models. Fixed the logic to add them to the scratch buffer anyways.

Also, the scratch-buffer updations were getting invoked everywhere (mgmtd, backend clients). Limited the usage to mgmtd daemon only.