### PR TITLE
isisd: When the ISIS instance does not exist, the default metric will not be wide.

### DIFF
--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -685,7 +685,7 @@ module frr-isisd {
         type uint32 {
           range "0..16777215";
         }
-        must ". < 64 or /frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style = 'wide'";
+        must ". < 64 or /frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style = 'wide' or not(/frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style)";
         default "10";
         description
           "Default level-1 metric for this IS-IS circuit.";
@@ -695,7 +695,7 @@ module frr-isisd {
         type uint32 {
           range "0..16777215";
         }
-        must ". < 64 or /frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style = 'wide'";
+        must ". < 64 or /frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style = 'wide' or not(/frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style)";
         default "10";
         description
           "Default level-2 metric for this IS-IS circuit.";


### PR DESCRIPTION
When the ISIS instance does not exist, this check causes the default value of the ISIS instance's metric to become narrow. 

The following two scenarios present issues: 
1) When the ISIS metric configuration under the interface exceeds 63, we are unable to delete the ISIS instance.
2) When the ISIS instance is not created, we are unable to modify an ISIS metric that exceeds 63.

Signed-off-by: zhou-run <zhou.run@h3c.com>