### PR TITLE
zebra: Add more vrf name to debugs

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -290,6 +290,7 @@ void redistribute_delete(const struct route_node *rn,
 	if (IS_ZEBRA_DEBUG_RIB) {
 		uint8_t old_inst, new_inst;
 		uint32_t table = 0;
+		struct vrf *vrf = vrf_lookup_by_id(vrfid);
 
 		old_inst = new_inst = 0;
 
@@ -302,8 +303,8 @@ void redistribute_delete(const struct route_node *rn,
 			table = new_re->table;
 		}
 
-		zlog_debug("(%u:%u):%pRN: Redist del: re %p (%u:%s), new re %p (%u:%s)",
-			   vrfid, table, rn, old_re, old_inst,
+		zlog_debug("(%s:%u):%pRN: Redist del: re %p (%u:%s), new re %p (%u:%s)",
+			   VRF_LOGNAME(vrf), table, rn, old_re, old_inst,
 			   old_re ? zebra_route_string(old_re->type) : "None",
 			   new_re, new_inst,
 			   new_re ? zebra_route_string(new_re->type) : "None");

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -735,11 +735,13 @@ static int route_notify_internal(const struct route_node *rn, int type,
 
 	client = zserv_find_client(type, instance);
 	if (!client || !client->notify_owner) {
-		if (IS_ZEBRA_DEBUG_PACKET)
-			zlog_debug(
-				"Not Notifying Owner: %s about prefix %pRN(%u) %d vrf: %u",
-				zebra_route_string(type), rn, table_id, note,
-				vrf_id);
+		if (IS_ZEBRA_DEBUG_PACKET) {
+			struct vrf *vrf = vrf_lookup_by_id(vrf_id);
+
+			zlog_debug("Not Notifying Owner: %s about prefix %pRN(%u) %d vrf: %s",
+				   zebra_route_string(type), rn, table_id, note,
+				   VRF_LOGNAME(vrf));
+		}
 		return 0;
 	}
 
@@ -2129,8 +2131,8 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 	vrf_id = zvrf_id(zvrf);
 
 	if (IS_ZEBRA_DEBUG_RECV)
-		zlog_debug("%s: p=(%u:%u)%pFX, msg flags=0x%x, flags=0x%x",
-			   __func__, vrf_id, api.tableid, &api.prefix,
+		zlog_debug("%s: p=(%s:%u)%pFX, msg flags=0x%x, flags=0x%x",
+			   __func__, zvrf_name(zvrf), api.tableid, &api.prefix,
 			   (int)api.message, api.flags);
 
 	/* Allocate new route. */


### PR DESCRIPTION
Trying to debug some cross vrf stuff in zebra and frankly it's hard to grep the file for the routes you are interested in.  Let's clean this up some and get a bit better information for us developers