### PR TITLE
lib: fix base64 encoding

### DIFF
--- a/lib/base64.c
+++ b/lib/base64.c
@@ -11,7 +11,6 @@
 #include "base64.h"
 #include "compiler.h"
 
-static const int CHARS_PER_LINE = 72;
 static const char *ENCODING =
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
@@ -19,7 +18,6 @@ void base64_init_encodestate(struct base64_encodestate *state_in)
 {
 	state_in->step = step_A;
 	state_in->result = 0;
-	state_in->stepcount = 0;
 }
 
 char base64_encode_value(char value_in)
@@ -76,12 +74,6 @@ int base64_encode_block(const char *plaintext_in, int length_in, char *code_out,
 				*codechar++ = base64_encode_value(result);
 				result  = (fragment & 0x03f) >> 0;
 				*codechar++ = base64_encode_value(result);
-
-				++(state_in->stepcount);
-				if (state_in->stepcount == CHARS_PER_LINE/4) {
-					*codechar++ = '\n';
-					state_in->stepcount = 0;
-				}
 		}
 	}
 	/* control should not reach here */
@@ -105,7 +97,6 @@ int base64_encode_blockend(char *code_out, struct base64_encodestate *state_in)
 	case step_A:
 		break;
 	}
-	*codechar++ = '\n';
 
 	return codechar - code_out;
 }

--- a/lib/base64.h
+++ b/lib/base64.h
@@ -14,7 +14,6 @@ enum base64_encodestep {
 struct base64_encodestate {
 	enum base64_encodestep step;
 	char result;
-	int stepcount;
 };
 
 void base64_init_encodestate(struct base64_encodestate *state_in);


### PR DESCRIPTION
Remove adding of line feeds when encondig. We're using these functions only for encoding binary data for storing in YANG data tree.

According to RFC 7950, section 9.8.2:
```
9.8.2.  Lexical Representation

   Binary values are encoded with the base64 encoding scheme (see
   Section 4 in [RFC4648]).
```

According to mentioned RFC 4648, section 3.1:
```
   Implementations MUST NOT add line feeds to base-encoded data unless
   the specification referring to this document explicitly directs base
   encoders to add line feeds after a specific number of characters.
```

Therefore, line feeds must not be added to the encoded data.