### PR TITLE
Fix LYD_NEW_PATH_OUTPUT issue to support libyang v3.x

### DIFF
--- a/lib/yang.c
+++ b/lib/yang.c
@@ -25,6 +25,11 @@ DEFINE_MTYPE_STATIC(LIB, YANG_DATA, "YANG data structure");
 #define yang_lyd_find_xpath3(ctx_node, tree, xpath, format, prefix_data, vars, \
 			     set)                                              \
 	lyd_find_xpath3(ctx_node, tree, xpath, vars, set)
+
+#ifndef LYD_NEW_VAL_OUTPUT
+#define LYD_NEW_VAL_OUTPUT LYD_NEW_PATH_OUTPUT
+#endif
+
 #else
 #define yang_lyd_find_xpath3(ctx_node, tree, xpath, format, prefix_data, vars, \
 			     set)                                              \
@@ -671,7 +676,7 @@ void yang_dnode_rpc_output_add(struct lyd_node *output, const char *xpath,
 	LY_ERR err;
 
 	err = lyd_new_path(output, ly_native_ctx, xpath, value,
-			   LYD_NEW_PATH_OUTPUT | LYD_NEW_PATH_UPDATE, NULL);
+			   LYD_NEW_VAL_OUTPUT | LYD_NEW_PATH_UPDATE, NULL);
 	assert(err == LY_SUCCESS);
 }
 


### PR DESCRIPTION
There will be a LYD_NEW_PATH_OUTPUT undeclared error if using the latest libyang V3.x version.  It was reported in #16287 before.
I fixed the error to support that. And it's compatible with old version.

> lib/yang.c: In function ‘yang_dnode_rpc_output_add’:
lib/yang.c:674:7: error: ‘LYD_NEW_PATH_OUTPUT’ undeclared (first use in this function); did you mean ‘LYD_NEW_VAL_OUTPUT’?
674 | LYD_NEW_PATH_OUTPUT | LYD_NEW_PATH_UPDATE, NULL);
| ^~~~~~~~~~~~~~~~~~~
| LYD_NEW_VAL_OUTPUT
lib/yang.c:674:7: note: each undeclared identifier is reported only once for each function it appears in
make[1]: *** [Makefile:10793: lib/yang.lo] Error 1
make[1]: Leaving directory '/opt/frr'
make: *** [Makefile:6576: all] Error 2
