### PR TITLE
bgpd: Some memory optimizations

### DIFF
--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -159,6 +159,45 @@ struct attr {
 	/* Path origin attribute */
 	uint8_t origin;
 
+	/* ES info */
+	uint8_t es_flags;
+	/* Path is not "locally-active" on the advertising VTEP. This is
+	 * translated into an ARP-ND ECOM.
+	 */
+#define ATTR_ES_PROXY_ADVERT (1 << 0)
+	/* Destination ES is present locally. This flag is set on local
+	 * paths and sync paths
+	 */
+#define ATTR_ES_IS_LOCAL (1 << 1)
+	/* There are one or more non-best paths from ES peers. Note that
+	 * this flag is only set on the local MAC-IP paths in the VNI
+	 * route table (not set in the global routing table). And only
+	 * non-proxy advertisements from an ES peer can result in this
+	 * flag being set.
+	 */
+#define ATTR_ES_PEER_ACTIVE (1 << 2)
+	/* There are one or more non-best proxy paths from ES peers */
+#define ATTR_ES_PEER_PROXY (1 << 3)
+	/* An ES peer has router bit set - only applicable if
+	 * ATTR_ES_PEER_ACTIVE is set
+	 */
+#define ATTR_ES_PEER_ROUTER (1 << 4)
+
+	/* These two flags are only set on L3 routes installed in a
+	 * VRF as a result of EVPN MAC-IP route
+	 * XXX - while splitting up per-family attrs these need to be
+	 * classified as non-EVPN
+	 */
+#define ATTR_ES_L3_NHG_USE    (1 << 5)
+#define ATTR_ES_L3_NHG_ACTIVE (1 << 6)
+#define ATTR_ES_L3_NHG	      (ATTR_ES_L3_NHG_USE | ATTR_ES_L3_NHG_ACTIVE)
+
+	/* NA router flag (R-bit) support in EVPN */
+	uint8_t router_flag;
+
+	/* Distance as applied by Route map */
+	uint8_t distance;
+
 	/* PMSI tunnel type (RFC 6514). */
 	enum pta_type pmsi_tnl_type;
 
@@ -214,42 +253,6 @@ struct attr {
 	/* Flag for default gateway extended community in EVPN */
 	uint8_t default_gw;
 
-	/* NA router flag (R-bit) support in EVPN */
-	uint8_t router_flag;
-
-	/* ES info */
-	uint8_t es_flags;
-	/* Path is not "locally-active" on the advertising VTEP. This is
-	 * translated into an ARP-ND ECOM.
-	 */
-#define ATTR_ES_PROXY_ADVERT (1 << 0)
-	/* Destination ES is present locally. This flag is set on local
-	 * paths and sync paths
-	 */
-#define ATTR_ES_IS_LOCAL (1 << 1)
-	/* There are one or more non-best paths from ES peers. Note that
-	 * this flag is only set on the local MAC-IP paths in the VNI
-	 * route table (not set in the global routing table). And only
-	 * non-proxy advertisements from an ES peer can result in this
-	 * flag being set.
-	 */
-#define ATTR_ES_PEER_ACTIVE (1 << 2)
-	/* There are one or more non-best proxy paths from ES peers */
-#define ATTR_ES_PEER_PROXY (1 << 3)
-	/* An ES peer has router bit set - only applicable if
-	 * ATTR_ES_PEER_ACTIVE is set
-	 */
-#define ATTR_ES_PEER_ROUTER (1 << 4)
-
-	/* These two flags are only set on L3 routes installed in a
-	 * VRF as a result of EVPN MAC-IP route
-	 * XXX - while splitting up per-family attrs these need to be
-	 * classified as non-EVPN
-	 */
-#define ATTR_ES_L3_NHG_USE (1 << 5)
-#define ATTR_ES_L3_NHG_ACTIVE (1 << 6)
-#define ATTR_ES_L3_NHG (ATTR_ES_L3_NHG_USE | ATTR_ES_L3_NHG_ACTIVE)
-
 	/* route tag */
 	route_tag_t tag;
 
@@ -259,13 +262,16 @@ struct attr {
 	/* MPLS label */
 	mpls_label_t label;
 
+	/* EVPN DF preference for DF election on local ESs */
+	uint16_t df_pref;
+	uint8_t df_alg;
+
 	/* SRv6 VPN SID */
 	struct bgp_attr_srv6_vpn *srv6_vpn;
 
 	/* SRv6 L3VPN SID */
 	struct bgp_attr_srv6_l3vpn *srv6_l3vpn;
 
-	uint16_t encap_tunneltype;		     /* grr */
 	struct bgp_attr_encap_subtlv *encap_subtlvs; /* rfc5512 */
 
 #ifdef ENABLE_BGP_VNC
@@ -287,8 +293,7 @@ struct attr {
 	/* EVPN local router-mac */
 	struct ethaddr rmac;
 
-	/* Distance as applied by Route map */
-	uint8_t distance;
+	uint16_t encap_tunneltype;
 
 	/* rmap set table */
 	uint32_t rmap_table_id;
@@ -301,10 +306,6 @@ struct attr {
 
 	/* SR-TE Color */
 	uint32_t srte_color;
-
-	/* EVPN DF preference and algorithm for DF election on local ESs */
-	uint16_t df_pref;
-	uint8_t df_alg;
 
 	/* Nexthop type */
 	enum nexthop_types_t nh_type;

--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -74,8 +74,8 @@ struct bgp_damp_config {
 	unsigned int ceiling;		  /* Max value a penalty can attain */
 	unsigned int decay_rate_per_tick; /* Calculated from half-life */
 	unsigned int decay_array_size; /* Calculated using config parameters */
-	double scale_factor;
 	unsigned int reuse_scale_factor;
+	double scale_factor;
 
 	/* Decay array per-set based. */
 	double *decay_array;
@@ -86,6 +86,7 @@ struct bgp_damp_config {
 	/* Reuse list array per-set based. */
 	struct bgp_damp_info **reuse_list;
 	int reuse_offset;
+	safi_t safi;
 
 	/* All dampening information which is not on reuse list.  */
 	struct bgp_damp_info *no_reuse_list;
@@ -94,7 +95,6 @@ struct bgp_damp_config {
 	struct event *t_reuse;
 
 	afi_t afi;
-	safi_t safi;
 };
 
 #define BGP_DAMP_NONE           0

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -369,6 +369,8 @@ struct bgp_static {
 	/* Import check status.  */
 	uint8_t valid;
 
+	uint16_t encap_tunneltype;
+
 	/* IGP metric. */
 	uint32_t igpmetric;
 
@@ -394,7 +396,6 @@ struct bgp_static {
 	/* EVPN */
 	esi_t *eth_s_id;
 	struct ethaddr *router_mac;
-	uint16_t encap_tunneltype;
 	struct prefix gatewayIp;
 };
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -416,6 +416,17 @@ struct bgp_aggregate {
 	/* AS set generation. */
 	uint8_t as_set;
 
+	/* Optional modify flag to override ORIGIN */
+	uint8_t origin;
+
+	/** Are there MED mismatches? */
+	bool med_mismatched;
+	/* MED matching state. */
+	/** Did we get the first MED value? */
+	bool med_initialized;
+	/** Match only equal MED. */
+	bool match_med;
+
 	/* Route-map for aggregated route. */
 	struct {
 		char *name;
@@ -430,9 +441,6 @@ struct bgp_aggregate {
 
 	/* Count of routes of origin type egp under this aggregate. */
 	unsigned long egp_origin_count;
-
-	/* Optional modify flag to override ORIGIN */
-	uint8_t origin;
 
 	/* Hash containing the communities of all the
 	 * routes under this aggregate.
@@ -469,13 +477,6 @@ struct bgp_aggregate {
 	/* SAFI configuration. */
 	safi_t safi;
 
-	/** Match only equal MED. */
-	bool match_med;
-	/* MED matching state. */
-	/** Did we get the first MED value? */
-	bool med_initialized;
-	/** Are there MED mismatches? */
-	bool med_mismatched;
 	/** MED value found in current group. */
 	uint32_t med_matched_value;
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -888,10 +888,10 @@ struct peer_group {
 struct bgp_notify {
 	uint8_t code;
 	uint8_t subcode;
-	char *data;
 	bgp_size_t length;
-	uint8_t *raw_data;
 	bool hard_reset;
+	char *data;
+	uint8_t *raw_data;
 };
 
 /* Next hop self address. */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1890,11 +1890,11 @@ struct bgp_nlri {
 	/* SAFI.  */
 	uint8_t safi; /* iana_safi_t */
 
-	/* Pointer to NLRI byte stream.  */
-	uint8_t *nlri;
-
 	/* Length of whole NLRI.  */
 	bgp_size_t length;
+
+	/* Pointer to NLRI byte stream.  */
+	uint8_t *nlri;
 };
 
 /* BGP versions.  */


### PR DESCRIPTION
Some low-hanging fruits to optimize the memory, especially for attr, nlri data structures. Looks like we can safe ~100Mb of memory easily for 2 BGP full tables.