### PR TITLE
isisd: fix the json of display database

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -5912,9 +5912,24 @@ static void format_items_(uint16_t mtid, enum isis_tlv_context context,
 			  int indent)
 {
 	struct isis_item *i;
+	struct json_object *item_arr_json = NULL;
 
-	for (i = items->head; i; i = i->next)
-		format_item(mtid, context, type, i, buf, json, indent);
+	if (json && items->count) {
+		char item_tlv_type[16] = { 0 };
+
+		snprintf(item_tlv_type, sizeof(item_tlv_type), "tlv-%d", type);
+		item_arr_json = json_object_new_array();
+		json_object_object_add(json, item_tlv_type, item_arr_json);
+	}
+	for (i = items->head; i; i = i->next) {
+		struct json_object *item_json = NULL;
+
+		if (json && item_arr_json) {
+			item_json = json_object_new_object();
+			json_object_array_add(item_arr_json, item_json);
+		}
+		format_item(mtid, context, type, i, buf, item_json, indent);
+	}
 }
 
 static void free_item(enum isis_tlv_context tlv_context,


### PR DESCRIPTION
This LSP has two items for `tlv-22` ( other TLV with many items also has this issue ), 
but only one item for `tlv-22` is displayed by "show isis database detail json".

`show isis database detail` is:  ( More in commit log )
```
0023.0000.0000.02-00       51   0x0000019e  0x7351     683    0/0/0
  Extended Reachability: 0023.0000.0000.00 (Metric: 0)
  Extended Reachability: 0023.0000.0001.00 (Metric: 0)
```

Before: ( Only one item for `tlv-22` )
```
{
  "areas":[
    {
      "area":{
        "name":"A"
      },
      "levels":[
        {
        },
        {
          "id":2,
          "lsps":[
            {
              "lsp":{
                "id":"0023.0000.0000.00-00",
                "own":" "
              },
              "pdu-len":64,
              "seq-number":"0x000006a4",
              "chksum":"0xc137",
              "holdtime":1174,
              "att-p-ol":"0/0/0",
              "protocols-supported":{
                "0":"IPv4"
              },
              "area-addr":"47",
              "te-router-id":"73.73.73.73",
              "router-capability":{
                "id":"73.73.73.73",
                "flag-d":"0",
                "flag-s":"0"
              },
              "ipv4":"73.73.73.73",
              "ext-ip-reach":{
              },
              "mt-id":"Extended",
              "ip-reach":"44.1.1.0/24",
              "ip-reach-metric":10,
              "down":""
            },
            {
              "lsp":{
                "id":"0023.0000.0000.02-00",
                "own":" "
              },
              "pdu-len":51,
              "seq-number":"0x0000019f",
              "chksum":"0x7152",
              "holdtime":1133,
              "att-p-ol":"0/0/0",
              "ext-reach":{  <-  Only one item for tlv-22
                "mt-id":"Extended",
                "id":"0023.0000.0001.00",
                "metric":0
              }
            },
            {
              "lsp":{
                "id":"0023.0000.0001.00-00",
                "own":"*"
              },
              "pdu-len":44,
              "seq-number":"0x000001aa",
              "chksum":"0x783a",
              "holdtime":1174,
              "att-p-ol":"0/0/0",
              "protocols-supported":{
                "0":"IPv4"
              },
              "area-addr":"47",
              "ext-ip-reach":{
              },
              "mt-id":"Extended",
              "ip-reach":"44.1.1.0/24",
              "ip-reach-metric":10,
              "down":""
            }
          ],
          "count":3
        }
      ]
    }
  ]
}
```

After: ( Two items for `tlv-22` )
```
{
  "areas":[
    {
      "area":{
        "name":"A"
      },
      "levels":[
        {
        },
        {
          "id":2,
          "lsps":[
            {
              "lsp":{
                "id":"0023.0000.0000.00-00",
                "own":" "
              },
              "pdu-len":77,
              "seq-number":"0x000006a3",
              "chksum":"0x1e8b",
              "holdtime":783,
              "att-p-ol":"0/0/0",
              "protocols-supported":{
                "0":"IPv4"
              },
              "tlv-1":[
                {
                  "area-addr":"47"
                }
              ],
              "te-router-id":"73.73.73.73",
              "router-capability":{
                "id":"73.73.73.73",
                "flag-d":"0",
                "flag-s":"0"
              },
              "tlv-22":[
                {
                  "ext-reach":{
                    "mt-id":"Extended",
                    "id":"0023.0000.0000.02",
                    "metric":10
                  }
                }
              ],
              "tlv-132":[
                {
                  "ipv4":"73.73.73.73"
                }
              ],
              "tlv-135":[
                {
                  "ext-ip-reach":{
                  },
                  "mt-id":"Extended",
                  "ip-reach":"44.1.1.0/24",
                  "ip-reach-metric":10,
                  "down":""
                }
              ]
            },
            {
              "lsp":{
                "id":"0023.0000.0000.02-00",
                "own":" "
              },
              "pdu-len":51,
              "seq-number":"0x0000019e",
              "chksum":"0x7351",
              "holdtime":771,
              "att-p-ol":"0/0/0",
              "tlv-22":[ <- Two items are displayed for "tlv-22"
                {
                  "ext-reach":{
                    "mt-id":"Extended",
                    "id":"0023.0000.0000.00",
                    "metric":0
                  }
                },
                {
                  "ext-reach":{
                    "mt-id":"Extended",
                    "id":"0023.0000.0001.00",
                    "metric":0
                  }
                }
              ]
            },
            {
              "lsp":{
                "id":"0023.0000.0001.00-00",
                "own":"*"
              },
              "pdu-len":76,
              "seq-number":"0x000001a9",
              "chksum":"0x35fe",
              "holdtime":798,
              "att-p-ol":"0/0/0",
              "protocols-supported":{
                "0":"IPv4"
              },
              "tlv-1":[
                {
                  "area-addr":"47"
                }
              ],
              "te-router-id":"192.168.0.77",
              "router-capability":{
                "id":"192.168.0.77",
                "flag-d":"0",
                "flag-s":"0"
              },
              "tlv-22":[
                {
                  "ext-reach":{
                    "mt-id":"Extended",
                    "id":"0023.0000.0000.02",
                    "metric":10
                  }
                }
              ],
              "tlv-132":[
                {
                  "ipv4":"192.168.0.77"
                }
              ],
              "tlv-135":[
                {
                  "ext-ip-reach":{
                  },
                  "mt-id":"Extended",
                  "ip-reach":"44.1.1.0/24",
                  "ip-reach-metric":10,
                  "down":""
                }
              ]
            }
          ],
          "count":3
        }
      ]
    }
  ]
}
```