### PR TITLE
tests: Avoid importing unused modules

### DIFF
--- a/tests/topotests/eigrp_topo1/test_eigrp_topo1.py
+++ b/tests/topotests/eigrp_topo1/test_eigrp_topo1.py
@@ -143,7 +143,6 @@ def test_zebra_ipv4_routingTable():
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
 
-    failures = 0
     router_list = tgen.routers().values()
     for router in router_list:
         output = router.vtysh_cmd("show ip route json", isjson=True)

--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
@@ -22,7 +22,6 @@ Following tests are covered to test EVPN-Type5 functionality:
 
 import os
 import sys
-import json
 import time
 import pytest
 import platform
@@ -69,7 +68,7 @@ from lib.bgp import (
     verify_attributes_for_evpn_routes,
     verify_evpn_routes,
 )
-from lib.topojson import build_topo_from_json, build_config_from_json
+from lib.topojson import build_config_from_json
 
 pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
 

--- a/tests/topotests/fpm_testing_topo1/test_fpm_topo1.py
+++ b/tests/topotests/fpm_testing_topo1/test_fpm_topo1.py
@@ -14,7 +14,6 @@ test_fpm_topo1.py: Testing FPM module
 
 """
 import os
-import re
 import sys
 import pytest
 import json
@@ -28,7 +27,6 @@ sys.path.append(os.path.join(CWD, "../"))
 # Import topogen and topotest helpers
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
-from lib.topolog import logger
 
 
 pytestmark = [pytest.mark.fpm, pytest.mark.sharpd]

--- a/tests/topotests/grpc_basic/test_basic_grpc.py
+++ b/tests/topotests/grpc_basic/test_basic_grpc.py
@@ -19,7 +19,6 @@ import pytest
 from lib.common_config import step
 from lib.micronet import commander
 from lib.topogen import Topogen, TopoRouter
-from lib.topolog import logger
 from lib.topotest import json_cmp
 
 CWD = os.path.dirname(os.path.realpath(__file__))
@@ -60,7 +59,7 @@ def tgen(request):
     tgen.start_topology()
     router_list = tgen.routers()
 
-    for rname, router in router_list.items():
+    for _, router in router_list.items():
         router.load_config(TopoRouter.RD_ZEBRA, "zebra.conf", f"-M grpc:{GRPCP_ZEBRA}")
         router.load_config(TopoRouter.RD_STATIC, "", f"-M grpc:{GRPCP_STATICD}")
         # router.load_config(TopoRouter.RD_BFDD, "", f"-M grpc:{GRPCP_BFDD}")

--- a/tests/topotests/isis_advertise_high_metrics/test_isis_advertise_high_metrics.py
+++ b/tests/topotests/isis_advertise_high_metrics/test_isis_advertise_high_metrics.py
@@ -30,8 +30,6 @@ import re
 import sys
 import pytest
 import json
-from time import sleep
-from functools import partial
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
@@ -39,7 +37,6 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # pylint: disable=C0413
 # Import topogen and topotest helpers
-from lib import topotest
 from lib.common_config import (
     retry,
     stop_router,

--- a/tests/topotests/isis_lfa_topo1/test_isis_lfa_topo1.py
+++ b/tests/topotests/isis_lfa_topo1/test_isis_lfa_topo1.py
@@ -42,7 +42,6 @@ import os
 import sys
 import pytest
 import json
-import time
 import tempfile
 from functools import partial
 
@@ -169,7 +168,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 
@@ -832,7 +831,7 @@ def test_rib_ipv6_step18():
     rname = "rt1"
     router = tgen.gears[rname]
     test_func = partial(_rt2_neigh_down, router)
-    success, result = topotest.run_and_expect(test_func, None, count=200, wait=0.05)
+    _, result = topotest.run_and_expect(test_func, None, count=200, wait=0.05)
     assert result is None, 'rt2 neighbor is still present on "{}"'.format(router)
 
     router_compare_json_output(
@@ -1034,7 +1033,7 @@ def test_rib_ipv6_step24():
     rname = "rt1"
     router = tgen.gears[rname]
     test_func = partial(_bfd_down, router)
-    success, result = topotest.run_and_expect(test_func, None, count=30, wait=0.3)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.3)
     assert result is None, 'BFD session is still up on "{}"'.format(router)
 
     router_compare_json_output(

--- a/tests/topotests/isis_lsp_bits_topo1/test_isis_lsp_bits_topo1.py
+++ b/tests/topotests/isis_lsp_bits_topo1/test_isis_lsp_bits_topo1.py
@@ -131,7 +131,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/isis_rlfa_topo1/test_isis_rlfa_topo1.py
+++ b/tests/topotests/isis_rlfa_topo1/test_isis_rlfa_topo1.py
@@ -170,7 +170,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/isis_snmp/test_isis_snmp.py
+++ b/tests/topotests/isis_snmp/test_isis_snmp.py
@@ -147,7 +147,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/isis_sr_flex_algo_topo1/test_isis_sr_flex_algo_topo1.py
+++ b/tests/topotests/isis_sr_flex_algo_topo1/test_isis_sr_flex_algo_topo1.py
@@ -37,7 +37,6 @@ import os
 import sys
 import pytest
 import json
-import tempfile
 from copy import deepcopy
 from functools import partial
 
@@ -121,7 +120,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     tgen.stop_topology()

--- a/tests/topotests/isis_sr_flex_algo_topo2/test_isis_sr_flex_algo_topo2.py
+++ b/tests/topotests/isis_sr_flex_algo_topo2/test_isis_sr_flex_algo_topo2.py
@@ -47,7 +47,6 @@ import os
 import sys
 import pytest
 import json
-import time
 from functools import partial
 
 # Save the Current Working Directory to find configuration files.
@@ -67,7 +66,6 @@ pytestmark = [pytest.mark.isisd]
 def build_topo(tgen):
     "Build function"
 
-    routers = []
     for i in range(0, 10):
         rt = tgen.add_router("rt{}".format(i))
         rt.run("sysctl -w net.ipv4.fib_multipath_hash_policy=1")
@@ -140,7 +138,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     tgen.stop_topology()
@@ -174,7 +172,7 @@ def check_rib(name, cmd, expected_file):
     logger.info('[+] check {} "{}" {}'.format(name, cmd, expected_file))
     tgen = get_topogen()
     func = partial(_check, name, cmd, expected_file)
-    success, result = topotest.run_and_expect(func, None, count=120, wait=0.5)
+    _, result = topotest.run_and_expect(func, None, count=120, wait=0.5)
     assert result is None, "Failed"
 
 

--- a/tests/topotests/isis_sr_te_topo1/test_isis_sr_te_topo1.py
+++ b/tests/topotests/isis_sr_te_topo1/test_isis_sr_te_topo1.py
@@ -164,7 +164,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 
@@ -641,7 +641,7 @@ def test_srte_route_map_with_sr_policy_check_nextop_step5():
     )
 
     # (re-)build the SR Policy two times to ensure that reinstalling still works
-    for i in [1, 2]:
+    for _ in [1, 2]:
         cmp_json_output(
             "rt1", "show ip route bgp json", "step5/show_ip_route_bgp_inactive_srte.ref"
         )

--- a/tests/topotests/isis_sr_topo1/test_isis_sr_topo1.py
+++ b/tests/topotests/isis_sr_topo1/test_isis_sr_topo1.py
@@ -137,7 +137,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
+++ b/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
@@ -60,7 +60,6 @@ test_isis_srv6_topo1.py:
 """
 
 import os
-import re
 import sys
 import json
 import functools
@@ -212,7 +211,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
 
     # Teardown the topology
@@ -250,7 +249,7 @@ def check_ping6(name, dest_addr, expect_connected):
     logger.info("[+] check {} {} {}".format(name, dest_addr, match))
     tgen = get_topogen()
     func = functools.partial(_check, name, dest_addr, match)
-    success, result = topotest.run_and_expect(func, None, count=10, wait=1)
+    _, result = topotest.run_and_expect(func, None, count=10, wait=1)
     assert result is None, "Failed"
 
 

--- a/tests/topotests/isis_tilfa_topo1/test_isis_tilfa_topo1.py
+++ b/tests/topotests/isis_tilfa_topo1/test_isis_tilfa_topo1.py
@@ -54,7 +54,6 @@ import os
 import sys
 import pytest
 import json
-import tempfile
 from functools import partial
 from time import sleep
 
@@ -144,7 +143,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/isis_topo1/test_isis_topo1.py
+++ b/tests/topotests/isis_topo1/test_isis_topo1.py
@@ -104,7 +104,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 
@@ -160,7 +160,7 @@ def test_isis_route_installation():
             return topotest.json_cmp(actual, expected)
 
         test_func = functools.partial(compare_isis_installed_routes, router, expected)
-        (result, diff) = topotest.run_and_expect(test_func, None, wait=1, count=10)
+        (result, _) = topotest.run_and_expect(test_func, None, wait=1, count=10)
         assertmsg = "Router '{}' routes mismatch".format(rname)
         assert result, assertmsg
 
@@ -205,7 +205,7 @@ def test_isis_route6_installation():
         test_func = functools.partial(
             compare_isis_v6_installed_routes, router, expected
         )
-        (result, diff) = topotest.run_and_expect(test_func, None, wait=1, count=10)
+        (result, _) = topotest.run_and_expect(test_func, None, wait=1, count=10)
         assertmsg = "Router '{}' routes mismatch".format(rname)
         assert result, assertmsg
 
@@ -237,7 +237,7 @@ def test_isis_summary_json():
         pytest.skip(tgen.errors)
 
     logger.info("Checking 'show isis summary json'")
-    for rname, router in tgen.routers().items():
+    for rname, _ in tgen.routers().items():
         logger.info("Checking router %s", rname)
         json_output = tgen.gears[rname].vtysh_cmd("show isis summary json", isjson=True)
         assertmsg = "Test isis summary json failed in '{}' data '{}'".format(
@@ -257,7 +257,7 @@ def test_isis_interface_json():
         pytest.skip(tgen.errors)
 
     logger.info("Checking 'show isis interface json'")
-    for rname, router in tgen.routers().items():
+    for rname, _ in tgen.routers().items():
         logger.info("Checking router %s", rname)
         json_output = tgen.gears[rname].vtysh_cmd(
             "show isis interface json", isjson=True
@@ -294,7 +294,7 @@ def test_isis_neighbor_json():
 
     # tgen.mininet_cli()
     logger.info("Checking 'show isis neighbor json'")
-    for rname, router in tgen.routers().items():
+    for rname, _ in tgen.routers().items():
         logger.info("Checking router %s", rname)
         json_output = tgen.gears[rname].vtysh_cmd(
             "show isis neighbor json", isjson=True
@@ -330,7 +330,7 @@ def test_isis_database_json():
 
     # tgen.mininet_cli()
     logger.info("Checking 'show isis database json'")
-    for rname, router in tgen.routers().items():
+    for rname, _ in tgen.routers().items():
         logger.info("Checking router %s", rname)
         json_output = tgen.gears[rname].vtysh_cmd(
             "show isis database json", isjson=True
@@ -755,7 +755,7 @@ def dict_merge(dct, merge_dct):
     Source:
     https://gist.github.com/angstwad/bf22d1822c38a92ec0a9
     """
-    for k, v in merge_dct.items():
+    for k, _ in merge_dct.items():
         if k in dct and isinstance(dct[k], dict) and topotest.is_mapping(merge_dct[k]):
             dict_merge(dct[k], merge_dct[k])
         else:

--- a/tests/topotests/isis_topo1_vrf/test_isis_topo1_vrf.py
+++ b/tests/topotests/isis_topo1_vrf/test_isis_topo1_vrf.py
@@ -118,7 +118,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     # move back rx-eth0 to default VRF
@@ -287,7 +287,7 @@ def dict_merge(dct, merge_dct):
     Source:
     https://gist.github.com/angstwad/bf22d1822c38a92ec0a9
     """
-    for k, v in merge_dct.items():
+    for k, _ in merge_dct.items():
         if k in dct and isinstance(dct[k], dict) and topotest.is_mapping(merge_dct[k]):
             dict_merge(dct[k], merge_dct[k])
         else:

--- a/tests/topotests/key_sendaccept/test_keychain.py
+++ b/tests/topotests/key_sendaccept/test_keychain.py
@@ -27,7 +27,7 @@ def tgen(request):
     tgen.start_topology()
 
     router_list = tgen.routers()
-    for rname, router in router_list.items():
+    for _, router in router_list.items():
         router.load_frr_config("frr.conf")
 
     tgen.start_router()

--- a/tests/topotests/ldp_oc_acl_topo1/test_ldp_oc_acl_topo1.py
+++ b/tests/topotests/ldp_oc_acl_topo1/test_ldp_oc_acl_topo1.py
@@ -117,7 +117,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/ldp_oc_topo1/test_ldp_oc_topo1.py
+++ b/tests/topotests/ldp_oc_topo1/test_ldp_oc_topo1.py
@@ -116,7 +116,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/ldp_snmp/test_ldp_snmp_topo1.py
+++ b/tests/topotests/ldp_snmp/test_ldp_snmp_topo1.py
@@ -136,7 +136,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/ldp_sync_isis_topo1/test_ldp_sync_isis_topo1.py
+++ b/tests/topotests/ldp_sync_isis_topo1/test_ldp_sync_isis_topo1.py
@@ -129,7 +129,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/ldp_sync_ospf_topo1/test_ldp_sync_ospf_topo1.py
+++ b/tests/topotests/ldp_sync_ospf_topo1/test_ldp_sync_ospf_topo1.py
@@ -128,7 +128,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/ldp_vpls_topo1/test_ldp_vpls_topo1.py
+++ b/tests/topotests/ldp_vpls_topo1/test_ldp_vpls_topo1.py
@@ -129,7 +129,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -333,7 +333,7 @@ def __create_bgp_global(tgen, input_dict, router, build=False):
             else:
                 del_action = False
 
-            for rs_timer, value in timer.items():
+            for rs_timer, _ in timer.items():
                 rs_timer_value = timer.setdefault(rs_timer, None)
 
                 if rs_timer_value and rs_timer != "delete":
@@ -1229,7 +1229,7 @@ def modify_bgp_config_when_bgpd_down(tgen, topo, input_dict):
         # Copy bgp config file to /etc/frr
         for dut in input_dict.keys():
             router_list = tgen.routers()
-            for router, rnode in router_list.items():
+            for router, _ in router_list.items():
                 if router != dut:
                     continue
 
@@ -1750,7 +1750,7 @@ def verify_as_numbers(tgen, topo, input_dict, expected=True):
 
             for bgp_neighbor, peer_data in bgp_neighbors.items():
                 remote_as = input_dict[bgp_neighbor]["bgp"]["local_as"]
-                for dest_link, peer_dict in peer_data["dest_link"].items():
+                for dest_link, _ in peer_data["dest_link"].items():
                     neighbor_ip = None
                     data = topo["routers"][bgp_neighbor]["links"]
 
@@ -1833,7 +1833,7 @@ def verify_bgp_convergence_from_running_config(tgen, dut=None, expected=True):
             return errormsg
 
         for vrf, addr_family_data in show_bgp_json.items():
-            for address_family, neighborship_data in addr_family_data.items():
+            for _, neighborship_data in addr_family_data.items():
                 total_peer = 0
                 no_of_peer = 0
 
@@ -1980,7 +1980,7 @@ def clear_bgp_and_verify(tgen, topo, router, rid=None):
             bgp_neighbors = bgp_addr_type[addr_type]["unicast"]["neighbor"]
 
             for bgp_neighbor, peer_data in bgp_neighbors.items():
-                for dest_link, peer_dict in peer_data["dest_link"].items():
+                for dest_link, _ in peer_data["dest_link"].items():
                     data = topo["routers"][bgp_neighbor]["links"]
 
                     if dest_link in data:
@@ -3231,7 +3231,7 @@ def verify_graceful_restart(
                 if bgp_neighbor != peer:
                     continue
 
-                for dest_link, peer_dict in peer_data["dest_link"].items():
+                for dest_link, _ in peer_data["dest_link"].items():
                     data = topo["routers"][bgp_neighbor]["links"]
 
                     if dest_link in data:
@@ -3479,7 +3479,7 @@ def verify_r_bit(tgen, topo, addr_type, input_dict, dut, peer, expected=True):
                 if bgp_neighbor != peer:
                     continue
 
-                for dest_link, peer_dict in peer_data["dest_link"].items():
+                for dest_link, _ in peer_data["dest_link"].items():
                     data = topo["routers"][bgp_neighbor]["links"]
 
                     if dest_link in data:
@@ -3597,7 +3597,7 @@ def verify_eor(tgen, topo, addr_type, input_dict, dut, peer, expected=True):
                 if bgp_neighbor != peer:
                     continue
 
-                for dest_link, peer_dict in peer_data["dest_link"].items():
+                for dest_link, _ in peer_data["dest_link"].items():
                     data = topo["routers"][bgp_neighbor]["links"]
 
                     if dest_link in data:
@@ -3762,7 +3762,7 @@ def verify_f_bit(tgen, topo, addr_type, input_dict, dut, peer, expected=True):
                 if bgp_neighbor != peer:
                     continue
 
-                for dest_link, peer_dict in peer_data["dest_link"].items():
+                for dest_link, _ in peer_data["dest_link"].items():
                     data = topo["routers"][bgp_neighbor]["links"]
 
                     if dest_link in data:
@@ -3890,7 +3890,7 @@ def verify_graceful_restart_timers(tgen, topo, addr_type, input_dict, dut, peer)
                 if bgp_neighbor != peer:
                     continue
 
-                for dest_link, peer_dict in peer_data["dest_link"].items():
+                for dest_link, _ in peer_data["dest_link"].items():
                     data = topo["routers"][bgp_neighbor]["links"]
 
                     if dest_link in data:

--- a/tests/topotests/lib/checkping.py
+++ b/tests/topotests/lib/checkping.py
@@ -33,5 +33,5 @@ def check_ping(name, dest_addr, expect_connected, count, wait, source_addr=None)
     logger.info("[+] check {} {} {}".format(name, dest_addr, match))
     tgen = get_topogen()
     func = functools.partial(_check, name, dest_addr, source_addr, match)
-    success, result = topotest.run_and_expect(func, None, count=count, wait=wait)
+    _, result = topotest.run_and_expect(func, None, count=count, wait=wait)
     assert result is None, "Failed"

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -7,7 +7,6 @@
 
 import functools
 import ipaddress
-import json
 import os
 import platform
 import socket
@@ -442,7 +441,7 @@ def check_router_status(tgen):
 
     try:
         router_list = tgen.routers()
-        for router, rnode in router_list.items():
+        for _, rnode in router_list.items():
             result = rnode.check_router_running()
             if result != "":
                 daemons = []
@@ -686,7 +685,7 @@ def prep_load_config_to_routers(tgen, *config_name_list):
     """
 
     routers = tgen.routers()
-    for rname, router in routers.items():
+    for rname, _ in routers.items():
         destname = "{}/{}/{}".format(tgen.logdir, rname, FRRCFG_FILE)
         wmode = "w"
         for cfbase in config_name_list:
@@ -871,7 +870,7 @@ def get_frr_ipv6_linklocal(tgen, router, intf=None, vrf=None):
     """
 
     router_list = tgen.routers()
-    for rname, rnode in router_list.items():
+    for rname, _ in router_list.items():
         if rname != router:
             continue
 
@@ -887,7 +886,7 @@ def get_frr_ipv6_linklocal(tgen, router, intf=None, vrf=None):
             cmd = "show interface vrf {}".format(vrf)
         else:
             cmd = "show interface"
-        for chk_ll in range(0, 60):
+        for _ in range(0, 60):
             sleep(1 / 4)
             ifaces = router_list[router].run('vtysh -c "{}"'.format(cmd))
             # Fix newlines (make them all the same)
@@ -3095,7 +3094,7 @@ def configure_brctl(tgen, topo, input_dict):
                             "{} dev {} master {}".format(ip_cmd, brctl_name, vrf)
                         )
 
-                        for intf_name, data in topo["routers"][dut]["links"].items():
+                        for _, data in topo["routers"][dut]["links"].items():
                             if "vrf" not in data:
                                 continue
 
@@ -4942,7 +4941,7 @@ def scapy_send_raw_packet(tgen, topo, senderRouter, intf, packet=None):
     sender_interface = intf
     rnode = tgen.routers()[senderRouter]
 
-    for destLink, data in topo["routers"][senderRouter]["links"].items():
+    for _, data in topo["routers"][senderRouter]["links"].items():
         if "type" in data and data["type"] == "loopback":
             continue
 

--- a/tests/topotests/lib/fe_client.py
+++ b/tests/topotests/lib/fe_client.py
@@ -9,7 +9,6 @@
 # noqa: E501
 #
 import argparse
-import json
 import logging
 import os
 import socket
@@ -216,7 +215,7 @@ class Session:
             self.sess_id = reply.session_reply.session_id
         else:
             self.sess_id = 0
-            mdata, req_id = self.get_native_msg_header(MSG_CODE_SESSION_REQ)
+            mdata, _ = self.get_native_msg_header(MSG_CODE_SESSION_REQ)
             mdata += struct.pack(MSG_SESSION_REQ_FMT)
             mdata += "test-client".encode("utf-8") + b"\x00"
 
@@ -324,7 +323,7 @@ class Session:
 
     def get_data(self, query, data=True, config=False):
         # Create the message
-        mdata, req_id = self.get_native_msg_header(MSG_CODE_GET_DATA)
+        mdata, _ = self.get_native_msg_header(MSG_CODE_GET_DATA)
         flags = GET_DATA_FLAG_STATE if data else 0
         flags |= GET_DATA_FLAG_CONFIG if config else 0
         mdata += struct.pack(MSG_GET_DATA_FMT, MSG_FORMAT_JSON, flags)
@@ -333,7 +332,7 @@ class Session:
         self.send_native_msg(mdata)
         logging.debug("Sent GET-TREE")
 
-        mhdr, mfixed, mdata = self.recv_native_msg()
+        _, mfixed, mdata = self.recv_native_msg()
         assert mdata[-1] == 0
         result = mdata[:-1].decode("utf-8")
 
@@ -342,7 +341,7 @@ class Session:
 
     def add_notify_select(self, replace, notif_xpaths):
         # Create the message
-        mdata, req_id = self.get_native_msg_header(MSG_CODE_NOTIFY_SELECT)
+        mdata, _ = self.get_native_msg_header(MSG_CODE_NOTIFY_SELECT)
         mdata += struct.pack(MSG_NOTIFY_SELECT_FMT, replace)
 
         for xpath in notif_xpaths:
@@ -355,7 +354,7 @@ class Session:
         if xpaths:
             self.add_notify_select(True, xpaths)
 
-        for remaining in Timeout(60):
+        for _ in Timeout(60):
             logging.debug("Waiting for Notify Message")
             mhdr, mfixed, mdata = self.recv_native_msg()
             if mhdr[HDR_FIELD_CODE] == MSG_CODE_NOTIFY:

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -1545,7 +1545,7 @@ def verify_ospf_database(
                             )
                             return errormsg
     if ospf_external_lsa:
-        for ospf_ext_lsa, ext_lsa_data in ospf_external_lsa.items():
+        for ospf_ext_lsa, _ in ospf_external_lsa.items():
             if ospf_ext_lsa in show_ospf_json["AS External Link States"]:
                 logger.info(
                     "[DUT: %s]  OSPF LSDB:External LSA %s", router, ospf_ext_lsa
@@ -2509,7 +2509,7 @@ def verify_ospf_gr_helper(tgen, topo, dut, input_dict=None):
         raise ValueError(errormsg)
         return errormsg
 
-    for ospf_gr, gr_data in input_dict.items():
+    for ospf_gr, _ in input_dict.items():
         try:
             if input_dict[ospf_gr] == show_ospf_json[ospf_gr]:
                 logger.info(

--- a/tests/topotests/lib/pim.py
+++ b/tests/topotests/lib/pim.py
@@ -149,7 +149,7 @@ def _add_pim_rp_config(tgen, topo, input_dict, router, build, config_data_dict):
         # At least one interface must be enabled for PIM on the router
         pim_if_enabled = False
         pim6_if_enabled = False
-        for destLink, data in topo[dut]["links"].items():
+        for _, data in topo[dut]["links"].items():
             if "pim" in data:
                 pim_if_enabled = True
             if "pim6" in data:
@@ -603,7 +603,7 @@ def find_rp_details(tgen, topo):
                 # ip address of RP
                 rp_addr = rp_dict["rp_addr"]
 
-                for link, data in topo["routers"][router]["links"].items():
+                for _, data in topo["routers"][router]["links"].items():
                     if data["ipv4"].split("/")[0] == rp_addr:
                         rp_details[router] = rp_addr
 
@@ -2089,7 +2089,7 @@ def verify_pim_interface(
                     )
                     return True
         else:
-            for destLink, data in topo["routers"][dut]["links"].items():
+            for _, data in topo["routers"][dut]["links"].items():
                 if "type" in data and data["type"] == "loopback":
                     continue
 
@@ -2292,7 +2292,7 @@ def clear_pim_interfaces(tgen, dut):
 
     # Waiting for maximum 60 sec
     fail_intf = []
-    for retry in range(1, 13):
+    for _ in range(1, 13):
         sleep(5)
         logger.info("[DUT: %s]: Waiting for 5 sec for PIM neighbors" " to come up", dut)
         run_json_after = run_frr_cmd(rnode, "show ip pim neighbor json", isjson=True)
@@ -2368,7 +2368,7 @@ def clear_igmp_interfaces(tgen, dut):
 
     total_groups_before_clear = igmp_json["totalGroups"]
 
-    for key, value in igmp_json.items():
+    for _, value in igmp_json.items():
         if type(value) is not dict:
             continue
 
@@ -2381,7 +2381,7 @@ def clear_igmp_interfaces(tgen, dut):
     result = run_frr_cmd(rnode, "clear ip igmp interfaces")
 
     # Waiting for maximum 60 sec
-    for retry in range(1, 13):
+    for _ in range(1, 13):
         logger.info(
             "[DUT: %s]: Waiting for 5 sec for igmp interfaces" " to come up", dut
         )
@@ -2460,7 +2460,7 @@ def clear_mroute_verify(tgen, dut, expected=True):
 
     # RFC 3376: 8.2. Query Interval - Default: 125 seconds
     # So waiting for maximum 130 sec to get the igmp report
-    for retry in range(1, 26):
+    for _ in range(1, 26):
         logger.info("[DUT: %s]: Waiting for 2 sec for mroutes" " to come up", dut)
         sleep(5)
         keys_json1 = mroute_json_1.keys()
@@ -2671,7 +2671,7 @@ def add_rp_interfaces_and_pim_config(tgen, topo, interface, rp, rp_mapping):
     try:
         config_data = []
 
-        for group, rp_list in rp_mapping.items():
+        for _, rp_list in rp_mapping.items():
             for _rp in rp_list:
                 config_data.append("interface {}".format(interface))
                 config_data.append("ip address {}".format(_rp))
@@ -2720,7 +2720,7 @@ def scapy_send_bsr_raw_packet(tgen, topo, senderRouter, receiverRouter, packet=N
     script_path = os.path.join(CWD, "send_bsr_packet.py")
     node = tgen.net[senderRouter]
 
-    for destLink, data in topo["routers"][senderRouter]["links"].items():
+    for _, data in topo["routers"][senderRouter]["links"].items():
         if "type" in data and data["type"] == "loopback":
             continue
 
@@ -2795,12 +2795,12 @@ def find_rp_from_bsrp_info(tgen, dut, bsr, grp=None):
 
         # RP with lowest priority
         if len(priority_dict) != 1:
-            rp_p, lowest_priority = sorted(rp_priority.items(), key=lambda x: x[1])[0]
+            rp_p, _ = sorted(rp_priority.items(), key=lambda x: x[1])[0]
             rp_details[group] = rp_p
 
         # RP with highest hash value
         if len(priority_dict) == 1:
-            rp_h, highest_hash = sorted(rp_hash.items(), key=lambda x: x[1])[-1]
+            rp_h, _ = sorted(rp_hash.items(), key=lambda x: x[1])[-1]
             rp_details[group] = rp_h
 
         # RP with highest IP address
@@ -3239,7 +3239,7 @@ def verify_pim_join(
         interface_json = show_pim_join_json[interface]
 
         grp_addr = grp_addr.split("/")[0]
-        for source, data in interface_json[grp_addr].items():
+        for _, data in interface_json[grp_addr].items():
             # Verify pim join
             if pim_join:
                 if data["group"] == grp_addr and data["channelJoinName"] == "JOIN":

--- a/tests/topotests/mgmt_debug_flags/test_debug.py
+++ b/tests/topotests/mgmt_debug_flags/test_debug.py
@@ -27,7 +27,7 @@ def tgen(request):
     tgen = Topogen(topodef, request.module.__name__)
     tgen.start_topology()
 
-    for rname, router in tgen.routers().items():
+    for _, router in tgen.routers().items():
         router.load_frr_config("frr.conf")
 
     tgen.start_router()

--- a/tests/topotests/mgmt_notif/test_notif.py
+++ b/tests/topotests/mgmt_notif/test_notif.py
@@ -10,7 +10,6 @@
 Test YANG Notifications
 """
 import json
-import logging
 import os
 
 import pytest
@@ -35,7 +34,7 @@ def tgen(request):
     tgen.start_topology()
 
     router_list = tgen.routers()
-    for rname, router in router_list.items():
+    for _, router in router_list.items():
         router.load_frr_config("frr.conf")
 
     tgen.start_router()

--- a/tests/topotests/mgmt_oper/oper.py
+++ b/tests/topotests/mgmt_oper/oper.py
@@ -146,7 +146,7 @@ def check_kernel(r1, super_prefix, count, add, is_blackhole, vrf, matchvia):
 
     # logger.debug("checking kernel routing table%s:\n%s", vrfstr, kernel)
 
-    for i, net in enumerate(get_ip_networks(super_prefix, count)):
+    for _, net in enumerate(get_ip_networks(super_prefix, count)):
         if not add:
             assert str(net) not in kernel
             continue
@@ -233,7 +233,7 @@ def do_config(
         if vrf:
             f.write("vrf {}\n".format(vrf))
 
-        for i, net in enumerate(get_ip_networks(super_prefix, count)):
+        for _, net in enumerate(get_ip_networks(super_prefix, count)):
             if add:
                 f.write("ip route {} {}\n".format(net, via))
             else:

--- a/tests/topotests/mgmt_oper/test_oper.py
+++ b/tests/topotests/mgmt_oper/test_oper.py
@@ -12,16 +12,10 @@ Test static route functionality
 
 import ipaddress
 import math
-import time
 
 import pytest
 from lib.topogen import Topogen
 from oper import check_kernel_32, do_oper_test
-
-try:
-    from deepdiff import DeepDiff as dd_json_cmp
-except ImportError:
-    dd_json_cmp = None
 
 pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
 

--- a/tests/topotests/mgmt_rpc/test_rpc.py
+++ b/tests/topotests/mgmt_rpc/test_rpc.py
@@ -32,7 +32,7 @@ def tgen(request):
     tgen.start_topology()
 
     router_list = tgen.routers()
-    for rname, router in router_list.items():
+    for _, router in router_list.items():
         router.load_frr_config("frr.conf")
 
     tgen.start_router()

--- a/tests/topotests/mgmt_tests/test_yang_mgmt.py
+++ b/tests/topotests/mgmt_tests/test_yang_mgmt.py
@@ -66,7 +66,6 @@ from lib.common_config import (
     start_router_daemons,
 )
 from lib.topolog import logger
-from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
 from lib.topojson import build_config_from_json
 
 pytestmark = [pytest.mark.bgpd, pytest.mark.staticd, pytest.mark.mgmtd]

--- a/tests/topotests/msdp_topo1/test_msdp_topo1.py
+++ b/tests/topotests/msdp_topo1/test_msdp_topo1.py
@@ -101,7 +101,7 @@ def setup_module(mod):
     app_helper.init(tgen)
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     app_helper.cleanup()

--- a/tests/topotests/multicast_pim6_sm_topo1/test_multicast_pim6_sm1.py
+++ b/tests/topotests/multicast_pim6_sm_topo1/test_multicast_pim6_sm1.py
@@ -221,7 +221,7 @@ def verify_state_incremented(state_before, state_after):
     """
 
     for router, state_data in state_before.items():
-        for state, value in state_data.items():
+        for state, _ in state_data.items():
             if state_before[router][state] >= state_after[router][state]:
                 errormsg = (
                     "[DUT: %s]: state %s value has not"

--- a/tests/topotests/multicast_pim6_sm_topo1/test_multicast_pim6_sm2.py
+++ b/tests/topotests/multicast_pim6_sm_topo1/test_multicast_pim6_sm2.py
@@ -175,7 +175,7 @@ def verify_state_incremented(state_before, state_after):
     """
 
     for router, state_data in state_before.items():
-        for state, value in state_data.items():
+        for state, _ in state_data.items():
             if state_before[router][state] >= state_after[router][state]:
                 errormsg = (
                     "[DUT: %s]: state %s value has not"

--- a/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_ospf_topo2.py
+++ b/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_ospf_topo2.py
@@ -20,10 +20,7 @@ Following tests are covered:
 
 import os
 import sys
-import json
 import time
-import datetime
-from time import sleep
 import pytest
 
 # Save the Current Working Directory to find configuration files.
@@ -43,14 +40,9 @@ from lib.common_config import (
     write_test_footer,
     step,
     reset_config_on_routers,
-    shutdown_bringup_interface,
     apply_raw_config,
     add_interfaces_to_vlan,
-    kill_router_daemons,
-    start_router_daemons,
-    create_static_routes,
     check_router_status,
-    topo_daemons,
     required_linux_kernel_version,
 )
 from lib.pim import (
@@ -59,9 +51,6 @@ from lib.pim import (
     verify_mroutes,
     clear_mroute,
     clear_pim_interface_traffic,
-    verify_pim_config,
-    verify_upstream_iif,
-    verify_multicast_traffic,
     verify_multicast_flag_state,
     verify_igmp_groups,
     McastTesterHelper,

--- a/tests/topotests/multicast_pim_sm_topo1/test_multicast_pim_sm_topo1.py
+++ b/tests/topotests/multicast_pim_sm_topo1/test_multicast_pim_sm_topo1.py
@@ -64,7 +64,6 @@ from lib.common_config import (
     reset_config_on_routers,
     shutdown_bringup_interface,
     required_linux_kernel_version,
-    topo_daemons,
 )
 from lib.pim import (
     create_pim_config,
@@ -214,7 +213,7 @@ def verify_state_incremented(state_before, state_after):
     """
 
     for router, state_data in state_before.items():
-        for state, value in state_data.items():
+        for state, _ in state_data.items():
             if state_before[router][state] >= state_after[router][state]:
                 errormsg = (
                     "[DUT: %s]: state %s value has not"

--- a/tests/topotests/multicast_pim_sm_topo2/test_multicast_pim_sm_topo2.py
+++ b/tests/topotests/multicast_pim_sm_topo2/test_multicast_pim_sm_topo2.py
@@ -62,7 +62,6 @@ from lib.common_config import (
     start_router_daemons,
     stop_router,
     required_linux_kernel_version,
-    topo_daemons,
 )
 from lib.pim import (
     create_pim_config,
@@ -211,7 +210,7 @@ def verify_state_incremented(state_before, state_after):
     """
 
     for router, state_data in state_before.items():
-        for state, value in state_data.items():
+        for state, _ in state_data.items():
             if state_before[router][state] >= state_after[router][state]:
                 errormsg = (
                     "[DUT: %s]: state %s value has not"

--- a/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
+++ b/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
@@ -57,7 +57,7 @@ sys.path.append(os.path.join(CWD, "../lib/"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topogen import Topogen, get_topogen
 from lib.common_config import (
     start_topology,
     write_test_header,
@@ -68,7 +68,6 @@ from lib.common_config import (
     apply_raw_config,
     check_router_status,
     required_linux_kernel_version,
-    topo_daemons,
 )
 from lib.pim import (
     create_pim_config,
@@ -354,7 +353,7 @@ def verify_pim_stats_increament(stats_before, stats_after):
     """
 
     for router, stats_data in stats_before.items():
-        for stats, value in stats_data.items():
+        for stats, _ in stats_data.items():
             if stats_before[router][stats] >= stats_after[router][stats]:
                 errormsg = (
                     "[DUT: %s]: state %s value has not"

--- a/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo4.py
+++ b/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo4.py
@@ -55,7 +55,6 @@ from lib.common_config import (
     apply_raw_config,
     create_static_routes,
     required_linux_kernel_version,
-    topo_daemons,
 )
 from lib.pim import (
     create_pim_config,
@@ -191,7 +190,7 @@ def reset_stats(stats):
     """
 
     for router, state_data in stats.items():
-        for state, value in state_data.items():
+        for state, _ in state_data.items():
             stats[router][state] = 0
             logger.info(
                 "[DUT: %s]: stats %s value has reset" " reset, Current value: %s",
@@ -214,7 +213,7 @@ def verify_state_incremented(state_before, state_after):
     """
 
     for router, state_data in state_before.items():
-        for state, value in state_data.items():
+        for state, _ in state_data.items():
             if state_before[router][state] >= state_after[router][state]:
                 errormsg = (
                     "[DUT: %s]: state %s value has not"

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp.py
@@ -87,7 +87,6 @@ TC_32 : Verify RP info and (*,G) mroute after deleting the RP and shut / no
 import os
 import sys
 import time
-from time import sleep
 import datetime
 import pytest
 
@@ -112,10 +111,7 @@ from lib.common_config import (
     reset_config_on_routers,
     step,
     shutdown_bringup_interface,
-    kill_router_daemons,
-    start_router_daemons,
     create_static_routes,
-    topo_daemons,
 )
 from lib.pim import (
     create_pim_config,
@@ -128,10 +124,7 @@ from lib.pim import (
     verify_pim_rp_info,
     verify_pim_state,
     clear_pim_interface_traffic,
-    clear_igmp_interfaces,
-    clear_pim_interfaces,
     clear_mroute,
-    clear_mroute_verify,
     McastTesterHelper,
 )
 

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp1.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp1.py
@@ -112,9 +112,6 @@ from lib.common_config import (
     reset_config_on_routers,
     step,
     shutdown_bringup_interface,
-    kill_router_daemons,
-    start_router_daemons,
-    create_static_routes,
 )
 from lib.pim import (
     create_pim_config,
@@ -123,9 +120,7 @@ from lib.pim import (
     verify_join_state_and_timer,
     verify_mroutes,
     verify_pim_neighbors,
-    get_pim_interface_traffic,
     verify_pim_rp_info,
-    verify_pim_state,
     clear_pim_interface_traffic,
     clear_igmp_interfaces,
     clear_pim_interfaces,

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp2.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp2.py
@@ -123,14 +123,9 @@ from lib.pim import (
     verify_join_state_and_timer,
     verify_mroutes,
     verify_pim_neighbors,
-    get_pim_interface_traffic,
     verify_pim_rp_info,
-    verify_pim_state,
     clear_pim_interface_traffic,
-    clear_igmp_interfaces,
-    clear_pim_interfaces,
     clear_mroute,
-    clear_mroute_verify,
     McastTesterHelper,
 )
 

--- a/tests/topotests/multicast_pim_uplink_topo1/test_multicast_pim_uplink_topo1.py
+++ b/tests/topotests/multicast_pim_uplink_topo1/test_multicast_pim_uplink_topo1.py
@@ -25,7 +25,6 @@ Following tests are covered to test multicast pim uplink:
 
 import os
 import sys
-import json
 import time
 import pytest
 
@@ -356,7 +355,7 @@ def verify_state_incremented(state_before, state_after):
     """
 
     for router, state_data in state_before.items():
-        for state, value in state_data.items():
+        for state, _ in state_data.items():
             if state_before[router][state] > state_after[router][state]:
                 errormsg = (
                     "[DUT: %s]: state %s value has not"
@@ -1682,7 +1681,7 @@ def test_mroutes_updated_correctly_after_source_interface_shut_noshut_p1(request
 
     step("Shut and No shut source interface multiple time")
 
-    for i in range(0, 2):
+    for _ in range(0, 2):
         step("Shut and no shut the source interface from DUT")
         intf_r1_i2 = topo["routers"]["r1"]["links"]["i2"]["interface"]
         shutdown_bringup_interface(tgen, "r1", intf_r1_i2, False)

--- a/tests/topotests/multicast_pim_uplink_topo2/test_multicast_pim_uplink_topo2.py
+++ b/tests/topotests/multicast_pim_uplink_topo2/test_multicast_pim_uplink_topo2.py
@@ -213,7 +213,7 @@ def verify_state_incremented(state_before, state_after):
     """
 
     for router, state_data in state_before.items():
-        for state, value in state_data.items():
+        for state, _ in state_data.items():
             if state_before[router][state] > state_after[router][state]:
                 errormsg = (
                     "[DUT: %s]: state %s value has not"

--- a/tests/topotests/nb_config/test_nb_config.py
+++ b/tests/topotests/nb_config/test_nb_config.py
@@ -30,7 +30,7 @@ def tgen(request):
     tgen.start_topology()
 
     router_list = tgen.routers()
-    for rname, router in router_list.items():
+    for _, router in router_list.items():
         router.load_frr_config("frr.conf")
 
     tgen.start_router()

--- a/tests/topotests/nhrp_redundancy/test_nhrp_redundancy.py
+++ b/tests/topotests/nhrp_redundancy/test_nhrp_redundancy.py
@@ -10,7 +10,6 @@
 import os
 import sys
 import json
-from time import sleep
 from functools import partial
 import pytest
 
@@ -207,7 +206,7 @@ def test_protocols_convergence():
     router_list = tgen.routers()
 
     # Check NHRP cache on servers and clients
-    for rname, router in router_list.items():
+    for _, router in router_list.items():
 
         json_file = "{}/{}/nhrp_cache.json".format(CWD, router.name)
         if not os.path.isfile(json_file):

--- a/tests/topotests/ospf6_gr_topo1/test_ospf6_gr_topo1.py
+++ b/tests/topotests/ospf6_gr_topo1/test_ospf6_gr_topo1.py
@@ -135,7 +135,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/ospf6_loopback_cost/test_ospf6_loopback_cost.py
+++ b/tests/topotests/ospf6_loopback_cost/test_ospf6_loopback_cost.py
@@ -30,7 +30,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # pylint: disable=C0413
 from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topogen import Topogen, get_topogen
 
 
 def setup_module(mod):
@@ -46,7 +46,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     tgen = get_topogen()
     tgen.stop_topology()
 

--- a/tests/topotests/ospf6_point_to_multipoint/test_ospf6_point_to_multipoint.py
+++ b/tests/topotests/ospf6_point_to_multipoint/test_ospf6_point_to_multipoint.py
@@ -153,7 +153,7 @@ def setup_module(mod):
     # tgen.mininet_cli()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     tgen.stop_topology()
@@ -229,7 +229,7 @@ def test_ospfv3_routingTable():
     # tgen.mininet_cli()
 
     # Verify OSPFv3 Routing Table
-    for router, rnode in tgen.routers().items():
+    for router, _ in tgen.routers().items():
         logger.info('Waiting for router "%s" convergence', router)
 
         # Load expected results from the command

--- a/tests/topotests/ospf6_topo1/test_ospf6_topo1.py
+++ b/tests/topotests/ospf6_topo1/test_ospf6_topo1.py
@@ -153,7 +153,7 @@ def setup_module(mod):
     # tgen.mininet_cli()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     tgen.stop_topology()
@@ -229,7 +229,7 @@ def test_ospfv3_routingTable():
     # tgen.mininet_cli()
 
     # Verify OSPFv3 Routing Table
-    for router, rnode in tgen.routers().items():
+    for router, _ in tgen.routers().items():
         logger.info('Waiting for router "%s" convergence', router)
 
         # Load expected results from the command
@@ -351,7 +351,7 @@ def test_ospfv3_routingTable_write_multiplier():
     r1.vtysh_cmd("clear ipv6 ospf interface r1-sw5")
 
     # Verify OSPFv3 Routing Table
-    for router, rnode in tgen.routers().items():
+    for router, _ in tgen.routers().items():
         logger.info('Waiting for router "%s" convergence', router)
 
         # Load expected results from the command

--- a/tests/topotests/ospf6_topo1_vrf/test_ospf6_topo1_vrf.py
+++ b/tests/topotests/ospf6_topo1_vrf/test_ospf6_topo1_vrf.py
@@ -186,7 +186,7 @@ def setup_module(mod):
     # tgen.mininet_cli()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     tgen.stop_topology()
@@ -260,7 +260,7 @@ def test_ospfv3_routingTable():
     # For debugging, uncomment the next line
     # tgen.mininet_cli()
     # Verify OSPFv3 Routing Table
-    for router, rnode in tgen.routers().items():
+    for router, _ in tgen.routers().items():
         logger.info('Waiting for router "%s" convergence', router)
 
         # Load expected results from the command
@@ -391,7 +391,7 @@ def test_ospfv3_routingTable_write_multiplier():
     r1.vtysh_cmd("clear ipv6 ospf interface r1-sw5")
 
     # Verify OSPFv3 Routing Table
-    for router, rnode in tgen.routers().items():
+    for router, _ in tgen.routers().items():
         logger.info('Waiting for router "%s" convergence', router)
 
         # Load expected results from the command

--- a/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_topo1.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_topo1.py
@@ -147,7 +147,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 
@@ -2893,7 +2893,7 @@ def test_ospf_type5_summary_tc51_p2(request):
 
     step("Configure and re configure all the commands 10 times in a loop.")
 
-    for itrate in range(0, 10):
+    for _ in range(0, 10):
         ospf_summ_r1 = {
             "r0": {
                 "ospf": {

--- a/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_type7_lsa.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_type7_lsa.py
@@ -139,7 +139,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/ospf_basic_functionality/test_ospf_authentication.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_authentication.py
@@ -109,7 +109,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/ospf_basic_functionality/test_ospf_chaos.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_chaos.py
@@ -118,7 +118,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
@@ -121,7 +121,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 
@@ -193,7 +193,7 @@ def test_ospf_ecmp_tc16_p0(request):
 
     step("Verify that route in R2 in stalled with 8 next hops.")
     nh = []
-    for item in range(1, 7):
+    for _ in range(1, 7):
         nh.append(topo["routers"]["r0"]["links"]["r1-link1"]["ipv4"].split("/")[0])
 
     nh2 = topo["routers"]["r0"]["links"]["r1"]["ipv4"].split("/")[0]

--- a/tests/topotests/ospf_basic_functionality/test_ospf_flood_reduction.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_flood_reduction.py
@@ -51,7 +51,6 @@ from lib.common_config import (
     create_static_routes,
     step,
     topo_daemons,
-    shutdown_bringup_interface,
     check_router_status,
     start_topology,
     write_test_header,
@@ -65,8 +64,6 @@ from lib.common_config import (
     write_test_header,
     write_test_footer,
     reset_config_on_routers,
-    stop_router,
-    start_router,
     step,
     create_static_routes,
     kill_router_daemons,
@@ -163,7 +160,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
@@ -119,7 +119,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/ospf_basic_functionality/test_ospf_p2mp.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_p2mp.py
@@ -105,7 +105,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
@@ -134,7 +134,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
@@ -130,7 +130,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 
@@ -208,7 +208,7 @@ def test_ospf_redistribution_tc5_p0(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     dut = "r1"
-    for num in range(0, nretry):
+    for _ in range(0, nretry):
         result = verify_ospf_rib(tgen, dut, input_dict, next_hop=nh, expected=False)
         if result is not True:
             break
@@ -332,7 +332,7 @@ def test_ospf_redistribution_tc6_p0(request):
     assert result is True, "Testcase {} : Failed \n Error: {}".format(tc_name, result)
 
     dut = "r1"
-    for num in range(0, nretry):
+    for _ in range(0, nretry):
         result = verify_ospf_rib(tgen, dut, input_dict, next_hop=nh, expected=False)
         if result is not True:
             break

--- a/tests/topotests/ospf_basic_functionality/test_ospf_single_area.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_single_area.py
@@ -115,7 +115,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/ospf_dual_stack/test_ospf_dual_stack.py
+++ b/tests/topotests/ospf_dual_stack/test_ospf_dual_stack.py
@@ -72,7 +72,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper1.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper1.py
@@ -29,7 +29,6 @@ from lib.common_config import (
     write_test_footer,
     reset_config_on_routers,
     step,
-    create_interfaces_cfg,
     scapy_send_raw_packet,
 )
 
@@ -38,7 +37,6 @@ from lib.topojson import build_config_from_json
 
 from lib.ospf import (
     verify_ospf_neighbor,
-    clear_ospf,
     verify_ospf_gr_helper,
     create_router_ospf,
 )

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper3.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper3.py
@@ -29,7 +29,6 @@ from lib.common_config import (
     write_test_footer,
     reset_config_on_routers,
     step,
-    create_interfaces_cfg,
     scapy_send_raw_packet,
 )
 
@@ -38,7 +37,6 @@ from lib.topojson import build_config_from_json
 
 from lib.ospf import (
     verify_ospf_neighbor,
-    clear_ospf,
     verify_ospf_gr_helper,
     create_router_ospf,
 )

--- a/tests/topotests/ospf_gr_topo1/test_ospf_gr_topo1.py
+++ b/tests/topotests/ospf_gr_topo1/test_ospf_gr_topo1.py
@@ -144,7 +144,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/ospf_instance_redistribute/test_ospf_instance_redistribute.py
+++ b/tests/topotests/ospf_instance_redistribute/test_ospf_instance_redistribute.py
@@ -15,7 +15,6 @@ test_ospf_instance_redistribute
 """
 
 import os
-import re
 import sys
 import pytest
 import json

--- a/tests/topotests/ospf_metric_propagation/test_ospf_metric_propagation.py
+++ b/tests/topotests/ospf_metric_propagation/test_ospf_metric_propagation.py
@@ -11,14 +11,13 @@
 import os
 import sys
 import json
-from time import sleep
 from functools import partial
 import pytest
 
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topogen import Topogen, get_topogen
 from lib.topolog import logger
 
 
@@ -166,7 +165,7 @@ def setup_module(mod):
             tgen.set_error("unsupported version")
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     tgen.stop_topology()

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/test_ospf_multi_vrf_bgp_route_leak.py
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/test_ospf_multi_vrf_bgp_route_leak.py
@@ -16,7 +16,7 @@ import pytest
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topogen import Topogen, get_topogen
 from lib.topolog import logger
 
 
@@ -139,7 +139,7 @@ def setup_module(mod):
             tgen.set_error("unsupported version")
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     tgen.stop_topology()

--- a/tests/topotests/ospf_netns_vrf/test_ospf_netns_vrf.py
+++ b/tests/topotests/ospf_netns_vrf/test_ospf_netns_vrf.py
@@ -104,13 +104,13 @@ def setup_module(mod):
             tgen.set_error("unsupported version")
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 
     # Move interfaces out of vrf namespace and delete the namespace
     router_list = tgen.routers()
-    for rname, router in router_list.items():
+    for rname, _ in router_list.items():
         tgen.net[rname].reset_intf_netns(rname + "-eth0")
         tgen.net[rname].reset_intf_netns(rname + "-eth1")
         tgen.net[rname].delete_netns(rname + "-ospf-cust1")

--- a/tests/topotests/ospf_nssa_topo1/test_ospf_nssa_topo1.py
+++ b/tests/topotests/ospf_nssa_topo1/test_ospf_nssa_topo1.py
@@ -106,7 +106,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/ospf_p2mp/test_ospf_p2mp_broadcast.py
+++ b/tests/topotests/ospf_p2mp/test_ospf_p2mp_broadcast.py
@@ -9,21 +9,16 @@
 
 import os
 import sys
-import json
-from time import sleep
 from functools import partial
 import pytest
 
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topogen import Topogen, get_topogen
 from lib.topolog import logger
 
 from lib.common_config import (
-    run_frr_cmd,
-    shutdown_bringup_interface,
-    start_router_daemons,
     step,
 )
 
@@ -112,7 +107,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     tgen.stop_topology()

--- a/tests/topotests/ospf_p2mp/test_ospf_p2mp_non_broadcast.py
+++ b/tests/topotests/ospf_p2mp/test_ospf_p2mp_non_broadcast.py
@@ -10,7 +10,6 @@
 
 import os
 import sys
-import json
 from time import sleep
 from functools import partial
 import pytest
@@ -18,13 +17,10 @@ import pytest
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topogen import Topogen, get_topogen
 from lib.topolog import logger
 
 from lib.common_config import (
-    run_frr_cmd,
-    shutdown_bringup_interface,
-    start_router_daemons,
     step,
 )
 
@@ -116,7 +112,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     tgen.stop_topology()

--- a/tests/topotests/ospf_prefix_suppression/test_ospf_prefix_suppression.py
+++ b/tests/topotests/ospf_prefix_suppression/test_ospf_prefix_suppression.py
@@ -10,21 +10,16 @@
 
 import os
 import sys
-import json
-from time import sleep
 from functools import partial
 import pytest
 
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topogen import Topogen, get_topogen
 from lib.topolog import logger
 
 from lib.common_config import (
-    run_frr_cmd,
-    shutdown_bringup_interface,
-    start_router_daemons,
     step,
 )
 
@@ -125,7 +120,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     tgen.stop_topology()

--- a/tests/topotests/ospf_single_switch/test_ospf_single_switch.py
+++ b/tests/topotests/ospf_single_switch/test_ospf_single_switch.py
@@ -14,12 +14,11 @@ from functools import partial
 import pytest
 
 from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topogen import Topogen, get_topogen
 from lib.topolog import logger
 
 from lib.common_config import verify_rib
 from lib.ospf import verify_ospf_rib
-from _ast import Try
 
 pytestmark = pytest.mark.ospfd
 
@@ -86,7 +85,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Tear-down the test environment"
     tgen = get_topogen()
     tgen.stop_topology()

--- a/tests/topotests/ospf_sr_te_topo1/test_ospf_sr_te_topo1.py
+++ b/tests/topotests/ospf_sr_te_topo1/test_ospf_sr_te_topo1.py
@@ -164,7 +164,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/ospf_sr_topo1/test_ospf_sr_topo1.py
+++ b/tests/topotests/ospf_sr_topo1/test_ospf_sr_topo1.py
@@ -136,7 +136,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/ospf_suppress_fa/test_ospf_suppress_fa.py
+++ b/tests/topotests/ospf_suppress_fa/test_ospf_suppress_fa.py
@@ -24,7 +24,6 @@ import os
 import sys
 import json
 from functools import partial
-import re
 import pytest
 
 # Save the Current Working Directory to find configuration files.

--- a/tests/topotests/ospf_tilfa_topo1/test_ospf_tilfa_topo1.py
+++ b/tests/topotests/ospf_tilfa_topo1/test_ospf_tilfa_topo1.py
@@ -110,7 +110,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/ospf_topo1/test_ospf_topo1.py
+++ b/tests/topotests/ospf_topo1/test_ospf_topo1.py
@@ -93,7 +93,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     tgen.stop_topology()

--- a/tests/topotests/ospf_topo2/test_ospf_topo2.py
+++ b/tests/topotests/ospf_topo2/test_ospf_topo2.py
@@ -66,7 +66,7 @@ def tgen(request):
 
     router_list = tgen.routers()
 
-    for rname, router in router_list.items():
+    for _, router in router_list.items():
         router.load_frr_config("frr.conf")
 
     tgen.start_router()

--- a/tests/topotests/ospf_unnumbered/test_ospf_unnumbered.py
+++ b/tests/topotests/ospf_unnumbered/test_ospf_unnumbered.py
@@ -89,7 +89,7 @@ def setup_module(mod):
     # tgen.mininet_cli()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     tgen.stop_topology()

--- a/tests/topotests/ospf_unnumbered_point_to_multipoint/test_ospf_unnumbered_point_to_multipoint.py
+++ b/tests/topotests/ospf_unnumbered_point_to_multipoint/test_ospf_unnumbered_point_to_multipoint.py
@@ -92,7 +92,7 @@ def setup_module(mod):
     # tgen.mininet_cli()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     tgen.stop_topology()

--- a/tests/topotests/ospfapi/test_ospf_clientapi.py
+++ b/tests/topotests/ospfapi/test_ospf_clientapi.py
@@ -16,7 +16,6 @@ import signal
 import subprocess
 import sys
 import time
-from datetime import datetime, timedelta
 from functools import partial
 
 import pytest
@@ -35,8 +34,7 @@ from lib.topotest import interface_set_status, json_cmp
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
-from lib.topolog import logger
+from lib.topogen import Topogen, TopoRouter
 
 pytestmark = [pytest.mark.ospfd]
 

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_asbr_summary_topo1.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_asbr_summary_topo1.py
@@ -29,7 +29,6 @@ from time import sleep
 from lib.common_config import (
     start_topology,
     write_test_header,
-    kill_router_daemons,
     write_test_footer,
     reset_config_on_routers,
     stop_router,
@@ -37,7 +36,6 @@ from lib.common_config import (
     verify_rib,
     create_static_routes,
     step,
-    start_router_daemons,
     create_route_maps,
     shutdown_bringup_interface,
     create_prefix_lists,
@@ -163,7 +161,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 
@@ -2456,7 +2454,7 @@ def test_ospfv3_type5_summary_tc51_p2(request):
 
     step("Configure and re configure all the commands 10 times in a loop.")
 
-    for itrate in range(0, 10):
+    for _ in range(0, 10):
         ospf_summ_r1 = {
             "r0": {
                 "ospf6": {

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_authentication.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_authentication.py
@@ -14,9 +14,7 @@ import sys
 import time
 import pytest
 from time import sleep
-from copy import deepcopy
 import json
-from lib.topotest import frr_unicode
 
 pytestmark = pytest.mark.ospf6d
 
@@ -39,11 +37,8 @@ from lib.common_config import (
     shutdown_bringup_interface,
 )
 from lib.topolog import logger
-from lib.topojson import build_topo_from_json, build_config_from_json
-from lib.ospf import verify_ospf6_neighbor, config_ospf6_interface, clear_ospf
-from ipaddress import IPv4Address
-
-# Global variables
+from lib.topojson import build_config_from_json
+from lib.ospf import verify_ospf6_neighbor, config_ospf6_interface
 topo = None
 # Reading the data from JSON File for topology creation
 jsonFile = "{}/ospfv3_authentication.json".format(CWD)
@@ -118,7 +113,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
     * `mod`: module name

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp.py
@@ -122,7 +122,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 
@@ -285,7 +285,7 @@ def test_ospfv3_ecmp_tc16_p0(request):
 
     step("Verify that route in R2 in stalled with 8 next hops.")
     nh = []
-    for item in range(1, 7):
+    for _ in range(1, 7):
         nh.append(llip)
 
     llip = get_llip("r0", "r1")

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp_lan.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp_lan.py
@@ -13,11 +13,6 @@ import os
 import sys
 import time
 import pytest
-import json
-from copy import deepcopy
-from ipaddress import IPv4Address
-from lib.topotest import frr_unicode
-import ipaddress
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
@@ -37,9 +32,6 @@ from lib.common_config import (
     verify_rib,
     create_static_routes,
     step,
-    create_route_maps,
-    shutdown_bringup_interface,
-    create_interfaces_cfg,
     get_frr_ipv6_linklocal,
 )
 from lib.topolog import logger
@@ -47,16 +39,11 @@ from lib.topojson import build_config_from_json
 
 from lib.ospf import (
     verify_ospf6_neighbor,
-    config_ospf_interface,
     clear_ospf,
     verify_ospf6_rib,
     create_router_ospf,
-    verify_ospf6_interface,
-    verify_ospf6_database,
-    config_ospf6_interface,
 )
 
-from ipaddress import IPv6Address
 
 pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
 
@@ -137,7 +124,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa.py
@@ -78,7 +78,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa2.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa2.py
@@ -13,15 +13,10 @@ import os
 import sys
 import time
 import pytest
-from copy import deepcopy
 import ipaddress
 from lib.ospf import (
     verify_ospf6_neighbor,
-    config_ospf6_interface,
-    clear_ospf,
     verify_ospf6_rib,
-    verify_ospf6_interface,
-    verify_ospf6_database,
     create_router_ospf,
 )
 
@@ -29,12 +24,6 @@ from lib.ospf import (
 # Import topogen and topotest helpers
 from lib.topogen import Topogen, get_topogen
 
-from lib.bgp import (
-    verify_bgp_convergence,
-    create_router_bgp,
-    clear_bgp_and_verify,
-    verify_bgp_rib,
-)
 from lib.topolog import logger
 from lib.common_config import (
     start_topology,
@@ -44,12 +33,9 @@ from lib.common_config import (
     verify_rib,
     create_static_routes,
     step,
-    create_route_maps,
-    shutdown_bringup_interface,
     create_interfaces_cfg,
     check_router_status,
 )
-from ipaddress import IPv4Address
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
 

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_routemaps.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_routemaps.py
@@ -136,7 +136,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_rte_calc.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_rte_calc.py
@@ -45,7 +45,6 @@ from lib.ospf import (
     verify_ospf6_neighbor,
     clear_ospf,
     verify_ospf6_rib,
-    verify_ospf_database,
     create_router_ospf,
     config_ospf6_interface,
     verify_ospf6_interface,
@@ -127,7 +126,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_single_area.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_single_area.py
@@ -36,7 +36,6 @@ from lib.common_config import (
     step,
     create_interfaces_cfg,
     create_debug_log_config,
-    apply_raw_config,
 )
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
@@ -121,7 +120,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/pim_acl/test_pim_acl.py
+++ b/tests/topotests/pim_acl/test_pim_acl.py
@@ -169,7 +169,7 @@ def setup_module(module):
     tgen.start_router()
 
 
-def teardown_module(module):
+def teardown_module():
     tgen = get_topogen()
     tgen.stop_topology()
 

--- a/tests/topotests/pim_basic/test_pim.py
+++ b/tests/topotests/pim_basic/test_pim.py
@@ -88,7 +88,7 @@ def setup_module(mod):
     # tgen.mininet_cli()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/pim_igmp_vrf/test_pim_vrf.py
+++ b/tests/topotests/pim_igmp_vrf/test_pim_vrf.py
@@ -92,7 +92,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.topotest import iproute2_is_vrf_capable
-from lib.common_config import required_linux_kernel_version, retry
+from lib.common_config import required_linux_kernel_version
 from lib.pim import McastTesterHelper
 
 
@@ -205,7 +205,7 @@ def setup_module(module):
         )
 
 
-def teardown_module(module):
+def teardown_module():
     tgen = get_topogen()
     tgen.stop_topology()
 

--- a/tests/topotests/rip_allow_ecmp/test_rip_allow_ecmp.py
+++ b/tests/topotests/rip_allow_ecmp/test_rip_allow_ecmp.py
@@ -20,7 +20,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # pylint: disable=C0413
 from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topogen import Topogen, get_topogen
 from lib.common_config import step
 
 pytestmark = [pytest.mark.ripd]
@@ -39,7 +39,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     tgen = get_topogen()
     tgen.stop_topology()
 

--- a/tests/topotests/rip_bfd_topo1/test_rip_bfd_topo1.py
+++ b/tests/topotests/rip_bfd_topo1/test_rip_bfd_topo1.py
@@ -20,7 +20,6 @@ import pytest
 from functools import partial
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter
-from lib.topolog import logger
 
 pytestmark = [
     pytest.mark.bfdd,

--- a/tests/topotests/rip_passive_interface/test_rip_passive_interface.py
+++ b/tests/topotests/rip_passive_interface/test_rip_passive_interface.py
@@ -21,7 +21,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # pylint: disable=C0413
 from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topogen import Topogen, get_topogen
 from lib.common_config import step
 
 pytestmark = [pytest.mark.ripd]
@@ -40,7 +40,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     tgen = get_topogen()
     tgen.stop_topology()
 

--- a/tests/topotests/ripng_allow_ecmp/test_ripng_allow_ecmp.py
+++ b/tests/topotests/ripng_allow_ecmp/test_ripng_allow_ecmp.py
@@ -20,7 +20,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # pylint: disable=C0413
 from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topogen import Topogen, get_topogen
 from lib.common_config import step
 
 pytestmark = [pytest.mark.ripngd]
@@ -39,7 +39,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     tgen = get_topogen()
     tgen.stop_topology()
 

--- a/tests/topotests/ripng_route_map/test_ripng_route_map.py
+++ b/tests/topotests/ripng_route_map/test_ripng_route_map.py
@@ -20,8 +20,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # pylint: disable=C0413
 from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
-from lib.common_config import step
+from lib.topogen import Topogen, get_topogen
 
 pytestmark = [pytest.mark.ripngd]
 
@@ -39,7 +38,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     tgen = get_topogen()
     tgen.stop_topology()
 

--- a/tests/topotests/route_scale/scale_test_common.py
+++ b/tests/topotests/route_scale/scale_test_common.py
@@ -182,7 +182,6 @@ def route_install_helper(iter):
 
     # Build up a list of dicts with params for each step of the test;
     # use defaults where the step doesn't supply a value
-    scale_setups = []
     s = scale_steps[iter]
 
     d = dict(zip(scale_keys, s))

--- a/tests/topotests/route_scale/test_route_scale1.py
+++ b/tests/topotests/route_scale/test_route_scale1.py
@@ -14,11 +14,8 @@ test_route_scale1.py: Testing route scale
 
 """
 import os
-import re
 import sys
 import pytest
-import json
-from functools import partial
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
@@ -26,9 +23,6 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # pylint: disable=C0413
 # Import topogen and topotest helpers
-from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
-from lib.topolog import logger
 
 from scale_test_common import (
     scale_build_common,

--- a/tests/topotests/route_scale/test_route_scale2.py
+++ b/tests/topotests/route_scale/test_route_scale2.py
@@ -14,11 +14,8 @@ test_route_scale2.py: Testing route scale
 
 """
 import os
-import re
 import sys
 import pytest
-import json
-from functools import partial
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
@@ -26,9 +23,6 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # pylint: disable=C0413
 # Import topogen and topotest helpers
-from lib import topotest
-from lib.topogen import Topogen, TopoRouter, get_topogen
-from lib.topolog import logger
 
 from scale_test_common import (
     scale_build_common,

--- a/tests/topotests/simple_snmp_test/test_simple_snmp.py
+++ b/tests/topotests/simple_snmp_test/test_simple_snmp.py
@@ -79,7 +79,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
 

--- a/tests/topotests/srv6_encap_src_addr/test_srv6_encap_src_addr.py
+++ b/tests/topotests/srv6_encap_src_addr/test_srv6_encap_src_addr.py
@@ -18,7 +18,6 @@ import os
 import sys
 import json
 import pytest
-import functools
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
@@ -56,7 +55,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     tgen = get_topogen()
     tgen.stop_topology()
 

--- a/tests/topotests/srv6_locator/test_srv6_locator.py
+++ b/tests/topotests/srv6_locator/test_srv6_locator.py
@@ -56,7 +56,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     tgen = get_topogen()
     tgen.stop_topology()
 
@@ -81,12 +81,12 @@ def test_srv6():
 
     def check_srv6_locator(router, expected_file):
         func = functools.partial(_check_srv6_locator, router, expected_file)
-        success, result = topotest.run_and_expect(func, None, count=10, wait=0.5)
+        _, result = topotest.run_and_expect(func, None, count=10, wait=0.5)
         assert result is None, "Failed"
 
     def check_sharpd_chunk(router, expected_file):
         func = functools.partial(_check_sharpd_chunk, router, expected_file)
-        success, result = topotest.run_and_expect(func, None, count=10, wait=0.5)
+        _, result = topotest.run_and_expect(func, None, count=10, wait=0.5)
         assert result is None, "Failed"
 
     # FOR DEVELOPER:

--- a/tests/topotests/srv6_locator_custom_bits_length/test_srv6_locator_custom_bits_length.py
+++ b/tests/topotests/srv6_locator_custom_bits_length/test_srv6_locator_custom_bits_length.py
@@ -52,7 +52,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     tgen = get_topogen()
     tgen.stop_topology()
 
@@ -77,12 +77,12 @@ def test_srv6():
 
     def check_srv6_locator(router, expected_file):
         func = functools.partial(_check_srv6_locator, router, expected_file)
-        success, result = topotest.run_and_expect(func, None, count=10, wait=0.5)
+        _, result = topotest.run_and_expect(func, None, count=10, wait=0.5)
         assert result is None, "Failed"
 
     def check_sharpd_chunk(router, expected_file):
         func = functools.partial(_check_sharpd_chunk, router, expected_file)
-        success, result = topotest.run_and_expect(func, None, count=10, wait=0.5)
+        _, result = topotest.run_and_expect(func, None, count=10, wait=0.5)
         assert result is None, "Failed"
 
     # FOR DEVELOPER:

--- a/tests/topotests/srv6_locator_usid/test_srv6_locator_usid.py
+++ b/tests/topotests/srv6_locator_usid/test_srv6_locator_usid.py
@@ -49,7 +49,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     tgen = get_topogen()
     tgen.stop_topology()
 
@@ -70,13 +70,13 @@ def _check_sharpd_chunk(router, expected_chunk_file):
 
 def check_srv6_locator(router, expected_file):
     func = functools.partial(_check_srv6_locator, router, expected_file)
-    success, result = topotest.run_and_expect(func, None, count=5, wait=3)
+    _, result = topotest.run_and_expect(func, None, count=5, wait=3)
     assert result is None, "Failed"
 
 
 def check_sharpd_chunk(router, expected_file):
     func = functools.partial(_check_sharpd_chunk, router, expected_file)
-    success, result = topotest.run_and_expect(func, None, count=5, wait=3)
+    _, result = topotest.run_and_expect(func, None, count=5, wait=3)
     assert result is None, "Failed"
 
 

--- a/tests/topotests/srv6_static_route/test_srv6_route.py
+++ b/tests/topotests/srv6_static_route/test_srv6_route.py
@@ -55,7 +55,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     tgen = get_topogen()
     tgen.stop_topology()
 
@@ -74,7 +74,7 @@ def test_srv6_static_route():
 
     def check_srv6_static_route(router, expected_file):
         func = functools.partial(_check_srv6_static_route, router, expected_file)
-        success, result = topotest.run_and_expect(func, None, count=15, wait=1)
+        _, result = topotest.run_and_expect(func, None, count=15, wait=1)
         assert result is None, "Failed"
 
     # FOR DEVELOPER:

--- a/tests/topotests/static_routing_mpls/test_static_routing_mpls.py
+++ b/tests/topotests/static_routing_mpls/test_static_routing_mpls.py
@@ -14,11 +14,8 @@ test_static_routing_mpls.py: Testing MPLS configuration with mpls interface sett
 """
 
 import os
-import re
 import sys
 import pytest
-import json
-from functools import partial
 import functools
 
 # Save the Current Working Directory to find configuration files.
@@ -113,7 +110,7 @@ def _check_mpls_state(router, interface, configured=True):
     test_func = functools.partial(
         _check_mpls_state_interface, router, interface, up=configured
     )
-    success, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
+    success, _ = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
     return success
 
 

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo2_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo2_ebgp.py
@@ -150,7 +150,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment
 

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo3_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo3_ebgp.py
@@ -134,7 +134,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment
 

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo4_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo4_ebgp.py
@@ -113,7 +113,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo1_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo1_ibgp.py
@@ -110,7 +110,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment
 

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo2_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo2_ibgp.py
@@ -152,7 +152,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment
 

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo3_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo3_ibgp.py
@@ -133,7 +133,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment
 

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo4_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo4_ibgp.py
@@ -111,7 +111,7 @@ def setup_module(mod):
     logger.info("Running setup_module() done")
 
 
-def teardown_module(mod):
+def teardown_module():
     """
     Teardown the pytest environment.
 

--- a/tests/topotests/static_simple/test_static_simple.py
+++ b/tests/topotests/static_simple/test_static_simple.py
@@ -13,11 +13,10 @@ import datetime
 import ipaddress
 import math
 import os
-import sys
 import re
 
 import pytest
-from lib.topogen import TopoRouter, Topogen, get_topogen
+from lib.topogen import TopoRouter, Topogen
 from lib.topolog import logger
 from lib.common_config import retry, step
 
@@ -80,7 +79,7 @@ def check_kernel(r1, super_prefix, count, add, is_blackhole, vrf, matchvia):
         kernel = r1.run(f"ip -4 route show{vrfstr}")
 
     logger.debug("checking kernel routing table%s:\n%s", vrfstr, kernel)
-    for i, net in enumerate(get_ip_networks(super_prefix, count)):
+    for _, net in enumerate(get_ip_networks(super_prefix, count)):
         if not add:
             assert str(net) not in kernel
             continue
@@ -116,7 +115,6 @@ def do_config(
     else:
         super_prefix = "2001::/48" if do_ipv6 else "10.0.0.0/8"
 
-    matchtype = ""
     matchvia = ""
     if via == "blackhole":
         pass
@@ -146,7 +144,7 @@ def do_config(
         if vrf:
             f.write("vrf {}\n".format(vrf))
 
-        for i, net in enumerate(get_ip_networks(super_prefix, count)):
+        for _, net in enumerate(get_ip_networks(super_prefix, count)):
             if add:
                 f.write("ip route {} {}\n".format(net, via))
             else:

--- a/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
+++ b/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
@@ -15,7 +15,6 @@ test_zebra_multiple_connected.py: Testing multiple connected
 """
 
 import os
-import re
 import sys
 import pytest
 import json
@@ -29,7 +28,6 @@ sys.path.append(os.path.join(CWD, "../"))
 # Import topogen and topotest helpers
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
-from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
@@ -157,7 +155,7 @@ def test_zebra_noprefix_connected():
     test_func = partial(
         topotest.router_output_cmp, router, "show ip route 192.168.44.0/24", expected
     )
-    result, diff = topotest.run_and_expect(test_func, "", count=20, wait=1)
+    result, _ = topotest.run_and_expect(test_func, "", count=20, wait=1)
     assert result, "Connected Route should not have been added"
 
 

--- a/tests/topotests/zebra_netlink/test_zebra_netlink.py
+++ b/tests/topotests/zebra_netlink/test_zebra_netlink.py
@@ -13,9 +13,7 @@ test_zebra_netlink.py: Test some basic interactions with kernel using Netlink
 """
 # pylint: disable=C0413
 import ipaddress
-import json
 import sys
-from functools import partial
 
 import pytest
 from lib import topotest
@@ -42,7 +40,7 @@ def tgen(request):
 
     # Initialize all routers.
     router_list = tgen.routers()
-    for rname, router in router_list.items():
+    for _, router in router_list.items():
         router.load_config(TopoRouter.RD_ZEBRA, "zebra.conf")
         router.load_config(TopoRouter.RD_SHARP)
 

--- a/tests/topotests/zebra_nht_resolution/test_verify_nh_resolution.py
+++ b/tests/topotests/zebra_nht_resolution/test_verify_nh_resolution.py
@@ -16,7 +16,6 @@ import sys
 import pytest
 
 from lib.common_config import (
-    start_topology,
     verify_rib,
     verify_ip_nht,
     step,
@@ -24,7 +23,6 @@ from lib.common_config import (
 )
 
 # pylint: disable=C0413
-from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 

--- a/tests/topotests/zebra_opaque/test_zebra_opaque.py
+++ b/tests/topotests/zebra_opaque/test_zebra_opaque.py
@@ -32,7 +32,7 @@ def setup_module(mod):
 
     router_list = tgen.routers()
 
-    for i, (rname, router) in enumerate(router_list.items(), 1):
+    for _, (rname, router) in enumerate(router_list.items(), 1):
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )
@@ -49,7 +49,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     tgen = get_topogen()
     tgen.stop_topology()
 
@@ -98,17 +98,17 @@ def test_zebra_opaque():
 
     router = tgen.gears["r1"]
     test_func = functools.partial(_bgp_converge, router)
-    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, 'Cannot see BGP community aliases "{}"'.format(router)
 
     router = tgen.gears["r3"]
     test_func = functools.partial(_ospf_converge, router)
-    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, 'Cannot see OSPFv2 opaque attributes "{}"'.format(router)
 
     router = tgen.gears["r3"]
     test_func = functools.partial(_ospf6_converge, router)
-    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, 'Cannot see OSPFv3 opaque attributes "{}"'.format(router)
 
 

--- a/tests/topotests/zebra_rib/test_zebra_rib.py
+++ b/tests/topotests/zebra_rib/test_zebra_rib.py
@@ -71,7 +71,7 @@ def setup_module(mod):
     tgen.start_router()
 
 
-def teardown_module(mod):
+def teardown_module():
     "Teardown the pytest environment"
     tgen = get_topogen()
     tgen.stop_topology()
@@ -235,7 +235,7 @@ def test_route_map_usage():
         return topotest.json_cmp(output, expected)
 
     test_func = partial(check_initial_routes_installed, r1)
-    success, result = topotest.run_and_expect(test_func, None, count=40, wait=1)
+    _, result = topotest.run_and_expect(test_func, None, count=40, wait=1)
 
     static_rmapfile = "%s/r1/static_rmap.ref" % (thisDir)
     expected = open(static_rmapfile).read().rstrip()

--- a/tests/topotests/zebra_seg6_route/test_zebra_seg6_route.py
+++ b/tests/topotests/zebra_seg6_route/test_zebra_seg6_route.py
@@ -80,7 +80,7 @@ def test_zebra_seg6_routes():
 
     expected = open_json_file(os.path.join(CWD, "{}/routes_setup.json".format("r1")))
     test_func = partial(check_connected, r1, "2001::/64", expected)
-    success, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, "Failed to fully setup connected routes needed"
 
     manifests = open_json_file(os.path.join(CWD, "{}/routes.json".format("r1")))
@@ -96,7 +96,7 @@ def test_zebra_seg6_routes():
         )
         logger.info("CHECK {} {} {}".format(dest, nh, sid))
         test_func = partial(check, r1, dest, manifest["out"])
-        success, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+        _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
         assert result is None, "Failed"
 
 

--- a/tests/topotests/zebra_seg6local_route/test_zebra_seg6local_route.py
+++ b/tests/topotests/zebra_seg6local_route/test_zebra_seg6local_route.py
@@ -101,7 +101,7 @@ def test_zebra_seg6local_routes():
             dest,
             manifest["out"],
         )
-        success, result = topotest.run_and_expect(test_func, None, count=25, wait=1)
+        _, result = topotest.run_and_expect(test_func, None, count=25, wait=1)
         assert result is None, "Failed"
 
 


### PR DESCRIPTION
tests: Avoid importing unused modules at test suites

There is no issue / failures with the test suites
For code maintainability, removing unused modules.