### PR TITLE
zebra: fix route deletion during zebra shutdown

### DIFF
--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -202,6 +202,12 @@ extern void vrf_init(int (*create)(struct vrf *vrf),
 		     int (*destroy)(struct vrf *vrf));
 
 /*
+ * Iterate over custom VRFs and round up by processing the default VRF.
+ */
+typedef void (*vrf_iter_func)(struct vrf *vrf);
+extern void vrf_iterate(vrf_iter_func fnc);
+
+/*
  * Call vrf_terminate when the protocol is being shutdown
  */
 extern void vrf_terminate(void);

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -205,6 +205,12 @@ static void sigint(void)
 	list_delete(&zrouter.client_list);
 	list_delete(&zrouter.stale_client_list);
 
+	/*
+	 * Besides other clean-ups zebra's vrf_disable() also enqueues installed
+	 * routes for removal from the kernel, unless ZEBRA_VRF_RETAIN is set.
+	 */
+	vrf_iterate(vrf_disable);
+
 	/* Indicate that all new dplane work has been enqueued. When that
 	 * work is complete, the dataplane will enqueue an event
 	 * with the 'finalize' function.


### PR DESCRIPTION
Restore the order of execution in zebra's main thread:
  vrf_terminate();
  zebra_dplane_finish();
  zebra_dplane_shutdown();
changed in commit 3b0e17067ee1ed09318ddb3314ad341959813d85.

  vrf_terminate() enqueues routes for deletion in dplane thread.
  zebra_dplane_shutdown() effectively forces dplane thread
to immediately cease and join (leaving unprocessed routes), while
  zebra_dplane_finish() has a condition that prevents
zebra_dplane_shutdown() from running until all routes queued for dplane thread have been deleted.

Closes https://github.com/FRRouting/frr/issues/14062
Closes https://github.com/FRRouting/frr/issues/14178