### PR TITLE
Output configuration of mgmtd-converted daemons from mgmtd

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -176,6 +176,7 @@ enum node_type {
 	BMP_NODE,		/* BMP config under router bgp */
 	ISIS_SRV6_NODE,    /* ISIS SRv6 node */
 	ISIS_SRV6_NODE_MSD_NODE,    /* ISIS SRv6 Node MSDs node */
+	MGMTD_NODE,		 /* MGMTD node. */
 	NODE_TYPE_MAX, /* maximum */
 };
 /* clang-format on */

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -2575,10 +2575,6 @@ const char *nb_client_name(enum nb_client client)
 
 static void nb_load_callbacks(const struct frr_yang_module_info *module)
 {
-
-	if (module->ignore_cbs)
-		return;
-
 	for (size_t i = 0; module->nodes[i].xpath; i++) {
 		struct nb_node *nb_node;
 		uint32_t priority;

--- a/mgmtd/mgmt_main.c
+++ b/mgmtd/mgmt_main.c
@@ -185,6 +185,10 @@ static void mgmt_vrf_terminate(void)
 	vrf_terminate();
 }
 
+#ifdef HAVE_STATICD
+extern const struct frr_yang_module_info frr_staticd_info;
+#endif
+
 /*
  * List of YANG modules to be loaded in the process context of
  * MGMTd.
@@ -201,11 +205,10 @@ static const struct frr_yang_module_info *const mgmt_yang_modules[] = {
 /*
  * YANG module info supported by backend clients get added here.
  * NOTE: Always set .ignore_cbs true for to avoid validating
- * backend northbound callbacks during loading.
+ * backend configuration northbound callbacks during loading.
  */
 #ifdef HAVE_STATICD
-	&(struct frr_yang_module_info){.name = "frr-staticd",
-				       .ignore_cbs = true},
+	&frr_staticd_info,
 #endif
 };
 

--- a/mgmtd/mgmt_vty.c
+++ b/mgmtd/mgmt_vty.c
@@ -462,6 +462,24 @@ static void mgmt_config_read_in(struct event *event)
 	}
 }
 
+static int mgmtd_config_write(struct vty *vty)
+{
+	struct lyd_node *root;
+
+	LY_LIST_FOR (running_config->dnode, root) {
+		nb_cli_show_dnode_cmds(vty, root, false);
+	}
+
+	return 1;
+}
+
+static struct cmd_node mgmtd_node = {
+	.name = "mgmtd",
+	.node = MGMTD_NODE,
+	.prompt = "",
+	.config_write = mgmtd_config_write,
+};
+
 void mgmt_vty_init(void)
 {
 	/*
@@ -479,6 +497,7 @@ void mgmt_vty_init(void)
 			&mgmt_daemon_info->read_in);
 
 	install_node(&debug_node);
+	install_node(&mgmtd_node);
 
 	install_element(VIEW_NODE, &show_mgmt_be_adapter_cmd);
 	install_element(VIEW_NODE, &show_mgmt_be_xpath_reg_cmd);

--- a/staticd/static_nb.c
+++ b/staticd/static_nb.c
@@ -16,18 +16,10 @@ const struct frr_yang_module_info frr_staticd_info = {
 	.name = "frr-staticd",
 	.nodes = {
 		{
-			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd",
-			.cbs = {
-				.cli_show = static_cli_show,
-				.cli_show_end = static_cli_show_end,
-			}
-		},
-		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list",
 			.cbs = {
 				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_create,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_destroy,
-				.cli_cmp = static_route_list_cli_cmp,
 			}
 		},
 		{
@@ -35,7 +27,6 @@ const struct frr_yang_module_info frr_staticd_info = {
 			.cbs = {
 				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_create,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_destroy,
-				.cli_cmp = static_path_list_cli_cmp,
 			}
 		},
 		{
@@ -51,8 +42,6 @@ const struct frr_yang_module_info frr_staticd_info = {
 				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_create,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_destroy,
 				.pre_validate = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_pre_validate,
-				.cli_show = static_nexthop_cli_show,
-				.cli_cmp = static_nexthop_cli_cmp,
 			}
 		},
 		{
@@ -150,7 +139,6 @@ const struct frr_yang_module_info frr_staticd_info = {
 			.cbs = {
 				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_create,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_destroy,
-				.cli_cmp = static_src_list_cli_cmp,
 			}
 		},
 		{
@@ -158,7 +146,6 @@ const struct frr_yang_module_info frr_staticd_info = {
 			.cbs = {
 				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_create,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_destroy,
-				.cli_cmp = static_path_list_cli_cmp,
 			}
 		},
 		{
@@ -174,8 +161,6 @@ const struct frr_yang_module_info frr_staticd_info = {
 				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_create,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_destroy,
 				.pre_validate = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_pre_validate,
-				.cli_show = static_src_nexthop_cli_show,
-				.cli_cmp = static_nexthop_cli_cmp,
 			}
 		},
 		{

--- a/staticd/static_vrf.c
+++ b/staticd/static_vrf.c
@@ -124,26 +124,12 @@ struct static_vrf *static_vrf_lookup_by_name(const char *name)
 	return NULL;
 }
 
-static int static_vrf_config_write(struct vty *vty)
-{
-	struct lyd_node *dnode;
-	int written = 0;
-
-	dnode = yang_dnode_get(running_config->dnode, "/frr-routing:routing");
-	if (dnode) {
-		nb_cli_show_dnode_cmds(vty, dnode, false);
-		written = 1;
-	}
-
-	return written;
-}
-
 void static_vrf_init(void)
 {
 	vrf_init(static_vrf_new, static_vrf_enable, static_vrf_disable,
 		 static_vrf_delete);
 
-	vrf_cmd_init(static_vrf_config_write);
+	vrf_cmd_init(NULL);
 }
 
 void static_vrf_terminate(void)

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -1234,8 +1234,10 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
 	return static_route_nb_run(vty, &args);
 }
 
-void static_cli_show(struct vty *vty, const struct lyd_node *dnode,
-		     bool show_defaults)
+#ifdef INCLUDE_MGMTD_CMDDEFS_ONLY
+
+static void static_cli_show(struct vty *vty, const struct lyd_node *dnode,
+			    bool show_defaults)
 {
 	const char *vrf;
 
@@ -1244,7 +1246,7 @@ void static_cli_show(struct vty *vty, const struct lyd_node *dnode,
 		vty_out(vty, "vrf %s\n", vrf);
 }
 
-void static_cli_show_end(struct vty *vty, const struct lyd_node *dnode)
+static void static_cli_show_end(struct vty *vty, const struct lyd_node *dnode)
 {
 	const char *vrf;
 
@@ -1444,8 +1446,9 @@ static void nexthop_cli_show(struct vty *vty, const struct lyd_node *route,
 	vty_out(vty, "\n");
 }
 
-void static_nexthop_cli_show(struct vty *vty, const struct lyd_node *dnode,
-			     bool show_defaults)
+static void static_nexthop_cli_show(struct vty *vty,
+				    const struct lyd_node *dnode,
+				    bool show_defaults)
 {
 	const struct lyd_node *path = yang_dnode_get_parent(dnode, "path-list");
 	const struct lyd_node *route =
@@ -1454,8 +1457,9 @@ void static_nexthop_cli_show(struct vty *vty, const struct lyd_node *dnode,
 	nexthop_cli_show(vty, route, NULL, path, dnode, show_defaults);
 }
 
-void static_src_nexthop_cli_show(struct vty *vty, const struct lyd_node *dnode,
-				 bool show_defaults)
+static void static_src_nexthop_cli_show(struct vty *vty,
+					const struct lyd_node *dnode,
+					bool show_defaults)
 {
 	const struct lyd_node *path = yang_dnode_get_parent(dnode, "path-list");
 	const struct lyd_node *src = yang_dnode_get_parent(path, "src-list");
@@ -1464,8 +1468,8 @@ void static_src_nexthop_cli_show(struct vty *vty, const struct lyd_node *dnode,
 	nexthop_cli_show(vty, route, src, path, dnode, show_defaults);
 }
 
-int static_nexthop_cli_cmp(const struct lyd_node *dnode1,
-			   const struct lyd_node *dnode2)
+static int static_nexthop_cli_cmp(const struct lyd_node *dnode1,
+				  const struct lyd_node *dnode2)
 {
 	enum static_nh_type nh_type1, nh_type2;
 	struct prefix prefix1, prefix2;
@@ -1519,8 +1523,8 @@ int static_nexthop_cli_cmp(const struct lyd_node *dnode1,
 	return if_cmp_name_func(vrf1, vrf2);
 }
 
-int static_route_list_cli_cmp(const struct lyd_node *dnode1,
-			      const struct lyd_node *dnode2)
+static int static_route_list_cli_cmp(const struct lyd_node *dnode1,
+				     const struct lyd_node *dnode2)
 {
 	const char *afi_safi1, *afi_safi2;
 	afi_t afi1, afi2;
@@ -1545,8 +1549,8 @@ int static_route_list_cli_cmp(const struct lyd_node *dnode1,
 	return prefix_cmp(&prefix1, &prefix2);
 }
 
-int static_src_list_cli_cmp(const struct lyd_node *dnode1,
-			    const struct lyd_node *dnode2)
+static int static_src_list_cli_cmp(const struct lyd_node *dnode1,
+				   const struct lyd_node *dnode2)
 {
 	struct prefix prefix1, prefix2;
 
@@ -1556,8 +1560,8 @@ int static_src_list_cli_cmp(const struct lyd_node *dnode1,
 	return prefix_cmp(&prefix1, &prefix2);
 }
 
-int static_path_list_cli_cmp(const struct lyd_node *dnode1,
-			     const struct lyd_node *dnode2)
+static int static_path_list_cli_cmp(const struct lyd_node *dnode1,
+				    const struct lyd_node *dnode2)
 {
 	uint32_t table_id1, table_id2;
 	uint8_t distance1, distance2;
@@ -1574,7 +1578,62 @@ int static_path_list_cli_cmp(const struct lyd_node *dnode1,
 	return (int)distance1 - (int)distance2;
 }
 
-#ifndef INCLUDE_MGMTD_CMDDEFS_ONLY
+const struct frr_yang_module_info frr_staticd_info = {
+	.name = "frr-staticd",
+	.ignore_cbs = true,
+	.nodes = {
+		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd",
+			.cbs = {
+				.cli_show = static_cli_show,
+				.cli_show_end = static_cli_show_end,
+			}
+		},
+		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list",
+			.cbs = {
+				.cli_cmp = static_route_list_cli_cmp,
+			}
+		},
+		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list",
+			.cbs = {
+				.cli_cmp = static_path_list_cli_cmp,
+			}
+		},
+		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop",
+			.cbs = {
+				.cli_show = static_nexthop_cli_show,
+				.cli_cmp = static_nexthop_cli_cmp,
+			}
+		},
+		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/src-list",
+			.cbs = {
+				.cli_cmp = static_src_list_cli_cmp,
+			}
+		},
+		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/src-list/path-list",
+			.cbs = {
+				.cli_cmp = static_path_list_cli_cmp,
+			}
+		},
+		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/src-list/path-list/frr-nexthops/nexthop",
+			.cbs = {
+				.cli_show = static_src_nexthop_cli_show,
+				.cli_cmp = static_nexthop_cli_cmp,
+			}
+		},
+		{
+			.xpath = NULL,
+		},
+	}
+};
+
+#else /* ifdef INCLUDE_MGMTD_CMDDEFS_ONLY */
 
 DEFPY_YANG(debug_staticd, debug_staticd_cmd,
 	   "[no] debug static [{events$events|route$route|bfd$bfd}]",

--- a/staticd/static_vty.h
+++ b/staticd/static_vty.h
@@ -11,22 +11,6 @@
 extern "C" {
 #endif
 
-void static_cli_show(struct vty *vty, const struct lyd_node *dnode,
-		     bool show_defaults);
-void static_cli_show_end(struct vty *vty, const struct lyd_node *dnode);
-void static_nexthop_cli_show(struct vty *vty, const struct lyd_node *dnode,
-			     bool show_defaults);
-void static_src_nexthop_cli_show(struct vty *vty, const struct lyd_node *dnode,
-				 bool show_defaults);
-int static_nexthop_cli_cmp(const struct lyd_node *dnode1,
-			   const struct lyd_node *dnode2);
-int static_route_list_cli_cmp(const struct lyd_node *dnode1,
-			      const struct lyd_node *dnode2);
-int static_src_list_cli_cmp(const struct lyd_node *dnode1,
-			    const struct lyd_node *dnode2);
-int static_path_list_cli_cmp(const struct lyd_node *dnode1,
-			     const struct lyd_node *dnode2);
-
 void static_vty_init(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
When a daemon becomes mgmtd-converted, mgmtd starts processing its vty configuration commands. It makes sense to output the configuration from mgmtd as well, so that everything related to vty config is handled in one place.