### PR TITLE
building-frr-for-centos7: fix frr config path error 

### DIFF
--- a/doc/developer/building-frr-for-centos6.rst
+++ b/doc/developer/building-frr-for-centos6.rst
@@ -159,6 +159,7 @@ an example.)
     cd frr
     ./bootstrap.sh
     ./configure \
+        --sysconfdir=/etc \
         --bindir=/usr/bin \
         --sbindir=/usr/lib/frr \
         --libdir=/usr/lib/frr \

--- a/doc/developer/building-frr-for-centos7.rst
+++ b/doc/developer/building-frr-for-centos7.rst
@@ -56,6 +56,7 @@ an example.)
     cd frr
     ./bootstrap.sh
     ./configure \
+        --sysconfdir=/etc \
         --bindir=/usr/bin \
         --sbindir=/usr/lib/frr \
         --libdir=/usr/lib/frr \

--- a/doc/developer/building-frr-for-centos8.rst
+++ b/doc/developer/building-frr-for-centos8.rst
@@ -50,6 +50,7 @@ an example.)
     cd frr
     ./bootstrap.sh
     ./configure \
+        --sysconfdir=/etc \
         --bindir=/usr/bin \
         --sbindir=/usr/lib/frr \
         --libdir=/usr/lib/frr \


### PR DESCRIPTION
According to the ` building-frr-for-centos7`  document, the following errors were found during building：
```
[root@c7dev frr]# systemctl start frr
Job for frr.service failed because the control process exited with error code. See "systemctl status frr.service" and "journalctl -xe" for details.
[root@c7dev frr]# journalctl -xe
-- Unit frr.service has begun starting up.
Aug 05 10:35:05 c7dev frrinit.sh[76294]: cannot run start: /usr/local/etc/frr/daemons does not exist
Aug 05 10:35:05 c7dev systemd[1]: frr.service: control process exited, code=exited status=1
Aug 05 10:35:05 c7dev systemd[1]: Failed to start FRRouting.
-- Subject: Unit frr.service has failed
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit frr.service has failed.
-- 
-- The result is failed.
```
