### PR TITLE
ospfd: Solved crash in OSPF TE parsing

### DIFF
--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -2246,6 +2246,10 @@ static int ospf_te_parse_te(struct ls_ted *ted, struct ospf_lsa *lsa)
 	}
 
 	/* Get corresponding Edge from Link State Data Base */
+	if (IPV4_NET0(attr.standard.local.s_addr) && !attr.standard.local_id) {
+		ote_debug("  |- Found no TE Link local address/ID. Abort!");
+		return -1;
+	}
 	edge = get_edge(ted, attr.adv, attr.standard.local);
 	old = edge->attributes;
 


### PR DESCRIPTION
Iggy Frankovic discovered an ospfd crash when perfomring fuzzing of OSPF LSA packets. The crash occurs in ospf_te_parse_te() function when attemping to create corresponding egde from TE Link parameters. If there is no local address, an edge is created but without any attributes. During parsing, the function try to access to this attribute fields which has not been created causing an ospfd crash.

The patch simply check if the te parser has found a valid local address. If not found, we stop the parser which avoid the crash.