### PR TITLE
lib: stick `XREF_SETUP` into libfrrzmq

### DIFF
--- a/lib/frr_zmq.c
+++ b/lib/frr_zmq.c
@@ -21,6 +21,8 @@
 #include "log.h"
 #include "lib_errors.h"
 
+XREF_SETUP();
+
 DEFINE_MTYPE_STATIC(LIB, ZEROMQ_CB, "ZeroMQ callback");
 
 /* libzmq's context */


### PR DESCRIPTION
Didn't catch this one when adding the warning/error (with -Werror) for missing this.  Neither the CI nor I build with ZeroMQ enabled :(.

---
fixes:
```
lib/libfrrzmq.la: warning: binary has no FRRouting.XREF note
lib/libfrrzmq.la-   one of FRR_MODULE_SETUP, FRR_DAEMON_INFO or XREF_SETUP must be used
```