### PR TITLE
zebra: fix dplane_ctx_iptable use-after-free

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -4047,6 +4047,7 @@ static int dplane_ctx_iptable_init(struct zebra_dplane_ctx *ctx,
 
 	ctx->zd_vrf_id = iptable->vrf_id;
 	memcpy(&ctx->u.iptable, iptable, sizeof(struct zebra_pbr_iptable));
+	ctx->u.iptable.interface_name_list = NULL;
 	if (iptable->nb_interface > 0) {
 		ctx->u.iptable.interface_name_list = list_new();
 		ctx->u.iptable.interface_name_list->del =


### PR DESCRIPTION
Fix a crash because a use-after-free.

> =================================================================
> ==1249835==ERROR: AddressSanitizer: heap-use-after-free on address 0x604000074210 at pc 0x7fa1b42a652c bp 0x7ffc477a2aa0 sp 0x7ffc477a2a98
> READ of size 8 at 0x604000074210 thread T0
>     #0 0x7fa1b42a652b in list_delete_all_node git/frr/lib/linklist.c:299:20
>     #1 0x7fa1b42a683f in list_delete git/frr/lib/linklist.c:312:2
>     #2 0x5ee515 in dplane_ctx_free_internal git/frr/zebra/zebra_dplane.c:858:4
>     #3 0x5ee59c in dplane_ctx_free git/frr/zebra/zebra_dplane.c:884:2
>     #4 0x5ee544 in dplane_ctx_fini git/frr/zebra/zebra_dplane.c:905:2
>     #5 0x7045c0 in rib_process_dplane_results git/frr/zebra/zebra_rib.c:4928:4
>     #6 0x7fa1b4434fb2 in event_call git/frr/lib/event.c:1970:2
>     #7 0x7fa1b42a0ccf in frr_run git/frr/lib/libfrr.c:1213:3
>     #8 0x556808 in main git/frr/zebra/main.c:488:2
>     #9 0x7fa1b3d0bd09 in __libc_start_main csu/../csu/libc-start.c:308:16
>     #10 0x4453e9 in _start (/usr/lib/frr/zebra+0x4453e9)
>
> 0x604000074210 is located 0 bytes inside of 40-byte region [0x604000074210,0x604000074238)
> freed by thread T0 here:
>     #0 0x4bf1dd in free (/usr/lib/frr/zebra+0x4bf1dd)
>     #1 0x7fa1b42df0c0 in qfree git/frr/lib/memory.c:130:2
>     #2 0x7fa1b42a68ce in list_free_internal git/frr/lib/linklist.c:24:2
>     #3 0x7fa1b42a6870 in list_delete git/frr/lib/linklist.c:313:2
>     #4 0x5ee515 in dplane_ctx_free_internal git/frr/zebra/zebra_dplane.c:858:4
>     #5 0x5ee59c in dplane_ctx_free git/frr/zebra/zebra_dplane.c:884:2
>     #6 0x5ee544 in dplane_ctx_fini git/frr/zebra/zebra_dplane.c:905:2
>     #7 0x7045c0 in rib_process_dplane_results git/frr/zebra/zebra_rib.c:4928:4
>     #8 0x7fa1b4434fb2 in event_call git/frr/lib/event.c:1970:2
>     #9 0x7fa1b42a0ccf in frr_run git/frr/lib/libfrr.c:1213:3
>     #10 0x556808 in main git/frr/zebra/main.c:488:2
>     #11 0x7fa1b3d0bd09 in __libc_start_main csu/../csu/libc-start.c:308:16
>
> previously allocated by thread T0 here:
>     #0 0x4bf5d2 in calloc (/usr/lib/frr/zebra+0x4bf5d2)
>     #1 0x7fa1b42dee18 in qcalloc git/frr/lib/memory.c:105:27
>     #2 0x7fa1b42a3784 in list_new git/frr/lib/linklist.c:18:9
>     #3 0x6d165f in pbr_iptable_alloc_intern git/frr/zebra/zebra_pbr.c:1015:29
>     #4 0x7fa1b426ad1f in hash_get git/frr/lib/hash.c:147:13
>     #5 0x6d15f2 in zebra_pbr_add_iptable git/frr/zebra/zebra_pbr.c:1030:13
>     #6 0x5db2a3 in zread_iptable git/frr/zebra/zapi_msg.c:3759:3
>     #7 0x5e365d in zserv_handle_commands git/frr/zebra/zapi_msg.c:4039:3
>     #8 0x7e09fc in zserv_process_messages git/frr/zebra/zserv.c:520:3
>     #9 0x7fa1b4434fb2 in event_call git/frr/lib/event.c:1970:2
>     #10 0x7fa1b42a0ccf in frr_run git/frr/lib/libfrr.c:1213:3
>     #11 0x556808 in main git/frr/zebra/main.c:488:2
>     #12 0x7fa1b3d0bd09 in __libc_start_main csu/../csu/libc-start.c:308:16

Fixes: 1cc380679e ("zebra: Actually free all memory associated ctx->u.iptable.interface_name_list")