### PR TITLE
bgpd: Fix `no set as-path prepend ASNUM...`

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -6288,13 +6288,12 @@ DEFPY_YANG(
 }
 
 DEFUN_YANG (no_set_aspath_prepend,
-	    no_set_aspath_prepend_cmd,
-	    "no set as-path prepend [ASNUM] [last-as [(1-10)]]",
+	    no_set_aspath_prepend_last_as_cmd,
+	    "no set as-path prepend [last-as [(1-10)]]",
 	    NO_STR
 	    SET_STR
 	    "Transform BGP AS_PATH attribute\n"
 	    "Prepend to the as-path\n"
-	    AS_STR
 	    "Use the peers AS-number\n"
 	    "Number of times to insert\n")
 {
@@ -6304,6 +6303,15 @@ DEFUN_YANG (no_set_aspath_prepend,
 	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 	return nb_cli_apply_changes(vty, NULL);
 }
+
+ALIAS_YANG (no_set_aspath_prepend,
+            no_set_aspath_prepend_as_cmd,
+            "no set as-path prepend ASNUM...",
+            NO_STR
+            SET_STR
+            "Transform BGP AS_PATH attribute\n"
+            "Prepend to the as-path\n"
+            AS_STR)
 
 DEFUN_YANG (set_aspath_exclude,
 	    set_aspath_exclude_cmd,
@@ -7981,7 +7989,8 @@ void bgp_route_map_init(void)
 	install_element(RMAP_NODE, &set_aspath_exclude_access_list_cmd);
 	install_element(RMAP_NODE, &set_aspath_replace_asn_cmd);
 	install_element(RMAP_NODE, &set_aspath_replace_access_list_cmd);
-	install_element(RMAP_NODE, &no_set_aspath_prepend_cmd);
+	install_element(RMAP_NODE, &no_set_aspath_prepend_last_as_cmd);
+	install_element(RMAP_NODE, &no_set_aspath_prepend_as_cmd);
 	install_element(RMAP_NODE, &no_set_aspath_exclude_cmd);
 	install_element(RMAP_NODE, &no_set_aspath_exclude_all_cmd);
 	install_element(RMAP_NODE, &no_set_aspath_exclude_access_list_cmd);

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -5897,10 +5897,11 @@ DEFUN_YANG (set_table_id,
 
 DEFUN_YANG (no_set_table_id,
 	    no_set_table_id_cmd,
-	    "no set table",
+	    "no set table [(1-4294967295)]",
 	    NO_STR
 	    SET_STR
-	    "export route to non-main kernel table\n")
+	    "export route to non-main kernel table\n"
+	    "Kernel routing table id\n")
 {
 	const char *xpath = "./set-action[action='frr-bgp-route-map:table']";
 	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);


### PR DESCRIPTION
If entering `no set as-path prepend 1 2 3`, it's warned as unknown command.

Now fixed, and the following combinations work fine:

```
no set as-path prepend
no set as-path prepend last-as
no set as-path prepend last-as 1
no set as-path prepend 1
no set as-path prepend 1 2
```

Fixes: https://github.com/FRRouting/frr/issues/15912