### PR TITLE
zebra: Kernel routes are not updated properly in zebra RIB / nhg nexthop check is wrong #13561

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2648,7 +2648,7 @@ static unsigned nexthop_active_check(struct route_node *rn,
 
 		ifp = if_lookup_by_index(nexthop->ifindex, nexthop->vrf_id);
 
-		if (ifp && ifp->vrf->vrf_id == vrf_id && if_is_up(ifp)) {
+		if (ifp && ifp->vrf->vrf_id == vrf_id && if_is_up(ifp) && if_connected_count(ifp->connected)) {
 			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 			goto skip_check;
 		}


### PR DESCRIPTION
Kernel routes are not updated properly in zebra RIB / nhg nexthop check is wrong: #13561 

Introduction:
Zebra is not restoring the routes properly as mentioned in the bug-13561. When we do flush on an interface having the default route, zebra is still advertising the default route which it shouldn't. As we flush the interface the default route should unadvertised in vtysh -c "show ip route". 

Implementation details:
To overcome this issue we have added a check. Which helps in checking whether the interface has at least one connected route.  If the interface has a connected route then it will skip the intermediate checks and go directly to "skip_check: ". With this check in place everything is working - where default route is being unadvertised in vtysh -c "show ip route".

Necessary unit testing and topotests have been done.

Thanks
Denny Agussy
Nandini D