### PR TITLE
redhat: Set config/logfile mask to be 0640 for RHEL

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -420,7 +420,9 @@ routing state through standard SNMP MIBs.
 %else
     --disable-pathd \
 %endif
-    --enable-snmp
+    --enable-snmp \
+    --enable-configfile-mask=0640 \
+    --enable-logfile-mask=0640
     # end
 
 make %{?_smp_mflags} MAKEINFO="makeinfo --no-split"


### PR DESCRIPTION
Related: https://github.com/FRRouting/frr/issues/14817