### PR TITLE
lib: fix calloc warning on recent compiler

### DIFF
--- a/lib/elf_py.c
+++ b/lib/elf_py.c
@@ -1307,7 +1307,7 @@ static PyObject *elffile_load(PyTypeObject *type, PyObject *args,
 	}
 #endif
 
-	w->sects = calloc(sizeof(PyObject *), w->ehdr->e_shnum);
+	w->sects = calloc(w->ehdr->e_shnum, sizeof(PyObject *));
 	w->n_sect = w->ehdr->e_shnum;
 
 	return (PyObject *)w;


### PR DESCRIPTION
Fix the following compiler warning:
```
lib/elf_py.c: In function _elffile_load_:
lib/elf_py.c:1310:34: warning: _calloc_ sizes specified with _sizeof_ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
 1310 |         w->sects = calloc(sizeof(PyObject *), w->ehdr->e_shnum);
      |                                  ^~~~~~~~
lib/elf_py.c:1310:34: note: earlier argument should specify number of elements, later size of each element
```