### PR TITLE
ospfd:fix show_ip_ospf_gr_helper

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -10807,38 +10807,23 @@ DEFPY (show_ip_ospf_gr_helper,
 		}
 
 		ospf = ospf_lookup_by_inst_name(inst, vrf_name);
-
-		if (ospf == NULL || !ospf->oi_running) {
-
-			if (uj)
-				vty_json(vty, json);
-			else
-				vty_out(vty,
-					"%% OSPF is not enabled in vrf %s\n",
-					vrf_name);
-
-			return CMD_SUCCESS;
-		}
-
 	} else {
 		/* Default Vrf */
 		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
-
-		if (ospf == NULL || !ospf->oi_running) {
-
-			if (uj)
-				vty_json(vty, json);
-			else
-				vty_out(vty,
-					"%% OSPF is not enabled in vrf default\n");
-
-			return CMD_SUCCESS;
-		}
-
-		ospf_show_gr_helper_details(vty, ospf, use_vrf, json, uj,
-					    detail);
 	}
 
+	if (ospf == NULL || !ospf->oi_running) {
+
+		if (uj)
+			vty_json(vty, json);
+		else
+			vty_out(vty,
+				"%% OSPF is not enabled in vrf %s\n", vrf_name ? vrf_name : "default");
+
+		return CMD_SUCCESS;
+	}
+
+	ospf_show_gr_helper_details(vty, ospf, use_vrf, json, uj, detail);
 	if (uj)
 		vty_json(vty, json);
 


### PR DESCRIPTION
Small fix for the command "show ip ospf vrf NAME graceful-restart helper detail". FRR did not show information by vrf's name.
**Error description**: If i have ``` router ospf vrf red```, vtysh's command ```show ip ospf vrf red graceful-restart helper``` will not show anything. But command ```show ip ospf vrf all graceful-restart helper``` will work normally. This fix fixes the display of information by vrf's name.