### PR TITLE
nhrpd: fix sending /32 shortcut

### DIFF
--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -219,6 +219,10 @@ int nhrp_route_read(ZAPI_CALLBACK_ARGS)
 	if (api.type == ZEBRA_ROUTE_NHRP)
 		return 0;
 
+	/* ignore local routes */
+	if (api.type == ZEBRA_ROUTE_LOCAL)
+		return 0;
+
 	sockunion_family(&nexthop_addr) = AF_UNSPEC;
 	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP)) {
 		api_nh = &api.nexthops[0];


### PR DESCRIPTION
The remote spoke always sends a 32 prefix length to a shortcut request. In the example, the remote spoke as the IP address 192.168.2.1/24.

spoke1# sh ip nhrp shortcut
Type     Prefix                   Via                      Identity
dynamic  192.168.2.1/32           10.255.255.2

Do not deal with local routes in nhrpd. Now:

spoke1# sh ip nhrp shortcut
Type     Prefix                   Via                      Identity
dynamic  192.168.2.0/24           10.255.255.2

Fixes: d4aa24ba7d ("*: Introduce Local Host Routes to FRR")