### PR TITLE
bgpd: fix printfrr_bp for non initialized peers

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -8901,6 +8901,12 @@ static ssize_t printfrr_bp(struct fbuf *buf, struct printfrr_eargs *ea,
 	if (!peer)
 		return bputs(buf, "(null)");
 
+	if (!peer->host) {
+		if (peer->conf_if)
+			return bprintfrr(buf, "%s", peer->conf_if);
+		return bprintfrr(buf, "%pSU", &peer->connection->su);
+	}
+
 	return bprintfrr(buf, "%s(%s)", peer->host,
 			 peer->hostname ? peer->hostname : "Unknown");
 }


### PR DESCRIPTION
Fix printfrr_bp for non initialized peers. For example:

> Sep 26 17:56:44 r1 bgpd[26295]: [GJPH1-W8PZV] Resetting peer (null)(Unknown) due to change in addpath config

Is now:

> Oct 02 14:00:59 r1 bgpd[12795]: [MNE5N-K0G4Z] Resetting peer 2.2.2.2 due to change in addpath config