### PR TITLE
zebra: remove proto nhid from system, when NHG_DEL is sent

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1719,7 +1719,8 @@ void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe)
 
 	nhe->refcnt--;
 
-	if (!zebra_router_in_shutdown() && nhe->refcnt <= 0 &&
+	if (!PROTO_OWNED(nhe) && !zebra_router_in_shutdown() &&
+	    nhe->refcnt <= 0 &&
 	    CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) &&
 	    !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_KEEP_AROUND)) {
 		nhe->refcnt = 1;


### PR DESCRIPTION
When suppressing a nexthop group, the proto nhid is still present in the system:

> ubuntu2204(config)# nexthop-group LL
> 2023/12/04 21:23:44 SHARP: [Q5NBA-GN1BG] NHG ID assigned: 179687510
> ubuntu2204(config-nh-group)# nexthop 192.0.2.43 loop1
> ubuntu2204(config-nh-group)# no  nexthop 192.0.2.43 loop1
> 2023/12/04 21:23:56 ZEBRA: [RY75W-058E9] zebra_nhg_proto_del: deleted nhe 0x55edc18eb870 (179687510[260]), vrf 0, type sharp
> 2023/12/04 21:23:56 ZEBRA: [WDEB1-93HCZ] zebra_nhg_decrement_ref: nhe 0x55edc18eb870 (179687510[260]) 1 => 0
> 2023/12/04 21:23:56 SHARP: [H3QKG-WH8ZV] Removed nhg 179687510
> ubuntu2204(config-nh-group)#
> ubuntu2204(config-nh-group)# exi
> ubuntu2204(config)# <Ctrl-D>
> ////////// linux nexthop  list (ip nexthop ls)
> id 179687510 group 260 proto 194
> id 260 via 192.0.2.43 dev loop1 scope link proto 194

There is no need to keep nexthop group from protocol levels if there are no references to that nexthop group. Fix this by forcing the system removal only if it is a protocol nhid.

Fixes: 35729f38fa57 ("zebra: Add a timer to nexthop group deletion")