### PR TITLE
lib: Fix memory leak in snmp on shutdown

### DIFF
--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -377,9 +377,16 @@ void smux_events_update(void)
 	agentx_events_update();
 }
 
+static void smux_events_delete_thread(void *arg)
+{
+	XFREE(MTYPE_TMP, arg);
+}
+
 void smux_terminate(void)
 {
-	if (events)
+	if (events) {
+		events->del = smux_events_delete_thread;
 		list_delete(&events);
+	}
 }
 #endif /* SNMP_AGENTX */


### PR DESCRIPTION
The events list is storing a `struct event *` allocated as a MTYPE_TMP pointer, on shutdown ensure that it is properly free'd up.