### PR TITLE
nb_sysrepo : set change errmsg in sysrepo session

### DIFF
--- a/lib/northbound_sysrepo.c
+++ b/lib/northbound_sysrepo.c
@@ -279,11 +279,13 @@ static int frr_sr_config_change_cb_prepare(sr_session_ctx_t *session,
 	ret = nb_candidate_commit_prepare(context, candidate, NULL,
 					  &transaction, false, false, errmsg,
 					  sizeof(errmsg));
-	if (ret != NB_OK && ret != NB_ERR_NO_CHANGES)
-		flog_warn(
-			EC_LIB_LIBSYSREPO,
-			"%s: failed to prepare configuration transaction: %s (%s)",
-			__func__, nb_err_name(ret), errmsg);
+    if (ret != NB_OK && ret != NB_ERR_NO_CHANGES) {
+        flog_warn(
+                EC_LIB_LIBSYSREPO,
+                "%s: failed to prepare configuration transaction: %s (%s)",
+                __func__, nb_err_name(ret), errmsg);
+        sr_session_set_error_message(session, errmsg);
+    }
 
 	if (!transaction)
 		nb_config_free(candidate);


### PR DESCRIPTION
when error occur during the config change event, we should have this set in the sysrepo session,
so user can see what went wrong.

for example when using sysrepo based cli:

before the change:
```
pc# conf t
pc(config)# lib-frr-interface 
pc(config-lib-frr-interface)# no interface virbr0
pc(config-lib-frr-interface)# commit
[ERR] User callback failed.
commit_failed: failed to commit changes!
pc(config-lib-frr-interface)#
```

after the change:
```
pc(config-lib-frr-interface)# no interface virbr0 
pc(config-lib-frr-interface)# commit 
[ERR] only inactive interfaces can be deleted 
[ERR] User callback failed.
commit_failed: failed to commit changes!
pc(config-lib-frr-interface)#
```