### PR TITLE
doc: Update topotest doc to include iptables is needed

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -33,6 +33,7 @@ Installing Topotest Requirements
        net-tools \
        python3-pip \
        iputils-ping \
+       iptables \
        tshark \
        valgrind
    python3 -m pip install wheel


### PR DESCRIPTION
The nhrp tests skip tests that do not have iptables installed. As such we have ended up with a situation where the nrhp test is now failing locally for me because I have iptables installed and if the CI system had iptables installed it would have detected the problem as well.

Let's document that iptables is needed to do testing.