### PR TITLE
lib: fix copy srte_color from zapi_nexthop structure

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2174,6 +2174,7 @@ int zapi_nexthop_from_nexthop(struct zapi_nexthop *znh,
 	znh->weight = nh->weight;
 	znh->ifindex = nh->ifindex;
 	znh->gate = nh->gate;
+	znh->srte_color = nh->srte_color;
 
 	if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_ONLINK))
 		SET_FLAG(znh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);


### PR DESCRIPTION
When switching from nexthop to zapi_nexthop, the srte color is copied. Do the same in reverse.

Fixes: 31f937fb43f4 ("lib, zebra: Add SR-TE policy infrastructure to zebra")