### PR TITLE
tests: Skip bgp_l3vpn vrf tests on 32bit systems

### DIFF
--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/test_bgp_l3vpn_to_bgp_vrf.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/test_bgp_l3vpn_to_bgp_vrf.py
@@ -84,6 +84,9 @@ def test_check_scale_up():
     CliOnFail = None
     # For debugging, uncomment the next line
     # CliOnFail = 'tgen.mininet_cli'
+    # Skip test on 32bit platforms (limited memory)
+    if sys.maxsize <= 2**32:
+        pytest.skip("skipped because of limited memory on 32bit platforms")
     CheckFunc = "ltemplateVersionCheck('4.1', iproute2='4.9')"
     # uncomment next line to start cli *before* script is run
     # CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, iproute2=\'4.9\')'
@@ -94,6 +97,9 @@ def test_check_scale_down():
     CliOnFail = None
     # For debugging, uncomment the next line
     # CliOnFail = 'tgen.mininet_cli'
+    # Skip test on 32bit platforms (limited memory)
+    if sys.maxsize <= 2**32:
+        pytest.skip("skipped because of limited memory on 32bit platforms")
     CheckFunc = "ltemplateVersionCheck('4.1', iproute2='4.9')"
     # uncomment next line to start cli *before* script is run
     # CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, iproute2=\'4.9\')'


### PR DESCRIPTION
Tests may fail because of limited memory on 32bit system