### PR TITLE
bfdd, yang: change bfd timer and multiplier values

### DIFF
--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -338,7 +338,7 @@ void bfd_cli_show_minimum_ttl(struct vty *vty, const struct lyd_node *dnode,
 
 DEFPY_YANG(
 	bfd_peer_mult, bfd_peer_mult_cmd,
-	"[no] detect-multiplier ![(2-255)$multiplier]",
+	"[no] detect-multiplier ![(1-255)$multiplier]",
 	NO_STR
 	"Configure peer detection multiplier\n"
 	"Configure peer detection multiplier value\n")
@@ -357,7 +357,7 @@ void bfd_cli_show_mult(struct vty *vty, const struct lyd_node *dnode,
 
 DEFPY_YANG(
 	bfd_peer_rx, bfd_peer_rx_cmd,
-	"[no] receive-interval ![(10-60000)$interval]",
+	"[no] receive-interval ![(10-4294967)$interval]",
 	NO_STR
 	"Configure peer receive interval\n"
 	"Configure peer receive interval value in milliseconds\n")
@@ -381,7 +381,7 @@ void bfd_cli_show_rx(struct vty *vty, const struct lyd_node *dnode,
 
 DEFPY_YANG(
 	bfd_peer_tx, bfd_peer_tx_cmd,
-	"[no] transmit-interval ![(10-60000)$interval]",
+	"[no] transmit-interval ![(10-4294967)$interval]",
 	NO_STR
 	"Configure peer transmit interval\n"
 	"Configure peer transmit interval value in milliseconds\n")
@@ -439,7 +439,7 @@ void bfd_cli_show_echo(struct vty *vty, const struct lyd_node *dnode,
 
 DEFPY_YANG(
 	bfd_peer_echo_interval, bfd_peer_echo_interval_cmd,
-	"[no] echo-interval ![(10-60000)$interval]",
+	"[no] echo-interval ![(10-4294967)$interval]",
 	NO_STR
 	"Configure peer echo intervals\n"
 	"Configure peer echo rx/tx intervals value in milliseconds\n")
@@ -462,7 +462,7 @@ DEFPY_YANG(
 
 DEFPY_YANG(
 	bfd_peer_echo_transmit_interval, bfd_peer_echo_transmit_interval_cmd,
-	"[no] echo transmit-interval ![(10-60000)$interval]",
+	"[no] echo transmit-interval ![(10-4294967)$interval]",
 	NO_STR
 	"Configure peer echo intervals\n"
 	"Configure desired transmit interval\n"
@@ -492,7 +492,7 @@ void bfd_cli_show_desired_echo_transmission_interval(
 
 DEFPY_YANG(
 	bfd_peer_echo_receive_interval, bfd_peer_echo_receive_interval_cmd,
-	"[no] echo receive-interval ![<disabled$disabled|(10-60000)$interval>]",
+	"[no] echo receive-interval ![<disabled$disabled|(10-4294967)$interval>]",
 	NO_STR
 	"Configure peer echo intervals\n"
 	"Configure required receive interval\n"
@@ -577,19 +577,19 @@ void bfd_cli_show_profile(struct vty *vty, const struct lyd_node *dnode,
 }
 
 ALIAS_YANG(bfd_peer_mult, bfd_profile_mult_cmd,
-      "[no] detect-multiplier ![(2-255)$multiplier]",
+      "[no] detect-multiplier ![(1-255)$multiplier]",
       NO_STR
       "Configure peer detection multiplier\n"
       "Configure peer detection multiplier value\n")
 
 ALIAS_YANG(bfd_peer_tx, bfd_profile_tx_cmd,
-      "[no] transmit-interval ![(10-60000)$interval]",
+      "[no] transmit-interval ![(10-4294967)$interval]",
       NO_STR
       "Configure peer transmit interval\n"
       "Configure peer transmit interval value in milliseconds\n")
 
 ALIAS_YANG(bfd_peer_rx, bfd_profile_rx_cmd,
-      "[no] receive-interval ![(10-60000)$interval]",
+      "[no] receive-interval ![(10-4294967)$interval]",
       NO_STR
       "Configure peer receive interval\n"
       "Configure peer receive interval value in milliseconds\n")
@@ -621,14 +621,14 @@ ALIAS_YANG(bfd_peer_echo, bfd_profile_echo_cmd,
       "Configure echo mode\n")
 
 ALIAS_YANG(bfd_peer_echo_interval, bfd_profile_echo_interval_cmd,
-      "[no] echo-interval ![(10-60000)$interval]",
+      "[no] echo-interval ![(10-4294967)$interval]",
       NO_STR
       "Configure peer echo interval\n"
       "Configure peer echo interval value in milliseconds\n")
 
 ALIAS_YANG(
 	bfd_peer_echo_transmit_interval, bfd_profile_echo_transmit_interval_cmd,
-	"[no] echo transmit-interval ![(10-60000)$interval]",
+	"[no] echo transmit-interval ![(10-4294967)$interval]",
 	NO_STR
 	"Configure peer echo intervals\n"
 	"Configure desired transmit interval\n"
@@ -636,7 +636,7 @@ ALIAS_YANG(
 
 ALIAS_YANG(
 	bfd_peer_echo_receive_interval, bfd_profile_echo_receive_interval_cmd,
-	"[no] echo receive-interval ![<disabled$disabled|(10-60000)$interval>]",
+	"[no] echo receive-interval ![<disabled$disabled|(10-4294967)$interval>]",
 	NO_STR
 	"Configure peer echo intervals\n"
 	"Configure required receive interval\n"

--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -139,7 +139,7 @@ Peer / Profile Configuration
 
 BFD peers and profiles share the same BFD session configuration commands.
 
-.. clicmd:: detect-multiplier (2-255)
+.. clicmd:: detect-multiplier (1-255)
 
    Configures the detection multiplier to determine packet loss. The
    remote transmission interval will be multiplied by this value to
@@ -151,23 +151,23 @@ BFD peers and profiles share the same BFD session configuration commands.
    detect failures only after 900 milliseconds without receiving
    packets.
 
-.. clicmd:: receive-interval (10-60000)
+.. clicmd:: receive-interval (10-4294967)
 
    Configures the minimum interval that this system is capable of
    receiving control packets. The default value is 300 milliseconds.
 
-.. clicmd:: transmit-interval (10-60000)
+.. clicmd:: transmit-interval (10-4294967)
 
    The minimum transmission interval (less jitter) that this system
    wants to use to send BFD control packets. Defaults to 300ms.
 
-.. clicmd:: echo receive-interval <disabled|(10-60000)>
+.. clicmd:: echo receive-interval <disabled|(10-4294967)>
 
    Configures the minimum interval that this system is capable of
    receiving echo packets. Disabled means that this system doesn't want
    to receive echo packets. The default value is 50 milliseconds.
 
-.. clicmd:: echo transmit-interval (10-60000)
+.. clicmd:: echo transmit-interval (10-4294967)
 
    The minimum transmission interval (less jitter) that this system
    wants to use to send BFD echo packets. Defaults to 50ms.

--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -65,7 +65,7 @@ module frr-bfdd {
   typedef multiplier {
     description "Detection multiplier";
     type uint8 {
-      range "2..255";
+      range "1..255";
     }
   }
 
@@ -169,7 +169,7 @@ module frr-bfdd {
 
     leaf desired-transmission-interval {
       type uint32 {
-          range "10000..60000000";
+          range "10000..max";
       }
       units microseconds;
       default 300000;
@@ -178,7 +178,7 @@ module frr-bfdd {
 
     leaf required-receive-interval {
       type uint32 {
-          range "10000..60000000";
+          range "10000..max";
       }
       units microseconds;
       default 300000;
@@ -210,7 +210,7 @@ module frr-bfdd {
 
     leaf desired-echo-transmission-interval {
       type uint32 {
-          range "10000..60000000";
+          range "10000..max";
       }
       units microseconds;
       default 50000;
@@ -219,7 +219,7 @@ module frr-bfdd {
 
     leaf required-echo-receive-interval {
       type uint32 {
-          range "0 | 10000..60000000";
+          range "0 | 10000..max";
       }
       units microseconds;
       default 50000;


### PR DESCRIPTION
The minimum and maximum values for BFD timers and multiplier settings have been updated to align with RFC 5880 requirements.

Since the values inputted via VTY are in milliseconds, the maximum permissible value on the VTY interface is 4,294,967 milliseconds.

For the multiplier setting, the minimum value is now restricted to be greater than zero, as zero is not allowed.

The minimum transmit interval has been set to 10 milliseconds to ensure reliable service performance.