### PR TITLE
bgpd: fix misplaced arguments in bgp_redistribute_add()

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -542,7 +542,7 @@ static int zebra_read_route(ZAPI_CALLBACK_ARGS)
 
 		/* Now perform the add/update. */
 		bgp_redistribute_add(bgp, &api.prefix, &nexthop, ifindex,
-				     nhtype, bhtype, api.distance, api.metric,
+				     nhtype, api.distance, bhtype, api.metric,
 				     api.type, api.instance, api.tag);
 	} else {
 		bgp_redistribute_delete(bgp, &api.prefix, api.type,

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/zebra-vrf-default.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/zebra-vrf-default.txt
@@ -2,7 +2,7 @@ O   10.0.1.0/24 [110/10] is directly connected, r1-eth0, weight 1, XX:XX:XX
 C>* 10.0.1.0/24 is directly connected, r1-eth0, weight 1, XX:XX:XX
 L>* 10.0.1.1/32 is directly connected, r1-eth0, weight 1, XX:XX:XX
 O>* 10.0.2.0/24 [110/20] via 10.0.20.2, r1-eth1, weight 1, XX:XX:XX
-B>* 10.0.3.0/24 [20/20] via 10.0.30.3, r1-eth2 (vrf neno), weight 1, XX:XX:XX
+B>* 10.0.3.0/24 [110/20] via 10.0.30.3, r1-eth2 (vrf neno), weight 1, XX:XX:XX
 O>* 10.0.4.0/24 [110/20] via 10.0.20.2, r1-eth1, weight 1, XX:XX:XX
 O   10.0.20.0/24 [110/10] is directly connected, r1-eth1, weight 1, XX:XX:XX
 C>* 10.0.20.0/24 is directly connected, r1-eth1, weight 1, XX:XX:XX

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/zebra-vrf-neno.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r1/zebra-vrf-neno.txt
@@ -1,7 +1,7 @@
 VRF neno:
 O>* 10.0.3.0/24 [110/20] via 10.0.30.3, r1-eth2, weight 1, XX:XX:XX
-B>* 10.0.4.0/24 [20/20] via 10.0.20.2, r1-eth1 (vrf default), weight 1, XX:XX:XX
+B>* 10.0.4.0/24 [110/20] via 10.0.20.2, r1-eth1 (vrf default), weight 1, XX:XX:XX
 O   10.0.30.0/24 [110/10] is directly connected, r1-eth2, weight 1, XX:XX:XX
 C>* 10.0.30.0/24 is directly connected, r1-eth2, weight 1, XX:XX:XX
 L>* 10.0.30.1/32 is directly connected, r1-eth2, weight 1, XX:XX:XX
-B>* 10.0.40.0/24 [20/20] via 10.0.20.2, r1-eth1 (vrf default), weight 1, XX:XX:XX
+B>* 10.0.40.0/24 [110/20] via 10.0.20.2, r1-eth1 (vrf default), weight 1, XX:XX:XX

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/zebra-vrf-default.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/zebra-vrf-default.txt
@@ -4,7 +4,7 @@ O   10.0.2.0/24 [110/10] is directly connected, r2-eth0, weight 1, XX:XX:XX
 C>* 10.0.2.0/24 is directly connected, r2-eth0, weight 1, XX:XX:XX
 L>* 10.0.2.2/32 is directly connected, r2-eth0, weight 1, XX:XX:XX
 O>* 10.0.3.0/24 [110/20] via 10.0.20.1, r2-eth1, weight 1, XX:XX:XX
-B>* 10.0.4.0/24 [20/20] via 10.0.40.4, r2-eth2 (vrf ray), weight 1, XX:XX:XX
+B>* 10.0.4.0/24 [110/20] via 10.0.40.4, r2-eth2 (vrf ray), weight 1, XX:XX:XX
 O   10.0.20.0/24 [110/10] is directly connected, r2-eth1, weight 1, XX:XX:XX
 C>* 10.0.20.0/24 is directly connected, r2-eth1, weight 1, XX:XX:XX
 L>* 10.0.20.2/32 is directly connected, r2-eth1, weight 1, XX:XX:XX

--- a/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/zebra-vrf-ray.txt
+++ b/tests/topotests/ospf_multi_vrf_bgp_route_leak/r2/zebra-vrf-ray.txt
@@ -1,10 +1,10 @@
 VRF ray:
-B   10.0.1.0/24 [20/20] via 10.0.20.1, r2-eth1 (vrf default) inactive, weight 1, XX:XX:XX
+B   10.0.1.0/24 [110/20] via 10.0.20.1, r2-eth1 (vrf default) inactive, weight 1, XX:XX:XX
 B   10.0.2.0/24 [20/0] is directly connected, r2-eth0 (vrf default) inactive, weight 1, XX:XX:XX
-B>* 10.0.3.0/24 [20/20] via 10.0.20.1, r2-eth1 (vrf default), weight 1, XX:XX:XX
+B>* 10.0.3.0/24 [110/20] via 10.0.20.1, r2-eth1 (vrf default), weight 1, XX:XX:XX
 O>* 10.0.4.0/24 [110/20] via 10.0.40.4, r2-eth2, weight 1, XX:XX:XX
 B   10.0.20.0/24 [20/0] is directly connected, r2-eth1 (vrf default) inactive, weight 1, XX:XX:XX
-B>* 10.0.30.0/24 [20/20] via 10.0.20.1, r2-eth1 (vrf default), weight 1, XX:XX:XX
+B>* 10.0.30.0/24 [110/20] via 10.0.20.1, r2-eth1 (vrf default), weight 1, XX:XX:XX
 O   10.0.40.0/24 [110/10] is directly connected, r2-eth2, weight 1, XX:XX:XX
 C>* 10.0.40.0/24 is directly connected, r2-eth2, weight 1, XX:XX:XX
 L>* 10.0.40.2/32 is directly connected, r2-eth2, weight 1, XX:XX:XX


### PR DESCRIPTION
Fix the misplaced arguments "bhtype" and "api.distance" in bgp_redistribute_add().