### PR TITLE
tools: fix pim interface config deletionII

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1093,9 +1093,12 @@ def pim_delete_move_lines(lines_to_add, lines_to_del):
             if (
                 ctx_keys[0].startswith("interface")
                 and line
-                and line.startswith("ip pim ")
+                and (line.startswith("ip pim ") or line.startswith("ip multicast "))
             ):
-                lines_to_del.remove((ctx_keys, line))
+                lines_to_del_to_del.append((ctx_keys, line))
+
+    for ctx_keys, line in lines_to_del_to_del:
+        lines_to_del.remove((ctx_keys, line))
 
     return (lines_to_add, lines_to_del)
 


### PR DESCRIPTION
When no ip pim is performed subsequent pim related configs under the interface also implicitly deleted. The previous fix was attempting to remove from the same list which was being integrated.
First collect the lines to remove in separate list then at the end remove from the original lines_to_del.

commit 623af04e1c does not work properly if tries to delete an entry from existing list which is being walked on.



Testing done:
```
frr.conf:
no interface config

running-config:
--------------
interface swp1
ip pim
ip pim active-active
ip pim allow-rp rp-list sample
ip pim bfd
ip pim use-source 1.1.1.1
ip multicast boundary oil test
exit

frr-reload log pointing only no ip pim config
is removed under interface:
2024-04-18 18:44:37,202  INFO: "frr defaults datacenter" cannot be removed 2024-04-18 18:44:37,202  INFO: "service integrated-vtysh-config" cannot be removed 2024-04-18 18:44:37,504  INFO: Executed "interface swp1  no ip pim exit" 2024-04-18 18:44:37,505  INFO: /var/run/frr/reload-YHS51E.txt content
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>