### PR TITLE
ospf:fix handling transmit delay when receiving link state ack

### DIFF
--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -292,6 +292,9 @@ extern struct ospf_lsa *ospf_lsa_lookup_by_id(struct ospf_area *, uint32_t,
 extern struct ospf_lsa *ospf_lsa_lookup_by_header(struct ospf_area *,
 						  struct lsa_header *);
 extern int ospf_lsa_more_recent(struct ospf_lsa *, struct ospf_lsa *);
+extern int ospf_lsa_more_recent_with_trans_delay(struct ospf_lsa *l1, struct ospf_lsa *l2,
+						 int trans_delay);
+
 extern int ospf_lsa_different(struct ospf_lsa *, struct ospf_lsa *,
 			      bool ignore_rcvd_flag);
 extern void ospf_flush_self_originated_lsas_now(struct ospf *);

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -2076,6 +2076,8 @@ static void ospf_ls_upd(struct ospf *ospf, struct ip *iph,
 	list_delete(&lsas);
 }
 
+static int ls_age_increment(struct ospf_lsa *lsa, int delay);
+
 /* OSPF Link State Acknowledgment message read -- RFC2328 Section 13.7. */
 static void ospf_ls_ack(struct ip *iph, struct ospf_header *ospfh,
 			struct stream *s, struct ospf_interface *oi,
@@ -2124,7 +2126,9 @@ static void ospf_ls_ack(struct ip *iph, struct ospf_header *ospfh,
 
 		lsr = ospf_ls_retransmit_lookup(nbr, lsa);
 
-		if (lsr != NULL && ospf_lsa_more_recent(lsr, lsa) == 0) {
+		if (lsr != NULL &&
+		    ospf_lsa_more_recent_with_trans_delay(lsr, lsa,
+							  OSPF_IF_PARAM(oi, transmit_delay)) == 0) {
 			ospf_ls_retransmit_delete(nbr, lsr);
 			ospf_check_and_gen_init_seq_lsa(oi, lsa);
 		}


### PR DESCRIPTION
This is the fix of https://github.com/FRRouting/frr/issues/16944. The detailed cause of the problem has been answered in the issue.

When transmit delay is greater than OSPF_LSA_MAXAGE_DIFF(900), the age of lsa in link state ack packet exceeds OSPF_LSA_MAXAGE_DIFF compared to the age of lsa in retransmit list. (ospf_packet.c:3318) This makes the reply LSA considered different from the LSA in the retransmit list, so the lsa in retransmit list can never be cleared.（ospf_packet.c:2127）

In this fix, the LSA in the retransmit list will be added with transmit delay and then compared with the lsa in the ack.

This may not be a good solution.I checked other implementations of OSPF, and some projects stipulate that the delay is between 1-3600. Perhaps the simplest solution is to limit the transmit delay to less than 900.