### PR TITLE
*: Modify agentx to be allowed to be called

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -26,6 +26,7 @@
 #include "bfd.h"
 #include "libfrr.h"
 #include "ns.h"
+#include "libagentx.h"
 
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_attr.h"
@@ -516,7 +517,9 @@ int main(int argc, char **argv)
 		bgp_option_set(BGP_OPT_NO_ZEBRA);
 	bgp_error_init();
 	/* Initializations. */
+	libagentx_init();
 	bgp_vrf_init();
+
 
 #ifdef HAVE_SCRIPTING
 	bgp_script_init();

--- a/eigrpd/eigrp_main.c
+++ b/eigrpd/eigrp_main.c
@@ -36,6 +36,7 @@
 #include "distribute.h"
 #include "libfrr.h"
 #include "routemap.h"
+#include "libagentx.h"
 //#include "if_rmap.h"
 
 #include "eigrpd/eigrp_structs.h"
@@ -178,9 +179,11 @@ int main(int argc, char **argv, char **envp)
 
 	/* EIGRP master init. */
 	eigrp_master_init();
+
 	eigrp_om->master = frr_init();
 	master = eigrp_om->master;
 
+	libagentx_init();
 	eigrp_error_init();
 	eigrp_vrf_init();
 	vrf_init(NULL, NULL, NULL, NULL);

--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -28,6 +28,7 @@
 #include "libfrr.h"
 #include "routemap.h"
 #include "affinitymap.h"
+#include "libagentx.h"
 
 #include "isisd/isis_affinitymap.h"
 #include "isisd/isis_constants.h"
@@ -307,6 +308,7 @@ int main(int argc, char **argv, char **envp)
 	/*
 	 *  initializations
 	 */
+	libagentx_init();
 	cmd_init_config_callbacks(isis_config_start, isis_config_end);
 	isis_error_init();
 	access_list_init();

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -36,6 +36,7 @@
 #include "libfrr.h"
 #include "lib_errors.h"
 #include "zlog_recirculate.h"
+#include "libagentx.h"
 
 static void		 ldpd_shutdown(void);
 static pid_t		 start_child(enum ldpd_process, char *, int, int, int);
@@ -370,6 +371,7 @@ main(int argc, char *argv[])
 	zlog_recirculate_subscribe(master, pipe_lde_log[0]);
 	zlog_recirculate_subscribe(master, pipe_ldpe_log[0]);
 
+	libagentx_init();
 	vrf_init(NULL, NULL, NULL, NULL);
 	access_list_init();
 	ldp_vty_init();

--- a/lib/libagentx.c
+++ b/lib/libagentx.c
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* SNMP cli support
+ * Copyright (C) 2024 Donald Sharp <sharpd@nvidia.com> NVIDIA Corporation
+ */
+#include <zebra.h>
+
+#include "lib/hook.h"
+#include "lib/libagentx.h"
+#include "command.h"
+
+DEFINE_HOOK(agentx_cli_enabled, (), ());
+DEFINE_HOOK(agentx_cli_disabled, (), ());
+
+bool agentx_enabled;
+
+/* AgentX node. */
+static int config_write_agentx(struct vty *vty)
+{
+	if (agentx_enabled)
+		vty_out(vty, "agentx\n");
+	return 1;
+}
+
+static struct cmd_node agentx_node = {
+	.name = "smux",
+	.node = SMUX_NODE,
+	.prompt = "",
+	.config_write = config_write_agentx,
+};
+
+DEFUN(agentx_enable, agentx_enable_cmd, "agentx",
+      "SNMP AgentX protocol settings\n")
+{
+	if (!hook_have_hooks(agentx_cli_enabled)) {
+		zlog_info(
+			"agentx specified but the agentx Module is not loaded, is this intentional?");
+
+		return CMD_SUCCESS;
+	}
+
+	hook_call(agentx_cli_enabled);
+
+	return CMD_SUCCESS;
+}
+
+DEFUN(no_agentx, no_agentx_cmd, "no agentx",
+      NO_STR "SNMP AgentX protocol settings\n")
+{
+	vty_out(vty, "SNMP AgentX support cannot be disabled once enabled\n");
+	if (!hook_call(agentx_cli_disabled))
+		return CMD_WARNING_CONFIG_FAILED;
+
+	return CMD_SUCCESS;
+}
+
+void libagentx_init(void)
+{
+	agentx_enabled = false;
+
+	install_node(&agentx_node);
+	install_element(CONFIG_NODE, &agentx_enable_cmd);
+	install_element(CONFIG_NODE, &no_agentx_cmd);
+}

--- a/lib/libagentx.h
+++ b/lib/libagentx.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* SNMP cli support
+ * Copyright (C) 2024 Donald Sharp <sharpd@nvidia.com> NVIDIA Corporation
+ */
+#ifndef __LIBAGENTX_H__
+#define __LIBAGENTX_H__
+
+extern void libagentx_init(void);
+extern bool agentx_enabled;
+
+DECLARE_HOOK(agentx_cli_enabled, (), ());
+DECLARE_HOOK(agentx_cli_disabled, (), ());
+
+#endif

--- a/lib/smux.h
+++ b/lib/smux.h
@@ -99,6 +99,7 @@ struct index_oid {
  */
 extern bool smux_enabled(void);
 
+extern void libagentx_init(void);
 extern void smux_init(struct event_loop *tm);
 extern void smux_agentx_enable(void);
 extern void smux_register_mib(const char *, struct variable *, size_t, int,

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -58,6 +58,7 @@ lib_libfrr_la_SOURCES = \
 	lib/ldp_sync.c \
 	lib/lib_errors.c \
 	lib/lib_vty.c \
+	lib/libagentx.c \
 	lib/libfrr.c \
 	lib/libfrr_trace.c \
 	lib/linklist.c \
@@ -252,6 +253,7 @@ pkginclude_HEADERS += \
 	lib/ldp_sync.h \
 	lib/lib_errors.h \
 	lib/lib_vty.h \
+	lib/libagentx.h \
 	lib/libfrr.h \
 	lib/libfrr_trace.h \
 	lib/libospf.h \

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -24,6 +24,7 @@
 #include "vrf.h"
 #include "bfd.h"
 #include "libfrr.h"
+#include "libagentx.h"
 
 #include "ospf6d.h"
 #include "ospf6_top.h"
@@ -266,6 +267,7 @@ int main(int argc, char *argv[], char *envp[])
 	/* thread master */
 	master = om6->master;
 
+	libagentx_init();
 	keychain_init();
 	ospf6_vrf_init();
 	access_list_init();

--- a/ospfd/ospf_main.c
+++ b/ospfd/ospf_main.c
@@ -28,6 +28,7 @@
 #include "libfrr.h"
 #include "routemap.h"
 #include "keychain.h"
+#include "libagentx.h"
 
 #include "ospfd/ospfd.h"
 #include "ospfd/ospf_interface.h"
@@ -256,6 +257,7 @@ int main(int argc, char **argv)
 	master = om->master;
 
 	/* Library inits. */
+	libagentx_init();
 	ospf_debug_init();
 	ospf_vrf_init();
 

--- a/python/xref2vtysh.py
+++ b/python/xref2vtysh.py
@@ -32,7 +32,7 @@ frr_top_src = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # not quite obvious...
 
 daemon_flags = {
-    "lib/agentx.c": "VTYSH_ISISD|VTYSH_RIPD|VTYSH_OSPFD|VTYSH_OSPF6D|VTYSH_BGPD|VTYSH_ZEBRA",
+    "lib/libagentx.c": "VTYSH_ISISD|VTYSH_RIPD|VTYSH_OSPFD|VTYSH_OSPF6D|VTYSH_BGPD|VTYSH_ZEBRA",
     "lib/filter.c": "VTYSH_ACL_SHOW",
     "lib/filter_cli.c": "VTYSH_ACL_CONFIG",
     "lib/if.c": "VTYSH_INTERFACE",

--- a/ripd/rip_main.c
+++ b/ripd/rip_main.c
@@ -23,6 +23,7 @@
 #include "routemap.h"
 #include "bfd.h"
 #include "mgmt_be_client.h"
+#include "libagentx.h"
 
 #include "ripd/ripd.h"
 #include "ripd/rip_bfd.h"
@@ -190,6 +191,7 @@ int main(int argc, char **argv)
 	master = frr_init();
 
 	/* Library initialization. */
+	libagentx_init();
 	rip_error_init();
 	keychain_init_new(true);
 	rip_vrf_init();

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -26,6 +26,7 @@
 #include "routemap.h"
 #include "routing_nb.h"
 #include "mgmt_be_client.h"
+#include "libagentx.h"
 
 #include "zebra/zebra_router.h"
 #include "zebra/zebra_errors.h"
@@ -435,6 +436,7 @@ int main(int argc, char **argv)
 	zrouter.master = frr_init();
 
 	/* Zebra related initialize. */
+	libagentx_init();
 	zebra_router_init(asic_offload, notify_on_ack, v6_with_v4_nexthop);
 	zserv_init();
 	zebra_rib_init();


### PR DESCRIPTION
If you had a situation where an operator turned on ospfd with snmp but not ospf6d and agentx was configured then you get into a situation where ospf6d would complain that the config for agentx did not exist.  Let's modify the code to allow this situation to happen.

Fixes: #15896