### PR TITLE
zebra: notify nht client about protocol type change

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1123,6 +1123,9 @@ static bool compare_state(struct route_entry *r1,
 	if ((!r1 && r2) || (r1 && !r2))
 		return true;
 
+	if (r1->type != r2->type)
+		return true;
+
 	if (r1->distance != r2->distance)
 		return true;
 


### PR DESCRIPTION
The protocol type is of interest to NHT clients. Comparea the field for changes.