### PR TITLE
bgpd: Have `show bgp vrf all ipv4 uni summ` display vrf NAME

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -11659,8 +11659,9 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 						: bgp->name);
 			} else {
 				vty_out(vty,
-					"BGP router identifier %pI4, local AS number %s vrf-id %d",
+					"BGP router identifier %pI4, local AS number %s %s vrf-id %d",
 					&bgp->router_id, bgp->as_pretty,
+					bgp->name_pretty,
 					bgp->vrf_id == VRF_UNKNOWN
 						? -1
 						: (int)bgp->vrf_id);

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6_summary.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6_summary.ref
@@ -1,4 +1,4 @@
-BGP router identifier 192.168.0.1, local AS number 100 vrf-id 0
+BGP router identifier 192.168.0.1, local AS number 100 VRF default vrf-id 0
 BGP table version 1
 RIB entries 1, using XXXX bytes of memory
 Peers 2, using XXXX KiB of memory

--- a/tests/topotests/all_protocol_startup/r1/show_ip_bgp_summary.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_ip_bgp_summary.ref
@@ -1,4 +1,4 @@
-BGP router identifier 192.168.0.1, local AS number 100 vrf-id 0
+BGP router identifier 192.168.0.1, local AS number 100 VRF default vrf-id 0
 BGP table version 1
 RIB entries 1, using XXXX bytes of memory
 Peers 4, using XXXX KiB of memory


### PR DESCRIPTION
The vrf name was not being displayed in this output. New output:

eva# show bgp vrf all ipv4 uni summ
BGP router identifier 0.0.0.0, local AS number 99 VRF RED vrf-id 14 BGP table version 0
RIB entries 0, using 0 bytes of memory
Peers 1, using 20 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
192.168.119.1   4          0         0         0        0    0    0    never       Active        0 N/A

Total number of neighbors 1
BGP router identifier 0.0.0.0, local AS number 99 VRF GREEN vrf-id 15 BGP table version 0
RIB entries 0, using 0 bytes of memory
Peers 1, using 20 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
192.168.119.1   4          0         0         0        0    0    0    never       Active        0 N/A

Total number of neighbors 1
BGP router identifier 192.168.122.1, local AS number 99 VRF default vrf-id 0 BGP table version 0
RIB entries 0, using 0 bytes of memory
Peers 1, using 20 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
192.168.119.1   4          0         0         0        0    0    0    never       Active        0 N/A

Total number of neighbors 1
BGP router identifier 0.0.0.0, local AS number 99 VRF GrEEn vrf-id -1 BGP table version 0
RIB entries 0, using 0 bytes of memory
Peers 1, using 20 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
192.168.119.1   4          0         0         0        0    0    0    never         Idle        0 N/A

Total number of neighbors 1
eva#