### PR TITLE
lib, vtysh: fix 'show ip[v6] access-list ... json' formatting

### DIFF
--- a/lib/filter.c
+++ b/lib/filter.c
@@ -458,7 +458,6 @@ static int filter_show(struct vty *vty, const char *name, afi_t afi,
 	struct filter_cisco *filter;
 	bool first;
 	json_object *json = NULL;
-	json_object *json_proto = NULL;
 
 	master = access_master_get(afi);
 	if (master == NULL) {
@@ -469,12 +468,7 @@ static int filter_show(struct vty *vty, const char *name, afi_t afi,
 
 	if (use_json)
 		json = json_object_new_object();
-
-	/* Print the name of the protocol */
-	if (json) {
-		json_proto = json_object_new_object();
-		json_object_object_add(json, frr_protoname, json_proto);
-	} else
+	else
 		vty_out(vty, "%s:\n", frr_protoname);
 
 	for (access = master->str.head; access; access = access->next) {
@@ -496,7 +490,7 @@ static int filter_show(struct vty *vty, const char *name, afi_t afi,
 
 				if (json) {
 					json_acl = json_object_new_object();
-					json_object_object_add(json_proto,
+					json_object_object_add(json,
 							       access->name,
 							       json_acl);
 
@@ -596,7 +590,7 @@ DEFUN (show_mac_access_list_name,
 	return filter_show(vty, argv[3]->arg, AFI_L2VPN, false);
 }
 
-DEFUN (show_ip_access_list,
+DEFUN_NOSH (show_ip_access_list,
        show_ip_access_list_cmd,
        "show ip access-list [json]",
        SHOW_STR
@@ -608,7 +602,7 @@ DEFUN (show_ip_access_list,
 	return filter_show(vty, NULL, AFI_IP, uj);
 }
 
-DEFUN (show_ip_access_list_name,
+DEFUN_NOSH (show_ip_access_list_name,
        show_ip_access_list_name_cmd,
        "show ip access-list ACCESSLIST4_NAME [json]",
        SHOW_STR
@@ -622,7 +616,7 @@ DEFUN (show_ip_access_list_name,
 	return filter_show(vty, argv[idx_acl]->arg, AFI_IP, uj);
 }
 
-DEFUN (show_ipv6_access_list,
+DEFUN_NOSH (show_ipv6_access_list,
        show_ipv6_access_list_cmd,
        "show ipv6 access-list [json]",
        SHOW_STR
@@ -634,7 +628,7 @@ DEFUN (show_ipv6_access_list,
 	return filter_show(vty, NULL, AFI_IP6, uj);
 }
 
-DEFUN (show_ipv6_access_list_name,
+DEFUN_NOSH (show_ipv6_access_list_name,
        show_ipv6_access_list_name_cmd,
        "show ipv6 access-list ACCESSLIST6_NAME [json]",
        SHOW_STR

--- a/tests/topotests/nb_config/test_nb_config.py
+++ b/tests/topotests/nb_config/test_nb_config.py
@@ -50,7 +50,7 @@ def test_access_list_config_ordering(tgen):
     output = r1.vtysh_cmd("show ip access-list test json")
     got = json.loads(output)
     expected = json.loads(
-        '{"ZEBRA":{"test":{"type":"Standard", "addressFamily":"IPv4", "rules":[{"sequenceNumber":1, "filterType":"permit", "address":"10.0.0.1", "mask":"0.0.0.0"}]}}}'
+        '{"zebra":{"test":{"type":"Standard", "addressFamily":"IPv4", "rules":[{"sequenceNumber":1, "filterType":"permit", "address":"10.0.0.1", "mask":"0.0.0.0"}]}}}'
     )
     result = json_cmp(got, expected)
     assert result is None
@@ -63,7 +63,7 @@ def test_access_list_config_ordering(tgen):
     output = r1.vtysh_cmd("show ip access-list test json")
     got = json.loads(output)
     expected = json.loads(
-        '{"ZEBRA":{"test":{"type":"Zebra", "addressFamily":"IPv4", "rules":[{"sequenceNumber":1, "filterType":"permit", "prefix":"10.0.0.0/8", "exact-match":false}]}}}'
+        '{"zebra":{"test":{"type":"Zebra", "addressFamily":"IPv4", "rules":[{"sequenceNumber":1, "filterType":"permit", "prefix":"10.0.0.0/8", "exact-match":false}]}}}'
     )
     result = json_cmp(got, expected)
     assert result is None

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -68,6 +68,10 @@ extern struct event_loop *master;
 	VTYSH_ZEBRA | VTYSH_RIPD | VTYSH_RIPNGD | VTYSH_OSPFD | VTYSH_OSPF6D | \
 		VTYSH_BGPD | VTYSH_ISISD | VTYSH_PIMD | VTYSH_EIGRPD |         \
 		VTYSH_FABRICD
+#define VTYSH_ACCESS_LIST_SHOW                                                 \
+	VTYSH_ZEBRA | VTYSH_RIPD | VTYSH_RIPNGD | VTYSH_OSPFD | VTYSH_OSPF6D | \
+		VTYSH_BGPD | VTYSH_ISISD | VTYSH_PIMD | VTYSH_EIGRPD |         \
+		VTYSH_FABRICD
 #define VTYSH_PREFIX_LIST_SHOW                                                 \
 	VTYSH_ZEBRA | VTYSH_RIPD | VTYSH_RIPNGD | VTYSH_OSPFD | VTYSH_OSPF6D | \
 		VTYSH_BGPD | VTYSH_ISISD | VTYSH_PIMD | VTYSH_EIGRPD |         \


### PR DESCRIPTION
Similarly to recently fixed 'show ip[v6] prefix-list ...' - PR#15750, json output is not valid for 'show ip[v6] access-list ... json' commands, as it goes through all the running daemons and for each one it calls 'filter_show' creating a new json object. To aggreagate the output and create a valid json that can later be parsed, the commands were moved to vtysh and formatted accordingly

Before and after for json objects the same as here: [PR#15750](https://github.com/FRRouting/frr/pull/15750)