### PR TITLE
topotests: load configuration from vtysh

### DIFF
--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -37,6 +37,7 @@ import re
 import shlex
 import subprocess
 import sys
+import time
 from collections import OrderedDict
 
 import lib.topolog as topolog
@@ -915,6 +916,16 @@ class TopoRouter(TopoGear):
                 topotest.sysctl_assure(
                     nrouter, "net.mpls.conf.{}.input".format(interface), 1
                 )
+
+        for i in range(10):
+            if self.check_router_running() == "":
+                break
+            time.sleep(1)
+
+        self.cmd("for file in $(ls /etc/frr/*.confall); do echo >> $file; done")
+        # self.cmd("cat /etc/frr/*.confall | vtysh -f /dev/stdin")
+        self.cmd("cat /etc/frr/*.confall | sed 1iXFRR_start_configuration | sed 1iconfigure\ t\ file-lock | sed '$aXFRR_end_configuration' | vtysh")
+        self.cmd("for file in $(ls /etc/frr/*.confall); do mv $file ${file%.confall}.conf; done")
 
         return result
 

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1658,7 +1658,7 @@ class Router(Node):
                 self.daemons[daemon] = 1
             if param is not None:
                 self.daemons_options[daemon] = param
-            conf_file = "/etc/{}/{}.conf".format(self.routertype, daemon)
+            conf_file = "/etc/{}/{}.confall".format(self.routertype, daemon)
             if source and not os.path.exists(source):
                 logger.warning(
                     "missing config '%s' for '%s' creating empty file '%s'",
@@ -1676,7 +1676,7 @@ class Router(Node):
             elif source:
                 # copy zebra.conf to mgmtd folder, which can be used during startup
                 if daemon == "zebra" and not self.unified_config:
-                    conf_file_mgmt = "/etc/{}/{}.conf".format(self.routertype, "mgmtd")
+                    conf_file_mgmt = "/etc/{}/{}.confall".format(self.routertype, "mgmtd")
                     logger.debug(
                         "copying '%s' as '%s' on '%s'",
                         source,


### PR DESCRIPTION
Dirty fix to check that is possible to load configuration from vtysh at startup.

It tests that northbound configuration can be committed together.

An issue with a common commit was reported in https://github.com/FRRouting/frr/pull/16772