### PR TITLE
nhrp: fix race condition in  null lladdr from zebra

### DIFF
--- a/nhrpd/netlink_arp.c
+++ b/nhrpd/netlink_arp.c
@@ -191,6 +191,11 @@ int nhrp_neighbor_operation(ZAPI_CALLBACK_ARGS)
 			       "Netlink: update binding for %pSU dev %s from c %pSU peer.vc.nbma %pSU to lladdr %pSU",
 			       &addr, ifp->name, &c->cur.remote_nbma_natoa,
 			       &c->cur.peer->vc->remote.nbma, &lladdr);
+
+			if (lladdr.sa.sa_family == AF_UNSPEC)
+				/* nothing from zebra, so use nhrp peer */
+				lladdr = c->cur.peer->vc->remote.nbma;
+
 			/* In case of shortcuts, nbma is given by lladdr, not
 			 * vc->remote.nbma.
 			 */


### PR DESCRIPTION
when neighbor is added (due to routing) at the same as NHRP is adding the neighbor entry, NHRP ends up using the null lladdr vs the address learned via NHRP.