### PR TITLE
isisd: The hold time of hello packets on a P2P link does not match the sending interval.

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -358,12 +358,14 @@ void isis_adj_state_change(struct isis_adjacency **padj,
 				 * purposes */
 				adj->last_flap = time(NULL);
 				adj->flaps++;
-			} else if (old_state == ISIS_ADJ_UP) {
-				circuit->adj_state_changes++;
+			} else {
+				if (old_state == ISIS_ADJ_UP) {
+					circuit->adj_state_changes++;
 
-				circuit->upadjcount[level - 1]--;
-				if (circuit->upadjcount[level - 1] == 0)
-					isis_tx_queue_clean(circuit->tx_queue);
+					circuit->upadjcount[level - 1]--;
+					if (circuit->upadjcount[level - 1] == 0)
+						isis_tx_queue_clean(circuit->tx_queue);
+				}
 
 				if (new_state == ISIS_ADJ_DOWN) {
 					listnode_delete(
@@ -409,10 +411,12 @@ void isis_adj_state_change(struct isis_adjacency **padj,
 						master, send_l2_csnp, circuit,
 						0, &circuit->t_send_csnp[1]);
 				}
-			} else if (old_state == ISIS_ADJ_UP) {
-				circuit->upadjcount[level - 1]--;
-				if (circuit->upadjcount[level - 1] == 0)
-					isis_tx_queue_clean(circuit->tx_queue);
+			} else {
+				if (old_state == ISIS_ADJ_UP) {
+					circuit->upadjcount[level - 1]--;
+					if (circuit->upadjcount[level - 1] == 0)
+						isis_tx_queue_clean(circuit->tx_queue);
+				}
 
 				if (new_state == ISIS_ADJ_DOWN) {
 					if (adj->circuit->u.p2p.neighbor == adj)

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -2082,7 +2082,7 @@ static void send_hello_cb(struct event *thread)
 		circuit->u.p2p.t_send_p2p_hello = NULL;
 		send_hello(circuit, 1);
 		send_hello_sched(circuit, ISIS_LEVEL1,
-				 1000 * circuit->hello_interval[1]);
+				 1000 * circuit->hello_interval[0]);
 		return;
 	}
 


### PR DESCRIPTION
The hold time filled in the hello packets of a P2P link is calculated based on the level 1 configuration, while the hello timer is based on the level 2 configuration. If the hello interval times in level 1 and level 2 configurations are inconsistent, it may lead to neighbor establishment failure.