### PR TITLE
isisd: Fix memory leaks when the transition of neighbor state from non-UP to DOWN

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -358,12 +358,15 @@ void isis_adj_state_change(struct isis_adjacency **padj,
 				 * purposes */
 				adj->last_flap = time(NULL);
 				adj->flaps++;
-			} else if (old_state == ISIS_ADJ_UP) {
-				circuit->adj_state_changes++;
+			} else {
+				if (old_state == ISIS_ADJ_UP) {
+					circuit->adj_state_changes++;
 
-				circuit->upadjcount[level - 1]--;
-				if (circuit->upadjcount[level - 1] == 0)
-					isis_tx_queue_clean(circuit->tx_queue);
+					circuit->upadjcount[level - 1]--;
+					if (circuit->upadjcount[level - 1] == 0)
+						isis_tx_queue_clean(
+							circuit->tx_queue);
+				}
 
 				if (new_state == ISIS_ADJ_DOWN) {
 					listnode_delete(
@@ -409,10 +412,13 @@ void isis_adj_state_change(struct isis_adjacency **padj,
 						master, send_l2_csnp, circuit,
 						0, &circuit->t_send_csnp[1]);
 				}
-			} else if (old_state == ISIS_ADJ_UP) {
-				circuit->upadjcount[level - 1]--;
-				if (circuit->upadjcount[level - 1] == 0)
-					isis_tx_queue_clean(circuit->tx_queue);
+			} else {
+				if (old_state == ISIS_ADJ_UP) {
+					circuit->upadjcount[level - 1]--;
+					if (circuit->upadjcount[level - 1] == 0)
+						isis_tx_queue_clean(
+							circuit->tx_queue);
+				}
 
 				if (new_state == ISIS_ADJ_DOWN) {
 					if (adj->circuit->u.p2p.neighbor == adj)


### PR DESCRIPTION
When receiving a hello packet, if the neighbor state transitions directly from a non-ISIS_ADJ_UP state (such as ISIS_ADJ_INITIALIZING) to ISIS_ADJ_DOWN state, the neighbor entry cannot be deleted. If the neighbor is removed or the neighbor's System ID changes, it may result in memory leakage in the neighbor entry.

Test Scenario:
LAN link between Router A and Router B is established. Router A does not configure neighbor authentication, while Router B is configured with neighbor authentication. When the neighbor entry on Router B ages out, the neighbor state on Router A transitions to INIT. If Router B is then removed, the neighbor state on Router A transitions to DOWN and persists.

Signed-off-by: zhou-run <zhou.run@h3c.com>