### PR TITLE
tests: Add v4/v6 forwarding off/on

### DIFF
--- a/tests/topotests/forwarding_on_off/r1/frr.conf
+++ b/tests/topotests/forwarding_on_off/r1/frr.conf
@@ -1,0 +1,14 @@
+int lo
+  ip address 10.1.1.1/32
+  ip address 10:1::1:1/128
+
+int eth0
+  ip address 10.1.2.1/24
+  ipv6 address 10:1::2:1/120
+
+ip route 10.1.1.2/32 10.1.2.2
+ip route 10.1.1.3/32 10.1.2.2
+ip route 10.1.3.0/24 10.1.2.2
+ipv6 route 10:1::1:2/128 10:1::2:2
+ipv6 route 10:1::1:3/128 10:1::2:2
+ipv6 route 10:1::3:0/90 10:1::2:2

--- a/tests/topotests/forwarding_on_off/r2/frr.conf
+++ b/tests/topotests/forwarding_on_off/r2/frr.conf
@@ -1,0 +1,19 @@
+no ip forwarding
+no ipv6 forwarding
+
+int lo
+  ip address 10.1.1.2/32
+  ipv6 address 10:1::1:2/128
+
+int eth0
+  ip address 10.1.2.2/24
+  ipv6 address 10:1::2:2/120
+
+int eth1
+  ip address 10.1.3.2/24
+  ipv6 address 10:1::3:2/120
+
+ip route 10.1.1.1/32 10.1.2.1
+ip route 10.1.1.3/32 10.1.3.3
+ipv6 route 10:1::1:1/128 10:1::2:1
+ipv6 route 10:1::1:3/128 10:1::3:3

--- a/tests/topotests/forwarding_on_off/r3/frr.conf
+++ b/tests/topotests/forwarding_on_off/r3/frr.conf
@@ -1,0 +1,15 @@
+int lo
+  ip address 10.1.1.3/32
+  ipv6 address 10:1::1:3/128
+
+int eth0
+  ip address 10.1.3.3/24
+  ipv6 address 10:1::3:3/120
+
+
+ip route 10.1.1.1/32 10.1.3.2
+ip route 10.1.1.2/32 10.1.3.2
+ip route 10.1.2.0/24 10.1.3.2
+ipv6 route 10:1::1:1/128 10:1::3:2
+ipv6 route 10:1::1:2/128 10:1::3:2
+ipv6 route 10:1::2:0/120 10:1::3:2

--- a/tests/topotests/forwarding_on_off/test_forwarding_on_off.py
+++ b/tests/topotests/forwarding_on_off/test_forwarding_on_off.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_forwarding_on_off.py
+#
+# Copyright (c) 2024 by Nvidia Corporation
+# Donald Sharp
+#
+
+"""
+test_forwarding_on_off.py: Test that forwarding is turned off then back on
+
+"""
+
+import ipaddress
+import json
+import pytest
+import sys
+import time
+
+from functools import partial
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+from lib.checkping import check_ping
+
+pytestmark = [
+    pytest.mark.staticd,
+]
+
+
+def build_topo(tgen):
+    """Build the topology used by all tests below."""
+
+    # Create 3 routers
+    r1 = tgen.add_router("r1")
+    r2 = tgen.add_router("r2")
+    r3 = tgen.add_router("r3")
+
+    # Add a link between r1 <-> r2 and r2 <-> r3
+    tgen.add_link(r1, r2, ifname1="eth0", ifname2="eth0")
+    tgen.add_link(r2, r3, ifname1="eth1", ifname2="eth0")
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for _, router in router_list.items():
+        router.load_frr_config("frr.conf")
+
+    tgen.start_router()
+
+
+def teardown_module():
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_no_forwarding():
+    tgen = get_topogen()
+    r2 = tgen.gears["r2"]
+
+    def _no_forwarding(family, status):
+        logger.info("Testing for: {} {}".format(family, status))
+        rc, o, e = r2.net.cmd_status(
+            'vtysh -c "show zebra" | grep "{}" | grep "{}"'.format(family, status)
+        )
+
+        logger.info("Output: {}".format(o))
+        return rc
+
+    test_func = partial(_no_forwarding, "v4 Forwarding", "Off")
+    _, result = topotest.run_and_expect(test_func, 0, count=15, wait=1)
+    assert result == 0
+
+    test_func = partial(_no_forwarding, "v6 Forwarding", "Off")
+    _, result = topotest.run_and_expect(test_func, 0, count=15, wait=1)
+    assert result == 0
+
+    logger.info("Sending pings that should fail")
+    check_ping("r1", "10.1.1.3", False, 10, 1)
+    check_ping("r1", "10:1::1:3", False, 10, 1)
+
+    logger.info("Turning on Forwarding")
+    r2.vtysh_cmd("conf\nip forwarding\nipv6 forwarding")
+
+    test_func = partial(_no_forwarding, "v4 Forwarding", "On")
+    _, result = topotest.run_and_expect(test_func, 0, count=15, wait=1)
+    assert result == 0
+
+    test_func = partial(_no_forwarding, "v6 Forwarding", "On")
+    _, result = topotest.run_and_expect(test_func, 0, count=15, wait=1)
+    assert result == 0
+
+    check_ping("r1", "10.1.1.3", True, 10, 1)
+    check_ping("r1", "10:1::1:3", True, 10, 1)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
There are no tests that ensured that turning off then on v4 and v6 forwarding actually worked.  This does so. This was found via looking at the code coverage.