### PR TITLE
ospfd: can not delete "segment-routing node-msd" when SR if off

### DIFF
--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -580,6 +580,7 @@ static void ospf_sr_stop(void)
 	hash_clean(OspfSR.neighbors, (void *)sr_node_del);
 	OspfSR.self = NULL;
 	OspfSR.status = SR_OFF;
+	OspfSR.msd = 0;
 }
 
 /*


### PR DESCRIPTION
This fixes the initial implementation of commit 7743f2f8c00 ("OSPFd: Update Segment Routing PR following review") where it wsa not possible to remove the "segment-routing node-msd" CLI nodes via vtysh once segment-routing got disabled.

Closes #14910

Should be backported to `stable/9.0` and `stable/9.1`