### PR TITLE
lib: fix the ASAN OneDefinitionRule violation.

### DIFF
--- a/staticd/static_main.c
+++ b/staticd/static_main.c
@@ -53,7 +53,7 @@ struct option longopts[] = { { 0 } };
 /* Master of threads. */
 struct event_loop *master;
 
-struct mgmt_be_client *mgmt_be_client;
+static struct mgmt_be_client *mgmt_be_client;
 
 static struct frr_daemon_info staticd_di;
 


### PR DESCRIPTION
Rename global client pointer variables and make the linkage static.