### PR TITLE
isisd: remove unused router_address fields

### DIFF
--- a/isisd/isis_adjacency.h
+++ b/isisd/isis_adjacency.h
@@ -74,12 +74,10 @@ struct isis_adjacency {
 	struct nlpids nlpids; /* protocols spoken ... */
 	struct in_addr *ipv4_addresses;
 	unsigned int ipv4_address_count;
-	struct in_addr router_address;
 	struct in6_addr *ll_ipv6_addrs; /* Link local IPv6 neighbor address */
 	unsigned int ll_ipv6_count;
 	struct in6_addr *global_ipv6_addrs; /* Global IPv6 neighbor address */
 	unsigned int global_ipv6_count;
-	struct in6_addr router_address6;
 	uint8_t prio[ISIS_LEVELS];      /* priorityOfNeighbour for DIS */
 	int circuit_t;			/* from hello PDU hdr */
 	int level;			/* level (1 or 2) */

--- a/isisd/isis_route.c
+++ b/isisd/isis_route.c
@@ -260,24 +260,6 @@ isis_route_info_new(struct prefix *prefix, struct prefix_ipv6 *src_p,
 			       ISIS_CIRCUIT_FLAPPED_AFTER_SPF))
 			SET_FLAG(rinfo->flag, ISIS_ROUTE_FLAG_ZEBRA_RESYNC);
 
-		/* update neighbor router address */
-		switch (prefix->family) {
-		case AF_INET:
-			if (depth == 2 && prefix->prefixlen == IPV4_MAX_BITLEN)
-				adj->router_address = prefix->u.prefix4;
-			break;
-		case AF_INET6:
-			if (depth == 2 && prefix->prefixlen == IPV6_MAX_BITLEN
-			    && (!src_p || !src_p->prefixlen)) {
-				adj->router_address6 = prefix->u.prefix6;
-			}
-			break;
-		default:
-			flog_err(EC_LIB_DEVELOPMENT,
-				 "%s: unknown address family [%d]", __func__,
-				 prefix->family);
-			exit(1);
-		}
 		adjinfo2nexthop(prefix->family, rinfo->nexthops, adj, sr,
 				label_stack);
 		if (!allow_ecmp)


### PR DESCRIPTION
These were added in e38e0df01ad3 but never used anywhere.  Also the code grabs any random /32 or /128 that is directly connected to the adjacent router, which may not even be an address of that router itself.