### PR TITLE
nhrpd: Added a command "no tunnel protection vici profile PROFILE"

### DIFF
--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -295,10 +295,15 @@ DEFUN(tunnel_protection, tunnel_protection_cmd,
 }
 
 DEFUN(no_tunnel_protection, no_tunnel_protection_cmd,
-	"no tunnel protection",
+	"no tunnel protection [vici profile PROFILE [fallback-profile FALLBACK]]",
 	NO_STR
 	"NHRP/GRE integration\n"
-	"IPsec protection\n")
+	"IPsec protection\n"
+	"VICI (StrongSwan)\n"
+	"IPsec profile\n"
+	"IPsec profile name\n"
+	"Fallback IPsec profile\n"
+	"Fallback IPsec profile name\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 


### PR DESCRIPTION
For compatibility with frr-reload, a command
"no tunnel protection [vici profile PROFILE [fallback-profile FALLBACK]]" was added.
This fix closes https://github.com/FRRouting/frr/issues/16628