### PR TITLE
yang: Added missed prefix to the frr-deviations-ietf-routing yang file

### DIFF
--- a/yang/ietf/frr-deviations-ietf-routing.yang
+++ b/yang/ietf/frr-deviations-ietf-routing.yang
@@ -6,6 +6,9 @@ module frr-deviations-ietf-routing {
   import ietf-routing {
     prefix ietf-routing;
   }
+  import ietf-rip {
+    prefix ietf-rip;
+  }
 
   organization
     "FRRouting";


### PR DESCRIPTION
Added missed prefix to the frr-deviations-ietf-routing yang file

Below warning is seen at frr-deviations-ietf-routing.yang file while applying pyang.
**"warning: "ietf-rip" looks like a prefix but is not defined"**

Corrected warning by including the module