### PR TITLE
topotests: fix ignore routes with linkdown

### DIFF
--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1296,6 +1296,8 @@ def fix_netns_limits(ns):
 
     sysctl_assure(ns, "net.ipv4.conf.all.ignore_routes_with_linkdown", 1)
     sysctl_assure(ns, "net.ipv6.conf.all.ignore_routes_with_linkdown", 1)
+    sysctl_assure(ns, "net.ipv4.conf.default.ignore_routes_with_linkdown", 1)
+    sysctl_assure(ns, "net.ipv6.conf.default.ignore_routes_with_linkdown", 1)
 
     # igmp
     sysctl_atleast(ns, "net.ipv4.igmp_max_memberships", 1000)


### PR DESCRIPTION
In topotest, a given interface has only the ignore routes bit turned on for IPv6 only, whereas topotest is expected to turn it on for all address families.

> # show interface
> Interface r2-r3-eth2 is up, line protocol is up
> [..]
>  flags: <UP,BROADCAST,RUNNING,MULTICAST>
>  Ignore all v6 routes with linkdown
>  Type: Ethernet
>  [..]

This is because the only the 'default' ipv6 ignore sysctl is set to
1. Use the /proc/sys/net/conf/<family>/default/ignore_routes_with_linkdown flag instead, to have same behaviour for ipv4 and ipv6.

Fixes: 4958158787ce ("tests: micronet: update infra")