### PR TITLE
bgpd: bmp loc-rib peer up/down for vrfs

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -39,6 +39,8 @@
 #include "bgpd/bgp_trace.h"
 #include "bgpd/bgp_network.h"
 #include "bgpd/bgp_label.h"
+#include "bgpd/bgp_open.h"
+#include "bgpd/bgp_aspath.h"
 
 static void bmp_close(struct bmp *bmp);
 static struct bmp_bgp *bmp_bgp_find(struct bgp *bgp);
@@ -246,6 +248,33 @@ static void bmp_free(struct bmp *bmp)
 #define BMP_PEER_TYPE_LOCAL_INSTANCE 2
 #define BMP_PEER_TYPE_LOC_RIB_INSTANCE 3
 
+/* determine the peer type for per-peer headers from a vrf_id
+ * for non loc-rib peer type only
+ */
+static inline int bmp_get_peer_type_vrf(vrf_id_t vrf_id)
+{
+	switch (vrf_id) {
+	case VRF_DEFAULT:
+		return BMP_PEER_TYPE_GLOBAL_INSTANCE;
+	case VRF_UNKNOWN:
+		/* when the VRF is unknown consider it a local instance */
+		return BMP_PEER_TYPE_LOCAL_INSTANCE;
+	default:
+		return BMP_PEER_TYPE_RD_INSTANCE;
+	}
+}
+
+/* determine the peer type for per-peer headers from a struct peer
+ * provide a bgp->peer_self for loc-rib
+ */
+static inline int bmp_get_peer_type(struct peer *peer)
+{
+	if (peer->bgp->peer_self == peer)
+		return BMP_PEER_TYPE_LOC_RIB_INSTANCE;
+
+	return bmp_get_peer_type_vrf(peer->bgp->vrf_id);
+}
+
 static inline int bmp_get_peer_distinguisher(struct bmp *bmp, afi_t afi,
 					     uint8_t peer_type,
 					     uint64_t *result_ref)
@@ -370,17 +399,18 @@ static void bmp_put_info_tlv(struct stream *s, uint16_t type,
 	stream_put(s, string, len);
 }
 
-static void __attribute__((unused))
-bmp_put_vrftablename_info_tlv(struct stream *s, struct bmp *bmp)
+/* put the vrf table name of the bgp instance bmp is bound to in a tlv on the
+ * stream
+ */
+static void bmp_put_vrftablename_info_tlv(struct stream *s, struct bgp *bgp)
 {
+	const char *vrftablename = "global";
 
 #define BMP_INFO_TYPE_VRFTABLENAME 3
-	const char *vrftablename = "global";
-	if (bmp->targets->bgp->inst_type != BGP_INSTANCE_TYPE_DEFAULT) {
-		struct vrf *vrf = vrf_lookup_by_id(bmp->targets->bgp->vrf_id);
 
-		vrftablename = vrf ? vrf->name : NULL;
-	}
+	if (bgp->inst_type != BGP_INSTANCE_TYPE_DEFAULT)
+		vrftablename = bgp->name;
+
 	if (vrftablename != NULL)
 		bmp_put_info_tlv(s, BMP_INFO_TYPE_VRFTABLENAME, vrftablename);
 }
@@ -428,6 +458,10 @@ static void bmp_notify_put(struct stream *s, struct bgp_notify *nfy)
 			+ sizeof(marker));
 }
 
+/* send peer up/down for peer based on down boolean value
+ * returns the message to send or NULL if the peer_distinguisher is not
+ * available
+ */
 static struct stream *bmp_peerstate(struct peer *peer, bool down)
 {
 	struct stream *s;
@@ -438,11 +472,14 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 	uptime.tv_usec = 0;
 	monotime_to_realtime(&uptime, &uptime_real);
 
+	uint8_t peer_type = bmp_get_peer_type(peer);
+	bool is_locrib = peer_type == BMP_PEER_TYPE_LOC_RIB_INSTANCE;
+
 #define BGP_BMP_MAX_PACKET_SIZE	1024
 #define BMP_PEERUP_INFO_TYPE_STRING 0
 	s = stream_new(BGP_MAX_PACKET_SIZE);
 
-	if (peer_established(peer->connection) && !down) {
+	if ((peer_established(peer->connection) || is_locrib) && !down) {
 		struct bmp_bgp_peer *bbpeer;
 
 		bmp_common_hdr(s, BMP_VERSION_3,
@@ -452,7 +489,9 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 				 &uptime_real);
 
 		/* Local Address (16 bytes) */
-		if (peer->su_local->sa.sa_family == AF_INET6)
+		if (!peer->su_local || is_locrib)
+			stream_put(s, 0, 16);
+		else if (peer->su_local->sa.sa_family == AF_INET6)
 			stream_put(s, &peer->su_local->sin6.sin6_addr, 16);
 		else if (peer->su_local->sa.sa_family == AF_INET) {
 			stream_putl(s, 0);
@@ -462,15 +501,21 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 		}
 
 		/* Local Port, Remote Port */
-		if (peer->su_local->sa.sa_family == AF_INET6)
+		if (is_locrib)
+			stream_putw(s, 0);
+		else if (peer->su_local->sa.sa_family == AF_INET6)
 			stream_putw(s, htons(peer->su_local->sin6.sin6_port));
 		else if (peer->su_local->sa.sa_family == AF_INET)
 			stream_putw(s, htons(peer->su_local->sin.sin_port));
-		if (peer->su_remote->sa.sa_family == AF_INET6)
+
+		if (is_locrib)
+			stream_putw(s, 0);
+		else if (peer->su_remote->sa.sa_family == AF_INET6)
 			stream_putw(s, htons(peer->su_remote->sin6.sin6_port));
 		else if (peer->su_remote->sa.sa_family == AF_INET)
 			stream_putw(s, htons(peer->su_remote->sin.sin_port));
 
+		/* TODO craft message with fields & capabilities for loc-rib */
 		static const uint8_t dummy_open[] = {
 			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -510,31 +555,39 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 		type_pos = stream_get_endp(s);
 		stream_putc(s, 0);	/* placeholder for down reason */
 
-		switch (peer->last_reset) {
-		case PEER_DOWN_NOTIFY_RECEIVED:
-			type = BMP_PEERDOWN_REMOTE_NOTIFY;
-			bmp_notify_put(s, &peer->notify);
-			break;
-		case PEER_DOWN_CLOSE_SESSION:
-			type = BMP_PEERDOWN_REMOTE_CLOSE;
-			break;
-		case PEER_DOWN_WAITING_NHT:
-			type = BMP_PEERDOWN_LOCAL_FSM;
-			stream_putw(s, BGP_FSM_TcpConnectionFails);
-			break;
-		/*
-		 * TODO: Map remaining PEER_DOWN_* reasons to RFC event codes.
-		 * TODO: Implement BMP_PEERDOWN_LOCAL_NOTIFY.
-		 *
-		 * See RFC7854 ss. 4.9
-		 */
-		default:
-			type = BMP_PEERDOWN_LOCAL_FSM;
-			stream_putw(s, BMP_PEER_DOWN_NO_RELEVANT_EVENT_CODE);
-			break;
+		if (is_locrib) {
+			type = BMP_PEERDOWN_LOCAL_TLV;
+		} else {
+			switch (peer->last_reset) {
+			case PEER_DOWN_NOTIFY_RECEIVED:
+				type = BMP_PEERDOWN_REMOTE_NOTIFY;
+				bmp_notify_put(s, &peer->notify);
+				break;
+			case PEER_DOWN_CLOSE_SESSION:
+				type = BMP_PEERDOWN_REMOTE_CLOSE;
+				break;
+			case PEER_DOWN_WAITING_NHT:
+				type = BMP_PEERDOWN_LOCAL_FSM;
+				stream_putw(s, BGP_FSM_TcpConnectionFails);
+				break;
+			/*
+			 * TODO: Map remaining PEER_DOWN_* reasons to RFC event
+			 * codes.
+			 * TODO: Implement BMP_PEERDOWN_LOCAL_NOTIFY.
+			 *
+			 * See RFC7854 ss. 4.9
+			 */
+			default:
+				type = BMP_PEERDOWN_LOCAL_FSM;
+				stream_putw(s, BMP_PEER_DOWN_NO_RELEVANT_EVENT_CODE);
+				break;
+			}
 		}
 		stream_putc_at(s, type_pos, type);
 	}
+
+	if (is_locrib)
+		bmp_put_vrftablename_info_tlv(s, peer->bgp);
 
 	len = stream_get_endp(s);
 	stream_putl_at(s, BMP_LENGTH_POS, len); /* message length is set. */
@@ -558,6 +611,25 @@ static int bmp_send_peerup(struct bmp *bmp)
 	return 0;
 }
 
+static int bmp_send_peerup_vrf(struct bmp *bmp)
+{
+	struct bmp_bgp *bmpbgp = bmp->targets->bmpbgp;
+	struct stream *s;
+
+	/* send unconditionally because state may has been set before the
+	 * session was up. and in this case the peer up has not been sent.
+	 */
+	bmp_bgp_update_vrf_status(bmpbgp, vrf_state_unknown);
+
+	s = bmp_peerstate(bmpbgp->bgp->peer_self, bmpbgp->vrf_state == vrf_state_down);
+
+	pullwr_write_stream(bmp->pullwr, s);
+	stream_free(s);
+
+	return 0;
+}
+
+/* send a stream to all bmp sessions configured in a bgp instance */
 /* XXX: kludge - filling the pullwr's buffer */
 static void bmp_send_all(struct bmp_bgp *bmpbgp, struct stream *s)
 {
@@ -568,6 +640,16 @@ static void bmp_send_all(struct bmp_bgp *bmpbgp, struct stream *s)
 		frr_each(bmp_session, &bt->sessions, bmp)
 			pullwr_write_stream(bmp->pullwr, s);
 	stream_free(s);
+}
+
+static void bmp_send_all_safe(struct bmp_bgp *bmpbgp, struct stream *s)
+{
+	if (!bmpbgp) {
+		stream_free(s);
+		return;
+	}
+
+	bmp_send_all(bmpbgp, s);
 }
 
 /*
@@ -816,7 +898,7 @@ static int bmp_peer_status_changed(struct peer *peer)
 		}
 	}
 
-	bmp_send_all(bmpbgp, bmp_peerstate(peer, false));
+	bmp_send_all_safe(bmpbgp, bmp_peerstate(peer, false));
 	return 0;
 }
 
@@ -838,7 +920,7 @@ static int bmp_peer_backward(struct peer *peer)
 		bbpeer->open_rx_len = 0;
 	}
 
-	bmp_send_all(bmpbgp, bmp_peerstate(peer, true));
+	bmp_send_all_safe(bmpbgp, bmp_peerstate(peer, true));
 	return 0;
 }
 
@@ -1476,6 +1558,7 @@ static void bmp_wrfill(struct bmp *bmp, struct pullwr *pullwr)
 {
 	switch(bmp->state) {
 	case BMP_PeerUp:
+		bmp_send_peerup_vrf(bmp);
 		bmp_send_peerup(bmp);
 		bmp->state = BMP_Run;
 		break;
@@ -1839,6 +1922,7 @@ static struct bmp_bgp *bmp_bgp_get(struct bgp *bgp)
 
 	bmpbgp = XCALLOC(MTYPE_BMP, sizeof(*bmpbgp));
 	bmpbgp->bgp = bgp;
+	bmpbgp->vrf_state = vrf_state_unknown;
 	bmpbgp->mirror_qsizelimit = ~0UL;
 	bmp_mirrorq_init(&bmpbgp->mirrorq);
 	bmp_bgph_add(&bmp_bgph, bmpbgp);
@@ -1871,6 +1955,79 @@ static int bmp_bgp_del(struct bgp *bgp)
 	if (bmpbgp)
 		bmp_bgp_put(bmpbgp);
 	return 0;
+}
+
+static void bmp_bgp_peer_vrf(struct bmp_bgp_peer *bbpeer, struct bgp *bgp)
+{
+	struct peer *peer = bgp->peer_self;
+	uint16_t send_holdtime;
+	as_t local_as;
+
+	if (CHECK_FLAG(peer->flags, PEER_FLAG_TIMER))
+		send_holdtime = peer->holdtime;
+	else
+		send_holdtime = peer->bgp->default_holdtime;
+
+	/* local-as Change */
+	if (peer->change_local_as)
+		local_as = peer->change_local_as;
+	else
+		local_as = peer->local_as;
+
+	struct stream *s = bgp_open_make(peer, send_holdtime, local_as);
+	size_t open_len = stream_get_endp(s);
+
+	bbpeer->open_rx_len = open_len;
+	bbpeer->open_rx = XMALLOC(MTYPE_BMP_OPEN, open_len);
+	memcpy(bbpeer->open_rx, s->data, open_len);
+
+	bbpeer->open_tx_len = open_len;
+	bbpeer->open_tx = bbpeer->open_rx;
+}
+
+/* update the vrf status of the bmpbgp struct for vrf peer up/down
+ *
+ * if force is unknown, use zebra vrf state
+ *
+ * returns true if state has changed
+ */
+bool bmp_bgp_update_vrf_status(struct bmp_bgp *bmpbgp, enum bmp_vrf_state force)
+{
+	enum bmp_vrf_state old_state;
+	struct bmp_bgp_peer *bbpeer;
+	struct peer *peer;
+	struct vrf *vrf;
+	struct bgp *bgp;
+	bool changed;
+
+	if (!bmpbgp || !bmpbgp->bgp)
+		return false;
+
+	bgp = bmpbgp->bgp;
+	old_state = bmpbgp->vrf_state;
+
+	vrf = bgp_vrf_lookup_by_instance_type(bgp);
+	bmpbgp->vrf_state = force != vrf_state_unknown ? force
+			    : vrf_is_enabled(vrf)      ? vrf_state_up
+						       : vrf_state_down;
+
+	changed = old_state != bmpbgp->vrf_state;
+	if (changed) {
+		peer = bmpbgp->bgp->peer_self;
+		if (bmpbgp->vrf_state == vrf_state_up) {
+			bbpeer = bmp_bgp_peer_get(peer);
+			bmp_bgp_peer_vrf(bbpeer, bgp);
+		} else {
+			bbpeer = bmp_bgp_peer_find(peer->qobj_node.nid);
+			if (bbpeer) {
+				XFREE(MTYPE_BMP_OPEN, bbpeer->open_rx);
+				bmp_peerh_del(&bmp_peerh, bbpeer);
+				XFREE(MTYPE_BMP_PEER, bbpeer);
+			}
+		}
+	}
+
+	return changed;
 }
 
 static struct bmp_bgp_peer *bmp_bgp_peer_find(uint64_t peerid)
@@ -2953,6 +3110,44 @@ static int bgp_bmp_early_fini(void)
 	return 0;
 }
 
+/* called when a bgp instance goes up/down, implying that the underlying VRF
+ * has been created or deleted in zebra
+ */
+static int bmp_vrf_state_changed(struct bgp *bgp)
+{
+	struct bmp_bgp *bmpbgp = bmp_bgp_find(bgp);
+
+	if (!bmp_bgp_update_vrf_status(bmpbgp, vrf_state_unknown))
+		return 1;
+
+	bmp_send_all_safe(bmpbgp,
+			  bmp_peerstate(bgp->peer_self, bmpbgp->vrf_state == vrf_state_down));
+
+	return 0;
+}
+
+/* called when an interface goes up/down in a vrf, this may signal that the
+ * VRF changed state and is how bgp_snmp detects vrf state changes
+ */
+static int bmp_vrf_itf_state_changed(struct bgp *bgp, struct interface *itf)
+{
+	struct bmp_bgp *bmpbgp;
+	enum bmp_vrf_state new_state;
+
+	/* if the update is not about the vrf device double-check
+	 * the zebra status of the vrf
+	 */
+	if (!itf || !if_is_vrf(itf))
+		return bmp_vrf_state_changed(bgp);
+
+	bmpbgp = bmp_bgp_find(bgp);
+	new_state = if_is_up(itf) ? vrf_state_up : vrf_state_down;
+	if (bmp_bgp_update_vrf_status(bmpbgp, new_state))
+		bmp_send_all(bmpbgp, bmp_peerstate(bgp->peer_self, new_state == vrf_state_down));
+
+	return 0;
+}
+
 static int bgp_bmp_module_init(void)
 {
 	hook_register(bgp_packet_dump, bmp_mirror_packet);
@@ -2965,6 +3160,8 @@ static int bgp_bmp_module_init(void)
 	hook_register(frr_late_init, bgp_bmp_init);
 	hook_register(bgp_route_update, bmp_route_update);
 	hook_register(frr_early_fini, bgp_bmp_early_fini);
+	hook_register(bgp_instance_state, bmp_vrf_state_changed);
+	hook_register(bgp_vrf_status_changed, bmp_vrf_itf_state_changed);
 	return 0;
 }
 

--- a/bgpd/bgp_bmp.h
+++ b/bgpd/bgp_bmp.h
@@ -268,10 +268,19 @@ PREDECL_HASH(bmp_bgph);
 
 #define BMP_PEER_DOWN_NO_RELEVANT_EVENT_CODE 0x00
 
+enum bmp_vrf_state {
+	vrf_state_down = -1,
+	vrf_state_unknown = 0,
+	vrf_state_up = 1,
+};
+
 struct bmp_bgp {
 	struct bmp_bgph_item bbi;
 
 	struct bgp *bgp;
+
+	enum bmp_vrf_state vrf_state;
+
 	struct bmp_targets_head targets;
 
 	struct bmp_mirrorq_head mirrorq;
@@ -280,12 +289,17 @@ struct bmp_bgp {
 	size_t mirror_qsizelimit;
 };
 
+extern bool bmp_bgp_update_vrf_status(struct bmp_bgp *bmpbgp, enum bmp_vrf_state force);
+
 enum {
-	BMP_PEERDOWN_LOCAL_NOTIFY       = 1,
-	BMP_PEERDOWN_LOCAL_FSM          = 2,
-	BMP_PEERDOWN_REMOTE_NOTIFY      = 3,
-	BMP_PEERDOWN_REMOTE_CLOSE       = 4,
-	BMP_PEERDOWN_ENDMONITOR         = 5,
+	/* RFC7854 - 10.8 */
+	BMP_PEERDOWN_LOCAL_NOTIFY = 1,
+	BMP_PEERDOWN_LOCAL_FSM = 2,
+	BMP_PEERDOWN_REMOTE_NOTIFY = 3,
+	BMP_PEERDOWN_REMOTE_CLOSE = 4,
+	BMP_PEERDOWN_ENDMONITOR = 5,
+	/* RFC9069 - 8.4 */
+	BMP_PEERDOWN_LOCAL_TLV = 6,
 };
 
 enum {

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -43,6 +43,7 @@ DECLARE_HOOK(bgp_packet_send,
 
 /* Packet send and receive function prototypes. */
 extern void bgp_keepalive_send(struct peer *peer);
+extern struct stream *bgp_open_make(struct peer *peer, uint16_t send_holdtime, as_t local_as);
 extern void bgp_open_send(struct peer_connection *connection);
 extern void bgp_notify_send(struct peer_connection *connection, uint8_t code,
 			    uint8_t sub_code);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -85,6 +85,7 @@ DEFINE_QOBJ_TYPE(bgp_master);
 DEFINE_QOBJ_TYPE(bgp);
 DEFINE_QOBJ_TYPE(peer);
 DEFINE_HOOK(bgp_inst_delete, (struct bgp *bgp), (bgp));
+DEFINE_HOOK(bgp_instance_state, (struct bgp *bgp), (bgp));
 
 /* BGP process wide configuration.  */
 static struct bgp_master bgp_master;
@@ -3929,6 +3930,9 @@ void bgp_instance_up(struct bgp *bgp)
 	struct peer *peer;
 	struct listnode *node, *next;
 
+	/* notify BMP of instance state changed */
+	hook_call(bgp_instance_state, bgp);
+
 	bgp_set_redist_vrf_bitmaps(bgp, true);
 
 	/* Register with zebra. */
@@ -3956,6 +3960,9 @@ void bgp_instance_down(struct bgp *bgp)
 
 	/* Cleanup evpn instance state */
 	bgp_evpn_instance_down(bgp);
+
+	/* notify BMP of instance state changed */
+	hook_call(bgp_instance_state, bgp);
 
 	/* Stop timers. */
 	if (bgp->t_rmap_def_originate_eval)

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -880,6 +880,7 @@ DECLARE_HOOK(bgp_snmp_traps_config_write, (struct vty *vty), (vty));
 DECLARE_HOOK(bgp_config_end, (struct bgp *bgp), (bgp));
 DECLARE_HOOK(bgp_hook_vrf_update, (struct vrf *vrf, bool enabled),
 	     (vrf, enabled));
+DECLARE_HOOK(bgp_instance_state, (struct bgp *bgp), (bgp));
 
 /* Thread callback information */
 struct afi_safi_info {

--- a/tests/topotests/bgp_bmp/test_bgp_bmp.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp.py
@@ -234,15 +234,11 @@ def vpn_prefixes(policy):
 
     prefixes = ["172.31.10.1/32", "2001::2222/128"]
 
-    if policy == PRE_POLICY:
-        # labels are not yet supported in adj-RIB-in. Do not test for the moment
-        labels = None
-    else:
-        # "label vpn export" value in r2/bgpd.conf
-        labels = {
-            "172.31.10.1/32": 102,
-            "2001::2222/128": 105,
-        }
+    # "label vpn export" value in r2/bgpd.conf
+    labels = {
+        "172.31.10.1/32": 102,
+        "2001::2222/128": 105,
+    }
 
     # add prefixes
     configure_prefixes(tgen, "r2", 65502, "unicast", prefixes, vrf="vrf1")

--- a/tests/topotests/bgp_bmp_vrf/r1/bgpd.conf
+++ b/tests/topotests/bgp_bmp_vrf/r1/bgpd.conf
@@ -1,0 +1,23 @@
+router bgp 65501 vrf vrf1
+ bgp router-id 192.168.0.1
+ bgp log-neighbor-changes
+ no bgp ebgp-requires-policy
+ neighbor 192.168.0.2 remote-as 65502
+ neighbor 192:168::2 remote-as 65502
+!
+ bmp targets bmp1
+  bmp connect 192.0.2.10 port 1789 min-retry 100 max-retry 10000
+ exit
+!
+
+ address-family ipv4 unicast
+  neighbor 192.168.0.2 activate
+  neighbor 192.168.0.2 soft-reconfiguration inbound
+  no neighbor 192:168::2 activate
+ exit-address-family
+!
+ address-family ipv6 unicast
+  neighbor 192:168::2 activate
+  neighbor 192:168::2 soft-reconfiguration inbound
+ exit-address-family
+!

--- a/tests/topotests/bgp_bmp_vrf/r1/zebra.conf
+++ b/tests/topotests/bgp_bmp_vrf/r1/zebra.conf
@@ -1,0 +1,7 @@
+interface r1-eth0
+ ip address 192.0.2.1/24
+!
+interface r1-eth1
+ ip address 192.168.0.1/24
+ ipv6 address 192:168::1/64
+!

--- a/tests/topotests/bgp_bmp_vrf/r2/bgpd.conf
+++ b/tests/topotests/bgp_bmp_vrf/r2/bgpd.conf
@@ -1,0 +1,19 @@
+router bgp 65502
+ bgp router-id 192.168.0.2
+ bgp log-neighbor-changes
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.0.1 remote-as 65501
+ neighbor 192:168::1 remote-as 65501
+!
+ address-family ipv4 unicast
+  neighbor 192.168.0.1 activate
+  no neighbor 192:168::1 activate
+  redistribute connected
+ exit-address-family
+!
+ address-family ipv6 unicast
+  neighbor 192:168::1 activate
+  redistribute connected
+ exit-address-family
+!

--- a/tests/topotests/bgp_bmp_vrf/r2/zebra.conf
+++ b/tests/topotests/bgp_bmp_vrf/r2/zebra.conf
@@ -1,0 +1,8 @@
+interface r2-eth0
+ ip address 192.168.0.2/24
+ ipv6 address 192:168::2/64
+!
+interface r2-eth1
+ ip address 172.31.0.2/24
+ ipv6 address 172:31::2/64
+!

--- a/tests/topotests/bgp_bmp_vrf/test_bgp_bmp_vrf.py
+++ b/tests/topotests/bgp_bmp_vrf/test_bgp_bmp_vrf.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright 2023 6WIND S.A.
+# Authored by Farid Mihoub <farid.mihoub@6wind.com>
+#
+
+"""
+test_bgp_bmp.py: Test BGP BMP functionalities
+
+    +------+            +------+               +------+
+    |      |            |      |               |      |
+    | BMP1 |------------|  R1  |---------------|  R2  |
+    |      |            |      |               |      |
+    +------+            +------+               +------+
+
+Setup two routers R1 and R2 with one link configured with IPv4 and
+IPv6 addresses.
+Configure BGP in R1 and R2 to exchange prefixes from
+the latter to the first router.
+Setup a link between R1 and the BMP server, activate the BMP feature in R1
+and ensure the monitored BGP sessions logs are well present on the BMP server.
+"""
+
+from functools import partial
+from ipaddress import ip_network
+import json
+import os
+import platform
+import pytest
+import sys
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join("../"))
+sys.path.append(os.path.join("../lib/"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.bgp import verify_bgp_convergence_from_running_config
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.bgpd]
+
+# remember the last sequence number of the logging messages
+SEQ = 0
+
+PRE_POLICY = "pre-policy"
+POST_POLICY = "post-policy"
+LOC_RIB = "loc-rib"
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+    tgen.add_bmp_server("bmp1", ip="192.0.2.10", defaultRoute="via 192.0.2.1")
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["bmp1"])
+
+    tgen.add_link(tgen.gears["r1"], tgen.gears["r2"], "r1-eth1", "r2-eth0")
+
+
+def setup_module(mod):
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    tgen.net["r1"].cmd(
+        """
+ip link add vrf1 type vrf table 10
+ip link set vrf1 up
+ip link set r1-eth1 master vrf1
+"""
+    )
+
+    for rname, router in tgen.routers().items():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP,
+            os.path.join(CWD, "{}/bgpd.conf".format(rname)),
+            "-M bmp",
+        )
+
+    tgen.start_router()
+
+    logger.info("starting BMP servers")
+    for bmp_name, server in tgen.get_bmp_servers().items():
+        server.start(log_file=os.path.join(tgen.logdir, bmp_name, "bmp.log"))
+
+
+def teardown_module(_mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_convergence():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    result = verify_bgp_convergence_from_running_config(tgen, dut="r1")
+    assert result is True, "BGP is not converging"
+
+
+def get_bmp_messages():
+    """
+    Read the BMP logging messages.
+    """
+    messages = []
+    tgen = get_topogen()
+    text_output = tgen.gears["bmp1"].run(
+        "cat {}".format(os.path.join(tgen.logdir, "bmp1", "bmp.log"))
+    )
+
+    for m in text_output.splitlines():
+        # some output in the bash can break the message decoding
+        try:
+            messages.append(json.loads(m))
+        except Exception as e:
+            logger.warning(str(e) + " message: {}".format(str(m)))
+            continue
+
+    if not messages:
+        logger.error("Bad BMP log format, check your BMP server")
+
+    return messages
+
+
+def check_for_prefixes(expected_prefixes, bmp_log_type, policy, labels=None):
+    """
+    Check for the presence of the given prefixes in the BMP server logs with
+    the given message type and the set policy.
+    """
+    global SEQ
+    # we care only about the new messages
+    messages = [
+        m for m in sorted(get_bmp_messages(), key=lambda d: d["seq"]) if m["seq"] > SEQ
+    ]
+
+    # get the list of pairs (prefix, policy, seq) for the given message type
+    prefixes = [
+        m["ip_prefix"]
+        for m in messages
+        if "ip_prefix" in m.keys()
+        and "bmp_log_type" in m.keys()
+        and m["bmp_log_type"] == bmp_log_type
+        and m["policy"] == policy
+        and (
+            labels is None
+            or (
+                m["ip_prefix"] in labels.keys() and m["label"] == labels[m["ip_prefix"]]
+            )
+        )
+    ]
+
+    # check for prefixes
+    for ep in expected_prefixes:
+        if ep not in prefixes:
+            msg = "The prefix {} is not present in the {} log messages."
+            logger.debug(msg.format(ep, bmp_log_type))
+            return False
+
+    SEQ = messages[-1]["seq"]
+    return True
+
+
+def check_for_peer_message(expected_peers, bmp_log_type):
+    """
+    Check for the presence of a peer up message for the peer
+    """
+    global SEQ
+    # we care only about the new messages
+    messages = [
+        m for m in sorted(get_bmp_messages(), key=lambda d: d["seq"]) if m["seq"] > SEQ
+    ]
+
+    # get the list of pairs (prefix, policy, seq) for the given message type
+    peers = [
+        m["peer_ip"]
+        for m in messages
+        if "peer_ip" in m.keys() and m["bmp_log_type"] == bmp_log_type
+    ]
+
+    # check for prefixes
+    for ep in expected_peers:
+        if ep not in peers:
+            msg = "The peer {} is not present in the {} log messages."
+            logger.debug(msg.format(ep, bmp_log_type))
+            return False
+
+    SEQ = messages[-1]["seq"]
+    return True
+
+
+def set_bmp_policy(tgen, node, asn, target, safi, policy, vrf=None):
+    """
+    Configure the bmp policy.
+    """
+    vrf = " vrf {}".format(vrf) if vrf else ""
+    cmd = [
+        "con t\n",
+        "router bgp {}{}\n".format(asn, vrf),
+        "bmp targets {}\n".format(target),
+        "bmp monitor ipv4 {} {}\n".format(safi, policy),
+        "bmp monitor ipv6 {} {}\n".format(safi, policy),
+        "end\n",
+    ]
+    tgen.gears[node].vtysh_cmd("".join(cmd))
+
+
+def configure_prefixes(tgen, node, asn, safi, prefixes, vrf=None, update=True):
+    """
+    Configure the bgp prefixes.
+    """
+    withdraw = "no " if not update else ""
+    vrf = " vrf {}".format(vrf) if vrf else ""
+    for p in prefixes:
+        ip = ip_network(p)
+        cmd = [
+            "conf t\n",
+            "router bgp {}{}\n".format(asn, vrf),
+            "address-family ipv{} {}\n".format(ip.version, safi),
+            "{}network {}\n".format(withdraw, ip),
+            "exit-address-family\n",
+        ]
+        logger.debug("setting prefix: ipv{} {} {}".format(ip.version, safi, ip))
+        tgen.gears[node].vtysh_cmd("".join(cmd))
+
+
+def unicast_prefixes(policy):
+    """
+    Setup the BMP  monitor policy, Add and withdraw ipv4/v6 prefixes.
+    Check if the previous actions are logged in the BMP server with the right
+    message type and the right policy.
+    """
+    tgen = get_topogen()
+    set_bmp_policy(tgen, "r1", 65501, "bmp1", "unicast", policy, vrf="vrf1")
+
+    prefixes = ["172.31.0.15/32", "2111::1111/128"]
+    # add prefixes
+    configure_prefixes(tgen, "r2", 65502, "unicast", prefixes)
+
+    logger.info("checking for updated prefixes")
+    # check
+    test_func = partial(check_for_prefixes, prefixes, "update", policy)
+    success, _ = topotest.run_and_expect(test_func, True, wait=0.5)
+    assert success, "Checking the updated prefixes has been failed !."
+
+    # withdraw prefixes
+    configure_prefixes(tgen, "r2", 65502, "unicast", prefixes, update=False)
+    logger.info("checking for withdrawed prefxies")
+    # check
+    test_func = partial(check_for_prefixes, prefixes, "withdraw", policy)
+    success, _ = topotest.run_and_expect(test_func, True, wait=0.5)
+    assert success, "Checking the withdrawed prefixes has been failed !."
+
+
+def test_bmp_server_logging():
+    """
+    Assert the logging of the bmp server.
+    """
+
+    def check_for_log_file():
+        tgen = get_topogen()
+        output = tgen.gears["bmp1"].run(
+            "ls {}".format(os.path.join(tgen.logdir, "bmp1"))
+        )
+        if "bmp.log" not in output:
+            return False
+        return True
+
+    success, _ = topotest.run_and_expect(check_for_log_file, True, wait=0.5)
+    assert success, "The BMP server is not logging"
+
+
+def test_peer_up():
+    """
+    Checking for BMP peers up messages
+    """
+
+    peers = ["192.168.0.2", "192:168::2"]
+
+    logger.info("checking for BMP peers up messages")
+
+    test_func = partial(check_for_peer_message, peers, "peer up")
+    success, _ = topotest.run_and_expect(test_func, True, wait=0.5)
+    assert success, "Checking the updated prefixes has been failed !."
+
+
+def test_bmp_bgp_unicast():
+    """
+    Add/withdraw bgp unicast prefixes and check the bmp logs.
+    """
+    logger.info("*** Unicast prefixes pre-policy logging ***")
+    unicast_prefixes(PRE_POLICY)
+    logger.info("*** Unicast prefixes post-policy logging ***")
+    unicast_prefixes(POST_POLICY)
+    logger.info("*** Unicast prefixes loc-rib logging ***")
+    unicast_prefixes(LOC_RIB)
+
+
+def test_peer_down():
+    """
+    Checking for BMP peers down messages
+    """
+    tgen = get_topogen()
+
+    tgen.gears["r2"].vtysh_cmd("clear bgp *")
+
+    peers = ["192.168.0.2", "192:168::2"]
+
+    logger.info("checking for BMP peers down messages")
+
+    test_func = partial(check_for_peer_message, peers, "peer down")
+    success, _ = topotest.run_and_expect(test_func, True, wait=0.5)
+    assert success, "Checking the updated prefixes has been failed !."
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/lib/bmp_collector/bmp.py
+++ b/tests/topotests/lib/bmp_collector/bmp.py
@@ -316,7 +316,8 @@ class BMPStatisticsReport:
 
 
 # ------------------------------------------------------------------------------
-class BMPPeerDownNotification:
+@BMPMsg.register_msg_type(BMPCodes.BMP_MSG_TYPE_PEER_DOWN_NOTIFICATION)
+class BMPPeerDownNotification(BMPPerPeerMessage):
     """
     0 1 2 3 4 5 6 7 8 1 2 3 4 5 6 7 8 1 2 3 4 5 6 7 8 1 2 3 4 5 6 7 8
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -326,7 +327,20 @@ class BMPPeerDownNotification:
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     """
 
-    pass
+    @classmethod
+    def dissect(cls, data):
+        data, peer_msg = super().dissect(data)
+
+        msg = {
+            **peer_msg,
+            **{
+                "bmp_log_type": "peer down",
+            },
+        }
+
+        # XXX: dissect the bgp open message
+
+        return msg
 
 
 # ------------------------------------------------------------------------------

--- a/tests/topotests/lib/bmp_collector/bmp.py
+++ b/tests/topotests/lib/bmp_collector/bmp.py
@@ -360,6 +360,7 @@ class BMPPeerUpNotification(BMPPerPeerMessage):
         msg = {
             **peer_msg,
             **{
+                "bmp_log_type": "peer up",
                 "local_ip": bin2str_ipaddress(local_addr, peer_msg.get("ipv6")),
                 "local_port": int(local_port),
                 "remote_port": int(remote_port),


### PR DESCRIPTION
added bmp bgp peer for vrfs
added peer up vrf in bmp peer up state
added vrf state in bmpbgp
added safe bmp_peer_sendall : bmp_peer_sendall_safe
changed bgp_open_send to call new bgp_open_make
bgp_open_make creates a bgp open packet, now used in bmp for peer up vrf
added hook and call to bgp instance state
vrf peer state is recomputed when interfaces (including vrf itf) go up / down
and when it gets created or removed

Link: https://github.com/mxyns/frr/commit/e48ba380700d53124131f4e4419f646c05b40c86
Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>
Signed-off-by: Maxence Younsi <mx.yns@outlook.fr>