### PR TITLE
lib: fix affinity map duplicate

### DIFF
--- a/mgmtd/subdir.am
+++ b/mgmtd/subdir.am
@@ -19,7 +19,6 @@ mgmtd_libmgmt_be_nb_la_SOURCES = \
 	zebra/zebra_cli.c \
 	# end
 nodist_mgmtd_libmgmt_be_nb_la_SOURCES = \
-	lib/affinitymap_cli.c \
 	# end
 mgmtd_libmgmt_be_nb_la_CFLAGS = $(AM_CFLAGS) -DINCLUDE_MGMTD_CMDDEFS_ONLY
 mgmtd_libmgmt_be_nb_la_CPPFLAGS = $(AM_CPPFLAGS) -DINCLUDE_MGMTD_CMDDEFS_ONLY


### PR DESCRIPTION
Fix duplicate definition of frr_affinity_map_cli_info in libfrr.so.0 and libmgmt_be_nb.so.0

> =================================================================
> ==3860488==ERROR: AddressSanitizer: odr-violation (0x7f12c98c4d20):
>   [1] size=296 'frr_affinity_map_cli_info' lib/affinitymap_cli.c:77:35
>   [2] size=296 'frr_affinity_map_cli_info' lib/affinitymap_cli.c:77:35
> These globals were registered at these points:
>   [1]:
>     #0 0x7f12c9a36f40 in __asan_register_globals ../../../../src/libsanitizer/asan/asan_globals.cpp:341
>     #1 0x7f12c9585b7d in _sub_I_00099_1 (/lib/libfrr.so.0+0x185b7d)
>     #2 0x7f12ca437fe1 in call_init elf/dl-init.c:72
>
>   [2]:
>     #0 0x7f12c9a36f40 in __asan_register_globals ../../../../src/libsanitizer/asan/asan_globals.cpp:341
>     #1 0x7f12c93824ed in _sub_I_00099_1 (/lib/libmgmt_be_nb.so.0+0x6f4ed)
>     #2 0x7f12ca437fe1 in call_init elf/dl-init.c:72
>
> ==3860488==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
> SUMMARY: AddressSanitizer: odr-violation: global 'frr_affinity_map_cli_info' at lib/affinitymap_cli.c:77:35
> ==3860488==ABORTING

Fixes: dc6ff4c0de ("lib: convert affinity-map to mgmtd")