### PR TITLE
bgpd: Set correct TTL for the dynamic neighbor peers

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -431,13 +431,25 @@ static void bgp_accept(struct event *thread)
 			/* Dynamic neighbor has been created, let it proceed */
 			peer1->fd = bgp_sock;
 
+			if (bgp_set_socket_ttl(peer1, bgp_sock) < 0) {
+				peer1->last_reset = PEER_DOWN_SOCKET_ERROR;
+				zlog_err("%s: Unable to set min/max TTL on peer %s (dynamic), error received: %s(%d)",
+					 __func__, peer1->host,
+					 safe_strerror(errno), errno);
+				return;
+			}
+
 			/* Set the user configured MSS to TCP socket */
 			if (CHECK_FLAG(peer1->flags, PEER_FLAG_TCP_MSS))
 				sockopt_tcp_mss_set(bgp_sock, peer1->tcp_mss);
 
+			frr_with_privs (&bgpd_privs) {
+				vrf_bind(peer1->bgp->vrf_id, bgp_sock,
+					 bgp_get_bound_name(peer1));
+			}
+			bgp_peer_reg_with_nht(peer1);
 			bgp_fsm_change_status(peer1, Active);
-			EVENT_OFF(
-				peer1->t_start); /* created in peer_create() */
+			EVENT_OFF(peer1->t_start);
 
 			if (peer_active(peer1)) {
 				if (CHECK_FLAG(peer1->flags,


### PR DESCRIPTION
In an EBGP multihop configuration with dynamic neighbors, the TTL configured is not being updated for the socket.

Issue:
Assume the following topology:
Host (Dynamic peer to spine - 192.168.1.100) - Leaf - Spine (192.168.1.1)

When the host establishes a BGP multihop session to the spine, the connection uses the MAXTTL value instead of the configured TTL (in this case, 2). This issue is only observed with dynamic peers.

Logs: look at the TTL is still MAXTTL, instead of “2” configured.

18:13:18.872395 48:b0:2d:0c:58:0b > 48:b0:2d:66:64:6b, ethertype IPv4 (0x0800), length 85: (tos 0xc0, ttl 255, id 32078, offset 0, flags [DF], proto TCP (6), length 71)
192.168.1.100.179 > 192.168.1.1.40967: Flags [P.], cksum 0xfe89 (correct), seq 28406:28425, ack 28424, win 255, options [nop,nop,TS val 4192664793 ecr 2814447051], length 19: BGP
Keepalive Message (4), length: 19

Fix:
Whenever a dynamic peer is created, the socket TTL should be updated with the configured TTL, in this case 2.

19:13:24.894890 48:b0:2d:0c:58:0b > 48:b0:2d:66:64:6b, ethertype IPv4 (0x0800), length 85: (tos 0xc0, ttl 2, id 1131, offset 0, flags [DF], proto TCP (6), length 71)
    192.168.1.100.179 > 192.168.1.1.41937: Flags [P.], cksum 0x7a67 (correct), seq 2046150759:2046150778, ack 4286110599, win 255, options [nop,nop,TS val 4196270815 ecr 2818051226], length 19: BGP
        Keepalive Message (4), length: 19

Testing: UT

UT logs:
2023-12-29T19:13:21.892205+00:00 host bgpd[1591425]: [WWPV7-YSZB5] Dynamic Neighbor 192.168.1.1/32 matches group test listen range 192.168.1.0/30 2023-12-29T19:13:21.892654+00:00 host bgpd[1591425]: [GBPAR-M31QF] 192.168.1.1 Dynamic Neighbor added, group test count 1 2023-12-29T19:13:21.892993+00:00 host bgpd[1591425]: [GPE2H-K9QRE] bgp_set_socket_ttl:  set TxTTL on peer (rtrid 0.0.0.0) socket, err = 2, peer ttl 2

 Conflicts:
	bgpd/bgp_network.c

Ticket: #