### PR TITLE
lib: Don't print warning if not a daemon

### DIFF
--- a/lib/event.c
+++ b/lib/event.c
@@ -555,8 +555,9 @@ struct event_loop *event_master_create(const char *name)
 	}
 
 	if (rv->fd_limit > STUPIDLY_LARGE_FD_SIZE) {
-		zlog_warn("FD Limit set: %u is stupidly large.  Is this what you intended?  Consider using --limit-fds also limiting size to %u",
-			  rv->fd_limit, STUPIDLY_LARGE_FD_SIZE);
+		if (frr_is_daemon())
+			zlog_warn("FD Limit set: %u is stupidly large.  Is this what you intended?  Consider using --limit-fds also limiting size to %u",
+				  rv->fd_limit, STUPIDLY_LARGE_FD_SIZE);
 
 		rv->fd_limit = STUPIDLY_LARGE_FD_SIZE;
 	}

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -1474,3 +1474,11 @@ const char *frr_vers2str(uint32_t version, char *buf, int buflen)
 
 	return buf;
 }
+
+bool frr_is_daemon(void)
+{
+	if (di)
+		return true;
+
+	return false;
+}

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -190,7 +190,7 @@ extern const char *frr_get_progname(void);
 extern enum frr_cli_mode frr_get_cli_mode(void);
 extern uint32_t frr_get_fd_limit(void);
 extern bool frr_is_startup_fd(int fd);
-
+extern bool frr_is_daemon(void);
 /* call order of these hooks is as ordered here */
 DECLARE_HOOK(frr_early_init, (struct event_loop * tm), (tm));
 DECLARE_HOOK(frr_late_init, (struct event_loop * tm), (tm));


### PR DESCRIPTION
vtysh will print out the `stupidly large FD limit` upon every run of the program if the ulimit is set stupidly large.  Prevent this from being displayed for vtysh.

Fixes: #16516