### PR TITLE
lib: fix show route map JSON display

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -1459,8 +1459,6 @@ zebra Terminal Mode Commands
 
 .. clicmd:: show ip prefix-list [NAME]
 
-.. clicmd:: show route-map [NAME]
-
 .. clicmd:: show ip protocol
 
 .. clicmd:: show ip forward

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1070,20 +1070,17 @@ static int vty_show_route_map(struct vty *vty, const char *name, bool use_json)
 {
 	struct route_map *map;
 	json_object *json = NULL;
-	json_object *json_proto = NULL;
 
-	if (use_json) {
+	if (use_json)
 		json = json_object_new_object();
-		json_proto = json_object_new_object();
-		json_object_object_add(json, frr_protonameinst, json_proto);
-	} else
+	else
 		vty_out(vty, "%s:\n", frr_protonameinst);
 
 	if (name) {
 		map = route_map_lookup_by_name(name);
 
 		if (map) {
-			vty_show_route_map_entry(vty, map, json_proto);
+			vty_show_route_map_entry(vty, map, json);
 		} else if (!use_json) {
 			vty_out(vty, "%s: 'route-map %s' not found\n",
 				frr_protonameinst, name);
@@ -1099,7 +1096,7 @@ static int vty_show_route_map(struct vty *vty, const char *name, bool use_json)
 		list_sort(maplist, sort_route_map);
 
 		for (ALL_LIST_ELEMENTS_RO(maplist, ln, map))
-			vty_show_route_map_entry(vty, map, json_proto);
+			vty_show_route_map_entry(vty, map, json);
 
 		list_delete(&maplist);
 	}
@@ -3145,13 +3142,13 @@ DEFPY (rmap_clear_counters,
 
 }
 
-DEFUN (rmap_show_name,
-       rmap_show_name_cmd,
-       "show route-map [WORD] [json]",
-       SHOW_STR
-       "route-map information\n"
-       "route-map name\n"
-       JSON_STR)
+DEFUN_NOSH (rmap_show_name,
+            rmap_show_name_cmd,
+            "show route-map [WORD] [json]",
+            SHOW_STR
+            "route-map information\n"
+            "route-map name\n"
+            JSON_STR)
 {
 	bool uj = use_json(argc, argv);
 	int idx = 0;

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -3396,6 +3396,63 @@ DEFUN (vtysh_show_running_config,
 	return vtysh_write_terminal(self, vty, argc, argv);
 }
 
+static void show_route_map_send(const char *route_map, bool json)
+{
+	unsigned int i;
+	bool first = true;
+	char command_line[128];
+
+	snprintf(command_line, sizeof(command_line), "show route-map ");
+	if (route_map)
+		strlcat(command_line, route_map, sizeof(command_line));
+	if (json)
+		strlcat(command_line, " json", sizeof(command_line));
+
+	if (json)
+		vty_out(vty, "{");
+
+	for (i = 0; i < array_size(vtysh_client); i++) {
+		const struct vtysh_client *client = &vtysh_client[i];
+		bool is_connected = true;
+
+		if (!CHECK_FLAG(client->flag, VTYSH_RMAP))
+			continue;
+
+		for (; client; client = client->next)
+			if (client->fd < 0)
+				is_connected = false;
+
+		if (!is_connected)
+			continue;
+
+		if (json && !first)
+			vty_out(vty, ",");
+		else
+			first = false;
+
+		if (json)
+			vty_out(vty, "\"%s\":", vtysh_client[i].name);
+
+		vtysh_client_execute_name(vtysh_client[i].name, command_line);
+	}
+
+	if (json)
+		vty_out(vty, "}\n");
+}
+
+DEFPY (show_route_map,
+       show_route_map_cmd,
+       "show route-map [WORD]$route_map [json]$json",
+       SHOW_STR
+       "route-map information\n"
+       "route-map name\n"
+       JSON_STR)
+{
+	show_route_map_send(route_map, !!json);
+
+	return CMD_SUCCESS;
+}
+
 DEFUN (vtysh_integrated_config,
        vtysh_integrated_config_cmd,
        "service integrated-vtysh-config",
@@ -5046,6 +5103,8 @@ void vtysh_init_vty(void)
 	install_element(ENABLE_NODE, &vtysh_show_running_config_cmd);
 	install_element(ENABLE_NODE, &vtysh_copy_running_config_cmd);
 	install_element(ENABLE_NODE, &vtysh_copy_to_running_cmd);
+
+	install_element(ENABLE_NODE, &show_route_map_cmd);
 
 	/* "write terminal" command. */
 	install_element(ENABLE_NODE, &vtysh_write_terminal_cmd);


### PR DESCRIPTION
Fixes #13515 .

This PR moves the `show route-map` daemon output aggregation to `vtysh` so we can properly format the JSON output. It also removes a `zebra` lingering documentation that duplicates the one found in `route-map` docs.