### PR TITLE
isisd: When the metric-type is configured as "wide", the IS-IS generates incorrect metric values for IPv4 directly connected routes.

### DIFF
--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1260,7 +1260,7 @@ static int isis_spf_preload_tent_ip_reach_cb(const struct prefix *prefix,
 	struct isis_vertex *parent = args->parent;
 	struct prefix_pair ip_info;
 	enum vertextype vtype;
-	bool has_valid_psid = false;
+	bool has_valid_psid = false, transition = false;
 
 	if (external)
 		return LSP_ITER_CONTINUE;
@@ -1270,10 +1270,17 @@ static int isis_spf_preload_tent_ip_reach_cb(const struct prefix *prefix,
 	prefix_copy(&ip_info.dest, prefix);
 	apply_mask(&ip_info.dest);
 
-	if (prefix->family == AF_INET)
+	if (prefix->family == AF_INET) {
 		vtype = VTYPE_IPREACH_INTERNAL;
-	else
+
+		if (spftree->area->newmetric)
+			vtype = VTYPE_IPREACH_TE;
+
+		if (spftree->area->oldmetric && spftree->area->newmetric)
+			transition = true;
+	} else {
 		vtype = VTYPE_IP6REACH_INTERNAL;
+	}
 
 	/* Parse list of Prefix-SID subTLVs if SR is enabled */
 	if (spftree->area->srdb.enabled && subtlvs) {
@@ -1288,6 +1295,11 @@ static int isis_spf_preload_tent_ip_reach_cb(const struct prefix *prefix,
 			has_valid_psid = true;
 			isis_spf_add_local(spftree, vtype, &ip_info, NULL, 0,
 					   psid, parent);
+			if (transition)
+				isis_spf_add_local(spftree,
+						   VTYPE_IPREACH_INTERNAL,
+						   &ip_info, NULL, 0, psid,
+						   parent);
 
 			/*
 			 * Stop the Prefix-SID iteration since we only support
@@ -1296,9 +1308,13 @@ static int isis_spf_preload_tent_ip_reach_cb(const struct prefix *prefix,
 			break;
 		}
 	}
-	if (!has_valid_psid)
+	if (!has_valid_psid) {
 		isis_spf_add_local(spftree, vtype, &ip_info, NULL, 0, NULL,
 				   parent);
+		if (transition)
+			isis_spf_add_local(spftree, VTYPE_IPREACH_INTERNAL,
+					   &ip_info, NULL, 0, NULL, parent);
+	}
 
 	return LSP_ITER_CONTINUE;
 }

--- a/tests/isisd/test_isis_spf.refout
+++ b/tests/isisd/test_isis_spf.refout
@@ -2,7 +2,7 @@ test# test isis topology 1 root rt1 spf
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -61,7 +61,7 @@ test# test isis topology 2 root rt1 spf
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt4                  TE-IS        10     rt4                  -         rt1(4)
 rt5                  TE-IS        10     rt5                  -         rt1(4)
 rt2                  TE-IS        15     rt2                  -         rt1(4)
@@ -122,7 +122,7 @@ test# test isis topology 3 root rt1 spf ipv4-only
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -149,7 +149,7 @@ test# test isis topology 4 root rt1 spf ipv4-only
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -182,7 +182,7 @@ test# test isis topology 5 root rt1 spf ipv4-only
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -218,7 +218,7 @@ test# test isis topology 6 root rt1 spf ipv4-only
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -266,7 +266,7 @@ test# test isis topology 7 root rt1 spf ipv4-only
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt4                  TE-IS        10     rt4                  -         rt1(4)
 rt5                  TE-IS        20     rt4                  -         rt4(4)
 rt7                  TE-IS        20     rt4                  -         rt4(4)
@@ -314,7 +314,7 @@ test# test isis topology 8 root rt1 spf ipv4-only
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt4                  TE-IS        10     rt4                  -         rt1(4)
 rt3                  TE-IS        20     rt2                  -         rt2(4)
@@ -361,7 +361,7 @@ test# test isis topology 9 root rt1 spf
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -438,7 +438,7 @@ test# test isis topology 10 root rt1 spf
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        20     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt4                  -         rt1(4)
@@ -503,7 +503,7 @@ test# test isis topology 11 root rt1 spf
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt2                  pseudo_TE-IS 20     rt3                  -         rt3(4)
@@ -564,7 +564,7 @@ test# test isis topology 12 root rt1 spf ipv4-only
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -603,7 +603,7 @@ test# test isis topology 13 root rt1 spf ipv4-only
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -638,7 +638,7 @@ test# test isis topology 4 root rt1 reverse-spf ipv4-only
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -671,7 +671,7 @@ test# test isis topology 11 root rt1 reverse-spf
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10                                    rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt2                  pseudo_TE-IS 20     rt3                  -         rt3(4)
@@ -725,7 +725,7 @@ test# test isis topology 1 root rt1 lfa system-id rt2
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -792,7 +792,7 @@ test# test isis topology 2 root rt4 lfa system-id rt1 pseudonode-id 1
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt4                                                                   
-10.0.255.4/32        IP internal  0                                     rt4(4)
+10.0.255.4/32        IP TE        0                                     rt4(4)
 rt1                  TE-IS        10     rt1                  -         rt4(4)
 rt5                  TE-IS        10     rt5                  -         rt4(4)
 rt6                  TE-IS        10     rt6                  -         rt4(4)
@@ -865,7 +865,7 @@ test# test isis topology 2 root rt4 lfa system-id rt6
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt4                                                                   
-10.0.255.4/32        IP internal  0                                     rt4(4)
+10.0.255.4/32        IP TE        0                                     rt4(4)
 rt1                  TE-IS        10     rt1                  -         rt4(4)
 rt5                  TE-IS        10     rt5                  -         rt4(4)
 rt6                  TE-IS        10     rt6                  -         rt4(4)
@@ -938,7 +938,7 @@ test# test isis topology 3 root rt1 lfa system-id rt2
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -988,7 +988,7 @@ test# test isis topology 3 root rt1 lfa system-id rt3
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -1035,7 +1035,7 @@ test# test isis topology 7 root rt1 lfa system-id rt4
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt4                  TE-IS        10     rt4                  -         rt1(4)
 rt5                  TE-IS        20     rt4                  -         rt4(4)
 rt7                  TE-IS        20     rt4                  -         rt4(4)
@@ -1113,7 +1113,7 @@ test# test isis topology 7 root rt7 lfa system-id rt8
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt7                                                                   
-10.0.255.7/32        IP internal  0                                     rt7(4)
+10.0.255.7/32        IP TE        0                                     rt7(4)
 rt4                  TE-IS        10     rt4                  -         rt7(4)
 rt8                  TE-IS        10     rt8                  -         rt7(4)
 rt10                 TE-IS        20     rt10                 -         rt7(4)
@@ -1195,7 +1195,7 @@ test# test isis topology 7 root rt8 lfa system-id rt11
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt8                                                                   
-10.0.255.8/32        IP internal  0                                     rt8(4)
+10.0.255.8/32        IP TE        0                                     rt8(4)
 rt5                  TE-IS        10     rt5                  -         rt8(4)
 rt7                  TE-IS        10     rt7                  -         rt8(4)
 rt9                  TE-IS        10     rt9                  -         rt8(4)
@@ -1272,7 +1272,7 @@ test# test isis topology 9 root rt3 lfa system-id rt1
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt3                                                                   
-10.0.255.3/32        IP internal  0                                     rt3(4)
+10.0.255.3/32        IP TE        0                                     rt3(4)
 rt1                  TE-IS        10     rt1                  -         rt3(4)
 rt2                  TE-IS        20     rt1                  -         rt1(4)
 10.0.255.1/32        IP TE        20     rt1                  -         rt1(4)
@@ -1379,7 +1379,7 @@ test# test isis topology 10 root rt8 lfa system-id rt5
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt8                                                                   
-10.0.255.8/32        IP internal  0                                     rt8(4)
+10.0.255.8/32        IP TE        0                                     rt8(4)
 rt5                  TE-IS        10     rt5                  -         rt8(4)
 rt2                  TE-IS        20     rt5                  -         rt5(4)
 10.0.255.5/32        IP TE        20     rt5                  -         rt5(4)
@@ -1478,7 +1478,7 @@ test# test isis topology 11 root rt3 lfa system-id rt5
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt3                                                                   
-10.0.255.3/32        IP internal  0                                     rt3(4)
+10.0.255.3/32        IP TE        0                                     rt3(4)
 rt1                  TE-IS        10     rt1                  -         rt3(4)
 rt2                  TE-IS        10     rt2                  -         rt3(4)
 rt5                  TE-IS        10     rt5                  -         rt3(4)
@@ -1557,7 +1557,7 @@ test# test isis topology 13 root rt4 lfa system-id rt3
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt4                                                                   
-10.0.255.4/32        IP internal  0                                     rt4(4)
+10.0.255.4/32        IP TE        0                                     rt4(4)
 rt2                  TE-IS        10     rt2                  -         rt4(4)
 rt3                  TE-IS        10     rt3                  -         rt4(4)
 rt1                  TE-IS        20     rt2                  -         rt2(4)
@@ -1615,7 +1615,7 @@ test# test isis topology 14 root rt1 lfa system-id rt1 pseudonode-id 1
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        10     rt4                  -         rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
@@ -1672,7 +1672,7 @@ test# test isis topology 14 root rt1 lfa system-id rt2
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        10     rt4                  -         rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
@@ -1737,7 +1737,7 @@ test# test isis topology 14 root rt5 lfa system-id rt4
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt5                                                                   
-10.0.255.5/32        IP internal  0                                     rt5(4)
+10.0.255.5/32        IP TE        0                                     rt5(4)
 rt4                  TE-IS        10     rt4                  -         rt5(4)
 rt1                  pseudo_TE-IS 20     rt4                  -         rt4(4)
 rt1                  TE-IS        20     rt4                  -         rt1(2)
@@ -1825,7 +1825,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt5                  TE-IS        20     rt3                  -         rt3(4)
 10.0.255.3/32        IP TE        20     rt3                  -         rt3(4)
@@ -1840,7 +1840,7 @@ rt2                  TE-IS        50     rt3                  -         rt4(4)
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -1966,7 +1966,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt5                                                                   
-10.0.255.5/32        IP internal  0                                     rt5(4)
+10.0.255.5/32        IP TE        0                                     rt5(4)
 rt6                  TE-IS        10     rt6                  -         rt5(4)
 rt4                  TE-IS        20     rt6                  -         rt6(4)
 10.0.255.6/32        IP TE        20     rt6                  -         rt6(4)
@@ -1982,7 +1982,7 @@ rt2                  TE-IS        45     rt6                  -         rt1(4)
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt5                                                                   
-10.0.255.5/32        IP internal  0                                     rt5(4)
+10.0.255.5/32        IP TE        0                                     rt5(4)
 rt1                  TE-IS        10     rt1                  -         rt5(4)
 rt4                  TE-IS        10     rt4                  -         rt5(4)
 rt6                  TE-IS        10     rt6                  -         rt5(4)
@@ -2125,7 +2125,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt5                                                                   
-10.0.255.5/32        IP internal  0                                     rt5(4)
+10.0.255.5/32        IP TE        0                                     rt5(4)
 rt6                  TE-IS        10     rt6                  -         rt5(4)
 rt4                  TE-IS        20     rt6                  -         rt6(4)
 10.0.255.6/32        IP TE        20     rt6                  -         rt6(4)
@@ -2142,7 +2142,7 @@ rt1                  TE-IS        40     rt3                  -         rt3(4)
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt5                                                                   
-10.0.255.5/32        IP internal  0                                     rt5(4)
+10.0.255.5/32        IP TE        0                                     rt5(4)
 rt4                  TE-IS        10     rt4                  -         rt5(4)
 rt6                  TE-IS        10     rt6                  -         rt5(4)
 rt2                  TE-IS        20     rt4                  -         rt4(4)
@@ -2212,7 +2212,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt5                                                                   
-10.0.255.5/32        IP internal  0                                     rt5(4)
+10.0.255.5/32        IP TE        0                                     rt5(4)
 rt4                  TE-IS        10     rt4                  -         rt5(4)
 rt6                  TE-IS        10     rt6                  -         rt5(4)
 rt2                  TE-IS        20     rt4                  -         rt4(4)
@@ -2227,7 +2227,7 @@ rt3                  TE-IS        30     rt4                  -         rt2(4)
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt5                                                                   
-10.0.255.5/32        IP internal  0                                     rt5(4)
+10.0.255.5/32        IP TE        0                                     rt5(4)
 rt4                  TE-IS        10     rt4                  -         rt5(4)
 rt6                  TE-IS        10     rt6                  -         rt5(4)
 rt2                  TE-IS        20     rt4                  -         rt4(4)
@@ -2278,7 +2278,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt5                  TE-IS        20     rt3                  -         rt3(4)
 10.0.255.3/32        IP TE        20     rt3                  -         rt3(4)
@@ -2297,7 +2297,7 @@ rt2                  TE-IS        70     rt3                  -         rt4(4)
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -2364,7 +2364,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt4                                                                   
-10.0.255.4/32        IP internal  0                                     rt4(4)
+10.0.255.4/32        IP TE        0                                     rt4(4)
 rt2                  TE-IS        10     rt2                  -         rt4(4)
 rt6                  TE-IS        10     rt6                  -         rt4(4)
 rt1                  TE-IS        20     rt2                  -         rt2(4)
@@ -2384,7 +2384,7 @@ rt7                  TE-IS        30     rt6                  -         rt5(4)
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt4                                                                   
-10.0.255.4/32        IP internal  0                                     rt4(4)
+10.0.255.4/32        IP TE        0                                     rt4(4)
 rt2                  TE-IS        10     rt2                  -         rt4(4)
 rt3                  TE-IS        10     rt3                  -         rt4(4)
 rt6                  TE-IS        10     rt6                  -         rt4(4)
@@ -2454,7 +2454,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt11                                                                  
-10.0.255.11/32       IP internal  0                                     rt11(4)
+10.0.255.11/32       IP TE        0                                     rt11(4)
 rt10                 TE-IS        10     rt10                 -         rt11(4)
 rt12                 TE-IS        10     rt12                 -         rt11(4)
 rt9                  TE-IS        20     rt12                 -         rt12(4)
@@ -2483,7 +2483,7 @@ rt3                  TE-IS        60     rt12                 -         rt6(4)
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt11                                                                  
-10.0.255.11/32       IP internal  0                                     rt11(4)
+10.0.255.11/32       IP TE        0                                     rt11(4)
 rt8                  TE-IS        10     rt8                  -         rt11(4)
 rt10                 TE-IS        10     rt10                 -         rt11(4)
 rt12                 TE-IS        10     rt12                 -         rt11(4)
@@ -2579,7 +2579,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt6                                                                   
-10.0.255.6/32        IP internal  0                                     rt6(4)
+10.0.255.6/32        IP TE        0                                     rt6(4)
 rt3                  TE-IS        10     rt3                  -         rt6(4)
 rt2                  TE-IS        20     rt3                  -         rt3(4)
 10.0.255.3/32        IP TE        20     rt3                  -         rt3(4)
@@ -2614,7 +2614,7 @@ rt10                 TE-IS        60     rt9                  -         rt11(4)
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt6                                                                   
-10.0.255.6/32        IP internal  0                                     rt6(4)
+10.0.255.6/32        IP TE        0                                     rt6(4)
 rt3                  TE-IS        10     rt3                  -         rt6(4)
 rt5                  TE-IS        10     rt5                  -         rt6(4)
 rt2                  TE-IS        20     rt3                  -         rt3(4)
@@ -2708,7 +2708,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt2                                                                   
-10.0.255.2/32        IP internal  0                                     rt2(4)
+10.0.255.2/32        IP TE        0                                     rt2(4)
 rt1                  TE-IS        10     rt1                  -         rt2(4)
 rt3                  TE-IS        10     rt3                  -         rt2(4)
 rt4                  TE-IS        20     rt1                  -         rt1(4)
@@ -2736,7 +2736,7 @@ rt12                 TE-IS        60     rt3                  -         rt9(4)
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt2                                                                   
-10.0.255.2/32        IP internal  0                                     rt2(4)
+10.0.255.2/32        IP TE        0                                     rt2(4)
 rt1                  TE-IS        10     rt1                  -         rt2(4)
 rt3                  TE-IS        10     rt3                  -         rt2(4)
 rt5                  TE-IS        10     rt5                  -         rt2(4)
@@ -2817,7 +2817,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt2                                                                   
-10.0.255.2/32        IP internal  0                                     rt2(4)
+10.0.255.2/32        IP TE        0                                     rt2(4)
 rt1                  TE-IS        50     rt1                  -         rt2(4)
 rt3                  TE-IS        50     rt3                  -         rt2(4)
 rt2                                                                   
@@ -2833,7 +2833,7 @@ rt6                  TE-IS        70     rt3                  -         rt5(4)
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt2                                                                   
-10.0.255.2/32        IP internal  0                                     rt2(4)
+10.0.255.2/32        IP TE        0                                     rt2(4)
 rt4                  TE-IS        10     rt4                  -         rt2(4)
 rt5                  TE-IS        20     rt4                  -         rt4(4)
 rt6                  TE-IS        20     rt4                  -         rt4(4)
@@ -2968,7 +2968,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
 10.0.255.2/32        IP TE        20     rt2                  -         rt2(4)
@@ -2986,7 +2986,7 @@ rt7                  TE-IS        50     rt2                  -         rt5(4)
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
@@ -3046,7 +3046,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt5                  TE-IS        20     rt3                  -         rt3(4)
 10.0.255.3/32        IP TE        20     rt3                  -         rt3(4)
@@ -3129,7 +3129,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt4                  TE-IS        10     rt4                  -         rt1(4)
 rt5                  TE-IS        10     rt5                  -         rt1(4)
 rt2                  TE-IS        15     rt2                  -         rt1(4)
@@ -3219,7 +3219,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        15     rt2                  -         rt1(4)
 10.0.255.2/32        IP TE        25     rt2                  -         rt2(4)
 rt3                  TE-IS        30     rt3                  -         rt1(4)
@@ -3305,7 +3305,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt5                                                                   
-10.0.255.5/32        IP internal  0                                     rt5(4)
+10.0.255.5/32        IP TE        0                                     rt5(4)
 rt6                  TE-IS        10     rt6                  -         rt5(4)
 rt4                  TE-IS        20     rt6                  -         rt6(4)
 10.0.255.6/32        IP TE        20     rt6                  -         rt6(4)
@@ -3398,7 +3398,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt5                                                                   
-10.0.255.5/32        IP internal  0                                     rt5(4)
+10.0.255.5/32        IP TE        0                                     rt5(4)
 rt6                  TE-IS        10     rt6                  -         rt5(4)
 rt4                  TE-IS        20     rt6                  -         rt6(4)
 10.0.255.6/32        IP TE        20     rt6                  -         rt6(4)
@@ -3452,7 +3452,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt5                                                                   
-10.0.255.5/32        IP internal  0                                     rt5(4)
+10.0.255.5/32        IP TE        0                                     rt5(4)
 rt4                  TE-IS        10     rt4                  -         rt5(4)
 rt6                  TE-IS        10     rt6                  -         rt5(4)
 rt2                  TE-IS        20     rt4                  -         rt4(4)
@@ -3486,7 +3486,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt5                  TE-IS        20     rt3                  -         rt3(4)
 10.0.255.3/32        IP TE        20     rt3                  -         rt3(4)
@@ -3533,7 +3533,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt4                                                                   
-10.0.255.4/32        IP internal  0                                     rt4(4)
+10.0.255.4/32        IP TE        0                                     rt4(4)
 rt2                  TE-IS        10     rt2                  -         rt4(4)
 rt1                  TE-IS        20     rt2                  -         rt2(4)
 10.0.255.2/32        IP TE        20     rt2                  -         rt2(4)
@@ -3577,7 +3577,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 rt5                  TE-IS        20     rt3                  -         rt3(4)
 10.0.255.3/32        IP TE        20     rt3                  -         rt3(4)
@@ -3626,7 +3626,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt4                                                                   
-10.0.255.4/32        IP internal  0                                     rt4(4)
+10.0.255.4/32        IP TE        0                                     rt4(4)
 rt2                  TE-IS        10     rt2                  -         rt4(4)
 rt6                  TE-IS        10     rt6                  -         rt4(4)
 rt1                  TE-IS        20     rt2                  -         rt2(4)
@@ -3678,7 +3678,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt11                                                                  
-10.0.255.11/32       IP internal  0                                     rt11(4)
+10.0.255.11/32       IP TE        0                                     rt11(4)
 rt10                 TE-IS        10     rt10                 -         rt11(4)
 rt12                 TE-IS        10     rt12                 -         rt11(4)
 rt9                  TE-IS        20     rt12                 -         rt12(4)
@@ -3752,7 +3752,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt6                                                                   
-10.0.255.6/32        IP internal  0                                     rt6(4)
+10.0.255.6/32        IP TE        0                                     rt6(4)
 rt3                  TE-IS        10     rt3                  -         rt6(4)
 rt2                  TE-IS        20     rt3                  -         rt3(4)
 10.0.255.3/32        IP TE        20     rt3                  -         rt3(4)
@@ -3831,7 +3831,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt2                                                                   
-10.0.255.2/32        IP internal  0                                     rt2(4)
+10.0.255.2/32        IP TE        0                                     rt2(4)
 rt3                  TE-IS        10     rt3                  -         rt2(4)
 rt5                  TE-IS        10     rt5                  -         rt2(4)
 rt6                  TE-IS        20     rt3                  -         rt3(4)
@@ -3896,7 +3896,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt2                                                                   
-10.0.255.2/32        IP internal  0                                     rt2(4)
+10.0.255.2/32        IP TE        0                                     rt2(4)
 rt1                  TE-IS        10     rt1                  -         rt2(4)
 rt3                  TE-IS        10     rt3                  -         rt2(4)
 rt4                  TE-IS        20     rt1                  -         rt1(4)
@@ -3956,7 +3956,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
 10.0.255.2/32        IP TE        20     rt2                  -         rt2(4)
@@ -4053,7 +4053,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt3                  TE-IS        10     rt3                  -         rt1(4)
 10.0.255.3/32        IP TE        20     rt3                  -         rt3(4)
 rt4                  TE-IS        110    rt3                  -         rt3(4)
@@ -4162,7 +4162,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt9                                                                   
-10.0.255.9/32        IP internal  0                                     rt9(4)
+10.0.255.9/32        IP TE        0                                     rt9(4)
 rt6                  TE-IS        10     rt6                  -         rt9(4)
 rt7                  TE-IS        10     rt7                  -         rt9(4)
 rt8                  TE-IS        10     rt8                  -         rt9(4)
@@ -4331,7 +4331,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt9                                                                   
-10.0.255.9/32        IP internal  0                                     rt9(4)
+10.0.255.9/32        IP TE        0                                     rt9(4)
 rt5                  TE-IS        10     rt5                  -         rt9(4)
 rt6                  TE-IS        10     rt6                  -         rt9(4)
 rt7                  TE-IS        10     rt7                  -         rt9(4)
@@ -4430,7 +4430,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt3                  TE-IS        20     rt3                  -         rt1(4)
 rt4                  TE-IS        20     rt4                  -         rt1(4)
 rt6                  TE-IS        30     rt3                  -         rt3(4)
@@ -4542,7 +4542,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt3                  TE-IS        20     rt3                  -         rt1(4)
 rt5                  TE-IS        20     rt2                  -         rt2(4)
@@ -4635,7 +4635,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt2                                                                   
-10.0.255.2/32        IP internal  0                                     rt2(4)
+10.0.255.2/32        IP TE        0                                     rt2(4)
 rt1                  TE-IS        50     rt1                  -         rt2(4)
 rt3                  TE-IS        50     rt3                  -         rt2(4)
 rt2                                                                   
@@ -4725,7 +4725,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
 10.0.255.2/32        IP TE        20     rt2                  -         rt2(4)
@@ -4772,7 +4772,7 @@ Q-space:
 IS-IS paths to level-1 routers that speak IP
 Vertex               Type         Metric Next-Hop             Interface Parent
 rt1                                                                   
-10.0.255.1/32        IP internal  0                                     rt1(4)
+10.0.255.1/32        IP TE        0                                     rt1(4)
 rt2                  TE-IS        10     rt2                  -         rt1(4)
 rt4                  TE-IS        20     rt2                  -         rt2(4)
 10.0.255.2/32        IP TE        20     rt2                  -         rt2(4)


### PR DESCRIPTION
The IPv4 directly connected route prefix exists in both the root LSP and the root's neighbor LSP:
1. When generating vertices for directly connected route prefixes with a metric of 0 based on the root LSP, the `isis_spf_preload_tent_ip_reach_cb` function only generates vertices of type `VTYPE_IPREACH_INTERNAL `without distinguishing between `area->oldmetric` and `area->newmetric`.
2. When generating vertices for the directly connected route prefix based on the neighbor LSP, the `isis_spf_process_lsp` function will generate vertices of type `VTYPE_IPREACH_INTERNAL` and `VTYPE_IPREACH_TE` based on `area->oldmetric` and `area->newmetric`, where the vertex metric is the sum of the metric from the root IS to the neighbor IS and from the neighbor IS to the root IS, respectively.

If `area->newmetric==1`, the same directly connected route prefix will have both `VTYPE_IPREACH_INTERNAL` vertices with a metric of 0 and` VTYPE_IPREACH_TE` vertices with a non-zero metric. During route generation, the `isis_spf_loop` function will prioritize selecting `VTYPE_IPREACH_TE` vertices, leading to incorrect metrics for the directly connected routes.

Signed-off-by: zhou-run [zhou.run@h3c.com](mailto:zhou.run@h3c.com)