### PR TITLE
ospfd: Add prefix-list filtering of OSPF neighbors on OSPF interface

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -757,6 +757,32 @@ Interfaces
    optional IPv4 address is specified, the prefix suppression will apply
    to the OSPF interface associated with the specified interface address.
 
+.. clicmd:: ip ospf neighbor-filter NAME [A.B.C.D]
+
+   Configure an IP prefix-list to use to filter packets received from
+   OSPF neighbors on the OSPF interface. The prefix-list should include rules
+   to permit or deny OSPF neighbors by IP source address. This is useful for
+   multi-access interfaces where adjacencies with only a subset of the
+   reachable neighbors are desired. Applications include testing partially
+   meshed topologies, OSPF Denial of Sevice (DoS) mitigation, and avoidance
+   of adjacencies with OSPF neighbors not meeting traffic engineering criteria.
+
+      Example:
+
+.. code-block:: frr
+
+   !
+   ! Prefix-list to block neighbor with source address 10.1.0.2
+   !
+   ip prefix-list nbr-filter seq 10 deny 10.1.0.2/32
+   ip prefix-list nbr-filter seq 200 permit any
+   !
+   ! Configure the neighbor filter prefix-list on interface eth0
+   !
+   interface eth0
+    ip ospf neighbor-filter nbr-filter
+   !
+
 .. clicmd:: ip ospf area (A.B.C.D|(0-4294967295))
 
 

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -19,6 +19,7 @@
 #include "zclient.h"
 #include "bfd.h"
 #include "ldp_sync.h"
+#include "plist.h"
 
 #include "ospfd/ospfd.h"
 #include "ospfd/ospf_bfd.h"
@@ -65,6 +66,34 @@ int ospf_interface_neighbor_count(struct ospf_interface *oi)
 	}
 
 	return count;
+}
+
+
+void ospf_intf_neighbor_filter_apply(struct ospf_interface *oi)
+{
+	struct route_node *rn;
+	struct ospf_neighbor *nbr = NULL;
+	struct prefix nbr_src_prefix = { AF_INET, IPV4_MAX_BITLEN, { 0 } };
+
+	if (!oi->nbr_filter)
+		return;
+
+	/*
+	 * Kill neighbors that don't match the neighbor filter prefix-list
+	 * excluding the neighbor for the router itself and any neighbors
+	 * that are already down.
+	 */
+	for (rn = route_top(oi->nbrs); rn; rn = route_next(rn)) {
+		nbr = rn->info;
+		if (nbr && nbr != oi->nbr_self && nbr->state != NSM_Down) {
+			nbr_src_prefix.u.prefix4 = nbr->src;
+			if (prefix_list_apply(oi->nbr_filter,
+					      (struct prefix *)&(
+						      nbr_src_prefix)) !=
+			    PREFIX_PERMIT)
+				OSPF_NSM_EVENT_EXECUTE(nbr, NSM_KillNbr);
+		}
+	}
 }
 
 int ospf_if_get_output_cost(struct ospf_interface *oi)
@@ -526,6 +555,7 @@ static struct ospf_if_params *ospf_new_if_params(void)
 	UNSET_IF_PARAM(oip, if_area);
 	UNSET_IF_PARAM(oip, opaque_capable);
 	UNSET_IF_PARAM(oip, keychain_name);
+	UNSET_IF_PARAM(oip, nbr_filter_name);
 
 	oip->auth_crypt = list_new();
 
@@ -544,6 +574,7 @@ static void ospf_del_if_params(struct interface *ifp,
 {
 	list_delete(&oip->auth_crypt);
 	XFREE(MTYPE_OSPF_IF_PARAMS, oip->keychain_name);
+	XFREE(MTYPE_OSPF_IF_PARAMS, oip->nbr_filter_name);
 	ospf_interface_disable_bfd(ifp, oip);
 	ldp_sync_info_free(&(oip->ldp_sync_info));
 	XFREE(MTYPE_OSPF_IF_PARAMS, oip);
@@ -579,7 +610,8 @@ void ospf_free_if_params(struct interface *ifp, struct in_addr addr)
 	    !OSPF_IF_PARAM_CONFIGURED(oip, if_area) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, opaque_capable) &&
 	    !OSPF_IF_PARAM_CONFIGURED(oip, prefix_suppression) &&
-		!OSPF_IF_PARAM_CONFIGURED(oip, keychain_name) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, keychain_name) &&
+	    !OSPF_IF_PARAM_CONFIGURED(oip, nbr_filter_name) &&
 	    listcount(oip->auth_crypt) == 0) {
 		ospf_del_if_params(ifp, oip);
 		rn->info = NULL;

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -124,6 +124,9 @@ struct ospf_if_params {
 
 	/* Opaque LSA capability at interface level (see RFC5250) */
 	DECLARE_IF_PARAM(bool, opaque_capable);
+
+	/* Name of prefix-list name for packet source address filtering. */
+	DECLARE_IF_PARAM(char *, nbr_filter_name);
 };
 
 enum { MEMBER_ALLROUTERS = 0,
@@ -241,6 +244,9 @@ struct ospf_interface {
 
 	/* List of configured NBMA neighbor. */
 	struct list *nbr_nbma;
+
+	/* Configured prefix-list for filtering neighbors. */
+	struct prefix_list *nbr_filter;
 
 	/* Graceful-Restart data. */
 	struct {
@@ -367,6 +373,7 @@ extern void ospf_crypt_key_add(struct list *list, struct crypt_key *key);
 extern int ospf_crypt_key_delete(struct list *list, uint8_t key_id);
 extern uint8_t ospf_default_iftype(struct interface *ifp);
 extern int ospf_interface_neighbor_count(struct ospf_interface *oi);
+extern void ospf_intf_neighbor_filter_apply(struct ospf_interface *oi);
 
 /* Set all multicast memberships appropriately based on the type and
    state of the interface. */

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1769,6 +1769,7 @@ static void ospf_prefix_list_update(struct prefix_list *plist)
 	int type;
 	int abr_inv = 0;
 	struct ospf_area *area;
+	struct ospf_interface *oi;
 	struct listnode *node, *n1;
 
 	/* If OSPF instatnce does not exist, return right now. */
@@ -1821,6 +1822,19 @@ static void ospf_prefix_list_update(struct prefix_list *plist)
 				PREFIX_LIST_OUT(area) = prefix_list_lookup(
 					AFI_IP, PREFIX_NAME_OUT(area));
 				abr_inv++;
+			}
+		}
+
+		/* Update interface neighbor-filter lists. */
+		for (ALL_LIST_ELEMENTS_RO(ospf->oiflist, node, oi)) {
+			if (OSPF_IF_PARAM(oi, nbr_filter_name) &&
+			    strcmp(OSPF_IF_PARAM(oi, nbr_filter_name),
+				   prefix_list_name(plist)) == 0) {
+				oi->nbr_filter = prefix_list_lookup(
+					AFI_IP,
+					OSPF_IF_PARAM(oi, nbr_filter_name));
+				if (oi->nbr_filter)
+					ospf_intf_neighbor_filter_apply(oi);
 			}
 		}
 


### PR DESCRIPTION
This commit adds the capabiity to filter OSPF neighbors using a prefix-list with rules matching the neighbor's IP source address. Configuration, filtering, immediate neighbor pruning, topo-tests, and documentation are included. The command is:

     ip ospf neighbor-filter <prefix-list> [A.B.C.D]