### PR TITLE
tools: fix some special commands for reloading pim

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1163,7 +1163,12 @@ def pim_delete_move_lines(lines_to_add, lines_to_del):
             ctx_keys[0] in pim_disable
             and ctx_keys[0].startswith("interface")
             and line
-            and (line.startswith("ip pim ") or line.startswith("ip multicast "))
+            and (
+                line.startswith("ip pim ")
+                or line.startswith("no ip pim ")
+                or line.startswith("ip multicast ")
+                or line.startswith("no ip multicast ")
+            )
         ):
             lines_to_del_to_del.append((ctx_keys, line))
 


### PR DESCRIPTION
The issue is we can't remove all pim configurations including some special configurations (e.g., `no ip pim bsm`) for one interface.

For one pim-disable interface, all such pim depdendent options (including `ip pim ` and `no ip pim `) should be completely removed.

Also append `no ip multicast` for the same purpose, it is no use at present, but for future use.

The running config:
```
interface A
 ip pim
 no ip pim bsm
exit
```

Reload the new config:
```
interface A
exit
```

Before:
```
2024-10-05 20:52:33,467  INFO: Executed "interface A  no ip pim exit"
2024-10-05 20:52:33,482  INFO: Executed "interface A  ip pim bsm exit"
```
And the pim configurations in running configuration are not removed after reloading:
```
interface A
 ip pim <- Wrong
exit
```

After:
```
2024-10-05 20:56:27,489  INFO: Executed "interface A  no ip pim exit"
```
And all the pim configuration are removed.