### PR TITLE
lib: fix access/prefix-list entry update

### DIFF
--- a/lib/filter.c
+++ b/lib/filter.c
@@ -410,7 +410,10 @@ void access_list_filter_add(struct access_list *access,
 		filter->prev = access->tail;
 		access->tail = filter;
 	}
+}
 
+void access_list_filter_update(struct access_list *access)
+{
 	/* Run hook function. */
 	if (access->master->add_hook)
 		(*access->master->add_hook)(access);

--- a/lib/filter.h
+++ b/lib/filter.h
@@ -128,6 +128,7 @@ struct filter *filter_new(void);
 void access_list_filter_add(struct access_list *access, struct filter *filter);
 void access_list_filter_delete(struct access_list *access,
 			       struct filter *filter);
+void access_list_filter_update(struct access_list *access);
 int64_t filter_new_seq_get(struct access_list *access);
 
 extern const struct frr_yang_module_info frr_filter_info;


### PR DESCRIPTION
```
lib: fix access-list entry update

When an access-list entry is updated, current NB code calls notification
hooks for each updated field. It means that when multiple fields of an
entry are changed in a single commit, the hooks are run with an interim
state of an access-list instead of a final one. To fix the issue, we
should call the hooks once, after all fields of an entry are updated.
```
```
lib: fix prefix-list entry update

When a prefix-list entry is updated, current NB code calls the
replacement code multiple times, once per each updated field. It means
that when multiple fields of an entry are changed in a single commit,
the replacement is done with an interim state of a prefix-list instead
of a final one. To fix the issue, we should call the replacement code
once, after all fields of an entry are updated.
```