### PR TITLE
zebra: Reorg `struct route_entry` to have important bits first

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -85,24 +85,11 @@ struct route_entry {
 	 */
 	struct nhg_hash_entry *nhe;
 
-	/* Nexthop group from FIB (optional), reflecting what is actually
-	 * installed in the FIB if that differs. The 'backup' group is used
-	 * when backup nexthops are present in the route's nhg.
-	 */
-	struct nexthop_group fib_ng;
-	struct nexthop_group fib_backup_ng;
-
 	/* Nexthop group hash entry IDs. The "installed" id is the id
 	 * used in linux/netlink, if available.
 	 */
 	uint32_t nhe_id;
 	uint32_t nhe_installed_id;
-
-	/* Tag */
-	route_tag_t tag;
-
-	/* Uptime. */
-	time_t uptime;
 
 	/* Type of this route. */
 	int type;
@@ -160,7 +147,20 @@ struct route_entry {
 	/* Distance. */
 	uint8_t distance;
 
+	/* Tag */
+	route_tag_t tag;
+
+	/* Uptime. */
+	time_t uptime;
+
 	struct re_opaque *opaque;
+
+	/* Nexthop group from FIB (optional), reflecting what is actually
+	 * installed in the FIB if that differs. The 'backup' group is used
+	 * when backup nexthops are present in the route's nhg.
+	 */
+	struct nexthop_group fib_ng;
+	struct nexthop_group fib_backup_ng;
 };
 
 #define RIB_SYSTEM_ROUTE(R) RSYSTEM_ROUTE((R)->type)


### PR DESCRIPTION
The `struct route_entry` had items that were almost never used at the front of the data structure resulting in items that would be loaded first into memory that were never used.  Let's reorg a tiny bit and put all the frequently used items in the first cache line.  I'm sure people will notice .000000001 speedup

new layout:

sharpd@eva /w/h/s/frr1 (reorg_route_entry)> /home/sharpd/pahole/build/pahole --reorganize --show_reorg_steps -C route_entry zebra/.libs/zebra struct route_entry {
	struct re_list_item        next;                 /*     0     8 */
	struct nhg_hash_entry *    nhe;                  /*     8     8 */
	uint32_t                   nhe_id;               /*    16     4 */
	uint32_t                   nhe_installed_id;     /*    20     4 */
	int                        type;                 /*    24     4 */
	vrf_id_t                   vrf_id;               /*    28     4 */
	uint32_t                   table;                /*    32     4 */
	uint32_t                   metric;               /*    36     4 */
	uint32_t                   mtu;                  /*    40     4 */
	uint32_t                   nexthop_mtu;          /*    44     4 */
	uint32_t                   flags;                /*    48     4 */
	uint32_t                   status;               /*    52     4 */
	uint32_t                   dplane_sequence;      /*    56     4 */
	uint16_t                   instance;             /*    60     2 */
	uint8_t                    distance;             /*    62     1 */

	/* XXX 1 byte hole, try to pack */

	/* --- cacheline 1 boundary (64 bytes) --- */
	route_tag_t                tag;                  /*    64     4 */

	/* XXX 4 bytes hole, try to pack */

	time_t                     uptime;               /*    72     8 */
	struct re_opaque *         opaque;               /*    80     8 */
	struct nexthop_group       fib_ng;               /*    88    32 */
	struct nexthop_group       fib_backup_ng;        /*   120    32 */

	/* size: 152, cachelines: 3, members: 20 */
	/* sum members: 147, holes: 2, sum holes: 5 */
	/* last cacheline: 24 bytes */
};