### PR TITLE
babeld: Free IPv4 Memory in interface_reset

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -695,6 +695,9 @@ interface_reset(struct interface *ifp)
            babel_ifp->cost,
            babel_ifp->ipv4 ? ", IPv4" : "");
 
+    if (babel_ifp->ipv4 != NULL)
+		free(babel_ifp->ipv4);
+
     return 1;
 }
 


### PR DESCRIPTION
Release memory allocated for the IPv4 address during the interface reset. The addition of `free(babel_ifp->ipv4)` ensures proper cleanup, preventing potential memory leaks.

The ASan leak log for reference:

```
***********************************************************************************
Address Sanitizer Error detected in babel_topo1.test_babel_topo1/r2.asan.babeld.18864

=================================================================
==18864==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 8 byte(s) in 2 object(s) allocated from:
    #0 0x7f3f4531bb40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x55c1806cb28d in babel_interface_address_add babeld/babel_interface.c:112
    #2 0x7f3f44de9e29 in zclient_read lib/zclient.c:4425
    #3 0x7f3f44db9dfa in event_call lib/event.c:1965
    #4 0x7f3f44cfd3bf in frr_run lib/libfrr.c:1214
    #5 0x55c1806cc81b in main babeld/babel_main.c:202
    #6 0x7f3f4451fc86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 8 byte(s) leaked in 2 allocation(s).
***********************************************************************************
```