### PR TITLE
bgpd: fix 'show bgp neighbors' output

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -12750,7 +12750,7 @@ static void bgp_show_neighbor_graceful_restart_remote_mode(struct vty *vty,
 	if (json)
 		json_object_string_add(json, "remoteGrMode", mode);
 	else
-		vty_out(vty, "%s\n", mode);
+		vty_out(vty, "%s", mode);
 }
 
 static void bgp_show_neighbor_graceful_restart_local_mode(struct vty *vty,
@@ -12782,7 +12782,7 @@ static void bgp_show_neighbor_graceful_restart_local_mode(struct vty *vty,
 	if (json)
 		json_object_string_add(json, "localGrMode", mode);
 	else
-		vty_out(vty, "%s\n", mode);
+		vty_out(vty, "%s", mode);
 }
 
 static void bgp_show_neighbor_graceful_restart_capability_per_afi_safi(


### PR DESCRIPTION
The 'show bgp neighbors' output appends additional lines after GR mode
helpers.

> # show bgp neighbors
> [..]
>     End-of-RIB received: IPv4 VPN
>     Local GR Mode: Helper*
>
>     Remote GR Mode: Helper
>
>     R bit: True
>

Fix this by not appending the extra line feed.

> # show bgp neighbors
> [..]
>     End-of-RIB received: IPv4 VPN
>     Local GR Mode: Helper*
>     Remote GR Mode: Helper
>     R bit: True

Fixes: 0e4e879b4084 ("bgpd: fix silly format string SNAFU")