### PR TITLE
qpb: Add missing `#include nexthop.h`

### DIFF
--- a/qpb/qpb.h
+++ b/qpb/qpb.h
@@ -14,6 +14,7 @@
 #ifndef _QPB_H
 #define _QPB_H
 
+#include "nexthop.h"
 #include "prefix.h"
 
 #include "qpb/qpb.pb-c.h"


### PR DESCRIPTION
In `qpb.h` we have a bunch of functions that make use of `union g_addr`. `union g_addr` is defined in `nexthop.h`, which actually is NOT included in `qpb.h`.

Let's add the missing `#include nexthop.h`.