### PR TITLE
tests: remove reliance on time.sleep

### DIFF
--- a/tests/topotests/mgmt_oper/test_oper.py
+++ b/tests/topotests/mgmt_oper/test_oper.py
@@ -95,7 +95,6 @@ def test_oper(tgen):
     check_kernel_32(r1, "12.12.12.12", 1, "")
     check_kernel_32(r1, "13.13.13.13", 1, "red")
     check_kernel_32(r1, "14.14.14.14", 1, "red")
-    time.sleep(2)
     do_oper_test(tgen, query_results)
 
 

--- a/tests/topotests/mgmt_oper/test_scale.py
+++ b/tests/topotests/mgmt_oper/test_scale.py
@@ -52,7 +52,6 @@ def test_oper_simple(tgen):
 
     r1 = tgen.gears["r1"].net
 
-    time.sleep(2)
     count = 20 * 1000
 
     vrf = None  # "red"


### PR DESCRIPTION
Use proper retry loop to wait for state to converge, not some arbitrary delay.

fixes #15878