### PR TITLE
ospf6d: OSPFv3 route change comparision fixed for ASBR-only change

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -1357,9 +1357,10 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 	 * does not match with the new entry then add the new route
 	 */
 	if (old_entry_updated == false) {
-		if ((old == NULL) || (old->type != route->type)
-		    || (old->path.type != route->path.type)
-		    || (old->path.cost != route->path.cost))
+		if ((old == NULL) || (old->type != route->type) ||
+		    (old->path.type != route->path.type) ||
+		    (old->path.cost != route->path.cost) ||
+		    (old->path.router_bits != route->path.router_bits))
 			add_route = true;
 	}
 

--- a/ospf6d/ospf6_route.h
+++ b/ospf6d/ospf6_route.h
@@ -290,6 +290,7 @@ extern const char *const ospf6_path_type_substr[OSPF6_PATH_TYPE_MAX];
 	 prefix_same(&(ra)->prefix, &(rb)->prefix) &&                          \
 	 (ra)->path.type == (rb)->path.type &&                                 \
 	 (ra)->path.cost == (rb)->path.cost &&                                 \
+	 (ra)->path.router_bits == (rb)->path.router_bits &&                   \
 	 (ra)->path.u.cost_e2 == (rb)->path.u.cost_e2 &&                       \
 	 listcount(ra->paths) == listcount(rb->paths) &&                       \
 	 ospf6_route_cmp_nexthops(ra, rb))


### PR DESCRIPTION
When a router route already exists in the area border routers table as an ABR and it solely changes its ABR or ASBR status, the change was missed and border route is not updated. This fixes the comparison for the router_bits in the ospf6_path structure.

This fixes issue https://github.com/FRRouting/frr/issues/16053 although the actual problem is not the computing router (r2) and not the OSPFv3 redistribution (r3).

Fixes: https://github.com/FRRouting/frr/issues/16053