### PR TITLE
 ospf6d: OSPFv3 manual key authentication neglects checking the SA ID.

### DIFF
--- a/ospf6d/ospf6_auth_trailer.c
+++ b/ospf6d/ospf6_auth_trailer.c
@@ -517,6 +517,15 @@ int ospf6_auth_check_digest(struct ospf6_header *oh, struct ospf6_interface *oi,
 		}
 	} else if (CHECK_FLAG(oi->at_data.flags,
 			      OSPF6_AUTH_TRAILER_MANUAL_KEY)) {
+		if (oi->at_data.key_id != ntohs(ospf6_auth->id)) {
+			if (IS_OSPF6_DEBUG_AUTH_RX)
+				zlog_err("RECV[%s]: Auth SA ID mismatch for %s, received %u vs configured %u",
+					 oi->interface->name,
+					 ospf6_message_type(oh->type),
+					 ntohs(ospf6_auth->id),
+					 oi->at_data.key_id);
+			return OSPF6_AUTH_VALIDATE_FAILURE;
+		}
 		auth_str = oi->at_data.auth_key;
 		hash_algo = oi->at_data.hash_algo;
 	}

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_authentication.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_authentication.py
@@ -175,7 +175,7 @@ def test_ospf6_auth_trailer_tc1_md5(request):
     result = config_ospf6_interface(tgen, topo, r1_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify that the neighbour is not FULL between R1 and R2.")
+    step("Verify that the neighbor is not FULL between R1 and R2.")
     # wait for dead time expiry.
     sleep(6)
     dut = "r1"
@@ -208,7 +208,7 @@ def test_ospf6_auth_trailer_tc1_md5(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2  "
+        "Verify that the neighbor is FULL between R1 and R2  "
         "using show ipv6 ospf6 neighbor cmd."
     )
 
@@ -266,7 +266,7 @@ def test_ospf6_auth_trailer_tc1_md5(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2 using"
+        "Verify that the neighbor is FULL between R1 and R2 using"
         " show ip ospf6 neighbor cmd."
     )
 
@@ -283,7 +283,7 @@ def test_ospf6_auth_trailer_tc1_md5(request):
 
     dut = "r2"
     step(
-        "Verify that the neighbour is not FULL between R1 and R2 using "
+        "Verify that the neighbor is not FULL between R1 and R2 using "
         "show ip ospf6 neighbor cmd."
     )
     ospf6_covergence = verify_ospf6_neighbor(tgen, topo, dut=dut, expected=False)
@@ -295,7 +295,7 @@ def test_ospf6_auth_trailer_tc1_md5(request):
     shutdown_bringup_interface(tgen, dut, intf, True)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2 using "
+        "Verify that the neighbor is FULL between R1 and R2 using "
         "show ip ospf6 neighbor cmd."
     )
 
@@ -341,7 +341,7 @@ def test_ospf6_auth_trailer_tc2_sha256(request):
     result = config_ospf6_interface(tgen, topo, r1_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify that the neighbour is not FULL between R1 and R2.")
+    step("Verify that the neighbor is not FULL between R1 and R2.")
     # wait for dead time expiry.
     sleep(6)
     dut = "r1"
@@ -374,7 +374,7 @@ def test_ospf6_auth_trailer_tc2_sha256(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2  "
+        "Verify that the neighbor is FULL between R1 and R2  "
         "using show ipv6 ospf6 neighbor cmd."
     )
 
@@ -432,7 +432,7 @@ def test_ospf6_auth_trailer_tc2_sha256(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2 using"
+        "Verify that the neighbor is FULL between R1 and R2 using"
         " show ip ospf6 neighbor cmd."
     )
 
@@ -449,7 +449,7 @@ def test_ospf6_auth_trailer_tc2_sha256(request):
 
     dut = "r2"
     step(
-        "Verify that the neighbour is not FULL between R1 and R2 using "
+        "Verify that the neighbor is not FULL between R1 and R2 using "
         "show ip ospf6 neighbor cmd."
     )
     ospf6_covergence = verify_ospf6_neighbor(tgen, topo, dut=dut, expected=False)
@@ -461,7 +461,66 @@ def test_ospf6_auth_trailer_tc2_sha256(request):
     shutdown_bringup_interface(tgen, dut, intf, True)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2 using "
+        "Verify that the neighbor is FULL between R1 and R2 using "
+        "show ip ospf6 neighbor cmd."
+    )
+
+    dut = "r2"
+    ospf6_covergence = verify_ospf6_neighbor(tgen, topo, dut=dut)
+    assert ospf6_covergence is True, "Testcase {} :Failed \n Error:  {}".format(
+        tc_name, ospf6_covergence
+    )
+
+    step("Change the key ID on R2 to not match R1")
+    r2_ospf6_auth = {
+        "r2": {
+            "links": {
+                "r1": {
+                    "ospf6": {
+                        "hash-algo": "hmac-sha-256",
+                        "key": "ospf6",
+                        "key-id": "30",
+                    }
+                }
+            }
+        }
+    }
+    result = config_ospf6_interface(tgen, topo, r2_ospf6_auth)
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    step(
+        "Verify on R1 that R2 nbr is deleted due to key-id mismatch "
+        "after dead interval expiry"
+    )
+    #  wait till the dead timer expiry
+    sleep(6)
+    dut = "r2"
+    ospf6_covergence = verify_ospf6_neighbor(
+        tgen, topo, dut=dut, expected=False, retry_timeout=5
+    )
+    assert ospf6_covergence is not True, "Testcase {} :Failed \n Error:  {}".format(
+        tc_name, ospf6_covergence
+    )
+
+    step("Correct the key ID on R2 so that it matches R1")
+    r2_ospf6_auth = {
+        "r2": {
+            "links": {
+                "r1": {
+                    "ospf6": {
+                        "hash-algo": "hmac-sha-256",
+                        "key": "ospf6",
+                        "key-id": "10",
+                    }
+                }
+            }
+        }
+    }
+    result = config_ospf6_interface(tgen, topo, r2_ospf6_auth)
+    assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
+
+    step(
+        "Verify that the neighbor is FULL between R1 and R2 using "
         "show ip ospf6 neighbor cmd."
     )
 
@@ -524,7 +583,7 @@ def test_ospf6_auth_trailer_tc3_keychain_md5(request):
     result = config_ospf6_interface(tgen, topo, r1_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify that the neighbour is not FULL between R1 and R2.")
+    step("Verify that the neighbor is not FULL between R1 and R2.")
     # wait for dead time expiry.
     sleep(6)
     dut = "r1"
@@ -555,7 +614,7 @@ def test_ospf6_auth_trailer_tc3_keychain_md5(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2  "
+        "Verify that the neighbor is FULL between R1 and R2  "
         "using show ipv6 ospf6 neighbor cmd."
     )
 
@@ -600,7 +659,7 @@ def test_ospf6_auth_trailer_tc3_keychain_md5(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2 using"
+        "Verify that the neighbor is FULL between R1 and R2 using"
         " show ip ospf6 neighbor cmd."
     )
 
@@ -617,7 +676,7 @@ def test_ospf6_auth_trailer_tc3_keychain_md5(request):
 
     dut = "r2"
     step(
-        "Verify that the neighbour is not FULL between R1 and R2 using "
+        "Verify that the neighbor is not FULL between R1 and R2 using "
         "show ip ospf6 neighbor cmd."
     )
     ospf6_covergence = verify_ospf6_neighbor(tgen, topo, dut=dut, expected=False)
@@ -629,7 +688,7 @@ def test_ospf6_auth_trailer_tc3_keychain_md5(request):
     shutdown_bringup_interface(tgen, dut, intf, True)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2 using "
+        "Verify that the neighbor is FULL between R1 and R2 using "
         "show ip ospf6 neighbor cmd."
     )
 
@@ -692,7 +751,7 @@ def test_ospf6_auth_trailer_tc4_keychain_sha256(request):
     result = config_ospf6_interface(tgen, topo, r1_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify that the neighbour is not FULL between R1 and R2.")
+    step("Verify that the neighbor is not FULL between R1 and R2.")
     # wait for dead time expiry.
     sleep(6)
     dut = "r1"
@@ -723,7 +782,7 @@ def test_ospf6_auth_trailer_tc4_keychain_sha256(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2  "
+        "Verify that the neighbor is FULL between R1 and R2  "
         "using show ipv6 ospf6 neighbor cmd."
     )
 
@@ -768,7 +827,7 @@ def test_ospf6_auth_trailer_tc4_keychain_sha256(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2 using"
+        "Verify that the neighbor is FULL between R1 and R2 using"
         " show ip ospf6 neighbor cmd."
     )
 
@@ -785,7 +844,7 @@ def test_ospf6_auth_trailer_tc4_keychain_sha256(request):
 
     dut = "r2"
     step(
-        "Verify that the neighbour is not FULL between R1 and R2 using "
+        "Verify that the neighbor is not FULL between R1 and R2 using "
         "show ip ospf6 neighbor cmd."
     )
     ospf6_covergence = verify_ospf6_neighbor(tgen, topo, dut=dut, expected=False)
@@ -797,7 +856,7 @@ def test_ospf6_auth_trailer_tc4_keychain_sha256(request):
     shutdown_bringup_interface(tgen, dut, intf, True)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2 using "
+        "Verify that the neighbor is FULL between R1 and R2 using "
         "show ip ospf6 neighbor cmd."
     )
 
@@ -843,7 +902,7 @@ def test_ospf6_auth_trailer_tc5_md5_keymissmatch(request):
     result = config_ospf6_interface(tgen, topo, r1_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify that the neighbour is not FULL between R1 and R2.")
+    step("Verify that the neighbor is not FULL between R1 and R2.")
     # wait for dead time expiry.
     sleep(6)
     dut = "r1"
@@ -876,11 +935,11 @@ def test_ospf6_auth_trailer_tc5_md5_keymissmatch(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify that the neighbour is not FULL between R1 and R2  "
+        "Verify that the neighbor is not FULL between R1 and R2  "
         "using show ipv6 ospf6 neighbor cmd."
     )
 
-    step("Verify that the neighbour is FULL between R1 and R2.")
+    step("Verify that the neighbor is FULL between R1 and R2.")
     # wait for dead time expiry.
     sleep(6)
     dut = "r2"
@@ -913,7 +972,7 @@ def test_ospf6_auth_trailer_tc5_md5_keymissmatch(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2  "
+        "Verify that the neighbor is FULL between R1 and R2  "
         "using show ipv6 ospf6 neighbor cmd."
     )
 
@@ -959,7 +1018,7 @@ def test_ospf6_auth_trailer_tc6_sha256_mismatch(request):
     result = config_ospf6_interface(tgen, topo, r1_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify that the neighbour is not FULL between R1 and R2.")
+    step("Verify that the neighbor is not FULL between R1 and R2.")
     # wait for dead time expiry.
     sleep(6)
     dut = "r1"
@@ -991,7 +1050,7 @@ def test_ospf6_auth_trailer_tc6_sha256_mismatch(request):
     result = config_ospf6_interface(tgen, topo, r2_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify that the neighbour is not FULL between R1 and R2.")
+    step("Verify that the neighbor is not FULL between R1 and R2.")
     # wait for dead time expiry.
     sleep(6)
     dut = "r2"
@@ -1024,7 +1083,7 @@ def test_ospf6_auth_trailer_tc6_sha256_mismatch(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2  "
+        "Verify that the neighbor is FULL between R1 and R2  "
         "using show ipv6 ospf6 neighbor cmd."
     )
 
@@ -1095,7 +1154,7 @@ def test_ospf6_auth_trailer_tc7_keychain_md5_missmatch(request):
     result = config_ospf6_interface(tgen, topo, r1_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify that the neighbour is not FULL between R1 and R2.")
+    step("Verify that the neighbor is not FULL between R1 and R2.")
     # wait for dead time expiry.
     sleep(6)
     dut = "r1"
@@ -1125,7 +1184,7 @@ def test_ospf6_auth_trailer_tc7_keychain_md5_missmatch(request):
     result = config_ospf6_interface(tgen, topo, r2_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify that the neighbour is not FULL between R1 and R2.")
+    step("Verify that the neighbor is not FULL between R1 and R2.")
     # wait for dead time expiry.
     sleep(6)
     dut = "r2"
@@ -1156,7 +1215,7 @@ def test_ospf6_auth_trailer_tc7_keychain_md5_missmatch(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2  "
+        "Verify that the neighbor is FULL between R1 and R2  "
         "using show ipv6 ospf6 neighbor cmd."
     )
 
@@ -1227,7 +1286,7 @@ def test_ospf6_auth_trailer_tc8_keychain_sha256_missmatch(request):
     result = config_ospf6_interface(tgen, topo, r1_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify that the neighbour is not FULL between R1 and R2.")
+    step("Verify that the neighbor is not FULL between R1 and R2.")
     # wait for dead time expiry.
     sleep(6)
     dut = "r1"
@@ -1257,7 +1316,7 @@ def test_ospf6_auth_trailer_tc8_keychain_sha256_missmatch(request):
     result = config_ospf6_interface(tgen, topo, r2_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify that the neighbour is not FULL between R1 and R2.")
+    step("Verify that the neighbor is not FULL between R1 and R2.")
     # wait for dead time expiry.
     sleep(6)
     dut = "r2"
@@ -1288,7 +1347,7 @@ def test_ospf6_auth_trailer_tc8_keychain_sha256_missmatch(request):
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2  "
+        "Verify that the neighbor is FULL between R1 and R2  "
         "using show ipv6 ospf6 neighbor cmd."
     )
 
@@ -1335,7 +1394,7 @@ def test_ospf6_auth_trailer_tc9_keychain_not_configured(request):
     result = config_ospf6_interface(tgen, topo, r1_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify that the neighbour is not FULL between R1 and R2.")
+    step("Verify that the neighbor is not FULL between R1 and R2.")
     # wait for dead time expiry.
     sleep(6)
     dut = "r1"
@@ -1365,7 +1424,7 @@ def test_ospf6_auth_trailer_tc9_keychain_not_configured(request):
     result = config_ospf6_interface(tgen, topo, r2_ospf6_auth)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
-    step("Verify that the neighbour is not FULL between R1 and R2.")
+    step("Verify that the neighbor is not FULL between R1 and R2.")
     # wait for dead time expiry.
     sleep(6)
     dut = "r2"
@@ -1396,7 +1455,7 @@ def test_ospf6_auth_trailer_tc10_no_auth_trailer(request):
     router2 = tgen.gears["r2"]
 
     step(
-        "Verify that the neighbour is FULL between R1 and R2  "
+        "Verify that the neighbor is FULL between R1 and R2  "
         "using show ipv6 ospf6 neighbor cmd."
     )
 


### PR DESCRIPTION
    Also, add topotest variation to verify checking.

    This corrects https://github.com/FRRouting/frr/issues/16100.