### PR TITLE
ripd/ripd.c - rip_auth_md5 : Change the start value of sequence 1 to 0

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -1051,7 +1051,7 @@ static size_t rip_auth_md5_ah_write(struct stream *s, struct rip_interface *ri,
 	/* RFC2080: The value used in the sequence number is
 	   arbitrary, but two suggestions are the time of the
 	   message's creation or a simple message counter. */
-	stream_putl(s, ++seq);
+	stream_putl(s, seq++);
 
 	/* Reserved field must be zero. */
 	stream_putl(s, 0);


### PR DESCRIPTION
Start the sequence at zero to make md5 authentication compatible with bird