### PR TITLE
build: display local state dir configuration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2913,7 +2913,8 @@ compiler                : ${CC}
 compiler flags          : ${CFLAGS} ${WERROR} ${AC_CFLAGS} ${SAN_FLAGS}
 make                    : ${MAKE-make}
 linker flags            : ${LDFLAGS} ${SAN_FLAGS} ${LIBS} ${LIBCAP} ${LIBREADLINE} ${LIBM}
-state file directory    : ${e_frr_runstatedir}
+local state file dir    : ${e_frr_libstatedir}
+run state file dir      : ${e_frr_runstatedir}
 config file directory   : ${e_frr_sysconfdir}
 module directory        : ${e_moduledir}
 script directory        : ${e_scriptdir}


### PR DESCRIPTION
Configure is displaying the run state directory but not the local state directory.

> FRRouting configuration
> ------------------------------
> state file directory    : /usr/var/run/frr
> config file directory   : /etc/frr

Display the local state directory as well.

> local state file dir    : /usr/var/lib/frr
> run state file dir      : /usr/var/run/frr
> config file directory   : /etc/frr