### PR TITLE
bgpd: cleanup references to debug bgp allow-martians

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -50,7 +50,6 @@ unsigned long conf_bgp_debug_keepalive;
 unsigned long conf_bgp_debug_update;
 unsigned long conf_bgp_debug_bestpath;
 unsigned long conf_bgp_debug_zebra;
-unsigned long conf_bgp_debug_allow_martians;
 unsigned long conf_bgp_debug_nht;
 unsigned long conf_bgp_debug_update_groups;
 unsigned long conf_bgp_debug_vpn;
@@ -71,7 +70,6 @@ unsigned long term_bgp_debug_keepalive;
 unsigned long term_bgp_debug_update;
 unsigned long term_bgp_debug_bestpath;
 unsigned long term_bgp_debug_zebra;
-unsigned long term_bgp_debug_allow_martians;
 unsigned long term_bgp_debug_nht;
 unsigned long term_bgp_debug_update_groups;
 unsigned long term_bgp_debug_vpn;
@@ -2165,7 +2163,6 @@ DEFUN (no_debug_bgp,
 	TERM_DEBUG_OFF(as4, AS4_SEGMENT);
 	TERM_DEBUG_OFF(neighbor_events, NEIGHBOR_EVENTS);
 	TERM_DEBUG_OFF(zebra, ZEBRA);
-	TERM_DEBUG_OFF(allow_martians, ALLOW_MARTIANS);
 	TERM_DEBUG_OFF(nht, NHT);
 	TERM_DEBUG_OFF(vpn, VPN_LEAK_FROM_VRF);
 	TERM_DEBUG_OFF(vpn, VPN_LEAK_TO_VRF);
@@ -2240,9 +2237,6 @@ DEFUN_NOSH (show_debugging_bgp,
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 		vty_out(vty, "  BGP graceful-restart debugging is on\n");
-
-	if (BGP_DEBUG(allow_martians, ALLOW_MARTIANS))
-		vty_out(vty, "  BGP allow martian next hop debugging is on\n");
 
 	if (BGP_DEBUG(vpn, VPN_LEAK_FROM_VRF))
 		vty_out(vty,
@@ -2354,11 +2348,6 @@ static int bgp_config_write_debug(struct vty *vty)
 				vty, "debug bgp zebra prefix",
 				bgp_debug_zebra_prefixes);
 		}
-	}
-
-	if (CONF_BGP_DEBUG(allow_martians, ALLOW_MARTIANS)) {
-		vty_out(vty, "debug bgp allow-martians\n");
-		write++;
 	}
 
 	if (CONF_BGP_DEBUG(vpn, VPN_LEAK_FROM_VRF)) {

--- a/bgpd/bgp_debug.h
+++ b/bgpd/bgp_debug.h
@@ -61,7 +61,6 @@ extern unsigned long conf_bgp_debug_keepalive;
 extern unsigned long conf_bgp_debug_update;
 extern unsigned long conf_bgp_debug_bestpath;
 extern unsigned long conf_bgp_debug_zebra;
-extern unsigned long conf_bgp_debug_allow_martians;
 extern unsigned long conf_bgp_debug_nht;
 extern unsigned long conf_bgp_debug_update_groups;
 extern unsigned long conf_bgp_debug_vpn;
@@ -80,7 +79,6 @@ extern unsigned long term_bgp_debug_keepalive;
 extern unsigned long term_bgp_debug_update;
 extern unsigned long term_bgp_debug_bestpath;
 extern unsigned long term_bgp_debug_zebra;
-extern unsigned long term_bgp_debug_allow_martians;
 extern unsigned long term_bgp_debug_nht;
 extern unsigned long term_bgp_debug_update_groups;
 extern unsigned long term_bgp_debug_vpn;
@@ -120,7 +118,6 @@ struct bgp_debug_filter {
 #define BGP_DEBUG_UPDATE_PREFIX       0x04
 #define BGP_DEBUG_UPDATE_DETAIL       0x08
 #define BGP_DEBUG_ZEBRA               0x01
-#define BGP_DEBUG_ALLOW_MARTIANS      0x01
 #define BGP_DEBUG_NHT                 0x01
 #define BGP_DEBUG_UPDATE_GROUPS       0x01
 #define BGP_DEBUG_VPN_LEAK_FROM_VRF   0x01


### PR DESCRIPTION
The debug command was removed in 17e9298e47 ("bgpd: Remove 'debug bgp allow-martian'")

Cleanup all references to the debug command.