### PR TITLE
lib: Introducing interface type to struct interface

### DIFF
--- a/lib/if.h
+++ b/lib/if.h
@@ -19,6 +19,19 @@ extern "C" {
 
 DECLARE_MTYPE(CONNECTED_LABEL);
 
+/* Interface type - ones of interest. */
+enum intf_type {
+	IF_OTHER = 0,  /* Anything else */
+	IF_VXLAN,      /* VxLAN interface */
+	IF_VRF,	       /* VRF device */
+	IF_BRIDGE,     /* bridge device */
+	IF_VLAN,       /* VLAN sub-interface */
+	IF_MACVLAN,    /* MAC VLAN interface*/
+	IF_VETH,       /* VETH interface*/
+	IF_BOND,       /* Bond */
+	IF_GRE,	       /* GRE interface */
+};
+
 /* Interface link-layer type, if known. Derived from:
  *
  * net/if_arp.h on various platforms - Linux especially.
@@ -308,6 +321,7 @@ struct interface {
 	 * fashion?
 	 */
 	bool configured;
+	enum intf_type if_type;
 
 	QOBJ_FIELDS;
 };

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2782,6 +2782,7 @@ static void zebra_interface_if_set_value(struct stream *s,
 	STREAM_GETL(s, ifp->link_ifindex);
 	STREAM_GETL(s, ifp->ll_type);
 	STREAM_GETL(s, ifp->hw_addr_len);
+	STREAM_GETL(s, ifp->if_type);
 	if (ifp->hw_addr_len)
 		STREAM_GET(ifp->hw_addr, s,
 			   MIN(ifp->hw_addr_len, INTERFACE_HWADDR_MAX));

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -79,6 +79,7 @@ static void zserv_encode_interface(struct stream *s, struct interface *ifp)
 	stream_putl(s, zif->link_ifindex);
 	stream_putl(s, ifp->ll_type);
 	stream_putl(s, ifp->hw_addr_len);
+	stream_putl(s, zif->zif_type);
 	if (ifp->hw_addr_len)
 		stream_put(s, ifp->hw_addr, ifp->hw_addr_len);
 


### PR DESCRIPTION
Adding new field (interface type like Vlan,SVI,VRR etc..) in the struct interface to inform all zebra clients like ospf/bgp.

This can help protocols take appropriate action based on a specific interface type.

Ticket #3668878

Signed-off-by:.Chirag Shah.<chirag@nvidia.com>
Signed-off-by: Rajasekar Raja <rajasekarr@nvidia.com>
