### PR TITLE
isisd: After the router switches IS-IS type several times, the neighbor adjacency cannot be established.

### DIFF
--- a/isisd/isis_events.c
+++ b/isisd/isis_events.c
@@ -83,6 +83,7 @@ static void circuit_commence_level(struct isis_circuit *circuit, int level)
 
 		send_hello_sched(circuit, level, TRIGGERED_IIH_DELAY);
 		circuit->u.bc.lan_neighs[level - 1] = list_new();
+		circuit->u.bc.adjdb[level - 1] = list_new();
 	}
 }
 
@@ -108,6 +109,10 @@ static void circuit_resign_level(struct isis_circuit *circuit, int level)
 		circuit->u.bc.is_dr[idx] = 0;
 		if (circuit->u.bc.lan_neighs[idx] != NULL)
 			list_delete(&circuit->u.bc.lan_neighs[idx]);
+		if (circuit->u.bc.adjdb[idx]) {
+			circuit->u.bc.adjdb[idx]->del = isis_delete_adj;
+			list_delete(&circuit->u.bc.adjdb[idx]);
+		}
 	}
 
 	return;


### PR DESCRIPTION
1. Router A is configured with "is-type level-1-2", while Router B is configured with "is-type level-1". Only level 1 neighbor entries are present on Router A.
2. After configuring Router B with "is-type level-2-only", both level 1 and level 2 neighbor entries exist on Router A. The state of these entries is UP, and the level 1 neighbor entry is currently aging.
3. Before the level 1 neighbor entry on Router A ages out, configuring Router B with "is-type level-1", both level 1 and level 2 neighbor entries exist on Router A. The level 2 neighbor entry is UP and will age out normally. However, the level 1 neighbor entry remains in the Initializing state, preventing the establishment of level 1 neighbor adjacency between Router A and Router B.

When the adjacency type of the link is switched in function `isis_circuit_is_type_set()`, the function `circuit_resign_level()` is called to delete the old level's `circuit->u.bc.lan_neighs` linked list. If the old level is not level-1-2, the function `circuit_commence_level()` is called to create a new level's `circuit->u.bc.lan_neighs` linked list, but neither of these functions handle the `circuit->u.bc.adjdb` linked list. This leads to a situation where upon receiving hello packets again in function `process_lan_hello()` before the `circuit->u.bc.adjdb` linked list entries age out, the `circuit->u.bc.lan_neighs` linked list is not constructed based on the `circuit->u.bc.adjdb` linked list. As a result, the hello packets sent will consistently lack an SNPA, causing the neighbor to remain unable to establish an adjacency upon receiving the hello packets.

Signed-off-by: zhou-run <zhou.run@h3c.com>