### PR TITLE
Add ability to handle `noprefixroute` to zebra

### DIFF
--- a/lib/if.h
+++ b/lib/if.h
@@ -434,6 +434,8 @@ struct connected {
 #define ZEBRA_IFA_SECONDARY    (1 << 0)
 #define ZEBRA_IFA_PEER         (1 << 1)
 #define ZEBRA_IFA_UNNUMBERED   (1 << 2)
+#define ZEBRA_IFA_NOPREFIXROUTE (1 << 3)
+
 	/* N.B. the ZEBRA_IFA_PEER flag should be set if and only if
 	   a peer address has been configured.  If this flag is set,
 	   the destination field must contain the peer address.

--- a/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
+++ b/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
@@ -144,6 +144,23 @@ def test_zebra_system_recursion():
     assert result is None, "Kernel route is missing from zebra"
 
 
+def test_zebra_noprefix_connected():
+    "Test that a noprefixroute created does not create a connected route"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+    router.run("ip addr add 192.168.44.1/24 dev r1-eth1 noprefixroute")
+    expected = "% Network not in table"
+    test_func = partial(
+        topotest.router_output_cmp, router, "show ip route 192.168.44.0/24", expected
+    )
+    result, diff = topotest.run_and_expect(test_func, "", count=20, wait=1)
+    assert result, "Connected Route should not have been added"
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -282,13 +282,15 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 			return;
 	}
 
-	rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_CONNECT, 0,
-		flags, &p, NULL, &nh, 0, zvrf->table_id, metric, 0, 0, 0,
-		false);
+	if (!CHECK_FLAG(ifc->flags, ZEBRA_IFA_NOPREFIXROUTE)) {
+		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id,
+			ZEBRA_ROUTE_CONNECT, 0, flags, &p, NULL, &nh, 0,
+			zvrf->table_id, metric, 0, 0, 0, false);
 
-	rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_CONNECT, 0,
-		flags, &p, NULL, &nh, 0, zvrf->table_id, metric, 0, 0, 0,
-		false);
+		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id,
+			ZEBRA_ROUTE_CONNECT, 0, flags, &p, NULL, &nh, 0,
+			zvrf->table_id, metric, 0, 0, 0, false);
+	}
 
 	if (install_local) {
 		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL,
@@ -481,11 +483,15 @@ void connected_down(struct interface *ifp, struct connected *ifc)
 	 * Same logic as for connected_up(): push the changes into the
 	 * head.
 	 */
-	rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_CONNECT, 0,
-		   0, &p, NULL, &nh, 0, zvrf->table_id, 0, 0, false);
+	if (!CHECK_FLAG(ifc->flags, ZEBRA_IFA_NOPREFIXROUTE)) {
+		rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id,
+			   ZEBRA_ROUTE_CONNECT, 0, 0, &p, NULL, &nh, 0,
+			   zvrf->table_id, 0, 0, false);
 
-	rib_delete(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_CONNECT,
-		   0, 0, &p, NULL, &nh, 0, zvrf->table_id, 0, 0, false);
+		rib_delete(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id,
+			   ZEBRA_ROUTE_CONNECT, 0, 0, &p, NULL, &nh, 0,
+			   zvrf->table_id, 0, 0, false);
+	}
 
 	if (remove_local) {
 		rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id,

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1423,6 +1423,9 @@ int netlink_interface_addr_dplane(struct nlmsghdr *h, ns_id_t ns_id,
 	if (kernel_flags & IFA_F_SECONDARY)
 		dplane_ctx_intf_set_secondary(ctx);
 
+	if (kernel_flags & IFA_F_NOPREFIXROUTE)
+		dplane_ctx_intf_set_noprefixroute(ctx);
+
 	/* Label */
 	if (tb[IFA_LABEL]) {
 		label = (char *)RTA_DATA(tb[IFA_LABEL]);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1317,6 +1317,9 @@ static void zebra_if_addr_update_ctx(struct zebra_dplane_ctx *ctx,
 	if (dplane_ctx_intf_is_secondary(ctx))
 		SET_FLAG(flags, ZEBRA_IFA_SECONDARY);
 
+	if (dplane_ctx_intf_is_noprefixroute(ctx))
+		SET_FLAG(flags, ZEBRA_IFA_NOPREFIXROUTE);
+
 	/* Label? */
 	if (dplane_ctx_intf_has_label(ctx))
 		label = dplane_ctx_get_intf_label(ctx);
@@ -2333,6 +2336,12 @@ static void connected_dump_vty(struct vty *vty, json_object *json,
 			CHECK_FLAG(connected->flags, ZEBRA_IFA_SECONDARY));
 	else if (CHECK_FLAG(connected->flags, ZEBRA_IFA_SECONDARY))
 		vty_out(vty, " secondary");
+
+	if (json)
+		json_object_boolean_add(json_addr, "noPrefixRoute",
+					CHECK_FLAG(connected->flags, ZEBRA_IFA_NOPREFIXROUTE));
+	else if (CHECK_FLAG(connected->flags, ZEBRA_IFA_NOPREFIXROUTE))
+		vty_out(vty, " noprefixroute");
 
 	if (json)
 		json_object_boolean_add(

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -230,6 +230,7 @@ struct dplane_intf_info {
 #define DPLANE_INTF_BROADCAST   (1 << 2)
 #define DPLANE_INTF_HAS_DEST    DPLANE_INTF_CONNECTED
 #define DPLANE_INTF_HAS_LABEL   (1 << 4)
+#define DPLANE_INTF_NOPREFIXROUTE (1 << 5)
 
 	/* Interface address/prefix */
 	struct prefix prefix;
@@ -2541,6 +2542,13 @@ bool dplane_ctx_intf_is_connected(const struct zebra_dplane_ctx *ctx)
 	return (ctx->u.intf.flags & DPLANE_INTF_CONNECTED);
 }
 
+bool dplane_ctx_intf_is_noprefixroute(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return (ctx->u.intf.flags & DPLANE_INTF_NOPREFIXROUTE);
+}
+
 bool dplane_ctx_intf_is_secondary(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
@@ -2567,6 +2575,13 @@ void dplane_ctx_intf_set_secondary(struct zebra_dplane_ctx *ctx)
 	DPLANE_CTX_VALID(ctx);
 
 	ctx->u.intf.flags |= DPLANE_INTF_SECONDARY;
+}
+
+void dplane_ctx_intf_set_noprefixroute(struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	ctx->u.intf.flags |= DPLANE_INTF_NOPREFIXROUTE;
 }
 
 void dplane_ctx_intf_set_broadcast(struct zebra_dplane_ctx *ctx)

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -658,6 +658,8 @@ bool dplane_ctx_intf_is_connected(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_intf_set_connected(struct zebra_dplane_ctx *ctx);
 bool dplane_ctx_intf_is_secondary(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_intf_set_secondary(struct zebra_dplane_ctx *ctx);
+bool dplane_ctx_intf_is_noprefixroute(const struct zebra_dplane_ctx *ctx);
+void dplane_ctx_intf_set_noprefixroute(struct zebra_dplane_ctx *ctx);
 bool dplane_ctx_intf_is_broadcast(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_intf_set_broadcast(struct zebra_dplane_ctx *ctx);
 const struct prefix *dplane_ctx_get_intf_addr(


### PR DESCRIPTION
See individual commits, but you can mark a route as a noprefixroute and the connected route will not appear in the local or routing table.  Let's honor it.