### PR TITLE
bgpd: fix displaying srv6 sid

### DIFF
--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -419,22 +419,21 @@ void rfapi_vty_out_vncinfo(struct vty *vty, const struct prefix *p,
 		else
 			vty_out(vty, " label=%u",
 				decode_label(&bpi->extra->label[0]));
+	}
 
-		if (bpi->attr->srv6_l3vpn || bpi->attr->srv6_vpn) {
-			struct in6_addr *sid_tmp =
-				bpi->attr->srv6_l3vpn
-					? (&bpi->attr->srv6_l3vpn->sid)
-					: (&bpi->attr->srv6_vpn->sid);
-			vty_out(vty, " sid=%pI6", sid_tmp);
+	if (bpi->attr->srv6_l3vpn || bpi->attr->srv6_vpn) {
+		struct in6_addr *sid_tmp =
+			bpi->attr->srv6_l3vpn ? (&bpi->attr->srv6_l3vpn->sid)
+					      : (&bpi->attr->srv6_vpn->sid);
+		vty_out(vty, " sid=%pI6", sid_tmp);
 
-			if (bpi->attr->srv6_l3vpn &&
-			    bpi->attr->srv6_l3vpn->loc_block_len != 0) {
-				vty_out(vty, " sid_structure=[%d,%d,%d,%d]",
-					bpi->attr->srv6_l3vpn->loc_block_len,
-					bpi->attr->srv6_l3vpn->loc_node_len,
-					bpi->attr->srv6_l3vpn->func_len,
-					bpi->attr->srv6_l3vpn->arg_len);
-			}
+		if (bpi->attr->srv6_l3vpn &&
+		    bpi->attr->srv6_l3vpn->loc_block_len != 0) {
+			vty_out(vty, " sid_structure=[%d,%d,%d,%d]",
+				bpi->attr->srv6_l3vpn->loc_block_len,
+				bpi->attr->srv6_l3vpn->loc_node_len,
+				bpi->attr->srv6_l3vpn->func_len,
+				bpi->attr->srv6_l3vpn->arg_len);
 		}
 	}
 


### PR DESCRIPTION
98efa5bc6b ("bgpd: bgp_path_info_extra memory optimization") has removed SID info from the extra structure.

Do not test for extra presence.

Fixes: 98efa5bc6b ("bgpd: bgp_path_info_extra memory optimization")