### PR TITLE
tests: Fix test_evpn_mh.py to correctly call bridge program

### DIFF
--- a/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
+++ b/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
@@ -264,7 +264,7 @@ def config_bridge(node):
     node.run("ip link set dev bridge type bridge mcast_snooping 0")
     node.run("ip link set dev bridge type bridge vlan_stats_enabled 1")
     node.run("ip link set dev bridge up")
-    node.run("/sbin/bridge vlan add vid 1000 dev bridge")
+    node.run("/sbin/bridge vlan add vid 1000 dev bridge self")
 
 
 def config_vxlan(node, node_ip):


### PR DESCRIPTION
Getting this error:

2024-01-17 19:05:20,688 WARNING: torm11: Router(torm11): proc failed: rc 255 pid 2436134
	args: /usr/bin/nsenter --mount=/proc/2435168/ns/mnt --net=/proc/2435168/ns/net --uts=/proc/2435168/ns/uts -F /bin/bash -c /sbin/bridge vlan add vid 1000 dev bridge
	stdout: RTNETLINK answers: Operation not supported
	stderr: *empty*

As I understand it the correct thing to do here is pass in: bridge vlan add vid 1000 dev bridge self