### PR TITLE
Zebra nexthop rework

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1248,9 +1248,7 @@ static void bgp_zebra_announce_parse_nexthop(
 	/* EVPN MAC-IP routes are installed with a L3 NHG id */
 	if (nhg_id && bgp_evpn_path_es_use_nhg(bgp, info, nhg_id)) {
 		mpinfo = NULL;
-		api->nhgid = *nhg_id;
-		if (*nhg_id)
-			SET_FLAG(api->message, ZAPI_MESSAGE_NHG);
+		zapi_route_set_nhg_id(api, nhg_id);
 	} else {
 		mpinfo = info;
 	}

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -1169,6 +1169,15 @@ static inline void zapi_route_set_blackhole(struct zapi_route *api,
 	SET_FLAG(api->message, ZAPI_MESSAGE_NEXTHOP);
 };
 
+static inline void zapi_route_set_nhg_id(struct zapi_route *api,
+					 uint32_t *nhg_id)
+{
+	api->nexthop_num = 0;
+	api->nhgid = *nhg_id;
+	if (api->nhgid)
+		SET_FLAG(api->message, ZAPI_MESSAGE_NHG);
+};
+
 extern enum zclient_send_status
 zclient_send_mlag_register(struct zclient *client, uint32_t bit_map);
 extern enum zclient_send_status

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -251,8 +251,7 @@ static bool route_add(const struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
 
 	/* Only send via ID if nhgroup has been successfully installed */
 	if (nhgid && sharp_nhgroup_id_is_installed(nhgid)) {
-		SET_FLAG(api.message, ZAPI_MESSAGE_NHG);
-		api.nhgid = nhgid;
+		zapi_route_set_nhg_id(&api, &nhgid);
 	} else {
 		for (ALL_NEXTHOPS_PTR(nhg, nh)) {
 			/* Check if we set a VNI label */


### PR DESCRIPTION
This rework permits to decorrelate the ZAPI nexthop build from the ZAPI route build.
The new function bgp_zebra_announce_parse_nexthop() will later be used to update the nexthop groups

