### PR TITLE
pbrd: fix show pbr map detail json

### DIFF
--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -267,7 +267,7 @@ specified in the rule are also applied to the packet.
    this action,
    so this field will be ignored unless another dataplane provider is used.
 
-.. clicmd:: show pbr map [NAME] [detail|json]
+.. clicmd:: show pbr map [NAME] [detail] [json]
 
    Display pbr maps either all or by ``NAME``. If ``detail`` is set, it will
    give information about each rule's unique internal ID and some extra

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -1818,7 +1818,7 @@ static void vty_json_pbr_map(json_object *j, struct vty *vty,
 
 DEFPY (show_pbr_map,
 	show_pbr_map_cmd,
-	"show pbr map [NAME$name] [detail$detail|json$json]",
+	"show pbr map [NAME$name] [detail$detail] [json$json]",
 	SHOW_STR
 	PBR_STR
 	"PBR Map\n"


### PR DESCRIPTION
'detail' and 'josn' keyword is given as an optional parameter for cli arguments. Hence 'detail' keyword was consider as a pbr 'name' for "show pbr map detail json" command.

Before Fix:

```
cumulus#
cumulus# show pbr map detail json
[
]
cumulus#
```

After Fix:
```
cumulus# show pbr map detail json
[
  {
    "name":"MAP1",
    "valid":false,
    "policies":[
      {
        "id":1,
        "sequenceNumber":10,
        "ruleNumber":309,
        "vrfUnchanged":false,
        "installed":false,
        "installedReason":"Invalid Src or Dst",
        "vrfName":"default"
      }
    ]
  }
]
cumulus#
```

Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>