### PR TITLE
tests: embed YANG in mgmtd unit-test bin

### DIFF
--- a/tests/lib/subdir.am
+++ b/tests/lib/subdir.am
@@ -34,6 +34,10 @@ tests_lib_test_grpc_CXXFLAGS = $(WERROR) $(TESTS_CXXFLAGS)
 tests_lib_test_grpc_CPPFLAGS = $(TESTS_CPPFLAGS)
 tests_lib_test_grpc_LDADD = $(GRPC_TESTS_LDADD)
 tests_lib_test_grpc_SOURCES = tests/lib/test_grpc.cpp
+nodist_tests_lib_test_grpc_SOURCES = \
+	yang/frr-bfdd.yang.c \
+	yang/frr-staticd.yang.c \
+	# end
 
 
 ##############################################################################


### PR DESCRIPTION
`make check` should run w/o installing FRR first. Thus we need to embed the yang modules otherwise mgmtd unit-test fails.