### PR TITLE
Router pim config

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -55,16 +55,22 @@ Certain signals have special meanings to *pimd*.
 *pimd* invocation options. Common options that can be specified
 (:ref:`common-invocation-options`).
 
-.. clicmd:: ip pim rp A.B.C.D A.B.C.D/M
+PIM Routers
+-----------
+
+.. clicmd:: router pim [vrf NAME]
+   Configure global PIM protocol
+
+.. clicmd:: rp A.B.C.D A.B.C.D/M
 
    In order to use pim, it is necessary to configure a RP for join messages to
    be sent to. Currently the only methodology to do this is via static rp
    commands. All routers in the pim network must agree on these values. The
    first ip address is the RP's address and the second value is the matching
    prefix of group ranges covered. This command is vrf aware, to configure for
-   a vrf, enter the vrf submode.
+   a vrf, specify the vrf in the router pim block.
 
-.. clicmd:: ip pim rp keep-alive-timer (1-65535)
+.. clicmd:: rp keep-alive-timer (1-65535)
 
    Modify the time out value for a S,G flow from 1-65535 seconds at RP.
    The normal keepalive period for the KAT(S,G) defaults to 210 seconds.
@@ -74,41 +80,41 @@ Certain signals have special meanings to *pimd*.
    max(Keepalive_Period, RP_Keepalive_Period) when a Register-Stop is sent.
    If choosing a value below 31 seconds be aware that some hardware platforms
    cannot see data flowing in better than 30 second chunks. This command is
-   vrf aware, to configure for a vrf, enter the vrf submode.
+   vrf aware, to configure for a vrf, specify the vrf in the router pim block.
 
-.. clicmd:: ip pim register-accept-list PLIST
+.. clicmd:: register-accept-list PLIST
 
    When pim receives a register packet the source of the packet will be compared
    to the prefix-list specified, PLIST, and if a permit is received normal
    processing continues.  If a deny is returned for the source address of the
    register packet a register stop message is sent to the source.
 
-.. clicmd:: ip pim spt-switchover infinity-and-beyond [prefix-list PLIST]
+.. clicmd:: spt-switchover infinity-and-beyond [prefix-list PLIST]
 
    On the last hop router if it is desired to not switch over to the SPT tree
    configure this command. Optional parameter prefix-list can be use to control
    which groups to switch or not switch. If a group is PERMIT as per the
    PLIST, then the SPT switchover does not happen for it and if it is DENY,
    then the SPT switchover happens.
-   This command is vrf aware, to configure for a vrf,
-   enter the vrf submode.
+   This command is vrf aware, to configure for a vrf, specify the vrf in the
+   router pim block.
 
-.. clicmd:: ip pim ecmp
+.. clicmd:: ecmp
 
    If pim has the a choice of ECMP nexthops for a particular RPF, pim will
    cause S,G flows to be spread out amongst the nexthops. If this command is
    not specified then the first nexthop found will be used. This command is vrf
-   aware, to configure for a vrf, enter the vrf submode.
+   aware, to configure for a vrf, specify the vrf in the router pim block.
 
-.. clicmd:: ip pim ecmp rebalance
+.. clicmd:: ecmp rebalance
 
    If pim is using ECMP and an interface goes down, cause pim to rebalance all
    S,G flows across the remaining nexthops. If this command is not configured
    pim only modifies those S,G flows that were using the interface that went
-   down. This command is vrf aware, to configure for a vrf, enter the vrf
-   submode.
+   down. This command is vrf aware, to configure for a vrf, specify the vrf in
+   the router pim block.
 
-.. clicmd:: ip pim join-prune-interval (1-65535)
+.. clicmd:: join-prune-interval (1-65535)
 
    Modify the join/prune interval that pim uses to the new value. Time is
    specified in seconds. This command is vrf aware, to configure for a vrf,
@@ -116,39 +122,42 @@ Certain signals have special meanings to *pimd*.
    a value smaller than 60 seconds be aware that this can and will affect
    convergence at scale.
 
-.. clicmd:: ip pim keep-alive-timer (1-65535)
+.. clicmd:: keep-alive-timer (1-65535)
 
    Modify the time out value for a S,G flow from 1-65535 seconds. If choosing
    a value below 31 seconds be aware that some hardware platforms cannot see data
    flowing in better than 30 second chunks. This command is vrf aware, to
-   configure for a vrf, enter the vrf submode.
+   configure for a vrf, specify the vrf in the router pim block.
 
-.. clicmd:: ip pim packets (1-255)
+.. clicmd:: packets (1-255)
 
    When processing packets from a neighbor process the number of packets
    incoming at one time before moving on to the next task. The default value is
    3 packets.  This command is only useful at scale when you can possibly have
    a large number of pim control packets flowing. This command is vrf aware, to
-   configure for a vrf, enter the vrf submode.
+   configure for a vrf, specify the vrf in the router pim block.
 
-.. clicmd:: ip pim register-suppress-time (1-65535)
+.. clicmd:: register-suppress-time (1-65535)
 
    Modify the time that pim will register suppress a FHR will send register
    notifications to the kernel. This command is vrf aware, to configure for a
-   vrf, enter the vrf submode.
+   vrf, specify the vrf in the router pim block.
 
-.. clicmd:: ip pim send-v6-secondary
+.. clicmd:: send-v6-secondary
 
    When sending pim hello packets tell pim to send any v6 secondary addresses
    on the interface. This information is used to allow pim to use v6 nexthops
    in it's decision for RPF lookup. This command is vrf aware, to configure for
-   a vrf, enter the vrf submode.
+   a vrf, specify the vrf in the router pim block.
 
-.. clicmd:: ip pim ssm prefix-list WORD
+.. clicmd:: ssm prefix-list WORD
 
    Specify a range of group addresses via a prefix-list that forces pim to
-   never do SM over. This command is vrf aware, to configure for a vrf, enter
-   the vrf submode.
+   never do SM over. This command is vrf aware, to configure for a vrf, specify
+   the vrf in the router pim block.
+
+Global Multicast
+----------------
 
 .. clicmd:: ip multicast rpf-lookup-mode WORD
 
@@ -334,11 +343,12 @@ MSDP can be setup in different ways:
 .. note::
 
    MSDP default peer and SA filtering is not implemented.
+   MSDP configuration is available under 'router pim'
 
 
 Commands available for MSDP:
 
-.. clicmd:: ip msdp timers (1-65535) (1-65535) [(1-65535)]
+.. clicmd:: msdp timers (1-65535) (1-65535) [(1-65535)]
 
    Configure global MSDP timers.
 
@@ -354,16 +364,16 @@ Commands available for MSDP:
    configures the interval between connection attempts. The default value
    is 30 seconds.
 
-.. clicmd:: ip msdp mesh-group WORD member A.B.C.D
+.. clicmd:: msdp mesh-group WORD member A.B.C.D
 
    Create or update a mesh group to include the specified MSDP peer.
 
-.. clicmd:: ip msdp mesh-group WORD source A.B.C.D
+.. clicmd:: msdp mesh-group WORD source A.B.C.D
 
    Create or update a mesh group to set the source address used to connect to
    peers.
 
-.. clicmd:: ip msdp peer A.B.C.D source A.B.C.D
+.. clicmd:: msdp peer A.B.C.D source A.B.C.D
 
    Create a regular MSDP session with peer using the specified source address.
 
@@ -734,8 +744,9 @@ Sample configuration
    ! You may want to enable ssmpingd for troubleshooting
    ! See http://www.venaas.no/multicast/ssmping/
    !
-   ip ssmpingd 1.1.1.1
-   ip ssmpingd 2.2.2.2
+   router pim
+    ssmpingd 1.1.1.1
+    ssmpingd 2.2.2.2
 
    ! HINTS:
    !  - Enable "ip pim ssm" on the interface directly attached to the

--- a/doc/user/pimv6.rst
+++ b/doc/user/pimv6.rst
@@ -47,21 +47,28 @@ Certain signals have special meanings to *pim6d*.
 *pim6d* invocation options. Common options that can be specified
 (:ref:`common-invocation-options`).
 
-.. clicmd:: ipv6 pim rp X:X::X:X Y:Y::Y:Y/M
+PIMv6 Router
+------------
+
+.. clicmd:: router pim6 [vrf NAME]
+
+   Configure the global PIMv6 protocol
+
+.. clicmd:: rp X:X::X:X Y:Y::Y:Y/M
 
    In order to use pimv6, it is necessary to configure a RP for join messages to
    be sent to. Currently the only methodology to do this is via static rp
    commands. All routers in the pimv6 network must agree on these values. The
    first ipv6 address is the RP's address and the second value is the matching
    prefix of group ranges covered. This command is vrf aware, to configure for
-   a vrf, enter the vrf submode.
+   a vrf, specify the vrf in the router pim6 block.
 
-.. clicmd:: ipv6 pim rp X:X::X:X prefix-list WORD
+.. clicmd:: rp X:X::X:X prefix-list WORD
 
    This CLI helps in configuring RP address for a range of groups specified
    by the prefix-list.
 
-.. clicmd:: ipv6 pim rp keep-alive-timer (1-65535)
+.. clicmd:: rp keep-alive-timer (1-65535)
 
    Modify the time out value for a S,G flow from 1-65535 seconds at RP.
    The normal keepalive period for the KAT(S,G) defaults to 210 seconds.
@@ -71,19 +78,19 @@ Certain signals have special meanings to *pim6d*.
    max(Keepalive_Period, RP_Keepalive_Period) when a Register-Stop is sent.
    If choosing a value below 31 seconds be aware that some hardware platforms
    cannot see data flowing in better than 30 second chunks. This command is
-   vrf aware, to configure for a vrf, enter the vrf submode.
+   vrf aware, to configure for a vrf, specify the vrf in the router pim6 block.
 
-.. clicmd:: ipv6 pim spt-switchover infinity-and-beyond [prefix-list PLIST]
+.. clicmd:: spt-switchover infinity-and-beyond [prefix-list PLIST]
 
    On the last hop router if it is desired to not switch over to the SPT tree
    configure this command. Optional parameter prefix-list can be use to control
    which groups to switch or not switch. If a group is PERMIT as per the
    PLIST, then the SPT switchover does not happen for it and if it is DENY,
    then the SPT switchover happens.
-   This command is vrf aware, to configure for a vrf,
-   enter the vrf submode.
+   This command is vrf aware, to configure for a vrf, specify the vrf in the
+   router pim6 block.
 
-.. clicmd:: ipv6 pim join-prune-interval (1-65535)
+.. clicmd:: join-prune-interval (1-65535)
 
    Modify the join/prune interval that pim uses to the new value. Time is
    specified in seconds. This command is vrf aware, to configure for a vrf,
@@ -91,28 +98,28 @@ Certain signals have special meanings to *pim6d*.
    a value smaller than 60 seconds be aware that this can and will affect
    convergence at scale.
 
-.. clicmd:: ipv6 pim keep-alive-timer (1-65535)
+.. clicmd:: keep-alive-timer (1-65535)
 
    Modify the time out value for a S,G flow from 1-65535 seconds. If choosing
    a value below 31 seconds be aware that some hardware platforms cannot see data
    flowing in better than 30 second chunks. This command is vrf aware, to
-   configure for a vrf, enter the vrf submode.
+   configure for a vrf, specify the vrf in the router pim6 block.
 
-.. clicmd:: ipv6 pim packets (1-255)
+.. clicmd:: packets (1-255)
 
    When processing packets from a neighbor process the number of packets
    incoming at one time before moving on to the next task. The default value is
    3 packets.  This command is only useful at scale when you can possibly have
    a large number of pim control packets flowing. This command is vrf aware, to
-   configure for a vrf, enter the vrf submode.
+   configure for a vrf, specify the vrf in the router pim6 block.
 
-.. clicmd:: ipv6 pim register-suppress-time (1-65535)
+.. clicmd:: register-suppress-time (1-65535)
 
    Modify the time that pim will register suppress a FHR will send register
    notifications to the kernel. This command is vrf aware, to configure for a
-   vrf, enter the vrf submode.
+   vrf, specify the vrf in the router pim6 block.
 
-.. clicmd:: ipv6 ssmpingd [X:X::X:X]
+.. clicmd:: ssmpingd [X:X::X:X]
 
    Enable ipv6 ssmpingd configuration. A network level management tool
    to check whether one can receive multicast packets via SSM from host.
@@ -417,7 +424,7 @@ Clear commands reset various variables.
 
 .. clicmd:: clear ipv6 pim [vrf NAME] interface traffic
 
-   When this command is issued, resets the information about the 
+   When this command is issued, resets the information about the
    number of PIM protocol packets sent/received on an interface.
 
 .. clicmd:: clear ipv6 pim oil
@@ -494,7 +501,7 @@ the config was written out.
 
 .. clicmd:: debug mld trace [detail]
 
-   This traces mld code and how it is running. 
+   This traces mld code and how it is running.
 
 .. clicmd:: debug pimv6 bsm
 

--- a/lib/command.h
+++ b/lib/command.h
@@ -182,6 +182,8 @@ enum node_type {
 	ISIS_SRV6_NODE_MSD_NODE,    /* ISIS SRv6 Node MSDs node */
 	MGMTD_NODE,		 /* MGMTD node. */
 	RPKI_VRF_NODE,  /* RPKI node for VRF */
+	PIM_NODE,		 /* PIM protocol mode */
+	PIM6_NODE,		 /* PIM protocol for IPv6 mode */
 	NODE_TYPE_MAX, /* maximum */
 };
 /* clang-format on */

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -41,45 +41,207 @@ static struct cmd_node debug_node = {
 	.config_write = pim_debug_config_write,
 };
 
-DEFPY (ipv6_pim_joinprune_time,
-       ipv6_pim_joinprune_time_cmd,
-       "ipv6 pim join-prune-interval (1-65535)$jpi",
-       IPV6_STR
-       PIM_STR
+DEFPY_NOSH (router_pim6,
+            router_pim6_cmd,
+            "router pim6 [vrf NAME]",
+            "Enable a routing process\n"
+            "Start PIM6 configuration\n"
+            VRF_CMD_HELP_STR)
+{
+	char xpath[XPATH_MAXLEN];
+	const char *vrf_name;
+
+	if (vrf)
+		vrf_name = vrf;
+	else
+		vrf_name = VRF_DEFAULT_NAME;
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim",
+		 vrf_name, FRR_PIM_AF_XPATH_VAL);
+	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+	if (nb_cli_apply_changes_clear_pending(vty, NULL) != CMD_SUCCESS)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	VTY_PUSH_XPATH(PIM6_NODE, xpath);
+
+	return CMD_SUCCESS;
+}
+
+DEFPY (no_router_pim6,
+       no_router_pim6_cmd,
+       "no router pim6 [vrf NAME]",
+       NO_STR
+       "Enable a routing process\n"
+       "Start PIM6 configuration\n"
+       VRF_CMD_HELP_STR)
+{
+	char xpath[XPATH_MAXLEN];
+	const char *vrf_name;
+
+	if (vrf)
+		vrf_name = vrf;
+	else
+		vrf_name = VRF_DEFAULT_NAME;
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim",
+		 vrf_name, FRR_PIM_AF_XPATH_VAL);
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY (pim6_joinprune_time,
+       pim6_joinprune_time_cmd,
+       "join-prune-interval (1-65535)$jpi",
        "Join Prune Send Interval\n"
        "Seconds\n")
 {
 	return pim_process_join_prune_cmd(vty, jpi_str);
 }
+DEFPY_ATTR(ipv6_joinprune_time,
+           ipv6_pim_joinprune_time_cmd,
+           "ipv6 pim join-prune-interval (1-65535)$jpi",
+           IPV6_STR PIM_STR
+           "Join Prune Send Interval\n"
+           "Seconds\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (no_ipv6_pim_joinprune_time,
-       no_ipv6_pim_joinprune_time_cmd,
-       "no ipv6 pim join-prune-interval [(1-65535)]",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_join_prune_cmd(vty, jpi_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim6_joinprune_time,
+       no_pim6_joinprune_time_cmd,
+       "no join-prune-interval [(1-65535)]",
        NO_STR
-       IPV6_STR
-       PIM_STR
        "Join Prune Send Interval\n"
        IGNORED_IN_NO_STR)
 {
 	return pim_process_no_join_prune_cmd(vty);
 }
+DEFPY_ATTR(no_ipv6_pim_joinprune_time,
+           no_ipv6_pim_joinprune_time_cmd,
+           "no ipv6 pim join-prune-interval [(1-65535)]",
+           NO_STR
+           IPV6_STR
+           PIM_STR
+           "Join Prune Send Interval\n"
+           IGNORED_IN_NO_STR,
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ipv6_pim_spt_switchover_infinity,
-       ipv6_pim_spt_switchover_infinity_cmd,
-       "ipv6 pim spt-switchover infinity-and-beyond",
-       IPV6_STR
-       PIM_STR
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_join_prune_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim6_spt_switchover_infinity,
+       pim6_spt_switchover_infinity_cmd,
+       "spt-switchover infinity-and-beyond",
        "SPT-Switchover\n"
        "Never switch to SPT Tree\n")
 {
 	return pim_process_spt_switchover_infinity_cmd(vty);
 }
+DEFPY_ATTR(ipv6_spt_switchover_infinity,
+           ipv6_pim_spt_switchover_infinity_cmd,
+           "ipv6 pim spt-switchover infinity-and-beyond",
+           IPV6_STR
+           PIM_STR
+           "SPT-Switchover\n"
+           "Never switch to SPT Tree\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ipv6_pim_spt_switchover_infinity_plist,
-       ipv6_pim_spt_switchover_infinity_plist_cmd,
-       "ipv6 pim spt-switchover infinity-and-beyond prefix-list PREFIXLIST6_NAME$plist",
-       IPV6_STR
-       PIM_STR
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_spt_switchover_infinity_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim6_spt_switchover_infinity_plist,
+       pim6_spt_switchover_infinity_plist_cmd,
+       "spt-switchover infinity-and-beyond prefix-list PREFIXLIST6_NAME$plist",
        "SPT-Switchover\n"
        "Never switch to SPT Tree\n"
        "Prefix-List to control which groups to switch\n"
@@ -87,25 +249,104 @@ DEFPY (ipv6_pim_spt_switchover_infinity_plist,
 {
 	return pim_process_spt_switchover_prefixlist_cmd(vty, plist);
 }
+DEFPY_ATTR(ipv6_spt_switchover_infinity_plist,
+           ipv6_pim_spt_switchover_infinity_plist_cmd,
+           "ipv6 pim spt-switchover infinity-and-beyond prefix-list PREFIXLIST6_NAME$plist",
+           IPV6_STR
+           PIM_STR
+           "SPT-Switchover\n"
+           "Never switch to SPT Tree\n"
+           "Prefix-List to control which groups to switch\n"
+           "Prefix-List name\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (no_ipv6_pim_spt_switchover_infinity,
-       no_ipv6_pim_spt_switchover_infinity_cmd,
-       "no ipv6 pim spt-switchover infinity-and-beyond",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_spt_switchover_prefixlist_cmd(vty, plist);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim6_spt_switchover_infinity,
+       no_pim6_spt_switchover_infinity_cmd,
+       "no spt-switchover infinity-and-beyond",
        NO_STR
-       IPV6_STR
-       PIM_STR
        "SPT_Switchover\n"
        "Never switch to SPT Tree\n")
 {
 	return pim_process_no_spt_switchover_cmd(vty);
 }
+DEFPY_ATTR(no_ipv6_pim_spt_switchover_infinity,
+           no_ipv6_pim_spt_switchover_infinity_cmd,
+           "no ipv6 pim spt-switchover infinity-and-beyond",
+           NO_STR
+           IPV6_STR
+           PIM_STR
+           "SPT_Switchover\n"
+           "Never switch to SPT Tree\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (no_ipv6_pim_spt_switchover_infinity_plist,
-       no_ipv6_pim_spt_switchover_infinity_plist_cmd,
-       "no ipv6 pim spt-switchover infinity-and-beyond prefix-list PREFIXLIST6_NAME",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_spt_switchover_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim6_spt_switchover_infinity_plist,
+       no_pim6_spt_switchover_infinity_plist_cmd,
+       "no spt-switchover infinity-and-beyond prefix-list PREFIXLIST6_NAME",
        NO_STR
-       IPV6_STR
-       PIM_STR
        "SPT_Switchover\n"
        "Never switch to SPT Tree\n"
        "Prefix-List to control which groups to switch\n"
@@ -113,99 +354,452 @@ DEFPY (no_ipv6_pim_spt_switchover_infinity_plist,
 {
 	return pim_process_no_spt_switchover_cmd(vty);
 }
+DEFPY_ATTR(no_ipv6_pim_spt_switchover_infinity_plist,
+           no_ipv6_pim_spt_switchover_infinity_plist_cmd,
+           "no ipv6 pim spt-switchover infinity-and-beyond prefix-list PREFIXLIST6_NAME",
+           NO_STR
+           IPV6_STR
+           PIM_STR
+           "SPT_Switchover\n"
+           "Never switch to SPT Tree\n"
+           "Prefix-List to control which groups to switch\n"
+           "Prefix-List name\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ipv6_pim_packets,
-       ipv6_pim_packets_cmd,
-       "ipv6 pim packets (1-255)",
-       IPV6_STR
-       PIM_STR
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_spt_switchover_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim6_packets,
+       pim6_packets_cmd,
+       "packets (1-255)",
        "packets to process at one time per fd\n"
        "Number of packets\n")
 {
 	return pim_process_pim_packet_cmd(vty, packets_str);
 }
+DEFPY_ATTR(ipv6_pim_packets,
+           ipv6_pim_packets_cmd,
+           "ipv6 pim packets (1-255)",
+           IPV6_STR
+           PIM_STR
+           "packets to process at one time per fd\n"
+           "Number of packets\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (no_ipv6_pim_packets,
-       no_ipv6_pim_packets_cmd,
-       "no ipv6 pim packets [(1-255)]",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_pim_packet_cmd(vty, packets_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim6_packets,
+       no_pim6_packets_cmd,
+       "no packets [(1-255)]",
        NO_STR
-       IPV6_STR
-       PIM_STR
        "packets to process at one time per fd\n"
        IGNORED_IN_NO_STR)
 {
 	return pim_process_no_pim_packet_cmd(vty);
 }
+DEFPY_ATTR(no_ipv6_pim_packets,
+           no_ipv6_pim_packets_cmd,
+           "no ipv6 pim packets [(1-255)]",
+           NO_STR
+           IPV6_STR
+           PIM_STR
+           "packets to process at one time per fd\n"
+           IGNORED_IN_NO_STR,
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ipv6_pim_keep_alive,
-       ipv6_pim_keep_alive_cmd,
-       "ipv6 pim keep-alive-timer (1-65535)$kat",
-       IPV6_STR
-       PIM_STR
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_pim_packet_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim6_keep_alive,
+       pim6_keep_alive_cmd,
+       "keep-alive-timer (1-65535)$kat",
        "Keep alive Timer\n"
        "Seconds\n")
 {
 	return pim_process_keepalivetimer_cmd(vty, kat_str);
 }
+DEFPY_ATTR(ipv6_pim_keep_alive,
+           ipv6_pim_keep_alive_cmd,
+           "ipv6 pim keep-alive-timer (1-65535)$kat",
+           IPV6_STR
+           PIM_STR
+           "Keep alive Timer\n"
+           "Seconds\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (no_ipv6_pim_keep_alive,
-       no_ipv6_pim_keep_alive_cmd,
-       "no ipv6 pim keep-alive-timer [(1-65535)]",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_keepalivetimer_cmd(vty, kat_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim6_keep_alive,
+       no_pim6_keep_alive_cmd,
+       "no keep-alive-timer [(1-65535)]",
        NO_STR
-       IPV6_STR
-       PIM_STR
        "Keep alive Timer\n"
        IGNORED_IN_NO_STR)
 {
 	return pim_process_no_keepalivetimer_cmd(vty);
 }
+DEFPY_ATTR(no_ipv6_pim_keep_alive,
+           no_ipv6_pim_keep_alive_cmd,
+           "no ipv6 pim keep-alive-timer [(1-65535)]",
+           NO_STR
+           IPV6_STR
+           PIM_STR
+           "Keep alive Timer\n"
+           IGNORED_IN_NO_STR,
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ipv6_pim_rp_keep_alive,
-       ipv6_pim_rp_keep_alive_cmd,
-       "ipv6 pim rp keep-alive-timer (1-65535)$kat",
-       IPV6_STR
-       PIM_STR
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_keepalivetimer_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim6_rp_keep_alive,
+       pim6_rp_keep_alive_cmd,
+       "rp keep-alive-timer (1-65535)$kat",
        "Rendezvous Point\n"
        "Keep alive Timer\n"
        "Seconds\n")
 {
 	return pim_process_rp_kat_cmd(vty, kat_str);
 }
+DEFPY_ATTR(ipv6_pim_rp_keep_alive,
+           ipv6_pim_rp_keep_alive_cmd,
+           "ipv6 pim rp keep-alive-timer (1-65535)$kat",
+           IPV6_STR
+           PIM_STR
+           "Rendezvous Point\n"
+           "Keep alive Timer\n"
+           "Seconds\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (no_ipv6_pim_rp_keep_alive,
-       no_ipv6_pim_rp_keep_alive_cmd,
-       "no ipv6 pim rp keep-alive-timer [(1-65535)]",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_rp_kat_cmd(vty, kat_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim6_rp_keep_alive,
+       no_pim6_rp_keep_alive_cmd,
+       "no rp keep-alive-timer [(1-65535)]",
        NO_STR
-       IPV6_STR
-       PIM_STR
        "Rendezvous Point\n"
        "Keep alive Timer\n"
        IGNORED_IN_NO_STR)
 {
 	return pim_process_no_rp_kat_cmd(vty);
 }
+DEFPY_ATTR(no_ipv6_pim_rp_keep_alive,
+           no_ipv6_pim_rp_keep_alive_cmd,
+           "no ipv6 pim rp keep-alive-timer [(1-65535)]",
+           NO_STR
+           IPV6_STR
+           PIM_STR
+           "Rendezvous Point\n"
+           "Keep alive Timer\n"
+           IGNORED_IN_NO_STR,
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ipv6_pim_register_suppress,
-       ipv6_pim_register_suppress_cmd,
-       "ipv6 pim register-suppress-time (1-65535)$rst",
-       IPV6_STR
-       PIM_STR
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_rp_kat_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim6_register_suppress,
+       pim6_register_suppress_cmd,
+       "register-suppress-time (1-65535)$rst",
        "Register Suppress Timer\n"
        "Seconds\n")
 {
 	return pim_process_register_suppress_cmd(vty, rst_str);
 }
+DEFPY_ATTR(ipv6_pim_register_suppress,
+           ipv6_pim_register_suppress_cmd,
+           "ipv6 pim register-suppress-time (1-65535)$rst",
+           IPV6_STR
+           PIM_STR
+           "Register Suppress Timer\n"
+           "Seconds\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (no_ipv6_pim_register_suppress,
-       no_ipv6_pim_register_suppress_cmd,
-       "no ipv6 pim register-suppress-time [(1-65535)]",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_register_suppress_cmd(vty, rst_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim6_register_suppress,
+       no_pim6_register_suppress_cmd,
+       "no register-suppress-time [(1-65535)]",
        NO_STR
-       IPV6_STR
-       PIM_STR
        "Register Suppress Timer\n"
        IGNORED_IN_NO_STR)
 {
 	return pim_process_no_register_suppress_cmd(vty);
+}
+DEFPY_ATTR(no_ipv6_pim_register_suppress,
+           no_ipv6_pim_register_suppress_cmd,
+           "no ipv6 pim register-suppress-time [(1-65535)]",
+           NO_STR
+           IPV6_STR
+           PIM_STR
+           "Register Suppress Timer\n"
+           IGNORED_IN_NO_STR,
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_register_suppress_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
 }
 
 DEFPY (interface_ipv6_pim,
@@ -405,11 +999,9 @@ DEFPY (interface_no_ipv6_mroute,
 					    source_str);
 }
 
-DEFPY (ipv6_pim_rp,
-       ipv6_pim_rp_cmd,
-       "ipv6 pim rp X:X::X:X$rp [X:X::X:X/M]$gp",
-       IPV6_STR
-       PIM_STR
+DEFPY (pim6_rp,
+       pim6_rp_cmd,
+       "rp X:X::X:X$rp [X:X::X:X/M]$gp",
        "Rendezvous Point\n"
        "ipv6 address of RP\n"
        "Group Address range to cover\n")
@@ -418,13 +1010,53 @@ DEFPY (ipv6_pim_rp,
 
 	return pim_process_rp_cmd(vty, rp_str, group_str);
 }
+DEFPY_ATTR(ipv6_pim_rp,
+           ipv6_pim_rp_cmd,
+           "ipv6 pim rp X:X::X:X$rp [X:X::X:X/M]$gp",
+           IPV6_STR
+           PIM_STR
+           "Rendezvous Point\n"
+           "ipv6 address of RP\n"
+           "Group Address range to cover\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *group_str = (gp_str) ? gp_str : "FF00::0/8";
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (no_ipv6_pim_rp,
-       no_ipv6_pim_rp_cmd,
-       "no ipv6 pim rp X:X::X:X$rp [X:X::X:X/M]$gp",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_rp_cmd(vty, rp_str, group_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim6_rp,
+       no_pim6_rp_cmd,
+       "no rp X:X::X:X$rp [X:X::X:X/M]$gp",
        NO_STR
-       IPV6_STR
-       PIM_STR
        "Rendezvous Point\n"
        "ipv6 address of RP\n"
        "Group Address range to cover\n")
@@ -433,12 +1065,53 @@ DEFPY (no_ipv6_pim_rp,
 
 	return pim_process_no_rp_cmd(vty, rp_str, group_str);
 }
+DEFPY_ATTR(no_ipv6_pim_rp,
+           no_ipv6_pim_rp_cmd,
+           "no ipv6 pim rp X:X::X:X$rp [X:X::X:X/M]$gp",
+           NO_STR
+           IPV6_STR
+           PIM_STR
+           "Rendezvous Point\n"
+           "ipv6 address of RP\n"
+           "Group Address range to cover\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *group_str = (gp_str) ? gp_str : "FF00::0/8";
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ipv6_pim_rp_prefix_list,
-       ipv6_pim_rp_prefix_list_cmd,
-       "ipv6 pim rp X:X::X:X$rp prefix-list PREFIXLIST6_NAME$plist",
-       IPV6_STR
-       PIM_STR
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_rp_cmd(vty, rp_str, group_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim6_rp_prefix_list,
+       pim6_rp_prefix_list_cmd,
+       "rp X:X::X:X$rp prefix-list PREFIXLIST6_NAME$plist",
        "Rendezvous Point\n"
        "ipv6 address of RP\n"
        "group prefix-list filter\n"
@@ -446,19 +1119,102 @@ DEFPY (ipv6_pim_rp_prefix_list,
 {
 	return pim_process_rp_plist_cmd(vty, rp_str, plist);
 }
+DEFPY_ATTR(ipv6_pim_rp_prefix_list,
+           ipv6_pim_rp_prefix_list_cmd,
+           "ipv6 pim rp X:X::X:X$rp prefix-list PREFIXLIST6_NAME$plist",
+           IPV6_STR
+           PIM_STR
+           "Rendezvous Point\n"
+           "ipv6 address of RP\n"
+           "group prefix-list filter\n"
+           "Name of a prefix-list\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (no_ipv6_pim_rp_prefix_list,
-       no_ipv6_pim_rp_prefix_list_cmd,
-       "no ipv6 pim rp X:X::X:X$rp prefix-list PREFIXLIST6_NAME$plist",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_rp_plist_cmd(vty, rp_str, plist);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim6_rp_prefix_list,
+       no_pim6_rp_prefix_list_cmd,
+       "no rp X:X::X:X$rp prefix-list PREFIXLIST6_NAME$plist",
        NO_STR
-       IPV6_STR
-       PIM_STR
        "Rendezvous Point\n"
        "ipv6 address of RP\n"
        "group prefix-list filter\n"
        "Name of a prefix-list\n")
 {
 	return pim_process_no_rp_plist_cmd(vty, rp_str, plist);
+}
+DEFPY_ATTR(no_ipv6_pim_rp_prefix_list,
+           no_ipv6_pim_rp_prefix_list_cmd,
+           "no ipv6 pim rp X:X::X:X$rp prefix-list PREFIXLIST6_NAME$plist",
+           NO_STR
+           IPV6_STR
+           PIM_STR
+           "Rendezvous Point\n"
+           "ipv6 address of RP\n"
+           "group prefix-list filter\n"
+           "Name of a prefix-list\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_rp_plist_cmd(vty, rp_str, plist);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
 }
 
 DEFPY (ipv6_pim_bsm,
@@ -503,10 +1259,9 @@ DEFPY (no_ipv6_pim_ucast_bsm,
 	return pim_process_no_unicast_bsm_cmd(vty);
 }
 
-DEFPY (ipv6_ssmpingd,
-      ipv6_ssmpingd_cmd,
-      "ipv6 ssmpingd [X:X::X:X]$source",
-      IPV6_STR
+DEFPY (pim6_ssmpingd,
+       pim6_ssmpingd_cmd,
+       "ssmpingd [X:X::X:X]$source",
       CONF_SSMPINGD_STR
       "Source address\n")
 {
@@ -514,19 +1269,98 @@ DEFPY (ipv6_ssmpingd,
 
 	return pim_process_ssmpingd_cmd(vty, NB_OP_CREATE, src_str);
 }
+DEFPY_ATTR(ipv6_ssmpingd,
+           ipv6_ssmpingd_cmd,
+           "ipv6 ssmpingd [X:X::X:X]$source",
+           IPV6_STR
+           CONF_SSMPINGD_STR
+           "Source address\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *src_str = (source_str) ? source_str : "::";
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 
-DEFPY (no_ipv6_ssmpingd,
-      no_ipv6_ssmpingd_cmd,
-      "no ipv6 ssmpingd [X:X::X:X]$source",
-      NO_STR
-      IPV6_STR
-      CONF_SSMPINGD_STR
-      "Source address\n")
+	ret = pim_process_ssmpingd_cmd(vty, NB_OP_CREATE, src_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim6_ssmpingd,
+       no_pim6_ssmpingd_cmd,
+       "no ssmpingd [X:X::X:X]$source",
+       NO_STR
+       CONF_SSMPINGD_STR
+       "Source address\n")
 {
 	const char *src_str = (source_str) ? source_str : "::";
 
 	return pim_process_ssmpingd_cmd(vty, NB_OP_DESTROY, src_str);
+}
+DEFPY_ATTR(no_ipv6_ssmpingd,
+           no_ipv6_ssmpingd_cmd,
+           "no ipv6 ssmpingd [X:X::X:X]$source",
+           NO_STR
+           IPV6_STR
+           CONF_SSMPINGD_STR
+           "Source address\n",
+           CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *src_str = (source_str) ? source_str : "::";
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM6_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_ssmpingd_cmd(vty, NB_OP_DESTROY, src_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
 }
 
 DEFPY (interface_ipv6_mld_join,
@@ -1733,12 +2567,16 @@ DEFPY (debug_pimv6_bsm,
 	return CMD_SUCCESS;
 }
 
-void pim_cmd_init(void)
+struct cmd_node pim6_node = {
+	.name = "pim6",
+	.node = PIM6_NODE,
+	.parent_node = CONFIG_NODE,
+	.prompt = "%s(config-pim6)# ",
+	.config_write = pim_router_config_write,
+};
+
+static void pim_install_deprecated(void)
 {
-	if_cmd_init(pim_interface_config_write);
-
-	install_node(&debug_node);
-
 	install_element(CONFIG_NODE, &ipv6_pim_joinprune_time_cmd);
 	install_element(CONFIG_NODE, &no_ipv6_pim_joinprune_time_cmd);
 	install_element(CONFIG_NODE, &ipv6_pim_spt_switchover_infinity_cmd);
@@ -1753,28 +2591,6 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE, &no_ipv6_pim_rp_keep_alive_cmd);
 	install_element(CONFIG_NODE, &ipv6_pim_register_suppress_cmd);
 	install_element(CONFIG_NODE, &no_ipv6_pim_register_suppress_cmd);
-	install_element(INTERFACE_NODE, &interface_ipv6_pim_cmd);
-	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_cmd);
-	install_element(INTERFACE_NODE, &interface_ipv6_pim_drprio_cmd);
-	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_drprio_cmd);
-	install_element(INTERFACE_NODE, &interface_ipv6_pim_hello_cmd);
-	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_hello_cmd);
-	install_element(INTERFACE_NODE, &interface_ipv6_pim_activeactive_cmd);
-	install_element(INTERFACE_NODE, &interface_ipv6_pim_ssm_cmd);
-	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_ssm_cmd);
-	install_element(INTERFACE_NODE, &interface_ipv6_pim_sm_cmd);
-	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_sm_cmd);
-	install_element(INTERFACE_NODE,
-			&interface_ipv6_pim_boundary_oil_cmd);
-	install_element(INTERFACE_NODE,
-			&interface_no_ipv6_pim_boundary_oil_cmd);
-	install_element(INTERFACE_NODE, &interface_ipv6_mroute_cmd);
-	install_element(INTERFACE_NODE, &interface_no_ipv6_mroute_cmd);
-	/* Install BSM command */
-	install_element(INTERFACE_NODE, &ipv6_pim_bsm_cmd);
-	install_element(INTERFACE_NODE, &no_ipv6_pim_bsm_cmd);
-	install_element(INTERFACE_NODE, &ipv6_pim_ucast_bsm_cmd);
-	install_element(INTERFACE_NODE, &no_ipv6_pim_ucast_bsm_cmd);
 	install_element(CONFIG_NODE, &ipv6_pim_rp_cmd);
 	install_element(VRF_NODE, &ipv6_pim_rp_cmd);
 	install_element(CONFIG_NODE, &no_ipv6_pim_rp_cmd);
@@ -1787,6 +2603,69 @@ void pim_cmd_init(void)
 	install_element(VRF_NODE, &ipv6_ssmpingd_cmd);
 	install_element(CONFIG_NODE, &no_ipv6_ssmpingd_cmd);
 	install_element(VRF_NODE, &no_ipv6_ssmpingd_cmd);
+}
+
+void pim_cmd_init(void)
+{
+	if_cmd_init(pim_interface_config_write);
+
+	install_node(&debug_node);
+
+	pim_install_deprecated();
+
+	install_element(CONFIG_NODE, &router_pim6_cmd);
+	install_element(CONFIG_NODE, &no_router_pim6_cmd);
+
+	install_node(&pim6_node);
+	install_default(PIM6_NODE);
+
+	install_element(PIM6_NODE, &pim6_joinprune_time_cmd);
+	install_element(PIM6_NODE, &no_pim6_joinprune_time_cmd);
+	install_element(PIM6_NODE, &pim6_spt_switchover_infinity_cmd);
+	install_element(PIM6_NODE, &pim6_spt_switchover_infinity_plist_cmd);
+	install_element(PIM6_NODE, &no_pim6_spt_switchover_infinity_cmd);
+	install_element(PIM6_NODE, &no_pim6_spt_switchover_infinity_plist_cmd);
+	install_element(PIM6_NODE, &pim6_packets_cmd);
+	install_element(PIM6_NODE, &no_pim6_packets_cmd);
+	install_element(PIM6_NODE, &pim6_keep_alive_cmd);
+	install_element(PIM6_NODE, &no_pim6_keep_alive_cmd);
+	install_element(PIM6_NODE, &pim6_rp_keep_alive_cmd);
+	install_element(PIM6_NODE, &no_pim6_rp_keep_alive_cmd);
+	install_element(PIM6_NODE, &pim6_register_suppress_cmd);
+	install_element(PIM6_NODE, &no_pim6_register_suppress_cmd);
+	install_element(PIM6_NODE, &pim6_rp_cmd);
+	install_element(PIM6_NODE, &no_pim6_rp_cmd);
+	install_element(PIM6_NODE, &pim6_rp_prefix_list_cmd);
+	install_element(PIM6_NODE, &no_pim6_rp_prefix_list_cmd);
+	install_element(PIM6_NODE, &pim6_ssmpingd_cmd);
+	install_element(PIM6_NODE, &no_pim6_ssmpingd_cmd);
+
+	install_element(CONFIG_NODE, &ipv6_mld_group_watermark_cmd);
+	install_element(VRF_NODE, &ipv6_mld_group_watermark_cmd);
+	install_element(CONFIG_NODE, &no_ipv6_mld_group_watermark_cmd);
+	install_element(VRF_NODE, &no_ipv6_mld_group_watermark_cmd);
+
+	install_element(INTERFACE_NODE, &interface_ipv6_pim_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_pim_drprio_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_drprio_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_pim_hello_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_hello_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_pim_activeactive_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_pim_ssm_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_ssm_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_pim_sm_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_sm_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_pim_boundary_oil_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_boundary_oil_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_mroute_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_mroute_cmd);
+	/* Install BSM command */
+	install_element(INTERFACE_NODE, &ipv6_pim_bsm_cmd);
+	install_element(INTERFACE_NODE, &no_ipv6_pim_bsm_cmd);
+	install_element(INTERFACE_NODE, &ipv6_pim_ucast_bsm_cmd);
+	install_element(INTERFACE_NODE, &no_ipv6_pim_ucast_bsm_cmd);
+
 	install_element(INTERFACE_NODE, &interface_ipv6_mld_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ipv6_mld_cmd);
 	install_element(INTERFACE_NODE, &interface_ipv6_mld_join_cmd);
@@ -1796,10 +2675,6 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &interface_ipv6_mld_query_interval_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_no_ipv6_mld_query_interval_cmd);
-	install_element(CONFIG_NODE, &ipv6_mld_group_watermark_cmd);
-	install_element(VRF_NODE, &ipv6_mld_group_watermark_cmd);
-	install_element(CONFIG_NODE, &no_ipv6_mld_group_watermark_cmd);
-	install_element(VRF_NODE, &no_ipv6_mld_group_watermark_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_ipv6_mld_query_max_response_time_cmd);
 	install_element(INTERFACE_NODE,

--- a/pimd/pim_addr.h
+++ b/pimd/pim_addr.h
@@ -26,6 +26,7 @@ typedef struct prefix_ipv4 prefix_pim;
 #define PIM_MAX_BITLEN	IPV4_MAX_BITLEN
 #define PIM_AF_NAME     "ip"
 #define PIM_AF_DBG	"pim"
+#define PIM_AF_ROUTER	"pim"
 #define GM_AF_DBG	"igmp"
 #define PIM_MROUTE_DBG  "mroute"
 #define PIMREG          "pimreg"
@@ -58,6 +59,7 @@ typedef struct prefix_ipv6 prefix_pim;
 #define PIM_MAX_BITLEN	IPV6_MAX_BITLEN
 #define PIM_AF_NAME     "ipv6"
 #define PIM_AF_DBG	"pimv6"
+#define PIM_AF_ROUTER	"pim6"
 #define GM_AF_DBG	"mld"
 #define PIM_MROUTE_DBG  "mroute6"
 #define PIMREG          "pim6reg"

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1457,19 +1457,13 @@ static void clear_interfaces(struct pim_instance *pim)
 static void pim_cli_legacy_mesh_group_behavior(struct vty *vty,
 					       const char *gname)
 {
-	const char *vrfname;
 	char xpath_value[XPATH_MAXLEN];
 	char xpath_member_value[XPATH_MAXLEN];
 	const struct lyd_node *member_dnode;
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return;
-
 	/* Get mesh group base XPath. */
 	snprintf(xpath_value, sizeof(xpath_value),
-		 FRR_PIM_VRF_XPATH "/msdp-mesh-groups[name='%s']",
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4", gname);
+		 "%s/msdp-mesh-groups[name='%s']", VTY_CURR_XPATH, gname);
 	/* Group must exists, otherwise just quit. */
 	if (!yang_dnode_exists(vty->candidate_config->dnode, xpath_value))
 		return;
@@ -1477,8 +1471,7 @@ static void pim_cli_legacy_mesh_group_behavior(struct vty *vty,
 	/* Group members check: */
 	strlcpy(xpath_member_value, xpath_value, sizeof(xpath_member_value));
 	strlcat(xpath_member_value, "/members", sizeof(xpath_member_value));
-	if (yang_dnode_exists(vty->candidate_config->dnode,
-			      xpath_member_value)) {
+	if (yang_dnode_exists(vty->candidate_config->dnode, xpath_member_value)) {
 		member_dnode = yang_dnode_get(vty->candidate_config->dnode,
 					      xpath_member_value);
 		if (!member_dnode || !yang_is_last_list_dnode(member_dnode))
@@ -2989,22 +2982,108 @@ DEFUN (show_ip_ssmpingd,
 	return CMD_SUCCESS;
 }
 
-DEFUN (ip_pim_spt_switchover_infinity,
-       ip_pim_spt_switchover_infinity_cmd,
-       "ip pim spt-switchover infinity-and-beyond",
-       IP_STR
-       PIM_STR
+DEFPY_NOSH (router_pim,
+				router_pim_cmd,
+				"router pim [vrf NAME]",
+				"Enable a routing process\n"
+				"Start PIM configuration\n"
+				VRF_CMD_HELP_STR)
+{
+	char xpath[XPATH_MAXLEN];
+	const char *vrf_name;
+
+	if (vrf)
+		vrf_name = vrf;
+	else
+		vrf_name = VRF_DEFAULT_NAME;
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim",
+		 vrf_name, FRR_PIM_AF_XPATH_VAL);
+	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+	if (nb_cli_apply_changes_clear_pending(vty, NULL) != CMD_SUCCESS)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	VTY_PUSH_XPATH(PIM_NODE, xpath);
+	return CMD_SUCCESS;
+}
+
+DEFPY (no_router_pim,
+       no_router_pim_cmd,
+       "no router pim [vrf NAME]",
+       NO_STR
+       "Enable a routing process\n"
+       "Start PIM configuration\n"
+       VRF_CMD_HELP_STR)
+{
+	char xpath[XPATH_MAXLEN];
+	const char *vrf_name;
+
+	if (vrf)
+		vrf_name = vrf;
+	else
+		vrf_name = VRF_DEFAULT_NAME;
+
+	snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim",
+		 vrf_name, FRR_PIM_AF_XPATH_VAL);
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+
+DEFPY (pim_spt_switchover_infinity,
+       pim_spt_switchover_infinity_cmd,
+       "spt-switchover infinity-and-beyond",
        "SPT-Switchover\n"
        "Never switch to SPT Tree\n")
 {
 	return pim_process_spt_switchover_infinity_cmd(vty);
 }
+DEFPY_ATTR(ip_pim_spt_switchover_infinity,
+			  ip_pim_spt_switchover_infinity_cmd,
+			  "ip pim spt-switchover infinity-and-beyond",
+			  IP_STR
+			  PIM_STR
+			  "SPT-Switchover\n"
+			  "Never switch to SPT Tree\n",
+	   CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ip_pim_spt_switchover_infinity_plist,
-       ip_pim_spt_switchover_infinity_plist_cmd,
-       "ip pim spt-switchover infinity-and-beyond prefix-list PREFIXLIST4_NAME$plist",
-       IP_STR
-       PIM_STR
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_spt_switchover_infinity_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim_spt_switchover_infinity_plist,
+       pim_spt_switchover_infinity_plist_cmd,
+       "spt-switchover infinity-and-beyond prefix-list PREFIXLIST4_NAME$plist",
        "SPT-Switchover\n"
        "Never switch to SPT Tree\n"
        "Prefix-List to control which groups to switch\n"
@@ -3012,25 +3091,104 @@ DEFPY (ip_pim_spt_switchover_infinity_plist,
 {
 	return pim_process_spt_switchover_prefixlist_cmd(vty, plist);
 }
+DEFPY_ATTR(ip_pim_spt_switchover_infinity_plist,
+			  ip_pim_spt_switchover_infinity_plist_cmd,
+			  "ip pim spt-switchover infinity-and-beyond prefix-list PREFIXLIST4_NAME$plist",
+			  IP_STR
+			  PIM_STR
+			  "SPT-Switchover\n"
+			  "Never switch to SPT Tree\n"
+			  "Prefix-List to control which groups to switch\n"
+			  "Prefix-List name\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFUN (no_ip_pim_spt_switchover_infinity,
-       no_ip_pim_spt_switchover_infinity_cmd,
-       "no ip pim spt-switchover infinity-and-beyond",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_spt_switchover_prefixlist_cmd(vty, plist);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_spt_switchover_infinity,
+       no_pim_spt_switchover_infinity_cmd,
+       "no spt-switchover infinity-and-beyond",
        NO_STR
-       IP_STR
-       PIM_STR
        "SPT_Switchover\n"
        "Never switch to SPT Tree\n")
 {
 	return pim_process_no_spt_switchover_cmd(vty);
 }
+DEFPY_ATTR(no_ip_pim_spt_switchover_infinity,
+			  no_ip_pim_spt_switchover_infinity_cmd,
+			  "no ip pim spt-switchover infinity-and-beyond",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "SPT_Switchover\n"
+			  "Never switch to SPT Tree\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFUN (no_ip_pim_spt_switchover_infinity_plist,
-       no_ip_pim_spt_switchover_infinity_plist_cmd,
-       "no ip pim spt-switchover infinity-and-beyond prefix-list PREFIXLIST4_NAME",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_spt_switchover_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_spt_switchover_infinity_plist,
+       no_pim_spt_switchover_infinity_plist_cmd,
+       "no spt-switchover infinity-and-beyond prefix-list PREFIXLIST4_NAME",
        NO_STR
-       IP_STR
-       PIM_STR
        "SPT_Switchover\n"
        "Never switch to SPT Tree\n"
        "Prefix-List to control which groups to switch\n"
@@ -3038,28 +3196,61 @@ DEFUN (no_ip_pim_spt_switchover_infinity_plist,
 {
 	return pim_process_no_spt_switchover_cmd(vty);
 }
+DEFPY_ATTR(no_ip_pim_spt_switchover_infinity_plist,
+			  no_ip_pim_spt_switchover_infinity_plist_cmd,
+			  "no ip pim spt-switchover infinity-and-beyond prefix-list PREFIXLIST4_NAME",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "SPT_Switchover\n"
+			  "Never switch to SPT Tree\n"
+			  "Prefix-List to control which groups to switch\n"
+			  "Prefix-List name\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_spt_switchover_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
 
 DEFPY (pim_register_accept_list,
        pim_register_accept_list_cmd,
-       "[no] ip pim register-accept-list PREFIXLIST4_NAME$word",
+       "[no] register-accept-list PREFIXLIST4_NAME$word",
        NO_STR
-       IP_STR
-       PIM_STR
        "Only accept registers from a specific source prefix list\n"
        "Prefix-List name\n")
 {
-	const char *vrfname;
 	char reg_alist_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	snprintf(reg_alist_xpath, sizeof(reg_alist_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 "frr-routing:ipv4");
-	strlcat(reg_alist_xpath, "/register-accept-list",
-		sizeof(reg_alist_xpath));
+		 "./register-accept-list");
 
 	if (no)
 		nb_cli_enqueue_change(vty, reg_alist_xpath,
@@ -3070,122 +3261,559 @@ DEFPY (pim_register_accept_list,
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+DEFPY_ATTR(ip_pim_register_accept_list,
+			  ip_pim_register_accept_list_cmd,
+			  "[no] ip pim register-accept-list PREFIXLIST4_NAME$word",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "Only accept registers from a specific source prefix list\n"
+			  "Prefix-List name\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char reg_alist_xpath[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ip_pim_joinprune_time,
-       ip_pim_joinprune_time_cmd,
-       "ip pim join-prune-interval (1-65535)$jpi",
-       IP_STR
-       "pim multicast routing\n"
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	snprintf(reg_alist_xpath, sizeof(reg_alist_xpath),
+		 "./register-accept-list");
+
+	if (no)
+		nb_cli_enqueue_change(vty, reg_alist_xpath, NB_OP_DESTROY, NULL);
+	else
+		nb_cli_enqueue_change(vty, reg_alist_xpath, NB_OP_MODIFY, word);
+
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim_joinprune_time,
+       pim_joinprune_time_cmd,
+       "join-prune-interval (1-65535)$jpi",
        "Join Prune Send Interval\n"
        "Seconds\n")
 {
 	return pim_process_join_prune_cmd(vty, jpi_str);
 }
+DEFPY_ATTR(ip_pim_joinprune_time,
+			  ip_pim_joinprune_time_cmd,
+			  "ip pim join-prune-interval (1-65535)$jpi",
+			  IP_STR
+			  PIM_STR
+			  "Join Prune Send Interval\n"
+			  "Seconds\n",
+	   CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFUN (no_ip_pim_joinprune_time,
-       no_ip_pim_joinprune_time_cmd,
-       "no ip pim join-prune-interval [(1-65535)]",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_join_prune_cmd(vty, jpi_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_joinprune_time,
+       no_pim_joinprune_time_cmd,
+       "no join-prune-interval [(1-65535)]",
        NO_STR
-       IP_STR
-       "pim multicast routing\n"
        "Join Prune Send Interval\n"
        IGNORED_IN_NO_STR)
 {
 	return pim_process_no_join_prune_cmd(vty);
 }
+DEFPY_ATTR(no_ip_pim_joinprune_time,
+			  no_ip_pim_joinprune_time_cmd,
+			  "no ip pim join-prune-interval [(1-65535)]",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "Join Prune Send Interval\n"
+			  IGNORED_IN_NO_STR,
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ip_pim_register_suppress,
-       ip_pim_register_suppress_cmd,
-       "ip pim register-suppress-time (1-65535)$rst",
-       IP_STR
-       "pim multicast routing\n"
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_join_prune_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim_register_suppress,
+       pim_register_suppress_cmd,
+       "register-suppress-time (1-65535)$rst",
        "Register Suppress Timer\n"
        "Seconds\n")
 {
 	return pim_process_register_suppress_cmd(vty, rst_str);
 }
+DEFPY_ATTR(ip_pim_register_suppress,
+			  ip_pim_register_suppress_cmd,
+			  "ip pim register-suppress-time (1-65535)$rst",
+			  IP_STR
+			  PIM_STR
+			  "Register Suppress Timer\n"
+			  "Seconds\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFUN (no_ip_pim_register_suppress,
-       no_ip_pim_register_suppress_cmd,
-       "no ip pim register-suppress-time [(1-65535)]",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_register_suppress_cmd(vty, rst_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_register_suppress,
+       no_pim_register_suppress_cmd,
+       "no register-suppress-time [(1-65535)]",
        NO_STR
-       IP_STR
-       "pim multicast routing\n"
        "Register Suppress Timer\n"
        IGNORED_IN_NO_STR)
 {
 	return pim_process_no_register_suppress_cmd(vty);
 }
+DEFPY_ATTR(no_ip_pim_register_suppress,
+			  no_ip_pim_register_suppress_cmd,
+			  "no ip pim register-suppress-time [(1-65535)]",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "Register Suppress Timer\n"
+			  IGNORED_IN_NO_STR,
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ip_pim_rp_keep_alive,
-       ip_pim_rp_keep_alive_cmd,
-       "ip pim rp keep-alive-timer (1-65535)$kat",
-       IP_STR
-       "pim multicast routing\n"
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_register_suppress_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim_rp_keep_alive,
+       pim_rp_keep_alive_cmd,
+       "rp keep-alive-timer (1-65535)$kat",
        "Rendezvous Point\n"
        "Keep alive Timer\n"
        "Seconds\n")
 {
 	return pim_process_rp_kat_cmd(vty, kat_str);
 }
+DEFPY_ATTR(ip_pim_rp_keep_alive,
+			  ip_pim_rp_keep_alive_cmd,
+			  "ip pim rp keep-alive-timer (1-65535)$kat",
+			  IP_STR
+			  PIM_STR
+			  "Rendezvous Point\n"
+			  "Keep alive Timer\n"
+			  "Seconds\n",
+	   CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFUN (no_ip_pim_rp_keep_alive,
-       no_ip_pim_rp_keep_alive_cmd,
-       "no ip pim rp keep-alive-timer [(1-65535)]",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_rp_kat_cmd(vty, kat_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_rp_keep_alive,
+       no_pim_rp_keep_alive_cmd,
+       "no rp keep-alive-timer [(1-65535)]",
        NO_STR
-       IP_STR
-       "pim multicast routing\n"
        "Rendezvous Point\n"
        "Keep alive Timer\n"
        IGNORED_IN_NO_STR)
 {
 	return pim_process_no_rp_kat_cmd(vty);
 }
+DEFPY_ATTR(no_ip_pim_rp_keep_alive,
+			  no_ip_pim_rp_keep_alive_cmd,
+			  "no ip pim rp keep-alive-timer [(1-65535)]",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "Rendezvous Point\n"
+			  "Keep alive Timer\n"
+			  IGNORED_IN_NO_STR,
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ip_pim_keep_alive,
-       ip_pim_keep_alive_cmd,
-       "ip pim keep-alive-timer (1-65535)$kat",
-       IP_STR
-       "pim multicast routing\n"
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_rp_kat_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim_keep_alive,
+       pim_keep_alive_cmd,
+       "keep-alive-timer (1-65535)$kat",
        "Keep alive Timer\n"
        "Seconds\n")
 {
 	return pim_process_keepalivetimer_cmd(vty, kat_str);
 }
+DEFPY_ATTR(ip_pim_keep_alive,
+			  ip_pim_keep_alive_cmd,
+			  "ip pim keep-alive-timer (1-65535)$kat",
+			  IP_STR
+			  PIM_STR
+			  "Keep alive Timer\n"
+			  "Seconds\n",
+	   CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFUN (no_ip_pim_keep_alive,
-       no_ip_pim_keep_alive_cmd,
-       "no ip pim keep-alive-timer [(1-65535)]",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_keepalivetimer_cmd(vty, kat_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_keep_alive,
+       no_pim_keep_alive_cmd,
+       "no keep-alive-timer [(1-65535)]",
        NO_STR
-       IP_STR
-       "pim multicast routing\n"
        "Keep alive Timer\n"
        IGNORED_IN_NO_STR)
 {
 	return pim_process_no_keepalivetimer_cmd(vty);
 }
+DEFPY_ATTR(no_ip_pim_keep_alive,
+			  no_ip_pim_keep_alive_cmd,
+			  "no ip pim keep-alive-timer [(1-65535)]",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "Keep alive Timer\n"
+			  IGNORED_IN_NO_STR,
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ip_pim_packets,
-       ip_pim_packets_cmd,
-       "ip pim packets (1-255)",
-       IP_STR
-       "pim multicast routing\n"
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_keepalivetimer_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim_packets,
+       pim_packets_cmd,
+       "packets (1-255)",
        "packets to process at one time per fd\n"
        "Number of packets\n")
 {
 	return pim_process_pim_packet_cmd(vty, packets_str);
 }
+DEFPY_ATTR(ip_pim_packets,
+			  ip_pim_packets_cmd,
+			  "ip pim packets (1-255)",
+			  IP_STR
+			  PIM_STR
+			  "packets to process at one time per fd\n"
+			  "Number of packets\n",
+	   CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFUN (no_ip_pim_packets,
-       no_ip_pim_packets_cmd,
-       "no ip pim packets [(1-255)]",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_pim_packet_cmd(vty, packets_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_packets,
+       no_pim_packets_cmd,
+       "no packets [(1-255)]",
        NO_STR
-       IP_STR
-       "pim multicast routing\n"
        "packets to process at one time per fd\n"
        IGNORED_IN_NO_STR)
 {
 	return pim_process_no_pim_packet_cmd(vty);
+}
+DEFPY_ATTR(no_ip_pim_packets,
+			  no_ip_pim_packets_cmd,
+			  "no ip pim packets [(1-255)]",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "packets to process at one time per fd\n"
+			  IGNORED_IN_NO_STR,
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_pim_packet_cmd(vty);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
 }
 
 DEFPY (ip_igmp_group_watermark,
@@ -3217,64 +3845,131 @@ DEFPY (no_ip_igmp_group_watermark,
 	return CMD_SUCCESS;
 }
 
-DEFUN (ip_pim_v6_secondary,
-       ip_pim_v6_secondary_cmd,
-       "ip pim send-v6-secondary",
-       IP_STR
-       "pim multicast routing\n"
+DEFPY (pim_v6_secondary,
+       pim_v6_secondary_cmd,
+       "send-v6-secondary",
        "Send v6 secondary addresses\n")
 {
-	const char *vrfname;
 	char send_v6_secondary_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	snprintf(send_v6_secondary_xpath, sizeof(send_v6_secondary_xpath),
-		 FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
-	strlcat(send_v6_secondary_xpath, "/send-v6-secondary",
-		sizeof(send_v6_secondary_xpath));
+		 "./send-v6-secondary");
 
 	nb_cli_enqueue_change(vty, send_v6_secondary_xpath, NB_OP_MODIFY,
 			      "true");
 
 	return nb_cli_apply_changes(vty, NULL);
 }
-
-DEFUN (no_ip_pim_v6_secondary,
-       no_ip_pim_v6_secondary_cmd,
-       "no ip pim send-v6-secondary",
-       NO_STR
-       IP_STR
-       "pim multicast routing\n"
-       "Send v6 secondary addresses\n")
+DEFPY_ATTR(ip_pim_v6_secondary,
+			  ip_pim_v6_secondary_cmd,
+			  "ip pim send-v6-secondary",
+			  IP_STR
+			  PIM_STR
+			  "Send v6 secondary addresses\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
 {
-	const char *vrfname;
 	char send_v6_secondary_xpath[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
 	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
 		return CMD_WARNING_CONFIG_FAILED;
+	}
 
 	snprintf(send_v6_secondary_xpath, sizeof(send_v6_secondary_xpath),
-		 FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
-	strlcat(send_v6_secondary_xpath, "/send-v6-secondary",
-		sizeof(send_v6_secondary_xpath));
+		 "./send-v6-secondary");
+	nb_cli_enqueue_change(vty, send_v6_secondary_xpath, NB_OP_MODIFY,
+			      "true");
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_v6_secondary,
+       no_pim_v6_secondary_cmd,
+       "no send-v6-secondary",
+       NO_STR
+       "Send v6 secondary addresses\n")
+{
+	char send_v6_secondary_xpath[XPATH_MAXLEN];
+
+	snprintf(send_v6_secondary_xpath, sizeof(send_v6_secondary_xpath),
+		 "./send-v6-secondary");
 
 	nb_cli_enqueue_change(vty, send_v6_secondary_xpath, NB_OP_MODIFY,
 			      "false");
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+DEFPY_ATTR(no_ip_pim_v6_secondary,
+			  no_ip_pim_v6_secondary_cmd,
+			  "no ip pim send-v6-secondary",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "Send v6 secondary addresses\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char send_v6_secondary_xpath[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ip_pim_rp,
-       ip_pim_rp_cmd,
-       "ip pim rp A.B.C.D$rp [A.B.C.D/M]$gp",
-       IP_STR
-       "pim multicast routing\n"
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	snprintf(send_v6_secondary_xpath, sizeof(send_v6_secondary_xpath),
+		 "./send-v6-secondary");
+	nb_cli_enqueue_change(vty, send_v6_secondary_xpath, NB_OP_MODIFY,
+			      "false");
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim_rp,
+       pim_rp_cmd,
+       "rp A.B.C.D$rp [A.B.C.D/M]$gp",
        "Rendezvous Point\n"
        "ip address of RP\n"
        "Group Address range to cover\n")
@@ -3283,12 +3978,52 @@ DEFPY (ip_pim_rp,
 
 	return pim_process_rp_cmd(vty, rp_str, group_str);
 }
+DEFPY_ATTR(ip_pim_rp,
+			  ip_pim_rp_cmd,
+			  "ip pim rp A.B.C.D$rp [A.B.C.D/M]$gp",
+			  IP_STR
+			  PIM_STR
+			  "Rendezvous Point\n"
+			  "ip address of RP\n"
+			  "Group Address range to cover\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	const char *group_str = (gp_str) ? gp_str : "224.0.0.0/4";
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (ip_pim_rp_prefix_list,
-       ip_pim_rp_prefix_list_cmd,
-       "ip pim rp A.B.C.D$rp prefix-list PREFIXLIST4_NAME$plist",
-       IP_STR
-       "pim multicast routing\n"
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_rp_cmd(vty, rp_str, group_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim_rp_prefix_list,
+       pim_rp_prefix_list_cmd,
+       "rp A.B.C.D$rp prefix-list PREFIXLIST4_NAME$plist",
        "Rendezvous Point\n"
        "ip address of RP\n"
        "group prefix-list filter\n"
@@ -3296,13 +4031,53 @@ DEFPY (ip_pim_rp_prefix_list,
 {
 	return pim_process_rp_plist_cmd(vty, rp_str, plist);
 }
+DEFPY_ATTR(ip_pim_rp_prefix_list,
+			  ip_pim_rp_prefix_list_cmd,
+			  "ip pim rp A.B.C.D$rp prefix-list PREFIXLIST4_NAME$plist",
+			  IP_STR
+			  PIM_STR
+			  "Rendezvous Point\n"
+			  "ip address of RP\n"
+			  "group prefix-list filter\n"
+			  "Name of a prefix-list\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (no_ip_pim_rp,
-       no_ip_pim_rp_cmd,
-       "no ip pim rp A.B.C.D$rp [A.B.C.D/M]$gp",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_rp_plist_cmd(vty, rp_str, plist);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_rp,
+       no_pim_rp_cmd,
+       "no rp A.B.C.D$rp [A.B.C.D/M]$gp",
        NO_STR
-       IP_STR
-       "pim multicast routing\n"
        "Rendezvous Point\n"
        "ip address of RP\n"
        "Group Address range to cover\n")
@@ -3311,13 +4086,54 @@ DEFPY (no_ip_pim_rp,
 
 	return pim_process_no_rp_cmd(vty, rp_str, group_str);
 }
+DEFPY_ATTR(no_ip_pim_rp,
+			  no_ip_pim_rp_cmd,
+			  "no ip pim rp A.B.C.D$rp [A.B.C.D/M]$gp",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "Rendezvous Point\n"
+			  "ip address of RP\n"
+			  "Group Address range to cover\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	const char *group_str = (gp_str) ? gp_str : "224.0.0.0/4";
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY (no_ip_pim_rp_prefix_list,
-       no_ip_pim_rp_prefix_list_cmd,
-       "no ip pim rp A.B.C.D$rp prefix-list PREFIXLIST4_NAME$plist",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_rp_cmd(vty, rp_str, group_str);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_rp_prefix_list,
+       no_pim_rp_prefix_list_cmd,
+       "no rp A.B.C.D$rp prefix-list PREFIXLIST4_NAME$plist",
        NO_STR
-       IP_STR
-       "pim multicast routing\n"
        "Rendezvous Point\n"
        "ip address of RP\n"
        "group prefix-list filter\n"
@@ -3325,103 +4141,263 @@ DEFPY (no_ip_pim_rp_prefix_list,
 {
 	return pim_process_no_rp_plist_cmd(vty, rp_str, plist);
 }
+DEFPY_ATTR(no_ip_pim_rp_prefix_list,
+			  no_ip_pim_rp_prefix_list_cmd,
+			  "no ip pim rp A.B.C.D$rp prefix-list PREFIXLIST4_NAME$plist",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "Rendezvous Point\n"
+			  "ip address of RP\n"
+			  "group prefix-list filter\n"
+			  "Name of a prefix-list\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFUN (ip_pim_ssm_prefix_list,
-       ip_pim_ssm_prefix_list_cmd,
-       "ip pim ssm prefix-list PREFIXLIST4_NAME",
-       IP_STR
-       "pim multicast routing\n"
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	ret = pim_process_no_rp_plist_cmd(vty, rp_str, plist);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim_ssm_prefix_list,
+       pim_ssm_prefix_list_cmd,
+       "ssm prefix-list PREFIXLIST4_NAME$plist",
        "Source Specific Multicast\n"
        "group range prefix-list filter\n"
        "Name of a prefix-list\n")
 {
-	const char *vrfname;
 	char ssm_plist_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
+	snprintf(ssm_plist_xpath, sizeof(ssm_plist_xpath), "./ssm-prefix-list");
 
-	snprintf(ssm_plist_xpath, sizeof(ssm_plist_xpath), FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
-	strlcat(ssm_plist_xpath, "/ssm-prefix-list", sizeof(ssm_plist_xpath));
-
-	nb_cli_enqueue_change(vty, ssm_plist_xpath, NB_OP_MODIFY, argv[4]->arg);
+	nb_cli_enqueue_change(vty, ssm_plist_xpath, NB_OP_MODIFY, plist);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+DEFPY_ATTR(ip_pim_ssm_prefix_list,
+			  ip_pim_ssm_prefix_list_cmd,
+			  "ip pim ssm prefix-list PREFIXLIST4_NAME$plist",
+			  IP_STR
+			  PIM_STR
+			  "Source Specific Multicast\n"
+			  "group range prefix-list filter\n"
+			  "Name of a prefix-list\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char ssm_plist_xpath[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFUN (no_ip_pim_ssm_prefix_list,
-       no_ip_pim_ssm_prefix_list_cmd,
-       "no ip pim ssm prefix-list",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	snprintf(ssm_plist_xpath, sizeof(ssm_plist_xpath), "./ssm-prefix-list");
+	nb_cli_enqueue_change(vty, ssm_plist_xpath, NB_OP_MODIFY, plist);
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_ssm_prefix_list,
+       no_pim_ssm_prefix_list_cmd,
+       "no ssm prefix-list",
        NO_STR
-       IP_STR
-       "pim multicast routing\n"
        "Source Specific Multicast\n"
        "group range prefix-list filter\n")
 {
-	const char *vrfname;
 	char ssm_plist_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(ssm_plist_xpath, sizeof(ssm_plist_xpath),
-		 FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
-	strlcat(ssm_plist_xpath, "/ssm-prefix-list", sizeof(ssm_plist_xpath));
+	snprintf(ssm_plist_xpath, sizeof(ssm_plist_xpath), "./ssm-prefix-list");
 
 	nb_cli_enqueue_change(vty, ssm_plist_xpath, NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+DEFPY_ATTR(no_ip_pim_ssm_prefix_list,
+			  no_ip_pim_ssm_prefix_list_cmd,
+			  "no ip pim ssm prefix-list",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "Source Specific Multicast\n"
+			  "group range prefix-list filter\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char ssm_plist_xpath[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFUN (no_ip_pim_ssm_prefix_list_name,
-       no_ip_pim_ssm_prefix_list_name_cmd,
-       "no ip pim ssm prefix-list PREFIXLIST4_NAME",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	snprintf(ssm_plist_xpath, sizeof(ssm_plist_xpath), "./ssm-prefix-list");
+	nb_cli_enqueue_change(vty, ssm_plist_xpath, NB_OP_DESTROY, NULL);
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_ssm_prefix_list_name,
+       no_pim_ssm_prefix_list_name_cmd,
+       "no ssm prefix-list PREFIXLIST4_NAME$plist",
        NO_STR
-       IP_STR
-       "pim multicast routing\n"
        "Source Specific Multicast\n"
        "group range prefix-list filter\n"
        "Name of a prefix-list\n")
 {
-	const char *vrfname;
 	const struct lyd_node *ssm_plist_dnode;
 	char ssm_plist_xpath[XPATH_MAXLEN];
 	const char *ssm_plist_name;
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(ssm_plist_xpath, sizeof(ssm_plist_xpath),
-		 FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
-	strlcat(ssm_plist_xpath, "/ssm-prefix-list", sizeof(ssm_plist_xpath));
+	snprintf(ssm_plist_xpath, sizeof(ssm_plist_xpath), "%s/ssm-prefix-list",
+		 VTY_CURR_XPATH);
 	ssm_plist_dnode = yang_dnode_get(vty->candidate_config->dnode,
 					 ssm_plist_xpath);
 
 	if (!ssm_plist_dnode) {
-		vty_out(vty,
-			"%% pim ssm prefix-list %s doesn't exist\n",
-			argv[5]->arg);
+		vty_out(vty, "%% pim ssm prefix-list %s doesn't exist\n", plist);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
 	ssm_plist_name = yang_dnode_get_string(ssm_plist_dnode, ".");
 
-	if (ssm_plist_name && !strcmp(ssm_plist_name, argv[5]->arg)) {
-		nb_cli_enqueue_change(vty, ssm_plist_xpath, NB_OP_DESTROY,
-				      NULL);
-
+	if (ssm_plist_name && !strcmp(ssm_plist_name, plist)) {
+		nb_cli_enqueue_change(vty, ssm_plist_xpath, NB_OP_DESTROY, NULL);
 		return nb_cli_apply_changes(vty, NULL);
 	}
 
-	vty_out(vty, "%% pim ssm prefix-list %s doesn't exist\n", argv[5]->arg);
+	vty_out(vty, "%% pim ssm prefix-list %s doesn't exist\n", plist);
 
 	return CMD_WARNING_CONFIG_FAILED;
+}
+DEFPY_ATTR(no_ip_pim_ssm_prefix_list_name,
+			  no_ip_pim_ssm_prefix_list_name_cmd,
+			  "no ip pim ssm prefix-list PREFIXLIST4_NAME$plist",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "Source Specific Multicast\n"
+			  "group range prefix-list filter\n"
+			  "Name of a prefix-list\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	const struct lyd_node *ssm_plist_dnode;
+	char ssm_plist_xpath[XPATH_MAXLEN];
+	const char *ssm_plist_name;
+	int ret = CMD_WARNING_CONFIG_FAILED;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	snprintf(ssm_plist_xpath, sizeof(ssm_plist_xpath), "%s/ssm-prefix-list",
+		 VTY_CURR_XPATH);
+	ssm_plist_dnode = yang_dnode_get(vty->candidate_config->dnode,
+					 ssm_plist_xpath);
+	if (ssm_plist_dnode) {
+		ssm_plist_name = yang_dnode_get_string(ssm_plist_dnode, ".");
+		if (ssm_plist_name && !strcmp(ssm_plist_name, plist)) {
+			nb_cli_enqueue_change(vty, ssm_plist_xpath,
+					      NB_OP_DESTROY, NULL);
+			ret = nb_cli_apply_changes(vty, NULL);
+		} else {
+			vty_out(vty, "%% pim ssm prefix-list %s doesn't exist\n",
+				plist);
+		}
+	} else {
+		vty_out(vty, "%% pim ssm prefix-list %s doesn't exist\n", plist);
+	}
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
 }
 
 DEFUN (show_ip_pim_ssm_range,
@@ -3511,135 +4487,354 @@ DEFPY (show_ip_pim_bsr,
 	return pim_show_bsr_helper(vrf, vty, !!json);
 }
 
-DEFUN (ip_ssmpingd,
-       ip_ssmpingd_cmd,
-       "ip ssmpingd [A.B.C.D]",
-       IP_STR
+DEFPY (pim_ssmpingd,
+       pim_ssmpingd_cmd,
+       "ssmpingd [A.B.C.D]$src",
        CONF_SSMPINGD_STR
        "Source address\n")
 {
-	int idx_ipv4 = 2;
-	const char *src_str = (argc == 3) ? argv[idx_ipv4]->arg : "0.0.0.0";
+	if (src_str)
+		return pim_process_ssmpingd_cmd(vty, NB_OP_CREATE, src_str);
+	else
+		return pim_process_ssmpingd_cmd(vty, NB_OP_CREATE, "0.0.0.0");
+}
+DEFPY_ATTR(ip_pim_ssmpingd,
+			  ip_ssmpingd_cmd,
+			  "ip ssmpingd [A.B.C.D]$src",
+			  IP_STR
+			  CONF_SSMPINGD_STR
+			  "Source address\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-	return pim_process_ssmpingd_cmd(vty, NB_OP_CREATE, src_str);
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	if (src_str)
+		ret = pim_process_ssmpingd_cmd(vty, NB_OP_CREATE, src_str);
+	else
+		ret = pim_process_ssmpingd_cmd(vty, NB_OP_CREATE, "0.0.0.0");
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
 }
 
-DEFUN (no_ip_ssmpingd,
-       no_ip_ssmpingd_cmd,
-       "no ip ssmpingd [A.B.C.D]",
+DEFPY (no_pim_ssmpingd,
+       no_pim_ssmpingd_cmd,
+       "no ssmpingd [A.B.C.D]$src",
        NO_STR
-       IP_STR
        CONF_SSMPINGD_STR
        "Source address\n")
 {
-	int idx_ipv4 = 3;
-	const char *src_str = (argc == 4) ? argv[idx_ipv4]->arg : "0.0.0.0";
+	if (src_str)
+		return pim_process_ssmpingd_cmd(vty, NB_OP_DESTROY, src_str);
+	else
+		return pim_process_ssmpingd_cmd(vty, NB_OP_DESTROY, "0.0.0.0");
+}
+DEFPY_ATTR(no_ip_pim_ssmpingd,
+			  no_ip_ssmpingd_cmd,
+			  "no ip ssmpingd [A.B.C.D]$src",
+			  NO_STR
+			  IP_STR
+			  CONF_SSMPINGD_STR
+			  "Source address\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-	return pim_process_ssmpingd_cmd(vty, NB_OP_DESTROY, src_str);
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	if (src_str)
+		ret = pim_process_ssmpingd_cmd(vty, NB_OP_DESTROY, src_str);
+	else
+		ret = pim_process_ssmpingd_cmd(vty, NB_OP_DESTROY, "0.0.0.0");
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
 }
 
-DEFUN (ip_pim_ecmp,
-       ip_pim_ecmp_cmd,
-       "ip pim ecmp",
-       IP_STR
-       "pim multicast routing\n"
+DEFPY (pim_ecmp,
+       pim_ecmp_cmd,
+       "ecmp",
        "Enable PIM ECMP \n")
 {
-	const char *vrfname;
 	char ecmp_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
-	strlcat(ecmp_xpath, "/ecmp", sizeof(ecmp_xpath));
-
+	snprintf(ecmp_xpath, sizeof(ecmp_xpath), "./ecmp");
 	nb_cli_enqueue_change(vty, ecmp_xpath, NB_OP_MODIFY, "true");
+
 	return nb_cli_apply_changes(vty, NULL);
 }
-
-DEFUN (no_ip_pim_ecmp,
-       no_ip_pim_ecmp_cmd,
-       "no ip pim ecmp",
-       NO_STR
-       IP_STR
-       "pim multicast routing\n"
-       "Disable PIM ECMP \n")
+DEFPY_ATTR(ip_pim_ecmp,
+			  ip_pim_ecmp_cmd,
+			  "ip pim ecmp",
+			  IP_STR
+			  PIM_STR
+			  "Enable PIM ECMP \n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
 {
-	const char *vrfname;
 	char ecmp_xpath[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
 	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
 		return CMD_WARNING_CONFIG_FAILED;
+	}
 
-	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
-	strlcat(ecmp_xpath, "/ecmp", sizeof(ecmp_xpath));
+	snprintf(ecmp_xpath, sizeof(ecmp_xpath), "./ecmp");
+	nb_cli_enqueue_change(vty, ecmp_xpath, NB_OP_MODIFY, "true");
+	ret = nb_cli_apply_changes(vty, NULL);
 
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_ecmp,
+       no_pim_ecmp_cmd,
+       "no ecmp",
+       NO_STR
+       "Disable PIM ECMP \n")
+{
+	char ecmp_xpath[XPATH_MAXLEN];
+
+	snprintf(ecmp_xpath, sizeof(ecmp_xpath), "./ecmp");
 	nb_cli_enqueue_change(vty, ecmp_xpath, NB_OP_MODIFY, "false");
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+DEFPY_ATTR(no_ip_pim_ecmp,
+			  no_ip_pim_ecmp_cmd,
+			  "no ip pim ecmp",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "Disable PIM ECMP \n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char ecmp_xpath[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFUN (ip_pim_ecmp_rebalance,
-       ip_pim_ecmp_rebalance_cmd,
-       "ip pim ecmp rebalance",
-       IP_STR
-       "pim multicast routing\n"
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	snprintf(ecmp_xpath, sizeof(ecmp_xpath), "./ecmp");
+	nb_cli_enqueue_change(vty, ecmp_xpath, NB_OP_MODIFY, "false");
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (pim_ecmp_rebalance,
+       pim_ecmp_rebalance_cmd,
+       "ecmp rebalance",
        "Enable PIM ECMP \n"
        "Enable PIM ECMP Rebalance\n")
 {
-	const char *vrfname;
 	char ecmp_xpath[XPATH_MAXLEN];
 	char ecmp_rebalance_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(ecmp_xpath, sizeof(ecmp_xpath), FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
-	strlcat(ecmp_xpath, "/ecmp", sizeof(ecmp_xpath));
+	snprintf(ecmp_xpath, sizeof(ecmp_xpath), "./ecmp");
 	snprintf(ecmp_rebalance_xpath, sizeof(ecmp_rebalance_xpath),
-		 FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
-	strlcat(ecmp_rebalance_xpath, "/ecmp-rebalance",
-		sizeof(ecmp_rebalance_xpath));
+		 "./ecmp-rebalance");
 
 	nb_cli_enqueue_change(vty, ecmp_xpath, NB_OP_MODIFY, "true");
 	nb_cli_enqueue_change(vty, ecmp_rebalance_xpath, NB_OP_MODIFY, "true");
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+DEFPY_ATTR(ip_pim_ecmp_rebalance,
+			  ip_pim_ecmp_rebalance_cmd,
+			  "ip pim ecmp rebalance",
+			  IP_STR
+			  PIM_STR
+			  "Enable PIM ECMP \n"
+			  "Enable PIM ECMP Rebalance\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char ecmp_xpath[XPATH_MAXLEN];
+	char ecmp_rebalance_xpath[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFUN (no_ip_pim_ecmp_rebalance,
-       no_ip_pim_ecmp_rebalance_cmd,
-       "no ip pim ecmp rebalance",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	snprintf(ecmp_xpath, sizeof(ecmp_xpath), "./ecmp");
+	snprintf(ecmp_rebalance_xpath, sizeof(ecmp_rebalance_xpath),
+		 "./ecmp-rebalance");
+	nb_cli_enqueue_change(vty, ecmp_xpath, NB_OP_MODIFY, "true");
+	nb_cli_enqueue_change(vty, ecmp_rebalance_xpath, NB_OP_MODIFY, "true");
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_ecmp_rebalance,
+       no_pim_ecmp_rebalance_cmd,
+       "no ecmp rebalance",
        NO_STR
-       IP_STR
-       "pim multicast routing\n"
        "Disable PIM ECMP \n"
        "Disable PIM ECMP Rebalance\n")
 {
-	const char *vrfname;
 	char ecmp_rebalance_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	snprintf(ecmp_rebalance_xpath, sizeof(ecmp_rebalance_xpath),
-		 FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
-	strlcat(ecmp_rebalance_xpath, "/ecmp-rebalance",
-		sizeof(ecmp_rebalance_xpath));
+		 "./ecmp-rebalance");
 
 	nb_cli_enqueue_change(vty, ecmp_rebalance_xpath, NB_OP_MODIFY, "false");
 
 	return nb_cli_apply_changes(vty, NULL);
+}
+DEFPY_ATTR(no_ip_pim_ecmp_rebalance,
+			  no_ip_pim_ecmp_rebalance_cmd,
+			  "no ip pim ecmp rebalance",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "Disable PIM ECMP \n"
+			  "Disable PIM ECMP Rebalance\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char ecmp_rebalance_xpath[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	snprintf(ecmp_rebalance_xpath, sizeof(ecmp_rebalance_xpath),
+		 "./ecmp-rebalance");
+	nb_cli_enqueue_change(vty, ecmp_rebalance_xpath, NB_OP_MODIFY, "false");
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
 }
 
 DEFUN (interface_ip_igmp,
@@ -4648,15 +5843,24 @@ DEFPY (debug_pim_zebra,
 	return CMD_SUCCESS;
 }
 
-DEFUN(debug_pim_mlag, debug_pim_mlag_cmd, "debug pim mlag",
-      DEBUG_STR DEBUG_PIM_STR DEBUG_PIM_MLAG_STR)
+DEFUN(debug_pim_mlag,
+		debug_pim_mlag_cmd,
+		"debug pim mlag",
+		DEBUG_STR
+		DEBUG_PIM_STR
+		DEBUG_PIM_MLAG_STR)
 {
 	PIM_DO_DEBUG_MLAG;
 	return CMD_SUCCESS;
 }
 
-DEFUN(no_debug_pim_mlag, no_debug_pim_mlag_cmd, "no debug pim mlag",
-      NO_STR DEBUG_STR DEBUG_PIM_STR DEBUG_PIM_MLAG_STR)
+DEFUN(no_debug_pim_mlag,
+		no_debug_pim_mlag_cmd,
+		"no debug pim mlag",
+		NO_STR
+		DEBUG_STR
+		DEBUG_PIM_STR
+		DEBUG_PIM_MLAG_STR)
 {
 	PIM_DONT_DEBUG_MLAG;
 	return CMD_SUCCESS;
@@ -5016,145 +6220,286 @@ ALIAS(no_ip_pim_bfd, no_ip_pim_bfd_param_cmd,
       "Desired min transmit interval\n")
 #endif /* !HAVE_BFDD */
 
-DEFPY(ip_msdp_peer, ip_msdp_peer_cmd,
-      "ip msdp peer A.B.C.D$peer source A.B.C.D$source",
-      IP_STR
+DEFPY(pim_msdp_peer, pim_msdp_peer_cmd,
+      "msdp peer A.B.C.D$peer source A.B.C.D$source",
       CFG_MSDP_STR
       "Configure MSDP peer\n"
       "Peer IP address\n"
       "Source address for TCP connection\n"
       "Local IP address\n")
 {
-	const char *vrfname;
-	char temp_xpath[XPATH_MAXLEN];
 	char msdp_peer_source_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	snprintf(msdp_peer_source_xpath, sizeof(msdp_peer_source_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 "frr-routing:ipv4");
-	snprintf(temp_xpath, sizeof(temp_xpath),
-		 "/msdp-peer[peer-ip='%s']/source-ip", peer_str);
-	strlcat(msdp_peer_source_xpath, temp_xpath,
-		sizeof(msdp_peer_source_xpath));
-
+		 "./msdp-peer[peer-ip='%s']/source-ip", peer_str);
 	nb_cli_enqueue_change(vty, msdp_peer_source_xpath, NB_OP_MODIFY,
 			      source_str);
 
-	return nb_cli_apply_changes(vty,
-			FRR_PIM_INTERFACE_XPATH, "frr-routing:ipv4");
+	return nb_cli_apply_changes(vty, NULL);
+}
+DEFPY_ATTR(ip_pim_msdp_peer,
+			  ip_msdp_peer_cmd,
+			  "ip msdp peer A.B.C.D$peer source A.B.C.D$source",
+			  IP_STR
+			  CFG_MSDP_STR
+			  "Configure MSDP peer\n"
+			  "Peer IP address\n"
+			  "Source address for TCP connection\n"
+			  "Local IP address\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char msdp_peer_source_xpath[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	snprintf(msdp_peer_source_xpath, sizeof(msdp_peer_source_xpath),
+		 "./msdp-peer[peer-ip='%s']/source-ip", peer_str);
+	nb_cli_enqueue_change(vty, msdp_peer_source_xpath, NB_OP_MODIFY,
+			      source_str);
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
 }
 
-DEFPY(ip_msdp_timers, ip_msdp_timers_cmd,
-      "ip msdp timers (1-65535)$keepalive (1-65535)$holdtime [(1-65535)$connretry]",
-      IP_STR
+DEFPY(pim_msdp_timers, pim_msdp_timers_cmd,
+      "msdp timers (1-65535)$keepalive (1-65535)$holdtime [(1-65535)$connretry]",
       CFG_MSDP_STR
       "MSDP timers configuration\n"
       "Keep alive period (in seconds)\n"
       "Hold time period (in seconds)\n"
       "Connection retry period (in seconds)\n")
 {
-	const char *vrfname;
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	nb_cli_enqueue_change(vty, "./hold-time", NB_OP_MODIFY, holdtime_str);
-	nb_cli_enqueue_change(vty, "./keep-alive", NB_OP_MODIFY, keepalive_str);
+	nb_cli_enqueue_change(vty, "./msdp/hold-time", NB_OP_MODIFY,
+			      holdtime_str);
+	nb_cli_enqueue_change(vty, "./msdp/keep-alive", NB_OP_MODIFY,
+			      keepalive_str);
 	if (connretry_str)
-		nb_cli_enqueue_change(vty, "./connection-retry", NB_OP_MODIFY,
-				      connretry_str);
+		nb_cli_enqueue_change(vty, "./msdp/connection-retry",
+				      NB_OP_MODIFY, connretry_str);
 	else
-		nb_cli_enqueue_change(vty, "./connection-retry", NB_OP_DESTROY,
-				      NULL);
+		nb_cli_enqueue_change(vty, "./msdp/connection-retry",
+				      NB_OP_DESTROY, NULL);
 
-	nb_cli_apply_changes(vty, FRR_PIM_MSDP_XPATH, "frr-pim:pimd", "pim",
-			     vrfname, "frr-routing:ipv4");
+	nb_cli_apply_changes(vty, NULL);
 	return CMD_SUCCESS;
 }
+DEFPY_ATTR(ip_pim_msdp_timers,
+			  ip_msdp_timers_cmd,
+			  "ip msdp timers (1-65535)$keepalive (1-65535)$holdtime [(1-65535)$connretry]",
+			  IP_STR
+			  CFG_MSDP_STR
+			  "MSDP timers configuration\n"
+			  "Keep alive period (in seconds)\n"
+			  "Hold time period (in seconds)\n"
+			  "Connection retry period (in seconds)\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY(no_ip_msdp_timers, no_ip_msdp_timers_cmd,
-      "no ip msdp timers [(1-65535) (1-65535) [(1-65535)]]",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	nb_cli_enqueue_change(vty, "./msdp/hold-time", NB_OP_MODIFY,
+			      holdtime_str);
+	nb_cli_enqueue_change(vty, "./msdp/keep-alive", NB_OP_MODIFY,
+			      keepalive_str);
+	if (connretry_str)
+		nb_cli_enqueue_change(vty, "./msdp/connection-retry",
+				      NB_OP_MODIFY, connretry_str);
+	else
+		nb_cli_enqueue_change(vty, "./msdp/connection-retry",
+				      NB_OP_DESTROY, NULL);
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY(no_pim_msdp_timers, no_pim_msdp_timers_cmd,
+      "no msdp timers [(1-65535) (1-65535) [(1-65535)]]",
       NO_STR
-      IP_STR
       CFG_MSDP_STR
       "MSDP timers configuration\n"
       IGNORED_IN_NO_STR
       IGNORED_IN_NO_STR
       IGNORED_IN_NO_STR)
 {
-	const char *vrfname;
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	nb_cli_enqueue_change(vty, "./hold-time", NB_OP_DESTROY, NULL);
-	nb_cli_enqueue_change(vty, "./keep-alive", NB_OP_DESTROY, NULL);
-	nb_cli_enqueue_change(vty, "./connection-retry", NB_OP_DESTROY, NULL);
-
-	nb_cli_apply_changes(vty, FRR_PIM_MSDP_XPATH, "frr-pim:pimd", "pim",
-			     vrfname, "frr-routing:ipv4");
-
+	nb_cli_enqueue_change(vty, "./msdp/hold-time", NB_OP_DESTROY, NULL);
+	nb_cli_enqueue_change(vty, "./msdp/keep-alive", NB_OP_DESTROY, NULL);
+	nb_cli_enqueue_change(vty, "./msdp/connection-retry", NB_OP_DESTROY,
+			      NULL);
+	nb_cli_apply_changes(vty, NULL);
 	return CMD_SUCCESS;
 }
+DEFPY_ATTR(no_ip_pim_msdp_timers,
+			  no_ip_msdp_timers_cmd,
+			  "no ip msdp timers [(1-65535) (1-65535) [(1-65535)]]",
+			  NO_STR
+			  IP_STR
+			  CFG_MSDP_STR
+			  "MSDP timers configuration\n"
+			  IGNORED_IN_NO_STR
+			  IGNORED_IN_NO_STR
+			  IGNORED_IN_NO_STR,
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFUN (no_ip_msdp_peer,
-       no_ip_msdp_peer_cmd,
-       "no ip msdp peer A.B.C.D",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	nb_cli_enqueue_change(vty, "./msdp/hold-time", NB_OP_DESTROY, NULL);
+	nb_cli_enqueue_change(vty, "./msdp/keep-alive", NB_OP_DESTROY, NULL);
+	nb_cli_enqueue_change(vty, "./msdp/connection-retry", NB_OP_DESTROY,
+			      NULL);
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY (no_pim_msdp_peer,
+       no_pim_msdp_peer_cmd,
+       "no msdp peer A.B.C.D",
        NO_STR
-       IP_STR
        CFG_MSDP_STR
        "Delete MSDP peer\n"
        "peer ip address\n")
 {
-	const char *vrfname;
 	char msdp_peer_xpath[XPATH_MAXLEN];
-	char temp_xpath[XPATH_MAXLEN];
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
 
 	snprintf(msdp_peer_xpath, sizeof(msdp_peer_xpath),
-		 FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4");
-	snprintf(temp_xpath, sizeof(temp_xpath),
-		 "/msdp-peer[peer-ip='%s']",
-		 argv[4]->arg);
-
-	strlcat(msdp_peer_xpath, temp_xpath, sizeof(msdp_peer_xpath));
-
+		 "./msdp-peer[peer-ip='%s']", peer_str);
 	nb_cli_enqueue_change(vty, msdp_peer_xpath, NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+DEFPY_ATTR(no_ip_pim_msdp_peer,
+			  no_ip_msdp_peer_cmd,
+			  "no ip msdp peer A.B.C.D",
+			  NO_STR
+			  IP_STR
+			  CFG_MSDP_STR
+			  "Delete MSDP peer\n"
+			  "peer ip address\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char msdp_peer_xpath[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY(ip_msdp_mesh_group_member,
-      ip_msdp_mesh_group_member_cmd,
-      "ip msdp mesh-group WORD$gname member A.B.C.D$maddr",
-      IP_STR
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	snprintf(msdp_peer_xpath, sizeof(msdp_peer_xpath),
+		 "./msdp-peer[peer-ip='%s']", peer_str);
+	nb_cli_enqueue_change(vty, msdp_peer_xpath, NB_OP_DESTROY, NULL);
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY(pim_msdp_mesh_group_member,
+      pim_msdp_mesh_group_member_cmd,
+      "msdp mesh-group WORD$gname member A.B.C.D$maddr",
       CFG_MSDP_STR
       "Configure MSDP mesh-group\n"
       "Mesh group name\n"
       "Mesh group member\n"
       "Peer IP address\n")
 {
-	const char *vrfname;
 	char xpath_value[XPATH_MAXLEN];
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
 
 	/* Create mesh group. */
 	snprintf(xpath_value, sizeof(xpath_value),
-		 FRR_PIM_VRF_XPATH "/msdp-mesh-groups[name='%s']",
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4", gname);
+		 "./msdp-mesh-groups[name='%s']", gname);
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_CREATE, NULL);
 
 	/* Create mesh group member. */
@@ -5165,30 +6510,76 @@ DEFPY(ip_msdp_mesh_group_member,
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+DEFPY_ATTR(ip_pim_msdp_mesh_group_member,
+			  ip_msdp_mesh_group_member_cmd,
+			  "ip msdp mesh-group WORD$gname member A.B.C.D$maddr",
+			  IP_STR
+			  CFG_MSDP_STR
+			  "Configure MSDP mesh-group\n"
+			  "Mesh group name\n"
+			  "Mesh group member\n"
+			  "Peer IP address\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char xpath_value[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY(no_ip_msdp_mesh_group_member,
-      no_ip_msdp_mesh_group_member_cmd,
-      "no ip msdp mesh-group WORD$gname member A.B.C.D$maddr",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	/* Create mesh group. */
+	snprintf(xpath_value, sizeof(xpath_value),
+		 "./msdp-mesh-groups[name='%s']", gname);
+	nb_cli_enqueue_change(vty, xpath_value, NB_OP_CREATE, NULL);
+
+	/* Create mesh group member. */
+	strlcat(xpath_value, "/members[address='", sizeof(xpath_value));
+	strlcat(xpath_value, maddr_str, sizeof(xpath_value));
+	strlcat(xpath_value, "']", sizeof(xpath_value));
+	nb_cli_enqueue_change(vty, xpath_value, NB_OP_CREATE, NULL);
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY(no_pim_msdp_mesh_group_member,
+      no_pim_msdp_mesh_group_member_cmd,
+      "no msdp mesh-group WORD$gname member A.B.C.D$maddr",
       NO_STR
-      IP_STR
       CFG_MSDP_STR
       "Delete MSDP mesh-group member\n"
       "Mesh group name\n"
       "Mesh group member\n"
       "Peer IP address\n")
 {
-	const char *vrfname;
 	char xpath_value[XPATH_MAXLEN];
 	char xpath_member_value[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	/* Get mesh group base XPath. */
 	snprintf(xpath_value, sizeof(xpath_value),
-		 FRR_PIM_VRF_XPATH "/msdp-mesh-groups[name='%s']",
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4", gname);
+		 "%s/msdp-mesh-groups[name='%s']", VTY_CURR_XPATH, gname);
 
 	if (!yang_dnode_exists(vty->candidate_config->dnode, xpath_value)) {
 		vty_out(vty, "%% mesh-group does not exist\n");
@@ -5217,28 +6608,95 @@ DEFPY(no_ip_msdp_mesh_group_member,
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+DEFPY_ATTR(no_ip_pim_msdp_mesh_group_member,
+			  no_ip_msdp_mesh_group_member_cmd,
+			  "no ip msdp mesh-group WORD$gname member A.B.C.D$maddr",
+			  NO_STR
+			  IP_STR
+			  CFG_MSDP_STR
+			  "Delete MSDP mesh-group member\n"
+			  "Mesh group name\n"
+			  "Mesh group member\n"
+			  "Peer IP address\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char xpath_value[XPATH_MAXLEN];
+	char xpath_member_value[XPATH_MAXLEN];
+	int ret = CMD_WARNING_CONFIG_FAILED;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY(ip_msdp_mesh_group_source,
-      ip_msdp_mesh_group_source_cmd,
-      "ip msdp mesh-group WORD$gname source A.B.C.D$saddr",
-      IP_STR
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	/* Get mesh group base XPath. */
+	snprintf(xpath_value, sizeof(xpath_value),
+		 "%s/msdp-mesh-groups[name='%s']", VTY_CURR_XPATH, gname);
+
+	if (yang_dnode_exists(vty->candidate_config->dnode, xpath_value)) {
+		/* Remove mesh group member. */
+		strlcpy(xpath_member_value, xpath_value,
+			sizeof(xpath_member_value));
+		strlcat(xpath_member_value, "/members[address='",
+			sizeof(xpath_member_value));
+		strlcat(xpath_member_value, maddr_str,
+			sizeof(xpath_member_value));
+		strlcat(xpath_member_value, "']", sizeof(xpath_member_value));
+		if (yang_dnode_exists(vty->candidate_config->dnode,
+				      xpath_member_value)) {
+			nb_cli_enqueue_change(vty, xpath_member_value,
+					      NB_OP_DESTROY, NULL);
+
+			/*
+			 * If this is the last member, then we must remove the group altogether
+			 * to not break legacy CLI behaviour.
+			 */
+			pim_cli_legacy_mesh_group_behavior(vty, gname);
+			ret = nb_cli_apply_changes(vty, NULL);
+		} else {
+			vty_out(vty, "%% mesh-group member does not exist\n");
+		}
+	} else {
+		vty_out(vty, "%% mesh-group does not exist\n");
+	}
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY(pim_msdp_mesh_group_source,
+      pim_msdp_mesh_group_source_cmd,
+      "msdp mesh-group WORD$gname source A.B.C.D$saddr",
       CFG_MSDP_STR
       "Configure MSDP mesh-group\n"
       "Mesh group name\n"
       "Mesh group local address\n"
       "Source IP address for the TCP connection\n")
 {
-	const char *vrfname;
 	char xpath_value[XPATH_MAXLEN];
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
 
 	/* Create mesh group. */
 	snprintf(xpath_value, sizeof(xpath_value),
-		 FRR_PIM_VRF_XPATH "/msdp-mesh-groups[name='%s']",
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4", gname);
+		 "./msdp-mesh-groups[name='%s']", gname);
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_CREATE, NULL);
 
 	/* Create mesh group source. */
@@ -5247,29 +6705,72 @@ DEFPY(ip_msdp_mesh_group_source,
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+DEFPY_ATTR(ip_pim_msdp_mesh_group_source,
+			  ip_msdp_mesh_group_source_cmd,
+			  "ip msdp mesh-group WORD$gname source A.B.C.D$saddr",
+			  IP_STR
+			  CFG_MSDP_STR
+			  "Configure MSDP mesh-group\n"
+			  "Mesh group name\n"
+			  "Mesh group local address\n"
+			  "Source IP address for the TCP connection\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char xpath_value[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY(no_ip_msdp_mesh_group_source,
-      no_ip_msdp_mesh_group_source_cmd,
-      "no ip msdp mesh-group WORD$gname source [A.B.C.D]",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	/* Create mesh group. */
+	snprintf(xpath_value, sizeof(xpath_value),
+		 "./msdp-mesh-groups[name='%s']", gname);
+	nb_cli_enqueue_change(vty, xpath_value, NB_OP_CREATE, NULL);
+	/* Create mesh group source. */
+	strlcat(xpath_value, "/source", sizeof(xpath_value));
+	nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, saddr_str);
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY(no_pim_msdp_mesh_group_source,
+      no_pim_msdp_mesh_group_source_cmd,
+      "no msdp mesh-group WORD$gname source [A.B.C.D]",
       NO_STR
-      IP_STR
       CFG_MSDP_STR
       "Delete MSDP mesh-group source\n"
       "Mesh group name\n"
       "Mesh group source\n"
       "Mesh group local address\n")
 {
-	const char *vrfname;
 	char xpath_value[XPATH_MAXLEN];
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
 
 	/* Get mesh group base XPath. */
 	snprintf(xpath_value, sizeof(xpath_value),
-		 FRR_PIM_VRF_XPATH "/msdp-mesh-groups[name='%s']",
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4", gname);
+		 "./msdp-mesh-groups[name='%s']", gname);
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_CREATE, NULL);
 
 	/* Create mesh group source. */
@@ -5284,32 +6785,131 @@ DEFPY(no_ip_msdp_mesh_group_source,
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+DEFPY_ATTR(no_ip_pim_msdp_mesh_group_source,
+			  no_ip_msdp_mesh_group_source_cmd,
+			  "no ip msdp mesh-group WORD$gname source [A.B.C.D]",
+			  NO_STR
+			  IP_STR
+			  CFG_MSDP_STR
+			  "Delete MSDP mesh-group source\n"
+			  "Mesh group name\n"
+			  "Mesh group source\n"
+			  "Mesh group local address\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char xpath_value[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFPY(no_ip_msdp_mesh_group,
-      no_ip_msdp_mesh_group_cmd,
-      "no ip msdp mesh-group WORD$gname",
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	/* Get mesh group base XPath. */
+	snprintf(xpath_value, sizeof(xpath_value),
+		 "./msdp-mesh-groups[name='%s']", gname);
+	nb_cli_enqueue_change(vty, xpath_value, NB_OP_CREATE, NULL);
+
+	/* Create mesh group source. */
+	strlcat(xpath_value, "/source", sizeof(xpath_value));
+	nb_cli_enqueue_change(vty, xpath_value, NB_OP_DESTROY, NULL);
+
+	/*
+	 * If this is the last member, then we must remove the group altogether
+	 * to not break legacy CLI behaviour.
+	 */
+	pim_cli_legacy_mesh_group_behavior(vty, gname);
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY(no_pim_msdp_mesh_group,
+      no_pim_msdp_mesh_group_cmd,
+      "no msdp mesh-group WORD$gname",
       NO_STR
-      IP_STR
       CFG_MSDP_STR
       "Delete MSDP mesh-group\n"
       "Mesh group name\n")
 {
-	const char *vrfname;
 	char xpath_value[XPATH_MAXLEN];
-
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
 
 	/* Get mesh group base XPath. */
 	snprintf(xpath_value, sizeof(xpath_value),
-		 FRR_PIM_VRF_XPATH "/msdp-mesh-groups[name='%s']",
-		 "frr-pim:pimd", "pim", vrfname, "frr-routing:ipv4", gname);
+		 "%s/msdp-mesh-groups[name='%s']", VTY_CURR_XPATH, gname);
 	if (!yang_dnode_exists(vty->candidate_config->dnode, xpath_value))
 		return CMD_SUCCESS;
 
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_DESTROY, NULL);
 	return nb_cli_apply_changes(vty, NULL);
+}
+DEFPY_ATTR(no_ip_pim_msdp_mesh_group,
+			  no_ip_msdp_mesh_group_cmd,
+			  "no ip msdp mesh-group WORD$gname",
+			  NO_STR
+			  IP_STR
+			  CFG_MSDP_STR
+			  "Delete MSDP mesh-group\n"
+			  "Mesh group name\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char xpath_value[XPATH_MAXLEN];
+	int ret = CMD_SUCCESS;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
+
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	/* Get mesh group base XPath. */
+	snprintf(xpath_value, sizeof(xpath_value),
+		 "%s/msdp-mesh-groups[name='%s']", VTY_CURR_XPATH, gname);
+	if (yang_dnode_exists(vty->candidate_config->dnode, xpath_value)) {
+		nb_cli_enqueue_change(vty, xpath_value, NB_OP_DESTROY, NULL);
+		ret = nb_cli_apply_changes(vty, NULL);
+	}
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
 }
 
 static void ip_msdp_show_mesh_group(struct vty *vty, struct pim_msdp_mg *mg,
@@ -5329,7 +6929,8 @@ static void ip_msdp_show_mesh_group(struct vty *vty, struct pim_msdp_mg *mg,
 	if (json) {
 		/* currently there is only one mesh group but we should still
 		 * make
-		 * it a dict with mg-name as key */
+		 * it a dict with mg-name as key
+		 */
 		json_mg_row = json_object_new_object();
 		json_object_string_add(json_mg_row, "name",
 				       mg->mesh_group_name);
@@ -6311,31 +7912,66 @@ DEFUN_HIDDEN (show_ip_pim_vxlan_sg_work,
 	return CMD_SUCCESS;
 }
 
-DEFUN_HIDDEN (no_ip_pim_mlag,
-	      no_ip_pim_mlag_cmd,
-	      "no ip pim mlag",
+DEFPY_HIDDEN (no_pim_mlag,
+	      no_pim_mlag_cmd,
+	      "no mlag",
 	      NO_STR
-	      IP_STR
-	      PIM_STR
 	      "MLAG\n")
 {
 	char mlag_xpath[XPATH_MAXLEN];
 
-	snprintf(mlag_xpath, sizeof(mlag_xpath), FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", "default", "frr-routing:ipv4");
-	strlcat(mlag_xpath, "/mlag", sizeof(mlag_xpath));
-
+	snprintf(mlag_xpath, sizeof(mlag_xpath), "./mlag");
 	nb_cli_enqueue_change(vty, mlag_xpath, NB_OP_DESTROY, NULL);
-
 
 	return nb_cli_apply_changes(vty, NULL);
 }
+DEFPY_ATTR(no_ip_pim_mlag,
+			  no_ip_pim_mlag_cmd,
+			  "no ip pim mlag",
+			  NO_STR
+			  IP_STR
+			  PIM_STR
+			  "MLAG\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
+{
+	char mlag_xpath[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-DEFUN_HIDDEN (ip_pim_mlag,
-	      ip_pim_mlag_cmd,
-	      "ip pim mlag INTERFACE role [primary|secondary] state [up|down] addr A.B.C.D",
-	      IP_STR
-	      PIM_STR
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	snprintf(mlag_xpath, sizeof(mlag_xpath), "./mlag");
+	nb_cli_enqueue_change(vty, mlag_xpath, NB_OP_DESTROY, NULL);
+	ret = nb_cli_apply_changes(vty, NULL);
+
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+DEFPY_HIDDEN (pim_mlag,
+	      pim_mlag_cmd,
+	      "mlag INTERFACE$iface role [primary|secondary]$role state [up|down]$state addr A.B.C.D$addr",
 	      "MLAG\n"
 	      "peerlink sub interface\n"
 	      "MLAG role\n"
@@ -6347,83 +7983,153 @@ DEFUN_HIDDEN (ip_pim_mlag,
 	      "configure PIP\n"
 	      "unique ip address\n")
 {
-	int idx;
 	char mlag_peerlink_rif_xpath[XPATH_MAXLEN];
 	char mlag_my_role_xpath[XPATH_MAXLEN];
 	char mlag_peer_state_xpath[XPATH_MAXLEN];
 	char mlag_reg_address_xpath[XPATH_MAXLEN];
 
 	snprintf(mlag_peerlink_rif_xpath, sizeof(mlag_peerlink_rif_xpath),
-		 FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", "default", "frr-routing:ipv4");
-	strlcat(mlag_peerlink_rif_xpath, "/mlag/peerlink-rif",
-		sizeof(mlag_peerlink_rif_xpath));
-
-	idx = 3;
-	nb_cli_enqueue_change(vty, mlag_peerlink_rif_xpath, NB_OP_MODIFY,
-			      argv[idx]->arg);
+		 "./mlag/peerlink-rif");
+	nb_cli_enqueue_change(vty, mlag_peerlink_rif_xpath, NB_OP_MODIFY, iface);
 
 	snprintf(mlag_my_role_xpath, sizeof(mlag_my_role_xpath),
-		 FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", "default", "frr-routing:ipv4");
-	strlcat(mlag_my_role_xpath, "/mlag/my-role",
-		sizeof(mlag_my_role_xpath));
-
-	idx += 2;
-	if (!strcmp(argv[idx]->arg, "primary")) {
+		 "./mlag/my-role");
+	if (!strcmp(role, "primary")) {
 		nb_cli_enqueue_change(vty, mlag_my_role_xpath, NB_OP_MODIFY,
 				      "MLAG_ROLE_PRIMARY");
-
-	} else if (!strcmp(argv[idx]->arg, "secondary")) {
+	} else if (!strcmp(role, "secondary")) {
 		nb_cli_enqueue_change(vty, mlag_my_role_xpath, NB_OP_MODIFY,
 				      "MLAG_ROLE_SECONDARY");
-
 	} else {
-		vty_out(vty, "unknown MLAG role %s\n", argv[idx]->arg);
+		vty_out(vty, "unknown MLAG role %s\n", role);
 		return CMD_WARNING;
 	}
 
 	snprintf(mlag_peer_state_xpath, sizeof(mlag_peer_state_xpath),
-		 FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", "default", "frr-routing:ipv4");
-	strlcat(mlag_peer_state_xpath, "/mlag/peer-state",
-		sizeof(mlag_peer_state_xpath));
-
-	idx += 2;
-	if (!strcmp(argv[idx]->arg, "up")) {
+		 "./mlag/peer-state");
+	if (!strcmp(state, "up")) {
 		nb_cli_enqueue_change(vty, mlag_peer_state_xpath, NB_OP_MODIFY,
 				      "true");
-
-	} else if (strcmp(argv[idx]->arg, "down")) {
+	} else if (strcmp(state, "down")) {
 		nb_cli_enqueue_change(vty, mlag_peer_state_xpath, NB_OP_MODIFY,
 				      "false");
-
 	} else {
-		vty_out(vty, "unknown MLAG state %s\n", argv[idx]->arg);
+		vty_out(vty, "unknown MLAG state %s\n", state);
 		return CMD_WARNING;
 	}
 
 	snprintf(mlag_reg_address_xpath, sizeof(mlag_reg_address_xpath),
-		 FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", "default", "frr-routing:ipv4");
-	strlcat(mlag_reg_address_xpath, "/mlag/reg-address",
-		sizeof(mlag_reg_address_xpath));
-
-	idx += 2;
+		 "./mlag/reg-address");
 	nb_cli_enqueue_change(vty, mlag_reg_address_xpath, NB_OP_MODIFY,
-			      argv[idx]->arg);
+			      addr_str);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
-
-void pim_cmd_init(void)
+DEFPY_ATTR(ip_pim_mlag,
+			  ip_pim_mlag_cmd,
+			  "ip pim mlag INTERFACE$iface role [primary|secondary]$role state [up|down]$state addr A.B.C.D$addr",
+			  IP_STR
+			  PIM_STR
+			  "MLAG\n"
+			  "peerlink sub interface\n"
+			  "MLAG role\n"
+			  "MLAG role primary\n"
+			  "MLAG role secondary\n"
+			  "peer session state\n"
+			  "peer session state up\n"
+			  "peer session state down\n"
+			  "configure PIP\n"
+			  "unique ip address\n",
+			  CMD_ATTR_HIDDEN | CMD_ATTR_DEPRECATED)
 {
-	if_cmd_init(pim_interface_config_write);
+	char mlag_peerlink_rif_xpath[XPATH_MAXLEN];
+	char mlag_my_role_xpath[XPATH_MAXLEN];
+	char mlag_peer_state_xpath[XPATH_MAXLEN];
+	char mlag_reg_address_xpath[XPATH_MAXLEN];
+	int ret;
+	const char *vrfname;
+	char xpath[XPATH_MAXLEN];
+	int orig_node = -1;
 
-	install_node(&debug_node);
+	vrfname = pim_cli_get_vrf_name(vty);
+	if (vrfname) {
+		snprintf(xpath, sizeof(xpath), FRR_PIM_VRF_XPATH,
+			 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+		if (nb_cli_apply_changes_clear_pending(vty, NULL) ==
+		    CMD_SUCCESS) {
+			orig_node = vty->node;
+			VTY_PUSH_XPATH(PIM_NODE, xpath);
+		} else {
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else {
+		vty_out(vty, "%% Failed to determine vrf name\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 
-	install_element(ENABLE_NODE, &pim_test_sg_keepalive_cmd);
+	snprintf(mlag_peerlink_rif_xpath, sizeof(mlag_peerlink_rif_xpath),
+		 "./mlag/peerlink-rif");
+	nb_cli_enqueue_change(vty, mlag_peerlink_rif_xpath, NB_OP_MODIFY, iface);
 
+	snprintf(mlag_my_role_xpath, sizeof(mlag_my_role_xpath),
+		 "./mlag/my-role");
+	if (!strcmp(role, "primary")) {
+		nb_cli_enqueue_change(vty, mlag_my_role_xpath, NB_OP_MODIFY,
+				      "MLAG_ROLE_PRIMARY");
+	} else if (!strcmp(role, "secondary")) {
+		nb_cli_enqueue_change(vty, mlag_my_role_xpath, NB_OP_MODIFY,
+				      "MLAG_ROLE_SECONDARY");
+	} else {
+		vty_out(vty, "unknown MLAG role %s\n", role);
+		ret = CMD_WARNING;
+		goto done;
+	}
+
+	snprintf(mlag_peer_state_xpath, sizeof(mlag_peer_state_xpath),
+		 "./mlag/peer-state");
+	if (!strcmp(state, "up")) {
+		nb_cli_enqueue_change(vty, mlag_peer_state_xpath, NB_OP_MODIFY,
+				      "true");
+	} else if (strcmp(state, "down")) {
+		nb_cli_enqueue_change(vty, mlag_peer_state_xpath, NB_OP_MODIFY,
+				      "false");
+	} else {
+		vty_out(vty, "unknown MLAG state %s\n", state);
+		ret = CMD_WARNING;
+		goto done;
+	}
+
+	snprintf(mlag_reg_address_xpath, sizeof(mlag_reg_address_xpath),
+		 "./mlag/reg-address");
+	nb_cli_enqueue_change(vty, mlag_reg_address_xpath, NB_OP_MODIFY,
+			      addr_str);
+
+	ret = nb_cli_apply_changes(vty, NULL);
+
+done:
+	if (orig_node != -1) {
+		vty->node = orig_node;
+		vty->xpath_index--;
+	}
+
+	return ret;
+}
+
+struct cmd_node pim_node = {
+	.name = "pim",
+	.node = PIM_NODE,
+	.parent_node = CONFIG_NODE,
+	.prompt = "%s(config-pim)# ",
+	.config_write = pim_router_config_write,
+};
+
+/* This function installs all of the deprecated PIM configuration commands that live in the global config and/or VRF nodes
+ * This configuration has been moved to the new 'router pim' config node instead like all the other routing protocols.
+ * No new commands should be added here.
+ */
+static void pim_install_deprecated(void)
+{
 	install_element(CONFIG_NODE, &ip_pim_rp_cmd);
 	install_element(VRF_NODE, &ip_pim_rp_cmd);
 	install_element(CONFIG_NODE, &no_ip_pim_rp_cmd);
@@ -6449,8 +8155,8 @@ void pim_cmd_init(void)
 	install_element(CONFIG_NODE,
 			&no_ip_pim_spt_switchover_infinity_plist_cmd);
 	install_element(VRF_NODE, &no_ip_pim_spt_switchover_infinity_plist_cmd);
-	install_element(CONFIG_NODE, &pim_register_accept_list_cmd);
-	install_element(VRF_NODE, &pim_register_accept_list_cmd);
+	install_element(CONFIG_NODE, &ip_pim_register_accept_list_cmd);
+	install_element(VRF_NODE, &ip_pim_register_accept_list_cmd);
 	install_element(CONFIG_NODE, &ip_pim_joinprune_time_cmd);
 	install_element(CONFIG_NODE, &no_ip_pim_joinprune_time_cmd);
 	install_element(CONFIG_NODE, &ip_pim_keep_alive_cmd);
@@ -6467,14 +8173,6 @@ void pim_cmd_init(void)
 	install_element(VRF_NODE, &ip_pim_v6_secondary_cmd);
 	install_element(CONFIG_NODE, &no_ip_pim_v6_secondary_cmd);
 	install_element(VRF_NODE, &no_ip_pim_v6_secondary_cmd);
-	install_element(CONFIG_NODE, &ip_ssmpingd_cmd);
-	install_element(VRF_NODE, &ip_ssmpingd_cmd);
-	install_element(CONFIG_NODE, &no_ip_ssmpingd_cmd);
-	install_element(VRF_NODE, &no_ip_ssmpingd_cmd);
-	install_element(CONFIG_NODE, &ip_msdp_peer_cmd);
-	install_element(VRF_NODE, &ip_msdp_peer_cmd);
-	install_element(CONFIG_NODE, &no_ip_msdp_peer_cmd);
-	install_element(VRF_NODE, &no_ip_msdp_peer_cmd);
 	install_element(CONFIG_NODE, &ip_pim_ecmp_cmd);
 	install_element(VRF_NODE, &ip_pim_ecmp_cmd);
 	install_element(CONFIG_NODE, &no_ip_pim_ecmp_cmd);
@@ -6485,10 +8183,87 @@ void pim_cmd_init(void)
 	install_element(VRF_NODE, &no_ip_pim_ecmp_rebalance_cmd);
 	install_element(CONFIG_NODE, &ip_pim_mlag_cmd);
 	install_element(CONFIG_NODE, &no_ip_pim_mlag_cmd);
-	install_element(CONFIG_NODE, &ip_igmp_group_watermark_cmd);
-	install_element(VRF_NODE, &ip_igmp_group_watermark_cmd);
-	install_element(CONFIG_NODE, &no_ip_igmp_group_watermark_cmd);
-	install_element(VRF_NODE, &no_ip_igmp_group_watermark_cmd);
+
+	install_element(CONFIG_NODE, &ip_ssmpingd_cmd);
+	install_element(VRF_NODE, &ip_ssmpingd_cmd);
+	install_element(CONFIG_NODE, &no_ip_ssmpingd_cmd);
+	install_element(VRF_NODE, &no_ip_ssmpingd_cmd);
+
+	install_element(CONFIG_NODE, &ip_msdp_peer_cmd);
+	install_element(VRF_NODE, &ip_msdp_peer_cmd);
+	install_element(CONFIG_NODE, &no_ip_msdp_peer_cmd);
+	install_element(VRF_NODE, &no_ip_msdp_peer_cmd);
+	install_element(CONFIG_NODE, &ip_msdp_timers_cmd);
+	install_element(VRF_NODE, &ip_msdp_timers_cmd);
+	install_element(CONFIG_NODE, &no_ip_msdp_timers_cmd);
+	install_element(VRF_NODE, &no_ip_msdp_timers_cmd);
+	install_element(CONFIG_NODE, &ip_msdp_mesh_group_member_cmd);
+	install_element(VRF_NODE, &ip_msdp_mesh_group_member_cmd);
+	install_element(CONFIG_NODE, &no_ip_msdp_mesh_group_member_cmd);
+	install_element(VRF_NODE, &no_ip_msdp_mesh_group_member_cmd);
+	install_element(CONFIG_NODE, &ip_msdp_mesh_group_source_cmd);
+	install_element(VRF_NODE, &ip_msdp_mesh_group_source_cmd);
+	install_element(CONFIG_NODE, &no_ip_msdp_mesh_group_source_cmd);
+	install_element(VRF_NODE, &no_ip_msdp_mesh_group_source_cmd);
+	install_element(CONFIG_NODE, &no_ip_msdp_mesh_group_cmd);
+	install_element(VRF_NODE, &no_ip_msdp_mesh_group_cmd);
+}
+
+void pim_cmd_init(void)
+{
+	if_cmd_init(pim_interface_config_write);
+
+	install_node(&debug_node);
+
+	install_element(CONFIG_NODE, &router_pim_cmd);
+	install_element(CONFIG_NODE, &no_router_pim_cmd);
+
+	install_node(&pim_node);
+	install_default(PIM_NODE);
+
+	install_element(PIM_NODE, &pim_rp_cmd);
+	install_element(PIM_NODE, &no_pim_rp_cmd);
+	install_element(PIM_NODE, &pim_rp_prefix_list_cmd);
+	install_element(PIM_NODE, &no_pim_rp_prefix_list_cmd);
+	install_element(PIM_NODE, &no_pim_ssm_prefix_list_cmd);
+	install_element(PIM_NODE, &no_pim_ssm_prefix_list_name_cmd);
+	install_element(PIM_NODE, &pim_ssm_prefix_list_cmd);
+	install_element(PIM_NODE, &pim_register_suppress_cmd);
+	install_element(PIM_NODE, &no_pim_register_suppress_cmd);
+	install_element(PIM_NODE, &pim_spt_switchover_infinity_cmd);
+	install_element(PIM_NODE, &pim_spt_switchover_infinity_plist_cmd);
+	install_element(PIM_NODE, &no_pim_spt_switchover_infinity_cmd);
+	install_element(PIM_NODE, &no_pim_spt_switchover_infinity_plist_cmd);
+	install_element(PIM_NODE, &pim_register_accept_list_cmd);
+	install_element(PIM_NODE, &pim_joinprune_time_cmd);
+	install_element(PIM_NODE, &no_pim_joinprune_time_cmd);
+	install_element(PIM_NODE, &pim_keep_alive_cmd);
+	install_element(PIM_NODE, &pim_rp_keep_alive_cmd);
+	install_element(PIM_NODE, &no_pim_keep_alive_cmd);
+	install_element(PIM_NODE, &no_pim_rp_keep_alive_cmd);
+	install_element(PIM_NODE, &pim_packets_cmd);
+	install_element(PIM_NODE, &no_pim_packets_cmd);
+	install_element(PIM_NODE, &pim_v6_secondary_cmd);
+	install_element(PIM_NODE, &no_pim_v6_secondary_cmd);
+	install_element(PIM_NODE, &pim_ecmp_cmd);
+	install_element(PIM_NODE, &no_pim_ecmp_cmd);
+	install_element(PIM_NODE, &pim_ecmp_rebalance_cmd);
+	install_element(PIM_NODE, &no_pim_ecmp_rebalance_cmd);
+	install_element(PIM_NODE, &pim_mlag_cmd);
+	install_element(PIM_NODE, &no_pim_mlag_cmd);
+
+	install_element(PIM_NODE, &pim_ssmpingd_cmd);
+	install_element(PIM_NODE, &no_pim_ssmpingd_cmd);
+
+	install_element(PIM_NODE, &pim_msdp_peer_cmd);
+	install_element(PIM_NODE, &no_pim_msdp_peer_cmd);
+	install_element(PIM_NODE, &pim_msdp_timers_cmd);
+	install_element(PIM_NODE, &no_pim_msdp_timers_cmd);
+	install_element(PIM_NODE, &pim_msdp_mesh_group_member_cmd);
+	install_element(PIM_NODE, &no_pim_msdp_mesh_group_member_cmd);
+	install_element(PIM_NODE, &pim_msdp_mesh_group_source_cmd);
+	install_element(PIM_NODE, &no_pim_msdp_mesh_group_source_cmd);
+	install_element(PIM_NODE, &no_pim_msdp_mesh_group_cmd);
 
 	install_element(INTERFACE_NODE, &interface_ip_igmp_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ip_igmp_cmd);
@@ -6533,6 +8308,22 @@ void pim_cmd_init(void)
 	// Static mroutes NEB
 	install_element(INTERFACE_NODE, &interface_ip_mroute_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ip_mroute_cmd);
+
+	install_element(INTERFACE_NODE, &interface_pim_use_source_cmd);
+	install_element(INTERFACE_NODE, &interface_no_pim_use_source_cmd);
+	/* Install BSM command */
+	install_element(INTERFACE_NODE, &ip_pim_bsm_cmd);
+	install_element(INTERFACE_NODE, &no_ip_pim_bsm_cmd);
+	install_element(INTERFACE_NODE, &ip_pim_ucast_bsm_cmd);
+	install_element(INTERFACE_NODE, &no_ip_pim_ucast_bsm_cmd);
+	/* Install BFD command */
+	install_element(INTERFACE_NODE, &ip_pim_bfd_cmd);
+	install_element(INTERFACE_NODE, &ip_pim_bfd_param_cmd);
+	install_element(INTERFACE_NODE, &no_ip_pim_bfd_profile_cmd);
+	install_element(INTERFACE_NODE, &no_ip_pim_bfd_cmd);
+#if HAVE_BFDD == 0
+	install_element(INTERFACE_NODE, &no_ip_pim_bfd_param_cmd);
+#endif /* !HAVE_BFDD */
 
 	install_element(VIEW_NODE, &show_ip_igmp_interface_cmd);
 	install_element(VIEW_NODE, &show_ip_igmp_interface_vrf_all_cmd);
@@ -6590,6 +8381,20 @@ void pim_cmd_init(void)
 	install_element(VIEW_NODE, &show_ip_pim_bsrp_cmd);
 	install_element(VIEW_NODE, &show_ip_pim_bsm_db_cmd);
 	install_element(VIEW_NODE, &show_ip_pim_statistics_cmd);
+	install_element(VIEW_NODE, &show_ip_msdp_peer_detail_cmd);
+	install_element(VIEW_NODE, &show_ip_msdp_peer_detail_vrf_all_cmd);
+	install_element(VIEW_NODE, &show_ip_msdp_sa_detail_cmd);
+	install_element(VIEW_NODE, &show_ip_msdp_sa_detail_vrf_all_cmd);
+	install_element(VIEW_NODE, &show_ip_msdp_sa_sg_cmd);
+	install_element(VIEW_NODE, &show_ip_msdp_sa_sg_vrf_all_cmd);
+	install_element(VIEW_NODE, &show_ip_msdp_mesh_group_cmd);
+	install_element(VIEW_NODE, &show_ip_msdp_mesh_group_vrf_all_cmd);
+	install_element(VIEW_NODE, &show_ip_pim_ssm_range_cmd);
+	install_element(VIEW_NODE, &show_ip_pim_group_type_cmd);
+	install_element(VIEW_NODE, &show_ip_pim_vxlan_sg_cmd);
+	install_element(VIEW_NODE, &show_ip_pim_vxlan_sg_work_cmd);
+
+	install_element(ENABLE_NODE, &pim_test_sg_keepalive_cmd);
 
 	install_element(ENABLE_NODE, &clear_ip_mroute_count_cmd);
 	install_element(ENABLE_NODE, &clear_ip_interfaces_cmd);
@@ -6604,134 +8409,98 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &show_debugging_pim_cmd);
 
 	install_element(ENABLE_NODE, &debug_igmp_cmd);
-	install_element(ENABLE_NODE, &no_debug_igmp_cmd);
-	install_element(ENABLE_NODE, &debug_igmp_events_cmd);
-	install_element(ENABLE_NODE, &no_debug_igmp_events_cmd);
-	install_element(ENABLE_NODE, &debug_igmp_packets_cmd);
-	install_element(ENABLE_NODE, &no_debug_igmp_packets_cmd);
-	install_element(ENABLE_NODE, &debug_igmp_trace_cmd);
-	install_element(ENABLE_NODE, &no_debug_igmp_trace_cmd);
-	install_element(ENABLE_NODE, &debug_igmp_trace_detail_cmd);
-	install_element(ENABLE_NODE, &no_debug_igmp_trace_detail_cmd);
-	install_element(ENABLE_NODE, &debug_mroute_cmd);
-	install_element(ENABLE_NODE, &debug_mroute_detail_cmd);
-	install_element(ENABLE_NODE, &no_debug_mroute_cmd);
-	install_element(ENABLE_NODE, &no_debug_mroute_detail_cmd);
-	install_element(ENABLE_NODE, &debug_pim_static_cmd);
-	install_element(ENABLE_NODE, &no_debug_pim_static_cmd);
-	install_element(ENABLE_NODE, &debug_pim_cmd);
-	install_element(ENABLE_NODE, &debug_pim_nht_cmd);
-	install_element(ENABLE_NODE, &debug_pim_nht_det_cmd);
-	install_element(ENABLE_NODE, &debug_pim_nht_rp_cmd);
-	install_element(ENABLE_NODE, &no_debug_pim_nht_rp_cmd);
-	install_element(ENABLE_NODE, &debug_pim_events_cmd);
-	install_element(ENABLE_NODE, &debug_pim_packets_cmd);
-	install_element(ENABLE_NODE, &debug_pim_packetdump_send_cmd);
-	install_element(ENABLE_NODE, &debug_pim_packetdump_recv_cmd);
-	install_element(ENABLE_NODE, &debug_pim_trace_cmd);
-	install_element(ENABLE_NODE, &debug_pim_trace_detail_cmd);
-	install_element(ENABLE_NODE, &debug_ssmpingd_cmd);
-	install_element(ENABLE_NODE, &no_debug_ssmpingd_cmd);
-	install_element(ENABLE_NODE, &debug_pim_zebra_cmd);
-	install_element(ENABLE_NODE, &debug_pim_mlag_cmd);
-	install_element(ENABLE_NODE, &no_debug_pim_mlag_cmd);
-	install_element(ENABLE_NODE, &debug_pim_vxlan_cmd);
-	install_element(ENABLE_NODE, &no_debug_pim_vxlan_cmd);
-	install_element(ENABLE_NODE, &debug_msdp_cmd);
-	install_element(ENABLE_NODE, &no_debug_msdp_cmd);
-	install_element(ENABLE_NODE, &debug_msdp_events_cmd);
-	install_element(ENABLE_NODE, &no_debug_msdp_events_cmd);
-	install_element(ENABLE_NODE, &debug_msdp_packets_cmd);
-	install_element(ENABLE_NODE, &no_debug_msdp_packets_cmd);
-	install_element(ENABLE_NODE, &debug_mtrace_cmd);
-	install_element(ENABLE_NODE, &no_debug_mtrace_cmd);
-	install_element(ENABLE_NODE, &debug_bsm_cmd);
-	install_element(ENABLE_NODE, &no_debug_bsm_cmd);
-
 	install_element(CONFIG_NODE, &debug_igmp_cmd);
+	install_element(ENABLE_NODE, &no_debug_igmp_cmd);
 	install_element(CONFIG_NODE, &no_debug_igmp_cmd);
+	install_element(ENABLE_NODE, &debug_igmp_events_cmd);
 	install_element(CONFIG_NODE, &debug_igmp_events_cmd);
+	install_element(ENABLE_NODE, &no_debug_igmp_events_cmd);
 	install_element(CONFIG_NODE, &no_debug_igmp_events_cmd);
+	install_element(ENABLE_NODE, &debug_igmp_packets_cmd);
 	install_element(CONFIG_NODE, &debug_igmp_packets_cmd);
+	install_element(ENABLE_NODE, &no_debug_igmp_packets_cmd);
 	install_element(CONFIG_NODE, &no_debug_igmp_packets_cmd);
+	install_element(ENABLE_NODE, &debug_igmp_trace_cmd);
 	install_element(CONFIG_NODE, &debug_igmp_trace_cmd);
+	install_element(ENABLE_NODE, &no_debug_igmp_trace_cmd);
 	install_element(CONFIG_NODE, &no_debug_igmp_trace_cmd);
+	install_element(ENABLE_NODE, &debug_igmp_trace_detail_cmd);
 	install_element(CONFIG_NODE, &debug_igmp_trace_detail_cmd);
+	install_element(ENABLE_NODE, &no_debug_igmp_trace_detail_cmd);
 	install_element(CONFIG_NODE, &no_debug_igmp_trace_detail_cmd);
+	install_element(ENABLE_NODE, &debug_mroute_cmd);
 	install_element(CONFIG_NODE, &debug_mroute_cmd);
+	install_element(ENABLE_NODE, &debug_mroute_detail_cmd);
 	install_element(CONFIG_NODE, &debug_mroute_detail_cmd);
+	install_element(ENABLE_NODE, &no_debug_mroute_cmd);
 	install_element(CONFIG_NODE, &no_debug_mroute_cmd);
+	install_element(ENABLE_NODE, &no_debug_mroute_detail_cmd);
 	install_element(CONFIG_NODE, &no_debug_mroute_detail_cmd);
+	install_element(ENABLE_NODE, &debug_pim_static_cmd);
 	install_element(CONFIG_NODE, &debug_pim_static_cmd);
+	install_element(ENABLE_NODE, &no_debug_pim_static_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_static_cmd);
+	install_element(ENABLE_NODE, &debug_pim_cmd);
 	install_element(CONFIG_NODE, &debug_pim_cmd);
+	install_element(ENABLE_NODE, &debug_pim_nht_cmd);
 	install_element(CONFIG_NODE, &debug_pim_nht_cmd);
+	install_element(ENABLE_NODE, &debug_pim_nht_det_cmd);
 	install_element(CONFIG_NODE, &debug_pim_nht_det_cmd);
+	install_element(ENABLE_NODE, &debug_pim_nht_rp_cmd);
 	install_element(CONFIG_NODE, &debug_pim_nht_rp_cmd);
+	install_element(ENABLE_NODE, &no_debug_pim_nht_rp_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_nht_rp_cmd);
+	install_element(ENABLE_NODE, &debug_pim_events_cmd);
 	install_element(CONFIG_NODE, &debug_pim_events_cmd);
+	install_element(ENABLE_NODE, &debug_pim_packets_cmd);
 	install_element(CONFIG_NODE, &debug_pim_packets_cmd);
+	install_element(ENABLE_NODE, &debug_pim_packetdump_send_cmd);
 	install_element(CONFIG_NODE, &debug_pim_packetdump_send_cmd);
+	install_element(ENABLE_NODE, &debug_pim_packetdump_recv_cmd);
 	install_element(CONFIG_NODE, &debug_pim_packetdump_recv_cmd);
+	install_element(ENABLE_NODE, &debug_pim_trace_cmd);
 	install_element(CONFIG_NODE, &debug_pim_trace_cmd);
+	install_element(ENABLE_NODE, &debug_pim_trace_detail_cmd);
 	install_element(CONFIG_NODE, &debug_pim_trace_detail_cmd);
+	install_element(ENABLE_NODE, &debug_ssmpingd_cmd);
 	install_element(CONFIG_NODE, &debug_ssmpingd_cmd);
+	install_element(ENABLE_NODE, &no_debug_ssmpingd_cmd);
 	install_element(CONFIG_NODE, &no_debug_ssmpingd_cmd);
+	install_element(ENABLE_NODE, &debug_pim_zebra_cmd);
 	install_element(CONFIG_NODE, &debug_pim_zebra_cmd);
+	install_element(ENABLE_NODE, &debug_pim_mlag_cmd);
 	install_element(CONFIG_NODE, &debug_pim_mlag_cmd);
+	install_element(ENABLE_NODE, &no_debug_pim_mlag_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_mlag_cmd);
+	install_element(ENABLE_NODE, &debug_pim_vxlan_cmd);
 	install_element(CONFIG_NODE, &debug_pim_vxlan_cmd);
+	install_element(ENABLE_NODE, &no_debug_pim_vxlan_cmd);
 	install_element(CONFIG_NODE, &no_debug_pim_vxlan_cmd);
+	install_element(ENABLE_NODE, &debug_msdp_cmd);
 	install_element(CONFIG_NODE, &debug_msdp_cmd);
+	install_element(ENABLE_NODE, &no_debug_msdp_cmd);
 	install_element(CONFIG_NODE, &no_debug_msdp_cmd);
+	install_element(ENABLE_NODE, &debug_msdp_events_cmd);
 	install_element(CONFIG_NODE, &debug_msdp_events_cmd);
+	install_element(ENABLE_NODE, &no_debug_msdp_events_cmd);
 	install_element(CONFIG_NODE, &no_debug_msdp_events_cmd);
+	install_element(ENABLE_NODE, &debug_msdp_packets_cmd);
 	install_element(CONFIG_NODE, &debug_msdp_packets_cmd);
+	install_element(ENABLE_NODE, &no_debug_msdp_packets_cmd);
 	install_element(CONFIG_NODE, &no_debug_msdp_packets_cmd);
+	install_element(ENABLE_NODE, &debug_mtrace_cmd);
 	install_element(CONFIG_NODE, &debug_mtrace_cmd);
+	install_element(ENABLE_NODE, &no_debug_mtrace_cmd);
 	install_element(CONFIG_NODE, &no_debug_mtrace_cmd);
+	install_element(ENABLE_NODE, &debug_bsm_cmd);
 	install_element(CONFIG_NODE, &debug_bsm_cmd);
+	install_element(ENABLE_NODE, &no_debug_bsm_cmd);
 	install_element(CONFIG_NODE, &no_debug_bsm_cmd);
 
-	install_element(CONFIG_NODE, &ip_msdp_timers_cmd);
-	install_element(VRF_NODE, &ip_msdp_timers_cmd);
-	install_element(CONFIG_NODE, &no_ip_msdp_timers_cmd);
-	install_element(VRF_NODE, &no_ip_msdp_timers_cmd);
-	install_element(CONFIG_NODE, &ip_msdp_mesh_group_member_cmd);
-	install_element(VRF_NODE, &ip_msdp_mesh_group_member_cmd);
-	install_element(CONFIG_NODE, &no_ip_msdp_mesh_group_member_cmd);
-	install_element(VRF_NODE, &no_ip_msdp_mesh_group_member_cmd);
-	install_element(CONFIG_NODE, &ip_msdp_mesh_group_source_cmd);
-	install_element(VRF_NODE, &ip_msdp_mesh_group_source_cmd);
-	install_element(CONFIG_NODE, &no_ip_msdp_mesh_group_source_cmd);
-	install_element(VRF_NODE, &no_ip_msdp_mesh_group_source_cmd);
-	install_element(CONFIG_NODE, &no_ip_msdp_mesh_group_cmd);
-	install_element(VRF_NODE, &no_ip_msdp_mesh_group_cmd);
-	install_element(VIEW_NODE, &show_ip_msdp_peer_detail_cmd);
-	install_element(VIEW_NODE, &show_ip_msdp_peer_detail_vrf_all_cmd);
-	install_element(VIEW_NODE, &show_ip_msdp_sa_detail_cmd);
-	install_element(VIEW_NODE, &show_ip_msdp_sa_detail_vrf_all_cmd);
-	install_element(VIEW_NODE, &show_ip_msdp_sa_sg_cmd);
-	install_element(VIEW_NODE, &show_ip_msdp_sa_sg_vrf_all_cmd);
-	install_element(VIEW_NODE, &show_ip_msdp_mesh_group_cmd);
-	install_element(VIEW_NODE, &show_ip_msdp_mesh_group_vrf_all_cmd);
-	install_element(VIEW_NODE, &show_ip_pim_ssm_range_cmd);
-	install_element(VIEW_NODE, &show_ip_pim_group_type_cmd);
-	install_element(VIEW_NODE, &show_ip_pim_vxlan_sg_cmd);
-	install_element(VIEW_NODE, &show_ip_pim_vxlan_sg_work_cmd);
-	install_element(INTERFACE_NODE, &interface_pim_use_source_cmd);
-	install_element(INTERFACE_NODE, &interface_no_pim_use_source_cmd);
-	/* Install BSM command */
-	install_element(INTERFACE_NODE, &ip_pim_bsm_cmd);
-	install_element(INTERFACE_NODE, &no_ip_pim_bsm_cmd);
-	install_element(INTERFACE_NODE, &ip_pim_ucast_bsm_cmd);
-	install_element(INTERFACE_NODE, &no_ip_pim_ucast_bsm_cmd);
-	/* Install BFD command */
-	install_element(INTERFACE_NODE, &ip_pim_bfd_cmd);
-	install_element(INTERFACE_NODE, &ip_pim_bfd_param_cmd);
-	install_element(INTERFACE_NODE, &no_ip_pim_bfd_profile_cmd);
-	install_element(INTERFACE_NODE, &no_ip_pim_bfd_cmd);
-#if HAVE_BFDD == 0
-	install_element(INTERFACE_NODE, &no_ip_pim_bfd_param_cmd);
-#endif /* !HAVE_BFDD */
+	install_element(CONFIG_NODE, &ip_igmp_group_watermark_cmd);
+	install_element(VRF_NODE, &ip_igmp_group_watermark_cmd);
+	install_element(CONFIG_NODE, &no_ip_igmp_group_watermark_cmd);
+	install_element(VRF_NODE, &no_ip_igmp_group_watermark_cmd);
+
+	pim_install_deprecated();
 }

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -100,25 +100,13 @@ int pim_process_no_join_prune_cmd(struct vty *vty)
 
 int pim_process_spt_switchover_infinity_cmd(struct vty *vty)
 {
-	const char *vrfname;
 	char spt_plist_xpath[XPATH_MAXLEN];
 	char spt_action_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	snprintf(spt_plist_xpath, sizeof(spt_plist_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 FRR_PIM_AF_XPATH_VAL);
-	strlcat(spt_plist_xpath, "/spt-switchover/spt-infinity-prefix-list",
-		sizeof(spt_plist_xpath));
-
+		 "%s/spt-switchover/spt-infinity-prefix-list", VTY_CURR_XPATH);
 	snprintf(spt_action_xpath, sizeof(spt_action_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 FRR_PIM_AF_XPATH_VAL);
-	strlcat(spt_action_xpath, "/spt-switchover/spt-action",
-		sizeof(spt_action_xpath));
+		 "%s/spt-switchover/spt-action", VTY_CURR_XPATH);
 
 	if (yang_dnode_exists(vty->candidate_config->dnode, spt_plist_xpath))
 		nb_cli_enqueue_change(vty, spt_plist_xpath, NB_OP_DESTROY,
@@ -132,55 +120,30 @@ int pim_process_spt_switchover_infinity_cmd(struct vty *vty)
 int pim_process_spt_switchover_prefixlist_cmd(struct vty *vty,
 					      const char *plist)
 {
-	const char *vrfname;
 	char spt_plist_xpath[XPATH_MAXLEN];
 	char spt_action_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	snprintf(spt_plist_xpath, sizeof(spt_plist_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 FRR_PIM_AF_XPATH_VAL);
-	strlcat(spt_plist_xpath, "/spt-switchover/spt-infinity-prefix-list",
-		sizeof(spt_plist_xpath));
-
+		 "./spt-switchover/spt-infinity-prefix-list");
 	snprintf(spt_action_xpath, sizeof(spt_action_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 FRR_PIM_AF_XPATH_VAL);
-	strlcat(spt_action_xpath, "/spt-switchover/spt-action",
-		sizeof(spt_action_xpath));
+		 "./spt-switchover/spt-action");
 
 	nb_cli_enqueue_change(vty, spt_action_xpath, NB_OP_MODIFY,
 			      "PIM_SPT_INFINITY");
-	nb_cli_enqueue_change(vty, spt_plist_xpath, NB_OP_MODIFY,
-			      plist);
+	nb_cli_enqueue_change(vty, spt_plist_xpath, NB_OP_MODIFY, plist);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
 
 int pim_process_no_spt_switchover_cmd(struct vty *vty)
 {
-	const char *vrfname;
 	char spt_plist_xpath[XPATH_MAXLEN];
 	char spt_action_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	snprintf(spt_plist_xpath, sizeof(spt_plist_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 FRR_PIM_AF_XPATH_VAL);
-	strlcat(spt_plist_xpath, "/spt-switchover/spt-infinity-prefix-list",
-		sizeof(spt_plist_xpath));
-
+		 "./spt-switchover/spt-infinity-prefix-list");
 	snprintf(spt_action_xpath, sizeof(spt_action_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 FRR_PIM_AF_XPATH_VAL);
-	strlcat(spt_action_xpath, "/spt-switchover/spt-action",
-		sizeof(spt_action_xpath));
+		 "./spt-switchover/spt-action");
 
 	nb_cli_enqueue_change(vty, spt_plist_xpath, NB_OP_DESTROY, NULL);
 	nb_cli_enqueue_change(vty, spt_action_xpath, NB_OP_MODIFY,
@@ -217,35 +180,20 @@ int pim_process_no_pim_packet_cmd(struct vty *vty)
 
 int pim_process_keepalivetimer_cmd(struct vty *vty, const char *kat)
 {
-	const char *vrfname;
 	char ka_timer_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
+	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), "./keep-alive-timer");
 
-	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
-	strlcat(ka_timer_xpath, "/keep-alive-timer", sizeof(ka_timer_xpath));
-
-	nb_cli_enqueue_change(vty, ka_timer_xpath, NB_OP_MODIFY,
-			      kat);
+	nb_cli_enqueue_change(vty, ka_timer_xpath, NB_OP_MODIFY, kat);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
 
 int pim_process_no_keepalivetimer_cmd(struct vty *vty)
 {
-	const char *vrfname;
 	char ka_timer_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), FRR_PIM_VRF_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL);
-	strlcat(ka_timer_xpath, "/keep-alive-timer", sizeof(ka_timer_xpath));
+	snprintf(ka_timer_xpath, sizeof(ka_timer_xpath), "./keep-alive-timer");
 
 	nb_cli_enqueue_change(vty, ka_timer_xpath, NB_OP_DESTROY, NULL);
 
@@ -254,35 +202,25 @@ int pim_process_no_keepalivetimer_cmd(struct vty *vty)
 
 int pim_process_rp_kat_cmd(struct vty *vty, const char *rpkat)
 {
-	const char *vrfname;
 	char rp_ka_timer_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	snprintf(rp_ka_timer_xpath, sizeof(rp_ka_timer_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 FRR_PIM_AF_XPATH_VAL);
-	strlcat(rp_ka_timer_xpath, "/rp-keep-alive-timer",
-		sizeof(rp_ka_timer_xpath));
+		 "./rp-keep-alive-timer");
 
-	nb_cli_enqueue_change(vty, rp_ka_timer_xpath, NB_OP_MODIFY,
-			      rpkat);
+	nb_cli_enqueue_change(vty, rp_ka_timer_xpath, NB_OP_MODIFY, rpkat);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
 
 int pim_process_no_rp_kat_cmd(struct vty *vty)
 {
-	const char *vrfname;
 	char rp_ka_timer[6];
 	char rp_ka_timer_xpath[XPATH_MAXLEN];
 	uint v;
 	char rs_timer_xpath[XPATH_MAXLEN];
 
-	snprintf(rs_timer_xpath, sizeof(rs_timer_xpath),
-		 FRR_PIM_ROUTER_XPATH, FRR_PIM_AF_XPATH_VAL);
+	snprintf(rs_timer_xpath, sizeof(rs_timer_xpath), FRR_PIM_ROUTER_XPATH,
+		 FRR_PIM_AF_XPATH_VAL);
 	strlcat(rs_timer_xpath, "/register-suppress-time",
 		sizeof(rs_timer_xpath));
 
@@ -301,18 +239,10 @@ int pim_process_no_rp_kat_cmd(struct vty *vty)
 		v = UINT16_MAX;
 	snprintf(rp_ka_timer, sizeof(rp_ka_timer), "%u", v);
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	snprintf(rp_ka_timer_xpath, sizeof(rp_ka_timer_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 FRR_PIM_AF_XPATH_VAL);
-	strlcat(rp_ka_timer_xpath, "/rp-keep-alive-timer",
-		sizeof(rp_ka_timer_xpath));
+		 "./rp-keep-alive-timer");
 
-	nb_cli_enqueue_change(vty, rp_ka_timer_xpath, NB_OP_MODIFY,
-			      rp_ka_timer);
+	nb_cli_enqueue_change(vty, rp_ka_timer_xpath, NB_OP_MODIFY, rp_ka_timer);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -531,9 +461,7 @@ int pim_process_no_ip_mroute_cmd(struct vty *vty, const char *interface,
 int pim_process_rp_cmd(struct vty *vty, const char *rp_str,
 		       const char *group_str)
 {
-	const char *vrfname;
 	char group_xpath[XPATH_MAXLEN];
-	char rp_xpath[XPATH_MAXLEN];
 	int printed;
 	int result = 0;
 	struct prefix group;
@@ -575,14 +503,9 @@ int pim_process_rp_cmd(struct vty *vty, const char *rp_str,
 	}
 #endif
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(rp_xpath, sizeof(rp_xpath), FRR_PIM_STATIC_RP_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL, rp_str);
 	printed = snprintf(group_xpath, sizeof(group_xpath),
-			   "%s/group-list[.='%s']", rp_xpath, group_str);
+			   "./" FRR_PIM_STATIC_RP_XPATH "/group-list[.='%s']",
+			   rp_str, group_str);
 
 	if (printed >= (int)(sizeof(group_xpath))) {
 		vty_out(vty, "Xpath too long (%d > %u)", printed + 1,
@@ -601,15 +524,10 @@ int pim_process_no_rp_cmd(struct vty *vty, const char *rp_str,
 	char group_xpath[XPATH_MAXLEN];
 	char rp_xpath[XPATH_MAXLEN];
 	int printed;
-	const char *vrfname;
 	const struct lyd_node *group_dnode;
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(rp_xpath, sizeof(rp_xpath), FRR_PIM_STATIC_RP_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL, rp_str);
+	snprintf(rp_xpath, sizeof(rp_xpath), "%s/" FRR_PIM_STATIC_RP_XPATH,
+		 VTY_CURR_XPATH, rp_str);
 	printed = snprintf(group_xpath, sizeof(group_xpath),
 			   "%s/group-list[.='%s']", rp_xpath, group_str);
 
@@ -636,16 +554,10 @@ int pim_process_no_rp_cmd(struct vty *vty, const char *rp_str,
 int pim_process_rp_plist_cmd(struct vty *vty, const char *rp_str,
 			     const char *prefix_list)
 {
-	const char *vrfname;
 	char rp_plist_xpath[XPATH_MAXLEN];
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
 	snprintf(rp_plist_xpath, sizeof(rp_plist_xpath),
-		 FRR_PIM_STATIC_RP_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 FRR_PIM_AF_XPATH_VAL, rp_str);
+		 "./" FRR_PIM_STATIC_RP_XPATH, rp_str);
 	strlcat(rp_plist_xpath, "/prefix-list", sizeof(rp_plist_xpath));
 
 	nb_cli_enqueue_change(vty, rp_plist_xpath, NB_OP_MODIFY, prefix_list);
@@ -658,19 +570,12 @@ int pim_process_no_rp_plist_cmd(struct vty *vty, const char *rp_str,
 {
 	char rp_xpath[XPATH_MAXLEN];
 	char plist_xpath[XPATH_MAXLEN];
-	const char *vrfname;
 	const struct lyd_node *plist_dnode;
 	const char *plist;
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(rp_xpath, sizeof(rp_xpath), FRR_PIM_STATIC_RP_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL, rp_str);
-
-	snprintf(plist_xpath, sizeof(plist_xpath), FRR_PIM_STATIC_RP_XPATH,
-		 "frr-pim:pimd", "pim", vrfname, FRR_PIM_AF_XPATH_VAL, rp_str);
+	snprintf(rp_xpath, sizeof(rp_xpath), "%s/" FRR_PIM_STATIC_RP_XPATH,
+		 VTY_CURR_XPATH, rp_str);
+	snprintf(plist_xpath, sizeof(plist_xpath), "%s", rp_xpath);
 	strlcat(plist_xpath, "/prefix-list", sizeof(plist_xpath));
 
 	plist_dnode = yang_dnode_get(vty->candidate_config->dnode, plist_xpath);
@@ -679,7 +584,7 @@ int pim_process_no_rp_plist_cmd(struct vty *vty, const char *rp_str,
 		return NB_OK;
 	}
 
-	plist = yang_dnode_get_string(plist_dnode, "%s", plist_xpath);
+	plist = yang_dnode_get_string(plist_dnode, NULL);
 	if (strcmp(prefix_list, plist)) {
 		vty_out(vty, "%% Unable to find specified RP\n");
 		return NB_OK;
@@ -3408,21 +3313,11 @@ int gm_process_no_last_member_query_interval_cmd(struct vty *vty)
 int pim_process_ssmpingd_cmd(struct vty *vty, enum nb_operation operation,
 			     const char *src_str)
 {
-	const char *vrfname;
-	char ssmpingd_ip_xpath[XPATH_MAXLEN];
 	char ssmpingd_src_ip_xpath[XPATH_MAXLEN];
 	int printed;
 
-	vrfname = pim_cli_get_vrf_name(vty);
-	if (vrfname == NULL)
-		return CMD_WARNING_CONFIG_FAILED;
-
-	snprintf(ssmpingd_ip_xpath, sizeof(ssmpingd_ip_xpath),
-		 FRR_PIM_VRF_XPATH, "frr-pim:pimd", "pim", vrfname,
-		 FRR_PIM_AF_XPATH_VAL);
 	printed = snprintf(ssmpingd_src_ip_xpath, sizeof(ssmpingd_src_ip_xpath),
-			   "%s/ssm-pingd-source-ip[.='%s']", ssmpingd_ip_xpath,
-			   src_str);
+			   "./ssm-pingd-source-ip[.='%s']", src_str);
 	if (printed >= (int)sizeof(ssmpingd_src_ip_xpath)) {
 		vty_out(vty, "Xpath too long (%d > %u)", printed + 1,
 			XPATH_MAXLEN);
@@ -5704,4 +5599,35 @@ int pim_show_bsm_db_helper(const char *vrf, struct vty *vty, bool uj)
 	pim_show_bsm_db(v->info, vty, uj);
 
 	return CMD_SUCCESS;
+}
+
+int pim_router_config_write(struct vty *vty)
+{
+	struct vrf *vrf;
+	struct pim_instance *pim;
+	int writes = 0;
+	char framestr[64] = { 0 };
+
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+		pim = vrf->info;
+
+		if (!pim)
+			continue;
+
+		snprintfrr(framestr, sizeof(framestr), "router %s",
+			   PIM_AF_ROUTER);
+		if (vrf->vrf_id != VRF_DEFAULT) {
+			strlcat(framestr, " vrf ", sizeof(framestr));
+			strlcat(framestr, vrf->name, sizeof(framestr));
+		}
+		vty_frame(vty, "%s\n", framestr);
+		++writes;
+
+		writes += pim_global_config_write_worker(pim, vty);
+
+		vty_endframe(vty, "exit\n");
+		++writes;
+	}
+
+	return writes;
 }

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -182,6 +182,8 @@ int pim_show_interface_traffic_helper(const char *vrf, const char *if_name,
 void clear_pim_interfaces(struct pim_instance *pim);
 void pim_show_bsr(struct pim_instance *pim, struct vty *vty, bool uj);
 int pim_show_bsr_helper(const char *vrf, struct vty *vty, bool uj);
+int pim_router_config_write(struct vty *vty);
+
 /*
  * Special Macro to allow us to get the correct pim_instance;
  */

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -1276,8 +1276,7 @@ static void pim_msdp_src_del(struct pim_msdp_mg *mg)
 }
 
 /*********************** MSDP feature APIs *********************************/
-int pim_msdp_config_write(struct pim_instance *pim, struct vty *vty,
-			  const char *spaces)
+int pim_msdp_config_write(struct pim_instance *pim, struct vty *vty)
 {
 	struct pim_msdp_mg *mg;
 	struct listnode *mbrnode;
@@ -1292,14 +1291,14 @@ int pim_msdp_config_write(struct pim_instance *pim, struct vty *vty,
 		if (mg->src_ip.s_addr != INADDR_ANY) {
 			pim_inet4_dump("<src?>", mg->src_ip, src_str,
 				       sizeof(src_str));
-			vty_out(vty, "%sip msdp mesh-group %s source %s\n",
-				spaces, mg->mesh_group_name, src_str);
+			vty_out(vty, " msdp mesh-group %s source %s\n",
+				mg->mesh_group_name, src_str);
 			++count;
 		}
 
 		for (ALL_LIST_ELEMENTS_RO(mg->mbr_list, mbrnode, mbr)) {
-			vty_out(vty, "%sip msdp mesh-group %s member %pI4\n",
-				spaces, mg->mesh_group_name, &mbr->mbr_ip);
+			vty_out(vty, " msdp mesh-group %s member %pI4\n",
+				mg->mesh_group_name, &mbr->mbr_ip);
 			++count;
 		}
 	}
@@ -1307,8 +1306,7 @@ int pim_msdp_config_write(struct pim_instance *pim, struct vty *vty,
 	return count;
 }
 
-bool pim_msdp_peer_config_write(struct vty *vty, struct pim_instance *pim,
-				const char *spaces)
+bool pim_msdp_peer_config_write(struct vty *vty, struct pim_instance *pim)
 {
 	struct pim_msdp_peer *mp;
 	struct listnode *node;
@@ -1319,8 +1317,8 @@ bool pim_msdp_peer_config_write(struct vty *vty, struct pim_instance *pim,
 		if (mp->flags & PIM_MSDP_PEERF_IN_GROUP)
 			continue;
 
-		vty_out(vty, "%sip msdp peer %pI4 source %pI4\n", spaces,
-			&mp->peer, &mp->local);
+		vty_out(vty, " msdp peer %pI4 source %pI4\n", &mp->peer,
+			&mp->local);
 		written = true;
 	}
 

--- a/pimd/pim_msdp.h
+++ b/pimd/pim_msdp.h
@@ -228,10 +228,8 @@ void pim_msdp_peer_pkt_rxed(struct pim_msdp_peer *mp);
 void pim_msdp_peer_stop_tcp_conn(struct pim_msdp_peer *mp, bool chg_state);
 void pim_msdp_peer_reset_tcp_conn(struct pim_msdp_peer *mp, const char *rc_str);
 void pim_msdp_write(struct event *thread);
-int pim_msdp_config_write(struct pim_instance *pim, struct vty *vty,
-			  const char *spaces);
-bool pim_msdp_peer_config_write(struct vty *vty, struct pim_instance *pim,
-				const char *spaces);
+int pim_msdp_config_write(struct pim_instance *pim, struct vty *vty);
+bool pim_msdp_peer_config_write(struct vty *vty, struct pim_instance *pim);
 void pim_msdp_peer_pkt_txed(struct pim_msdp_peer *mp);
 void pim_msdp_sa_ref(struct pim_instance *pim, struct pim_msdp_peer *mp,
 		     pim_sgaddr *sg, struct in_addr rp);
@@ -339,14 +337,13 @@ static inline void pim_msdp_sa_local_del(struct pim_instance *pim,
 }
 
 static inline int pim_msdp_config_write(struct pim_instance *pim,
-					struct vty *vty, const char *spaces)
+					struct vty *vty)
 {
 	return 0;
 }
 
 static inline bool pim_msdp_peer_config_write(struct vty *vty,
-					      struct pim_instance *pim,
-					      const char *spaces)
+					      struct pim_instance *pim)
 {
 	return false;
 }

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -207,9 +207,6 @@ int routing_control_plane_protocols_name_validate(
 	"./frr-pim:pim/address-family[address-family='%s']/"            \
 	"mroute[source-addr='%s'][group-addr='%s']"
 #define FRR_PIM_STATIC_RP_XPATH                                         \
-	"/frr-routing:routing/control-plane-protocols/"                 \
-	"control-plane-protocol[type='%s'][name='%s'][vrf='%s']/"       \
-	"frr-pim:pim/address-family[address-family='%s']/"              \
 	"frr-pim-rp:rp/static-rp/rp-list[rp-address='%s']"
 #define FRR_GMP_INTERFACE_XPATH                                         \
 	"./frr-gmp:gmp/address-family[address-family='%s']"
@@ -218,6 +215,5 @@ int routing_control_plane_protocols_name_validate(
 #define FRR_GMP_JOIN_XPATH                                              \
 	"./frr-gmp:gmp/address-family[address-family='%s']/"            \
 	"static-group[group-addr='%s'][source-addr='%s']"
-#define FRR_PIM_MSDP_XPATH FRR_PIM_VRF_XPATH "/msdp"
 
 #endif /* _FRR_PIM_NB_H_ */

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -1129,8 +1129,7 @@ int pim_rp_set_upstream_addr(struct pim_instance *pim, pim_addr *up,
 	return 1;
 }
 
-int pim_rp_config_write(struct pim_instance *pim, struct vty *vty,
-			const char *spaces)
+int pim_rp_config_write(struct pim_instance *pim, struct vty *vty)
 {
 	struct listnode *node;
 	struct rp_info *rp_info;
@@ -1146,13 +1145,11 @@ int pim_rp_config_write(struct pim_instance *pim, struct vty *vty,
 
 		rp_addr = rp_info->rp.rpf_addr;
 		if (rp_info->plist)
-			vty_out(vty,
-				"%s" PIM_AF_NAME
-				" pim rp %pPA prefix-list %s\n",
-				spaces, &rp_addr, rp_info->plist);
+			vty_out(vty, " rp %pPA prefix-list %s\n", &rp_addr,
+				rp_info->plist);
 		else
-			vty_out(vty, "%s" PIM_AF_NAME " pim rp %pPA %pFX\n",
-				spaces, &rp_addr, &rp_info->group);
+			vty_out(vty, " rp %pPA %pFX\n", &rp_addr,
+				&rp_info->group);
 		count++;
 	}
 

--- a/pimd/pim_rp.h
+++ b/pimd/pim_rp.h
@@ -46,8 +46,7 @@ int pim_rp_change(struct pim_instance *pim, pim_addr new_rp_addr,
 void pim_rp_prefix_list_update(struct pim_instance *pim,
 			       struct prefix_list *plist);
 
-int pim_rp_config_write(struct pim_instance *pim, struct vty *vty,
-			const char *spaces);
+int pim_rp_config_write(struct pim_instance *pim, struct vty *vty);
 
 void pim_rp_setup(struct pim_instance *pim);
 

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -172,89 +172,66 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 {
 	int writes = 0;
 	struct pim_ssm *ssm = pim->ssm_info;
-	char spaces[10];
 
-	if (pim->vrf->vrf_id == VRF_DEFAULT)
-		snprintf(spaces, sizeof(spaces), "%s", "");
-	else
-		snprintf(spaces, sizeof(spaces), "%s", " ");
-
-	writes += pim_msdp_peer_config_write(vty, pim, spaces);
-	writes += pim_msdp_config_write(pim, vty, spaces);
+	writes += pim_msdp_peer_config_write(vty, pim);
+	writes += pim_msdp_config_write(pim, vty);
 
 	if (!pim->send_v6_secondary) {
-		vty_out(vty, "%sno ip pim send-v6-secondary\n", spaces);
+		vty_out(vty, " no send-v6-secondary\n");
 		++writes;
 	}
 
-	writes += pim_rp_config_write(pim, vty, spaces);
+	writes += pim_rp_config_write(pim, vty);
 
 	if (pim->vrf->vrf_id == VRF_DEFAULT) {
 		if (router->register_suppress_time
 		    != PIM_REGISTER_SUPPRESSION_TIME_DEFAULT) {
-			vty_out(vty, "%s" PIM_AF_NAME " pim register-suppress-time %d\n",
-				spaces, router->register_suppress_time);
+			vty_out(vty, " register-suppress-time %d\n",
+				router->register_suppress_time);
 			++writes;
 		}
 		if (router->t_periodic != PIM_DEFAULT_T_PERIODIC) {
-			vty_out(vty, "%s" PIM_AF_NAME " pim join-prune-interval %d\n",
-				spaces, router->t_periodic);
+			vty_out(vty, " join-prune-interval %d\n",
+				router->t_periodic);
 			++writes;
 		}
 
 		if (router->packet_process != PIM_DEFAULT_PACKET_PROCESS) {
-			vty_out(vty, "%s" PIM_AF_NAME " pim packets %d\n", spaces,
-				router->packet_process);
+			vty_out(vty, " packets %d\n", router->packet_process);
 			++writes;
 		}
 	}
 	if (pim->keep_alive_time != PIM_KEEPALIVE_PERIOD) {
-		vty_out(vty, "%s" PIM_AF_NAME " pim keep-alive-timer %d\n",
-			spaces, pim->keep_alive_time);
+		vty_out(vty, " keep-alive-timer %d\n", pim->keep_alive_time);
 		++writes;
 	}
 	if (pim->rp_keep_alive_time != (unsigned int)PIM_RP_KEEPALIVE_PERIOD) {
-		vty_out(vty, "%s" PIM_AF_NAME " pim rp keep-alive-timer %d\n",
-			spaces, pim->rp_keep_alive_time);
+		vty_out(vty, " rp keep-alive-timer %d\n",
+			pim->rp_keep_alive_time);
 		++writes;
 	}
 	if (ssm->plist_name) {
-		vty_out(vty, "%sip pim ssm prefix-list %s\n", spaces,
-			ssm->plist_name);
+		vty_out(vty, " ssm prefix-list %s\n", ssm->plist_name);
 		++writes;
 	}
 	if (pim->register_plist) {
-		vty_out(vty, "%sip pim register-accept-list %s\n", spaces,
-			pim->register_plist);
+		vty_out(vty, " register-accept-list %s\n", pim->register_plist);
 		++writes;
 	}
 	if (pim->spt.switchover == PIM_SPT_INFINITY) {
 		if (pim->spt.plist)
 			vty_out(vty,
-				"%s" PIM_AF_NAME " pim spt-switchover infinity-and-beyond prefix-list %s\n",
-				spaces, pim->spt.plist);
+				" spt-switchover infinity-and-beyond prefix-list %s\n",
+				pim->spt.plist);
 		else
-			vty_out(vty,
-				"%s" PIM_AF_NAME " pim spt-switchover infinity-and-beyond\n",
-				spaces);
+			vty_out(vty, " spt-switchover infinity-and-beyond\n");
 		++writes;
 	}
 	if (pim->ecmp_rebalance_enable) {
-		vty_out(vty, "%sip pim ecmp rebalance\n", spaces);
+		vty_out(vty, " ecmp rebalance\n");
 		++writes;
 	} else if (pim->ecmp_enable) {
-		vty_out(vty, "%sip pim ecmp\n", spaces);
-		++writes;
-	}
-
-	if (pim->gm_watermark_limit != 0) {
-#if PIM_IPV == 4
-		vty_out(vty, "%s" PIM_AF_NAME " igmp watermark-warn %u\n",
-			spaces, pim->gm_watermark_limit);
-#else
-		vty_out(vty, "%s" PIM_AF_NAME " mld watermark-warn %u\n",
-			spaces, pim->gm_watermark_limit);
-#endif
+		vty_out(vty, " ecmp\n");
 		++writes;
 	}
 
@@ -263,8 +240,7 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 		struct ssmpingd_sock *ss;
 		++writes;
 		for (ALL_LIST_ELEMENTS_RO(pim->ssmpingd_list, node, ss)) {
-			vty_out(vty, "%s" PIM_AF_NAME " ssmpingd %pPA\n",
-				spaces, &ss->source_addr);
+			vty_out(vty, " ssmpingd %pPA\n", &ss->source_addr);
 			++writes;
 		}
 	}
@@ -272,8 +248,8 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 	if (pim->msdp.hold_time != PIM_MSDP_PEER_HOLD_TIME
 	    || pim->msdp.keep_alive != PIM_MSDP_PEER_KA_TIME
 	    || pim->msdp.connection_retry != PIM_MSDP_PEER_CONNECT_RETRY_TIME) {
-		vty_out(vty, "%sip msdp timers %u %u", spaces,
-			pim->msdp.hold_time, pim->msdp.keep_alive);
+		vty_out(vty, " msdp timers %u %u", pim->msdp.hold_time,
+			pim->msdp.keep_alive);
 		if (pim->msdp.connection_retry
 		    != PIM_MSDP_PEER_CONNECT_RETRY_TIME)
 			vty_out(vty, " %u", pim->msdp.connection_retry);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1677,6 +1677,24 @@ static struct cmd_node bfd_profile_node = {
 };
 #endif /* HAVE_BFDD */
 
+#ifdef HAVE_PIMD
+static struct cmd_node pim_node = {
+	.name = "pim",
+	.node = PIM_NODE,
+	.parent_node = CONFIG_NODE,
+	.prompt = "%s(config-pim)# ",
+};
+#endif /* HAVE_PIMD */
+
+#ifdef HAVE_PIM6D
+static struct cmd_node pim6_node = {
+	.name = "pim6",
+	.node = PIM6_NODE,
+	.parent_node = CONFIG_NODE,
+	.prompt = "%s(config-pim6)# ",
+};
+#endif /* HAVE_PIM6D */
+
 /* Defined in lib/vty.c */
 extern struct cmd_node vty_node;
 
@@ -2413,6 +2431,30 @@ DEFUNSH(VTYSH_BFDD, bfd_profile_enter, bfd_profile_enter_cmd,
 }
 #endif /* HAVE_BFDD */
 
+#ifdef HAVE_PIMD
+DEFUNSH(VTYSH_PIMD, router_pim, router_pim_cmd,
+	"router pim [vrf NAME]",
+	ROUTER_STR
+	"Start PIM configuration\n"
+	VRF_CMD_HELP_STR)
+{
+	vty->node = PIM_NODE;
+	return CMD_SUCCESS;
+}
+#endif /* HAVE_PIMD */
+
+#ifdef HAVE_PIM6D
+DEFUNSH(VTYSH_PIM6D, router_pim6, router_pim6_cmd,
+	"router pim6 [vrf NAME]",
+	ROUTER_STR
+	"Start PIMv6 configuration\n"
+	VRF_CMD_HELP_STR)
+{
+	vty->node = PIM6_NODE;
+	return CMD_SUCCESS;
+}
+#endif /* HAVE_PIM6D*/
+
 DEFUNSH(VTYSH_ALL, vtysh_line_vty, vtysh_line_vty_cmd, "line vty",
 	"Configure a terminal line\n"
 	"Virtual terminal\n")
@@ -2825,6 +2867,34 @@ DEFUNSH(VTYSH_PATHD, vtysh_quit_pathd, vtysh_quit_pathd_cmd, "quit",
 	return vtysh_exit_pathd(self, vty, argc, argv);
 }
 #endif /* HAVE_PATHD */
+
+#ifdef HAVE_PIMD
+DEFUNSH(VTYSH_PIMD, vtysh_exit_pimd, vtysh_exit_pimd_cmd, "exit",
+	"Exit current mode and down to previous mode\n")
+{
+	return vtysh_exit(vty);
+}
+
+DEFUNSH(VTYSH_PIMD, vtysh_quit_pimd, vtysh_quit_pimd_cmd, "quit",
+	"Exit current mode and down to previous mode\n")
+{
+	return vtysh_exit_pimd(self, vty, argc, argv);
+}
+#endif /* HAVE_PIMD */
+
+#ifdef HAVE_PIM6D
+DEFUNSH(VTYSH_PIM6D, vtysh_exit_pim6d, vtysh_exit_pim6d_cmd, "exit",
+	"Exit current mode and down to previous mode\n")
+{
+	return vtysh_exit(vty);
+}
+
+DEFUNSH(VTYSH_PIM6D, vtysh_quit_pim6d, vtysh_quit_pim6d_cmd, "quit",
+	"Exit current mode and down to previous mode\n")
+{
+	return vtysh_exit_pim6d(self, vty, argc, argv);
+}
+#endif /* HAVE_PIM6D */
 
 DEFUNSH(VTYSH_ALL, vtysh_exit_line_vty, vtysh_exit_line_vty_cmd, "exit",
 	"Exit current mode and down to previous mode\n")
@@ -5293,6 +5363,25 @@ void vtysh_init_vty(void)
 	install_element(INTERFACE_NODE, &vtysh_exit_interface_cmd);
 	install_element(INTERFACE_NODE, &vtysh_quit_interface_cmd);
 
+	/* pimd */
+#ifdef HAVE_PIMD
+	install_node(&pim_node);
+	install_element(CONFIG_NODE, &router_pim_cmd);
+	install_element(PIM_NODE, &vtysh_exit_pimd_cmd);
+	install_element(PIM_NODE, &vtysh_quit_pimd_cmd);
+	install_element(PIM_NODE, &vtysh_end_all_cmd);
+#endif /* HAVE_PIMD */
+
+	/* pim6d */
+#ifdef HAVE_PIM6D
+	install_node(&pim6_node);
+	install_element(CONFIG_NODE, &router_pim6_cmd);
+	install_element(PIM6_NODE, &vtysh_exit_pim6d_cmd);
+	install_element(PIM6_NODE, &vtysh_quit_pim6d_cmd);
+	install_element(PIM6_NODE, &vtysh_end_all_cmd);
+#endif /* HAVE_PIM6D */
+
+	/* zebra and all, cont. */
 	install_node(&link_params_node);
 	install_element(INTERFACE_NODE, &vtysh_link_params_cmd);
 	install_element(LINK_PARAMS_NODE, &no_link_params_enable_cmd);

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -497,6 +497,11 @@ void vtysh_config_parse_line(void *arg, const char *line)
 			config = config_get(BFD_NODE, line);
 		else if (strncmp(line, "rpki", strlen("rpki")) == 0)
 			config = config_get(RPKI_NODE, line);
+		else if (strncmp(line, "router pim", strlen("router pim")) == 0)
+			config = config_get(PIM_NODE, line);
+		else if (strncmp(line, "router pim6", strlen("router pim6")) ==
+			 0)
+			config = config_get(PIM6_NODE, line);
 		else {
 			if (strncmp(line, "log", strlen("log")) == 0 ||
 			    strncmp(line, "hostname", strlen("hostname")) == 0 ||


### PR DESCRIPTION
Added new 'router pim[6] [vrf NAME]' config node.

Moved all existing global/vrf PIM configs to the new subnode and the existing configuration was set to be hidden and deprecated.
Both versions of the configuration still work together for the time being until they can be safely removed.

PIM now always writes out configuration in the "router pim" syntax so ,in order to support frr-reload, the JSON based configuration in the PIM topotests also needs to generate configuration in the same syntax.

Config file style tests are left in the global pim configuration syntax for now as a test of backwards compatibility.

Fixes #16196