### PR TITLE
Generate support bundle on test failure

### DIFF
--- a/tests/topotests/bgp_evpn_overlay_index_gateway/test_bgp_evpn_overlay_index_gateway.py
+++ b/tests/topotests/bgp_evpn_overlay_index_gateway/test_bgp_evpn_overlay_index_gateway.py
@@ -58,7 +58,6 @@ from lib.common_config import (
     step,
     write_test_header,
     write_test_footer,
-    generate_support_bundle,
 )
 
 # Required to instantiate the topology builder class.
@@ -277,8 +276,6 @@ def test_evpn_gateway_ip_basic_topo(request):
 
     result, assertmsg = evpn_gateway_ip_show_op_check("base")
 
-    if result is not None:
-        generate_support_bundle()
     assert result is None, assertmsg
 
     write_test_footer(tc_name)
@@ -319,8 +316,6 @@ def test_evpn_gateway_ip_flap_rt5(request):
     )
 
     result, assertmsg = evpn_gateway_ip_show_op_check("no_rt5")
-    if result is not None:
-        generate_support_bundle()
     assert result is None, assertmsg
 
     step("Advertise type-5 routes again")
@@ -339,8 +334,6 @@ def test_evpn_gateway_ip_flap_rt5(request):
     )
 
     result, assertmsg = evpn_gateway_ip_show_op_check("base")
-    if result is not None:
-        generate_support_bundle()
 
     assert result is None, assertmsg
 
@@ -371,8 +364,6 @@ def test_evpn_gateway_ip_flap_rt2(request):
     pe1.cmd_raises("ip link set dev vxlan100 down")
 
     result, assertmsg = evpn_gateway_ip_show_op_check("no_rt2")
-    if result is not None:
-        generate_support_bundle()
     assert result is None, assertmsg
 
     step("Bring up VxLAN interface at PE1 and advertise type-2 routes again")
@@ -380,8 +371,6 @@ def test_evpn_gateway_ip_flap_rt2(request):
     pe1.cmd_raises("ip link set dev vxlan100 up")
 
     result, assertmsg = evpn_gateway_ip_show_op_check("base")
-    if result is not None:
-        generate_support_bundle()
     assert result is None, assertmsg
 
     write_test_footer(tc_name)

--- a/tests/topotests/bgp_flowspec/test_bgp_flowspec_topo.py
+++ b/tests/topotests/bgp_flowspec/test_bgp_flowspec_topo.py
@@ -51,7 +51,6 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
-from lib.common_config import generate_support_bundle
 
 # Required to instantiate the topology builder class.
 
@@ -140,10 +139,7 @@ def test_bgp_convergence():
     )
     _, res = topotest.run_and_expect(test_func, None, count=210, wait=1)
     assertmsg = "BGP router network did not converge"
-    if res is not None:
-        generate_support_bundle()
-        assert res is None, assertmsg
-    generate_support_bundle()
+    assert res is None, assertmsg
 
 
 def test_bgp_flowspec():

--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -26,7 +26,7 @@ from munet.base import Commander, proc_error
 from munet.cleanup import cleanup_current, cleanup_previous
 from munet.config import ConfigOptionsProxy
 from munet.testing.util import pause_test
-
+from lib.common_config import generate_support_bundle
 from lib import topolog, topotest
 
 try:
@@ -598,6 +598,10 @@ def pytest_runtest_setup(item):
     module = item.parent.module
     script_dir = os.path.abspath(os.path.dirname(module.__file__))
     os.environ["PYTEST_TOPOTEST_SCRIPTDIR"] = script_dir
+
+
+def pytest_exception_interact(node, call, report):
+    generate_support_bundle()
 
 
 def pytest_runtest_makereport(item, call):

--- a/tests/topotests/lib/snmptest.py
+++ b/tests/topotests/lib/snmptest.py
@@ -112,7 +112,7 @@ class SnmpTester(object):
         notif = re.sub(":", "", notif)
         notif = re.sub('"([0-9]{2}) ([0-9]{2}) "', r"\1\2", notif)
         notif = re.sub('"([0-9]{2}) "', r"\1", notif)
-        elems = re.findall("([0-9,\.]+) = ([0-9,\.]+)", notif)
+        elems = re.findall(r"([0-9,\.]+) = ([0-9,\.]+)", notif)
 
         # remove common part
         elems = elems[1:]
@@ -222,7 +222,7 @@ class SnmpTester(object):
         # don't consider additional application messages
         notifs = [elem for index, elem in enumerate(notifs_first) if index % 2 != 0]
 
-        oid_v4 = "1\.3\.6\.1\.2\.1\.15"
+        oid_v4 = r"1\.3\.6\.1\.2\.1\.15"
         for one_notif in notifs:
             is_ipv4_notif = re.search(oid_v4, one_notif)
             if is_ipv4_notif != None:
@@ -241,7 +241,7 @@ class SnmpTester(object):
         # don't consider additional application messages
         notifs = [elem for index, elem in enumerate(results) if index % 2 != 0]
 
-        oid_v6 = "1\.3\.6\.1\.3\.5\.1"
+        oid_v6 = r"1\.3\.6\.1\.3\.5\.1"
         for one_notif in notifs:
             is_ipv6_notif = re.search(oid_v6, one_notif)
             if is_ipv6_notif != None:

--- a/tools/etc/frr/support_bundle_commands.conf
+++ b/tools/etc/frr/support_bundle_commands.conf
@@ -34,6 +34,8 @@ show bgp nexthop
 show bgp vrf all summary
 show bgp vrf all ipv4
 show bgp vrf all ipv6
+show bgp vrf all ipv4 vpn
+show bgp vrf all ipv6 vpn
 show bgp vrf all neighbors
 
 show bgp evpn route


### PR DESCRIPTION
1) Auto generate a support bundle on test failure
2) snmp tests were generating python warnings
3) support bundles were missing some bgp vpnv4 data, add it in
