### PR TITLE
nhrpd: core dump on shutdown (backport #15879)

### DIFF
--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -83,13 +83,13 @@ static void nhrp_request_stop(void)
 	debugf(NHRP_DEBUG_COMMON, "Exiting...");
 	frr_early_fini();
 
-	nhrp_shortcut_terminate();
+	vrf_terminate();
 	nhrp_nhs_terminate();
 	nhrp_zebra_terminate();
 	vici_terminate();
 	evmgr_terminate();
 	nhrp_vc_terminate();
-	vrf_terminate();
+	nhrp_shortcut_terminate();
 
 	debugf(NHRP_DEBUG_COMMON, "Done.");
 	frr_fini();


### PR DESCRIPTION
This fixes a merge conflict encountered when backporting  #15879