### PR TITLE
bgpd: backpressure - fix ret value and log err for evpn

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -1490,11 +1490,12 @@ int evpn_route_select_install(struct bgp *bgp, struct bgpevpn *vpn,
 	    && !bgp_addpath_is_addpath_used(&bgp->tx_addpath, afi, safi)) {
 		if (bgp_zebra_has_route_changed(old_select)) {
 			if (CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS))
-				evpn_zebra_install(bgp, vpn,
-						   (const struct prefix_evpn *)
-							   bgp_dest_get_prefix(
-								   dest),
-						   old_select);
+				ret = evpn_zebra_install(bgp, vpn,
+							 (const struct prefix_evpn
+								  *)
+								 bgp_dest_get_prefix(
+									 dest),
+							 old_select);
 			else
 				bgp_zebra_route_install(dest, old_select, bgp,
 							true, vpn, false);
@@ -1532,10 +1533,11 @@ int evpn_route_select_install(struct bgp *bgp, struct bgpevpn *vpn,
 	    && (new_select->sub_type == BGP_ROUTE_IMPORTED ||
 			bgp_evpn_attr_is_sync(new_select->attr))) {
 		if (CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS))
-			evpn_zebra_install(bgp, vpn,
-					   (const struct prefix_evpn *)
-						   bgp_dest_get_prefix(dest),
-					   new_select);
+			ret = evpn_zebra_install(bgp, vpn,
+						 (const struct prefix_evpn *)
+							 bgp_dest_get_prefix(
+								 dest),
+						 new_select);
 		else
 			bgp_zebra_route_install(dest, new_select, bgp, true,
 						vpn, false);
@@ -1559,11 +1561,12 @@ int evpn_route_select_install(struct bgp *bgp, struct bgpevpn *vpn,
 		    old_select->sub_type == BGP_ROUTE_IMPORTED) {
 			if (CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS) ||
 			    CHECK_FLAG(bgp->flags, BGP_FLAG_VNI_DOWN))
-				evpn_zebra_uninstall(bgp, vpn,
-						     (const struct prefix_evpn *)
-							     bgp_dest_get_prefix(
-								     dest),
-						     old_select, false);
+				ret = evpn_zebra_uninstall(bgp, vpn,
+							   (const struct prefix_evpn
+								    *)
+								   bgp_dest_get_prefix(
+									   dest),
+							   old_select, false);
 			else
 				bgp_zebra_route_install(dest, old_select, bgp,
 							false, vpn, false);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1785,6 +1785,7 @@ static void bgp_handle_route_announcements_to_zebra(struct event *e)
 	struct bgp_table *table = NULL;
 	enum zclient_send_status status = ZCLIENT_SEND_SUCCESS;
 	bool install;
+	const struct prefix_evpn *evp = NULL;
 
 	while (count < ZEBRA_ANNOUNCEMENTS_LIMIT) {
 		is_evpn = false;
@@ -1796,8 +1797,11 @@ static void bgp_handle_route_announcements_to_zebra(struct event *e)
 
 		table = bgp_dest_table(dest);
 		install = CHECK_FLAG(dest->flags, BGP_NODE_SCHEDULE_FOR_INSTALL);
-		if (table->afi == AFI_L2VPN && table->safi == SAFI_EVPN)
+		if (table->afi == AFI_L2VPN && table->safi == SAFI_EVPN) {
 			is_evpn = true;
+			evp = (const struct prefix_evpn *)bgp_dest_get_prefix(
+				dest);
+		}
 
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("BGP %s%s route %pBD(%s) with dest %p and flags 0x%x to zebra",
@@ -1834,6 +1838,17 @@ static void bgp_handle_route_announcements_to_zebra(struct event *e)
 
 			UNSET_FLAG(dest->flags, BGP_NODE_SCHEDULE_FOR_DELETE);
 		}
+
+		if (is_evpn && status == ZCLIENT_SEND_FAILURE)
+			flog_err(EC_BGP_EVPN_FAIL,
+				 "%s (%u): Failed to %s EVPN %pFX %s route in VNI %u",
+				 vrf_id_to_name(table->bgp->vrf_id),
+				 table->bgp->vrf_id,
+				 install ? "install" : "uninstall", evp,
+				 evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE
+					 ? "MACIP"
+					 : "IMET",
+				 dest->za_vpn->vni);
 
 		bgp_path_info_unlock(dest->za_bgp_pi);
 		dest->za_bgp_pi = NULL;


### PR DESCRIPTION
The return value of evpn_route_select_install is ignored in all cases except during vni route table install/uninstall and based on the returned value, an error is logged. Fixing this.

Also, log error for evpn in case route install to zebra fails.

Ticket :#3992392

No functionality issue here. Just making sure we don't have dead code and log error 