### PR TITLE
bgpd: network routing does not become valid/invalid while interface up…

### DIFF
--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -396,6 +396,7 @@ void bgp_connected_add(struct bgp *bgp, struct connected *ifc)
 		if (prefix_ipv4_any((struct prefix_ipv4 *)&p))
 			return;
 
+		bgp_static_valid_change(bgp, &p, true);
 		bgp_address_add(bgp, ifc, addr);
 
 		dest = bgp_node_get(bgp->connected_table[AFI_IP], &p);
@@ -429,6 +430,7 @@ void bgp_connected_add(struct bgp *bgp, struct connected *ifc)
 		if (IN6_IS_ADDR_LINKLOCAL(&p.u.prefix6))
 			return;
 
+		bgp_static_valid_change(bgp, &p, true);
 		bgp_address_add(bgp, ifc, addr);
 
 		dest = bgp_node_get(bgp->connected_table[AFI_IP6], &p);
@@ -460,7 +462,9 @@ void bgp_connected_delete(struct bgp *bgp, struct connected *ifc)
 		if (prefix_ipv4_any((struct prefix_ipv4 *)&p))
 			return;
 
+		bgp_static_valid_change(bgp, &p, false);
 		bgp_address_del(bgp, ifc, addr);
+		
 
 		dest = bgp_node_lookup(bgp->connected_table[AFI_IP], &p);
 	} else if (addr->family == AF_INET6) {
@@ -470,6 +474,7 @@ void bgp_connected_delete(struct bgp *bgp, struct connected *ifc)
 		if (IN6_IS_ADDR_LINKLOCAL(&p.u.prefix6))
 			return;
 
+		bgp_static_valid_change(bgp, &p, false);
 		bgp_address_del(bgp, ifc, addr);
 
 		dest = bgp_node_lookup(bgp->connected_table[AFI_IP6], &p);

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -783,6 +783,8 @@ extern void bgp_static_update(struct bgp *bgp, const struct prefix *p,
 extern void bgp_static_withdraw(struct bgp *bgp, const struct prefix *p,
 				afi_t afi, safi_t safi, struct prefix_rd *prd);
 
+void bgp_static_valid_change(struct bgp *bgp, const struct prefix *p, bool valid);
+
 extern int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
 			  const char *rd_str, const char *label_str, afi_t afi,
 			  safi_t safi, const char *rmap, int backdoor,


### PR DESCRIPTION
bgpd: network routing does not become valid/invalid while interface up/down

1. Delete the address under the interface or the interface is down, the network route should become invalid.
2. Interface up, the network route should become.

Signed-off-by: fang-yuping [fang.yuping@h3c.com](mailtofang.yuping@h3c.com)