### PR TITLE
zebra: backpressure - Fix Null ptr access (Coverity Issue)

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1782,7 +1782,7 @@ static void bgp_handle_route_announcements_to_zebra(struct event *e)
 
 		table = bgp_dest_table(dest);
 		install = CHECK_FLAG(dest->flags, BGP_NODE_SCHEDULE_FOR_INSTALL);
-		if (table && table->afi == AFI_L2VPN && table->safi == SAFI_EVPN)
+		if (table->afi == AFI_L2VPN && table->safi == SAFI_EVPN)
 			is_evpn = true;
 
 		if (BGP_DEBUG(zebra, ZEBRA))


### PR DESCRIPTION
Fix dereferencing NULL ptr making coverity happy.

Ticket :#3390099