### PR TITLE
isisd: The neighbor entry still displays the deleted hostname of the neighbor.

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -293,7 +293,7 @@ const char *isis_adj_name(const struct isis_adjacency *adj)
 	struct isis_dynhn *dyn;
 
 	dyn = dynhn_find_by_id(adj->circuit->isis, adj->sysid);
-	if (dyn)
+	if (adj->circuit->area->dynhostname && dyn)
 		return dyn->hostname;
 
 	snprintfrr(buf, sizeof(buf), "%pSY", adj->sysid);

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -482,13 +482,19 @@ static void lsp_update_data(struct isis_lsp *lsp, struct isis_lsp_hdr *hdr,
 
 	lsp->tlvs = tlvs;
 
-	if (area->dynhostname && lsp->tlvs->hostname
-	    && lsp->hdr.rem_lifetime) {
-		isis_dynhn_insert(
-			area->isis, lsp->hdr.lsp_id, lsp->tlvs->hostname,
-			(lsp->hdr.lsp_bits & LSPBIT_IST) == IS_LEVEL_1_AND_2
-				? IS_LEVEL_2
-				: IS_LEVEL_1);
+	if (area->dynhostname && lsp->hdr.rem_lifetime) {
+		if (lsp->tlvs->hostname) {
+			isis_dynhn_insert(area->isis, lsp->hdr.lsp_id,
+					  lsp->tlvs->hostname,
+					  (lsp->hdr.lsp_bits & LSPBIT_IST) ==
+							  IS_LEVEL_1_AND_2
+						  ? IS_LEVEL_2
+						  : IS_LEVEL_1);
+		} else {
+			if (!LSP_PSEUDO_ID(lsp->hdr.lsp_id) &&
+			    !LSP_FRAGMENT(lsp->hdr.lsp_id))
+				isis_dynhn_remove(area->isis, lsp->hdr.lsp_id);
+		}
 	}
 
 	return;
@@ -2224,6 +2230,10 @@ void lsp_tick(struct event *thread)
 						next = lspdb_next(
 							&area->lspdb[level],
 							next);
+
+				if (!LSP_PSEUDO_ID(lsp->hdr.lsp_id))
+					isis_dynhn_remove(area->isis,
+							  lsp->hdr.lsp_id);
 
 				lspdb_del(&area->lspdb[level], lsp);
 				lsp_destroy(lsp);

--- a/tests/topotests/isis_topo1/test_isis_topo1.py
+++ b/tests/topotests/isis_topo1/test_isis_topo1.py
@@ -685,6 +685,9 @@ def _check_lsp_overload_bit(router, overloaded_router_lsp, att_p_ol_expected):
     )
 
     database_json = json.loads(isis_database_output)
+    if "lsps" not in database_json["areas"][0]["levels"][1]:
+        return "The LSP of {} has not been synchronized yet ".format(router.name)
+
     att_p_ol = database_json["areas"][0]["levels"][1]["lsps"][0]["attPOl"]
     if att_p_ol == att_p_ol_expected:
         return True


### PR DESCRIPTION
1. The `lsp_update_data()` function will check for the presence of the `ISIS_TLV_DYNAMIC_HOSTNAME `in the LSP, and then call `isis_dynhn_insert()` to add a hostname entry corresponding to the LSP ID. However, when the `ISIS_TLV_DYNAMIC_HOSTNAME `is not present in the LSP, the hostname entry corresponding to the LSP ID should also be deleted.
2. The command “show isis neighbor” invokes `isis_adj_name()` to display the System ID or hostname, but it does not check the `area->dynhostname` flag.

Signed-off-by: zhou-run <zhou.run@h3c.com>