### PR TITLE
zebra: fix table heap-after-free crash

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1362,6 +1362,8 @@ int zapi_route_encode(uint8_t cmd, struct stream *s, struct zapi_route *api)
 	stream_putc(s, api->type);
 
 	stream_putw(s, api->instance);
+	if (CHECK_FLAG(api->message, ZAPI_MESSAGE_TABLEID))
+		SET_FLAG(api->flags, ZEBRA_FLAG_TABLEID);
 	stream_putl(s, api->flags);
 	stream_putl(s, api->message);
 
@@ -1421,6 +1423,8 @@ int zapi_route_encode(uint8_t cmd, struct stream *s, struct zapi_route *api)
 				return -1;
 			}
 
+			if (CHECK_FLAG(api->message, ZAPI_MESSAGE_TABLEID))
+				SET_FLAG(api->flags, ZEBRA_FLAG_TABLEID);
 			if (zapi_nexthop_encode(s, api_nh, api->flags,
 						api->message)
 			    != 0)
@@ -1459,6 +1463,9 @@ int zapi_route_encode(uint8_t cmd, struct stream *s, struct zapi_route *api)
 					api_nh->label_num, MPLS_MAX_LABELS);
 				return -1;
 			}
+
+			if (CHECK_FLAG(api->message, ZAPI_MESSAGE_TABLEID))
+				SET_FLAG(api->flags, ZEBRA_FLAG_TABLEID);
 
 			if (zapi_nexthop_encode(s, api_nh, api->flags,
 						api->message)

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -578,6 +578,12 @@ struct zapi_route {
  * kernel (NLM_F_APPEND at the very least )
  */
 #define ZEBRA_FLAG_OUTOFSYNC          0x400
+/*
+ * This flag lets us know that the route entry is
+ * associated to the table ID and must remain when the
+ * table ID is de-associated from a VRF.
+ */
+#define ZEBRA_FLAG_TABLEID 0x800
 
 	/* The older XXX_MESSAGE flags live here */
 	uint32_t message;

--- a/tests/topotests/zebra_rib/r1/import_mrib_table_2.json
+++ b/tests/topotests/zebra_rib/r1/import_mrib_table_2.json
@@ -68,7 +68,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -97,7 +97,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -126,7 +126,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -155,7 +155,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,

--- a/tests/topotests/zebra_rib/r1/import_mrib_table_3.json
+++ b/tests/topotests/zebra_rib/r1/import_mrib_table_3.json
@@ -68,7 +68,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -97,7 +97,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -126,7 +126,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -155,7 +155,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -238,7 +238,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,

--- a/tests/topotests/zebra_rib/r1/import_mrib_table_4.json
+++ b/tests/topotests/zebra_rib/r1/import_mrib_table_4.json
@@ -68,7 +68,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -97,7 +97,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -126,7 +126,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -155,7 +155,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,

--- a/tests/topotests/zebra_rib/r1/import_table_2.json
+++ b/tests/topotests/zebra_rib/r1/import_table_2.json
@@ -68,7 +68,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -97,7 +97,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -126,7 +126,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -155,7 +155,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,

--- a/tests/topotests/zebra_rib/r1/import_table_3.json
+++ b/tests/topotests/zebra_rib/r1/import_table_3.json
@@ -68,7 +68,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -97,7 +97,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -126,7 +126,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -155,7 +155,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -238,7 +238,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,

--- a/tests/topotests/zebra_rib/r1/import_table_4.json
+++ b/tests/topotests/zebra_rib/r1/import_table_4.json
@@ -68,7 +68,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -97,7 +97,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -126,7 +126,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,
@@ -155,7 +155,7 @@
             "installed": true,
             "table": 254,
             "internalStatus": 16,
-            "internalFlags": 9,
+            "internalFlags": 2057,
             "nexthops": [
                 {
                     "flags": 3,

--- a/tests/topotests/zebra_rib/r1/v4_route_table_1_no_vrf.json
+++ b/tests/topotests/zebra_rib/r1/v4_route_table_1_no_vrf.json
@@ -15,6 +15,38 @@
       ]
     }
   ],
+  "10.0.0.0/24": [
+    {
+      "protocol": "static",
+      "vrfName": "default",
+      "installed": true,
+      "table": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "unreachable": true,
+          "blackhole": true,
+          "active": true
+        }
+      ]
+    }
+  ],
+  "10.1.0.0/24": [
+    {
+      "protocol": "static",
+      "vrfName": "default",
+      "installed": true,
+      "table": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "ip": "192.168.211.254",
+          "interfaceName": "r1-eth1",
+          "active": true
+        }
+      ]
+    }
+  ],
   "10.2.0.0/24": null,
   "10.3.0.0/24": null,
   "192.168.210.0/24": null,

--- a/tests/topotests/zebra_rib/r1/v4_route_table_1_no_vrf.json
+++ b/tests/topotests/zebra_rib/r1/v4_route_table_1_no_vrf.json
@@ -1,0 +1,22 @@
+{
+  "0.0.0.0/0": [
+    {
+      "protocol": "kernel",
+      "vrfName": "default",
+      "installed": true,
+      "table": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "unreachable": true,
+          "blackhole": true,
+          "active": true
+        }
+      ]
+    }
+  ],
+  "10.2.0.0/24": null,
+  "10.3.0.0/24": null,
+  "192.168.210.0/24": null,
+  "192.168.210.1/32": null
+}

--- a/tests/topotests/zebra_rib/r1/v4_route_table_1_no_vrf.txt
+++ b/tests/topotests/zebra_rib/r1/v4_route_table_1_no_vrf.txt
@@ -1,0 +1,1 @@
+blackhole default

--- a/tests/topotests/zebra_rib/r1/v4_route_table_1_no_vrf.txt
+++ b/tests/topotests/zebra_rib/r1/v4_route_table_1_no_vrf.txt
@@ -1,1 +1,3 @@
 blackhole default
+blackhole 10.0.0.0/24 proto XXXX metric 20
+10.1.0.0/24 via 192.168.211.254 dev r1-eth1 proto XXXX metric 20

--- a/tests/topotests/zebra_rib/r1/v4_route_table_1_vrf_red.json
+++ b/tests/topotests/zebra_rib/r1/v4_route_table_1_vrf_red.json
@@ -1,0 +1,82 @@
+{
+  "0.0.0.0/0": [
+    {
+      "protocol": "kernel",
+      "vrfName": "RED",
+      "installed": true,
+      "table": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "unreachable": true,
+          "blackhole": true,
+          "active": true
+        }
+      ]
+    }
+  ],
+  "10.2.0.0/24": [
+    {
+      "protocol": "static",
+      "vrfName": "RED",
+      "installed": true,
+      "table": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "ip": "192.168.210.254",
+          "interfaceName": "r1-eth0",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "10.3.0.0/24": [
+    {
+      "protocol": "static",
+      "vrfName": "RED",
+      "installed": true,
+      "table": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "ip": "192.168.212.254",
+          "interfaceName": "r1-eth2",
+          "vrf": "default",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "192.168.210.0/24": [
+    {
+      "protocol": "connected",
+      "vrfName": "RED",
+      "installed": true,
+      "table": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "directlyConnected": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "192.168.210.1/32": [
+    {
+      "protocol": "local",
+      "vrfName": "RED",
+      "installed": true,
+      "table": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/zebra_rib/r1/v4_route_table_1_vrf_red.json
+++ b/tests/topotests/zebra_rib/r1/v4_route_table_1_vrf_red.json
@@ -15,6 +15,39 @@
       ]
     }
   ],
+  "10.0.0.0/24": [
+    {
+      "protocol": "static",
+      "vrfName": "RED",
+      "installed": true,
+      "table": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "unreachable": true,
+          "blackhole": true,
+          "active": true
+        }
+      ]
+    }
+  ],
+  "10.1.0.0/24": [
+    {
+      "protocol": "static",
+      "vrfName": "RED",
+      "installed": true,
+      "table": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "ip": "192.168.211.254",
+          "interfaceName": "r1-eth1",
+          "vrf": "default",
+          "active": true
+        }
+      ]
+    }
+  ],
   "10.2.0.0/24": [
     {
       "protocol": "static",

--- a/tests/topotests/zebra_rib/r1/v4_route_table_1_vrf_red.txt
+++ b/tests/topotests/zebra_rib/r1/v4_route_table_1_vrf_red.txt
@@ -1,0 +1,4 @@
+blackhole default
+10.2.0.0/24 via 192.168.210.254 dev r1-eth0 proto XXXX metric 20
+10.3.0.0/24 via 192.168.212.254 dev r1-eth2 proto XXXX metric 20
+192.168.210.0/24 dev r1-eth0 proto XXXX scope link src 192.168.210.1 

--- a/tests/topotests/zebra_rib/r1/v4_route_table_1_vrf_red.txt
+++ b/tests/topotests/zebra_rib/r1/v4_route_table_1_vrf_red.txt
@@ -1,4 +1,6 @@
 blackhole default
+blackhole 10.0.0.0/24 proto XXXX metric 20
+10.1.0.0/24 via 192.168.211.254 dev r1-eth1 proto XXXX metric 20
 10.2.0.0/24 via 192.168.210.254 dev r1-eth0 proto XXXX metric 20
 10.3.0.0/24 via 192.168.212.254 dev r1-eth2 proto XXXX metric 20
 192.168.210.0/24 dev r1-eth0 proto XXXX scope link src 192.168.210.1 

--- a/tests/topotests/zebra_rib/test_zebra_rib.py
+++ b/tests/topotests/zebra_rib/test_zebra_rib.py
@@ -139,6 +139,16 @@ def test_zebra_kernel_route_vrf():
     step("Add routes in table 1")
     r1.run("ip route add blackhole default table {}".format(table_id))
 
+    r1.vtysh_cmd(
+        """
+configure terminal
+ ip route 10.0.0.0/24 blackhole table {}
+ ip route 10.1.0.0/24 192.168.211.254 nexthop-vrf default table {}
+""".format(
+            table_id, table_id
+        )
+    )
+
     json_file = "{}/r1/v4_route_table_1_no_vrf.json".format(CWD)
     expected = json.loads(open(json_file).read())
     test_func = partial(

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -401,6 +401,7 @@ extern void zebra_nhg_mark_keep(void);
 
 /* Nexthop resolution processing */
 struct route_entry; /* Forward ref to avoid circular includes */
+extern void nexthop_vrf_update(struct route_node *rn, struct route_entry *re, vrf_id_t vrf_id);
 extern int nexthop_active_update(struct route_node *rn, struct route_entry *re,
 				 struct route_entry *old_re);
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -903,6 +903,11 @@ void zebra_rtable_node_cleanup(struct route_table *table,
 		rib_unlink(node, re);
 	}
 
+	zebra_node_info_cleanup(node);
+}
+
+void zebra_node_info_cleanup(struct route_node *node)
+{
 	if (node->info) {
 		rib_dest_t *dest = node->info;
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4503,6 +4503,12 @@ rib_update_handle_kernel_route_down_possibility(struct route_node *rn,
 	bool alive = false;
 
 	for (ALL_NEXTHOPS(re->nhe->nhg, nexthop)) {
+		if (!nexthop->ifindex) {
+			/* blackhole nexthops have no interfaces */
+			alive = true;
+			break;
+		}
+
 		struct interface *ifp = if_lookup_by_index(nexthop->ifindex,
 							   nexthop->vrf_id);
 

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -457,8 +457,11 @@ static void zebra_vrf_table_create(struct zebra_vrf *zvrf, afi_t afi,
 	memset(&p, 0, sizeof(p));
 	p.family = afi2family(afi);
 
+	/* create a fake default route or get the existing one */
 	rn = srcdest_rnode_get(zvrf->table[afi][safi], &p, NULL);
-	zebra_rib_create_dest(rn);
+	if (!rn->info)
+		/* do not override the existing default route */
+		zebra_rib_create_dest(rn);
 }
 
 /* Allocate new zebra VRF. */

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -263,6 +263,8 @@ extern void zebra_vrf_init(void);
 
 extern void zebra_rtable_node_cleanup(struct route_table *table,
 				      struct route_node *node);
+extern void zebra_node_info_cleanup(struct route_node *node);
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fix a heap-after-free that causes zebra to crash even without address-sanitizer. To reproduce:

> echo "100 my_table" | tee -a /etc/iproute2/rt_tables
> ip route add blackhole default table 100
> ip route show table 100
> ip l add red type vrf table 100
> ip l del red
> ip route del blackhole default table 100

> ==2866266==ERROR: AddressSanitizer: heap-use-after-free on address 0x606000154f54 at pc 0x7fa32474b83f bp 0x7ffe94f67d90 sp 0x7ffe94f67d88
> READ of size 1 at 0x606000154f54 thread T0
>     #0 0x7fa32474b83e in rn_hash_node_const_find lib/table.c:28
>     #1 0x7fa32474bab1 in rn_hash_node_find lib/table.c:28
>     #2 0x7fa32474d783 in route_node_get lib/table.c:283
>     #3 0x7fa3247328dd in srcdest_rnode_get lib/srcdest_table.c:231
>     #4 0x55b0e4fa8da4 in rib_find_rn_from_ctx zebra/zebra_rib.c:1957
>     #5 0x55b0e4fa8e31 in rib_process_result zebra/zebra_rib.c:1988
>     #6 0x55b0e4fb9d64 in rib_process_dplane_results zebra/zebra_rib.c:4894
>     #7 0x7fa32476689c in event_call lib/event.c:1996
>     #8 0x7fa32463b7b2 in frr_run lib/libfrr.c:1232
>     #9 0x55b0e4e6c32a in main zebra/main.c:526
>     #10 0x7fa32424fd09 in __libc_start_main ../csu/libc-start.c:308
>     #11 0x55b0e4e2d649 in _start (/usr/lib/frr/zebra+0x1a1649)
>
> 0x606000154f54 is located 20 bytes inside of 56-byte region [0x606000154f40,0x606000154f78)
> freed by thread T0 here:
>     #0 0x7fa324ca9b6f in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:123
>     #1 0x7fa324668d8f in qfree lib/memory.c:130
>     #2 0x7fa32474c421 in route_table_free lib/table.c:126
>     #3 0x7fa32474bf96 in route_table_finish lib/table.c:46
>     #4 0x55b0e4fbca3a in zebra_router_free_table zebra/zebra_router.c:191
>     #5 0x55b0e4fbccea in zebra_router_release_table zebra/zebra_router.c:214
>     #6 0x55b0e4fd428e in zebra_vrf_disable zebra/zebra_vrf.c:219
>     #7 0x7fa32476fabf in vrf_disable lib/vrf.c:326
>     #8 0x7fa32476f5d4 in vrf_delete lib/vrf.c:231
>     #9 0x55b0e4e4ad36 in interface_vrf_change zebra/interface.c:1478
>     #10 0x55b0e4e4d5d2 in zebra_if_dplane_ifp_handling zebra/interface.c:1949
>     #11 0x55b0e4e4fb89 in zebra_if_dplane_result zebra/interface.c:2268
>     #12 0x55b0e4fb9f26 in rib_process_dplane_results zebra/zebra_rib.c:4954
>     #13 0x7fa32476689c in event_call lib/event.c:1996
>     #14 0x7fa32463b7b2 in frr_run lib/libfrr.c:1232
>     #15 0x55b0e4e6c32a in main zebra/main.c:526
>     #16 0x7fa32424fd09 in __libc_start_main ../csu/libc-start.c:308
>
> previously allocated by thread T0 here:
>     #0 0x7fa324caa037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
>     #1 0x7fa324668c4d in qcalloc lib/memory.c:105
>     #2 0x7fa32474bf33 in route_table_init_with_delegate lib/table.c:38
>     #3 0x7fa32474e73c in route_table_init lib/table.c:512
>     #4 0x55b0e4fbc353 in zebra_router_get_table zebra/zebra_router.c:137
>     #5 0x55b0e4fd4da0 in zebra_vrf_table_create zebra/zebra_vrf.c:358
>     #6 0x55b0e4fd3d30 in zebra_vrf_enable zebra/zebra_vrf.c:140
>     #7 0x7fa32476f9b2 in vrf_enable lib/vrf.c:286
>     #8 0x55b0e4e4af76 in interface_vrf_change zebra/interface.c:1533
>     #9 0x55b0e4e4d612 in zebra_if_dplane_ifp_handling zebra/interface.c:1968
>     #10 0x55b0e4e4fb89 in zebra_if_dplane_result zebra/interface.c:2268
>     #11 0x55b0e4fb9f26 in rib_process_dplane_results zebra/zebra_rib.c:4954
>     #12 0x7fa32476689c in event_call lib/event.c:1996
>     #13 0x7fa32463b7b2 in frr_run lib/libfrr.c:1232
>     #14 0x55b0e4e6c32a in main zebra/main.c:526
>     #15 0x7fa32424fd09 in __libc_start_main ../csu/libc-start.c:308

Fixes: d8612e6545 ("zebra: Track tables allocated by vrf and cleanup")