### PR TITLE
bgpd: add json support for BGP L3NHG values

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10568,8 +10568,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 		vty_out(vty, "\n");
 
 
-	if (path->extra && path->extra->vrfleak &&
-	    path->extra->vrfleak->parent && !json_paths) {
+	if (path->extra && path->extra->vrfleak && path->extra->vrfleak->parent) {
 		struct bgp_path_info *parent_ri;
 		struct bgp_dest *dest, *pdest;
 
@@ -10579,31 +10578,68 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 		if (dest && dest->pdest) {
 			pdest = dest->pdest;
 			if (is_pi_family_evpn(parent_ri)) {
-				vty_out(vty, "  Imported from ");
-				vty_out(vty, BGP_RD_AS_FORMAT(bgp->asnotation),
-					(struct prefix_rd *)bgp_dest_get_prefix(
-						pdest));
-				vty_out(vty, ":%pFX, VNI %s",
-					(struct prefix_evpn *)
-						bgp_dest_get_prefix(dest),
-					vni_buf);
-				if (CHECK_FLAG(attr->es_flags, ATTR_ES_L3_NHG))
+				if (json_paths) {
+					json_object_string_addf(
+						json_path, "importedFrom",
+						BGP_RD_AS_FORMAT(bgp->asnotation),
+						(struct prefix_rd *)
+							bgp_dest_get_prefix(
+								pdest));
+					if (safi != SAFI_EVPN)
+						json_object_string_add(json_path,
+								       "vni",
+								       vni_buf);
+				} else {
+					vty_out(vty, "  Imported from ");
+					vty_out(vty,
+						BGP_RD_AS_FORMAT(bgp->asnotation),
+						(struct prefix_rd *)
+							bgp_dest_get_prefix(
+								pdest));
+					vty_out(vty, ":%pFX, VNI %s",
+						(struct prefix_evpn *)
+							bgp_dest_get_prefix(dest),
+						vni_buf);
+				}
+				if (CHECK_FLAG(attr->es_flags, ATTR_ES_L3_NHG) &&
+				    !json_paths) {
 					vty_out(vty, ", L3NHG %s",
 						CHECK_FLAG(
 							attr->es_flags,
 							ATTR_ES_L3_NHG_ACTIVE)
 							? "active"
 							: "inactive");
-				vty_out(vty, "\n");
-
+					vty_out(vty, "\n");
+				} else if (json_paths) {
+					json_object_boolean_add(
+						json_path, "l3nhg",
+						CHECK_FLAG(attr->es_flags,
+							   ATTR_ES_L3_NHG));
+					json_object_boolean_add(
+						json_path, "l3nhgActive",
+						CHECK_FLAG(attr->es_flags,
+							   ATTR_ES_L3_NHG_ACTIVE));
+				}
 			} else {
-				vty_out(vty, "  Imported from ");
-				vty_out(vty, BGP_RD_AS_FORMAT(bgp->asnotation),
-					(struct prefix_rd *)bgp_dest_get_prefix(
-						pdest));
-				vty_out(vty, ":%pFX\n",
-					(struct prefix_evpn *)
-						bgp_dest_get_prefix(dest));
+				if (json_paths) {
+					json_object_string_addf(
+						json_path, "importedFrom",
+						BGP_RD_AS_FORMAT(bgp->asnotation),
+						(struct prefix_rd *)
+							bgp_dest_get_prefix(
+								pdest));
+				} else {
+					vty_out(vty, "  Imported from ");
+					vty_out(vty,
+						BGP_RD_AS_FORMAT(bgp->asnotation),
+						(struct prefix_rd *)
+							bgp_dest_get_prefix(
+								pdest));
+					vty_out(vty, ":%pFX\n",
+						(struct prefix_evpn *)
+							bgp_dest_get_prefix(
+								dest));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Some json attributes are missing for L3NHG values.

> PE1# show bgp vrf all detail
> [..]
> Instance vrf-purple:
> BGP table version is 1, local router ID is 27.3.0.85, vrf id 7
> Default local pref 100, local AS 65000
> BGP routing table entry for fe80::4620:ff:feff:ff01/128, version 1
> Paths: (1 available, best #1, vrf vrf-purple)
>   Not advertised to any peer
>   Imported from 10.30.30.30:5:[2]:[0]:[48]:[44:20:00:ff:ff:01]:[128]:[fe80::4620:ff:feff:ff01], VNI 4000  Local
>     ::ffff:a1e:1e1e (metric 20) from 10.30.30.30 (10.30.30.30) announce-nh-self
>       Origin IGP, localpref 100, valid, internal, best (First path received)
>       Extended Community: RT:65000:4000 ET:8
>       Last update: Thu Aug 22 18:23:38 2024
>
> Displayed 1 routes and 1 total paths

> PE1# show bgp vrf all json detail
> {
> "vrf-purple":{
>  "vrfId": 7,
>  "vrfName": "vrf-purple",
>  "tableVersion": 1,
>  "routerId": "27.3.0.85",
>  "defaultLocPrf": 100,
>  "localAS": 65000,
>  "routes": { "fe80::4620:ff:feff:ff01/128": [{"importedFrom":"10.30.30.30:5","l3nhg":false,"l3nhgActive":false,
> "aspath":{"string":"Local","segments":[],"length":0},"announceNexthopSelf":true,"origin":"IGP","locPrf":100,
> "valid":true,"version":1,"bestpath":{"overall":true,"selectionReason":"First path received"},
> "extendedCommunity":{"string":"RT:65000:4000 ET:8"},"lastUpdate":{"epoch":1724343817,
> "string":"Thu Aug 22 18:23:37 2024\n"},
> "nexthops":[{"ip":"::ffff:a1e:1e1e","hostname":"PE2","afi":"ipv6",
> "scope":"global","metric":20,"accessible":true,"used":true}],
> "peer":{"peerId":"10.30.30.30","routerId":"10.30.30.30","hostname":"PE2","type":"internal"}}]
>  }  }
> }