### PR TITLE
pbrd: fix map seq installed flag in json

### DIFF
--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -1667,8 +1667,7 @@ static void vty_json_pbrms(json_object *j, struct vty *vty,
 	json_object_int_add(jpbrm, "sequenceNumber", pbrms->seqno);
 	json_object_int_add(jpbrm, "ruleNumber", pbrms->ruleno);
 	json_object_boolean_add(jpbrm, "vrfUnchanged", pbrms->vrf_unchanged);
-	json_object_boolean_add(jpbrm, "installed",
-				pbr_nht_get_installed(nhg_name));
+	json_object_boolean_add(jpbrm, "installed", pbrms->installed);
 	json_object_string_add(jpbrm, "installedReason",
 			       pbrms->reason ? rbuf : "Valid");
 

--- a/tests/topotests/pbr_topo1/r1/pbr-map.json
+++ b/tests/topotests/pbr_topo1/r1/pbr-map.json
@@ -18,7 +18,7 @@
       {
         "sequenceNumber":10,
         "vrfUnchanged":false,
-        "installed":true,
+        "installed":false,
         "installedReason":"Invalid Src or Dst",
         "nexthopGroup":{
           "name":"C",
@@ -98,7 +98,7 @@
       {
         "sequenceNumber":5,
         "vrfUnchanged":false,
-        "installed":false,
+        "installed":true,
         "installedReason":"Invalid NH-group",
         "nexthopGroup":{
           "name":"B",
@@ -111,7 +111,7 @@
       {
         "sequenceNumber":10,
         "vrfUnchanged":true,
-        "installed":false,
+        "installed":true,
         "installedReason":"Valid",
         "matchSrc":"1.2.0.0\/16",
         "matchDst":"3.4.5.0\/24"


### PR DESCRIPTION

Post fix:
```
tor-2# show pbr map json
[
  {
    "name":"global-vrf-PBR-map",
    "valid":true,
    "policies":[
      {
        "id":1,
        "sequenceNumber":10,
        "ruleNumber":309,
        "vrfUnchanged":false,
        "installed":true,   <<<< now display correct value
        "installedReason":"Valid",
        "vrfName":"sym_1",
        "matchSrc":"10.1.200.0\/24",
        "matchDst":"10.6.200.0\/24"
      }
    ]
  }
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>