### PR TITLE
Revert "ospfd: fix per-interface sockets"

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -271,10 +271,6 @@ struct ospf_interface *ospf_if_new(struct ospf *ospf, struct interface *ifp,
 
 	QOBJ_REG(oi, ospf_interface);
 
-	/* If first oi, check per-intf write socket */
-	if (ospf->oi_running && ospf->intf_socket_enabled)
-		ospf_ifp_sock_init(ifp);
-
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("%s: ospf interface %s vrf %s id %u created",
 			   __func__, ifp->name, ospf_get_name(ospf),
@@ -331,8 +327,6 @@ void ospf_if_cleanup(struct ospf_interface *oi)
 
 void ospf_if_free(struct ospf_interface *oi)
 {
-	struct interface *ifp = oi->ifp;
-
 	ospf_if_down(oi);
 
 	ospf_fifo_free(oi->obuf);
@@ -366,10 +360,6 @@ void ospf_if_free(struct ospf_interface *oi)
 	listnode_delete(oi->area->oiflist, oi);
 
 	event_cancel_event(master, oi);
-
-	/* If last oi, close per-interface socket */
-	if (ospf_oi_count(ifp) == 0)
-		ospf_ifp_sock_close(ifp);
 
 	memset(oi, 0, sizeof(*oi));
 	XFREE(MTYPE_OSPF_IF, oi);
@@ -1426,8 +1416,7 @@ static int ospf_ifp_up(struct interface *ifp)
 
 	/* Open per-intf write socket if configured */
 	ospf = ifp->vrf->info;
-
-	if (ospf && ospf->oi_running && ospf->intf_socket_enabled)
+	if (ospf && ospf->intf_socket_enabled)
 		ospf_ifp_sock_init(ifp);
 
 	ospf_if_recalculate_output_cost(ifp);

--- a/ospfd/ospf_network.c
+++ b/ospfd/ospf_network.c
@@ -159,8 +159,7 @@ int ospf_if_ipmulticast(int fd, struct prefix *p, ifindex_t ifindex)
  * Helper to open and set up a socket; returns the new fd on success,
  * -1 on error.
  */
-static int sock_init_common(vrf_id_t vrf_id, const char *name, int proto,
-			    int *pfd)
+static int sock_init_common(vrf_id_t vrf_id, const char *name, int *pfd)
 {
 	int ospf_sock;
 	int ret, hincl = 1;
@@ -171,7 +170,8 @@ static int sock_init_common(vrf_id_t vrf_id, const char *name, int proto,
 	}
 
 	frr_with_privs(&ospfd_privs) {
-		ospf_sock = vrf_socket(AF_INET, SOCK_RAW, proto, vrf_id, name);
+		ospf_sock = vrf_socket(AF_INET, SOCK_RAW, IPPROTO_OSPFIGP,
+				       vrf_id, name);
 		if (ospf_sock < 0) {
 			flog_err(EC_LIB_SOCKET, "%s: socket: %s", __func__,
 				 safe_strerror(errno));
@@ -244,8 +244,7 @@ int ospf_sock_init(struct ospf *ospf)
 	if (ospf->fd > 0)
 		return -1;
 
-	ret = sock_init_common(ospf->vrf_id, ospf->name, IPPROTO_OSPFIGP,
-			       &(ospf->fd));
+	ret = sock_init_common(ospf->vrf_id, ospf->name, &(ospf->fd));
 
 	if (ret >= 0) /* Update socket buffer sizes */
 		ospf_sock_bufsize_update(ospf, ospf->fd, OSPF_SOCK_BOTH);
@@ -259,8 +258,8 @@ int ospf_sock_init(struct ospf *ospf)
 int ospf_ifp_sock_init(struct interface *ifp)
 {
 	struct ospf_if_info *oii;
-	struct ospf_interface *oi = NULL;
-	struct ospf *ospf = NULL;
+	struct ospf_interface *oi;
+	struct ospf *ospf;
 	struct route_node *rn;
 	int ret;
 
@@ -271,26 +270,17 @@ int ospf_ifp_sock_init(struct interface *ifp)
 	if (oii->oii_fd > 0)
 		return 0;
 
-	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
-		if (rn && rn->info) {
-			oi = rn->info;
-			ospf = oi->ospf;
-			break;
-		}
-	}
-
-	if (ospf == NULL)
+	rn = route_top(IF_OIFS(ifp));
+	if (rn && rn->info) {
+		oi = rn->info;
+		ospf = oi->ospf;
+	} else
 		return -1;
 
-	ret = sock_init_common(ifp->vrf->vrf_id, ifp->name, IPPROTO_OSPFIGP,
-			       &oii->oii_fd);
+	ret = sock_init_common(ifp->vrf->vrf_id, ifp->name, &oii->oii_fd);
 
-	if (ret >= 0) { /* Update socket buffer sizes */
-		/* Write-only, so no recv buf */
-		setsockopt_so_recvbuf(oii->oii_fd, 0);
-
-		ospf_sock_bufsize_update(ospf, oii->oii_fd, OSPF_SOCK_SEND);
-	}
+	if (ret >= 0) /* Update socket buffer sizes */
+		ospf_sock_bufsize_update(ospf, oii->oii_fd, OSPF_SOCK_BOTH);
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("%s: ifp %s, oii %p, fd %d", __func__, ifp->name,


### PR DESCRIPTION
This reverts commit 60b77869e554b6d2b38ea507031926f4effe390a.

A regression seen and vtysh is hanging on FreeBSD systems where OSPF is enabled per interface.

Issue: https://github.com/FRRouting/frr/issues/14790