### PR TITLE
bgpd: backpressure - Fix to avoid CPU hog

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -6317,9 +6317,11 @@ struct bgpevpn *bgp_evpn_new(struct bgp *bgp, vni_t vni,
 void bgp_evpn_free(struct bgp *bgp, struct bgpevpn *vpn)
 {
 	struct bgp_dest *dest = NULL;
+	uint32_t ann_count = zebra_announce_count(&bm->zebra_announce_head);
 
-	while (zebra_announce_count(&bm->zebra_announce_head)) {
+	while (ann_count) {
 		dest = zebra_announce_pop(&bm->zebra_announce_head);
+		ann_count--;
 		if (dest->za_vpn == vpn) {
 			bgp_path_info_unlock(dest->za_bgp_pi);
 			bgp_dest_unlock_node(dest);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3908,11 +3908,13 @@ int bgp_delete(struct bgp *bgp)
 	int i;
 	struct bgp_dest *dest = NULL;
 	struct graceful_restart_info *gr_info;
+	uint32_t ann_count = zebra_announce_count(&bm->zebra_announce_head);
 
 	assert(bgp);
 
-	while (zebra_announce_count(&bm->zebra_announce_head)) {
+	while (ann_count) {
 		dest = zebra_announce_pop(&bm->zebra_announce_head);
+		ann_count--;
 		if (dest->za_bgp_pi->peer->bgp == bgp) {
 			bgp_path_info_unlock(dest->za_bgp_pi);
 			bgp_dest_unlock_node(dest);


### PR DESCRIPTION
In case when bgp_evpn_free or bgp_delete is called and the announce_list has few items where vpn/bgp does not match, we add the item back to the list. Because of this the list count is always > 0 thereby hogging CPU or infinite loop.

Ticket: #3905624