### PR TITLE
topotests: avoid console errors if no mpls - do not merge

### DIFF
--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1759,7 +1759,8 @@ class Router(Node):
 
         # Really want to use sysctl_atleast here, but only when MPLS is actually being
         # used
-        self.cmd("echo 100000 > /proc/sys/net/mpls/platform_labels")
+        if self.hasmpls:
+            self.cmd("echo 100000 > /proc/sys/net/mpls/platform_labels")
 
         if g_pytest_config.name_in_option_list(self.name, "--shell"):
             self.run_in_window(os.getenv("SHELL", "bash"), title="sh-%s" % self.name)

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1759,7 +1759,9 @@ class Router(Node):
 
         # Really want to use sysctl_atleast here, but only when MPLS is actually being
         # used
-        if self.hasmpls:
+        if self.hasmpls == True:
+            self.cmd("echo 100000 > /proc/sys/net/mpls/platform_labels")
+        else:
             self.cmd("echo 100000 > /proc/sys/net/mpls/platform_labels")
 
         if g_pytest_config.name_in_option_list(self.name, "--shell"):


### PR DESCRIPTION
On some environments, when running topotests, we get: 
```
modprobe: FATAL: Module mpls-router not found in directory /lib/modules/6.5.0-1017-azure 
  ...
/usr/bin/nsenter --mount=/proc/27565/ns/mnt --net=/proc/27565/ns/net --uts=/proc/27565/ns/uts -F /bin/bash -c echo 100000 > /proc/sys/net/mpls/platform_labels
/proc/sys/net/mpls/platform_labels: No such file or directory
```