### PR TITLE
lib: fix nexthop_group_nexthop_num_no_recurse() is static

### DIFF
--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -81,7 +81,8 @@ uint8_t nexthop_group_nexthop_num(const struct nexthop_group *nhg)
 	return num;
 }
 
-uint8_t nexthop_group_nexthop_num_no_recurse(const struct nexthop_group *nhg)
+static uint8_t
+nexthop_group_nexthop_num_no_recurse(const struct nexthop_group *nhg)
 {
 	struct nexthop *nhop;
 	uint8_t num = 0;

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -151,8 +151,6 @@ extern void nexthop_group_json_nexthop(json_object *j,
 /* Return the number of nexthops in this nhg */
 extern uint8_t nexthop_group_nexthop_num(const struct nexthop_group *nhg);
 extern uint8_t
-nexthop_group_nexthop_num_no_recurse(const struct nexthop_group *nhg);
-extern uint8_t
 nexthop_group_active_nexthop_num(const struct nexthop_group *nhg);
 
 extern bool nexthop_group_has_label(const struct nexthop_group *nhg);


### PR DESCRIPTION
No need to declare 'nexthop_group_nexthop_num_no_recurse()' as external.

Fixes: 98cda54a9543 ("zebra: Add recursive functionality to NHE's")