### PR TITLE
vty: change output of errors from mgmtd

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -3570,8 +3570,9 @@ static void vty_mgmt_set_config_result_notified(
 		zlog_err("SET_CONFIG request for client 0x%" PRIx64
 			 " failed, Error: '%s'",
 			 client_id, errmsg_if_any ? errmsg_if_any : "Unknown");
-		vty_out(vty, "ERROR: SET_CONFIG request failed, Error: %s\n",
-			errmsg_if_any ? errmsg_if_any : "Unknown");
+		vty_out(vty, "%% Configuration failed.\n\n");
+		if (errmsg_if_any)
+			vty_out(vty, "%s\n", errmsg_if_any);
 	} else {
 		debug_fe_client("SET_CONFIG request for client 0x%" PRIx64
 				" req-id %" PRIu64 " was successfull",
@@ -3602,8 +3603,9 @@ static void vty_mgmt_commit_config_result_notified(
 		zlog_err("COMMIT_CONFIG request for client 0x%" PRIx64
 			 " failed, Error: '%s'",
 			 client_id, errmsg_if_any ? errmsg_if_any : "Unknown");
-		vty_out(vty, "ERROR: COMMIT_CONFIG request failed, Error: %s\n",
-			errmsg_if_any ? errmsg_if_any : "Unknown");
+		vty_out(vty, "%% Configuration failed.\n\n");
+		if (errmsg_if_any)
+			vty_out(vty, "%s\n", errmsg_if_any);
 	} else {
 		debug_fe_client("COMMIT_CONFIG request for client 0x%" PRIx64
 				" req-id %" PRIu64 " was successfull",


### PR DESCRIPTION
Make errors look the same way as in regular non-mgmtd vty. We don't need to show information about some internal request names.

Before:
```
ERROR: SET_CONFIG request failed, Error: YANG error(s):
 Path: Data location "/frr-affinity-map:lib/affinity-maps/affinity-map[name='a']".
 Error: Unique data leaf(s) "value" not satisfied in "/frr-affinity-map:lib/affinity-maps/affinity-map[name='b']" and "/frr-affinity-map:lib/affinity-maps/affinity-map[name='a']".
```

After:
```
% Configuration failed.

YANG error(s):
 Path: Data location "/frr-affinity-map:lib/affinity-maps/affinity-map[name='b']".
 Error: Unique data leaf(s) "value" not satisfied in "/frr-affinity-map:lib/affinity-maps/affinity-map[name='a']" and "/frr-affinity-map:lib/affinity-maps/affinity-map[name='b']".
```