### PR TITLE
bgpd: fix wrong display of default vrf name

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12347,7 +12347,9 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 						VRF_DEFAULT_NAME);
 				else
 					vty_out(vty, ", vrf %s",
-						bgp->name);
+						(bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT)
+						? VRF_DEFAULT_NAME
+						: bgp->name);
 			}
 		} else
 			vty_out(vty, ", no best path");


### PR DESCRIPTION
The following output displays a ((null)) vrf:

> rt2> show bgp ipv4 labeled-unicast prefix 172.16.1.1/32
> BGP routing table entry for 172.16.1.1/32, version 2
> Local label: 16
> Paths: (1 available, best #1, table default, vrf (null))
>   Advertised to non peer-group peers:
>   172.16.1.1
> [..]

Fix this by displaying the appropriate default vrf name when possible.