### PR TITLE
bgpd: fix build error

### DIFF
--- a/bgpd/bgp_snmp_bgp4v2.c
+++ b/bgpd/bgp_snmp_bgp4v2.c
@@ -602,7 +602,7 @@ bgp4v2PathAttrLookup(struct variable *v, oid name[], size_t *length,
 			family = AF_INET;
 		else
 			family = AF_INET6;
-		memset(&paddr.ip._v4_addr, 0, sizeof(paddr.ip));
+		memset(&paddr.ip, 0, sizeof(paddr.ip));
 	}
 
 	do {


### PR DESCRIPTION
I recieve the following error with GCC 9.4.0:
```
In file included from /usr/include/string.h:495,
                 from ./lib/zebra.h:23,
                 from bgpd/bgp_snmp_bgp4v2.c:7:
In function ‘memset’,
    inlined from ‘bgp4v2PathAttrLookup’ at bgpd/bgp_snmp_bgp4v2.c:605:3,
    inlined from ‘bgp4v2PathAttrTable’ at bgpd/bgp_snmp_bgp4v2.c:747:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:71:10: error: ‘__builtin_memset’ offset [9, 20] from the object at ‘paddr’ is out of the bounds of referenced subobject ‘_v4_addr’ with type ‘struct in_addr’ at offset 4 [-Werror=array-bounds]
   71 |   return __builtin___memset_chk (__dest, __ch, __len, __bos0 (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```