### PR TITLE
vtysh: Remove deprecated shell_access code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -784,8 +784,6 @@ AC_ARG_ENABLE([configfile_mask],
   AS_HELP_STRING([--enable-configfile-mask=ARG], [set mask for config files]))
 AC_ARG_ENABLE([logfile_mask],
   AS_HELP_STRING([--enable-logfile-mask=ARG], [set mask for log files]))
-AC_ARG_ENABLE([shell_access],
-  AS_HELP_STRING([--enable-shell-access], [Allow users to access shell/telnet/ssh]))
 AC_ARG_ENABLE([realms],
   AS_HELP_STRING([--enable-realms], [enable REALMS support under Linux]))
 AC_ARG_ENABLE([rtadv],
@@ -896,10 +894,6 @@ fi
 
 AC_SUBST([DFLT_NAME])
 AC_DEFINE_UNQUOTED([DFLT_NAME], ["$DFLT_NAME"], [Name of the configuration default set])
-
-if test "$enable_shell_access" = "yes"; then
-   AC_DEFINE([HAVE_SHELL_ACCESS], [1], [Allow user to use ssh/telnet/bash, be aware this is considered insecure])
-fi
 
 #
 # Python for clippy

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -309,13 +309,6 @@ options from the list below.
    make these arrays at build time.  Additionally if this parameter is
    not passed in FRR will default to 16 ECMP.
 
-.. option:: --enable-shell-access
-
-   Turn on the ability of FRR to access some shell options( telnet/ssh/bash/etc. )
-   from vtysh itself.  This option is considered extremely unsecure and should only
-   be considered for usage if you really really know what you are doing.  This
-   option is deprecated and will be removed on Feb 1, 2024.
-
 .. option:: --enable-gcov
 
    Code coverage reports from gcov require adjustments to the C and LD flags.

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -4234,71 +4234,6 @@ DEFUN (vtysh_traceroute6,
 	return CMD_SUCCESS;
 }
 
-#if CONFDATE > 20240201
-CPP_NOTICE("Remove HAVE_SHELL_ACCESS and it's documentation");
-#endif
-#if defined(HAVE_SHELL_ACCESS)
-DEFUN (vtysh_telnet,
-       vtysh_telnet_cmd,
-       "telnet WORD",
-       "Open a telnet connection\n"
-       "IP address or hostname of a remote system\n")
-{
-	execute_command("telnet", 1, argv[1]->arg, NULL);
-	return CMD_SUCCESS;
-}
-
-DEFUN (vtysh_telnet_port,
-       vtysh_telnet_port_cmd,
-       "telnet WORD PORT",
-       "Open a telnet connection\n"
-       "IP address or hostname of a remote system\n"
-       "TCP Port number\n")
-{
-	execute_command("telnet", 2, argv[1]->arg, argv[2]->arg);
-	return CMD_SUCCESS;
-}
-
-DEFUN (vtysh_ssh,
-       vtysh_ssh_cmd,
-       "ssh WORD",
-       "Open an ssh connection\n"
-       "[user@]host\n")
-{
-	execute_command("ssh", 1, argv[1]->arg, NULL);
-	return CMD_SUCCESS;
-}
-
-DEFUN (vtysh_start_shell,
-       vtysh_start_shell_cmd,
-       "start-shell",
-       "Start UNIX shell\n")
-{
-	execute_command("sh", 0, NULL, NULL);
-	return CMD_SUCCESS;
-}
-
-DEFUN (vtysh_start_bash,
-       vtysh_start_bash_cmd,
-       "start-shell bash",
-       "Start UNIX shell\n"
-       "Start bash\n")
-{
-	execute_command("bash", 0, NULL, NULL);
-	return CMD_SUCCESS;
-}
-
-DEFUN (vtysh_start_zsh,
-       vtysh_start_zsh_cmd,
-       "start-shell zsh",
-       "Start UNIX shell\n"
-       "Start Z shell\n")
-{
-	execute_command("zsh", 0, NULL, NULL);
-	return CMD_SUCCESS;
-}
-#endif
-
 DEFUN (config_list,
        config_list_cmd,
        "list [permutations]",
@@ -5194,16 +5129,6 @@ void vtysh_init_vty(void)
 	install_element(VIEW_NODE, &vtysh_mtrace_cmd);
 	install_element(VIEW_NODE, &vtysh_ping6_cmd);
 	install_element(VIEW_NODE, &vtysh_traceroute6_cmd);
-#if defined(HAVE_SHELL_ACCESS)
-	install_element(VIEW_NODE, &vtysh_telnet_cmd);
-	install_element(VIEW_NODE, &vtysh_telnet_port_cmd);
-	install_element(VIEW_NODE, &vtysh_ssh_cmd);
-#endif
-#if defined(HAVE_SHELL_ACCESS)
-	install_element(ENABLE_NODE, &vtysh_start_shell_cmd);
-	install_element(ENABLE_NODE, &vtysh_start_bash_cmd);
-	install_element(ENABLE_NODE, &vtysh_start_zsh_cmd);
-#endif
 
 	/* debugging */
 	install_element(VIEW_NODE, &vtysh_show_error_code_cmd);


### PR DESCRIPTION
This code has been deprecated for over a year and frankly needs to be removed from the system.