### PR TITLE
ospfd: Send update for route with new metric

### DIFF
--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -110,7 +110,8 @@ ospf_external_info_add(struct ospf *ospf, uint8_t type, unsigned short instance,
 		new = rn->info;
 		if ((new->ifindex == ifindex)
 		    && (new->nexthop.s_addr == nexthop.s_addr)
-		    && (new->tag == tag)) {
+		    && (new->tag == tag)
+		    && (new->metric == metric)) {
 			route_unlock_node(rn);
 			return NULL; /* NULL => no LSA to refresh */
 		}


### PR DESCRIPTION
When an AS-external-route is deleted on our system and later added again with a new metric, then the ospfd would first send a LS-update to remove the old route and later another LS-update to add the route with the new metric again.
But when this metric-change happens with no time inbetween the ospfd recognizes this as the same route and does not send any LS-update. With the change made here, the ospfd will interpret this route as a different route, when the metric has changed.