### PR TITLE
ospfd: fix some ospf commands

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -1353,12 +1353,13 @@ DEFUN (ospf_area_shortcut,
 
 DEFUN (no_ospf_area_shortcut,
        no_ospf_area_shortcut_cmd,
-       "no area <A.B.C.D|(0-4294967295)> shortcut <enable|disable>",
+       "no area <A.B.C.D|(0-4294967295)> shortcut <default|enable|disable>",
        NO_STR
        "OSPF area parameters\n"
        "OSPF area ID in IP address format\n"
        "OSPF area ID as a decimal value\n"
        "Deconfigure the area's shortcutting mode\n"
+       "Deconfigure default shortcutting through the area\n"
        "Deconfigure enabled shortcutting through the area\n"
        "Deconfigure disabled shortcutting through the area\n")
 {

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -718,7 +718,7 @@ DEFUN (ospf_area_range_not_advertise,
 
 DEFUN (no_ospf_area_range,
        no_ospf_area_range_cmd,
-       "no area <A.B.C.D|(0-4294967295)> range A.B.C.D/M [<cost (0-16777215)|advertise [cost (0-16777215)]|not-advertise>]",
+       "no area <A.B.C.D|(0-4294967295)> range A.B.C.D/M [<cost [(0-16777215)]|advertise [cost [(0-16777215)]]|not-advertise>]",
        NO_STR
        "OSPF area parameters\n"
        "OSPF area ID in IP address format\n"


### PR DESCRIPTION
This is the fix of https://github.com/FRRouting/frr/issues/17039
1. no area range cost NUM, NUM can be omitted
2. no area shortcut MODE, MODE can be default, that is no area shortcut default

Closes https://github.com/FRRouting/frr/issues/17039