### PR TITLE
nhrpd: fixes duplicate auth extension

### DIFF
--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -597,6 +597,12 @@ static void nhrp_handle_resolution_req(struct nhrp_packet_parser *pp)
 				nhrp_ext_complete(zb, ext);
 			}
 			break;
+		case NHRP_EXTENSION_AUTHENTICATION:
+			/* Extensions can be copied from original packet except
+			 * authentication extension which must be regenerated
+			 * hop by hop.
+			 */
+			break;
 		default:
 			if (nhrp_ext_reply(zb, hdr, ifp, ext, &payload) < 0)
 				goto err;


### PR DESCRIPTION
When an NHRP peer was forwarding a message, it was copying all extensions from the originally received packet. The authentication extension must be regenerated hop by hop per RFC2332. This fix checks for the auth extension when copying extensions and omits the original packet auth and instead regenerates a new auth extension.

Fixes #16507