### PR TITLE
zebra: enqueue NHG_DEL in rib_nhg meta queue

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -430,6 +430,7 @@ extern int rib_queue_nhg_ctx_add(struct nhg_ctx *ctx);
 
 /* Enqueue incoming nhg from proto daemon for processing */
 extern int rib_queue_nhe_add(struct nhg_hash_entry *nhe);
+extern int rib_queue_nhe_del(struct nhg_hash_entry *nhe);
 
 /* Enqueue evpn route for processing */
 int zebra_rib_queue_evpn_route_add(vrf_id_t vrf_id, const struct ethaddr *rmac,


### PR DESCRIPTION
The NHG_DEL operation is done directly from ZAPI call, whereas the NHG_ADD operation is done in the rib_nhg meta queue.

This may be problematic when ADD is followed by DEL. Imagine a scenarion with two protocol NHIDs. <NH1> depends of <NH2> and <NH3>. The deletion of <NH3> at the protocol level will trigger 2 messages to ZEBRA: NHG_ADD(<NH1>) and NHG_DEL(<NH3>).

Those operations are properly enqueued in ZAPI, but in the end, the NHG_DEL is executed first. This causes NHG_ADD to unlink an already freed NHG.

Fix this by consistently enqueuing NHG_DEL and NHG_ADD operations.