### PR TITLE
ospfd: fix 'no maximum-paths' 'no write-multiplier'  commands

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2580,7 +2580,7 @@ DEFUN (no_ospf_write_multiplier,
 }
 
 ALIAS(no_ospf_write_multiplier, no_write_multiplier_cmd,
-      "no write-multiplier (1-100)", NO_STR
+      "no write-multiplier [(1-100)]", NO_STR
       "Write multiplier\n"
       "Maximum number of interface serviced per write\n")
 

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2654,9 +2654,10 @@ DEFUN (ospf_max_multipath,
 
 DEFUN (no_ospf_max_multipath,
        no_ospf_max_multipath_cmd,
-       "no maximum-paths",
+       "no maximum-paths [" CMD_RANGE_STR(1, MULTIPATH_NUM)"]",
        NO_STR
-       "Max no of multiple paths for ECMP support\n")
+       "Max no of multiple paths for ECMP support\n"
+       "Number of paths\n")
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 	uint16_t maxpaths = MULTIPATH_NUM;


### PR DESCRIPTION
1. Fixed the syntax of the 'no maximum-paths' command to allow the parameter (1-64) to be present. Since the corresponding 'set' command is 'maximum-paths (1-64)', its 'unset' command should also allow the parameter (1-64) to be either present or absent, aligning it with the same command in `bgp_vty.c` and `ospf6_top.c`.
2. Fixed the syntax of the 'no write-multiplier' command for the same reasons as above.