### PR TITLE
doc: Add reloading script into Python dependency section

### DIFF
--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -422,7 +422,12 @@ options to the configuration script.
 Python dependency, documentation and tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-FRR's documentation and basic unit tests heavily use code written in Python.
+FRR uses Python for these components:
+
+* configuration reloading (see :ref:`FRR-RELOAD <frr-reload>` for details),
+* documentation,
+* unit tests.
+
 Additionally, FRR ships Python extensions written in C which are used during
 its build process.
 


### PR DESCRIPTION
The [documentation](https://docs.frrouting.org/en/stable-8.0/installation.html#python-dependency-documentation-and-tests) says that Python is used only for docs, tests, and building process. But at the same time, [FRR uses the Python script](https://docs.frrouting.org/en/stable-8.0/frr-reload.html) for the "[frr reload](https://docs.frrouting.org/en/latest/setup.html#reloading)" operation.

Therefore, I propose to add this point to the documentation.

Related discussion: https://github.com/FRRouting/frr/discussions/16073