### PR TITLE
zebra: fnc->obuf could be accessed without a lock

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1394,8 +1394,14 @@ static void fpm_process_queue(struct event *t)
 	uint64_t processed_contexts = 0;
 
 	while (true) {
+		size_t writeable_amount;
+
+		frr_with_mutex (&fnc->obuf_mutex) {
+			writeable_amount = STREAM_WRITEABLE(fnc->obuf);
+		}
+
 		/* No space available yet. */
-		if (STREAM_WRITEABLE(fnc->obuf) < NL_PKT_BUF_SIZE) {
+		if (writeable_amount < NL_PKT_BUF_SIZE) {
 			no_bufs = true;
 			break;
 		}


### PR DESCRIPTION
Found by coverity.  Let's just lock the writeable
amount to see if it is possible.  It's ok because
we want to know if we have room *now*.  If another pthread runs it will only remove data from fnc->obuf and make more room.  So this is ok.