### PR TITLE
bgpd: cleanup for path_info extra labels

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -4128,7 +4128,7 @@ size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer, afi_t afi,
 void bgp_packet_mpattr_prefix(struct stream *s, afi_t afi, safi_t safi,
 			      const struct prefix *p,
 			      const struct prefix_rd *prd, mpls_label_t *label,
-			      uint32_t num_labels, bool addpath_capable,
+			      uint8_t num_labels, bool addpath_capable,
 			      uint32_t addpath_tx_id, struct attr *attr)
 {
 	switch (safi) {
@@ -4341,7 +4341,7 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer,
 				struct bpacket_attr_vec_arr *vecarr,
 				struct prefix *p, afi_t afi, safi_t safi,
 				struct peer *from, struct prefix_rd *prd,
-				mpls_label_t *label, uint32_t num_labels,
+				mpls_label_t *label, uint8_t num_labels,
 				bool addpath_capable, uint32_t addpath_tx_id,
 				struct bgp_path_info *bpi)
 {
@@ -4921,7 +4921,7 @@ size_t bgp_packet_mpunreach_start(struct stream *s, afi_t afi, safi_t safi)
 void bgp_packet_mpunreach_prefix(struct stream *s, const struct prefix *p,
 				 afi_t afi, safi_t safi,
 				 const struct prefix_rd *prd,
-				 mpls_label_t *label, uint32_t num_labels,
+				 mpls_label_t *label, uint8_t num_labels,
 				 bool addpath_capable, uint32_t addpath_tx_id,
 				 struct attr *attr)
 {

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -393,7 +393,7 @@ extern bgp_size_t bgp_packet_attribute(
 	struct bgp *bgp, struct peer *peer, struct stream *s, struct attr *attr,
 	struct bpacket_attr_vec_arr *vecarr, struct prefix *p, afi_t afi,
 	safi_t safi, struct peer *from, struct prefix_rd *prd,
-	mpls_label_t *label, uint32_t num_labels, bool addpath_capable,
+	mpls_label_t *label, uint8_t num_labels, bool addpath_capable,
 	uint32_t addpath_tx_id, struct bgp_path_info *bpi);
 extern void bgp_dump_routes_attr(struct stream *s, struct bgp_path_info *bpi,
 				 const struct prefix *p);
@@ -451,7 +451,7 @@ extern size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer,
 extern void bgp_packet_mpattr_prefix(struct stream *s, afi_t afi, safi_t safi,
 				     const struct prefix *p,
 				     const struct prefix_rd *prd,
-				     mpls_label_t *label, uint32_t num_labels,
+				     mpls_label_t *label, uint8_t num_labels,
 				     bool addpath_capable,
 				     uint32_t addpath_tx_id, struct attr *);
 extern size_t bgp_packet_mpattr_prefix_size(afi_t afi, safi_t safi,
@@ -462,7 +462,7 @@ extern size_t bgp_packet_mpunreach_start(struct stream *s, afi_t afi,
 					 safi_t safi);
 extern void bgp_packet_mpunreach_prefix(
 	struct stream *s, const struct prefix *p, afi_t afi, safi_t safi,
-	const struct prefix_rd *prd, mpls_label_t *label, uint32_t num_labels,
+	const struct prefix_rd *prd, mpls_label_t *label, uint8_t num_labels,
 	bool addpath_capable, uint32_t addpath_tx_id, struct attr *attr);
 extern void bgp_packet_mpunreach_end(struct stream *s, size_t attrlen_pnt);
 

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -2722,7 +2722,7 @@ bool bgp_debug_zebra(const struct prefix *p)
 const char *bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi,
 				    const struct prefix_rd *prd,
 				    union prefixconstptr pu,
-				    mpls_label_t *label, uint32_t num_labels,
+				    mpls_label_t *label, uint8_t num_labels,
 				    int addpath_valid, uint32_t addpath_id,
 				    struct bgp_route_evpn *overlay_index,
 				    char *str, int size)

--- a/bgpd/bgp_debug.h
+++ b/bgpd/bgp_debug.h
@@ -178,7 +178,7 @@ extern bool bgp_debug_zebra(const struct prefix *p);
 
 extern const char *bgp_debug_rdpfxpath2str(
 	afi_t afi, safi_t safi, const struct prefix_rd *prd,
-	union prefixconstptr pu, mpls_label_t *label, uint32_t num_labels,
+	union prefixconstptr pu, mpls_label_t *label, uint8_t num_labels,
 	int addpath_valid, uint32_t addpath_id,
 	struct bgp_route_evpn *overlay_index, char *str, int size);
 const char *bgp_notify_admin_message(char *buf, size_t bufsz, uint8_t *data,

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2896,7 +2896,7 @@ bgp_create_evpn_bgp_path_info(struct bgp_path_info *parent_pi,
 	if (parent_pi->extra) {
 		memcpy(&pi->extra->label, &parent_pi->extra->label,
 		       sizeof(pi->extra->label));
-		pi->extra->num_labels = parent_pi->extra->num_labels;
+		pi->extra->num_labels = bgp_path_info_num_labels(parent_pi);
 		pi->extra->igpmetric = parent_pi->extra->igpmetric;
 	}
 

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -1882,7 +1882,7 @@ static int update_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 	struct attr *attr_new;
 	struct attr local_attr;
 	mpls_label_t label[BGP_MAX_LABELS];
-	uint32_t num_labels = 1;
+	uint8_t num_labels = 1;
 	int route_change = 1;
 	uint8_t sticky = 0;
 	const struct prefix_evpn *evp;
@@ -4612,7 +4612,7 @@ static int process_type2_route(struct peer *peer, afi_t afi, safi_t safi,
 	uint8_t macaddr_len;
 	/* holds the VNI(s) as in packet */
 	mpls_label_t label[BGP_MAX_LABELS] = {};
-	uint32_t num_labels = 0;
+	uint8_t num_labels = 0;
 	uint32_t eth_tag;
 	int ret = 0;
 
@@ -4955,7 +4955,7 @@ static int process_type5_route(struct peer *peer, afi_t afi, safi_t safi,
 
 static void evpn_mpattr_encode_type5(struct stream *s, const struct prefix *p,
 				     const struct prefix_rd *prd,
-				     mpls_label_t *label, uint32_t num_labels,
+				     mpls_label_t *label, uint8_t num_labels,
 				     struct attr *attr)
 {
 	int len;
@@ -5745,7 +5745,7 @@ int bgp_evpn_uninstall_routes(struct bgp *bgp, struct bgpevpn *vpn)
 /*
  * TODO: Hardcoded for a maximum of 2 VNIs right now
  */
-char *bgp_evpn_label2str(mpls_label_t *label, uint32_t num_labels, char *buf,
+char *bgp_evpn_label2str(mpls_label_t *label, uint8_t num_labels, char *buf,
 			 int len)
 {
 	vni_t vni1, vni2;
@@ -5829,7 +5829,7 @@ void bgp_evpn_route2json(const struct prefix_evpn *p, json_object *json)
  */
 void bgp_evpn_encode_prefix(struct stream *s, const struct prefix *p,
 			    const struct prefix_rd *prd, mpls_label_t *label,
-			    uint32_t num_labels, struct attr *attr,
+			    uint8_t num_labels, struct attr *attr,
 			    bool addpath_capable, uint32_t addpath_tx_id)
 {
 	struct prefix_evpn *evp = (struct prefix_evpn *)p;
@@ -7659,7 +7659,7 @@ void bgp_evpn_handle_resolve_overlay_index_unset(struct hash_bucket *bucket,
  *
  */
 mpls_label_t *bgp_evpn_path_info_labels_get_l3vni(mpls_label_t *labels,
-						  uint32_t num_labels)
+						  uint8_t num_labels)
 {
 	if (!labels)
 		return NULL;

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -115,12 +115,12 @@ extern void bgp_evpn_advertise_type5_routes(struct bgp *bgp_vrf, afi_t afi,
 					    safi_t safi);
 extern void bgp_evpn_vrf_delete(struct bgp *bgp_vrf);
 extern void bgp_evpn_handle_router_id_update(struct bgp *bgp, int withdraw);
-extern char *bgp_evpn_label2str(mpls_label_t *label, uint32_t num_labels,
+extern char *bgp_evpn_label2str(mpls_label_t *label, uint8_t num_labels,
 				char *buf, int len);
 extern void bgp_evpn_route2json(const struct prefix_evpn *p, json_object *json);
 extern void bgp_evpn_encode_prefix(struct stream *s, const struct prefix *p,
 				   const struct prefix_rd *prd,
-				   mpls_label_t *label, uint32_t num_labels,
+				   mpls_label_t *label, uint8_t num_labels,
 				   struct attr *attr, bool addpath_capable,
 				   uint32_t addpath_tx_id);
 extern int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
@@ -177,7 +177,7 @@ extern void
 bgp_evpn_handle_resolve_overlay_index_unset(struct hash_bucket *bucket,
 					    void *arg);
 extern mpls_label_t *bgp_evpn_path_info_labels_get_l3vni(mpls_label_t *labels,
-							 uint32_t num_labels);
+							 uint8_t num_labels);
 extern vni_t bgp_evpn_path_info_get_l3vni(const struct bgp_path_info *pi);
 extern bool bgp_evpn_mpath_has_dvni(const struct bgp *bgp_vrf,
 				    struct bgp_path_info *mpinfo);

--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -89,9 +89,8 @@ mpls_label_t bgp_adv_label(struct bgp_dest *dest, struct bgp_path_info *pi,
 	if (!dest || !pi || !to)
 		return MPLS_INVALID_LABEL;
 
-	remote_label = (pi->extra && pi->extra->num_labels)
-			       ? pi->extra->label[0]
-			       : MPLS_INVALID_LABEL;
+	remote_label = bgp_path_info_num_labels(pi) ? pi->extra->label[0]
+						    : MPLS_INVALID_LABEL;
 	from = pi->peer;
 	reflect =
 		((from->sort == BGP_PEER_IBGP) && (to->sort == BGP_PEER_IBGP));

--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -89,7 +89,9 @@ mpls_label_t bgp_adv_label(struct bgp_dest *dest, struct bgp_path_info *pi,
 	if (!dest || !pi || !to)
 		return MPLS_INVALID_LABEL;
 
-	remote_label = pi->extra ? pi->extra->label[0] : MPLS_INVALID_LABEL;
+	remote_label = (pi->extra && pi->extra->num_labels)
+			       ? pi->extra->label[0]
+			       : MPLS_INVALID_LABEL;
 	from = pi->peer;
 	reflect =
 		((from->sort == BGP_PEER_IBGP) && (to->sort == BGP_PEER_IBGP));

--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -472,8 +472,8 @@ int bgp_nlri_parse_label(struct peer *peer, struct attr *attr,
 	return BGP_NLRI_PARSE_OK;
 }
 
-bool bgp_labels_same(const mpls_label_t *tbl_a, const uint32_t num_labels_a,
-		     const mpls_label_t *tbl_b, const uint32_t num_labels_b)
+bool bgp_labels_same(const mpls_label_t *tbl_a, const uint8_t num_labels_a,
+		     const mpls_label_t *tbl_b, const uint8_t num_labels_b)
 {
 	uint32_t i;
 

--- a/bgpd/bgp_label.h
+++ b/bgpd/bgp_label.h
@@ -27,9 +27,9 @@ extern mpls_label_t bgp_adv_label(struct bgp_dest *dest,
 extern int bgp_nlri_parse_label(struct peer *peer, struct attr *attr,
 				struct bgp_nlri *packet);
 extern bool bgp_labels_same(const mpls_label_t *tbl_a,
-			    const uint32_t num_labels_a,
+			    const uint8_t num_labels_a,
 			    const mpls_label_t *tbl_b,
-			    const uint32_t num_labels_b);
+			    const uint8_t num_labels_b);
 
 static inline int bgp_labeled_safi(safi_t safi)
 {

--- a/bgpd/bgp_mac.c
+++ b/bgpd/bgp_mac.c
@@ -125,7 +125,7 @@ static void bgp_process_mac_rescan_table(struct bgp *bgp, struct peer *peer,
 {
 	struct bgp_dest *pdest, *dest;
 	struct bgp_path_info *pi;
-	uint32_t num_labels;
+	uint8_t num_labels;
 	mpls_label_t *label_pnt;
 
 	for (pdest = bgp_table_top(table); pdest;

--- a/bgpd/bgp_mac.c
+++ b/bgpd/bgp_mac.c
@@ -125,6 +125,8 @@ static void bgp_process_mac_rescan_table(struct bgp *bgp, struct peer *peer,
 {
 	struct bgp_dest *pdest, *dest;
 	struct bgp_path_info *pi;
+	uint32_t num_labels;
+	mpls_label_t *label_pnt;
 
 	for (pdest = bgp_table_top(table); pdest;
 	     pdest = bgp_route_next(pdest)) {
@@ -140,8 +142,6 @@ static void bgp_process_mac_rescan_table(struct bgp *bgp, struct peer *peer,
 			const struct prefix *p = bgp_dest_get_prefix(dest);
 			struct prefix_evpn *pevpn = (struct prefix_evpn *)dest;
 			struct prefix_rd prd;
-			uint32_t num_labels = 0;
-			mpls_label_t *label_pnt = NULL;
 			struct bgp_route_evpn *evpn;
 
 			if (pevpn->family == AF_EVPN
@@ -169,10 +169,8 @@ static void bgp_process_mac_rescan_table(struct bgp *bgp, struct peer *peer,
 			    && !dest_affected)
 				continue;
 
-			if (pi->extra)
-				num_labels = pi->extra->num_labels;
-			if (num_labels)
-				label_pnt = &pi->extra->label[0];
+			num_labels = bgp_path_info_num_labels(pi);
+			label_pnt = num_labels ? &pi->extra->label[0] : NULL;
 
 			prd.family = AF_UNSPEC;
 			prd.prefixlen = 64;

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -2322,8 +2322,6 @@ static void vpn_leak_to_vrf_update_onevrf(struct bgp *to_bgp,   /* to */
 		if (!origin_local && path_vpn->extra
 		    && path_vpn->extra->num_labels) {
 			num_labels = path_vpn->extra->num_labels;
-			if (num_labels > BGP_MAX_LABELS)
-				num_labels = BGP_MAX_LABELS;
 			pLabels = path_vpn->extra->label;
 		}
 	}

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -957,21 +957,6 @@ void transpose_sid(struct in6_addr *sid, uint32_t label, uint8_t offset,
 	}
 }
 
-static bool labels_same(struct bgp_path_info *bpi, mpls_label_t *label,
-			uint32_t n)
-{
-	if (!bpi->extra) {
-		if (!n)
-			return true;
-		else
-			return false;
-	}
-
-	return bgp_labels_same((const mpls_label_t *)bpi->extra->label,
-			       bpi->extra->num_labels,
-			       (const mpls_label_t *)label, n);
-}
-
 /*
  * make encoded route labels match specified encoded label set
  */
@@ -1122,7 +1107,8 @@ leak_update(struct bgp *to_bgp, struct bgp_dest *bn,
 	}
 
 	if (bpi) {
-		bool labelssame = labels_same(bpi, label, num_labels);
+		bool labelssame = bgp_path_info_labels_same(bpi, label,
+							    num_labels);
 
 		if (CHECK_FLAG(source_bpi->flags, BGP_PATH_REMOVED)
 		    && CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -962,7 +962,7 @@ void transpose_sid(struct in6_addr *sid, uint32_t label, uint8_t offset,
  */
 static void setlabels(struct bgp_path_info *bpi,
 		      mpls_label_t *label, /* array of labels */
-		      uint32_t num_labels)
+		      uint8_t num_labels)
 {
 	if (num_labels)
 		assert(label);
@@ -975,7 +975,7 @@ static void setlabels(struct bgp_path_info *bpi,
 	}
 
 	struct bgp_path_info_extra *extra = bgp_path_info_extra_get(bpi);
-	uint32_t i;
+	uint8_t i;
 
 	for (i = 0; i < num_labels; ++i) {
 		extra->label[i] = label[i];
@@ -1064,7 +1064,7 @@ static struct bgp_path_info *
 leak_update(struct bgp *to_bgp, struct bgp_dest *bn,
 	    struct attr *new_attr, /* already interned */
 	    afi_t afi, safi_t safi, struct bgp_path_info *source_bpi,
-	    mpls_label_t *label, uint32_t num_labels, struct bgp *bgp_orig,
+	    mpls_label_t *label, uint8_t num_labels, struct bgp *bgp_orig,
 	    struct prefix *nexthop_orig, int nexthop_self_flag, int debug)
 {
 	const struct prefix *p = bgp_dest_get_prefix(bn);
@@ -2073,7 +2073,7 @@ static void vpn_leak_to_vrf_update_onevrf(struct bgp *to_bgp,   /* to */
 	const char *debugmsg;
 	struct prefix nexthop_orig;
 	mpls_label_t *label_pnt = NULL;
-	uint32_t num_labels = 0;
+	uint8_t num_labels = 0;
 	int nexthop_self_flag = 1;
 	struct bgp_path_info *bpi_ultimate = NULL;
 	struct bgp_path_info *bpi;
@@ -3957,7 +3957,7 @@ static void bgp_mplsvpn_nh_label_bind_send_nexthop_label(
 	struct bgp_mplsvpn_nh_label_bind_cache *bmnc, int cmd)
 {
 	struct prefix pfx_nh, *p = NULL;
-	uint32_t num_labels = 0, lsp_num_labels;
+	uint8_t num_labels = 0, lsp_num_labels;
 	mpls_label_t label[MPLS_MAX_LABELS];
 	struct nexthop *nh;
 	ifindex_t ifindex = IFINDEX_INTERNAL;

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -4111,8 +4111,7 @@ bool bgp_mplsvpn_path_uses_valid_mpls_label(struct bgp_path_info *pi)
 		/* prefix_sid attribute */
 		return false;
 
-	if (!pi->extra || !pi->extra->num_labels ||
-	    !bgp_is_valid_label(&pi->extra->label[0]))
+	if (!bgp_path_info_has_valid_label(pi))
 		/* invalid MPLS label */
 		return false;
 	return true;

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -494,8 +494,8 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop,
 	if (bgp_route->inst_type == BGP_INSTANCE_TYPE_VIEW)
 		return 1;
 	else if (safi == SAFI_UNICAST && pi &&
-		 pi->sub_type == BGP_ROUTE_IMPORTED && pi->extra &&
-		 pi->extra->num_labels && !bnc->is_evpn_gwip_nexthop)
+		 pi->sub_type == BGP_ROUTE_IMPORTED &&
+		 bgp_path_info_num_labels(pi) && !bnc->is_evpn_gwip_nexthop)
 		return bgp_isvalid_nexthop_for_mpls(bnc, pi);
 	else if (safi == SAFI_MPLS_VPN && pi &&
 		 pi->sub_type != BGP_ROUTE_IMPORTED)
@@ -1290,10 +1290,10 @@ void evaluate_paths(struct bgp_nexthop_cache *bnc)
 		bool bnc_is_valid_nexthop = false;
 		bool path_valid = false;
 
-		if (safi == SAFI_UNICAST && path->sub_type == BGP_ROUTE_IMPORTED
-		    && path->extra && path->extra->num_labels
-		    && (path->attr->evpn_overlay.type
-			!= OVERLAY_INDEX_GATEWAY_IP)) {
+		if (safi == SAFI_UNICAST &&
+		    path->sub_type == BGP_ROUTE_IMPORTED &&
+		    bgp_path_info_num_labels(path) &&
+		    (path->attr->evpn_overlay.type != OVERLAY_INDEX_GATEWAY_IP)) {
 			bnc_is_valid_nexthop =
 				bgp_isvalid_nexthop_for_mpls(bnc, path) ? true
 									: false;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4917,12 +4917,8 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	/* Update MPLS label */
 	if (has_valid_label) {
 		extra = bgp_path_info_extra_get(new);
-		if (!bgp_labels_same((const mpls_label_t *)extra->label,
-				     extra->num_labels, label, num_labels)) {
-			memcpy(&extra->label, label,
-			       num_labels * sizeof(mpls_label_t));
-			extra->num_labels = num_labels;
-		}
+		memcpy(&extra->label, label, num_labels * sizeof(mpls_label_t));
+		extra->num_labels = num_labels;
 		if (!(afi == AFI_L2VPN && safi == SAFI_EVPN))
 			bgp_set_valid_label(&extra->label[0]);
 	}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -294,7 +294,7 @@ bool bgp_path_info_has_valid_label(const struct bgp_path_info *path)
 bool bgp_path_info_labels_same(const struct bgp_path_info *bpi,
 			       const mpls_label_t *label, uint32_t n)
 {
-	uint32_t bpi_num_labels;
+	uint8_t bpi_num_labels;
 	const mpls_label_t *bpi_label;
 
 	bpi_num_labels = bgp_path_info_num_labels(bpi);
@@ -304,7 +304,7 @@ bool bgp_path_info_labels_same(const struct bgp_path_info *bpi,
 			       (const mpls_label_t *)label, n);
 }
 
-uint32_t bgp_path_info_num_labels(const struct bgp_path_info *pi)
+uint8_t bgp_path_info_num_labels(const struct bgp_path_info *pi)
 {
 	if (!pi)
 		return 0;
@@ -1782,7 +1782,7 @@ static bool bgp_check_role_applicability(afi_t afi, safi_t safi)
 static int bgp_input_modifier(struct peer *peer, const struct prefix *p,
 			      struct attr *attr, afi_t afi, safi_t safi,
 			      const char *rmap_name, mpls_label_t *label,
-			      uint32_t num_labels, struct bgp_dest *dest)
+			      uint8_t num_labels, struct bgp_dest *dest)
 {
 	struct bgp_filter *filter;
 	struct bgp_path_info rmap_path = { 0 };
@@ -4206,7 +4206,7 @@ static bool bgp_accept_own(struct peer *peer, afi_t afi, safi_t safi,
 void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 		struct attr *attr, afi_t afi, safi_t safi, int type,
 		int sub_type, struct prefix_rd *prd, mpls_label_t *label,
-		uint32_t num_labels, int soft_reconfig,
+		uint8_t num_labels, int soft_reconfig,
 		struct bgp_route_evpn *evpn)
 {
 	int ret;
@@ -5119,7 +5119,7 @@ filtered:
 void bgp_withdraw(struct peer *peer, const struct prefix *p,
 		  uint32_t addpath_id, afi_t afi, safi_t safi, int type,
 		  int sub_type, struct prefix_rd *prd, mpls_label_t *label,
-		  uint32_t num_labels, struct bgp_route_evpn *evpn)
+		  uint8_t num_labels, struct bgp_route_evpn *evpn)
 {
 	struct bgp *bgp;
 	char pfx_buf[BGP_PRD_PATH_STRLEN];
@@ -5346,7 +5346,7 @@ static void bgp_soft_reconfig_table_update(struct peer *peer,
 					   safi_t safi, struct prefix_rd *prd)
 {
 	struct bgp_path_info *pi;
-	uint32_t num_labels;
+	uint8_t num_labels;
 	mpls_label_t *label_pnt;
 	struct bgp_route_evpn evpn;
 
@@ -6367,7 +6367,7 @@ void bgp_static_update(struct bgp *bgp, const struct prefix *p,
 	int vnc_implicit_withdraw = 0;
 	mpls_label_t label = MPLS_INVALID_LABEL;
 #endif
-	uint32_t num_labels = 0;
+	uint8_t num_labels = 0;
 
 	assert(bgp_static);
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -195,8 +195,6 @@ static struct bgp_path_info_extra *bgp_path_info_extra_new(void)
 	struct bgp_path_info_extra *new;
 	new = XCALLOC(MTYPE_BGP_ROUTE_EXTRA,
 		      sizeof(struct bgp_path_info_extra));
-	new->label[0] = MPLS_INVALID_LABEL;
-	new->num_labels = 0;
 	new->flowspec = NULL;
 	return new;
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10137,7 +10137,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 			  json_object *json_paths)
 {
 	char buf[INET6_ADDRSTRLEN];
-	char tag_buf[30];
+	char vni_buf[30] = {};
 	struct attr *attr = path->attr;
 	time_t tbuf;
 	char timebuf[32];
@@ -10169,7 +10169,6 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 	uint32_t bos = 0;
 	uint32_t exp = 0;
 	mpls_label_t label = MPLS_INVALID_LABEL;
-	tag_buf[0] = '\0';
 	struct bgp_path_info *bpi_ultimate =
 		bgp_get_imported_bpi_ultimate(path);
 
@@ -10179,26 +10178,21 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 		json_nexthop_global = json_object_new_object();
 	}
 
+	if (path->extra && path->extra->num_labels) {
+		bgp_evpn_label2str(path->extra->label, path->extra->num_labels,
+				   vni_buf, sizeof(vni_buf));
+	}
+
 	if (safi == SAFI_EVPN) {
 		if (!json_paths)
 			vty_out(vty, "  Route %pFX", p);
-	}
 
-	if (path->extra) {
-		if (path->extra && path->extra->num_labels) {
-			bgp_evpn_label2str(path->extra->label,
-					   path->extra->num_labels, tag_buf,
-					   sizeof(tag_buf));
-		}
-		if (safi == SAFI_EVPN) {
-			if (!json_paths) {
-				if (tag_buf[0] != '\0')
-					vty_out(vty, " VNI %s", tag_buf);
-			} else {
-				if (tag_buf[0])
-					json_object_string_add(json_path, "vni",
-							       tag_buf);
-			}
+		if (vni_buf[0]) {
+			if (json_paths)
+				json_object_string_add(json_path, "vni",
+						       vni_buf);
+			else
+				vty_out(vty, " VNI %s", vni_buf);
 		}
 	}
 
@@ -10238,7 +10232,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 				vty_out(vty, ":%pFX, VNI %s",
 					(struct prefix_evpn *)
 						bgp_dest_get_prefix(dest),
-					tag_buf);
+					vni_buf);
 				if (CHECK_FLAG(attr->es_flags, ATTR_ES_L3_NHG))
 					vty_out(vty, ", L3NHG %s",
 						CHECK_FLAG(

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -757,6 +757,8 @@ extern void bgp_path_info_unset_flag(struct bgp_dest *dest,
 				     struct bgp_path_info *path, uint32_t flag);
 extern void bgp_path_info_path_with_addpath_rx_str(struct bgp_path_info *pi,
 						   char *buf, size_t buf_len);
+extern bool bgp_path_info_labels_same(const struct bgp_path_info *bpi,
+				      const mpls_label_t *label, uint32_t n);
 
 extern int bgp_nlri_parse_ip(struct peer *, struct attr *, struct bgp_nlri *);
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -751,6 +751,7 @@ extern void bgp_path_info_delete(struct bgp_dest *dest,
 extern struct bgp_path_info_extra *
 bgp_path_info_extra_get(struct bgp_path_info *path);
 extern bool bgp_path_info_has_valid_label(const struct bgp_path_info *path);
+extern uint32_t bgp_path_info_num_labels(const struct bgp_path_info *pi);
 extern void bgp_path_info_set_flag(struct bgp_dest *dest,
 				   struct bgp_path_info *path, uint32_t flag);
 extern void bgp_path_info_unset_flag(struct bgp_dest *dest,

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -238,7 +238,7 @@ struct bgp_path_info_extra {
 
 	/* MPLS label(s) - VNI(s) for EVPN-VxLAN  */
 	mpls_label_t label[BGP_MAX_LABELS];
-	uint32_t num_labels;
+	uint8_t num_labels;
 
 	/* timestamp of the rib installation */
 	time_t bgp_rib_uptime;
@@ -751,7 +751,7 @@ extern void bgp_path_info_delete(struct bgp_dest *dest,
 extern struct bgp_path_info_extra *
 bgp_path_info_extra_get(struct bgp_path_info *path);
 extern bool bgp_path_info_has_valid_label(const struct bgp_path_info *path);
-extern uint32_t bgp_path_info_num_labels(const struct bgp_path_info *pi);
+extern uint8_t bgp_path_info_num_labels(const struct bgp_path_info *pi);
 extern void bgp_path_info_set_flag(struct bgp_dest *dest,
 				   struct bgp_path_info *path, uint32_t flag);
 extern void bgp_path_info_unset_flag(struct bgp_dest *dest,
@@ -796,12 +796,12 @@ extern void bgp_update(struct peer *peer, const struct prefix *p,
 		       uint32_t addpath_id, struct attr *attr, afi_t afi,
 		       safi_t safi, int type, int sub_type,
 		       struct prefix_rd *prd, mpls_label_t *label,
-		       uint32_t num_labels, int soft_reconfig,
+		       uint8_t num_labels, int soft_reconfig,
 		       struct bgp_route_evpn *evpn);
 extern void bgp_withdraw(struct peer *peer, const struct prefix *p,
 			 uint32_t addpath_id, afi_t afi, safi_t safi, int type,
 			 int sub_type, struct prefix_rd *prd,
-			 mpls_label_t *label, uint32_t num_labels,
+			 mpls_label_t *label, uint8_t num_labels,
 			 struct bgp_route_evpn *evpn);
 
 /* for bgp_nexthop and bgp_damp */

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -750,6 +750,7 @@ extern void bgp_path_info_delete(struct bgp_dest *dest,
 				 struct bgp_path_info *pi);
 extern struct bgp_path_info_extra *
 bgp_path_info_extra_get(struct bgp_path_info *path);
+extern bool bgp_path_info_has_valid_label(const struct bgp_path_info *path);
 extern void bgp_path_info_set_flag(struct bgp_dest *dest,
 				   struct bgp_path_info *path, uint32_t flag);
 extern void bgp_path_info_unset_flag(struct bgp_dest *dest,

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1056,7 +1056,7 @@ static enum route_map_cmd_result_t
 route_match_vni(void *rule, const struct prefix *prefix, void *object)
 {
 	vni_t vni = 0;
-	unsigned int label_cnt = 0;
+	unsigned int label_cnt;
 	struct bgp_path_info *path = NULL;
 	struct prefix_evpn *evp = (struct prefix_evpn *) prefix;
 
@@ -1081,11 +1081,8 @@ route_match_vni(void *rule, const struct prefix *prefix, void *object)
 		&& evp->prefix.route_type != BGP_EVPN_IP_PREFIX_ROUTE))
 		return RMAP_NOOP;
 
-	if (path->extra == NULL)
-		return RMAP_NOMATCH;
-
-	for (;
-	     label_cnt < BGP_MAX_LABELS && label_cnt < path->extra->num_labels;
+	for (label_cnt = 0; label_cnt < BGP_MAX_LABELS &&
+			    label_cnt < bgp_path_info_num_labels(path);
 	     label_cnt++) {
 		if (vni == label2vni(&path->extra->label[label_cnt]))
 			return RMAP_MATCH;

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -657,7 +657,7 @@ static void revalidate_bgp_node(struct bgp_dest *bgp_dest, afi_t afi,
 {
 	struct bgp_adj_in *ain;
 	mpls_label_t *label;
-	uint32_t num_labels;
+	uint8_t num_labels;
 
 	for (ain = bgp_dest->adj_in; ain; ain = ain->next) {
 		struct bgp_path_info *path =

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -656,17 +656,16 @@ static void revalidate_bgp_node(struct bgp_dest *bgp_dest, afi_t afi,
 				safi_t safi)
 {
 	struct bgp_adj_in *ain;
+	mpls_label_t *label;
+	uint32_t num_labels;
 
 	for (ain = bgp_dest->adj_in; ain; ain = ain->next) {
 		struct bgp_path_info *path =
 			bgp_dest_get_bgp_path_info(bgp_dest);
-		mpls_label_t *label = NULL;
-		uint32_t num_labels = 0;
 
-		if (path && path->extra) {
-			label = path->extra->label;
-			num_labels = path->extra->num_labels;
-		}
+		num_labels = bgp_path_info_num_labels(path);
+		label = num_labels ? path->extra->label : NULL;
+
 		(void)bgp_update(ain->peer, bgp_dest_get_prefix(bgp_dest),
 				 ain->addpath_rx_id, ain->attr, afi, safi,
 				 ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, NULL, label,

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -665,7 +665,7 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 	uint32_t addpath_tx_id = 0;
 	struct prefix_rd *prd = NULL;
 	mpls_label_t label = MPLS_INVALID_LABEL, *label_pnt = NULL;
-	uint32_t num_labels = 0;
+	uint8_t num_labels = 0;
 
 	if (!subgrp)
 		return NULL;
@@ -1082,7 +1082,7 @@ void subgroup_default_update_packet(struct update_subgroup *subgrp,
 	struct bpacket_attr_vec_arr vecarr;
 	bool addpath_capable = false;
 	mpls_label_t label = MPLS_LABEL_IMPLICIT_NULL;
-	uint32_t num_labels = 0;
+	uint8_t num_labels = 0;
 
 	if (DISABLE_BGP_ANNOUNCE)
 		return;

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -812,9 +812,10 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 					path);
 				label_pnt = &label;
 				num_labels = 1;
-			} else if (path && path->extra) {
-				label_pnt = &path->extra->label[0];
-				num_labels = path->extra->num_labels;
+			} else {
+				num_labels = bgp_path_info_num_labels(path);
+				label_pnt = num_labels ? &path->extra->label[0]
+						       : NULL;
 			}
 
 			if (stream_empty(snlri))

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1271,8 +1271,6 @@ static void bgp_zebra_announce_parse_nexthop(
 	}
 
 	for (; mpinfo; mpinfo = bgp_path_info_mpath_next(mpinfo)) {
-		labels = NULL;
-		num_labels = 0;
 		uint32_t nh_weight;
 		bool is_evpn;
 		bool is_parent_evpn;
@@ -1313,7 +1311,7 @@ static void bgp_zebra_announce_parse_nexthop(
 			api_nh->srte_color = bgp_attr_get_color(info->attr);
 
 		if (bgp_debug_zebra(&api->prefix)) {
-			if (mpinfo->extra && mpinfo->extra->num_labels) {
+			if (bgp_path_info_num_labels(mpinfo)) {
 				zlog_debug("%s: p=%pFX, bgp_is_valid_label: %d",
 					   __func__, p,
 					   bgp_is_valid_label(
@@ -1385,13 +1383,10 @@ static void bgp_zebra_announce_parse_nexthop(
 		     mpinfo->peer->sort == BGP_PEER_CONFED))
 			*allow_recursion = true;
 
-		if (mpinfo->extra) {
-			labels = mpinfo->extra->label;
-			num_labels = mpinfo->extra->num_labels;
-		}
+		num_labels = bgp_path_info_num_labels(mpinfo);
+		labels = num_labels ? mpinfo->extra->label : NULL;
 
-		if (labels && (num_labels > 0) &&
-		    (is_evpn || bgp_is_valid_label(&labels[0]))) {
+		if (num_labels && (is_evpn || bgp_is_valid_label(&labels[0]))) {
 			enum lsp_types_t nh_label_type = ZEBRA_LSP_NONE;
 
 			if (is_evpn) {

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1243,7 +1243,7 @@ static void bgp_zebra_announce_parse_nexthop(
 	struct bgp_path_info local_info;
 	struct bgp_path_info *mpinfo_cp = &local_info;
 	mpls_label_t *labels;
-	uint32_t num_labels = 0;
+	uint8_t num_labels = 0;
 	mpls_label_t nh_label;
 	int nh_othervrf = 0;
 	bool nh_updated = false;
@@ -3904,8 +3904,7 @@ int bgp_zebra_srv6_manager_release_locator_chunk(const char *name)
 void bgp_zebra_send_nexthop_label(int cmd, mpls_label_t label,
 				  ifindex_t ifindex, vrf_id_t vrf_id,
 				  enum lsp_types_t ltype, struct prefix *p,
-				  uint32_t num_labels,
-				  mpls_label_t out_labels[])
+				  uint8_t num_labels, mpls_label_t out_labels[])
 {
 	struct zapi_labels zl = {};
 	struct zapi_nexthop *znh;

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1313,15 +1313,13 @@ static void bgp_zebra_announce_parse_nexthop(
 			api_nh->srte_color = bgp_attr_get_color(info->attr);
 
 		if (bgp_debug_zebra(&api->prefix)) {
-			if (mpinfo->extra) {
+			if (mpinfo->extra && mpinfo->extra->num_labels) {
 				zlog_debug("%s: p=%pFX, bgp_is_valid_label: %d",
 					   __func__, p,
 					   bgp_is_valid_label(
 						   &mpinfo->extra->label[0]));
 			} else {
-				zlog_debug(
-					"%s: p=%pFX, extra is NULL, no label",
-					__func__, p);
+				zlog_debug("%s: p=%pFX, no label", __func__, p);
 			}
 		}
 

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -122,7 +122,7 @@ extern int bgp_zebra_srv6_manager_release_locator_chunk(const char *name);
 extern void bgp_zebra_send_nexthop_label(int cmd, mpls_label_t label,
 					 ifindex_t index, vrf_id_t vrfid,
 					 enum lsp_types_t ltype,
-					 struct prefix *p, uint32_t num_labels,
+					 struct prefix *p, uint8_t num_labels,
 					 mpls_label_t out_labels[]);
 extern bool bgp_zebra_request_label_range(uint32_t base, uint32_t chunk_size,
 					  bool label_auto);

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -592,7 +592,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 		}
 	}
 
-	if (label)
+	if (label && *label != MPLS_INVALID_LABEL)
 		label_val = *label;
 	else
 		label_val = MPLS_LABEL_IMPLICIT_NULL;
@@ -1020,7 +1020,9 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 	new->extra->vnc = XCALLOC(MTYPE_BGP_ROUTE_EXTRA_VNC,
 				  sizeof(struct bgp_path_info_extra_vnc));
 	new->extra->vnc->vnc.export.rfapi_handle = (void *)rfd;
+
 	encode_label(label_val, &new->extra->label[0]);
+	new->extra->num_labels = 1;
 
 	/* debug */
 
@@ -1043,6 +1045,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 				bgp, prd, table, p, new);
 		bgp_dest_unlock_node(pdest);
 		encode_label(label_val, &bn->local_label);
+		new->extra->num_labels = 1;
 	}
 
 	bgp_dest_unlock_node(bn);

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -1271,7 +1271,7 @@ rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
 
 		/* label comes from MP_REACH_NLRI label */
 		vo->v.l2addr.label =
-			bpi->extra->num_labels
+			bgp_path_info_num_labels(bpi)
 				? decode_label(&bpi->extra->label[0])
 				: MPLS_INVALID_LABEL;
 
@@ -4166,7 +4166,7 @@ static void rfapiBgpTableFilteredImport(struct bgp *bgp,
 						       BGP_PATH_REMOVED))
 						continue;
 
-					if (bpi->extra && bpi->extra->num_labels)
+					if (bgp_path_info_num_labels(bpi))
 						label = decode_label(
 							&bpi->extra->label[0]);
 					(*rfapiBgpInfoFilteredImportFunction(

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -691,7 +691,10 @@ static void rfapiRibBi2Ri(struct bgp_path_info *bpi, struct rfapi_info *ri,
 			bpi->extra->vnc->vnc.import.rd.val[1];
 
 		/* label comes from MP_REACH_NLRI label */
-		vo->v.l2addr.label = decode_label(&bpi->extra->label[0]);
+		vo->v.l2addr.label =
+			bpi->extra->num_labels
+				? decode_label(&bpi->extra->label[0])
+				: MPLS_INVALID_LABEL;
 
 		rfapi_vn_options_free(
 			ri->vn_options); /* maybe free old version */

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -692,7 +692,7 @@ static void rfapiRibBi2Ri(struct bgp_path_info *bpi, struct rfapi_info *ri,
 
 		/* label comes from MP_REACH_NLRI label */
 		vo->v.l2addr.label =
-			bpi->extra->num_labels
+			bgp_path_info_num_labels(bpi)
 				? decode_label(&bpi->extra->label[0])
 				: MPLS_INVALID_LABEL;
 

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -413,7 +413,7 @@ void rfapi_vty_out_vncinfo(struct vty *vty, const struct prefix *p,
 		XFREE(MTYPE_ECOMMUNITY_STR, s);
 	}
 
-	if (bpi->extra != NULL && bpi->extra->num_labels) {
+	if (bgp_path_info_num_labels(bpi)) {
 		if (bpi->extra->label[0] == BGP_PREVENT_VRF_2_VRF_LEAK)
 			vty_out(vty, " label=VRF2VRF");
 		else
@@ -1052,7 +1052,7 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 		snprintf(buf_un, sizeof(buf_un), "%s",
 			 inet_ntop(pfx_vn.family, &pfx_vn.u.prefix, buf_ntop,
 				   sizeof(buf_ntop)));
-		if (bpi->extra && bpi->extra->num_labels) {
+		if (bgp_path_info_num_labels(bpi)) {
 			uint32_t l = decode_label(&bpi->extra->label[0]);
 			snprintf(buf_vn, sizeof(buf_vn), "Label: %d", l);
 		} else /* should never happen */
@@ -1161,8 +1161,7 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 			}
 		}
 	}
-	if (tun_type != BGP_ENCAP_TYPE_MPLS && bpi->extra &&
-	    bpi->extra->num_labels) {
+	if (tun_type != BGP_ENCAP_TYPE_MPLS && bgp_path_info_num_labels(bpi)) {
 		uint32_t l = decode_label(&bpi->extra->label[0]);
 
 		if (!MPLS_LABEL_IS_NULL(l)) {

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -413,7 +413,7 @@ void rfapi_vty_out_vncinfo(struct vty *vty, const struct prefix *p,
 		XFREE(MTYPE_ECOMMUNITY_STR, s);
 	}
 
-	if (bpi->extra != NULL) {
+	if (bpi->extra != NULL && bpi->extra->num_labels) {
 		if (bpi->extra->label[0] == BGP_PREVENT_VRF_2_VRF_LEAK)
 			vty_out(vty, " label=VRF2VRF");
 		else
@@ -1052,7 +1052,7 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 		snprintf(buf_un, sizeof(buf_un), "%s",
 			 inet_ntop(pfx_vn.family, &pfx_vn.u.prefix, buf_ntop,
 				   sizeof(buf_ntop)));
-		if (bpi->extra) {
+		if (bpi->extra && bpi->extra->num_labels) {
 			uint32_t l = decode_label(&bpi->extra->label[0]);
 			snprintf(buf_vn, sizeof(buf_vn), "Label: %d", l);
 		} else /* should never happen */
@@ -1161,7 +1161,8 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 			}
 		}
 	}
-	if (tun_type != BGP_ENCAP_TYPE_MPLS && bpi->extra) {
+	if (tun_type != BGP_ENCAP_TYPE_MPLS && bpi->extra &&
+	    bpi->extra->num_labels) {
 		uint32_t l = decode_label(&bpi->extra->label[0]);
 
 		if (!MPLS_LABEL_IS_NULL(l)) {

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -470,7 +470,7 @@ static void vnc_import_bgp_add_route_mode_resolve_nve_one_bi(
 	if (bgp_attr_get_ecommunity(bpi->attr))
 		ecommunity_merge(new_ecom, bgp_attr_get_ecommunity(bpi->attr));
 
-	if (bpi->extra && bpi->extra->num_labels)
+	if (bgp_path_info_num_labels(bpi))
 		label = decode_label(&bpi->extra->label[0]);
 
 	add_vnc_route(&vncHDResolveNve, bgp, SAFI_MPLS_VPN,
@@ -1699,7 +1699,8 @@ static void vnc_import_bgp_exterior_add_route_it(
 				if (bpi_interior->extra) {
 					prd = &bpi_interior->extra->vnc->vnc
 						       .import.rd;
-					if (bpi_interior->extra->num_labels)
+					if (bgp_path_info_num_labels(
+						    bpi_interior))
 						label = decode_label(
 							&bpi_interior->extra
 								 ->label[0]);
@@ -1870,7 +1871,8 @@ void vnc_import_bgp_exterior_del_route(
 				if (bpi_interior->extra) {
 					prd = &bpi_interior->extra->vnc->vnc
 						       .import.rd;
-					if (bpi_interior->extra->num_labels)
+					if (bgp_path_info_num_labels(
+						    bpi_interior))
 						label = decode_label(
 							&bpi_interior->extra
 								 ->label[0]);
@@ -2019,7 +2021,7 @@ void vnc_import_bgp_exterior_add_route_interior(
 
 			if (bpi_interior->extra) {
 				prd = &bpi_interior->extra->vnc->vnc.import.rd;
-				if (bpi_interior->extra->num_labels)
+				if (bgp_path_info_num_labels(bpi_interior))
 					label = decode_label(
 						&bpi_interior->extra->label[0]);
 			} else
@@ -2134,7 +2136,7 @@ void vnc_import_bgp_exterior_add_route_interior(
 					if (bpi->extra) {
 						prd = &bpi->extra->vnc->vnc
 							       .import.rd;
-						if (bpi->extra->num_labels)
+						if (bgp_path_info_num_labels(bpi))
 							label = decode_label(
 								&bpi->extra->label
 									 [0]);
@@ -2158,7 +2160,8 @@ void vnc_import_bgp_exterior_add_route_interior(
 				if (bpi_interior->extra) {
 					prd = &bpi_interior->extra->vnc->vnc
 						       .import.rd;
-					if (bpi_interior->extra->num_labels)
+					if (bgp_path_info_num_labels(
+						    bpi_interior))
 						label = decode_label(
 							&bpi_interior->extra
 								 ->label[0]);
@@ -2278,7 +2281,7 @@ void vnc_import_bgp_exterior_add_route_interior(
 			 */
 			if (bpi_interior->extra) {
 				prd = &bpi_interior->extra->vnc->vnc.import.rd;
-				if (bpi_interior->extra->num_labels)
+				if (bgp_path_info_num_labels(bpi_interior))
 					label = decode_label(
 						&bpi_interior->extra->label[0]);
 			} else
@@ -2387,7 +2390,7 @@ void vnc_import_bgp_exterior_del_route_interior(
 
 		if (bpi_interior->extra) {
 			prd = &bpi_interior->extra->vnc->vnc.import.rd;
-			if (bpi_interior->extra->num_labels)
+			if (bgp_path_info_num_labels(bpi_interior))
 				label = decode_label(
 					&bpi_interior->extra->label[0]);
 		} else
@@ -2466,7 +2469,7 @@ void vnc_import_bgp_exterior_del_route_interior(
 
 				if (bpi->extra) {
 					prd = &bpi->extra->vnc->vnc.import.rd;
-					if (bpi->extra->num_labels)
+					if (bgp_path_info_num_labels(bpi))
 						label = decode_label(
 							&bpi->extra->label[0]);
 				} else


### PR DESCRIPTION
The handling of MPLS labels in BGP faces an issue due to the way labels
are stored in memory. They are stored in bgp_path_info but not in
bgp_adj_in and bgp_adj_out structures. As a consequence, some
configuration changes result in losing labels or even a bgpd crash. For
example, when retrieving routes from the Adj-RIB-in table
("soft-reconfiguration inbound" enabled), labels are missing.

bgp_path_info stores the MPLS labels, as shown below:

> struct bgp_path_info {
>   struct bgp_path_info_extra *extra;
>   [...]
> struct bgp_path_info_extra {
>       mpls_label_t label[BGP_MAX_LABELS];
>       uint32_t num_labels;
>   [...]

To solve those issues, a solution would be to set label data to the
bgp_adj_in and bgp_adj_out structures in addition to the
bgp_path_info_extra structure. The idea is to reference a common label
pointer in all these three structures. And to store the data in a hash
list in order to save memory.

However, an issue in the code prevents us from setting clean data
without a rework. The extra->num_labels field, which is intended to
indicate the number of labels in extra->label[], is not reliably checked
or set. The code often incorrectly assumes that if the extra pointer is
present, then a label must also be present, leading to direct access to
extra->label[] without verifying extra->num_labels. This assumption
usually works because extra->label[0] is set to MPLS_INVALID_LABEL when
a new bgp_path_info_extra is created, but it is technically incorrect.

Cleanup the label code by setting num_labels each time values are set in
extra->label[] and checking extra->num_labels before accessing the
labels.

Add some functions to factorize frequent patterns in the code and do some
small rework.