### PR TITLE
lib: add log immediate-mode to running config output

### DIFF
--- a/lib/log_vty.c
+++ b/lib/log_vty.c
@@ -902,6 +902,8 @@ void log_config_write(struct vty *vty)
 		vty_out(vty, "no log error-category\n");
 	if (!zlog_get_prefix_xid())
 		vty_out(vty, "no log unique-id\n");
+	if (zlog_get_immediate_mode())
+		vty_out(vty, "log immediate-mode\n");
 
 	if (logmsgs_with_persist_bt) {
 		struct xrefdata *xrd;

--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -84,7 +84,7 @@ static struct zlog_targets_head zlog_targets;
 /* Global setting for buffered vs immediate output. The default is
  * per-pthread buffering.
  */
-static bool default_immediate;
+static bool zlog_default_immediate;
 
 /* cf. zlog.h for additional comments on this struct.
  *
@@ -445,7 +445,7 @@ static void vzlog_tls(struct zlog_tls *zlog_tls, const struct xref_logmsg *xref,
 	struct zlog_msg *msg;
 	char *buf;
 	bool ignoremsg = true;
-	bool immediate = default_immediate;
+	bool immediate = zlog_default_immediate;
 
 	/* avoid further processing cost if no target wants this message */
 	rcu_read_lock();
@@ -966,7 +966,12 @@ struct zlog_target *zlog_target_replace(struct zlog_target *oldzt,
  */
 void zlog_set_immediate(bool set_p)
 {
-	default_immediate = set_p;
+	zlog_default_immediate = set_p;
+}
+
+bool zlog_get_immediate_mode(void)
+{
+	return zlog_default_immediate;
 }
 
 /* common init */

--- a/lib/zlog.h
+++ b/lib/zlog.h
@@ -276,6 +276,7 @@ extern void zlog_tls_buffer_fini(void);
 
 /* Enable or disable 'immediate' output - default is to buffer messages. */
 extern void zlog_set_immediate(bool set_p);
+bool zlog_get_immediate_mode(void);
 
 extern const char *zlog_priority_str(int priority);
 


### PR DESCRIPTION
The immediate-mode log lib config wasn't in the running config output, but ... it should be, so add it.
