### PR TITLE
Improve coverage functionality

### DIFF
--- a/tests/topotests/munet/__main__.py
+++ b/tests/topotests/munet/__main__.py
@@ -16,6 +16,7 @@ import sys
 
 from . import cli
 from . import parser
+from .args import add_launch_args
 from .base import get_event_loop
 from .cleanup import cleanup_previous
 from .compat import PytestConfig
@@ -106,59 +107,35 @@ def main(*args):
     cap.add_argument(
         "--project-root", help="directory to stop searching for kinds config at"
     )
+
     rap = ap.add_argument_group(title="Runtime", description="runtime related options")
+    add_launch_args(rap.add_argument)
+
+    # Move to munet.args?
     rap.add_argument(
         "-C",
         "--cleanup",
         action="store_true",
         help="Remove the entire rundir (not just node subdirs) prior to running.",
     )
-    rap.add_argument(
-        "--gdb", metavar="NODE-LIST", help="comma-sep list of hosts to run gdb on"
-    )
-    rap.add_argument(
-        "--gdb-breakpoints",
-        metavar="BREAKPOINT-LIST",
-        help="comma-sep list of breakpoints to set",
-    )
-    rap.add_argument(
-        "--host",
-        action="store_true",
-        help="no isolation for top namespace, bridges exposed to default namespace",
-    )
-    rap.add_argument(
-        "--pcap",
-        metavar="TARGET-LIST",
-        help="comma-sep list of capture targets (NETWORK or NODE:IFNAME)",
-    )
-    rap.add_argument(
-        "--shell", metavar="NODE-LIST", help="comma-sep list of nodes to open shells on"
-    )
-    rap.add_argument(
-        "--stderr",
-        metavar="NODE-LIST",
-        help="comma-sep list of nodes to open windows viewing stderr",
-    )
-    rap.add_argument(
-        "--stdout",
-        metavar="NODE-LIST",
-        help="comma-sep list of nodes to open windows viewing stdout",
-    )
+    # Move to munet.args?
     rap.add_argument(
         "--topology-only",
         action="store_true",
         help="Do not run any node commands",
     )
-    rap.add_argument("--unshare-inline", action="store_true", help=argparse.SUPPRESS)
     rap.add_argument(
         "--validate-only",
         action="store_true",
         help="Validate the config against the schema definition",
     )
+    rap.add_argument("--unshare-inline", action="store_true", help=argparse.SUPPRESS)
+
     rap.add_argument("-v", "--verbose", action="store_true", help="be verbose")
     rap.add_argument(
         "-V", "--version", action="store_true", help="print the verison number and exit"
     )
+
     eap = ap.add_argument_group(title="Uncommon", description="uncommonly used options")
     eap.add_argument("--log-config", help="logging config file (yaml, toml, json, ...)")
     eap.add_argument(
@@ -181,7 +158,6 @@ def main(*args):
 
     rundir = args.rundir if args.rundir else "/tmp/munet"
     args.rundir = rundir
-
     if args.cleanup:
         if os.path.exists(rundir):
             if not os.path.exists(f"{rundir}/config.json"):
@@ -193,7 +169,6 @@ def main(*args):
                 sys.exit(1)
             else:
                 subprocess.run(["/usr/bin/rm", "-rf", rundir], check=True)
-
     subprocess.run(f"mkdir -p {rundir} && chmod 755 {rundir}", check=True, shell=True)
     os.environ["MUNET_RUNDIR"] = rundir
 

--- a/tests/topotests/munet/args.py
+++ b/tests/topotests/munet/args.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+#
+# April 14 2024, Christian Hopps <chopps@labn.net>
+#
+# Copyright (c) 2024, LabN Consulting, L.L.C.
+#
+"""Common CLI execute argument."""
+
+
+def add_launch_args(add_func):
+
+    add_func("--gdb", metavar="NODE-LIST", help="comma-sep list of hosts to run gdb on")
+    add_func(
+        "--gdb-breakpoints",
+        metavar="BREAKPOINT-LIST",
+        help="comma-sep list of breakpoints to set",
+    )
+    add_func(
+        "--gdb-use-emacs",
+        action="store_true",
+        help="Use emacsclient to run gdb instead of a shell",
+    )
+
+    add_func(
+        "--host",
+        action="store_true",
+        help="no isolation for top namespace, bridges exposed to default namespace",
+    )
+    add_func(
+        "--pcap",
+        metavar="TARGET-LIST",
+        help="comma-sep list of capture targets (NETWORK or NODE:IFNAME) or 'all'",
+    )
+    add_func(
+        "--shell", metavar="NODE-LIST", help="comma-sep list of nodes to open shells on"
+    )
+    add_func(
+        "--stderr",
+        metavar="NODE-LIST",
+        help="comma-sep list of nodes to open windows viewing stderr",
+    )
+    add_func(
+        "--stdout",
+        metavar="NODE-LIST",
+        help="comma-sep list of nodes to open windows viewing stdout",
+    )
+
+
+def add_testing_args(add_func):
+    add_func(
+        "--cli-on-error",
+        action="store_true",
+        help="CLI on test failure",
+    )
+
+    add_func(
+        "--coverage",
+        action="store_true",
+        help="Enable coverage gathering if supported",
+    )
+
+    add_func(
+        "--cov-build-dir",
+        help="Specify the build dir for locating coverage data files",
+    )
+
+    add_launch_args(add_func)
+
+    add_func(
+        "--pause",
+        action="store_true",
+        help="Pause after each test",
+    )
+    add_func(
+        "--pause-at-end",
+        action="store_true",
+        help="Pause before taking munet down",
+    )
+    add_func(
+        "--pause-on-error",
+        action="store_true",
+        help="Pause after (disables default when --shell or -vtysh given)",
+    )
+    add_func(
+        "--no-pause-on-error",
+        dest="pause_on_error",
+        action="store_false",
+        help="Do not pause after (disables default when --shell or -vtysh given)",
+    )

--- a/tests/topotests/munet/base.py
+++ b/tests/topotests/munet/base.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import tempfile
 import time as time_mod
+
 from collections import defaultdict
 from pathlib import Path
 from typing import Union
@@ -28,8 +29,10 @@ from typing import Union
 from . import config as munet_config
 from . import linux
 
+
 try:
     import pexpect
+
     from pexpect.fdpexpect import fdspawn
     from pexpect.popen_spawn import PopenSpawn
 
@@ -273,6 +276,9 @@ def get_event_loop():
     """
     policy = asyncio.get_event_loop_policy()
     loop = policy.get_event_loop()
+    if not hasattr(os, "pidfd_open"):
+        return loop
+
     owatcher = policy.get_child_watcher()
     logging.debug(
         "event_loop_fixture: global policy %s, current loop %s, current watcher %s",

--- a/tests/topotests/munet/mucmd.py
+++ b/tests/topotests/munet/mucmd.py
@@ -9,7 +9,6 @@
 import argparse
 import json
 import os
-import subprocess
 import sys
 
 from pathlib import Path
@@ -90,19 +89,14 @@ def main(*args):
     ecmd = "/usr/bin/nsenter"
     eargs = [ecmd]
 
-    output = subprocess.check_output(["/usr/bin/nsenter", "--help"], encoding="utf-8")
-    if " -a," in output:
-        eargs.append("-a")
-    else:
-        # -U doesn't work
-        for flag in ["-u", "-i", "-m", "-n", "-C", "-T"]:
-            if f" {flag}," in output:
-                eargs.append(flag)
+    #start mucmd same way base process is started
+    eargs.append(f"--mount=/proc/{pid}/ns/mnt")
+    eargs.append(f"--net=/proc/{pid}/ns/net")
     eargs.append(f"--pid=/proc/{pid}/ns/pid_for_children")
+    eargs.append(f"--uts=/proc/{pid}/ns/uts")
     eargs.append(f"--wd={rundir}")
-    eargs.extend(["-t", pid])
     eargs += args.shellcmd
-    # print("Using ", eargs)
+    #print("Using ", eargs)
     return os.execvpe(ecmd, eargs, {**env, **envcfg})
 
 

--- a/tests/topotests/munet/munet-schema.json
+++ b/tests/topotests/munet/munet-schema.json
@@ -99,6 +99,15 @@
           "server-port": {
             "type": "number"
           },
+          "ssh-identity-file": {
+            "type": "string"
+          },
+          "ssh-user": {
+            "type": "string"
+          },
+          "ssh-password": {
+            "type": "string"
+          },
           "qemu": {
             "type": "object",
             "properties": {
@@ -106,6 +115,15 @@
                 "type": "string"
               },
               "disk": {
+                "type": "string"
+              },
+              "disk-driver": {
+                "type": "string"
+              },
+              "disk-template": {
+                "type": "string"
+              },
+              "initial-cmd": {
                 "type": "string"
               },
               "kerenel": {
@@ -139,6 +157,9 @@
                     "type": "string"
                   },
                   "password": {
+                    "type": "string"
+                  },
+                  "initial-password": {
                     "type": "string"
                   },
                   "expects": {
@@ -407,6 +428,15 @@
               "server-port": {
                 "type": "number"
               },
+              "ssh-identity-file": {
+                "type": "string"
+              },
+              "ssh-user": {
+                "type": "string"
+              },
+              "ssh-password": {
+                "type": "string"
+              },
               "qemu": {
                 "type": "object",
                 "properties": {
@@ -414,6 +444,15 @@
                     "type": "string"
                   },
                   "disk": {
+                    "type": "string"
+                  },
+                  "disk-driver": {
+                    "type": "string"
+                  },
+                  "disk-template": {
+                    "type": "string"
+                  },
+                  "initial-cmd": {
                     "type": "string"
                   },
                   "kerenel": {
@@ -447,6 +486,9 @@
                         "type": "string"
                       },
                       "password": {
+                        "type": "string"
+                      },
+                      "initial-password": {
                         "type": "string"
                       },
                       "expects": {

--- a/tests/topotests/munet/parser.py
+++ b/tests/topotests/munet/parser.py
@@ -230,7 +230,7 @@ def load_kinds(args, search=None):
     if args:
         os.chdir(args.rundir)
 
-    args_config = args.kinds_config if args else None
+    args_config = args.kinds_config if args and hasattr(args, "kinds_config") else None
     try:
         if search is None:
             search = [cwd]
@@ -305,7 +305,7 @@ async def async_build_topology(
 
     # create search directories from common root if given
     cpath = Path(config["config_pathname"]).absolute()
-    project_root = args.project_root if args else None
+    project_root = args.project_root if args and hasattr(args, "project_root") else None
     if not search_root:
         search_root = find_project_root(cpath, project_root)
     if not search_root:
@@ -341,7 +341,11 @@ async def async_build_topology(
         pytestconfig=pytestconfig,
         isolated=isolated,
         pid=top_level_pidns,
-        unshare_inline=args.unshare_inline if args else unshare_inline,
+        unshare_inline=(
+            args.unshare_inline
+            if args and hasattr(args, "unshare_inline")
+            else unshare_inline
+        ),
         logger=logger,
     )
 


### PR DESCRIPTION
- improve coverage functionality
- update munet to latest release (0.14.0), brings in a a bugfix for running on older kernels with missing functionality (pidfd_open), as well as new generic gcov coverage support that we would like to leverage. remaining changes are in areas not currently utilized by topotest (e.g., mutest, and qemu/vm).