### PR TITLE
doc: add graphiz dependency for dev docs

### DIFF
--- a/doc/developer/.readthedocs.yaml
+++ b/doc/developer/.readthedocs.yaml
@@ -6,6 +6,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - graphviz
 
 python:
   install:


### PR DESCRIPTION
There's a graph in cli.rst that needs graphviz to be built.