### PR TITLE
bgpd: add resolved_prefix visibility on nht

### DIFF
--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -1003,6 +1003,8 @@ static void bgp_show_nexthop(struct vty *vty, struct bgp *bgp,
 			if (bnc->is_evpn_gwip_nexthop)
 				json_object_boolean_true_add(json_nexthop,
 							     "isEvpnGatewayIp");
+			json_object_string_addf(json, "resolvedPrefix", "%pFX",
+						&bnc->resolved_prefix);
 		} else {
 			vty_out(vty, " %s valid [IGP metric %d], #paths %d",
 				buf, bnc->metric, bnc->path_count);
@@ -1010,6 +1012,8 @@ static void bgp_show_nexthop(struct vty *vty, struct bgp *bgp,
 				vty_out(vty, ", peer %s", peer->host);
 			if (bnc->is_evpn_gwip_nexthop)
 				vty_out(vty, " EVPN Gateway IP");
+			vty_out(vty, "\n  Resolved prefix %pFX",
+				&bnc->resolved_prefix);
 			vty_out(vty, "\n");
 		}
 		bgp_show_nexthops_detail(vty, bgp, bnc, json_nexthop);

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -90,6 +90,7 @@ struct bgp_nexthop_cache {
 	struct bgp_nexthop_cache_head *tree;
 
 	struct prefix prefix;
+	struct prefix resolved_prefix;
 	void *nht_info; /* In BGP, peer session */
 	LIST_HEAD(path_list, bgp_path_info) paths;
 	unsigned int path_count;

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -626,6 +626,8 @@ static void bgp_process_nexthop_update(struct bgp_nexthop_cache *bnc,
 	} else if (nhr->nexthop_num) {
 		struct peer *peer = bnc->nht_info;
 
+		prefix_copy(&bnc->resolved_prefix, &nhr->prefix);
+
 		/* notify bgp fsm if nbr ip goes from invalid->valid */
 		if (!bnc->nexthop_num)
 			UNSET_FLAG(bnc->flags, BGP_NEXTHOP_PEER_NOTIFIED);
@@ -731,6 +733,7 @@ static void bgp_process_nexthop_update(struct bgp_nexthop_cache *bnc,
 			}
 		}
 	} else {
+		memset(&bnc->resolved_prefix, 0, sizeof(bnc->resolved_prefix));
 		bnc->flags &= ~BGP_NEXTHOP_EVPN_INCOMPLETE;
 		bnc->flags &= ~BGP_NEXTHOP_VALID;
 		bnc->flags &= ~BGP_NEXTHOP_LABELED_VALID;


### PR DESCRIPTION
The nexthop tracking never displays the prefix that has been used in ZEBRA to resolve its nexthop. This information will be useful if some decision has to be taken regarding any loops, that is to say if for instance a BGP prefix is resolved over a prefix in ZEBRA that is exactly the same.

Store the value in bgp nexthop context, and display it.