### PR TITLE
lib: fix coverity issues

### DIFF
--- a/lib/darr.h
+++ b/lib/darr.h
@@ -291,7 +291,7 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  */
 #define darr_ensure_i_mt(A, I, MT)                                             \
 	({                                                                     \
-		assert((int)(I) >= 0 && (int)(I) <= INT_MAX);                  \
+		assert((int)(I) >= 0 && (uint)(I) <= INT_MAX);                 \
 		int _i = (int)(I);                                             \
 		if (_i > darr_maxi(A))                                         \
 			_darr_resize_mt((A), _i + 1, MT);                      \

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -1143,8 +1143,7 @@ LY_ERR yang_lyd_trim_xpath(struct lyd_node **root, const char *xpath)
 	}
 	darr_free(remove);
 
-	if (set)
-		ly_set_free(set, NULL);
+	ly_set_free(set, NULL);
 
 	return LY_SUCCESS;
 #endif

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -1087,7 +1087,7 @@ static int fe_adapter_send_tree_data(struct mgmt_fe_session_ctx *session,
 	uint8_t *buf = NULL;
 	int ret = 0;
 
-	darr_append_n(buf, offsetof(typeof(*msg), result));
+	darr_append_n(buf, sizeof(*msg));
 	msg = (typeof(msg))buf;
 	msg->refer_id = session->session_id;
 	msg->req_id = req_id;


### PR DESCRIPTION
** CID 1575504:  Insecure data handling  (TAINTED_SCALAR) (maybe)
** CID 1575505:  Integer handling issues  (CONSTANT_EXPRESSION_RESULT)
** CID 1575506:  Integer handling issues  (CONSTANT_EXPRESSION_RESULT)
** CID 1575507:  Null pointer dereferences  (REVERSE_INULL)