### PR TITLE
isisd: fix heap-after-free with prefix sid

### DIFF
--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -703,6 +703,7 @@ static void isis_spf_add_local(struct isis_spftree *spftree,
 		} else { /* vertex->d_N > cost */
 			/*         f) */
 			isis_vertex_queue_delete(&spftree->tents, vertex);
+			hash_release(spftree->prefix_sids, vertex);
 			isis_vertex_del(vertex);
 		}
 	}
@@ -808,6 +809,7 @@ static void process_N(struct isis_spftree *spftree, enum vertextype vtype,
 			/*      4) */
 		} else {
 			isis_vertex_queue_delete(&spftree->tents, vertex);
+			hash_release(spftree->prefix_sids, vertex);
 			isis_vertex_del(vertex);
 		}
 	}


### PR DESCRIPTION
Trying to build a new topotest based on the attached commit but the following head-after-free error is raised.

```
==2334217==ERROR: AddressSanitizer: heap-use-after-free on address 0x61000001d0a0 at pc 0x563828c8de6f bp 0x7fffbdaee560 sp 0x7fffbdaee558
READ of size 1 at 0x61000001d0a0 thread T0
    #0 0x563828c8de6e in prefix_sid_cmp isisd/isis_spf.c:187
    #1 0x7f84b8204f71 in hash_get lib/hash.c:142
    #2 0x7f84b82055ec in hash_lookup lib/hash.c:184
    #3 0x563828c8e185 in isis_spf_prefix_sid_lookup isisd/isis_spf.c:209
    #4 0x563828c90642 in isis_spf_add2tent isisd/isis_spf.c:598
    #5 0x563828c91cd0 in process_N isisd/isis_spf.c:824
    #6 0x563828c93852 in isis_spf_process_lsp isisd/isis_spf.c:1041
    #7 0x563828c98dde in isis_spf_loop isisd/isis_spf.c:1821
    #8 0x563828c998de in isis_run_spf isisd/isis_spf.c:1983
    #9 0x563828c99c7b in isis_run_spf_with_protection isisd/isis_spf.c:2009
    #10 0x563828c9a60d in isis_run_spf_cb isisd/isis_spf.c:2090
    #11 0x7f84b835c72d in event_call lib/event.c:2011
    #12 0x7f84b8236d93 in frr_run lib/libfrr.c:1217
    #13 0x563828c21918 in main isisd/isis_main.c:346
    #14 0x7f84b7e4fd09 in __libc_start_main ../csu/libc-start.c:308
    #15 0x563828c20df9 in _start (/usr/lib/frr/isisd+0xf5df9)

0x61000001d0a0 is located 96 bytes inside of 184-byte region [0x61000001d040,0x61000001d0f8)
freed by thread T0 here:
    #0 0x7f84b88a9b6f in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:123
    #1 0x7f84b8263bae in qfree lib/memory.c:130
    #2 0x563828c8e433 in isis_vertex_del isisd/isis_spf.c:249
    #3 0x563828c91c95 in process_N isisd/isis_spf.c:811
    #4 0x563828c93852 in isis_spf_process_lsp isisd/isis_spf.c:1041
    #5 0x563828c98dde in isis_spf_loop isisd/isis_spf.c:1821
    #6 0x563828c998de in isis_run_spf isisd/isis_spf.c:1983
    #7 0x563828c99c7b in isis_run_spf_with_protection isisd/isis_spf.c:2009
    #8 0x563828c9a60d in isis_run_spf_cb isisd/isis_spf.c:2090
    #9 0x7f84b835c72d in event_call lib/event.c:2011
    #10 0x7f84b8236d93 in frr_run lib/libfrr.c:1217
    #11 0x563828c21918 in main isisd/isis_main.c:346
    #12 0x7f84b7e4fd09 in __libc_start_main ../csu/libc-start.c:308

previously allocated by thread T0 here:
    #0 0x7f84b88aa037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7f84b8263a6c in qcalloc lib/memory.c:105
    #2 0x563828c8e262 in isis_vertex_new isisd/isis_spf.c:225
    #3 0x563828c904db in isis_spf_add2tent isisd/isis_spf.c:588
    #4 0x563828c91cd0 in process_N isisd/isis_spf.c:824
    #5 0x563828c93852 in isis_spf_process_lsp isisd/isis_spf.c:1041
    #6 0x563828c98dde in isis_spf_loop isisd/isis_spf.c:1821
    #7 0x563828c998de in isis_run_spf isisd/isis_spf.c:1983
    #8 0x563828c99c7b in isis_run_spf_with_protection isisd/isis_spf.c:2009
    #9 0x563828c9a60d in isis_run_spf_cb isisd/isis_spf.c:2090
    #10 0x7f84b835c72d in event_call lib/event.c:2011
    #11 0x7f84b8236d93 in frr_run lib/libfrr.c:1217
    #12 0x563828c21918 in main isisd/isis_main.c:346
    #13 0x7f84b7e4fd09 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: heap-use-after-free isisd/isis_spf.c:187 in prefix_sid_cmp
Shadow bytes around the buggy address:
  0x0c207fffb9c0: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c207fffb9d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c207fffb9e0: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c207fffb9f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c207fffba00: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
=>0x0c207fffba10: fd fd fd fd[fd]fd fd fd fd fd fd fd fd fd fd fa
  0x0c207fffba20: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c207fffba30: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c207fffba40: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c207fffba50: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c207fffba60: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==2334217==ABORTING
```
