### PR TITLE
ospfd: fix cli shown in running config when turning off ldp-sync

### DIFF
--- a/ospfd/ospf_ldp_sync.c
+++ b/ospfd/ospf_ldp_sync.c
@@ -774,7 +774,7 @@ DEFPY (no_ospf_mpls_ldp_sync,
        "Disable MPLS LDP-IGP Sync\n")
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
-	ospf_ldp_sync_gbl_exit(ospf, false);
+	ospf_ldp_sync_gbl_exit(ospf, true);
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
LDP-Sync is automatically enabled on interfaces when turned on in
router ospf context.   The user can remove ldp-sync from running
on an interface, by issuing a "no ip ospd mpls ldp-sync" command.
To remove all ldp-sync interface commands the user must delete
ldp-sync at the router level.  The code was not correctly removing
the config.   This PR fixes that issue.   Now the extra cli
ldp-sync interface commands are removed when ldp-sync is disabled.