### PR TITLE
ospf6d: Prevent heap-buffer-overflow with unknown type

### DIFF
--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -176,6 +176,7 @@ static int ospf6_extract_grace_lsa_fields(struct ospf6_lsa *lsa,
 				return OSPF6_FAILURE;
 			break;
 		default:
+			sum += TLV_SIZE(tlvh);
 			if (IS_DEBUG_OSPF6_GR)
 				zlog_debug("%s, Ignoring unknown TLV type:%d",
 					   __func__, ntohs(tlvh->type));


### PR DESCRIPTION
When parsing a osf6 grace lsa field and we receive an unknown tlv type, ospf6d was not incrementing the pointer to get beyond the tlv.  Leaving a situation where ospf6d would parse the packet incorrectly.