### PR TITLE
bgpd: move mp_nexthop_prefer_global boolean attribute to nh_flags

### DIFF
--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -159,6 +159,7 @@ struct attr {
 
 #define BGP_ATTR_NH_VALID 0x01
 #define BGP_ATTR_NH_IF_OPERSTATE 0x02
+#define BGP_ATTR_NH_MP_PREFER_GLOBAL 0x04 /* MP Nexthop preference */
 
 	/* Path origin attribute */
 	uint8_t origin;
@@ -254,9 +255,6 @@ struct attr {
 
 	/* MP Nexthop length */
 	uint8_t mp_nexthop_len;
-
-	/* MP Nexthop preference */
-	uint8_t mp_nexthop_prefer_global;
 
 	/* Static MAC for EVPN */
 	uint8_t sticky;

--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -129,15 +129,19 @@ int bgp_path_info_nexthop_cmp(struct bgp_path_info *bpi1,
 					&bpi2->attr->mp_nexthop_global);
 				break;
 			case BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL:
-				addr1 = (bpi1->attr->mp_nexthop_prefer_global)
+				addr1 = (CHECK_FLAG(bpi1->attr->nh_flags,
+						    BGP_ATTR_NH_MP_PREFER_GLOBAL))
 						? bpi1->attr->mp_nexthop_global
 						: bpi1->attr->mp_nexthop_local;
-				addr2 = (bpi2->attr->mp_nexthop_prefer_global)
+				addr2 = (CHECK_FLAG(bpi2->attr->nh_flags,
+						    BGP_ATTR_NH_MP_PREFER_GLOBAL))
 						? bpi2->attr->mp_nexthop_global
 						: bpi2->attr->mp_nexthop_local;
 
-				if (!bpi1->attr->mp_nexthop_prefer_global
-				    && !bpi2->attr->mp_nexthop_prefer_global)
+				if (!CHECK_FLAG(bpi1->attr->nh_flags,
+						BGP_ATTR_NH_MP_PREFER_GLOBAL) &&
+				    !CHECK_FLAG(bpi2->attr->nh_flags,
+						BGP_ATTR_NH_MP_PREFER_GLOBAL))
 					compare = !bgp_interface_same(
 						bpi1->peer->ifp,
 						bpi2->peer->ifp);

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -1065,7 +1065,8 @@ static int make_prefix(int afi, struct bgp_path_info *pi, struct prefix *p)
 			 */
 			else if (pi->attr->mp_nexthop_len
 				 == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL) {
-				if (pi->attr->mp_nexthop_prefer_global)
+				if (CHECK_FLAG(pi->attr->nh_flags,
+					       BGP_ATTR_NH_MP_PREFER_GLOBAL))
 					p->u.prefix6 =
 						pi->attr->mp_nexthop_global;
 				else

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9323,9 +9323,10 @@ void route_vty_out(struct vty *vty, const struct prefix *p,
 						       "link-local");
 
 				if ((IPV6_ADDR_CMP(&attr->mp_nexthop_global,
-						   &attr->mp_nexthop_local)
-				     != 0)
-				    && !attr->mp_nexthop_prefer_global)
+						   &attr->mp_nexthop_local) !=
+				     0) &&
+				    !CHECK_FLAG(attr->nh_flags,
+						BGP_ATTR_NH_MP_PREFER_GLOBAL))
 					json_object_boolean_true_add(
 						json_nexthop_ll, "used");
 				else
@@ -9337,10 +9338,11 @@ void route_vty_out(struct vty *vty, const struct prefix *p,
 		} else {
 			/* Display LL if LL/Global both in table unless
 			 * prefer-global is set */
-			if (((attr->mp_nexthop_len
-			      == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL)
-			     && !attr->mp_nexthop_prefer_global)
-			    || (path->peer->conf_if)) {
+			if (((attr->mp_nexthop_len ==
+			      BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL) &&
+			     !CHECK_FLAG(attr->nh_flags,
+					 BGP_ATTR_NH_MP_PREFER_GLOBAL)) ||
+			    (path->peer->conf_if)) {
 				if (path->peer->conf_if) {
 					len = vty_out(vty, "%s",
 						      path->peer->conf_if);
@@ -10588,7 +10590,8 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 			json_object_boolean_true_add(json_nexthop_ll,
 						     "accessible");
 
-			if (!attr->mp_nexthop_prefer_global)
+			if (!CHECK_FLAG(attr->nh_flags,
+					BGP_ATTR_NH_MP_PREFER_GLOBAL))
 				json_object_boolean_true_add(json_nexthop_ll,
 							     "used");
 			else
@@ -10598,7 +10601,8 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 			vty_out(vty, "    (%s) %s\n",
 				inet_ntop(AF_INET6, &attr->mp_nexthop_local,
 					  buf, INET6_ADDRSTRLEN),
-				attr->mp_nexthop_prefer_global
+				CHECK_FLAG(attr->nh_flags,
+					   BGP_ATTR_NH_MP_PREFER_GLOBAL)
 					? "(prefer-global)"
 					: "(used)");
 		}

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3935,11 +3935,11 @@ route_set_ipv6_nexthop_prefer_global(void *rule, const struct prefix *prefix,
 	if (CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IN)
 	    || CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IMPORT)) {
 		/* Set next hop preference to global */
-		path->attr->mp_nexthop_prefer_global = true;
+		SET_FLAG(path->attr->nh_flags, BGP_ATTR_NH_MP_PREFER_GLOBAL);
 		SET_FLAG(path->attr->rmap_change_flags,
 			 BATTR_RMAP_IPV6_PREFER_GLOBAL_CHANGED);
 	} else {
-		path->attr->mp_nexthop_prefer_global = false;
+		UNSET_FLAG(path->attr->nh_flags, BGP_ATTR_NH_MP_PREFER_GLOBAL);
 		SET_FLAG(path->attr->rmap_change_flags,
 			 BATTR_RMAP_IPV6_PREFER_GLOBAL_CHANGED);
 	}

--- a/bgpd/bgp_snmp_bgp4v2.c
+++ b/bgpd/bgp_snmp_bgp4v2.c
@@ -853,7 +853,8 @@ static uint8_t *bgp4v2PathAttrTable(struct variable *v, oid name[],
 		case BGP_ATTR_NHLEN_IPV6_GLOBAL:
 			return SNMP_INTEGER(2);
 		case BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL:
-			if (path->attr->mp_nexthop_prefer_global)
+			if (CHECK_FLAG(path->attr->nh_flags,
+				       BGP_ATTR_NH_MP_PREFER_GLOBAL))
 				return SNMP_INTEGER(2);
 			else
 				return SNMP_INTEGER(4);
@@ -867,7 +868,8 @@ static uint8_t *bgp4v2PathAttrTable(struct variable *v, oid name[],
 		case BGP_ATTR_NHLEN_IPV6_GLOBAL:
 			return SNMP_IP6ADDRESS(path->attr->mp_nexthop_global);
 		case BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL:
-			if (path->attr->mp_nexthop_prefer_global)
+			if (CHECK_FLAG(path->attr->nh_flags,
+				       BGP_ATTR_NH_MP_PREFER_GLOBAL))
 				return SNMP_IP6ADDRESS(
 					path->attr->mp_nexthop_global);
 			else

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -943,7 +943,8 @@ bgp_path_info_to_ipv6_nexthop(struct bgp_path_info *path, ifindex_t *ifindex)
 	    || path->attr->mp_nexthop_len
 		       == BGP_ATTR_NHLEN_VPNV6_GLOBAL_AND_LL) {
 		/* Check if route-map is set to prefer global over link-local */
-		if (path->attr->mp_nexthop_prefer_global) {
+		if (CHECK_FLAG(path->attr->nh_flags,
+			       BGP_ATTR_NH_MP_PREFER_GLOBAL)) {
 			nexthop = &path->attr->mp_nexthop_global;
 			if (IN6_IS_ADDR_LINKLOCAL(nexthop))
 				*ifindex = path->attr->nh_ifindex;


### PR DESCRIPTION
Move mp_nexthop_prefer_global boolean attribute to nh_flags. It does not currently save memory because of the packing.


After the change:
```
$ pahole /usr/lib/frr/bgpd | grep -A100 'struct attr {' | grep -B100 -m1 '}'
struct attr {
	struct aspath *            aspath;               /*     0     8 */
	struct community *         community;            /*     8     8 */
	long unsigned int          refcnt;               /*    16     8 */
	_uint64_t                  flag;                 /*    24     8 */
	struct in_addr             nexthop;              /*    32     4 */
	uint32_t                   med;                  /*    36     4 */
	uint32_t                   local_pref;           /*    40     4 */
	ifindex_t                  nh_ifindex;           /*    44     4 */
	uint8_t                    nh_flags;             /*    48     1 */
	uint8_t                    origin;               /*    49     1 */
	uint8_t                    es_flags;             /*    50     1 */
	uint8_t                    router_flag;          /*    51     1 */
	uint8_t                    distance;             /*    52     1 */
	uint8_t                    df_alg;               /*    53     1 */
	uint16_t                   df_pref;              /*    54     2 */
	enum pta_type              pmsi_tnl_type;        /*    56     4 */
	uint32_t                   rmap_change_flags;    /*    60     4 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	struct in6_addr            mp_nexthop_global;    /*    64    16 */
	struct in6_addr            mp_nexthop_local;     /*    80    16 */
	ifindex_t                  nh_lla_ifindex;       /*    96     4 */
	mpls_label_t               label;                /*   100     4 */
	struct ecommunity *        ecommunity;           /*   104     8 */
	struct ecommunity *        ipv6_ecommunity;      /*   112     8 */
	struct lcommunity *        lcommunity;           /*   120     8 */
	/* --- cacheline 2 boundary (128 bytes) --- */
	struct cluster_list *      cluster1;             /*   128     8 */
	struct transit *           transit;              /*   136     8 */
	struct in_addr             mp_nexthop_global_in; /*   144     4 */
	struct in_addr             aggregator_addr;      /*   148     4 */
	struct in_addr             originator_id;        /*   152     4 */
	uint32_t                   weight;               /*   156     4 */
	as_t                       aggregator_as;        /*   160     4 */
	uint8_t                    mp_nexthop_len;       /*   164     1 */
	uint8_t                    sticky;               /*   165     1 */
	uint8_t                    default_gw;           /*   166     1 */

	/* XXX 1 byte hole, try to pack */

	route_tag_t                tag;                  /*   168     4 */
	uint32_t                   label_index;          /*   172     4 */
	struct bgp_attr_srv6_vpn * srv6_vpn;             /*   176     8 */
	struct bgp_attr_srv6_l3vpn * srv6_l3vpn;         /*   184     8 */
	/* --- cacheline 3 boundary (192 bytes) --- */
	struct bgp_attr_encap_subtlv * encap_subtlvs;    /*   192     8 */
	struct bgp_attr_encap_subtlv * vnc_subtlvs;      /*   200     8 */
	struct bgp_route_evpn      evpn_overlay;         /*   208    36 */
	uint32_t                   mm_seqnum;            /*   244     4 */
	uint32_t                   mm_sync_seqnum;       /*   248     4 */
	struct ethaddr             rmac;                 /*   252     6 */
	/* --- cacheline 4 boundary (256 bytes) was 2 bytes ago --- */
	uint16_t                   encap_tunneltype;     /*   258     2 */
	uint32_t                   rmap_table_id;        /*   260     4 */
	uint32_t                   link_bw;              /*   264     4 */
	esi_t                      esi;                  /*   268    10 */

	/* XXX 2 bytes hole, try to pack */

	uint32_t                   srte_color;           /*   280     4 */
	enum nexthop_types_t       nh_type;              /*   284     4 */
	enum blackhole_type        bh_type;              /*   288     4 */
	uint32_t                   otc;                  /*   292     4 */
	_uint64_t                  aigp_metric;          /*   296     8 */

	/* size: 304, cachelines: 5, members: 53 */
	/* sum members: 301, holes: 2, sum holes: 3 */
	/* last cacheline: 48 bytes */
};
```
