### PR TITLE
pbrd: Fix PBR handling for last rule deletion

### DIFF
--- a/pbrd/pbr_nht.c
+++ b/pbrd/pbr_nht.c
@@ -650,7 +650,15 @@ static void pbr_nht_release_individual_nexthop(struct pbr_map_sequence *pbrms)
 
 void pbr_nht_delete_individual_nexthop(struct pbr_map_sequence *pbrms)
 {
-	pbr_map_delete_nexthops(pbrms);
+	struct pbr_map *pbrm = pbrms->parent;
+
+	/* The idea here is to send a delete command to zebra only once,
+	 * and set 'valid' and 'installed' to false only when the last
+	 * rule is being deleted. In other words, the pbr common should be
+	 * updated only when the last rule is being updated or deleted.
+	 */
+	if (pbrm->seqnumbers->count == 1)
+		pbr_map_delete_nexthops(pbrms);
 
 	pbr_nht_release_individual_nexthop(pbrms);
 }


### PR DESCRIPTION
Issue:
Previously, the PBR common was updated for every rule update or deletion

example:
let say we have three rule 11, 12, 13 and if we are removing rule 12. in the current code we are making the entire map "valid" to false.

pbr-map MAP1 seq 11
match src-ip 90.1.1.2/32
set nexthop 20.1.1.2 swp1

pbr-map MAP1 seq 12
match src-ip 90.1.1.3/32
set nexthop 20.1.1.2 swp1

pbr-map MAP1 seq 13
match src-ip 90.1.1.4/32
set nexthop 20.1.1.2 swp1

no pbr-map MAP1 seq 12 ==> turns whole map valid to false.

r1(config)# end
r1# show pbr map
  pbr-map MAP1 valid: no
    Seq: 11 rule: 310
        Installed: yes Reason: Valid
        SRC IP Match: 90.1.1.2/32
        nexthop 20.1.1.2 swp1
          Installed: yes Tableid: 10002
    Seq: 13 rule: 312
        Installed: yes Reason: Valid
        SRC IP Match: 90.1.1.4/32
        nexthop 20.1.1.2 swp1
          Installed: yes Tableid: 10004

Fix:
Now, the PBR common will only be updated when the last rule is being deleted. This change ensures that we only send a delete request to Zebra once, and only set the valid and installed flags to false when the last rule is deleted. This optimizes the handling of PBR rules and reduces unnecessary interactions with Zebra

Testing: UT in MR notes

Ticket: #

Signed-off-by: Rajesh Varatharaj <rvaratharaj@nvidia.com>