### PR TITLE
bgpd: [GR] fix mode change vtysh return code

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3347,7 +3347,7 @@ DEFUN (bgp_neighbor_graceful_restart_set,
 {
 	int idx_peer = 1;
 	struct peer *peer;
-	int ret = BGP_GR_FAILURE;
+	int result = BGP_GR_FAILURE, ret = BGP_GR_SUCCESS;
 
 	VTY_BGP_GR_DEFINE_LOOP_VARIABLE;
 
@@ -3359,8 +3359,8 @@ DEFUN (bgp_neighbor_graceful_restart_set,
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	ret = bgp_neighbor_graceful_restart(peer, PEER_GR_CMD);
-	if (ret == BGP_GR_SUCCESS) {
+	result = bgp_neighbor_graceful_restart(peer, PEER_GR_CMD);
+	if (result == BGP_GR_SUCCESS) {
 		VTY_BGP_GR_ROUTER_DETECT(bgp, peer, peer->bgp->peer);
 		VTY_SEND_BGP_GR_CAPABILITY_TO_ZEBRA(peer->bgp, ret);
 		vty_out(vty,
@@ -3371,7 +3371,11 @@ DEFUN (bgp_neighbor_graceful_restart_set,
 		zlog_debug(
 			"[BGP_GR] bgp_neighbor_graceful_restart_set_cmd : END ");
 
-	return bgp_vty_return(vty, ret);
+	if (ret != BGP_GR_SUCCESS)
+		vty_out(vty,
+			"As part of configuring graceful-restart, capability send to zebra failed\n");
+
+	return bgp_vty_return(vty, result);
 }
 
 DEFUN (no_bgp_neighbor_graceful_restart,
@@ -3384,7 +3388,7 @@ DEFUN (no_bgp_neighbor_graceful_restart,
       )
 {
 	int idx_peer = 2;
-	int ret = BGP_GR_FAILURE;
+	int result = BGP_GR_FAILURE, ret = BGP_GR_SUCCESS;
 	struct peer *peer;
 
 	VTY_BGP_GR_DEFINE_LOOP_VARIABLE;
@@ -3397,7 +3401,7 @@ DEFUN (no_bgp_neighbor_graceful_restart,
 		zlog_debug(
 			"[BGP_GR] no_bgp_neighbor_graceful_restart_set_cmd : START ");
 
-	ret = bgp_neighbor_graceful_restart(peer, NO_PEER_GR_CMD);
+	result = bgp_neighbor_graceful_restart(peer, NO_PEER_GR_CMD);
 	if (ret == BGP_GR_SUCCESS) {
 		VTY_BGP_GR_ROUTER_DETECT(bgp, peer, peer->bgp->peer);
 		VTY_SEND_BGP_GR_CAPABILITY_TO_ZEBRA(peer->bgp, ret);
@@ -3409,7 +3413,11 @@ DEFUN (no_bgp_neighbor_graceful_restart,
 		zlog_debug(
 			"[BGP_GR] no_bgp_neighbor_graceful_restart_set_cmd : END ");
 
-	return bgp_vty_return(vty, ret);
+	if (ret != BGP_GR_SUCCESS)
+		vty_out(vty,
+			"As part of configuring graceful-restart, capability send to zebra failed\n");
+
+	return bgp_vty_return(vty, result);
 }
 
 DEFUN (bgp_neighbor_graceful_restart_helper_set,


### PR DESCRIPTION
When a bgp neighbor graceful-restart config mode change is applied, after accepting the config if it does not take effect instead of throwing vtysh error code,
return the success to vtysh and warn the user.
The debug log is already present at critical code point where GR failure is seen during config apply.


Testing Done:

```
root@tor-1:# vtysh -c 'config t' -c 'router bgp 65564 vrf VRF2' -c 'neighbor 20.1.1.1 graceful-restart'
As part of configuring graceful-restart, capability send to zebra failed root@tor-1:# echo $?
0
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>