### PR TITLE
bgpd: fix attr comparaison bgp_adj_in_set

### DIFF
--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -169,7 +169,7 @@ void bgp_adj_in_set(struct bgp_dest *dest, struct peer *peer, struct attr *attr,
 
 	for (adj = dest->adj_in; adj; adj = adj->next) {
 		if (adj->peer == peer && adj->addpath_rx_id == addpath_id) {
-			if (adj->attr != attr) {
+			if (!attrhash_cmp(adj->attr, attr)) {
 				bgp_attr_unintern(&adj->attr);
 				adj->attr = bgp_attr_intern(attr);
 			}


### PR DESCRIPTION
Seen by code review.

In bgp_adj_in_set(), attr has not yet been interned. adj->attr is always different from attr. adj->attr is always uninterned and interned even if attr and adj->attr are identical.

Fix the comparison.