### PR TITLE
lib: Keychain.c was using free

### DIFF
--- a/lib/keychain.c
+++ b/lib/keychain.c
@@ -37,6 +37,7 @@ static void keychain_free(struct keychain *keychain)
 static struct key *key_new(void)
 {
 	struct key *key = XCALLOC(MTYPE_KEY, sizeof(struct key));
+
 	QOBJ_REG(key, key);
 	return key;
 }
@@ -77,7 +78,7 @@ static int key_cmp_func(void *arg1, void *arg2)
 static void key_delete_func(struct key *key)
 {
 	if (key->string)
-		free(key->string);
+		XFREE(MTYPE_KEY, key->string);
 	key_free(key);
 }
 


### PR DESCRIPTION
This is a bit of a bummer that this slipped through for so long.