### PR TITLE
zebra: Cleanup leaked memory on shutdown from GR code

### DIFF
--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -298,6 +298,16 @@ struct zebra_gr_afi_clean {
  * Functions to deal with capabilities
  */
 
+void zebra_gr_client_final_shutdown(struct zserv *client)
+{
+	struct client_gr_info *info;
+
+	while (!TAILQ_EMPTY(&client->gr_info_queue)) {
+		info = TAILQ_FIRST(&client->gr_info_queue);
+		zebra_gr_client_info_delete(client, info);
+	}
+}
+
 /*
  * Function to decode and call appropriate functions
  * to handle client capabilities.

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -675,10 +675,14 @@ static void zserv_client_free(struct zserv *client)
 	 * If any instance are graceful restart enabled,
 	 * client is not deleted
 	 */
-	if (DYNAMIC_CLIENT_GR_DISABLED(client)) {
+	if (DYNAMIC_CLIENT_GR_DISABLED(client) || zebra_router_in_shutdown()) {
 		if (IS_ZEBRA_DEBUG_EVENT)
 			zlog_debug("%s: Deleting client %s", __func__,
 				   zebra_route_string(client->proto));
+
+		if (zebra_router_in_shutdown())
+			zebra_gr_client_final_shutdown(client);
+
 		zserv_client_delete(client);
 	} else {
 		/* Handle cases where client has GR instance. */

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -378,6 +378,7 @@ __attribute__((__noreturn__)) void zebra_finalize(struct event *event);
 /*
  * Graceful restart functions.
  */
+extern void zebra_gr_client_final_shutdown(struct zserv *client);
 extern int zebra_gr_client_disconnect(struct zserv *client);
 extern void zebra_gr_client_reconnect(struct zserv *client);
 extern void zebra_gr_stale_client_cleanup(struct list *client_list);


### PR DESCRIPTION
Recent commit: 6b2554b94a
Exposed, via Address Sanitation, that memory was being leaked.  Unfortunately the CI system did not catch this.

Two pieces of memory were being lost: The zserv client data structure as well as anything on the client->gr_info_queue. Clean these up.