### PR TITLE
pathd: add dynamic candidate path metric [computed] keyword

### DIFF
--- a/doc/user/pathd.rst
+++ b/doc/user/pathd.rst
@@ -327,7 +327,7 @@ Configuration Commands
    Delete or specify a bandwidth constraint for a dynamic candidate path.
 
 
-.. clicmd:: metric [bound] METRIC VALUE [required]
+.. clicmd:: metric [bound] METRIC VALUE [required] [computed]
 
    Delete or specify a metric constraint for a dynamic candidate path.
 


### PR DESCRIPTION
Add the 'computed' keyword for a given metric.

> [..]
> metric te computed

When set by the PCC, the PCE must send back a computed metric value in the PCResponse value.