### PR TITLE
bgpd: Remove dead code from recent commit

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10609,13 +10609,6 @@ DEFPY(bgp_imexport_vrf, bgp_imexport_vrf_cmd,
 			 */
 			SET_FLAG(vrf_bgp->vrf_flags, BGP_VRF_AUTO);
 		}
-
-		if (ret) {
-			vty_out(vty,
-				"VRF %s is not configured as a bgp instance\n",
-				import_name);
-			return CMD_WARNING;
-		}
 	}
 
 	if (remove) {


### PR DESCRIPTION
Recent commit 4d0e7a49cf8d4311a485281fa50bbff6ee8ca6cc brought in changes that moved a check for ret up
in the code, caused some code to be left around
and be effectively dead since it would never be called.