### PR TITLE
isisd: Add extra checks for reading stream

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -2152,6 +2152,19 @@ static int unpack_item_ext_subtlvs(uint16_t mtid, uint8_t len, struct stream *s,
 			return 1;
 		}
 
+		if (subtlv_len == 0) {
+			sbuf_push(log, indent, "TLV %hhu: subtlv length is 0",
+				  subtlv_type);
+			return 1;
+		}
+
+		if (subtlv_len > STREAM_READABLE(s)) {
+			sbuf_push(log, indent,
+				  "TLV %hhu: Stream amount readable %lu is less than specified subtlv_len %u size",
+				  subtlv_type, STREAM_READABLE(s), subtlv_len);
+			return 1;
+		}
+
 		switch (subtlv_type) {
 		/* Standard Metric as defined in RFC5305 */
 		case ISIS_SUBTLV_ADMIN_GRP:


### PR DESCRIPTION
Let's prevent some issues from happening from
reading bad data from a peer.

==1853291==ERROR: AddressSanitizer: stack-buffer-overflow on address 0xfa85eb113121 at pc 0xc6a2300ccce8 bp 0xffffebaa1c50 sp 0xffffebaa1c48 WRITE of size 1 at 0xfa85eb113121 thread T0
    #0 0xc6a2300ccce4 in unpack_item_ext_subtlv_asla /home/ubuntu/frr-public/frr_public_private-libfuzzer/isisd/isis_tlvs.c:1950:11
    #1 0xc6a2300cc5c0 in unpack_item_ext_subtlvs /home/ubuntu/frr-public/frr_public_private-libfuzzer/isisd/isis_tlvs.c:2555:8
    #2 0xc6a2300c3264 in unpack_item_extended_reach /home/ubuntu/frr-public/frr_public_private-libfuzzer/isisd/isis_tlvs.c:3890:7
    #3 0xc6a2300be3e4 in unpack_item /home/ubuntu/frr-public/frr_public_private-libfuzzer/isisd/isis_tlvs.c:7027:10
    #4 0xc6a2300bd140 in unpack_tlv_with_items /home/ubuntu/frr-public/frr_public_private-libfuzzer/isisd/isis_tlvs.c:7091:8
    #5 0xc6a2300fb268 in unpack_tlv /home/ubuntu/frr-public/frr_public_private-libfuzzer/isisd/isis_tlvs.c:8010:10
    #6 0xc6a2300ad508 in unpack_tlvs /home/ubuntu/frr-public/frr_public_private-libfuzzer/isisd/isis_tlvs.c:8032:8
    #7 0xc6a2300ad2d4 in isis_unpack_tlvs /home/ubuntu/frr-public/frr_public_private-libfuzzer/isisd/isis_tlvs.c:8063:7
    #8 0xc6a230016840 in process_lsp /home/ubuntu/frr-public/frr_public_private-libfuzzer/isisd/isis_pdu.c:969:6
    #9 0xc6a230012ff8 in isis_handle_pdu /home/ubuntu/frr-public/frr_public_private-libfuzzer/isisd/isis_pdu.c:1823:12
    #10 0xc6a22ffa7f0c in LLVMFuzzerTestOneInput /home/ubuntu/frr-public/frr_public_private-libfuzzer/isisd/isis_main.c:376:5

Let's just make sure that we have enough data to read.

Reported-by: Iggy Frankovic <iggyfran@amazon.com>