### PR TITLE
bgpd: fix evpn mh esi down

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3477,9 +3477,8 @@ uninstall_evpn_route_entry_in_vni_mac(struct bgp *bgp, struct bgpevpn *vpn,
  * Uninstall route entry from the VRF routing table and send message
  * to zebra, if appropriate.
  */
-static int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
-					     const struct prefix_evpn *evp,
-					     struct bgp_path_info *parent_pi)
+int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf, const struct prefix_evpn *evp,
+				      struct bgp_path_info *parent_pi)
 {
 	struct bgp_dest *dest;
 	struct bgp_path_info *pi;
@@ -3846,10 +3845,8 @@ static int bgp_evpn_route_rmac_self_check(struct bgp *bgp_vrf,
 }
 
 /* don't import hosts that are locally attached */
-static inline bool
-bgp_evpn_skip_vrf_import_of_local_es(struct bgp *bgp_vrf,
-				     const struct prefix_evpn *evp,
-				     struct bgp_path_info *pi, int install)
+bool bgp_evpn_skip_vrf_import_of_local_es(struct bgp *bgp_vrf, const struct prefix_evpn *evp,
+					  struct bgp_path_info *pi, int install)
 {
 	esi_t *esi;
 

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -195,4 +195,8 @@ extern enum zclient_send_status
 evpn_zebra_uninstall(struct bgp *bgp, struct bgpevpn *vpn,
 		     const struct prefix_evpn *p, struct bgp_path_info *pi,
 		     bool is_sync);
+bool bgp_evpn_skip_vrf_import_of_local_es(struct bgp *bgp_vrf, const struct prefix_evpn *evp,
+					  struct bgp_path_info *pi, int install);
+int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf, const struct prefix_evpn *evp,
+				      struct bgp_path_info *parent_pi);
 #endif /* _QUAGGA_BGP_EVPN_H */

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -3807,6 +3807,7 @@ int bgp_evpn_local_es_evi_add(struct bgp *bgp, esi_t *esi, vni_t vni)
 		bgp_evpn_ead_evi_route_update(bgp, es, vpn, &p);
 	}
 
+	bgp_evpn_local_es_evi_unistall_local_routes_in_vrfs(es, es_evi);
 	/* update EAD-ES */
 	if (bgp_evpn_local_es_is_active(es))
 		bgp_evpn_ead_es_route_update(bgp, es);
@@ -5056,5 +5057,40 @@ void bgp_evpn_switch_ead_evi_rx(void)
 					       vtep_node, vtep_next, vtep))
 				bgp_evpn_es_evi_vtep_re_eval_active(bgp, vtep);
 		}
+	}
+}
+
+void bgp_evpn_local_es_evi_unistall_local_routes_in_vrfs(struct bgp_evpn_es *es,
+							 struct bgp_evpn_es_evi *es_evi)
+{
+	struct listnode *node;
+	struct bgp_path_es_info *es_info;
+	struct bgp_path_info *pi;
+	const struct prefix_evpn *evp;
+	struct bgp_evpn_es_vrf *es_vrf = es_evi->es_vrf;
+
+	if (!es_vrf)
+		return;
+
+	for (ALL_LIST_ELEMENTS_RO(es->macip_global_path_list, node, es_info)) {
+		pi = es_info->pi;
+
+		if (!bgp_evpn_is_macip_path(pi))
+			continue;
+
+		evp = (const struct prefix_evpn *)bgp_dest_get_prefix(pi->net);
+
+		if (!(CHECK_FLAG(pi->flags, BGP_PATH_VALID) && pi->type == ZEBRA_ROUTE_BGP &&
+		      pi->sub_type == BGP_ROUTE_NORMAL))
+			continue;
+
+		if (BGP_DEBUG(evpn_mh, EVPN_MH_RT))
+			zlog_debug("route %pFX is matched on local esi %s, uninstall from %s route table",
+				   evp, es->esi_str, es_vrf->bgp_vrf->name_pretty);
+
+		if (!bgp_evpn_skip_vrf_import_of_local_es(es_vrf->bgp_vrf, evp, pi, 0))
+			continue;
+
+		uninstall_evpn_route_entry_in_vrf(es_vrf->bgp_vrf, evp, pi);
 	}
 }

--- a/bgpd/bgp_evpn_mh.h
+++ b/bgpd/bgp_evpn_mh.h
@@ -459,5 +459,7 @@ extern void bgp_evpn_path_nh_add(struct bgp *bgp_vrf, struct bgp_path_info *pi);
 extern void bgp_evpn_path_nh_del(struct bgp *bgp_vrf, struct bgp_path_info *pi);
 extern void bgp_evpn_mh_config_ead_export_rt(struct bgp *bgp,
 					     struct ecommunity *ecom, bool del);
+extern void bgp_evpn_local_es_evi_unistall_local_routes_in_vrfs(struct bgp_evpn_es *es,
+								struct bgp_evpn_es_evi *es_evi);
 
 #endif /* _FRR_BGP_EVPN_MH_H */


### PR DESCRIPTION
In symmetric routing, when local ESI is down,
the MH peer learnt local mac-ip
prefix is installed into teannt vrf (given l3vni).

When ESI is back up and associated to evi/vni then remove the local synced mac-ip imported routes from the tenant vrf as local neigh/arp is present.


Testing:

peer advertised mac-ip route:
```
*> [2]:[0]:[48]:[aa:aa:aa:00:00:01]:[32]:[45.0.0.51] RD 27.0.0.4:9
                    27.0.0.4 (spine-1)
                                                           0 64435 65016 i
                    ESI:03:44:38:39:ff:ff:01:00:00:01
                    RT:65016:1000 RT:65016:4000 ET:8 Rmac:44:38:39:ff:ff:16
``` 

When local ESI is flapped
```
torm-11:# ip neigh show 45.0.0.51
45.0.0.51 dev vlan1000 lladdr aa:aa:aa:00:00:01 REACHABLE proto zebra
```

Before fix:

(The imported route remained in tenant-vrf)
```
torm-11:# ip route show vrf vrf1 45.0.0.51
45.0.0.51 nhid 257 proto bgp metric 20
```

After fix:

The route is no longer present once the ESI come back up.
```
torm-11# ip route show vrf vrf1 45.0.0.51
torm-11#
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>