### PR TITLE
Fix IPV6 src-dest route

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -310,6 +310,21 @@ Global Commands
    The descriptor for this bit should exist in :file:`/etc/iproute2/protodown_reasons.d/`
    to display with :clicmd:`ip -d link show`.
 
+Nexthop Objects
+===============
+
+If dataplane supports nexthop objects, zebra uses this feature to install
+nexthops, instead of embedding them in every route. This behavior can be toggled
+with
+
+.. clicmd:: [no] zebra nexthop kernel enable
+
+for linux kernel or ``[no] fpm use-next-hop-groups`` for
+:ref:`FPM <fpm-commands>`.
+
+However, linux kernel doesn't support referencing nexthop object in IPv6 source
+routes, so zebra will fallback to embeded nexthops for those.
+
 Nexthop Tracking
 ================
 
@@ -1339,6 +1354,8 @@ the FPM a complete copy of the forwarding table(s) when it reconnects.
 
 For more details on the implementation, please read the developer's manual FPM
 section.
+
+.. _fpm-commands:
 
 FPM Commands
 ============

--- a/staticd/static_nht.h
+++ b/staticd/static_nht.h
@@ -16,14 +16,14 @@ extern "C" {
  * us call this function to find the nexthop we are tracking so it
  * can be installed or removed.
  *
- * sp -> The route we are looking at.  If NULL then look at all
+ * rn -> The route node we are looking at.  If NULL then look at all
  *       routes.
  * nhp -> The nexthop that is being tracked.
  * nh_num -> number of valid nexthops.
  * afi -> The afi we are working in.
  * vrf_id -> The vrf the nexthop is in.
  */
-extern void static_nht_update(struct prefix *sp, struct prefix *nhp,
+extern void static_nht_update(struct route_node *rn, struct prefix *nhp,
 			      uint32_t nh_num, afi_t afi, safi_t safi,
 			      vrf_id_t vrf_id);
 

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -344,7 +344,7 @@ void static_zebra_nht_register(struct static_nexthop *nh, bool reg)
 			if (nh->state == STATIC_NOT_INSTALLED ||
 			    nh->state == STATIC_SENT_TO_ZEBRA)
 				nh->state = STATIC_START;
-			static_nht_update(&rn->p, &nhtd->nh, nhtd->nh_num, afi,
+			static_nht_update(rn, &nhtd->nh, nhtd->nh_num, afi,
 					  si->safi, nh->nh_vrf_id);
 			return;
 		}

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2361,6 +2361,7 @@ ssize_t netlink_route_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx
 	}
 
 	if ((!fpm && kernel_nexthops_supported()
+	     && (p->family != AF_INET6 || !src_p)
 	     && (!proto_nexthops_only()
 		 || is_proto_nhg(dplane_ctx_get_nhe_id(ctx), 0)))
 	    || (fpm && force_nhg)) {


### PR DESCRIPTION
Fix issues of IPv6 src-dest route:

    (confg)# ipv6 route 1::1/128 from 2::2/128 fe80::1 eth0

1. staticd doesn't handle them on nht event
2. linux kernel rejects routes with both source and nexthop object.
