### PR TITLE
lib, gcc-plugin: fix 64-bit time_t prints

### DIFF
--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -1556,8 +1556,9 @@ static enum nb_error nb_op_yield(struct nb_op_yield_state *ys)
 	unsigned long min_us = MAX(1, NB_OP_WALK_INTERVAL_US / 50000);
 	struct timeval tv = { .tv_sec = 0, .tv_usec = min_us };
 
-	DEBUGD(&nb_dbg_events, "NB oper-state: yielding %s for %lus (should_batch %d)",
-	       ys->xpath, tv.tv_usec, ys->should_batch);
+	DEBUGD(&nb_dbg_events,
+	       "NB oper-state: yielding %s for %lldus (should_batch %d)",
+	       ys->xpath, (long long)tv.tv_usec, ys->should_batch);
 
 	if (ys->should_batch) {
 		/*

--- a/tools/gcc-plugins/frr-format.c
+++ b/tools/gcc-plugins/frr-format.c
@@ -66,6 +66,8 @@ static GTY(()) tree local_pid_t_node;
 static GTY(()) tree local_uid_t_node;
 static GTY(()) tree local_gid_t_node;
 static GTY(()) tree local_time_t_node;
+static GTY(()) tree local_suseconds_t_node;
+static GTY(()) tree local_suseconds64_t_node;
 
 static GTY(()) tree local_socklen_t_node;
 static GTY(()) tree local_in_addr_t_node;
@@ -85,6 +87,8 @@ static struct type_special {
   { &local_uid_t_node,		NULL,			&local_uid_t_node, },
   { &local_gid_t_node,		NULL,			&local_gid_t_node, },
   { &local_time_t_node,		NULL,			&local_time_t_node, },
+  { &local_suseconds_t_node,	NULL,			&local_suseconds_t_node, },
+  { &local_suseconds64_t_node,	NULL,			&local_suseconds64_t_node, },
   { NULL,			NULL,			NULL, }
 };
 
@@ -4176,6 +4180,8 @@ handle_finish_parse (void *event_data, void *data)
   setup_type ("uid_t", &local_uid_t_node);
   setup_type ("gid_t", &local_gid_t_node);
   setup_type ("time_t", &local_time_t_node);
+  setup_type ("__suseconds_t", &local_suseconds_t_node);
+  setup_type ("__suseconds64_t", &local_suseconds64_t_node);
 
   setup_type ("socklen_t", &local_socklen_t_node);
   setup_type ("in_addr_t", &local_in_addr_t_node);


### PR DESCRIPTION
The gcc plugin was already warning about printfrr'ing `time_t`, but `struct timeval` uses `suseconds_t`.

- fix the one place where this matters in lib/NB code
- add `__suseconds_t`/`__suseconds64_t` to things that the GCC plugin will warn about

(The GCC plugin is executed on one of the Debian 12 build VMs in CI, i.e. this will cause CI failures there in the future. [In addition to 32bit builds where it fails if the OS has moved to 64-bit time_t, which is Ubuntu 24.04+ / Debian 13+.])

---
part of fixing #15881