### PR TITLE
*: Let's use the native IFNAMSIZ instead of INTERFACE_NAMSIZ

### DIFF
--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -242,7 +242,7 @@ babel_get_myid(void)
     /* We failed to get a global EUI64 from the interfaces we were given.
      Let's try to find an interface with a MAC address. */
     for(i = 1; i < 256; i++) {
-        char buf[INTERFACE_NAMSIZ], *ifname;
+        char buf[IFNAMSIZ], *ifname;
         unsigned char eui[8];
         ifname = if_indextoname(i, buf);
         if(ifname == NULL)

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -193,7 +193,7 @@ struct bfd_key {
 	uint16_t mhop;
 	struct in6_addr peer;
 	struct in6_addr local;
-	char ifname[INTERFACE_NAMSIZ];
+	char ifname[IFNAMSIZ];
 	char vrfname[VRF_NAMSIZ];
 } __attribute__((packed));
 

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -547,7 +547,7 @@ static int bgp_fs_local_install_interface(struct bgp *bgp,
 			return CMD_SUCCESS;
 		pbr_if = XCALLOC(MTYPE_TMP,
 				 sizeof(struct bgp_pbr_interface));
-		strlcpy(pbr_if->name, ifname, INTERFACE_NAMSIZ);
+		strlcpy(pbr_if->name, ifname, IFNAMSIZ);
 		RB_INSERT(bgp_pbr_interface_head, head, pbr_if);
 		*bgp_pbr_interface_any = false;
 	} else {

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -134,7 +134,7 @@ struct bgp_pbr_entry_main {
 
 struct bgp_pbr_interface {
 	RB_ENTRY(bgp_pbr_interface) id_entry;
-	char name[INTERFACE_NAMSIZ];
+	char name[IFNAMSIZ];
 };
 
 RB_HEAD(bgp_pbr_interface_head, bgp_pbr_interface);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2353,7 +2353,7 @@ static int rule_notify_owner(ZAPI_CALLBACK_ARGS)
 	enum zapi_rule_notify_owner note;
 	struct bgp_pbr_action *bgp_pbra;
 	struct bgp_pbr_rule *bgp_pbr = NULL;
-	char ifname[INTERFACE_NAMSIZ + 1];
+	char ifname[IFNAMSIZ + 1];
 
 	if (!zapi_rule_notify_decode(zclient->ibuf, &seqno, &priority, &unique,
 				     ifname, &note))

--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -341,7 +341,7 @@ struct iface_ldp_sync {
 
 struct iface {
 	RB_ENTRY(iface)		 entry;
-	char			 name[INTERFACE_NAMSIZ];
+	char name[IFNAMSIZ];
 	ifindex_t		 ifindex;
 	struct if_addr_head	 addr_list;
 	struct in6_addr		 linklocal;
@@ -447,7 +447,7 @@ struct ldp_entity_stats {
 struct l2vpn_if {
 	RB_ENTRY(l2vpn_if)	 entry;
 	struct l2vpn		*l2vpn;
-	char			 ifname[INTERFACE_NAMSIZ];
+	char ifname[IFNAMSIZ];
 	ifindex_t		 ifindex;
 	int			 operative;
 	uint8_t			 mac[ETH_ALEN];
@@ -464,7 +464,7 @@ struct l2vpn_pw {
 	int			 af;
 	union ldpd_addr		 addr;
 	uint32_t		 pwid;
-	char			 ifname[INTERFACE_NAMSIZ];
+	char ifname[IFNAMSIZ];
 	ifindex_t		 ifindex;
 	bool			 enabled;
 	uint32_t		 remote_group;
@@ -496,7 +496,7 @@ struct l2vpn {
 	int			 type;
 	int			 pw_type;
 	int			 mtu;
-	char			 br_ifname[INTERFACE_NAMSIZ];
+	char br_ifname[IFNAMSIZ];
 	ifindex_t		 br_ifindex;
 	struct l2vpn_if_head	 if_tree;
 	struct l2vpn_pw_head	 pw_tree;
@@ -618,7 +618,7 @@ struct kroute {
 };
 
 struct kaddr {
-	char			 ifname[INTERFACE_NAMSIZ];
+	char ifname[IFNAMSIZ];
 	ifindex_t		 ifindex;
 	int			 af;
 	union ldpd_addr		 addr;
@@ -627,7 +627,7 @@ struct kaddr {
 };
 
 struct kif {
-	char			 ifname[INTERFACE_NAMSIZ];
+	char ifname[IFNAMSIZ];
 	ifindex_t		 ifindex;
 	int			 flags;
 	int			 operative;
@@ -645,7 +645,7 @@ struct acl_check {
 /* control data structures */
 struct ctl_iface {
 	int			 af;
-	char			 name[INTERFACE_NAMSIZ];
+	char name[IFNAMSIZ];
 	ifindex_t		 ifindex;
 	int			 state;
 	enum iface_type		 type;
@@ -656,7 +656,7 @@ struct ctl_iface {
 };
 
 struct ctl_disc_if {
-	char			 name[INTERFACE_NAMSIZ];
+	char name[IFNAMSIZ];
 	int			 active_v4;
 	int			 active_v6;
 	int			 no_adj;
@@ -672,7 +672,7 @@ struct ctl_adj {
 	int			 af;
 	struct in_addr		 id;
 	enum hello_type		 type;
-	char			 ifname[INTERFACE_NAMSIZ];
+	char ifname[IFNAMSIZ];
 	union ldpd_addr		 src_addr;
 	uint16_t		 holdtime;
 	uint16_t		 holdtime_remaining;
@@ -712,7 +712,7 @@ struct ctl_rt {
 struct ctl_pw {
 	uint16_t		 type;
 	char			 l2vpn_name[L2VPN_NAME_LEN];
-	char			 ifname[INTERFACE_NAMSIZ];
+	char ifname[IFNAMSIZ];
 	uint32_t		 pwid;
 	struct in_addr		 lsr_id;
 	uint32_t		 local_label;
@@ -728,7 +728,7 @@ struct ctl_pw {
 };
 
 struct ctl_ldp_sync {
-	char			 name[INTERFACE_NAMSIZ];
+	char name[IFNAMSIZ];
 	ifindex_t		 ifindex;
 	bool			 in_sync;
 	bool			 timer_running;

--- a/lib/if.c
+++ b/lib/if.c
@@ -362,8 +362,7 @@ struct interface *if_lookup_by_name(const char *name, vrf_id_t vrf_id)
 	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 	struct interface if_tmp;
 
-	if (!vrf || !name
-	    || strnlen(name, INTERFACE_NAMSIZ) == INTERFACE_NAMSIZ)
+	if (!vrf || !name || strnlen(name, IFNAMSIZ) == IFNAMSIZ)
 		return NULL;
 
 	strlcpy(if_tmp.name, name, sizeof(if_tmp.name));
@@ -374,7 +373,7 @@ struct interface *if_lookup_by_name_vrf(const char *name, struct vrf *vrf)
 {
 	struct interface if_tmp;
 
-	if (!name || strnlen(name, INTERFACE_NAMSIZ) == INTERFACE_NAMSIZ)
+	if (!name || strnlen(name, IFNAMSIZ) == IFNAMSIZ)
 		return NULL;
 
 	strlcpy(if_tmp.name, name, sizeof(if_tmp.name));
@@ -386,7 +385,7 @@ static struct interface *if_lookup_by_name_all_vrf(const char *name)
 	struct vrf *vrf;
 	struct interface *ifp;
 
-	if (!name || strnlen(name, INTERFACE_NAMSIZ) == INTERFACE_NAMSIZ)
+	if (!name || strnlen(name, IFNAMSIZ) == IFNAMSIZ)
 		return NULL;
 
 	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {

--- a/lib/if.h
+++ b/lib/if.h
@@ -88,8 +88,6 @@ enum zebra_link_type {
    FreeBSD define value in /usr/include/net/if.h.
    #define IFNAMSIZ        16
 */
-
-#define INTERFACE_NAMSIZ      IFNAMSIZ
 #define INTERFACE_HWADDR_MAX  20
 
 typedef signed int ifindex_t;
@@ -218,7 +216,7 @@ struct interface {
 	   To delete, just set ifindex to IFINDEX_INTERNAL to indicate that the
 	   interface does not exist in the kernel.
 	 */
-	char name[INTERFACE_NAMSIZ];
+	char name[IFNAMSIZ];
 
 	/* Interface index (should be IFINDEX_INTERNAL for non-kernel or
 	   deleted interfaces).

--- a/lib/ldp_sync.h
+++ b/lib/ldp_sync.h
@@ -59,7 +59,7 @@ struct ldp_igp_sync_if_state {
 struct ldp_igp_sync_if_state_req {
 	int proto;
 	ifindex_t ifindex;
-	char name[INTERFACE_NAMSIZ];
+	char name[IFNAMSIZ];
 };
 
 #ifdef __cplusplus

--- a/lib/mlag.c
+++ b/lib/mlag.c
@@ -92,7 +92,7 @@ stream_failure:
 }
 
 #define MLAG_MROUTE_ADD_LENGTH                                                 \
-	(VRF_NAMSIZ + INTERFACE_NAMSIZ + 4 + 4 + 4 + 4 + 1 + 1 + 4)
+	(VRF_NAMSIZ + IFNAMSIZ + 4 + 4 + 4 + 4 + 1 + 1 + 4)
 
 int mlag_lib_decode_mroute_add(struct stream *s, struct mlag_mroute_add *msg,
 			       size_t *length)
@@ -108,14 +108,14 @@ int mlag_lib_decode_mroute_add(struct stream *s, struct mlag_mroute_add *msg,
 	STREAM_GETC(s, msg->am_i_dr);
 	STREAM_GETC(s, msg->am_i_dual_active);
 	STREAM_GETL(s, msg->vrf_id);
-	STREAM_GET(msg->intf_name, s, INTERFACE_NAMSIZ);
+	STREAM_GET(msg->intf_name, s, IFNAMSIZ);
 
 	return 0;
 stream_failure:
 	return -1;
 }
 
-#define MLAG_MROUTE_DEL_LENGTH (VRF_NAMSIZ + INTERFACE_NAMSIZ + 4 + 4 + 4 + 4)
+#define MLAG_MROUTE_DEL_LENGTH (VRF_NAMSIZ + IFNAMSIZ + 4 + 4 + 4 + 4)
 
 int mlag_lib_decode_mroute_del(struct stream *s, struct mlag_mroute_del *msg,
 			       size_t *length)
@@ -128,7 +128,7 @@ int mlag_lib_decode_mroute_del(struct stream *s, struct mlag_mroute_del *msg,
 	STREAM_GETL(s, msg->group_ip);
 	STREAM_GETL(s, msg->owner_id);
 	STREAM_GETL(s, msg->vrf_id);
-	STREAM_GET(msg->intf_name, s, INTERFACE_NAMSIZ);
+	STREAM_GET(msg->intf_name, s, IFNAMSIZ);
 
 	return 0;
 stream_failure:
@@ -140,7 +140,7 @@ int mlag_lib_decode_mlag_status(struct stream *s, struct mlag_status *msg)
 	if (s == NULL || msg == NULL)
 		return -1;
 
-	STREAM_GET(msg->peerlink_rif, s, INTERFACE_NAMSIZ);
+	STREAM_GET(msg->peerlink_rif, s, IFNAMSIZ);
 	STREAM_GETL(s, msg->my_role);
 	STREAM_GETL(s, msg->peer_state);
 	return 0;

--- a/lib/mlag.h
+++ b/lib/mlag.h
@@ -65,7 +65,7 @@ struct mlag_frr_status {
 };
 
 struct mlag_status {
-	char peerlink_rif[INTERFACE_NAMSIZ];
+	char peerlink_rif[IFNAMSIZ];
 	enum mlag_role my_role;
 	enum mlag_state peer_state;
 };
@@ -86,7 +86,7 @@ struct mlag_mroute_add {
 	bool am_i_dr;
 	bool am_i_dual_active;
 	vrf_id_t vrf_id;
-	char intf_name[INTERFACE_NAMSIZ];
+	char intf_name[IFNAMSIZ];
 };
 
 struct mlag_mroute_del {
@@ -95,7 +95,7 @@ struct mlag_mroute_del {
 	uint32_t group_ip;
 	enum mlag_owner owner_id;
 	vrf_id_t vrf_id;
-	char intf_name[INTERFACE_NAMSIZ];
+	char intf_name[IFNAMSIZ];
 };
 
 struct mlag_msg {

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -138,7 +138,7 @@ struct pbr_rule {
 	struct pbr_filter filter;
 	struct pbr_action action;
 
-	char ifname[INTERFACE_NAMSIZ + 1];
+	char ifname[IFNAMSIZ + 1];
 };
 
 /* TCP flags value shared

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1851,7 +1851,7 @@ int zapi_pbr_rule_encode(struct stream *s, struct pbr_rule *r)
 	zapi_pbr_rule_filter_encode(s, &(r->filter));
 	zapi_pbr_rule_action_encode(s, &(r->action));
 
-	stream_put(s, r->ifname, INTERFACE_NAMSIZ);
+	stream_put(s, r->ifname, IFNAMSIZ);
 
 	/* Put length at the first point of the stream. */
 	stream_putw_at(s, 0, stream_get_endp(s));
@@ -1875,7 +1875,7 @@ bool zapi_pbr_rule_decode(struct stream *s, struct pbr_rule *r)
 	if (!zapi_pbr_rule_action_decode(s, &(r->action)))
 		goto stream_failure;
 
-	STREAM_GET(r->ifname, s, INTERFACE_NAMSIZ);
+	STREAM_GET(r->ifname, s, IFNAMSIZ);
 	return true;
 
 stream_failure:
@@ -2034,7 +2034,7 @@ bool zapi_rule_notify_decode(struct stream *s, uint32_t *seqno,
 	STREAM_GETL(s, seq);
 	STREAM_GETL(s, prio);
 	STREAM_GETL(s, uni);
-	STREAM_GET(ifname, s, INTERFACE_NAMSIZ);
+	STREAM_GET(ifname, s, IFNAMSIZ);
 
 	if (zclient_debug)
 		zlog_debug("%s: %u %u %u %s", __func__, seq, prio, uni, ifname);
@@ -2526,12 +2526,12 @@ static int zclient_vrf_delete(ZAPI_CALLBACK_ARGS)
 static int zclient_interface_add(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
-	char ifname_tmp[INTERFACE_NAMSIZ + 1] = {};
+	char ifname_tmp[IFNAMSIZ + 1] = {};
 	struct stream *s = zclient->ibuf;
 	struct vrf *vrf;
 
 	/* Read interface name. */
-	STREAM_GET(ifname_tmp, s, INTERFACE_NAMSIZ);
+	STREAM_GET(ifname_tmp, s, IFNAMSIZ);
 
 	/* Lookup/create interface by name. */
 	vrf = vrf_lookup_by_id(vrf_id);
@@ -2562,10 +2562,10 @@ stream_failure:
 struct interface *zebra_interface_state_read(struct stream *s, vrf_id_t vrf_id)
 {
 	struct interface *ifp;
-	char ifname_tmp[INTERFACE_NAMSIZ + 1] = {};
+	char ifname_tmp[IFNAMSIZ + 1] = {};
 
 	/* Read interface name. */
-	STREAM_GET(ifname_tmp, s, INTERFACE_NAMSIZ);
+	STREAM_GET(ifname_tmp, s, IFNAMSIZ);
 
 	/* Lookup this by interface index. */
 	ifp = if_lookup_by_name(ifname_tmp, vrf_id);
@@ -3055,12 +3055,12 @@ struct interface *zebra_interface_vrf_update_read(struct stream *s,
 						  vrf_id_t vrf_id,
 						  vrf_id_t *new_vrf_id)
 {
-	char ifname[INTERFACE_NAMSIZ + 1] = {};
+	char ifname[IFNAMSIZ + 1] = {};
 	struct interface *ifp;
 	vrf_id_t new_id;
 
 	/* Read interface name. */
-	STREAM_GET(ifname, s, INTERFACE_NAMSIZ);
+	STREAM_GET(ifname, s, IFNAMSIZ);
 
 	/* Lookup interface. */
 	ifp = if_lookup_by_name(ifname, vrf_id);
@@ -3946,7 +3946,7 @@ enum zclient_send_status zebra_send_pw(struct zclient *zclient, int command,
 	stream_reset(s);
 
 	zclient_create_header(s, command, VRF_DEFAULT);
-	stream_write(s, pw->ifname, INTERFACE_NAMSIZ);
+	stream_write(s, pw->ifname, IFNAMSIZ);
 	stream_putl(s, pw->ifindex);
 
 	/* Put type */
@@ -3993,7 +3993,7 @@ int zebra_read_pw_status_update(ZAPI_CALLBACK_ARGS, struct zapi_pw_status *pw)
 	s = zclient->ibuf;
 
 	/* Get data. */
-	stream_get(pw->ifname, s, INTERFACE_NAMSIZ);
+	stream_get(pw->ifname, s, IFNAMSIZ);
 	STREAM_GETL(s, pw->ifindex);
 	STREAM_GETL(s, pw->status);
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -629,7 +629,7 @@ struct zapi_sr_policy {
 };
 
 struct zapi_pw {
-	char ifname[INTERFACE_NAMSIZ];
+	char ifname[IFNAMSIZ];
 	ifindex_t ifindex;
 	int type;
 	int af;
@@ -642,7 +642,7 @@ struct zapi_pw {
 };
 
 struct zapi_pw_status {
-	char ifname[INTERFACE_NAMSIZ];
+	char ifname[IFNAMSIZ];
 	ifindex_t ifindex;
 	uint32_t status;
 };

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -932,7 +932,7 @@ struct ospf_interface *ospf_vl_new(struct ospf *ospf,
 {
 	struct ospf_interface *voi;
 	struct interface *vi;
-	char ifname[INTERFACE_NAMSIZ];
+	char ifname[IFNAMSIZ];
 	struct ospf_area *area;
 	struct in_addr area_id;
 	struct connected *co;

--- a/pbrd/pbr_nht.h
+++ b/pbrd/pbr_nht.h
@@ -36,7 +36,7 @@ struct pbr_nexthop_cache {
 	struct pbr_nexthop_group_cache *parent;
 
 	char vrf_name[VRF_NAMSIZ + 1];
-	char intf_name[INTERFACE_NAMSIZ + 1];
+	char intf_name[IFNAMSIZ + 1];
 
 	struct nexthop nexthop;
 

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -178,7 +178,7 @@ static int rule_notify_owner(ZAPI_CALLBACK_ARGS)
 	enum zapi_rule_notify_owner note;
 	struct pbr_map_sequence *pbrms;
 	struct pbr_map_interface *pmi;
-	char ifname[INTERFACE_NAMSIZ + 1];
+	char ifname[IFNAMSIZ + 1];
 	uint64_t installed;
 
 	if (!zapi_rule_notify_decode(zclient->ibuf, &seqno, &priority, &unique,

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1059,8 +1059,8 @@ void pim_show_state(struct pim_instance *pim, struct vty *vty,
 	frr_each (rb_pim_oil, &pim->channel_oil_head, c_oil) {
 		char src_str[PIM_ADDRSTRLEN];
 		char grp_str[PIM_ADDRSTRLEN];
-		char in_ifname[INTERFACE_NAMSIZ + 1];
-		char out_ifname[INTERFACE_NAMSIZ + 1];
+		char in_ifname[IFNAMSIZ + 1];
+		char out_ifname[IFNAMSIZ + 1];
 		int oif_vif_index;
 		struct interface *ifp_in;
 		bool isRpt;
@@ -3662,8 +3662,8 @@ void show_mroute(struct pim_instance *pim, struct vty *vty, pim_sgaddr *sg,
 	int first;
 	char grp_str[PIM_ADDRSTRLEN];
 	char src_str[PIM_ADDRSTRLEN];
-	char in_ifname[INTERFACE_NAMSIZ + 1];
-	char out_ifname[INTERFACE_NAMSIZ + 1];
+	char in_ifname[IFNAMSIZ + 1];
+	char out_ifname[IFNAMSIZ + 1];
 	int oif_vif_index;
 	struct interface *ifp_in;
 	char proto[100];

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1487,7 +1487,7 @@ void pim_if_update_assert_tracking_desired(struct interface *ifp)
  */
 void pim_if_create_pimreg(struct pim_instance *pim)
 {
-	char pimreg_name[INTERFACE_NAMSIZ];
+	char pimreg_name[IFNAMSIZ];
 
 	if (!pim->regiface) {
 		if (pim->vrf->vrf_id == VRF_DEFAULT)

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -97,7 +97,7 @@ struct pim_router {
 	struct in_addr local_vtep_ip;
 	struct pim_mlag_stats mlag_stats;
 	enum pim_mlag_flags mlag_flags;
-	char peerlink_rif[INTERFACE_NAMSIZ];
+	char peerlink_rif[IFNAMSIZ];
 	struct interface *peerlink_rif_p;
 };
 

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -434,7 +434,7 @@ static void pim_mlag_up_local_add_send(struct pim_instance *pim,
 	stream_putc(s, !(PIM_UPSTREAM_FLAG_TEST_MLAG_NON_DF(up->flags)));
 	stream_putl(s, vrf->vrf_id);
 	/* XXX - this field is a No-op for VXLAN*/
-	stream_put(s, NULL, INTERFACE_NAMSIZ);
+	stream_put(s, NULL, IFNAMSIZ);
 
 	stream_fifo_push_safe(router->mlag_fifo, s);
 	pim_mlag_signal_zpthread();
@@ -467,7 +467,7 @@ static void pim_mlag_up_local_del_send(struct pim_instance *pim,
 	stream_putl(s, MLAG_OWNER_VXLAN);
 	stream_putl(s, vrf->vrf_id);
 	/* XXX - this field is a No-op for VXLAN */
-	stream_put(s, NULL, INTERFACE_NAMSIZ);
+	stream_put(s, NULL, IFNAMSIZ);
 
 	/* XXX - is this the the most optimal way to do things */
 	stream_fifo_push_safe(router->mlag_fifo, s);

--- a/ripd/rip_snmp.c
+++ b/ripd/rip_snmp.c
@@ -195,7 +195,7 @@ static int rip_snmp_ifaddr_del(struct connected *ifc)
 	if (!rn)
 		return 0;
 	i = rn->info;
-	if (!strncmp(i->name, ifp->name, INTERFACE_NAMSIZ)) {
+	if (!strncmp(i->name, ifp->name, IFNAMSIZ)) {
 		rn->info = NULL;
 		route_unlock_node(rn);
 		route_unlock_node(rn);

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -131,7 +131,7 @@ struct static_nexthop {
 	bool nh_registered;
 	bool nh_valid;
 
-	char ifname[INTERFACE_NAMSIZ + 1];
+	char ifname[IFNAMSIZ + 1];
 
 	/* Label information */
 	struct static_nh_label snh_label;
@@ -239,7 +239,7 @@ extern void zebra_stable_node_cleanup(struct route_table *table,
  * Max string return via API static_get_nh_str in size_t
  */
 
-#define NEXTHOP_STR (INET6_ADDRSTRLEN + INTERFACE_NAMSIZ + 25)
+#define NEXTHOP_STR (INET6_ADDRSTRLEN + IFNAMSIZ + 25)
 /*
  * For the given nexthop, returns the string
  * nexthop : returns the formatted string in nexthop

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -830,12 +830,12 @@ int ifam_read(struct ifa_msghdr *ifam)
 	struct interface *ifp = NULL;
 	union sockunion addr, mask, brd;
 	bool dest_same = false;
-	char ifname[INTERFACE_NAMSIZ];
+	char ifname[IFNAMSIZ];
 	short ifnlen = 0;
 	bool isalias = false;
 	uint32_t flags = 0;
 
-	ifname[0] = ifname[INTERFACE_NAMSIZ - 1] = '\0';
+	ifname[0] = ifname[IFNAMSIZ - 1] = '\0';
 
 	/* Allocate and read address information. */
 	ifam_read_mesg(ifam, &addr, &mask, &brd, ifname, &ifnlen);
@@ -847,7 +847,7 @@ int ifam_read(struct ifa_msghdr *ifam)
 		return -1;
 	}
 
-	if (ifnlen && strncmp(ifp->name, ifname, INTERFACE_NAMSIZ))
+	if (ifnlen && strncmp(ifp->name, ifname, IFNAMSIZ))
 		isalias = true;
 
 	/*
@@ -991,7 +991,7 @@ void rtm_read(struct rt_msghdr *rtm)
 	int flags;
 	uint32_t zebra_flags;
 	union sockunion dest, mask, gate;
-	char ifname[INTERFACE_NAMSIZ + 1];
+	char ifname[IFNAMSIZ + 1];
 	short ifnlen = 0;
 	struct nexthop nh;
 	struct prefix p;

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -58,7 +58,7 @@ DEFINE_MTYPE_STATIC(ZEBRA, ADV_IF, "Advertised Interface");
 
 /* adv list node */
 struct adv_if {
-	char name[INTERFACE_NAMSIZ];
+	char name[IFNAMSIZ];
 	struct adv_if_list_item list_item;
 };
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -64,7 +64,7 @@ static void zserv_encode_interface(struct stream *s, struct interface *ifp)
 	/* Interface information. */
 	struct zebra_if *zif = ifp->info;
 
-	stream_put(s, ifp->name, INTERFACE_NAMSIZ);
+	stream_put(s, ifp->name, IFNAMSIZ);
 	stream_putl(s, ifp->ifindex);
 	stream_putc(s, ifp->status);
 	stream_putq(s, ifp->flags);
@@ -842,7 +842,7 @@ void zsend_rule_notify_owner(const struct zebra_dplane_ctx *ctx,
 	stream_putl(s, dplane_ctx_rule_get_seq(ctx));
 	stream_putl(s, dplane_ctx_rule_get_priority(ctx));
 	stream_putl(s, dplane_ctx_rule_get_unique(ctx));
-	stream_put(s, dplane_ctx_rule_get_ifname(ctx), INTERFACE_NAMSIZ);
+	stream_put(s, dplane_ctx_rule_get_ifname(ctx), IFNAMSIZ);
 
 	stream_putw_at(s, 0, stream_get_endp(s));
 
@@ -1036,7 +1036,7 @@ int zsend_pw_update(struct zserv *client, struct zebra_pw *pw)
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, ZEBRA_PW_STATUS_UPDATE, pw->vrf_id);
-	stream_write(s, pw->ifname, INTERFACE_NAMSIZ);
+	stream_write(s, pw->ifname, IFNAMSIZ);
 	stream_putl(s, pw->ifindex);
 	stream_putl(s, pw->status);
 
@@ -3008,7 +3008,7 @@ static void zread_srv6_manager_request(ZAPI_HANDLER_ARGS)
 static void zread_pseudowire(ZAPI_HANDLER_ARGS)
 {
 	struct stream *s;
-	char ifname[INTERFACE_NAMSIZ];
+	char ifname[IFNAMSIZ];
 	ifindex_t ifindex;
 	int type;
 	int af;
@@ -3024,8 +3024,8 @@ static void zread_pseudowire(ZAPI_HANDLER_ARGS)
 	s = msg;
 
 	/* Get data. */
-	STREAM_GET(ifname, s, INTERFACE_NAMSIZ);
-	ifname[INTERFACE_NAMSIZ - 1] = '\0';
+	STREAM_GET(ifname, s, IFNAMSIZ);
+	ifname[IFNAMSIZ - 1] = '\0';
 	STREAM_GETL(s, ifindex);
 	STREAM_GETL(s, type);
 	STREAM_GETL(s, af);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -391,7 +391,7 @@ struct zebra_dplane_ctx {
 	vrf_id_t zd_vrf_id;
 	uint32_t zd_table_id;
 
-	char zd_ifname[INTERFACE_NAMSIZ];
+	char zd_ifname[IFNAMSIZ];
 	ifindex_t zd_ifindex;
 
 	/* Support info for different kinds of updates */

--- a/zebra/zebra_mlag.c
+++ b/zebra/zebra_mlag.c
@@ -985,8 +985,7 @@ int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 			/* No Batching */
 			stream_putw(s, MLAG_MSG_NO_BATCH);
 			/* Actual Data */
-			zebra_fill_protobuf_msg(s, msg->peerlink,
-						INTERFACE_NAMSIZ);
+			zebra_fill_protobuf_msg(s, msg->peerlink, IFNAMSIZ);
 			stream_putl(s, msg->my_role);
 			stream_putl(s, msg->peer_state);
 			zebra_mlag_status_update__free_unpacked(msg, NULL);
@@ -1034,9 +1033,9 @@ int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 			stream_putl(s, msg->vrf_id);
 			if (msg->owner_id == MLAG_OWNER_INTERFACE)
 				zebra_fill_protobuf_msg(s, msg->intf_name,
-							INTERFACE_NAMSIZ);
+							IFNAMSIZ);
 			else
-				stream_put(s, NULL, INTERFACE_NAMSIZ);
+				stream_put(s, NULL, IFNAMSIZ);
 			zebra_mlag_mroute_add__free_unpacked(msg, NULL);
 		} break;
 		case ZEBRA_MLAG__HEADER__MESSAGE_TYPE__ZEBRA_MLAG_MROUTE_DEL: {
@@ -1061,9 +1060,9 @@ int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 			stream_putl(s, msg->vrf_id);
 			if (msg->owner_id == MLAG_OWNER_INTERFACE)
 				zebra_fill_protobuf_msg(s, msg->intf_name,
-							INTERFACE_NAMSIZ);
+							IFNAMSIZ);
 			else
-				stream_put(s, NULL, INTERFACE_NAMSIZ);
+				stream_put(s, NULL, IFNAMSIZ);
 			zebra_mlag_mroute_del__free_unpacked(msg, NULL);
 		} break;
 		case ZEBRA_MLAG__HEADER__MESSAGE_TYPE__ZEBRA_MLAG_MROUTE_ADD_BULK: {
@@ -1085,8 +1084,7 @@ int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 
 			/* Actual Data */
 			for (i = 0; i < Bulk_msg->n_mroute_add; i++) {
-				if (STREAM_SIZE(s)
-				    < VRF_NAMSIZ + 22 + INTERFACE_NAMSIZ) {
+				if (STREAM_SIZE(s) < VRF_NAMSIZ + 22 + IFNAMSIZ) {
 					zlog_warn(
 						"We have received more messages than we can parse at this point in time: %zu",
 						Bulk_msg->n_mroute_add);
@@ -1105,11 +1103,11 @@ int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 				stream_putc(s, msg->am_i_dual_active);
 				stream_putl(s, msg->vrf_id);
 				if (msg->owner_id == MLAG_OWNER_INTERFACE)
-					zebra_fill_protobuf_msg(
-						s, msg->intf_name,
-						INTERFACE_NAMSIZ);
+					zebra_fill_protobuf_msg(s,
+								msg->intf_name,
+								IFNAMSIZ);
 				else
-					stream_put(s, NULL, INTERFACE_NAMSIZ);
+					stream_put(s, NULL, IFNAMSIZ);
 			}
 
 			stream_putw_at(s, length_spot, i + 1);
@@ -1136,8 +1134,7 @@ int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 
 			/* Actual Data */
 			for (i = 0; i < Bulk_msg->n_mroute_del; i++) {
-				if (STREAM_SIZE(s)
-				    < VRF_NAMSIZ + 16 + INTERFACE_NAMSIZ) {
+				if (STREAM_SIZE(s) < VRF_NAMSIZ + 16 + IFNAMSIZ) {
 					zlog_warn(
 						"We have received more messages than we can parse at this time");
 					break;
@@ -1152,11 +1149,11 @@ int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 				stream_putl(s, msg->owner_id);
 				stream_putl(s, msg->vrf_id);
 				if (msg->owner_id == MLAG_OWNER_INTERFACE)
-					zebra_fill_protobuf_msg(
-						s, msg->intf_name,
-						INTERFACE_NAMSIZ);
+					zebra_fill_protobuf_msg(s,
+								msg->intf_name,
+								IFNAMSIZ);
 				else
-					stream_put(s, NULL, INTERFACE_NAMSIZ);
+					stream_put(s, NULL, IFNAMSIZ);
 			}
 
 			stream_putw_at(s, length_spot, i + 1);

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -234,7 +234,7 @@ struct pbr_rule_unique_lookup {
 	struct zebra_pbr_rule *rule;
 	int sock;
 	uint32_t unique;
-	char ifname[INTERFACE_NAMSIZ + 1];
+	char ifname[IFNAMSIZ + 1];
 	vrf_id_t vrf_id;
 };
 
@@ -259,7 +259,7 @@ pbr_rule_lookup_unique(struct zebra_pbr_rule *zrule)
 	struct pbr_rule_unique_lookup pul;
 
 	pul.unique = zrule->rule.unique;
-	strlcpy(pul.ifname, zrule->rule.ifname, INTERFACE_NAMSIZ);
+	strlcpy(pul.ifname, zrule->rule.ifname, IFNAMSIZ);
 	pul.rule = NULL;
 	pul.vrf_id = zrule->vrf_id;
 	pul.sock = zrule->sock;

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -46,7 +46,7 @@ struct zebra_pbr_rule {
 
 	struct pbr_rule rule;
 
-	char ifname[INTERFACE_NAMSIZ];
+	char ifname[IFNAMSIZ];
 
 	struct zebra_pbr_action action;
 

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -678,7 +678,7 @@ void zebra_ptm_bfd_dst_register(ZAPI_HANDLER_ARGS)
 	uint8_t detect_mul;
 	unsigned int min_rx_timer;
 	unsigned int min_tx_timer;
-	char if_name[INTERFACE_NAMSIZ];
+	char if_name[IFNAMSIZ];
 	uint8_t len;
 	void *out_ctxt;
 	char buf[INET6_ADDRSTRLEN];
@@ -841,7 +841,7 @@ void zebra_ptm_bfd_dst_deregister(ZAPI_HANDLER_ARGS)
 	struct prefix src_p;
 	struct prefix dst_p;
 	uint8_t multi_hop;
-	char if_name[INTERFACE_NAMSIZ];
+	char if_name[IFNAMSIZ];
 	uint8_t len;
 	char buf[INET6_ADDRSTRLEN];
 	char tmp_buf[64];

--- a/zebra/zebra_pw.h
+++ b/zebra/zebra_pw.h
@@ -24,7 +24,7 @@ extern "C" {
 struct zebra_pw {
 	RB_ENTRY(zebra_pw) pw_entry, static_pw_entry;
 	vrf_id_t vrf_id;
-	char ifname[INTERFACE_NAMSIZ];
+	char ifname[IFNAMSIZ];
 	ifindex_t ifindex;
 	int type;
 	int af;


### PR DESCRIPTION
INTERFACE_NAMSIZ is just a redefine of IFNAMSIZ and IFNAMSIZ is the standard for interface name length on all platforms that FRR currently compiles on.