### PR TITLE
No connected/local/kernel nexthops at first

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -1637,7 +1637,11 @@ zebra Terminal Mode Commands
    option as that nexthop groups are per namespace in linux.
    If you specify singleton you would like to see the singleton
    nexthop groups that do have an afi. [type] allows you to filter those
-   only coming from a specific NHG type (protocol).
+   only coming from a specific NHG type (protocol).  A nexthop group
+   that has `Initial Delay`, means that this nexthop group entry
+   was not installed because no-one was using it at that point and
+   Zebra can delay installing this route until it is used by something
+   else.
 
 .. clicmd:: show <ip|ipv6> zebra route dump [<vrf> VRFNAME]
 

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -152,6 +152,25 @@ struct nhg_hash_entry {
  * when installation is successful.
  */
 #define NEXTHOP_GROUP_REINSTALL (1 << 8)
+
+/*
+ * Connected routes and kernel routes received
+ * from the kernel or created by Zebra do no
+ * need to be installed.  For connected, this
+ * is because the routes are in the local table
+ * but not imported and we create an amalgram
+ * route for it.  For kernel routes if the route
+ * is an pre-nhg route, there is no nexthop associated
+ * with it and we should not create it until it
+ * is used by something else.
+ * The reason for this is because is that this just
+ * fills up the DPlane's nexthop slots when there
+ * are a bunch of interfaces or pre-existing routes
+ * As such let's not initially install it ( but
+ * pretend it was successful ) and if another route
+ * chooses this NHG then we can install it then.
+ */
+#define NEXTHOP_GROUP_INITIAL_DELAY_INSTALL (1 << 9)
 };
 
 /* Upper 4 bits of the NHG are reserved for indicating the NHG type */
@@ -364,7 +383,7 @@ extern uint8_t zebra_nhg_nhe2grp(struct nh_grp *grp, struct nhg_hash_entry *nhe,
 				 int size);
 
 /* Dataplane install/uninstall */
-extern void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe);
+extern void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe, uint8_t type);
 extern void zebra_nhg_uninstall_kernel(struct nhg_hash_entry *nhe);
 extern void zebra_interface_nhg_reinstall(struct interface *ifp);
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -688,7 +688,7 @@ void rib_install_kernel(struct route_node *rn, struct route_entry *re,
 	/*
 	 * Install the resolved nexthop object first.
 	 */
-	zebra_nhg_install_kernel(re->nhe);
+	zebra_nhg_install_kernel(re->nhe, re->type);
 
 	/*
 	 * If this is a replace to a new RE let the originator of the RE
@@ -4384,9 +4384,14 @@ int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
 	 * Use a temporary nhe to convey info to the common/main api.
 	 */
 	zebra_nhe_init(&nhe, afi, (ng ? ng->nexthop : NULL));
-	if (ng)
+	if (ng) {
 		nhe.nhg.nexthop = ng->nexthop;
-	else if (re->nhe_id > 0)
+
+		if (re->type == ZEBRA_ROUTE_CONNECT ||
+		    re->type == ZEBRA_ROUTE_LOCAL ||
+		    re->type == ZEBRA_ROUTE_KERNEL)
+			SET_FLAG(nhe.flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL);
+	} else if (re->nhe_id > 0)
 		nhe.id = re->nhe_id;
 
 	n = zebra_nhe_copy(&nhe, 0);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1230,6 +1230,13 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 			else
 				vty_out(vty, ", Installed");
 		}
+		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL)) {
+			if (json)
+				json_object_boolean_true_add(json,
+							     "initialDelay");
+			else
+				vty_out(vty, ", Initial Delay");
+		}
 		if (!json)
 			vty_out(vty, "\n");
 	}


### PR DESCRIPTION
When creating these three types of routes, we are also implicitly creating a nexthop group that matches these routes.  If these routes already exist in the kernel using the old style of nexthops there is no need to immediately install these nexthops.  Make it so that they initially will `pretend` install and then when it is really needed install them.