### PR TITLE
lib,zebra,sharpd: allow recursive resolution of nexthop-groups

### DIFF
--- a/doc/user/nexthop_groups.rst
+++ b/doc/user/nexthop_groups.rst
@@ -56,3 +56,9 @@ listing of ECMP nexthops used to forward packets.
    * **buckets**: Number of buckets in the hash (1-256)
    * **idle-timer**: Idle timer in seconds (1-4294967295)
    * **unbalanced-timer**: Unbalanced timer in seconds (1-4294967295)
+
+.. clicmd:: recursive
+
+   Flag a nexthop-group that allows recursive resolution for its
+   nexthops. Without this flag, zebra will not validate or resolve the
+   nexthops in the group.

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -717,6 +717,30 @@ DEFPY(no_nexthop_group_resilience,
 	return CMD_SUCCESS;
 }
 
+DEFPY(nexthop_group_recursive,
+      nexthop_group_recursive_cmd,
+      "[no] recursive",
+      NO_STR
+      "Allow recursive resolution\n")
+{
+	VTY_DECLVAR_CONTEXT(nexthop_group_cmd, nhgc);
+	uint32_t flags;
+
+	flags = nhgc->flags;
+
+	if (no)
+		UNSET_FLAG(nhgc->flags, NHG_CMD_FLAG_RECURSIVE);
+	else
+		SET_FLAG(nhgc->flags, NHG_CMD_FLAG_RECURSIVE);
+
+	if (flags != nhgc->flags) {
+		if (nhg_hooks.modify)
+			nhg_hooks.modify(nhgc);
+	}
+
+	return CMD_SUCCESS;
+}
+
 static void nexthop_group_save_nhop(struct nexthop_group_cmd *nhgc,
 				    const char *nhvrf_name,
 				    const union sockunion *addr,
@@ -1184,6 +1208,10 @@ static int nexthop_group_write(struct vty *vty)
 
 		vty_out(vty, "nexthop-group %s\n", nhgc->name);
 
+		/* Flags */
+		if (CHECK_FLAG(nhgc->flags, NHG_CMD_FLAG_RECURSIVE))
+			vty_out(vty, " recursive\n");
+
 		if (nhgc->nhg.nhgr.buckets)
 			vty_out(vty,
 				" resilient buckets %u idle-timer %u unbalanced-timer %u\n",
@@ -1383,6 +1411,8 @@ void nexthop_group_init(void (*new)(const char *name),
 
 	install_element(NH_GROUP_NODE, &nexthop_group_resilience_cmd);
 	install_element(NH_GROUP_NODE, &no_nexthop_group_resilience_cmd);
+
+	install_element(NH_GROUP_NODE, &nexthop_group_recursive_cmd);
 
 	memset(&nhg_hooks, 0, sizeof(nhg_hooks));
 

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -90,6 +90,8 @@ struct nexthop_group_cmd {
 
 	struct nexthop_group nhg;
 
+	uint32_t flags;
+
 	struct list *nhg_list;
 
 	QOBJ_FIELDS;
@@ -98,6 +100,13 @@ RB_HEAD(nhgc_entry_head, nexthp_group_cmd);
 RB_PROTOTYPE(nhgc_entry_head, nexthop_group_cmd, nhgc_entry,
 	     nexthop_group_cmd_compare)
 DECLARE_QOBJ_TYPE(nexthop_group_cmd);
+
+/*
+ * Flags values
+ */
+/* Request/allow recursive resolution for an NHG */
+#define NHG_CMD_FLAG_RECURSIVE (1 << 0)
+
 
 /*
  * Initialize nexthop_groups.  If you are interested in when

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1347,6 +1347,7 @@ static int zapi_nhg_encode(struct stream *s, int cmd, struct zapi_nhg *api_nhg)
 
 	stream_putw(s, api_nhg->proto);
 	stream_putl(s, api_nhg->id);
+	stream_putl(s, api_nhg->flags);
 
 	stream_putw(s, api_nhg->resilience.buckets);
 	stream_putl(s, api_nhg->resilience.idle_timer);

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -493,6 +493,7 @@ struct zapi_nexthop {
 struct zapi_nhg {
 	uint16_t proto;
 	uint32_t id;
+	uint32_t flags;
 
 	struct nhg_resilience resilience;
 
@@ -502,6 +503,9 @@ struct zapi_nhg {
 	uint16_t backup_nexthop_num;
 	struct zapi_nexthop backup_nexthops[MULTIPATH_NUM];
 };
+
+/* Flags for the zapi NHG message. */
+#define ZAPI_NHG_FLAG_RECURSIVE 0x01
 
 /*
  * Some of these data structures do not map easily to

--- a/sharpd/sharp_nht.c
+++ b/sharpd/sharp_nht.c
@@ -129,7 +129,7 @@ static void sharp_nhgroup_modify_cb(const struct nexthop_group_cmd *nhgc)
 	if (nhgc->backup_list_name[0])
 		bnhgc = nhgc_find(nhgc->backup_list_name);
 
-	nhg_add(snhg->id, &nhgc->nhg, (bnhgc ? &bnhgc->nhg : NULL));
+	nhg_add(snhg->id, nhgc, bnhgc);
 }
 
 static void sharp_nhgroup_add_nexthop_cb(const struct nexthop_group_cmd *nhgc,
@@ -145,7 +145,7 @@ static void sharp_nhgroup_add_nexthop_cb(const struct nexthop_group_cmd *nhgc,
 	if (nhgc->backup_list_name[0])
 		bnhgc = nhgc_find(nhgc->backup_list_name);
 
-	nhg_add(snhg->id, &nhgc->nhg, (bnhgc ? &bnhgc->nhg : NULL));
+	nhg_add(snhg->id, nhgc, bnhgc);
 }
 
 static void sharp_nhgroup_del_nexthop_cb(const struct nexthop_group_cmd *nhgc,
@@ -161,7 +161,7 @@ static void sharp_nhgroup_del_nexthop_cb(const struct nexthop_group_cmd *nhgc,
 	if (nhgc->backup_list_name[0])
 		bnhgc = nhgc_find(nhgc->backup_list_name);
 
-	nhg_add(snhg->id, &nhgc->nhg, (bnhgc ? &bnhgc->nhg : NULL));
+	nhg_add(snhg->id, nhgc, bnhgc);
 }
 
 static void sharp_nhgroup_delete_cb(const char *name)

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -571,17 +571,24 @@ void vrf_label_add(vrf_id_t vrf_id, afi_t afi, mpls_label_t label)
 	zclient_send_vrf_label(g_zclient, vrf_id, afi, label, ZEBRA_LSP_SHARP);
 }
 
-void nhg_add(uint32_t id, const struct nexthop_group *nhg,
-	     const struct nexthop_group *backup_nhg)
+void nhg_add(uint32_t id, const struct nexthop_group_cmd *nhgc,
+	     const struct nexthop_group_cmd *backup_nhgc)
 {
 	struct zapi_nhg api_nhg = {};
+	const struct nexthop_group *nhg;
 	struct zapi_nexthop *api_nh;
 	struct nexthop *nh;
 	bool is_valid = true;
 
 	api_nhg.id = id;
 
-	api_nhg.resilience = nhg->nhgr;
+	nhg = &(nhgc->nhg);
+
+	api_nhg.resilience = nhgc->nhg.nhgr;
+
+	/* Ask for recursion if needed */
+	if (CHECK_FLAG(nhgc->flags, NHG_CMD_FLAG_RECURSIVE))
+		SET_FLAG(api_nhg.flags, ZAPI_NHG_FLAG_RECURSIVE);
 
 	for (ALL_NEXTHOPS_PTR(nhg, nh)) {
 		if (api_nhg.nexthop_num >= MULTIPATH_NUM) {
@@ -594,7 +601,8 @@ void nhg_add(uint32_t id, const struct nexthop_group *nhg,
 		/* Unresolved nexthops will lead to failure - only send
 		 * nexthops that zebra will consider valid.
 		 */
-		if (nh->ifindex == 0)
+		if (!CHECK_FLAG(nhgc->flags, NHG_CMD_FLAG_RECURSIVE) &&
+		    nh->ifindex == 0)
 			continue;
 
 		api_nh = &api_nhg.nexthops[api_nhg.nexthop_num];
@@ -616,14 +624,18 @@ void nhg_add(uint32_t id, const struct nexthop_group *nhg,
 		goto done;
 	}
 
-	if (backup_nhg) {
-		for (ALL_NEXTHOPS_PTR(backup_nhg, nh)) {
+	if (backup_nhgc) {
+		nhg = &(backup_nhgc->nhg);
+
+		for (ALL_NEXTHOPS_PTR(nhg, nh)) {
 			if (api_nhg.backup_nexthop_num >= MULTIPATH_NUM) {
 				zlog_warn(
 					"%s: number of backup nexthops greater than max multipath size, truncating",
 					__func__);
 				break;
 			}
+
+			/* TODO-- */
 
 			/* Unresolved nexthop: will be rejected by zebra.
 			 * That causes a problem, since the primary nexthops

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -15,8 +15,8 @@ int sharp_zclient_create(uint32_t session_id);
 int sharp_zclient_delete(uint32_t session_id);
 
 extern void vrf_label_add(vrf_id_t vrf_id, afi_t afi, mpls_label_t label);
-extern void nhg_add(uint32_t id, const struct nexthop_group *nhg,
-		    const struct nexthop_group *backup_nhg);
+extern void nhg_add(uint32_t id, const struct nexthop_group_cmd *nhgc,
+		    const struct nexthop_group_cmd *backup_nhgc);
 extern void nhg_del(uint32_t id);
 extern void sharp_zebra_nexthop_watch(struct prefix *p, vrf_id_t vrf_id, bool import, bool watch,
 				      bool connected, bool mrib);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1982,6 +1982,7 @@ static int zapi_nhg_decode(struct stream *s, int cmd, struct zapi_nhg *api_nhg)
 
 	STREAM_GETW(s, api_nhg->proto);
 	STREAM_GETL(s, api_nhg->id);
+	STREAM_GETL(s, api_nhg->flags);
 
 	if (cmd == ZEBRA_NHG_DEL)
 		goto done;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2114,6 +2114,9 @@ static void zread_nhg_add(ZAPI_HANDLER_ARGS)
 	nhe->zapi_instance = client->instance;
 	nhe->zapi_session = client->session_id;
 
+	/* TODO -- may need an AFI, so try to derive one */
+	nhe->afi = zebra_nhg_get_afi(nhg, AFI_IP);
+
 	/* Take over the list(s) of nexthops */
 	nhe->nhg.nexthop = nhg->nexthop;
 	nhg->nexthop = NULL;
@@ -2125,11 +2128,8 @@ static void zread_nhg_add(ZAPI_HANDLER_ARGS)
 		bnhg = NULL;
 	}
 
-	/*
-	 * TODO:
-	 * Assume fully resolved for now and install.
-	 * Resolution is going to need some more work.
-	 */
+	if (CHECK_FLAG(api_nhg.flags, ZAPI_NHG_FLAG_RECURSIVE))
+		SET_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSION_REQ);
 
 	/* Enqueue to workqueue for processing */
 	rib_queue_nhe_add(nhe);

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -3798,10 +3798,10 @@ bool zebra_nhg_proto_nexthops_only(void)
 	return proto_nexthops_only;
 }
 
-/* Add NHE from upper level proto */
-struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
-					   uint16_t instance, uint32_t session,
-					   struct nexthop_group *nhg, afi_t afi)
+/*
+ * Add NHE from upper level proto/daemon
+ */
+struct nhg_hash_entry *zebra_nhe_proto_add(struct nhg_hash_entry *nhe)
 {
 	struct nhg_hash_entry lookup;
 	struct nhg_hash_entry *new, *old;
@@ -3809,11 +3809,15 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 	struct nexthop *newhop;
 	bool replace = false;
 	int ret = 0;
+	const struct nexthop_group *nhg;
 
-	if (!nhg->nexthop) {
+	if (nhe)
+		nhg = &nhe->nhg;
+
+	if (!nhe || !nhg->nexthop) {
 		if (IS_ZEBRA_DEBUG_NHG)
 			zlog_debug("%s: id %u, no nexthops passed to add",
-				   __func__, id);
+				   __func__, (nhe ? nhe->id : 0));
 		return NULL;
 	}
 
@@ -3830,7 +3834,7 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 			if (IS_ZEBRA_DEBUG_NHG)
 				zlog_debug(
 					"%s: id %u, backup nexthops not supported",
-					__func__, id);
+					__func__, nhe->id);
 			return NULL;
 		}
 
@@ -3838,7 +3842,7 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 			if (IS_ZEBRA_DEBUG_NHG)
 				zlog_debug(
 					"%s: id %u, blackhole nexthop not supported",
-					__func__, id);
+					__func__, nhe->id);
 			return NULL;
 		}
 
@@ -3846,7 +3850,7 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 			if (IS_ZEBRA_DEBUG_NHG)
 				zlog_debug(
 					"%s: id %u, nexthop without gateway not supported",
-					__func__, id);
+					__func__, nhe->id);
 			return NULL;
 		}
 
@@ -3854,19 +3858,19 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 			if (IS_ZEBRA_DEBUG_NHG)
 				zlog_debug(
 					"%s: id %u, nexthop without ifindex is not supported",
-					__func__, id);
+					__func__, nhe->id);
 			return NULL;
 		}
 		SET_FLAG(newhop->flags, NEXTHOP_FLAG_ACTIVE);
 	}
 
-	zebra_nhe_init(&lookup, afi, nhg->nexthop);
+	zebra_nhe_init(&lookup, nhe->afi, nhg->nexthop);
 	lookup.nhg.nexthop = nhg->nexthop;
 	lookup.nhg.nhgr = nhg->nhgr;
-	lookup.id = id;
-	lookup.type = type;
+	lookup.id = nhe->id;
+	lookup.type = nhe->type;
 
-	old = zebra_nhg_lookup_id(id);
+	old = zebra_nhg_lookup_id(nhe->id);
 
 	if (old) {
 		/*
@@ -3882,19 +3886,19 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 		zebra_nhg_release_all_deps(old);
 	}
 
-	new = zebra_nhg_rib_find_nhe(&lookup, afi);
+	new = zebra_nhg_rib_find_nhe(&lookup, nhe->afi);
 
 	if (!new) {
 		if (IS_ZEBRA_DEBUG_NHG)
-			zlog_debug("%s: zebra_nhg_rib_find_nhe failed for id %u", __func__, id);
+			zlog_debug("%s: zebra_nhg_rib_find_nhe failed for id %u", __func__, nhe->id);
 		return NULL;
 	}
 
 	zebra_nhg_increment_ref(new);
 
 	/* Capture zapi client info */
-	new->zapi_instance = instance;
-	new->zapi_session = session;
+	new->zapi_instance = nhe->zapi_instance;
+	new->zapi_session = nhe->zapi_session;
 
 	zebra_nhg_set_valid_if_active(new);
 

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -354,6 +354,61 @@ zebra_nhg_connect_depends(struct nhg_hash_entry *nhe,
 	}
 }
 
+/*
+ * Determine nhg address-family, with special rules for singletons
+ */
+afi_t zebra_nhg_get_afi(const struct nexthop_group *nhg, afi_t route_afi)
+{
+	afi_t afi = AFI_UNSPEC, last_afi = AFI_UNSPEC;
+	const struct nexthop *nh;
+	bool all_same = true;
+
+	nh = nhg->nexthop;
+
+	/* There are some special rules that apply to nexthops' AFIs. */
+	while (nh) {
+		switch (nh->type) {
+			/*
+			 * This switch case handles setting the afi different
+			 * for ipv4/v6 routes. Ifindex nexthop
+			 * objects cannot be ambiguous, they must be Address
+			 * Family specific as that the kernel relies on these
+			 * for some reason.  blackholes can be v6 because the
+			 * v4 kernel infrastructure allows the usage of v6
+			 * blackholes in this case.   if we get here, we will
+			 * either use the AF of the route, or the one we got
+			 * passed from here from the kernel.
+			 */
+		case NEXTHOP_TYPE_IFINDEX:
+			afi = route_afi;
+			break;
+		case NEXTHOP_TYPE_BLACKHOLE:
+			afi = AFI_IP6;
+			break;
+		case NEXTHOP_TYPE_IPV4_IFINDEX:
+		case NEXTHOP_TYPE_IPV4:
+			afi = AFI_IP;
+			break;
+		case NEXTHOP_TYPE_IPV6_IFINDEX:
+		case NEXTHOP_TYPE_IPV6:
+			afi = AFI_IP6;
+			break;
+		}
+
+		if (last_afi != AF_UNSPEC && last_afi != afi)
+			all_same = false;
+
+		last_afi = afi;
+		nh = nh->next;
+	}
+
+	if (!all_same)
+		zlog_warn("Not all Nexthops had equivalent AFIs; "
+			  "something is seriously wrong");
+
+	return afi;
+}
+
 /* Init an nhe, for use in a hash lookup for example */
 void zebra_nhe_init(struct nhg_hash_entry *nhe, afi_t afi,
 		    const struct nexthop *nh)
@@ -2809,6 +2864,72 @@ skip_check:
 	return CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 }
 
+
+/* This function verifies reachability of one given nexthop in an incoming
+ * protocol daemon's nhg. The result is unconditionally stored
+ * in nexthop->flags field. The nexthop->ifindex will be updated
+ * appropriately as well.
+ *
+ * The return value is the final value of 'ACTIVE' flag.
+ */
+static unsigned int nhg_nexthop_active_check(struct nexthop *nexthop,
+					     struct nhg_hash_entry *nhe)
+{
+	uint32_t mtu = 0;
+	vrf_id_t vrf_id;
+	uint32_t flags = 0;
+
+	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+		zlog_debug("%s: nhe %u, nexthop %pNHv", __func__, nhe->id,
+			   nexthop);
+
+	/* Map flags for use in the nexthop check */
+	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSION_REQ))
+		SET_FLAG(flags, ZEBRA_FLAG_ALLOW_RECURSION);
+
+	vrf_id = nexthop->vrf_id;
+
+	switch (nexthop->type) {
+	case NEXTHOP_TYPE_IFINDEX:
+		if (nexthop_active(nexthop, nhe, NULL, nhe->type, flags, &mtu,
+				   vrf_id))
+			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
+		else
+			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
+		break;
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		if (nexthop_active(nexthop, nhe, NULL, nhe->type, flags, &mtu,
+				   vrf_id))
+			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
+		else
+			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
+		break;
+	case NEXTHOP_TYPE_IPV6:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		if (nexthop_active(nexthop, nhe, NULL, nhe->type, flags, &mtu,
+				   vrf_id))
+			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
+		else
+			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
+		break;
+	case NEXTHOP_TYPE_BLACKHOLE:
+		SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
+		break;
+	default:
+		break;
+	}
+
+	if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE)) {
+		if (IS_ZEBRA_DEBUG_RIB_DETAILED)
+			zlog_debug("        %s: Unable to find active nexthop",
+				   __func__);
+		return 0;
+	}
+
+	return CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
+}
+
 /* Helper function called after resolution to walk nhg rb trees
  * and toggle the NEXTHOP_GROUP_VALID flag if the nexthop
  * is active on singleton NHEs.
@@ -2969,6 +3090,70 @@ static uint32_t nexthop_list_active_update(struct route_node *rn,
 	return counter;
 }
 
+
+/*
+ * Process a list of nexthops, given an nhe, determining
+ * whether each one is ACTIVE/installable at this time.
+ */
+static uint32_t nhg_nexthop_list_active_update(struct nhg_hash_entry *nhe,
+					       bool is_backup, bool *change_p)
+{
+	unsigned int prev_active, new_active;
+	ifindex_t prev_index;
+	uint32_t counter = 0;
+	struct nexthop *nexthop;
+	struct nexthop_group *nhg = &nhe->nhg;
+
+	nexthop = nhg->nexthop;
+
+	/*
+	 * In the route-entry path, there's a call to
+	 * nexthop_list_set_evpn_dvni() to work with evpn routes
+	 * and their nexthops. Without a route here, we aren't making
+	 * that call.
+	 */
+
+	/* Process nexthops one-by-one */
+	for (; nexthop; nexthop = nexthop->next) {
+		prev_active = CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
+		prev_index = nexthop->ifindex;
+
+		/* Include the containing nhe for primary nexthops: if there's
+		 * recursive resolution, we capture the backup info also.
+		 */
+		new_active = nhg_nexthop_active_check(nexthop,
+						      (is_backup ? NULL : nhe));
+
+		/*
+		 * We need to respect the multipath_num here
+		 * as that what we should be able to install from
+		 * a multipath perspective should not be a data plane
+		 * decision point.
+		 */
+		if (new_active && counter >= zrouter.zav.multipath_num) {
+			struct nexthop *nh;
+
+			/* Set it and its resolved nexthop as inactive. */
+			for (nh = nexthop; nh; nh = nh->resolved)
+				UNSET_FLAG(nh->flags, NEXTHOP_FLAG_ACTIVE);
+
+			new_active = 0;
+		}
+
+		if (new_active)
+			counter++;
+
+		/* Check for changes to the nexthop
+		 * TODO -- is this enough of a check? we should probably be
+		 * making more-detailed "change" tests, in case the details of
+		 * a singleton nexthop change.
+		 */
+		if (prev_active != new_active || prev_index != nexthop->ifindex)
+			(*change_p) = true;
+	}
+
+	return counter;
+}
 
 static uint32_t proto_nhg_nexthop_active_update(struct nexthop_group *nhg)
 {
@@ -3221,6 +3406,13 @@ int nexthop_active_update(struct route_node *rn, struct route_entry *re,
 	struct nhg_hash_entry *curr_nhe, *remove;
 	uint32_t curr_active = 0, backup_active = 0;
 
+	/*
+	 * TODO -- examine this path, in case we want incoming routes to
+	 * trigger checks for proto nhgs also.
+	 * Maybe we can split the rn/re parts of the active check into
+	 * their own function, so we can run those parts separately from
+	 * the nexthop checking when we're processing an re.
+	 */
 	if (PROTO_OWNED(re->nhe) ||
 	    CHECK_FLAG(re->nhe->flags, NEXTHOP_GROUP_RECEIVED_FROM_EXTERNAL))
 		return proto_nhg_nexthop_active_update(&re->nhe->nhg);
@@ -3799,28 +3991,15 @@ bool zebra_nhg_proto_nexthops_only(void)
 }
 
 /*
- * Add NHE from upper level proto/daemon
+ * Validation helper for incoming daemon-owned nhgs. This does not do full, live
+ * validation using the RIB, it just does a few simple checks.
  */
-struct nhg_hash_entry *zebra_nhe_proto_add(struct nhg_hash_entry *nhe)
+static bool proto_nhe_check(struct nhg_hash_entry *nhe)
 {
-	struct nhg_hash_entry lookup;
-	struct nhg_hash_entry *new, *old;
-	struct nhg_connected *rb_node_dep = NULL;
 	struct nexthop *newhop;
-	bool replace = false;
-	int ret = 0;
-	const struct nexthop_group *nhg;
+	struct nexthop_group *nhg;
 
-	if (nhe)
-		nhg = &nhe->nhg;
-
-	if (!nhe || !nhg->nexthop) {
-		if (IS_ZEBRA_DEBUG_NHG)
-			zlog_debug("%s: id %u, no nexthops passed to add",
-				   __func__, (nhe ? nhe->id : 0));
-		return NULL;
-	}
-
+	nhg = &nhe->nhg;
 
 	/* Set nexthop list as active, since they wont go through rib
 	 * processing.
@@ -3835,7 +4014,7 @@ struct nhg_hash_entry *zebra_nhe_proto_add(struct nhg_hash_entry *nhe)
 				zlog_debug(
 					"%s: id %u, backup nexthops not supported",
 					__func__, nhe->id);
-			return NULL;
+			return false;
 		}
 
 		if (newhop->type == NEXTHOP_TYPE_BLACKHOLE) {
@@ -3843,7 +4022,7 @@ struct nhg_hash_entry *zebra_nhe_proto_add(struct nhg_hash_entry *nhe)
 				zlog_debug(
 					"%s: id %u, blackhole nexthop not supported",
 					__func__, nhe->id);
-			return NULL;
+			return false;
 		}
 
 		if (newhop->type == NEXTHOP_TYPE_IFINDEX) {
@@ -3851,7 +4030,7 @@ struct nhg_hash_entry *zebra_nhe_proto_add(struct nhg_hash_entry *nhe)
 				zlog_debug(
 					"%s: id %u, nexthop without gateway not supported",
 					__func__, nhe->id);
-			return NULL;
+			return false;
 		}
 
 		if (!newhop->ifindex) {
@@ -3859,9 +4038,53 @@ struct nhg_hash_entry *zebra_nhe_proto_add(struct nhg_hash_entry *nhe)
 				zlog_debug(
 					"%s: id %u, nexthop without ifindex is not supported",
 					__func__, nhe->id);
-			return NULL;
+			return false;
 		}
 		SET_FLAG(newhop->flags, NEXTHOP_FLAG_ACTIVE);
+	}
+
+	return true;
+}
+
+
+/*
+ * Add NHE from upper level proto/daemon
+ */
+struct nhg_hash_entry *zebra_nhe_proto_add(struct nhg_hash_entry *nhe)
+{
+	struct nhg_hash_entry lookup;
+	struct nhg_hash_entry *new, *old;
+	struct nhg_connected *rb_node_dep = NULL;
+	bool replace = false;
+	int ret = 0;
+	const struct nexthop_group *nhg;
+	uint32_t count = 0;
+	bool change_p = false;
+
+	if (nhe)
+		nhg = &nhe->nhg;
+
+	if (!nhe || !nhg->nexthop) {
+		if (IS_ZEBRA_DEBUG_NHG)
+			zlog_debug("%s: id %u, no nexthops passed to add",
+				   __func__, (nhe ? nhe->id : 0));
+		return NULL;
+	}
+
+	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSION_REQ)) {
+		/* Evaluate nexthops, determine whether active, perform
+		 * recursive resolution if requested by the daemon.
+		 */
+		count = nhg_nexthop_list_active_update(nhe, false, &change_p);
+
+		if (IS_ZEBRA_DEBUG_NHG)
+			zlog_debug("%s: %pNG => count %u%s", __func__, nhe, count,
+				   (change_p ? ", changed" : ""));
+
+	} else {
+		/* Simple validation, limited checking */
+		if (!proto_nhe_check(nhe))
+			return NULL;
 	}
 
 	zebra_nhe_init(&lookup, nhe->afi, nhg->nexthop);
@@ -3899,6 +4122,13 @@ struct nhg_hash_entry *zebra_nhe_proto_add(struct nhg_hash_entry *nhe)
 	/* Capture zapi client info */
 	new->zapi_instance = nhe->zapi_instance;
 	new->zapi_session = nhe->zapi_session;
+
+	/*
+	 * If we have valid nexthops to install, ok to proceed and
+	 * install/update.
+	 * If not, if we had routes using the nhg, we need to get them fixed
+	 * to match the current status of the nhg.
+	 */
 
 	zebra_nhg_set_valid_if_active(new);
 
@@ -4258,5 +4488,10 @@ void dump_nhg_flags(uint32_t flags, char *buf, size_t len)
 		if (!first)
 			strlcat(buf, ", ", len);
 		strlcat(buf, "Initial Delay", len);
+	}
+	if (CHECK_FLAG(flags, NEXTHOP_GROUP_RECURSION_REQ)) {
+		if (!first)
+			strlcat(buf, ", ", len);
+		strlcat(buf, "Req Recursion", len);
 	}
 }

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -178,6 +178,10 @@ struct nhg_hash_entry {
  * by the NHG layer, not the EVPN-MH layer.
  */
 #define NEXTHOP_GROUP_STALE_FDB (1 << 11)
+/*
+ * Recursion requested/allowed
+ */
+#define NEXTHOP_GROUP_RECURSION_REQ (1 << 12)
 };
 
 /* Upper 4 bits of the NHG are reserved for indicating the NHG type */
@@ -235,7 +239,7 @@ struct nhg_ctx {
 	afi_t afi;
 
 	/*
-	 * This should only ever be ZEBRA_ROUTE_NHG unless we get a a kernel
+	 * This should only ever be ZEBRA_ROUTE_NHG unless we get a kernel
 	 * created nexthop not made by us.
 	 */
 	int type;
@@ -420,6 +424,9 @@ extern const char *zebra_nhg_afi2str(struct nhg_hash_entry *nhe);
 
 /* Format NHG flags into a comma-separated string for display */
 extern void dump_nhg_flags(uint32_t flags, char *buf, size_t len);
+
+/* Determine nhg address-family, with special rules for singletons */
+afi_t zebra_nhg_get_afi(const struct nexthop_group *nhg, afi_t route_afi);
 
 #ifdef _FRR_ATTRIBUTE_PRINTFRR
 #pragma FRR printfrr_ext "%pNG" (const struct nhg_hash_entry *)

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -355,14 +355,13 @@ zebra_nhg_rib_find_nhe(struct nhg_hash_entry *rt_nhe, afi_t rt_afi);
  */
 
 /*
- * Add NHE. If already exists, Replace.
+ * Add NHE using id and info from 'nhe'. If id already exists, replace. The
+ * caller's data isn't touched - it's just used to locate or create an nhe
+ * internally.
  *
- * Returns allocated NHE on success, otherwise NULL.
+ * Returns > 0 on success, otherwise < 0.
  */
-struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
-					   uint16_t instance, uint32_t session,
-					   struct nexthop_group *nhg,
-					   afi_t afi);
+struct nhg_hash_entry *zebra_nhe_proto_add(struct nhg_hash_entry *nhe);
 
 /*
  * Del NHE.

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2497,12 +2497,8 @@ static void process_subq_nhg(struct listnode *lnode)
 				zsend_nhg_notify(nhe->type, nhe->zapi_instance,
 						 nhe->zapi_session, nhe->id,
 						 ZAPI_NHG_REMOVE_FAIL);
-
 		} else {
-			newnhe = zebra_nhg_proto_add(nhe->id, nhe->type,
-						     nhe->zapi_instance,
-						     nhe->zapi_session,
-						     &nhe->nhg, 0);
+			newnhe = zebra_nhe_proto_add(nhe);
 
 			/* Report error to daemon via ZAPI */
 			if (newnhe == NULL)

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1225,6 +1225,8 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 			json_object_boolean_true_add(json, "keepAround");
 		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_FPM))
 			json_object_boolean_true_add(json, "fpm");
+		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSION_REQ))
+			json_object_boolean_true_add(json, "reqRecurs");
 	} else {
 		/* Text output - use common formatter */
 		char flags_buf[256];


### PR DESCRIPTION
Add initial support for recursive resolution of nexthop-groups:

- add a flags field to the nexthop-group zapi message, and assign a RECURSION flag value
- add a "recursive" config option to the nexthop-group config submode
- use the config and zapi changes in sharpd
- in zebra, add code to iterate over a group's nexthops, use the zebra validity-checking logic, and update as necessary. This is driven by daemon-owned nhgs, allowing the use of recursive nexthops in those nhgs.

I'm making this a draft for now, so we can have some discussion. There are still some gaps - sharpd's groups aren't being uninstalled and deleted properly, for example, so I'd like to clean that up. I'm not sure that all necessary changes to a nexthop are being detected in this path. And I haven't exercised these nexthop-group changes in coordination with routes, so there are some questions and TODOs there also.
