### PR TITLE
'show bgp detail' memory improvement

### DIFF
--- a/bgpd/bgp_aspath.h
+++ b/bgpd/bgp_aspath.h
@@ -52,9 +52,6 @@ struct aspath {
 	/* segment data */
 	struct assegment *segments;
 
-	/* AS path as a json object */
-	json_object *json;
-
 	/* String expression of AS path.  This string is used by vty output
 	   and AS path regular expression match.  */
 	char *str;
@@ -109,7 +106,7 @@ extern struct aspath *aspath_empty(enum asnotation_mode asnotation);
 extern struct aspath *aspath_empty_get(void);
 extern struct aspath *aspath_str2aspath(const char *str,
 					enum asnotation_mode asnotation);
-extern void aspath_str_update(struct aspath *as, bool make_json);
+extern void aspath_str_update(struct aspath *as);
 extern void aspath_free(struct aspath *aspath);
 extern struct aspath *aspath_intern(struct aspath *aspath);
 extern json_object *aspath_get_json(struct aspath *aspath);

--- a/bgpd/bgp_aspath.h
+++ b/bgpd/bgp_aspath.h
@@ -112,6 +112,7 @@ extern struct aspath *aspath_str2aspath(const char *str,
 extern void aspath_str_update(struct aspath *as, bool make_json);
 extern void aspath_free(struct aspath *aspath);
 extern struct aspath *aspath_intern(struct aspath *aspath);
+extern json_object *aspath_get_json(struct aspath *aspath);
 extern void aspath_unintern(struct aspath **aspath);
 extern const char *aspath_print(struct aspath *aspath);
 extern void aspath_print_vty(struct vty *vty, struct aspath *aspath);

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -990,7 +990,7 @@ static void attr_show_all_iterator(struct hash_bucket *bucket, struct vty *vty)
 	vty_out(vty, "\taspath: %s Community: %s Large Community: %s\n",
 		aspath_print(attr->aspath),
 		community_str(attr->community, false),
-		lcommunity_str(attr->lcommunity, false, false));
+		lcommunity_str(attr->lcommunity, false));
 	vty_out(vty, "\tExtended Community: %s Extended IPv6 Community: %s\n",
 		ecommunity_str(attr->ecommunity),
 		ecommunity_str(attr->ipv6_ecommunity));

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -989,7 +989,7 @@ static void attr_show_all_iterator(struct hash_bucket *bucket, struct vty *vty)
 		attr->origin, attr->weight, attr->label, sid, attr->aigp_metric);
 	vty_out(vty, "\taspath: %s Community: %s Large Community: %s\n",
 		aspath_print(attr->aspath),
-		community_str(attr->community, false, false),
+		community_str(attr->community, false),
 		lcommunity_str(attr->lcommunity, false, false));
 	vty_out(vty, "\tExtended Community: %s Extended IPv6 Community: %s\n",
 		ecommunity_str(attr->ecommunity),

--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -540,7 +540,7 @@ static bool community_regexp_match(struct community *com, regex_t *reg)
 	if (com == NULL || com->size == 0)
 		str = "";
 	else
-		str = community_str(com, false, true);
+		str = community_str(com, true);
 
 	regstr = bgp_alias2community_str(str);
 

--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -614,7 +614,7 @@ static bool lcommunity_regexp_match(struct lcommunity *com, regex_t *reg)
 	if (com == NULL || com->size == 0)
 		str = "";
 	else
-		str = lcommunity_str(com, false, true);
+		str = lcommunity_str(com, true);
 
 	regstr = bgp_alias2community_str(str);
 

--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -169,7 +169,8 @@ struct community *community_uniq_sort(struct community *com)
  */
 static void community_json_list(struct community *com,
 				json_object *json_community_list, char *str,
-				int len, bool translate_alias)
+				int len, bool translate_alias,
+				struct printbuf *pb, bool incremental_print)
 {
 	int i;
 	int first;
@@ -191,8 +192,12 @@ static void community_json_list(struct community *com,
 
 		switch (comval) {
 		case COMMUNITY_GSHUT:
-			strlcat(str, "graceful-shutdown", len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, "graceful-shutdown", len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"gracefulShutdown\"",
+					  i ? "," : "");
+			else if (json_community_list) {
 				json_string = json_object_new_string(
 					"gracefulShutdown");
 				json_object_array_add(json_community_list,
@@ -200,8 +205,11 @@ static void community_json_list(struct community *com,
 			}
 			break;
 		case COMMUNITY_ACCEPT_OWN:
-			strlcat(str, "accept-own", len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, "accept-own", len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"acceptOwn\"", i ? "," : "");
+			else if (json_community_list) {
 				json_string = json_object_new_string(
 					"acceptown");
 				json_object_array_add(json_community_list,
@@ -209,8 +217,12 @@ static void community_json_list(struct community *com,
 			}
 			break;
 		case COMMUNITY_ROUTE_FILTER_TRANSLATED_v4:
-			strlcat(str, "route-filter-translated-v4", len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, "route-filter-translated-v4", len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"routeFilterTranslateV4\"",
+					  i ? "," : "");
+			else if (json_community_list) {
 				json_string = json_object_new_string(
 					"routeFilterTranslatedV4");
 				json_object_array_add(json_community_list,
@@ -218,8 +230,12 @@ static void community_json_list(struct community *com,
 			}
 			break;
 		case COMMUNITY_ROUTE_FILTER_v4:
-			strlcat(str, "route-filter-v4", len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, "route-filter-v4", len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"routeFilterV4\"",
+					  i ? "," : "");
+			else if (json_community_list) {
 				json_string = json_object_new_string(
 					"routeFilterV4");
 				json_object_array_add(json_community_list,
@@ -227,8 +243,12 @@ static void community_json_list(struct community *com,
 			}
 			break;
 		case COMMUNITY_ROUTE_FILTER_TRANSLATED_v6:
-			strlcat(str, "route-filter-translated-v6", len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, "route-filter-translated-v6", len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"routeFilterTranslatedV6\"",
+					  i ? "," : "");
+			else if (json_community_list) {
 				json_string = json_object_new_string(
 					"routeFilterTranslatedV6");
 				json_object_array_add(json_community_list,
@@ -236,8 +256,12 @@ static void community_json_list(struct community *com,
 			}
 			break;
 		case COMMUNITY_ROUTE_FILTER_v6:
-			strlcat(str, "route-filter-v6", len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, "route-filter-v6", len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"routeFilterV6\"",
+					  i ? "," : "");
+			else if (json_community_list) {
 				json_string = json_object_new_string(
 					"routeFilterV6");
 				json_object_array_add(json_community_list,
@@ -245,8 +269,11 @@ static void community_json_list(struct community *com,
 			}
 			break;
 		case COMMUNITY_LLGR_STALE:
-			strlcat(str, "llgr-stale", len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, "llgr-stale", len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"llgrStale\"", i ? "," : "");
+			else if (json_community_list) {
 				json_string = json_object_new_string(
 					"llgrStale");
 				json_object_array_add(json_community_list,
@@ -254,8 +281,11 @@ static void community_json_list(struct community *com,
 			}
 			break;
 		case COMMUNITY_NO_LLGR:
-			strlcat(str, "no-llgr", len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, "no-llgr", len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"noLlgr\"", i ? "," : "");
+			else if (json_community_list) {
 				json_string = json_object_new_string(
 					"noLlgr");
 				json_object_array_add(json_community_list,
@@ -263,8 +293,12 @@ static void community_json_list(struct community *com,
 			}
 			break;
 		case COMMUNITY_ACCEPT_OWN_NEXTHOP:
-			strlcat(str, "accept-own-nexthop", len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, "accept-own-nexthop", len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"acceptownnexthop\"",
+					  i ? "," : "");
+			else if (json_community_list) {
 				json_string = json_object_new_string(
 					"acceptownnexthop");
 				json_object_array_add(json_community_list,
@@ -272,8 +306,11 @@ static void community_json_list(struct community *com,
 			}
 			break;
 		case COMMUNITY_BLACKHOLE:
-			strlcat(str, "blackhole", len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, "blackhole", len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"blackhole\"", i ? "," : "");
+			else if (json_community_list) {
 				json_string = json_object_new_string(
 					"blackhole");
 				json_object_array_add(json_community_list,
@@ -281,8 +318,11 @@ static void community_json_list(struct community *com,
 			}
 			break;
 		case COMMUNITY_NO_EXPORT:
-			strlcat(str, "no-export", len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, "no-export", len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"noExport\"", i ? "," : "");
+			else if (json_community_list) {
 				json_string =
 					json_object_new_string("noExport");
 				json_object_array_add(json_community_list,
@@ -290,8 +330,11 @@ static void community_json_list(struct community *com,
 			}
 			break;
 		case COMMUNITY_NO_ADVERTISE:
-			strlcat(str, "no-advertise", len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, "no-advertise", len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"noAdvertise\"", i ? "," : "");
+			else if (json_community_list) {
 				json_string =
 					json_object_new_string("noAdvertise");
 				json_object_array_add(json_community_list,
@@ -299,16 +342,22 @@ static void community_json_list(struct community *com,
 			}
 			break;
 		case COMMUNITY_LOCAL_AS:
-			strlcat(str, "local-AS", len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, "local-AS", len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"localAs\"", i ? "," : "");
+			else if (json_community_list) {
 				json_string = json_object_new_string("localAs");
 				json_object_array_add(json_community_list,
 						      json_string);
 			}
 			break;
 		case COMMUNITY_NO_PEER:
-			strlcat(str, "no-peer", len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, "no-peer", len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"noPeer\"", i ? "," : "");
+			else if (json_community_list) {
 				json_string = json_object_new_string("noPeer");
 				json_object_array_add(json_community_list,
 						      json_string);
@@ -322,8 +371,14 @@ static void community_json_list(struct community *com,
 			const char *com2alias =
 				translate_alias ? bgp_community2alias(buf) : buf;
 
-			strlcat(str, com2alias, len);
-			if (json_community_list) {
+			if (str)
+				strlcat(str, com2alias, len);
+			if (incremental_print)
+				sprintbuf(pb, "%s\"%s\"", i ? "," : "",
+					  translate_alias
+						  ? bgp_community2alias(buf)
+						  : buf);
+			else if (json_community_list) {
 				json_string = json_object_new_string(com2alias);
 				json_object_array_add(json_community_list,
 						      json_string);
@@ -445,7 +500,7 @@ static void set_community_string(struct community *com, bool make_json,
 	str = XCALLOC(MTYPE_COMMUNITY_STR, len);
 
 	community_json_list(com, make_json ? json_community_list : NULL, str,
-			    len, translate_alias);
+			    len, translate_alias, NULL, false);
 
 	if (make_json) {
 		json_object_string_add(com->json, "string", str);
@@ -933,6 +988,25 @@ static void bgp_aggr_community_prepare(struct hash_bucket *hb, void *arg)
 		*aggr_community = community_dup(hb_community);
 }
 
+static int community_list_json_to_string(struct json_object *jso,
+					 struct printbuf *pb, int level,
+					 int flags)
+{
+	struct community *com;
+
+	com = json_object_get_userdata(jso);
+	assert(com);
+	if (!com->str)
+		return 0;
+	printbuf_strappend(pb, "{\"string\":\"");
+	printbuf_memappend(pb, com->str, strlen(com->str));
+	printbuf_strappend(pb, "\",\"list\":[");
+
+	community_json_list(com, NULL, NULL, 0, true, pb, true);
+	printbuf_strappend(pb, "]}");
+	return 0;
+}
+
 void bgp_aggr_community_remove(void *arg)
 {
 	struct community *community = arg;
@@ -1053,4 +1127,14 @@ void bgp_remove_comm_from_aggregate_hash(struct bgp_aggregate *aggregate,
 			community_free(&ret_comm);
 		}
 	}
+}
+
+json_object *community_get_json(struct community *com)
+{
+	json_object *json_community_list = NULL;
+
+	json_community_list = json_object_new_object();
+	json_object_set_serializer(json_community_list,
+				   community_list_json_to_string, com, NULL);
+	return json_community_list;
 }

--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -33,11 +33,6 @@ void community_free(struct community **com)
 	XFREE(MTYPE_COMMUNITY_VAL, (*com)->val);
 	XFREE(MTYPE_COMMUNITY_STR, (*com)->str);
 
-	if ((*com)->json) {
-		json_object_free((*com)->json);
-		(*com)->json = NULL;
-	}
-
 	XFREE(MTYPE_COMMUNITY, (*com));
 }
 
@@ -150,7 +145,6 @@ struct community *community_uniq_sort(struct community *com)
 		return NULL;
 
 	new = community_new();
-	new->json = NULL;
 
 	for (i = 0; i < com->size; i++) {
 		val = community_val_get(com, i);
@@ -167,16 +161,14 @@ struct community *community_uniq_sort(struct community *com)
 /* Convert communities attribute to string and optionally add json objects
  * into the pased json_community_list string
  */
-static void community_json_list(struct community *com,
-				json_object *json_community_list, char *str,
-				int len, bool translate_alias,
-				struct printbuf *pb, bool incremental_print)
+static void community_json_list(struct community *com, char *str, int len,
+				bool translate_alias, struct printbuf *pb,
+				bool incremental_print)
 {
 	int i;
 	int first;
 	first = 1;
 	uint32_t comval;
-	json_object *json_string = NULL;
 	uint16_t as;
 	uint16_t val;
 
@@ -197,24 +189,12 @@ static void community_json_list(struct community *com,
 			if (incremental_print)
 				sprintbuf(pb, "%s\"gracefulShutdown\"",
 					  i ? "," : "");
-			else if (json_community_list) {
-				json_string = json_object_new_string(
-					"gracefulShutdown");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		case COMMUNITY_ACCEPT_OWN:
 			if (str)
 				strlcat(str, "accept-own", len);
 			if (incremental_print)
 				sprintbuf(pb, "%s\"acceptOwn\"", i ? "," : "");
-			else if (json_community_list) {
-				json_string = json_object_new_string(
-					"acceptown");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		case COMMUNITY_ROUTE_FILTER_TRANSLATED_v4:
 			if (str)
@@ -222,12 +202,6 @@ static void community_json_list(struct community *com,
 			if (incremental_print)
 				sprintbuf(pb, "%s\"routeFilterTranslateV4\"",
 					  i ? "," : "");
-			else if (json_community_list) {
-				json_string = json_object_new_string(
-					"routeFilterTranslatedV4");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		case COMMUNITY_ROUTE_FILTER_v4:
 			if (str)
@@ -235,12 +209,6 @@ static void community_json_list(struct community *com,
 			if (incremental_print)
 				sprintbuf(pb, "%s\"routeFilterV4\"",
 					  i ? "," : "");
-			else if (json_community_list) {
-				json_string = json_object_new_string(
-					"routeFilterV4");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		case COMMUNITY_ROUTE_FILTER_TRANSLATED_v6:
 			if (str)
@@ -248,12 +216,6 @@ static void community_json_list(struct community *com,
 			if (incremental_print)
 				sprintbuf(pb, "%s\"routeFilterTranslatedV6\"",
 					  i ? "," : "");
-			else if (json_community_list) {
-				json_string = json_object_new_string(
-					"routeFilterTranslatedV6");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		case COMMUNITY_ROUTE_FILTER_v6:
 			if (str)
@@ -261,36 +223,18 @@ static void community_json_list(struct community *com,
 			if (incremental_print)
 				sprintbuf(pb, "%s\"routeFilterV6\"",
 					  i ? "," : "");
-			else if (json_community_list) {
-				json_string = json_object_new_string(
-					"routeFilterV6");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		case COMMUNITY_LLGR_STALE:
 			if (str)
 				strlcat(str, "llgr-stale", len);
 			if (incremental_print)
 				sprintbuf(pb, "%s\"llgrStale\"", i ? "," : "");
-			else if (json_community_list) {
-				json_string = json_object_new_string(
-					"llgrStale");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		case COMMUNITY_NO_LLGR:
 			if (str)
 				strlcat(str, "no-llgr", len);
 			if (incremental_print)
 				sprintbuf(pb, "%s\"noLlgr\"", i ? "," : "");
-			else if (json_community_list) {
-				json_string = json_object_new_string(
-					"noLlgr");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		case COMMUNITY_ACCEPT_OWN_NEXTHOP:
 			if (str)
@@ -298,70 +242,36 @@ static void community_json_list(struct community *com,
 			if (incremental_print)
 				sprintbuf(pb, "%s\"acceptownnexthop\"",
 					  i ? "," : "");
-			else if (json_community_list) {
-				json_string = json_object_new_string(
-					"acceptownnexthop");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		case COMMUNITY_BLACKHOLE:
 			if (str)
 				strlcat(str, "blackhole", len);
 			if (incremental_print)
 				sprintbuf(pb, "%s\"blackhole\"", i ? "," : "");
-			else if (json_community_list) {
-				json_string = json_object_new_string(
-					"blackhole");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		case COMMUNITY_NO_EXPORT:
 			if (str)
 				strlcat(str, "no-export", len);
 			if (incremental_print)
 				sprintbuf(pb, "%s\"noExport\"", i ? "," : "");
-			else if (json_community_list) {
-				json_string =
-					json_object_new_string("noExport");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		case COMMUNITY_NO_ADVERTISE:
 			if (str)
 				strlcat(str, "no-advertise", len);
 			if (incremental_print)
 				sprintbuf(pb, "%s\"noAdvertise\"", i ? "," : "");
-			else if (json_community_list) {
-				json_string =
-					json_object_new_string("noAdvertise");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		case COMMUNITY_LOCAL_AS:
 			if (str)
 				strlcat(str, "local-AS", len);
 			if (incremental_print)
 				sprintbuf(pb, "%s\"localAs\"", i ? "," : "");
-			else if (json_community_list) {
-				json_string = json_object_new_string("localAs");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		case COMMUNITY_NO_PEER:
 			if (str)
 				strlcat(str, "no-peer", len);
 			if (incremental_print)
 				sprintbuf(pb, "%s\"noPeer\"", i ? "," : "");
-			else if (json_community_list) {
-				json_string = json_object_new_string("noPeer");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		default:
 			as = CHECK_FLAG((comval >> 16), 0xFFFF);
@@ -378,11 +288,6 @@ static void community_json_list(struct community *com,
 					  translate_alias
 						  ? bgp_community2alias(buf)
 						  : buf);
-			else if (json_community_list) {
-				json_string = json_object_new_string(com2alias);
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
 			break;
 		}
 	}
@@ -408,33 +313,21 @@ static void community_json_list(struct community *com,
    0xFFFFFF04      "no-peer"
 
    For other values, "AS:VAL" format is used.  */
-static void set_community_string(struct community *com, bool make_json,
-				 bool translate_alias)
+static void set_community_string(struct community *com, bool translate_alias)
 {
 	int i;
 	char *str;
 	int len;
 	uint32_t comval;
-	json_object *json_community_list = NULL;
 
 	if (!com)
 		return;
-
-	if (make_json) {
-		com->json = json_object_new_object();
-		json_community_list = json_object_new_array();
-	}
 
 	/* When communities attribute is empty.  */
 	if (com->size == 0) {
 		str = XMALLOC(MTYPE_COMMUNITY_STR, 1);
 		str[0] = '\0';
 
-		if (make_json) {
-			json_object_string_add(com->json, "string", "");
-			json_object_object_add(com->json, "list",
-					       json_community_list);
-		}
 		com->str = str;
 		return;
 	}
@@ -499,13 +392,8 @@ static void set_community_string(struct community *com, bool make_json,
 	/* Allocate memory.  */
 	str = XCALLOC(MTYPE_COMMUNITY_STR, len);
 
-	community_json_list(com, make_json ? json_community_list : NULL, str,
-			    len, translate_alias, NULL, false);
+	community_json_list(com, str, len, translate_alias, NULL, false);
 
-	if (make_json) {
-		json_object_string_add(com->json, "string", str);
-		json_object_object_add(com->json, "list", json_community_list);
-	}
 	com->str = str;
 }
 
@@ -530,7 +418,7 @@ struct community *community_intern(struct community *com)
 
 	/* Make string.  */
 	if (!find->str)
-		set_community_string(find, false, true);
+		set_community_string(find, true);
 
 	return find;
 }
@@ -591,16 +479,13 @@ struct community *community_dup(struct community *com)
 }
 
 /* Return string representation of communities attribute. */
-char *community_str(struct community *com, bool make_json, bool translate_alias)
+char *community_str(struct community *com, bool translate_alias)
 {
 	if (!com)
 		return NULL;
 
-	if (make_json && !com->json && com->str)
-		XFREE(MTYPE_COMMUNITY_STR, com->str);
-
 	if (!com->str)
-		set_community_string(com, make_json, translate_alias);
+		set_community_string(com, translate_alias);
 	return com->str;
 }
 
@@ -910,7 +795,6 @@ struct community *community_str2com(const char *str)
 		case community_token_no_peer:
 			if (com == NULL) {
 				com = community_new();
-				com->json = NULL;
 			}
 			community_add_val(com, val);
 			break;
@@ -1002,7 +886,7 @@ static int community_list_json_to_string(struct json_object *jso,
 	printbuf_memappend(pb, com->str, strlen(com->str));
 	printbuf_strappend(pb, "\",\"list\":[");
 
-	community_json_list(com, NULL, NULL, 0, true, pb, true);
+	community_json_list(com, NULL, 0, true, pb, true);
 	printbuf_strappend(pb, "]}");
 	return 0;
 }

--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -164,6 +164,175 @@ struct community *community_uniq_sort(struct community *com)
 	return new;
 }
 
+/* Convert communities attribute to string and optionally add json objects
+ * into the pased json_community_list string
+ */
+static void community_json_list(struct community *com,
+				json_object *json_community_list, char *str,
+				int len, bool translate_alias)
+{
+	int i;
+	int first;
+	first = 1;
+	uint32_t comval;
+	json_object *json_string = NULL;
+	uint16_t as;
+	uint16_t val;
+
+	/* Fill in string.  */
+	for (i = 0; i < com->size; i++) {
+		memcpy(&comval, com_nthval(com, i), sizeof(uint32_t));
+		comval = ntohl(comval);
+
+		if (first)
+			first = 0;
+		else
+			strlcat(str, " ", len);
+
+		switch (comval) {
+		case COMMUNITY_GSHUT:
+			strlcat(str, "graceful-shutdown", len);
+			if (json_community_list) {
+				json_string = json_object_new_string(
+					"gracefulShutdown");
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		case COMMUNITY_ACCEPT_OWN:
+			strlcat(str, "accept-own", len);
+			if (json_community_list) {
+				json_string = json_object_new_string(
+					"acceptown");
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		case COMMUNITY_ROUTE_FILTER_TRANSLATED_v4:
+			strlcat(str, "route-filter-translated-v4", len);
+			if (json_community_list) {
+				json_string = json_object_new_string(
+					"routeFilterTranslatedV4");
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		case COMMUNITY_ROUTE_FILTER_v4:
+			strlcat(str, "route-filter-v4", len);
+			if (json_community_list) {
+				json_string = json_object_new_string(
+					"routeFilterV4");
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		case COMMUNITY_ROUTE_FILTER_TRANSLATED_v6:
+			strlcat(str, "route-filter-translated-v6", len);
+			if (json_community_list) {
+				json_string = json_object_new_string(
+					"routeFilterTranslatedV6");
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		case COMMUNITY_ROUTE_FILTER_v6:
+			strlcat(str, "route-filter-v6", len);
+			if (json_community_list) {
+				json_string = json_object_new_string(
+					"routeFilterV6");
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		case COMMUNITY_LLGR_STALE:
+			strlcat(str, "llgr-stale", len);
+			if (json_community_list) {
+				json_string = json_object_new_string(
+					"llgrStale");
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		case COMMUNITY_NO_LLGR:
+			strlcat(str, "no-llgr", len);
+			if (json_community_list) {
+				json_string = json_object_new_string(
+					"noLlgr");
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		case COMMUNITY_ACCEPT_OWN_NEXTHOP:
+			strlcat(str, "accept-own-nexthop", len);
+			if (json_community_list) {
+				json_string = json_object_new_string(
+					"acceptownnexthop");
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		case COMMUNITY_BLACKHOLE:
+			strlcat(str, "blackhole", len);
+			if (json_community_list) {
+				json_string = json_object_new_string(
+					"blackhole");
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		case COMMUNITY_NO_EXPORT:
+			strlcat(str, "no-export", len);
+			if (json_community_list) {
+				json_string =
+					json_object_new_string("noExport");
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		case COMMUNITY_NO_ADVERTISE:
+			strlcat(str, "no-advertise", len);
+			if (json_community_list) {
+				json_string =
+					json_object_new_string("noAdvertise");
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		case COMMUNITY_LOCAL_AS:
+			strlcat(str, "local-AS", len);
+			if (json_community_list) {
+				json_string = json_object_new_string("localAs");
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		case COMMUNITY_NO_PEER:
+			strlcat(str, "no-peer", len);
+			if (json_community_list) {
+				json_string = json_object_new_string("noPeer");
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		default:
+			as = CHECK_FLAG((comval >> 16), 0xFFFF);
+			val = CHECK_FLAG(comval, 0xFFFF);
+			char buf[32];
+			snprintf(buf, sizeof(buf), "%u:%d", as, val);
+			const char *com2alias =
+				translate_alias ? bgp_community2alias(buf) : buf;
+
+			strlcat(str, com2alias, len);
+			if (json_community_list) {
+				json_string = json_object_new_string(com2alias);
+				json_object_array_add(json_community_list,
+						      json_string);
+			}
+			break;
+		}
+	}
+}
+
 /* Convert communities attribute to string.
 
    For Well-known communities value, below keyword is used.
@@ -190,12 +359,8 @@ static void set_community_string(struct community *com, bool make_json,
 	int i;
 	char *str;
 	int len;
-	int first;
 	uint32_t comval;
-	uint16_t as;
-	uint16_t val;
 	json_object *json_community_list = NULL;
-	json_object *json_string = NULL;
 
 	if (!com)
 		return;
@@ -278,160 +443,9 @@ static void set_community_string(struct community *com, bool make_json,
 
 	/* Allocate memory.  */
 	str = XCALLOC(MTYPE_COMMUNITY_STR, len);
-	first = 1;
 
-	/* Fill in string.  */
-	for (i = 0; i < com->size; i++) {
-		memcpy(&comval, com_nthval(com, i), sizeof(uint32_t));
-		comval = ntohl(comval);
-
-		if (first)
-			first = 0;
-		else
-			strlcat(str, " ", len);
-
-		switch (comval) {
-		case COMMUNITY_GSHUT:
-			strlcat(str, "graceful-shutdown", len);
-			if (make_json) {
-				json_string = json_object_new_string(
-					"gracefulShutdown");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		case COMMUNITY_ACCEPT_OWN:
-			strlcat(str, "accept-own", len);
-			if (make_json) {
-				json_string = json_object_new_string(
-					"acceptown");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		case COMMUNITY_ROUTE_FILTER_TRANSLATED_v4:
-			strlcat(str, "route-filter-translated-v4", len);
-			if (make_json) {
-				json_string = json_object_new_string(
-					"routeFilterTranslatedV4");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		case COMMUNITY_ROUTE_FILTER_v4:
-			strlcat(str, "route-filter-v4", len);
-			if (make_json) {
-				json_string = json_object_new_string(
-					"routeFilterV4");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		case COMMUNITY_ROUTE_FILTER_TRANSLATED_v6:
-			strlcat(str, "route-filter-translated-v6", len);
-			if (make_json) {
-				json_string = json_object_new_string(
-					"routeFilterTranslatedV6");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		case COMMUNITY_ROUTE_FILTER_v6:
-			strlcat(str, "route-filter-v6", len);
-			if (make_json) {
-				json_string = json_object_new_string(
-					"routeFilterV6");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		case COMMUNITY_LLGR_STALE:
-			strlcat(str, "llgr-stale", len);
-			if (make_json) {
-				json_string = json_object_new_string(
-					"llgrStale");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		case COMMUNITY_NO_LLGR:
-			strlcat(str, "no-llgr", len);
-			if (make_json) {
-				json_string = json_object_new_string(
-					"noLlgr");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		case COMMUNITY_ACCEPT_OWN_NEXTHOP:
-			strlcat(str, "accept-own-nexthop", len);
-			if (make_json) {
-				json_string = json_object_new_string(
-					"acceptownnexthop");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		case COMMUNITY_BLACKHOLE:
-			strlcat(str, "blackhole", len);
-			if (make_json) {
-				json_string = json_object_new_string(
-					"blackhole");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		case COMMUNITY_NO_EXPORT:
-			strlcat(str, "no-export", len);
-			if (make_json) {
-				json_string =
-					json_object_new_string("noExport");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		case COMMUNITY_NO_ADVERTISE:
-			strlcat(str, "no-advertise", len);
-			if (make_json) {
-				json_string =
-					json_object_new_string("noAdvertise");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		case COMMUNITY_LOCAL_AS:
-			strlcat(str, "local-AS", len);
-			if (make_json) {
-				json_string = json_object_new_string("localAs");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		case COMMUNITY_NO_PEER:
-			strlcat(str, "no-peer", len);
-			if (make_json) {
-				json_string = json_object_new_string("noPeer");
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		default:
-			as = CHECK_FLAG((comval >> 16), 0xFFFF);
-			val = CHECK_FLAG(comval, 0xFFFF);
-			char buf[32];
-			snprintf(buf, sizeof(buf), "%u:%d", as, val);
-			const char *com2alias =
-				translate_alias ? bgp_community2alias(buf) : buf;
-
-			strlcat(str, com2alias, len);
-			if (make_json) {
-				json_string = json_object_new_string(com2alias);
-				json_object_array_add(json_community_list,
-						      json_string);
-			}
-			break;
-		}
-	}
+	community_json_list(com, make_json ? json_community_list : NULL, str,
+			    len, translate_alias);
 
 	if (make_json) {
 		json_object_string_add(com->json, "string", str);

--- a/bgpd/bgp_community.h
+++ b/bgpd/bgp_community.h
@@ -21,9 +21,6 @@ struct community {
 	/* Communities value.  */
 	uint32_t *val;
 
-	/* Communities as a json object */
-	json_object *json;
-
 	/* String of community attribute.  This sring is used by vty output
 	   and expanded community-list for regular expression match.  */
 	char *str;
@@ -62,8 +59,7 @@ extern struct community *community_parse(uint32_t *pnt, unsigned short length);
 extern struct community *community_intern(struct community *com);
 extern json_object *community_get_json(struct community *com);
 extern void community_unintern(struct community **com);
-extern char *community_str(struct community *com, bool make_json,
-			   bool translate_alias);
+extern char *community_str(struct community *com, bool translate_alias);
 extern unsigned int community_hash_make(const struct community *com);
 extern struct community *community_str2com(const char *str);
 extern bool community_match(const struct community *com1,

--- a/bgpd/bgp_community.h
+++ b/bgpd/bgp_community.h
@@ -60,6 +60,7 @@ extern void community_free(struct community **comm);
 extern struct community *community_uniq_sort(struct community *com);
 extern struct community *community_parse(uint32_t *pnt, unsigned short length);
 extern struct community *community_intern(struct community *com);
+extern json_object *community_get_json(struct community *com);
 extern void community_unintern(struct community **com);
 extern char *community_str(struct community *com, bool make_json,
 			   bool translate_alias);

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -439,8 +439,7 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 	if (CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES)))
 		snprintf(buf + strlen(buf), size - strlen(buf),
 			 ", large-community %s",
-			 lcommunity_str(bgp_attr_get_lcommunity(attr), false,
-					true));
+			 lcommunity_str(bgp_attr_get_lcommunity(attr), true));
 
 	if (CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES)))
 		snprintf(buf + strlen(buf), size - strlen(buf),

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -433,10 +433,8 @@ bool bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 			 attr->med);
 
 	if (CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES)))
-		snprintf(buf + strlen(buf), size - strlen(buf),
-			 ", community %s",
-			 community_str(bgp_attr_get_community(attr), false,
-				       true));
+		snprintf(buf + strlen(buf), size - strlen(buf), ", community %s",
+			 community_str(bgp_attr_get_community(attr), true));
 
 	if (CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES)))
 		snprintf(buf + strlen(buf), size - strlen(buf),

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -169,22 +169,25 @@ struct lcommunity *lcommunity_merge(struct lcommunity *lcom1,
  */
 static char *lcommunity_json_list(struct lcommunity *lcom,
 				  json_object *json_lcommunity_list,
-				  bool translate_alias)
+				  bool translate_alias, bool return_buffer,
+				  struct printbuf *pb, bool incremental_print)
 {
 	int i, len;
 	const uint8_t *pnt;
 	uint32_t global, local1, local2;
-	char *str_buf;
-	size_t str_buf_sz;
+	char *str_buf = NULL;
+	size_t str_buf_sz = 0;
 	json_object *json_string = NULL;
 
 	/* 1 space + lcom->size lcom strings + null terminator */
-	str_buf_sz = (LCOMMUNITY_STRLEN * lcom->size) + 2;
-	str_buf = XCALLOC(MTYPE_LCOMMUNITY_STR, str_buf_sz);
+	if (return_buffer) {
+		str_buf_sz = (LCOMMUNITY_STRLEN * lcom->size) + 2;
+		str_buf = XCALLOC(MTYPE_LCOMMUNITY_STR, str_buf_sz);
+	}
 
 	len = 0;
 	for (i = 0; i < lcom->size; i++) {
-		if (i > 0)
+		if (return_buffer && i > 0)
 			len = strlcat(str_buf, " ", str_buf_sz);
 
 		pnt = lcom->val + (i * LCOMMUNITY_SIZE);
@@ -207,15 +210,18 @@ static char *lcommunity_json_list(struct lcommunity *lcom,
 		const char *com2alias =
 			translate_alias ? bgp_community2alias(lcsb) : lcsb;
 		size_t individual_len = strlen(com2alias);
-		if (individual_len + len > str_buf_sz) {
-			str_buf_sz = individual_len + len + 1;
-			str_buf = XREALLOC(MTYPE_LCOMMUNITY_STR, str_buf,
-					   str_buf_sz);
+		if (str_buf) {
+			if (individual_len + len > str_buf_sz) {
+				str_buf_sz = individual_len + len + 1;
+				str_buf = XREALLOC(MTYPE_LCOMMUNITY_STR,
+						   str_buf, str_buf_sz);
+			}
+			len = strlcat(str_buf, com2alias, str_buf_sz);
 		}
 
-		len = strlcat(str_buf, com2alias, str_buf_sz);
-
-		if (json_lcommunity_list) {
+		if (incremental_print)
+			sprintbuf(pb, "%s\"%s\"", i ? "," : "", com2alias);
+		else if (json_lcommunity_list) {
 			json_string = json_object_new_string(com2alias);
 			json_object_array_add(json_lcommunity_list,
 					      json_string);
@@ -253,7 +259,7 @@ static void set_lcommunity_string(struct lcommunity *lcom, bool make_json,
 
 	str_buf = lcommunity_json_list(lcom,
 				       make_json ? json_lcommunity_list : NULL,
-				       translate_alias);
+				       translate_alias, true, NULL, false);
 
 	if (make_json) {
 		json_object_string_add(lcom->json, "string", str_buf);
@@ -567,6 +573,24 @@ static void bgp_aggr_lcommunity_prepare(struct hash_bucket *hb, void *arg)
 		*aggr_lcommunity = lcommunity_dup(hb_lcommunity);
 }
 
+static int lcommunity_json_to_string(struct json_object *jso,
+				     struct printbuf *pb, int level, int flags)
+{
+	struct lcommunity *lcom;
+
+	lcom = json_object_get_userdata(jso);
+	assert(lcom);
+	if (!lcom->str)
+		return 0;
+	printbuf_strappend(pb, "{\"string\":\"");
+	printbuf_memappend(pb, lcom->str, strlen(lcom->str));
+	printbuf_strappend(pb, "\",\"list\":[");
+
+	lcommunity_json_list(lcom, NULL, 0, false, pb, true);
+	printbuf_strappend(pb, "]}");
+	return 0;
+}
+
 void bgp_aggr_lcommunity_remove(void *arg)
 {
 	struct lcommunity *lcommunity = arg;
@@ -686,4 +710,14 @@ void bgp_remove_lcomm_from_aggregate_hash(struct bgp_aggregate *aggregate,
 			lcommunity_free(&ret_lcomm);
 		}
 	}
+}
+
+json_object *lcommunity_get_json(struct lcommunity *lcom)
+{
+	json_object *json_lcommunity = NULL;
+
+	json_lcommunity = json_object_new_object();
+	json_object_set_serializer(json_lcommunity, lcommunity_json_to_string,
+				   lcom, NULL);
+	return json_lcommunity;
 }

--- a/bgpd/bgp_lcommunity.h
+++ b/bgpd/bgp_lcommunity.h
@@ -25,9 +25,6 @@ struct lcommunity {
 	/* Large Communities value.  */
 	uint8_t *val;
 
-	/* Large Communities as a json object */
-	json_object *json;
-
 	/* Human readable format string.  */
 	char *str;
 };
@@ -56,8 +53,7 @@ extern struct hash *lcommunity_hash(void);
 extern struct lcommunity *lcommunity_str2com(const char *);
 extern bool lcommunity_match(const struct lcommunity *,
 			     const struct lcommunity *);
-extern char *lcommunity_str(struct lcommunity *, bool make_json,
-			    bool translate_alias);
+extern char *lcommunity_str(struct lcommunity *, bool translate_alias);
 extern bool lcommunity_include(struct lcommunity *lcom, uint8_t *ptr);
 extern void lcommunity_del_val(struct lcommunity *lcom, uint8_t *ptr);
 

--- a/bgpd/bgp_lcommunity.h
+++ b/bgpd/bgp_lcommunity.h
@@ -48,6 +48,7 @@ extern struct lcommunity *lcommunity_merge(struct lcommunity *,
 					   struct lcommunity *);
 extern struct lcommunity *lcommunity_uniq_sort(struct lcommunity *);
 extern struct lcommunity *lcommunity_intern(struct lcommunity *);
+extern json_object *lcommunity_get_json(struct lcommunity *lcom);
 extern bool lcommunity_cmp(const void *arg1, const void *arg2);
 extern void lcommunity_unintern(struct lcommunity **);
 extern unsigned int lcommunity_hash_make(const void *);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10515,6 +10515,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 	json_object *json_peer = NULL;
 	json_object *json_string = NULL;
 	json_object *json_adv_to = NULL;
+	json_object *json_aspath = NULL;
 	int first = 0;
 	struct listnode *node, *nnode;
 	struct peer *peer;
@@ -10654,11 +10655,9 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 	/* Line1 display AS-path, Aggregator */
 	if (attr->aspath) {
 		if (json_paths) {
-			if (!attr->aspath->json)
-				aspath_str_update(attr->aspath, true);
-			json_object_lock(attr->aspath->json);
+			json_aspath = aspath_get_json(attr->aspath);
 			json_object_object_add(json_path, "aspath",
-					       attr->aspath->json);
+					       json_aspath);
 		} else {
 			if (attr->aspath->segments)
 				vty_out(vty, "  %s", attr->aspath->str);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10516,6 +10516,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 	json_object *json_string = NULL;
 	json_object *json_adv_to = NULL;
 	json_object *json_aspath = NULL;
+	json_object *json_community = NULL;
 	int first = 0;
 	struct listnode *node, *nnode;
 	struct peer *peer;
@@ -11215,13 +11216,10 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 	/* Line 4 display Community */
 	if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES)) {
 		if (json_paths) {
-			if (!bgp_attr_get_community(attr)->json)
-				community_str(bgp_attr_get_community(attr),
-					      true, true);
-			json_object_lock(bgp_attr_get_community(attr)->json);
-			json_object_object_add(
-				json_path, "community",
-				bgp_attr_get_community(attr)->json);
+			json_community =
+                          community_get_json(bgp_attr_get_community(attr));
+			json_object_object_add(json_path, "community",
+					       json_community);
 		} else {
 			vty_out(vty, "      Community: %s\n",
 				bgp_attr_get_community(attr)->str);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10517,6 +10517,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 	json_object *json_adv_to = NULL;
 	json_object *json_aspath = NULL;
 	json_object *json_community = NULL;
+	json_object *json_lcommunity = NULL;
 	int first = 0;
 	struct listnode *node, *nnode;
 	struct peer *peer;
@@ -11259,13 +11260,10 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 	/* Line 6 display Large community */
 	if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES)) {
 		if (json_paths) {
-			if (!bgp_attr_get_lcommunity(attr)->json)
-				lcommunity_str(bgp_attr_get_lcommunity(attr),
-					       true, true);
-			json_object_lock(bgp_attr_get_lcommunity(attr)->json);
-			json_object_object_add(
-				json_path, "largeCommunity",
-				bgp_attr_get_lcommunity(attr)->json);
+			json_lcommunity = lcommunity_get_json(
+				bgp_attr_get_lcommunity(attr));
+			json_object_object_add(json_path, "largeCommunity",
+					       json_lcommunity);
 		} else {
 			vty_out(vty, "      Large Community: %s\n",
 				bgp_attr_get_lcommunity(attr)->str);

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -6504,7 +6504,7 @@ DEFUN_YANG (set_community,
 	XFREE(MTYPE_TMP, str);
 
 	/* Set communites attribute string.  */
-	str = community_str(com, false, false);
+	str = community_str(com, false);
 
 	if (additive) {
 		size_t argstr_sz = strlen(str) + strlen(" additive") + 1;

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -16418,7 +16418,7 @@ static void community_show_all_iterator(struct hash_bucket *bucket,
 
 	com = (struct community *)bucket->data;
 	vty_out(vty, "[%p] (%ld) %s\n", (void *)com, com->refcnt,
-		community_str(com, false, false));
+		community_str(com, false));
 }
 
 /* Show BGP's community internal data. */
@@ -22204,7 +22204,7 @@ static const char *community_list_config_str(struct community_entry *entry)
 	const char *str;
 
 	if (entry->style == COMMUNITY_LIST_STANDARD)
-		str = community_str(entry->u.com, false, false);
+		str = community_str(entry->u.com, false);
 	else if (entry->style == LARGE_COMMUNITY_LIST_STANDARD)
 		str = lcommunity_str(entry->u.lcom, false, false);
 	else

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -16447,7 +16447,7 @@ static void lcommunity_show_all_iterator(struct hash_bucket *bucket,
 
 	lcom = (struct lcommunity *)bucket->data;
 	vty_out(vty, "[%p] (%ld) %s\n", (void *)lcom, lcom->refcnt,
-		lcommunity_str(lcom, false, false));
+		lcommunity_str(lcom, false));
 }
 
 /* Show BGP's community internal data. */
@@ -22206,7 +22206,7 @@ static const char *community_list_config_str(struct community_entry *entry)
 	if (entry->style == COMMUNITY_LIST_STANDARD)
 		str = community_str(entry->u.com, false);
 	else if (entry->style == LARGE_COMMUNITY_LIST_STANDARD)
-		str = lcommunity_str(entry->u.lcom, false, false);
+		str = lcommunity_str(entry->u.lcom, false);
 	else
 		str = entry->config;
 

--- a/lib/asn.h
+++ b/lib/asn.h
@@ -50,7 +50,8 @@ extern bool asn_str2asn_notation(const char *asstring, as_t *asn,
 				 enum asnotation_mode *asnotation);
 extern const char *asn_mode2str(enum asnotation_mode asnotation);
 void asn_asn2json_array(json_object *jseg_list, as_t asn,
-			enum asnotation_mode asnotation);
+			enum asnotation_mode asnotation, struct printbuf *pb,
+			bool incremental_print);
 void asn_asn2json(json_object *jseg_list, const char *attr,
 		  as_t asn, enum asnotation_mode asnotation);
 extern char *asn_asn2string(const as_t *as, char *buf, size_t len,

--- a/lib/json.h
+++ b/lib/json.h
@@ -13,6 +13,7 @@ extern "C" {
 #include "command.h"
 #include "printfrr.h"
 #include <json-c/json.h>
+#include <json-c/printbuf.h>
 
 /*
  * FRR style JSON iteration.


### PR DESCRIPTION
After having loaded a full route, the memory consumption still increases after executing the 'show bgp ipv4 json detail' command. The memory consumed is related to json objects stored for BGP as paths, standard and large communities.

The below pull request proposes to incrementally display each path detailed information, without relying on the json storage.

Memory consumed after BGP routes have been loaded:
```
dut-orwell-nianticvf# show ip route summary
Route Source         Routes               FIB  (vrf default)
kernel               1                    1
connected            2                    2
ebgp                 993276               992665
ibgp                 0                    0
------
Totals               993279               992668

root@dut-orwell-nianticvf:~# ps -aux | grep bgpd
root      106598 84.0 10.2 1224244 1044028 ?     Ssl  15:54   1:46 /usr/bin/bgpd -A 127.0.0.1 -M snmp -M rpki -M bmp
```

Memory consumed after the 'show bgp ipv4 json detail' command is executed, without fix:
```
root@dut-orwell-nianticvf:~# time vtysh -c "show bgp ipv4 detail json" > /tmp/aa.txt

real    0m25.336s
user    0m2.438s
sys     0m4.745s
root@dut-orwell-nianticvf:~# ps -aux | grep bgpd
root       16770 59.0 18.6 2080984 1900816 ?     Ssl  09:13   2:03 /usr/bin/bgpd -A 127.0.0.1 -M snmp -M rpki -M bmp
```


after fix:
```
root@dut-orwell-nianticvf:~# time vtysh -c "show bgp ipv4 detail json" > /tmp/aa.txt

real    0m33.106s
user    0m2.594s
sys     0m4.533s
root@dut-sureau-nianticvf:~# ps -aux | grep bgpd
root       45983 45.4 13.6 1567712 1387988 ?     Ssl  11:24   2:10 /usr/bin/bgpd -A 127.0.0.1 -M snmp -M rpki -M bmp

```
