### PR TITLE
vtysh_config: do not warn about non-existing configuration file

### DIFF
--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -638,12 +638,8 @@ static int vtysh_read_config(const char *config_file_path, bool dry_run)
 	int ret;
 
 	confp = fopen(config_file_path, "r");
-	if (confp == NULL) {
-		fprintf(stderr,
-			"%% Can't open configuration file %s due to '%s'.\n",
-			config_file_path, safe_strerror(errno));
+	if (confp == NULL)
 		return CMD_ERR_NO_FILE;
-	}
 
 	save = vtysh_add_timestamp;
 	vtysh_add_timestamp = false;


### PR DESCRIPTION
We not always check return status, so it is not fatal to have missing file. And when it is fatal, we check status and print another message.