### PR TITLE
isisd: fix update link params after circuit is up

### DIFF
--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -327,7 +327,7 @@ void isis_link_params_update(struct isis_circuit *circuit,
 		return;
 
 	/* Sanity Check */
-	if ((ifp == NULL) || (circuit->state != C_STATE_UP))
+	if (ifp == NULL)
 		return;
 
 	te_debug("ISIS-TE(%s): Update circuit parameters for interface %s",


### PR DESCRIPTION
If the link-params are set when the circuit not yet up, the link-params are never updated.

isis_link_params_update() is called from isis_circuit_up() but returns immediately because circuit->state != C_STATE_UP. circuit->state is updated in isis_csm_state_change after isis_circuit_up().

> struct isis_circuit *isis_csm_state_change(enum isis_circuit_event event,
> 					   struct isis_circuit *circuit,
> 					   void *arg)
> {
> [...]
> 			if (isis_circuit_up(circuit) != ISIS_OK) {
> 				isis_circuit_deconfigure(circuit, area);
> 				break;
> 			}
> 			circuit->state = C_STATE_UP;
> 			isis_event_circuit_state_change(circuit, circuit->area,
> 							1);

Do not return isis_link_params_update() if circuit->state != C_STATE_UP.

Fixes: 0fdd8b2b11 ("isisd: update link params after circuit is up")