### PR TITLE
bgpd: fix proper json format for unicast statistics for non exists vrf

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12934,7 +12934,7 @@ DEFUN (show_ip_bgp_l2vpn_evpn_statistics,
 	struct json_object *json_afi_safi = NULL, *json = NULL;
 
 	bgp_vty_find_and_parse_afi_safi_bgp(vty, argv, argc, &idx, &afi, &safi,
-					    &bgp, false);
+					    &bgp, uj);
 	if (!idx)
 		return CMD_WARNING;
 
@@ -12972,7 +12972,7 @@ DEFUN(show_ip_bgp_afi_safi_statistics, show_ip_bgp_afi_safi_statistics_cmd,
 	struct json_object *json_afi_safi = NULL, *json = NULL;
 
 	bgp_vty_find_and_parse_afi_safi_bgp(vty, argv, argc, &idx, &afi, &safi,
-					    &bgp, false);
+					    &bgp, uj);
 	if (!idx)
 		return CMD_WARNING;
 


### PR DESCRIPTION


show bgp vrf afi unicast statistics json output is not return in json format for non exists vrf.

Fix:
Json output is formatted for non exists vrf cases.

Command supported:

```
show bgp vrf <VRFNAME> ipv4/ipv6 unicast statistics json
show bgp vrf <VRFNAME> l2vpn evpn statistics json
```

Before Fix:

```
leaf11#
leaf11# show bgp vrf test ipv4 unicast statistics json
View/Vrf test is unknown
leaf11#
leaf11# show bgp vrf test ipv6 unicast statistics json
View/Vrf test is unknown
leaf11#
leaf11# show bgp vrf default1 l2vpn evpn statistics json
View/Vrf default1 is unknown
leaf11#

```

After Fix:

```
leaf11#
leaf11# show bgp vrf test ipv4 unicast statistics json
{
  "warning":"View/Vrf is unknown"
}
leaf11#
leaf11#
leaf11# show bgp vrf test ipv6 unicast statistics json
{
  "warning":"View/Vrf is unknown"
}
leaf11#
leaf11# show bgp vrf default1 l2vpn evpn statistics json
{
  "warning":"View/Vrf is unknown"
}
leaf11#
```

Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>