### PR TITLE
lib: mgmtd: fix too early daemon detach of mgmtd

### DIFF
--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -202,7 +202,7 @@ extern void frr_config_fork(void);
 
 extern void frr_run(struct event_loop *master);
 extern void frr_detach(void);
-extern void frr_vty_serv_start(void);
+extern void frr_vty_serv_start(bool check_detach);
 extern void frr_vty_serv_stop(void);
 
 extern bool frr_zclient_addr(struct sockaddr_storage *sa, socklen_t *sa_len,

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -3502,7 +3502,7 @@ static void vty_mgmt_server_connected(struct mgmt_fe_client *client,
 
 	/* Start or stop listening for vty connections */
 	if (connected)
-		frr_vty_serv_start();
+		frr_vty_serv_start(true);
 	else
 		frr_vty_serv_stop();
 }


### PR DESCRIPTION
Correct FRR startup counts on a daemon's vty socket to be open when the parent process exits. The parent process waits for `frr_check_detach()` to be called by the child before exiting. The problem is when the `FRR_MANUAL_VTY_START` flag is set the vty socket was not opened but `frr_check_detach()` was called anyway.

Instead add a bool option for `frr_check_detach()` to be called when the socket is opened with `frr_vty_serv_start()`, and do so when "manually" calling said function (i.e., when FRR_MANUAL_VTY_START is set).

The `FRR_MANUAL_VTY_START` flag is only set by mgmtd. The reason we wait to open the vty socket is so that mgmtd can parse the various daemon specific config files it has taken over, after the event loop has started, but before we receive any possible new config from `vtysh`.

fixes #16362