### PR TITLE
pbr: format change in nexthop-group json output

### DIFF
--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -1080,24 +1080,27 @@ void nexthop_group_json_nexthop(json_object *j, const struct nexthop *nh)
 
 	switch (nh->type) {
 	case NEXTHOP_TYPE_IFINDEX:
-		json_object_string_add(j, "nexthop",
+		json_object_string_add(j, "interfaceName",
 				       ifindex2ifname(nh->ifindex, nh->vrf_id));
+		json_object_int_add(j, "vrfId", nh->vrf_id);
 		break;
 	case NEXTHOP_TYPE_IPV4:
 		json_object_string_addf(j, "nexthop", "%pI4", &nh->gate.ipv4);
 		break;
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
 		json_object_string_addf(j, "nexthop", "%pI4", &nh->gate.ipv4);
-		json_object_string_add(j, "vrfId",
+		json_object_string_add(j, "interfaceName",
 				       ifindex2ifname(nh->ifindex, nh->vrf_id));
+		json_object_int_add(j, "vrfId", nh->vrf_id);
 		break;
 	case NEXTHOP_TYPE_IPV6:
 		json_object_string_addf(j, "nexthop", "%pI6", &nh->gate.ipv6);
 		break;
 	case NEXTHOP_TYPE_IPV6_IFINDEX:
 		json_object_string_addf(j, "nexthop", "%pI6", &nh->gate.ipv6);
-		json_object_string_add(j, "vrfId",
+		json_object_string_add(j, "interfaceName",
 				       ifindex2ifname(nh->ifindex, nh->vrf_id));
+		json_object_int_add(j, "vrfId", nh->vrf_id);
 		break;
 	case NEXTHOP_TYPE_BLACKHOLE:
 		break;

--- a/pbrd/pbr_nht.c
+++ b/pbrd/pbr_nht.c
@@ -1402,6 +1402,7 @@ struct pbr_nht_show {
 	struct vty *vty;
 	json_object *json;
 	const char *name;
+	uint16_t nhg_count;
 };
 
 static void pbr_nht_show_nhg(struct hash_bucket *b, void *data)
@@ -1447,7 +1448,8 @@ static void pbr_nht_json_nhg(struct hash_bucket *b, void *data)
 		json_object_object_add(this_group, "nexthops", group_hops);
 	}
 
-	json_object_array_add(j, this_group);
+	json_object_object_addf(j, this_group, "%u", pnhgc->table_id);
+	pns->nhg_count++;
 }
 
 void pbr_nht_show_nexthop_group(struct vty *vty, const char *name)
@@ -1460,14 +1462,17 @@ void pbr_nht_show_nexthop_group(struct vty *vty, const char *name)
 	hash_iterate(pbr_nhg_hash, pbr_nht_show_nhg, &pns);
 }
 
-void pbr_nht_json_nexthop_group(json_object *j, const char *name)
+void pbr_nht_json_nexthop_group(json_object *j, const char *name,
+				uint16_t *pbr_nhg_count)
 {
 	struct pbr_nht_show pns;
 
 	pns.name = name;
 	pns.json = j;
+	pns.nhg_count = 0;
 
 	hash_iterate(pbr_nhg_hash, pbr_nht_json_nhg, &pns);
+	*pbr_nhg_count = pns.nhg_count;
 }
 
 void pbr_nht_init(void)

--- a/pbrd/pbr_nht.h
+++ b/pbrd/pbr_nht.h
@@ -126,7 +126,8 @@ extern char *pbr_nht_nexthop_make_name(char *name, size_t l, uint32_t seqno,
 				       char *buffer);
 
 extern void pbr_nht_show_nexthop_group(struct vty *vty, const char *name);
-extern void pbr_nht_json_nexthop_group(json_object *j, const char *name);
+extern void pbr_nht_json_nexthop_group(json_object *j, const char *name,
+				       uint16_t *pbr_nhg_count);
 
 /*
  * When we get a callback from zebra about a nexthop changing

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -1865,13 +1865,14 @@ DEFPY(show_pbr_nexthop_group,
       JSON_STR)
 {
 	json_object *j = NULL;
+	uint16_t pbr_nhg_count = 0;
 
 	if (json)
-		j = json_object_new_array();
+		j = json_object_new_object();
 
 	if (j) {
-		pbr_nht_json_nexthop_group(j, word);
-
+		pbr_nht_json_nexthop_group(j, word, &pbr_nhg_count);
+		json_object_int_add(j, "nhgCount", pbr_nhg_count);
 		vty_json(vty, j);
 	} else
 		pbr_nht_show_nexthop_group(vty, word);


### PR DESCRIPTION
 - JSON format is changed. currently json output returns as array format, in which we cannot add extra attributes under it. so, we modified the JSON format into dict.
 - Added nhgCount into vtysh "show pbr nexthop-groups json".
 - Addressed interface-name & vrf-id issues. currently, "vrfId" is mapped with interface name.

supported commands:

```
show pbr nexthop-groups json
show pbr nexthop-groups <nh-grp> json
```

Testing:

**Before fix:**

```
leaf12# show pbr nexthop-groups json
[
  {
    "id":10001,
    "name":"nh-grp-2",
    "valid":true,
    "installed":false,
    "nexthops":[
      {
        "nexthop":"12.10.10.1",
        "vrfId":"swp1", ====> wrongly mapped
        "valid":true
      }
    ]
  },
  {
    "id":10000,
    "name":"nh-grp-1",
    "valid":false,
    "installed":false,
    "nexthops":[
      {
        "nexthop":"11.10.10.1",
        "vrfId":"lo", ====> wrongly mapped
        "valid":false
      }
    ]
  }
]
```

**After fix:**

```
leaf11# show pbr nexthop-groups nh-grp-1 json
{
  "10000":{
    "id":10000,
    "name":"nh-grp-1",
    "valid":false,
    "installed":false,
    "nexthops":[
      {
        "nexthop":"11.10.10.1",
        "valid":false
      },
      {
        "nexthop":"2.2.2.1",
        "interfaceName":"swp1",
        "vrfId":0,
        "valid":false
      }
    ]
  },
  "nhgCount":1
}
```

Signed-off-by: Sindhu Parvathi Gopinathan's <sgopinathan@nvidia.com>