### PR TITLE
zebra: include route source set by route-map in show output

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2369,6 +2369,14 @@ ssize_t netlink_route_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx
 				break;
 
 			setsrc = nexthop_set_src(nexthop, p->family, &src);
+			if (setsrc && IS_ZEBRA_DEBUG_KERNEL) {
+				if (p->family == AF_INET)
+					zlog_debug("%s: %pFX set src %pI4",
+						   __func__, p, &src.ipv4);
+				else if (p->family == AF_INET6)
+					zlog_debug("%s: %pFX set src %pI6",
+						   __func__, p, &src.ipv6);
+			}
 		}
 
 		if (setsrc) {
@@ -2411,6 +2419,16 @@ ssize_t netlink_route_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx
 
 				setsrc = nexthop_set_src(nexthop, p->family,
 							 &src);
+				if (setsrc && IS_ZEBRA_DEBUG_KERNEL) {
+					if (p->family == AF_INET)
+						zlog_debug("%s: %pFX set src %pI4",
+							   __func__, p,
+							   &src.ipv4);
+					else if (p->family == AF_INET6)
+						zlog_debug("%s: %pFX set src %pI6",
+							   __func__, p,
+							   &src.ipv6);
+				}
 				continue;
 			}
 
@@ -2472,6 +2490,16 @@ ssize_t netlink_route_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx
 
 				setsrc = nexthop_set_src(nexthop, p->family,
 							 &src);
+				if (setsrc && IS_ZEBRA_DEBUG_KERNEL) {
+					if (p->family == AF_INET)
+						zlog_debug("%s: %pFX set src %pI4",
+							   __func__, p,
+							   &src.ipv4);
+					else if (p->family == AF_INET6)
+						zlog_debug("%s: %pFX set src %pI6",
+							   __func__, p,
+							   &src.ipv6);
+				}
 				continue;
 			}
 

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -45,8 +45,10 @@ bool rnh_get_hide_backups(void);
 
 void show_nexthop_json_helper(json_object *json_nexthop,
 			      const struct nexthop *nexthop,
+			      const struct route_node *rn,
 			      const struct route_entry *re);
-void show_route_nexthop_helper(struct vty *vty, const struct route_entry *re,
+void show_route_nexthop_helper(struct vty *vty, const struct route_node *rn,
+			       const struct route_entry *re,
 			       const struct nexthop *nexthop);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Include the prefix source address when set by a route-map in show output for routes, in various formats.
Add some debugs when encoding netlink route messages with a source address.