### PR TITLE
zebra: Fix coverity issue in `dplane_srv6_encap_srcaddr_set`

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -5947,8 +5947,7 @@ dplane_srv6_encap_srcaddr_set(const struct in6_addr *addr, ns_id_t ns_id)
 		atomic_fetch_add_explicit(&zdplane_info
 						   .dg_srv6_encap_srcaddr_set_errors,
 					  1, memory_order_relaxed);
-		if (ctx)
-			dplane_ctx_free(&ctx);
+		dplane_ctx_free(&ctx);
 	}
 	return result;
 }


### PR DESCRIPTION
Fix the following coverity issue:

```
*** CID 1575079:  Null pointer dereferences  (REVERSE_INULL) /zebra/zebra_dplane.c: 5950 in dplane_srv6_encap_srcaddr_set()
5944     	if (ret == AOK)
5945     		result = ZEBRA_DPLANE_REQUEST_QUEUED;
5946     	else {
5947     		atomic_fetch_add_explicit(&zdplane_info
5948     						   .dg_srv6_encap_srcaddr_set_errors,
5949     					  1, memory_order_relaxed);
     CID 1575079:  Null pointer dereferences  (REVERSE_INULL)
     Null-checking "ctx" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
5950     		if (ctx)
5951     			dplane_ctx_free(&ctx);
5952     	}
5953     	return result;
5954     }
5955
```

Remove the pointer check for `ctx`. At this point in the function it has to be non null since we deref'ed it. Additionally the alloc function that creates it cannot fail.