### PR TITLE
yang: lib: interface MTUs can be larger than uint16

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -1677,7 +1677,7 @@ lib_interface_state_mtu_get_elem(struct nb_cb_get_elem_args *args)
 {
 	const struct interface *ifp = args->list_entry;
 
-	return yang_data_new_uint16(args->xpath, ifp->mtu);
+	return yang_data_new_uint32(args->xpath, ifp->mtu);
 }
 
 /*

--- a/yang/frr-interface.yang
+++ b/yang/frr-interface.yang
@@ -241,17 +241,18 @@ module frr-interface {
     }
 
     leaf mtu {
-      type uint16;
+      type uint32;
       description
-        "The size of the largest IPV4 packet that the interface
-         will send and receive.";
+        "The size of the largest IPV4 packet that the interface will send.
+         Normally this will never be larger than 65535; however, some devices
+         (e.g., vrf) can have larger values";
     }
 
     leaf mtu6 {
       type uint32;
       description
         "The size of the largest IPV6 packet that the interface
-         will send and receive.";
+         will send.";
     }
 
     leaf speed {


### PR DESCRIPTION
Technically changing a leaf from uint16 to uint32 is a NBC change; however, increasing this to uint32 should not break anyone in reality.