### PR TITLE
lib,vtysh: add per-daemon log file config

### DIFF
--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -152,6 +152,20 @@ Basic Config Commands
    deprecated ``log trap`` command) will be used. The ``no`` form of the command
    disables logging to a file.
 
+.. clicmd:: log daemon DAEMON file [FILENAME [LEVEL]]
+
+   Configure file logging for a single FRR daemon. If you want to log
+   into a file, please specify ``filename`` as in this example:
+
+   ::
+
+      log daemon bgpd file /var/log/frr/bgpd.log informational
+
+   If the optional second argument specifying the logging level is not present,
+   the default logging level (typically debugging, but can be changed using the
+   deprecated ``log trap`` command) will be used. The ``no`` form of the command
+   disables logging to a file for a single FRR daemon.
+
 .. clicmd:: log syslog [LEVEL]
 
    Enable logging output to syslog. If the optional second argument specifying

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -11,3 +11,4 @@
 /grammar_sandbox
 /clippy
 /defun_lex.c
+vtysh_daemons.h

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -540,11 +540,21 @@ EXTRA_DIST += \
 BUILT_SOURCES += \
 	lib/gitversion.h \
 	lib/route_types.h \
+	lib/vtysh_daemons.h \
 	# end
 
 ## force route_types.h
 $(lib_clippy_OBJECTS): lib/route_types.h
 $(lib_libfrr_la_OBJECTS): lib/route_types.h
+
+# force lib_daemons.h
+$(lib_libfrr_la_OBJECTS): lib/vtysh_daemons.h
+
+CLEANFILES += lib/vtysh_daemons.h
+lib/vtysh_daemons.h:
+	@$(MKDIR_P) lib
+	$(PERL) $(top_srcdir)/vtysh/daemons.pl $(vtysh_daemons) > lib/vtysh_daemons.h
+
 
 AM_YFLAGS = -d -Dapi.prefix=@BISON_OPENBRACE@cmd_yy@BISON_CLOSEBRACE@ @BISON_VERBOSE@
 

--- a/vtysh/.gitignore
+++ b/vtysh/.gitignore
@@ -1,6 +1,5 @@
 vtysh
 vtysh_cmd.c
-vtysh_daemons.h
 
 # does not exist anymore - remove 2023-10-04 or so
 extract.pl

--- a/vtysh/subdir.am
+++ b/vtysh/subdir.am
@@ -29,13 +29,3 @@ noinst_HEADERS += \
 vtysh_vtysh_LDADD = lib/libfrr.la $(LIBCAP) $(LIBREADLINE) $(LIBS) $(LIBPAM)
 
 EXTRA_DIST += vtysh/daemons.pl
-
-BUILT_SOURCES += vtysh/vtysh_daemons.h
-
-# force vtysh_daemons.h
-$(vtysh_vtysh_OBJECTS): vtysh/vtysh_daemons.h
-
-CLEANFILES += vtysh/vtysh_daemons.h
-vtysh/vtysh_daemons.h:
-	@$(MKDIR_P) vtysh
-	$(PERL) $(top_srcdir)/vtysh/daemons.pl $(vtysh_daemons) > vtysh/vtysh_daemons.h

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -31,7 +31,7 @@
 #include "network.h"
 #include "filter.h"
 #include "vtysh/vtysh.h"
-#include "vtysh/vtysh_daemons.h"
+#include "lib/vtysh_daemons.h"
 #include "log.h"
 #include "vrf.h"
 #include "libfrr.h"


### PR DESCRIPTION
Add a config that specifies per-daemon log file names. The new clis are like this:

  log daemon <name> file <file> [<level>]
  no log daemon <name> file [file [level]]

We've talked about wanting to do this to support transition to a single integrated config, so this is sort of a "what do we think about this" PR.

Move the handy generated list of daemon names from vtysh/ to lib/, edit the gitignore files to match. 
