### PR TITLE
bgpd : Prevent deletion of BGP peer groups associated to listen range

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5197,6 +5197,7 @@ DEFUN (no_neighbor_peer_group,
 	int idx_word = 2;
 	struct peer_group *group;
 	afi_t afi;
+
 	group = peer_group_lookup(bgp, argv[idx_word]->arg);
 	if (group) {
 		for (afi = AFI_IP; afi < AFI_MAX; afi++) {

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5196,9 +5196,17 @@ DEFUN (no_neighbor_peer_group,
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	int idx_word = 2;
 	struct peer_group *group;
-
+	afi_t afi;
 	group = peer_group_lookup(bgp, argv[idx_word]->arg);
 	if (group) {
+		for (afi = AFI_IP; afi < AFI_MAX; afi++) {
+			int lr_count = listcount(group->listen_range[afi]);
+
+			if (lr_count) {
+				vty_out(vty, "%%Peer-group %s is attached to %d listen-range(s), delete them first\n", group->name, lr_count);
+				return CMD_WARNING_CONFIG_FAILED;
+				}
+			}
 		peer_group_notify_unconfig(group);
 		peer_group_delete(group);
 	} else {


### PR DESCRIPTION
Description:
----
Deleting a peer group also deletes its associated BGP listen range. This behaviour is undesired as it could cause unintended configuration changes.

Fix :
-----
-Do not allow peer group deletion until they are no longer associated with any listen range. -Check the count of listen ranges attached to the group. If any listen ranges are found, returns a configuration warning, preventing the deletion.

Signed-off-by: Pooja Rathore <rathorepo@vmware.com>