### PR TITLE
bgpd: Convert the bgp_advertise_attr->adv to a fifo (backport #14554)

### DIFF
--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -11,26 +11,19 @@
 PREDECL_DLIST(bgp_adv_fifo);
 
 struct update_subgroup;
+struct bgp_advertise;
+
+PREDECL_DLIST(bgp_advertise_attr_fifo);
+
+struct bgp_advertise_attr;
 
 /* BGP advertise attribute.  */
-struct bgp_advertise_attr {
-	/* Head of advertisement pointer. */
-	struct bgp_advertise *adv;
-
-	/* Reference counter.  */
-	unsigned long refcnt;
-
-	/* Attribute pointer to be announced.  */
-	struct attr *attr;
-};
-
 struct bgp_advertise {
 	/* FIFO for advertisement.  */
 	struct bgp_adv_fifo_item fifo;
 
-	/* Link list for same attribute advertise.  */
-	struct bgp_advertise *next;
-	struct bgp_advertise *prev;
+	/* FIFO for this item in the bgp_advertise_attr fifo */
+	struct bgp_advertise_attr_fifo_item item;
 
 	/* Prefix information.  */
 	struct bgp_dest *dest;
@@ -45,7 +38,20 @@ struct bgp_advertise {
 	struct bgp_path_info *pathi;
 };
 
+DECLARE_DLIST(bgp_advertise_attr_fifo, struct bgp_advertise, item);
 DECLARE_DLIST(bgp_adv_fifo, struct bgp_advertise, fifo);
+
+/* BGP advertise attribute.  */
+struct bgp_advertise_attr {
+	/* Head of advertisement pointer. */
+	struct bgp_advertise_attr_fifo_head fifo;
+
+	/* Reference counter.  */
+	unsigned long refcnt;
+
+	/* Attribute pointer to be announced.  */
+	struct attr *attr;
+};
 
 /* BGP adjacency out.  */
 struct bgp_adj_out {

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -426,7 +426,7 @@ bgp_advertise_clean_subgroup(struct update_subgroup *subgrp,
 		bgp_advertise_delete(baa, adv);
 
 		/* Fetch next advertise candidate. */
-		next = baa->adv;
+		next = bgp_advertise_attr_fifo_first(&baa->fifo);
 
 		/* Unintern BGP advertise attribute.  */
 		bgp_advertise_attr_unintern(subgrp->hash, baa);


### PR DESCRIPTION
This is a backport to stable/9.0 of #14554 ; the mergify backport had merge conflicts, so I've closed that version in favor of this one.