### PR TITLE
bgpd: Free up non-freed json memory on function return

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -12046,6 +12046,8 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 
 	if (show_failed && !failed_count) {
 		if (use_json) {
+			json_object_free(json_peers);
+
 			json_object_int_add(json, "failedPeersCount", 0);
 			json_object_int_add(json, "dynamicPeers", dn_count);
 			json_object_int_add(json, "totalPeers", count);


### PR DESCRIPTION
json_peers is allocated in the above if statement block for json but is not freed in this code path.  Noticed by running Address Sanitizer.