### PR TITLE
ripd/ripngd: use common header for display command

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3054,7 +3054,10 @@ DEFUN (show_ip_rip,
 	}
 
 	vty_out(vty,
-		"Codes: R - RIP, C - connected, S - Static, O - OSPF, B - BGP\n"
+		"Codes: K - kernel route, C - connected, L - local, S - static,\n"
+		"       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,\n"
+		"       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,\n"
+		"       f - OpenFabric, t - Table-Direct\n"
 		"Sub-codes:\n"
 		"      (n) - normal, (s) - static, (d) - default, (r) - redistribute,\n"
 		"      (i) - interface\n\n"

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2070,7 +2070,10 @@ DEFUN (show_ipv6_ripng,
 
 	/* Header of display. */
 	vty_out(vty,
-		"Codes: R - RIPng, C - connected, S - Static, O - OSPF, B - BGP\n"
+		"Codes: K - kernel route, C - connected, L - local, S - static,\n"
+		"       R - RIPng, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,\n"
+		"       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,\n"
+		"       f - OpenFabric, t - Table-Direct\n"
 		"Sub-codes:\n"
 		"      (n) - normal, (s) - static, (d) - default, (r) - redistribute,\n"
 		"      (i) - interface, (a/S) - aggregated/Suppressed\n\n"

--- a/tests/topotests/rip_topo1/r1/show_ip_rip.ref
+++ b/tests/topotests/rip_topo1/r1/show_ip_rip.ref
@@ -1,4 +1,7 @@
-Codes: R - RIP, C - connected, S - Static, O - OSPF, B - BGP
+Codes: K - kernel route, C - connected, L - local, S - static,
+       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
+       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
+       f - OpenFabric, t - Table-Direct
 Sub-codes:
       (n) - normal, (s) - static, (d) - default, (r) - redistribute,
       (i) - interface

--- a/tests/topotests/rip_topo1/r2/show_ip_rip.ref
+++ b/tests/topotests/rip_topo1/r2/show_ip_rip.ref
@@ -1,4 +1,7 @@
-Codes: R - RIP, C - connected, S - Static, O - OSPF, B - BGP
+Codes: K - kernel route, C - connected, L - local, S - static,
+       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
+       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
+       f - OpenFabric, t - Table-Direct
 Sub-codes:
       (n) - normal, (s) - static, (d) - default, (r) - redistribute,
       (i) - interface

--- a/tests/topotests/rip_topo1/r3/show_ip_rip.ref
+++ b/tests/topotests/rip_topo1/r3/show_ip_rip.ref
@@ -1,4 +1,7 @@
-Codes: R - RIP, C - connected, S - Static, O - OSPF, B - BGP
+Codes: K - kernel route, C - connected, L - local, S - static,
+       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
+       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
+       f - OpenFabric, t - Table-Direct
 Sub-codes:
       (n) - normal, (s) - static, (d) - default, (r) - redistribute,
       (i) - interface

--- a/tests/topotests/ripng_topo1/r1/show_ipv6_ripng.ref
+++ b/tests/topotests/ripng_topo1/r1/show_ipv6_ripng.ref
@@ -1,4 +1,7 @@
-Codes: R - RIPng, C - connected, S - Static, O - OSPF, B - BGP
+Codes: K - kernel route, C - connected, L - local, S - static,
+       R - RIPng, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
+       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
+       f - OpenFabric, t - Table-Direct
 Sub-codes:
       (n) - normal, (s) - static, (d) - default, (r) - redistribute,
       (i) - interface, (a/S) - aggregated/Suppressed

--- a/tests/topotests/ripng_topo1/r2/show_ipv6_ripng.ref
+++ b/tests/topotests/ripng_topo1/r2/show_ipv6_ripng.ref
@@ -1,4 +1,7 @@
-Codes: R - RIPng, C - connected, S - Static, O - OSPF, B - BGP
+Codes: K - kernel route, C - connected, L - local, S - static,
+       R - RIPng, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
+       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
+       f - OpenFabric, t - Table-Direct
 Sub-codes:
       (n) - normal, (s) - static, (d) - default, (r) - redistribute,
       (i) - interface, (a/S) - aggregated/Suppressed

--- a/tests/topotests/ripng_topo1/r3/show_ipv6_ripng.ref
+++ b/tests/topotests/ripng_topo1/r3/show_ipv6_ripng.ref
@@ -1,4 +1,7 @@
-Codes: R - RIPng, C - connected, S - Static, O - OSPF, B - BGP
+Codes: K - kernel route, C - connected, L - local, S - static,
+       R - RIPng, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
+       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
+       f - OpenFabric, t - Table-Direct
 Sub-codes:
       (n) - normal, (s) - static, (d) - default, (r) - redistribute,
       (i) - interface, (a/S) - aggregated/Suppressed


### PR DESCRIPTION
Both rip and ripng can import routes from other protocols, e.g. ISIS. But their header doesn't list the description for these abbreviations.

Let `show ip rip` (and `show ipv6 ripng`) uses the common header.

Before:
```
Codes: R - RIP, C - connected, S - Static, O - OSPF, B - BGP
Sub-codes:
      (n) - normal, (s) - static, (d) - default, (r) - redistribute,
      (i) - interface
```

After:
```
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

Sub-codes:
      (n) - normal, (s) - static, (d) - default, (r) - redistribute,
      (i) - interface
```