### PR TITLE
Revert "zebra: Cleanup zrouter.stale_client_list on shutdown"

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -203,7 +203,6 @@ static void sigint(void)
 	rib_update_finish();
 
 	list_delete(&zrouter.client_list);
-	list_delete(&zrouter.stale_client_list);
 
 	/* Indicate that all new dplane work has been enqueued. When that
 	 * work is complete, the dataplane will enqueue an event


### PR DESCRIPTION
This reverts commit 71f7ecb571cd8a87c97ae952db1f1fafa7ef627a.