### PR TITLE
lib: fix oper-state memleak

### DIFF
--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -477,7 +477,7 @@ static enum nb_error nb_op_ys_init_node_infos(struct nb_op_yield_state *ys)
 {
 	struct nb_op_node_info *ni;
 	struct lyd_node_inner *inner;
-	struct lyd_node *node;
+	struct lyd_node *node = NULL;
 	enum nb_error ret;
 	uint i, len;
 	char *tmp;
@@ -547,6 +547,8 @@ static enum nb_error nb_op_ys_init_node_infos(struct nb_op_yield_state *ys)
 	darr_foreach_i (ys->node_infos, i) {
 		ret = nb_op_ys_finalize_node_info(ys, i);
 		if (ret != NB_OK) {
+			if (ys->node_infos[0].inner)
+				lyd_free_all(&ys->node_infos[0].inner->node);
 			darr_free(ys->node_infos);
 			return ret;
 		}

--- a/tests/topotests/mgmt_oper/test_simple.py
+++ b/tests/topotests/mgmt_oper/test_simple.py
@@ -92,18 +92,18 @@ def test_oper_simple(tgen):
             'rib[afi-safi-name="frr-routing:ipv4-unicast"][table-id="254"]/route',
             "simple-results/result-ribs-rib-route-nokey.json",
         ),
+        (
+            '/frr-vrf:lib/vrf[name="default"]/frr-zebra:zebra/ribs/'
+            'rib[afi-safi-name="frr-routing:ipv4-unicast"][table-id="254"]/'
+            'route[prefix="1.1.1.0/24"]',
+            "simple-results/result-ribs-rib-route-prefix.json",
+        ),
         # Missing entry
         (
             '/frr-vrf:lib/vrf[name="default"]/frr-zebra:zebra/ribs/'
             'rib[afi-safi-name="frr-routing:ipv4-unicast"][table-id="254"]/'
             'route[prefix="1.1.0.0/24"]',
             "simple-results/result-empty.json",
-        ),
-        (
-            '/frr-vrf:lib/vrf[name="default"]/frr-zebra:zebra/ribs/'
-            'rib[afi-safi-name="frr-routing:ipv4-unicast"][table-id="254"]/'
-            'route[prefix="1.1.1.0/24"]',
-            "simple-results/result-ribs-rib-route-prefix.json",
         ),
         # Leaf reference
         (


### PR DESCRIPTION
Fix memleak when a key-ed query was done for which the key didn't exist.