### PR TITLE
pim6d: valgrind issue fixes

### DIFF
--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -416,11 +416,8 @@ void pim_null_register_send(struct pim_upstream *up)
 	memset(buffer, 0, (sizeof(ip6_hdr) + sizeof(pim_msg_header)));
 	memcpy(buffer, &ip6_hdr, sizeof(ip6_hdr));
 
-	pim_msg_header.ver = 0;
-	pim_msg_header.type = 0;
-	pim_msg_header.reserved = 0;
-
-	pim_msg_header.checksum = 0;
+	memset(&pim_msg_header, 0, sizeof(pim_msg_header));
+	memset(&ph, 0, sizeof(ph));
 
 	ph.src = up->sg.src;
 	ph.dst = up->sg.grp;


### PR DESCRIPTION
**Problem Statement:**
Syscall param sendmsg(msg.msg_iov[0]) points to uninitialised byte(s) at 0x4975157: sendmsg (sendmsg.c:28)
==2263111==    by 0x1413BE: pim_msg_send_frame (pim_pim.c:629)
==2263111==    by 0x1413BE: pim_msg_send (pim_pim.c:743)
==2263111==    by 0x1425DC: pim_register_send (pim_register.c:332)
==2263111==    by 0x1427EE: pim_null_register_send (pim_register.c:443)
==2263111==    by 0x14D228: pim_upstream_register_stop_timer (pim_upstream.c:1608)
==2263111==    by 0x48CE6DF: thread_call (thread.c:1693)
==2263111==    by 0x4899EFF: frr_run (libfrr.c:1068)
==2263111==    by 0x11D035: main (pim6_main.c:190)
==2263111==  Address 0x1ffeffdcb1 is on thread 1's stack
==2263111==  in frame #2, created by pim_register_send (pim_register.c:273)
==2263111==  Uninitialised value was created by a stack allocation
==2263111==    at 0x142690: pim_null_register_send (pim_register.c:389)

**RCA:**
1. All members of struct pim_msg_header were not initiliased while sending null register packet. Therefore when the pointers are assigned while sending the msg via sendmsg, it complains the pointer points to uninitialised byte.
2. struct ipv6_ph ph was also not initialised.

**Fix:**
Initialised all the members using memset.