### PR TITLE
bgpd: fix the dead code

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -1396,11 +1396,7 @@ char *ecommunity_ecom2str(struct ecommunity *ecom, int format, int filter)
 			if (sub_type == ECOMMUNITY_LINK_BANDWIDTH)
 				ecommunity_lb_str(encbuf, sizeof(encbuf), pnt,
 						  ecom->disable_ieee_floating);
-			else
-				unk_ecom = 1;
-		} else if (type == ECOMMUNITY_ENCODE_AS_NON_TRANS) {
-			sub_type = *pnt++;
-			if (sub_type == ECOMMUNITY_EXTENDED_LINK_BANDWIDTH)
+			else if (sub_type == ECOMMUNITY_EXTENDED_LINK_BANDWIDTH)
 				ipv6_ecommunity_lb_str(encbuf, sizeof(encbuf),
 						       pnt);
 			else


### PR DESCRIPTION
Fixed the Coverity scanner issue 1586018:

** CID 1586018: Control flow issues (DEADCODE) /bgpd/bgp_ecommunity.c: 1402 in ecommunity_ecom2str()