### PR TITLE
ospfd: add support for "no router-info [<area|as>] command"

### DIFF
--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -1723,9 +1723,11 @@ DEFUN (router_info,
 
 DEFUN (no_router_info,
        no_router_info_cmd,
-       "no router-info",
+       "no router-info [<area|as>]",
        NO_STR
-       "Disable the Router Information functionality\n")
+       "Disable the Router Information functionality\n"
+       "Disable the Router Information functionality with AS flooding scope\n"
+       "Disable the Router Information functionality with Area flooding scope\n")
 {
 
 	if (!OspfRI.enabled)


### PR DESCRIPTION
frr-reload.py will walk through all config contexts and prepend no to the CLI command. This requires that the vtysh shell code accepts a full command.

To Reproduce

```
vtysh -c "conf t" -c "router ospf" -c "router-info area"
vtysh -c "conf t" -c "router ospf" -c "no router-info area" % Unknown command: no router-info area
vtysh -c "conf t" -c "router ospf" -c "no router-info"
```

Closes #15335

Backport to `stable/9.0` and `stable/9.1`