### PR TITLE
lib: Do not convert EVPN prefixes into IPv4/IPv6 if not needed

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -2548,7 +2548,6 @@ route_map_result_t route_map_apply_ext(struct route_map *map,
 	struct route_map_index *index = NULL;
 	struct route_map_rule *set = NULL;
 	bool skip_match_clause = false;
-	struct prefix conv;
 
 	if (recursion > RMAP_RECURSION_LIMIT) {
 		if (map)
@@ -2571,31 +2570,14 @@ route_map_result_t route_map_apply_ext(struct route_map *map,
 
 	map->applied++;
 
-	/*
-	 * Handling for matching evpn_routes in the prefix table.
-	 *
-	 * We convert type2/5 prefix to ipv4/6 prefix to do longest
-	 * prefix matching on.
-	 */
 	if (prefix->family == AF_EVPN) {
-		if (evpn_prefix2prefix(prefix, &conv) != 0) {
-			if (unlikely(CHECK_FLAG(rmap_debug,
-						DEBUG_ROUTEMAP_DETAIL)))
-				zlog_debug(
-					"Unable to convert EVPN prefix %pFX into IPv4/IPv6 prefix. Falling back to non-optimized route-map lookup",
-					prefix);
-		} else {
-			if (unlikely(CHECK_FLAG(rmap_debug,
-						DEBUG_ROUTEMAP_DETAIL)))
-				zlog_debug(
-					"Converted EVPN prefix %pFX into %pFX for optimized route-map lookup",
-					prefix, &conv);
-
-			prefix = &conv;
-		}
+		index = map->head;
+	} else {
+		skip_match_clause = true;
+		index = route_map_get_index(map, prefix, match_object,
+					    &match_ret);
 	}
 
-	index = route_map_get_index(map, prefix, match_object, &match_ret);
 	if (index) {
 		index->applied++;
 		if (unlikely(CHECK_FLAG(rmap_debug, DEBUG_ROUTEMAP)))
@@ -2619,7 +2601,6 @@ route_map_result_t route_map_apply_ext(struct route_map *map,
 			ret = RMAP_DENYMATCH;
 		goto route_map_apply_end;
 	}
-	skip_match_clause = true;
 
 	for (; index; index = index->next) {
 		if (!skip_match_clause) {


### PR DESCRIPTION
Replacing https://github.com/FRRouting/frr/pull/15414