### PR TITLE
isisd: adjust the format of display command

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -726,13 +726,13 @@ void isis_adj_print_vty(struct isis_adjacency *adj, struct vty *vty,
 		now = time(NULL);
 		if (adj->last_upd) {
 			if (adj->last_upd + adj->hold_time < now)
-				vty_out(vty, " Expiring");
+				vty_out(vty, " Expiring ");
 			else
 				vty_out(vty, " %-9llu",
 					(unsigned long long)adj->last_upd
 						+ adj->hold_time - now);
 		} else
-			vty_out(vty, "-        ");
+			vty_out(vty, " -        ");
 		vty_out(vty, "%-10pSY", adj->snpa);
 		vty_out(vty, "\n");
 	}

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -1318,7 +1318,7 @@ static void isis_neighbor_common_vty(struct vty *vty, const char *id,
 
 		if (detail == ISIS_UI_LEVEL_BRIEF)
 			vty_out(vty,
-				"  System Id           Interface   L  State        Holdtime SNPA\n");
+				" System Id           Interface   L  State         Holdtime SNPA\n");
 
 		for (ALL_LIST_ELEMENTS_RO(area->circuit_list, cnode, circuit)) {
 			if (circuit->circ_type == CIRCUIT_T_BROADCAST) {


### PR DESCRIPTION
Before:
```
anlan# show isis neighbor
Area xx:
  System Id           Interface   L  State        Holdtime SNPA
 0023.0000.0000      enp1s0      2  Down          Expiring2c53.4a30.0820
```

After:
```
anlan# show isis neighbor
Area xx:
 System Id           Interface   L  State         Holdtime SNPA
 0023.0000.0000      enp1s0      2  Down          Expiring 2c53.4a30.0820
```

The `-` display format caused by no hello packet in `isis_adj_print_vty()` is same as that of above "Expiring".