### PR TITLE
isisd: Fix infinity flag not being set successfully

### DIFF
--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1469,13 +1469,12 @@ static void spf_adj_list_parse_tlv(struct isis_spftree *spftree,
 		sadj->metric = metric;
 	if (oldmetric)
 		SET_FLAG(flags, F_ISIS_SPF_ADJ_OLDMETRIC);
+	if ((oldmetric && sadj->metric == ISIS_NARROW_METRIC_INFINITY) ||
+	    (!oldmetric && sadj->metric == ISIS_WIDE_METRIC_INFINITY))
+		SET_FLAG(flags, F_ISIS_SPF_ADJ_METRIC_INFINITY);
 	sadj->lsp = lsp;
 	sadj->subtlvs = subtlvs;
 	sadj->flags = flags;
-
-	if ((oldmetric && metric == ISIS_NARROW_METRIC_INFINITY)
-	    || (!oldmetric && metric == ISIS_WIDE_METRIC_INFINITY))
-		SET_FLAG(flags, F_ISIS_SPF_ADJ_METRIC_INFINITY);
 
 	/* Set real adjacency. */
 	if (!CHECK_FLAG(spftree->flags, F_SPFTREE_NO_ADJACENCIES)


### PR DESCRIPTION
When creating SPF neighbors and calling spf_adj_list_parse_tlv(), the F_ISIS_SPF_ADJ_METRIC_INFINITY flag is only set to a local variable flags and not set to the SPF neighbor sadj->flags. Additionally, the pseudo node metric pseudo_metric is also not reflected in the F_ISIS_SPF_ADJ_METRIC_INFINITY flag, the metric should be checked using sadj->metric.