### PR TITLE
tools: fix frr-reload for nbr deletion

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -992,15 +992,16 @@ def bgp_delete_move_lines(lines_to_add, lines_to_del):
                 del_dict[ctx_keys[0]][re_pg.group(1)] = list()
                 found_pg_del_cmd = True
 
+    # move neighbor remote-as lines at the end
+    for ctx_keys, line in lines_to_del_to_app:
+        lines_to_del.remove((ctx_keys, line))
+        lines_to_del.append((ctx_keys, line))
+
     if found_pg_del_cmd == False:
         bgp_delete_inst_move_line(lines_to_del)
         if del_nbr_dict:
             bgp_remove_neighbor_cfg(lines_to_del, del_nbr_dict)
         return (lines_to_add, lines_to_del)
-
-    for ctx_keys, line in lines_to_del_to_app:
-        lines_to_del.remove((ctx_keys, line))
-        lines_to_del.append((ctx_keys, line))
 
     # {'router bgp 65001': {'PG': ['10.1.1.2'], 'PG1': ['10.1.1.21']},
     #  'router bgp 65001 vrf vrf1': {'PG': ['10.1.1.2'], 'PG1': ['10.1.1.21']}}


### PR DESCRIPTION
bgp neighbor config can have multiple lines, if neighbor is deleted via frr-reload, no neighbor remote-as <> wipes out the neighbor, subsequent neighbor associated config deletion would throw generic error.
Frr-reload needs to move neighbor remote-as line to end and allow all other config lines to be removed.


Testing Done:
config:
```
neighbor swp3 interface remote-as external
 neighbor swp3 bfd 3 300 300
 neighbor swp3 password leaf11-spine
```

```
INFO: Executed "router bgp 65101  no neighbor swp3 interface remote-as external"
INFO: Failed to execute router bgp 65101  no neighbor swp3 bfd 3 300 300
INFO: Failed to execute router bgp 65101  no neighbor swp3 bfd 3 300
INFO: Failed to execute router bgp 65101  no neighbor swp3 bfd 3
INFO: Failed to execute router bgp 65101  no neighbor swp3 bfd
INFO: Failed to execute router bgp 65101  no neighbor swp3
INFO: Failed to execute router bgp 65101  no neighbor
INFO: Failed to execute router bgp 65101  no
  ERROR: "router bgp 65101 --  no" we failed to remove this command
  ERROR: % Specify remote-as or peer-group commands first

INFO: Failed to execute router bgp 65101  no neighbor swp3 password leaf11-spine
INFO: Failed to execute router bgp 65101  no neighbor swp3 password
INFO: Failed to execute router bgp 65101  no neighbor swp3
INFO: Failed to execute router bgp 65101  no neighbor
INFO: Failed to execute router bgp 65101  no
 ERROR: "router bgp 65101 --  no" we failed to remove this command
 ERROR: % Specify remote-as or peer-group commands first
```

After fix:
```
move the neighbor remote-as deletion line to end which allows to remove other neighbor associated lines to be deleted.
router bgp 65101  no neighbor swp3 interface remote-as external
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>
