### PR TITLE
mgmtd: fix a couple compilation warnings.

### DIFF
--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -1061,7 +1061,7 @@ static void be_client_handle_notify(struct mgmt_be_client *client, void *msgbuf,
 	struct mgmt_msg_notify_data *notif_msg = msgbuf;
 	struct nb_node *nb_node;
 	struct lyd_node *dnode;
-	const char *data;
+	const char *data = NULL;
 	const char *notif;
 	LY_ERR err;
 

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -1518,7 +1518,6 @@ static void fe_adapter_handle_notify_select(struct mgmt_fe_session_ctx *session,
 	const char **selectors = NULL;
 	const char **new;
 
-	/* An empty message clears the selectors */
 	if (msg_len >= sizeof(*msg)) {
 		selectors = mgmt_msg_native_strings_decode(msg, msg_len,
 							   msg->selectors);
@@ -1531,7 +1530,7 @@ static void fe_adapter_handle_notify_select(struct mgmt_fe_session_ctx *session,
 	if (msg->replace) {
 		darr_free_free(session->notify_xpaths);
 		session->notify_xpaths = selectors;
-	} else {
+	} else if (selectors) {
 		new = darr_append_nz(session->notify_xpaths,
 				     darr_len(selectors));
 		memcpy(new, selectors, darr_len(selectors) * sizeof(*selectors));


### PR DESCRIPTION
Also an empty (thus non-replace) notify selectors message shouldn't clear the selectors, it should just do nothing.