### PR TITLE
tools, ospfclient: add a config option to skip installing python scripts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -850,6 +850,9 @@ AC_ARG_WITH([frr-format],
 AC_ARG_ENABLE([version-build-config],
   AS_HELP_STRING([--disable-version-build-config], [do not include build configs in show version command]))
 
+AC_ARG_ENABLE([python_runtime],
+  AS_HELP_STRING([--disable-python-runtime], [do not install python scripts or have python runtime dependency]))
+
 #if openssl, else use the internal
 AS_IF([test "$with_crypto" = "openssl"], [
 AC_CHECK_LIB([crypto], [EVP_DigestInit], [LIBS="$LIBS -lcrypto"], [], [])
@@ -2810,6 +2813,9 @@ AM_CONDITIONAL([VRRPD], [test "$enable_vrrpd" != "no"])
 AM_CONDITIONAL([PATHD], [test "$enable_pathd" != "no"])
 AM_CONDITIONAL([PATHD_PCEP], [test "$enable_pathd" != "no"])
 AM_CONDITIONAL([DP_DPDK], [test "$enable_dp_dpdk" = "yes"])
+
+
+AM_CONDITIONAL([PYTHON_RUNTIME_DEPENDENCY], [test "$enable_python_runtime" != "no"])
 
 AC_CONFIG_FILES([Makefile],[
 	test "$enable_dev_build" = "yes" && makefile_devbuild="--dev-build"

--- a/ospfclient/subdir.am
+++ b/ospfclient/subdir.am
@@ -7,10 +7,13 @@ lib_LTLIBRARIES += ospfclient/libfrrospfapiclient.la
 noinst_PROGRAMS += ospfclient/ospfclient
 #man8 += $(MANBUILD)/frr-ospfclient.8
 
+if PYTHON_RUNTIME_DEPENDENCY
 sbin_SCRIPTS += \
 	ospfclient/ospfclient.py \
 	# end
 endif
+endif
+
 
 ospfclient_libfrrospfapiclient_la_LDFLAGS = $(LIB_LDFLAGS) -version-info 0:0:0
 ospfclient_libfrrospfapiclient_la_LIBADD = lib/libfrr.la

--- a/tools/subdir.am
+++ b/tools/subdir.am
@@ -13,15 +13,20 @@ EXTRA_PROGRAMS += \
 	# end
 
 sbin_PROGRAMS += tools/ssd
+
+if PYTHON_RUNTIME_DEPENDENCY
+sbin_SCRIPTS += \
+	tools/frr-reload.py \
+	tools/generate_support_bundle.py \
+	tools/frr_babeltrace.py
+endif
+
 sbin_SCRIPTS += \
 	tools/frr-reload \
-	tools/frr-reload.py \
 	tools/frr \
 	\
 	tools/frrcommon.sh \
 	tools/frrinit.sh \
-	tools/generate_support_bundle.py \
-	tools/frr_babeltrace.py \
 	tools/watchfrr.sh \
 	# end
 


### PR DESCRIPTION
The new config option `--disable-python-runtime` allows `make install` to proceed without installing any of the python scripts. When installing from deb/rpm packages those are bundled as `frr-pythontools`, which is independent from the frr binaries and can already be skipped.  I.e, this PR gives the option to  skip those scripts when building/installing from sources too.