### PR TITLE
ospfd: Fix heap corruption vulnerability when parsing SR-Algorithm TLV

### DIFF
--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -1459,7 +1459,8 @@ void ospf_sr_ri_lsa_update(struct ospf_lsa *lsa)
 	/* Update Algorithm, SRLB and MSD if present */
 	if (algo != NULL) {
 		int i;
-		for (i = 0; i < ntohs(algo->header.length); i++)
+		for (i = 0;
+		     i < ntohs(algo->header.length) && i < ALGORITHM_COUNT; i++)
 			srn->algo[i] = algo->value[0];
 		for (; i < ALGORITHM_COUNT; i++)
 			srn->algo[i] = SR_ALGORITHM_UNSET;


### PR DESCRIPTION
When parsing the SR-Algorithm TLV in the OSPF Router Information Opaque LSA, assure that not more than the maximum number of supported algorithms are copied from the TLV.