### PR TITLE
bgpd:aspath leak fix

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -1407,7 +1407,8 @@ struct aspath *aspath_remove_private_asns(struct aspath *aspath, as_t peer_asn)
 		last_new_seg = new_seg;
 		seg = seg->next;
 	}
-
+	if (!aspath->refcnt)
+		aspath_free(aspath);
 	aspath_str_update(new, false);
 	return new;
 }


### PR DESCRIPTION
The function aspath_remove_private_asns was using an aspath to perform some operation and didn't free it after usage leading to the leak below.

```*********************************************************************************** Address Sanitizer Error detected in bgp_remove_private_as_route_map.test_bgp_remove_private_as_route_map/r2.asan.bgpd.27074

================================================================= ==27074==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 80 byte(s) in 2 object(s) allocated from:
    #0 0x7fd0a4b95d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7fd0a45932ff in qcalloc lib/memory.c:105
    #2 0x562b630b44cc in aspath_dup bgpd/bgp_aspath.c:689
    #3 0x562b62f48498 in route_set_aspath_prepend bgpd/bgp_routemap.c:2283
    #4 0x7fd0a45ec39a in route_map_apply_ext lib/routemap.c:2690
    #5 0x562b62efbb1f in subgroup_announce_check bgpd/bgp_route.c:2434
    #6 0x562b62efd4e2 in subgroup_process_announce_selected bgpd/bgp_route.c:2990
    #7 0x562b62f6a829 in subgroup_announce_table bgpd/bgp_updgrp_adv.c:765
    #8 0x562b62f6acbb in subgroup_announce_route bgpd/bgp_updgrp_adv.c:818
    #9 0x562b62f6ae90 in subgroup_coalesce_timer bgpd/bgp_updgrp_adv.c:368
    #10 0x7fd0a463322a in event_call lib/event.c:1970
    #11 0x7fd0a4576566 in frr_run lib/libfrr.c:1214
    #12 0x562b62dbd8f1 in main bgpd/bgp_main.c:510
    #13 0x7fd0a35b8c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 80 byte(s) in 2 object(s) allocated from:
    #0 0x7fd0a4b95d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7fd0a45932ff in qcalloc lib/memory.c:105
    #2 0x562b630b44cc in aspath_dup bgpd/bgp_aspath.c:689
    #3 0x562b62f48498 in route_set_aspath_prepend bgpd/bgp_routemap.c:2283
    #4 0x7fd0a45ec39a in route_map_apply_ext lib/routemap.c:2690
    #5 0x562b62efbb1f in subgroup_announce_check bgpd/bgp_route.c:2434
    #6 0x562b62efd4e2 in subgroup_process_announce_selected bgpd/bgp_route.c:2990
    #7 0x562b62f6a829 in subgroup_announce_table bgpd/bgp_updgrp_adv.c:765
    #8 0x562b62f6acbb in subgroup_announce_route bgpd/bgp_updgrp_adv.c:818
    #9 0x562b62f5b844 in updgrp_policy_update_walkcb bgpd/bgp_updgrp.c:1685
    #10 0x562b62f59442 in update_group_walkcb bgpd/bgp_updgrp.c:1721
    #11 0x7fd0a455a7aa in hash_walk lib/hash.c:270
    #12 0x562b62f64a48 in update_group_af_walk bgpd/bgp_updgrp.c:2062
    #13 0x562b62f6508c in update_group_walk bgpd/bgp_updgrp.c:2071
    #14 0x562b62f6520c in update_group_policy_update bgpd/bgp_updgrp.c:1769
    #15 0x562b62f4c2be in bgp_route_map_process_update bgpd/bgp_routemap.c:4501
    #16 0x562b62f4d81a in bgp_route_map_process_update_cb bgpd/bgp_routemap.c:4683
    #17 0x7fd0a45ed7e8 in route_map_walk_update_list lib/routemap.c:870
    #18 0x562b62f337a2 in bgp_route_map_update_timer bgpd/bgp_routemap.c:4695
    #19 0x7fd0a463322a in event_call lib/event.c:1970
    #20 0x7fd0a4576566 in frr_run lib/libfrr.c:1214
    #21 0x562b62dbd8f1 in main bgpd/bgp_main.c:510
    #22 0x7fd0a35b8c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 64 byte(s) in 2 object(s) allocated from:
    #0 0x7fd0a4b95b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7fd0a459301f in qmalloc lib/memory.c:100
    #2 0x562b630b313f in aspath_make_str_count bgpd/bgp_aspath.c:551
    #3 0x562b630b3ecf in aspath_str_update bgpd/bgp_aspath.c:659
    #4 0x562b630b88b7 in aspath_prepend bgpd/bgp_aspath.c:1484
    #5 0x562b62f484a8 in route_set_aspath_prepend bgpd/bgp_routemap.c:2289
    #6 0x7fd0a45ec39a in route_map_apply_ext lib/routemap.c:2690
    #7 0x562b62efbb1f in subgroup_announce_check bgpd/bgp_route.c:2434
    #8 0x562b62efd4e2 in subgroup_process_announce_selected bgpd/bgp_route.c:2990
    #9 0x562b62f6a829 in subgroup_announce_table bgpd/bgp_updgrp_adv.c:765
    #10 0x562b62f6acbb in subgroup_announce_route bgpd/bgp_updgrp_adv.c:818
    #11 0x562b62f6ae90 in subgroup_coalesce_timer bgpd/bgp_updgrp_adv.c:368
    #12 0x7fd0a463322a in event_call lib/event.c:1970
    #13 0x7fd0a4576566 in frr_run lib/libfrr.c:1214
    #14 0x562b62dbd8f1 in main bgpd/bgp_main.c:510
    #15 0x7fd0a35b8c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 64 byte(s) in 2 object(s) allocated from:
    #0 0x7fd0a4b95b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7fd0a459301f in qmalloc lib/memory.c:100
    #2 0x562b630b313f in aspath_make_str_count bgpd/bgp_aspath.c:551
    #3 0x562b630b3ecf in aspath_str_update bgpd/bgp_aspath.c:659
    #4 0x562b630b88b7 in aspath_prepend bgpd/bgp_aspath.c:1484
    #5 0x562b62f484a8 in route_set_aspath_prepend bgpd/bgp_routemap.c:2289
    #6 0x7fd0a45ec39a in route_map_apply_ext lib/routemap.c:2690
    #7 0x562b62efbb1f in subgroup_announce_check bgpd/bgp_route.c:2434
    #8 0x562b62efd4e2 in subgroup_process_announce_selected bgpd/bgp_route.c:2990
    #9 0x562b62f6a829 in subgroup_announce_table bgpd/bgp_updgrp_adv.c:765
    #10 0x562b62f6acbb in subgroup_announce_route bgpd/bgp_updgrp_adv.c:818
    #11 0x562b62f5b844 in updgrp_policy_update_walkcb bgpd/bgp_updgrp.c:1685
    #12 0x562b62f59442 in update_group_walkcb bgpd/bgp_updgrp.c:1721
    #13 0x7fd0a455a7aa in hash_walk lib/hash.c:270
    #14 0x562b62f64a48 in update_group_af_walk bgpd/bgp_updgrp.c:2062
    #15 0x562b62f6508c in update_group_walk bgpd/bgp_updgrp.c:2071
    #16 0x562b62f6520c in update_group_policy_update bgpd/bgp_updgrp.c:1769
    #17 0x562b62f4c2be in bgp_route_map_process_update bgpd/bgp_routemap.c:4501
    #18 0x562b62f4d81a in bgp_route_map_process_update_cb bgpd/bgp_routemap.c:4683
    #19 0x7fd0a45ed7e8 in route_map_walk_update_list lib/routemap.c:870
    #20 0x562b62f337a2 in bgp_route_map_update_timer bgpd/bgp_routemap.c:4695
    #21 0x7fd0a463322a in event_call lib/event.c:1970
    #22 0x7fd0a4576566 in frr_run lib/libfrr.c:1214
    #23 0x562b62dbd8f1 in main bgpd/bgp_main.c:510
    #24 0x7fd0a35b8c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 48 byte(s) in 2 object(s) allocated from:
    #0 0x7fd0a4b95d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7fd0a45932ff in qcalloc lib/memory.c:105
    #2 0x562b630b280d in assegment_new bgpd/bgp_aspath.c:105
    #3 0x562b630b28f7 in assegment_dup bgpd/bgp_aspath.c:145
    #4 0x562b630b29e8 in assegment_dup_all bgpd/bgp_aspath.c:162
    #5 0x562b630b8895 in aspath_prepend bgpd/bgp_aspath.c:1483
    #6 0x562b62f484a8 in route_set_aspath_prepend bgpd/bgp_routemap.c:2289
    #7 0x7fd0a45ec39a in route_map_apply_ext lib/routemap.c:2690
    #8 0x562b62efbb1f in subgroup_announce_check bgpd/bgp_route.c:2434
    #9 0x562b62efd4e2 in subgroup_process_announce_selected bgpd/bgp_route.c:2990
    #10 0x562b62f6a829 in subgroup_announce_table bgpd/bgp_updgrp_adv.c:765
    #11 0x562b62f6acbb in subgroup_announce_route bgpd/bgp_updgrp_adv.c:818
    #12 0x562b62f5b844 in updgrp_policy_update_walkcb bgpd/bgp_updgrp.c:1685
    #13 0x562b62f59442 in update_group_walkcb bgpd/bgp_updgrp.c:1721
    #14 0x7fd0a455a7aa in hash_walk lib/hash.c:270
    #15 0x562b62f64a48 in update_group_af_walk bgpd/bgp_updgrp.c:2062
    #16 0x562b62f6508c in update_group_walk bgpd/bgp_updgrp.c:2071
    #17 0x562b62f6520c in update_group_policy_update bgpd/bgp_updgrp.c:1769
    #18 0x562b62f4c2be in bgp_route_map_process_update bgpd/bgp_routemap.c:4501
    #19 0x562b62f4d81a in bgp_route_map_process_update_cb bgpd/bgp_routemap.c:4683
    #20 0x7fd0a45ed7e8 in route_map_walk_update_list lib/routemap.c:870
    #21 0x562b62f337a2 in bgp_route_map_update_timer bgpd/bgp_routemap.c:4695
    #22 0x7fd0a463322a in event_call lib/event.c:1970
    #23 0x7fd0a4576566 in frr_run lib/libfrr.c:1214
    #24 0x562b62dbd8f1 in main bgpd/bgp_main.c:510
    #25 0x7fd0a35b8c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 48 byte(s) in 2 object(s) allocated from:
    #0 0x7fd0a4b95d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7fd0a45932ff in qcalloc lib/memory.c:105
    #2 0x562b630b280d in assegment_new bgpd/bgp_aspath.c:105
    #3 0x562b630b28f7 in assegment_dup bgpd/bgp_aspath.c:145
    #4 0x562b630b29e8 in assegment_dup_all bgpd/bgp_aspath.c:162
    #5 0x562b630b8895 in aspath_prepend bgpd/bgp_aspath.c:1483
    #6 0x562b62f484a8 in route_set_aspath_prepend bgpd/bgp_routemap.c:2289
    #7 0x7fd0a45ec39a in route_map_apply_ext lib/routemap.c:2690
    #8 0x562b62efbb1f in subgroup_announce_check bgpd/bgp_route.c:2434
    #9 0x562b62efd4e2 in subgroup_process_announce_selected bgpd/bgp_route.c:2990
    #10 0x562b62f6a829 in subgroup_announce_table bgpd/bgp_updgrp_adv.c:765
    #11 0x562b62f6acbb in subgroup_announce_route bgpd/bgp_updgrp_adv.c:818
    #12 0x562b62f6ae90 in subgroup_coalesce_timer bgpd/bgp_updgrp_adv.c:368
    #13 0x7fd0a463322a in event_call lib/event.c:1970
    #14 0x7fd0a4576566 in frr_run lib/libfrr.c:1214
    #15 0x562b62dbd8f1 in main bgpd/bgp_main.c:510
    #16 0x7fd0a35b8c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 16 byte(s) in 2 object(s) allocated from:
    #0 0x7fd0a4b95b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7fd0a459301f in qmalloc lib/memory.c:100
    #2 0x562b630b2879 in assegment_data_new bgpd/bgp_aspath.c:83
    #3 0x562b630b2879 in assegment_new bgpd/bgp_aspath.c:108
    #4 0x562b630b28f7 in assegment_dup bgpd/bgp_aspath.c:145
    #5 0x562b630b29e8 in assegment_dup_all bgpd/bgp_aspath.c:162
    #6 0x562b630b8895 in aspath_prepend bgpd/bgp_aspath.c:1483
    #7 0x562b62f484a8 in route_set_aspath_prepend bgpd/bgp_routemap.c:2289
    #8 0x7fd0a45ec39a in route_map_apply_ext lib/routemap.c:2690
    #9 0x562b62efbb1f in subgroup_announce_check bgpd/bgp_route.c:2434
    #10 0x562b62efd4e2 in subgroup_process_announce_selected bgpd/bgp_route.c:2990
    #11 0x562b62f6a829 in subgroup_announce_table bgpd/bgp_updgrp_adv.c:765
    #12 0x562b62f6acbb in subgroup_announce_route bgpd/bgp_updgrp_adv.c:818
    #13 0x562b62f6ae90 in subgroup_coalesce_timer bgpd/bgp_updgrp_adv.c:368
    #14 0x7fd0a463322a in event_call lib/event.c:1970
    #15 0x7fd0a4576566 in frr_run lib/libfrr.c:1214
    #16 0x562b62dbd8f1 in main bgpd/bgp_main.c:510
    #17 0x7fd0a35b8c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 16 byte(s) in 2 object(s) allocated from:
    #0 0x7fd0a4b95b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7fd0a459301f in qmalloc lib/memory.c:100
    #2 0x562b630b2879 in assegment_data_new bgpd/bgp_aspath.c:83
    #3 0x562b630b2879 in assegment_new bgpd/bgp_aspath.c:108
    #4 0x562b630b28f7 in assegment_dup bgpd/bgp_aspath.c:145
    #5 0x562b630b29e8 in assegment_dup_all bgpd/bgp_aspath.c:162
    #6 0x562b630b8895 in aspath_prepend bgpd/bgp_aspath.c:1483
    #7 0x562b62f484a8 in route_set_aspath_prepend bgpd/bgp_routemap.c:2289
    #8 0x7fd0a45ec39a in route_map_apply_ext lib/routemap.c:2690
    #9 0x562b62efbb1f in subgroup_announce_check bgpd/bgp_route.c:2434
    #10 0x562b62efd4e2 in subgroup_process_announce_selected bgpd/bgp_route.c:2990
    #11 0x562b62f6a829 in subgroup_announce_table bgpd/bgp_updgrp_adv.c:765
    #12 0x562b62f6acbb in subgroup_announce_route bgpd/bgp_updgrp_adv.c:818
    #13 0x562b62f5b844 in updgrp_policy_update_walkcb bgpd/bgp_updgrp.c:1685
    #14 0x562b62f59442 in update_group_walkcb bgpd/bgp_updgrp.c:1721
    #15 0x7fd0a455a7aa in hash_walk lib/hash.c:270
    #16 0x562b62f64a48 in update_group_af_walk bgpd/bgp_updgrp.c:2062
    #17 0x562b62f6508c in update_group_walk bgpd/bgp_updgrp.c:2071
    #18 0x562b62f6520c in update_group_policy_update bgpd/bgp_updgrp.c:1769
    #19 0x562b62f4c2be in bgp_route_map_process_update bgpd/bgp_routemap.c:4501
    #20 0x562b62f4d81a in bgp_route_map_process_update_cb bgpd/bgp_routemap.c:4683
    #21 0x7fd0a45ed7e8 in route_map_walk_update_list lib/routemap.c:870
    #22 0x562b62f337a2 in bgp_route_map_update_timer bgpd/bgp_routemap.c:4695
    #23 0x7fd0a463322a in event_call lib/event.c:1970
    #24 0x7fd0a4576566 in frr_run lib/libfrr.c:1214
    #25 0x562b62dbd8f1 in main bgpd/bgp_main.c:510
    #26 0x7fd0a35b8c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 416 byte(s) leaked in 16 allocation(s). ***********************************************************************************```