### PR TITLE
bgpd: fix ecommunity_fill_pbr_action heap-buffer-overflow

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -1609,8 +1609,8 @@ int ecommunity_fill_pbr_action(struct ecommunity_val *ecom_eval,
 		 * in the 'Network Address of Next- Hop'
 		 * field of the associated MP_REACH_NLRI.
 		 */
-		struct ecommunity_ip *ip_ecom = (struct ecommunity_ip *)
-			ecom_eval + 2;
+		struct ecommunity_ip *ip_ecom =
+			(struct ecommunity_ip *)&ecom_eval->val[2];
 
 		api->u.zr.redirect_ip_v4 = ip_ecom->ip;
 	} else


### PR DESCRIPTION
Fix the following heap-buffer-overflow:

> ==3901635==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020003a5940 at pc 0x56260067bb48 bp 0x7ffe8a4f3840 sp 0x7ffe8a4f3838
> READ of size 4 at 0x6020003a5940 thread T0
>     #0 0x56260067bb47 in ecommunity_fill_pbr_action bgpd/bgp_ecommunity.c:1587
>     #1 0x5626007a246e in bgp_pbr_build_and_validate_entry bgpd/bgp_pbr.c:939
>     #2 0x5626007b25e6 in bgp_pbr_update_entry bgpd/bgp_pbr.c:2933
>     #3 0x562600909d18 in bgp_zebra_announce bgpd/bgp_zebra.c:1351
>     #4 0x5626007d5efd in bgp_process_main_one bgpd/bgp_route.c:3528
>     #5 0x5626007d6b43 in bgp_process_wq bgpd/bgp_route.c:3641
>     #6 0x7f450f34c2cc in work_queue_run lib/workqueue.c:266
>     #7 0x7f450f327a27 in event_call lib/event.c:1970
>     #8 0x7f450f21a637 in frr_run lib/libfrr.c:1213
>     #9 0x56260062fc04 in main bgpd/bgp_main.c:540
>     #10 0x7f450ee2dd09 in __libc_start_main ../csu/libc-start.c:308
>     #11 0x56260062ca29 in _start (/usr/lib/frr/bgpd+0x2e3a29)
>
> 0x6020003a5940 is located 0 bytes to the right of 16-byte region [0x6020003a5930,0x6020003a5940)
> allocated by thread T0 here:
>     #0 0x7f450f6aa1f8 in __interceptor_realloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:164
>     #1 0x7f450f244f8a in qrealloc lib/memory.c:112
>     #2 0x562600673313 in ecommunity_add_val_internal bgpd/bgp_ecommunity.c:143
>     #3 0x5626006735bc in ecommunity_uniq_sort_internal bgpd/bgp_ecommunity.c:193
>     #4 0x5626006737e3 in ecommunity_parse_internal bgpd/bgp_ecommunity.c:228
>     #5 0x562600673890 in ecommunity_parse bgpd/bgp_ecommunity.c:236
>     #6 0x562600640469 in bgp_attr_ext_communities bgpd/bgp_attr.c:2674
>     #7 0x562600646eb3 in bgp_attr_parse bgpd/bgp_attr.c:3893
>     #8 0x562600791b7e in bgp_update_receive bgpd/bgp_packet.c:2141
>     #9 0x56260079ba6b in bgp_process_packet bgpd/bgp_packet.c:3406
>     #10 0x7f450f327a27 in event_call lib/event.c:1970
>     #11 0x7f450f21a637 in frr_run lib/libfrr.c:1213
>     #12 0x56260062fc04 in main bgpd/bgp_main.c:540
>     #13 0x7f450ee2dd09 in __libc_start_main ../csu/libc-start.c:308

Fixes: dacf6ec120 ("bgpd: utility routine to convert flowspec actions into pbr actions")