### PR TITLE
isisd: fix crash when configuring the circuit type for the interface.

### DIFF
--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -3821,7 +3821,8 @@ int lib_interface_isis_circuit_type_modify(struct nb_cb_modify_args *args)
 	case NB_EV_APPLY:
 		circuit = nb_running_get_entry(args->dnode, NULL, true);
 		circuit->is_type_config = circ_type;
-		isis_circuit_is_type_set(circuit, circ_type);
+		if (!circuit->area || circuit->area->is_type == IS_LEVEL_1_AND_2)
+			isis_circuit_is_type_set(circuit, circ_type);
 		break;
 	}
 


### PR DESCRIPTION
1. When both Router A and Router B are configured with "is-type level-1," the `area->is_type` will be assigned the value `IS_LEVEL_1`, and `circuit->is_type` will also be assigned the value `IS_LEVEL_1`.
2. Configuring the circuit type "isis circuit-type level-1-2" for the interface of Router A will inadvertently call `lib_interface_isis_circuit_type_modify` to assign `circuit->is_type` the value `IS_LEVEL_1_AND_2`. This causes the hello packets reception and transmission, as well as the reception of LSP/SNP packets, to check `circuit->is_type`, allowing the level-2 hello packets to be sent and received normally, and level-2 LSP/SNP packets to be received normally.
3. When Router B modifies the configuration to "is-type level-2," and Router A and Router B establish a level-2 neighbor relationship, Router B sends level-2 LSP packets to Router A. Upon receiving these, Router A calls `isis_spf_schedule` to calculate the level-2 SPT, which results in accessing a null pointer. 

When defining the behavior of the ISIS router, the call to `isis_area_is_type_set` will check that `area->is_type` is not `IS_LEVEL_1_AND_2`, and it disallows` circuit->is_type_config` from overriding `circuit->is_type`. Therefore, when configuring the circuit type for the interface, it should also check that `area->is_type` is not `IS_LEVEL_1_AND_2` and disallow `circuit->is_type_config `from overriding `circuit->is_type`.