### PR TITLE
tests, zebra: rename nexthop-group depends dependends                                                

### DIFF
--- a/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
+++ b/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
@@ -436,7 +436,7 @@ def verify_nexthop_group(nhg_id, recursive=False, ecmp=0):
             continue
 
         if ecmp or recursive:
-            ecmpcount = re.search(r"Depends:.*\n", output)
+            ecmpcount = re.search(r"Child groups:.*\n", output)
             if ecmpcount is None:
                 found = False
                 sleep(1)

--- a/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
+++ b/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
@@ -420,7 +420,7 @@ def verify_nexthop_group(nhg_id, recursive=False, ecmp=0):
     count = 0
     valid = None
     ecmpcount = None
-    depends = None
+    children = None
     resolved_id = None
     installed = None
     found = False
@@ -443,21 +443,21 @@ def verify_nexthop_group(nhg_id, recursive=False, ecmp=0):
                 continue
 
             # list of IDs in group
-            depends = re.findall(r"\((\d+)\)", ecmpcount.group(0))
+            children = re.findall(r"\((\d+)\)", ecmpcount.group(0))
 
             if ecmp:
-                if len(depends) != ecmp:
+                if len(children) != ecmp:
                     found = False
                     sleep(1)
                     continue
             else:
                 # If recursive, we need to look at its resolved group
-                if len(depends) != 1:
+                if len(children) != 1:
                     found = False
                     sleep(1)
                     continue
 
-                resolved_id = int(depends[0])
+                resolved_id = int(children[0])
                 verify_nexthop_group(resolved_id, False)
         else:
             installed = re.search(r"Installed", output)
@@ -469,19 +469,17 @@ def verify_nexthop_group(nhg_id, recursive=False, ecmp=0):
 
     assert valid is not None, "Nexthop Group ID={} not marked Valid".format(nhg_id)
     if ecmp or recursive:
-        assert ecmpcount is not None, "Nexthop Group ID={} has no depends".format(
+        assert ecmpcount is not None, "Nexthop Group ID={} has no children".format(
             nhg_id
         )
         if ecmp:
             assert (
-                len(depends) == ecmp
+                len(children) == ecmp
             ), "Nexthop Group ID={} doesn't match ecmp size".format(nhg_id)
         else:
             assert (
-                len(depends) == 1
-            ), "Nexthop Group ID={} should only have one recursive depend".format(
-                nhg_id
-            )
+                len(children) == 1
+            ), "Nexthop Group ID={} should only have one recursive child".format(nhg_id)
     else:
         assert installed is not None, "Nexthop Group ID={} not marked Installed".format(
             nhg_id

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -135,7 +135,7 @@ struct zebra_if {
 	 * we will use this list to update the nexthops
 	 * pointing to it with that info.
 	 */
-	struct nhg_connected_tree_head nhg_dependents;
+	struct nhg_connected_tree_head nhg_parent;
 
 	/* Information about up/down changes */
 	unsigned int up_count;
@@ -331,7 +331,7 @@ void link_param_cmd_set_float(struct interface *ifp, float *field,
 void link_param_cmd_unset(struct interface *ifp, uint32_t type);
 
 /* Nexthop group connected functions */
-extern bool if_nhg_dependents_is_empty(const struct interface *ifp);
+extern bool if_nhg_parent_is_empty(const struct interface *ifp);
 
 extern void vrf_add_update(struct vrf *vrfp);
 extern void zebra_l2_map_slave_to_bond(struct zebra_if *zif, vrf_id_t vrf);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3678,8 +3678,8 @@ int dplane_ctx_nexthop_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	nexthop_group_copy(&(ctx->u.rinfo.nhe.ng), &(nhe->nhg));
 
 	/* If this is a group, convert it to a grp array of ids */
-	if (!zebra_nhg_depends_is_empty(nhe)
-	    && !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSIVE))
+	if (!zebra_nhg_child_is_empty(nhe) &&
+	    !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSIVE))
 		ctx->u.rinfo.nhe.nh_grp_count = zebra_nhg_nhe2grp(
 			ctx->u.rinfo.nhe.nh_grp, nhe, MULTIPATH_NUM);
 

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -71,23 +71,23 @@ struct nhg_hash_entry {
 	 * Using a rb tree here to make lookups
 	 * faster with ID's.
 	 *
-	 * nhg_depends the RB tree of entries that this
+	 * nhg_child the RB tree of entries that this
 	 * group contains.
 	 *
 	 * nhg_parent the RB tree of entries that
 	 * this group is being used by
 	 *
 	 * NHG id 3 with nexthops id 1/2
-	 * nhg(3)->nhg_depends has 1 and 2 in the tree
+	 * nhg(3)->nhg_child has 1 and 2 in the tree
 	 * nhg(3)->nhg_parent is empty
 	 *
-	 * nhg(1)->nhg_depends is empty
+	 * nhg(1)->nhg_child is empty
 	 * nhg(1)->nhg_parent is 3 in the tree
 	 *
-	 * nhg(2)->nhg_depends is empty
+	 * nhg(2)->nhg_child is empty
 	 * nhg(2)->nhg_parent is 3 in the tree
 	 */
-	struct nhg_connected_tree_head nhg_depends, nhg_parent;
+	struct nhg_connected_tree_head nhg_child, nhg_parent;
 
 	struct event *timer;
 
@@ -272,8 +272,8 @@ struct nexthop_group *zebra_nhg_get_backup_nhg(struct nhg_hash_entry *nhe);
 
 extern struct nhg_hash_entry *zebra_nhg_resolve(struct nhg_hash_entry *nhe);
 
-extern unsigned int zebra_nhg_depends_count(const struct nhg_hash_entry *nhe);
-extern bool zebra_nhg_depends_is_empty(const struct nhg_hash_entry *nhe);
+extern unsigned int zebra_nhg_child_count(const struct nhg_hash_entry *nhe);
+extern bool zebra_nhg_child_is_empty(const struct nhg_hash_entry *nhe);
 
 extern unsigned int zebra_nhg_parent_count(const struct nhg_hash_entry *nhe);
 extern bool zebra_nhg_parent_is_empty(const struct nhg_hash_entry *nhe);

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -74,20 +74,20 @@ struct nhg_hash_entry {
 	 * nhg_depends the RB tree of entries that this
 	 * group contains.
 	 *
-	 * nhg_dependents the RB tree of entries that
+	 * nhg_parent the RB tree of entries that
 	 * this group is being used by
 	 *
 	 * NHG id 3 with nexthops id 1/2
 	 * nhg(3)->nhg_depends has 1 and 2 in the tree
-	 * nhg(3)->nhg_dependents is empty
+	 * nhg(3)->nhg_parent is empty
 	 *
 	 * nhg(1)->nhg_depends is empty
-	 * nhg(1)->nhg_dependents is 3 in the tree
+	 * nhg(1)->nhg_parent is 3 in the tree
 	 *
 	 * nhg(2)->nhg_depends is empty
-	 * nhg(2)->nhg_dependents is 3 in the tree
+	 * nhg(2)->nhg_parent is 3 in the tree
 	 */
-	struct nhg_connected_tree_head nhg_depends, nhg_dependents;
+	struct nhg_connected_tree_head nhg_depends, nhg_parent;
 
 	struct event *timer;
 
@@ -275,9 +275,8 @@ extern struct nhg_hash_entry *zebra_nhg_resolve(struct nhg_hash_entry *nhe);
 extern unsigned int zebra_nhg_depends_count(const struct nhg_hash_entry *nhe);
 extern bool zebra_nhg_depends_is_empty(const struct nhg_hash_entry *nhe);
 
-extern unsigned int
-zebra_nhg_dependents_count(const struct nhg_hash_entry *nhe);
-extern bool zebra_nhg_dependents_is_empty(const struct nhg_hash_entry *nhe);
+extern unsigned int zebra_nhg_parent_count(const struct nhg_hash_entry *nhe);
+extern bool zebra_nhg_parent_is_empty(const struct nhg_hash_entry *nhe);
 
 /* Lookup ID, doesn't create */
 extern struct nhg_hash_entry *zebra_nhg_lookup_id(uint32_t id);

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -355,7 +355,7 @@ unsigned long zebra_nhg_score_proto(int type);
 extern void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe);
 extern void zebra_nhg_increment_ref(struct nhg_hash_entry *nhe);
 
-/* Check validity of nhe, if invalid will update dependents as well */
+/* Check validity of nhe, if invalid will update parents as well */
 extern void zebra_nhg_check_valid(struct nhg_hash_entry *nhe);
 
 /* Convert nhe depends to a grp context that can be passed around safely */

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1241,12 +1241,12 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 				nhe->ifp->ifindex);
 	}
 
-	if (!zebra_nhg_depends_is_empty(nhe)) {
+	if (!zebra_nhg_child_is_empty(nhe)) {
 		if (json)
 			json_depends = json_object_new_array();
 		else
 			vty_out(vty, "     Child groups:");
-		frr_each(nhg_connected_tree, &nhe->nhg_depends, rb_node_dep) {
+		frr_each (nhg_connected_tree, &nhe->nhg_child, rb_node_dep) {
 			if (json_depends)
 				json_object_array_add(
 					json_depends,

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1359,13 +1359,12 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 					       json_backup_nexthop_array);
 	}
 
-	if (!zebra_nhg_dependents_is_empty(nhe)) {
+	if (!zebra_nhg_parent_is_empty(nhe)) {
 		if (json)
 			json_dependants = json_object_new_array();
 		else
 			vty_out(vty, "     Parent groups:");
-		frr_each(nhg_connected_tree, &nhe->nhg_dependents,
-			  rb_node_dep) {
+		frr_each (nhg_connected_tree, &nhe->nhg_parent, rb_node_dep) {
 			if (json)
 				json_object_array_add(
 					json_dependants,
@@ -1484,7 +1483,7 @@ static void if_nexthop_group_dump_vty(struct vty *vty, struct interface *ifp)
 
 	zebra_if = ifp->info;
 
-	frr_each (nhg_connected_tree, &zebra_if->nhg_dependents, rb_node_dep) {
+	frr_each (nhg_connected_tree, &zebra_if->nhg_parent, rb_node_dep) {
 		if (first) {
 			vty_out(vty, "Interface %s:\n", ifp->name);
 			first = false;

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1245,7 +1245,7 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 		if (json)
 			json_depends = json_object_new_array();
 		else
-			vty_out(vty, "     Depends:");
+			vty_out(vty, "     Child groups:");
 		frr_each(nhg_connected_tree, &nhe->nhg_depends, rb_node_dep) {
 			if (json_depends)
 				json_object_array_add(
@@ -1363,7 +1363,7 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 		if (json)
 			json_dependants = json_object_new_array();
 		else
-			vty_out(vty, "     Dependents:");
+			vty_out(vty, "     Parent groups:");
 		frr_each(nhg_connected_tree, &nhe->nhg_dependents,
 			  rb_node_dep) {
 			if (json)


### PR DESCRIPTION
The hierarchy between next-hop groups in the "show nexthop-group rib"                                
output can be challenging to understand. The terms "depends" and                                     
"dependents" refer to child and parent next-hop groups, respectively.                                
                                                                                                     
> r1# show nexthop-group  rib 181818168                                                                
> ID: 181818168 (sharp)                                                                                
>      RefCnt: 1                                                                                       
>      Uptime: 00:06:42                                                                                
>      VRF: default                                                                                    
>      Depends: (96) (97)                                                                              
>            via 1.1.1.1 (vrf default) inactive, weight 1                                              
>            via 1.1.1.2 (vrf default) inactive, weight 1                                              
> r1# show nexthop-group  rib 96                                                                       
> ID: 96 (sharp)                                                                                       
>      RefCnt: 2                                                                                       
>      Uptime: 00:06:59                                                                                
>      VRF: default                                                                                    
>            via 1.1.1.1 (vrf default) inactive, weight 1                                              
>      Dependents: (181818168)                                                                         
                                                                                                     
Rename "Depends" and "Dependents" to child and parent.                                               
                                                                                                     
> r1# show nexthop-group  rib 181818168                                                                
> ID: 181818168 (sharp)                                                                                
>      RefCnt: 1                                                                                       
>      Uptime: 00:06:42                                                                                
>      VRF: default                                                                                    
>      Child groups: (96) (97)                                                                         
>            via 1.1.1.1 (vrf default) inactive, weight 1                                              
>            via 1.1.1.2 (vrf default) inactive, weight 1                                              
> r1# show nexthop-group  rib 96                                                                       
> ID: 96 (sharp)                                                                                       
>      RefCnt: 2                                                                                       
>      Uptime: 00:06:59                                                                                
>      VRF: default                                                                                    
>            via 1.1.1.1 (vrf default) inactive, weight 1                                              
>      Parent groups: (181818168)                                                                      

Also rename the code                                               