### PR TITLE
packaging: Require account validation with pam_unix.so if PAM enabled

### DIFF
--- a/debian/frr.pam
+++ b/debian/frr.pam
@@ -1,4 +1,4 @@
 # Any user may call vtysh but only those belonging to the group frrvty can
 # actually connect to the socket and use the program.
 auth	sufficient	pam_permit.so
-account	sufficient	pam_rootok.so
+account	sufficient	pam_permit.so

--- a/redhat/frr.pam
+++ b/redhat/frr.pam
@@ -4,8 +4,8 @@
 ##### if running frr as root:
 # Only allow root (and possibly wheel) to use this because enable access
 # is unrestricted.
-auth       sufficient   pam_rootok.so
-account    sufficient   pam_rootok.so
+auth	sufficient	pam_permit.so
+account	sufficient	pam_permit.so
 
 # Uncomment the following line to implicitly trust users in the "wheel" group.
 #auth       sufficient   pam_wheel.so trust use_uid


### PR DESCRIPTION
With a current pam_rootok.so, it works only with `root` account. If the user is under `frrvty`, `frr` group, it gets the error:

```
% groups | grep -o -E "frrvty|frr"
frrvty
frr

% vtysh -c 'end'
vtysh_pam: Failed in account validation: Permission denied(6)
```

Checking the logs:

```
vtysh[23930]: pam_rootok(frr:account): root check failed
```

Let's require a valid user, instead of the root user only.