### PR TITLE
ripd: fix show run output for distribute-list

### DIFF
--- a/ripd/rip_cli.c
+++ b/ripd/rip_cli.c
@@ -1375,6 +1375,22 @@ const struct frr_yang_module_info frr_ripd_cli_info = {
 			.cbs.cli_show = cli_show_rip_non_passive_interface,
 		},
 		{
+			.xpath = "/frr-ripd:ripd/instance/distribute-list/in/access-list",
+			.cbs.cli_show = group_distribute_list_ipv4_cli_show,
+		},
+		{
+			.xpath = "/frr-ripd:ripd/instance/distribute-list/out/access-list",
+			.cbs.cli_show = group_distribute_list_ipv4_cli_show,
+		},
+		{
+			.xpath = "/frr-ripd:ripd/instance/distribute-list/in/prefix-list",
+			.cbs.cli_show = group_distribute_list_ipv4_cli_show,
+		},
+		{
+			.xpath = "/frr-ripd:ripd/instance/distribute-list/out/prefix-list",
+			.cbs.cli_show = group_distribute_list_ipv4_cli_show,
+		},
+		{
 			.xpath = "/frr-ripd:ripd/instance/redistribute",
 			.cbs.cli_show = cli_show_rip_redistribute,
 		},

--- a/ripd/rip_nb.c
+++ b/ripd/rip_nb.c
@@ -143,7 +143,6 @@ const struct frr_yang_module_info frr_ripd_info = {
 			.cbs = {
 				.modify = group_distribute_list_ipv4_modify,
 				.destroy = group_distribute_list_ipv4_destroy,
-				.cli_show = group_distribute_list_ipv4_cli_show,
 			}
 		},
 		{
@@ -151,7 +150,6 @@ const struct frr_yang_module_info frr_ripd_info = {
 			.cbs = {
 				.modify = group_distribute_list_ipv4_modify,
 				.destroy = group_distribute_list_ipv4_destroy,
-				.cli_show = group_distribute_list_ipv4_cli_show,
 			}
 		},
 		{
@@ -159,7 +157,6 @@ const struct frr_yang_module_info frr_ripd_info = {
 			.cbs = {
 				.modify = group_distribute_list_ipv4_modify,
 				.destroy = group_distribute_list_ipv4_destroy,
-				.cli_show = group_distribute_list_ipv4_cli_show,
 			}
 		},
 		{
@@ -167,7 +164,6 @@ const struct frr_yang_module_info frr_ripd_info = {
 			.cbs = {
 				.modify = group_distribute_list_ipv4_modify,
 				.destroy = group_distribute_list_ipv4_destroy,
-				.cli_show = group_distribute_list_ipv4_cli_show,
 			}
 		},
 		{


### PR DESCRIPTION
CLI show callbacks should be defined in frr_ripd_cli_info instead of frr_ripd_info, because only the former is loaded by mgmtd and only its callbacks are getting called for config output.

Fixes #16527