### PR TITLE
ospf6d: rework ospf6 neighbor state display 

### DIFF
--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -846,6 +846,24 @@ DEFPY(ipv6_ospf6_p2xp_neigh_poll_interval,
 
 	p2xp_unicast_hello_sched(p2xp_cfg);
 	return CMD_SUCCESS;
+
+}
+
+/* build state value */
+static void ospf6_neighbor_state_message(struct ospf6_neighbor *on,
+					 char *nstate, size_t nstate_len)
+{
+	/* Neighbor State */
+	if (on->ospf6_if->type == OSPF_IFTYPE_POINTOPOINT)
+		snprintf(nstate, nstate_len, "PointToPoint");
+	else {
+		if (on->router_id == on->drouter)
+			snprintf(nstate, nstate_len, "DR");
+		else if (on->router_id == on->bdrouter)
+			snprintf(nstate, nstate_len, "BR");
+		else
+			snprintf(nstate, nstate_len, "DROther");
+	}
 }
 
 /* show neighbor structure */
@@ -892,6 +910,7 @@ static void ospf6_neighbor_show(struct vty *vty, struct ospf6_neighbor *on,
 		else
 			snprintf(nstate, sizeof(nstate), "DROther");
 	}
+	ospf6_neighbor_state_message(on, nstate, sizeof(nstate));
 
 	/* Duration */
 	monotime_since(&on->last_changed, &res);

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -873,7 +873,7 @@ static void ospf6_neighbor_show(struct vty *vty, struct ospf6_neighbor *on,
 	char router_id[16];
 	char duration[64];
 	struct timeval res;
-	char nstate[16];
+	char nstate[17];
 	char deadtime[64];
 	long h, m, s;
 	json_object *json_route;

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -5089,14 +5089,9 @@ DEFUN (show_ip_ospf_neighbor_all,
 	if (ospf) {
 		ret = show_ip_ospf_neighbor_all_common(vty, ospf, json, uj,
 						       use_vrf);
-		if (uj) {
-			vty_out(vty, "%s\n",
-				json_object_to_json_string_ext(
-					json, JSON_C_TO_STRING_PRETTY));
-		}
-	}
-
-	if (uj)
+		if (uj)
+			vty_json(vty, json);
+	} else if (uj)
 		json_object_free(json);
 
 	return ret;

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -780,15 +780,15 @@ def verify_ospf6_neighbor(tgen, topo=None, dut=None, input_dict=None, lan=False)
                 "neighbors": {
                     "r1": {
                         "state": "Full",
-                        "role": "DR"
+                        "nbrState": "Full/DR"
                     },
                     "r2": {
                         "state": "Full",
-                        "role": "DROther"
+                        "nbrState": "Full/DROther"
                     },
                     "r3": {
                         "state": "Full",
-                        "role": "DROther"
+                        "nbrState": "Full/DROther"
                     }
                 }
             }


### PR DESCRIPTION
A separate function ospf6_neighbor_state_message() is created
to return a string that stands for the neighbor kind: DR, BDR,
DROther, or PointToPoint.

Add the following attributes in each neighbor of the vty command:
'show ipv6 ospf6 neighbor detail json'
- nbrPriority : integer
- Role: DR, BDR, DROther, or PointToPoint
- nbrState : <state>/<Role> where:
   o Role is the above attribute
   o state is "None",    "Down",     "Attempt", "Init", "Twoway",
              "ExStart", "ExChange", "Loading", "Full"
- routerDeadIntervalTimerDueMsec: integer value otherwise "inactive"

Enter in a deprecation workflow for neighborState value, which is
replaced by nbrState.
Add the following attributes in each neighbor of the vty command:
'show ipv6 ospf6 neighbor json':
- nbrPriority : integer
- Role: DR, BDR, DROther, or PointToPoint
- nbrState : <state>/<Role> where:
   o Role is the above attribute
   o state is "None",    "Down",     "Attempt", "Init", "Twoway",
              "ExStart", "ExChange", "Loading", "Full"
- routerDeadIntervalTimerDueMsec: integer value otherwise "inactive"

Enter in a deprecation workflow for state and priority values, which
are replaced by nbrState.

and update related tests