### PR TITLE
Zebra rtadv use without init

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -936,14 +936,26 @@ def generate_support_bundle():
     """
 
     tgen = get_topogen()
+    if tgen is None:
+        logger.warn(
+            "Support bundle attempted to be generated, but topogen is not being used"
+        )
+        return True
+
     router_list = tgen.routers()
     test_name = os.environ.get("PYTEST_CURRENT_TEST").split(":")[-1].split(" ")[0]
 
     bundle_procs = {}
     for rname, rnode in router_list.items():
         logger.info("Spawn collection of support bundle for %s", rname)
-        dst_bundle = "{}/{}/support_bundles/{}".format(tgen.logdir, rname, test_name)
-        rnode.run("mkdir -p " + dst_bundle)
+        try:
+            dst_bundle = "{}/{}/support_bundles/{}".format(
+                tgen.logdir, rname, test_name
+            )
+            rnode.run("mkdir -p " + dst_bundle)
+        except Exception as err:
+            logger.error("Generation of Support bundle failed {}".format(err))
+            return True
 
         gen_sup_cmd = [
             "/usr/lib/frr/generate_support_bundle.py",

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -184,13 +184,13 @@ static int rtadv_recv_packet(struct zebra_vrf *zvrf, int sock, uint8_t *buf,
 static void rtadv_send_packet(int sock, struct interface *ifp,
 			      enum ipv6_nd_suppress_ra_status stop)
 {
-	struct msghdr msg;
-	struct iovec iov;
+	struct msghdr msg = { 0 };
+	struct iovec iov = { 0 };
 	struct cmsghdr *cmsgptr;
 	struct in6_pktinfo *pkt;
-	struct sockaddr_in6 addr;
-	unsigned char buf[RTADV_MSG_SIZE];
-	char adata[RTADV_ADATA_SIZE];
+	struct sockaddr_in6 addr = { 0 };
+	unsigned char buf[RTADV_MSG_SIZE] = { 0 };
+	char adata[RTADV_ADATA_SIZE] = { 0 };
 
 	struct nd_router_advert *rtadv;
 	int ret;


### PR DESCRIPTION
1) Ensure that generate_support_bundles doesn't crash the run
2) Cleanup a sendmsg call that sent down uninited data.