### PR TITLE
tests: use logger.warning not logger.warn

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -936,7 +936,7 @@ def generate_support_bundle():
 
     tgen = get_topogen()
     if tgen is None:
-        logger.warn(
+        logger.warning(
             "Support bundle attempted to be generated, but topogen is not being used"
         )
         return True

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -424,7 +424,7 @@ def run_and_expect(func, what, count=20, wait=3):
     minimum_wait_time = 15  # The overall minimum seconds for the test to wait
     wait_time = wait * count
     if wait_time < minimum_wait_time:
-        logger.warn(
+        logger.warning(
             f"Waiting time is too small (count={count}, wait={wait}), using default values (count={minimum_count}, wait={minimum_wait})"
         )
         count = minimum_count


### PR DESCRIPTION
Apparently logger.warn is being deprecated.  So let's switch over to logger.warning.  Clearly it's better