### PR TITLE
fix warning if ripngd disabled

### DIFF
--- a/mgmtd/mgmt_vty.c
+++ b/mgmtd/mgmt_vty.c
@@ -608,13 +608,13 @@ void mgmt_vty_init(void)
 	 * here one by one.
 	 */
 	zebra_cli_init();
-#if HAVE_RIPD
+#ifdef HAVE_RIPD
 	rip_cli_init();
 #endif
-#if HAVE_RIPNGD
+#ifdef HAVE_RIPNGD
 	ripng_cli_init();
 #endif
-#if HAVE_STATICD
+#ifdef HAVE_STATICD
 	static_vty_init();
 #endif
 


### PR DESCRIPTION
`./configure [...] --disable-ripngd` 

could lead to:

```
mgmtd/mgmt_vty.c:614:5: warning: "HAVE_RIPNGD" is not defined, evaluates to 0 [-Wundef]
  614 | #if HAVE_RIPNGD
      |     ^~~~~~~~~~~
```