### PR TITLE
zebra: fix evpn mh bond member proto reinstall

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1656,8 +1656,10 @@ static void interface_if_protodown(struct interface *ifp, bool protodown,
 				   uint32_t rc_bitfield)
 {
 	struct zebra_if *zif = ifp->info;
-	bool old_protodown;
+	bool old_protodown, reason_extern;
 
+	reason_extern = !!CHECK_FLAG(zif->protodown_rc,
+				     ZEBRA_PROTODOWN_EXTERNAL);
 	/*
 	 * Set our reason code to note it wasn't us.
 	 * If the reason we got from the kernel is ONLY frr though, don't
@@ -1673,8 +1675,8 @@ static void interface_if_protodown(struct interface *ifp, bool protodown,
 		return;
 
 	if (IS_ZEBRA_DEBUG_EVPN_MH_ES || IS_ZEBRA_DEBUG_DPLANE)
-		zlog_debug("interface %s dplane change, protodown %s",
-			   ifp->name, protodown ? "on" : "off");
+		zlog_debug("interface %s dplane change, protodown %s curr reason_extern %u",
+			   ifp->name, protodown ? "on" : "off", reason_extern);
 
 	/* Set protodown, respectively */
 	COND_FLAG(zif->flags, ZIF_FLAG_PROTODOWN, protodown);
@@ -1696,6 +1698,13 @@ static void interface_if_protodown(struct interface *ifp, bool protodown,
 				zlog_debug(
 					"bond mbr %s protodown off recv'd but already sent protodown off to the dplane",
 					ifp->name);
+			return;
+		}
+
+		if (!protodown && reason_extern) {
+			if (IS_ZEBRA_DEBUG_EVPN_MH_ES || IS_ZEBRA_DEBUG_KERNEL)
+				zlog_debug("bond member %s has protodown reason external and clear the reason, skip reinstall.",
+					   ifp->name);
 			return;
 		}
 


### PR DESCRIPTION
In case of EVPN MH bond, a member port going in protodown state due to external reason (one case being linkflap), 
frr updates the state correctly but upon manually clearing external reason trigger FRR to reinstate protodown without any reason code.

Fix is to ensure if the protodown reason was external and new state is to have protodown 'off' then do no reinstate protodown.

Testing:

```
switch:#ip link show swp1
4: swp1: <NO-CARRIER,BROADCAST,MULTICAST,SLAVE,UP> mtu 9216 qdisc
   pfifo_fast master bond1 state DOWN mode DEFAULT group default qlen
   1000
       link/ether 1c:34:da:2c:aa:68 brd ff:ff:ff:ff:ff:ff protodown on
       protodown_reason <linkflap>

switch:#ip link set swp1 protodown off protodown_reason linkflap off 

switch:#ip link show swp1
 4: swp1: <NO-CARRIER,BROADCAST,MULTICAST,SLAVE,UP> mtu 9216 qdisc
    pfifo_fast master bond1 state DOWN mode DEFAULT group default qlen
    1000
        link/ether 1c:34:da:2c:aa:68 brd ff:ff:ff:ff:ff:ff
 ```
 
 Signed-off-by: Chirag Shah <chirag@nvidia.com>