### PR TITLE
mgmtd, lib: remove batch ids from cfg apply reply 

### DIFF
--- a/lib/mgmt.proto
+++ b/lib/mgmt.proto
@@ -112,9 +112,8 @@ message BeCfgDataApplyReq {
 
 message BeCfgDataApplyReply {
   required uint64 txn_id = 1;
-  repeated uint64 batch_ids = 2;
-  required bool success = 3;
-  optional string error_if_any = 4;
+  required bool success = 2;
+  optional string error_if_any = 3;
 }
 
 message BeOperDataGetReq {

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -469,14 +469,10 @@ mgmt_be_adapter_handle_msg(struct mgmt_be_client_adapter *adapter,
 	case MGMTD__BE_MESSAGE__MESSAGE_CFG_APPLY_REPLY:
 		MGMTD_BE_ADAPTER_DBG(
 			"Got %s CFG_APPLY_REPLY from '%s' txn-id %" PRIx64
-			" for %zu batches id %" PRIu64 "-%" PRIu64 " err:'%s'",
+			" err:'%s'",
 			be_msg->cfg_apply_reply->success ? "successful"
 							 : "failed",
 			adapter->name, be_msg->cfg_apply_reply->txn_id,
-			be_msg->cfg_apply_reply->n_batch_ids,
-			be_msg->cfg_apply_reply->batch_ids[0],
-			be_msg->cfg_apply_reply->batch_ids
-				[be_msg->cfg_apply_reply->n_batch_ids - 1],
 			be_msg->cfg_apply_reply->error_if_any
 				? be_msg->cfg_apply_reply->error_if_any
 				: "None");
@@ -486,8 +482,6 @@ mgmt_be_adapter_handle_msg(struct mgmt_be_client_adapter *adapter,
 		mgmt_txn_notify_be_cfg_apply_reply(
 			be_msg->cfg_apply_reply->txn_id,
 			be_msg->cfg_apply_reply->success,
-			(uint64_t *)be_msg->cfg_apply_reply->batch_ids,
-			be_msg->cfg_apply_reply->n_batch_ids,
 			be_msg->cfg_apply_reply->error_if_any, adapter);
 		break;
 	case MGMTD__BE_MESSAGE__MESSAGE_GET_REPLY:

--- a/mgmtd/mgmt_txn.h
+++ b/mgmtd/mgmt_txn.h
@@ -223,8 +223,7 @@ extern int mgmt_txn_notify_be_cfg_validate_reply(
  */
 extern int
 mgmt_txn_notify_be_cfg_apply_reply(uint64_t txn_id, bool success,
-				       uint64_t batch_ids[],
-				       size_t num_batch_ids, char *error_if_any,
+				       char *error_if_any,
 				       struct mgmt_be_client_adapter *adapter);
 
 /*


### PR DESCRIPTION
The config is always applied fully, all batches are included. There's no
need to pass a list of applied batches as it always contains all of
them.