### PR TITLE
bgpd: Reduce # of iterations when doing llgr

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -696,9 +696,8 @@ static void bgp_set_llgr_stale(struct peer *peer, afi_t afi, safi_t safi)
 					attr = *pi->attr;
 					bgp_attr_add_llgr_community(&attr);
 					pi->attr = bgp_attr_intern(&attr);
-					bgp_recalculate_afi_safi_bestpaths(
-						peer->bgp, afi, safi);
-
+					bgp_process(peer->bgp, rm, pi, afi,
+						    safi);
 					break;
 				}
 		}
@@ -724,9 +723,7 @@ static void bgp_set_llgr_stale(struct peer *peer, afi_t afi, safi_t safi)
 				attr = *pi->attr;
 				bgp_attr_add_llgr_community(&attr);
 				pi->attr = bgp_attr_intern(&attr);
-				bgp_recalculate_afi_safi_bestpaths(peer->bgp,
-								   afi, safi);
-
+				bgp_process(peer->bgp, dest, pi, afi, safi);
 				break;
 			}
 	}


### PR DESCRIPTION
Code was scanning a table then identifying a prefix that needed to be modified then calling code that
reran bestpath on the entire table again.

If you had multiple items that needed processing
you would end up scanning and setting the entire
table to be scanned multiple times.  No bueno.

a) We do not need to reprocess items that are not
being modified.

b) We do not need to walk the entire table multiple times, we have the data that is needed already.

Modify the code to just call bgp_process on the
interesting nodes.