### PR TITLE
mgmtd: add support for native 'edit' operation

### DIFF
--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -329,6 +329,36 @@ int mgmt_fe_send_get_data_req(struct mgmt_fe_client *client,
 	return ret;
 }
 
+int mgmt_fe_send_edit_req(struct mgmt_fe_client *client, uint64_t session_id,
+			  uint64_t req_id, uint8_t datastore,
+			  LYD_FORMAT request_type, uint8_t flags,
+			  uint8_t operation, const char *xpath, const char *data)
+{
+	struct mgmt_msg_edit *msg;
+	int ret;
+
+	msg = mgmt_msg_native_alloc_msg(struct mgmt_msg_edit, 0,
+					MTYPE_MSG_NATIVE_EDIT);
+	msg->refer_id = session_id;
+	msg->req_id = req_id;
+	msg->code = MGMT_MSG_CODE_EDIT;
+	msg->request_type = request_type;
+	msg->flags = flags;
+	msg->datastore = datastore;
+	msg->operation = operation;
+
+	mgmt_msg_native_xpath_encode(msg, xpath);
+	if (data)
+		mgmt_msg_native_append(msg, data, strlen(data) + 1);
+
+	debug_fe_client("Sending EDIT_REQ session-id %" PRIu64
+			" req-id %" PRIu64 " xpath: %s",
+			session_id, req_id, xpath);
+
+	ret = mgmt_msg_native_send_msg(&client->client.conn, msg, false);
+	mgmt_msg_native_free_msg(msg);
+	return ret;
+}
 
 static int mgmt_fe_client_handle_msg(struct mgmt_fe_client *client,
 				     Mgmtd__FeMessage *fe_msg)
@@ -503,7 +533,9 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 	struct mgmt_fe_client_session *session = NULL;
 	struct mgmt_msg_notify_data *notify_msg;
 	struct mgmt_msg_tree_data *tree_msg;
+	struct mgmt_msg_edit_reply *edit_msg;
 	struct mgmt_msg_error *err_msg;
+	const char *xpath = NULL;
 	const char *data = NULL;
 	size_t dlen;
 
@@ -553,6 +585,28 @@ static void fe_client_handle_native_msg(struct mgmt_fe_client *client,
 						     tree_msg->result,
 						     msg_len - sizeof(*tree_msg),
 						     tree_msg->partial_error);
+		break;
+	case MGMT_MSG_CODE_EDIT_REPLY:
+		if (!session->client->cbs.edit_notify)
+			return;
+
+		edit_msg = (typeof(edit_msg))msg;
+		if (msg_len < sizeof(*edit_msg)) {
+			log_err_fe_client("Corrupt edit-reply msg recv");
+			return;
+		}
+
+		xpath = mgmt_msg_native_xpath_decode(edit_msg, msg_len);
+		if (!xpath) {
+			log_err_fe_client("Corrupt edit-reply msg recv");
+			return;
+		}
+
+		session->client->cbs.edit_notify(client, client->user_data,
+						 session->client_id,
+						 msg->refer_id,
+						 session->user_ctx, msg->req_id,
+						 xpath);
 		break;
 	case MGMT_MSG_CODE_NOTIFY:
 		if (!session->client->cbs.async_notification)

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -114,6 +114,12 @@ struct mgmt_fe_client_cbs {
 			       LYD_FORMAT result_type, void *result, size_t len,
 			       int partial_error);
 
+	/* Called when edit result is returned */
+	int (*edit_notify)(struct mgmt_fe_client *client, uintptr_t user_data,
+			   uint64_t client_id, uint64_t session_id,
+			   uintptr_t session_ctx, uint64_t req_id,
+			   const char *xpath);
+
 	/* Called with asynchronous notifications from backends */
 	int (*async_notification)(struct mgmt_fe_client *client,
 				  uintptr_t user_data, uint64_t client_id,
@@ -408,6 +414,45 @@ extern int mgmt_fe_send_get_data_req(struct mgmt_fe_client *client,
 				     uint8_t datastore, LYD_FORMAT result_type,
 				     uint8_t flags, uint8_t defaults,
 				     const char *xpath);
+
+/*
+ * Send EDIT to MGMTD daemon.
+ *
+ * client
+ *    Client object.
+ *
+ * session_id
+ *    Client session ID.
+ *
+ * req_id
+ *    Client request ID.
+ *
+ * datastore
+ *    Datastore for editing.
+ *
+ * request_type
+ *    The LYD_FORMAT of the request.
+ *
+ * flags
+ *    Flags to control the behavior of the request.
+ *
+ * operation
+ *    NB_OP_* operation to perform.
+ *
+ * xpath
+ *    the xpath to edit.
+ *
+ * data
+ *    the data tree.
+ *
+ * Returns:
+ *    0 on success, otherwise msg_conn_send_msg() return values.
+ */
+extern int mgmt_fe_send_edit_req(struct mgmt_fe_client *client,
+				 uint64_t session_id, uint64_t req_id,
+				 uint8_t datastore, LYD_FORMAT request_type,
+				 uint8_t flags, uint8_t operation,
+				 const char *xpath, const char *data);
 
 /*
  * Destroy library and cleanup everything.

--- a/lib/mgmt_msg_native.c
+++ b/lib/mgmt_msg_native.c
@@ -14,6 +14,8 @@ DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_GET_TREE, "native get tree msg");
 DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_TREE_DATA, "native tree data msg");
 DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_GET_DATA, "native get data msg");
 DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_NOTIFY, "native get data msg");
+DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_EDIT, "native edit msg");
+DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_EDIT_REPLY, "native edit reply msg");
 
 int vmgmt_msg_native_send_error(struct msg_conn *conn, uint64_t sess_or_txn_id,
 				uint64_t req_id, bool short_circuit_ok,

--- a/lib/mgmt_msg_native.h
+++ b/lib/mgmt_msg_native.h
@@ -21,6 +21,7 @@ extern "C" {
 #include "memory.h"
 #include "mgmt_msg.h"
 #include "mgmt_defines.h"
+#include "northbound.h"
 
 #include <stdalign.h>
 
@@ -149,6 +150,8 @@ DECLARE_MTYPE(MSG_NATIVE_GET_TREE);
 DECLARE_MTYPE(MSG_NATIVE_TREE_DATA);
 DECLARE_MTYPE(MSG_NATIVE_GET_DATA);
 DECLARE_MTYPE(MSG_NATIVE_NOTIFY);
+DECLARE_MTYPE(MSG_NATIVE_EDIT);
+DECLARE_MTYPE(MSG_NATIVE_EDIT_REPLY);
 
 /*
  * Native message codes
@@ -158,6 +161,8 @@ DECLARE_MTYPE(MSG_NATIVE_NOTIFY);
 #define MGMT_MSG_CODE_TREE_DATA 2
 #define MGMT_MSG_CODE_GET_DATA	3
 #define MGMT_MSG_CODE_NOTIFY	4
+#define MGMT_MSG_CODE_EDIT	 5
+#define MGMT_MSG_CODE_EDIT_REPLY 6
 
 /*
  * Datastores
@@ -316,6 +321,60 @@ struct mgmt_msg_notify_data {
 };
 _Static_assert(sizeof(struct mgmt_msg_notify_data) ==
 		       offsetof(struct mgmt_msg_notify_data, data),
+	       "Size mismatch");
+
+#define EDIT_FLAG_IMPLICIT_LOCK	  0x01
+#define EDIT_FLAG_IMPLICIT_COMMIT 0x02
+
+#define EDIT_OP_CREATE	0
+#define EDIT_OP_DELETE	4
+#define EDIT_OP_MERGE	2
+#define EDIT_OP_REPLACE 5
+#define EDIT_OP_REMOVE	3
+
+_Static_assert(EDIT_OP_CREATE == NB_OP_CREATE_EXCL, "Operation mismatch");
+_Static_assert(EDIT_OP_DELETE == NB_OP_DELETE, "Operation mismatch");
+_Static_assert(EDIT_OP_MERGE == NB_OP_MODIFY, "Operation mismatch");
+_Static_assert(EDIT_OP_REPLACE == NB_OP_REPLACE, "Operation mismatch");
+_Static_assert(EDIT_OP_REMOVE == NB_OP_DESTROY, "Operation mismatch");
+
+/**
+ * struct mgmt_msg_edit - frontend edit request.
+ *
+ * @request_type: ``LYD_FORMAT`` for the @data.
+ * @flags: combination of ``EDIT_FLAG_*`` flags.
+ * @datastore: the datastore to edit.
+ * @operation: one of ``EDIT_OP_*`` operations.
+ * @data: the xpath followed by the tree data for the operation.
+ *        for CREATE, xpath points to the parent node.
+ */
+struct mgmt_msg_edit {
+	struct mgmt_msg_header;
+	uint8_t request_type;
+	uint8_t flags;
+	uint8_t datastore;
+	uint8_t operation;
+	uint8_t resv2[4];
+
+	alignas(8) char data[];
+};
+_Static_assert(sizeof(struct mgmt_msg_edit) ==
+		       offsetof(struct mgmt_msg_edit, data),
+	       "Size mismatch");
+
+/**
+ * struct mgmt_msg_edit_reply - frontend edit reply.
+ *
+ * @data: the xpath of the data node that was created.
+ */
+struct mgmt_msg_edit_reply {
+	struct mgmt_msg_header;
+	uint8_t resv2[8];
+
+	alignas(8) char data[];
+};
+_Static_assert(sizeof(struct mgmt_msg_edit_reply) ==
+		       offsetof(struct mgmt_msg_edit_reply, data),
 	       "Size mismatch");
 
 /*
@@ -504,13 +563,13 @@ extern int vmgmt_msg_native_send_error(struct msg_conn *conn,
  *	The xpath string or NULL if there was an error decoding (i.e., the
  *	message is corrupt).
  */
-#define mgmt_msg_native_xpath_data_decode(msg, msglen, data)                   \
+#define mgmt_msg_native_xpath_data_decode(msg, msglen, __data)                 \
 	({                                                                     \
 		size_t __len = (msglen) - sizeof(*msg);                        \
 		const char *__s = NULL;                                        \
 		if (msg->vsplit && msg->vsplit <= __len &&                     \
 		    msg->data[msg->vsplit - 1] == 0) {                         \
-			(data) = msg->data + msg->vsplit;                      \
+			(__data) = msg->data + msg->vsplit;                    \
 			__s = msg->data;                                       \
 		}                                                              \
 		__s;                                                           \

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -1005,6 +1005,44 @@ extern int nb_candidate_edit(struct nb_config *candidate,
 			     const struct yang_data *data);
 
 /*
+ * Edit a candidate configuration. Value is given as JSON/XML.
+ *
+ * candidate
+ *    Candidate configuration to edit.
+ *
+ * operation
+ *    Operation to apply.
+ *
+ * format
+ *    LYD_FORMAT of the value.
+ *
+ * xpath
+ *    XPath of the configuration node being edited.
+ *    For create, it must be the parent.
+ *
+ * data
+ *    New data tree for the node.
+ *
+ * xpath_created
+ *    XPath of the created node if operation is "create".
+ *
+ * errmsg
+ *    Buffer to store human-readable error message in case of error.
+ *
+ * errmsg_len
+ *    Size of errmsg.
+ *
+ * Returns:
+ *    - NB_OK on success.
+ *    - NB_ERR for other errors.
+ */
+extern int nb_candidate_edit_tree(struct nb_config *candidate,
+				  enum nb_operation operation,
+				  LYD_FORMAT format, const char *xpath,
+				  const char *data, char *xpath_created,
+				  char *errmsg, size_t errmsg_len);
+
+/*
  * Create diff for configuration.
  *
  * dnode

--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -342,38 +342,6 @@ static void nb_op_resume_data_tree(struct nb_op_yield_state *ys)
 /* ======================= */
 
 /**
- * __xpath_pop_node() - remove the last node from xpath string
- * @xpath: an xpath string
- *
- * Return: NB_OK or NB_ERR_NOT_FOUND if nothing left to pop.
- */
-static int __xpath_pop_node(char *xpath)
-{
-	int len = strlen(xpath);
-	bool abs = xpath[0] == '/';
-	char *slash;
-
-	/* "//" or "/" => NULL */
-	if (abs && (len == 1 || (len == 2 && xpath[1] == '/')))
-		return NB_ERR_NOT_FOUND;
-
-	slash = (char *)frrstr_back_to_char(xpath, '/');
-	/* "/foo/bar/" or "/foo/bar//" => "/foo " */
-	if (slash && slash == &xpath[len - 1]) {
-		xpath[--len] = 0;
-		slash = (char *)frrstr_back_to_char(xpath, '/');
-		if (slash && slash == &xpath[len - 1]) {
-			xpath[--len] = 0;
-			slash = (char *)frrstr_back_to_char(xpath, '/');
-		}
-	}
-	if (!slash)
-		return NB_ERR_NOT_FOUND;
-	*slash = 0;
-	return NB_OK;
-}
-
-/**
  * nb_op_xpath_to_trunk() - generate a lyd_node tree (trunk) using an xpath.
  * @xpath_in: xpath query string to build trunk from.
  * @dnode: resulting tree (trunk)
@@ -398,7 +366,7 @@ static enum nb_error nb_op_xpath_to_trunk(const char *xpath_in,
 		if (err == LY_SUCCESS)
 			break;
 
-		ret = __xpath_pop_node(xpath);
+		ret = yang_xpath_pop_node(xpath);
 		if (ret != NB_OK)
 			break;
 	}

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -419,6 +419,10 @@ extern int vty_mgmt_send_get_req(struct vty *vty, bool is_config,
 extern int vty_mgmt_send_get_data_req(struct vty *vty, uint8_t datastore,
 				      LYD_FORMAT result_type, uint8_t flags,
 				      uint8_t defaults, const char *xpath);
+extern int vty_mgmt_send_edit_req(struct vty *vty, uint8_t datastore,
+				  LYD_FORMAT request_type, uint8_t flags,
+				  uint8_t operation, const char *xpath,
+				  const char *data);
 extern int vty_mgmt_send_lockds_req(struct vty *vty, Mgmtd__DatastoreId ds_id,
 				    bool lock, bool scok);
 extern void vty_mgmt_resume_response(struct vty *vty, int ret);

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -771,6 +771,14 @@ extern int yang_get_key_preds(char *s, const struct lysc_node *snode,
 extern int yang_get_node_keys(struct lyd_node *node, struct yang_list_keys *keys);
 
 /**
+ * yang_xpath_pop_node() - remove the last node from xpath string
+ * @xpath: an xpath string
+ *
+ * Return: NB_OK or NB_ERR_NOT_FOUND if nothing left to pop.
+ */
+extern int yang_xpath_pop_node(char *xpath);
+
+/**
  * yang_resolve_snodes() - Resolve an XPath to matching schema nodes.
  * @ly_ctx: libyang context to operate on.
  * @xpath: the path or XPath to resolve.
@@ -800,6 +808,11 @@ extern LY_ERR yang_lyd_new_list(struct lyd_node_inner *parent,
 				const struct yang_list_keys *keys,
 				struct lyd_node **nodes);
 extern LY_ERR yang_lyd_trim_xpath(struct lyd_node **rootp, const char *xpath);
+extern LY_ERR yang_lyd_parse_data(const struct ly_ctx *ctx,
+				  struct lyd_node *parent, struct ly_in *in,
+				  LYD_FORMAT format, uint32_t parse_options,
+				  uint32_t validate_options,
+				  struct lyd_node **tree);
 
 #ifdef __cplusplus
 }

--- a/mgmtd/mgmt_fe_adapter.h
+++ b/mgmtd/mgmt_fe_adapter.h
@@ -163,6 +163,26 @@ mgmt_fe_adapter_send_tree_data(uint64_t session_id, uint64_t txn_id,
 			       int partial_error, bool short_circuit_ok);
 
 /**
+ * Send edit reply back to client. If error is not 0, a native error is sent.
+ *
+ * This also cleans up and frees the transaction.
+ *
+ * Args:
+ *     session_id: the session.
+ *     txn_id: the txn_id this data pertains to
+ *     req_id: the req id for the edit message
+ *     unlock: implicit-lock flag was set in the request
+ *     commit: implicit-commit flag was set in the request
+ *     xpath: the xpath of the data node that was created
+ *     error: the error code, zero for successful request
+ *     errstr: the error string, if error is non-zero
+ */
+extern int mgmt_fe_adapter_send_edit_reply(uint64_t session_id, uint64_t txn_id,
+					   uint64_t req_id, bool unlock,
+					   bool commit, const char *xpath,
+					   int16_t error, const char *errstr);
+
+/**
  * Send an error back to the FE client using native messaging.
  *
  * This also cleans up and frees the transaction.

--- a/mgmtd/mgmt_txn.h
+++ b/mgmtd/mgmt_txn.h
@@ -43,6 +43,7 @@
 PREDECL_LIST(mgmt_txns);
 
 struct mgmt_master;
+struct mgmt_edit_req;
 
 enum mgmt_txn_type {
 	MGMTD_TXN_TYPE_NONE = 0,
@@ -171,16 +172,17 @@ extern int mgmt_txn_send_set_config_req(uint64_t txn_id, uint64_t req_id,
  * implicit
  *    TRUE if the commit is implicit, FALSE otherwise.
  *
+ * edit
+ *    Additional info when triggered from native edit request.
+ *
  * Returns:
  *    0 on success, -1 on failures.
  */
-extern int mgmt_txn_send_commit_config_req(uint64_t txn_id, uint64_t req_id,
-					   Mgmtd__DatastoreId src_ds_id,
-					   struct mgmt_ds_ctx *dst_ds_ctx,
-					   Mgmtd__DatastoreId dst_ds_id,
-					   struct mgmt_ds_ctx *src_ds_ctx,
-					   bool validate_only, bool abort,
-					   bool implicit);
+extern int mgmt_txn_send_commit_config_req(
+	uint64_t txn_id, uint64_t req_id, Mgmtd__DatastoreId src_ds_id,
+	struct mgmt_ds_ctx *dst_ds_ctx, Mgmtd__DatastoreId dst_ds_id,
+	struct mgmt_ds_ctx *src_ds_ctx, bool validate_only, bool abort,
+	bool implicit, struct mgmt_edit_req *edit);
 
 /*
  * Send get-{cfg,data} request to be processed later in transaction.
@@ -218,6 +220,31 @@ extern int mgmt_txn_send_get_tree_oper(uint64_t txn_id, uint64_t req_id,
 				       LYD_FORMAT result_type, uint8_t flags,
 				       uint32_t wd_options, bool simple_xpath,
 				       const char *xpath);
+
+/**
+ * Send edit request.
+ *
+ * Args:
+ *	txn_id: Transaction identifier.
+ *	req_id: FE client request identifier.
+ *	ds_id: Datastore ID.
+ *	ds_ctx: Datastore context.
+ *	commit_ds_id: Commit datastore ID.
+ *	commit_ds_ctx: Commit datastore context.
+ *	unlock: Unlock datastores after the edit.
+ *	commit: Commit the candidate datastore after the edit.
+ *	request_type: LYD_FORMAT request type.
+ *	flags: option flags for the request.
+ *	operation: The operation to perform.
+ *	xpath: The xpath of data node to edit.
+ *	data: The data tree.
+ */
+extern int
+mgmt_txn_send_edit(uint64_t txn_id, uint64_t req_id, Mgmtd__DatastoreId ds_id,
+		   struct mgmt_ds_ctx *ds_ctx, Mgmtd__DatastoreId commit_ds_id,
+		   struct mgmt_ds_ctx *commit_ds_ctx, bool unlock, bool commit,
+		   LYD_FORMAT request_type, uint8_t flags, uint8_t operation,
+		   const char *xpath, const char *data);
 
 /*
  * Notifiy backend adapter on connection.


### PR DESCRIPTION
This operation basically implements support for RESTCONF operations. It receives an xpath and a data tree in JSON/XML format, instead of a list of (xpath, value) tuples as required by the current protobuf interface.