### PR TITLE
debian: Ensure we properly depend on the right version of libyang2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Build-Depends: bison,
                librtr-dev (>= 0.8.0~) <!pkg.frr.nortrlib>,
                libsnmp-dev,
                libssh-dev <!pkg.frr.nortrlib>,
-               libyang2-dev (>= 2.1.80),
+               libyang2-dev (>= 2.1.128),
                lsb-base,
                pkg-config,
                protobuf-c-compiler,
@@ -42,6 +42,7 @@ Vcs-Git: https://github.com/FRRouting/frr.git -b debian/master
 Package: frr
 Architecture: linux-any
 Depends: iproute2,
+         libyang2 (>= 2.1.128),
          logrotate (>= 3.2-11),
          lsof,
          ${misc:Depends},

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -187,7 +187,7 @@ BuildRequires:  make
 BuildRequires:  ncurses-devel
 BuildRequires:  readline-devel
 BuildRequires:  texinfo
-BuildRequires:  libyang-devel >= 2.1.80
+BuildRequires:  libyang-devel >= 2.1.128
 %if 0%{?rhel} && 0%{?rhel} < 7
 #python27-devel is available from ius community repo for RedHat/CentOS 6
 BuildRequires:  python27-devel


### PR DESCRIPTION
Fixes: #15372