### PR TITLE
topotests: fix snmptrap log OID parsing

### DIFF
--- a/tests/topotests/bgp_snmp_bgp4v2mib/test_bgp_snmp_bgp4v2mib.py
+++ b/tests/topotests/bgp_snmp_bgp4v2mib/test_bgp_snmp_bgp4v2mib.py
@@ -276,7 +276,7 @@ def test_bgp_snmp_bgp4v2():
         pytest.skip(error_msg)
 
     rr.vtysh_cmd("clear bgp *")
-    _, result = topotest.run_and_expect(_snmptrap_ipv4, True, count=2, wait=10)
+    _, result = topotest.run_and_expect(_snmptrap_ipv4, True, count=30, wait=1)
     assertmsg = "Can't fetch SNMP trap for ipv4"
     assert result, assertmsg
 
@@ -308,8 +308,7 @@ def test_bgp_snmp_bgp4v2():
     r2.vtysh_cmd("conf\nbgp snmp traps bgp4-mibv2")
     r2.vtysh_cmd("conf\nno bgp snmp traps rfc4273")
     rr.vtysh_cmd("clear bgp *")
-    sleep(30)
-    _, result = topotest.run_and_expect(_snmptrap_ipv6, True, count=2, wait=10)
+    _, result = topotest.run_and_expect(_snmptrap_ipv6, True, count=60, wait=1)
     assertmsg = "Can't fetch SNMP trap for ipv6"
     assert result, assertmsg
 

--- a/tests/topotests/lib/snmptest.py
+++ b/tests/topotests/lib/snmptest.py
@@ -213,14 +213,15 @@ class SnmpTester(object):
         return False
 
     def get_notif_bgp4(self, output_file):
+        notifs = []
         notif_list = []
         whitecleanfile = re.sub("\t", " ", output_file)
         results = whitecleanfile.strip().split("\n")
 
-        # don't consider SNMP additional messages
-        notifs_first = [elem for elem in results if not ("SNMP" in elem)]
-        # don't consider additional application messages
-        notifs = [elem for index, elem in enumerate(notifs_first) if index % 2 != 0]
+        # don't consider additional SNMP or application messages
+        for result in results:
+            if re.search(r"(\.([0-9]+))+\s", result):
+                notifs.append(result)
 
         oid_v4 = r"1\.3\.6\.1\.2\.1\.15"
         for one_notif in notifs:
@@ -232,14 +233,15 @@ class SnmpTester(object):
         return notif_list
 
     def get_notif_bgp4v2(self, output_file):
+        notifs = []
         notif_list = []
         whitecleanfile = re.sub("\t", " ", output_file)
         results = whitecleanfile.strip().split("\n")
 
-        # don't consider SNMP additional messages
-        notifs_first = [elem for elem in results if not ("SNMP" in elem)]
-        # don't consider additional application messages
-        notifs = [elem for index, elem in enumerate(results) if index % 2 != 0]
+        # don't consider additional SNMP or application messages
+        for result in results:
+            if re.search(r"(\.([0-9]+))+\s", result):
+                notifs.append(result)
 
         oid_v6 = r"1\.3\.6\.1\.3\.5\.1"
         for one_notif in notifs:


### PR DESCRIPTION
Fixes failures on the SNMP parsing in the traps on `bgp_snmp_bgp4v2mib` topotest. The original code skipped every 2nd request which will cause intermittent failures based on timing and how many SNMP traps are produced.