### PR TITLE
bgpd: Add `debug bgp updates detail` command

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -1148,6 +1148,31 @@ DEFUN (debug_bgp_update,
 	return CMD_SUCCESS;
 }
 
+DEFPY (debug_bgp_update_detail,
+       debug_bgp_update_detail_cmd,
+       "[no] debug bgp updates detail",
+       NO_STR
+       DEBUG_STR
+       BGP_STR
+       "BGP updates\n"
+       "Show detailed information about updates\n")
+{
+	if (vty->node == CONFIG_NODE) {
+		if (no)
+			DEBUG_OFF(update, UPDATE_DETAIL);
+		else
+			DEBUG_ON(update, UPDATE_DETAIL);
+	} else {
+		if (no)
+			TERM_DEBUG_OFF(update, UPDATE_DETAIL);
+		else
+			TERM_DEBUG_ON(update, UPDATE_DETAIL);
+		vty_out(vty, "BGP updates detail debugging is on\n");
+	}
+
+	return CMD_SUCCESS;
+}
+
 DEFUN (debug_bgp_update_direct,
        debug_bgp_update_direct_cmd,
        "debug bgp updates <in|out>",
@@ -2304,6 +2329,11 @@ static int bgp_config_write_debug(struct vty *vty)
 						   bgp_debug_update_out_peers);
 	}
 
+	if (CONF_BGP_DEBUG(update, UPDATE_DETAIL)) {
+		vty_out(vty, "debug bgp updates detail\n");
+		write++;
+	}
+
 	if (CONF_BGP_DEBUG(zebra, ZEBRA)) {
 		if (!bgp_debug_zebra_prefixes
 		    || list_isempty(bgp_debug_zebra_prefixes)) {
@@ -2409,6 +2439,8 @@ void bgp_debug_init(void)
 	install_element(CONFIG_NODE, &debug_bgp_keepalive_cmd);
 	install_element(ENABLE_NODE, &debug_bgp_update_cmd);
 	install_element(CONFIG_NODE, &debug_bgp_update_cmd);
+	install_element(ENABLE_NODE, &debug_bgp_update_detail_cmd);
+	install_element(CONFIG_NODE, &debug_bgp_update_detail_cmd);
 	install_element(ENABLE_NODE, &debug_bgp_zebra_cmd);
 	install_element(CONFIG_NODE, &debug_bgp_zebra_cmd);
 	install_element(ENABLE_NODE, &debug_bgp_update_groups_cmd);

--- a/bgpd/bgp_debug.h
+++ b/bgpd/bgp_debug.h
@@ -112,6 +112,7 @@ struct bgp_debug_filter {
 #define BGP_DEBUG_UPDATE_IN           0x01
 #define BGP_DEBUG_UPDATE_OUT          0x02
 #define BGP_DEBUG_UPDATE_PREFIX       0x04
+#define BGP_DEBUG_UPDATE_DETAIL       0x08
 #define BGP_DEBUG_ZEBRA               0x01
 #define BGP_DEBUG_ALLOW_MARTIANS      0x01
 #define BGP_DEBUG_NHT                 0x01

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2349,7 +2349,8 @@ static int bgp_update_receive(struct peer_connection *connection,
 				"%pBP rcvd UPDATE with errors in attr(s)!! Withdrawing route.",
 				peer);
 
-		if (ret && bgp_debug_update(peer, NULL, NULL, 1)) {
+		if (ret && bgp_debug_update(peer, NULL, NULL, 1) &&
+		    BGP_DEBUG(update, UPDATE_DETAIL)) {
 			zlog_debug("%pBP rcvd UPDATE w/ attr: %s", peer,
 				   peer->rcvd_attr_str);
 			peer->rcvd_attr_printed = 1;
@@ -2384,7 +2385,7 @@ static int bgp_update_receive(struct peer_connection *connection,
 		}
 	}
 
-	if (BGP_DEBUG(update, UPDATE_IN))
+	if (BGP_DEBUG(update, UPDATE_IN) && BGP_DEBUG(update, UPDATE_DETAIL))
 		zlog_debug("%pBP rcvd UPDATE wlen %d attrlen %d alen %d", peer,
 			   withdraw_len, attribute_len, update_len);
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3903,11 +3903,14 @@ Debugging
    information on BGP events such as peer connection / disconnection, session
    establishment / teardown, and capability negotiation.
 
-.. clicmd:: debug bgp updates
+.. clicmd:: debug bgp updates [detail]
 
    Enable or disable debugging for BGP updates. This provides information on
    BGP UPDATE messages transmitted and received between local and remote
    instances.
+
+   If ``detail`` is specified, the output will include the full BGP UPDATE with
+   detailed information such as attribute length, withdraw length, and more.
 
 .. clicmd:: debug bgp updates <in|out> [<A.B.C.D|X:X::X:X|WORD> [prefix-list WORD]]
 


### PR DESCRIPTION
When filtering with `debug bgp updates in x.x.x.x prefix-list plist`, we want to filter out unnecessary messages like:

```
127.0.0.1(Unknown) rcvd UPDATE wlen 0 attrlen 20 alen 5
```

Such a line as above will be repeated for all the paths received and it's useless without knowing the prefix (because NLRIs are not parsed yet).

But want to see only relevant ones:

```
127.0.0.1(Unknown) rcvd UPDATE w/ attr: nexthop 127.0.0.1, origin i, path 65002
127.0.0.1(Unknown) rcvd 10.255.255.1/32 IPv4 unicast
```

With `debug bgp updates detail` we can combine this to something like:

```
127.0.0.1(Unknown) rcvd UPDATE w/ attr: nexthop 127.0.0.1, origin i, path 65002
127.0.0.1(Unknown) rcvd UPDATE wlen 0 attrlen 20 alen 5
127.0.0.1(Unknown) rcvd 10.255.255.1/32 IPv4 unicast
```