### PR TITLE
Add option to build pkg with grpc support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,11 @@ Build-Depends: bison,
                python3-sphinx:native,
                texinfo (>= 4.7),
                lua5.3 <pkg.frr.lua>,
-               liblua5.3-dev <pkg.frr.lua>
+               liblua5.3-dev <pkg.frr.lua>,
+	       libgrpc-dev (>=1.16.1) <pkg.frr.grpc>,
+	       libgrpc++-dev (>=1.16.1) <pkg.frr.grpc>,
+	       protobuf-compiler (>=3.6.1) <pkg.frr.grpc>,
+	       protobuf-compiler-grpc (>=1.16.1) <pkg.frr.grpc>
 Standards-Version: 4.5.0.3
 Homepage: https://www.frrouting.org/
 Vcs-Browser: https://github.com/FRRouting/frr/tree/debian/master
@@ -136,3 +140,13 @@ Description: FRRouting suite - Python tools
  .
  Without this package installed, "reload" (as a systemd or init script
  invocation) will not work for the FRR daemons.
+
+Package: frr-grpc
+Architecture: linux-any
+Depends: frr (= ${binary:Version}),
+         ${misc:Depends},
+	 ${shlibs:Depends}
+Description: FRRouting suite - GRPC interface
+ This provides the GRPC interface to the daemons.
+Build-Profiles: <pkg.frr.grpc>
+

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,6 +4,13 @@ Upstream-Contact: maintainers@frrouting.org, security@frrouting.org
 Source: https://www.frrouting.org/
 
 Files: *
+Comment: Note: GPL Versions of FRR binaries
+    If GRPC module is installed then please be aware that the
+    combination of the GRPC (licensed under Apache License) and 
+    FRR (Licensed under GPLv2+) will force the resulting grpc 
+    modules and related binaries to GPLv3
+    Impacted binary files: frr/libfrrgrpc_pb.* frr/modules/grpc.so
+    FRR built or used without GRPC is not impacted
 Copyright: 1996-2003 by the original Zebra authors:
     Kunihiro Ishiguro <kunihiro@zebra.org>
     Toshiaki Takada <takada@zebra.org>
@@ -376,6 +383,24 @@ License: LGPL-2.1+
  On Debian systems, the full text of the GNU Lesser General Public
  License version 2.1 can be found in the file
  `/usr/share/common-licenses/LGPL-2.1'.
+
+License: GPL-3
+ This package is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this package; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ .
+ On Debian systems, the complete text of the GNU General
+ Public License can be found in `/usr/share/common-licenses/GPL-3'.
 
 License: BSD-0-clause
  Redistribution and use in source and binary forms, with or without

--- a/debian/frr-grpc.install
+++ b/debian/frr-grpc.install
@@ -1,0 +1,2 @@
+usr/lib/*/frr/libfrrgrpc_pb.*
+usr/lib/*/frr/modules/grpc.so

--- a/debian/rules
+++ b/debian/rules
@@ -33,6 +33,12 @@ else
   CONF_PIM6=--disable-pim6d
 endif
 
+ifeq ($(filter pkg.frr.grpc,$(DEB_BUILD_PROFILES)),)
+  CONF_GRPC=--disable-grpc
+else
+  CONF_GRPC=--enable-grpc
+endif
+
 export PYTHON=python3
 
 %:
@@ -51,6 +57,7 @@ override_dh_auto_configure:
 		$(CONF_RPKI) \
 		$(CONF_LUA) \
 		$(CONF_PIM6) \
+		$(CONF_GRPC) \
 		--with-libpam \
 		--enable-doc \
 		--enable-doc-html \

--- a/doc/developer/packaging-debian.rst
+++ b/doc/developer/packaging-debian.rst
@@ -68,6 +68,8 @@ buster.)
      +----------------+-------------------+-----------------------------------------+
      | pkg.frr.pim6d  | pkg.frr.nopim6d   | builds pim6d (default enabled)          |
      +----------------+-------------------+-----------------------------------------+
+     | pkg.frr.grpc   | pkg.frr.nogrpc    | builds with grpc support (default: no)  |
+     +----------------+-------------------+-----------------------------------------+
 
    * the ``-uc -us`` options to disable signing the packages with your GPG key
 

--- a/doc/developer/packaging-redhat.rst
+++ b/doc/developer/packaging-redhat.rst
@@ -67,24 +67,27 @@ Tested on CentOS 6, CentOS 7, CentOS 8 and Fedora 24.
 
       ############### FRRouting (FRR) configure options #################
       # with-feature options
-      %{!?with_pam:           %global  with_pam           0 }
-      %{!?with_ospfclient:    %global  with_ospfclient    1 }
-      %{!?with_ospfapi:       %global  with_ospfapi       1 }
-      %{!?with_irdp:          %global  with_irdp          1 }
-      %{!?with_rtadv:         %global  with_rtadv         1 }
-      %{!?with_ldpd:          %global  with_ldpd          1 }
-      %{!?with_nhrpd:         %global  with_nhrpd         1 }
-      %{!?with_eigrp:         %global  with_eigrpd        1 }
-      %{!?with_shared:        %global  with_shared        1 }
-      %{!?with_multipath:     %global  with_multipath     256 }
-      %{!?frr_user:           %global  frr_user           frr }
-      %{!?vty_group:          %global  vty_group          frrvty }
-      %{!?with_fpm:           %global  with_fpm           0 }
-      %{!?with_watchfrr:      %global  with_watchfrr      1 }
+      %{!?with_babeld:        %global  with_babeld        1 }
+      %{!?with_bfdd:          %global  with_bfdd          1 }
       %{!?with_bgp_vnc:       %global  with_bgp_vnc       0 }
+      %{!?with_cumulus:       %global  with_cumulus       0 }
+      %{!?with_eigrpd:        %global  with_eigrpd        1 }
+      %{!?with_fpm:           %global  with_fpm           1 }
+      %{!?with_mgmtd_test_be_client: %global with_mgmtd_test_be_client 0 }
+      %{!?with_ldpd:          %global  with_ldpd          1 }
+      %{!?with_multipath:     %global  with_multipath     256 }
+      %{!?with_nhrpd:         %global  with_nhrpd         1 }
+      %{!?with_ospfapi:       %global  with_ospfapi       1 }
+      %{!?with_ospfclient:    %global  with_ospfclient    1 }
+      %{!?with_pam:           %global  with_pam           0 }
+      %{!?with_pbrd:          %global  with_pbrd          1 }
       %{!?with_pimd:          %global  with_pimd          1 }
       %{!?with_pim6d:         %global  with_pim6d         1 }
-      %{!?with_rpki:          %global  with_rpki          0 }
+      %{!?with_vrrpd:         %global  with_vrrpd         1 }
+      %{!?with_rtadv:         %global  with_rtadv         1 }
+      %{!?with_watchfrr:      %global  with_watchfrr      1 }
+      %{!?with_pathd:         %global  with_pathd         1 }
+      %{!?with_grpc:          %global  with_grpc          0 }
 
 8. Build the RPM::
 

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -30,6 +30,7 @@
 %{!?with_rtadv:         %global  with_rtadv         1 }
 %{!?with_watchfrr:      %global  with_watchfrr      1 }
 %{!?with_pathd:         %global  with_pathd         1 }
+%{!?with_grpc:          %global  with_grpc          0 }
 
 # user and group
 %{!?frr_user:           %global  frr_user           frr }
@@ -201,6 +202,12 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-sphinx
 %endif
 %endif
+%if %{with_grpc}
+BuildRequires:  grpc-devel >= 1.16.1
+BuildRequires:  protobuf-devel >= 3.6.1
+BuildRequires:  protobuf-compiler >= 3.6.1
+BuildRequires:  protobuf-c-devel
+%endif
 %if 0%{?rhel} > 7
 #platform-python-devel is needed for /usr/bin/pathfix.py
 BuildRequires:  platform-python-devel
@@ -300,6 +307,17 @@ Adds SNMP support to FRR's daemons by attaching to net-snmp's snmpd
 through the AgentX protocol.  Provides read-only access to current
 routing state through standard SNMP MIBs.
 
+
+%if %{with_grpc}
+%package grpc
+Summary: GRPC support for FRR daemons
+Group: System Environment/Daemons
+License: GPLv3+
+Requires: %{name} = %{version}-%{release}
+
+%description grpc
+Adds GRPC support to the individual FRR daemons.
+%endif
 
 %prep
 %setup -q -n frr-%{frrversion}
@@ -424,6 +442,11 @@ routing state through standard SNMP MIBs.
     --enable-pathd \
 %else
     --disable-pathd \
+%endif
+%if %{with_grpc}
+    --enable-grpc \
+%else
+    --disable-grpc \
 %endif
     --enable-snmp
     # end
@@ -782,6 +805,12 @@ sed -i 's/ -M rpki//' %{_sysconfdir}/frr/daemons
 %{_libdir}/libfrrsnmp.so*
 %{_libdir}/frr/modules/*snmp.so
 
+
+%if %{with_grpc}
+%files grpc
+%{_libdir}/libfrrgrpc_pb.*
+%{_libdir}/frr/modules/grpc.so
+%endif
 
 %files devel
 %{_libdir}/lib*.so


### PR DESCRIPTION
Adding Debian and RedHat packages with GRPC support built.
The GRPC part will be built as an extra submodule.
By default (at this time), the building of the GRPC is disabled unless specifically requested
To enable it, use `pkg.frr.grpc` as documented in `doc/developer/packaging-debian.rst`
