### PR TITLE
zebra: clean up one comment

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1473,7 +1473,6 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 
 	ifi = NLMSG_DATA(h);
 
-	/* assume if not default zns, then new VRF */
 	if (!(h->nlmsg_type == RTM_NEWLINK || h->nlmsg_type == RTM_DELLINK)) {
 		/* If this is not link add/delete message so print warning. */
 		zlog_debug("%s: wrong kernel message %s", __func__,


### PR DESCRIPTION
With the commit `605df8d4`, all real things are moved into dplane. So the operations mentioned in this comment have nothing to do with this function `netlink_link_change()`.

Just remove that confusing and useless comment.