### PR TITLE
zebra: fix wrong check for mpls label

### DIFF
--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -2476,7 +2476,7 @@ static int zebra_mpls_cleanup_zclient_labels(struct zserv *client)
  * hash..
  */
 struct zebra_fec *zebra_mpls_fec_for_label(struct zebra_vrf *zvrf,
-					   mpls_label_t label)
+					   struct prefix *p, mpls_label_t label)
 {
 	struct route_node *rn;
 	struct zebra_fec *fec;
@@ -2491,8 +2491,11 @@ struct zebra_fec *zebra_mpls_fec_for_label(struct zebra_vrf *zvrf,
 			if (!rn->info)
 				continue;
 			fec = rn->info;
-			if (fec->label == label)
+			if (fec->label == label) {
+				if (p && prefix_same(p, &rn->p))
+					return NULL;
 				return fec;
+			}
 		}
 	}
 
@@ -2502,9 +2505,10 @@ struct zebra_fec *zebra_mpls_fec_for_label(struct zebra_vrf *zvrf,
 /*
  * Inform if specified label is currently bound to a FEC or not.
  */
-int zebra_mpls_label_already_bound(struct zebra_vrf *zvrf, mpls_label_t label)
+int zebra_mpls_label_already_bound(struct zebra_vrf *zvrf, struct prefix *p,
+				   mpls_label_t label)
 {
-	return (zebra_mpls_fec_for_label(zvrf, label) ? 1 : 0);
+	return (zebra_mpls_fec_for_label(zvrf, p, label) ? 1 : 0);
 }
 
 /*

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -203,12 +203,13 @@ int zebra_mpls_fec_unregister(struct zebra_vrf *zvrf, struct prefix *p,
  * hash..
  */
 struct zebra_fec *zebra_mpls_fec_for_label(struct zebra_vrf *zvrf,
-					   mpls_label_t label);
+					   struct prefix *p, mpls_label_t label);
 
 /*
  * Inform if specified label is currently bound to a FEC or not.
  */
-int zebra_mpls_label_already_bound(struct zebra_vrf *zvrf, mpls_label_t label);
+int zebra_mpls_label_already_bound(struct zebra_vrf *zvrf, struct prefix *p,
+				   mpls_label_t label);
 
 /*
  * Add static FEC to label binding. If there are clients registered for this

--- a/zebra/zebra_mpls_vty.c
+++ b/zebra/zebra_mpls_vty.c
@@ -210,7 +210,7 @@ static int zebra_mpls_bind(struct vty *vty, int add_cmd, const char *prefix,
 				vty_out(vty, "%% Invalid label\n");
 				return CMD_WARNING_CONFIG_FAILED;
 			}
-			if (zebra_mpls_label_already_bound(zvrf, label)) {
+			if (zebra_mpls_label_already_bound(zvrf, &p, label)) {
 				vty_out(vty,
 					"%% Label already bound to a FEC\n");
 				return CMD_WARNING_CONFIG_FAILED;


### PR DESCRIPTION
Add a parameter for `zebra_mpls_fec_for_label()`, as before if it is `NULL`, otherwise exclude what this parameter represents.

Before:
```
anlan(config)# mpls label bind 1.1.1.2/32 88
anlan(config)# mpls label bind 1.1.1.2/32 88
% Label already bound to a FEC
anlan(config)# mpls label bind 1.1.1.3/32 88
% Label already bound to a FEC
```

After:
```
anlan(config)# mpls label bind 1.1.1.2/32 88
anlan(config)# mpls label bind 1.1.1.2/32 88
anlan(config)# mpls label bind 1.1.1.3/32 88
% Label already bound to a FEC
```

The immediate effect is that  `systemctl reload frr` will fail with adding this command line without this commit.