### PR TITLE
zebra: Remove nl_addraw_l

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -672,21 +672,6 @@ void netlink_parse_rtattr_nested(struct rtattr **tb, int max,
 	netlink_parse_rtattr(tb, max, RTA_DATA(rta), RTA_PAYLOAD(rta));
 }
 
-bool nl_addraw_l(struct nlmsghdr *n, unsigned int maxlen, const void *data,
-		 unsigned int len)
-{
-	if (NLMSG_ALIGN(n->nlmsg_len) + NLMSG_ALIGN(len) > maxlen) {
-		zlog_err("ERROR message exceeded bound of %d", maxlen);
-		return false;
-	}
-
-	memcpy(NLMSG_TAIL(n), data, len);
-	memset((uint8_t *)NLMSG_TAIL(n) + len, 0, NLMSG_ALIGN(len) - len);
-	n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + NLMSG_ALIGN(len);
-
-	return true;
-}
-
 bool nl_attr_put(struct nlmsghdr *n, unsigned int maxlen, int type,
 		 const void *data, unsigned int alen)
 {

--- a/zebra/kernel_netlink.h
+++ b/zebra/kernel_netlink.h
@@ -77,14 +77,6 @@ extern void netlink_parse_rtattr_flags(struct rtattr **tb, int max,
 				 unsigned short flags);
 extern void netlink_parse_rtattr_nested(struct rtattr **tb, int max,
 					struct rtattr *rta);
-/*
- * nl_addraw_l copies raw form the netlink message buffer into netlink
- * message header pointer. It ensures the aligned data buffer does not
- * override past max length.
- * return value is 0 if its successful
- */
-extern bool nl_addraw_l(struct nlmsghdr *n, unsigned int maxlen,
-			const void *data, unsigned int len);
 extern const char *nl_msg_type_to_str(uint16_t msg_type);
 extern const char *nl_rtproto_to_str(uint8_t rtproto);
 extern const char *nl_family_to_str(uint8_t family);


### PR DESCRIPTION
This function is never used.  So let's remove it.