### PR TITLE
bgpd: add 'default hostname-capability'

### DIFF
--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1896,7 +1896,8 @@ uint16_t bgp_open_capability(struct stream *s, struct peer *peer,
 	}
 
 	/* Hostname capability */
-	if (cmd_hostname_get()) {
+	if (CHECK_FLAG(peer->bgp->flags, BGP_FLAG_HOSTNAME_CAPABILITY) &&
+	    cmd_hostname_get()) {
 		SET_FLAG(peer->cap, PEER_CAP_HOSTNAME_ADV);
 		stream_putc(s, BGP_OPEN_OPT_CAP);
 		rcapp = stream_get_endp(s); /* Ptr to length placeholder */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -519,6 +519,7 @@ struct bgp {
 #define BGP_FLAG_LU_IPV6_EXPLICIT_NULL (1ULL << 34)
 #define BGP_FLAG_SOFT_VERSION_CAPABILITY (1ULL << 35)
 #define BGP_FLAG_ENFORCE_FIRST_AS (1ULL << 36)
+#define BGP_FLAG_HOSTNAME_CAPABILITY	 (1ULL << 36)
 
 	/* BGP default address-families.
 	 * New peers inherit enabled afi/safis from bgp instance.

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1913,6 +1913,11 @@ Configuring Peers
    outputs. It's easier to troubleshoot if you have a number of BGP peers
    and a number of routes to check.
 
+.. clicmd:: bgp default hostname-capability
+
+   This command enables hostname capability advertisement by default
+   for all the neighbors. This is enabled by default.
+
 .. clicmd:: bgp default software-version-capability
 
    This command enables software version capability advertisement by default


### PR DESCRIPTION
The BGP capability option 72 defines the hostname option as per draft-walton-bgp-hostname-capability.
It is a draft, and some equipements do not support this option.

Add the 'bgp default hostname-capability' command to change the behaviour.