### PR TITLE
tools: fix missing check interfaces for reloading pim

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1140,14 +1140,14 @@ def pim_delete_move_lines(lines_to_add, lines_to_del):
     # they are implicitly deleted by 'no ip pim'.
     # Remove all such depdendent options from delete
     # pending list.
-    pim_disable = False
+    pim_disable = []
     lines_to_del_to_del = []
 
     index = -1
     for ctx_keys, line in lines_to_del:
         index = index + 1
         if ctx_keys[0].startswith("interface") and line and line == "ip pim":
-            pim_disable = True
+            pim_disable.append(ctx_keys[0])
 
         # no ip msdp peer <> does not accept source so strip it off.
         if line and line.startswith("ip msdp peer "):
@@ -1158,14 +1158,14 @@ def pim_delete_move_lines(lines_to_add, lines_to_del):
                 lines_to_del.remove((ctx_keys, line))
                 lines_to_del.insert(index, (ctx_keys, new_line))
 
-    if pim_disable:
-        for ctx_keys, line in lines_to_del:
-            if (
-                ctx_keys[0].startswith("interface")
-                and line
-                and (line.startswith("ip pim ") or line.startswith("ip multicast "))
-            ):
-                lines_to_del_to_del.append((ctx_keys, line))
+    for ctx_keys, line in lines_to_del:
+        if (
+            ctx_keys[0] in pim_disable
+            and ctx_keys[0].startswith("interface")
+            and line
+            and (line.startswith("ip pim ") or line.startswith("ip multicast "))
+        ):
+            lines_to_del_to_del.append((ctx_keys, line))
 
     for ctx_keys, line in lines_to_del_to_del:
         lines_to_del.remove((ctx_keys, line))


### PR DESCRIPTION
Without checking interfaces, the other interfaces' changes will be wrongly lost.

Running config:
```
interface A
ip pim
ip pim use-source 11.0.0.1
exit
!
interface B
ip pim
ip pim use-source 22.0.0.1
exit
!
```

Reload the new config:
```
interface A
exit
!
interface B
ip pim
exit
```

Before:
```
2024-09-29 10:08:27,686  INFO: Executed "interface A  no ip pim exit"
```

After:
```
2024-09-29 10:05:01,356  INFO: Executed "interface A  no ip pim exit"
2024-09-29 10:05:01,376  INFO: Executed "interface B  no ip pim use-source 22.0.0.1 exit"
```