### PR TITLE
zebra: display ptmStatus order in interface json

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -3133,7 +3133,7 @@ static void if_dump_vty_json(struct vty *vty, struct interface *ifp,
 		json_object_string_add(json_if, "lastLinkDown",
 				       zebra_if->down_last);
 
-	zebra_ptm_show_status(vty, json, ifp);
+	zebra_ptm_show_status(vty, json_if, ifp);
 
 	json_object_string_add(json_if, "vrfName", ifp->vrf->name);
 


### PR DESCRIPTION
Display ptmStatus in correct order in show interface json output.

Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>
