### PR TITLE
isisd: fix building flex-algo asla at init

### DIFF
--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2875,6 +2875,8 @@ int isis_instance_flex_algo_create(struct nb_cb_create_args *args)
 
 int isis_instance_flex_algo_destroy(struct nb_cb_destroy_args *args)
 {
+	struct listnode *node, *nnode;
+	struct flex_algo *fa;
 	struct isis_area *area;
 	uint32_t algorithm;
 
@@ -2883,7 +2885,11 @@ int isis_instance_flex_algo_destroy(struct nb_cb_destroy_args *args)
 
 	switch (args->event) {
 	case NB_EV_APPLY:
-		flex_algo_delete(area->flex_algos, algorithm);
+		for (ALL_LIST_ELEMENTS(area->flex_algos->flex_algos, node,
+				       nnode, fa)) {
+			if (fa->algorithm == algorithm)
+				flex_algo_free(area->flex_algos, fa);
+		}
 		lsp_regenerate_schedule(area, area->is_type, 0);
 		break;
 	case NB_EV_VALIDATE:

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2884,6 +2884,7 @@ int isis_instance_flex_algo_create(struct nb_cb_create_args *args)
 
 int isis_instance_flex_algo_destroy(struct nb_cb_destroy_args *args)
 {
+	struct isis_circuit *circuit;
 	struct listnode *node, *nnode;
 	struct flex_algo *fa;
 	struct isis_area *area;
@@ -2898,6 +2899,12 @@ int isis_instance_flex_algo_destroy(struct nb_cb_destroy_args *args)
 				       nnode, fa)) {
 			if (fa->algorithm == algorithm)
 				flex_algo_free(area->flex_algos, fa);
+		}
+		if (list_isempty(area->flex_algos->flex_algos)) {
+			for (ALL_LIST_ELEMENTS_RO(area->circuit_list, node,
+						  circuit))
+				isis_link_params_update_asla(circuit,
+							     circuit->interface);
 		}
 		lsp_regenerate_schedule(area, area->is_type, 0);
 		break;

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2838,7 +2838,9 @@ int isis_instance_flex_algo_create(struct nb_cb_create_args *args)
 {
 	struct isis_area *area;
 	struct flex_algo *fa;
-	bool advertise;
+	bool advertise, update_te;
+	struct isis_circuit *circuit;
+	struct listnode *node;
 	uint32_t algorithm;
 	uint32_t priority = FLEX_ALGO_PRIO_DEFAULT;
 	struct isis_flex_algo_alloc_arg arg;
@@ -2851,6 +2853,7 @@ int isis_instance_flex_algo_create(struct nb_cb_create_args *args)
 		area = nb_running_get_entry(args->dnode, NULL, true);
 		arg.algorithm = algorithm;
 		arg.area = area;
+		update_te = list_isempty(area->flex_algos->flex_algos);
 		fa = flex_algo_alloc(area->flex_algos, algorithm, &arg);
 		fa->priority = priority;
 		fa->advertise_definition = advertise;
@@ -2861,6 +2864,12 @@ int isis_instance_flex_algo_create(struct nb_cb_create_args *args)
 				&fa->admin_group_include_any);
 			admin_group_allow_explicit_zero(
 				&fa->admin_group_include_all);
+		}
+		if (update_te) {
+			for (ALL_LIST_ELEMENTS_RO(area->circuit_list, node,
+						  circuit))
+				isis_link_params_update_asla(circuit,
+							     circuit->interface);
 		}
 		lsp_regenerate_schedule(area, area->is_type, 0);
 		break;

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -164,8 +164,8 @@ void isis_mpls_te_term(struct isis_area *area)
 	XFREE(MTYPE_ISIS_MPLS_TE, area->mta);
 }
 
-static void isis_link_params_update_asla(struct isis_circuit *circuit,
-					 struct interface *ifp)
+void isis_link_params_update_asla(struct isis_circuit *circuit,
+				  struct interface *ifp)
 {
 	struct isis_asla_subtlvs *asla;
 	struct listnode *node, *nnode;

--- a/isisd/isis_te.h
+++ b/isisd/isis_te.h
@@ -112,6 +112,8 @@ void isis_mpls_te_init(void);
 void isis_mpls_te_create(struct isis_area *area);
 void isis_mpls_te_disable(struct isis_area *area);
 void isis_mpls_te_term(struct isis_area *area);
+void isis_link_params_update_asla(struct isis_circuit *circuit,
+				  struct interface *ifp);
 void isis_link_params_update(struct isis_circuit *, struct interface *);
 int isis_mpls_te_update(struct interface *);
 void isis_te_lsp_event(struct isis_lsp *lsp, enum lsp_event event);

--- a/lib/flex_algo.c
+++ b/lib/flex_algo.c
@@ -20,9 +20,6 @@
 DEFINE_MTYPE_STATIC(LIB, FLEX_ALGO_DATABASE, "Flex-Algo database");
 DEFINE_MTYPE_STATIC(LIB, FLEX_ALGO, "Flex-Algo algorithm information");
 
-static void _flex_algo_delete(struct flex_algos *flex_algos,
-			      struct flex_algo *fa);
-
 struct flex_algos *flex_algos_alloc(flex_algo_allocator_t allocator,
 				    flex_algo_releaser_t releaser)
 {
@@ -42,7 +39,7 @@ void flex_algos_free(struct flex_algos *flex_algos)
 	struct flex_algo *fa;
 
 	for (ALL_LIST_ELEMENTS(flex_algos->flex_algos, node, nnode, fa))
-		_flex_algo_delete(flex_algos, fa);
+		flex_algo_free(flex_algos, fa);
 	list_delete(&flex_algos->flex_algos);
 	XFREE(MTYPE_FLEX_ALGO_DATABASE, flex_algos);
 }
@@ -63,8 +60,7 @@ struct flex_algo *flex_algo_alloc(struct flex_algos *flex_algos,
 	return fa;
 }
 
-static void _flex_algo_delete(struct flex_algos *flex_algos,
-			      struct flex_algo *fa)
+void flex_algo_free(struct flex_algos *flex_algos, struct flex_algo *fa)
 {
 	if (flex_algos->releaser)
 		flex_algos->releaser(fa->data);
@@ -73,19 +69,6 @@ static void _flex_algo_delete(struct flex_algos *flex_algos,
 	admin_group_term(&fa->admin_group_include_all);
 	listnode_delete(flex_algos->flex_algos, fa);
 	XFREE(MTYPE_FLEX_ALGO, fa);
-}
-
-
-void flex_algo_delete(struct flex_algos *flex_algos, uint8_t algorithm)
-{
-	struct listnode *node, *nnode;
-	struct flex_algo *fa;
-
-	for (ALL_LIST_ELEMENTS(flex_algos->flex_algos, node, nnode, fa)) {
-		if (fa->algorithm != algorithm)
-			continue;
-		_flex_algo_delete(flex_algos, fa);
-	}
 }
 
 /**

--- a/lib/flex_algo.h
+++ b/lib/flex_algo.h
@@ -117,7 +117,6 @@ struct flex_algo *flex_algo_alloc(struct flex_algos *flex_algos,
 				  uint8_t algorithm, void *arg);
 struct flex_algo *flex_algo_lookup(struct flex_algos *flex_algos,
 				   uint8_t algorithm);
-void flex_algos_free(struct flex_algos *flex_algos);
 bool flex_algo_definition_cmp(struct flex_algo *fa1, struct flex_algo *fa2);
 void flex_algo_delete(struct flex_algos *flex_algos, uint8_t algorithm);
 bool flex_algo_id_valid(uint16_t algorithm);

--- a/lib/flex_algo.h
+++ b/lib/flex_algo.h
@@ -115,10 +115,10 @@ struct flex_algos *flex_algos_alloc(flex_algo_allocator_t allocator,
 void flex_algos_free(struct flex_algos *flex_algos);
 struct flex_algo *flex_algo_alloc(struct flex_algos *flex_algos,
 				  uint8_t algorithm, void *arg);
+void flex_algo_free(struct flex_algos *flex_algos, struct flex_algo *fa);
 struct flex_algo *flex_algo_lookup(struct flex_algos *flex_algos,
 				   uint8_t algorithm);
 bool flex_algo_definition_cmp(struct flex_algo *fa1, struct flex_algo *fa2);
-void flex_algo_delete(struct flex_algos *flex_algos, uint8_t algorithm);
 bool flex_algo_id_valid(uint16_t algorithm);
 char *flex_algo_metric_type_print(char *type_str, size_t sz,
 				  enum flex_algo_metric_type metric_type);


### PR DESCRIPTION
When an color affinity is set on an interface before configuring the flex-algorithm, the ASLA (Application Specific Link-Attribute) sub-TLV is not build. Flex-algo fails to build the paths when a affinity constraint is required because of the lacking of information contained in ASLA. There are no problems when the configuration order is reversed. For example:

> affinity-map red bit-position 1
>
> interface eth2
>  link-params
>   affinity red
>
> router isis 1
>  mpls-te on
>  flex-algo 129
>   dataplane sr-mpls
>   advertise-definition
>   affinity include-any green

In isis_link_params_update_asla(), the ASLA sub-TLV is not build when the list of flex-algos is empty.

Update ASLA when the first flex-algorithm is configured.

Fixes: 893882ee20 ("isisd: add isis flex-algo configuration backend")