### PR TITLE
ospfd: fix the bug where ip_ospf_dead-interval_minimal_hello-multiplier did not reset hello timer

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8208,6 +8208,8 @@ static int ospf_vty_dead_interval_set(struct vty *vty, const char *interval_str,
 				ospf_nbr_timer_update(oi);
 	}
 
+	if (params->fast_hello != OSPF_FAST_HELLO_DEFAULT)
+		ospf_reset_hello_timer(ifp, addr, false);
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
Fix the bug where ip_ospf_dead-interval_minimal_hello-multiplier did not reset hello timer.

The command ip_ospf_dead-interval_minimal_hello-multiplier sets the OSPF dead interval to 1 second and the hello interval to 1/arg seconds to accelerate OSPF convergence. Once this command is set, the hello timer should immediately reset and send a new hello packet to inform its neighbors, similar to what the ip ospf hello-interval command does. 