### PR TITLE
lib: add seg6localContext json attribute in nexthop information

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -1166,6 +1166,7 @@ void nexthop_json_helper(json_object *json_nexthop,
 	json_object *json_labels = NULL;
 	json_object *json_backups = NULL;
 	json_object *json_seg6local = NULL;
+	json_object *json_seg6local_context = NULL;
 	json_object *json_seg6 = NULL;
 	json_object *json_segs = NULL;
 	int i;
@@ -1331,8 +1332,16 @@ void nexthop_json_helper(json_object *json_nexthop,
 				       seg6local_action2str(
 					       nexthop->nh_srv6
 						       ->seg6local_action));
+		json_seg6local_context = json_object_new_object();
 		json_object_object_add(json_nexthop, "seg6local",
 				       json_seg6local);
+
+		seg6local_context2json(&nexthop->nh_srv6->seg6local_ctx,
+				       nexthop->nh_srv6->seg6local_action,
+				       json_seg6local_context);
+		json_object_object_add(json_nexthop, "seg6localContext",
+				       json_seg6local_context);
+
 		if (nexthop->nh_srv6->seg6_segs &&
 		    nexthop->nh_srv6->seg6_segs->num_segs == 1) {
 			json_seg6 = json_object_new_object();

--- a/lib/srv6.c
+++ b/lib/srv6.c
@@ -71,6 +71,44 @@ int snprintf_seg6_segs(char *str,
 	return strlen(str);
 }
 
+void seg6local_context2json(const struct seg6local_context *ctx,
+			    uint32_t action, json_object *json)
+{
+	switch (action) {
+	case ZEBRA_SEG6_LOCAL_ACTION_END:
+		json_object_boolean_add(json, "USP", true);
+		return;
+	case ZEBRA_SEG6_LOCAL_ACTION_END_X:
+	case ZEBRA_SEG6_LOCAL_ACTION_END_DX6:
+		json_object_string_addf(json, "nh6", "%pI6", &ctx->nh6);
+		return;
+	case ZEBRA_SEG6_LOCAL_ACTION_END_DX4:
+		json_object_string_addf(json, "nh4", "%pI4", &ctx->nh4);
+		return;
+	case ZEBRA_SEG6_LOCAL_ACTION_END_T:
+	case ZEBRA_SEG6_LOCAL_ACTION_END_DT6:
+	case ZEBRA_SEG6_LOCAL_ACTION_END_DT4:
+	case ZEBRA_SEG6_LOCAL_ACTION_END_DT46:
+		json_object_int_add(json, "table", ctx->table);
+		return;
+	case ZEBRA_SEG6_LOCAL_ACTION_END_DX2:
+		json_object_boolean_add(json, "none", true);
+		return;
+	case ZEBRA_SEG6_LOCAL_ACTION_END_B6:
+	case ZEBRA_SEG6_LOCAL_ACTION_END_B6_ENCAP:
+		json_object_string_addf(json, "nh6", "%pI6", &ctx->nh6);
+		return;
+	case ZEBRA_SEG6_LOCAL_ACTION_END_BM:
+	case ZEBRA_SEG6_LOCAL_ACTION_END_S:
+	case ZEBRA_SEG6_LOCAL_ACTION_END_AS:
+	case ZEBRA_SEG6_LOCAL_ACTION_END_AM:
+	case ZEBRA_SEG6_LOCAL_ACTION_UNSPEC:
+	default:
+		json_object_boolean_add(json, "unknown", true);
+		return;
+	}
+}
+
 const char *seg6local_context2str(char *str, size_t size,
 				  const struct seg6local_context *ctx,
 				  uint32_t action)

--- a/lib/srv6.h
+++ b/lib/srv6.h
@@ -319,6 +319,8 @@ seg6local_action2str(uint32_t action);
 const char *seg6local_context2str(char *str, size_t size,
 				  const struct seg6local_context *ctx,
 				  uint32_t action);
+void seg6local_context2json(const struct seg6local_context *ctx,
+			    uint32_t action, json_object *json);
 
 static inline const char *srv6_sid_ctx2str(char *str, size_t size,
 					   const struct srv6_sid_ctx *ctx)


### PR DESCRIPTION
Some srv6 behaviors have a context attached that is visible if no json is requested:

> # show ipv6 route
> [..]
> B>* 2001:db8:1:1:100::/128 [20/0] is directly connected, vrf10, seg6local End.DT6 table 10, weight 1, 00:00:14
> B>* 2001:db8:1:1:200::/128 [20/0] is directly connected, vrf20, seg6local End.DT6 table 20, weight 1, 00:00:14
>

The json does not dump this attribute:
> # show ipv6 route 2001:db8:1:1:100::/128 json
> [..]
>      "nexthops":[
>        {
>          "flags":3,
>          "fib":true,
>          "directlyConnected":true,
>          "interfaceIndex":6,
>          "interfaceName":"vrf10",
>          "active":true,
>          "weight":1,
>          "seg6local":{
>            "action":"End.DT6"
>          },
>        }
>

Add the json support for this.

>      "nexthops":[
>        {
>          "flags":3,
>          "fib":true,
>          "directlyConnected":true,
>          "interfaceIndex":6,
>          "interfaceName":"vrf10",
>          "active":true,
>          "weight":1,
>          "seg6local":{
>            "action":"End.DT6"
>          },
>          "seg6localContext":{
>            "table":10
>          }
>        }
>