### PR TITLE
zebra: Deny the routes if ip protocol CLI refers to an undefined rmap

### DIFF
--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -299,8 +299,7 @@ int ip_protocol_rm_add(struct zebra_vrf *zvrf, const char *rmap, int rtype,
 		route_map_lookup_by_name(PROTO_RM_NAME(zvrf, afi, rtype));
 	route_map_counter_increment(PROTO_RM_MAP(zvrf, afi, rtype));
 
-	if (PROTO_RM_MAP(zvrf, afi, rtype)) {
-
+	if (PROTO_RM_NAME(zvrf, afi, rtype)) {
 		if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 			zlog_debug(
 				"%u: IPv4 Routemap config for protocol %d scheduling RIB processing",
@@ -326,7 +325,7 @@ int ip_protocol_rm_del(struct zebra_vrf *zvrf, const char *rmap, int rtype,
 	if (!rmap || strcmp(rmap, PROTO_RM_NAME(zvrf, afi, rtype)) == 0) {
 
 		route_map_counter_decrement(PROTO_RM_MAP(zvrf, afi, rtype));
-		if (PROTO_RM_MAP(zvrf, afi, rtype)) {
+		if (PROTO_RM_NAME(zvrf, afi, rtype)) {
 			if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 				zlog_debug(
 					"%u: IPv4 Routemap unconfig for protocol %d, scheduling RIB processing",


### PR DESCRIPTION
Currently zebra does not deny the routes if `ip protocol <proto> route-map FOO`
commmand is configured with reference to an undefined route-map (FOO in this case).
However, on FRR restart, in zebra_route_map_check() routes get denied if route-map name is available but the route-map is not defined. This change was introduced in fd303a4ba14c762550db972317e1e88528768005.

Fix:
When `ip protocol <proto> route-map FOO` CLI is configured with reference to an undefined route-map FOO, let the processing in ip_protocol_rm_add() and ip_protocol_rm_del() go through so that zebra can deny the routes instead of simply returning. This will result in consistent behavior.

Testing Done:

Before fix:
```
spine-1# configure
spine-1(config)# ip protocol bgp route-map rmap7

root@spine-1:mgmt:/var/home/cumulus# vtysh -c "show run" | grep rmap7
ip protocol bgp route-map rmap7
root@spine-1:mgmt:/var/home/cumulus#

spine-1(config)# do show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, A - Babel, D - SHARP, F - PBR, f - OpenFabric,
       Z - FRR,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

C>* 27.0.0.1/32 is directly connected, lo, 02:27:45
B>* 27.0.0.3/32 [20/0] via fe80::202:ff:fe00:21, downlink_1, weight 1, 02:27:35
B>* 27.0.0.4/32 [20/0] via fe80::202:ff:fe00:29, downlink_2, weight 1, 02:27:40
B>* 27.0.0.5/32 [20/0] via fe80::202:ff:fe00:31, downlink_3, weight 1, 02:27:40
B>* 27.0.0.6/32 [20/0] via fe80::202:ff:fe00:39, downlink_4, weight 1, 02:27:40
```

After fix:
```
spine-1(config)# ip protocol bgp route-map route-map67
spine-1(config)# do show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, A - Babel, D - SHARP, F - PBR, f - OpenFabric,
       Z - FRR,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

C>* 27.0.0.1/32 is directly connected, lo, 00:35:03
B   27.0.0.3/32 [20/0] via fe80::202:ff:fe00:21, downlink_1 inactive, weight 1, 00:34:58
B   27.0.0.4/32 [20/0] via fe80::202:ff:fe00:29, downlink_2 inactive, weight 1, 00:34:57
B   27.0.0.5/32 [20/0] via fe80::202:ff:fe00:31, downlink_3 inactive, weight 1, 00:34:57
B   27.0.0.6/32 [20/0] via fe80::202:ff:fe00:39, downlink_4 inactive, weight 1, 00:34:58
spine-1(config)#

root@spine-1:mgmt:/var/home/cumulus# ip route show
root@spine-1:mgmt:/var/home/cumulus#
```