### PR TITLE
build: throw in a few more `XREF_SETUP`

### DIFF
--- a/grpc/frrgrpc_pb.c
+++ b/grpc/frrgrpc_pb.c
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: ISC
+/*
+ * libfrrgrpc_pb library stub source
+ */
+
+#include "config.h"
+#include "xref.h"
+
+XREF_SETUP();

--- a/grpc/subdir.am
+++ b/grpc/subdir.am
@@ -10,6 +10,10 @@ nodist_grpc_libfrrgrpc_pb_la_SOURCES = \
 	grpc/frr-northbound.pb.cc \
 	grpc/frr-northbound.grpc.pb.cc \
 	# end
+
+grpc_libfrrgrpc_pb_la_SOURCES = \
+	grpc/frrgrpc_pb.c \
+	# end
 endif
 
 CLEANFILES += \

--- a/mlag/mlag_pb.c
+++ b/mlag/mlag_pb.c
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: ISC
+/*
+ * libmlag_pb library stub
+ */
+
+#include "config.h"
+#include "xref.h"
+
+XREF_SETUP();

--- a/mlag/subdir.am
+++ b/mlag/subdir.am
@@ -5,6 +5,7 @@ endif
 mlag_libmlag_pb_la_LDFLAGS = $(LIB_LDFLAGS) -version-info 0:0:0
 mlag_libmlag_pb_la_CPPFLAGS = $(AM_CPPFLAGS) $(PROTOBUF_C_CFLAGS)
 mlag_libmlag_pb_la_SOURCES = \
+	mlag/mlag_pb.c \
 	# end
 
 nodist_mlag_libmlag_pb_la_SOURCES = \


### PR DESCRIPTION
This really should be all of them.

---
The two pceplib ones won't in fact trigger the warning because they're `noinst_LTLIBRARIES`, and those are not scanned for xrefs. `mlag_pb` and `frrgrpc_pb` do trigger the warning.