### PR TITLE
bgpd, tests: don't send local nexthop from rr client

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2472,6 +2472,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 			if (IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local))
 				global_and_ll = true;
 		} else if (!ibgp_to_ibgp && !transparent &&
+			   !CHECK_FLAG(from->af_flags[afi][safi], PEER_FLAG_REFLECTOR_CLIENT) &&
 			   IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_local) && peer->shared_network &&
 			   (from == bgp->peer_self || peer->sort == BGP_PEER_EBGP))
 			global_and_ll = true;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2148,7 +2148,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 	struct attr *piattr;
 	route_map_result_t ret;
 	int transparent;
-	int reflect;
+	int ibgp_to_ibgp;
 	afi_t afi;
 	safi_t safi;
 	int samepeer_safe = 0; /* for synthetic mplsvpns routes */
@@ -2357,14 +2357,14 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 		}
 	}
 
-	/* Route-Reflect check. */
+	/* iBGP to iBGP check. */
 	if (from->sort == BGP_PEER_IBGP && peer->sort == BGP_PEER_IBGP)
-		reflect = 1;
+		ibgp_to_ibgp = 1;
 	else
-		reflect = 0;
+		ibgp_to_ibgp = 0;
 
 	/* IBGP reflection check. */
-	if (reflect && !samepeer_safe) {
+	if (ibgp_to_ibgp && !samepeer_safe) {
 		/* A route from a Client peer. */
 		if (CHECK_FLAG(from->af_flags[afi][safi],
 			       PEER_FLAG_REFLECTOR_CLIENT)) {
@@ -2410,8 +2410,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 
 	/* If originator-id is not set and the route is to be reflected,
 	   set the originator id */
-	if (reflect
-	    && (!(attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ORIGINATOR_ID)))) {
+	if (ibgp_to_ibgp && (!(attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ORIGINATOR_ID)))) {
 		IPV4_ADDR_COPY(&(attr->originator_id), &(from->remote_id));
 		SET_FLAG(attr->flag, BGP_ATTR_ORIGINATOR_ID);
 	}
@@ -2444,7 +2443,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 	 * announced to an EBGP peer (and they have the same attributes barring
 	 * their nexthop).
 	 */
-	if (reflect)
+	if (ibgp_to_ibgp)
 		SET_FLAG(attr->rmap_change_flags, BATTR_REFLECTED);
 
 #define NEXTHOP_IS_V6                                                          \
@@ -2472,7 +2471,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 			 */
 			if (IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_local))
 				global_and_ll = true;
-		} else if (!reflect && !transparent &&
+		} else if (!ibgp_to_ibgp && !transparent &&
 			   IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_local) && peer->shared_network &&
 			   (from == bgp->peer_self || peer->sort == BGP_PEER_EBGP))
 			global_and_ll = true;
@@ -2694,9 +2693,8 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 			       PEER_FLAG_NEXTHOP_SELF)
 		    || CHECK_FLAG(peer->af_flags[afi][safi],
 				  PEER_FLAG_FORCE_NEXTHOP_SELF)) {
-			if (!reflect
-			    || CHECK_FLAG(peer->af_flags[afi][safi],
-					  PEER_FLAG_FORCE_NEXTHOP_SELF)) {
+			if (!ibgp_to_ibgp ||
+			    CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_FORCE_NEXTHOP_SELF)) {
 				subgroup_announce_reset_nhop(
 					(peer_cap_enhe(peer, afi, safi)
 						 ? AF_INET6

--- a/tests/topotests/bgp_nexthop_ipv6/r4/show_bgp_ipv6_step2.json
+++ b/tests/topotests/bgp_nexthop_ipv6/r4/show_bgp_ipv6_step2.json
@@ -9,13 +9,7 @@
             "ip": "fd00:0:2::1",
             "hostname": "rr",
             "afi": "ipv6",
-            "scope": "global"
-          },
-          {
-            "ip": "link-local:rr:eth-sw",
-            "hostname": "rr",
-            "afi": "ipv6",
-            "scope": "link-local",
+            "scope": "global",
             "used": true
           }
         ]
@@ -28,13 +22,7 @@
             "ip": "fd00:0:2::2",
             "hostname": "rr",
             "afi": "ipv6",
-            "scope": "global"
-          },
-          {
-            "ip": "link-local:rr:eth-sw",
-            "hostname": "rr",
-            "afi": "ipv6",
-            "scope": "link-local",
+            "scope": "global",
             "used": true
           }
         ]
@@ -47,13 +35,7 @@
             "ip": "fd00:0:2::3",
             "hostname": "rr",
             "afi": "ipv6",
-            "scope": "global"
-          },
-          {
-            "ip": "link-local:rr:eth-sw",
-            "hostname": "rr",
-            "afi": "ipv6",
-            "scope": "link-local",
+            "scope": "global",
             "used": true
           }
         ]
@@ -117,13 +99,7 @@
             "ip": "fd00:0:2::1",
             "hostname": "rr",
             "afi": "ipv6",
-            "scope": "global"
-          },
-          {
-            "ip": "link-local:rr:eth-sw",
-            "hostname": "rr",
-            "afi": "ipv6",
-            "scope": "link-local",
+            "scope": "global",
             "used": true
           }
         ]
@@ -136,13 +112,7 @@
             "ip": "fd00:0:2::2",
             "hostname": "rr",
             "afi": "ipv6",
-            "scope": "global"
-          },
-          {
-            "ip": "link-local:rr:eth-sw",
-            "hostname": "rr",
-            "afi": "ipv6",
-            "scope": "link-local",
+            "scope": "global",
             "used": true
           }
         ]
@@ -155,13 +125,7 @@
             "ip": "fd00:0:2::3",
             "hostname": "rr",
             "afi": "ipv6",
-            "scope": "global"
-          },
-          {
-            "ip": "link-local:rr:eth-sw",
-            "hostname": "rr",
-            "afi": "ipv6",
-            "scope": "link-local",
+            "scope": "global",
             "used": true
           }
         ]

--- a/tests/topotests/bgp_nexthop_ipv6/r5/show_bgp_ipv6_step2.json
+++ b/tests/topotests/bgp_nexthop_ipv6/r5/show_bgp_ipv6_step2.json
@@ -9,13 +9,7 @@
             "ip": "fd00:0:3::9",
             "hostname": "rr",
             "afi": "ipv6",
-            "scope": "global"
-          },
-          {
-            "ip": "link-local:rr:eth-r5",
-            "hostname": "rr",
-            "afi": "ipv6",
-            "scope": "link-local",
+            "scope": "global",
             "used": true
           }
         ]
@@ -28,13 +22,7 @@
             "ip": "fd00:0:3::9",
             "hostname": "rr",
             "afi": "ipv6",
-            "scope": "global"
-          },
-          {
-            "ip": "link-local:rr:eth-r5",
-            "hostname": "rr",
-            "afi": "ipv6",
-            "scope": "link-local",
+            "scope": "global",
             "used": true
           }
         ]
@@ -47,13 +35,7 @@
             "ip": "fd00:0:3::9",
             "hostname": "rr",
             "afi": "ipv6",
-            "scope": "global"
-          },
-          {
-            "ip": "link-local:rr:eth-r5",
-            "hostname": "rr",
-            "afi": "ipv6",
-            "scope": "link-local",
+            "scope": "global",
             "used": true
           }
         ]
@@ -117,13 +99,7 @@
             "ip": "fd00:0:3::9",
             "hostname": "rr",
             "afi": "ipv6",
-            "scope": "global"
-          },
-          {
-            "ip": "link-local:rr:eth-r5",
-            "hostname": "rr",
-            "afi": "ipv6",
-            "scope": "link-local",
+            "scope": "global",
             "used": true
           }
         ]
@@ -136,13 +112,7 @@
             "ip": "fd00:0:3::9",
             "hostname": "rr",
             "afi": "ipv6",
-            "scope": "global"
-          },
-          {
-            "ip": "link-local:rr:eth-r5",
-            "hostname": "rr",
-            "afi": "ipv6",
-            "scope": "link-local",
+            "scope": "global",
             "used": true
           }
         ]
@@ -155,13 +125,7 @@
             "ip": "fd00:0:3::9",
             "hostname": "rr",
             "afi": "ipv6",
-            "scope": "global"
-          },
-          {
-            "ip": "link-local:rr:eth-r5",
-            "hostname": "rr",
-            "afi": "ipv6",
-            "scope": "link-local",
+            "scope": "global",
             "used": true
           }
         ]


### PR DESCRIPTION
Depends on https://github.com/FRRouting/frr/pull/17071 merge

```
AS 65000  | AS 65001
          |
      RR  |
       |  |
R1 --- | --- R2
          |
```

When r1 peer is an iBGP route reflector client of rr and r2 peer is a
eBGP neighbor of rr, and all three routers shares the same network, r2
receives announcements coming from r1 with a IPv6 link-local nexthop
from rr. This is incorrect as r2 should send traffic to r1 without
involving rr.

Do not send an IPv6 link-local nexthop if the originating peer is a
route-reflector client.

Link: https://github.com/FRRouting/frr/pull/16219#issuecomment-2397425505
Link: https://github.com/FRRouting/frr/pull/17037#discussion_r1792529683