### PR TITLE
docs: clean up some developer doc warnings

### DIFF
--- a/doc/developer/northbound/demos.rst
+++ b/doc/developer/northbound/demos.rst
@@ -2,7 +2,9 @@ Transactional CLI
 -----------------
 
 This short demo shows some of the capabilities of the new transactional
-CLI: |asciicast|
+CLI:
+
+|asciicast1|
 
 ConfD + NETCONF + Cisco YDK
 ---------------------------
@@ -17,9 +19,9 @@ using Cisco’s YANG Development Kit (YDK).
 -  Script used in the demo:
    https://gist.github.com/rwestphal/defa9bd1ccf216ab082d4711ae402f95
 
-|asciicast|
+|asciicast2|
 
-.. |asciicast| image:: https://asciinema.org/a/jL0BS5HfP2kS6N1HfgsZvfZk1.png
+.. |asciicast1| image:: https://asciinema.org/a/jL0BS5HfP2kS6N1HfgsZvfZk1.png
    :target: https://asciinema.org/a/jL0BS5HfP2kS6N1HfgsZvfZk1
-.. |asciicast| image:: https://asciinema.org/a/VfMElNxsjLcdvV7484E6ChxWv.png
+.. |asciicast2| image:: https://asciinema.org/a/VfMElNxsjLcdvV7484E6ChxWv.png
    :target: https://asciinema.org/a/VfMElNxsjLcdvV7484E6ChxWv

--- a/doc/developer/northbound/ppr-basic-test-topology.rst
+++ b/doc/developer/northbound/ppr-basic-test-topology.rst
@@ -1258,7 +1258,7 @@ Using the ``show isis ppr`` command, verify that all routers installed
 the PPR-IDs for the paths they are part of. Example:
 
 Router RT11
-'''''''''''
+^^^^^^^^^^^
 
 ::
 

--- a/doc/developer/northbound/retrofitting-configuration-commands.rst
+++ b/doc/developer/northbound/retrofitting-configuration-commands.rst
@@ -1,24 +1,5 @@
-Table of Contents
------------------
-
--  `Introduction <#introduction>`__
--  `Retrofitting process <#retrofitting-process>`__
-
-   -  `Step 1: writing a YANG module <#step1>`__
-   -  `Step 2: generate skeleton northbound callbacks <#step2>`__
-   -  `Step 3: update the frr_yang_module_info array of all relevant
-      daemons <#step3>`__
-   -  `Step 4: implement the northbound configuration
-      callbacks <#step4>`__
-   -  `Step 5: rewrite the CLI commands as dumb wrappers around the
-      northbound callbacks <#step5>`__
-   -  `Step 6: implement the ``cli_show`` callbacks <#step6>`__
-   -  `Step 7: consolidation <#step7>`__
-
--  `Final Considerations <#final-considerations>`__
-
-Introduction
-------------
+Retrofitting Configuration Commands
+-----------------------------------
 
 This page explains how to convert existing CLI configuration commands to
 the new northbound model. This documentation is meant to be the primary
@@ -88,7 +69,7 @@ possible. As we’ll see later, not all constraints can be expressed using
 the YANG language and sometimes we’ll need to resort to code-level
 validation in the northbound callbacks.
 
-   Tip: the [[YANG tools]] page details several tools and commands that
+   Tip: the :doc:`yang-tools` page details several tools and commands that
    might be useful when writing a YANG module, like validating YANG
    files, indenting YANG files, validating instance data, etc.
 
@@ -1875,7 +1856,7 @@ Final Considerations
 --------------------
 
 Testing
-^^^^^^^
+~~~~~~~
 
 Converting CLI commands to the new northbound model can be a complicated
 task for beginners, but the more commands one converts, the easier it
@@ -1888,7 +1869,7 @@ to use valgrind and static code analyzers to catch other types of
 problems like memory leaks.
 
 Amount of work
-^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~
 
 The output below gives a rough estimate of the total number of
 configuration commands that need to be converted per daemon:

--- a/doc/developer/northbound/yang-tools.rst
+++ b/doc/developer/northbound/yang-tools.rst
@@ -1,3 +1,9 @@
+Yang Tools
+~~~~~~~~~~
+
+Here's some information about various tools for working with yang
+models.
+
 yanglint cheat sheet
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -470,7 +470,7 @@ One can live view daemon or the frr logs in separate windows using the
 
 For each capture a window is opened displaying a live summary of the captured
 packets. Additionally, the entire packet stream is captured in a pcap file in
-the tests log directory e.g.,::
+the tests log directory e.g.,
 
 When using a unified log file ``frr.log`` one substitutes ``frr`` for the
 daemon name in the ``--logd`` CLI option, e.g.,


### PR DESCRIPTION
A few fixups to clean up some dev doc warnings, in the northbound files especially.