### PR TITLE
bgpd: Free Memory for confed_peers in bgp_free

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4060,10 +4060,14 @@ void bgp_free(struct bgp *bgp)
 	bgp_srv6_cleanup(bgp);
 	bgp_confederation_id_unset(bgp);
 
+	for (int i = 0; i < bgp->confed_peers_cnt; i++)
+		XFREE(MTYPE_BGP_NAME, bgp->confed_peers[i].as_pretty);
+
 	XFREE(MTYPE_BGP_NAME, bgp->as_pretty);
 	XFREE(MTYPE_BGP_NAME, bgp->name);
 	XFREE(MTYPE_BGP_NAME, bgp->name_pretty);
 	XFREE(MTYPE_BGP_NAME, bgp->snmp_stats);
+	XFREE(MTYPE_BGP_CONFED_LIST, bgp->confed_peers);
 
 	XFREE(MTYPE_BGP, bgp);
 }


### PR DESCRIPTION
Release memory associated with `bgp->confed_peers` in the `bgp_free` function to ensure proper cleanup. This fix prevents memory leaks related to `confed_peers`.

The ASan leak log for reference:

```
***********************************************************************************
Address Sanitizer Error detected in bgp_confederation_astype.test_bgp_confederation_astype/r2.asan.bgpd.15045

=================================================================
==15045==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f5666787b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f56661867c7 in qrealloc lib/memory.c:112
    #2 0x55a3b4736a40 in bgp_confederation_peers_add bgpd/bgpd.c:681
    #3 0x55a3b46b3363 in bgp_confederation_peers bgpd/bgp_vty.c:2068
    #4 0x7f5666109021 in cmd_execute_command_real lib/command.c:978
    #5 0x7f5666109a52 in cmd_execute_command_strict lib/command.c:1087
    #6 0x7f5666109ab1 in command_config_read_one_line lib/command.c:1247
    #7 0x7f5666109d98 in config_from_file lib/command.c:1300
    #8 0x7f566623c6d0 in vty_read_file lib/vty.c:2614
    #9 0x7f566623c7fa in vty_read_config lib/vty.c:2860
    #10 0x7f56661682e4 in frr_config_read_in lib/libfrr.c:978
    #11 0x7f5666226034 in event_call lib/event.c:1974
    #12 0x7f566616942b in frr_run lib/libfrr.c:1214
    #13 0x55a3b44f319d in main bgpd/bgp_main.c:510
    #14 0x7f56651acc86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Indirect leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x7f5666720538 in strdup (/usr/lib/x86_64-linux-gnu/libasan.so.4+0x77538)
    #1 0x7f5666186898 in qstrdup lib/memory.c:117
    #2 0x55a3b4736adb in bgp_confederation_peers_add bgpd/bgpd.c:687
    #3 0x55a3b46b3363 in bgp_confederation_peers bgpd/bgp_vty.c:2068
    #4 0x7f5666109021 in cmd_execute_command_real lib/command.c:978
    #5 0x7f5666109a52 in cmd_execute_command_strict lib/command.c:1087
    #6 0x7f5666109ab1 in command_config_read_one_line lib/command.c:1247
    #7 0x7f5666109d98 in config_from_file lib/command.c:1300
    #8 0x7f566623c6d0 in vty_read_file lib/vty.c:2614
    #9 0x7f566623c7fa in vty_read_config lib/vty.c:2860
    #10 0x7f56661682e4 in frr_config_read_in lib/libfrr.c:978
    #11 0x7f5666226034 in event_call lib/event.c:1974
    #12 0x7f566616942b in frr_run lib/libfrr.c:1214
    #13 0x55a3b44f319d in main bgpd/bgp_main.c:510
    #14 0x7f56651acc86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)
	***********************************************************************************
```