### PR TITLE
babel: Added null check after retrieving babel_ifp

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -108,6 +108,7 @@ babel_interface_address_add (ZAPI_CALLBACK_ARGS)
     if (prefix->family == AF_INET) {
         flush_interface_routes(ifc->ifp, 0);
         babel_ifp = babel_get_if_nfo(ifc->ifp);
+        assert (babel_ifp != NULL);
         if (babel_ifp->ipv4 == NULL) {
             babel_ifp->ipv4 = malloc(4);
             if (babel_ifp->ipv4 == NULL) {
@@ -144,6 +145,7 @@ babel_interface_address_delete (ZAPI_CALLBACK_ARGS)
     if (prefix->family == AF_INET) {
         flush_interface_routes(ifc->ifp, 0);
         babel_ifp = babel_get_if_nfo(ifc->ifp);
+	assert (babel_ifp != NULL);
 	if (babel_ifp->ipv4 != NULL
 	    && memcmp(babel_ifp->ipv4, &prefix->u.prefix4, IPV4_MAX_BYTELEN)
 		       == 0) {
@@ -542,7 +544,10 @@ DEFPY (babel_set_channel,
 unsigned
 jitter(babel_interface_nfo *babel_ifp, int urgent)
 {
-    unsigned interval = babel_ifp->hello_interval;
+    unsigned interval;
+
+    assert (babel_ifp != NULL);
+    interval = babel_ifp->hello_interval;
     if(urgent)
         interval = MIN(interval, 100);
     else
@@ -553,7 +558,10 @@ jitter(babel_interface_nfo *babel_ifp, int urgent)
 unsigned
 update_jitter(babel_interface_nfo *babel_ifp, int urgent)
 {
-    unsigned interval = babel_ifp->hello_interval;
+    unsigned interval;
+
+    assert (babel_ifp != NULL);
+    interval = babel_ifp->hello_interval;
     if(urgent)
         interval = MIN(interval, 100);
     else
@@ -566,10 +574,11 @@ update_jitter(babel_interface_nfo *babel_ifp, int urgent)
 static int
 interface_recalculate(struct interface *ifp)
 {
-    babel_interface_nfo *babel_ifp = babel_get_if_nfo(ifp);
     unsigned char *tmp = NULL;
     int mtu, rc;
     struct ipv6_mreq mreq;
+    babel_interface_nfo *babel_ifp = babel_get_if_nfo(ifp);
+    assert (babel_ifp != NULL);
 
     if (!IS_ENABLE(ifp))
         return -1;
@@ -656,6 +665,7 @@ interface_reset(struct interface *ifp)
     int rc;
     struct ipv6_mreq mreq;
     babel_interface_nfo *babel_ifp = babel_get_if_nfo(ifp);
+    assert (babel_ifp != NULL);
 
     if (!CHECK_FLAG(babel_ifp->flags, BABEL_IF_IS_UP))
         return 0;
@@ -777,6 +787,7 @@ show_babel_interface_sub (struct vty *vty, struct interface *ifp)
     return;
   }
   babel_ifp = babel_get_if_nfo (ifp);
+  assert (babel_ifp != NULL);
   vty_out (vty, "  Babel protocol is running on this interface\n");
   vty_out (vty, "  Operating mode is \"%s\"\n",
            CHECK_FLAG(babel_ifp->flags, BABEL_IF_WIRED) ? "wired" : "wireless");
@@ -1228,6 +1239,7 @@ interface_config_write (struct vty *vty)
         if (ifp->desc)
             vty_out (vty, " description %s\n",ifp->desc);
         babel_interface_nfo *babel_ifp = babel_get_if_nfo (ifp);
+	assert (babel_ifp != NULL);
         /* wireless is the default*/
         if (CHECK_FLAG (babel_ifp->flags, BABEL_IF_WIRED))
         {
@@ -1330,6 +1342,7 @@ babel_interface_allocate (void)
 {
     babel_interface_nfo *babel_ifp;
     babel_ifp = XCALLOC(MTYPE_BABEL_IF, sizeof(babel_interface_nfo));
+    assert (babel_ifp != NULL);
     /* All flags are unset */
     babel_ifp->bucket_time = babel_now.tv_sec;
     babel_ifp->bucket = BUCKET_TOKENS_MAX;
@@ -1349,6 +1362,8 @@ babel_interface_allocate (void)
 static void
 babel_interface_free (babel_interface_nfo *babel_ifp)
 {
+    assert (babel_ifp != NULL);
+
     if (babel_ifp->ipv4){
         free(babel_ifp->ipv4);
         babel_ifp->ipv4 = NULL;


### PR DESCRIPTION
babel: Added null check after retrieving babel_ifp
Asserting the further instructions when the babel interface pointer is NULL