### PR TITLE
lib: fix __darr_in_vsprintf

### DIFF
--- a/lib/darr.c
+++ b/lib/darr.c
@@ -58,6 +58,7 @@ char *__darr_in_vsprintf(char **sp, bool concat, const char *fmt, va_list ap)
 	size_t inlen = concat ? darr_strlen(*sp) : 0;
 	size_t capcount = strlen(fmt) + MIN(inlen + 64, 128);
 	ssize_t len;
+	va_list ap_copy;
 
 	darr_ensure_cap(*sp, capcount);
 
@@ -68,7 +69,9 @@ char *__darr_in_vsprintf(char **sp, bool concat, const char *fmt, va_list ap)
 	if (darr_len(*sp) == 0)
 		*darr_append(*sp) = 0;
 again:
-	len = vsnprintf(darr_last(*sp), darr_avail(*sp), fmt, ap);
+	va_copy(ap_copy, ap);
+	len = vsnprintf(darr_last(*sp), darr_avail(*sp), fmt, ap_copy);
+	va_end(ap_copy);
 	if (len < 0)
 		darr_in_strcat(*sp, fmt);
 	else if ((size_t)len < darr_avail(*sp))

--- a/lib/darr.c
+++ b/lib/darr.c
@@ -70,11 +70,11 @@ char *__darr_in_vsprintf(char **sp, bool concat, const char *fmt, va_list ap)
 		*darr_append(*sp) = 0;
 again:
 	va_copy(ap_copy, ap);
-	len = vsnprintf(darr_last(*sp), darr_avail(*sp), fmt, ap_copy);
+	len = vsnprintf(darr_last(*sp), darr_avail(*sp) + 1, fmt, ap_copy);
 	va_end(ap_copy);
 	if (len < 0)
 		darr_in_strcat(*sp, fmt);
-	else if ((size_t)len < darr_avail(*sp))
+	else if ((size_t)len <= darr_avail(*sp))
 		_darr_len(*sp) += len;
 	else {
 		darr_ensure_cap(*sp, darr_len(*sp) + (size_t)len);


### PR DESCRIPTION
If the initial darr capacity is not enough for the output, the `ap` is reused multiple times, which is wrong, because it may be altered by `vsnprintf`. Make a copy of `ap` each time instead of reusing.