### PR TITLE
pimd: Cleanup inclusion of headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1581,6 +1581,21 @@ FRR_INCLUDES
 #endif
 ])dnl
 
+AC_CHECK_HEADERS([netinet6/ip6_mroute.h], [], [],[
+	#include <sys/socket.h>
+	#include <sys/param.h>
+	#include <sys/types.h>
+	#include <netinet/in.h>
+	#include <net/route.h>
+])
+
+m4_define([FRR_INCLUDES],
+FRR_INCLUDES
+[#ifdef HAVE_NETINET_IP6_MROUTE_H
+# include <netinet6/ip6_mroute.h>
+#endif
+])dnl
+
 AC_MSG_CHECKING([for RFC3678 protocol-independed API])
 AC_COMPILE_IFELSE(
 [ AC_LANG_PROGRAM([[

--- a/pimd/pim_mroute.h
+++ b/pimd/pim_mroute.h
@@ -25,8 +25,19 @@
 #include <netinet/in.h>
 #if defined(HAVE_LINUX_MROUTE_H)
 #include <linux/mroute.h>
-#else
-#include "linux/mroute.h"
+#endif
+
+#if defined(HAVE_NETINET_IP_MROUTE_H)
+#include <netinet/ip_mroute.h>
+/*
+ * MRT_TABLE of 155 is needed because it is not defined
+ * on FreeBSD.  MRT_TABLE is for vrf's.  There is no
+ * equivalent on BSD at this point in time.  Let's
+ * just get it compiling
+ */
+#ifndef MRT_TABLE
+#define MRT_TABLE 155
+#endif
 #endif
 
 typedef struct vifctl pim_vifctl;
@@ -70,8 +81,17 @@ typedef struct sioc_sg_req pim_sioc_sg_req;
 
 #if defined(HAVE_LINUX_MROUTE6_H)
 #include <linux/mroute6.h>
-#else
-#include "linux/mroute6.h"
+#endif
+#if defined(HAVE_NETINET_IP6_MROUTE_H)
+#include <sys/param.h>
+#include <netinet6/ip6_mroute.h>
+
+/*
+ * See the v4 discussion above
+ */
+#ifndef MRT_TABLE
+#define MRT_TABLE 155
+#endif
 #endif
 
 #ifndef MRT_INIT


### PR DESCRIPTION
FRR needs to properly include the FreeBSD headers for compilation on FreeBSD.  I have setup v6 as well
but I have not even tested it.  Since I know
that the form is the same I think this is ok
at the moment.  This is a step forward.

Because of this change *clearly* no-one is even
using pim on FreeBSD.  <look at the MRT_XXX values to prove to yourself>.  In any event this is a step in the direction of getting that working again.