### PR TITLE
*: move common NHT update decoding bits into lib/

### DIFF
--- a/bgpd/bgp_nht.h
+++ b/bgpd/bgp_nht.h
@@ -7,9 +7,10 @@
 #define _BGP_NHT_H
 
 /**
- * bgp_parse_nexthop_update() - parse a nexthop update message from Zebra.
+ * bgp_nexthop_update() - process a nexthop update message from Zebra.
  */
-extern void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id);
+extern void bgp_nexthop_update(struct vrf *vrf, struct prefix *match,
+			       struct zapi_route *nhr);
 
 /**
  * bgp_find_or_add_nexthop() - lookup the nexthop cache table for the bnc

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -100,13 +100,6 @@ static int bgp_router_id_update(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-/* Nexthop update message from zebra. */
-static int bgp_read_nexthop_update(ZAPI_CALLBACK_ARGS)
-{
-	bgp_parse_nexthop_update(cmd, vrf_id);
-	return 0;
-}
-
 /* Set or clear interface on which unnumbered neighbor is configured. This
  * would in turn cause BGP to initiate or turn off IPv6 RAs on this
  * interface.
@@ -3332,7 +3325,6 @@ static zclient_handler *const bgp_handlers[] = {
 	[ZEBRA_INTERFACE_NBR_ADDRESS_DELETE] = bgp_interface_nbr_address_delete,
 	[ZEBRA_REDISTRIBUTE_ROUTE_ADD] = zebra_read_route,
 	[ZEBRA_REDISTRIBUTE_ROUTE_DEL] = zebra_read_route,
-	[ZEBRA_NEXTHOP_UPDATE] = bgp_read_nexthop_update,
 	[ZEBRA_FEC_UPDATE] = bgp_read_fec_update,
 	[ZEBRA_LOCAL_ES_ADD] = bgp_zebra_process_local_es_add,
 	[ZEBRA_LOCAL_ES_DEL] = bgp_zebra_process_local_es_del,
@@ -3454,6 +3446,7 @@ void bgp_zebra_init(struct event_loop *master, unsigned short instance)
 	zclient_init(zclient, ZEBRA_ROUTE_BGP, 0, &bgpd_privs);
 	zclient->zebra_connected = bgp_zebra_connected;
 	zclient->zebra_capabilities = bgp_zebra_capabilities;
+	zclient->nexthop_update = bgp_nexthop_update;
 	zclient->instance = instance;
 
 	/* Initialize special zclient for synchronous message exchanges. */

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -4298,6 +4298,28 @@ stream_failure:
 	return -1;
 }
 
+static int zclient_nexthop_update(ZAPI_CALLBACK_ARGS)
+{
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
+	struct prefix match;
+	struct zapi_route route;
+
+	if (!vrf) {
+		zlog_warn("nexthop update for unknown VRF ID %u", vrf_id);
+		return 0;
+	}
+
+	if (!zapi_nexthop_update_decode(zclient->ibuf, &match, &route)) {
+		zlog_err("failed to decode nexthop update");
+		return -1;
+	}
+
+	if (zclient->nexthop_update)
+		zclient->nexthop_update(vrf, &match, &route);
+
+	return 0;
+}
+
 static zclient_handler *const lib_handlers[] = {
 	/* fundamentals */
 	[ZEBRA_CAPABILITIES] = zclient_capability_decode,
@@ -4310,6 +4332,9 @@ static zclient_handler *const lib_handlers[] = {
 	[ZEBRA_INTERFACE_DELETE] = zclient_interface_delete,
 	[ZEBRA_INTERFACE_UP] = zclient_interface_up,
 	[ZEBRA_INTERFACE_DOWN] = zclient_interface_down,
+
+	/* NHT pre-decode */
+	[ZEBRA_NEXTHOP_UPDATE] = zclient_nexthop_update,
 
 	/* BFD */
 	[ZEBRA_BFD_DEST_REPLAY] = zclient_bfd_session_replay,

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2269,8 +2269,8 @@ const char *zapi_nexthop2str(const struct zapi_nexthop *znh, char *buf,
 /*
  * Decode the nexthop-tracking update message
  */
-bool zapi_nexthop_update_decode(struct stream *s, struct prefix *match,
-				struct zapi_route *nhr)
+static bool zapi_nexthop_update_decode(struct stream *s, struct prefix *match,
+				       struct zapi_route *nhr)
 {
 	uint32_t i;
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -293,6 +293,8 @@ struct zapi_cap {
 typedef int (zclient_handler)(ZAPI_CALLBACK_ARGS);
 /* clang-format on */
 
+struct zapi_route;
+
 /* Structure for the zebra client. */
 struct zclient {
 	/* The thread master we schedule ourselves on */
@@ -347,6 +349,8 @@ struct zclient {
 	/* Pointer to the callback functions. */
 	void (*zebra_connected)(struct zclient *);
 	void (*zebra_capabilities)(struct zclient_capabilities *cap);
+	void (*nexthop_update)(struct vrf *vrf, struct prefix *match,
+			       struct zapi_route *nhr);
 
 	int (*handle_error)(enum zebra_error_types error);
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -349,6 +349,17 @@ struct zclient {
 	/* Pointer to the callback functions. */
 	void (*zebra_connected)(struct zclient *);
 	void (*zebra_capabilities)(struct zclient_capabilities *cap);
+
+	/*
+	 * match -> is the prefix that the calling daemon asked to be matched
+	 * against.
+	 * nhr->prefix -> is the actual prefix that was matched against in the
+	 * rib itself.
+	 *
+	 * This distinction is made because a LPM can be made if there is a
+	 * covering route.  This way the upper level protocol can make a
+	 * decision point about whether or not it wants to use the match or not.
+	 */
 	void (*nexthop_update)(struct vrf *vrf, struct prefix *match,
 			       struct zapi_route *nhr);
 
@@ -1127,18 +1138,6 @@ int zapi_nexthop_from_nexthop(struct zapi_nexthop *znh,
 			      const struct nexthop *nh);
 int zapi_backup_nexthop_from_nexthop(struct zapi_nexthop *znh,
 				     const struct nexthop *nh);
-/*
- * match -> is the prefix that the calling daemon asked to be matched
- * against.
- * nhr->prefix -> is the actual prefix that was matched against in the
- * rib itself.
- *
- * This distinction is made because a LPM can be made if there is a
- * covering route.  This way the upper level protocol can make a decision
- * point about whether or not it wants to use the match or not.
- */
-extern bool zapi_nexthop_update_decode(struct stream *s, struct prefix *match,
-				       struct zapi_route *nhr);
 const char *zapi_nexthop2str(const struct zapi_nexthop *znh, char *buf,
 			     int bufsize);
 

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -147,30 +147,22 @@ void ospf6_zebra_import_default_route(struct ospf6 *ospf6, bool unreg)
 			 __func__);
 }
 
-static int ospf6_zebra_import_check_update(ZAPI_CALLBACK_ARGS)
+static void ospf6_zebra_import_check_update(struct vrf *vrf,
+					    struct prefix *matched,
+					    struct zapi_route *nhr)
 {
 	struct ospf6 *ospf6;
-	struct zapi_route nhr;
-	struct prefix matched;
 
-	ospf6 = ospf6_lookup_by_vrf_id(vrf_id);
+	ospf6 = (struct ospf6 *)vrf->info;
 	if (ospf6 == NULL || !IS_OSPF6_ASBR(ospf6))
-		return 0;
+		return;
 
-	if (!zapi_nexthop_update_decode(zclient->ibuf, &matched, &nhr)) {
-		zlog_err("%s[%u]: Failure to decode route", __func__,
-			 ospf6->vrf_id);
-		return -1;
-	}
+	if (matched->family != AF_INET6 || matched->prefixlen != 0 ||
+	    nhr->type == ZEBRA_ROUTE_OSPF6)
+		return;
 
-	if (matched.family != AF_INET6 || matched.prefixlen != 0 ||
-	    nhr.type == ZEBRA_ROUTE_OSPF6)
-		return 0;
-
-	ospf6->nssa_default_import_check.status = !!nhr.nexthop_num;
+	ospf6->nssa_default_import_check.status = !!nhr->nexthop_num;
 	ospf6_abr_nssa_type_7_defaults(ospf6);
-
-	return 0;
 }
 
 static int ospf6_zebra_if_address_update_add(ZAPI_CALLBACK_ARGS)
@@ -763,7 +755,6 @@ static zclient_handler *const ospf6_handlers[] = {
 	[ZEBRA_INTERFACE_ADDRESS_DELETE] = ospf6_zebra_if_address_update_delete,
 	[ZEBRA_REDISTRIBUTE_ROUTE_ADD] = ospf6_zebra_read_route,
 	[ZEBRA_REDISTRIBUTE_ROUTE_DEL] = ospf6_zebra_read_route,
-	[ZEBRA_NEXTHOP_UPDATE] = ospf6_zebra_import_check_update,
 };
 
 void ospf6_zebra_init(struct event_loop *master)
@@ -773,6 +764,7 @@ void ospf6_zebra_init(struct event_loop *master)
 			      array_size(ospf6_handlers));
 	zclient_init(zclient, ZEBRA_ROUTE_OSPF6, 0, &ospf6d_privs);
 	zclient->zebra_connected = ospf6_zebra_connected;
+	zclient->nexthop_update = ospf6_zebra_import_check_update;
 
 	/* Install command element for zebra node. */
 	install_element(VIEW_NODE, &show_ospf6_zebra_cmd);

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1487,30 +1487,20 @@ void ospf_zebra_import_default_route(struct ospf *ospf, bool unreg)
 			 __func__);
 }
 
-static int ospf_zebra_import_check_update(ZAPI_CALLBACK_ARGS)
+static void ospf_zebra_import_check_update(struct vrf *vrf, struct prefix *match,
+					   struct zapi_route *nhr)
 {
-	struct ospf *ospf;
-	struct zapi_route nhr;
-	struct prefix matched;
+	struct ospf *ospf = vrf->info;
 
-	ospf = ospf_lookup_by_vrf_id(vrf_id);
 	if (ospf == NULL || !IS_OSPF_ASBR(ospf))
-		return 0;
+		return;
 
-	if (!zapi_nexthop_update_decode(zclient->ibuf, &matched, &nhr)) {
-		zlog_err("%s[%u]: Failure to decode route", __func__,
-			 ospf->vrf_id);
-		return -1;
-	}
+	if (match->family != AF_INET || match->prefixlen != 0 ||
+	    nhr->type == ZEBRA_ROUTE_OSPF)
+		return;
 
-	if (matched.family != AF_INET || matched.prefixlen != 0 ||
-	    nhr.type == ZEBRA_ROUTE_OSPF)
-		return 0;
-
-	ospf->nssa_default_import_check.status = !!nhr.nexthop_num;
+	ospf->nssa_default_import_check.status = !!nhr->nexthop_num;
 	ospf_abr_nssa_type7_defaults(ospf);
-
-	return 0;
 }
 
 int ospf_distribute_list_out_set(struct ospf *ospf, int type, const char *name)
@@ -2183,7 +2173,6 @@ static zclient_handler *const ospf_handlers[] = {
 
 	[ZEBRA_REDISTRIBUTE_ROUTE_ADD] = ospf_zebra_read_route,
 	[ZEBRA_REDISTRIBUTE_ROUTE_DEL] = ospf_zebra_read_route,
-	[ZEBRA_NEXTHOP_UPDATE] = ospf_zebra_import_check_update,
 
 	[ZEBRA_OPAQUE_MESSAGE] = ospf_opaque_msg_handler,
 
@@ -2197,6 +2186,7 @@ void ospf_zebra_init(struct event_loop *master, unsigned short instance)
 			      array_size(ospf_handlers));
 	zclient_init(zclient, ZEBRA_ROUTE_OSPF, instance, &ospfd_privs);
 	zclient->zebra_connected = ospf_zebra_connected;
+	zclient->nexthop_update = ospf_zebra_import_check_update;
 
 	/* Initialize special zclient for synchronous message exchanges. */
 	struct zclient_options options = zclient_options_default;

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -364,38 +364,30 @@ void route_delete(struct pbr_nexthop_group_cache *pnhgc, afi_t afi)
 	}
 }
 
-static int pbr_zebra_nexthop_update(ZAPI_CALLBACK_ARGS)
+static void pbr_zebra_nexthop_update(struct vrf *vrf, struct prefix *matched,
+				     struct zapi_route *nhr)
 {
-	struct zapi_route nhr;
-	struct prefix matched;
 	uint32_t i;
 
-	if (!zapi_nexthop_update_decode(zclient->ibuf, &matched, &nhr)) {
-		zlog_err("Failure to decode Nexthop update message");
-		return 0;
-	}
-
 	if (DEBUG_MODE_CHECK(&pbr_dbg_zebra, DEBUG_MODE_ALL)) {
-
 		DEBUGD(&pbr_dbg_zebra,
 		       "%s: Received Nexthop update: %pFX against %pFX",
-		       __func__, &matched, &nhr.prefix);
+		       __func__, matched, &nhr->prefix);
 
 		DEBUGD(&pbr_dbg_zebra, "%s:   (Nexthops(%u)", __func__,
-		       nhr.nexthop_num);
+		       nhr->nexthop_num);
 
-		for (i = 0; i < nhr.nexthop_num; i++) {
+		for (i = 0; i < nhr->nexthop_num; i++) {
 			DEBUGD(&pbr_dbg_zebra,
 			       "%s:     Type: %d: vrf: %d, ifindex: %d gate: %pI4",
-			       __func__, nhr.nexthops[i].type,
-			       nhr.nexthops[i].vrf_id, nhr.nexthops[i].ifindex,
-			       &nhr.nexthops[i].gate.ipv4);
+			       __func__, nhr->nexthops[i].type,
+			       nhr->nexthops[i].vrf_id, nhr->nexthops[i].ifindex,
+			       &nhr->nexthops[i].gate.ipv4);
 		}
 	}
 
-	nhr.prefix = matched;
-	pbr_nht_nexthop_update(&nhr);
-	return 1;
+	nhr->prefix = *matched;
+	pbr_nht_nexthop_update(nhr);
 }
 
 extern struct zebra_privs_t pbr_privs;
@@ -405,7 +397,6 @@ static zclient_handler *const pbr_handlers[] = {
 	[ZEBRA_INTERFACE_ADDRESS_DELETE] = interface_address_delete,
 	[ZEBRA_ROUTE_NOTIFY_OWNER] = route_notify_owner,
 	[ZEBRA_RULE_NOTIFY_OWNER] = rule_notify_owner,
-	[ZEBRA_NEXTHOP_UPDATE] = pbr_zebra_nexthop_update,
 };
 
 void pbr_zebra_init(void)
@@ -417,6 +408,7 @@ void pbr_zebra_init(void)
 
 	zclient_init(zclient, ZEBRA_ROUTE_PBR, 0, &pbr_privs);
 	zclient->zebra_connected = zebra_connected;
+	zclient->nexthop_update = pbr_zebra_nexthop_update;
 }
 
 void pbr_zebra_destroy(void)

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -45,7 +45,8 @@ struct pnc_hash_walk_data {
 	struct interface *ifp;
 };
 
-int pim_parse_nexthop_update(ZAPI_CALLBACK_ARGS);
+void pim_nexthop_update(struct vrf *vrf, struct prefix *match,
+			struct zapi_route *nhr);
 int pim_find_or_track_nexthop(struct pim_instance *pim, pim_addr addr,
 			      struct pim_upstream *up, struct rp_info *rp,
 			      struct pim_nexthop_cache *out_pnc);

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -428,7 +428,6 @@ static zclient_handler *const pim_handlers[] = {
 	[ZEBRA_INTERFACE_ADDRESS_ADD] = pim_zebra_if_address_add,
 	[ZEBRA_INTERFACE_ADDRESS_DELETE] = pim_zebra_if_address_del,
 
-	[ZEBRA_NEXTHOP_UPDATE] = pim_parse_nexthop_update,
 	[ZEBRA_ROUTER_ID_UPDATE] = pim_router_id_update_zebra,
 
 #if PIM_IPV == 4
@@ -449,6 +448,7 @@ void pim_zebra_init(void)
 
 	zclient->zebra_capabilities = pim_zebra_capabilities;
 	zclient->zebra_connected = pim_zebra_connected;
+	zclient->nexthop_update = pim_nexthop_update;
 
 	zclient_init(zclient, ZEBRA_ROUTE_PIM, 0, &pimd_privs);
 	if (PIM_DEBUG_PIM_TRACE) {


### PR DESCRIPTION
All users of `ZEBRA_NEXTHOP_UPDATE` check the VRF and then call into `zapi_nexthop_update_decode` before further processing.  Move this into common code in lib/.

`zapi_nexthop_update_decode` is private at the end of this chain of commits.

---
This is prep work for further NHT refactoring & cleanup. There should be no visible/functional changes from this series of commits.