### PR TITLE
lib, zebra: Check for not being a blackhole route

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -1150,11 +1150,7 @@ static ssize_t printfrr_nh(struct fbuf *buf, struct printfrr_eargs *ea,
 	return -1;
 }
 
-bool nexthop_is_ifindex_type(const struct nexthop *nh)
+bool nexthop_is_blackhole(const struct nexthop *nh)
 {
-	if (nh->type == NEXTHOP_TYPE_IFINDEX ||
-	    nh->type == NEXTHOP_TYPE_IPV4_IFINDEX ||
-	    nh->type == NEXTHOP_TYPE_IPV6_IFINDEX)
-		return true;
-	return false;
+	return nh->type == NEXTHOP_TYPE_BLACKHOLE;
 }

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -240,8 +240,8 @@ extern struct nexthop *nexthop_dup(const struct nexthop *nexthop,
 extern struct nexthop *nexthop_dup_no_recurse(const struct nexthop *nexthop,
 					      struct nexthop *rparent);
 
-/* Check nexthop of IFINDEX type */
-extern bool nexthop_is_ifindex_type(const struct nexthop *nh);
+/* Is this nexthop a blackhole? */
+extern bool nexthop_is_blackhole(const struct nexthop *nh);
 
 /*
  * Parse one or more backup index values, as comma-separated numbers,

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -3664,8 +3664,9 @@ void zebra_interface_nhg_reinstall(struct interface *ifp)
 					"%s: Setting the valid flag for nhe %pNG, interface: %s",
 					__func__, rb_node_dep->nhe, ifp->name);
 		}
+
 		/* Check for singleton NHG associated to interface */
-		if (nexthop_is_ifindex_type(nh) &&
+		if (!nexthop_is_blackhole(nh) &&
 		    zebra_nhg_depends_is_empty(rb_node_dep->nhe)) {
 			struct nhg_connected *rb_node_dependent;
 


### PR DESCRIPTION
In zebra_interface_nhg_reinstall zebra is checking that the nhg is a singleton and not a blackhole nhg.  This was originally done with checking that the nexthop is a NEXTHOP_TYPE_IFINDEX, NEXTHOP_TYPE_IPV4_IFINDEX and NEXTHOP_TYPE_IPV6_IFINDEX.  This was excluding NEXTHOP_TYPE_IPV4 and NEXTHOP_TYPE_IPV6.  These were both possible to be received and maintained from the upper level protocol for when a route is being recursively resolved. If we have gotten to this point in zebra_interface_nhg_reinstall the nexthop group has already been installed at least once and we *know* that it is actually a valid nexthop.  What the test is really trying to do is ensure that we are not reinstalling a blackhole nexthop group( Which is not possible to even be here by the way, but safety first! ).  So let's change to test for that instead.