### PR TITLE
bgpd: When using dev build add pointer information to %pBD

### DIFF
--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -239,7 +239,11 @@ static ssize_t printfrr_bd(struct fbuf *buf, struct printfrr_eargs *ea,
 	if (!dest)
 		return bputs(buf, "(null)");
 
+#if !defined(DEV_BUILD)
 	/* need to get the real length even if buffer too small */
 	prefix2str(p, cbuf, sizeof(cbuf));
 	return bputs(buf, cbuf);
+#else
+	return bprintfrr(buf, "%s(%p)", prefix2str(p, cbuf, sizeof(cbuf)), dest);
+#endif
 }

--- a/doc/developer/logging.rst
+++ b/doc/developer/logging.rst
@@ -383,7 +383,8 @@ bgpd
 
 .. frrfmt:: %pBD (struct bgp_dest *)
 
-   Print prefix for a BGP destination.
+   Print prefix for a BGP destination.  When using ``--enable-dev-build`` include
+   the pointer value for the bgp_dest.
 
    :frrfmtout:`fe80::1234/64`
 


### PR DESCRIPTION
When building FRR with `--enable-dev-build`.  Add a bit of code to include the pointer value as part of the output. Helps with tracking down issues and let's us see more data when using the dev build option.

New output:

2024/03/08 19:48:56 BGP: [V0J1J-W5RHA] 11.0.20.1/32(0x5759ddf8d7c0) for 11.0.20.1/32