### PR TITLE
bgpd: add bgp snmp traps rfc4382 command

### DIFF
--- a/bgpd/bgp_mplsvpn_snmp.c
+++ b/bgpd/bgp_mplsvpn_snmp.c
@@ -590,6 +590,11 @@ static int bgp_vrf_check_update_active(struct bgp *bgp, struct interface *ifp)
 		/* add trap in here */
 		bgp->snmp_stats->active = new_active;
 
+		if (!CHECK_FLAG(bm->options, BGP_OPT_TRAPS_RFC4382)) {
+			bgp_mpls_l3vpn_update_last_changed(bgp);
+			return 0;
+		}
+
 		/* send relevent trap */
 		if (bgp->snmp_stats->active)
 			trap = MPLSL3VPNVRFUP;

--- a/bgpd/bgp_snmp.c
+++ b/bgpd/bgp_snmp.c
@@ -50,6 +50,21 @@ DEFPY(bgp_snmp_traps_rfc4273, bgp_snmp_traps_rfc4273_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY(bgp_snmp_traps_rfc4382, bgp_snmp_traps_rfc4382_cmd,
+      "[no$no] bgp snmp traps rfc4382",
+      NO_STR BGP_STR
+      "Configure BGP SNMP\n"
+      "Configure SNMP traps for BGP\n"
+      "Configure use of rfc4382 SNMP traps for BGP\n")
+{
+	if (no) {
+		UNSET_FLAG(bm->options, BGP_OPT_TRAPS_RFC4382);
+		return CMD_SUCCESS;
+	}
+	SET_FLAG(bm->options, BGP_OPT_TRAPS_RFC4382);
+	return CMD_SUCCESS;
+}
+
 DEFPY(bgp_snmp_traps_bgp4_mibv2, bgp_snmp_traps_bgp4_mibv2_cmd,
       "[no$no] bgp snmp traps bgp4-mibv2",
       NO_STR BGP_STR
@@ -69,9 +84,12 @@ static void bgp_snmp_traps_init(void)
 {
 	install_element(CONFIG_NODE, &bgp_snmp_traps_rfc4273_cmd);
 	install_element(CONFIG_NODE, &bgp_snmp_traps_bgp4_mibv2_cmd);
+	install_element(CONFIG_NODE, &bgp_snmp_traps_rfc4382_cmd);
 
 	SET_FLAG(bm->options, BGP_OPT_TRAPS_RFC4273);
 	/* BGP4MIBv2 traps are disabled by default */
+
+	SET_FLAG(bm->options, BGP_OPT_TRAPS_RFC4382);
 }
 
 int bgp_cli_snmp_traps_config_write(struct vty *vty)
@@ -84,6 +102,10 @@ int bgp_cli_snmp_traps_config_write(struct vty *vty)
 	}
 	if (CHECK_FLAG(bm->options, BGP_OPT_TRAPS_BGP4MIBV2)) {
 		vty_out(vty, "bgp snmp traps bgp4-mibv2\n");
+		write++;
+	}
+	if (!CHECK_FLAG(bm->options, BGP_OPT_TRAPS_RFC4382)) {
+		vty_out(vty, "no bgp snmp traps rfc4382\n");
 		write++;
 	}
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -131,6 +131,7 @@ struct bgp_master {
 #define BGP_OPT_NO_ZEBRA                 (1 << 2)
 #define BGP_OPT_TRAPS_RFC4273            (1 << 3)
 #define BGP_OPT_TRAPS_BGP4MIBV2          (1 << 4)
+#define BGP_OPT_TRAPS_RFC4382		 (1 << 5)
 
 	uint64_t updgrp_idspace;
 	uint64_t subgrp_idspace;

--- a/doc/user/snmptrap.rst
+++ b/doc/user/snmptrap.rst
@@ -215,3 +215,9 @@ possibility to select the MIB he wants to receive traps from:
 By default, only rfc4273 traps are enabled and sent.
 
 .. [Draft-IETF-idr-bgp4-mibv2-11] <https://tools.ietf.org/id/draft-ietf-idr-bgp4-mibv2-11.txt>
+
+The :rfc:`4382` also defines traps to inform when an L3VPN network changes
+the operational status of its VRF interface. The user can choose to suppress
+those traps or not.
+
+.. clicmd:: bgp snmp traps rfc4382


### PR DESCRIPTION
Add a trap command to disable or enable the traps defined by the RFC4382.