### PR TITLE
bgpd : Ensure logging for dynamic neighbor listen limit reached

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4403,6 +4403,11 @@ struct peer *peer_lookup_dynamic_neighbor(struct bgp *bgp, union sockunion *su)
 		zlog_debug("%s Dynamic Neighbor added, group %s count %d",
 			   peer->host, group->name, dncount);
 
+	if (dncount == gbgp->dynamic_neighbors_limit) {
+		zlog_warn("Dynamic Neighbor %s added as last connection. Peer-group %s reached maximum listen limit %d",
+			  peer->host, group->name,
+			  gbgp->dynamic_neighbors_limit);
+	}
 	return peer;
 }
 


### PR DESCRIPTION
Description :
------
Dynamic neighbors exceeding the listen limit were rejected without appropriate logging. Previously, only rejection logs were generated, leaving users unaware of when the limit being reached.

Fix :
------
Adding a log message for when the listen limit is reached.

Signed-off-by: Pooja Rathore <rathorepo@vmware.com>