### PR TITLE
zebra: Fix crash during reconnect

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1336,7 +1336,7 @@ static void fpm_enqueue_l3vni_table(struct hash_bucket *bucket, void *arg)
 	struct zebra_l3vni *zl3vni = bucket->data;
 
 	fra->zl3vni = zl3vni;
-	hash_iterate(zl3vni->rmac_table, fpm_enqueue_rmac_table, zl3vni);
+	hash_iterate(zl3vni->rmac_table, fpm_enqueue_rmac_table, fra);
 }
 
 static void fpm_rmac_send(struct event *t)


### PR DESCRIPTION
`fpm_enqueue_rmac_table` expects an `fpm_rmac_arg *` as its argument.

The issue can be reproduced by dropping the TCP session using:
```
ss -K dst 127.0.0.1 dport = 2620
```

I've seen that you have `tests` folder but I'm new to the frr codebase, if you give me small guidelines I can add a test for my PR.