### PR TITLE
ospfd: Fixup ospf_lsa.[ch] to properly spell out parameters for funct…

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2613,8 +2613,7 @@ void ospf_external_lsa_refresh_default(struct ospf *ospf)
 	}
 }
 
-void ospf_external_lsa_refresh_type(struct ospf *ospf, uint8_t type,
-				    unsigned short instance, int force)
+void ospf_external_lsa_refresh_type(struct ospf *ospf, uint8_t type, uint8_t instance, int force)
 {
 	struct route_node *rn;
 	struct external_info *ei;
@@ -3170,9 +3169,9 @@ int ospf_check_nbr_status(struct ospf *ospf)
 }
 
 
-void ospf_maxage_lsa_remover(struct event *thread)
+void ospf_maxage_lsa_remover(struct event *event)
 {
-	struct ospf *ospf = EVENT_ARG(thread);
+	struct ospf *ospf = EVENT_ARG(event);
 	struct ospf_lsa *lsa, *old;
 	struct route_node *rn;
 	int reschedule = 0;
@@ -3202,7 +3201,7 @@ void ospf_maxage_lsa_remover(struct event *thread)
 			}
 
 			/* TODO: maybe convert this function to a work-queue */
-			if (event_should_yield(thread)) {
+			if (event_should_yield(event)) {
 				OSPF_TIMER_ON(ospf->t_maxage,
 					      ospf_maxage_lsa_remover, 0);
 				route_unlock_node(
@@ -3418,9 +3417,9 @@ static int ospf_lsa_maxage_walker_remover(struct ospf *ospf,
 }
 
 /* Periodical check of MaxAge LSA. */
-void ospf_lsa_maxage_walker(struct event *thread)
+void ospf_lsa_maxage_walker(struct event *event)
 {
-	struct ospf *ospf = EVENT_ARG(thread);
+	struct ospf *ospf = EVENT_ARG(event);
 	struct route_node *rn;
 	struct ospf_lsa *lsa;
 	struct ospf_area *area;
@@ -4157,11 +4156,11 @@ void ospf_refresher_unregister_lsa(struct ospf *ospf, struct ospf_lsa *lsa)
 	}
 }
 
-void ospf_lsa_refresh_walker(struct event *t)
+void ospf_lsa_refresh_walker(struct event *e)
 {
 	struct list *refresh_list;
 	struct listnode *node, *nnode;
-	struct ospf *ospf = EVENT_ARG(t);
+	struct ospf *ospf = EVENT_ARG(e);
 	struct ospf_lsa *lsa;
 	int i;
 	struct list *lsa_to_refresh = list_new();

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -225,122 +225,111 @@ enum lsid_status { LSID_AVAILABLE = 0, LSID_CHANGE, LSID_NOT_AVAILABLE };
 /* Prototypes. */
 /* XXX: Eek, time functions, similar are in lib/thread.c */
 extern struct timeval int2tv(int);
-extern struct timeval msec2tv(int);
+extern struct timeval msec2tv(int a);
 
-extern int get_age(struct ospf_lsa *);
-extern uint16_t ospf_lsa_checksum(struct lsa_header *);
-extern int ospf_lsa_checksum_valid(struct lsa_header *);
-extern int ospf_lsa_refresh_delay(struct ospf_lsa *);
+extern int get_age(struct ospf_lsa *lsa);
+extern uint16_t ospf_lsa_checksum(struct lsa_header *lsah);
+extern int ospf_lsa_checksum_valid(struct lsa_header *lsah);
+extern int ospf_lsa_refresh_delay(struct ospf_lsa *lsa);
 
-extern const char *dump_lsa_key(struct ospf_lsa *);
-extern uint32_t lsa_seqnum_increment(struct ospf_lsa *);
-extern void lsa_header_set(struct stream *, uint8_t, uint8_t, struct in_addr,
-			   struct in_addr);
-extern struct ospf_neighbor *ospf_nbr_lookup_ptop(struct ospf_interface *);
-extern int ospf_check_nbr_status(struct ospf *);
+extern const char *dump_lsa_key(struct ospf_lsa *lsa);
+extern uint32_t lsa_seqnum_increment(struct ospf_lsa *lsa);
+extern void lsa_header_set(struct stream *s, uint8_t options, uint8_t type, struct in_addr id,
+			   struct in_addr router_id);
+extern struct ospf_neighbor *ospf_nbr_lookup_ptop(struct ospf_interface *oi);
+extern int ospf_check_nbr_status(struct ospf *ospf);
 
 /* Prototype for LSA primitive. */
 extern struct ospf_lsa *ospf_lsa_new(void);
 extern struct ospf_lsa *ospf_lsa_new_and_data(size_t size);
-extern struct ospf_lsa *ospf_lsa_dup(struct ospf_lsa *);
-extern void ospf_lsa_free(struct ospf_lsa *);
-extern struct ospf_lsa *ospf_lsa_lock(struct ospf_lsa *);
-extern void ospf_lsa_unlock(struct ospf_lsa **);
-extern void ospf_lsa_discard(struct ospf_lsa *);
-extern int ospf_lsa_flush_schedule(struct ospf *, struct ospf_lsa *);
-extern struct lsa_header *ospf_lsa_data_new(size_t);
-extern struct lsa_header *ospf_lsa_data_dup(struct lsa_header *);
-extern void ospf_lsa_data_free(struct lsa_header *);
+extern struct ospf_lsa *ospf_lsa_dup(struct ospf_lsa *lsa);
+extern void ospf_lsa_free(struct ospf_lsa *lsa);
+extern struct ospf_lsa *ospf_lsa_lock(struct ospf_lsa *lsa);
+extern void ospf_lsa_unlock(struct ospf_lsa **lsa);
+extern void ospf_lsa_discard(struct ospf_lsa *lsa);
+extern int ospf_lsa_flush_schedule(struct ospf *ospf, struct ospf_lsa *lsa);
+extern struct lsa_header *ospf_lsa_data_new(size_t size);
+extern struct lsa_header *ospf_lsa_data_dup(struct lsa_header *lsah);
+extern void ospf_lsa_data_free(struct lsa_header *lsah);
 
 /* Prototype for various LSAs */
 extern void ospf_router_lsa_body_set(struct stream **s, struct ospf_area *area);
 extern uint8_t router_lsa_flags(struct ospf_area *area);
-extern int ospf_router_lsa_update(struct ospf *);
-extern int ospf_router_lsa_update_area(struct ospf_area *);
+extern int ospf_router_lsa_update(struct ospf *ospf);
+extern int ospf_router_lsa_update_area(struct ospf_area *area);
 
-extern void ospf_network_lsa_update(struct ospf_interface *);
+extern void ospf_network_lsa_update(struct ospf_interface *oi);
 
-extern struct ospf_lsa *
-ospf_summary_lsa_originate(struct prefix_ipv4 *, uint32_t, struct ospf_area *);
-extern struct ospf_lsa *ospf_summary_asbr_lsa_originate(struct prefix_ipv4 *,
-							uint32_t,
-							struct ospf_area *);
+extern struct ospf_lsa *ospf_summary_lsa_originate(struct prefix_ipv4 *p, uint32_t metric,
+						   struct ospf_area *area);
+extern struct ospf_lsa *ospf_summary_asbr_lsa_originate(struct prefix_ipv4 *p, uint32_t metric,
+							struct ospf_area *area);
 
-extern struct ospf_lsa *ospf_lsa_install(struct ospf *, struct ospf_interface *,
-					 struct ospf_lsa *);
+extern struct ospf_lsa *ospf_lsa_install(struct ospf *ospf, struct ospf_interface *oi,
+					 struct ospf_lsa *lsa);
 
 extern void ospf_nssa_lsa_flush(struct ospf *ospf, struct prefix_ipv4 *p);
-extern void ospf_external_lsa_flush(struct ospf *, uint8_t,
-				    struct prefix_ipv4 *,
+extern void ospf_external_lsa_flush(struct ospf *ospf, uint8_t type, struct prefix_ipv4 *p,
 				    ifindex_t /* , struct in_addr nexthop */);
 
-extern struct in_addr ospf_get_ip_from_ifp(struct ospf_interface *);
+extern struct in_addr ospf_get_ip_from_ifp(struct ospf_interface *oi);
 
-extern struct ospf_lsa *ospf_external_lsa_originate(struct ospf *,
-						    struct external_info *);
+extern struct ospf_lsa *ospf_external_lsa_originate(struct ospf *ospf, struct external_info *ei);
 extern struct ospf_lsa *ospf_nssa_lsa_originate(struct ospf_area *area,
 						struct external_info *ei);
 extern struct ospf_lsa *ospf_nssa_lsa_refresh(struct ospf_area *area,
 					      struct ospf_lsa *lsa,
 					      struct external_info *ei);
 extern void ospf_external_lsa_rid_change(struct ospf *ospf);
-extern struct ospf_lsa *ospf_lsa_lookup(struct ospf *ospf, struct ospf_area *,
-					uint32_t, struct in_addr,
-					struct in_addr);
-extern struct ospf_lsa *ospf_lsa_lookup_by_id(struct ospf_area *, uint32_t,
-					      struct in_addr);
-extern struct ospf_lsa *ospf_lsa_lookup_by_header(struct ospf_area *,
-						  struct lsa_header *);
-extern int ospf_lsa_more_recent(struct ospf_lsa *, struct ospf_lsa *);
-extern int ospf_lsa_different(struct ospf_lsa *, struct ospf_lsa *,
-			      bool ignore_rcvd_flag);
-extern void ospf_flush_self_originated_lsas_now(struct ospf *);
+extern struct ospf_lsa *ospf_lsa_lookup(struct ospf *ospf, struct ospf_area *area, uint32_t type,
+					struct in_addr id, struct in_addr adv_router);
+extern struct ospf_lsa *ospf_lsa_lookup_by_id(struct ospf_area *area, uint32_t type,
+					      struct in_addr id);
+extern struct ospf_lsa *ospf_lsa_lookup_by_header(struct ospf_area *area, struct lsa_header *lsah);
+extern int ospf_lsa_more_recent(struct ospf_lsa *l1, struct ospf_lsa *l2);
+extern int ospf_lsa_different(struct ospf_lsa *l1, struct ospf_lsa *l2, bool ignore_rcvd_flag);
+extern void ospf_flush_self_originated_lsas_now(struct ospf *ospf);
 
-extern int ospf_lsa_is_self_originated(struct ospf *, struct ospf_lsa *);
+extern int ospf_lsa_is_self_originated(struct ospf *ospf, struct ospf_lsa *lsa);
 
-extern struct ospf_lsa *ospf_lsa_lookup_by_prefix(struct ospf_lsdb *, uint8_t,
-						  struct prefix_ipv4 *,
-						  struct in_addr);
+extern struct ospf_lsa *ospf_lsa_lookup_by_prefix(struct ospf_lsdb *lsdb, uint8_t type,
+						  struct prefix_ipv4 *p, struct in_addr router_id);
 
-extern void ospf_lsa_maxage(struct ospf *, struct ospf_lsa *);
-extern uint32_t get_metric(uint8_t *);
+extern void ospf_lsa_maxage(struct ospf *ospf, struct ospf_lsa *lsa);
+extern uint32_t get_metric(uint8_t *metric);
 
-extern void ospf_lsa_maxage_walker(struct event *thread);
-extern struct ospf_lsa *ospf_lsa_refresh(struct ospf *, struct ospf_lsa *);
+extern void ospf_lsa_maxage_walker(struct event *event);
+extern struct ospf_lsa *ospf_lsa_refresh(struct ospf *ospf, struct ospf_lsa *lsa);
 
-extern void ospf_external_lsa_refresh_default(struct ospf *);
+extern void ospf_external_lsa_refresh_default(struct ospf *ospf);
 
-extern void ospf_external_lsa_refresh_type(struct ospf *, uint8_t,
-					   unsigned short, int);
-extern struct ospf_lsa *ospf_external_lsa_refresh(struct ospf *,
-						  struct ospf_lsa *,
-						  struct external_info *, int,
-						  bool aggr);
+extern void ospf_external_lsa_refresh_type(struct ospf *ospf, uint8_t type, uint8_t instance,
+					   int force);
+extern struct ospf_lsa *ospf_external_lsa_refresh(struct ospf *ospf, struct ospf_lsa *lsa,
+						  struct external_info *ei, int force, bool aggr);
 extern enum lsid_status ospf_lsa_unique_id(struct ospf *ospf,
 					   struct ospf_lsdb *lsdb,
 					   uint8_t type, struct prefix_ipv4 *p,
 					   struct in_addr *addr);
-extern void ospf_schedule_lsa_flood_area(struct ospf_area *, struct ospf_lsa *);
-extern void ospf_schedule_lsa_flush_area(struct ospf_area *, struct ospf_lsa *);
+extern void ospf_schedule_lsa_flood_area(struct ospf_area *area, struct ospf_lsa *lsa);
+extern void ospf_schedule_lsa_flush_area(struct ospf_area *area, struct ospf_lsa *lsa);
 
-extern void ospf_refresher_register_lsa(struct ospf *, struct ospf_lsa *);
-extern void ospf_refresher_unregister_lsa(struct ospf *, struct ospf_lsa *);
-extern void ospf_lsa_refresh_walker(struct event *thread);
+extern void ospf_refresher_register_lsa(struct ospf *ospf, struct ospf_lsa *lsa);
+extern void ospf_refresher_unregister_lsa(struct ospf *ospf, struct ospf_lsa *lsa);
+extern void ospf_lsa_refresh_walker(struct event *event);
 
-extern void ospf_lsa_maxage_delete(struct ospf *, struct ospf_lsa *);
+extern void ospf_lsa_maxage_delete(struct ospf *ospf, struct ospf_lsa *lsa);
 
-extern void ospf_discard_from_db(struct ospf *, struct ospf_lsdb *,
-				 struct ospf_lsa *);
+extern void ospf_discard_from_db(struct ospf *ospf, struct ospf_lsdb *lsdb, struct ospf_lsa *lsa);
 
-extern int metric_type(struct ospf *, uint8_t, unsigned short);
-extern int metric_value(struct ospf *, uint8_t, unsigned short);
+extern int metric_type(struct ospf *ospf, uint8_t src, unsigned short instance);
+extern int metric_value(struct ospf *ospf, uint8_t src, unsigned short instance);
 
 extern char link_info_set(struct stream **s, struct in_addr id,
 			  struct in_addr data, uint8_t type, uint8_t tos,
 			  uint16_t cost);
 
-extern struct in_addr ospf_get_nssa_ip(struct ospf_area *);
-extern int ospf_translated_nssa_compare(struct ospf_lsa *, struct ospf_lsa *);
+extern struct in_addr ospf_get_nssa_ip(struct ospf_area *area);
 extern struct ospf_lsa *ospf_translated_nssa_refresh(struct ospf *ospf,
 						     struct ospf_lsa *type7,
 						     struct ospf_lsa *type5);
@@ -351,7 +340,7 @@ extern void ospf_check_and_gen_init_seq_lsa(struct ospf_interface *oi,
 					    struct ospf_lsa *lsa);
 extern void ospf_flush_lsa_from_area(struct ospf *ospf, struct in_addr area_id,
 				     int type);
-extern void ospf_maxage_lsa_remover(struct event *thread);
+extern void ospf_maxage_lsa_remover(struct event *event);
 extern bool ospf_check_dna_lsa(const struct ospf_lsa *lsa);
 extern void ospf_refresh_area_self_lsas(struct ospf_area *area);
 


### PR DESCRIPTION
…ions

Our standard says when in a .h file and declaring a function all parameters must have their variables spelled out.  Let's do this for ospf_lsa.h

Modified ospf_lsa.c to also use event instead of thread, and uint8_t instead of unsigned short.