### PR TITLE
nhrpd: unset noarp flag using a zapi message

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -4520,6 +4520,24 @@ static void zclient_event(enum zclient_event event, struct zclient *zclient)
 	}
 }
 
+enum zclient_send_status zclient_interface_set_arp(struct zclient *client,
+						   struct interface *ifp,
+						   bool arp_enable)
+{
+	struct stream *s;
+
+	s = client->obuf;
+	stream_reset(s);
+
+	zclient_create_header(s, ZEBRA_INTERFACE_SET_ARP, ifp->vrf->vrf_id);
+
+	stream_putl(s, ifp->ifindex);
+	stream_putc(s, arp_enable);
+
+	stream_putw_at(s, 0, stream_get_endp(s));
+	return zclient_send_message(client);
+}
+
 enum zclient_send_status zclient_interface_set_master(struct zclient *client,
 						      struct interface *master,
 						      struct interface *slave)

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -98,6 +98,7 @@ typedef enum {
 	ZEBRA_INTERFACE_UP,
 	ZEBRA_INTERFACE_DOWN,
 	ZEBRA_INTERFACE_SET_MASTER,
+	ZEBRA_INTERFACE_SET_ARP,
 	ZEBRA_INTERFACE_SET_PROTODOWN,
 	ZEBRA_ROUTE_ADD,
 	ZEBRA_ROUTE_DELETE,
@@ -1036,6 +1037,9 @@ extern int zclient_read_header(struct stream *s, int sock, uint16_t *size,
  */
 extern bool zapi_parse_header(struct stream *zmsg, struct zmsghdr *hdr);
 
+extern enum zclient_send_status zclient_interface_set_arp(struct zclient *client,
+							  struct interface *ifp,
+							  bool arp_enable);
 extern enum zclient_send_status
 zclient_interface_set_master(struct zclient *client, struct interface *master,
 			     struct interface *slave);

--- a/nhrpd/linux.c
+++ b/nhrpd/linux.c
@@ -8,7 +8,6 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <linux/if_packet.h>
-#include <sys/ioctl.h>
 
 #include "nhrp_protocol.h"
 #include "os.h"
@@ -98,25 +97,6 @@ int os_recvmsg(uint8_t *buf, size_t *len, int *ifindex, uint8_t *addr,
 	return 0;
 }
 
-static int linux_configure_arp(const char *iface, int on)
-{
-	struct ifreq ifr;
-
-	strlcpy(ifr.ifr_name, iface, IFNAMSIZ);
-	if (ioctl(nhrp_socket_fd, SIOCGIFFLAGS, &ifr))
-		return -1;
-
-	if (on)
-		ifr.ifr_flags &= ~IFF_NOARP;
-	else
-		ifr.ifr_flags |= IFF_NOARP;
-
-	if (ioctl(nhrp_socket_fd, SIOCSIFFLAGS, &ifr))
-		return -1;
-
-	return 0;
-}
-
 static int linux_icmp_redirect_off(const char *iface)
 {
 	char fname[PATH_MAX];
@@ -144,7 +124,6 @@ int os_configure_dmvpn(unsigned int ifindex, const char *ifname, int af)
 		ret |= linux_icmp_redirect_off(ifname);
 		break;
 	}
-	ret |= linux_configure_arp(ifname, 1);
 
 	return ret;
 }

--- a/nhrpd/netlink.h
+++ b/nhrpd/netlink.h
@@ -11,7 +11,6 @@
 extern int netlink_nflog_group;
 extern int netlink_mcast_nflog_group;
 
-int netlink_configure_arp(unsigned int ifindex, int pf);
 void netlink_update_binding(struct interface *ifp, union sockunion *proto,
 			    union sockunion *nbma);
 void netlink_set_nflog_group(int nlgroup);

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -351,6 +351,7 @@ void nhrp_interface_update(struct interface *ifp)
 		if (!if_ad->configured) {
 			os_configure_dmvpn(ifp->ifindex, ifp->name,
 					   afi2family(afi));
+			nhrp_interface_update_arp(ifp, true);
 			nhrp_send_zebra_configure_arp(ifp, afi2family(afi));
 			if_ad->configured = 1;
 			nhrp_interface_update_address(ifp, afi, 1);

--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -452,6 +452,12 @@ int nhrp_send_zebra_gre_request(struct interface *ifp)
 	return zclient_send_zebra_gre_request(zclient, ifp);
 }
 
+void nhrp_interface_update_arp(struct interface *ifp, bool arp_enable)
+{
+	zclient_interface_set_arp(zclient, ifp, arp_enable);
+}
+
+
 void nhrp_zebra_terminate(void)
 {
 	zclient_register_neigh(zclient, VRF_DEFAULT, AFI_IP, false);

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -362,6 +362,7 @@ int sock_open_unix(const char *path);
 
 void nhrp_interface_init(void);
 void nhrp_interface_update(struct interface *ifp);
+void nhrp_interface_update_arp(struct interface *ifp, bool arp_enable);
 void nhrp_interface_update_mtu(struct interface *ifp, afi_t afi);
 void nhrp_interface_update_nbma(struct interface *ifp,
 				struct nhrp_gre_info *gre_info);

--- a/tests/topotests/nhrp_topo/test_nhrp_topo.py
+++ b/tests/topotests/nhrp_topo/test_nhrp_topo.py
@@ -182,6 +182,27 @@ def test_protocols_convergence():
         assertmsg = '"{}" JSON output mismatches'.format(router.name)
         assert result is None, assertmsg
 
+    # check that the NOARP flag is removed from rX-gre0 interfaces
+    for rname, router in router_list.items():
+        if rname == "r3":
+            continue
+
+        expected = {
+            "{}-gre0".format(rname): {
+                "flags": "<UP,RUNNING>",
+            }
+        }
+        test_func = partial(
+            topotest.router_json_cmp,
+            router,
+            "show interface {}-gre0 json".format(rname),
+            expected,
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
+
+        assertmsg = '"{}-gre0 interface flags incorrect'.format(router.name)
+        assert result is None, assertmsg
+
     for rname, router in router_list.items():
         if rname == "r3":
             continue

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -3662,6 +3662,27 @@ DEFUN (show_interface_desc_vrf_all,
 	return CMD_SUCCESS;
 }
 
+void if_arp(struct interface *ifp, bool enable)
+{
+	int ret;
+
+	if (!CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE))
+		return;
+
+	if (enable)
+		ret = if_unset_flags(ifp, IFF_NOARP);
+	else
+		ret = if_set_flags(ifp, IFF_NOARP);
+
+	if (ret < 0) {
+		zlog_debug("Can't %sset noarp flag on interface %s",
+			   enable ? "" : "un", ifp->name);
+		return;
+	}
+
+	if_refresh(ifp);
+}
+
 int if_multicast_set(struct interface *ifp)
 {
 	struct zebra_if *if_data;

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -314,6 +314,7 @@ extern int if_ipv6_address_install(struct interface *ifp, struct prefix *prefix,
 extern int if_ip_address_uinstall(struct interface *ifp, struct prefix *prefix);
 extern int if_shutdown(struct interface *ifp);
 extern int if_no_shutdown(struct interface *ifp);
+extern void if_arp(struct interface *ifp, bool enable);
 extern int if_multicast_set(struct interface *ifp);
 extern int if_multicast_unset(struct interface *ifp);
 extern int if_linkdetect(struct interface *ifp, bool detect);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -3124,6 +3124,28 @@ stream_failure:
 }
 
 
+static void zread_interface_set_arp(ZAPI_HANDLER_ARGS)
+{
+	struct stream *s = msg;
+	struct interface *ifp;
+	bool arp_enable;
+	vrf_id_t vrf_id = zvrf->vrf->vrf_id;
+	int ifindex;
+
+	STREAM_GETL(s, ifindex);
+	STREAM_GETC(s, arp_enable);
+	ifp = if_lookup_by_index(ifindex, vrf_id);
+
+	if (!ifp)
+		return;
+
+	if_arp(ifp, arp_enable);
+
+stream_failure:
+	return;
+}
+
+
 static void zread_vrf_label(ZAPI_HANDLER_ARGS)
 {
 	struct interface *ifp;
@@ -3905,6 +3927,7 @@ void (*const zserv_handlers[])(ZAPI_HANDLER_ARGS) = {
 	[ZEBRA_REMOTE_MACIP_DEL] = zebra_vxlan_remote_macip_del,
 	[ZEBRA_DUPLICATE_ADDR_DETECTION] = zebra_vxlan_dup_addr_detection,
 	[ZEBRA_INTERFACE_SET_MASTER] = zread_interface_set_master,
+	[ZEBRA_INTERFACE_SET_ARP] = zread_interface_set_arp,
 	[ZEBRA_PW_ADD] = zread_pseudowire,
 	[ZEBRA_PW_DELETE] = zread_pseudowire,
 	[ZEBRA_PW_SET] = zread_pseudowire,


### PR DESCRIPTION
Unset the IFF_NOARP interface flag using a ZAPI message. It removes the dependency to if.h headers.
