### PR TITLE
OSPF6: Refactor to prepare for E-LSA handling

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -553,8 +553,7 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 	lsa_header = (struct ospf6_lsa_header *)buffer;
 
 	if (route->type == OSPF6_DEST_TYPE_ROUTER) {
-		router_lsa = (struct ospf6_inter_router_lsa *)
-			ospf6_lsa_header_end(lsa_header);
+		router_lsa = lsa_after_header(lsa_header);
 		p = (caddr_t)router_lsa + sizeof(struct ospf6_inter_router_lsa);
 
 		/* Fill Inter-Area-Router-LSA */
@@ -565,8 +564,7 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 		router_lsa->router_id = ADV_ROUTER_IN_PREFIX(&route->prefix);
 		type = htons(OSPF6_LSTYPE_INTER_ROUTER);
 	} else {
-		prefix_lsa = (struct ospf6_inter_prefix_lsa *)
-			ospf6_lsa_header_end(lsa_header);
+		prefix_lsa = lsa_after_header(lsa_header);
 		p = (caddr_t)prefix_lsa + sizeof(struct ospf6_inter_prefix_lsa);
 
 		/* Fill Inter-Area-Prefix-LSA */
@@ -1016,8 +1014,7 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 				   oa->name);
 		}
 
-		prefix_lsa = (struct ospf6_inter_prefix_lsa *)
-			ospf6_lsa_header_end(lsa->header);
+		prefix_lsa = lsa_after_header(lsa->header);
 		prefix.family = AF_INET6;
 		prefix.prefixlen = prefix_lsa->prefix.prefix_length;
 		ospf6_prefix_in6_addr(&prefix.u.prefix6, prefix_lsa,
@@ -1036,8 +1033,7 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 				   oa->name);
 		}
 
-		router_lsa = (struct ospf6_inter_router_lsa *)
-			ospf6_lsa_header_end(lsa->header);
+		router_lsa = lsa_after_header(lsa->header);
 		ospf6_linkstate_prefix(router_lsa->router_id, htonl(0), &prefix);
 		if (is_debug)
 			inet_ntop(AF_INET, &router_lsa->router_id, buf,
@@ -1429,8 +1425,7 @@ static char *ospf6_inter_area_prefix_lsa_get_prefix_str(struct ospf6_lsa *lsa,
 	char tbuf[16];
 
 	if (lsa != NULL) {
-		prefix_lsa = (struct ospf6_inter_prefix_lsa *)
-			ospf6_lsa_header_end(lsa->header);
+		prefix_lsa = lsa_after_header(lsa->header);
 
 		ospf6_prefix_in6_addr(&in6, prefix_lsa, &prefix_lsa->prefix);
 		if (buf) {
@@ -1452,8 +1447,7 @@ static int ospf6_inter_area_prefix_lsa_show(struct vty *vty,
 	struct ospf6_inter_prefix_lsa *prefix_lsa;
 	char buf[INET6_ADDRSTRLEN];
 
-	prefix_lsa = (struct ospf6_inter_prefix_lsa *)ospf6_lsa_header_end(
-		lsa->header);
+	prefix_lsa = lsa_after_header(lsa->header);
 
 	if (use_json) {
 		json_object_int_add(
@@ -1489,9 +1483,7 @@ static char *ospf6_inter_area_router_lsa_get_prefix_str(struct ospf6_lsa *lsa,
 	struct ospf6_inter_router_lsa *router_lsa;
 
 	if (lsa != NULL) {
-		router_lsa = (struct ospf6_inter_router_lsa *)
-			ospf6_lsa_header_end(lsa->header);
-
+		router_lsa = lsa_after_header(lsa->header);
 
 		if (buf)
 			inet_ntop(AF_INET, &router_lsa->router_id, buf, buflen);
@@ -1508,8 +1500,7 @@ static int ospf6_inter_area_router_lsa_show(struct vty *vty,
 	struct ospf6_inter_router_lsa *router_lsa;
 	char buf[64];
 
-	router_lsa = (struct ospf6_inter_router_lsa *)ospf6_lsa_header_end(
-		lsa->header);
+	router_lsa = lsa_after_header(lsa->header);
 
 	ospf6_options_printbuf(router_lsa->options, buf, sizeof(buf));
 	if (use_json) {

--- a/ospf6d/ospf6_abr.h
+++ b/ospf6d/ospf6_abr.h
@@ -17,22 +17,6 @@ extern unsigned char conf_debug_ospf6_abr;
 #define OSPF6_DEBUG_ABR_OFF() (conf_debug_ospf6_abr = 0)
 #define IS_OSPF6_DEBUG_ABR (conf_debug_ospf6_abr)
 
-/* Inter-Area-Prefix-LSA */
-#define OSPF6_INTER_PREFIX_LSA_MIN_SIZE        4U /* w/o IPv6 prefix */
-struct ospf6_inter_prefix_lsa {
-	uint32_t metric;
-	struct ospf6_prefix prefix;
-};
-
-/* Inter-Area-Router-LSA */
-#define OSPF6_INTER_ROUTER_LSA_FIX_SIZE       12U
-struct ospf6_inter_router_lsa {
-	uint8_t mbz;
-	uint8_t options[3];
-	uint32_t metric;
-	uint32_t router_id;
-};
-
 #define OSPF6_ABR_SUMMARY_METRIC(E)                                            \
 	(ntohl((E)->metric & htonl(OSPF6_EXT_PATH_METRIC_MAX)))
 #define OSPF6_ABR_SUMMARY_METRIC_SET(E, C)                                     \

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -103,8 +103,7 @@ struct ospf6_lsa *ospf6_as_external_lsa_originate(struct ospf6_route *route,
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	as_external_lsa = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-		lsa_header);
+	as_external_lsa = lsa_after_header(lsa_header);
 	p = (caddr_t)((caddr_t)as_external_lsa
 		      + sizeof(struct ospf6_as_external_lsa));
 
@@ -217,8 +216,7 @@ static route_tag_t ospf6_as_external_lsa_get_tag(struct ospf6_lsa *lsa)
 	if (!lsa)
 		return 0;
 
-	external = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-		lsa->header);
+	external = lsa_after_header(lsa->header);
 
 	if (!CHECK_FLAG(external->bits_metric, OSPF6_ASBR_BIT_T))
 		return 0;
@@ -521,8 +519,7 @@ void ospf6_asbr_lsa_add(struct ospf6_lsa *lsa)
 	type = ntohs(lsa->header->type);
 	oa = lsa->lsdb->data;
 
-	external = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-		lsa->header);
+	external = lsa_after_header(lsa->header);
 
 	if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL))
 		zlog_debug("Calculate AS-External route for %s", lsa->name);
@@ -726,8 +723,7 @@ void ospf6_asbr_lsa_remove(struct ospf6_lsa *lsa,
 	int type;
 	bool debug = false;
 
-	external = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-		lsa->header);
+	external = lsa_after_header(lsa->header);
 
 	if (IS_OSPF6_DEBUG_EXAMIN(AS_EXTERNAL) || (IS_OSPF6_DEBUG_NSSA))
 		debug = true;
@@ -2425,8 +2421,7 @@ static char *ospf6_as_external_lsa_get_prefix_str(struct ospf6_lsa *lsa,
 	char tbuf[16];
 
 	if (lsa) {
-		external = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-			lsa->header);
+		external = lsa_after_header(lsa->header);
 
 		if (pos == 0) {
 			ospf6_prefix_in6_addr(&in6, external,
@@ -2460,8 +2455,7 @@ static int ospf6_as_external_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 	char buf[64];
 
 	assert(lsa->header);
-	external = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-		lsa->header);
+	external = lsa_after_header(lsa->header);
 
 	/* bits */
 	snprintf(buf, sizeof(buf), "%c%c%c",
@@ -3028,8 +3022,7 @@ ospf6_originate_summary_lsa(struct ospf6 *ospf6,
 			return;
 		}
 
-		external = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-			aggr_lsa->header);
+		external = lsa_after_header(aggr_lsa->header);
 		metric = (unsigned long)OSPF6_ASBR_METRIC(external);
 		tag = ospf6_as_external_lsa_get_tag(aggr_lsa);
 		mtype = CHECK_FLAG(external->bits_metric,
@@ -3177,7 +3170,7 @@ ospf6_handle_external_aggr_modify(struct ospf6 *ospf6,
 		return OSPF6_FAILURE;
 	}
 
-	asel = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(lsa->header);
+	asel = lsa_after_header(lsa->header);
 	metric = (unsigned long)OSPF6_ASBR_METRIC(asel);
 	tag = ospf6_as_external_lsa_get_tag(lsa);
 	mtype = CHECK_FLAG(asel->bits_metric,
@@ -3366,8 +3359,7 @@ static void ospf6_handle_aggregated_exnl_rt(struct ospf6 *ospf6,
 	lsa = ospf6_lsdb_lookup(htons(OSPF6_LSTYPE_AS_EXTERNAL),
 				htonl(info->id), ospf6->router_id, ospf6->lsdb);
 	if (lsa) {
-		ext_lsa = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-			lsa->header);
+		ext_lsa = lsa_after_header(lsa->header);
 
 		if (rt->prefix.prefixlen != ext_lsa->prefix.prefix_length)
 			return;

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -39,6 +39,7 @@
 #include "ospf6d.h"
 #include "ospf6_spf.h"
 #include "ospf6_nssa.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
 

--- a/ospf6d/ospf6_asbr.h
+++ b/ospf6d/ospf6_asbr.h
@@ -79,17 +79,6 @@ struct ospf6_external_aggr_rt {
 	struct hash *match_extnl_hash;
 };
 
-/* AS-External-LSA */
-#define OSPF6_AS_EXTERNAL_LSA_MIN_SIZE         4U /* w/o IPv6 prefix */
-struct ospf6_as_external_lsa {
-	uint32_t bits_metric;
-
-	struct ospf6_prefix prefix;
-	/* followed by none or one forwarding address */
-	/* followed by none or one external route tag */
-	/* followed by none or one referenced LS-ID */
-};
-
 #define OSPF6_ASBR_BIT_T  ntohl (0x01000000)
 #define OSPF6_ASBR_BIT_F  ntohl (0x02000000)
 #define OSPF6_ASBR_BIT_E  ntohl (0x04000000)

--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -26,6 +26,7 @@
 
 #include "ospf6_flood.h"
 #include "ospf6_nssa.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 
 unsigned char conf_debug_ospf6_flooding;

--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -30,6 +30,7 @@
 #include "ospf6d/ospf6_flood.h"
 #include "ospf6d/ospf6_intra.h"
 #include "ospf6d/ospf6_spf.h"
+#include "ospf6d/ospf6_tlv.h"
 #include "ospf6d/ospf6_gr.h"
 #include "ospf6d/ospf6_gr_clippy.c"
 
@@ -57,13 +58,13 @@ static int ospf6_gr_lsa_originate(struct ospf6_interface *oi,
 	grace_lsa = (struct ospf6_grace_lsa *)ospf6_lsa_header_end(lsa_header);
 
 	/* Put grace period. */
-	grace_lsa->tlv_period.header.type = htons(GRACE_PERIOD_TYPE);
-	grace_lsa->tlv_period.header.length = htons(GRACE_PERIOD_LENGTH);
+	grace_lsa->tlv_period.header.type = htons(TLV_GRACE_PERIOD_TYPE);
+	grace_lsa->tlv_period.header.length = htons(TLV_GRACE_PERIOD_LENGTH);
 	grace_lsa->tlv_period.interval = htonl(gr_info->grace_period);
 
 	/* Put restart reason. */
-	grace_lsa->tlv_reason.header.type = htons(RESTART_REASON_TYPE);
-	grace_lsa->tlv_reason.header.length = htons(RESTART_REASON_LENGTH);
+	grace_lsa->tlv_reason.header.type = htons(TLV_GRACE_RESTART_REASON_TYPE);
+	grace_lsa->tlv_reason.header.length = htons(TLV_GRACE_RESTART_REASON_LENGTH);
 	grace_lsa->tlv_reason.reason = reason;
 
 	/* Fill LSA Header */

--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -56,7 +56,7 @@ static int ospf6_gr_lsa_originate(struct ospf6_interface *oi,
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	grace_lsa = (struct ospf6_grace_lsa *)ospf6_lsa_header_end(lsa_header);
+	grace_lsa = lsa_after_header(lsa_header);
 
 	/* Put grace period. */
 	grace_lsa->tlv_period.header.type = htons(TLV_GRACE_PERIOD_TYPE);

--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -65,7 +65,8 @@ static int ospf6_gr_lsa_originate(struct ospf6_interface *oi,
 
 	/* Put restart reason. */
 	grace_lsa->tlv_reason.header.type = htons(TLV_GRACE_RESTART_REASON_TYPE);
-	grace_lsa->tlv_reason.header.length = htons(TLV_GRACE_RESTART_REASON_LENGTH);
+	grace_lsa->tlv_reason.header.length =
+		htons(TLV_GRACE_RESTART_REASON_LENGTH);
 	grace_lsa->tlv_reason.reason = reason;
 
 	/* Fill LSA Header */

--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -16,6 +16,7 @@
 #include "printfrr.h"
 #include "lib_errors.h"
 
+#include "ospf6_proto.h"
 #include "ospf6d/ospf6_lsa.h"
 #include "ospf6d/ospf6_lsdb.h"
 #include "ospf6d/ospf6_route.h"

--- a/ospf6d/ospf6_gr.h
+++ b/ospf6d/ospf6_gr.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 /*
- * OSPF6 Graceful Retsart helper functions.
+ * OSPF6 Graceful Restart helper functions.
+ * Ref RFC 5187
  *
  * Copyright (C) 2021-22 Vmware, Inc.
  * Rajesh Kumar Girada
@@ -60,58 +61,16 @@ enum ospf6_gr_helper_rejected_reason {
 	OSPF6_HELPER_RESTARTING,
 };
 
-#ifdef roundup
-#define ROUNDUP(val, gran) roundup(val, gran)
-#else /* roundup */
-#define ROUNDUP(val, gran) (((val)-1 | (gran)-1) + 1)
-#endif /* roundup */
 
-/*
- * Generic TLV (type, length, value) macros
- */
-struct tlv_header {
-	uint16_t type;   /* Type of Value */
-	uint16_t length; /* Length of Value portion only, in bytes */
-};
-
-#define TLV_HDR_SIZE (sizeof(struct tlv_header))
-
-#define TLV_BODY_SIZE(tlvh) (ROUNDUP(ntohs((tlvh)->length), sizeof(uint32_t)))
-
-#define TLV_SIZE(tlvh) (uint32_t)(TLV_HDR_SIZE + TLV_BODY_SIZE(tlvh))
-
-#define TLV_HDR_TOP(lsah)                                                      \
-	(struct tlv_header *)((char *)(lsah) + OSPF6_LSA_HEADER_SIZE)
-
-#define TLV_HDR_NEXT(tlvh)                                                     \
-	(struct tlv_header *)((char *)(tlvh) + TLV_SIZE(tlvh))
-
-/* Ref RFC5187 appendix-A */
-/* Grace period TLV */
-#define GRACE_PERIOD_TYPE 1
-#define GRACE_PERIOD_LENGTH 4
-struct grace_tlv_graceperiod {
-	struct tlv_header header;
-	uint32_t interval;
-};
-#define GRACE_PERIOD_TLV_SIZE sizeof(struct grace_tlv_graceperiod)
-
-/* Restart reason TLV */
-#define RESTART_REASON_TYPE 2
-#define RESTART_REASON_LENGTH 1
-struct grace_tlv_restart_reason {
-	struct tlv_header header;
-	uint8_t reason;
-	uint8_t reserved[3];
-};
-#define GRACE_RESTART_REASON_TLV_SIZE sizeof(struct grace_tlv_restart_reason)
+#define GRACE_PERIOD_TLV_SIZE sizeof(struct tlv_grace_period)
+#define GRACE_RESTART_REASON_TLV_SIZE sizeof(struct tlv_grace_restart_reason)
 
 #define OSPF6_GRACE_LSA_MIN_SIZE                                               \
 	GRACE_PERIOD_TLV_SIZE + GRACE_RESTART_REASON_TLV_SIZE
 
 struct ospf6_grace_lsa {
-	struct grace_tlv_graceperiod tlv_period;
-	struct grace_tlv_restart_reason tlv_reason;
+	struct tlv_grace_period tlv_period;
+	struct tlv_grace_restart_reason tlv_reason;
 };
 
 struct advRtr {

--- a/ospf6d/ospf6_gr.h
+++ b/ospf6d/ospf6_gr.h
@@ -62,7 +62,7 @@ enum ospf6_gr_helper_rejected_reason {
 };
 
 
-#define GRACE_PERIOD_TLV_SIZE sizeof(struct tlv_grace_period)
+#define GRACE_PERIOD_TLV_SIZE	      sizeof(struct tlv_grace_period)
 #define GRACE_RESTART_REASON_TLV_SIZE sizeof(struct tlv_grace_restart_reason)
 
 #define OSPF6_GRACE_LSA_MIN_SIZE                                               \

--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -147,7 +147,6 @@ static int ospf6_extract_grace_lsa_fields(struct ospf6_lsa *lsa,
 
 	for (tlvh = lsdesc_start(lsah); sum < length && tlvh;
 	     tlvh = TLV_HDR_NEXT(tlvh)) {
-
 		/* Check TLV len against overall LSA */
 		if (sum + TLV_SIZE(tlvh) > length) {
 			if (IS_DEBUG_OSPF6_GR)
@@ -1243,7 +1242,6 @@ static int ospf6_grace_lsa_show_info(struct vty *vty, struct ospf6_lsa *lsa,
 
 	for (tlvh = lsdesc_start(lsah); sum < length && tlvh;
 	     tlvh = TLV_HDR_NEXT(tlvh)) {
-
 		/* Check TLV len */
 		if (sum + TLV_SIZE(tlvh) > length) {
 			if (vty)

--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -145,7 +145,7 @@ static int ospf6_extract_grace_lsa_fields(struct ospf6_lsa *lsa,
 
 	length = ntohs(lsah->length) - OSPF6_LSA_HEADER_SIZE;
 
-	for (tlvh = TLV_HDR_TOP(lsah); sum < length && tlvh;
+	for (tlvh = lsdesc_start(lsah); sum < length && tlvh;
 	     tlvh = TLV_HDR_NEXT(tlvh)) {
 
 		/* Check TLV len against overall LSA */
@@ -1241,7 +1241,7 @@ static int ospf6_grace_lsa_show_info(struct vty *vty, struct ospf6_lsa *lsa,
 		zlog_debug("  TLV info:");
 	}
 
-	for (tlvh = TLV_HDR_TOP(lsah); sum < length && tlvh;
+	for (tlvh = lsdesc_start(lsah); sum < length && tlvh;
 	     tlvh = TLV_HDR_NEXT(tlvh)) {
 
 		/* Check TLV len */

--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -32,6 +32,7 @@
 #include "ospf6_neighbor.h"
 #include "ospf6_intra.h"
 #include "ospf6d.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
 #include "ospf6d/ospf6_gr_helper_clippy.c"
@@ -129,8 +130,8 @@ static int ospf6_extract_grace_lsa_fields(struct ospf6_lsa *lsa,
 {
 	struct ospf6_lsa_header *lsah = NULL;
 	struct tlv_header *tlvh = NULL;
-	struct grace_tlv_graceperiod *gracePeriod;
-	struct grace_tlv_restart_reason *grReason;
+	struct tlv_grace_period *gracePeriod;
+	struct tlv_grace_restart_reason *grReason;
 	uint16_t length = 0;
 	int sum = 0;
 
@@ -157,8 +158,8 @@ static int ospf6_extract_grace_lsa_fields(struct ospf6_lsa *lsa,
 		}
 
 		switch (ntohs(tlvh->type)) {
-		case GRACE_PERIOD_TYPE:
-			gracePeriod = (struct grace_tlv_graceperiod *)tlvh;
+		case TLV_GRACE_PERIOD_TYPE:
+			gracePeriod = (struct tlv_grace_period *)tlvh;
 			*interval = ntohl(gracePeriod->interval);
 			sum += TLV_SIZE(tlvh);
 
@@ -167,8 +168,8 @@ static int ospf6_extract_grace_lsa_fields(struct ospf6_lsa *lsa,
 			    || *interval < OSPF6_MIN_GRACE_INTERVAL)
 				return OSPF6_FAILURE;
 			break;
-		case RESTART_REASON_TYPE:
-			grReason = (struct grace_tlv_restart_reason *)tlvh;
+		case TLV_GRACE_RESTART_REASON_TYPE:
+			grReason = (struct tlv_grace_restart_reason *)tlvh;
 			*reason = grReason->reason;
 			sum += TLV_SIZE(tlvh);
 
@@ -1218,8 +1219,8 @@ static int ospf6_grace_lsa_show_info(struct vty *vty, struct ospf6_lsa *lsa,
 {
 	struct ospf6_lsa_header *lsah = NULL;
 	struct tlv_header *tlvh = NULL;
-	struct grace_tlv_graceperiod *gracePeriod;
-	struct grace_tlv_restart_reason *grReason;
+	struct tlv_grace_period *gracePeriod;
+	struct tlv_grace_restart_reason *grReason;
 	uint16_t length = 0;
 	int sum = 0;
 
@@ -1255,8 +1256,8 @@ static int ospf6_grace_lsa_show_info(struct vty *vty, struct ospf6_lsa *lsa,
 		}
 
 		switch (ntohs(tlvh->type)) {
-		case GRACE_PERIOD_TYPE:
-			gracePeriod = (struct grace_tlv_graceperiod *)tlvh;
+		case TLV_GRACE_PERIOD_TYPE:
+			gracePeriod = (struct tlv_grace_period *)tlvh;
 			sum += TLV_SIZE(tlvh);
 
 			if (vty) {
@@ -1272,8 +1273,8 @@ static int ospf6_grace_lsa_show_info(struct vty *vty, struct ospf6_lsa *lsa,
 					   ntohl(gracePeriod->interval));
 			}
 			break;
-		case RESTART_REASON_TYPE:
-			grReason = (struct grace_tlv_restart_reason *)tlvh;
+		case TLV_GRACE_RESTART_REASON_TYPE:
+			grReason = (struct tlv_grace_restart_reason *)tlvh;
 			sum += TLV_SIZE(tlvh);
 			if (vty) {
 				if (use_json)

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -30,6 +30,7 @@
 #include "ospf6d.h"
 #include "ospf6_bfd.h"
 #include "ospf6_zebra.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
 #include "ospf6_proto.h"

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -14,6 +14,7 @@
 #include "plist.h"
 #include "zclient.h"
 
+#include "ospf6_proto.h"
 #include "ospf6_lsa.h"
 #include "ospf6_lsdb.h"
 #include "ospf6_top.h"
@@ -33,7 +34,6 @@
 #include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
-#include "ospf6_proto.h"
 #include "lib/keychain.h"
 #include "ospf6_auth_trailer.h"
 #include "ospf6d/ospf6_interface_clippy.c"

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -196,9 +196,7 @@ int ospf6_router_is_stub_router(struct ospf6_lsa *lsa)
 	struct ospf6_router_lsa *rtr_lsa;
 
 	if (lsa != NULL && OSPF6_LSA_IS_TYPE(ROUTER, lsa)) {
-		rtr_lsa = (struct ospf6_router_lsa
-				   *)((caddr_t)lsa->header
-				      + sizeof(struct ospf6_lsa_header));
+		rtr_lsa = lsa_after_header(lsa->header);
 
 		if (!OSPF6_OPT_ISSET(rtr_lsa->options, OSPF6_OPT_R)) {
 			return OSPF6_IS_STUB_ROUTER;
@@ -459,9 +457,7 @@ static int ospf6_network_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 	char buf[128], options[32];
 	json_object *json_arr = NULL;
 
-	network_lsa =
-		(struct ospf6_network_lsa *)((caddr_t)lsa->header
-					     + sizeof(struct ospf6_lsa_header));
+	network_lsa = lsa_after_header(lsa->header);
 
 	ospf6_options_printbuf(network_lsa->options, options, sizeof(options));
 	if (use_json)
@@ -682,8 +678,7 @@ static int ospf6_link_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 	json_object *json_arr = NULL;
 	char prefix_string[133];
 
-	link_lsa = (struct ospf6_link_lsa *)((caddr_t)lsa->header
-					     + sizeof(struct ospf6_lsa_header));
+	link_lsa = lsa_after_header(lsa->header);
 
 	ospf6_options_printbuf(link_lsa->options, options, sizeof(options));
 	inet_ntop(AF_INET6, &link_lsa->linklocal_addr, buf, sizeof(buf));
@@ -852,10 +847,7 @@ static char *ospf6_intra_prefix_lsa_get_prefix_str(struct ospf6_lsa *lsa,
 	char tbuf[16];
 
 	if (lsa) {
-		intra_prefix_lsa =
-			(struct ospf6_intra_prefix_lsa
-				 *)((caddr_t)lsa->header
-				    + sizeof(struct ospf6_lsa_header));
+		intra_prefix_lsa = lsa_after_header(lsa->header);
 
 		prefixnum = ntohs(intra_prefix_lsa->prefix_num);
 		if ((pos + 1) > prefixnum)
@@ -906,9 +898,7 @@ static int ospf6_intra_prefix_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 	json_object *json_arr = NULL;
 	char prefix_string[133];
 
-	intra_prefix_lsa = (struct ospf6_intra_prefix_lsa
-				    *)((caddr_t)lsa->header
-				       + sizeof(struct ospf6_lsa_header));
+	intra_prefix_lsa = lsa_after_header(lsa->header);
 
 	prefixnum = ntohs(intra_prefix_lsa->prefix_num);
 
@@ -1306,9 +1296,7 @@ void ospf6_intra_prefix_lsa_originate_transit(struct event *thread)
 			}
 		}
 
-		link_lsa = (struct ospf6_link_lsa
-				    *)((caddr_t)lsa->header
-				       + sizeof(struct ospf6_lsa_header));
+		link_lsa = lsa_after_header(lsa->header);
 
 		prefix_num = (unsigned short)ntohl(link_lsa->prefix_num);
 		start = (char *)link_lsa + sizeof(struct ospf6_link_lsa);

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -243,7 +243,7 @@ void ospf6_router_lsa_originate(struct event *thread)
 
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	router_lsa = (struct ospf6_router_lsa *)ospf6_lsa_header_end(lsa_header);
+	router_lsa = lsa_after_header(lsa_header);
 
 	ospf6_router_lsa_options_set(oa, router_lsa);
 
@@ -304,8 +304,7 @@ void ospf6_router_lsa_originate(struct event *thread)
 			/* Reset Buffer to fill next Router LSA */
 			memset(buffer, 0, sizeof(buffer));
 			lsa_header = (struct ospf6_lsa_header *)buffer;
-			router_lsa = (struct ospf6_router_lsa *)
-				ospf6_lsa_header_end(lsa_header);
+			router_lsa = lsa_after_header(lsa_header);
 
 			ospf6_router_lsa_options_set(oa, router_lsa);
 
@@ -564,15 +563,13 @@ void ospf6_network_lsa_originate(struct event *thread)
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	network_lsa =
-		(struct ospf6_network_lsa *)ospf6_lsa_header_end(lsa_header);
+	network_lsa = lsa_after_header(lsa_header);
 
 	/* Collect the interface's Link-LSAs to describe
 	   network's optional capabilities */
 	type = htons(OSPF6_LSTYPE_LINK);
 	for (ALL_LSDB_TYPED(oi->lsdb, type, lsa)) {
-		link_lsa = (struct ospf6_link_lsa *)ospf6_lsa_header_end(
-			lsa->header);
+		link_lsa = lsa_after_header(lsa->header);
 		network_lsa->options[0] |= link_lsa->options[0];
 		network_lsa->options[1] |= link_lsa->options[1];
 		network_lsa->options[2] |= link_lsa->options[2];
@@ -796,7 +793,7 @@ void ospf6_link_lsa_originate(struct event *thread)
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	link_lsa = (struct ospf6_link_lsa *)ospf6_lsa_header_end(lsa_header);
+	link_lsa = lsa_after_header(lsa_header);
 
 	/* Fill Link-LSA */
 	link_lsa->priority = oi->priority;
@@ -1038,8 +1035,7 @@ void ospf6_intra_prefix_lsa_originate_stub(struct event *thread)
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	intra_prefix_lsa = (struct ospf6_intra_prefix_lsa *)ospf6_lsa_header_end(
-		lsa_header);
+	intra_prefix_lsa = lsa_after_header(lsa_header);
 
 	/* Fill Intra-Area-Prefix-LSA */
 	intra_prefix_lsa->ref_type = htons(OSPF6_LSTYPE_ROUTER);
@@ -1154,8 +1150,7 @@ void ospf6_intra_prefix_lsa_originate_stub(struct event *thread)
 			/* Prepare next buffer */
 			memset(buffer, 0, sizeof(buffer));
 			lsa_header = (struct ospf6_lsa_header *)buffer;
-			intra_prefix_lsa = (struct ospf6_intra_prefix_lsa *)
-				ospf6_lsa_header_end(lsa_header);
+			intra_prefix_lsa = lsa_after_header(lsa_header);
 
 			/* Fill Intra-Area-Prefix-LSA */
 			intra_prefix_lsa->ref_type = htons(OSPF6_LSTYPE_ROUTER);
@@ -1262,8 +1257,7 @@ void ospf6_intra_prefix_lsa_originate_transit(struct event *thread)
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	intra_prefix_lsa = (struct ospf6_intra_prefix_lsa *)ospf6_lsa_header_end(
-		lsa_header);
+	intra_prefix_lsa = lsa_after_header(lsa_header);
 
 	/* Fill Intra-Area-Prefix-LSA */
 	intra_prefix_lsa->ref_type = htons(OSPF6_LSTYPE_NETWORK);
@@ -1659,10 +1653,7 @@ void ospf6_intra_prefix_route_ecmp_path(struct ospf6_area *oa,
 					}
 					continue;
 				}
-				intra_prefix_lsa =
-					(struct ospf6_intra_prefix_lsa *)
-						ospf6_lsa_header_end(
-							lsa->header);
+				intra_prefix_lsa = lsa_after_header(lsa->header);
 
 				if (intra_prefix_lsa->ref_adv_router
 				     == oa->ospf6->router_id) {
@@ -1743,8 +1734,7 @@ void ospf6_intra_prefix_lsa_add(struct ospf6_lsa *lsa)
 
 	oa = OSPF6_AREA(lsa->lsdb->data);
 
-	intra_prefix_lsa = (struct ospf6_intra_prefix_lsa *)ospf6_lsa_header_end(
-		lsa->header);
+	intra_prefix_lsa = lsa_after_header(lsa->header);
 	if (intra_prefix_lsa->ref_type == htons(OSPF6_LSTYPE_ROUTER) ||
 	    intra_prefix_lsa->ref_type == htons(OSPF6_LSTYPE_NETWORK))
 		ospf6_linkstate_prefix(intra_prefix_lsa->ref_adv_router,
@@ -1972,8 +1962,7 @@ void ospf6_intra_prefix_lsa_remove(struct ospf6_lsa *lsa)
 
 	oa = OSPF6_AREA(lsa->lsdb->data);
 
-	intra_prefix_lsa = (struct ospf6_intra_prefix_lsa *)ospf6_lsa_header_end(
-		lsa->header);
+	intra_prefix_lsa = lsa_after_header(lsa->header);
 
 	prefix_num = ntohs(intra_prefix_lsa->prefix_num);
 	start = (caddr_t)intra_prefix_lsa

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -419,30 +419,13 @@ void ospf6_router_lsa_originate(struct event *thread)
 static char *ospf6_network_lsa_get_ar_id(struct ospf6_lsa *lsa, char *buf,
 					 int buflen, int pos)
 {
-	char *start, *end, *current;
-	struct ospf6_network_lsa *network_lsa;
-	struct ospf6_network_lsdesc *lsdesc;
+	struct ospf6_network_lsdesc *lsdesc = nth_lsdesc(lsa->header, pos);
 
-	if (lsa) {
-		network_lsa = (struct ospf6_network_lsa
-				       *)((caddr_t)lsa->header
-					  + sizeof(struct ospf6_lsa_header));
+	if (!lsdesc || !buf || buflen < (1 + INET_ADDRSTRLEN))
+		return NULL;
 
-		start = (char *)network_lsa + sizeof(struct ospf6_network_lsa);
-		end = (char *)lsa->header + ntohs(lsa->header->length);
-		current = start + pos * (sizeof(struct ospf6_network_lsdesc));
-
-		if ((current + sizeof(struct ospf6_network_lsdesc)) <= end) {
-			lsdesc = (struct ospf6_network_lsdesc *)current;
-			if (buf) {
-				inet_ntop(AF_INET, &lsdesc->router_id, buf,
-					  buflen);
-				return buf;
-			}
-		}
-	}
-
-	return NULL;
+	inet_ntop(AF_INET, &lsdesc->router_id, buf, buflen);
+	return buf;
 }
 
 static int ospf6_network_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -592,8 +592,6 @@ static char *ospf6_link_lsa_get_prefix_str(struct ospf6_lsa *lsa, char *buf,
 	inet_ntop(AF_INET6, &in6, buf, buflen);
 
 	return buf;
-
-
 }
 
 static int ospf6_link_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -246,9 +246,7 @@ void ospf6_router_lsa_originate(struct event *thread)
 	ospf6_router_lsa_options_set(oa, router_lsa);
 
 	/* describe links for each interfaces */
-	lsdesc = (struct ospf6_router_lsdesc
-			  *)((caddr_t)router_lsa
-			     + sizeof(struct ospf6_router_lsa));
+	lsdesc = lsdesc_start_lsa_type(lsa_header, OSPF6_LSTYPE_ROUTER);
 
 	for (ALL_LIST_ELEMENTS(oa->if_list, node, nnode, oi)) {
 		/* Interfaces in state Down or Loopback are not described */
@@ -271,9 +269,9 @@ void ospf6_router_lsa_originate(struct event *thread)
 		    && ((size_t)((char *)lsdesc - buffer)
 				+ sizeof(struct ospf6_router_lsdesc)
 			> oa->router_lsa_size_limit)) {
-			if ((caddr_t)lsdesc
-			    == (caddr_t)router_lsa
-				       + sizeof(struct ospf6_router_lsa)) {
+			if (lsdesc ==
+			    lsdesc_start_lsa_type(lsa_header,
+						  OSPF6_LSTYPE_ROUTER)) {
 				zlog_warn(
 					"Size limit setting for Router-LSA too short");
 				return;
@@ -307,9 +305,8 @@ void ospf6_router_lsa_originate(struct event *thread)
 			ospf6_router_lsa_options_set(oa, router_lsa);
 
 			/* describe links for each interfaces */
-			lsdesc = (struct ospf6_router_lsdesc
-					  *)((caddr_t)router_lsa
-					     + sizeof(struct ospf6_router_lsa));
+			lsdesc = lsdesc_start_lsa_type(lsa_header,
+						       OSPF6_LSTYPE_ROUTER);
 
 			link_state_id++;
 		}
@@ -571,9 +568,7 @@ void ospf6_network_lsa_originate(struct event *thread)
 		network_lsa->options[2] |= link_lsa->options[2];
 	}
 
-	lsdesc = (struct ospf6_network_lsdesc
-			  *)((caddr_t)network_lsa
-			     + sizeof(struct ospf6_network_lsa));
+	lsdesc = lsdesc_start_lsa_type(lsa_header, OSPF6_LSTYPE_NETWORK);
 
 	/* set Link Description to the router itself */
 	lsdesc->router_id = oi->area->ospf6->router_id;
@@ -797,8 +792,7 @@ void ospf6_link_lsa_originate(struct event *thread)
 	       sizeof(struct in6_addr));
 	link_lsa->prefix_num = htonl(oi->route_connected->count);
 
-	op = (struct ospf6_prefix *)((caddr_t)link_lsa
-				     + sizeof(struct ospf6_link_lsa));
+	op = lsdesc_start_lsa_type(lsa_header, OSPF6_LSTYPE_LINK);
 
 	/* connected prefix to advertise */
 	for (route = ospf6_route_head(oi->route_connected); route;
@@ -1109,12 +1103,10 @@ void ospf6_intra_prefix_lsa_originate_stub(struct event *thread)
 
 	/* put prefixes to advertise */
 	prefix_num = 0;
-	op = (struct ospf6_prefix *)((caddr_t)intra_prefix_lsa
-				     + sizeof(struct ospf6_intra_prefix_lsa));
+	op = lsdesc_start_lsa_type(lsa_header, OSPF6_LSTYPE_INTRA_PREFIX);
 	for (route = ospf6_route_head(route_advertise); route;
 	     route = ospf6_route_best_next(route)) {
 		if (((caddr_t)op - (caddr_t)lsa_header) > MAX_LSA_PAYLOAD) {
-
 			intra_prefix_lsa->prefix_num = htons(prefix_num);
 
 			/* Fill LSA Header */
@@ -1149,10 +1141,8 @@ void ospf6_intra_prefix_lsa_originate_stub(struct event *thread)
 
 			/* Put next set of prefixes to advertise */
 			prefix_num = 0;
-			op = (struct ospf6_prefix
-				      *)((caddr_t)intra_prefix_lsa
-					 + sizeof(struct
-						  ospf6_intra_prefix_lsa));
+			op = lsdesc_start_lsa_type(lsa_header,
+						   OSPF6_LSTYPE_INTRA_PREFIX);
 		}
 
 		op->prefix_length = route->prefix.prefixlen;
@@ -1339,8 +1329,7 @@ void ospf6_intra_prefix_lsa_originate_transit(struct event *thread)
 			zlog_debug("Trailing garbage in %s", lsa->name);
 	}
 
-	op = (struct ospf6_prefix *)((caddr_t)intra_prefix_lsa
-				     + sizeof(struct ospf6_intra_prefix_lsa));
+	op = lsdesc_start_lsa_type(lsa_header, OSPF6_LSTYPE_INTRA_PREFIX);
 
 	prefix_num = 0;
 	for (route = ospf6_route_head(route_advertise); route;

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -44,41 +44,20 @@ uint32_t conf_debug_ospf6_brouter_specific_area_id;
 /* RFC2740 3.4.3.1 Router-LSA */
 /******************************/
 
+/* OSPF6_LSTYPE_ROUTER */
 static char *ospf6_router_lsa_get_nbr_id(struct ospf6_lsa *lsa, char *buf,
 					 int buflen, int pos)
 {
-	struct ospf6_router_lsa *router_lsa;
-	struct ospf6_router_lsdesc *lsdesc;
-	char *start, *end;
 	char buf1[INET_ADDRSTRLEN], buf2[INET_ADDRSTRLEN];
+	struct ospf6_router_lsdesc *lsdesc = nth_lsdesc(lsa->header, pos);
 
-	if (lsa) {
-		router_lsa = (struct ospf6_router_lsa
-				      *)((char *)lsa->header
-					 + sizeof(struct ospf6_lsa_header));
-		start = (char *)router_lsa + sizeof(struct ospf6_router_lsa);
-		end = (char *)lsa->header + ntohs(lsa->header->length);
+	if (!lsdesc || !buf || buflen < (2 + 2 * INET_ADDRSTRLEN))
+		return NULL;
 
-		lsdesc = (struct ospf6_router_lsdesc
-				  *)(start
-				     + pos * (sizeof(struct
-						     ospf6_router_lsdesc)));
-		if ((char *)lsdesc + sizeof(struct ospf6_router_lsdesc)
-		    <= end) {
-			if (buf && (buflen > INET_ADDRSTRLEN * 2)) {
-				inet_ntop(AF_INET,
-					  &lsdesc->neighbor_interface_id, buf1,
-					  sizeof(buf1));
-				inet_ntop(AF_INET, &lsdesc->neighbor_router_id,
-					  buf2, sizeof(buf2));
-				snprintf(buf, buflen, "%s/%s", buf2, buf1);
-
-				return buf;
-			}
-		}
-	}
-
-	return NULL;
+	inet_ntop(AF_INET, &lsdesc->neighbor_interface_id, buf1, sizeof(buf1));
+	inet_ntop(AF_INET, &lsdesc->neighbor_router_id, buf2, sizeof(buf2));
+	snprintf(buf, buflen, "%s/%s", buf2, buf1);
+	return buf;
 }
 
 static int ospf6_router_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -32,6 +32,7 @@
 #include "ospf6_flood.h"
 #include "ospf6d.h"
 #include "ospf6_spf.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 
 unsigned char conf_debug_ospf6_brouter = 0;

--- a/ospf6d/ospf6_intra.h
+++ b/ospf6d/ospf6_intra.h
@@ -55,30 +55,6 @@ extern in_addr_t conf_debug_ospf6_brouter_specific_area_id;
 	(IS_OSPF6_DEBUG_BROUTER_SPECIFIC_AREA                                  \
 	 && conf_debug_ospf6_brouter_specific_area_id == (area_id))
 
-/* Router-LSA */
-#define OSPF6_ROUTER_LSA_MIN_SIZE              4U
-struct ospf6_router_lsa {
-	uint8_t bits;
-	uint8_t options[3];
-	/* followed by ospf6_router_lsdesc(s) */
-};
-
-/* Link State Description in Router-LSA */
-#define OSPF6_ROUTER_LSDESC_FIX_SIZE          16U
-struct ospf6_router_lsdesc {
-	uint8_t type;
-	uint8_t reserved;
-	uint16_t metric; /* output cost */
-	uint32_t interface_id;
-	uint32_t neighbor_interface_id;
-	in_addr_t neighbor_router_id;
-};
-
-#define OSPF6_ROUTER_LSDESC_POINTTOPOINT       1
-#define OSPF6_ROUTER_LSDESC_TRANSIT_NETWORK    2
-#define OSPF6_ROUTER_LSDESC_STUB_NETWORK       3
-#define OSPF6_ROUTER_LSDESC_VIRTUAL_LINK       4
-
 enum stub_router_mode {
 	OSPF6_NOT_STUB_ROUTER,
 	OSPF6_IS_STUB_ROUTER,
@@ -98,42 +74,6 @@ enum stub_router_mode {
 	(ntohl(((struct ospf6_router_lsdesc *)(x))->neighbor_interface_id))
 #define ROUTER_LSDESC_GET_NBR_ROUTERID(x)                                      \
 	(((struct ospf6_router_lsdesc *)(x))->neighbor_router_id)
-
-/* Network-LSA */
-#define OSPF6_NETWORK_LSA_MIN_SIZE             4U
-struct ospf6_network_lsa {
-	uint8_t reserved;
-	uint8_t options[3];
-	/* followed by ospf6_netowrk_lsd(s) */
-};
-
-/* Link State Description in Router-LSA */
-#define OSPF6_NETWORK_LSDESC_FIX_SIZE          4U
-struct ospf6_network_lsdesc {
-	in_addr_t router_id;
-};
-#define NETWORK_LSDESC_GET_NBR_ROUTERID(x)                                     \
-	(((struct ospf6_network_lsdesc *)(x))->router_id)
-
-/* Link-LSA */
-#define OSPF6_LINK_LSA_MIN_SIZE               24U /* w/o 1st IPv6 prefix */
-struct ospf6_link_lsa {
-	uint8_t priority;
-	uint8_t options[3];
-	struct in6_addr linklocal_addr;
-	uint32_t prefix_num;
-	/* followed by ospf6 prefix(es) */
-};
-
-/* Intra-Area-Prefix-LSA */
-#define OSPF6_INTRA_PREFIX_LSA_MIN_SIZE       12U /* w/o 1st IPv6 prefix */
-struct ospf6_intra_prefix_lsa {
-	uint16_t prefix_num;
-	uint16_t ref_type;
-	uint32_t ref_id;
-	in_addr_t ref_adv_router;
-	/* followed by ospf6 prefix(es) */
-};
 
 
 #define OSPF6_ROUTER_LSA_SCHEDULE(oa)                                          \

--- a/ospf6d/ospf6_intra.h
+++ b/ospf6d/ospf6_intra.h
@@ -13,10 +13,13 @@ extern in_addr_t conf_debug_ospf6_brouter_specific_area_id;
 #define OSPF6_DEBUG_BROUTER_SUMMARY         0x01
 #define OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER 0x02
 #define OSPF6_DEBUG_BROUTER_SPECIFIC_AREA   0x04
+
 #define OSPF6_DEBUG_BROUTER_ON()                                               \
 	(conf_debug_ospf6_brouter |= OSPF6_DEBUG_BROUTER_SUMMARY)
+
 #define OSPF6_DEBUG_BROUTER_OFF()                                              \
 	(conf_debug_ospf6_brouter &= ~OSPF6_DEBUG_BROUTER_SUMMARY)
+
 #define IS_OSPF6_DEBUG_BROUTER                                                 \
 	(conf_debug_ospf6_brouter & OSPF6_DEBUG_BROUTER_SUMMARY)
 
@@ -26,14 +29,17 @@ extern in_addr_t conf_debug_ospf6_brouter_specific_area_id;
 		conf_debug_ospf6_brouter |=                                    \
 			OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER;                   \
 	} while (0)
+
 #define OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER_OFF()                              \
 	do {                                                                   \
 		conf_debug_ospf6_brouter_specific_router_id = 0;               \
 		conf_debug_ospf6_brouter &=                                    \
 			~OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER;                  \
 	} while (0)
+
 #define IS_OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER                                 \
 	(conf_debug_ospf6_brouter & OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER)
+
 #define IS_OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER_ID(router_id)                   \
 	(IS_OSPF6_DEBUG_BROUTER_SPECIFIC_ROUTER                                \
 	 && conf_debug_ospf6_brouter_specific_router_id == (router_id))
@@ -43,14 +49,17 @@ extern in_addr_t conf_debug_ospf6_brouter_specific_area_id;
 		conf_debug_ospf6_brouter_specific_area_id = (area_id);         \
 		conf_debug_ospf6_brouter |= OSPF6_DEBUG_BROUTER_SPECIFIC_AREA; \
 	} while (0)
+
 #define OSPF6_DEBUG_BROUTER_SPECIFIC_AREA_OFF()                                \
 	do {                                                                   \
 		conf_debug_ospf6_brouter_specific_area_id = 0;                 \
 		conf_debug_ospf6_brouter &=                                    \
 			~OSPF6_DEBUG_BROUTER_SPECIFIC_AREA;                    \
 	} while (0)
+
 #define IS_OSPF6_DEBUG_BROUTER_SPECIFIC_AREA                                   \
 	(conf_debug_ospf6_brouter & OSPF6_DEBUG_BROUTER_SPECIFIC_AREA)
+
 #define IS_OSPF6_DEBUG_BROUTER_SPECIFIC_AREA_ID(area_id)                       \
 	(IS_OSPF6_DEBUG_BROUTER_SPECIFIC_AREA                                  \
 	 && conf_debug_ospf6_brouter_specific_area_id == (area_id))
@@ -68,10 +77,13 @@ enum stub_router_mode {
 		 : 0)
 #define ROUTER_LSDESC_GET_METRIC(x)                                            \
 	(ntohs(((struct ospf6_router_lsdesc *)(x))->metric))
+
 #define ROUTER_LSDESC_GET_IFID(x)                                              \
 	(ntohl(((struct ospf6_router_lsdesc *)(x))->interface_id))
+
 #define ROUTER_LSDESC_GET_NBR_IFID(x)                                          \
 	(ntohl(((struct ospf6_router_lsdesc *)(x))->neighbor_interface_id))
+
 #define ROUTER_LSDESC_GET_NBR_ROUTERID(x)                                      \
 	(((struct ospf6_router_lsdesc *)(x))->neighbor_router_id)
 
@@ -82,18 +94,21 @@ enum stub_router_mode {
 			event_add_event(master, ospf6_router_lsa_originate,    \
 					oa, 0, &(oa)->thread_router_lsa);      \
 	} while (0)
+
 #define OSPF6_NETWORK_LSA_SCHEDULE(oi)                                         \
 	do {                                                                   \
 		if (!CHECK_FLAG((oi)->flag, OSPF6_INTERFACE_DISABLE))          \
 			event_add_event(master, ospf6_network_lsa_originate,   \
 					oi, 0, &(oi)->thread_network_lsa);     \
 	} while (0)
+
 #define OSPF6_LINK_LSA_SCHEDULE(oi)                                            \
 	do {                                                                   \
 		if (!CHECK_FLAG((oi)->flag, OSPF6_INTERFACE_DISABLE))          \
 			event_add_event(master, ospf6_link_lsa_originate, oi,  \
 					0, &(oi)->thread_link_lsa);            \
 	} while (0)
+
 #define OSPF6_INTRA_PREFIX_LSA_SCHEDULE_STUB(oa)                               \
 	do {                                                                   \
 		if (CHECK_FLAG((oa)->flag, OSPF6_AREA_ENABLE))                 \
@@ -101,6 +116,7 @@ enum stub_router_mode {
 				master, ospf6_intra_prefix_lsa_originate_stub, \
 				oa, 0, &(oa)->thread_intra_prefix_lsa);        \
 	} while (0)
+
 #define OSPF6_INTRA_PREFIX_LSA_SCHEDULE_TRANSIT(oi)                            \
 	do {                                                                   \
 		if (!CHECK_FLAG((oi)->flag, OSPF6_INTERFACE_DISABLE))          \

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -65,7 +65,7 @@ static int ospf6_unknown_lsa_show(struct vty *vty, struct ospf6_lsa *lsa,
 {
 	char *start, *end, *current;
 
-	start = ospf6_lsa_header_end(lsa->header);
+	start = lsa_after_header(lsa->header);
 	end = ospf6_lsa_end(lsa->header);
 
 	if (use_json) {
@@ -234,8 +234,8 @@ int ospf6_lsa_is_changed(struct ospf6_lsa *lsa1, struct ospf6_lsa *lsa2)
 	if (length <= 0)
 		return 0;
 
-	return memcmp(ospf6_lsa_header_end(lsa1->header),
-		      ospf6_lsa_header_end(lsa2->header), length);
+	return memcmp(lsa_after_header(lsa1->header),
+		      lsa_after_header(lsa2->header), length);
 }
 
 /* ospf6 age functions */

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -92,6 +92,30 @@ void *nth_lsdesc(struct ospf6_lsa_header *header, int pos)
 	return NULL;
 }
 
+void *nth_prefix(struct ospf6_lsa_header *header, int pos)
+{
+	struct ospf6_prefix *prefix = lsdesc_start(header);
+	char *end = ospf6_lsa_end(header);
+	int i = 0;
+
+	if (ntohs(header->type) != OSPF6_LSTYPE_LINK &&
+	    ntohs(header->type) != OSPF6_LSTYPE_INTRA_PREFIX)
+		return NULL;
+
+	if (pos == 0)
+		return prefix;
+
+	while ((char *)prefix < end &&
+	       (char *)prefix + OSPF6_PREFIX_SIZE(prefix) <= end) {
+		if (i == pos)
+			return prefix;
+		i++;
+		prefix = OSPF6_PREFIX_NEXT(prefix);
+	}
+
+	return NULL;
+}
+
 struct ospf6 *ospf6_get_by_lsdb(struct ospf6_lsa *lsa)
 {
 	struct ospf6 *ospf6 = NULL;

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -70,6 +70,28 @@ void *lsdesc_start(struct ospf6_lsa_header *header)
 
 static struct ospf6_lsa_handler *lsa_handlers[OSPF6_LSTYPE_SIZE];
 
+void *nth_lsdesc(struct ospf6_lsa_header *header, int pos)
+{
+	char *lsdesc = lsdesc_start(header);
+	char *lsa_end = ospf6_lsa_end(header);
+	char *nth;
+	int lsdesc_size;
+
+	if (ntohs(header->type) == OSPF6_LSTYPE_ROUTER)
+		lsdesc_size = OSPF6_ROUTER_LSDESC_FIX_SIZE;
+	else if (ntohs(header->type) == OSPF6_LSTYPE_NETWORK)
+		lsdesc_size = OSPF6_NETWORK_LSDESC_FIX_SIZE;
+	else
+		return NULL;
+
+	nth = lsdesc + (pos * lsdesc_size);
+
+	if (nth + lsdesc_size <= lsa_end)
+		return nth;
+
+	return NULL;
+}
+
 struct ospf6 *ospf6_get_by_lsdb(struct ospf6_lsa *lsa)
 {
 	struct ospf6 *ospf6 = NULL;

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -92,6 +92,11 @@ static inline char *ospf6_lsa_header_end(struct ospf6_lsa_header *header)
 	return (char *)header + sizeof(struct ospf6_lsa_header);
 }
 
+static inline void *lsa_after_header(struct ospf6_lsa_header *header)
+{
+	return (char *)header + sizeof(struct ospf6_lsa_header);
+}
+
 static inline char *ospf6_lsa_end(struct ospf6_lsa_header *header)
 {
 	return (char *)header + ntohs(header->length);

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -88,7 +88,6 @@ struct ospf6_lsa_header {
 };
 
 
-
 static inline char *ospf6_lsa_header_end(struct ospf6_lsa_header *header)
 {
 	return (char *)header + sizeof(struct ospf6_lsa_header);
@@ -124,7 +123,7 @@ static inline uint16_t ospf6_lsa_size(struct ospf6_lsa_header *header)
 #define OSPF6_LSA_IS_SEQWRAP(L) ((L)->header->seqnum == htonl(OSPF_MAX_SEQUENCE_NUMBER + 1))
 
 /* Router-LSA */
-#define OSPF6_ROUTER_LSA_MIN_SIZE              4U
+#define OSPF6_ROUTER_LSA_MIN_SIZE 4U
 struct ospf6_router_lsa {
 	uint8_t bits;
 	uint8_t options[3];
@@ -132,7 +131,7 @@ struct ospf6_router_lsa {
 };
 
 /* Link State Description in Router-LSA */
-#define OSPF6_ROUTER_LSDESC_FIX_SIZE          16U
+#define OSPF6_ROUTER_LSDESC_FIX_SIZE 16U
 struct ospf6_router_lsdesc {
 	uint8_t type;
 	uint8_t reserved;
@@ -142,13 +141,13 @@ struct ospf6_router_lsdesc {
 	in_addr_t neighbor_router_id;
 };
 
-#define OSPF6_ROUTER_LSDESC_POINTTOPOINT       1
-#define OSPF6_ROUTER_LSDESC_TRANSIT_NETWORK    2
-#define OSPF6_ROUTER_LSDESC_STUB_NETWORK       3
-#define OSPF6_ROUTER_LSDESC_VIRTUAL_LINK       4
+#define OSPF6_ROUTER_LSDESC_POINTTOPOINT    1
+#define OSPF6_ROUTER_LSDESC_TRANSIT_NETWORK 2
+#define OSPF6_ROUTER_LSDESC_STUB_NETWORK    3
+#define OSPF6_ROUTER_LSDESC_VIRTUAL_LINK    4
 
 /* Network-LSA */
-#define OSPF6_NETWORK_LSA_MIN_SIZE             4U
+#define OSPF6_NETWORK_LSA_MIN_SIZE 4U
 struct ospf6_network_lsa {
 	uint8_t reserved;
 	uint8_t options[3];
@@ -156,7 +155,7 @@ struct ospf6_network_lsa {
 };
 
 /* Link State Description in Network-LSA */
-#define OSPF6_NETWORK_LSDESC_FIX_SIZE          4U
+#define OSPF6_NETWORK_LSDESC_FIX_SIZE 4U
 struct ospf6_network_lsdesc {
 	in_addr_t router_id;
 };
@@ -164,14 +163,14 @@ struct ospf6_network_lsdesc {
 	(((struct ospf6_network_lsdesc *)(x))->router_id)
 
 /* Inter-Area-Prefix-LSA */
-#define OSPF6_INTER_PREFIX_LSA_MIN_SIZE        4U /* w/o IPv6 prefix */
+#define OSPF6_INTER_PREFIX_LSA_MIN_SIZE 4U /* w/o IPv6 prefix */
 struct ospf6_inter_prefix_lsa {
 	uint32_t metric;
 	struct ospf6_prefix prefix;
 };
 
 /* Inter-Area-Router-LSA */
-#define OSPF6_INTER_ROUTER_LSA_FIX_SIZE       12U
+#define OSPF6_INTER_ROUTER_LSA_FIX_SIZE 12U
 struct ospf6_inter_router_lsa {
 	uint8_t mbz;
 	uint8_t options[3];
@@ -180,7 +179,7 @@ struct ospf6_inter_router_lsa {
 };
 
 /* AS-External-LSA */
-#define OSPF6_AS_EXTERNAL_LSA_MIN_SIZE         4U /* w/o IPv6 prefix */
+#define OSPF6_AS_EXTERNAL_LSA_MIN_SIZE 4U /* w/o IPv6 prefix */
 struct ospf6_as_external_lsa {
 	uint32_t bits_metric;
 
@@ -193,7 +192,7 @@ struct ospf6_as_external_lsa {
 /* FIXME: move nssa lsa here. */
 
 /* Link-LSA */
-#define OSPF6_LINK_LSA_MIN_SIZE               24U /* w/o 1st IPv6 prefix */
+#define OSPF6_LINK_LSA_MIN_SIZE 24U /* w/o 1st IPv6 prefix */
 struct ospf6_link_lsa {
 	uint8_t priority;
 	uint8_t options[3];
@@ -203,7 +202,7 @@ struct ospf6_link_lsa {
 };
 
 /* Intra-Area-Prefix-LSA */
-#define OSPF6_INTRA_PREFIX_LSA_MIN_SIZE       12U /* w/o 1st IPv6 prefix */
+#define OSPF6_INTRA_PREFIX_LSA_MIN_SIZE 12U /* w/o 1st IPv6 prefix */
 struct ospf6_intra_prefix_lsa {
 	uint16_t prefix_num;
 	uint16_t ref_type;

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -374,4 +374,6 @@ struct ospf6_lsa *ospf6_find_external_lsa(struct ospf6 *ospf6,
 void *lsdesc_start_lsa_type(struct ospf6_lsa_header *header, int lsa_type);
 void *lsdesc_start(struct ospf6_lsa_header *header);
 
+void *nth_lsdesc(struct ospf6_lsa_header *header, int pos);
+
 #endif /* OSPF6_LSA_H */

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -87,6 +87,8 @@ struct ospf6_lsa_header {
 	uint16_t length;     /* LSA length */
 };
 
+
+
 static inline char *ospf6_lsa_header_end(struct ospf6_lsa_header *header)
 {
 	return (char *)header + sizeof(struct ospf6_lsa_header);
@@ -120,7 +122,6 @@ static inline uint16_t ospf6_lsa_size(struct ospf6_lsa_header *header)
 #define OSPF6_LSA_IS_MAXAGE(L) (ospf6_lsa_age_current (L) == OSPF_LSA_MAXAGE)
 #define OSPF6_LSA_IS_CHANGED(L1, L2) ospf6_lsa_is_changed (L1, L2)
 #define OSPF6_LSA_IS_SEQWRAP(L) ((L)->header->seqnum == htonl(OSPF_MAX_SEQUENCE_NUMBER + 1))
-
 
 /* Router-LSA */
 #define OSPF6_ROUTER_LSA_MIN_SIZE              4U
@@ -369,4 +370,8 @@ extern void ospf6_flush_self_originated_lsas_now(struct ospf6 *ospf6);
 extern struct ospf6 *ospf6_get_by_lsdb(struct ospf6_lsa *lsa);
 struct ospf6_lsa *ospf6_find_external_lsa(struct ospf6 *ospf6,
 					  struct prefix *p);
+
+void *lsdesc_start_lsa_type(struct ospf6_lsa_header *header, int lsa_type);
+void *lsdesc_start(struct ospf6_lsa_header *header);
+
 #endif /* OSPF6_LSA_H */

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -240,6 +240,7 @@ struct ospf6_lsa {
 	bool tobe_acknowledged;
 };
 
+
 #define OSPF6_LSA_HEADERONLY 0x01
 #define OSPF6_LSA_FLOODBACK  0x02
 #define OSPF6_LSA_DUPLICATE  0x04

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -375,5 +375,6 @@ void *lsdesc_start_lsa_type(struct ospf6_lsa_header *header, int lsa_type);
 void *lsdesc_start(struct ospf6_lsa_header *header);
 
 void *nth_lsdesc(struct ospf6_lsa_header *header, int pos);
+void *nth_prefix(struct ospf6_lsa_header *header, int pos);
 
 #endif /* OSPF6_LSA_H */

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -117,6 +117,95 @@ static inline uint16_t ospf6_lsa_size(struct ospf6_lsa_header *header)
 #define OSPF6_LSA_IS_SEQWRAP(L) ((L)->header->seqnum == htonl(OSPF_MAX_SEQUENCE_NUMBER + 1))
 
 
+/* Router-LSA */
+#define OSPF6_ROUTER_LSA_MIN_SIZE              4U
+struct ospf6_router_lsa {
+	uint8_t bits;
+	uint8_t options[3];
+	/* followed by ospf6_router_lsdesc(s) */
+};
+
+/* Link State Description in Router-LSA */
+#define OSPF6_ROUTER_LSDESC_FIX_SIZE          16U
+struct ospf6_router_lsdesc {
+	uint8_t type;
+	uint8_t reserved;
+	uint16_t metric; /* output cost */
+	uint32_t interface_id;
+	uint32_t neighbor_interface_id;
+	in_addr_t neighbor_router_id;
+};
+
+#define OSPF6_ROUTER_LSDESC_POINTTOPOINT       1
+#define OSPF6_ROUTER_LSDESC_TRANSIT_NETWORK    2
+#define OSPF6_ROUTER_LSDESC_STUB_NETWORK       3
+#define OSPF6_ROUTER_LSDESC_VIRTUAL_LINK       4
+
+/* Network-LSA */
+#define OSPF6_NETWORK_LSA_MIN_SIZE             4U
+struct ospf6_network_lsa {
+	uint8_t reserved;
+	uint8_t options[3];
+	/* followed by ospf6_network_lsdesc(s) */
+};
+
+/* Link State Description in Network-LSA */
+#define OSPF6_NETWORK_LSDESC_FIX_SIZE          4U
+struct ospf6_network_lsdesc {
+	in_addr_t router_id;
+};
+#define NETWORK_LSDESC_GET_NBR_ROUTERID(x)                                     \
+	(((struct ospf6_network_lsdesc *)(x))->router_id)
+
+/* Inter-Area-Prefix-LSA */
+#define OSPF6_INTER_PREFIX_LSA_MIN_SIZE        4U /* w/o IPv6 prefix */
+struct ospf6_inter_prefix_lsa {
+	uint32_t metric;
+	struct ospf6_prefix prefix;
+};
+
+/* Inter-Area-Router-LSA */
+#define OSPF6_INTER_ROUTER_LSA_FIX_SIZE       12U
+struct ospf6_inter_router_lsa {
+	uint8_t mbz;
+	uint8_t options[3];
+	uint32_t metric;
+	uint32_t router_id;
+};
+
+/* AS-External-LSA */
+#define OSPF6_AS_EXTERNAL_LSA_MIN_SIZE         4U /* w/o IPv6 prefix */
+struct ospf6_as_external_lsa {
+	uint32_t bits_metric;
+
+	struct ospf6_prefix prefix;
+	/* followed by none or one forwarding address */
+	/* followed by none or one external route tag */
+	/* followed by none or one referenced LS-ID */
+};
+
+/* FIXME: move nssa lsa here. */
+
+/* Link-LSA */
+#define OSPF6_LINK_LSA_MIN_SIZE               24U /* w/o 1st IPv6 prefix */
+struct ospf6_link_lsa {
+	uint8_t priority;
+	uint8_t options[3];
+	struct in6_addr linklocal_addr;
+	uint32_t prefix_num;
+	/* followed by ospf6 prefix(es) */
+};
+
+/* Intra-Area-Prefix-LSA */
+#define OSPF6_INTRA_PREFIX_LSA_MIN_SIZE       12U /* w/o 1st IPv6 prefix */
+struct ospf6_intra_prefix_lsa {
+	uint16_t prefix_num;
+	uint16_t ref_type;
+	uint32_t ref_id;
+	in_addr_t ref_adv_router;
+	/* followed by ospf6 prefix(es) */
+};
+
 struct ospf6_lsa {
 	char name[64]; /* dump string */
 

--- a/ospf6d/ospf6_lsdb.c
+++ b/ospf6d/ospf6_lsdb.c
@@ -229,8 +229,7 @@ struct ospf6_lsa *ospf6_find_inter_prefix_lsa(struct ospf6 *ospf6,
 		struct ospf6_inter_prefix_lsa *prefix_lsa;
 		struct prefix prefix;
 
-		prefix_lsa = (struct ospf6_inter_prefix_lsa *)
-			ospf6_lsa_header_end(lsa->header);
+		prefix_lsa = lsa_after_header(lsa->header);
 		prefix.family = AF_INET6;
 		prefix.prefixlen = prefix_lsa->prefix.prefix_length;
 		ospf6_prefix_in6_addr(&prefix.u.prefix6, prefix_lsa,

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -33,6 +33,7 @@
 
 #include "ospf6_flood.h"
 #include "ospf6d.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include <netinet/ip6.h>
 #include "lib/libospf.h"

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -1304,9 +1304,7 @@ static unsigned ospf6_lsa_examin(struct ospf6_lsa_header *lsah,
 		   4 bytes of referenced link state ID. */
 		if (headeronly)
 			break;
-		as_external_lsa =
-			(struct ospf6_as_external_lsa
-				 *)((caddr_t)lsah + OSPF6_LSA_HEADER_SIZE);
+		as_external_lsa = lsa_after_header(lsah);
 		exp_length =
 			OSPF6_LSA_HEADER_SIZE + OSPF6_AS_EXTERNAL_LSA_MIN_SIZE;
 		/* To find out if the last optional field (Referenced Link State
@@ -1351,8 +1349,7 @@ static unsigned ospf6_lsa_examin(struct ospf6_lsa_header *lsah,
 		   by N>=0 IPv6 prefix blocks (with N declared beforehand). */
 		if (headeronly)
 			break;
-		link_lsa = (struct ospf6_link_lsa *)((caddr_t)lsah
-						     + OSPF6_LSA_HEADER_SIZE);
+		link_lsa = lsa_after_header(lsah);
 		return ospf6_prefixes_examin(
 			(struct ospf6_prefix *)((caddr_t)link_lsa
 						+ OSPF6_LINK_LSA_MIN_SIZE),
@@ -1367,9 +1364,7 @@ static unsigned ospf6_lsa_examin(struct ospf6_lsa_header *lsah,
 		   */
 		if (headeronly)
 			break;
-		intra_prefix_lsa =
-			(struct ospf6_intra_prefix_lsa
-				 *)((caddr_t)lsah + OSPF6_LSA_HEADER_SIZE);
+		intra_prefix_lsa = lsa_after_header(lsah);
 		return ospf6_prefixes_examin(
 			(struct ospf6_prefix
 				 *)((caddr_t)intra_prefix_lsa

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -30,6 +30,7 @@
 #include "ospf6_lsa.h"
 #include "ospf6_spf.h"
 #include "ospf6_zebra.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
 

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -52,8 +52,7 @@ static int ospf6_abr_nssa_am_elected(struct ospf6_area *oa)
 
 	/* Verify all the router LSA to compare the router ID */
 	for (ALL_LSDB_TYPED(oa->lsdb, type, lsa)) {
-		router_lsa = (struct ospf6_router_lsa *)ospf6_lsa_header_end(
-			lsa->header);
+		router_lsa = lsa_after_header(lsa->header);
 
 		/* ignore non-ABR routers */
 		if (!CHECK_FLAG(router_lsa->bits, OSPF6_ROUTER_BIT_B))
@@ -414,8 +413,7 @@ static struct ospf6_lsa *ospf6_lsa_translated_nssa_new(struct ospf6_area *area,
 	}
 
 	/* find the translated Type-5 for this Type-7 */
-	nssa = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-		type7->header);
+	nssa = lsa_after_header(type7->header);
 	prefix.family = AF_INET6;
 	prefix.prefixlen = nssa->prefix.prefix_length;
 	ospf6_prefix_in6_addr(&prefix.u.prefix6, nssa, &nssa->prefix);
@@ -435,10 +433,8 @@ static struct ospf6_lsa *ospf6_lsa_translated_nssa_new(struct ospf6_area *area,
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	extnew = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-		lsa_header);
-	ext = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-		type7->header);
+	extnew = lsa_after_header(lsa_header);
+	ext = lsa_after_header(type7->header);
 	old_ptr =
 		(caddr_t)((caddr_t)ext + sizeof(struct ospf6_as_external_lsa));
 	new_ptr = (caddr_t)((caddr_t)extnew
@@ -546,8 +542,7 @@ struct ospf6_lsa *ospf6_translated_nssa_refresh(struct ospf6_area *area,
 				"%s: try to find translated Type-5 LSA for %s",
 				__func__, type7->name);
 
-		ext_lsa = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-			type7->header);
+		ext_lsa = lsa_after_header(type7->header);
 		prefix.family = AF_INET6;
 		prefix.prefixlen = ext_lsa->prefix.prefix_length;
 		ospf6_prefix_in6_addr(&prefix.u.prefix6, ext_lsa,
@@ -614,8 +609,7 @@ static void ospf6_abr_translate_nssa(struct ospf6_area *area,
 	struct ospf6 *ospf6;
 
 	ospf6 = area->ospf6;
-	nssa_lsa = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-		lsa->header);
+	nssa_lsa = lsa_after_header(lsa->header);
 
 	if (!CHECK_FLAG(nssa_lsa->prefix.prefix_options,
 			OSPF6_PREFIX_OPTION_P)) {
@@ -1240,8 +1234,7 @@ void ospf6_nssa_lsa_originate(struct ospf6_route *route,
 	/* prepare buffer */
 	memset(buffer, 0, sizeof(buffer));
 	lsa_header = (struct ospf6_lsa_header *)buffer;
-	as_external_lsa = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-		lsa_header);
+	as_external_lsa = lsa_after_header(lsa_header);
 	p = (caddr_t)((caddr_t)as_external_lsa
 		      + sizeof(struct ospf6_as_external_lsa));
 

--- a/ospf6d/ospf6_proto.h
+++ b/ospf6d/ospf6_proto.h
@@ -16,11 +16,12 @@
 #define ALLSPFROUTERS6 "ff02::5"
 #define ALLDROUTERS6   "ff02::6"
 
-#define OSPF6_ROUTER_BIT_W     (1 << 3)
+/* RFC 5340 A.4.3 Router-LSAs Options field */
+#define OSPF6_ROUTER_BIT_NT    (1 << 4)
+#define OSPF6_ROUTER_BIT_W     (1 << 3) /* DEPRECATED */
 #define OSPF6_ROUTER_BIT_V     (1 << 2)
 #define OSPF6_ROUTER_BIT_E     (1 << 1)
 #define OSPF6_ROUTER_BIT_B     (1 << 0)
-#define OSPF6_ROUTER_BIT_NT    (1 << 4)
 
 
 /* OSPF options */

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -16,11 +16,11 @@
 #include "frrevent.h"
 #include "lib_errors.h"
 
+#include "ospf6_proto.h"
 #include "ospf6_lsa.h"
 #include "ospf6_lsdb.h"
 #include "ospf6_route.h"
 #include "ospf6_area.h"
-#include "ospf6_proto.h"
 #include "ospf6_abr.h"
 #include "ospf6_asbr.h"
 #include "ospf6_spf.h"

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -290,8 +290,7 @@ static void ospf6_nexthop_calc(struct ospf6_vertex *w, struct ospf6_vertex *v,
 			       != lsa->header->id)
 			continue;
 
-		link_lsa = (struct ospf6_link_lsa *)ospf6_lsa_header_end(
-			lsa->header);
+		link_lsa = lsa_after_header(lsa->header);
 		if (IS_OSPF6_DEBUG_SPF(PROCESS)) {
 			inet_ntop(AF_INET6, &link_lsa->linklocal_addr, buf,
 				  sizeof(buf));
@@ -1136,8 +1135,7 @@ int ospf6_ase_calculate_route(struct ospf6 *ospf6, struct ospf6_lsa *lsa,
 		return 0;
 	}
 
-	external = (struct ospf6_as_external_lsa *)ospf6_lsa_header_end(
-		lsa->header);
+	external = lsa_after_header(lsa->header);
 	prefix.family = AF_INET6;
 	prefix.prefixlen = external->prefix.prefix_length;
 	ospf6_prefix_in6_addr(&prefix.u.prefix6, external, &external->prefix);

--- a/ospf6d/ospf6_tlv.h
+++ b/ospf6d/ospf6_tlv.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * OSPFv3 Type Length Value.
+ *
+ */
+
+#ifndef OSPF6_TLV_H
+#define OSPF6_TLV_H
+
+/*
+ * Generic TLV (type, length, value) macros
+ */
+struct tlv_header {
+	uint16_t type;	 /* Type of Value */
+	uint16_t length; /* Length of Value portion only, in bytes */
+};
+
+#ifdef roundup
+#define ROUNDUP(val, gran) roundup(val, gran)
+#else /* roundup */
+#define ROUNDUP(val, gran) (((val)-1 | (gran)-1) + 1)
+#endif /* roundup */
+
+#define TLV_HDR_SIZE (sizeof(struct tlv_header))
+
+#define TLV_BODY_SIZE(tlvh) (ROUNDUP(ntohs((tlvh)->length), sizeof(uint32_t)))
+
+#define TLV_SIZE(tlvh) ((uint32_t)(TLV_HDR_SIZE + TLV_BODY_SIZE(tlvh)))
+
+#define TLV_HDR_TOP(lsah)                                                      \
+	((struct tlv_header *)((char *)(lsah) + OSPF6_LSA_HEADER_SIZE))
+
+#define TLV_HDR_NEXT(tlvh)                                                     \
+	((struct tlv_header *)((char *)(tlvh) + TLV_SIZE(tlvh)))
+
+/*
+ * RFC 5187 - OSPFv3 Graceful Restart - Grace-LSA
+ * Graceful restart predates Extended-LSA TLVs and IANA TLV register.
+ */
+/* Grace period TLV. */
+#define TLV_GRACE_PERIOD_TYPE 1
+#define TLV_GRACE_PERIOD_LENGTH 4
+struct tlv_grace_period {
+	struct tlv_header header;
+	uint32_t interval;
+};
+
+/* Restart reason TLV. */
+#define TLV_GRACE_RESTART_REASON_TYPE 2
+#define TLV_GRACE_RESTART_REASON_LENGTH 1
+struct tlv_grace_restart_reason {
+	struct tlv_header header;
+	uint8_t reason;
+	uint8_t reserved[3];
+};
+
+
+#endif /* OSPF6_TLV_H */

--- a/ospf6d/ospf6_tlv.h
+++ b/ospf6d/ospf6_tlv.h
@@ -27,9 +27,6 @@ struct tlv_header {
 
 #define TLV_SIZE(tlvh) ((uint32_t)(TLV_HDR_SIZE + TLV_BODY_SIZE(tlvh)))
 
-#define TLV_HDR_TOP(lsah)                                                      \
-	((struct tlv_header *)((char *)(lsah) + OSPF6_LSA_HEADER_SIZE))
-
 #define TLV_HDR_NEXT(tlvh)                                                     \
 	((struct tlv_header *)((char *)(tlvh) + TLV_SIZE(tlvh)))
 

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -37,6 +37,7 @@
 #include "ospf6_intra.h"
 #include "ospf6_spf.h"
 #include "ospf6d.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
 #include "ospf6_nssa.h"

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -27,6 +27,7 @@
 #include "ospf6_zebra.h"
 #include "ospf6d.h"
 #include "ospf6_area.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
 

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -30,6 +30,7 @@
 #include "ospf6_flood.h"
 #include "ospf6d.h"
 #include "ospf6_bfd.h"
+#include "ospf6_tlv.h"
 #include "ospf6_gr.h"
 #include "lib/json.h"
 #include "ospf6_nssa.h"

--- a/ospf6d/subdir.am
+++ b/ospf6d/subdir.am
@@ -58,6 +58,7 @@ noinst_HEADERS += \
 	ospf6d/ospf6_route.h \
 	ospf6d/ospf6_routemap_nb.h \
 	ospf6d/ospf6_spf.h \
+	ospf6d/ospf6_tlv.h \
 	ospf6d/ospf6_top.h \
 	ospf6d/ospf6_zebra.h \
 	ospf6d/ospf6d.h \

--- a/tests/ospf6d/test_lsdb.c
+++ b/tests/ospf6d/test_lsdb.c
@@ -12,6 +12,7 @@
 #include "vector.h"
 #include "vty.h"
 
+#include "ospf6d/ospf6_proto.h" /* for struct ospf6_prefix */
 #include "ospf6d/ospf6_lsa.h"
 #include "ospf6d/ospf6_lsdb.h"
 


### PR DESCRIPTION
This PR contains what I hope would be the less controversial bits of the Work In Progress on PR #16532.

It refactors the ospf6d implementation in order to
* enable future use of the existing TLV handling when E-LSAs are added
* cleanup some pointer casts and pointer arithmetic to improve readability