### PR TITLE
zebra: Actually display I/O buffer sizes (part-2)

### DIFF
--- a/lib/stream.c
+++ b/lib/stream.c
@@ -1241,9 +1241,7 @@ void stream_fifo_init(struct stream_fifo *fifo)
 /* Add new stream to fifo. */
 void stream_fifo_push(struct stream_fifo *fifo, struct stream *s)
 {
-#if defined DEV_BUILD
 	size_t max, curmax;
-#endif
 
 	if (fifo->tail)
 		fifo->tail->next = s;
@@ -1252,15 +1250,11 @@ void stream_fifo_push(struct stream_fifo *fifo, struct stream *s)
 
 	fifo->tail = s;
 	fifo->tail->next = NULL;
-#if !defined DEV_BUILD
-	atomic_fetch_add_explicit(&fifo->count, 1, memory_order_release);
-#else
 	max = atomic_fetch_add_explicit(&fifo->count, 1, memory_order_release);
 	curmax = atomic_load_explicit(&fifo->max_count, memory_order_relaxed);
 	if (max > curmax)
 		atomic_store_explicit(&fifo->max_count, max,
 				      memory_order_relaxed);
-#endif
 }
 
 void stream_fifo_push_safe(struct stream_fifo *fifo, struct stream *s)


### PR DESCRIPTION
An extension of commit-8d8f12ba8e5cd11c189b8475b05539fa8415ccb9

Removing ifdef DEV_BUILD in stream_fifo_push as well to make the 'sh zebra client' display the current I/O fifo along with max fifo items.

TICKET :#3390099