### PR TITLE
zebra: Prefer local routes when they are the same

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -282,6 +282,15 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 			return;
 	}
 
+	if (install_local) {
+		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL,
+			0, flags, &plocal, NULL, &nh, 0, zvrf->table_id, 0, 0,
+			0, 0, false);
+		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id,
+			ZEBRA_ROUTE_LOCAL, 0, flags, &plocal, NULL, &nh, 0,
+			zvrf->table_id, 0, 0, 0, 0, false);
+	}
+
 	if (!CHECK_FLAG(ifc->flags, ZEBRA_IFA_NOPREFIXROUTE)) {
 		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id,
 			ZEBRA_ROUTE_CONNECT, 0, flags, &p, NULL, &nh, 0,
@@ -290,15 +299,6 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id,
 			ZEBRA_ROUTE_CONNECT, 0, flags, &p, NULL, &nh, 0,
 			zvrf->table_id, metric, 0, 0, 0, false);
-	}
-
-	if (install_local) {
-		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL,
-			0, flags, &plocal, NULL, &nh, 0, zvrf->table_id, 0, 0,
-			0, 0, false);
-		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id,
-			ZEBRA_ROUTE_LOCAL, 0, flags, &plocal, NULL, &nh, 0,
-			zvrf->table_id, 0, 0, 0, 0, false);
 	}
 
 	/* Schedule LSP forwarding entries for processing, if appropriate. */


### PR DESCRIPTION
Currently when a local route directly matches the
connected route the connected route is preferred.
Modify the code such that the local route is preferred instead.

Old:
L * 192.168.66.1/32 is directly connected, dummy1, 00:31:47 C>* 192.168.66.1/32 is directly connected, dummy1, 00:31:47

New:

C * 192.168.66.1/32 is directly connected, dummy1, 00:00:05 L>* 192.168.66.1/32 is directly connected, dummy1, 00:00:05