### PR TITLE
pim6d: Fix memory leaks

### DIFF
--- a/pimd/pim6_main.c
+++ b/pimd/pim6_main.c
@@ -26,6 +26,7 @@
 #include "pim_nb.h"
 #include "pim6_cmd.h"
 #include "pim6_mld.h"
+#include "pim_zlookup.h"
 
 zebra_capabilities_t _caps_p[] = {
 	ZCAP_SYS_ADMIN,
@@ -189,11 +190,20 @@ int main(int argc, char **argv, char **envp)
 
 static void pim6_terminate(void)
 {
+	struct zclient *zclient;
+
 	pim_vrf_terminate();
 	pim_router_terminate();
 
 	prefix_list_reset();
 	access_list_reset();
 
+	zclient = pim_zebra_zclient_get();
+	if (zclient) {
+		zclient_stop(zclient);
+		zclient_free(zclient);
+	}
+
+	zclient_lookup_free();
 	frr_fini();
 }


### PR DESCRIPTION
**Problem Statement:**
Mentioning few of the leaks here:

=3843268== 6 bytes in 3 blocks are still reachable in loss record 1 of 29
==3843268==    at 0x483C855: malloc (vg_replace_malloc.c:381)
==3843268==    by 0x489ED0E: qmalloc (memory.c:106)
==3843268==    by 0x48DE8DB: redist_add_instance (zclient.c:125)
==3843268==    by 0x48DF561: zclient_init (zclient.c:647)
==3843268==    by 0x14FFA3: pim_zebra_init (pim_zebra.c:527)
==3843268==    by 0x11D021: main (pim6_main.c:178)
==3843268==
==3843268== 24 bytes in 1 blocks are still reachable in loss record 2 of 29
==3843268==    at 0x484147B: calloc (vg_replace_malloc.c:1328)
==3843268==    by 0x489EE03: qcalloc (memory.c:111)
==3843268==    by 0x4878DDE: buffer_new (buffer.c:72)
==3843268==    by 0x48DE7BF: zclient_new (zclient.c:75)
==3843268==    by 0x14FF1D: pim_zebra_init (pim_zebra.c:516)
==3843268==    by 0x11D021: main (pim6_main.c:178)
==3843268==
==3843268== 24 bytes in 1 blocks are still reachable in loss record 3 of 29
==3843268==    at 0x484147B: calloc (vg_replace_malloc.c:1328)
==3843268==    by 0x489EE03: qcalloc (memory.c:111)
==3843268==    by 0x4878DDE: buffer_new (buffer.c:72)
==3843268==    by 0x48DE7BF: zclient_new (zclient.c:75)
==3843268==    by 0x150A3D: zclient_lookup_new (pim_zlookup.c:131)
==3843268==    by 0x11D021: main (pim6_main.c:178)

**RCA:**
Memory is allocated when the daemon started but
it is not freed when terminated.

**Fix:**
Freeing the memory when daemon goes down.