### PR TITLE
isisd: When operating multiple areas, the system ID behaves abnormally.

### DIFF
--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -252,11 +252,12 @@ int isis_instance_area_address_destroy(struct nb_cb_destroy_args *args)
 		return NB_ERR_INCONSISTENCY;
 
 	listnode_delete(area->area_addrs, addrp);
-	XFREE(MTYPE_ISIS_AREA_ADDR, addrp);
 	/*
 	 * Last area address - reset the SystemID for this router
 	 */
-	if (listcount(area->area_addrs) == 0) {
+	if (!memcmp(addrp->area_addr + addrp->addr_len, area->isis->sysid,
+		    ISIS_SYS_ID_LEN) &&
+	    listcount(area->area_addrs) == 0) {
 		for (ALL_LIST_ELEMENTS_RO(area->circuit_list, cnode, circuit))
 			for (lvl = IS_LEVEL_1; lvl <= IS_LEVEL_2; ++lvl) {
 				if (circuit->u.bc.is_dr[lvl - 1])
@@ -267,6 +268,8 @@ int isis_instance_area_address_destroy(struct nb_cb_destroy_args *args)
 		if (IS_DEBUG_EVENTS)
 			zlog_debug("Router has no SystemID");
 	}
+
+	XFREE(MTYPE_ISIS_AREA_ADDR, addrp);
 
 	return NB_OK;
 }

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -496,6 +496,7 @@ void isis_area_destroy(struct isis_area *area)
 {
 	struct listnode *node, *nnode;
 	struct isis_circuit *circuit;
+	struct iso_address *addr;
 
 	QOBJ_UNREG(area);
 
@@ -544,6 +545,15 @@ void isis_area_destroy(struct isis_area *area)
 
 	if (!CHECK_FLAG(im->options, F_ISIS_UNIT_TEST))
 		isis_redist_area_finish(area);
+
+	if (listcount(area->area_addrs) > 0) {
+		addr = listgetdata(listhead(area->area_addrs));
+		if (!memcmp(addr->area_addr + addr->addr_len, area->isis->sysid,
+			    ISIS_SYS_ID_LEN)) {
+			memset(area->isis->sysid, 0, ISIS_SYS_ID_LEN);
+			area->isis->sysid_set = 0;
+		}
+	}
 
 	list_delete(&area->area_addrs);
 


### PR DESCRIPTION
When there are multiple areas on the same router, the following two scenarios exist:
1. When clearing the net in one of the areas, the system ID is unconditionally cleared, even if the net does not include the current system ID.
2. When deleting one of the areas, even if the net under the area includes the current system ID, the system ID still remains.

Signed-off-by: zhou-run <zhou.run@h3c.com>
