### PR TITLE
isisd: Fix NHLFE entry memory leaks

### DIFF
--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -627,6 +627,50 @@ static int sr_local_block_release_label(struct sr_local_block *srlb,
 	return 0;
 }
 
+static bool sr_adj_same_subnet_ipv4(struct in_addr ipv4,
+				    struct isis_circuit *circuit)
+{
+	struct listnode *node;
+	struct prefix ipv4_adj;
+	struct prefix_ipv4 *ipv4_circuit;
+
+	ipv4_adj.family = AF_INET;
+	ipv4_adj.u.prefix4 = ipv4;
+
+	for (ALL_LIST_ELEMENTS_RO(circuit->ip_addrs, node, ipv4_circuit)) {
+		ipv4_adj.prefixlen = ipv4_circuit->prefixlen;
+		if (!prefix_cmp(&ipv4_adj, (struct prefix *)ipv4_circuit))
+			return true;
+	}
+
+	return false;
+}
+
+static bool sr_adj_same_subnet_ipv6(struct in6_addr *ipv6,
+				    struct isis_circuit *circuit)
+{
+	struct listnode *node;
+	struct prefix ipv6_adj;
+	struct prefix_ipv6 *ipv6_circuit;
+
+	ipv6_adj.family = AF_INET6;
+	IPV6_ADDR_COPY(&ipv6_adj.u.prefix6, ipv6);
+
+	for (ALL_LIST_ELEMENTS_RO(circuit->ipv6_link, node, ipv6_circuit)) {
+		ipv6_adj.prefixlen = ipv6_circuit->prefixlen;
+		if (!prefix_cmp(&ipv6_adj, (struct prefix *)ipv6_circuit))
+			return true;
+	}
+
+	for (ALL_LIST_ELEMENTS_RO(circuit->ipv6_non_link, node, ipv6_circuit)) {
+		ipv6_adj.prefixlen = ipv6_circuit->prefixlen;
+		if (!prefix_cmp(&ipv6_adj, (struct prefix *)ipv6_circuit))
+			return true;
+	}
+
+	return false;
+}
+
 /* --- Segment Routing Adjacency-SID management functions ------------------- */
 
 /**
@@ -658,10 +702,16 @@ void sr_adj_sid_add_single(struct isis_adjacency *adj, int family, bool backup,
 		if (!circuit->ip_router || !adj->ipv4_address_count)
 			return;
 
+		if (!sr_adj_same_subnet_ipv4(adj->ipv4_addresses[0], circuit))
+			return;
+
 		nexthop.ipv4 = adj->ipv4_addresses[0];
 		break;
 	case AF_INET6:
 		if (!circuit->ipv6_router || !adj->ll_ipv6_count)
+			return;
+
+		if (!sr_adj_same_subnet_ipv6(&adj->ll_ipv6_addrs[0], circuit))
 			return;
 
 		nexthop.ipv6 = adj->ll_ipv6_addrs[0];


### PR DESCRIPTION
Before adding an NHLFE entry, zebra calls `nhlfe_nexthop_active_ipv4()/nhlfe_nexthop_active_ipv6()` to check if there is a corresponding directly connected route for the next hop prefix of the NHLFE. If such a route exists, it directly overwrites the output interface of the NHLFE's next hop with the output interface of the directly connected route. If the output interface of the directly connected route is different from the output interface of the NHLFE's next hop, deleting the NHLFE entry later will fail because `nhlfe_nhop_match()` cannot find the same next hop address and output interface, leading to an NHLFE entry leak.

Of course, the above situation generally does not occur, but ISIS adjacency labels can cause issues.
Establishing neighbors in ISIS only requires the existence of the neighbor's IP address and does not need the neighbor's IP address to be in the same subnet as the local IP address. When zebra creates an adjacency label entry, it uses the neighbor's IP address as the next hop. If the neighbor's IP address is not in the same subnet as the local IP address and there is a local directly connected route with the neighbor's IP address prefix, it will result in an issue where the corresponding adjacency label entry in zebra cannot be deleted.

We cannot enforce that ISIS must establish neighbors using IPv4 and IPv6 addresses in the same subnet, but we can ensure that IPv4 or IPv6 addresses in different subnets do not create adjacency labels.