### PR TITLE
Pim vxlan issues

### DIFF
--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -43,7 +43,7 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 {
 	struct pim_interface *pim_ifp = NULL;
 
-	if (PIM_DEBUG_PIM_TRACE)
+	if (PIM_DEBUG_PIM_J_P)
 		zlog_debug(
 			"%s: join (S,G)=%pSG rpt=%d wc=%d upstream=%pPAs holdtime=%d from %pPA on %s",
 			__func__, sg, !!(source_flags & PIM_RPT_BIT_MASK),
@@ -115,7 +115,7 @@ static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 {
 	struct pim_interface *pim_ifp = NULL;
 
-	if (PIM_DEBUG_PIM_TRACE)
+	if (PIM_DEBUG_PIM_J_P)
 		zlog_debug(
 			"%s: prune (S,G)=%pSG rpt=%d wc=%d upstream=%pPAs holdtime=%d from %pPA on %s",
 			__func__, sg, source_flags & PIM_RPT_BIT_MASK,
@@ -147,7 +147,7 @@ static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 		 * Received Prune(*,G) messages are processed even if the
 		 * RP in the message does not match RP(G).
 		 */
-		if (PIM_DEBUG_PIM_TRACE)
+		if (PIM_DEBUG_PIM_J_P)
 			zlog_debug("%s: Prune received with RP(%pPAs) for %pSG",
 				   __func__, &sg->src, sg);
 

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -248,7 +248,7 @@ struct rp_info *pim_rp_find_match_group(struct pim_instance *pim,
 	}
 
 	rp_info = rn->info;
-	if (PIM_DEBUG_PIM_TRACE) {
+	if (PIM_DEBUG_PIM_TRACE_DETAIL) {
 		if (best)
 			zlog_debug(
 				"Lookedup(%pFX): prefix_list match %s, rn %p found: %pFX",

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -32,7 +32,7 @@ static pim_addr pim_rpf_find_rpf_addr(struct pim_upstream *up);
 void pim_rpf_set_refresh_time(struct pim_instance *pim)
 {
 	pim->last_route_change_time = pim_time_monotonic_usec();
-	if (PIM_DEBUG_PIM_TRACE)
+	if (PIM_DEBUG_PIM_TRACE_DETAIL)
 		zlog_debug("%s: vrf(%s) New last route change time: %" PRId64,
 			   __func__, pim->vrf->name,
 			   pim->last_route_change_time);

--- a/pimd/pim_vxlan.h
+++ b/pimd/pim_vxlan.h
@@ -49,6 +49,9 @@ struct pim_vxlan_sg {
 	struct interface *iif;
 	/* on a MLAG setup the peerlink is added as a static OIF */
 	struct interface *orig_oif;
+
+	struct event *null_register;
+	uint32_t null_register_sent;
 };
 
 enum pim_vxlan_mlag_flags {


### PR DESCRIPTION
One fix to pim vxlan behavior and several debug changes to make debugging easier on the eyes.

The pim vxlan behavior change is to be more persistent about sending the Null Register on startup.   Effectively one thing that was noticed during internal testing is that the null register is sometimes not received on the RP.  Just sending one at startup time ( when all the other routers/switches are starting up too ) leave you with a situation where the next Null register is 60 seconds out.  PIM VXlan wants to build the SPT tree as fast as possible.  So let's facilitate this.