### PR TITLE
bgpd: Fix crash when deleting the SRv6 locator

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3408,6 +3408,9 @@ static int bgp_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
 	struct in6_addr *tovpn_sid;
 	struct prefix_ipv6 tmp_prefi;
 
+	if (!bgp)
+		return 0;
+
 	if (zapi_srv6_locator_decode(zclient->ibuf, &loc) < 0)
 		return -1;
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3385,11 +3385,11 @@ static int bgp_zebra_process_srv6_locator_add(ZAPI_CALLBACK_ARGS)
 	struct bgp *bgp = bgp_get_default();
 	const char *loc_name = bgp->srv6_locator_name;
 
-	if (zapi_srv6_locator_decode(zclient->ibuf, &loc) < 0)
-		return -1;
-
 	if (!bgp || !bgp->srv6_enabled)
 		return 0;
+
+	if (zapi_srv6_locator_decode(zclient->ibuf, &loc) < 0)
+		return -1;
 
 	if (bgp_zebra_srv6_manager_get_locator_chunk(loc_name) < 0)
 		return -1;


### PR DESCRIPTION
When BGP receives a `SRV6_LOCATOR_DEL` from zebra, it invokes `bgp_zebra_process_srv6_locator_delete` to process the message.

`bgp_zebra_process_srv6_locator_delete` obtains a pointer to the default BGP instance and then dereferences this pointer.

If the default BGP instance is not ready / not configured yet, this pointer this pointer is `NULL` and dereferencing it causes BGP to crash.

This commit fix the issue by adding a a check to verify if the pointer is `NULL` and returning early if it is.