### PR TITLE
ospf6d: Handling Topo Change in GR-HELPER mode for max-age lsas

### DIFF
--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -295,9 +295,7 @@ void ospf6_install_lsa(struct ospf6_lsa *lsa)
 	lsa->installed = now;
 
 	/* Topo change handling */
-	if (CHECK_LSA_TOPO_CHG_ELIGIBLE(ntohs(lsa->header->type))
-	    && !CHECK_FLAG(lsa->flag, OSPF6_LSA_DUPLICATE)) {
-
+	if (CHECK_LSA_TOPO_CHG_ELIGIBLE(ntohs(lsa->header->type))) {
 		/* check if it is new lsa ? or existing lsa got modified ?*/
 		if (!old || OSPF6_LSA_IS_CHANGED(old, lsa))
 			ospf6_helper_handle_topo_chg(ospf6, lsa);


### PR DESCRIPTION
Description:
OSPF6 GR HELPER router should  consider as TOPOCHANGE when it receives lsas with max age and should exit from Helper. But, it is not exiting from helper because this max age lsa is considered as duplicated lsa since the sender uses same seq number for max age lsa from the previous lsa update. Currently, topo change is not considered for duplicated lsas. So removed the duplicated check when validating TOPOCHNAGE.