### PR TITLE
isisd: Fix crash when enabling OpenFabric on an interface

### DIFF
--- a/isisd/isis_srv6.c
+++ b/isisd/isis_srv6.c
@@ -183,7 +183,7 @@ void isis_srv6_interface_set(struct isis_area *area, const char *ifname)
 		isis_zebra_srv6_sid_uninstall(area, sid);
 	}
 
-	strncpy(area->srv6db.config.srv6_ifname, ifname, IF_NAMESIZE - 1);
+	strlcpy(area->srv6db.config.srv6_ifname, ifname, sizeof(area->srv6db.config.srv6_ifname));
 
 	if (!if_lookup_by_name(area->srv6db.config.srv6_ifname, VRF_DEFAULT)) {
 		sr_debug("Interface %s not yet exist in data plane, deferring SIDs installation until it's created", area->srv6db.config.srv6_ifname);
@@ -789,7 +789,7 @@ void isis_srv6_area_init(struct isis_area *area)
 				       ISIS_SRV6);
 	srv6db->config.max_end_d_msd =
 		yang_get_default_uint8("%s/msd/node-msd/max-end-d", ISIS_SRV6);
-	strncpy(srv6db->config.srv6_ifname, yang_get_default_string("%s/interface", ISIS_SRV6), IF_NAMESIZE - 1);
+	strlcpy(srv6db->config.srv6_ifname, yang_get_default_string("%s/interface", ISIS_SRV6), sizeof(srv6db->config.srv6_ifname));
 #else
 	srv6db->config.enabled = false;
 	srv6db->config.max_seg_left_msd = ISIS_DEFAULT_SRV6_MAX_SEG_LEFT_MSD;

--- a/isisd/isis_srv6.c
+++ b/isisd/isis_srv6.c
@@ -777,6 +777,7 @@ void isis_srv6_area_init(struct isis_area *area)
 	srv6db->srv6_endx_sids = list_new();
 
 	/* Pull defaults from the YANG module */
+#ifndef FABRICD
 	srv6db->config.enabled = yang_get_default_bool("%s/enabled", ISIS_SRV6);
 	srv6db->config.max_seg_left_msd =
 		yang_get_default_uint8("%s/msd/node-msd/max-segs-left",
@@ -789,6 +790,14 @@ void isis_srv6_area_init(struct isis_area *area)
 	srv6db->config.max_end_d_msd =
 		yang_get_default_uint8("%s/msd/node-msd/max-end-d", ISIS_SRV6);
 	strncpy(srv6db->config.srv6_ifname, yang_get_default_string("%s/interface", ISIS_SRV6), IF_NAMESIZE - 1);
+#else
+	srv6db->config.enabled = false;
+	srv6db->config.max_seg_left_msd = ISIS_DEFAULT_SRV6_MAX_SEG_LEFT_MSD;
+	srv6db->config.max_end_pop_msd = ISIS_DEFAULT_SRV6_MAX_END_POP_MSD;
+	srv6db->config.max_h_encaps_msd = ISIS_DEFAULT_SRV6_MAX_H_ENCAPS_MSD;
+	srv6db->config.max_end_d_msd = ISIS_DEFAULT_SRV6_MAX_END_D_MSD;
+	strlcpy(srv6db->config.srv6_ifname, ISIS_DEFAULT_SRV6_IFNAME, sizeof(srv6db->config.srv6_ifname));
+#endif
 
 	/* Initialize SRv6 Locator chunks list */
 	srv6db->srv6_locator_chunks = list_new();

--- a/isisd/isis_srv6.h
+++ b/isisd/isis_srv6.h
@@ -13,6 +13,12 @@
 #include "lib/srv6.h"
 #include "isisd/isis_tlvs.h"
 
+#define ISIS_DEFAULT_SRV6_MAX_SEG_LEFT_MSD        3
+#define ISIS_DEFAULT_SRV6_MAX_END_POP_MSD         3
+#define ISIS_DEFAULT_SRV6_MAX_H_ENCAPS_MSD        2
+#define ISIS_DEFAULT_SRV6_MAX_END_D_MSD           5
+#define ISIS_DEFAULT_SRV6_IFNAME                 "sr0"
+
 /* SRv6 SID structure */
 struct isis_srv6_sid_structure {
 	uint8_t loc_block_len;


### PR DESCRIPTION
`isis_srv6_area_init` should not use `yang_get_default_*` functions for fabricd.

Fixes: https://github.com/FRRouting/frr/issues/14722