### PR TITLE
ospfd: fix some ospf cmds' param range

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -853,7 +853,7 @@ Graceful Restart
    affects the restarting router.
    By default 'strict-lsa-checking' is enabled"
 
-.. clicmd:: graceful-restart helper supported-grace-time
+.. clicmd:: graceful-restart helper supported-grace-time (10-1800)
 
 
    Supports as HELPER for configured grace period.

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8302,7 +8302,7 @@ DEFUN_HIDDEN (ospf_dead_interval,
 
 DEFUN (ip_ospf_dead_interval_minimal,
        ip_ospf_dead_interval_minimal_addr_cmd,
-       "ip ospf dead-interval minimal hello-multiplier (1-10) [A.B.C.D]",
+       "ip ospf dead-interval minimal hello-multiplier (2-20) [A.B.C.D]",
        "IP Information\n"
        "OSPF interface commands\n"
        "Interval time after which a neighbor is declared down\n"
@@ -8323,7 +8323,7 @@ DEFUN (ip_ospf_dead_interval_minimal,
 
 DEFUN (no_ip_ospf_dead_interval,
        no_ip_ospf_dead_interval_cmd,
-       "no ip ospf dead-interval [<(1-65535)|minimal hello-multiplier (1-10)> [A.B.C.D]]",
+       "no ip ospf dead-interval [<(1-65535)|minimal hello-multiplier (2-20)> [A.B.C.D]]",
        NO_STR
        "IP Information\n"
        "OSPF interface commands\n"
@@ -8390,7 +8390,7 @@ DEFUN (no_ip_ospf_dead_interval,
 
 DEFUN_HIDDEN (no_ospf_dead_interval,
               no_ospf_dead_interval_cmd,
-              "no ospf dead-interval [<(1-65535)|minimal hello-multiplier (1-10)> [A.B.C.D]]",
+              "no ospf dead-interval [<(1-65535)|minimal hello-multiplier (2-20)> [A.B.C.D]]",
               NO_STR
               "OSPF interface commands\n"
               "Interval time after which a neighbor is declared down\n"


### PR DESCRIPTION
1. fix ip ospf dead-interval minimal hello-multiplier param range (2-20) accroding to OSPFv2 doc(ospfd.rst)
2. add param range of graceful-restart helper supported-grace-time in OSPFv2 doc(ospfd.rst)
3. check other cmds' param range