### PR TITLE
pimd: Give a clearer warning when the kernel is not compiled right

### DIFF
--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -56,10 +56,14 @@ int pim_mroute_set(struct pim_instance *pim, int enable)
 			err = setsockopt(pim->mroute_socket, PIM_IPPROTO,
 					 MRT_TABLE, &data, data_len);
 			if (err) {
-				zlog_warn(
-					"%s %s: failure: setsockopt(fd=%d,PIM_IPPROTO, MRT_TABLE=%d): errno=%d: %s",
-					__FILE__, __func__, pim->mroute_socket,
-					data, errno, safe_strerror(errno));
+				if (err == ENOPROTOOPT)
+					zlog_err("%s Kernel is not compiled with CONFIG_IP_MROUTE_MULTIPLE_TABLES and vrf's will not work",
+						 __func__);
+				else
+					zlog_warn("%s %s: failure: setsockopt(fd=%d,PIM_IPPROTO, MRT_TABLE=%d): errno=%d: %s",
+						  __FILE__, __func__,
+						  pim->mroute_socket, data,
+						  errno, safe_strerror(errno));
 				return -1;
 			}
 		}


### PR DESCRIPTION
When the kernel is not compiled with mroute vrf's enabled it will fail the call to initialize the vrf.  As such let's recognize this specific error code and output a specific warning to the operator to help them figure this problem out.