### PR TITLE
ospf6d: add conditional debug log macro

### DIFF
--- a/lib/zlog.h
+++ b/lib/zlog.h
@@ -115,6 +115,8 @@ static inline void zlog_ref(const struct xref_logmsg *xref,
 #define zlog_notice(...) _zlog_ecref(0, LOG_NOTICE, __VA_ARGS__)
 #define zlog_debug(...)  _zlog_ecref(0, LOG_DEBUG, __VA_ARGS__)
 
+#define zlog_debug_if(condition, ...) if (condition) zlog_debug(__VA_ARGS__)
+
 #define flog_err(ferr_id, format, ...)                                         \
 	_zlog_ecref(ferr_id, LOG_ERR, format, ## __VA_ARGS__)
 #define flog_warn(ferr_id, format, ...)                                        \

--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -56,8 +56,8 @@ bool ospf6_check_and_set_router_abr(struct ospf6 *o)
 	bool is_backbone = false;
 
 	for (ALL_LIST_ELEMENTS_RO(o->area_list, node, oa)) {
-		if (IS_OSPF6_DEBUG_ABR)
-			zlog_debug("%s, area_id %pI4", __func__, &oa->area_id);
+		zlog_debug_if(IS_OSPF6_DEBUG_ABR, "%s, area_id %pI4", __func__,
+			      &oa->area_id);
 		if (IS_AREA_ENABLED(oa))
 			area_count++;
 
@@ -66,13 +66,13 @@ bool ospf6_check_and_set_router_abr(struct ospf6 *o)
 	}
 
 	if ((area_count > 1) && (is_backbone)) {
-		if (IS_OSPF6_DEBUG_ABR)
-			zlog_debug("%s : set flag OSPF6_FLAG_ABR", __func__);
+		zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+			      "%s : set flag OSPF6_FLAG_ABR", __func__);
 		SET_FLAG(o->flag, OSPF6_FLAG_ABR);
 		return true;
 	} else {
-		if (IS_OSPF6_DEBUG_ABR)
-			zlog_debug("%s : reset flag OSPF6_FLAG_ABR", __func__);
+		zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+			      "%s : reset flag OSPF6_FLAG_ABR", __func__);
 		UNSET_FLAG(o->flag, OSPF6_FLAG_ABR);
 		return false;
 	}
@@ -200,28 +200,25 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 	    && route->type != OSPF6_DEST_TYPE_RANGE
 	    && ((route->type != OSPF6_DEST_TYPE_ROUTER)
 		|| !CHECK_FLAG(route->path.router_bits, OSPF6_ROUTER_BIT_E))) {
-		if (IS_OSPF6_DEBUG_ABR)
-			zlog_debug(
-				"%s: Route type %d flag 0x%x is none of network, range nor ASBR, ignore",
-				__func__, route->type, route->path.router_bits);
+		zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+			      "%s: Route type %d flag 0x%x is none of network, range nor ASBR, ignore",
+			      __func__, route->type, route->path.router_bits);
 		return 0;
 	}
 
 	/* AS External routes are never considered */
 	if (route->path.type == OSPF6_PATH_TYPE_EXTERNAL1
 	    || route->path.type == OSPF6_PATH_TYPE_EXTERNAL2) {
-		if (IS_OSPF6_DEBUG_ABR)
-			zlog_debug("%s : Path type is external, skip",
-				   __func__);
+		zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+			      "%s : Path type is external, skip", __func__);
 		return 0;
 	}
 
 	/* do not generate if the path's area is the same as target area */
 	if (route->path.area_id == area->area_id) {
-		if (IS_OSPF6_DEBUG_ABR)
-			zlog_debug(
-				"%s: The route is in the area itself, ignore",
-				__func__);
+		zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+			      "%s: The route is in the area itself, ignore",
+			      __func__);
 		return 0;
 	}
 
@@ -237,10 +234,9 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		    && access_list_apply(EXPORT_LIST(route_area),
 					 &route->prefix)
 			       == FILTER_DENY) {
-			if (IS_OSPF6_DEBUG_ABR)
-				zlog_debug(
-					"%s: prefix %pFX was denied by export-list",
-					__func__, &route->prefix);
+			zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+				      "%s: prefix %pFX was denied by export-list",
+				      __func__, &route->prefix);
 			filter = true;
 		}
 
@@ -249,10 +245,9 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		    && prefix_list_apply(PREFIX_LIST_OUT(route_area),
 					 &route->prefix)
 			       != PREFIX_PERMIT) {
-			if (IS_OSPF6_DEBUG_ABR)
-				zlog_debug(
-					"%s: prefix %pFX was denied by prefix-list out",
-					__func__, &route->prefix);
+			zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+				      "%s: prefix %pFX was denied by prefix-list out",
+				      __func__, &route->prefix);
 			filter = true;
 		}
 
@@ -260,10 +255,9 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		if (IMPORT_LIST(area)
 		    && access_list_apply(IMPORT_LIST(area), &route->prefix)
 			       == FILTER_DENY) {
-			if (IS_OSPF6_DEBUG_ABR)
-				zlog_debug(
-					"%s: prefix %pFX was denied by import-list",
-					__func__, &route->prefix);
+			zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+				      "%s: prefix %pFX was denied by import-list",
+				      __func__, &route->prefix);
 			filter = true;
 		}
 
@@ -271,10 +265,9 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		if (PREFIX_LIST_IN(area)
 		    && prefix_list_apply(PREFIX_LIST_IN(area), &route->prefix)
 			       != PREFIX_PERMIT) {
-			if (IS_OSPF6_DEBUG_ABR)
-				zlog_debug(
-					"%s: prefix %pFX was denied by prefix-list in",
-					__func__, &route->prefix);
+			zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+				      "%s: prefix %pFX was denied by prefix-list in",
+				      __func__, &route->prefix);
 			filter = true;
 		}
 
@@ -290,21 +283,19 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 
 	/* do not generate if the nexthops belongs to the target area */
 	if (ospf6_abr_nexthops_belong_to_area(route, area)) {
-		if (IS_OSPF6_DEBUG_ABR)
-			zlog_debug(
-				"%s: The route's nexthop is in the same area, ignore",
-				__func__);
+		zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+			      "%s: The route's nexthop is in the same area, ignore",
+			      __func__);
 		return 0;
 	}
 
 	if (route->type == OSPF6_DEST_TYPE_ROUTER) {
 		if (ADV_ROUTER_IN_PREFIX(&route->prefix)
 		    == area->ospf6->router_id) {
-			if (IS_OSPF6_DEBUG_ABR)
-				zlog_debug(
-					"%s: Skipping ASBR announcement for ABR (%pI4)",
-					__func__,
-					&ADV_ROUTER_IN_PREFIX(&route->prefix));
+			zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+				      "%s: Skipping ASBR announcement for ABR (%pI4)",
+				      __func__,
+				      &ADV_ROUTER_IN_PREFIX(&route->prefix));
 			return 0;
 		}
 	}
@@ -313,11 +304,10 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		if (IS_OSPF6_DEBUG_ABR
 		    || IS_OSPF6_DEBUG_ORIGINATE(INTER_ROUTER)) {
 			is_debug++;
-			if (IS_OSPF6_DEBUG_ABR)
-				zlog_debug(
-					"Originating summary in area %s for ASBR %pI4",
-					area->name,
-					&ADV_ROUTER_IN_PREFIX(&route->prefix));
+			zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+				      "Originating summary in area %s for ASBR %pI4",
+				      area->name,
+				      &ADV_ROUTER_IN_PREFIX(&route->prefix));
 		}
 	} else {
 		if (IS_OSPF6_DEBUG_ABR
@@ -328,11 +318,10 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		    route->path.origin.type ==
 		    htons(OSPF6_LSTYPE_INTER_PREFIX)) {
 			if (!CHECK_FLAG(route->flag, OSPF6_ROUTE_BEST)) {
-				if (is_debug)
-					zlog_debug(
-						"%s: route %pFX with cost %u is not best, ignore.",
-						__func__, &route->prefix,
-						route->path.cost);
+				zlog_debug_if(is_debug,
+					      "%s: route %pFX with cost %u is not best, ignore.",
+					      __func__, &route->prefix,
+					      route->path.cost);
 				return 0;
 			}
 		}
@@ -340,34 +329,30 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		if (route->path.origin.type ==
 		    htons(OSPF6_LSTYPE_INTRA_PREFIX)) {
 			if (!CHECK_FLAG(route->flag, OSPF6_ROUTE_BEST)) {
-				if (is_debug)
-					zlog_debug(
-						"%s: intra-prefix route %pFX with cost %u is not best, ignore.",
-						__func__, &route->prefix,
-						route->path.cost);
+				zlog_debug_if(is_debug,
+					      "%s: intra-prefix route %pFX with cost %u is not best, ignore.",
+					      __func__, &route->prefix,
+					      route->path.cost);
 				return 0;
 			}
 		}
 
-		if (is_debug)
-			zlog_debug(
-				"Originating summary in area %s for %pFX cost %u",
-				area->name, &route->prefix, route->path.cost);
+		zlog_debug_if(is_debug,
+			      "Originating summary in area %s for %pFX cost %u",
+			      area->name, &route->prefix, route->path.cost);
 	}
 
 	/* if this route has just removed, remove corresponding LSA */
 	if (CHECK_FLAG(route->flag, OSPF6_ROUTE_REMOVE)) {
-		if (is_debug)
-			zlog_debug(
-				"The route has just removed, purge previous LSA");
+		zlog_debug_if(is_debug,
+			      "The route has just removed, purge previous LSA");
 
 		if (route->type == OSPF6_DEST_TYPE_RANGE) {
 			/* Whether the route have active longer prefix */
 			if (!CHECK_FLAG(route->flag,
 					OSPF6_ROUTE_ACTIVE_SUMMARY)) {
-				if (is_debug)
-					zlog_debug(
-						"The range is not active. withdraw");
+				zlog_debug_if(is_debug,
+					      "The range is not active. withdraw");
 
 				ospf6_abr_delete_route(summary, summary_table,
 						       old);
@@ -381,9 +366,8 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 
 	if ((route->type == OSPF6_DEST_TYPE_ROUTER)
 	    && (IS_AREA_STUB(area) || IS_AREA_NSSA(area))) {
-		if (is_debug)
-			zlog_debug(
-				"Area has been stubbed, purge Inter-Router LSA");
+		zlog_debug_if(is_debug,
+			      "Area has been stubbed, purge Inter-Router LSA");
 
 		ospf6_abr_delete_route(summary, summary_table, old);
 		return 0;
@@ -391,8 +375,8 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 
 	if (area->no_summary
 	    && (route->path.subtype != OSPF6_PATH_SUBTYPE_DEFAULT_RT)) {
-		if (is_debug)
-			zlog_debug("Area has been stubbed, purge prefix LSA");
+		zlog_debug_if(is_debug,
+			      "Area has been stubbed, purge prefix LSA");
 
 		ospf6_abr_delete_route(summary, summary_table, old);
 		return 0;
@@ -413,9 +397,8 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		 */
 		if ((route->type != OSPF6_DEST_TYPE_RANGE)
 		    && (route->path.cost != OSPF_AREA_RANGE_COST_UNSPEC)) {
-			if (is_debug)
-				zlog_debug(
-					"The cost exceeds LSInfinity, withdraw");
+			zlog_debug_if(is_debug,
+				      "The cost exceeds LSInfinity, withdraw");
 			if (old)
 				ospf6_lsa_purge(old);
 			return 0;
@@ -426,9 +409,8 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 	if (route->type == OSPF6_DEST_TYPE_ROUTER) {
 		/* Only the preferred best path is considered */
 		if (!CHECK_FLAG(route->flag, OSPF6_ROUTE_BEST)) {
-			if (is_debug)
-				zlog_debug(
-					"This is the secondary path to the ASBR, ignore");
+			zlog_debug_if(is_debug,
+				      "This is the secondary path to the ASBR, ignore");
 			ospf6_abr_delete_route(summary, summary_table, old);
 			return 0;
 		}
@@ -439,10 +421,9 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		assert(route_area);
 
 		if (IS_AREA_NSSA(route_area)) {
-			if (is_debug)
-				zlog_debug(
-					"%s: The route comes from NSSA area, skip",
-					__func__);
+			zlog_debug_if(is_debug,
+				      "%s: The route comes from NSSA area, skip",
+				      __func__);
 			ospf6_abr_delete_route(summary, summary_table, old);
 			return 0;
 		}
@@ -469,10 +450,9 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		if (range && !CHECK_FLAG(range->flag, OSPF6_ROUTE_REMOVE)
 		    && (route->path.area_id != OSPF_AREA_BACKBONE
 			|| !IS_AREA_TRANSIT(area))) {
-			if (is_debug)
-				zlog_debug(
-					"Suppressed by range %pFX of area %s",
-					&range->prefix, route_area->name);
+			zlog_debug_if(is_debug,
+				      "Suppressed by range %pFX of area %s",
+				      &range->prefix, route_area->name);
 			/* The existing summary route could be a range, don't
 			 * remove it in this case
 			 */
@@ -487,17 +467,16 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 	if (route->type == OSPF6_DEST_TYPE_RANGE) {
 		/* If DoNotAdvertise is set */
 		if (CHECK_FLAG(route->flag, OSPF6_ROUTE_DO_NOT_ADVERTISE)) {
-			if (is_debug)
-				zlog_debug(
-					"This is the range with DoNotAdvertise set. ignore");
+			zlog_debug_if(is_debug,
+				      "This is the range with DoNotAdvertise set. ignore");
 			ospf6_abr_delete_route(summary, summary_table, old);
 			return 0;
 		}
 
 		/* If there are no active prefixes in this range, remove */
 		if (!CHECK_FLAG(route->flag, OSPF6_ROUTE_ACTIVE_SUMMARY)) {
-			if (is_debug)
-				zlog_debug("The range is not active. withdraw");
+			zlog_debug_if(is_debug,
+				      "The range is not active. withdraw");
 			ospf6_abr_delete_route(summary, summary_table, old);
 			return 0;
 		}
@@ -606,8 +585,8 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 	/* Originate */
 	ospf6_lsa_originate_area(lsa, area);
 
-	if (IS_OSPF6_DEBUG_ABR)
-		zlog_debug("%s : finish area %s", __func__, area->name);
+	zlog_debug_if(IS_OSPF6_DEBUG_ABR, "%s : finish area %s", __func__,
+		      area->name);
 
 	return 1;
 }
@@ -703,9 +682,8 @@ void ospf6_abr_range_update(struct ospf6_route *range, struct ospf6 *ospf6)
 	/* update range's cost and active flag */
 	cost = ospf6_abr_range_compute_cost(range, ospf6);
 
-	if (IS_OSPF6_DEBUG_ABR)
-		zlog_debug("%s: range %pFX, cost %d", __func__, &range->prefix,
-			   cost);
+	zlog_debug_if(IS_OSPF6_DEBUG_ABR, "%s: range %pFX, cost %d", __func__,
+		      &range->prefix, cost);
 
 	/* Non-zero cost is a proxy for active longer prefixes in this range.
 	 * If there are active routes covered by this range AND either the
@@ -724,8 +702,8 @@ void ospf6_abr_range_update(struct ospf6_route *range, struct ospf6 *ospf6)
 	if (!ospf6_abr_range_summary_needs_update(range, cost))
 		return;
 
-	if (IS_OSPF6_DEBUG_ABR)
-		zlog_debug("%s: range %pFX update", __func__, &range->prefix);
+	zlog_debug_if(IS_OSPF6_DEBUG_ABR, "%s: range %pFX update", __func__,
+		      &range->prefix);
 
 	if (CHECK_FLAG(range->flag, OSPF6_ROUTE_NSSA_RANGE)) {
 		if (CHECK_FLAG(range->flag, OSPF6_ROUTE_ACTIVE_SUMMARY)
@@ -751,8 +729,7 @@ void ospf6_abr_range_update(struct ospf6_route *range, struct ospf6 *ospf6)
 	if (CHECK_FLAG(range->flag, OSPF6_ROUTE_ACTIVE_SUMMARY)
 	    && summary_orig) {
 		if (!CHECK_FLAG(range->flag, OSPF6_ROUTE_BLACKHOLE_ADDED)) {
-			if (IS_OSPF6_DEBUG_ABR)
-				zlog_debug("Add discard route");
+			zlog_debug_if(IS_OSPF6_DEBUG_ABR, "Add discard route");
 
 			ospf6_zebra_add_discard(range, ospf6);
 		}
@@ -760,8 +737,8 @@ void ospf6_abr_range_update(struct ospf6_route *range, struct ospf6 *ospf6)
 		/* Summary removed or no summary generated as no
 		 * specifics exist */
 		if (CHECK_FLAG(range->flag, OSPF6_ROUTE_BLACKHOLE_ADDED)) {
-			if (IS_OSPF6_DEBUG_ABR)
-				zlog_debug("Delete discard route");
+			zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+				      "Delete discard route");
 
 			ospf6_zebra_delete_discard(range, ospf6);
 		}
@@ -830,10 +807,9 @@ void ospf6_abr_defaults_to_stub(struct ospf6 *o)
 	for (ALL_LIST_ELEMENTS(o->area_list, node, nnode, oa)) {
 		if (IS_AREA_STUB(oa) || (IS_AREA_NSSA(oa) && oa->no_summary)) {
 			/* announce defaults to stubby areas */
-			if (IS_OSPF6_DEBUG_ABR)
-				zlog_debug(
-					"Announcing default route into stubby area %s",
-					oa->name);
+			zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+				      "Announcing default route into stubby area %s",
+				      oa->name);
 			UNSET_FLAG(def->flag, OSPF6_ROUTE_REMOVE);
 			ospf6_abr_originate_summary_to_area(def, oa);
 		} else {
@@ -843,10 +819,9 @@ void ospf6_abr_defaults_to_stub(struct ospf6 *o)
 						   oa->summary_prefix);
 			if (route
 			    && (route->path.subtype == def->path.subtype)) {
-				if (IS_OSPF6_DEBUG_ABR)
-					zlog_debug(
-						"Withdrawing default route from non-stubby area %s",
-						oa->name);
+				zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+					      "Withdrawing default route from non-stubby area %s",
+					      oa->name);
 				SET_FLAG(def->flag, OSPF6_ROUTE_REMOVE);
 				ospf6_abr_originate_summary_to_area(def, oa);
 			}
@@ -893,14 +868,12 @@ void ospf6_abr_old_path_update(struct ospf6_route *old_route,
 					     o_path->nh_list);
 		}
 
-		if (IS_OSPF6_DEBUG_ABR || IS_OSPF6_DEBUG_EXAMIN(INTER_PREFIX))
-			zlog_debug("%s: paths %u nh %u", __func__,
-				   old_route->paths
-					   ? listcount(old_route->paths)
-					   : 0,
-				   old_route->nh_list
-					   ? listcount(old_route->nh_list)
-					   : 0);
+		zlog_debug_if(IS_OSPF6_DEBUG_ABR ||
+				      IS_OSPF6_DEBUG_EXAMIN(INTER_PREFIX),
+			      "%s: paths %u nh %u", __func__,
+			      old_route->paths ? listcount(old_route->paths) : 0,
+			      old_route->nh_list ? listcount(old_route->nh_list)
+						 : 0);
 
 		if (table->hook_add)
 			(*table->hook_add)(old_route);
@@ -923,9 +896,8 @@ void ospf6_abr_old_path_update(struct ospf6_route *old_route,
 void ospf6_abr_old_route_remove(struct ospf6_lsa *lsa, struct ospf6_route *old,
 				struct ospf6_route_table *table)
 {
-	if (IS_OSPF6_DEBUG_ABR)
-		zlog_debug("%s: route %pFX, paths %d", __func__, &old->prefix,
-			   listcount(old->paths));
+	zlog_debug_if(IS_OSPF6_DEBUG_ABR, "%s: route %pFX, paths %d", __func__,
+		      &old->prefix, listcount(old->paths));
 
 	if (listcount(old->paths) > 1) {
 		struct listnode *anode, *anext, *nnode, *rnode, *rnext;
@@ -942,8 +914,8 @@ void ospf6_abr_old_route_remove(struct ospf6_lsa *lsa, struct ospf6_route *old,
 							rnode, rnext, rnh)) {
 					if (!ospf6_nexthop_is_same(rnh, nh))
 						continue;
-					if (IS_OSPF6_DEBUG_ABR)
-						zlog_debug("deleted nexthop");
+					zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+						      "deleted nexthop");
 					listnode_delete(old->nh_list, rnh);
 					ospf6_nexthop_delete(rnh);
 				}
@@ -955,13 +927,14 @@ void ospf6_abr_old_route_remove(struct ospf6_lsa *lsa, struct ospf6_route *old,
 
 		if (nh_updated) {
 			if (listcount(old->paths)) {
-				if (IS_OSPF6_DEBUG_ABR
-				    || IS_OSPF6_DEBUG_EXAMIN(INTER_PREFIX))
-					zlog_debug("%s: old %pFX updated nh %u",
-						   __func__, &old->prefix,
-						   old->nh_list ? listcount(
-							   old->nh_list)
-								: 0);
+				zlog_debug_if(IS_OSPF6_DEBUG_ABR ||
+						      IS_OSPF6_DEBUG_EXAMIN(
+							      INTER_PREFIX),
+					      "%s: old %pFX updated nh %u",
+					      __func__, &old->prefix,
+					      old->nh_list
+						      ? listcount(old->nh_list)
+						      : 0);
 
 				if (table->hook_add)
 					(*table->hook_add)(old);
@@ -1062,9 +1035,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 	route = ospf6_route_lookup(&prefix, table);
 	if (route) {
 		ospf6_route_lock(route);
-		if (is_debug)
-			zlog_debug("%s: route %pFX, paths %d", __func__,
-				   &prefix, listcount(route->paths));
+		zlog_debug_if(is_debug, "%s: route %pFX, paths %d", __func__,
+			      &prefix, listcount(route->paths));
 	}
 	while (route && ospf6_route_is_prefix(&prefix, route)) {
 		if (route->path.area_id == oa->area_id
@@ -1082,11 +1054,11 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 					    lsa->header->adv_router) {
 						old = route;
 
-						if (is_debug)
-							zlog_debug(
-								"%s: old entry found in paths, adv_router %pI4",
-								__func__,
-								&o_path->origin.adv_router);
+						zlog_debug_if(is_debug,
+							      "%s: old entry found in paths, adv_router %pI4",
+							      __func__,
+							      &o_path->origin
+								       .adv_router);
 
 						break;
 					}
@@ -1103,16 +1075,14 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 
 	/* (1) if cost == LSInfinity or if the LSA is MaxAge */
 	if (cost == OSPF_LS_INFINITY) {
-		if (is_debug)
-			zlog_debug("cost is LS_INFINITY, ignore");
+		zlog_debug_if(is_debug, "cost is LS_INFINITY, ignore");
 		if (old)
 			ospf6_abr_old_route_remove(lsa, old, table);
 		return;
 	}
 	if (OSPF6_LSA_IS_MAXAGE(lsa)) {
-		if (is_debug)
-			zlog_debug("%s: LSA %s is MaxAge, ignore", __func__,
-				   lsa->name);
+		zlog_debug_if(is_debug, "%s: LSA %s is MaxAge, ignore",
+			      __func__, lsa->name);
 		if (old)
 			ospf6_abr_old_route_remove(lsa, old, table);
 		return;
@@ -1121,9 +1091,7 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 
 	/* (2) if the LSA is self-originated, ignore */
 	if (lsa->header->adv_router == oa->ospf6->router_id) {
-		if (is_debug)
-			zlog_debug("LSA %s is self-originated, ignore",
-				   lsa->name);
+		zlog_debug_if("LSA %s is self-originated, ignore", lsa->name);
 		if (old)
 			ospf6_route_remove(old, table);
 		return;
@@ -1137,9 +1105,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 
 		range = ospf6_route_lookup(&prefix, oa->range_table);
 		if (range) {
-			if (is_debug)
-				zlog_debug(
-					"Prefix is equal to address range, ignore");
+			zlog_debug_if(is_debug,
+				      "Prefix is equal to address range, ignore");
 			if (old)
 				ospf6_route_remove(old, table);
 			return;
@@ -1147,8 +1114,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 
 		if (CHECK_FLAG(prefix_lsa->prefix.prefix_options,
 			       OSPF6_PREFIX_OPTION_NU)) {
-			if (is_debug)
-				zlog_debug("Prefix has the NU bit set, ignore");
+			zlog_debug_if(is_debug,
+				      "Prefix has the NU bit set, ignore");
 			if (old)
 				ospf6_route_remove(old, table);
 			return;
@@ -1160,9 +1127,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 		assert(router_lsa);
 		if (!OSPF6_OPT_ISSET(router_lsa->options, OSPF6_OPT_R)
 		    || !OSPF6_OPT_ISSET(router_lsa->options, OSPF6_OPT_V6)) {
-			if (is_debug)
-				zlog_debug(
-					"Router-LSA has the V6-bit or R-bit unset, ignore");
+			zlog_debug_if(is_debug,
+				      "Router-LSA has the V6-bit or R-bit unset, ignore");
 			if (old)
 				ospf6_route_remove(old, table);
 
@@ -1173,10 +1139,9 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 		   Inter-Router LSA for an ABR
 		*/
 		if (lsa->header->adv_router == router_lsa->router_id) {
-			if (is_debug)
-				zlog_debug(
-					"Ignoring Inter-Router LSA for an ABR (%s)",
-					buf);
+			zlog_debug_if(is_debug,
+				      "Ignoring Inter-Router LSA for an ABR (%s)",
+				      buf);
 			if (old)
 				ospf6_route_remove(old, table);
 
@@ -1190,22 +1155,19 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 	if (abr_entry == NULL || abr_entry->path.area_id != oa->area_id
 	    || CHECK_FLAG(abr_entry->flag, OSPF6_ROUTE_REMOVE)
 	    || !CHECK_FLAG(abr_entry->path.router_bits, OSPF6_ROUTER_BIT_B)) {
-		if (is_debug)
-			zlog_debug(
-				"%s: ABR router entry %pFX does not exist, ignore",
-				__func__, &abr_prefix);
+		zlog_debug_if(is_debug,
+			      "%s: ABR router entry %pFX does not exist, ignore",
+			      __func__, &abr_prefix);
 		if (old) {
 			if (old->type == OSPF6_DEST_TYPE_ROUTER &&
 			    oa->intra_brouter_calc) {
-				if (is_debug)
-					zlog_debug(
-						"%s: intra_brouter_calc is on, skip brouter remove: %s (%p)",
-						__func__, buf, (void *)old);
+				zlog_debug_if(is_debug,
+					      "%s: intra_brouter_calc is on, skip brouter remove: %s (%p)",
+					      __func__, buf, (void *)old);
 			} else {
-				if (is_debug)
-					zlog_debug(
-						"%s: remove old entry: %s %p ",
-						__func__, buf, (void *)old);
+				zlog_debug_if(is_debug,
+					      "%s: remove old entry: %s %p ",
+					      __func__, buf, (void *)old);
 				ospf6_abr_old_route_remove(lsa, old, table);
 			}
 		}
@@ -1240,13 +1202,10 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 	   are identical.
 	*/
 	old = ospf6_route_lookup(&prefix, table);
-	if (old) {
-		if (is_debug)
-			zlog_debug("%s: found old route %pFX, paths %d",
-				   __func__, &prefix, listcount(old->paths));
-	}
-	for (old_route = old; old_route; old_route = old_route->next) {
+	zlog_debug_if(old && is_debug, "%s: found old route %pFX, paths %d",
+		      __func__, &prefix, listcount(old->paths));
 
+	for (old_route = old; old_route; old_route = old_route->next) {
 		/* The route linked-list is grouped in batches of prefix.
 		 * If the new prefix is not the same as the one of interest
 		 * then we have walked over the end of the batch and so we
@@ -1259,11 +1218,10 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 			continue;
 
 		if ((ospf6_route_cmp(route, old_route) != 0)) {
-			if (is_debug)
-				zlog_debug(
-					"%s: old %p %pFX cost %u new route cost %u are not same",
-					__func__, (void *)old_route, &prefix,
-					old_route->path.cost, route->path.cost);
+			zlog_debug_if(is_debug,
+				      "%s: old %p %pFX cost %u new route cost %u are not same",
+				      __func__, (void *)old_route, &prefix,
+				      old_route->path.cost, route->path.cost);
 
 			/* Check new route's adv. router is same in one of
 			 * the paths with differed cost, if so remove the
@@ -1296,18 +1254,16 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 			/* Add the new path to route's path list */
 			listnode_add_sort(old_route->paths, ecmp_path);
 
-			if (is_debug) {
-				zlog_debug(
-					"%s: route %pFX cost %u another path %pI4 added with nh %u, effective paths %u nh %u",
-					__func__, &route->prefix,
-					old_route->path.cost,
-					&ecmp_path->origin.adv_router,
-					listcount(ecmp_path->nh_list),
-					old_route->paths
-						? listcount(old_route->paths)
-						: 0,
-					listcount(old_route->nh_list));
-			}
+			zlog_debug_if(is_debug,
+				      "%s: route %pFX cost %u another path %pI4 added with nh %u, effective paths %u nh %u",
+				      __func__, &route->prefix,
+				      old_route->path.cost,
+				      &ecmp_path->origin.adv_router,
+				      listcount(ecmp_path->nh_list),
+				      old_route->paths
+					      ? listcount(old_route->paths)
+					      : 0,
+				      listcount(old_route->nh_list));
 		} else {
 			struct ospf6_route *tmp_route;
 
@@ -1330,12 +1286,11 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 			}
 		}
 
-		if (is_debug)
-			zlog_debug(
-				"%s: Update route: %s %p old cost %u new cost %u nh %u",
-				__func__, buf, (void *)old_route,
-				old_route->path.cost, route->path.cost,
-				listcount(old_route->nh_list));
+		zlog_debug_if(is_debug,
+			      "%s: Update route: %s %p old cost %u new cost %u nh %u",
+			      __func__, buf, (void *)old_route,
+			      old_route->path.cost, route->path.cost,
+			      listcount(old_route->nh_list));
 
 		/* For Inter-Prefix route: Update RIB/FIB,
 		 * For Inter-Router trigger summary update
@@ -1357,13 +1312,11 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 	}
 
 	if (add_route) {
-		if (is_debug) {
-			zlog_debug(
-				"%s: Install new route: %s cost %u nh %u adv_router %pI4",
-				__func__, buf, route->path.cost,
-				listcount(route->nh_list),
-				&route->path.origin.adv_router);
-		}
+		zlog_debug_if(is_debug,
+			      "%s: Install new route: %s cost %u nh %u adv_router %pI4",
+			      __func__, buf, route->path.cost,
+			      listcount(route->nh_list),
+			      &route->path.origin.adv_router);
 
 		path = ospf6_path_dup(&route->path);
 		ospf6_copy_nexthops(path->nh_list, abr_entry->nh_list);
@@ -1404,15 +1357,14 @@ void ospf6_abr_prefix_resummarize(struct ospf6 *o)
 {
 	struct ospf6_route *route;
 
-	if (IS_OSPF6_DEBUG_ABR)
-		zlog_debug("Re-examining Inter-Prefix Summaries");
+	zlog_debug_if(IS_OSPF6_DEBUG_ABR, "Re-examining Inter-Prefix Summaries");
 
 	for (route = ospf6_route_head(o->route_table); route;
 	     route = ospf6_route_next(route))
 		ospf6_abr_originate_summary(route, o);
 
-	if (IS_OSPF6_DEBUG_ABR)
-		zlog_debug("Finished re-examining Inter-Prefix Summaries");
+	zlog_debug_if(IS_OSPF6_DEBUG_ABR,
+		      "Finished re-examining Inter-Prefix Summaries");
 }
 
 

--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -28,6 +28,8 @@
 #include "ospf6_nssa.h"
 #include "ospf6_gr.h"
 
+#define zlog_debug_if(condition, ...) if (condition) zlog_debug(__VA_ARGS__)
+
 unsigned char conf_debug_ospf6_flooding;
 
 struct ospf6_lsdb *ospf6_get_scoped_lsdb(struct ospf6_lsa *lsa)
@@ -76,10 +78,9 @@ void ospf6_lsa_originate(struct ospf6 *ospf6, struct ospf6_lsa *lsa)
 	struct ospf6_lsdb *lsdb_self;
 
 	if (lsa->header->adv_router == INADDR_ANY) {
-		if (IS_OSPF6_DEBUG_ORIGINATE_TYPE(lsa->header->type))
-			zlog_debug(
-				"Refusing to originate LSA (zero router ID): %s",
-				lsa->name);
+		zlog_debug_if(IS_OSPF6_DEBUG_ORIGINATE_TYPE(lsa->header->type),
+			      "Refusing to originate LSA (zero router ID): %s",
+			      lsa->name);
 
 		ospf6_lsa_delete(lsa);
 		return;
@@ -93,8 +94,8 @@ void ospf6_lsa_originate(struct ospf6 *ospf6, struct ospf6_lsa *lsa)
 	   suppress this update of the LSA */
 	if (old && !OSPF6_LSA_IS_DIFFER(lsa, old)
 	    && !ospf6->gr_info.finishing_restart) {
-		if (IS_OSPF6_DEBUG_ORIGINATE_TYPE(lsa->header->type))
-			zlog_debug("Suppress updating LSA: %s", lsa->name);
+		zlog_debug_if(IS_OSPF6_DEBUG_ORIGINATE_TYPE(lsa->header->type),
+			      "Suppress updating LSA: %s", lsa->name);
 		ospf6_lsa_delete(lsa);
 		return;
 	}
@@ -149,9 +150,9 @@ void ospf6_external_lsa_purge(struct ospf6 *ospf6, struct ospf6_lsa *lsa)
 		lsa = ospf6_lsdb_lookup(htons(OSPF6_LSTYPE_TYPE_7), id,
 					ospf6->router_id, oa->lsdb);
 		if (lsa) {
-			if (IS_OSPF6_DEBUG_NSSA)
-				zlog_debug("withdraw type 7 lsa, LS ID: %u",
-					   htonl(id));
+			zlog_debug_if(IS_OSPF6_DEBUG_NSSA,
+				      "withdraw type 7 lsa, LS ID: %u",
+				      htonl(id));
 
 			ospf6_lsa_purge(lsa);
 		}
@@ -245,9 +246,8 @@ void ospf6_install_lsa(struct ospf6_lsa *lsa)
 				lsa->header->adv_router, lsa->lsdb);
 	if (old) {
 		if (ntohs(lsa->header->type) == OSPF6_LSTYPE_TYPE_7) {
-			if (IS_OSPF6_DEBUG_NSSA)
-				zlog_debug("%s : old LSA %s", __func__,
-					   lsa->name);
+			zlog_debug_if(IS_OSPF6_DEBUG_NSSA, "%s : old LSA %s",
+				      __func__, lsa->name);
 			lsa->external_lsa_id = old->external_lsa_id;
 		}
 		EVENT_OFF(old->expire);
@@ -267,9 +267,9 @@ void ospf6_install_lsa(struct ospf6_lsa *lsa)
 	if (OSPF6_LSA_IS_SEQWRAP(lsa)
 	    && !(CHECK_FLAG(lsa->flag, OSPF6_LSA_SEQWRAPPED)
 		 && lsa->header->seqnum == htonl(OSPF_MAX_SEQUENCE_NUMBER))) {
-		if (IS_OSPF6_DEBUG_EXAMIN_TYPE(lsa->header->type))
-			zlog_debug("lsa install wrapping: sequence 0x%x",
-				   ntohl(lsa->header->seqnum));
+		zlog_debug_if(IS_OSPF6_DEBUG_EXAMIN_TYPE(lsa->header->type),
+			      "lsa install wrapping: sequence 0x%x",
+			      ntohl(lsa->header->seqnum));
 		SET_FLAG(lsa->flag, OSPF6_LSA_SEQWRAPPED);
 		/* in lieu of premature_aging, since we do not want to recreate
 		 * this lsa
@@ -285,11 +285,11 @@ void ospf6_install_lsa(struct ospf6_lsa *lsa)
 		ospf6_lsa_checksum(lsa->header);
 	}
 
-	if (IS_OSPF6_DEBUG_LSA_TYPE(lsa->header->type)
-	    || IS_OSPF6_DEBUG_EXAMIN_TYPE(lsa->header->type))
-		zlog_debug("%s Install LSA: %s age %d seqnum %x in LSDB.",
-			   __func__, lsa->name, ntohs(lsa->header->age),
-			   ntohl(lsa->header->seqnum));
+	zlog_debug_if(IS_OSPF6_DEBUG_LSA_TYPE(lsa->header->type) ||
+			      IS_OSPF6_DEBUG_EXAMIN_TYPE(lsa->header->type),
+		      "%s Install LSA: %s age %d seqnum %x in LSDB.", __func__,
+		      lsa->name, ntohs(lsa->header->age),
+		      ntohl(lsa->header->seqnum));
 
 	/* actually install */
 	lsa->installed = now;
@@ -315,10 +315,11 @@ void ospf6_install_lsa(struct ospf6_lsa *lsa)
 	if (ntohs(lsa->header->type) == OSPF6_LSTYPE_ROUTER) {
 		area = OSPF6_AREA(lsa->lsdb->data);
 		if (old == NULL) {
-			if (IS_OSPF6_DEBUG_LSA_TYPE(lsa->header->type)
-			    || IS_OSPF6_DEBUG_EXAMIN_TYPE(lsa->header->type))
-				zlog_debug("%s: New router LSA %s", __func__,
-					   lsa->name);
+			zlog_debug_if(IS_OSPF6_DEBUG_LSA_TYPE(lsa->header->type) ||
+					      IS_OSPF6_DEBUG_EXAMIN_TYPE(
+						      lsa->header->type),
+				      "%s: New router LSA %s", __func__,
+				      lsa->name);
 			ospf6_abr_nssa_check_status(area->ospf6);
 		}
 	}
@@ -345,37 +346,32 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 
 	/* (1) For each neighbor */
 	for (ALL_LIST_ELEMENTS(oi->neighbor_list, node, nnode, on)) {
-		if (is_debug)
-			zlog_debug("To neighbor %s", on->name);
+		zlog_debug_if(is_debug, "To neighbor %s", on->name);
 
 		/* (a) if neighbor state < Exchange, examin next */
 		if (on->state < OSPF6_NEIGHBOR_EXCHANGE) {
-			if (is_debug)
-				zlog_debug(
-					"Neighbor state less than ExChange, next neighbor");
+			zlog_debug_if(is_debug,
+				      "Neighbor state less than ExChange, next neighbor");
 			continue;
 		}
 
 		/* (b) if neighbor not yet Full, check request-list */
 		if (on->state != OSPF6_NEIGHBOR_FULL) {
-			if (is_debug)
-				zlog_debug("Neighbor not yet Full");
+			zlog_debug_if(is_debug, "Neighbor not yet Full");
 
 			req = ospf6_lsdb_lookup(
 				lsa->header->type, lsa->header->id,
 				lsa->header->adv_router, on->request_list);
 			if (req == NULL) {
-				if (is_debug)
-					zlog_debug(
-						"Not on request-list for this neighbor");
+				zlog_debug_if(is_debug,
+					      "Not on request-list for this neighbor");
 				/* fall through */
 			} else {
 				/* If new LSA less recent, examin next neighbor
 				 */
 				if (ospf6_lsa_compare(lsa, req) > 0) {
-					if (is_debug)
-						zlog_debug(
-							"Requesting is older, next neighbor");
+					zlog_debug_if(is_debug,
+						      "Requesting is older, next neighbor");
 					continue;
 				}
 
@@ -383,9 +379,8 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 				   request-list and
 				   examin next neighbor */
 				if (ospf6_lsa_compare(lsa, req) == 0) {
-					if (is_debug)
-						zlog_debug(
-							"Requesting the same, remove it, next neighbor");
+					zlog_debug_if(is_debug,
+						      "Requesting the same, remove it, next neighbor");
 					if (req == on->last_ls_req) {
 						/* sanity check refcount */
 						assert(req->lock >= 2);
@@ -402,9 +397,8 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 				/* If the new LSA is more recent, delete from
 				 * request-list */
 				if (ospf6_lsa_compare(lsa, req) < 0) {
-					if (is_debug)
-						zlog_debug(
-							"Received is newer, remove requesting");
+					zlog_debug_if(is_debug,
+						      "Received is newer, remove requesting");
 					if (req == on->last_ls_req) {
 						ospf6_lsa_unlock(&req);
 						on->last_ls_req = NULL;
@@ -421,26 +415,24 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 		/* (c) If the new LSA was received from this neighbor,
 		   examin next neighbor */
 		if (from == on) {
-			if (is_debug)
-				zlog_debug(
-					"Received is from the neighbor, next neighbor");
+			zlog_debug_if(is_debug,
+				      "Received is from the neighbor, next neighbor");
 			continue;
 		}
 
 		if ((oi->area->ospf6->inst_shutdown)
 		    || CHECK_FLAG(lsa->flag, OSPF6_LSA_FLUSH)) {
-			if (is_debug)
-				zlog_debug(
-					"%s: Send LSA %s (age %d) update now",
-					__func__, lsa->name,
-					ntohs(lsa->header->age));
+			zlog_debug_if(is_debug,
+				      "%s: Send LSA %s (age %d) update now",
+				      __func__, lsa->name,
+				      ntohs(lsa->header->age));
 			ospf6_lsupdate_send_neighbor_now(on, lsa);
 			continue;
 		} else {
 			/* (d) add retrans-list, schedule retransmission */
-			if (is_debug)
-				zlog_debug("Add retrans-list of neighbor %s ",
-					   on->name);
+			zlog_debug_if(is_debug,
+				      "Add retrans-list of neighbor %s ",
+				      on->name);
 
 			/* Do not increment the retrans count if the lsa is
 			 * already present in the retrans list.
@@ -452,10 +444,9 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 				struct ospf6_lsa *orig;
 				struct ospf6_lsdb *lsdb;
 
-				if (is_debug)
-					zlog_debug(
-						"Increment %s from retrans_list of %s",
-						lsa->name, on->name);
+				zlog_debug_if(is_debug,
+					      "Increment %s from retrans_list of %s",
+					      lsa->name, on->name);
 
 				/* Increment the retrans count on the original
 				 * copy of LSA if present, to maintain the
@@ -484,10 +475,9 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 
 	/* (2) examin next interface if not added to retrans-list */
 	if (retrans_added == 0) {
-		if (is_debug)
-			zlog_debug(
-				"No retransmission scheduled, next interface %s",
-				oi->interface->name);
+		zlog_debug_if(is_debug,
+			      "No retransmission scheduled, next interface %s",
+			      oi->interface->name);
 		return;
 	}
 
@@ -496,9 +486,8 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 	if (from && from->ospf6_if == oi
 	    && (from->router_id == oi->drouter
 		|| from->router_id == oi->bdrouter)) {
-		if (is_debug)
-			zlog_debug(
-				"Received is from the I/F's DR or BDR, next interface");
+		zlog_debug_if(is_debug,
+			      "Received is from the I/F's DR or BDR, next interface");
 		return;
 	}
 
@@ -506,17 +495,15 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 	   and the interface state is BDR, examin next interface */
 	if (from && from->ospf6_if == oi) {
 		if (oi->state == OSPF6_INTERFACE_BDR) {
-			if (is_debug)
-				zlog_debug(
-					"Received is from the I/F, itself BDR, next interface");
+			zlog_debug_if(is_debug,
+				      "Received is from the I/F, itself BDR, next interface");
 			return;
 		}
 		SET_FLAG(lsa->flag, OSPF6_LSA_FLOODBACK);
 	}
 
 	/* (5) flood the LSA out the interface. */
-	if (is_debug)
-		zlog_debug("Schedule flooding for the interface");
+	zlog_debug_if(is_debug, "Schedule flooding for the interface");
 	if ((oi->type == OSPF_IFTYPE_BROADCAST)
 	    || (oi->type == OSPF_IFTYPE_POINTOPOINT)) {
 		ospf6_lsdb_add(ospf6_lsa_copy(lsa), oi->lsupdate_list);
@@ -562,8 +549,8 @@ static void ospf6_flood_process(struct ospf6_neighbor *from,
 		    && !(ntohs(lsa->header->type) & OSPF6_LSTYPE_UBIT_MASK)
 		    && (oa != OSPF6_INTERFACE(lsa->lsdb->data)->area)) {
 
-			if (IS_OSPF6_DEBUG_FLOODING)
-				zlog_debug("Unknown LSA, do not flood");
+			zlog_debug_if(IS_OSPF6_DEBUG_FLOODING,
+				      "Unknown LSA, do not flood");
 			continue;
 		}
 
@@ -610,10 +597,11 @@ static void ospf6_flood_clear_interface(struct ospf6_lsa *lsa,
 					lsa->header->adv_router,
 					on->retrans_list);
 		if (rem && !ospf6_lsa_compare(rem, lsa)) {
-			if (IS_OSPF6_DEBUG_FLOODING
-			    || IS_OSPF6_DEBUG_FLOOD_TYPE(lsa->header->type))
-				zlog_debug("Remove %s from retrans_list of %s",
-					   rem->name, on->name);
+			zlog_debug_if(IS_OSPF6_DEBUG_FLOODING ||
+					      IS_OSPF6_DEBUG_FLOOD_TYPE(
+						      lsa->header->type),
+				      "Remove %s from retrans_list of %s",
+				      rem->name, on->name);
 			ospf6_decrement_retrans_count(rem);
 			ospf6_lsdb_remove(rem, on->retrans_list);
 		}
@@ -692,17 +680,15 @@ static void ospf6_acknowledge_lsa_bdrouter(struct ospf6_lsa *lsa,
 	   otherwide do nothing. */
 	if (ismore_recent < 0) {
 		if (oi->drouter == from->router_id) {
-			if (is_debug)
-				zlog_debug(
-					"Delayed acknowledgement (BDR & MoreRecent & from DR)");
+			zlog_debug_if(is_debug,
+				      "Delayed acknowledgement (BDR & MoreRecent & from DR)");
 			/* Delayed acknowledgement */
 			ospf6_lsdb_add(ospf6_lsa_copy(lsa), oi->lsack_list);
 			event_add_timer(master, ospf6_lsack_send_interface, oi,
 					3, &oi->thread_send_lsack);
 		} else {
-			if (is_debug)
-				zlog_debug(
-					"No acknowledgement (BDR & MoreRecent & ! from DR)");
+			zlog_debug_if(is_debug,
+				      "No acknowledgement (BDR & MoreRecent & ! from DR)");
 		}
 		return;
 	}
@@ -713,17 +699,15 @@ static void ospf6_acknowledge_lsa_bdrouter(struct ospf6_lsa *lsa,
 	if (CHECK_FLAG(lsa->flag, OSPF6_LSA_DUPLICATE)
 	    && CHECK_FLAG(lsa->flag, OSPF6_LSA_IMPLIEDACK)) {
 		if (oi->drouter == from->router_id) {
-			if (is_debug)
-				zlog_debug(
-					"Delayed acknowledgement (BDR & Duplicate & ImpliedAck & from DR)");
+			zlog_debug_if(is_debug,
+				      "Delayed acknowledgement (BDR & Duplicate & ImpliedAck & from DR)");
 			/* Delayed acknowledgement */
 			ospf6_lsdb_add(ospf6_lsa_copy(lsa), oi->lsack_list);
 			event_add_timer(master, ospf6_lsack_send_interface, oi,
 					3, &oi->thread_send_lsack);
 		} else {
-			if (is_debug)
-				zlog_debug(
-					"No acknowledgement (BDR & Duplicate & ImpliedAck & ! from DR)");
+			zlog_debug_if(is_debug,
+				      "No acknowledgement (BDR & Duplicate & ImpliedAck & ! from DR)");
 		}
 		return;
 	}
@@ -733,8 +717,8 @@ static void ospf6_acknowledge_lsa_bdrouter(struct ospf6_lsa *lsa,
 	   Direct acknowledgement sent */
 	if (CHECK_FLAG(lsa->flag, OSPF6_LSA_DUPLICATE)
 	    && !CHECK_FLAG(lsa->flag, OSPF6_LSA_IMPLIEDACK)) {
-		if (is_debug)
-			zlog_debug("Direct acknowledgement (BDR & Duplicate)");
+		zlog_debug_if(is_debug,
+			      "Direct acknowledgement (BDR & Duplicate)");
 		ospf6_lsdb_add(ospf6_lsa_copy(lsa), from->lsack_list);
 		event_add_event(master, ospf6_lsack_send_neighbor, from, 0,
 				&from->thread_send_lsack);
@@ -765,17 +749,16 @@ static void ospf6_acknowledge_lsa_allother(struct ospf6_lsa *lsa,
 	/* LSA has been flood back out receiving interface.
 	   No acknowledgement sent. */
 	if (CHECK_FLAG(lsa->flag, OSPF6_LSA_FLOODBACK)) {
-		if (is_debug)
-			zlog_debug("No acknowledgement (AllOther & FloodBack)");
+		zlog_debug_if(is_debug,
+			      "No acknowledgement (AllOther & FloodBack)");
 		return;
 	}
 
 	/* LSA is more recent than database copy, but was not flooded
 	   back out receiving interface. Delayed acknowledgement sent. */
 	if (ismore_recent < 0) {
-		if (is_debug)
-			zlog_debug(
-				"Delayed acknowledgement (AllOther & MoreRecent)");
+		zlog_debug_if(is_debug,
+			      "Delayed acknowledgement (AllOther & MoreRecent)");
 		/* Delayed acknowledgement */
 		ospf6_lsdb_add(ospf6_lsa_copy(lsa), oi->lsack_list);
 		event_add_timer(master, ospf6_lsack_send_interface, oi, 3,
@@ -787,9 +770,8 @@ static void ospf6_acknowledge_lsa_allother(struct ospf6_lsa *lsa,
 	   No acknowledgement sent. */
 	if (CHECK_FLAG(lsa->flag, OSPF6_LSA_DUPLICATE)
 	    && CHECK_FLAG(lsa->flag, OSPF6_LSA_IMPLIEDACK)) {
-		if (is_debug)
-			zlog_debug(
-				"No acknowledgement (AllOther & Duplicate & ImpliedAck)");
+		zlog_debug_if(is_debug,
+			      "No acknowledgement (AllOther & Duplicate & ImpliedAck)");
 		return;
 	}
 
@@ -798,9 +780,8 @@ static void ospf6_acknowledge_lsa_allother(struct ospf6_lsa *lsa,
 	   Direct acknowledgement sent */
 	if (CHECK_FLAG(lsa->flag, OSPF6_LSA_DUPLICATE)
 	    && !CHECK_FLAG(lsa->flag, OSPF6_LSA_IMPLIEDACK)) {
-		if (is_debug)
-			zlog_debug(
-				"Direct acknowledgement (AllOther & Duplicate)");
+		zlog_debug_if(is_debug,
+			      "Direct acknowledgement (AllOther & Duplicate)");
 		ospf6_lsdb_add(ospf6_lsa_copy(lsa), from->lsack_list);
 		event_add_event(master, ospf6_lsack_send_neighbor, from, 0,
 				&from->thread_send_lsack);
@@ -874,12 +855,12 @@ static bool ospf6_lsa_check_min_arrival(struct ospf6_lsa *lsa,
 	time_delta_ms = (res.tv_sec * 1000) + (int)(res.tv_usec / 1000);
 
 	if (time_delta_ms < from->ospf6_if->area->ospf6->lsa_minarrival) {
-		if (IS_OSPF6_DEBUG_FLOODING ||
-		    IS_OSPF6_DEBUG_FLOOD_TYPE(lsa->header->type))
-			zlog_debug(
-				"LSA can't be updated within MinLSArrival, %dms < %dms, discard",
-				time_delta_ms,
-				from->ospf6_if->area->ospf6->lsa_minarrival);
+		zlog_debug_if(IS_OSPF6_DEBUG_FLOODING ||
+				      IS_OSPF6_DEBUG_FLOOD_TYPE(
+					      lsa->header->type),
+			      "LSA can't be updated within MinLSArrival, %dms < %dms, discard",
+			      time_delta_ms,
+			      from->ospf6_if->area->ospf6->lsa_minarrival);
 		return true;
 	}
 	return false;
@@ -898,13 +879,11 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 
 	/* if we receive a LSA with invalid seqnum drop it */
 	if (ntohl(lsa_header->seqnum) - 1 == OSPF_MAX_SEQUENCE_NUMBER) {
-		if (IS_OSPF6_DEBUG_EXAMIN_TYPE(lsa_header->type)) {
-			zlog_debug(
-				"received lsa [%s Id:%pI4 Adv:%pI4] with invalid seqnum 0x%x, ignore",
-				ospf6_lstype_name(lsa_header->type),
-				&lsa_header->id, &lsa_header->adv_router,
-				ntohl(lsa_header->seqnum));
-		}
+		zlog_debug_if(IS_OSPF6_DEBUG_EXAMIN_TYPE(lsa_header->type),
+			      "received lsa [%s Id:%pI4 Adv:%pI4] with invalid seqnum 0x%x, ignore",
+			      ospf6_lstype_name(lsa_header->type),
+			      &lsa_header->id, &lsa_header->adv_router,
+			      ntohl(lsa_header->seqnum));
 		return;
 	}
 
@@ -920,12 +899,11 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 
 	/* (1) LSA Checksum */
 	if (!ospf6_lsa_checksum_valid(new->header)) {
-		if (is_debug)
-			zlog_debug(
-				"Wrong LSA Checksum %s (Router-ID: %pI4) [Type:%s Checksum:%#06hx), discard",
-				from->name, &from->router_id,
-				ospf6_lstype_name(new->header->type),
-				ntohs(new->header->checksum));
+		zlog_debug_if(is_debug,
+			      "Wrong LSA Checksum %s (Router-ID: %pI4) [Type:%s Checksum:%#06hx), discard",
+			      from->name, &from->router_id,
+			      ospf6_lstype_name(new->header->type),
+			      ntohs(new->header->checksum));
 		ospf6_lsa_delete(new);
 		return;
 	}
@@ -934,9 +912,8 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 	   RFC2470 3.5.1. Receiving Link State Update packets  */
 	if (IS_AREA_STUB(from->ospf6_if->area)
 	    && OSPF6_LSA_SCOPE(new->header->type) == OSPF6_SCOPE_AS) {
-		if (is_debug)
-			zlog_debug(
-				"AS-External-LSA (or AS-scope LSA) in stub area, discard");
+		zlog_debug_if(is_debug,
+			      "AS-External-LSA (or AS-scope LSA) in stub area, discard");
 		ospf6_lsa_delete(new);
 		return;
 	}
@@ -956,8 +933,7 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 		new->lsdb = from->ospf6_if->area->ospf6->lsdb;
 		break;
 	default:
-		if (is_debug)
-			zlog_debug("LSA has reserved scope, discard");
+		zlog_debug_if(is_debug, "LSA has reserved scope, discard");
 		ospf6_lsa_delete(new);
 		return;
 	}
@@ -966,9 +942,8 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 	       is in states Exchange or Loading */
 	if (ospf6_is_maxage_lsa_drop(new, from)) {
 		/* log */
-		if (is_debug)
-			zlog_debug(
-				"Drop MaxAge LSA with direct acknowledgement.");
+		zlog_debug_if(is_debug,
+			      "Drop MaxAge LSA with direct acknowledgement.");
 
 		/* a) Acknowledge back to neighbor (Direct acknowledgement,
 		 * 13.5) */
@@ -988,8 +963,7 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 	if (old) {
 		ismore_recent = ospf6_lsa_compare(new, old);
 		if (ntohl(new->header->seqnum) == ntohl(old->header->seqnum)) {
-			if (is_debug)
-				zlog_debug("Received is duplicated LSA");
+			zlog_debug_if(is_debug, "Received is duplicated LSA");
 			SET_FLAG(new->flag, OSPF6_LSA_DUPLICATE);
 		}
 	}
@@ -1011,9 +985,8 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 
 		monotime(&new->received);
 
-		if (is_debug)
-			zlog_debug(
-				"Install, Flood, Possibly acknowledge the received LSA");
+		zlog_debug_if(is_debug,
+			      "Install, Flood, Possibly acknowledge the received LSA");
 
 		/* Remove older copies of this LSA from retx lists */
 		if (old)
@@ -1031,37 +1004,31 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 			assert(ospf6);
 
 			if (OSPF6_LSA_IS_MAXAGE(new)) {
-
-				if (IS_DEBUG_OSPF6_GR)
-					zlog_debug(
-						"%s, Received a maxage GraceLSA from router %pI4",
-						__func__,
-						&new->header->adv_router);
+				zlog_debug_if(IS_DEBUG_OSPF6_GR,
+					      "%s, Received a maxage GraceLSA from router %pI4",
+					      __func__,
+					      &new->header->adv_router);
 				if (old) {
 					ospf6_process_maxage_grace_lsa(
 						ospf6, new, from);
 				} else {
-					if (IS_DEBUG_OSPF6_GR)
-						zlog_debug(
-							"%s, GraceLSA doesn't exist in lsdb, so discarding GraceLSA",
-							__func__);
+					zlog_debug_if(IS_DEBUG_OSPF6_GR,
+						      "%s, GraceLSA doesn't exist in lsdb, so discarding GraceLSA",
+						      __func__);
 					ospf6_lsa_delete(new);
 					return;
 				}
 			} else {
-
-				if (IS_DEBUG_OSPF6_GR)
-					zlog_debug(
-						"%s, Received a GraceLSA from router %pI4",
-						__func__,
-						&new->header->adv_router);
+				zlog_debug_if(IS_DEBUG_OSPF6_GR,
+					      "%s, Received a GraceLSA from router %pI4",
+					      __func__,
+					      &new->header->adv_router);
 
 				if (ospf6_process_grace_lsa(ospf6, new, from)
 				    == OSPF6_GR_NOT_HELPER) {
-					if (IS_DEBUG_OSPF6_GR)
-						zlog_debug(
-							"%s, Not moving to HELPER role, So dicarding GraceLSA",
-							__func__);
+					zlog_debug_if(IS_DEBUG_OSPF6_GR,
+						      "%s, Not moving to HELPER role, So dicarding GraceLSA",
+						      __func__);
 					return;
 				}
 			}
@@ -1089,10 +1056,9 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 		if (self_originated) {
 			if (from->ospf6_if->area->ospf6->gr_info
 				    .restart_in_progress) {
-				if (IS_DEBUG_OSPF6_GR)
-					zlog_debug(
-						"Graceful Restart in progress -- not flushing self-originated LSA: %s",
-						new->name);
+				zlog_debug_if(IS_DEBUG_OSPF6_GR,
+					      "Graceful Restart in progress -- not flushing self-originated LSA: %s",
+					      new->name);
 				return;
 			}
 
@@ -1101,11 +1067,9 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 			   another router. We have to make a new instance of the
 			   LSA
 			   or have to flush this LSA. */
-			if (is_debug) {
-				zlog_debug(
-					"Newer instance of the self-originated LSA");
-				zlog_debug("Schedule reorigination");
-			}
+			zlog_debug_if(is_debug,
+				      "Newer instance of the self-originated LSA\n"
+				      "Schedule reorigination");
 			event_add_event(master, ospf6_lsa_refresh, new, 0,
 					&new->refresh);
 		}
@@ -1153,19 +1117,15 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 					new->header->adv_router,
 					from->retrans_list);
 		if (rem) {
-			if (is_debug) {
-				zlog_debug(
-					"It is on the neighbor's retrans-list.");
-				zlog_debug(
-					"Treat as an Implied acknowledgement");
-			}
+			zlog_debug_if(is_debug,
+				      "It is on the neighbor's retrans-list.\n"
+				      "Treat as an Implied acknowledgement");
 			SET_FLAG(new->flag, OSPF6_LSA_IMPLIEDACK);
 			ospf6_decrement_retrans_count(rem);
 			ospf6_lsdb_remove(rem, from->retrans_list);
 		}
 
-		if (is_debug)
-			zlog_debug("Possibly acknowledge and then discard");
+		zlog_debug_if(is_debug, "Possibly acknowledge and then discard");
 
 		/* (b) possibly acknowledge */
 		ospf6_acknowledge_lsa(new, ismore_recent, from);
@@ -1182,21 +1142,18 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 		   simply discard the received LSA */
 		if (OSPF6_LSA_IS_MAXAGE(old)
 		    && old->header->seqnum == htonl(OSPF_MAX_SEQUENCE_NUMBER)) {
-			if (is_debug) {
-				zlog_debug("The LSA is in Seqnumber Wrapping");
-				zlog_debug("MaxAge & MaxSeqNum, discard");
-			}
+			zlog_debug_if(is_debug,
+				      "The LSA is in Seqnumber Wrapping\n"
+				      "MaxAge & MaxSeqNum, discard");
 			ospf6_lsa_delete(new);
 			return;
 		}
 
 		/* Otherwise, Send database copy of this LSA to this neighbor */
 		{
-			if (is_debug) {
-				zlog_debug("Database copy is more recent.");
-				zlog_debug(
-					"Send back directly and then discard");
-			}
+			zlog_debug_if(is_debug,
+				      "Database copy is more recent.\n"
+				      "Send back directly and then discard");
 
 			/* Neighbor router sent recent age for LSA,
 			 * Router could be restarted while current copy is
@@ -1205,10 +1162,10 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 			    && !OSPF6_LSA_IS_MAXAGE(new)) {
 				if (new->header->adv_router
 				    != from->ospf6_if->area->ospf6->router_id) {
-					if (is_debug)
-						zlog_debug(
-							"%s: Current copy of LSA %s is MAXAGE, but new has recent age, flooding/installing.",
-							__PRETTY_FUNCTION__, old->name);
+					zlog_debug_if(is_debug,
+						      "%s: Current copy of LSA %s is MAXAGE, but new has recent age, flooding/installing.",
+						      __PRETTY_FUNCTION__,
+						      old->name);
 					ospf6_lsa_purge(old);
 					ospf6_flood(from, new);
 					ospf6_install_lsa(new);
@@ -1218,10 +1175,9 @@ void ospf6_receive_lsa(struct ospf6_neighbor *from,
 				 * ourselves. Fall through and send
 				 * LS Update with our current copy.
 				 */
-				if (is_debug)
-					zlog_debug(
-						"%s: Current copy of self-originated LSA %s is MAXAGE, but new has recent age, re-sending current one.",
-						__PRETTY_FUNCTION__, old->name);
+				zlog_debug_if(is_debug,
+					      "%s: Current copy of self-originated LSA %s is MAXAGE, but new has recent age, re-sending current one.",
+					      __PRETTY_FUNCTION__, old->name);
 			}
 
 			/* MinLSArrival check as per RFC 2328 13 (8) */

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -117,13 +117,13 @@ static struct ospf6_vertex *ospf6_vertex_create(struct ospf6_lsa *lsa)
 	/* name */
 	ospf6_linkstate_prefix2str(&v->vertex_id, v->name, sizeof(v->name));
 
-	if (IS_OSPF6_DEBUG_SPF(PROCESS))
-		zlog_debug("%s: Creating vertex %s of type %s (0x%04hx) lsa %s",
-			   __func__, v->name,
-			   ((ntohs(lsa->header->type) == OSPF6_LSTYPE_ROUTER)
-				    ? "Router"
-				    : "N/W"),
-			   ntohs(lsa->header->type), lsa->name);
+	zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+		      "%s: Creating vertex %s of type %s (0x%04hx) lsa %s",
+		      __func__, v->name,
+		      ((ntohs(lsa->header->type) == OSPF6_LSTYPE_ROUTER)
+			       ? "Router"
+			       : "N/W"),
+		      ntohs(lsa->header->type), lsa->name);
 
 
 	/* Associated LSA */
@@ -244,9 +244,9 @@ static char *ospf6_lsdesc_backlink(struct ospf6_lsa *lsa, caddr_t lsdesc,
 		}
 	}
 
-	if (IS_OSPF6_DEBUG_SPF(PROCESS))
-		zlog_debug("Vertex %s Lsa %s Backlink %s", v->name, lsa->name,
-			   (found ? "OK" : "FAIL"));
+	zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+		      "Vertex %s Lsa %s Backlink %s", v->name, lsa->name,
+		      (found ? "OK" : "FAIL"));
 
 	return found;
 }
@@ -303,8 +303,8 @@ static void ospf6_nexthop_calc(struct ospf6_vertex *w, struct ospf6_vertex *v,
 		i++;
 	}
 
-	if (i == 0 && IS_OSPF6_DEBUG_SPF(PROCESS))
-		zlog_debug("No nexthop for %s found", w->name);
+	zlog_debug_if(i == 0 && IS_OSPF6_DEBUG_SPF(PROCESS),
+		      "No nexthop for %s found", w->name);
 }
 
 static int ospf6_spf_install(struct ospf6_vertex *v,
@@ -313,23 +313,21 @@ static int ospf6_spf_install(struct ospf6_vertex *v,
 	struct ospf6_route *route;
 	struct ospf6_vertex *prev;
 
-	if (IS_OSPF6_DEBUG_SPF(PROCESS))
-		zlog_debug("SPF install %s (lsa %s) hops %d cost %d", v->name,
-			   v->lsa->name, v->hops, v->cost);
+	zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+		      "SPF install %s (lsa %s) hops %d cost %d", v->name,
+		      v->lsa->name, v->hops, v->cost);
 
 	route = ospf6_route_lookup(&v->vertex_id, result_table);
 	if (route && route->path.cost < v->cost) {
-		if (IS_OSPF6_DEBUG_SPF(PROCESS))
-			zlog_debug(
-				"  already installed with lower cost (%d), ignore",
-				route->path.cost);
+		zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+			      "  already installed with lower cost (%d), ignore",
+			      route->path.cost);
 		ospf6_vertex_delete(v);
 		return -1;
 	} else if (route && route->path.cost == v->cost) {
-		if (IS_OSPF6_DEBUG_SPF(PROCESS))
-			zlog_debug(
-				"  another path found to route %pFX lsa %s, merge",
-				&route->prefix, v->lsa->name);
+		zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+			      "  another path found to route %pFX lsa %s, merge",
+			      &route->prefix, v->lsa->name);
 
 		/* merging the parent's nexthop information to the child's
 		 * if the parent is not the root of the tree.
@@ -342,13 +340,11 @@ static int ospf6_spf_install(struct ospf6_vertex *v,
 
 		if ((VERTEX_IS_TYPE(ROUTER, v)
 		     && route->path.origin.id != v->lsa->header->id)) {
-			if (IS_OSPF6_DEBUG_SPF(PROCESS)) {
-				zlog_debug(
-					"%s: V lsa %s id %u, route id %u are different",
-					__func__, v->lsa->name,
-					ntohl(v->lsa->header->id),
-					ntohl(route->path.origin.id));
-			}
+			zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+				      "%s: V lsa %s id %u, route id %u are different",
+				      __func__, v->lsa->name,
+				      ntohl(v->lsa->header->id),
+				      ntohl(route->path.origin.id));
 			return 0;
 		}
 
@@ -608,13 +604,12 @@ static void ospf6_spf_calculation_thread(struct event *t)
 		ospf6_abr_range_reset_cost(ospf6);
 
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, node, oa)) {
-
 		if (oa == ospf6->backbone)
 			continue;
 
 		monotime(&oa->ts_spf);
-		if (IS_OSPF6_DEBUG_SPF(PROCESS))
-			zlog_debug("SPF calculation for Area %s", oa->name);
+		zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+			      "SPF calculation for Area %s", oa->name);
 		if (IS_OSPF6_DEBUG_SPF(DATABASE))
 			ospf6_spf_log_database(oa);
 
@@ -627,9 +622,9 @@ static void ospf6_spf_calculation_thread(struct event *t)
 
 	if (ospf6->backbone) {
 		monotime(&ospf6->backbone->ts_spf);
-		if (IS_OSPF6_DEBUG_SPF(PROCESS))
-			zlog_debug("SPF calculation for Backbone area %s",
-				   ospf6->backbone->name);
+		zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+			      "SPF calculation for Backbone area %s",
+			      ospf6->backbone->name);
 		if (IS_OSPF6_DEBUG_SPF(DATABASE))
 			ospf6_spf_log_database(ospf6->backbone);
 
@@ -656,11 +651,10 @@ static void ospf6_spf_calculation_thread(struct event *t)
 
 	ospf6_spf_reason_string(ospf6->spf_reason, rbuf, sizeof(rbuf));
 
-	if (IS_OSPF6_DEBUG_SPF(PROCESS) || IS_OSPF6_DEBUG_SPF(TIME))
-		zlog_debug(
-			"SPF processing: # Areas: %d, SPF runtime: %lld sec %lld usec, Reason: %s",
-			areas_processed, (long long)runtime.tv_sec,
-			(long long)runtime.tv_usec, rbuf);
+	zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS) || IS_OSPF6_DEBUG_SPF(TIME),
+		      "SPF processing: # Areas: %d, SPF runtime: %lld sec %lld usec, Reason: %s",
+		      areas_processed, (long long)runtime.tv_sec,
+		      (long long)runtime.tv_usec, rbuf);
 
 	ospf6->last_spf_reason = ospf6->spf_reason;
 	ospf6_reset_spf_reason(ospf6);
@@ -687,10 +681,10 @@ void ospf6_spf_schedule(struct ospf6 *ospf6, unsigned int reason)
 
 	/* SPF calculation timer is already scheduled. */
 	if (event_is_scheduled(ospf6->t_spf_calc)) {
-		if (IS_OSPF6_DEBUG_SPF(PROCESS) || IS_OSPF6_DEBUG_SPF(TIME))
-			zlog_debug(
-				"SPF: calculation timer is already scheduled: %p",
-				(void *)ospf6->t_spf_calc);
+		zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS) ||
+				      IS_OSPF6_DEBUG_SPF(TIME),
+			      "SPF: calculation timer is already scheduled: %p",
+			      (void *)ospf6->t_spf_calc);
 		return;
 	}
 
@@ -720,8 +714,8 @@ void ospf6_spf_schedule(struct ospf6 *ospf6, unsigned int reason)
 		ospf6->spf_hold_multiplier = 1;
 	}
 
-	if (IS_OSPF6_DEBUG_SPF(PROCESS) || IS_OSPF6_DEBUG_SPF(TIME))
-		zlog_debug("SPF: Rescheduling in %ld msec", delay);
+	zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS) || IS_OSPF6_DEBUG_SPF(TIME),
+		      "SPF: Rescheduling in %ld msec", delay);
 
 	EVENT_OFF(ospf6->t_spf_calc);
 	event_add_timer_msec(master, ospf6_spf_calculation_thread, ospf6, delay,
@@ -1015,16 +1009,16 @@ struct ospf6_lsa *ospf6_create_single_router_lsa(struct ospf6_area *area,
 		num_lsa++;
 		rtr_lsa = ospf6_lsdb_next(end, rtr_lsa);
 	}
-	if (IS_OSPF6_DEBUG_SPF(PROCESS))
-		zlog_debug("%s: adv_router %s num_lsa %u to convert.", __func__,
-			   ifbuf, num_lsa);
+	zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+		      "%s: adv_router %s num_lsa %u to convert.", __func__,
+		      ifbuf, num_lsa);
 	if (num_lsa == 1)
 		return lsa;
 
 	if (num_lsa == 0) {
-		if (IS_OSPF6_DEBUG_SPF(PROCESS))
-			zlog_debug("%s: adv_router %s not found in LSDB.",
-				   __func__, ifbuf);
+		zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+			      "%s: adv_router %s not found in LSDB.", __func__,
+			      ifbuf);
 		return NULL;
 	}
 
@@ -1088,11 +1082,11 @@ struct ospf6_lsa *ospf6_create_single_router_lsa(struct ospf6_area *area,
 	/* Store Aggregated LSA into area temp lsdb */
 	ospf6_lsdb_add(lsa, area->temp_router_lsa_lsdb);
 
-	if (IS_OSPF6_DEBUG_SPF(PROCESS))
-		zlog_debug("%s: LSA %s id %u type 0%x len %u num_lsa %u",
-			   __func__, lsa->name, ntohl(lsa->header->id),
-			   ntohs(lsa->header->type), ntohs(lsa->header->length),
-			   num_lsa);
+	zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+		      "%s: LSA %s id %u type 0%x len %u num_lsa %u", __func__,
+		      lsa->name, ntohl(lsa->header->id),
+		      ntohs(lsa->header->type), ntohs(lsa->header->length),
+		      num_lsa);
 
 	return lsa;
 }
@@ -1102,11 +1096,10 @@ void ospf6_remove_temp_router_lsa(struct ospf6_area *area)
 	struct ospf6_lsa *lsa = NULL, *lsanext;
 
 	for (ALL_LSDB(area->temp_router_lsa_lsdb, lsa, lsanext)) {
-		if (IS_OSPF6_DEBUG_SPF(PROCESS))
-			zlog_debug(
-				"%s Remove LSA %s lsa->lock %u lsdb count %u",
-				__func__, lsa->name, lsa->lock,
-				area->temp_router_lsa_lsdb->count);
+		zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+			      "%s Remove LSA %s lsa->lock %u lsdb count %u",
+			      __func__, lsa->name, lsa->lock,
+			      area->temp_router_lsa_lsdb->count);
 		ospf6_lsdb_remove(lsa, area->temp_router_lsa_lsdb);
 	}
 }
@@ -1122,18 +1115,16 @@ int ospf6_ase_calculate_route(struct ospf6 *ospf6, struct ospf6_lsa *lsa,
 
 	assert(lsa);
 
-	if (IS_OSPF6_DEBUG_SPF(PROCESS))
-		zlog_debug("%s :  start", __func__);
+	zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS), "%s :  start", __func__);
 
 	if (ntohs(lsa->header->type) == OSPF6_LSTYPE_TYPE_7)
-		if (IS_OSPF6_DEBUG_SPF(PROCESS))
-			zlog_debug("%s: Processing Type-7", __func__);
+		zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+			      "%s: Processing Type-7", __func__);
 
 	/* Stay away from any Local Translated Type-7 LSAs */
 	if (CHECK_FLAG(lsa->flag, OSPF6_LSA_LOCAL_XLT)) {
-		if (IS_OSPF6_DEBUG_SPF(PROCESS))
-			zlog_debug("%s: Rejecting Local translated LSA",
-				   __func__);
+		zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+			      "%s: Rejecting Local translated LSA", __func__);
 		return 0;
 	}
 
@@ -1157,9 +1148,9 @@ int ospf6_ase_calculate_route(struct ospf6 *ospf6, struct ospf6_lsa *lsa,
 
 		route = ospf6_route_lookup(&prefix, ospf6->route_table);
 		if (route == NULL) {
-			if (IS_OSPF6_DEBUG_SPF(PROCESS))
-				zlog_debug("%s: no external route %pFX",
-					   __func__, &prefix);
+			zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+				      "%s: no external route %pFX", __func__,
+				      &prefix);
 			return 0;
 		}
 
@@ -1174,10 +1165,9 @@ int ospf6_ase_calculate_route(struct ospf6 *ospf6, struct ospf6_lsa *lsa,
 		else if (CHECK_FLAG(route->flag, OSPF6_ROUTE_ADD)
 			 || CHECK_FLAG(route->flag, OSPF6_ROUTE_CHANGE)) {
 			if (hook_add) {
-				if (IS_OSPF6_DEBUG_SPF(PROCESS))
-					zlog_debug(
-						"%s: add external route %pFX",
-						__func__, &prefix);
+				zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+					      "%s: add external route %pFX",
+					      __func__, &prefix);
 				(*hook_add)(route);
 			}
 		}
@@ -1195,9 +1185,9 @@ int ospf6_ase_calculate_route(struct ospf6 *ospf6, struct ospf6_lsa *lsa,
 
 		route = ospf6_route_lookup(&prefix, area->route_table);
 		if (route == NULL) {
-			if (IS_OSPF6_DEBUG_SPF(PROCESS))
-				zlog_debug("%s: no route %pFX, area %s",
-					   __func__, &prefix, area->name);
+			zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+				      "%s: no route %pFX, area %s", __func__,
+				      &prefix, area->name);
 			return 0;
 		}
 
@@ -1208,17 +1198,16 @@ int ospf6_ase_calculate_route(struct ospf6 *ospf6, struct ospf6_lsa *lsa,
 		}
 
 		if (CHECK_FLAG(route->flag, OSPF6_ROUTE_REMOVE)) {
-			if (IS_OSPF6_DEBUG_SPF(PROCESS))
-				zlog_debug("%s : remove route %pFX, area %s",
-					   __func__, &prefix, area->name);
+			zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+				      "%s : remove route %pFX, area %s",
+				      __func__, &prefix, area->name);
 			ospf6_route_remove(route, area->route_table);
 		} else if (CHECK_FLAG(route->flag, OSPF6_ROUTE_ADD)
 			   || CHECK_FLAG(route->flag, OSPF6_ROUTE_CHANGE)) {
 			if (hook_add) {
-				if (IS_OSPF6_DEBUG_SPF(PROCESS))
-					zlog_debug(
-						"%s: add nssa route %pFX, area %s",
-						__func__, &prefix, area->name);
+				zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+					      "%s: add nssa route %pFX, area %s",
+					      __func__, &prefix, area->name);
 				(*hook_add)(route);
 			}
 			ospf6_abr_check_translate_nssa(area, lsa);
@@ -1245,9 +1234,9 @@ static void ospf6_ase_calculate_timer(struct event *t)
 	/*  This version simple adds to the table all NSSA areas  */
 	if (ospf6->anyNSSA) {
 		for (ALL_LIST_ELEMENTS(ospf6->area_list, node, nnode, area)) {
-			if (IS_OSPF6_DEBUG_SPF(PROCESS))
-				zlog_debug("%s : looking at area %s", __func__,
-					   area->name);
+			zlog_debug_if(IS_OSPF6_DEBUG_SPF(PROCESS),
+				      "%s : looking at area %s", __func__,
+				      area->name);
 
 			type = htons(OSPF6_LSTYPE_TYPE_7);
 			for (ALL_LSDB_TYPED(area->lsdb, type, lsa))


### PR DESCRIPTION
Introduces a new logging macro: zlog_debug_if(condition, message) and uses it to replace a repeating pattern:

    if (condition)
    	zlog_debug(...)

becomes:

    zlog_debug_if(condition, ...)

Code readability is improved when debug logging reads like statements. It is meant to be used without side effects in the format string evaluation.