### PR TITLE
vrrpd: iterate over all ancillary messages

### DIFF
--- a/vrrpd/vrrp_packet.c
+++ b/vrrpd/vrrp_packet.c
@@ -234,7 +234,7 @@ ssize_t vrrp_pkt_parse_datagram(int family, int version, bool ipv4_ph,
 	} else if (family == AF_INET6) {
 		struct cmsghdr *c;
 
-		for (c = CMSG_FIRSTHDR(m); c != NULL; CMSG_NXTHDR(m, c)) {
+		for (c = CMSG_FIRSTHDR(m); c != NULL; c = CMSG_NXTHDR(m, c)) {
 			if (c->cmsg_level == IPPROTO_IPV6
 			    && c->cmsg_type == IPV6_HOPLIMIT)
 				break;


### PR DESCRIPTION
Assign the return of `CMSG_NXTHDR` so we can really iterate over the ancillary data.