### PR TITLE
tests: add topotest for PG remote-as add del

### DIFF
--- a/tests/topotests/bgp_peer_group/r1/bgpd.conf
+++ b/tests/topotests/bgp_peer_group/r1/bgpd.conf
@@ -5,4 +5,8 @@ router bgp 65001
   neighbor PG timers 3 10
   neighbor 192.168.255.3 peer-group PG
   neighbor r1-eth0 interface peer-group PG
+  neighbor PG1 peer-group
+  neighbor PG1 remote-as external
+  neighbor PG1 timers 3 20
+  neighbor 192.168.251.2 peer-group PG1
 !

--- a/tests/topotests/bgp_peer_group/r1/zebra.conf
+++ b/tests/topotests/bgp_peer_group/r1/zebra.conf
@@ -2,5 +2,8 @@
 interface r1-eth0
  ip address 192.168.255.1/24
 !
+interface r1-eth1
+ ip address 192.168.251.1/30
+!
 ip forwarding
 !

--- a/tests/topotests/bgp_peer_group/r2/bgpd.conf
+++ b/tests/topotests/bgp_peer_group/r2/bgpd.conf
@@ -4,4 +4,8 @@ router bgp 65002
   neighbor PG remote-as external
   neighbor PG timers 3 10
   neighbor r2-eth0 interface peer-group PG
+  neighbor PG1 peer-group
+  neighbor PG1 remote-as external
+  neighbor PG1 timers 3 20
+  neighbor 192.168.251.1 peer-group PG1
 !

--- a/tests/topotests/bgp_peer_group/r2/zebra.conf
+++ b/tests/topotests/bgp_peer_group/r2/zebra.conf
@@ -2,5 +2,8 @@
 interface r2-eth0
  ip address 192.168.255.2/24
 !
+interface r2-eth1
+ ip address 192.168.251.2/30
+!
 ip forwarding
 !

--- a/tests/topotests/bgp_peer_group/test_bgp_peer-group.py
+++ b/tests/topotests/bgp_peer_group/test_bgp_peer-group.py
@@ -22,7 +22,7 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
-
+from lib.topolog import logger
 
 pytestmark = [pytest.mark.bgpd]
 
@@ -35,6 +35,10 @@ def build_topo(tgen):
     switch.add_link(tgen.gears["r1"])
     switch.add_link(tgen.gears["r2"])
     switch.add_link(tgen.gears["r3"])
+
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
 
 
 def setup_module(mod):
@@ -70,6 +74,7 @@ def test_bgp_peer_group():
         expected = {
             "r1-eth0": {"peerGroup": "PG", "bgpState": "Established"},
             "192.168.255.3": {"peerGroup": "PG", "bgpState": "Established"},
+            "192.168.251.2": {"peerGroup": "PG1", "bgpState": "Established"},
         }
         return topotest.json_cmp(output, expected)
 
@@ -94,6 +99,48 @@ def test_bgp_peer_group():
     test_func = functools.partial(_bgp_peer_group_check_advertised_routes)
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, "Failed checking advertised routes from r3"
+
+
+def test_bgp_peer_group_remote_as_del_readd():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    logger.info("Remove bgp peer-group PG1 remote-as neighbor should be retained")
+    r1.cmd(
+        'vtysh -c "config t" -c "router bgp 65001" '
+        + ' -c "no neighbor PG1 remote-as external" '
+    )
+
+    def _bgp_peer_group_remoteas_del():
+        output = json.loads(tgen.gears["r1"].vtysh_cmd("show bgp neighbor json"))
+        expected = {
+            "192.168.251.2": {"peerGroup": "PG1", "bgpState": "Active"},
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_peer_group_remoteas_del)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed bgp convergence in r1"
+
+    logger.info("Re-add bgp peer-group PG1 remote-as neighbor should be established")
+    r1.cmd(
+        'vtysh -c "config t" -c "router bgp 65001" '
+        + ' -c "neighbor PG1 remote-as external" '
+    )
+
+    def _bgp_peer_group_remoteas_add():
+        output = json.loads(tgen.gears["r1"].vtysh_cmd("show bgp neighbor json"))
+        expected = {
+            "192.168.251.2": {"peerGroup": "PG1", "bgpState": "Established"},
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_peer_group_remoteas_add)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed bgp convergence in r1"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This topotest covers the PR-15574's coverage where a change is not to delete neighbors when the associated peer-group's remote-as is removed.


Testing:

```
test_bgp_peer-group.py::test_bgp_peer_group

---------------------------------------------------------------------------- live log call ----------------------------------------------------------------------------- 2024-03-29 18:12:22,608 INFO: r1: checking if daemons are running 2024-03-29 18:12:22,802 INFO: r2: checking if daemons are running 2024-03-29 18:12:22,911 INFO: r3: checking if daemons are running 2024-03-29 18:12:23,015 INFO: topo: Remove bgp peer-group PG1 remote-as neighbor should be retained 2024-03-29 18:12:25,605 INFO: topo: Re-add bgp peer-group PG1 remote-as neighbor should be established

----------------------------------------------------------- generated xml file: /tmp/topotests/topotests.xml ----------------------------------------------------------- ========================================================================== 2 passed in 17.63s ==========================================================================
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>
