### PR TITLE
zebra: fix crash when macvlan link-interface is in another netns

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5157,6 +5157,11 @@ void zebra_vxlan_macvlan_up(struct interface *ifp)
 
 	zif = ifp->info;
 	assert(zif);
+
+	if (zif->link_nsid)
+		/* the link interface is another namespace */
+		return;
+
 	link_ifp = zif->link;
 	link_zif = link_ifp->info;
 	assert(link_zif);


### PR DESCRIPTION
A macvlan interface can have its underlying link-interface in another
namespace (aka. netns). However, by default, zebra does not know the
interface from the other namespaces. It results in a crash the pointer
to the link interface is NULL.

> 6  0x0000559d77a329d3 in zebra_vxlan_macvlan_up (ifp=0x559d798b8e00) at /root/frr/zebra/zebra_vxlan.c:4676
> 4676		link_zif = link_ifp->info;
> (gdb) list
> 4671		struct interface *link_ifp, *link_if;
> 4672
> 4673		zif = ifp->info;
> 4674		assert(zif);
> 4675		link_ifp = zif->link;
> 4676		link_zif = link_ifp->info;
> 4677		assert(link_zif);
> 4678
> (gdb) p zif->link
> $2 = (struct interface *) 0x0
> (gdb) p zif->link_ifindex
> $3 = 15

Fix the crash by returning when the macvlan link-interface is in another
namespace. No need to go further because any vxlan under the macvlan
interface would not be accessible by zebra.

Closes https://github.com/FRRouting/frr/issues/15370