### PR TITLE
bgpd : backpressure - Handle BGP-Zebra(EPVN) Install evt Creation

### DIFF
--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -186,4 +186,12 @@ extern bool is_route_injectable_into_evpn_non_supp(struct bgp_path_info *pi);
 extern void bgp_aggr_supp_withdraw_from_evpn(struct bgp *bgp, afi_t afi,
 					     safi_t safi);
 
+extern enum zclient_send_status evpn_zebra_install(struct bgp *bgp,
+						   struct bgpevpn *vpn,
+						   const struct prefix_evpn *p,
+						   struct bgp_path_info *pi);
+extern enum zclient_send_status
+evpn_zebra_uninstall(struct bgp *bgp, struct bgpevpn *vpn,
+		     const struct prefix_evpn *p, struct bgp_path_info *pi,
+		     bool is_sync);
 #endif /* _QUAGGA_BGP_EVPN_H */

--- a/bgpd/bgp_evpn_mh.h
+++ b/bgpd/bgp_evpn_mh.h
@@ -418,10 +418,12 @@ extern int bgp_evpn_local_es_add(struct bgp *bgp, esi_t *esi,
 extern int bgp_evpn_local_es_del(struct bgp *bgp, esi_t *esi);
 extern int bgp_evpn_local_es_evi_add(struct bgp *bgp, esi_t *esi, vni_t vni);
 extern int bgp_evpn_local_es_evi_del(struct bgp *bgp, esi_t *esi, vni_t vni);
-extern int bgp_evpn_remote_es_evi_add(struct bgp *bgp, struct bgpevpn *vpn,
-		const struct prefix_evpn *p);
-extern int bgp_evpn_remote_es_evi_del(struct bgp *bgp, struct bgpevpn *vpn,
-		const struct prefix_evpn *p);
+extern enum zclient_send_status
+bgp_evpn_remote_es_evi_add(struct bgp *bgp, struct bgpevpn *vpn,
+			   const struct prefix_evpn *p);
+extern enum zclient_send_status
+bgp_evpn_remote_es_evi_del(struct bgp *bgp, struct bgpevpn *vpn,
+			   const struct prefix_evpn *p);
 extern void bgp_evpn_mh_init(void);
 extern void bgp_evpn_mh_finish(void);
 void bgp_evpn_vni_es_init(struct bgpevpn *vpn);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3402,9 +3402,9 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 				    && (new_select->sub_type == BGP_ROUTE_NORMAL
 					|| new_select->sub_type
 						   == BGP_ROUTE_IMPORTED))
-
 					bgp_zebra_route_install(dest, old_select,
-								bgp, true);
+								bgp, true, NULL,
+								false);
 			}
 		}
 
@@ -3522,9 +3522,10 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 			if (old_select &&
 			    is_route_parent_evpn(old_select))
 				bgp_zebra_route_install(dest, old_select, bgp,
-							false);
+							false, NULL, false);
 
-			bgp_zebra_route_install(dest, new_select, bgp, true);
+			bgp_zebra_route_install(dest, new_select, bgp, true,
+						NULL, false);
 		} else {
 			/* Withdraw the route from the kernel. */
 			if (old_select && old_select->type == ZEBRA_ROUTE_BGP
@@ -3533,7 +3534,7 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 				|| old_select->sub_type == BGP_ROUTE_IMPORTED))
 
 				bgp_zebra_route_install(dest, old_select, bgp,
-							false);
+							false, NULL, false);
 		}
 	}
 
@@ -4430,7 +4431,8 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	if (pi && pi->attr->rmap_table_id != new_attr.rmap_table_id) {
 		if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
 			/* remove from RIB previous entry */
-			bgp_zebra_route_install(dest, pi, bgp, false);
+			bgp_zebra_route_install(dest, pi, bgp, false, NULL,
+						false);
 	}
 
 	if (peer->sort == BGP_PEER_EBGP) {

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -78,6 +78,8 @@ struct bgp_dest {
 
 	struct zebra_announce_item zai;
 	struct bgp_path_info *za_bgp_pi;
+	struct bgpevpn *za_vpn;
+	bool za_is_sync;
 
 	uint64_t version;
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1687,12 +1687,11 @@ void bgp_zebra_announce_table(struct bgp *bgp, afi_t afi, safi_t safi)
 	for (dest = bgp_table_top(table); dest; dest = bgp_route_next(dest))
 		for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next)
 			if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED) &&
-
 			    (pi->type == ZEBRA_ROUTE_BGP
 			     && (pi->sub_type == BGP_ROUTE_NORMAL
 				 || pi->sub_type == BGP_ROUTE_IMPORTED)))
-
-				bgp_zebra_route_install(dest, pi, bgp, true);
+				bgp_zebra_route_install(dest, pi, bgp, true,
+							NULL, false);
 }
 
 /* Announce routes of any bgp subtype of a table to zebra */
@@ -1714,7 +1713,8 @@ void bgp_zebra_announce_table_all_subtypes(struct bgp *bgp, afi_t afi,
 		for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next)
 			if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED) &&
 			    pi->type == ZEBRA_ROUTE_BGP)
-				bgp_zebra_route_install(dest, pi, bgp, true);
+				bgp_zebra_route_install(dest, pi, bgp, true,
+							NULL, false);
 }
 
 enum zclient_send_status bgp_zebra_withdraw_actual(struct bgp_dest *dest,
@@ -1767,6 +1767,7 @@ enum zclient_send_status bgp_zebra_withdraw_actual(struct bgp_dest *dest,
 #define ZEBRA_ANNOUNCEMENTS_LIMIT 1000
 static void bgp_handle_route_announcements_to_zebra(struct event *e)
 {
+	bool is_evpn = false;
 	uint32_t count = 0;
 	struct bgp_dest *dest = NULL;
 	struct bgp_table *table = NULL;
@@ -1781,6 +1782,8 @@ static void bgp_handle_route_announcements_to_zebra(struct event *e)
 
 		table = bgp_dest_table(dest);
 		install = CHECK_FLAG(dest->flags, BGP_NODE_SCHEDULE_FOR_INSTALL);
+		if (table && table->afi == AFI_L2VPN && table->safi == SAFI_EVPN)
+			is_evpn = true;
 
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("BGP %s route %pBD(%s) with dest %p and flags 0x%x to zebra",
@@ -1788,17 +1791,38 @@ static void bgp_handle_route_announcements_to_zebra(struct event *e)
 				   table->bgp->name_pretty, dest, dest->flags);
 
 		if (install) {
-			status = bgp_zebra_announce_actual(dest, dest->za_bgp_pi,
-							   table->bgp);
+			if (is_evpn)
+				status =
+					evpn_zebra_install(table->bgp,
+							   dest->za_vpn,
+							   (const struct prefix_evpn
+								    *)
+								   bgp_dest_get_prefix(
+									   dest),
+							   dest->za_bgp_pi);
+			else
+				status = bgp_zebra_announce_actual(dest,
+								   dest->za_bgp_pi,
+								   table->bgp);
 			UNSET_FLAG(dest->flags, BGP_NODE_SCHEDULE_FOR_INSTALL);
 		} else {
-			status = bgp_zebra_withdraw_actual(dest, dest->za_bgp_pi,
-							   table->bgp);
+			if (is_evpn)
+				status = evpn_zebra_uninstall(
+					table->bgp, dest->za_vpn,
+					(const struct prefix_evpn *)
+						bgp_dest_get_prefix(dest),
+					dest->za_bgp_pi, false);
+			else
+				status = bgp_zebra_withdraw_actual(dest,
+								   dest->za_bgp_pi,
+								   table->bgp);
+
 			UNSET_FLAG(dest->flags, BGP_NODE_SCHEDULE_FOR_DELETE);
 		}
 
 		bgp_path_info_unlock(dest->za_bgp_pi);
 		dest->za_bgp_pi = NULL;
+		dest->za_vpn = NULL;
 		bgp_dest_unlock_node(dest);
 
 		if (status == ZCLIENT_SEND_BUFFERED)
@@ -1852,8 +1876,16 @@ static void bgp_zebra_buffer_write_ready(void)
  *                                     withdrawn.
  */
 void bgp_zebra_route_install(struct bgp_dest *dest, struct bgp_path_info *info,
-			     struct bgp *bgp, bool install)
+			     struct bgp *bgp, bool install, struct bgpevpn *vpn,
+			     bool is_sync)
 {
+	bool is_evpn = false;
+	struct bgp_table *table = NULL;
+
+	table = bgp_dest_table(dest);
+	if (table && table->afi == AFI_L2VPN && table->safi == SAFI_EVPN)
+		is_evpn = true;
+
 	/*
 	 * BGP is installing this route and bgp has been configured
 	 * to suppress announcements until the route has been installed
@@ -1863,7 +1895,7 @@ void bgp_zebra_route_install(struct bgp_dest *dest, struct bgp_path_info *info,
 		if (BGP_SUPPRESS_FIB_ENABLED(bgp))
 			SET_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING);
 
-		if (bgp->main_zebra_update_hold)
+		if (bgp->main_zebra_update_hold && !is_evpn)
 			return;
 	} else {
 		UNSET_FLAG(dest->flags, BGP_NODE_FIB_INSTALL_PENDING);
@@ -1873,7 +1905,7 @@ void bgp_zebra_route_install(struct bgp_dest *dest, struct bgp_path_info *info,
 	 * Don't try to install if we're not connected to Zebra or Zebra doesn't
 	 * know of this instance.
 	 */
-	if (!bgp_install_info_to_zebra(bgp))
+	if (!bgp_install_info_to_zebra(bgp) && !is_evpn)
 		return;
 
 	if (!CHECK_FLAG(dest->flags, BGP_NODE_SCHEDULE_FOR_INSTALL) &&
@@ -1893,12 +1925,17 @@ void bgp_zebra_route_install(struct bgp_dest *dest, struct bgp_path_info *info,
 		dest->za_bgp_pi = info;
 	} else if (CHECK_FLAG(dest->flags, BGP_NODE_SCHEDULE_FOR_DELETE)) {
 		assert(dest->za_bgp_pi);
-		if (install)
+		if (install & !is_evpn)
 			bgp_zebra_withdraw_actual(dest, dest->za_bgp_pi, bgp);
 
 		bgp_path_info_unlock(dest->za_bgp_pi);
 		bgp_path_info_lock(info);
 		dest->za_bgp_pi = info;
+	}
+
+	if (is_evpn) {
+		dest->za_vpn = vpn;
+		dest->za_is_sync = is_sync;
 	}
 
 	if (install) {
@@ -1931,7 +1968,8 @@ void bgp_zebra_withdraw_table_all_subtypes(struct bgp *bgp, afi_t afi, safi_t sa
 		for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next) {
 			if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED)
 			    && (pi->type == ZEBRA_ROUTE_BGP))
-				bgp_zebra_route_install(dest, pi, bgp, false);
+				bgp_zebra_route_install(dest, pi, bgp, false,
+							NULL, false);
 		}
 	}
 }

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -30,7 +30,8 @@ extern int bgp_zebra_get_table_range(struct zclient *zc, uint32_t chunk_size,
 extern int bgp_if_update_all(void);
 extern void bgp_zebra_route_install(struct bgp_dest *dest,
 				    struct bgp_path_info *path, struct bgp *bgp,
-				    bool install);
+				    bool install, struct bgpevpn *vpn,
+				    bool is_sync);
 extern void bgp_zebra_announce_table(struct bgp *bgp, afi_t afi, safi_t safi);
 
 /* Announce routes of any bgp subtype of a table to zebra */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -530,6 +530,7 @@ struct bgp {
 #define BGP_FLAG_SOFT_VERSION_CAPABILITY (1ULL << 35)
 #define BGP_FLAG_ENFORCE_FIRST_AS (1ULL << 36)
 #define BGP_FLAG_DYNAMIC_CAPABILITY (1ULL << 37)
+#define BGP_FLAG_VNI_DOWN		 (1ULL << 38)
 
 	/* BGP default address-families.
 	 * New peers inherit enabled afi/safis from bgp instance.


### PR DESCRIPTION
Current changes deals with EVPN routes installation to zebra.

In evpn_route_select_install() we invoke evpn_zebra_install/uninstall which sends zclient_send_message().

This is a continuation of code changes (similar to ccfe452763d16c432fa81fd20e805bec819b345e) but to handle evpn part of the code.

Ticket: #3390099

Related MRs:
Backpressure server code changes: https://github.com/FRRouting/frr/pull/15411 (Merged)
Backpressure Non EVPN client(BGP) code changes : https://github.com/FRRouting/frr/pull/15524 (Merged)