### PR TITLE
sharpd: Fix coverity issues

### DIFF
--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -1018,7 +1018,7 @@ static int sharp_zebra_process_neigh(ZAPI_CALLBACK_ARGS)
 	}
 
 	zlog_debug("Received: %s %pSU dev %s lladr %pSU",
-		   (cmd = ZEBRA_NEIGH_ADDED) ? "NEW" : "DEL", &addr, ifp->name,
+		   (cmd == ZEBRA_NEIGH_ADDED) ? "NEW" : "DEL", &addr, ifp->name,
 		   &lladdr);
 
 	return 0;


### PR DESCRIPTION
New commits had an assignment instead of a comparison option.  Coverity wisely found it.