### PR TITLE
Reduce the number of Singleton objects when using weight for NHG's

### DIFF
--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -207,6 +207,8 @@ extern bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2);
 extern bool nexthop_same_no_labels(const struct nexthop *nh1,
 				   const struct nexthop *nh2);
 extern int nexthop_cmp(const struct nexthop *nh1, const struct nexthop *nh2);
+extern int nexthop_cmp_no_weight(const struct nexthop *nh1,
+				 const struct nexthop *nh2);
 extern int nexthop_g_addr_cmp(enum nexthop_types_t type,
 			      const union g_addr *addr1,
 			      const union g_addr *addr2);


### PR DESCRIPTION
    Currently FRR when it has two nexthop groups:
    A
      nexthop 1 weight 5
      nexthop 2 weight 6
      nexthop 3 weight 7
    B
      nexthop 1 weight 3
      nexthop 2 weight 4
      nexthop 3 weight 5
    
    We end up with 5 singleton nexthops and two groups:
    
    ID: 181818168 (sharp)
         RefCnt: 1
         Uptime: 00:04:52
         VRF: default
         Valid, Installed
         Depends: (69) (70) (71)
               via 192.168.119.1, enp13s0 (vrf default), weight 182
               via 192.168.119.2, enp13s0 (vrf default), weight 218
               via 192.168.119.3, enp13s0 (vrf default), weight 255
    ID: 181818169 (sharp)
         RefCnt: 1
         Uptime: 00:02:08
         VRF: default
         Valid, Installed
         Depends: (71) (127) (128)
               via 192.168.119.1, enp13s0 (vrf default), weight 127
               via 192.168.119.2, enp13s0 (vrf default), weight 170
               via 192.168.119.3, enp13s0 (vrf default), weight 255
    
    id 69 via 192.168.119.1 dev enp13s0 scope link proto 194
    id 70 via 192.168.119.2 dev enp13s0 scope link proto 194
    id 71 via 192.168.119.3 dev enp13s0 scope link proto 194
    id 127 via 192.168.119.1 dev enp13s0 scope link proto 194
    id 128 via 192.168.119.2 dev enp13s0 scope link proto 194
    id 181818168 group 69,182/70,218/71,255 proto 194
    id 181818169 group 71,255/127,127/128,170 proto 194
    
    This is not a desirable state to be in.  If you have a
    link flapping in the network and weights are changing
    rapidly you end up with a large number of singleton
    nexthops that are being used by the nexthop groups.
    This fills up asic space and clutters the table.
    Additionally singleton nexthops cannot have any weight
    and the fact that you attempt to create a singleton
    nexthop with different weights means nothing to the
    linux kernel( or any asic dplane ).  Let's modify
    the code to always create the singleton nexthops
    without a weight and then just creating the
    NHG's that use the singletons with the appropriate
    weight.
    ID: 181818168 (sharp)
         RefCnt: 1
         Uptime: 00:00:32
         VRF: default
         Valid, Installed
         Depends: (22) (24) (28)
               via 192.168.119.1, enp13s0 (vrf default), weight 182
               via 192.168.119.2, enp13s0 (vrf default), weight 218
               via 192.168.119.3, enp13s0 (vrf default), weight 255
    ID: 181818169 (sharp)
         RefCnt: 1
         Uptime: 00:00:14
         VRF: default
         Valid, Installed
         Depends: (22) (24) (28)
               via 192.168.119.1, enp13s0 (vrf default), weight 153
               via 192.168.119.2, enp13s0 (vrf default), weight 204
               via 192.168.119.3, enp13s0 (vrf default), weight 255
    
    id 22 via 192.168.119.1 dev enp13s0 scope link proto 194
    id 24 via 192.168.119.2 dev enp13s0 scope link proto 194
    id 28 via 192.168.119.3 dev enp13s0 scope link proto 194
    id 181818168 group 22,182/24,218/28,255 proto 194
    id 181818169 group 22,153/24,204/28,255 proto 194

