### PR TITLE
bgpd: show neighbor hostname if description is not set

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -12617,6 +12617,9 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 				/* Make sure `Desc` column is the lastest in
 				 * the output.
 				 * If the description is not set, try
+				 * to print the hostname if the
+				 * capability is enabled and received.
+				 * If the hostname is not set, try
 				 * to print the software version if the
 				 * capability is enabled and received.
 				 */
@@ -12625,7 +12628,12 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 						bgp_peer_description_stripped(
 							peer->desc,
 							show_wide ? 64 : 20));
-				else if (peer->soft_version) {
+				else if (peer->hostname) {
+					vty_out(vty, " %s",
+						bgp_peer_description_stripped(
+							peer->hostname,
+							show_wide ? 64 : 20));
+				} else if (peer->soft_version) {
 					vty_out(vty, " %s",
 						bgp_peer_description_stripped(
 							peer->soft_version,


### PR DESCRIPTION
Follow up to #13947 

If a description is not set for a neighbor then print the hostname if it's advertised, then fall back to software version.

The hostname is arguably a better description than the software version in the summary output so it should be printed first if available, then fall back to software version if it's not

Current behavior (on VyOS so it's FRR 9.1.1)

```
Neighbor           V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
*fd00:0:0:ffff::1  4     204225    345953   7343928       36    0    0 5d21h28m            1       28 FRRouting/9.1.1
*fd00:0:0:ffff::3  4     204225      8502   7345456       36    0    0 5d21h28m            1       28 FRRouting/9.1.1
*fd00:0:0:ffff::4  4     204225    291082   7346479       36    0    0 5d21h29m            1       28 FRRouting/9.1.1
*fd00:0:0:ffff::5  4     204225    369410   7346325       36    0    0 5d21h29m            1       28 FRRouting/9.1.1
*fd00:0:0:ffff::6  4     204225    241150   7346325       36    0    0 5d21h29m            1       28 FRRouting/9.1.1
*fd00:0:0:ffff::7  4     204225      4846    129630       36    0    0 03:04:08            1       28 FRRouting/9.1.1
*fd00:0:0:ffff::8  4     204225    308826   7330273       36    0    0 5d21h27m            1       28 FRRouting/9.1.1
*fd00:0:0:ffff::9  4     204225     90658   7343832       36    0    0 5d21h28m            1       28 FRRouting/9.1.1
*fd00:0:0:ffff::a  4     204225    212580   7346479       36    0    0 5d21h29m            1       28 FRRouting/9.1.1
```

New behavior

```
Neighbor           V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
*fd00:0:0:ffff::1  4     204225    345953   7343928       36    0    0 5d21h28m            1       28 router.ams1
*fd00:0:0:ffff::3  4     204225      8502   7345456       36    0    0 5d21h28m            1       28 router.cgk1
*fd00:0:0:ffff::4  4     204225    291082   7346479       36    0    0 5d21h29m            1       28 router.chi1
*fd00:0:0:ffff::5  4     204225    369410   7346325       36    0    0 5d21h29m            1       28 router.dal1
*fd00:0:0:ffff::6  4     204225    241150   7346325       36    0    0 5d21h29m            1       28 router.ewr1
*fd00:0:0:ffff::7  4     204225      4846    129630       36    0    0 03:04:08            1       28 router.fnc1
*fd00:0:0:ffff::8  4     204225    308826   7330273       36    0    0 5d21h27m            1       28 router.fra1
*fd00:0:0:ffff::9  4     204225     90658   7343832       36    0    0 5d21h28m            1       28 router.gru1
*fd00:0:0:ffff::a  4     204225    212580   7346479       36    0    0 5d21h29m            1       28 router.iad1
```

Need to figure out if [these lines](https://github.com/FRRouting/frr/blob/master/bgpd/bgp_vty.c#L11810-L11812) need to be handled as well as it seems to have similar functionality of displaying the software version

```
RS1(config-router)# do show bgp l2vpn evpn summary failed
BGP router identifier 192.168.0.179, local AS number 4200000179 VRF default vrf-id 0
BGP table version 0
RIB entries 5, using 480 bytes of memory
Peers 1, using 20 KiB of memory
Peer groups 2, using 128 bytes of memory

Neighbor        EstdCnt DropCnt ResetTime Reason
S1(fd00::10:10)       2       2  00:00:05  No path to specified Neighbor (FRRouting/10.0.1)
```

Quick and dirty would be below, but isn't the most elegant thing to look at

```c
vty_out(vty, " %s (%s)\n",
	peer_down_str[(int)peer->last_reset],
	peer->hostname ? peer->hostname : 
	peer->software_version ? peer->software_version : "n/a");

```