### PR TITLE
cmake install prefix

### DIFF
--- a/doc/developer/building-libyang.rst
+++ b/doc/developer/building-libyang.rst
@@ -41,7 +41,7 @@ DEB packages are available as CI artifacts `here
    cd libyang
    git checkout v2.1.128
    mkdir build; cd build
-   cmake -D CMAKE_INSTALL_PREFIX:PATH=/usr \
+   cmake --install-prefix /usr \
          -D CMAKE_BUILD_TYPE:String="Release" ..
    make
    sudo make install

--- a/doc/developer/cross-compiling.rst
+++ b/doc/developer/cross-compiling.rst
@@ -148,7 +148,7 @@ be built and installed generally like:
    CC=${HOST_ARCH}-gcc \
    CXX=${HOST_ARCH}-g++ \
    cmake \
-       -DCMAKE_INSTALL_PREFIX=/usr/${HOST_ARCH} \
+       --install-prefix /usr/${HOST_ARCH} \
        ..
    make
    make install

--- a/doc/developer/northbound/plugins-sysrepo.rst
+++ b/doc/developer/northbound/plugins-sysrepo.rst
@@ -32,7 +32,7 @@ libyang
    cd libyang
    git checkout v2.1.148
    mkdir build; cd build
-   cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+   cmake --install-prefix /usr \
          -DCMAKE_BUILD_TYPE:String="Release" ..
    make
    sudo make install
@@ -51,7 +51,7 @@ Sysrepo
    cd sysrepo/
    git checkout v2.2.150
    mkdir build; cd build
-   cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+   cmake --install-prefix /usr \
          -DCMAKE_BUILD_TYPE:String="Release" ..
    make
    sudo make install

--- a/doc/developer/static-linking.rst
+++ b/doc/developer/static-linking.rst
@@ -44,7 +44,7 @@ when building libyang statically.
 The resultant cmake command is::
 
    cmake -DENABLE_STATIC=ON -DENABLE_LYD_PRIV=ON \
-         -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+         --install-prefix /usr \
          -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
          -DCMAKE_BUILD_TYPE:String="Release" ..
 


### PR DESCRIPTION
Since cmake 3.21, we should use `--install-prefix`
  see https://cmake.org/cmake/help/latest/manual/cmake.1.html