### PR TITLE
zebra: Remove static ARP entries on interface down events

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -28,6 +28,7 @@
 #include "zebra/zapi_msg.h"
 #include "zebra/zebra_vxlan.h"
 #include "zebra/zebra_errors.h"
+#include "zebra/zebra_neigh.h"
 
 #define ZEBRA_PTM_SUPPORT
 
@@ -522,6 +523,8 @@ void zebra_interface_down_update(struct interface *ifp)
 
 		zsend_interface_update(ZEBRA_INTERFACE_DOWN, client, ifp);
 	}
+
+	zebra_neigh_del_all(ifp);
 }
 
 /* Interface information update. */

--- a/zebra/zebra_neigh.c
+++ b/zebra/zebra_neigh.c
@@ -152,6 +152,19 @@ void zebra_neigh_del(struct interface *ifp, struct ipaddr *ip)
 	zebra_neigh_free(n);
 }
 
+/* kernel neigh delete all for a given interface */
+void zebra_neigh_del_all(struct interface *ifp)
+{
+	struct zebra_neigh_ent *n, *nn;
+
+	if (IS_ZEBRA_DEBUG_NEIGH)
+		zlog_debug("zebra neigh delete all for interface %s/%d",
+			   ifp->name, ifp->ifindex);
+
+	RB_FOREACH_SAFE (n, zebra_neigh_rb_head, &zneigh_info->neigh_rb_tree, nn)
+		zebra_neigh_del(ifp, &n->ip);
+}
+
 /* kernel neigh add */
 void zebra_neigh_add(struct interface *ifp, struct ipaddr *ip,
 		     struct ethaddr *mac)

--- a/zebra/zebra_neigh.h
+++ b/zebra/zebra_neigh.h
@@ -43,6 +43,7 @@ struct zebra_neigh_info {
 extern void zebra_neigh_add(struct interface *ifp, struct ipaddr *ip,
 			    struct ethaddr *mac);
 extern void zebra_neigh_del(struct interface *ifp, struct ipaddr *ip);
+extern void zebra_neigh_del_all(struct interface *ifp);
 extern void zebra_neigh_show(struct vty *vty);
 extern void zebra_neigh_init(void);
 extern void zebra_neigh_terminate(void);


### PR DESCRIPTION
Without this patch, static ARP entries remain active even if the interface is down, but the kernel already removed them.

Closes https://github.com/FRRouting/frr/issues/14652