### PR TITLE
isisd: display all the algorithms at the same time

### DIFF
--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -320,12 +320,12 @@ Showing ISIS information
    Show the ISIS database globally, for a specific LSP id without or with
    details.
 
-.. clicmd:: show isis topology [level-1|level-2] [algorithm (128-255)]
+.. clicmd:: show isis topology [level-1|level-2] [algorithm [(128-255)]]
 
    Show topology IS-IS paths to Intermediate Systems, globally, in area
    (level-1) or domain (level-2).
 
-.. clicmd:: show isis route [level-1|level-2] [prefix-sid|backup] [algorithm (128-255)]
+.. clicmd:: show isis route [level-1|level-2] [prefix-sid|backup] [algorithm [(128-255)]]
 
    Show the ISIS routing table, as determined by the most recent SPF
    calculation.
@@ -435,7 +435,7 @@ Known limitations:
    clear the Node flag that is set by default for Prefix-SIDs associated to
    loopback addresses. This option is necessary to configure Anycast-SIDs.
 
-.. clicmd:: show isis segment-routing node [algorithm (128-255)]
+.. clicmd:: show isis segment-routing node [algorithm [(128-255)]]
 
    Show detailed information about all learned Segment Routing Nodes.
 

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -2912,6 +2912,7 @@ static void show_isis_route_common(struct vty *vty, int levels,
 			jstr = json_object_new_string(
 				area->area_tag ? area->area_tag : "null");
 			json_object_object_add(*json, "area", jstr);
+			json_object_int_add(*json, "algorithm", algo);
 		} else {
 			vty_out(vty, "Area %s:",
 				area->area_tag ? area->area_tag : "null");


### PR DESCRIPTION
Add the ability to display all the flexible-algorithms at the same time in the following commands:

- show isis route algorithm
- show isis topology algorithm
- show isis segment-routing node algorithm

It is currently only possible to show only one given algorithm X

- show isis route algorithm X
- show isis topology algorithm X
- show isis segment-routing node algorithm X
