### PR TITLE
bgpd: fix do not skip paths with same nexthop

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3256,15 +3256,6 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,
 				if (!peer_established(pi->peer->connection))
 					continue;
 
-			if (!bgp_path_info_nexthop_cmp(pi, new_select)) {
-				if (debug)
-					zlog_debug(
-						"%pBD(%s): %s has the same nexthop as the bestpath, skip it",
-						dest, bgp->name_pretty,
-						path_buf);
-				continue;
-			}
-
 			bgp_path_info_cmp(bgp, pi, new_select, &paths_eq,
 					  mpath_cfg, debug, pfx_buf, afi, safi,
 					  &dest->reason);

--- a/tests/topotests/bgp_duplicate_nexthop/r1/bgpd.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r1/bgpd.conf
@@ -1,0 +1,13 @@
+router bgp 64500
+ bgp router-id 192.0.2.1
+ no bgp ebgp-requires-policy
+ neighbor rrserver peer-group
+ neighbor rrserver remote-as 64500
+ neighbor rrserver update-source lo
+ neighbor rrserver timers connect 2
+ neighbor 192.0.2.3 peer-group rrserver
+ address-family ipv4 unicast
+  neighbor rrserver next-hop-self
+  neighbor rrserver activate
+  exit-address-family
+!

--- a/tests/topotests/bgp_duplicate_nexthop/r1/isisd.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r1/isisd.conf
@@ -1,0 +1,26 @@
+hostname r1
+interface lo
+ ip router isis 1
+ isis passive
+!
+interface r1-eth1
+ ip router isis 1
+ isis network point-to-point
+!
+interface r1-eth2
+ ip router isis 1
+ isis network point-to-point
+!
+interface r1-eth4
+ ip router isis 1
+ isis network point-to-point
+!
+router isis 1
+ net 49.0123.6452.0001.00
+ is-type level-2-only
+ mpls-te on
+ segment-routing on
+ segment-routing global-block 16000 17000
+ segment-routing node-msd 10
+ segment-routing prefix 192.0.2.1/32 index 1
+!

--- a/tests/topotests/bgp_duplicate_nexthop/r1/zebra.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r1/zebra.conf
@@ -1,0 +1,24 @@
+log stdout
+interface lo
+ ip address 192.0.2.1/32
+!
+interface r1-eth0
+ ip address 172.31.10.1/24
+!
+interface r1-eth1
+ ip address 172.31.0.1/24
+ mpls enable
+!
+interface r1-eth2
+ ip address 172.31.2.1/24
+ mpls enable
+!
+interface r1-eth3
+ ip address 172.31.11.1/24
+ mpls enable
+!
+interface r1-eth4
+ ip address 172.31.8.1/24
+ mpls enable
+!
+

--- a/tests/topotests/bgp_duplicate_nexthop/r3/bgpd.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r3/bgpd.conf
@@ -1,0 +1,16 @@
+router bgp 64500 view one
+ bgp router-id 192.0.2.3
+ neighbor rr peer-group
+ neighbor rr remote-as 64500
+ neighbor rr update-source lo
+ neighbor 192.0.2.1 peer-group rr
+ neighbor 192.0.2.5 peer-group rr
+ neighbor 192.0.2.6 peer-group rr
+ neighbor 192.0.2.8 peer-group rr
+ !
+ address-family ipv4 unicast
+  neighbor rr activate
+  neighbor rr route-reflector-client
+  neighbor rr addpath-tx-all-paths
+ exit-address-family
+!

--- a/tests/topotests/bgp_duplicate_nexthop/r3/isisd.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r3/isisd.conf
@@ -1,0 +1,38 @@
+hostname r3
+interface lo
+ ip router isis 1
+ isis passive
+!
+interface r3-eth0
+ ip router isis 1
+ isis network point-to-point
+!
+interface r3-eth1
+ ip router isis 1
+ isis network point-to-point
+!
+interface r3-eth2
+ ip router isis 1
+ isis network point-to-point
+!
+interface r3-eth3
+ ip router isis 1
+ isis network point-to-point
+!
+interface r3-eth4
+ ip router isis 1
+ isis network point-to-point
+!
+interface r3-eth5
+ ip router isis 1
+ isis network point-to-point
+!
+router isis 1
+ net 49.0123.6452.0003.00
+ is-type level-2-only
+ mpls-te on
+ segment-routing on
+ segment-routing global-block 16000 17000
+ segment-routing node-msd 10
+ segment-routing prefix 192.0.2.3/32 index 3
+!

--- a/tests/topotests/bgp_duplicate_nexthop/r3/zebra.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r3/zebra.conf
@@ -1,0 +1,16 @@
+log stdout
+interface lo
+ ip address 192.0.2.3/32
+!
+interface r3-eth0
+ ip address 172.31.0.3/24
+ mpls enable
+!
+interface r3-eth1
+ ip address 172.31.4.3/24
+ mpls enable
+!
+interface r3-eth2
+ ip address 172.31.5.3/24
+ mpls enable
+!

--- a/tests/topotests/bgp_duplicate_nexthop/r4/isisd.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r4/isisd.conf
@@ -1,0 +1,30 @@
+hostname r4
+interface lo
+ ip router isis 1
+ isis passive
+!
+interface r4-eth0
+ ip router isis 1
+ isis network point-to-point
+!
+interface r4-eth1
+ ip router isis 1
+ isis network point-to-point
+!
+interface r4-eth2
+ ip router isis 1
+ isis network point-to-point
+!
+interface r4-eth3
+ ip router isis 1
+ isis network point-to-point
+!
+router isis 1
+ net 49.0123.6452.0004.00
+ is-type level-2-only
+ mpls-te on
+ segment-routing on
+ segment-routing global-block 16000 17000
+ segment-routing node-msd 10
+ segment-routing prefix 192.0.2.4/32 index 4
+!

--- a/tests/topotests/bgp_duplicate_nexthop/r4/zebra.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r4/zebra.conf
@@ -1,0 +1,20 @@
+log stdout
+interface lo
+ ip address 192.0.2.4/32
+!
+interface r4-eth0
+ ip address 172.31.2.4/24
+ mpls enable
+!
+interface r4-eth1
+ ip address 172.31.6.4/24
+ mpls enable
+!
+interface r4-eth2
+ ip address 172.31.7.4/24
+ mpls enable
+!
+interface r4-eth3
+ mpls enable
+!
+

--- a/tests/topotests/bgp_duplicate_nexthop/r5/bgpd.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r5/bgpd.conf
@@ -1,0 +1,19 @@
+router bgp 64500
+ bgp router-id 192.0.2.5
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor rrserver peer-group
+ neighbor rrserver remote-as 64500
+ neighbor rrserver update-source lo
+ neighbor rrserver timers connect 2
+ neighbor 192.0.2.3 peer-group rrserver
+ address-family ipv4 unicast
+  network 192.0.2.9/32
+  network 192.0.2.8/32 route-map rmap
+  neighbor rrserver activate
+  neighbor rrserver addpath-tx-all-paths
+ exit-address-family
+!
+route-map rmap permit 1
+ set ip next-hop 192.0.2.9
+exit

--- a/tests/topotests/bgp_duplicate_nexthop/r5/isisd.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r5/isisd.conf
@@ -1,0 +1,26 @@
+hostname r5
+interface lo
+ ip router isis 1
+ isis passive
+!
+interface r5-eth1
+ ip router isis 1
+ isis network point-to-point
+!
+interface r5-eth2
+ ip router isis 1
+ isis network point-to-point
+!
+interface r5-eth3
+ ip router isis 1
+ isis network point-to-point
+!
+router isis 1
+ net 49.0123.6452.0005.00
+ is-type level-2-only
+ mpls-te on
+ segment-routing on
+ segment-routing global-block 16000 17000
+ segment-routing node-msd 10
+ segment-routing prefix 192.0.2.5/32 index 55
+!

--- a/tests/topotests/bgp_duplicate_nexthop/r5/zebra.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r5/zebra.conf
@@ -1,0 +1,19 @@
+log stdout
+mpls label dynamic-block 5000 5999
+interface lo
+ ip address 192.0.2.5/32
+!
+interface r5-eth0
+ ip address 172.31.12.5/24
+!
+interface r5-eth1
+ ip address 172.31.4.5/24
+ mpls enable
+!
+interface r5-eth2
+ ip address 172.31.7.5/24
+ mpls enable
+!
+interface r5-eth3
+ ip address 172.31.21.5/24
+!

--- a/tests/topotests/bgp_duplicate_nexthop/r6/bgpd.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r6/bgpd.conf
@@ -1,0 +1,19 @@
+router bgp 64500
+ bgp router-id 192.0.2.6
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor rrserver peer-group
+ neighbor rrserver remote-as 64500
+ neighbor rrserver update-source lo
+ neighbor rrserver bfd
+ neighbor 192.0.2.3 peer-group rrserver
+ address-family ipv4 unicast
+  network 192.0.2.9/32
+  network 192.0.2.8/32 route-map rmap
+  neighbor rrserver activate
+  neighbor rrserver addpath-tx-all-paths
+ exit-address-family
+!
+route-map rmap permit 1
+ set ip next-hop 192.0.2.9
+exit

--- a/tests/topotests/bgp_duplicate_nexthop/r6/isisd.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r6/isisd.conf
@@ -1,0 +1,22 @@
+hostname r6
+interface lo
+ ip router isis 1
+ isis passive
+!
+interface r6-eth1
+ ip router isis 1
+ isis network point-to-point
+!
+interface r6-eth2
+ ip router isis 1
+ isis network point-to-point
+!
+router isis 1
+ net 49.0123.6452.0006.00
+ is-type level-2-only
+ mpls-te on
+ segment-routing on
+ segment-routing global-block 16000 17000
+ segment-routing node-msd 10
+ segment-routing prefix 192.0.2.6/32 index 6
+!

--- a/tests/topotests/bgp_duplicate_nexthop/r6/zebra.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r6/zebra.conf
@@ -1,0 +1,20 @@
+log stdout
+mpls label dynamic-block 6000 6999
+interface lo
+ ip address 192.0.2.6/32
+!
+interface r6-eth0
+ ip address 172.31.13.6/24
+!
+interface r6-eth1
+ ip address 172.31.5.6/24
+ mpls enable
+!
+interface r6-eth2
+ ip address 172.31.6.6/24
+ mpls enable
+!
+interface r6-eth3
+ ip address 172.31.22.6/24
+!
+

--- a/tests/topotests/bgp_duplicate_nexthop/test_bgp_duplicate_nexthop.py
+++ b/tests/topotests/bgp_duplicate_nexthop/test_bgp_duplicate_nexthop.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_bgp_duplicate_nexthop.py
+#
+# Copyright 2024 6WIND S.A.
+#
+
+"""
+ test_bgp_nhg_duplicate_nexthop.py:
+ Check that the FRR BGP daemon on r1 selects updates with same nexthops
+
+
++---+----+          +---+----+          +--------+
+|        |          |        +          |        |
+|  r1    +----------+  r3    +----------+  r5    +
+|        |          |  rr    +    +-----+        |
++++-+----+          +--------+\  /      +--------+
+    |                          \/
+    |                          /\
+    |               +--------+/  \      +--------+
+    |               |        +    +-----+        +
+    +---------------+  r4    +----------+  r6    +
+                    |        |          |        |
+                    +--------+          +--------+
+"""
+
+import os
+import sys
+import json
+from functools import partial
+import pytest
+import functools
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.common_check import ip_check_path_selection, iproute2_check_path_selection
+from lib.common_config import step
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+# Required to instantiate the topology builder class.
+
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def build_topo(tgen):
+    "Build function"
+
+    # Create 7 PE routers.
+    tgen.add_router("r1")
+    tgen.add_router("r3")
+    tgen.add_router("r4")
+    tgen.add_router("r5")
+    tgen.add_router("r6")
+
+    # switch
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+
+    switch = tgen.add_switch("s4")
+    switch.add_link(tgen.gears["r5"])
+
+    switch = tgen.add_switch("s5")
+    switch.add_link(tgen.gears["r6"])
+
+    switch = tgen.add_switch("s6")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r3"])
+
+    switch = tgen.add_switch("s7")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r4"])
+
+    switch = tgen.add_switch("s8")
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["r5"])
+
+    switch = tgen.add_switch("s9")
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["r6"])
+
+    switch = tgen.add_switch("s10")
+    switch.add_link(tgen.gears["r4"])
+    switch.add_link(tgen.gears["r6"])
+
+    switch = tgen.add_switch("s11")
+    switch.add_link(tgen.gears["r4"])
+    switch.add_link(tgen.gears["r5"])
+
+    switch = tgen.add_switch("s12")
+    switch.add_link(tgen.gears["r5"])
+
+    switch = tgen.add_switch("s13")
+    switch.add_link(tgen.gears["r6"])
+
+    switch = tgen.add_switch("s14")
+    switch.add_link(tgen.gears["r1"])
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for rname, router in router_list.items():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_ISIS, os.path.join(CWD, "{}/isisd.conf".format(rname))
+        )
+        if rname in ("r1", "r3", "r5", "r6"):
+            router.load_config(
+                TopoRouter.RD_BGP, os.path.join(CWD, "{}/bgpd.conf".format(rname))
+            )
+
+    # Initialize all routers.
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+
+    tgen.stop_topology()
+
+
+def check_ipv4_prefix_with_multiple_nexthops(prefix, multipath=True):
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info(
+        f"Check that {prefix} unicast entry is installed with paths for r5 and r6"
+    )
+
+    r5_nh = [
+        {
+            "ip": "192.0.2.5",
+            "active": True,
+            "recursive": True,
+        },
+        {
+            "ip": "172.31.0.3",
+            "interfaceName": "r1-eth1",
+            "active": True,
+            "labels": [
+                16055,
+            ],
+        },
+        {
+            "ip": "172.31.2.4",
+            "interfaceName": "r1-eth2",
+            "active": True,
+            "labels": [
+                16055,
+            ],
+        },
+    ]
+
+    r6_nh = [
+        {
+            "ip": "192.0.2.6",
+            "active": True,
+            "recursive": True,
+        },
+        {
+            "ip": "172.31.0.3",
+            "interfaceName": "r1-eth1",
+            "active": True,
+            "labels": [
+                16006,
+            ],
+        },
+        {
+            "ip": "172.31.2.4",
+            "interfaceName": "r1-eth2",
+            "active": True,
+            "labels": [
+                16006,
+            ],
+        },
+    ]
+
+    expected = {
+        prefix: [
+            {
+                "prefix": prefix,
+                "protocol": "bgp",
+                "metric": 0,
+                "table": 254,
+                "nexthops": [],
+            }
+        ]
+    }
+    for nh in r5_nh:
+        expected[prefix][0]["nexthops"].append(nh)
+    if multipath:
+        for nh in r6_nh:
+            expected[prefix][0]["nexthops"].append(nh)
+
+    test_func = functools.partial(
+        ip_check_path_selection, tgen.gears["r1"], prefix, expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert (
+        result is None
+    ), f"Failed to check that {prefix} uses the IGP label 16055 and 16006"
+
+
+def get_nh_formatted(nexthop, fib=True, duplicate=False):
+    nh = dict(nexthop)
+    if duplicate:
+        nh.update({"duplicate": True})
+    if fib:
+        nh.update({"fib": True})
+    return nh
+
+
+def check_ipv4_prefix_recursive_with_multiple_nexthops(
+    prefix, recursive_nexthop, multipath=True
+):
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    logger.info(
+        f"Check that {prefix} unicast entry is correctly recursive via {recursive_nexthop} with paths for r5 and r6"
+    )
+
+    r5_nh = [
+        {
+            "ip": "172.31.0.3",
+            "interfaceName": "r1-eth1",
+            "active": True,
+            "labels": [
+                16055,
+            ],
+        },
+        {
+            "ip": "172.31.2.4",
+            "interfaceName": "r1-eth2",
+            "active": True,
+            "labels": [
+                16055,
+            ],
+        },
+    ]
+
+    r6_nh = [
+        {
+            "ip": "172.31.0.3",
+            "interfaceName": "r1-eth1",
+            "active": True,
+            "labels": [
+                16006,
+            ],
+        },
+        {
+            "ip": "172.31.2.4",
+            "interfaceName": "r1-eth2",
+            "active": True,
+            "labels": [
+                16006,
+            ],
+        },
+    ]
+
+    expected = {
+        prefix: [
+            {
+                "prefix": prefix,
+                "protocol": "bgp",
+                "metric": 0,
+                "table": 254,
+                "nexthops": [],
+            }
+        ]
+    }
+
+    recursive_nh = [
+        {
+            "ip": recursive_nexthop,
+            "active": True,
+            "recursive": True,
+        },
+    ]
+    for nh in recursive_nh:
+        expected[prefix][0]["nexthops"].append(get_nh_formatted(nh, fib=False))
+
+    for nh in r5_nh:
+        expected[prefix][0]["nexthops"].append(get_nh_formatted(nh))
+
+    if multipath:
+        for nh in r6_nh:
+            expected[prefix][0]["nexthops"].append(get_nh_formatted(nh))
+
+        for nh in recursive_nh:
+            expected[prefix][0]["nexthops"].append(
+                get_nh_formatted(nh, fib=False, duplicate=True)
+            )
+
+        for nh in r5_nh:
+            expected[prefix][0]["nexthops"].append(
+                get_nh_formatted(nh, fib=False, duplicate=True)
+            )
+
+        for nh in r6_nh:
+            expected[prefix][0]["nexthops"].append(
+                get_nh_formatted(nh, fib=False, duplicate=True)
+            )
+
+    test_func = functools.partial(
+        ip_check_path_selection, tgen.gears["r1"], prefix, expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert (
+        result is None
+    ), f"Failed to check that {prefix} is correctly recursive via {recursive_nexthop}"
+
+
+def check_ipv4_prefix_with_multiple_nexthops_linux(prefix):
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step(
+        f"Check that {prefix} unicast entry is installed with paths for r5 and r6 on Linux"
+    )
+
+    r5_nh = [
+        {
+            "encap": "mpls",
+            "dst": "16055",
+            "gateway": "172.31.0.3",
+            "dev": "r1-eth1",
+        },
+        {
+            "encap": "mpls",
+            "dst": "16055",
+            "gateway": "172.31.2.4",
+            "dev": "r1-eth2",
+        },
+    ]
+
+    r6_nh = [
+        {
+            "encap": "mpls",
+            "dst": "16006",
+            "gateway": "172.31.0.3",
+            "dev": "r1-eth1",
+        },
+        {
+            "encap": "mpls",
+            "dst": "16006",
+            "gateway": "172.31.2.4",
+            "dev": "r1-eth2",
+        },
+    ]
+
+    expected = [
+        {
+            "dst": prefix,
+            "protocol": "bgp",
+            "metric": 20,
+            "nexthops": [],
+        }
+    ]
+
+    # only one path
+    for nh in r5_nh:
+        expected[0]["nexthops"].append(nh)
+    for nh in r6_nh:
+        expected[0]["nexthops"].append(nh)
+
+    test_func = functools.partial(
+        iproute2_check_path_selection, tgen.routers()["r1"], prefix, expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert (
+        result is None
+    ), f"Failed to check that {prefix} unicast entry is installed with paths for r5 and r6 on Linux"
+
+
+def test_bgp_ipv4_convergence():
+    """
+    Check that R1 has received the 192.0.2.9/32 prefix from R5, and R6
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Ensure that the 192.0.2.9/32 route is available")
+    check_ipv4_prefix_with_multiple_nexthops("192.0.2.9/32")
+
+    check_ipv4_prefix_with_multiple_nexthops_linux("192.0.2.9")
+
+
+def test_bgp_ipv4_recursive_routes():
+    """
+    Check that R1 has received the recursive routes, and duplicate nexthops are in zebra, but are not installed
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    check_ipv4_prefix_recursive_with_multiple_nexthops("192.0.2.8/32", "192.0.2.9")
+
+    check_ipv4_prefix_with_multiple_nexthops_linux("192.0.2.8")
+
+
+def test_bgp_ipv4_recursive_routes_when_no_mpath():
+    """
+    Unconfigure multipath ibgp
+    Check that duplicate nexthops are not in zebra
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    tgen.gears["r1"].vtysh_cmd(
+        """
+        configure terminal
+        router bgp
+        address family ipv4 unicast
+        maximum-paths ibgp 1
+        """,
+        isjson=False,
+    )
+    tgen.gears["r1"].vtysh_cmd("clear bgp ipv4 *")
+    check_ipv4_prefix_with_multiple_nexthops("192.0.2.9/32", multipath=False)
+
+    check_ipv4_prefix_recursive_with_multiple_nexthops(
+        "192.0.2.8/32", "192.0.2.9", multipath=False
+    )
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/lib/common_check.py
+++ b/tests/topotests/lib/common_check.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# common_check.py
+#
+# Copyright 2024 6WIND S.A.
+
+#
+import json
+from lib import topotest
+
+
+def ip_check_path_selection(router, ipaddr_str, expected, vrf_name=None):
+    if vrf_name:
+        cmdstr = f'show ip route vrf {vrf_name} {ipaddr_str} json'
+    else:
+        cmdstr = f'show ip route {ipaddr_str} json'
+    try:
+        output = json.loads(router.vtysh_cmd(cmdstr))
+    except:
+        output = {}
+
+    ret = topotest.json_cmp(output, expected)
+    if ret is None:
+        num_nh_expected = len(expected[ipaddr_str][0]["nexthops"])
+        num_nh_observed = len(output[ipaddr_str][0]["nexthops"])
+        if num_nh_expected == num_nh_observed:
+            return ret
+        return "{}, prefix {} does not have the correct number of nexthops : observed {}, expected {}".format(
+            router.name, ipaddr_str, num_nh_observed, num_nh_expected
+        )
+    return ret
+
+
+def iproute2_check_path_selection(router, ipaddr_str, expected, vrf_name=None):
+    if not topotest.iproute2_is_json_capable():
+        return None
+
+    if vrf_name:
+        cmdstr = f'ip -json route show vrf {vrf_name} {ipaddr_str}'
+    else:
+        cmdstr = f'ip -json route show {ipaddr_str}'
+    try:
+        output = json.loads(cmdstr)
+    except:
+        output = []
+
+    return topotest.json_cmp(output, expected)

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -602,6 +602,30 @@ def is_linux():
     return False
 
 
+def iproute2_is_json_capable():
+    """
+    Checks if the iproute2 version installed on the system is capable of
+    handling JSON outputss
+
+    Returns True if capability can be detected, returns False otherwise.
+    """
+    if is_linux():
+        try:
+            subp = subprocess.Popen(
+                ["ip", "-json", "route", "show"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+            )
+            iproute2_err = subp.communicate()[1].splitlines()[0].split()[0]
+
+            if iproute2_err != "Error:":
+                return True
+        except Exception:
+            pass
+    return False
+
+
 def iproute2_is_vrf_capable():
     """
     Checks if the iproute2 version installed on the system is capable of


### PR DESCRIPTION
Under a setup where two BGP prefixes are available from multiple sources, if one of the two prefixes is recursive over the other BGP prefix, then it will not be considered as multipath. The below output shows the two prefixes 192.0.2.24/32 and 192.0.2.21/32. The 192.0.2.[5,6,8] are the known IP addresses visible from the IGP.

> # show bgp ipv4 192.0.2.24/32
> *>i 192.0.2.24/32    192.0.2.21               0    100      0 i
> * i                  192.0.2.21               0    100      0 i
> * i                  192.0.2.21               0    100      0 i
> # show bgp ipv4 192.0.2.21/32
>  *>i 192.0.2.21/32    192.0.2.5                0    100      0 i
>  *=i                  192.0.2.6                0    100      0 i
>  *=i                  192.0.2.8                0    100      0 i

The bgp best selection algorithm refuses to consider the paths to '192.0.2.24/32' as multipath, whereas the BGP paths which use the BGP peer as nexthop are considered multipath.

> ... has the same nexthop as the bestpath, skip it ...

Previously, this condition has been added to prevent ZEBRA from installing routes with same nexthop:

>     Here you can see the two paths with nexthop 210.2.2.2
>     superm-redxp-05# show ip route 2.23.24.192/28
>     Routing entry for 2.23.24.192/28
>       Known via "bgp", distance 20, metric 0, best
>       Last update 00:32:12 ago
>       * 210.2.2.2, via swp3
>       * 210.2.0.2, via swp1
>       * 210.2.1.2, via swp2
>       * 210.2.2.2, via swp3
> [..]

But today, ZEBRA knows how to handle it. When receiving incoming routes, nexthop groups are used. At creation, duplicated nexthops are identified, and will not be installed. The below output illustrate the duplicate paths to 172.16.0.200 received by an other peer.

> r1# show ip route 172.18.1.100 nexthop-group
> Routing entry for 172.18.1.100/32
>   Known via "bgp", distance 200, metric 0, best
>   Last update 00:03:03 ago
>   Nexthop Group ID: 75757580
>     172.16.0.200 (recursive), weight 1
>   *   172.31.0.3, via r1-eth1, label 16055, weight 1
>   *   172.31.2.4, via r1-eth2, label 16055, weight 1
>   *   172.31.0.3, via r1-eth1, label 16006, weight 1
>   *   172.31.2.4, via r1-eth2, label 16006, weight 1
>   *   172.31.8.7, via r1-eth4, label 16008, weight 1
>     172.16.0.200 (duplicate nexthop removed) (recursive), weight 1
>       172.31.0.3, via r1-eth1 (duplicate nexthop removed), label 16055, weight 1
>       172.31.2.4, via r1-eth2 (duplicate nexthop removed), label 16055, weight 1
>       172.31.0.3, via r1-eth1 (duplicate nexthop removed), label 16006, weight 1
>       172.31.2.4, via r1-eth2 (duplicate nexthop removed), label 16006, weight 1
>       172.31.8.7, via r1-eth4 (duplicate nexthop removed), label 16008, weight 1

Fix this by proposing to let ZEBRA handle this duplicate decision.

Fixes: 7dc9d4e4e360 ("bgp may add multiple path entries with the same nexthop")