### PR TITLE
zebra: unlock if_table route_nodes

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1799,14 +1799,18 @@ int netlink_tunneldump_read(struct zebra_ns *zns)
 
 		ret = netlink_request_tunneldump(zns, PF_BRIDGE,
 						 tmp_if->ifindex);
-		if (ret < 0)
+		if (ret < 0) {
+			route_unlock_node(rn);
 			return ret;
+		}
 
 		ret = netlink_parse_info(netlink_link_change, netlink_cmd,
 					 &dp_info, 0, true);
 
-		if (ret < 0)
+		if (ret < 0) {
+			route_unlock_node(rn);
 			return ret;
+		}
 	}
 
 	return 0;

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -663,6 +663,7 @@ static int zebra_evpn_map_vlan_ns(struct ns *ns,
 			vni_id = zebra_vxlan_if_access_vlan_vni_find(zif, br_if);
 			if (vni_id) {
 				found = 1;
+				route_unlock_node(rn);
 				break;
 			}
 		}
@@ -757,6 +758,7 @@ static int zebra_evpn_from_svi_ns(struct ns *ns,
 				zebra_vxlan_if_access_vlan_vni_find(zif, br_if);
 			if (vni_id) {
 				found = 1;
+				route_unlock_node(rn);
 				break;
 			}
 		}
@@ -842,6 +844,7 @@ static int zvni_map_to_macvlan_ns(struct ns *ns, void *_in_param, void **_p_ifp)
 
 		if (zif->link == in_param->svi_if) {
 			*p_ifp = tmp_if;
+			route_unlock_node(rn);
 			return NS_WALK_STOP;
 		}
 	}


### PR DESCRIPTION
Must unlock if we break during iteration over any lib/table tree; the per-ns if_table tree needs some cleanup.
