### PR TITLE
*: fix 'show nexthop-group rib' displays invalid VRF

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -2851,6 +2851,7 @@ static void bgp_evpn_l3nhg_zebra_add_v4_or_v6(struct bgp_evpn_es_vrf *es_vrf,
 	if (!api_nhg.nexthop_num)
 		return;
 
+	api_nhg.vrf_id = VRF_DEFAULT;
 	zclient_nhg_send(zclient, ZEBRA_NHG_ADD, &api_nhg);
 }
 
@@ -2895,6 +2896,7 @@ static void bgp_evpn_l3nhg_zebra_del_v4_or_v6(struct bgp_evpn_es_vrf *es_vrf,
 	frrtrace(4, frr_bgp, evpn_mh_nhg_zsend, false, v4_nhg, api_nhg.id,
 		 es_vrf);
 
+	api_nhg.vrf_id = VRF_DEFAULT;
 	zclient_nhg_send(zclient, ZEBRA_NHG_DEL, &api_nhg);
 }
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1164,7 +1164,7 @@ static int zapi_nhg_encode(struct stream *s, int cmd, struct zapi_nhg *api_nhg)
 	}
 
 	stream_reset(s);
-	zclient_create_header(s, cmd, VRF_DEFAULT);
+	zclient_create_header(s, cmd, api_nhg->vrf_id);
 
 	stream_putw(s, api_nhg->proto);
 	stream_putl(s, api_nhg->id);

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -486,6 +486,8 @@ struct zapi_nhg {
 
 	uint16_t backup_nexthop_num;
 	struct zapi_nexthop backup_nexthops[MULTIPATH_NUM];
+
+	uint32_t vrf_id;
 };
 
 /*

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -539,6 +539,7 @@ void nhg_add(uint32_t id, const struct nexthop_group *nhg,
 	bool is_valid = true;
 
 	api_nhg.id = id;
+	api_nhg.vrf_id = VRF_DEFAULT;
 
 	api_nhg.resilience = nhg->nhgr;
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1962,6 +1962,7 @@ static void zread_nhg_del(ZAPI_HANDLER_ARGS)
 	/* Create a temporary nhe */
 	nhe = zebra_nhg_alloc();
 	nhe->id = api_nhg.id;
+	nhe->vrf_id = zvrf_id(zvrf);
 	nhe->type = api_nhg.proto;
 	nhe->zapi_instance = client->instance;
 	nhe->zapi_session = client->session_id;
@@ -2165,6 +2166,7 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 	 */
 	if (!re->nhe_id) {
 		zebra_nhe_init(&nhe, afi, ng->nexthop);
+		nhe.vrf_id = re->vrf_id;
 		nhe.nhg.nexthop = ng->nexthop;
 		nhe.backup_info = bnhg;
 		n = zebra_nhe_copy(&nhe, 0);

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -3423,6 +3423,7 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 	lookup.nhg.nhgr = nhg->nhgr;
 	lookup.id = id;
 	lookup.type = type;
+	lookup.vrf_id = nhe->vrf_id;
 
 	old = zebra_nhg_lookup_id(id);
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4373,6 +4373,7 @@ int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
 	else if (re->nhe_id > 0)
 		nhe.id = re->nhe_id;
 
+	nhe.vrf_id = re->vrf_id;
 	n = zebra_nhe_copy(&nhe, 0);
 	ret = rib_add_multipath_nhe(afi, safi, p, src_p, re, n, startup);
 


### PR DESCRIPTION
When configuring a VRF route with a nexthop group, the nexthop group displays a wrong VRF:
> ubuntu2204(config)# nexthop-group A
> ubuntu2204(config-nh-group)# nexthop 172.31.0.100
> ubuntu2204(config-nh-group)# end
> ubuntu2204# sharp install routes vrf vrf3 2.2.2.0 nexthop-group A 1
> ubuntu2204# show ip route vrf vrf3 nexthop-group
> [..]
> D>* 2.2.2.0/32 [150/0] (633) via 172.31.0.100, loop3 (vrf default), weight 1, 00:00:07
> ubuntu2204# show nexthop-group rib 633
> [..]
>      VRF: default
> [..]

Fix this by using the vrf_id of the route that uses the nexthop-group. Also, when NHG_ADD is used, the zapi_nhg structure hosts the vrf_id value.

The displayed VRF value is only a consistency change, and does not prevent an user to attach two different routes from different VRFs with the same NHG. It is up to the CP daemon to ensure routes are using the appropriate NHG.

Fixes: df9069cd18a3 ("zebra: Add some more output to show nexthop-group")