### PR TITLE
sharpd: Set Callback Function for Memory Cleanup

### DIFF
--- a/sharpd/sharp_main.c
+++ b/sharpd/sharp_main.c
@@ -60,6 +60,7 @@ static void sharp_global_init(void)
 {
 	memset(&sg, 0, sizeof(sg));
 	sg.nhs = list_new();
+	sg.nhs->del = (void (*)(void *))sharp_nh_tracker_free;
 	sg.ted = NULL;
 	sg.srv6_locators = list_new();
 }

--- a/sharpd/sharp_nht.c
+++ b/sharpd/sharp_nht.c
@@ -40,6 +40,11 @@ struct sharp_nh_tracker *sharp_nh_tracker_get(struct prefix *p)
 	return nht;
 }
 
+void sharp_nh_tracker_free(struct sharp_nh_tracker *nht)
+{
+	XFREE(MTYPE_NH_TRACKER, nht);
+}
+
 void sharp_nh_tracker_dump(struct vty *vty)
 {
 	struct listnode *node;

--- a/sharpd/sharp_nht.h
+++ b/sharpd/sharp_nht.h
@@ -18,6 +18,7 @@ struct sharp_nh_tracker {
 };
 
 extern struct sharp_nh_tracker *sharp_nh_tracker_get(struct prefix *p);
+extern void sharp_nh_tracker_free(struct sharp_nh_tracker *nht);
 
 extern void sharp_nh_tracker_dump(struct vty *vty);
 


### PR DESCRIPTION
Implement a callback function for memory cleanup of sharp_nh_tracker. Specifically, set `sharp_nh_tracker_free` as the deletion function for the `sg.nhs` list. This ensures proper cleanup of resources when elements are removed.

The ASan leak log for reference:

```
***********************************************************************************
Address Sanitizer Error detected in zebra_nht_resolution.test_verify_nh_resolution/r1.asan.sharpd.32320

=================================================================
==32320==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x7f4ee812ad28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7f4ee7b291cc in qcalloc lib/memory.c:105
    #2 0x5582be672011 in sharp_nh_tracker_get sharpd/sharp_nht.c:36
    #3 0x5582be680b42 in watch_nexthop_v4_magic sharpd/sharp_vty.c:139
    #4 0x5582be680b42 in watch_nexthop_v4 sharpd/sharp_vty_clippy.c:192
    #5 0x7f4ee7aac0b1 in cmd_execute_command_real lib/command.c:978
    #6 0x7f4ee7aac575 in cmd_execute_command lib/command.c:1036
    #7 0x7f4ee7aac9f4 in cmd_execute lib/command.c:1203
    #8 0x7f4ee7bd50bb in vty_command lib/vty.c:594
    #9 0x7f4ee7bd5566 in vty_execute lib/vty.c:1357
    #10 0x7f4ee7bdde37 in vtysh_read lib/vty.c:2365
    #11 0x7f4ee7bc8dfa in event_call lib/event.c:1965
    #12 0x7f4ee7b0c3bf in frr_run lib/libfrr.c:1214
    #13 0x5582be671252 in main sharpd/sharp_main.c:188
    #14 0x7f4ee6f1bc86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 64 byte(s) leaked in 1 allocation(s).
***********************************************************************************
```