### PR TITLE
ospfd: reset spf_hold_multiplier when current SPF delay state is changed

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2291,6 +2291,10 @@ static int ospf_timers_spf_set(struct vty *vty, unsigned int delay,
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 
+	if (ospf->spf_delay != delay || ospf->spf_holdtime != hold ||
+	    ospf->spf_max_holdtime != max)
+		ospf->spf_hold_multiplier = 1;
+
 	ospf->spf_delay = delay;
 	ospf->spf_holdtime = hold;
 	ospf->spf_max_holdtime = max;


### PR DESCRIPTION
OSPFD The issue occurs when the new value set using the timers throttle spf command is larger than the previous one. In this case, the holdTimeMultiplier does not reset to 1 and remains greater than 1, leading to an incorrect min_holdtime. 