### PR TITLE
bgpd: Fix memory leak for default-originate with route-map

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -914,8 +914,8 @@ void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)
 						bgp_attr_flush(new_attr);
 						new_attr = bgp_attr_intern(
 							tmp_pi.attr);
-						bgp_attr_flush(tmp_pi.attr);
 					}
+					bgp_attr_flush(tmp_pi.attr);
 					subgroup_announce_reset_nhop(
 						(peer_cap_enhe(peer, afi, safi)
 							 ? AF_INET6


### PR DESCRIPTION
Closes https://github.com/FRRouting/frr/issues/15113