### PR TITLE
bgpd: Unset advertised capabilities if capability is disabled

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1292,10 +1292,6 @@ void bgp_capability_send(struct peer *peer, afi_t afi, safi_t safi,
 				   iana_safi2str(pkt_safi));
 		break;
 	case CAPABILITY_CODE_RESTART:
-		if (!CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART) &&
-		    !CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART_HELPER))
-			return;
-
 		stream_putc(s, action);
 		stream_putc(s, CAPABILITY_CODE_RESTART);
 		cap_len = stream_get_endp(s);
@@ -1348,9 +1344,6 @@ void bgp_capability_send(struct peer *peer, afi_t afi, safi_t safi,
 			  action == CAPABILITY_ACTION_SET);
 		break;
 	case CAPABILITY_CODE_LLGR:
-		if (!CHECK_FLAG(peer->cap, PEER_CAP_RESTART_ADV))
-			return;
-
 		stream_putc(s, action);
 		stream_putc(s, CAPABILITY_CODE_LLGR);
 		cap_len = stream_get_endp(s);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3260,6 +3260,8 @@ DEFUN (bgp_graceful_restart_disable,
 	GR_DISABLE)
 {
 	int ret = BGP_GR_FAILURE;
+	struct listnode *node, *nnode;
+	struct peer *peer;
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 		zlog_debug(
@@ -3277,6 +3279,15 @@ DEFUN (bgp_graceful_restart_disable,
 			"[BGP_GR] bgp_graceful_restart_disable_cmd : END ");
 	vty_out(vty,
 		"Graceful restart configuration changed, reset all peers to take effect\n");
+
+	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
+		bgp_capability_send(peer, AFI_IP, SAFI_UNICAST,
+				    CAPABILITY_CODE_RESTART,
+				    CAPABILITY_ACTION_UNSET);
+		bgp_capability_send(peer, AFI_IP, SAFI_UNICAST,
+				    CAPABILITY_CODE_LLGR,
+				    CAPABILITY_ACTION_UNSET);
+	}
 
 	return bgp_vty_return(vty, ret);
 }

--- a/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_addpath.py
+++ b/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_addpath.py
@@ -135,7 +135,7 @@ def test_bgp_dynamic_capability_addpath():
     step("Disable Addpath capability RX and check if it's exchanged dynamically")
 
     # Clear message stats to check if we receive a notification or not after we
-    # change the settings fo LLGR.
+    # disable addpath-rx.
     r1.vtysh_cmd("clear bgp 192.168.1.2 message-stats")
     r2.vtysh_cmd(
         """
@@ -173,6 +173,46 @@ def test_bgp_dynamic_capability_addpath():
     )
     _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assert result is None, "Session was reset after disabling Addpath RX flags"
+
+    # Clear message stats to check if we receive a notification or not after we
+    # disable Addpath capability.
+    r1.vtysh_cmd("clear bgp 192.168.1.2 message-stats")
+    r1.vtysh_cmd(
+        """
+    configure terminal
+    router bgp
+     address-family ipv4 unicast
+      no neighbor 192.168.1.2 addpath-tx-all-paths
+    """
+    )
+
+    def _bgp_check_if_addpath_capability_is_absent():
+        output = json.loads(r1.vtysh_cmd("show bgp neighbor json"))
+        expected = {
+            "192.168.1.2": {
+                "bgpState": "Established",
+                "neighborCapabilities": {
+                    "dynamic": "advertisedAndReceived",
+                    "addPath": {
+                        "ipv4Unicast": {
+                            "txAdvertisedAndReceived": None,
+                            "txAdvertised": None,
+                            "rxAdvertised": True,
+                        }
+                    },
+                },
+                "messageStats": {
+                    "notificationsRecv": 0,
+                },
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(
+        _bgp_check_if_addpath_capability_is_absent,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "Failed to disable Addpath capability"
 
 
 if __name__ == "__main__":

--- a/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_graceful_restart.py
+++ b/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_graceful_restart.py
@@ -159,7 +159,7 @@ def test_bgp_dynamic_capability_graceful_restart():
     )
 
     # Clear message stats to check if we receive a notification or not after we
-    # change the settings fo LLGR.
+    # disable graceful-restart notification support.
     r1.vtysh_cmd("clear bgp 192.168.1.2 message-stats")
     r2.vtysh_cmd(
         """
@@ -206,6 +206,40 @@ def test_bgp_dynamic_capability_graceful_restart():
     assert (
         result is None
     ), "Session was reset after changing Graceful-Restart notification support"
+
+    # Clear message stats to check if we receive a notification or not after we
+    # disable GR.
+    r1.vtysh_cmd("clear bgp 192.168.1.2 message-stats")
+    r1.vtysh_cmd(
+        """
+    configure terminal
+    router bgp
+     bgp graceful-restart-disable
+    """
+    )
+
+    def _bgp_check_if_gr_llgr_capability_is_absent():
+        output = json.loads(r1.vtysh_cmd("show bgp neighbor json"))
+        expected = {
+            "192.168.1.2": {
+                "bgpState": "Established",
+                "neighborCapabilities": {
+                    "dynamic": "advertisedAndReceived",
+                    "gracefulRestartCapability": "received",
+                    "longLivedGracefulRestart": "received",
+                },
+                "messageStats": {
+                    "notificationsRecv": 0,
+                },
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(
+        _bgp_check_if_gr_llgr_capability_is_absent,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "Failed to disable GR/LLGR capabilities"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When using dynamic capabilities, do not forget to unset advertised capabilities.

Otherwise, it's kept as advertised.