### PR TITLE
bgpd: fix compile error

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3339,7 +3339,9 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 		return;
 	}
 
+#ifdef ENABLE_BGP_VNC
 	const struct prefix *p = bgp_dest_get_prefix(dest);
+#endif
 
 	debug = bgp_debug_bestpath(dest);
 	if (debug)


### PR DESCRIPTION
This is happening when configuring with `--disable-bgp-vnc`:
```
./bgpd/bgp_route.c:3342:23: error: unused variable ‘p’ [-Werror=unused-variable]

 3342 |  const struct prefix *p = bgp_dest_get_prefix(dest);
```