### PR TITLE
[WIP] Only keep nh local when present #16198

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2492,8 +2492,11 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 		    || (!reflect && !transparent
 			&& IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_local)
 			&& peer->shared_network
-			&& (from == bgp->peer_self
-			    || peer->sort == BGP_PEER_EBGP))) {
+			&& ((from == bgp->peer_self
+				&& peer->sort == BGP_PEER_EBGP)
+				|| (from != bgp->peer_self
+					&& IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local)
+					&& peer->sort == BGP_PEER_EBGP)))) {
 			if (safi == SAFI_MPLS_VPN)
 				attr->mp_nexthop_len =
 					BGP_ATTR_NHLEN_VPNV6_GLOBAL_AND_LL;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2482,7 +2482,11 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 	 */
 	if (NEXTHOP_IS_V6) {
 		attr->mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL;
-		if ((CHECK_FLAG(peer->af_flags[afi][safi],
+		if (CHECK_FLAG(peer->af_flags[afi][safi],
+				PEER_FLAG_NEXTHOP_LOCAL_UNCHANGED)
+		     && !IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local)) {
+			zlog_debug("No link-local next-hop. Ignoring other checks");
+		} else if ((CHECK_FLAG(peer->af_flags[afi][safi],
 				PEER_FLAG_NEXTHOP_LOCAL_UNCHANGED)
 		     && IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local))
 		    || (!reflect && !transparent

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2482,21 +2482,19 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 	 */
 	if (NEXTHOP_IS_V6) {
 		attr->mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL;
-		if (CHECK_FLAG(peer->af_flags[afi][safi],
-				PEER_FLAG_NEXTHOP_LOCAL_UNCHANGED)
-		     && !IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local)) {
-			zlog_debug("No link-local next-hop. Ignoring other checks");
-		} else if ((CHECK_FLAG(peer->af_flags[afi][safi],
+		if ((CHECK_FLAG(peer->af_flags[afi][safi],
 				PEER_FLAG_NEXTHOP_LOCAL_UNCHANGED)
 		     && IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local))
 		    || (!reflect && !transparent
 			&& IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_local)
 			&& peer->shared_network
-			&& ((from == bgp->peer_self
-				&& peer->sort == BGP_PEER_EBGP)
-				|| (from != bgp->peer_self
-					&& IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local)
-					&& peer->sort == BGP_PEER_EBGP)))) {
+                        && ((from == bgp->peer_self
+                            && peer->sort == BGP_PEER_EBGP)
+                            || (from == bgp->peer_self
+                                && peer->sort != BGP_PEER_EBGP)
+                            || (from != bgp->peer_self
+                                && IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local)
+                                && peer->sort == BGP_PEER_EBGP)))) {
 			if (safi == SAFI_MPLS_VPN)
 				attr->mp_nexthop_len =
 					BGP_ATTR_NHLEN_VPNV6_GLOBAL_AND_LL;


### PR DESCRIPTION
This is another potential fix for #16198

* First we modify the original `(from == bgp->peer_self || peer->sort == BGP_PEER_EBGP)` to an `&&` operator.
* Then we create a second case for a remote_peer and check `IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local)` (e.g. link-local nh is actually included by remote peer.

In [rfc2545 section 3](https://datatracker.ietf.org/doc/html/rfc2545#section-3) we have:

> The link-local address shall be included in the Next Hop field if and
> only if the BGP speaker shares a common subnet with the entity
> identified by the global IPv6 address carried in the Network Address
> of Next Hop field and the peer the route is being advertised to.
> In all other cases a BGP speaker shall advertise to its peer in the
> Network Address field only the global IPv6 address of the next hop
> (the value of the Length of Network Address of Next Hop field shall
> be set to 16).

The code in FRR assumes that a remote prefix from a device on the same segment as an eBGP peer already has it's link-local next-hop field set and sets `attr->mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL`.  If this field is empty our own link-local will be added later in the update formation code HOWEVER the global next-hop is left unchanged.

This proposal expands the truth of (A OR B) to "(A AND B) OR (!A AND B) OR (A AND !B)" such that we can isolate (!A AND B) and add an extra test to ensure that original next-hop actually contains a link-local.

Fixes: https://github.com/FRRouting/frr/issues/16198

