### PR TITLE
isisd: The hold time of hello packets on a P2P link does not match the sending interval.

### DIFF
--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -2082,7 +2082,7 @@ static void send_hello_cb(struct event *thread)
 		circuit->u.p2p.t_send_p2p_hello = NULL;
 		send_hello(circuit, 1);
 		send_hello_sched(circuit, ISIS_LEVEL1,
-				 1000 * circuit->hello_interval[1]);
+				 1000 * circuit->hello_interval[0]);
 		return;
 	}
 


### PR DESCRIPTION
The hold time filled in the hello packets of a P2P link is calculated based on the level 1 configuration, while the hello timer is based on the level 2 configuration. If the hello interval times in level 1 and level 2 configurations are inconsistent, it may lead to neighbor establishment failure.

Signed-off-by: zhou-run <zhou.run@h3c.com>