### PR TITLE
grpc: fix grpc for various failures

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -36,16 +36,24 @@ Installing Topotest Requirements
        tshark \
        valgrind
    python3 -m pip install wheel
-   python3 -m pip install 'protobuf<4'
    python3 -m pip install 'pytest>=6.2.4' 'pytest-xdist>=2.3.0'
    python3 -m pip install 'scapy>=2.4.5'
    python3 -m pip install xmltodict
    python3 -m pip install git+https://github.com/Exa-Networks/exabgp@0659057837cd6c6351579e9f0fa47e9fb7de7311
    useradd -d /var/run/exabgp/ -s /bin/false exabgp
 
-   # To enable the gRPC topotest install:
-   # It's important to include 'protobuf<4' here to avoid incompatible grpcio-tools versions.
-   python3 -m pip install 'protobuf<4' grpcio grpcio-tools
+The version of protobuf package that is installed on your system will determine
+which versions of the python protobuf packages you need to install.
+
+.. code:: shell
+   # - Either - For protobuf version <= 3.12
+   python3 -m pip install 'protobuf<4'
+
+   # - OR- for protobuf version >= 3.21
+   python3 -m pip install 'protobuf>=4'
+
+   # To enable the gRPC topotest also install:
+   python3 -m pip install grpcio grpcio-tools
 
 
 Enable Coredumps

--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -32,7 +32,7 @@ extern "C" {
 #if __clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 5)
 #  define _RET_NONNULL    , returns_nonnull
 #endif
-#if __has_attribute(fallthrough)
+#if __has_attribute(fallthrough) && !defined(__cplusplus)
 #  define fallthrough __attribute__((fallthrough));
 #endif
 # define _CONSTRUCTOR(x)  constructor(x)
@@ -56,7 +56,7 @@ extern "C" {
 #if __GNUC__ < 5
 #  define __has_attribute(x) 0
 #endif
-#if __GNUC__ >= 7
+#if __GNUC__ >= 7 && !defined(__cplusplus)
 #  define fallthrough __attribute__((fallthrough));
 #endif
 #endif
@@ -112,7 +112,7 @@ extern "C" {
 #ifndef _ALLOC_SIZE
 # define _ALLOC_SIZE(x)
 #endif
-#ifndef fallthrough
+#if !defined(fallthrough) && !defined(__cplusplus)
 #define fallthrough
 #endif
 #ifndef _DEPRECATED

--- a/tests/lib/subdir.am
+++ b/tests/lib/subdir.am
@@ -25,7 +25,7 @@ copy_script: tests/lib/script1.lua
 	$(INSTALL_SCRIPT) $< tests/lib/script1.lua
 
 ##############################################################################
-GRPC_TESTS_LDADD = mgmtd/libmgmt_be_nb.la staticd/libstatic.a grpc/libfrrgrpc_pb.la -lgrpc++ -lprotobuf $(ALL_TESTS_LDADD) $(LIBYANG_LIBS) -lm
+GRPC_TESTS_LDADD = mgmtd/libmgmt_be_nb.la staticd/libstatic.a grpc/libfrrgrpc_pb.la $(GRPC_LIBS) $(ALL_TESTS_LDADD) $(LIBYANG_LIBS) -lm
 
 if GRPC
 check_PROGRAMS += tests/lib/test_grpc

--- a/tests/topotests/grpc_basic/test_basic_grpc.py
+++ b/tests/topotests/grpc_basic/test_basic_grpc.py
@@ -142,7 +142,7 @@ def test_shutdown_checks(tgen):
     time.sleep(1)
     try:
         for r in tgen.routers().values():
-            r.net.stopRouter()
+            r.net.stopRouter(False)
             r.net.checkRouterCores()
     finally:
         if p:


### PR DESCRIPTION
lib: don't define a `fallthrough` in c++ to avoid conflict with protobuf c++

check: add link libs required by some versions of grpc++ or it's dependent linked libs

tests: don't fail the test due to known at exit memleaks

Closes: https://github.com/FRRouting/frr/issues/15475