### PR TITLE
zebra: clear evpn dup-addr return error-msg when there is no vni

### DIFF
--- a/zebra/zebra_nb_rpcs.c
+++ b/zebra/zebra_nb_rpcs.c
@@ -12,6 +12,8 @@
 #include "zebra/zebra_router.h"
 #include "zebra/zebra_vrf.h"
 #include "zebra/zebra_vxlan.h"
+#include "zebra/zebra_vxlan_if.h"
+#include "zebra/zebra_evpn.h"
 
 /*
  * XPath: /frr-zebra:clear-evpn-dup-addr
@@ -21,6 +23,11 @@ int clear_evpn_dup_addr_rpc(struct nb_cb_rpc_args *args)
 	struct zebra_vrf *zvrf;
 	int ret = NB_OK;
 
+	if (!is_evpn_enabled()) {
+		snprintf(args->errmsg, args->errmsg_len,
+			 "%% EVPN not enabled\n");
+		return NB_ERR_VALIDATION;
+	}
 	zvrf = zebra_vrf_get_evpn();
 
 	if (yang_dnode_exists(args->input, "all-vnis")) {
@@ -29,6 +36,12 @@ int clear_evpn_dup_addr_rpc(struct nb_cb_rpc_args *args)
 		vni_t vni = yang_dnode_get_uint32(args->input, "vni-id");
 		struct ipaddr host_ip = {.ipa_type = IPADDR_NONE};
 		struct ethaddr mac;
+
+		if (!zebra_evpn_lookup(vni)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "%% VNI %u does not exist\n", vni);
+			return NB_ERR_VALIDATION;
+		}
 
 		if (yang_dnode_exists(args->input, "mac-addr")) {
 			yang_dnode_get_mac(&mac, args->input, "mac-addr");


### PR DESCRIPTION
clear evpn dup-addr cli returns error-msg for below conditions,

 - If evpn is not enabled &
 - If there is no VNI exists.

supported command:

```
clear evpn dup-addr vni <vni-id>
```


Testing:

```
bharat# clear evpn dup-addr vni 20
Error type: validation
Error description: % EVPN not enabled

bharat# clear evpn dup-addr vni 20
Error type: validation
Error description: % VNI 20 does not exist
```

Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>
Signed-off-by: Chirag Shah <chirag@nvidia.com>
