### PR TITLE
lib, vtysh: Drop `terminal no length` cmd

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -2111,17 +2111,6 @@ DEFUN (config_terminal_length,
 	return CMD_SUCCESS;
 }
 
-DEFUN (config_terminal_no_length,
-       config_terminal_no_length_cmd,
-       "terminal no length",
-       "Set terminal line parameters\n"
-       NO_STR
-       "Set number of lines on a screen\n")
-{
-	vty->lines = -1;
-	return CMD_SUCCESS;
-}
-
 DEFUN (service_terminal_length,
        service_terminal_length_cmd,
        "service terminal-length (0-512)",
@@ -2522,7 +2511,6 @@ void cmd_init(int terminal)
 		install_element(VIEW_NODE, &config_help_cmd);
 		install_element(VIEW_NODE, &config_enable_cmd);
 		install_element(VIEW_NODE, &config_terminal_length_cmd);
-		install_element(VIEW_NODE, &config_terminal_no_length_cmd);
 		install_element(VIEW_NODE, &show_commandtree_cmd);
 		install_element(VIEW_NODE, &echo_cmd);
 		install_element(VIEW_NODE, &autocomplete_cmd);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -3767,8 +3767,7 @@ DEFUN (vtysh_terminal_length,
 	free(vtysh_pager_name);
 	vtysh_pager_name = NULL;
 
-	if (!strcmp(argv[0]->text, "no") || !strcmp(argv[1]->text, "no")) {
-		/* "terminal no length" = use VTYSH_PAGER */
+	if (!strcmp(argv[0]->text, "no")) {
 		vtysh_pager_envdef(true);
 		return CMD_SUCCESS;
 	}
@@ -3783,13 +3782,6 @@ DEFUN (vtysh_terminal_length,
 
 	return CMD_SUCCESS;
 }
-
-ALIAS_DEPRECATED(vtysh_terminal_length,
-       vtysh_terminal_no_length_cmd,
-       "terminal no length",
-       "Set terminal line parameters\n"
-       NO_STR
-       "Set number of lines on a screen\n")
 
 DEFUN (vtysh_show_daemons,
        vtysh_show_daemons_cmd,
@@ -5151,7 +5143,6 @@ void vtysh_init_vty(void)
 	install_element(CONFIG_NODE, &vtysh_terminal_paginate_cmd);
 	install_element(VIEW_NODE, &vtysh_terminal_paginate_cmd);
 	install_element(VIEW_NODE, &vtysh_terminal_length_cmd);
-	install_element(VIEW_NODE, &vtysh_terminal_no_length_cmd);
 	install_element(VIEW_NODE, &vtysh_show_daemons_cmd);
 
 	install_element(VIEW_NODE, &vtysh_terminal_monitor_cmd);


### PR DESCRIPTION
It's deprecated long time ago, let's just drop it.