### PR TITLE
zebra: fix loading kernel routes without netlink

### DIFF
--- a/zebra/if_ioctl.c
+++ b/zebra/if_ioctl.c
@@ -296,6 +296,8 @@ void interface_list(struct zebra_ns *zns)
 	   /proc/net/if_inet6. */
 	ifaddr_proc_ipv6();
 #endif /* HAVE_PROC_NET_IF_INET6 */
+
+	zebra_dplane_startup_stage(zns, ZEBRA_DPLANE_INTERFACES_READ);
 }
 
 #endif /* OPEN_BSD */

--- a/zebra/if_sysctl.c
+++ b/zebra/if_sysctl.c
@@ -128,6 +128,8 @@ void interface_list(struct zebra_ns *zns)
 
 	/* Free sysctl buffer. */
 	XFREE(MTYPE_TMP, ref);
+
+	zebra_dplane_startup_stage(zns, ZEBRA_DPLANE_INTERFACES_READ);
 }
 
 #endif /* !defined(GNU_LINUX) && !defined(OPEN_BSD) */

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1468,10 +1468,12 @@ static void routing_socket(struct zebra_ns *zns)
 
 void interface_list_second(struct zebra_ns *zns)
 {
+	zebra_dplane_startup_stage(zns, ZEBRA_DPLANE_ADDRESSES_READ);
 }
 
 void interface_list_tunneldump(struct zebra_ns *zns)
 {
+	zebra_dplane_startup_stage(zns, ZEBRA_DPLANE_TUNNELS_READ);
 }
 
 /* Exported interface function.  This function simply calls


### PR DESCRIPTION
Commit 605df8d44 zebra: Use zebra dplane for RTM link and addr broke loading of kernel routes at startup for configurations without netlink.

It rearranged the startup sequence in zebra_ns_enable() to pass via zebra_ns_startup_continue(), triggered through zebra_dplane_startup_stage() calls. However, it neglected to make these calls in the non-netlink code path. As a result zebra failed to load kernel routes at startup on platforms such as FreeBSD.

Insert these calls so we run through all of the expected startup stages.