### PR TITLE
tools: fix frr-reload route-map desc cmd

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1094,8 +1094,21 @@ def ignore_delete_re_add_lines(lines_to_add, lines_to_del):
     lines_to_add_to_del = []
     lines_to_del_to_del = []
 
+    index = 0
     for (ctx_keys, line) in lines_to_del:
         deleted = False
+
+        # no form of route-map description command only
+        # accept 'no description', replace 'no description blah'
+        # to just 'no description'.
+        index = index + 1
+        if (
+            ctx_keys[0].startswith("route-map")
+            and line
+            and line.startswith("description ")
+        ):
+            lines_to_del.remove((ctx_keys, line))
+            lines_to_del.insert(index, (ctx_keys, "description"))
 
         # If there is a change in the segment routing block ranges, do it
         # in-place, to avoid requesting spurious label chunks which might fail


### PR DESCRIPTION
Fix frr-reload script to only render 'no description' rather than 'no description blah'


Testing:
```
route-map TEST permit 140
 description rule for PFIX_IPV6_7
 match ipv6 address prefix-list PFIX_IPV6_7
exit
!
end

torc-11# confi t
torc-11(config)# route-map TEST permit 140
torc-11(config-route-map)# no description rule for PFIX_IPV6_7 % Unknown command: no description rule for PFIX_IPV6_7

torc-11(config-route-map)# no description rule
% There is no matched command.
torc-11(config-route-map)# no description
  <cr>
torc-11(config-route-map)# no description
torc-11(config-route-map)#
```

Using frr-reload failure log:
```
2023-10-31 00:30:31,972  INFO: Failed to execute route-map TEST permit 140  no description rule for PFIX_IPV6_7 exit 2023-10-31 00:30:31,972 ERROR: "route-map TEST permit 140 --  no description rule for PFIX_IPV6_7 -- exit" we failed to remove this command 2023-10-31 00:30:31,972 ERROR: % Unknown command:  no description rule for PFIX_IPV6_7
```

**With fix:** frr-reload log:
```
2023-11-02 06:10:30,024  INFO: Executed "route-map TEST permit 140  no description exit"
```