### PR TITLE
bgpd,lib: fix logging from rpki_create_socket()

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -1297,6 +1297,11 @@ static int rpki_create_socket(void *_cache)
 
 	rpki_vrf = cache->rpki_vrf;
 
+	if (frr_pthread_non_controlled_startup(cache->rtr_socket->thread_id,
+					       "RPKI RTRLIB socket",
+					       "rpki_create_socket") < 0)
+		return -1;
+
 	if (rpki_vrf->vrfname == NULL)
 		vrf = vrf_lookup_by_id(VRF_DEFAULT);
 	else

--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -220,6 +220,37 @@ void frr_pthread_stop_all(void)
 	}
 }
 
+static void *frr_pthread_attr_non_controlled_start(void *arg)
+{
+	struct frr_pthread *fpt = arg;
+
+	fpt->running = true;
+
+	return NULL;
+}
+
+/* Create a FRR pthread context from a non FRR pthread initialized from an
+ * external library in order to allow logging */
+int frr_pthread_non_controlled_startup(pthread_t thread, const char *name,
+				       const char *os_name)
+{
+	struct frr_pthread_attr attr = {
+		.start = frr_pthread_attr_non_controlled_start,
+		.stop = frr_pthread_attr_default.stop,
+	};
+	struct frr_pthread *fpt;
+
+	fpt = frr_pthread_new(&attr, name, os_name);
+	if (!fpt)
+		return -1;
+
+	fpt->thread = thread;
+	fpt->rcu_thread = rcu_thread_new(NULL);
+	frr_pthread_inner(fpt);
+
+	return 0;
+}
+
 /*
  * ----------------------------------------------------------------------------
  * Default Event Loop

--- a/lib/frr_pthread.h
+++ b/lib/frr_pthread.h
@@ -202,6 +202,9 @@ void frr_pthread_stop_all(void);
 #define pthread_condattr_setclock(A, B)
 #endif
 
+int frr_pthread_non_controlled_startup(pthread_t thread, const char *name,
+				       const char *os_name);
+
 /* mutex auto-lock/unlock */
 
 /* variant 1:

--- a/lib/frrcu.h
+++ b/lib/frrcu.h
@@ -40,6 +40,12 @@ extern "C" {
 /* opaque */
 struct rcu_thread;
 
+/* sets up rcu thread info
+ *
+ * return value must be passed into the thread's call to rcu_thread_start()
+ */
+extern struct rcu_thread *rcu_thread_new(void *arg);
+
 /* called before new thread creation, sets up rcu thread info for new thread
  * before it actually exits.  This ensures possible RCU references are held
  * for thread startup.


### PR DESCRIPTION
Fix the following crash when logging from rpki_create_socket():

> #0  raise (sig=<optimized out>) at ../sysdeps/unix/sysv/linux/raise.c:50
> #1  0x00007f6e21723798 in core_handler (signo=6, siginfo=0x7f6e1e502ef0, context=0x7f6e1e502dc0) at lib/sigevent.c:248
> #2  <signal handler called>
> #3  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
> #4  0x00007f6e2144e537 in __GI_abort () at abort.c:79
> #5  0x00007f6e2176348e in _zlog_assert_failed (xref=0x7f6e2180c920 <_xref.16>, extra=0x0) at lib/zlog.c:670
> #6  0x00007f6e216b1eda in rcu_read_lock () at lib/frrcu.c:294
> #7  0x00007f6e21762da8 in vzlog_notls (xref=0x0, prio=2, fmt=0x7f6e217afe50 "%s:%d: %s(): assertion (%s) failed", ap=0x7f6e1e504248) at lib/zlog.c:425
> #8  0x00007f6e217632fb in vzlogx (xref=0x0, prio=2, fmt=0x7f6e217afe50 "%s:%d: %s(): assertion (%s) failed", ap=0x7f6e1e504248) at lib/zlog.c:627
> #9  0x00007f6e217621f5 in zlog (prio=2, fmt=0x7f6e217afe50 "%s:%d: %s(): assertion (%s) failed") at lib/zlog.h:73
> #10 0x00007f6e21763596 in _zlog_assert_failed (xref=0x7f6e2180c920 <_xref.16>, extra=0x0) at lib/zlog.c:687
> #11 0x00007f6e216b1eda in rcu_read_lock () at lib/frrcu.c:294
> #12 0x00007f6e21762da8 in vzlog_notls (xref=0x7f6e21a50040 <_xref.68>, prio=4, fmt=0x7f6e21a4999f "getaddrinfo: debug", ap=0x7f6e1e504878) at lib/zlog.c:425
> #13 0x00007f6e217632fb in vzlogx (xref=0x7f6e21a50040 <_xref.68>, prio=4, fmt=0x7f6e21a4999f "getaddrinfo: debug", ap=0x7f6e1e504878) at lib/zlog.c:627
> #14 0x00007f6e21a3f774 in zlog_ref (xref=0x7f6e21a50040 <_xref.68>, fmt=0x7f6e21a4999f "getaddrinfo: debug") at ./lib/zlog.h:84
> #15 0x00007f6e21a451b2 in rpki_create_socket (_cache=0x55729149cc30) at bgpd/bgp_rpki.c:1337
> #16 0x00007f6e2120e7b7 in tr_tcp_open (tr_socket=0x5572914d1520) at rtrlib/rtrlib/transport/tcp/tcp_transport.c:111
> #17 0x00007f6e2120e212 in tr_open (socket=0x5572914b5e00) at rtrlib/rtrlib/transport/transport.c:16
> #18 0x00007f6e2120faa2 in rtr_fsm_start (rtr_socket=0x557290e17180) at rtrlib/rtrlib/rtr/rtr.c:130
> #19 0x00007f6e218b7ea7 in start_thread (arg=<optimized out>) at pthread_create.c:477
> #20 0x00007f6e21527a2f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

rpki_create_socket() is a hook function called from the rtrlib library. The issue arises because rtrlib initiates its own separate pthread in which it runs the hook, which does not establish an FRR RCU context. Consequently, this leads to failures in the logging mechanism that relies on RCU.

Initialize a new FRR pthread context from the rtrlib pthread with a valid RCU context to allow logging from the rpki_create_socket() and dependent functions.

Link: https://github.com/FRRouting/frr/issues/15260
Fixes: a951752d4a ("bgpd: create cache server socket in vrf")