### PR TITLE
tests: Remove `log monitor XX ` from topotests

### DIFF
--- a/tests/topotests/srv6_encap_src_addr/r1/zebra.conf
+++ b/tests/topotests/srv6_encap_src_addr/r1/zebra.conf
@@ -4,7 +4,6 @@ hostname r1
 ! debug zebra rib detailed
 !
 log stdout notifications
-log monitor notifications
 log commands
 log file zebra.log debugging
 !

--- a/tests/topotests/srv6_sid_manager/rt1/bgpd.conf
+++ b/tests/topotests/srv6_sid_manager/rt1/bgpd.conf
@@ -6,7 +6,6 @@ hostname rt1
 password zebra
 !
 log stdout notifications
-log monitor notifications
 log commands
 !
 !debug bgp neighbor-events

--- a/tests/topotests/srv6_sid_manager/rt6/bgpd.conf
+++ b/tests/topotests/srv6_sid_manager/rt6/bgpd.conf
@@ -6,7 +6,6 @@ hostname rt6
 password zebra
 !
 log stdout notifications
-log monitor notifications
 log commands
 !
 !debug bgp neighbor-events


### PR DESCRIPTION
`log monitor XX` command is deprecated and does nothing. Let's remove it.