### PR TITLE
bgpd: fix do not use api.backup_nexthop in ZAPI message

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1331,10 +1331,7 @@ static void bgp_zebra_announce_parse_nexthop(
 							 &nh_weight))
 				continue;
 		}
-		if (CHECK_FLAG(info->flags, BGP_PATH_SELECTED))
-			api_nh = &api->nexthops[*valid_nh_count];
-		else
-			api_nh = &api->backup_nexthops[*valid_nh_count];
+		api_nh = &api->nexthops[*valid_nh_count];
 
 		api_nh->srte_color = bgp_attr_get_color(info->attr);
 


### PR DESCRIPTION
The backup_nexthop entry list has been populated by mistake, and should not. Fix this by reverting the introduced behavior.

Fixes: 237ebf8d4503 ("bgpd: rework bgp_zebra_announce() function, separate nexthop handling")