### PR TITLE
tools/gcc-plugins: don't crash on array parameters

### DIFF
--- a/tools/gcc-plugins/frr-format.c
+++ b/tools/gcc-plugins/frr-format.c
@@ -2685,7 +2685,8 @@ tree type_normalize (tree type, tree *cousin, tree target = NULL)
 {
   while (1)
     {
-      if (TREE_CODE (type) == FUNCTION_TYPE || TREE_CODE (type) == POINTER_TYPE)
+      if (TREE_CODE (type) == FUNCTION_TYPE || TREE_CODE (type) == POINTER_TYPE
+	  || TREE_CODE (type) == ARRAY_TYPE)
 	return type;
       if (target)
 	/* Strip off any "const" etc.  */


### PR DESCRIPTION
Need to have arrays as a stop condition in this type normalization function, like pointers and function pointers.  Actual arrays as argument types are extremely rare to see because C has this array-decay-to-pointer thing, but it can happen.

---
Fixes the ICE/GCC crash in #12346