### PR TITLE
bgpd: Ensure evpn local table display shows route send status

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2561,7 +2561,7 @@ static void evpn_show_route_vni_multicast(struct vty *vty, struct bgp *bgp,
 
 	/* Prefix and num paths displayed once per prefix. */
 	route_vty_out_detail_header(vty, bgp, dest, bgp_dest_get_prefix(dest),
-				    NULL, afi, safi, json, false);
+				    NULL, afi, safi, json, false, true);
 
 	/* Display each path for this prefix. */
 	for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next) {
@@ -2663,7 +2663,7 @@ static void evpn_show_route_vni_macip(struct vty *vty, struct bgp *bgp,
 
 	/* Prefix and num paths displayed once per prefix. */
 	route_vty_out_detail_header(vty, bgp, dest, (struct prefix *)&p, NULL,
-				    afi, safi, json, false);
+				    afi, safi, json, false, true);
 
 	evp = (const struct prefix_evpn *)bgp_dest_get_prefix(dest);
 
@@ -2798,7 +2798,7 @@ static void evpn_show_route_rd_macip(struct vty *vty, struct bgp *bgp,
 
 	/* Prefix and num paths displayed once per prefix. */
 	route_vty_out_detail_header(vty, bgp, dest, bgp_dest_get_prefix(dest),
-				    prd, afi, safi, json, false);
+				    prd, afi, safi, json, false, false);
 
 	if (json)
 		json_paths = json_object_new_array();
@@ -2905,9 +2905,10 @@ static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
 			}
 
 			/* Prefix and num paths displayed once per prefix. */
-			route_vty_out_detail_header(
-				vty, bgp, dest, bgp_dest_get_prefix(dest), prd,
-				afi, safi, json_prefix, false);
+			route_vty_out_detail_header(vty, bgp, dest,
+						    bgp_dest_get_prefix(dest),
+						    prd, afi, safi, json_prefix,
+						    false, false);
 
 			prefix_cnt++;
 		}
@@ -3042,9 +3043,10 @@ static void evpn_show_route_rd_all_macip(struct vty *vty, struct bgp *bgp,
 					    p->prefixlen);
 		} else
 			/* Prefix and num paths displayed once per prefix. */
-			route_vty_out_detail_header(
-				vty, bgp, dest, p, (struct prefix_rd *)rd_destp,
-				AFI_L2VPN, SAFI_EVPN, json_prefix, false);
+			route_vty_out_detail_header(vty, bgp, dest, p,
+						    (struct prefix_rd *)rd_destp,
+						    AFI_L2VPN, SAFI_EVPN,
+						    json_prefix, false, false);
 
 		/* For EVPN, the prefix is displayed for each path (to
 		 * fit in with code that already exists).
@@ -3197,11 +3199,14 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 
 			/* Prefix and num paths displayed once per prefix. */
 			if (detail)
-				route_vty_out_detail_header(
-					vty, bgp, dest,
-					bgp_dest_get_prefix(dest),
-					(struct prefix_rd *)rd_destp, AFI_L2VPN,
-					SAFI_EVPN, json_prefix, false);
+				route_vty_out_detail_header(vty, bgp, dest,
+							    bgp_dest_get_prefix(
+								    dest),
+							    (struct prefix_rd *)
+								    rd_destp,
+							    AFI_L2VPN, SAFI_EVPN,
+							    json_prefix, false,
+							    false);
 
 			/* For EVPN, the prefix is displayed for each path (to
 			 * fit in

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -903,7 +903,8 @@ extern void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 					const struct prefix *p,
 					const struct prefix_rd *prd, afi_t afi,
 					safi_t safi, json_object *json,
-					bool incremental_print);
+					bool incremental_print,
+					bool local_table);
 extern void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 				 struct bgp_dest *bn, const struct prefix *p,
 				 struct bgp_path_info *path, afi_t afi,


### PR DESCRIPTION
evpn has a concept of `local` tables where the evpn routes are actually converted into underlying routes/neighbor table entries( or vice versa ).  Then this local route is propagated to the global evpn l2vpn table and sent to the peers.  Certain show commands in evpn look
operate on the local table but make the output look like the data has not been sent to the peer.  This is confusing for the operator.  Modify the code
such that local tables get a `Local BGP table not advertised` in the place where the code talks about whom has received the data or not.

Example:
torm11# show bgp l2vpn evpn route vni 1000 mac 8a:a1:cc:73:a3:ac ip 45.0.0.5 BGP routing table entry for [2]:[0]:[48]:[8a:a1:cc:73:a3:ac]:[32]:[45.0.0.5] Paths: (2 available, best #2)
  Local BGP table not advertised
  Route [2]:[0]:[48]:[8a:a1:cc:73:a3:ac]:[32]:[45.0.0.5] VNI 1000
  Imported from 192.168.100.18:2:[2]:[0]:[48]:[8a:a1:cc:73:a3:ac]:[32]:[45.0.0.5], VNI 1000
  65101 65005
    192.168.100.18(leaf2) from leaf2(192.168.5.1) (192.168.100.14)
      Origin IGP, valid, external
      Extended Community: RT:65005:1000 ET:8
      Last update: Thu Mar 21 14:29:04 2024
  Route [2]:[0]:[48]:[8a:a1:cc:73:a3:ac]:[32]:[45.0.0.5] VNI 1000
  Imported from 192.168.100.18:2:[2]:[0]:[48]:[8a:a1:cc:73:a3:ac]:[32]:[45.0.0.5], VNI 1000
  65101 65005
    192.168.100.18(leaf1) from leaf1(192.168.1.1) (192.168.100.13)
      Origin IGP, valid, external, bestpath-from-AS 65101, best (Router ID)
      Extended Community: RT:65005:1000 ET:8
      Last update: Thu Mar 21 14:29:04 2024