### PR TITLE
bgpd: fix route leaking from the default l3vrf

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -2240,8 +2240,9 @@ static void vpn_leak_to_vrf_update_onevrf(struct bgp *to_bgp,   /* to */
 	 * Let the kernel to decide with double lookup the real next-hop
 	 * interface when installing the route.
 	 */
-	if (src_bgp || bpi_ultimate->sub_type == BGP_ROUTE_STATIC ||
-	    bpi_ultimate->sub_type == BGP_ROUTE_REDISTRIBUTE) {
+	if (src_vrf->vrf_id != VRF_DEFAULT &&
+	    (src_bgp || bpi_ultimate->sub_type == BGP_ROUTE_STATIC ||
+	     bpi_ultimate->sub_type == BGP_ROUTE_REDISTRIBUTE)) {
 		ifp = if_get_vrf_loopback(src_vrf->vrf_id);
 		if (ifp)
 			static_attr.nh_ifindex = ifp->ifindex;

--- a/tests/topotests/bgp_vrf_route_leak_basic/test_bgp-vrf-route-leak-basic.py
+++ b/tests/topotests/bgp_vrf_route_leak_basic/test_bgp-vrf-route-leak-basic.py
@@ -116,7 +116,7 @@ def test_vrf_route_leak_donna():
                 "nexthops": [
                     {
                         "fib": True,
-                        "interfaceName": "lo",
+                        "interfaceName": "dummy0",
                         "vrf": "default",
                         "active": True,
                     },

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/zebra-vrf-ray.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/zebra-vrf-ray.txt
@@ -1,9 +1,9 @@
 VRF ray:
 B   10.0.1.0/24 [20/20] via 10.0.20.1, r2-eth1 (vrf default) inactive, weight 1, XX:XX:XX
-B   10.0.2.0/24 [20/0] is directly connected, lo (vrf default) inactive, weight 1, XX:XX:XX
+B   10.0.2.0/24 [20/0] is directly connected, r2-eth0 (vrf default) inactive, weight 1, XX:XX:XX
 B>* 10.0.3.0/24 [20/20] via 10.0.20.1, r2-eth1 (vrf default), weight 1, XX:XX:XX
 O>* 10.0.4.0/24 [110/20] via 10.0.40.4, r2-eth2, weight 1, XX:XX:XX
-B   10.0.20.0/24 [20/0] is directly connected, lo (vrf default) inactive, weight 1, XX:XX:XX
+B   10.0.20.0/24 [20/0] is directly connected, r2-eth1 (vrf default) inactive, weight 1, XX:XX:XX
 B>* 10.0.30.0/24 [20/20] via 10.0.20.1, r2-eth1 (vrf default), weight 1, XX:XX:XX
 O   10.0.40.0/24 [110/10] is directly connected, r2-eth2, weight 1, XX:XX:XX
 C>* 10.0.40.0/24 is directly connected, r2-eth2, XX:XX:XX


### PR DESCRIPTION
Leaked route from the l3VRF are installed with the loopback as the nexthop interface instead of the real interface.

> B>* 10.0.0.0/30 [20/0] is directly connected, lo (vrf default), weight 1, 00:21:01

Routing of packet from a L3VRF to the default L3VRF destined to a leak prefix fails because of the default routing rules on Linux.

> 0:      from all lookup local
> 1000:   from all lookup [l3mdev-table]
> 32766:  from all lookup main
> 32767:  from all lookup default

When the packet is received in the loopback interface, the local rules are checked without match, then the l3mdev-table says to route to the loopback. A routing loop occurs (TTL is decreasing).

> 12:26:27.928748 ens37 In  IP (tos 0x0, ttl 64, id 26402, offset 0, flags [DF], proto ICMP (1), length 84)
>     10.0.0.2 > 10.0.1.2: ICMP echo request, id 47463, seq 1, length 64
> 12:26:27.928784 red   Out IP (tos 0x0, ttl 63, id 26402, offset 0, flags [DF], proto ICMP (1), length 84)
>     10.0.0.2 > 10.0.1.2: ICMP echo request, id 47463, seq 1, length 64
> 12:26:27.928797 ens38 Out IP (tos 0x0, ttl 63, id 26402, offset 0, flags [DF], proto ICMP (1), length 84)
>     10.0.0.2 > 10.0.1.2: ICMP echo request, id 47463, seq 1, length 64

Do not set the lo interface as a nexthop interface. Keep the real interface where possible.

Fixes: db7cf73a33 ("bgpd: fix interface on leaks from redistribute connected")
Fixes: 067fbab4e4 ("bgpd: fix interface on leaks from network statement")
Fixes: 8a02d9fe1e ("bgpd: Set nh ifindex to VRF's interface, not the real")
Fixes: https://github.com/FRRouting/frr/issues/15909