### PR TITLE
tests: munet: update to version 0.14.9

### DIFF
--- a/tests/topotests/munet/cli.py
+++ b/tests/topotests/munet/cli.py
@@ -106,9 +106,13 @@ def is_host_regex(restr):
 
 
 def get_host_regex(restr):
-    if len(restr) < 3 or restr[0] != "/" or restr[-1] != "/":
+    try:
+        if len(restr) < 3 or restr[0] != "/" or restr[-1] != "/":
+            return None
+        return re.compile(restr[1:-1])
+    except re.error:
+        logging.error("Invalid regex")
         return None
-    return re.compile(restr[1:-1])
 
 
 def host_in(restr, names):
@@ -126,8 +130,8 @@ def expand_host(restr, names):
     hosts = []
     regexp = get_host_regex(restr)
     if not regexp:
-        assert restr in names
-        hosts.append(restr)
+        if restr in names:
+            hosts.append(restr)
     else:
         for name in names:
             if regexp.fullmatch(name):

--- a/tests/topotests/munet/logconf-mutest.yaml
+++ b/tests/topotests/munet/logconf-mutest.yaml
@@ -1,5 +1,8 @@
 version: 1
 formatters:
+  result_color:
+    class: munet.mulog.ResultColorFormatter
+    format: '%(levelname)5s: %(message)s'
   brief:
     format: '%(levelname)5s: %(message)s'
   operfmt:
@@ -22,7 +25,7 @@ handlers:
   info_console:
     level: INFO
     class: logging.StreamHandler
-    formatter: brief
+    formatter: result_color
     stream: ext://sys.stderr
   oper_console:
     level: DEBUG

--- a/tests/topotests/munet/mucmd.py
+++ b/tests/topotests/munet/mucmd.py
@@ -89,14 +89,14 @@ def main(*args):
     ecmd = "/usr/bin/nsenter"
     eargs = [ecmd]
 
-    # start mucmd same way base process is started
+    #start mucmd same way base process is started
     eargs.append(f"--mount=/proc/{pid}/ns/mnt")
     eargs.append(f"--net=/proc/{pid}/ns/net")
     eargs.append(f"--pid=/proc/{pid}/ns/pid_for_children")
     eargs.append(f"--uts=/proc/{pid}/ns/uts")
     eargs.append(f"--wd={rundir}")
     eargs += args.shellcmd
-    # print("Using ", eargs)
+    #print("Using ", eargs)
     return os.execvpe(ecmd, eargs, {**env, **envcfg})
 
 

--- a/tests/topotests/munet/mulog.py
+++ b/tests/topotests/munet/mulog.py
@@ -12,6 +12,9 @@ import logging
 from pathlib import Path
 
 
+do_color = True
+
+
 class MultiFileHandler(logging.FileHandler):
     """A logging handler that logs to new files based on the logger name.
 
@@ -118,5 +121,28 @@ class ColorFormatter(logging.Formatter):
         super().__init__(fmt, datefmt, style, **kwargs)
 
     def format(self, record):
+        if not do_color:
+            return super().format(record)
         formatter = self.formatters.get(record.levelno)
         return formatter.format(record)
+
+
+class ResultColorFormatter(logging.Formatter):
+    """A formatter that colorizes PASS/FAIL strings based on level."""
+
+    green = "\x1b[32m"
+    red = "\x1b[31m"
+    reset = "\x1b[0m"
+
+    def format(self, record):
+        s = super().format(record)
+        if not do_color:
+            return s
+        idx = s.find("FAIL")
+        if idx >= 0 and record.levelno > logging.INFO:
+            s = s[:idx] + self.red + "FAIL" + self.reset + s[idx + 4 :]
+        elif record.levelno == logging.INFO:
+            idx = s.find("PASS")
+            if idx >= 0:
+                s = s[:idx] + self.green + "PASS" + self.reset + s[idx + 4 :]
+        return s

--- a/tests/topotests/munet/munet-schema.json
+++ b/tests/topotests/munet/munet-schema.json
@@ -93,6 +93,9 @@
           "image": {
             "type": "string"
           },
+          "hostnet": {
+            "type": "boolean"
+          },
           "server": {
             "type": "string"
           },
@@ -383,6 +386,9 @@
               },
               "ipv6": {
                 "type": "string"
+              },
+              "external": {
+                "type": "boolean"
               }
             }
           }
@@ -421,6 +427,9 @@
               },
               "image": {
                 "type": "string"
+              },
+              "hostnet": {
+                "type": "boolean"
               },
               "server": {
                 "type": "string"

--- a/tests/topotests/munet/mutest/userapi.py
+++ b/tests/topotests/munet/mutest/userapi.py
@@ -544,7 +544,9 @@ class TestCase:
         """
         js = self._command_json(target, cmd)
         if js is None:
-            return expect_fail, {}
+            # Always fail on bad json, even if user expected failure
+            # return expect_fail, {}
+            return False, {}
 
         try:
             # Convert to string to validate the input is valid JSON
@@ -556,7 +558,9 @@ class TestCase:
             self.olog.warning(
                 "JSON load failed. Check match value is in JSON format: %s", error
             )
-            return expect_fail, {}
+            # Always fail on bad json, even if user expected failure
+            # return expect_fail, {}
+            return False, {}
 
         if exact_match:
             deep_diff = json_cmp(expect, js)

--- a/tests/topotests/munet/watchlog.py
+++ b/tests/topotests/munet/watchlog.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 class MatchFoundError(Exception):
     """An error raised when a match is not found."""
-
     def __init__(self, watchlog, match):
         self.watchlog = watchlog
         self.match = match


### PR DESCRIPTION
Topotest relevant changes:

    - add support for `timeout` arg to `cmd_*()`
    - handle invalid regexp in CLI commands
    - fix long interface name support

Full munet changelog:

    munet: 0.14.9: add support for `timeout` arg to `cmd_*()`
    munet: 0.14.8: cleanup the cleanup (kill) on launch options
    munet: 0.14.7: allow multiple extra commands for shell console init
    munet: 0.14.6:
      - qemu: gather gcda files where munet can find them
      - handle invalid regexp in CLI commands
    munet: 0.14.5:
      - (podman) pull missing images for containers
      - fix long interface name support
      - add another router example
    munet: 0.14.4: mutest: add color to PASS/FAIL indicators on tty consoles
    munet: 0.14.3: Add hostnet node that runs it's commands in the host network namespace. 
    munet: 0.14.2:
      - always fail mutest tests on bad json inputs
      - improve ssh-remote for common use-case of connecting to host connected devices
      - fix ready-cmd for python v3.11+
    munet: 0.14.1: Improved host interface support.
