### PR TITLE
build: protobuf is required so update building docs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1953,6 +1953,10 @@ AC_SUBST([SNMP_CFLAGS])
 dnl ---------------
 dnl libyang
 dnl ---------------
+PKG_CHECK_MODULES([LIBYANG], [libyang >= 2.1.128], , [
+  AC_MSG_WARN([Recommended libyang version is >= 2.1.128.])
+])
+
 PKG_CHECK_MODULES([LIBYANG], [libyang >= 2.0.0], , [
   AC_MSG_ERROR([libyang (>= 2.0.0) was not found on your system.])
 ])

--- a/doc/developer/building-frr-for-archlinux.rst
+++ b/doc/developer/building-frr-for-archlinux.rst
@@ -11,18 +11,12 @@ Installing Dependencies
       git autoconf automake libtool make cmake pcre readline texinfo \
       pkg-config pam json-c bison flex python-pytest \
       c-ares python python2-ipaddress python-sphinx \
-      net-snmp perl libcap libelf libunwind
+      net-snmp perl libcap libelf libunwind protobuf-c
 
 .. include:: building-libunwind-note.rst
 
 .. include:: building-libyang.rst
 
-Protobuf
-^^^^^^^^
-
-.. code-block:: console
-
-   sudo pacman -S protobuf-c
 
 ZeroMQ
 ^^^^^^

--- a/doc/developer/building-frr-for-ubuntu1404.rst
+++ b/doc/developer/building-frr-for-ubuntu1404.rst
@@ -14,16 +14,11 @@ Installing Dependencies
       git autoconf automake libtool make libreadline-dev texinfo \
       pkg-config libpam0g-dev libjson-c-dev bison flex python3-pytest \
       libc-ares-dev python3-dev python3-sphinx install-info build-essential \
+      protobuf-c-compiler libprotobuf-c-dev \
       libsnmp-dev perl libcap-dev libelf-dev
 
 .. include:: building-libyang.rst
 
-Protobuf
-^^^^^^^^
-
-.. code-block:: console
-
-   sudo apt-get install protobuf-c-compiler libprotobuf-c-dev
 
 Building & Installing FRR
 -------------------------

--- a/doc/developer/building-frr-for-ubuntu1604.rst
+++ b/doc/developer/building-frr-for-ubuntu1604.rst
@@ -19,12 +19,6 @@ Installing Dependencies
 
 .. include:: building-libyang.rst
 
-Protobuf
-^^^^^^^^
-
-.. code-block:: console
-
-   sudo apt-get install protobuf-c-compiler libprotobuf-c-dev
 
 Building & Installing FRR
 -------------------------

--- a/doc/developer/building-frr-for-ubuntu1804.rst
+++ b/doc/developer/building-frr-for-ubuntu1804.rst
@@ -15,18 +15,13 @@ Installing Dependencies
       pkg-config libpam0g-dev libjson-c-dev bison flex \
       libc-ares-dev python3-dev python3-sphinx \
       install-info build-essential libsnmp-dev perl libcap-dev \
+      protobuf-c-compiler libprotobuf-c-dev \
       libelf-dev libunwind-dev
 
 .. include:: building-libunwind-note.rst
 
 .. include:: building-libyang.rst
 
-Protobuf
-^^^^^^^^
-
-.. code-block:: console
-
-   sudo apt-get install protobuf-c-compiler libprotobuf-c-dev
 
 ZeroMQ
 ^^^^^^

--- a/doc/developer/building-frr-for-ubuntu2004.rst
+++ b/doc/developer/building-frr-for-ubuntu2004.rst
@@ -15,22 +15,33 @@ Installing Dependencies
       pkg-config libpam0g-dev libjson-c-dev bison flex \
       libc-ares-dev python3-dev python3-sphinx \
       install-info build-essential libsnmp-dev perl \
+      protobuf-c-compiler libprotobuf-c-dev \
       libcap-dev libelf-dev libunwind-dev
 
 .. include:: building-libunwind-note.rst
 
-Note that Ubuntu 20 no longer installs python 2.x, so it must be
-installed explicitly. Ensure that your system has a symlink named
-``/usr/bin/python`` pointing at ``/usr/bin/python3``.
-
 .. include:: building-libyang.rst
 
-Protobuf
-^^^^^^^^
+GRPC
+^^^^
+If GRPC is enabled using ``--enable-grpc`` the following packages should be
+installed.
 
 .. code-block:: console
 
-   sudo apt-get install protobuf-c-compiler libprotobuf-c-dev
+   sudo apt-get install libgrpc++-dev protobuf-compiler-grpc \
+
+
+Config Rollbacks
+^^^^^^^^^^^^^^^^
+
+If config rollbacks are enabled using ``--enable-config-rollbacks``
+the sqlite3 developer package also should be installed.
+
+.. code-block:: console
+
+   sudo apt install libsqlite3-dev
+
 
 ZeroMQ
 ^^^^^^

--- a/doc/developer/building-frr-for-ubuntu2204.rst
+++ b/doc/developer/building-frr-for-ubuntu2204.rst
@@ -16,27 +16,19 @@ Installing Dependencies
       libc-ares-dev python3-dev python3-sphinx \
       install-info build-essential libsnmp-dev perl \
       libcap-dev libelf-dev libunwind-dev \
+      protobuf-c-compiler libprotobuf-c-dev \
       libyang2 libyang2-dev
 
 .. include:: building-libunwind-note.rst
 
-Note that Ubuntu >= 20 no longer installs python 2.x, so it must be
-installed explicitly. Ensure that your system has a symlink named
-``/usr/bin/python`` pointing at ``/usr/bin/python3``.
-
-.. code-block:: shell
-
-   sudo ln -s /usr/bin/python3 /usr/bin/python
-   python --version
-
-
-Protobuf
-^^^^^^^^
-This is optional
+GRPC
+^^^^
+If GRPC is enabled using ``--enable-grpc`` the following packages should be
+installed.
 
 .. code-block:: console
 
-   sudo apt-get install protobuf-c-compiler libprotobuf-c-dev
+   sudo apt-get install libgrpc++-dev protobuf-compiler-grpc \
 
 
 Config Rollbacks

--- a/doc/developer/building-libyang.rst
+++ b/doc/developer/building-libyang.rst
@@ -14,7 +14,8 @@ DEB packages are available as CI artifacts `here
 
 .. warning::
 
-   ``libyang`` version 2.0.0 or newer is required to build FRR.
+   ``libyang`` version 2.0.0 or newer is required to build FRR, version 2.1.128
+   or newer is recommended.
 
 .. note::
 
@@ -39,7 +40,7 @@ DEB packages are available as CI artifacts `here
 
    git clone https://github.com/CESNET/libyang.git
    cd libyang
-   git checkout v2.0.0
+   git checkout v2.1.128
    mkdir build; cd build
    cmake -D CMAKE_INSTALL_PREFIX:PATH=/usr \
          -D CMAKE_BUILD_TYPE:String="Release" ..

--- a/docker/ubuntu-ci/Dockerfile
+++ b/docker/ubuntu-ci/Dockerfile
@@ -41,6 +41,12 @@ RUN apt update && apt upgrade -y && \
         cmake \
         libpcre2-dev \
     && \
+    # GRPC extra build requirements
+    apt-get install -y \
+        libgrpc-dev \
+        libgrpc++-dev \
+        protobuf-compiler-grpc \
+    && \
     # Runtime/triage/testing requirements
     apt-get install -y \
         curl \
@@ -91,7 +97,7 @@ USER frr:frr
 RUN cd && pwd && ls -al && \
     git clone https://github.com/CESNET/libyang.git && \
     cd libyang && \
-    git checkout v2.1.80 && \
+    git checkout v2.1.128 && \
     mkdir build; cd build && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr \
           -DCMAKE_BUILD_TYPE:String="Release" .. && \
@@ -112,6 +118,7 @@ RUN cd ~/frr && \
        --enable-user=frr \
        --enable-group=frr \
        --enable-config-rollbacks \
+       --enable-grpc \
        --enable-vty-group=frrvty \
        --enable-snmp=agentx \
        --enable-scripting \


### PR DESCRIPTION
- recommend using libyang 2.1.128 but accept 2.0.0 for now.
- update ubuntu building doc to add GRPC section
- update ubuntu reference docker builds to match grpc doc change