### PR TITLE
Fix order of NB callbacks (and a crash)

### DIFF
--- a/lib/affinitymap_northbound.c
+++ b/lib/affinitymap_northbound.c
@@ -94,7 +94,8 @@ const struct frr_yang_module_info frr_affinity_map_info = {
 			.cbs = {
 				.create = lib_affinity_map_create,
 				.destroy = lib_affinity_map_destroy,
-			}
+			},
+			.priority = NB_DFLT_PRIORITY - 1,
 		},
 		{
 			.xpath = "/frr-affinity-map:lib/affinity-maps/affinity-map/value",

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -391,11 +391,14 @@ void nb_config_replace(struct nb_config *config_dst,
 static inline int nb_config_cb_compare(const struct nb_config_cb *a,
 				       const struct nb_config_cb *b)
 {
-	/* Sort by priority first. */
+	/*
+	 * Sort by priority first. If the operation is "destroy", reverse the
+	 * order, so that the dependencies are destroyed before the dependants.
+	 */
 	if (a->nb_node->priority < b->nb_node->priority)
-		return -1;
+		return a->operation != NB_CB_DESTROY ? -1 : 1;
 	if (a->nb_node->priority > b->nb_node->priority)
-		return 1;
+		return a->operation != NB_CB_DESTROY ? 1 : -1;
 
 	/*
 	 * Preserve the order of the configuration changes as told by libyang.


### PR DESCRIPTION
```
lib: add missing priority for affinity map callbacks

Other objects depend on affinity-maps being created before them by using
leafref with require-instance true. Set the priority to ensure that.
```
```
lib: fix order of northbound callbacks

When ordering the NB callbacks according to their priorities, if the
operation is "destroy" we should reverse the order, to destroy the
dependants before the dependencies.

This fixes the crash, that can be reproduced with the following steps:

frr# conf term file-lock
frr(config)# affinity-map map bit-position 10
frr(config)# interface test
frr(config-if)# link-params
frr(config-link-params)# affinity map
frr(config-link-params)# exit
frr(config-if)# exit
frr(config)# mgmt commit apply
frr(config)# no affinity-map map
frr(config)# interface test
frr(config-if)# link-params
frr(config-link-params)# no affinity map
frr(config-link-params)# exit
frr(config-if)# exit
frr(config)# mgmt commit apply

```