### PR TITLE
pimd: enhance topotest of autorp, fix autorp cli bug

### DIFF
--- a/pimd/pim_autorp.c
+++ b/pimd/pim_autorp.c
@@ -851,6 +851,7 @@ void pim_autorp_add_candidate_rp_plist(struct pim_instance *pim,
 	snprintf(rp->grplist, sizeof(rp->grplist), "%s", plist);
 	/* A new group prefix list implies that any previous group prefix is now invalid */
 	memset(&(rp->grp), 0, sizeof(rp->grp));
+	rp->grp.family = AF_INET;
 
 	pim_autorp_new_announcement(pim);
 }
@@ -1155,7 +1156,7 @@ void pim_autorp_show_autorp(struct vty *vty, struct pim_instance *pim,
 
 		table = ttable_dump(tt, "\n");
 		vty_out(vty, "%s\n", table);
-		XFREE(MTYPE_TMP, table);
+		XFREE(MTYPE_TMP_TTABLE, table);
 	}
 
 	ttable_del(tt);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -4609,7 +4609,7 @@ DEFPY (pim_autorp_announce_rp,
        "Prefix list\n"
        "List name\n")
 {
-	return pim_process_autorp_candidate_rp_cmd(vty, no, rpaddr_str, grp,
+	return pim_process_autorp_candidate_rp_cmd(vty, no, rpaddr_str, (grp_str ? grp : NULL),
 						   plist);
 }
 

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -639,9 +639,9 @@ int pim_process_autorp_candidate_rp_cmd(struct vty *vty, bool no,
 	char grpstr[64];
 
 	if (no) {
-		if (!is_default_prefix((const struct prefix *)grp) || plist) {
+		if ((grp && !is_default_prefix((const struct prefix *)grp)) || plist) {
 			/* If any single values are set, only destroy those */
-			if (!is_default_prefix((const struct prefix *)grp)) {
+			if (grp && !is_default_prefix((const struct prefix *)grp)) {
 				snprintfrr(xpath, sizeof(xpath),
 					   "%s/candidate-rp-list[rp-address='%s']/group",
 					   FRR_PIM_AUTORP_XPATH, rpaddr_str);
@@ -663,12 +663,12 @@ int pim_process_autorp_candidate_rp_cmd(struct vty *vty, bool no,
 			nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 		}
 	} else {
-		if (!is_default_prefix((const struct prefix *)grp) || plist) {
+		if ((grp && !is_default_prefix((const struct prefix *)grp)) || plist) {
 			snprintfrr(xpath, sizeof(xpath),
 				   "%s/candidate-rp-list[rp-address='%s']",
 				   FRR_PIM_AUTORP_XPATH, rpaddr_str);
 			nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
-			if (!is_default_prefix((const struct prefix *)grp)) {
+			if (grp && !is_default_prefix((const struct prefix *)grp)) {
 				snprintfrr(xpath, sizeof(xpath),
 					   "%s/candidate-rp-list[rp-address='%s']/group",
 					   FRR_PIM_AUTORP_XPATH, rpaddr_str);


### PR DESCRIPTION
Expands the autorp topotest to include the "announce" cli commands and fixes cli bugs uncovered during this development