### PR TITLE
zebra: Fix crash on macvlan link down/up

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5159,6 +5159,15 @@ void zebra_vxlan_macvlan_up(struct interface *ifp)
 	zif = ifp->info;
 	assert(zif);
 	link_ifp = zif->link;
+	if (!link_ifp) {
+		if (IS_ZEBRA_DEBUG_VXLAN)
+			zlog_debug(
+				"macvlan parent link is not found. Parent index %d ifp %s",
+				zif->link_ifindex,
+				ifindex2ifname(zif->link_ifindex,
+					       ifp->vrf->vrf_id));
+		return;
+	}
 	link_zif = link_ifp->info;
 	assert(link_zif);
 


### PR DESCRIPTION
Whenever a link up change was detected on a macvlan device where the linked device wasn't visible in the namespace zebra was running in, the linked zebra interface was NULL. This was already handled in the event of a link down, but was ommitted from the upside. Added the same null check to the up-side.

Relates to https://github.com/FRRouting/frr/issues/13523