### PR TITLE
tools: fix frr-reload multiple no description cmds

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1072,7 +1072,7 @@ def ignore_delete_re_add_lines(lines_to_add, lines_to_del):
     lines_to_add_to_del = []
     lines_to_del_to_del = []
 
-    index = 0
+    index = -1
     for (ctx_keys, line) in lines_to_del:
         deleted = False
 


### PR DESCRIPTION
Ensure to change description for index 0 from the list.

Ticket: #3628756
Testing Done:

After fix:
start with three interfaces description delete in lines_to_del: (Pdb) lines_to_del
[(('interface swp1',), "description swp1 -> sp1's swp1"), (('interface swp2',), "description swp2 -> sp2's swp 1"), (('interface swp3',), "description swp3 -> sp3's swp1")]

After first iteration swp1:
(Pdb) index
0
(Pdb) lines_to_del
[(('interface swp1',), 'description'), (('interface swp2',), "description swp2 -> sp2's swp1"), (('interface swp 1s2',), "description swp3 -> sp3's swp1")]

After second iteration swp2:
(Pdb) lines_to_del
[(('interface swp1',), 'description'), (('interface swp2',), 'description'), (('interface swp3',), "description swp3 -> sp3's swp1")]

After third iteration swp3 fix
(Pdb) lines_to_del
[(('interface swp1',), 'description'), (('interface swp2',), 'description'), (('interface swp3',), 'description' )]