### PR TITLE
zebra: fix rejected route due to wrong nexthop-group

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -176,6 +176,10 @@ static void if_nhg_dependents_release(const struct interface *ifp)
 	frr_each(nhg_connected_tree, &zif->nhg_dependents, rb_node_dep) {
 		rb_node_dep->nhe->ifp = NULL; /* Null it out */
 		zebra_nhg_check_valid(rb_node_dep->nhe);
+		if (CHECK_FLAG(rb_node_dep->nhe->flags,
+			       NEXTHOP_GROUP_KEEP_AROUND) &&
+		    rb_node_dep->nhe->refcnt == 1)
+			zebra_nhg_decrement_ref(rb_node_dep->nhe);
 	}
 }
 


### PR DESCRIPTION
A specific sequence of actions involving the addition and removal of IP routes and network interfaces can lead to a route installation failure. The issue occurs under the following conditions:

 - Initially, there is no route present via the ens3 interface.
 - Adds a route: ip route 10.0.0.0/24 192.168.0.100 ens3
 - Removes the same route: no ip route 10.0.0.0/24 192.168.0.100 ens3
 - Removes the ens3 interface.
 - Re-adds the ens3 interface.
 - Again adds the same route: ip route 10.0.0.0/24 192.168.0.100 ens3
 - And again removes it: no ip route 10.0.0.0/24 192.168.0.100 ens3
 - Shuts down the ens3 interface
 - Reactivates the interface
 - Adds the route once more: ip route 10.0.0.0/24 192.168.0.100 ens3

The route appears to be rejected.
> r1 # show ip route nexthop
> S>r 10.0.0.0/24 [1/0] (6) via 192.168.0.100, ens3, weight 1, 00:00:01

The commit 35729f38fa ("zebra: Add a timer to nexthop group deletion") introduced a feature to keep a nexthop-group in Zebra for a certain period even when it is no longer in use. But if a nexthop-group interface is removed during this period, the association between the nexthop-group and the interface is lost in zebra memory. If the interface is later added back and a route is re-established, the nexthop-group interface dependency is not correctly reestablished. As a consequence, the nexthop-group flags remain unset when the interface is down. Upon the interface's reactivation, zebra does not reinstall the nexthop-group in the kernel because it is marked as valid and installed, but in reality, it does not exist in the kernel (it was removed when the interface was down). Thus, attempts to install a route via this nexthop-group ID fail.

Stop maintaining a nexthop-group when its associated interface is no longer present.

Here is a script to reproduce the issue:

```
killall zebra staticd mgmtd

sleep 1

echo >/tmp/zebra.log

cat>zebra.conf <<EOF
log file /tmp/zebra.log
!
debug zebra rib
debug zebra nexthop detail
EOF

/usr/lib/frr/zebra -d -f zebra.conf
/usr/lib/frr/mgmtd -d
/usr/lib/frr/staticd -d

ip l set lo up
ip link add ens3 type dummy
ip l set ens3 up
ip add add 192.168.0.1/24 dev ens3



sleep 1

# Show initial state
echo Show initial state >>/tmp/zebra.log
printf "show ip route nexthop\nshow nexthop-group rib" | vtysh
ip r
ip nexthop

# read -n1 -r -p "Press any key to continue..."

# Install route
echo Install route >>/tmp/zebra.log
printf "conf\nip route 10.0.0.0/24 192.168.0.100 ens3" | vtysh
sleep 0.5
printf "show ip route nexthop\nshow nexthop-group rib" | vtysh
ip r
ip nexthop

# read -n1 -r -p "Press any key to continue..."

# uninstall the route - nexthop-group is kept for 180 seconds
echo Uninstall route >>/tmp/zebra.log
printf "conf\nno ip route 10.0.0.0/24 192.168.0.100 ens3" | vtysh
sleep 0.5
printf "show ip route nexthop\nshow nexthop-group rib" | vtysh
ip r
ip nexthop

# read -n1 -r -p "Press any key to continue..."

# Set interface down. nexthop-group removed by kernel but still in zebra
echo Set interface down >>/tmp/zebra.log
ip l set ens3 down 
sleep 0.5
printf "show ip route nexthop\nshow nexthop-group rib" | vtysh
ip r
ip nexthop

# read -n1 -r -p "Press any key to continue..."

# rename interface
echo rename interface >>/tmp/zebra.log
ip l set ens3 name _ens3; ip l set _ens3 up; ip l set _ens3 down; ip l set _ens3 name ens3
sleep 0.5
printf "show ip route nexthop\nshow nexthop-group rib" | vtysh
ip r
ip nexthop

# read -n1 -r -p "Press any key to continue..."

# Set interface up.
echo Set interface Up >>/tmp/zebra.log
ip l set ens3 up
sleep 0.5
printf "show ip route nexthop\nshow nexthop-group rib" | vtysh
ip r
ip nexthop

# read -n1 -r -p "Press any key to continue..."

# Set route back. Route is rejected
echo Set route back >>/tmp/zebra.log
printf "conf\nip route 10.0.0.0/24 192.168.0.100 ens3" | vtysh
sleep 0.5
printf "show ip route nexthop\nshow nexthop-group rib" | vtysh
ip r
ip nexthop

read -n1 -r -p "Press any key to continue..."

# uninstall the route - nexthop-group is kept for 180 seconds
echo Uninstall route 2 >>/tmp/zebra.log
printf "conf\nno ip route 10.0.0.0/24 192.168.0.100 ens3" | vtysh
sleep 0.5
printf "show ip route nexthop\nshow nexthop-group rib" | vtysh
ip r
ip nexthop

# read -n1 -r -p "Press any key to continue..."

# Set interface down. nexthop-group removed by kernel but still in zebra
echo Set interface down 2 >>/tmp/zebra.log
ip l set ens3 down 
sleep 0.5
printf "show ip route nexthop\nshow nexthop-group rib" | vtysh
ip r
ip nexthop

# read -n1 -r -p "Press any key to continue..."

# Set interface up.
echo Set interface Up 2 >>/tmp/zebra.log
ip l set ens3 up
sleep 0.5
printf "show ip route nexthop\nshow nexthop-group rib" | vtysh
ip r
ip nexthop

# read -n1 -r -p "Press any key to continue..."

# Set route back. Route is rejected
echo Set route back 2 >>/tmp/zebra.log
printf "conf\nip route 10.0.0.0/24 192.168.0.100 ens3" | vtysh
sleep 0.5
printf "show ip route nexthop\nshow nexthop-group rib" | vtysh
ip r
ip nexthop
```

Execution shows:
```
root@r1:~# bash -x script 
+ killall zebra staticd mgmtd
+ sleep 1
+ echo
+ /usr/lib/frr/zebra -d
+ /usr/lib/frr/mgmtd -d
+ /usr/lib/frr/staticd -d
+ ip l set lo up
+ ip link add ens3 type dummy
RTNETLINK answers: File exists
+ ip l set ens3 up
+ ip add add 192.168.0.1/24 dev ens3
RTNETLINK answers: File exists
+ sleep 1
+ echo Show initial state
+ printf 'show ip route nexthop\nshow nexthop-group rib'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# show ip route nexthop
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

C>* 192.168.0.0/24 (3) is directly connected, ens3, 00:00:01
L>* 192.168.0.1/32 (3) is directly connected, ens3, 00:00:01
r1# show nexthop-group rib
ID: 3 (zebra)
     RefCnt: 4
     Uptime: 00:00:01
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 4 (zebra)
     RefCnt: 2
     Uptime: 00:00:01
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
r1# 
+ ip r
192.168.0.0/24 dev ens3 proto kernel scope link src 192.168.0.1 
+ ip nexthop
id 3 dev ens3 scope host proto zebra 
id 4 dev ens3 scope link proto zebra 
+ echo Install route
+ printf 'conf\nip route 10.0.0.0/24 192.168.0.100 ens3'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# conf
r1(config)# ip route 10.0.0.0/24 192.168.0.100 ens3
r1(config)# 
+ sleep 0.5
+ printf 'show ip route nexthop\nshow nexthop-group rib'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# show ip route nexthop
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

S>* 10.0.0.0/24 [1/0] (6) via 192.168.0.100, ens3, weight 1, 00:00:00
C>* 192.168.0.0/24 (3) is directly connected, ens3, 00:00:01
L>* 192.168.0.1/32 (3) is directly connected, ens3, 00:00:01
r1# show nexthop-group rib
ID: 3 (zebra)
     RefCnt: 4
     Uptime: 00:00:01
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 4 (zebra)
     RefCnt: 2
     Uptime: 00:00:01
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 6 (zebra)
     RefCnt: 1
     Uptime: 00:00:00
     VRF: default
     Valid, Installed
     Interface Index: 2
           via 192.168.0.100, ens3 (vrf default), weight 1
r1# 
+ ip r
10.0.0.0/24 nhid 6 via 192.168.0.100 dev ens3 proto 196 metric 20 
192.168.0.0/24 dev ens3 proto kernel scope link src 192.168.0.1 
+ ip nexthop
id 3 dev ens3 scope host proto zebra 
id 4 dev ens3 scope link proto zebra 
id 6 via 192.168.0.100 dev ens3 scope link proto zebra 
+ echo Uninstall route
+ printf 'conf\nno ip route 10.0.0.0/24 192.168.0.100 ens3'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# conf
r1(config)# no ip route 10.0.0.0/24 192.168.0.100 ens3
r1(config)# 
+ sleep 0.5
+ printf 'show ip route nexthop\nshow nexthop-group rib'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# show ip route nexthop
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

C>* 192.168.0.0/24 (3) is directly connected, ens3, 00:00:02
L>* 192.168.0.1/32 (3) is directly connected, ens3, 00:00:02
r1# show nexthop-group rib
ID: 3 (zebra)
     RefCnt: 4
     Uptime: 00:00:02
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 4 (zebra)
     RefCnt: 2
     Uptime: 00:00:02
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 6 (zebra)
     RefCnt: 1 Time to Deletion: 00:02:59
     Uptime: 00:00:01
     VRF: default
     Valid, Installed
     Interface Index: 2
           via 192.168.0.100, ens3 (vrf default), weight 1
r1# 
+ ip r
192.168.0.0/24 dev ens3 proto kernel scope link src 192.168.0.1 
+ ip nexthop
id 3 dev ens3 scope host proto zebra 
id 4 dev ens3 scope link proto zebra 
id 6 via 192.168.0.100 dev ens3 scope link proto zebra 
+ echo Set interface down
+ ip l set ens3 down
+ sleep 0.5
+ printf 'show ip route nexthop\nshow nexthop-group rib'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# show ip route nexthop
r1# show nexthop-group rib
ID: 6 (zebra)
     RefCnt: 1 Time to Deletion: 00:02:58
     Uptime: 00:00:01
     VRF: default
     Interface Index: 2
           via 192.168.0.100, ens3 (vrf default), weight 1
r1# 
+ ip r
+ ip nexthop
+ echo rename interface
+ ip l set ens3 name _ens3
+ ip l set _ens3 up
+ ip l set _ens3 down
+ ip l set _ens3 name ens3
+ sleep 0.5
+ printf 'show ip route nexthop\nshow nexthop-group rib'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# show ip route nexthop
r1# show nexthop-group rib
ID: 6 (zebra)
     RefCnt: 1 Time to Deletion: 00:02:58
     Uptime: 00:00:02
     VRF: default
           via 192.168.0.100, ens3 (vrf default), weight 1
r1# 
+ ip r
+ ip nexthop
+ echo Set interface Up
+ ip l set ens3 up
+ sleep 0.5
+ printf 'show ip route nexthop\nshow nexthop-group rib'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# show ip route nexthop
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

C>* 192.168.0.0/24 (11) is directly connected, ens3, 00:00:01
L>* 192.168.0.1/32 (11) is directly connected, ens3, 00:00:01
r1# show nexthop-group rib
ID: 11 (zebra)
     RefCnt: 4
     Uptime: 00:00:01
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 12 (zebra)
     RefCnt: 2
     Uptime: 00:00:01
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 6 (zebra)
     RefCnt: 1 Time to Deletion: 00:02:57
     Uptime: 00:00:03
     VRF: default
           via 192.168.0.100, ens3 (vrf default), weight 1
r1# 
+ ip r
192.168.0.0/24 dev ens3 proto kernel scope link src 192.168.0.1 
+ ip nexthop
id 11 dev ens3 scope host proto zebra 
id 12 dev ens3 scope link proto zebra 
+ echo Set route back
+ printf 'conf\nip route 10.0.0.0/24 192.168.0.100 ens3'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# conf
r1(config)# ip route 10.0.0.0/24 192.168.0.100 ens3
r1(config)# 
+ sleep 0.5
+ printf 'show ip route nexthop\nshow nexthop-group rib'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# show ip route nexthop
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

S>* 10.0.0.0/24 [1/0] (6) via 192.168.0.100, ens3, weight 1, 00:00:00
C>* 192.168.0.0/24 (11) is directly connected, ens3, 00:00:01
L>* 192.168.0.1/32 (11) is directly connected, ens3, 00:00:01
r1# show nexthop-group rib
ID: 11 (zebra)
     RefCnt: 4
     Uptime: 00:00:01
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 12 (zebra)
     RefCnt: 2
     Uptime: 00:00:01
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 6 (zebra)
     RefCnt: 1
     Uptime: 00:00:00
     VRF: default
     Valid, Installed
           via 192.168.0.100, ens3 (vrf default), weight 1
r1# 
+ ip r
10.0.0.0/24 nhid 6 via 192.168.0.100 dev ens3 proto 196 metric 20 
192.168.0.0/24 dev ens3 proto kernel scope link src 192.168.0.1 
+ ip nexthop
id 6 via 192.168.0.100 dev ens3 scope link proto zebra 
id 11 dev ens3 scope host proto zebra 
id 12 dev ens3 scope link proto zebra 
+ read -n1 -r -p 'Press any key to continue...'
Press any key to continue...
+ echo Uninstall route 2
+ vtysh
+ printf 'conf\nno ip route 10.0.0.0/24 192.168.0.100 ens3'
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# conf
r1(config)# no ip route 10.0.0.0/24 192.168.0.100 ens3
r1(config)# 
+ sleep 0.5
+ printf 'show ip route nexthop\nshow nexthop-group rib'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# show ip route nexthop
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

C>* 192.168.0.0/24 (11) is directly connected, ens3, 00:00:03
L>* 192.168.0.1/32 (11) is directly connected, ens3, 00:00:03
r1# show nexthop-group rib
ID: 11 (zebra)
     RefCnt: 4
     Uptime: 00:00:03
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 12 (zebra)
     RefCnt: 2
     Uptime: 00:00:03
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 6 (zebra)
     RefCnt: 1 Time to Deletion: 00:02:59
     Uptime: 00:00:02
     VRF: default
     Valid, Installed
           via 192.168.0.100, ens3 (vrf default), weight 1
r1# 
+ ip r
192.168.0.0/24 dev ens3 proto kernel scope link src 192.168.0.1 
+ ip nexthop
id 6 via 192.168.0.100 dev ens3 scope link proto zebra 
id 11 dev ens3 scope host proto zebra 
id 12 dev ens3 scope link proto zebra 
+ echo Set interface down 2
+ ip l set ens3 down
+ sleep 0.5
+ printf 'show ip route nexthop\nshow nexthop-group rib'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# show ip route nexthop
r1# show nexthop-group rib
ID: 6 (zebra)
     RefCnt: 1 Time to Deletion: 00:02:58
     Uptime: 00:00:02
     VRF: default
     Valid, Installed
           via 192.168.0.100, ens3 (vrf default), weight 1
r1# 
+ ip r
+ ip nexthop
+ echo Set interface Up 2
+ ip l set ens3 up
+ sleep 0.5
+ printf 'show ip route nexthop\nshow nexthop-group rib'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# show ip route nexthop
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

C>* 192.168.0.0/24 (16) is directly connected, ens3, 00:00:01
L>* 192.168.0.1/32 (16) is directly connected, ens3, 00:00:01
r1# show nexthop-group rib
ID: 16 (zebra)
     RefCnt: 4
     Uptime: 00:00:01
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 17 (zebra)
     RefCnt: 2
     Uptime: 00:00:01
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 6 (zebra)
     RefCnt: 1 Time to Deletion: 00:02:58
     Uptime: 00:00:03
     VRF: default
     Valid, Installed
           via 192.168.0.100, ens3 (vrf default), weight 1
r1# 
+ ip r
192.168.0.0/24 dev ens3 proto kernel scope link src 192.168.0.1 
+ ip nexthop
id 16 dev ens3 scope host proto zebra 
id 17 dev ens3 scope link proto zebra 
+ echo Set route back 2
+ printf 'conf\nip route 10.0.0.0/24 192.168.0.100 ens3'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# conf
r1(config)# ip route 10.0.0.0/24 192.168.0.100 ens3
r1(config)# 
+ sleep 0.5
+ printf 'show ip route nexthop\nshow nexthop-group rib'
+ vtysh
% Can't open configuration file /etc/frr/vtysh.conf due to 'No such file or directory'.
Configuration file[/etc/frr/frr.conf] processing failure: 11

Hello, this is FRRouting (version 10.1-dev-my-manual-build).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

r1# show ip route nexthop
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

S>r 10.0.0.0/24 [1/0] (6) via 192.168.0.100, ens3, weight 1, 00:00:01
C>* 192.168.0.0/24 (16) is directly connected, ens3, 00:00:02
L>* 192.168.0.1/32 (16) is directly connected, ens3, 00:00:02
r1# show nexthop-group rib
ID: 16 (zebra)
     RefCnt: 4
     Uptime: 00:00:02
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 17 (zebra)
     RefCnt: 2
     Uptime: 00:00:02
     VRF: default
     Valid, Installed
     Interface Index: 2
           is directly connected, ens3 (vrf default)
ID: 6 (zebra)
     RefCnt: 1
     Uptime: 00:00:01
     VRF: default
     Valid, Installed
           via 192.168.0.100, ens3 (vrf default), weight 1
r1# 
+ ip r
192.168.0.0/24 dev ens3 proto kernel scope link src 192.168.0.1 
+ ip nexthop
id 16 dev ens3 scope host proto zebra 
id 17 dev ens3 scope link proto zebra 
```