### PR TITLE
zebra: Add encap type when building packet for FPM

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2413,18 +2413,20 @@ ssize_t netlink_route_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx
 					    p, routedesc, bytelen, nexthop,
 					    &req->n, &req->r, datalen, cmd))
 					return 0;
+
+				/*
+				 * Add encapsulation information when
+				 * installing via FPM.
+				 */
+				if (fpm) {
+					if (!netlink_route_nexthop_encap(&req->n,
+									 datalen,
+									 nexthop))
+						return 0;
+				}
+
 				nexthop_num++;
 				break;
-			}
-
-			/*
-			 * Add encapsulation information when installing via
-			 * FPM.
-			 */
-			if (fpm) {
-				if (!netlink_route_nexthop_encap(
-					    &req->n, datalen, nexthop))
-					return 0;
 			}
 		}
 


### PR DESCRIPTION
Currently in the single nexthop case w/ evpn sending down via the FPM the encap type is not being set
for the nexthop.

This looks like the result of some code reorg for the nexthop happened but the fpm failed to be accounted for. Let's just move the encap type encoding to where it will happen.