### PR TITLE
ospfd: Fix opaque functab memory leak and opaque AS External LSA cleanup problems

### DIFF
--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -2092,7 +2092,7 @@ void ospf_apiserver_flush_opaque_lsa(struct ospf_apiserver *apiserv,
 					lsa, (void *)&param, 0);
 		break;
 	case OSPF_OPAQUE_AS_LSA:
-		LSDB_LOOP (OPAQUE_LINK_LSDB(ospf), rn, lsa)
+		LSDB_LOOP (OPAQUE_AS_LSDB(ospf), rn, lsa)
 			apiserver_flush_opaque_type_callback(lsa,
 							     (void *)&param, 0);
 		break;


### PR DESCRIPTION
   1. Fix ospf opaque LSA function table memory leak.
   2. Remove incorrect one-to-one association of OSPF opaque LS info-per-type to function table (since there many be many).
   3. Fix a problem with opaque AS external LSA cleanup that was exposed by the above change. 
   4. Also fix memory leak in ospf_opaque_type9_lsa_if_cleanup(). 