### PR TITLE
zebra: be consistent about v6 nexthops for v4 routes

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2642,13 +2642,6 @@ static unsigned nexthop_active_check(struct route_node *rn,
 			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 		break;
 	case NEXTHOP_TYPE_IPV6:
-		family = AFI_IP6;
-		if (nexthop_active(nexthop, nhe, &rn->p, re->type, re->flags,
-				   &mtu, vrf_id))
-			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
-		else
-			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
-		break;
 	case NEXTHOP_TYPE_IPV6_IFINDEX:
 		/* RFC 5549, v4 prefix with v6 NH */
 		if (rn->p.family != AF_INET)


### PR DESCRIPTION
Treat TYPE_IPV6 and TYPE_IPV6_IFINDEX nexthops the same way when processing v4 (RFC 5549) routes. TYPE_IPV6 nexthops were being treated as if the prefix was v6: that causes the zebra 'ip protocol' routemap to fail to match and prevents use of the routemap to set a v4 source address when installing the route. That in turn prevents locally-sourced traffic to the v4 prefix from working correctly.
