### PR TITLE
isis, lib: add isis srv6 end sid to ls_prefix

### DIFF
--- a/isisd/isis_lsp.h
+++ b/isisd/isis_lsp.h
@@ -143,6 +143,8 @@ int isis_lsp_iterate_ip_reach(struct isis_lsp *lsp, int family, uint16_t mtid,
 			      lsp_ip_reach_iter_cb cb, void *arg);
 int isis_lsp_iterate_is_reach(struct isis_lsp *lsp, uint16_t mtid,
 			      lsp_is_reach_iter_cb cb, void *arg);
+int isis_lsp_iterate_srv6_locator(struct isis_lsp *lsp, uint16_t mtid,
+				  lsp_ip_reach_iter_cb cb, void *arg);
 
 #define lsp_flood(lsp, circuit) \
 	_lsp_flood((lsp), (circuit), __func__, __FILE__, __LINE__)

--- a/isisd/isis_te.h
+++ b/isisd/isis_te.h
@@ -103,6 +103,7 @@ struct isis_te_args {
 	struct ls_ted *ted;
 	struct ls_vertex *vertex;
 	bool export;
+	bool srv6_locator;
 };
 
 enum lsp_event { LSP_UNKNOWN, LSP_ADD, LSP_UPD, LSP_DEL, LSP_INC, LSP_TICK };

--- a/lib/link_state.h
+++ b/lib/link_state.h
@@ -243,6 +243,7 @@ struct ls_attributes {
 #define LS_PREF_EXTENDED_TAG	0x04
 #define LS_PREF_METRIC		0x08
 #define LS_PREF_SR		0x10
+#define LS_PREF_SRV6		0x20
 
 /* Link State Prefix */
 struct ls_prefix {
@@ -258,6 +259,11 @@ struct ls_prefix {
 		uint8_t sid_flag;	/* Segment Routing Flags */
 		uint8_t algo;		/* Algorithm for Segment Routing */
 	} sr;
+	struct ls_srv6_sid {
+		struct in6_addr sid; /* Segment Routing ID */
+		uint16_t behavior;   /* Endpoint behavior bound to the SID */
+		uint8_t flags;	     /* Flags */
+	} srv6;
 };
 
 /**


### PR DESCRIPTION
According to draft-ietf-lsr-isis-srv6-extensions draft, the End SID should be available in link state prefix information. Add the SID information in the link state prefix.

I have however a problem. how to test it .. I tried , but without success:

![srv6_sr_added_on_option_222](https://github.com/FRRouting/frr/assets/16295538/510f7f2b-a293-4cd4-9db6-9debc701792a)

Observed
```
r3# show isis database  detail r3.00-00
Area TE:
IS-IS Level-2 link-state database:
LSP ID                  PduLen  SeqNumber   Chksum  Holdtime  ATT/P/OL
r3.00-00             *    628   0x0000000a  0xf151     326    0/0/0
[..]
  MT Reachability: 0000.0000.0002.00 (Metric: 10) ipv6-unicast
    Admin Group: 0x00000020
      Bit positions: 5
    Local Interface IPv6 Address(es): 2001:db8:3::3:3
    Remote Interface IPv6 Address(es): 2001:db8:3::3:2
[..]
    Adjacency-SID: 15001, Weight: 0, Flags: F:1 B:0, V:1, L:1, S:0, P:0
    SRv6 End.X SID: fc00:0:3:1::, Algorithm: SPF, Weight: 0, Endpoint Behavior: End.DX6, Flags: B:0, S:0, P:0
        SRv6 SID Structure Locator Block length: 24, Locator Node length: 24, Function length: 16, Argument length: 0,

# show isis mpls-te database subnet detail
[..]

  Subnet: 2001:db8:ffff::4/128  Adv. Vertex: 0000.0000.0004     Metric: 10      Status: Sync
    Origin: ISIS_L2
    SID: 1400   Algorithm: 0    Flags: 0x60
[..]

```

Expected:

```
# show isis mpls-te database subnet detail
[..]
  Subnet: 2001:db8:ffff::4/128  Adv. Vertex: 0000.0000.0004     Metric: 10      Status: Sync
    Origin: ISIS_L2
    SID: 1400   Algorithm: 0    Flags: 0x60
    SIDv6: fc00:0:3:1::   Algorithm: 0    Flags: 0x00
[..]
```
