### PR TITLE
lib: fix clang SA warnings

### DIFF
--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -751,8 +751,8 @@ static const struct lysc_node *nb_op_sib_next(struct nb_op_yield_state *ys,
 
 	/*
 	 * If the node info stack is shorter than the schema path then we are
-	 * doign specific query still on the node from the schema path (should
-	 * match) so just return NULL (i.e., don't process siblings)
+	 * working our way down the specific query path so just return NULL
+	 * (i.e., don't process siblings)
 	 */
 	if (darr_len(ys->schema_path) > darr_len(ys->node_infos))
 		return NULL;
@@ -760,21 +760,21 @@ static const struct lysc_node *nb_op_sib_next(struct nb_op_yield_state *ys,
 	 * If sib is on top of the node info stack then
 	 * 1) it's a container node -or-
 	 * 2) it's a list node that we were walking and we've reach the last entry
-	 * 3) if sib is a list and the list was empty we never would have
+	 *
+	 * If sib is a list and the list was empty we never would have
 	 * pushed sib on the stack so the top of the stack is the parent
 	 *
 	 * If the query string included this node then we do not process any
 	 * siblings as we are not walking all the parent's children just this
 	 * specified one give by the query string.
 	 */
-	if (sib == darr_last(ys->node_infos)->schema &&
-	    darr_len(ys->schema_path) >= darr_len(ys->node_infos))
-		return NULL;
-	/* case (3) */
-	else if (sib->nodetype == LYS_LIST &&
-		 parent == darr_last(ys->node_infos)->schema &&
-		 darr_len(ys->schema_path) > darr_len(ys->node_infos))
-		return NULL;
+	if (darr_len(ys->schema_path) == darr_len(ys->node_infos)) {
+		struct nb_op_node_info *node_infos = darr_last(ys->node_infos);
+
+		assert(node_infos);
+		if (sib == node_infos->schema)
+			return NULL;
+	}
 
 	sib = __sib_next(yn, sib->next);
 	if (sib)
@@ -801,6 +801,7 @@ static const struct lysc_node *nb_op_sib_first(struct nb_op_yield_state *ys,
 {
 	const struct lysc_node *sib = lysc_node_child(parent);
 	const struct lysc_node *first_sib;
+	struct nb_op_node_info *last = darr_last(ys->node_infos);
 
 	/*
 	 * NOTE: when we want to handle root level walks we will need to use
@@ -817,10 +818,9 @@ static const struct lysc_node *nb_op_sib_first(struct nb_op_yield_state *ys,
 	 * base of the user query, return the next schema node from the query
 	 * string (schema_path).
 	 */
-	if (darr_last(ys->node_infos) != NULL &&
-	    !CHECK_FLAG(darr_last(ys->node_infos)->schema->nodetype,
-			LYS_CASE | LYS_CHOICE))
-		assert(darr_last(ys->node_infos)->schema == parent);
+	if (last != NULL &&
+	    !CHECK_FLAG(last->schema->nodetype, LYS_CASE | LYS_CHOICE))
+		assert(last->schema == parent);
 	if (darr_lasti(ys->node_infos) < ys->query_base_level)
 		return ys->schema_path[darr_lasti(ys->node_infos) + 1];
 
@@ -908,9 +908,10 @@ static enum nb_error __walk(struct nb_op_yield_state *ys, bool is_resume)
 	 * Otherwise get the first child of the container we are walking,
 	 * starting with non-yielding children.
 	 */
-	if (is_resume)
+	if (is_resume) {
+		assert(darr_last(ys->node_infos) != NULL);
 		sib = darr_last(ys->node_infos)->schema;
-	else {
+	} else {
 		/*
 		 * Start with non-yielding children first.
 		 *
@@ -1477,7 +1478,8 @@ static void nb_op_walk_continue(struct event *thread)
 		goto finish;
 
 	/* otherwise we are at a resumable node */
-	assert(darr_last(ys->node_infos)->has_lookup_next);
+	assert(darr_last(ys->node_infos) &&
+	       darr_last(ys->node_infos)->has_lookup_next);
 
 	ret = __walk(ys, true);
 	if (ret == NB_YIELD) {


### PR DESCRIPTION
Also, cleanup some unreachable code in `nb_op_sib_next()`.