### PR TITLE
isisd: fix the display topology command

### DIFF
--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -2343,9 +2343,6 @@ static void show_isis_topology_common(struct vty *vty, int levels,
 		return;
 
 	for (ALL_LIST_ELEMENTS_RO(isis->area_list, node, area)) {
-		vty_out(vty,
-			"Area %s:", area->area_tag ? area->area_tag : "null");
-
 #ifndef FABRICD
 		/*
 		 * The shapes of the flex algo spftree 2-dimensional array
@@ -2360,6 +2357,9 @@ static void show_isis_topology_common(struct vty *vty, int levels,
 			fa_data = (struct isis_flex_algo_data *)fa->data;
 		} else
 			fa_data = NULL;
+
+		vty_out(vty,
+			"Area %s:", area->area_tag ? area->area_tag : "null");
 
 		if (algo != SR_ALGORITHM_SPF)
 			vty_out(vty, " Algorithm %hhu\n", algo);


### PR DESCRIPTION
The unconfigured flexible algorithm should not be displayed.

Before: (Here only 128 is configured)
```
anlan# show isis topology algorithm
Area A: Algorithm 128

Area A:Area A:Area A:Area A:Area A:Area A:Area A:Area A:Area A:Area ...
......
anlan#
```

After:
```
anlan# show isis topology algorithm
Area A: Algorithm 128

anlan#
```