### PR TITLE
ospfd: logging behavior for area id mismatches

### DIFF
--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -2806,9 +2806,7 @@ static enum ospf_read_return_enum ospf_read_helper(struct ospf *ospf)
 	 * or header area is backbone but ospf_interface is not
 	 * check for VLINK interface
 	 */
-	if ((oi == NULL)
-	    || (OSPF_IS_AREA_ID_BACKBONE(ospfh->area_id)
-		&& !OSPF_IS_AREA_ID_BACKBONE(oi->area->area_id))) {
+	if (oi == NULL) {
 		if ((oi = ospf_associate_packet_vl(ospf, ifp, iph, ospfh))
 		    == NULL) {
 			if (!ospf->instance && IS_DEBUG_OSPF_EVENT)


### PR DESCRIPTION
When an ospf interface is not in the backbone area, but it receives a packet from the backbone, no logs are generated for this mismatch due to the current check. However, the opposite scenario does generate logs. Removing this check shouldn’t cause issues, because the `ospf_verify_header()` function will still drop packets with a different area id, even if the VLINK is active.