### PR TITLE
ospfd: fix the bug that the empty area was not free after no_area_range was executed

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -781,6 +781,8 @@ DEFUN (no_ospf_area_range_substitute,
 
 	ospf_area_range_substitute_unset(ospf, area, &p);
 
+	ospf_area_check_free(ospf, area_id);
+
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
When we use the `no area X.X.X.X range A.B.C.D/M` command, if the area no longer has an interface to which it belongs, then the area should be deleted from the LSDB. This processing logic is consistent with instructions such as `no network area` and `no area authentication`.

CLOSES https://github.com/FRRouting/frr/issues/17079 https://github.com/FRRouting/frr/issues/17080