### PR TITLE
isisd: fix wrong check for MT commands

### DIFF
--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -4297,14 +4297,6 @@ static int lib_interface_isis_multi_topology_common(
 
 	switch (event) {
 	case NB_EV_VALIDATE:
-		circuit = nb_running_get_entry(dnode, NULL, false);
-		if (circuit && circuit->area && circuit->area->oldmetric) {
-			snprintf(
-				errmsg, errmsg_len,
-				"Multi topology IS-IS can only be used with wide metrics");
-			return NB_ERR_VALIDATION;
-		}
-		break;
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;


### PR DESCRIPTION
```
anlan# show run
!
interface eth0
 ip router isis A
exit
!
router isis A
 metric-style narrow <- NOT wide
exit
!
end
anlan (config)# int eth0
anlan (config-if)# no isis topology ipv6-unicast
% Configuration failed.

Error type: validation
Error description: Multi topology IS-IS can only be used with wide metrics
```

The MT commands are mainly controlled by the binded area, not by interface. Currently if there is any MT configuration in the area, `metric-style` must be with the `wide` mode, this requirement is sufficient.  So, the unnecessary/wrong check for MT in the interface should be removed.