### PR TITLE
Lib zebra h cleanup 2

### DIFF
--- a/babeld/babel_main.c
+++ b/babeld/babel_main.c
@@ -5,6 +5,8 @@ Copyright 2011 by Matthieu Boutier and Juliusz Chroboczek
 
 /* include zebra library */
 #include <zebra.h>
+#include <fcntl.h>
+
 #include "getopt.h"
 #include "if.h"
 #include "log.h"

--- a/babeld/kernel.c
+++ b/babeld/kernel.c
@@ -11,6 +11,7 @@ Copyright 2011, 2012 by Matthieu Boutier and Juliusz Chroboczek
 #include <sys/time.h>
 #include <sys/param.h>
 #include <time.h>
+#include <fcntl.h>
 
 #include "babeld.h"
 

--- a/bfdd/control.c
+++ b/bfdd/control.c
@@ -11,6 +11,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 
 #include <sys/un.h>
 

--- a/bfdd/control.c
+++ b/bfdd/control.c
@@ -11,6 +11,8 @@
  */
 
 #include <zebra.h>
+
+#include <fcntl.h>
 #include <sys/stat.h>
 
 #include <sys/un.h>

--- a/bgpd/bgp_btoa.c
+++ b/bgpd/bgp_btoa.c
@@ -4,6 +4,7 @@
  */
 
 #include <zebra.h>
+#include <fcntl.h>
 
 #include "zebra.h"
 #include "stream.h"

--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -4,6 +4,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 
 #include "log.h"
 #include "stream.h"

--- a/isisd/isis_bpf.c
+++ b/isisd/isis_bpf.c
@@ -8,6 +8,9 @@
  */
 
 #include <zebra.h>
+
+#include <fcntl.h>
+
 #if ISIS_METHOD == ISIS_METHOD_BPF
 #include <net/if.h>
 #include <netinet/if_ether.h>

--- a/ldpd/control.c
+++ b/ldpd/control.c
@@ -6,6 +6,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 #include <sys/un.h>
 
 #include "ldpd.h"

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -9,6 +9,8 @@
  */
 
 #include <zebra.h>
+
+#include <fcntl.h>
 #include <sys/wait.h>
 
 #include "ldpd.h"

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -10,6 +10,7 @@
 
 #include <zebra.h>
 
+#include <signal.h>
 #include <fcntl.h>
 #include <sys/wait.h>
 

--- a/ldpd/socket.c
+++ b/ldpd/socket.c
@@ -9,6 +9,7 @@
  */
 
 #include <zebra.h>
+#include <fcntl.h>
 
 #include "ldpd.h"
 #include "ldpe.h"

--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -4,6 +4,7 @@
  */
 
 #include <zebra.h>
+#include <fcntl.h>
 
 #ifdef SNMP_AGENTX
 #include <net-snmp/net-snmp-config.h>

--- a/lib/command.c
+++ b/lib/command.c
@@ -11,6 +11,7 @@
 
 #include <zebra.h>
 #include <sys/utsname.h>
+#include <sys/stat.h>
 #include <lib/version.h>
 
 #include "command.h"

--- a/lib/command.c
+++ b/lib/command.c
@@ -12,6 +12,8 @@
 #include <zebra.h>
 #include <sys/utsname.h>
 #include <sys/stat.h>
+#include <fcntl.h>
+
 #include <lib/version.h>
 
 #include "command.h"

--- a/lib/event.c
+++ b/lib/event.c
@@ -6,6 +6,8 @@
 /* #define DEBUG */
 
 #include <zebra.h>
+
+#include <signal.h>
 #include <sys/resource.h>
 
 #include "frrevent.h"

--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -5,6 +5,9 @@
  */
 
 #include <zebra.h>
+
+#include <signal.h>
+
 #include <pthread.h>
 #ifdef HAVE_PTHREAD_NP_H
 #include <pthread_np.h>

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -6,6 +6,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 #include <sys/un.h>
 
 #include <sys/types.h>

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -8,6 +8,7 @@
 #include <zebra.h>
 #include <sys/stat.h>
 #include <sys/un.h>
+#include <fcntl.h>
 
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -6,6 +6,8 @@
  */
 
 #include <zebra.h>
+
+#include <signal.h>
 #include <sys/stat.h>
 #include <sys/un.h>
 #include <fcntl.h>

--- a/lib/mgmt_msg.c
+++ b/lib/mgmt_msg.c
@@ -7,6 +7,8 @@
  * Copyright (c) 2023, LabN Consulting, L.L.C.
  */
 #include <zebra.h>
+#include <sys/stat.h>
+
 #include "debug.h"
 #include "network.h"
 #include "sockopt.h"

--- a/lib/netns_linux.c
+++ b/lib/netns_linux.c
@@ -5,6 +5,7 @@
  */
 
 #include <zebra.h>
+#include <fcntl.h>
 
 #ifdef HAVE_NETNS
 #undef _GNU_SOURCE

--- a/lib/network.c
+++ b/lib/network.c
@@ -5,6 +5,7 @@
  */
 
 #include <zebra.h>
+#include <fcntl.h>
 #include "log.h"
 #include "network.h"
 #include "lib_errors.h"

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -5,6 +5,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 
 #include "libfrr.h"
 #include "lib/version.h"

--- a/lib/pid_output.c
+++ b/lib/pid_output.c
@@ -5,6 +5,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 #include <fcntl.h>
 #include <log.h>
 #include "lib/version.h"

--- a/lib/privs.c
+++ b/lib/privs.c
@@ -7,6 +7,7 @@
  */
 #include <zebra.h>
 
+#include <pwd.h>
 #include <grp.h>
 
 #ifdef HAVE_LCAPS

--- a/lib/sigevent.c
+++ b/lib/sigevent.c
@@ -4,6 +4,8 @@
  */
 
 #include <zebra.h>
+
+#include <signal.h>
 #include <sigevent.h>
 #include <log.h>
 #include <memory.h>

--- a/lib/sockunion.h
+++ b/lib/sockunion.h
@@ -13,6 +13,7 @@
 #include "if.h"
 #include <sys/un.h>
 #ifdef __OpenBSD__
+#include <net/route.h>
 #include <netmpls/mpls.h>
 #endif
 

--- a/lib/systemd.c
+++ b/lib/systemd.c
@@ -5,6 +5,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 #include <sys/un.h>
 
 #include "frrevent.h"

--- a/lib/vector.c
+++ b/lib/vector.c
@@ -4,6 +4,7 @@
  */
 
 #include <zebra.h>
+#include <string.h>
 
 #include "vector.h"
 #include "memory.h"

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -5,7 +5,7 @@
  */
 
 #include <zebra.h>
-
+#include <sys/stat.h>
 #include <lib/version.h>
 #include <sys/types.h>
 #include <sys/types.h>

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -5,6 +5,8 @@
  */
 
 #include <zebra.h>
+
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <lib/version.h>
 #include <sys/types.h>

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -41,7 +41,6 @@
 #include <time.h>
 #include <limits.h>
 #include <inttypes.h>
-#include <stdbool.h>
 #ifdef HAVE_SYS_ENDIAN_H
 #include <sys/endian.h>
 #endif

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -90,8 +90,6 @@
 #include <net/if_var.h>
 #endif /* HAVE_NET_IF_VAR_H */
 
-#include <net/route.h>
-
 #ifndef HAVE_NETLINK
 #define RT_TABLE_MAIN		0
 #define RT_TABLE_LOCAL		RT_TABLE_MAIN

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -118,7 +118,6 @@
 #include <netinet6/in.h>
 #endif /* HAVE_NETINET6_IN_H */
 
-
 #ifdef HAVE_NETINET6_IP6_H
 #include <netinet6/ip6.h>
 #endif /* HAVE_NETINET6_IP6_H */
@@ -231,12 +230,6 @@ struct in_pktinfo {
 
 /* default zebra TCP port for zclient */
 #define ZEBRA_PORT			2600
-
-/*
- * The compiler.h header is used for anyone using the CPP_NOTICE
- * since this is universally needed, let's add it to zebra.h
- */
-#include "compiler.h"
 
 /* Zebra route's types are defined in route_types.h */
 #include "lib/route_types.h"

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -17,7 +17,6 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <ctype.h>
-#include <errno.h>
 #ifdef HAVE_STROPTS_H
 #include <stropts.h>
 #endif /* HAVE_STROPTS_H */

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -25,7 +25,6 @@
 #ifdef HAVE_STROPTS_H
 #include <stropts.h>
 #endif /* HAVE_STROPTS_H */
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/param.h>
 #ifdef HAVE_SYS_SYSCTL_H

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -18,7 +18,6 @@
 #include <stddef.h>
 #include <ctype.h>
 #include <errno.h>
-#include <signal.h>
 #include <string.h>
 #ifdef HAVE_STROPTS_H
 #include <stropts.h>

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -20,7 +20,6 @@
 #include <errno.h>
 #include <signal.h>
 #include <string.h>
-#include <pwd.h>
 #ifdef HAVE_STROPTS_H
 #include <stropts.h>
 #endif /* HAVE_STROPTS_H */

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -25,7 +25,6 @@
 #ifdef HAVE_STROPTS_H
 #include <stropts.h>
 #endif /* HAVE_STROPTS_H */
-#include <sys/select.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/param.h>

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -18,7 +18,6 @@
 #include <stddef.h>
 #include <ctype.h>
 #include <errno.h>
-#include <fcntl.h>
 #include <signal.h>
 #include <string.h>
 #include <pwd.h>

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -18,7 +18,6 @@
 #include <stddef.h>
 #include <ctype.h>
 #include <errno.h>
-#include <string.h>
 #ifdef HAVE_STROPTS_H
 #include <stropts.h>
 #endif /* HAVE_STROPTS_H */

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -37,7 +37,6 @@
 #endif /* HAVE_SYS_KSYM_H */
 #include <sys/time.h>
 #include <time.h>
-#include <limits.h>
 #include <inttypes.h>
 #ifdef HAVE_SYS_ENDIAN_H
 #include <sys/endian.h>

--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -5,6 +5,7 @@
 
 #include "zebra.h"
 #include <sys/stat.h>
+#include <fcntl.h>
 
 #ifdef HAVE_GLIBC_BACKTRACE
 #include <execinfo.h>

--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -4,6 +4,7 @@
  */
 
 #include "zebra.h"
+#include <sys/stat.h>
 
 #ifdef HAVE_GLIBC_BACKTRACE
 #include <execinfo.h>

--- a/lib/zlog_5424.c
+++ b/lib/zlog_5424.c
@@ -13,6 +13,7 @@
  */
 
 #include "zebra.h"
+#include <fcntl.h>
 
 #include "frrsendmmsg.h"
 

--- a/lib/zlog_targets.c
+++ b/lib/zlog_targets.c
@@ -5,6 +5,7 @@
 
 #include "zebra.h"
 
+#include <fcntl.h>
 #include <sys/un.h>
 #include <syslog.h>
 

--- a/nhrpd/linux.c
+++ b/nhrpd/linux.c
@@ -5,6 +5,7 @@
 
 #include "zebra.h"
 
+#include <fcntl.h>
 #include <errno.h>
 #include <linux/if_packet.h>
 #include <sys/ioctl.h>

--- a/nhrpd/vici.c
+++ b/nhrpd/vici.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <fcntl.h>
 
 #include "frrevent.h"
 #include "zbuf.h"

--- a/ospf6d/ospf6_auth_trailer.c
+++ b/ospf6d/ospf6_auth_trailer.c
@@ -4,6 +4,7 @@
  */
 
 #include "zebra.h"
+#include <sys/stat.h>
 
 #ifdef CRYPTO_OPENSSL
 #include <openssl/evp.h>

--- a/ospfd/ospf_auth.c
+++ b/ospfd/ospf_auth.c
@@ -5,6 +5,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 
 #ifdef CRYPTO_OPENSSL
 #include <openssl/evp.h>

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -5,6 +5,7 @@
  */
 
 #include <zebra.h>
+#include <fcntl.h>
 
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/tests/bgpd/test_packet.c
+++ b/tests/bgpd/test_packet.c
@@ -7,6 +7,7 @@
  */
 
 #include <zebra.h>
+#include <fcntl.h>
 
 #include "qobj.h"
 #include "vty.h"

--- a/tests/helpers/c/main.c
+++ b/tests/helpers/c/main.c
@@ -3,6 +3,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 
 #include <lib/version.h>
 #include "getopt.h"

--- a/tests/isisd/test_isis_spf.c
+++ b/tests/isisd/test_isis_spf.c
@@ -5,6 +5,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 
 #include <lib/version.h>
 #include "getopt.h"

--- a/tests/lib/cli/common_cli.c
+++ b/tests/lib/cli/common_cli.c
@@ -7,6 +7,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 
 #include "frrevent.h"
 #include "vty.h"

--- a/tests/lib/northbound/test_oper_data.c
+++ b/tests/lib/northbound/test_oper_data.c
@@ -5,6 +5,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 
 #include "frrevent.h"
 #include "vty.h"

--- a/tests/lib/test_privs.c
+++ b/tests/lib/test_privs.c
@@ -3,6 +3,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 
 #include <lib/version.h>
 #include "getopt.h"

--- a/tests/ospfd/test_ospf_spf.c
+++ b/tests/ospfd/test_ospf_spf.c
@@ -1,4 +1,5 @@
 #include <zebra.h>
+#include <sys/stat.h>
 
 #include "getopt.h"
 #include "frrevent.h"

--- a/tools/gen_northbound_callbacks.c
+++ b/tools/gen_northbound_callbacks.c
@@ -7,6 +7,7 @@
 #define REALLY_NEED_PLAIN_GETOPT 1
 
 #include <zebra.h>
+#include <sys/stat.h>
 
 #include <unistd.h>
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -5,6 +5,7 @@
 
 #include <zebra.h>
 
+#include <pwd.h>
 #include <grp.h>
 
 #include <sys/un.h>

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -5,6 +5,7 @@
 
 #include <zebra.h>
 
+#include <sys/stat.h>
 #include <sys/un.h>
 #include <setjmp.h>
 #include <pwd.h>

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -5,6 +5,7 @@
 
 #include <zebra.h>
 
+#include <signal.h>
 #include <sys/stat.h>
 #include <sys/un.h>
 #include <setjmp.h>

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -7,6 +7,7 @@
 
 #include <zebra.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 
 #include "frrevent.h"
 #include <log.h>

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -6,6 +6,8 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
+
 #include "frrevent.h"
 #include <log.h>
 #include <network.h>

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -6,6 +6,8 @@
  */
 
 #include <zebra.h>
+
+#include <signal.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 

--- a/watchfrr/watchfrr_vty.c
+++ b/watchfrr/watchfrr_vty.c
@@ -6,6 +6,8 @@
  */
 
 #include <zebra.h>
+
+#include <signal.h>
 #include <sys/wait.h>
 
 #include "memory.h"

--- a/zebra/if_sysctl.c
+++ b/zebra/if_sysctl.c
@@ -6,6 +6,8 @@
 
 #include <zebra.h>
 
+#include <net/route.h>
+
 #if !defined(GNU_LINUX) && !defined(OPEN_BSD)
 
 #include "if.h"

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -4,6 +4,7 @@
  */
 
 #include <zebra.h>
+#include <fcntl.h>
 
 #ifdef HAVE_NETLINK
 #include <linux/netlink.h>

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -5,6 +5,8 @@
 
 #include <zebra.h>
 
+#include <net/route.h>
+
 #ifndef HAVE_NETLINK
 
 #include <net/if_types.h>

--- a/zebra/netconf_netlink.c
+++ b/zebra/netconf_netlink.c
@@ -6,6 +6,7 @@
  *                     Donald Sharp
  */
 #include <zebra.h>
+#include <fcntl.h>
 
 #ifdef HAVE_NETLINK /* Netlink OSes only */
 

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -6,6 +6,8 @@
 
 #include <zebra.h>
 
+#include <net/route.h>
+
 #ifndef HAVE_NETLINK
 
 #ifdef __OpenBSD__

--- a/zebra/rtread_sysctl.c
+++ b/zebra/rtread_sysctl.c
@@ -6,6 +6,8 @@
 
 #include <zebra.h>
 
+#include <net/route.h>
+
 #if !defined(GNU_LINUX)
 
 #include "memory.h"

--- a/zebra/zebra_mpls_netlink.c
+++ b/zebra/zebra_mpls_netlink.c
@@ -4,6 +4,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 
 #ifdef HAVE_NETLINK
 

--- a/zebra/zebra_netns_id.c
+++ b/zebra/zebra_netns_id.c
@@ -5,6 +5,7 @@
  */
 
 #include <zebra.h>
+#include <sys/stat.h>
 
 #ifdef GNU_LINUX
 #include <linux/if_link.h>

--- a/zebra/zebra_netns_id.c
+++ b/zebra/zebra_netns_id.c
@@ -6,6 +6,7 @@
 
 #include <zebra.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 
 #ifdef GNU_LINUX
 #include <linux/if_link.h>

--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -5,6 +5,7 @@
  */
 
 #include <zebra.h>
+#include <fcntl.h>
 
 #ifdef HAVE_NETLINK
 #ifdef HAVE_NETNS


### PR DESCRIPTION
Second round.

Before:
```
Executed in   11.94 secs    fish           external
   usr time  169.24 secs    0.00 micros  169.24 secs
   sys time   52.49 secs  628.00 micros   52.48 secs
```

After:
```
Executed in   11.85 secs    fish           external
   usr time  166.39 secs  379.00 micros  166.39 secs
   sys time   50.87 secs  206.00 micros   50.87 secs
```

More time saved in usr time and sys, starting to hit diminishing returns on actual wall clock time for me.
