### PR TITLE
lib: fix SQLite dbfile path length

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -59,7 +59,7 @@ char config_default[512];
 char frr_zclientpath[512];
 static char pidfile_default[1024];
 #ifdef HAVE_SQLITE3
-static char dbfile_default[512];
+static char dbfile_default[1024];
 #endif
 static char vtypath_default[512];
 


### PR DESCRIPTION
I can't see them but apparently this causes compiler warnings.

---

```
lib/libfrr.c:734:66: error: ‘%s’ directive output may be truncated writing up to 15 bytes into a region of size between 1 and 511
```

Double checked that SQLite3 is enabled (it is) and running quite recent GCC (13.2.0) but still not seeing this. Might be something they changed on the GCC side and it only shows on GCC 11 or 12? Either way just make the string larger.

Since I can't see it — @donaldsharp can you confirm this fixes it?