### PR TITLE
ospfd: fix internal ldp-sync state flags when feature is disabled

### DIFF
--- a/ospfd/ospf_ldp_sync.c
+++ b/ospfd/ospf_ldp_sync.c
@@ -901,7 +901,7 @@ DEFPY (no_mpls_ldp_sync,
 	 *  stop holddown timer if running
 	 *  restore ospf cost
 	 */
-	SET_FLAG(ldp_sync_info->flags, LDP_SYNC_FLAG_IF_CONFIG);
+	UNSET_FLAG(ldp_sync_info->flags, LDP_SYNC_FLAG_IF_CONFIG);
 	ldp_sync_info->enabled = LDP_IGP_SYNC_DEFAULT;
 	ldp_sync_info->state = LDP_IGP_SYNC_STATE_NOT_REQUIRED;
 	EVENT_OFF(ldp_sync_info->t_holddown);

--- a/tests/topotests/ldp_sync_ospf_topo1/r2/show_ospf_ldp_sync.ref
+++ b/tests/topotests/ldp_sync_ospf_topo1/r2/show_ospf_ldp_sync.ref
@@ -5,8 +5,8 @@
     "ldpIgpSyncState":"Sync achieved"
   },
   "r2-eth2":{
-    "ldpIgpSyncEnabled":false,
+    "ldpIgpSyncEnabled":true,
     "holdDownTimeInSec":50,
-    "ldpIgpSyncState":"Sync not required"
+    "ldpIgpSyncState":"Sync achieved"
   }
 }

--- a/tests/topotests/ldp_sync_ospf_topo1/r2/show_ospf_ldp_sync_r1_eth1_shutdown.ref
+++ b/tests/topotests/ldp_sync_ospf_topo1/r2/show_ospf_ldp_sync_r1_eth1_shutdown.ref
@@ -5,8 +5,8 @@
     "ldpIgpSyncState":"Holding down until Sync"
   },
   "r2-eth2":{
-    "ldpIgpSyncEnabled":false,
+    "ldpIgpSyncEnabled":true,
     "holdDownTimeInSec":50,
-    "ldpIgpSyncState":"Sync not required"
+    "ldpIgpSyncState":"Sync achieved"
   }
 }

--- a/tests/topotests/ldp_sync_ospf_topo1/r2/show_ospf_ldp_sync_r2_eth1_shutdown.ref
+++ b/tests/topotests/ldp_sync_ospf_topo1/r2/show_ospf_ldp_sync_r2_eth1_shutdown.ref
@@ -1,7 +1,7 @@
 {
   "r2-eth2":{
-    "ldpIgpSyncEnabled":false,
+    "ldpIgpSyncEnabled":true,
     "holdDownTimeInSec":50,
-    "ldpIgpSyncState":"Sync not required"
+    "ldpIgpSyncState":"Sync achieved"
   }
 }

--- a/tests/topotests/ldp_sync_ospf_topo1/r3/show_ospf_ldp_sync.ref
+++ b/tests/topotests/ldp_sync_ospf_topo1/r3/show_ospf_ldp_sync.ref
@@ -1,8 +1,8 @@
 {
   "r3-eth1":{
-    "ldpIgpSyncEnabled":false,
+    "ldpIgpSyncEnabled":true,
     "holdDownTimeInSec":50,
-    "ldpIgpSyncState":"Sync not required"
+    "ldpIgpSyncState":"Sync achieved"
   },
   "r3-eth2":{
     "ldpIgpSyncEnabled":true,

--- a/tests/topotests/ldp_sync_ospf_topo1/r3/show_ospf_ldp_sync_r1_eth1_shutdown.ref
+++ b/tests/topotests/ldp_sync_ospf_topo1/r3/show_ospf_ldp_sync_r1_eth1_shutdown.ref
@@ -1,8 +1,8 @@
 {
   "r3-eth1":{
-    "ldpIgpSyncEnabled":false,
+    "ldpIgpSyncEnabled":true,
     "holdDownTimeInSec":50,
-    "ldpIgpSyncState":"Sync not required"
+    "ldpIgpSyncState":"Sync achieved"
   },
   "r3-eth2":{
     "ldpIgpSyncEnabled":true,

--- a/tests/topotests/ldp_sync_ospf_topo1/r3/show_ospf_ldp_sync_r2_eth1_shutdown.ref
+++ b/tests/topotests/ldp_sync_ospf_topo1/r3/show_ospf_ldp_sync_r2_eth1_shutdown.ref
@@ -1,8 +1,8 @@
 {
   "r3-eth1":{
-    "ldpIgpSyncEnabled":false,
+    "ldpIgpSyncEnabled":true,
     "holdDownTimeInSec":50,
-    "ldpIgpSyncState":"Sync not required"
+    "ldpIgpSyncState":"Sync achieved"
   },
   "r3-eth2":{
     "ldpIgpSyncEnabled":true,


### PR DESCRIPTION
When enabling "mpls ldp-sync" under "router ospf" ospfd configures SET_FLAG(ldp_sync_info->flags, LDP_SYNC_FLAG_IF_CONFIG) so internally knowing that the ldp-sync feature is enabled. However the flag is not cleared when turning of the feature using "nompls ldp-sync"!

Closes #16375

Please backup this to stable/10.0 and stable/9.1