### PR TITLE
docker/ubi8-minimal: add protobuf-c runtime dep

### DIFF
--- a/docker/ubi8-minimal/Dockerfile
+++ b/docker/ubi8-minimal/Dockerfile
@@ -10,6 +10,7 @@ ADD docker/ubi8-minimal/almalinux.repo /etc/yum.repos.d/almalinux.repo
 # and later reinstall it again: https://bugzilla.redhat.com/show_bug.cgi?id=1668185
 RUN rpm --quiet -e --nodeps tzdata >/dev/null 2>&1
 
+# Keep the list of dependencies alphabetically sorted for easier maintenance
 RUN microdnf --disableplugin=subscription-manager --setopt=install_weak_deps=0 install \
     autoconf \
     automake \
@@ -29,6 +30,7 @@ RUN microdnf --disableplugin=subscription-manager --setopt=install_weak_deps=0 i
     pcre-devel \
     pkgconfig \
     platform-python-devel \
+    protobuf-c-devel \
     python3-devel \
     python3-pytest \
     python3-sphinx \
@@ -37,7 +39,6 @@ RUN microdnf --disableplugin=subscription-manager --setopt=install_weak_deps=0 i
     systemd-devel \
     texinfo \
     tzdata \
-    protobuf-c-devel \
     && microdnf --disableplugin=subscription-manager clean all
 
 RUN curl -sSL -o /tmp/libyang2.rpm https://ci1.netdef.org/artifact/LIBYANG-LIBYANG2/shared/build-181/RedHat-8-x86_64-Packages/libyang-2.1.80-1.el8.x86_64.rpm \
@@ -92,12 +93,14 @@ ADD docker/ubi8-minimal/almalinux.repo /etc/yum.repos.d/almalinux.repo
 
 RUN rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-8
 
+# Keep the list of dependencies alphabetically sorted for easier maintenance
 RUN microdnf --disableplugin=subscription-manager --setopt=install_weak_deps=0 install \
     c-ares \
     initscripts \
     net-snmp-agent-libs \
     net-snmp-libs \
     openssl \
+    protobuf-c \
     python3 \
     shadow-utils \
     systemd \


### PR DESCRIPTION
FRR's RPM package requires protobuf-c to be installed on the runtime system, otherwise it will refuse to be installed.