### PR TITLE
Route notification optim

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -22,6 +22,7 @@
 #include "mpls.h"
 #include "srcdest_table.h"
 #include "zebra/zebra_nhg.h"
+#include "zclient.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -628,6 +629,10 @@ extern int rib_add_gr_run(afi_t afi, vrf_id_t vrf_id, uint8_t proto,
 			  uint8_t instance);
 
 extern void zebra_vty_init(void);
+extern void
+zebra_route_notify_job_owner_list_enqueue(struct route_node *rn,
+					  const struct zebra_dplane_ctx *ctx,
+					  enum zapi_route_notify_owner note);
 
 extern pid_t pid;
 

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -633,6 +633,7 @@ extern void
 zebra_route_notify_job_owner_list_enqueue(struct route_node *rn,
 					  const struct zebra_dplane_ctx *ctx,
 					  enum zapi_route_notify_owner note);
+extern void zebra_route_notification_information_display(struct vty *vty);
 
 extern pid_t pid;
 

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -66,7 +66,8 @@ extern int zsend_route_notify_owner(const struct route_node *rn,
 				    enum zapi_route_notify_owner note,
 				    afi_t afi, safi_t safi);
 extern int zsend_route_notify_owner_ctx(const struct zebra_dplane_ctx *ctx,
-					enum zapi_route_notify_owner note);
+					enum zapi_route_notify_owner note,
+					bool enqueue_to_list);
 
 extern void zsend_rule_notify_owner(const struct zebra_dplane_ctx *ctx,
 				    enum zapi_rule_notify_owner note);
@@ -109,7 +110,11 @@ extern int zsend_zebra_srv6_locator_delete(struct zserv *client,
 					   struct srv6_locator *loc);
 extern int zsend_srv6_manager_get_locator_chunk_response(struct zserv *client,
 		vrf_id_t vrf_id, struct srv6_locator *loc);
-
+extern int route_notify_internal_prefix(const struct prefix *p, int type,
+					uint16_t instance, vrf_id_t vrf_id,
+					uint32_t table_id,
+					enum zapi_route_notify_owner note,
+					afi_t afi, safi_t safi);
 #ifdef __cplusplus
 }
 #endif

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -114,7 +114,8 @@ extern int route_notify_internal_prefix(const struct prefix *p, int type,
 					uint16_t instance, vrf_id_t vrf_id,
 					uint32_t table_id,
 					enum zapi_route_notify_owner note,
-					afi_t afi, safi_t safi);
+					afi_t afi, safi_t safi,
+					struct stream_fifo *out_fifo);
 #ifdef __cplusplus
 }
 #endif

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5319,3 +5319,15 @@ struct route_table *rib_tables_iter_next(rib_tables_iter_t *iter)
 
 	return table;
 }
+
+void zebra_route_notification_information_display(struct vty *vty)
+{
+	vty_out(vty,
+		"Route notify owner list count %u, processed %u, max per batch %u\n",
+		zebra_route_notify_job_owner_list_num,
+		zebra_route_notify_job_owner_list_processed,
+		zebra_route_notify_job_owner_list_max_batch);
+	vty_out(vty, "Process Notify Client list count %u, processed %u\n",
+		zebra_process_notify_client_list_num,
+		zebra_process_notify_client_list_processed);
+}

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -4152,6 +4152,18 @@ DEFUN (zebra_show_routing_tables_summary,
 	return CMD_SUCCESS;
 }
 
+/* Display route notification information */
+DEFUN(show_debugging_route_notification,
+      show_debugging_route_notification_cmd,
+      "show debugging route-notification",
+      SHOW_STR
+      DEBUG_STR
+      "Display route notification information\n")
+{
+	zebra_route_notification_information_display(vty);
+	return CMD_SUCCESS;
+}
+
 /* Table configuration write function. */
 static int config_write_table(struct vty *vty)
 {
@@ -4475,4 +4487,5 @@ void zebra_vty_init(void)
 #endif /* HAVE_SCRIPTING */
 
 	install_element(VIEW_NODE, &zebra_show_routing_tables_summary_cmd);
+	install_element(VIEW_NODE, &show_debugging_route_notification_cmd);
 }


### PR DESCRIPTION
To notify route owner, for each prefix installed, a notification message is sent.
Dataplane result is a linear function, and the time will increase, and may lead to starvation issues under heavy loaded conditions.

It has been observed that the thread in charge of the result takes time, because there are many routes results, and because the I/O operations to zebra are repeated. Lets try to optimize it by:
- by separating the route notification job in a separate thread
- by sending zapi batches messages to reduce the number of I/O operations.

The below graph is what has been observed, 
 [
![graph2](https://github.com/FRRouting/frr/assets/16295538/557454c5-ceca-4e5f-b5d7-2d329b437a18)
](url)