### PR TITLE
bgpd: Fix frrtrace arguments for bmp_eor tracing

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -848,7 +848,7 @@ static void bmp_eor(struct bmp *bmp, afi_t afi, safi_t safi, uint8_t flags,
 	iana_afi_t pkt_afi = IANA_AFI_IPV4;
 	iana_safi_t pkt_safi = IANA_SAFI_UNICAST;
 
-	frrtrace(3, frr_bgp, bmp_eor, afi, safi, flags, peer_type_flag);
+	frrtrace(4, frr_bgp, bmp_eor, afi, safi, flags, peer_type_flag);
 
 	s = stream_new(BGP_MAX_PACKET_SIZE);
 

--- a/bgpd/bgp_trace.h
+++ b/bgpd/bgp_trace.h
@@ -135,7 +135,7 @@ TRACEPOINT_LOGLEVEL(frr_bgp, bmp_mirror_packet, TRACE_INFO)
 TRACEPOINT_EVENT(
 	frr_bgp,
 	bmp_eor,
-	TP_ARGS(afi_t, afi, safi_t, safi, uint8_t, flags, peer_type_flag),
+	TP_ARGS(afi_t, afi, safi_t, safi, uint8_t, flags, uint8_t, peer_type_flag),
 	TP_FIELDS(
 		ctf_integer(afi_t, afi, afi)
 		ctf_integer(safi_t, safi, safi)


### PR DESCRIPTION
Arguments number was wrong.