### PR TITLE
bfdd: Add check for flag Multipoint (M)

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -89,6 +89,8 @@ struct bfd_echo_pkt {
 #define BFD_CBIT 0x08
 #define BFD_ABIT 0x04
 #define BFD_DEMANDBIT 0x02
+#define BFD_MBIT	      0x01
+#define BFD_GETMBIT(flags)    (flags & BFD_MBIT)
 #define BFD_SETDEMANDBIT(flags, val)                                           \
 	{                                                                      \
 		if ((val))                                                     \

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -862,6 +862,12 @@ void bfd_recv_cb(struct event *t)
 		return;
 	}
 
+	if (BFD_GETMBIT(cp->flags)) {
+		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
+			 "detect non-zero Multipoint (M) flag");
+		return;
+	}
+
 	if (cp->discrs.my_discr == 0) {
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
 			 "'my discriminator' is zero");


### PR DESCRIPTION
According to RFC 5880:
Multipoint (M)
This bit is reserved for future point-to-multipoint extensions to BFD. It MUST be zero on both transmit and receipt.
Signed-off-by: zmw12306 <zmw12306@gmail.com>