### PR TITLE
lib: move non-error from __log_err to __dbg

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -3591,8 +3591,9 @@ static void vty_mgmt_set_config_result_notified(
 			vty_out(vty, "%s\n", errmsg_if_any);
 	} else {
 		debug_fe_client("SET_CONFIG request for client 0x%" PRIx64
-				" req-id %" PRIu64 " was successfull",
-				client_id, req_id);
+				" req-id %" PRIu64 " was successfull%s%s",
+				client_id, req_id, errmsg_if_any ? ": " : "",
+				errmsg_if_any ?: "");
 	}
 
 	if (implicit_commit) {
@@ -3624,8 +3625,9 @@ static void vty_mgmt_commit_config_result_notified(
 			vty_out(vty, "%s\n", errmsg_if_any);
 	} else {
 		debug_fe_client("COMMIT_CONFIG request for client 0x%" PRIx64
-				" req-id %" PRIu64 " was successfull",
-				client_id, req_id);
+				" req-id %" PRIu64 " was successfull%s%s",
+				client_id, req_id, errmsg_if_any ? ": " : "",
+				errmsg_if_any ?: "");
 		if (errmsg_if_any)
 			vty_out(vty, "MGMTD: %s\n", errmsg_if_any);
 	}
@@ -3656,8 +3658,9 @@ static int vty_mgmt_get_data_result_notified(
 	}
 
 	debug_fe_client("GET_DATA request succeeded, client 0x%" PRIx64
-			" req-id %" PRIu64,
-			client_id, req_id);
+			" req-id %" PRIu64 "%s%s",
+			client_id, req_id, errmsg_if_any ? ": " : "",
+			errmsg_if_any ?: "");
 
 	if (req_id != mgmt_last_req_id) {
 		mgmt_last_req_id = req_id;

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -980,8 +980,8 @@ static int mgmt_txn_create_config_batches(struct mgmt_txn_req *txn_req,
 		}
 
 		if (!chg_clients)
-			__log_err("No connected daemon is interested in XPATH %s",
-				  xpath);
+			__dbg("Daemons interested in XPATH are not currently connected: %s",
+			      xpath);
 
 		cmtcfg_req->clients |= chg_clients;
 
@@ -992,7 +992,7 @@ static int mgmt_txn_create_config_batches(struct mgmt_txn_req *txn_req,
 	if (!num_chgs) {
 		(void)mgmt_txn_send_commit_cfg_reply(txn_req->txn,
 						     MGMTD_NO_CFG_CHANGES,
-						     "No changes found to commit!");
+						     "No connected daemons interested in changes");
 		return -1;
 	}
 


### PR DESCRIPTION
Additionally, print `errmsg_if_any` in successful debug messages if non-NULL.

fixes #16386 #16043