### PR TITLE
tests: Allow convergence before adding multicast routes

### DIFF
--- a/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_transit_router_topo3.py
+++ b/tests/topotests/multicast_pim_dr_nondr_test/test_pim_dr_nondr_with_transit_router_topo3.py
@@ -25,6 +25,10 @@ import time
 import datetime
 from time import sleep
 import pytest
+from functools import partial
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
@@ -593,6 +597,66 @@ def pre_config_for_source_dr_tests(
 
     result = create_pim_config(tgen, topo, input_dict)
     assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    expected = {
+        "r2-s1-eth1.2501": {
+            "state": "up",
+            "address": "10.1.1.1",
+            "neighbors": {
+                "10.1.1.2": {
+                    "address": "10.1.1.2",
+                }
+            },
+            "drAddress": "10.1.1.2",
+        }
+    }
+
+    step("Ensure that neighbors have come up on the vlan")
+    r2 = tgen.gears["r2"]
+    test_func = partial(
+        topotest.router_json_cmp,
+        r2,
+        "show ip pim interface r2-s1-eth1.2501 json",
+        expected,
+    )
+    result, _ = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result, "Neighbors did not come up: {}".format(result)
+
+    expected = {
+        "10.1.1.0/24": [
+            {
+                "prefix": "10.1.1.0/24",
+                "prefixLen": 24,
+                "protocol": "ospf",
+                "vrfName": "default",
+                "distance": 110,
+                "metric": 20,
+                "nexthops": [
+                    {
+                        "ip": "10.0.3.1",
+                        "afi": "ipv4",
+                        "interfaceName": "r5-r4-eth1",
+                        "weight": 1,
+                    },
+                    {
+                        "ip": "10.0.3.1",
+                        "afi": "ipv4",
+                        "interfaceName": "r5-r4-eth1",
+                        "weight": 1,
+                    },
+                ],
+            }
+        ]
+    }
+
+    step("Ensure that the vlan route is available where it is needed")
+    r5 = tgen.gears["r5"]
+    test_func = partial(
+        topotest.router_json_cmp, r5, "show ip route 10.1.1.0/24 json", expected
+    )
+
+    result, _ = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result, "vlan routes are not available on r5\n{}".format(result)
 
     step("Configure IGMP on R5 port and send IGMP join for groups " "(226.1.1.1-5)")
 


### PR DESCRIPTION
Current code adds a new vlan interface, sets up ospf and pim on it and immediately starts shoving data down the pipes. This of course has the fun thing where the IGP and pim do not always come up in a nice neat manner and the test is looking for state from a nice neat come up, even though pim is `working` correctly it is not correct for what the test wants.

Modify the code to ensure that ospf is up and has propagated the route where it is needed as well as that pim neighbors have properly come up, then initiate the multicast streams and igmp reports.