### PR TITLE
lib: add flag to have libyang load internal ietf-yang-library module

### DIFF
--- a/lib/grammar_sandbox_main.c
+++ b/lib/grammar_sandbox_main.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
 
 	vty_init(master, true);
 	lib_cmd_init();
-	nb_init(master, NULL, 0, false);
+	nb_init(master, NULL, 0, false, false);
 
 	vty_stdio(vty_do_exit);
 

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -820,7 +820,8 @@ struct event_loop *frr_init(void)
 	log_ref_vty_init();
 	lib_error_init();
 
-	nb_init(master, di->yang_modules, di->n_yang_modules, true);
+	nb_init(master, di->yang_modules, di->n_yang_modules, true,
+		(di->flags & FRR_LOAD_YANG_LIBRARY) != 0);
 	if (nb_db_init() != NB_OK)
 		flog_warn(EC_LIB_NB_DATABASE,
 			  "%s: failed to initialize northbound database",

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -46,6 +46,11 @@ extern "C" {
  * is responsible for calling frr_vty_serv() itself.
  */
 #define FRR_MANUAL_VTY_START (1 << 7)
+/* If FRR_LOAD_YANG_LIBRARY is set then libyang will be told to load and
+ * implement it's internal ietf-yang-library implementation. This should
+ * normally only be done from mgmtd.
+ */
+#define FRR_LOAD_YANG_LIBRARY (1 << 8)
 
 PREDECL_DLIST(log_args);
 struct log_arg {

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -2701,7 +2701,7 @@ void nb_validate_callbacks(void)
 
 void nb_init(struct event_loop *tm,
 	     const struct frr_yang_module_info *const modules[],
-	     size_t nmodules, bool db_enabled)
+	     size_t nmodules, bool db_enabled, bool load_library)
 {
 	struct yang_module *loaded[nmodules], **loadedp = loaded;
 
@@ -2717,7 +2717,7 @@ void nb_init(struct event_loop *tm,
 
 	nb_db_enabled = db_enabled;
 
-	yang_init(true, explicit_compile);
+	yang_init(true, explicit_compile, load_library);
 
 	/* Load YANG modules and their corresponding northbound callbacks. */
 	for (size_t i = 0; i < nmodules; i++) {

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -1703,10 +1703,12 @@ void nb_validate_callbacks(void);
  *
  * db_enabled
  *    Set this to record the transactions in the transaction log.
+ *
+ * load_library
+ *    Set this to have libyang to load/implement the ietf-yang-library.
  */
-extern void nb_init(struct event_loop *tm,
-		    const struct frr_yang_module_info *const modules[],
-		    size_t nmodules, bool db_enabled);
+extern void nb_init(struct event_loop *tm, const struct frr_yang_module_info *const modules[],
+		    size_t nmodules, bool db_enabled, bool load_library);
 
 /*
  * Finish the northbound layer gracefully. Should be called only when the daemon

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -976,7 +976,7 @@ void yang_debugging_set(bool enable)
 	}
 }
 
-struct ly_ctx *yang_ctx_new_setup(bool embedded_modules, bool explicit_compile)
+struct ly_ctx *yang_ctx_new_setup(bool embedded_modules, bool explicit_compile, bool load_library)
 {
 	struct ly_ctx *ctx = NULL;
 	const char *yang_models_path = YANG_MODELS_PATH;
@@ -994,7 +994,9 @@ struct ly_ctx *yang_ctx_new_setup(bool embedded_modules, bool explicit_compile)
 				     YANG_MODELS_PATH);
 	}
 
-	options = LY_CTX_NO_YANGLIBRARY | LY_CTX_DISABLE_SEARCHDIR_CWD;
+	options = LY_CTX_DISABLE_SEARCHDIR_CWD;
+	if (!load_library)
+		options |= LY_CTX_NO_YANGLIBRARY;
 	if (explicit_compile)
 		options |= LY_CTX_EXPLICIT_COMPILE;
 	err = ly_ctx_new(yang_models_path, options, &ctx);
@@ -1007,7 +1009,7 @@ struct ly_ctx *yang_ctx_new_setup(bool embedded_modules, bool explicit_compile)
 	return ctx;
 }
 
-void yang_init(bool embedded_modules, bool defer_compile)
+void yang_init(bool embedded_modules, bool defer_compile, bool load_library)
 {
 	/* Initialize libyang global parameters that affect all containers. */
 	ly_set_log_clb(ly_zlog_cb
@@ -1019,7 +1021,7 @@ void yang_init(bool embedded_modules, bool defer_compile)
 	ly_log_options(LY_LOLOG | LY_LOSTORE);
 
 	/* Initialize libyang container for native models. */
-	ly_native_ctx = yang_ctx_new_setup(embedded_modules, defer_compile);
+	ly_native_ctx = yang_ctx_new_setup(embedded_modules, defer_compile, load_library);
 	if (!ly_native_ctx) {
 		flog_err(EC_LIB_LIBYANG, "%s: ly_ctx_new() failed", __func__);
 		exit(1);

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -607,9 +607,11 @@ extern struct yang_data *yang_data_list_find(const struct list *list,
  * explicit_compile
  *    True if the caller will later call ly_ctx_compile to compile all loaded
  *    modules at once.
+ * load_library
+ *    Set this to have libyang to load/implement the ietf-yang-library.
  */
-extern struct ly_ctx *yang_ctx_new_setup(bool embedded_modules,
-					 bool explicit_compile);
+extern struct ly_ctx *yang_ctx_new_setup(bool embedded_modules, bool explicit_compile,
+					 bool load_library);
 
 /*
  * Enable or disable libyang verbose debugging.
@@ -727,8 +729,10 @@ extern const char *yang_print_errors(struct ly_ctx *ly_ctx, char *buf,
  *    Specify whether libyang should attempt to look for embedded YANG modules.
  * defer_compile
  *    Hold off on compiling modules until yang_init_loading_complete is called.
+ * load_library
+ *    Set this to have libyang to load/implement the ietf-yang-library.
  */
-extern void yang_init(bool embedded_modules, bool defer_compile);
+extern void yang_init(bool embedded_modules, bool defer_compile, bool load_library);
 
 /*
  * Should be called after yang_init and all yang_module_load()s have been done,

--- a/lib/yang_translator.c
+++ b/lib/yang_translator.c
@@ -166,7 +166,7 @@ struct yang_translator *yang_translator_load(const char *path)
 	RB_INSERT(yang_translators, &yang_translators, translator);
 
 	/* Initialize the translator libyang context. */
-	translator->ly_ctx = yang_ctx_new_setup(false, false);
+	translator->ly_ctx = yang_ctx_new_setup(false, false, false);
 	if (!translator->ly_ctx) {
 		flog_warn(EC_LIB_LIBYANG, "%s: ly_ctx_new() failed", __func__);
 		goto error;
@@ -512,7 +512,7 @@ static unsigned int yang_module_nodes_count(const struct lys_module *module)
 
 void yang_translator_init(void)
 {
-	ly_translator_ctx = yang_ctx_new_setup(true, false);
+	ly_translator_ctx = yang_ctx_new_setup(true, false, false);
 	if (!ly_translator_ctx) {
 		flog_err(EC_LIB_LIBYANG, "%s: ly_ctx_new() failed", __func__);
 		exit(1);

--- a/mgmtd/mgmt.c
+++ b/mgmtd/mgmt.c
@@ -57,9 +57,6 @@ void mgmt_init(void)
 	/* Initialize MGMTD Transaction module */
 	mgmt_txn_init(mm, mm->master);
 
-	/* Add yang-library module */
-	yang_module_load("ietf-yang-library", NULL);
-
 	/* Initialize the MGMTD Frontend Adapter Module */
 	mgmt_fe_adapter_init(mm->master);
 

--- a/mgmtd/mgmt_main.c
+++ b/mgmtd/mgmt_main.c
@@ -214,7 +214,7 @@ FRR_DAEMON_INFO(mgmtd, MGMTD,
 		.n_yang_modules = array_size(mgmt_yang_modules),
 
 		/* avoid libfrr trying to read our config file for us */
-		.flags = FRR_MANUAL_VTY_START | FRR_NO_SPLIT_CONFIG,
+		.flags = FRR_MANUAL_VTY_START | FRR_NO_SPLIT_CONFIG | FRR_LOAD_YANG_LIBRARY,
 	);
 /* clang-format on */
 

--- a/tests/bgpd/test_peer_attr.c
+++ b/tests/bgpd/test_peer_attr.c
@@ -1355,7 +1355,7 @@ static void bgp_startup(void)
 	zprivs_init(&bgpd_privs);
 
 	master = event_master_create(NULL);
-	nb_init(master, NULL, 0, false);
+	nb_init(master, NULL, 0, false, false);
 	bgp_master_init(master, BGP_SOCKET_SNDBUF_SIZE, list_new());
 	bgp_option_set(BGP_OPT_NO_LISTEN);
 	vrf_init(NULL, NULL, NULL, NULL);

--- a/tests/helpers/c/main.c
+++ b/tests/helpers/c/main.c
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
 	vty_init(master, false);
 	lib_cmd_init();
 	debug_init();
-	nb_init(master, NULL, 0, false);
+	nb_init(master, NULL, 0, false, false);
 
 	/* OSPF vty inits. */
 	test_vty_init();

--- a/tests/isisd/test_isis_spf.c
+++ b/tests/isisd/test_isis_spf.c
@@ -546,7 +546,7 @@ int main(int argc, char **argv)
 	cmd_init(1);
 	cmd_hostname_set("test");
 	vty_init(master, false);
-	yang_init(true, false);
+	yang_init(true, false, false);
 	if (debug)
 		zlog_aux_init("NONE: ", LOG_DEBUG);
 	else

--- a/tests/lib/cli/common_cli.c
+++ b/tests/lib/cli/common_cli.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
 	for (yangcount = 0; test_yang_modules && test_yang_modules[yangcount];
 	     yangcount++)
 		;
-	nb_init(master, test_yang_modules, yangcount, false);
+	nb_init(master, test_yang_modules, yangcount, false, false);
 
 	test_init(argc, argv);
 

--- a/tests/lib/cli/test_commands.c
+++ b/tests/lib/cli/test_commands.c
@@ -197,7 +197,7 @@ static void test_init(void)
 
 	cmd_init(1);
 	debug_init();
-	nb_init(master, NULL, 0, false);
+	nb_init(master, NULL, 0, false, false);
 
 	install_node(&bgp_node);
 	install_node(&rip_node);

--- a/tests/lib/northbound/test_oper_data.c
+++ b/tests/lib/northbound/test_oper_data.c
@@ -461,7 +461,7 @@ int main(int argc, char **argv)
 	vty_init(master, false);
 	lib_cmd_init();
 	debug_init();
-	nb_init(master, modules, array_size(modules), false);
+	nb_init(master, modules, array_size(modules), false, false);
 
 	install_element(ENABLE_NODE, &test_rpc_cmd);
 

--- a/tests/lib/test_grpc.cpp
+++ b/tests/lib/test_grpc.cpp
@@ -111,8 +111,7 @@ static void static_startup(void)
 	static_debug_init();
 
 	master = event_master_create(NULL);
-	nb_init(master, staticd_yang_modules, array_size(staticd_yang_modules),
-		false);
+	nb_init(master, staticd_yang_modules, array_size(staticd_yang_modules), false, false);
 
 	static_zebra_init();
 	vty_init(master, true);

--- a/tools/gen_northbound_callbacks.c
+++ b/tools/gen_northbound_callbacks.c
@@ -448,7 +448,7 @@ int main(int argc, char *argv[])
 	if (argc != 1)
 		usage(EXIT_FAILURE);
 
-	yang_init(false, true);
+	yang_init(false, true, false);
 
 	if (search_path)
 		ly_ctx_set_searchdir(ly_native_ctx, search_path);

--- a/tools/gen_yang_deviations.c
+++ b/tools/gen_yang_deviations.c
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
 	if (argc != 1)
 		usage(EXIT_FAILURE);
 
-	yang_init(false, false);
+	yang_init(false, false, false);
 
 	/* Load YANG module. */
 	module = yang_module_load(argv[0], NULL);


### PR DESCRIPTION
Mgmtd makes use of libyang's internal ietf-yang-library module to add support for said module to FRR management. Previously, ietf-yang-library was loading this module explicitly; however, that required that libyang's `ietf-yang-library.yang` module definition file be co-located with FRR's so that it (and ietf-datastore.yang) would be found when searched for by libyang. This isn't always the case depending on how the user compiles and installs libyang so mgmtd was failing to run in these cases.

Instead of doing it that way we simply tell libyang to load it's internal version of ietf-yang-library when we initialize the libyang context.

This required adding a boolean to a couple of the init functions which is why so many files are touched (although all the changes are minimal).
