### PR TITLE
bgpd: fix colored routes not installed after a switchover

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -978,8 +978,7 @@ void bgp_nexthop_update(struct vrf *vrf, struct prefix *match,
 		frr_each (bgp_nexthop_cache, &bgp->nexthop_cache_table[afi],
 			  bnc_iter) {
 			if (!prefix_same(match, &bnc_iter->prefix) ||
-			    bnc_iter->srte_color == 0 ||
-			    CHECK_FLAG(bnc_iter->flags, BGP_NEXTHOP_VALID))
+			    bnc_iter->srte_color == 0)
 				continue;
 
 			bgp_process_nexthop_update(bnc_iter, nhr, false);


### PR DESCRIPTION
On a multihomed setup with colored bgp updates, when the primary PE goes offline, only a small subset of colored bgp routes are not switching to the secondary pe.

When a switchover happens, due to a remote IP becoming unreachable, some nexthop tracking down notifications are sent, but those messages are completely ignored for colored bgp updates.

The original code has been thought for enabling the SR-TE service, when IP reachability is ok, but not when services goes offline.

Fix this by extending the down notification mechanism for colored routes too.

Fixes: 545aeef1d13e ("bgpd: extend the NHT code to understand SR-TE colors")