### PR TITLE
zebra: Only notify dplane work pthread when needed

### DIFF
--- a/fpm/fpm.h
+++ b/fpm/fpm.h
@@ -65,7 +65,7 @@
 /*
  * Largest message that can be sent to or received from the FPM.
  */
-#define FPM_MAX_MSG_LEN 4096
+#define FPM_MAX_MSG_LEN MAX(MULTIPATH_NUM * 32, 4096)
 
 #ifdef __SUNPRO_C
 #pragma pack(1)

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1525,7 +1525,7 @@ static void fpm_process_queue(struct event *t)
 	 * until the dataplane thread gets scheduled for new,
 	 * unrelated work.
 	 */
-	if (dplane_provider_out_ctx_queue_len(fnc->prov) > 0)
+	if (processed_contexts)
 		dplane_provider_work_ready();
 }
 

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1512,8 +1512,12 @@ static void fpm_process_queue(struct event *t)
 
 	/* Re-schedule if we ran out of buffer space */
 	if (no_bufs) {
-		event_add_event(fnc->fthread->master, fpm_process_queue, fnc, 0,
-				&fnc->t_dequeue);
+		if (processed_contexts)
+			event_add_event(fnc->fthread->master, fpm_process_queue, fnc, 0,
+					&fnc->t_dequeue);
+		else
+			event_add_timer_msec(fnc->fthread->master, fpm_process_queue, fnc, 10,
+					     &fnc->t_dequeue);
 		event_add_timer(fnc->fthread->master, fpm_process_wedged, fnc,
 				DPLANE_FPM_NL_WEDGIE_TIME, &fnc->t_wedged);
 	} else


### PR DESCRIPTION
The fpm_nl_process function was getting the count
of the total number of ctx's processed.  This leads to after having processed 1 context to always signal the dataplane that there is work to do.  Change the code to only notify the dplane worker when a context was actually added to the outgoing context queue.