### PR TITLE
TI-LFA incorrectly included pseudo-nodes when calculating PQ space.

### DIFF
--- a/isisd/isis_lfa.c
+++ b/isisd/isis_lfa.c
@@ -1064,7 +1064,7 @@ static void lfa_calc_reach_nodes(struct isis_spftree *spftree,
 	for (ALL_QUEUE_ELEMENTS_RO(&spftree->paths, node, vertex)) {
 		char buf[VID2STR_BUFFER];
 
-		if (!VTYPE_IS(vertex->type))
+		if (vertex->type != VTYPE_NONPSEUDO_IS && vertex->type != VTYPE_NONPSEUDO_TE_IS)
 			continue;
 
 		/* Skip root node. */


### PR DESCRIPTION
When there are pseudo-nodes on the device, during TI-LFA calculation of PQ space, even if this IS vertex is not originally a P/Q node, it might be calculated as a P/Q node due to the presence of pseudo-nodes, causing this IS vertex to become a P/Q node.