### PR TITLE
tests: add asyncio default config param to quiet warning

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -37,7 +37,7 @@ Installing Topotest Requirements
        tshark \
        valgrind
    python3 -m pip install wheel
-   python3 -m pip install 'pytest>=6.2.4' 'pytest-xdist>=2.3.0'
+   python3 -m pip install 'pytest>=8.3.2' 'pytest-asyncio>=0.24.0' 'pytest-xdist>=3.6.1'
    python3 -m pip install 'scapy>=2.4.5'
    python3 -m pip install xmltodict
    python3 -m pip install git+https://github.com/Exa-Networks/exabgp@0659057837cd6c6351579e9f0fa47e9fb7de7311

--- a/tests/topotests/pytest.ini
+++ b/tests/topotests/pytest.ini
@@ -2,6 +2,7 @@
 [pytest]
 
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = module
 
 # NEEDS_EXABGP_4_2_11_FRR
 


### PR DESCRIPTION
Update the topotest doc to the latest pytest* pkg versions known to work together