### PR TITLE
lowercase and localize debug/err macros

### DIFF
--- a/lib/mgmt_be_client.h
+++ b/lib/mgmt_be_client.h
@@ -95,12 +95,12 @@ extern struct debug mgmt_dbg_be_client;
  * API prototypes
  ***************************************************************/
 
-#define MGMTD_BE_CLIENT_DBG(fmt, ...)                                          \
+#define debug_be_client(fmt, ...)                                              \
 	DEBUGD(&mgmt_dbg_be_client, "BE-CLIENT: %s: " fmt, __func__,           \
 	       ##__VA_ARGS__)
-#define MGMTD_BE_CLIENT_ERR(fmt, ...)                                          \
+#define log_err_be_client(fmt, ...)                                            \
 	zlog_err("BE-CLIENT: %s: ERROR: " fmt, __func__, ##__VA_ARGS__)
-#define MGMTD_DBG_BE_CLIENT_CHECK()                                            \
+#define debug_check_be_client()                                                \
 	DEBUG_MODE_CHECK(&mgmt_dbg_be_client, DEBUG_MODE_ALL)
 
 /**

--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -79,14 +79,13 @@ mgmt_fe_find_session_by_client_id(struct mgmt_fe_client *client,
 
 	FOREACH_SESSION_IN_LIST (client, session) {
 		if (session->client_id == client_id) {
-			MGMTD_FE_CLIENT_DBG("Found session-id %" PRIu64
-					    " using client-id %" PRIu64,
-					    session->session_id, client_id);
+			debug_fe_client("Found session-id %" PRIu64
+					" using client-id %" PRIu64,
+					session->session_id, client_id);
 			return session;
 		}
 	}
-	MGMTD_FE_CLIENT_DBG("Session not found using client-id %" PRIu64,
-			    client_id);
+	debug_fe_client("Session not found using client-id %" PRIu64, client_id);
 	return NULL;
 }
 
@@ -98,15 +97,14 @@ mgmt_fe_find_session_by_session_id(struct mgmt_fe_client *client,
 
 	FOREACH_SESSION_IN_LIST (client, session) {
 		if (session->session_id == session_id) {
-			MGMTD_FE_CLIENT_DBG(
-				"Found session of client-id %" PRIu64
-				" using session-id %" PRIu64,
-				session->client_id, session_id);
+			debug_fe_client("Found session of client-id %" PRIu64
+					" using session-id %" PRIu64,
+					session->client_id, session_id);
 			return session;
 		}
 	}
-	MGMTD_FE_CLIENT_DBG("Session not found using session-id %" PRIu64,
-			    session_id);
+	debug_fe_client("Session not found using session-id %" PRIu64,
+			session_id);
 	return NULL;
 }
 
@@ -133,8 +131,7 @@ static int mgmt_fe_send_register_req(struct mgmt_fe_client *client)
 	fe_msg.message_case = MGMTD__FE_MESSAGE__MESSAGE_REGISTER_REQ;
 	fe_msg.register_req = &rgstr_req;
 
-	MGMTD_FE_CLIENT_DBG(
-		"Sending REGISTER_REQ message to MGMTD Frontend server");
+	debug_fe_client("Sending REGISTER_REQ message to MGMTD Frontend server");
 
 	return mgmt_fe_client_send_msg(client, &fe_msg, true);
 }
@@ -160,9 +157,8 @@ static int mgmt_fe_send_session_req(struct mgmt_fe_client *client,
 	fe_msg.message_case = MGMTD__FE_MESSAGE__MESSAGE_SESSION_REQ;
 	fe_msg.session_req = &sess_req;
 
-	MGMTD_FE_CLIENT_DBG(
-		"Sending SESSION_REQ %s message for client-id %" PRIu64,
-		create ? "create" : "destroy", session->client_id);
+	debug_fe_client("Sending SESSION_REQ %s message for client-id %" PRIu64,
+			create ? "create" : "destroy", session->client_id);
 
 	return mgmt_fe_client_send_msg(client, &fe_msg, true);
 }
@@ -185,9 +181,8 @@ int mgmt_fe_send_lockds_req(struct mgmt_fe_client *client, uint64_t session_id,
 	fe_msg.message_case = MGMTD__FE_MESSAGE__MESSAGE_LOCKDS_REQ;
 	fe_msg.lockds_req = &lockds_req;
 
-	MGMTD_FE_CLIENT_DBG(
-		"Sending LOCKDS_REQ (%sLOCK) message for DS:%s session-id %" PRIu64,
-		lock ? "" : "UN", dsid2name(ds_id), session_id);
+	debug_fe_client("Sending LOCKDS_REQ (%sLOCK) message for DS:%s session-id %" PRIu64,
+			lock ? "" : "UN", dsid2name(ds_id), session_id);
 
 
 	return mgmt_fe_client_send_msg(client, &fe_msg, scok);
@@ -215,10 +210,9 @@ int mgmt_fe_send_setcfg_req(struct mgmt_fe_client *client, uint64_t session_id,
 	fe_msg.message_case = MGMTD__FE_MESSAGE__MESSAGE_SETCFG_REQ;
 	fe_msg.setcfg_req = &setcfg_req;
 
-	MGMTD_FE_CLIENT_DBG(
-		"Sending SET_CONFIG_REQ message for DS:%s session-id %" PRIu64
-		" (#xpaths:%d)",
-		dsid2name(ds_id), session_id, num_data_reqs);
+	debug_fe_client("Sending SET_CONFIG_REQ message for DS:%s session-id %" PRIu64
+			" (#xpaths:%d)",
+			dsid2name(ds_id), session_id, num_data_reqs);
 
 	return mgmt_fe_client_send_msg(client, &fe_msg, false);
 }
@@ -245,9 +239,8 @@ int mgmt_fe_send_commitcfg_req(struct mgmt_fe_client *client,
 	fe_msg.message_case = MGMTD__FE_MESSAGE__MESSAGE_COMMCFG_REQ;
 	fe_msg.commcfg_req = &commitcfg_req;
 
-	MGMTD_FE_CLIENT_DBG(
-		"Sending COMMIT_CONFIG_REQ message for Src-DS:%s, Dst-DS:%s session-id %" PRIu64,
-		dsid2name(src_ds_id), dsid2name(dest_ds_id), session_id);
+	debug_fe_client("Sending COMMIT_CONFIG_REQ message for Src-DS:%s, Dst-DS:%s session-id %" PRIu64,
+			dsid2name(src_ds_id), dsid2name(dest_ds_id), session_id);
 
 	return mgmt_fe_client_send_msg(client, &fe_msg, false);
 }
@@ -273,10 +266,9 @@ int mgmt_fe_send_get_req(struct mgmt_fe_client *client, uint64_t session_id,
 	fe_msg.message_case = MGMTD__FE_MESSAGE__MESSAGE_GET_REQ;
 	fe_msg.get_req = &getcfg_req;
 
-	MGMTD_FE_CLIENT_DBG("Sending GET_REQ (iscfg %d) message for DS:%s session-id %" PRIu64
-			    " (#xpaths:%d)",
-			    is_config, dsid2name(ds_id), session_id,
-			    num_data_reqs);
+	debug_fe_client("Sending GET_REQ (iscfg %d) message for DS:%s session-id %" PRIu64
+			" (#xpaths:%d)",
+			is_config, dsid2name(ds_id), session_id, num_data_reqs);
 
 	return mgmt_fe_client_send_msg(client, &fe_msg, false);
 }
@@ -325,9 +317,9 @@ int mgmt_fe_send_get_data_req(struct mgmt_fe_client *client, uint64_t session_id
 	msg->flags = flags;
 	strlcpy(msg->xpath, xpath, xplen + 1);
 
-	MGMTD_FE_CLIENT_DBG("Sending GET_DATA_REQ session-id %" PRIu64
-			    " req-id %" PRIu64 " xpath: %s",
-			    session_id, req_id, xpath);
+	debug_fe_client("Sending GET_DATA_REQ session-id %" PRIu64
+			" req-id %" PRIu64 " xpath: %s",
+			session_id, req_id, xpath);
 
 	ret = mgmt_msg_native_send_msg(&client->client.conn, msg, false);
 	mgmt_msg_native_free_msg(msg);
@@ -348,30 +340,28 @@ static int mgmt_fe_client_handle_msg(struct mgmt_fe_client *client,
 	case MGMTD__FE_MESSAGE__MESSAGE_SESSION_REPLY:
 		if (fe_msg->session_reply->create &&
 		    fe_msg->session_reply->has_client_conn_id) {
-			MGMTD_FE_CLIENT_DBG(
-				"Got SESSION_REPLY (create) for client-id %" PRIu64
-				" with session-id: %" PRIu64,
-				fe_msg->session_reply->client_conn_id,
-				fe_msg->session_reply->session_id);
+			debug_fe_client("Got SESSION_REPLY (create) for client-id %" PRIu64
+					" with session-id: %" PRIu64,
+					fe_msg->session_reply->client_conn_id,
+					fe_msg->session_reply->session_id);
 
 			session = mgmt_fe_find_session_by_client_id(
 				client, fe_msg->session_reply->client_conn_id);
 
 			if (session && fe_msg->session_reply->success) {
-				MGMTD_FE_CLIENT_DBG(
-					"Session Created for client-id %" PRIu64,
-					fe_msg->session_reply->client_conn_id);
+				debug_fe_client("Session Created for client-id %" PRIu64,
+						fe_msg->session_reply
+							->client_conn_id);
 				session->session_id =
 					fe_msg->session_reply->session_id;
 			} else {
-				MGMTD_FE_CLIENT_ERR(
+				log_err_fe_client(
 					"Session Create failed for client-id %" PRIu64,
 					fe_msg->session_reply->client_conn_id);
 			}
 		} else if (!fe_msg->session_reply->create) {
-			MGMTD_FE_CLIENT_DBG(
-				"Got SESSION_REPLY (destroy) for session-id %" PRIu64,
-				fe_msg->session_reply->session_id);
+			debug_fe_client("Got SESSION_REPLY (destroy) for session-id %" PRIu64,
+					fe_msg->session_reply->session_id);
 
 			session = mgmt_fe_find_session_by_session_id(
 				client, fe_msg->session_req->session_id);
@@ -388,8 +378,8 @@ static int mgmt_fe_client_handle_msg(struct mgmt_fe_client *client,
 				session->user_ctx);
 		break;
 	case MGMTD__FE_MESSAGE__MESSAGE_LOCKDS_REPLY:
-		MGMTD_FE_CLIENT_DBG("Got LOCKDS_REPLY for session-id %" PRIu64,
-				    fe_msg->lockds_reply->session_id);
+		debug_fe_client("Got LOCKDS_REPLY for session-id %" PRIu64,
+				fe_msg->lockds_reply->session_id);
 		session = mgmt_fe_find_session_by_session_id(
 			client, fe_msg->lockds_reply->session_id);
 
@@ -405,8 +395,8 @@ static int mgmt_fe_client_handle_msg(struct mgmt_fe_client *client,
 				fe_msg->lockds_reply->error_if_any);
 		break;
 	case MGMTD__FE_MESSAGE__MESSAGE_SETCFG_REPLY:
-		MGMTD_FE_CLIENT_DBG("Got SETCFG_REPLY for session-id %" PRIu64,
-				    fe_msg->setcfg_reply->session_id);
+		debug_fe_client("Got SETCFG_REPLY for session-id %" PRIu64,
+				fe_msg->setcfg_reply->session_id);
 
 		session = mgmt_fe_find_session_by_session_id(
 			client, fe_msg->setcfg_reply->session_id);
@@ -423,8 +413,8 @@ static int mgmt_fe_client_handle_msg(struct mgmt_fe_client *client,
 				fe_msg->setcfg_reply->error_if_any);
 		break;
 	case MGMTD__FE_MESSAGE__MESSAGE_COMMCFG_REPLY:
-		MGMTD_FE_CLIENT_DBG("Got COMMCFG_REPLY for session-id %" PRIu64,
-				    fe_msg->commcfg_reply->session_id);
+		debug_fe_client("Got COMMCFG_REPLY for session-id %" PRIu64,
+				fe_msg->commcfg_reply->session_id);
 
 		session = mgmt_fe_find_session_by_session_id(
 			client, fe_msg->commcfg_reply->session_id);
@@ -443,8 +433,8 @@ static int mgmt_fe_client_handle_msg(struct mgmt_fe_client *client,
 				fe_msg->commcfg_reply->error_if_any);
 		break;
 	case MGMTD__FE_MESSAGE__MESSAGE_GET_REPLY:
-		MGMTD_FE_CLIENT_DBG("Got GET_REPLY for session-id %" PRIu64,
-				    fe_msg->get_reply->session_id);
+		debug_fe_client("Got GET_REPLY for session-id %" PRIu64,
+				fe_msg->get_reply->session_id);
 
 		session =
 			mgmt_fe_find_session_by_session_id(client,
@@ -513,16 +503,15 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 	struct mgmt_msg_error *err_msg;
 	char *notify_data = NULL;
 
-	MGMTD_FE_CLIENT_DBG("Got native message for session-id %" PRIu64,
-			    msg->refer_id);
+	debug_fe_client("Got native message for session-id %" PRIu64,
+			msg->refer_id);
 
 	if (msg->code != MGMT_MSG_CODE_NOTIFY) {
 		session = mgmt_fe_find_session_by_session_id(client,
 							     msg->refer_id);
 		if (!session || !session->client) {
-			MGMTD_FE_CLIENT_ERR(
-				"No session for received native msg session-id %" PRIu64,
-				msg->refer_id);
+			log_err_fe_client("No session for received native msg session-id %" PRIu64,
+					  msg->refer_id);
 			return;
 		}
 	}
@@ -534,7 +523,7 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 
 		err_msg = (typeof(err_msg))msg;
 		if (!MGMT_MSG_VALIDATE_NUL_TERM(err_msg, msg_len)) {
-			MGMTD_FE_CLIENT_ERR("Corrupt error msg recv");
+			log_err_fe_client("Corrupt error msg recv");
 			return;
 		}
 		session->client->cbs.error_notify(client, client->user_data,
@@ -550,7 +539,7 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 
 		tree_msg = (typeof(tree_msg))msg;
 		if (msg_len < sizeof(*tree_msg)) {
-			MGMTD_FE_CLIENT_ERR("Corrupt tree-data msg recv");
+			log_err_fe_client("Corrupt tree-data msg recv");
 			return;
 		}
 		session->client->cbs.get_tree_notify(client, client->user_data,
@@ -567,13 +556,13 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 	case MGMT_MSG_CODE_NOTIFY:
 		notify_msg = (typeof(notify_msg))msg;
 		if (msg_len < sizeof(*notify_msg)) {
-			MGMTD_FE_CLIENT_ERR("Corrupt notify-data msg recv");
+			log_err_fe_client("Corrupt notify-data msg recv");
 			return;
 		}
 
 		if (notify_msg->result_type != LYD_LYB &&
 		    !MGMT_MSG_VALIDATE_NUL_TERM(notify_msg, msg_len)) {
-			MGMTD_FE_CLIENT_ERR("Corrupt error msg recv");
+			log_err_fe_client("Corrupt error msg recv");
 			return;
 		}
 		if (notify_msg->result_type == LYD_JSON)
@@ -585,8 +574,8 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 							notify_msg->result_type,
 							LYD_JSON, true);
 		if (!notify_data) {
-			MGMTD_FE_CLIENT_ERR("Can't convert format %d to JSON",
-					    notify_msg->result_type);
+			log_err_fe_client("Can't convert format %d to JSON",
+					  notify_msg->result_type);
 			return;
 		}
 		FOREACH_SESSION_IN_LIST (client, session) {
@@ -603,9 +592,9 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 			darr_free(notify_data);
 		break;
 	default:
-		MGMTD_FE_CLIENT_ERR("unknown native message session-id %" PRIu64
-				    " req-id %" PRIu64 " code %u",
-				    msg->refer_id, msg->req_id, msg->code);
+		log_err_fe_client("unknown native message session-id %" PRIu64
+				  " req-id %" PRIu64 " code %u",
+				  msg->refer_id, msg->req_id, msg->code);
 		break;
 	}
 }
@@ -626,20 +615,18 @@ static void mgmt_fe_client_process_msg(uint8_t version, uint8_t *data,
 		if (len >= sizeof(*msg))
 			fe_client_handle_native_msg(client, msg, len);
 		else
-			MGMTD_FE_CLIENT_ERR("native message to FE client %s too short %zu",
-					    client->name, len);
+			log_err_fe_client("native message to FE client %s too short %zu",
+					  client->name, len);
 		return;
 	}
 
 	fe_msg = mgmtd__fe_message__unpack(NULL, len, data);
 	if (!fe_msg) {
-		MGMTD_FE_CLIENT_DBG("Failed to decode %zu bytes from server.",
-				    len);
+		debug_fe_client("Failed to decode %zu bytes from server.", len);
 		return;
 	}
-	MGMTD_FE_CLIENT_DBG(
-		"Decoded %zu bytes of message(msg: %u/%u) from server", len,
-		fe_msg->message_case, fe_msg->message_case);
+	debug_fe_client("Decoded %zu bytes of message(msg: %u/%u) from server",
+			len, fe_msg->message_case, fe_msg->message_case);
 	(void)mgmt_fe_client_handle_msg(client, fe_msg);
 	mgmtd__fe_message__free_unpacked(fe_msg, NULL);
 }
@@ -660,7 +647,7 @@ static int _notify_connect_disconnect(struct msg_client *msg_client,
 
 	/* Walk list of sessions for this FE client deleting them */
 	if (!connected && mgmt_sessions_count(&client->sessions)) {
-		MGMTD_FE_CLIENT_DBG("Cleaning up existing sessions");
+		debug_fe_client("Cleaning up existing sessions");
 
 		FOREACH_SESSION_IN_LIST (client, session) {
 			assert(session->client);
@@ -731,7 +718,7 @@ static int mgmt_debug_fe_client_config_write(struct vty *vty)
 
 void mgmt_debug_fe_client_show_debug(struct vty *vty)
 {
-	if (MGMTD_DBG_FE_CLIENT_CHECK())
+	if (debug_check_fe_client())
 		vty_out(vty, "debug mgmt client frontend\n");
 }
 
@@ -777,9 +764,9 @@ struct mgmt_fe_client *mgmt_fe_client_create(const char *client_name,
 			mgmt_fe_client_notify_disconnect,
 			mgmt_fe_client_process_msg, MGMTD_FE_MAX_NUM_MSG_PROC,
 			MGMTD_FE_MAX_NUM_MSG_WRITE, MGMTD_FE_MAX_MSG_LEN, true,
-			"FE-client", MGMTD_DBG_FE_CLIENT_CHECK());
+			"FE-client", debug_check_fe_client());
 
-	MGMTD_FE_CLIENT_DBG("Initialized client '%s'", client_name);
+	debug_fe_client("Initialized client '%s'", client_name);
 
 	return client;
 }
@@ -848,9 +835,8 @@ enum mgmt_result mgmt_fe_destroy_client_session(struct mgmt_fe_client *client,
 
 	if (session->session_id &&
 	    mgmt_fe_send_session_req(client, session, false) != 0)
-		MGMTD_FE_CLIENT_ERR(
-			"Failed to send session destroy request for the session-id %" PRIu64,
-			session->session_id);
+		log_err_fe_client("Failed to send session destroy request for the session-id %" PRIu64,
+				  session->session_id);
 
 	mgmt_sessions_del(&client->sessions, session);
 	XFREE(MTYPE_MGMTD_FE_SESSION, session);
@@ -867,8 +853,7 @@ void mgmt_fe_client_destroy(struct mgmt_fe_client *client)
 
 	assert(client == __fe_client);
 
-	MGMTD_FE_CLIENT_DBG("Destroying MGMTD Frontend Client '%s'",
-			    client->name);
+	debug_fe_client("Destroying MGMTD Frontend Client '%s'", client->name);
 
 	FOREACH_SESSION_IN_LIST (client, session)
 		mgmt_fe_destroy_client_session(client, session->client_id);

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -132,12 +132,12 @@ extern struct debug mgmt_dbg_fe_client;
  * API prototypes
  ***************************************************************/
 
-#define MGMTD_FE_CLIENT_DBG(fmt, ...)                                          \
+#define debug_fe_client(fmt, ...)                                              \
 	DEBUGD(&mgmt_dbg_fe_client, "FE-CLIENT: %s: " fmt, __func__,           \
 	       ##__VA_ARGS__)
-#define MGMTD_FE_CLIENT_ERR(fmt, ...)                                          \
+#define log_err_fe_client(fmt, ...)                                            \
 	zlog_err("FE-CLIENT: %s: ERROR: " fmt, __func__, ##__VA_ARGS__)
-#define MGMTD_DBG_FE_CLIENT_CHECK()                                            \
+#define debug_check_fe_client()                                                \
 	DEBUG_MODE_CHECK(&mgmt_dbg_fe_client, DEBUG_MODE_ALL)
 
 /*

--- a/mgmtd/mgmt_ds.c
+++ b/mgmtd/mgmt_ds.c
@@ -15,10 +15,9 @@
 #include "mgmtd/mgmt_txn.h"
 #include "libyang/libyang.h"
 
-#define MGMTD_DS_DBG(fmt, ...)                                                 \
+#define __dbg(fmt, ...)                                                        \
 	DEBUGD(&mgmt_debug_ds, "DS: %s: " fmt, __func__, ##__VA_ARGS__)
-#define MGMTD_DS_ERR(fmt, ...)                                                 \
-	zlog_err("%s: ERROR: " fmt, __func__, ##__VA_ARGS__)
+#define __log_err(fmt, ...) zlog_err("%s: ERROR: " fmt, __func__, ##__VA_ARGS__)
 
 struct mgmt_ds_ctx {
 	Mgmtd__DatastoreId ds_id;
@@ -81,8 +80,8 @@ static int mgmt_ds_replace_dst_with_src_ds(struct mgmt_ds_ctx *src,
 	if (!src || !dst)
 		return -1;
 
-	MGMTD_DS_DBG("Replacing %s with %s", mgmt_ds_id2name(dst->ds_id),
-		     mgmt_ds_id2name(src->ds_id));
+	__dbg("Replacing %s with %s", mgmt_ds_id2name(dst->ds_id),
+	      mgmt_ds_id2name(src->ds_id));
 
 	if (src->config_ds && dst->config_ds)
 		nb_config_replace(dst->root.cfg_root, src->root.cfg_root, true);
@@ -104,7 +103,7 @@ static int mgmt_ds_merge_src_with_dst_ds(struct mgmt_ds_ctx *src,
 	if (!src || !dst)
 		return -1;
 
-	MGMTD_DS_DBG("Merging DS %d with %d", dst->ds_id, src->ds_id);
+	__dbg("Merging DS %d with %d", dst->ds_id, src->ds_id);
 	if (src->config_ds && dst->config_ds)
 		ret = nb_config_merge(dst->root.cfg_root, src->root.cfg_root,
 				      true);
@@ -114,7 +113,7 @@ static int mgmt_ds_merge_src_with_dst_ds(struct mgmt_ds_ctx *src,
 					 src->root.dnode_root, 0);
 	}
 	if (ret != 0) {
-		MGMTD_DS_ERR("merge failed with err: %d", ret);
+		__log_err("merge failed with err: %d", ret);
 		return ret;
 	}
 
@@ -299,7 +298,7 @@ static int mgmt_walk_ds_nodes(
 
 	assert(mgmt_ds_node_iter_fn);
 
-	MGMTD_DS_DBG(" -- START: base xpath: '%s'", base_xpath);
+	__dbg(" -- START: base xpath: '%s'", base_xpath);
 
 	if (!base_dnode)
 		/*
@@ -310,9 +309,9 @@ static int mgmt_walk_ds_nodes(
 	if (!base_dnode)
 		return -1;
 
-	MGMTD_DS_DBG("           search base schema: '%s'",
-		     lysc_path(base_dnode->schema, LYSC_PATH_LOG, xpath,
-			       sizeof(xpath)));
+	__dbg("           search base schema: '%s'",
+	      lysc_path(base_dnode->schema, LYSC_PATH_LOG, xpath,
+			sizeof(xpath)));
 
 	nbnode = (struct nb_node *)base_dnode->schema->priv;
 	(*mgmt_ds_node_iter_fn)(base_xpath, base_dnode, nbnode, ctx);
@@ -335,7 +334,7 @@ static int mgmt_walk_ds_nodes(
 
 		(void)lyd_path(dnode, LYD_PATH_STD, xpath, sizeof(xpath));
 
-		MGMTD_DS_DBG(" -- Child xpath: %s", xpath);
+		__dbg(" -- Child xpath: %s", xpath);
 
 		ret = mgmt_walk_ds_nodes(root, xpath, dnode,
 					 mgmt_ds_node_iter_fn, ctx);
@@ -343,7 +342,7 @@ static int mgmt_walk_ds_nodes(
 			break;
 	}
 
-	MGMTD_DS_DBG(" -- END: base xpath: '%s'", base_xpath);
+	__dbg(" -- END: base xpath: '%s'", base_xpath);
 
 	return ret;
 }
@@ -407,8 +406,7 @@ int mgmt_ds_load_config_from_file(struct mgmt_ds_ctx *dst,
 		return -1;
 
 	if (mgmt_ds_load_cfg_from_file(file_path, &iter) != 0) {
-		MGMTD_DS_ERR("Failed to load config from the file %s",
-			     file_path);
+		__log_err("Failed to load config from the file %s", file_path);
 		return -1;
 	}
 
@@ -451,7 +449,7 @@ int mgmt_ds_iter_data(Mgmtd__DatastoreId ds_id, struct nb_config *root,
 	 * Oper-state should be kept in mind though for the prefix walk
 	 */
 
-	MGMTD_DS_DBG(" -- START DS walk for DSid: %d", ds_id);
+	__dbg(" -- START DS walk for DSid: %d", ds_id);
 
 	/* If the base_xpath is empty then crawl the sibblings */
 	if (xpath[0] == 0) {

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -17,10 +17,9 @@
 #include "mgmtd/mgmt_memory.h"
 #include "mgmtd/mgmt_txn.h"
 
-#define MGMTD_TXN_DBG(fmt, ...)                                                \
+#define __dbg(fmt, ...)                                                        \
 	DEBUGD(&mgmt_debug_txn, "TXN: %s: " fmt, __func__, ##__VA_ARGS__)
-#define MGMTD_TXN_ERR(fmt, ...)                                                \
-	zlog_err("%s: ERROR: " fmt, __func__, ##__VA_ARGS__)
+#define __log_err(fmt, ...) zlog_err("%s: ERROR: " fmt, __func__, ##__VA_ARGS__)
 
 #define MGMTD_TXN_LOCK(txn)   mgmt_txn_lock(txn, __FILE__, __LINE__)
 #define MGMTD_TXN_UNLOCK(txn) mgmt_txn_unlock(txn, __FILE__, __LINE__)
@@ -314,7 +313,7 @@ static void mgmt_txn_cfg_batch_free(struct mgmt_txn_be_cfg_batch **batch)
 	size_t indx;
 	struct mgmt_commit_cfg_req *cmtcfg_req;
 
-	MGMTD_TXN_DBG(" freeing batch txn-id %" PRIu64, (*batch)->txn->txn_id);
+	__dbg(" freeing batch txn-id %" PRIu64, (*batch)->txn->txn_id);
 
 	assert((*batch)->txn && (*batch)->txn->type == MGMTD_TXN_TYPE_CONFIG);
 
@@ -371,15 +370,15 @@ static struct mgmt_txn_req *mgmt_txn_req_alloc(struct mgmt_txn_ctx *txn,
 					       sizeof(struct mgmt_set_cfg_req));
 		assert(txn_req->req.set_cfg);
 		mgmt_txn_reqs_add_tail(&txn->set_cfg_reqs, txn_req);
-		MGMTD_TXN_DBG("Added a new SETCFG req-id: %" PRIu64
-			      " txn-id: %" PRIu64 ", session-id: %" PRIu64,
-			      txn_req->req_id, txn->txn_id, txn->session_id);
+		__dbg("Added a new SETCFG req-id: %" PRIu64 " txn-id: %" PRIu64
+		      ", session-id: %" PRIu64,
+		      txn_req->req_id, txn->txn_id, txn->session_id);
 		break;
 	case MGMTD_TXN_PROC_COMMITCFG:
 		txn->commit_cfg_req = txn_req;
-		MGMTD_TXN_DBG("Added a new COMMITCFG req-id: %" PRIu64
-			      " txn-id: %" PRIu64 " session-id: %" PRIu64,
-			      txn_req->req_id, txn->txn_id, txn->session_id);
+		__dbg("Added a new COMMITCFG req-id: %" PRIu64
+		      " txn-id: %" PRIu64 " session-id: %" PRIu64,
+		      txn_req->req_id, txn->txn_id, txn->session_id);
 
 		FOREACH_MGMTD_BE_CLIENT_ID (id) {
 			txn_req->req.commit_cfg.be_phase[id] =
@@ -396,17 +395,17 @@ static struct mgmt_txn_req *mgmt_txn_req_alloc(struct mgmt_txn_ctx *txn,
 				sizeof(struct mgmt_get_data_req));
 		assert(txn_req->req.get_data);
 		mgmt_txn_reqs_add_tail(&txn->get_cfg_reqs, txn_req);
-		MGMTD_TXN_DBG("Added a new GETCFG req-id: %" PRIu64
-			      " txn-id: %" PRIu64 " session-id: %" PRIu64,
-			      txn_req->req_id, txn->txn_id, txn->session_id);
+		__dbg("Added a new GETCFG req-id: %" PRIu64 " txn-id: %" PRIu64
+		      " session-id: %" PRIu64,
+		      txn_req->req_id, txn->txn_id, txn->session_id);
 		break;
 	case MGMTD_TXN_PROC_GETTREE:
 		txn_req->req.get_tree = XCALLOC(MTYPE_MGMTD_TXN_GETTREE_REQ,
 						sizeof(struct txn_req_get_tree));
 		mgmt_txn_reqs_add_tail(&txn->get_tree_reqs, txn_req);
-		MGMTD_TXN_DBG("Added a new GETTREE req-id: %" PRIu64
-			      " txn-id: %" PRIu64 " session-id: %" PRIu64,
-			      txn_req->req_id, txn->txn_id, txn->session_id);
+		__dbg("Added a new GETTREE req-id: %" PRIu64 " txn-id: %" PRIu64
+		      " session-id: %" PRIu64,
+		      txn_req->req_id, txn->txn_id, txn->session_id);
 		break;
 	case MGMTD_TXN_COMMITCFG_TIMEOUT:
 	case MGMTD_TXN_GETTREE_TIMEOUT:
@@ -425,41 +424,24 @@ static void mgmt_txn_req_free(struct mgmt_txn_req **txn_req)
 	enum mgmt_be_client_id id;
 	struct mgmt_be_client_adapter *adapter;
 	struct mgmt_commit_cfg_req *ccreq;
+	struct mgmt_set_cfg_req *set_cfg;
 	bool cleanup;
 
 	switch ((*txn_req)->req_event) {
 	case MGMTD_TXN_PROC_SETCFG:
-		for (indx = 0; indx < (*txn_req)->req.set_cfg->num_cfg_changes;
-		     indx++) {
-			if ((*txn_req)->req.set_cfg->cfg_changes[indx].value) {
-				MGMTD_TXN_DBG("Freeing value for %s at %p ==> '%s'",
-					      (*txn_req)
-						      ->req.set_cfg
-						      ->cfg_changes[indx]
-						      .xpath,
-					      (*txn_req)
-						      ->req.set_cfg
-						      ->cfg_changes[indx]
-						      .value,
-					      (*txn_req)
-						      ->req.set_cfg
-						      ->cfg_changes[indx]
-						      .value);
-				free((void *)(*txn_req)
-					     ->req.set_cfg->cfg_changes[indx]
-					     .value);
-			}
+		set_cfg = (*txn_req)->req.set_cfg;
+		for (indx = 0; indx < set_cfg->num_cfg_changes; indx++) {
+			if (set_cfg->cfg_changes[indx].value)
+				free((void *)set_cfg->cfg_changes[indx].value);
 		}
 		req_list = &(*txn_req)->txn->set_cfg_reqs;
-		MGMTD_TXN_DBG("Deleting SETCFG req-id: %" PRIu64
-			      " txn-id: %" PRIu64,
-			      (*txn_req)->req_id, (*txn_req)->txn->txn_id);
+		__dbg("Deleting SETCFG req-id: %" PRIu64 " txn-id: %" PRIu64,
+		      (*txn_req)->req_id, (*txn_req)->txn->txn_id);
 		XFREE(MTYPE_MGMTD_TXN_SETCFG_REQ, (*txn_req)->req.set_cfg);
 		break;
 	case MGMTD_TXN_PROC_COMMITCFG:
-		MGMTD_TXN_DBG("Deleting COMMITCFG req-id: %" PRIu64
-			      " txn-id: %" PRIu64,
-			      (*txn_req)->req_id, (*txn_req)->txn->txn_id);
+		__dbg("Deleting COMMITCFG req-id: %" PRIu64 " txn-id: %" PRIu64,
+		      (*txn_req)->req_id, (*txn_req)->txn->txn_id);
 
 		ccreq = &(*txn_req)->req.commit_cfg;
 		cleanup = (ccreq->phase >= MGMTD_COMMIT_PHASE_TXN_CREATE &&
@@ -495,9 +477,8 @@ static void mgmt_txn_req_free(struct mgmt_txn_req **txn_req)
 					     ->req.get_data->xpaths[indx]);
 		}
 		req_list = &(*txn_req)->txn->get_cfg_reqs;
-		MGMTD_TXN_DBG("Deleting GETCFG req-id: %" PRIu64
-			      " txn-id: %" PRIu64,
-			      (*txn_req)->req_id, (*txn_req)->txn->txn_id);
+		__dbg("Deleting GETCFG req-id: %" PRIu64 " txn-id: %" PRIu64,
+		      (*txn_req)->req_id, (*txn_req)->txn->txn_id);
 		if ((*txn_req)->req.get_data->reply)
 			XFREE(MTYPE_MGMTD_TXN_GETDATA_REPLY,
 			      (*txn_req)->req.get_data->reply);
@@ -508,9 +489,8 @@ static void mgmt_txn_req_free(struct mgmt_txn_req **txn_req)
 		XFREE(MTYPE_MGMTD_TXN_GETDATA_REQ, (*txn_req)->req.get_data);
 		break;
 	case MGMTD_TXN_PROC_GETTREE:
-		MGMTD_TXN_DBG("Deleting GETTREE req-id: %" PRIu64
-			      " of txn-id: %" PRIu64,
-			      (*txn_req)->req_id, (*txn_req)->txn->txn_id);
+		__dbg("Deleting GETTREE req-id: %" PRIu64 " of txn-id: %" PRIu64,
+		      (*txn_req)->req_id, (*txn_req)->txn->txn_id);
 		req_list = &(*txn_req)->txn->get_tree_reqs;
 		lyd_free_all((*txn_req)->req.get_tree->client_results);
 		XFREE(MTYPE_MGMTD_XPATH, (*txn_req)->req.get_tree->xpath);
@@ -523,9 +503,8 @@ static void mgmt_txn_req_free(struct mgmt_txn_req **txn_req)
 
 	if (req_list) {
 		mgmt_txn_reqs_del(req_list, *txn_req);
-		MGMTD_TXN_DBG("Removed req-id: %" PRIu64
-			      " from request-list (left:%zu)",
-			      (*txn_req)->req_id, mgmt_txn_reqs_count(req_list));
+		__dbg("Removed req-id: %" PRIu64 " from request-list (left:%zu)",
+		      (*txn_req)->req_id, mgmt_txn_reqs_count(req_list));
 	}
 
 	MGMTD_TXN_UNLOCK(&(*txn_req)->txn);
@@ -550,10 +529,10 @@ static void mgmt_txn_process_set_cfg(struct event *thread)
 	assert(txn);
 	cmt_stats = mgmt_fe_get_session_commit_stats(txn->session_id);
 
-	MGMTD_TXN_DBG("Processing %zu SET_CONFIG requests txn-id:%" PRIu64
-		      " session-id: %" PRIu64,
-		      mgmt_txn_reqs_count(&txn->set_cfg_reqs), txn->txn_id,
-		      txn->session_id);
+	__dbg("Processing %zu SET_CONFIG requests txn-id:%" PRIu64
+	      " session-id: %" PRIu64,
+	      mgmt_txn_reqs_count(&txn->set_cfg_reqs), txn->txn_id,
+	      txn->session_id);
 
 	FOREACH_TXN_REQ_IN_LIST (&txn->set_cfg_reqs, txn_req) {
 		assert(txn_req->req_event == MGMTD_TXN_PROC_SETCFG);
@@ -605,11 +584,11 @@ static void mgmt_txn_process_set_cfg(struct event *thread)
 			/* We expect the user to have locked the DST DS */
 			if (!mgmt_ds_is_locked(txn_req->req.set_cfg->dst_ds_ctx,
 					       txn->session_id)) {
-				MGMTD_TXN_ERR("DS %u not locked for implicit commit txn-id: %" PRIu64
-					      " session-id: %" PRIu64 " err: %s",
-					      txn_req->req.set_cfg->dst_ds_id,
-					      txn->txn_id, txn->session_id,
-					      strerror(ret));
+				__log_err("DS %u not locked for implicit commit txn-id: %" PRIu64
+					  " session-id: %" PRIu64 " err: %s",
+					  txn_req->req.set_cfg->dst_ds_id,
+					  txn->txn_id, txn->session_id,
+					  strerror(ret));
 				mgmt_fe_send_set_cfg_reply(
 					txn->session_id, txn->txn_id,
 					txn_req->req.set_cfg->ds_id,
@@ -640,9 +619,9 @@ static void mgmt_txn_process_set_cfg(struct event *thread)
 						      txn_req->req_id,
 						      MGMTD_SUCCESS, NULL,
 						      false) != 0) {
-			MGMTD_TXN_ERR("Failed to send SET_CONFIG_REPLY txn-id %" PRIu64
-				      " session-id: %" PRIu64,
-				      txn->txn_id, txn->session_id);
+			__log_err("Failed to send SET_CONFIG_REPLY txn-id %" PRIu64
+				  " session-id: %" PRIu64,
+				  txn->txn_id, txn->session_id);
 		}
 
 mgmt_txn_process_set_cfg_done:
@@ -659,9 +638,8 @@ mgmt_txn_process_set_cfg_done:
 
 	left = mgmt_txn_reqs_count(&txn->set_cfg_reqs);
 	if (left) {
-		MGMTD_TXN_DBG("Processed maximum number of Set-Config requests (%d/%d/%d). Rescheduling for rest.",
-			      num_processed, MGMTD_TXN_MAX_NUM_SETCFG_PROC,
-			      (int)left);
+		__dbg("Processed maximum number of Set-Config requests (%d/%d/%d). Rescheduling for rest.",
+		      num_processed, MGMTD_TXN_MAX_NUM_SETCFG_PROC, (int)left);
 		mgmt_txn_register_event(txn, MGMTD_TXN_PROC_SETCFG);
 	}
 }
@@ -692,9 +670,9 @@ static int mgmt_txn_send_commit_cfg_reply(struct mgmt_txn_ctx *txn,
 					  txn->commit_cfg_req->req.commit_cfg
 						  .validate_only,
 					  result, error_if_any) != 0) {
-		MGMTD_TXN_ERR("Failed to send COMMIT-CONFIG-REPLY txn-id: %" PRIu64
-			      " session-id: %" PRIu64,
-			      txn->txn_id, txn->session_id);
+		__log_err("Failed to send COMMIT-CONFIG-REPLY txn-id: %" PRIu64
+			  " session-id: %" PRIu64,
+			  txn->txn_id, txn->session_id);
 	}
 
 	if (txn->commit_cfg_req->req.commit_cfg.implicit && txn->session_id &&
@@ -706,9 +684,9 @@ static int mgmt_txn_send_commit_cfg_reply(struct mgmt_txn_ctx *txn,
 				       success ? MGMTD_SUCCESS
 					       : MGMTD_INTERNAL_ERROR,
 				       error_if_any, true) != 0) {
-		MGMTD_TXN_ERR("Failed to send SET-CONFIG-REPLY txn-id: %" PRIu64
-			      " session-id: %" PRIu64,
-			      txn->txn_id, txn->session_id);
+		__log_err("Failed to send SET-CONFIG-REPLY txn-id: %" PRIu64
+			  " session-id: %" PRIu64,
+			  txn->txn_id, txn->session_id);
 	}
 
 	if (success) {
@@ -791,8 +769,8 @@ mgmt_try_move_commit_to_next_phase(struct mgmt_txn_ctx *txn,
 {
 	enum mgmt_be_client_id id;
 
-	MGMTD_TXN_DBG("txn-id: %" PRIu64 ", Phase '%s'",
-		      txn->txn_id, mgmt_txn_commit_phase_str(txn));
+	__dbg("txn-id: %" PRIu64 ", Phase '%s'", txn->txn_id,
+	      mgmt_txn_commit_phase_str(txn));
 
 	/*
 	 * Check if all clients has moved to next phase or not.
@@ -818,8 +796,8 @@ mgmt_try_move_commit_to_next_phase(struct mgmt_txn_ctx *txn,
 	 */
 	cmtcfg_req->phase++;
 
-	MGMTD_TXN_DBG("Move entire txn-id: %" PRIu64 " to phase '%s'",
-		      txn->txn_id, mgmt_txn_commit_phase_str(txn));
+	__dbg("Move entire txn-id: %" PRIu64 " to phase '%s'", txn->txn_id,
+	      mgmt_txn_commit_phase_str(txn));
 
 	mgmt_txn_register_event(txn, MGMTD_TXN_PROC_COMMITCFG);
 
@@ -866,8 +844,7 @@ static int mgmt_txn_create_config_batches(struct mgmt_txn_req *txn_req,
 		if (!value)
 			value = (char *)MGMTD_BE_CONTAINER_NODE_VAL;
 
-		MGMTD_TXN_DBG("XPATH: %s, Value: '%s'", xpath,
-			      value ? value : "NIL");
+		__dbg("XPATH: %s, Value: '%s'", xpath, value ? value : "NIL");
 
 		clients = mgmt_be_interested_clients(xpath, true);
 
@@ -925,8 +902,8 @@ static int mgmt_txn_create_config_batches(struct mgmt_txn_req *txn_req,
 			batch->value[batch->num_cfg_data].encoded_str_val =
 				value;
 
-			MGMTD_TXN_DBG(" -- %s, batch item:%d", adapter->name,
-				      (int)batch->num_cfg_data);
+			__dbg(" -- %s, batch item:%d", adapter->name,
+			      (int)batch->num_cfg_data);
 
 			batch->num_cfg_data++;
 			num_chgs++;
@@ -936,7 +913,7 @@ static int mgmt_txn_create_config_batches(struct mgmt_txn_req *txn_req,
 			snprintf(err_buf, sizeof(err_buf),
 				 "No validator module found for XPATH: '%s",
 				 xpath);
-			MGMTD_TXN_ERR("***** %s", err_buf);
+			__log_err("***** %s", err_buf);
 		}
 
 		cmtcfg_req->clients |= chg_clients;
@@ -1157,10 +1134,8 @@ static int mgmt_txn_send_be_txn_create(struct mgmt_txn_ctx *txn)
 	 * come back.
 	 */
 
-	MGMTD_TXN_DBG("txn-id: %" PRIu64 " session-id: %" PRIu64
-		      " Phase '%s'",
-		      txn->txn_id, txn->session_id,
-		      mgmt_txn_commit_phase_str(txn));
+	__dbg("txn-id: %" PRIu64 " session-id: %" PRIu64 " Phase '%s'",
+	      txn->txn_id, txn->session_id, mgmt_txn_commit_phase_str(txn));
 
 	return 0;
 }
@@ -1193,8 +1168,9 @@ static int mgmt_txn_send_be_cfg_data(struct mgmt_txn_ctx *txn,
 			(void)mgmt_txn_send_commit_cfg_reply(
 				txn, MGMTD_INTERNAL_ERROR,
 				"Internal Error! Could not send config data to backend!");
-			MGMTD_TXN_ERR("Could not send CFGDATA_CREATE txn-id: %" PRIu64
-				      " to client '%s", txn->txn_id, adapter->name);
+			__log_err("Could not send CFGDATA_CREATE txn-id: %" PRIu64
+				  " to client '%s",
+				  txn->txn_id, adapter->name);
 			return -1;
 		}
 
@@ -1238,8 +1214,8 @@ static void mgmt_txn_cfg_commit_timedout(struct event *thread)
 	if (!txn->commit_cfg_req)
 		return;
 
-	MGMTD_TXN_ERR("Backend timeout txn-id: %" PRIu64 " aborting commit",
-		      txn->txn_id);
+	__log_err("Backend timeout txn-id: %" PRIu64 " aborting commit",
+		  txn->txn_id);
 
 	/*
 	 * Send a COMMIT_CONFIG_REPLY with failure.
@@ -1290,9 +1266,9 @@ static int txn_get_tree_data_done(struct mgmt_txn_ctx *txn,
 	mgmt_txn_req_free(&txn_req);
 
 	if (ret) {
-		MGMTD_TXN_ERR("Error sending the results of GETTREE for txn-id %" PRIu64
-			      " req_id %" PRIu64 " to requested type %u",
-			      txn->txn_id, req_id, get_tree->result_type);
+		__log_err("Error sending the results of GETTREE for txn-id %" PRIu64
+			  " req_id %" PRIu64 " to requested type %u",
+			  txn->txn_id, req_id, get_tree->result_type);
 
 		(void)mgmt_fe_adapter_txn_error(txn->txn_id, req_id, false, ret,
 						"Error converting results of GETTREE");
@@ -1314,8 +1290,8 @@ static void txn_get_tree_timeout(struct event *thread)
 	assert(txn->type == MGMTD_TXN_TYPE_SHOW);
 
 
-	MGMTD_TXN_ERR("Backend timeout txn-id: %" PRIu64 " ending get-tree",
-		      txn->txn_id);
+	__log_err("Backend timeout txn-id: %" PRIu64 " ending get-tree",
+		  txn->txn_id);
 
 	/*
 	 * Send a get-tree data reply.
@@ -1388,10 +1364,9 @@ static void mgmt_txn_process_commit_cfg(struct event *thread)
 	txn = (struct mgmt_txn_ctx *)EVENT_ARG(thread);
 	assert(txn);
 
-	MGMTD_TXN_DBG("Processing COMMIT_CONFIG for txn-id: %" PRIu64
-		      " session-id: %" PRIu64 " Phase '%s'",
-		      txn->txn_id, txn->session_id,
-		      mgmt_txn_commit_phase_str(txn));
+	__dbg("Processing COMMIT_CONFIG for txn-id: %" PRIu64
+	      " session-id: %" PRIu64 " Phase '%s'",
+	      txn->txn_id, txn->session_id, mgmt_txn_commit_phase_str(txn));
 
 	assert(txn->commit_cfg_req);
 	cmtcfg_req = &txn->commit_cfg_req->req.commit_cfg;
@@ -1417,13 +1392,13 @@ static void mgmt_txn_process_commit_cfg(struct event *thread)
 			 * Backend by now.
 			 */
 #ifndef MGMTD_LOCAL_VALIDATIONS_ENABLED
-		MGMTD_TXN_DBG("txn-id: %" PRIu64 " session-id: %" PRIu64
-			      " trigger sending CFG_VALIDATE_REQ to all backend clients",
-			      txn->txn_id, txn->session_id);
+		__dbg("txn-id: %" PRIu64 " session-id: %" PRIu64
+		      " trigger sending CFG_VALIDATE_REQ to all backend clients",
+		      txn->txn_id, txn->session_id);
 #else  /* ifndef MGMTD_LOCAL_VALIDATIONS_ENABLED */
-		MGMTD_TXN_DBG("txn-id: %" PRIu64 " session-id: %" PRIu64
-			      " trigger sending CFG_APPLY_REQ to all backend clients",
-			      txn->txn_id, txn->session_id);
+		__dbg("txn-id: %" PRIu64 " session-id: %" PRIu64
+		      " trigger sending CFG_APPLY_REQ to all backend clients",
+		      txn->txn_id, txn->session_id);
 #endif /* ifndef MGMTD_LOCAL_VALIDATIONS_ENABLED */
 		break;
 	case MGMTD_COMMIT_PHASE_APPLY_CFG:
@@ -1512,8 +1487,8 @@ static void mgmt_txn_send_getcfg_reply_data(struct mgmt_txn_req *txn_req,
 	data_reply->next_indx = (!get_reply->last_batch ? get_req->total_reply
 							: -1);
 
-	MGMTD_TXN_DBG("Sending %zu Get-Config/Data replies next-index:%" PRId64,
-		      data_reply->n_data, data_reply->next_indx);
+	__dbg("Sending %zu Get-Config/Data replies next-index:%" PRId64,
+	      data_reply->n_data, data_reply->next_indx);
 
 	switch (txn_req->req_event) {
 	case MGMTD_TXN_PROC_GETCFG:
@@ -1521,11 +1496,10 @@ static void mgmt_txn_send_getcfg_reply_data(struct mgmt_txn_req *txn_req,
 					   txn_req->txn->txn_id, get_req->ds_id,
 					   txn_req->req_id, MGMTD_SUCCESS,
 					   data_reply, NULL) != 0) {
-			MGMTD_TXN_ERR("Failed to send GET-CONFIG-REPLY txn-id: %" PRIu64
-				      " session-id: %" PRIu64
-				      " req-id: %" PRIu64,
-				      txn_req->txn->txn_id,
-				      txn_req->txn->session_id, txn_req->req_id);
+			__log_err("Failed to send GET-CONFIG-REPLY txn-id: %" PRIu64
+				  " session-id: %" PRIu64 " req-id: %" PRIu64,
+				  txn_req->txn->txn_id,
+				  txn_req->txn->session_id, txn_req->req_id);
 		}
 		break;
 	case MGMTD_TXN_PROC_SETCFG:
@@ -1533,7 +1507,7 @@ static void mgmt_txn_send_getcfg_reply_data(struct mgmt_txn_req *txn_req,
 	case MGMTD_TXN_PROC_GETTREE:
 	case MGMTD_TXN_GETTREE_TIMEOUT:
 	case MGMTD_TXN_COMMITCFG_TIMEOUT:
-		MGMTD_TXN_ERR("Invalid Txn-Req-Event %u", txn_req->req_event);
+		__log_err("Invalid Txn-Req-Event %u", txn_req->req_event);
 		break;
 	}
 
@@ -1576,8 +1550,8 @@ static void txn_iter_get_config_data_cb(const char *xpath, struct lyd_node *node
 
 	get_reply->num_reply++;
 	get_req->total_reply++;
-	MGMTD_TXN_DBG(" [%d] XPATH: '%s', Value: '%s'", get_req->total_reply,
-		      data->xpath, data_value->encoded_str_val);
+	__dbg(" [%d] XPATH: '%s', Value: '%s'", get_req->total_reply,
+	      data->xpath, data_value->encoded_str_val);
 
 	if (get_reply->num_reply == MGMTD_MAX_NUM_DATA_REPLY_IN_BATCH)
 		mgmt_txn_send_getcfg_reply_data(txn_req, get_req);
@@ -1611,8 +1585,8 @@ static int mgmt_txn_get_config(struct mgmt_txn_ctx *txn,
 	 */
 	get_reply = get_data->reply;
 	for (indx = 0; indx < get_data->num_xpaths; indx++) {
-		MGMTD_TXN_DBG("Trying to get all data under '%s'",
-			      get_data->xpaths[indx]);
+		__dbg("Trying to get all data under '%s'",
+		      get_data->xpaths[indx]);
 		mgmt_init_get_data_reply(get_reply);
 		/*
 		 * mgmt_ds_iter_data works on path prefixes, but the user may
@@ -1623,16 +1597,15 @@ static int mgmt_txn_get_config(struct mgmt_txn_ctx *txn,
 				      get_data->xpaths[indx],
 				      txn_iter_get_config_data_cb,
 				      (void *)txn_req) == -1) {
-			MGMTD_TXN_DBG("Invalid Xpath '%s",
-				      get_data->xpaths[indx]);
+			__dbg("Invalid Xpath '%s", get_data->xpaths[indx]);
 			mgmt_fe_send_get_reply(txn->session_id, txn->txn_id,
 					       get_data->ds_id, txn_req->req_id,
 					       MGMTD_INTERNAL_ERROR, NULL,
 					       "Invalid xpath");
 			goto mgmt_txn_get_config_failed;
 		}
-		MGMTD_TXN_DBG("Got %d remaining data-replies for xpath '%s'",
-			      get_reply->num_reply, get_data->xpaths[indx]);
+		__dbg("Got %d remaining data-replies for xpath '%s'",
+		      get_reply->num_reply, get_data->xpaths[indx]);
 		get_reply->last_batch = true;
 		mgmt_txn_send_getcfg_reply_data(txn_req, get_data);
 	}
@@ -1659,10 +1632,10 @@ static void mgmt_txn_process_get_cfg(struct event *thread)
 	txn = (struct mgmt_txn_ctx *)EVENT_ARG(thread);
 	assert(txn);
 
-	MGMTD_TXN_DBG("Processing %zu GET_CONFIG requests txn-id: %" PRIu64
-		      " session-id: %" PRIu64,
-		      mgmt_txn_reqs_count(&txn->get_cfg_reqs), txn->txn_id,
-		      txn->session_id);
+	__dbg("Processing %zu GET_CONFIG requests txn-id: %" PRIu64
+	      " session-id: %" PRIu64,
+	      mgmt_txn_reqs_count(&txn->get_cfg_reqs), txn->txn_id,
+	      txn->session_id);
 
 	FOREACH_TXN_REQ_IN_LIST (&txn->get_cfg_reqs, txn_req) {
 		error = false;
@@ -1671,11 +1644,10 @@ static void mgmt_txn_process_get_cfg(struct event *thread)
 		assert(cfg_root);
 
 		if (mgmt_txn_get_config(txn, txn_req, cfg_root) != 0) {
-			MGMTD_TXN_ERR("Unable to retrieve config from DS %d txn-id: %" PRIu64
-				      " session-id: %" PRIu64
-				      " req-id: %" PRIu64,
-				      txn_req->req.get_data->ds_id, txn->txn_id,
-				      txn->session_id, txn_req->req_id);
+			__log_err("Unable to retrieve config from DS %d txn-id: %" PRIu64
+				  " session-id: %" PRIu64 " req-id: %" PRIu64,
+				  txn_req->req.get_data->ds_id, txn->txn_id,
+				  txn->session_id, txn_req->req_id);
 			error = true;
 		}
 
@@ -1698,8 +1670,8 @@ static void mgmt_txn_process_get_cfg(struct event *thread)
 	}
 
 	if (mgmt_txn_reqs_count(&txn->get_cfg_reqs)) {
-		MGMTD_TXN_DBG("Processed maximum number of Get-Config requests (%d/%d). Rescheduling for rest.",
-			      num_processed, MGMTD_TXN_MAX_NUM_GETCFG_PROC);
+		__dbg("Processed maximum number of Get-Config requests (%d/%d). Rescheduling for rest.",
+		      num_processed, MGMTD_TXN_MAX_NUM_GETCFG_PROC);
 		mgmt_txn_register_event(txn, MGMTD_TXN_PROC_GETCFG);
 	}
 }
@@ -1746,8 +1718,8 @@ static struct mgmt_txn_ctx *mgmt_txn_create_new(uint64_t session_id,
 		txn->txn_id = mgmt_txn_mm->next_txn_id++;
 		hash_get(mgmt_txn_mm->txn_hash, txn, hash_alloc_intern);
 
-		MGMTD_TXN_DBG("Added new '%s' txn-id: %" PRIu64,
-			      mgmt_txn_type2str(type), txn->txn_id);
+		__dbg("Added new '%s' txn-id: %" PRIu64,
+		      mgmt_txn_type2str(type), txn->txn_id);
 
 		if (type == MGMTD_TXN_TYPE_CONFIG)
 			mgmt_txn_mm->cfg_txn = txn;
@@ -1829,9 +1801,8 @@ uint64_t mgmt_txn_get_session_id(uint64_t txn_id)
 static void mgmt_txn_lock(struct mgmt_txn_ctx *txn, const char *file, int line)
 {
 	txn->refcount++;
-	MGMTD_TXN_DBG("%s:%d --> Lock %s txn-id: %" PRIu64 " refcnt: %d", file,
-		      line, mgmt_txn_type2str(txn->type), txn->txn_id,
-		      txn->refcount);
+	__dbg("%s:%d --> Lock %s txn-id: %" PRIu64 " refcnt: %d", file, line,
+	      mgmt_txn_type2str(txn->type), txn->txn_id, txn->refcount);
 }
 
 static void mgmt_txn_unlock(struct mgmt_txn_ctx **txn, const char *file,
@@ -1840,9 +1811,8 @@ static void mgmt_txn_unlock(struct mgmt_txn_ctx **txn, const char *file,
 	assert(*txn && (*txn)->refcount);
 
 	(*txn)->refcount--;
-	MGMTD_TXN_DBG("%s:%d --> Unlock %s txn-id: %" PRIu64 " refcnt: %d",
-		      file, line, mgmt_txn_type2str((*txn)->type),
-		      (*txn)->txn_id, (*txn)->refcount);
+	__dbg("%s:%d --> Unlock %s txn-id: %" PRIu64 " refcnt: %d", file, line,
+	      mgmt_txn_type2str((*txn)->type), (*txn)->txn_id, (*txn)->refcount);
 	if (!(*txn)->refcount) {
 		if ((*txn)->type == MGMTD_TXN_TYPE_CONFIG)
 			if (mgmt_txn_mm->cfg_txn == *txn)
@@ -1855,10 +1825,9 @@ static void mgmt_txn_unlock(struct mgmt_txn_ctx **txn, const char *file,
 		hash_release(mgmt_txn_mm->txn_hash, *txn);
 		mgmt_txns_del(&mgmt_txn_mm->txn_list, *txn);
 
-		MGMTD_TXN_DBG("Deleted %s txn-id: %" PRIu64
-			      " session-id: %" PRIu64,
-			      mgmt_txn_type2str((*txn)->type), (*txn)->txn_id,
-			      (*txn)->session_id);
+		__dbg("Deleted %s txn-id: %" PRIu64 " session-id: %" PRIu64,
+		      mgmt_txn_type2str((*txn)->type), (*txn)->txn_id,
+		      (*txn)->session_id);
 
 		XFREE(MTYPE_MGMTD_TXN, *txn);
 	}
@@ -1990,7 +1959,7 @@ int mgmt_txn_send_set_config_req(uint64_t txn_id, uint64_t req_id,
 		return -1;
 
 	if (implicit_commit && mgmt_txn_reqs_count(&txn->set_cfg_reqs)) {
-		MGMTD_TXN_ERR(
+		__log_err(
 			"For implicit commit config only one SETCFG-REQ can be allowed!");
 		return -1;
 	}
@@ -2033,12 +2002,11 @@ int mgmt_txn_send_set_config_req(uint64_t txn_id, uint64_t req_id,
 			continue;
 		}
 
-		MGMTD_TXN_DBG("XPath: '%s', Value: '%s'",
-			      cfg_req[indx]->data->xpath,
-			      (cfg_req[indx]->data->value &&
-					       cfg_req[indx]->data->value->encoded_str_val
-				       ? cfg_req[indx]->data->value->encoded_str_val
-				       : "NULL"));
+		__dbg("XPath: '%s', Value: '%s'", cfg_req[indx]->data->xpath,
+		      (cfg_req[indx]->data->value &&
+				       cfg_req[indx]->data->value->encoded_str_val
+			       ? cfg_req[indx]->data->value->encoded_str_val
+			       : "NULL"));
 		strlcpy(cfg_chg->xpath, cfg_req[indx]->data->xpath,
 			sizeof(cfg_chg->xpath));
 		cfg_chg->value =
@@ -2048,8 +2016,8 @@ int mgmt_txn_send_set_config_req(uint64_t txn_id, uint64_t req_id,
 						  ->data->value->encoded_str_val)
 				 : NULL);
 		if (cfg_chg->value)
-			MGMTD_TXN_DBG("Allocated value at %p ==> '%s'",
-				      cfg_chg->value, cfg_chg->value);
+			__dbg("Allocated value at %p ==> '%s'", cfg_chg->value,
+			      cfg_chg->value);
 
 		(*num_chgs)++;
 	}
@@ -2079,9 +2047,9 @@ int mgmt_txn_send_commit_config_req(uint64_t txn_id, uint64_t req_id,
 		return -1;
 
 	if (txn->commit_cfg_req) {
-		MGMTD_TXN_ERR("Commit already in-progress txn-id: %" PRIu64
-			      " session-id: %" PRIu64 ". Cannot start another",
-			      txn->txn_id, txn->session_id);
+		__log_err("Commit already in-progress txn-id: %" PRIu64
+			  " session-id: %" PRIu64 ". Cannot start another",
+			  txn->txn_id, txn->session_id);
 		return -1;
 	}
 
@@ -2129,15 +2097,14 @@ int mgmt_txn_notify_be_adapter_conn(struct mgmt_be_client_adapter *adapter,
 		 */
 		txn = mgmt_txn_create_new(0, MGMTD_TXN_TYPE_CONFIG);
 		if (!txn) {
-			MGMTD_TXN_ERR("Failed to create CONFIG Transaction for downloading CONFIGs for client '%s'",
-				      adapter->name);
+			__log_err("Failed to create CONFIG Transaction for downloading CONFIGs for client '%s'",
+				  adapter->name);
 			nb_config_diff_del_changes(adapter_cfgs);
 			return -1;
 		}
 
-		MGMTD_TXN_DBG("Created initial txn-id: %" PRIu64
-			      " for BE client '%s'",
-			      txn->txn_id, adapter->name);
+		__dbg("Created initial txn-id: %" PRIu64 " for BE client '%s'",
+		      txn->txn_id, adapter->name);
 		/*
 		 * Set the changeset for transaction to commit and trigger the
 		 * commit request.
@@ -2238,9 +2205,10 @@ int mgmt_txn_notify_be_cfgdata_reply(uint64_t txn_id, bool success,
 	cmtcfg_req = &txn->commit_cfg_req->req.commit_cfg;
 
 	if (!success) {
-		MGMTD_TXN_ERR("CFGDATA_CREATE_REQ sent to '%s' failed txn-id: %" PRIu64
-			      " err: %s", adapter->name, txn->txn_id,
-			      error_if_any ? error_if_any : "None");
+		__log_err("CFGDATA_CREATE_REQ sent to '%s' failed txn-id: %" PRIu64
+			  " err: %s",
+			  adapter->name, txn->txn_id,
+			  error_if_any ? error_if_any : "None");
 		mgmt_txn_send_commit_cfg_reply(
 			txn, MGMTD_INTERNAL_ERROR,
 			error_if_any
@@ -2249,9 +2217,9 @@ int mgmt_txn_notify_be_cfgdata_reply(uint64_t txn_id, bool success,
 		return 0;
 	}
 
-	MGMTD_TXN_DBG("CFGDATA_CREATE_REQ sent to '%s' was successful txn-id: %" PRIu64
-		      " err: %s", adapter->name, txn->txn_id,
-		      error_if_any ? error_if_any : "None");
+	__dbg("CFGDATA_CREATE_REQ sent to '%s' was successful txn-id: %" PRIu64
+	      " err: %s",
+	      adapter->name, txn->txn_id, error_if_any ? error_if_any : "None");
 
 	cmtcfg_req->be_phase[adapter->id] = MGMTD_COMMIT_PHASE_APPLY_CFG;
 
@@ -2274,10 +2242,10 @@ int mgmt_txn_notify_be_cfg_apply_reply(uint64_t txn_id, bool success,
 	cmtcfg_req = &txn->commit_cfg_req->req.commit_cfg;
 
 	if (!success) {
-		MGMTD_TXN_ERR("CFGDATA_APPLY_REQ sent to '%s' failed txn-id: %" PRIu64
-			      " err: %s",
-			      adapter->name, txn->txn_id,
-			      error_if_any ? error_if_any : "None");
+		__log_err("CFGDATA_APPLY_REQ sent to '%s' failed txn-id: %" PRIu64
+			  " err: %s",
+			  adapter->name, txn->txn_id,
+			  error_if_any ? error_if_any : "None");
 		mgmt_txn_send_commit_cfg_reply(
 			txn, MGMTD_INTERNAL_ERROR,
 			error_if_any
@@ -2322,7 +2290,7 @@ int mgmt_txn_send_get_req(uint64_t txn_id, uint64_t req_id,
 	for (indx = 0;
 	     indx < num_reqs && indx < MGMTD_MAX_NUM_DATA_REPLY_IN_BATCH;
 	     indx++) {
-		MGMTD_TXN_DBG("XPath: '%s'", data_req[indx]->data->xpath);
+		__dbg("XPath: '%s'", data_req[indx]->data->xpath);
 		txn_req->req.get_data->xpaths[indx] =
 			strdup(data_req[indx]->data->xpath);
 		txn_req->req.get_data->num_xpaths++;
@@ -2427,13 +2395,13 @@ state:
 	FOREACH_BE_CLIENT_BITS (id, clients) {
 		ret = mgmt_be_send_native(id, msg);
 		if (ret) {
-			MGMTD_TXN_ERR("Could not send get-tree message to backend client %s",
-				      mgmt_be_client_id2name(id));
+			__log_err("Could not send get-tree message to backend client %s",
+				  mgmt_be_client_id2name(id));
 			continue;
 		}
 
-		MGMTD_TXN_DBG("Sent get-tree req to backend client %s",
-			      mgmt_be_client_id2name(id));
+		__dbg("Sent get-tree req to backend client %s",
+		      mgmt_be_client_id2name(id));
 
 		/* record that we sent the request to the client */
 		get_tree->sent_clients |= (1u << id);
@@ -2467,8 +2435,8 @@ int mgmt_txn_notify_error(struct mgmt_be_client_adapter *adapter,
 	struct mgmt_txn_req *txn_req;
 
 	if (!txn) {
-		MGMTD_TXN_ERR("Error reply from %s cannot find txn-id %" PRIu64,
-			      adapter->name, txn_id);
+		__log_err("Error reply from %s cannot find txn-id %" PRIu64,
+			  adapter->name, txn_id);
 		return -1;
 	}
 
@@ -2477,15 +2445,14 @@ int mgmt_txn_notify_error(struct mgmt_be_client_adapter *adapter,
 		if (txn_req->req_id == req_id)
 			break;
 	if (!txn_req) {
-		MGMTD_TXN_ERR("Error reply from %s for txn-id %" PRIu64
-			      " cannot find req_id %" PRIu64,
-			      adapter->name, txn_id, req_id);
+		__log_err("Error reply from %s for txn-id %" PRIu64
+			  " cannot find req_id %" PRIu64,
+			  adapter->name, txn_id, req_id);
 		return -1;
 	}
 
-	MGMTD_TXN_ERR("Error reply from %s for txn-id %" PRIu64
-		      " req_id %" PRIu64,
-		      adapter->name, txn_id, req_id);
+	__log_err("Error reply from %s for txn-id %" PRIu64 " req_id %" PRIu64,
+		  adapter->name, txn_id, req_id);
 
 	switch (txn_req->req_event) {
 	case MGMTD_TXN_PROC_GETTREE:
@@ -2528,8 +2495,8 @@ int mgmt_txn_notify_tree_data_reply(struct mgmt_be_client_adapter *adapter,
 	LY_ERR err;
 
 	if (!txn) {
-		MGMTD_TXN_ERR("GETTREE reply from %s for a missing txn-id %" PRIu64,
-			      adapter->name, txn_id);
+		__log_err("GETTREE reply from %s for a missing txn-id %" PRIu64,
+			  adapter->name, txn_id);
 		return -1;
 	}
 
@@ -2538,9 +2505,9 @@ int mgmt_txn_notify_tree_data_reply(struct mgmt_be_client_adapter *adapter,
 		if (txn_req->req_id == req_id)
 			break;
 	if (!txn_req) {
-		MGMTD_TXN_ERR("GETTREE reply from %s for txn-id %" PRIu64
-			      " missing req_id %" PRIu64,
-			      adapter->name, txn_id, req_id);
+		__log_err("GETTREE reply from %s for txn-id %" PRIu64
+			  " missing req_id %" PRIu64,
+			  adapter->name, txn_id, req_id);
 		return -1;
 	}
 
@@ -2552,11 +2519,9 @@ int mgmt_txn_notify_tree_data_reply(struct mgmt_be_client_adapter *adapter,
 				 LYD_PARSE_STRICT | LYD_PARSE_ONLY,
 				 0 /*LYD_VALIDATE_OPERATIONAL*/, &tree);
 	if (err) {
-		MGMTD_TXN_ERR("GETTREE reply from %s for txn-id %" PRIu64
-			      " req_id %" PRIu64
-			      " error parsing result of type %u",
-			      adapter->name, txn_id, req_id,
-			      data_msg->result_type);
+		__log_err("GETTREE reply from %s for txn-id %" PRIu64
+			  " req_id %" PRIu64 " error parsing result of type %u",
+			  adapter->name, txn_id, req_id, data_msg->result_type);
 	}
 	if (!err) {
 		/* TODO: we could merge ly_errs here if it's not binary */
@@ -2567,9 +2532,9 @@ int mgmt_txn_notify_tree_data_reply(struct mgmt_be_client_adapter *adapter,
 			err = lyd_merge_siblings(&get_tree->client_results,
 						 tree, LYD_MERGE_DESTRUCT);
 		if (err) {
-			MGMTD_TXN_ERR("GETTREE reply from %s for txn-id %" PRIu64
-				      " req_id %" PRIu64 " error merging result",
-				      adapter->name, txn_id, req_id);
+			__log_err("GETTREE reply from %s for txn-id %" PRIu64
+				  " req_id %" PRIu64 " error merging result",
+				  adapter->name, txn_id, req_id);
 		}
 	}
 	if (!get_tree->partial_error)
@@ -2642,12 +2607,12 @@ int mgmt_txn_rollback_trigger_cfg_apply(struct mgmt_ds_ctx *src_ds_ctx,
 	 */
 	txn = mgmt_txn_create_new(0, MGMTD_TXN_TYPE_CONFIG);
 	if (!txn) {
-		MGMTD_TXN_ERR(
+		__log_err(
 			"Failed to create CONFIG Transaction for downloading CONFIGs");
 		return -1;
 	}
 
-	MGMTD_TXN_DBG("Created rollback txn-id: %" PRIu64, txn->txn_id);
+	__dbg("Created rollback txn-id: %" PRIu64, txn->txn_id);
 
 	/*
 	 * Set the changeset for transaction to commit and trigger the commit


### PR DESCRIPTION
The old code using `ALL_CAP_MACROS` draws too much attention away from the actual functional code. Use localized names that are still noticeably different don't demand you stare at them instead of the actual functional code.