### PR TITLE
zebra: fix head-after-free when accessing NHE dependencies

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -3714,6 +3714,7 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 					  rb_node_dep)
 					zebra_nhg_decrement_ref(
 						rb_node_dep->nhe);
+				nhg_connected_tree_free(&old->nhg_depends);
 			}
 
 			/* Dont call the dec API, we dont want to uninstall the ID */


### PR DESCRIPTION
After having refreshed a recursive protocol NHG, a heaf after free happens on the NHG dependencies.

> READ of size 4 at 0x60e000074cc0 thread T0
>     #0 0x555ea629eef0 in zebra_nhg_decrement_ref zebra/zebra_nhg.c:1904
>     #1 0x555ea62a2748 in zebra_nhg_proto_add zebra/zebra_nhg.c:3981
>     #2 0x555ea62ccf6c in process_subq_nhg zebra/zebra_rib.c:2737
>     #3 0x555ea62ccf6c in process_subq zebra/zebra_rib.c:3342
>     #4 0x555ea62ccf6c in meta_queue_process zebra/zebra_rib.c:3395
>     #5 0x7fd799f1207f in work_queue_run lib/workqueue.c:282
>     #6 0x7fd799ef3d3b in event_call lib/event.c:2011
>     #7 0x7fd799e1b897 in frr_run lib/libfrr.c:1212
>     #8 0x555ea61860b6 in main zebra/main.c:533
>     #9 0x7fd799829d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
>     #10 0x7fd799829e3f in __libc_start_main_impl ../csu/libc-start.c:392
>     #11 0x555ea6188ed4 in _start (/usr/lib/frr/zebra+0x1b4ed4)
>
> 0x60e000074cc0 is located 96 bytes inside of 160-byte region [0x60e000074c60,0x60e000074d00)
> freed by thread T0 here:
>     #0 0x7fd79a2b4537 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:127
>     #1 0x555ea629ef69 in nhg_connected_tree_decrement_ref zebra/zebra_nhg.c:187
>     #2 0x555ea629eec7 in zebra_nhg_decrement_ref zebra/zebra_nhg.c:1920
>     #3 0x555ea62bc110 in route_entry_update_nhe zebra/zebra_rib.c:454
>     #4 0x555ea62bc3fb in rib_handle_nhg_replace zebra/zebra_rib.c:478
>     #5 0x555ea62a22f8 in zebra_nhg_proto_add zebra/zebra_nhg.c:3966

Actually, 'debug zebra nexthop detail' is enabled and tries to display nhg_depend list whose NHE have been previously flushed. Fix this by removing the nhg_depends list itself, before sending it to zebra_nhg_free().