### PR TITLE
lib: fix initialization of northbound nodes

### DIFF
--- a/lib/yang.c
+++ b/lib/yang.c
@@ -199,6 +199,16 @@ next:
 		if (ret == YANG_ITER_STOP)
 			return ret;
 	}
+	LY_LIST_FOR ((const struct lysc_node *)lysc_node_notifs(snode), child) {
+		ret = yang_snodes_iterate_subtree(child, module, cb, flags, arg);
+		if (ret == YANG_ITER_STOP)
+			return ret;
+	}
+	LY_LIST_FOR ((const struct lysc_node *)lysc_node_actions(snode), child) {
+		ret = yang_snodes_iterate_subtree(child, module, cb, flags, arg);
+		if (ret == YANG_ITER_STOP)
+			return ret;
+	}
 	return ret;
 }
 


### PR DESCRIPTION
When actions and notification are defined as descendants of other nodes, they are not getting initialized, because the iterator skips them. Fix the iterator to include them when traversing the schema.