### PR TITLE
vtysh & zebra: Interface order of ipv4 

### DIFF
--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -1970,6 +1970,14 @@ module frr-zebra {
           description
             "Optional string label for the address.";
         }
+
+        leaf setorder {
+          type uint8 {
+            range "1..100";
+          }
+          description
+            "The order of the IP address.";
+        }
       }
 
       list ipv4-p2p-addrs {

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -329,6 +329,13 @@ const struct frr_yang_module_info frr_zebra_info = {
 			}
 		},
 		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ipv4-addrs/setorder",
+			.cbs = {
+				.modify = lib_interface_zebra_ipv4_addrs_setorder_modify,
+				.destroy = lib_interface_zebra_ipv4_addrs_setorder_destroy,
+			}
+		},
+		{
 			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ipv4-p2p-addrs",
 			.cbs = {
 				.create = lib_interface_zebra_ipv4_p2p_addrs_create,

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -39,8 +39,7 @@ int zebra_import_kernel_table_table_id_modify(struct nb_cb_modify_args *args);
 int zebra_import_kernel_table_table_id_destroy(struct nb_cb_destroy_args *args);
 int zebra_import_kernel_table_distance_modify(struct nb_cb_modify_args *args);
 int zebra_import_kernel_table_route_map_modify(struct nb_cb_modify_args *args);
-int zebra_import_kernel_table_route_map_destroy(
-	struct nb_cb_destroy_args *args);
+int zebra_import_kernel_table_route_map_destroy(struct nb_cb_destroy_args *args);
 int zebra_allow_external_route_update_create(struct nb_cb_create_args *args);
 int zebra_allow_external_route_update_destroy(struct nb_cb_destroy_args *args);
 int zebra_dplane_queue_limit_modify(struct nb_cb_modify_args *args);
@@ -88,6 +87,10 @@ int lib_interface_zebra_ipv4_addrs_create(struct nb_cb_create_args *args);
 int lib_interface_zebra_ipv4_addrs_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_zebra_ipv4_addrs_label_modify(struct nb_cb_modify_args *args);
 int lib_interface_zebra_ipv4_addrs_label_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_zebra_ipv4_addrs_setorder_modify(
+	struct nb_cb_modify_args *args);
+int lib_interface_zebra_ipv4_addrs_setorder_destroy(
+	struct nb_cb_destroy_args *args);
 int lib_interface_zebra_ipv4_p2p_addrs_create(struct nb_cb_create_args *args);
 int lib_interface_zebra_ipv4_p2p_addrs_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_zebra_ipv4_p2p_addrs_label_modify(
@@ -281,11 +284,12 @@ struct yang_data *
 lib_interface_zebra_state_vlan_id_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_interface_zebra_state_vni_id_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *lib_interface_zebra_state_remote_vtep_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *lib_interface_zebra_state_mcast_group_get_elem(
-	struct nb_cb_get_elem_args *args);
-struct yang_data *lib_interface_zebra_state_bond_get_elem(struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_interface_zebra_state_remote_vtep_get_elem(struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_interface_zebra_state_mcast_group_get_elem(struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_interface_zebra_state_bond_get_elem(struct nb_cb_get_elem_args *args);
 int lib_vrf_zebra_router_id_modify(struct nb_cb_modify_args *args);
 int lib_vrf_zebra_router_id_destroy(struct nb_cb_destroy_args *args);
 int lib_vrf_zebra_ipv6_router_id_modify(struct nb_cb_modify_args *args);
@@ -328,20 +332,20 @@ const void *
 lib_vrf_zebra_ribs_rib_route_lookup_next(struct nb_cb_lookup_entry_args *args);
 struct yang_data *
 lib_vrf_zebra_ribs_rib_route_prefix_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_zebra_ribs_rib_route_protocol_get_elem(
-	struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_protocol_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *lib_vrf_zebra_ribs_rib_route_protocol_v6_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_zebra_ribs_rib_route_vrf_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_zebra_ribs_rib_route_distance_get_elem(
-	struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_distance_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_zebra_ribs_rib_route_metric_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *
 lib_vrf_zebra_ribs_rib_route_tag_get_elem(struct nb_cb_get_elem_args *args);
-struct yang_data *lib_vrf_zebra_ribs_rib_route_selected_get_elem(
-	struct nb_cb_get_elem_args *args);
+struct yang_data *
+lib_vrf_zebra_ribs_rib_route_selected_get_elem(struct nb_cb_get_elem_args *args);
 struct yang_data *lib_vrf_zebra_ribs_rib_route_installed_get_elem(
 	struct nb_cb_get_elem_args *args);
 struct yang_data *

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -968,6 +968,46 @@ int lib_interface_zebra_ipv4_addrs_label_destroy(struct nb_cb_destroy_args *args
 	return NB_OK;
 }
 
+
+/* XPath: /frr-interface:lib/interface/frr-zebra:zebra/ipv4-addrs/setorder */
+int lib_interface_zebra_ipv4_addrs_setorder_modify(struct nb_cb_modify_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+		if (nb_running_get_entry_non_rec(lyd_parent(args->dnode), NULL,
+						 false)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "Changing setorder is not allowed");
+			return NB_ERR_VALIDATION;
+		}
+		break;
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		break;
+	}
+
+	return NB_OK;
+}
+
+/* XPath: /frr-interface:lib/interface/frr-zebra:zebra/ipv4-addrs/setorder */
+int lib_interface_zebra_ipv4_addrs_setorder_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+		snprintf(args->errmsg, args->errmsg_len,
+			 "Removing setorder is not allowed");
+		return NB_ERR_VALIDATION;
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		break;
+	}
+
+	return NB_OK;
+}
+
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ipv4-p2p-addrs
  */
@@ -1726,8 +1766,7 @@ int lib_interface_zebra_link_params_utilized_bandwidth_destroy(
  * XPath:
  * /frr-interface:lib/interface/frr-zebra:zebra/link-params/legacy-admin-group
  */
-int lib_interface_zebra_legacy_admin_group_modify(
-	struct nb_cb_modify_args *args)
+int lib_interface_zebra_legacy_admin_group_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct if_link_params *iflp;
@@ -1751,8 +1790,7 @@ int lib_interface_zebra_legacy_admin_group_modify(
 	return NB_OK;
 }
 
-int lib_interface_zebra_legacy_admin_group_destroy(
-	struct nb_cb_destroy_args *args)
+int lib_interface_zebra_legacy_admin_group_destroy(struct nb_cb_destroy_args *args)
 {
 	struct interface *ifp;
 	struct if_link_params *iflp;
@@ -1908,8 +1946,9 @@ int lib_interface_zebra_affinity_mode_modify(struct nb_cb_modify_args *args)
 		if (affinity_mode == AFFINITY_MODE_STANDARD) {
 			if (!IS_PARAM_SET(iflp, LP_ADM_GRP) &&
 			    IS_PARAM_SET(iflp, LP_EXTEND_ADM_GRP)) {
-				iflp->admin_grp = admin_group_get_offset(
-					&iflp->ext_admin_grp, 0);
+				iflp->admin_grp =
+					admin_group_get_offset(&iflp->ext_admin_grp,
+							       0);
 				SET_PARAM(iflp, LP_ADM_GRP);
 			}
 			admin_group_clear(&iflp->ext_admin_grp);
@@ -1933,8 +1972,9 @@ int lib_interface_zebra_affinity_mode_modify(struct nb_cb_modify_args *args)
 				SET_PARAM(iflp, LP_EXTEND_ADM_GRP);
 			} else if (!IS_PARAM_SET(iflp, LP_ADM_GRP) &&
 				   IS_PARAM_SET(iflp, LP_EXTEND_ADM_GRP)) {
-				iflp->admin_grp = admin_group_get_offset(
-					&iflp->ext_admin_grp, 0);
+				iflp->admin_grp =
+					admin_group_get_offset(&iflp->ext_admin_grp,
+							       0);
 				SET_PARAM(iflp, LP_ADM_GRP);
 			}
 		}
@@ -3102,7 +3142,7 @@ int lib_interface_zebra_ipv6_router_advertisements_rdnss_rdnss_address_create(
 	struct nb_cb_create_args *args)
 {
 	struct interface *ifp;
-	struct rtadv_rdnss rdnss = {{{{0}}}}, *p;
+	struct rtadv_rdnss rdnss = { { { { 0 } } } }, *p;
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
@@ -3181,7 +3221,7 @@ int lib_interface_zebra_ipv6_router_advertisements_dnssl_dnssl_domain_create(
 	struct nb_cb_create_args *args)
 {
 	struct interface *ifp;
-	struct rtadv_dnssl dnssl = {{0}}, *p;
+	struct rtadv_dnssl dnssl = { { 0 } }, *p;
 	int ret;
 
 	strlcpy(dnssl.name, yang_dnode_get_string(args->dnode, "domain"),


### PR DESCRIPTION
Feature request: interface ip addresses order [#15464](https://github.com/FRRouting/frr/issues/15464)



Introduction:
As per the issue mentioned about IP addresses not being maintained in the order in which they are assigned/configured on an interface, we have added a keyword, setorder, which allows to control the order of the IPs on interfaces.

Feature Overview:
With this feature in place, we can control the order of IPs as needed, and when we restart FRR, the order will be restored according to our setorder parameter, which takes the next immediate integer as its value. Any other commands on an interface will not have their order changed in /etc/frr/frr.conf, except for the IPs with the setorder keyword. All other commands will follow the order in which they are configured.

Implementation Details:
The feature ensures that IPs on interfaces are configured according to the setorder parameter. When we restart FRR, this feature initiates by backing up /etc/frr/frr.conf to a temporary file before modifying the order within frr.conf. Subsequently, sorting occurs based on the setorder keyword and updates are pushed to /etc/frr/frr.conf. Now, the IPs are configured in the sorted order as specified.

Testing and Validation:
Required unit and functionality testing have been completed.

NOTE:
This feature works only when vtysh.conf "service integrated-vtysh-config"

For your reference:
Before restarting frr
interface eth0
ip address 2.2.3.178/24 setorder 5
ip address 3.1.3.178/24 setorder 5
ip address 45.46.8.7/24 setorder 4
ip address 55.65.8.7/24 setorder 1
ip address 76.75.3.9/24 setorder 2
exit

After restarting the frr
interface eth0
ip address 55.65.8.7/24 setorder 1
ip address 76.75.3.9/24 setorder 2
ip address 45.46.8.7/24 setorder 4
ip address 2.2.3.178/24 setorder 5
ip address 3.1.3.178/24 setorder 5
exit

The order in which they will be configered by zebra and ip's order in kernel
ip addr show eth0
562: eth0@if563: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
link/ether 02:42:0c:0c:00:02 brd ff:ff:ff:ff:ff:ff link-netnsid 0
inet 12.12.0.2/16 brd 12.12.255.255 scope global eth0
valid_lft forever preferred_lft forever
inet 55.65.8.7/24 brd 55.65.8.255 scope global eth0
valid_lft forever preferred_lft forever
inet 76.75.3.9/24 brd 76.75.3.255 scope global eth0
valid_lft forever preferred_lft forever
inet 45.46.8.7/24 brd 45.46.8.255 scope global eth0
valid_lft forever preferred_lft forever
inet 2.2.3.178/24 brd 2.2.3.255 scope global eth0
valid_lft forever preferred_lft forever
inet 3.1.3.178/24 brd 3.1.3.255 scope global eth0
valid_lft forever preferred_lft forever

Conclusion
Please reach out to me if any clarifications are required. If required we can also extend our support to integrate this feature with respect to IPv6, contingent upon the acceptance of the current patch.

Thanks
Denny Agussy