### PR TITLE
tests: ospf_netns_vrf should give more time for coming up

### DIFF
--- a/tests/topotests/ospf_netns_vrf/test_ospf_netns_vrf.py
+++ b/tests/topotests/ospf_netns_vrf/test_ospf_netns_vrf.py
@@ -234,7 +234,7 @@ def test_ospf_json():
             "show ip ospf vrf {0}-ospf-cust1 json".format(rname),
             expected,
         )
-        _, diff = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
+        _, diff = topotest.run_and_expect(test_func, None, count=30, wait=1)
         assertmsg = '"{}" JSON output mismatches'.format(rname)
         assert diff is None, assertmsg
 


### PR DESCRIPTION
Test fails:

            test_func = partial(
                topotest.router_json_cmp,
                router,
                "show ip ospf vrf {0}-ospf-cust1 json".format(rname),
                expected,
            )
            _, diff = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
            assertmsg = '"{}" JSON output mismatches'.format(rname)
>           assert diff is None, assertmsg
E           AssertionError: "r1" JSON output mismatches
E           assert Generated JSON diff error report:
E
E             > $->r1-ospf-cust1->areas->0.0.0.0->nbrFullAdjacentCounter: output has element with value '1' but in expected it has value '2'

/home/sharpd/frr2/tests/topotests/ospf_netns_vrf/test_ospf_netns_vrf.py:239: AssertionError

Support bundle has this data:
r1# show ip ospf vrf all neighbor
% 2024/08/28 14:55:54.763

VRF Name: r1-ospf-cust1

Neighbor ID     Pri State           Up Time         Dead Time Address         Interface                        RXmtL RqstL DBsmL
10.0.255.3        1 Full/DR         10.547s           39.456s 10.0.3.1        r1-eth1:10.0.3.2                     0     0     0
10.0.255.2        1 Full/Backup     0.543s            38.378s 10.0.3.3        r1-eth1:10.0.3.2                     1     0     0

So immediately after the test fails this test, the neighbor comes up. Let's give the test a bit more time for failure to not happen