### PR TITLE
tools: fix frr-reload interface desc cmd

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1106,6 +1106,17 @@ def ignore_delete_re_add_lines(lines_to_add, lines_to_del):
             lines_to_del.remove((ctx_keys, line))
             lines_to_del.insert(index, (ctx_keys, "description"))
 
+        # interface x ; description blah
+        # no form of description does not accept any argument,
+        # strip arg before rendering
+        if (
+            ctx_keys[0].startswith("interface ")
+            and line
+            and line.startswith("description ")
+        ):
+            lines_to_del.remove((ctx_keys, line))
+            lines_to_del.insert(index, (ctx_keys, "description"))
+
         # If there is a change in the segment routing block ranges, do it
         # in-place, to avoid requesting spurious label chunks which might fail
         if line and "segment-routing global-block" in line:


### PR DESCRIPTION
Fix frr-reload script to only render 'no description' rather than 'no description blah'


Testing Done:

Before:
```
2023-11-29 02:38:55,758  INFO: Failed to execute interface hostbond_1 no description hostbond_1_to_host exit
2023-11-29 02:38:55,758 ERROR: "interface hostbond_1 --  no description hostbond_1_to_host -- exit" we failed to remove this command 2023-11-29 02:38:55,758 ERROR: % Unknown command:  no description hostbond_1_to_host
```
After fix it removes the description under interface.

Signed-off-by: Chirag Shah <chirag@nvidia.com>