### PR TITLE
bgpd: A couple more bgpd crash fixes for malformed packets 

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3399,15 +3399,6 @@ static int bgp_attr_check(struct peer *peer, struct attr *attr,
 	    !length)
 		return BGP_ATTR_PARSE_WITHDRAW;
 
-	/* "An UPDATE message that contains the MP_UNREACH_NLRI is not required
-	   to carry any other path attributes.", though if MP_REACH_NLRI or NLRI
-	   are present, it should.  Check for any other attribute being present
-	   instead.
-	 */
-	if ((!CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI)) &&
-	     CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_MP_UNREACH_NLRI))))
-		return BGP_ATTR_PARSE_PROCEED;
-
 	if (!CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_ORIGIN)))
 		type = BGP_ATTR_ORIGIN;
 
@@ -3425,6 +3416,16 @@ static int bgp_attr_check(struct peer *peer, struct attr *attr,
 	if (peer->sort == BGP_PEER_IBGP
 	    && !CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)))
 		type = BGP_ATTR_LOCAL_PREF;
+
+	/* An UPDATE message that contains the MP_UNREACH_NLRI is not required
+	 * to carry any other path attributes. Though if MP_REACH_NLRI or NLRI
+	 * are present, it should. Check for any other attribute being present
+	 * instead.
+	 */
+	if (!CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_MP_REACH_NLRI)) &&
+	    CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_MP_UNREACH_NLRI)))
+		return type ? BGP_ATTR_PARSE_MISSING_MANDATORY
+			    : BGP_ATTR_PARSE_PROCEED;
 
 	/* If any of the well-known mandatory attributes are not present
 	 * in an UPDATE message, then "treat-as-withdraw" MUST be used.

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3391,10 +3391,13 @@ static int bgp_attr_check(struct peer *peer, struct attr *attr,
 	uint8_t type = 0;
 
 	/* BGP Graceful-Restart End-of-RIB for IPv4 unicast is signaled as an
-	 * empty UPDATE.  */
+	 * empty UPDATE. Treat-as-withdraw, otherwise if we just ignore it,
+	 * we will pass it to be processed as a normal UPDATE without mandatory
+	 * attributes, that could lead to harmful behavior.
+	 */
 	if (CHECK_FLAG(peer->cap, PEER_CAP_RESTART_RCV) && !attr->flag &&
 	    !length)
-		return BGP_ATTR_PARSE_PROCEED;
+		return BGP_ATTR_PARSE_WITHDRAW;
 
 	/* "An UPDATE message that contains the MP_UNREACH_NLRI is not required
 	   to carry any other path attributes.", though if MP_REACH_NLRI or NLRI
@@ -3889,7 +3892,13 @@ done:
 	aspath_unintern(&as4_path);
 
 	transit = bgp_attr_get_transit(attr);
-	if (ret != BGP_ATTR_PARSE_ERROR) {
+	/* If we received an UPDATE with mandatory attributes, then
+	 * the unrecognized transitive optional attribute of that
+	 * path MUST be passed. Otherwise, it's an error, and from
+	 * security perspective it might be very harmful if we continue
+	 * here with the unrecognized attributes.
+	 */
+	if (ret == BGP_ATTR_PARSE_PROCEED) {
 		/* Finally intern unknown attribute. */
 		if (transit)
 			bgp_attr_set_transit(attr, transit_intern(transit));

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -364,6 +364,7 @@ enum bgp_attr_parse_ret {
 	/* only used internally, send notify + convert to BGP_ATTR_PARSE_ERROR
 	 */
 	BGP_ATTR_PARSE_ERROR_NOTIFYPLS = -3,
+	BGP_ATTR_PARSE_MISSING_MANDATORY = -4,
 };
 
 struct bpacket_attr_vec_arr;

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2359,7 +2359,12 @@ static int bgp_update_receive(struct peer_connection *connection,
 	/* Network Layer Reachability Information. */
 	update_len = end - stream_pnt(s);
 
-	if (update_len && attribute_len) {
+	/* If we received MP_UNREACH_NLRI attribute, but also NLRIs, then
+	 * NLRIs should be handled as a new data. Though, if we received
+	 * NLRIs without mandatory attributes, they should be ignored.
+	 */
+	if (update_len && attribute_len &&
+	    attr_parse_ret != BGP_ATTR_PARSE_MISSING_MANDATORY) {
 		/* Set NLRI portion to structure. */
 		nlris[NLRI_UPDATE].afi = AFI_IP;
 		nlris[NLRI_UPDATE].safi = SAFI_UNICAST;


### PR DESCRIPTION
Found when fuzzing, in the normal case, such packets can't exist at all.