### PR TITLE
tools: Handle seq num for BGP as-path in frr-reload.py

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1475,6 +1475,35 @@ def ignore_delete_re_add_lines(lines_to_add, lines_to_del):
                 lines_to_add.append((add_cmd, None))
                 lines_to_del_to_del.append((ctx_keys, None))
 
+        # bgp as-path access-list can be specified without a seq number.
+        # However, the running config always
+        # adds `seq X` (sequence number). So, ignore such lines as well.
+        # Examples:
+        #      bgp as-path access-list important_internet_bgp_as_numbers seq 30 permit _40841_"
+        re_bgp_as_path = re.search(
+            "^(bgp )(as-path )(access-list )(\S+\s+)(seq \d+\s+)(permit|deny)(.*)$",
+            ctx_keys[0],
+        )
+        if re_bgp_as_path:
+            found = False
+            tmpline = (
+                re_bgp_as_path.group(1)
+                + re_bgp_as_path.group(2)
+                + re_bgp_as_path.group(3)
+                + re_bgp_as_path.group(4)
+                + re_bgp_as_path.group(6)
+                + re_bgp_as_path.group(7)
+            )
+            for ctx in lines_to_add:
+                if ctx[0][0] == tmpline:
+                    lines_to_del_to_del.append((ctx_keys, None))
+                    lines_to_add_to_del.append(((tmpline,), None))
+                    found = True
+            if found is False:
+                add_cmd = ("no " + ctx_keys[0],)
+                lines_to_add.append((add_cmd, None))
+                lines_to_del_to_del.append((ctx_keys, None))
+
         if (
             len(ctx_keys) == 3
             and ctx_keys[0].startswith("router bgp")


### PR DESCRIPTION
If frr.conf has bgp as-path access-list clause without sequence number then upon performing frr-rleoad, the running config clause with sequence number will always be deleted and the new ones without sequence will be re-added.
This could lead to blackhole until the config gets reapplied.

Testing:

```
frr.conf:
bgp as-path access-list important_internet_bgp_as_numbers permit _16509_

Running config:
bgp as-path access-list important_internet_bgp_as_numbers seq 5 permit _16509_
!

Before fix
Upon frr-reload it deletes and readd line as without seq

2024-04-26 03:16:45,772  INFO: Executed "no bgp as-path access-list important_internet_bgp_as_numbers seq 5 permit _16509_"

'bgp as-path access-list important_internet_bgp_as_numbers permit _16509_\n'

After fix:
no form is not executed and no delta determine between frr.conf and running-config.
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>