### PR TITLE
build: make clang-format ignore DEFUN/DEFPY

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -207,4 +207,21 @@ SpacesInSquareBrackets: false
 Standard: Cpp03
 TabWidth: 8
 UseTab: Always
+WhitespaceSensitiveMacros:
+  - "DEFPY"
+  - "DEFPY_HIDDEN"
+  - "DEFPY_NOSH"
+  - "DEFPY_YANG"
+  - "DEFPY_YANG_HIDDEN"
+  - "DEFPY_YANG_NOSH"
+  - "DEFSH"
+  - "DEFSH_HIDDEN"
+  - "DEFUN"
+  - "DEFUN_HIDDEN"
+  - "DEFUN_NOSH"
+  - "DEFUN_YANG"
+  - "DEFUN_YANG_HIDDEN"
+  - "DEFUN_YANG_NOSH"
+  - "DEFUNSH"
+  - "DEFUNSH_HIDDEN"
 ...


### PR DESCRIPTION
This makes clang-format not wreck all our hand-formatted DEFUN/DEFPY statements.  We apparently missed this option when we originally looked at setting up the .clang-format control file...

---
_how did we not see this option earlier, this is such a continuous (even if small) nuisance_