### PR TITLE
bgpd: Ignore auto created VRF BGP instances

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3620,10 +3620,13 @@ struct bgp *bgp_lookup_by_name(const char *name)
 	struct bgp *bgp;
 	struct listnode *node, *nnode;
 
-	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp))
+	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
+		if (CHECK_FLAG(bgp->vrf_flags, BGP_VRF_AUTO))
+			continue;
 		if ((bgp->name == NULL && name == NULL)
 		    || (bgp->name && name && strcmp(bgp->name, name) == 0))
 			return bgp;
+	}
 	return NULL;
 }
 


### PR DESCRIPTION
Configuration:

```
vtysh <<EOF
configure

vrf vrf100
 vni 10100
exit-vrf

router bgp 50
 address-family l2vpn evpn
  advertise-all-vni
 exit-address-family
exit

router bgp 100 vrf vrf100
exit
EOF
```

TL;DR; When we configure `advertise-all-vni` (in this case), a new BGP instance is created with the name vrf100, and ASN 50. Next, when we create `router bgp 100 vrf vrf100`, we look for the BGP instance with the same name and we found it, but ASNs are different 50 vs. 100.

Every such a new auto created instance is flagged with BGP_VRF_AUTO.

After the fix:

```
router bgp 50
 !
 address-family l2vpn evpn
  advertise-all-vni
 exit-address-family
exit
!
router bgp 100 vrf vrf100
exit
!
end
donatas.net(config)# router bgp 51
BGP is already running; AS is 50
donatas.net(config)# router bgp 50
donatas.net(config-router)# router bgp 101 vrf vrf100
BGP is already running; AS is 100
donatas.net(config)# router bgp 100 vrf vrf100
donatas.net(config-router)#
```

Fixes: https://github.com/FRRouting/frr/issues/16152
Fixes: https://github.com/FRRouting/frr/issues/9537