### PR TITLE
pimd: miscellaneous fixes

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -62,7 +62,6 @@ static void gm_sg_timer_start(struct gm_if *gm_ifp, struct gm_sg *sg,
 		sg->iface->ifp->name, &sg->sgaddr
 
 /* clang-format off */
-#if PIM_IPV == 6
 static const pim_addr gm_all_hosts = {
 	.s6_addr = {
 		0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -84,13 +83,6 @@ static const pim_addr gm_dummy_untracked = {
 		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 	},
 };
-#else
-/* 224.0.0.1 */
-static const pim_addr gm_all_hosts = { .s_addr = htonl(0xe0000001), };
-/* 224.0.0.22 */
-static const pim_addr gm_all_routers = { .s_addr = htonl(0xe0000016), };
-static const pim_addr gm_dummy_untracked = { .s_addr = 0xffffffff, };
-#endif
 /* clang-format on */
 
 #define IPV6_MULTICAST_SCOPE_LINK 2

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -934,10 +934,9 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ss
 		yang_dnode_get_pimaddr(&source_addr, args->dnode, NULL);
 		result = pim_ssmpingd_start(pim, source_addr);
 		if (result) {
-			snprintf(
-				args->errmsg, args->errmsg_len,
-				"%% Failure starting ssmpingd for source %pPA: %d",
-				&source_addr, result);
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "%% Failure starting ssmpingd for source %pPA: %d", &source_addr,
+				   result);
 			return NB_ERR_INCONSISTENCY;
 		}
 	}
@@ -964,10 +963,9 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ss
 		yang_dnode_get_pimaddr(&source_addr, args->dnode, NULL);
 		result = pim_ssmpingd_stop(pim, source_addr);
 		if (result) {
-			snprintf(
-				args->errmsg, args->errmsg_len,
-				"%% Failure stopping ssmpingd for source %pPA: %d",
-				&source_addr, result);
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "%% Failure stopping ssmpingd for source %pPA: %d", &source_addr,
+				   result);
 			return NB_ERR_INCONSISTENCY;
 		}
 
@@ -3860,10 +3858,9 @@ int lib_interface_gmp_address_family_join_group_destroy(
 					    GM_JOIN_STATIC);
 
 		if (result) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "%% Failure leaving " GM
-				 " group %pPAs %pPAs on interface %s: %d",
-				 &source_addr, &group_addr, ifp->name, result);
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "%% Failure leaving " GM " group %pPAs %pPAs on interface %s: %d",
+				   &source_addr, &group_addr, ifp->name, result);
 
 			return NB_ERR_INCONSISTENCY;
 		}
@@ -3952,9 +3949,9 @@ int lib_interface_gmp_address_family_static_group_destroy(
 		result = pim_if_static_group_del(ifp, group_addr, source_addr);
 
 		if (result) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "%% Failure removing static group %pPAs %pPAs on interface %s: %d",
-				 &source_addr, &group_addr, ifp->name, result);
+			snprintfrr(args->errmsg, args->errmsg_len,
+				   "%% Failure removing static group %pPAs %pPAs on interface %s: %d",
+				   &source_addr, &group_addr, ifp->name, result);
 
 			return NB_ERR_INCONSISTENCY;
 		}


### PR DESCRIPTION
Two small fixes in PIM:
- Remove unreacheable code
- Fix some badly formated northbound output