### PR TITLE
zebra: Check both IPv4 and IPv6 NH before removing RMAC

### DIFF
--- a/tests/topotests/bgp_evpn_rt5/r1/bgpd.conf
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgpd.conf
@@ -20,7 +20,11 @@ router bgp 65000 vrf r1-vrf-101
  address-family ipv4 unicast
   network 192.168.102.21/32
  exit-address-family
+ address-family ipv6 unicast
+  network fd00::1/128
+ exit-address-family
  address-family l2vpn evpn
   advertise ipv4 unicast
+  advertise ipv6 unicast
  exit-address-family
  !

--- a/tests/topotests/bgp_evpn_rt5/r1/zebra.conf
+++ b/tests/topotests/bgp_evpn_rt5/r1/zebra.conf
@@ -17,6 +17,7 @@ interface r1-eth0
 !
 interface loop101 vrf r1-vrf-101
  ip address 192.168.102.21/32
+ ipv6 address fd00::1/128
 !
 
 

--- a/tests/topotests/bgp_evpn_rt5/r2/bgpd.conf
+++ b/tests/topotests/bgp_evpn_rt5/r2/bgpd.conf
@@ -21,7 +21,11 @@ router bgp 65000 vrf r2-vrf-101
  address-family ipv4 unicast
   network 192.168.101.41/32
  exit-address-family
+ address-family ipv6 unicast
+  network fd00::2/128
+ exit-address-family
  address-family l2vpn evpn
   advertise ipv4 unicast
+  advertise ipv6 unicast
  exit-address-family
  !

--- a/tests/topotests/bgp_evpn_rt5/r2/zebra.conf
+++ b/tests/topotests/bgp_evpn_rt5/r2/zebra.conf
@@ -11,6 +11,7 @@ vrf r2-vrf-101
 !
 interface loop101 vrf r2-vrf-101
  ip address 192.168.101.41/32
+ ipv6 address fd00::2/128
 !
 interface r2-eth0
  ip address 192.168.100.41/24

--- a/tests/topotests/bgp_evpn_rt5/test_bgp_evpn.py
+++ b/tests/topotests/bgp_evpn_rt5/test_bgp_evpn.py
@@ -25,6 +25,8 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
+from lib.bgp import verify_bgp_rib
+from lib.common_config import apply_raw_config
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
@@ -178,11 +180,17 @@ def test_protocols_convergence():
     output = tgen.gears["r1"].vtysh_cmd("show bgp vrf r1-vrf-101 ipv4", isjson=False)
     logger.info("==== result from show bgp vrf r1-vrf-101 ipv4")
     logger.info(output)
+    output = tgen.gears["r1"].vtysh_cmd("show bgp vrf r1-vrf-101 ipv6", isjson=False)
+    logger.info("==== result from show bgp vrf r1-vrf-101 ipv6")
+    logger.info(output)
     output = tgen.gears["r1"].vtysh_cmd("show bgp vrf r1-vrf-101", isjson=False)
     logger.info("==== result from show bgp vrf r1-vrf-101 ")
     logger.info(output)
     output = tgen.gears["r1"].vtysh_cmd("show ip route vrf r1-vrf-101", isjson=False)
     logger.info("==== result from show ip route vrf r1-vrf-101")
+    logger.info(output)
+    output = tgen.gears["r1"].vtysh_cmd("show ipv6 route vrf r1-vrf-101", isjson=False)
+    logger.info("==== result from show ipv6 route vrf r1-vrf-101")
     logger.info(output)
     output = tgen.gears["r1"].vtysh_cmd("show evpn vni detail", isjson=False)
     logger.info("==== result from show evpn vni detail")
@@ -191,10 +199,125 @@ def test_protocols_convergence():
     logger.info("==== result from show evpn next-hops vni all")
     logger.info(output)
     output = tgen.gears["r1"].vtysh_cmd("show evpn rmac vni all", isjson=False)
-    logger.info("==== result from show evpn next-hops vni all")
+    logger.info("==== result from show evpn rmac vni all")
     logger.info(output)
+
+    expected = {
+        "fd00::2/128": [
+            {
+                "prefix": "fd00::2/128",
+                "vrfName": "r1-vrf-101",
+                "nexthops": [
+                    {
+                        "ip": "::ffff:c0a8:6429",
+                    }
+                ],
+            }
+        ]
+    }
+    result = topotest.router_json_cmp(
+        tgen.gears["r1"], "show ipv6 route vrf r1-vrf-101 fd00::2/128 json", expected
+    )
+    assert result is None, "ipv6 route check failed"
+
+    expected = {
+        "101": {
+            "numNextHops": 2,
+            "192.168.100.41": {
+                "nexthopIp": "192.168.100.41",
+            },
+            "::ffff:c0a8:6429": {
+                "nexthopIp": "::ffff:c0a8:6429",
+            },
+        }
+    }
+    result = topotest.router_json_cmp(
+        tgen.gears["r1"], "show evpn next-hops vni all json", expected
+    )
+    assert result is None, "evpn next-hops check failed"
+
+    expected = {"101": {"numRmacs": 1}}
+    result = topotest.router_json_cmp(
+        tgen.gears["r1"], "show evpn rmac vni all json", expected
+    )
+    assert result is None, "evpn rmac number check failed"
+
     # Check IPv4 and IPv6 connectivity between r1 and r2 ( routing vxlan evpn)
     pingrouter = tgen.gears["r1"]
+    logger.info(
+        "Check Ping IPv4 from  R1(r1-vrf-101) to R2(r2-vrf-101 = 192.168.101.41)"
+    )
+    output = pingrouter.run("ip netns exec r1-vrf-101 ping 192.168.101.41 -f -c 1000")
+    logger.info(output)
+    if "1000 packets transmitted, 1000 received" not in output:
+        assertmsg = (
+            "expected ping IPv4 from R1(r1-vrf-101) to R2(192.168.101.41) should be ok"
+        )
+        assert 0, assertmsg
+    else:
+        logger.info("Check Ping IPv4 from R1(r1-vrf-101) to R2(192.168.101.41) OK")
+
+    logger.info("Check Ping IPv6 from  R1(r1-vrf-101) to R2(r2-vrf-101 = fd00::2)")
+    output = pingrouter.run("ip netns exec r1-vrf-101 ping fd00::2 -f -c 1000")
+    logger.info(output)
+    if "1000 packets transmitted, 1000 received" not in output:
+        assert 0, "expected ping IPv6 from R1(r1-vrf-101) to R2(fd00::2) should be ok"
+    else:
+        logger.info("Check Ping IPv6 from R1(r1-vrf-101) to R2(fd00::2) OK")
+
+    config_no_ipv6 = {
+        "r2": {
+            "raw_config": [
+                "router bgp 65000 vrf r2-vrf-101",
+                "address-family ipv6 unicast",
+                "no network fd00::2/128",
+            ]
+        }
+    }
+
+    logger.info("==== Remove IPv6 network on R2")
+    result = apply_raw_config(tgen, config_no_ipv6)
+    assert result is True, "Failed to remove IPv6 network on R2, Error: {} ".format(
+        result
+    )
+    ipv6_routes = {
+        "r1": {
+            "static_routes": [
+                {
+                    "vrf": "r1-vrf-101",
+                    "network": ["fd00::2/128"],
+                }
+            ]
+        }
+    }
+    result = verify_bgp_rib(tgen, "ipv6", "r1", ipv6_routes, expected=False)
+    assert result is not True, "expect IPv6 route fd00::2/128 withdrawn"
+    output = tgen.gears["r1"].vtysh_cmd("show evpn next-hops vni all", isjson=False)
+    logger.info("==== result from show evpn next-hops vni all")
+    logger.info(output)
+    output = tgen.gears["r1"].vtysh_cmd("show evpn rmac vni all", isjson=False)
+    logger.info("==== result from show evpn next-hops vni all")
+    logger.info(output)
+
+    expected = {
+        "101": {
+            "numNextHops": 1,
+            "192.168.100.41": {
+                "nexthopIp": "192.168.100.41",
+            },
+        }
+    }
+    result = topotest.router_json_cmp(
+        tgen.gears["r1"], "show evpn next-hops vni all json", expected
+    )
+    assert result is None, "evpn next-hops check failed"
+
+    expected = {"101": {"numRmacs": 1}}
+    result = topotest.router_json_cmp(
+        tgen.gears["r1"], "show evpn rmac vni all json", expected
+    )
+    assert result is None, "evpn rmac number check failed"
+
     logger.info(
         "Check Ping IPv4 from  R1(r1-vrf-101) to R2(r2-vrf-101 = 192.168.101.41)"
     )

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1413,25 +1413,43 @@ static void zl3vni_remote_rmac_del(struct zebra_l3vni *zl3vni,
 				   struct zebra_mac *zrmac,
 				   struct ipaddr *vtep_ip)
 {
-	struct ipaddr ipv4_vtep;
+	struct ipaddr tmp_ip;
+	struct ipaddr *ipv4_vtep, *ipv6_nh;
 
-	if (!zl3vni_nh_lookup(zl3vni, vtep_ip)) {
-		memset(&ipv4_vtep, 0, sizeof(ipv4_vtep));
-		ipv4_vtep.ipa_type = IPADDR_V4;
-		if (vtep_ip->ipa_type == IPADDR_V6)
-			ipv4_mapped_ipv6_to_ipv4(&vtep_ip->ipaddr_v6,
-						 &ipv4_vtep.ipaddr_v4);
-		else
-			memcpy(&(ipv4_vtep.ipaddr_v4), &vtep_ip->ipaddr_v4,
-			       sizeof(struct in_addr));
+	memset(&tmp_ip, 0, sizeof(tmp_ip));
+	if (vtep_ip->ipa_type == IPADDR_V6) {
+		if (!IS_MAPPED_IPV6(&vtep_ip->ipaddr_v6)) {
+			zlog_warn("Unsupported IPv6 EVPN nexthop %pIA", vtep_ip);
+			return;
+		}
+		ipv4_vtep = &tmp_ip;
+		ipv6_nh = vtep_ip;
+		ipv4_vtep->ipa_type = IPADDR_V4;
+		ipv4_mapped_ipv6_to_ipv4(&ipv6_nh->ipaddr_v6,
+					 &ipv4_vtep->ipaddr_v4);
+	} else {
+		ipv4_vtep = vtep_ip;
+		ipv6_nh = &tmp_ip;
+		ipv6_nh->ipa_type = IPADDR_V6;
+		ipv4_to_ipv4_mapped_ipv6(&ipv6_nh->ipaddr_v6,
+					 ipv4_vtep->ipaddr_v4);
+	}
+
+	/*
+	 * We may have IPv4 and IPv4-mapped IPv6 address of the VTEP as
+	 * nexthops, but only IPv4 is inserted to rmac nh_list. Check for both
+	 * before deleting from rmac.
+	 */
+	if (!zl3vni_nh_lookup(zl3vni, ipv4_vtep) &&
+	    !zl3vni_nh_lookup(zl3vni, ipv6_nh)) {
 
 		/* remove nh from rmac's list */
-		l3vni_rmac_nh_list_nh_delete(zl3vni, zrmac, &ipv4_vtep);
+		l3vni_rmac_nh_list_nh_delete(zl3vni, zrmac, ipv4_vtep);
 		/* delete nh is same as current selected, fall back to
 		 * one present in the list
 		 */
 		if (IPV4_ADDR_SAME(&zrmac->fwd_info.r_vtep_ip,
-				   &ipv4_vtep.ipaddr_v4) &&
+				   &ipv4_vtep->ipaddr_v4) &&
 		    listcount(zrmac->nh_list)) {
 			struct ipaddr *vtep;
 
@@ -1440,7 +1458,7 @@ static void zl3vni_remote_rmac_del(struct zebra_l3vni *zl3vni,
 			if (IS_ZEBRA_DEBUG_VXLAN)
 				zlog_debug(
 					"L3VNI %u Remote VTEP nh change(%pIA -> %pI4) for RMAC %pEA",
-					zl3vni->vni, &ipv4_vtep,
+					zl3vni->vni, ipv4_vtep,
 					&zrmac->fwd_info.r_vtep_ip,
 					&zrmac->macaddr);
 


### PR DESCRIPTION
IPv4 and IPv4-mapped IPv6 address of a VTEP is used as nexthops of EVPN routes. Thus should check for both IPv4 and IPv6 before removing RMAC. Otherwise, withdrawing the last route in one address family breaks the other.