### PR TITLE
bgpd: add missing white-space between route short status and network …

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9046,6 +9046,9 @@ static void route_vty_short_status_out(struct vty *vty,
 		vty_out(vty, "i");
 	else
 		vty_out(vty, " ");
+
+	/* adding space between next column */
+	vty_out(vty, " ");
 }
 
 static char *bgp_nexthop_hostname(struct peer *peer,

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -66,8 +66,8 @@ enum bgp_show_adj_route_type {
 #define BGP_SHOW_NCODE_HEADER "Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self\n"
 #define BGP_SHOW_RPKI_HEADER                                                   \
 	"RPKI validation codes: V valid, I invalid, N Not found\n\n"
-#define BGP_SHOW_HEADER "    Network          Next Hop            Metric LocPrf Weight Path\n"
-#define BGP_SHOW_HEADER_WIDE "    Network                                      Next Hop                                  Metric LocPrf Weight Path\n"
+#define BGP_SHOW_HEADER "     Network          Next Hop            Metric LocPrf Weight Path\n"
+#define BGP_SHOW_HEADER_WIDE "     Network                                      Next Hop                                  Metric LocPrf Weight Path\n"
 
 /* Maximum number of labels we can process or send with a prefix. We
  * really do only 1 for MPLS (BGP-LU) but we can do 2 for EVPN-VxLAN.

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post4.1.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post4.1.ref
@@ -5,5 +5,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-    Network          Next Hop            Metric LocPrf Weight Path
- *> 192.168.0.0      0.0.0.0                  0         32768 i
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  192.168.0.0      0.0.0.0                  0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post5.0.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post5.0.ref
@@ -5,5 +5,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-    Network          Next Hop            Metric LocPrf Weight Path
- *> 192.168.0.0/24   0.0.0.0                  0         32768 i
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  192.168.0.0/24   0.0.0.0                  0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post6.1.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4-post6.1.ref
@@ -6,5 +6,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-    Network          Next Hop            Metric LocPrf Weight Path
- *> 192.168.0.0/24   0.0.0.0                  0         32768 i
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  192.168.0.0/24   0.0.0.0                  0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv4.ref
@@ -3,5 +3,5 @@ Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
 Origin codes: i - IGP, e - EGP, ? - incomplete
 
-    Network          Next Hop            Metric LocPrf Weight Path
- *> 192.168.0.0      0.0.0.0                  0         32768 i
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  192.168.0.0      0.0.0.0                  0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6-post4.1.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6-post4.1.ref
@@ -5,5 +5,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-    Network          Next Hop            Metric LocPrf Weight Path
- *> fc00::/64        ::                       0         32768 i
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  fc00::/64        ::                       0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6.ref
@@ -3,5 +3,5 @@ Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
 Origin codes: i - IGP, e - EGP, ? - incomplete
 
-    Network          Next Hop            Metric LocPrf Weight Path
- *> fc00::/64        ::                       0         32768 i
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  fc00::/64        ::                       0         32768 i

--- a/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6_post6.1.ref
+++ b/tests/topotests/all_protocol_startup/r1/show_bgp_ipv6_post6.1.ref
@@ -6,5 +6,5 @@ Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
 Origin codes:  i - IGP, e - EGP, ? - incomplete
 RPKI validation codes: V valid, I invalid, N Not found
 
-    Network          Next Hop            Metric LocPrf Weight Path
- *> fc00::/64        ::                       0         32768 i
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  fc00::/64        ::                       0         32768 i

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/scripts/add_routes.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/scripts/add_routes.py
@@ -9,9 +9,9 @@ luCommand(
 luCommand(
     "r4", 'vtysh -c "show bgp next"', "99.0.0.. valid", "wait", "See CE static NH"
 )
-luCommand("r1", 'vtysh -c "show bgp ipv4 uni"', "i5.*i5", "wait", "See CE routes")
-luCommand("r3", 'vtysh -c "show bgp ipv4 uni"', "i5.*i5", "wait", "See CE routes")
-luCommand("r4", 'vtysh -c "show bgp ipv4 uni"', "i5.*i5", "wait", "See CE routes")
+luCommand("r1", 'vtysh -c "show bgp ipv4 uni"', "i 5.*i 5", "wait", "See CE routes")
+luCommand("r3", 'vtysh -c "show bgp ipv4 uni"', "i 5.*i 5", "wait", "See CE routes")
+luCommand("r4", 'vtysh -c "show bgp ipv4 uni"', "i 5.*i 5", "wait", "See CE routes")
 luCommand("ce1", 'vtysh -c "show bgp ipv4 uni 5.1.0.0/24"', "", "none", "See CE routes")
 luCommand("r1", 'vtysh -c "show bgp ipv4 uni 5.1.0.0/24"', "", "none", "See CE routes")
 luCommand("ce2", 'vtysh -c "show bgp ipv4 uni 5.1.0.0/24"', "", "none", "See CE routes")
@@ -39,22 +39,22 @@ luCommand(
 luCommand(
     "r3",
     'vtysh -c "show bgp ipv4 vpn"',
-    "i99.0.0.1/32",
+    "i 99.0.0.1/32",
     "wait",
     "See R1s static address",
 )
 luCommand(
     "r4",
     'vtysh -c "show bgp ipv4 vpn"',
-    "i99.0.0.1/32",
+    "i 99.0.0.1/32",
     "wait",
     "See R1s static address",
 )
 luCommand(
-    "r3", 'vtysh -c "show bgp ipv4 vpn rd 10:1"', "i5.*i5", "wait", "See R1s imports"
+    "r3", 'vtysh -c "show bgp ipv4 vpn rd 10:1"', "i 5.*i 5", "wait", "See R1s imports"
 )
 luCommand(
-    "r4", 'vtysh -c "show bgp ipv4 vpn rd 10:1"', "i5.*i5", "wait", "See R1s imports"
+    "r4", 'vtysh -c "show bgp ipv4 vpn rd 10:1"', "i 5.*i 5", "wait", "See R1s imports"
 )
 
 luCommand(
@@ -86,14 +86,14 @@ if have2ndImports:
 luCommand(
     "r1",
     'vtysh -c "show bgp ipv4 vpn"',
-    "i99.0.0.2/32",
+    "i 99.0.0.2/32",
     "wait",
     "See R3s static address",
 )
 luCommand(
     "r4",
     'vtysh -c "show bgp ipv4 vpn"',
-    "i99.0.0.2/32",
+    "i 99.0.0.2/32",
     "wait",
     "See R3s static address",
 )
@@ -101,14 +101,14 @@ if have2ndImports:
     luCommand(
         "r1",
         'vtysh -c "show bgp ipv4 vpn rd 10:3"',
-        "i5.*i5",
+        "i 5.*i 5",
         "none",
         "See R3s imports",
     )
     luCommand(
         "r4",
         'vtysh -c "show bgp ipv4 vpn rd 10:3"',
-        "i5.*i5",
+        "i 5.*i 5",
         "none",
         "See R3s imports",
     )
@@ -133,22 +133,22 @@ luCommand(
 luCommand(
     "r1",
     'vtysh -c "show bgp ipv4 vpn"',
-    "i99.0.0.3/32",
+    "i 99.0.0.3/32",
     "wait",
     "See R4s static address",
 )
 luCommand(
     "r3",
     'vtysh -c "show bgp ipv4 vpn"',
-    "i99.0.0.3/32",
+    "i 99.0.0.3/32",
     "wait",
     "See R4s static address",
 )
 luCommand(
-    "r1", 'vtysh -c "show bgp ipv4 vpn rd 10:4"', "i5.*i5", "wait", "See R4s imports"
+    "r1", 'vtysh -c "show bgp ipv4 vpn rd 10:4"', "i 5.*i 5", "wait", "See R4s imports"
 )
 luCommand(
-    "r3", 'vtysh -c "show bgp ipv4 vpn rd 10:4"', "i5.*i5", "wait", "See R4s imports"
+    "r3", 'vtysh -c "show bgp ipv4 vpn rd 10:4"', "i 5.*i 5", "wait", "See R4s imports"
 )
 
 


### PR DESCRIPTION
…columns

When running `show ip bgp` command, the 'route short status' and
    'network' columns do not have white-space between them.

    Old show:
        Network          Next Hop            Metric LocPrf Weight Path
     *>i1.1.1.1/32       10.1.12.111              0    100      0 i

    New show:
         Network          Next Hop            Metric LocPrf Weight Path
     *>i 1.1.1.1/32       10.1.12.111              0    100      0 i

    Added white-space to enhance readability between them.