### PR TITLE
tests: fix ospf_suppress_fa timing issue

### DIFF
--- a/tests/topotests/ospf_suppress_fa/r2/ospfd.conf
+++ b/tests/topotests/ospf_suppress_fa/r2/ospfd.conf
@@ -10,6 +10,7 @@ interface r2-eth1
  ip ospf dead-interval 10
 !
 router ospf
+ ospf router-id 10.0.23.2
  network 10.0.12.0/24 area 0
  network 10.0.23.0/24 area 1
  area 1 nssa 


### PR DESCRIPTION
Set static router-id for OSPF, because otherwise it depends on timing of router-id updates received from zebra and may differ between test runs.

Fixes #15261 