### PR TITLE
eigrpd, mgmtd, ospf6d: frr_fini is last

### DIFF
--- a/eigrpd/eigrp_main.c
+++ b/eigrpd/eigrp_main.c
@@ -94,9 +94,10 @@ static void sighup(void)
 static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
-	eigrp_terminate();
 
 	keychain_terminate();
+
+	eigrp_terminate();
 
 	exit(0);
 }

--- a/mgmtd/mgmt_testc.c
+++ b/mgmtd/mgmt_testc.c
@@ -133,8 +133,10 @@ static void sigusr1(void)
 static void quit(int exit_code)
 {
 	EVENT_OFF(event_timeout);
-	frr_fini();
 	darr_free(__client_cbs.notif_xpaths);
+
+	frr_fini();
+
 	exit(exit_code);
 }
 

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -110,9 +110,10 @@ static void __attribute__((noreturn)) ospf6_exit(int status)
 
 	ospf6_master_delete();
 
+	keychain_terminate();
+
 	frr_fini();
 
-	keychain_terminate();
 	exit(status);
 }
 


### PR DESCRIPTION
I noticed that ospf6d always had a linked list memory leak. Tracking it down shows that frr_fini() shuts down the memory system and prints out memory not cleaned up.  eigrpd, mgmtd and ospf6d all called cleanup functions after frr_fini leaving memory leaked that was not really leaked.