### PR TITLE
doc: add "enforce-first-as" to BGP documentation

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1521,6 +1521,13 @@ Configuring Peers
    value is carried encoded as uint32. To enable backward compatibility we
    need to disable IEEE floating-point encoding option per-peer.
 
+.. clicmd:: neighbor PEER enforce-first-as
+
+   Discard updates received from the specified (eBGP) peer if the AS_PATH
+   attribute does not contain the PEER's ASN as the first AS_PATH segment.
+
+   Default: disabled.
+
 .. clicmd:: neighbor PEER extended-optional-parameters
 
    Force Extended Optional Parameters Length format to be used for OPEN messages.


### PR DESCRIPTION
With the deprecation of the global "bgp enforce-first-as" command back in https://github.com/FRRouting/frr/pull/2259 the newly introduced option to enable that setting on a specific peer was not documented. This commit adds the necessary documentation and states the command's default.