### PR TITLE
bgpd: check bgp evpn instance presence in soo

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3628,7 +3628,7 @@ static bool bgp_evpn_route_matches_macvrf_soo(struct bgp_path_info *pi,
 	struct ecommunity *macvrf_soo;
 	bool ret = false;
 
-	if (!bgp_evpn->evpn_info)
+	if (!bgp_evpn || !bgp_evpn->evpn_info)
 		return false;
 
 	/* We only stamp the mac-vrf soo on routes from our local L2VNI.


### PR DESCRIPTION
    (pi=pi@entry=0x55e86ec1a5a0, evp=evp@entry=0x7fff4edc2160)
    at bgpd/bgp_evpn.c:3623
3623    bgpd/bgp_evpn.c: No such file or directory.
(gdb) info locals
bgp_evpn = 0x0
macvrf_soo = <optimized out>
ret = false
__func__ = <optimized out>

```
#3  bgp_evpn_route_matches_macvrf_soo (pi=pi@entry=0x55e86ec1a5a0, evp=evp@entry=0x7fff4edc2160)
    at bgpd/bgp_evpn.c:3623
#4  0x000055e86cb7598b in bgp_evpn_install_uninstall_table (bgp=bgp@entry=0x55e86e9cd010, afi=afi@entry=AFI_L2VPN,
    safi=safi@entry=SAFI_EVPN, p=p@entry=0x0, pi=pi@entry=0x55e86ec1a5a0, import=import@entry=1, in_vrf_rt=true,
    in_vni_rt=true) at bgpd/bgp_evpn.c:4200
#5  0x000055e86cb79b4b in install_uninstall_evpn_route (import=1, pi=pi@entry=0x55e86ec1a5a0, p=p@entry=0x0,
    safi=safi@entry=SAFI_EVPN, afi=afi@entry=AFI_L2VPN, bgp=bgp@entry=0x55e86e9cd010) at bgpd/bgp_evpn.c:6266
#6  bgp_evpn_import_route (bgp=bgp@entry=0x55e86e9cd010, afi=afi@entry=AFI_L2VPN, safi=safi@entry=SAFI_EVPN,
    p=p@entry=0x7fff4edc2160, pi=pi@entry=0x55e86ec1a5a0) at bgpd/bgp_evpn.c:6266
#7  0x000055e86cbce383 in bgp_update (peer=peer@entry=0x55e86ea35400, p=p@entry=0x7fff4edc2160,
    addpath_id=addpath_id@entry=0, attr=attr@entry=0x7fff4edc4400, afi=afi@entry=AFI_L2VPN, safi=<optimized out>,
    safi@entry=SAFI_EVPN, type=9, sub_type=0, prd=0x7fff4edc2120, label=0x7fff4edc211c, num_labels=1,
    soft_reconfig=0, evpn=0x7fff4edc2130) at bgpd/bgp_route.c:4805
#8  0x000055e86cb70db3 in process_type5_route (peer=peer@entry=0x55e86ea35400, afi=afi@entry=AFI_L2VPN,
    safi=safi@entry=SAFI_EVPN, attr=attr@entry=0x7fff4edc4400, pfx=<optimized out>, psize=psize@entry=34,
    addpath_id=0) at bgpd/bgp_evpn.c:4922
#9  0x000055e86cb78191 in bgp_nlri_parse_evpn (peer=0x55e86ea35400, attr=0x7fff4edc4400, packet=<optimized out>,
    withdraw=0) at bgpd/bgp_evpn.c:5997
#10 0x000055e86cbb3b45 in bgp_nlri_parse (peer=peer@entry=0x55e86ea35400, attr=attr@entry=0x7fff4edc4400,
    packet=packet@entry=0x7fff4edc43d0, mp_withdraw=mp_withdraw@entry=0) at bgpd/bgp_packet.c:363
#11 0x000055e86cbb47a0 in bgp_update_receive (peer=peer@entry=0x55e86ea35400, size=size@entry=161)
    at bgpd/bgp_packet.c:2076
#12 0x000055e86cbb78a1 in bgp_process_packet (thread=<optimized out>) at bgpd/bgp_packet.c:2931
#13 0x00007fbae7d3160d in thread_call (thread=thread@entry=0x7fff4edc4740) at lib/thread.c:2008
#14 0x00007fbae7ceb888 in frr_run (master=0x55e86e3dc4f0) at lib/libfrr.c:1223
#15 0x000055e86cb5742c in main (argc=<optimized out>, argv=<optimized out>) at bgpd/bgp_main.c:554
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>