### PR TITLE
docker: fix typos in docs for ubuntu20-ci and ubuntu22-ci

### DIFF
--- a/doc/developer/building-docker.rst
+++ b/doc/developer/building-docker.rst
@@ -14,7 +14,7 @@ source-built FRR on the following base platforms:
 
 The following platform images are used to support Travis CI and can also
 be used to reproduce topotest failures when the docker host is Ubuntu
-(tested on 18.04 and 20.04):
+(tested on 20.04 and 22.04):
 
 * Ubuntu 20.04
 * Ubuntu 22.04
@@ -139,12 +139,12 @@ Build image (from project root directory)::
 
 Running Full Topotest::
 
-   docker run --init -it --privileged --name frr -v /lib/modules:/lib/modules \
+   docker run --init -it --privileged --name frr-ubuntu20 -v /lib/modules:/lib/modules \
        frr-ubuntu20:latest bash -c 'cd ~/frr/tests/topotests ; sudo pytest -nauto --dist=loadfile'
 
 Extract results from the above run into `run-results` dir and analyze::
 
-   tests/topotest/analyze.py -C frr -Ar run-results
+   tests/topotests/analyze.py -C frr-ubuntu20 -Ar run-results
 
 Start the container::
 
@@ -176,12 +176,12 @@ Build image (from project root directory)::
 
 Running Full Topotest::
 
-   docker run --init -it --privileged --name frr -v /lib/modules:/lib/modules \
+   docker run --init -it --privileged --name frr-ubuntu22 -v /lib/modules:/lib/modules \
        frr-ubuntu22:latest bash -c 'cd ~/frr/tests/topotests ; sudo pytest -nauto --dist=loadfile'
 
 Extract results from the above run into `run-results` dir and analyze::
 
-   tests/topotest/analyze.py -C frr -Ar run-results
+   tests/topotests/analyze.py -C frr-ubuntu22 -Ar run-results
 
 Start the container::
 

--- a/docker/ubuntu20-ci/README.md
+++ b/docker/ubuntu20-ci/README.md
@@ -11,13 +11,13 @@ docker build -t frr-ubuntu20:latest --build-arg=UBUNTU_VERSION=20.04 -f docker/u
 # Running Full Topotest
 
 ```
-docker run --init -it --privileged --name frr -v /lib/modules:/lib/modules frr-ubuntu22:latest bash -c 'cd ~/frr/tests/topotests ; sudo pytest -nauto --dist=loadfile'
+docker run --init -it --privileged --name frr-ubuntu20 -v /lib/modules:/lib/modules frr-ubuntu20:latest bash -c 'cd ~/frr/tests/topotests ; sudo pytest -nauto --dist=loadfile'
 ```
 
 # Extract results from the above run into `run-results` dir and analyze
 
 ```
-tests/topotest/analyze.py -C frr -Ar run-results
+tests/topotests/analyze.py -C frr-ubuntu20 -Ar run-results
 ```
 
 # Running
@@ -41,13 +41,13 @@ docker exec -it frr-ubuntu20 bash
 # topotest -- when Host O/S is Ubuntu only
 
 ```
-docker exec frr-ubuntu20 bash -c 'cd ~/frr/tests/topotests/ospf-topo1 ; sudo pytest test_ospf_topo1.py'
+docker exec frr-ubuntu20 bash -c 'cd ~/frr/tests/topotests/ospf_topo1 ; sudo pytest test_ospf_topo1.py'
 ```
 
 # stop & remove container
 
 ```
-docker stop frr-ubuntu20 ; docker rm frr-ubuntu18
+docker stop frr-ubuntu20 ; docker rm frr-ubuntu20
 ```
 
 # remove image

--- a/docker/ubuntu22-ci/README.md
+++ b/docker/ubuntu22-ci/README.md
@@ -11,43 +11,43 @@ docker build -t frr-ubuntu22:latest -f docker/ubuntu-ci/Dockerfile .
 # Running Full Topotest
 
 ```
-docker run --init -it --privileged --name frr -v /lib/modules:/lib/modules frr-ubuntu22:latest bash -c 'cd ~/frr/tests/topotests ; sudo pytest -nauto --dist=loadfile'
+docker run --init -it --privileged --name frr-ubuntu22 -v /lib/modules:/lib/modules frr-ubuntu22:latest bash -c 'cd ~/frr/tests/topotests ; sudo pytest -nauto --dist=loadfile'
 ```
 
 # Extract results from the above run into `run-results` dir and analyze
 
 ```
-tests/topotest/analyze.py -C frr -Ar run-results
+tests/topotests/analyze.py -C frr-ubuntu22 -Ar run-results
 ```
 
 # Running
 
 ```
-docker run -d --init --privileged --name frr --mount type=bind,source=/lib/modules,target=/lib/modules frr-ubuntu22:latest
+docker run -d --init --privileged --name frr-ubuntu22 --mount type=bind,source=/lib/modules,target=/lib/modules frr-ubuntu22:latest
 ```
 
 # make check
 
 ```
-docker exec frr bash -c 'cd ~/frr ; make check'
+docker exec frr-ubuntu22 bash -c 'cd ~/frr ; make check'
 ```
 
 # interactive bash
 
 ```
-docker exec -it frr bash
+docker exec -it frr-ubuntu22 bash
 ```
 
 # topotest -- when Host O/S is Ubuntu only
 
 ```
-docker exec frr bash -c 'cd ~/frr/tests/topotests/ospf-topo1 ; sudo pytest test_ospf_topo1.py'
+docker exec frr-ubuntu22 bash -c 'cd ~/frr/tests/topotests/ospf_topo1 ; sudo pytest test_ospf_topo1.py'
 ```
 
 # stop & remove container
 
 ```
-docker stop frr ; docker rm frr
+docker stop frr-ubuntu22 ; docker rm frr-ubuntu22
 ```
 
 # remove image


### PR DESCRIPTION
Fix typos in docs.
Also sync doc/developer/building-docker.rst with docker/ubuntu20-ci/README.md and docker/ubuntu22-ci/README.md