### PR TITLE
zebra: add an approach to keep the NHG ID unchanged for recursive rou…

### DIFF
--- a/tests/topotests/zebra_nhg_id/r1/zebra.conf
+++ b/tests/topotests/zebra_nhg_id/r1/zebra.conf
@@ -1,0 +1,17 @@
+log timestamp precision 3
+
+interface r1-eth0
+ ip address 10.1.1.1/24
+exit
+
+interface r1-eth1
+ ip address 10.2.2.1/24
+exit
+
+interface r1-eth2
+ ip address 10.3.3.1/24
+exit
+
+interface r1-eth3
+ ip address 10.4.4.1/24
+exit

--- a/tests/topotests/zebra_nhg_id/test_zebra_nhg_id.py
+++ b/tests/topotests/zebra_nhg_id/test_zebra_nhg_id.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_zebra_nhg_id.py
+#
+# Copyright (c) 2024 by
+# Accton, Inc
+# Yongxin Cao
+#
+
+"""
+test_zebra_nhg_id.py: Test zebra NHG ID preservation
+"""
+
+
+import os
+import sys
+import re
+
+import pytest
+from lib.topogen import TopoRouter, Topogen
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.staticd]
+
+
+@pytest.fixture(scope="module")
+def tgen(request):
+    "Setup/Teardown the environment and provide tgen argument to tests"
+
+    topodef = {
+        "s1": ("r1",),
+        "s2": ("r1",),
+        "s3": ("r1",),
+        "s4": ("r1",),
+    }
+
+    tgen = Topogen(topodef, request.module.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_config(TopoRouter.RD_ZEBRA, os.path.join(CWD, "r1/zebra.conf"))
+
+    tgen.start_router()
+    yield tgen
+
+
+def test_nhg_id(tgen):
+
+    r1 = tgen.routers()["r1"]
+
+    r1.vtysh_cmd("conf t\nip route 1.1.1.1/24 100.0.0.1")
+    r1.vtysh_cmd("conf t\nip route 1.1.1.1/24 200.0.0.1")
+    r1.vtysh_cmd("conf t\nip route 100.0.0.1/24 10.1.1.2")
+    r1.vtysh_cmd("conf t\nip route 100.0.0.1/24 10.2.2.2")
+    r1.vtysh_cmd("conf t\nip route 200.0.0.1/24 10.3.3.2")
+    r1.vtysh_cmd("conf t\nip route 200.0.0.1/24 10.4.4.2")
+    r1.vtysh_cmd("conf t\nip route 200.0.0.1/24 10.4.4.2")
+
+    text1 = r1.vtysh_cmd("show ip route 200.0.0.0/24 nexthop-group")
+
+    r1.run(f"sudo ip link set dev r1-eth0 down")
+
+    text2 = r1.vtysh_cmd("show ip route 200.0.0.0/24 nexthop-group")
+
+    regex = r"Nexthop Group ID:\s+([^\n]+)"
+    matches1 = re.findall(regex, text1)
+    matches2 = re.findall(regex, text2)
+
+    assert matches1 == matches2

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -138,6 +138,8 @@ struct route_entry {
  */
 #define ROUTE_ENTRY_ROUTE_REPLACING 0x80
 
+#define ROUTE_ENTRY_NHG_PRESERVED 0x100
+
 	/* Sequence value incremented for each dataplane operation */
 	uint32_t dplane_sequence;
 

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -282,12 +282,17 @@ extern bool zebra_nhg_dependents_is_empty(const struct nhg_hash_entry *nhe);
 /* Lookup ID, doesn't create */
 extern struct nhg_hash_entry *zebra_nhg_lookup_id(uint32_t id);
 
+/* Lookup preserved, doesn't create */
+extern struct nhg_hash_entry *zebra_presvd_nhg_lookup(struct nhg_hash_entry *lookup);
+
 /* Hash functions */
 extern uint32_t zebra_nhg_hash_key(const void *arg);
 extern uint32_t zebra_nhg_id_key(const void *arg);
+extern uint32_t zebra_nhg_presvd_key(const void *arg);
 
 extern bool zebra_nhg_hash_equal(const void *arg1, const void *arg2);
 extern bool zebra_nhg_hash_id_equal(const void *arg1, const void *arg2);
+extern bool zebra_nhg_presvd_hash_equal(const void *arg1, const void *arg2);
 
 /*
  * Process a context off of a queue.

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -254,6 +254,7 @@ void zebra_router_terminate(void)
 	hash_iterate(zrouter.nhgs_id, zebra_nhg_hash_free_zero_id, NULL);
 	hash_clean_and_free(&zrouter.nhgs_id, zebra_nhg_hash_free);
 	hash_clean_and_free(&zrouter.nhgs, NULL);
+	hash_clean_and_free(&zrouter.nhgs_presvd, NULL);
 
 	hash_clean_and_free(&zrouter.rules_hash, zebra_pbr_rules_free);
 
@@ -319,6 +320,9 @@ void zebra_router_init(bool asic_offload, bool notify_on_ack,
 		hash_create_size(8, zebra_nhg_id_key, zebra_nhg_hash_id_equal,
 				 "Zebra Router Nexthop Groups ID index");
 
+	zrouter.nhgs_presvd =
+		hash_create_size(8, zebra_nhg_presvd_key, zebra_nhg_presvd_hash_equal,
+				 "Zebra Router Preserved Nexthop Groups");
 	zrouter.qdisc_hash =
 		hash_create_size(8, zebra_tc_qdisc_hash_key,
 				 zebra_tc_qdisc_hash_equal, "TC (qdisc) Hash");

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -202,6 +202,9 @@ struct zebra_router {
 	struct hash *nhgs;
 	struct hash *nhgs_id;
 
+	/* The hash of preserved nexthop */
+	struct hash *nhgs_presvd;
+
 	/*
 	 * Does the underlying system provide an asic offload
 	 */


### PR DESCRIPTION
…tes and to quickly fix involved NHGs in the dataplanes when recursive routes converge

This modification requirements comes from the HLD
https://github.com/eddieruan-alibaba/SONiC/blob/eruan-recursive/doc/recursive/recursive_route.md

For achieving this quick fixup, we need the following changes
1. change NHG ID hash method, preserve the NHG ID
2. add a new function zebra_rnh_fixup_depends() to make a quick fixup on involved recursive NHGs in dataplanes