### PR TITLE
 staticd: Handle static routes appropriately

### DIFF
--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -94,7 +94,16 @@ static int static_ifp_destroy(struct interface *ifp)
 
 static int interface_address_add(ZAPI_CALLBACK_ARGS)
 {
-	zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
+	struct interface *ifp;
+	struct connected *ifc;
+
+	ifc = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
+
+	ifp = ifc->ifp;
+
+	/* route walk */
+	if (CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE))
+		static_ifindex_update(ifp, true);
 
 	return 0;
 }


### PR DESCRIPTION
zebra not restore routes when have more then one iface with common network and one iface is flaping (up, then get IP) #16110 

Introduction:
As per the bug when setting up a route via dum2 and assuming it will be restored after the interface is restored. There is a weird behavior. Good behavior "get addr + up" then the route is activated as expected. But when "up + get addr" the route is inactive, though the interface is up and the connected route is added.

Implementation details:
We have added a check whether the interface is up or not and triggering the function which potentially leads to route walk.

Hope this implementation is a good an approach, if not let's know the alternative one, so that we can work on it.

Thanks
Denny Agussy