### PR TITLE
tests: add --gdb-use-emacs option

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -583,6 +583,12 @@ Here's an example of launching ``zebra`` and ``bgpd`` inside ``gdb`` on router
           --gdb-breakpoints=nb_config_diff \
           all-protocol-startup
 
+Finally, for Emacs users, you can specify ``--gdb-use-emacs``. When specified
+the first router and daemon to be launched in gdb will be launched and run with
+Emacs gdb functionality by using `emacsclient --eval` commands. This provides an
+IDE debugging experience for Emacs users. This functionality works best when
+using password-less sudo.
+
 Reporting Memleaks with FRR Memory Statistics
 """""""""""""""""""""""""""""""""""""""""""""
 

--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -103,6 +103,12 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
+        "--gdb-use-emacs",
+        action="store_true",
+        help="Use emacsclient to run gdb instead of a shell",
+    )
+
+    parser.addoption(
         "--logd",
         action="append",
         metavar="DAEMON[,ROUTER[,...]",


### PR DESCRIPTION
When specified `--gdb-use-emacs` will launch the daemon with gdb inside a running emacs server using `emacsclient --eval` commands.