### PR TITLE
zebra: Fix opaque memory leak in rare situation

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2693,6 +2693,7 @@ static void early_route_memory_free(struct zebra_early_route *ere)
 	if (ere->re_nhe)
 		zebra_nhg_free(ere->re_nhe);
 
+	zapi_re_opaque_free(ere->re->opaque);
 	XFREE(MTYPE_RE, ere->re);
 	XFREE(MTYPE_WQ_WRAPPER, ere);
 }


### PR DESCRIPTION
Fix this:
*********************************************************************************** Address Sanitizer Error detected in zebra_opaque.test_zebra_opaque/r3.asan.zebra.11099

================================================================= ==11099==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 66 byte(s) in 1 object(s) allocated from:
    #0 0x7f527fc06b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f527f5e852b in qmalloc lib/memory.c:100
    #2 0x56418d20832d in zread_route_add zebra/zapi_msg.c:2125
    #3 0x56418d215d08 in zserv_handle_commands zebra/zapi_msg.c:4011
    #4 0x56418d32ab5b in zserv_process_messages zebra/zserv.c:520
    #5 0x7f527f6938d3 in event_call lib/event.c:2003
    #6 0x7f527f5cb692 in frr_run lib/libfrr.c:1218
    #7 0x56418d1c3336 in main zebra/main.c:508
    #8 0x7f527e656c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)

SUMMARY: AddressSanitizer: 66 byte(s) leaked in 1 allocation(s). ***********************************************************************************

Code inspection leads to some code paths where the opaque data was not freed up.