### PR TITLE
bgpd: Allow specification of AS 0 for rpki commands

### DIFF
--- a/doc/user/rpki.rst
+++ b/doc/user/rpki.rst
@@ -215,15 +215,18 @@ Displaying RPKI
 
    Display RPKI configuration state including timers values.
 
-.. clicmd:: show rpki prefix <A.B.C.D/M|X:X::X:X/M> [(1-4294967295)] [vrf NAME] [json]
+.. clicmd:: show rpki prefix <A.B.C.D/M|X:X::X:X/M> [ASN] [vrf NAME] [json]
 
    Display validated prefixes received from the cache servers filtered
-   by the specified prefix.
+   by the specified prefix.  The AS number space has been increased
+   to allow the choice of using AS 0 because RFC-7607 specifically
+   calls out the usage of 0 in a special case.
 
 .. clicmd:: show rpki as-number ASN [vrf NAME] [json]
 
    Display validated prefixes received from the cache servers filtered
-   by ASN.
+   by ASN.  The usage of AS 0 is allowed because RFC-76067 specifically
+   calls out the usage of 0 in a special case.
 
 .. clicmd:: show rpki prefix-table [vrf NAME] [json]
 


### PR DESCRIPTION
RFC-7607 specifically calls out the allowed usage
of AS 0 to signal that the a particular address is not in use and should be guarded against.  Add
the ability to specify this special AS in the rpki commands.

eva# show rpki  as-number 0
RPKI/RTR prefix table
Prefix                                   Prefix Length  Origin-AS
2.57.180.0                                  22 -  24   0
2.58.144.0                                  22 -  22   0
2.59.116.0                                  24 -  24   0
4.42.228.0                                  22 -  22   0
5.57.80.0                                   22 -  22   0
<snip>
2a13:df87:b400::                            38 -  38   0
2a13:df84::                                 32 -  32   0
2630::                                      16 -  16   0
Number of IPv4 Prefixes: 1166
Number of IPv6 Prefixes: 617

eva# show rpki prefix 2630::/16 0
Prefix                                   Prefix Length  Origin-AS
2630::                                      16 -  16   0
eva#

Fixes: #15778