### PR TITLE
ospfd:reset wait timer when reading ip ospf dead-interval

### DIFF
--- a/ospfd/ospf_ism.c
+++ b/ospfd/ospf_ism.c
@@ -258,7 +258,7 @@ void ospf_hello_timer(struct event *thread)
 	OSPF_HELLO_TIMER_ON(oi);
 }
 
-static void ospf_wait_timer(struct event *thread)
+void ospf_wait_timer(struct event *thread)
 {
 	struct ospf_interface *oi;
 

--- a/ospfd/ospf_ism.h
+++ b/ospfd/ospf_ism.h
@@ -76,6 +76,7 @@ extern void ospf_ism_event(struct event *thread);
 extern void ism_change_status(struct ospf_interface *, int);
 extern void ospf_hello_timer(struct event *thread);
 extern int ospf_dr_election(struct ospf_interface *oi);
+extern void ospf_wait_timer(struct event *thread);
 
 DECLARE_HOOK(ospf_ism_change,
 	     (struct ospf_interface * oi, int state, int oldstate),


### PR DESCRIPTION
The fix addressed the issue found at https://github.com/FRRouting/frr/issues/16905.
In the fix, after reconfiguring the dead-interval, the waitTimer, like the helloTimer, will refresh immediately.

In the current OSPF implementation, after configuring the ip ospf dead-interval, the waitTimer does not refresh immediately but waits for the waitTimer to expire before being reconfigured.

In issue 16905, when we configure the waitTimer to a very large value and then clear the OSPF process using clear ip ospf process, the waitTimer is forcibly reset and will wait for this large value until it expires.At this point, configuring a very small value for the dead-interval will not take effect immediately, which results in having to wait a long time. It appears as though the state is stuck.Therefore, if the configured dead-interval is large, we have to use clear ip ospf process each time to refresh the waitTimer.