### PR TITLE
ospfd: Implement non-broadcast support for point-to-multipoint networks

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -494,11 +494,11 @@ Graceful Restart
 
 
    Configure Graceful Restart (RFC 5187) helper support.
-   By default, helper support is disabled for all neighbours.
+   By default, helper support is disabled for all neighbors.
    This config enables/disables helper support on this router
-   for all neighbours.
+   for all neighbors.
    To enable/disable helper support for a specific
-   neighbour, the router-id (A.B.C.D) has to be specified.
+   neighbor, the router-id (A.B.C.D) has to be specified.
 
 .. clicmd:: graceful-restart helper strict-lsa-checking
 

--- a/doc/user/ospf_fundamentals.rst
+++ b/doc/user/ospf_fundamentals.rst
@@ -12,7 +12,7 @@ OSPF Fundamentals
 :term:`distance-vector` protocols, such as :abbr:`RIP` or :abbr:`BGP`, where
 routers describe available `paths` (i.e. routes) to each other, in
 :term:`link-state` protocols routers instead describe the state of their links
-to their immediate neighbouring routers.
+to their immediate neighboring routers.
 
 .. index::
    single: Link State Announcement
@@ -127,7 +127,7 @@ LSA Flooding
 """"""""""""
 
 OSPF defines several related mechanisms, used to manage synchronisation of
-:abbr:`LSDB` s between neighbours as neighbours form adjacencies and the
+:abbr:`LSDB` s between neighbors as neighbors form adjacencies and the
 propagation, or `flooding` of new or updated :abbr:`LSA` s.
 
 
@@ -259,7 +259,7 @@ called `intra-area routes`.
      LSA is originated for such a link.
 
      Stub
-        A link with no adjacent neighbours, or a host route.
+        A link with no adjacent neighbors, or a host route.
 
   - Link ID and Data
 
@@ -339,8 +339,8 @@ The example below shows two :abbr:`LSA` s, both originated by the same router
 of different LSA types.
 
 The first LSA being the router LSA describing 192.168.0.49's links: 2 links
-to multi-access networks with fully-adjacent neighbours (i.e. Transit
-links) and 1 being a Stub link (no adjacent neighbours).
+to multi-access networks with fully-adjacent neighbors (i.e. Transit
+links) and 1 being a Stub link (no adjacent neighbors).
 
 The second LSA being a Network LSA, for which 192.168.0.49 is the
 :abbr:`DR`, listing the Router IDs of 4 routers on that network which

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -239,6 +239,17 @@ To start OSPF process you have to specify the OSPF router.
    This configuration setting MUST be consistent across all routers within the
    OSPF domain.
 
+.. clicmd:: neighbor A.B.C.D [poll-interval (1-65535)] [priority (0-255)]
+
+
+   Configures OSPF neighbors for non-broadcast multi-access (NBMA) networks
+   and point-to-multipoint non-broadcast networks. The `poll-interval`
+   specifies the rate for sending hello packets to neighbors that are not
+   active. When the configured neighbor is discovered, hello packets will be
+   sent at the rate of the hello-interval. The default `poll-interval` is 60
+   seconds. The `priority` is used to for the Designated Router (DR) election
+   on non-broadcast multi-access networks.
+
 .. clicmd:: network A.B.C.D/M area A.B.C.D
 
 .. clicmd:: network A.B.C.D/M area (0-4294967295)
@@ -580,7 +591,7 @@ Interfaces
    Note that OSPF MD5 authentication requires that time never go backwards
    (correct time is NOT important, only that it never goes backwards), even
    across resets, if ospfd is to be able to promptly reestablish adjacencies
-   with its neighbours after restarts/reboots. The host should have system time
+   with its neighbors after restarts/reboots. The host should have system time
    be set at boot from an external or non-volatile source (e.g. battery backed
    clock, NTP, etc.) or else the system clock should be periodically saved to
    non-volatile storage and restored at boot if MD5 authentication is to be
@@ -612,7 +623,7 @@ Interfaces
    Note that OSPF HMAC cryptographic authentication requires that time never go backwards
    (correct time is NOT important, only that it never goes backwards), even
    across resets, if ospfd is to be able to promptly reestablish adjacencies
-   with its neighbours after restarts/reboots. The host should have system time
+   with its neighbors after restarts/reboots. The host should have system time
    be set at boot from an external or non-volatile source (e.g. battery backed
    clock, NTP, etc.) or else the system clock should be periodically saved to
    non-volatile storage and restored at boot if HMAC cryptographic authentication is to be
@@ -679,7 +690,7 @@ Interfaces
    it's recommended to set the hello delay and hello interval with the same values.
    The default value is 10 seconds.
 
-.. clicmd:: ip ospf network (broadcast|non-broadcast|point-to-multipoint [delay-reflood]|point-to-point [dmvpn])
+.. clicmd:: ip ospf network (broadcast|non-broadcast|point-to-multipoint [delay-reflood|non-broadcast]|point-to-point [dmvpn])
 
    When configuring a point-to-point network on an interface and the interface
    has a /32 address associated with then OSPF will treat the interface
@@ -690,6 +701,13 @@ Interfaces
    When used in a DMVPN network at a spoke, this OSPF will be configured in
    point-to-point, but the HUB will be a point-to-multipoint. To make this
    topology work, specify the optional 'dmvpn' parameter at the spoke.
+
+   When the network is configured as point-to-multipoint and `non-broadcast`
+   is specified, the network doesn't support broadcast or multicast delivery
+   and neighbors cannot be discovered from OSPF hello received from the
+   OSPFAllRouters (224.0.0.5). Rather, they must be explicitly configured
+   using the :clicmd:`neighbor A.B.C.D` configuration command as they are
+   on non-broadcast networks.
 
    When the network is configured as point-to-multipoint and `delay-reflood`
    is specified, LSAs received on the interface from neighbors on the
@@ -838,11 +856,11 @@ Graceful Restart
 
 
    Configure Graceful Restart (RFC 3623) helper support.
-   By default, helper support is disabled for all neighbours.
+   By default, helper support is disabled for all neighbors.
    This config enables/disables helper support on this router
-   for all neighbours.
+   for all neighbors.
    To enable/disable helper support for a specific
-   neighbour, the router-id (A.B.C.D) has to be specified.
+   neighbor, the router-id (A.B.C.D) has to be specified.
 
 .. clicmd:: graceful-restart helper strict-lsa-checking
 
@@ -1082,7 +1100,7 @@ Router Information
    respectively the PCE IP address, Autonomous System (AS) numbers of
    controlled domains, neighbor ASs, flag and scope. For flag and scope, please
    refer to :rfc`5088` for the BITPATTERN recognition. Multiple 'pce neighbor'
-   command could be specified in order to specify all PCE neighbours.
+   command could be specified in order to specify all PCE neighbors.
 
 .. clicmd:: show ip ospf router-info
 

--- a/lib/libospf.h
+++ b/lib/libospf.h
@@ -69,6 +69,7 @@ extern "C" {
 #define OSPF_MTU_IGNORE_DEFAULT             0
 #define OSPF_FAST_HELLO_DEFAULT             0
 #define OSPF_P2MP_DELAY_REFLOOD_DEFAULT	    false
+#define OSPF_P2MP_NON_BROADCAST_DEFAULT	    false
 #define OSPF_OPAQUE_CAPABLE_DEFAULT true
 #define OSPF_PREFIX_SUPPRESSION_DEFAULT	    false
 #define OSPF_AREA_BACKBONE              0x00000000      /* 0.0.0.0 */

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -765,8 +765,9 @@ int ospf_flood_through_interface(struct ospf_interface *oi,
 	    packets must be sent, as unicasts, to each adjacent	neighbor
 	    (i.e., those in state Exchange or greater).	 The destination
 	    IP addresses for these packets are the neighbors' IP
-	    addresses.   */
-	if (oi->type == OSPF_IFTYPE_NBMA) {
+	    addresses. This behavior is extended to P2MP networks which
+	    don't support broadcast. */
+	if (OSPF_IF_NON_BROADCAST(oi)) {
 		struct ospf_neighbor *nbr;
 
 		for (rn = route_top(oi->nbrs); rn; rn = route_next(rn)) {

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -147,17 +147,11 @@ void ospf_if_reset(struct interface *ifp)
 	}
 }
 
-void ospf_if_reset_variables(struct ospf_interface *oi)
+static void ospf_if_default_variables(struct ospf_interface *oi)
 {
 	/* Set default values. */
-	/* don't clear this flag.  oi->flag = OSPF_IF_DISABLE; */
 
-	if (oi->vl_data)
-		oi->type = OSPF_IFTYPE_VIRTUALLINK;
-	else
-		/* preserve network-type */
-		if (oi->type != OSPF_IFTYPE_NBMA)
-		oi->type = OSPF_IFTYPE_BROADCAST;
+	oi->type = OSPF_IFTYPE_BROADCAST;
 
 	oi->state = ISM_Down;
 
@@ -254,7 +248,7 @@ struct ospf_interface *ospf_if_new(struct ospf *ospf, struct interface *ifp,
 	oi->ls_ack_direct.ls_ack = list_new();
 
 	/* Set default values. */
-	ospf_if_reset_variables(oi);
+	ospf_if_default_variables(oi);
 
 	/* Set pseudo neighbor to Null */
 	oi->nbr_self = NULL;

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -119,6 +119,9 @@ struct ospf_if_params {
 	/* point-to-multipoint delayed reflooding configuration */
 	bool p2mp_delay_reflood;
 
+	/* point-to-multipoint doesn't support broadcast */
+	bool p2mp_non_broadcast;
+
 	/* Opaque LSA capability at interface level (see RFC5250) */
 	DECLARE_IF_PARAM(bool, opaque_capable);
 };
@@ -185,12 +188,19 @@ struct ospf_interface {
 
 	/* OSPF Network Type. */
 	uint8_t type;
+#define OSPF_IF_NON_BROADCAST(O)                                               \
+	(((O)->type == OSPF_IFTYPE_NBMA) ||                                    \
+	 ((((O)->type == OSPF_IFTYPE_POINTOMULTIPOINT) &&                      \
+	   (O)->p2mp_non_broadcast)))
 
 	/* point-to-point DMVPN configuration */
 	uint8_t ptp_dmvpn;
 
 	/* point-to-multipoint delayed reflooding */
 	bool p2mp_delay_reflood;
+
+	/* point-to-multipoint doesn't support broadcast */
+	bool p2mp_non_broadcast;
 
 	/* State of Interface State Machine. */
 	uint8_t state;
@@ -326,7 +336,6 @@ extern void ospf_if_update_params(struct interface *ifp, struct in_addr addr);
 extern int ospf_if_new_hook(struct interface *ifp);
 extern void ospf_if_init(void);
 extern void ospf_if_stream_unset(struct ospf_interface *oi);
-extern void ospf_if_reset_variables(struct ospf_interface *oi);
 extern int ospf_if_is_enable(struct ospf_interface *oi);
 extern int ospf_if_get_output_cost(struct ospf_interface *oi);
 extern void ospf_if_recalculate_output_cost(struct interface *ifp);

--- a/ospfd/ospf_ism.c
+++ b/ospfd/ospf_ism.c
@@ -367,7 +367,7 @@ static int ism_interface_up(struct ospf_interface *oi)
 		/* Otherwise, the state transitions to Waiting. */
 		next_state = ISM_Waiting;
 
-	if (oi->type == OSPF_IFTYPE_NBMA)
+	if (OSPF_IF_NON_BROADCAST(oi))
 		ospf_nbr_nbma_if_update(oi->ospf, oi);
 
 	/*  ospf_ism_event (t); */

--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -431,7 +431,7 @@ static struct ospf_neighbor *ospf_nbr_add(struct ospf_interface *oi,
 	memcpy(&nbr->address, p, sizeof(struct prefix));
 
 	nbr->nbr_nbma = NULL;
-	if (oi->type == OSPF_IFTYPE_NBMA) {
+	if (OSPF_IF_NON_BROADCAST(oi)) {
 		struct ospf_nbr_nbma *nbr_nbma;
 		struct listnode *node;
 
@@ -485,7 +485,7 @@ struct ospf_neighbor *ospf_nbr_get(struct ospf_interface *oi,
 		route_unlock_node(rn);
 		nbr = rn->info;
 
-		if (oi->type == OSPF_IFTYPE_NBMA && nbr->state == NSM_Attempt) {
+		if (OSPF_IF_NON_BROADCAST(nbr->oi) && nbr->state == NSM_Attempt) {
 			nbr->src = iph->ip_src;
 			memcpy(&nbr->address, p, sizeof(struct prefix));
 		}

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -166,7 +166,7 @@ static int nsm_hello_received(struct ospf_neighbor *nbr)
 	OSPF_NSM_TIMER_ON(nbr->t_inactivity, ospf_inactivity_timer,
 			  nbr->v_inactivity);
 
-	if (nbr->oi->type == OSPF_IFTYPE_NBMA && nbr->nbr_nbma)
+	if (OSPF_IF_NON_BROADCAST(nbr->oi) && nbr->nbr_nbma != NULL)
 		EVENT_OFF(nbr->nbr_nbma->t_poll);
 
 	/* Send proactive ARP requests */
@@ -377,7 +377,7 @@ static int nsm_kill_nbr(struct ospf_neighbor *nbr)
 		return 0;
 	}
 
-	if (nbr->oi->type == OSPF_IFTYPE_NBMA && nbr->nbr_nbma != NULL) {
+	if (OSPF_IF_NON_BROADCAST(nbr->oi) && nbr->nbr_nbma != NULL) {
 		struct ospf_nbr_nbma *nbr_nbma = nbr->nbr_nbma;
 
 		nbr_nbma->nbr = NULL;

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -1096,6 +1096,7 @@ struct ospf_interface *add_ospf_interface(struct connected *co,
 	oi->type = IF_DEF_PARAMS(co->ifp)->type;
 	oi->ptp_dmvpn = IF_DEF_PARAMS(co->ifp)->ptp_dmvpn;
 	oi->p2mp_delay_reflood = IF_DEF_PARAMS(co->ifp)->p2mp_delay_reflood;
+	oi->p2mp_non_broadcast = IF_DEF_PARAMS(co->ifp)->p2mp_non_broadcast;
 
 	/* Add pseudo neighbor. */
 	ospf_nbr_self_reset(oi, oi->ospf->router_id);
@@ -1989,7 +1990,7 @@ static void ospf_nbr_nbma_add(struct ospf_nbr_nbma *nbr_nbma,
 	struct route_node *rn;
 	struct prefix p;
 
-	if (oi->type != OSPF_IFTYPE_NBMA)
+	if (!OSPF_IF_NON_BROADCAST(oi))
 		return;
 
 	if (nbr_nbma->nbr != NULL)
@@ -2036,7 +2037,7 @@ void ospf_nbr_nbma_if_update(struct ospf *ospf, struct ospf_interface *oi)
 	struct route_node *rn;
 	struct prefix_ipv4 p;
 
-	if (oi->type != OSPF_IFTYPE_NBMA)
+	if (!OSPF_IF_NON_BROADCAST(oi))
 		return;
 
 	for (rn = route_top(ospf->nbr_nbma); rn; rn = route_next(rn))
@@ -2095,7 +2096,7 @@ int ospf_nbr_nbma_set(struct ospf *ospf, struct in_addr nbr_addr)
 	rn->info = nbr_nbma;
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->oiflist, node, oi)) {
-		if (oi->type == OSPF_IFTYPE_NBMA)
+		if (OSPF_IF_NON_BROADCAST(oi))
 			if (prefix_match(oi->address, (struct prefix *)&p)) {
 				ospf_nbr_nbma_add(nbr_nbma, oi);
 				break;

--- a/tests/topotests/ospf_p2mp/r1/frr-p2mp-non-broadcast.conf
+++ b/tests/topotests/ospf_p2mp/r1/frr-p2mp-non-broadcast.conf
@@ -1,0 +1,26 @@
+!
+hostname r1
+password zebra
+log file /tmp/r1-frr.log
+ip forwarding
+!
+interface r1-eth0
+ ip address 10.1.0.1/24
+ ip ospf network point-to-multipoint non-broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+interface r1-eth1
+ ip address 10.1.1.1/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+router ospf
+  ospf router-id 1.1.1.1
+  distance 20
+  network 10.1.0.0/24 area 0
+  network 10.1.1.0/24 area 0
+  neighbor 10.1.0.2 poll-interval 5
+  neighbor 10.1.0.3 poll-interval 5
+  neighbor 10.1.0.4 poll-interval 5
+!

--- a/tests/topotests/ospf_p2mp/r1/frr-p2mp.conf
+++ b/tests/topotests/ospf_p2mp/r1/frr-p2mp.conf
@@ -1,0 +1,23 @@
+!
+hostname r1
+password zebra
+log file /tmp/r1-frr.log
+ip forwarding
+!
+interface r1-eth0
+ ip address 10.1.0.1/24
+ ip ospf network point-to-multipoint
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+interface r1-eth1
+ ip address 10.1.1.1/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+router ospf
+  ospf router-id 1.1.1.1
+  distance 20
+  network 10.1.0.0/24 area 0
+  network 10.1.1.0/24 area 0
+!

--- a/tests/topotests/ospf_p2mp/r2/frr-p2mp-non-broadcast.conf
+++ b/tests/topotests/ospf_p2mp/r2/frr-p2mp-non-broadcast.conf
@@ -1,0 +1,29 @@
+!
+hostname r2
+password zebra
+log file /tmp/r1-frr.log
+ip forwarding
+!
+interface r2-eth0
+ ip address 10.1.0.2/24
+ ip ospf network point-to-multipoint non-broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+interface r2-eth1
+ ip address 10.1.2.2/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+!
+!
+router ospf
+  ospf router-id 2.2.2.2
+  distance 20
+  network 10.1.0.0/24 area 0
+  network 10.1.2.0/24 area 0
+  neighbor 10.1.0.1 poll-interval 5
+  neighbor 10.1.0.3 poll-interval 5
+  neighbor 10.1.0.4 poll-interval 5
+!

--- a/tests/topotests/ospf_p2mp/r2/frr-p2mp.conf
+++ b/tests/topotests/ospf_p2mp/r2/frr-p2mp.conf
@@ -1,0 +1,26 @@
+!
+hostname r2
+password zebra
+log file /tmp/r1-frr.log
+ip forwarding
+!
+interface r2-eth0
+ ip address 10.1.0.2/24
+ ip ospf network point-to-multipoint
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+interface r2-eth1
+ ip address 10.1.2.2/24
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+!
+!
+router ospf
+  ospf router-id 2.2.2.2
+  distance 20
+  network 10.1.0.0/24 area 0
+  network 10.1.2.0/24 area 0
+!

--- a/tests/topotests/ospf_p2mp/r3/frr-p2mp-non-broadcast.conf
+++ b/tests/topotests/ospf_p2mp/r3/frr-p2mp-non-broadcast.conf
@@ -1,0 +1,28 @@
+!
+hostname r3
+password zebra
+log file /tmp/r1-frr.log
+ip forwarding
+!
+interface r3-eth0
+ ip address 10.1.0.3/24
+ ip ospf network point-to-multipoint non-broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+interface r3-eth1
+ ip address 10.1.3.3/24
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+router ospf
+  ospf router-id 3.3.3.3
+  distance 20
+  network 10.1.0.0/24 area 0
+  network 10.1.3.0/24 area 0
+  neighbor 10.1.0.1 poll-interval 5
+  neighbor 10.1.0.2 poll-interval 5
+  neighbor 10.1.0.4 poll-interval 5

--- a/tests/topotests/ospf_p2mp/r3/frr-p2mp.conf
+++ b/tests/topotests/ospf_p2mp/r3/frr-p2mp.conf
@@ -1,0 +1,25 @@
+!
+hostname r3
+password zebra
+log file /tmp/r1-frr.log
+ip forwarding
+!
+interface r3-eth0
+ ip address 10.1.0.3/24
+ ip ospf network point-to-multipoint
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+interface r3-eth1
+ ip address 10.1.3.3/24
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+router ospf
+  ospf router-id 3.3.3.3
+  distance 20
+  network 10.1.0.0/24 area 0
+  network 10.1.3.0/24 area 0

--- a/tests/topotests/ospf_p2mp/r4/frr-p2mp-non-broadcast.conf
+++ b/tests/topotests/ospf_p2mp/r4/frr-p2mp-non-broadcast.conf
@@ -1,0 +1,28 @@
+!
+hostname r4
+password zebra
+log file /tmp/r1-frr.log
+ip forwarding
+!
+interface r4-eth0
+ ip address 10.1.0.4/24
+ ip ospf network point-to-multipoint non-broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+interface r4-eth1
+ ip address 10.1.4.4/24
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+router ospf
+  ospf router-id 4.4.4.4
+  distance 20
+  network 10.1.0.0/24 area 0
+  network 10.1.4.0/24 area 0
+  neighbor 10.1.0.1 poll-interval 5
+  neighbor 10.1.0.2 poll-interval 5
+  neighbor 10.1.0.3 poll-interval 5

--- a/tests/topotests/ospf_p2mp/r4/frr-p2mp.conf
+++ b/tests/topotests/ospf_p2mp/r4/frr-p2mp.conf
@@ -1,0 +1,25 @@
+!
+hostname r4
+password zebra
+log file /tmp/r1-frr.log
+ip forwarding
+!
+interface r4-eth0
+ ip address 10.1.0.4/24
+ ip ospf network point-to-multipoint
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+interface r4-eth1
+ ip address 10.1.4.4/24
+ ip ospf network broadcast
+ ip ospf hello-interval 1
+ ip ospf dead-interval 30
+!
+!
+router ospf
+  ospf router-id 4.4.4.4
+  distance 20
+  network 10.1.0.0/24 area 0
+  network 10.1.4.0/24 area 0

--- a/tests/topotests/ospf_p2mp/test_ospf_p2mp_broadcast.py
+++ b/tests/topotests/ospf_p2mp/test_ospf_p2mp_broadcast.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_ospf_prefix_p2mp_broadcast.py
+#
+# Copyright (c) 2024 LabN Consulting
+# Acee Lindem
+#
+
+import os
+import sys
+import json
+from time import sleep
+from functools import partial
+import pytest
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+from lib.common_config import (
+    run_frr_cmd,
+    shutdown_bringup_interface,
+    start_router_daemons,
+    step,
+)
+
+
+"""
+test_ospf_p2mp_broadcast.py: Test OSPF Point-to-multipoint
+"""
+
+TOPOLOGY = """
+            +-----+             +-----+
+10.1.1.0/24 | r1  |             | r2  | 10.1.2.0/24
+ -----------+     |             |     +----------
+            +--+--+             +--+--+
+               |    10.1.0.0/24    |
+               |     +-------+     |
+               +---- |       |-----+
+                     | P2MP  |
+               +---- |       |-----+
+               |     +-------+     |
+               |                   |
+               |                   |
+            +--+--+              +-+---+
+10.1.3.0/24 | r3  |              | r4  | 10.1.4.0/24
+ -----------+     |              |     +----------
+            +-----+              +-----+
+
+
+"""
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# Required to instantiate the topology builder class.
+
+pytestmark = [pytest.mark.ospfd, pytest.mark.bgpd]
+
+
+def build_topo(tgen):
+    "Build function"
+
+    # Create 4 routers
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+    tgen.add_router("r3")
+    tgen.add_router("r4")
+
+    # Interconect them all to the P2MP network
+    switch = tgen.add_switch("s0-p2mp")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["r4"])
+
+    # Add standalone network to router 1
+    switch = tgen.add_switch("s-r1-1")
+    switch.add_link(tgen.gears["r1"])
+
+    # Add standalone network to router 2
+    switch = tgen.add_switch("s-r2-1")
+    switch.add_link(tgen.gears["r2"])
+
+    # Add standalone network to router 3
+    switch = tgen.add_switch("s-r3-1")
+    switch.add_link(tgen.gears["r3"])
+
+    # Add standalone network to router 4
+    switch = tgen.add_switch("s-r4-1")
+    switch.add_link(tgen.gears["r4"])
+
+
+def setup_module(mod):
+    logger.info("OSPF Point-to-MultiPoint:\n {}".format(TOPOLOGY))
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    # Starting Routers
+    router_list = tgen.routers()
+
+    for rname, router in router_list.items():
+        logger.info("Loading router %s" % rname)
+        router.load_frr_config(os.path.join(CWD, "{}/frr-p2mp.conf".format(rname)))
+
+    # Initialize all routers.
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def verify_p2mp_interface(tgen):
+    "Verify the P2MP Configuration and interface settings"
+
+    r1 = tgen.gears["r1"]
+
+    step("Test running configuration for P2MP configuration")
+    rc = 0
+    rc, _, _ = tgen.net["r1"].cmd_status(
+        "show running ospfd | grep 'ip ospf network point-to-multipoint'", warn=False
+    )
+    assertmsg = "'ip ospf network point-to-multipoint' applied, but not present in r1 configuration"
+    assert rc, assertmsg
+
+    step("Test OSPF interface for P2MP settings")
+    input_dict = {
+        "interfaces": {
+            "r1-eth0": {
+                "ospfEnabled": True,
+                "interfaceIp": {
+                    "10.1.0.1": {
+                        "ipAddress": "10.1.0.1",
+                        "ipAddressPrefixlen": 24,
+                        "ospfIfType": "Broadcast",
+                        "routerId": "1.1.1.1",
+                        "networkType": "POINTOMULTIPOINT",
+                        "cost": 10,
+                        "state": "Point-To-Point",
+                        "nbrCount": 3,
+                        "nbrAdjacentCount": 3,
+                        "prefixSuppression": False,
+                        "p2mpDelayReflood": False,
+                        "p2mpNonBroadcast": False,
+                    }
+                },
+                "ipAddress": "10.1.0.1",
+                "ipAddressPrefixlen": 24,
+                "ospfIfType": "Broadcast",
+                "area": "0.0.0.0",
+                "routerId": "1.1.1.1",
+                "networkType": "POINTOMULTIPOINT",
+                "cost": 10,
+                "state": "Point-To-Point",
+                "opaqueCapable": True,
+                "nbrCount": 3,
+                "nbrAdjacentCount": 3,
+                "prefixSuppression": False,
+                "p2mpDelayReflood": False,
+                "p2mpNonBroadcast": False,
+            }
+        }
+    }
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip ospf interface r1-eth0 json", input_dict
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "P2MP Interface Mismatch on router r1"
+    assert result is None, assertmsg
+
+
+def verify_non_p2mp_interface(tgen):
+    "Verify the removal of P2MP Configuration and interface settings"
+    r1 = tgen.gears["r1"]
+
+    step("Test running configuration for removal of P2MP configuration")
+    rc = 0
+    rc, _, _ = tgen.net["r1"].cmd_status(
+        "show running ospfd | grep -q 'ip ospf network point-to-multipoint'", warn=False
+    )
+    assertmsg = "'ip ospf network point-to-multipoint' not applied, but present in r1 configuration"
+    assert rc, assertmsg
+
+    step("Test OSPF interface for default settings")
+    input_dict = {
+        "interfaces": {
+            "r1-eth0": {
+                "ospfEnabled": True,
+                "interfaceIp": {
+                    "10.1.0.1": {
+                        "ipAddress": "10.1.0.1",
+                        "ipAddressPrefixlen": 24,
+                        "ospfIfType": "Broadcast",
+                        "routerId": "1.1.1.1",
+                        "networkType": "BROADCAST",
+                        "cost": 10,
+                        "prefixSuppression": False,
+                    }
+                },
+                "ipAddress": "10.1.0.1",
+                "ipAddressPrefixlen": 24,
+                "ospfIfType": "Broadcast",
+                "area": "0.0.0.0",
+                "routerId": "1.1.1.1",
+                "networkType": "BROADCAST",
+                "cost": 10,
+                "opaqueCapable": True,
+                "prefixSuppression": False,
+            }
+        }
+    }
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip ospf interface r1-eth0 json", input_dict
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "P2MP Interface Mismatch on router r1"
+    assert result is None, assertmsg
+
+
+def verify_p2mp_neighbor(tgen, router, neighbor, state, intf_addr, interface):
+    topo_router = tgen.gears[router]
+
+    step("Verify neighbor " + neighbor + " in " + state + " state")
+    input_dict = {
+        "default": {
+            neighbor: [
+                {
+                    "nbrState": state,
+                    "ifaceAddress": intf_addr,
+                    "ifaceName": interface,
+                }
+            ],
+        }
+    }
+    test_func = partial(
+        topotest.router_json_cmp,
+        topo_router,
+        "show ip ospf neighbor " + neighbor + " json",
+        input_dict,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "P2MP Neighbor " + neighbor + " not in " + state
+    assert result is None, assertmsg
+
+
+def verify_p2mp_route(tgen, router, prefix, prefix_len, nexthop, interface):
+    topo_router = tgen.gears[router]
+
+    step("Verify router " + router + " p2mp route " + prefix + " installed")
+    input_dict = {
+        prefix: [
+            {
+                "prefix": prefix,
+                "prefixLen": prefix_len,
+                "protocol": "ospf",
+                "nexthops": [
+                    {
+                        "ip": nexthop,
+                        "interfaceName": interface,
+                    }
+                ],
+            }
+        ]
+    }
+    test_func = partial(
+        topotest.router_json_cmp,
+        topo_router,
+        "show ip route " + prefix + " json",
+        input_dict,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = prefix + " not installed on router " + router
+    assert result is None, assertmsg
+
+
+def test_p2mp_broadcast_interface():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("Skipped because of router(s) failure")
+
+    step("Verify router r1 interface r1-eth0 p2mp configuration")
+    verify_p2mp_interface(tgen)
+
+    step("Verify router r1 p2mp interface r1-eth0 neighbors")
+    verify_p2mp_neighbor(
+        tgen, "r1", "2.2.2.2", "Full/DROther", "10.1.0.2", "r1-eth0:10.1.0.1"
+    )
+    verify_p2mp_neighbor(
+        tgen, "r1", "3.3.3.3", "Full/DROther", "10.1.0.3", "r1-eth0:10.1.0.1"
+    )
+    verify_p2mp_neighbor(
+        tgen, "r1", "4.4.4.4", "Full/DROther", "10.1.0.4", "r1-eth0:10.1.0.1"
+    )
+
+    step("Verify router r1 p2mp routes installed")
+    verify_p2mp_route(tgen, "r1", "10.1.2.0/24", 24, "10.1.0.2", "r1-eth0")
+    verify_p2mp_route(tgen, "r1", "10.1.3.0/24", 24, "10.1.0.3", "r1-eth0")
+    verify_p2mp_route(tgen, "r1", "10.1.4.0/24", 24, "10.1.0.4", "r1-eth0")
+
+    step("Verify router r1 interface r1-eth0 p2mp configuration removal")
+    r1 = tgen.gears["r1"]
+    r1.vtysh_cmd("conf t\ninterface r1-eth0\nno ip ospf network point-to-multipoint")
+    verify_non_p2mp_interface(tgen)
+
+    step("Verify router r1 interface r1-eth0 p2mp configuration application")
+    r1.vtysh_cmd("conf t\ninterface r1-eth0\nip ospf network point-to-multipoint")
+    verify_p2mp_interface(tgen)
+
+    step("Verify restablishment of r1-eth0 p2mp neighbors")
+    verify_p2mp_neighbor(
+        tgen, "r1", "2.2.2.2", "Full/DROther", "10.1.0.2", "r1-eth0:10.1.0.1"
+    )
+    verify_p2mp_neighbor(
+        tgen, "r1", "3.3.3.3", "Full/DROther", "10.1.0.3", "r1-eth0:10.1.0.1"
+    )
+    verify_p2mp_neighbor(
+        tgen, "r1", "4.4.4.4", "Full/DROther", "10.1.0.4", "r1-eth0:10.1.0.1"
+    )
+
+    step("Verify router r1 p2mp routes reinstalled")
+    verify_p2mp_route(tgen, "r1", "10.1.2.0/24", 24, "10.1.0.2", "r1-eth0")
+    verify_p2mp_route(tgen, "r1", "10.1.3.0/24", 24, "10.1.0.3", "r1-eth0")
+    verify_p2mp_route(tgen, "r1", "10.1.4.0/24", 24, "10.1.0.4", "r1-eth0")
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/ospf_p2mp/test_ospf_p2mp_non_broadcast.py
+++ b/tests/topotests/ospf_p2mp/test_ospf_p2mp_non_broadcast.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_ospf_prefix_p2mp_non_broadcast.py
+#
+# Copyright (c) 2024 LabN Consulting
+# Acee Lindem
+#
+
+import os
+import sys
+import json
+from time import sleep
+from functools import partial
+import pytest
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+from lib.common_config import (
+    run_frr_cmd,
+    shutdown_bringup_interface,
+    start_router_daemons,
+    step,
+)
+
+
+"""
+test_ospf_p2mp_non_broadcast.py: Test OSPF Point-to-multipoint Non-Broadcast
+                                 Full Mesh
+"""
+
+TOPOLOGY = """
+            +-----+             +-----+
+10.1.1.0/24 | r1  |             | r2  | 10.1.2.0/24
+ -----------+     |             |     +----------
+            +--+--+             +--+--+
+               |    10.1.0.0/24    |
+               |     +-------+     |
+               +---- |       |-----+
+                     | P2MP  |
+               +---- |       |-----+
+               |     +-------+     |
+               |                   |
+               |                   |
+            +--+--+              +-+---+
+10.1.3.0/24 | r3  |              | r4  | 10.1.4.0/24
+ -----------+     |              |     +----------
+            +-----+              +-----+
+
+
+"""
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# Required to instantiate the topology builder class.
+
+pytestmark = [pytest.mark.ospfd, pytest.mark.bgpd]
+
+
+def build_topo(tgen):
+    "Build function"
+
+    # Create 4 routers
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+    tgen.add_router("r3")
+    tgen.add_router("r4")
+
+    # Interconect them all to the P2MP network
+    switch = tgen.add_switch("s0-p2mp")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["r4"])
+
+    # Add standalone network to router 1
+    switch = tgen.add_switch("s-r1-1")
+    switch.add_link(tgen.gears["r1"])
+
+    # Add standalone network to router 2
+    switch = tgen.add_switch("s-r2-1")
+    switch.add_link(tgen.gears["r2"])
+
+    # Add standalone network to router 3
+    switch = tgen.add_switch("s-r3-1")
+    switch.add_link(tgen.gears["r3"])
+
+    # Add standalone network to router 4
+    switch = tgen.add_switch("s-r4-1")
+    switch.add_link(tgen.gears["r4"])
+
+
+def setup_module(mod):
+    logger.info("OSPF Point-to-MultiPoint Non-Broadcast:\n {}".format(TOPOLOGY))
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    # Starting Routers
+    router_list = tgen.routers()
+
+    for rname, router in router_list.items():
+        logger.info("Loading router %s" % rname)
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr-p2mp-non-broadcast.conf".format(rname))
+        )
+
+    # Initialize all routers.
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def verify_p2mp_interface(tgen, router, nbr_cnt, nbr_adj_cnt, non_broadcast):
+    "Verify the P2MP Configuration and interface settings"
+
+    topo_router = tgen.gears[router]
+
+    step("Test running configuration for P2MP configuration")
+    rc = 0
+    rc, _, _ = tgen.net[router].cmd_status(
+        "show running ospfd | grep 'ip ospf network point-to-multipoint'", warn=False
+    )
+    assertmsg = (
+        "'ip ospf network point-to-multipoint' applied, but not present in "
+        + router
+        + "configuration"
+    )
+    assert rc, assertmsg
+
+    step("Test OSPF interface for P2MP settings")
+    input_dict = {
+        "interfaces": {
+            "r1-eth0": {
+                "ospfEnabled": True,
+                "interfaceIp": {
+                    "10.1.0.1": {
+                        "ipAddress": "10.1.0.1",
+                        "ipAddressPrefixlen": 24,
+                        "ospfIfType": "Broadcast",
+                        "routerId": "1.1.1.1",
+                        "networkType": "POINTOMULTIPOINT",
+                        "cost": 10,
+                        "state": "Point-To-Point",
+                        "nbrCount": nbr_cnt,
+                        "nbrAdjacentCount": nbr_adj_cnt,
+                        "prefixSuppression": False,
+                        "p2mpDelayReflood": False,
+                        "p2mpNonBroadcast": non_broadcast,
+                    }
+                },
+                "ipAddress": "10.1.0.1",
+                "ipAddressPrefixlen": 24,
+                "ospfIfType": "Broadcast",
+                "area": "0.0.0.0",
+                "routerId": "1.1.1.1",
+                "networkType": "POINTOMULTIPOINT",
+                "cost": 10,
+                "state": "Point-To-Point",
+                "opaqueCapable": True,
+                "nbrCount": nbr_cnt,
+                "nbrAdjacentCount": nbr_adj_cnt,
+                "prefixSuppression": False,
+                "p2mpDelayReflood": False,
+                "p2mpNonBroadcast": non_broadcast,
+            }
+        }
+    }
+    test_func = partial(
+        topotest.router_json_cmp,
+        topo_router,
+        "show ip ospf interface r1-eth0 json",
+        input_dict,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "P2MP Interface Mismatch on router r1"
+    assert result is None, assertmsg
+
+
+def verify_p2mp_neighbor(tgen, router, neighbor, state, intf_addr, interface):
+    topo_router = tgen.gears[router]
+
+    step("Verify neighbor " + neighbor + " in " + state + " state")
+    input_dict = {
+        "default": {
+            neighbor: [
+                {
+                    "nbrState": state,
+                    "ifaceAddress": intf_addr,
+                    "ifaceName": interface,
+                }
+            ],
+        }
+    }
+    test_func = partial(
+        topotest.router_json_cmp,
+        topo_router,
+        "show ip ospf neighbor " + neighbor + " json",
+        input_dict,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "P2MP Neighbor " + neighbor + " not in " + state
+    assert result is None, assertmsg
+
+
+def verify_p2mp_route(tgen, router, prefix, prefix_len, nexthop, interface):
+    topo_router = tgen.gears[router]
+
+    step("Verify router " + router + " p2mp route " + prefix + " installed")
+    input_dict = {
+        prefix: [
+            {
+                "prefix": prefix,
+                "prefixLen": prefix_len,
+                "protocol": "ospf",
+                "nexthops": [
+                    {
+                        "ip": nexthop,
+                        "interfaceName": interface,
+                    }
+                ],
+            }
+        ]
+    }
+    test_func = partial(
+        topotest.router_json_cmp,
+        topo_router,
+        "show ip route " + prefix + " json",
+        input_dict,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = prefix + " not installed on router " + router
+    assert result is None, assertmsg
+
+
+def test_p2mp_non_broadcast_connectivity():
+    tgen = get_topogen()
+    r1 = tgen.gears["r1"]
+
+    if tgen.routers_have_failure():
+        pytest.skip("Skipped because of router(s) failure")
+
+    step("Verify router r1 interface OSPF point-to-multipoint non-broadcast interface")
+    verify_p2mp_interface(tgen, "r1", 3, 3, True)
+
+    step("Verify router r1 interface r1-eth0 p2mp non-broadcast configuration")
+    rc, _, _ = tgen.net["r1"].cmd_status(
+        "show running ospfd | grep -q 'ip ospf network point-to-multipoint non-broadcast'",
+        warn=False,
+    )
+    assertmsg = "'ip ospf network point-to-multipoint non-broadcast' applied, but not present in R1 configuration"
+    assert rc, assertmsg
+
+    step("Verify router r1 OSPF point-to-multipoint neighbors")
+    verify_p2mp_neighbor(
+        tgen, "r1", "2.2.2.2", "Full/DROther", "10.1.0.2", "r1-eth0:10.1.0.1"
+    )
+    verify_p2mp_neighbor(
+        tgen, "r1", "3.3.3.3", "Full/DROther", "10.1.0.3", "r1-eth0:10.1.0.1"
+    )
+    verify_p2mp_neighbor(
+        tgen, "r1", "4.4.4.4", "Full/DROther", "10.1.0.4", "r1-eth0:10.1.0.1"
+    )
+
+    step("Verify router r1 OSPF point-to-multipoint routes are installed")
+    verify_p2mp_route(tgen, "r1", "10.1.2.0/24", 24, "10.1.0.2", "r1-eth0")
+    verify_p2mp_route(tgen, "r1", "10.1.3.0/24", 24, "10.1.0.3", "r1-eth0")
+    verify_p2mp_route(tgen, "r1", "10.1.4.0/24", 24, "10.1.0.4", "r1-eth0")
+
+    step("Remove r1 interface r1-eth0 p2mp non-broadcast configuration")
+    r1.vtysh_cmd("conf t\ninterface r1-eth0\nip ospf network point-to-multipoint")
+    rc, _, _ = tgen.net["r1"].cmd_status(
+        "show running ospfd | grep -q 'ip ospf network point-to-multipoint non-broadcast'",
+        warn=False,
+    )
+    assertmsg = "'ip ospf network point-to-multipoint non-broadcast' not applied, but present in r1 configuration"
+    assert rc, assertmsg
+
+    step("Verify router r1 interface OSPF point-to-multipoint broadcast interface")
+    verify_p2mp_interface(tgen, "r1", 3, 3, False)
+
+    step("Add r1 interface r1-eth0 p2mp non-broadcast configuration back")
+    r1.vtysh_cmd(
+        "conf t\ninterface r1-eth0\nip ospf network point-to-multipoint non-broadcast"
+    )
+    rc, _, _ = tgen.net["r1"].cmd_status(
+        "show running ospfd | grep 'ip ospf network point-to-multipoint non-broadcast'",
+        warn=False,
+    )
+    assertmsg = "'ip ospf netrwork point-to-multipoint non-broadcast' applied, but not present in R1 configuration"
+    assert rc, assertmsg
+
+    step("Verify router r1 interface OSPF point-to-multipoint non-broadcast interface")
+    verify_p2mp_interface(tgen, "r1", 3, 3, True)
+
+    step(
+        "Verify router r1 OSPF point-to-multipoint neighbors adjacencies restablished."
+    )
+    verify_p2mp_neighbor(
+        tgen, "r1", "2.2.2.2", "Full/DROther", "10.1.0.2", "r1-eth0:10.1.0.1"
+    )
+    verify_p2mp_neighbor(
+        tgen, "r1", "3.3.3.3", "Full/DROther", "10.1.0.3", "r1-eth0:10.1.0.1"
+    )
+    verify_p2mp_neighbor(
+        tgen, "r1", "4.4.4.4", "Full/DROther", "10.1.0.4", "r1-eth0:10.1.0.1"
+    )
+
+
+def test_p2mp_non_broadcast_partial_mesh_connectivity():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip("Skipped because of router(s) failure")
+
+    """
+    test_ospf_p2mp_non_broadcast.py: Test OSPF Point-to-multipoint Non-Broadcast
+                                     Partial Mesh
+    """
+
+    TOPOLOGY = """
+                +-----+             +------+
+    10.1.1.0/24 | r1  |             | r4   | 10.1.4.0/24
+     -----------+     |             |      +----------
+                +-+---+             +--+-+-+
+                  |        P2MP        |
+                  |     Non-Broadcast  |
+                  |     10.1.0.0/24    |
+                +-+---+              +-+---+
+    10.1.2.0/24 | r2  |              | r3  | 10.1.3.0/24
+     -----------+     +--------------+     +----------
+                +-----+              +-----+
+
+
+     """
+    logger.info("OSPF Point-to-MultiPoint Non-Broadcast:\n {}".format(TOPOLOGY))
+
+    step("Change configuration to a partial mesh")
+    step("Delete neighbors in full mesh")
+    r1 = tgen.gears["r1"]
+    r1.vtysh_cmd("conf t\nrouter ospf\nno neighbor 10.1.0.3")
+    r1.vtysh_cmd("conf t\nrouter ospf\nno neighbor 10.1.0.4")
+    r2 = tgen.gears["r2"]
+    r2.vtysh_cmd("conf t\nrouter ospf\nno neighbor 10.1.0.4")
+    r3 = tgen.gears["r3"]
+    r3.vtysh_cmd("conf t\nrouter ospf\nno neighbor 10.1.0.1")
+    r4 = tgen.gears["r4"]
+    r4.vtysh_cmd("conf t\nrouter ospf\nno neighbor 10.1.0.1")
+    r4.vtysh_cmd("conf t\nrouter ospf\nno neighbor 10.1.0.2")
+
+    step("Flap interfaces on P2MP network to avoid transients")
+    r1.vtysh_cmd("conf t\ninterface r1-eth0\nshut")
+    r2.vtysh_cmd("conf t\ninterface r2-eth0\nshut")
+    r3.vtysh_cmd("conf t\ninterface r3-eth0\nshut")
+    r4.vtysh_cmd("conf t\ninterface r4-eth0\nshut")
+    r1.vtysh_cmd("conf t\ninterface r1-eth0\nno shut")
+    r2.vtysh_cmd("conf t\ninterface r2-eth0\nno shut")
+    r3.vtysh_cmd("conf t\ninterface r3-eth0\nno shut")
+    r4.vtysh_cmd("conf t\ninterface r4-eth0\nno shut")
+
+    step("Verify router r1 interface OSPF point-to-multipoint non-broadcast interface")
+    verify_p2mp_interface(tgen, "r1", 1, 1, True)
+
+    step("Verify router r1 interface r1-eth0 p2mp neighbor")
+    verify_p2mp_neighbor(
+        tgen, "r1", "2.2.2.2", "Full/DROther", "10.1.0.2", "r1-eth0:10.1.0.1"
+    )
+
+    step("Verify router r1 p2mp routes are installed")
+    verify_p2mp_route(tgen, "r1", "10.1.2.0/24", 24, "10.1.0.2", "r1-eth0")
+    verify_p2mp_route(tgen, "r1", "10.1.3.0/24", 24, "10.1.0.2", "r1-eth0")
+    verify_p2mp_route(tgen, "r1", "10.1.4.0/24", 24, "10.1.0.2", "r1-eth0")
+
+    """
+    test_ospf_p2mp_non_broadcast.py: Test OSPF Point-to-multipoint Non-Broadcast
+                                     Modified Partial Mesh
+    """
+
+    TOPOLOGY = """
+                +-----+             +------+
+    10.1.1.0/24 | r1  |             | r4   | 10.1.4.0/24
+     -----------+     +-------------+      +----------
+                +-----+             +--+-+-+
+                           P2MP        |
+                        Non-Broadcast  |
+                        10.1.0.0/24    |
+                +-+---+              +-+---+
+    10.1.2.0/24 | r2  |              | r3  | 10.1.3.0/24
+     -----------+     +--------------+     +----------
+                +-----+              +-----+
+
+
+     """
+    logger.info("OSPF Point-to-MultiPoint Non-Broadcast:\n {}".format(TOPOLOGY))
+
+    step("Change configuration to a partial mesh")
+    step("Modify neighbors in partial mesh")
+    r1 = tgen.gears["r1"]
+    r1.vtysh_cmd("conf t\nrouter ospf\nno neighbor 10.1.0.2")
+    r1.vtysh_cmd("conf t\nrouter ospf\nneighbor 10.1.0.4 poll-interval 5")
+    r2 = tgen.gears["r2"]
+    r2.vtysh_cmd("conf t\nrouter ospf\nno neighbor 10.1.0.1")
+    r4 = tgen.gears["r4"]
+    r4.vtysh_cmd("conf t\nrouter ospf\nneighbor 10.1.0.1")
+
+    step("Flap interfaces on P2MP network to avoid transients")
+    r1.vtysh_cmd("conf t\ninterface r1-eth0\nshut")
+    r2.vtysh_cmd("conf t\ninterface r2-eth0\nshut")
+    r3.vtysh_cmd("conf t\ninterface r3-eth0\nshut")
+    r4.vtysh_cmd("conf t\ninterface r4-eth0\nshut")
+    r1.vtysh_cmd("conf t\ninterface r1-eth0\nno shut")
+    r2.vtysh_cmd("conf t\ninterface r2-eth0\nno shut")
+    r3.vtysh_cmd("conf t\ninterface r3-eth0\nno shut")
+    r4.vtysh_cmd("conf t\ninterface r4-eth0\nno shut")
+
+    step("Verify router r1 interface r1-eth0")
+    step("Verify router r1 interface OSPF point-to-multipoint non-broadcast interface")
+    verify_p2mp_interface(tgen, "r1", 1, 1, True)
+
+    step("Verify router r1 interface r1-eth0 p2mp neighbor")
+    input_dict = {
+        "neighbors": {
+            "4.4.4.4": [
+                {
+                    "nbrState": "Full/DROther",
+                    "ifaceAddress": "10.1.0.4",
+                    "ifaceName": "r1-eth0:10.1.0.1",
+                }
+            ],
+        }
+    }
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip ospf neighbor json", input_dict
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "P2MP Non-Broadcast Neighbors not adjacent on router r1"
+    assert result is None, assertmsg
+
+    step("Verify router r1 interface r1-eth0 p2mp routes are installed")
+    verify_p2mp_route(tgen, "r1", "10.1.2.0/24", 24, "10.1.0.4", "r1-eth0")
+    verify_p2mp_route(tgen, "r1", "10.1.3.0/24", 24, "10.1.0.4", "r1-eth0")
+    verify_p2mp_route(tgen, "r1", "10.1.4.0/24", 24, "10.1.0.4", "r1-eth0")
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
This extends non-broadcast support to point-to-multipoint networks. Neighbors will be explicitly configured and polled in lieu of multicast dicovery. Toptotests and documentation updates are included.

The AllOSPFRouters (224.0.0.5) is still joined for non-broadcast networks since it is joined for NBMA networks. It seems this could be removed but it should done be in a separate commit.