### PR TITLE
zebra: Convince SA that the ng will always be valid

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4413,7 +4413,8 @@ int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
 				return -1;
 			}
 
-			if (ifp->ifindex == ng->nexthop->ifindex)
+			if (ng && ng->nexthop &&
+			    ifp->ifindex == ng->nexthop->ifindex)
 				re->type = ZEBRA_ROUTE_CONNECT;
 		}
 	}


### PR DESCRIPTION
There is a code path that could theoretically get you to a point where the ng->nexthop is a NULL value.
Let's just make sure the SA system believes that
cannot happen anymore.