### PR TITLE
tests: test invokes a script which does not exist

### DIFF
--- a/tests/topotests/bgp_peer_type_multipath_relax/test_bgp_peer-type_multipath-relax.py
+++ b/tests/topotests/bgp_peer_type_multipath_relax/test_bgp_peer-type_multipath-relax.py
@@ -103,7 +103,6 @@ def setup_module(mod):
 
     # For all registered routers, load the zebra configuration file
     for rname, router in tgen.routers().items():
-        router.run("/bin/bash {}/setup_vrfs".format(CWD))
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )


### PR DESCRIPTION
Apparently test_bgp_peer_type_multipath_relax.py does no really need to run a `setup_vrfs` script.  Looking at the other configuration for this test there are no vrf's in the frr configuration.  So let's remove it