### PR TITLE
ospfd: Fix recent SA warning in ospf_packet.c 

### DIFF
--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -3335,7 +3335,7 @@ static int ospf_make_ls_ack(struct ospf_interface *oi,
 	struct ospf_lsa_list_entry *ls_ack_list_entry;
 	uint16_t length = OSPF_LS_ACK_MIN_SIZE;
 	struct ospf_lsa *lsa;
-	struct in_addr first_dst_addr;
+	struct in_addr first_dst_addr = { INADDR_ANY };
 
 	/*
 	 * For direct LS Acks, assure the destination address doesn't
@@ -3346,8 +3346,7 @@ static int ospf_make_ls_ack(struct ospf_interface *oi,
 		if (ls_ack_list_first)
 			first_dst_addr.s_addr =
 				ls_ack_list_first->list_entry_dst.s_addr;
-	} else
-		first_dst_addr.s_addr = INADDR_ANY;
+	}
 
 	frr_each_safe (ospf_lsa_list, ls_ack_list, ls_ack_list_entry) {
 		lsa = ls_ack_list_entry->lsa;

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8041,7 +8041,7 @@ static int ospf_vty_dead_interval_set(struct vty *vty, const char *interval_str,
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	uint32_t seconds;
 	uint8_t hellomult;
-	struct in_addr addr;
+	struct in_addr addr = { INADDR_ANY };
 	int ret;
 	struct ospf_if_params *params;
 	struct ospf_interface *oi;

--- a/tests/topotests/mgmt_rpc/test_rpc.py
+++ b/tests/topotests/mgmt_rpc/test_rpc.py
@@ -14,6 +14,7 @@ import os
 import threading
 
 import pytest
+from lib.common_config import retry
 from lib.topogen import Topogen
 from lib.topotest import json_cmp
 
@@ -40,12 +41,20 @@ def tgen(request):
     tgen.stop_topology()
 
 
+# Verify the backend test client has connected
+@retry(retry_timeout=10, initial_wait=5)
+def check_client_connect(r1):
+    out = r1.vtysh_cmd("show mgmt backend-adapter all")
+    assert "mgmtd-testc" in out
+
+
 def test_backend_rpc(tgen):
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
 
     r1 = tgen.gears["r1"]
 
+    # Run the backend test client which registers to handle the `clear ip rip` command.
     be_client_path = "/usr/lib/frr/mgmtd_testc"
     rc, _, _ = r1.net.cmd_status(be_client_path + " --help")
 
@@ -62,6 +71,10 @@ def test_backend_rpc(tgen):
 
     t = threading.Thread(target=run_testc)
     t.start()
+
+    # We need to wait for mgmtd_testc to connect before issuing the command.
+    res = check_client_connect(r1)
+    assert res is None
 
     r1.vtysh_cmd("clear ip rip vrf testname")
 


### PR DESCRIPTION
     ospfd: Fix recent SA warning in ospf_packet.c      

     The commit ed480148844259b7e9e30ed92489cdf44085457e introduced an SA
    warning in ospf_packet.c. This commit rectifies it. Also fix similar
    SA error in ospf_vty.c.

    Signed-off-by: Acee <aceelindem@gmail.com>