### PR TITLE
lib, zebra: fix exit commands

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1374,7 +1374,7 @@ DEFUN (disable,
 }
 
 /* Down vty node level. */
-DEFUN (config_exit,
+DEFUN_YANG (config_exit,
        config_exit_cmd,
        "exit",
        "Exit current mode and down to previous mode\n")

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -636,7 +636,7 @@ int vrf_configure_backend(enum vrf_backend_type backend)
 }
 
 /* vrf CLI commands */
-DEFUN_NOSH(vrf_exit,
+DEFUN_YANG_NOSH (vrf_exit,
            vrf_exit_cmd,
 	   "exit-vrf",
 	   "Exit current mode and down to previous mode\n")

--- a/zebra/zebra_cli.c
+++ b/zebra/zebra_cli.c
@@ -241,7 +241,7 @@ DEFUN_YANG_NOSH (link_params,
 	return ret;
 }
 
-DEFUN_NOSH (exit_link_params,
+DEFUN_YANG_NOSH (exit_link_params,
 	exit_link_params_cmd,
 	"exit-link-params",
 	"Exit from Link Params configuration mode\n")


### PR DESCRIPTION
If a command is not marked as `YANG`-converted, the current command batching buffer is flushed before executing the command. We shouldn't flush the buffer when executing an `exit` command. It should only be flushed if the next command is not `YANG`-converted, which is checked by the command itself, not the previous `exit`.

Fixes #15706.