### PR TITLE
staticd: fix duplicate global variable

### DIFF
--- a/staticd/static_main.c
+++ b/staticd/static_main.c
@@ -53,7 +53,7 @@ struct option longopts[] = { { 0 } };
 /* Master of threads. */
 struct event_loop *master;
 
-struct mgmt_be_client *mgmt_be_client;
+struct mgmt_be_client *static_mgmt_be_client;
 
 static struct frr_daemon_info staticd_di;
 
@@ -71,7 +71,7 @@ static void sigint(void)
 	/* Disable BFD events to avoid wasting processing. */
 	bfd_protocol_integration_set_shutdown(true);
 
-	mgmt_be_client_destroy(mgmt_be_client);
+	mgmt_be_client_destroy(static_mgmt_be_client);
 
 	static_vrf_terminate();
 
@@ -161,7 +161,8 @@ int main(int argc, char **argv, char **envp)
 	static_vty_init();
 
 	/* Initialize MGMT backend functionalities */
-	mgmt_be_client = mgmt_be_client_create("staticd", NULL, 0, master);
+	static_mgmt_be_client = mgmt_be_client_create("staticd", NULL, 0,
+						      master);
 
 	hook_register(routing_conf_event,
 		      routing_control_plane_protocols_name_validate);


### PR DESCRIPTION
The mgmt_be_client pointer is defined twice in the code. This leads to address sanitizer issue:

> ==2807373==ERROR: AddressSanitizer: odr-violation (0x563c96f1c1a0):
>   [1] size=8 'mgmt_be_client' staticd/static_main.c:56:24
>   [2] size=8 'mgmt_be_client' lib/mgmt_be_client.c:119:24
> These globals were registered at these points:
>   [1]:
>     #0 0x7f5b0088a928 in __asan_register_globals ../../../../src/libsanitizer/asan/asan_globals.cpp:341
>     #1 0x563c96ec2a55 in _sub_I_00099_1 (/root/frr3/staticd/.libs/staticd+0x16a55)
>     #2 0x7f5afff3aeba in call_init ../csu/libc-start.c:145
>     #3 0x7f5afff3aeba in __libc_start_main_impl ../csu/libc-start.c:379
>
>   [2]:
>     #0 0x7f5b0088a928 in __asan_register_globals ../../../../src/libsanitizer/asan/asan_globals.cpp:341
>     #1 0x7f5b004ab2a4 in _sub_I_00099_1 (/root/frr3/lib/.libs/libfrr.so.0+0x2552a4)
>     #2 0x7f5b0124c47d in call_init elf/dl-init.c:70

Fix this by renaming the static variable to static_mgmt_be_client.

Fixes: 7aecb8639cc2 ("lib: mgmtd: remove abstraction layer and other cleanup")