### PR TITLE
bgpd: Do not show TCP MSS if the socket is broken

### DIFF
--- a/lib/sockopt.c
+++ b/lib/sockopt.c
@@ -672,6 +672,9 @@ int sockopt_tcp_mss_get(int sock)
 	int tcp_maxseg = 0;
 	socklen_t tcp_maxseg_len = sizeof(tcp_maxseg);
 
+	if (sock < 0)
+		return 0;
+
 	ret = getsockopt(sock, IPPROTO_TCP, TCP_MAXSEG, &tcp_maxseg,
 			 &tcp_maxseg_len);
 	if (ret != 0) {


### PR DESCRIPTION
Closes https://github.com/FRRouting/frr/issues/15321