### PR TITLE
lib: nexthop code should use uint16_t for nexthop counting

### DIFF
--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -70,10 +70,10 @@ static struct nexthop *nexthop_group_tail(const struct nexthop_group *nhg)
 	return nexthop;
 }
 
-uint8_t nexthop_group_nexthop_num(const struct nexthop_group *nhg)
+uint16_t nexthop_group_nexthop_num(const struct nexthop_group *nhg)
 {
 	struct nexthop *nhop;
-	uint8_t num = 0;
+	uint16_t num = 0;
 
 	for (ALL_NEXTHOPS_PTR(nhg, nhop))
 		num++;
@@ -81,11 +81,10 @@ uint8_t nexthop_group_nexthop_num(const struct nexthop_group *nhg)
 	return num;
 }
 
-static uint8_t
-nexthop_group_nexthop_num_no_recurse(const struct nexthop_group *nhg)
+static uint16_t nexthop_group_nexthop_num_no_recurse(const struct nexthop_group *nhg)
 {
 	struct nexthop *nhop;
-	uint8_t num = 0;
+	uint16_t num = 0;
 
 	for (nhop = nhg->nexthop; nhop; nhop = nhop->next)
 		num++;
@@ -93,10 +92,10 @@ nexthop_group_nexthop_num_no_recurse(const struct nexthop_group *nhg)
 	return num;
 }
 
-uint8_t nexthop_group_active_nexthop_num(const struct nexthop_group *nhg)
+uint16_t nexthop_group_active_nexthop_num(const struct nexthop_group *nhg)
 {
 	struct nexthop *nhop;
-	uint8_t num = 0;
+	uint16_t num = 0;
 
 	for (ALL_NEXTHOPS_PTR(nhg, nhop)) {
 		if (CHECK_FLAG(nhop->flags, NEXTHOP_FLAG_ACTIVE))
@@ -184,11 +183,9 @@ static struct nexthop *nhg_nh_find(const struct nexthop_group *nhg,
 	return NULL;
 }
 
-static bool
-nexthop_group_equal_common(const struct nexthop_group *nhg1,
-			   const struct nexthop_group *nhg2,
-			   uint8_t (*nexthop_group_nexthop_num_func)(
-				   const struct nexthop_group *nhg))
+static bool nexthop_group_equal_common(
+	const struct nexthop_group *nhg1, const struct nexthop_group *nhg2,
+	uint16_t (*nexthop_group_nexthop_num_func)(const struct nexthop_group *nhg))
 {
 	if (nhg1 && !nhg2)
 		return false;

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -149,9 +149,8 @@ extern void nexthop_group_json_nexthop(json_object *j,
 				       const struct nexthop *nh);
 
 /* Return the number of nexthops in this nhg */
-extern uint8_t nexthop_group_nexthop_num(const struct nexthop_group *nhg);
-extern uint8_t
-nexthop_group_active_nexthop_num(const struct nexthop_group *nhg);
+extern uint16_t nexthop_group_nexthop_num(const struct nexthop_group *nhg);
+extern uint16_t nexthop_group_active_nexthop_num(const struct nexthop_group *nhg);
 
 extern bool nexthop_group_has_label(const struct nexthop_group *nhg);
 


### PR DESCRIPTION
It's possible to specify via the cli and configure how many nexthops that are allowed on the system.  If you happen to have > 255 then things are about to get interesting otherwise.

Let's allow up to 65k nexthops (ha!)