### PR TITLE
tests: Ensure bgp suppress fib has a chance to transmit data to peer

### DIFF
--- a/tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py
+++ b/tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py
@@ -140,7 +140,7 @@ def test_bgp_better_admin_won():
         topotest.router_json_cmp, r3, "show ip route 40.0.0.0 json", expected
     )
 
-    _, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assertmsg = '"r3" route to 40.0.0.0 should have been lost'
     assert result is None, assertmsg
 
@@ -155,7 +155,7 @@ def test_bgp_better_admin_won():
         "show ip route 40.0.0.0 json",
         expected,
     )
-    _, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assertmsg = '"r3" route to 40.0.0.0 did not come back'
     assert result is None, assertmsg
 
@@ -196,7 +196,7 @@ def test_bgp_allow_as_in():
         expected,
     )
 
-    _, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assertmsg = '"r1" 192.168.1.1/32 route should have arrived'
     assert result is None, assertmsg
 
@@ -212,7 +212,7 @@ def test_bgp_allow_as_in():
         expected,
     )
 
-    _, result = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assertmsg = '"r2" 192.168.1.1/32 route should be gone'
     assert result is None, assertmsg
 


### PR DESCRIPTION
Giving only 5 seconds to pass bgp data to peers on a heavily loaded system is a recipe for not having fun.  Add more time.