### PR TITLE
build: exclude deprecated decls from -Werror

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -453,6 +453,7 @@ fi
 AC_C_FLAG([-Wno-unused-parameter])
 AC_C_FLAG([-Wno-missing-field-initializers])
 AC_C_FLAG([-Wno-microsoft-anon-tag])
+AC_C_FLAG([-Wno-error=deprecated-declarations])
 
 AC_C_FLAG([-Wc++-compat], [], [CXX_COMPAT_CFLAGS="-Wc++-compat"])
 AC_SUBST([CXX_COMPAT_CFLAGS])


### PR DESCRIPTION
Other parts of the system can change (e.g. libc-ares), making things deprecated, and then our build fails for no reason inside FRR.  This shouldn't be an error.

---
I'm gonna say this is the correct thing to do even after the libc-ares fix (#15837)for the deprecated bits is merged.