### PR TITLE
tools: frr-reload strip interface vrf ctx line

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -220,6 +220,23 @@ def get_normalized_mac_ip_line(line):
     return line
 
 
+def get_normalized_interface_vrf(line):
+    """
+    If 'interface <int_name> vrf <vrf_name>' is present in file,
+    we need to remove the explicit "vrf <vrf_name>"
+    so that the context information is created
+    correctly and configurations are matched appropriately.
+    """
+
+    intf_vrf = re.search("interface (\S+) vrf (\S+)", line)
+    if intf_vrf:
+        old_line = "vrf %s" % intf_vrf.group(2)
+        new_line = line.replace(old_line, "").strip()
+        return new_line
+
+    return line
+
+
 # This dictionary contains a tree of all commands that we know start a
 # new multi-line context. All other commands are treated either as
 # commands inside a multi-line context or as single-line contexts. This
@@ -294,6 +311,10 @@ class Config(object):
 
             # Compress duplicate whitespaces
             line = " ".join(line.split())
+
+            # Remove 'vrf <vrf_name>' from 'interface <x> vrf <vrf_name>'
+            if line.startswith("interface ") and "vrf" in line:
+                line = get_normalized_interface_vrf(line)
 
             if ":" in line:
                 line = get_normalized_mac_ip_line(line)


### PR DESCRIPTION
if frr.conf file contains 'interface x vrf <name> config it causes protocol (like ospf) neighbor session flap, as replayed via frr-reload deletes interface base config line ('interface x') from running config and readds with 'interface x vrf <name>' line from frr.conf.
This deletion and re-addition of lines leads to neighborship flaps.

This issue is by product of (PR-10411 | https://github.com/FRRouting/frr/pull/10411) (commit id: 788a036fdb)
where running config for interface config no loger displays associated vrf line.


Testing:

frr.conf:
```
interface swp1.2 vrf vrf1012
ip ospf network point-to-point
```
running-config:
```
interface swp1.2
 ip ospf network point-to-point
 exit
```

Before fix:

frr-reload logs:
```
2024-04-09 00:28:31,096  INFO: Executed "interface swp1.2  no ip ospf network point-to-point exit"

 'interface swp1.2 vrf vrf1012\n ip ospf network
 point-to-point\nexit\n',
```

After fix:
frr-reload strips vrf line, thus no config change between frr.conf and running config.


Signed-off-by: Chirag Shah <chirag@nvidia.com>
