### PR TITLE
OSPF6: Define Extended LSAs and TLVs

### DIFF
--- a/ospf6d/ospf6_abr.h
+++ b/ospf6d/ospf6_abr.h
@@ -17,22 +17,6 @@ extern unsigned char conf_debug_ospf6_abr;
 #define OSPF6_DEBUG_ABR_OFF() (conf_debug_ospf6_abr = 0)
 #define IS_OSPF6_DEBUG_ABR (conf_debug_ospf6_abr)
 
-/* Inter-Area-Prefix-LSA */
-#define OSPF6_INTER_PREFIX_LSA_MIN_SIZE        4U /* w/o IPv6 prefix */
-struct ospf6_inter_prefix_lsa {
-	uint32_t metric;
-	struct ospf6_prefix prefix;
-};
-
-/* Inter-Area-Router-LSA */
-#define OSPF6_INTER_ROUTER_LSA_FIX_SIZE       12U
-struct ospf6_inter_router_lsa {
-	uint8_t mbz;
-	uint8_t options[3];
-	uint32_t metric;
-	uint32_t router_id;
-};
-
 #define OSPF6_ABR_SUMMARY_METRIC(E)                                            \
 	(ntohl((E)->metric & htonl(OSPF6_EXT_PATH_METRIC_MAX)))
 #define OSPF6_ABR_SUMMARY_METRIC_SET(E, C)                                     \

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -39,6 +39,7 @@
 #include "ospf6d.h"
 #include "ospf6_spf.h"
 #include "ospf6_nssa.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
 

--- a/ospf6d/ospf6_asbr.h
+++ b/ospf6d/ospf6_asbr.h
@@ -79,17 +79,6 @@ struct ospf6_external_aggr_rt {
 	struct hash *match_extnl_hash;
 };
 
-/* AS-External-LSA */
-#define OSPF6_AS_EXTERNAL_LSA_MIN_SIZE         4U /* w/o IPv6 prefix */
-struct ospf6_as_external_lsa {
-	uint32_t bits_metric;
-
-	struct ospf6_prefix prefix;
-	/* followed by none or one forwarding address */
-	/* followed by none or one external route tag */
-	/* followed by none or one referenced LS-ID */
-};
-
 #define OSPF6_ASBR_BIT_T  ntohl (0x01000000)
 #define OSPF6_ASBR_BIT_F  ntohl (0x02000000)
 #define OSPF6_ASBR_BIT_E  ntohl (0x04000000)

--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -26,6 +26,7 @@
 
 #include "ospf6_flood.h"
 #include "ospf6_nssa.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 
 unsigned char conf_debug_ospf6_flooding;

--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -30,6 +30,7 @@
 #include "ospf6d/ospf6_flood.h"
 #include "ospf6d/ospf6_intra.h"
 #include "ospf6d/ospf6_spf.h"
+#include "ospf6d/ospf6_tlv.h"
 #include "ospf6d/ospf6_gr.h"
 #include "ospf6d/ospf6_gr_clippy.c"
 
@@ -57,13 +58,13 @@ static int ospf6_gr_lsa_originate(struct ospf6_interface *oi,
 	grace_lsa = (struct ospf6_grace_lsa *)ospf6_lsa_header_end(lsa_header);
 
 	/* Put grace period. */
-	grace_lsa->tlv_period.header.type = htons(GRACE_PERIOD_TYPE);
-	grace_lsa->tlv_period.header.length = htons(GRACE_PERIOD_LENGTH);
+	grace_lsa->tlv_period.header.type = htons(TLV_GRACE_PERIOD_TYPE);
+	grace_lsa->tlv_period.header.length = htons(TLV_GRACE_PERIOD_LENGTH);
 	grace_lsa->tlv_period.interval = htonl(gr_info->grace_period);
 
 	/* Put restart reason. */
-	grace_lsa->tlv_reason.header.type = htons(RESTART_REASON_TYPE);
-	grace_lsa->tlv_reason.header.length = htons(RESTART_REASON_LENGTH);
+	grace_lsa->tlv_reason.header.type = htons(TLV_GRACE_RESTART_REASON_TYPE);
+	grace_lsa->tlv_reason.header.length = htons(TLV_GRACE_RESTART_REASON_LENGTH);
 	grace_lsa->tlv_reason.reason = reason;
 
 	/* Fill LSA Header */

--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -16,6 +16,7 @@
 #include "printfrr.h"
 #include "lib_errors.h"
 
+#include "ospf6_proto.h"
 #include "ospf6d/ospf6_lsa.h"
 #include "ospf6d/ospf6_lsdb.h"
 #include "ospf6d/ospf6_route.h"

--- a/ospf6d/ospf6_gr.h
+++ b/ospf6d/ospf6_gr.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 /*
- * OSPF6 Graceful Retsart helper functions.
+ * OSPF6 Graceful Restart helper functions.
+ * Ref RFC 5187
  *
  * Copyright (C) 2021-22 Vmware, Inc.
  * Rajesh Kumar Girada
@@ -66,52 +67,15 @@ enum ospf6_gr_helper_rejected_reason {
 #define ROUNDUP(val, gran) (((val)-1 | (gran)-1) + 1)
 #endif /* roundup */
 
-/*
- * Generic TLV (type, length, value) macros
- */
-struct tlv_header {
-	uint16_t type;   /* Type of Value */
-	uint16_t length; /* Length of Value portion only, in bytes */
-};
-
-#define TLV_HDR_SIZE (sizeof(struct tlv_header))
-
-#define TLV_BODY_SIZE(tlvh) (ROUNDUP(ntohs((tlvh)->length), sizeof(uint32_t)))
-
-#define TLV_SIZE(tlvh) (uint32_t)(TLV_HDR_SIZE + TLV_BODY_SIZE(tlvh))
-
-#define TLV_HDR_TOP(lsah)                                                      \
-	(struct tlv_header *)((char *)(lsah) + OSPF6_LSA_HEADER_SIZE)
-
-#define TLV_HDR_NEXT(tlvh)                                                     \
-	(struct tlv_header *)((char *)(tlvh) + TLV_SIZE(tlvh))
-
-/* Ref RFC5187 appendix-A */
-/* Grace period TLV */
-#define GRACE_PERIOD_TYPE 1
-#define GRACE_PERIOD_LENGTH 4
-struct grace_tlv_graceperiod {
-	struct tlv_header header;
-	uint32_t interval;
-};
-#define GRACE_PERIOD_TLV_SIZE sizeof(struct grace_tlv_graceperiod)
-
-/* Restart reason TLV */
-#define RESTART_REASON_TYPE 2
-#define RESTART_REASON_LENGTH 1
-struct grace_tlv_restart_reason {
-	struct tlv_header header;
-	uint8_t reason;
-	uint8_t reserved[3];
-};
-#define GRACE_RESTART_REASON_TLV_SIZE sizeof(struct grace_tlv_restart_reason)
+#define GRACE_PERIOD_TLV_SIZE sizeof(struct tlv_grace_period)
+#define GRACE_RESTART_REASON_TLV_SIZE sizeof(struct tlv_grace_restart_reason)
 
 #define OSPF6_GRACE_LSA_MIN_SIZE                                               \
 	GRACE_PERIOD_TLV_SIZE + GRACE_RESTART_REASON_TLV_SIZE
 
 struct ospf6_grace_lsa {
-	struct grace_tlv_graceperiod tlv_period;
-	struct grace_tlv_restart_reason tlv_reason;
+	struct tlv_grace_period tlv_period;
+	struct tlv_grace_restart_reason tlv_reason;
 };
 
 struct advRtr {

--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -32,6 +32,7 @@
 #include "ospf6_neighbor.h"
 #include "ospf6_intra.h"
 #include "ospf6d.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
 #include "ospf6d/ospf6_gr_helper_clippy.c"
@@ -129,8 +130,8 @@ static int ospf6_extract_grace_lsa_fields(struct ospf6_lsa *lsa,
 {
 	struct ospf6_lsa_header *lsah = NULL;
 	struct tlv_header *tlvh = NULL;
-	struct grace_tlv_graceperiod *gracePeriod;
-	struct grace_tlv_restart_reason *grReason;
+	struct tlv_grace_period *gracePeriod;
+	struct tlv_grace_restart_reason *grReason;
 	uint16_t length = 0;
 	int sum = 0;
 
@@ -157,8 +158,8 @@ static int ospf6_extract_grace_lsa_fields(struct ospf6_lsa *lsa,
 		}
 
 		switch (ntohs(tlvh->type)) {
-		case GRACE_PERIOD_TYPE:
-			gracePeriod = (struct grace_tlv_graceperiod *)tlvh;
+		case TLV_GRACE_PERIOD_TYPE:
+			gracePeriod = (struct tlv_grace_period *)tlvh;
 			*interval = ntohl(gracePeriod->interval);
 			sum += TLV_SIZE(tlvh);
 
@@ -167,8 +168,8 @@ static int ospf6_extract_grace_lsa_fields(struct ospf6_lsa *lsa,
 			    || *interval < OSPF6_MIN_GRACE_INTERVAL)
 				return OSPF6_FAILURE;
 			break;
-		case RESTART_REASON_TYPE:
-			grReason = (struct grace_tlv_restart_reason *)tlvh;
+		case TLV_GRACE_RESTART_REASON_TYPE:
+			grReason = (struct tlv_grace_restart_reason *)tlvh;
 			*reason = grReason->reason;
 			sum += TLV_SIZE(tlvh);
 
@@ -1217,8 +1218,8 @@ static int ospf6_grace_lsa_show_info(struct vty *vty, struct ospf6_lsa *lsa,
 {
 	struct ospf6_lsa_header *lsah = NULL;
 	struct tlv_header *tlvh = NULL;
-	struct grace_tlv_graceperiod *gracePeriod;
-	struct grace_tlv_restart_reason *grReason;
+	struct tlv_grace_period *gracePeriod;
+	struct tlv_grace_restart_reason *grReason;
 	uint16_t length = 0;
 	int sum = 0;
 
@@ -1254,8 +1255,8 @@ static int ospf6_grace_lsa_show_info(struct vty *vty, struct ospf6_lsa *lsa,
 		}
 
 		switch (ntohs(tlvh->type)) {
-		case GRACE_PERIOD_TYPE:
-			gracePeriod = (struct grace_tlv_graceperiod *)tlvh;
+		case TLV_GRACE_PERIOD_TYPE:
+			gracePeriod = (struct tlv_grace_period *)tlvh;
 			sum += TLV_SIZE(tlvh);
 
 			if (vty) {
@@ -1271,8 +1272,8 @@ static int ospf6_grace_lsa_show_info(struct vty *vty, struct ospf6_lsa *lsa,
 					   ntohl(gracePeriod->interval));
 			}
 			break;
-		case RESTART_REASON_TYPE:
-			grReason = (struct grace_tlv_restart_reason *)tlvh;
+		case TLV_GRACE_RESTART_REASON_TYPE:
+			grReason = (struct tlv_grace_restart_reason *)tlvh;
 			sum += TLV_SIZE(tlvh);
 			if (vty) {
 				if (use_json)

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -30,6 +30,7 @@
 #include "ospf6d.h"
 #include "ospf6_bfd.h"
 #include "ospf6_zebra.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
 #include "ospf6_proto.h"

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -14,6 +14,7 @@
 #include "plist.h"
 #include "zclient.h"
 
+#include "ospf6_proto.h"
 #include "ospf6_lsa.h"
 #include "ospf6_lsdb.h"
 #include "ospf6_top.h"
@@ -33,7 +34,6 @@
 #include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
-#include "ospf6_proto.h"
 #include "lib/keychain.h"
 #include "ospf6_auth_trailer.h"
 #include "ospf6d/ospf6_interface_clippy.c"

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -32,6 +32,7 @@
 #include "ospf6_flood.h"
 #include "ospf6d.h"
 #include "ospf6_spf.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 
 unsigned char conf_debug_ospf6_brouter = 0;

--- a/ospf6d/ospf6_intra.h
+++ b/ospf6d/ospf6_intra.h
@@ -55,30 +55,6 @@ extern in_addr_t conf_debug_ospf6_brouter_specific_area_id;
 	(IS_OSPF6_DEBUG_BROUTER_SPECIFIC_AREA                                  \
 	 && conf_debug_ospf6_brouter_specific_area_id == (area_id))
 
-/* Router-LSA */
-#define OSPF6_ROUTER_LSA_MIN_SIZE              4U
-struct ospf6_router_lsa {
-	uint8_t bits;
-	uint8_t options[3];
-	/* followed by ospf6_router_lsdesc(s) */
-};
-
-/* Link State Description in Router-LSA */
-#define OSPF6_ROUTER_LSDESC_FIX_SIZE          16U
-struct ospf6_router_lsdesc {
-	uint8_t type;
-	uint8_t reserved;
-	uint16_t metric; /* output cost */
-	uint32_t interface_id;
-	uint32_t neighbor_interface_id;
-	in_addr_t neighbor_router_id;
-};
-
-#define OSPF6_ROUTER_LSDESC_POINTTOPOINT       1
-#define OSPF6_ROUTER_LSDESC_TRANSIT_NETWORK    2
-#define OSPF6_ROUTER_LSDESC_STUB_NETWORK       3
-#define OSPF6_ROUTER_LSDESC_VIRTUAL_LINK       4
-
 enum stub_router_mode {
 	OSPF6_NOT_STUB_ROUTER,
 	OSPF6_IS_STUB_ROUTER,
@@ -98,42 +74,6 @@ enum stub_router_mode {
 	(ntohl(((struct ospf6_router_lsdesc *)(x))->neighbor_interface_id))
 #define ROUTER_LSDESC_GET_NBR_ROUTERID(x)                                      \
 	(((struct ospf6_router_lsdesc *)(x))->neighbor_router_id)
-
-/* Network-LSA */
-#define OSPF6_NETWORK_LSA_MIN_SIZE             4U
-struct ospf6_network_lsa {
-	uint8_t reserved;
-	uint8_t options[3];
-	/* followed by ospf6_netowrk_lsd(s) */
-};
-
-/* Link State Description in Router-LSA */
-#define OSPF6_NETWORK_LSDESC_FIX_SIZE          4U
-struct ospf6_network_lsdesc {
-	in_addr_t router_id;
-};
-#define NETWORK_LSDESC_GET_NBR_ROUTERID(x)                                     \
-	(((struct ospf6_network_lsdesc *)(x))->router_id)
-
-/* Link-LSA */
-#define OSPF6_LINK_LSA_MIN_SIZE               24U /* w/o 1st IPv6 prefix */
-struct ospf6_link_lsa {
-	uint8_t priority;
-	uint8_t options[3];
-	struct in6_addr linklocal_addr;
-	uint32_t prefix_num;
-	/* followed by ospf6 prefix(es) */
-};
-
-/* Intra-Area-Prefix-LSA */
-#define OSPF6_INTRA_PREFIX_LSA_MIN_SIZE       12U /* w/o 1st IPv6 prefix */
-struct ospf6_intra_prefix_lsa {
-	uint16_t prefix_num;
-	uint16_t ref_type;
-	uint32_t ref_id;
-	in_addr_t ref_adv_router;
-	/* followed by ospf6 prefix(es) */
-};
 
 
 #define OSPF6_ROUTER_LSA_SCHEDULE(oa)                                          \

--- a/ospf6d/ospf6_intra.h
+++ b/ospf6d/ospf6_intra.h
@@ -13,10 +13,13 @@ extern in_addr_t conf_debug_ospf6_brouter_specific_area_id;
 #define OSPF6_DEBUG_BROUTER_SUMMARY         0x01
 #define OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER 0x02
 #define OSPF6_DEBUG_BROUTER_SPECIFIC_AREA   0x04
+
 #define OSPF6_DEBUG_BROUTER_ON()                                               \
 	(conf_debug_ospf6_brouter |= OSPF6_DEBUG_BROUTER_SUMMARY)
+
 #define OSPF6_DEBUG_BROUTER_OFF()                                              \
 	(conf_debug_ospf6_brouter &= ~OSPF6_DEBUG_BROUTER_SUMMARY)
+
 #define IS_OSPF6_DEBUG_BROUTER                                                 \
 	(conf_debug_ospf6_brouter & OSPF6_DEBUG_BROUTER_SUMMARY)
 
@@ -26,14 +29,17 @@ extern in_addr_t conf_debug_ospf6_brouter_specific_area_id;
 		conf_debug_ospf6_brouter |=                                    \
 			OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER;                   \
 	} while (0)
+
 #define OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER_OFF()                              \
 	do {                                                                   \
 		conf_debug_ospf6_brouter_specific_router_id = 0;               \
 		conf_debug_ospf6_brouter &=                                    \
 			~OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER;                  \
 	} while (0)
+
 #define IS_OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER                                 \
 	(conf_debug_ospf6_brouter & OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER)
+
 #define IS_OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER_ID(router_id)                   \
 	(IS_OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER                                \
 	 && conf_debug_ospf6_brouter_specific_router_id == (router_id))
@@ -43,14 +49,17 @@ extern in_addr_t conf_debug_ospf6_brouter_specific_area_id;
 		conf_debug_ospf6_brouter_specific_area_id = (area_id);         \
 		conf_debug_ospf6_brouter |= OSPF6_DEBUG_BROUTER_SPECIFIC_AREA; \
 	} while (0)
+
 #define OSPF6_DEBUG_BROUTER_SPECIFIC_AREA_OFF()                                \
 	do {                                                                   \
 		conf_debug_ospf6_brouter_specific_area_id = 0;                 \
 		conf_debug_ospf6_brouter &=                                    \
 			~OSPF6_DEBUG_BROUTER_SPECIFIC_AREA;                    \
 	} while (0)
+
 #define IS_OSPF6_DEBUG_BROUTER_SPECIFIC_AREA                                   \
 	(conf_debug_ospf6_brouter & OSPF6_DEBUG_BROUTER_SPECIFIC_AREA)
+
 #define IS_OSPF6_DEBUG_BROUTER_SPECIFIC_AREA_ID(area_id)                       \
 	(IS_OSPF6_DEBUG_BROUTER_SPECIFIC_AREA                                  \
 	 && conf_debug_ospf6_brouter_specific_area_id == (area_id))
@@ -68,10 +77,13 @@ enum stub_router_mode {
 		 : 0)
 #define ROUTER_LSDESC_GET_METRIC(x)                                            \
 	(ntohs(((struct ospf6_router_lsdesc *)(x))->metric))
+
 #define ROUTER_LSDESC_GET_IFID(x)                                              \
 	(ntohl(((struct ospf6_router_lsdesc *)(x))->interface_id))
+
 #define ROUTER_LSDESC_GET_NBR_IFID(x)                                          \
 	(ntohl(((struct ospf6_router_lsdesc *)(x))->neighbor_interface_id))
+
 #define ROUTER_LSDESC_GET_NBR_ROUTERID(x)                                      \
 	(((struct ospf6_router_lsdesc *)(x))->neighbor_router_id)
 
@@ -82,18 +94,21 @@ enum stub_router_mode {
 			event_add_event(master, ospf6_router_lsa_originate,    \
 					oa, 0, &(oa)->thread_router_lsa);      \
 	} while (0)
+
 #define OSPF6_NETWORK_LSA_SCHEDULE(oi)                                         \
 	do {                                                                   \
 		if (!CHECK_FLAG((oi)->flag, OSPF6_INTERFACE_DISABLE))          \
 			event_add_event(master, ospf6_network_lsa_originate,   \
 					oi, 0, &(oi)->thread_network_lsa);     \
 	} while (0)
+
 #define OSPF6_LINK_LSA_SCHEDULE(oi)                                            \
 	do {                                                                   \
 		if (!CHECK_FLAG((oi)->flag, OSPF6_INTERFACE_DISABLE))          \
 			event_add_event(master, ospf6_link_lsa_originate, oi,  \
 					0, &(oi)->thread_link_lsa);            \
 	} while (0)
+
 #define OSPF6_INTRA_PREFIX_LSA_SCHEDULE_STUB(oa)                               \
 	do {                                                                   \
 		if (CHECK_FLAG((oa)->flag, OSPF6_AREA_ENABLE))                 \
@@ -101,6 +116,7 @@ enum stub_router_mode {
 				master, ospf6_intra_prefix_lsa_originate_stub, \
 				oa, 0, &(oa)->thread_intra_prefix_lsa);        \
 	} while (0)
+
 #define OSPF6_INTRA_PREFIX_LSA_SCHEDULE_TRANSIT(oi)                            \
 	do {                                                                   \
 		if (!CHECK_FLAG((oi)->flag, OSPF6_INTERFACE_DISABLE))          \

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -59,7 +59,19 @@
 #define OSPF6_LSTYPE_LINK             0x0008
 #define OSPF6_LSTYPE_INTRA_PREFIX     0x2009
 #define OSPF6_LSTYPE_GRACE_LSA	      0x000b
-#define OSPF6_LSTYPE_SIZE             0x000c
+
+/* Extended LSA types from RFC 8362 */
+#define OSPF6_LSTYPE_E_ROUTER         (0x20 + OSPF6_LSTYPE_ROUTER)
+#define OSPF6_LSTYPE_E_NETWORK        (0x20 + OSPF6_LSTYPE_NETWORK)
+#define OSPF6_LSTYPE_E_INTER_PREFIX   (0x20 + OSPF6_LSTYPE_INTER_PREFIX)
+#define OSPF6_LSTYPE_E_INTER_ROUTER   (0x20 + OSPF6_LSTYPE_INTER_ROUTER)
+#define OSPF6_LSTYPE_E_AS_EXTERNAL    (0x20 + OSPF6_LSTYPE_AS_EXTERNAL)
+/* 0x20 + OSPF6_LSTYPE_GROUP_MEMBERSHIP is unused, not to be allocated */
+#define OSPF6_LSTYPE_E_TYPE_7         (0x20 + OSPF6_LSTYPE_TYPE_7)
+#define OSPF6_LSTYPE_E_LINK           (0x20 + OSPF6_LSTYPE_LINK)
+#define OSPF6_LSTYPE_E_INTRA_PREFIX   (0x20 + OSPF6_LSTYPE_INTRA_PREFIX)
+
+#define OSPF6_LSTYPE_SIZE             0x002c /* End of sparse lookup table */
 
 /* Masks for LS Type : RFC 2740 A.4.2.1 "LS type" */
 #define OSPF6_LSTYPE_UBIT_MASK        0x8000
@@ -124,6 +136,12 @@ struct ospf6_router_lsa {
 	/* followed by ospf6_router_lsdesc(s) */
 };
 
+/* Extended Router-LSA (RFC 8362)
+ * struct ospf6_e_router_lsa is optionally followed by struct tlv_router_link
+ * Router-Link TLV (RFC 8362)
+ */
+#define ospf6_e_router_lsa ospf6_router_lsa
+
 /* Link State Description in Router-LSA */
 #define OSPF6_ROUTER_LSDESC_FIX_SIZE          16U
 struct ospf6_router_lsdesc {
@@ -148,6 +166,13 @@ struct ospf6_network_lsa {
 	/* followed by ospf6_network_lsdesc(s) */
 };
 
+/* E-Network-LSA (RFC 8362)
+ * struct ospf6_e_network_lsa is followed by Attached-Routers TLV.
+ * If the TLV is not included in the LSA, the LSA is malformed.
+ * If multiple TLVs are included, those subsequent to the first MUST be ignored.
+ */
+#define ospf6_e_network_lsa ospf6_network_lsa
+
 /* Link State Description in Network-LSA */
 #define OSPF6_NETWORK_LSDESC_FIX_SIZE          4U
 struct ospf6_network_lsdesc {
@@ -163,6 +188,11 @@ struct ospf6_inter_prefix_lsa {
 	struct ospf6_prefix prefix;
 };
 
+/* E-Inter-Area-Prefix-LSA (RFC 8362)
+ * MUST be followed by a single Inter-Area-Prefix TLV
+ */
+#define ospf6_e_inter_prefix_lsa ospf6_inter_prefix_lsa
+
 /* Inter-Area-Router-LSA */
 #define OSPF6_INTER_ROUTER_LSA_FIX_SIZE       12U
 struct ospf6_inter_router_lsa {
@@ -171,6 +201,11 @@ struct ospf6_inter_router_lsa {
 	uint32_t metric;
 	uint32_t router_id;
 };
+
+/* E-Inter-Area-Router-LSA
+ * MUST be followed by a single Inter-Area-Router TLV
+ */
+#define ospf6_e_inter_router_lsa ospf6_inter_router_lsa
 
 /* AS-External-LSA */
 #define OSPF6_AS_EXTERNAL_LSA_MIN_SIZE         4U /* w/o IPv6 prefix */
@@ -182,6 +217,11 @@ struct ospf6_as_external_lsa {
 	/* followed by none or one external route tag */
 	/* followed by none or one referenced LS-ID */
 };
+
+/* E-AS-External-LSA
+ * MUST contain a single External-Prefix TLV
+ */
+#define ospf6_e_as_external_lsa ospf6_as_external_lsa
 
 /* FIXME: move nssa lsa here. */
 
@@ -195,6 +235,15 @@ struct ospf6_link_lsa {
 	/* followed by ospf6 prefix(es) */
 };
 
+/* E-Link-LSA
+ * struct ospf6_e_link_lsa is followed by any of:
+ * Intra-Area-Prefix TLV (zero or many MAY be included),
+ * IPv6 Link-Local Address TLV (one SHOULD be included, >1 MUST be ignored),
+ * IPv4 Link-Local Address TLV (one SHOULD be included, >1 MUST be ignored),
+ * one of IPv4/IPv6 lladdr MUST be included.
+ */
+#define ospf6_e_link_lsa ospf6_link_lsa
+
 /* Intra-Area-Prefix-LSA */
 #define OSPF6_INTRA_PREFIX_LSA_MIN_SIZE       12U /* w/o 1st IPv6 prefix */
 struct ospf6_intra_prefix_lsa {
@@ -204,6 +253,12 @@ struct ospf6_intra_prefix_lsa {
 	in_addr_t ref_adv_router;
 	/* followed by ospf6 prefix(es) */
 };
+
+/* E-Intra-Area-Prefix-LSA
+ * Like Intra-Area-Prefix-LSA, except Referenced LS Type MUST be
+ * E-Router-LSA (0xA021) or an E-Network-LSA (0xA022)
+ */
+#define ospf6_e_intra_prefix_lsa ospf6_intra_prefix_lsa
 
 struct ospf6_lsa {
 	char name[64]; /* dump string */

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -116,6 +116,94 @@ static inline uint16_t ospf6_lsa_size(struct ospf6_lsa_header *header)
 #define OSPF6_LSA_IS_CHANGED(L1, L2) ospf6_lsa_is_changed (L1, L2)
 #define OSPF6_LSA_IS_SEQWRAP(L) ((L)->header->seqnum == htonl(OSPF_MAX_SEQUENCE_NUMBER + 1))
 
+/* Router-LSA */
+#define OSPF6_ROUTER_LSA_MIN_SIZE              4U
+struct ospf6_router_lsa {
+	uint8_t bits;
+	uint8_t options[3];
+	/* followed by ospf6_router_lsdesc(s) */
+};
+
+/* Link State Description in Router-LSA */
+#define OSPF6_ROUTER_LSDESC_FIX_SIZE          16U
+struct ospf6_router_lsdesc {
+	uint8_t type;
+	uint8_t reserved;
+	uint16_t metric; /* output cost */
+	uint32_t interface_id;
+	uint32_t neighbor_interface_id;
+	in_addr_t neighbor_router_id;
+};
+
+#define OSPF6_ROUTER_LSDESC_POINTTOPOINT       1
+#define OSPF6_ROUTER_LSDESC_TRANSIT_NETWORK    2
+#define OSPF6_ROUTER_LSDESC_STUB_NETWORK       3
+#define OSPF6_ROUTER_LSDESC_VIRTUAL_LINK       4
+
+/* Network-LSA */
+#define OSPF6_NETWORK_LSA_MIN_SIZE             4U
+struct ospf6_network_lsa {
+	uint8_t reserved;
+	uint8_t options[3];
+	/* followed by ospf6_network_lsdesc(s) */
+};
+
+/* Link State Description in Network-LSA */
+#define OSPF6_NETWORK_LSDESC_FIX_SIZE          4U
+struct ospf6_network_lsdesc {
+	in_addr_t router_id;
+};
+#define NETWORK_LSDESC_GET_NBR_ROUTERID(x)                                     \
+	(((struct ospf6_network_lsdesc *)(x))->router_id)
+
+/* Inter-Area-Prefix-LSA */
+#define OSPF6_INTER_PREFIX_LSA_MIN_SIZE        4U /* w/o IPv6 prefix */
+struct ospf6_inter_prefix_lsa {
+	uint32_t metric;
+	struct ospf6_prefix prefix;
+};
+
+/* Inter-Area-Router-LSA */
+#define OSPF6_INTER_ROUTER_LSA_FIX_SIZE       12U
+struct ospf6_inter_router_lsa {
+	uint8_t mbz;
+	uint8_t options[3];
+	uint32_t metric;
+	uint32_t router_id;
+};
+
+/* AS-External-LSA */
+#define OSPF6_AS_EXTERNAL_LSA_MIN_SIZE         4U /* w/o IPv6 prefix */
+struct ospf6_as_external_lsa {
+	uint32_t bits_metric;
+
+	struct ospf6_prefix prefix;
+	/* followed by none or one forwarding address */
+	/* followed by none or one external route tag */
+	/* followed by none or one referenced LS-ID */
+};
+
+/* FIXME: move nssa lsa here. */
+
+/* Link-LSA */
+#define OSPF6_LINK_LSA_MIN_SIZE               24U /* w/o 1st IPv6 prefix */
+struct ospf6_link_lsa {
+	uint8_t priority;
+	uint8_t options[3];
+	struct in6_addr linklocal_addr;
+	uint32_t prefix_num;
+	/* followed by ospf6 prefix(es) */
+};
+
+/* Intra-Area-Prefix-LSA */
+#define OSPF6_INTRA_PREFIX_LSA_MIN_SIZE       12U /* w/o 1st IPv6 prefix */
+struct ospf6_intra_prefix_lsa {
+	uint16_t prefix_num;
+	uint16_t ref_type;
+	uint32_t ref_id;
+	in_addr_t ref_adv_router;
+	/* followed by ospf6 prefix(es) */
+};
 
 struct ospf6_lsa {
 	char name[64]; /* dump string */

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -33,6 +33,7 @@
 
 #include "ospf6_flood.h"
 #include "ospf6d.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include <netinet/ip6.h>
 #include "lib/libospf.h"

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -30,6 +30,7 @@
 #include "ospf6_lsa.h"
 #include "ospf6_spf.h"
 #include "ospf6_zebra.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
 

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -16,11 +16,11 @@
 #include "frrevent.h"
 #include "lib_errors.h"
 
+#include "ospf6_proto.h"
 #include "ospf6_lsa.h"
 #include "ospf6_lsdb.h"
 #include "ospf6_route.h"
 #include "ospf6_area.h"
-#include "ospf6_proto.h"
 #include "ospf6_abr.h"
 #include "ospf6_asbr.h"
 #include "ospf6_spf.h"

--- a/ospf6d/ospf6_tlv.h
+++ b/ospf6d/ospf6_tlv.h
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * OSPFv3 Type Length Value.
+ *
+ */
+
+#ifndef OSPF6_TLV_H
+#define OSPF6_TLV_H
+
+/*
+ * Generic TLV (type, length, value) macros
+ */
+struct tlv_header {
+	uint16_t type;	 /* Type of Value */
+	uint16_t length; /* Length of Value portion only, in bytes */
+};
+
+#define TLV_HDR_SIZE (sizeof(struct tlv_header))
+
+#define TLV_BODY_SIZE(tlvh) (ROUNDUP(ntohs((tlvh)->length), sizeof(uint32_t)))
+
+#define TLV_SIZE(tlvh) ((uint32_t)(TLV_HDR_SIZE + TLV_BODY_SIZE(tlvh)))
+
+#define TLV_HDR_TOP(lsah)                                                      \
+	((struct tlv_header *)((char *)(lsah) + OSPF6_LSA_HEADER_SIZE))
+
+#define TLV_HDR_NEXT(tlvh)                                                     \
+	((struct tlv_header *)((char *)(tlvh) + TLV_SIZE(tlvh)))
+
+/*
+ * RFC 5187 - OSPFv3 Graceful Restart - Grace-LSA
+ * Graceful restart predates Extended-LSA TLVs and IANA TLV register.
+ */
+/* Grace period TLV. */
+#define TLV_GRACE_PERIOD_TYPE 1
+#define TLV_GRACE_PERIOD_LENGTH 4
+struct tlv_grace_period {
+	struct tlv_header header;
+	uint32_t interval;
+};
+
+/* Restart reason TLV. */
+#define TLV_GRACE_RESTART_REASON_TYPE 2
+#define TLV_GRACE_RESTART_REASON_LENGTH 1
+struct tlv_grace_restart_reason {
+	struct tlv_header header;
+	uint8_t reason;
+	uint8_t reserved[3];
+};
+
+
+#endif /* OSPF6_TLV_H */

--- a/ospf6d/ospf6_tlv.h
+++ b/ospf6d/ospf6_tlv.h
@@ -49,4 +49,148 @@ struct tlv_grace_restart_reason {
 };
 
 
+/*
+ * OSPFv3 Extended-LSA TLV Types
+ *
+ * Ref:
+ * Internet Assigned Numbers Authority
+ * Open Shortest Path First v3 (OSPFv3) Parameters
+ * https://www.iana.org/assignments/ospfv3-parameters/ospfv3-parameters.xhtml
+ *
+ * RFC 8362 - OSPFv3 Link State Advertisement (LSA) Extensibility
+ */
+enum ospf6_extended_lsa_tlv_types {
+	OSPF6_TLV_RESERVED = 0,
+	OSPF6_TLV_ROUTER_LINK = 1,
+	OSPF6_TLV_ATTACHED_ROUTERS = 2,
+	OSPF6_TLV_INTER_AREA_PREFIX = 3,
+	OSPF6_TLV_INTER_AREA_ROUTER = 4,
+	OSPF6_TLV_EXTERNAL_PREFIX = 5,
+	OSPF6_TLV_INTRA_AREA_PREFIX = 6,
+	OSPF6_TLV_IPV6_LL_ADDR = 7,
+	OSPF6_TLV_IPV4_LL_ADDR = 8,
+	OSPF6_TLV_EXTENDED_PREFIX_RANGE = 9 /* RFC 8666 */
+};
+
+#define TLV_ROUTER_LINK_TYPE 1
+#define TLV_ROUTER_LINK_LENGTH 16U /* plus Sub-TLVs */
+/* fields correspond to struct ospf6_router_lsdesc - RFC 8362 3.2 */
+struct tlv_router_link {
+	struct tlv_header header;
+	uint8_t type;
+	uint8_t reserved;
+	uint16_t metric; /* output cost */
+	uint32_t interface_id;
+	uint32_t neighbor_interface_id;
+	in_addr_t neighbor_router_id;
+};
+
+#define TLV_ATTACHED_ROUTERS_TYPE 2
+#define TLV_ATTACHED_ROUTERS_LENGTH 4U /* times adjacent neighbors */
+/* fields correspond to struct ospf6_network_lsdesc - RFC 8362 3.3 */
+struct tlv_attached_routers {
+	struct tlv_header header;
+	in_addr_t router_id;
+};
+
+#define TLV_INTER_AREA_PREFIX_TYPE 3
+#define TLV_INTER_AREA_PREFIX_LENGTH 20U /* plus Sub-TLVs */
+struct tlv_inter_area_prefix {
+	struct tlv_header header;
+	uint32_t metric; /* of which 8bits must be zero */
+	struct ospf6_prefix prefix;
+};
+
+#define TLV_INTER_AREA_ROUTER_TYPE 4
+#define TLV_INTER_AREA_ROUTER_LENGTH 12U /* plus Sub-TLVs */
+struct tlv_inter_area_router {
+	struct tlv_header header;
+	uint8_t mbz;
+	uint8_t options[3];
+	uint32_t metric; /* of which 8 bits must be zero */
+	uint32_t router_id;
+};
+
+#define TLV_EXTERNAL_PREFIX_TYPE 5
+#define TLV_EXTERNAL_PREFIX_LENGTH 24U /* plus Sub-TLVs */
+struct tlv_external_prefix {
+	struct tlv_header header;
+	uint32_t metric; /* FIXME: first 8 bits unclear in RFC 8362. */
+	struct ospf6_prefix prefix;
+};
+
+#define TLV_INTRA_AREA_PREFIX_TYPE 6
+#define TLV_INTRA_AREA_PREFIX_LENGTH 24U /* plus Sub-TLVs */
+struct tlv_intra_area_prefix {
+	struct tlv_header header;
+	uint32_t metric; /* of which 8bits must be zero */
+	struct ospf6_prefix prefix;
+};
+
+#define TLV_IPV6_LINK_LOCAL_ADDRESS_TYPE 7
+#define TLV_IPV6_LINK_LOCAL_ADDRESS_LENGTH 16U /* plus Sub-TLVs */
+struct tlv_ipv6_link_local_address {
+	struct tlv_header header;
+	struct in6_addr addr;
+};
+
+#define TLV_IPV4_LINK_LOCAL_ADDRESS_TYPE 8
+#define TLV_IPV4_LINK_LOCAL_ADDRESS_LENGTH 4U /* plus Sub-TLVs */
+struct tlv_ipv4_link_local_address {
+	struct tlv_header header;
+	struct in_addr addr;
+};
+
+
+/*
+ * OSPFv3 Extended-LSA Sub-TLV Types
+ *
+ * Ref:
+ * Internet Assigned Numbers Authority
+ * Open Shortest Path First v3 (OSPFv3) Parameters
+ * https://www.iana.org/assignments/ospfv3-parameters/ospfv3-parameters.xhtml#extended-lsa-sub-tlvs
+ *
+ * RFC 8362 - OSPFv3 Link State Advertisement (LSA) Extensibility
+ */
+enum ospf6_extended_lsa_stlv_types {
+	OSPF6_STLV_RESERVED = 0,
+	OSPF6_STLV_IPV6_FWD_ADDR = 1,
+	OSPF6_STLV_IPV4_FWD_ADDR = 2,
+	OSPF6_STLV_ROUTE_TAG = 3,
+	OSPF6_STLV_PREFIX_SID = 4, /* RFC 8666 */
+	OSPF6_STLV_ADJ_SID = 5,
+	OSPF6_STLV_LAN_ADJ_SID = 6,
+	OSPF6_STLV_SID_LBL = 7,
+	OSPF6_STLV_GRACEFUL_LINK_SHUTDOWN = 8,
+	OSPF6_STLV_LINK_MSD = 9,
+	OSPF6_STLV_LINK_ATTRS = 10,
+	OSPF6_STLV_APP_LINK_ATTRS = 11, /* RFC 9492 */
+	OSPF6_STLV_SHARED_RISK_LINK_GROUP = 12,
+	OSPF6_STLV_UNIDIRECT_LINK_DELAY = 13,
+	OSPF6_STLV_UNIDIRECT_MINMAX_LINK_DELAY = 14,
+	OSPF6_STLV_UNIDIRECT_DELAY_VARIATION = 15,
+	OSPF6_STLV_UNIDIRECT_LOSS = 16,
+	OSPF6_STLV_UNIDIRECT_RESID_BW = 17,
+	OSPF6_STLV_UNIDIRECT_AVAIL_BW = 18,
+	OSPF6_STLV_UNIDIRECT_USED_BW = 19,
+	OSPF6_STLV_ADMIN_GROUP = 20,
+	OSPF6_STLV_ADMIN_GROUP_EXT = 21,
+	OSPF6_STLV_TE_METRIC = 22,
+	OSPF6_STLV_MAX_BW = 23,
+	OSPF6_STLV_LOCAL_IPV6_ADDR = 24,
+	OSPF6_STLV_REMOTE_IPV6_ADDR = 25,
+	OSPF6_STLV_FLEX_ALG_PREFIX_METRIC = 26,	      /* RFC 9350 */
+	OSPF6_STLV_PREFIX_SOURCE_OSPF_ROUTER_ID = 27, /* RFC 9084 */
+	OSPF6_STLV_PREFIX_SOURCE_ROUTER_ADDR = 28,
+	OSPF6_STLV_L2_BUNDLE_MEMBER_ATTRS = 29, /* RFC 9356 */
+	OSPF6_STLV_SRV6_SID_STRUCTURE = 30,	/* RFC 9513 */
+	OSPF6_STLV_SRV6_ENDX_SID = 31,
+	OSPF6_STLV_SRV6_LAN_ENDX_SID = 32,
+	OSPF6_STLV_FLEX_ALG_ASBR_METRIC = 33,
+	OSPF6_STLV_GENERIC_METRIC = 34,
+	OSPF6_STLV_IP_ALG_PREFIX_REACH = 35, /* RFC 9502 */
+	OSPF6_STLV_IP_FLEX_ALG_ASBR_METRIC = 36
+};
+
+
 #endif /* OSPF6_TLV_H */

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -37,6 +37,7 @@
 #include "ospf6_intra.h"
 #include "ospf6_spf.h"
 #include "ospf6d.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
 #include "ospf6_nssa.h"

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -27,6 +27,7 @@
 #include "ospf6_zebra.h"
 #include "ospf6d.h"
 #include "ospf6_area.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
 

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -30,6 +30,7 @@
 #include "ospf6_flood.h"
 #include "ospf6d.h"
 #include "ospf6_bfd.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
 #include "ospf6_nssa.h"

--- a/ospf6d/subdir.am
+++ b/ospf6d/subdir.am
@@ -58,6 +58,7 @@ noinst_HEADERS += \
 	ospf6d/ospf6_route.h \
 	ospf6d/ospf6_routemap_nb.h \
 	ospf6d/ospf6_spf.h \
+	ospf6d/ospf6_tlv.h \
 	ospf6d/ospf6_top.h \
 	ospf6d/ospf6_zebra.h \
 	ospf6d/ospf6d.h \

--- a/tests/ospf6d/test_lsdb.c
+++ b/tests/ospf6d/test_lsdb.c
@@ -12,6 +12,7 @@
 #include "vector.h"
 #include "vty.h"
 
+#include "ospf6d/ospf6_proto.h" /* for struct ospf6_prefix */
 #include "ospf6d/ospf6_lsa.h"
 #include "ospf6d/ospf6_lsdb.h"
 


### PR DESCRIPTION
This is work in progress towards an implementation of [RFC 8362](https://datatracker.ietf.org/doc/html/rfc8362) - OSPFv3 Link State Advertisement (LSA) Extensibility.

This PR is currently a Draft, for early feedback.