### PR TITLE
Adds note about VRRP issues inside a VM with underlying bridge networking

### DIFF
--- a/doc/user/vrrp.rst
+++ b/doc/user/vrrp.rst
@@ -519,6 +519,7 @@ Check:
 - Do you have unusual ``sysctls`` enabled that could affect the operation of
   multicast traffic?
 - Are you running in ESXi? See below.
+- Are you running in a linux VM with a bridged network? See below.
 
 
 My master router is not forwarding traffic
@@ -549,6 +550,24 @@ This is a significant security issue in some deployments so make sure you
 understand what you're doing. On 6.7 and later, you can use the MAC Learning
 feature instead, explained `here
 <https://www.virtuallyghetto.com/2018/04/native-mac-learning-in-vsphere-6-7-removes-the-need-for-promiscuous-mode-for-nested-esxi.html>`_.
+
+Issue reference: https://github.com/FRRouting/frr/issues/5386
+
+My router is running in a linux VM with a bridged host network and VRRP has issues
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Issues can arise with VRRP (especially IPv6) when you have a VM running on top
+of a linux host, where your physical network is in a bridge, and the VM
+has an interface attached to the bridge. By default, the linux bridge will
+snoop multicast traffic, and you will likely see sporadic VRRP advertisements failing
+to be received. IPv6 traffic was be particularly affected.
+
+This was observed on a VM running on proxmox, and the solution was to disable
+multicast snooping on the bridge:
+
+.. code-block:: console
+
+   echo 0 > /sys/devices/virtual/net/vmbr0/bridge/multicast_snooping
 
 Issue reference: https://github.com/FRRouting/frr/issues/5386
 


### PR DESCRIPTION
This week I have learnt more about VRRP and IPv6 than I can care to elaborate on 😂 

Essentially we are running our FRR routers inside VMs, and those VMs have network interfaces placed in a bridge on the host (in this case, Proxmox). VRRP on IPv4 had no issues, but I was having incredibly strange behaviour with IPv6 and the VMs randomly no longer receiving the VRRP announcements.

Given it took almost 3 days of debugging, thought it would be worthwhile adding to the (already brilliant) docs on this, in case anyone else hits the same issue in the future.