### PR TITLE
bgpd: "default-originate" shouldn't withdraw non-default routes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2169,9 +2169,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 	 * configured for default-originate */
 	if (CHECK_FLAG(peer->af_flags[afi][safi],
 		       PEER_FLAG_DEFAULT_ORIGINATE)) {
-		if (p->family == AF_INET && p->u.prefix4.s_addr == INADDR_ANY)
-			return false;
-		else if (p->family == AF_INET6 && p->prefixlen == 0)
+		if ((p->family == AF_INET || p->family == AF_INET6) && p->prefixlen == 0)
 			return false;
 	}
 

--- a/tests/topotests/bgp_default_route/r1/bgpd.conf
+++ b/tests/topotests/bgp_default_route/r1/bgpd.conf
@@ -3,6 +3,7 @@ router bgp 65000
   neighbor 192.168.255.2 remote-as 65001
   neighbor 192.168.255.2 timers 3 10
   address-family ipv4 unicast
+    network 0.0.0.0/1
     neighbor 192.168.255.2 default-originate
   exit-address-family
 !

--- a/tests/topotests/bgp_default_route/r1/zebra.conf
+++ b/tests/topotests/bgp_default_route/r1/zebra.conf
@@ -1,4 +1,6 @@
 !
+ip route 0.0.0.0/1 blackhole
+!
 interface lo
  ip address 172.16.255.254/32
 !


### PR DESCRIPTION
Prevent "default-originate" from withdrawing non-default routes like 0.0.0.0/1 by checking prefix length.