### PR TITLE
lib, mgmtd: fix missing embedded modules

### DIFF
--- a/lib/yang.c
+++ b/lib/yang.c
@@ -40,7 +40,8 @@ static LY_ERR yang_module_imp_clb(const char *mod_name, const char *mod_rev,
 	struct yang_module_embed *e;
 
 	if (!strcmp(mod_name, "ietf-inet-types") ||
-	    !strcmp(mod_name, "ietf-yang-types"))
+	    !strcmp(mod_name, "ietf-yang-types") ||
+	    !strcmp(mod_name, "ietf-yang-metadata"))
 		/* libyang has these built in, don't try finding them here */
 		return LY_ENOTFOUND;
 

--- a/mgmtd/subdir.am
+++ b/mgmtd/subdir.am
@@ -61,6 +61,7 @@ mgmtd_mgmtd_SOURCES = \
 	# end
 nodist_mgmtd_mgmtd_SOURCES = \
 	yang/frr-zebra.yang.c \
+	yang/frr-zebra-route-map.yang.c \
 	yang/ietf/ietf-netconf-acm.yang.c \
 	yang/ietf/ietf-netconf.yang.c \
 	yang/ietf/ietf-netconf-with-defaults.yang.c \


### PR DESCRIPTION
Fixes the following warnings:
```
MGMTD: [HG1WF-2N96F] YANG model "ietf-yang-metadata@*" "*@*"not embedded, trying external file
MGMTD: [HG1WF-2N96F] YANG model "frr-zebra-route-map@*" "*@*"not embedded, trying external file
```