### PR TITLE
Add a topotest for per-peer BGP GR

### DIFF
--- a/tests/topotests/bgp_gr_restart_retain_routes_per_peer/r1/bgpd.conf
+++ b/tests/topotests/bgp_gr_restart_retain_routes_per_peer/r1/bgpd.conf
@@ -1,0 +1,11 @@
+router bgp 65001
+ no bgp ebgp-requires-policy
+ bgp graceful-restart preserve-fw-state
+ neighbor 192.168.255.2 graceful-restart
+ neighbor 192.168.255.2 remote-as external
+ neighbor 192.168.255.2 timers 1 3
+ neighbor 192.168.255.2 timers connect 1
+ address-family ipv4
+  redistribute connected
+ exit-address-family
+!

--- a/tests/topotests/bgp_gr_restart_retain_routes_per_peer/r1/zebra.conf
+++ b/tests/topotests/bgp_gr_restart_retain_routes_per_peer/r1/zebra.conf
@@ -1,0 +1,7 @@
+!
+interface lo
+ ip address 172.16.255.1/32
+!
+interface r1-eth0
+ ip address 192.168.255.1/24
+!

--- a/tests/topotests/bgp_gr_restart_retain_routes_per_peer/r2/bgpd.conf
+++ b/tests/topotests/bgp_gr_restart_retain_routes_per_peer/r2/bgpd.conf
@@ -1,0 +1,8 @@
+router bgp 65002
+ no bgp ebgp-requires-policy
+ bgp graceful-restart preserve-fw-state
+ neighbor 192.168.255.1 graceful-restart
+ neighbor 192.168.255.1 remote-as external
+ neighbor 192.168.255.1 timers 1 3
+ neighbor 192.168.255.1 timers connect 1
+!

--- a/tests/topotests/bgp_gr_restart_retain_routes_per_peer/r2/zebra.conf
+++ b/tests/topotests/bgp_gr_restart_retain_routes_per_peer/r2/zebra.conf
@@ -1,0 +1,5 @@
+no zebra nexthop kernel enable
+!
+interface r2-eth0
+ ip address 192.168.255.2/24
+!

--- a/tests/topotests/bgp_gr_restart_retain_routes_per_peer/test_bgp_gr_restart_retain_routes_per_peer.py
+++ b/tests/topotests/bgp_gr_restart_retain_routes_per_peer/test_bgp_gr_restart_retain_routes_per_peer.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2022 by
+# Donatas Abraitis <donatas@opensourcerouting.org>
+#
+
+"""
+Test if routes are retained during BGP restarts.
+"""
+
+import os
+import sys
+import json
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.common_config import step, stop_router
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def build_topo(tgen):
+    for routern in range(1, 3):
+        tgen.add_router("r{}".format(routern))
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for i, (rname, router) in enumerate(router_list.items(), 1):
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP, os.path.join(CWD, "{}/bgpd.conf".format(rname))
+        )
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_gr_restart_retain_routes_per_peer():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    def _bgp_converge():
+        output = json.loads(r2.vtysh_cmd("show bgp ipv4 neighbors 192.168.255.1 json"))
+        expected = {
+            "192.168.255.1": {
+                "bgpState": "Established",
+                "addressFamilyInfo": {"ipv4Unicast": {"acceptedPrefixCounter": 2}},
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_check_bgp_retained_routes():
+        output = json.loads(r2.vtysh_cmd("show bgp ipv4 unicast 172.16.255.1/32 json"))
+        expected = {"paths": [{"stale": True}]}
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_check_kernel_retained_routes():
+        output = json.loads(r2.cmd("ip -j route show 172.16.255.1/32 proto bgp dev r2-eth0"))
+        expected = [{"dst":"172.16.255.1","gateway":"192.168.255.1","metric":20}]
+        return topotest.json_cmp(output, expected)
+
+    step("Initial BGP converge")
+    test_func = functools.partial(_bgp_converge)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to see BGP convergence on R2"
+
+    step("Restart R1")
+    stop_router(tgen, "r1")
+
+    step("Check if routes (BGP) are retained at R2")
+    test_func = functools.partial(_bgp_check_bgp_retained_routes)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to see BGP retained routes on R2"
+
+    step("Check if routes (Kernel) are retained at R2")
+    assert _bgp_check_kernel_retained_routes() is None, "Failed to retain BGP routes in kernel on R2"
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
This topotest ensures that per-peer graceful restart retains the route over restart. When running locally, it didn't work for me, so validating it with topotest.