### PR TITLE
tools: add iproute2 alias for pathd daemon

### DIFF
--- a/tools/etc/iproute2/rt_protos.d/frr.conf
+++ b/tools/etc/iproute2/rt_protos.d/frr.conf
@@ -12,3 +12,4 @@
 195  pbr
 196  static
 197  openfabric
+198  srte


### PR DESCRIPTION
With SRv6 traffic engineering, some ipv6 routes will be installed by the Pathd daemon.
Populate the iproute2 aliasing table with pathd.