### PR TITLE
zebra: Refactor memory allocation in zebra_rnh.c

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1434,8 +1434,8 @@ void show_nexthop_json_helper(json_object *json_nexthop,
 							 ->seg[0]);
 			json_object_object_add(json_nexthop, "seg6", json_seg6);
 		} else {
-			json_segs = json_object_new_array();
 			if (nexthop->nh_srv6->seg6_segs) {
+				json_segs = json_object_new_array();
 				for (int seg_idx = 0;
 				     seg_idx <
 				     nexthop->nh_srv6->seg6_segs->num_segs;


### PR DESCRIPTION
Fix memory leaks by allocating `json_segs` conditionally on `nexthop->nh_srv6->seg6_segs`. The previous code allocated memory even when not in use or attached to the JSON tree.

The ASan leak log for reference:

```
Direct leak of 3240 byte(s) in 45 object(s) allocated from:
    #0 0x7f6e84a35d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f6e83de9e6f in json_object_new_array (/lib/x86_64-linux-gnu/libjson-c.so.3+0x3e6f)
    #2 0x564dcab5c1a6 in vty_show_ip_route zebra/zebra_vty.c:705
    #3 0x564dcab5cc71 in do_show_route_helper zebra/zebra_vty.c:955
    #4 0x564dcab5d418 in do_show_ip_route zebra/zebra_vty.c:1039
    #5 0x564dcab63ee5 in show_route_magic zebra/zebra_vty.c:1878
    #6 0x564dcab63ee5 in show_route zebra/zebra_vty_clippy.c:659
    #7 0x7f6e843b6fb1 in cmd_execute_command_real lib/command.c:978
    #8 0x7f6e843b7475 in cmd_execute_command lib/command.c:1036
    #9 0x7f6e843b78f4 in cmd_execute lib/command.c:1203
    #10 0x7f6e844dfe3b in vty_command lib/vty.c:594
    #11 0x7f6e844e02e6 in vty_execute lib/vty.c:1357
    #12 0x7f6e844e8bb7 in vtysh_read lib/vty.c:2365
    #13 0x7f6e844d3b7a in event_call lib/event.c:1965
    #14 0x7f6e844172b0 in frr_run lib/libfrr.c:1214
    #15 0x564dcaa50e81 in main zebra/main.c:488
    #16 0x7f6e837f7c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 11520 byte(s) in 45 object(s) allocated from:
    #0 0x7f6e84a35d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f6e83de88c0 in array_list_new (/lib/x86_64-linux-gnu/libjson-c.so.3+0x28c0)

Indirect leak of 1080 byte(s) in 45 object(s) allocated from:
    #0 0x7f6e84a35d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f6e83de8897 in array_list_new (/lib/x86_64-linux-gnu/libjson-c.so.3+0x2897)
```

Fixes #14786 