### PR TITLE
bgpd: fix register NHT with appropriate colored ext. community

### DIFF
--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -517,9 +517,11 @@ static inline void bgp_attr_set_ecommunity(struct attr *attr,
 {
 	attr->ecommunity = ecomm;
 
-	if (ecomm)
+	if (ecomm) {
 		SET_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES));
-	else
+		if (ecommunity_select_color(ecomm))
+			SET_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_SRTE_COLOR));
+	} else
 		UNSET_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES));
 }
 


### PR DESCRIPTION
When receiving a BGP update that includes a colored extended community, the nexthop is tracked in the bgp nexthop tracking context, but the color is never recorded.

Actually, the srte color is set only when the SRTE_COLOR attribute is set, and this is an internal flag that is only set when a local route-map sets the sr-te-color parameter.
Fix this by removing that condition.

Fixes: 442e2edcfaef ("bgpd: add functions related to srte_color management")