### PR TITLE
lib: remove nb/yang memory cleanup when daemonizing

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -957,8 +957,6 @@ static void frr_daemonize(void)
 	}
 
 	close(fds[1]);
-	nb_terminate();
-	yang_terminate();
 	frr_daemon_wait(fds[0]);
 }
 


### PR DESCRIPTION
We're not calling any other termination functions to free allocated memory when daemonizing except these two. There's no reason for such an exception, and because of these calls we have the following libyang warnings every time FRR is started:
```
MGMTD: libyang: String "15" not freed from the dictionary, refcount 2
MGMTD: libyang: String "200" not freed from the dictionary, refcount 2
MGMTD: libyang: String "mrib-then-urib" not freed from the dictionary, refcount 2
MGMTD: libyang: String "1000" not freed from the dictionary, refcount 2
MGMTD: libyang: String "10" not freed from the dictionary, refcount 2
MGMTD: libyang: String "5" not freed from the dictionary, refcount 2
```

Remove these calls to get rid of the unnecessary warnings.