### PR TITLE
docker: fix /sbin/modprobe missing

### DIFF
--- a/docker/ubuntu-ci/Dockerfile
+++ b/docker/ubuntu-ci/Dockerfile
@@ -45,6 +45,7 @@ RUN apt update && apt upgrade -y && \
     apt-get install -y \
         curl \
         gdb \
+        kmod \
         iproute2 \
         iputils-ping \
         liblua5.3-dev \


### PR DESCRIPTION
kmod is needed in order to get modprobe