### PR TITLE
zebra: Remove deprecated items

### DIFF
--- a/tests/topotests/bgp_evpn_vxlan_svd_topo1/PE1/evpn.vni.json
+++ b/tests/topotests/bgp_evpn_vxlan_svd_topo1/PE1/evpn.vni.json
@@ -1,7 +1,7 @@
 {
   "vni":101,
   "type":"L2",
-  "vrf":"default",
+  "tenantVrf":"default",
   "vxlanInterface":"vxlan0",
   "vtepIp":"10.10.10.10",
   "mcastGroup":"0.0.0.0",

--- a/tests/topotests/bgp_evpn_vxlan_svd_topo1/PE2/evpn.vni.json
+++ b/tests/topotests/bgp_evpn_vxlan_svd_topo1/PE2/evpn.vni.json
@@ -1,7 +1,7 @@
 {
   "vni":101,
   "type":"L2",
-  "vrf":"default",
+  "tenantVrf":"default",
   "vxlanInterface":"vxlan0",
   "vtepIp":"10.30.30.30",
   "mcastGroup":"0.0.0.0",

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -109,11 +109,6 @@ void zebra_evpn_print(struct zebra_evpn *zevpn, void **ctxt)
 	} else {
 		json_object_int_add(json, "vni", zevpn->vni);
 		json_object_string_add(json, "type", "L2");
-#if CONFDATE > 20240210
-CPP_NOTICE("Drop `vrf` from JSON output")
-#endif
-		json_object_string_add(json, "vrf",
-				       vrf_id_to_name(zevpn->vrf_id));
 		json_object_string_add(json, "tenantVrf",
 				       vrf_id_to_name(zevpn->vrf_id));
 	}
@@ -142,10 +137,6 @@ CPP_NOTICE("Drop `vrf` from JSON output")
 	} else {
 		json_object_string_add(json, "vxlanInterface",
 				       zevpn->vxlan_if->name);
-#if CONFDATE > 20240210
-CPP_NOTICE("Drop `ifindex` from JSON output")
-#endif
-		json_object_int_add(json, "ifindex", zevpn->vxlan_if->ifindex);
 		json_object_int_add(json, "vxlanIfindex",
 				    zevpn->vxlan_if->ifindex);
 		if (zevpn->svi_if) {

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -769,10 +769,6 @@ static void zl3vni_print(struct zebra_l3vni *zl3vni, void **ctx)
 		json_evpn_list = json_object_new_array();
 		json_object_int_add(json, "vni", zl3vni->vni);
 		json_object_string_add(json, "type", "L3");
-#if CONFDATE > 20240210
-CPP_NOTICE("Drop `vrf` from JSON outputs")
-#endif
-		json_object_string_add(json, "vrf", zl3vni_vrf_name(zl3vni));
 		json_object_string_add(json, "tenantVrf",
 				       zl3vni_vrf_name(zl3vni));
 		json_object_string_addf(json, "localVtepIp", "%pI4",


### PR DESCRIPTION
Both zebra_evpn.c and zebra_vxlan.c have items that were deprecated a year ago.  Let's remove them.