### PR TITLE
pceplib: fix compilation error

### DIFF
--- a/pceplib/test/pcep_utils_counters_test.c
+++ b/pceplib/test/pcep_utils_counters_test.c
@@ -113,7 +113,7 @@ void test_create_subgroup_counter()
 	CU_ASSERT_FALSE(create_subgroup_counter(NULL, counter_id, counter_name,
 						counter_name_json));
 	CU_ASSERT_FALSE(create_subgroup_counter(subgroup, counter_id + 1,
-						counter_name));
+						counter_name, counter_name_json));
 	CU_ASSERT_FALSE(
 		create_subgroup_counter(subgroup, counter_id, NULL, NULL));
 	CU_ASSERT_EQUAL(subgroup->num_counters, 0);


### PR DESCRIPTION
The following compilation error happens, with pcep test files.

> In file included from pceplib/test/pcep_utils_counters_test.c:31:
> pceplib/test/pcep_utils_counters_test.c: In function 'test_create_subgroup_counter':
> pceplib/test/pcep_utils_counters_test.c:127:25: error: too few arguments to function 'create_subgroup_counter'
>   127 |         CU_ASSERT_FALSE(create_subgroup_counter(subgroup, counter_id + 1,
>       |                         ^~~~~~~~~~~~~~~~~~~~~~~
> In file included from pceplib/test/pcep_utils_counters_test.c:33:
> ./pceplib/pcep_utils_counters.h:163:6: note: declared here
>   163 | bool create_subgroup_counter(struct counters_subgroup *subgroup,
>       |      ^~~~~~~~~~~~~~~~~~~~~~~
> Makefile:10948: recipe for target 'pceplib/test/pceplib_test_pcep_utils_tests-pcep_utils_counters_test.o' failed
> make[3]: *** [pceplib/test/pceplib_test_pcep_utils_tests-pcep_utils_counters_test.o] Error 1
> make[3]: *** Waiting for unfinished jobs....

There is a missing parameter.

Fixes: 09047d2bf614 ("pceplib: add json string option to subgroup counter")