### PR TITLE
lib: Prevent infinite loop in ospf

### DIFF
--- a/lib/sockopt.c
+++ b/lib/sockopt.c
@@ -23,9 +23,12 @@ void setsockopt_so_recvbuf(int sock, int size)
 {
 	int orig_req = size;
 
-	while (setsockopt(sock, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size))
-	       == -1)
+	while (setsockopt(sock, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size)) ==
+	       -1) {
+		if (size == 0)
+			break;
 		size /= 2;
+	}
 
 	if (size != orig_req)
 		flog_err(EC_LIB_SOCKET,
@@ -37,9 +40,12 @@ void setsockopt_so_sendbuf(const int sock, int size)
 {
 	int orig_req = size;
 
-	while (setsockopt(sock, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size))
-	       == -1)
+	while (setsockopt(sock, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size)) ==
+	       -1) {
+		if (size == 0)
+			break;
 		size /= 2;
+	}
 
 	if (size != orig_req)
 		flog_err(EC_LIB_SOCKET,


### PR DESCRIPTION
For some series of calls in FREEBSD setting the SO_RCVBUF size will always fail under freebsd.  This is no bueno since the setsockopt_so_recvbuf call goes into an infinite loop.

(gdb) bt
 0  setsockopt () at setsockopt.S:4
 1  0x0000000083065870 in setsockopt_so_recvbuf (sock=15, size=0) at lib/sockopt.c:26
 2  0x00000000002bd200 in ospf_ifp_sock_init (ifp=<optimized out>, ifp@entry=0x8d1dd500) at ospfd/ospf_network.c:290
 3  0x00000000002ad1e0 in ospf_if_new (ospf=0x8eefc000, ifp=0x8d1dd500, p=0x8eecf1c0) at ospfd/ospf_interface.c:276
 4  0x0000000000304ee0 in add_ospf_interface (co=0x8eecbe10, area=0x8d192100) at ospfd/ospfd.c:1115
 5  0x00000000003050fc in ospf_network_run_interface (ospf=0x8eefc000, ifp=0x8d1dd500, p=0x80ff63f8, given_area=0x8d192100)
    at ospfd/ospfd.c:1460
 6  ospf_network_run (p=0x80ff63f8, area=0x8d192100) at ospfd/ospfd.c:1474
 7  ospf_network_set (ospf=ospf@entry=0x8eefc000, p=p@entry=0x80ff63f8, area_id=..., df=<optimized out>) at ospfd/ospfd.c:1247
 8  0x00000000002e876c in ospf_network_area (self=<optimized out>, vty=0x8eef3180, argc=<optimized out>, argv=<optimized out>)
    at ospfd/ospf_vty.c:560
 9  0x0000000083006f24 in cmd_execute_command_real (vline=vline@entry=0x8eee9100, vty=vty@entry=0x8eef3180, cmd=<optimized out>,
    cmd@entry=0x0, up_level=<optimized out>) at lib/command.c:978
 10 0x0000000083006b30 in cmd_execute_command (vline=0x8eee9100, vty=vty@entry=0x8eef3180, cmd=cmd@entry=0x0, vtysh=vtysh@entry=0)
    at lib/command.c:1037
 11 0x0000000083007044 in cmd_execute (vty=vty@entry=0x8eef3180, cmd=cmd@entry=0x8eefb000 "network 192.168.64.0/24 area 0.0.0.0",
    matched=0x0, vtysh=0) at lib/command.c:1203
 12 0x000000008307e9cc in vty_command (vty=0x8eef3180, buf=0x8eefb000 "network 192.168.64.0/24 area 0.0.0.0") at lib/vty.c:594
 13 vty_execute (vty=vty@entry=0x8eef3180) at lib/vty.c:1357
 14 0x000000008307ce40 in vtysh_read (thread=<optimized out>) at lib/vty.c:2365
 15 0x0000000083073db0 in event_call (thread=thread@entry=0x80ff88a0) at lib/event.c:1965
 16 0x000000008302c604 in frr_run (master=0x8d188140) at lib/libfrr.c:1214
 17 0x000000000029c330 in main (argc=6, argv=<optimized out>) at ospfd/ospf_main.c:252
(gdb)

Force the setsockopt function to quit when the value we are passing no longer makes any sense.

Fixes: #14790