### PR TITLE
zebra: Remove duplicate host routes for the loopback address

### DIFF
--- a/tests/topotests/ospf_unnumbered_point_to_multipoint/r1/v4_route.json
+++ b/tests/topotests/ospf_unnumbered_point_to_multipoint/r1/v4_route.json
@@ -17,21 +17,6 @@
     {
       "prefix": "10.0.10.1\/32",
       "prefixLen": 32,
-      "protocol": "local",
-      "vrfId": 0,
-      "vrfName": "default",
-      "distance": 0,
-      "metric": 0,
-      "installed": true,
-      "table": 254,
-      "internalStatus": 16,
-      "internalFlags": 0,
-      "internalNextHopNum": 1,
-      "internalNextHopActiveNum": 1
-    },
-    {
-      "prefix": "10.0.10.1\/32",
-      "prefixLen": 32,
       "protocol": "connected",
       "vrfId": 0,
       "vrfName": "default",
@@ -86,21 +71,6 @@
     }
   ],
   "10.1.1.2\/32": [
-    {
-      "prefix": "10.1.1.2\/32",
-      "prefixLen": 32,
-      "protocol": "local",
-      "vrfId": 0,
-      "vrfName": "default",
-      "distance": 0,
-      "metric": 0,
-      "installed": true,
-      "table": 254,
-      "internalStatus": 16,
-      "internalFlags": 0,
-      "internalNextHopNum": 1,
-      "internalNextHopActiveNum": 1
-    },
     {
       "prefix": "10.1.1.2\/32",
       "prefixLen": 32,

--- a/tests/topotests/ospf_unnumbered_point_to_multipoint/r2/v4_route.json
+++ b/tests/topotests/ospf_unnumbered_point_to_multipoint/r2/v4_route.json
@@ -36,21 +36,6 @@
     {
       "prefix": "10.0.20.1\/32",
       "prefixLen": 32,
-      "protocol": "local",
-      "vrfId": 0,
-      "vrfName": "default",
-      "distance": 0,
-      "metric": 0,
-      "installed": true,
-      "table": 254,
-      "internalStatus": 16,
-      "internalFlags": 0,
-      "internalNextHopNum": 1,
-      "internalNextHopActiveNum": 1
-    },
-    {
-      "prefix": "10.0.20.1\/32",
-      "prefixLen": 32,
       "protocol": "connected",
       "vrfId": 0,
       "vrfName": "default",
@@ -86,21 +71,6 @@
     }
   ],
   "10.1.2.2\/32": [
-    {
-      "prefix": "10.1.2.2\/32",
-      "prefixLen": 32,
-      "protocol": "local",
-      "vrfId": 0,
-      "vrfName": "default",
-      "distance": 0,
-      "metric": 0,
-      "installed": true,
-      "table": 254,
-      "internalStatus": 16,
-      "internalFlags": 0,
-      "internalNextHopNum": 1,
-      "internalNextHopActiveNum": 1
-    },
     {
       "prefix": "10.1.2.2\/32",
       "prefixLen": 32,

--- a/tests/topotests/ospf_unnumbered_point_to_multipoint/r3/v4_route.json
+++ b/tests/topotests/ospf_unnumbered_point_to_multipoint/r3/v4_route.json
@@ -93,21 +93,6 @@
     {
       "prefix": "10.1.3.2\/32",
       "prefixLen": 32,
-      "protocol": "local",
-      "vrfId": 0,
-      "vrfName": "default",
-      "distance": 0,
-      "metric": 0,
-      "installed": true,
-      "table": 254,
-      "internalStatus": 16,
-      "internalFlags": 0,
-      "internalNextHopNum": 1,
-      "internalNextHopActiveNum": 1
-    },
-    {
-      "prefix": "10.1.3.2\/32",
-      "prefixLen": 32,
       "protocol": "connected",
       "vrfId": 0,
       "vrfName": "default",

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -338,7 +338,11 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 			NULL, &nh, 0, zvrf->table_id, metric, 0, 0, 0, false, true);
 	}
 
-	if (install_local) {
+	/*
+	 * Skip local route if it would be identical to the connected route
+	 * (e.g., /32 or /128 addresses).
+	 */
+	if (install_local && !prefix_same(&p, &plocal)) {
 		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, flags, &plocal,
 			NULL, &nh, 0, zvrf->table_id, 0, 0, 0, 0, false, true);
 		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, flags,
@@ -539,7 +543,11 @@ void connected_down(struct interface *ifp, struct connected *ifc)
 			   zvrf->table_id, 0, 0, false);
 	}
 
-	if (remove_local) {
+	/*
+	 * Skip local route removal if it would be identical to the connected
+	 * route (e.g., /32 or /128 addresses).
+	 */
+	if (remove_local && !prefix_same(&p, &plocal)) {
 		rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id,
 			   ZEBRA_ROUTE_LOCAL, 0, 0, &plocal, NULL, &nh, 0,
 			   zvrf->table_id, 0, 0, false);


### PR DESCRIPTION
Currently two host routes are created for a loopback address on /32 subnet. The fix is to remove the one marked "local".

interface lo
 ip address 10.0.0.1/32
exit
!
enke-vm1# show ip route 10.0.0.1/32
Routing entry for 10.0.0.1/32
  Known via "local", distance 0, metric 0
  Last update 00:03:38 ago
  * directly connected, lo, weight 1

Routing entry for 10.0.0.1/32
  Known via "connected", distance 0, metric 0, best
  Last update 00:03:38 ago
  * directly connected, lo, weight 1