### PR TITLE
isisd: fix json display for database command

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -822,15 +822,24 @@ int lsp_print_all(struct vty *vty, struct json_object *json,
 {
 	struct isis_lsp *lsp;
 	int lsp_count = 0;
+	struct json_object *lsp_json = NULL;
 
 	if (detail == ISIS_UI_LEVEL_BRIEF) {
 		frr_each (lspdb, head, lsp) {
-			lsp_print_common(lsp, vty, json, dynhost, isis);
+			if (json) {
+				lsp_json = json_object_new_object();
+				json_object_array_add(json, lsp_json);
+			}
+			lsp_print_common(lsp, vty, lsp_json, dynhost, isis);
 			lsp_count++;
 		}
 	} else if (detail == ISIS_UI_LEVEL_DETAIL) {
 		frr_each (lspdb, head, lsp) {
-			lsp_print_detail(lsp, vty, json, dynhost, isis);
+			if (json) {
+				lsp_json = json_object_new_object();
+				json_object_array_add(json, lsp_json);
+			}
+			lsp_print_detail(lsp, vty, lsp_json, dynhost, isis);
 			lsp_count++;
 		}
 	}

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -2681,6 +2681,7 @@ void show_isis_database_lspdb_json(struct json_object *json,
 {
 	struct isis_lsp *lsp;
 	int lsp_count;
+	struct json_object *lsp_arr_json;
 
 	if (lspdb_count(lspdb) > 0) {
 		lsp = lsp_for_sysid(lspdb, sysid_str, area->isis);
@@ -2697,9 +2698,12 @@ void show_isis_database_lspdb_json(struct json_object *json,
 				lsp_print_json(lsp, json, area->dynhostname,
 					       area->isis);
 		} else if (sysid_str == NULL) {
-			lsp_count =
-				lsp_print_all(NULL, json, lspdb, ui_level,
-					      area->dynhostname, area->isis);
+			lsp_arr_json = json_object_new_array();
+			json_object_object_add(json, "lsps", lsp_arr_json);
+
+			lsp_count = lsp_print_all(NULL, lsp_arr_json, lspdb,
+						  ui_level, area->dynhostname,
+						  area->isis);
 
 			json_object_int_add(json, "count", lsp_count);
 		}


### PR DESCRIPTION
The current json display lost a lot of LSPs, added them.

Fixed the json format for two commands:
"show isis database detail json"
"show isis database json"


Before: ( There should be 3 LSPs )
```
anlan# show isis database json
{
  "areas":[
    {
      "area":{
        "name":"A"
      },
      "levels":[
        {
        },
        {
          "id":2,
          "lsp":{
            "id":"0023.0000.0001.00-00",
            "own":"*"
          },
          "pdu-len":86,
          "seq-number":"0x000001ab",
          "chksum":"0x3fdc",
          "holdtime":1177,
          "att-p-ol":"0/0/0",
          "count":3
        }
      ]
    }
  ]
}


anlan# show isis database detail json
{
  "areas":[
    {
      "area":{
        "name":"A"
      },
      "levels":[
        {
        },
        {
          "id":2,
          "lsp":{
            "id":"0023.0000.0001.00-00",
            "own":"*"
          },
          "pdu-len":54,
          "seq-number":"0x000001aa",
          "chksum":"0xc3d8",
          "holdtime":1135,
          "att-p-ol":"0/0/0",
          "protocols-supported":{
            "0":"IPv4"
          },
          "area-addr":"47",
          "te-router-id":"73.73.73.73",
          "router-capability":{
            "id":"73.73.73.73",
            "flag-d":"0",
            "flag-s":"0"
          },
          "ipv4":"73.73.73.73",
          "ext-ip-reach":{
          },
          "mt-id":"Extended",
          "ip-reach":"192.168.0.0/24",
          "ip-reach-metric":10,
          "down":"",
          "ext-reach":{
            "mt-id":"Extended",
            "id":"0023.0000.0001.00",
            "metric":0
          },
          "subtlvs":{
          },
          "count":3
        }
      ]
    }
  ]
}
```

After:  ( Ok with 3 LSPs )
```
anlan# show isis database json
{
  "areas":[
    {
      "area":{
        "name":"A"
      },
      "levels":[
        {
        },
        {
          "id":2,
          "lsps":[
            {
              "lsp":{
                "id":"0023.0000.0000.00-00",
                "own":" "
              },
              "pdu-len":64,
              "seq-number":"0x000001af",
              "chksum":"0xba38",
              "holdtime":1130,
              "att-p-ol":"0/0/0"
            },
            {
              "lsp":{
                "id":"0023.0000.0000.02-00",
                "own":" "
              },
              "pdu-len":51,
              "seq-number":"0x00000188",
              "chksum":"0x9f3b",
              "holdtime":1167,
              "att-p-ol":"0/0/0"
            },
            {
              "lsp":{
                "id":"0023.0000.0001.00-00",
                "own":"*"
              },
              "pdu-len":54,
              "seq-number":"0x000001ad",
              "chksum":"0xbddb",
              "holdtime":1175,
              "att-p-ol":"0/0/0"
            }
          ],
          "count":3
        }
      ]
    }
  ]
}

anlan# show isis database detail json
{
  "areas":[
    {
      "area":{
        "name":"A"
      },
      "levels":[
        {
        },
        {
          "id":2,
          "lsps":[
            {
              "lsp":{
                "id":"0023.0000.0000.00-00",
                "own":" "
              },
              "pdu-len":77,
              "seq-number":"0x000001b0",
              "chksum":"0x138e",
              "holdtime":1154,
              "att-p-ol":"0/0/0",
              "protocols-supported":{
                "0":"IPv4"
              },
              "area-addr":"47",
              "te-router-id":"73.73.73.73",
              "router-capability":{
                "id":"73.73.73.73",
                "flag-d":"0",
                "flag-s":"0"
              },
              "ext-reach":{
                "mt-id":"Extended",
                "id":"0023.0000.0000.02",
                "metric":10
              },
              "ipv4":"73.73.73.73",
              "ext-ip-reach":{
              },
              "mt-id":"Extended",
              "ip-reach":"44.1.1.0/24",
              "ip-reach-metric":10,
              "down":""
            },
            {
              "lsp":{
                "id":"0023.0000.0000.02-00",
                "own":" "
              },
              "pdu-len":51,
              "seq-number":"0x00000188",
              "chksum":"0x9f3b",
              "holdtime":1155,
              "att-p-ol":"0/0/0",
              "ext-reach":{
                "mt-id":"Extended",
                "id":"0023.0000.0001.00",
                "metric":0
              }
            },
            {
              "lsp":{
                "id":"0023.0000.0001.00-00",
                "own":"*"
              },
              "pdu-len":86,
              "seq-number":"0x000001ae",
              "chksum":"0x39df",
              "holdtime":1188,
              "att-p-ol":"0/0/0",
              "protocols-supported":{
                "0":"IPv4"
              },
              "area-addr":"47",
              "te-router-id":"192.168.0.77",
              "router-capability":{
                "id":"192.168.0.77",
                "flag-d":"0",
                "flag-s":"0"
              },
              "ext-reach":{
                "mt-id":"Extended",
                "id":"0023.0000.0000.02",
                "metric":10
              },
              "ipv4":"192.168.0.77",
              "ext-ip-reach":{
              },
              "mt-id":"Extended",
              "ip-reach":"192.168.0.0/24",
              "ip-reach-metric":10,
              "down":"",
              "subtlvs":{
              }
            }
          ],
          "count":3
        }
      ]
    }
  ]
}

```