### PR TITLE
pathd: fix excessive doc string on pcep msd command

### DIFF
--- a/pathd/path_pcep_cli.c
+++ b/pathd/path_pcep_cli.c
@@ -2044,7 +2044,6 @@ DEFPY(pcep_cli_no_pcc,
 DEFPY(pcep_cli_pcc_pcc_msd,
       pcep_cli_pcc_pcc_msd_cmd,
       "msd (1-32)",
-      NO_STR
       "PCC maximum SID depth \n"
       "PCC maximum SID depth value\n")
 {


### PR DESCRIPTION
The following message appears after starting pathd:
> root@ubuntu2204:~# vtysh
> 2023/10/31 05:59:10 [K2CCG-5Y7ZJ] Excessive docstring while parsing 'msd (1-32)'
> 2023/10/31 05:59:10 [W7ENN-K2SVA] ----------
> 2023/10/31 05:59:10 [WCW75-6TZPF] PCC maximum SID depth value
> 2023/10/31 05:59:10 [W7ENN-K2SVA] ----------

Remove the excessive doc string in the pcep msd command.

Fixes: d6d2527448ef ("pathd: fix 'no msd' command not possible under pcc node")