### PR TITLE
Tests random order

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -750,6 +750,28 @@ IDE/editor if supported (e.g., the emacs ``cov-mode`` package)
 NOTE: the *.gcda files in ``/tmp/topotests/gcda`` are cumulative so if you do
 not remove them they will aggregate data across multiple topotest runs.
 
+How to run tests in a random order
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To introduce additional randomness in the call order you can install the
+pytest-random-order module.
+
+.. code:: console
+
+   pip3 install pytest-random-order
+
+Then when you run the tests, add this to the command line:
+
+.. code:: console
+
+   sudo -E python3 -m pytest -n <some value> --dist=loadfile --random-order=package
+
+This causes the tests to be run in a random order.  The run of the test will give
+you the seed for the random order so you can use that to specify a repeat run
+if you can cause a specific test to fail more often.  Consult the pytest-random-order
+documentation for how to do this.
+
+
 How to reproduce failed Tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
+++ b/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
@@ -21,7 +21,7 @@ import pytest
 import glob
 from time import sleep
 
-pytestmark = [
+pytestmark = [pytest.mark.random_order(disabled=True),
     pytest.mark.babeld,
     pytest.mark.bgpd,
     pytest.mark.isisd,

--- a/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
+++ b/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
@@ -21,7 +21,8 @@ import pytest
 import glob
 from time import sleep
 
-pytestmark = [pytest.mark.random_order(disabled=True),
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
     pytest.mark.babeld,
     pytest.mark.bgpd,
     pytest.mark.isisd,

--- a/tests/topotests/babel_topo1/test_babel_topo1.py
+++ b/tests/topotests/babel_topo1/test_babel_topo1.py
@@ -20,7 +20,7 @@ import pytest
 import json
 from functools import partial
 
-pytestmark = [pytest.mark.babeld]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.babeld]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bfd_bgp_cbit_topo3/test_bfd_bgp_cbit_topo3.py
+++ b/tests/topotests/bfd_bgp_cbit_topo3/test_bfd_bgp_cbit_topo3.py
@@ -28,7 +28,11 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.bfdd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.bfdd,
+]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_bgp_cbit_topo3/test_bfd_bgp_cbit_topo3.py
+++ b/tests/topotests/bfd_bgp_cbit_topo3/test_bfd_bgp_cbit_topo3.py
@@ -28,7 +28,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.bfdd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.bfdd]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_isis_topo1/test_bfd_isis_topo1.py
+++ b/tests/topotests/bfd_isis_topo1/test_bfd_isis_topo1.py
@@ -71,7 +71,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bfdd, pytest.mark.isisd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.isisd]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_isis_topo1/test_bfd_isis_topo1.py
+++ b/tests/topotests/bfd_isis_topo1/test_bfd_isis_topo1.py
@@ -71,7 +71,11 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.isisd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bfdd,
+    pytest.mark.isisd,
+]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_ospf_topo1/test_bfd_ospf_topo1.py
+++ b/tests/topotests/bfd_ospf_topo1/test_bfd_ospf_topo1.py
@@ -71,7 +71,11 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bfdd,
+    pytest.mark.ospfd,
+]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_ospf_topo1/test_bfd_ospf_topo1.py
+++ b/tests/topotests/bfd_ospf_topo1/test_bfd_ospf_topo1.py
@@ -71,7 +71,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bfdd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.ospfd]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_profiles_topo1/test_bfd_profiles_topo1.py
+++ b/tests/topotests/bfd_profiles_topo1/test_bfd_profiles_topo1.py
@@ -29,7 +29,13 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bfdd,
+    pytest.mark.bgpd,
+    pytest.mark.isisd,
+    pytest.mark.ospfd,
+]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_profiles_topo1/test_bfd_profiles_topo1.py
+++ b/tests/topotests/bfd_profiles_topo1/test_bfd_profiles_topo1.py
@@ -29,7 +29,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bfdd, pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.ospfd]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_topo1/test_bfd_topo1.py
+++ b/tests/topotests/bfd_topo1/test_bfd_topo1.py
@@ -29,7 +29,11 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bfdd,
+    pytest.mark.bgpd,
+]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_topo1/test_bfd_topo1.py
+++ b/tests/topotests/bfd_topo1/test_bfd_topo1.py
@@ -29,7 +29,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bfdd, pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_topo2/test_bfd_topo2.py
+++ b/tests/topotests/bfd_topo2/test_bfd_topo2.py
@@ -30,7 +30,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bfdd, pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd, pytest.mark.ospfd]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_topo2/test_bfd_topo2.py
+++ b/tests/topotests/bfd_topo2/test_bfd_topo2.py
@@ -30,7 +30,12 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bfdd,
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_topo3/test_bfd_topo3.py
+++ b/tests/topotests/bfd_topo3/test_bfd_topo3.py
@@ -29,7 +29,11 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bfdd,
+    pytest.mark.bgpd,
+]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_topo3/test_bfd_topo3.py
+++ b/tests/topotests/bfd_topo3/test_bfd_topo3.py
@@ -29,7 +29,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bfdd, pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd]
 
 
 def setup_module(mod):

--- a/tests/topotests/bfd_vrf_topo1/test_bfd_vrf_topo1.py
+++ b/tests/topotests/bfd_vrf_topo1/test_bfd_vrf_topo1.py
@@ -32,7 +32,11 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bfdd,
+    pytest.mark.bgpd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bfd_vrf_topo1/test_bfd_vrf_topo1.py
+++ b/tests/topotests/bfd_vrf_topo1/test_bfd_vrf_topo1.py
@@ -32,7 +32,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bfdd, pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bfd_vrflite_topo1/test_bfd_vrflite_topo1.py
+++ b/tests/topotests/bfd_vrflite_topo1/test_bfd_vrflite_topo1.py
@@ -32,7 +32,11 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bfdd,
+    pytest.mark.bgpd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bfd_vrflite_topo1/test_bfd_vrflite_topo1.py
+++ b/tests/topotests/bfd_vrflite_topo1/test_bfd_vrflite_topo1.py
@@ -32,7 +32,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bfdd, pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_6vpe_ebgp_topo1/test_bgp_6vpe_ebgp_topo1.py
+++ b/tests/topotests/bgp_6vpe_ebgp_topo1/test_bgp_6vpe_ebgp_topo1.py
@@ -26,7 +26,11 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.checkping import check_ping
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.isisd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.isisd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_6vpe_ebgp_topo1/test_bgp_6vpe_ebgp_topo1.py
+++ b/tests/topotests/bgp_6vpe_ebgp_topo1/test_bgp_6vpe_ebgp_topo1.py
@@ -26,7 +26,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.checkping import check_ping
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.isisd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.isisd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_accept_own/test_bgp_accept_own.py
+++ b/tests/topotests/bgp_accept_own/test_bgp_accept_own.py
@@ -24,7 +24,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_addpath_best_selected/test_bgp_addpath_best_selected.py
+++ b/tests/topotests/bgp_addpath_best_selected/test_bgp_addpath_best_selected.py
@@ -22,7 +22,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_addpath_paths_limit/test_bgp_addpath_paths_limit.py
+++ b/tests/topotests/bgp_addpath_paths_limit/test_bgp_addpath_paths_limit.py
@@ -22,7 +22,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_aggregate_address_matching_med/test_bgp_aggregate_address_matching_med.py
+++ b/tests/topotests/bgp_aggregate_address_matching_med/test_bgp_aggregate_address_matching_med.py
@@ -24,7 +24,7 @@ from lib.common_config import (
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_aggregate_address_origin/test_bgp_aggregate-address_origin.py
+++ b/tests/topotests/bgp_aggregate_address_origin/test_bgp_aggregate-address_origin.py
@@ -31,7 +31,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_aggregate_address_route_map/test_bgp_aggregate-address_route-map.py
+++ b/tests/topotests/bgp_aggregate_address_route_map/test_bgp_aggregate-address_route-map.py
@@ -34,7 +34,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_aggregate_address_topo1/test_bgp_aggregate_address_topo1.py
+++ b/tests/topotests/bgp_aggregate_address_topo1/test_bgp_aggregate_address_topo1.py
@@ -26,7 +26,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_aggregator_zero/test_bgp_aggregator_zero.py
+++ b/tests/topotests/bgp_aggregator_zero/test_bgp_aggregator_zero.py
@@ -24,7 +24,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_aigp/test_bgp_aigp.py
+++ b/tests/topotests/bgp_aigp/test_bgp_aigp.py
@@ -30,7 +30,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_always_compare_med/test_bgp_always_compare_med_topo1.py
+++ b/tests/topotests/bgp_always_compare_med/test_bgp_always_compare_med_topo1.py
@@ -55,7 +55,11 @@ from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, verify_bgp_rib, create_router_bgp, clear_bgp
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Reading the data from JSON File for topology creation
 topo = None

--- a/tests/topotests/bgp_always_compare_med/test_bgp_always_compare_med_topo1.py
+++ b/tests/topotests/bgp_always_compare_med/test_bgp_always_compare_med_topo1.py
@@ -55,7 +55,7 @@ from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, verify_bgp_rib, create_router_bgp, clear_bgp
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Reading the data from JSON File for topology creation
 topo = None

--- a/tests/topotests/bgp_as_allow_in/test_bgp_as_allow_in.py
+++ b/tests/topotests/bgp_as_allow_in/test_bgp_as_allow_in.py
@@ -60,7 +60,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_as_allow_in/test_bgp_as_allow_in.py
+++ b/tests/topotests/bgp_as_allow_in/test_bgp_as_allow_in.py
@@ -60,7 +60,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_as_override/test_bgp_as_override.py
+++ b/tests/topotests/bgp_as_override/test_bgp_as_override.py
@@ -23,7 +23,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_as_wide_bgp_identifier/test_bgp_as_wide_bgp_identifier.py
+++ b/tests/topotests/bgp_as_wide_bgp_identifier/test_bgp_as_wide_bgp_identifier.py
@@ -29,7 +29,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_asdot_regex/test_bgp_asdot_regex.py
+++ b/tests/topotests/bgp_asdot_regex/test_bgp_asdot_regex.py
@@ -34,7 +34,7 @@ import pytest
 from functools import partial
 
 # add after imports, before defining classes or functions:
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_aspath_zero/test_bgp_aspath_zero.py
+++ b/tests/topotests/bgp_aspath_zero/test_bgp_aspath_zero.py
@@ -24,7 +24,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_auth/test_bgp_auth1.py
+++ b/tests/topotests/bgp_auth/test_bgp_auth1.py
@@ -50,7 +50,7 @@ from bgp_auth_common import (
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/topotests/bgp_auth/test_bgp_auth1.py
+++ b/tests/topotests/bgp_auth/test_bgp_auth1.py
@@ -50,7 +50,11 @@ from bgp_auth_common import (
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/topotests/bgp_auth/test_bgp_auth2.py
+++ b/tests/topotests/bgp_auth/test_bgp_auth2.py
@@ -50,7 +50,7 @@ from bgp_auth_common import (
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/topotests/bgp_auth/test_bgp_auth2.py
+++ b/tests/topotests/bgp_auth/test_bgp_auth2.py
@@ -50,7 +50,11 @@ from bgp_auth_common import (
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/topotests/bgp_auth/test_bgp_auth3.py
+++ b/tests/topotests/bgp_auth/test_bgp_auth3.py
@@ -49,7 +49,11 @@ from bgp_auth_common import (
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/topotests/bgp_auth/test_bgp_auth3.py
+++ b/tests/topotests/bgp_auth/test_bgp_auth3.py
@@ -49,7 +49,7 @@ from bgp_auth_common import (
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/topotests/bgp_auth/test_bgp_auth4.py
+++ b/tests/topotests/bgp_auth/test_bgp_auth4.py
@@ -49,7 +49,11 @@ from bgp_auth_common import (
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/topotests/bgp_auth/test_bgp_auth4.py
+++ b/tests/topotests/bgp_auth/test_bgp_auth4.py
@@ -49,7 +49,7 @@ from bgp_auth_common import (
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/topotests/bgp_basic_functionality_topo1/test_bgp_basic_functionality.py
+++ b/tests/topotests/bgp_basic_functionality_topo1/test_bgp_basic_functionality.py
@@ -78,7 +78,11 @@ from lib.topogen import Topogen, get_topogen
 from lib.topojson import build_config_from_json
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 # Global Variable

--- a/tests/topotests/bgp_basic_functionality_topo1/test_bgp_basic_functionality.py
+++ b/tests/topotests/bgp_basic_functionality_topo1/test_bgp_basic_functionality.py
@@ -78,7 +78,7 @@ from lib.topogen import Topogen, get_topogen
 from lib.topojson import build_config_from_json
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 # Global Variable

--- a/tests/topotests/bgp_bfd_down_cease_notification/test_bgp_bfd_down_cease_notification.py
+++ b/tests/topotests/bgp_bfd_down_cease_notification/test_bgp_bfd_down_cease_notification.py
@@ -27,7 +27,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import kill_router_daemons, step
 
-pytestmark = [pytest.mark.bfdd, pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_bfd_down_cease_notification/test_bgp_bfd_down_cease_notification.py
+++ b/tests/topotests/bgp_bfd_down_cease_notification/test_bgp_bfd_down_cease_notification.py
@@ -27,7 +27,11 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import kill_router_daemons, step
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bfdd,
+    pytest.mark.bgpd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_bfd_down_cease_notification/test_bgp_bfd_down_cease_notification_shutdown.py
+++ b/tests/topotests/bgp_bfd_down_cease_notification/test_bgp_bfd_down_cease_notification_shutdown.py
@@ -27,7 +27,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import kill_router_daemons, step
 
-pytestmark = [pytest.mark.bfdd, pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_bfd_down_cease_notification/test_bgp_bfd_down_cease_notification_shutdown.py
+++ b/tests/topotests/bgp_bfd_down_cease_notification/test_bgp_bfd_down_cease_notification_shutdown.py
@@ -27,7 +27,11 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import kill_router_daemons, step
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.bgpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bfdd,
+    pytest.mark.bgpd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_blackhole_community/test_bgp_blackhole_community.py
+++ b/tests/topotests/bgp_blackhole_community/test_bgp_blackhole_community.py
@@ -25,7 +25,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_bmp/test_bgp_bmp.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp.py
@@ -41,7 +41,7 @@ from lib.bgp import verify_bgp_convergence_from_running_config
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 # remember the last sequence number of the logging messages
 SEQ = 0

--- a/tests/topotests/bgp_color_extcommunities/test_bgp_color_extcommunities.py
+++ b/tests/topotests/bgp_color_extcommunities/test_bgp_color_extcommunities.py
@@ -28,7 +28,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_comm_list_delete/test_bgp_comm-list_delete.py
+++ b/tests/topotests/bgp_comm_list_delete/test_bgp_comm-list_delete.py
@@ -30,7 +30,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_comm_list_match/test_bgp_comm_list_match.py
+++ b/tests/topotests/bgp_comm_list_match/test_bgp_comm_list_match.py
@@ -35,7 +35,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_communities_topo1/test_bgp_communities.py
+++ b/tests/topotests/bgp_communities_topo1/test_bgp_communities.py
@@ -50,7 +50,7 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 from copy import deepcopy
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/bgp_communities_topo1/test_bgp_communities.py
+++ b/tests/topotests/bgp_communities_topo1/test_bgp_communities.py
@@ -50,7 +50,11 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 from copy import deepcopy
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/bgp_communities_topo1/test_bgp_communities_topo2.py
+++ b/tests/topotests/bgp_communities_topo1/test_bgp_communities_topo2.py
@@ -52,7 +52,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/bgp_communities_topo1/test_bgp_communities_topo2.py
+++ b/tests/topotests/bgp_communities_topo1/test_bgp_communities_topo2.py
@@ -52,7 +52,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/bgp_community_change_update/test_bgp_community_change_update.py
+++ b/tests/topotests/bgp_community_change_update/test_bgp_community_change_update.py
@@ -44,7 +44,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 from time import sleep
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_conditional_advertisement/test_bgp_conditional_advertisement.py
+++ b/tests/topotests/bgp_conditional_advertisement/test_bgp_conditional_advertisement.py
@@ -130,7 +130,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_conditional_advertisement_static_route/test_bgp_conditional_advertisement_static_route.py
+++ b/tests/topotests/bgp_conditional_advertisement_static_route/test_bgp_conditional_advertisement_static_route.py
@@ -16,7 +16,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_conditional_advertisement_track_peer/test_bgp_conditional_advertisement_track_peer.py
+++ b/tests/topotests/bgp_conditional_advertisement_track_peer/test_bgp_conditional_advertisement_track_peer.py
@@ -29,7 +29,7 @@ from lib.common_config import (
     step,
 )
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_confed1/test_bgp_confed1.py
+++ b/tests/topotests/bgp_confed1/test_bgp_confed1.py
@@ -28,7 +28,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_confederation_astype/test_bgp_confederation_astype.py
+++ b/tests/topotests/bgp_confederation_astype/test_bgp_confederation_astype.py
@@ -18,7 +18,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_dampening_per_peer/test_bgp_dampening_per_peer.py
+++ b/tests/topotests/bgp_dampening_per_peer/test_bgp_dampening_per_peer.py
@@ -11,7 +11,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_dampening_per_safi/test_bgp_dampening_per_safi.py
+++ b/tests/topotests/bgp_dampening_per_safi/test_bgp_dampening_per_safi.py
@@ -12,7 +12,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_default_afi_safi/test_bgp-default-afi-safi.py
+++ b/tests/topotests/bgp_default_afi_safi/test_bgp-default-afi-safi.py
@@ -21,7 +21,7 @@ import sys
 import json
 import pytest
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_default_originate/test_bgp_default_originate_2links.py
+++ b/tests/topotests/bgp_default_originate/test_bgp_default_originate_2links.py
@@ -90,7 +90,7 @@ ipv6_uptime_dict = {
 DEFAULT_ROUTES = {"ipv4": "0.0.0.0/0", "ipv6": "0::0/0"}
 NEXT_HOP_IP = {"ipv4": "Null0", "ipv6": "Null0"}
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def setup_module(mod):

--- a/tests/topotests/bgp_default_originate/test_bgp_default_originate_topo1_1.py
+++ b/tests/topotests/bgp_default_originate/test_bgp_default_originate_topo1_1.py
@@ -54,7 +54,7 @@ from lib.common_config import (
 )
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bgp_default_originate/test_bgp_default_originate_topo1_1.py
+++ b/tests/topotests/bgp_default_originate/test_bgp_default_originate_topo1_1.py
@@ -54,7 +54,11 @@ from lib.common_config import (
 )
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bgp_default_originate/test_bgp_default_originate_topo1_2.py
+++ b/tests/topotests/bgp_default_originate/test_bgp_default_originate_topo1_2.py
@@ -57,7 +57,11 @@ from lib.common_config import (
 )
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bgp_default_originate/test_bgp_default_originate_topo1_2.py
+++ b/tests/topotests/bgp_default_originate/test_bgp_default_originate_topo1_2.py
@@ -57,7 +57,7 @@ from lib.common_config import (
 )
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bgp_default_originate/test_bgp_default_originate_topo1_3.py
+++ b/tests/topotests/bgp_default_originate/test_bgp_default_originate_topo1_3.py
@@ -56,7 +56,7 @@ from lib.common_config import (
     check_router_status,
 )
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bgp_default_originate/test_bgp_default_originate_topo1_3.py
+++ b/tests/topotests/bgp_default_originate/test_bgp_default_originate_topo1_3.py
@@ -56,7 +56,11 @@ from lib.common_config import (
     check_router_status,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bgp_default_originate/test_default_orginate_vrf.py
+++ b/tests/topotests/bgp_default_originate/test_default_orginate_vrf.py
@@ -43,7 +43,7 @@ from lib.common_config import (
     check_router_status,
 )
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bgp_default_originate/test_default_orginate_vrf.py
+++ b/tests/topotests/bgp_default_originate/test_default_orginate_vrf.py
@@ -43,7 +43,11 @@ from lib.common_config import (
     check_router_status,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bgp_default_originate/test_default_originate_conditional_routemap.py
+++ b/tests/topotests/bgp_default_originate/test_default_originate_conditional_routemap.py
@@ -61,7 +61,11 @@ CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
 sys.path.append(os.path.join(CWD, "../lib/"))
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Required to instantiate the topology builder class.
 

--- a/tests/topotests/bgp_default_originate/test_default_originate_conditional_routemap.py
+++ b/tests/topotests/bgp_default_originate/test_default_originate_conditional_routemap.py
@@ -61,7 +61,7 @@ CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
 sys.path.append(os.path.join(CWD, "../lib/"))
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Required to instantiate the topology builder class.
 

--- a/tests/topotests/bgp_default_originate_timer/test_bgp_default_originate_timer.py
+++ b/tests/topotests/bgp_default_originate_timer/test_bgp_default_originate_timer.py
@@ -28,7 +28,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_default_originate_withdraw/test_bgp_default_originate_withdraw.py
+++ b/tests/topotests/bgp_default_originate_withdraw/test_bgp_default_originate_withdraw.py
@@ -27,7 +27,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_default_route/test_bgp_default-originate.py
+++ b/tests/topotests/bgp_default_route/test_bgp_default-originate.py
@@ -22,7 +22,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_default_route_route_map_match/test_bgp_default-originate_route-map_match.py
+++ b/tests/topotests/bgp_default_route_route_map_match/test_bgp_default-originate_route-map_match.py
@@ -22,7 +22,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_default_route_route_map_match2/test_bgp_default-originate_route-map_match2.py
+++ b/tests/topotests/bgp_default_route_route_map_match2/test_bgp_default-originate_route-map_match2.py
@@ -25,7 +25,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_default_route_route_map_match_set/test_bgp_default-originate_route-map_match_set.py
+++ b/tests/topotests/bgp_default_route_route_map_match_set/test_bgp_default-originate_route-map_match_set.py
@@ -24,7 +24,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_default_route_route_map_set/test_bgp_default-originate_route-map_set.py
+++ b/tests/topotests/bgp_default_route_route_map_set/test_bgp_default-originate_route-map_set.py
@@ -22,7 +22,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_disable_addpath_rx/test_disable_addpath_rx.py
+++ b/tests/topotests/bgp_disable_addpath_rx/test_disable_addpath_rx.py
@@ -23,7 +23,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_distance_change/test_bgp_admin_dist.py
+++ b/tests/topotests/bgp_distance_change/test_bgp_admin_dist.py
@@ -103,7 +103,7 @@ from lib.topolog import logger
 # Global variables
 topo = None
 bgp_convergence = False
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 NETWORK = {
     "ipv4": [

--- a/tests/topotests/bgp_distance_change/test_bgp_admin_dist.py
+++ b/tests/topotests/bgp_distance_change/test_bgp_admin_dist.py
@@ -103,7 +103,11 @@ from lib.topolog import logger
 # Global variables
 topo = None
 bgp_convergence = False
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 NETWORK = {
     "ipv4": [

--- a/tests/topotests/bgp_distance_change/test_bgp_admin_dist_vrf.py
+++ b/tests/topotests/bgp_distance_change/test_bgp_admin_dist_vrf.py
@@ -88,7 +88,11 @@ from lib.topolog import logger
 # Global variables
 topo = None
 bgp_convergence = False
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 NETWORK = {
     "ipv4": [

--- a/tests/topotests/bgp_distance_change/test_bgp_admin_dist_vrf.py
+++ b/tests/topotests/bgp_distance_change/test_bgp_admin_dist_vrf.py
@@ -88,7 +88,7 @@ from lib.topolog import logger
 # Global variables
 topo = None
 bgp_convergence = False
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 NETWORK = {
     "ipv4": [

--- a/tests/topotests/bgp_distance_change/test_bgp_distance_change.py
+++ b/tests/topotests/bgp_distance_change/test_bgp_distance_change.py
@@ -33,7 +33,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_dont_capability_negotiate/test_bgp_dont_capability_negotiate.py
+++ b/tests/topotests/bgp_dont_capability_negotiate/test_bgp_dont_capability_negotiate.py
@@ -16,7 +16,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_duplicate_nexthop/test_bgp_duplicate_nexthop.py
+++ b/tests/topotests/bgp_duplicate_nexthop/test_bgp_duplicate_nexthop.py
@@ -48,7 +48,7 @@ from lib.topolog import logger
 # Required to instantiate the topology builder class.
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_addpath.py
+++ b/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_addpath.py
@@ -19,7 +19,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_fqdn.py
+++ b/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_fqdn.py
@@ -15,7 +15,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_graceful_restart.py
+++ b/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_graceful_restart.py
@@ -17,7 +17,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_orf.py
+++ b/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_orf.py
@@ -15,7 +15,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_role.py
+++ b/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_role.py
@@ -15,7 +15,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_software_version.py
+++ b/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_software_version.py
@@ -16,7 +16,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_ebgp_common_subnet_nexthop_unchanged/test_bgp-ebgp-common-subnet-nexthop-unchanged.py
+++ b/tests/topotests/bgp_ebgp_common_subnet_nexthop_unchanged/test_bgp-ebgp-common-subnet-nexthop-unchanged.py
@@ -26,7 +26,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_ebgp_requires_policy/test_bgp_ebgp_requires_policy.py
+++ b/tests/topotests/bgp_ebgp_requires_policy/test_bgp_ebgp_requires_policy.py
@@ -42,7 +42,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_ecmp_topo1/test_bgp_ecmp_topo1.py
+++ b/tests/topotests/bgp_ecmp_topo1/test_bgp_ecmp_topo1.py
@@ -32,7 +32,7 @@ from lib.topolog import logger
 # Required to instantiate the topology builder class.
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 total_ebgp_peers = 20

--- a/tests/topotests/bgp_ecmp_topo2/test_ebgp_ecmp_topo2.py
+++ b/tests/topotests/bgp_ecmp_topo2/test_ebgp_ecmp_topo2.py
@@ -53,7 +53,11 @@ from lib.bgp import verify_bgp_convergence, create_router_bgp, clear_bgp
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/bgp_ecmp_topo2/test_ebgp_ecmp_topo2.py
+++ b/tests/topotests/bgp_ecmp_topo2/test_ebgp_ecmp_topo2.py
@@ -53,7 +53,7 @@ from lib.bgp import verify_bgp_convergence, create_router_bgp, clear_bgp
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/bgp_ecmp_topo2/test_ibgp_ecmp_topo2.py
+++ b/tests/topotests/bgp_ecmp_topo2/test_ibgp_ecmp_topo2.py
@@ -53,7 +53,11 @@ from lib.bgp import verify_bgp_convergence, create_router_bgp, clear_bgp
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/bgp_ecmp_topo2/test_ibgp_ecmp_topo2.py
+++ b/tests/topotests/bgp_ecmp_topo2/test_ibgp_ecmp_topo2.py
@@ -53,7 +53,7 @@ from lib.bgp import verify_bgp_convergence, create_router_bgp, clear_bgp
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/bgp_ecmp_topo3/test_ibgp_ecmp_topo3.py
+++ b/tests/topotests/bgp_ecmp_topo3/test_ibgp_ecmp_topo3.py
@@ -43,7 +43,11 @@ from lib.topolog import logger
 from lib.topojson import build_config_from_json
 from lib.bgp import create_router_bgp, verify_bgp_convergence
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/bgp_ecmp_topo3/test_ibgp_ecmp_topo3.py
+++ b/tests/topotests/bgp_ecmp_topo3/test_ibgp_ecmp_topo3.py
@@ -43,7 +43,7 @@ from lib.topolog import logger
 from lib.topojson import build_config_from_json
 from lib.bgp import create_router_bgp, verify_bgp_convergence
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/bgp_evpn_maximum_prefix/test_bgp_evpn_maximum_prefix.py
+++ b/tests/topotests/bgp_evpn_maximum_prefix/test_bgp_evpn_maximum_prefix.py
@@ -18,7 +18,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def setup_module(mod):

--- a/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
+++ b/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
@@ -24,7 +24,7 @@ import json
 import platform
 from functools import partial
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.pimd]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
+++ b/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
@@ -24,7 +24,11 @@ import json
 import platform
 from functools import partial
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.pimd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.pimd,
+]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bgp_evpn_overlay_index_gateway/test_bgp_evpn_overlay_index_gateway.py
+++ b/tests/topotests/bgp_evpn_overlay_index_gateway/test_bgp_evpn_overlay_index_gateway.py
@@ -62,7 +62,7 @@ from lib.common_config import (
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Global variables

--- a/tests/topotests/bgp_evpn_route_map_match/test_bgp_evpn_route_map_match.py
+++ b/tests/topotests/bgp_evpn_route_map_match/test_bgp_evpn_route_map_match.py
@@ -15,7 +15,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_evpn_rt5/test_bgp_evpn.py
+++ b/tests/topotests/bgp_evpn_rt5/test_bgp_evpn.py
@@ -32,7 +32,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
@@ -36,7 +36,11 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.common_config import step
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
@@ -36,7 +36,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
+++ b/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
@@ -46,7 +46,7 @@ from lib.common_config import required_linux_kernel_version
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
+++ b/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
@@ -46,7 +46,11 @@ from lib.common_config import required_linux_kernel_version
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
@@ -31,7 +31,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
@@ -31,7 +31,11 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_extcomm_list_delete/test_bgp_extcomm-list_delete.py
+++ b/tests/topotests/bgp_extcomm_list_delete/test_bgp_extcomm-list_delete.py
@@ -28,7 +28,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib import topotest
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_extended_link_bandwidth/test_bgp_extended_link_bandwidth.py
+++ b/tests/topotests/bgp_extended_link_bandwidth/test_bgp_extended_link_bandwidth.py
@@ -18,7 +18,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def setup_module(mod):

--- a/tests/topotests/bgp_extended_optional_parameters_length/test_bgp_extended_optional_parameters_length.py
+++ b/tests/topotests/bgp_extended_optional_parameters_length/test_bgp_extended_optional_parameters_length.py
@@ -17,7 +17,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_features/test_bgp_features.py
+++ b/tests/topotests/bgp_features/test_bgp_features.py
@@ -32,7 +32,11 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+]
 
 #####################################################
 #

--- a/tests/topotests/bgp_features/test_bgp_features.py
+++ b/tests/topotests/bgp_features/test_bgp_features.py
@@ -32,7 +32,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
 
 #####################################################
 #

--- a/tests/topotests/bgp_flowspec/test_bgp_flowspec_topo.py
+++ b/tests/topotests/bgp_flowspec/test_bgp_flowspec_topo.py
@@ -55,7 +55,7 @@ from lib.topolog import logger
 # Required to instantiate the topology builder class.
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 #####################################################

--- a/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-1.py
+++ b/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-1.py
@@ -122,7 +122,7 @@ from lib.common_config import (
     required_linux_kernel_version,
 )
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Global variables

--- a/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-2.py
+++ b/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-2.py
@@ -121,7 +121,7 @@ from lib.common_config import (
     required_linux_kernel_version,
 )
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Global variables

--- a/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-3.py
+++ b/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-3.py
@@ -122,7 +122,7 @@ from lib.common_config import (
     required_linux_kernel_version,
 )
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Global variables

--- a/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-4.py
+++ b/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-4.py
@@ -123,7 +123,7 @@ from lib.common_config import (
     required_linux_kernel_version,
 )
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Global variables

--- a/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-1.py
+++ b/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-1.py
@@ -116,7 +116,7 @@ from lib.common_config import (
     required_linux_kernel_version,
 )
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Global variables

--- a/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-2.py
+++ b/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-2.py
@@ -117,7 +117,7 @@ from lib.common_config import (
     required_linux_kernel_version,
 )
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Global variables

--- a/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-3.py
+++ b/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-3.py
@@ -116,7 +116,7 @@ from lib.common_config import (
     required_linux_kernel_version,
 )
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Global variables

--- a/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-4.py
+++ b/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-4.py
@@ -116,7 +116,7 @@ from lib.common_config import (
     required_linux_kernel_version,
 )
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Global variables

--- a/tests/topotests/bgp_gr_functionality_topo3/test_bgp_gr_functionality_topo3.py
+++ b/tests/topotests/bgp_gr_functionality_topo3/test_bgp_gr_functionality_topo3.py
@@ -57,7 +57,7 @@ from lib.common_config import (
     required_linux_kernel_version,
 )
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Global variables

--- a/tests/topotests/bgp_gr_notification/test_bgp_gr_notification.py
+++ b/tests/topotests/bgp_gr_notification/test_bgp_gr_notification.py
@@ -32,7 +32,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_gr_restart_retain_routes/test_bgp_gr_per_neighbor_restart_retain_routes.py
+++ b/tests/topotests/bgp_gr_restart_retain_routes/test_bgp_gr_per_neighbor_restart_retain_routes.py
@@ -25,7 +25,7 @@ from lib import topotest
 from lib.topogen import Topogen, get_topogen
 from lib.common_config import step, stop_router
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_gr_restart_retain_routes/test_bgp_gr_restart_retain_routes.py
+++ b/tests/topotests/bgp_gr_restart_retain_routes/test_bgp_gr_restart_retain_routes.py
@@ -24,7 +24,7 @@ from lib import topotest
 from lib.topogen import Topogen, get_topogen
 from lib.common_config import step, stop_router
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_gshut/test_bgp_gshut.py
+++ b/tests/topotests/bgp_gshut/test_bgp_gshut.py
@@ -59,7 +59,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_gshut_topo1/test_ebgp_gshut_topo1.py
+++ b/tests/topotests/bgp_gshut_topo1/test_ebgp_gshut_topo1.py
@@ -56,7 +56,7 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/bgp_gshut_topo1/test_ebgp_gshut_topo1.py
+++ b/tests/topotests/bgp_gshut_topo1/test_ebgp_gshut_topo1.py
@@ -56,7 +56,11 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/bgp_gshut_topo1/test_ibgp_gshut_topo1.py
+++ b/tests/topotests/bgp_gshut_topo1/test_ibgp_gshut_topo1.py
@@ -51,7 +51,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/bgp_gshut_topo1/test_ibgp_gshut_topo1.py
+++ b/tests/topotests/bgp_gshut_topo1/test_ibgp_gshut_topo1.py
@@ -51,7 +51,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/bgp_instance_del_test/customize.py
+++ b/tests/topotests/bgp_instance_del_test/customize.py
@@ -1,1 +1,227 @@
-../bgp_l3vpn_to_bgp_vrf/customize.py
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2017 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+
+r"""
+customize.py: Simple FRR MPLS L3VPN test topology
+
+                  |
+             +----+----+
+             |   ce1   |
+             | 99.0.0.1|                              CE Router
+             +----+----+
+       192.168.1. | .2  ce1-eth0
+                  | .1  r1-eth4
+             +---------+
+             |    r1   |
+             | 1.1.1.1 |                              PE Router
+             +----+----+
+                  | .1  r1-eth0
+                  |
+            ~~~~~~~~~~~~~
+          ~~     sw0     ~~
+          ~~ 10.0.1.0/24 ~~
+            ~~~~~~~~~~~~~
+                  |10.0.1.0/24
+                  |
+                  | .2  r2-eth0
+             +----+----+
+             |    r2   |
+             | 2.2.2.2 |                              P router
+             +--+---+--+
+    r2-eth2  .2 |   | .2  r2-eth1
+         ______/     \______
+        /                   \
+  ~~~~~~~~~~~~~        ~~~~~~~~~~~~~
+~~     sw2     ~~    ~~     sw1     ~~
+~~ 10.0.3.0/24 ~~    ~~ 10.0.2.0/24 ~~
+  ~~~~~~~~~~~~~        ~~~~~~~~~~~~~
+        |                 /    |
+         \      _________/     |
+          \    /                \
+r3-eth1 .3 |  | .3  r3-eth0      | .4 r4-eth0
+      +----+--+---+         +----+----+
+      |     r3    |         |    r4   | r4-eth5
+      |  3.3.3.3  |         | 4.4.4.4 |-------+       PE Routers
+      +-----------+         +---------+       |
+192.168.1.1 |r3.eth4 192.168.1.1 | r4-eth4    |192.168.2.1
+         .2 |       ceX-eth0  .2 |            |         .2
+      +-----+-----+         +----+-----+ +----+-----+
+      |    ce2    |         |   ce3    | |   ce4    |
+      | 99.0.0.2  |         | 99.0.0.3 | | 99.0.0.4 | CE Routers
+      +-----+-----+         +----+-----+ +----+-----+
+            |                    |            |
+
+"""
+
+import os
+import platform
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import get_topogen
+from lib.topolog import logger
+from lib.ltemplate import ltemplateRtrCmd
+
+# Required to instantiate the topology builder class.
+
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+# test name based on directory
+TEST = os.path.basename(CWD)
+
+
+def build_topo(tgen):
+    "Build function"
+
+    # This function only purpose is to define allocation and relationship
+    # between routers, switches and hosts.
+    #
+    # Create P/PE routers
+    # check for mpls
+    tgen.add_router("r1")
+    if tgen.hasmpls != True:
+        logger.info("MPLS not available, tests will be skipped")
+        return
+    mach = platform.machine()
+    krel = platform.release()
+    if mach[:1] == "a" and topotest.version_cmp(krel, "4.11") < 0:
+        logger.info("Need Kernel version 4.11 to run on arm processor")
+        return
+    for routern in range(2, 5):
+        tgen.add_router("r{}".format(routern))
+    # Create CE routers
+    for routern in range(1, 5):
+        tgen.add_router("ce{}".format(routern))
+
+    # CE/PE links
+    tgen.add_link(tgen.gears["ce1"], tgen.gears["r1"], "ce1-eth0", "r1-eth4")
+    tgen.add_link(tgen.gears["ce2"], tgen.gears["r3"], "ce2-eth0", "r3-eth4")
+    tgen.add_link(tgen.gears["ce3"], tgen.gears["r4"], "ce3-eth0", "r4-eth4")
+    tgen.add_link(tgen.gears["ce4"], tgen.gears["r4"], "ce4-eth0", "r4-eth5")
+
+    # Create a switch with just one router connected to it to simulate a
+    # empty network.
+    switch = {}
+    switch[0] = tgen.add_switch("sw0")
+    switch[0].add_link(tgen.gears["r1"], nodeif="r1-eth0")
+    switch[0].add_link(tgen.gears["r2"], nodeif="r2-eth0")
+
+    switch[1] = tgen.add_switch("sw1")
+    switch[1].add_link(tgen.gears["r2"], nodeif="r2-eth1")
+    switch[1].add_link(tgen.gears["r3"], nodeif="r3-eth0")
+    switch[1].add_link(tgen.gears["r4"], nodeif="r4-eth0")
+
+    switch[1] = tgen.add_switch("sw2")
+    switch[1].add_link(tgen.gears["r2"], nodeif="r2-eth2")
+    switch[1].add_link(tgen.gears["r3"], nodeif="r3-eth1")
+
+
+def ltemplatePreRouterStartHook():
+    cc = ltemplateRtrCmd()
+    krel = platform.release()
+    tgen = get_topogen()
+    logger.info("pre router-start hook, kernel=" + krel)
+
+    # check for mpls
+    if tgen.hasmpls != True:
+        logger.info("MPLS not available, skipping setup")
+        return False
+    # trace errors/unexpected output
+    cc.resetCounts()
+    # configure r2 mpls interfaces
+    intfs = ["lo", "r2-eth0", "r2-eth1", "r2-eth2"]
+    for intf in intfs:
+        cc.doCmd(tgen, "r2", "echo 1 > /proc/sys/net/mpls/conf/{}/input".format(intf))
+
+    # configure cust1 VRFs & MPLS
+    rtrs = ["r1", "r3", "r4"]
+    cmds = [
+        "ip link add {0}-cust1 type vrf table 10",
+        "ip ru add oif {0}-cust1 table 10",
+        "ip ru add iif {0}-cust1 table 10",
+        "ip link set dev {0}-cust1 up",
+    ]
+    for rtr in rtrs:
+        for cmd in cmds:
+            cc.doCmd(tgen, rtr, cmd.format(rtr))
+        cc.doCmd(tgen, rtr, "ip link set dev {0}-eth4 master {0}-cust1".format(rtr))
+        intfs = [rtr + "-cust1", "lo", rtr + "-eth0", rtr + "-eth4"]
+        for intf in intfs:
+            cc.doCmd(
+                tgen, rtr, "echo 1 > /proc/sys/net/mpls/conf/{}/input".format(intf)
+            )
+        logger.info(
+            "setup {0} vrf {0}-cust1, {0}-eth4. enabled mpls input.".format(rtr)
+        )
+    # configure cust4 VRFs & MPLS
+    cmds = [
+        "ip link add {0}-cust4 type vrf table 30",
+        "ip link set dev {0}-cust4 up",
+        "ip link add {0}-cust5 type vrf table 40",
+        "ip link set dev {0}-cust5 up",
+    ]
+    rtr = "r1"
+    for cmd in cmds:
+        cc.doCmd(tgen, rtr, cmd.format(rtr))
+    logger.info("setup {0} vrf {0}-cust3 and{0}-cust4.".format(rtr))
+    # configure cust2 VRFs & MPLS
+    rtrs = ["r4"]
+    cmds = [
+        "ip link add {0}-cust2 type vrf table 20",
+        "ip ru add oif {0}-cust2 table 20",
+        "ip ru add iif {0}-cust2 table 20",
+        "ip link set dev {0}-cust2 up",
+    ]
+    for rtr in rtrs:
+        for cmd in cmds:
+            cc.doCmd(tgen, rtr, cmd.format(rtr))
+        cc.doCmd(tgen, rtr, "ip link set dev {0}-eth5 master {0}-cust2".format(rtr))
+        intfs = [rtr + "-cust2", rtr + "-eth5"]
+        for intf in intfs:
+            cc.doCmd(
+                tgen, rtr, "echo 1 > /proc/sys/net/mpls/conf/{}/input".format(intf)
+            )
+        logger.info(
+            "setup {0} vrf {0}-cust2, {0}-eth5. enabled mpls input.".format(rtr)
+        )
+    # put ce4-eth0 into a VRF (no default instance!)
+    rtrs = ["ce4"]
+    cmds = [
+        "ip link add {0}-cust2 type vrf table 20",
+        "ip ru add oif {0}-cust2 table 20",
+        "ip ru add iif {0}-cust2 table 20",
+        "ip link set dev {0}-cust2 up",
+    ]
+    for rtr in rtrs:
+        for cmd in cmds:
+            cc.doCmd(tgen, rtr, cmd.format(rtr))
+        cc.doCmd(tgen, rtr, "ip link set dev {0}-eth0 master {0}-cust2".format(rtr))
+    if cc.getOutput() != 0:
+        InitSuccess = False
+        logger.info(
+            "Unexpected output seen ({} times, tests will be skipped".format(
+                cc.getOutput()
+            )
+        )
+    else:
+        rtrs = ["r1", "r3", "r4", "ce4"]
+        for rtr in rtrs:
+            logger.info("{} configured".format(rtr))
+            cc.doCmd(tgen, rtr, "ip -d link show type vrf")
+            cc.doCmd(tgen, rtr, "ip link show")
+        InitSuccess = True
+        logger.info("VRF config successful!")
+    return InitSuccess
+
+
+def ltemplatePostRouterStartHook():
+    logger.info("post router-start hook")
+    return True

--- a/tests/topotests/bgp_instance_del_test/test_bgp_instance_del_test.py
+++ b/tests/topotests/bgp_instance_del_test/test_bgp_instance_del_test.py
@@ -17,7 +17,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
 from lib.ltemplate import *
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ldpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ldpd, pytest.mark.ospfd]
 
 
 def test_check_linux_vrf():

--- a/tests/topotests/bgp_instance_del_test/test_bgp_instance_del_test.py
+++ b/tests/topotests/bgp_instance_del_test/test_bgp_instance_del_test.py
@@ -17,7 +17,12 @@ sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
 from lib.ltemplate import *
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ldpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ldpd,
+    pytest.mark.ospfd,
+]
 
 
 def test_check_linux_vrf():

--- a/tests/topotests/bgp_ipv4_class_e_peer/test_bgp_ipv4_class_e_peer.py
+++ b/tests/topotests/bgp_ipv4_class_e_peer/test_bgp_ipv4_class_e_peer.py
@@ -27,7 +27,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ebgp_ibgp_nbr.py
+++ b/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ebgp_ibgp_nbr.py
@@ -44,7 +44,11 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 topo = None

--- a/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ebgp_ibgp_nbr.py
+++ b/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ebgp_ibgp_nbr.py
@@ -44,7 +44,7 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 topo = None

--- a/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ebgp_nbr.py
+++ b/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ebgp_nbr.py
@@ -42,7 +42,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 topo = None

--- a/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ebgp_nbr.py
+++ b/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ebgp_nbr.py
@@ -42,7 +42,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 topo = None

--- a/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ebgp_unnumbered_nbr.py
+++ b/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ebgp_unnumbered_nbr.py
@@ -43,7 +43,11 @@ from lib.bgp import create_router_bgp, verify_bgp_convergence, verify_bgp_rib
 
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 topo = None

--- a/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ebgp_unnumbered_nbr.py
+++ b/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ebgp_unnumbered_nbr.py
@@ -43,7 +43,7 @@ from lib.bgp import create_router_bgp, verify_bgp_convergence, verify_bgp_rib
 
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 topo = None

--- a/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ibgp_nbr.py
+++ b/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ibgp_nbr.py
@@ -45,7 +45,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 topo = None

--- a/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ibgp_nbr.py
+++ b/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ibgp_nbr.py
@@ -45,7 +45,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 topo = None

--- a/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ibgp_unnumbered_nbr.py
+++ b/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ibgp_unnumbered_nbr.py
@@ -41,7 +41,7 @@ from lib.topojson import build_config_from_json
 # Global variables
 topo = None
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 NETWORK_CMD_IP = "1.0.1.17/32"

--- a/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ibgp_unnumbered_nbr.py
+++ b/tests/topotests/bgp_ipv4_over_ipv6/test_rfc5549_ibgp_unnumbered_nbr.py
@@ -41,7 +41,11 @@ from lib.topojson import build_config_from_json
 # Global variables
 topo = None
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 NETWORK_CMD_IP = "1.0.1.17/32"

--- a/tests/topotests/bgp_ipv6_ll_peering/test_bgp_ipv6_ll_peering.py
+++ b/tests/topotests/bgp_ipv6_ll_peering/test_bgp_ipv6_ll_peering.py
@@ -23,7 +23,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_ipv6_rtadv/test_bgp_ipv6_rtadv.py
+++ b/tests/topotests/bgp_ipv6_rtadv/test_bgp_ipv6_rtadv.py
@@ -32,7 +32,7 @@ from lib.topolog import logger
 # Required to instantiate the topology builder class.
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_l3vpn_label_export/test_bgp_l3vpn_label_export.py
+++ b/tests/topotests/bgp_l3vpn_label_export/test_bgp_l3vpn_label_export.py
@@ -27,7 +27,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import kill_router_daemons, start_router_daemons, step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/test_bgp_l3vpn_to_bgp_direct.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/test_bgp_l3vpn_to_bgp_direct.py
@@ -16,7 +16,11 @@ sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
 
 from lib.ltemplate import *
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+]
 
 
 def test_adjacencies():

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/test_bgp_l3vpn_to_bgp_direct.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/test_bgp_l3vpn_to_bgp_direct.py
@@ -16,7 +16,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
 
 from lib.ltemplate import *
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
 
 
 def test_adjacencies():

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/test_bgp_l3vpn_to_bgp_vrf.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/test_bgp_l3vpn_to_bgp_vrf.py
@@ -16,7 +16,11 @@ sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
 
 from lib.ltemplate import *
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+]
 
 
 def test_check_linux_vrf():

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/test_bgp_l3vpn_to_bgp_vrf.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/test_bgp_l3vpn_to_bgp_vrf.py
@@ -16,7 +16,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
 
 from lib.ltemplate import *
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
 
 
 def test_check_linux_vrf():

--- a/tests/topotests/bgp_labeled_unicast_addpath/test_bgp_labeled_unicast_addpath.py
+++ b/tests/topotests/bgp_labeled_unicast_addpath/test_bgp_labeled_unicast_addpath.py
@@ -27,7 +27,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_labeled_unicast_default_originate/test_bgp_labeled_unicast_default_originate.py
+++ b/tests/topotests/bgp_labeled_unicast_default_originate/test_bgp_labeled_unicast_default_originate.py
@@ -23,7 +23,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_large_comm_list_match/test_bgp_large_comm_list_match.py
+++ b/tests/topotests/bgp_large_comm_list_match/test_bgp_large_comm_list_match.py
@@ -40,7 +40,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_large_community/test_bgp_large_community_topo_1.py
+++ b/tests/topotests/bgp_large_community/test_bgp_large_community_topo_1.py
@@ -58,7 +58,7 @@ from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, clear_bgp_and_verify
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Save the Current Working Directory to find configuration files.

--- a/tests/topotests/bgp_large_community/test_bgp_large_community_topo_2.py
+++ b/tests/topotests/bgp_large_community/test_bgp_large_community_topo_2.py
@@ -82,7 +82,7 @@ from lib.bgp import verify_bgp_convergence, create_router_bgp, clear_bgp_and_ver
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Global variables

--- a/tests/topotests/bgp_link_bw_ip/test_bgp_linkbw_ip.py
+++ b/tests/topotests/bgp_link_bw_ip/test_bgp_linkbw_ip.py
@@ -31,7 +31,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 """

--- a/tests/topotests/bgp_listen_on_multiple_addresses/test_bgp_listen_on_multiple_addresses.py
+++ b/tests/topotests/bgp_listen_on_multiple_addresses/test_bgp_listen_on_multiple_addresses.py
@@ -41,7 +41,7 @@ from lib.common_config import start_topology
 from lib.topotest import router_json_cmp, run_and_expect
 from functools import partial
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 LISTEN_ADDRESSES = {

--- a/tests/topotests/bgp_llgr/test_bgp_llgr.py
+++ b/tests/topotests/bgp_llgr/test_bgp_llgr.py
@@ -21,7 +21,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_local_as/test_bgp_local_as.py
+++ b/tests/topotests/bgp_local_as/test_bgp_local_as.py
@@ -24,7 +24,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_local_as_dotplus_private_remove/test_bgp_local_as_dotplus_private_remove.py
+++ b/tests/topotests/bgp_local_as_dotplus_private_remove/test_bgp_local_as_dotplus_private_remove.py
@@ -41,7 +41,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_local_as_private_remove/test_bgp_local_as_private_remove.py
+++ b/tests/topotests/bgp_local_as_private_remove/test_bgp_local_as_private_remove.py
@@ -28,7 +28,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_local_asn/test_bgp_local_asn_agg.py
+++ b/tests/topotests/bgp_local_asn/test_bgp_local_asn_agg.py
@@ -45,7 +45,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_local_asn/test_bgp_local_asn_agg.py
+++ b/tests/topotests/bgp_local_asn/test_bgp_local_asn_agg.py
@@ -45,7 +45,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_local_asn/test_bgp_local_asn_ecmp.py
+++ b/tests/topotests/bgp_local_asn/test_bgp_local_asn_ecmp.py
@@ -53,7 +53,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_local_asn/test_bgp_local_asn_ecmp.py
+++ b/tests/topotests/bgp_local_asn/test_bgp_local_asn_ecmp.py
@@ -53,7 +53,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_local_asn/test_bgp_local_asn_topo1.py
+++ b/tests/topotests/bgp_local_asn/test_bgp_local_asn_topo1.py
@@ -72,7 +72,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 NETWORK = {"ipv4": "10.1.1.0/32", "ipv6": "10:1::1:0/128"}

--- a/tests/topotests/bgp_local_asn/test_bgp_local_asn_topo1.py
+++ b/tests/topotests/bgp_local_asn/test_bgp_local_asn_topo1.py
@@ -72,7 +72,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 NETWORK = {"ipv4": "10.1.1.0/32", "ipv6": "10:1::1:0/128"}

--- a/tests/topotests/bgp_local_asn/test_bgp_local_asn_topo2.py
+++ b/tests/topotests/bgp_local_asn/test_bgp_local_asn_topo2.py
@@ -54,7 +54,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_local_asn/test_bgp_local_asn_topo2.py
+++ b/tests/topotests/bgp_local_asn/test_bgp_local_asn_topo2.py
@@ -54,7 +54,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_local_asn/test_bgp_local_asn_vrf_topo1.py
+++ b/tests/topotests/bgp_local_asn/test_bgp_local_asn_vrf_topo1.py
@@ -50,7 +50,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_local_asn/test_bgp_local_asn_vrf_topo1.py
+++ b/tests/topotests/bgp_local_asn/test_bgp_local_asn_vrf_topo1.py
@@ -50,7 +50,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_local_asn/test_bgp_local_asn_vrf_topo2.py
+++ b/tests/topotests/bgp_local_asn/test_bgp_local_asn_vrf_topo2.py
@@ -49,7 +49,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_local_asn/test_bgp_local_asn_vrf_topo2.py
+++ b/tests/topotests/bgp_local_asn/test_bgp_local_asn_vrf_topo2.py
@@ -49,7 +49,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_local_asn_dot/test_bgp_local_asn_dot_agg.py
+++ b/tests/topotests/bgp_local_asn_dot/test_bgp_local_asn_dot_agg.py
@@ -58,7 +58,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_local_asn_dot/test_bgp_local_asn_dot_agg.py
+++ b/tests/topotests/bgp_local_asn_dot/test_bgp_local_asn_dot_agg.py
@@ -58,7 +58,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_local_asn_dot/test_bgp_local_asn_dot_ecmp.py
+++ b/tests/topotests/bgp_local_asn_dot/test_bgp_local_asn_dot_ecmp.py
@@ -66,7 +66,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_local_asn_dot/test_bgp_local_asn_dot_ecmp.py
+++ b/tests/topotests/bgp_local_asn_dot/test_bgp_local_asn_dot_ecmp.py
@@ -66,7 +66,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_local_asn_dot/test_bgp_local_asn_dot_topo1.py
+++ b/tests/topotests/bgp_local_asn_dot/test_bgp_local_asn_dot_topo1.py
@@ -85,7 +85,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 NETWORK = {"ipv4": "10.1.1.0/32", "ipv6": "10:1::1:0/128"}

--- a/tests/topotests/bgp_local_asn_dot/test_bgp_local_asn_dot_topo1.py
+++ b/tests/topotests/bgp_local_asn_dot/test_bgp_local_asn_dot_topo1.py
@@ -85,7 +85,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 NETWORK = {"ipv4": "10.1.1.0/32", "ipv6": "10:1::1:0/128"}

--- a/tests/topotests/bgp_lu_explicitnull/test_bgp_lu_explicitnull.py
+++ b/tests/topotests/bgp_lu_explicitnull/test_bgp_lu_explicitnull.py
@@ -29,7 +29,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Basic scenario for BGP-LU. Nodes are directly connected.

--- a/tests/topotests/bgp_lu_topo1/test_bgp_lu.py
+++ b/tests/topotests/bgp_lu_topo1/test_bgp_lu.py
@@ -30,7 +30,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 # Required to instantiate the topology builder class.
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Basic scenario for BGP-LU. Nodes are directly connected.

--- a/tests/topotests/bgp_lu_topo2/test_bgp_lu2.py
+++ b/tests/topotests/bgp_lu_topo2/test_bgp_lu2.py
@@ -31,7 +31,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 #
 # Basic scenario for BGP-LU. Nodes are directly connected.

--- a/tests/topotests/bgp_max_med_on_startup/test_bgp_max_med_on_startup.py
+++ b/tests/topotests/bgp_max_med_on_startup/test_bgp_max_med_on_startup.py
@@ -25,7 +25,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_maximum_prefix_invalid_update/test_bgp_maximum_prefix_invalid_update.py
+++ b/tests/topotests/bgp_maximum_prefix_invalid_update/test_bgp_maximum_prefix_invalid_update.py
@@ -32,7 +32,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_maximum_prefix_out/test_bgp_maximum_prefix_out.py
+++ b/tests/topotests/bgp_maximum_prefix_out/test_bgp_maximum_prefix_out.py
@@ -27,7 +27,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_minimum_holdtime/test_bgp_minimum_holdtime.py
+++ b/tests/topotests/bgp_minimum_holdtime/test_bgp_minimum_holdtime.py
@@ -22,7 +22,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_multi_vrf_topo1/test_bgp_multi_vrf_topo1.py
+++ b/tests/topotests/bgp_multi_vrf_topo1/test_bgp_multi_vrf_topo1.py
@@ -129,7 +129,11 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/bgp_multi_vrf_topo1/test_bgp_multi_vrf_topo1.py
+++ b/tests/topotests/bgp_multi_vrf_topo1/test_bgp_multi_vrf_topo1.py
@@ -129,7 +129,7 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/bgp_multi_vrf_topo2/test_bgp_multi_vrf_topo2.py
+++ b/tests/topotests/bgp_multi_vrf_topo2/test_bgp_multi_vrf_topo2.py
@@ -87,7 +87,7 @@ from lib.bgp import clear_bgp, verify_bgp_rib, create_router_bgp, verify_bgp_con
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/bgp_multi_vrf_topo2/test_bgp_multi_vrf_topo2.py
+++ b/tests/topotests/bgp_multi_vrf_topo2/test_bgp_multi_vrf_topo2.py
@@ -87,7 +87,11 @@ from lib.bgp import clear_bgp, verify_bgp_rib, create_router_bgp, verify_bgp_con
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/bgp_multiview_topo1/test_bgp_multiview_topo1.py
+++ b/tests/topotests/bgp_multiview_topo1/test_bgp_multiview_topo1.py
@@ -64,7 +64,7 @@ from lib.topogen import get_topogen, Topogen
 from lib.common_config import step
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 fatal_error = ""

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/test_nexthop_mp_ipv4_6.py
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/test_nexthop_mp_ipv4_6.py
@@ -27,7 +27,11 @@ from lib.topolog import logger
 from lib.checkping import check_ping
 from lib.bgp import verify_bgp_convergence_from_running_config
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.isisd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.isisd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/test_nexthop_mp_ipv4_6.py
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/test_nexthop_mp_ipv4_6.py
@@ -27,7 +27,7 @@ from lib.topolog import logger
 from lib.checkping import check_ping
 from lib.bgp import verify_bgp_convergence_from_running_config
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.isisd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.isisd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_node_target_extcommunities/test_bgp_node_target_extcommunities.py
+++ b/tests/topotests/bgp_node_target_extcommunities/test_bgp_node_target_extcommunities.py
@@ -26,7 +26,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_oad/test_bgp_oad.py
+++ b/tests/topotests/bgp_oad/test_bgp_oad.py
@@ -16,7 +16,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_orf/test_bgp_orf.py
+++ b/tests/topotests/bgp_orf/test_bgp_orf.py
@@ -20,7 +20,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_path_attribute_discard/test_bgp_path_attribute_discard.py
+++ b/tests/topotests/bgp_path_attribute_discard/test_bgp_path_attribute_discard.py
@@ -26,7 +26,7 @@ from lib import topotest
 from lib.topogen import Topogen, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_path_attribute_treat_as_withdraw/test_bgp_path_attribute_treat_as_withdraw.py
+++ b/tests/topotests/bgp_path_attribute_treat_as_withdraw/test_bgp_path_attribute_treat_as_withdraw.py
@@ -38,7 +38,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_path_attributes_topo1/test_bgp_path_attributes.py
+++ b/tests/topotests/bgp_path_attributes_topo1/test_bgp_path_attributes.py
@@ -72,7 +72,7 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 # Address read from env variables

--- a/tests/topotests/bgp_path_attributes_topo1/test_bgp_path_attributes.py
+++ b/tests/topotests/bgp_path_attributes_topo1/test_bgp_path_attributes.py
@@ -72,7 +72,11 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 # Address read from env variables

--- a/tests/topotests/bgp_path_selection/test_bgp_path_selection.py
+++ b/tests/topotests/bgp_path_selection/test_bgp_path_selection.py
@@ -24,7 +24,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_peer_graceful_shutdown/test_bgp_peer_graceful_shutdown.py
+++ b/tests/topotests/bgp_peer_graceful_shutdown/test_bgp_peer_graceful_shutdown.py
@@ -16,7 +16,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_peer_group/test_bgp_peer-group.py
+++ b/tests/topotests/bgp_peer_group/test_bgp_peer-group.py
@@ -24,7 +24,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_peer_type_multipath_relax/test_bgp_peer-type_multipath-relax.py
+++ b/tests/topotests/bgp_peer_type_multipath_relax/test_bgp_peer-type_multipath-relax.py
@@ -59,7 +59,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 # Prefixes used in the test

--- a/tests/topotests/bgp_peer_type_multipath_relax/test_bgp_peer-type_multipath-relax.py
+++ b/tests/topotests/bgp_peer_type_multipath_relax/test_bgp_peer-type_multipath-relax.py
@@ -59,7 +59,11 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 # Prefixes used in the test

--- a/tests/topotests/bgp_prefix_list_any/test_bgp_prefix_list_any.py
+++ b/tests/topotests/bgp_prefix_list_any/test_bgp_prefix_list_any.py
@@ -16,7 +16,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_prefix_list_topo1/test_prefix_lists.py
+++ b/tests/topotests/bgp_prefix_list_topo1/test_prefix_lists.py
@@ -59,7 +59,7 @@ from lib.bgp import verify_bgp_convergence, create_router_bgp, clear_bgp_and_ver
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Global variables

--- a/tests/topotests/bgp_prefix_list_topo1/test_prefix_modify.py
+++ b/tests/topotests/bgp_prefix_list_topo1/test_prefix_modify.py
@@ -52,7 +52,7 @@ from lib.bgp import verify_bgp_convergence, create_router_bgp, clear_bgp
 
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 # Global variables

--- a/tests/topotests/bgp_prefix_sid/test_bgp_prefix_sid.py
+++ b/tests/topotests/bgp_prefix_sid/test_bgp_prefix_sid.py
@@ -27,7 +27,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_prefix_sid2/test_bgp_prefix_sid2.py
+++ b/tests/topotests/bgp_prefix_sid2/test_bgp_prefix_sid2.py
@@ -27,7 +27,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_recursive_route_ebgp_multi_hop/test_bgp_recursive_route_ebgp_multi_hop.py
+++ b/tests/topotests/bgp_recursive_route_ebgp_multi_hop/test_bgp_recursive_route_ebgp_multi_hop.py
@@ -66,7 +66,11 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/bgp_recursive_route_ebgp_multi_hop/test_bgp_recursive_route_ebgp_multi_hop.py
+++ b/tests/topotests/bgp_recursive_route_ebgp_multi_hop/test_bgp_recursive_route_ebgp_multi_hop.py
@@ -66,7 +66,7 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/bgp_redistribute_table/test_bgp_redistribute_table.py
+++ b/tests/topotests/bgp_redistribute_table/test_bgp_redistribute_table.py
@@ -32,7 +32,7 @@ from lib.topolog import logger
 # Required to instantiate the topology builder class.
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_reject_as_sets/test_bgp_reject_as_sets.py
+++ b/tests/topotests/bgp_reject_as_sets/test_bgp_reject_as_sets.py
@@ -34,7 +34,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_remote_as_auto/test_bgp_remote_as_auto.py
+++ b/tests/topotests/bgp_remote_as_auto/test_bgp_remote_as_auto.py
@@ -19,7 +19,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def setup_module(mod):

--- a/tests/topotests/bgp_remove_private_as/test_bgp_remove_private_as.py
+++ b/tests/topotests/bgp_remove_private_as/test_bgp_remove_private_as.py
@@ -42,7 +42,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from functools import partial
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_remove_private_as_route_map/test_bgp_remove_private_as_route_map.py
+++ b/tests/topotests/bgp_remove_private_as_route_map/test_bgp_remove_private_as_route_map.py
@@ -15,7 +15,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_rfapi_basic_sanity/test_bgp_rfapi_basic_sanity.py
+++ b/tests/topotests/bgp_rfapi_basic_sanity/test_bgp_rfapi_basic_sanity.py
@@ -16,7 +16,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
 
 from lib.ltemplate import *
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
 
 
 def test_add_routes():

--- a/tests/topotests/bgp_rfapi_basic_sanity/test_bgp_rfapi_basic_sanity.py
+++ b/tests/topotests/bgp_rfapi_basic_sanity/test_bgp_rfapi_basic_sanity.py
@@ -16,7 +16,11 @@ sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
 
 from lib.ltemplate import *
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+]
 
 
 def test_add_routes():

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/customize.py
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/customize.py
@@ -1,1 +1,102 @@
-../bgp_rfapi_basic_sanity/customize.py
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2017-2018 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+# Modified by LabN Consulting, L.L.C.
+#
+
+r"""
+customize.py: Simple FRR MPLS L3VPN test topology
+
+             +---------+
+             |    r1   |
+             | 1.1.1.1 |                              PE Router
+             +----+----+
+                  | .1  r1-eth0
+                  |
+            ~~~~~~~~~~~~~
+          ~~     sw0     ~~
+          ~~ 10.0.1.0/24 ~~
+            ~~~~~~~~~~~~~
+                  |10.0.1.0/24
+                  |
+                  | .2  r2-eth0
+             +----+----+
+             |    r2   |
+             | 2.2.2.2 |                              P router
+             +--+---+--+
+    r2-eth2  .2 |   | .2  r2-eth1
+         ______/     \______
+        /                   \
+  ~~~~~~~~~~~~~        ~~~~~~~~~~~~~
+~~     sw2     ~~    ~~     sw1     ~~
+~~ 10.0.3.0/24 ~~    ~~ 10.0.2.0/24 ~~
+  ~~~~~~~~~~~~~        ~~~~~~~~~~~~~
+        |                 /    |
+         \      _________/     |
+          \    /                \
+r3-eth1 .3 |  | .3  r3-eth0      | .4 r4-eth0
+      +----+--+---+         +----+----+
+      |     r3    |         |    r4   |
+      |  3.3.3.3  |         | 4.4.4.4 |               PE Routers
+      +-----------+         +---------+
+ 
+"""
+
+import os
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib.topogen import get_topogen
+from lib.topolog import logger
+from lib.ltemplate import ltemplateRtrCmd
+
+# Required to instantiate the topology builder class.
+
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+# test name based on directory
+TEST = os.path.basename(CWD)
+
+
+def build_topo(tgen):
+    "Build function"
+
+    # This function only purpose is to define allocation and relationship
+    # between routers, switches and hosts.
+    #
+    # Create P/PE routers
+    tgen.add_router("r1")
+    for routern in range(2, 5):
+        tgen.add_router("r{}".format(routern))
+    # Create a switch with just one router connected to it to simulate a
+    # empty network.
+    switch = {}
+    switch[0] = tgen.add_switch("sw0")
+    switch[0].add_link(tgen.gears["r1"], nodeif="r1-eth0")
+    switch[0].add_link(tgen.gears["r2"], nodeif="r2-eth0")
+
+    switch[1] = tgen.add_switch("sw1")
+    switch[1].add_link(tgen.gears["r2"], nodeif="r2-eth1")
+    switch[1].add_link(tgen.gears["r3"], nodeif="r3-eth0")
+    switch[1].add_link(tgen.gears["r4"], nodeif="r4-eth0")
+
+    switch[2] = tgen.add_switch("sw2")
+    switch[2].add_link(tgen.gears["r2"], nodeif="r2-eth2")
+    switch[2].add_link(tgen.gears["r3"], nodeif="r3-eth1")
+
+
+def ltemplatePreRouterStartHook():
+    cc = ltemplateRtrCmd()
+    tgen = get_topogen()
+    logger.info("pre router-start hook")
+    return True
+
+
+def ltemplatePostRouterStartHook():
+    logger.info("post router-start hook")
+    return True

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/test_bgp_rfapi_basic_sanity_config2.py
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/test_bgp_rfapi_basic_sanity_config2.py
@@ -1,1 +1,84 @@
-../bgp_rfapi_basic_sanity/test_bgp_rfapi_basic_sanity.py
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2018, LabN Consulting, L.L.C.
+# Authored by Lou Berger <lberger@labn.net>
+#
+
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
+
+from lib.ltemplate import *
+
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd]
+
+
+def test_add_routes():
+    CliOnFail = None
+    # For debugging, uncomment the next line
+    # CliOnFail = 'tgen.mininet_cli'
+    CheckFunc = "ltemplateVersionCheck('3.1')"
+    # uncomment next line to start cli *before* script is run
+    # CheckFunc = 'ltemplateVersionCheck(\'3.1\', cli=True)'
+    ltemplateTest("scripts/add_routes.py", False, CliOnFail, CheckFunc)
+
+
+def test_adjacencies():
+    CliOnFail = None
+    # For debugging, uncomment the next line
+    # CliOnFail = 'tgen.mininet_cli'
+    CheckFunc = "ltemplateVersionCheck('3.1')"
+    # uncomment next line to start cli *before* script is run
+    # CheckFunc = 'ltemplateVersionCheck(\'3.1\', cli=True)'
+    ltemplateTest("scripts/adjacencies.py", False, CliOnFail, CheckFunc)
+
+
+def test_check_routes():
+    CliOnFail = None
+    # For debugging, uncomment the next line
+    # CliOnFail = 'tgen.mininet_cli'
+    CheckFunc = "ltemplateVersionCheck('3.1')"
+    # uncomment next line to start cli *before* script is run
+    # CheckFunc = 'ltemplateVersionCheck(\'3.1\', cli=True)'
+    ltemplateTest("scripts/check_routes.py", False, CliOnFail, CheckFunc)
+
+
+def test_check_close():
+    CliOnFail = None
+    # For debugging, uncomment the next line
+    # CliOnFail = 'tgen.mininet_cli'
+    CheckFunc = "ltemplateVersionCheck('3.1')"
+    # uncomment next line to start cli *before* script is run
+    # CheckFunc = 'ltemplateVersionCheck(\'3.1\', cli=True)'
+    ltemplateTest("scripts/check_close.py", False, CliOnFail, CheckFunc)
+
+
+def test_check_timeout():
+    CliOnFail = None
+    # For debugging, uncomment the next line
+    # CliOnFail = 'tgen.mininet_cli'
+    CheckFunc = "ltemplateVersionCheck('3.1')"
+    # uncomment next line to start cli *before* script is run
+    # CheckFunc = 'ltemplateVersionCheck(\'3.1\', cli=True)'
+    ltemplateTest("scripts/check_timeout.py", False, CliOnFail, CheckFunc)
+
+
+def test_cleanup_all():
+    CliOnFail = None
+    # For debugging, uncomment the next line
+    # CliOnFail = 'tgen.mininet_cli'
+    CheckFunc = "ltemplateVersionCheck('3.1')"
+    # uncomment next line to start cli *before* script is run
+    # CheckFunc = 'ltemplateVersionCheck(\'3.1\', cli=True)'
+    ltemplateTest("scripts/cleanup_all.py", False, CliOnFail, CheckFunc)
+
+
+if __name__ == "__main__":
+    retval = pytest.main(["-s"])
+    sys.exit(retval)

--- a/tests/topotests/bgp_rmap_extcommunity_none/test_bgp_rmap_extcommunity_none.py
+++ b/tests/topotests/bgp_rmap_extcommunity_none/test_bgp_rmap_extcommunity_none.py
@@ -18,7 +18,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_roles_capability/test_bgp_roles_capability.py
+++ b/tests/topotests/bgp_roles_capability/test_bgp_roles_capability.py
@@ -26,7 +26,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 topodef = {f"s{i}": ("r1", f"r{i}") for i in range(2, 7)}

--- a/tests/topotests/bgp_roles_filtering/test_bgp_roles_filtering.py
+++ b/tests/topotests/bgp_roles_filtering/test_bgp_roles_filtering.py
@@ -25,7 +25,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 topodef = {f"s{i}": (f"r{i}", "r10") for i in range(1, 8)}

--- a/tests/topotests/bgp_route_aggregation/test_bgp_aggregation.py
+++ b/tests/topotests/bgp_route_aggregation/test_bgp_aggregation.py
@@ -51,7 +51,11 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False
@@ -814,11 +818,7 @@ def test_route_summarisation_with_as_set_p1(request):
     )
 
     for addr_type in ADDR_TYPES:
-        for (
-            pfx,
-            seq_id,
-            network,
-        ) in zip(
+        for (pfx, seq_id, network,) in zip(
             [1, 2, 3, 4, 5],
             [10, 20, 30, 40, 50],
             [NETWORK_1_1, NETWORK_1_2, NETWORK_1_3, NETWORK_1_4, NETWORK_1_5],

--- a/tests/topotests/bgp_route_aggregation/test_bgp_aggregation.py
+++ b/tests/topotests/bgp_route_aggregation/test_bgp_aggregation.py
@@ -51,7 +51,7 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/bgp_route_map/test_route_map_topo1.py
+++ b/tests/topotests/bgp_route_map/test_route_map_topo1.py
@@ -40,7 +40,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 #################################

--- a/tests/topotests/bgp_route_map/test_route_map_topo1.py
+++ b/tests/topotests/bgp_route_map/test_route_map_topo1.py
@@ -40,7 +40,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 #################################

--- a/tests/topotests/bgp_route_map/test_route_map_topo2.py
+++ b/tests/topotests/bgp_route_map/test_route_map_topo2.py
@@ -131,7 +131,11 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 # Global variables

--- a/tests/topotests/bgp_route_map/test_route_map_topo2.py
+++ b/tests/topotests/bgp_route_map/test_route_map_topo2.py
@@ -131,7 +131,7 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 # Global variables

--- a/tests/topotests/bgp_route_map_delay_timer/test_bgp_route_map_delay_timer.py
+++ b/tests/topotests/bgp_route_map_delay_timer/test_bgp_route_map_delay_timer.py
@@ -15,7 +15,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_route_map_match_ipv6_nexthop/test_bgp_route_map_match_ipv6_nexthop.py
+++ b/tests/topotests/bgp_route_map_match_ipv6_nexthop/test_bgp_route_map_match_ipv6_nexthop.py
@@ -16,7 +16,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_route_map_match_source_protocol/test_bgp_route_map_match_source_protocol.py
+++ b/tests/topotests/bgp_route_map_match_source_protocol/test_bgp_route_map_match_source_protocol.py
@@ -24,7 +24,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_route_map_match_tag_untagged/test_bgp_route_map_match_tag_untagged.py
+++ b/tests/topotests/bgp_route_map_match_tag_untagged/test_bgp_route_map_match_tag_untagged.py
@@ -19,7 +19,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_route_map_on_match_next/test_bgp_route_map_on_match_next.py
+++ b/tests/topotests/bgp_route_map_on_match_next/test_bgp_route_map_on_match_next.py
@@ -24,7 +24,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_route_map_vpn_import/test_bgp_route_map_vpn_import.py
+++ b/tests/topotests/bgp_route_map_vpn_import/test_bgp_route_map_vpn_import.py
@@ -25,7 +25,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_route_origin_parser/test_bgp_route_origin_parser.py
+++ b/tests/topotests/bgp_route_origin_parser/test_bgp_route_origin_parser.py
@@ -22,7 +22,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_route_server_client/test_bgp_route_server_client.py
+++ b/tests/topotests/bgp_route_server_client/test_bgp_route_server_client.py
@@ -15,7 +15,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_rpki_topo1/r3/rtrd.py
+++ b/tests/topotests/bgp_rpki_topo1/r3/rtrd.py
@@ -1,1 +1,330 @@
-../r1/rtrd.py
+#!/usr/bin/python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Copyright (C) 2023 Tomas Hlavacek (tmshlvck@gmail.com)
+
+from typing import List, Tuple, Callable, Type
+import socket
+import threading
+import socketserver
+import struct
+import ipaddress
+import csv
+import os
+import sys
+
+LISTEN_HOST, LISTEN_PORT = "0.0.0.0", 15432
+VRPS_FILE = os.path.join(sys.path[0], "vrps.csv")
+
+
+def dbg(m: str):
+    print(m)
+    sys.stdout.flush()
+
+
+class RTRDatabase(object):
+    def __init__(self, vrps_file: str) -> None:
+        self.last_serial = 0
+        self.ann4 = []
+        self.ann6 = []
+        self.withdraw4 = []
+        self.withdraw6 = []
+
+        with open(vrps_file, "r") as fh:
+            for rasn, rnet, rmaxlen, _ in csv.reader(fh):
+                try:
+                    net = ipaddress.ip_network(rnet)
+                    asn = int(rasn[2:])
+                    maxlen = int(rmaxlen)
+                    if net.version == 6:
+                        self.ann6.append((asn, str(net), maxlen))
+                    elif net.version == 4:
+                        self.ann4.append((asn, str(net), maxlen))
+                    else:
+                        raise ValueError(f"Unknown AFI: {net.version}")
+                except Exception as e:
+                    dbg(
+                        f"VRPS load: ignoring {str((rasn, rnet,rmaxlen))} because {str(e)}"
+                    )
+
+    def get_serial(self) -> int:
+        return self.last_serial
+
+    def set_serial(self, serial: int) -> None:
+        self.last_serial = serial
+
+    def get_announcements4(self, serial: int = 0) -> List[Tuple[int, str, int]]:
+        if serial > self.last_serial:
+            return self.ann4
+        else:
+            return []
+
+    def get_withdrawals4(self, serial: int = 0) -> List[Tuple[int, str, int]]:
+        if serial > self.last_serial:
+            return self.withdraw4
+        else:
+            return []
+
+    def get_announcements6(self, serial: int = 0) -> List[Tuple[int, str, int]]:
+        if serial > self.last_serial:
+            return self.ann6
+        else:
+            return []
+
+    def get_withdrawals6(self, serial: int = 0) -> List[Tuple[int, str, int]]:
+        if serial > self.last_serial:
+            return self.withdraw6
+        else:
+            return []
+
+
+class RTRConnHandler(socketserver.BaseRequestHandler):
+    PROTO_VERSION = 0
+
+    def setup(self) -> None:
+        self.session_id = 2345
+        self.serial = 1024
+
+        dbg(f"New connection from: {str(self.client_address)} ")
+        # TODO: register for notifies
+
+    def finish(self) -> None:
+        pass
+        # TODO: de-register
+
+    HEADER_LEN = 8
+
+    def decode_header(self, buf: bytes) -> Tuple[int, int, int, int]:
+        # common header in all received packets
+        return struct.unpack("!BBHI", buf)
+        # reutnrs (proto_ver, pdu_type, sess_id, length)
+
+    SERNOTIFY_TYPE = 0
+    SERNOTIFY_LEN = 12
+
+    def send_sernotify(self, serial: int) -> None:
+        # serial notify PDU
+        dbg(f"<Serial Notify session_id={self.session_id} serial={serial}")
+        self.request.send(
+            struct.pack(
+                "!BBHII",
+                self.PROTO_VERSION,
+                self.SERNOTIFY_TYPE,
+                self.session_id,
+                self.SERNOTIFY_LEN,
+                serial,
+            )
+        )
+
+    CACHERESPONSE_TYPE = 3
+    CACHERESPONSE_LEN = 8
+
+    def send_cacheresponse(self) -> None:
+        # cache response PDU
+        dbg(f"<Cache response session_id={self.session_id}")
+        self.request.send(
+            struct.pack(
+                "!BBHI",
+                self.PROTO_VERSION,
+                self.CACHERESPONSE_TYPE,
+                self.session_id,
+                self.CACHERESPONSE_LEN,
+            )
+        )
+
+    FLAGS_ANNOUNCE = 1
+    FLAGS_WITHDRAW = 0
+
+    IPV4_TYPE = 4
+    IPV4_LEN = 20
+
+    def send_ipv4(self, ipnet: str, asn: int, maxlen: int, flags: int):
+        # IPv4 PDU
+        dbg(f"<IPv4 net={ipnet} asn={asn} maxlen={maxlen} flags={flags}")
+        ip = ipaddress.IPv4Network(ipnet)
+        self.request.send(
+            struct.pack(
+                "!BBHIBBBB4sI",
+                self.PROTO_VERSION,
+                self.IPV4_TYPE,
+                0,
+                self.IPV4_LEN,
+                flags,
+                ip.prefixlen,
+                maxlen,
+                0,
+                ip.network_address.packed,
+                asn,
+            )
+        )
+
+    def announce_ipv4(self, ipnet, asn, maxlen):
+        self.send_ipv4(ipnet, asn, maxlen, self.FLAGS_ANNOUNCE)
+
+    def withdraw_ipv4(self, ipnet, asn, maxlen):
+        self.send_ipv4(ipnet, asn, maxlen, self.FLAGS_WITHDRAW)
+
+    IPV6_TYPE = 6
+    IPV6_LEN = 32
+
+    def send_ipv6(self, ipnet: str, asn: int, maxlen: int, flags: int):
+        # IPv6 PDU
+        dbg(f"<IPv6 net={ipnet} asn={asn} maxlen={maxlen} flags={flags}")
+        ip = ipaddress.IPv6Network(ipnet)
+        self.request.send(
+            struct.pack(
+                "!BBHIBBBB16sI",
+                self.PROTO_VERSION,
+                self.IPV6_TYPE,
+                0,
+                self.IPV6_LEN,
+                flags,
+                ip.prefixlen,
+                maxlen,
+                0,
+                ip.network_address.packed,
+                asn,
+            )
+        )
+
+    def announce_ipv6(self, ipnet: str, asn: int, maxlen: int):
+        self.send_ipv6(ipnet, asn, maxlen, self.FLAGS_ANNOUNCE)
+
+    def withdraw_ipv6(self, ipnet: str, asn: int, maxlen: int):
+        self.send_ipv6(ipnet, asn, maxlen, self.FLAGS_WITHDRAW)
+
+    EOD_TYPE = 7
+    EOD_LEN = 12
+
+    def send_endofdata(self, serial: int):
+        # end of data PDU
+        dbg(f"<End of Data session_id={self.session_id} serial={serial}")
+        self.server.db.set_serial(serial)
+        self.request.send(
+            struct.pack(
+                "!BBHII",
+                self.PROTO_VERSION,
+                self.EOD_TYPE,
+                self.session_id,
+                self.EOD_LEN,
+                serial,
+            )
+        )
+
+    CACHERESET_TYPE = 8
+    CACHERESET_LEN = 8
+
+    def send_cachereset(self):
+        # cache reset PDU
+        dbg("<Cache Reset")
+        self.request.send(
+            struct.pack(
+                "!BBHI",
+                self.PROTO_VERSION,
+                self.CACHERESET_TYPE,
+                0,
+                self.CACHERESET_LEN,
+            )
+        )
+
+    SERIAL_QUERY_TYPE = 1
+    SERIAL_QUERY_LEN = 12
+
+    def handle_serial_query(self, buf: bytes, sess_id: int):
+        serial = struct.unpack("!I", buf)[0]
+        dbg(f">Serial query: {serial}")
+        if sess_id:
+            self.server.db.set_serial(serial)
+        else:
+            self.server.db.set_serial(0)
+        self.send_cacheresponse()
+
+        for asn, ipnet, maxlen in self.server.db.get_announcements4(serial):
+            self.announce_ipv4(ipnet, asn, maxlen)
+
+        for asn, ipnet, maxlen in self.server.db.get_withdrawals4(serial):
+            self.withdraw_ipv4(ipnet, asn, maxlen)
+
+        for asn, ipnet, maxlen in self.server.db.get_announcements6(serial):
+            self.announce_ipv6(ipnet, asn, maxlen)
+
+        for asn, ipnet, maxlen in self.server.db.get_withdrawals6(serial):
+            self.withdraw_ipv6(ipnet, asn, maxlen)
+
+        self.send_endofdata(self.serial)
+
+    RESET_TYPE = 2
+
+    def handle_reset(self):
+        dbg(">Reset")
+        self.session_id += 1
+        self.server.db.set_serial(0)
+        self.send_cacheresponse()
+
+        for asn, ipnet, maxlen in self.server.db.get_announcements4(self.serial):
+            self.announce_ipv4(ipnet, asn, maxlen)
+
+        for asn, ipnet, maxlen in self.server.db.get_announcements6(self.serial):
+            self.announce_ipv6(ipnet, asn, maxlen)
+
+        self.send_endofdata(self.serial)
+
+    ERROR_TYPE = 10
+
+    def handle_error(self, buf: bytes):
+        dbg(f">Error: {str(buf)}")
+        self.server.shutdown()
+        self.server.stopped = True
+        raise ConnectionError("Received an RPKI error packet from FRR. Exiting")
+
+    def handle(self):
+        while True:
+            b = self.request.recv(self.HEADER_LEN, socket.MSG_WAITALL)
+            if len(b) == 0:
+                break
+            proto_ver, pdu_type, sess_id, length = self.decode_header(b)
+            dbg(
+                f">Header proto_ver={proto_ver} pdu_type={pdu_type} sess_id={sess_id} length={length}"
+            )
+
+            if sess_id:
+                self.session_id = sess_id
+
+            if pdu_type == self.SERIAL_QUERY_TYPE:
+                b = self.request.recv(
+                    self.SERIAL_QUERY_LEN - self.HEADER_LEN, socket.MSG_WAITALL
+                )
+                self.handle_serial_query(b, sess_id)
+
+            elif pdu_type == self.RESET_TYPE:
+                self.handle_reset()
+
+            elif pdu_type == self.ERROR_TYPE:
+                b = self.request.recv(length - self.HEADER_LEN, socket.MSG_WAITALL)
+                self.handle_error(b)
+
+
+class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    def __init__(
+        self, bind: Tuple[str, int], handler: Type[RTRConnHandler], db: RTRDatabase
+    ) -> None:
+        super().__init__(bind, handler)
+        self.db = db
+
+
+def main():
+    db = RTRDatabase(VRPS_FILE)
+    server = ThreadedTCPServer((LISTEN_HOST, LISTEN_PORT), RTRConnHandler, db)
+    dbg(f"Server listening on {LISTEN_HOST} port {LISTEN_PORT}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        f = open(sys.argv[1], "w")
+        sys.__stdout__ = f
+        sys.stdout = f
+        sys.__stderr__ = f
+        sys.stderr = f
+
+    main()

--- a/tests/topotests/bgp_rpki_topo1/test_bgp_rpki_topo1.py
+++ b/tests/topotests/bgp_rpki_topo1/test_bgp_rpki_topo1.py
@@ -18,7 +18,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_rr_ibgp/test_bgp_rr_ibgp_topo1.py
+++ b/tests/topotests/bgp_rr_ibgp/test_bgp_rr_ibgp_topo1.py
@@ -35,7 +35,7 @@ from lib.topolog import logger
 # Required to instantiate the topology builder class.
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_sender_as_path_loop_detection/test_bgp_sender-as-path-loop-detection.py
+++ b/tests/topotests/bgp_sender_as_path_loop_detection/test_bgp_sender-as-path-loop-detection.py
@@ -28,7 +28,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_set_aspath_exclude/test_bgp_set_aspath_exclude.py
+++ b/tests/topotests/bgp_set_aspath_exclude/test_bgp_set_aspath_exclude.py
@@ -24,7 +24,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_set_aspath_replace/test_bgp_set_aspath_replace.py
+++ b/tests/topotests/bgp_set_aspath_replace/test_bgp_set_aspath_replace.py
@@ -26,7 +26,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_set_local_preference_add_subtract/test_bgp_set_local-preference_add_subtract.py
+++ b/tests/topotests/bgp_set_local_preference_add_subtract/test_bgp_set_local-preference_add_subtract.py
@@ -28,7 +28,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_snmp_bgp4v2mib/test_bgp_snmp_bgp4v2mib.py
+++ b/tests/topotests/bgp_snmp_bgp4v2mib/test_bgp_snmp_bgp4v2mib.py
@@ -26,7 +26,11 @@ from lib.snmptest import SnmpTester
 from lib import topotest
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.snmp]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.snmp,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_snmp_bgp4v2mib/test_bgp_snmp_bgp4v2mib.py
+++ b/tests/topotests/bgp_snmp_bgp4v2mib/test_bgp_snmp_bgp4v2mib.py
@@ -26,7 +26,7 @@ from lib.snmptest import SnmpTester
 from lib import topotest
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.snmp]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.snmp]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_snmp_mplsl3vpn/test_bgp_snmp_mplsvpn.py
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/test_bgp_snmp_mplsvpn.py
@@ -29,7 +29,7 @@ from lib import topotest
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.snmp]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.snmp]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_snmp_mplsl3vpn/test_bgp_snmp_mplsvpn.py
+++ b/tests/topotests/bgp_snmp_mplsl3vpn/test_bgp_snmp_mplsvpn.py
@@ -29,7 +29,12 @@ from lib import topotest
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.snmp]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.isisd,
+    pytest.mark.snmp,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_software_version/test_bgp_software_version.py
+++ b/tests/topotests/bgp_software_version/test_bgp_software_version.py
@@ -17,7 +17,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_soo/test_bgp_soo.py
+++ b/tests/topotests/bgp_soo/test_bgp_soo.py
@@ -26,7 +26,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_srv6_sid_reachability/test_bgp_srv6_sid_reachability.py
+++ b/tests/topotests/bgp_srv6_sid_reachability/test_bgp_srv6_sid_reachability.py
@@ -20,7 +20,11 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import required_linux_kernel_version
 from lib.checkping import check_ping
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_srv6_sid_reachability/test_bgp_srv6_sid_reachability.py
+++ b/tests/topotests/bgp_srv6_sid_reachability/test_bgp_srv6_sid_reachability.py
@@ -20,7 +20,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import required_linux_kernel_version
 from lib.checkping import check_ping
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_srv6l3vpn_over_ipv6/test_bgp_srv6l3vpn_over_ipv6.py
+++ b/tests/topotests/bgp_srv6l3vpn_over_ipv6/test_bgp_srv6l3vpn_over_ipv6.py
@@ -21,7 +21,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import required_linux_kernel_version
 from lib.checkping import check_ping
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_srv6l3vpn_route_leak/test_bgp_srv6l3vpn_route_leak.py
+++ b/tests/topotests/bgp_srv6l3vpn_route_leak/test_bgp_srv6l3vpn_route_leak.py
@@ -19,7 +19,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_srv6l3vpn_sid/test_bgp_srv6l3vpn_sid.py
+++ b/tests/topotests/bgp_srv6l3vpn_sid/test_bgp_srv6l3vpn_sid.py
@@ -38,6 +38,7 @@ from lib.checkping import check_ping
 
 pytestmark = pytest.mark.random_order(disabled=True)
 
+
 def build_topo(tgen):
     r"""
      CE1     CE3      CE5

--- a/tests/topotests/bgp_srv6l3vpn_sid/test_bgp_srv6l3vpn_sid.py
+++ b/tests/topotests/bgp_srv6l3vpn_sid/test_bgp_srv6l3vpn_sid.py
@@ -36,6 +36,7 @@ from lib.topolog import logger
 from lib.common_config import required_linux_kernel_version
 from lib.checkping import check_ping
 
+pytestmark = pytest.mark.random_order(disabled=True)
 
 def build_topo(tgen):
     r"""

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/test_bgp_srv6l3vpn_to_bgp_vrf.py
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf/test_bgp_srv6l3vpn_to_bgp_vrf.py
@@ -25,7 +25,7 @@ from lib.topolog import logger
 from lib.common_config import required_linux_kernel_version
 from lib.checkping import check_ping
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/test_bgp_srv6l3vpn_to_bgp_vrf2.py
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf2/test_bgp_srv6l3vpn_to_bgp_vrf2.py
@@ -25,7 +25,7 @@ from lib.topolog import logger
 from lib.common_config import required_linux_kernel_version
 from lib.checkping import check_ping
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/test_bgp_srv6l3vpn_to_bgp_vrf3.py
+++ b/tests/topotests/bgp_srv6l3vpn_to_bgp_vrf3/test_bgp_srv6l3vpn_to_bgp_vrf3.py
@@ -23,7 +23,7 @@ from lib.topolog import logger
 from lib.common_config import required_linux_kernel_version
 from lib.checkping import check_ping, check_ping
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py
+++ b/tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py
@@ -24,7 +24,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_tcp_mss/test_bgp_tcp_mss.py
+++ b/tests/topotests/bgp_tcp_mss/test_bgp_tcp_mss.py
@@ -26,7 +26,7 @@ import pytest
 import functools
 
 # add after imports, before defining classes or functions:
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_tcp_mss/test_bgp_vrf_tcp_mss.py
+++ b/tests/topotests/bgp_tcp_mss/test_bgp_vrf_tcp_mss.py
@@ -20,7 +20,7 @@ import sys
 import pytest
 
 # add after imports, before defining classes or functions:
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/bgp_tcp_mss_passive/test_bgp_tcp_mss_passive.py
+++ b/tests/topotests/bgp_tcp_mss_passive/test_bgp_tcp_mss_passive.py
@@ -23,7 +23,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_unique_rid/test_bgp_unique_rid.py
+++ b/tests/topotests/bgp_unique_rid/test_bgp_unique_rid.py
@@ -60,7 +60,7 @@ from lib.topogen import Topogen, get_topogen
 from lib.topojson import build_config_from_json
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.staticd]
 
 # Required to instantiate the topology builder class.
 from lib.common_config import (

--- a/tests/topotests/bgp_unique_rid/test_bgp_unique_rid.py
+++ b/tests/topotests/bgp_unique_rid/test_bgp_unique_rid.py
@@ -60,7 +60,12 @@ from lib.topogen import Topogen, get_topogen
 from lib.topojson import build_config_from_json
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 # Required to instantiate the topology builder class.
 from lib.common_config import (

--- a/tests/topotests/bgp_unique_rid/test_bgp_unique_rid_vrf.py
+++ b/tests/topotests/bgp_unique_rid/test_bgp_unique_rid_vrf.py
@@ -57,7 +57,7 @@ from lib.topogen import Topogen, get_topogen
 from lib.topojson import build_config_from_json
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Required to instantiate the topology builder class.
 from lib.common_config import (

--- a/tests/topotests/bgp_unique_rid/test_bgp_unique_rid_vrf.py
+++ b/tests/topotests/bgp_unique_rid/test_bgp_unique_rid_vrf.py
@@ -57,7 +57,11 @@ from lib.topogen import Topogen, get_topogen
 from lib.topojson import build_config_from_json
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Required to instantiate the topology builder class.
 from lib.common_config import (

--- a/tests/topotests/bgp_unnumbered/test_bgp_unnumbered.py
+++ b/tests/topotests/bgp_unnumbered/test_bgp_unnumbered.py
@@ -23,7 +23,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_update_delay/test_bgp_update_delay.py
+++ b/tests/topotests/bgp_update_delay/test_bgp_update_delay.py
@@ -57,7 +57,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/bgp_vpn_5549_route_map/test_bgp_vpn_5549_route_map.py
+++ b/tests/topotests/bgp_vpn_5549_route_map/test_bgp_vpn_5549_route_map.py
@@ -23,7 +23,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_vpnv4_asbr/test_bgp_vpnv4_asbr.py
+++ b/tests/topotests/bgp_vpnv4_asbr/test_bgp_vpnv4_asbr.py
@@ -60,7 +60,7 @@ from lib.checkping import check_ping
 # Required to instantiate the topology builder class.
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_vpnv4_ebgp/test_bgp_vpnv4_ebgp.py
+++ b/tests/topotests/bgp_vpnv4_ebgp/test_bgp_vpnv4_ebgp.py
@@ -35,7 +35,7 @@ from lib.topolog import logger
 # Required to instantiate the topology builder class.
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_vpnv4_gre/test_bgp_vpnv4_gre.py
+++ b/tests/topotests/bgp_vpnv4_gre/test_bgp_vpnv4_gre.py
@@ -32,7 +32,7 @@ from lib.topolog import logger
 # Required to instantiate the topology builder class.
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_vpnv4_noretain/test_bgp_vpnv4_noretain.py
+++ b/tests/topotests/bgp_vpnv4_noretain/test_bgp_vpnv4_noretain.py
@@ -33,7 +33,7 @@ from lib.topolog import logger
 # Required to instantiate the topology builder class.
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_vpnv4_per_nexthop_label/test_bgp_vpnv4_per_nexthop_label.py
+++ b/tests/topotests/bgp_vpnv4_per_nexthop_label/test_bgp_vpnv4_per_nexthop_label.py
@@ -49,7 +49,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 PREFIXES_R11 = ["172.31.0.11/32", "172.31.0.20/32", "172.31.0.111/32"]
 PREFIXES_R12 = ["172.31.0.12/32", "172.31.0.15/32"]

--- a/tests/topotests/bgp_vpnv6_per_nexthop_label/test_bgp_vpnv6_per_nexthop_label.py
+++ b/tests/topotests/bgp_vpnv6_per_nexthop_label/test_bgp_vpnv6_per_nexthop_label.py
@@ -49,7 +49,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 PREFIXES_R11 = ["172:31::11/128", "172:31::20/128", "172:31::111/128"]
 PREFIXES_R12 = ["172:31::12/128", "172:31::15/128"]

--- a/tests/topotests/bgp_vrf_different_asn/test_bgp_vrf_different_asn.py
+++ b/tests/topotests/bgp_vrf_different_asn/test_bgp_vrf_different_asn.py
@@ -19,7 +19,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_vrf_dynamic_route_leak/test_bgp_vrf_dynamic_route_leak_topo1.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak/test_bgp_vrf_dynamic_route_leak_topo1.py
@@ -62,7 +62,11 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}

--- a/tests/topotests/bgp_vrf_dynamic_route_leak/test_bgp_vrf_dynamic_route_leak_topo1.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak/test_bgp_vrf_dynamic_route_leak_topo1.py
@@ -62,7 +62,7 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}

--- a/tests/topotests/bgp_vrf_dynamic_route_leak/test_bgp_vrf_dynamic_route_leak_topo2.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak/test_bgp_vrf_dynamic_route_leak_topo2.py
@@ -59,7 +59,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}

--- a/tests/topotests/bgp_vrf_dynamic_route_leak/test_bgp_vrf_dynamic_route_leak_topo2.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak/test_bgp_vrf_dynamic_route_leak_topo2.py
@@ -59,7 +59,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}

--- a/tests/topotests/bgp_vrf_dynamic_route_leak_topo3/test_bgp_vrf_dynamic_route_leak_topo3.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak_topo3/test_bgp_vrf_dynamic_route_leak_topo3.py
@@ -59,7 +59,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}
@@ -849,25 +853,23 @@ def test_dynamic_imported_matching_prefix_based_on_community_list_p0(request):
                 result = verify_bgp_rib(
                     tgen, addr_type, "r3", static_routes, expected=False
                 )
-                assert result is not True, (
-                    "Testcase {} : Failed \nError {}\n"
-                    "Routes {} still in BGP table".format(
-                        tc_name,
-                        result,
-                        static_routes["r3"]["static_routes"][0]["network"],
-                    )
+                assert (
+                    result is not True
+                ), "Testcase {} : Failed \nError {}\n" "Routes {} still in BGP table".format(
+                    tc_name,
+                    result,
+                    static_routes["r3"]["static_routes"][0]["network"],
                 )
 
                 result = verify_rib(
                     tgen, addr_type, "r3", static_routes, expected=False
                 )
-                assert result is not True, (
-                    "Testcase {} : Failed Error {}"
-                    "Routes {} still in Route table".format(
-                        tc_name,
-                        result,
-                        static_routes["r3"]["static_routes"][0]["network"],
-                    )
+                assert (
+                    result is not True
+                ), "Testcase {} : Failed Error {}" "Routes {} still in Route table".format(
+                    tc_name,
+                    result,
+                    static_routes["r3"]["static_routes"][0]["network"],
                 )
             else:
                 result = verify_bgp_rib(tgen, addr_type, "r3", static_routes)
@@ -924,25 +926,23 @@ def test_dynamic_imported_matching_prefix_based_on_community_list_p0(request):
                 result = verify_bgp_rib(
                     tgen, addr_type, "r3", static_routes, expected=False
                 )
-                assert result is not True, (
-                    "Testcase {} : Failed \nError {}\n"
-                    "Routes {} still in BGP table".format(
-                        tc_name,
-                        result,
-                        static_routes["r3"]["static_routes"][0]["network"],
-                    )
+                assert (
+                    result is not True
+                ), "Testcase {} : Failed \nError {}\n" "Routes {} still in BGP table".format(
+                    tc_name,
+                    result,
+                    static_routes["r3"]["static_routes"][0]["network"],
                 )
 
                 result = verify_rib(
                     tgen, addr_type, "r3", static_routes, expected=False
                 )
-                assert result is not True, (
-                    "Testcase {} : Failed Error {}"
-                    "Routes {} still in Route table".format(
-                        tc_name,
-                        result,
-                        static_routes["r3"]["static_routes"][0]["network"],
-                    )
+                assert (
+                    result is not True
+                ), "Testcase {} : Failed Error {}" "Routes {} still in Route table".format(
+                    tc_name,
+                    result,
+                    static_routes["r3"]["static_routes"][0]["network"],
                 )
             else:
                 result = verify_bgp_rib(tgen, addr_type, "r3", static_routes)
@@ -1155,25 +1155,23 @@ def test_dynamic_import_routes_delete_static_route_p1(request):
                 result = verify_bgp_rib(
                     tgen, addr_type, "r2", static_routes, expected=False
                 )
-                assert result is not True, (
-                    "Testcase {} : Failed \nError {}\n"
-                    "Routes {} still in BGP table".format(
-                        tc_name,
-                        result,
-                        static_routes["r2"]["static_routes"][0]["network"],
-                    )
+                assert (
+                    result is not True
+                ), "Testcase {} : Failed \nError {}\n" "Routes {} still in BGP table".format(
+                    tc_name,
+                    result,
+                    static_routes["r2"]["static_routes"][0]["network"],
                 )
 
                 result = verify_rib(
                     tgen, addr_type, "r2", static_routes, expected=False
                 )
-                assert result is not True, (
-                    "Testcase {} : Failed Error {}"
-                    "Routes {} still in Route table".format(
-                        tc_name,
-                        result,
-                        static_routes[dut]["static_routes"][0]["network"],
-                    )
+                assert (
+                    result is not True
+                ), "Testcase {} : Failed Error {}" "Routes {} still in Route table".format(
+                    tc_name,
+                    result,
+                    static_routes[dut]["static_routes"][0]["network"],
                 )
 
     step("Delete static routes from vrf BLUE")
@@ -1213,23 +1211,21 @@ def test_dynamic_import_routes_delete_static_route_p1(request):
                 result = verify_bgp_rib(
                     tgen, addr_type, dut, static_routes, expected=False
                 )
-                assert result is not True, (
-                    "Testcase {} : Failed \nError {}\n"
-                    "Routes {} still in BGP table".format(
-                        tc_name,
-                        result,
-                        static_routes[dut]["static_routes"][0]["network"],
-                    )
+                assert (
+                    result is not True
+                ), "Testcase {} : Failed \nError {}\n" "Routes {} still in BGP table".format(
+                    tc_name,
+                    result,
+                    static_routes[dut]["static_routes"][0]["network"],
                 )
 
                 result = verify_rib(tgen, addr_type, dut, static_routes, expected=False)
-                assert result is not True, (
-                    "Testcase {} : Failed Error {}"
-                    "Routes {} still in Route table".format(
-                        tc_name,
-                        result,
-                        static_routes[dut]["static_routes"][0]["network"],
-                    )
+                assert (
+                    result is not True
+                ), "Testcase {} : Failed Error {}" "Routes {} still in Route table".format(
+                    tc_name,
+                    result,
+                    static_routes[dut]["static_routes"][0]["network"],
                 )
 
     step("Delete static routes from vrf default")

--- a/tests/topotests/bgp_vrf_dynamic_route_leak_topo3/test_bgp_vrf_dynamic_route_leak_topo3.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak_topo3/test_bgp_vrf_dynamic_route_leak_topo3.py
@@ -59,7 +59,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}

--- a/tests/topotests/bgp_vrf_dynamic_route_leak_topo4/test_bgp_vrf_dynamic_route_leak_topo4-1.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak_topo4/test_bgp_vrf_dynamic_route_leak_topo4-1.py
@@ -56,7 +56,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}

--- a/tests/topotests/bgp_vrf_dynamic_route_leak_topo4/test_bgp_vrf_dynamic_route_leak_topo4-1.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak_topo4/test_bgp_vrf_dynamic_route_leak_topo4-1.py
@@ -56,7 +56,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}
@@ -350,25 +354,23 @@ def test_dynamic_import_recursive_import_tenant_vrf_p1(request):
                     result = verify_bgp_rib(
                         tgen, addr_type, "r4", static_routes, expected=False
                     )
-                    assert result is not True, (
-                        "Testcase {} : Failed \nError {}\n"
-                        "Routes {} still in BGP table".format(
-                            tc_name,
-                            result,
-                            static_routes["r4"]["static_routes"][0]["network"],
-                        )
+                    assert (
+                        result is not True
+                    ), "Testcase {} : Failed \nError {}\n" "Routes {} still in BGP table".format(
+                        tc_name,
+                        result,
+                        static_routes["r4"]["static_routes"][0]["network"],
                     )
 
                     result = verify_rib(
                         tgen, addr_type, "r4", static_routes, expected=False
                     )
-                    assert result is not True, (
-                        "Testcase {} : Failed Error {}"
-                        "Routes {} still in Route table".format(
-                            tc_name,
-                            result,
-                            static_routes["r4"]["static_routes"][0]["network"],
-                        )
+                    assert (
+                        result is not True
+                    ), "Testcase {} : Failed Error {}" "Routes {} still in Route table".format(
+                        tc_name,
+                        result,
+                        static_routes["r4"]["static_routes"][0]["network"],
                     )
                 else:
                     result = verify_bgp_rib(tgen, addr_type, "r4", static_routes)

--- a/tests/topotests/bgp_vrf_dynamic_route_leak_topo4/test_bgp_vrf_dynamic_route_leak_topo4-2.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak_topo4/test_bgp_vrf_dynamic_route_leak_topo4-2.py
@@ -56,7 +56,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}
@@ -489,25 +493,23 @@ def test_dynamic_import_routes_between_two_tenant_vrf_p0(request):
                     result = verify_bgp_rib(
                         tgen, addr_type, dut, static_routes, expected=False
                     )
-                    assert result is not True, (
-                        "Testcase {} : Failed \nError {}\n"
-                        "Routes {} still in BGP table".format(
-                            tc_name,
-                            result,
-                            static_routes[dut]["static_routes"][0]["network"],
-                        )
+                    assert (
+                        result is not True
+                    ), "Testcase {} : Failed \nError {}\n" "Routes {} still in BGP table".format(
+                        tc_name,
+                        result,
+                        static_routes[dut]["static_routes"][0]["network"],
                     )
 
                     result = verify_rib(
                         tgen, addr_type, dut, static_routes, expected=False
                     )
-                    assert result is not True, (
-                        "Testcase {} : Failed \nError {}\n"
-                        "Routes {} still in Route table".format(
-                            tc_name,
-                            result,
-                            static_routes[dut]["static_routes"][0]["network"],
-                        )
+                    assert (
+                        result is not True
+                    ), "Testcase {} : Failed \nError {}\n" "Routes {} still in Route table".format(
+                        tc_name,
+                        result,
+                        static_routes[dut]["static_routes"][0]["network"],
                     )
                 else:
                     result = verify_bgp_rib(tgen, addr_type, dut, static_routes)
@@ -878,25 +880,23 @@ def test_dynamic_import_routes_between_two_tenant_vrf_p0(request):
                     result = verify_bgp_rib(
                         tgen, addr_type, dut, static_routes, expected=False
                     )
-                    assert result is not True, (
-                        "Testcase {} : Failed \nError {}\n"
-                        "Routes {} still in BGP table".format(
-                            tc_name,
-                            result,
-                            static_routes[dut]["static_routes"][0]["network"],
-                        )
+                    assert (
+                        result is not True
+                    ), "Testcase {} : Failed \nError {}\n" "Routes {} still in BGP table".format(
+                        tc_name,
+                        result,
+                        static_routes[dut]["static_routes"][0]["network"],
                     )
 
                     result = verify_rib(
                         tgen, addr_type, dut, static_routes, expected=False
                     )
-                    assert result is not True, (
-                        "Testcase {} : Failed Error {}"
-                        "Routes {} still in Route table".format(
-                            tc_name,
-                            result,
-                            static_routes[dut]["static_routes"][0]["network"],
-                        )
+                    assert (
+                        result is not True
+                    ), "Testcase {} : Failed Error {}" "Routes {} still in Route table".format(
+                        tc_name,
+                        result,
+                        static_routes[dut]["static_routes"][0]["network"],
                     )
                 else:
                     result = verify_bgp_rib(tgen, addr_type, dut, static_routes)

--- a/tests/topotests/bgp_vrf_dynamic_route_leak_topo4/test_bgp_vrf_dynamic_route_leak_topo4-2.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak_topo4/test_bgp_vrf_dynamic_route_leak_topo4-2.py
@@ -56,7 +56,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}

--- a/tests/topotests/bgp_vrf_dynamic_route_leak_topo4/test_bgp_vrf_dynamic_route_leak_topo4-3.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak_topo4/test_bgp_vrf_dynamic_route_leak_topo4-3.py
@@ -56,7 +56,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}
@@ -350,25 +354,23 @@ def test_dynamic_import_routes_between_tenant_to_default_vrf_p0(request):
                     result = verify_bgp_rib(
                         tgen, addr_type, dut, static_routes, expected=False
                     )
-                    assert result is not True, (
-                        "Testcase {} : Failed \nError {}\n"
-                        "Routes {} still in BGP table".format(
-                            tc_name,
-                            result,
-                            static_routes[dut]["static_routes"][0]["network"],
-                        )
+                    assert (
+                        result is not True
+                    ), "Testcase {} : Failed \nError {}\n" "Routes {} still in BGP table".format(
+                        tc_name,
+                        result,
+                        static_routes[dut]["static_routes"][0]["network"],
                     )
 
                     result = verify_rib(
                         tgen, addr_type, dut, static_routes, expected=False
                     )
-                    assert result is not True, (
-                        "Testcase {} : Failed \nError {}\n"
-                        "Routes {} still in BGP table".format(
-                            tc_name,
-                            result,
-                            static_routes[dut]["static_routes"][0]["network"],
-                        )
+                    assert (
+                        result is not True
+                    ), "Testcase {} : Failed \nError {}\n" "Routes {} still in BGP table".format(
+                        tc_name,
+                        result,
+                        static_routes[dut]["static_routes"][0]["network"],
                     )
                 else:
                     result = verify_bgp_rib(tgen, addr_type, dut, static_routes)
@@ -499,25 +501,23 @@ def test_dynamic_import_routes_between_tenant_to_default_vrf_p0(request):
                     result = verify_bgp_rib(
                         tgen, addr_type, dut, static_routes, expected=False
                     )
-                    assert result is not True, (
-                        "Testcase {} : Failed \nError {}\n"
-                        "Routes {} still in BGP table".format(
-                            tc_name,
-                            result,
-                            static_routes[dut]["static_routes"][0]["network"],
-                        )
+                    assert (
+                        result is not True
+                    ), "Testcase {} : Failed \nError {}\n" "Routes {} still in BGP table".format(
+                        tc_name,
+                        result,
+                        static_routes[dut]["static_routes"][0]["network"],
                     )
 
                     result = verify_rib(
                         tgen, addr_type, dut, static_routes, expected=False
                     )
-                    assert result is not True, (
-                        "Testcase {} : Failed Error {}"
-                        "Routes {} still in Route table".format(
-                            tc_name,
-                            result,
-                            static_routes[dut]["static_routes"][0]["network"],
-                        )
+                    assert (
+                        result is not True
+                    ), "Testcase {} : Failed Error {}" "Routes {} still in Route table".format(
+                        tc_name,
+                        result,
+                        static_routes[dut]["static_routes"][0]["network"],
                     )
                 else:
                     result = verify_bgp_rib(tgen, addr_type, dut, static_routes)
@@ -880,25 +880,23 @@ def test_dynamic_import_routes_between_tenant_to_default_vrf_p0(request):
                     result = verify_bgp_rib(
                         tgen, addr_type, dut, static_routes, expected=False
                     )
-                    assert result is not True, (
-                        "Testcase {} : Failed \nError {}\n"
-                        "Routes {} still in BGP table".format(
-                            tc_name,
-                            result,
-                            static_routes[dut]["static_routes"][0]["network"],
-                        )
+                    assert (
+                        result is not True
+                    ), "Testcase {} : Failed \nError {}\n" "Routes {} still in BGP table".format(
+                        tc_name,
+                        result,
+                        static_routes[dut]["static_routes"][0]["network"],
                     )
 
                     result = verify_rib(
                         tgen, addr_type, dut, static_routes, expected=False
                     )
-                    assert result is not True, (
-                        "Testcase {} : Failed Error {}"
-                        "Routes {} still in Route table".format(
-                            tc_name,
-                            result,
-                            static_routes[dut]["static_routes"][0]["network"],
-                        )
+                    assert (
+                        result is not True
+                    ), "Testcase {} : Failed Error {}" "Routes {} still in Route table".format(
+                        tc_name,
+                        result,
+                        static_routes[dut]["static_routes"][0]["network"],
                     )
                 else:
                     result = verify_bgp_rib(tgen, addr_type, dut, static_routes)

--- a/tests/topotests/bgp_vrf_dynamic_route_leak_topo4/test_bgp_vrf_dynamic_route_leak_topo4-3.py
+++ b/tests/topotests/bgp_vrf_dynamic_route_leak_topo4/test_bgp_vrf_dynamic_route_leak_topo4-3.py
@@ -56,7 +56,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}

--- a/tests/topotests/bgp_vrf_leaking_5549_routes/test_bgp_vrf_leaking.py
+++ b/tests/topotests/bgp_vrf_leaking_5549_routes/test_bgp_vrf_leaking.py
@@ -19,7 +19,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_vrf_leaking_rt_change_route_maps/test_bgp_vrf_leaking_rt_change_route_maps.py
+++ b/tests/topotests/bgp_vrf_leaking_rt_change_route_maps/test_bgp_vrf_leaking_rt_change_route_maps.py
@@ -26,7 +26,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_vrf_lite_best_path_test/test_bgp_vrf_lite_best_path_topo1.py
+++ b/tests/topotests/bgp_vrf_lite_best_path_test/test_bgp_vrf_lite_best_path_topo1.py
@@ -55,7 +55,7 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}

--- a/tests/topotests/bgp_vrf_lite_best_path_test/test_bgp_vrf_lite_best_path_topo1.py
+++ b/tests/topotests/bgp_vrf_lite_best_path_test/test_bgp_vrf_lite_best_path_topo1.py
@@ -55,7 +55,11 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}

--- a/tests/topotests/bgp_vrf_lite_best_path_test/test_bgp_vrf_lite_best_path_topo2.py
+++ b/tests/topotests/bgp_vrf_lite_best_path_test/test_bgp_vrf_lite_best_path_topo2.py
@@ -54,7 +54,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}

--- a/tests/topotests/bgp_vrf_lite_best_path_test/test_bgp_vrf_lite_best_path_topo2.py
+++ b/tests/topotests/bgp_vrf_lite_best_path_test/test_bgp_vrf_lite_best_path_topo2.py
@@ -54,7 +54,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "11.11.11.1/32", "ipv6": "11:11::1/128"}

--- a/tests/topotests/bgp_vrf_lite_ipv6_rtadv/test_bgp_vrf_lite_ipv6_rtadv.py
+++ b/tests/topotests/bgp_vrf_lite_ipv6_rtadv/test_bgp_vrf_lite_ipv6_rtadv.py
@@ -32,7 +32,7 @@ from lib.common_config import required_linux_kernel_version
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_vrf_md5_peering/test_bgp_vrf_md5_peering.py
+++ b/tests/topotests/bgp_vrf_md5_peering/test_bgp_vrf_md5_peering.py
@@ -23,7 +23,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_vrf_netns/test_bgp_vrf_netns_topo.py
+++ b/tests/topotests/bgp_vrf_netns/test_bgp_vrf_netns_topo.py
@@ -30,7 +30,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 total_ebgp_peers = 1

--- a/tests/topotests/bgp_vrf_route_leak_basic/test_bgp-vrf-route-leak-basic.py
+++ b/tests/topotests/bgp_vrf_route_leak_basic/test_bgp-vrf-route-leak-basic.py
@@ -26,7 +26,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.checkping import check_ping
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/bgp_weighted_ecmp_recursive/test_bgp_weighted_ecmp_recursive.py
+++ b/tests/topotests/bgp_weighted_ecmp_recursive/test_bgp_weighted_ecmp_recursive.py
@@ -17,7 +17,7 @@ import json
 import pytest
 import functools
 
-pytestmark = [pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/config_timing/test_config_timing.py
+++ b/tests/topotests/config_timing/test_config_timing.py
@@ -33,7 +33,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/cspf_topo1/test_cspf_topo1.py
+++ b/tests/topotests/cspf_topo1/test_cspf_topo1.py
@@ -64,7 +64,7 @@ from lib.topolog import logger
 # and Finally pytest
 import pytest
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/eigrp_topo1/test_eigrp_topo1.py
+++ b/tests/topotests/eigrp_topo1/test_eigrp_topo1.py
@@ -20,7 +20,7 @@ import sys
 import pytest
 import json
 
-pytestmark = [pytest.mark.eigrpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.eigrpd]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/evpn_pim_1/test_evpn_pim_topo1.py
+++ b/tests/topotests/evpn_pim_1/test_evpn_pim_topo1.py
@@ -20,7 +20,11 @@ import pytest
 import json
 from functools import partial
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd, pytest.mark.bgpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.pimd,
+    pytest.mark.bgpd,
+]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/evpn_pim_1/test_evpn_pim_topo1.py
+++ b/tests/topotests/evpn_pim_1/test_evpn_pim_topo1.py
@@ -20,7 +20,7 @@ import pytest
 import json
 from functools import partial
 
-pytestmark = [pytest.mark.pimd, pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd, pytest.mark.bgpd]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_chaos_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_chaos_topo1.py
@@ -62,7 +62,7 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Reading the data from JSON File for topology creation
 # Global variables

--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_chaos_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_chaos_topo1.py
@@ -62,7 +62,11 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Reading the data from JSON File for topology creation
 # Global variables

--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
@@ -70,7 +70,11 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "10.1.1.1/32", "ipv6": "10::1/128"}

--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
@@ -70,7 +70,7 @@ from lib.bgp import (
 )
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 NETWORK1_1 = {"ipv4": "10.1.1.1/32", "ipv6": "10::1/128"}

--- a/tests/topotests/example_test/test_template.py
+++ b/tests/topotests/example_test/test_template.py
@@ -21,7 +21,8 @@ from lib.topolog import logger
 
 # TODO: select markers based on daemons used during test
 # pytest module level markers
-pytestmark = [pytest.mark.random_order(disabled=True)
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
     # pytest.mark.babeld,
     # pytest.mark.bfdd,
     # pytest.mark.bgpd,

--- a/tests/topotests/example_test/test_template.py
+++ b/tests/topotests/example_test/test_template.py
@@ -21,7 +21,7 @@ from lib.topolog import logger
 
 # TODO: select markers based on daemons used during test
 # pytest module level markers
-pytestmark = [
+pytestmark = [pytest.mark.random_order(disabled=True)
     # pytest.mark.babeld,
     # pytest.mark.bfdd,
     # pytest.mark.bgpd,

--- a/tests/topotests/example_test/test_template_json.py
+++ b/tests/topotests/example_test/test_template_json.py
@@ -20,7 +20,7 @@ from lib import fixtures
 
 
 # TODO: select markers based on daemons used during test
-pytestmark = [
+pytestmark = [pytest.mark.random_order(disabled=True)
     pytest.mark.bgpd,
     # pytest.mark.ospfd,
     # pytest.mark.ospf6d

--- a/tests/topotests/example_test/test_template_json.py
+++ b/tests/topotests/example_test/test_template_json.py
@@ -20,7 +20,8 @@ from lib import fixtures
 
 
 # TODO: select markers based on daemons used during test
-pytestmark = [pytest.mark.random_order(disabled=True)
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
     pytest.mark.bgpd,
     # pytest.mark.ospfd,
     # pytest.mark.ospf6d

--- a/tests/topotests/example_topojson_test/test_topo_json_multiple_links/test_example_topojson_multiple_links.py
+++ b/tests/topotests/example_topojson_test/test_topo_json_multiple_links/test_example_topojson_multiple_links.py
@@ -43,7 +43,7 @@ from lib.topojson import build_topo_from_json, build_config_from_json
 # pytest module level markers
 """
 pytestmark = pytest.mark.bfdd # single marker
-pytestmark = [
+pytestmark = [pytest.mark.random_order(disabled=True)
 	pytest.mark.bgpd,
 	pytest.mark.ospfd,
 	pytest.mark.ospf6d

--- a/tests/topotests/example_topojson_test/test_topo_json_single_link/test_example_topojson.py
+++ b/tests/topotests/example_topojson_test/test_topo_json_single_link/test_example_topojson.py
@@ -43,7 +43,7 @@ from lib.topojson import build_topo_from_json, build_config_from_json
 # pytest module level markers
 """
 pytestmark = pytest.mark.bfdd # single marker
-pytestmark = [
+pytestmark = [pytest.mark.random_order(disabled=True)
 	pytest.mark.bgpd,
 	pytest.mark.ospfd,
 	pytest.mark.ospf6d

--- a/tests/topotests/example_topojson_test/test_topo_json_single_link_loopback/test_example_topojson.py
+++ b/tests/topotests/example_topojson_test/test_topo_json_single_link_loopback/test_example_topojson.py
@@ -44,7 +44,7 @@ from lib.topojson import build_topo_from_json, build_config_from_json
 # pytest module level markers
 """
 pytestmark = pytest.mark.bfdd # single marker
-pytestmark = [
+pytestmark = [pytest.mark.random_order(disabled=True)
 	pytest.mark.bgpd,
 	pytest.mark.ospfd,
 	pytest.mark.ospf6d

--- a/tests/topotests/fpm_testing_topo1/test_fpm_topo1.py
+++ b/tests/topotests/fpm_testing_topo1/test_fpm_topo1.py
@@ -29,7 +29,11 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.fpm, pytest.mark.sharpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.fpm,
+    pytest.mark.sharpd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/fpm_testing_topo1/test_fpm_topo1.py
+++ b/tests/topotests/fpm_testing_topo1/test_fpm_topo1.py
@@ -29,7 +29,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
 
-pytestmark = [pytest.mark.fpm, pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.fpm, pytest.mark.sharpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/grpc_basic/test_basic_grpc.py
+++ b/tests/topotests/grpc_basic/test_basic_grpc.py
@@ -31,7 +31,7 @@ GRPCP_OSPFD = 50055
 GRPCP_PIMD = 50056
 GRPCP_MGMTD = 50057
 
-pytestmark = [
+pytestmark = [pytest.mark.random_order(disabled=True),
     pytest.mark.mgmtd,
     # pytest.mark.bfdd,
     # pytest.mark.isisd,

--- a/tests/topotests/grpc_basic/test_basic_grpc.py
+++ b/tests/topotests/grpc_basic/test_basic_grpc.py
@@ -31,7 +31,8 @@ GRPCP_OSPFD = 50055
 GRPCP_PIMD = 50056
 GRPCP_MGMTD = 50057
 
-pytestmark = [pytest.mark.random_order(disabled=True),
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
     pytest.mark.mgmtd,
     # pytest.mark.bfdd,
     # pytest.mark.isisd,

--- a/tests/topotests/isis_advertise_high_metrics/test_isis_advertise_high_metrics.py
+++ b/tests/topotests/isis_advertise_high_metrics/test_isis_advertise_high_metrics.py
@@ -47,7 +47,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/isis_lfa_topo1/test_isis_lfa_topo1.py
+++ b/tests/topotests/isis_lfa_topo1/test_isis_lfa_topo1.py
@@ -57,7 +57,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd]
 
 # Global multi-dimensional dictionary containing all expected outputs
 outputs = {}

--- a/tests/topotests/isis_lsp_bits_topo1/test_isis_lsp_bits_topo1.py
+++ b/tests/topotests/isis_lsp_bits_topo1/test_isis_lsp_bits_topo1.py
@@ -67,7 +67,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd]
 
 
 # Global multi-dimensional dictionary containing all expected outputs

--- a/tests/topotests/isis_rlfa_topo1/test_isis_rlfa_topo1.py
+++ b/tests/topotests/isis_rlfa_topo1/test_isis_rlfa_topo1.py
@@ -66,7 +66,11 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd, pytest.mark.ldpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.isisd,
+    pytest.mark.ldpd,
+]
 
 # Global multi-dimensional dictionary containing all expected outputs
 outputs = {}

--- a/tests/topotests/isis_rlfa_topo1/test_isis_rlfa_topo1.py
+++ b/tests/topotests/isis_rlfa_topo1/test_isis_rlfa_topo1.py
@@ -66,7 +66,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.isisd, pytest.mark.ldpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd, pytest.mark.ldpd]
 
 # Global multi-dimensional dictionary containing all expected outputs
 outputs = {}

--- a/tests/topotests/isis_snmp/test_isis_snmp.py
+++ b/tests/topotests/isis_snmp/test_isis_snmp.py
@@ -66,7 +66,12 @@ from lib.snmptest import SnmpTester
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd, pytest.mark.ldpd, pytest.mark.snmp]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.isisd,
+    pytest.mark.ldpd,
+    pytest.mark.snmp,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/isis_snmp/test_isis_snmp.py
+++ b/tests/topotests/isis_snmp/test_isis_snmp.py
@@ -66,7 +66,7 @@ from lib.snmptest import SnmpTester
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.isisd, pytest.mark.ldpd, pytest.mark.snmp]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd, pytest.mark.ldpd, pytest.mark.snmp]
 
 
 def build_topo(tgen):

--- a/tests/topotests/isis_sr_flex_algo_topo1/test_isis_sr_flex_algo_topo1.py
+++ b/tests/topotests/isis_sr_flex_algo_topo1/test_isis_sr_flex_algo_topo1.py
@@ -51,7 +51,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd]
 
 # Global multi-dimensional dictionary containing all expected outputs
 outputs = {}

--- a/tests/topotests/isis_sr_flex_algo_topo2/test_isis_sr_flex_algo_topo2.py
+++ b/tests/topotests/isis_sr_flex_algo_topo2/test_isis_sr_flex_algo_topo2.py
@@ -60,7 +60,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/isis_sr_te_topo1/test_isis_sr_te_topo1.py
+++ b/tests/topotests/isis_sr_te_topo1/test_isis_sr_te_topo1.py
@@ -80,7 +80,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.pathd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.pathd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/isis_sr_te_topo1/test_isis_sr_te_topo1.py
+++ b/tests/topotests/isis_sr_te_topo1/test_isis_sr_te_topo1.py
@@ -80,7 +80,12 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.pathd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.isisd,
+    pytest.mark.pathd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/isis_sr_topo1/test_isis_sr_topo1.py
+++ b/tests/topotests/isis_sr_topo1/test_isis_sr_topo1.py
@@ -69,7 +69,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
+++ b/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
@@ -78,7 +78,7 @@ from lib.common_config import (
     create_interface_in_kernel,
 )
 
-pytestmark = [pytest.mark.isisd, pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd, pytest.mark.sharpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
+++ b/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
@@ -78,7 +78,11 @@ from lib.common_config import (
     create_interface_in_kernel,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd, pytest.mark.sharpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.isisd,
+    pytest.mark.sharpd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/isis_te_topo1/test_isis_te_topo1.py
+++ b/tests/topotests/isis_te_topo1/test_isis_te_topo1.py
@@ -64,7 +64,7 @@ from lib.topolog import logger
 # and Finally pytest
 import pytest
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/isis_tilfa_topo1/test_isis_tilfa_topo1.py
+++ b/tests/topotests/isis_tilfa_topo1/test_isis_tilfa_topo1.py
@@ -69,7 +69,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd]
 
 # Global multi-dimensional dictionary containing all expected outputs
 outputs = {}

--- a/tests/topotests/isis_topo1/test_isis_topo1.py
+++ b/tests/topotests/isis_topo1/test_isis_topo1.py
@@ -34,7 +34,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd]
 
 VERTEX_TYPE_LIST = [
     "pseudo_IS",

--- a/tests/topotests/isis_topo1_vrf/test_isis_topo1_vrf.py
+++ b/tests/topotests/isis_topo1_vrf/test_isis_topo1_vrf.py
@@ -29,7 +29,7 @@ from lib.topotest import iproute2_is_vrf_capable
 from lib.common_config import required_linux_kernel_version
 
 
-pytestmark = [pytest.mark.isisd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd]
 
 VERTEX_TYPE_LIST = [
     "pseudo_IS",

--- a/tests/topotests/key_sendaccept/test_keychain.py
+++ b/tests/topotests/key_sendaccept/test_keychain.py
@@ -14,7 +14,11 @@ import json
 import pytest
 from lib.topogen import Topogen
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ripd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ripd,
+    pytest.mark.mgmtd,
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/key_sendaccept/test_keychain.py
+++ b/tests/topotests/key_sendaccept/test_keychain.py
@@ -14,7 +14,7 @@ import json
 import pytest
 from lib.topogen import Topogen
 
-pytestmark = [pytest.mark.ripd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ripd, pytest.mark.mgmtd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/ldp_oc_acl_topo1/test_ldp_oc_acl_topo1.py
+++ b/tests/topotests/ldp_oc_acl_topo1/test_ldp_oc_acl_topo1.py
@@ -64,7 +64,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ldpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ldpd, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ldp_oc_acl_topo1/test_ldp_oc_acl_topo1.py
+++ b/tests/topotests/ldp_oc_acl_topo1/test_ldp_oc_acl_topo1.py
@@ -64,7 +64,11 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ldpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ldpd,
+    pytest.mark.ospfd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ldp_oc_topo1/test_ldp_oc_topo1.py
+++ b/tests/topotests/ldp_oc_topo1/test_ldp_oc_topo1.py
@@ -63,7 +63,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ldpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ldpd, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ldp_oc_topo1/test_ldp_oc_topo1.py
+++ b/tests/topotests/ldp_oc_topo1/test_ldp_oc_topo1.py
@@ -63,7 +63,11 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ldpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ldpd,
+    pytest.mark.ospfd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ldp_snmp/test_ldp_snmp_topo1.py
+++ b/tests/topotests/ldp_snmp/test_ldp_snmp_topo1.py
@@ -65,7 +65,7 @@ from lib.snmptest import SnmpTester
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ldpd, pytest.mark.isisd, pytest.mark.snmp]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ldpd, pytest.mark.isisd, pytest.mark.snmp]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ldp_snmp/test_ldp_snmp_topo1.py
+++ b/tests/topotests/ldp_snmp/test_ldp_snmp_topo1.py
@@ -65,7 +65,12 @@ from lib.snmptest import SnmpTester
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ldpd, pytest.mark.isisd, pytest.mark.snmp]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ldpd,
+    pytest.mark.isisd,
+    pytest.mark.snmp,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ldp_sync_isis_topo1/test_ldp_sync_isis_topo1.py
+++ b/tests/topotests/ldp_sync_isis_topo1/test_ldp_sync_isis_topo1.py
@@ -65,7 +65,11 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd, pytest.mark.ldpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.isisd,
+    pytest.mark.ldpd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ldp_sync_isis_topo1/test_ldp_sync_isis_topo1.py
+++ b/tests/topotests/ldp_sync_isis_topo1/test_ldp_sync_isis_topo1.py
@@ -65,7 +65,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.isisd, pytest.mark.ldpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.isisd, pytest.mark.ldpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ldp_sync_ospf_topo1/test_ldp_sync_ospf_topo1.py
+++ b/tests/topotests/ldp_sync_ospf_topo1/test_ldp_sync_ospf_topo1.py
@@ -64,7 +64,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ldpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ldpd, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ldp_sync_ospf_topo1/test_ldp_sync_ospf_topo1.py
+++ b/tests/topotests/ldp_sync_ospf_topo1/test_ldp_sync_ospf_topo1.py
@@ -64,7 +64,11 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ldpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ldpd,
+    pytest.mark.ospfd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ldp_topo1/test_ldp_topo1.py
+++ b/tests/topotests/ldp_topo1/test_ldp_topo1.py
@@ -65,7 +65,11 @@ from lib.topogen import Topogen, get_topogen
 
 fatal_error = ""
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ldpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ldpd,
+    pytest.mark.ospfd,
+]
 
 #####################################################
 ##

--- a/tests/topotests/ldp_topo1/test_ldp_topo1.py
+++ b/tests/topotests/ldp_topo1/test_ldp_topo1.py
@@ -65,7 +65,7 @@ from lib.topogen import Topogen, get_topogen
 
 fatal_error = ""
 
-pytestmark = [pytest.mark.ldpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ldpd, pytest.mark.ospfd]
 
 #####################################################
 ##

--- a/tests/topotests/ldp_vpls_topo1/test_ldp_vpls_topo1.py
+++ b/tests/topotests/ldp_vpls_topo1/test_ldp_vpls_topo1.py
@@ -65,7 +65,11 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ldpd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ldpd,
+    pytest.mark.ospfd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ldp_vpls_topo1/test_ldp_vpls_topo1.py
+++ b/tests/topotests/ldp_vpls_topo1/test_ldp_vpls_topo1.py
@@ -65,7 +65,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ldpd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ldpd, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/mgmt_config/test_config.py
+++ b/tests/topotests/mgmt_config/test_config.py
@@ -61,7 +61,11 @@ import pytest
 from lib.common_config import retry, step
 from lib.topogen import Topogen, TopoRouter
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 
 @retry(retry_timeout=1, initial_wait=0.1)

--- a/tests/topotests/mgmt_config/test_config.py
+++ b/tests/topotests/mgmt_config/test_config.py
@@ -61,7 +61,7 @@ import pytest
 from lib.common_config import retry, step
 from lib.topogen import Topogen, TopoRouter
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
 
 
 @retry(retry_timeout=1, initial_wait=0.1)

--- a/tests/topotests/mgmt_config/test_regression.py
+++ b/tests/topotests/mgmt_config/test_regression.py
@@ -12,7 +12,7 @@ Test mgmtd regressions
 import pytest
 from lib.topogen import Topogen
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_config/test_regression.py
+++ b/tests/topotests/mgmt_config/test_regression.py
@@ -12,7 +12,11 @@ Test mgmtd regressions
 import pytest
 from lib.topogen import Topogen
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_debug_flags/test_debug.py
+++ b/tests/topotests/mgmt_debug_flags/test_debug.py
@@ -16,7 +16,7 @@ from lib.common_config import step
 from lib.topogen import Topogen
 from munet.watchlog import WatchLog
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_debug_flags/test_debug.py
+++ b/tests/topotests/mgmt_debug_flags/test_debug.py
@@ -16,7 +16,11 @@ from lib.common_config import step
 from lib.topogen import Topogen
 from munet.watchlog import WatchLog
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_fe_client/oper.py
+++ b/tests/topotests/mgmt_fe_client/oper.py
@@ -1,1 +1,264 @@
-../mgmt_oper/oper.py
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: ISC
+#
+# October 29 2023, Christian Hopps <chopps@labn.net>
+#
+# Copyright (c) 2023, LabN Consulting, L.L.C.
+#
+
+import datetime
+import ipaddress
+import json
+import logging
+import math
+import os
+import pprint
+import re
+
+from lib.common_config import retry, step
+from lib.topolog import logger
+from lib.topotest import json_cmp as tt_json_cmp
+
+try:
+    from deepdiff import DeepDiff as dd_json_cmp
+except ImportError:
+    dd_json_cmp = None
+
+
+def json_cmp(got, expect, exact_match):
+    if dd_json_cmp:
+        if exact_match:
+            deep_diff = dd_json_cmp(expect, got)
+            # Convert DeepDiff completely into dicts or lists at all levels
+            json_diff = json.loads(deep_diff.to_json())
+        else:
+            json_diff = dd_json_cmp(expect, got, ignore_order=True)
+            # Convert DeepDiff completely into dicts or lists at all levels
+            # json_diff = json.loads(deep_diff.to_json())
+            # Remove new fields in json object from diff
+            if json_diff.get("dictionary_item_added") is not None:
+                del json_diff["dictionary_item_added"]
+            # Remove new json objects in json array from diff
+            if (new_items := json_diff.get("iterable_item_added")) is not None:
+                new_item_paths = list(new_items.keys())
+                for path in new_item_paths:
+                    if type(new_items[path]) is dict:
+                        del new_items[path]
+                if len(new_items) == 0:
+                    del json_diff["iterable_item_added"]
+        if not json_diff:
+            json_diff = None
+    else:
+        json_diff = tt_json_cmp(got, expect, exact_match)
+        json_diff = str(json_diff)
+    return json_diff
+
+
+def enable_debug(router):
+    router.vtysh_cmd("debug northbound callbacks configuration")
+
+
+def disable_debug(router):
+    router.vtysh_cmd("no debug northbound callbacks configuration")
+
+
+@retry(retry_timeout=30, initial_wait=1)
+def _do_oper_test(tgen, qr):
+    r1 = tgen.gears["r1"].net
+
+    qcmd = (
+        r"vtysh -c 'show mgmt get-data {} {}' "
+        r"""| sed -e 's/"phy-address": ".*"/"phy-address": "rubout"/'"""
+        r"""| sed -e 's/"uptime": ".*"/"uptime": "rubout"/'"""
+        r"""| sed -e 's/"vrf": "[0-9]*"/"vrf": "rubout"/'"""
+        r"""| sed -e 's/"if-index": [0-9][0-9]*/"if-index": "rubout"/'"""
+        r"""| sed -e 's/"id": [0-9][0-9]*/"id": "rubout"/'"""
+    )
+    # Don't use this for now.
+    dd_json_cmp = None
+
+    expected = open(qr[1], encoding="ascii").read()
+    output = r1.cmd_nostatus(qcmd.format(qr[0], qr[2] if len(qr) > 2 else ""))
+
+    try:
+        ojson = json.loads(output)
+    except json.decoder.JSONDecodeError as error:
+        logging.error("Error decoding json: %s\noutput:\n%s", error, output)
+        raise
+
+    try:
+        ejson = json.loads(expected)
+    except json.decoder.JSONDecodeError as error:
+        logging.error(
+            "Error decoding json exp result: %s\noutput:\n%s", error, expected
+        )
+        raise
+
+    if dd_json_cmp:
+        cmpout = json_cmp(ojson, ejson, exact_match=True)
+        if cmpout:
+            logging.warning(
+                "-------DIFF---------\n%s\n---------DIFF----------",
+                pprint.pformat(cmpout),
+            )
+    else:
+        cmpout = tt_json_cmp(ojson, ejson, exact=True)
+        if cmpout:
+            logging.warning(
+                "-------EXPECT--------\n%s\n------END-EXPECT------",
+                json.dumps(ejson, indent=4),
+            )
+            logging.warning(
+                "--------GOT----------\n%s\n-------END-GOT--------",
+                json.dumps(ojson, indent=4),
+            )
+
+    assert cmpout is None
+
+
+def do_oper_test(tgen, query_results):
+    reset = True
+    for qr in query_results:
+        step(f"Perform query '{qr[0]}'", reset=reset)
+        if reset:
+            reset = False
+        _do_oper_test(tgen, qr)
+
+
+def get_ip_networks(super_prefix, count):
+    count_log2 = math.log(count, 2)
+    if count_log2 != int(count_log2):
+        count_log2 = int(count_log2) + 1
+    else:
+        count_log2 = int(count_log2)
+    network = ipaddress.ip_network(super_prefix)
+    return tuple(network.subnets(count_log2))[0:count]
+
+
+@retry(retry_timeout=30, initial_wait=0.1)
+def check_kernel(r1, super_prefix, count, add, is_blackhole, vrf, matchvia):
+    network = ipaddress.ip_network(super_prefix)
+    vrfstr = f" vrf {vrf}" if vrf else ""
+    if network.version == 6:
+        kernel = r1.cmd_raises(f"ip -6 route show{vrfstr}")
+    else:
+        kernel = r1.cmd_raises(f"ip -4 route show{vrfstr}")
+
+    # logger.debug("checking kernel routing table%s:\n%s", vrfstr, kernel)
+
+    for _, net in enumerate(get_ip_networks(super_prefix, count)):
+        if not add:
+            assert str(net) not in kernel
+            continue
+
+        if is_blackhole:
+            route = f"blackhole {str(net)} proto (static|196) metric 20"
+        else:
+            route = (
+                f"{str(net)}(?: nhid [0-9]+)? {matchvia} "
+                "proto (static|196) metric 20"
+            )
+        assert re.search(route, kernel), f"Failed to find \n'{route}'\n in \n'{kernel}'"
+
+
+def addrgen(a, count, step=1):
+    for _ in range(0, count, step):
+        yield a
+        a += step
+
+
+@retry(retry_timeout=30, initial_wait=0.1)
+def check_kernel_32(r1, start_addr, count, vrf, step=1):
+    start = ipaddress.ip_address(start_addr)
+    vrfstr = f" vrf {vrf}" if vrf else ""
+    if start.version == 6:
+        kernel = r1.cmd_raises(f"ip -6 route show{vrfstr}")
+    else:
+        kernel = r1.cmd_raises(f"ip -4 route show{vrfstr}")
+
+    nentries = len(re.findall("\n", kernel))
+    logging.info("checking kernel routing table%s: (%s entries)", vrfstr, nentries)
+
+    for addr in addrgen(start, count, step):
+        assert str(addr) in kernel, f"Failed to find '{addr}' in {nentries} entries"
+
+
+def do_config(
+    r1,
+    count,
+    add=True,
+    do_ipv6=False,
+    via=None,
+    vrf=None,
+    use_cli=False,
+):
+    optype = "adding" if add else "removing"
+    iptype = "IPv6" if do_ipv6 else "IPv4"
+
+    #
+    # Set the route details
+    #
+
+    if vrf:
+        super_prefix = "2111::/48" if do_ipv6 else "111.0.0.0/8"
+    else:
+        super_prefix = "2055::/48" if do_ipv6 else "55.0.0.0/8"
+
+    matchvia = ""
+    if via == "blackhole":
+        pass
+    elif via:
+        matchvia = f"dev {via}"
+    else:
+        if vrf:
+            via = "2102::2" if do_ipv6 else "3.3.3.2"
+            matchvia = f"via {via} dev r1-eth1"
+        else:
+            via = "2101::2" if do_ipv6 else "1.1.1.2"
+            matchvia = f"via {via} dev r1-eth0"
+
+    vrfdbg = " in vrf {}".format(vrf) if vrf else ""
+    logger.debug("{} {} static {} routes{}".format(optype, count, iptype, vrfdbg))
+
+    #
+    # Generate config file in a retrievable place
+    #
+
+    config_file = os.path.join(
+        r1.logdir, r1.name, "{}-routes-{}.conf".format(iptype.lower(), optype)
+    )
+    with open(config_file, "w") as f:
+        if use_cli:
+            f.write("configure terminal\n")
+        if vrf:
+            f.write("vrf {}\n".format(vrf))
+
+        for _, net in enumerate(get_ip_networks(super_prefix, count)):
+            if add:
+                f.write("ip route {} {}\n".format(net, via))
+            else:
+                f.write("no ip route {} {}\n".format(net, via))
+
+    #
+    # Load config file.
+    #
+
+    if use_cli:
+        load_command = 'vtysh < "{}"'.format(config_file)
+    else:
+        load_command = 'vtysh -f "{}"'.format(config_file)
+    tstamp = datetime.datetime.now()
+    output = r1.cmd_raises(load_command)
+    delta = (datetime.datetime.now() - tstamp).total_seconds()
+
+    #
+    # Verify the results are in the kernel
+    #
+    check_kernel(r1, super_prefix, count, add, via == "blackhole", vrf, matchvia)
+
+    optyped = "added" if add else "removed"
+    logger.debug(
+        "{} {} {} static routes under {}{} in {}s".format(
+            optyped, count, iptype.lower(), super_prefix, vrfdbg, delta
+        )
+    )

--- a/tests/topotests/mgmt_fe_client/test_client.py
+++ b/tests/topotests/mgmt_fe_client/test_client.py
@@ -14,7 +14,11 @@ import pytest
 from lib.topogen import Topogen
 from oper import check_kernel_32
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_fe_client/test_client.py
+++ b/tests/topotests/mgmt_fe_client/test_client.py
@@ -14,7 +14,7 @@ import pytest
 from lib.topogen import Topogen
 from oper import check_kernel_32
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_notif/oper.py
+++ b/tests/topotests/mgmt_notif/oper.py
@@ -1,1 +1,264 @@
-../mgmt_oper/oper.py
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: ISC
+#
+# October 29 2023, Christian Hopps <chopps@labn.net>
+#
+# Copyright (c) 2023, LabN Consulting, L.L.C.
+#
+
+import datetime
+import ipaddress
+import json
+import logging
+import math
+import os
+import pprint
+import re
+
+from lib.common_config import retry, step
+from lib.topolog import logger
+from lib.topotest import json_cmp as tt_json_cmp
+
+try:
+    from deepdiff import DeepDiff as dd_json_cmp
+except ImportError:
+    dd_json_cmp = None
+
+
+def json_cmp(got, expect, exact_match):
+    if dd_json_cmp:
+        if exact_match:
+            deep_diff = dd_json_cmp(expect, got)
+            # Convert DeepDiff completely into dicts or lists at all levels
+            json_diff = json.loads(deep_diff.to_json())
+        else:
+            json_diff = dd_json_cmp(expect, got, ignore_order=True)
+            # Convert DeepDiff completely into dicts or lists at all levels
+            # json_diff = json.loads(deep_diff.to_json())
+            # Remove new fields in json object from diff
+            if json_diff.get("dictionary_item_added") is not None:
+                del json_diff["dictionary_item_added"]
+            # Remove new json objects in json array from diff
+            if (new_items := json_diff.get("iterable_item_added")) is not None:
+                new_item_paths = list(new_items.keys())
+                for path in new_item_paths:
+                    if type(new_items[path]) is dict:
+                        del new_items[path]
+                if len(new_items) == 0:
+                    del json_diff["iterable_item_added"]
+        if not json_diff:
+            json_diff = None
+    else:
+        json_diff = tt_json_cmp(got, expect, exact_match)
+        json_diff = str(json_diff)
+    return json_diff
+
+
+def enable_debug(router):
+    router.vtysh_cmd("debug northbound callbacks configuration")
+
+
+def disable_debug(router):
+    router.vtysh_cmd("no debug northbound callbacks configuration")
+
+
+@retry(retry_timeout=30, initial_wait=1)
+def _do_oper_test(tgen, qr):
+    r1 = tgen.gears["r1"].net
+
+    qcmd = (
+        r"vtysh -c 'show mgmt get-data {} {}' "
+        r"""| sed -e 's/"phy-address": ".*"/"phy-address": "rubout"/'"""
+        r"""| sed -e 's/"uptime": ".*"/"uptime": "rubout"/'"""
+        r"""| sed -e 's/"vrf": "[0-9]*"/"vrf": "rubout"/'"""
+        r"""| sed -e 's/"if-index": [0-9][0-9]*/"if-index": "rubout"/'"""
+        r"""| sed -e 's/"id": [0-9][0-9]*/"id": "rubout"/'"""
+    )
+    # Don't use this for now.
+    dd_json_cmp = None
+
+    expected = open(qr[1], encoding="ascii").read()
+    output = r1.cmd_nostatus(qcmd.format(qr[0], qr[2] if len(qr) > 2 else ""))
+
+    try:
+        ojson = json.loads(output)
+    except json.decoder.JSONDecodeError as error:
+        logging.error("Error decoding json: %s\noutput:\n%s", error, output)
+        raise
+
+    try:
+        ejson = json.loads(expected)
+    except json.decoder.JSONDecodeError as error:
+        logging.error(
+            "Error decoding json exp result: %s\noutput:\n%s", error, expected
+        )
+        raise
+
+    if dd_json_cmp:
+        cmpout = json_cmp(ojson, ejson, exact_match=True)
+        if cmpout:
+            logging.warning(
+                "-------DIFF---------\n%s\n---------DIFF----------",
+                pprint.pformat(cmpout),
+            )
+    else:
+        cmpout = tt_json_cmp(ojson, ejson, exact=True)
+        if cmpout:
+            logging.warning(
+                "-------EXPECT--------\n%s\n------END-EXPECT------",
+                json.dumps(ejson, indent=4),
+            )
+            logging.warning(
+                "--------GOT----------\n%s\n-------END-GOT--------",
+                json.dumps(ojson, indent=4),
+            )
+
+    assert cmpout is None
+
+
+def do_oper_test(tgen, query_results):
+    reset = True
+    for qr in query_results:
+        step(f"Perform query '{qr[0]}'", reset=reset)
+        if reset:
+            reset = False
+        _do_oper_test(tgen, qr)
+
+
+def get_ip_networks(super_prefix, count):
+    count_log2 = math.log(count, 2)
+    if count_log2 != int(count_log2):
+        count_log2 = int(count_log2) + 1
+    else:
+        count_log2 = int(count_log2)
+    network = ipaddress.ip_network(super_prefix)
+    return tuple(network.subnets(count_log2))[0:count]
+
+
+@retry(retry_timeout=30, initial_wait=0.1)
+def check_kernel(r1, super_prefix, count, add, is_blackhole, vrf, matchvia):
+    network = ipaddress.ip_network(super_prefix)
+    vrfstr = f" vrf {vrf}" if vrf else ""
+    if network.version == 6:
+        kernel = r1.cmd_raises(f"ip -6 route show{vrfstr}")
+    else:
+        kernel = r1.cmd_raises(f"ip -4 route show{vrfstr}")
+
+    # logger.debug("checking kernel routing table%s:\n%s", vrfstr, kernel)
+
+    for _, net in enumerate(get_ip_networks(super_prefix, count)):
+        if not add:
+            assert str(net) not in kernel
+            continue
+
+        if is_blackhole:
+            route = f"blackhole {str(net)} proto (static|196) metric 20"
+        else:
+            route = (
+                f"{str(net)}(?: nhid [0-9]+)? {matchvia} "
+                "proto (static|196) metric 20"
+            )
+        assert re.search(route, kernel), f"Failed to find \n'{route}'\n in \n'{kernel}'"
+
+
+def addrgen(a, count, step=1):
+    for _ in range(0, count, step):
+        yield a
+        a += step
+
+
+@retry(retry_timeout=30, initial_wait=0.1)
+def check_kernel_32(r1, start_addr, count, vrf, step=1):
+    start = ipaddress.ip_address(start_addr)
+    vrfstr = f" vrf {vrf}" if vrf else ""
+    if start.version == 6:
+        kernel = r1.cmd_raises(f"ip -6 route show{vrfstr}")
+    else:
+        kernel = r1.cmd_raises(f"ip -4 route show{vrfstr}")
+
+    nentries = len(re.findall("\n", kernel))
+    logging.info("checking kernel routing table%s: (%s entries)", vrfstr, nentries)
+
+    for addr in addrgen(start, count, step):
+        assert str(addr) in kernel, f"Failed to find '{addr}' in {nentries} entries"
+
+
+def do_config(
+    r1,
+    count,
+    add=True,
+    do_ipv6=False,
+    via=None,
+    vrf=None,
+    use_cli=False,
+):
+    optype = "adding" if add else "removing"
+    iptype = "IPv6" if do_ipv6 else "IPv4"
+
+    #
+    # Set the route details
+    #
+
+    if vrf:
+        super_prefix = "2111::/48" if do_ipv6 else "111.0.0.0/8"
+    else:
+        super_prefix = "2055::/48" if do_ipv6 else "55.0.0.0/8"
+
+    matchvia = ""
+    if via == "blackhole":
+        pass
+    elif via:
+        matchvia = f"dev {via}"
+    else:
+        if vrf:
+            via = "2102::2" if do_ipv6 else "3.3.3.2"
+            matchvia = f"via {via} dev r1-eth1"
+        else:
+            via = "2101::2" if do_ipv6 else "1.1.1.2"
+            matchvia = f"via {via} dev r1-eth0"
+
+    vrfdbg = " in vrf {}".format(vrf) if vrf else ""
+    logger.debug("{} {} static {} routes{}".format(optype, count, iptype, vrfdbg))
+
+    #
+    # Generate config file in a retrievable place
+    #
+
+    config_file = os.path.join(
+        r1.logdir, r1.name, "{}-routes-{}.conf".format(iptype.lower(), optype)
+    )
+    with open(config_file, "w") as f:
+        if use_cli:
+            f.write("configure terminal\n")
+        if vrf:
+            f.write("vrf {}\n".format(vrf))
+
+        for _, net in enumerate(get_ip_networks(super_prefix, count)):
+            if add:
+                f.write("ip route {} {}\n".format(net, via))
+            else:
+                f.write("no ip route {} {}\n".format(net, via))
+
+    #
+    # Load config file.
+    #
+
+    if use_cli:
+        load_command = 'vtysh < "{}"'.format(config_file)
+    else:
+        load_command = 'vtysh -f "{}"'.format(config_file)
+    tstamp = datetime.datetime.now()
+    output = r1.cmd_raises(load_command)
+    delta = (datetime.datetime.now() - tstamp).total_seconds()
+
+    #
+    # Verify the results are in the kernel
+    #
+    check_kernel(r1, super_prefix, count, add, via == "blackhole", vrf, matchvia)
+
+    optyped = "added" if add else "removed"
+    logger.debug(
+        "{} {} {} static routes under {}{} in {}s".format(
+            optyped, count, iptype.lower(), super_prefix, vrfdbg, delta
+        )
+    )

--- a/tests/topotests/mgmt_notif/test_notif.py
+++ b/tests/topotests/mgmt_notif/test_notif.py
@@ -17,7 +17,12 @@ from lib.topogen import Topogen
 from lib.topotest import json_cmp
 from oper import check_kernel_32
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ripd, pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ripd,
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/topotests/mgmt_notif/test_notif.py
+++ b/tests/topotests/mgmt_notif/test_notif.py
@@ -17,7 +17,7 @@ from lib.topogen import Topogen
 from lib.topotest import json_cmp
 from oper import check_kernel_32
 
-pytestmark = [pytest.mark.ripd, pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ripd, pytest.mark.staticd, pytest.mark.mgmtd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/topotests/mgmt_oper/test_oper.py
+++ b/tests/topotests/mgmt_oper/test_oper.py
@@ -17,7 +17,11 @@ import pytest
 from lib.topogen import Topogen
 from oper import check_kernel_32, do_oper_test
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_oper/test_oper.py
+++ b/tests/topotests/mgmt_oper/test_oper.py
@@ -17,7 +17,7 @@ import pytest
 from lib.topogen import Topogen
 from oper import check_kernel_32, do_oper_test
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_oper/test_querying.py
+++ b/tests/topotests/mgmt_oper/test_querying.py
@@ -19,7 +19,11 @@ from lib.common_config import step
 from lib.topogen import Topogen
 from oper import check_kernel_32
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_oper/test_querying.py
+++ b/tests/topotests/mgmt_oper/test_querying.py
@@ -19,7 +19,7 @@ from lib.common_config import step
 from lib.topogen import Topogen
 from oper import check_kernel_32
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_oper/test_scale.py
+++ b/tests/topotests/mgmt_oper/test_scale.py
@@ -19,7 +19,7 @@ from lib.common_config import step
 from lib.topogen import Topogen, TopoRouter
 from oper import check_kernel_32
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_oper/test_scale.py
+++ b/tests/topotests/mgmt_oper/test_scale.py
@@ -19,7 +19,11 @@ from lib.common_config import step
 from lib.topogen import Topogen, TopoRouter
 from oper import check_kernel_32
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_oper/test_simple.py
+++ b/tests/topotests/mgmt_oper/test_simple.py
@@ -15,7 +15,11 @@ import pytest
 from lib.topogen import Topogen
 from oper import check_kernel_32, do_oper_test
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_oper/test_simple.py
+++ b/tests/topotests/mgmt_oper/test_simple.py
@@ -15,7 +15,7 @@ import pytest
 from lib.topogen import Topogen
 from oper import check_kernel_32, do_oper_test
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_rpc/test_rpc.py
+++ b/tests/topotests/mgmt_rpc/test_rpc.py
@@ -17,7 +17,11 @@ import pytest
 from lib.topogen import Topogen
 from lib.topotest import json_cmp
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ripd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ripd,
+    pytest.mark.mgmtd,
+]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/topotests/mgmt_rpc/test_rpc.py
+++ b/tests/topotests/mgmt_rpc/test_rpc.py
@@ -17,7 +17,7 @@ import pytest
 from lib.topogen import Topogen
 from lib.topotest import json_cmp
 
-pytestmark = [pytest.mark.ripd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ripd, pytest.mark.mgmtd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/topotests/mgmt_startup/test_bigconf.py
+++ b/tests/topotests/mgmt_startup/test_bigconf.py
@@ -21,7 +21,11 @@ from util import check_kernel, check_vtysh_up, write_big_route_conf
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 
 track = Timeout(0)

--- a/tests/topotests/mgmt_startup/test_bigconf.py
+++ b/tests/topotests/mgmt_startup/test_bigconf.py
@@ -21,7 +21,7 @@ from util import check_kernel, check_vtysh_up, write_big_route_conf
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
 
 
 track = Timeout(0)

--- a/tests/topotests/mgmt_startup/test_cfgfile_var.py
+++ b/tests/topotests/mgmt_startup/test_cfgfile_var.py
@@ -31,7 +31,7 @@ from lib.common_config import step
 from lib.topogen import Topogen, TopoRouter
 from util import check_kernel
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_startup/test_cfgfile_var.py
+++ b/tests/topotests/mgmt_startup/test_cfgfile_var.py
@@ -31,7 +31,11 @@ from lib.common_config import step
 from lib.topogen import Topogen, TopoRouter
 from util import check_kernel
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_startup/test_late_bigconf.py
+++ b/tests/topotests/mgmt_startup/test_late_bigconf.py
@@ -22,7 +22,11 @@ from util import check_kernel, check_vtysh_up, write_big_route_conf
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 track = Timeout(0)
 ROUTE_COUNT = 2500

--- a/tests/topotests/mgmt_startup/test_late_bigconf.py
+++ b/tests/topotests/mgmt_startup/test_late_bigconf.py
@@ -22,7 +22,7 @@ from util import check_kernel, check_vtysh_up, write_big_route_conf
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
 
 track = Timeout(0)
 ROUTE_COUNT = 2500

--- a/tests/topotests/mgmt_startup/test_late_uniconf.py
+++ b/tests/topotests/mgmt_startup/test_late_uniconf.py
@@ -14,7 +14,7 @@ import pytest
 from lib.topogen import Topogen
 from util import _test_staticd_late_start
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_startup/test_late_uniconf.py
+++ b/tests/topotests/mgmt_startup/test_late_uniconf.py
@@ -14,7 +14,11 @@ import pytest
 from lib.topogen import Topogen
 from util import _test_staticd_late_start
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_startup/test_latestart.py
+++ b/tests/topotests/mgmt_startup/test_latestart.py
@@ -14,7 +14,7 @@ import pytest
 from lib.topogen import Topogen, TopoRouter
 from util import _test_staticd_late_start
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_startup/test_latestart.py
+++ b/tests/topotests/mgmt_startup/test_latestart.py
@@ -14,7 +14,11 @@ import pytest
 from lib.topogen import Topogen, TopoRouter
 from util import _test_staticd_late_start
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/mgmt_tests/test_yang_mgmt.py
+++ b/tests/topotests/mgmt_tests/test_yang_mgmt.py
@@ -68,7 +68,7 @@ from lib.common_config import (
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd, pytest.mark.mgmtd]
 
 # Global variables
 ADDR_TYPES = check_address_types()

--- a/tests/topotests/mgmt_tests/test_yang_mgmt.py
+++ b/tests/topotests/mgmt_tests/test_yang_mgmt.py
@@ -68,7 +68,12 @@ from lib.common_config import (
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 # Global variables
 ADDR_TYPES = check_address_types()

--- a/tests/topotests/msdp_mesh_topo1/test_msdp_mesh_topo1.py
+++ b/tests/topotests/msdp_mesh_topo1/test_msdp_mesh_topo1.py
@@ -32,7 +32,12 @@ from lib.topolog import logger
 
 from lib.pim import McastTesterHelper
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.pimd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+    pytest.mark.pimd,
+]
 
 app_helper = McastTesterHelper()
 

--- a/tests/topotests/msdp_mesh_topo1/test_msdp_mesh_topo1.py
+++ b/tests/topotests/msdp_mesh_topo1/test_msdp_mesh_topo1.py
@@ -32,7 +32,7 @@ from lib.topolog import logger
 
 from lib.pim import McastTesterHelper
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.pimd]
 
 app_helper = McastTesterHelper()
 

--- a/tests/topotests/msdp_topo1/test_msdp_topo1.py
+++ b/tests/topotests/msdp_topo1/test_msdp_topo1.py
@@ -33,7 +33,11 @@ from lib.topolog import logger
 
 from lib.pim import McastTesterHelper
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.pimd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.pimd,
+]
 
 app_helper = McastTesterHelper()
 

--- a/tests/topotests/msdp_topo1/test_msdp_topo1.py
+++ b/tests/topotests/msdp_topo1/test_msdp_topo1.py
@@ -33,7 +33,7 @@ from lib.topolog import logger
 
 from lib.pim import McastTesterHelper
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.pimd]
 
 app_helper = McastTesterHelper()
 

--- a/tests/topotests/msdp_topo2/test_msdp_topo2.py
+++ b/tests/topotests/msdp_topo2/test_msdp_topo2.py
@@ -45,7 +45,7 @@ from lib.topolog import logger
 
 from lib.pim import McastTesterHelper
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.pimd]
 
 app_helper = McastTesterHelper()
 

--- a/tests/topotests/msdp_topo2/test_msdp_topo2.py
+++ b/tests/topotests/msdp_topo2/test_msdp_topo2.py
@@ -45,11 +45,16 @@ from lib.topolog import logger
 
 from lib.pim import McastTesterHelper
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.pimd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.pimd,
+]
 
 app_helper = McastTesterHelper()
 
 MCAST_ADDR = "229.1.2.3"
+
 
 def build_topo(tgen):
     "Build function"
@@ -334,10 +339,8 @@ def test_mroute():
                 },
             },
         },
-        "r3": {
-        },
-        "r4": {
-        },
+        "r3": {},
+        "r4": {},
         "r5": {
             MCAST_ADDR: {
                 "192.168.6.100": {

--- a/tests/topotests/multicast_mld_join_topo1/test_multicast_mld_local_join.py
+++ b/tests/topotests/multicast_mld_join_topo1/test_multicast_mld_local_join.py
@@ -59,7 +59,7 @@ r3_r4_links = []
 r4_r2_links = []
 r4_r3_links = []
 
-pytestmark = [pytest.mark.pim6d, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pim6d, pytest.mark.staticd]
 
 TOPOLOGY = """
                +-------------------+

--- a/tests/topotests/multicast_mld_join_topo1/test_multicast_mld_local_join.py
+++ b/tests/topotests/multicast_mld_join_topo1/test_multicast_mld_local_join.py
@@ -59,7 +59,11 @@ r3_r4_links = []
 r4_r2_links = []
 r4_r3_links = []
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pim6d, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.pim6d,
+    pytest.mark.staticd,
+]
 
 TOPOLOGY = """
                +-------------------+

--- a/tests/topotests/multicast_pim6_sm_topo1/test_multicast_pim6_sm1.py
+++ b/tests/topotests/multicast_pim6_sm_topo1/test_multicast_pim6_sm1.py
@@ -102,7 +102,7 @@ HOLD_TIMER = 3
 PREFERRED_NEXT_HOP = "link_local"
 ASSERT_MSG = "Testcase {} : Failed Error: {}"
 
-pytestmark = [pytest.mark.pim6d]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pim6d]
 
 
 def setup_module(mod):

--- a/tests/topotests/multicast_pim6_sm_topo1/test_multicast_pim6_sm2.py
+++ b/tests/topotests/multicast_pim6_sm_topo1/test_multicast_pim6_sm2.py
@@ -84,7 +84,7 @@ HOLD_TIMER = 3
 PREFERRED_NEXT_HOP = "link_local"
 ASSERT_MSG = "Testcase {} : Failed Error: {}"
 
-pytestmark = [pytest.mark.pim6d]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pim6d]
 
 
 @pytest.fixture(scope="function")

--- a/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp1.py
+++ b/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp1.py
@@ -83,7 +83,7 @@ STAR = "*"
 SOURCE = "Static"
 ASSERT_MSG = "Testcase {} : Failed Error: {}"
 
-pytestmark = [pytest.mark.pim6d]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pim6d]
 
 
 def build_topo(tgen):

--- a/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp2.py
+++ b/tests/topotests/multicast_pim6_static_rp_topo1/test_multicast_pim6_static_rp2.py
@@ -84,7 +84,7 @@ STAR = "*"
 SOURCE = "Static"
 ASSERT_MSG = "Testcase {} : Failed Error: {}"
 
-pytestmark = [pytest.mark.pim6d]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pim6d]
 
 
 def build_topo(tgen):

--- a/tests/topotests/multicast_pim_bsm_topo1/test_mcast_pim_bsmp_01.py
+++ b/tests/topotests/multicast_pim_bsm_topo1/test_mcast_pim_bsmp_01.py
@@ -99,7 +99,11 @@ from lib.topolog import logger
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.pimd,
+    pytest.mark.staticd,
+]
 
 TOPOLOGY = """
 

--- a/tests/topotests/multicast_pim_bsm_topo1/test_mcast_pim_bsmp_01.py
+++ b/tests/topotests/multicast_pim_bsm_topo1/test_mcast_pim_bsmp_01.py
@@ -99,7 +99,7 @@ from lib.topolog import logger
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.pimd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd, pytest.mark.staticd]
 
 TOPOLOGY = """
 

--- a/tests/topotests/multicast_pim_bsm_topo2/test_mcast_pim_bsmp_02.py
+++ b/tests/topotests/multicast_pim_bsm_topo2/test_mcast_pim_bsmp_02.py
@@ -78,7 +78,7 @@ from lib.pim import (
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.pimd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd, pytest.mark.staticd]
 
 
 TOPOLOGY = """

--- a/tests/topotests/multicast_pim_bsm_topo2/test_mcast_pim_bsmp_02.py
+++ b/tests/topotests/multicast_pim_bsm_topo2/test_mcast_pim_bsmp_02.py
@@ -78,7 +78,11 @@ from lib.pim import (
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.pimd,
+    pytest.mark.staticd,
+]
 
 
 TOPOLOGY = """

--- a/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_ospf_topo2.py
+++ b/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_ospf_topo2.py
@@ -61,7 +61,7 @@ from lib.topojson import build_config_from_json
 HELLO_TIMER = 1
 HOLD_TIMER = 3
 
-pytestmark = [pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd]
 
 TOPOLOGY = """
 

--- a/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_static_routes_topo1.py
+++ b/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_static_routes_topo1.py
@@ -68,7 +68,7 @@ from lib.topojson import build_config_from_json
 HELLO_TIMER = 1
 HOLD_TIMER = 3
 
-pytestmark = [pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd]
 
 TOPOLOGY = """
 

--- a/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_transit_router_topo3.py
+++ b/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_transit_router_topo3.py
@@ -66,7 +66,7 @@ from lib.topojson import build_config_from_json
 HELLO_TIMER = 1
 HOLD_TIMER = 3
 
-pytestmark = [pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd]
 
 TOPOLOGY = """
 

--- a/tests/topotests/multicast_pim_sm_topo1/test_multicast_pim_sm_topo1.py
+++ b/tests/topotests/multicast_pim_sm_topo1/test_multicast_pim_sm_topo1.py
@@ -42,7 +42,7 @@ import time
 from time import sleep
 import pytest
 
-pytestmark = [pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/multicast_pim_sm_topo2/test_multicast_pim_sm_topo2.py
+++ b/tests/topotests/multicast_pim_sm_topo2/test_multicast_pim_sm_topo2.py
@@ -37,7 +37,7 @@ import sys
 import time
 import pytest
 
-pytestmark = [pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
+++ b/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
@@ -45,7 +45,7 @@ from time import sleep
 import json
 import functools
 
-pytestmark = [pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
+++ b/tests/topotests/multicast_pim_sm_topo3/test_multicast_pim_sm_topo3.py
@@ -263,14 +263,11 @@ def verify_state_incremented(state_before, state_after):
         for intf, v2 in v1.items():
             for state, value in v2.items():
                 if value >= state_after[ttype][intf][state]:
-                    errormsg = (
-                        "[DUT: %s]: state %s value has not incremented, Initial value: %s, Current value: %s [FAILED!!]"
-                        % (
-                            intf,
-                            state,
-                            value,
-                            state_after[ttype][intf][state],
-                        )
+                    errormsg = "[DUT: %s]: state %s value has not incremented, Initial value: %s, Current value: %s [FAILED!!]" % (
+                        intf,
+                        state,
+                        value,
+                        state_after[ttype][intf][state],
                     )
                     return errormsg
 

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp.py
@@ -128,7 +128,7 @@ from lib.pim import (
     McastTesterHelper,
 )
 
-pytestmark = [pytest.mark.pimd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp.py
@@ -128,7 +128,11 @@ from lib.pim import (
     McastTesterHelper,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.pimd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp1.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp1.py
@@ -129,7 +129,7 @@ from lib.pim import (
     McastTesterHelper,
 )
 
-pytestmark = [pytest.mark.pimd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp1.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp1.py
@@ -129,7 +129,11 @@ from lib.pim import (
     McastTesterHelper,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.pimd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp2.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp2.py
@@ -129,7 +129,7 @@ from lib.pim import (
     McastTesterHelper,
 )
 
-pytestmark = [pytest.mark.pimd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp2.py
+++ b/tests/topotests/multicast_pim_static_rp_topo1/test_multicast_pim_static_rp2.py
@@ -129,7 +129,11 @@ from lib.pim import (
     McastTesterHelper,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.pimd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/multicast_pim_uplink_topo1/test_multicast_pim_uplink_topo1.py
+++ b/tests/topotests/multicast_pim_uplink_topo1/test_multicast_pim_uplink_topo1.py
@@ -108,7 +108,7 @@ r4_r3_links = []
 HELLO_TIMER = 1
 HOLD_TIMER = 3
 
-pytestmark = [pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd]
 
 
 def setup_module(mod):

--- a/tests/topotests/multicast_pim_uplink_topo2/test_multicast_pim_uplink_topo2.py
+++ b/tests/topotests/multicast_pim_uplink_topo2/test_multicast_pim_uplink_topo2.py
@@ -89,7 +89,7 @@ r2_r4_links = []
 r4_r2_links = []
 r4_r3_links = []
 
-pytestmark = [pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd]
 
 
 def setup_module(mod):

--- a/tests/topotests/multicast_pim_uplink_topo3/test_multicast_pim_uplink_topo3.py
+++ b/tests/topotests/multicast_pim_uplink_topo3/test_multicast_pim_uplink_topo3.py
@@ -138,7 +138,7 @@ r3_r4_links = []
 r4_r2_links = []
 r4_r3_links = []
 
-pytestmark = [pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd]
 
 
 def setup_module(mod):

--- a/tests/topotests/nb_config/test_nb_config.py
+++ b/tests/topotests/nb_config/test_nb_config.py
@@ -15,7 +15,7 @@ import pytest
 from lib.topogen import Topogen
 from lib.topotest import json_cmp
 
-pytestmark = [pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.mgmtd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/topotests/nhrp_redundancy/test_nhrp_redundancy.py
+++ b/tests/topotests/nhrp_redundancy/test_nhrp_redundancy.py
@@ -69,7 +69,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.nhrpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.nhrpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/nhrp_topo/test_nhrp_topo.py
+++ b/tests/topotests/nhrp_topo/test_nhrp_topo.py
@@ -228,8 +228,8 @@ def test_nhrp_connection():
     def relink_session():
         for r in ["r1", "r2"]:
             tgen.gears[r].vtysh_cmd("clear ip nhrp cache")
-            tgen.net[r].cmd("ip l del {}-gre0".format(r));
-        _populate_iface();
+            tgen.net[r].cmd("ip l del {}-gre0".format(r))
+        _populate_iface()
 
     @retry(retry_timeout=40, initial_wait=5)
     def verify_same_password():
@@ -255,23 +255,28 @@ def test_nhrp_connection():
 
     ### Passwords are different
     logger.info("Modify password and send ping again, should drop")
-    hubrouter.vtysh_cmd("""
+    hubrouter.vtysh_cmd(
+        """
         configure
             interface r2-gre0
                 ip nhrp authentication secret12
-    """)
+    """
+    )
     relink_session()
     verify_mismatched_password()
-    
+
     ### Passwords are the same - again
     logger.info("Recover password and verify conectivity is back")
-    hubrouter.vtysh_cmd("""
+    hubrouter.vtysh_cmd(
+        """
         configure
             interface r2-gre0
                 ip nhrp authentication secret
-    """)
+    """
+    )
     relink_session()
     verify_same_password()
+
 
 def test_route_install():
     "Test use of NHRP routes by other protocols (sharpd here)."

--- a/tests/topotests/nhrp_topo/test_nhrp_topo.py
+++ b/tests/topotests/nhrp_topo/test_nhrp_topo.py
@@ -32,7 +32,7 @@ from lib.common_config import required_linux_kernel_version, retry
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.nhrpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.nhrpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf6_ecmp_inter_area/test_ospf6_ecmp_inter_area.py
+++ b/tests/topotests/ospf6_ecmp_inter_area/test_ospf6_ecmp_inter_area.py
@@ -66,7 +66,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospf6d]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospf6d]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf6_gr_topo1/test_ospf6_gr_topo1.py
+++ b/tests/topotests/ospf6_gr_topo1/test_ospf6_gr_topo1.py
@@ -69,7 +69,7 @@ from lib.common_config import (
     start_router_daemons,
 )
 
-pytestmark = [pytest.mark.ospf6d]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospf6d]
 
 # Global multi-dimensional dictionary containing all expected outputs
 outputs = {}

--- a/tests/topotests/ospf6_point_to_multipoint/test_ospf6_point_to_multipoint.py
+++ b/tests/topotests/ospf6_point_to_multipoint/test_ospf6_point_to_multipoint.py
@@ -76,7 +76,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf6_topo1/test_ospf6_topo1.py
+++ b/tests/topotests/ospf6_topo1/test_ospf6_topo1.py
@@ -76,7 +76,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf6_topo1_vrf/test_ospf6_topo1_vrf.py
+++ b/tests/topotests/ospf6_topo1_vrf/test_ospf6_topo1_vrf.py
@@ -79,7 +79,7 @@ from lib.topotest import iproute2_is_vrf_capable
 from lib.common_config import required_linux_kernel_version
 
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf6_topo2/test_ospf6_topo2.py
+++ b/tests/topotests/ospf6_topo2/test_ospf6_topo2.py
@@ -30,7 +30,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospf6d]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospf6d]
 
 
 def expect_lsas(router, area, lsas, wait=5, extra_params=""):

--- a/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_topo1.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_topo1.py
@@ -54,7 +54,7 @@ from lib.ospf import (
     verify_ospf_summary,
 )
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_topo1.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_topo1.py
@@ -54,7 +54,11 @@ from lib.ospf import (
     verify_ospf_summary,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_type7_lsa.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_type7_lsa.py
@@ -43,7 +43,7 @@ from lib.ospf import (
     verify_ospf_summary,
 )
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_type7_lsa.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_asbr_summary_type7_lsa.py
@@ -43,7 +43,11 @@ from lib.ospf import (
     verify_ospf_summary,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_authentication.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_authentication.py
@@ -40,7 +40,7 @@ from lib.topojson import build_config_from_json
 from lib.ospf import verify_ospf_neighbor, config_ospf_interface, clear_ospf
 from ipaddress import IPv4Address
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_chaos.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_chaos.py
@@ -43,7 +43,7 @@ from lib.ospf import verify_ospf_neighbor, verify_ospf_rib, create_router_ospf
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 # Global variables
 topo = None

--- a/tests/topotests/ospf_basic_functionality/test_ospf_chaos.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_chaos.py
@@ -43,7 +43,11 @@ from lib.ospf import verify_ospf_neighbor, verify_ospf_rib, create_router_ospf
 from lib.topolog import logger
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 topo = None

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
@@ -45,7 +45,11 @@ from lib.ospf import (
     redistribute_ospf,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 
 topo = None

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp.py
@@ -45,7 +45,7 @@ from lib.ospf import (
     redistribute_ospf,
 )
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 
 topo = None

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp_lan.py
@@ -43,7 +43,11 @@ from lib.ospf import (
     redistribute_ospf,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_ecmp_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_ecmp_lan.py
@@ -43,7 +43,7 @@ from lib.ospf import (
     redistribute_ospf,
 )
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_flood_reduction.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_flood_reduction.py
@@ -33,7 +33,7 @@ CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
 sys.path.append(os.path.join(CWD, "../lib/"))
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 # Global variables
 topo = None
 

--- a/tests/topotests/ospf_basic_functionality/test_ospf_flood_reduction.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_flood_reduction.py
@@ -33,7 +33,11 @@ CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
 sys.path.append(os.path.join(CWD, "../lib/"))
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 # Global variables
 topo = None
 

--- a/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
@@ -47,7 +47,7 @@ from lib.ospf import (
 )
 from ipaddress import IPv4Address
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_lan.py
@@ -47,7 +47,11 @@ from lib.ospf import (
 )
 from ipaddress import IPv4Address
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
@@ -40,7 +40,11 @@ sys.path.append(os.path.join(CWD, "../lib/"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_nssa.py
@@ -40,7 +40,7 @@ sys.path.append(os.path.join(CWD, "../lib/"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_p2mp.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_p2mp.py
@@ -45,7 +45,7 @@ from lib.ospf import (
 )
 
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 # Global variables
 topo = None

--- a/tests/topotests/ospf_basic_functionality/test_ospf_p2mp.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_p2mp.py
@@ -45,7 +45,11 @@ from lib.ospf import (
 )
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 topo = None

--- a/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
@@ -45,7 +45,11 @@ from lib.ospf import (
     redistribute_ospf,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_routemaps.py
@@ -45,7 +45,7 @@ from lib.ospf import (
     redistribute_ospf,
 )
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
@@ -49,7 +49,7 @@ from lib.ospf import (
     verify_ospf_interface,
 )
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_rte_calc.py
@@ -49,7 +49,12 @@ from lib.ospf import (
     verify_ospf_interface,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/ospf_basic_functionality/test_ospf_single_area.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_single_area.py
@@ -47,7 +47,7 @@ from lib.ospf import (
     verify_ospf_interface,
 )
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 # Global variables
 topo = None
 

--- a/tests/topotests/ospf_basic_functionality/test_ospf_single_area.py
+++ b/tests/topotests/ospf_basic_functionality/test_ospf_single_area.py
@@ -47,7 +47,11 @@ from lib.ospf import (
     verify_ospf_interface,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 # Global variables
 topo = None
 

--- a/tests/topotests/ospf_dual_stack/test_ospf_dual_stack.py
+++ b/tests/topotests/ospf_dual_stack/test_ospf_dual_stack.py
@@ -25,7 +25,7 @@ from lib.ospf import (
     verify_ospf6_neighbor,
 )
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospf_dual_stack/test_ospf_dual_stack.py
+++ b/tests/topotests/ospf_dual_stack/test_ospf_dual_stack.py
@@ -25,7 +25,11 @@ from lib.ospf import (
     verify_ospf6_neighbor,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper1.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper1.py
@@ -41,7 +41,7 @@ from lib.ospf import (
     create_router_ospf,
 )
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 # Global variables
 topo = None

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper2.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper2.py
@@ -43,7 +43,7 @@ from lib.ospf import (
     create_router_ospf,
 )
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 # Global variables
 topo = None

--- a/tests/topotests/ospf_gr_helper/test_ospf_gr_helper3.py
+++ b/tests/topotests/ospf_gr_helper/test_ospf_gr_helper3.py
@@ -41,7 +41,7 @@ from lib.ospf import (
     create_router_ospf,
 )
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 # Global variables
 topo = None

--- a/tests/topotests/ospf_gr_topo1/test_ospf_gr_topo1.py
+++ b/tests/topotests/ospf_gr_topo1/test_ospf_gr_topo1.py
@@ -78,7 +78,7 @@ from lib.common_config import (
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 # Global multi-dimensional dictionary containing all expected outputs
 outputs = {}

--- a/tests/topotests/ospf_instance_redistribute/test_ospf_instance_redistribute.py
+++ b/tests/topotests/ospf_instance_redistribute/test_ospf_instance_redistribute.py
@@ -19,7 +19,7 @@ import sys
 import pytest
 import json
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.sharpd]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/ospf_instance_redistribute/test_ospf_instance_redistribute.py
+++ b/tests/topotests/ospf_instance_redistribute/test_ospf_instance_redistribute.py
@@ -19,7 +19,11 @@ import sys
 import pytest
 import json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.sharpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.sharpd,
+]
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/ospf_metric_propagation/test_ospf_metric_propagation.py
+++ b/tests/topotests/ospf_metric_propagation/test_ospf_metric_propagation.py
@@ -54,7 +54,11 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.bgpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.bgpd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_metric_propagation/test_ospf_metric_propagation.py
+++ b/tests/topotests/ospf_metric_propagation/test_ospf_metric_propagation.py
@@ -54,7 +54,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/test_ospf_multi_vrf_bgp_route_leak.py
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/test_ospf_multi_vrf_bgp_route_leak.py
@@ -58,7 +58,11 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.bgpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.bgpd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/test_ospf_multi_vrf_bgp_route_leak.py
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/test_ospf_multi_vrf_bgp_route_leak.py
@@ -58,7 +58,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_netns_vrf/test_ospf_netns_vrf.py
+++ b/tests/topotests/ospf_netns_vrf/test_ospf_netns_vrf.py
@@ -30,7 +30,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_nssa_topo1/test_ospf_nssa_topo1.py
+++ b/tests/topotests/ospf_nssa_topo1/test_ospf_nssa_topo1.py
@@ -56,7 +56,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_p2mp/test_ospf_p2mp_broadcast.py
+++ b/tests/topotests/ospf_p2mp/test_ospf_p2mp_broadcast.py
@@ -55,7 +55,11 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.bgpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.bgpd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_p2mp/test_ospf_p2mp_broadcast.py
+++ b/tests/topotests/ospf_p2mp/test_ospf_p2mp_broadcast.py
@@ -55,7 +55,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_p2mp/test_ospf_p2mp_non_broadcast.py
+++ b/tests/topotests/ospf_p2mp/test_ospf_p2mp_non_broadcast.py
@@ -57,7 +57,11 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.bgpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.bgpd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_p2mp/test_ospf_p2mp_non_broadcast.py
+++ b/tests/topotests/ospf_p2mp/test_ospf_p2mp_non_broadcast.py
@@ -57,7 +57,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_prefix_suppression/test_ospf_prefix_suppression.py
+++ b/tests/topotests/ospf_prefix_suppression/test_ospf_prefix_suppression.py
@@ -57,7 +57,11 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.bgpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.bgpd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_prefix_suppression/test_ospf_prefix_suppression.py
+++ b/tests/topotests/ospf_prefix_suppression/test_ospf_prefix_suppression.py
@@ -57,7 +57,7 @@ sys.path.append(os.path.join(CWD, "../"))
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.bgpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.bgpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_sr_te_topo1/test_ospf_sr_te_topo1.py
+++ b/tests/topotests/ospf_sr_te_topo1/test_ospf_sr_te_topo1.py
@@ -80,7 +80,12 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.pathd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+    pytest.mark.pathd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_sr_te_topo1/test_ospf_sr_te_topo1.py
+++ b/tests/topotests/ospf_sr_te_topo1/test_ospf_sr_te_topo1.py
@@ -80,7 +80,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.pathd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.pathd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_sr_topo1/test_ospf_sr_topo1.py
+++ b/tests/topotests/ospf_sr_topo1/test_ospf_sr_topo1.py
@@ -68,7 +68,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_suppress_fa/test_ospf_suppress_fa.py
+++ b/tests/topotests/ospf_suppress_fa/test_ospf_suppress_fa.py
@@ -38,7 +38,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_te_topo1/test_ospf_te_topo1.py
+++ b/tests/topotests/ospf_te_topo1/test_ospf_te_topo1.py
@@ -63,7 +63,7 @@ from lib.topolog import logger
 # and Finally pytest
 import pytest
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_tilfa_topo1/test_ospf_tilfa_topo1.py
+++ b/tests/topotests/ospf_tilfa_topo1/test_ospf_tilfa_topo1.py
@@ -55,7 +55,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_topo1/test_ospf_topo1.py
+++ b/tests/topotests/ospf_topo1/test_ospf_topo1.py
@@ -32,7 +32,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf_topo2/test_ospf_topo2.py
+++ b/tests/topotests/ospf_topo2/test_ospf_topo2.py
@@ -26,7 +26,8 @@ import time
 from lib.topogen import Topogen
 
 
-pytestmark = [pytest.mark.random_order(disabled=True),
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
     pytest.mark.ospf6d,
     pytest.mark.ospfd,
 ]

--- a/tests/topotests/ospf_topo2/test_ospf_topo2.py
+++ b/tests/topotests/ospf_topo2/test_ospf_topo2.py
@@ -26,7 +26,7 @@ import time
 from lib.topogen import Topogen
 
 
-pytestmark = [
+pytestmark = [pytest.mark.random_order(disabled=True),
     pytest.mark.ospf6d,
     pytest.mark.ospfd,
 ]

--- a/tests/topotests/ospf_unnumbered/test_ospf_unnumbered.py
+++ b/tests/topotests/ospf_unnumbered/test_ospf_unnumbered.py
@@ -31,7 +31,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/ospf_unnumbered_point_to_multipoint/test_ospf_unnumbered_point_to_multipoint.py
+++ b/tests/topotests/ospf_unnumbered_point_to_multipoint/test_ospf_unnumbered_point_to_multipoint.py
@@ -30,7 +30,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 
 CWD = os.path.dirname(os.path.realpath(__file__))

--- a/tests/topotests/ospfapi/test_ospf_clientapi.py
+++ b/tests/topotests/ospfapi/test_ospf_clientapi.py
@@ -36,7 +36,7 @@ from lib.topotest import interface_set_status, json_cmp
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 TESTDIR = os.path.abspath(CWD)

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_asbr_summary_topo1.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_asbr_summary_topo1.py
@@ -52,7 +52,11 @@ from lib.ospf import (
     verify_ospf_summary,
 )
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 topo = None

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_asbr_summary_topo1.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_asbr_summary_topo1.py
@@ -52,7 +52,7 @@ from lib.ospf import (
     verify_ospf_summary,
 )
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 # Global variables
 topo = None

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp.py
@@ -46,7 +46,11 @@ from lib.ospf import (
 )
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp.py
@@ -46,7 +46,7 @@ from lib.ospf import (
 )
 
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp_lan.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp_lan.py
@@ -45,7 +45,7 @@ from lib.ospf import (
 )
 
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp_lan.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp_lan.py
@@ -45,7 +45,11 @@ from lib.ospf import (
 )
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa.py
@@ -23,7 +23,7 @@ sys.path.append(os.path.join(CWD, "../lib/"))
 
 # pylint: disable=C0413
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa2.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa2.py
@@ -44,7 +44,11 @@ from lib.topojson import build_config_from_json
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 topo = None

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa2.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa2.py
@@ -44,7 +44,7 @@ from lib.topojson import build_config_from_json
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 # Global variables
 topo = None

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_routemaps.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_routemaps.py
@@ -46,7 +46,11 @@ from lib.ospf import (
 )
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_routemaps.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_routemaps.py
@@ -46,7 +46,7 @@ from lib.ospf import (
 )
 
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_rte_calc.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_rte_calc.py
@@ -51,7 +51,11 @@ from lib.ospf import (
 )
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_rte_calc.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_rte_calc.py
@@ -51,7 +51,7 @@ from lib.ospf import (
 )
 
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_single_area.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_single_area.py
@@ -51,7 +51,11 @@ from lib.ospf import (
 
 from ipaddress import IPv6Address
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.staticd,
+]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_single_area.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_single_area.py
@@ -51,7 +51,7 @@ from lib.ospf import (
 
 from ipaddress import IPv6Address
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/pbr_topo1/test_pbr_topo1.py
+++ b/tests/topotests/pbr_topo1/test_pbr_topo1.py
@@ -37,7 +37,7 @@ from lib.common_config import shutdown_bringup_interface
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.pbrd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pbrd]
 
 #####################################################
 ##

--- a/tests/topotests/pim_acl/test_pim_acl.py
+++ b/tests/topotests/pim_acl/test_pim_acl.py
@@ -105,7 +105,7 @@ from lib.topolog import logger
 # Required to instantiate the topology builder class.
 from lib.pim import McastTesterHelper
 
-pytestmark = [pytest.mark.pimd, pytest.mark.ospfd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd, pytest.mark.ospfd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/pim_acl/test_pim_acl.py
+++ b/tests/topotests/pim_acl/test_pim_acl.py
@@ -105,7 +105,11 @@ from lib.topolog import logger
 # Required to instantiate the topology builder class.
 from lib.pim import McastTesterHelper
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd, pytest.mark.ospfd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.pimd,
+    pytest.mark.ospfd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/pim_basic/test_pim.py
+++ b/tests/topotests/pim_basic/test_pim.py
@@ -18,7 +18,7 @@ import pytest
 import json
 from functools import partial
 
-pytestmark = [pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.pimd]
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/pim_basic_topo2/test_pim_basic_topo2.py
+++ b/tests/topotests/pim_basic_topo2/test_pim_basic_topo2.py
@@ -30,7 +30,11 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.pimd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bfdd,
+    pytest.mark.pimd,
+]
 
 
 def build_topo(tgen):

--- a/tests/topotests/pim_basic_topo2/test_pim_basic_topo2.py
+++ b/tests/topotests/pim_basic_topo2/test_pim_basic_topo2.py
@@ -30,7 +30,7 @@ from lib.topolog import logger
 
 # Required to instantiate the topology builder class.
 
-pytestmark = [pytest.mark.bfdd, pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bfdd, pytest.mark.pimd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/pim_igmp_vrf/test_pim_vrf.py
+++ b/tests/topotests/pim_igmp_vrf/test_pim_vrf.py
@@ -96,7 +96,11 @@ from lib.common_config import required_linux_kernel_version
 from lib.pim import McastTesterHelper
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.pimd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.ospfd,
+    pytest.mark.pimd,
+]
 
 
 def build_topo(tgen):
@@ -354,6 +358,7 @@ def _test_vrf_pimreg_interfaces():
     assertmsg = "PIM router R1, VRF red (table 12) pimreg12 interface missing or incorrect status"
     assert res is None, assertmsg
 
+
 def test_vrf_pimreg_interfaces():
     tgen = get_topogen()
     r1 = tgen.gears["r1"]
@@ -364,6 +369,7 @@ def test_vrf_pimreg_interfaces():
         output = r1.net.cmd_nostatus("ip -o link")
         logging.error("ip link info after failure: %s", output)
         raise
+
 
 ##################################
 ###  Test PIM / IGMP with VRF

--- a/tests/topotests/pim_igmp_vrf/test_pim_vrf.py
+++ b/tests/topotests/pim_igmp_vrf/test_pim_vrf.py
@@ -96,7 +96,7 @@ from lib.common_config import required_linux_kernel_version
 from lib.pim import McastTesterHelper
 
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.pimd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ospfd, pytest.mark.pimd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/rip_allow_ecmp/test_rip_allow_ecmp.py
+++ b/tests/topotests/rip_allow_ecmp/test_rip_allow_ecmp.py
@@ -23,7 +23,7 @@ from lib import topotest
 from lib.topogen import Topogen, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.ripd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ripd]
 
 
 def setup_module(mod):

--- a/tests/topotests/rip_bfd_topo1/test_rip_bfd_topo1.py
+++ b/tests/topotests/rip_bfd_topo1/test_rip_bfd_topo1.py
@@ -21,7 +21,7 @@ from functools import partial
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter
 
-pytestmark = [
+pytestmark = [pytest.mark.random_order(disabled=True),
     pytest.mark.bfdd,
     pytest.mark.ripd,
 ]

--- a/tests/topotests/rip_bfd_topo1/test_rip_bfd_topo1.py
+++ b/tests/topotests/rip_bfd_topo1/test_rip_bfd_topo1.py
@@ -21,7 +21,8 @@ from functools import partial
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter
 
-pytestmark = [pytest.mark.random_order(disabled=True),
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
     pytest.mark.bfdd,
     pytest.mark.ripd,
 ]

--- a/tests/topotests/rip_passive_interface/test_rip_passive_interface.py
+++ b/tests/topotests/rip_passive_interface/test_rip_passive_interface.py
@@ -24,7 +24,7 @@ from lib import topotest
 from lib.topogen import Topogen, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.ripd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ripd]
 
 
 def setup_module(mod):

--- a/tests/topotests/rip_topo1/test_rip_topo1.py
+++ b/tests/topotests/rip_topo1/test_rip_topo1.py
@@ -28,7 +28,7 @@ from lib.topogen import Topogen, get_topogen
 
 fatal_error = ""
 
-pytestmark = [pytest.mark.ripd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ripd]
 
 #####################################################
 ##

--- a/tests/topotests/ripng_allow_ecmp/test_ripng_allow_ecmp.py
+++ b/tests/topotests/ripng_allow_ecmp/test_ripng_allow_ecmp.py
@@ -23,7 +23,7 @@ from lib import topotest
 from lib.topogen import Topogen, get_topogen
 from lib.common_config import step
 
-pytestmark = [pytest.mark.ripngd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ripngd]
 
 
 def setup_module(mod):

--- a/tests/topotests/ripng_route_map/test_ripng_route_map.py
+++ b/tests/topotests/ripng_route_map/test_ripng_route_map.py
@@ -22,7 +22,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, get_topogen
 
-pytestmark = [pytest.mark.ripngd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ripngd]
 
 
 def setup_module(mod):

--- a/tests/topotests/ripng_topo1/test_ripng_topo1.py
+++ b/tests/topotests/ripng_topo1/test_ripng_topo1.py
@@ -27,7 +27,7 @@ from lib.topogen import Topogen, get_topogen
 
 fatal_error = ""
 
-pytestmark = [pytest.mark.ripd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.ripd]
 
 #####################################################
 ##

--- a/tests/topotests/route_scale/test_route_scale1.py
+++ b/tests/topotests/route_scale/test_route_scale1.py
@@ -34,7 +34,7 @@ from scale_test_common import (
 )
 
 
-pytestmark = [pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.sharpd]
 
 
 def build(tgen):

--- a/tests/topotests/route_scale/test_route_scale2.py
+++ b/tests/topotests/route_scale/test_route_scale2.py
@@ -34,7 +34,7 @@ from scale_test_common import (
 )
 
 
-pytestmark = [pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.sharpd]
 
 
 def build(tgen):

--- a/tests/topotests/simple_snmp_test/test_simple_snmp.py
+++ b/tests/topotests/simple_snmp_test/test_simple_snmp.py
@@ -26,7 +26,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.snmptest import SnmpTester
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.snmp]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.snmp]
 
 
 def setup_module(mod):

--- a/tests/topotests/simple_snmp_test/test_simple_snmp.py
+++ b/tests/topotests/simple_snmp_test/test_simple_snmp.py
@@ -26,7 +26,12 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.snmptest import SnmpTester
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.isisd, pytest.mark.snmp]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.isisd,
+    pytest.mark.snmp,
+]
 
 
 def setup_module(mod):

--- a/tests/topotests/srv6_encap_src_addr/test_srv6_encap_src_addr.py
+++ b/tests/topotests/srv6_encap_src_addr/test_srv6_encap_src_addr.py
@@ -27,7 +27,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.sharpd]
 
 
 def open_json_file(filename):

--- a/tests/topotests/srv6_encap_src_addr/test_srv6_encap_src_addr.py
+++ b/tests/topotests/srv6_encap_src_addr/test_srv6_encap_src_addr.py
@@ -27,7 +27,11 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.sharpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.sharpd,
+]
 
 
 def open_json_file(filename):

--- a/tests/topotests/srv6_locator/test_srv6_locator.py
+++ b/tests/topotests/srv6_locator/test_srv6_locator.py
@@ -28,7 +28,11 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.sharpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.sharpd,
+]
 
 
 def open_json_file(filename):

--- a/tests/topotests/srv6_locator/test_srv6_locator.py
+++ b/tests/topotests/srv6_locator/test_srv6_locator.py
@@ -28,7 +28,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.sharpd]
 
 
 def open_json_file(filename):

--- a/tests/topotests/srv6_locator_custom_bits_length/test_srv6_locator_custom_bits_length.py
+++ b/tests/topotests/srv6_locator_custom_bits_length/test_srv6_locator_custom_bits_length.py
@@ -24,7 +24,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.sharpd]
 
 
 def open_json_file(filename):

--- a/tests/topotests/srv6_locator_custom_bits_length/test_srv6_locator_custom_bits_length.py
+++ b/tests/topotests/srv6_locator_custom_bits_length/test_srv6_locator_custom_bits_length.py
@@ -24,7 +24,11 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.sharpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.sharpd,
+]
 
 
 def open_json_file(filename):

--- a/tests/topotests/srv6_locator_usid/test_srv6_locator_usid.py
+++ b/tests/topotests/srv6_locator_usid/test_srv6_locator_usid.py
@@ -24,7 +24,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.sharpd]
 
 
 def open_json_file(filename):

--- a/tests/topotests/srv6_locator_usid/test_srv6_locator_usid.py
+++ b/tests/topotests/srv6_locator_usid/test_srv6_locator_usid.py
@@ -24,7 +24,11 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.sharpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.sharpd,
+]
 
 
 def open_json_file(filename):

--- a/tests/topotests/srv6_static_route/test_srv6_route.py
+++ b/tests/topotests/srv6_static_route/test_srv6_route.py
@@ -27,7 +27,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.sharpd]
 
 
 def open_json_file(filename):

--- a/tests/topotests/srv6_static_route/test_srv6_route.py
+++ b/tests/topotests/srv6_static_route/test_srv6_route.py
@@ -27,7 +27,11 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.sharpd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.sharpd,
+]
 
 
 def open_json_file(filename):

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo1_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo1_ebgp.py
@@ -50,7 +50,11 @@ from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 ADDR_TYPES = check_address_types()

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo1_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo1_ebgp.py
@@ -50,7 +50,7 @@ from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 ADDR_TYPES = check_address_types()

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo2_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo2_ebgp.py
@@ -58,7 +58,11 @@ from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo2_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo2_ebgp.py
@@ -58,7 +58,7 @@ from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo3_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo3_ebgp.py
@@ -52,7 +52,7 @@ from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo3_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo3_ebgp.py
@@ -52,7 +52,11 @@ from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo4_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo4_ebgp.py
@@ -57,7 +57,7 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/static_routing_with_ebgp/test_static_routes_topo4_ebgp.py
+++ b/tests/topotests/static_routing_with_ebgp/test_static_routes_topo4_ebgp.py
@@ -57,7 +57,11 @@ from lib.bgp import (
 from lib.topojson import build_config_from_json
 
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo1_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo1_ibgp.py
@@ -49,7 +49,7 @@ from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo1_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo1_ibgp.py
@@ -49,7 +49,11 @@ from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo2_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo2_ibgp.py
@@ -58,7 +58,11 @@ from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
 from lib.topojson import build_config_from_json
 from lib.topotest import version_cmp
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo2_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo2_ibgp.py
@@ -58,7 +58,7 @@ from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
 from lib.topojson import build_config_from_json
 from lib.topotest import version_cmp
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo3_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo3_ibgp.py
@@ -51,7 +51,7 @@ from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo3_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo3_ibgp.py
@@ -51,7 +51,11 @@ from lib.topolog import logger
 from lib.bgp import verify_bgp_convergence, create_router_bgp, verify_bgp_rib
 from lib.topojson import build_config_from_json
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 # Global variables
 BGP_CONVERGENCE = False

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo4_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo4_ibgp.py
@@ -61,7 +61,11 @@ ADDR_TYPES = check_address_types()
 NETWORK = {"ipv4": "2.2.2.2/32", "ipv6": "22:22::2/128"}
 NEXT_HOP_IP = {}
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.staticd,
+]
 
 
 def setup_module(mod):

--- a/tests/topotests/static_routing_with_ibgp/test_static_routes_topo4_ibgp.py
+++ b/tests/topotests/static_routing_with_ibgp/test_static_routes_topo4_ibgp.py
@@ -61,7 +61,7 @@ ADDR_TYPES = check_address_types()
 NETWORK = {"ipv4": "2.2.2.2/32", "ipv6": "22:22::2/128"}
 NEXT_HOP_IP = {}
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.staticd]
 
 
 def setup_module(mod):

--- a/tests/topotests/static_simple/test_static_simple.py
+++ b/tests/topotests/static_simple/test_static_simple.py
@@ -20,7 +20,7 @@ from lib.topogen import TopoRouter, Topogen
 from lib.topolog import logger
 from lib.common_config import retry, step
 
-pytestmark = [pytest.mark.staticd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/static_vrf/test_static_vrf.py
+++ b/tests/topotests/static_vrf/test_static_vrf.py
@@ -16,7 +16,11 @@ import pytest
 from lib.topogen import Topogen
 from lib.common_config import retry
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.staticd,
+    pytest.mark.mgmtd,
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/static_vrf/test_static_vrf.py
+++ b/tests/topotests/static_vrf/test_static_vrf.py
@@ -16,7 +16,7 @@ import pytest
 from lib.topogen import Topogen
 from lib.common_config import retry
 
-pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.staticd, pytest.mark.mgmtd]
 
 
 @pytest.fixture(scope="module")

--- a/tests/topotests/tc_basic/test_tc_basic.py
+++ b/tests/topotests/tc_basic/test_tc_basic.py
@@ -22,7 +22,7 @@ sys.path.append(os.path.join(CWD, "../lib/"))
 from lib.topogen import Topogen, TopoRouter
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.sharpd]
 
 
 def build_topo(tgen):

--- a/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
+++ b/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
@@ -20,6 +20,8 @@ import pytest
 import json
 from functools import partial
 
+pytestmark = pytest.mark.random_order(disabled=True)
+
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))

--- a/tests/topotests/zebra_netlink/test_zebra_netlink.py
+++ b/tests/topotests/zebra_netlink/test_zebra_netlink.py
@@ -20,7 +20,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.sharpd]
 
 
 #####################################################

--- a/tests/topotests/zebra_nht_resolution/test_verify_nh_resolution.py
+++ b/tests/topotests/zebra_nht_resolution/test_verify_nh_resolution.py
@@ -29,7 +29,7 @@ from lib.topolog import logger
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
 
-pytestmark = [pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.sharpd]
 
 # GLOBAL VARIABLES
 NH1 = "2.2.2.32"

--- a/tests/topotests/zebra_opaque/test_zebra_opaque.py
+++ b/tests/topotests/zebra_opaque/test_zebra_opaque.py
@@ -22,7 +22,12 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.ospf6d]
+pytestmark = [
+    pytest.mark.random_order(disabled=True),
+    pytest.mark.bgpd,
+    pytest.mark.ospfd,
+    pytest.mark.ospf6d,
+]
 
 
 def setup_module(mod):

--- a/tests/topotests/zebra_opaque/test_zebra_opaque.py
+++ b/tests/topotests/zebra_opaque/test_zebra_opaque.py
@@ -22,7 +22,7 @@ sys.path.append(os.path.join(CWD, "../"))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.ospf6d]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.bgpd, pytest.mark.ospfd, pytest.mark.ospf6d]
 
 
 def setup_module(mod):

--- a/tests/topotests/zebra_rib/test_zebra_rib.py
+++ b/tests/topotests/zebra_rib/test_zebra_rib.py
@@ -32,7 +32,7 @@ from lib.topolog import logger
 from time import sleep
 
 
-pytestmark = [pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.sharpd]
 krel = platform.release()
 
 

--- a/tests/topotests/zebra_seg6_route/test_zebra_seg6_route.py
+++ b/tests/topotests/zebra_seg6_route/test_zebra_seg6_route.py
@@ -26,7 +26,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.sharpd]
 
 
 def open_json_file(filename):

--- a/tests/topotests/zebra_seg6local_route/test_zebra_seg6local_route.py
+++ b/tests/topotests/zebra_seg6local_route/test_zebra_seg6local_route.py
@@ -27,7 +27,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.common_config import required_linux_kernel_version
 
-pytestmark = [pytest.mark.sharpd]
+pytestmark = [pytest.mark.random_order(disabled=True), pytest.mark.sharpd]
 
 
 def open_json_file(filename):


### PR DESCRIPTION
Add the ability to the test suites to run the tests in a random order.  

pip3 install pytest-random-order

sudo -E python3 -m pytest -s -vv -n <number> --dist=loadfile --random-order=package

Consult the pytest-random-order module for further instructions.