### PR TITLE
bgpd: pi->attr is deref'ed in all paths leading up to test

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -1057,7 +1057,7 @@ static int make_prefix(int afi, struct bgp_path_info *pi, struct prefix *p)
 		break;
 	case AFI_IP6:
 		p->family = AF_INET6;
-		if (pi->attr && pi->attr->srv6_l3vpn) {
+		if (pi->attr->srv6_l3vpn) {
 			IPV6_ADDR_COPY(&(p->u.prefix6),
 				       &(pi->attr->srv6_l3vpn->sid));
 			p->prefixlen = IPV6_MAX_BITLEN;


### PR DESCRIPTION
In make_prefix, the code checks to see if the pi->attr is non-NULL.  Since (A) we cannot have a path_info without an attribute and (B) all paths leading up to the test in make_prefix already have pi->attr deref'ed and the code is not crashing we know this is safe to remove.