### PR TITLE
lib: remove incorrect comment from northbound

### DIFF
--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -906,11 +906,6 @@ void nb_candidate_edit_config_changes(
 	if (error && *error) {
 		char buf[BUFSIZ];
 
-		/*
-		 * Failure to edit the candidate configuration should never
-		 * happen in practice, unless there's a bug in the code. When
-		 * that happens, log the error but otherwise ignore it.
-		 */
 		snprintf(err_buf, err_bufsize,
 			 "%% Failed to edit configuration.\n\n%s",
 			 yang_print_errors(ly_native_ctx, buf, sizeof(buf)));


### PR DESCRIPTION
This was true when we had only a CLI for configuration. Now mgmtd has a public frontend interface that can be used by external applications, and they can send invalid requests that lead to errors.

This is still true for CLI though, so the same comment still stays in `nb_cli_apply_changes_internal`.