### PR TITLE
zebra: Set Free Functions for Traffic Control Hash Tables

### DIFF
--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -241,9 +241,9 @@ void zebra_router_terminate(void)
 			    zebra_pbr_ipset_entry_free);
 	hash_clean_and_free(&zrouter.ipset_hash, zebra_pbr_ipset_free);
 	hash_clean_and_free(&zrouter.iptable_hash, zebra_pbr_iptable_free);
-	hash_clean_and_free(&zrouter.filter_hash, NULL);
-	hash_clean_and_free(&zrouter.qdisc_hash, NULL);
-	hash_clean_and_free(&zrouter.class_hash, NULL);
+	hash_clean_and_free(&zrouter.filter_hash, (void (*)(void *)) zebra_tc_filter_free);
+	hash_clean_and_free(&zrouter.qdisc_hash, (void (*)(void *)) zebra_tc_qdisc_free);
+	hash_clean_and_free(&zrouter.class_hash, (void (*)(void *)) zebra_tc_class_free);
 
 #ifdef HAVE_SCRIPTING
 	zebra_script_destroy();

--- a/zebra/zebra_tc.c
+++ b/zebra/zebra_tc.c
@@ -132,13 +132,18 @@ static void *tc_qdisc_alloc_intern(void *arg)
 	return new;
 }
 
+void zebra_tc_qdisc_free(struct zebra_tc_qdisc *qdisc)
+{
+	XFREE(MTYPE_TC_QDISC, qdisc);
+}
+
 static struct zebra_tc_qdisc *tc_qdisc_free(struct zebra_tc_qdisc *hash_data,
 					    bool free_data)
 {
 	hash_release(zrouter.qdisc_hash, hash_data);
 
 	if (free_data) {
-		XFREE(MTYPE_TC_QDISC, hash_data);
+		zebra_tc_qdisc_free(hash_data);
 		return NULL;
 	}
 
@@ -178,7 +183,7 @@ void zebra_tc_qdisc_install(struct zebra_tc_qdisc *qdisc)
 			new = hash_get(zrouter.qdisc_hash, qdisc,
 				       tc_qdisc_alloc_intern);
 			(void)dplane_tc_qdisc_install(new);
-			XFREE(MTYPE_TC_QDISC, old);
+			zebra_tc_qdisc_free(old);
 		}
 	} else {
 		new = hash_get(zrouter.qdisc_hash, qdisc,
@@ -243,13 +248,18 @@ static void *tc_class_alloc_intern(void *arg)
 	return new;
 }
 
+void zebra_tc_class_free(struct zebra_tc_class *class)
+{
+	XFREE(MTYPE_TC_CLASS, class);
+}
+
 static struct zebra_tc_class *tc_class_free(struct zebra_tc_class *hash_data,
 					    bool free_data)
 {
 	hash_release(zrouter.class_hash, hash_data);
 
 	if (free_data) {
-		XFREE(MTYPE_TC_CLASS, hash_data);
+		zebra_tc_class_free(hash_data);
 		return NULL;
 	}
 
@@ -353,13 +363,18 @@ bool zebra_tc_filter_hash_equal(const void *arg1, const void *arg2)
 	return true;
 }
 
+void zebra_tc_filter_free(struct zebra_tc_filter *filter)
+{
+	XFREE(MTYPE_TC_FILTER, filter);
+}
+
 static struct zebra_tc_filter *tc_filter_free(struct zebra_tc_filter *hash_data,
 					      bool free_data)
 {
 	hash_release(zrouter.filter_hash, hash_data);
 
 	if (free_data) {
-		XFREE(MTYPE_TC_FILTER, hash_data);
+		zebra_tc_filter_free(hash_data);
 		return NULL;
 	}
 

--- a/zebra/zebra_tc.h
+++ b/zebra/zebra_tc.h
@@ -42,16 +42,19 @@ uint32_t zebra_tc_qdisc_hash_key(const void *arg);
 bool zebra_tc_qdisc_hash_equal(const void *arg1, const void *arg2);
 void zebra_tc_qdisc_install(struct zebra_tc_qdisc *qdisc);
 void zebra_tc_qdisc_uninstall(struct zebra_tc_qdisc *qdisc);
+void zebra_tc_qdisc_free(struct zebra_tc_qdisc *qdisc);
 
 uint32_t zebra_tc_class_hash_key(const void *arg);
 bool zebra_tc_class_hash_equal(const void *arg1, const void *arg2);
 void zebra_tc_class_add(struct zebra_tc_class *class);
 void zebra_tc_class_delete(struct zebra_tc_class *class);
+void zebra_tc_class_free(struct zebra_tc_class *class);
 
 const char *tc_filter_kind2str(uint32_t type);
 enum tc_qdisc_kind tc_filter_str2kind(const char *type);
 void zebra_tc_filter_add(struct zebra_tc_filter *filter);
 void zebra_tc_filter_delete(struct zebra_tc_filter *filter);
+void zebra_tc_filter_free(struct zebra_tc_filter *filter);
 
 void zebra_tc_filters_free(void *arg);
 uint32_t zebra_tc_filter_hash_key(const void *arg);


### PR DESCRIPTION
Configure hash table cleanup with specific free functions for `zrouter.filter_hash`, `zrouter.qdisc_hash`, and `zrouter.class_hash`. This ensures proper memory cleanup, addressing memory leaks.

The ASan leak log for reference:

```
***********************************************************************************
Address Sanitizer Error detected in tc_basic.test_tc_basic/r1.asan.zebra.15495

=================================================================
==15495==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 176 byte(s) in 1 object(s) allocated from:
    #0 0x7fd5660ffd28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7fd565afe238 in qcalloc lib/memory.c:105
    #2 0x5564521c6c9e in tc_filter_alloc_intern zebra/zebra_tc.c:389
    #3 0x7fd565ac49e8 in hash_get lib/hash.c:147
    #4 0x5564521c7c74 in zebra_tc_filter_add zebra/zebra_tc.c:409
    #5 0x55645210755a in zread_tc_filter zebra/zapi_msg.c:3428
    #6 0x5564521127c1 in zserv_handle_commands zebra/zapi_msg.c:4004
    #7 0x5564522208b2 in zserv_process_messages zebra/zserv.c:520
    #8 0x7fd565b9e034 in event_call lib/event.c:1974
    #9 0x7fd565ae142b in frr_run lib/libfrr.c:1214
    #10 0x5564520c14b1 in main zebra/main.c:492
    #11 0x7fd564ec2c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7fd5660ffd28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7fd565afe238 in qcalloc lib/memory.c:105
    #2 0x5564521c6c6e in tc_class_alloc_intern zebra/zebra_tc.c:239
    #3 0x7fd565ac49e8 in hash_get lib/hash.c:147
    #4 0x5564521c784f in zebra_tc_class_add zebra/zebra_tc.c:293
    #5 0x556452107ce5 in zread_tc_class zebra/zapi_msg.c:3315
    #6 0x5564521127c1 in zserv_handle_commands zebra/zapi_msg.c:4004
    #7 0x5564522208b2 in zserv_process_messages zebra/zserv.c:520
    #8 0x7fd565b9e034 in event_call lib/event.c:1974
    #9 0x7fd565ae142b in frr_run lib/libfrr.c:1214
    #10 0x5564520c14b1 in main zebra/main.c:492
    #11 0x7fd564ec2c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 12 byte(s) in 1 object(s) allocated from:
    #0 0x7fd5660ffd28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7fd565afe238 in qcalloc lib/memory.c:105
    #2 0x5564521c6c3e in tc_qdisc_alloc_intern zebra/zebra_tc.c:128
    #3 0x7fd565ac49e8 in hash_get lib/hash.c:147
    #4 0x5564521c753b in zebra_tc_qdisc_install zebra/zebra_tc.c:184
    #5 0x556452108203 in zread_tc_qdisc zebra/zapi_msg.c:3286
    #6 0x5564521127c1 in zserv_handle_commands zebra/zapi_msg.c:4004
    #7 0x5564522208b2 in zserv_process_messages zebra/zserv.c:520
    #8 0x7fd565b9e034 in event_call lib/event.c:1974
    #9 0x7fd565ae142b in frr_run lib/libfrr.c:1214
    #10 0x5564520c14b1 in main zebra/main.c:492
    #11 0x7fd564ec2c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 228 byte(s) leaked in 3 allocation(s).
***********************************************************************************
```