### PR TITLE
bgpd: Ignore routes from evpn if VRF is unknown

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3037,6 +3037,9 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 			vrf_id_to_name(bgp_vrf->vrf_id), evp, parent_pi,
 			parent_pi->flags);
 
+	if (bgp_vrf->vrf_id == VRF_UNKNOWN)
+		return -1;
+
 	/* Create (or fetch) route within the VRF. */
 	/* NOTE: There is no RD here. */
 	if (is_evpn_prefix_ipaddr_v4(evp)) {


### PR DESCRIPTION
Fix for a bug, where FRR fails to install route received for an unknown but later-created VRF - detailed description can be found here:

https://github.com/FRRouting/frr/issues/13708

This is our internal bug fix we introduced that fixed this issue for us shortly after submitting the issue report.