### PR TITLE
redhat: rpm spec: added protobuf-c to deps & fix bogus changelog date

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -180,6 +180,7 @@ BuildRequires:  flex
 BuildRequires:  gcc
 BuildRequires:  json-c-devel
 BuildRequires:  libcap-devel
+BuildRequires:  protobuf-c-devel
 BuildRequires:  make
 BuildRequires:  ncurses-devel
 BuildRequires:  readline-devel
@@ -799,7 +800,7 @@ sed -i 's/ -M rpki//' %{_sysconfdir}/frr/daemons
 
 * Tue Oct 10 2023 Donatas Abraitis <donatas@opensourcerouting.org> - %{version}
 
-* Thu Oct 09 2023 Donatas Abraitis <donatas@opensourcerouting.org> - 9.1
+* Mon Oct 09 2023 Donatas Abraitis <donatas@opensourcerouting.org> - 9.1
 - Major highlights:
 -   OSPFv2 HMAC-SHA Cryptographic Authentication
 -   BGP MAC-VRF Site-Of-Origin support


### PR DESCRIPTION
Fixes for:
```python
checking for protoc-c... no
configure: error: in `/builddir/build/BUILD/frr-frr-9.1':
configure: error: protobuf requested but protoc-c not found.  Install protobuf-c.
```

And rpmlint warnings:
```python
warning: line 208: It's not recommended to have unversioned Obsoletes: Obsoletes:          gated mrt zebra frr-sysvinit
warning: bogus date in %changelog: Thu Oct 09 2023 Donatas Abraitis <donatas@opensourcerouting.org> - 9.1
    line 208: It's not recommended to have unversioned Obsoletes: Obsoletes:          gated mrt zebra frr-sysvinit
    bogus date in %changelog: Thu Oct 09 2023 Donatas Abraitis <donatas@opensourcerouting.org> - 9.1
```