### PR TITLE
bgpd: Fix SRv6 memory leaks spotted by Address Sanitizer

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1473,6 +1473,15 @@ static void bgp_srv6_init(struct bgp *bgp)
 
 static void bgp_srv6_cleanup(struct bgp *bgp)
 {
+	if (bgp->tovpn_sid_locator != NULL)
+		srv6_locator_chunk_free(&bgp->tovpn_sid_locator);
+	if (bgp->tovpn_zebra_vrf_sid_last_sent != NULL)
+		XFREE(MTYPE_BGP_SRV6_SID, bgp->tovpn_zebra_vrf_sid_last_sent);
+	if (bgp->tovpn_sid != NULL) {
+		sid_unregister(bgp, bgp->tovpn_sid);
+		XFREE(MTYPE_BGP_SRV6_SID, bgp->tovpn_sid);
+	}
+
 	if (bgp->srv6_locator_chunks)
 		list_delete(&bgp->srv6_locator_chunks);
 	if (bgp->srv6_functions)

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1473,6 +1473,20 @@ static void bgp_srv6_init(struct bgp *bgp)
 
 static void bgp_srv6_cleanup(struct bgp *bgp)
 {
+	for (afi_t afi = AFI_IP; afi < AFI_MAX; afi++) {
+		if (bgp->vpn_policy[afi].tovpn_sid_locator != NULL)
+			srv6_locator_chunk_free(
+				&bgp->vpn_policy[afi].tovpn_sid_locator);
+		if (bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent != NULL)
+			XFREE(MTYPE_BGP_SRV6_SID,
+			      bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent);
+		if (bgp->vpn_policy[afi].tovpn_sid != NULL) {
+			sid_unregister(bgp, bgp->vpn_policy[afi].tovpn_sid);
+			XFREE(MTYPE_BGP_SRV6_SID,
+			      bgp->vpn_policy[afi].tovpn_sid);
+		}
+	}
+
 	if (bgp->tovpn_sid_locator != NULL)
 		srv6_locator_chunk_free(&bgp->tovpn_sid_locator);
 	if (bgp->tovpn_zebra_vrf_sid_last_sent != NULL)
@@ -4145,18 +4159,6 @@ void bgp_free(struct bgp *bgp)
 		if (bgp->vpn_policy[afi].tovpn_rd_pretty)
 			XFREE(MTYPE_BGP_NAME,
 			      bgp->vpn_policy[afi].tovpn_rd_pretty);
-		if (bgp->vpn_policy[afi].tovpn_sid_locator != NULL)
-			srv6_locator_chunk_free(
-				&bgp->vpn_policy[afi].tovpn_sid_locator);
-		if (bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent != NULL)
-			XFREE(MTYPE_BGP_SRV6_SID,
-			      bgp->vpn_policy[afi]
-				      .tovpn_zebra_vrf_sid_last_sent);
-		if (bgp->vpn_policy[afi].tovpn_sid != NULL) {
-			sid_unregister(bgp, bgp->vpn_policy[afi].tovpn_sid);
-			XFREE(MTYPE_BGP_SRV6_SID,
-			      bgp->vpn_policy[afi].tovpn_sid);
-		}
 	}
 	bgp_srv6_cleanup(bgp);
 	bgp_confederation_id_unset(bgp);


### PR DESCRIPTION
Fix a couple of memory leaks spotted by Address Sanitizer:

```

=================================================================
==970960==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 592 byte(s) in 2 object(s) allocated from:
    #0 0xfeb98b28a4b4 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    https://github.com/FRRouting/frr/pull/1 0xfeb98ae572f8 in qcalloc lib/memory.c:105
    https://github.com/FRRouting/frr/issues/2 0xfeb98ae76138 in srv6_locator_chunk_alloc lib/srv6.c:138
    https://github.com/FRRouting/frr/issues/3 0xb7f3c8508fa0 in ensure_vrf_tovpn_sid_per_vrf bgpd/bgp_mplsvpn.c:831
    https://github.com/FRRouting/frr/issues/4 0xb7f3c8509494 in ensure_vrf_tovpn_sid bgpd/bgp_mplsvpn.c:866
    https://github.com/FRRouting/frr/pull/5 0xb7f3c85028a8 in vpn_leak_postchange bgpd/bgp_mplsvpn.h:289
    https://github.com/FRRouting/frr/pull/6 0xb7f3c851a7c0 in vpn_leak_postchange_all bgpd/bgp_mplsvpn.c:3769
    https://github.com/FRRouting/frr/pull/7 0xb7f3c86f6ef0 in bgp_zebra_process_srv6_locator_chunk bgpd/bgp_zebra.c:3378
    https://github.com/FRRouting/frr/pull/8 0xfeb98afa6e14 in zclient_read lib/zclient.c:4608
    https://github.com/FRRouting/frr/issues/9 0xfeb98af3d684 in event_call lib/event.c:2011
    https://github.com/FRRouting/frr/pull/10 0xfeb98ae2788c in frr_run lib/libfrr.c:1217
    https://github.com/FRRouting/frr/issues/11 0xb7f3c83cbf0c in main bgpd/bgp_main.c:545
    https://github.com/FRRouting/frr/pull/12 0xfeb98a8973f8 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    https://github.com/FRRouting/frr/pull/13 0xfeb98a8974c8 in __libc_start_main_impl ../csu/libc-start.c:392
    https://github.com/FRRouting/frr/issues/14 0xb7f3c83c832c in _start (/usr/lib/frr/bgpd+0x2d832c)

Direct leak of 32 byte(s) in 2 object(s) allocated from:
    #0 0xfeb98b28a4b4 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    https://github.com/FRRouting/frr/pull/1 0xfeb98ae572f8 in qcalloc lib/memory.c:105
    https://github.com/FRRouting/frr/issues/2 0xb7f3c8508fd8 in ensure_vrf_tovpn_sid_per_vrf bgpd/bgp_mplsvpn.c:832
    https://github.com/FRRouting/frr/issues/3 0xb7f3c8509494 in ensure_vrf_tovpn_sid bgpd/bgp_mplsvpn.c:866
    https://github.com/FRRouting/frr/issues/4 0xb7f3c85028a8 in vpn_leak_postchange bgpd/bgp_mplsvpn.h:289
    https://github.com/FRRouting/frr/pull/5 0xb7f3c851a7c0 in vpn_leak_postchange_all bgpd/bgp_mplsvpn.c:3769
    https://github.com/FRRouting/frr/pull/6 0xb7f3c86f6ef0 in bgp_zebra_process_srv6_locator_chunk bgpd/bgp_zebra.c:3378
    https://github.com/FRRouting/frr/pull/7 0xfeb98afa6e14 in zclient_read lib/zclient.c:4608
    https://github.com/FRRouting/frr/pull/8 0xfeb98af3d684 in event_call lib/event.c:2011
    https://github.com/FRRouting/frr/issues/9 0xfeb98ae2788c in frr_run lib/libfrr.c:1217
    https://github.com/FRRouting/frr/pull/10 0xb7f3c83cbf0c in main bgpd/bgp_main.c:545
    https://github.com/FRRouting/frr/issues/11 0xfeb98a8973f8 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    https://github.com/FRRouting/frr/pull/12 0xfeb98a8974c8 in __libc_start_main_impl ../csu/libc-start.c:392
    https://github.com/FRRouting/frr/pull/13 0xb7f3c83c832c in _start (/usr/lib/frr/bgpd+0x2d832c)

Direct leak of 32 byte(s) in 2 object(s) allocated from:
    #0 0xfeb98b28a4b4 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    https://github.com/FRRouting/frr/pull/1 0xfeb98ae572f8 in qcalloc lib/memory.c:105
    https://github.com/FRRouting/frr/issues/2 0xb7f3c8506520 in vpn_leak_zebra_vrf_sid_update_per_vrf bgpd/bgp_mplsvpn.c:439
    https://github.com/FRRouting/frr/issues/3 0xb7f3c85068d8 in vpn_leak_zebra_vrf_sid_update bgpd/bgp_mplsvpn.c:459
    https://github.com/FRRouting/frr/issues/4 0xb7f3c86f6aec in bgp_ifp_create bgpd/bgp_zebra.c:3345
    https://github.com/FRRouting/frr/pull/5 0xfeb98adfd3f8 in hook_call_if_real lib/if.c:48
    https://github.com/FRRouting/frr/pull/6 0xfeb98adfe750 in if_new_via_zapi lib/if.c:181
    https://github.com/FRRouting/frr/pull/7 0xfeb98af98084 in zclient_interface_add lib/zclient.c:2592
    https://github.com/FRRouting/frr/pull/8 0xfeb98afa6d24 in zclient_read lib/zclient.c:4606
    https://github.com/FRRouting/frr/issues/9 0xfeb98af3d684 in event_call lib/event.c:2011
    https://github.com/FRRouting/frr/pull/10 0xfeb98ae2788c in frr_run lib/libfrr.c:1217
    https://github.com/FRRouting/frr/issues/11 0xb7f3c83cbf0c in main bgpd/bgp_main.c:545
    https://github.com/FRRouting/frr/pull/12 0xfeb98a8973f8 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    https://github.com/FRRouting/frr/pull/13 0xfeb98a8974c8 in __libc_start_main_impl ../csu/libc-start.c:392
    https://github.com/FRRouting/frr/issues/14 0xb7f3c83c832c in _start (/usr/lib/frr/bgpd+0x2d832c)

SUMMARY: AddressSanitizer: 656 byte(s) leaked in 6 allocation(s).

```