### PR TITLE
bgpd: Fix display when using `missing-as-worst`

### DIFF
--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -845,10 +845,10 @@ extern void route_vty_out(struct vty *vty, const struct prefix *p,
 extern void route_vty_out_tag(struct vty *vty, const struct prefix *p,
 			      struct bgp_path_info *path, int display,
 			      safi_t safi, json_object *json);
-extern void route_vty_out_tmp(struct vty *vty, struct bgp_dest *dest,
-			      const struct prefix *p, struct attr *attr,
-			      safi_t safi, bool use_json, json_object *json_ar,
-			      bool wide);
+extern void route_vty_out_tmp(struct vty *vty, struct bgp *bgp,
+			      struct bgp_dest *dest, const struct prefix *p,
+			      struct attr *attr, safi_t safi, bool use_json,
+			      json_object *json_ar, bool wide);
 extern void route_vty_out_overlay(struct vty *vty, const struct prefix *p,
 				  struct bgp_path_info *path, int display,
 				  json_object *json);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -328,15 +328,16 @@ static void subgrp_show_adjq_vty(struct update_subgroup *subgrp,
 			}
 			if ((flags & UPDWALK_FLAGS_ADVQUEUE) && adj->adv &&
 			    adj->adv->baa) {
-				route_vty_out_tmp(
-					vty, dest, dest_p, adj->adv->baa->attr,
-					SUBGRP_SAFI(subgrp), 0, NULL, false);
+				route_vty_out_tmp(vty, bgp, dest, dest_p,
+						  adj->adv->baa->attr,
+						  SUBGRP_SAFI(subgrp), 0, NULL,
+						  false);
 				output_count++;
 			}
 			if ((flags & UPDWALK_FLAGS_ADVERTISED) && adj->attr) {
-				route_vty_out_tmp(vty, dest, dest_p, adj->attr,
-						  SUBGRP_SAFI(subgrp), 0, NULL,
-						  false);
+				route_vty_out_tmp(vty, bgp, dest, dest_p,
+						  adj->attr, SUBGRP_SAFI(subgrp),
+						  0, NULL, false);
 				output_count++;
 			}
 		}

--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -191,7 +191,7 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 				}
 				rd_header = 0;
 			}
-			route_vty_out_tmp(vty, rm, bgp_dest_get_prefix(rm),
+			route_vty_out_tmp(vty, bgp, rm, bgp_dest_get_prefix(rm),
 					  attr, safi, use_json, json_routes,
 					  false);
 			output_count++;

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -425,6 +425,11 @@ Route Selection
 
    Disabled by default.
 
+.. clicmd:: bgp bestpath med missing-as-worst
+
+   If the paths MED value is missing and this command is configured
+   then treat it as the worse possible value that it can be.
+
 .. clicmd:: maximum-paths (1-128)
 
    Sets the maximum-paths value used for ecmp calculations for this


### PR DESCRIPTION
The usage of the `bgp bestpath med missing-as-worst` command was being accepted and applied during bestpath, but during output of the routes affected by this it would not give any indication that this was happening or what med value was being used.

Fixes: #15718