### PR TITLE
tools: Add `rebase` label only when the PR is opened

### DIFF
--- a/.github/workflows/behind-base.yml
+++ b/.github/workflows/behind-base.yml
@@ -2,7 +2,7 @@ name: Add rebase label if the branch is > 50 commits behind
 
 on:
   pull_request_target:
-    types: [synchronize, opened, reopened, labeled, unlabeled]
+    types: [opened]
 
 jobs:
   behind:


### PR DESCRIPTION
No need to spam on other events.