### PR TITLE
bgpd: fix label lost when vrf loopback comes back

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -280,7 +280,8 @@ done:
  *
  * Sending this vrf-label association is qualified by a) whether vrf->vpn
  * exporting is active ("export vpn" is enabled, vpn-policy RD and RT list
- * are set) and b) whether vpn-policy label is set.
+ * are set), b) whether vpn-policy label is set and c) the vrf loopback
+ * interface is up.
  *
  * If any of these conditions do not hold, then we send MPLS_LABEL_NONE
  * for this vrf, which zebra interprets to mean "delete this vrf-label
@@ -288,6 +289,7 @@ done:
  */
 void vpn_leak_zebra_vrf_label_update(struct bgp *bgp, afi_t afi)
 {
+	struct interface *ifp;
 	mpls_label_t label = MPLS_LABEL_NONE;
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_LABEL);
 
@@ -301,7 +303,9 @@ void vpn_leak_zebra_vrf_label_update(struct bgp *bgp, afi_t afi)
 	}
 
 	if (vpn_leak_to_vpn_active(bgp, afi, NULL, false)) {
-		label = bgp->vpn_policy[afi].tovpn_label;
+		ifp = if_get_vrf_loopback(bgp->vrf_id);
+		if (ifp && if_is_vrf(ifp) && if_is_up(ifp))
+			label = bgp->vpn_policy[afi].tovpn_label;
 	}
 
 	if (debug) {

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -234,7 +234,7 @@ static int bgp_ifp_up(struct interface *ifp)
 	hook_call(bgp_vrf_status_changed, bgp, ifp);
 	bgp_nht_ifp_up(ifp);
 
-	if (bgp_get_default() && if_is_loopback(ifp)) {
+	if (bgp_get_default() && if_is_vrf(ifp)) {
 		vpn_leak_zebra_vrf_label_update(bgp, AFI_IP);
 		vpn_leak_zebra_vrf_label_update(bgp, AFI_IP6);
 		vpn_leak_zebra_vrf_sid_update(bgp, AFI_IP);
@@ -289,7 +289,7 @@ static int bgp_ifp_down(struct interface *ifp)
 	hook_call(bgp_vrf_status_changed, bgp, ifp);
 	bgp_nht_ifp_down(ifp);
 
-	if (bgp_get_default() && if_is_loopback(ifp)) {
+	if (bgp_get_default() && if_is_vrf(ifp)) {
 		vpn_leak_zebra_vrf_label_withdraw(bgp, AFI_IP);
 		vpn_leak_zebra_vrf_label_withdraw(bgp, AFI_IP6);
 		vpn_leak_zebra_vrf_sid_withdraw(bgp, AFI_IP);


### PR DESCRIPTION
VRF-label association drops when the VRF loopback goes down, however, it does not return once the interface is enabled again.

Logs show that when VRF loopback goes down, a label drop message is sent to zebra and immediately resent label installation to zebra: 2024/07/16 13:26:29 BGP: [RVJ1J-J2T22] ifp down r1-cust1 vrf id 7 2024/07/16 13:26:29 BGP: [WA2QY-06STJ] vpn_leak_zebra_vrf_label_withdraw: deleting label for vrf VRF r1-cust1 (id=7) 2024/07/16 13:26:30 BGP: [S82AC-6YAC8] vpn_leak_zebra_vrf_label_update: vrf VRF r1-cust1: afi IPv4: setting label 80 for vrf id 7

Since the interface is down, the netlink message is not send to kernel. Once the interface comes back, zebra ignore the installation assuming the label is already seen.

To fix this, add a check for the interface status before attempting to reinstall the label.