### PR TITLE
zebra: Add CLI to display SRv6 SIDs allocated

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -910,6 +910,10 @@ and this section also helps that case.
    Chunks:
    - prefix: 2001:db8:2:2::/64, owner: sharp
 
+.. clicmd:: show segment-routing srv6 [locator NAME] sid [X:X::X:X] [json]
+
+   Displays the information regarding SRv6 local SID(s) allocated from a given locator.
+
 .. clicmd:: segment-routing
 
    Move from configure mode to segment-routing node.

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -914,6 +914,17 @@ and this section also helps that case.
 
    Displays the information regarding SRv6 local SID(s) allocated from a given locator.
 
+::
+
+   router# show segment-routing srv6 sid
+    SID                   Behavior    Context                Daemon/Instance    Locator    Allocation Type
+    --------------------  ----------  ---------------------  -----------------  ---------  -----------------
+    fcbb:bbbb:1::         uN          -                      isis(0)            MAIN       dynamic
+    fcbb:bbbb:1:fe00::    uDT6        VRF 'vrf10'            bgp(0)             MAIN       dynamic
+    fcbb:bbbb:1:fe01::    uDT6        VRF 'vrf20'            bgp(0)             MAIN       dynamic
+    fcbb:bbbb:1:e000::    uA          Interface 'eth-sw1'    isis(0)            MAIN       dynamic
+    fcbb:bbbb:1:e001::    uA          Interface 'eth-sw1'    isis(0)            MAIN       dynamic
+
 .. clicmd:: segment-routing
 
    Move from configure mode to segment-routing node.

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -925,6 +925,63 @@ and this section also helps that case.
     fcbb:bbbb:1:e000::    uA          Interface 'eth-sw1'    isis(0)            MAIN       dynamic
     fcbb:bbbb:1:e001::    uA          Interface 'eth-sw1'    isis(0)            MAIN       dynamic
 
+   router# show segment-routing srv6 sid fc00:0:1:e000:: detail
+    SID                   Behavior    Context                Daemon/Instance    Locator    Allocation Type
+    --------------------  ----------  ---------------------  -----------------  ---------  -----------------
+    fcbb:bbbb:1::         uN          -                      isis(0)            MAIN       dynamic
+    fcbb:bbbb:1:e000::    uA          Interface 'eth-sw1'    isis(0)            MAIN       dynamic
+
+   router# show segment-routing srv6 sid json
+   {
+      "fc00:0:1::":{
+         "sid":"fc00:0:1::",
+         "behavior":"uN",
+         "context":{},
+         "locator":"loc1",
+         "allocationMode":"dynamic",
+         "clients":[
+            {
+            "proto":"isis",
+            "instance":0
+            }
+         ]
+      },
+      "fc00:0:1:1::":{
+         "sid":"fc00:0:1:1::",
+         "behavior":"uA",
+         "context":{
+            "interfaceIndex":2,
+            "interfaceName":"eth-sw1",
+            "nexthopIpv6Address":"fe80::4423:f3ff:fe8b:fed"
+         },
+         "locator":"loc1",
+         "allocationMode":"dynamic",
+         "clients":[
+            {
+            "proto":"isis",
+            "instance":0
+            }
+         ]
+      },
+      "fc00:0:1:2::":{
+         "sid":"fc00:0:1:2::",
+         "behavior":"uA",
+         "context":{
+            "interfaceIndex":2,
+            "interfaceName":"eth-sw1",
+            "nexthopIpv6Address":"fe80::9005:fdff:fe18:1237"
+         },
+         "locator":"loc1",
+         "allocationMode":"dynamic",
+         "clients":[
+            {
+            "proto":"isis",
+            "instance":0
+            }
+         ]
+      }
+   }
+
 .. clicmd:: segment-routing
 
    Move from configure mode to segment-routing node.

--- a/isisd/isis_srv6.c
+++ b/isisd/isis_srv6.c
@@ -142,6 +142,7 @@ bool isis_srv6_locator_unset(struct isis_area *area)
 		 */
 		ctx.behavior = ZEBRA_SEG6_LOCAL_ACTION_END_X;
 		ctx.nh6 = sra->nexthop;
+		ctx.ifindex = sra->adj->circuit->interface->ifindex;
 		isis_zebra_release_srv6_sid(&ctx);
 
 		srv6_endx_sid_del(sra);

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -669,6 +669,7 @@ void isis_zebra_request_srv6_sid_endx(struct isis_adjacency *adj)
 
 	ctx.behavior = ZEBRA_SEG6_LOCAL_ACTION_END_X;
 	ctx.nh6 = nexthop;
+	ctx.ifindex = circuit->interface->ifindex;
 	ret = isis_zebra_request_srv6_sid(&ctx, &sid_value,
 					  area->srv6db.config.srv6_locator_name);
 	if (!ret) {

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -752,6 +752,7 @@ DEFUN (no_srv6_locator,
 	struct listnode *node, *nnode;
 	struct zebra_srv6_sid_ctx *ctx;
 	struct srv6_locator *locator = zebra_srv6_locator_lookup(argv[2]->arg);
+
 	if (!locator) {
 		vty_out(vty, "%% Can't find SRv6 locator\n");
 		return CMD_WARNING_CONFIG_FAILED;


### PR DESCRIPTION
Add a CLI to display the information regarding SRv6 local SID(s) allocated from a given locator.

Usage examples:

```
router# show segment-routing srv6 sid

 SID                Behavior    Context                Daemon/Instance
 -----------------  ----------  ---------------------  -----------------
 fc00:0:1::         uN          -                      isis(0)
 fc00:0:1:fe00::    uDT6        VRF 'vrf10'            bgp(0)
 fc00:0:1:fe01::    uDT6        VRF 'vrf20'            bgp(0)
 fc00:0:1:e000::    uA          Interface 'eth-sw1'    isis(0)
 fc00:0:1:e001::    uA          Interface 'eth-sw1'    isis(0)
```
