### PR TITLE
doc: Document on how to start specific daemons with unified config in topotests

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -1332,6 +1332,15 @@ Example:
            router.load_config(TopoRouter.RD_ZEBRA, "zebra.conf")
            router.load_config(TopoRouter.RD_OSPF)
 
+or using unified config (specifying which daemons to run is optional):
+
+.. code:: py
+
+      for _, (rname, router) in enumerate(router_list.items(), 1):
+         router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)), [
+            TopoRouter.RD_ZEBRA
+            TopoRouter.RD_MGMTD,
+            TopoRouter.RD_BGP])
 
 - The topology definition or build function
 

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1430,7 +1430,7 @@ class Router(Node):
         self.daemondir = None
         self.hasmpls = False
         self.routertype = "frr"
-        self.unified_config = None
+        self.unified_config = False
         self.daemons = {
             "zebra": 0,
             "ripd": 0,
@@ -1653,7 +1653,7 @@ class Router(Node):
         # print "Daemons before:", self.daemons
         if daemon in self.daemons.keys() or daemon == "frr":
             if daemon == "frr":
-                self.unified_config = 1
+                self.unified_config = True
             else:
                 self.daemons[daemon] = 1
             if param is not None:


### PR DESCRIPTION
E.g.:

```
for _, (rname, router) in enumerate(router_list.items(), 1):
    router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
```