### PR TITLE
sharpd: fix set ZAPI_MESSAGE_NEXTHOP in nhg only when nexthops used

### DIFF
--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -247,12 +247,12 @@ static bool route_add(const struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
 	memcpy(&api.prefix, p, sizeof(*p));
 
 	api.flags = flags;
-	SET_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP);
 
 	/* Only send via ID if nhgroup has been successfully installed */
 	if (nhgid && sharp_nhgroup_id_is_installed(nhgid)) {
 		zapi_route_set_nhg_id(&api, &nhgid);
 	} else {
+		SET_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP);
 		for (ALL_NEXTHOPS_PTR(nhg, nh)) {
 			/* Check if we set a VNI label */
 			if (nh->nh_label &&


### PR DESCRIPTION
The ZAPI_MESSAGE_NEXTHOP flag is systematically set, even if the route message does not include any nexthops. Limit the usage of this value only when nexthops are present.

Fixes: 8a71d93d85a6 ("sharpd: Add Super Happy Advanced Routing Protocol")