### PR TITLE
ospfd: OSPFAPI Server options to limit to local connections and per-instance TCP

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -28,6 +28,12 @@ Configuring OSPF
 
    Enable the OSPF API server. This is required to use ``ospfclient``.
 
+.. option:: -l, --apiserver_addr <address>
+
+   Specify the local IPv4 address to which to bind the OSPF API server socket.
+   If unspecified, connections are accepted to any address. Specification of
+   127.0.0.1 can be used to limit socket access to local applications.
+
 *ospfd* must acquire interface information from *zebra* in order to function.
 Therefore *zebra* must be running before invoking *ospfd*. Also, if *zebra* is
 restarted then *ospfd* must be too.

--- a/ospfd/ospf_apiserver.h
+++ b/ospfd/ospf_apiserver.h
@@ -67,6 +67,14 @@ enum ospf_apiserver_event {
 };
 
 /* -----------------------------------------------------------
+ * External definitions for OSPF API ospfd parameters.
+ * -----------------------------------------------------------
+ */
+
+extern int ospf_apiserver_enable;
+extern struct in_addr ospf_apiserver_addr;
+
+/* -----------------------------------------------------------
  * Following are functions to manage client connections.
  * -----------------------------------------------------------
  */


### PR DESCRIPTION


This commit include OSPFAPI Server options to:

 1. Limit the OSPFAPI server connections to local (i.e., loopback) connections.
 2. Allow different OSPFAPI server TCP ports to be specified for different OSPF instances in /etc/services.