### PR TITLE
lib: fix apply_finish callback in northbound

### DIFF
--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -1873,7 +1873,7 @@ static void nb_transaction_apply_finish(struct nb_transaction *transaction,
 
 			dnode = lyd_parent(dnode);
 			if (!dnode)
-				break;
+				continue;
 
 			/*
 			 * The dnode from 'delete' callbacks point to elements


### PR DESCRIPTION
When a node is top-level, we shouldn't stop the whole processing, we should just skip this single node.