### PR TITLE
yang: ietf-netconf-acm needs to be in libfrr

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -153,6 +153,7 @@ nodist_lib_libfrr_la_SOURCES = \
 	yang/frr-nexthop.yang.c \
 	yang/ietf/frr-deviations-ietf-key-chain.yang.c \
 	yang/ietf/ietf-routing-types.yang.c \
+	yang/ietf/ietf-netconf-acm.yang.c \
 	yang/ietf/ietf-key-chain.yang.c \
 	yang/ietf/ietf-interfaces.yang.c \
 	yang/ietf/ietf-bgp-types.yang.c \

--- a/mgmtd/subdir.am
+++ b/mgmtd/subdir.am
@@ -61,7 +61,6 @@ mgmtd_mgmtd_SOURCES = \
 nodist_mgmtd_mgmtd_SOURCES = \
 	yang/frr-zebra.yang.c \
 	yang/frr-zebra-route-map.yang.c \
-	yang/ietf/ietf-netconf-acm.yang.c \
 	yang/ietf/ietf-netconf.yang.c \
 	yang/ietf/ietf-netconf-with-defaults.yang.c \
 	# nothing


### PR DESCRIPTION
ietf-key-chain depends on ietf-netconf-acm, and lib/ code sets up the former, so ietf-netconf-acm needs to be embedded in the libfrr too.