### PR TITLE
bgpd: Don't try to add link-local when NEXTHOP_LOCAL_UNCHANGED

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2482,7 +2482,11 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 	 */
 	if (NEXTHOP_IS_V6) {
 		attr->mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL;
-		if ((CHECK_FLAG(peer->af_flags[afi][safi],
+		if (CHECK_FLAG(peer->af_flags[afi][safi],
+				PEER_FLAG_NEXTHOP_LOCAL_UNCHANGED)
+		     && !IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local)) {
+			zlog_debug("No link-local next-hop. Ignoring other checks");
+		} else if ((CHECK_FLAG(peer->af_flags[afi][safi],
 				PEER_FLAG_NEXTHOP_LOCAL_UNCHANGED)
 		     && IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local))
 		    || (!reflect && !transparent


### PR DESCRIPTION
We currently insert a our own link-local address as a next-hop when the peer shares the same network segment even though the prefix was received _without_ a link-local next-hop from another peer on the same network segment.  Whilst this behaviour seems incorrect, even when we explicitly set `PEER_FLAG_NEXTHOP_LOCAL_UNCHANGED` and there is no link-local next-hop in the prefix, we still try to set one.

This PR adds an additional check combined with `PEER_FLAG_NEXTHOP_LOCAL_UNCHANGED` so that we do not set `attr->mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL` when `!IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local)` (e.g. the next-hop is not present)

Fixes: #16198 