### PR TITLE
lib, zebra: Fix a couple compilation warnings

### DIFF
--- a/lib/srv6.h
+++ b/lib/srv6.h
@@ -335,24 +335,23 @@ static inline const char *srv6_sid_ctx2str(char *str, size_t size,
 		break;
 
 	case ZEBRA_SEG6_LOCAL_ACTION_END:
-		len += snprintf(str + len, size - len, " USP");
+		snprintf(str + len, size - len, " USP");
 		break;
 
 	case ZEBRA_SEG6_LOCAL_ACTION_END_X:
 	case ZEBRA_SEG6_LOCAL_ACTION_END_DX6:
-		len += snprintfrr(str + len, size - len, " nh6 %pI6", &ctx->nh6);
+		snprintfrr(str + len, size - len, " nh6 %pI6", &ctx->nh6);
 		break;
 
 	case ZEBRA_SEG6_LOCAL_ACTION_END_DX4:
-		len += snprintfrr(str + len, size - len, " nh4 %pI4", &ctx->nh4);
+		snprintfrr(str + len, size - len, " nh4 %pI4", &ctx->nh4);
 		break;
 
 	case ZEBRA_SEG6_LOCAL_ACTION_END_T:
 	case ZEBRA_SEG6_LOCAL_ACTION_END_DT6:
 	case ZEBRA_SEG6_LOCAL_ACTION_END_DT4:
 	case ZEBRA_SEG6_LOCAL_ACTION_END_DT46:
-		len += snprintf(str + len, size - len, " vrf_id %u",
-				ctx->vrf_id);
+		snprintf(str + len, size - len, " vrf_id %u", ctx->vrf_id);
 		break;
 
 	case ZEBRA_SEG6_LOCAL_ACTION_END_DX2:
@@ -364,7 +363,7 @@ static inline const char *srv6_sid_ctx2str(char *str, size_t size,
 	case ZEBRA_SEG6_LOCAL_ACTION_END_AM:
 	case ZEBRA_SEG6_LOCAL_ACTION_END_BPF:
 	default:
-		len += snprintf(str + len, size - len, " unknown(%s)", __func__);
+		snprintf(str + len, size - len, " unknown(%s)", __func__);
 	}
 
 	return str;

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -969,7 +969,7 @@ static int zebra_sr_config(struct vty *vty)
 				&srv6->encap_src_addr);
 		}
 	}
-	if (zebra_srv6_is_enable()) {
+	if (srv6 && zebra_srv6_is_enable()) {
 		vty_out(vty, "  locators\n");
 		for (ALL_LIST_ELEMENTS_RO(srv6->locators, node, locator)) {
 			inet_ntop(AF_INET6, &locator->prefix.prefix,


### PR DESCRIPTION
Fixes the following compilation warnings:

```
error	15-Aug-2024 13:54:10	In file included from lib/bfd.c:16:
error	15-Aug-2024 13:54:10	In file included from ./lib/zclient.h:22:
error	15-Aug-2024 13:54:10	In file included from ./lib/nexthop.h:14:
error	15-Aug-2024 13:54:10	./lib/srv6.h:338:3: warning: Value stored to 'len' is never read [deadcode.DeadStores]
error	15-Aug-2024 13:54:10	                len += snprintf(str + len, size - len, " USP");
error	15-Aug-2024 13:54:10	                ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error	15-Aug-2024 13:54:10	./lib/srv6.h:343:3: warning: Value stored to 'len' is never read [deadcode.DeadStores]
error	15-Aug-2024 13:54:10	                len += snprintfrr(str + len, size - len, " nh6 %pI6", &ctx->nh6);
error	15-Aug-2024 13:54:10	                ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error	15-Aug-2024 13:54:10	./lib/srv6.h:347:3: warning: Value stored to 'len' is never read [deadcode.DeadStores]
error	15-Aug-2024 13:54:10	                len += snprintfrr(str + len, size - len, " nh4 %pI4", &ctx->nh4);
error	15-Aug-2024 13:54:10	                ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error	15-Aug-2024 13:54:10	./lib/srv6.h:354:3: warning: Value stored to 'len' is never read [deadcode.DeadStores]
error	15-Aug-2024 13:54:10	                len += snprintf(str + len, size - len, " vrf_id %u",
error	15-Aug-2024 13:54:10	                ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error	15-Aug-2024 13:54:10	./lib/srv6.h:367:3: warning: Value stored to 'len' is never read [deadcode.DeadStores]
error	15-Aug-2024 13:54:10	                len += snprintf(str + len, size - len, " unknown(%s)", __func__);
error	15-Aug-2024 13:54:10	                ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
error	15-Aug-2024 14:20:01	zebra/zebra_srv6_vty.c:974:8: warning: Access to field 'locators' results in a dereference of a null pointer (loaded from variable 'srv6') [core.NullDereference]
error	15-Aug-2024 14:20:01	                for (ALL_LIST_ELEMENTS_RO(srv6->locators, node, locator)) {
error	15-Aug-2024 14:20:01	                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error	15-Aug-2024 14:20:01	./lib/linklist.h:345:11: note: expanded from macro 'ALL_LIST_ELEMENTS_RO'
error	15-Aug-2024 14:20:01	        (node) = listhead(list), ((data) = NULL);                              \
error	15-Aug-2024 14:20:01	                 ^~~~~~~~~~~~~~
error	15-Aug-2024 14:20:01	./lib/linklist.h:63:22: note: expanded from macro 'listhead'
error	15-Aug-2024 14:20:01	#define listhead(X) ((X) ? ((X)->head) : NULL)
error	15-Aug-2024 14:20:01	                     ^
```