### PR TITLE
zebra: Don't bind netns ID netlink socket to mcast groups

### DIFF
--- a/zebra/zebra_netns_id.c
+++ b/zebra/zebra_netns_id.c
@@ -180,7 +180,6 @@ ns_id_t zebra_ns_id_get(const char *netnspath, int fd_param)
 	}
 	memset(&snl, 0, sizeof(snl));
 	snl.nl_family = AF_NETLINK;
-	snl.nl_groups = RTNLGRP_NSID;
 	snl.nl_pid = 0; /* AUTO PID */
 	ret = bind(sock, (struct sockaddr *)&snl, sizeof(snl));
 	if (ret < 0) {


### PR DESCRIPTION
The netlink socket in `zebra_ns_id_get()` is only used to get netns id. There's no need to subscribe to multicast groups. In some heavy-loaded cases, unexpected notification races with normal reply message and causes failure:

    zebra[110338]: [NMNEE-JJKPF][EC 4043309094] netlink recvmsg: bad sequence number 505ac8 (expected 66ea845f)

BTW, to subscribe to RTNLGRP_NSID, `nl_groups` should be `1 << (RTNLGRP_NSID - 1)`. This code has never worked as expected.