### PR TITLE
zebra, sharpd: add srv6 End.DX6 support

### DIFF
--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -448,6 +448,7 @@ DEFPY (install_seg6local_routes,
 	      End_X$seg6l_endx X:X::X:X$seg6l_endx_nh6|\
 	      End_T$seg6l_endt (1-4294967295)$seg6l_endt_table|\
 	      End_DX4$seg6l_enddx4 A.B.C.D$seg6l_enddx4_nh4|\
+	      End_DX6$seg6l_enddx6 X:X::X:X$seg6l_enddx6_nh6|\
 	      End_DT6$seg6l_enddt6 (1-4294967295)$seg6l_enddt6_table|\
 	      End_DT4$seg6l_enddt4 (1-4294967295)$seg6l_enddt4_table|\
 	      End_DT46$seg6l_enddt46 (1-4294967295)$seg6l_enddt46_table>\
@@ -467,6 +468,8 @@ DEFPY (install_seg6local_routes,
        "Redirect table id to use\n"
        "SRv6 End.DX4 function to use\n"
        "V4 Nexthop address to use\n"
+       "SRv6 End.DX6 function to use\n"
+       "V6 Nexthop address to use\n"
        "SRv6 End.DT6 function to use\n"
        "Redirect table id to use\n"
        "SRv6 End.DT4 function to use\n"
@@ -516,6 +519,9 @@ DEFPY (install_seg6local_routes,
 	if (seg6l_enddx4) {
 		action = ZEBRA_SEG6_LOCAL_ACTION_END_DX4;
 		ctx.nh4 = seg6l_enddx4_nh4;
+	} else if (seg6l_enddx6) {
+		action = ZEBRA_SEG6_LOCAL_ACTION_END_DX6;
+		ctx.nh6 = seg6l_enddx6_nh6;
 	} else if (seg6l_endx) {
 		action = ZEBRA_SEG6_LOCAL_ACTION_END_X;
 		ctx.nh6 = seg6l_endx_nh6;

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1683,6 +1683,16 @@ static bool _netlink_route_build_singlepath(const struct prefix *p,
 						 sizeof(struct in_addr)))
 					return false;
 				break;
+			case ZEBRA_SEG6_LOCAL_ACTION_END_DX6:
+				if (!nl_attr_put32(nlmsg, req_size,
+						   SEG6_LOCAL_ACTION,
+						   SEG6_LOCAL_ACTION_END_DX6))
+					return false;
+				if (!nl_attr_put(nlmsg, req_size,
+						 SEG6_LOCAL_NH6, &ctx->nh6,
+						 sizeof(struct in_addr)))
+					return false;
+				break;
 			case ZEBRA_SEG6_LOCAL_ACTION_END_DT6:
 				if (!nl_attr_put32(nlmsg, req_size,
 						   SEG6_LOCAL_ACTION,
@@ -1714,7 +1724,6 @@ static bool _netlink_route_build_singlepath(const struct prefix *p,
 					return false;
 				break;
 			case ZEBRA_SEG6_LOCAL_ACTION_END_DX2:
-			case ZEBRA_SEG6_LOCAL_ACTION_END_DX6:
 			case ZEBRA_SEG6_LOCAL_ACTION_END_B6:
 			case ZEBRA_SEG6_LOCAL_ACTION_END_B6_ENCAP:
 			case ZEBRA_SEG6_LOCAL_ACTION_END_BM:
@@ -2929,6 +2938,18 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 						    &req->n, buflen,
 						    SEG6_LOCAL_NH4, &ctx->nh4,
 						    sizeof(struct in_addr)))
+							return 0;
+						break;
+					case SEG6_LOCAL_ACTION_END_DX6:
+						if (!nl_attr_put32(&req->n,
+								   buflen,
+								   SEG6_LOCAL_ACTION,
+								   SEG6_LOCAL_ACTION_END_DX6))
+							return 0;
+						if (!nl_attr_put(&req->n, buflen,
+								 SEG6_LOCAL_NH6,
+								 &ctx->nh6,
+								 sizeof(struct in_addr)))
 							return 0;
 						break;
 					case SEG6_LOCAL_ACTION_END_DT6:


### PR DESCRIPTION
Add the support for adding DX6 behavior into netlink layer of zebra. Add the necessary test in sharpd.

> ubuntu2204# sharp install seg6local-routes 1:1::1:2 nexthop-seg6local loop1 End_DX6 4:4::4:6 1
> ubuntu2204# do show ipv6 route
> [..]
> D>* 1:1::1:2/128 [150/0] is directly connected, loop1, seg6local End.DX6 nh6 4:4::4:6, weight 1, 00:00:03