### PR TITLE
lib: remove zebra_interface_vrf_update_read()

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -3059,36 +3059,6 @@ stream_failure:
 	return NULL;
 }
 
-struct interface *zebra_interface_vrf_update_read(struct stream *s,
-						  vrf_id_t vrf_id,
-						  vrf_id_t *new_vrf_id)
-{
-	char ifname[IFNAMSIZ + 1] = {};
-	struct interface *ifp;
-	vrf_id_t new_id;
-
-	/* Read interface name. */
-	STREAM_GET(ifname, s, IFNAMSIZ);
-
-	/* Lookup interface. */
-	ifp = if_lookup_by_name(ifname, vrf_id);
-	if (ifp == NULL) {
-		flog_err(EC_LIB_ZAPI_ENCODE,
-			 "INTERFACE_VRF_UPDATE: Cannot find IF %s in VRF %d",
-			 ifname, vrf_id);
-		return NULL;
-	}
-
-	/* Fetch new VRF Id. */
-	STREAM_GETL(s, new_id);
-
-	*new_vrf_id = new_id;
-	return ifp;
-
-stream_failure:
-	return NULL;
-}
-
 /* filter unwanted messages until the expected one arrives */
 static int zclient_read_sync_response(struct zclient *zclient,
 				      uint16_t expected_cmd)

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -1043,9 +1043,6 @@ extern struct connected *zebra_interface_address_read(int, struct stream *,
 						      vrf_id_t);
 extern struct nbr_connected *
 zebra_interface_nbr_address_read(int, struct stream *, vrf_id_t);
-extern struct interface *zebra_interface_vrf_update_read(struct stream *s,
-							 vrf_id_t vrf_id,
-							 vrf_id_t *new_vrf_id);
 extern int zebra_router_id_update_read(struct stream *s, struct prefix *rid);
 
 extern struct interface *zebra_interface_link_params_read(struct stream *s,


### PR DESCRIPTION
zebra_interface_vrf_update_read is orphan. Remove it.

Fixes: b580c52698 ("*: remove ZEBRA_INTERFACE_VRF_UPDATE")