### PR TITLE
zebra: evpn: not coerce VTEP IP to IPv4 in nh_list

### DIFF
--- a/tests/topotests/bgp_evpn_rt5/r1/bgpd.conf
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgpd.conf
@@ -20,7 +20,11 @@ router bgp 65000 vrf r1-vrf-101
  address-family ipv4 unicast
   network 192.168.102.21/32
  exit-address-family
+ address-family ipv6 unicast
+  network fd00::1/128
+ exit-address-family
  address-family l2vpn evpn
   advertise ipv4 unicast
+  advertise ipv6 unicast
  exit-address-family
  !

--- a/tests/topotests/bgp_evpn_rt5/r1/zebra.conf
+++ b/tests/topotests/bgp_evpn_rt5/r1/zebra.conf
@@ -17,6 +17,7 @@ interface r1-eth0
 !
 interface loop101 vrf r1-vrf-101
  ip address 192.168.102.21/32
+ ipv6 address fd00::1/128
 !
 
 

--- a/tests/topotests/bgp_evpn_rt5/r2/bgpd.conf
+++ b/tests/topotests/bgp_evpn_rt5/r2/bgpd.conf
@@ -21,7 +21,11 @@ router bgp 65000 vrf r2-vrf-101
  address-family ipv4 unicast
   network 192.168.101.41/32
  exit-address-family
+ address-family ipv6 unicast
+  network fd00::2/128
+ exit-address-family
  address-family l2vpn evpn
   advertise ipv4 unicast
+  advertise ipv6 unicast
  exit-address-family
  !

--- a/tests/topotests/bgp_evpn_rt5/r2/zebra.conf
+++ b/tests/topotests/bgp_evpn_rt5/r2/zebra.conf
@@ -11,6 +11,7 @@ vrf r2-vrf-101
 !
 interface loop101 vrf r2-vrf-101
  ip address 192.168.101.41/32
+ ipv6 address fd00::2/128
 !
 interface r2-eth0
  ip address 192.168.100.41/24

--- a/tests/topotests/bgp_evpn_rt5/test_bgp_evpn.py
+++ b/tests/topotests/bgp_evpn_rt5/test_bgp_evpn.py
@@ -25,6 +25,8 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
+from lib.bgp import verify_bgp_rib
+from lib.common_config import apply_raw_config
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
@@ -179,11 +181,17 @@ def test_protocols_convergence():
     output = tgen.gears["r1"].vtysh_cmd("show bgp vrf r1-vrf-101 ipv4", isjson=False)
     logger.info("==== result from show bgp vrf r1-vrf-101 ipv4")
     logger.info(output)
+    output = tgen.gears["r1"].vtysh_cmd("show bgp vrf r1-vrf-101 ipv6", isjson=False)
+    logger.info("==== result from show bgp vrf r1-vrf-101 ipv6")
+    logger.info(output)
     output = tgen.gears["r1"].vtysh_cmd("show bgp vrf r1-vrf-101", isjson=False)
     logger.info("==== result from show bgp vrf r1-vrf-101 ")
     logger.info(output)
     output = tgen.gears["r1"].vtysh_cmd("show ip route vrf r1-vrf-101", isjson=False)
     logger.info("==== result from show ip route vrf r1-vrf-101")
+    logger.info(output)
+    output = tgen.gears["r1"].vtysh_cmd("show ipv6 route vrf r1-vrf-101", isjson=False)
+    logger.info("==== result from show ipv6 route vrf r1-vrf-101")
     logger.info(output)
     output = tgen.gears["r1"].vtysh_cmd("show evpn vni detail", isjson=False)
     logger.info("==== result from show evpn vni detail")
@@ -192,10 +200,125 @@ def test_protocols_convergence():
     logger.info("==== result from show evpn next-hops vni all")
     logger.info(output)
     output = tgen.gears["r1"].vtysh_cmd("show evpn rmac vni all", isjson=False)
-    logger.info("==== result from show evpn next-hops vni all")
+    logger.info("==== result from show evpn rmac vni all")
     logger.info(output)
+
+    expected = {
+        "fd00::2/128": [
+            {
+                "prefix": "fd00::2/128",
+                "vrfName": "r1-vrf-101",
+                "nexthops": [
+                    {
+                        "ip": "::ffff:c0a8:6429",
+                    }
+                ],
+            }
+        ]
+    }
+    result = topotest.router_json_cmp(
+        tgen.gears["r1"], "show ipv6 route vrf r1-vrf-101 fd00::2/128 json", expected
+    )
+    assert result is None, "ipv6 route check failed"
+
+    expected = {
+        "101": {
+            "numNextHops": 2,
+            "192.168.100.41": {
+                "nexthopIp": "192.168.100.41",
+            },
+            "::ffff:c0a8:6429": {
+                "nexthopIp": "::ffff:c0a8:6429",
+            },
+        }
+    }
+    result = topotest.router_json_cmp(
+        tgen.gears["r1"], "show evpn next-hops vni all json", expected
+    )
+    assert result is None, "evpn next-hops check failed"
+
+    expected = {"101": {"numRmacs": 1}}
+    result = topotest.router_json_cmp(
+        tgen.gears["r1"], "show evpn rmac vni all json", expected
+    )
+    assert result is None, "evpn rmac number check failed"
+
     # Check IPv4 and IPv6 connectivity between r1 and r2 ( routing vxlan evpn)
     pingrouter = tgen.gears["r1"]
+    logger.info(
+        "Check Ping IPv4 from  R1(r1-vrf-101) to R2(r2-vrf-101 = 192.168.101.41)"
+    )
+    output = pingrouter.run("ip netns exec r1-vrf-101 ping 192.168.101.41 -f -c 1000")
+    logger.info(output)
+    if "1000 packets transmitted, 1000 received" not in output:
+        assertmsg = (
+            "expected ping IPv4 from R1(r1-vrf-101) to R2(192.168.101.41) should be ok"
+        )
+        assert 0, assertmsg
+    else:
+        logger.info("Check Ping IPv4 from R1(r1-vrf-101) to R2(192.168.101.41) OK")
+
+    logger.info("Check Ping IPv6 from  R1(r1-vrf-101) to R2(r2-vrf-101 = fd00::2)")
+    output = pingrouter.run("ip netns exec r1-vrf-101 ping fd00::2 -f -c 1000")
+    logger.info(output)
+    if "1000 packets transmitted, 1000 received" not in output:
+        assert 0, "expected ping IPv6 from R1(r1-vrf-101) to R2(fd00::2) should be ok"
+    else:
+        logger.info("Check Ping IPv6 from R1(r1-vrf-101) to R2(fd00::2) OK")
+
+    config_no_ipv6 = {
+        "r2": {
+            "raw_config": [
+                "router bgp 65000 vrf r2-vrf-101",
+                "address-family ipv6 unicast",
+                "no network fd00::2/128",
+            ]
+        }
+    }
+
+    logger.info("==== Remove IPv6 network on R2")
+    result = apply_raw_config(tgen, config_no_ipv6)
+    assert result is True, "Failed to remove IPv6 network on R2, Error: {} ".format(
+        result
+    )
+    ipv6_routes = {
+        "r1": {
+            "static_routes": [
+                {
+                    "vrf": "r1-vrf-101",
+                    "network": ["fd00::2/128"],
+                }
+            ]
+        }
+    }
+    result = verify_bgp_rib(tgen, "ipv6", "r1", ipv6_routes, expected=False)
+    assert result is not True, "expect IPv6 route fd00::2/128 withdrawn"
+    output = tgen.gears["r1"].vtysh_cmd("show evpn next-hops vni all", isjson=False)
+    logger.info("==== result from show evpn next-hops vni all")
+    logger.info(output)
+    output = tgen.gears["r1"].vtysh_cmd("show evpn rmac vni all", isjson=False)
+    logger.info("==== result from show evpn next-hops vni all")
+    logger.info(output)
+
+    expected = {
+        "101": {
+            "numNextHops": 1,
+            "192.168.100.41": {
+                "nexthopIp": "192.168.100.41",
+            },
+        }
+    }
+    result = topotest.router_json_cmp(
+        tgen.gears["r1"], "show evpn next-hops vni all json", expected
+    )
+    assert result is None, "evpn next-hops check failed"
+
+    expected = {"101": {"numRmacs": 1}}
+    result = topotest.router_json_cmp(
+        tgen.gears["r1"], "show evpn rmac vni all json", expected
+    )
+    assert result is None, "evpn rmac number check failed"
+
     logger.info(
         "Check Ping IPv4 from  R1(r1-vrf-101) to R2(r2-vrf-101 = 192.168.101.41)"
     )


### PR DESCRIPTION
In L3 BGP-EVPN, if there are both IPv4 and IPv6 routes in the VPN, zebra maintains two instances of `struct zebra_neigh` object: one with IPv4 address of the nexthop, and another with IPv6 address that is an IPv4 mapped to IPv6, but only one intance of `struct zebra_mac` object, that contains a list of nexthop addresses that use this mac.

The code in `zebra_vxlan` module uses the fact that the list is empty as the indication that the `zebra_mac` object is unused, and needs to be dropped. However, preexisting code used nexthop address converted to IPv4 notation for the element of this list. As a result, when two `zebra_neigh` objects, one IPv4 and one IPv6-mapped-IPv4 were linked to the `zebra_mac` object, only one element was added to the list. Consequently, when one of the two `zebra_neigh` objects was dropped, the only element in the list was removed, making it empty, and `zebra_mac` object was dropped, and neigbrour cache elements uninstalled from the kernel.

As a result, after the last route in _one_ family was removed from a remote vtep, all remaining routes in the _other_ family became unreachable, because RMAC of the vtep was removed.

This commit makes `zebra_mac` use uncoerced IP address of the `zebra_neigh` object for the entries in the `nh_list`. This way, `zebra_mac` object no longer loses track of `zebra_neigh` objects that need it.

Bug-ID: 16340