### PR TITLE
pimd: fix crash when mixing ssm/any-source joins

### DIFF
--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -457,8 +457,6 @@ struct gm_source *igmp_get_source_by_addr(struct gm_group *group,
 
 	listnode_add(group->group_source_list, src);
 
-	/* Any source (*,G) is forwarded only if mode is EXCLUDE {empty} */
-	igmp_anysource_forward_stop(group);
 	return src;
 }
 


### PR DESCRIPTION
Fixes: #15630

There is no reason to call `igmp_anysource_forward_stop()`  inside a call to 
`igmp_get_source_by_addr()`. The decision to start/stop forwarding is already handled correctly 
by pim outside `igmp_get_source_by_addr()`. That call was left there from the days pim was
initially imported in.

The problem was happening because `igmp_find_source_by_addr()` would fail to find the group/source  combo when 
mixing `(*, G)` and `(S, G)`, so a new entry is correctly created, but `igmp_anysource_forward_stop(group)` always stops (and eventually frees) `(*, G)` , but leaving a bad state because the new entry for `(S, G)` shouldn't have caused `(*, G)` to go away.

Tested the fix with multiple receivers on the same interface with several  ssm and any source senders and receivers with various combination of start/stop orders and they all worked correctly.
 