### PR TITLE
zebra: Check if the route entry not installed if flagged as queued

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -608,7 +608,8 @@ zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 				continue;
 			}
 
-			if (CHECK_FLAG(re->status, ROUTE_ENTRY_QUEUED)) {
+			if (CHECK_FLAG(re->status, ROUTE_ENTRY_QUEUED) &&
+			    !CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED)) {
 				if (IS_ZEBRA_DEBUG_NHT_DETAILED)
 					zlog_debug(
 						"        Route Entry %s queued",


### PR DESCRIPTION
After zebra (and bgp/staticd) restart, BGP peer address over an IPSec tunnel becomes unresolved. We can not reproduce at will, but out of 35 VMs, one can enter this state.

```
default# show ip bgp 172.32.0.2/32
BGP routing table entry for 172.32.0.2/32, version 0
Paths: (2 available, no best path)
Not advertised to any peer
Local
172.32.0.9 (inaccessible) from 172.32.0.9 (172.32.0.9). <<<<< nexthop inaccessible, IPsec tunnel to nexthop is up
Origin incomplete, metric 100000, localpref 10000, invalid, internal
Last update: Tue Mar 26 04:09:13 2024
Local
172.32.0.5 (inaccessible) from 172.32.0.5 (172.32.0.5) <<<<< nexthop inaccessible, IPsec tunnel to nexthop is up
Origin incomplete, metric 100000, localpref 10000, invalid, internal
Last update: Tue Mar 26 04:09:11 2024
default#

default# show ip nht
VRF default:
Resolve via default: on
100.72.56.1
resolved via connected
is directly connected, ethernet1/1
Client list: static(fd 24)
172.32.0.5
unresolved
Client list: bgp(fd 40)
172.32.0.9
unresolved
Client list: bgp(fd 40)
default#
```

Also, what was spotted is that `internalStatus` is 24, which is queued + installed.

```
default# show ip route 172.32.0.4/32 json
{
  "172.32.0.4/32":[
    {
      "internalStatus":24, <<<<<<<<<<<<<<<  0x18
      "internalFlags":73,
}
```

This is similar to this issue also https://github.com/FRRouting/frr/issues/15535.