### PR TITLE
isisd: fix mispelling with ISIS_SR_LAN_BACKUP

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -687,7 +687,7 @@ void isis_adj_print_json(struct isis_adjacency *adj, struct json_object *json,
 			default:
 				continue;
 			}
-			backup = (sra->type == ISIS_SR_LAN_BACKUP) ? " (backup)"
+			backup = (sra->type == ISIS_SR_ADJ_BACKUP) ? " (backup)"
 								   : "";
 
 			json_object_string_add(adj_sid_json, "nexthop",
@@ -862,7 +862,7 @@ void isis_adj_print_vty(struct isis_adjacency *adj, struct vty *vty,
 			default:
 				continue;
 			}
-			backup = (sra->type == ISIS_SR_LAN_BACKUP) ? " (backup)"
+			backup = (sra->type == ISIS_SR_ADJ_BACKUP) ? " (backup)"
 								   : "";
 
 			vty_out(vty, "    %s %s%s: %u\n",

--- a/isisd/isis_lfa.c
+++ b/isisd/isis_lfa.c
@@ -916,9 +916,8 @@ int isis_tilfa_check(struct isis_spftree *spftree_pc,
 
 		adj = isis_adj_find(spftree_pc->area, spftree_pc->level,
 				    vertex->N.id);
-		if (adj
-		    && isis_sr_adj_sid_find(adj, spftree_pc->family,
-					    ISIS_SR_LAN_BACKUP)) {
+		if (adj && isis_sr_adj_sid_find(adj, spftree_pc->family,
+						ISIS_SR_ADJ_BACKUP)) {
 			if (IS_DEBUG_LFA)
 				zlog_debug(
 					"ISIS-LFA: %s %s already covered by node protection",

--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -462,8 +462,7 @@ void isis_area_delete_backup_adj_sids(struct isis_area *area, int level)
 	struct listnode *node, *nnode;
 
 	for (ALL_LIST_ELEMENTS(area->srdb.adj_sids, node, nnode, sra))
-		if (sra->type == ISIS_SR_LAN_BACKUP
-		    && (sra->adj->level & level))
+		if (sra->type == ISIS_SR_ADJ_BACKUP && (sra->adj->level & level))
 			sr_adj_sid_del(sra);
 }
 
@@ -689,7 +688,7 @@ void sr_adj_sid_add_single(struct isis_adjacency *adj, int family, bool backup,
 		circuit->ext = isis_alloc_ext_subtlvs();
 
 	sra = XCALLOC(MTYPE_ISIS_SR_INFO, sizeof(*sra));
-	sra->type = backup ? ISIS_SR_LAN_BACKUP : ISIS_SR_ADJ_NORMAL;
+	sra->type = backup ? ISIS_SR_ADJ_BACKUP : ISIS_SR_ADJ_NORMAL;
 	sra->input_label = input_label;
 	sra->nexthop.family = family;
 	sra->nexthop.address = nexthop;
@@ -819,7 +818,7 @@ static void sr_adj_sid_del(struct sr_adjacency *sra)
 		exit(1);
 	}
 
-	if (sra->type == ISIS_SR_LAN_BACKUP && sra->backup_nexthops) {
+	if (sra->type == ISIS_SR_ADJ_BACKUP && sra->backup_nexthops) {
 		sra->backup_nexthops->del =
 			(void (*)(void *))isis_nexthop_delete;
 		list_delete(&sra->backup_nexthops);

--- a/isisd/isis_sr.h
+++ b/isisd/isis_sr.h
@@ -82,7 +82,7 @@ struct sr_local_block {
 /* Segment Routing Adjacency-SID type. */
 enum sr_adj_type {
 	ISIS_SR_ADJ_NORMAL = 0,
-	ISIS_SR_LAN_BACKUP,
+	ISIS_SR_ADJ_BACKUP,
 };
 
 /* Segment Routing Adjacency. */

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -454,7 +454,7 @@ void isis_zebra_send_adjacency_sid(int cmd, const struct sr_adjacency *sra)
 	znh->labels[0] = MPLS_LABEL_IMPLICIT_NULL;
 
 	/* Set backup nexthops. */
-	if (sra->type == ISIS_SR_LAN_BACKUP) {
+	if (sra->type == ISIS_SR_ADJ_BACKUP) {
 		int count;
 
 		count = isis_zebra_add_nexthops(isis, sra->backup_nexthops,


### PR DESCRIPTION
The ISIS_SR_LAN_BACKUP should be renamed to ISIS_SR_ADJ_BACKUP.

Fixes: 26f6acafc369 ("isisd: add support for segment routing")