### PR TITLE
bgpd: backpressure - fix evpn route sync to zebra

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1794,6 +1794,8 @@ static void bgp_handle_route_announcements_to_zebra(struct event *e)
 	bool install;
 
 	while (count < ZEBRA_ANNOUNCEMENTS_LIMIT) {
+		is_evpn = false;
+
 		dest = zebra_announce_pop(&bm->zebra_announce_head);
 
 		if (!dest)


### PR DESCRIPTION
In scaled EVPN + ipv4/ipv6 uni route sync to zebra, some of the ipv4/ipv6 routes skipped re installation
due to incorrect local variable's stale value.
Once the local variable value reset in each loop iteration all skipped routes synced to zebra properly.


Signed-off-by: Rajasekar Raja <rajasekarr@nvidia.com>
Signed-off-by: Chirag Shah <chirag@nvidia.com>
