### PR TITLE
zebra: fix mpls command

### DIFF
--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -2638,8 +2638,16 @@ int zebra_mpls_write_fec_config(struct vty *vty, struct zebra_vrf *zvrf)
 				continue;
 
 			write = 1;
-			vty_out(vty, "mpls label bind %pFX %s\n", &rn->p,
-				label2str(fec->label, 0, lstr, BUFSIZ));
+
+			if (fec->label == MPLS_LABEL_IPV4_EXPLICIT_NULL ||
+			    fec->label == MPLS_LABEL_IPV6_EXPLICIT_NULL)
+				strlcpy(lstr, "explicit-null", sizeof(lstr));
+			else if (fec->label == MPLS_LABEL_IMPLICIT_NULL)
+				strlcpy(lstr, "implicit-null", sizeof(lstr));
+			else
+				snprintf(lstr, sizeof(lstr), "%d", fec->label);
+
+			vty_out(vty, "mpls label bind %pFX %s\n", &rn->p, lstr);
 		}
 	}
 

--- a/zebra/zebra_mpls_vty.c
+++ b/zebra/zebra_mpls_vty.c
@@ -247,7 +247,7 @@ DEFUN (mpls_label_bind,
 
 DEFUN (no_mpls_label_bind,
        no_mpls_label_bind_cmd,
-       "no mpls label bind <A.B.C.D/M|X:X::X:X/M> [<(16-1048575)|implicit-null>]",
+       "no mpls label bind <A.B.C.D/M|X:X::X:X/M> [<(16-1048575)|implicit-null|explicit-null>]",
        NO_STR
        MPLS_STR
        "Label configuration\n"
@@ -255,7 +255,8 @@ DEFUN (no_mpls_label_bind,
        "IPv4 prefix\n"
        "IPv6 prefix\n"
        "MPLS Label to bind\n"
-       "Use Implicit-Null Label\n")
+       "Use Implicit-Null Label\n"
+       "Use Explicit-Null Label\n")
 {
 	return zebra_mpls_bind(vty, 0, argv[4]->arg, NULL);
 }


### PR DESCRIPTION
Configured with "mpls label bind 1.1.1.1/32 explicit-null", the running configuration is:
```
!
mpls label bind 1.1.1.1/32 IPv4 Explicit Null
!
```

After this commit, the running configuration is:
```
!
mpls label bind 1.1.1.1/32 explicit-null
!
```

And add the support for the "no" form:
```
anlan(config)# mpls label bind 1.1.1.1/32 explicit-null
anlan(config)# no mpls label bind  1.1.1.1/32 explicit-null
```