### PR TITLE
bgpd: fix avoid calling VPN processing at VRF interface creation

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3338,7 +3338,7 @@ static int bgp_ifp_create(struct interface *ifp)
 	bgp_update_interface_nbrs(bgp, ifp, ifp);
 	hook_call(bgp_vrf_status_changed, bgp, ifp);
 
-	if (bgp_get_default() && if_is_loopback(ifp)) {
+	if (bgp_get_default() && if_is_loopback_exact(ifp)) {
 		vpn_leak_zebra_vrf_label_update(bgp, AFI_IP);
 		vpn_leak_zebra_vrf_label_update(bgp, AFI_IP6);
 		vpn_leak_zebra_vrf_sid_update(bgp, AFI_IP);


### PR DESCRIPTION
At VRF interface creation, the vpn_leak*() functions are called, whereas at creation, the VRF interface may not be yet operational because it is not up.

Calling the VPN processing functions is useless compared to before interface processing. Also, betting on interface up event now is not justified, as a separate notification will be sent later.

Fix this by not triggering changes for VRF interface creation.

Fixes: 94d12dc490d7 ("bgpd: update route leak when vrf appears")