### PR TITLE
Bmp improvements about statistics

### DIFF
--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -182,12 +182,15 @@ void bgp_adj_in_set(struct bgp_dest *dest, struct peer *peer, struct attr *attr,
 	adj->uptime = monotime(NULL);
 	adj->addpath_rx_id = addpath_id;
 	BGP_ADJ_IN_ADD(dest, adj);
+	peer->stat_pfx_adj_rib_in++;
 	bgp_dest_lock_node(dest);
 }
 
 void bgp_adj_in_remove(struct bgp_dest **dest, struct bgp_adj_in *bai)
 {
 	bgp_attr_unintern(&bai->attr);
+	if (bai->peer)
+		bai->peer->stat_pfx_adj_rib_in--;
 	BGP_ADJ_IN_DEL(*dest, bai);
 	*dest = bgp_dest_unlock_node(*dest);
 	peer_unlock(bai->peer); /* adj_in peer reference */

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1647,6 +1647,8 @@ static void bmp_stats(struct event *thread)
 					 peer->stat_pfx_nh_invalid);
 		bmp_stat_put_u64(s, &count, BMP_STATS_SIZE_ADJ_RIB_IN,
 				 peer->stat_pfx_adj_rib_in);
+		bmp_stat_put_u64(s, &count, BMP_STATS_SIZE_LOC_RIB,
+				 peer->stat_pfx_loc_rib);
 
 		stream_putl_at(s, count_pos, count);
 

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1642,8 +1642,9 @@ static void bmp_stats(struct event *thread)
 				peer->stat_pfx_dup_withdraw);
 		bmp_stat_put_u32(s, &count, BMP_STATS_UPD_7606_WITHDRAW,
 				peer->stat_upd_7606);
-		bmp_stat_put_u32(s, &count, BMP_STATS_FRR_NH_INVALID,
-				peer->stat_pfx_nh_invalid);
+		if (bt->stats_send_experimental)
+			bmp_stat_put_u32(s, &count, BMP_STATS_FRR_NH_INVALID,
+					 peer->stat_pfx_nh_invalid);
 		bmp_stat_put_u64(s, &count, BMP_STATS_SIZE_ADJ_RIB_IN,
 				 peer->stat_pfx_adj_rib_in);
 
@@ -1900,6 +1901,7 @@ static struct bmp_targets *bmp_targets_get(struct bgp *bgp, const char *name)
 	bt->name = XSTRDUP(MTYPE_BMP_TARGETSNAME, name);
 	bt->bgp = bgp;
 	bt->bmpbgp = bmp_bgp_get(bgp);
+	bt->stats_send_experimental = true;
 	bmp_session_init(&bt->sessions);
 	bmp_qhash_init(&bt->updhash);
 	bmp_qlist_init(&bt->updlist);
@@ -2480,6 +2482,21 @@ DEFPY(bmp_stats_cfg,
 	return CMD_SUCCESS;
 }
 
+DEFPY(bmp_stats_send_experimental,
+      bmp_stats_send_experimental_cmd,
+      "[no] bmp stats send-experimental",
+      NO_STR
+      BMP_STR
+      "Send BMP statistics messages\n"
+      "Send experimental BMP stats [65531-65534]\n")
+{
+	VTY_DECLVAR_CONTEXT_SUB(bmp_targets, bt);
+
+	bt->stats_send_experimental = !!no;
+
+	return CMD_SUCCESS;
+}
+
 #define BMP_POLICY_IS_LOCRIB(str) ((str)[0] == 'l') /* __l__oc-rib */
 #define BMP_POLICY_IS_PRE(str) ((str)[1] == 'r')    /* p__r__e-policy */
 
@@ -2772,6 +2789,9 @@ static int bmp_config_write(struct bgp *bgp, struct vty *vty)
 		if (bt->acl_name)
 			vty_out(vty, "  ip access-list %s\n", bt->acl_name);
 
+		if (!bt->stats_send_experimental)
+			vty_out(vty, "  no bmp stats send-experimental\n");
+
 		if (bt->stat_msec)
 			vty_out(vty, "  bmp stats interval %d\n",
 					bt->stat_msec);
@@ -2827,6 +2847,7 @@ static int bgp_bmp_init(struct event_loop *tm)
 	install_element(BMP_NODE, &no_bmp_listener_cmd);
 	install_element(BMP_NODE, &bmp_connect_cmd);
 	install_element(BMP_NODE, &bmp_acl_cmd);
+	install_element(BMP_NODE, &bmp_stats_send_experimental_cmd);
 	install_element(BMP_NODE, &bmp_stats_cmd);
 	install_element(BMP_NODE, &bmp_monitor_cmd);
 	install_element(BMP_NODE, &bmp_mirror_cmd);

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1592,6 +1592,15 @@ static void bmp_stat_put_u32(struct stream *s, size_t *cnt, uint16_t type,
 	(*cnt)++;
 }
 
+static void bmp_stat_put_u64(struct stream *s, size_t *cnt, uint16_t type,
+			     uint64_t value)
+{
+	stream_putw(s, type);
+	stream_putw(s, 8);
+	stream_putq(s, value);
+	(*cnt)++;
+}
+
 static void bmp_stats(struct event *thread)
 {
 	struct bmp_targets *bt = EVENT_ARG(thread);
@@ -1635,6 +1644,8 @@ static void bmp_stats(struct event *thread)
 				peer->stat_upd_7606);
 		bmp_stat_put_u32(s, &count, BMP_STATS_FRR_NH_INVALID,
 				peer->stat_pfx_nh_invalid);
+		bmp_stat_put_u64(s, &count, BMP_STATS_SIZE_ADJ_RIB_IN,
+				 peer->stat_pfx_adj_rib_in);
 
 		stream_putl_at(s, count_pos, count);
 

--- a/bgpd/bgp_bmp.h
+++ b/bgpd/bgp_bmp.h
@@ -240,6 +240,8 @@ struct bmp_targets {
 
 	uint64_t cnt_accept, cnt_aclrefused;
 
+	bool stats_send_experimental;
+
 	QOBJ_FIELDS;
 };
 DECLARE_QOBJ_TYPE(bmp_targets);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -487,6 +487,8 @@ void bgp_path_info_add_with_caller(const char *name, struct bgp_dest *dest,
 	bgp_dest_lock_node(dest);
 	peer_lock(pi->peer); /* bgp_path_info peer reference */
 	bgp_dest_set_defer_flag(dest, false);
+	if (pi->peer)
+		pi->peer->stat_pfx_loc_rib++;
 	hook_call(bgp_snmp_update_stats, dest, pi, true);
 }
 
@@ -507,6 +509,8 @@ struct bgp_dest *bgp_path_info_reap(struct bgp_dest *dest,
 	pi->next = NULL;
 	pi->prev = NULL;
 
+	if (pi->peer)
+		pi->peer->stat_pfx_loc_rib--;
 	hook_call(bgp_snmp_update_stats, dest, pi, false);
 
 	bgp_path_info_unlock(pi);
@@ -521,6 +525,8 @@ static struct bgp_dest *bgp_path_info_reap_unsorted(struct bgp_dest *dest,
 	pi->next = NULL;
 	pi->prev = NULL;
 
+	if (pi->peer)
+		pi->peer->stat_pfx_loc_rib--;
 	hook_call(bgp_snmp_update_stats, dest, pi, false);
 	bgp_path_info_unlock(pi);
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1667,6 +1667,7 @@ struct peer {
 	uint32_t stat_pfx_nh_invalid;
 	uint32_t stat_pfx_dup_withdraw;
 	uint32_t stat_upd_7606;  /* RFC7606: treat-as-withdraw */
+	uint64_t stat_pfx_loc_rib; /* RFC7854 : Number of routes in Loc-RIB */
 	uint64_t stat_pfx_adj_rib_in; /* RFC7854 : Number of routes in Adj-RIBs-In */
 
 	/* BGP state count */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1667,6 +1667,7 @@ struct peer {
 	uint32_t stat_pfx_nh_invalid;
 	uint32_t stat_pfx_dup_withdraw;
 	uint32_t stat_upd_7606;  /* RFC7606: treat-as-withdraw */
+	uint64_t stat_pfx_adj_rib_in; /* RFC7854 : Number of routes in Adj-RIBs-In */
 
 	/* BGP state count */
 	uint32_t established; /* Established */

--- a/doc/user/bmp.rst
+++ b/doc/user/bmp.rst
@@ -23,6 +23,7 @@ The `BMP` implementation in FRR has the following properties:
   - 3: count of **prefixes** with loop in cluster id
   - 4: count of **prefixes** with loop in AS-path
   - 5: count of **prefixes** with loop in originator
+  - 7: count of **routes** in adj-rib-in
   - 11: count of updates subjected to :rfc:`7607` "treat as withdrawal"
     handling due to errors
   - 65531: *experimental* count of prefixes rejected due to invalid next-hop

--- a/doc/user/bmp.rst
+++ b/doc/user/bmp.rst
@@ -147,6 +147,11 @@ associated with a particular ``bmp targets``:
    Send BMP Statistics (counter) messages at the specified interval (in
    milliseconds.)
 
+.. clicmd:: bmp stats send-experimental
+
+   Send BMP Statistics (counter) messages whose code is defined as
+   experimental (in the [65531-65534] range).
+
 .. clicmd:: bmp monitor AFI SAFI <pre-policy|post-policy|loc-rib>
 
    Perform Route Monitoring for the specified AFI and SAFI.  Only IPv4 and

--- a/doc/user/bmp.rst
+++ b/doc/user/bmp.rst
@@ -24,6 +24,7 @@ The `BMP` implementation in FRR has the following properties:
   - 4: count of **prefixes** with loop in AS-path
   - 5: count of **prefixes** with loop in originator
   - 7: count of **routes** in adj-rib-in
+  - 8: count of **routes** in Loc-RIB
   - 11: count of updates subjected to :rfc:`7607` "treat as withdrawal"
     handling due to errors
   - 65531: *experimental* count of prefixes rejected due to invalid next-hop


### PR DESCRIPTION
Add support for BMP stats option 7 and 8.
Add vty command to disable sending experimental stats numbers.