### PR TITLE
pimd: re-evaluated S,G OILs upon RP changes and empty SG upstream oils

### DIFF
--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -1219,7 +1219,7 @@ int pim_upstream_mroute_add(struct channel_oil *c_oil, const char *name)
 	return pim_upstream_mroute_update(c_oil, name);
 }
 
-/* Look for IIF changes and update the dateplane entry only if the IIF
+/* Look for IIF changes and update the dataplane entry only if the IIF
  * has changed.
  */
 int pim_upstream_mroute_iif_update(struct channel_oil *c_oil, const char *name)

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1944,6 +1944,40 @@ void pim_upstream_terminate(struct pim_instance *pim)
 		wheel_delete(pim->upstream_sg_wheel);
 	pim->upstream_sg_wheel = NULL;
 }
+bool pim_sg_is_reevaluate_oil_req(struct pim_instance *pim,
+				  struct pim_upstream *up)
+{
+	struct pim_interface *pim_ifp = NULL;
+
+	/*
+	 * Attempt to retrieve the PIM interface information if the RPF
+	 * interface is present
+	 */
+	if (up->rpf.source_nexthop.interface) {
+		pim_ifp = up->rpf.source_nexthop.interface->info;
+	} else {
+		if (PIM_DEBUG_PIM_TRACE) {
+			zlog_debug("%s: up %s RPF is not present", __func__,
+				   up->sg_str);
+		}
+	}
+
+	/*
+	 * Determine if a reevaluation of the outgoing interface list (OIL) is
+	 * required. This may be necessary in scenarios such as MSDP where the
+	 * RP role for a group changes from secondary to primary. In such cases,
+	 * SGRpt may receive a prune, resulting in an S,G entry with a NULL OIL.
+	 * The S,G upstream should then inherit the OIL from *,G, which is
+	 * particularly important for VXLAN setups.
+	 */
+	if (up->channel_oil->oil_inherited_rescan ||
+	    (pim_ifp && I_am_RP(pim_ifp->pim, up->sg.grp)) ||
+	    pim_upstream_empty_inherited_olist(up)) {
+		return true;
+	}
+
+	return false;
+}
 
 bool pim_upstream_equal(const void *arg1, const void *arg2)
 {
@@ -2079,7 +2113,7 @@ static void pim_upstream_sg_running(void *arg)
 	 * only doing this at this point in time
 	 * to get us up and working for the moment
 	 */
-	if (up->channel_oil->oil_inherited_rescan) {
+	if (pim_sg_is_reevaluate_oil_req(pim, up)) {
 		if (PIM_DEBUG_TRACE)
 			zlog_debug(
 				"%s: Handling unscanned inherited_olist for %s[%s]",

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -383,4 +383,6 @@ uint32_t pim_up_mlag_local_cost(struct pim_upstream *up);
 uint32_t pim_up_mlag_peer_cost(struct pim_upstream *up);
 void pim_upstream_reeval_use_rpt(struct pim_instance *pim);
 int pim_upstream_could_register(struct pim_upstream *up);
+bool pim_sg_is_reevaluate_oil_req(struct pim_instance *pim,
+				  struct pim_upstream *up);
 #endif /* PIM_UPSTREAM_H */


### PR DESCRIPTION
Topology:
```

TOR11 (FHR) --- LEAF-11---SPINE1 (RP)MSDP SPINE-2(RP)MSDP --- LEAF-12 -- TOR12 (LHR)
        |         |                    |				|       |
	|         -----------------------------------------------------(ECMP)   |
	|         |		                                |               |
	 -----------------------------------------------------------------------(ECMP)
```
Issue:
In some triggers, S,G upstream is preserved even with the PP timer expiry, resulting
in S,G with NULL OILS. This could be because we create a dummy S,G upstream and
dummy channel_oif for *,G, where RPF is UNKNOWN. As a result, PIM+VXLAN traffic is never
forwarded downstream to LHR.

Fix:
when the S,G stream is running, Determine if a reevaluation of the outgoing interface
 list (OIL) is required. S,G upstream should then inherit the OIL from *,G.

Testing:
- Evpn pim tests - TestEvpnPimSingleVtepOneMdt.test_02_broadcast_traffic_spt_zero
- pim-smoke

Ticket: #

Signed-off-by: Rajesh Varatharaj <rvaratharaj@nvidia.com>


