### PR TITLE
lib, mgmtd: respect base xpath in mgmtd

### DIFF
--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -426,8 +426,7 @@ static int mgmt_be_txn_cfg_prepare(struct mgmt_be_txn_ctx *txn)
 				client_ctx->candidate_config,
 				txn_req->req.set_cfg.cfg_changes,
 				(size_t)txn_req->req.set_cfg.num_cfg_changes,
-				NULL, NULL, 0, err_buf, sizeof(err_buf),
-				&error);
+				NULL, err_buf, sizeof(err_buf), &error);
 			if (error) {
 				err_buf[sizeof(err_buf) - 1] = 0;
 				MGMTD_BE_CLIENT_ERR(

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -763,8 +763,8 @@ static bool nb_is_operation_allowed(struct nb_node *nb_node,
 
 void nb_candidate_edit_config_changes(
 	struct nb_config *candidate_config, struct nb_cfg_change cfg_changes[],
-	size_t num_cfg_changes, const char *xpath_base, const char *curr_xpath,
-	int xpath_index, char *err_buf, int err_bufsize, bool *error)
+	size_t num_cfg_changes, const char *xpath_base, char *err_buf,
+	int err_bufsize, bool *error)
 {
 	if (error)
 		*error = false;
@@ -776,25 +776,18 @@ void nb_candidate_edit_config_changes(
 	for (size_t i = 0; i < num_cfg_changes; i++) {
 		struct nb_cfg_change *change = &cfg_changes[i];
 		struct nb_node *nb_node;
+		char *change_xpath = change->xpath;
 		char xpath[XPATH_MAXLEN];
 		struct yang_data *data;
 		int ret;
 
-		/* Handle relative XPaths. */
 		memset(xpath, 0, sizeof(xpath));
-		if (xpath_index > 0 &&
-		    (xpath_base[0] == '.' || change->xpath[0] == '.'))
-			strlcpy(xpath, curr_xpath, sizeof(xpath));
-		if (xpath_base[0]) {
-			if (xpath_base[0] == '.')
-				strlcat(xpath, xpath_base + 1, sizeof(xpath));
-			else
-				strlcat(xpath, xpath_base, sizeof(xpath));
+		/* If change xpath is relative, prepend base xpath. */
+		if (change_xpath[0] == '.') {
+			strlcpy(xpath, xpath_base, sizeof(xpath));
+			change_xpath++; /* skip '.' */
 		}
-		if (change->xpath[0] == '.')
-			strlcat(xpath, change->xpath + 1, sizeof(xpath));
-		else
-			strlcpy(xpath, change->xpath, sizeof(xpath));
+		strlcat(xpath, change_xpath, sizeof(xpath));
 
 		/* Find the northbound node associated to the data path. */
 		nb_node = nb_node_find(xpath);

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -916,12 +916,6 @@ extern bool nb_candidate_needs_update(const struct nb_config *candidate);
  * xpath_base
  *    Base xpath for config.
  *
- * curr_xpath
- *    Current xpath for config.
- *
- * xpath_index
- *    Index of xpath being processed.
- *
  * err_buf
  *    Buffer to store human-readable error message in case of error.
  *
@@ -933,8 +927,8 @@ extern bool nb_candidate_needs_update(const struct nb_config *candidate);
  */
 extern void nb_candidate_edit_config_changes(
 	struct nb_config *candidate_config, struct nb_cfg_change cfg_changes[],
-	size_t num_cfg_changes, const char *xpath_base, const char *curr_xpath,
-	int xpath_index, char *err_buf, int err_bufsize, bool *error);
+	size_t num_cfg_changes, const char *xpath_base, char *err_buf,
+	int err_bufsize, bool *error);
 
 /*
  * Delete candidate configuration changes.

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -412,7 +412,8 @@ extern bool vty_mgmt_fe_enabled(void);
 extern bool vty_mgmt_should_process_cli_apply_changes(struct vty *vty);
 
 extern bool mgmt_vty_read_configs(void);
-extern int vty_mgmt_send_config_data(struct vty *vty, bool implicit_commit);
+extern int vty_mgmt_send_config_data(struct vty *vty, const char *xpath_base,
+				     bool implicit_commit);
 extern int vty_mgmt_send_commit_config(struct vty *vty, bool validate_only,
 				       bool abort);
 extern int vty_mgmt_send_get_req(struct vty *vty, bool is_config,

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -664,8 +664,8 @@ static void mgmt_txn_process_set_cfg(struct event *thread)
 						 txn_req->req.set_cfg->cfg_changes,
 						 (size_t)txn_req->req.set_cfg
 							 ->num_cfg_changes,
-						 NULL, NULL, 0, err_buf,
-						 sizeof(err_buf), &error);
+						 NULL, err_buf, sizeof(err_buf),
+						 &error);
 		if (error) {
 			mgmt_fe_send_set_cfg_reply(txn->session_id, txn->txn_id,
 						   txn_req->req.set_cfg->ds_id,

--- a/mgmtd/mgmt_vty.c
+++ b/mgmtd/mgmt_vty.c
@@ -157,7 +157,7 @@ DEFPY(mgmt_set_config_data, mgmt_set_config_data_cmd,
 	vty->cfg_changes[0].operation = NB_OP_CREATE;
 	vty->num_cfg_changes = 1;
 
-	vty_mgmt_send_config_data(vty, false);
+	vty_mgmt_send_config_data(vty, NULL, false);
 	return CMD_SUCCESS;
 }
 
@@ -174,7 +174,7 @@ DEFPY(mgmt_delete_config_data, mgmt_delete_config_data_cmd,
 	vty->cfg_changes[0].operation = NB_OP_DESTROY;
 	vty->num_cfg_changes = 1;
 
-	vty_mgmt_send_config_data(vty, false);
+	vty_mgmt_send_config_data(vty, NULL, false);
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
`nb_cli_apply_changes` can be called with base xpath which should be prepended to xpaths of every change in a transaction. This base xpath is respected by regular northbound CLI but not by mgmtd. This commit fixes the problem.