### PR TITLE
zebra: Update Zebra DPDK >=22.11 API

### DIFF
--- a/zebra/dpdk/zebra_dplane_dpdk.h
+++ b/zebra/dpdk/zebra_dplane_dpdk.h
@@ -20,4 +20,6 @@ extern void zd_dpdk_port_show(struct vty *vty, uint16_t port_id, bool uj,
 extern void zd_dpdk_stat_show(struct vty *vty);
 extern void zd_dpdk_vty_init(void);
 
+extern struct zebra_privs_t zserv_privs;
+
 #endif


### PR DESCRIPTION
Hi,

This is my first try to fix Zebra against DPDK >= 22.11 API. Starting from this version DPDK had some changes:

> External users may still register their driver using the associated driver headers (see enable_driver_sdk meson option). **The rte_driver and rte_device objects are now opaque and must be manipulated through added accessors**.

There are few issues still:
1. To enable the DPDK we need to compile FRRouting with `--enable-dp-dpdk=yes`
2. usr/lib/*/frr/modules/zebra_dplane_dpdk.so is missing from debian/frr.install . For testing purpose I've created a script that adds this option and missing lib in the corresponding files.
3. Zebra is still crashing when I don't have any interfaces attached to DPDK. Keeps #15910 opened until we figured out the issue.

Partial solves #15910 .