### PR TITLE
lib: serialize pthread startup

### DIFF
--- a/lib/frr_pthread.h
+++ b/lib/frr_pthread.h
@@ -47,6 +47,17 @@ struct frr_pthread {
 	struct frr_pthread_attr attr;
 
 	/*
+	 * Startup serialization: newly-started pthreads wait at a point
+	 * very early in life so that there isn't a race with the
+	 * starting pthread. The OS 'start' apis don't make any guarantees
+	 * about which pthread runs first - the existing pthread that has
+	 * called the 'start' api, or the new pthread that is just starting.
+	 */
+	pthread_cond_t startup_cond;
+	pthread_mutex_t startup_cond_mtx;
+	atomic_bool started;
+
+	/*
 	 * Notification mechanism for allowing pthreads to notify their parents
 	 * when they are ready to do work. This mechanism has two associated
 	 * functions:


### PR DESCRIPTION
Add a new condition var and mutex to serialize pthread startup. The order in which the parent and a new child run is not deterministic. With this change, when a new pthread is started it will wait very early on for the parent pthread to permit it to run. This ensures that that the ordering between parent and child is predictable.

Fixes: #15699 