### PR TITLE
lib: make `python/ts_expand.py` actually work

### DIFF
--- a/lib/atomlist.h
+++ b/lib/atomlist.h
@@ -6,8 +6,8 @@
 #ifndef _FRR_ATOMLIST_H
 #define _FRR_ATOMLIST_H
 
-#ifndef _TYPESAFE_EXPAND_MACROS
 #include "typesafe.h"
+#ifndef _TYPESAFE_EXPAND_MACROS
 #include "frratomic.h"
 #endif /* _TYPESAFE_EXPAND_MACROS */
 


### PR DESCRIPTION
`lib/typesafe.h` was supposed to be outside the `_TYPESAFE_EXPAND_MACROS` guard, so that including `lib/atomlist.h` grabs all the typesafe container macros.

(No effect on normal build, as `_TYPESAFE_EXPAND_MACROS` is never defined there.)

---
blech. off by one line error in the `#ifndef`.