### PR TITLE
zebra: Properly note that a nhg's nexthop has gone down

### DIFF
--- a/tests/topotests/isis_tilfa_topo1/rt5/step10/show_ip_route.ref
+++ b/tests/topotests/isis_tilfa_topo1/rt5/step10/show_ip_route.ref
@@ -457,8 +457,7 @@
           "fib":true,
           "ip":"10.0.8.6",
           "afi":"ipv4",
-          "interfaceName":"eth-rt6",
-          "active":true
+          "interfaceName":"eth-rt6"
         }
       ]
     }

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -215,7 +215,7 @@ static char re_status_output_char(const struct route_entry *re,
 			if (is_fib) {
 				star_p = !!CHECK_FLAG(nhop->flags,
 						      NEXTHOP_FLAG_FIB);
-			} else
+			} else if (CHECK_FLAG(nhop->flags, NEXTHOP_FLAG_ACTIVE))
 				star_p = true;
 		}
 


### PR DESCRIPTION
Current code when a link is set down is to just mark the nexthop group as not properly setup.  Leaving situations where when an interface goes down and show output is entered we see incorrect state.  This is true for anything that would be checking those flags at that point in time.

Modify the interface down nexthop group code to notice the nexthops appropriately ( and I mean set the appropriate flags ) and to allow a `show ip route` command to actually display what is going on with the nexthops.

eva# show ip route 1.0.0.0
Routing entry for 1.0.0.0/32
  Known via "sharp", distance 150, metric 0, best
  Last update 00:00:06 ago
  * 192.168.44.33, via dummy1, weight 1
  * 192.168.45.33, via dummy2, weight 1

sharpd@eva:~/frr1$ sudo ip link set dummy2 down

eva# show ip route 1.0.0.0
Routing entry for 1.0.0.0/32
  Known via "sharp", distance 150, metric 0, best
  Last update 00:00:12 ago
  * 192.168.44.33, via dummy1, weight 1 192.168.45.33, via dummy2 inactive, weight 1

Notice now that the 1.0.0.0/32 route now correctly displays the route for the nexthop group entry.