### PR TITLE
isisd: fix renaming backup define for ENDX SID

### DIFF
--- a/isisd/isis_srv6.c
+++ b/isisd/isis_srv6.c
@@ -363,7 +363,7 @@ void isis_area_delete_backup_srv6_endx_sids(struct isis_area *area, int level)
 	struct listnode *node, *nnode;
 
 	for (ALL_LIST_ELEMENTS(area->srv6db.srv6_endx_sids, node, nnode, sra))
-		if (sra->type == ISIS_SRV6_LAN_BACKUP &&
+		if (sra->type == ISIS_SRV6_ADJ_BACKUP &&
 		    (sra->adj->level & level))
 			srv6_endx_sid_del(sra);
 }
@@ -420,7 +420,7 @@ void srv6_endx_sid_add_single(struct isis_adjacency *adj, bool backup,
 			   : SRV6_ENDPOINT_BEHAVIOR_END_X;
 
 	sra = XCALLOC(MTYPE_ISIS_SRV6_INFO, sizeof(*sra));
-	sra->type = backup ? ISIS_SRV6_LAN_BACKUP : ISIS_SRV6_ADJ_NORMAL;
+	sra->type = backup ? ISIS_SRV6_ADJ_BACKUP : ISIS_SRV6_ADJ_NORMAL;
 	sra->behavior = behavior;
 	sra->locator = chunk;
 	sra->structure.loc_block_len = chunk->block_bits_length;
@@ -538,7 +538,7 @@ void srv6_endx_sid_del(struct srv6_adjacency *sra)
 		exit(1);
 	}
 
-	if (sra->type == ISIS_SRV6_LAN_BACKUP && sra->backup_nexthops) {
+	if (sra->type == ISIS_SRV6_ADJ_BACKUP && sra->backup_nexthops) {
 		sra->backup_nexthops->del =
 			(void (*)(void *))isis_nexthop_delete;
 		list_delete(&sra->backup_nexthops);

--- a/isisd/isis_srv6.h
+++ b/isisd/isis_srv6.h
@@ -68,7 +68,7 @@ struct isis_srv6_locator {
 /* SRv6 Adjacency-SID type */
 enum srv6_adj_type {
 	ISIS_SRV6_ADJ_NORMAL = 0,
-	ISIS_SRV6_LAN_BACKUP,
+	ISIS_SRV6_ADJ_BACKUP,
 };
 
 /* SRv6 Adjacency. */


### PR DESCRIPTION
The define has inheritated from a wrong naming in sr-mpls. Fix this by renaming ISIS_SRV6_LAN_BACKUP to ISIS_SRV6_ADJ_BACKUP.

Fixes: 2566656a6f50 ("isisd: Add data structure for SRv6 Adjacency SIDs")