### PR TITLE
lib, mgmtd: don't register NB config callbacks in mgmtd

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -1748,6 +1748,8 @@ lib_interface_state_phy_address_get_elem(struct nb_cb_get_elem_args *args)
 }
 
 /* clang-format off */
+
+/* cli_show callbacks are kept here for daemons not yet converted to mgmtd */
 const struct frr_yang_module_info frr_interface_info = {
 	.name = "frr-interface",
 	.nodes = {
@@ -1824,6 +1826,29 @@ const struct frr_yang_module_info frr_interface_info = {
 			.cbs = {
 				.get_elem = lib_interface_state_phy_address_get_elem,
 			}
+		},
+		{
+			.xpath = NULL,
+		},
+	}
+};
+
+const struct frr_yang_module_info frr_interface_cli_info = {
+	.name = "frr-interface",
+	.ignore_cfg_cbs = true,
+	.nodes = {
+		{
+			.xpath = "/frr-interface:lib/interface",
+			.cbs = {
+				.cli_show = cli_show_interface,
+				.cli_show_end = cli_show_interface_end,
+			},
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/description",
+			.cbs = {
+				.cli_show = cli_show_interface_desc,
+			},
 		},
 		{
 			.xpath = NULL,

--- a/lib/if.h
+++ b/lib/if.h
@@ -636,6 +636,7 @@ extern void if_down_via_zapi(struct interface *ifp);
 extern void if_destroy_via_zapi(struct interface *ifp);
 
 extern const struct frr_yang_module_info frr_interface_info;
+extern const struct frr_yang_module_info frr_interface_cli_info;
 
 #ifdef __cplusplus
 }

--- a/lib/routing_nb.c
+++ b/lib/routing_nb.c
@@ -27,3 +27,13 @@ const struct frr_yang_module_info frr_routing_info = {
 		},
 	}
 };
+
+const struct frr_yang_module_info frr_routing_cli_info = {
+	.name = "frr-routing",
+	.ignore_cfg_cbs = true,
+	.nodes = {
+		{
+			.xpath = NULL,
+		},
+	}
+};

--- a/lib/routing_nb.h
+++ b/lib/routing_nb.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 extern const struct frr_yang_module_info frr_routing_info;
+extern const struct frr_yang_module_info frr_routing_cli_info;
 
 /* Mandatory callbacks. */
 int routing_control_plane_protocols_control_plane_protocol_create(

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -1034,6 +1034,8 @@ lib_vrf_state_active_get_elem(struct nb_cb_get_elem_args *args)
 }
 
 /* clang-format off */
+
+/* cli_show callbacks are kept here for daemons not yet converted to mgmtd */
 const struct frr_yang_module_info frr_vrf_info = {
 	.name = "frr-vrf",
 	.nodes = {
@@ -1069,3 +1071,19 @@ const struct frr_yang_module_info frr_vrf_info = {
 	}
 };
 
+const struct frr_yang_module_info frr_vrf_cli_info = {
+	.name = "frr-vrf",
+	.ignore_cfg_cbs = true,
+	.nodes = {
+		{
+			.xpath = "/frr-vrf:lib/vrf",
+			.cbs = {
+				.cli_show = lib_vrf_cli_write,
+				.cli_show_end = lib_vrf_cli_write_end,
+			},
+		},
+		{
+			.xpath = NULL,
+		},
+	}
+};

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -294,6 +294,7 @@ extern int vrf_enable(struct vrf *vrf);
 extern void vrf_delete(struct vrf *vrf);
 
 extern const struct frr_yang_module_info frr_vrf_info;
+extern const struct frr_yang_module_info frr_vrf_cli_info;
 
 #ifdef __cplusplus
 }

--- a/mgmtd/mgmt_main.c
+++ b/mgmtd/mgmt_main.c
@@ -171,10 +171,10 @@ const struct frr_yang_module_info zebra_route_map_info = {
  */
 static const struct frr_yang_module_info *const mgmt_yang_modules[] = {
 	&frr_filter_cli_info,
-	&frr_interface_info,
+	&frr_interface_cli_info,
 	&frr_route_map_cli_info,
-	&frr_routing_info,
-	&frr_vrf_info,
+	&frr_routing_cli_info,
+	&frr_vrf_cli_info,
 	&frr_affinity_map_cli_info,
 
 	/* mgmtd-only modules */


### PR DESCRIPTION
mgmtd is supposed to only register CLI callbacks. If configuration callbacks are registered, they are getting called on startup when mgmtd reads config files, and they can use infrastructure that is not initialized on mgmtd, or allocate some memory that is never freed.