### PR TITLE
Implement BGP-wide configuration for graceful restart

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -2046,9 +2046,10 @@ static int bgp_start_deferral_timer(struct bgp *bgp, afi_t afi, safi_t safi,
 	}
 	gr_info->eor_required++;
 	/* Send message to RIB indicating route update pending */
-	if (gr_info->af_enabled[afi][safi] == false) {
-		gr_info->af_enabled[afi][safi] = true;
-		/* Send message to RIB */
+	if (gr_info->af_enabled == false) {
+		gr_info->af_enabled = true;
+		gr_info->route_sync = false;
+		bgp->gr_route_sync_pending = true;
 		bgp_zebra_update(bgp, afi, safi,
 				 ZEBRA_CLIENT_ROUTE_UPDATE_PENDING);
 	}
@@ -2082,7 +2083,7 @@ static int bgp_update_gr_info(struct peer *peer, afi_t afi, safi_t safi)
 	if (BGP_PEER_GRACEFUL_RESTART_CAPABLE(peer)
 	    && BGP_PEER_RESTARTING_MODE(peer)) {
 		/* Check if the forwarding state is preserved */
-		if (CHECK_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD)) {
+		if (bgp_gr_is_forwarding_preserved(bgp)) {
 			gr_info = &(bgp->gr_info[afi][safi]);
 			ret = bgp_start_deferral_timer(bgp, afi, safi, gr_info);
 		}
@@ -2199,8 +2200,7 @@ bgp_establish(struct peer_connection *connection)
 			} else {
 				if (BGP_PEER_GRACEFUL_RESTART_CAPABLE(peer) &&
 				    BGP_PEER_RESTARTING_MODE(peer) &&
-				    CHECK_FLAG(peer->bgp->flags,
-					       BGP_FLAG_GR_PRESERVE_FWD))
+				    bgp_gr_is_forwarding_preserved(peer->bgp))
 					peer->bgp->gr_info[afi][safi]
 						.eor_required++;
 			}
@@ -2702,10 +2702,14 @@ bgp_peer_inherit_global_gr_mode(struct peer *peer,
 	switch (global_gr_mode) {
 	case GLOBAL_HELPER:
 		BGP_PEER_GR_HELPER_ENABLE(peer);
+		break;
 	case GLOBAL_GR:
 		BGP_PEER_GR_ENABLE(peer);
+		break;
 	case GLOBAL_DISABLE:
 		BGP_PEER_GR_DISABLE(peer);
+		break;
+	case GLOBAL_INVALID:
 	default:
 		zlog_err("Unexpected Global GR mode %d", global_gr_mode);
 	}

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -151,7 +151,7 @@ int bgp_neighbor_graceful_restart(struct peer *peer,
 				  enum peer_gr_command peer_gr_cmd);
 unsigned int bgp_peer_gr_action(struct peer *peer, enum peer_mode old_peer_state,
 				enum peer_mode new_peer_state);
-void bgp_peer_move_to_gr_mode(struct peer *peer, int new_state);
+void bgp_peer_move_to_gr_mode(struct peer *peer, enum peer_mode new_state);
 unsigned int bgp_peer_gr_helper_enable(struct peer *peer);
 unsigned int bgp_peer_gr_enable(struct peer *peer);
 unsigned int bgp_peer_gr_global_inherit(struct peer *peer);
@@ -160,9 +160,6 @@ enum peer_mode bgp_peer_gr_mode_get(struct peer *peer);
 enum global_mode bgp_global_gr_mode_get(struct bgp *bgp);
 enum peer_mode bgp_get_peer_gr_mode_from_flags(struct peer *peer);
 unsigned int bgp_peer_gr_global_inherit_unset(struct peer *peer);
-int bgp_gr_lookup_n_update_all_peer(struct bgp *bgp,
-		enum global_mode global_new_state,
-		enum global_mode global_old_state);
 void bgp_peer_gr_flags_update(struct peer *peer);
 const char *print_peer_gr_mode(enum peer_mode pr_mode);
 const char *print_peer_gr_cmd(enum peer_gr_command pr_gr_cmd);

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -519,7 +519,9 @@ int main(int argc, char **argv)
 		bgp_option_set(BGP_OPT_NO_FIB);
 	if (no_zebra_flag)
 		bgp_option_set(BGP_OPT_NO_ZEBRA);
-	SET_FLAG(bm->flags, BM_FLAG_GRACEFUL_RESTART);
+	if (bgpd_di.graceful_restart)
+		SET_FLAG(bm->flags, BM_FLAG_GRACEFUL_RESTART);
+
 	bgp_error_init();
 	/* Initializations. */
 	libagentx_init();

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -511,6 +511,7 @@ int main(int argc, char **argv)
 
 	/* BGP master init. */
 	bgp_master_init(frr_init(), buffer_size, addresses);
+	bm->startup_time = monotime(NULL);
 	bm->port = bgp_port;
 	if (bgp_port == 0)
 		bgp_option_set(BGP_OPT_NO_LISTEN);
@@ -518,6 +519,7 @@ int main(int argc, char **argv)
 		bgp_option_set(BGP_OPT_NO_FIB);
 	if (no_zebra_flag)
 		bgp_option_set(BGP_OPT_NO_ZEBRA);
+	SET_FLAG(bm->flags, BM_FLAG_GRACEFUL_RESTART);
 	bgp_error_init();
 	/* Initializations. */
 	libagentx_init();

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -519,20 +519,17 @@ static int bgp_capability_restart(struct peer *peer,
 	UNSET_FLAG(restart_flag_time, 0xF000);
 	peer->v_gr_restart = restart_flag_time;
 
-	if (bgp_debug_neighbor_events(peer)) {
-		zlog_debug(
-			"%s Peer has%srestarted. Restart Time: %d, N-bit set: %s",
-			peer->host,
-			CHECK_FLAG(peer->cap,
-				   PEER_CAP_GRACEFUL_RESTART_R_BIT_RCV)
-				? " "
-				: " not ",
-			peer->v_gr_restart,
-			CHECK_FLAG(peer->cap,
-				   PEER_CAP_GRACEFUL_RESTART_N_BIT_RCV)
-				? "yes"
-				: "no");
-	}
+	if (bgp_debug_neighbor_events(peer))
+		zlog_debug("%pBP OPEN has GR capability, Restart time %d R-bit %s N-bit %s",
+			   peer, peer->v_gr_restart,
+			   CHECK_FLAG(peer->cap,
+				      PEER_CAP_GRACEFUL_RESTART_R_BIT_RCV)
+				   ? "SET"
+				   : "NOT-SET",
+			   CHECK_FLAG(peer->cap,
+				      PEER_CAP_GRACEFUL_RESTART_N_BIT_RCV)
+				   ? "SET"
+				   : "NOT-SET");
 
 	while (stream_get_getp(s) + 4 <= end) {
 		afi_t afi;
@@ -556,14 +553,12 @@ static int bgp_capability_restart(struct peer *peer,
 					iana_safi2str(pkt_safi));
 		} else {
 			if (bgp_debug_neighbor_events(peer))
-				zlog_debug(
-					"%s Address family %s is%spreserved",
-					peer->host, get_afi_safi_str(afi, safi, false),
-					CHECK_FLAG(
-						peer->af_cap[afi][safi],
-						PEER_CAP_RESTART_AF_PRESERVE_RCV)
-						? " "
-						: " not ");
+				zlog_debug("%pBP F-bit %s for %s", peer,
+					   CHECK_FLAG(peer->af_cap[afi][safi],
+						      PEER_CAP_RESTART_AF_PRESERVE_RCV)
+						   ? "SET"
+						   : "NOT-SET",
+					   get_afi_safi_str(afi, safi, false));
 
 			SET_FLAG(peer->af_cap[afi][safi],
 				 PEER_CAP_RESTART_AF_RCV);

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1587,14 +1587,11 @@ static void bgp_peer_send_gr_capability(struct stream *s, struct peer *peer,
 	uint32_t restart_time;
 	unsigned long capp = 0;
 	unsigned long rcapp = 0;
+	struct bgp *bgp = peer->bgp;
 
 	if (!CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART)
 	    && !CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART_HELPER))
 		return;
-
-	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-		zlog_debug("[BGP_GR] Sending helper Capability for Peer :%s :",
-			   peer->host);
 
 	SET_FLAG(peer->cap, PEER_CAP_RESTART_ADV);
 	stream_putc(s, BGP_OPEN_OPT_CAP);
@@ -1605,41 +1602,40 @@ static void bgp_peer_send_gr_capability(struct stream *s, struct peer *peer,
 	/* Set Restart Capability Len Pointer */
 	rcapp = stream_get_endp(s);
 	stream_putc(s, 0);
-	restart_time = peer->bgp->restart_time;
-	if (peer->bgp->t_startup) {
+	restart_time = bgp->restart_time;
+	if (peer->bgp->t_startup || bgp_in_graceful_restart()) {
 		SET_FLAG(restart_time, GRACEFUL_RESTART_R_BIT);
 		SET_FLAG(peer->cap, PEER_CAP_GRACEFUL_RESTART_R_BIT_ADV);
-		if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-			zlog_debug("[BGP_GR] Sending R-Bit for peer: %s",
-				   peer->host);
 	}
 
-	if (CHECK_FLAG(peer->bgp->flags, BGP_FLAG_GRACEFUL_NOTIFICATION)) {
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_NOTIFICATION)) {
 		SET_FLAG(restart_time, GRACEFUL_RESTART_N_BIT);
 		SET_FLAG(peer->cap, PEER_CAP_GRACEFUL_RESTART_N_BIT_ADV);
-		if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-			zlog_debug("[BGP_GR] Sending N-Bit for peer: %s",
-				   peer->host);
 	}
 
 	stream_putw(s, restart_time);
+
+	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
+		zlog_debug("%s: Sending GR Capability, Restart time %d R-bit %s, N-bit %s",
+			   peer->host, bgp->restart_time,
+			   CHECK_FLAG(peer->cap,
+				      PEER_CAP_GRACEFUL_RESTART_R_BIT_ADV)
+				   ? "SET"
+				   : "NOT-SET",
+			   CHECK_FLAG(peer->cap,
+				      PEER_CAP_GRACEFUL_RESTART_N_BIT_ADV)
+				   ? "SET"
+				   : "NOT-SET");
 
 	/* Send address-family specific graceful-restart capability
 	 * only when GR config is present
 	 */
 	if (CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART)) {
-		if (CHECK_FLAG(peer->bgp->flags, BGP_FLAG_GR_PRESERVE_FWD)
-		    && BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-			zlog_debug("[BGP_GR] F bit Set");
-
 		FOREACH_AFI_SAFI (afi, safi) {
+			bool f_bit = false;
+
 			if (!peer->afc[afi][safi])
 				continue;
-
-			if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-				zlog_debug(
-					"[BGP_GR] Sending GR Capability for AFI :%d :, SAFI :%d:",
-					afi, safi);
 
 			/* Convert AFI, SAFI to values for
 			 * packet.
@@ -1648,11 +1644,15 @@ static void bgp_peer_send_gr_capability(struct stream *s, struct peer *peer,
 						  &pkt_safi);
 			stream_putw(s, pkt_afi);
 			stream_putc(s, pkt_safi);
-			if (CHECK_FLAG(peer->bgp->flags,
-				       BGP_FLAG_GR_PRESERVE_FWD))
-				stream_putc(s, GRACEFUL_RESTART_F_BIT);
-			else
-				stream_putc(s, 0);
+
+			f_bit = bgp_gr_is_forwarding_preserved(bgp);
+
+			if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
+				zlog_debug("... F-bit %s for %s",
+					   f_bit ? "SET" : "NOT-SET",
+					   get_afi_safi_str(afi, safi, false));
+
+			stream_putc(s, f_bit ? GRACEFUL_RESTART_F_BIT : 0);
 		}
 	}
 

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1296,7 +1296,7 @@ void bgp_capability_send(struct peer *peer, afi_t afi, safi_t safi,
 		stream_putc(s, 0);
 		gr_restart_time = peer->bgp->restart_time;
 
-		if (peer->bgp->t_startup) {
+		if (peer->bgp->t_startup || bgp_in_graceful_restart()) {
 			SET_FLAG(gr_restart_time, GRACEFUL_RESTART_R_BIT);
 			SET_FLAG(peer->cap, PEER_CAP_GRACEFUL_RESTART_R_BIT_ADV);
 		}

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -696,10 +696,9 @@ void bgp_open_send(struct peer_connection *connection)
 	bgp_packet_set_size(s);
 
 	if (bgp_debug_neighbor_events(peer))
-		zlog_debug(
-			"%s sending OPEN, version %d, my as %u, holdtime %d, id %pI4",
-			peer->host, BGP_VERSION_4, local_as, send_holdtime,
-			&peer->local_id);
+		zlog_debug("%pBP fd %d sending OPEN, version %d, my as %u, holdtime %d, id %pI4",
+			   peer, peer->connection->fd, BGP_VERSION_4, local_as,
+			   send_holdtime, &peer->local_id);
 
 	/* Dump packet if debug option is set. */
 	/* bgp_packet_dump (s); */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3652,7 +3652,7 @@ DEFUN (bgp_neighbor_graceful_restart_disable_set,
 
 	ret = bgp_neighbor_graceful_restart(peer, PEER_DISABLE_CMD);
 	if (ret == BGP_GR_SUCCESS) {
-		if (peer->bgp->t_startup)
+		if (peer->bgp->t_startup || bgp_in_graceful_restart())
 			bgp_peer_gr_flags_update(peer);
 
 		VTY_BGP_GR_ROUTER_DETECT(bgp, peer, peer->bgp->peer);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3706,8 +3706,9 @@ DEFPY (neighbor_graceful_shutdown,
 	afi_t afi;
 	safi_t safi;
 	struct peer *peer;
-	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	int ret;
+
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
 	peer = peer_and_group_lookup_vty(vty, neighbor);
 	if (!peer)

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3019,6 +3019,98 @@ DEFUN (no_bgp_deterministic_med,
 	return CMD_SUCCESS;
 }
 
+static int bgp_inst_gr_config_vty(struct vty *vty, struct bgp *bgp, bool on,
+				  bool disable)
+{
+	int ret = BGP_GR_FAILURE;
+
+	/*
+	 * Update the instance and all its peers, if appropriate.
+	 * Then, inform zebra of BGP's GR capabilities, if needed.
+	 */
+	if (disable)
+		ret = bgp_gr_update_all(bgp, on ? GLOBAL_DISABLE_CMD
+						: NO_GLOBAL_DISABLE_CMD);
+	else
+		ret = bgp_gr_update_all(bgp,
+					on ? GLOBAL_GR_CMD : NO_GLOBAL_GR_CMD);
+
+	VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(bgp, bgp->peer,
+							      ret);
+	return ret;
+}
+
+static int bgp_global_gr_config_vty(struct vty *vty, bool on, bool disable)
+{
+	struct listnode *node, *nnode;
+	struct bgp *bgp;
+	bool vrf_cfg = false;
+	int ret = BGP_GR_FAILURE;
+
+	if (disable) {
+		if ((on && CHECK_FLAG(bm->flags, BM_FLAG_GR_DISABLED)) ||
+		    (!on && !CHECK_FLAG(bm->flags, BM_FLAG_GR_DISABLED)))
+			return CMD_SUCCESS;
+	} else {
+		if ((on && CHECK_FLAG(bm->flags, BM_FLAG_GR_RESTARTER)) ||
+		    (!on && !CHECK_FLAG(bm->flags, BM_FLAG_GR_RESTARTER)))
+			return CMD_SUCCESS;
+	}
+
+	/* See if GR is set per-vrf and warn user to delete */
+	if (!CHECK_FLAG(bm->flags, BM_FLAG_GR_CONFIGURED)) {
+		for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
+			enum global_mode gr_mode = bgp_global_gr_mode_get(bgp);
+
+			if (gr_mode != GLOBAL_HELPER) {
+				vty_out(vty,
+					"%% graceful-restart configuration found in %s, mode %d\n",
+					bgp->name_pretty, gr_mode);
+				vrf_cfg = true;
+			}
+		}
+	}
+
+	if (vrf_cfg) {
+		vty_out(vty,
+			"%%Failed: global graceful-restart not permitted with per-vrf configuration\n");
+		return CMD_WARNING;
+	}
+
+	/* Set flag globally */
+	if (on) {
+		if (disable) {
+			UNSET_FLAG(bm->flags, BM_FLAG_GR_RESTARTER);
+			SET_FLAG(bm->flags, BM_FLAG_GR_DISABLED);
+		} else {
+			SET_FLAG(bm->flags, BM_FLAG_GR_RESTARTER);
+			UNSET_FLAG(bm->flags, BM_FLAG_GR_DISABLED);
+		}
+	} else {
+		if (disable)
+			UNSET_FLAG(bm->flags, BM_FLAG_GR_DISABLED);
+		else
+			UNSET_FLAG(bm->flags, BM_FLAG_GR_RESTARTER);
+	}
+
+	/* Initiate processing for all BGP instances. */
+	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
+		ret = bgp_inst_gr_config_vty(vty, bgp, on, disable);
+		if (ret != BGP_GR_SUCCESS)
+			vty_out(vty,
+				"%% Applying global graceful-restart %s config to vrf %s failed, error %d\n",
+				(disable) ? "disable" : "",
+				bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT
+					? "Default"
+					: bgp->name,
+				ret);
+	}
+
+	vty_out(vty,
+		"Graceful restart configuration changed, reset all peers to take effect\n");
+	return bgp_vty_return(vty, ret);
+}
+
 /* "bgp graceful-restart mode" configuration. */
 DEFUN (bgp_graceful_restart,
 	bgp_graceful_restart_cmd,
@@ -3027,6 +3119,9 @@ DEFUN (bgp_graceful_restart,
 	GR_CMD
       )
 {
+	if (vty->node == CONFIG_NODE)
+		return bgp_global_gr_config_vty(vty, true, false);
+
 	int ret = BGP_GR_FAILURE;
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
@@ -3034,11 +3129,8 @@ DEFUN (bgp_graceful_restart,
 
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
-	ret = bgp_gr_update_all(bgp, GLOBAL_GR_CMD);
+	ret = bgp_inst_gr_config_vty(vty, bgp, true, false);
 	if (ret == BGP_GR_SUCCESS) {
-		VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(bgp,
-								      bgp->peer,
-								      ret);
 		vty_out(vty,
 			"Graceful restart configuration changed, reset all peers to take effect\n");
 	}
@@ -3057,6 +3149,9 @@ DEFUN (no_bgp_graceful_restart,
 	NO_GR_CMD
       )
 {
+	if (vty->node == CONFIG_NODE)
+		return bgp_global_gr_config_vty(vty, false, false);
+
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
@@ -3064,7 +3159,7 @@ DEFUN (no_bgp_graceful_restart,
 
 	int ret = BGP_GR_FAILURE;
 
-	ret = bgp_gr_update_all(bgp, NO_GLOBAL_GR_CMD);
+	ret = bgp_inst_gr_config_vty(vty, bgp, false, false);
 	if (ret == BGP_GR_SUCCESS) {
 		VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(bgp,
 								      bgp->peer,
@@ -3087,12 +3182,21 @@ DEFUN (bgp_graceful_restart_stalepath_time,
 	"Set the max time to hold onto restarting peer's stale paths\n"
 	"Delay value (seconds)\n")
 {
-	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	int idx_number = 3;
 	uint32_t stalepath;
 
 	stalepath = strtoul(argv[idx_number]->arg, NULL, 10);
-	bgp->stalepath_time = stalepath;
+	if (vty->node == CONFIG_NODE) {
+		struct listnode *node, *nnode;
+		struct bgp *bgp;
+
+		bm->stalepath_time = stalepath;
+		for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp))
+			bgp->stalepath_time = stalepath;
+	} else {
+		VTY_DECLVAR_CONTEXT(bgp, bgp);
+		bgp->stalepath_time = stalepath;
+	}
 	return CMD_SUCCESS;
 }
 
@@ -3104,20 +3208,32 @@ DEFUN (bgp_graceful_restart_restart_time,
 	"Set the time to wait to delete stale routes before a BGP open message is received\n"
 	"Delay value (seconds)\n")
 {
-	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	int idx_number = 3;
 	uint32_t restart;
 	struct listnode *node, *nnode;
 	struct peer *peer;
 
 	restart = strtoul(argv[idx_number]->arg, NULL, 10);
-	bgp->restart_time = restart;
 
-	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer))
-		bgp_capability_send(peer, AFI_IP, SAFI_UNICAST,
-				    CAPABILITY_CODE_RESTART,
-				    CAPABILITY_ACTION_SET);
+	if (vty->node == CONFIG_NODE) {
+		struct bgp *bgp;
 
+		bm->restart_time = restart;
+		for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
+			bgp->restart_time = restart;
+			for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer))
+				bgp_capability_send(peer, AFI_IP, SAFI_UNICAST,
+						    CAPABILITY_CODE_RESTART,
+						    CAPABILITY_ACTION_SET);
+		}
+	} else {
+		VTY_DECLVAR_CONTEXT(bgp, bgp);
+		bgp->restart_time = restart;
+		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer))
+			bgp_capability_send(peer, AFI_IP, SAFI_UNICAST,
+					    CAPABILITY_CODE_RESTART,
+					    CAPABILITY_ACTION_SET);
+	}
 	return CMD_SUCCESS;
 }
 
@@ -3129,16 +3245,32 @@ DEFUN (bgp_graceful_restart_select_defer_time,
        "Set the time to defer the BGP route selection after restart\n"
        "Delay value (seconds, 0 - disable)\n")
 {
-	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	int idx_number = 3;
 	uint32_t defer_time;
 
 	defer_time = strtoul(argv[idx_number]->arg, NULL, 10);
-	bgp->select_defer_time = defer_time;
-	if (defer_time == 0)
-		SET_FLAG(bgp->flags, BGP_FLAG_SELECT_DEFER_DISABLE);
-	else
-		UNSET_FLAG(bgp->flags, BGP_FLAG_SELECT_DEFER_DISABLE);
+	if (vty->node == CONFIG_NODE) {
+		struct listnode *node, *nnode;
+		struct bgp *bgp;
+
+		bm->select_defer_time = defer_time;
+		for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
+			bgp->select_defer_time = defer_time;
+			if (defer_time == 0)
+				SET_FLAG(bgp->flags,
+					 BGP_FLAG_SELECT_DEFER_DISABLE);
+			else
+				UNSET_FLAG(bgp->flags,
+					   BGP_FLAG_SELECT_DEFER_DISABLE);
+		}
+	} else {
+		VTY_DECLVAR_CONTEXT(bgp, bgp);
+		bgp->select_defer_time = defer_time;
+		if (defer_time == 0)
+			SET_FLAG(bgp->flags, BGP_FLAG_SELECT_DEFER_DISABLE);
+		else
+			UNSET_FLAG(bgp->flags, BGP_FLAG_SELECT_DEFER_DISABLE);
+	}
 
 	return CMD_SUCCESS;
 }
@@ -3152,9 +3284,17 @@ DEFUN (no_bgp_graceful_restart_stalepath_time,
 	"Set the max time to hold onto restarting peer's stale paths\n"
 	"Delay value (seconds)\n")
 {
-	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	if (vty->node == CONFIG_NODE) {
+		struct listnode *node, *nnode;
+		struct bgp *bgp;
 
-	bgp->stalepath_time = BGP_DEFAULT_STALEPATH_TIME;
+		bm->stalepath_time = BGP_DEFAULT_STALEPATH_TIME;
+		for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp))
+			bgp->stalepath_time = BGP_DEFAULT_STALEPATH_TIME;
+	} else {
+		VTY_DECLVAR_CONTEXT(bgp, bgp);
+		bgp->stalepath_time = BGP_DEFAULT_STALEPATH_TIME;
+	}
 	return CMD_SUCCESS;
 }
 
@@ -3167,17 +3307,30 @@ DEFUN (no_bgp_graceful_restart_restart_time,
 	"Set the time to wait to delete stale routes before a BGP open message is received\n"
 	"Delay value (seconds)\n")
 {
-	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	struct listnode *node, *nnode;
 	struct peer *peer;
 
-	bgp->restart_time = BGP_DEFAULT_RESTART_TIME;
+	if (vty->node == CONFIG_NODE) {
+		struct bgp *bgp;
 
-	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer))
-		bgp_capability_send(peer, AFI_IP, SAFI_UNICAST,
-				    CAPABILITY_CODE_RESTART,
-				    CAPABILITY_ACTION_UNSET);
+		bm->restart_time = BGP_DEFAULT_RESTART_TIME;
+		for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
+			bgp->restart_time = BGP_DEFAULT_RESTART_TIME;
 
+			for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer))
+				bgp_capability_send(peer, AFI_IP, SAFI_UNICAST,
+						    CAPABILITY_CODE_RESTART,
+						    CAPABILITY_ACTION_UNSET);
+		}
+	} else {
+		VTY_DECLVAR_CONTEXT(bgp, bgp);
+		bgp->restart_time = BGP_DEFAULT_RESTART_TIME;
+
+		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer))
+			bgp_capability_send(peer, AFI_IP, SAFI_UNICAST,
+					    CAPABILITY_CODE_RESTART,
+					    CAPABILITY_ACTION_UNSET);
+	}
 	return CMD_SUCCESS;
 }
 
@@ -3190,10 +3343,21 @@ DEFUN (no_bgp_graceful_restart_select_defer_time,
        "Set the time to defer the BGP route selection after restart\n"
        "Delay value (seconds)\n")
 {
-	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	if (vty->node == CONFIG_NODE) {
+		struct listnode *node, *nnode;
+		struct bgp *bgp;
 
-	bgp->select_defer_time = BGP_DEFAULT_SELECT_DEFERRAL_TIME;
-	UNSET_FLAG(bgp->flags, BGP_FLAG_SELECT_DEFER_DISABLE);
+		bm->select_defer_time = BGP_DEFAULT_SELECT_DEFERRAL_TIME;
+		for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
+			bgp->select_defer_time =
+				BGP_DEFAULT_SELECT_DEFERRAL_TIME;
+			UNSET_FLAG(bgp->flags, BGP_FLAG_SELECT_DEFER_DISABLE);
+		}
+	} else {
+		VTY_DECLVAR_CONTEXT(bgp, bgp);
+		bgp->select_defer_time = BGP_DEFAULT_SELECT_DEFERRAL_TIME;
+		UNSET_FLAG(bgp->flags, BGP_FLAG_SELECT_DEFER_DISABLE);
+	}
 
 	return CMD_SUCCESS;
 }
@@ -3205,8 +3369,17 @@ DEFUN (bgp_graceful_restart_preserve_fw,
 	"Graceful restart capability parameters\n"
 	"Sets F-bit indication that fib is preserved while doing Graceful Restart\n")
 {
-	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	SET_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD);
+	if (vty->node == CONFIG_NODE) {
+		struct listnode *node, *nnode;
+		struct bgp *bgp;
+
+		SET_FLAG(bm->flags, BM_FLAG_GR_PRESERVE_FWD);
+		for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp))
+			SET_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD);
+	} else {
+		VTY_DECLVAR_CONTEXT(bgp, bgp);
+		SET_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD);
+	}
 	return CMD_SUCCESS;
 }
 
@@ -3218,8 +3391,17 @@ DEFUN (no_bgp_graceful_restart_preserve_fw,
 	"Graceful restart capability parameters\n"
 	"Unsets F-bit indication that fib is preserved while doing Graceful Restart\n")
 {
-	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	UNSET_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD);
+	if (vty->node == CONFIG_NODE) {
+		struct listnode *node, *nnode;
+		struct bgp *bgp;
+
+		UNSET_FLAG(bm->flags, BM_FLAG_GR_PRESERVE_FWD);
+		for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp))
+			UNSET_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD);
+	} else {
+		VTY_DECLVAR_CONTEXT(bgp, bgp);
+		UNSET_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD);
+	}
 	return CMD_SUCCESS;
 }
 
@@ -3271,6 +3453,9 @@ DEFUN (bgp_graceful_restart_disable,
 	BGP_STR
 	GR_DISABLE)
 {
+	if (vty->node == CONFIG_NODE)
+		return bgp_global_gr_config_vty(vty, true, true);
+
 	int ret = BGP_GR_FAILURE;
 	struct listnode *node, *nnode;
 	struct peer *peer;
@@ -3281,11 +3466,8 @@ DEFUN (bgp_graceful_restart_disable,
 
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
-	ret = bgp_gr_update_all(bgp, GLOBAL_DISABLE_CMD);
+	ret = bgp_inst_gr_config_vty(vty, bgp, true, true);
 	if (ret == BGP_GR_SUCCESS) {
-		VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(bgp,
-								      bgp->peer,
-								      ret);
 		vty_out(vty,
 			"Graceful restart configuration changed, reset all peers to take effect\n");
 
@@ -3313,6 +3495,9 @@ DEFUN (no_bgp_graceful_restart_disable,
 	NO_GR_DISABLE
       )
 {
+	if (vty->node == CONFIG_NODE)
+		return bgp_global_gr_config_vty(vty, false, true);
+
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
@@ -3321,11 +3506,8 @@ DEFUN (no_bgp_graceful_restart_disable,
 
 	int ret = BGP_GR_FAILURE;
 
-	ret = bgp_gr_update_all(bgp, NO_GLOBAL_DISABLE_CMD);
+	ret = bgp_inst_gr_config_vty(vty, bgp, false, true);
 	if (ret == BGP_GR_SUCCESS) {
-		VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(bgp,
-								      bgp->peer,
-								      ret);
 		vty_out(vty,
 			"Graceful restart configuration changed, reset all peers to take effect\n");
 	}
@@ -19166,6 +19348,7 @@ int bgp_config_write(struct vty *vty)
 
 	hook_call(bgp_snmp_traps_config_write, vty);
 
+	vty_out(vty, "!\n");
 	if (bm->rmap_update_timer != RMAP_DEFAULT_UPDATE_TIMER)
 		vty_out(vty, "bgp route-map delay-timer %u\n",
 			bm->rmap_update_timer);
@@ -19179,6 +19362,30 @@ int bgp_config_write(struct vty *vty)
 
 	if (bm->wait_for_fib)
 		vty_out(vty, "bgp suppress-fib-pending\n");
+
+	if (bm->stalepath_time != BGP_DEFAULT_STALEPATH_TIME)
+		vty_out(vty, "bgp graceful-restart stalepath-time %u\n",
+			bm->stalepath_time);
+
+	if (bm->restart_time != BGP_DEFAULT_RESTART_TIME)
+		vty_out(vty, "bgp graceful-restart restart-time %u\n",
+			bm->restart_time);
+
+	if (bm->select_defer_time != BGP_DEFAULT_SELECT_DEFERRAL_TIME)
+		vty_out(vty, "bgp graceful-restart select-defer-time %u\n",
+			bm->select_defer_time);
+
+	if (CHECK_FLAG(bm->flags, BM_FLAG_GR_RESTARTER))
+		vty_out(vty, "bgp graceful-restart\n");
+	else if (CHECK_FLAG(bm->flags, BM_FLAG_GR_DISABLED))
+		vty_out(vty, "bgp graceful-restart-disable\n");
+
+	if (CHECK_FLAG(bm->flags, BM_FLAG_GR_PRESERVE_FWD))
+		vty_out(vty, "bgp graceful-restart preserve-fw-state\n");
+
+	if (bm->rib_stale_time != BGP_DEFAULT_RIB_STALE_TIME)
+		vty_out(vty, "bgp graceful-restart rib-stale-time %u\n",
+			bm->rib_stale_time);
 
 	if (CHECK_FLAG(bm->flags, BM_FLAG_GRACEFUL_SHUTDOWN))
 		vty_out(vty, "bgp graceful-shutdown\n");
@@ -19442,15 +19649,21 @@ int bgp_config_write(struct vty *vty)
 				" bgp long-lived-graceful-restart stale-time %u\n",
 				bgp->llgr_stale_time);
 
-		/* BGP graceful-restart. */
-		if (bgp->stalepath_time != BGP_DEFAULT_STALEPATH_TIME)
-			vty_out(vty,
-				" bgp graceful-restart stalepath-time %u\n",
-				bgp->stalepath_time);
+		/* BGP per-instance graceful-restart. */
+		/* BGP-wide settings and per-instance settings are mutually
+		 * exclusive.
+		 */
+		if (bm->stalepath_time == BGP_DEFAULT_STALEPATH_TIME)
+			if (bgp->stalepath_time != BGP_DEFAULT_STALEPATH_TIME)
+				vty_out(vty,
+					" bgp graceful-restart stalepath-time %u\n",
+					bgp->stalepath_time);
 
-		if (bgp->restart_time != BGP_DEFAULT_RESTART_TIME)
-			vty_out(vty, " bgp graceful-restart restart-time %u\n",
-				bgp->restart_time);
+		if (bm->restart_time == BGP_DEFAULT_RESTART_TIME)
+			if (bgp->restart_time != BGP_DEFAULT_RESTART_TIME)
+				vty_out(vty,
+					" bgp graceful-restart restart-time %u\n",
+					bgp->restart_time);
 
 		if (!!CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_NOTIFICATION) !=
 		    SAVE_BGP_GRACEFUL_NOTIFICATION)
@@ -19460,30 +19673,34 @@ int bgp_config_write(struct vty *vty)
 					? ""
 					: "no ");
 
-		if (bgp->select_defer_time != BGP_DEFAULT_SELECT_DEFERRAL_TIME)
-			vty_out(vty,
-				" bgp graceful-restart select-defer-time %u\n",
-				bgp->select_defer_time);
+		if (bm->select_defer_time == BGP_DEFAULT_SELECT_DEFERRAL_TIME)
+			if (bgp->select_defer_time !=
+			    BGP_DEFAULT_SELECT_DEFERRAL_TIME)
+				vty_out(vty,
+					" bgp graceful-restart select-defer-time %u\n",
+					bgp->select_defer_time);
 
-		if (bgp_global_gr_mode_get(bgp) == GLOBAL_GR)
-			vty_out(vty, " bgp graceful-restart\n");
+		if (!CHECK_FLAG(bm->flags, BM_FLAG_GR_CONFIGURED)) {
+			if (bgp_global_gr_mode_get(bgp) == GLOBAL_GR)
+				vty_out(vty, " bgp graceful-restart\n");
 
-		if (bgp_global_gr_mode_get(bgp) == GLOBAL_DISABLE)
-			vty_out(vty, " bgp graceful-restart-disable\n");
+			if (bgp_global_gr_mode_get(bgp) == GLOBAL_DISABLE)
+				vty_out(vty, " bgp graceful-restart-disable\n");
+		}
 
-		/* BGP graceful-restart Preserve State F bit. */
-		if (CHECK_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD))
-			vty_out(vty,
-				" bgp graceful-restart preserve-fw-state\n");
+		if (!CHECK_FLAG(bm->flags, BM_FLAG_GR_PRESERVE_FWD))
+			if (CHECK_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD))
+				vty_out(vty,
+					" bgp graceful-restart preserve-fw-state\n");
 
 		/* BGP TCP keepalive */
 		bgp_config_tcp_keepalive(vty, bgp);
 
-		/* Stale timer for RIB */
-		if (bgp->rib_stale_time != BGP_DEFAULT_RIB_STALE_TIME)
-			vty_out(vty,
-				" bgp graceful-restart rib-stale-time %u\n",
-				bgp->rib_stale_time);
+		if (bm->rib_stale_time == BGP_DEFAULT_RIB_STALE_TIME)
+			if (bgp->rib_stale_time != BGP_DEFAULT_RIB_STALE_TIME)
+				vty_out(vty,
+					" bgp graceful-restart rib-stale-time %u\n",
+					bgp->rib_stale_time);
 
 		/* BGP bestpath method. */
 		if (CHECK_FLAG(bgp->flags, BGP_FLAG_ASPATH_IGNORE))
@@ -20141,6 +20358,26 @@ void bgp_vty_init(void)
 	/* global bgp graceful-shutdown command */
 	install_element(CONFIG_NODE, &bgp_graceful_shutdown_cmd);
 	install_element(CONFIG_NODE, &no_bgp_graceful_shutdown_cmd);
+
+	/* BGP-wide graceful-restart commands. */
+	install_element(CONFIG_NODE, &bgp_graceful_restart_cmd);
+	install_element(CONFIG_NODE, &no_bgp_graceful_restart_cmd);
+	install_element(CONFIG_NODE, &bgp_graceful_restart_disable_cmd);
+	install_element(CONFIG_NODE, &no_bgp_graceful_restart_disable_cmd);
+	install_element(CONFIG_NODE, &bgp_graceful_restart_stalepath_time_cmd);
+	install_element(CONFIG_NODE,
+			&no_bgp_graceful_restart_stalepath_time_cmd);
+	install_element(CONFIG_NODE, &bgp_graceful_restart_restart_time_cmd);
+	install_element(CONFIG_NODE, &no_bgp_graceful_restart_restart_time_cmd);
+	install_element(CONFIG_NODE,
+			&bgp_graceful_restart_select_defer_time_cmd);
+	install_element(CONFIG_NODE,
+			&no_bgp_graceful_restart_select_defer_time_cmd);
+	install_element(CONFIG_NODE, &bgp_graceful_restart_preserve_fw_cmd);
+	install_element(CONFIG_NODE, &no_bgp_graceful_restart_preserve_fw_cmd);
+	install_element(CONFIG_NODE, &bgp_graceful_restart_rib_stale_time_cmd);
+	install_element(CONFIG_NODE,
+			&no_bgp_graceful_restart_rib_stale_time_cmd);
 
 	/* Dummy commands (Currently not supported) */
 	install_element(BGP_NODE, &no_synchronization_cmd);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -19408,6 +19408,8 @@ int bgp_config_write(struct vty *vty)
 	if (bm->outq_limit != BM_DEFAULT_Q_LIMIT)
 		vty_out(vty, "bgp output-queue-limit %u\n", bm->outq_limit);
 
+	vty_out(vty, "!\n");
+
 	/* BGP configuration. */
 	for (ALL_LIST_ELEMENTS(bm->bgp, mnode, mnnode, bgp)) {
 

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -60,8 +60,6 @@ struct bgp;
 
 #define VTY_BGP_GR_ROUTER_DETECT(_bgp, _peer, _peer_list)                      \
 	do {                                                                   \
-		if (_peer->bgp->t_startup)                                     \
-			bgp_peer_gr_flags_update(_peer);                       \
 		for (ALL_LIST_ELEMENTS(_peer_list, node, nnode, peer_loop)) {  \
 			if (CHECK_FLAG(peer_loop->flags,                       \
 				       PEER_FLAG_GRACEFUL_RESTART))            \
@@ -84,30 +82,27 @@ struct bgp;
 		}                                                              \
 	} while (0)
 
-#define VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(                 \
-	_bgp, _peer_list, _ret)                                                \
-	do {                                                                   \
-		struct peer *peer_loop;                                        \
-		bool gr_router_detected = false;                               \
-		struct listnode *node = {0};                                   \
-		struct listnode *nnode = {0};                                  \
-		for (ALL_LIST_ELEMENTS(_peer_list, node, nnode, peer_loop)) {  \
-			if (peer_loop->bgp->t_startup)                         \
-				bgp_peer_gr_flags_update(peer_loop);           \
-			if (CHECK_FLAG(peer_loop->flags,                       \
-				       PEER_FLAG_GRACEFUL_RESTART))            \
-				gr_router_detected = true;                     \
-		}                                                              \
-		if (gr_router_detected                                         \
-		    && _bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) {     \
-			if (bgp_zebra_send_capabilities(_bgp, false))          \
-				_ret = BGP_ERR_INVALID_VALUE;                  \
-		} else if (!gr_router_detected                                 \
-			   && _bgp->present_zebra_gr_state                     \
-				      == ZEBRA_GR_ENABLE) {                    \
-			if (bgp_zebra_send_capabilities(_bgp, true))           \
-				_ret = BGP_ERR_INVALID_VALUE;                  \
-		}                                                              \
+#define VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(_bgp,             \
+							      _peer_list, _ret) \
+	do {                                                                    \
+		struct peer *peer_loop;                                         \
+		bool gr_router_detected = false;                                \
+		struct listnode *node = { 0 };                                  \
+		struct listnode *nnode = { 0 };                                 \
+		for (ALL_LIST_ELEMENTS(_peer_list, node, nnode, peer_loop)) {   \
+			if (CHECK_FLAG(peer_loop->flags,                        \
+				       PEER_FLAG_GRACEFUL_RESTART))             \
+				gr_router_detected = true;                      \
+		}                                                               \
+		if (gr_router_detected &&                                       \
+		    _bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) {         \
+			if (bgp_zebra_send_capabilities(_bgp, false))           \
+				_ret = BGP_ERR_INVALID_VALUE;                   \
+		} else if (!gr_router_detected &&                               \
+			   _bgp->present_zebra_gr_state == ZEBRA_GR_ENABLE) {   \
+			if (bgp_zebra_send_capabilities(_bgp, true))            \
+				_ret = BGP_ERR_INVALID_VALUE;                   \
+		}                                                               \
 	} while (0)
 
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3979,6 +3979,11 @@ int bgp_zebra_send_capabilities(struct bgp *bgp, bool disable)
 		return BGP_GR_FAILURE;
 	}
 
+	if (BGP_DEBUG(zebra, ZEBRA))
+		zlog_debug("%s(%d): Sending GR capability %s to zebra",
+			   bgp->name_pretty, bgp->vrf_id,
+			   disable ? "disabled" : "enabled");
+
 	/* Check if capability is already sent. If the flag force is set
 	 * send the capability since this can be initial bgp configuration
 	 */
@@ -3994,8 +3999,8 @@ int bgp_zebra_send_capabilities(struct bgp *bgp, bool disable)
 
 	if (zclient_capabilities_send(ZEBRA_CLIENT_CAPABILITIES, zclient, &api)
 	    == ZCLIENT_SEND_FAILURE) {
-		zlog_err("%s: %s error sending capability", __func__,
-			 bgp->name_pretty);
+		zlog_err("%s(%d): Error sending GR capability to zebra",
+			 bgp->name_pretty, bgp->vrf_id);
 		ret = BGP_GR_FAILURE;
 	} else {
 		if (disable)
@@ -4003,9 +4008,6 @@ int bgp_zebra_send_capabilities(struct bgp *bgp, bool disable)
 		else
 			bgp->present_zebra_gr_state = ZEBRA_GR_ENABLE;
 
-		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_debug("%s: %s send capabilty success", __func__,
-				   bgp->name_pretty);
 		ret = BGP_GR_SUCCESS;
 	}
 	return ret;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1475,9 +1475,7 @@ int bgp_peer_gr_init(struct peer *peer)
 		{ PEER_HELPER, bgp_peer_gr_action }, { PEER_GLOBAL_INHERIT, NULL }
 	}
 	};
-	memcpy(&peer->PEER_GR_FSM, local_Peer_GR_FSM,
-					sizeof(local_Peer_GR_FSM));
-	peer->peer_gr_present_state = PEER_GLOBAL_INHERIT;
+	memcpy(&peer->PEER_GR_FSM, local_Peer_GR_FSM, sizeof(local_Peer_GR_FSM));
 	bgp_peer_move_to_gr_mode(peer, PEER_GLOBAL_INHERIT);
 
 	return BGP_GR_SUCCESS;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -167,6 +167,8 @@ struct bgp_master {
 #define BM_FLAG_GR_RESTARTER		 (1 << 3)
 #define BM_FLAG_GR_DISABLED		 (1 << 4)
 #define BM_FLAG_GR_PRESERVE_FWD		 (1 << 5)
+#define BM_FLAG_GRACEFUL_RESTART	 (1 << 6)
+#define BM_FLAG_GR_COMPLETE		 (1 << 7)
 
 #define BM_FLAG_GR_CONFIGURED (BM_FLAG_GR_RESTARTER | BM_FLAG_GR_DISABLED)
 
@@ -175,6 +177,9 @@ struct bgp_master {
 	uint32_t stalepath_time;
 	uint32_t select_defer_time;
 	uint32_t rib_stale_time;
+
+	time_t startup_time;
+	time_t gr_completion_time;
 
 	bool terminating;	/* global flag that sigint terminate seen */
 
@@ -305,9 +310,9 @@ struct graceful_restart_info {
 	/* Best route select */
 	struct event *t_route_select;
 	/* AFI, SAFI enabled */
-	bool af_enabled[AFI_MAX][SAFI_MAX];
+	bool af_enabled;
 	/* Route update completed */
-	bool route_sync[AFI_MAX][SAFI_MAX];
+	bool route_sync;
 };
 
 enum global_mode {
@@ -558,6 +563,9 @@ struct bgp {
 	 * - ZEBRA_GR_ENABLE / ZEBRA_GR_DISABLE
 	 */
 	enum zebra_gr_mode present_zebra_gr_state;
+
+	/* Is deferred path selection still not complete? */
+	bool gr_route_sync_pending;
 
 	/* BGP Per AF flags */
 	uint16_t af_flags[AFI_MAX][SAFI_MAX];
@@ -2752,6 +2760,59 @@ static inline bool bgp_in_graceful_shutdown(struct bgp *bgp)
 	/* True if either set for this instance or globally */
 	return (!!CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN) ||
 	        !!CHECK_FLAG(bm->flags, BM_FLAG_GRACEFUL_SHUTDOWN));
+}
+
+static inline bool bgp_in_graceful_restart(void)
+{
+	/* True if BGP has (re)started gracefully (based on flags
+	 * noted at startup) and GR is not complete.
+	 */
+	return (CHECK_FLAG(bm->flags, BM_FLAG_GRACEFUL_RESTART) &&
+		!CHECK_FLAG(bm->flags, BM_FLAG_GR_COMPLETE));
+}
+
+static inline bool bgp_is_graceful_restart_complete(void)
+{
+	/* True if BGP has (re)started gracefully (based on flags
+	 * noted at startup) and GR is marked as complete.
+	 */
+	return (CHECK_FLAG(bm->flags, BM_FLAG_GRACEFUL_RESTART) &&
+		CHECK_FLAG(bm->flags, BM_FLAG_GR_COMPLETE));
+}
+
+static inline void bgp_update_gr_completion(void)
+{
+	struct listnode *node, *nnode;
+	struct bgp *bgp;
+
+	/*
+	 * Check and mark GR complete. This is done when deferred
+	 * path selection has been completed for all instances and
+	 * route-advertisement/EOR and route-sync with zebra has
+	 * been invoked.
+	 */
+	if (!CHECK_FLAG(bm->flags, BM_FLAG_GRACEFUL_RESTART) ||
+	    CHECK_FLAG(bm->flags, BM_FLAG_GR_COMPLETE))
+		return;
+
+	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
+		if (bgp->gr_route_sync_pending)
+			return;
+	}
+
+	SET_FLAG(bm->flags, BM_FLAG_GR_COMPLETE);
+	bm->gr_completion_time = monotime(NULL);
+}
+
+static inline bool bgp_gr_is_forwarding_preserved(struct bgp *bgp)
+{
+	/*
+	 * Is forwarding state preserved? Based either on config
+	 * or if BGP restarted gracefully.
+	 * TBD: Additional AFI/SAFI based checks etc.
+	 */
+	return (CHECK_FLAG(bm->flags, BM_FLAG_GRACEFUL_RESTART) ||
+		CHECK_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD));
 }
 
 /* For benefit of rfapi */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -163,6 +163,18 @@ struct bgp_master {
 	uint32_t flags;
 #define BM_FLAG_GRACEFUL_SHUTDOWN        (1 << 0)
 #define BM_FLAG_SEND_EXTRA_DATA_TO_ZEBRA (1 << 1)
+#define BM_FLAG_MAINTENANCE_MODE	 (1 << 2)
+#define BM_FLAG_GR_RESTARTER		 (1 << 3)
+#define BM_FLAG_GR_DISABLED		 (1 << 4)
+#define BM_FLAG_GR_PRESERVE_FWD		 (1 << 5)
+
+#define BM_FLAG_GR_CONFIGURED (BM_FLAG_GR_RESTARTER | BM_FLAG_GR_DISABLED)
+
+	/* BGP-wide graceful restart config params */
+	uint32_t restart_time;
+	uint32_t stalepath_time;
+	uint32_t select_defer_time;
+	uint32_t rib_stale_time;
 
 	bool terminating;	/* global flag that sigint terminate seen */
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1080,6 +1080,52 @@ Default global mode is helper and default peer per mode is inherit from global.
 If per peer mode is configured, the GR mode of this particular peer will
 override the global mode.
 
+.. _bgp-GR-config-mode-cmd:
+
+BGP GR Config Mode Commands
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. clicmd:: bgp graceful-restart
+
+   This command will enable BGP graceful restart functionality for all BGP instances.
+
+.. clicmd:: bgp graceful-restart-disable
+
+   This command will disable both the functionality graceful restart and helper
+   mode for all BGP instances
+
+.. clicmd:: bgp graceful-restart select-defer-time (0-3600)
+
+   This is command, will set deferral time to value specified.
+
+.. clicmd:: bgp graceful-restart rib-stale-time (1-3600)
+
+   This is command, will set the time for which stale routes are kept in RIB.
+
+.. clicmd:: bgp graceful-restart restart-time (0-4095)
+
+   Set the time to wait to delete stale routes before a BGP open message
+   is received.
+
+   Using with Long-lived Graceful Restart capability, this is recommended
+   setting this timer to 0 and control stale routes with
+   ``bgp long-lived-graceful-restart stale-time``.
+
+   Default value is 120.
+
+.. clicmd:: bgp graceful-restart stalepath-time (1-4095)
+
+   This is command, will set the max time (in seconds) to hold onto
+   restarting peer's stale paths.
+
+   It also controls Enhanced Route-Refresh timer.
+
+   If this command is configured and the router does not receive a Route-Refresh EoRR
+   message, the router removes the stale routes from the BGP table after the timer
+   expires. The stale path timer is started when the router receives a Route-Refresh
+   BoRR message
+
+
 .. _bgp-GR-global-mode-cmd:
 
 BGP GR Global Mode Commands

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -92,6 +92,12 @@ be specified (:ref:`common-invocation-options`).
    the operator has turned off communication to zebra and is running bgpd
    as a complete standalone process.
 
+.. option:: -K, --graceful_restart
+
+   Bgpd will use this option to denote either a planned FRR graceful
+   restart or a bgpd-only graceful restart, and this will drive the BGP
+   GR restarting router procedures.
+
 LABEL MANAGER
 -------------
 

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -118,6 +118,8 @@ struct frr_daemon_info {
 	bool dryrun;
 	bool daemon_mode;
 	bool terminal;
+	bool graceful_restart;
+	int gr_cleanup_time;
 	enum frr_cli_mode cli_mode;
 
 	struct event *read_in;

--- a/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-4.py
+++ b/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-4.py
@@ -81,6 +81,8 @@ import os
 import sys
 import time
 import pytest
+import functools
+import json
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
@@ -91,6 +93,7 @@ sys.path.append(os.path.join("../lib/"))
 # Import topogen and topotest helpers
 from lib.topogen import Topogen, get_topogen
 from lib.topolog import logger
+from lib import topotest
 
 # Required to instantiate the topology builder class.
 
@@ -1676,6 +1679,304 @@ def BGP_GR_TC_52_p1(request):
         ), "Testcase {} :Failed \n Routes are still present \n Error {}".format(
             tc_name, result
         )
+
+    write_test_footer(tc_name)
+
+
+def test_BGP_GR_TC_53_p1(request):
+    """
+    Test Objective : Peer-level inherit from BGP wide Restarting
+    Global Mode : GR Restart
+    PerPeer Mode :  None
+    GR Mode effective : GR Restart
+
+    """
+
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    # Check router status
+    check_router_status(tgen)
+
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Creating configuration from JSON
+    reset_config_on_routers(tgen)
+
+    step("Configure R1 as GR restarting node in global level")
+
+    input_dict = {
+        "r1": {"graceful-restart": {"graceful-restart": True}},
+        "r2": {"graceful-restart": {"graceful-restart-helper": True}},
+    }
+
+    output = tgen.gears["r1"].vtysh_cmd(
+        """
+        configure terminal
+        bgp graceful-restart
+        !
+        """
+    )
+
+    step("Verify that R2 receives GR restarting capabilities" " from R1")
+
+    for addr_type in ADDR_TYPES:
+        result = verify_graceful_restart(
+            tgen, topo, addr_type, input_dict, dut="r1", peer="r2"
+        )
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+        result = verify_graceful_restart(
+            tgen, topo, addr_type, input_dict, dut="r2", peer="r1"
+        )
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+
+    for addr_type in ADDR_TYPES:
+        dut = "r1"
+        peer = "r2"
+        protocol = "bgp"
+        next_hop = next_hop_per_address_family(
+            tgen, dut, peer, addr_type, NEXT_HOP_IP_2
+        )
+        input_topo = {"r2": topo["routers"]["r2"]}
+        result = verify_rib(tgen, addr_type, dut, input_topo, next_hop, protocol)
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+
+        dut = "r2"
+        peer = "r1"
+        next_hop = next_hop_per_address_family(
+            tgen, dut, peer, addr_type, NEXT_HOP_IP_1
+        )
+        input_topo = {"r1": topo["routers"]["r1"]}
+        result = verify_bgp_rib(tgen, addr_type, dut, input_topo, next_hop)
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+        result = verify_rib(tgen, addr_type, dut, input_topo, next_hop, protocol)
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+
+    step("Kill BGPd on router R1")
+
+    kill_router_daemons(tgen, "r1", ["bgpd"])
+
+    step(
+        "Verify that R1 keeps the stale entries in FIB and R2 keeps stale entries in RIB & FIB"
+    )
+
+    for addr_type in ADDR_TYPES:
+        dut = "r1"
+        peer = "r2"
+        protocol = "bgp"
+        next_hop = next_hop_per_address_family(
+            tgen, dut, peer, addr_type, NEXT_HOP_IP_2
+        )
+        input_topo = {"r2": topo["routers"]["r2"]}
+        result = verify_rib(tgen, addr_type, dut, input_topo, next_hop, protocol)
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+
+        dut = "r2"
+        peer = "r1"
+        next_hop = next_hop_per_address_family(
+            tgen, dut, peer, addr_type, NEXT_HOP_IP_1
+        )
+        input_topo = {"r1": topo["routers"]["r1"]}
+        result = verify_bgp_rib(tgen, addr_type, dut, input_topo, next_hop)
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+        result = verify_rib(tgen, addr_type, dut, input_topo, next_hop, protocol)
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+
+    # Configure graceful-restart-disable at config global level verify that the functionality works
+    step("Bring up BGP on R1 and configure graceful-restart-disable")
+
+    start_router_daemons(tgen, "r1", ["bgpd"])
+
+    input_dict = {
+        "r1": {"graceful-restart": {"graceful-restart-disable": True}},
+        "r2": {"graceful-restart": {"graceful-restart-helper": True}},
+    }
+
+    output = tgen.gears["r1"].vtysh_cmd(
+        """
+        configure terminal
+        bgp graceful-restart-disable
+        !
+        """
+    )
+
+    step("Verify on R2 that R1 does't advertise any GR capabilities")
+
+    for addr_type in ADDR_TYPES:
+        result = verify_graceful_restart(
+            tgen, topo, addr_type, input_dict, dut="r1", peer="r2"
+        )
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+        result = verify_graceful_restart(
+            tgen, topo, addr_type, input_dict, dut="r2", peer="r1"
+        )
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+
+    for addr_type in ADDR_TYPES:
+        dut = "r1"
+        peer = "r2"
+        protocol = "bgp"
+        next_hop = next_hop_per_address_family(
+            tgen, dut, peer, addr_type, NEXT_HOP_IP_2
+        )
+        input_topo = {"r2": topo["routers"]["r2"]}
+        result = verify_rib(tgen, addr_type, dut, input_topo, next_hop, protocol)
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+
+        dut = "r2"
+        peer = "r1"
+        next_hop = next_hop_per_address_family(
+            tgen, dut, peer, addr_type, NEXT_HOP_IP_1
+        )
+        input_topo = {"r1": topo["routers"]["r1"]}
+        result = verify_bgp_rib(tgen, addr_type, dut, input_topo, next_hop)
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+        result = verify_rib(tgen, addr_type, dut, input_topo, next_hop, protocol)
+        assert result is True, "Testcase {} :Failed \n Error {}".format(tc_name, result)
+
+    step("Kill BGP on R1")
+
+    kill_router_daemons(tgen, "r1", ["bgpd"])
+
+    step("Verify on R2 and R1 that none of the routers keep stale entries")
+
+    for addr_type in ADDR_TYPES:
+        dut = "r1"
+        peer = "r2"
+        protocol = "bgp"
+        next_hop = next_hop_per_address_family(
+            tgen, dut, peer, addr_type, NEXT_HOP_IP_2
+        )
+        input_topo = {"r2": topo["routers"]["r2"]}
+        result = verify_rib(
+            tgen, addr_type, dut, input_topo, next_hop, protocol, expected=False
+        )
+        assert result is not True, (
+            "Testcase {} : Failed \n "
+            "Expected: Routes should not be present in {} FIB \n "
+            "Found: {}".format(tc_name, dut, result)
+        )
+
+        dut = "r2"
+        peer = "r1"
+        next_hop = next_hop_per_address_family(
+            tgen, dut, peer, addr_type, NEXT_HOP_IP_1
+        )
+        input_topo = {"r1": topo["routers"]["r1"]}
+        result = verify_bgp_rib(
+            tgen, addr_type, dut, input_topo, next_hop, expected=False
+        )
+        assert result is not True, (
+            "Testcase {} : Failed \n "
+            "Expected: Routes should not be present in {} BGP RIB \n "
+            "Found: {}".format(tc_name, dut, result)
+        )
+
+        result = verify_rib(
+            tgen, addr_type, dut, input_topo, next_hop, protocol, expected=False
+        )
+        assert result is not True, (
+            "Testcase {} : Failed \n "
+            "Expected: Routes should not be present in {} FIB \n "
+            "Found: {}".format(tc_name, dut, result)
+        )
+
+    step(
+        "Bring up BGP on R1, enable GR and configure bgp graceful-restart restart-time at global level"
+    )
+
+    start_router_daemons(tgen, "r1", ["bgpd"])
+
+    output = tgen.gears["r1"].vtysh_cmd(
+        """
+        configure terminal
+        no bgp graceful-restart-disable
+        bgp graceful-restart
+        bgp graceful-restart stalepath-time 420
+        bgp graceful-restart restart-time 240
+        bgp graceful-restart select-defer-time 420
+        !
+        """
+    )
+
+    step("Verify on R2 that R1 sent the updated GR restart-time")
+
+    def _bgp_check_if_gr_restart_time_was_updated():
+        output = json.loads(tgen.gears["r2"].vtysh_cmd("show bgp neighbor json"))
+
+        expected = {
+            "192.168.0.1": {
+                "gracefulRestartInfo": {
+                    "localGrMode": "Helper*",
+                    "remoteGrMode": "Restart",
+                    "timers": {
+                        "configuredRestartTimer": 120,
+                        "receivedRestartTimer": 240,
+                    },
+                },
+            },
+            "fd00::1": {
+                "gracefulRestartInfo": {
+                    "localGrMode": "Helper*",
+                    "remoteGrMode": "Restart",
+                    "timers": {
+                        "configuredRestartTimer": 120,
+                        "receivedRestartTimer": 240,
+                    },
+                },
+            },
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(
+        _bgp_check_if_gr_restart_time_was_updated,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "R2 did not receive the updated GR restart-time of 240s"
+
+    def _bgp_check_if_gr_timer_on_restarting_node_was_updated():
+        output = json.loads(tgen.gears["r1"].vtysh_cmd("show bgp neighbor json"))
+
+        expected = {
+            "192.168.0.2": {
+                "gracefulRestartInfo": {
+                    "localGrMode": "Restart*",
+                    "remoteGrMode": "Helper",
+                    "timers": {
+                        "configuredRestartTimer": 240,
+                        "receivedRestartTimer": 120,
+                    },
+                    "ipv4Unicast": {
+                        "timers": {"stalePathTimer": 420, "selectionDeferralTimer": 420}
+                    },
+                },
+            },
+            "fd00::2": {
+                "gracefulRestartInfo": {
+                    "localGrMode": "Restart*",
+                    "remoteGrMode": "Helper",
+                    "timers": {
+                        "configuredRestartTimer": 240,
+                        "receivedRestartTimer": 120,
+                    },
+                    "ipv6Unicast": {
+                        "timers": {"stalePathTimer": 420, "selectionDeferralTimer": 420}
+                    },
+                },
+            },
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(
+        _bgp_check_if_gr_timer_on_restarting_node_was_updated,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert (
+        result is None
+    ), "R1 did not update the GR select-deferral and stale-path timer to 420s"
 
     write_test_footer(tc_name)
 

--- a/tests/topotests/bgp_gr_notification/test_bgp_gr_notification.py
+++ b/tests/topotests/bgp_gr_notification/test_bgp_gr_notification.py
@@ -195,15 +195,15 @@ def test_bgp_administrative_reset_gr():
     step("Reset and shutdown R1")
     _bgp_clear_r1_and_shutdown()
 
-    step("Check if Hard Reset notification wasn't sent from R2")
-    test_func = functools.partial(_bgp_check_hard_reset)
-    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
-    assert result is None, "Failed to send Administrative Reset notification from R2"
-
     step("Check if stale routes are retained on R1")
     test_func = functools.partial(_bgp_check_gr_notification_stale)
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, "Failed to see retained stale routes on R1"
+
+    step("Check if Hard Reset notification wasn't sent from R2")
+    test_func = functools.partial(_bgp_check_hard_reset)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to send Administrative Reset notification from R2"
 
 
 if __name__ == "__main__":

--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -3269,29 +3269,24 @@ def verify_graceful_restart(
 
             # Local GR mode
             if "bgp" not in input_dict[dut] and "graceful-restart" in input_dict[dut]:
-                    if (
-                        "graceful-restart" in input_dict[dut]["graceful-restart"]
-                        and input_dict[dut]["graceful-restart"][
-                            "graceful-restart"
-                        ]
-                    ):
-                        lmode = "Restart*"
-                    elif (
-                        "graceful-restart-disable"
-                        in input_dict[dut]["graceful-restart"]
-                        and input_dict[dut]["graceful-restart"][
-                            "graceful-restart-disable"
-                        ]
-                    ):
-                        lmode = "Disable*"
-                    else:
-                        lmode = "Helper*"
+                if (
+                    "graceful-restart" in input_dict[dut]["graceful-restart"]
+                    and input_dict[dut]["graceful-restart"]["graceful-restart"]
+                ):
+                    lmode = "Restart*"
+                elif (
+                    "graceful-restart-disable" in input_dict[dut]["graceful-restart"]
+                    and input_dict[dut]["graceful-restart"]["graceful-restart-disable"]
+                ):
+                    lmode = "Disable*"
+                else:
+                    lmode = "Helper*"
 
             if lmode is None:
                 if "address_family" in input_dict[dut]["bgp"]:
                     bgp_neighbors = input_dict[dut]["bgp"]["address_family"][addr_type][
-                    "unicast"
-                ]["neighbor"][peer]["dest_link"]
+                        "unicast"
+                    ]["neighbor"][peer]["dest_link"]
 
                     for dest_link, data in bgp_neighbors.items():
                         if (
@@ -3336,7 +3331,10 @@ def verify_graceful_restart(
 
             # Remote GR mode
 
-            if "bgp" in input_dict[peer] and "address_family" in input_dict[peer]["bgp"]:
+            if (
+                "bgp" in input_dict[peer]
+                and "address_family" in input_dict[peer]["bgp"]
+            ):
                 bgp_neighbors = input_dict[peer]["bgp"]["address_family"][addr_type][
                     "unicast"
                 ]["neighbor"][dut]["dest_link"]
@@ -3358,7 +3356,10 @@ def verify_graceful_restart(
                         rmode = None
 
             if rmode is None:
-                if "bgp" in input_dict[peer] and  "graceful-restart" in input_dict[peer]["bgp"]:
+                if (
+                    "bgp" in input_dict[peer]
+                    and "graceful-restart" in input_dict[peer]["bgp"]
+                ):
                     if (
                         "graceful-restart"
                         in input_dict[peer]["bgp"]["graceful-restart"]
@@ -3379,13 +3380,13 @@ def verify_graceful_restart(
                         rmode = "Helper"
 
             if rmode is None:
-                if "bgp" not in input_dict[peer] and "graceful-restart" in input_dict[peer]:
+                if (
+                    "bgp" not in input_dict[peer]
+                    and "graceful-restart" in input_dict[peer]
+                ):
                     if (
-                        "graceful-restart"
-                        in input_dict[peer]["graceful-restart"]
-                        and input_dict[peer]["graceful-restart"][
-                            "graceful-restart"
-                        ]
+                        "graceful-restart" in input_dict[peer]["graceful-restart"]
+                        and input_dict[peer]["graceful-restart"]["graceful-restart"]
                     ):
                         rmode = "Restart"
                     elif (

--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -3266,27 +3266,48 @@ def verify_graceful_restart(
 
             lmode = None
             rmode = None
+
             # Local GR mode
-            if "address_family" in input_dict[dut]["bgp"]:
-                bgp_neighbors = input_dict[dut]["bgp"]["address_family"][addr_type][
+            if "bgp" not in input_dict[dut] and "graceful-restart" in input_dict[dut]:
+                    if (
+                        "graceful-restart" in input_dict[dut]["graceful-restart"]
+                        and input_dict[dut]["graceful-restart"][
+                            "graceful-restart"
+                        ]
+                    ):
+                        lmode = "Restart*"
+                    elif (
+                        "graceful-restart-disable"
+                        in input_dict[dut]["graceful-restart"]
+                        and input_dict[dut]["graceful-restart"][
+                            "graceful-restart-disable"
+                        ]
+                    ):
+                        lmode = "Disable*"
+                    else:
+                        lmode = "Helper*"
+
+            if lmode is None:
+                if "address_family" in input_dict[dut]["bgp"]:
+                    bgp_neighbors = input_dict[dut]["bgp"]["address_family"][addr_type][
                     "unicast"
                 ]["neighbor"][peer]["dest_link"]
 
-                for dest_link, data in bgp_neighbors.items():
-                    if (
-                        "graceful-restart-helper" in data
-                        and data["graceful-restart-helper"]
-                    ):
-                        lmode = "Helper"
-                    elif "graceful-restart" in data and data["graceful-restart"]:
-                        lmode = "Restart"
-                    elif (
-                        "graceful-restart-disable" in data
-                        and data["graceful-restart-disable"]
-                    ):
-                        lmode = "Disable"
-                    else:
-                        lmode = None
+                    for dest_link, data in bgp_neighbors.items():
+                        if (
+                            "graceful-restart-helper" in data
+                            and data["graceful-restart-helper"]
+                        ):
+                            lmode = "Helper"
+                        elif "graceful-restart" in data and data["graceful-restart"]:
+                            lmode = "Restart"
+                        elif (
+                            "graceful-restart-disable" in data
+                            and data["graceful-restart-disable"]
+                        ):
+                            lmode = "Disable"
+                        else:
+                            lmode = None
 
             if lmode is None:
                 if "graceful-restart" in input_dict[dut]["bgp"]:
@@ -3314,7 +3335,8 @@ def verify_graceful_restart(
                 return True
 
             # Remote GR mode
-            if "address_family" in input_dict[peer]["bgp"]:
+
+            if "bgp" in input_dict[peer] and "address_family" in input_dict[peer]["bgp"]:
                 bgp_neighbors = input_dict[peer]["bgp"]["address_family"][addr_type][
                     "unicast"
                 ]["neighbor"][dut]["dest_link"]
@@ -3336,7 +3358,7 @@ def verify_graceful_restart(
                         rmode = None
 
             if rmode is None:
-                if "graceful-restart" in input_dict[peer]["bgp"]:
+                if "bgp" in input_dict[peer] and  "graceful-restart" in input_dict[peer]["bgp"]:
                     if (
                         "graceful-restart"
                         in input_dict[peer]["bgp"]["graceful-restart"]
@@ -3349,6 +3371,27 @@ def verify_graceful_restart(
                         "graceful-restart-disable"
                         in input_dict[peer]["bgp"]["graceful-restart"]
                         and input_dict[peer]["bgp"]["graceful-restart"][
+                            "graceful-restart-disable"
+                        ]
+                    ):
+                        rmode = "Disable"
+                    else:
+                        rmode = "Helper"
+
+            if rmode is None:
+                if "bgp" not in input_dict[peer] and "graceful-restart" in input_dict[peer]:
+                    if (
+                        "graceful-restart"
+                        in input_dict[peer]["graceful-restart"]
+                        and input_dict[peer]["graceful-restart"][
+                            "graceful-restart"
+                        ]
+                    ):
+                        rmode = "Restart"
+                    elif (
+                        "graceful-restart-disable"
+                        in input_dict[peer]["graceful-restart"]
+                        and input_dict[peer]["graceful-restart"][
                             "graceful-restart-disable"
                         ]
                     ):

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -622,10 +622,10 @@ static inline struct nexthop_group *rib_get_fib_backup_nhg(
 }
 
 extern void zebra_gr_process_client(afi_t afi, vrf_id_t vrf_id, uint8_t proto,
-				    uint8_t instance);
+				    uint8_t instance, time_t restart_time);
 
 extern int rib_add_gr_run(afi_t afi, vrf_id_t vrf_id, uint8_t proto,
-			  uint8_t instance);
+			  uint8_t instance, time_t restart_time);
 
 extern void zebra_vty_init(void);
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2414,6 +2414,7 @@ static void zsend_capabilities(struct zserv *client, struct zebra_vrf *zvrf)
 	stream_putl(s, zrouter.multipath_num);
 	stream_putc(s, zebra_mlag_get_role());
 	stream_putc(s, zrouter.v6_with_v4_nexthop);
+	stream_putc(s, zrouter.graceful_restart);
 	stream_putw_at(s, 0, stream_get_endp(s));
 	zserv_send_message(client, s);
 }

--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -103,6 +103,7 @@ static struct client_gr_info *zebra_gr_client_info_create(struct zserv *client)
 	info->stale_client_ptr = client;
 
 	TAILQ_INSERT_TAIL(&(client->gr_info_queue), info, gr_info);
+	info->client_ptr = client;
 	return info;
 }
 
@@ -290,6 +291,7 @@ struct zebra_gr_afi_clean {
 	afi_t afi;
 	uint8_t proto;
 	uint8_t instance;
+	time_t restart_time;
 
 	struct event *t_gac;
 };
@@ -420,7 +422,7 @@ void zread_client_capabilities(ZAPI_HANDLER_ARGS)
 		 * Schedule for after anything already in the meta Q
 		 */
 		rib_add_gr_run(api.afi, api.vrf_id, client->proto,
-			       client->instance);
+			       client->instance, client->restart_time);
 		zebra_gr_process_client_stale_routes(client, info);
 		break;
 	case ZEBRA_CLIENT_ROUTE_UPDATE_PENDING:
@@ -455,7 +457,11 @@ static void zebra_gr_route_stale_delete_timer_expiry(struct event *thread)
 	struct zserv *client;
 	struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
 
-	client = (struct zserv *)info->stale_client_ptr;
+	info->t_stale_removal = NULL;
+	if (zrouter.graceful_restart)
+		client = (struct zserv *)info->client_ptr;
+	else
+		client = (struct zserv *)info->stale_client_ptr;
 
 	cnt = zebra_gr_delete_stale_routes(info);
 
@@ -486,16 +492,24 @@ static void zebra_gr_route_stale_delete_timer_expiry(struct event *thread)
  *
  * Returns true when a node is deleted else false
  */
-static bool zebra_gr_process_route_entry(struct zserv *client,
-					 struct route_node *rn,
-					 struct route_entry *re)
+static bool zebra_gr_process_route_entry(struct route_node *rn,
+					 struct route_entry *re,
+					 time_t compare_time, uint8_t proto)
 {
+	struct nexthop *nexthop;
+	char buf[PREFIX2STR_BUFFER];
+
 	/* If the route is not refreshed after restart, delete the entry */
-	if (re->uptime < client->restart_time) {
-		if (IS_ZEBRA_DEBUG_RIB)
-			zlog_debug("%s: Client %s stale route %pFX is deleted",
-				   __func__, zebra_route_string(client->proto),
-				   &rn->p);
+	if (re->uptime < compare_time) {
+		if (IS_ZEBRA_DEBUG_RIB) {
+			prefix2str(&rn->p, buf, sizeof(buf));
+			zlog_debug("%s: Client %s stale route %s is deleted",
+				   __func__, zebra_route_string(proto), buf);
+		}
+		SET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
+		for (ALL_NEXTHOPS(re->nhe->nhg, nexthop))
+			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_FIB);
+
 		rib_delnode(rn, re);
 
 		return true;
@@ -532,8 +546,9 @@ static void zebra_gr_delete_stale_route_table_afi(struct event *event)
 
 			if (re->type == gac->proto &&
 			    re->instance == gac->instance &&
-			    zebra_gr_process_route_entry(
-				    gac->info->stale_client_ptr, rn, re))
+			    zebra_gr_process_route_entry(rn, re,
+							 gac->restart_time,
+							 gac->proto))
 				n++;
 
 			/* If the max route count is reached
@@ -567,28 +582,42 @@ static int32_t zebra_gr_delete_stale_route(struct client_gr_info *info,
 	uint8_t proto;
 	uint16_t instance;
 	struct zserv *s_client;
+	struct zserv *client;
+	time_t restart_time = time(NULL);
 
-	s_client = info->stale_client_ptr;
-	if (s_client == NULL) {
-		LOG_GR("%s: Stale client %s(%u) not present", __func__,
-		       zvrf->vrf->name, zvrf->vrf->vrf_id);
+	if ((info == NULL) || (zvrf == NULL))
 		return -1;
-	}
 
-	proto = s_client->proto;
-	instance = s_client->instance;
+	if (zrouter.graceful_restart) {
+		client = info->client_ptr;
+		if (client == NULL) {
+			LOG_GR("%s: client not present", __func__);
+			return -1;
+		}
+		proto = client->proto;
+		instance = client->instance;
+		restart_time = zrouter.startup_time;
+	} else {
+		s_client = info->stale_client_ptr;
+		if (s_client == NULL) {
+			LOG_GR("%s: Stale client not present", __func__);
+			return -1;
+		}
+		proto = s_client->proto;
+		instance = s_client->instance;
+		restart_time = s_client->restart_time;
+	}
 
 	LOG_GR("%s: Client %s %s(%u) stale routes are being deleted", __func__,
 	       zebra_route_string(proto), zvrf->vrf->name, zvrf->vrf->vrf_id);
 
 	/* Process routes for all AFI */
 	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
-
 		/*
 		 * Schedule for immediately after anything in the
 		 * meta-Q
 		 */
-		rib_add_gr_run(afi, info->vrf_id, proto, instance);
+		rib_add_gr_run(afi, info->vrf_id, proto, instance, restart_time);
 	}
 	return 0;
 }
@@ -641,12 +670,13 @@ static void zebra_gr_process_client_stale_routes(struct zserv *client,
 
 	/*
 	 * Route update completed for all AFI, SAFI
-	 * Cancel the stale timer, routes are already being processed
+	 * Also perform the cleanup if FRR itself is gracefully restarting.
 	 */
-	if (info->t_stale_removal) {
+	info->route_sync_done_time = monotime(NULL);
+	if (info->t_stale_removal || zrouter.graceful_restart) {
 		struct vrf *vrf = vrf_lookup_by_id(info->vrf_id);
 
-		LOG_GR("%s: Client %s canceled stale delete timer vrf %s(%d)",
+		LOG_GR("%s: Client %s route update complete for all AFI/SAFI in vrf %s(%d)",
 		       __func__, zebra_route_string(client->proto),
 		       VRF_LOGNAME(vrf), info->vrf_id);
 		EVENT_OFF(info->t_stale_removal);
@@ -654,7 +684,7 @@ static void zebra_gr_process_client_stale_routes(struct zserv *client,
 }
 
 void zebra_gr_process_client(afi_t afi, vrf_id_t vrf_id, uint8_t proto,
-			     uint8_t instance)
+			     uint8_t instance, time_t restart_time)
 {
 	struct zserv *client = zserv_find_client(proto, instance);
 	struct client_gr_info *info = NULL;
@@ -676,6 +706,7 @@ void zebra_gr_process_client(afi_t afi, vrf_id_t vrf_id, uint8_t proto,
 	gac->afi = afi;
 	gac->proto = proto;
 	gac->instance = instance;
+	gac->restart_time = restart_time;
 
 	event_add_event(zrouter.master, zebra_gr_delete_stale_route_table_afi,
 			gac, 0, &gac->t_gac);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3159,6 +3159,7 @@ struct meta_q_gr_run {
 	vrf_id_t vrf_id;
 	uint8_t proto;
 	uint8_t instance;
+	time_t restart_time;
 };
 
 static void process_subq_gr_run(struct listnode *lnode)
@@ -3166,7 +3167,7 @@ static void process_subq_gr_run(struct listnode *lnode)
 	struct meta_q_gr_run *gr_run = listgetdata(lnode);
 
 	zebra_gr_process_client(gr_run->afi, gr_run->vrf_id, gr_run->proto,
-				gr_run->instance);
+				gr_run->instance, gr_run->restart_time);
 
 	XFREE(MTYPE_WQ_WRAPPER, gr_run);
 }
@@ -4266,7 +4267,8 @@ static int rib_meta_queue_early_route_add(struct meta_queue *mq, void *data)
 	return 0;
 }
 
-int rib_add_gr_run(afi_t afi, vrf_id_t vrf_id, uint8_t proto, uint8_t instance)
+int rib_add_gr_run(afi_t afi, vrf_id_t vrf_id, uint8_t proto, uint8_t instance,
+		   time_t restart_time)
 {
 	struct meta_q_gr_run *gr_run;
 
@@ -4276,6 +4278,7 @@ int rib_add_gr_run(afi_t afi, vrf_id_t vrf_id, uint8_t proto, uint8_t instance)
 	gr_run->proto = proto;
 	gr_run->vrf_id = vrf_id;
 	gr_run->instance = instance;
+	gr_run->restart_time = restart_time;
 
 	return mq_add_handler(gr_run, rib_meta_queue_gr_run_add);
 }
@@ -4693,6 +4696,10 @@ void rib_sweep_route(struct event *t)
 {
 	struct vrf *vrf;
 	struct zebra_vrf *zvrf;
+
+	zrouter.rib_sweep_time = monotime(NULL);
+	/* TODO: Change to debug */
+	zlog_info("Sweeping the RIB for stale routes...");
 
 	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
 		if ((zvrf = vrf->info) == NULL)

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -238,7 +238,7 @@ void zebra_router_terminate(void)
 {
 	struct zebra_router_table *zrt, *tmp;
 
-	EVENT_OFF(zrouter.sweeper);
+	EVENT_OFF(zrouter.t_rib_sweep);
 
 	RB_FOREACH_SAFE (zrt, zebra_router_table_head, &zrouter.tables, tmp)
 		zebra_router_free_table(zrt);

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -191,10 +191,16 @@ struct zebra_router {
 	enum multicast_mode ipv4_multicast_mode;
 
 	/*
-	 * Time for when we sweep the rib from old routes
+	 * zebra start time and time of sweeping RIB of old routes
 	 */
 	time_t startup_time;
-	struct event *sweeper;
+	time_t rib_sweep_time;
+
+	/* FRR fast/graceful restart info */
+	bool graceful_restart;
+	int gr_cleanup_time;
+#define ZEBRA_GR_DEFAULT_RIB_SWEEP_TIME 500
+	struct event *t_rib_sweep;
 
 	/*
 	 * The hash of nexthop groups associated with this router

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3825,6 +3825,20 @@ DEFUN (show_zebra,
 	struct vrf *vrf;
 	struct ttable *table = ttable_new(&ttable_styles[TTSTYLE_BLANK]);
 	char *out;
+	char timebuf[MONOTIME_STRLEN];
+
+	time_to_string(zrouter.startup_time, timebuf);
+	vty_out(vty, "Zebra started%s at time %s",
+		zrouter.graceful_restart ? " gracefully" : "", timebuf);
+
+	if (zrouter.t_rib_sweep)
+		vty_out(vty,
+			"Zebra RIB sweep timer running, remaining time %lds\n",
+			event_timer_remain_second(zrouter.t_rib_sweep));
+	else {
+		time_to_string(zrouter.rib_sweep_time, timebuf);
+		vty_out(vty, "Zebra RIB sweep happened at %s", timebuf);
+	}
 
 	ttable_rowseps(table, 0, BOTTOM, true, '-');
 	ttable_add_row(table, "OS|%s(%s)", cmd_system_get(), cmd_release_get());

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -64,6 +64,8 @@ struct client_gr_info {
 	/* Book keeping */
 	void *stale_client_ptr;
 	struct event *t_stale_removal;
+	void *client_ptr;
+	time_t route_sync_done_time;
 
 	TAILQ_ENTRY(client_gr_info) gr_info;
 };


### PR DESCRIPTION
Commit 1:
    Add support for a BGP-wide setting for graceful restart modes and
    parameters. This setting will apply to all BGP peers across all BGP
    instances, but per-neighbor configuration can override it.
    Per-instance configuration is disallowed if the BGP-wide setting
    is in effect.

Commit2:
    Streamline the BGP graceful-restart configuration at the global and
    peer level some more. Similar to many other neighbor capability
    parameters like MP and ENHE, reset the session immediately upon a
    change to the configuration. This will be more aligned with the
    transactional UI model also and will not require a separate 'clear'
    command to be executed.
    
    Note: Peer-group graceful-restart configuration is not yet supported.

Commit3:
    bgpd: Refine restarter operation - R-bit & F-bit
    
    Introduce BGP-wide flags to denote if BGP has started gracefully
    and GR is in progress or not. Use this for setting of the R-bit in
    the GR capability, and not a timer which is set for any new
    instance creation. Mark graceful restart is complete when the
    deferred path selection has been done and route sync with zebra as
    well as deferred EOR advertisement has been initiated.
    
    Introduce a function to check on F-bit setting rather than just
    base it on configuration.
    
    Subsequent commits will extend these functionalities.

Commit 4:
   bgpd: Refine OPEN debug logs for graceful restart
    
    This also fixes Rx F-bit log which was incorrect.
