### PR TITLE
ospfd: Correct LSA parser which fulfill the TED

### DIFF
--- a/tests/topotests/ospf_te_topo1/r1/ospfd.conf
+++ b/tests/topotests/ospf_te_topo1/r1/ospfd.conf
@@ -2,13 +2,13 @@
 interface lo
   ip ospf area 0.0.0.0
 !
-interface r1-eth0
+interface eth0
   ip ospf network point-to-point
   ip ospf hello-interval 2
   ip ospf dead-interval 10
   ip ospf area 0.0.0.0
 !
-interface r1-eth1
+interface eth1
   ip ospf network point-to-point
   ip ospf hello-interval 2
   ip ospf dead-interval 10

--- a/tests/topotests/ospf_te_topo1/r1/zebra.conf
+++ b/tests/topotests/ospf_te_topo1/r1/zebra.conf
@@ -2,7 +2,7 @@
 interface lo
  ip address 10.0.255.1/32
 !
-interface r1-eth0
+interface eth0
  ip address 10.0.0.1/24
  link-params
   metric 20
@@ -12,7 +12,7 @@ interface r1-eth0
   enable
   exit-link-params
 !
-interface r1-eth1
+interface eth1
  ip address 10.0.1.1/24
  link-params
   enable

--- a/tests/topotests/ospf_te_topo1/r2/ospfd.conf
+++ b/tests/topotests/ospf_te_topo1/r2/ospfd.conf
@@ -2,25 +2,25 @@
 interface lo
   ip ospf area 0.0.0.0
 !
-interface r2-eth0
+interface eth0
   ip ospf network point-to-point
   ip ospf hello-interval 2
   ip ospf dead-interval 10
   ip ospf area 0.0.0.0
 !
-interface r2-eth1
+interface eth1
   ip ospf network point-to-point
   ip ospf hello-interval 2
   ip ospf dead-interval 10
   ip ospf area 0.0.0.0
 !
-interface r2-eth2
+interface eth2
   ip ospf network point-to-point
   ip ospf area 0.0.0.0
   ip ospf hello-interval 2
   ip ospf dead-interval 10
 !
-interface r2-eth3
+interface eth3
   ip ospf network point-to-point
   ip ospf hello-interval 2
   ip ospf dead-interval 10

--- a/tests/topotests/ospf_te_topo1/r2/zebra.conf
+++ b/tests/topotests/ospf_te_topo1/r2/zebra.conf
@@ -2,25 +2,25 @@
 interface lo
  ip address 10.0.255.2/32
 !
-interface r2-eth0
+interface eth0
  ip address 10.0.0.2/24
  link-params
   enable
   exit-link-params
 !
-interface r2-eth1
+interface eth1
  ip address 10.0.1.2/24
  link-params
   enable
   exit-link-params
 !
-interface r2-eth2
+interface eth2
  ip address 10.0.3.2/24
  link-params
   enable
   exit-link-params
 !
-interface r2-eth3
+interface eth3
  ip address 10.0.4.2/24
  link-params
   metric 30

--- a/tests/topotests/ospf_te_topo1/r3/ospfd.conf
+++ b/tests/topotests/ospf_te_topo1/r3/ospfd.conf
@@ -2,13 +2,13 @@
 interface lo
   ip ospf area 0.0.0.0
 !
-interface r3-eth0
+interface eth0
   ip ospf network point-to-point
   ip ospf area 0.0.0.0
   ip ospf hello-interval 2
   ip ospf dead-interval 10
 !
-interface r3-eth1
+interface eth1
   ip ospf network point-to-point
   ip ospf area 0.0.0.0
   ip ospf hello-interval 2

--- a/tests/topotests/ospf_te_topo1/r3/zebra.conf
+++ b/tests/topotests/ospf_te_topo1/r3/zebra.conf
@@ -2,14 +2,14 @@
 interface lo
  ip address 10.0.255.3/32
 !
-interface r3-eth0
+interface eth0
  ip address 10.0.3.1/24
  link-params
   enable
   admin-grp 0x20
   exit-link-params
 !
-interface r3-eth1
+interface eth1
  ip address 10.0.5.1/24
  link-params
   enable

--- a/tests/topotests/ospf_te_topo1/r4/ospfd.conf
+++ b/tests/topotests/ospf_te_topo1/r4/ospfd.conf
@@ -2,7 +2,7 @@
 interface lo
  ip ospf area 0.0.0.0
 !
-interface r4-eth0
+interface eth0
  ip ospf network point-to-point
  ip ospf hello-interval 2
  ip ospf dead-interval 10

--- a/tests/topotests/ospf_te_topo1/r4/zebra.conf
+++ b/tests/topotests/ospf_te_topo1/r4/zebra.conf
@@ -2,7 +2,7 @@
 interface lo
  ip address 10.0.255.4/32
 !
-interface r4-eth0
+interface eth0
  ip address 10.0.4.1/24
  link-params
   enable


### PR DESCRIPTION
Traffic Engineering Database (TED) is fulfill from the various LSA advertised and received by the router. To remove information on the TED, 2 mechanisms are used: i) parse TE Opaque LSA when there are flushed and ii) compare the list of prefixes advertised in the Router LSA with the list of corresponding edges and subnets contained in the TED. However, this second mechanism assumes that the Router LSA is unique and contains all prefixes of the advertised router. But, this is wrong. Prefixes could be advertised with several Router LSA. This conduct to remove edge and subnet in the TED while it should be maintained. The result is a faulty test with ospf_sr_te_topo1 topotest when server is heavy loaded.
    
This simple patch removed deletion of edges and subnets when parsing the Router LSA and only removed them when the corresponding TE Opaque LSA is flushed. In addition, TE Opaque LSA are not flushed when OSPF ajacency goes down. This patch also correct this second problem.

As consequence, the OSPF TE topotest which is using switches to interconnect router has been updated to use direct interconnection between router. Indeed, during the test, interfaces are shutdown on some routers to simulate link failure and check that the TED is correctly updated. However, the switch between router avoid the detection by the neighbor router that the interface is down i.e. the interface line remains up as it is connected to the switch and not to the router.
    
This PR solve the issue #14994
