### PR TITLE
sharpd: Add ability to turn off watching of redistribution

### DIFF
--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -54,7 +54,8 @@ DEFPY(watch_neighbor, watch_neighbor_cmd,
 
 
 DEFPY(watch_redistribute, watch_redistribute_cmd,
-      "sharp watch [vrf NAME$vrf_name] redistribute " FRR_REDIST_STR_SHARPD,
+      "[no] sharp watch [vrf NAME$vrf_name] redistribute " FRR_REDIST_STR_SHARPD,
+      NO_STR
       "Sharp routing Protocol\n"
       "Watch for changes\n"
       "The vrf we would like to watch if non-default\n"
@@ -75,7 +76,7 @@ DEFPY(watch_redistribute, watch_redistribute_cmd,
 	}
 
 	source = proto_redistnum(AFI_IP, argv[argc-1]->text);
-	sharp_redistribute_vrf(vrf, source);
+	sharp_redistribute_vrf(vrf, source, !no);
 
 	return CMD_SUCCESS;
 }

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -704,10 +704,11 @@ static int sharp_redistribute_route(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-void sharp_redistribute_vrf(struct vrf *vrf, int type)
+void sharp_redistribute_vrf(struct vrf *vrf, int type, bool turn_on)
 {
-	zebra_redistribute_send(ZEBRA_REDISTRIBUTE_ADD, zclient, AFI_IP, type,
-				0, vrf->vrf_id);
+	zebra_redistribute_send(turn_on ? ZEBRA_REDISTRIBUTE_ADD
+					: ZEBRA_REDISTRIBUTE_DELETE,
+				zclient, AFI_IP, type, 0, vrf->vrf_id);
 }
 
 static zclient_handler *const sharp_opaque_handlers[] = {

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -55,7 +55,7 @@ extern void sharp_zebra_send_arp(const struct interface *ifp,
 /* Register Link State Opaque messages */
 extern void sharp_zebra_register_te(void);
 
-extern void sharp_redistribute_vrf(struct vrf *vrf, int source);
+extern void sharp_redistribute_vrf(struct vrf *vrf, int source, bool turn_on);
 
 extern int sharp_zebra_srv6_manager_get_locator_chunk(const char *lname);
 extern int sharp_zebra_srv6_manager_release_locator_chunk(const char *lname);


### PR DESCRIPTION
Wanted to do some testing of redistribute without having to restart sharpd over and over.  Added ability to turn off the `sharp watch redistribute XX` functionality.