### PR TITLE
zebra: unlock node only after operation in zebra_free_rnh()

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -220,10 +220,9 @@ void zebra_free_rnh(struct rnh *rnh)
 		if (rern) {
 			rib_dest_t *dest;
 
-			route_unlock_node(rern);
-
 			dest = rib_dest_from_rnode(rern);
 			rnh_list_del(&dest->nht, rnh);
+			route_unlock_node(rern);
 		}
 	}
 	free_state(rnh->vrf_id, rnh->state, rnh->node);


### PR DESCRIPTION
Move route_unlock_node() after rnh_list_del().