### PR TITLE
bgpd: backpressure - Avoid use after free

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -6339,9 +6339,9 @@ void bgp_evpn_free(struct bgp *bgp, struct bgpevpn *vpn)
 	     dest = dest_next) {
 		dest_next = zebra_announce_next(&bm->zebra_announce_head, dest);
 		if (dest->za_vpn == vpn) {
+			zebra_announce_del(&bm->zebra_announce_head, dest);
 			bgp_path_info_unlock(dest->za_bgp_pi);
 			bgp_dest_unlock_node(dest);
-			zebra_announce_del(&bm->zebra_announce_head, dest);
 		}
 	}
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3954,9 +3954,9 @@ int bgp_delete(struct bgp *bgp)
 		dest_next = zebra_announce_next(&bm->zebra_announce_head, dest);
 		dest_table = bgp_dest_table(dest);
 		if (dest_table->bgp == bgp) {
+			zebra_announce_del(&bm->zebra_announce_head, dest);
 			bgp_path_info_unlock(dest->za_bgp_pi);
 			bgp_dest_unlock_node(dest);
-			zebra_announce_del(&bm->zebra_announce_head, dest);
 		}
 	}
 


### PR DESCRIPTION
Coverity complains there is a use after free (1598495 and 1598496) At this point, most likely dest->refcount cannot go 1 and free up the dest, but there might be some code path where this can happen.

Fixing this with a simple order change (no harm fix).

Ticket :#4001204