### PR TITLE
babeld: Free IPv4 Memory in babel_interface_free

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -695,8 +695,10 @@ interface_reset(struct interface *ifp)
            babel_ifp->cost,
            babel_ifp->ipv4 ? ", IPv4" : "");
 
-    if (babel_ifp->ipv4 != NULL)
+    if (babel_ifp->ipv4 != NULL){
 		free(babel_ifp->ipv4);
+		babel_ifp->ipv4 = NULL;
+    }
 
     return 1;
 }
@@ -1348,5 +1350,9 @@ babel_interface_allocate (void)
 static void
 babel_interface_free (babel_interface_nfo *babel_ifp)
 {
+    if (babel_ifp->ipv4){
+        free(babel_ifp->ipv4);
+        babel_ifp->ipv4 = NULL;
+    }
     XFREE(MTYPE_BABEL_IF, babel_ifp);
 }


### PR DESCRIPTION
Ensure proper memory cleanup by freeing the `babel_ifp->ipv4` when babel interface is deleted. This prevents memory leaks.

The ASan leak log for reference:

```
***********************************************************************************
Address Sanitizer Error detected in all_protocol_startup.test_all_protocol_startup/r1.asan.babeld.4141

=================================================================
==4141==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 40 byte(s) in 10 object(s) allocated from:
    #0 0x7f1cde6a9b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x562b8eff328d in babel_interface_address_add babeld/babel_interface.c:112
    #2 0x7f1cde1772cb in zclient_read lib/zclient.c:4425
    #3 0x7f1cde14729c in event_call lib/event.c:1980
    #4 0x7f1cde08a3bf in frr_run lib/libfrr.c:1214
    #5 0x562b8eff481b in main babeld/babel_main.c:202
    #6 0x7f1cdd8acc86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 40 byte(s) leaked in 10 allocation(s).
***********************************************************************************
```