### PR TITLE
ospf6d: Fix metric when sending AS-external LSAs

### DIFF
--- a/ospf6d/ospf6_abr.h
+++ b/ospf6d/ospf6_abr.h
@@ -33,11 +33,12 @@ struct ospf6_inter_router_lsa {
 	uint32_t router_id;
 };
 
-#define OSPF6_ABR_SUMMARY_METRIC(E) (ntohl ((E)->metric & htonl (0x00ffffff)))
+#define OSPF6_ABR_SUMMARY_METRIC(E)                                            \
+	(ntohl((E)->metric & htonl(OSPF6_EXT_PATH_METRIC_MAX)))
 #define OSPF6_ABR_SUMMARY_METRIC_SET(E, C)                                     \
 	{                                                                      \
 		(E)->metric &= htonl(0x00000000);                              \
-		(E)->metric |= htonl(0x00ffffff) & htonl(C);                   \
+		(E)->metric |= htonl(OSPF6_EXT_PATH_METRIC_MAX) & htonl(C);    \
 	}
 
 #define OSPF6_ABR_RANGE_CLEAR_COST(range) (range->path.cost = OSPF_AREA_RANGE_COST_UNSPEC)

--- a/ospf6d/ospf6_asbr.h
+++ b/ospf6d/ospf6_asbr.h
@@ -94,11 +94,13 @@ struct ospf6_as_external_lsa {
 #define OSPF6_ASBR_BIT_F  ntohl (0x02000000)
 #define OSPF6_ASBR_BIT_E  ntohl (0x04000000)
 
-#define OSPF6_ASBR_METRIC(E) (ntohl ((E)->bits_metric & htonl (0x00ffffff)))
+#define OSPF6_ASBR_METRIC(E)                                                   \
+	(ntohl((E)->bits_metric & htonl(OSPF6_EXT_PATH_METRIC_MAX)))
 #define OSPF6_ASBR_METRIC_SET(E, C)                                            \
 	{                                                                      \
-		(E)->bits_metric &= htonl(0xff000000);                         \
-		(E)->bits_metric |= htonl(0x00ffffff) & htonl(C);              \
+		(E)->bits_metric &= htonl(~OSPF6_EXT_PATH_METRIC_MAX);         \
+		(E)->bits_metric |= htonl(OSPF6_EXT_PATH_METRIC_MAX) &         \
+				    htonl(C);                                  \
 	}
 
 extern void ospf6_asbr_lsa_add(struct ospf6_lsa *lsa);
@@ -115,7 +117,8 @@ extern void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 					struct prefix *prefix,
 					unsigned int nexthop_num,
 					const struct in6_addr *nexthop,
-					route_tag_t tag, struct ospf6 *ospf6);
+					route_tag_t tag, struct ospf6 *ospf6,
+					uint32_t metric);
 extern void ospf6_asbr_redistribute_remove(int type, ifindex_t ifindex,
 					   struct prefix *prefix,
 					   struct ospf6 *ospf6);

--- a/ospf6d/ospf6_route.h
+++ b/ospf6d/ospf6_route.h
@@ -115,6 +115,7 @@ struct ospf6_path {
 	/* Cost */
 	uint8_t metric_type;
 	uint32_t cost;
+	uint32_t redistribute_cost;
 
 	struct prefix ls_prefix;
 
@@ -138,6 +139,8 @@ struct ospf6_path {
 #define OSPF6_PATH_SUBTYPE_DEFAULT_RT   1
 
 #define OSPF6_PATH_COST_IS_CONFIGURED(path) (path.u.cost_config != OSPF_AREA_RANGE_COST_UNSPEC)
+
+#define OSPF6_EXT_PATH_METRIC_MAX 0x00ffffff
 
 #include "prefix.h"
 #include "table.h"

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -289,7 +289,7 @@ static int ospf6_zebra_read_route(ZAPI_CALLBACK_ARGS)
 	if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD)
 		ospf6_asbr_redistribute_add(api.type, ifindex, &api.prefix,
 					    api.nexthop_num, nexthop, api.tag,
-					    ospf6);
+					    ospf6, api.metric);
 	else
 		ospf6_asbr_redistribute_remove(api.type, ifindex, &api.prefix,
 					       ospf6);


### PR DESCRIPTION
When ospf6d originates an AS-external route that has been read from a kernel routing table, then the metric of that route was ignored until now. In my case all of these routes were announced with metric 1 in LS-updates.

Now the metric of the kernel route is added to whatever metric ospf6d already computed originally.