### PR TITLE
bgpd: Revalidate locally originated routes also when RPKI state changes

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -604,7 +604,6 @@ static void bgpd_sync_callback(struct event *thread)
 
 		atomic_store_explicit(&rpki_vrf->rtr_update_overflow, 0,
 				      memory_order_seq_cst);
-		revalidate_all_routes(rpki_vrf);
 		return;
 	}
 
@@ -626,6 +625,8 @@ static void bgpd_sync_callback(struct event *thread)
 			return;
 		}
 	}
+
+	revalidate_all_routes(rpki_vrf);
 
 	for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, bgp)) {
 		safi_t safi;
@@ -722,6 +723,8 @@ static void revalidate_all_routes(struct rpki_vrf *rpki_vrf)
 			continue;
 		if (vrf && bgp->vrf_id != vrf->vrf_id)
 			continue;
+
+		bgp_static_add(bgp);
 
 		for (ALL_LIST_ELEMENTS_RO(bgp->peer, peer_listnode, peer)) {
 			afi_t afi;


### PR DESCRIPTION
If we have something like:

```
router bgp 65001
 network 10.10.10.0/24 route-map rpki
!
route-map rpki permit 10
 match rpki valid
 set local-preference 150
route-map rpki permit 20
 match rpki notfound
 set local-preference 50
!
```

Then 10.10.10.0/24 is never revalidated when RPKI state changes. E.g. if it was valid, and moves to notfound => local-preference remains 150, but should be 50.

With this patch we force BGP network (static) routes to be revalidated when revalidation event is triggered from RPKI module.