### PR TITLE
bgpd: Drop unnecessary null-termination for fqdn

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -3307,8 +3307,6 @@ static void bgp_dynamic_capability_fqdn(uint8_t *pnt, int action,
 		data += len;
 
 		if (len) {
-			str[len] = '\0';
-
 			XFREE(MTYPE_BGP_PEER_HOST, peer->hostname);
 			XFREE(MTYPE_BGP_PEER_HOST, peer->domainname);
 


### PR DESCRIPTION
str[len] is already null terminated before:

```
		if (len > BGP_MAX_HOSTNAME) {
			memcpy(&str, data, BGP_MAX_HOSTNAME);
			str[BGP_MAX_HOSTNAME] = '\0';
		} else if (len) {
			memcpy(&str, data, len);
			str[len] = '\0';
		}
```

CID: 1569357