### PR TITLE
BGP TCP non established : get port and ip

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1796,6 +1796,22 @@ bgp_connect_fail(struct peer_connection *connection)
 	return bgp_stop(connection);
 }
 
+/* after connect is called(), getpeername is able to return
+ * port and address on non established streams
+ */
+static void bgp_connect_in_progress_update_connection(struct peer *peer)
+{
+	bgp_getsockname(peer);
+	if (!peer->su_remote && !BGP_CONNECTION_SU_UNSPEC(peer->connection)) {
+		/* if connect initiated, then dest port and dest addresses are well known */
+		peer->su_remote = sockunion_dup(&peer->connection->su);
+		if (sockunion_family(peer->su_remote) == AF_INET)
+			peer->su_remote->sin.sin_port = htons(peer->port);
+		else if (sockunion_family(peer->su_remote) == AF_INET6)
+			peer->su_remote->sin6.sin6_port = htons(peer->port);
+	}
+}
+
 /* This function is the first starting point of all BGP connection. It
  * try to connect to remote peer with non-blocking IO.
  */
@@ -1892,6 +1908,8 @@ static enum bgp_fsm_state_progress bgp_start(struct peer_connection *connection)
 				 __func__, peer->connection->fd);
 			return BGP_FSM_FAILURE;
 		}
+		bgp_connect_in_progress_update_connection(peer);
+
 		/*
 		 * - when the socket becomes ready, poll() will signify POLLOUT
 		 * - if it fails to connect, poll() will signify POLLHUP

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -875,11 +875,7 @@ int bgp_getsockname(struct peer *peer)
 	}
 
 	peer->su_local = sockunion_getsockname(peer->connection->fd);
-	if (!peer->su_local)
-		return -1;
 	peer->su_remote = sockunion_getpeername(peer->connection->fd);
-	if (!peer->su_remote)
-		return -1;
 
 	if (!bgp_zebra_nexthop_set(peer->su_local, peer->su_remote,
 				   &peer->nexthop, peer)) {


### PR DESCRIPTION
On non established TCP sessions, the remote/local address/port information is not available.
However, for outgoing TCP connections, this is possible.

Lets do it.

