### PR TITLE
mgmtd: fix local validation

### DIFF
--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -1237,7 +1237,7 @@ static int mgmt_txn_prepare_config(struct mgmt_txn_ctx *txn)
 	nb_ctx.client = NB_CLIENT_MGMTD_SERVER;
 	nb_ctx.user = (void *)txn;
 
-	ret = nb_candidate_validate_yang(nb_config, false, err_buf,
+	ret = nb_candidate_validate_yang(nb_config, true, err_buf,
 					 sizeof(err_buf) - 1);
 	if (ret != NB_OK) {
 		if (strncmp(err_buf, " ", strlen(err_buf)) == 0)


### PR DESCRIPTION
When validating the config, we shouldn't also validate state.