### PR TITLE
zebra: add route nhg specific counter

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2162,7 +2162,12 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 	 * if this is a new/unknown nhe, a new copy will be allocated
 	 * and stored.
 	 */
-	if (!re->nhe_id) {
+	if (re->nhe_id) {
+		if (api.prefix.family == AF_INET)
+			client->v4_route_nhg_add_cnt++;
+		else
+			client->v6_route_nhg_add_cnt++;
+	} else {
 		zebra_nhe_init(&nhe, afi, ng->nexthop);
 		nhe.nhg.nexthop = ng->nexthop;
 		nhe.backup_info = bnhg;

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1092,6 +1092,10 @@ static void zebra_show_client_detail(struct vty *vty, struct zserv *client)
 		client->v4_route_upd8_cnt, client->v4_route_del_cnt);
 	vty_out(vty, "IPv6        %-12u%-12u%-12u\n", client->v6_route_add_cnt,
 		client->v6_route_upd8_cnt, client->v6_route_del_cnt);
+	vty_out(vty, "IPv4 NHG    %-12u%-12u%-12u\n",
+		client->v4_route_nhg_add_cnt, 0, 0);
+	vty_out(vty, "IPv6 NHG    %-12u%-12u%-12u\n",
+		client->v6_route_nhg_add_cnt, 0, 0);
 	vty_out(vty, "Redist:v4   %-12u%-12u%-12u\n", client->redist_v4_add_cnt,
 		0, client->redist_v4_del_cnt);
 	vty_out(vty, "Redist:v6   %-12u%-12u%-12u\n", client->redist_v6_add_cnt,

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -142,6 +142,8 @@ struct zserv {
 	uint32_t redist_v4_del_cnt;
 	uint32_t redist_v6_add_cnt;
 	uint32_t redist_v6_del_cnt;
+	uint32_t v4_route_nhg_add_cnt;
+	uint32_t v6_route_nhg_add_cnt;
 	uint32_t v4_route_add_cnt;
 	uint32_t v4_route_upd8_cnt;
 	uint32_t v4_route_del_cnt;


### PR DESCRIPTION
It would be nice to account for the route nhgs.
But I don't know how to accommodate this counter with current Add/Update/Delete model.
I look for opinions on it would not be better to account it at protocol level instead?