### PR TITLE
ospfd, ospf6d: Fix spacing nit for `show ... summary-address` command

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -2015,7 +2015,7 @@ ospf6_show_summary_address(struct vty *vty, struct ospf6 *ospf6,
 
 	if (!uj) {
 		ospf6_show_vrf_name(vty, ospf6, json_vrf);
-		vty_out(vty, "aggregation delay interval :%u(in seconds)\n\n",
+		vty_out(vty, "aggregation delay interval: %u(in seconds)\n\n",
 			ospf6->aggr_delay_interval);
 		vty_out(vty, "%s\n", header);
 	} else {

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -11994,7 +11994,7 @@ static int ospf_show_summary_address(struct vty *vty, struct ospf *ospf,
 	ospf_show_vrf_name(ospf, vty, json_vrf, use_vrf);
 
 	if (!uj) {
-		vty_out(vty, "aggregation delay interval :%u(in seconds)\n\n",
+		vty_out(vty, "aggregation delay interval: %u(in seconds)\n\n",
 			ospf->aggr_delay_interval);
 	} else {
 		json_object_int_add(json_vrf, "aggregationDelayInterval",


### PR DESCRIPTION
```
r1# sh ipv6 ospf6 summary-address
VRF Name: default
aggregation delay interval :5(in seconds)
```

Just hit this random and looks ugly, let's fix it.