### PR TITLE
zebra: skip blackhole nexthop when sending multipath netlink updates

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2449,6 +2449,8 @@ ssize_t netlink_route_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx
 
 		nexthop_num = 0;
 		for (ALL_NEXTHOPS_PTR(dplane_ctx_get_ng(ctx), nexthop)) {
+			if (nexthop->type == NEXTHOP_TYPE_BLACKHOLE)
+				continue;
 			if (CHECK_FLAG(nexthop->flags,
 				       NEXTHOP_FLAG_RECURSIVE)) {
 				/* This only works for IPv4 now */


### PR DESCRIPTION
In case of multipath, when zebra is sending netlink updates to the kernel, if one of the nexthops is a blackhole zebra tags on unnecessary bytes at the end of the message.

This is rejected by kernel resulting in zebra marking the route as rejected. This change fixes that by skipping a blackhole nexthop