### PR TITLE
tests: Fix zebra_seg6_route

### DIFF
--- a/tests/topotests/zebra_seg6_route/r1/routes_setup.json
+++ b/tests/topotests/zebra_seg6_route/r1/routes_setup.json
@@ -1,0 +1,28 @@
+{
+  "2001::/64":[
+    {
+      "prefix":"2001::/64",
+      "prefixLen":64,
+      "protocol":"connected",
+      "vrfName":"default",
+      "selected":true,
+      "destSelected":true,
+      "distance":0,
+      "metric":0,
+      "installed":true,
+      "internalStatus":16,
+      "internalFlags":8,
+      "internalNextHopNum":1,
+      "internalNextHopActiveNum":1,
+      "nexthops":[
+        {
+          "flags":3,
+          "fib":true,
+          "directlyConnected":true,
+          "interfaceName":"dum0",
+          "active":true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/zebra_seg6_route/test_zebra_seg6_route.py
+++ b/tests/topotests/zebra_seg6_route/test_zebra_seg6_route.py
@@ -73,6 +73,16 @@ def test_zebra_seg6_routes():
             return False
         return topotest.json_cmp(output, expected)
 
+    def check_connected(router, dest, expected):
+        logger.info("Checking for connected")
+        output = json.loads(router.vtysh_cmd("show ipv6 route {} json".format(dest)))
+        return topotest.json_cmp(output, expected)
+
+    expected = open_json_file(os.path.join(CWD, "{}/routes_setup.json".format("r1")))
+    test_func = partial(check_connected, r1, "2001::/64", expected)
+    success, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, "Failed to fully setup connected routes needed"
+
     manifests = open_json_file(os.path.join(CWD, "{}/routes.json".format("r1")))
     for manifest in manifests:
         dest = manifest["in"]["dest"]


### PR DESCRIPTION
Locally this test would occassionally fail for me
because the connected route the sharp route being
installed has not fully come up yet due to heavy
load and start up slowness.  Add a bit of code
to look for the problem and make sure it doesn't
happen.