### PR TITLE
topotests: lib, fix filter out "At line 73 in /usr/share/snmp/mibs/ie…

### DIFF
--- a/tests/topotests/lib/snmptest.py
+++ b/tests/topotests/lib/snmptest.py
@@ -85,15 +85,18 @@ class SnmpTester(object):
         return out_dict, out_list
 
     def get(self, oid):
-        cmd = "snmpget {0} {1}".format(self._snmp_config(), oid)
-
+        cmd = "snmpget {0} {1} 2>&1 | grep -v SNMPv2-PDU".format(
+            self._snmp_config(), oid
+        )
         result = self.router.cmd(cmd)
         if "not found" in result:
             return None
         return self._get_snmp_value(result)
 
     def get_next(self, oid):
-        cmd = "snmpgetnext {0} {1}".format(self._snmp_config(), oid)
+        cmd = "snmpgetnext {0} {1} 2>&1 | grep -v SNMPv2-PDU".format(
+            self._snmp_config(), oid
+        )
 
         result = self.router.cmd(cmd)
         print("get_next: {}".format(result))
@@ -102,7 +105,9 @@ class SnmpTester(object):
         return self._get_snmp_value(result)
 
     def walk(self, oid):
-        cmd = "snmpwalk {0} {1}".format(self._snmp_config(), oid)
+        cmd = "snmpwalk {0} {1} 2>&1 | grep -v SNMPv2-PDU".format(
+            self._snmp_config(), oid
+        )
 
         result = self.router.cmd(cmd)
         return self._parse_multiline(result)


### PR DESCRIPTION
…tf/SNMPv2-PDU" message

When testing SNMP service on FRR, the following error message may appear on some distros.

> # snmpwalk -v2c -c public .1.3.6 1.1.1.1 <OID>
> Bad operator (INTEGER): At line 73 in /usr/share/snmp/mibs/ietf/SNMPv2-PDU
> [..then result ..]
>

The error message is due to the /etc/snmp/snmp.conf file. By default, this file is used by both snmp server and client side. The net-snmp MIB parsing routing loads MIBS, to bind oids with the naming scheme used by the MIBS.

> # cat /etc/frr/snmp.conf
> [snmp]
> mibs +ALL
>

A potential fix would consist in modifying the SNMPv2-PDU.mib file: the problem is known on ubuntu distros, as the snmp-mibs-downloader package has not updated the SNMPv2-PDU.mib file.

The choice is done to not modify the original distro where the test is run on. Fix the topotests by ignoring the 'SNMPv2-PDU line 73" error message, and keep the other error messages that may happen, for instance, when an unknown oid name value is requested.