### PR TITLE
bgpd: EVPN fix per rd specific type-2 json output

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2820,9 +2820,9 @@ static void evpn_show_route_rd_macip(struct vty *vty, struct bgp *bgp,
 		path_cnt++;
 	}
 
-	if (json && path_cnt) {
+	if (json) {
 		if (path_cnt)
-			json_object_object_addf(json, json_paths, "%pFX", &p);
+			json_object_object_add(json, "paths", json_paths);
 		json_object_int_add(json, "numPaths", path_cnt);
 	} else {
 		vty_out(vty, "\nDisplayed %u paths for requested prefix\n",


### PR DESCRIPTION
Current Issue:

paths key is not there for 'show bgp l2vpn evpn route rd <rd-id> mac <mac> json' uses evpn prefix as key for each path.
Replace the evpn prefix with "paths".
This aligned with overall EVPN RIB json output like 'show bgp l2vpn evpn route json'
'show bgp l2vpn evpn route rd <> type 2 json'


Testing:

Before fix:
```
leaf22# show bgp l2vpn evpn route rd 6.0.0.17:2 mac 00:02:00:00:00:12 json {
  "prefix":"[2]:[0]:[48]:[00:02:00:00:00:12]",
  "prefixLen":352,
  "rd":"6.0.0.17:2",
  "routeType":2,
  "ethTag":0,
  "macLen":48,
  "mac":"00:02:00:00:00:12",
  "advertisedTo":{
    "220.20.0.33":{
      "hostname":"spine21"
    },
    "220.21.0.33":{
      "hostname":"spine22"
    }
  },
  "[2]:[0]:[48]:[00:02:00:00:00:12]":[ <=====  Prefix info instead of "paths" key
    [
      {
        "vni":"101101",
        "aspath":{
          "string":"65202 65024",
          "segments":[
            {
              "type":"as-sequence",
              "list":[
                65202,
                65024
              ]
            }
          ],
          "length":2
        },
        "esi":"03:00:00:00:77:02:04:00:00:18",
        "es_info":{
          "localEs":true
        },
        "origin":"IGP",
        "valid":true,
        "version":5,
        "bestpath":{
          "bestpathFromAs":65202,
          "overall":true,
          "selectionReason":"Older Path"
        },
        "extendedCommunity":{
          "string":"RT:65024:101101 ET:8"
        },
        "lastUpdate":{
          "epoch":1726803218,
          "string":"Fri Sep 20 03:33:38 2024\n"
        },
        "nexthops":[
          {
            "ip":"6.0.0.17",
            "hostname":"spine21",
            "afi":"ipv4",
            "metric":0,
            "accessible":true,
            "used":true
          }
        ],
        "peer":{
          "peerId":"220.20.0.33",
          "routerId":"6.0.0.20",
          "hostname":"spine21",
          "type":"external"
        }
      }
    ],
    [
      {
        "vni":"101101",
        "aspath":{
          "string":"65202 65024",
          "segments":[
            {
              "type":"as-sequence",
              "list":[
                65202,
                65024
              ]
            }
          ],
          "length":2
        },
        "esi":"03:00:00:00:77:02:04:00:00:18",
        "es_info":{
          "localEs":true
        },
        "origin":"IGP",
        "valid":true,
        "version":5,
        "extendedCommunity":{
          "string":"RT:65024:101101 ET:8"
        },
        "lastUpdate":{
          "epoch":1726803218,
          "string":"Fri Sep 20 03:33:38 2024\n"
        },
        "nexthops":[
          {
            "ip":"6.0.0.17",
            "hostname":"spine22",
            "afi":"ipv4",
            "metric":0,
            "accessible":true,
            "used":true
          }
        ],
        "peer":{
          "peerId":"220.21.0.33",
          "routerId":"6.0.0.21",
          "hostname":"spine22",
          "type":"external"
        }
      }
    ]
  ],
  "numPaths":2
}
```

After fix:

```
leaf22# show bgp l2vpn evpn route rd 6.0.0.17:2 mac 00:02:00:00:00:12 json {
  "prefix":"[2]:[0]:[48]:[00:02:00:00:00:12]",
  "prefixLen":352,
  "rd":"6.0.0.17:2",
  "routeType":2,
  "ethTag":0,
  "macLen":48,
  "mac":"00:02:00:00:00:12",
  "advertisedTo":{
    "220.20.0.33":{
      "hostname":"spine21"
    },
    "220.21.0.33":{
      "hostname":"spine22"
    }
  },
  "paths":[
    [
      {
        "vni":"101101",
        "aspath":{
          "string":"65202 65024",
          "segments":[
            {
              "type":"as-sequence",
              "list":[
                65202,
                65024
              ]
            }
          ],
          "length":2
        },
        "esi":"03:00:00:00:77:02:04:00:00:18",
        "es_info":{
          "localEs":true
        },
        "origin":"IGP",
        "valid":true,
        "version":3,
        "bestpath":{
          "bestpathFromAs":65202,
          "overall":true,
          "selectionReason":"Router ID"
        },
        "extendedCommunity":{
          "string":"RT:65024:101101 ET:8"
        },
        "lastUpdate":{
          "epoch":1727175046,
          "string":"Tue Sep 24 10:50:46 2024\n"
        },
        "nexthops":[
          {
            "ip":"6.0.0.17",
            "hostname":"spine21",
            "afi":"ipv4",
            "metric":0,
            "accessible":true,
            "used":true
          }
        ],
        "peer":{
          "peerId":"220.20.0.33",
          "routerId":"6.0.0.20",
          "hostname":"spine21",
          "type":"external"
        }
      }
    ],
    [
      {
        "vni":"101101",
        "aspath":{
          "string":"65202 65024",
          "segments":[
            {
              "type":"as-sequence",
              "list":[
                65202,
                65024
              ]
            }
          ],
          "length":2
        },
        "esi":"03:00:00:00:77:02:04:00:00:18",
        "es_info":{
          "localEs":true
        },
        "origin":"IGP",
        "valid":true,
        "version":3,
        "extendedCommunity":{
          "string":"RT:65024:101101 ET:8"
        },
        "lastUpdate":{
          "epoch":1727175046,
          "string":"Tue Sep 24 10:50:46 2024\n"
        },
        "nexthops":[
          {
            "ip":"6.0.0.17",
            "hostname":"spine22",
            "afi":"ipv4",
            "metric":0,
            "accessible":true,
            "used":true
          }
        ],
        "peer":{
          "peerId":"220.21.0.33",
          "routerId":"6.0.0.21",
          "hostname":"spine22",
          "type":"external"
        }
      }
    ]
  ],
  "numPaths":2
}
```

Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>