### PR TITLE
 isisd: Adding the prefix SID will not regenerate the LSP.

### DIFF
--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2436,6 +2436,8 @@ int isis_instance_segment_routing_prefix_sid_map_prefix_sid_create(
 	pcfg = isis_sr_cfg_prefix_add(area, &prefix, SR_ALGORITHM_SPF);
 	nb_running_set_entry(args->dnode, pcfg);
 
+	lsp_regenerate_schedule(area, area->is_type, 0);
+
 	return NB_OK;
 }
 


### PR DESCRIPTION
After configuring the prefix SID, the LSP will not regenerate, whereas deleting the prefix SID will immediately trigger regeneration. Therefore, in general, the LSP will only be regenerated after it has naturally aged out, at which point the new prefix SID will be included. It is worth considering regenerating the LSP immediately after configuring the prefix SID to make the behavior symmetrical with that of deleting a prefix SID.

Test Scenario:
When the command "segment-routing prefix A.B.C.D/M absolute/index xxx" is configured on RouterA, RouterA will not regenerate the LSP. However, using the "no segment-routing prefix A.B.C.D/M" command will regenerate the LSP.
