### PR TITLE
tests: Fix topotest warnings

### DIFF
--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/test_bgp_srv6l3vpn_to_bgp_vrf.py
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/test_bgp_srv6l3vpn_to_bgp_vrf.py
@@ -92,7 +92,8 @@ def setup_module(mod):
     tgen.start_topology()
     router_list = tgen.routers()
     for rname, router in tgen.routers().items():
-        router.run("/bin/bash {}/{}/setup.sh".format(CWD, rname))
+        if os.path.exists("{}/{}/setup.sh".format(CWD, rname)):
+            router.run("/bin/bash {}/{}/setup.sh".format(CWD, rname))
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/test_bgp_srv6l3vpn_to_bgp_vrf2.py
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/test_bgp_srv6l3vpn_to_bgp_vrf2.py
@@ -56,7 +56,8 @@ def setup_module(mod):
     tgen = Topogen(build_topo, mod.__name__)
     tgen.start_topology()
     for rname, router in tgen.routers().items():
-        router.run("/bin/bash {}/{}/setup.sh".format(CWD, rname))
+        if os.path.exists("{}/{}/setup.sh".format(CWD, rname)):
+            router.run("/bin/bash {}/{}/setup.sh".format(CWD, rname))
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/test_bgp_srv6l3vpn_to_bgp_vrf3.py
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/test_bgp_srv6l3vpn_to_bgp_vrf3.py
@@ -53,7 +53,8 @@ def setup_module(mod):
     tgen = Topogen(build_topo, mod.__name__)
     tgen.start_topology()
     for rname, router in tgen.routers().items():
-        router.run("/bin/bash {}/{}/setup.sh".format(CWD, rname))
+        if os.path.exists("{}/{}/setup.sh".format(CWD, rname)):
+            router.run("/bin/bash {}/{}/setup.sh".format(CWD, rname))
         router.load_config(
             TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
         )


### PR DESCRIPTION
Fix a bunch of warnings observed when running the `bgp_srv6l3vpn_to_bgp_vrf*` topotests.

```
/media/workspace/frr/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/r1/setup.sh: No such file or directory
/media/workspace/frr/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/r2/setup.sh: No such file or directory
/media/workspace/frr/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/ce1/setup.sh: No such file or directory
/media/workspace/frr/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/ce2/setup.sh: No such file or directory
...
```