### PR TITLE
bgpd: Add some missing data to `show bgp attribute-info`

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -2249,7 +2249,7 @@ void aspath_finish(void)
 /* return and as path value */
 const char *aspath_print(struct aspath *as)
 {
-	return (as ? as->str : NULL);
+	return as ? as->str : "(null)";
 }
 
 /* Printing functions */

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -911,9 +911,16 @@ static void attr_show_all_iterator(struct hash_bucket *bucket, struct vty *vty)
 
 	vty_out(vty,
 		"\tflags: %" PRIu64
-		" distance: %u med: %u local_pref: %u origin: %u weight: %u label: %u sid: %pI6\n",
+		" distance: %u med: %u local_pref: %u origin: %u weight: %u label: %u sid: %pI6 aigp_metric: %" PRIu64
+		"\n",
 		attr->flag, attr->distance, attr->med, attr->local_pref,
-		attr->origin, attr->weight, attr->label, sid);
+		attr->origin, attr->weight, attr->label, sid, attr->aigp_metric);
+	vty_out(vty,
+		"\taspath: %s Community: %s Extended Community: %s Large Community: %s\n",
+		aspath_print(attr->aspath),
+		community_str(attr->community, false, false),
+		ecommunity_str(attr->ecommunity),
+		lcommunity_str(attr->lcommunity, false, false));
 }
 
 void attr_show_all(struct vty *vty)

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -263,8 +263,11 @@ struct ecommunity *ecommunity_dup(struct ecommunity *ecom)
 }
 
 /* Return string representation of ecommunities attribute. */
-char *ecommunity_str(struct ecommunity *ecom)
+const char *ecommunity_str(struct ecommunity *ecom)
 {
+	if (!ecom)
+		return "(null)";
+
 	if (!ecom->str)
 		ecom->str =
 			ecommunity_ecom2str(ecom, ECOMMUNITY_FORMAT_DISPLAY, 0);

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -346,7 +346,7 @@ extern void ecommunity_strfree(char **s);
 extern bool ecommunity_include(struct ecommunity *e1, struct ecommunity *e2);
 extern bool ecommunity_match(const struct ecommunity *,
 			     const struct ecommunity *);
-extern char *ecommunity_str(struct ecommunity *ecom);
+extern const char *ecommunity_str(struct ecommunity *ecom);
 extern struct ecommunity_val *ecommunity_lookup(const struct ecommunity *,
 						uint8_t, uint8_t);
 

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -443,7 +443,7 @@ static unsigned int updgrp_hash_key_make(const void *p)
 	key = jhash_1word((peer->flags & PEER_FLAG_AIGP), key);
 
 	if (peer->soo[afi][safi]) {
-		char *soo_str = ecommunity_str(peer->soo[afi][safi]);
+		const char *soo_str = ecommunity_str(peer->soo[afi][safi]);
 
 		key = jhash_1word(jhash(soo_str, strlen(soo_str), SEED1), key);
 	}


### PR DESCRIPTION
See the commit but when dumping the attributes that have been interned it is still impossible to tell them apart.  Add some more discriminating data.  There will be more in the future.