### PR TITLE
tools: fix typo in configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2034,7 +2034,7 @@ dnl libyang
 dnl ---------------
 PKG_CHECK_MODULES([LIBYANG], [libyang >= 2.1.128], , [
 AC_MSG_ERROR([m4_normalize([libyang >= 2.1.128 is required, and was not found on your system.
-Pleaes consult doc/developer/building-libyang.rst for instructions on installing or building libyang.])])])
+Please consult doc/developer/building-libyang.rst for instructions on installing or building libyang.])])])
 ac_cflags_save="$CFLAGS"
 CFLAGS="$CFLAGS $LIBYANG_CFLAGS"
 AC_CHECK_MEMBER([struct lyd_node.priv], [], [


### PR DESCRIPTION
Fix a small typo nit in the configure script.