### PR TITLE
doc: Add some documentation around a new pthread call

### DIFF
--- a/doc/developer/rcu.rst
+++ b/doc/developer/rcu.rst
@@ -232,6 +232,15 @@ Internals
    that case, either all of the library's threads must be registered for RCU,
    or the code must instead pass a (non-RCU) copy of the data to the library.
 
+.. c:function:: int frr_pthread_non_controlled_startup(pthread_t thread, const char *name, const char *os_name)
+
+   If a pthread is started outside the control of normal pthreads in frr
+   then frr_pthread_non_controlled_startup should be called.  This will
+   properly setup both the pthread with rcu usage as well as some data
+   structures pertaining to the name of the pthread.  This is especially
+   important if the pthread created ends up calling back into FRR and
+   one of the various zlog_XXX functions is called.
+
 .. c:function:: void rcu_shutdown(void)
 
    Stop the RCU sweeper thread and make sure all cleanup has finished.


### PR DESCRIPTION
Not necessarily the correct place for this but there is no other place and it needs to be called out and I would rather have some documentation in place.  Long term I would like to add a bunch of frr_pthread documentation but at this point in time it's not there.  We can
re-arrange when that happens.