### PR TITLE
bgpd: Fix `no` form for `neighbor X capability software-version`

### DIFF
--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -2039,7 +2039,6 @@ uint16_t bgp_open_capability(struct stream *s, struct peer *peer,
 	 * or disable its use, and that switch MUST be off by default.
 	 */
 	if (peergroup_flag_check(peer, PEER_FLAG_CAPABILITY_SOFT_VERSION) ||
-	    CHECK_FLAG(peer->bgp->flags, BGP_FLAG_SOFT_VERSION_CAPABILITY) ||
 	    peer->sort == BGP_PEER_IBGP || peer->sub_sort == BGP_PEER_EBGP_OAD) {
 		SET_FLAG(peer->cap, PEER_CAP_SOFT_VERSION_ADV);
 		stream_putc(s, BGP_OPEN_OPT_CAP);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -18416,9 +18416,19 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 	}
 
 	/* capability software-version */
-	if (peergroup_flag_check(peer, PEER_FLAG_CAPABILITY_SOFT_VERSION))
-		vty_out(vty, " neighbor %s capability software-version\n",
-			addr);
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_SOFT_VERSION_CAPABILITY)) {
+		if (!peergroup_flag_check(peer,
+					  PEER_FLAG_CAPABILITY_SOFT_VERSION))
+			vty_out(vty,
+				" no neighbor %s capability software-version\n",
+				addr);
+	} else {
+		if (peergroup_flag_check(peer,
+					 PEER_FLAG_CAPABILITY_SOFT_VERSION))
+			vty_out(vty,
+				" neighbor %s capability software-version\n",
+				addr);
+	}
 
 	/* dont-capability-negotiation */
 	if (peergroup_flag_check(peer, PEER_FLAG_DONT_CAPABILITY))

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1541,6 +1541,9 @@ struct peer *peer_new(struct bgp *bgp)
 	if (CHECK_FLAG(bgp->flags, BGP_FLAG_ENFORCE_FIRST_AS))
 		SET_FLAG(peer->flags, PEER_FLAG_ENFORCE_FIRST_AS);
 
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_SOFT_VERSION_CAPABILITY))
+		SET_FLAG(peer->flags, PEER_FLAG_CAPABILITY_SOFT_VERSION);
+
 	SET_FLAG(peer->flags_invert, PEER_FLAG_CAPABILITY_FQDN);
 	SET_FLAG(peer->flags, PEER_FLAG_CAPABILITY_FQDN);
 


### PR DESCRIPTION
If `bgp default software-version-capability` is enabled, allow unsetting this for a single neighbor also.