### PR TITLE
bgpd: Fix format overflow for graceful-restart debug logs

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -2720,7 +2720,7 @@ int bgp_gr_lookup_n_update_all_peer(struct bgp *bgp,
 	return BGP_GR_SUCCESS;
 }
 
-int bgp_gr_update_all(struct bgp *bgp, int global_gr_cmd)
+int bgp_gr_update_all(struct bgp *bgp, enum global_gr_command global_gr_cmd)
 {
 	enum global_mode global_new_state = GLOBAL_INVALID;
 	enum global_mode global_old_state = GLOBAL_INVALID;
@@ -2874,7 +2874,8 @@ enum peer_mode bgp_peer_gr_mode_get(struct peer *peer)
 	return peer->peer_gr_present_state;
 }
 
-int bgp_neighbor_graceful_restart(struct peer *peer, int peer_gr_cmd)
+int bgp_neighbor_graceful_restart(struct peer *peer,
+				  enum peer_gr_command peer_gr_cmd)
 {
 	enum peer_mode peer_new_state = PEER_INVALID;
 	enum peer_mode peer_old_state = PEER_INVALID;
@@ -2933,8 +2934,8 @@ int bgp_neighbor_graceful_restart(struct peer *peer, int peer_gr_cmd)
 	return result;
 }
 
-unsigned int bgp_peer_gr_action(struct peer *peer, int old_peer_state,
-				int new_peer_state)
+unsigned int bgp_peer_gr_action(struct peer *peer, enum peer_mode old_peer_state,
+				enum peer_mode new_peer_state)
 {
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 		zlog_debug(
@@ -2942,7 +2943,7 @@ unsigned int bgp_peer_gr_action(struct peer *peer, int old_peer_state,
 			__func__, print_peer_gr_mode(old_peer_state),
 			print_peer_gr_mode(new_peer_state));
 
-	int bgp_gr_global_mode = GLOBAL_INVALID;
+	enum global_mode bgp_gr_global_mode = GLOBAL_INVALID;
 	unsigned int ret = BGP_GR_FAILURE;
 
 	if (old_peer_state == new_peer_state) {
@@ -2974,10 +2975,10 @@ unsigned int bgp_peer_gr_action(struct peer *peer, int old_peer_state,
 
 		BGP_PEER_GR_GLOBAL_INHERIT_UNSET(peer);
 
-		if (new_peer_state == bgp_gr_global_mode) {
-			/*This is incremental updates i.e no tear down
-			 *of the existing session
-			 *as the peer is already working in the same mode.
+		if ((int)new_peer_state == (int)bgp_gr_global_mode) {
+			/* This is incremental updates i.e no tear down
+			 * of the existing session
+			 * as the peer is already working in the same mode.
 			 */
 			ret = BGP_GR_SUCCESS;
 		} else {
@@ -3004,8 +3005,7 @@ unsigned int bgp_peer_gr_action(struct peer *peer, int old_peer_state,
 
 		BGP_PEER_GR_GLOBAL_INHERIT_SET(peer);
 
-		if (old_peer_state == bgp_gr_global_mode) {
-
+		if ((int)old_peer_state == (int)bgp_gr_global_mode) {
 			/* This is incremental updates
 			 *i.e no tear down of the existing session
 			 *as the peer is already working in the same mode.

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -143,10 +143,11 @@ extern void bgp_adjust_routeadv(struct peer *);
 DECLARE_HOOK(peer_backward_transition, (struct peer *peer), (peer));
 DECLARE_HOOK(peer_established, (struct peer *peer), (peer));
 
-int bgp_gr_update_all(struct bgp *bgp, int global_gr_cmd);
-int bgp_neighbor_graceful_restart(struct peer *peer, int peer_gr_cmd);
-unsigned int bgp_peer_gr_action(struct peer *peer,
-		int old_peer_state, int new_peer_state);
+int bgp_gr_update_all(struct bgp *bgp, enum global_gr_command global_gr_cmd);
+int bgp_neighbor_graceful_restart(struct peer *peer,
+				  enum peer_gr_command peer_gr_cmd);
+unsigned int bgp_peer_gr_action(struct peer *peer, enum peer_mode old_peer_state,
+				enum peer_mode new_peer_state);
 void bgp_peer_move_to_gr_mode(struct peer *peer, int new_state);
 unsigned int bgp_peer_gr_helper_enable(struct peer *peer);
 unsigned int bgp_peer_gr_enable(struct peer *peer);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1051,7 +1051,8 @@ enum peer_gr_command {
 	NO_PEER_HELPER_CMD
 };
 
-typedef unsigned int  (*bgp_peer_gr_action_ptr)(struct peer *, int, int);
+typedef unsigned int (*bgp_peer_gr_action_ptr)(struct peer *, enum peer_mode,
+					       enum peer_mode);
 
 struct bgp_peer_gr {
 	enum peer_mode next_state;


### PR DESCRIPTION
Use enum instead of int, and make the compiler happy when using -format-overflow.

Without this patch, it does not compile e.g. on Debian12.