### PR TITLE
ospfd: Send LS Updates in response to LS Request as unicast.

### DIFF
--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -1486,12 +1486,8 @@ static void ospf_ls_req(struct ip *iph, struct ospf_header *ospfh,
 
 		/* Packet overflows MTU size, send immediately. */
 		if (length + ntohs(find->data->length) > ospf_packet_max(oi)) {
-			if (oi->type == OSPF_IFTYPE_NBMA)
-				ospf_ls_upd_send(nbr, ls_upd,
-						 OSPF_SEND_PACKET_DIRECT, 0);
-			else
-				ospf_ls_upd_send(nbr, ls_upd,
-						 OSPF_SEND_PACKET_INDIRECT, 0);
+			ospf_ls_upd_send(nbr, ls_upd,
+					 OSPF_SEND_PACKET_DIRECT, 0);
 
 			/* Only remove list contents.  Keep ls_upd. */
 			list_delete_all_node(ls_upd);
@@ -1508,12 +1504,7 @@ static void ospf_ls_req(struct ip *iph, struct ospf_header *ospfh,
 
 	/* Send rest of Link State Update. */
 	if (listcount(ls_upd) > 0) {
-		if (oi->type == OSPF_IFTYPE_NBMA)
-			ospf_ls_upd_send(nbr, ls_upd, OSPF_SEND_PACKET_DIRECT,
-					 0);
-		else
-			ospf_ls_upd_send(nbr, ls_upd, OSPF_SEND_PACKET_INDIRECT,
-					 0);
+		ospf_ls_upd_send(nbr, ls_upd, OSPF_SEND_PACKET_DIRECT, 0);
 
 		list_delete(&ls_upd);
 	} else


### PR DESCRIPTION
With this fix, OSPF LS Updates sent in response to OSPF LS Requests during the DB Exchange process will be sent as unicasts. Unless the timing of multiple database exchanges coincides, there is little chance that the LSAs in the LS Update are required by OSPF routers other than the one which elicited the LS Update. 

While RFC 2328 is somewhat ambiguous on this point, FRR OSPFv3 (ospf6d) already does it correctly - see ospf6_lsupdate_send_neighbor(struct event *thread). Also, if there is any doubt, one can refer to the C++ code at ospf.org (John Moy's seminal OSPF reference implementation). 