### PR TITLE
ospfd: update ospf_asbr_status when using no_area_nssa command

### DIFF
--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -1730,6 +1730,8 @@ int ospf_area_nssa_unset(struct ospf *ospf, struct in_addr area_id)
 	area->no_summary = 0;
 	area->suppress_fa = 0;
 	area->NSSATranslatorRole = OSPF_NSSA_ROLE_CANDIDATE;
+	if (area->NSSATranslatorState == OSPF_NSSA_TRANSLATE_ENABLED)
+		ospf_asbr_status_update(ospf, --ospf->redistribute);
 	area->NSSATranslatorState = OSPF_NSSA_TRANSLATE_DISABLED;
 	area->NSSATranslatorStabilityInterval = OSPF_NSSA_TRANS_STABLE_DEFAULT;
 	ospf_area_type_set(area, OSPF_AREA_DEFAULT);


### PR DESCRIPTION
In the processing of nssa, if the number of areas that need to be translated is greater than 0, then abr will be regarded as asbr, and it will be marked (0x3) in the flag of router lsa. When a certain area is set from nssa to a normal area, the areas that need to be translated may be reduced. The asbr should be re-interpreted as abr when the translated area is 0.

CLOSES https://github.com/FRRouting/frr/issues/17105