### PR TITLE
isisd: fix ip/ipv6 reachability tlvs

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -8016,7 +8016,6 @@ void isis_tlvs_add_extended_ip_reach(struct isis_tlvs *tlvs,
 	apply_mask_ipv4(&r->prefix);
 
 	if (pcfgs) {
-		r->subtlvs = isis_alloc_subtlvs(ISIS_CONTEXT_SUBTLV_IP_REACH);
 		for (int i = 0; i < SR_ALGORITHM_COUNT; i++) {
 			struct isis_prefix_sid *psid;
 			struct sr_prefix_cfg *pcfg = pcfgs[i];
@@ -8026,6 +8025,10 @@ void isis_tlvs_add_extended_ip_reach(struct isis_tlvs *tlvs,
 
 			psid = XCALLOC(MTYPE_ISIS_SUBTLV, sizeof(*psid));
 			isis_sr_prefix_cfg2subtlv(pcfg, external, psid);
+
+			if (!r->subtlvs)
+				r->subtlvs = isis_alloc_subtlvs(
+					ISIS_CONTEXT_SUBTLV_IP_REACH);
 			append_item(&r->subtlvs->prefix_sids,
 				    (struct isis_item *)psid);
 		}
@@ -8044,7 +8047,6 @@ void isis_tlvs_add_ipv6_reach(struct isis_tlvs *tlvs, uint16_t mtid,
 	memcpy(&r->prefix, dest, sizeof(*dest));
 	apply_mask_ipv6(&r->prefix);
 	if (pcfgs) {
-		r->subtlvs = isis_alloc_subtlvs(ISIS_CONTEXT_SUBTLV_IP_REACH);
 		for (int i = 0; i < SR_ALGORITHM_COUNT; i++) {
 			struct isis_prefix_sid *psid;
 			struct sr_prefix_cfg *pcfg = pcfgs[i];
@@ -8054,6 +8056,10 @@ void isis_tlvs_add_ipv6_reach(struct isis_tlvs *tlvs, uint16_t mtid,
 
 			psid = XCALLOC(MTYPE_ISIS_SUBTLV, sizeof(*psid));
 			isis_sr_prefix_cfg2subtlv(pcfg, external, psid);
+
+			if (!r->subtlvs)
+				r->subtlvs = isis_alloc_subtlvs(
+					ISIS_CONTEXT_SUBTLV_IPV6_REACH);
 			append_item(&r->subtlvs->prefix_sids,
 				    (struct isis_item *)psid);
 		}


### PR DESCRIPTION
Don't allocate subtlvs container if there's nothing to add to it. If the container is allocated, the "sub-TLVs presence" bit is set in the TLVs even if there's no actual sub-TLVs, what violates the RFC.

Fixes #14514.