### PR TITLE
V6 rr semantics zrouter

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -59,8 +59,6 @@ int retain_mode = 0;
 
 int graceful_restart;
 
-bool v6_rr_semantics = false;
-
 /* Receive buffer size for kernel control sockets */
 #define RCVBUFSIZE_MIN 4194304
 #ifdef HAVE_NETLINK
@@ -385,7 +383,7 @@ int main(int argc, char **argv)
 			vrf_configure_backend(VRF_BACKEND_NETNS);
 			break;
 		case OPTION_V6_RR_SEMANTICS:
-			v6_rr_semantics = true;
+			zrouter.v6_rr_semantics = true;
 			break;
 		case OPTION_ASIC_OFFLOAD:
 			if (!strcmp(optarg, "notify_on_offload"))

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -627,8 +627,6 @@ extern void zebra_vty_init(void);
 
 extern pid_t pid;
 
-extern bool v6_rr_semantics;
-
 extern uint32_t rt_table_main_id;
 
 /* Name of hook calls */

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2209,7 +2209,7 @@ ssize_t netlink_route_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx
 	req->n.nlmsg_flags = NLM_F_CREATE | NLM_F_REQUEST;
 
 	if (((cmd == RTM_NEWROUTE) &&
-	     ((p->family == AF_INET) || v6_rr_semantics)) ||
+	     ((p->family == AF_INET) || zrouter.v6_rr_semantics)) ||
 	    force_rr)
 		req->n.nlmsg_flags |= NLM_F_REPLACE;
 
@@ -3095,8 +3095,7 @@ netlink_put_route_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx)
 	} else if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_INSTALL) {
 		cmd = RTM_NEWROUTE;
 	} else if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_UPDATE) {
-
-		if (p->family == AF_INET || v6_rr_semantics) {
+		if (p->family == AF_INET || zrouter.v6_rr_semantics) {
 			/* Single 'replace' operation */
 
 			/*

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2209,7 +2209,8 @@ ssize_t netlink_route_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx
 	req->n.nlmsg_flags = NLM_F_CREATE | NLM_F_REQUEST;
 
 	if (((cmd == RTM_NEWROUTE) &&
-	     ((p->family == AF_INET) || zrouter.v6_rr_semantics)) ||
+	     ((p->family == AF_INET) || kernel_nexthops_supported() ||
+	      zrouter.v6_rr_semantics)) ||
 	    force_rr)
 		req->n.nlmsg_flags |= NLM_F_REPLACE;
 
@@ -3095,7 +3096,8 @@ netlink_put_route_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx)
 	} else if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_INSTALL) {
 		cmd = RTM_NEWROUTE;
 	} else if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_UPDATE) {
-		if (p->family == AF_INET || zrouter.v6_rr_semantics) {
+		if (p->family == AF_INET || kernel_nexthops_supported() ||
+		    zrouter.v6_rr_semantics) {
 			/* Single 'replace' operation */
 
 			/*

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -209,6 +209,8 @@ struct zebra_router {
 	bool notify_on_ack;
 	bool v6_with_v4_nexthop;
 
+	bool v6_rr_semantics;
+
 	/*
 	 * If the asic is notifying us about successful nexthop
 	 * allocation/control.  Some developers have made their

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -4028,6 +4028,17 @@ static int config_write_protocol(struct vty *vty)
 	return 1;
 }
 
+static inline bool zebra_vty_v6_rr_semantics_used(void)
+{
+	if (zebra_nhg_kernel_nexthops_enabled())
+		return true;
+
+	if (zrouter.v6_rr_semantics)
+		return true;
+
+	return false;
+}
+
 DEFUN (show_zebra,
        show_zebra_cmd,
        "show zebra",
@@ -4048,7 +4059,8 @@ DEFUN (show_zebra,
 	ttable_add_row(table, "EVPN|%s", is_evpn_enabled() ? "On" : "Off");
 	ttable_add_row(table, "Kernel socket buffer size|%d", rcvbufsize);
 	ttable_add_row(table, "v6 Route Replace Semantics|%s",
-		       zrouter.v6_rr_semantics ? "Replace" : "Delete then Add");
+		       zebra_vty_v6_rr_semantics_used() ? "Replace"
+							: "Delete then Add");
 
 #ifdef GNU_LINUX
 	if (!vrf_is_backend_netns())

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -4048,7 +4048,7 @@ DEFUN (show_zebra,
 	ttable_add_row(table, "EVPN|%s", is_evpn_enabled() ? "On" : "Off");
 	ttable_add_row(table, "Kernel socket buffer size|%d", rcvbufsize);
 	ttable_add_row(table, "v6 Route Replace Semantics|%s",
-		       v6_rr_semantics ? "Replace" : "Delete than Add");
+		       zrouter.v6_rr_semantics ? "Replace" : "Delete then Add");
 
 #ifdef GNU_LINUX
 	if (!vrf_is_backend_netns())

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -4047,7 +4047,8 @@ DEFUN (show_zebra,
 	ttable_add_row(table, "MPLS|%s", mpls_enabled ? "On" : "Off");
 	ttable_add_row(table, "EVPN|%s", is_evpn_enabled() ? "On" : "Off");
 	ttable_add_row(table, "Kernel socket buffer size|%d", rcvbufsize);
-
+	ttable_add_row(table, "v6 Route Replace Semantics|%s",
+		       v6_rr_semantics ? "Replace" : "Delete than Add");
 
 #ifdef GNU_LINUX
 	if (!vrf_is_backend_netns())


### PR DESCRIPTION
1) add to `show zebra` the v6_rr_semantics flag
2) Move v6_rr_semantics to zrouter

Long term we need to figure out how to figure this out so we don't need to carry this anymore.  v6_rr_semantics is fixed in latest kernels as far as I can tell now