### PR TITLE
zebra: pbr hash cleanup

### DIFF
--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -134,7 +134,7 @@ struct pbr_rule {
 
 	uint32_t seq;
 	uint32_t priority;
-	uint32_t unique;
+	uint32_t unique; /* scope: originating daemon + interface */
 	struct pbr_filter filter;
 	struct pbr_action action;
 


### PR DESCRIPTION
    In the zebra PBR rule database, the hash was previously calculated
    over many fields, including most of the filter and action values.

    But a given rule should be identifiable by just:

	1. the identity of its originating daemon (ZAPI socket FD); and
	2. the 'unique' field in struct pbr_rule

    However, pbrd assigns a 'unique' field value per map (which may be assigned to multiple interfaces, yielding multiple corresponding rules). We could possibly modify pbrd to generate a 'unique' field value per rule instance, but the simpler solution for the moment is to also hash on the interface name.

    This commit changes the PBR hash function to use only the following parameters:

	1. the identity of its originating daemon (ZAPI socket FD); and
	2. the 'unique' field in struct pbr_rule
	3. the interface name

    The goal of the above change is to get a better handle on what parameters uniquely identify a rule, to (eventually) allow the assignment or parallel generation of a globally-unique identifier for each rule that can be used with a dataplane.

    This commit also removes the inefficient pbr_rule_lookup_unique() code that iterated linearly over the entire rule database.

ISSUES:
I invite review comments particularly on these issues

1. The claim that socket, unique, and interface are sufficient to uniquely identify a PBR rule globally
2. I don't have a good idea of how to test these changes to ensure there isn't some unexpected dependency on the previous hashing scheme. Ideas welcome.