### PR TITLE
bgpd: Enable BGP dynamic capability by default for datacenter profile

### DIFF
--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1975,7 +1975,7 @@ uint16_t bgp_open_capability(struct stream *s, struct peer *peer,
 	}
 
 	/* Dynamic capability. */
-	if (CHECK_FLAG(peer->flags, PEER_FLAG_DYNAMIC_CAPABILITY)) {
+	if (peergroup_flag_check(peer, PEER_FLAG_DYNAMIC_CAPABILITY)) {
 		SET_FLAG(peer->cap, PEER_CAP_DYNAMIC_ADV);
 		stream_putc(s, BGP_OPEN_OPT_CAP);
 		ext_opt_params

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1544,6 +1544,9 @@ struct peer *peer_new(struct bgp *bgp)
 	if (CHECK_FLAG(bgp->flags, BGP_FLAG_SOFT_VERSION_CAPABILITY))
 		SET_FLAG(peer->flags, PEER_FLAG_CAPABILITY_SOFT_VERSION);
 
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_DYNAMIC_CAPABILITY))
+		SET_FLAG(peer->flags, PEER_FLAG_DYNAMIC_CAPABILITY);
+
 	SET_FLAG(peer->flags_invert, PEER_FLAG_CAPABILITY_FQDN);
 	SET_FLAG(peer->flags, PEER_FLAG_CAPABILITY_FQDN);
 
@@ -2918,6 +2921,13 @@ static void peer_group2peer_config_copy(struct peer_group *group,
 		if (CHECK_FLAG(conf->flags, PEER_FLAG_CAPABILITY_SOFT_VERSION))
 			SET_FLAG(peer->flags,
 				 PEER_FLAG_CAPABILITY_SOFT_VERSION);
+
+	/* capability dynamic apply */
+	if (!CHECK_FLAG(peer->flags_override,
+			PEER_FLAG_DYNAMIC_CAPABILITY))
+		if (CHECK_FLAG(conf->flags, PEER_FLAG_DYNAMIC_CAPABILITY))
+			SET_FLAG(peer->flags,
+				 PEER_FLAG_DYNAMIC_CAPABILITY);
 
 	/* password apply */
 	if (!CHECK_FLAG(peer->flags_override, PEER_FLAG_PASSWORD))

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -522,6 +522,7 @@ struct bgp {
 #define BGP_FLAG_LU_IPV6_EXPLICIT_NULL (1ULL << 34)
 #define BGP_FLAG_SOFT_VERSION_CAPABILITY (1ULL << 35)
 #define BGP_FLAG_ENFORCE_FIRST_AS (1ULL << 36)
+#define BGP_FLAG_DYNAMIC_CAPABILITY (1ULL << 37)
 
 	/* BGP default address-families.
 	 * New peers inherit enabled afi/safis from bgp instance.

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1816,7 +1816,7 @@ Configuring Peers
    This includes changing graceful-restart (LLGR also) timers,
    enabling/disabling add-path, and other supported capabilities.
 
-.. clicmd:: neighbor PEER capability fqdn 
+.. clicmd:: neighbor PEER capability fqdn
 
    Allow BGP to negotiate the FQDN Capability with its peers.
 
@@ -1825,7 +1825,7 @@ Configuring Peers
 
    This capability is activated by default. The ``no neighbor PEER capability
    fqdn`` avoid negotiation of that capability. This is useful for peers who
-   are not supporting this capability or supporting BGP Capabilities 
+   are not supporting this capability or supporting BGP Capabilities
    Negotiation RFC 2842.
 
 .. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> accept-own
@@ -1948,6 +1948,13 @@ Configuring Peers
    This command shows the hostname of the next-hop in certain BGP commands
    outputs. It's easier to troubleshoot if you have a number of BGP peers
    and a number of routes to check.
+
+.. clicmd:: bgp default dynamic-capability
+
+   This command enables dynamic capability advertisement by default
+   for all the neighbors.
+
+   For ``datacenter`` profile, this is enabled by default.
 
 .. clicmd:: bgp default software-version-capability
 
@@ -3219,7 +3226,7 @@ that the 2001:db8:2:2:: prefix is valid.
 
 .. code-block:: frr
 
-   r1# show bgp nexthop detail 
+   r1# show bgp nexthop detail
    Current BGP nexthop cache:
     2001:db8:2:2:: valid [IGP metric 0], #paths 4
      gate 2001:db8:12::2, if eth0


### PR DESCRIPTION
Dynamic capability provides more value without resetting the sessions for some important other capabilities to exchange, like: graceful-restart, addpath, orf, fqdn, etc.

Since we support it already, enable it by default.