### PR TITLE
zebra: bridge flap handle vlan membership update

### DIFF
--- a/zebra/zebra_evpn_mh.h
+++ b/zebra/zebra_evpn_mh.h
@@ -378,7 +378,8 @@ extern void zebra_evpn_es_bypass_update(struct zebra_evpn_es *es,
 extern void zebra_evpn_proc_remote_nh(ZAPI_HANDLER_ARGS);
 extern struct zebra_evpn_es_evi *
 zebra_evpn_es_evi_find(struct zebra_evpn_es *es, struct zebra_evpn *zevpn);
-
+extern int zebra_evpn_vl_vxl_bridge_lookup(uint16_t vid,
+					   struct zebra_if *vxlan_zif);
 void zebra_build_type3_esi(uint32_t lid, struct ethaddr *mac, esi_t *esi);
 
 void zebra_evpn_es_sys_mac_update(struct zebra_if *zif, struct ethaddr *sysmac);

--- a/zebra/zebra_l2.c
+++ b/zebra/zebra_l2.c
@@ -384,7 +384,7 @@ void zebra_l2_vxlanif_update_access_vlan(struct interface *ifp,
 		return;
 
 	old_access_vlan = zif->l2info.vxl.vni_info.vni.access_vlan;
-	;
+
 	if (old_access_vlan == access_vlan)
 		return;
 

--- a/zebra/zebra_vxlan_if.c
+++ b/zebra/zebra_vxlan_if.c
@@ -506,7 +506,7 @@ static int zebra_vxlan_if_add_update_vni(struct zebra_if *zif,
 	if ((hashcount(ctx->old_vni_table) == 0) ||
 	    !(old_vni = hash_release(ctx->old_vni_table, &vni_tmp))) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug("vxlan %s adding vni(%d, %d)",
+			zlog_debug("%s vxlan %s adding vni(%d, %d)", __func__,
 				   zif->ifp->name, vni->vni, vni->access_vlan);
 
 		zebra_vxlan_if_vni_entry_add(zif, &vni_tmp);
@@ -521,17 +521,39 @@ static int zebra_vxlan_if_add_update_vni(struct zebra_if *zif,
 
 	if (old_vni->access_vlan != vni->access_vlan) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"vxlan %s updating vni(%d, %d) -> vni(%d, %d)",
-				zif->ifp->name, old_vni->vni,
-				old_vni->access_vlan, vni->vni,
-				vni->access_vlan);
+			zlog_debug("%s vxlan %s updating vni(%d, %d) -> vni(%d, %d)",
+				   __func__, zif->ifp->name, old_vni->vni,
+				   old_vni->access_vlan, vni->vni,
+				   vni->access_vlan);
 
 		zebra_evpn_vl_vxl_deref(old_vni->access_vlan, old_vni->vni,
 					zif);
 		zebra_evpn_vl_vxl_ref(vni->access_vlan, vni->vni, zif);
 		zebra_vxlan_if_update_vni(zif->ifp, vni, ctx);
 		zebra_vxlan_vni_free(old_vni);
+	} else {
+		int ret;
+
+		ret = zebra_evpn_vl_vxl_bridge_lookup(vni->access_vlan, zif);
+		/* Here ret value 0 implied bridge vlan mapping is not present
+		 * repopulated. Ignore ret value 1 as it means vlan mapping is
+		 * present in bridge table.
+		 */
+		if (ret < 0) {
+			if (IS_ZEBRA_DEBUG_VXLAN)
+				zlog_debug("%s vxlan %s vni %u has error accessing bridge table.",
+					   __func__, zif->ifp->name, vni->vni);
+		} else if (ret == 0) {
+			if (IS_ZEBRA_DEBUG_VXLAN)
+				zlog_debug("%s vxlan %s vni (%u, %u) not present in bridge table",
+					   __func__, zif->ifp->name, vni->vni,
+					   vni->access_vlan);
+			zebra_evpn_vl_vxl_deref(old_vni->access_vlan,
+						old_vni->vni, zif);
+			zebra_evpn_vl_vxl_ref(vni->access_vlan, vni->vni, zif);
+			zebra_vxlan_if_update_vni(zif->ifp, vni, ctx);
+			zebra_vxlan_vni_free(old_vni);
+		}
 	}
 
 	return 0;
@@ -768,6 +790,7 @@ vni_t zebra_vxlan_if_access_vlan_vni_find(struct zebra_if *zif,
 	return vni->vni;
 }
 
+/* SVD VLAN-VNI mapping update */
 int zebra_vxlan_if_vni_table_add_update(struct interface *ifp,
 					struct hash *vni_table)
 {


### PR DESCRIPTION
Upon bridge flap, the associated SVD case, VLAN membership is not updated correctly.
When SVI comes up, the VNI could not associate with it as bridge VLAN membership was not updated.

Testing:

Before fix:
-----------
```
tor-1:#ifdown br_l3vni ; sleep 1 ; ifup br_l3vni
tor-1:# vtysh -c 'show evpn vni 8888'
VNI: 8888
  Type: L3
  Tenant VRF: sym_1
  Vlan: 490
  Bridge: br_l3vni
  Local Vtep Ip: 27.0.0.9
  Vxlan-Intf: vxlan99
  SVI-If: None    <<<<<< SVI not found
  State: Down     <<<<<< status remained in down BGP is not informed
  VNI Filter: none
  System MAC: None
  Router MAC: None
  L2 VNIs: 1800 1801 1900 1901
```

After fix:
----------

```
tor-1:# ifdown br_l3vni; sleep 1; ifup br_l3vni
tor-1:# vtysh

Hello, this is FRRouting (version 8.4.3).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

tor-1# show evpn vni 8888
VNI: 8888
  Type: L3
  Tenant VRF: sym_1
  Vlan: 490
  Bridge: br_l3vni
  Local Vtep Ip: 27.0.0.9
  Vxlan-Intf: vxlan99
  SVI-If: vlan490_l3 <<<<<<
  State: Up          <<<<<<
  VNI Filter: none
  System MAC: 44:38:39:ff:ff:29
  Router MAC: 44:38:39:ff:ff:29
  L2 VNIs: 1800 1801 1900 1901
  ```
  
  Signed-off-by: Chirag Shah <chirag@nvidia.com>