### PR TITLE
isisd: added prefix propogation/leaking

### DIFF
--- a/isisd/isis_constants.h
+++ b/isisd/isis_constants.h
@@ -148,6 +148,15 @@
 
 #define LLC_LEN 3
 
+/*
+ * implementation specific route-leaking values
+ */
+
+#define LEVEL2_TO_LEVEL1   4
+#define LEVEL1_TO_LEVEL2   5
+#define LVL_ISIS_LEAKING_1 0
+#define LVL_ISIS_LEAKING_2 1
+
 /* we need to be aware of the fact we are using ISO sized
  * packets, using isomtu = mtu - LLC_LEN
  */

--- a/isisd/isis_lsp.h
+++ b/isisd/isis_lsp.h
@@ -99,6 +99,8 @@ void lsp_purge_non_exist(int level, struct isis_lsp_hdr *hdr,
 	memcpy((I), isis->sysid, ISIS_SYS_ID_LEN);                             \
 	(I)[ISIS_SYS_ID_LEN] = 0;                                              \
 	(I)[ISIS_SYS_ID_LEN + 1] = 0
+void iteration_in_level1_lspdb(struct isis_area *area,
+                                      struct isis_lsp *lsp_d);
 int lsp_id_cmp(uint8_t *id1, uint8_t *id2);
 int lsp_compare(char *areatag, struct isis_lsp *lsp, uint32_t seqno,
 		uint16_t checksum, uint16_t rem_lifetime);
@@ -149,5 +151,4 @@ int isis_lsp_iterate_is_reach(struct isis_lsp *lsp, uint16_t mtid,
 void _lsp_flood(struct isis_lsp *lsp, struct isis_circuit *circuit,
 		const char *func, const char *file, int line);
 void lsp_init(void);
-
 #endif /* ISIS_LSP */

--- a/isisd/isis_nb.c
+++ b/isisd/isis_nb.c
@@ -454,6 +454,64 @@ const struct frr_yang_module_info frr_isisd_info = {
 			},
 		},
 		{
+			.xpath = "/frr-isisd:isis/instance/route_leaking/ipv4",
+			.cbs = {
+				.apply_finish = leaking_ipv4_apply_finish,
+				.cli_show = cli_show_isis_leaking_ipv4,
+				.create = isis_instance_leaking_ipv4_create,
+				.destroy = isis_instance_leaking_ipv4_destroy,
+			},
+		},
+		{
+			.xpath = "/frr-isisd:isis/instance/route_leaking/ipv4/route-map",
+			.cbs = {
+				.destroy = isis_instance_route_leaking_ipv4_route_map_destroy,
+				.modify = isis_instance_route_leaking_ipv4_route_map_modify,
+			},
+		},
+		{
+			.xpath = "/frr-isisd:isis/instance/route_leaking/ipv4/metric",
+			.cbs = {
+				.modify = isis_instance_route_leaking_ipv4_metric_modify,
+			},
+		},
+		{
+			.xpath = "/frr-isisd:isis/instance/route_leaking/ipv6",
+			.cbs = {
+				.apply_finish = leaking_ipv6_apply_finish,
+				.cli_show = cli_show_isis_leaking_ipv6,
+				.create = isis_instance_leaking_ipv6_create,
+				.destroy = isis_instance_leaking_ipv6_destroy,
+			},
+		},
+		{
+			.xpath = "/frr-isisd:isis/instance/route_leaking/ipv6/route-map",
+			.cbs = {
+				.destroy = isis_instance_route_leaking_ipv6_route_map_destroy,
+				.modify = isis_instance_route_leaking_ipv6_route_map_modify,
+			},
+		},
+		{
+			.xpath = "/frr-isisd:isis/instance/route_leaking/ipv6/metric",
+			.cbs = {
+				.modify = isis_instance_route_leaking_ipv6_metric_modify,
+			},
+		},
+		{
+			.xpath = "/frr-isisd:isis/instance/redistribute/ipv4/level_from",
+			.cbs = {
+				.destroy = isis_instance_route_leaking_ipv6_route_map_destroy,
+				.modify = isis_instance_route_leaking_ipv6_metric_modify,
+			},
+		},
+		{
+			.xpath = "/frr-isisd:isis/instance/redistribute/ipv6/level_from",
+			.cbs = {
+				.destroy = isis_instance_route_leaking_ipv6_route_map_destroy,
+				.modify = isis_instance_route_leaking_ipv6_metric_modify,
+			},
+		},
+		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv4-multicast",
 			.cbs = {
 				.cli_show = cli_show_isis_mt_ipv4_multicast,

--- a/isisd/isis_nb.h
+++ b/isisd/isis_nb.h
@@ -139,6 +139,32 @@ int isis_instance_redistribute_ipv6_metric_destroy(
 int isis_instance_redistribute_ipv6_table_create(struct nb_cb_create_args *args);
 int isis_instance_redistribute_ipv6_table_destroy(
 	struct nb_cb_destroy_args *args);
+int isis_instance_route_leaking_ipv4_route_map_modify(
+	struct nb_cb_modify_args *args);
+int isis_instance_route_leaking_ipv4_route_map_destroy(
+	struct nb_cb_destroy_args *args);
+int isis_instance_route_leaking_ipv4_metric_modify(
+	struct nb_cb_modify_args *args);
+int isis_instance_route_leaking_ipv4_metric_destroy(
+	struct nb_cb_destroy_args *args);
+int isis_instance_route_leaking_ipv4_table_create(struct nb_cb_create_args *args);
+int isis_instance_route_leaking_ipv4_table_destroy(
+	struct nb_cb_destroy_args *args);
+int isis_instance_route_leaking_ipv6_table_destroy(
+	struct nb_cb_destroy_args *args);
+int isis_instance_route_leaking_ipv6_table_create(struct nb_cb_create_args *args);
+int isis_instance_route_leaking_ipv6_metric_destroy(
+	struct nb_cb_destroy_args *args);
+int isis_instance_route_leaking_ipv6_metric_modify(
+	struct nb_cb_modify_args *args);
+int isis_instance_route_leaking_ipv6_route_map_destroy(
+	struct nb_cb_destroy_args *args);
+int isis_instance_route_leaking_ipv6_route_map_modify(
+	struct nb_cb_modify_args *args);
+int isis_instance_leaking_ipv4_create(struct nb_cb_create_args *args);
+int isis_instance_leaking_ipv4_destroy(struct nb_cb_destroy_args *args);
+int isis_instance_leaking_ipv6_create(struct nb_cb_create_args *args);
+int isis_instance_leaking_ipv6_destroy(struct nb_cb_destroy_args *args);
 int isis_instance_multi_topology_ipv4_multicast_create(
 	struct nb_cb_create_args *args);
 int isis_instance_multi_topology_ipv4_multicast_destroy(
@@ -528,6 +554,9 @@ void default_info_origin_ipv6_apply_finish(
 void redistribute_apply_finish(const struct lyd_node *dnode, int family);
 void redistribute_ipv4_apply_finish(struct nb_cb_apply_finish_args *args);
 void redistribute_ipv6_apply_finish(struct nb_cb_apply_finish_args *args);
+void leaking_ipv4_apply_finish(struct nb_cb_apply_finish_args *args);
+void leaking_ipv6_apply_finish(struct nb_cb_apply_finish_args *args);
+void leaking_apply_finish(const struct lyd_node *dnode, int family);
 void isis_instance_segment_routing_srgb_apply_finish(
 	struct nb_cb_apply_finish_args *args);
 void isis_instance_segment_routing_srlb_apply_finish(
@@ -618,6 +647,16 @@ void cli_show_isis_redistribute_ipv4(struct vty *vty,
 void cli_show_isis_redistribute_ipv6(struct vty *vty,
 				     const struct lyd_node *dnode,
 				     bool show_defaults);
+void cli_show_isis_leaking_ipv4(struct vty *vty, const struct lyd_node *dnode,
+				bool show_defaults);
+void cli_show_isis_leaking_ipv6(struct vty *vty, const struct lyd_node *dnode,
+				bool show_defaults);
+void cli_show_isis_route_leaking_ipv4_table(struct vty *vty,
+					    const struct lyd_node *dnode,
+					    bool show_defaults);
+void cli_show_isis_route_leaking_ipv6_table(struct vty *vty,
+					    const struct lyd_node *dnode,
+					    bool show_defaults);
 void cli_show_isis_mt_ipv4_multicast(struct vty *vty,
 				     const struct lyd_node *dnode,
 				     bool show_defaults);
@@ -786,6 +825,8 @@ void isis_notif_own_lsp_purge(const struct isis_circuit *circuit,
 int cli_cmp_isis_redistribute_table(const struct lyd_node *dnode1,
 				    const struct lyd_node *dnode2);
 
+int cli_cmp_isis_route_leaking_table(const struct lyd_node *dnode1,
+				     const struct lyd_node *dnode2);
 /* We also declare hook for every notification */
 
 DECLARE_HOOK(isis_hook_db_overload, (const struct isis_area *area), (area));

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -1441,6 +1441,191 @@ int isis_instance_redistribute_ipv6_table_destroy(struct nb_cb_destroy_args *arg
 }
 
 /*
+ *  XPath: /frr-isisd:isis/intance/route_leaking/ipv4
+ */
+void leaking_apply_finish(const struct lyd_node *dnode, int family)
+{
+	assert(family == AF_INET || family == AF_INET6);
+	int type, level;
+	unsigned long metric = 0;
+	const char *routemap = NULL;
+	struct isis_area *area;
+
+	type = yang_dnode_get_enum(dnode, "./protocol");
+	level = yang_dnode_get_enum(dnode, "./level");
+	area = nb_running_get_entry(dnode, NULL, true);
+
+	if (yang_dnode_exists(dnode, "./route-map"))
+		routemap = yang_dnode_get_string(dnode, "./route-map");
+
+	isis_levels_redist_set(area, level, family, type, metric, routemap, 0,
+			       0);
+	if (level == IS_LEVEL_2)
+		lsp_regenerate_schedule(area, IS_LEVEL_1, 0);
+	else
+		lsp_regenerate_schedule(area, IS_LEVEL_2, 0);
+}
+
+void leaking_ipv4_apply_finish(struct nb_cb_apply_finish_args *args)
+{
+	leaking_apply_finish(args->dnode, AF_INET);
+}
+
+void leaking_ipv6_apply_finish(struct nb_cb_apply_finish_args *args)
+{
+	leaking_apply_finish(args->dnode, AF_INET6);
+}
+
+int isis_instance_leaking_ipv4_create(struct nb_cb_create_args *args)
+{
+	/* It's all done by redistribute_apply_finish */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-isisd:isis/instance/route_leaking/ipv6
+ */
+
+int isis_instance_leaking_ipv6_create(struct nb_cb_create_args *args)
+{
+	/* It's all done by redistribute_apply_finish */
+	return NB_OK;
+}
+/*
+ * XPath: /frr-isisd:isis/instance/route_leaking/ipv4/route-map
+ * XPath: /frr-isisd:isis/instance/route_leaking/ipv4/table/route-map
+ */
+int isis_instance_route_leaking_ipv4_route_map_modify(
+	struct nb_cb_modify_args *args)
+{
+	/* It's all done by redistribute_apply_finish */
+	return NB_OK;
+}
+
+int isis_instance_route_leaking_ipv4_route_map_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	/* It's all done by redistribute_apply_finish */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-isisd:isis/instance/route_leaking/ipv4/metric
+ */
+int isis_instance_route_leaking_ipv4_metric_modify(struct nb_cb_modify_args *args)
+{
+	/* It's all done by redistribute_apply_finish */
+	return NB_OK;
+}
+
+int isis_instance_route_leaking_ipv4_metric_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	/* It's all done by redistribute_apply_finish */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-isisd:isis/instance/redistribute/ipv4/table
+ */
+int isis_instance_route_leaking_ipv4_table_create(struct nb_cb_create_args *args)
+{
+	/* TODO: support table redistribution between levels in  IS-IS*/
+	return NB_OK;
+}
+
+int isis_instance_route_leaking_ipv4_table_destroy(struct nb_cb_destroy_args *args)
+{
+	/* TODO: support table redistribution between levels in  IS-IS*/
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-isisd:isis/instance/redistribute/ipv6/route-map
+ */
+int isis_instance_route_leaking_ipv6_route_map_modify(
+	struct nb_cb_modify_args *args)
+{
+	/* It's all done by redistribute_apply_finish */
+	return NB_OK;
+}
+
+int isis_instance_route_leaking_ipv6_route_map_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	/* It's all done by redistribute_apply_finish */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-isisd:isis/instance/redistribute/ipv6/metric
+ */
+int isis_instance_route_leaking_ipv6_metric_modify(struct nb_cb_modify_args *args)
+{
+	/* It's all done by redistribute_apply_finish */
+	return NB_OK;
+}
+
+int isis_instance_route_leaking_ipv6_metric_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	/* It's all done by redistribute_apply_finish */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-isisd:isis/instance/redistribute/ipv6/table
+ */
+int isis_instance_route_leaking_ipv6_table_create(struct nb_cb_create_args *args)
+{
+	/* TODO: support table redistribution between levels in IS-IS*/
+	return NB_OK;
+}
+
+int isis_instance_route_leaking_ipv6_table_destroy(struct nb_cb_destroy_args *args)
+{
+	/* TODO: support table redistribution between levels in  IS-IS*/
+	return NB_OK;
+}
+
+
+int isis_instance_leaking_ipv4_destroy(struct nb_cb_destroy_args *args)
+{
+	struct isis_area *area;
+	const char *routemap = NULL;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	area = nb_running_get_entry(args->dnode, NULL, true);
+
+	if (yang_dnode_exists(args->dnode, "route-map"))
+		routemap = yang_dnode_get_string(args->dnode, "route-map");
+
+	isis_leaking_unset(area, routemap);
+
+	return NB_OK;
+}
+
+int isis_instance_leaking_ipv6_destroy(struct nb_cb_destroy_args *args)
+{
+	struct isis_area *area;
+	const char *routemap = NULL;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	area = nb_running_get_entry(args->dnode, NULL, true);
+
+	if (yang_dnode_exists(args->dnode, "route-map"))
+		routemap = yang_dnode_get_string(args->dnode, "route-map");
+
+	isis_leaking_unset(area, routemap);
+
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-isisd:isis/instance/multi-topology/ipv4-multicast
  */
 static int isis_multi_topology_common(enum nb_event event,

--- a/isisd/isis_pdu.h
+++ b/isisd/isis_pdu.h
@@ -192,6 +192,8 @@ void isis_receive(struct event *thread);
 
 #define ISIS_AUTH_MD5_SIZE       16U
 
+#define REDISTRIBUTE_TO_L2   2
+#define REDISTRIBUTE_TO_L1   1
 /*
  * Sending functions
  */

--- a/isisd/isis_redist.h
+++ b/isisd/isis_redist.h
@@ -14,6 +14,8 @@
 #define DEFAULT_ORIGINATE 1
 #define DEFAULT_ORIGINATE_ALWAYS 2
 
+#include "isis_tlvs.h"
+
 struct isis_ext_info {
 	int origin;
 	uint32_t metric;
@@ -37,6 +39,24 @@ struct isis_redist_table_present_args {
 	bool rtda_found;
 };
 
+struct isis_levels_redist {
+	int redist;
+	int family;
+	int type;
+	int level_to;
+	int level_from;
+	uint32_t metric;
+	char *map_name;
+	struct route_map *map;
+	uint16_t table; 
+	bool up_down_flag;
+};
+
+struct levels_redist_match {
+	struct list *extended_ip_reach;
+	struct list *ipv6_reach;
+};
+
 struct isis;
 struct isis_area;
 struct prefix;
@@ -56,6 +76,8 @@ int isis_redist_config_write(struct vty *vty, struct isis_area *area,
 			     int family);
 void isis_redist_init(void);
 void isis_redist_area_finish(struct isis_area *area);
+int isis_leaking_config_write(struct vty *vty, struct isis_area *area,
+			      int family);
 
 void isis_redist_set(struct isis_area *area, int level, int family, int type,
 		     uint32_t metric, const char *routemap, int originate_type,
@@ -69,4 +91,11 @@ bool isis_redist_table_is_present(const struct vty *vty,
 				  struct isis_redist_table_present_args *rtda);
 uint16_t isis_redist_table_get_first(const struct vty *vty,
 				     struct isis_redist_table_present_args *rtda);
+
+void isis_iteration_in_lspdb(struct isis_area *area,
+			     struct isis_levels_redist *redist);
+void isis_levels_redist_set(struct isis_area *area, int level, int family,
+			    int type, uint32_t metric, const char *routemap,
+			    int originate_type, uint16_t table);
+void isis_leaking_unset(struct isis_area *area, const char *routemap);
 #endif

--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -152,7 +152,7 @@ mpls_label_t sr_prefix_out_label(struct lspdb_head *lspdb, int family,
 {
 	struct isis_sr_block *nh_srgb;
 
-	if (last_hop) {
+	if (last_hop && !CHECK_FLAG(psid->flags, ISIS_PREFIX_SID_READVERTISED)) {
 		if (!CHECK_FLAG(psid->flags, ISIS_PREFIX_SID_NO_PHP))
 			return MPLS_LABEL_IMPLICIT_NULL;
 
@@ -406,6 +406,13 @@ struct sr_prefix_cfg *isis_sr_cfg_prefix_find(struct isis_area *area,
 	prefix_copy(&pcfg.prefix, prefix.p);
 	pcfg.algorithm = algorithm;
 	return srdb_prefix_cfg_find(&area->srdb.config.prefix_sids, &pcfg);
+}
+
+/* fiil Prefix-SID Sub-TLV flags according to IS-IS level's redistribution*/
+void isis_redist_cfg2subtlvs(struct isis_prefix_sid *psid)
+{
+	/* RFC 8667 section #2.1.1.2 */
+        SET_FLAG(psid->flags, ISIS_PREFIX_SID_READVERTISED);
 }
 
 /**

--- a/isisd/isis_sr.h
+++ b/isisd/isis_sr.h
@@ -213,6 +213,7 @@ extern void isis_sr_cfg_prefix_del(struct sr_prefix_cfg *pcfg);
 extern struct sr_prefix_cfg *
 isis_sr_cfg_prefix_find(struct isis_area *area, union prefixconstptr prefix,
 			uint8_t algorithm);
+extern void isis_redist_cfg2subtlvs(struct isis_prefix_sid *psid);
 extern void isis_sr_prefix_cfg2subtlv(const struct sr_prefix_cfg *pcfg,
 				      bool external,
 				      struct isis_prefix_sid *psid);

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -4041,6 +4041,31 @@ out:
 	return 1;
 }
 
+/*Functions for redistribte routes inside IS-IS*/
+struct isis_extended_ip_reach* copy_extended_ip_reach(struct isis_item *ip_reach_s,
+				    uint32_t metric, bool up_down_flag)
+{
+	struct isis_extended_ip_reach *ip_reach_d =
+		(struct isis_extended_ip_reach *)copy_item_extended_ip_reach(
+			ip_reach_s);
+
+	ip_reach_d->metric = metric;
+	ip_reach_d->down = up_down_flag;
+
+	/* RFC 8667 section #2.1.1.2 */
+	if (ip_reach_d->subtlvs) {
+		for (struct isis_item *i = ip_reach_d->subtlvs->prefix_sids.head; i; i = i->next)
+			isis_redist_cfg2subtlvs((struct isis_prefix_sid*)i);
+	}
+
+	return ip_reach_d;
+}
+
+void append_extended_ip_reach(struct isis_tlvs *tlvs,
+		struct isis_item *ip_reach)
+{
+	append_item(&tlvs->extended_ip_reach, (struct isis_item *)ip_reach);
+}
 /* Functions related to TLV 137 Dynamic Hostname */
 
 static char *copy_tlv_dynamic_hostname(const char *hostname)
@@ -4673,6 +4698,30 @@ out:
 	if (rv)
 		free_item_ipv6_reach((struct isis_item *)rv);
 	return 1;
+}
+
+/*Functions for redistribte routes inside IS-IS*/
+struct isis_ipv6_reach* copy_ipv6_reach(struct isis_item *ipv6_reach_s, uint32_t metric,
+						bool up_down_flag)
+{
+	struct isis_ipv6_reach *ipv6_reach_d =
+		(struct isis_ipv6_reach *)copy_item_ipv6_reach(ipv6_reach_s);
+
+	ipv6_reach_d->metric = metric;
+	ipv6_reach_d->down   = up_down_flag;
+
+	/* RFC 8667 section #2.1.1.2 */
+        if (ipv6_reach_d->subtlvs) {
+                for (struct isis_item *i = ipv6_reach_d->subtlvs->prefix_sids.head; i; i = i->next)
+                        isis_redist_cfg2subtlvs((struct isis_prefix_sid*)i);
+	}
+
+	return ipv6_reach_d;
+}
+
+void append_ipv6_reach(struct isis_tlvs *tlvs, struct isis_item *ipv6_reach)
+{
+	append_item(&tlvs->ipv6_reach, (struct isis_item *)ipv6_reach);
 }
 
 /* Functions related to TLV 242 Router Capability as per RFC7981 */

--- a/isisd/isis_tlvs.h
+++ b/isisd/isis_tlvs.h
@@ -900,4 +900,13 @@ void isis_tlvs_add_srv6_lan_endx_sid(struct isis_ext_subtlvs *exts,
 				     struct isis_srv6_lan_endx_sid_subtlv *lan);
 void isis_tlvs_del_srv6_lan_endx_sid(struct isis_ext_subtlvs *exts,
 				     struct isis_srv6_lan_endx_sid_subtlv *lan);
+
+/*Functions for redistribte routes inside IS-IS*/
+struct isis_extended_ip_reach *copy_extended_ip_reach(struct isis_item *ip_reach_s,
+				    uint32_t metric, bool up_down_flag);
+struct isis_ipv6_reach *copy_ipv6_reach(struct isis_item *ipv6_reach_s, uint32_t metric,
+						bool up_down_flag);
+void append_extended_ip_reach(struct isis_tlvs *tlvs,
+		struct isis_item *ip_reach);
+void append_ipv6_reach(struct isis_tlvs *tlvs, struct isis_item *ipv6_reach);
 #endif

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -332,6 +332,11 @@ struct isis_area *isis_area_create(const char *area_tag, const char *vrf_name)
 	area->area_addrs = list_new();
 	area->area_addrs->del = delete_area_addr;
 
+        for (int level = 0; level < 2; level++)
+                area->levels_redist_list[level] = list_new();
+
+	area->levels_redist_sett = list_new();
+
 	if (!CHECK_FLAG(im->options, F_ISIS_UNIT_TEST))
 		event_add_timer(master, lsp_tick, area, 1, &area->t_tick);
 	flags_initialize(&area->flags);
@@ -546,6 +551,11 @@ void isis_area_destroy(struct isis_area *area)
 		isis_redist_area_finish(area);
 
 	list_delete(&area->area_addrs);
+
+	for (int level = 0; level < 2; level++)
+                list_delete(&area->levels_redist_list[level]);
+
+	list_delete(&area->levels_redist_sett);
 
 	for (int i = SPF_PREFIX_PRIO_CRITICAL; i <= SPF_PREFIX_PRIO_MEDIUM;
 	     i++) {
@@ -3561,6 +3571,8 @@ static int isis_config_write(struct vty *vty)
 			}
 			write += isis_redist_config_write(vty, area, AF_INET);
 			write += isis_redist_config_write(vty, area, AF_INET6);
+			write += isis_leaking_config_write(vty, area, AF_INET);
+			write += isis_leaking_config_write(vty, area, AF_INET6);
 			/* ISIS - Lsp generation interval */
 			if (area->lsp_gen_interval[0]
 			    == area->lsp_gen_interval[1]) {

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -46,6 +46,7 @@ static const bool fabricd = false;
 #define PROTO_TYPE ZEBRA_ROUTE_ISIS
 #define PROTO_NAME "isis"
 #define PROTO_HELP "IS-IS routing protocol\n"
+#define PROTO_HELP_REDIST     "Intermediate System to Intermediate System (IS-IS)\n"
 #define PROTO_REDIST_STR FRR_REDIST_STR_ISISD
 #define PROTO_IP_REDIST_STR FRR_IP_REDIST_STR_ISISD
 #define PROTO_IP6_REDIST_STR FRR_IP6_REDIST_STR_ISISD
@@ -255,6 +256,9 @@ struct isis_area {
 	uint64_t auth_failures[2];
 	uint64_t id_len_mismatches[2];
 	uint64_t lsp_error_counter[2];
+
+	struct list *levels_redist_sett;
+	struct list *levels_redist_list[2];
 
 	QOBJ_FIELDS;
 };

--- a/lib/command.h
+++ b/lib/command.h
@@ -394,6 +394,8 @@ struct cmd_node {
 #define NO_STR "Negate a command or set its defaults\n"
 #define IGNORED_IN_NO_STR "Ignored value in no form\n"
 #define REDIST_STR "Redistribute information from another routing protocol\n"
+#define ROUTE_LEAKING	  "route_leaking\n"
+#define LEAKING_STR	  "Leaking between level's in IS-IS routing protocol\n"
 #define CLEAR_STR "Reset functions\n"
 #define RIP_STR "RIP information\n"
 #define EIGRP_STR "EIGRP information\n"

--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -104,6 +104,16 @@ module frr-isisd {
         description
           "This enum indicates capability for both levels.";
       }
+        enum "level2_to_level1" {
+        value 4;
+        description
+          "This enum indicates capability for both levels.";
+      }
+      enum "level1_to_level2" {
+        value 5;
+        description
+          "This enum indicates capability for both levels.";
+      }
     }
     description
       "This type defines IS-IS level of an object.";
@@ -310,6 +320,27 @@ module frr-isisd {
     }
 
     uses redistribute-attributes;
+  }
+
+  grouping leaking-attributes {
+    description
+      "Common optional attributes of any leaking entry.";
+    leaf route-map {
+      type frr-route-map:route-map-ref;
+      description
+        "Applies the conditions of the specified route-map to routes that
+         are redistributed into this routing instance.";
+    }
+
+    leaf metric {
+      type uint32 {
+        range "0..16777215";
+      }
+      default "0";
+      description
+        "Metric used for the redistributed route. If 0,
+         the default-metric attribute is used instead.";
+    }
   }
 
   grouping isis-password {
@@ -1483,7 +1514,6 @@ module frr-isisd {
             "IPv4 route redistribution.";
           leaf protocol {
             type frr-route-types:frr-route-types-v4;
-            must ". != \"isis\"";
             description
               "Originating routing protocol for the IPv4 routes.";
           }
@@ -1494,6 +1524,15 @@ module frr-isisd {
             description
               "IS-IS level into which the routes should be redistributed.";
           }
+
+	  leaf level_from {
+            type level;
+	    when "../protocol = \"isis\"";
+	    mandatory true;
+            must "(. != \"level-1-2\") and ((../../../is-type = \"level-1-2\") and (. != ../level))";
+            description
+              "IS-IS level from which the routes should be redistributed.";
+	  }
 
           choice protocol-type {
             case protocol-table {
@@ -1527,16 +1566,24 @@ module frr-isisd {
             "IPv6 route redistribution.";
           leaf protocol {
             type frr-route-types:frr-route-types-v6;
-            must ". != \"isis\"";
             description
               "Originating routing protocol for the IPv6 routes.";
           }
 
-          leaf level {
+           leaf level {
             type level;
             must "(. != \"level-1-2\") and ((../../../is-type = \"level-1-2\") or (. = ../../../is-type))";
             description
               "IS-IS level into which the routes should be redistributed.";
+          }
+
+          leaf level_from {
+            type level;
+            when "../protocol = \"isis\"";
+            mandatory true;
+            must "(. != \"level-1-2\") and ((../../../is-type = \"level-1-2\") and (. != ../level))";
+            description
+              "IS-IS level from which the routes should be redistributed.";
           }
 
           choice protocol-type {
@@ -2078,6 +2125,45 @@ module frr-isisd {
         }
       }
 
+      container route_leaking {
+        description
+          "Redistributes routes learned from other routing protocols.";
+        list ipv4 {
+          key "protocol level";
+          description
+            "IPv4 route redistribution.";
+          leaf protocol {
+            type frr-route-types:frr-route-types-v4;
+            description
+              "Originating routing protocol for the IPv4 routes.";
+          }
+
+          leaf level {
+            type level;
+            description
+              "IS-IS level into which the routes should be redistributed.";
+          }
+
+          uses leaking-attributes;
+        }
+        list ipv6 {
+          key "protocol level";
+          description
+            "IPv6 route redistribution.";
+          leaf protocol {
+            type frr-route-types:frr-route-types-v6;
+            description
+              "Originating routing protocol for the IPv6 routes.";
+          }
+
+          leaf level {
+            type level;
+            description
+              "IS-IS level into which the routes should be redistributed.";
+          }
+         uses redistribute-attributes;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
added:
1) default prefix propogation from level-1 to level-2 db on level_1_2 edge according to RFC 1195 
2) cli command "redistribute ipv4/ipv6 isis level-m into level-n route-map map_name" 
3) maneged leaking from level-2 into level-1 accoding to RFC 5302 
4) Re-advertisement Flag in SR subtlv in redistributed prefix accoding to RFC 8667