### PR TITLE
bgpd: Free epvn_overlay memory on error

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -555,7 +555,7 @@ static void *evpn_overlay_hash_alloc(void *p)
 	return p;
 }
 
-static void evpn_overlay_free(struct bgp_route_evpn *bre)
+void evpn_overlay_free(struct bgp_route_evpn *bre)
 {
 	XFREE(MTYPE_BGP_EVPN_OVERLAY, bre);
 }

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -646,5 +646,6 @@ bgp_attr_set_vnc_subtlvs(struct attr *attr,
 }
 
 extern bool route_matches_soo(struct bgp_path_info *pi, struct ecommunity *soo);
+extern void evpn_overlay_free(struct bgp_route_evpn *bre);
 
 #endif /* _QUAGGA_BGP_ATTR_H */

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -4921,6 +4921,7 @@ static int process_type5_route(struct peer *peer, afi_t afi, safi_t safi,
 		flog_err(EC_BGP_EVPN_ROUTE_INVALID,
 			 "%u:%s - Rx EVPN Type-5 NLRI with invalid length %d",
 			 peer->bgp->vrf_id, peer->host, psize);
+		evpn_overlay_free(evpn);
 		return -1;
 	}
 
@@ -4953,6 +4954,7 @@ static int process_type5_route(struct peer *peer, afi_t afi, safi_t safi,
 			EC_BGP_EVPN_ROUTE_INVALID,
 			"%u:%s - Rx EVPN Type-5 NLRI with invalid IP Prefix length %d",
 			peer->bgp->vrf_id, peer->host, ippfx_len);
+		evpn_overlay_free(evpn);
 		return -1;
 	}
 	p.prefix.prefix_addr.ip_prefix_length = ippfx_len;
@@ -5033,6 +5035,7 @@ static int process_type5_route(struct peer *peer, afi_t afi, safi_t safi,
 		}
 		bgp_withdraw(peer, (struct prefix *)&p, addpath_id, afi, safi,
 			     ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, &label, 1);
+		evpn_overlay_free(evpn);
 	}
 
 	return 0;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4608,6 +4608,8 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 		 */
 		if ((afi == AFI_L2VPN) && evpn)
 			bgp_attr_set_evpn_overlay(attr, evpn);
+		else
+			evpn_overlay_free(evpn);
 		bgp_adj_in_set(dest, peer, attr, addpath_id, &bgp_labels);
 	}
 
@@ -4770,6 +4772,8 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	 */
 	if (soft_reconfig && (afi == AFI_L2VPN) && evpn)
 		bgp_attr_set_evpn_overlay(&new_attr, evpn);
+	else
+		evpn_overlay_free(evpn);
 
 	/* Apply incoming route-map.
 	 * NB: new_attr may now contain newly allocated values from route-map


### PR DESCRIPTION
When parsing EVPN NLRIs, and an error occurred, do no forget to free the memory.