### PR TITLE
tools: Add option to frr-reload to specify alternate logfile

### DIFF
--- a/doc/user/frr-reload.rst
+++ b/doc/user/frr-reload.rst
@@ -25,6 +25,8 @@ There are several options that control the behavior of ``frr-reload``:
 * ``--stdout``: print output to stdout
 * ``--bindir BINDIR``: path to the vtysh executable
 * ``--confdir CONFDIR``: path to the existing daemon config files
+* ``--logfile FILENAME``: file (with path) to logfile for the reload operation.
+  Default is ``/var/log/frr/frr-reload.log``
 * ``--rundir RUNDIR``: path to a folder to be used to write the temporary files
   needed by the script to do its job. The script should have write access to it
 * ``--daemon DAEMON``: by default ``frr-reload.py`` assumes that we are using

--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -2113,12 +2113,17 @@ if __name__ == "__main__":
         help="Use logfmt as log format",
         default=False,
     )
+    parser.add_argument(
+        "--logfile",
+        help="logfile for frr-reload",
+        default="/var/log/frr/frr-reload.log",
+    )
 
     args = parser.parse_args()
 
     # Logging
     # For --test log to stdout
-    # For --reload log to /var/log/frr/frr-reload.log
+    # For --reload log to --logfile (default: "/var/log/frr/frr-reload.log")
     # If --logfmt, use the logfmt format
     formatter = logging.Formatter("%(asctime)s %(levelname)5s: %(message)s")
     handler = logging.StreamHandler()
@@ -2133,9 +2138,9 @@ if __name__ == "__main__":
             logging.WARNING, "\033[91m%s\033[0m" % logging.getLevelName(logging.WARNING)
         )
     if args.reload:
-        if not os.path.isdir("/var/log/frr/"):
-            os.makedirs("/var/log/frr/", mode=0o0755)
-        handler = logging.FileHandler("/var/log/frr/frr-reload.log")
+        if not os.path.isdir(os.path.dirname(args.logfile)):
+            os.makedirs(os.path.dirname(args.logfile), mode=0o0755)
+        handler = logging.FileHandler(args.logfile)
     if args.stdout:
         handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)


### PR DESCRIPTION
Adding option --logfile to specify a different logfile instead of the default /var/log/frr/frr-reload.log

This solves the issue with multiple FRR instances running in different network namespaces to use different
logfiles

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>