### PR TITLE
zebra: supports to listen teamd nlmsg as bond type

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -215,6 +215,8 @@ static void netlink_determine_zebra_iftype(const char *kind,
 		*zif_type = ZEBRA_IF_VETH;
 	else if (strcmp(kind, "bond") == 0)
 		*zif_type = ZEBRA_IF_BOND;
+	else if (strcmp(kind, "team") == 0)
+		*zif_type = ZEBRA_IF_BOND;
 	else if (strcmp(kind, "gre") == 0)
 		*zif_type = ZEBRA_IF_GRE;
 }


### PR DESCRIPTION
this feature is to support teamd driver when configing ethernet segment's id and sys_mac via vtysh/zebra.

there are 2 approaches to support lacp protocol.
1st:  linux bonding driver via tool (ifenslave_2.13~deb11u1_all.deb) via ip link cli command.
2nd: via teamd driver by nlmsg
https://github.com/jpirko/libteam/blob/master/libteam/libteam.c#L477

example for nlmsg from bonding driver:
https://cpp.hotexamples.com/examples/-/-/rtnl_link_add/cpp-rtnl_link_add-function-examples.html

comparison between bonding driver and teamd driver:
https://github.com/jpirko/libteam/wiki/Bonding-vs.-Team-features

hence, support teamd driver as what bonding driver does. we should add teamd nlmsg as bond type so that we are able to config associated es data.