### PR TITLE
pimd: fix crash unconfiguring rp keepalive timer

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -287,8 +287,15 @@ int pim_process_no_rp_kat_cmd(struct vty *vty)
 		sizeof(rs_timer_xpath));
 
 	/* RFC4601 */
-	v = yang_dnode_get_uint16(vty->candidate_config->dnode, "%s",
-				  rs_timer_xpath);
+	/* Check if register suppress time is configured or assigned
+	 * the default register suppress time.
+	 */
+	if (yang_dnode_exists(vty->candidate_config->dnode, rs_timer_xpath))
+		v = yang_dnode_get_uint16(vty->candidate_config->dnode, "%s",
+					  rs_timer_xpath);
+	else
+		v = PIM_REGISTER_SUPPRESSION_TIME_DEFAULT;
+
 	v = 3 * v + PIM_REGISTER_PROBE_TIME_DEFAULT;
 	if (v > UINT16_MAX)
 		v = UINT16_MAX;


### PR DESCRIPTION
pimd crashs while unconfigure of rp ka timer as we are trying to access a yand dnode(suppress timer) which does not exist at the moment.

User just configured rp keepalive timer and not suppress timer, the yang dnode would not be present. Instead of directly accessing yang_dnode_get_unit16, first check the yang node exist using the xpath.

Ticket: #3874971

Testing:

Before:
------
tor-11(config)# no ip pim rp keep-alive-timer 3000 vtysh: error reading from pimd: Success (0)Warning: closing connection to pimd because of an I/O error!

Broadcast message from root@tor-11 (somewhere) (Mon Apr 22 17:29:12 2024):

cumulus-core: Running cl-support for core files "pimd.25467.1713806952.core"

After:
-----
tor-11(config)# no ip pim rp keep-alive-timer 3000 tor-11(config)#