### PR TITLE
isisd: Three-Way Handshake State Change from Expiring

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -358,7 +358,7 @@ void isis_adj_state_change(struct isis_adjacency **padj,
 				 * purposes */
 				adj->last_flap = time(NULL);
 				adj->flaps++;
-			} else if (old_state == ISIS_ADJ_UP) {
+			} else if (old_state == ISIS_ADJ_UP || old_state == ISIS_ADJ_INITIALIZING) {
 				circuit->adj_state_changes++;
 
 				circuit->upadjcount[level - 1]--;

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -409,7 +409,7 @@ void isis_adj_state_change(struct isis_adjacency **padj,
 						master, send_l2_csnp, circuit,
 						0, &circuit->t_send_csnp[1]);
 				}
-			} else if (old_state == ISIS_ADJ_UP) {
+			} else if (old_state == ISIS_ADJ_UP || old_state == ISIS_ADJ_INITIALIZING) {
 				circuit->upadjcount[level - 1]--;
 				if (circuit->upadjcount[level - 1] == 0)
 					isis_tx_queue_clean(circuit->tx_queue);

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -358,7 +358,8 @@ void isis_adj_state_change(struct isis_adjacency **padj,
 				 * purposes */
 				adj->last_flap = time(NULL);
 				adj->flaps++;
-			} else if (old_state == ISIS_ADJ_UP || old_state == ISIS_ADJ_INITIALIZING) {
+			} else if (old_state == ISIS_ADJ_UP ||
+				   old_state == ISIS_ADJ_INITIALIZING) {
 				circuit->adj_state_changes++;
 
 				circuit->upadjcount[level - 1]--;
@@ -409,7 +410,8 @@ void isis_adj_state_change(struct isis_adjacency **padj,
 						master, send_l2_csnp, circuit,
 						0, &circuit->t_send_csnp[1]);
 				}
-			} else if (old_state == ISIS_ADJ_UP || old_state == ISIS_ADJ_INITIALIZING) {
+			} else if (old_state == ISIS_ADJ_UP ||
+				   old_state == ISIS_ADJ_INITIALIZING) {
 				circuit->upadjcount[level - 1]--;
 				if (circuit->upadjcount[level - 1] == 0)
 					isis_tx_queue_clean(circuit->tx_queue);


### PR DESCRIPTION
Under certain conditions the ISIS three-way handshake becomes stuck in an 'Expiring' mode and does not clear the neighbor entry. This fix will clear the neighbor entry if this condition becomes true.