### PR TITLE
yang: add missing `zif-gre` zebra interface type

### DIFF
--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -151,6 +151,12 @@ module frr-zebra {
       "Zebra interface type macvlan.";
   }
 
+  identity zif-gre {
+    base zebra-interface-type;
+    description
+      "Zebra interface type gre.";
+  }
+
   /*
    * Multicast RPF mode configurable type
    */

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -55,6 +55,10 @@ lib_interface_zebra_state_zif_type_get_elem(struct nb_cb_get_elem_args *args)
 
 	zebra_if = ifp->info;
 
+	/*
+	 * NOTE: when adding a new type to the switch, make sure it is defined
+	 * in it's YANG model.
+	 */
 	switch (zebra_if->zif_type) {
 	case ZEBRA_IF_OTHER:
 		type = "frr-zebra:zif-other";


### PR DESCRIPTION
This was caught by the grpc_basic test which was receiving an invalid error result, which was returned b/c inside zebra the libyang code was flagging the value as invalid for a derived zebra interface type.