### PR TITLE
bgpd: do allocate vrf label only when necessary

### DIFF
--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -170,16 +170,6 @@ static inline int vpn_leak_to_vpn_active(struct bgp *bgp_vrf, afi_t afi,
 		return 0;
 	}
 
-	/* Is there an "auto" export label that isn't allocated yet? */
-	if (CHECK_FLAG(bgp_vrf->vpn_policy[afi].flags,
-		BGP_VPN_POLICY_TOVPN_LABEL_AUTO) &&
-		(bgp_vrf->vpn_policy[afi].tovpn_label == MPLS_LABEL_NONE)) {
-
-		if (pmsg)
-			*pmsg = "auto label not allocated";
-		return 0;
-	}
-
 	/* Is there a "manual" export label that isn't allocated yet? */
 	if (!CHECK_FLAG(bgp_vrf->vpn_policy[afi].flags,
 			BGP_VPN_POLICY_TOVPN_LABEL_AUTO) &&

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -9711,8 +9711,6 @@ DEFPY (af_label_vpn_export,
 				 BGP_VPN_POLICY_TOVPN_LABEL_AUTO);
 			/* fetch a label */
 			bgp->vpn_policy[afi].tovpn_label = MPLS_LABEL_NONE;
-			bgp_lp_get(LP_TYPE_VRF, &bgp->vpn_policy[afi],
-				   vpn_leak_label_callback);
 		} else {
 			bgp->vpn_policy[afi].tovpn_label = label;
 			UNSET_FLAG(bgp->vpn_policy[afi].flags,


### PR DESCRIPTION
Today, with the following bgp instance configured, the local VRF label is allocated even if it is not used.

> router bgp 65500 vrf vrf1
>  address-family ipv4 unicast
>   label vpn export allocation-mode per-nexthop
>   label vpn export auto
>   rd vpn export 444:1
>   rt vpn both 52:100
>   export vpn
>   import vpn

The 'show mpls table' indicates that the 16 label value is allocated, but never used in the exported prefixes.

> r1# show mpls table
>  Inbound Label  Type  Nexthop         Outbound Label
>  -----------------------------------------------------
>  16             BGP   vrf1            -
>  17             BGP   192.168.255.13  -
>  18             BGP   192.0.2.12      -
>  19             BGP   192.0.2.11      -

Fix this by only allocating new label values when really used. Consequently, only 3 labels will be allocated instead of previously 4.

> r1# show mpls table
>  Inbound Label  Type  Nexthop         Outbound Label
>  -----------------------------------------------------
>  16             BGP   192.168.255.13  -
>  17             BGP   192.0.2.11      -
>  18             BGP   192.0.2.12      -

Fixes: 577be36a41be ("bgpd: add support for l3vpn per-nexthop label")