### PR TITLE
bgpd: lttng tp add ethtag to macip zebra send

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -914,7 +914,7 @@ static int bgp_zebra_send_remote_macip(struct bgp *bgp, struct bgpevpn *vpn,
 	zclient_create_header(
 		s, add ? ZEBRA_REMOTE_MACIP_ADD : ZEBRA_REMOTE_MACIP_DEL,
 		bgp->vrf_id);
-	stream_putl(s, vpn->vni);
+	stream_putl(s, vpn ? vpn->vni : 0);
 
 	if (mac) /* Mac Addr */
 		stream_put(s, &mac->octet, ETH_ALEN);
@@ -960,7 +960,7 @@ static int bgp_zebra_send_remote_macip(struct bgp *bgp, struct bgpevpn *vpn,
 			snprintf(esi_buf, sizeof(esi_buf), "-");
 		zlog_debug(
 			"Tx %s MACIP, VNI %u MAC %pEA IP %pIA flags 0x%x seq %u remote VTEP %pI4 esi %s",
-			add ? "ADD" : "DEL", vpn->vni,
+			add ? "ADD" : "DEL", (vpn ? vpn->vni : 0),
 			(mac ? mac : &p->prefix.macip_addr.mac),
 			&p->prefix.macip_addr.ip, flags, seq, &remote_vtep_ip,
 			esi_buf);
@@ -1003,14 +1003,14 @@ static int bgp_zebra_send_remote_vtep(struct bgp *bgp, struct bgpevpn *vpn,
 	zclient_create_header(
 		s, add ? ZEBRA_REMOTE_VTEP_ADD : ZEBRA_REMOTE_VTEP_DEL,
 		bgp->vrf_id);
-	stream_putl(s, vpn->vni);
+	stream_putl(s, vpn ? vpn->vni : 0);
 	if (is_evpn_prefix_ipaddr_v4(p))
 		stream_put_in_addr(s, &p->prefix.imet_addr.ip.ipaddr_v4);
 	else if (is_evpn_prefix_ipaddr_v6(p)) {
 		flog_err(
 			EC_BGP_VTEP_INVALID,
 			"Bad remote IP when trying to %s remote VTEP for VNI %u",
-			add ? "ADD" : "DEL", vpn->vni);
+			add ? "ADD" : "DEL", (vpn ? vpn->vni : 0));
 		return -1;
 	}
 	stream_putl(s, flood_control);
@@ -1019,7 +1019,7 @@ static int bgp_zebra_send_remote_vtep(struct bgp *bgp, struct bgpevpn *vpn,
 
 	if (bgp_debug_zebra(NULL))
 		zlog_debug("Tx %s Remote VTEP, VNI %u remote VTEP %pI4",
-			   add ? "ADD" : "DEL", vpn->vni,
+			   add ? "ADD" : "DEL", (vpn ? vpn->vni : 0),
 			   &p->prefix.imet_addr.ip.ipaddr_v4);
 
 	frrtrace(3, frr_bgp, evpn_bum_vtep_zsend, add, vpn, p);

--- a/bgpd/bgp_trace.h
+++ b/bgpd/bgp_trace.h
@@ -309,6 +309,7 @@ TRACEPOINT_EVENT(
 	TP_FIELDS(
 		ctf_string(action, add ? "add" : "del")
 		ctf_integer(vni_t, vni, (vpn ? vpn->vni : 0))
+		ctf_integer(uint32_t, eth_tag, &pfx->prefix.macip_addr.eth_tag)
 		ctf_array(unsigned char, mac, &pfx->prefix.macip_addr.mac,
 			sizeof(struct ethaddr))
 		ctf_array(unsigned char, ip, &pfx->prefix.macip_addr.ip,

--- a/bgpd/bgp_trace.h
+++ b/bgpd/bgp_trace.h
@@ -308,7 +308,7 @@ TRACEPOINT_EVENT(
 		struct in_addr, vtep, esi_t *, esi),
 	TP_FIELDS(
 		ctf_string(action, add ? "add" : "del")
-		ctf_integer(vni_t, vni, vpn->vni)
+		ctf_integer(vni_t, vni, (vpn ? vpn->vni : 0))
 		ctf_array(unsigned char, mac, &pfx->prefix.macip_addr.mac,
 			sizeof(struct ethaddr))
 		ctf_array(unsigned char, ip, &pfx->prefix.macip_addr.ip,
@@ -326,7 +326,7 @@ TRACEPOINT_EVENT(
 		const struct prefix_evpn *, pfx),
 	TP_FIELDS(
 		ctf_string(action, add ? "add" : "del")
-		ctf_integer(vni_t, vni, vpn->vni)
+		ctf_integer(vni_t, vni, (vpn ? vpn->vni : 0))
 		ctf_integer_network_hex(unsigned int, vtep,
 			pfx->prefix.imet_addr.ip.ipaddr_v4.s_addr)
 	)


### PR DESCRIPTION
Two commits:

1) bgpd: lttng tp add ethtag to macip zebra send


    Testing Done:

    2023-09-08T17:33:03.731 frr_bgp:evpn_mac_ip_zsend {'action': 'add',
    'vni': 1003, 'eth_tag': 968006412, 'mac': '00:02:00:00:00:40', 'ip': '',
    'vtep': '27.0.0.16', 'esi': '00:00:00:00:00:00:00:00:00:00'}

Signed-off-by: Chirag Shah <chirag@nvidia.com>

2) bgpd: fix coverity warnings about evpn vpn variable

    A few paths could see a vpn variable with a NULL value;
    check and protect those paths.

Signed-off-by: Mark Stapp <mstapp@nvidia.com>
