### PR TITLE
bgpd: remove bgpd.h from bgp script header

### DIFF
--- a/bgpd/bgp_script.h
+++ b/bgpd/bgp_script.h
@@ -7,7 +7,6 @@
 #define __BGP_SCRIPT__
 
 #include <zebra.h>
-#include "bgpd.h"
 
 #ifdef HAVE_SCRIPTING
 
@@ -17,6 +16,10 @@
  * Initialize scripting stuff.
  */
 void bgp_script_init(void);
+
+/* Forward references */
+struct peer;
+struct attr;
 
 void lua_pushpeer(lua_State *L, const struct peer *peer);
 


### PR DESCRIPTION
Use forward references instead of including the main bgpd.h header in the bgp scripting header: because of the way the lua scripting infra builds, changes to bgpd.h were affecting other modules.