### PR TITLE
Print all errors when validating NB configuration

### DIFF
--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -871,9 +871,14 @@ int nb_candidate_update(struct nb_config *candidate)
 int nb_candidate_validate_yang(struct nb_config *candidate, bool no_state,
 			       char *errmsg, size_t errmsg_len)
 {
-	if (lyd_validate_all(&candidate->dnode, ly_native_ctx,
-			     no_state ? LYD_VALIDATE_NO_STATE
-				      : LYD_VALIDATE_PRESENT,
+	uint32_t options = LYD_VALIDATE_MULTI_ERROR;
+
+	if (no_state)
+		SET_FLAG(options, LYD_VALIDATE_NO_STATE);
+	else
+		SET_FLAG(options, LYD_VALIDATE_PRESENT);
+
+	if (lyd_validate_all(&candidate->dnode, ly_native_ctx, options,
 			     NULL) != 0) {
 		yang_print_errors(ly_native_ctx, errmsg, errmsg_len);
 		return NB_ERR_VALIDATION;

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -676,7 +676,6 @@ static void ly_log_cb(LY_LOG_LEVEL level, const char *msg, const char *path)
 const char *yang_print_errors(struct ly_ctx *ly_ctx, char *buf, size_t buf_len)
 {
 	struct ly_err_item *ei;
-	const char *path;
 
 	ei = ly_err_first(ly_ctx);
 	if (!ei)
@@ -684,15 +683,13 @@ const char *yang_print_errors(struct ly_ctx *ly_ctx, char *buf, size_t buf_len)
 
 	strlcpy(buf, "YANG error(s):\n", buf_len);
 	for (; ei; ei = ei->next) {
-		strlcat(buf, " ", buf_len);
+		if (ei->path) {
+			strlcat(buf, " Path: ", buf_len);
+			strlcat(buf, ei->path, buf_len);
+			strlcat(buf, "\n", buf_len);
+		}
+		strlcat(buf, " Error: ", buf_len);
 		strlcat(buf, ei->msg, buf_len);
-		strlcat(buf, "\n", buf_len);
-	}
-
-	path = ly_errpath(ly_ctx);
-	if (path) {
-		strlcat(buf, " YANG path: ", buf_len);
-		strlcat(buf, path, buf_len);
 		strlcat(buf, "\n", buf_len);
 	}
 


### PR DESCRIPTION
Currently, the YANG data tree validation stops on the first error that is found. As an operator has to fix all the validation errors before the config can be commited, it's useful to let them know about all the errors at once.