### PR TITLE
tests: tweak timers to avoid frequent failures on slow CI hardware

### DIFF
--- a/tests/topotests/ospf_metric_propagation/r1/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/r1/frr.conf
@@ -8,18 +8,18 @@ interface r1-eth0
  ip address 10.0.1.1/24
  ip ospf cost 100
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 interface r1-eth1 vrf blue
  ip address 10.0.10.1/24
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 !
 interface r1-eth2 vrf green
  ip address 10.0.91.1/24
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 !
 router ospf

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-1.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-1.json
@@ -2,32 +2,15 @@
   "10.0.94.0/24":[
     {
       "prefix":"10.0.94.0/24",
-      "prefixLen":24,
       "protocol":"bgp",
       "vrfName":"green",
-      "selected":true,
-      "destSelected":true,
-      "distance":20,
       "metric":34,
       "installed":true,
-      "table":12,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
-      "nexthopGroupId":"*",
-      "installedNexthopGroupId":"*",
-      "uptime":"*",
       "nexthops":[
         {
-          "flags":3,
-          "fib":true,
           "ip":"10.0.10.5",
-          "afi":"ipv4",
           "interfaceName":"r1-eth1",
-          "vrf":"blue",
-          "active":true,
-          "weight":1
+          "vrf":"blue"
         }
       ]
     }

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-2.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-2.json
@@ -2,32 +2,15 @@
   "10.0.94.0/24":[
     {
       "prefix":"10.0.94.0/24",
-      "prefixLen":24,
       "protocol":"bgp",
       "vrfName":"green",
-      "selected":true,
-      "destSelected":true,
-      "distance":20,
       "metric":136,
       "installed":true,
-      "table":12,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
-      "nexthopGroupId":"*",
-      "installedNexthopGroupId":"*",
-      "uptime":"*",
       "nexthops":[
         {
-          "flags":3,
-          "fib":true,
           "ip":"10.0.1.2",
-          "afi":"ipv4",
           "interfaceName":"r1-eth0",
-          "vrf":"default",
-          "active":true,
-          "weight":1
+          "vrf":"default"
         }
       ]
     }

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-3.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-3.json
@@ -2,32 +2,15 @@
   "10.0.94.0/24":[
     {
       "prefix":"10.0.94.0/24",
-      "prefixLen":24,
       "protocol":"bgp",
       "vrfName":"green",
-      "selected":true,
-      "destSelected":true,
-      "distance":20,
       "metric":1138,
       "installed":true,
-      "table":12,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
-      "nexthopGroupId":"*",
-      "installedNexthopGroupId":"*",
-      "uptime":"*",
       "nexthops":[
         {
-          "flags":3,
-          "fib":true,
           "ip":"10.0.1.2",
-          "afi":"ipv4",
           "interfaceName":"r1-eth0",
-          "vrf":"default",
-          "active":true,
-          "weight":1
+          "vrf":"default"
         }
       ]
     }

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-4.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-4.json
@@ -2,32 +2,15 @@
   "10.0.94.0/24":[
     {
       "prefix":"10.0.94.0/24",
-      "prefixLen":24,
       "protocol":"bgp",
       "vrfName":"green",
-      "selected":true,
-      "destSelected":true,
-      "distance":20,
       "metric":1218,
       "installed":true,
-      "table":12,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
-      "nexthopGroupId":"*",
-      "installedNexthopGroupId":"*",
-      "uptime":"*",
       "nexthops":[
         {
-          "flags":3,
-          "fib":true,
           "ip":"10.0.1.2",
-          "afi":"ipv4",
           "interfaceName":"r1-eth0",
-          "vrf":"default",
-          "active":true,
-          "weight":1
+          "vrf":"default"
         }
       ]
     }

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-5.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-5.json
@@ -2,32 +2,15 @@
   "10.0.94.0/24":[
     {
       "prefix":"10.0.94.0/24",
-      "prefixLen":24,
       "protocol":"bgp",
       "vrfName":"green",
-      "selected":true,
-      "destSelected":true,
-      "distance":20,
       "metric":238,
       "installed":true,
-      "table":12,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
-      "nexthopGroupId":"*",
-      "installedNexthopGroupId":"*",
-      "uptime":"*",
       "nexthops":[
         {
-          "flags":3,
-          "fib":true,
           "ip":"10.0.1.2",
-          "afi":"ipv4",
           "interfaceName":"r1-eth0",
-          "vrf":"default",
-          "active":true,
-          "weight":1
+          "vrf":"default"
         }
       ]
     }

--- a/tests/topotests/ospf_metric_propagation/r1/show_ip_route-6.json
+++ b/tests/topotests/ospf_metric_propagation/r1/show_ip_route-6.json
@@ -2,32 +2,15 @@
   "10.0.94.0/24":[
     {
       "prefix":"10.0.94.0/24",
-      "prefixLen":24,
       "protocol":"bgp",
       "vrfName":"green",
-      "selected":true,
-      "destSelected":true,
-      "distance":20,
       "metric":136,
       "installed":true,
-      "table":12,
-      "internalStatus":16,
-      "internalFlags":8,
-      "internalNextHopNum":1,
-      "internalNextHopActiveNum":1,
-      "nexthopGroupId":"*",
-      "installedNexthopGroupId":"*",
-      "uptime":"*",
       "nexthops":[
         {
-          "flags":3,
-          "fib":true,
           "ip":"10.0.10.5",
-          "afi":"ipv4",
           "interfaceName":"r1-eth1",
-          "vrf":"blue",
-          "active":true,
-          "weight":1
+          "vrf":"blue"
         }
       ]
     }

--- a/tests/topotests/ospf_metric_propagation/r2/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/r2/frr.conf
@@ -8,18 +8,18 @@ interface r2-eth0
  ip address 10.0.1.2/24
  ip ospf cost 100
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 interface r2-eth1 vrf blue
  ip address 10.0.20.2/24
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 interface r2-eth2 vrf green
  ip address 10.0.70.2/24
  ip ospf cost 1000
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 router ospf
   ospf router-id 10.0.255.2

--- a/tests/topotests/ospf_metric_propagation/r3/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/r3/frr.conf
@@ -8,18 +8,18 @@ interface r3-eth0
  ip address 10.0.3.3/24
  ip ospf cost 100
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 interface r3-eth1 vrf blue
  ip address 10.0.30.3/24
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 interface r3-eth2 vrf green
  ip address 10.0.80.3/24
  ip ospf cost 1000
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 router ospf
   ospf router-id 10.0.255.3

--- a/tests/topotests/ospf_metric_propagation/r4/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/r4/frr.conf
@@ -8,17 +8,17 @@ interface r4-eth0
  ip address 10.0.3.4/24
  ip ospf cost 100
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 interface r4-eth1 vrf blue
  ip address 10.0.40.4/24
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 interface r4-eth2 vrf green
  ip address 10.0.94.4/24
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 router ospf
   ospf router-id 10.0.255.4

--- a/tests/topotests/ospf_metric_propagation/ra/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/ra/frr.conf
@@ -7,17 +7,17 @@ ip forwarding
 interface ra-eth0
  ip address 10.0.50.5/24
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 interface ra-eth1
  ip address 10.0.10.5/24
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 interface ra-eth2
  ip address 10.0.20.5/24
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 router ospf
   ospf router-id 10.0.255.5

--- a/tests/topotests/ospf_metric_propagation/rb/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/rb/frr.conf
@@ -7,17 +7,17 @@ ip forwarding
 interface rb-eth0
  ip address 10.0.50.6/24
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 interface rb-eth1
  ip address 10.0.30.6/24
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 interface rb-eth2
  ip address 10.0.40.6/24
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 router ospf
   ospf router-id 10.0.255.6

--- a/tests/topotests/ospf_metric_propagation/rc/frr.conf
+++ b/tests/topotests/ospf_metric_propagation/rc/frr.conf
@@ -7,12 +7,12 @@ ip forwarding
 interface rc-eth0
  ip address 10.0.70.7/24
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 interface rc-eth1
  ip address 10.0.80.7/24
  ip ospf hello-interval 1
- ip ospf dead-interval 30
+ ip ospf dead-interval 40
 !
 router ospf
   ospf router-id 10.0.255.7

--- a/tests/topotests/ospf_metric_propagation/test_ospf_metric_propagation.py
+++ b/tests/topotests/ospf_metric_propagation/test_ospf_metric_propagation.py
@@ -282,7 +282,7 @@ def test_link_1_2_3_4_down():
     assert result is None, assertmsg
 
 
-def test_link_1_2_4_down():
+def test_link_1_2_4_down_3_up():
     "Test path R1 -> R2 -> Rc -> R3  -> R4"
     tgen = get_topogen()
 
@@ -304,7 +304,7 @@ def test_link_1_2_4_down():
     assert result is None, assertmsg
 
 
-def test_link_1_4_down():
+def test_link_1_4_down_2_up():
     "Test path R1 -> R2 -> Ra -> Rb -> R3  -> R4"
     tgen = get_topogen()
 
@@ -320,13 +320,13 @@ def test_link_1_4_down():
     test_func = partial(
         topotest.router_json_cmp, r1, "show ip route vrf green 10.0.94.2 json", expected
     )
-    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    _, result = topotest.run_and_expect(test_func, None, count=120, wait=2)
 
     assertmsg = "r1 JSON output mismatches"
     assert result is None, assertmsg
 
 
-def test_link_4_down():
+def test_link_4_down_1_up():
     "Test path R1 -> Ra -> Rb -> R3  -> R4"
     tgen = get_topogen()
 
@@ -342,7 +342,7 @@ def test_link_4_down():
     test_func = partial(
         topotest.router_json_cmp, r1, "show ip route vrf green 10.0.94.2 json", expected
     )
-    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    _, result = topotest.run_and_expect(test_func, None, count=120, wait=2)
 
     assertmsg = "r1 JSON output mismatches"
     assert result is None, assertmsg
@@ -364,7 +364,7 @@ def test_link_1_2_3_4_up():
     test_func = partial(
         topotest.router_json_cmp, r1, "show ip route vrf green 10.0.94.2 json", expected
     )
-    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    _, result = topotest.run_and_expect(test_func, None, count=120, wait=2)
 
     assertmsg = "r1 JSON output mismatches"
     assert result is None, assertmsg


### PR DESCRIPTION
This tests started failing more frequently on Debian ARM recently. Could be just a slow convergence issue, so I'm giving it extra time to converge. I may need to do the same with other test cases in the file, but will wait and see the result of changing this one only.