### PR TITLE
lib: darr needs to use memory.h for both alloc and free

### DIFF
--- a/lib/darr.c
+++ b/lib/darr.c
@@ -9,7 +9,7 @@
 #include "darr.h"
 #include "memory.h"
 
-DEFINE_MTYPE_STATIC(LIB, DARR, "Dynamic Array");
+DEFINE_MTYPE(LIB, DARR, "Dynamic Array");
 
 static uint _msb(uint count)
 {

--- a/lib/darr.h
+++ b/lib/darr.h
@@ -35,6 +35,9 @@
  * - DAs will never have capacity 0 unless they are NULL pointers.
  */
 #include <zebra.h>
+#include "memory.h"
+
+DECLARE_MTYPE(DARR);
 
 struct darr_metadata {
 	uint len;
@@ -111,7 +114,8 @@ void *__darr_resize(void *a, uint count, size_t esize);
 #define darr_free(A)                                                           \
 	do {                                                                   \
 		if ((A)) {                                                     \
-			free(_darr_meta(A));                                   \
+			void *__ptr = _darr_meta(A);                           \
+			XFREE(MTYPE_DARR, __ptr);                              \
 			(A) = NULL;                                            \
 		}                                                              \
 	} while (0)


### PR DESCRIPTION
Was using XREALLOC() and then free(). instant "memleaks".