### PR TITLE
Lib zebra h cleanup

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -12,6 +12,7 @@
  */
 
 #include <zebra.h>
+#include <sys/ioctl.h>
 
 #ifdef GNU_LINUX
 #include <linux/filter.h>

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -46,11 +46,6 @@
 #include "bgpd/rfapi/rfapi_encap_tlv.h"
 #include "bgpd/rfapi/vnc_debug.h"
 
-#ifdef HAVE_GLIBC_BACKTRACE
-/* for backtrace and friends */
-#include <execinfo.h>
-#endif /* HAVE_GLIBC_BACKTRACE */
-
 #define DEBUG_CLEANUP 0
 
 struct ethaddr rfapi_ethaddr0 = {{0}};
@@ -2091,24 +2086,7 @@ int rfapi_close(void *handle)
 	vnc_zlog_debug_verbose("%s: rfd=%p", __func__, rfd);
 
 #ifdef RFAPI_WHO_IS_CALLING_ME
-#ifdef HAVE_GLIBC_BACKTRACE
-#define RFAPI_DEBUG_BACKTRACE_NENTRIES 5
-	{
-		void *buf[RFAPI_DEBUG_BACKTRACE_NENTRIES];
-		char **syms;
-		int i;
-		size_t size;
-
-		size = backtrace(buf, RFAPI_DEBUG_BACKTRACE_NENTRIES);
-		syms = backtrace_symbols(buf, size);
-		for (i = 0; i < size && i < RFAPI_DEBUG_BACKTRACE_NENTRIES;
-		     ++i) {
-			vnc_zlog_debug_verbose("backtrace[%2d]: %s", i,
-					       syms[i]);
-		}
-		free(syms);
-	}
-#endif
+	zlog_backtrace(LOG_INFO);
 #endif
 
 	bgp = rfd->bgp;

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -44,11 +44,6 @@
 #include "bgpd/rfapi/rfapi_encap_tlv.h"
 #include "bgpd/rfapi/vnc_debug.h"
 
-#ifdef HAVE_GLIBC_BACKTRACE
-/* for backtrace and friends */
-#include <execinfo.h>
-#endif /* HAVE_GLIBC_BACKTRACE */
-
 #undef DEBUG_MONITOR_MOVE_SHORTER
 #undef DEBUG_RETURNED_NHL
 #undef DEBUG_ROUTE_COUNTERS
@@ -76,32 +71,6 @@ struct rfapi_withdraw {
 	 */
 	int lockoffset;
 };
-
-/*
- * DEBUG FUNCTION
- * It's evil and fiendish. It's compiler-dependent.
- * ? Might need LDFLAGS -rdynamic to produce all function names
- */
-void rfapiDebugBacktrace(void)
-{
-#ifdef HAVE_GLIBC_BACKTRACE
-#define RFAPI_DEBUG_BACKTRACE_NENTRIES	200
-	void *buf[RFAPI_DEBUG_BACKTRACE_NENTRIES];
-	char **syms;
-	size_t i;
-	size_t size;
-
-	size = backtrace(buf, RFAPI_DEBUG_BACKTRACE_NENTRIES);
-	syms = backtrace_symbols(buf, size);
-
-	for (i = 0; i < size && i < RFAPI_DEBUG_BACKTRACE_NENTRIES; ++i) {
-		vnc_zlog_debug_verbose("backtrace[%2zu]: %s", i, syms[i]);
-	}
-
-	free(syms);
-#else
-#endif
-}
 
 /*
  * DEBUG FUNCTION
@@ -1709,7 +1678,7 @@ struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
 
 #ifdef DEBUG_RETURNED_NHL
 	vnc_zlog_debug_verbose("%s: called with node pfx=%rRN", __func__, rn);
-	rfapiDebugBacktrace();
+	zlog_backtrace(LOG_INFO);
 #endif
 
 	rfapiQprefix2Rprefix(p, &rprefix);

--- a/bgpd/rfapi/rfapi_import.h
+++ b/bgpd/rfapi/rfapi_import.h
@@ -57,8 +57,6 @@ struct rfapi_import_table {
 
 extern uint8_t rfapiRfpCost(struct attr *attr);
 
-extern void rfapiDebugBacktrace(void);
-
 extern void rfapiCheckRouteCount(void);
 
 /*

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -13,6 +13,11 @@
 #include <zebra.h>
 #include <json-c/json_object.h>
 
+#ifdef CRYPTO_OPENSSL
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#endif
+
 #ifdef CRYPTO_INTERNAL
 #include "md5.h"
 #endif

--- a/lib/command.c
+++ b/lib/command.c
@@ -10,6 +10,7 @@
  */
 
 #include <zebra.h>
+#include <sys/utsname.h>
 #include <lib/version.h>
 
 #include "command.h"

--- a/lib/frrsendmmsg.h
+++ b/lib/frrsendmmsg.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * FRR sendmmsg wrapper
+ * Copyright (C) 2024 by Nvidia, Inc.
+ *                       Donald Sharp
+ */
+#ifndef __FRRSENDMMSG_H__
+#define __FRRSENDMMSG_H__
+
+#if !defined(HAVE_STRUCT_MMSGHDR_MSG_HDR) || !defined(HAVE_SENDMMSG)
+/* avoid conflicts in case we have partial support */
+#define mmsghdr	 frr_mmsghdr
+#define sendmmsg frr_sendmmsg
+
+struct mmsghdr {
+	struct msghdr msg_hdr;
+	unsigned int msg_len;
+};
+
+/* just go 1 at a time here, the loop this is used in will handle the rest */
+static inline int sendmmsg(int fd, struct mmsghdr *mmh, unsigned int len,
+			   int flags)
+{
+	int rv = sendmsg(fd, &mmh->msg_hdr, 0);
+
+	return rv > 0 ? 1 : rv;
+}
+#endif
+
+#endif

--- a/lib/imsg-buffer.c
+++ b/lib/imsg-buffer.c
@@ -6,6 +6,7 @@
  */
 
 #include <zebra.h>
+#include <sys/uio.h>
 
 #include "queue.h"
 #include "imsg.h"

--- a/lib/log.c
+++ b/lib/log.c
@@ -8,6 +8,10 @@
 
 #include <zebra.h>
 
+#ifdef HAVE_GLIBC_BACKTRACE
+#include <execinfo.h>
+#endif /* HAVE_GLIBC_BACKTRACE */
+
 #include "zclient.h"
 #include "log.h"
 #include "memory.h"

--- a/lib/privs.c
+++ b/lib/privs.c
@@ -7,6 +7,8 @@
  */
 #include <zebra.h>
 
+#include <grp.h>
+
 #ifdef HAVE_LCAPS
 #include <sys/capability.h>
 #include <sys/prctl.h>

--- a/lib/privs.c
+++ b/lib/privs.c
@@ -6,6 +6,12 @@
  * Copyright (c) 2005, 2011, Oracle and/or its affiliates. All rights reserved.
  */
 #include <zebra.h>
+
+#ifdef HAVE_LCAPS
+#include <sys/capability.h>
+#include <sys/prctl.h>
+#endif /* HAVE_LCAPS */
+
 #include "log.h"
 #include "privs.h"
 #include "memory.h"

--- a/lib/pullwr.c
+++ b/lib/pullwr.c
@@ -6,6 +6,8 @@
 
 #include "zebra.h"
 
+#include <sys/ioctl.h>
+
 #include "pullwr.h"
 #include "memory.h"
 #include "monotime.h"

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -227,6 +227,7 @@ pkginclude_HEADERS += \
 	lib/frr_pthread.h \
 	lib/frratomic.h \
 	lib/frrcu.h \
+	lib/frrsendmmsg.h \
 	lib/frrstr.h \
 	lib/graph.h \
 	lib/hash.h \

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -5,6 +5,7 @@
  */
 
 #include <zebra.h>
+#include <sys/ioctl.h>
 
 #include "if.h"
 #include "vrf.h"

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -36,7 +36,6 @@
 #include <sys/sysctl.h>
 #endif
 #endif /* HAVE_SYS_SYSCTL_H */
-#include <sys/ioctl.h>
 #ifdef HAVE_SYS_CONF_H
 #include <sys/conf.h>
 #endif /* HAVE_SYS_CONF_H */

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -63,11 +63,6 @@
 /* misc include group */
 #include <stdarg.h>
 
-#ifdef HAVE_LCAPS
-#include <sys/capability.h>
-#include <sys/prctl.h>
-#endif /* HAVE_LCAPS */
-
 /* network include group */
 
 #include <sys/socket.h>

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -45,7 +45,6 @@
 #include <syslog.h>
 #include <sys/time.h>
 #include <time.h>
-#include <sys/uio.h>
 #include <sys/utsname.h>
 #include <limits.h>
 #include <inttypes.h>

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -156,10 +156,6 @@
 #define UINT32_MAX	(4294967295U)
 #endif
 
-#ifdef HAVE_GLIBC_BACKTRACE
-#include <execinfo.h>
-#endif /* HAVE_GLIBC_BACKTRACE */
-
 /* Local includes: */
 #if !defined(__GNUC__)
 #define __attribute__(x)

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -47,7 +47,6 @@
 #include <time.h>
 #include <sys/uio.h>
 #include <sys/utsname.h>
-#include <sys/resource.h>
 #include <limits.h>
 #include <inttypes.h>
 #include <stdbool.h>

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -42,7 +42,6 @@
 #ifdef HAVE_SYS_KSYM_H
 #include <sys/ksym.h>
 #endif /* HAVE_SYS_KSYM_H */
-#include <syslog.h>
 #include <sys/time.h>
 #include <time.h>
 #include <sys/utsname.h>

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -22,7 +22,6 @@
 #include <signal.h>
 #include <string.h>
 #include <pwd.h>
-#include <grp.h>
 #ifdef HAVE_STROPTS_H
 #include <stropts.h>
 #endif /* HAVE_STROPTS_H */

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -44,7 +44,6 @@
 #endif /* HAVE_SYS_KSYM_H */
 #include <sys/time.h>
 #include <time.h>
-#include <sys/utsname.h>
 #include <limits.h>
 #include <inttypes.h>
 #include <stdbool.h>

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -81,7 +81,6 @@
 #include "openbsd-tree.h"
 
 #include <netinet/in.h>
-#include <netinet/in_systm.h>
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
 

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -83,11 +83,6 @@
 #endif
 #endif
 
-#ifdef CRYPTO_OPENSSL
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#endif
-
 #include "openbsd-tree.h"
 
 #include <netinet/in.h>

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -140,22 +140,6 @@
 #include <netinet6/nd6.h>
 #endif /* HAVE_NETINET6_ND6_H */
 
-/* Some systems do not define UINT32_MAX, etc.. from inttypes.h
- * e.g. this makes life easier for FBSD 4.11 users.
- */
-#ifndef INT16_MAX
-#define INT16_MAX	(32767)
-#endif
-#ifndef INT32_MAX
-#define INT32_MAX	(2147483647)
-#endif
-#ifndef UINT16_MAX
-#define UINT16_MAX	(65535U)
-#endif
-#ifndef UINT32_MAX
-#define UINT32_MAX	(4294967295U)
-#endif
-
 /* Local includes: */
 #if !defined(__GNUC__)
 #define __attribute__(x)

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -203,26 +203,6 @@ size_t strlcpy(char *__restrict dest,
 void explicit_bzero(void *buf, size_t len);
 #endif
 
-#if !defined(HAVE_STRUCT_MMSGHDR_MSG_HDR) || !defined(HAVE_SENDMMSG)
-/* avoid conflicts in case we have partial support */
-#define mmsghdr frr_mmsghdr
-#define sendmmsg frr_sendmmsg
-
-struct mmsghdr {
-	struct msghdr msg_hdr;
-	unsigned int msg_len;
-};
-
-/* just go 1 at a time here, the loop this is used in will handle the rest */
-static inline int sendmmsg(int fd, struct mmsghdr *mmh, unsigned int len,
-			   int flags)
-{
-	int rv = sendmsg(fd, &mmh->msg_hdr, 0);
-
-	return rv > 0 ? 1 : rv;
-}
-#endif
-
 /*
  * RFC 3542 defines several macros for using struct cmsghdr.
  * Here, we define those that are not present

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -134,8 +134,6 @@
 #include <netinet6/ip6.h>
 #endif /* HAVE_NETINET6_IP6_H */
 
-#include <netinet/icmp6.h>
-
 #ifdef HAVE_NETINET6_ND6_H
 #include <netinet6/nd6.h>
 #endif /* HAVE_NETINET6_ND6_H */

--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -5,6 +5,10 @@
 
 #include "zebra.h"
 
+#ifdef HAVE_GLIBC_BACKTRACE
+#include <execinfo.h>
+#endif /* HAVE_GLIBC_BACKTRACE */
+
 #include <unistd.h>
 #include <sys/time.h>
 #include <sys/mman.h>

--- a/lib/zlog_5424.c
+++ b/lib/zlog_5424.c
@@ -14,6 +14,8 @@
 
 #include "zebra.h"
 
+#include "frrsendmmsg.h"
+
 #include "zlog_5424.h"
 
 #include <sys/un.h>

--- a/lib/zlog_live.c
+++ b/lib/zlog_live.c
@@ -5,6 +5,8 @@
 
 #include "zebra.h"
 
+#include "frrsendmmsg.h"
+
 #include "zlog_live.h"
 
 #include "memory.h"

--- a/nhrpd/linux.c
+++ b/nhrpd/linux.c
@@ -7,6 +7,7 @@
 
 #include <errno.h>
 #include <linux/if_packet.h>
+#include <sys/ioctl.h>
 
 #include "nhrp_protocol.h"
 #include "os.h"

--- a/ospf6d/ospf6_auth_trailer.c
+++ b/ospf6d/ospf6_auth_trailer.c
@@ -4,6 +4,12 @@
  */
 
 #include "zebra.h"
+
+#ifdef CRYPTO_OPENSSL
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#endif
+
 #include "config.h"
 #include "memory.h"
 #include "ospf6d.h"

--- a/ospfd/ospf_auth.c
+++ b/ospfd/ospf_auth.c
@@ -6,6 +6,11 @@
 
 #include <zebra.h>
 
+#ifdef CRYPTO_OPENSSL
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#endif
+
 #include "linklist.h"
 #include "if.h"
 #include "checksum.h"

--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -13,6 +13,7 @@
  */
 
 #include <zebra.h>
+#include <netinet/icmp6.h>
 #include <netinet/ip6.h>
 
 #include "lib/memory.h"

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -6,6 +6,7 @@
  */
 
 #include <zebra.h>
+#include <sys/ioctl.h>
 
 #include "lib/json.h"
 #include "command.h"

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -6,6 +6,7 @@
 
 #include <zebra.h>
 #include <netinet/icmp6.h>
+#include <sys/ioctl.h>
 
 #include "log.h"
 #include "privs.h"

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -5,6 +5,8 @@
  */
 
 #include <zebra.h>
+#include <netinet/icmp6.h>
+
 #include "log.h"
 #include "privs.h"
 #include "if.h"

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -6,6 +6,11 @@
 
 #include <zebra.h>
 
+#ifdef CRYPTO_OPENSSL
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#endif
+
 #include "vrf.h"
 #include "if.h"
 #include "command.h"

--- a/sharpd/sharp_logpump.c
+++ b/sharpd/sharp_logpump.c
@@ -5,6 +5,7 @@
  */
 
 #include <zebra.h>
+#include <sys/resource.h>
 
 #include "vty.h"
 #include "command.h"

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -5,6 +5,8 @@
 
 #include <zebra.h>
 
+#include <grp.h>
+
 #include <sys/un.h>
 #include <setjmp.h>
 #include <sys/wait.h>

--- a/zebra/if_ioctl.c
+++ b/zebra/if_ioctl.c
@@ -5,6 +5,7 @@
  */
 
 #include <zebra.h>
+#include <sys/ioctl.h>
 
 #ifdef OPEN_BSD
 

--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -6,6 +6,8 @@
 
 #include <zebra.h>
 
+#include <sys/ioctl.h>
+
 #include "linklist.h"
 #include "if.h"
 #include "prefix.h"

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -6,6 +6,7 @@
  */
 
 #include <zebra.h>
+#include <netinet/icmp6.h>
 
 #include "memory.h"
 #include "sockopt.h"

--- a/zebra/zebra_mpls_openbsd.c
+++ b/zebra/zebra_mpls_openbsd.c
@@ -4,6 +4,7 @@
  */
 
 #include <zebra.h>
+#include <sys/ioctl.h>
 
 #ifdef OPEN_BSD
 

--- a/zebra/zebra_mpls_openbsd.c
+++ b/zebra/zebra_mpls_openbsd.c
@@ -5,6 +5,7 @@
 
 #include <zebra.h>
 #include <sys/ioctl.h>
+#include <sys/uio.h>
 
 #ifdef OPEN_BSD
 


### PR DESCRIPTION
Zebra.h has become a bit of a dumping ground for system headers.  Let's make a single pass through zebra.h and properly locate stuff where it belongs.  Especially for includes that are only used by 1-2 files.

Initial results of compile time on my machine actually surprised me.

I run a make -j32

Before timings:
```
   Executed in   13.12 secs    fish           external
   usr time  208.02 secs  360.00 micros  208.02 secs
   sys time   68.33 secs  179.00 micros   68.33 secs
```

After Timings:

```
Executed in   10.92 secs    fish           external
   usr time  158.24 secs  328.00 micros  158.24 secs
   sys time   50.81 secs  162.00 micros   50.81 secs
```




