### PR TITLE
zebra: Ensure non-equal id's are not same nhg's

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -525,9 +525,18 @@ bool zebra_nhg_hash_equal(const void *arg1, const void *arg2)
 	struct nexthop *nexthop1;
 	struct nexthop *nexthop2;
 
-	/* No matter what if they equal IDs, assume equal */
-	if (nhe1->id && nhe2->id && (nhe1->id == nhe2->id))
-		return true;
+	/* If both NHG's have id's then we can just know that
+	 * they are either identical or not.  This comparison
+	 * is only ever used for hash equality.  NHE's id
+	 * is sufficient to distinguish them.  This is especially
+	 * true if NHG's are owned by an upper level protocol.
+	 */
+	if (nhe1->id && nhe2->id) {
+		if (nhe1->id == nhe2->id)
+			return true;
+
+		return false;
+	}
 
 	if (nhe1->type != nhe2->type)
 		return false;


### PR DESCRIPTION
The function zebra_nhg_hash_equal is only used
as a hash function for storage of NHG's and retrieval. If you have say two nhg's:

31 (25/26)
32 (25/26)

This function would return them as being equal.  Which of course leads to the problem when you attempt to hash_release 32 but release 31 from the hash.  Then later when you attempt to do hash comparisons 32 has actually been freed leaving to use after free situations and shit goes down hill fast.

This hash is only used as part of the hash comparison function for nexthop group storage.  Since this is so let's always return the 31/32 nhg's are not equal at all.

We possibly have a different problem where we are creating 31 and 32 ( when 31 should have just been used instead of 32 ) but we need to prevent any type of hash release problem at all. This supercedes any other issue( that should be tracked down on it's own ).  Since you can have use after free situation that leads to a crash -vs- some possible nexthop group duplication which is very minor in comparison.