### PR TITLE
lib/printf: pick up ISO C23 / N2680 from FreeBSD

### DIFF
--- a/doc/developer/logging.rst
+++ b/doc/developer/logging.rst
@@ -77,7 +77,14 @@ are available:
 
 .. note::
 
-   ``printfrr()`` does not support the ``%n`` format.
+   ``printfrr()`` does not support the ``%n`` format.  It does support ISO C23
+   ``%b``, ``%w99d`` and ``%wf99d`` additions, but the latter two are not
+   supported by the ``frr-format`` plugin yet, and all 3 aren't supported by
+   the older compilers still in use on some supported platforms.
+
+   ``%b`` can be used with ``FMT_NSTD``, but ``%w99d`` and ``%wf99d`` require
+   work in the ``frr-format`` plugin before they are really usable.
+
 
 AS-Safety
 ^^^^^^^^^
@@ -557,8 +564,9 @@ Integer formats
    cause compiler warnings when used without the plugin.  Use with
    :c:macro:`FMT_NSTD` if necessary.
 
-   It is possible ISO C23 may introduce another format for these, possibly
-   ``%w64d`` discussed in `JTC 1/SC 22/WG 14/N2680 <http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2680.pdf>`_.
+   As anticipated, ISO C23 has introduced new modifiers for this, specifically
+   ``%w64d`` (= ``%Ld``) and ``%w64u`` (= ``%Lu``).  Unfortunately, these new
+   modifiers are not supported by ``frr-format`` yet.
 
 .. frrfmt:: %Lu (uint64_t)
 

--- a/lib/printf/README
+++ b/lib/printf/README
@@ -1,6 +1,7 @@
 This is the printf implementation from FreeBSD.  The history of this code is:
 - imported on 2019-05-12, from SVN revision 347514
 - resynced on 2023-09-03, to pick up `%b` implementation
+- resynced on 2024-03-10, to pick up `%w[f](8|16|32|64)d` implementation
 
 Please don't reindent or otherwise mangle the files to make importing fixes
 easy (not that there are significant changes likely to happen...)

--- a/lib/printf/printflocal.h
+++ b/lib/printf/printflocal.h
@@ -52,6 +52,7 @@
 #define	PTRDIFFT	0x800		/* ptrdiff_t */
 #define	INTMAXT		0x1000		/* intmax_t */
 #define	CHARINT		0x2000		/* print char using int format */
+#define	FASTINT		0x4000		/* int_fastN_t */
 
 /*
  * Macros for converting digits to letters and vice versa

--- a/lib/printf/vfprintf.c
+++ b/lib/printf/vfprintf.c
@@ -416,6 +416,49 @@ reswitch:	switch (ch) {
 		case 't':
 			flags |= PTRDIFFT;
 			goto rflag;
+		case 'w':
+			/*
+			 * Fixed-width integer types.  On all platforms we
+			 * support, int8_t is equivalent to char, int16_t
+			 * is equivalent to short, int32_t is equivalent
+			 * to int, int64_t is equivalent to long long int.
+			 * Furthermore, int_fast8_t, int_fast16_t and
+			 * int_fast32_t are equivalent to int, and
+			 * int_fast64_t is equivalent to long long int.
+			 */
+			flags &= ~(CHARINT|SHORTINT|LONGINT|LLONGINT|INTMAXT);
+			if (fmt[0] == 'f') {
+				flags |= FASTINT;
+				fmt++;
+			} else {
+				flags &= ~FASTINT;
+			}
+			if (fmt[0] == '8') {
+				if (!(flags & FASTINT))
+					flags |= CHARINT;
+				else
+					(void) 0;	/* no flag set = 32 */
+				fmt += 1;
+			} else if (fmt[0] == '1' && fmt[1] == '6') {
+				if (!(flags & FASTINT))
+					flags |= SHORTINT;
+				else
+					(void) 0;	/* no flag set = 32 */
+				fmt += 2;
+			} else if (fmt[0] == '3' && fmt[1] == '2') {
+				/* no flag set = 32 */
+				fmt += 2;
+			} else if (fmt[0] == '6' && fmt[1] == '4') {
+				flags |= LLONGINT;
+				fmt += 2;
+			} else {
+				if (flags & FASTINT) {
+					flags &= ~FASTINT;
+					fmt--;
+				}
+				goto invalid;
+			}
+			goto rflag;
 		case 'z':
 			flags |= SIZET;
 			goto rflag;
@@ -684,6 +727,7 @@ number:			if ((dprec = prec) >= 0)
 		default:	/* "%?" prints ?, unless ? is NUL */
 			if (ch == '\0')
 				goto done;
+invalid:
 			/* pretend it was %c with argument ch */
 			buf[0] = ch;
 			cp = buf;

--- a/tests/lib/test_printfrr.c
+++ b/tests/lib/test_printfrr.c
@@ -143,6 +143,8 @@ int main(int argc, char **argv)
 		NAN,
 	};
 	uint64_t ui64 = 0xfeed1278cafef00d;
+	uint16_t i16 = -23456;
+	int_fast8_t if8 = 123;
 	struct in_addr ip;
 	char *p;
 	char buf[256];
@@ -168,6 +170,16 @@ int main(int argc, char **argv)
 
 	FMT_NSTD(printchk("11110000000011111010010111000011", "%b", 0xf00fa5c3));
 	FMT_NSTD(printchk("0b01011010", "%#010b", 0x5a));
+
+/* FMT_NSTD is conditional on the frr-format plugin being NOT enabled.
+ * However, the frr-format plugin does not support %wd/%wfd yet, so this needs
+ * to be unconditional.
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat"
+	printchk("123 -23456 feed1278cafef00d 9876", "%wf8d %w16d %w64x %d",
+		 if8, i16, ui64, 9876);
+#pragma GCC diagnostic pop
 
 	inet_aton("192.168.1.2", &ip);
 	printchk("192.168.1.2", "%pI4", &ip);


### PR DESCRIPTION
ISO C23 has new printf specifiers for `intXX_t` and cousins, most relevant for us `%w64d` for `int64_t` and `%w64u` for `uint64_t`. `w64` is a length modifier like `l` for long, `h` for `short`, and `hh` for `char`. It works in combination with `%d`/`%u`/`%x`/etc.

This picks up the `lib/printf` changes for this (straight from FreeBSD), adds a quick test and updates related docs.

The `w64` modifier is **NOT** ready for use yet since neither the compilers on older distros nor the `frr-format` plugin support type checking for it yet. If it's added to `frr-format`, it will become usable together with the `FMT_NSTD` macro¹. Unfortunately the `frr-format` plugin, being derived from GCC's internal code, is some rather impressive spaghetti and resyncing it with the upstream GCC changes for `w64` & co. takes some work.

---

¹ essentially if we have *any* platform in the CI that does proper type checking for this, it's enough; the checks don't variate with older compiler versions and therefore can be disabled there. But right now, none of the platforms in CI is correctly set up (yet) for warnings on this.