### PR TITLE
bgpd: revamp evpn debugs nexthop and l3vni

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3067,11 +3067,22 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 	/* Process for route leaking. */
 	vpn_leak_from_vrf_update(bgp_get_default(), bgp_vrf, pi);
 
-	if (bgp_debug_zebra(NULL))
-		zlog_debug("... %s pi dest %p (l %d) pi %p (l %d, f 0x%x)",
-			   new_pi ? "new" : "update", dest,
+	if (bgp_debug_zebra(NULL)) {
+		struct ipaddr nhip = {};
+
+		if (pi->net->rn->p.family == AF_INET6) {
+			SET_IPADDR_V6(&nhip);
+			IPV6_ADDR_COPY(&nhip.ipaddr_v6, &pi->attr->mp_nexthop_global);
+		} else {
+			SET_IPADDR_V4(&nhip);
+			IPV4_ADDR_COPY(&nhip.ipaddr_v4, &pi->attr->nexthop);
+		}
+		zlog_debug("... %s pi %s dest %p (l %d) pi %p (l %d, f 0x%x) nh %pIA",
+			   new_pi ? "new" : "update",
+			   bgp_vrf->name_pretty, dest,
 			   bgp_dest_get_lock_count(dest), pi, pi->lock,
-			   pi->flags);
+			   pi->flags, &nhip);
+	}
 
 	bgp_dest_unlock_node(dest);
 
@@ -3380,10 +3391,22 @@ static int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 		return 0;
 	}
 
-	if (bgp_debug_zebra(NULL))
-		zlog_debug("... delete dest %p (l %d) pi %p (l %d, f 0x%x)",
-			   dest, bgp_dest_get_lock_count(dest), pi, pi->lock,
-			   pi->flags);
+	if (bgp_debug_zebra(NULL)) {
+		struct ipaddr nhip = {};
+
+		if (pi->net->rn->p.family == AF_INET6) {
+			SET_IPADDR_V6(&nhip);
+			IPV6_ADDR_COPY(&nhip.ipaddr_v6, &pi->attr->mp_nexthop_global);
+		} else {
+			SET_IPADDR_V4(&nhip);
+			IPV4_ADDR_COPY(&nhip.ipaddr_v4, &pi->attr->nexthop);
+		}
+
+		zlog_debug("... delete pi %s dest %p (l %d) pi %p (l %d, f 0x%x) nh %pIA",
+			   bgp_vrf->name_pretty, dest,
+			   bgp_dest_get_lock_count(dest), pi, pi->lock,
+			   pi->flags, &nhip);
+	}
 
 	/* Process for route leaking. */
 	vpn_leak_from_vrf_withdraw(bgp_get_default(), bgp_vrf, pi);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2936,12 +2936,11 @@ static int bgp_zebra_process_local_l3vni(ZAPI_CALLBACK_ARGS)
 		is_anycast_mac = stream_getl(s);
 
 		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_debug(
-				"Rx L3-VNI ADD VRF %s VNI %u Originator-IP %pI4 RMAC svi-mac %pEA vrr-mac %pEA filter %s svi-if %u",
-				vrf_id_to_name(vrf_id), l3vni, &originator_ip,
-				&svi_rmac, &vrr_rmac,
-				filter ? "prefix-routes-only" : "none",
-				svi_ifindex);
+			zlog_debug("Rx L3VNI ADD VRF %s VNI %u Originator-IP %pI4 RMAC svi-mac %pEA vrr-mac %pEA filter %s svi-if %u",
+				   vrf_id_to_name(vrf_id), l3vni,
+				   &originator_ip, &svi_rmac, &vrr_rmac,
+				   filter ? "prefix-routes-only" : "none",
+				   svi_ifindex);
 
 		frrtrace(8, frr_bgp, evpn_local_l3vni_add_zrecv, l3vni, vrf_id,
 			 &svi_rmac, &vrr_rmac, filter, originator_ip,
@@ -2952,7 +2951,7 @@ static int bgp_zebra_process_local_l3vni(ZAPI_CALLBACK_ARGS)
 					 is_anycast_mac);
 	} else {
 		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_debug("Rx L3-VNI DEL VRF %s VNI %u",
+			zlog_debug("Rx L3VNI DEL VRF %s VNI %u",
 				   vrf_id_to_name(vrf_id), l3vni);
 
 		frrtrace(2, frr_bgp, evpn_local_l3vni_del_zrecv, l3vni, vrf_id);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -2265,14 +2265,13 @@ static int zl3vni_send_add_to_client(struct zebra_l3vni *zl3vni)
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug(
-			"Send L3_VNI_ADD %u VRF %s RMAC %pEA VRR %pEA local-ip %pI4 filter %s to %s",
-			zl3vni->vni, vrf_id_to_name(zl3vni_vrf_id(zl3vni)),
-			&svi_rmac, &vrr_rmac, &zl3vni->local_vtep_ip,
-			CHECK_FLAG(zl3vni->filter, PREFIX_ROUTES_ONLY)
-				? "prefix-routes-only"
-				: "none",
-			zebra_route_string(client->proto));
+		zlog_debug("Send L3VNI ADD %u VRF %s RMAC %pEA VRR %pEA local-ip %pI4 filter %s to %s",
+			   zl3vni->vni, vrf_id_to_name(zl3vni_vrf_id(zl3vni)),
+			   &svi_rmac, &vrr_rmac, &zl3vni->local_vtep_ip,
+			   CHECK_FLAG(zl3vni->filter, PREFIX_ROUTES_ONLY)
+				   ? "prefix-routes-only"
+				   : "none",
+			   zebra_route_string(client->proto));
 
 	client->l3vniadd_cnt++;
 	return zserv_send_message(client, s);
@@ -2300,7 +2299,7 @@ static int zl3vni_send_del_to_client(struct zebra_l3vni *zl3vni)
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
-		zlog_debug("Send L3_VNI_DEL %u VRF %s to %s", zl3vni->vni,
+		zlog_debug("Send L3VNI DEL %u VRF %s to %s", zl3vni->vni,
 			   vrf_id_to_name(zl3vni_vrf_id(zl3vni)),
 			   zebra_route_string(client->proto));
 


### PR DESCRIPTION
Add nexthop fied when import/unimport evpn route in vrf, print bgp vrf instance name which contains "VRF" keyword.

Include pathcount which is list of paths linked to nexthop.

add and delete l3vni to keep symmetric "L3VNI" keyword as used in other debug statements.


Testing Done:
```
2023/12/27 05:10:03.339616 BGP: [HPE1G-3H7F2] ... new pi VRF vrf2 dest 0x55663e8372c0 (l 2) pi 0x55663e8374d0 (l 1, f 0x4010) nh 6.0.0.1

2023/12/27 05:58:56.650116 BGP: [MC0JJ-7ZYQB] ... delete pi VRF vrf2 dest 0x55663e885110 (l 5) pi 0x55663e8851e0 (l 1, f 0x4098) nh 6.0.0.1

2023/12/27 05:10:03.339581 BGP: [P4TBX-3W31N] evpn VRF vrf2 nh 6.0.0.1 rmac 00:02:00:00:00:04 add to zebra

2023/12/27 06:13:12.685906 BGP: [SWSCZ-2Z6M4] evpn vrf VRF vrf1 nh 6.0.0.1 del to zebra

2023/12/27 05:10:03.339603 BGP: [Y2EAK-4N7FV] path 60.1.1.111/32 linked to VRF vrf2 nh 6.0.0.1 pathcount 0

2023/12/27 05:58:56.650125 BGP: [GVE17-CSNTB] path 81.1.1.0/24 unlinked from VRF vrf2 nh 6.0.0.1 pathcount 16

2023/12/27 05:08:10.108038 ZEBRA: [Q8ZEK-CT776] Send L3VNI ADD 104001 VRF vrf1 RMAC 00:04:ba:10:10:62 VRR 1c:34:da:19:59:62 local-ip 6.0.0.31 filter none to bgp

2023/12/27 05:08:26.043121 ZEBRA: [R43YF-2MKZ3] Send L3VNI DEL 104001 VRF vrf1 to bgp
```

Signed-off-by:Chirag Shah <chirag@nvidia.com>