### PR TITLE
isisd: Even after configuring "no hostname dynamic", the topology still displays the hostname.

### DIFF
--- a/isisd/isis_misc.c
+++ b/isisd/isis_misc.c
@@ -370,18 +370,20 @@ const char *print_sys_hostname(const uint8_t *sysid)
 	struct isis_dynhn *dyn;
 	struct isis *isis = NULL;
 	struct listnode *node;
+	struct isis_area *area = NULL;
 
 	if (!sysid)
 		return "nullsysid";
 
 	/* For our system ID return our host name */
-	isis = isis_lookup_by_sysid(sysid);
-	if (isis && !CHECK_FLAG(im->options, F_ISIS_UNIT_TEST))
+	area = isis_area_lookup_by_sysid(sysid);
+	if (area && area->dynhostname && !CHECK_FLAG(im->options, F_ISIS_UNIT_TEST))
 		return cmd_hostname_get();
 
 	for (ALL_LIST_ELEMENTS_RO(im->isis, node, isis)) {
+		area = isis_area_lookup_by_sysid(isis->sysid);
 		dyn = dynhn_find_by_id(isis, sysid);
-		if (dyn)
+		if (area && area->dynhostname && dyn)
 			return dyn->hostname;
 	}
 

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -285,10 +285,12 @@ void isis_area_add_circuit(struct isis_area *area,
 void isis_area_del_circuit(struct isis_area *area,
 			   struct isis_circuit *circuit);
 
+void isis_area_address_delete(void *arg);
 struct isis_area *isis_area_create(const char *, const char *);
 struct isis_area *isis_area_lookup(const char *, vrf_id_t vrf_id);
 struct isis_area *isis_area_lookup_by_vrf(const char *area_tag,
 					  const char *vrf_name);
+struct isis_area *isis_area_lookup_by_sysid(const uint8_t *sysid);
 int isis_area_get(struct vty *vty, const char *area_tag);
 void isis_area_destroy(struct isis_area *area);
 void isis_filter_update(struct access_list *access);


### PR DESCRIPTION
The command "show isis topology" calls `print_sys_hostname()` to display the system ID or hostname, but it does not check the `area->dynhostname` flag.

Signed-off-by: zhou-run <zhou.run@h3c.com>