### PR TITLE
Only set nh link-local if it exists #16198

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2487,6 +2487,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 		     && IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local))
 		    || (!reflect && !transparent
 			&& IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_local)
+			&& IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local)
 			&& peer->shared_network
 			&& (from == bgp->peer_self
 			    || peer->sort == BGP_PEER_EBGP))) {


### PR DESCRIPTION
Issue #16198

The current code assumes that the peer originating the prefix on the same subnet is including it's link-local as a next-hop (and probably should according to the [RFC](https://datatracker.ietf.org/doc/html/rfc2545#section-3) ).  However, if it does not include the link-local in addition [e.g.](https://github.com/Exa-Networks/exabgp/issues/694) to the global IPv6, FRR will erroneously insert it's own link-local address when the advertising to other peers on the same network.

This PR adds an extra check to see if the link-local actually exists before setting `BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL`.