### PR TITLE
pathd: retry label-manager connection asynchronously

### DIFF
--- a/pathd/path_main.c
+++ b/pathd/path_main.c
@@ -58,7 +58,7 @@ static void sighup(void)
 static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
-	zlog_notice("Unregisterfrom opaque,etc ");
+	zlog_notice("Unregister from opaque,etc ");
 	pathd_shutdown();
 
 	exit(0);


### PR DESCRIPTION
Remove blocking "sleep" calls from the pathd code that initializes and connects the synchronous zapi session used for, sigh, label-manager. Be prepared to retry on a timer.
Also clean up a typo in a log message.

Fixes: #15847 