### PR TITLE
lib: mgmtd: fix debug cli commands and memleaks

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -88,6 +88,8 @@ enum node_type {
 	DEBUG_VNC_NODE,		 /* Debug VNC node. */
 	RMAP_DEBUG_NODE,         /* Route-map debug node */
 	RESOLVER_DEBUG_NODE,	 /* Resolver debug node */
+	MGMT_BE_DEBUG_NODE,	 /* mgmtd backend-client debug node */
+	MGMT_FE_DEBUG_NODE,	 /* mgmtd frontend-client debug node */
 	AAA_NODE,		 /* AAA node. */
 	EXTLOG_NODE,		 /* RFC5424 & co. extended syslog */
 	KEYCHAIN_NODE,		 /* Key-chain node. */

--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -880,7 +880,7 @@ static void mgmt_debug_client_be_set_all(uint32_t flags, bool set)
 static int mgmt_debug_be_client_config_write(struct vty *vty)
 {
 	if (DEBUG_MODE_CHECK(&mgmt_dbg_be_client, DEBUG_MODE_CONF))
-		vty_out(vty, "debug mgmt client frontend\n");
+		vty_out(vty, "debug mgmt client backend\n");
 
 	return 1;
 }
@@ -895,8 +895,8 @@ static struct debug_callbacks mgmt_dbg_be_client_cbs = {
 	.debug_set_all = mgmt_debug_client_be_set_all};
 
 static struct cmd_node mgmt_dbg_node = {
-	.name = "mgmt backend client",
-	.node = DEBUG_NODE,
+	.name = "debug mgmt client backend",
+	.node = MGMT_BE_DEBUG_NODE,
 	.prompt = "",
 	.config_write = mgmt_debug_be_client_config_write,
 };

--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -580,8 +580,8 @@ static struct debug_callbacks mgmt_dbg_fe_client_cbs = {
 	.debug_set_all = mgmt_debug_client_fe_set_all};
 
 static struct cmd_node mgmt_dbg_node = {
-	.name = "mgmt client frontend",
-	.node = DEBUG_NODE,
+	.name = "debug mgmt client frontend",
+	.node = MGMT_FE_DEBUG_NODE,
 	.prompt = "",
 	.config_write = mgmt_debug_fe_client_config_write,
 };

--- a/mgmtd/mgmt_vty.c
+++ b/mgmtd/mgmt_vty.c
@@ -379,7 +379,7 @@ DEFPY(mgmt_rollback,
 
 int config_write_mgmt_debug(struct vty *vty);
 static struct cmd_node debug_node = {
-	.name = "debug",
+	.name = "mgmt debug",
 	.node = DEBUG_NODE,
 	.prompt = "",
 	.config_write = config_write_mgmt_debug,

--- a/tools/valgrind.supp
+++ b/tools/valgrind.supp
@@ -24,6 +24,15 @@
    fun:zprivs_caps_init
 }
 {
+   <zprivs_init leak in library code we do not control>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:getgrouplist
+   fun:zprivs_init
+   fun:frr_init
+}
+{
    <sqlite3 leak in a function we do not control>
    Memcheck:Leak
    fun:malloc

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -455,6 +455,12 @@ void vtysh_config_parse_line(void *arg, const char *line)
 		else if (strncmp(line, "debug resolver",
 				 strlen("debug resolver")) == 0)
 			config = config_get(RESOLVER_DEBUG_NODE, line);
+		else if (strncmp(line, "debug mgmt client frontend",
+				 strlen("debug mgmt client frontend")) == 0)
+			config = config_get(MGMT_FE_DEBUG_NODE, line);
+		else if (strncmp(line, "debug mgmt client backend",
+				 strlen("debug mgmt client backend")) == 0)
+			config = config_get(MGMT_BE_DEBUG_NODE, line);
 		else if (strncmp(line, "debug", strlen("debug")) == 0)
 			config = config_get(DEBUG_NODE, line);
 		else if (strncmp(line, "password", strlen("password")) == 0


### PR DESCRIPTION
- Cannot have 2 cmd_node's with same .node number. Install the mgmtd client library debug nodes (client frontend and client backend) using new unique node numbers. Fixes memleaks.

- Fix "debug mgmt client backend" to generate correct config (and not for frontend).

- Also suppress some normal external lib reachable valgrind memleaks, this allows a clean valgrind run with memleak type "all"