### PR TITLE
doc: remove [no] from commands

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3473,7 +3473,7 @@ The import filtering described in item (2) is constrained just to Type-2
 The EVPN MAC-VRF Site-of-Origin can be configured using a single CLI command
 under ``address-family l2vpn evpn`` of the EVPN underlay BGP instance.
 
-.. clicmd:: [no] mac-vrf soo <site-of-origin-string>
+.. clicmd:: mac-vrf soo <site-of-origin-string>
 
 Example configuration:
 
@@ -3619,7 +3619,7 @@ route maybe fragmented.
 The number of EVIs per-EAD route can be configured via the following
 BGP command -
 
-.. clicmd:: [no] ead-es-frag evi-limit (1-1000)
+.. clicmd:: ead-es-frag evi-limit (1-1000)
 
 Sample Configuration
 ^^^^^^^^^^^^^^^^^^^^^

--- a/doc/user/mgmtd.rst
+++ b/doc/user/mgmtd.rst
@@ -371,22 +371,22 @@ MGMT Daemon debug commands
 
 The following debug commands enable debugging within the management daemon:
 
-.. clicmd:: [no] debug mgmt backend
+.. clicmd:: debug mgmt backend
 
    Enable[/Disable] debugging messages related to backend operations within the
    management daemon.
 
-.. clicmd:: [no] debug mgmt datastore
+.. clicmd:: debug mgmt datastore
 
    Enable[/Disable] debugging messages related to YANG datastore operations
    within the management daemon.
 
-.. clicmd:: [no] debug mgmt frontend
+.. clicmd:: debug mgmt frontend
 
    Enable[/Disable] debugging messages related to frontend operations within the
    management daemon.
 
-.. clicmd:: [no] debug mgmt transaction
+.. clicmd:: debug mgmt transaction
 
    Enable[/Disable] debugging messages related to transactions within the
    management daemon.
@@ -398,12 +398,12 @@ MGMT Client debug commands
 The following debug commands enable debugging within the management front and
 backend clients:
 
-.. clicmd:: [no] debug mgmt client backend
+.. clicmd:: debug mgmt client backend
 
    Enable[/Disable] debugging messages related to backend operations inside the
    backend mgmtd clients.
 
-.. clicmd:: [no] debug mgmt client frontend
+.. clicmd:: debug mgmt client frontend
 
    Enable[/Disable] debugging messages related to frontend operations inside the
    frontend mgmtd clients.

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -246,7 +246,7 @@ Under link parameter statement, the following commands set the different TE valu
    as specified in RFC3630 (OSPF) or RFC5305 (ISIS). Admin-group is also known
    as Resource Class/Color in the OSPF protocol.
 
-.. clicmd:: [no] affinity AFFINITY-MAP-NAME
+.. clicmd:: affinity AFFINITY-MAP-NAME
 
    This commands configures the Traffic Engineering Admin-Group of the
    interface using the affinity-map definitions (:ref:`affinity-map`).
@@ -257,7 +257,7 @@ Under link parameter statement, the following commands set the different TE valu
    ``admin-grp`` and ``affinity`` commands provide two ways of setting
    admin-groups. They cannot be both set on the same interface.
 
-.. clicmd:: [no] affinity-mode [extended|standard|both]
+.. clicmd:: affinity-mode [extended|standard|both]
 
    This commands configures which admin-group format is set by the affinity
    command. ``extended`` Admin-Group is the default and uses the RFC7308 format.


### PR DESCRIPTION
The rule is to document only positive versions of commands.