### PR TITLE
isisd: fix crash at flex-algo affinity setting

### DIFF
--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2994,18 +2994,10 @@ static int isis_instance_flex_algo_affinity_set(struct nb_cb_create_args *args,
 	uint32_t algorithm;
 	const char *val;
 
-	algorithm = yang_dnode_get_uint32(args->dnode, "../../flex-algo");
-	area = nb_running_get_entry(args->dnode, NULL, true);
 	val = yang_dnode_get_string(args->dnode, ".");
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
-		fa = flex_algo_lookup(area->flex_algos, algorithm);
-		if (!fa) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "flex-algo object not found");
-			return NB_ERR_RESOURCE;
-		}
 		map = affinity_map_get(val);
 		if (!map) {
 			snprintf(args->errmsg, args->errmsg_len,
@@ -3017,6 +3009,9 @@ static int isis_instance_flex_algo_affinity_set(struct nb_cb_create_args *args,
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
+		algorithm = yang_dnode_get_uint32(args->dnode,
+						  "../../flex-algo");
+		area = nb_running_get_entry(args->dnode, NULL, true);
 		fa = flex_algo_lookup(area->flex_algos, algorithm);
 		if (!fa) {
 			snprintf(args->errmsg, args->errmsg_len,
@@ -3057,18 +3052,10 @@ isis_instance_flex_algo_affinity_unset(struct nb_cb_destroy_args *args,
 	uint32_t algorithm;
 	const char *val;
 
-	algorithm = yang_dnode_get_uint32(args->dnode, "../../flex-algo");
-	area = nb_running_get_entry(args->dnode, NULL, true);
 	val = yang_dnode_get_string(args->dnode, ".");
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
-		fa = flex_algo_lookup(area->flex_algos, algorithm);
-		if (!fa) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "flex-algo object not found");
-			return NB_ERR_RESOURCE;
-		}
 		map = affinity_map_get(val);
 		if (!map) {
 			snprintf(args->errmsg, args->errmsg_len,
@@ -3080,6 +3067,9 @@ isis_instance_flex_algo_affinity_unset(struct nb_cb_destroy_args *args,
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
+		algorithm = yang_dnode_get_uint32(args->dnode,
+						  "../../flex-algo");
+		area = nb_running_get_entry(args->dnode, NULL, true);
 		fa = flex_algo_lookup(area->flex_algos, algorithm);
 		if (!fa) {
 			snprintf(args->errmsg, args->errmsg_len,

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -3156,19 +3156,16 @@ int isis_instance_flex_algo_affinity_exclude_any_destroy(
 int isis_instance_flex_algo_prefix_metric_create(struct nb_cb_create_args *args)
 {
 	struct isis_area *area;
-	const char *area_tag;
 	struct flex_algo *fa;
 	uint32_t algorithm;
-
-	area_tag = yang_dnode_get_string(args->dnode, "../../../area-tag");
-	area = isis_area_lookup(area_tag, VRF_DEFAULT);
-	if (!area)
-		return NB_ERR_RESOURCE;
 
 	algorithm = yang_dnode_get_uint32(args->dnode, "../flex-algo");
 
 	switch (args->event) {
 	case NB_EV_APPLY:
+		area = nb_running_get_entry(args->dnode, NULL, true);
+		if (!area)
+			return NB_ERR_RESOURCE;
 		fa = flex_algo_lookup(area->flex_algos, algorithm);
 		if (!fa) {
 			snprintf(args->errmsg, args->errmsg_len,
@@ -3191,19 +3188,17 @@ int isis_instance_flex_algo_prefix_metric_destroy(
 	struct nb_cb_destroy_args *args)
 {
 	struct isis_area *area;
-	const char *area_tag;
 	struct flex_algo *fa;
 	uint32_t algorithm;
-
-	area_tag = yang_dnode_get_string(args->dnode, "../../../area-tag");
-	area = isis_area_lookup(area_tag, VRF_DEFAULT);
-	if (!area)
-		return NB_ERR_RESOURCE;
 
 	algorithm = yang_dnode_get_uint32(args->dnode, "../flex-algo");
 
 	switch (args->event) {
 	case NB_EV_APPLY:
+		area = nb_running_get_entry(args->dnode, NULL, true);
+		if (!area)
+			return NB_ERR_RESOURCE;
+
 		fa = flex_algo_lookup(area->flex_algos, algorithm);
 		if (!fa) {
 			snprintf(args->errmsg, args->errmsg_len,
@@ -3226,19 +3221,17 @@ static int isis_instance_flex_algo_dplane_set(struct nb_cb_create_args *args,
 					      int type)
 {
 	struct isis_area *area;
-	const char *area_tag;
 	struct flex_algo *fa;
 	uint32_t algorithm;
-
-	area_tag = yang_dnode_get_string(args->dnode, "../../../area-tag");
-	area = isis_area_lookup(area_tag, VRF_DEFAULT);
-	if (!area)
-		return NB_ERR_RESOURCE;
 
 	algorithm = yang_dnode_get_uint32(args->dnode, "../flex-algo");
 
 	switch (args->event) {
 	case NB_EV_APPLY:
+		area = nb_running_get_entry(args->dnode, NULL, true);
+		if (!area)
+			return NB_ERR_RESOURCE;
+
 		fa = flex_algo_lookup(area->flex_algos, algorithm);
 		if (!fa) {
 			snprintf(args->errmsg, args->errmsg_len,
@@ -3268,19 +3261,17 @@ static int isis_instance_flex_algo_dplane_unset(struct nb_cb_destroy_args *args,
 						int type)
 {
 	struct isis_area *area;
-	const char *area_tag;
 	struct flex_algo *fa;
 	uint32_t algorithm;
-
-	area_tag = yang_dnode_get_string(args->dnode, "../../../area-tag");
-	area = isis_area_lookup(area_tag, VRF_DEFAULT);
-	if (!area)
-		return NB_ERR_RESOURCE;
 
 	algorithm = yang_dnode_get_uint32(args->dnode, "../flex-algo");
 
 	switch (args->event) {
 	case NB_EV_APPLY:
+		area = nb_running_get_entry(args->dnode, NULL, true);
+		if (!area)
+			return NB_ERR_RESOURCE;
+
 		fa = flex_algo_lookup(area->flex_algos, algorithm);
 		if (!fa) {
 			snprintf(args->errmsg, args->errmsg_len,
@@ -3350,21 +3341,19 @@ int isis_instance_flex_algo_dplane_ip_destroy(struct nb_cb_destroy_args *args)
 int isis_instance_flex_algo_metric_type_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
-	const char *area_tag;
 	struct flex_algo *fa;
 	uint32_t algorithm;
 	enum flex_algo_metric_type metric_type;
-
-	area_tag = yang_dnode_get_string(args->dnode, "../../../area-tag");
-	area = isis_area_lookup(area_tag, VRF_DEFAULT);
-	if (!area)
-		return NB_ERR_RESOURCE;
 
 	algorithm = yang_dnode_get_uint32(args->dnode, "../flex-algo");
 	metric_type = yang_dnode_get_enum(args->dnode, NULL);
 
 	switch (args->event) {
 	case NB_EV_APPLY:
+		area = nb_running_get_entry(args->dnode, NULL, true);
+		if (!area)
+			return NB_ERR_RESOURCE;
+
 		fa = flex_algo_lookup(area->flex_algos, algorithm);
 		if (!fa) {
 			snprintf(args->errmsg, args->errmsg_len,
@@ -3390,21 +3379,19 @@ int isis_instance_flex_algo_metric_type_modify(struct nb_cb_modify_args *args)
 int isis_instance_flex_algo_priority_modify(struct nb_cb_modify_args *args)
 {
 	struct isis_area *area;
-	const char *area_tag;
 	struct flex_algo *fa;
 	uint32_t algorithm;
 	uint32_t priority;
-
-	area_tag = yang_dnode_get_string(args->dnode, "../../../area-tag");
-	area = isis_area_lookup(area_tag, VRF_DEFAULT);
-	if (!area)
-		return NB_ERR_RESOURCE;
 
 	algorithm = yang_dnode_get_uint32(args->dnode, "../flex-algo");
 	priority = yang_dnode_get_uint32(args->dnode, NULL);
 
 	switch (args->event) {
 	case NB_EV_APPLY:
+		area = nb_running_get_entry(args->dnode, NULL, true);
+		if (!area)
+			return NB_ERR_RESOURCE;
+
 		fa = flex_algo_lookup(area->flex_algos, algorithm);
 		if (!fa) {
 			snprintf(args->errmsg, args->errmsg_len,
@@ -3426,21 +3413,19 @@ int isis_instance_flex_algo_priority_modify(struct nb_cb_modify_args *args)
 int isis_instance_flex_algo_priority_destroy(struct nb_cb_destroy_args *args)
 {
 	struct isis_area *area;
-	const char *area_tag;
 	struct flex_algo *fa;
 	uint32_t algorithm;
 	uint32_t priority = FLEX_ALGO_PRIO_DEFAULT;
-
-	area_tag = yang_dnode_get_string(args->dnode, "../../../area-tag");
-	area = isis_area_lookup(area_tag, VRF_DEFAULT);
-	if (!area)
-		return NB_ERR_RESOURCE;
 
 	algorithm = yang_dnode_get_uint32(args->dnode, "../flex-algo");
 	priority = yang_dnode_get_uint32(args->dnode, NULL);
 
 	switch (args->event) {
 	case NB_EV_APPLY:
+		area = nb_running_get_entry(args->dnode, NULL, true);
+		if (!area)
+			return NB_ERR_RESOURCE;
+
 		fa = flex_algo_lookup(area->flex_algos, algorithm);
 		if (!fa) {
 			snprintf(args->errmsg, args->errmsg_len,


### PR DESCRIPTION
The following causes a isisd crash.

> router # cat config
> affinity-map green bit-position 0
> router isis 1
>  flex-algo 129
>   affinity exclude-any green
> router # vtysh -f config

> router #0  raise (sig=<optimized out>) at ../sysdeps/unix/sysv/linux/raise.c:50
> https://github.com/FRRouting/frr/pull/1  0x00007f650cd32756 in core_handler (signo=6, siginfo=0x7ffc56f93070, context=0x7ffc56f92f40) at lib/sigevent.c:258
> https://github.com/FRRouting/frr/issues/2  <signal handler called>
> https://github.com/FRRouting/frr/issues/3  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
> https://github.com/FRRouting/frr/issues/4  0x00007f650c91c537 in __GI_abort () at abort.c:79
> https://github.com/FRRouting/frr/pull/5  0x00007f650cd007c9 in nb_running_get_entry_worker (dnode=0x0, xpath=0x0, abort_if_not_found=true, rec_search=true) at lib/northbound.c:2531
> https://github.com/FRRouting/frr/pull/6  0x00007f650cd007f9 in nb_running_get_entry (dnode=0x55d9ad406e00, xpath=0x0, abort_if_not_found=true) at lib/northbound.c:2537
> https://github.com/FRRouting/frr/pull/7  0x000055d9ab302248 in isis_instance_flex_algo_affinity_set (args=0x7ffc56f947a0, type=2) at isisd/isis_nb_config.c:2998
> https://github.com/FRRouting/frr/pull/8  0x000055d9ab3027c0 in isis_instance_flex_algo_affinity_exclude_any_create (args=0x7ffc56f947a0) at isisd/isis_nb_config.c:3155
> https://github.com/FRRouting/frr/issues/9  0x00007f650ccfe284 in nb_callback_create (context=0x7ffc56f94d20, nb_node=0x55d9ad28b540, event=NB_EV_VALIDATE, dnode=0x55d9ad406e00, resource=0x0, errmsg=0x7ffc56f94de0 "",
>     errmsg_len=8192) at lib/northbound.c:1487
> https://github.com/FRRouting/frr/pull/10 0x00007f650ccff067 in nb_callback_configuration (context=0x7ffc56f94d20, event=NB_EV_VALIDATE, change=0x55d9ad406d40, errmsg=0x7ffc56f94de0 "", errmsg_len=8192) at lib/northbound.c:1884
> https://github.com/FRRouting/frr/issues/11 0x00007f650ccfda31 in nb_candidate_validate_code (context=0x7ffc56f94d20, candidate=0x55d9ad20d710, changes=0x7ffc56f94d38, errmsg=0x7ffc56f94de0 "", errmsg_len=8192)
>     at lib/northbound.c:1246
> https://github.com/FRRouting/frr/pull/12 0x00007f650ccfdc67 in nb_candidate_commit_prepare (context=..., candidate=0x55d9ad20d710, comment=0x0, transaction=0x7ffc56f94da0, skip_validate=false, ignore_zero_change=false,
>     errmsg=0x7ffc56f94de0 "", errmsg_len=8192) at lib/northbound.c:1317
> https://github.com/FRRouting/frr/pull/13 0x00007f650ccfdec4 in nb_candidate_commit (context=..., candidate=0x55d9ad20d710, save_transaction=true, comment=0x0, transaction_id=0x0, errmsg=0x7ffc56f94de0 "", errmsg_len=8192)
>     at lib/northbound.c:1381
> https://github.com/FRRouting/frr/issues/14 0x00007f650cd045ba in nb_cli_classic_commit (vty=0x55d9ad3f7490) at lib/northbound_cli.c:57
> https://github.com/FRRouting/frr/pull/15 0x00007f650cd04749 in nb_cli_pending_commit_check (vty=0x55d9ad3f7490) at lib/northbound_cli.c:96
> https://github.com/FRRouting/frr/issues/16 0x00007f650cc94340 in cmd_execute_command_real (vline=0x55d9ad3eea10, vty=0x55d9ad3f7490, cmd=0x0, up_level=0) at lib/command.c:1000
> https://github.com/FRRouting/frr/issues/17 0x00007f650cc94599 in cmd_execute_command (vline=0x55d9ad3eea10, vty=0x55d9ad3f7490, cmd=0x0, vtysh=0) at lib/command.c:1080
> https://github.com/FRRouting/frr/issues/18 0x00007f650cc94a0c in cmd_execute (vty=0x55d9ad3f7490, cmd=0x55d9ad401d30 "XFRR_end_configuration", matched=0x0, vtysh=0) at lib/command.c:1228
> https://github.com/FRRouting/frr/issues/19 0x00007f650cd523a4 in vty_command (vty=0x55d9ad3f7490, buf=0x55d9ad401d30 "XFRR_end_configuration") at lib/vty.c:625
> https://github.com/FRRouting/frr/issues/20 0x00007f650cd5413d in vty_execute (vty=0x55d9ad3f7490) at lib/vty.c:1388
> https://github.com/FRRouting/frr/issues/21 0x00007f650cd56353 in vtysh_read (thread=0x7ffc56f99370) at lib/vty.c:2400
> https://github.com/FRRouting/frr/pull/22 0x00007f650cd4b6fd in event_call (thread=0x7ffc56f99370) at lib/event.c:1996
> https://github.com/FRRouting/frr/issues/23 0x00007f650ccd1365 in frr_run (master=0x55d9ad103cf0) at lib/libfrr.c:1231
> https://github.com/FRRouting/frr/pull/24 0x000055d9ab29036e in main (argc=2, argv=0x7ffc56f99598, envp=0x7ffc56f995b0) at isisd/isis_main.c:354

Configuring the same in vtysh configure interactive mode works properly.
When using "vtysh -f", the northbound compatible configuration is
committed together whereas, in interactive mode, it committed line by
line. In the first situation, in validation state nb_running_get_entry()
fails because the area not yet in running.

Do not use nb_running_get_entry() northbound validation state.

Fixes: https://github.com/FRRouting/frr/commit/893882ee20473fc5356ec40bbc6438d652a11167 ("isisd: add isis flex-algo configuration backend")