### PR TITLE
bgpd: add input per-peer priority pkt queue

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1177,6 +1177,11 @@ void bgp_peer_connection_buffers_free(struct peer_connection *connection)
 			connection->ibuf = NULL;
 		}
 
+		if (connection->ibuf_priority) {
+			stream_fifo_free(connection->ibuf_priority);
+			connection->ibuf_priority = NULL;
+		}
+
 		if (connection->obuf) {
 			stream_fifo_free(connection->obuf);
 			connection->obuf = NULL;
@@ -1211,6 +1216,7 @@ struct peer_connection *bgp_peer_connection_new(struct peer *peer)
 	connection->fd = -1;
 
 	connection->ibuf = stream_fifo_new();
+	connection->ibuf_priority = stream_fifo_new();
 	connection->obuf = stream_fifo_new();
 	pthread_mutex_init(&connection->io_mtx, NULL);
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1197,6 +1197,8 @@ struct peer_connection {
 	/* Packet receive and send buffer. */
 	pthread_mutex_t io_mtx;	  // guards ibuf, obuf
 	struct stream_fifo *ibuf; // packets waiting to be processed
+	struct stream_fifo *ibuf_priority; // keepalive/open/notify packets
+					   // waiting to be processed
 	struct stream_fifo *obuf; // packets waiting to be written
 
 	struct ringbuf *ibuf_work; // WiP buffer used by bgp_read() only


### PR DESCRIPTION
Under heavy loaded system with many connections, and many BGP updates received, the system has issues to maintain BGP connectivity with peers.

For instance, the wireshark capture indicates a BGP open packet is received, and is processed by the device many seconds after. Obviously, the remote peer had already flushed the connection..

The proposed fix attempts to create a second stream of buffers reserved for prioritary BGP packets: BGP OPEN, BGP NOTIF, BGP KEEPALIVE. When running the bgp_packet_receive() job, this prioritary fifo is dequeued before consuming the standard fifo queue.