### PR TITLE
lib,bgpd,vtysh: move bgp vty defines to lib

### DIFF
--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -13,8 +13,6 @@ struct bgp;
 #define BGP_INSTANCE_HELP_STR "BGP view\nBGP VRF\nView/VRF name\n"
 #define BGP_INSTANCE_ALL_HELP_STR "BGP view\nBGP VRF\nAll Views/VRFs\n"
 
-#define BGP_AF_STR "Address Family\n"
-#define BGP_AF_MODIFIER_STR "Address Family modifier\n"
 #define BGP_AFI_CMD_STR         "<ipv4|ipv6>"
 #define BGP_AFI_HELP_STR BGP_AF_STR BGP_AF_STR
 #define BGP_SAFI_CMD_STR        "<unicast|multicast|vpn>"

--- a/lib/command.h
+++ b/lib/command.h
@@ -462,6 +462,8 @@ struct cmd_node {
 #define MPLS_LDP_SYNC_HOLDDOWN_STR                                             \
 	"Time to wait for LDP-SYNC to occur before restoring if cost\n"
 #define NO_MPLS_LDP_SYNC_HOLDDOWN_STR "holddown timer disable\n"
+#define BGP_AF_STR "Address Family\n"
+#define BGP_AF_MODIFIER_STR "Address Family modifier\n"
 
 /* Command warnings. */
 #define NO_PASSWD_CMD_WARNING                                                  \

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -39,7 +39,6 @@
 #include "frrstr.h"
 #include "json.h"
 #include "ferr.h"
-#include "bgpd/bgp_vty.h"
 
 DEFINE_MTYPE_STATIC(MVTYSH, VTYSH_CMD, "Vtysh cmd copy");
 


### PR DESCRIPTION
Stop including a bgp header file from vtysh (ouch); move a couple of cli string defines to a library header.
