### PR TITLE
bgpd: backpressure - Fix to withdraw evpn type-5 routes immediately

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3810,8 +3810,7 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 			 */
 			if (old_select &&
 			    is_route_parent_evpn(old_select))
-				bgp_zebra_route_install(dest, old_select, bgp,
-							false, NULL, false);
+				bgp_zebra_withdraw_actual(dest, old_select, bgp);
 
 			bgp_zebra_route_install(dest, new_select, bgp, true,
 						NULL, false);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1891,11 +1891,9 @@ static void bgp_zebra_buffer_write_ready(void)
  *                                     save new pi, mark as going to be
  *                                     withdrawan, remove install flag
  *
- *    Withdrawal       Install         Special case, send withdrawal immediately
- *                                     Leave dest on list, release old pi,
+ *    Withdrawal       Install         Leave dest on list, release old pi,
  *                                     save new pi, mark as going to be
- *                                     installed.  <see note about evpn
- *                                     in bgp_route.c in bgp_process_main_one>
+ *                                     installed.
  *    Withdrawal       Withdrawal      Leave dest on list, release old pi,
  *                                     save new pi, mark as going to be
  *                                     withdrawn.
@@ -1950,9 +1948,6 @@ void bgp_zebra_route_install(struct bgp_dest *dest, struct bgp_path_info *info,
 		dest->za_bgp_pi = info;
 	} else if (CHECK_FLAG(dest->flags, BGP_NODE_SCHEDULE_FOR_DELETE)) {
 		assert(dest->za_bgp_pi);
-		if (install & !is_evpn)
-			bgp_zebra_withdraw_actual(dest, dest->za_bgp_pi, bgp);
-
 		bgp_path_info_unlock(dest->za_bgp_pi);
 		bgp_path_info_lock(info);
 		dest->za_bgp_pi = info;


### PR DESCRIPTION
As part of backpressure changes, there is a bug where immediate withdraw is to be sent for evpn imported type-5 prefix to clear the nh neigh and RMAC entry.

Fixing this by sending withdraw immediately to keep it inline with the code today

Ticket: #3905571