### PR TITLE
tests: fix zebra_rib range

### DIFF
--- a/tests/topotests/zebra_rib/test_zebra_rib.py
+++ b/tests/topotests/zebra_rib/test_zebra_rib.py
@@ -153,7 +153,7 @@ def test_zebra_kernel_admin_distance():
     # metric.  That needs to be properly resolved.  Making a note for
     # coming back around later and fixing this.
     # tgen.mininet_cli()
-    for i in range(1, 2):
+    for i in range(1, 3):
         json_file = "{}/r1/v4_route_{}.json".format(CWD, i)
         expected = json.loads(open(json_file).read())
 


### PR DESCRIPTION
Range is wrong. We want values 1 and 2 but we only test 1.

> >>> for i in range(1, 2):
> ...     print(i)
> ...
> 1

Fixes: abd2a1ff3f ("tests: Test some basic kernel <-> zebra interactions")