### PR TITLE
bmp: fix vty_out for monitor afi loc-rib

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2766,7 +2766,7 @@ static int bmp_config_write(struct bgp *bgp, struct vty *vty)
 					afi2str_lower(afi), safi2str(safi));
 			if (CHECK_FLAG(bt->afimon[afi][safi], BMP_MON_LOC_RIB))
 				vty_out(vty, "  bmp monitor %s %s loc-rib\n",
-					afi2str(afi), safi2str(safi));
+					afi2str_lower(afi), safi2str(safi));
 		}
 		frr_each (bmp_listeners, &bt->listeners, bl)
 			vty_out(vty, " \n  bmp listener %pSU port %d\n",


### PR DESCRIPTION
"show run" displays BMP monitor AFI in upper case.

> bmp targets bmp1
>  bmp monitor IPv4 unicast loc-rib

Display it in lower case.

> bmp targets bmp1
>  bmp monitor ipv4 unicast loc-rib