### PR TITLE
tools: fix reload interface deletion

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1757,12 +1757,13 @@ def compare_context_objects(newconf, running):
                 delete_bgpd = True
                 lines_to_del.append((running_ctx_keys, None))
 
-            # We cannot do 'no interface' or 'no vrf' in FRR, and so deal with it
-            elif (
-                running_ctx_keys[0].startswith("interface")
-                or running_ctx_keys[0].startswith("vrf")
-                or running_ctx_keys[0].startswith("router pim")
-            ):
+            elif running_ctx_keys[0].startswith("interface"):
+                lines_to_del.append((running_ctx_keys, None))
+
+            # We cannot do 'no vrf' in FRR, and so deal with it
+            elif running_ctx_keys[0].startswith("vrf") or running_ctx_keys[
+                0
+            ].startswith("router pim"):
                 for line in running_ctx.lines:
                     lines_to_del.append((running_ctx_keys, line))
 


### PR DESCRIPTION
## Current Behavior

- When reloading the configuration in FRR, the `frr-reload.py` script does not allow removing an entire interface context in one step. Instead, it attempts to delete each configuration line individually under the interface context.
- This line-by-line deletion can cause issues when the interface is already removed from the system.

**Specific Issue:**
- If an interface has been removed from the system, trying to delete specific configurations (such as IP addresses) under that interface context fails.
- For example, if an IP address was configured on an interface that no longer exists, trying to remove that IP address will result in an error because the interface itself is not present.

**Impact of the Issue:**
- This behavior leads to errors during the configuration reload process, making it difficult to cleanly manage and synchronize the FRR configuration with the actual state of the network interfaces on the system.
- Such errors can prevent successful application of configuration changes, disrupt network operations, and require manual intervention to resolve.

**Example:**
When the interface was removed from the `frr.conf` and then the reload script is executed the following error is triggered:
```
~$ frr-reload.py --reload --confdir frrouting/etc frrouting/etc/frr.conf --log-level warning
Failed to execute interface t4_1  no ip address 10.0.0.5 peer 10.0.0.6/32 exit
"interface t4_1 --  no ip address 10.0.0.5 peer 10.0.0.6/32 -- exit" we failed to remove this command
```

## Proposed Solution

- The proposed change allows the configuration to remove an interface using a single command (`no interface <interface-name>`).
  - The change affects only the whole removal of interfaces. If there are single lines removed under the interface context the script behaves like before.
- This command effectively removes all configurations related to the interface in one step, bypassing the need to delete each line individually.

**Advantages of the Solution:**
- By allowing the removal of the entire interface context, the solution makes the reloading process more straightforward and reduces the potential for errors.
- When an interface is already deleted, removing its configuration with a single command avoids errors related to non-existent interface elements like IP addresses.

