### PR TITLE
lib: fix build error on MacOS

### DIFF
--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -455,6 +455,12 @@ _Static_assert(sizeof(_uint64_t) == 8 && sizeof(_int64_t) == 8,
 #define unlikely(_x) !!(_x)
 #endif
 
+#ifdef __MACH__
+#define _DATA_SECTION(name) __attribute__((section("__DATA," name)))
+#else
+#define _DATA_SECTION(name) __attribute__((section(".data." name)))
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -69,14 +69,12 @@ struct memgroup {
 
 #define DECLARE_MGROUP(name) extern struct memgroup _mg_##name
 #define _DEFINE_MGROUP(mname, desc, ...)                                       \
-	struct memgroup _mg_##mname                                            \
-		__attribute__((section(".data.mgroups"))) = {                  \
-			.name = desc,                                          \
-			.types = NULL,                                         \
-			.next = NULL,                                          \
-			.insert = NULL,                                        \
-			.ref = NULL,                                           \
-			__VA_ARGS__                                            \
+	struct memgroup _mg_##mname _DATA_SECTION("mgroups") = {               \
+		.name = desc,                                                  \
+		.types = NULL,                                                 \
+		.next = NULL,                                                  \
+		.insert = NULL,                                                \
+		.ref = NULL,                                                   \
 	};                                                                     \
 	static void _mginit_##mname(void) __attribute__((_CONSTRUCTOR(1000))); \
 	static void _mginit_##mname(void)                                      \
@@ -105,13 +103,12 @@ struct memgroup {
 	/* end */
 
 #define DEFINE_MTYPE_ATTR(group, mname, attr, desc)                            \
-	attr struct memtype MTYPE_##mname[1]                                   \
-		__attribute__((section(".data.mtypes"))) = { {                 \
-			.name = desc,                                          \
-			.next = NULL,                                          \
-			.n_alloc = 0,                                          \
-			.size = 0,                                             \
-			.ref = NULL,                                           \
+	attr struct memtype MTYPE_##mname[1] _DATA_SECTION("mtypes") = { {     \
+		.name = desc,                                                  \
+		.next = NULL,                                                  \
+		.n_alloc = 0,                                                  \
+		.size = 0,                                                     \
+		.ref = NULL,                                                   \
 	} };                                                                   \
 	static void _mtinit_##mname(void) __attribute__((_CONSTRUCTOR(1001))); \
 	static void _mtinit_##mname(void)                                      \


### PR DESCRIPTION
Sections use a different syntax for Mach-O executables.

The `frr` package has a host build step in OpenWRT, which can be cross-compiled on macOS. This commit fixes errors while building OpenWRT on macOS host.

Fixes:
``` bash
# OpenWRT
make package/feeds/packages/frr/host/{clean,compile} -j 1 V=s
…
lib/command_graph.c:16:1: error: argument to 'section' attribute is not valid for this target: mach-o section specifier requires a segment and section separated by a comma DEFINE_MTYPE_STATIC(LIB, CMD_TOKENS, "Command Tokens"); ^
./lib/memory.h:139:2: note: expanded from macro 'DEFINE_MTYPE_STATIC'
        DEFINE_MTYPE_ATTR(group, name, static, desc)                           \
        ^
./lib/memory.h:109:26: note: expanded from macro 'DEFINE_MTYPE_ATTR'
                __attribute__((section(".data.mtypes"))) = { {                 \
```

Compile tested as part of OpenWRT buildroot: macOS 14.4.1, Ubuntu 22.04.4 LTS.
Changes from the original version [1]: rebased on master, fixed formatting style. Please let me know if any changes are needed.

[1] https://github.com/FRRouting/frr/pull/6032

Maintainer: @eqvinox
@polychaeta @qlyoung @donaldsharp @rzalamena @rubenk @robimarko