### PR TITLE
lib: Attach stdout to child only if --log=stdout and stdout FD is a tty

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -1125,9 +1125,12 @@ static void frr_terminal_close(int isexit)
 		 * don't redirect when stdout is set with --log stdout
 		 */
 		for (fd = 2; fd >= 0; fd--)
-			if (isatty(fd) &&
-			    (fd != STDOUT_FILENO || !logging_to_stdout))
+			if (logging_to_stdout && isatty(fd) &&
+			    fd == STDOUT_FILENO) {
+				/* Do nothing. */
+			} else {
 				dup2(nullfd, fd);
+			}
 		close(nullfd);
 	}
 }
@@ -1213,9 +1216,12 @@ void frr_run(struct event_loop *master)
 			 * stdout
 			 */
 			for (fd = 2; fd >= 0; fd--)
-				if (isatty(fd) &&
-				    (fd != STDOUT_FILENO || !logging_to_stdout))
+				if (logging_to_stdout && isatty(fd) &&
+				    fd == STDOUT_FILENO) {
+					/* Do nothing. */
+				} else {
 					dup2(nullfd, fd);
+				}
 			close(nullfd);
 		}
 


### PR DESCRIPTION
We've faced with a regression after we moved from frr 8.5 to a newer versions (9.0, 9.1, 10.0, 10.1).

In our automation we start frr from python code using subprocess like this:
```python
subprocess.run(
    ["/usr/lib/frr/frrinit.sh", "start"],
    stdout=subprocess.PIPE,
    stderr=subprocess.PIPE,
)
```
This call hangs in `poll()` for stdout FD indefinitely and `frrinit.sh` hangs in zombie state unless we kill `subprocess.run()` call.
If we remove stdout capturing from `subprocess.run()` call (make associated to stdout FD a tty FD), things go well and process terminates correctly with no hangs and zombies.
This commit fixes this situation where stdout of a process started in a daemon mode was attached to a calling process regardless of presence `--log` option.

If this patch is acceptable, it's worth backporting down to 9.0 branch, where the initial commit https://github.com/FRRouting/frr/commit/4d28aea95851dc14b3987b004f457d7a4a1535f8 appeared.