### PR TITLE
tests: bgp_evpn_mh timing issue fix

### DIFF
--- a/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
+++ b/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
@@ -389,13 +389,6 @@ def setup_module(module):
     tors.append("torm22")
     config_tors(tgen, tors)
 
-    hosts = []
-    hosts.append("hostd11")
-    hosts.append("hostd12")
-    hosts.append("hostd21")
-    hosts.append("hostd22")
-    config_hosts(tgen, hosts)
-
     # tgen.mininet_cli()
     # This is a sample of configuration loading.
     router_list = tgen.routers()
@@ -410,6 +403,13 @@ def setup_module(module):
             TopoRouter.RD_BGP, os.path.join(CWD, "{}/evpn.conf".format(rname))
         )
     tgen.start_router()
+
+    hosts = []
+    hosts.append("hostd11")
+    hosts.append("hostd12")
+    hosts.append("hostd21")
+    hosts.append("hostd22")
+    config_hosts(tgen, hosts)
     # tgen.mininet_cli()
 
 
@@ -634,6 +634,7 @@ def check_mac(dut, vni, mac, m_type, esi, intf, ping_gw=False, tgen=None):
 
     out = dut.vtysh_cmd("show evpn mac vni %d mac %s json" % (vni, mac))
 
+    tmp_esi = None
     mac_js = json.loads(out)
     for mac, info in mac_js.items():
         tmp_esi = info.get("esi", "")
@@ -642,7 +643,15 @@ def check_mac(dut, vni, mac, m_type, esi, intf, ping_gw=False, tgen=None):
         if tmp_esi == esi and tmp_m_type == m_type and intf == intf:
             return None
 
-    return "invalid vni %d mac %s out %s" % (vni, mac, mac_js)
+    return "invalid vni %d mac %s expected esi %s, %s m_type %s and intf %s out %s" % (
+        vni,
+        mac,
+        tmp_esi,
+        esi,
+        m_type,
+        intf,
+        mac_js,
+    )
 
 
 def test_evpn_mac():


### PR DESCRIPTION
This test is failing locally for me 100% of the time since zebra was converted to mgmtd usage.  The failed command is:

torm11# show evpn mac vni 1000 mac 00:00:00:00:00:11 json {
  "00:00:00:00:00:11":{
    "type":"auto",
    "uptime":"00:02:01",
    "localSequence":0,
    "remoteSequence":0,
    "detectionCount":0,
    "isDuplicate":false,
    "syncNeighCount":0,
    "neighbors":{
      "active":[
      ],
      "inactive":[
        "45.0.0.11"
      ]
    }
  }
}

The test is expecting an esi as a key in the output.  Re-arranging the startup of the tor's before the hosts fixes the issue.