### PR TITLE
bgpd: Fix memory leak when using auto RT

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5128,13 +5128,15 @@ static void evpn_auto_rt_import_add_for_vrf(struct bgp *bgp_vrf)
 {
 	struct bgp *bgp_evpn = NULL;
 
-	form_auto_rt(bgp_vrf, bgp_vrf->l3vni, bgp_vrf->vrf_import_rtl, true);
+	if (!is_l3vni_live(bgp_vrf))
+		return;
 
 	/* Map RT to VRF */
 	bgp_evpn = bgp_get_evpn();
-
 	if (!bgp_evpn)
 		return;
+
+	form_auto_rt(bgp_vrf, bgp_vrf->l3vni, bgp_vrf->vrf_import_rtl, true);
 
 	bgp_evpn_map_vrf_to_its_rts(bgp_vrf);
 }
@@ -5153,6 +5155,16 @@ static void evpn_auto_rt_import_delete_for_vrf(struct bgp *bgp_vrf)
  */
 static void evpn_auto_rt_export_add_for_vrf(struct bgp *bgp_vrf)
 {
+	struct bgp *bgp_evpn = NULL;
+
+	if (!is_l3vni_live(bgp_vrf))
+		return;
+
+	/* Map RT to VRF */
+	bgp_evpn = bgp_get_evpn();
+	if (!bgp_evpn)
+		return;
+
 	form_auto_rt(bgp_vrf, bgp_vrf->l3vni, bgp_vrf->vrf_export_rtl, true);
 }
 


### PR DESCRIPTION
Fixing memory leak found by ASAN:

```
Indirect leak of 24 byte(s) in 3 object(s) allocated from:
    0 0x7fde542b4887 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    1 0x7fde53f112b9 in qmalloc lib/memory.c:100
    2 0x55b1f4829b8d in ecommunity_add_val_internal bgpd/bgp_ecommunity.c:91
    3 0x55b1f482dab8 in form_auto_rt bgpd/bgp_evpn.c:628
    4 0x55b1f4839cad in evpn_auto_rt_import_add_for_vrf bgpd/bgp_evpn.c:5129
    5 0x55b1f4839cad in bgp_evpn_local_l3vni_add bgpd/bgp_evpn.c:6867
    6 0x55b1f4938215 in bgp_zebra_process_local_l3vni bgpd/bgp_zebra.c:3181
    7 0x7fde53f8ab4c in zclient_read lib/zclient.c:4626
    8 0x7fde53f64c9b in event_call lib/event.c:1996
    9 0x7fde53f03887 in frr_run lib/libfrr.c:1232
    10 0x55b1f4810850 in main bgpd/bgp_main.c:555
    11 0x7fde53a29d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
```