### PR TITLE
vtysh: Add `show event ...` commands

### DIFF
--- a/doc/developer/process-architecture.rst
+++ b/doc/developer/process-architecture.rst
@@ -87,7 +87,7 @@ are given by integer macros in :file:`frrevent.h` and are:
 
 ``EVENT_EXECUTE``
    Just before a task is run its type is changed to this. This is used to show
-   ``X`` as the type in the output of :clicmd:`show thread cpu`.
+   ``X`` as the type in the output of :clicmd:`show event cpu`.
 
 The programmer never has to work with these types explicitly. Each type of task
 is created and queued via special-purpose functions (actually macros, but
@@ -238,14 +238,14 @@ proceeding.
 
 In addition, the existing commands to show statistics and other information for
 tasks within the event driven model have been expanded to handle multiple
-pthreads; running :clicmd:`show thread cpu` will display the usual event
+pthreads; running :clicmd:`show event cpu` will display the usual event
 breakdown, but it will do so for each pthread running in the program. For
 example, :ref:`bgpd` runs a dedicated I/O pthread and shows the following
-output for :clicmd:`show thread cpu`:
+output for :clicmd:`show event cpu`:
 
 ::
 
-   frr# show thread cpu
+   frr# show event cpu
 
    Thread statistics for bgpd:
 

--- a/doc/developer/process-architecture.rst
+++ b/doc/developer/process-architecture.rst
@@ -247,7 +247,7 @@ output for :clicmd:`show event cpu`:
 
    frr# show event cpu
 
-   Thread statistics for bgpd:
+   Event statistics for bgpd:
 
    Showing statistics for pthread main
    ------------------------------------

--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -673,20 +673,20 @@ Terminal Mode Commands
 
 .. _common-show-commands:
 
-.. clicmd:: show thread cpu [r|w|t|e|x]
+.. clicmd:: show event cpu [r|w|t|e|x]
 
    This command displays system run statistics for all the different event
    types. If no options is specified all different run types are displayed
    together.  Additionally you can ask to look at (r)ead, (w)rite, (t)imer,
    (e)vent and e(x)ecute thread event types.
 
-.. clicmd:: show thread poll
+.. clicmd:: show event poll
 
    This command displays FRR's poll data.  It allows a glimpse into how
    we are setting each individual fd for the poll command at that point
    in time.
 
-.. clicmd:: show thread timers
+.. clicmd:: show event timers
 
    This command displays FRR's timer data for timers that will pop in
    the future.

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/scale_up.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/scale_up.py
@@ -226,7 +226,7 @@ else:
             ave_b = float(delta_b) / float(num)
             luCommand(
                 rtr,
-                'vtysh -c "show thread cpu"',
+                'vtysh -c "show event cpu"',
                 ".",
                 "pass",
                 "BGPd heap: {0} {1} --> {2} {3} ({4} {1}/vpn route)".format(
@@ -239,7 +239,7 @@ else:
             )
             luCommand(
                 rtr,
-                'vtysh -c "show thread cpu"',
+                'vtysh -c "show event cpu"',
                 ".",
                 "pass",
                 "Zebra heap: {0} {1} --> {2} {3} ({4} {1}/vpn route)".format(

--- a/tests/topotests/isis_topo1/test_isis_topo1.py
+++ b/tests/topotests/isis_topo1/test_isis_topo1.py
@@ -708,9 +708,9 @@ def _check_overload_timer(router, timer_expected):
 
     tgen = get_topogen()
     router = tgen.gears[router]
-    thread_output = router.vtysh_cmd("show thread timers")
+    output = router.vtysh_cmd("show event timers")
 
-    timer_running = "set_overload_on_start_timer" in thread_output
+    timer_running = "set_overload_on_start_timer" in output
     if timer_running == timer_expected:
         return True
     return "Expected timer running status: {}".format(timer_expected)

--- a/tools/etc/frr/support_bundle_commands.conf
+++ b/tools/etc/frr/support_bundle_commands.conf
@@ -80,9 +80,9 @@ show vrf
 show work-queues
 show debugging hashtable
 show running-config
-show thread cpu
-show thread poll
-show thread timers
+show event cpu
+show event poll
+show event timers
 show daemons
 show version
 CMD_LIST_END
@@ -177,7 +177,7 @@ CMD_LIST_END
 PROC_NAME:ospf6
 CMD_LIST_START
 show ipv6 ospf6 vrf all
-show ipv6 ospf6 vrfs 
+show ipv6 ospf6 vrfs
 show ipv6 ospf6 vrf all border-routers
 show ipv6 ospf6 vrf all border-routers detail
 show ipv6 ospf6 vrf all database

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2942,35 +2942,38 @@ static int show_one_daemon(struct vty *vty, struct cmd_token **argv, int argc,
 	return ret;
 }
 
-DEFUN (vtysh_show_thread_timer,
-       vtysh_show_thread_timer_cmd,
-       "show thread timers",
+#if CONFDATE > 20240707
+	CPP_NOTICE("Remove `show thread ...` commands")
+#endif
+DEFUN (vtysh_show_event_timer,
+       vtysh_show_event_timer_cmd,
+       "show event timers",
        SHOW_STR
-       "Thread information\n"
+       "Event information\n"
        "Show all timers and how long they have in the system\n")
 {
-	return show_per_daemon(vty, argv, argc, "Thread timers for %s:\n");
+	return show_per_daemon(vty, argv, argc, "Event timers for %s:\n");
 }
 
-DEFUN (vtysh_show_poll,
-       vtysh_show_poll_cmd,
-       "show thread poll",
+DEFUN (vtysh_show_event_poll,
+       vtysh_show_event_poll_cmd,
+       "show event poll",
        SHOW_STR
-       "Thread information\n"
-       "Thread Poll Information\n")
+       "Event information\n"
+       "Event Poll Information\n")
 {
-	return show_per_daemon(vty, argv, argc, "Thread statistics for %s:\n");
+	return show_per_daemon(vty, argv, argc, "Event statistics for %s:\n");
 }
 
-DEFUN (vtysh_show_thread,
-       vtysh_show_thread_cmd,
-       "show thread cpu [FILTER]",
+DEFUN (vtysh_show_event,
+       vtysh_show_event_cpu_cmd,
+       "show event cpu [FILTER]",
        SHOW_STR
-       "Thread information\n"
-       "Thread CPU usage\n"
+       "Event information\n"
+       "Event CPU usage\n"
        "Display filter (rwtexb)\n")
 {
-	return show_per_daemon(vty, argv, argc, "Thread statistics for %s:\n");
+	return show_per_daemon(vty, argv, argc, "Event statistics for %s:\n");
 }
 
 DEFUN (vtysh_show_work_queues,
@@ -5201,9 +5204,9 @@ void vtysh_init_vty(void)
 	install_element(VIEW_NODE, &vtysh_show_modules_cmd);
 	install_element(VIEW_NODE, &vtysh_show_work_queues_cmd);
 	install_element(VIEW_NODE, &vtysh_show_work_queues_daemon_cmd);
-	install_element(VIEW_NODE, &vtysh_show_thread_cmd);
-	install_element(VIEW_NODE, &vtysh_show_poll_cmd);
-	install_element(VIEW_NODE, &vtysh_show_thread_timer_cmd);
+	install_element(VIEW_NODE, &vtysh_show_event_cpu_cmd);
+	install_element(VIEW_NODE, &vtysh_show_event_poll_cmd);
+	install_element(VIEW_NODE, &vtysh_show_event_timer_cmd);
 
 	/* Logging */
 	install_element(VIEW_NODE, &vtysh_show_logging_cmd);


### PR DESCRIPTION
Deprecate `show thread ...` commands later, and add them as aliases.