### PR TITLE
zebra: Don't display the vrf if not using namespace based vrfs

### DIFF
--- a/zebra/table_manager.h
+++ b/zebra/table_manager.h
@@ -24,6 +24,7 @@ extern "C" {
 #if !defined(GNU_LINUX)
 /* BSD systems
  */
+#define RT_TABLE_ID_MAIN 0
 #else
 /* Linux Systems
  */

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -398,6 +398,7 @@ vrf_id_t zebra_vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id)
 
 	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
 		zvrf = vrf->info;
+
 		if (zvrf == NULL)
 			continue;
 		/* case vrf with netns : match the netnsid */
@@ -408,6 +409,7 @@ vrf_id_t zebra_vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id)
 			/* VRF is VRF_BACKEND_VRF_LITE */
 			if (zvrf->table_id != table_id)
 				continue;
+
 			return zvrf_id(zvrf);
 		}
 	}

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -858,6 +858,27 @@ static void vty_show_ip_route_detail_json(struct vty *vty,
 	vty_json(vty, json);
 }
 
+static void zebra_vty_display_vrf_header(struct vty *vty, struct zebra_vrf *zvrf, uint32_t tableid)
+{
+	if (!tableid)
+		vty_out(vty, "VRF %s:\n", zvrf_name(zvrf));
+	else {
+		if (vrf_is_backend_netns())
+			vty_out(vty, "VRF %s table %u:\n", zvrf_name(zvrf), tableid);
+		else {
+			vrf_id_t vrf = zebra_vrf_lookup_by_table(tableid, zvrf->zns->ns_id);
+
+			if (vrf == VRF_DEFAULT && tableid != RT_TABLE_ID_MAIN)
+				vty_out(vty, "table %u:\n", tableid);
+			else {
+				struct zebra_vrf *zvrf2 = zebra_vrf_lookup_by_id(vrf);
+
+				vty_out(vty, "VRF %s table %u:\n", zvrf_name(zvrf2), tableid);
+			}
+		}
+	}
+}
+
 static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 				 struct route_table *table, afi_t afi,
 				 bool use_fib, route_tag_t tag,
@@ -937,33 +958,9 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 				}
 				if (ctx->multi && ctx->header_done)
 					vty_out(vty, "\n");
-				if (ctx->multi || zvrf_id(zvrf) != VRF_DEFAULT
-				    || tableid) {
-					if (!tableid)
-						vty_out(vty, "VRF %s:\n",
-							zvrf_name(zvrf));
-					else {
-						if (vrf_is_backend_netns())
-							vty_out(vty, "VRF %s table %u:\n",
-								zvrf_name(zvrf), tableid);
-						else {
-							vrf_id_t vrf =
-								zebra_vrf_lookup_by_table(tableid,
-											  zvrf->zns->ns_id);
+				if (ctx->multi || zvrf_id(zvrf) != VRF_DEFAULT || tableid)
+					zebra_vty_display_vrf_header(vty, zvrf, tableid);
 
-							if (vrf == VRF_DEFAULT &&
-							    tableid != RT_TABLE_ID_MAIN)
-								vty_out(vty, "table %u:\n", tableid);
-							else {
-								struct zebra_vrf *zvrf2 =
-									zebra_vrf_lookup_by_id(vrf);
-
-								vty_out(vty, "VRF %s table %u:\n",
-									zvrf_name(zvrf2), tableid);
-							}
-						}
-					}
-				}
 				ctx->header_done = true;
 				first = 0;
 			}

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -942,11 +942,27 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 					if (!tableid)
 						vty_out(vty, "VRF %s:\n",
 							zvrf_name(zvrf));
-					else
-						vty_out(vty,
-							"VRF %s table %u:\n",
-							zvrf_name(zvrf),
-							tableid);
+					else {
+						if (vrf_is_backend_netns())
+							vty_out(vty, "VRF %s table %u:\n",
+								zvrf_name(zvrf), tableid);
+						else {
+							vrf_id_t vrf =
+								zebra_vrf_lookup_by_table(tableid,
+											  zvrf->zns->ns_id);
+
+							if (vrf == VRF_DEFAULT &&
+							    tableid != RT_TABLE_ID_MAIN)
+								vty_out(vty, "table %u:\n", tableid);
+							else {
+								struct zebra_vrf *zvrf2 =
+									zebra_vrf_lookup_by_id(vrf);
+
+								vty_out(vty, "VRF %s table %u:\n",
+									zvrf_name(zvrf2), tableid);
+							}
+						}
+					}
 				}
 				ctx->header_done = true;
 				first = 0;


### PR DESCRIPTION
Currently when doing a `show ip route table XXXX`, zebra is displaying the current default vrf as the vrf we are in.  We are displaying a table not a vrf.  This is only true if you are not using namespace based vrf's, so modify the output to display accordingly.