### PR TITLE
mgmtd: add notification selection to front-end API 

### DIFF
--- a/lib/darr.h
+++ b/lib/darr.h
@@ -24,6 +24,8 @@
  *  - darr_ensure_i
  *  - darr_ensure_i_mt
  *  - darr_free
+ *  - darr_free_free
+ *  - darr_free_func
  *  - darr_insert
  *  - darr_insert_mt
  *  - darr_insertz
@@ -215,6 +217,41 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
 			XFREE(__meta->mtype, __meta);                          \
 			(A) = NULL;                                            \
 		}                                                              \
+	} while (0)
+
+/**
+ * Free memory allocated for the dynamic array `A`, calling `darr_free` for
+ * each element of the array first.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ */
+#define darr_free_free(A)                                                      \
+	do {                                                                   \
+		for (uint __i = 0; __i < darr_len(A); __i++)                   \
+			if ((A)[__i]) {                                        \
+				struct darr_metadata *__meta =                 \
+					_darr_meta((A)[__i]);                  \
+				XFREE(__meta->mtype, __meta);                  \
+			}                                                      \
+		darr_free(A);                                                  \
+	} while (0)
+
+/**
+ * Free memory allocated for the dynamic array `A`, calling `F` routine
+ * for each element of the array first.
+ *
+ * Args:
+ *	A: The dynamic array, can be NULL.
+ *	F: The function to call for each element.
+ */
+
+#define darr_free_func(A, F)                                                   \
+	do {                                                                   \
+		for (uint __i = 0; __i < darr_len(A); __i++) {                 \
+			F((A)[__i]);                                           \
+		}                                                              \
+		darr_free(A);                                                  \
 	} while (0)
 
 /**

--- a/lib/mgmt_msg_native.c
+++ b/lib/mgmt_msg_native.c
@@ -19,6 +19,33 @@ DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_EDIT, "native edit msg");
 DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_EDIT_REPLY, "native edit reply msg");
 DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_RPC, "native RPC msg");
 DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_RPC_REPLY, "native RPC reply msg");
+DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_SESSION_REQ, "native session-req msg");
+DEFINE_MTYPE(MSG_NATIVE, MSG_NATIVE_SESSION_REPLY, "native session-reply msg");
+
+
+size_t mgmt_msg_min_sizes[] = {
+	[MGMT_MSG_CODE_ERROR] = sizeof(struct mgmt_msg_error),
+	[MGMT_MSG_CODE_GET_TREE] = sizeof(struct mgmt_msg_get_tree),
+	[MGMT_MSG_CODE_TREE_DATA] = sizeof(struct mgmt_msg_tree_data),
+	[MGMT_MSG_CODE_GET_DATA] = sizeof(struct mgmt_msg_get_data),
+	[MGMT_MSG_CODE_NOTIFY] = sizeof(struct mgmt_msg_notify_data),
+	[MGMT_MSG_CODE_EDIT] = sizeof(struct mgmt_msg_edit),
+	[MGMT_MSG_CODE_EDIT_REPLY] = sizeof(struct mgmt_msg_edit_reply),
+	[MGMT_MSG_CODE_RPC] = sizeof(struct mgmt_msg_rpc),
+	[MGMT_MSG_CODE_RPC_REPLY] = sizeof(struct mgmt_msg_rpc_reply),
+	[MGMT_MSG_CODE_NOTIFY_SELECT] = sizeof(struct mgmt_msg_notify_select),
+	[MGMT_MSG_CODE_SESSION_REQ] = sizeof(struct mgmt_msg_session_req),
+	[MGMT_MSG_CODE_SESSION_REPLY] = sizeof(struct mgmt_msg_session_reply),
+};
+size_t nmgmt_msg_min_sizes = sizeof(mgmt_msg_min_sizes) /
+			     sizeof(*mgmt_msg_min_sizes);
+
+size_t mgmt_msg_get_min_size(uint code)
+{
+	if (code >= nmgmt_msg_min_sizes)
+		return 0;
+	return mgmt_msg_min_sizes[code];
+}
 
 int vmgmt_msg_native_send_error(struct msg_conn *conn, uint64_t sess_or_txn_id,
 				uint64_t req_id, bool short_circuit_ok,

--- a/lib/mgmt_msg_native.c
+++ b/lib/mgmt_msg_native.c
@@ -6,6 +6,7 @@
  *
  */
 #include <zebra.h>
+#include "darr.h"
 #include "mgmt_msg_native.h"
 
 DEFINE_MGROUP(MSG_NATIVE, "Native message allocations");
@@ -49,4 +50,21 @@ int vmgmt_msg_native_send_error(struct msg_conn *conn, uint64_t sess_or_txn_id,
 	ret = mgmt_msg_native_send_msg(conn, msg, short_circuit_ok);
 	mgmt_msg_native_free_msg(msg);
 	return ret;
+}
+
+const char **_mgmt_msg_native_strings_decode(const void *_sdata, int sdlen)
+{
+	const char *sdata = _sdata;
+	const char **strings = NULL;
+	int len;
+
+	if (sdata[sdlen - 1] != 0)
+		return NULL;
+
+	for (; sdlen; sdata += len, sdlen -= len) {
+		*darr_append(strings) = darr_strdup(sdata);
+		len = 1 + darr_strlen(strings[darr_lasti(strings)]);
+	}
+
+	return strings;
 }

--- a/lib/mgmt_msg_native.h
+++ b/lib/mgmt_msg_native.h
@@ -525,6 +525,25 @@ extern int vmgmt_msg_native_send_error(struct msg_conn *conn,
 	})
 
 /**
+ * mgmt_msg_native_add_str() - Append [another] string to the msg.
+ * @msg: (IN/OUT) Pointer to the native message, variable may be updated.
+ * @s: string to append.
+ *
+ * Append string @s to the native message @msg. @msg is assumed to have a
+ * sequence of NUL-terminated strings at the end of it. This function appends
+ * the string @s and it's NUL terminating octet to the message.
+ *
+ * NOTE: Be aware @msg pointer may change as a result of reallocating the
+ * message to fit the new data. Any other pointers into the old message should
+ * be discarded.
+ */
+#define mgmt_msg_native_add_str(msg, s)                                        \
+	do {                                                                   \
+		int __len = strlen(s) + 1;                                     \
+		mgmt_msg_native_append(msg, s, __len);                         \
+	} while (0)
+
+/**
  * mgmt_msg_native_send_msg(msg, short_circuit_ok) - Send a native msg.
  * @conn: the mgmt_msg connection.
  * @msg: the native message.
@@ -688,6 +707,27 @@ extern int vmgmt_msg_native_send_error(struct msg_conn *conn,
  */
 #define mgmt_msg_native_data_len_decode(msg, msglen)                           \
 	((msglen) - sizeof(*msg) - msg->vsplit)
+
+/**
+ * mgmt_msg_native_strings_decode() - Get dynamic array of str ptrs from the msg.
+ * @msg: Pointer to the native message.
+ * @msglen: Length of the message.
+ * @sdata: pointer to the variable length string data at end of @msg.
+ *
+ * Given a pointer to a sequence of NUL-terminated strings allocate
+ * and return a dynamic array of dynamic array strings. This function
+ * can be used to decode a message that was built using
+ * mgmt_msg_native_add_str().
+ *
+ * Return: a dynamic array (darr) of string pointers, or NULL if the message
+ * is corrupt.
+ */
+#define mgmt_msg_native_strings_decode(msg, msg_len, sdata)                    \
+	_mgmt_msg_native_strings_decode(sdata,                                 \
+					(msg_len) - ((sdata) - (char *)(msg)))
+
+extern const char **_mgmt_msg_native_strings_decode(const void *sdata,
+						    int sdlen);
 
 #ifdef __cplusplus
 }

--- a/lib/mgmt_msg_native.h
+++ b/lib/mgmt_msg_native.h
@@ -176,6 +176,7 @@ DECLARE_MTYPE(MSG_NATIVE_RPC_REPLY);
 #define MGMT_MSG_CODE_EDIT_REPLY 6 /* Public API */
 #define MGMT_MSG_CODE_RPC	 7 /* Public API */
 #define MGMT_MSG_CODE_RPC_REPLY	 8 /* Public API */
+#define MGMT_MSG_CODE_NOTIFY_SELECT 9 /* Public API */
 
 /*
  * Datastores
@@ -424,6 +425,27 @@ struct mgmt_msg_rpc_reply {
 
 _Static_assert(sizeof(struct mgmt_msg_rpc_reply) ==
 		       offsetof(struct mgmt_msg_rpc_reply, data),
+	       "Size mismatch");
+
+/**
+ * struct mgmt_msg_notify_select - Add notification selectors for FE client.
+ *
+ * Add xpath prefix notification selectors to limit the notifications sent
+ * to the front-end client.
+ *
+ * @selectors: the xpath prefixes to selectors notifications through.
+ * @repalce: if true replace existing selectors with `selectors`.
+ */
+struct mgmt_msg_notify_select {
+	struct mgmt_msg_header;
+	uint8_t replace;
+	uint8_t resv2[7];
+
+	alignas(8) char selectors[];
+};
+
+_Static_assert(sizeof(struct mgmt_msg_notify_select) ==
+		       offsetof(struct mgmt_msg_notify_select, selectors),
 	       "Size mismatch");
 
 /*

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -897,7 +897,7 @@ char *yang_convert_lyd_format(const char *data, size_t data_len,
 
 	assert(out_format != LYD_LYB);
 
-	if (in_format != LYD_LYB && !MGMT_MSG_VALIDATE_NUL_TERM(data, data_len)) {
+	if (in_format != LYD_LYB && (!data_len || data[data_len - 1] != 0)) {
 		zlog_err("Corrupt input data, no NUL terminating byte");
 		return NULL;
 	}

--- a/tests/lib/test_darr.c
+++ b/tests/lib/test_darr.c
@@ -20,6 +20,8 @@
  * [x] - darr_foreach_i
  * [x] - darr_foreach_p
  * [x] - darr_free
+ * [x] - darr_free_free
+ * [x] - darr_free_func
  * [x] - darr_insert
  * [ ] - darr_insertz
  * [x] - darr_insert_n
@@ -318,6 +320,8 @@ static void test_string(void)
 	uint addlen = strlen(add);
 	char *da1 = NULL;
 	char *da2 = NULL;
+	const char **strings = NULL;
+	uint sum = 0;
 
 	assert(darr_strlen(da1) == 0);
 
@@ -412,6 +416,29 @@ static void test_string(void)
 	da1 = darr_in_strcatf(da1, "0123456789: %08x", 0xDEADBEEF);
 	assert(!strcmp("0123456789: deadbeef", da1));
 	darr_free(da1);
+
+	sum = 0;
+	*darr_append(strings) = "1";
+	*darr_append(strings) = "2";
+	*darr_append(strings) = "3";
+#define adder(x) (sum += atoi(x))
+	darr_free_func(strings, adder);
+	assert(sum == 6);
+	assert(strings == NULL);
+
+	sum = 0;
+	darr_free_func(strings, adder);
+	assert(sum == 0);
+	assert(strings == NULL);
+
+	*darr_append(strings) = NULL;
+	*darr_append(strings) = darr_strdup("2");
+	*darr_append(strings) = darr_strdup("3");
+	darr_free_free(strings);
+	assert(strings == NULL);
+
+	darr_free_free(strings);
+	assert(strings == NULL);
 }
 
 int main(int argc, char **argv)

--- a/tests/topotests/mgmt_notif/test_notif.py
+++ b/tests/topotests/mgmt_notif/test_notif.py
@@ -69,7 +69,7 @@ def test_frontend_notification(tgen):
     result = json_cmp(jsout, expected)
     assert result is None
 
-    output = r1.cmd_raises(fe_client_path + " --listen")
+    output = r1.cmd_raises(fe_client_path + " --use-protobuf --listen")
     jsout = json.loads(output)
 
     expected = {"frr-ripd:authentication-failure": {"interface-name": "r1-eth0"}}

--- a/tests/topotests/mgmt_notif/test_notif.py
+++ b/tests/topotests/mgmt_notif/test_notif.py
@@ -51,7 +51,7 @@ def test_frontend_notification(tgen):
 
     check_kernel_32(r1, "11.11.11.11", 1, "")
 
-    fe_client_path = CWD + "/../lib/fe_client.py"
+    fe_client_path = CWD + "/../lib/fe_client.py --verbose"
     rc, _, _ = r1.cmd_status(fe_client_path + " --help")
 
     if rc:
@@ -61,7 +61,7 @@ def test_frontend_notification(tgen):
     # So we filter to avoid that, all the rest are frr-ripd:authentication-failure
     # making our test deterministic
     output = r1.cmd_raises(
-        fe_client_path + " --listen  frr-ripd:authentication-failure"
+        fe_client_path + " --listen /frr-ripd:authentication-failure"
     )
     jsout = json.loads(output)
 


### PR DESCRIPTION
- Add new notification select message for front-end clients
- Add new native session-req and session-reply replacements for front-end protobuf messages
- Extend fe_client to support new native notify select and session-req messages
- Add topotest
- Add string array encoding/decode to native messages