### PR TITLE
isisd: Add missing `exit` statement to `show running-config` output

### DIFF
--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -2065,6 +2065,12 @@ void cli_show_isis_srv6_locator(struct vty *vty, const struct lyd_node *dnode,
 	vty_out(vty, "  locator %s\n", yang_dnode_get_string(dnode, NULL));
 }
 
+void cli_show_isis_srv6_locator_end(struct vty *vty,
+				    const struct lyd_node *dnode)
+{
+	vty_out(vty, " exit\n");
+}
+
 /*
  * XPath: /frr-isisd:isis/instance/segment-routing-srv6/enabled
  */

--- a/isisd/isis_nb.c
+++ b/isisd/isis_nb.c
@@ -873,6 +873,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 				.modify = isis_instance_segment_routing_srv6_locator_modify,
 				.destroy = isis_instance_segment_routing_srv6_locator_destroy,
 				.cli_show = cli_show_isis_srv6_locator,
+				.cli_show_end = cli_show_isis_srv6_locator_end,
 			},
 		},
 		{

--- a/isisd/isis_nb.h
+++ b/isisd/isis_nb.h
@@ -332,6 +332,8 @@ int isis_instance_segment_routing_srv6_locator_destroy(
 	struct nb_cb_destroy_args *args);
 void cli_show_isis_srv6_locator(struct vty *vty, const struct lyd_node *dnode,
 				bool show_defaults);
+void cli_show_isis_srv6_locator_end(struct vty *vty,
+				    const struct lyd_node *dnode);
 int isis_instance_segment_routing_srv6_msd_node_msd_max_segs_left_modify(
 	struct nb_cb_modify_args *args);
 int isis_instance_segment_routing_srv6_msd_node_msd_max_end_pop_modify(


### PR DESCRIPTION
Add missing `exit` statement to `show running-config` output.

```
router isis ISIS_CORE
 is-type level-2-only
 net 49.0001.0000.0000.0004.00
 lsp-mtu 1300
 topology ipv6-unicast
 log-adjacency-changes
 segment-routing srv6
  locator ISIS_LOC
 exit   <<<<<<<<<<<<<<<<<<<<<<<<
exit
```

Fixes https://github.com/FRRouting/frr/issues/16694