### PR TITLE
mgmtd: Add to .gitignore for mgmtd_testc program

### DIFF
--- a/mgmtd/.gitignore
+++ b/mgmtd/.gitignore
@@ -1,1 +1,2 @@
 mgmtd
+mgmtd_testc


### PR DESCRIPTION
This program, mgmtd_testc, is built with the
--enable-mgmtd-test-be-client configure option
but it is not .gitignore'd.  Let's fix that