### PR TITLE
mgmtd: Ensure map is NULL

### DIFF
--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -249,6 +249,8 @@ static void mgmt_register_client_xpath(enum mgmt_be_client_id id,
 {
 	struct mgmt_be_xpath_map **maps, *map;
 
+	maps = NULL;
+
 	switch (type) {
 	case MGMT_BE_XPATH_SUBSCR_TYPE_CFG:
 		maps = &be_cfg_xpath_map;


### PR DESCRIPTION
Build is complaining:
build	27-Aug-2024 05:46:38	mgmtd/mgmt_be_adapter.c: In function ‘mgmt_register_client_xpath’: build	27-Aug-2024 05:46:38	mgmtd/mgmt_be_adapter.c:274:27: warning: ‘maps’ may be used uninitialized [-Wmaybe-uninitialized]
build	27-Aug-2024 05:46:38	  274 |         map = darr_append(*maps);
build	27-Aug-2024 05:46:38	      |                           ^
build	27-Aug-2024 05:46:38	mgmtd/mgmt_be_adapter.c:250:36: note: ‘maps’ was declared here
build	27-Aug-2024 05:46:38	  250 |         struct mgmt_be_xpath_map **maps, *map;
build	27-Aug-2024 05:46:38	      |                                    ^~~~

Let's make the compiler happy, even though there is no problem.