### PR TITLE
bgpd: fix disable bfd profile for neighbors.

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -597,6 +597,9 @@ DEFUN(no_neighbor_bfd_profile, no_neighbor_bfd_profile_cmd,
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
 
+	if (!peer->bfd_config)
+		return CMD_SUCCESS;
+
 	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
 		bgp_group_configure_bfd(peer);
 	else


### PR DESCRIPTION
Before this patch after command
`no neighbor <A.B.C.D|X:X::X:X|WORD> bfd profile [BFDPROF]`
has always been created bfd-config for neighbor.
