### PR TITLE
lib, tests: fix some b0rked tests, then fix TSAN warnings

### DIFF
--- a/lib/frrcu.h
+++ b/lib/frrcu.h
@@ -156,7 +156,7 @@ extern void rcu_enqueue(struct rcu_head *head, const struct rcu_action *action);
 #define rcu_call(func, ptr, field)                                             \
 	do {                                                                   \
 		typeof(ptr) _ptr = (ptr);                                      \
-		void (*fptype)(typeof(ptr));                                   \
+		void (*_fptype)(typeof(ptr));                                  \
 		struct rcu_head *_rcu_head = &_ptr->field;                     \
 		static const struct rcu_action _rcu_action = {                 \
 			.type = RCUA_CALL,                                     \

--- a/tests/lib/test_atomlist.c
+++ b/tests/lib/test_atomlist.c
@@ -62,7 +62,7 @@ static struct asort_head shead;
 static struct testthread {
 	pthread_t pt;
 	struct seqlock sqlo;
-	size_t counter, nullops;
+	_Atomic size_t counter, nullops;
 } thr[NTHREADS];
 
 struct testrun {
@@ -97,10 +97,10 @@ static void trfunc_##name(unsigned int offset) \
 { \
 	size_t i = 0, n = 0;
 
-#define endtestrun \
-	thr[offset].counter = i; \
-	thr[offset].nullops = n; \
-}
+#define endtestrun                                                             \
+	atomic_store_explicit(&thr[offset].counter, i, memory_order_seq_cst);  \
+	atomic_store_explicit(&thr[offset].nullops, n, memory_order_seq_cst);  \
+	}
 
 deftestrun(add, "add vs. add", 0, false)
 	for (; i < NITEM / NTHREADS; i++)
@@ -288,10 +288,10 @@ static void run_tr(struct testrun *tr)
 	sv = seqlock_bump(&sqlo) - SEQLOCK_INCR;
 	for (size_t i = 0; i < NTHREADS; i++) {
 		seqlock_wait(&thr[i].sqlo, seqlock_cur(&sqlo));
-		s += thr[i].counter;
-		n += thr[i].nullops;
-		thr[i].counter = 0;
-		thr[i].nullops = 0;
+		s += atomic_load_explicit(&thr[i].counter, memory_order_seq_cst);
+		n += atomic_load_explicit(&thr[i].nullops, memory_order_seq_cst);
+		atomic_store_explicit(&thr[i].counter, 0, memory_order_seq_cst);
+		atomic_store_explicit(&thr[i].nullops, 0, memory_order_seq_cst);
 	}
 
 	delta = monotime_since(&tv, NULL);

--- a/tests/lib/test_seqlock.c
+++ b/tests/lib/test_seqlock.c
@@ -111,4 +111,5 @@ int main(int argc, char **argv)
 	writestr("main @release\n");
 	seqlock_release(&sqlo);
 	sleep(1);
+	pthread_join(thr1, NULL);
 }

--- a/tests/lib/test_seqlock.c
+++ b/tests/lib/test_seqlock.c
@@ -82,11 +82,11 @@ int main(int argc, char **argv)
 	assert(seqlock_held(&sqlo));
 
 	assert(seqlock_cur(&sqlo) == 1);
-	assert(seqlock_bump(&sqlo) == 1);
-	assert(seqlock_cur(&sqlo) == 5);
 	assert(seqlock_bump(&sqlo) == 5);
+	assert(seqlock_cur(&sqlo) == 5);
 	assert(seqlock_bump(&sqlo) == 9);
 	assert(seqlock_bump(&sqlo) == 13);
+	assert(seqlock_bump(&sqlo) == 17);
 	assert(seqlock_cur(&sqlo) == 17);
 
 	assert(seqlock_held(&sqlo));


### PR DESCRIPTION
First go around and fix a bunch of mixups in test_seqlock, then make TSAN understand that the world is not on fire.

Fixes: #16244 (hopefully)