### PR TITLE
srv6: Introduce IPv6 address in segment-list used by TE Policy

### DIFF
--- a/doc/user/pathd.rst
+++ b/doc/user/pathd.rst
@@ -288,6 +288,7 @@ Configuration Commands
 .. clicmd:: index INDEX nai adjacency A.B.C.D A.B.C.D
 .. clicmd:: index INDEX nai prefix A.B.C.D/M algorithm <0|1>
 .. clicmd:: index INDEX nai prefix A.B.C.D/M iface (0-65535)
+.. clicmd:: index INDEX ipv6-address X:X::X:X
 
    Delete or specify a segment in a segment list definition.
 

--- a/lib/srte.h
+++ b/lib/srte.h
@@ -19,6 +19,25 @@ enum zebra_sr_policy_status {
 	ZEBRA_SR_POLICY_DOWN,
 };
 
+/* SR types. */
+enum sr_types {
+	ZEBRA_SR_LSP_NONE = 0,	/* No LSP. */
+	ZEBRA_SR_LSP_SRTE = 1,	/* SR-TE LSP */
+	ZEBRA_SR_SRV6_SRTE = 2, /* SRv6 SID List*/
+};
+
+static inline enum lsp_types_t lsp_type_from_sr_type(enum sr_types sr_type)
+{
+	switch (sr_type) {
+	case ZEBRA_SR_LSP_SRTE:
+		return ZEBRA_LSP_SRTE;
+	case ZEBRA_SR_LSP_NONE:
+	case ZEBRA_SR_SRV6_SRTE:
+		return ZEBRA_LSP_NONE;
+	}
+	return ZEBRA_LSP_NONE;
+};
+
 static inline int sr_policy_compare(const struct ipaddr *a_endpoint,
 				    const struct ipaddr *b_endpoint,
 				    uint32_t a_color, uint32_t b_color)

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2477,8 +2477,7 @@ const char *zapi_nexthop2str(const struct zapi_nexthop *znh, char *buf,
 /*
  * Decode the nexthop-tracking update message
  */
-static bool zapi_nexthop_update_decode(struct stream *s, struct prefix *match,
-				       struct zapi_route *nhr)
+bool zapi_nexthop_update_decode(struct stream *s, struct prefix *match, struct zapi_route *nhr)
 {
 	uint32_t i;
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -4001,6 +4001,8 @@ enum zclient_send_status zebra_send_sr_policy(struct zclient *zclient, int cmd,
 int zapi_sr_policy_encode(struct stream *s, int cmd, struct zapi_sr_policy *zp)
 {
 	struct zapi_srte_tunnel *zt = &zp->segment_list;
+	struct zapi_nexthop *znh;
+	int i;
 
 	stream_reset(s);
 
@@ -4021,7 +4023,7 @@ int zapi_sr_policy_encode(struct stream *s, int cmd, struct zapi_sr_policy *zp)
 	}
 	stream_putw(s, zt->label_num);
 
-	for (int i = 0; i < zt->label_num; i++)
+	for (i = 0; i < zt->label_num; i++)
 		stream_putl(s, zt->labels[i]);
 
 	/* Encode SRv6-TE */
@@ -4036,6 +4038,18 @@ int zapi_sr_policy_encode(struct stream *s, int cmd, struct zapi_sr_policy *zp)
 		stream_put(s, &zt->srv6_segs.segs[0],
 			   zt->srv6_segs.num_segs * sizeof(struct in6_addr));
 
+	stream_putw(s, zt->nexthop_resolved_num);
+
+	for (i = 0; i < zt->nexthop_resolved_num; i++) {
+		znh = &zt->nexthop_resolved[i];
+
+		if (zapi_nexthop_encode(s, znh, 0, 0) < 0)
+			return -1;
+	}
+
+	stream_putl(s, zt->metric);
+	stream_putc(s, zt->distance);
+
 	/* Put length at the first point of the stream. */
 	stream_putw_at(s, 0, stream_get_endp(s));
 
@@ -4044,9 +4058,11 @@ int zapi_sr_policy_encode(struct stream *s, int cmd, struct zapi_sr_policy *zp)
 
 int zapi_sr_policy_decode(struct stream *s, struct zapi_sr_policy *zp)
 {
-	memset(zp, 0, sizeof(*zp));
-
 	struct zapi_srte_tunnel *zt = &zp->segment_list;
+	struct zapi_nexthop *znh;
+	int i;
+
+	memset(zp, 0, sizeof(*zp));
 
 	STREAM_GETL(s, zp->color);
 	STREAM_GET_IPADDR(s, &zp->endpoint);
@@ -4063,7 +4079,7 @@ int zapi_sr_policy_decode(struct stream *s, struct zapi_sr_policy *zp)
 			 MPLS_MAX_LABELS);
 		return -1;
 	}
-	for (int i = 0; i < zt->label_num; i++)
+	for (i = 0; i < zt->label_num; i++)
 		STREAM_GETL(s, zt->labels[i]);
 
 	/* Decode SRv6-TE */
@@ -4077,6 +4093,23 @@ int zapi_sr_policy_decode(struct stream *s, struct zapi_sr_policy *zp)
 	if (zt->srv6_segs.num_segs)
 		STREAM_GET(&zt->srv6_segs.segs[0], s,
 			   zt->srv6_segs.num_segs * sizeof(struct in6_addr));
+
+	STREAM_GETW(s, zt->nexthop_resolved_num);
+	if (zt->nexthop_resolved_num > MULTIPATH_NUM) {
+		flog_err(EC_LIB_ZAPI_ENCODE, "%s: invalid number of nexthops (%u)", __func__,
+			 zt->nexthop_resolved_num);
+		return -1;
+	}
+
+	for (i = 0; i < zt->nexthop_resolved_num; i++) {
+		znh = &zt->nexthop_resolved[i];
+
+		if (zapi_nexthop_decode(s, znh, 0, 0) != 0)
+			return -1;
+	}
+
+	STREAM_GETL(s, zt->metric);
+	STREAM_GETC(s, zt->distance);
 
 	return 0;
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -4025,6 +4025,18 @@ int zapi_sr_policy_encode(struct stream *s, int cmd, struct zapi_sr_policy *zp)
 	for (int i = 0; i < zt->label_num; i++)
 		stream_putl(s, zt->labels[i]);
 
+	/* Encode SRv6-TE */
+	if (zt->srv6_segs.num_segs > SRV6_MAX_SEGS) {
+		flog_err(EC_LIB_ZAPI_ENCODE, "%s: can't encode %zu SRv6 SIDS (maximum is %u)",
+			 __func__, zt->srv6_segs.num_segs, SRV6_MAX_SEGS);
+		return -1;
+	}
+
+	stream_putw(s, zt->srv6_segs.num_segs);
+	if (zt->srv6_segs.num_segs)
+		stream_put(s, &zt->srv6_segs.segs[0],
+			   zt->srv6_segs.num_segs * sizeof(struct in6_addr));
+
 	/* Put length at the first point of the stream. */
 	stream_putw_at(s, 0, stream_get_endp(s));
 
@@ -4054,6 +4066,18 @@ int zapi_sr_policy_decode(struct stream *s, struct zapi_sr_policy *zp)
 	}
 	for (int i = 0; i < zt->label_num; i++)
 		STREAM_GETL(s, zt->labels[i]);
+
+	/* Decode SRv6-TE */
+	STREAM_GETW(s, zt->srv6_segs.num_segs);
+
+	if (zt->srv6_segs.num_segs > SRV6_MAX_SEGS) {
+		flog_err(EC_LIB_ZAPI_ENCODE, "%s: can't encode %zu SRv6 SIDS (maximum is %u)",
+			 __func__, zt->srv6_segs.num_segs, SRV6_MAX_SEGS);
+		return -1;
+	}
+	if (zt->srv6_segs.num_segs)
+		STREAM_GET(&zt->srv6_segs.segs[0], s,
+			   zt->srv6_segs.num_segs * sizeof(struct in6_addr));
 
 	return 0;
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -651,7 +651,7 @@ struct zapi_labels {
 };
 
 struct zapi_srte_tunnel {
-	enum lsp_types_t type;
+	enum sr_types type;
 
 	/* MPLS-TE */
 	mpls_label_t local_label;

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -661,6 +661,12 @@ struct zapi_srte_tunnel {
 	/* SRv6-TE */
 	struct seg6_segs srv6_segs;
 
+	/* For SRv6 resolution. contains
+	 * the resolved next-hop obtained by nexthop tracking
+	 */
+	uint16_t nexthop_resolved_num;
+	struct zapi_nexthop nexthop_resolved[MULTIPATH_NUM];
+
 	uint32_t metric;
 	uint8_t distance;
 };

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -652,9 +652,14 @@ struct zapi_labels {
 
 struct zapi_srte_tunnel {
 	enum lsp_types_t type;
+
+	/* MPLS-TE */
 	mpls_label_t local_label;
 	uint8_t label_num;
 	mpls_label_t labels[MPLS_MAX_LABELS];
+
+	/* SRv6-TE */
+	struct seg6_segs srv6_segs;
 };
 
 struct zapi_sr_policy {

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -663,6 +663,7 @@ struct zapi_srte_tunnel {
 
 	/* For SRv6 resolution. contains
 	 * the resolved next-hop obtained by nexthop tracking
+	 * the original metric and distance values
 	 */
 	uint16_t nexthop_resolved_num;
 	struct zapi_nexthop nexthop_resolved[MULTIPATH_NUM];

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -660,6 +660,9 @@ struct zapi_srte_tunnel {
 
 	/* SRv6-TE */
 	struct seg6_segs srv6_segs;
+
+	uint32_t metric;
+	uint8_t distance;
 };
 
 struct zapi_sr_policy {
@@ -1413,6 +1416,9 @@ extern int zapi_client_close_notify_decode(struct stream *s,
 
 extern int zclient_send_zebra_gre_request(struct zclient *client,
 					  struct interface *ifp);
+
+extern bool zapi_nexthop_update_decode(struct stream *s, struct prefix *match,
+				       struct zapi_route *nhr);
 #ifdef __cplusplus
 }
 #endif

--- a/pathd/path_cli.c
+++ b/pathd/path_cli.c
@@ -466,6 +466,8 @@ int segment_list_has_prefix(
 DEFPY_YANG(srte_segment_list_segment, srte_segment_list_segment_cmd,
       "index (0-4294967295)$index <[mpls$has_mpls_label label (16-1048575)$label] "
       "|"
+      "[ipv6-address$has_ipv6_address X:X::X:X$ipv6_address]"
+      "|"
       "[nai$has_nai <"
       "prefix <A.B.C.D/M$prefix_ipv4|X:X::X:X/M$prefix_ipv6>"
       "<algorithm$has_algo (0-1)$algo| iface$has_iface_id (0-4294967295)$iface_id>"
@@ -478,6 +480,8 @@ DEFPY_YANG(srte_segment_list_segment, srte_segment_list_segment_cmd,
       "MPLS or IP Label\n"
       "Label\n"
       "Label Value\n"
+      "IPv6 address\n"
+      "IPv6 address Value\n"
       "Segment NAI\n"
       "NAI prefix identifier\n"
       "NAI IPv4 prefix identifier\n"
@@ -504,6 +508,12 @@ DEFPY_YANG(srte_segment_list_segment, srte_segment_list_segment_cmd,
 		snprintf(xpath, sizeof(xpath),
 			 "./segment[index='%s']/sid-value", index_str);
 		nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, label_str);
+		return nb_cli_apply_changes(vty, NULL);
+	}
+
+	if (has_ipv6_address != NULL) {
+		snprintf(xpath, sizeof(xpath), "./segment[index='%s']/srv6-sid-value", index_str);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, ipv6_address_str);
 		return nb_cli_apply_changes(vty, NULL);
 	}
 
@@ -551,6 +561,9 @@ void cli_show_srte_segment_list_segment(struct vty *vty,
 		vty_out(vty, " mpls label %s",
 			yang_dnode_get_string(dnode, "sid-value"));
 	}
+	if (yang_dnode_exists(dnode, "srv6-sid-value"))
+		vty_out(vty, " ipv6-address %s", yang_dnode_get_string(dnode, "srv6-sid-value"));
+
 	if (yang_dnode_exists(dnode, "nai")) {
 		struct ipaddr addr;
 		struct ipaddr addr_rmt;

--- a/pathd/path_nb.c
+++ b/pathd/path_nb.c
@@ -83,6 +83,14 @@ const struct frr_yang_module_info frr_pathd_info = {
 			.priority = NB_DFLT_PRIORITY - 1
 		},
 		{
+			.xpath = "/frr-pathd:pathd/srte/segment-list/segment/srv6-sid-value",
+			.cbs = {
+				.modify = pathd_srte_segment_list_segment_srv6_sid_value_modify,
+				.destroy = pathd_srte_segment_list_segment_srv6_sid_value_destroy,
+			},
+			.priority = NB_DFLT_PRIORITY - 1
+		},
+		{
 			.xpath = "/frr-pathd:pathd/srte/segment-list/segment/nai",
 			.cbs = {
 				.create = dummy_create,

--- a/pathd/path_nb.h
+++ b/pathd/path_nb.h
@@ -32,6 +32,8 @@ void pathd_srte_segment_list_segment_nai_apply_finish(
 	struct nb_cb_apply_finish_args *args);
 int pathd_srte_segment_list_segment_sid_value_destroy(
 	struct nb_cb_destroy_args *args);
+int pathd_srte_segment_list_segment_srv6_sid_value_modify(struct nb_cb_modify_args *args);
+int pathd_srte_segment_list_segment_srv6_sid_value_destroy(struct nb_cb_destroy_args *args);
 int pathd_srte_policy_create(struct nb_cb_create_args *args);
 int pathd_srte_policy_destroy(struct nb_cb_destroy_args *args);
 const void *pathd_srte_policy_get_next(struct nb_cb_get_next_args *args);

--- a/pathd/path_nb_config.c
+++ b/pathd/path_nb_config.c
@@ -740,6 +740,7 @@ int pathd_srte_policy_candidate_path_segment_list_name_modify(
 	candidate = nb_running_get_entry(args->dnode, NULL, true);
 	segment_list_name = yang_dnode_get_string(args->dnode, NULL);
 
+	path_nht_removed(candidate);
 	candidate->segment_list = srte_segment_list_find(segment_list_name);
 	candidate->lsp->segment_list = candidate->segment_list;
 	assert(candidate->segment_list);

--- a/pathd/path_nb_config.c
+++ b/pathd/path_nb_config.c
@@ -162,6 +162,44 @@ int pathd_srte_segment_list_segment_sid_value_destroy(
 	return NB_OK;
 }
 
+/*
+ * XPath: /frr-pathd:pathd/srte/segment-list/segment/srv6-sid-value
+ */
+int pathd_srte_segment_list_segment_srv6_sid_value_modify(struct nb_cb_modify_args *args)
+{
+	struct srte_segment_entry *segment = NULL;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	segment = nb_running_get_entry(args->dnode, NULL, true);
+
+	if (segment == NULL)
+		return NB_ERR;
+
+	yang_dnode_get_ipv6(&segment->srv6_sid_value, args->dnode, NULL);
+	SET_FLAG(segment->segment_list->flags, F_SEGMENT_LIST_MODIFIED);
+
+	return NB_OK;
+}
+
+int pathd_srte_segment_list_segment_srv6_sid_value_destroy(struct nb_cb_destroy_args *args)
+{
+	struct srte_segment_entry *segment = NULL;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	segment = nb_running_get_entry(args->dnode, NULL, true);
+
+	if (segment == NULL)
+		return NB_ERR;
+
+	memset(&segment->srv6_sid_value, 0, sizeof(segment->srv6_sid_value));
+	SET_FLAG(segment->segment_list->flags, F_SEGMENT_LIST_MODIFIED);
+
+	return NB_OK;
+}
 
 int pathd_srte_segment_list_segment_nai_destroy(struct nb_cb_destroy_args *args)
 {

--- a/pathd/path_pcep_config.c
+++ b/pathd/path_pcep_config.c
@@ -13,6 +13,7 @@
 #include "pathd/path_pcep.h"
 #include "pathd/path_pcep_config.h"
 #include "pathd/path_pcep_debug.h"
+#include "pathd/path_zebra.h"
 #include "frrevent.h"
 
 #define MAX_XPATH 256
@@ -421,6 +422,7 @@ int path_pcep_config_update_path(struct path *path)
 			number_of_sid_clashed++;
 	}
 
+	path_nht_removed(candidate);
 	candidate->lsp->segment_list = segment_list;
 	SET_FLAG(candidate->flags, F_CANDIDATE_MODIFIED);
 

--- a/pathd/path_zebra.c
+++ b/pathd/path_zebra.c
@@ -181,12 +181,23 @@ void path_zebra_add_sr_policy(struct srte_policy *policy,
 	zp.color = policy->color;
 	zp.endpoint = policy->endpoint;
 	strlcpy(zp.name, policy->name, sizeof(zp.name));
-	zp.segment_list.type = ZEBRA_LSP_SRTE;
-	zp.segment_list.local_label = policy->binding_sid;
-	zp.segment_list.label_num = 0;
-	RB_FOREACH (segment, srte_segment_entry_head, &segment_list->segments)
-		zp.segment_list.labels[zp.segment_list.label_num++] =
-			segment->sid_value;
+	segment = RB_MIN(srte_segment_entry_head, &segment_list->segments);
+
+	if (sid_zero_ipv6(&segment->srv6_sid_value)) {
+		zp.segment_list.type = ZEBRA_SR_LSP_SRTE;
+		zp.segment_list.local_label = policy->binding_sid;
+		zp.segment_list.label_num = 0;
+		RB_FOREACH (segment, srte_segment_entry_head, &segment_list->segments)
+			zp.segment_list.labels[zp.segment_list.label_num++] = segment->sid_value;
+	} else {
+		zp.segment_list.type = ZEBRA_SR_SRV6_SRTE;
+		zp.segment_list.local_label = MPLS_LABEL_NONE;
+		zp.segment_list.srv6_segs.num_segs = 0;
+		RB_FOREACH (segment, srte_segment_entry_head, &segment_list->segments)
+			IPV6_ADDR_COPY(&zp.segment_list.srv6_segs
+						.segs[zp.segment_list.srv6_segs.num_segs++],
+				       &segment->srv6_sid_value);
+	}
 	policy->status = SRTE_POLICY_STATUS_GOING_UP;
 
 	(void)zebra_send_sr_policy(pathd_zclient, ZEBRA_SR_POLICY_SET, &zp);
@@ -200,13 +211,22 @@ void path_zebra_add_sr_policy(struct srte_policy *policy,
 void path_zebra_delete_sr_policy(struct srte_policy *policy)
 {
 	struct zapi_sr_policy zp = {};
+	struct srte_segment_entry *segment;
 
 	zp.color = policy->color;
 	zp.endpoint = policy->endpoint;
 	strlcpy(zp.name, policy->name, sizeof(zp.name));
-	zp.segment_list.type = ZEBRA_LSP_SRTE;
-	zp.segment_list.local_label = policy->binding_sid;
-	zp.segment_list.label_num = 0;
+	segment = RB_MIN(srte_segment_entry_head, &policy->best_candidate->segment_list->segments);
+
+	if (sid_zero_ipv6(&segment->srv6_sid_value)) {
+		zp.segment_list.type = ZEBRA_SR_LSP_SRTE;
+		zp.segment_list.local_label = policy->binding_sid;
+		zp.segment_list.label_num = 0;
+	} else {
+		zp.segment_list.local_label = MPLS_LABEL_NONE;
+		zp.segment_list.type = ZEBRA_SR_SRV6_SRTE;
+		zp.segment_list.srv6_segs.num_segs = 0;
+	}
 	policy->status = SRTE_POLICY_STATUS_DOWN;
 
 	(void)zebra_send_sr_policy(pathd_zclient, ZEBRA_SR_POLICY_DELETE, &zp);

--- a/pathd/path_zebra.c
+++ b/pathd/path_zebra.c
@@ -10,6 +10,7 @@
 #include "lib_errors.h"
 #include "if.h"
 #include "prefix.h"
+#include "jhash.h"
 #include "zclient.h"
 #include "network.h"
 #include "stream.h"
@@ -48,6 +49,88 @@ struct in6_addr g_router_id_v6;
 pthread_mutex_t g_router_id_v4_mtx = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t g_router_id_v6_mtx = PTHREAD_MUTEX_INITIALIZER;
 
+DEFINE_MTYPE_STATIC(PATHD, PATH_NHT_DATA, "Pathd Nexthop tracking data");
+PREDECL_HASH(path_nht_hash);
+
+struct path_nht_data {
+	struct path_nht_hash_item itm;
+
+	struct prefix nh;
+
+	vrf_id_t nh_vrf_id;
+
+	uint32_t refcount;
+	uint8_t nh_num;
+	struct nexthop *nexthop;
+	bool registered;
+
+	uint32_t metric;
+	uint8_t distance;
+};
+
+static int path_nht_data_cmp(const struct path_nht_data *nhtd1, const struct path_nht_data *nhtd2)
+{
+	if (nhtd1->nh_vrf_id != nhtd2->nh_vrf_id)
+		return numcmp(nhtd1->nh_vrf_id, nhtd2->nh_vrf_id);
+
+	return prefix_cmp(&nhtd1->nh, &nhtd2->nh);
+}
+
+static unsigned int path_nht_data_hash(const struct path_nht_data *nhtd)
+{
+	unsigned int key = 0;
+
+	key = prefix_hash_key(&nhtd->nh);
+	return jhash_1word(nhtd->nh_vrf_id, key);
+}
+
+DECLARE_HASH(path_nht_hash, struct path_nht_data, itm, path_nht_data_cmp, path_nht_data_hash);
+
+static struct path_nht_hash_head path_nht_hash[1];
+
+static struct path_nht_data *path_nht_hash_getref(const struct path_nht_data *ref)
+{
+	struct path_nht_data *nhtd;
+
+	nhtd = path_nht_hash_find(path_nht_hash, ref);
+	if (!nhtd) {
+		nhtd = XCALLOC(MTYPE_PATH_NHT_DATA, sizeof(*nhtd));
+
+		prefix_copy(&nhtd->nh, &ref->nh);
+		nhtd->nh_vrf_id = ref->nh_vrf_id;
+
+		path_nht_hash_add(path_nht_hash, nhtd);
+	}
+
+	nhtd->refcount++;
+	return nhtd;
+}
+
+static bool path_nht_hash_decref(struct path_nht_data **nhtd_p)
+{
+	struct path_nht_data *nhtd = *nhtd_p;
+
+	*nhtd_p = NULL;
+
+	if (--nhtd->refcount > 0)
+		return true;
+
+	path_nht_hash_del(path_nht_hash, nhtd);
+	XFREE(MTYPE_PATH_NHT_DATA, nhtd);
+	return false;
+}
+
+static void path_nht_hash_clear(void)
+{
+	struct path_nht_data *nhtd;
+
+	while ((nhtd = path_nht_hash_pop(path_nht_hash))) {
+		if (nhtd->nexthop)
+			nexthops_free(nhtd->nexthop);
+		XFREE(MTYPE_PATH_NHT_DATA, nhtd);
+	}
+}
+
 /**
  * Gives the IPv4 router ID received from Zebra.
  *
@@ -57,6 +140,7 @@ pthread_mutex_t g_router_id_v6_mtx = PTHREAD_MUTEX_INITIALIZER;
 bool get_ipv4_router_id(struct in_addr *router_id)
 {
 	bool retval = false;
+
 	assert(router_id != NULL);
 	pthread_mutex_lock(&g_router_id_v4_mtx);
 	if (g_has_router_id_v4) {
@@ -76,6 +160,7 @@ bool get_ipv4_router_id(struct in_addr *router_id)
 bool get_ipv6_router_id(struct in6_addr *router_id)
 {
 	bool retval = false;
+
 	assert(router_id != NULL);
 	pthread_mutex_lock(&g_router_id_v6_mtx);
 	if (g_has_router_id_v6) {
@@ -84,6 +169,91 @@ bool get_ipv6_router_id(struct in6_addr *router_id)
 	}
 	pthread_mutex_unlock(&g_router_id_v6_mtx);
 	return retval;
+}
+
+static bool path_zebra_segment_list_srv6(struct srte_segment_list *segment_list)
+{
+	struct srte_segment_entry *segment;
+
+	segment = RB_MIN(srte_segment_entry_head, &segment_list->segments);
+	if (segment && !IPV6_ADDR_SAME(&segment->srv6_sid_value, &in6addr_any))
+		return true;
+
+	return false;
+}
+
+static bool path_zebra_nht_get_srv6_prefix(struct srte_segment_list *segment_list, struct prefix *nh)
+{
+	struct srte_segment_entry *segment;
+	bool found = false;
+
+	if (!segment_list)
+		return false;
+
+	segment = RB_MIN(srte_segment_entry_head, &segment_list->segments);
+	if (segment && !IPV6_ADDR_SAME(&segment->srv6_sid_value, &in6addr_any)) {
+		nh->family = AF_INET6;
+		nh->prefixlen = IPV6_MAX_BITLEN;
+		memcpy(&nh->u.prefix6, &segment->srv6_sid_value, sizeof(struct in6_addr));
+		found = true;
+	}
+	return found;
+}
+
+static void path_zebra_add_srv6_policy_internal(struct srte_policy *policy)
+{
+	struct path_nht_data *nhtd, lookup = {};
+	uint32_t cmd;
+	struct srte_candidate *candidate;
+	struct srte_segment_list *segment_list = NULL;
+
+	candidate = policy->best_candidate;
+	if (candidate && candidate->lsp)
+		segment_list = candidate->lsp->segment_list;
+
+	if (!segment_list)
+		return;
+
+	if (!path_zebra_nht_get_srv6_prefix(segment_list, &lookup.nh))
+		return;
+
+	lookup.nh_vrf_id = VRF_DEFAULT;
+
+	if (CHECK_FLAG(segment_list->flags, F_SEGMENT_LIST_NHT_REGISTERED)) {
+		/* nh->nh_registered means we own a reference on the nhtd */
+		nhtd = path_nht_hash_find(path_nht_hash, &lookup);
+
+		assertf(nhtd, "BUG: NH %pFX registered but not in hashtable", &lookup.nh);
+	} else {
+		nhtd = path_nht_hash_getref(&lookup);
+
+		if (nhtd->refcount > 1)
+			zlog_debug("Reusing registered nexthop(%pFX) for candidate %s pref %u (num %d)",
+				   &lookup.nh, candidate->name, candidate->preference, nhtd->nh_num);
+	}
+
+	SET_FLAG(segment_list->flags, F_SEGMENT_LIST_NHT_REGISTERED);
+
+	if (nhtd->nh_num) {
+		path_zebra_add_sr_policy(candidate->policy, segment_list);
+		return;
+	}
+	path_zebra_delete_sr_policy(candidate->policy);
+
+	if (nhtd->registered)
+		/* have no data, but did send register */
+		return;
+
+	cmd = ZEBRA_NEXTHOP_REGISTER;
+	zlog_debug("Registering nexthop(%pFX) for candidate %s pref %u", &lookup.nh,
+		   candidate->name, candidate->preference);
+
+	if (zclient_send_rnh(pathd_zclient, cmd, &lookup.nh, SAFI_UNICAST, false, false,
+			     VRF_DEFAULT) == ZCLIENT_SEND_FAILURE)
+		zlog_warn("%s: Failure to send nexthop %pFX for candidate %s pref %u to zebra",
+			  __func__, &lookup.nh, candidate->name, candidate->preference);
+	else
+		nhtd->registered = true;
 }
 
 static void path_zebra_connected(struct zclient *zclient)
@@ -105,8 +275,10 @@ static void path_zebra_connected(struct zclient *zclient)
 		segment_list = candidate->lsp->segment_list;
 		if (!segment_list)
 			continue;
-
-		path_zebra_add_sr_policy(policy, segment_list);
+		if (path_zebra_segment_list_srv6(segment_list))
+			path_zebra_add_srv6_policy_internal(policy);
+		else
+			path_zebra_add_sr_policy(policy, segment_list);
 	}
 }
 
@@ -140,6 +312,7 @@ static int path_zebra_router_id_update(ZAPI_CALLBACK_ARGS)
 	struct prefix pref;
 	const char *family;
 	char buf[PREFIX2STR_BUFFER];
+
 	zebra_router_id_update_read(zclient->ibuf, &pref);
 	if (pref.family == AF_INET) {
 		pthread_mutex_lock(&g_router_id_v4_mtx);
@@ -167,13 +340,58 @@ static int path_zebra_router_id_update(ZAPI_CALLBACK_ARGS)
 }
 
 /**
+ * Disconnect from NHT
+ */
+void path_nht_removed(struct srte_candidate *candidate)
+{
+	struct path_nht_data *nhtd, lookup;
+	struct srte_segment_list *segment_list;
+	bool was_zebra_registered;
+
+	if (!candidate || !candidate->lsp)
+		return;
+
+	segment_list = candidate->lsp->segment_list;
+	if (!segment_list)
+		return;
+
+	if (!CHECK_FLAG(segment_list->flags, F_SEGMENT_LIST_NHT_REGISTERED))
+		return;
+
+	if (!path_zebra_nht_get_srv6_prefix(segment_list, &lookup.nh))
+		return;
+
+	lookup.nh_vrf_id = VRF_DEFAULT;
+
+	/* nh->nh_registered means we own a reference on the nhtd */
+	nhtd = path_nht_hash_find(path_nht_hash, &lookup);
+
+	assertf(nhtd, "BUG: NH %pFX registered but not in hashtable", &lookup.nh);
+
+	was_zebra_registered = nhtd->registered;
+	UNSET_FLAG(segment_list->flags, F_SEGMENT_LIST_NHT_REGISTERED);
+	if (path_nht_hash_decref(&nhtd))
+		/* still got references alive */
+		return;
+
+	/* NB: nhtd is now NULL. */
+	if (!was_zebra_registered)
+		return;
+
+	if (zclient_send_rnh(pathd_zclient, ZEBRA_NEXTHOP_UNREGISTER, &lookup.nh, SAFI_UNICAST,
+			     false, false, VRF_DEFAULT) == ZCLIENT_SEND_FAILURE)
+		zlog_warn("%s: Failure to send nexthop %pFX for candidate %s pref %u to zebra",
+			  __func__, &lookup.nh, candidate->name, candidate->preference);
+}
+
+/**
  * Adds a segment routing policy to Zebra.
  *
  * @param policy The policy to add
  * @param segment_list The segment list for the policy
  */
-void path_zebra_add_sr_policy(struct srte_policy *policy,
-			      struct srte_segment_list *segment_list)
+static void path_zebra_add_sr_policy_internal(struct srte_policy *policy,
+					      struct srte_segment_list *segment_list)
 {
 	struct zapi_sr_policy zp = {};
 	struct srte_segment_entry *segment;
@@ -181,9 +399,8 @@ void path_zebra_add_sr_policy(struct srte_policy *policy,
 	zp.color = policy->color;
 	zp.endpoint = policy->endpoint;
 	strlcpy(zp.name, policy->name, sizeof(zp.name));
-	segment = RB_MIN(srte_segment_entry_head, &segment_list->segments);
 
-	if (sid_zero_ipv6(&segment->srv6_sid_value)) {
+	if (!path_zebra_segment_list_srv6(segment_list)) {
 		zp.segment_list.type = ZEBRA_SR_LSP_SRTE;
 		zp.segment_list.local_label = policy->binding_sid;
 		zp.segment_list.label_num = 0;
@@ -204,6 +421,20 @@ void path_zebra_add_sr_policy(struct srte_policy *policy,
 }
 
 /**
+ * Adds a segment routing policy to Zebra.
+ *
+ * @param policy The policy to add
+ * @param segment_list The segment list for the policy
+ */
+void path_zebra_add_sr_policy(struct srte_policy *policy, struct srte_segment_list *segment_list)
+{
+	if (path_zebra_segment_list_srv6(segment_list))
+		path_zebra_add_srv6_policy_internal(policy);
+	else
+		path_zebra_add_sr_policy_internal(policy, segment_list);
+}
+
+/**
  * Deletes a segment policy from Zebra.
  *
  * @param policy The policy to remove
@@ -211,14 +442,17 @@ void path_zebra_add_sr_policy(struct srte_policy *policy,
 void path_zebra_delete_sr_policy(struct srte_policy *policy)
 {
 	struct zapi_sr_policy zp = {};
-	struct srte_segment_entry *segment;
+	struct srte_segment_entry *segment = NULL;
 
 	zp.color = policy->color;
 	zp.endpoint = policy->endpoint;
 	strlcpy(zp.name, policy->name, sizeof(zp.name));
-	segment = RB_MIN(srte_segment_entry_head, &policy->best_candidate->segment_list->segments);
 
-	if (sid_zero_ipv6(&segment->srv6_sid_value)) {
+	if (policy->best_candidate && policy->best_candidate->segment_list)
+		segment = RB_MIN(srte_segment_entry_head,
+				 &policy->best_candidate->segment_list->segments);
+
+	if (segment && sid_zero_ipv6(&segment->srv6_sid_value)) {
 		zp.segment_list.type = ZEBRA_SR_LSP_SRTE;
 		zp.segment_list.local_label = policy->binding_sid;
 		zp.segment_list.label_num = 0;
@@ -312,6 +546,23 @@ static void path_zebra_label_manager_connect(struct event *event)
 	}
 }
 
+static void path_zebra_nexthop_update(struct vrf *vrf, struct prefix *match, struct zapi_route *nhr)
+{
+	struct path_nht_data *nhtd, lookup;
+
+	if (match->family != AF_INET6)
+		return;
+
+	memset(&lookup, 0, sizeof(lookup));
+	prefix_copy(&lookup.nh, match);
+	lookup.nh_vrf_id = vrf->vrf_id;
+
+	nhtd = path_nht_hash_find(path_nht_hash, &lookup);
+
+	if (!nhtd)
+		zlog_err("Unable to find next-hop data for the given route.");
+}
+
 static int path_zebra_opaque_msg_handler(ZAPI_CALLBACK_ARGS)
 {
 	int ret = 0;
@@ -386,13 +637,21 @@ void path_zebra_init(struct event_loop *loop)
 	zclient_sync->instance = 1;
 	zclient_sync->privs = &pathd_privs;
 
+	pathd_zclient->nexthop_update = path_zebra_nexthop_update;
+
 	/* Connect to the LM. */
 	t_sync_connect = NULL;
 	path_zebra_label_manager_connect(NULL);
+
+	/* Pathd nht init */
+	path_nht_hash_init(path_nht_hash);
 }
 
 void path_zebra_stop(void)
 {
+	path_nht_hash_clear();
+	path_nht_hash_fini(path_nht_hash);
+
 	zclient_stop(pathd_zclient);
 	zclient_free(pathd_zclient);
 	event_cancel(&t_sync_connect);

--- a/pathd/path_zebra.c
+++ b/pathd/path_zebra.c
@@ -68,6 +68,10 @@ struct path_nht_data {
 	uint8_t distance;
 };
 
+static void path_zebra_add_sr_policy_internal(struct srte_policy *policy,
+					      struct srte_segment_list *segment_list,
+					      struct path_nht_data *nhtd);
+
 static int path_nht_data_cmp(const struct path_nht_data *nhtd1, const struct path_nht_data *nhtd2)
 {
 	if (nhtd1->nh_vrf_id != nhtd2->nh_vrf_id)
@@ -235,7 +239,7 @@ static void path_zebra_add_srv6_policy_internal(struct srte_policy *policy)
 	SET_FLAG(segment_list->flags, F_SEGMENT_LIST_NHT_REGISTERED);
 
 	if (nhtd->nh_num) {
-		path_zebra_add_sr_policy(candidate->policy, segment_list);
+		path_zebra_add_sr_policy_internal(candidate->policy, segment_list, nhtd);
 		return;
 	}
 	path_zebra_delete_sr_policy(candidate->policy);
@@ -278,7 +282,7 @@ static void path_zebra_connected(struct zclient *zclient)
 		if (path_zebra_segment_list_srv6(segment_list))
 			path_zebra_add_srv6_policy_internal(policy);
 		else
-			path_zebra_add_sr_policy(policy, segment_list);
+			path_zebra_add_sr_policy_internal(policy, segment_list, NULL);
 	}
 }
 
@@ -391,10 +395,14 @@ void path_nht_removed(struct srte_candidate *candidate)
  * @param segment_list The segment list for the policy
  */
 static void path_zebra_add_sr_policy_internal(struct srte_policy *policy,
-					      struct srte_segment_list *segment_list)
+					      struct srte_segment_list *segment_list,
+					      struct path_nht_data *nhtd)
 {
 	struct zapi_sr_policy zp = {};
 	struct srte_segment_entry *segment;
+	struct zapi_nexthop *znh;
+	struct nexthop *nexthop;
+	int num = 0;
 
 	zp.color = policy->color;
 	zp.endpoint = policy->endpoint;
@@ -417,6 +425,16 @@ static void path_zebra_add_sr_policy_internal(struct srte_policy *policy,
 	}
 	policy->status = SRTE_POLICY_STATUS_GOING_UP;
 
+	if (nhtd && nhtd->nexthop) {
+		zp.segment_list.distance = nhtd->distance;
+		zp.segment_list.metric = nhtd->metric;
+		for (ALL_NEXTHOPS_PTR(nhtd, nexthop)) {
+			znh = &zp.segment_list.nexthop_resolved[num++];
+			zapi_nexthop_from_nexthop(znh, nexthop);
+		}
+		zp.segment_list.nexthop_resolved_num = nhtd->nh_num;
+	}
+
 	(void)zebra_send_sr_policy(pathd_zclient, ZEBRA_SR_POLICY_SET, &zp);
 }
 
@@ -431,7 +449,7 @@ void path_zebra_add_sr_policy(struct srte_policy *policy, struct srte_segment_li
 	if (path_zebra_segment_list_srv6(segment_list))
 		path_zebra_add_srv6_policy_internal(policy);
 	else
-		path_zebra_add_sr_policy_internal(policy, segment_list);
+		path_zebra_add_sr_policy_internal(policy, segment_list, NULL);
 }
 
 /**
@@ -546,6 +564,96 @@ static void path_zebra_label_manager_connect(struct event *event)
 	}
 }
 
+static void path_nht_srv6_update(struct prefix *nh, struct path_nht_data *nhtd)
+{
+	struct srte_policy *policy;
+	struct prefix sid_srv6 = {};
+	struct srte_candidate *candidate;
+	struct srte_segment_list *segment_list;
+
+	RB_FOREACH (policy, srte_policy_head, &srte_policies) {
+		if (policy->endpoint.ipa_type != AF_INET6)
+			continue;
+
+		candidate = policy->best_candidate;
+		if (!candidate)
+			continue;
+		if (!candidate->lsp)
+			continue;
+		segment_list = candidate->lsp->segment_list;
+		if (!segment_list)
+			continue;
+
+		/* srv6 segment lists are registered */
+		if (!CHECK_FLAG(segment_list->flags, F_SEGMENT_LIST_NHT_REGISTERED))
+			continue;
+
+		if (!path_zebra_nht_get_srv6_prefix(segment_list, &sid_srv6))
+			continue;
+		if (!IPV6_ADDR_SAME(&sid_srv6.u.prefix6, &nh->u.prefix6))
+			continue;
+		if (nhtd->nh_num)
+			path_zebra_add_sr_policy_internal(policy, segment_list, nhtd);
+		else
+			path_zebra_delete_sr_policy(policy);
+	}
+}
+
+static bool path_zebra_srv6_nexthop_info_update(struct path_nht_data *nhtd, struct zapi_route *nhr)
+{
+	struct nexthop *nexthop;
+	struct nexthop *nhlist_head = NULL;
+	struct nexthop *nhlist_tail = NULL;
+	struct nexthop *oldnh;
+	bool nh_changed = false;
+	int i;
+
+	if (!nhtd || !nhr)
+		return false;
+
+	if (nhtd && nhr)
+		nhtd->nh_num = nhr->nexthop_num;
+
+	if (!nhr->nexthop_num) {
+		nhtd->nh_num = nhr->nexthop_num;
+		if (nhtd->nexthop)
+			nexthop_free(nhtd->nexthop);
+		nhtd->nexthop = NULL;
+		return true;
+	}
+
+	if (nhtd->distance != nhr->distance || nhtd->metric != nhr->metric) {
+		nhtd->distance = nhr->distance;
+		nhtd->metric = nhr->metric;
+		nh_changed = true;
+	}
+
+	for (i = 0; i < nhr->nexthop_num; i++) {
+		nexthop = nexthop_from_zapi_nexthop(&nhr->nexthops[i]);
+
+		if (nhlist_tail) {
+			nhlist_tail->next = nexthop;
+			nhlist_tail = nexthop;
+		} else {
+			nhlist_tail = nexthop;
+			nhlist_head = nexthop;
+		}
+
+		for (oldnh = nhtd->nexthop; oldnh; oldnh = oldnh->next)
+			if (nexthop_same(oldnh, nexthop))
+				break;
+
+		if (!oldnh)
+			nh_changed = true;
+	}
+	if (nhtd->nexthop)
+		nexthop_free(nhtd->nexthop);
+	nhtd->nexthop = nhlist_head;
+	nhr->nexthop_num = nhr->nexthop_num;
+
+	return nh_changed;
+}
+
 static void path_zebra_nexthop_update(struct vrf *vrf, struct prefix *match, struct zapi_route *nhr)
 {
 	struct path_nht_data *nhtd, lookup;
@@ -561,6 +669,8 @@ static void path_zebra_nexthop_update(struct vrf *vrf, struct prefix *match, str
 
 	if (!nhtd)
 		zlog_err("Unable to find next-hop data for the given route.");
+	else if (path_zebra_srv6_nexthop_info_update(nhtd, nhr))
+		path_nht_srv6_update(&nhr->prefix, nhtd);
 }
 
 static int path_zebra_opaque_msg_handler(ZAPI_CALLBACK_ARGS)

--- a/pathd/path_zebra.h
+++ b/pathd/path_zebra.h
@@ -18,5 +18,6 @@ int path_zebra_request_label(mpls_label_t label);
 void path_zebra_release_label(mpls_label_t label);
 void path_zebra_init(struct event_loop *master);
 void path_zebra_stop(void);
+void path_nht_removed(struct srte_candidate *candidate);
 
 #endif /* _FRR_PATH_MPLS_H_ */

--- a/pathd/pathd.c
+++ b/pathd/pathd.c
@@ -616,7 +616,8 @@ void srte_policy_apply_changes(struct srte_policy *policy)
 			UNSET_FLAG(old_best_candidate->flags, F_CANDIDATE_BEST);
 			SET_FLAG(old_best_candidate->flags,
 				 F_CANDIDATE_MODIFIED);
-
+			if (old_best_candidate->lsp)
+				path_nht_removed(old_best_candidate);
 			/*
 			 * Rely on replace semantics if there's a new best
 			 * candidate.

--- a/pathd/pathd.h
+++ b/pathd/pathd.h
@@ -167,6 +167,9 @@ struct srte_segment_entry {
 	/* Label Value. */
 	mpls_label_t sid_value;
 
+	/* SRv6 SID. */
+	struct in6_addr srv6_sid_value;
+
 	/* NAI Type */
 	enum srte_segment_nai_type nai_type;
 	/* NAI local address when nai type is not NONE */

--- a/pathd/pathd.h
+++ b/pathd/pathd.h
@@ -210,6 +210,7 @@ struct srte_segment_list {
 #define F_SEGMENT_LIST_MODIFIED 0x0004
 #define F_SEGMENT_LIST_DELETED 0x0008
 #define F_SEGMENT_LIST_SID_CONFLICT 0x0010
+#define F_SEGMENT_LIST_NHT_REGISTERED 0x0020
 };
 RB_HEAD(srte_segment_list_head, srte_segment_list);
 RB_PROTOTYPE(srte_segment_list_head, srte_segment_list, entry,

--- a/tests/topotests/isis_srv6_te_topo1/dst/zebra.conf
+++ b/tests/topotests/isis_srv6_te_topo1/dst/zebra.conf
@@ -1,0 +1,22 @@
+log file zebra.log
+!
+hostname dst
+!
+! debug zebra kernel
+! debug zebra packet
+! debug zebra mpls
+!
+interface lo
+ ipv6 address fc00:0:9::1/128
+!
+interface eth-rt6
+ ip address 10.0.10.2/24
+ ipv6 address 2001:db8:10::2/64
+!
+ip forwarding
+!
+ip route 10.8.0.2/24 10.0.10.1
+ipv6 route 2001:db8:1::/64 2001:db8:10::1
+!
+line vty
+!

--- a/tests/topotests/isis_srv6_te_topo1/rt1/bgpd.conf
+++ b/tests/topotests/isis_srv6_te_topo1/rt1/bgpd.conf
@@ -1,0 +1,45 @@
+frr defaults traditional
+!
+hostname r1
+password zebra
+!
+log stdout notifications
+log commands
+!
+router bgp 65001
+ bgp router-id 192.0.2.1
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ neighbor fc00:0:6b::1 remote-as 65002
+ neighbor fc00:0:6b::1 ebgp-multihop
+ neighbor fc00:0:6b::1 update-source fc00:0:1b::1
+ neighbor fc00:0:6b::1 timers 1 3
+ neighbor fc00:0:6b::1 timers connect 1
+ neighbor fc00:0:6b::1 capability extended-nexthop
+ !
+ segment-routing srv6
+  locator loc2
+ !
+ address-family ipv6
+  neighbor fc00:0:6b::1 activate
+ exit-address-family
+!
+address-family ipv4 vpn
+  neighbor fc00:0:6b::1 activate
+ exit-address-family
+ !
+!
+router bgp 65001 vrf vrf10
+ bgp router-id 192.0.2.1
+ !
+ address-family ipv4 unicast
+  redistribute connected
+  sid vpn export auto
+  rd vpn export 65001:10
+  rt vpn both 0:10
+  import vpn
+  export vpn
+ exit-address-family
+ !
+!
+!

--- a/tests/topotests/isis_srv6_te_topo1/rt1/isisd.conf
+++ b/tests/topotests/isis_srv6_te_topo1/rt1/isisd.conf
@@ -1,0 +1,37 @@
+hostname rt1
+log file isisd.log
+!
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-sw1
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+router isis 1
+ lsp-gen-interval 2
+ net 49.0000.0000.0000.0001.00
+ is-type level-1
+ topology ipv6-unicast
+ lsp-gen-interval 1
+ lsp-refresh-interval 2
+ spf-interval 1
+ segment-routing srv6
+  locator loc1
+  node-msd
+   max-segs-left 3
+   max-end-pop 3
+   max-h-encaps 2
+   max-end-d 5
+  interface sr0
+!

--- a/tests/topotests/isis_srv6_te_topo1/rt1/step1/show_ipv6_route.ref
+++ b/tests/topotests/isis_srv6_te_topo1/rt1/step1/show_ipv6_route.ref
@@ -1,0 +1,246 @@
+{
+    "fc00:0:1::/128": [
+        {
+            "prefix": "fc00:0:1::/128",
+            "prefixLen": 128,
+            "protocol": "isis",
+            "selected": true,
+            "distance": 115,
+            "installed": true,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "active": true,
+                    "weight": 1,
+                    "seg6local": {
+                        "action": "End"
+                    }
+                }
+            ]
+        }
+    ],
+    "fc00:0:1:1::/128": [
+        {
+            "prefix": "fc00:0:1:1::/128",
+            "prefixLen": 128,
+            "protocol": "isis",
+            "selected": true,
+            "distance": 115,
+            "installed": true,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "active": true,
+                    "weight": 1,
+                    "seg6local": {
+                        "action": "End.X"
+                    }
+                }
+            ]
+        }
+    ],
+    "fc00:0:1:2::/128": [
+        {
+            "prefix": "fc00:0:1:2::/128",
+            "prefixLen": 128,
+            "protocol": "isis",
+            "selected": true,
+            "distance": 115,
+            "installed": true,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "active": true,
+                    "weight": 1,
+                    "seg6local": {
+                        "action": "End.X"
+                    }
+                }
+            ]
+        }
+    ],
+    "fc00:0:2::/48": [
+        {
+            "prefix": "fc00:0:2::/48",
+            "prefixLen": 48,
+            "protocol": "isis",
+            "selected": true,
+            "distance": 115,
+            "installed": true,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "afi": "ipv6",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "fc00:0:2::1/128": [
+        {
+            "prefix": "fc00:0:2::1/128",
+            "prefixLen": 128,
+            "protocol": "isis",
+            "selected": true,
+            "distance": 115,
+            "installed": true,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "afi": "ipv6",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "fc00:0:3::/48": [
+        {
+            "prefix": "fc00:0:3::/48",
+            "prefixLen": 48,
+            "protocol": "isis",
+            "selected": true,
+            "distance": 115,
+            "installed": true,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "afi": "ipv6",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "fc00:0:3::1/128": [
+        {
+            "prefix": "fc00:0:3::1/128",
+            "prefixLen": 128,
+            "protocol": "isis",
+            "selected": true,
+            "distance": 115,
+            "installed": true,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "afi": "ipv6",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "fc00:0:4::/48": [
+        {
+            "prefix": "fc00:0:4::/48",
+            "prefixLen": 48,
+            "protocol": "isis",
+            "selected": true,
+            "distance": 115,
+            "installed": true,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "afi": "ipv6",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "fc00:0:4::1/128": [
+        {
+            "prefix": "fc00:0:4::1/128",
+            "prefixLen": 128,
+            "protocol": "isis",
+            "selected": true,
+            "distance": 115,
+            "installed": true,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "afi": "ipv6",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "fc00:0:5::/48": [
+        {
+            "prefix": "fc00:0:5::/48",
+            "prefixLen": 48,
+            "protocol": "isis",
+            "selected": true,
+            "distance": 115,
+            "installed": true,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "afi": "ipv6",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "fc00:0:5::1/128": [
+        {
+            "prefix": "fc00:0:5::1/128",
+            "prefixLen": 128,
+            "protocol": "isis",
+            "selected": true,
+            "distance": 115,
+            "installed": true,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "afi": "ipv6",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "fc00:0:6::/48": [
+        {
+            "prefix": "fc00:0:6::/48",
+            "prefixLen": 48,
+            "protocol": "isis",
+            "selected": true,
+            "distance": 115,
+            "installed": true,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "afi": "ipv6",
+                    "active": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "afi": "ipv6",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/isis_srv6_te_topo1/rt1/step1/show_srv6_locator_table.ref
+++ b/tests/topotests/isis_srv6_te_topo1/rt1/step1/show_srv6_locator_table.ref
@@ -1,0 +1,18 @@
+{
+  "locators":[
+    {
+      "name":"loc1",
+      "prefix":"fc00:0:1::/48",
+      "blockBitsLength":32,
+      "nodeBitsLength":16,
+      "functionBitsLength":16,
+      "argumentBitsLength":0,
+      "statusUp":true,
+      "chunks":[
+        {
+          "prefix":"fc00:0:1::/48"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/isis_srv6_te_topo1/rt1/step1/show_yang_interface_isis_adjacencies.ref
+++ b/tests/topotests/isis_srv6_te_topo1/rt1/step1/show_yang_interface_isis_adjacencies.ref
@@ -1,0 +1,32 @@
+{
+  "frr-interface:lib": {
+    "interface": [
+      {
+        "name": "eth-sw1",
+        "vrf": "default",
+        "state": {
+          "frr-isisd:isis": {
+            "adjacencies": {
+              "adjacency": [
+                {
+                  "neighbor-sys-type": "level-1",
+                  "neighbor-sysid": "0000.0000.0003",
+                  "hold-timer": 10,
+                  "neighbor-priority": 64,
+                  "state": "up"
+                },
+                {
+                  "neighbor-sys-type": "level-1",
+                  "neighbor-sysid": "0000.0000.0002",
+                  "hold-timer": 10,
+                  "neighbor-priority": 64,
+                  "state": "up"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/topotests/isis_srv6_te_topo1/rt1/step2/show_srv6_route.ref
+++ b/tests/topotests/isis_srv6_te_topo1/rt1/step2/show_srv6_route.ref
@@ -1,0 +1,36 @@
+{
+    "2001:db8:10::/64": [
+        {
+            "prefix": "2001:db8:10::/64",
+            "prefixLen": 64,
+            "protocol": "static",
+            "distance": 1,
+            "installed": true,
+            "nexthops": [
+                {
+                    "flags": 133,
+                    "ip": "fc00:0:6::",
+                    "afi": "ipv6",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1,
+                    "srteColor": 1
+                },
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "afi": "ipv6",
+                    "weight": 1,
+                    "seg6local": {
+                        "action": "unspec"
+                    },
+                    "seg6": [
+                        "fc00:0:3::",
+                        "fc00:0:5::",
+                        "fc00:0:6::"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/isis_srv6_te_topo1/rt1/step3/show_srv6_additional_route.ref
+++ b/tests/topotests/isis_srv6_te_topo1/rt1/step3/show_srv6_additional_route.ref
@@ -1,0 +1,37 @@
+{
+  "fc00:0:6b::/48": [
+    {
+      "prefix": "fc00:0:6b::/48",
+      "prefixLen": 48,
+      "protocol": "static",
+      "selected": true,
+      "nexthops": [
+        {
+          "flags": 133,
+          "ip": "fc00:0:6::",
+          "afi": "ipv6",
+          "active":true,
+          "recursive": true,
+          "weight": 1,
+          "srteColor": 1
+        },
+        {
+          "flags": 3,
+          "fib": true,
+          "afi": "ipv6",
+          "resolver": true,
+          "active": true,
+          "weight": 1,
+          "seg6local": {
+            "action": "unspec"
+          },
+          "seg6": [
+            "fc00:0:3::",
+            "fc00:0:5::",
+            "fc00:0:6::"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/isis_srv6_te_topo1/rt1/step4/show_ipv6_route.ref
+++ b/tests/topotests/isis_srv6_te_topo1/rt1/step4/show_ipv6_route.ref
@@ -1,0 +1,37 @@
+{
+    "fc00:0:6b::/48": [
+        {
+            "prefix": "fc00:0:6b::/48",
+            "prefixLen": 48,
+            "protocol": "static",
+            "distance": 1,
+            "metric": 0,
+            "installed": true,
+            "nexthops": [
+                {
+                    "flags": 133,
+                    "ip": "fc00:0:6::",
+                    "afi": "ipv6",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1,
+                    "srteColor": 1
+                },
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "afi": "ipv6",
+                    "active": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "afi": "ipv6",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/isis_srv6_te_topo1/rt1/zebra.conf
+++ b/tests/topotests/isis_srv6_te_topo1/rt1/zebra.conf
@@ -1,0 +1,23 @@
+log file zebra.log
+!
+hostname rt1
+!
+! debug zebra kernel
+! debug zebra packet
+!
+interface lo
+ ipv6 address fc00:0:1::1/48
+ ipv6 address fc00:0:1b::1/48
+!
+interface eth-sw1
+ ip address 10.0.1.1/24
+ ipv6 address 2001:db8:1::1/64
+!
+interface eth-src
+ ip address 10.8.0.1/24
+exit
+!
+ip forwarding
+!
+line vty
+!

--- a/tests/topotests/isis_srv6_te_topo1/rt2/isisd.conf
+++ b/tests/topotests/isis_srv6_te_topo1/rt2/isisd.conf
@@ -1,0 +1,51 @@
+hostname rt2
+log file isisd.log
+!
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-sw1
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+interface eth-rt4-1
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+interface eth-rt4-2
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+router isis 1
+ lsp-gen-interval 2
+ net 49.0000.0000.0000.0002.00
+ is-type level-1
+ topology ipv6-unicast
+ lsp-gen-interval 1
+ lsp-refresh-interval 2
+ spf-interval 1
+ segment-routing srv6
+  locator loc1
+  node-msd
+   max-segs-left 3
+   max-end-pop 3
+   max-h-encaps 2
+   max-end-d 5
+  interface sr0
+!

--- a/tests/topotests/isis_srv6_te_topo1/rt2/zebra.conf
+++ b/tests/topotests/isis_srv6_te_topo1/rt2/zebra.conf
@@ -1,0 +1,32 @@
+log file zebra.log
+!
+hostname rt2
+!
+! debug zebra kernel
+! debug zebra packet
+!
+interface lo
+ ipv6 address fc00:0:2::1/128
+!
+interface eth-sw1
+ ip address 10.0.1.2/24
+ ipv6 address 2001:db8:1::2/64
+!
+interface eth-rt4-1
+ ip address 10.0.2.2/24
+!
+interface eth-rt4-2
+ ip address 10.0.3.2/24
+!
+segment-routing
+ srv6
+  locators
+   locator loc1
+    prefix fc00:0:2::/48 block-len 32 node-len 16 func-bits 16
+  !
+ !
+!
+ip forwarding
+!
+line vty
+!

--- a/tests/topotests/isis_srv6_te_topo1/rt3/isisd.conf
+++ b/tests/topotests/isis_srv6_te_topo1/rt3/isisd.conf
@@ -1,0 +1,51 @@
+hostname rt3
+log file isisd.log
+!
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-sw1
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+interface eth-rt5-1
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+interface eth-rt5-2
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+router isis 1
+ lsp-gen-interval 2
+ net 49.0000.0000.0000.0003.00
+ is-type level-1
+ topology ipv6-unicast
+ lsp-gen-interval 1
+ lsp-refresh-interval 2
+ spf-interval 1
+ segment-routing srv6
+  locator loc1
+  node-msd
+   max-segs-left 3
+   max-end-pop 3
+   max-h-encaps 2
+   max-end-d 5
+  interface sr0
+!

--- a/tests/topotests/isis_srv6_te_topo1/rt3/zebra.conf
+++ b/tests/topotests/isis_srv6_te_topo1/rt3/zebra.conf
@@ -1,0 +1,31 @@
+log file zebra.log
+!
+hostname rt3
+!
+! debug zebra kernel
+! debug zebra packet
+!
+interface lo
+ ipv6 address fc00:0:3::1/128
+!
+interface eth-sw1
+ ip address 10.0.1.3/24
+!
+interface eth-rt5-1
+ ip address 10.0.4.3/24
+!
+interface eth-rt5-2
+ ip address 10.0.5.3/24
+!
+segment-routing
+ srv6
+  locators
+   locator loc1
+    prefix fc00:0:3::/48 block-len 32 node-len 16 func-bits 16
+  !
+ !
+!
+ip forwarding
+!
+line vty
+!

--- a/tests/topotests/isis_srv6_te_topo1/rt4/isisd.conf
+++ b/tests/topotests/isis_srv6_te_topo1/rt4/isisd.conf
@@ -1,0 +1,59 @@
+hostname rt4
+log file isisd.log
+!
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-rt2-1
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+interface eth-rt2-2
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+interface eth-rt5
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+interface eth-rt6
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+router isis 1
+ lsp-gen-interval 2
+ net 49.0000.0000.0000.0004.00
+ is-type level-1
+ topology ipv6-unicast
+ lsp-gen-interval 1
+ lsp-refresh-interval 2
+ spf-interval 1
+ segment-routing srv6
+  locator loc1
+  node-msd
+   max-segs-left 3
+   max-end-pop 3
+   max-h-encaps 2
+   max-end-d 5
+  interface sr0
+!

--- a/tests/topotests/isis_srv6_te_topo1/rt4/zebra.conf
+++ b/tests/topotests/isis_srv6_te_topo1/rt4/zebra.conf
@@ -1,0 +1,34 @@
+log file zebra.log
+!
+hostname rt4
+!
+! debug zebra kernel
+! debug zebra packet
+!
+interface lo
+ ipv6 address fc00:0:4::1/128
+!
+interface eth-rt2-1
+ ip address 10.0.2.4/24
+!
+interface eth-rt2-2
+ ip address 10.0.3.4/24
+!
+interface eth-rt5
+ ip address 10.0.6.4/24
+!
+interface eth-rt6
+ ip address 10.0.7.4/24
+!
+segment-routing
+ srv6
+  locators
+   locator loc1
+    prefix fc00:0:4::/48 block-len 32 node-len 16 func-bits 16
+  !
+ !
+!
+ip forwarding
+!
+line vty
+!

--- a/tests/topotests/isis_srv6_te_topo1/rt5/isisd.conf
+++ b/tests/topotests/isis_srv6_te_topo1/rt5/isisd.conf
@@ -1,0 +1,59 @@
+hostname rt5
+log file isisd.log
+!
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-rt3-1
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+interface eth-rt3-2
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+interface eth-rt4
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+interface eth-rt6
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+router isis 1
+ lsp-gen-interval 2
+ net 49.0000.0000.0000.0005.00
+ is-type level-1
+ topology ipv6-unicast
+ lsp-gen-interval 1
+ lsp-refresh-interval 2
+ spf-interval 1
+ segment-routing srv6
+  locator loc1
+  node-msd
+   max-segs-left 3
+   max-end-pop 3
+   max-h-encaps 2
+   max-end-d 5
+  interface sr0
+!

--- a/tests/topotests/isis_srv6_te_topo1/rt5/zebra.conf
+++ b/tests/topotests/isis_srv6_te_topo1/rt5/zebra.conf
@@ -1,0 +1,34 @@
+log file zebra.log
+!
+hostname rt5
+!
+! debug zebra kernel
+! debug zebra packet
+!
+interface lo
+ ipv6 address fc00:0:5::1/128
+!
+interface eth-rt3-1
+ ip address 10.0.4.5/24
+!
+interface eth-rt3-2
+ ip address 10.0.5.5/24
+!
+interface eth-rt4
+ ip address 10.0.6.5/24
+!
+interface eth-rt6
+ ip address 10.0.8.5/24
+!
+segment-routing
+ srv6
+  locators
+   locator loc1
+    prefix fc00:0:5::/48 block-len 32 node-len 16 func-bits 16
+  !
+ !
+!
+ip forwarding
+!
+line vty
+!

--- a/tests/topotests/isis_srv6_te_topo1/rt6/bgpd.conf
+++ b/tests/topotests/isis_srv6_te_topo1/rt6/bgpd.conf
@@ -1,0 +1,45 @@
+frr defaults traditional
+!
+hostname r2
+password zebra
+!
+log stdout notifications
+log commands
+!
+router bgp 65002
+ bgp router-id 192.0.2.2
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ neighbor fc00:0:1b::1 remote-as 65001
+ neighbor fc00:0:1b::1 ebgp-multihop
+ neighbor fc00:0:1b::1 update-source fc00:0:6b::1
+ neighbor fc00:0:6b::1 timers 1 3
+ neighbor fc00:0:1b::1 timers connect 1
+ neighbor fc00:0:1b::1 capability extended-nexthop
+ !
+ segment-routing srv6
+  locator loc2
+ !
+ address-family ipv6
+  neighbor fc00:0:1b::1 activate
+  network 2001:db8:11::1/64
+ exit-address-family
+ !
+ address-family ipv4 vpn
+  neighbor fc00:0:1b::1 activate
+ exit-address-family
+ !
+!
+router bgp 65002 vrf vrf10
+ bgp router-id 192.0.2.2
+ !
+ address-family ipv4 unicast
+  redistribute connected
+  sid vpn export auto
+  rd vpn export 65002:10
+  rt vpn both 0:10
+  import vpn
+  export vpn
+ exit-address-family
+ !
+!

--- a/tests/topotests/isis_srv6_te_topo1/rt6/isisd.conf
+++ b/tests/topotests/isis_srv6_te_topo1/rt6/isisd.conf
@@ -1,0 +1,45 @@
+hostname rt6
+log file isisd.log
+!
+! debug isis events
+! debug isis route-events
+! debug isis spf-events
+! debug isis sr-events
+! debug isis lsp-gen
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-rt4
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+interface eth-rt5
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+ isis hello-interval 1
+ isis hello-multiplier 10
+!
+router isis 1
+ lsp-gen-interval 2
+ net 49.0000.0000.0000.0006.00
+ is-type level-1
+ topology ipv6-unicast
+ lsp-gen-interval 1
+ lsp-refresh-interval 2
+ spf-interval 1
+ segment-routing srv6
+  locator loc1
+  node-msd
+   max-segs-left 3
+   max-end-pop 3
+   max-h-encaps 2
+   max-end-d 5
+  interface sr0
+!

--- a/tests/topotests/isis_srv6_te_topo1/rt6/zebra.conf
+++ b/tests/topotests/isis_srv6_te_topo1/rt6/zebra.conf
@@ -1,0 +1,44 @@
+log file zebra.log
+!
+hostname rt6
+!
+! debug zebra kernel
+! debug zebra packet
+!
+interface lo
+ ipv6 address fc00:0:6::1/48
+ ipv6 address fc00:0:6b::1/48
+!
+interface eth-rt4
+ ip address 10.0.7.6/24
+!
+interface eth-rt5
+ ip address 10.0.8.6/24
+!
+interface eth-dst
+ ip address 10.0.10.1/24
+ ip address 2001:db8:10::1/64
+ ip address 2001:db8:11::1/64
+!
+segment-routing
+ srv6
+  locators
+   locator loc1
+    prefix fc00:0:6::/48 block-len 32 node-len 16 func-bits 16
+   exit
+   !
+   locator loc2
+    prefix fc00:0:6b::/48 block-len 32 node-len 16 func-bits 16
+   exit
+   !
+  exit
+  !
+ exit
+ !
+exit
+ip forwarding
+!
+ip route fc00:0:9::1/128 2001:db8:10::2
+!
+line vty
+!

--- a/tests/topotests/isis_srv6_te_topo1/src/zebra.conf
+++ b/tests/topotests/isis_srv6_te_topo1/src/zebra.conf
@@ -1,0 +1,6 @@
+ip route 10.0.10.0/24 10.8.0.1
+!
+interface eth-rt1
+ ip address 10.8.0.2/24
+exit
+!

--- a/tests/topotests/isis_srv6_te_topo1/test_isis_srv6_te_topo1.py
+++ b/tests/topotests/isis_srv6_te_topo1/test_isis_srv6_te_topo1.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright 2023 6WIND S.A.
+# Dmytro Shytyi <dmytro.shytyi@6wind.com>
+#
+
+
+"""
+test_isis_srv6_te_topo1.py:
+
+
+                         +---------+
+                         |         |
+                         |   SRC   |
+                         |         |
+                         +---------+
+                              |eth-rt1
+                              |
+                              |10.8.0.0/24
+                              |
+                              |eth-src
+                         +---------+
+                         |         |
+                         |   RT1   |
+                         |         |
+                         |         |
+                         +---------+
+                              |eth-sw1
+                              |
+                              |
+                              |
+         +---------+          |          +---------+
+         |         |          |          |         |
+         |   RT2   |eth-sw1   |   eth-sw1|   RT3   |
+         |         +----------+----------+         |
+         |         |     10.0.1.0/24     |         |
+         +---------+                     +---------+
+    eth-rt4-1|  |eth-rt4-2          eth-rt5-1|  |eth-rt5-2
+             |  |                            |  |
+  10.0.2.0/24|  |10.0.3.0/24      10.0.4.0/24|  |10.0.5.0/24
+             |  |                            |  |
+    eth-rt2-1|  |eth-rt2-2          eth-rt3-1|  |eth-rt3-2
+         +---------+                     +---------+
+         |         |                     |         |
+         |   RT4   |     10.0.6.0/24     |   RT5   |
+         |         +---------------------+         |
+         |         |eth-rt5       eth-rt4|         |
+         +---------+                     +---------+
+       eth-rt6|                                |eth-rt6
+              |                                |
+   10.0.7.0/24|                                |10.0.8.0/24
+              |          +---------+           |
+              |          |         |           |
+              |          |   RT6   |           |
+              +----------+         +-----------+
+                  eth-rt4|         |eth-rt5
+                         +---------+
+                              |eth-dst (.1)
+                              |
+                              |10.0.10.0/24
+                              |
+                              |eth-rt6 (.2)
+                         +---------+
+                         |         |
+                         |   DST   |
+                         |         |
+                         +---------+
+
+"""
+
+import os
+import re
+import sys
+import json
+import functools
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from lib.common_config import (
+    required_linux_kernel_version,
+    create_interface_in_kernel,
+)
+
+pytestmark = [pytest.mark.isisd, pytest.mark.bgpd, pytest.mark.pathd]
+
+
+def build_topo(tgen):
+    """Build function"""
+
+    # Define FRR Routers
+    tgen.add_router("rt1")
+    tgen.add_router("rt2")
+    tgen.add_router("rt3")
+    tgen.add_router("rt4")
+    tgen.add_router("rt5")
+    tgen.add_router("rt6")
+    tgen.add_router("dst")
+    tgen.add_router("src")
+
+    # Define connections
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["rt1"], nodeif="eth-sw1")
+    switch.add_link(tgen.gears["rt2"], nodeif="eth-sw1")
+    switch.add_link(tgen.gears["rt3"], nodeif="eth-sw1")
+
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["rt2"], nodeif="eth-rt4-1")
+    switch.add_link(tgen.gears["rt4"], nodeif="eth-rt2-1")
+
+    switch = tgen.add_switch("s3")
+    switch.add_link(tgen.gears["rt2"], nodeif="eth-rt4-2")
+    switch.add_link(tgen.gears["rt4"], nodeif="eth-rt2-2")
+
+    switch = tgen.add_switch("s4")
+    switch.add_link(tgen.gears["rt3"], nodeif="eth-rt5-1")
+    switch.add_link(tgen.gears["rt5"], nodeif="eth-rt3-1")
+
+    switch = tgen.add_switch("s5")
+    switch.add_link(tgen.gears["rt3"], nodeif="eth-rt5-2")
+    switch.add_link(tgen.gears["rt5"], nodeif="eth-rt3-2")
+
+    switch = tgen.add_switch("s6")
+    switch.add_link(tgen.gears["rt4"], nodeif="eth-rt5")
+    switch.add_link(tgen.gears["rt5"], nodeif="eth-rt4")
+
+    switch = tgen.add_switch("s7")
+    switch.add_link(tgen.gears["rt4"], nodeif="eth-rt6")
+    switch.add_link(tgen.gears["rt6"], nodeif="eth-rt4")
+
+    switch = tgen.add_switch("s8")
+    switch.add_link(tgen.gears["rt5"], nodeif="eth-rt6")
+    switch.add_link(tgen.gears["rt6"], nodeif="eth-rt5")
+
+    switch = tgen.add_switch("s9")
+    switch.add_link(tgen.gears["rt6"], nodeif="eth-dst")
+    switch.add_link(tgen.gears["dst"], nodeif="eth-rt6")
+
+    switch = tgen.add_switch("s10")
+    switch.add_link(tgen.gears["rt1"], nodeif="eth-src")
+    switch.add_link(tgen.gears["src"], nodeif="eth-rt1")
+
+    # Add dummy interface for SRv6
+    create_interface_in_kernel(
+        tgen,
+        "rt1",
+        "sr0",
+        "2001:db8::1",
+        netmask="128",
+        create=True,
+    )
+    create_interface_in_kernel(
+        tgen,
+        "rt2",
+        "sr0",
+        "2001:db8::2",
+        netmask="128",
+        create=True,
+    )
+    create_interface_in_kernel(
+        tgen,
+        "rt3",
+        "sr0",
+        "2001:db8::3",
+        netmask="128",
+        create=True,
+    )
+    create_interface_in_kernel(
+        tgen,
+        "rt4",
+        "sr0",
+        "2001:db8::4",
+        netmask="128",
+        create=True,
+    )
+    create_interface_in_kernel(
+        tgen,
+        "rt5",
+        "sr0",
+        "2001:db8::5",
+        netmask="128",
+        create=True,
+    )
+    create_interface_in_kernel(
+        tgen,
+        "rt6",
+        "sr0",
+        "2001:db8::6",
+        netmask="128",
+        create=True,
+    )
+
+
+def setup_module(mod):
+    """Sets up the pytest environment"""
+
+    # Verify if kernel requirements are satisfied
+    result = required_linux_kernel_version("4.10")
+    if result is not True:
+        pytest.skip("Kernel requirements are not met")
+
+    # Build the topology
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    # For all registered routers, load the zebra and isis configuration files
+    for rname, router in tgen.routers().items():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        if os.path.exists("{}/isisd.conf".format(rname)):
+            router.load_config(
+                TopoRouter.RD_ISIS, os.path.join(CWD, "{}/isisd.conf".format(rname))
+            )
+        if os.path.exists("{}/bgpd.conf".format(rname)):
+            router.load_config(
+                TopoRouter.RD_BGP, os.path.join(CWD, "{}/bgpd.conf".format(rname))
+            )
+        if os.path.exists("{}/pathd.conf".format(rname)):
+            router.load_config(
+                TopoRouter.RD_PATH, os.path.join(CWD, "{}/pathd.conf".format(rname))
+            )
+        if os.path.exists("{}/staticd.conf".format(rname)):
+            router.load_config(
+                TopoRouter.RD_STATIC, os.path.join(CWD, "{}/staticd.conf".format(rname))
+            )
+
+    tgen.gears["rt1"].run("sysctl net.vrf.strict_mode=1")
+    tgen.gears["rt1"].run("ip link add vrf10 type vrf table 10")
+    tgen.gears["rt1"].run("ip link set vrf10 up")
+    tgen.gears["rt1"].run("ip link set eth-src master vrf10")
+
+    tgen.gears["rt6"].run("sysctl net.vrf.strict_mode=1")
+    tgen.gears["rt6"].run("ip link add vrf10 type vrf table 10")
+    tgen.gears["rt6"].run("ip link set vrf10 up")
+    tgen.gears["rt6"].run("sysctl -w net.ipv6.conf.all.seg6_enabled=1")
+    tgen.gears["rt6"].run("sysctl -w net.ipv6.conf.default.seg6_enabled=1")
+    tgen.gears["rt6"].run("sysctl -w net.ipv6.conf.eth-rt4.seg6_enabled=1")
+    tgen.gears["rt6"].run("sysctl -w net.ipv6.conf.eth-rt5.seg6_enabled=1")
+
+    # Start routers
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    "Teardown the pytest environment"
+
+    # Teardown the topology
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def router_compare_json_output(rname, command, reference):
+    "Compare router JSON output"
+
+    logger.info('Comparing router "%s" "%s" output', rname, command)
+
+    tgen = get_topogen()
+    filename = "{}/{}/{}".format(CWD, rname, reference)
+    expected = json.loads(open(filename).read())
+
+    # Run test function until we get an result. Wait at most 60 seconds.
+    test_func = functools.partial(
+        topotest.router_json_cmp, tgen.gears[rname], command, expected
+    )
+    _, diff = topotest.run_and_expect(test_func, None, count=120, wait=0.5)
+    assertmsg = '"{}" JSON output mismatches the expected result'.format(rname)
+    assert diff is None, assertmsg
+
+
+#
+# Step 1
+#
+# Test initial network convergence
+#
+def test_isis_adjacencies_step1():
+    logger.info("Test (step 1): check IS-IS adjacencies")
+    tgen = get_topogen()
+
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for rname in ["rt1"]:
+        router_compare_json_output(
+            rname,
+            "show yang operational-data /frr-interface:lib isisd",
+            "step1/show_yang_interface_isis_adjacencies.ref",
+        )
+
+
+def test_configure_srv6_locators():
+    tgen = get_topogen()
+    tgen.gears["rt1"].vtysh_cmd(
+        "configure \n \
+         segment-routing \n \
+         traffic-eng \n \
+         segment-list srv6-header \n \
+         index 1 ipv6-address fc00:0:3:: \n \
+         index 2 ipv6-address fc00:0:5:: \n \
+         index 3 ipv6-address fc00:0:6:: \n \
+         exit \n \
+         exit \n \
+         srv6 \n \
+         locators \n \
+         locator loc1 \n \
+         prefix fc00:0:1::/48 block-len 32 node-len 16 func-bits 16 \n \
+         exit \n \
+         locator loc2 \n \
+         prefix fc00:0:1b::/48 block-len 32 node-len 16 func-bits 16 \n \
+         exit \n \
+         exit \n \
+         exit \n \
+         exit"
+    )
+
+
+def test_rib_ipv6_step1():
+    logger.info("Test (step 1): verify IPv6 RIB")
+    tgen = get_topogen()
+
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for rname in ["rt1"]:
+        router_compare_json_output(
+            rname, "show ipv6 route isis json", "step1/show_ipv6_route.ref"
+        )
+
+
+def test_srv6_locator_step1():
+    logger.info("Test (step 1): verify SRv6 Locator")
+    tgen = get_topogen()
+
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for rname in ["rt1"]:
+        router_compare_json_output(
+            rname,
+            "show segment-routing srv6 locator json",
+            "step1/show_srv6_locator_table.ref",
+        )
+
+
+#
+# Step 2
+#
+# Test SRv6 TE Policy activted
+#
+
+
+def test_srv6_te_policy_activated():
+    logger.info("Test (step 2): verify SRv6 TE policy activated")
+    tgen = get_topogen()
+
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    tgen.gears["rt1"].vtysh_cmd(
+        "configure \n \
+        ipv6 route 2001:db8:10::/64 fc00:0:6:: color 1 \n \
+        segment-routing \n \
+        traffic-eng \n \
+        policy color 1 endpoint fc00:0:6:: \n \
+        candidate-path preference 1 name srv6 explicit segment-list srv6-header \n \
+        exit \
+        exit \
+        exit \
+        !"
+    )
+
+    for rname in ["rt1"]:
+        router_compare_json_output(
+            rname,
+            "show ipv6 route static json",
+            "step2/show_srv6_route.ref",
+        )
+
+
+#
+# Step 3
+#
+# Test SRv6 additional srv6 route.
+#
+
+
+def test_srv6_te_policy_additional_route():
+    logger.info("Test (step 3): verify SRv6 TE additional route")
+    tgen = get_topogen()
+
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    tgen.gears["rt1"].vtysh_cmd(
+        "configure \n \
+        no ipv6 route 2001:db8:10::/64 fc00:0:6:: color 1 \n \
+        ipv6 route fc00:0:6b::/48 fc00:0:6:: color 1 \n \
+        exit \
+        !"
+    )
+
+    # Add this to use 'eth-dst' if for BGP tests.
+    tgen.gears["rt6"].run("ip link set eth-dst master vrf10")
+
+    for rname in ["rt1"]:
+        router_compare_json_output(
+            rname,
+            "show ipv6 route static json",
+            "step3/show_srv6_additional_route.ref",
+        )
+
+
+#
+# Step 4
+#
+# Test SRv6 TE Policy removed
+#
+
+
+def test_srv6_te_policy_removed():
+    logger.info("Test (step 3): verify SRv6 TE policy removed")
+    tgen = get_topogen()
+
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    tgen.gears["rt1"].vtysh_cmd(
+        "configure \n \
+        segment-routing \n \
+        traffic-eng \n \
+        no policy color 1 endpoint fc00:0:6:: \n \
+        exit \
+        exit \
+        exit \
+        !"
+    )
+
+    for rname in ["rt1"]:
+        router_compare_json_output(
+            rname,
+            "show ipv6 route static json",
+            "step4/show_ipv6_route.ref",
+        )
+
+
+# Memory leak test template
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-pathd.yang
+++ b/yang/frr-pathd.yang
@@ -90,6 +90,13 @@ module frr-pathd {
           type rt-types:mpls-label;
           description "MPLS label value";
         }
+        leaf srv6-sid-value {
+          type inet:ipv6-address;
+          description "SRv6 SID value";
+        }
+        must "not(../segment/sid-value) or not(../segment/srv6-sid-value)" {
+          error-message "Only MPLS label or SRv6 SID value can be configured in the same moment.";
+        }
         container nai {
           presence "The segment has a Node or Adjacency Identifier";
           description

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -490,7 +490,7 @@ static int parse_encap_seg6(struct rtattr *tb, struct in6_addr *segs)
 			RTA_DATA(tb_encap[SEG6_IPTUNNEL_SRH]);
 
 		for (i = ipt->srh[0].first_segment; i >= 0; i--)
-			memcpy(&segs[i], &ipt->srh[0].segments[i],
+			memcpy(&segs[ipt->srh[0].first_segment - i], &ipt->srh[0].segments[i],
 			       sizeof(struct in6_addr));
 
 		return ipt->srh[0].first_segment + 1;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2665,12 +2665,12 @@ static void zread_sr_policy_set(ZAPI_HANDLER_ARGS)
 				   __func__);
 		return;
 	}
+
 	zt = &zp.segment_list;
-	if (zt->label_num < 1) {
+	if (!(zt->label_num > 0 || zt->srv6_segs.num_segs > 0)) {
 		if (IS_ZEBRA_DEBUG_RECV)
-			zlog_debug(
-				"%s: SR-TE tunnel must contain at least one label",
-				__func__);
+			zlog_debug("%s: SR-TE tunnel must contain at least one label or SRv6 SID",
+				   __func__);
 		return;
 	}
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2674,7 +2674,7 @@ static void zread_sr_policy_set(ZAPI_HANDLER_ARGS)
 		return;
 	}
 
-	if (!mpls_enabled)
+	if (!mpls_enabled && zt->type != ZEBRA_SR_SRV6_SRTE)
 		return;
 
 	policy = zebra_sr_policy_find(zp.color, &zp.endpoint);

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2348,6 +2348,7 @@ static int nexthop_active(struct nexthop *nexthop, struct nhg_hash_entry *nhe,
 	if (nexthop->srte_color) {
 		struct ipaddr endpoint = {0};
 		struct zebra_sr_policy *policy;
+		struct nexthop *nexthop_resolved;
 
 		switch (afi) {
 		case AFI_IP:
@@ -2370,19 +2371,25 @@ static int nexthop_active(struct nexthop *nexthop, struct nhg_hash_entry *nhe,
 		policy = zebra_sr_policy_find(nexthop->srte_color, &endpoint);
 		if (policy && policy->status == ZEBRA_SR_POLICY_UP) {
 			resolved = 0;
-			frr_each_safe (nhlfe_list, &policy->lsp->nhlfe_list,
-				       nhlfe) {
-				if (!CHECK_FLAG(nhlfe->flags,
-						NHLFE_FLAG_SELECTED)
-				    || CHECK_FLAG(nhlfe->flags,
-						  NHLFE_FLAG_DELETED))
-					continue;
-				SET_FLAG(nexthop->flags,
-					 NEXTHOP_FLAG_RECURSIVE);
-				nexthop_set_resolved(afi, nhlfe->nexthop,
-						     nexthop, policy);
+			if (policy->segment_list.label_num > 0) {
+				frr_each_safe (nhlfe_list, &policy->lsp->nhlfe_list, nhlfe) {
+					if (!CHECK_FLAG(nhlfe->flags, NHLFE_FLAG_SELECTED) ||
+					    CHECK_FLAG(nhlfe->flags, NHLFE_FLAG_DELETED))
+						continue;
+					SET_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE);
+					nexthop_set_resolved(afi, nhlfe->nexthop, nexthop, policy);
+					resolved = 1;
+				}
+			} else if (policy->segment_list.nexthop_resolved_num) {
+				nexthop_resolved = nexthop_from_zapi_nexthop(
+					&policy->segment_list.nexthop_resolved[0]);
+
+				SET_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE);
+				nexthop_set_resolved(afi, nexthop_resolved, nexthop, policy);
 				resolved = 1;
+				nexthop_free(nexthop_resolved);
 			}
+
 			if (resolved)
 				return 1;
 		}

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1909,7 +1909,7 @@ static struct nexthop *nexthop_set_resolved(afi_t afi,
 		for (; label_num < policy->segment_list.label_num; label_num++)
 			labels[num_labels++] =
 				policy->segment_list.labels[label_num];
-		label_type = policy->segment_list.type;
+		label_type = lsp_type_from_sr_type(policy->segment_list.type);
 	} else if (newhop->nh_label) {
 		for (i = 0; i < newhop->nh_label->num_labels; i++) {
 			/* Be a bit picky about overrunning the local array */

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1947,8 +1947,12 @@ static struct nexthop *nexthop_set_resolved(afi_t afi,
 	if (num_labels)
 		nexthop_add_labels(resolved_hop, label_type, num_labels,
 				   labels);
-
-	if (nexthop->nh_srv6) {
+	if (policy) {
+		if (!sid_zero_ipv6(&policy->segment_list.srv6_segs.segs[0])) {
+			nexthop_add_srv6_seg6(resolved_hop, &policy->segment_list.srv6_segs.segs[0],
+					      policy->segment_list.srv6_segs.num_segs);
+		}
+	} else if (nexthop->nh_srv6) {
 		if (nexthop->nh_srv6->seg6local_action !=
 		    ZEBRA_SEG6_LOCAL_ACTION_UNSPEC)
 			nexthop_add_srv6_seg6local(resolved_hop,

--- a/zebra/zebra_srte.c
+++ b/zebra/zebra_srte.c
@@ -319,15 +319,21 @@ int zebra_sr_policy_validate(struct zebra_sr_policy *policy,
 			     struct zapi_srte_tunnel *new_tunnel)
 {
 	struct zapi_srte_tunnel old_tunnel = policy->segment_list;
-	struct zebra_lsp *lsp;
+	struct zebra_lsp *lsp = NULL;
+	bool srv6_sid_resolved = false;
 
 	if (new_tunnel)
 		policy->segment_list = *new_tunnel;
 
 	/* Try to resolve the Binding-SID nexthops. */
-	lsp = mpls_lsp_find(policy->zvrf, policy->segment_list.labels[0]);
-	if (!lsp || !lsp->best_nhlfe
-	    || lsp->addr_family != ipaddr_family(&policy->endpoint)) {
+	if (policy->segment_list.type == ZEBRA_SR_LSP_SRTE)
+		lsp = mpls_lsp_find(policy->zvrf, policy->segment_list.labels[0]);
+
+	/* Check if there are resolved nexthops in the segment list. */
+	srv6_sid_resolved = policy->segment_list.nexthop_resolved_num ? true : false;
+
+	if ((!lsp || !lsp->best_nhlfe || lsp->addr_family != ipaddr_family(&policy->endpoint)) &&
+	    !srv6_sid_resolved) {
 		if (policy->status == ZEBRA_SR_POLICY_UP)
 			zebra_sr_policy_deactivate(policy);
 		return -1;

--- a/zebra/zebra_srte.c
+++ b/zebra/zebra_srte.c
@@ -325,11 +325,9 @@ int zebra_sr_policy_bsid_install(struct zebra_sr_policy *policy)
 			out_labels = zt->labels;
 		}
 
-		if (mpls_lsp_install(
-			    policy->zvrf, zt->type, zt->local_label,
-			    num_out_labels, out_labels, nhlfe->nexthop->type,
-			    &nhlfe->nexthop->gate, nhlfe->nexthop->ifindex)
-		    < 0)
+		if (mpls_lsp_install(policy->zvrf, lsp_type_from_sr_type(zt->type), zt->local_label,
+				     num_out_labels, out_labels, nhlfe->nexthop->type,
+				     &nhlfe->nexthop->gate, nhlfe->nexthop->ifindex) < 0)
 			return -1;
 	}
 
@@ -341,7 +339,7 @@ void zebra_sr_policy_bsid_uninstall(struct zebra_sr_policy *policy,
 {
 	struct zapi_srte_tunnel *zt = &policy->segment_list;
 
-	mpls_lsp_uninstall_all_vrf(policy->zvrf, zt->type, old_bsid);
+	mpls_lsp_uninstall_all_vrf(policy->zvrf, lsp_type_from_sr_type(zt->type), old_bsid);
 }
 
 int zebra_sr_policy_label_update(mpls_label_t label,

--- a/zebra/zebra_srte.c
+++ b/zebra/zebra_srte.c
@@ -208,6 +208,14 @@ static void zebra_sr_policy_notify_update(struct zebra_sr_policy *policy)
 	}
 }
 
+static void zebra_sr_policy_srv6_activate(struct zebra_sr_policy *policy)
+{
+	policy->status = ZEBRA_SR_POLICY_UP;
+	zsend_sr_policy_notify_status(policy->color, &policy->endpoint, policy->name,
+				      ZEBRA_SR_POLICY_UP);
+	zebra_sr_policy_notify_update(policy);
+}
+
 static void zebra_sr_policy_activate(struct zebra_sr_policy *policy,
 				     struct zebra_lsp *lsp)
 {
@@ -223,21 +231,24 @@ static void zebra_sr_policy_update(struct zebra_sr_policy *policy,
 				   struct zebra_lsp *lsp,
 				   struct zapi_srte_tunnel *old_tunnel)
 {
-	bool bsid_changed;
-	bool segment_list_changed;
+	bool bsid_mpls_changed;
+	bool segment_list_mpls_changed, segment_list_srv6_changed;
 
 	policy->lsp = lsp;
 
-	bsid_changed =
-		policy->segment_list.local_label != old_tunnel->local_label;
-	segment_list_changed =
-		policy->segment_list.label_num != old_tunnel->label_num
-		|| memcmp(policy->segment_list.labels, old_tunnel->labels,
-			  sizeof(mpls_label_t)
-				  * policy->segment_list.label_num);
+	bsid_mpls_changed = policy->segment_list.local_label != old_tunnel->local_label;
+
+	segment_list_mpls_changed = policy->segment_list.label_num != old_tunnel->label_num ||
+				    memcmp(policy->segment_list.labels, old_tunnel->labels,
+					   sizeof(mpls_label_t) * policy->segment_list.label_num);
+
+	segment_list_srv6_changed =
+		policy->segment_list.srv6_segs.num_segs != old_tunnel->srv6_segs.num_segs ||
+		memcmp(policy->segment_list.srv6_segs.segs, old_tunnel->srv6_segs.segs,
+		       sizeof(struct in6_addr) * policy->segment_list.srv6_segs.num_segs);
 
 	/* Re-install label stack if necessary. */
-	if (bsid_changed || segment_list_changed) {
+	if (policy->lsp && (bsid_mpls_changed || segment_list_mpls_changed)) {
 		zebra_sr_policy_bsid_uninstall(policy, old_tunnel->local_label);
 		(void)zebra_sr_policy_bsid_install(policy);
 	}
@@ -246,7 +257,7 @@ static void zebra_sr_policy_update(struct zebra_sr_policy *policy,
 				      policy->name, ZEBRA_SR_POLICY_UP);
 
 	/* Handle segment-list update. */
-	if (segment_list_changed)
+	if (segment_list_mpls_changed || segment_list_srv6_changed)
 		zebra_sr_policy_notify_update(policy);
 }
 
@@ -254,8 +265,10 @@ static void zebra_sr_policy_deactivate(struct zebra_sr_policy *policy)
 {
 	policy->status = ZEBRA_SR_POLICY_DOWN;
 	policy->lsp = NULL;
-	zebra_sr_policy_bsid_uninstall(policy,
-				       policy->segment_list.local_label);
+
+	if (policy->segment_list.local_label)
+		zebra_sr_policy_bsid_uninstall(policy, policy->segment_list.local_label);
+
 	zsend_sr_policy_notify_status(policy->color, &policy->endpoint,
 				      policy->name, ZEBRA_SR_POLICY_DOWN);
 	zebra_sr_policy_notify_update(policy);
@@ -280,10 +293,13 @@ int zebra_sr_policy_validate(struct zebra_sr_policy *policy,
 	}
 
 	/* First label was resolved successfully. */
-	if (policy->status == ZEBRA_SR_POLICY_DOWN)
-		zebra_sr_policy_activate(policy, lsp);
-	else
+	if (policy->status == ZEBRA_SR_POLICY_DOWN) {
+		if (lsp)
+			zebra_sr_policy_activate(policy, lsp);
+		zebra_sr_policy_srv6_activate(policy);
+	} else {
 		zebra_sr_policy_update(policy, lsp, &old_tunnel);
+	}
 
 	return 0;
 }

--- a/zebra/zebra_srte.c
+++ b/zebra/zebra_srte.c
@@ -7,6 +7,7 @@
 
 #include "lib/zclient.h"
 #include "lib/lib_errors.h"
+#include "frrdistance.h"
 
 #include "zebra/zebra_srte.h"
 #include "zebra/zebra_mpls.h"
@@ -81,6 +82,40 @@ struct zebra_sr_policy *zebra_sr_policy_find_by_name(char *name)
 	return NULL;
 }
 
+static int process_routes_for_policy(struct zebra_sr_policy *policy, struct zserv *client,
+				     uint32_t message, struct stream *s, struct zapi_nexthop *znh)
+{
+	int ret, i;
+	struct prefix p = {};
+
+	assert(policy->status == ZEBRA_SR_POLICY_UP);
+	p.family = AF_INET6;
+	p.prefixlen = IPV6_MAX_BITLEN;
+	memcpy(&p.u.prefix6, &policy->endpoint.ipaddr_v6, sizeof(p.u.prefix6));
+
+	stream_putc(s, ZEBRA_ROUTE_SRTE);
+	stream_putw(s, 0); /* instance - not available */
+	stream_putc(s, policy->segment_list.distance);
+	stream_putl(s, policy->segment_list.metric);
+	stream_putw(s, policy->segment_list.nexthop_resolved_num);
+
+	for (i = 0; i < policy->segment_list.nexthop_resolved_num; i++) {
+		znh = &policy->segment_list.nexthop_resolved[i];
+		ret = zapi_nexthop_encode(s, znh, 0, 0);
+		if (ret < 0)
+			goto failure;
+	}
+	stream_putw_at(s, 0, stream_get_endp(s));
+
+	client->nh_last_upd_time = monotime(NULL);
+	return zserv_send_message(client, s);
+
+failure:
+	stream_free(s);
+	/* Handle failure as needed */
+	return ret;
+}
+
 static int zebra_sr_policy_notify_update_client(struct zebra_sr_policy *policy,
 						struct zserv *client)
 {
@@ -132,6 +167,12 @@ static int zebra_sr_policy_notify_update_client(struct zebra_sr_policy *policy,
 		exit(1);
 	}
 	stream_putl(s, policy->color);
+
+	if (policy->segment_list.srv6_segs.num_segs > SRV6_MAX_SIDS)
+		policy->segment_list.srv6_segs.num_segs = SRV6_MAX_SIDS;
+
+	if (policy->segment_list.srv6_segs.num_segs > 0)
+		return process_routes_for_policy(policy, client, message, s, &znh);
 
 	num = 0;
 	frr_each (nhlfe_list_const, &policy->lsp->nhlfe_list, nhlfe) {

--- a/zebra/zebra_srv6.h
+++ b/zebra/zebra_srv6.h
@@ -10,6 +10,7 @@
 #include <zebra.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include "zebra_srte.h"
 
 #include "qobj.h"
 #include "prefix.h"


### PR DESCRIPTION
These series of patches introduce new feature: user may configure ipv6-address in segment list.

Format:
```
index INDEX ipv6-address X:X::X:X
```

Example:
```
segment-routing
 traffic-eng
  segment-list SL1
   index 0 ipv6-address 2001:db8::1
```

Signed-off-by: Dmytro Shytyi <dmytro.shytyi@6wind.com>