### PR TITLE
sharpd: fix deleting nhid when suppressing nexthop from nh group

### DIFF
--- a/sharpd/sharp_nht.c
+++ b/sharpd/sharp_nht.c
@@ -174,7 +174,8 @@ static void sharp_nhgroup_delete_cb(const char *name)
 	if (!snhg)
 		return;
 
-	nhg_del(snhg->id);
+	if (sharp_nhgroup_id_is_installed(snhg->id))
+		nhg_del(snhg->id);
 	sharp_nhg_rb_del(&nhg_head, snhg);
 	XFREE(MTYPE_NHG, snhg);
 }

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -567,11 +567,11 @@ void nhg_add(uint32_t id, const struct nexthop_group *nhg,
 			zlog_debug("%s: nhg %u: no nexthops, deleting nexthop group", __func__,
 				   id);
 			zclient_nhg_send(zclient, ZEBRA_NHG_DEL, &api_nhg);
-		} else {
-			zlog_debug("%s: nhg %u not sent: no valid nexthops", __func__,
-				   id);
-			is_valid = false;
+			return;
 		}
+		zlog_debug("%s: nhg %u not sent: no valid nexthops", __func__,
+			   id);
+		is_valid = false;
 		goto done;
 	}
 

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -934,6 +934,7 @@ static int nhg_notify_owner(ZAPI_CALLBACK_ARGS)
 		zlog_debug("Failed install of nhg %u", id);
 		break;
 	case ZAPI_NHG_REMOVED:
+		sharp_nhgroup_id_set_installed(id, false);
 		zlog_debug("Removed nhg %u", id);
 		break;
 	case ZAPI_NHG_REMOVE_FAIL:


### PR DESCRIPTION
When no nexthops are in a nexthop group, two successive events are sent: NHG_DEL and NHG_ADD, but only the NHG_DEL one is necessary. Fixes this by returning in the nhg_add() function.

Fixes: 82beaf6ae520 ("sharpd: fix deleting nhid when suppressing nexthop from nh group")