### PR TITLE
bgpd: fix show run of network route-distinguisher

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7138,6 +7138,10 @@ int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
 			bgp_static->label = label;
 			bgp_static->prd = prd;
 
+			if (rd_str)
+				bgp_static->prd_pretty = XSTRDUP(MTYPE_BGP,
+								 rd_str);
+
 			if (rmap) {
 				XFREE(MTYPE_ROUTE_MAP_NAME,
 				      bgp_static->rmap.name);


### PR DESCRIPTION
Route-distinguisher is not printed properly in show run:

>  address-family ipv6 vpn
>   network ff01::/64 rd (null) label 7
>   network ff01::/64 rd (null) label 8

https://github.com/FRRouting/frr/commit/ad151f66aabaf29a16254eee3eea36a4d4ff674f ("bgpd: Refactor bgp_static_set/bgp_static_set_safi") merged
bgp_static_set_safi into bgp_static_set but inadvertently omitted the
handling of prd_pretty.

Copy the pretty RD string if available.

> address-family ipv6 vpn
>  network ff01::/64 rd 75:5 label 7
>  network ff01::/64 rd 85:5 label 8