### PR TITLE
[WIP] ospfd: Fix Memory Leak in `ospf_delete_opaque_functab`

### DIFF
--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -427,12 +427,9 @@ void ospf_delete_opaque_functab(uint8_t lsa_type, uint8_t opaque_type)
 				if (functab->oipt != NULL)
 					free_opaque_info_per_type(functab->oipt,
 								  true);
-				/* Dequeue listnode entry from the function table
-				 * list coreesponding to the opaque LSA type.
-				 * Note that the list deletion callback frees
-				 * the functab entry memory.
-				 */
+				/* Dequeue listnode entry from the list. */
 				listnode_delete(funclist, functab);
+				ospf_opaque_del_functab(functab);
 				break;
 			}
 		}


### PR DESCRIPTION
In a previous commit, the line `XFREE(MTYPE_OSPF_OPAQUE_FUNCTAB, functab)` was removed with the intention of relying on the list deletion callback for proper memory cleanup. However, it was discovered that the list deletion callback was not being triggered, leading to memory leaks.

This commit introduces a call to `ospf_opaque_del_functab`to ensure that memory is correctly deallocated when the list node is deleted. This fixes the memory leak introduced by the previous change.

The ASan leak log for reference:

```
***********************************************************************************
Address Sanitizer Error detected in ospf_sr_te_topo1.test_ospf_sr_te_topo1/rt5.asan.ospfd.10366

=================================================================
==10366==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 112 byte(s) in 1 object(s) allocated from:
    #0 0x7fe1a8ff8d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7fe1a89f7238 in qcalloc lib/memory.c:105
    #2 0x561f1a86a349 in ospf_register_opaque_functab ospfd/ospf_opaque.c:393
    #3 0x561f1a9485d8 in ospf_ext_init ospfd/ospf_ext.c:113
    #4 0x561f1a8699ff in ospf_opaque_init ospfd/ospf_opaque.c:83
    #5 0x561f1a827c59 in main ospfd/ospf_main.c:244
    #6 0x7fe1a7ff2c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 112 byte(s) in 1 object(s) allocated from:
    #0 0x7fe1a8ff8d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7fe1a89f7238 in qcalloc lib/memory.c:105
    #2 0x561f1a86a349 in ospf_register_opaque_functab ospfd/ospf_opaque.c:393
    #3 0x561f1a948658 in ospf_ext_init ospfd/ospf_ext.c:136
    #4 0x561f1a8699ff in ospf_opaque_init ospfd/ospf_opaque.c:83
    #5 0x561f1a827c59 in main ospfd/ospf_main.c:244
    #6 0x7fe1a7ff2c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 112 byte(s) in 1 object(s) allocated from:
    #0 0x7fe1a8ff8d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7fe1a89f7238 in qcalloc lib/memory.c:105
    #2 0x561f1a86a349 in ospf_register_opaque_functab ospfd/ospf_opaque.c:393
    #3 0x561f1a883e73 in ospf_router_info_register ospfd/ospf_ri.c:111
    #4 0x561f1a887b55 in router_info ospfd/ospf_ri.c:1689
    #5 0x7fe1a897a021 in cmd_execute_command_real lib/command.c:978
    #6 0x7fe1a897aa52 in cmd_execute_command_strict lib/command.c:1087
    #7 0x7fe1a897aab1 in command_config_read_one_line lib/command.c:1247
    #8 0x7fe1a897ad98 in config_from_file lib/command.c:1300
    #9 0x7fe1a8aad6d0 in vty_read_file lib/vty.c:2614
    #10 0x7fe1a8aad7fa in vty_read_config lib/vty.c:2860
    #11 0x7fe1a89d92e4 in frr_config_read_in lib/libfrr.c:978
    #12 0x7fe1a8a97034 in event_call lib/event.c:1974
    #13 0x7fe1a89da42b in frr_run lib/libfrr.c:1214
    #14 0x561f1a827c79 in main ospfd/ospf_main.c:252
    #15 0x7fe1a7ff2c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

Direct leak of 112 byte(s) in 1 object(s) allocated from:
    #0 0x7fe1a8ff8d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7fe1a89f7238 in qcalloc lib/memory.c:105
    #2 0x561f1a86a349 in ospf_register_opaque_functab ospfd/ospf_opaque.c:393
    #3 0x561f1a8b9e35 in ospf_mpls_te_init ospfd/ospf_te.c:92
    #4 0x561f1a8699e4 in ospf_opaque_init ospfd/ospf_opaque.c:73
    #5 0x561f1a827c59 in main ospfd/ospf_main.c:244
    #6 0x7fe1a7ff2c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 448 byte(s) leaked in 4 allocation(s).
***********************************************************************************
```