### PR TITLE
ospfd: Free `vertex parent` in `ospf_spf_remove_branch`

### DIFF
--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -440,6 +440,7 @@ static void ospf_spf_remove_branch(struct vertex_parent *vertex_parent,
 	 * be done anyway.
 	 */
 	listnode_delete(child->parents, vertex_parent);
+	vertex_parent_free(vertex_parent);
 
 	/*
 	 * Are there actually more parents left? If not, then delete the child!


### PR DESCRIPTION
The function `ospf_spf_remove_branch` now frees the memory associated with the vertex parent after removing it from the child's list of parents. This ensures proper cleanup and avoids memory leaks.

The ASan leak log for reference:

```
***********************************************************************************
Address Sanitizer Error detected in ospf_tilfa_topo1.test_ospf_tilfa_topo1/rt1.asan.ospfd.30426

=================================================================
==30426==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 64 byte(s) in 2 object(s) allocated from:
    #0 0x7f46d701f867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f46d6bbc30b in qmalloc ../lib/memory.c:100
    #2 0x55e69f5acd44 in vertex_parent_new ../ospfd/ospf_spf.c:157
    #3 0x55e69f5b1272 in ospf_spf_add_parent ../ospfd/ospf_spf.c:734
    #4 0x55e69f5b23d7 in ospf_nexthop_calculation ../ospfd/ospf_spf.c:977
    #5 0x55e69f5b4c4e in ospf_spf_next ../ospfd/ospf_spf.c:1487
    #6 0x55e69f5b68ff in ospf_spf_calculate ../ospfd/ospf_spf.c:1754
    #7 0x55e69f5bd871 in ospf_ti_lfa_generate_q_spaces ../ospfd/ospf_ti_lfa.c:673
    #8 0x55e69f5bd678 in ospf_ti_lfa_generate_q_spaces ../ospfd/ospf_ti_lfa.c:648
    #9 0x55e69f5be6c9 in ospf_ti_lfa_generate_p_space ../ospfd/ospf_ti_lfa.c:812
    #10 0x55e69f5bece9 in ospf_ti_lfa_generate_p_spaces ../ospfd/ospf_ti_lfa.c:874
    #11 0x55e69f5c0845 in ospf_ti_lfa_compute ../ospfd/ospf_ti_lfa.c:1101
    #12 0x55e69f5b6eea in ospf_spf_calculate_area ../ospfd/ospf_spf.c:1814
    #13 0x55e69f5b7215 in ospf_spf_calculate_areas ../ospfd/ospf_spf.c:1843
    #14 0x55e69f5b7452 in ospf_spf_calculate_schedule_worker ../ospfd/ospf_spf.c:1874
    #15 0x7f46d6ca7ba3 in event_call ../lib/event.c:1974
    #16 0x7f46d6b8fd8e in frr_run ../lib/libfrr.c:1214
    #17 0x55e69f51cc72 in main ../ospfd/ospf_main.c:252
    #18 0x7f46d666cd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

```