### PR TITLE
lib: fix processing of notifications on mgmt fe client

### DIFF
--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -117,7 +117,8 @@ struct mgmt_fe_client_cbs {
 	/* Called with asynchronous notifications from backends */
 	int (*async_notification)(struct mgmt_fe_client *client,
 				  uintptr_t user_data, uint64_t client_id,
-				  uintptr_t session_ctx, const char *result);
+				  uint64_t session_id, uintptr_t session_ctx,
+				  const char *result);
 
 	/* Called when new native error is returned */
 	int (*error_notify)(struct mgmt_fe_client *client, uintptr_t user_data,


### PR DESCRIPTION
Notifications are sent by mgmtd for each session of a client, so they should be processed once per each session.

Also, add session_id parameter to an async_notification callback as all other callbacks have this parameter.