### PR TITLE
bgpd: fix as-path exclude modify crash

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2357,7 +2357,7 @@ static void route_aspath_exclude_free(void *rule)
 	if (ase->exclude_aspath_acl) {
 		acl = ase->exclude_aspath_acl;
 		as_list_list_del(&acl->exclude_rule, ase);
-	} else {
+	} else if (ase->exclude_aspath_acl_name) {
 		/* no ref to acl, this aspath exclude is orphan */
 		as_exclude_remove_orphan(ase);
 	}

--- a/tests/topotests/bgp_set_aspath_exclude/test_bgp_set_aspath_exclude.py
+++ b/tests/topotests/bgp_set_aspath_exclude/test_bgp_set_aspath_exclude.py
@@ -128,7 +128,6 @@ def test_bgp_set_aspath_exclude_access_list():
 conf
  bgp as-path access-list FIRST permit ^65 
  route-map r2 permit 6 
-  no set as-path exclude as-path-access-list SECOND
   set as-path exclude as-path-access-list FIRST
     """
     )
@@ -147,7 +146,6 @@ clear bgp *
         """
 conf
  route-map r2 permit 6
-  no set as-path exclude as-path-access-list FIRST
   set as-path exclude as-path-access-list SECOND
     """
     )

--- a/tests/topotests/bgp_set_aspath_exclude/test_bgp_set_aspath_exclude.py
+++ b/tests/topotests/bgp_set_aspath_exclude/test_bgp_set_aspath_exclude.py
@@ -108,7 +108,7 @@ def test_bgp_set_aspath_exclude():
         pytest.skip(tgen.errors)
 
     test_func = functools.partial(bgp_converge, tgen.gears["r1"], expected_1)
-    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
 
     assert result is None, "Failed overriding incoming AS-PATH with route-map"
 
@@ -139,7 +139,7 @@ clear bgp *
     )
 
     test_func = functools.partial(bgp_converge, tgen.gears["r1"], expected_2)
-    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
 
     assert result is None, "Failed change of exclude rule in route map"
     r1.vtysh_cmd(
@@ -152,7 +152,7 @@ conf
 
     # tgen.mininet_cli()
     test_func = functools.partial(bgp_converge, tgen.gears["r1"], expected_1)
-    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
 
     assert result is None, "Failed reverting exclude rule in route map"
 
@@ -180,7 +180,7 @@ clear bgp *
     )
 
     test_func = functools.partial(bgp_converge, tgen.gears["r1"], expected_3)
-    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
 
     assert result is None, "Failed to removing current accesslist"
 
@@ -198,7 +198,7 @@ clear bgp *
     )
 
     test_func = functools.partial(bgp_converge, tgen.gears["r1"], expected_4)
-    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
 
     assert result is None, "Failed to renegotiate with peers 2"
 
@@ -217,7 +217,7 @@ clear bgp *
     )
 
     test_func = functools.partial(bgp_converge, tgen.gears["r1"], expected_3)
-    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
 
     assert result is None, "Failed to renegotiate with peers 2"
 
@@ -236,7 +236,7 @@ clear bgp *
     )
 
     test_func = functools.partial(bgp_converge, tgen.gears["r1"], expected_3)
-    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
 
     assert result is None, "Failed to renegotiate with peers 2"
 

--- a/tests/topotests/bgp_set_aspath_exclude/test_bgp_set_aspath_exclude.py
+++ b/tests/topotests/bgp_set_aspath_exclude/test_bgp_set_aspath_exclude.py
@@ -208,7 +208,26 @@ clear bgp *
         """
 conf
  route-map r2 permit 6
-  no set as-path exclude as-path-access-list SECOND
+  set as-path exclude 65555
+    """
+    )
+
+    r1.vtysh_cmd(
+        """
+clear bgp *
+    """
+    )
+
+    test_func = functools.partial(bgp_converge, tgen.gears["r1"], expected_3)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=0.5)
+
+    assert result is None, "Failed to renegotiate with peers 2"
+
+    r1.vtysh_cmd(
+        """
+conf
+ route-map r2 permit 6
+  set as-path exclude as-path-access-list NON-EXISTING
     """
     )
 


### PR DESCRIPTION
Fix a crash when modifying a route-map with set as-path exclude without as-path-access-list:

> router(config)# route-map routemaptest deny 1
> router(config-route-map)# set as-path exclude 33 34 35
> router(config-route-map)# set as-path exclude as-path-access-list test

> #0  raise (sig=<optimized out>) at ../sysdeps/unix/sysv/linux/raise.c:50
> #1  0x00007fb3959327de in core_handler (signo=11, siginfo=0x7ffd122da530, context=0x7ffd122da400) at lib/sigevent.c:258
> #2  <signal handler called>
> #3  0x000055ab2762a1bd in as_list_list_del (h=0x55ab27897680 <as_exclude_list_orphan>, item=0x55ab28204e20) at ./bgpd/bgp_aspath.h:77
> #4  0x000055ab2762d1a8 in as_exclude_remove_orphan (ase=0x55ab28204e20) at bgpd/bgp_aspath.c:1574
> #5  0x000055ab27550538 in route_aspath_exclude_free (rule=0x55ab28204e20) at bgpd/bgp_routemap.c:2366
> #6  0x00007fb39591f00c in route_map_rule_delete (list=0x55ab28203498, rule=0x55ab28204170) at lib/routemap.c:1357
> #7  0x00007fb39591f87c in route_map_add_set (index=0x55ab28203460, set_name=0x55ab276ad2aa "as-path exclude", set_arg=0x55ab281e4f70 "as-path-access-list test") at lib/routemap.c:1674
> #8  0x00007fb39591d3f3 in generic_set_add (index=0x55ab28203460, command=0x55ab276ad2aa "as-path exclude", arg=0x55ab281e4f70 "as-path-access-list test", errmsg=0x7ffd122db870 "",
>     errmsg_len=8192) at lib/routemap.c:533
> #9  0x000055ab2755e78e in lib_route_map_entry_set_action_rmap_set_action_exclude_as_path_modify (args=0x7ffd122db290) at bgpd/bgp_routemap_nb_config.c:2427
> #10 0x00007fb3958fe417 in nb_callback_modify (context=0x55ab28205aa0, nb_node=0x55ab27cb31e0, event=NB_EV_APPLY, dnode=0x55ab28202690, resource=0x55ab27c32148, errmsg=0x7ffd122db870 "",
>     errmsg_len=8192) at lib/northbound.c:1538
> #11 0x00007fb3958ff0ab in nb_callback_configuration (context=0x55ab28205aa0, event=NB_EV_APPLY, change=0x55ab27c32110, errmsg=0x7ffd122db870 "", errmsg_len=8192) at lib/northbound.c:1888
> #12 0x00007fb3958ff5e4 in nb_transaction_process (event=NB_EV_APPLY, transaction=0x55ab28205aa0, errmsg=0x7ffd122db870 "", errmsg_len=8192) at lib/northbound.c:2016
> #13 0x00007fb3958fddba in nb_candidate_commit_apply (transaction=0x55ab28205aa0, save_transaction=true, transaction_id=0x0, errmsg=0x7ffd122db870 "", errmsg_len=8192)
>     at lib/northbound.c:1356
> #14 0x00007fb3958fdef0 in nb_candidate_commit (context=..., candidate=0x55ab27c2c9a0, save_transaction=true, comment=0x0, transaction_id=0x0, errmsg=0x7ffd122db870 "", errmsg_len=8192)
>     at lib/northbound.c:1389
> #15 0x00007fb3959045ba in nb_cli_classic_commit (vty=0x55ab281f6680) at lib/northbound_cli.c:57
> #16 0x00007fb395904b5a in nb_cli_apply_changes_internal (vty=0x55ab281f6680, xpath_base=0x7ffd122dfd10 "/frr-route-map:lib/route-map[name='routemaptest']/entry[sequence='1']",
>     clear_pending=false) at lib/northbound_cli.c:184
> #17 0x00007fb395904ebf in nb_cli_apply_changes (vty=0x55ab281f6680, xpath_base_fmt=0x0) at lib/northbound_cli.c:240
> --Type <RET> for more, q to quit, c to continue without paging--
> #18 0x000055ab27557d2e in set_aspath_exclude_access_list_magic (self=0x55ab2775c300 <set_aspath_exclude_access_list_cmd>, vty=0x55ab281f6680, argc=5, argv=0x55ab28204c80,
>     as_path_filter_name=0x55ab28202040 "test") at bgpd/bgp_routemap.c:6397
> #19 0x000055ab2754bdea in set_aspath_exclude_access_list (self=0x55ab2775c300 <set_aspath_exclude_access_list_cmd>, vty=0x55ab281f6680, argc=5, argv=0x55ab28204c80)
>     at ./bgpd/bgp_routemap_clippy.c:856
> #20 0x00007fb39589435d in cmd_execute_command_real (vline=0x55ab281e61f0, vty=0x55ab281f6680, cmd=0x0, up_level=0) at lib/command.c:1003
> #21 0x00007fb3958944be in cmd_execute_command (vline=0x55ab281e61f0, vty=0x55ab281f6680, cmd=0x0, vtysh=0) at lib/command.c:1062
> #22 0x00007fb395894a0c in cmd_execute (vty=0x55ab281f6680, cmd=0x55ab28200f20 "set as-path exclude as-path-access-list test", matched=0x0, vtysh=0) at lib/command.c:1228
> #23 0x00007fb39595242c in vty_command (vty=0x55ab281f6680, buf=0x55ab28200f20 "set as-path exclude as-path-access-list test") at lib/vty.c:625
> #24 0x00007fb3959541c5 in vty_execute (vty=0x55ab281f6680) at lib/vty.c:1388
> #25 0x00007fb3959563db in vtysh_read (thread=0x7ffd122e2bb0) at lib/vty.c:2400
> #26 0x00007fb39594b785 in event_call (thread=0x7ffd122e2bb0) at lib/event.c:1996
> #27 0x00007fb3958d1365 in frr_run (master=0x55ab27b56d70) at lib/libfrr.c:1231
> #28 0x000055ab2747f1cc in main (argc=3, argv=0x7ffd122e2e08) at bgpd/bgp_main.c:555

Fixes: 094dcc3cda ("bgpd: fix "bgp as-pah access-list" with "set aspath exclude" set/unset issues")