### PR TITLE
lib, bgpd, tests, zebra: prefix_sg changes for V6 VTEP

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -2455,7 +2455,7 @@ static void bgp_evpn_es_frag_show_detail(struct vty *vty,
 }
 
 static char *bgp_evpn_es_vteps_str(char *vtep_str, struct bgp_evpn_es *es,
-				   uint8_t vtep_str_size)
+				   size_t vtep_str_size)
 {
 	char vtep_flag_str[BGP_EVPN_FLAG_STR_SZ];
 	struct listnode *node;
@@ -3956,7 +3956,7 @@ void bgp_evpn_vni_es_cleanup(struct bgpevpn *vpn)
 
 static char *bgp_evpn_es_evi_vteps_str(char *vtep_str,
 				       struct bgp_evpn_es_evi *es_evi,
-				       uint8_t vtep_str_size)
+				       size_t vtep_str_size)
 {
 	char vtep_flag_str[BGP_EVPN_FLAG_STR_SZ];
 	struct listnode *node;

--- a/lib/ipaddr.h
+++ b/lib/ipaddr.h
@@ -172,9 +172,11 @@ static inline bool ipaddr_is_same(const struct ipaddr *ip1,
 	return ipaddr_cmp(ip1, ip2) == 0;
 }
 
+/* clang-format off */
 #ifdef _FRR_ATTRIBUTE_PRINTFRR
 #pragma FRR printfrr_ext "%pIA"  (struct ipaddr *)
 #endif
+/* clang-format on */
 
 #ifdef __cplusplus
 }

--- a/lib/ipaddr.h
+++ b/lib/ipaddr.h
@@ -40,8 +40,9 @@ struct ipaddr {
 #define IS_IPADDR_V4(p)   ((p)->ipa_type == IPADDR_V4)
 #define IS_IPADDR_V6(p)   ((p)->ipa_type == IPADDR_V6)
 
-#define SET_IPADDR_V4(p)  (p)->ipa_type = IPADDR_V4
-#define SET_IPADDR_V6(p)  (p)->ipa_type = IPADDR_V6
+#define SET_IPADDR_NONE(p) ((p)->ipa_type = IPADDR_NONE)
+#define SET_IPADDR_V4(p)   ((p)->ipa_type = IPADDR_V4)
+#define SET_IPADDR_V6(p)   ((p)->ipa_type = IPADDR_V6)
 
 #define IPADDRSZ(p)                                                            \
 	(IS_IPADDR_V4((p)) ? sizeof(struct in_addr) : sizeof(struct in6_addr))

--- a/lib/ipaddr.h
+++ b/lib/ipaddr.h
@@ -166,6 +166,12 @@ static inline bool ipaddr_is_zero(const struct ipaddr *ip)
 	return true;
 }
 
+static inline bool ipaddr_is_same(const struct ipaddr *ip1,
+				  const struct ipaddr *ip2)
+{
+	return ipaddr_cmp(ip1, ip2) == 0;
+}
+
 #ifdef _FRR_ATTRIBUTE_PRINTFRR
 #pragma FRR printfrr_ext "%pIA"  (struct ipaddr *)
 #endif

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1124,6 +1124,15 @@ const char *prefix2str(union prefixconstptr pu, char *str, int size)
 	return str;
 }
 
+void prefix_mcast_ip_dump(const char *onfail, const struct ipaddr *addr,
+			  char *buf, int buf_size)
+{
+	if (ipaddr_is_zero(addr))
+		strlcpy(buf, "*", buf_size);
+	else
+		(void)snprintfrr(buf, buf_size, "%pIA", addr);
+}
+
 static ssize_t prefixhost2str(struct fbuf *fbuf, union prefixconstptr pu)
 {
 	const struct prefix *p = pu.p;
@@ -1166,7 +1175,7 @@ const char *prefix_sg2str(const struct prefix_sg *sg, char *sg_str)
 	char src_str[INET_ADDRSTRLEN];
 	char grp_str[INET_ADDRSTRLEN];
 
-	prefix_mcast_inet4_dump("<src?>", sg->src, src_str, sizeof(src_str));
+	prefix_mcast_ip_dump("<src?>", &sg->src, src_str, sizeof(src_str));
 	prefix_mcast_inet4_dump("<grp?>", sg->grp, grp_str, sizeof(grp_str));
 	snprintf(sg_str, PREFIX_SG_STR_LEN, "(%s,%s)", src_str, grp_str);
 
@@ -1637,10 +1646,10 @@ static ssize_t printfrr_psg(struct fbuf *buf, struct printfrr_eargs *ea,
 	if (!sg)
 		return bputs(buf, "(null)");
 
-	if (sg->src.s_addr == INADDR_ANY)
+	if (ipaddr_is_zero(&sg->src))
 		ret += bputs(buf, "(*,");
 	else
-		ret += bprintfrr(buf, "(%pI4,", &sg->src);
+		ret += bprintfrr(buf, "(%pIA,", &sg->src);
 
 	if (sg->grp.s_addr == INADDR_ANY)
 		ret += bputs(buf, "*)");

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -52,10 +52,10 @@ typedef enum {
 /* Maximum number of VTEPs per-ES -
  * XXX - temporary limit for allocating strings etc.
  */
-#define ES_VTEP_MAX_CNT 10
-#define ES_VTEP_LIST_STR_SZ (ES_VTEP_MAX_CNT * 16)
+#define ES_VTEP_MAX_CNT	    10
+#define ES_VTEP_LIST_STR_SZ (ES_VTEP_MAX_CNT * IPADDR_STRING_SIZE)
 
-#define ETHER_ADDR_STRLEN (3*ETH_ALEN)
+#define ETHER_ADDR_STRLEN (3 * ETH_ALEN)
 /*
  * there isn't a portable ethernet address type. We define our
  * own to simplify internal handling

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -282,7 +282,7 @@ struct prefix_fs {
 struct prefix_sg {
 	uint8_t family;
 	uint16_t prefixlen;
-	struct in_addr src __attribute__((aligned(8)));
+	struct ipaddr src __attribute__((aligned(8)));
 	struct in_addr grp;
 };
 
@@ -415,6 +415,8 @@ extern int str2prefix(const char *string, struct prefix *prefix);
 
 #define PREFIX2STR_BUFFER  PREFIX_STRLEN
 
+extern void prefix_mcast_ip_dump(const char *onfail, const struct ipaddr *addr,
+				 char *buf, int buf_size);
 extern void prefix_mcast_inet4_dump(const char *onfail, struct in_addr addr,
 				char *buf, int buf_size);
 extern const char *prefix_sg2str(const struct prefix_sg *sg, char *str);

--- a/lib/stream.c
+++ b/lib/stream.c
@@ -921,7 +921,7 @@ int stream_put_in_addr(struct stream *s, const struct in_addr *addr)
 	return sizeof(uint32_t);
 }
 
-bool stream_put_ipaddr(struct stream *s, struct ipaddr *ip)
+bool stream_put_ipaddr(struct stream *s, const struct ipaddr *ip)
 {
 	stream_putw(s, ip->ipa_type);
 

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -175,7 +175,7 @@ extern int stream_putq(struct stream *, uint64_t);
 extern int stream_putq_at(struct stream *, size_t, uint64_t);
 extern int stream_put_ipv4(struct stream *, uint32_t);
 extern int stream_put_in_addr(struct stream *s, const struct in_addr *addr);
-extern bool stream_put_ipaddr(struct stream *s, struct ipaddr *ip);
+extern bool stream_put_ipaddr(struct stream *s, const struct ipaddr *ip);
 extern int stream_put_in_addr_at(struct stream *s, size_t putp,
 				 const struct in_addr *addr);
 extern int stream_put_in6_addr_at(struct stream *s, size_t putp,

--- a/tests/lib/test_printfrr.c
+++ b/tests/lib/test_printfrr.c
@@ -230,18 +230,24 @@ int main(int argc, char **argv)
 	printchk("02:ca:fe:f0:0d:1e", "%pFXh", &pfx);
 
 	struct prefix_sg sg;
-	sg.src.s_addr = INADDR_ANY;
+	SET_IPADDR_V4(&sg.src);
+	sg.src.ipaddr_v4.s_addr = INADDR_ANY;
 	sg.grp.s_addr = INADDR_ANY;
 	printchk("(*,*)", "%pPSG4", &sg);
 
-	inet_aton("192.168.1.2", &sg.src);
+	inet_aton("192.168.1.2", &sg.src.ipaddr_v4);
 	printchk("(192.168.1.2,*)", "%pPSG4", &sg);
 
 	inet_aton("224.1.2.3", &sg.grp);
 	printchk("(192.168.1.2,224.1.2.3)", "%pPSG4", &sg);
 
-	sg.src.s_addr = INADDR_ANY;
+	SET_IPADDR_NONE(&sg.src);
+	sg.src.ipaddr_v4.s_addr = INADDR_ANY;
 	printchk("(*,224.1.2.3)", "%pPSG4", &sg);
+
+	SET_IPADDR_V6(&sg.src);
+	inet_pton(AF_INET6, "1:2:3:4::5", &sg.src.ipaddr_v6);
+	printchk("(1:2:3:4::5,224.1.2.3)", "%pPSG4", &sg);
 
 	uint8_t randhex[] = { 0x12, 0x34, 0x00, 0xca, 0xfe, 0x00, 0xaa, 0x55 };
 

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3026,7 +3026,7 @@ void zebra_evpn_es_if_oper_state_change(struct zebra_if *zif, bool up)
 }
 
 static char *zebra_evpn_es_vtep_str(char *vtep_str, struct zebra_evpn_es *es,
-				    uint8_t vtep_str_size)
+				    size_t vtep_str_size)
 {
 	struct zebra_evpn_es_vtep *zvtep;
 	struct listnode	*node;

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -108,10 +108,11 @@ static void zevpn_build_hash_table(void);
 static unsigned int zebra_vxlan_sg_hash_key_make(const void *p);
 static bool zebra_vxlan_sg_hash_eq(const void *p1, const void *p2);
 static void zebra_vxlan_sg_do_deref(struct zebra_vrf *zvrf,
-		struct in_addr sip, struct in_addr mcast_grp);
-static struct zebra_vxlan_sg *zebra_vxlan_sg_do_ref(struct zebra_vrf *vrf,
-						    struct in_addr sip,
-						    struct in_addr mcast_grp);
+				    const struct ipaddr *sip,
+				    const struct in_addr mcast_grp);
+static struct zebra_vxlan_sg *
+zebra_vxlan_sg_do_ref(struct zebra_vrf *vrf, const struct ipaddr *sip,
+		      const struct in_addr mcast_grp);
 static void zebra_vxlan_cleanup_sg_table(struct zebra_vrf *zvrf);
 
 bool zebra_evpn_do_dup_addr_detect(struct zebra_vrf *zvrf)
@@ -5891,7 +5892,10 @@ static int zebra_vxlan_sg_send(struct zebra_vrf *zvrf,
 
 	zclient_create_header(s, cmd, VRF_DEFAULT);
 	stream_putl(s, IPV4_MAX_BYTELEN);
-	stream_put(s, &sg->src.s_addr, IPV4_MAX_BYTELEN);
+	/*
+	 * There is currently no support for IPv6 VTEPs with PIM.
+	 */
+	stream_put(s, &sg->src.ipaddr_v4, IPV4_MAX_BYTELEN);
 	stream_put(s, &sg->grp.s_addr, IPV4_MAX_BYTELEN);
 
 	/* Write packet size. */
@@ -5914,9 +5918,17 @@ static int zebra_vxlan_sg_send(struct zebra_vrf *zvrf,
 static unsigned int zebra_vxlan_sg_hash_key_make(const void *p)
 {
 	const struct zebra_vxlan_sg *vxlan_sg = p;
+	uint32_t hash1;
 
-	return (jhash_2words(vxlan_sg->sg.src.s_addr,
-				vxlan_sg->sg.grp.s_addr, 0));
+	if (IS_IPADDR_V4(&vxlan_sg->sg.src)) {
+		return (jhash_2words(vxlan_sg->sg.src.ipaddr_v4.s_addr,
+				     vxlan_sg->sg.grp.s_addr, 0));
+	} else {
+		hash1 = jhash_1word(vxlan_sg->sg.grp.s_addr, 0);
+		return jhash2(vxlan_sg->sg.src.ipaddr_v6.s6_addr32,
+			      array_size(vxlan_sg->sg.src.ipaddr_v6.s6_addr32),
+			      hash1);
+	}
 }
 
 static bool zebra_vxlan_sg_hash_eq(const void *p1, const void *p2)
@@ -5924,8 +5936,8 @@ static bool zebra_vxlan_sg_hash_eq(const void *p1, const void *p2)
 	const struct zebra_vxlan_sg *sg1 = p1;
 	const struct zebra_vxlan_sg *sg2 = p2;
 
-	return ((sg1->sg.src.s_addr == sg2->sg.src.s_addr)
-		&& (sg1->sg.grp.s_addr == sg2->sg.grp.s_addr));
+	return (ipaddr_is_same(&sg1->sg.src, &sg2->sg.src) &&
+		(sg1->sg.grp.s_addr == sg2->sg.grp.s_addr));
 }
 
 static struct zebra_vxlan_sg *zebra_vxlan_sg_new(struct zebra_vrf *zvrf,
@@ -5961,7 +5973,7 @@ static struct zebra_vxlan_sg *zebra_vxlan_sg_add(struct zebra_vrf *zvrf,
 {
 	struct zebra_vxlan_sg *vxlan_sg;
 	struct zebra_vxlan_sg *parent = NULL;
-	struct in_addr sip;
+	struct ipaddr sip;
 
 	vxlan_sg = zebra_vxlan_sg_find(zvrf, sg);
 	if (vxlan_sg)
@@ -5972,9 +5984,9 @@ static struct zebra_vxlan_sg *zebra_vxlan_sg_add(struct zebra_vrf *zvrf,
 	 * 2. the XG entry is used by pimd to setup the
 	 * vxlan-termination-mroute
 	 */
-	if (sg->src.s_addr != INADDR_ANY) {
+	if (!ipaddr_is_zero(&sg->src)) {
 		memset(&sip, 0, sizeof(sip));
-		parent = zebra_vxlan_sg_do_ref(zvrf, sip, sg->grp);
+		parent = zebra_vxlan_sg_do_ref(zvrf, &sip, sg->grp);
 		if (!parent)
 			return NULL;
 	}
@@ -5989,7 +6001,7 @@ static struct zebra_vxlan_sg *zebra_vxlan_sg_add(struct zebra_vrf *zvrf,
 
 static void zebra_vxlan_sg_del(struct zebra_vxlan_sg *vxlan_sg)
 {
-	struct in_addr sip;
+	struct ipaddr sip;
 	struct zebra_vrf *zvrf;
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
@@ -5997,13 +6009,13 @@ static void zebra_vxlan_sg_del(struct zebra_vxlan_sg *vxlan_sg)
 	/* On SG entry deletion remove the reference to its parent XG
 	 * entry
 	 */
-	if (vxlan_sg->sg.src.s_addr != INADDR_ANY) {
+	if (!ipaddr_is_zero(&vxlan_sg->sg.src)) {
 		memset(&sip, 0, sizeof(sip));
-		zebra_vxlan_sg_do_deref(zvrf, sip, vxlan_sg->sg.grp);
+		zebra_vxlan_sg_do_deref(zvrf, &sip, vxlan_sg->sg.grp);
 	}
 
-	zebra_vxlan_sg_send(zvrf, &vxlan_sg->sg,
-			vxlan_sg->sg_str, ZEBRA_VXLAN_SG_DEL);
+	zebra_vxlan_sg_send(zvrf, &vxlan_sg->sg, vxlan_sg->sg_str,
+			    ZEBRA_VXLAN_SG_DEL);
 
 	hash_release(vxlan_sg->zvrf->vxlan_sg_table, vxlan_sg);
 
@@ -6014,14 +6026,15 @@ static void zebra_vxlan_sg_del(struct zebra_vxlan_sg *vxlan_sg)
 }
 
 static void zebra_vxlan_sg_do_deref(struct zebra_vrf *zvrf,
-		struct in_addr sip, struct in_addr mcast_grp)
+				    const struct ipaddr *sip,
+				    const struct in_addr mcast_grp)
 {
 	struct zebra_vxlan_sg *vxlan_sg;
 	struct prefix_sg sg;
 
 	sg.family = AF_INET;
 	sg.prefixlen = IPV4_MAX_BYTELEN;
-	sg.src = sip;
+	sg.src = *sip;
 	sg.grp = mcast_grp;
 	vxlan_sg = zebra_vxlan_sg_find(zvrf, &sg);
 	if (!vxlan_sg)
@@ -6034,16 +6047,16 @@ static void zebra_vxlan_sg_do_deref(struct zebra_vrf *zvrf,
 		zebra_vxlan_sg_del(vxlan_sg);
 }
 
-static struct zebra_vxlan_sg *zebra_vxlan_sg_do_ref(struct zebra_vrf *zvrf,
-						    struct in_addr sip,
-						    struct in_addr mcast_grp)
+static struct zebra_vxlan_sg *
+zebra_vxlan_sg_do_ref(struct zebra_vrf *zvrf, const struct ipaddr *sip,
+		      const struct in_addr mcast_grp)
 {
 	struct zebra_vxlan_sg *vxlan_sg;
 	struct prefix_sg sg;
 
 	sg.family = AF_INET;
 	sg.prefixlen = IPV4_MAX_BYTELEN;
-	sg.src = sip;
+	sg.src = *sip;
 	sg.grp = mcast_grp;
 	vxlan_sg = zebra_vxlan_sg_add(zvrf, &sg);
 	if (vxlan_sg)
@@ -6052,10 +6065,10 @@ static struct zebra_vxlan_sg *zebra_vxlan_sg_do_ref(struct zebra_vrf *zvrf,
 	return vxlan_sg;
 }
 
-void zebra_vxlan_sg_deref(struct in_addr local_vtep_ip,
-			  struct in_addr mcast_grp)
+void zebra_vxlan_sg_deref(struct in_addr local_vtep_ip, struct in_addr mcast_grp)
 {
 	struct zebra_vrf *zvrf;
+	struct ipaddr local_vtep_ipaddr;
 
 	if (local_vtep_ip.s_addr == INADDR_ANY
 	    || mcast_grp.s_addr == INADDR_ANY)
@@ -6063,20 +6076,26 @@ void zebra_vxlan_sg_deref(struct in_addr local_vtep_ip,
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
 
-	zebra_vxlan_sg_do_deref(zvrf, local_vtep_ip, mcast_grp);
+	SET_IPADDR_V4(&local_vtep_ipaddr);
+	local_vtep_ipaddr.ipaddr_v4 = local_vtep_ip;
+
+	zebra_vxlan_sg_do_deref(zvrf, &local_vtep_ipaddr, mcast_grp);
 }
 
 void zebra_vxlan_sg_ref(struct in_addr local_vtep_ip, struct in_addr mcast_grp)
 {
 	struct zebra_vrf *zvrf;
+	struct ipaddr local_vtep_ipaddr;
 
-	if (local_vtep_ip.s_addr == INADDR_ANY
-	    || mcast_grp.s_addr == INADDR_ANY)
+	if (local_vtep_ip.s_addr == INADDR_ANY || mcast_grp.s_addr == INADDR_ANY)
 		return;
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
 
-	zebra_vxlan_sg_do_ref(zvrf, local_vtep_ip, mcast_grp);
+	SET_IPADDR_V4(&local_vtep_ipaddr);
+	local_vtep_ipaddr.ipaddr_v4 = local_vtep_ip;
+
+	zebra_vxlan_sg_do_ref(zvrf, &local_vtep_ipaddr, mcast_grp);
 }
 
 static void zebra_vxlan_xg_pre_cleanup(struct hash_bucket *bucket, void *arg)
@@ -6086,7 +6105,7 @@ static void zebra_vxlan_xg_pre_cleanup(struct hash_bucket *bucket, void *arg)
 	/* increment the ref count against (*,G) to prevent them from being
 	 * deleted
 	 */
-	if (vxlan_sg->sg.src.s_addr == INADDR_ANY)
+	if (ipaddr_is_zero(&vxlan_sg->sg.src))
 		++vxlan_sg->ref_cnt;
 }
 
@@ -6095,7 +6114,7 @@ static void zebra_vxlan_xg_post_cleanup(struct hash_bucket *bucket, void *arg)
 	struct zebra_vxlan_sg *vxlan_sg = (struct zebra_vxlan_sg *)bucket->data;
 
 	/* decrement the dummy ref count against (*,G) to delete them */
-	if (vxlan_sg->sg.src.s_addr == INADDR_ANY) {
+	if (ipaddr_is_zero(&vxlan_sg->sg.src)) {
 		if (vxlan_sg->ref_cnt)
 			--vxlan_sg->ref_cnt;
 		if (!vxlan_sg->ref_cnt)


### PR DESCRIPTION
This changeset introduces changes in lib for prefix_sg (and associated downstream consumers in bgpd/zebra)

- src address in prefix_sg is now v6 aware (struct ipaddr)
- %pSG4 now prints a v6 src address
- Places where zebra uses prefix_sg src address are now V6 aware
- ES_VTEP_LIST_STR_SZ can now support a v6 VTEP address
  - This has impacts in bgpd and zebra as uint8_t is not enough for printing (size_t changes)

This is a part of the upstreaming process for #5885.