### PR TITLE
Bgp filter fun

### DIFF
--- a/bgpd/bgp_conditional_adv.c
+++ b/bgpd/bgp_conditional_adv.c
@@ -122,8 +122,9 @@ static void bgp_conditional_adv_routes(struct peer *peer, afi_t afi,
 			if (update_type == UPDATE_TYPE_ADVERTISE &&
 			    subgroup_announce_check(dest, pi, subgrp, dest_p,
 						    &attr, &advmap_attr)) {
-				bgp_adj_out_set_subgroup(dest, subgrp, &attr,
-							 pi);
+				if (!bgp_adj_out_set_subgroup(dest, subgrp,
+							      &attr, pi))
+					bgp_attr_flush(&attr);
 			} else {
 				/* If default originate is enabled for
 				 * the peer, do not send explicit

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6006,10 +6006,10 @@ bool bgp_outbound_policy_exists(struct peer *peer, struct bgp_filter *filter)
 	if (peer->sort == BGP_PEER_IBGP)
 		return true;
 
-	if (peer->sort == BGP_PEER_EBGP
-	    && (ROUTE_MAP_OUT_NAME(filter) || PREFIX_LIST_OUT_NAME(filter)
-		|| FILTER_LIST_OUT_NAME(filter)
-		|| DISTRIBUTE_OUT_NAME(filter)))
+	if (peer->sort == BGP_PEER_EBGP &&
+	    (ROUTE_MAP_OUT_NAME(filter) || PREFIX_LIST_OUT_NAME(filter) ||
+	     FILTER_LIST_OUT_NAME(filter) || DISTRIBUTE_OUT_NAME(filter) ||
+	     UNSUPPRESS_MAP_NAME(filter)))
 		return true;
 	return false;
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2979,7 +2979,7 @@ void subgroup_process_announce_selected(struct update_subgroup *subgrp,
 {
 	const struct prefix *p;
 	struct peer *onlypeer;
-	struct attr attr;
+	struct attr attr = { 0 }, *pattr = &attr;
 	struct bgp *bgp;
 	bool advertise;
 
@@ -3007,26 +3007,30 @@ void subgroup_process_announce_selected(struct update_subgroup *subgrp,
 	advertise = bgp_check_advertise(bgp, dest, safi);
 
 	if (selected) {
-		if (subgroup_announce_check(dest, selected, subgrp, p, &attr,
+		if (subgroup_announce_check(dest, selected, subgrp, p, pattr,
 					    NULL)) {
 			/* Route is selected, if the route is already installed
 			 * in FIB, then it is advertised
 			 */
 			if (advertise) {
 				if (!bgp_check_withdrawal(bgp, dest, safi)) {
-					struct attr *adv_attr =
-						bgp_attr_intern(&attr);
-
-					bgp_adj_out_set_subgroup(dest, subgrp,
-								 adv_attr,
-								 selected);
-				} else
+					if (!bgp_adj_out_set_subgroup(dest,
+								      subgrp,
+								      pattr,
+								      selected))
+						bgp_attr_flush(pattr);
+				} else {
 					bgp_adj_out_unset_subgroup(
 						dest, subgrp, 1, addpath_tx_id);
-			}
-		} else
+					bgp_attr_flush(pattr);
+				}
+			} else
+				bgp_attr_flush(pattr);
+		} else {
 			bgp_adj_out_unset_subgroup(dest, subgrp, 1,
 						   addpath_tx_id);
+			bgp_attr_flush(pattr);
+		}
 	}
 
 	/* If selected is NULL we must withdraw the path using addpath_tx_id */

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -441,7 +441,7 @@ extern struct bgp_adj_out *bgp_adj_out_alloc(struct update_subgroup *subgrp,
 extern void bgp_adj_out_remove_subgroup(struct bgp_dest *dest,
 					struct bgp_adj_out *adj,
 					struct update_subgroup *subgrp);
-extern void bgp_adj_out_set_subgroup(struct bgp_dest *dest,
+extern bool bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 				     struct update_subgroup *subgrp,
 				     struct attr *attr,
 				     struct bgp_path_info *path);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -520,7 +520,7 @@ bgp_advertise_clean_subgroup(struct update_subgroup *subgrp,
 	return next;
 }
 
-void bgp_adj_out_set_subgroup(struct bgp_dest *dest,
+bool bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 			      struct update_subgroup *subgrp, struct attr *attr,
 			      struct bgp_path_info *path)
 {
@@ -540,7 +540,7 @@ void bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 	bgp = SUBGRP_INST(subgrp);
 
 	if (DISABLE_BGP_ANNOUNCE)
-		return;
+		return false;
 
 	/* Look for adjacency information. */
 	adj = adj_lookup(
@@ -556,7 +556,7 @@ void bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 			bgp_addpath_id_for_peer(peer, afi, safi,
 						&path->tx_addpath));
 		if (!adj)
-			return;
+			return false;
 
 		subgrp->pscount++;
 	}
@@ -595,7 +595,7 @@ void bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 		 * will never be able to coalesce the 3rd peer down
 		 */
 		subgrp->version = MAX(subgrp->version, dest->version);
-		return;
+		return false;
 	}
 
 	if (adj->adv)
@@ -643,6 +643,8 @@ void bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 	bgp_adv_fifo_add_tail(&subgrp->sync->update, adv);
 
 	subgrp->version = MAX(subgrp->version, dest->version);
+
+	return true;
 }
 
 /* The only time 'withdraw' will be false is if we are sending
@@ -852,7 +854,7 @@ void subgroup_announce_route(struct update_subgroup *subgrp)
 void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)
 {
 	struct bgp *bgp;
-	struct attr attr;
+	struct attr attr = { 0 };
 	struct attr *new_attr = &attr;
 	struct aspath *aspath;
 	struct prefix p;
@@ -993,18 +995,19 @@ void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)
 		if (dest) {
 			for (pi = bgp_dest_get_bgp_path_info(dest); pi;
 			     pi = pi->next) {
-				if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
-					if (subgroup_announce_check(
-						    dest, pi, subgrp,
-						    bgp_dest_get_prefix(dest),
-						    &attr, NULL)) {
-						struct attr *default_attr =
-							bgp_attr_intern(&attr);
+				if (!CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
+					continue;
 
-						bgp_adj_out_set_subgroup(
-							dest, subgrp,
-							default_attr, pi);
-					}
+				if (subgroup_announce_check(dest, pi, subgrp,
+							    bgp_dest_get_prefix(
+								    dest),
+							    &attr, NULL)) {
+					if (!bgp_adj_out_set_subgroup(dest,
+								      subgrp,
+								      &attr, pi))
+						bgp_attr_flush(&attr);
+				} else
+					bgp_attr_flush(&attr);
 			}
 			bgp_dest_unlock_node(dest);
 		}

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -854,6 +854,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)
 	struct bgp *bgp;
 	struct attr attr;
 	struct attr *new_attr = &attr;
+	struct aspath *aspath;
 	struct prefix p;
 	struct peer *from;
 	struct bgp_dest *dest;
@@ -891,6 +892,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)
 	/* make coverity happy */
 	assert(attr.aspath);
 
+	aspath = attr.aspath;
 	attr.med = 0;
 	attr.flag |= ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC);
 
@@ -1046,7 +1048,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)
 		}
 	}
 
-	aspath_unintern(&attr.aspath);
+	aspath_unintern(&aspath);
 }
 
 /*


### PR DESCRIPTION
see individual commits

a) Allows unsuppress-maps to be part of the filtering system that would allow outgoing data to a peer.
b) Fix memory leak associated with late decision not to send data to peer in bgp