### PR TITLE
bgpd: fix route recursion on leaked routes

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1511,6 +1511,7 @@ void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 			struct bgp_path_info *info, struct bgp *bgp, afi_t afi,
 			safi_t safi)
 {
+	struct bgp_path_info *bpi_ultimate;
 	struct zapi_route api = { 0 };
 	unsigned int valid_nh_count = 0;
 	bool allow_recursion = false;
@@ -1554,15 +1555,9 @@ void bgp_zebra_announce(struct bgp_dest *dest, const struct prefix *p,
 
 	peer = info->peer;
 
-	if (info->type == ZEBRA_ROUTE_BGP
-	    && info->sub_type == BGP_ROUTE_IMPORTED) {
-
-		/* Obtain peer from parent */
-		if (info->extra && info->extra->vrfleak &&
-		    info->extra->vrfleak->parent)
-			peer = ((struct bgp_path_info *)(info->extra->vrfleak
-								 ->parent))
-				       ->peer;
+	if (info->type == ZEBRA_ROUTE_BGP) {
+		bpi_ultimate = bgp_get_imported_bpi_ultimate(info);
+		peer = bpi_ultimate->peer;
 	}
 
 	tag = info->attr->tag;

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_routes.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_routes.py
@@ -891,4 +891,11 @@ luCommand(
     "pass",
     "Redundant route 2 details",
 )
+luCommand(
+    "r1",
+    'vtysh -c "show ip route vrf r1-cust5 5.1.0.0/24"',
+    "Known via .bgp., distance 200, .* vrf r1-cust5, best",
+    "pass",
+    "Recursive route leak details",
+)
 # done


### PR DESCRIPTION
bgpd: fix route recursion on leaked routes

Leaked recursive routes are not resolved.

```
VRF r1-cust1:
B>  5.1.0.0/24 [200/98] via 99.0.0.1 (recursive), weight 1, 00:00:08
 *                       via 192.168.1.2, r1-eth4, weight 1, 00:00:08
B>* 99.0.0.1/32 [200/0] via 192.168.1.2, r1-eth4, weight 1, 00:00:08

VRF r1-cust4:
B   5.1.0.0/24 [20/98] via 99.0.0.1 (vrf r1-cust1) inactive, weight 1, 00:00:08
B>* 99.0.0.1/32 [20/0] via 192.168.1.2, r1-eth4 (vrf r1-cust1), weight 1, 00:00:08
```

When announcing the routes to zebra, use the peer of the ultimate bgp
path info instead of the one of the first parent path info to determine
whether the route is recursive.

The result is:
```
VRF r1-cust4:
B>  5.1.0.0/24 [20/98] via 99.0.0.1 (vrf r1-cust1) (recursive), weight 1, 00:00:02
  *                      via 192.168.1.2, r1-eth4 (vrf r1-cust1), weight 1, 00:00:02
B>* 99.0.0.1/32 [20/0] via 192.168.1.2, r1-eth4 (vrf r1-cust1), weight 1, 00:00:02
```
