### PR TITLE
zebra: fix EVPN svd based remote nh neigh del

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1759,9 +1759,9 @@ static int svd_remote_nh_add(struct zebra_l3vni *zl3vni,
 
 	} else if (memcmp(&nh->emac, rmac, ETH_ALEN) != 0) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug(
-				"SVD RMAC change(%pEA --> %pEA) for nexthop %pIA, prefix %pFX",
-				&nh->emac, rmac, vtep_ip, host_prefix);
+			zlog_debug("SVD RMAC change(%pEA --> %pEA) for nexthop %pIA, prefix %pFX refcnt %u",
+				   &nh->emac, rmac, vtep_ip, host_prefix,
+				   nh->refcnt);
 
 		memcpy(&nh->emac, rmac, ETH_ALEN);
 		/* install (update) the nh neigh in kernel */
@@ -2469,11 +2469,26 @@ static void zl3vni_del_rmac_hash_entry(struct hash_bucket *bucket, void *ctx)
 /* delete and uninstall nh hash entry */
 static void zl3vni_del_nh_hash_entry(struct hash_bucket *bucket, void *ctx)
 {
-	struct zebra_neigh *n = NULL;
+	struct zebra_neigh *n = NULL, *svd_nh = NULL;
 	struct zebra_l3vni *zl3vni = NULL;
 
 	n = (struct zebra_neigh *)bucket->data;
 	zl3vni = (struct zebra_l3vni *)ctx;
+
+	/* remove SVD based remote nexthop neigh entry */
+	svd_nh = svd_nh_lookup(&n->ip);
+	if (svd_nh) {
+		svd_nh->refcnt--;
+		if (IS_ZEBRA_DEBUG_VXLAN)
+			zlog_debug("%s L3VNI %u remove svd nh %pIA refcnt %u",
+				   __func__, zl3vni->vni, &n->ip,
+				   svd_nh->refcnt);
+		if (svd_nh->refcnt == 0) {
+			svd_nh_uninstall(zl3vni, svd_nh);
+			svd_nh_del(svd_nh);
+		}
+	}
+
 	zl3vni_nh_uninstall(zl3vni, n);
 	zl3vni_nh_del(zl3vni, n);
 }


### PR DESCRIPTION
In the context of SVD (Single VxLAN Device) for L3VNI, the remote VTEP's nexthop is programmed neighbor entry against SVD along with neighbor entry against SVI.

However, when L3VNI is removed or the VRF is disabled, all SVI based remote nexthop neighbors are uninstalled and deleted. The SVD based neigh entries remains in Zebra and the Kernel. Subsequently, when reconfiguring L3VNI and relearning the same nexthop, the neighbor entry is not programmed is because it is not removed from Zebra SVD neighbor hash table, leading to the failure to reprogram the entry.

With this fix, the SVD nexthop neigh entry is uninstalled and deleted from Zebra and Kernel.


Testing:
```
borderleaf:# ip neigh show 2.2.2.2

2.2.2.2 dev vlan2560_l3 lladdr 00:01:00:00:1d:09 extern_learn NOARP proto zebra 
2.2.2.2 dev vxlan99 lladdr 00:01:00:00:1d:09 extern_learn NOARP proto zebra

```

**With the fix:**

Zebra debug log shows both enties SVD (vxlan99) and SVI (vlan2560_l3) neighbor entries are deleted.

```
2024/05/03 18:41:33.527125 ZEBRA: [NH6N7-54CD1] Tx RTM_DELNEIGH family ipv4 IF vxlan99(16) Neigh 2.2.2.2 MAC  null flags 0x10 state 0x0 ext_flags 0x0
2024/05/03 18:41:33.527128 ZEBRA: [NH6N7-54CD1] Tx RTM_DELNEIGH family ipv4 IF vlan2560_l3(18) Neigh 2.2.2.2 MAC  null flags 0x10 state 0x0 ext_flags 0x0
```

```
borderleaf:# ip neigh show 2.2.2.2
borderleaf:#
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>
