### PR TITLE
bgpd: fix 'nexthop_set failed' error message often displayed

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1799,18 +1799,14 @@ bgp_connect_fail(struct peer_connection *connection)
  */
 static void bgp_connect_in_progress_update_connection(struct peer *peer)
 {
-	if (bgp_getsockname(peer) < 0) {
-		if (!peer->su_remote &&
-		    !BGP_CONNECTION_SU_UNSPEC(peer->connection)) {
-			/* if connect initiated, then dest port and dest addresses are well known */
-			peer->su_remote = sockunion_dup(&peer->connection->su);
-			if (sockunion_family(peer->su_remote) == AF_INET)
-				peer->su_remote->sin.sin_port =
-					htons(peer->port);
-			else if (sockunion_family(peer->su_remote) == AF_INET6)
-				peer->su_remote->sin6.sin6_port =
-					htons(peer->port);
-		}
+	bgp_updatesockname(peer);
+	if (!peer->su_remote && !BGP_CONNECTION_SU_UNSPEC(peer->connection)) {
+		/* if connect initiated, then dest port and dest addresses are well known */
+		peer->su_remote = sockunion_dup(&peer->connection->su);
+		if (sockunion_family(peer->su_remote) == AF_INET)
+			peer->su_remote->sin.sin_port = htons(peer->port);
+		else if (sockunion_family(peer->su_remote) == AF_INET6)
+			peer->su_remote->sin6.sin6_port = htons(peer->port);
 	}
 }
 

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -861,8 +861,7 @@ int bgp_connect(struct peer_connection *connection)
 				 htons(peer->port), ifindex);
 }
 
-/* After TCP connection is established.  Get local address and port. */
-int bgp_getsockname(struct peer *peer)
+void bgp_updatesockname(struct peer *peer)
 {
 	if (peer->su_local) {
 		sockunion_free(peer->su_local);
@@ -876,6 +875,12 @@ int bgp_getsockname(struct peer *peer)
 
 	peer->su_local = sockunion_getsockname(peer->connection->fd);
 	peer->su_remote = sockunion_getpeername(peer->connection->fd);
+}
+
+/* After TCP connection is established.  Get local address and port. */
+int bgp_getsockname(struct peer *peer)
+{
+	bgp_updatesockname(peer);
 
 	if (!bgp_zebra_nexthop_set(peer->su_local, peer->su_remote,
 				   &peer->nexthop, peer)) {

--- a/bgpd/bgp_network.h
+++ b/bgpd/bgp_network.h
@@ -23,6 +23,7 @@ extern void bgp_close_vrf_socket(struct bgp *bgp);
 extern void bgp_close(void);
 extern int bgp_connect(struct peer_connection *connection);
 extern int bgp_getsockname(struct peer *peer);
+extern void bgp_updatesockname(struct peer *peer);
 
 extern int bgp_md5_set_prefix(struct bgp *bgp, struct prefix *p,
 			      const char *password);


### PR DESCRIPTION
The below log message is often seen when peering with BGP peers. This message has been displayed by introducing a recent fix that exposes the IP/port information when available.

Fix this by separating the peer->su_[local/remote] contexts used for display, and for handling the peer session operational.

Two new attributes are appended to the peer structure: su_remote_display and su_local_display. Those fields are only used for display the network information (in vty and in snmp).

Fixes: 78ce63952a99 ("bgpd: fix addressing information of non established outgoing sessions")