### PR TITLE
yang: fix wrong check for isis metric style

### DIFF
--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -685,7 +685,7 @@ module frr-isisd {
         type uint32 {
           range "0..16777215";
         }
-        must ". < 64 or /frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style = 'wide' or not(/frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style)";
+        must ". < 64 or not(/frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style) or /frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style != 'narrow'";
         default "10";
         description
           "Default level-1 metric for this IS-IS circuit.";
@@ -695,7 +695,7 @@ module frr-isisd {
         type uint32 {
           range "0..16777215";
         }
-        must ". < 64 or /frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style = 'wide' or not(/frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style)";
+        must ". < 64 or not(/frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style) or /frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style != 'narrow'";
         default "10";
         description
           "Default level-2 metric for this IS-IS circuit.";


### PR DESCRIPTION
Before:
```
anlan(config)# route isis ix
anlan(config-router)# metric-style transition
...
anlan(config-if)# isis metric 200
% Configuration failed.

Error type: validation
Error description: YANG error(s):
 Path: Data location "/frr-interface:lib/interface[name='x']/frr-isisd:isis/metric/level-1".
 Error: Must condition ". < 64 or /frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style = 'wide' or not(/frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style)" not satisfied.
 Path: Data location "/frr-interface:lib/interface[name='x']/frr-isisd:isis/metric/level-2".
 Error: Must condition ". < 64 or /frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style = 'wide' or not(/frr-isisd:isis/instance[area-tag = current()/../../area-tag]/metric-style)" not satisfied
```

After:
```
anlan(config)# route isis ix
anlan(config-router)# metric-style transition
...
anlan(config-if)# isis metric 200
anlan(config-if)#
```