### PR TITLE
build: get rid of "unrecognized … anon-tag"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -275,7 +275,16 @@ AC_DEFUN([AC_C_FLAG], [{
     AC_CACHE_CHECK([[whether $CC supports $1]], cachename, [
 	AC_LANG_PUSH([C])
 	ac_c_flag_save="$CFLAGS"
-	CFLAGS="$CFLAGS $1"
+	dnl GCC ignores unknown -Wno-whatever flags, but errors on -Wwhatever
+	dnl except when it ignores them it prints:
+	dnl   cc1: note: unrecognized command-line option ‘-Wno-whatever’ may have been intended to silence earlier diagnostics
+	dnl which is annoying as hell.  So check for the positive flag instead.
+	flag_add="$1"
+	if test "$flag_add" != "${flag_add#-Wno-}"; then
+	    CFLAGS="$CFLAGS -W${flag_add#-Wno-}"
+	else
+	    CFLAGS="$CFLAGS $flag_add"
+	fi
 	AC_COMPILE_IFELSE(
 		[AC_LANG_PROGRAM([[$4]])],
 		[


### PR DESCRIPTION
GCC only errors out on unrecognized _positive_ `-Wsomething` flags, negative ones it ignores... but then prints a "note" about whenever an unrelated(!) warning/error occurs.  This is both annoying and confusing, since we now get a lot of:

```
cc1: note: unrecognized command-line option ‘-Wno-microsoft-anon-tag’ may have been intended to silence earlier diagnostics
```

Fix by checking for the positive flag in `AC_C_FLAG` instead, which will error out, and therefore `-Wno-microsoft-anon-tag` won't be added for GCC.  (It only exists on clang.)