### PR TITLE
zebra, build: disable irdp by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -789,7 +789,7 @@ AC_ARG_ENABLE([realms],
 AC_ARG_ENABLE([rtadv],
   AS_HELP_STRING([--disable-rtadv], [disable IPV6 router advertisement feature]))
 AC_ARG_ENABLE([irdp],
-  AS_HELP_STRING([--disable-irdp], [disable IRDP server support in zebra (enabled by default if supported)]))
+  AS_HELP_STRING([--enable-irdp], [enable IRDP server support in zebra]))
 AC_ARG_ENABLE([capabilities],
   AS_HELP_STRING([--disable-capabilities], [disable using POSIX capabilities]))
 AC_ARG_ENABLE([gcc_ultra_verbose],
@@ -2332,6 +2332,9 @@ yes)
   $IRDP || AC_MSG_ERROR(['IRDP requires in_pktinfo at the moment!'])
   ;;
 no)
+  IRDP=false
+  ;;
+*)
   IRDP=false
   ;;
 esac

--- a/debian/frr.install
+++ b/debian/frr.install
@@ -13,7 +13,6 @@ usr/lib/*/frr/modules/bgpd_bmp.so
 usr/lib/*/frr/modules/dplane_fpm_nl.so
 usr/lib/*/frr/modules/zebra_cumulus_mlag.so
 usr/lib/*/frr/modules/zebra_fpm.so
-usr/lib/*/frr/modules/zebra_irdp.so
 usr/lib/*/frr/modules/pathd_pcep.so
 usr/lib/frr/*.sh
 usr/lib/frr/*d

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -234,10 +234,9 @@ options from the list below.
    assigned to the realm. See the tc man page.  This option is currently not
    compatible with the usage of nexthop groups in the linux kernel itself.
 
-.. option:: --disable-irdp
+.. option:: --enable-irdp
 
-   Disable IRDP server support.  This is enabled by default if we have
-   both `struct in_pktinfo` and `struct icmphdr` available to us.
+   Enable IRDP server support. This is deprecated.
 
 .. option:: --disable-rtadv
 

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -322,7 +322,6 @@ routing state through standard SNMP MIBs.
     --localstatedir=%{_localstatedir} \
     --disable-static \
     --disable-werror \
-    --enable-irdp \
 %if %{with_multipath}
     --enable-multipath=%{with_multipath} \
 %endif
@@ -717,7 +716,6 @@ fi
 %endif
 %{_libdir}/frr/modules/zebra_cumulus_mlag.so
 %{_libdir}/frr/modules/dplane_fpm_nl.so
-%{_libdir}/frr/modules/zebra_irdp.so
 %{_libdir}/frr/modules/bgpd_bmp.so
 %{_libdir}/libfrr_pb.so*
 %{_libdir}/libfrrfpm_pb.so*

--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -369,7 +369,6 @@ parts:
             - --enable-ospfapi=yes
             - --enable-multipath=64
             - --enable-rtadv
-            - --enable-irdp
             - --enable-user=root
             - --enable-group=root
             - --enable-pimd


### PR DESCRIPTION
IRDP client (rdisc) was deleted from iputils more than 2 years ago. It's time to drop IRDP, but first let's stop building and including it in the packages by default to see if anyone will be complaining.