### PR TITLE
bgpd: Adjust terminology related to DSCP

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -817,9 +817,9 @@ int bgp_connect(struct peer_connection *connection)
 #ifdef IPTOS_PREC_INTERNETCONTROL
 	frr_with_privs(&bgpd_privs) {
 		if (sockunion_family(&connection->su) == AF_INET)
-			setsockopt_ipv4_tos(connection->fd, bm->tcp_dscp);
+			setsockopt_ipv4_tos(connection->fd, bm->ip_tos);
 		else if (sockunion_family(&connection->su) == AF_INET6)
-			setsockopt_ipv6_tclass(connection->fd, bm->tcp_dscp);
+			setsockopt_ipv6_tclass(connection->fd, bm->ip_tos);
 	}
 #endif
 
@@ -905,9 +905,9 @@ static int bgp_listener(int sock, struct sockaddr *sa, socklen_t salen,
 
 #ifdef IPTOS_PREC_INTERNETCONTROL
 		if (sa->sa_family == AF_INET)
-			setsockopt_ipv4_tos(sock, bm->tcp_dscp);
+			setsockopt_ipv4_tos(sock, bm->ip_tos);
 		else if (sa->sa_family == AF_INET6)
-			setsockopt_ipv6_tclass(sock, bm->tcp_dscp);
+			setsockopt_ipv6_tclass(sock, bm->ip_tos);
 #endif
 
 		sockopt_v6only(sa->sa_family, sock);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1760,10 +1760,10 @@ DEFPY (bgp_session_dscp,
        bgp_session_dscp_cmd,
        "bgp session-dscp (0-63)$dscp",
        BGP_STR
-       "Override default (C6) bgp TCP session DSCP value\n"
-       "Manually configured dscp parameter\n")
+       "Override default (CS6) DSCP for BGP connections\n"
+       "Manually configured DSCP value\n")
 {
-	bm->tcp_dscp = dscp << 2;
+	bm->ip_tos = dscp << 2;
 
 	return CMD_SUCCESS;
 }
@@ -1773,10 +1773,10 @@ DEFPY (no_bgp_session_dscp,
        "no bgp session-dscp [(0-63)]",
        NO_STR
        BGP_STR
-       "Override default (C6) bgp TCP session DSCP value\n"
-       "Manually configured dscp parameter\n")
+       "Override default (CS6) DSCP for BGP connections\n"
+       "Manually configured DSCP value\n")
 {
-	bm->tcp_dscp = IPTOS_PREC_INTERNETCONTROL;
+	bm->ip_tos = IPTOS_PREC_INTERNETCONTROL;
 
 	return CMD_SUCCESS;
 }
@@ -19191,9 +19191,9 @@ int bgp_config_write(struct vty *vty)
 	if (CHECK_FLAG(bm->flags, BM_FLAG_SEND_EXTRA_DATA_TO_ZEBRA))
 		vty_out(vty, "bgp send-extra-data zebra\n");
 
-	/* BGP session DSCP value */
-	if (bm->tcp_dscp != IPTOS_PREC_INTERNETCONTROL)
-		vty_out(vty, "bgp session-dscp %u\n", bm->tcp_dscp >> 2);
+	/* DSCP value for outgoing packets in BGP connections */
+	if (bm->ip_tos != IPTOS_PREC_INTERNETCONTROL)
+		vty_out(vty, "bgp session-dscp %u\n", bm->ip_tos >> 2);
 
 	/* BGP InQ limit */
 	if (bm->inq_limit != BM_DEFAULT_Q_LIMIT)

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -8375,7 +8375,7 @@ void bgp_master_init(struct event_loop *master, const int buffer_size,
 	bm->terminating = false;
 	bm->socket_buffer = buffer_size;
 	bm->wait_for_fib = false;
-	bm->tcp_dscp = IPTOS_PREC_INTERNETCONTROL;
+	bm->ip_tos = IPTOS_PREC_INTERNETCONTROL;
 	bm->inq_limit = BM_DEFAULT_Q_LIMIT;
 	bm->outq_limit = BM_DEFAULT_Q_LIMIT;
 	bm->t_bgp_sync_label_manager = NULL;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -166,8 +166,8 @@ struct bgp_master {
 
 	bool terminating;	/* global flag that sigint terminate seen */
 
-	/* DSCP value for TCP sessions */
-	uint8_t tcp_dscp;
+	/* TOS value for outgoing packets in BGP connections */
+	uint8_t ip_tos;
 
 #define BM_DEFAULT_Q_LIMIT 10000
 	uint32_t inq_limit;

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -4933,8 +4933,8 @@ setting.
 
 .. clicmd:: bgp session-dscp (0-63)
 
-This command allows bgp to control, at a global level, the TCP dscp values
-in the TCP header.
+This command allows the BGP daemon to control, at a global level, the DSCP value
+used in outgoing packets for each BGP connection.
 
 .. _bgp-suppress-fib:
 


### PR DESCRIPTION
The default DSCP used for BGP connections is CS6. The DSCP value is not part of the TCP header.

When setting the IP_TOS or IPV6_TCLASS socket options, the argument is not the 6-bit DSCP value, but an 8-bit value for the former IPv4 Type of Service field or IPv6 Traffic Class field, respectively.

Fixes: #11152