### PR TITLE
build: link libatomic if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1095,6 +1095,8 @@ dnl -------------------------
 AC_CHECK_HEADERS([stropts.h sys/ksym.h \
 	linux/version.h asm/types.h endian.h sys/endian.h])
 
+AC_CHECK_LIB([atomic], [main], [LIBS="$LIBS -latomic"], [], [])
+
 ac_stdatomic_ok=false
 AC_DEFINE([FRR_AUTOCONF_ATOMIC], [1], [did autoconf checks for atomic funcs])
 AC_CHECK_HEADER([stdatomic.h],[


### PR DESCRIPTION
It'll generally exist but be empty on systems that don't need it. (Some 32bit platforms now need it due to 64bit time_t, and the platform may not have 64bit atomic ops.)

---
part of fixing #15881