### PR TITLE
bgpd: Return success if lcomm/comm/extcomm name or entry is not found

### DIFF
--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -904,9 +904,9 @@ int community_list_set(struct community_list_handler *ch, const char *name,
 }
 
 /* Unset community-list */
-int community_list_unset(struct community_list_handler *ch, const char *name,
-			 const char *str, const char *seq, int direct,
-			 int style)
+void community_list_unset(struct community_list_handler *ch, const char *name,
+			  const char *str, const char *seq, int direct,
+			  int style)
 {
 	struct community_list_master *cm = NULL;
 	struct community_entry *entry = NULL;
@@ -916,14 +916,14 @@ int community_list_unset(struct community_list_handler *ch, const char *name,
 	/* Lookup community list.  */
 	list = community_list_lookup(ch, name, 0, COMMUNITY_LIST_MASTER);
 	if (list == NULL)
-		return COMMUNITY_LIST_ERR_CANT_FIND_LIST;
+		return;
 
 	cm = community_list_master_lookup(ch, COMMUNITY_LIST_MASTER);
 	/* Delete all of entry belongs to this community-list.  */
 	if (!str) {
 		community_list_delete(cm, list);
 		route_map_notify_dependencies(name, RMAP_EVENT_CLIST_DELETED);
-		return 0;
+		return;
 	}
 
 	if (style == COMMUNITY_LIST_STANDARD)
@@ -936,12 +936,10 @@ int community_list_unset(struct community_list_handler *ch, const char *name,
 		entry = community_list_entry_lookup(list, str, direct);
 
 	if (!entry)
-		return COMMUNITY_LIST_ERR_CANT_FIND_LIST;
+		return;
 
 	community_list_entry_delete(cm, list, entry);
 	route_map_notify_dependencies(name, RMAP_EVENT_CLIST_DELETED);
-
-	return 0;
 }
 
 bool lcommunity_list_any_match(struct lcommunity *lcom,
@@ -1172,9 +1170,9 @@ int lcommunity_list_set(struct community_list_handler *ch, const char *name,
 
 /* Unset community-list.  When str is NULL, delete all of
    community-list entry belongs to the specified name.  */
-int lcommunity_list_unset(struct community_list_handler *ch, const char *name,
-			  const char *str, const char *seq, int direct,
-			  int style)
+void lcommunity_list_unset(struct community_list_handler *ch, const char *name,
+			   const char *str, const char *seq, int direct,
+			   int style)
 {
 	struct community_list_master *cm = NULL;
 	struct community_entry *entry = NULL;
@@ -1185,14 +1183,14 @@ int lcommunity_list_unset(struct community_list_handler *ch, const char *name,
 	/* Lookup community list.  */
 	list = community_list_lookup(ch, name, 0, LARGE_COMMUNITY_LIST_MASTER);
 	if (list == NULL)
-		return COMMUNITY_LIST_ERR_CANT_FIND_LIST;
+		return;
 
 	cm = community_list_master_lookup(ch, LARGE_COMMUNITY_LIST_MASTER);
 	/* Delete all of entry belongs to this community-list.  */
 	if (!str) {
 		community_list_delete(cm, list);
 		route_map_notify_dependencies(name, RMAP_EVENT_LLIST_DELETED);
-		return 0;
+		return;
 	}
 
 	if (style == LARGE_COMMUNITY_LIST_STANDARD)
@@ -1201,7 +1199,7 @@ int lcommunity_list_unset(struct community_list_handler *ch, const char *name,
 		regex = bgp_regcomp(str);
 
 	if (!lcom && !regex)
-		return COMMUNITY_LIST_ERR_MALFORMED_VAL;
+		return;
 
 	if (lcom)
 		entry = community_list_entry_lookup(list, lcom, direct);
@@ -1214,12 +1212,10 @@ int lcommunity_list_unset(struct community_list_handler *ch, const char *name,
 		bgp_regex_free(regex);
 
 	if (!entry)
-		return COMMUNITY_LIST_ERR_CANT_FIND_LIST;
+		return;
 
 	community_list_entry_delete(cm, list, entry);
 	route_map_notify_dependencies(name, RMAP_EVENT_LLIST_DELETED);
-
-	return 0;
 }
 
 /* Set extcommunity-list.  */
@@ -1299,9 +1295,9 @@ int extcommunity_list_set(struct community_list_handler *ch, const char *name,
  * When str is NULL, delete all extcommunity-list entries belonging to the
  * specified name.
  */
-int extcommunity_list_unset(struct community_list_handler *ch, const char *name,
-			    const char *str, const char *seq, int direct,
-			    int style)
+void extcommunity_list_unset(struct community_list_handler *ch,
+			     const char *name, const char *str, const char *seq,
+			     int direct, int style)
 {
 	struct community_list_master *cm = NULL;
 	struct community_entry *entry = NULL;
@@ -1311,14 +1307,14 @@ int extcommunity_list_unset(struct community_list_handler *ch, const char *name,
 	/* Lookup extcommunity list.  */
 	list = community_list_lookup(ch, name, 0, EXTCOMMUNITY_LIST_MASTER);
 	if (list == NULL)
-		return COMMUNITY_LIST_ERR_CANT_FIND_LIST;
+		return;
 
 	cm = community_list_master_lookup(ch, EXTCOMMUNITY_LIST_MASTER);
 	/* Delete all of entry belongs to this extcommunity-list.  */
 	if (!str) {
 		community_list_delete(cm, list);
 		route_map_notify_dependencies(name, RMAP_EVENT_ECLIST_DELETED);
-		return 0;
+		return;
 	}
 
 	if (style == EXTCOMMUNITY_LIST_STANDARD)
@@ -1331,12 +1327,10 @@ int extcommunity_list_unset(struct community_list_handler *ch, const char *name,
 		entry = community_list_entry_lookup(list, str, direct);
 
 	if (!entry)
-		return COMMUNITY_LIST_ERR_CANT_FIND_LIST;
+		return;
 
 	community_list_entry_delete(cm, list, entry);
 	route_map_notify_dependencies(name, RMAP_EVENT_ECLIST_DELETED);
-
-	return 0;
 }
 
 /* Initializa community-list.  Return community-list handler.  */

--- a/bgpd/bgp_clist.h
+++ b/bgpd/bgp_clist.h
@@ -109,11 +109,9 @@ struct community_list_handler {
 };
 
 /* Error code of community-list.  */
-#define COMMUNITY_LIST_ERR_CANT_FIND_LIST        -1
-#define COMMUNITY_LIST_ERR_MALFORMED_VAL         -2
-#define COMMUNITY_LIST_ERR_STANDARD_CONFLICT     -3
-#define COMMUNITY_LIST_ERR_EXPANDED_CONFLICT     -4
-
+#define COMMUNITY_LIST_ERR_MALFORMED_VAL     -1
+#define COMMUNITY_LIST_ERR_STANDARD_CONFLICT -2
+#define COMMUNITY_LIST_ERR_EXPANDED_CONFLICT -3
 /* Handler.  */
 extern struct community_list_handler *bgp_clist;
 

--- a/bgpd/bgp_clist.h
+++ b/bgpd/bgp_clist.h
@@ -124,22 +124,22 @@ extern void community_list_terminate(struct community_list_handler *ch);
 extern int community_list_set(struct community_list_handler *ch,
 			      const char *name, const char *str,
 			      const char *seq, int direct, int style);
-extern int community_list_unset(struct community_list_handler *ch,
-				const char *name, const char *str,
-				const char *seq, int direct, int style);
+extern void community_list_unset(struct community_list_handler *ch,
+				 const char *name, const char *str,
+				 const char *seq, int direct, int style);
 extern int extcommunity_list_set(struct community_list_handler *ch,
 				 const char *name, const char *str,
 				 const char *seq, int direct, int style);
-extern int extcommunity_list_unset(struct community_list_handler *ch,
-				   const char *name, const char *str,
-				   const char *seq, int direct, int style);
+extern void extcommunity_list_unset(struct community_list_handler *ch,
+				    const char *name, const char *str,
+				    const char *seq, int direct, int style);
 extern int lcommunity_list_set(struct community_list_handler *ch,
 			       const char *name, const char *str,
 			       const char *seq, int direct, int style);
 extern bool lcommunity_list_valid(const char *community, int style);
-extern int lcommunity_list_unset(struct community_list_handler *ch,
-				 const char *name, const char *str,
-				 const char *seq, int direct, int style);
+extern void lcommunity_list_unset(struct community_list_handler *ch,
+				  const char *name, const char *str,
+				  const char *seq, int direct, int style);
 
 extern struct community_list_master *
 community_list_master_lookup(struct community_list_handler *ch, int master);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -21827,15 +21827,10 @@ DEFUN (no_community_list_standard_all,
 	argv_find(argv, argc, "COMMUNITY_LIST_NAME", &idx);
 	cl_name_or_number = argv[idx]->arg;
 
-	int ret = community_list_unset(bgp_clist, cl_name_or_number, str, seq,
-				       direct, style);
+	community_list_unset(bgp_clist, cl_name_or_number, str, seq, direct,
+			     style);
 
 	XFREE(MTYPE_TMP, str);
-
-	if (ret < 0) {
-		community_list_perror(vty, ret);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
 
 	return CMD_SUCCESS;
 }
@@ -21940,15 +21935,10 @@ DEFUN (no_community_list_expanded_all,
 	argv_find(argv, argc, "COMMUNITY_LIST_NAME", &idx);
 	cl_name_or_number = argv[idx]->arg;
 
-	int ret = community_list_unset(bgp_clist, cl_name_or_number, str, seq,
-				       direct, style);
+	community_list_unset(bgp_clist, cl_name_or_number, str, seq, direct,
+			     style);
 
 	XFREE(MTYPE_TMP, str);
-
-	if (ret < 0) {
-		community_list_perror(vty, ret);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
 
 	return CMD_SUCCESS;
 }
@@ -22105,7 +22095,6 @@ static int lcommunity_list_set_vty(struct vty *vty, int argc,
 static int lcommunity_list_unset_vty(struct vty *vty, int argc,
 				     struct cmd_token **argv, int style)
 {
-	int ret;
 	int direct = 0;
 	char *str = NULL;
 	int idx = 0;
@@ -22138,17 +22127,12 @@ static int lcommunity_list_unset_vty(struct vty *vty, int argc,
 	argv_find(argv, argc, "LCOMMUNITY_LIST_NAME", &idx);
 
 	/* Unset community list.  */
-	ret = lcommunity_list_unset(bgp_clist, argv[idx]->arg, str, seq, direct,
-				    style);
+	lcommunity_list_unset(bgp_clist, argv[idx]->arg, str, seq, direct,
+			      style);
 
 	/* Free temporary community list string allocated by
 	   argv_concat().  */
 	XFREE(MTYPE_TMP, str);
-
-	if (ret < 0) {
-		community_list_perror(vty, ret);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
 
 	return CMD_SUCCESS;
 }
@@ -22546,15 +22530,10 @@ DEFUN (no_extcommunity_list_standard_all,
 	argv_find(argv, argc, "EXTCOMMUNITY_LIST_NAME", &idx);
 	cl_number_or_name = argv[idx]->arg;
 
-	int ret = extcommunity_list_unset(bgp_clist, cl_number_or_name, str,
-					  seq, direct, style);
+	extcommunity_list_unset(bgp_clist, cl_number_or_name, str, seq, direct,
+				style);
 
 	XFREE(MTYPE_TMP, str);
-
-	if (ret < 0) {
-		community_list_perror(vty, ret);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
 
 	return CMD_SUCCESS;
 }
@@ -22611,15 +22590,10 @@ DEFUN (no_extcommunity_list_expanded_all,
 	argv_find(argv, argc, "EXTCOMMUNITY_LIST_NAME", &idx);
 	cl_number_or_name = argv[idx]->arg;
 
-	int ret = extcommunity_list_unset(bgp_clist, cl_number_or_name, str,
-					  seq, direct, style);
+	extcommunity_list_unset(bgp_clist, cl_number_or_name, str, seq, direct,
+				style);
 
 	XFREE(MTYPE_TMP, str);
-
-	if (ret < 0) {
-		community_list_perror(vty, ret);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
 
 	return CMD_SUCCESS;
 }

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -21715,9 +21715,6 @@ static const char *community_direct_str(int direct)
 static void community_list_perror(struct vty *vty, int ret)
 {
 	switch (ret) {
-	case COMMUNITY_LIST_ERR_CANT_FIND_LIST:
-		vty_out(vty, "%% Can't find community-list\n");
-		break;
 	case COMMUNITY_LIST_ERR_MALFORMED_VAL:
 		vty_out(vty, "%% Malformed community-list value\n");
 		break;


### PR DESCRIPTION
    bgpd: Return success if lcomm/comm/extcomm name or entry is not found
    
    Problem:
    Currently bgp prints `Can't find community-list` and returns CMD_WARNING_CONFIG_FAILED
    error if name or an entry for community, large-community and ext-community is not found. This
    causes frr-reload to fail.
    
    Fix:
    Return success if community, large-community and ext-community name or
    an entry is not found.
    
    Ticket:#3900813
    Testing Done:
    
    Before fix:
    ```
    root@tor-4:mgmt:/var/home/cumulus# cat /etc/frr/frr.conf
    <SNIP>
    bgp large-community-list standard lc22 seq 10 permit 4200857911:011:01 4200857911:011:011555
    no bgp large-community-list standard lc22 seq 10 permit 4200857911:011:01
    <SNIP>
    
    root@tor-4:mgmt:/var/home/cumulus# systemctl reload frr
    Job for frr.service failed.
    See "systemctl status frr.service" and "journalctl -xeu frr.service" for details.
    
    Syslog:
    <SNIP>
    2024-05-21T21:02:51.525965+00:00 tor-4 frrinit.sh[2349145]: % Can't find community-list
    2024-05-21T21:02:51.526487+00:00 tor-4 staticd[6167]: [VTVCM-Y2NW3] Configuration Read in Took: 00:00:00
    2024-05-21T21:02:51.526595+00:00 tor-4 frrinit.sh[2349155]: [2349155|staticd] done
    2024-05-21T21:02:51.526826+00:00 tor-4 frrinit.sh[2349145]: line 176: Failure to communicate[13] to bgpd, line: no bgp large-community-list standard lc22 seq 10 permit 4200857911:011:01
    2024-05-21T21:02:51.527928+00:00 tor-4 frrinit.sh[2349153]: [2349153|watchfrr] done
    2024-05-21T21:02:51.528382+00:00 tor-4 frrinit.sh[2349145]: [2349145|bgpd] Configuration file[/etc/frr/frr.conf] processing failure: 13
    <SNIP>
    ```
    
    After fix:
    ```
    root@tor-4:mgmt:/var/home/cumulus# cat /etc/frr/frr.conf
    <SNIP>
    bgp large-community-list standard lc22 seq 10 permit 4200857911:011:01 4200857911:011:011555
    no bgp large-community-list standard lc22 seq 10 permit 4200857911:011:01
    <SNIP>
    
    root@tor-4:mgmt:/var/home/cumulus# systemctl reload frr
    root@tor-4:mgmt:/var/home/cumulus#
    
    root@tor-4:mgmt:/var/home/cumulus# vtysh -c "show run" | grep lc22
    bgp large-community-list standard lc22 seq 10 permit 4200857911:11:1 4200857911:11:11555
    root@tor-4:mgmt:/var/home/cumulus#
    ```
    
    Signed-off-by: Pooja Jagadeesh Doijode <pdoijode@nvidia.com>
    Signed-off-by: Chirag Shah <chirag@nvidia.com>