### PR TITLE
tests: Fix route_scale startup issues

### DIFF
--- a/tests/topotests/route_scale/scale_test_common.py
+++ b/tests/topotests/route_scale/scale_test_common.py
@@ -86,6 +86,23 @@ def scale_converge_protocols():
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
 
+    logger.info("Ensuring that Connected Routes are actually installed")
+    r1 = tgen.gears["r1"]
+    expected = {
+        "routes": [
+            {"fib": 32, "rib": 32, "type": "connected"},
+            {"fib": 32, "rib": 32, "type": "local"},
+        ],
+        "routesTotal": 64,
+        "routesTotalFib": 64,
+    }
+
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route summary json", expected
+    )
+    success, result = topotest.run_and_expect(test_func, None, 60, 1)
+    assert success, "Connected routes are not properly installed:\n{}".format(result)
+
 
 def run_one_setup(r1, s):
     "Run one ecmp config"


### PR DESCRIPTION
Upstream CI is frequently running into a situation where the routes are not being installed.  These routes
start at the beginning and suddenly in the middle
they start working properly.

D   1.0.15.183/32 [150/0] via 192.168.0.1, r1-eth0 inactive, weight 1, 00:10:17
                          via 192.168.1.1, r1-eth1 inactive, weight 1, 00:10:17
D   1.0.15.184/32 [150/0] via 192.168.0.1, r1-eth0 inactive, weight 1, 00:10:17
                          via 192.168.1.1, r1-eth1 inactive, weight 1, 00:10:17
D   1.0.15.185/32 [150/0] via 192.168.0.1, r1-eth0 inactive, weight 1, 00:10:17
                          via 192.168.1.1, r1-eth1 inactive, weight 1, 00:10:17
D>* 1.0.15.186/32 [150/0] via 192.168.0.1, r1-eth0, weight 1, 00:10:17
  *                       via 192.168.1.1, r1-eth1, weight 1, 00:10:17
D>* 1.0.15.187/32 [150/0] via 192.168.0.1, r1-eth0, weight 1, 00:10:17
  *                       via 192.168.1.1, r1-eth1, weight 1, 00:10:17
D>* 1.0.15.188/32 [150/0] via 192.168.0.1, r1-eth0, weight 1, 00:10:17

Turning on some debugs showed that the failed installed routes are trying to be matched against the default route.  Thus implying all the connected routes for the test are not yet successfully installed.  Let's modify the test(s) on startup to just ensure that the connected routes are installed correctly.  I am no longer seeing the problem after this change.