### PR TITLE
zebra: The dplane_fpm_nl return path leaks memory

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -345,6 +345,8 @@ extern void _route_entry_dump(const char *func, union prefixconstptr pp,
 			      union prefixconstptr src_pp,
 			      const struct route_entry *re);
 
+void zebra_rib_route_entry_free(struct route_entry *re);
+
 struct route_entry *
 zebra_rib_route_entry_new(vrf_id_t vrf_id, int type, uint8_t instance,
 			  uint32_t flags, uint32_t nhe_id, uint32_t table_id,

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1027,6 +1027,8 @@ int netlink_route_change_read_unicast_internal(struct nlmsghdr *h,
 						 re, ng, startup, ctx);
 			if (ng)
 				nexthop_group_delete(&ng);
+			if (ctx)
+				zebra_rib_route_entry_free(re);
 		} else {
 			/*
 			 * I really don't see how this is possible

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4305,6 +4305,12 @@ struct route_entry *zebra_rib_route_entry_new(vrf_id_t vrf_id, int type,
 
 	return re;
 }
+
+void zebra_rib_route_entry_free(struct route_entry *re)
+{
+	XFREE(MTYPE_RE, re);
+}
+
 /*
  * Internal route-add implementation; there are a couple of different public
  * signatures. Callers in this path are responsible for the memory they


### PR DESCRIPTION
The route entry created when using a ctx to pass route entry data backup to the master pthread in zebra is being leaked.  Prevent this from happening.