### PR TITLE
Revert "bgpd: On shutdown do not create a workqueue for the self peer"

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1239,7 +1239,7 @@ void bgp_fsm_change_status(struct peer_connection *connection,
 	/* Transition into Clearing or Deleted must /always/ clear all routes..
 	 * (and must do so before actually changing into Deleted..
 	 */
-	if (status >= Clearing && peer != bgp->peer_self) {
+	if (status >= Clearing) {
 		bgp_clear_route_all(peer);
 
 		/* If no route was queued for the clear-node processing,


### PR DESCRIPTION
This reverts commit 7bf3c2fb195f34382e1bf00ed2c91310a1dc9f86. Commit reverted as it introduces a memoery leak during the tests