### PR TITLE
ospfd: Assure OSPF AS External routes are installed after link flap

### DIFF
--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -480,7 +480,7 @@ static int ospf_ase_route_match_same(struct route_table *rt,
 
 	assert(or);
 
-	if (or->path_type != newor->path_type)
+	if (or->changed || (or->path_type != newor->path_type))
 		return 0;
 
 	switch (or->path_type) {


### PR DESCRIPTION
OSPF intra/inter area routes were previously marked to assure they are re-installed after a fast link flap in the commit:

commit effee18744ad3e1777614f58350d74fb718d3211
Author: Donald Sharp <sharpd@nvidia.com>
Date:   Mon May 24 13:45:29 2021 -0400

    ospfd: Fix quick interface down up event handling in ospf

This commit extends this fix to OSPF AS External routes as well.