### PR TITLE
nhrpd: Implement retrying resolution request

### DIFF
--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -15,7 +15,8 @@
 DECLARE_MGROUP(NHRPD);
 
 #define NHRPD_DEFAULT_HOLDTIME	7200
-
+#define NHRPD_DEFAULT_PURGE_TIME 30
+#define NHRPD_PURGE_EXPIRE	 3000
 #define NHRP_DEFAULT_CONFIG	"nhrpd.conf"
 
 extern struct event_loop *master;
@@ -250,10 +251,12 @@ struct nhrp_shortcut {
 	union sockunion addr;
 
 	struct nhrp_reqid reqid;
-	struct event *t_timer;
+	struct event *t_shortcut_purge;
+	struct event *t_retry_resolution;
 
 	enum nhrp_cache_type type;
 	unsigned int holding_time;
+	unsigned int retry_interval;
 	unsigned route_installed : 1;
 	unsigned expiring : 1;
 


### PR DESCRIPTION
In the event that a resolution request is sent and and resolution reply is never received, resolution requests will continue to be sent until either the newly created shortcut has been purged or a resolution reply is finally received.

NHRPD_DEFAULT_PURGE_TIME and NHRPD_PURGE_EXPIRE are values that were previously hardcoded and  moved into macros for the sake of readability.