### PR TITLE
zebra: Pass in ZEBRA_ROUTE_MAX instead of true

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1167,7 +1167,8 @@ static void zebra_nhg_handle_install(struct nhg_hash_entry *nhe, bool install)
 					"%s nh id %u (flags 0x%x) associated dependent NHG %pNG install",
 					__func__, nhe->id, nhe->flags,
 					rb_node_dep->nhe);
-			zebra_nhg_install_kernel(rb_node_dep->nhe, true);
+			zebra_nhg_install_kernel(rb_node_dep->nhe,
+						 ZEBRA_ROUTE_MAX);
 		}
 	}
 }


### PR DESCRIPTION
zebra_nhg_install_kernel takes a route type.  We don't know it at that particular spot but we should not be passing in `true`.  Let's use ZEBRA_ROUTE_MAX to indicate we do not know, so that the correct thing is done.