### PR TITLE
Implement full XPath 1.0 functionality

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1968,6 +1968,13 @@ AC_CHECK_MEMBER([struct lyd_node.priv], [], [
     Instructions for this are included in the build documentation for your platform at http://docs.frrouting.org/projects/dev-guide/en/latest/building.html])
   ])
 ], [[#include <libyang/libyang.h>]])
+
+AC_CHECK_LIB([yang],[lyd_find_xpath3],[],[AC_MSG_ERROR([m4_normalize([
+libyang missing lyd_find_xpath3])])])
+dnl -- don't add lyd_new_list3 to this list unless bug is fixed upstream
+dnl -- https://github.com/CESNET/libyang/issues/2149
+AC_CHECK_FUNCS([ly_strerrcode ly_strvecode lyd_trim_xpath])
+
 CFLAGS="$ac_cflags_save"
 
 dnl ---------------

--- a/lib/mgmt_msg.c
+++ b/lib/mgmt_msg.c
@@ -207,7 +207,7 @@ bool mgmt_msg_procbufs(struct mgmt_msg_state *ms,
 }
 
 /**
- * Write data from a onto the socket, using streams that have been queued for
+ * Write data onto the socket, using streams that have been queued for
  * sending by mgmt_msg_send_msg. This function should be reschedulable.
  *
  * Args:

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -6,6 +6,7 @@
 
 #include <zebra.h>
 
+#include "darr.h"
 #include "libfrr.h"
 #include "log.h"
 #include "lib_errors.h"
@@ -167,6 +168,26 @@ struct nb_node *nb_node_find(const char *path)
 
 	return snode->priv;
 }
+
+struct nb_node **nb_nodes_find(const char *xpath)
+{
+	struct lysc_node **snodes = NULL;
+	struct nb_node **nb_nodes = NULL;
+	bool simple;
+	LY_ERR err;
+	uint i;
+
+	err = yang_resolve_snode_xpath(ly_native_ctx, xpath, &snodes, &simple);
+	if (err)
+		return NULL;
+
+	darr_ensure_i(nb_nodes, darr_lasti(snodes));
+	darr_foreach_i (snodes, i)
+		nb_nodes[i] = snodes[i]->priv;
+	darr_free(snodes);
+	return nb_nodes;
+}
+
 
 void nb_node_set_dependency_cbs(const char *dependency_xpath,
 				const char *dependant_xpath,

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -813,6 +813,14 @@ void nb_nodes_delete(void);
  */
 extern struct nb_node *nb_node_find(const char *xpath);
 
+/**
+ * nb_nodes_find() - find the NB nodes corresponding to complex xpath.
+ * @xpath: XPath to search for (with or without predicates).
+ *
+ * Return: a dynamic array (darr) of `struct nb_node *`s.
+ */
+extern struct nb_node **nb_nodes_find(const char *xpath);
+
 extern void nb_node_set_dependency_cbs(const char *dependency_xpath,
 				       const char *dependant_xpath,
 				       struct nb_dependency_callbacks *cbs);

--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -72,6 +72,7 @@ struct nb_op_node_info {
  * @schema_path: the schema nodes for each node in the query string.
  # @query_tokstr: the query string tokenized with NUL bytes.
  * @query_tokens: the string pointers to each query token (node).
+ * @non_specific_predicate: tracks if a query_token is non-specific predicate.
  * @walk_root_level: The topmost specific node, +1 is where we start walking.
  * @walk_start_level: @walk_root_level + 1.
  * @query_base_level: the level the query string stops at and full walks
@@ -85,6 +86,7 @@ struct nb_op_yield_state {
 	const struct lysc_node **schema_path;
 	char *query_tokstr;
 	char **query_tokens;
+	uint8_t *non_specific_predicate;
 	int walk_root_level;
 	int walk_start_level;
 	int query_base_level;
@@ -158,6 +160,7 @@ static inline void nb_op_free_yield_state(struct nb_op_yield_state *ys,
 		if (!nofree_tree && ys_root_node(ys))
 			lyd_free_all(ys_root_node(ys));
 		darr_free(ys->query_tokens);
+		darr_free(ys->non_specific_predicate);
 		darr_free(ys->query_tokstr);
 		darr_free(ys->schema_path);
 		darr_free(ys->node_infos);
@@ -1142,18 +1145,23 @@ static enum nb_error __walk(struct nb_op_yield_state *ys, bool is_resume)
 			is_specific_node = false;
 			if (list_start &&
 			    at_clevel <= darr_lasti(ys->query_tokens) &&
+			    !ys->non_specific_predicate[at_clevel] &&
 			    nb_op_schema_path_has_predicate(ys, at_clevel)) {
 				err = lyd_new_path(&pni->inner->node, NULL,
 						   ys->query_tokens[at_clevel],
 						   NULL, 0, &node);
 				if (!err)
-					/* predicate resolved to specific node */
 					is_specific_node = true;
+				else if (err == LY_EVALID)
+					ys->non_specific_predicate[at_clevel] = true;
 				else {
-					flog_warn(EC_LIB_NB_OPERATIONAL_DATA,
-						  "%s: unable to create node for specific query string: %s",
+					flog_err(EC_LIB_NB_OPERATIONAL_DATA,
+						  "%s: unable to create node for specific query string: %s: %s",
 						  __func__,
-						  ys->query_tokens[at_clevel]);
+						  ys->query_tokens[at_clevel],
+						  yang_ly_strerrcode(err));
+					ret = NB_ERR;
+					goto done;
 				}
 			}
 
@@ -1570,6 +1578,7 @@ static enum nb_error nb_op_yield(struct nb_op_yield_state *ys)
 static enum nb_error nb_op_ys_init_schema_path(struct nb_op_yield_state *ys,
 					       struct nb_node **last)
 {
+	struct nb_node **nb_nodes = NULL;
 	const struct lysc_node *sn;
 	struct nb_node *nblast;
 	char *s, *s2;
@@ -1587,6 +1596,11 @@ static enum nb_error nb_op_ys_init_schema_path(struct nb_op_yield_state *ys,
 	 * string over each schema trunk in the set.
 	 */
 	nblast = nb_node_find(ys->xpath);
+	if (!nblast) {
+		nb_nodes = nb_nodes_find(ys->xpath);
+		nblast = darr_len(nb_nodes) ? nb_nodes[0] : NULL;
+		darr_free(nb_nodes);
+	}
 	if (!nblast) {
 		flog_warn(EC_LIB_YANG_UNKNOWN_DATA_PATH,
 			  "%s: unknown data path: %s", __func__, ys->xpath);
@@ -1614,6 +1628,7 @@ static enum nb_error nb_op_ys_init_schema_path(struct nb_op_yield_state *ys,
 	/* create our arrays */
 	darr_append_n(ys->schema_path, count);
 	darr_append_n(ys->query_tokens, count);
+	darr_append_nz(ys->non_specific_predicate, count);
 	for (sn = nblast->snode; sn; sn = sn->parent)
 		ys->schema_path[--count] = sn;
 
@@ -1675,6 +1690,7 @@ error:
 	darr_free(ys->query_tokstr);
 	darr_free(ys->schema_path);
 	darr_free(ys->query_tokens);
+	darr_free(ys->non_specific_predicate);
 	return NB_ERR;
 }
 

--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -1409,11 +1409,8 @@ static enum nb_error __walk(struct nb_op_yield_state *ys, bool is_resume)
 			 */
 
 			if (!node) {
-				/* NOTE: can also use lyd_new_list2 here when available */
 				err = yang_lyd_new_list(ni[-1].inner, sib,
-							&ni->keys,
-							(struct lyd_node_inner *
-								 *)&node);
+							&ni->keys, &node);
 				if (err) {
 					darr_pop(ys->node_infos);
 					ret = NB_ERR_RESOURCE;

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -3688,88 +3688,9 @@ static void vty_out_yang_error(struct vty *vty, LYD_FORMAT format,
 	else if (ei->level == LY_LLWRN)
 		severity = "warning";
 
-	switch (ei->no) {
-	case LY_SUCCESS:
-		ecode = "ok";
-		break;
-	case LY_EMEM:
-		ecode = "out of memory";
-		break;
-	case LY_ESYS:
-		ecode = "system error";
-		break;
-	case LY_EINVAL:
-		ecode = "invalid value given";
-		break;
-	case LY_EEXIST:
-		ecode = "item exists";
-		break;
-	case LY_ENOTFOUND:
-		ecode = "item not found";
-		break;
-	case LY_EINT:
-		ecode = "operation interrupted";
-		break;
-	case LY_EVALID:
-		ecode = "validation failed";
-		break;
-	case LY_EDENIED:
-		ecode = "access denied";
-		break;
-	case LY_EINCOMPLETE:
-		ecode = "incomplete";
-		break;
-	case LY_ERECOMPILE:
-		ecode = "compile error";
-		break;
-	case LY_ENOT:
-		ecode = "not";
-		break;
-	default:
-	case LY_EPLUGIN:
-	case LY_EOTHER:
-		ecode = "other";
-		break;
-	}
-
-	if (err == LY_EVALID) {
-		switch (ei->vecode) {
-		case LYVE_SUCCESS:
-			evalid = NULL;
-			break;
-		case LYVE_SYNTAX:
-			evalid = "syntax";
-			break;
-		case LYVE_SYNTAX_YANG:
-			evalid = "yang-syntax";
-			break;
-		case LYVE_SYNTAX_YIN:
-			evalid = "yin-syntax";
-			break;
-		case LYVE_REFERENCE:
-			evalid = "reference";
-			break;
-		case LYVE_XPATH:
-			evalid = "xpath";
-			break;
-		case LYVE_SEMANTICS:
-			evalid = "semantics";
-			break;
-		case LYVE_SYNTAX_XML:
-			evalid = "xml-syntax";
-			break;
-		case LYVE_SYNTAX_JSON:
-			evalid = "json-syntax";
-			break;
-		case LYVE_DATA:
-			evalid = "data";
-			break;
-		default:
-		case LYVE_OTHER:
-			evalid = "other";
-			break;
-		}
-	}
+	ecode = yang_ly_strerrcode(err);
+	if (err == LY_EVALID && ei->vecode != LYVE_SUCCESS)
+		evalid = yang_ly_strvecode(ei->vecode);
 
 	switch (format) {
 	case LYD_XML:

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -719,11 +719,6 @@ extern int yang_get_key_preds(char *s, const struct lysc_node *snode,
 /* Get YANG keys from an existing dnode */
 extern int yang_get_node_keys(struct lyd_node *node, struct yang_list_keys *keys);
 
-/* Create a new list lyd_node using `yang_list_keys` */
-extern LY_ERR yang_lyd_new_list(struct lyd_node_inner *parent,
-				const struct lysc_node *snode,
-				const struct yang_list_keys *keys,
-				struct lyd_node_inner **node);
 /**
  * yang_resolve_snodes() - Resolve an XPath to matching schema nodes.
  * @ly_ctx: libyang context to operate on.
@@ -744,14 +739,16 @@ extern LY_ERR yang_lyd_new_list(struct lyd_node_inner *parent,
 extern LY_ERR yang_resolve_snode_xpath(struct ly_ctx *ly_ctx, const char *xpath,
 				       struct lysc_node ***snodes, bool *simple);
 
-/**
- * yang_trim_tree() - trim the data tree to the given xpath
- * @root: the data tree
- * @xpath: the xpath to trim @root to.
- *
- * Return: enum nb_error..
+/*
+ * Libyang future functions
  */
-extern int yang_trim_tree(struct lyd_node *root, const char *xpath);
+extern const char *yang_ly_strerrcode(LY_ERR err);
+extern const char *yang_ly_strvecode(LY_VECODE vecode);
+extern LY_ERR yang_lyd_new_list(struct lyd_node_inner *parent,
+				const struct lysc_node *snode,
+				const struct yang_list_keys *keys,
+				struct lyd_node **nodes);
+extern LY_ERR yang_lyd_trim_xpath(struct lyd_node **rootp, const char *xpath);
 
 #ifdef __cplusplus
 }

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -724,6 +724,35 @@ extern LY_ERR yang_lyd_new_list(struct lyd_node_inner *parent,
 				const struct lysc_node *snode,
 				const struct yang_list_keys *keys,
 				struct lyd_node_inner **node);
+/**
+ * yang_resolve_snodes() - Resolve an XPath to matching schema nodes.
+ * @ly_ctx: libyang context to operate on.
+ * @xpath: the path or XPath to resolve.
+ * @snodes: [OUT] pointer for resulting dynamic array (darr) of schema node
+ *          pointers.
+ * @simple: [OUT] indicates if @xpath was resolvable simply or not. Non-simple
+ *          means that the @xpath is not a simple path and utilizes XPath 1.0
+ *          functionality beyond simple key predicates.
+ *
+ * This function can be used to find the schema node (or nodes) that correspond
+ * to a given @xpath. If the @xpath includes non-key predicates (e.g., using
+ * functions) then @simple will be set to false, and @snodes may contain more
+ * than a single schema node.
+ *
+ * Return: a libyang error or LY_SUCCESS.
+ */
+extern LY_ERR yang_resolve_snode_xpath(struct ly_ctx *ly_ctx, const char *xpath,
+				       struct lysc_node ***snodes, bool *simple);
+
+/**
+ * yang_trim_tree() - trim the data tree to the given xpath
+ * @root: the data tree
+ * @xpath: the xpath to trim @root to.
+ *
+ * Return: enum nb_error..
+ */
+extern int yang_trim_tree(struct lyd_node *root, const char *xpath);
+
 #ifdef __cplusplus
 }
 #endif

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -1105,7 +1105,7 @@ static int fe_adapter_send_tree_data(struct mgmt_fe_session_ctx *session,
 				      LYD_PRINT_WITHSIBLINGS));
 	/* buf may have been reallocated and moved */
 	msg = (typeof(msg))buf;
-
+	(void)msg; /* suppress clang-SA unused warning on safety code */
 
 	if (ret != LY_SUCCESS) {
 		MGMTD_FE_ADAPTER_ERR("Error building get-tree result for client %s session-id %" PRIu64

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -1278,8 +1278,9 @@ static int txn_get_tree_data_done(struct mgmt_txn_ctx *txn,
 		/*
 		 * We have a complex query so Filter results by the xpath query.
 		 */
-		ret = yang_trim_tree(get_tree->client_results,
-				     txn_req->req.get_tree->xpath);
+		if (yang_lyd_trim_xpath(&get_tree->client_results,
+					txn_req->req.get_tree->xpath))
+			ret = NB_ERR;
 	}
 
 	if (ret == NB_OK)

--- a/mgmtd/mgmt_txn.h
+++ b/mgmtd/mgmt_txn.h
@@ -203,13 +203,15 @@ extern int mgmt_txn_send_get_req(uint64_t txn_id, uint64_t req_id,
  *	req_id: FE client request identifier.
  *	clients: Bitmask of clients to send get-tree to.
  *	result_type: LYD_FORMAT result format.
+ *	simple_xpath: true if xpath is simple (only key predicates).
  *	xpath: The xpath to get the tree from.
+ *
  * Return:
  *	0 on success.
  */
 extern int mgmt_txn_send_get_tree_oper(uint64_t txn_id, uint64_t req_id,
 				       uint64_t clients, LYD_FORMAT result_type,
-				       const char *xpath);
+				       bool simple_xpath, const char *xpath);
 
 /*
  * Notifiy backend adapter on connection.

--- a/tests/topotests/mgmt_oper/test_querying.py
+++ b/tests/topotests/mgmt_oper/test_querying.py
@@ -51,6 +51,16 @@ def test_oper_simple(tgen):
         pytest.skip(tgen.errors)
 
     query_results = [
+        # Non-key specific query with function filtering selector
+        '/frr-interface:lib/interface[contains(name,"eth")]/vrf',
+        # Non-key specific query with child value filtering selector
+        '/frr-interface:lib/interface[vrf="red"]/vrf',
+        '/frr-interface:lib/interface[./vrf="red"]/vrf',
+        # Container query with function filtering selector
+        '/frr-interface:lib/interface[contains(name,"eth")]/state',
+        # Multi list elemenet with function filtering selector
+        '/frr-interface:lib/interface[contains(name,"eth")]',
+        #
         # Specific list entry after non-specific lists
         '/frr-vrf:lib/vrf[name="default"]/frr-zebra:zebra/ribs/'
         'rib[afi-safi-name="frr-routing:ipv4-unicast"][table-id="254"]/'

--- a/tests/topotests/mgmt_oper/test_scale.py
+++ b/tests/topotests/mgmt_oper/test_scale.py
@@ -11,7 +11,7 @@
 """
 Test static route functionality
 """
-import logging
+import re
 import time
 
 import pytest
@@ -63,5 +63,11 @@ def test_oper_simple(tgen):
     check_kernel_32(r1, "20.0.0.0", count, vrf, 1000)
 
     step(f"All {count} routes installed in kernel, continuing")
-    output = r1.cmd_raises("vtysh -c 'show mgmt get-data /frr-vrf:lib'")
-    step("Got output: output")
+    # output = r1.cmd_raises("vtysh -c 'show mgmt get-data /frr-vrf:lib'")
+    # step(f"Got output: {output[0:1024]}")
+
+    query = '/frr-vrf:lib/vrf/frr-zebra:zebra/ribs/rib/route[contains(prefix,"20.0.0.12")]/prefix'
+    output = r1.cmd_raises(f"vtysh -c 'show mgmt get-data {query}'")
+    matches = re.findall(r'"prefix":', output)
+    # 20.0.0.12 + 20.0.0.12{0,1,2,3,4,5,6,7,8,9}
+    assert len(matches) == 11


### PR DESCRIPTION
Allow user to specify full YANG compatible XPath 1.0 functionality. This allows
for trimming results of generic queries using functions and other non-key
predicates from XPath 1.0
