### PR TITLE
ci: only run conflict check on pull-requests

### DIFF
--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -1,9 +1,8 @@
 name: Add a conflict label if PR needs to rebase
 
 on:
-  push:
   pull_request_target:
-    types: [synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
   conflicts:


### PR DESCRIPTION
This change will stop this action from running on forked repos. Previously whenever one pushed a change to one's development branch the action would "run but skip" which still generated an email notifications and thus was very annoying. :)

The "pull_request" event-id by default runs on event types of [ opened, reopened, synchronize ] which I believe is the original intention.