### PR TITLE
pimd: fix crash for two commands

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2058,6 +2058,10 @@ int lib_interface_pim_address_family_bsm_modify(struct nb_cb_modify_args *args)
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
+		if (!pim_ifp) {
+			pim_ifp = pim_if_new(ifp, false, true, false, false);
+			ifp->info = pim_ifp;
+		}
 		pim_ifp->bsm_enable = yang_dnode_get_bool(args->dnode, NULL);
 
 		break;
@@ -2083,6 +2087,10 @@ int lib_interface_pim_address_family_unicast_bsm_modify(
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
+		if (!pim_ifp) {
+			pim_ifp = pim_if_new(ifp, false, true, false, false);
+			ifp->info = pim_ifp;
+		}
 		pim_ifp->ucast_bsm_accept =
 			yang_dnode_get_bool(args->dnode, NULL);
 


### PR DESCRIPTION
Need "pim-enable" the interface for the two commands, otherwise it will crash.

```
PIM: lib_interface_pim_address_family_bsm_modify+0x68     561aa37a406c     7ffcc7b4cbd0 /usr/lib/frr/pimd (mapped at 0x561aa3726000)
PIM: nb_callback_modify+0xdc            7f6200961aac     7ffcc7b4cc00 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: nb_callback_configuration+0x14e     7f6200962740     7ffcc7b4cc90 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: nb_transaction_process+0x68        7f6200962c79     7ffcc7b4d120 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: nb_candidate_commit_apply+0x36     7f620096144f     7ffcc7b4d170 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: nb_candidate_commit+0x96           7f6200961585     7ffcc7b4d1b0 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: nb_cli_classic_commit+0x9e         7f6200967c4f     7ffcc7b4d200 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: nb_cli_apply_changes_internal+0x1fd     7f62009681ef     7ffcc7b4f250 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: nb_cli_apply_changes+0x2a9         7f6200968554     7ffcc7b51290 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: pim_process_no_bsm_cmd+0x4a        561aa378b7b6     7ffcc7b51b90 /usr/lib/frr/pimd (mapped at 0x561aa3726000)
PIM: no_ip_pim_bsm+0x23                 561aa37d8487     7ffcc7b51bb0 /usr/lib/frr/pimd (mapped at 0x561aa3726000)
PIM: cmd_execute_command_real+0x35a     7f62008f83c6     7ffcc7b51be0 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: cmd_execute_command+0x12f          7f62008f8527     7ffcc7b51c70 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: cmd_execute+0x95                   7f62008f8a75     7ffcc7b51cd0 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: vty_command+0x1b8                  7f62009b621a     7ffcc7b51d20 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: vty_execute+0x59                   7f62009b7fb3     7ffcc7b53db0 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: vtysh_read+0x1f6                   7f62009ba136     7ffcc7b53de0 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: event_call+0xd6                    7f62009af5df     7ffcc7b54040 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: frr_run+0x240                      7f6200935177     7ffcc7b54100 /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0 (mapped at 0x7f6200864000)
PIM: main+0x12e                         561aa37e7950     7ffcc7b54210 /usr/lib/frr/pimd (mapped at 0x561aa3726000)
PIM: __libc_start_main+0xea             7f6200681d0a     7ffcc7b54250 /lib/x86_64-linux-gnu/libc.so.6 (mapped at 0x7f620065b000)
PIM: _start+0x2a                        561aa377c42a     7ffcc7b54320 /usr/lib/frr/pimd (mapped at 0x561aa3726000)
```