### PR TITLE
bgpd: fix memory type for static->prd_pretty

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7177,7 +7177,7 @@ int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
 			bgp_static->prd = prd;
 
 			if (rd_str)
-				bgp_static->prd_pretty = XSTRDUP(MTYPE_BGP,
+				bgp_static->prd_pretty = XSTRDUP(MTYPE_BGP_NAME,
 								 rd_str);
 
 			if (rmap) {


### PR DESCRIPTION
A crash happens when executing the following command:

> ubuntu2204hwe# conf
> ubuntu2204hwe(config)# router bgp 65500
> ubuntu2204hwe(config-router)#  !
> ubuntu2204hwe(config-router)#  address-family ipv4 unicast
> ubuntu2204hwe(config-router-af)#   sid vpn export auto
> ubuntu2204hwe(config-router-af)#  exit-address-family
> ubuntu2204hwe(config-router)#  !
> ubuntu2204hwe(config-router)#  address-family ipv4 vpn
> ubuntu2204hwe(config-router-af)#   network 4.4.4.4/32 rd 55:55 label 556
> ubuntu2204hwe(config-router-af)#   network 5.5.5.5/32 rd 662:33 label 232
> ubuntu2204hwe(config-router-af)#  exit-address-family
> ubuntu2204hwe(config-router)# exit
> ubuntu2204hwe(config)# !
> ubuntu2204hwe(config)# no router bgp

The crash analysis indicates a memory item has been freed.

> #6  0x000076066a629c15 in mt_count_free (mt=0x56b57be85e00 <MTYPE_BGP_NAME>, ptr=0x60200038b4f0)
>     at lib/memory.c:73
> #7  mt_count_free (ptr=0x60200038b4f0, mt=0x56b57be85e00 <MTYPE_BGP_NAME>) at lib/memory.c:69
> #8  qfree (mt=mt@entry=0x56b57be85e00 <MTYPE_BGP_NAME>, ptr=0x60200038b4f0) at lib/memory.c:129
> #9  0x000056b57bb09ce9 in bgp_free (bgp=<optimized out>) at bgpd/bgpd.c:4120
> #10 0x000056b57bb0aa73 in bgp_unlock (bgp=<optimized out>) at ./bgpd/bgpd.h:2513
> #11 peer_free (peer=0x62a000000200) at bgpd/bgpd.c:1313
> #12 0x000056b57bb0aca8 in peer_unlock_with_caller (name=<optimized out>, peer=<optimized out>)
>     at bgpd/bgpd.c:1344
> #13 0x000076066a6dbb2c in event_call (thread=thread@entry=0x7ffc8cae1d60) at lib/event.c:2011
> #14 0x000076066a60aa88 in frr_run (master=0x613000000040) at lib/libfrr.c:1214
> #15 0x000056b57b8b2c44 in main (argc=<optimized out>, argv=<optimized out>) at bgpd/bgp_main.c:543

Actually, the BGP_NAME item has not been used at allocation for static->prd_pretty, and this results in reaching 0 quicker at bgp deletion.

Fix this by reassigning MTYPE_BGP_NAME to prd_pretty.

Fixes: 16600df2c4f4 ("bgpd: fix show run of network route-distinguisher")