### PR TITLE
*: create a single registry of daemons' default port values

### DIFF
--- a/babeld/babeld.h
+++ b/babeld/babeld.h
@@ -53,7 +53,6 @@ Copyright 2011 by Matthieu Boutier and Juliusz Chroboczek
 #endif
 
 
-#define BABEL_VTY_PORT 2609
 #define BABEL_DEFAULT_CONFIG "babeld.conf"
 
 /* Values in milliseconds */

--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -119,7 +119,7 @@ static const struct frr_yang_module_info *const bfdd_yang_modules[] = {
 
 /* clang-format off */
 FRR_DAEMON_INFO(bfdd, BFD,
-	.vty_port = 2617,
+	.vty_port = BFDD_VTY_PORT,
 	.proghelp = "Implementation of the BFD protocol.",
 
 	.signals = bfd_signals,

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2064,7 +2064,6 @@ struct bgp_nlri {
 #define BGP_UPTIME_LEN 25
 
 /* Default configuration settings for bgpd.  */
-#define BGP_VTY_PORT                          2605
 #define BGP_DEFAULT_CONFIG             "bgpd.conf"
 
 /* BGP Dynamic Neighbors feature */

--- a/eigrpd/eigrp_const.h
+++ b/eigrpd/eigrp_const.h
@@ -61,9 +61,6 @@
 /* IP TTL for EIGRP protocol. */
 #define EIGRP_IP_TTL             1
 
-/* VTY port number. */
-#define EIGRP_VTY_PORT          2613
-
 /* Default configuration file name for eigrp. */
 #define EIGRP_DEFAULT_CONFIG   "eigrpd.conf"
 

--- a/fpm/fpm.h
+++ b/fpm/fpm.h
@@ -63,11 +63,6 @@
 #define FPM_DEFAULT_IP              (htonl (INADDR_LOOPBACK))
 
 /*
- * default port for fpm connections
- */
-#define FPM_DEFAULT_PORT 2620
-
-/*
  * Largest message that can be sent to or received from the FPM.
  */
 #define FPM_MAX_MSG_LEN 4096

--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -51,9 +51,6 @@
 
 /* Default configuration file name */
 #define ISISD_DEFAULT_CONFIG "isisd.conf"
-/* Default vty port */
-#define ISISD_VTY_PORT       2608
-#define FABRICD_VTY_PORT     2618
 
 #define FABRICD_STATE_NAME "%s/fabricd.json", frr_libstatedir
 #define ISISD_STATE_NAME   "%s/isisd.json", frr_libstatedir

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -104,7 +104,6 @@ void ldp_agentx_enabled(void)
 enum ldpd_process ldpd_process;
 
 #define LDP_DEFAULT_CONFIG	"ldpd.conf"
-#define LDP_VTY_PORT		2612
 
 /* Master of threads. */
 struct event_loop *master;

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -208,7 +208,7 @@ bool frr_zclient_addr(struct sockaddr_storage *sa, socklen_t *sa_len,
 	if (!strncmp(path, ZAPI_TCP_PATHNAME, strlen(ZAPI_TCP_PATHNAME))) {
 		/* note: this functionality is disabled at bottom */
 		int af;
-		int port = ZEBRA_PORT;
+		int port = ZEBRA_TCP_PORT;
 		char *err = NULL;
 		struct sockaddr_in *sin = NULL;
 		struct sockaddr_in6 *sin6 = NULL;

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -55,6 +55,49 @@ struct log_arg {
 };
 DECLARE_DLIST(log_args, struct log_arg, itm);
 
+/* Registry of daemons' port defaults. Many of these are VTY ports; some
+ * daemons have default ports for other features such as ospfapi, or zebra's
+ * FPM.
+ */
+
+/* default zebra TCP port for zapi; this is currently disabled for security
+ * reasons.
+ */
+#define ZEBRA_TCP_PORT 2600
+
+#define ZEBRA_VTY_PORT 2601
+#define RIP_VTY_PORT 2602
+#define RIPNG_VTY_PORT 2603
+#define OSPF_VTY_PORT 2604
+#define BGP_VTY_PORT 2605
+#define OSPF6_VTY_PORT 2606
+
+/* Default API server port to accept connection request from client-side.
+ * This value could be overridden by "ospfapi" entry in "/etc/services".
+ */
+#define OSPF_API_SYNC_PORT 2607
+
+#define ISISD_VTY_PORT 2608
+#define BABEL_VTY_PORT 2609
+#define NHRP_VTY_PORT 2610
+#define PIMD_VTY_PORT 2611
+#define LDP_VTY_PORT 2612
+#define EIGRP_VTY_PORT 2613
+#define SHARP_VTY_PORT 2614
+#define PBR_VTY_PORT 2615
+#define STATIC_VTY_PORT 2616
+#define BFDD_VTY_PORT 2617
+#define FABRICD_VTY_PORT 2618
+#define VRRP_VTY_PORT 2619
+
+/* default port for FPM connections */
+#define FPM_DEFAULT_PORT 2620
+
+#define PATH_VTY_PORT 2621
+#define PIM6D_VTY_PORT 2622
+#define MGMTD_VTY_PORT 2623
+/* Registry of daemons' port defaults */
+
 enum frr_cli_mode {
 	FRR_CLI_CLASSIC = 0,
 	FRR_CLI_TRANSACTIONAL,

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -221,9 +221,6 @@ struct in_pktinfo {
 #define IN6_ARE_ADDR_EQUAL IN6_IS_ADDR_EQUAL
 #endif /* IN6_ARE_ADDR_EQUAL */
 
-/* default zebra TCP port for zclient */
-#define ZEBRA_PORT			2600
-
 /* Zebra route's types are defined in route_types.h */
 #include "lib/route_types.h"
 

--- a/mgmtd/mgmt.h
+++ b/mgmtd/mgmt.h
@@ -20,7 +20,6 @@
 #include "mgmtd/mgmt_txn.h"
 #include "mgmtd/mgmt_ds.h"
 
-#define MGMTD_VTY_PORT 2623
 #define MGMTD_SOCKET_BUF_SIZE 65535
 #define MGMTD_MAX_COMMIT_LIST 10
 

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -16,7 +16,6 @@ DECLARE_MGROUP(NHRPD);
 
 #define NHRPD_DEFAULT_HOLDTIME	7200
 
-#define NHRP_VTY_PORT		2610
 #define NHRP_DEFAULT_CONFIG	"nhrpd.conf"
 
 extern struct event_loop *master;

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -46,9 +46,6 @@
  * is excessive for just supporting a legacy compatibility file location
  */
 
-/* Default port values. */
-#define OSPF6_VTY_PORT             2606
-
 /* ospf6d privileges */
 zebra_capabilities_t _caps_p[] = {ZCAP_NET_RAW, ZCAP_BIND, ZCAP_SYS_ADMIN};
 

--- a/ospfd/ospf_api.h
+++ b/ospfd/ospf_api.h
@@ -21,10 +21,6 @@
 #define MTYPE_OSPF_API_MSG      MTYPE_TMP
 #define MTYPE_OSPF_API_FIFO     MTYPE_TMP
 
-/* Default API server port to accept connection request from client-side. */
-/* This value could be overridden by "ospfapi" entry in "/etc/services". */
-#define OSPF_API_SYNC_PORT      2607
-
 /* -----------------------------------------------------------
  * Generic messages
  * -----------------------------------------------------------

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -22,9 +22,6 @@
 
 #define OSPF_VERSION            2
 
-/* VTY port number. */
-#define OSPF_VTY_PORT          2604
-
 /* IP TTL for OSPF protocol. */
 #define OSPF_IP_TTL             1
 #define OSPF_VL_IP_TTL          100

--- a/pathd/path_main.c
+++ b/pathd/path_main.c
@@ -95,8 +95,6 @@ static const struct frr_yang_module_info *pathd_yang_modules[] = {
 	&frr_pathd_info,
 };
 
-#define PATH_VTY_PORT 2621
-
 /* clang-format off */
 FRR_DAEMON_INFO(pathd, PATH,
 	.vty_port = PATH_VTY_PORT,

--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -103,8 +103,6 @@ struct frr_signal_t pbr_signals[] = {
 	},
 };
 
-#define PBR_VTY_PORT 2615
-
 static const struct frr_yang_module_info *const pbrd_yang_modules[] = {
 	&frr_filter_info,
 	&frr_interface_info,

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -19,9 +19,6 @@
 #include "pim_memory.h"
 #include "pim_assert.h"
 
-#define PIMD_VTY_PORT       2611
-#define PIM6D_VTY_PORT      2622
-
 #define PIM_IP_PROTO_IGMP             (2)
 #define PIM_IP_PROTO_PIM              (103)
 #define PIM_IGMP_MIN_LEN              (8)

--- a/ripd/ripd.h
+++ b/ripd/ripd.h
@@ -51,7 +51,6 @@
 
 /* RIP port number. */
 #define RIP_PORT_DEFAULT               520
-#define RIP_VTY_PORT                  2602
 
 /* Default configuration file name. */
 #define RIPD_DEFAULT_CONFIG    "ripd.conf"

--- a/ripngd/ripngd.h
+++ b/ripngd/ripngd.h
@@ -16,7 +16,6 @@
 /* RIPng version and port number. */
 #define RIPNG_V1                         1
 #define RIPNG_PORT_DEFAULT             521
-#define RIPNG_VTY_PORT                2603
 #define RIPNG_MAX_PACKET_SIZE         1500
 #define RIPNG_PRIORITY_DEFAULT           0
 

--- a/sharpd/sharp_main.c
+++ b/sharpd/sharp_main.c
@@ -120,8 +120,6 @@ struct frr_signal_t sharp_signals[] = {
 	},
 };
 
-#define SHARP_VTY_PORT 2614
-
 static const struct frr_yang_module_info *const sharpd_yang_modules[] = {
 	&frr_filter_info,
 	&frr_interface_info,

--- a/staticd/static_main.c
+++ b/staticd/static_main.c
@@ -113,8 +113,6 @@ static const struct frr_yang_module_info *const staticd_yang_modules[] = {
 	&frr_staticd_info,
 };
 
-#define STATIC_VTY_PORT 2616
-
 /*
  * NOTE: .flags == FRR_NO_SPLIT_CONFIG to avoid reading split config, mgmtd will
  * do this for us now

--- a/vrrpd/vrrp_main.c
+++ b/vrrpd/vrrp_main.c
@@ -107,8 +107,6 @@ static const struct frr_yang_module_info *const vrrp_yang_modules[] = {
 	&frr_vrrpd_info,
 };
 
-#define VRRP_VTY_PORT 2619
-
 /* clang-format off */
 FRR_DAEMON_INFO(vrrpd, VRRP,
 	.vty_port = VRRP_VTY_PORT,

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -45,7 +45,6 @@
 #include "fpm/fpm.h"
 
 #define SOUTHBOUND_DEFAULT_ADDR INADDR_LOOPBACK
-#define SOUTHBOUND_DEFAULT_PORT 2620
 
 /*
  * Time in seconds that if the other end is not responding
@@ -217,7 +216,7 @@ DEFUN(fpm_set_address, fpm_set_address_cmd,
 		memset(sin, 0, sizeof(*sin));
 		sin->sin_family = AF_INET;
 		sin->sin_port =
-			port ? htons(port) : htons(SOUTHBOUND_DEFAULT_PORT);
+			port ? htons(port) : htons(FPM_DEFAULT_PORT);
 #ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
 		sin->sin_len = sizeof(*sin);
 #endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
@@ -235,7 +234,7 @@ DEFUN(fpm_set_address, fpm_set_address_cmd,
 	sin6 = (struct sockaddr_in6 *)&gfnc->addr;
 	memset(sin6, 0, sizeof(*sin6));
 	sin6->sin6_family = AF_INET6;
-	sin6->sin6_port = port ? htons(port) : htons(SOUTHBOUND_DEFAULT_PORT);
+	sin6->sin6_port = port ? htons(port) : htons(FPM_DEFAULT_PORT);
 #ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
 	sin6->sin6_len = sizeof(*sin6);
 #endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
@@ -402,7 +401,7 @@ static int fpm_write_config(struct vty *vty)
 		written = 1;
 		sin = (struct sockaddr_in *)&gfnc->addr;
 		vty_out(vty, "fpm address %pI4", &sin->sin_addr);
-		if (sin->sin_port != htons(SOUTHBOUND_DEFAULT_PORT))
+		if (sin->sin_port != htons(FPM_DEFAULT_PORT))
 			vty_out(vty, " port %d", ntohs(sin->sin_port));
 
 		vty_out(vty, "\n");
@@ -411,7 +410,7 @@ static int fpm_write_config(struct vty *vty)
 		written = 1;
 		sin6 = (struct sockaddr_in6 *)&gfnc->addr;
 		vty_out(vty, "fpm address %pI6", &sin6->sin6_addr);
-		if (sin6->sin6_port != htons(SOUTHBOUND_DEFAULT_PORT))
+		if (sin6->sin6_port != htons(FPM_DEFAULT_PORT))
 			vty_out(vty, " port %d", ntohs(sin6->sin6_port));
 
 		vty_out(vty, "\n");

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -31,9 +31,6 @@ extern "C" {
 
 struct zebra_vrf;
 
-/* Default port information. */
-#define ZEBRA_VTY_PORT                2601
-
 /* Default configuration filename. */
 #define DEFAULT_CONFIG_FILE "zebra.conf"
 


### PR DESCRIPTION
Create a single registry of default port values that daemons are using. Most of these are vty ports, but there are some others for features like ospfapi and zebra FPM. Currently, the various values are scattered through the code.
