### PR TITLE
mgmtd "edit" operation

### DIFF
--- a/lib/darr.c
+++ b/lib/darr.c
@@ -58,6 +58,7 @@ char *__darr_in_vsprintf(char **sp, bool concat, const char *fmt, va_list ap)
 	size_t inlen = concat ? darr_strlen(*sp) : 0;
 	size_t capcount = strlen(fmt) + MIN(inlen + 64, 128);
 	ssize_t len;
+	va_list ap_copy;
 
 	darr_ensure_cap(*sp, capcount);
 
@@ -68,7 +69,9 @@ char *__darr_in_vsprintf(char **sp, bool concat, const char *fmt, va_list ap)
 	if (darr_len(*sp) == 0)
 		*darr_append(*sp) = 0;
 again:
-	len = vsnprintf(darr_last(*sp), darr_avail(*sp), fmt, ap);
+	va_copy(ap_copy, ap);
+	len = vsnprintf(darr_last(*sp), darr_avail(*sp), fmt, ap_copy);
+	va_end(ap_copy);
 	if (len < 0)
 		darr_in_strcat(*sp, fmt);
 	else if ((size_t)len < darr_avail(*sp))

--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -538,6 +538,7 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 						  session->client_id,
 						  msg->refer_id,
 						  session->user_ctx, msg->req_id,
+						  err_msg->result_type,
 						  err_msg->error, errstr);
 		break;
 	case MGMT_MSG_CODE_TREE_DATA:

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -410,6 +410,45 @@ extern int mgmt_fe_send_get_data_req(struct mgmt_fe_client *client,
 				     const char *xpath);
 
 /*
+ * Send EDIT to MGMTD daemon.
+ *
+ * client
+ *    Client object.
+ *
+ * session_id
+ *    Client session ID.
+ *
+ * req_id
+ *    Client request ID.
+ *
+ * datastore
+ *    Datastore for editing.
+ *
+ * request_type
+ *    The LYD_FORMAT of the request.
+ *
+ * flags
+ *    Flags to control the behavior of the request.
+ *
+ * operation
+ *    NB_OP_* operation to perform.
+ *
+ * xpath
+ *    the xpath to edit.
+ *
+ * value
+ *    the value of data node.
+ *
+ * Returns:
+ *    0 on success, otherwise msg_conn_send_msg() return values.
+ */
+extern int mgmt_fe_send_edit_req(struct mgmt_fe_client *client,
+				 uint64_t session_id, uint64_t req_id,
+				 uint8_t datastore, LYD_FORMAT request_type,
+				 uint8_t flags, uint8_t operation,
+				 const char *xpath, const char *value);
+
+/*
  * Destroy library and cleanup everything.
  */
 extern void mgmt_fe_client_destroy(struct mgmt_fe_client *client);

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -122,7 +122,8 @@ struct mgmt_fe_client_cbs {
 	/* Called when new native error is returned */
 	int (*error_notify)(struct mgmt_fe_client *client, uintptr_t user_data,
 			    uint64_t client_id, uint64_t session_id,
-			    uintptr_t session_ctx, uint64_t req_id, int error,
+			    uintptr_t session_ctx, uint64_t req_id,
+			    LYD_FORMAT result_type, int error,
 			    const char *errstr);
 };
 

--- a/lib/mgmt_msg_native.c
+++ b/lib/mgmt_msg_native.c
@@ -47,3 +47,25 @@ int vmgmt_msg_native_send_error(struct msg_conn *conn, uint64_t sess_or_txn_id,
 	mgmt_msg_native_free_msg(msg);
 	return ret;
 }
+
+int mgmt_msg_native_send_success(struct msg_conn *conn, uint64_t sess_or_txn_id,
+				 uint64_t req_id, bool short_circuit_ok)
+{
+	struct mgmt_msg_error *msg;
+	int ret;
+
+	msg = mgmt_msg_native_alloc_msg(typeof(*msg), 0, MTYPE_MSG_NATIVE_ERROR);
+	msg->refer_id = sess_or_txn_id;
+	msg->req_id = req_id;
+	msg->code = MGMT_MSG_CODE_ERROR;
+	msg->error = 0;
+
+	if (conn->debug)
+		zlog_debug("Sending success session-id %" PRIu64
+			   " req-id %" PRIu64 " scok %d",
+			   sess_or_txn_id, req_id, short_circuit_ok);
+
+	ret = mgmt_msg_native_send_msg(conn, msg, short_circuit_ok);
+	mgmt_msg_native_free_msg(msg);
+	return ret;
+}

--- a/lib/mgmt_msg_native.c
+++ b/lib/mgmt_msg_native.c
@@ -15,6 +15,7 @@ DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_GET_TREE, "native get tree msg");
 DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_TREE_DATA, "native tree data msg");
 DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_GET_DATA, "native get data msg");
 DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_NOTIFY, "native get data msg");
+DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_EDIT, "native edit msg");
 
 int vmgmt_msg_native_send_error(struct msg_conn *conn, uint64_t sess_or_txn_id,
 				uint64_t req_id, bool short_circuit_ok,

--- a/lib/mgmt_msg_native.h
+++ b/lib/mgmt_msg_native.h
@@ -203,7 +203,7 @@ _Static_assert(sizeof(struct mgmt_msg_header) ==
 /**
  * struct mgmt_msg_error - Common error message.
  *
- * @error: An error value.
+ * @error: An error value. Zero means successful reply.
  * @errst: Description of error can be 0 length.
  *
  * This common error message can be used for replies for many msg requests
@@ -345,6 +345,22 @@ extern int vmgmt_msg_native_send_error(struct msg_conn *conn,
 				       bool short_circuit_ok, int16_t error,
 				       const char *errfmt, va_list ap)
 	PRINTFRR(6, 0);
+
+/**
+ * Send a native message sucess to the other end of the connection.
+ *
+ * Args:
+ *	conn: the connection.
+ *	sess_or_txn_id: Session ID (to FE client) or Txn ID (from BE client)
+ *	req_id: which req_id this success is associated with.
+ *	short_circuit_ok: if short circuit sending is OK.
+ *
+ * Return:
+ *	The return value of ``msg_conn_send_msg``.
+ */
+extern int mgmt_msg_native_send_success(struct msg_conn *conn,
+					uint64_t sess_or_txn_id,
+					uint64_t req_id, bool short_circuit_ok);
 
 /**
  * mgmt_msg_native_alloc_msg() - Create a native appendable msg.

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -976,6 +976,37 @@ extern int nb_candidate_edit(struct nb_config *candidate,
 			     const struct yang_data *data);
 
 /*
+ * Edit a candidate configuration. Value is given as JSON/XML.
+ *
+ * candidate
+ *    Candidate configuration to edit.
+ *
+ * operation
+ *    Operation to apply.
+ *
+ * format
+ *    LYD_FORMAT of the value.
+ *
+ * xpath
+ *    XPath of the configuration node being edited.
+ *    For create, it must be the parent.
+ *
+ * value
+ *    New value of the configuration node.
+ *
+ * errors
+ *    Pointer to store the error tree in case of error.
+ *
+ * Returns:
+ *    - NB_OK on success.
+ *    - NB_ERR for other errors.
+ */
+extern int nb_candidate_edit_tree(struct nb_config *candidate,
+				  enum nb_operation operation,
+				  LYD_FORMAT format, const char *xpath,
+				  const char *value, struct lyd_node **errors);
+
+/*
  * Create diff for configuration.
  *
  * dnode

--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -342,38 +342,6 @@ static void nb_op_resume_data_tree(struct nb_op_yield_state *ys)
 /* ======================= */
 
 /**
- * __xpath_pop_node() - remove the last node from xpath string
- * @xpath: an xpath string
- *
- * Return: NB_OK or NB_ERR_NOT_FOUND if nothing left to pop.
- */
-static int __xpath_pop_node(char *xpath)
-{
-	int len = strlen(xpath);
-	bool abs = xpath[0] == '/';
-	char *slash;
-
-	/* "//" or "/" => NULL */
-	if (abs && (len == 1 || (len == 2 && xpath[1] == '/')))
-		return NB_ERR_NOT_FOUND;
-
-	slash = (char *)frrstr_back_to_char(xpath, '/');
-	/* "/foo/bar/" or "/foo/bar//" => "/foo " */
-	if (slash && slash == &xpath[len - 1]) {
-		xpath[--len] = 0;
-		slash = (char *)frrstr_back_to_char(xpath, '/');
-		if (slash && slash == &xpath[len - 1]) {
-			xpath[--len] = 0;
-			slash = (char *)frrstr_back_to_char(xpath, '/');
-		}
-	}
-	if (!slash)
-		return NB_ERR_NOT_FOUND;
-	*slash = 0;
-	return NB_OK;
-}
-
-/**
  * nb_op_xpath_to_trunk() - generate a lyd_node tree (trunk) using an xpath.
  * @xpath_in: xpath query string to build trunk from.
  * @dnode: resulting tree (trunk)
@@ -398,7 +366,7 @@ static enum nb_error nb_op_xpath_to_trunk(const char *xpath_in,
 		if (err == LY_SUCCESS)
 			break;
 
-		ret = __xpath_pop_node(xpath);
+		ret = yang_xpath_pop_node(xpath);
 		if (ret != NB_OK)
 			break;
 	}

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -3827,8 +3827,8 @@ static int vty_mgmt_get_tree_result_notified(
 static int vty_mgmt_error_notified(struct mgmt_fe_client *client,
 				   uintptr_t user_data, uint64_t client_id,
 				   uint64_t session_id, uintptr_t session_ctx,
-				   uint64_t req_id, int error,
-				   const char *errstr)
+				   uint64_t req_id, LYD_FORMAT result_type,
+				   int error, const char *errstr)
 {
 	struct vty *vty = (struct vty *)session_ctx;
 	const char *cname = mgmt_fe_client_name(client);
@@ -3849,9 +3849,13 @@ static int vty_mgmt_error_notified(struct mgmt_fe_client *client,
 			" session-id %" PRIu64 " req-id %" PRIu64 "error-str %s",
 			error, cname, client_id, session_id, req_id, errstr);
 
-	if (error)
-		vty_out(vty, "%% %s (for %s, client %s)\n", errstr,
-			vty->mgmt_req_pending_cmd, cname);
+	if (error) {
+		if (result_type == LYD_UNKNOWN)
+			vty_out(vty, "%% %s (for %s, client %s)\n", errstr,
+				vty->mgmt_req_pending_cmd, cname);
+		else
+			vty_out(vty, "%s", errstr);
+	}
 
 	vty_mgmt_resume_response(vty, error ? CMD_WARNING : CMD_SUCCESS);
 

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -4125,6 +4125,28 @@ int vty_mgmt_send_get_data_req(struct vty *vty, uint8_t datastore,
 	return 0;
 }
 
+int vty_mgmt_send_edit_req(struct vty *vty, uint8_t datastore,
+			   LYD_FORMAT request_type, uint8_t flags,
+			   uint8_t operation, const char *xpath,
+			   const char *value)
+{
+	vty->mgmt_req_id++;
+
+	if (mgmt_fe_send_edit_req(mgmt_fe_client, vty->mgmt_session_id,
+				  vty->mgmt_req_id, datastore, request_type,
+				  flags, operation, xpath, value)) {
+		zlog_err("Failed to send EDIT to MGMTD session-id: %" PRIu64
+			 " req-id %" PRIu64 ".",
+			 vty->mgmt_session_id, vty->mgmt_req_id);
+		vty_out(vty, "Failed to send EDIT to MGMTD!\n");
+		return -1;
+	}
+
+	vty->mgmt_req_pending_cmd = "MESSAGE_EDIT_REQ";
+
+	return 0;
+}
+
 /* Install vty's own commands like `who' command. */
 void vty_init(struct event_loop *master_thread, bool do_command_logging)
 {

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -3849,8 +3849,9 @@ static int vty_mgmt_error_notified(struct mgmt_fe_client *client,
 			" session-id %" PRIu64 " req-id %" PRIu64 "error-str %s",
 			error, cname, client_id, session_id, req_id, errstr);
 
-	vty_out(vty, "%% %s (for %s, client %s)\n", errstr,
-		vty->mgmt_req_pending_cmd, cname);
+	if (error)
+		vty_out(vty, "%% %s (for %s, client %s)\n", errstr,
+			vty->mgmt_req_pending_cmd, cname);
 
 	vty_mgmt_resume_response(vty, error ? CMD_WARNING : CMD_SUCCESS);
 

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -419,6 +419,10 @@ extern int vty_mgmt_send_get_req(struct vty *vty, bool is_config,
 extern int vty_mgmt_send_get_data_req(struct vty *vty, uint8_t datastore,
 				      LYD_FORMAT result_type, uint8_t flags,
 				      uint8_t defaults, const char *xpath);
+extern int vty_mgmt_send_edit_req(struct vty *vty, uint8_t datastore,
+				  LYD_FORMAT request_type, uint8_t flags,
+				  uint8_t operation, const char *xpath,
+				  const char *value);
 extern int vty_mgmt_send_lockds_req(struct vty *vty, Mgmtd__DatastoreId ds_id,
 				    bool lock, bool scok);
 extern void vty_mgmt_resume_response(struct vty *vty, int ret);

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -12,6 +12,7 @@
 #include "yang.h"
 #include "yang_translator.h"
 #include "northbound.h"
+#include "frrstr.h"
 
 #include "lib/config_paths.h"
 
@@ -1083,6 +1084,32 @@ int yang_get_node_keys(struct lyd_node *node, struct yang_list_keys *keys)
 	return NB_OK;
 }
 
+int yang_xpath_pop_node(char *xpath)
+{
+	int len = strlen(xpath);
+	bool abs = xpath[0] == '/';
+	char *slash;
+
+	/* "//" or "/" => NULL */
+	if (abs && (len == 1 || (len == 2 && xpath[1] == '/')))
+		return NB_ERR_NOT_FOUND;
+
+	slash = (char *)frrstr_back_to_char(xpath, '/');
+	/* "/foo/bar/" or "/foo/bar//" => "/foo " */
+	if (slash && slash == &xpath[len - 1]) {
+		xpath[--len] = 0;
+		slash = (char *)frrstr_back_to_char(xpath, '/');
+		if (slash && slash == &xpath[len - 1]) {
+			xpath[--len] = 0;
+			slash = (char *)frrstr_back_to_char(xpath, '/');
+		}
+	}
+	if (!slash)
+		return NB_ERR_NOT_FOUND;
+	*slash = 0;
+	return NB_OK;
+}
+
 LY_ERR yang_create_error(struct lyd_node **errors, const char *type,
 			 const char *tag, const char *app_tag, const char *path,
 			 const char *message)
@@ -1294,6 +1321,40 @@ LY_ERR yang_lyd_trim_xpath(struct lyd_node **root, const char *xpath)
 
 	return LY_SUCCESS;
 #endif
+}
+
+/* Can be replaced by `lyd_parse_data` with libyang >= 2.1.156 */
+LY_ERR yang_lyd_parse_data(const struct ly_ctx *ctx, struct lyd_node *parent,
+			   struct ly_in *in, LYD_FORMAT format,
+			   uint32_t parse_options, uint32_t validate_options,
+			   struct lyd_node **tree)
+{
+	struct lyd_node *child;
+	LY_ERR err;
+
+	err = lyd_parse_data(ctx, parent, in, format, parse_options,
+			     validate_options, tree);
+	if (err)
+		return err;
+
+	if (!parent || !(parse_options & LYD_PARSE_ONLY))
+		return LY_SUCCESS;
+
+	/*
+	 * Versions prior to 2.1.156 don't return `tree` if `parent` is not NULL
+	 * and validation is disabled (`LYD_PARSE_ONLY`). To work around this,
+	 * go through the children and find the one with `LYD_NEW` flag set.
+	 */
+	*tree = NULL;
+
+	LY_LIST_FOR (lyd_child_no_keys(parent), child) {
+		if (child->flags & LYD_NEW) {
+			*tree = child;
+			break;
+		}
+	}
+
+	return LY_SUCCESS;
 }
 
 /*

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -760,6 +760,14 @@ extern int yang_get_key_preds(char *s, const struct lysc_node *snode,
 extern int yang_get_node_keys(struct lyd_node *node, struct yang_list_keys *keys);
 
 /**
+ * yang_xpath_pop_node() - remove the last node from xpath string
+ * @xpath: an xpath string
+ *
+ * Return: NB_OK or NB_ERR_NOT_FOUND if nothing left to pop.
+ */
+extern int yang_xpath_pop_node(char *xpath);
+
+/**
  * yang_create_error() - create a yang-error data node
  * @errors: pointer to the errors container to add the error to
  *          if *errors is NULL, the container is created
@@ -803,6 +811,11 @@ extern LY_ERR yang_lyd_new_list(struct lyd_node_inner *parent,
 				const struct yang_list_keys *keys,
 				struct lyd_node **nodes);
 extern LY_ERR yang_lyd_trim_xpath(struct lyd_node **rootp, const char *xpath);
+extern LY_ERR yang_lyd_parse_data(const struct ly_ctx *ctx,
+				  struct lyd_node *parent, struct ly_in *in,
+				  LYD_FORMAT format, uint32_t parse_options,
+				  uint32_t validate_options,
+				  struct lyd_node **tree);
 
 #ifdef __cplusplus
 }

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -104,6 +104,9 @@ extern struct ly_ctx *ly_native_ctx;
 /* Tree of all loaded YANG modules. */
 extern struct yang_modules yang_modules;
 
+/* yang-errors extension */
+extern struct lysc_ext_instance *yang_errors_ext;
+
 /*
  * Create a new YANG module and load it using libyang. If the YANG module is not
  * found in the YANG_MODELS_PATH directory, the program will exit with an error.
@@ -755,6 +758,20 @@ extern int yang_get_key_preds(char *s, const struct lysc_node *snode,
 
 /* Get YANG keys from an existing dnode */
 extern int yang_get_node_keys(struct lyd_node *node, struct yang_list_keys *keys);
+
+/**
+ * yang_create_error() - create a yang-error data node
+ * @errors: pointer to the errors container to add the error to
+ *          if *errors is NULL, the container is created
+ * @type: the error type
+ * @tag: the error tag
+ * @app_tag: the application-specific tag
+ * @path: the path to the node that caused the error
+ * @message: a message describing the error
+ */
+extern LY_ERR yang_create_error(struct lyd_node **errors, const char *type,
+				const char *tag, const char *app_tag,
+				const char *path, const char *message);
 
 /**
  * yang_resolve_snodes() - Resolve an XPath to matching schema nodes.

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -510,6 +510,14 @@ static int fe_adapter_send_error(struct mgmt_fe_session_ctx *session,
 	return ret;
 }
 
+static int fe_adapter_send_success(struct mgmt_fe_session_ctx *session,
+				   uint64_t req_id, bool short_circuit_ok)
+{
+	return mgmt_msg_native_send_success(session->adapter->conn,
+					    session->session_id, req_id,
+					    short_circuit_ok);
+}
+
 
 static void mgmt_fe_session_cfg_txn_clnup(struct event *thread)
 {
@@ -1510,6 +1518,26 @@ int mgmt_fe_adapter_txn_error(uint64_t txn_id, uint64_t req_id,
 	return ret;
 }
 
+int mgmt_fe_adapter_txn_success(uint64_t txn_id, uint64_t req_id,
+				bool short_circuit_ok)
+{
+	struct mgmt_fe_session_ctx *session;
+	int ret;
+
+	session = fe_adapter_session_by_txn_id(txn_id);
+	if (!session) {
+		__log_err("failed sending success for txn-id %" PRIu64
+			  " session not found",
+			  txn_id);
+		return -ENOENT;
+	}
+
+	ret = fe_adapter_send_success(session, req_id, short_circuit_ok);
+
+	mgmt_destroy_txn(&session->txn_id);
+
+	return ret;
+}
 
 struct mgmt_setcfg_stats *mgmt_fe_get_session_setcfg_stats(uint64_t session_id)
 {

--- a/mgmtd/mgmt_fe_adapter.h
+++ b/mgmtd/mgmt_fe_adapter.h
@@ -187,18 +187,37 @@ extern int mgmt_fe_adapter_txn_error(uint64_t txn_id, uint64_t req_id,
  * Send a success back to the FE client using native messaging.
  *
  * This also cleans up and frees the transaction.
- * 
+ *
  * Args:
  *     txn_id: the txn_id this success pertains to.
  *     short_circuit_ok: True if OK to short-circuit the call.
  *
  * Return:
  *    the return value from the underlying send function.
- * 
+ *
  */
 extern int mgmt_fe_adapter_txn_success(uint64_t txn_id, uint64_t req_id,
 				       bool short_circuit_ok);
 
+/**
+ * Send error back to the FE client in JSON/XML format using native messaging.
+ *
+ * This also cleans up and frees the transaction.
+ *
+ * Args:
+ *	txn_id: the txn_id this error pertains to.
+ *	short_circuit_ok: True if OK to short-circuit the call.
+ *	result_type: the format of the result data.
+ *	errors: the errors data tree.
+ *
+ * Return:
+ *	the return value from the underlying send function.
+ *
+ */
+extern int mgmt_fe_adapter_txn_errors(uint64_t txn_id, uint64_t req_id,
+				      bool short_circuit_ok,
+				      LYD_FORMAT result_type,
+				      struct lyd_node *errors);
 
 /* Fetch frontend client session set-config stats */
 extern struct mgmt_setcfg_stats *

--- a/mgmtd/mgmt_fe_adapter.h
+++ b/mgmtd/mgmt_fe_adapter.h
@@ -183,6 +183,22 @@ extern int mgmt_fe_adapter_txn_error(uint64_t txn_id, uint64_t req_id,
 				     bool short_circuit_ok, int16_t error,
 				     const char *errstr);
 
+/**
+ * Send a success back to the FE client using native messaging.
+ *
+ * This also cleans up and frees the transaction.
+ * 
+ * Args:
+ *     txn_id: the txn_id this success pertains to.
+ *     short_circuit_ok: True if OK to short-circuit the call.
+ *
+ * Return:
+ *    the return value from the underlying send function.
+ * 
+ */
+extern int mgmt_fe_adapter_txn_success(uint64_t txn_id, uint64_t req_id,
+				       bool short_circuit_ok);
+
 
 /* Fetch frontend client session set-config stats */
 extern struct mgmt_setcfg_stats *

--- a/mgmtd/mgmt_main.c
+++ b/mgmtd/mgmt_main.c
@@ -153,6 +153,12 @@ const struct frr_yang_module_info ietf_netconf_with_defaults_info = {
 	.nodes = { { .xpath = NULL } },
 };
 
+const struct frr_yang_module_info ietf_restconf = {
+	.name = "ietf-restconf",
+	.ignore_cfg_cbs = true,
+	.nodes = { { .xpath = NULL } },
+};
+
 /*
  * These are stub info structs that are used to load the modules used by backend
  * clients into mgmtd. The modules are used by libyang in order to support
@@ -178,6 +184,7 @@ static const struct frr_yang_module_info *const mgmt_yang_modules[] = {
 
 	/* mgmtd-only modules */
 	&ietf_netconf_with_defaults_info,
+	&ietf_restconf,
 
 	/*
 	 * YANG module info used by backend clients get added here.

--- a/mgmtd/mgmt_txn.h
+++ b/mgmtd/mgmt_txn.h
@@ -171,16 +171,20 @@ extern int mgmt_txn_send_set_config_req(uint64_t txn_id, uint64_t req_id,
  * implicit
  *    TRUE if the commit is implicit, FALSE otherwise.
  *
+ * unlock
+ *    if true, unlock candidate and running datastores after the commit.
+ *
+ * native
+ *    if true, send a native message reply.
+ *
  * Returns:
  *    0 on success, -1 on failures.
  */
-extern int mgmt_txn_send_commit_config_req(uint64_t txn_id, uint64_t req_id,
-					   Mgmtd__DatastoreId src_ds_id,
-					   struct mgmt_ds_ctx *dst_ds_ctx,
-					   Mgmtd__DatastoreId dst_ds_id,
-					   struct mgmt_ds_ctx *src_ds_ctx,
-					   bool validate_only, bool abort,
-					   bool implicit);
+extern int mgmt_txn_send_commit_config_req(
+	uint64_t txn_id, uint64_t req_id, Mgmtd__DatastoreId src_ds_id,
+	struct mgmt_ds_ctx *dst_ds_ctx, Mgmtd__DatastoreId dst_ds_id,
+	struct mgmt_ds_ctx *src_ds_ctx, bool validate_only, bool abort,
+	bool implicit, bool unlock, bool native);
 
 /*
  * Send get-{cfg,data} request to be processed later in transaction.
@@ -218,6 +222,31 @@ extern int mgmt_txn_send_get_tree_oper(uint64_t txn_id, uint64_t req_id,
 				       LYD_FORMAT result_type, uint8_t flags,
 				       uint32_t wd_options, bool simple_xpath,
 				       const char *xpath);
+
+/**
+ * Send edit request.
+ *
+ * Args:
+ *	txn_id: Transaction identifier.
+ *	req_id: FE client request identifier.
+ *	ds_id: Datastore ID.
+ *	ds_ctx: Datastore context.
+ *	commit_ds_id: Commit datastore ID.
+ *	commit_ds_ctx: Commit datastore context.
+ *	unlock: Unlock datastores after the edit.
+ *	commit: Commit the candidate datastore after the edit.
+ *	request_type: LYD_FORMAT request type.
+ *	flags: option flags for the request.
+ *	operation: The operation to perform.
+ *	xpath: The xpath of data node to edit.
+ *	value: The value of data node.
+ */
+extern int
+mgmt_txn_send_edit(uint64_t txn_id, uint64_t req_id, Mgmtd__DatastoreId ds_id,
+		   struct mgmt_ds_ctx *ds_ctx, Mgmtd__DatastoreId commit_ds_id,
+		   struct mgmt_ds_ctx *commit_ds_ctx, bool unlock, bool commit,
+		   LYD_FORMAT request_type, uint8_t flags, uint8_t operation,
+		   const char *xpath, const char *value);
 
 /*
  * Notifiy backend adapter on connection.

--- a/mgmtd/mgmt_vty.c
+++ b/mgmtd/mgmt_vty.c
@@ -237,6 +237,64 @@ DEFPY(mgmt_replace_config_data, mgmt_replace_config_data_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY(mgmt_edit, mgmt_edit_cmd,
+      "mgmt edit {create|delete|merge|replace|remove}$op XPATH [json|xml]$fmt [lock$lock] [commit$commit] [VALUE]",
+      MGMTD_STR
+      "Edit configuration data\n"
+      "Create data\n"
+      "Delete data\n"
+      "Merge data\n"
+      "Replace data\n"
+      "Remove data\n"
+      "XPath expression specifying the YANG data path\n"
+      "JSON input format (default)\n"
+      "XML input format\n"
+      "Lock the datastores automatically\n"
+      "Commit the changes automatically\n"
+      "Value\n")
+{
+	LYD_FORMAT format = (fmt && fmt[0] == 'x') ? LYD_XML : LYD_JSON;
+	uint8_t operation;
+	uint8_t flags = 0;
+
+	switch (op[2]) {
+	case 'e':
+		operation = NB_OP_CREATE_EXCL;
+		break;
+	case 'l':
+		operation = NB_OP_DELETE;
+		break;
+	case 'r':
+		operation = NB_OP_MODIFY;
+		break;
+	case 'p':
+		operation = NB_OP_REPLACE;
+		break;
+	case 'm':
+		operation = NB_OP_DESTROY;
+		break;
+	default:
+		vty_out(vty, "Invalid operation!\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	if (!value && (operation == NB_OP_CREATE_EXCL ||
+		       operation == NB_OP_MODIFY || operation == NB_OP_REPLACE)) {
+		vty_out(vty, "Value is missing!\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	if (lock)
+		flags |= EDIT_FLAG_IMPLICIT_LOCK;
+
+	if (commit)
+		flags |= EDIT_FLAG_IMPLICIT_COMMIT;
+
+	vty_mgmt_send_edit_req(vty, MGMT_MSG_DATASTORE_CANDIDATE, format, flags,
+			       operation, xpath, value);
+	return CMD_SUCCESS;
+}
+
 DEFPY(show_mgmt_get_config, show_mgmt_get_config_cmd,
       "show mgmt get-config [candidate|operational|running]$dsname WORD$path",
       SHOW_STR MGMTD_STR
@@ -641,6 +699,7 @@ void mgmt_vty_init(void)
 	install_element(CONFIG_NODE, &mgmt_delete_config_data_cmd);
 	install_element(CONFIG_NODE, &mgmt_remove_config_data_cmd);
 	install_element(CONFIG_NODE, &mgmt_replace_config_data_cmd);
+	install_element(CONFIG_NODE, &mgmt_edit_cmd);
 	install_element(CONFIG_NODE, &mgmt_load_config_cmd);
 	install_element(CONFIG_NODE, &mgmt_save_config_cmd);
 	install_element(CONFIG_NODE, &mgmt_rollback_cmd);

--- a/mgmtd/subdir.am
+++ b/mgmtd/subdir.am
@@ -64,6 +64,7 @@ nodist_mgmtd_mgmtd_SOURCES = \
 	yang/ietf/ietf-netconf-acm.yang.c \
 	yang/ietf/ietf-netconf.yang.c \
 	yang/ietf/ietf-netconf-with-defaults.yang.c \
+	yang/ietf/ietf-restconf.yang.c \
 	# nothing
 mgmtd_mgmtd_CFLAGS = $(AM_CFLAGS) -I ./
 mgmtd_mgmtd_LDADD = mgmtd/libmgmtd.a lib/libfrr.la $(LIBCAP) $(LIBM) $(LIBYANG_LIBS) $(UST_LIBS)

--- a/yang/ietf/ietf-restconf.yang
+++ b/yang/ietf/ietf-restconf.yang
@@ -1,0 +1,277 @@
+module ietf-restconf {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-restconf";
+  prefix "rc";
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     Author:   Andy Bierman
+               <mailto:andy@yumaworks.com>
+
+     Author:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>
+
+     Author:   Kent Watsen
+               <mailto:kwatsen@juniper.net>";
+
+  description
+    "This module contains conceptual YANG specifications
+     for basic RESTCONF media type definitions used in
+     RESTCONF protocol messages.
+
+     Note that the YANG definitions within this module do not
+     represent configuration data of any kind.
+     The 'restconf-media-type' YANG extension statement
+     provides a normative syntax for XML and JSON
+     message-encoding purposes.
+
+     Copyright (c) 2017 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8040; see
+     the RFC itself for full legal notices.";
+
+  revision 2017-01-26 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8040: RESTCONF Protocol.";
+  }
+
+  extension yang-data {
+    argument name {
+      yin-element true;
+    }
+    description
+      "This extension is used to specify a YANG data template that
+       represents conceptual data defined in YANG.  It is
+       intended to describe hierarchical data independent of
+       protocol context or specific message-encoding format.
+       Data definition statements within a yang-data extension
+       specify the generic syntax for the specific YANG data
+       template, whose name is the argument of the 'yang-data'
+       extension statement.
+
+       Note that this extension does not define a media type.
+       A specification using this extension MUST specify the
+       message-encoding rules, including the content media type.
+
+       The mandatory 'name' parameter value identifies the YANG
+       data template that is being defined.  It contains the
+       template name.
+
+       This extension is ignored unless it appears as a top-level
+       statement.  It MUST contain data definition statements
+       that result in exactly one container data node definition.
+       An instance of a YANG data template can thus be translated
+       into an XML instance document, whose top-level element
+       corresponds to the top-level container.
+       The module name and namespace values for the YANG module using
+       the extension statement are assigned to instance document data
+       conforming to the data definition statements within
+       this extension.
+
+       The substatements of this extension MUST follow the
+       'data-def-stmt' rule in the YANG ABNF.
+
+       The XPath document root is the extension statement itself,
+       such that the child nodes of the document root are
+       represented by the data-def-stmt substatements within
+       this extension.  This conceptual document is the context
+       for the following YANG statements:
+
+         - must-stmt
+         - when-stmt
+         - path-stmt
+         - min-elements-stmt
+         - max-elements-stmt
+         - mandatory-stmt
+         - unique-stmt
+         - ordered-by
+         - instance-identifier data type
+
+       The following data-def-stmt substatements are constrained
+       when used within a 'yang-data' extension statement.
+
+         - The list-stmt is not required to have a key-stmt defined.
+         - The if-feature-stmt is ignored if present.
+         - The config-stmt is ignored if present.
+         - The available identity values for any 'identityref'
+           leaf or leaf-list nodes are limited to the module
+           containing this extension statement and the modules
+           imported into that module.
+      ";
+  }
+
+  rc:yang-data yang-errors {
+    uses errors;
+  }
+
+  rc:yang-data yang-api {
+    uses restconf;
+  }
+
+  grouping errors {
+    description
+      "A grouping that contains a YANG container
+       representing the syntax and semantics of a
+       YANG Patch error report within a response message.";
+
+    container errors {
+      description
+        "Represents an error report returned by the server if
+         a request results in an error.";
+
+      list error {
+        description
+          "An entry containing information about one
+           specific error that occurred while processing
+           a RESTCONF request.";
+        reference
+          "RFC 6241, Section 4.3.";
+
+        leaf error-type {
+          type enumeration {
+            enum transport {
+              description
+                "The transport layer.";
+            }
+            enum rpc {
+              description
+                "The rpc or notification layer.";
+            }
+            enum protocol {
+              description
+                "The protocol operation layer.";
+            }
+            enum application {
+              description
+                "The server application layer.";
+            }
+          }
+          mandatory true;
+          description
+            "The protocol layer where the error occurred.";
+        }
+
+        leaf error-tag {
+          type string;
+          mandatory true;
+          description
+            "The enumerated error-tag.";
+        }
+
+        leaf error-app-tag {
+          type string;
+          description
+            "The application-specific error-tag.";
+        }
+
+        leaf error-path {
+          type instance-identifier;
+          description
+            "The YANG instance identifier associated
+             with the error node.";
+        }
+
+        leaf error-message {
+          type string;
+          description
+            "A message describing the error.";
+        }
+
+        anydata error-info {
+           description
+             "This anydata value MUST represent a container with
+              zero or more data nodes representing additional
+              error information.";
+        }
+      }
+    }
+  }
+
+  grouping restconf {
+    description
+      "Conceptual grouping representing the RESTCONF
+       root resource.";
+
+    container restconf {
+      description
+        "Conceptual container representing the RESTCONF
+         root resource.";
+
+      container data {
+        description
+          "Container representing the datastore resource.
+           Represents the conceptual root of all state data
+           and configuration data supported by the server.
+           The child nodes of this container can be any data
+           resources that are defined as top-level data nodes
+           from the YANG modules advertised by the server in
+           the 'ietf-yang-library' module.";
+      }
+
+      container operations {
+        description
+          "Container for all operation resources.
+
+           Each resource is represented as an empty leaf with the
+           name of the RPC operation from the YANG 'rpc' statement.
+
+           For example, the 'system-restart' RPC operation defined
+           in the 'ietf-system' module would be represented as
+           an empty leaf in the 'ietf-system' namespace.  This is
+           a conceptual leaf and will not actually be found in
+           the module:
+
+              module ietf-system {
+                leaf system-reset {
+                  type empty;
+                }
+              }
+
+           To invoke the 'system-restart' RPC operation:
+
+              POST /restconf/operations/ietf-system:system-restart
+
+           To discover the RPC operations supported by the server:
+
+              GET /restconf/operations
+
+           In XML, the YANG module namespace identifies the module:
+
+             <system-restart
+                xmlns='urn:ietf:params:xml:ns:yang:ietf-system'/>
+
+           In JSON, the YANG module name identifies the module:
+
+             { 'ietf-system:system-restart' : [null] }
+          ";
+      }
+      leaf yang-library-version {
+        type string {
+          pattern '\d{4}-\d{2}-\d{2}';
+        }
+        config false;
+        mandatory true;
+        description
+          "Identifies the revision date of the 'ietf-yang-library'
+           module that is implemented by this RESTCONF server.
+           Indicates the year, month, and day in YYYY-MM-DD
+           numeric format.";
+      }
+    }
+  }
+}

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -41,6 +41,7 @@ dist_yangmodels_DATA += yang/ietf/ietf-bgp-types.yang
 dist_yangmodels_DATA += yang/ietf/ietf-netconf-acm.yang
 dist_yangmodels_DATA += yang/ietf/ietf-netconf.yang
 dist_yangmodels_DATA += yang/ietf/ietf-netconf-with-defaults.yang
+dist_yangmodels_DATA += yang/ietf/ietf-restconf.yang
 
 if BFDD
 dist_yangmodels_DATA += yang/frr-bfdd.yang


### PR DESCRIPTION
This is work in progress. This PR adds a new "edit" operation to mgmtd that takes data in JSON/XML format instead of a list of (xpath, value) tuples as required by the existing protobuf API.