### PR TITLE
Link state srv6 capas

### DIFF
--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -797,6 +797,12 @@ static struct ls_vertex *lsp_to_vertex(struct ls_ted *ted, struct isis_lsp *lsp)
 				lnode.msd = cap->msd;
 				SET_FLAG(lnode.flags, LS_NODE_MSD);
 			}
+			if (cap->srv6_cap.is_srv6_capable) {
+				SET_FLAG(lnode.flags, LS_NODE_SRV6);
+				lnode.srv6_cap_flags = cap->srv6_cap.flags;
+				memcpy(&lnode.srv6_msd, &cap->srv6_msd,
+				       sizeof(struct isis_srv6_msd));
+			}
 		}
 	}
 

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -488,6 +488,10 @@ void isis_link_params_update(struct isis_circuit *circuit,
 			ext->status = EXT_ADJ_SID;
 		else if (IS_SUBTLV(ext, EXT_LAN_ADJ_SID))
 			ext->status = EXT_LAN_ADJ_SID;
+		else if (IS_SUBTLV(ext, EXT_SRV6_LAN_ENDX_SID))
+			ext->status = EXT_SRV6_LAN_ENDX_SID;
+		else if (IS_SUBTLV(ext, EXT_SRV6_ENDX_SID))
+			ext->status = EXT_SRV6_ENDX_SID;
 		else
 			ext->status = 0;
 	}
@@ -1048,7 +1052,51 @@ static struct ls_attributes *get_attributes(struct ls_node_id adv,
 			}
 		}
 	}
+	if (CHECK_FLAG(tlvs->status, EXT_SRV6_ENDX_SID)) {
+		struct isis_srv6_endx_sid_subtlv *endx =
+			(struct isis_srv6_endx_sid_subtlv *)
+				tlvs->srv6_endx_sid.head;
+		int i;
 
+		for (; endx; endx = endx->next) {
+			if (endx->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_BFLG) {
+				i = 1;
+				SET_FLAG(attr->flags, LS_ATTR_BCK_ADJ_SRV6SID);
+			} else {
+				i = 0;
+				SET_FLAG(attr->flags, LS_ATTR_ADJ_SRV6SID);
+			}
+			attr->adj_srv6_sid[i].flags = endx->flags;
+			attr->adj_srv6_sid[i].weight = endx->weight;
+			memcpy(&attr->adj_srv6_sid[i].sid, &endx->sid,
+			       sizeof(struct in6_addr));
+			attr->adj_srv6_sid[i].endpoint_behavior = endx->behavior;
+		}
+	}
+	if (CHECK_FLAG(tlvs->status, EXT_SRV6_LAN_ENDX_SID)) {
+		struct isis_srv6_lan_endx_sid_subtlv *lendx =
+			(struct isis_srv6_lan_endx_sid_subtlv *)
+				tlvs->srv6_lan_endx_sid.head;
+		int i;
+
+		for (; lendx; lendx = lendx->next) {
+			if (lendx->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_BFLG) {
+				i = 1;
+				SET_FLAG(attr->flags, LS_ATTR_BCK_ADJ_SRV6SID);
+			} else {
+				i = 0;
+				SET_FLAG(attr->flags, LS_ATTR_ADJ_SRV6SID);
+			}
+			memcpy(&attr->adj_srv6_sid[i].neighbor.sysid,
+			       &lendx->neighbor_id, ISIS_SYS_ID_LEN);
+			attr->adj_srv6_sid[i].flags = lendx->flags;
+			attr->adj_srv6_sid[i].weight = lendx->weight;
+			memcpy(&attr->adj_srv6_sid[i].sid, &lendx->sid,
+			       sizeof(struct in6_addr));
+			attr->adj_srv6_sid[i].endpoint_behavior =
+				lendx->behavior;
+		}
+	}
 	return attr;
 }
 

--- a/isisd/isis_te.h
+++ b/isisd/isis_te.h
@@ -69,9 +69,10 @@ typedef enum _status_t { disable, enable, learn } status_t;
 /* Mode for Inter-AS LSP */ /* TODO: Check how if LSP is flooded in RFC5316 */
 typedef enum _interas_mode_t { off, region, as, emulate } interas_mode_t;
 
-#define IS_EXT_TE(e)    (e && e->status != 0			\
-			   && e->status != EXT_ADJ_SID		\
-			   && e->status != EXT_LAN_ADJ_SID)
+#define IS_EXT_TE(e)                                                           \
+	(e && e->status != 0 && e->status != EXT_ADJ_SID &&                    \
+	 e->status != EXT_LAN_ADJ_SID && e->status != EXT_SRV6_ENDX_SID &&     \
+	 e->status != EXT_SRV6_LAN_ENDX_SID)
 #define IS_MPLS_TE(a)	(a && a->status == enable)
 #define IS_EXPORT_TE(a) (a->export)
 

--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -140,6 +140,12 @@ int ls_node_same(struct ls_node *n1, struct ls_node *n2)
 		if (CHECK_FLAG(n1->flags, LS_NODE_MSD) && (n1->msd != n2->msd))
 			return 0;
 	}
+	if (CHECK_FLAG(n1->flags, LS_NODE_SRV6)) {
+		if (n1->srv6_cap_flags != n2->srv6_cap_flags)
+			return 0;
+		if (memcmp(&n1->srv6_msd, &n2->srv6_msd, sizeof(n1->srv6_msd)))
+			return 0;
+	}
 
 	/* OK, n1 & n2 are equal */
 	return 1;

--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -320,6 +320,23 @@ int ls_attributes_same(struct ls_attributes *l1, struct ls_attributes *l2)
 					&l2->adj_sid[i].neighbor.addr)))
 			return 0;
 	}
+	for (int i = 0; i < ADJ_SRV6_MAX; i++) {
+		if (!CHECK_FLAG(l1->flags, (LS_ATTR_ADJ_SRV6SID << i)))
+			continue;
+		if (memcmp(&l1->adj_srv6_sid[i].sid, &l2->adj_srv6_sid[i].sid,
+			   sizeof(struct in6_addr)) ||
+		    (l1->adj_srv6_sid[i].flags != l2->adj_srv6_sid[i].flags) ||
+		    (l1->adj_srv6_sid[i].weight != l2->adj_srv6_sid[i].weight) ||
+		    (l1->adj_srv6_sid[i].endpoint_behavior !=
+		     l2->adj_srv6_sid[i].endpoint_behavior))
+			return 0;
+		if (((l1->adv.origin == ISIS_L1) ||
+		     (l1->adv.origin == ISIS_L2)) &&
+		    (memcmp(&l1->adj_srv6_sid[i].neighbor.sysid,
+			    &l2->adj_srv6_sid[i].neighbor.sysid,
+			    ISO_SYS_ID_LEN) != 0))
+			return 0;
+	}
 	if (CHECK_FLAG(l1->flags, LS_ATTR_SRLG)
 	    && ((l1->srlg_len != l2->srlg_len)
 		|| memcmp(l1->srlgs, l2->srlgs,
@@ -1298,6 +1315,26 @@ static struct ls_attributes *ls_parse_attributes(struct stream *s)
 		STREAM_GET(attr->adj_sid[ADJ_BCK_IPV6].neighbor.sysid, s,
 			   ISO_SYS_ID_LEN);
 	}
+	if (CHECK_FLAG(attr->flags, LS_ATTR_ADJ_SRV6SID)) {
+		STREAM_GET(&attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].sid, s,
+			   sizeof(struct in6_addr));
+		STREAM_GETC(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].flags);
+		STREAM_GETC(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].weight);
+		STREAM_GETW(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6]
+				       .endpoint_behavior);
+		STREAM_GET(attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].neighbor.sysid,
+			   s, ISO_SYS_ID_LEN);
+	}
+	if (CHECK_FLAG(attr->flags, LS_ATTR_BCK_ADJ_SRV6SID)) {
+		STREAM_GET(&attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].sid, s,
+			   sizeof(struct in6_addr));
+		STREAM_GETC(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].flags);
+		STREAM_GETC(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].weight);
+		STREAM_GETW(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6]
+				       .endpoint_behavior);
+		STREAM_GET(attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].neighbor.sysid,
+			   s, ISO_SYS_ID_LEN);
+	}
 	if (CHECK_FLAG(attr->flags, LS_ATTR_SRLG)) {
 		STREAM_GETC(s, len);
 		attr->srlgs = XCALLOC(MTYPE_LS_DB, len*sizeof(uint32_t));
@@ -1530,6 +1567,28 @@ static int ls_format_attributes(struct stream *s, struct ls_attributes *attr)
 		stream_putc(s, attr->adj_sid[ADJ_BCK_IPV6].flags);
 		stream_putc(s, attr->adj_sid[ADJ_BCK_IPV6].weight);
 		stream_put(s, attr->adj_sid[ADJ_BCK_IPV6].neighbor.sysid,
+			   ISO_SYS_ID_LEN);
+	}
+	if (CHECK_FLAG(attr->flags, LS_ATTR_ADJ_SRV6SID)) {
+		stream_put(s, &attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].sid,
+			   sizeof(struct in6_addr));
+		stream_putc(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].flags);
+		stream_putc(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].weight);
+		stream_putw(s, attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6]
+				       .endpoint_behavior);
+		stream_put(s,
+			   attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].neighbor.sysid,
+			   ISO_SYS_ID_LEN);
+	}
+	if (CHECK_FLAG(attr->flags, LS_ATTR_BCK_ADJ_SRV6SID)) {
+		stream_put(s, &attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].sid,
+			   sizeof(struct in6_addr));
+		stream_putc(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].flags);
+		stream_putc(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].weight);
+		stream_putw(s, attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6]
+				       .endpoint_behavior);
+		stream_put(s,
+			   attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].neighbor.sysid,
 			   ISO_SYS_ID_LEN);
 	}
 	if (CHECK_FLAG(attr->flags, LS_ATTR_SRLG)) {
@@ -2351,6 +2410,24 @@ static void ls_show_edge_vty(struct ls_edge *edge, struct vty *vty,
 			  attr->adj_sid[ADJ_BCK_IPV6].flags,
 			  attr->adj_sid[ADJ_BCK_IPV6].weight);
 	}
+	if (CHECK_FLAG(attr->flags, LS_ATTR_ADJ_SRV6SID)) {
+		sbuf_push(&sbuf, 4, "IPv6 Adjacency-SRV6-SID: %pI6",
+			  &attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].sid);
+		sbuf_push(&sbuf, 0,
+			  "\tFlags: 0x%x\tWeight: 0x%x\tbehavior: 0x%x\n",
+			  attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].flags,
+			  attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].weight,
+			  attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].endpoint_behavior);
+	}
+	if (CHECK_FLAG(attr->flags, LS_ATTR_BCK_ADJ_SRV6SID)) {
+		sbuf_push(&sbuf, 4, "IPv6 Bck. Adjacency-SRV6-SID: %pI6",
+			  &attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].sid);
+		sbuf_push(&sbuf, 0,
+			  "\tFlags: 0x%x\tWeight: 0x%x\tbehavior: 0x%x\n",
+			  attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].flags,
+			  attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].weight,
+			  attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].endpoint_behavior);
+	}
 	if (CHECK_FLAG(attr->flags, LS_ATTR_SRLG)) {
 		sbuf_push(&sbuf, 4, "SRLGs: %d", attr->srlg_len);
 		for (int i = 1; i < attr->srlg_len; i++) {
@@ -2372,7 +2449,7 @@ static void ls_show_edge_json(struct ls_edge *edge, struct json_object *json)
 	struct ls_attributes *attr;
 	struct json_object *jte, *jbw, *jobj, *jsr = NULL, *jsrlg, *js_ext_ag,
 					      *js_ext_ag_arr_word,
-					      *js_ext_ag_arr_bit;
+					      *js_ext_ag_arr_bit, *jsrv6 = NULL;
 	char buf[INET6_BUFSIZ];
 	char buf_ag[strlen("0xffffffff") + 1];
 	uint32_t bitmap;
@@ -2555,6 +2632,45 @@ static void ls_show_edge_json(struct ls_edge *edge, struct json_object *json)
 		json_object_string_add(jobj, "flags", buf);
 		json_object_int_add(jobj, "weight",
 				    attr->adj_sid[ADJ_BCK_IPV6].weight);
+		json_object_array_add(jsr, jobj);
+	}
+	if (CHECK_FLAG(attr->flags, LS_ATTR_ADJ_SRV6SID)) {
+		jsrv6 = json_object_new_array();
+		json_object_object_add(json, "segment-routing-ipv6", jsrv6);
+		jobj = json_object_new_object();
+		snprintfrr(buf, INET6_BUFSIZ, "%pI6",
+			   &attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].sid);
+		json_object_string_add(jobj, "adj-sid", buf);
+		snprintfrr(buf, 6, "0x%x",
+			   attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].flags);
+		json_object_string_add(jobj, "flags", buf);
+		json_object_int_add(jobj, "weight",
+				    attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6].weight);
+		snprintfrr(buf, 6, "0x%x",
+			   attr->adj_srv6_sid[ADJ_SRV6_PRI_IPV6]
+				   .endpoint_behavior);
+		json_object_string_add(jobj, "endpoint-behavior", buf);
+		json_object_array_add(jsr, jobj);
+	}
+	if (CHECK_FLAG(attr->flags, LS_ATTR_BCK_ADJ_SRV6SID)) {
+		if (!jsrv6) {
+			jsrv6 = json_object_new_array();
+			json_object_object_add(json, "segment-routing-ipv6",
+					       jsrv6);
+		}
+		jobj = json_object_new_object();
+		snprintfrr(buf, INET6_BUFSIZ, "%pI6",
+			   &attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].sid);
+		json_object_string_add(jobj, "adj-sid", buf);
+		snprintfrr(buf, 6, "0x%x",
+			   attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].flags);
+		json_object_string_add(jobj, "flags", buf);
+		json_object_int_add(jobj, "weight",
+				    attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6].weight);
+		snprintfrr(buf, 6, "0x%x",
+			   attr->adj_srv6_sid[ADJ_SRV6_BCK_IPV6]
+				   .endpoint_behavior);
+		json_object_string_add(jobj, "endpoint-behavior", buf);
 		json_object_array_add(jsr, jobj);
 	}
 }

--- a/lib/link_state.h
+++ b/lib/link_state.h
@@ -161,6 +161,8 @@ struct ls_node {
 #define LS_ATTR_BCK_ADJ_SID6	0x08000000
 #define LS_ATTR_SRLG		0x10000000
 #define LS_ATTR_EXT_ADM_GRP 0x20000000
+#define LS_ATTR_ADJ_SRV6SID	0x40000000
+#define LS_ATTR_BCK_ADJ_SRV6SID 0x80000000
 
 /* Link State Attributes */
 struct ls_attributes {
@@ -209,6 +211,18 @@ struct ls_attributes {
 			uint8_t sysid[ISO_SYS_ID_LEN]; /* or Sys-ID for ISIS */
 		} neighbor;
 	} adj_sid[4];		/* IPv4/IPv6 & Primary/Backup (LAN)-Adj. SID */
+#define ADJ_SRV6_PRI_IPV6 0
+#define ADJ_SRV6_BCK_IPV6 1
+#define ADJ_SRV6_MAX	  2
+	struct ls_srv6_adjacency {	    /* Adjacency SID for IS-IS */
+		struct in6_addr sid;	    /* SID as IPv6 address */
+		uint8_t flags;		    /* Flags */
+		uint8_t weight;		    /* Administrative weight */
+		uint16_t endpoint_behavior; /* Endpoint Behavior */
+		union {
+			uint8_t sysid[ISO_SYS_ID_LEN]; /* Sys-ID for ISIS */
+		} neighbor;
+	} adj_srv6_sid[2];
 	uint32_t *srlgs;	/* List of Shared Risk Link Group */
 	uint8_t srlg_len;	/* number of SRLG in the list */
 };

--- a/lib/link_state.h
+++ b/lib/link_state.h
@@ -106,6 +106,7 @@ extern int ls_node_id_same(struct ls_node_id i1, struct ls_node_id i2);
 #define LS_NODE_SR		0x0040
 #define LS_NODE_SRLB		0x0080
 #define LS_NODE_MSD		0x0100
+#define LS_NODE_SRV6		0x0200
 
 /* Link State Node structure */
 struct ls_node {
@@ -128,6 +129,14 @@ struct ls_node {
 	} srlb;
 	uint8_t algo[LIB_LS_SR_ALGO_COUNT]; /* Segment Routing Algorithms */
 	uint8_t msd;			/* Maximum Stack Depth */
+
+	uint16_t srv6_cap_flags; /* draft-ietf-idr-bgpls-srv6-ext, 3.1., flags field */
+	struct ls_srv6_msd { /* draft-ietf-idr-bgpls-srv6-ext, 3.2. */
+		uint8_t max_seg_left_msd;
+		uint8_t max_end_pop_msd;
+		uint8_t max_h_encaps_msd;
+		uint8_t max_end_d_msd;
+	} srv6_msd;
 };
 
 /* Link State flags to indicate which Attribute parameters are valid */


### PR DESCRIPTION
Add SRv6  information to link state database.
This information is now reachable from each side (IS-IS, or Pathd).