### PR TITLE
staticd: fix missing static routes

### DIFF
--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -341,7 +341,8 @@ void static_zebra_nht_register(struct static_nexthop *nh, bool reg)
 			/* refresh with existing data */
 			afi_t afi = prefix_afi(&lookup.nh);
 
-			if (nh->state == STATIC_NOT_INSTALLED)
+			if (nh->state == STATIC_NOT_INSTALLED ||
+			    nh->state == STATIC_SENT_TO_ZEBRA)
 				nh->state = STATIC_START;
 			static_nht_update(&rn->p, &nhtd->nh, nhtd->nh_num, afi,
 					  si->safi, nh->nh_vrf_id);


### PR DESCRIPTION
Use `vtysh` with this input file:
```
ip route A nh1
ip route A nh2
ip route B nh1
ip route B nh2
```

When running "ip route B" with "nh1" and "nh2", the procedure maybe is: 
1) Create the two nexthops: "nh1" and "nh2".
2) Register "nh1" with `static_zebra_nht_register()`, then the states of both
   "nh1" and "nht2" are set to "STATIC_SENT_TO_ZEBRA".
3) Register "nh2" with `static_zebra_nht_register()`, then only the routes with
   nexthop of "STATIC_START" will be sent to zebra.

So, send the routes with the nexthop of "STATIC_SENT_TO_ZEBRA" to zebra.