### PR TITLE
staticd: mgmt_be_client is duplicated

### DIFF
--- a/staticd/static_main.c
+++ b/staticd/static_main.c
@@ -53,7 +53,7 @@ struct option longopts[] = { { 0 } };
 /* Master of threads. */
 struct event_loop *master;
 
-struct mgmt_be_client *mgmt_be_client;
+static struct mgmt_be_client *mgmt_be_client;
 
 static struct frr_daemon_info staticd_di;
 

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -345,6 +345,8 @@ extern void _route_entry_dump(const char *func, union prefixconstptr pp,
 			      union prefixconstptr src_pp,
 			      const struct route_entry *re);
 
+void zebra_rib_route_entry_free(struct route_entry *re);
+
 struct route_entry *
 zebra_rib_route_entry_new(vrf_id_t vrf_id, int type, uint8_t instance,
 			  uint32_t flags, uint32_t nhe_id, uint32_t table_id,

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1027,6 +1027,8 @@ int netlink_route_change_read_unicast_internal(struct nlmsghdr *h,
 						 re, ng, startup, ctx);
 			if (ng)
 				nexthop_group_delete(&ng);
+			if (ctx)
+				zebra_rib_route_entry_free(re);
 		} else {
 			/*
 			 * I really don't see how this is possible

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4305,6 +4305,12 @@ struct route_entry *zebra_rib_route_entry_new(vrf_id_t vrf_id, int type,
 
 	return re;
 }
+
+void zebra_rib_route_entry_free(struct route_entry *re)
+{
+	XFREE(MTYPE_RE, re);
+}
+
 /*
  * Internal route-add implementation; there are a couple of different public
  * signatures. Callers in this path are responsible for the memory they


### PR DESCRIPTION
Asan output from staticd:
=================================================================
==28828==ERROR: AddressSanitizer: odr-violation (0x559a2cc91040):
  [1] size=8 'mgmt_be_client' staticd/static_main.c:56:24
  [2] size=8 'mgmt_be_client' lib/mgmt_be_client.c:119:24
These globals were registered at these points:
  [1]:
    #0 0x7fad289a8928 in __asan_register_globals ../../../../src/libsanitizer/asan/asan_globals.cpp:341
    #1 0x7fad28085eba in call_init ../csu/libc-start.c:145
    #2 0x7fad28085eba in __libc_start_main_impl ../csu/libc-start.c:379

  [2]:
    #0 0x7fad289a8928 in __asan_register_globals ../../../../src/libsanitizer/asan/asan_globals.cpp:341
    #1 0x7fad2936747d in call_init elf/dl-init.c:70

==28828==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
SUMMARY: AddressSanitizer: odr-violation: global 'mgmt_be_client' at staticd/static_main.c:56:24
==28828==ABORTING

The global variable mgmt_be_client is duplicated in both staticd/static_main.c and lib/mgmt_be_client.c. Both instances are public. To resolve this issue, I've modified the mgmt_be_client object in static_main.c to be static.