### PR TITLE
bgpd: fix bmp coverity issue 1600779

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -489,7 +489,7 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 				 &uptime_real);
 
 		/* Local Address (16 bytes) */
-		if (!peer->su_local || is_locrib)
+		if (is_locrib)
 			stream_put(s, 0, 16);
 		else if (peer->su_local->sa.sa_family == AF_INET6)
 			stream_put(s, &peer->su_local->sin6.sin6_addr, 16);


### PR DESCRIPTION
Fix bmp coverity issue 1600779. peer->su_local cannot be NULL.

Fixes: 035304c25a ("bgpd: bmp loc-rib peer up/down for vrfs")