### PR TITLE
docker: fix chmod issues when running container for debian

### DIFF
--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -24,5 +24,5 @@ RUN chown -R frr:frr /etc/frr /var/run/frr
 ENTRYPOINT ["/usr/bin/tini", "--"]
 
 # Default CMD starts watchfrr
-COPY docker-start /usr/lib/frr/docker-start
+COPY --chmod=0755 docker-start /usr/lib/frr/docker-start
 CMD ["/usr/lib/frr/docker-start"]


### PR DESCRIPTION
## Description
<!-- Chmod issue on Silicon m3 while running container-->

## Steps to Reproduce
<!-- After I run I get permission issue,  -->

1. **Environment Setup**:
   - 1: "Docker desktop running on Apple silicon M3"

2. **Reproduce Issue**:
   - Download Files On: "[Navigate to the directory containing the Dockerfile](https://github.com/FRRouting/frr/tree/master/docker/debian)."
   - Run Command: "`docker build -t frr-debian:latest .`"
   - Run Command: "`docker run -itd --privileged --name frr frr-debian:latest`"


3. **Expected Behavior**:
    Just Run as stated on document 

4. **Actual Behavior**:
    -Output: "`docker logs -f frr`"
     "`[FATAL tini (7)] exec /usr/lib/frr/docker-start failed: Permission denied`"

## Proposed Changes
     Chmod fixes this issue.

## Screenshots/Logs
-

## Additional Information

