### PR TITLE
tests: dont print sys.path when running grpc-query.py

### DIFF
--- a/tests/topotests/lib/grpc-query.py
+++ b/tests/topotests/lib/grpc-query.py
@@ -40,7 +40,6 @@ try:
 
     try:
         sys.path[0:0] = [tmpdir]
-        print(sys.path)
         import frr_northbound_pb2
         import frr_northbound_pb2_grpc
 


### PR DESCRIPTION
Don't print the sys.path when running grpc-query.py. Doing so was causing tests to fail.