### PR TITLE
build: fix a few python string escape warnings

### DIFF
--- a/doc/developer/conf.py
+++ b/doc/developer/conf.py
@@ -96,7 +96,7 @@ replace_vars = {
 
 # extract version information, installation location, other stuff we need to
 # use when building final documents
-val = re.compile('^S\["([^"]+)"\]="(.*)"$')
+val = re.compile(r'^S\["([^"]+)"\]="(.*)"$')
 try:
     with open("../../config.status", "r") as cfgstatus:
         for ln in cfgstatus.readlines():

--- a/doc/manpages/conf.py
+++ b/doc/manpages/conf.py
@@ -91,7 +91,7 @@ replace_vars = {
 
 # extract version information, installation location, other stuff we need to
 # use when building final documents
-val = re.compile('^S\["([^"]+)"\]="(.*)"$')
+val = re.compile(r'^S\["([^"]+)"\]="(.*)"$')
 try:
     with open("../../config.status", "r") as cfgstatus:
         for ln in cfgstatus.readlines():

--- a/doc/user/conf.py
+++ b/doc/user/conf.py
@@ -96,7 +96,7 @@ replace_vars = {
 
 # extract version information, installation location, other stuff we need to
 # use when building final documents
-val = re.compile('^S\["([^"]+)"\]="(.*)"$')
+val = re.compile(r'^S\["([^"]+)"\]="(.*)"$')
 try:
     with open("../../config.status", "r") as cfgstatus:
         for ln in cfgstatus.readlines():

--- a/python/firstheader.py
+++ b/python/firstheader.py
@@ -15,7 +15,7 @@ argp.add_argument("--autofix", action="store_const", const=True)
 argp.add_argument("--warn-empty", action="store_const", const=True)
 argp.add_argument("--pipe", action="store_const", const=True)
 
-include_re = re.compile('^#\s*include\s+["<]([^ ">]+)[">]', re.M)
+include_re = re.compile(r'^#\s*include\s+["<]([^ ">]+)[">]', re.M)
 
 ignore = [
     lambda fn: fn.startswith("tools/"),

--- a/python/makefile.py
+++ b/python/makefile.py
@@ -91,7 +91,7 @@ lines = before.splitlines()
 autoderp = "#AUTODERP# "
 out_lines = []
 bcdeps = []
-make_rule_re = re.compile("^([^:\s]+):\s*([^:\s]+)\s*($|\n)")
+make_rule_re = re.compile(r"^([^:\s]+):\s*([^:\s]+)\s*($|\n)")
 
 while lines:
     line = lines.pop(0)


### PR DESCRIPTION
When using a regex (or anything that uses `\?` escapes) in python, raw strings (`r"content"`) should be used so python doesn't consume the escapes itself.  Otherwise we get either broken behavior and/or `SyntaxWarning: invalid escape sequence '\['`