### PR TITLE
zebra: debug ifname in netlink link debugs

### DIFF
--- a/zebra/debug_nl.c
+++ b/zebra/debug_nl.c
@@ -983,6 +983,7 @@ next_rta:
 	zlog_debug("    rta [len=%d (payload=%zu) type=(%d) %s]", rta->rta_len,
 		   plen, rta_type, rta_type2str(rta_type));
 	switch (rta_type) {
+	case IFLA_IFNAME:
 	case IFLA_IFALIAS:
 		if (plen == 0) {
 			zlog_debug("      invalid length");


### PR DESCRIPTION
Print the ifname with netlink LINK debug output (pretty useful to see...)
