### PR TITLE
tests: ospf_suppress_fa sleeps, convert to run_and_expect

### DIFF
--- a/tests/topotests/ospf_suppress_fa/r1/initial.json
+++ b/tests/topotests/ospf_suppress_fa/r1/initial.json
@@ -1,0 +1,44 @@
+{
+  "routerId":"10.0.12.1",
+  "asExternalLinkStates":[
+    {
+      "options":"*|-|-|-|-|-|E|-",
+      "lsaFlags":6,
+      "lsaType":"AS-external-LSA",
+      "linkStateId":"3.3.1.1",
+      "advertisingRouter":"10.0.23.2",
+      "networkMask":32,
+      "metricType":"E2 (Larger than any link state path)",
+      "tos":0,
+      "metric":20,
+      "forwardAddress":"10.0.23.3",
+      "externalRouteTag":0
+    },
+    {
+      "options":"*|-|-|-|-|-|E|-",
+      "lsaFlags":6,
+      "lsaType":"AS-external-LSA",
+      "linkStateId":"3.3.2.2",
+      "advertisingRouter":"10.0.23.2",
+      "networkMask":32,
+      "metricType":"E2 (Larger than any link state path)",
+      "tos":0,
+      "metric":20,
+      "forwardAddress":"10.0.23.3",
+      "externalRouteTag":0
+    },
+    {
+      "options":"*|-|-|-|-|-|E|-",
+      "lsaFlags":6,
+      "lsaType":"AS-external-LSA",
+      "linkStateId":"3.3.3.3",
+      "advertisingRouter":"10.0.23.2",
+      "networkMask":32,
+      "metricType":"E2 (Larger than any link state path)",
+      "tos":0,
+      "metric":20,
+      "forwardAddress":"10.0.23.3",
+      "externalRouteTag":0
+    }
+  ]
+}

--- a/tests/topotests/ospf_suppress_fa/r1/neighbor.json
+++ b/tests/topotests/ospf_suppress_fa/r1/neighbor.json
@@ -1,0 +1,13 @@
+{
+  "neighbors":{
+    "10.0.23.2":[
+      {
+        "nbrPriority":1,
+        "converged":"Full",
+        "role":"DROther",
+        "ifaceAddress":"10.0.12.2",
+        "ifaceName":"r1-eth0:10.0.12.1"
+      }
+    ]
+  }
+}

--- a/tests/topotests/ospf_suppress_fa/r1/post.json
+++ b/tests/topotests/ospf_suppress_fa/r1/post.json
@@ -1,0 +1,44 @@
+{
+  "routerId":"10.0.12.1",
+  "asExternalLinkStates":[
+    {
+      "options":"*|-|-|-|-|-|E|-",
+      "lsaFlags":6,
+      "lsaType":"AS-external-LSA",
+      "linkStateId":"3.3.1.1",
+      "advertisingRouter":"10.0.23.2",
+      "networkMask":32,
+      "metricType":"E2 (Larger than any link state path)",
+      "tos":0,
+      "metric":20,
+      "forwardAddress":"0.0.0.0",
+      "externalRouteTag":0
+    },
+    {
+      "options":"*|-|-|-|-|-|E|-",
+      "lsaFlags":6,
+      "lsaType":"AS-external-LSA",
+      "linkStateId":"3.3.2.2",
+      "advertisingRouter":"10.0.23.2",
+      "networkMask":32,
+      "metricType":"E2 (Larger than any link state path)",
+      "tos":0,
+      "metric":20,
+      "forwardAddress":"0.0.0.0",
+      "externalRouteTag":0
+    },
+    {
+      "options":"*|-|-|-|-|-|E|-",
+      "lsaFlags":6,
+      "lsaType":"AS-external-LSA",
+      "linkStateId":"3.3.3.3",
+      "advertisingRouter":"10.0.23.2",
+      "networkMask":32,
+      "metricType":"E2 (Larger than any link state path)",
+      "tos":0,
+      "metric":20,
+      "forwardAddress":"0.0.0.0",
+      "externalRouteTag":0
+    }
+  ]
+}


### PR DESCRIPTION
The test_ospf_suppres_fa.py script is using straight up sleeps before testing that the next step worked properly. On a unloaded test system this will work 100% of the time on a loaded test system this will have random failures. Convert the test to use run_and_expect and give each section of the test 30 seconds to get to the next state appropriately instead of 10.