### PR TITLE
zebra: Move prefix lookup to outside re loop

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -891,15 +891,14 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 	for (rn = route_top(table); rn; rn = srcdest_route_next(rn)) {
 		dest = rib_dest_from_rnode(rn);
 
+		if (longer_prefix_p && !prefix_match(longer_prefix_p, &rn->p))
+			continue;
+
 		RNODE_FOREACH_RE (rn, re) {
 			if (use_fib && re != dest->selected_fib)
 				continue;
 
 			if (tag && re->tag != tag)
-				continue;
-
-			if (longer_prefix_p
-			    && !prefix_match(longer_prefix_p, &rn->p))
 				continue;
 
 			/* This can only be true when the afi is IPv4 */


### PR DESCRIPTION
Move the prefix lookup/comparison to outside the re loop and into the rn loop, since that is where the code should actually be.