### PR TITLE
bgpd: fix coverity issue in bgp_snmp_bgp4v2.c

### DIFF
--- a/bgpd/bgp_snmp_bgp4v2.c
+++ b/bgpd/bgp_snmp_bgp4v2.c
@@ -452,6 +452,7 @@ bgp4v2PathAttrLookup(struct variable *v, oid name[], size_t *length,
 		return NULL;
 	afi = afi_iana2int(name[namelen - 1]);
 	afi_len = afi == AFI_IP ? IN_ADDR_SIZE : IN6_ADDR_SIZE;
+	assert(IS_VALID_AFI(afi));
 
 #define BGP_NLRI_ENTRY_OFFSET namelen
 


### PR DESCRIPTION
CID 1570969 Overrun
/bgpd/bgp_snmp_bgp4v2.c: 534 in bgp4v2PathAttrLookup() /bgpd/bgp_snmp_bgp4v2.c: 575 in bgp4v2PathAttrLookup() /bgpd/bgp_snmp_bgp4v2.c: 514 in bgp4v2PathAttrLookup()

>>>     CID 1570969:    (OVERRUN)
>>>     Overrunning array "bgp->rib" of 4 64-byte elements at element index 4 (byte offset 319) using index "afi" (which evaluates to 4).