### PR TITLE
isisd: fix crash when reading asla

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -1914,8 +1914,8 @@ static int unpack_item_ext_subtlv_asla(uint16_t mtid, uint8_t subtlv_len,
 	uint8_t sabm_flag_len;
 	/* User-defined App Identifier Bit Flags/Length */
 	uint8_t uabm_flag_len;
-	uint8_t sabm[ASLA_APP_IDENTIFIER_BIT_LENGTH] = {0};
-	uint8_t uabm[ASLA_APP_IDENTIFIER_BIT_LENGTH] = {0};
+	uint8_t sabm[ASLA_APP_IDENTIFIER_BIT_MAX_LENGTH] = { 0 };
+	uint8_t uabm[ASLA_APP_IDENTIFIER_BIT_MAX_LENGTH] = { 0 };
 	uint8_t readable = subtlv_len;
 	uint8_t subsubtlv_type;
 	uint8_t subsubtlv_len;
@@ -1943,6 +1943,15 @@ static int unpack_item_ext_subtlv_asla(uint16_t mtid, uint8_t subtlv_len,
 	if (readable <
 	    asla->standard_apps_length + asla->user_def_apps_length) {
 		TLV_SIZE_MISMATCH(log, indent, "ASLA");
+		return -1;
+	}
+
+	if ((asla->standard_apps_length > ASLA_APP_IDENTIFIER_BIT_MAX_LENGTH) ||
+	    (asla->user_def_apps_length > ASLA_APP_IDENTIFIER_BIT_MAX_LENGTH)) {
+		zlog_err("Standard or User-Defined Application Identifier Bit Mask Length greater than %u bytes. Received respectively a length of %u and %u bytes.",
+			 ASLA_APP_IDENTIFIER_BIT_MAX_LENGTH,
+			 asla->standard_apps_length, asla->user_def_apps_length);
+		stream_forward_getp(s, readable);
 		return -1;
 	}
 

--- a/isisd/isis_tlvs.h
+++ b/isisd/isis_tlvs.h
@@ -717,6 +717,7 @@ struct isis_ext_subtlvs {
 #define ISIS_SABM_FLAG_X 0x10 /* Flex-Algorithm - RFC9350 */
 
 #define ASLA_APP_IDENTIFIER_BIT_LENGTH 1
+#define ASLA_APP_IDENTIFIER_BIT_MAX_LENGTH 8
 #define ASLA_LEGACY_FLAG 0x80
 #define ASLA_APPS_LENGTH_MASK 0x7f
 


### PR DESCRIPTION
isisd is crashing when reading a ASLA sub-TLV with Application Identifier Bit Mask length greater than 1 octet.

Set a limit of 8 bytes in accordance with RFC9479 and check that the received value does not exceed the limit.

Link: https://www.rfc-editor.org/rfc/rfc9479.html#name-application-identifier-bit-
Fixes: 5749ac83a8 ("isisd: add ASLA support")