### PR TITLE
bgpd: fix NULL argument warning

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -2838,7 +2838,7 @@ const char *print_peer_gr_cmd(enum peer_gr_command pr_gr_cmd)
 
 const char *print_global_gr_mode(enum global_mode gl_mode)
 {
-	const char *global_gr_mode = NULL;
+	const char *global_gr_mode = "???";
 
 	switch (gl_mode) {
 	case GLOBAL_HELPER:


### PR DESCRIPTION
gcc 12.2.0 complains `error: ‘%s’ directive argument is null`, even though all enum values are covered with a string.  Let's just go with a `???` default.