### PR TITLE
Cleanup some OSPF6_LSA_ macros

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -553,9 +553,8 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 	lsa_header = (struct ospf6_lsa_header *)buffer;
 
 	if (route->type == OSPF6_DEST_TYPE_ROUTER) {
-		router_lsa = (struct ospf6_inter_router_lsa
-				      *)((caddr_t)lsa_header
-					 + sizeof(struct ospf6_lsa_header));
+		router_lsa = (struct ospf6_inter_router_lsa *)
+			ospf6_lsa_header_end(lsa_header);
 		p = (caddr_t)router_lsa + sizeof(struct ospf6_inter_router_lsa);
 
 		/* Fill Inter-Area-Router-LSA */
@@ -566,9 +565,8 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		router_lsa->router_id = ADV_ROUTER_IN_PREFIX(&route->prefix);
 		type = htons(OSPF6_LSTYPE_INTER_ROUTER);
 	} else {
-		prefix_lsa = (struct ospf6_inter_prefix_lsa
-				      *)((caddr_t)lsa_header
-					 + sizeof(struct ospf6_lsa_header));
+		prefix_lsa = (struct ospf6_inter_prefix_lsa *)
+			ospf6_lsa_header_end(lsa_header);
 		p = (caddr_t)prefix_lsa + sizeof(struct ospf6_inter_prefix_lsa);
 
 		/* Fill Inter-Area-Prefix-LSA */
@@ -1018,9 +1016,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 				   oa->name);
 		}
 
-		prefix_lsa =
-			(struct ospf6_inter_prefix_lsa *)OSPF6_LSA_HEADER_END(
-				lsa->header);
+		prefix_lsa = (struct ospf6_inter_prefix_lsa *)
+			ospf6_lsa_header_end(lsa->header);
 		prefix.family = AF_INET6;
 		prefix.prefixlen = prefix_lsa->prefix.prefix_length;
 		ospf6_prefix_in6_addr(&prefix.u.prefix6, prefix_lsa,
@@ -1039,11 +1036,9 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 				   oa->name);
 		}
 
-		router_lsa =
-			(struct ospf6_inter_router_lsa *)OSPF6_LSA_HEADER_END(
-				lsa->header);
-		ospf6_linkstate_prefix(router_lsa->router_id, htonl(0),
-				       &prefix);
+		router_lsa = (struct ospf6_inter_router_lsa *)
+			ospf6_lsa_header_end(lsa->header);
+		ospf6_linkstate_prefix(router_lsa->router_id, htonl(0), &prefix);
 		if (is_debug)
 			inet_ntop(AF_INET, &router_lsa->router_id, buf,
 				  sizeof(buf));
@@ -1433,9 +1428,8 @@ static char *ospf6_inter_area_prefix_lsa_get_prefix_str(struct ospf6_lsa *lsa,
 	char tbuf[16];
 
 	if (lsa != NULL) {
-		prefix_lsa =
-			(struct ospf6_inter_prefix_lsa *)OSPF6_LSA_HEADER_END(
-				lsa->header);
+		prefix_lsa = (struct ospf6_inter_prefix_lsa *)
+			ospf6_lsa_header_end(lsa->header);
 
 		ospf6_prefix_in6_addr(&in6, prefix_lsa, &prefix_lsa->prefix);
 		if (buf) {
@@ -1457,7 +1451,7 @@ static int ospf6_inter_area_prefix_lsa_show(struct vty *vty,
 	struct ospf6_inter_prefix_lsa *prefix_lsa;
 	char buf[INET6_ADDRSTRLEN];
 
-	prefix_lsa = (struct ospf6_inter_prefix_lsa *)OSPF6_LSA_HEADER_END(
+	prefix_lsa = (struct ospf6_inter_prefix_lsa *)ospf6_lsa_header_end(
 		lsa->header);
 
 	if (use_json) {
@@ -1494,9 +1488,8 @@ static char *ospf6_inter_area_router_lsa_get_prefix_str(struct ospf6_lsa *lsa,
 	struct ospf6_inter_router_lsa *router_lsa;
 
 	if (lsa != NULL) {
-		router_lsa =
-			(struct ospf6_inter_router_lsa *)OSPF6_LSA_HEADER_END(
-				lsa->header);
+		router_lsa = (struct ospf6_inter_router_lsa *)
+			ospf6_lsa_header_end(lsa->header);
 
 
 		if (buf)
@@ -1514,7 +1507,7 @@ static int ospf6_inter_area_router_lsa_show(struct vty *vty,
 	struct ospf6_inter_router_lsa *router_lsa;
 	char buf[64];
 
-	router_lsa = (struct ospf6_inter_router_lsa *)OSPF6_LSA_HEADER_END(
+	router_lsa = (struct ospf6_inter_router_lsa *)ospf6_lsa_header_end(
 		lsa->header);
 
 	ospf6_options_printbuf(router_lsa->options, buf, sizeof(buf));

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -102,9 +102,8 @@ struct ospf6_lsa *ospf6_as_external_lsa_originate(struct ospf6_route *route,
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	as_external_lsa = (struct ospf6_as_external_lsa
-				   *)((caddr_t)lsa_header
-				      + sizeof(struct ospf6_lsa_header));
+	as_external_lsa = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
+		lsa_header);
 	p = (caddr_t)((caddr_t)as_external_lsa
 		      + sizeof(struct ospf6_as_external_lsa));
 
@@ -217,7 +216,7 @@ static route_tag_t ospf6_as_external_lsa_get_tag(struct ospf6_lsa *lsa)
 	if (!lsa)
 		return 0;
 
-	external = (struct ospf6_as_external_lsa *)OSPF6_LSA_HEADER_END(
+	external = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
 		lsa->header);
 
 	if (!CHECK_FLAG(external->bits_metric, OSPF6_ASBR_BIT_T))
@@ -521,7 +520,7 @@ void ospf6_asbr_lsa_add(struct ospf6_lsa *lsa)
 	type = ntohs(lsa->header->type);
 	oa = lsa->lsdb->data;
 
-	external = (struct ospf6_as_external_lsa *)OSPF6_LSA_HEADER_END(
+	external = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
 		lsa->header);
 
 	if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL))
@@ -726,7 +725,7 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 	int type;
 	bool debug = false;
 
-	external = (struct ospf6_as_external_lsa *)OSPF6_LSA_HEADER_END(
+	external = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
 		lsa->header);
 
 	if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL) || (IS_OSPF6_DEBUG_NSSA))
@@ -2425,7 +2424,7 @@ static char *ospf6_as_external_lsa_get_prefix_str(struct ospf6_lsa *lsa,
 	char tbuf[16];
 
 	if (lsa) {
-		external = (struct ospf6_as_external_lsa *)OSPF6_LSA_HEADER_END(
+		external = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
 			lsa->header);
 
 		if (pos == 0) {
@@ -2460,7 +2459,7 @@ static int ospf6_as_external_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 	char buf[64];
 
 	assert(lsa->header);
-	external = (struct ospf6_as_external_lsa *)OSPF6_LSA_HEADER_END(
+	external = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
 		lsa->header);
 
 	/* bits */
@@ -3028,8 +3027,8 @@ ospf6_originate_summary_lsa(struct ospf6 *ospf6,
 			return;
 		}
 
-		external = (struct ospf6_as_external_lsa *)OSPF6_LSA_HEADER_END
-					(aggr_lsa->header);
+		external = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
+			aggr_lsa->header);
 		metric = (unsigned long)OSPF6_ASBR_METRIC(external);
 		tag = ospf6_as_external_lsa_get_tag(aggr_lsa);
 		mtype = CHECK_FLAG(external->bits_metric,
@@ -3177,8 +3176,7 @@ ospf6_handle_external_aggr_modify(struct ospf6 *ospf6,
 		return OSPF6_FAILURE;
 	}
 
-	asel = (struct ospf6_as_external_lsa *)
-		OSPF6_LSA_HEADER_END(lsa->header);
+	asel = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(lsa->header);
 	metric = (unsigned long)OSPF6_ASBR_METRIC(asel);
 	tag = ospf6_as_external_lsa_get_tag(lsa);
 	mtype = CHECK_FLAG(asel->bits_metric,
@@ -3367,9 +3365,8 @@ static void ospf6_handle_aggregated_exnl_rt(struct ospf6 *ospf6,
 	lsa = ospf6_lsdb_lookup(htons(OSPF6_LSTYPE_AS_EXTERNAL),
 				htonl(info->id), ospf6->router_id, ospf6->lsdb);
 	if (lsa) {
-		ext_lsa = (struct ospf6_as_external_lsa
-			*)((char *)(lsa->header)
-			+ sizeof(struct ospf6_lsa_header));
+		ext_lsa = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
+			lsa->header);
 
 		if (rt->prefix.prefixlen != ext_lsa->prefix.prefix_length)
 			return;

--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -54,9 +54,7 @@ static int ospf6_gr_lsa_originate(struct ospf6_interface *oi,
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	grace_lsa =
-		(struct ospf6_grace_lsa *)((caddr_t)lsa_header
-					   + sizeof(struct ospf6_lsa_header));
+	grace_lsa = (struct ospf6_grace_lsa *)ospf6_lsa_header_end(lsa_header);
 
 	/* Put grace period. */
 	grace_lsa->tlv_period.header.type = htons(GRACE_PERIOD_TYPE);

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -242,9 +242,7 @@ void ospf6_router_lsa_originate(struct event *thread)
 
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	router_lsa =
-		(struct ospf6_router_lsa *)((caddr_t)lsa_header
-					    + sizeof(struct ospf6_lsa_header));
+	router_lsa = (struct ospf6_router_lsa *)ospf6_lsa_header_end(lsa_header);
 
 	ospf6_router_lsa_options_set(oa, router_lsa);
 
@@ -305,10 +303,8 @@ void ospf6_router_lsa_originate(struct event *thread)
 			/* Reset Buffer to fill next Router LSA */
 			memset(buffer, 0, sizeof(buffer));
 			lsa_header = (struct ospf6_lsa_header *)buffer;
-			router_lsa =
-				(struct ospf6_router_lsa
-					 *)((caddr_t)lsa_header
-					    + sizeof(struct ospf6_lsa_header));
+			router_lsa = (struct ospf6_router_lsa *)
+				ospf6_lsa_header_end(lsa_header);
 
 			ospf6_router_lsa_options_set(oa, router_lsa);
 
@@ -568,16 +564,14 @@ void ospf6_network_lsa_originate(struct event *thread)
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
 	network_lsa =
-		(struct ospf6_network_lsa *)((caddr_t)lsa_header
-					     + sizeof(struct ospf6_lsa_header));
+		(struct ospf6_network_lsa *)ospf6_lsa_header_end(lsa_header);
 
 	/* Collect the interface's Link-LSAs to describe
 	   network's optional capabilities */
 	type = htons(OSPF6_LSTYPE_LINK);
 	for (ALL_LSDB_TYPED(oi->lsdb, type, lsa)) {
-		link_lsa = (struct ospf6_link_lsa
-				    *)((caddr_t)lsa->header
-				       + sizeof(struct ospf6_lsa_header));
+		link_lsa = (struct ospf6_link_lsa *)ospf6_lsa_header_end(
+			lsa->header);
 		network_lsa->options[0] |= link_lsa->options[0];
 		network_lsa->options[1] |= link_lsa->options[1];
 		network_lsa->options[2] |= link_lsa->options[2];
@@ -800,8 +794,7 @@ void ospf6_link_lsa_originate(struct event *thread)
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	link_lsa = (struct ospf6_link_lsa *)((caddr_t)lsa_header
-					     + sizeof(struct ospf6_lsa_header));
+	link_lsa = (struct ospf6_link_lsa *)ospf6_lsa_header_end(lsa_header);
 
 	/* Fill Link-LSA */
 	link_lsa->priority = oi->priority;
@@ -1042,9 +1035,8 @@ void ospf6_intra_prefix_lsa_originate_stub(struct event *thread)
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	intra_prefix_lsa = (struct ospf6_intra_prefix_lsa
-				    *)((caddr_t)lsa_header
-				       + sizeof(struct ospf6_lsa_header));
+	intra_prefix_lsa = (struct ospf6_intra_prefix_lsa *)ospf6_lsa_header_end(
+		lsa_header);
 
 	/* Fill Intra-Area-Prefix-LSA */
 	intra_prefix_lsa->ref_type = htons(OSPF6_LSTYPE_ROUTER);
@@ -1159,10 +1151,8 @@ void ospf6_intra_prefix_lsa_originate_stub(struct event *thread)
 			/* Prepare next buffer */
 			memset(buffer, 0, sizeof(buffer));
 			lsa_header = (struct ospf6_lsa_header *)buffer;
-			intra_prefix_lsa =
-				(struct ospf6_intra_prefix_lsa
-					 *)((caddr_t)lsa_header
-					    + sizeof(struct ospf6_lsa_header));
+			intra_prefix_lsa = (struct ospf6_intra_prefix_lsa *)
+				ospf6_lsa_header_end(lsa_header);
 
 			/* Fill Intra-Area-Prefix-LSA */
 			intra_prefix_lsa->ref_type = htons(OSPF6_LSTYPE_ROUTER);
@@ -1269,9 +1259,8 @@ void ospf6_intra_prefix_lsa_originate_transit(struct event *thread)
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	intra_prefix_lsa = (struct ospf6_intra_prefix_lsa
-				    *)((caddr_t)lsa_header
-				       + sizeof(struct ospf6_lsa_header));
+	intra_prefix_lsa = (struct ospf6_intra_prefix_lsa *)ospf6_lsa_header_end(
+		lsa_header);
 
 	/* Fill Intra-Area-Prefix-LSA */
 	intra_prefix_lsa->ref_type = htons(OSPF6_LSTYPE_NETWORK);
@@ -1668,7 +1657,8 @@ void ospf6_intra_prefix_route_ecmp_path(struct ospf6_area *oa,
 				}
 				intra_prefix_lsa =
 					(struct ospf6_intra_prefix_lsa *)
-					OSPF6_LSA_HEADER_END(lsa->header);
+						ospf6_lsa_header_end(
+							lsa->header);
 
 				if (intra_prefix_lsa->ref_adv_router
 				     == oa->ospf6->router_id) {
@@ -1749,9 +1739,8 @@ void ospf6_intra_prefix_lsa_add(struct ospf6_lsa *lsa)
 
 	oa = OSPF6_AREA(lsa->lsdb->data);
 
-	intra_prefix_lsa =
-		(struct ospf6_intra_prefix_lsa *)OSPF6_LSA_HEADER_END(
-			lsa->header);
+	intra_prefix_lsa = (struct ospf6_intra_prefix_lsa *)ospf6_lsa_header_end(
+		lsa->header);
 	if (intra_prefix_lsa->ref_type == htons(OSPF6_LSTYPE_ROUTER) ||
 	    intra_prefix_lsa->ref_type == htons(OSPF6_LSTYPE_NETWORK))
 		ospf6_linkstate_prefix(intra_prefix_lsa->ref_adv_router,
@@ -1979,9 +1968,8 @@ void ospf6_intra_prefix_lsa_remove(struct ospf6_lsa *lsa)
 
 	oa = OSPF6_AREA(lsa->lsdb->data);
 
-	intra_prefix_lsa =
-		(struct ospf6_intra_prefix_lsa *)OSPF6_LSA_HEADER_END(
-			lsa->header);
+	intra_prefix_lsa = (struct ospf6_intra_prefix_lsa *)ospf6_lsa_header_end(
+		lsa->header);
 
 	prefix_num = ntohs(intra_prefix_lsa->prefix_num);
 	start = (caddr_t)intra_prefix_lsa

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -705,7 +705,8 @@ static int ospf6_link_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 	}
 
 	start = (char *)link_lsa + sizeof(struct ospf6_link_lsa);
-	end = (char *)lsa->header + ntohs(lsa->header->length);
+	end = ospf6_lsa_end(lsa->header);
+
 	for (current = start; current < end;
 	     current += OSPF6_PREFIX_SIZE(prefix)) {
 		prefix = (struct ospf6_prefix *)current;
@@ -864,7 +865,7 @@ static char *ospf6_intra_prefix_lsa_get_prefix_str(struct ospf6_lsa *lsa,
 
 		start = (char *)intra_prefix_lsa
 			+ sizeof(struct ospf6_intra_prefix_lsa);
-		end = (char *)lsa->header + ntohs(lsa->header->length);
+		end = ospf6_lsa_end(lsa->header);
 		current = start;
 
 		while (current + sizeof(struct ospf6_prefix) <= end) {
@@ -935,7 +936,8 @@ static int ospf6_intra_prefix_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 
 	start = (char *)intra_prefix_lsa
 		+ sizeof(struct ospf6_intra_prefix_lsa);
-	end = (char *)lsa->header + ntohs(lsa->header->length);
+	end = ospf6_lsa_end(lsa->header);
+
 	for (current = start; current < end;
 	     current += OSPF6_PREFIX_SIZE(prefix)) {
 		prefix = (struct ospf6_prefix *)current;
@@ -1315,7 +1317,8 @@ void ospf6_intra_prefix_lsa_originate_transit(struct event *thread)
 
 		prefix_num = (unsigned short)ntohl(link_lsa->prefix_num);
 		start = (char *)link_lsa + sizeof(struct ospf6_link_lsa);
-		end = (char *)lsa->header + ntohs(lsa->header->length);
+		end = ospf6_lsa_end(lsa->header);
+
 		for (current = start; current < end && prefix_num;
 		     current += OSPF6_PREFIX_SIZE(op)) {
 			op = (struct ospf6_prefix *)current;
@@ -1770,7 +1773,7 @@ void ospf6_intra_prefix_lsa_add(struct ospf6_lsa *lsa)
 	prefix_num = ntohs(intra_prefix_lsa->prefix_num);
 	start = (caddr_t)intra_prefix_lsa
 		+ sizeof(struct ospf6_intra_prefix_lsa);
-	end = OSPF6_LSA_END(lsa->header);
+	end = ospf6_lsa_end(lsa->header);
 	for (current = start; current < end; current += OSPF6_PREFIX_SIZE(op)) {
 		op = (struct ospf6_prefix *)current;
 		if (prefix_num == 0)
@@ -1974,7 +1977,7 @@ void ospf6_intra_prefix_lsa_remove(struct ospf6_lsa *lsa)
 	prefix_num = ntohs(intra_prefix_lsa->prefix_num);
 	start = (caddr_t)intra_prefix_lsa
 		+ sizeof(struct ospf6_intra_prefix_lsa);
-	end = OSPF6_LSA_END(lsa->header);
+	end = ospf6_lsa_end(lsa->header);
 	for (current = start; current < end; current += OSPF6_PREFIX_SIZE(op)) {
 		op = (struct ospf6_prefix *)current;
 		if (prefix_num == 0)

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -201,10 +201,10 @@ int ospf6_lsa_is_differ(struct ospf6_lsa *lsa1, struct ospf6_lsa *lsa2)
 		return 1;
 
 	/* compare body */
-	if (ntohs(lsa1->header->length) != ntohs(lsa2->header->length))
+	if (ospf6_lsa_size(lsa1->header) != ospf6_lsa_size(lsa2->header))
 		return 1;
 
-	len = ntohs(lsa1->header->length) - sizeof(struct ospf6_lsa_header);
+	len = ospf6_lsa_size(lsa1->header) - sizeof(struct ospf6_lsa_header);
 	return memcmp(lsa1->header + 1, lsa2->header + 1, len);
 }
 
@@ -214,7 +214,7 @@ int ospf6_lsa_is_changed(struct ospf6_lsa *lsa1, struct ospf6_lsa *lsa2)
 
 	if (OSPF6_LSA_IS_MAXAGE(lsa1) ^ OSPF6_LSA_IS_MAXAGE(lsa2))
 		return 1;
-	if (ntohs(lsa1->header->length) != ntohs(lsa2->header->length))
+	if (ospf6_lsa_size(lsa1->header) != ospf6_lsa_size(lsa2->header))
 		return 1;
 	/* Going beyond LSA headers to compare the payload only makes sense,
 	 * when both LSAs aren't header-only. */
@@ -228,7 +228,7 @@ int ospf6_lsa_is_changed(struct ospf6_lsa *lsa1, struct ospf6_lsa *lsa2)
 	if (CHECK_FLAG(lsa1->flag, OSPF6_LSA_HEADERONLY))
 		return 0;
 
-	length = OSPF6_LSA_SIZE(lsa1->header) - sizeof(struct ospf6_lsa_header);
+	length = ospf6_lsa_size(lsa1->header) - sizeof(struct ospf6_lsa_header);
 	/* Once upper layer verifies LSAs received, length underrun should
 	 * become a warning. */
 	if (length <= 0)
@@ -613,7 +613,7 @@ void ospf6_lsa_show_internal(struct vty *vty, struct ospf6_lsa *lsa,
 		json_object_int_add(json_obj, "checksum",
 				    ntohs(lsa->header->checksum));
 		json_object_int_add(json_obj, "length",
-				    ntohs(lsa->header->length));
+				    ospf6_lsa_size(lsa->header));
 		json_object_int_add(json_obj, "flag", lsa->flag);
 		json_object_int_add(json_obj, "lock", lsa->lock);
 		json_object_int_add(json_obj, "reTxCount", lsa->retrans_count);
@@ -630,7 +630,7 @@ void ospf6_lsa_show_internal(struct vty *vty, struct ospf6_lsa *lsa,
 			(unsigned long)ntohl(lsa->header->seqnum));
 		vty_out(vty, "CheckSum: %#06hx Length: %hu\n",
 			ntohs(lsa->header->checksum),
-			ntohs(lsa->header->length));
+			ospf6_lsa_size(lsa->header));
 		vty_out(vty, "Flag: %x \n", lsa->flag);
 		vty_out(vty, "Lock: %d \n", lsa->lock);
 		vty_out(vty, "ReTx Count: %d\n", lsa->retrans_count);
@@ -720,7 +720,7 @@ struct ospf6_lsa *ospf6_lsa_create(struct ospf6_lsa_header *header)
 	uint16_t lsa_size = 0;
 
 	/* size of the entire LSA */
-	lsa_size = ntohs(header->length); /* XXX vulnerable */
+	lsa_size = ospf6_lsa_size(header); /* XXX vulnerable */
 
 	lsa = ospf6_lsa_alloc(lsa_size);
 
@@ -947,7 +947,7 @@ unsigned short ospf6_lsa_checksum(struct ospf6_lsa_header *lsa_header)
 		buffer - (uint8_t *)&lsa_header->age; /* should be 2 */
 
 	/* Skip the AGE field */
-	uint16_t len = ntohs(lsa_header->length) - type_offset;
+	uint16_t len = ospf6_lsa_size(lsa_header) - type_offset;
 
 	/* Checksum offset starts from "type" field, not the beginning of the
 	   lsa_header struct. The offset is 14, rather than 16. */
@@ -963,7 +963,7 @@ int ospf6_lsa_checksum_valid(struct ospf6_lsa_header *lsa_header)
 		buffer - (uint8_t *)&lsa_header->age; /* should be 2 */
 
 	/* Skip the AGE field */
-	uint16_t len = ntohs(lsa_header->length) - type_offset;
+	uint16_t len = ospf6_lsa_size(lsa_header) - type_offset;
 
 	return (fletcher_checksum(buffer, len, FLETCHER_CHECKSUM_VALIDATE)
 		== 0);

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -66,7 +66,7 @@ static int ospf6_unknown_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 	char *start, *end, *current;
 
 	start = ospf6_lsa_header_end(lsa->header);
-	end = (char *)lsa->header + ntohs(lsa->header->length);
+	end = ospf6_lsa_end(lsa->header);
 
 	if (use_json) {
 		json_object_string_add(json_obj, "lsaType", "unknown");
@@ -548,7 +548,7 @@ void ospf6_lsa_show_dump(struct vty *vty, struct ospf6_lsa *lsa,
 	json_object *json = NULL;
 
 	start = (uint8_t *)lsa->header;
-	end = (uint8_t *)lsa->header + ntohs(lsa->header->length);
+	end = (uint8_t *)ospf6_lsa_end(lsa->header);
 
 	if (use_json) {
 		json = json_object_new_object();

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -63,10 +63,10 @@ struct ospf6 *ospf6_get_by_lsdb(struct ospf6_lsa *lsa)
 static int ospf6_unknown_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 				  json_object *json_obj, bool use_json)
 {
-	uint8_t *start, *end, *current;
+	char *start, *end, *current;
 
-	start = (uint8_t *)lsa->header + sizeof(struct ospf6_lsa_header);
-	end = (uint8_t *)lsa->header + ntohs(lsa->header->length);
+	start = ospf6_lsa_header_end(lsa->header);
+	end = (char *)lsa->header + ntohs(lsa->header->length);
 
 	if (use_json) {
 		json_object_string_add(json_obj, "lsaType", "unknown");
@@ -234,8 +234,8 @@ int ospf6_lsa_is_changed(struct ospf6_lsa *lsa1, struct ospf6_lsa *lsa2)
 	if (length <= 0)
 		return 0;
 
-	return memcmp(OSPF6_LSA_HEADER_END(lsa1->header),
-		      OSPF6_LSA_HEADER_END(lsa2->header), length);
+	return memcmp(ospf6_lsa_header_end(lsa1->header),
+		      ospf6_lsa_header_end(lsa2->header), length);
 }
 
 /* ospf6 age functions */

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -87,8 +87,6 @@ struct ospf6_lsa_header {
 	uint16_t length;     /* LSA length */
 };
 
-#define OSPF6_LSA_SIZE(h) (ntohs(((struct ospf6_lsa_header *)(h))->length))
-
 static inline char *ospf6_lsa_header_end(struct ospf6_lsa_header *header)
 {
 	return (char *)header + sizeof(struct ospf6_lsa_header);
@@ -97,6 +95,11 @@ static inline char *ospf6_lsa_header_end(struct ospf6_lsa_header *header)
 static inline char *ospf6_lsa_end(struct ospf6_lsa_header *header)
 {
 	return (char *)header + ntohs(header->length);
+}
+
+static inline uint16_t ospf6_lsa_size(struct ospf6_lsa_header *header)
+{
+	return ntohs(header->length);
 }
 
 #define OSPF6_LSA_IS_TYPE(t, L)                                                \

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -88,12 +88,15 @@ struct ospf6_lsa_header {
 };
 
 #define OSPF6_LSA_SIZE(h) (ntohs(((struct ospf6_lsa_header *)(h))->length))
-#define OSPF6_LSA_END(h)                                                       \
-	((caddr_t)(h) + ntohs(((struct ospf6_lsa_header *)(h))->length))
 
 static inline char *ospf6_lsa_header_end(struct ospf6_lsa_header *header)
 {
 	return (char *)header + sizeof(struct ospf6_lsa_header);
+}
+
+static inline char *ospf6_lsa_end(struct ospf6_lsa_header *header)
+{
+	return (char *)header + ntohs(header->length);
 }
 
 #define OSPF6_LSA_IS_TYPE(t, L)                                                \

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -87,10 +87,15 @@ struct ospf6_lsa_header {
 	uint16_t length;     /* LSA length */
 };
 
-#define OSPF6_LSA_HEADER_END(h) ((caddr_t)(h) + sizeof(struct ospf6_lsa_header))
 #define OSPF6_LSA_SIZE(h) (ntohs(((struct ospf6_lsa_header *)(h))->length))
 #define OSPF6_LSA_END(h)                                                       \
 	((caddr_t)(h) + ntohs(((struct ospf6_lsa_header *)(h))->length))
+
+static inline char *ospf6_lsa_header_end(struct ospf6_lsa_header *header)
+{
+	return (char *)header + sizeof(struct ospf6_lsa_header);
+}
+
 #define OSPF6_LSA_IS_TYPE(t, L)                                                \
 	((L)->header->type == htons(OSPF6_LSTYPE_##t) ? 1 : 0)
 #define OSPF6_LSA_IS_SAME(L1, L2)                                              \

--- a/ospf6d/ospf6_lsdb.c
+++ b/ospf6d/ospf6_lsdb.c
@@ -229,9 +229,8 @@ struct ospf6_lsa *ospf6_find_inter_prefix_lsa(struct ospf6 *ospf6,
 		struct ospf6_inter_prefix_lsa *prefix_lsa;
 		struct prefix prefix;
 
-		prefix_lsa =
-			(struct ospf6_inter_prefix_lsa *)OSPF6_LSA_HEADER_END(
-				lsa->header);
+		prefix_lsa = (struct ospf6_inter_prefix_lsa *)
+			ospf6_lsa_header_end(lsa->header);
 		prefix.family = AF_INET6;
 		prefix.prefixlen = prefix_lsa->prefix.prefix_length;
 		ospf6_prefix_in6_addr(&prefix.u.prefix6, prefix_lsa,

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -52,10 +52,8 @@ static int ospf6_abr_nssa_am_elected(struct ospf6_area *oa)
 
 	/* Verify all the router LSA to compare the router ID */
 	for (ALL_LSDB_TYPED(oa->lsdb, type, lsa)) {
-
-		router_lsa = (struct ospf6_router_lsa
-				      *)((caddr_t)lsa->header
-					 + sizeof(struct ospf6_lsa_header));
+		router_lsa = (struct ospf6_router_lsa *)ospf6_lsa_header_end(
+			lsa->header);
 
 		/* ignore non-ABR routers */
 		if (!CHECK_FLAG(router_lsa->bits, OSPF6_ROUTER_BIT_B))
@@ -416,7 +414,7 @@ static struct ospf6_lsa *ospf6_lsa_translated_nssa_new(struct ospf6_area *area,
 	}
 
 	/* find the translated Type-5 for this Type-7 */
-	nssa = (struct ospf6_as_external_lsa *)OSPF6_LSA_HEADER_END(
+	nssa = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
 		type7->header);
 	prefix.family = AF_INET6;
 	prefix.prefixlen = nssa->prefix.prefix_length;
@@ -437,12 +435,10 @@ static struct ospf6_lsa *ospf6_lsa_translated_nssa_new(struct ospf6_area *area,
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	extnew = (struct ospf6_as_external_lsa
-			  *)((caddr_t)lsa_header
-			     + sizeof(struct ospf6_lsa_header));
-	ext = (struct ospf6_as_external_lsa
-		       *)((caddr_t)(type7->header)
-			  + sizeof(struct ospf6_lsa_header));
+	extnew = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
+		lsa_header);
+	ext = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
+		type7->header);
 	old_ptr =
 		(caddr_t)((caddr_t)ext + sizeof(struct ospf6_as_external_lsa));
 	new_ptr = (caddr_t)((caddr_t)extnew
@@ -550,7 +546,7 @@ struct ospf6_lsa *ospf6_translated_nssa_refresh(struct ospf6_area *area,
 				"%s: try to find translated Type-5 LSA for %s",
 				__func__, type7->name);
 
-		ext_lsa = (struct ospf6_as_external_lsa *)OSPF6_LSA_HEADER_END(
+		ext_lsa = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
 			type7->header);
 		prefix.family = AF_INET6;
 		prefix.prefixlen = ext_lsa->prefix.prefix_length;
@@ -618,7 +614,7 @@ static void ospf6_abr_translate_nssa(struct ospf6_area *area,
 	struct ospf6 *ospf6;
 
 	ospf6 = area->ospf6;
-	nssa_lsa = (struct ospf6_as_external_lsa *)OSPF6_LSA_HEADER_END(
+	nssa_lsa = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
 		lsa->header);
 
 	if (!CHECK_FLAG(nssa_lsa->prefix.prefix_options,
@@ -1244,9 +1240,8 @@ void ospf6_nssa_lsa_originate(struct ospf6_route *route,
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	as_external_lsa = (struct ospf6_as_external_lsa
-				   *)((caddr_t)lsa_header
-				      + sizeof(struct ospf6_lsa_header));
+	as_external_lsa = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
+		lsa_header);
 	p = (caddr_t)((caddr_t)as_external_lsa
 		      + sizeof(struct ospf6_as_external_lsa));
 

--- a/ospf6d/ospf6_snmp.c
+++ b/ospf6d/ospf6_snmp.c
@@ -1017,7 +1017,7 @@ static uint8_t *ospfv3WwLsdbEntry(struct variable *v, oid *name, size_t *length,
 	case OSPFv3WWLSDBCHECKSUM:
 		return SNMP_INTEGER(ntohs(lsa->header->checksum));
 	case OSPFv3WWLSDBADVERTISEMENT:
-		*var_len = ntohs(lsa->header->length);
+		*var_len = ospf6_lsa_size(lsa->header);
 		return (uint8_t *)lsa->header;
 	case OSPFv3WWLSDBTYPEKNOWN:
 		return SNMP_INTEGER(OSPF6_LSA_IS_KNOWN(lsa->header->type)

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -130,10 +130,10 @@ static struct ospf6_vertex *ospf6_vertex_create(struct ospf6_lsa *lsa)
 	v->lsa = lsa;
 
 	/* capability bits + options */
-	v->capability = *(uint8_t *)(OSPF6_LSA_HEADER_END(lsa->header));
-	v->options[0] = *(uint8_t *)(OSPF6_LSA_HEADER_END(lsa->header) + 1);
-	v->options[1] = *(uint8_t *)(OSPF6_LSA_HEADER_END(lsa->header) + 2);
-	v->options[2] = *(uint8_t *)(OSPF6_LSA_HEADER_END(lsa->header) + 3);
+	v->capability = *(uint8_t *)(ospf6_lsa_header_end(lsa->header));
+	v->options[0] = *(uint8_t *)(ospf6_lsa_header_end(lsa->header) + 1);
+	v->options[1] = *(uint8_t *)(ospf6_lsa_header_end(lsa->header) + 2);
+	v->options[2] = *(uint8_t *)(ospf6_lsa_header_end(lsa->header) + 3);
 
 	v->nh_list = list_new();
 	v->nh_list->cmp = (int (*)(void *, void *))ospf6_nexthop_cmp;
@@ -206,7 +206,7 @@ static char *ospf6_lsdesc_backlink(struct ospf6_lsa *lsa, caddr_t lsdesc,
 	size = (OSPF6_LSA_IS_TYPE(ROUTER, lsa)
 			? sizeof(struct ospf6_router_lsdesc)
 			: sizeof(struct ospf6_network_lsdesc));
-	for (backlink = OSPF6_LSA_HEADER_END(lsa->header) + 4;
+	for (backlink = ospf6_lsa_header_end(lsa->header) + 4;
 	     backlink + size <= OSPF6_LSA_END(lsa->header); backlink += size) {
 		assert(!(OSPF6_LSA_IS_TYPE(NETWORK, lsa)
 			 && VERTEX_IS_TYPE(NETWORK, v)));
@@ -290,7 +290,7 @@ static void ospf6_nexthop_calc(struct ospf6_vertex *w, struct ospf6_vertex *v,
 			       != lsa->header->id)
 			continue;
 
-		link_lsa = (struct ospf6_link_lsa *)OSPF6_LSA_HEADER_END(
+		link_lsa = (struct ospf6_link_lsa *)ospf6_lsa_header_end(
 			lsa->header);
 		if (IS_OSPF6_DEBUG_SPF(PROCESS)) {
 			inet_ntop(AF_INET6, &link_lsa->linklocal_addr, buf,
@@ -510,7 +510,7 @@ void ospf6_spf_calculation(uint32_t router_id,
 		size = (VERTEX_IS_TYPE(ROUTER, v)
 				? sizeof(struct ospf6_router_lsdesc)
 				: sizeof(struct ospf6_network_lsdesc));
-		for (lsdesc = OSPF6_LSA_HEADER_END(v->lsa->header) + 4;
+		for (lsdesc = ospf6_lsa_header_end(v->lsa->header) + 4;
 		     lsdesc + size <= OSPF6_LSA_END(v->lsa->header);
 		     lsdesc += size) {
 			lsa = ospf6_lsdesc_lsa(lsdesc, v);
@@ -1063,7 +1063,7 @@ struct ospf6_lsa *ospf6_create_single_router_lsa(struct ospf6_area *area,
 		}
 
 		if (IS_OSPF6_DEBUG_SPF(PROCESS)) {
-			lsd = OSPF6_LSA_HEADER_END(rtr_lsa->header) + 4;
+			lsd = ospf6_lsa_header_end(rtr_lsa->header) + 4;
 			interface_id = ROUTER_LSDESC_GET_IFID(lsd);
 			inet_ntop(AF_INET, &interface_id, ifbuf, sizeof(ifbuf));
 			zlog_debug(
@@ -1074,7 +1074,7 @@ struct ospf6_lsa *ospf6_create_single_router_lsa(struct ospf6_area *area,
 
 		/* Append Next Link State ID LSA */
 		lsa_header = rtr_lsa->header;
-		memcpy(new_header, (OSPF6_LSA_HEADER_END(rtr_lsa->header) + 4),
+		memcpy(new_header, (ospf6_lsa_header_end(rtr_lsa->header) + 4),
 		       (ntohs(lsa_header->length) - lsa_length));
 		new_header += (ntohs(lsa_header->length) - lsa_length);
 		num_lsa--;
@@ -1137,7 +1137,7 @@ int ospf6_ase_calculate_route(struct ospf6 *ospf6, struct ospf6_lsa *lsa,
 		return 0;
 	}
 
-	external = (struct ospf6_as_external_lsa *)OSPF6_LSA_HEADER_END(
+	external = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
 		lsa->header);
 	prefix.family = AF_INET6;
 	prefix.prefixlen = external->prefix.prefix_length;

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -207,7 +207,7 @@ static char *ospf6_lsdesc_backlink(struct ospf6_lsa *lsa, caddr_t lsdesc,
 			? sizeof(struct ospf6_router_lsdesc)
 			: sizeof(struct ospf6_network_lsdesc));
 	for (backlink = ospf6_lsa_header_end(lsa->header) + 4;
-	     backlink + size <= OSPF6_LSA_END(lsa->header); backlink += size) {
+	     backlink + size <= ospf6_lsa_end(lsa->header); backlink += size) {
 		assert(!(OSPF6_LSA_IS_TYPE(NETWORK, lsa)
 			 && VERTEX_IS_TYPE(NETWORK, v)));
 
@@ -511,7 +511,7 @@ void ospf6_spf_calculation(uint32_t router_id,
 				? sizeof(struct ospf6_router_lsdesc)
 				: sizeof(struct ospf6_network_lsdesc));
 		for (lsdesc = ospf6_lsa_header_end(v->lsa->header) + 4;
-		     lsdesc + size <= OSPF6_LSA_END(v->lsa->header);
+		     lsdesc + size <= ospf6_lsa_end(v->lsa->header);
 		     lsdesc += size) {
 			lsa = ospf6_lsdesc_lsa(lsdesc, v);
 			if (lsa == NULL)

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -187,7 +187,7 @@ static struct ospf6_lsa *ospf6_lsdesc_lsa(caddr_t lsdesc,
 		inet_ntop(AF_INET, &adv_router, abuf, sizeof(abuf));
 		if (lsa)
 			zlog_debug("  Link to: %s len %u, V %s", lsa->name,
-				   ntohs(lsa->header->length), v->name);
+				   ospf6_lsa_size(lsa->header), v->name);
 		else
 			zlog_debug("  Link to: [%s Id:%s Adv:%s] No LSA , V %s",
 				   ospf6_lstype_name(type), ibuf, abuf,
@@ -1011,7 +1011,7 @@ struct ospf6_lsa *ospf6_create_single_router_lsa(struct ospf6_area *area,
 			continue;
 		}
 		lsa_header = rtr_lsa->header;
-		total_lsa_length += (ntohs(lsa_header->length) - lsa_length);
+		total_lsa_length += (ospf6_lsa_size(lsa_header) - lsa_length);
 		num_lsa++;
 		rtr_lsa = ospf6_lsdb_next(end, rtr_lsa);
 	}
@@ -1044,11 +1044,11 @@ struct ospf6_lsa *ospf6_create_single_router_lsa(struct ospf6_area *area,
 	if (!OSPF6_LSA_IS_MAXAGE(rtr_lsa)) {
 		/* Append first Link State ID LSA */
 		lsa_header = rtr_lsa->header;
-		memcpy(new_header, lsa_header, ntohs(lsa_header->length));
+		memcpy(new_header, lsa_header, ospf6_lsa_size(lsa_header));
 		/* Assign new lsa length as aggregated length. */
 		((struct ospf6_lsa_header *)new_header)->length =
 			htons(total_lsa_length);
-		new_header += ntohs(lsa_header->length);
+		new_header += ospf6_lsa_size(lsa_header);
 		num_lsa--;
 	}
 
@@ -1066,17 +1066,16 @@ struct ospf6_lsa *ospf6_create_single_router_lsa(struct ospf6_area *area,
 			lsd = ospf6_lsa_header_end(rtr_lsa->header) + 4;
 			interface_id = ROUTER_LSDESC_GET_IFID(lsd);
 			inet_ntop(AF_INET, &interface_id, ifbuf, sizeof(ifbuf));
-			zlog_debug(
-				"%s: Next Router LSA %s to aggreat with len %u interface_id %s",
-				__func__, rtr_lsa->name,
-				ntohs(lsa_header->length), ifbuf);
+			zlog_debug("%s: Next Router LSA %s to aggreat with len %u interface_id %s",
+				   __func__, rtr_lsa->name,
+				   ospf6_lsa_size(lsa_header), ifbuf);
 		}
 
 		/* Append Next Link State ID LSA */
 		lsa_header = rtr_lsa->header;
 		memcpy(new_header, (ospf6_lsa_header_end(rtr_lsa->header) + 4),
-		       (ntohs(lsa_header->length) - lsa_length));
-		new_header += (ntohs(lsa_header->length) - lsa_length);
+		       (ospf6_lsa_size(lsa_header) - lsa_length));
+		new_header += (ospf6_lsa_size(lsa_header) - lsa_length);
 		num_lsa--;
 
 		rtr_lsa = ospf6_lsdb_next(end, rtr_lsa);
@@ -1091,8 +1090,8 @@ struct ospf6_lsa *ospf6_create_single_router_lsa(struct ospf6_area *area,
 	if (IS_OSPF6_DEBUG_SPF(PROCESS))
 		zlog_debug("%s: LSA %s id %u type 0%x len %u num_lsa %u",
 			   __func__, lsa->name, ntohl(lsa->header->id),
-			   ntohs(lsa->header->type), ntohs(lsa->header->length),
-			   num_lsa);
+			   ntohs(lsa->header->type),
+			   ospf6_lsa_size(lsa->header), num_lsa);
 
 	return lsa;
 }


### PR DESCRIPTION
This PR proposes the removal of OSPF6_LSA_HEADER_END, OSPF6_LSA_SIZE and OSPF6_LSA_END macros. It replaces those macros with inline functions that enables better type checking and reduces the number of unchecked type casts. No functional change is intended.