### PR TITLE
watchfrr: Extend ignore option to daemon being killed

### DIFF
--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -600,6 +600,9 @@ static void daemon_restarting_operational(struct event *thread)
 
 static void daemon_down(struct daemon *dmn, const char *why)
 {
+	if (dmn->ignore_timeout)
+		return;
+
 	if (IS_UP(dmn) || (dmn->state == DAEMON_INIT))
 		flog_err(EC_WATCHFRR_CONNECTION, "%s state -> down : %s",
 			 dmn->name, why);


### PR DESCRIPTION
When testing GR features, it is desired to kill bgp (or really any daemon )and not immediately have bgp start up again. Modify the code to not attempt to restart the daemon by hand to let us developers work when the `watchfrr ignore XXX` command is issued.

Testing:
watchfrr ignore bgpd
kill -9 bgpd
start bgp by `/usr/lib/frr/watchfrr.sh start bgpd` at some point in time in the future

leaf-1# show watchfrr
watchfrr global phase: Idle
 Restart Command: "/usr/lib/frr/watchfrr.sh restart %s"
 Start Command: "/usr/lib/frr/watchfrr.sh start %s"
 Stop Command: "/usr/lib/frr/watchfrr.sh stop %s"
 Min Restart Interval: 60
 Max Restart Interval: 600
 Restart Timeout: 90
  zebra                Up
  bgpd                 Up/Ignoring Timeout
  staticd              Up
leaf-1#