### PR TITLE
bgpd: fix sending ipv6 local nexthop if global present

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -334,13 +334,11 @@ static int bgp_interface_address_add(ZAPI_CALLBACK_ARGS)
 		if (IN6_IS_ADDR_LINKLOCAL(&ifc->address->u.prefix6)
 		    && !list_isempty(ifc->ifp->nbr_connected))
 			bgp_start_interface_nbrs(bgp, ifc->ifp);
-		else {
+		else if (ifc->address->family == AF_INET6 &&
+			 !IN6_IS_ADDR_LINKLOCAL(&ifc->address->u.prefix6)) {
 			addr = ifc->address;
 
 			for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-				if (addr->family == AF_INET)
-					continue;
-
 				/*
 				 * If the Peer's interface name matches the
 				 * interface name for which BGP received the
@@ -354,7 +352,6 @@ static int bgp_interface_address_add(ZAPI_CALLBACK_ARGS)
 				if ((peer->conf_if &&
 				     (strcmp(peer->conf_if, ifc->ifp->name) ==
 				      0)) &&
-				    !IN6_IS_ADDR_LINKLOCAL(&addr->u.prefix6) &&
 				    ((IS_MAPPED_IPV6(
 					     &peer->nexthop.v6_global)) ||
 				     IN6_IS_ADDR_LINKLOCAL(

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -355,8 +355,8 @@ static int bgp_interface_address_add(ZAPI_CALLBACK_ARGS)
 			    ((IS_MAPPED_IPV6(&peer->nexthop.v6_global)) ||
 			     IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_global))) {
 				if (bgp_debug_zebra(ifc->address)) {
-					zlog_debug("Update peer %pBP's current intf addr %pI6 and send updates",
-						   peer, &peer->nexthop.v6_global);
+					zlog_debug("Update peer %pBP's current intf global addr from %pI6 to %pI6 and send updates",
+						   peer, &peer->nexthop.v6_global, &addr->u.prefix6);
 				}
 				memcpy(&peer->nexthop.v6_global, &addr->u.prefix6, IPV6_MAX_BYTELEN);
 				FOREACH_AFI_SAFI (afi, safi)

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -324,53 +324,43 @@ static int bgp_interface_address_add(ZAPI_CALLBACK_ARGS)
 	if (!bgp)
 		return 0;
 
-	if (if_is_operative(ifc->ifp)) {
-		bgp_connected_add(bgp, ifc);
+	if (!if_is_operative(ifc->ifp))
+		return 0;
 
-		/* If we have learnt of any neighbors on this interface,
-		 * check to kick off any BGP interface-based neighbors,
-		 * but only if this is a link-local address.
-		 */
-		if (IN6_IS_ADDR_LINKLOCAL(&ifc->address->u.prefix6)
-		    && !list_isempty(ifc->ifp->nbr_connected))
-			bgp_start_interface_nbrs(bgp, ifc->ifp);
-		else if (ifc->address->family == AF_INET6 &&
-			 !IN6_IS_ADDR_LINKLOCAL(&ifc->address->u.prefix6)) {
-			addr = ifc->address;
+	bgp_connected_add(bgp, ifc);
 
-			for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-				/*
-				 * If the Peer's interface name matches the
-				 * interface name for which BGP received the
-				 * update and if the received interface address
-				 * is a globalV6 and if the peer is currently
-				 * using a v4-mapped-v6 addr or a link local
-				 * address, then copy the Rxed global v6 addr
-				 * into peer's v6_global and send updates out
-				 * with new nexthop addr.
-				 */
-				if ((peer->conf_if &&
-				     (strcmp(peer->conf_if, ifc->ifp->name) ==
-				      0)) &&
-				    ((IS_MAPPED_IPV6(
-					     &peer->nexthop.v6_global)) ||
-				     IN6_IS_ADDR_LINKLOCAL(
-					     &peer->nexthop.v6_global))) {
+	/* If we have learnt of any neighbors on this interface,
+	 * check to kick off any BGP interface-based neighbors,
+	 * but only if this is a link-local address.
+	 */
+	if (IN6_IS_ADDR_LINKLOCAL(&ifc->address->u.prefix6) &&
+	    !list_isempty(ifc->ifp->nbr_connected))
+		bgp_start_interface_nbrs(bgp, ifc->ifp);
+	else if (ifc->address->family == AF_INET6 &&
+		 !IN6_IS_ADDR_LINKLOCAL(&ifc->address->u.prefix6)) {
+		addr = ifc->address;
 
-					if (bgp_debug_zebra(ifc->address)) {
-						zlog_debug(
-							"Update peer %pBP's current intf addr %pI6 and send updates",
-							peer,
-							&peer->nexthop
-								 .v6_global);
-					}
-					memcpy(&peer->nexthop.v6_global,
-					       &addr->u.prefix6,
-					       IPV6_MAX_BYTELEN);
-					FOREACH_AFI_SAFI (afi, safi)
-						bgp_announce_route(peer, afi,
-								   safi, true);
+		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
+			/*
+			 * If the Peer's interface name matches the
+			 * interface name for which BGP received the
+			 * update and if the received interface address
+			 * is a globalV6 and if the peer is currently
+			 * using a v4-mapped-v6 addr or a link local
+			 * address, then copy the Rxed global v6 addr
+			 * into peer's v6_global and send updates out
+			 * with new nexthop addr.
+			 */
+			if ((peer->conf_if && (strcmp(peer->conf_if, ifc->ifp->name) == 0)) &&
+			    ((IS_MAPPED_IPV6(&peer->nexthop.v6_global)) ||
+			     IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_global))) {
+				if (bgp_debug_zebra(ifc->address)) {
+					zlog_debug("Update peer %pBP's current intf addr %pI6 and send updates",
+						   peer, &peer->nexthop.v6_global);
 				}
+				memcpy(&peer->nexthop.v6_global, &addr->u.prefix6, IPV6_MAX_BYTELEN);
+				FOREACH_AFI_SAFI (afi, safi)
+					bgp_announce_route(peer, afi, safi, true);
 			}
 		}
 	}

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -302,11 +302,12 @@ static int bgp_ifp_down(struct interface *ifp)
 
 static int bgp_interface_address_add(ZAPI_CALLBACK_ARGS)
 {
-	struct connected *ifc;
+	struct connected *ifc, *connected;
 	struct bgp *bgp;
 	struct peer *peer;
 	struct prefix *addr;
 	struct listnode *node, *nnode;
+	bool v6_ll_in_nh_global;
 	afi_t afi;
 	safi_t safi;
 
@@ -341,6 +342,23 @@ static int bgp_interface_address_add(ZAPI_CALLBACK_ARGS)
 		addr = ifc->address;
 
 		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
+			v6_ll_in_nh_global = false;
+
+			if (IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_global)) {
+				frr_each (if_connected, ifc->ifp->connected, connected) {
+					if (connected->address->family != AF_INET6)
+						continue;
+					if (!IPV6_ADDR_SAME(&connected->address->u.prefix6,
+							    &peer->nexthop.v6_global))
+						continue;
+					/* peer->nexthop.v6_global contains a link-local address
+					 * that needs to be replaced by the global address.
+					 */
+					v6_ll_in_nh_global = true;
+					break;
+				}
+			}
+
 			/*
 			 * If the Peer's interface name matches the
 			 * interface name for which BGP received the
@@ -351,9 +369,10 @@ static int bgp_interface_address_add(ZAPI_CALLBACK_ARGS)
 			 * into peer's v6_global and send updates out
 			 * with new nexthop addr.
 			 */
-			if ((peer->conf_if && (strcmp(peer->conf_if, ifc->ifp->name) == 0)) &&
-			    ((IS_MAPPED_IPV6(&peer->nexthop.v6_global)) ||
-			     IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_global))) {
+			if (v6_ll_in_nh_global ||
+			    (peer->conf_if && strcmp(peer->conf_if, ifc->ifp->name) == 0 &&
+			     (IS_MAPPED_IPV6(&peer->nexthop.v6_global) ||
+			      IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_global)))) {
 				if (bgp_debug_zebra(ifc->address)) {
 					zlog_debug("Update peer %pBP's current intf global addr from %pI6 to %pI6 and send updates",
 						   peer, &peer->nexthop.v6_global, &addr->u.prefix6);

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/h1/zebra.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/h1/zebra.conf
@@ -1,0 +1,6 @@
+ipv6 route ::/0 fd00:100::2
+ip route 0.0.0.0/0 192.168.1.2
+interface eth-r1
+ ip address 192.168.1.1/24
+ ipv6 address fd00:100::1/64
+!

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/h2/zebra.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/h2/zebra.conf
@@ -1,0 +1,6 @@
+ipv6 route ::/0 fd00:700::2
+ip route 0.0.0.0/0 192.168.7.2
+interface eth-r7
+ ip address 192.168.7.1/24
+ ipv6 address fd00:700::1/64
+!

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/h3/zebra.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/h3/zebra.conf
@@ -1,0 +1,6 @@
+ipv6 route ::/0 fd00:800::2
+ip route 0.0.0.0/0 192.168.8.2
+interface eth-r8
+ ip address 192.168.8.1/24
+ ipv6 address fd00:800::1/64
+!

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r1/bgp_ipv4.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r1/bgp_ipv4.json
@@ -1,0 +1,70 @@
+{
+  "routes": {
+    "192.168.1.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "",
+        "nexthops": [
+          {
+            "ip": "0.0.0.0",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.7.0/24": [
+      {
+        "valid": true,
+        "multipath": true,
+        "path": "65000 65700",
+        "nexthops": [
+          {
+            "ip": "172.16.1.3",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      },
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65000 65700",
+        "nexthops": [
+          {
+            "ip": "172.16.0.2",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.8.0/24": [
+      {
+        "valid": true,
+        "multipath": true,
+        "path": "65000 65800",
+        "nexthops": [
+          {
+            "ip": "172.16.1.3",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      },
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65000 65800",
+        "nexthops": [
+          {
+            "ip": "172.16.0.2",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r1/bgp_ipv6_step1.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r1/bgp_ipv6_step1.json
@@ -1,0 +1,90 @@
+{
+  "routes": {
+    "fd00:100::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "",
+        "nexthops": [
+          {
+            "ip": "::",
+            "afi": "ipv6",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:700::/64": [
+      {
+        "valid": true,
+        "multipath": true,
+        "path": "65000 65700",
+        "nexthops": [
+          {
+            "ip": "fd00:0:2::3",
+            "afi": "ipv6",
+            "scope": "global"
+          },
+          {
+            "afi": "ipv6",
+            "scope": "link-local",
+            "used": true
+          }
+        ]
+      },
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65000 65700",
+        "nexthops": [
+          {
+            "ip": "fd00:0:1::2",
+            "afi": "ipv6",
+            "scope": "global"
+          },
+          {
+            "afi": "ipv6",
+            "scope": "link-local",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:800::/64": [
+      {
+        "valid": true,
+        "multipath": true,
+        "path": "65000 65800",
+        "nexthops": [
+          {
+            "ip": "fd00:0:2::3",
+            "afi": "ipv6",
+            "scope": "global"
+          },
+          {
+            "afi": "ipv6",
+            "scope": "link-local",
+            "used": true
+          }
+        ]
+      },
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65000 65800",
+        "nexthops": [
+          {
+            "ip": "fd00:0:1::2",
+            "afi": "ipv6",
+            "scope": "global"
+          },
+          {
+            "afi": "ipv6",
+            "scope": "link-local",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r1/bgpd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r1/bgpd.conf
@@ -1,0 +1,23 @@
+router bgp 65100
+ no bgp ebgp-requires-policy
+ neighbor 172.16.0.2 remote-as external
+ neighbor 172.16.1.3 remote-as external
+ ! neighbor 172.16.0.2 capability extended-nexthop
+ !
+ address-family ipv4 unicast
+  redistribute connected route-map RMAP4
+ !
+ address-family ipv6 unicast
+  redistribute connected route-map RMAP6
+  neighbor 172.16.0.2 activate
+  neighbor 172.16.1.3 activate
+ !
+
+ip prefix-list RANGE4 seq 10 permit 192.168.0.0/16 le 24
+ipv6 prefix-list RANGE6 seq 10 permit fd00:100::0/64
+
+route-map RMAP4 permit 10
+ match ip address prefix-list RANGE4
+!
+route-map RMAP6 permit 10
+ match ipv6 address prefix-list RANGE6

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r1/zebra.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r1/zebra.conf
@@ -1,0 +1,16 @@
+!
+interface eth-h1
+ ip address 192.168.1.2/24
+ ipv6 address fd00:100::2/64
+!
+interface eth-r2
+ ip address 172.16.0.1/24
+ ipv6 address fd00:0:1::1/64
+!
+interface eth-r3
+ ip address 172.16.1.1/24
+ ipv6 address fd00:0:2::1/64
+!
+interface lo
+ ip address 192.0.2.1/32
+ ipv6 address 2001:db8::1/128

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r2/bgp_ipv4.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r2/bgp_ipv4.json
@@ -1,0 +1,46 @@
+{
+  "routes": {
+    "192.168.1.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65100",
+        "nexthops": [
+          {
+            "ip": "172.16.0.1",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.7.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65700",
+        "nexthops": [
+          {
+            "ip": "172.17.0.7",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.8.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65800",
+        "nexthops": [
+          {
+            "ip": "172.17.0.8",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r2/bgp_ipv6_step1.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r2/bgp_ipv6_step1.json
@@ -1,0 +1,53 @@
+{
+  "routes": {
+    "fd00:100::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65100",
+        "nexthops": [
+          {
+            "ip": "fd00:0:1::1",
+            "afi": "ipv6",
+            "scope": "global"
+          },
+          {
+            "afi": "ipv6",
+            "scope": "link-local",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:700::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65700",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::7",
+            "scope": "global",
+            "afi": "ipv6",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:800::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65800",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::8",
+            "scope": "global",
+            "afi": "ipv6",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r2/bgpd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r2/bgpd.conf
@@ -1,0 +1,11 @@
+router bgp 65000
+ no bgp ebgp-requires-policy
+ neighbor 172.16.0.1 remote-as external
+ ! neighbor 172.16.0.1 capability extended-nexthop
+ neighbor 192.0.2.101 remote-as internal
+ neighbor 192.0.2.101 update-source 192.0.2.2
+ !
+ address-family ipv6 unicast
+  neighbor 172.16.0.1 activate
+  neighbor 192.0.2.101 activate
+ !

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r2/isisd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r2/isisd.conf
@@ -1,0 +1,24 @@
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-rr1
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r1
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+router isis 1
+ net 49.0000.0000.0000.0002.00
+ is-type level-1
+ lsp-gen-interval 1
+ topology ipv6-unicast
+!

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r2/zebra.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r2/zebra.conf
@@ -1,0 +1,12 @@
+!
+interface eth-r1
+ ip address 172.16.0.2/24
+ ipv6 address fd00:0:1::2/64
+!
+interface eth-rr1
+ ip address 10.0.0.2/24
+ ipv6 address fd00:0:3::2/64
+!
+interface lo
+ ip address 192.0.2.2/32
+ ipv6 address 2001:db8::2/128

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r3/bgp_ipv4.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r3/bgp_ipv4.json
@@ -1,0 +1,46 @@
+{
+  "routes": {
+    "192.168.1.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65100",
+        "nexthops": [
+          {
+            "ip": "172.16.1.1",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.7.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65700",
+        "nexthops": [
+          {
+            "ip": "172.17.0.7",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.8.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65800",
+        "nexthops": [
+          {
+            "ip": "172.17.0.8",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r3/bgp_ipv6_step1.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r3/bgp_ipv6_step1.json
@@ -1,0 +1,53 @@
+{
+  "routes": {
+    "fd00:100::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65100",
+        "nexthops": [
+          {
+            "ip": "fd00:0:2::1",
+            "afi": "ipv6",
+            "scope": "global"
+          },
+          {
+            "afi": "ipv6",
+            "scope": "link-local",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:700::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65700",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::7",
+            "scope": "global",
+            "afi": "ipv6",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:800::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65800",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::8",
+            "scope": "global",
+            "afi": "ipv6",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r3/bgpd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r3/bgpd.conf
@@ -1,0 +1,11 @@
+router bgp 65000
+ no bgp ebgp-requires-policy
+ neighbor 172.16.1.1 remote-as external
+ ! neighbor 172.16.1.1 capability extended-nexthop
+ neighbor 192.0.2.101 remote-as internal
+ neighbor 192.0.2.101 update-source 192.0.2.3
+ !
+ address-family ipv6 unicast
+  neighbor 172.16.1.1 activate
+  neighbor 192.0.2.101 activate
+ !

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r3/isisd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r3/isisd.conf
@@ -1,0 +1,24 @@
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-rr1
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r1
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+router isis 1
+ net 49.0000.0000.0000.0003.00
+ is-type level-1
+ lsp-gen-interval 1
+ topology ipv6-unicast
+!

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r3/zebra.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r3/zebra.conf
@@ -1,0 +1,12 @@
+!
+interface eth-r1
+ ip address 172.16.1.3/24
+ ipv6 address fd00:0:2::3/64
+!
+interface eth-rr1
+ ip address 10.0.1.3/24
+ ipv6 address fd00:0:4::3/64
+!
+interface lo
+ ip address 192.0.2.3/32
+ ipv6 address 2001:db8::3/128

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r4/bgp_ipv4.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r4/bgp_ipv4.json
@@ -1,0 +1,46 @@
+{
+  "routes": {
+    "192.168.1.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65100",
+        "nexthops": [
+          {
+            "ip": "172.16.0.1",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.7.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65700",
+        "nexthops": [
+          {
+            "ip": "172.17.0.7",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.8.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65800",
+        "nexthops": [
+          {
+            "ip": "172.17.0.8",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r4/bgp_ipv6_step1.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r4/bgp_ipv6_step1.json
@@ -1,0 +1,49 @@
+{
+  "routes": {
+    "fd00:100::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65100",
+        "nexthops": [
+          {
+            "ip": "fd00:0:1::1",
+            "afi": "ipv6",
+            "scope": "global",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:700::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65700",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::7",
+            "scope": "global",
+            "afi": "ipv6",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:800::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65800",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::8",
+            "scope": "global",
+            "afi": "ipv6",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r4/bgpd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r4/bgpd.conf
@@ -1,0 +1,13 @@
+router bgp 65000
+ neighbor 192.0.2.5 remote-as internal
+ neighbor 192.0.2.6 remote-as internal
+ neighbor 192.0.2.101 remote-as internal
+ neighbor 192.0.2.5 update-source 192.0.2.4
+ neighbor 192.0.2.6 update-source 192.0.2.4
+ neighbor 192.0.2.101 update-source 192.0.2.4
+ !
+ address-family ipv6 unicast
+  neighbor 192.0.2.5 activate
+  neighbor 192.0.2.6 activate
+  neighbor 192.0.2.101 activate
+ !

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r4/isisd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r4/isisd.conf
@@ -1,0 +1,26 @@
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-rr1
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r6
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+router isis 1
+ net 49.0000.0000.0000.0004.00
+ is-type level-1
+ lsp-gen-interval 1
+ topology ipv6-unicast
+!

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r4/zebra.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r4/zebra.conf
@@ -1,0 +1,12 @@
+!
+interface eth-r6
+ ip address 10.0.4.4/24
+ ipv6 address fd00:0:7::4/64
+!
+interface eth-rr1
+ ip address 10.0.2.4/24
+ ipv6 address fd00:0:5::4/64
+!
+interface lo
+ ip address 192.0.2.4/32
+ ipv6 address 2001:db8::4/128

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r5/bgp_ipv4.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r5/bgp_ipv4.json
@@ -1,0 +1,46 @@
+{
+  "routes": {
+    "192.168.1.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65100",
+        "nexthops": [
+          {
+            "ip": "172.16.0.1",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.7.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65700",
+        "nexthops": [
+          {
+            "ip": "172.17.0.7",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.8.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65800",
+        "nexthops": [
+          {
+            "ip": "172.17.0.8",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r5/bgp_ipv6_step1.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r5/bgp_ipv6_step1.json
@@ -1,0 +1,49 @@
+{
+  "routes": {
+    "fd00:100::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65100",
+        "nexthops": [
+          {
+            "ip": "fd00:0:1::1",
+            "afi": "ipv6",
+            "scope": "global",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:700::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65700",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::7",
+            "scope": "global",
+            "afi": "ipv6",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:800::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65800",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::8",
+            "scope": "global",
+            "afi": "ipv6",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r5/bgpd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r5/bgpd.conf
@@ -1,0 +1,13 @@
+router bgp 65000
+ neighbor 192.0.2.4 remote-as internal
+ neighbor 192.0.2.6 remote-as internal
+ neighbor 192.0.2.101 remote-as internal
+ neighbor 192.0.2.4 update-source 192.0.2.5
+ neighbor 192.0.2.6 update-source 192.0.2.5
+ neighbor 192.0.2.101 update-source 192.0.2.5
+ !
+ address-family ipv6 unicast
+  neighbor 192.0.2.4 activate
+  neighbor 192.0.2.6 activate
+  neighbor 192.0.2.101 activate
+ !

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r5/isisd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r5/isisd.conf
@@ -1,0 +1,26 @@
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-rr1
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r6
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+router isis 1
+ net 49.0000.0000.0000.0005.00
+ is-type level-1
+ lsp-gen-interval 1
+ topology ipv6-unicast
+!

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r5/zebra.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r5/zebra.conf
@@ -1,0 +1,12 @@
+!
+interface eth-r6
+ ip address 10.0.5.5/24
+ ipv6 address fd00:0:8::5/64
+!
+interface eth-rr1
+ ip address 10.0.3.5/24
+ ipv6 address fd00:0:6::5/64
+!
+interface lo
+ ip address 192.0.2.5/32
+ ipv6 address 2001:db8::5/128

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r6/bgp_ipv4.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r6/bgp_ipv4.json
@@ -1,0 +1,46 @@
+{
+  "routes": {
+    "192.168.1.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65100",
+        "nexthops": [
+          {
+            "ip": "172.16.0.1",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.7.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65700",
+        "nexthops": [
+          {
+            "ip": "172.17.0.7",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.8.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65800",
+        "nexthops": [
+          {
+            "ip": "172.17.0.8",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r6/bgp_ipv6_step1.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r6/bgp_ipv6_step1.json
@@ -1,0 +1,48 @@
+{
+  "routes": {
+    "fd00:100::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "nexthops": [
+          {
+            "ip": "fd00:0:1::1",
+            "afi": "ipv6",
+            "scope": "global",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:700::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65700",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::7",
+            "afi": "ipv6",
+            "scope": "global",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:800::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65800",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::8",
+            "afi": "ipv6",
+            "scope": "global",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r6/bgpd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r6/bgpd.conf
@@ -1,0 +1,17 @@
+router bgp 65000
+ no bgp ebgp-requires-policy
+ no bgp enforce-first-as
+ neighbor 192.0.2.4 remote-as internal
+ neighbor 192.0.2.5 remote-as internal
+ neighbor 192.0.2.101 remote-as internal
+ neighbor 172.17.0.201 remote-as external
+ neighbor 192.0.2.4 update-source 192.0.2.6
+ neighbor 192.0.2.5 update-source 192.0.2.6
+ neighbor 192.0.2.101 update-source 192.0.2.6
+ !
+ address-family ipv6 unicast
+  neighbor 192.0.2.4 activate
+  neighbor 192.0.2.5 activate
+  neighbor 192.0.2.101 activate
+  neighbor 172.17.0.201 activate
+ !

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r6/isisd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r6/isisd.conf
@@ -1,0 +1,31 @@
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-r4
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r5
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-sw1
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+router isis 1
+ net 49.0000.0000.0000.0006.00
+ is-type level-1
+ lsp-gen-interval 1
+ topology ipv6-unicast
+!

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r6/zebra.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r6/zebra.conf
@@ -1,0 +1,16 @@
+!
+interface eth-r4
+ ip address 10.0.4.6/24
+ ipv6 address fd00:0:7::6/64
+!
+interface eth-r5
+ ip address 10.0.5.6/24
+ ipv6 address fd00:0:8::6/64
+!
+interface eth-sw1
+ ip address 172.17.0.6/24
+ ipv6 address fd00:0:9::6/64
+!
+interface lo
+ ip address 192.0.2.6/32
+ ipv6 address 2001:db8::6/128

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r7/bgp_ipv4.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r7/bgp_ipv4.json
@@ -1,0 +1,46 @@
+{
+  "routes": {
+    "192.168.1.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65000 65100",
+        "nexthops": [
+          {
+            "ip": "172.17.0.6",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.7.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "",
+        "nexthops": [
+          {
+            "ip": "0.0.0.0",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.8.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65800",
+        "nexthops": [
+          {
+            "ip": "172.17.0.8",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r7/bgp_ipv6_step1.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r7/bgp_ipv6_step1.json
@@ -1,0 +1,48 @@
+{
+  "routes": {
+    "fd00:100::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65000 65100",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::6",
+            "afi": "ipv6",
+            "scope": "global",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:700::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "",
+        "nexthops": [
+          {
+            "ip": "::",
+            "afi": "ipv6",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:800::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65800",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::8",
+            "afi": "ipv6",
+            "scope": "global",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r7/bgpd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r7/bgpd.conf
@@ -1,0 +1,21 @@
+router bgp 65700
+ no bgp ebgp-requires-policy
+ no bgp enforce-first-as
+ neighbor 172.17.0.201 remote-as external
+ !
+ address-family ipv4 unicast
+  redistribute connected route-map RMAP4
+ !
+ address-family ipv6 unicast
+  redistribute connected route-map RMAP6
+  neighbor 172.17.0.201 activate
+ !
+
+ip prefix-list RANGE4 seq 10 permit 192.168.0.0/16 le 24
+ipv6 prefix-list RANGE6 seq 10 permit fd00:700::0/64
+
+route-map RMAP4 permit 10
+ match ip address prefix-list RANGE4
+!
+route-map RMAP6 permit 10
+ match ipv6 address prefix-list RANGE6

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r7/zebra.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r7/zebra.conf
@@ -1,0 +1,12 @@
+!
+interface eth-h2
+ ip address 192.168.7.2/24
+ ipv6 address fd00:700::2/64
+!
+interface eth-sw1
+ ip address 172.17.0.7/24
+ ipv6 address fd00:0:9::7/64
+!
+interface lo
+ ip address 192.0.2.7/32
+ ipv6 address 2001:db8::7/128

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r8/bgp_ipv4.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r8/bgp_ipv4.json
@@ -1,0 +1,46 @@
+{
+  "routes": {
+    "192.168.1.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65000 65100",
+        "nexthops": [
+          {
+            "ip": "172.17.0.6",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.7.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65700",
+        "nexthops": [
+          {
+            "ip": "172.17.0.7",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.8.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "",
+        "nexthops": [
+          {
+            "ip": "0.0.0.0",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r8/bgp_ipv6_step1.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r8/bgp_ipv6_step1.json
@@ -1,0 +1,48 @@
+{
+  "routes": {
+    "fd00:100::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65000 65100",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::6",
+            "afi": "ipv6",
+            "scope": "global",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:700::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65700",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::7",
+            "afi": "ipv6",
+            "scope": "global",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:800::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "",
+        "nexthops": [
+          {
+            "ip": "::",
+            "afi": "ipv6",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r8/bgpd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r8/bgpd.conf
@@ -1,0 +1,21 @@
+router bgp 65800
+ no bgp ebgp-requires-policy
+ no bgp enforce-first-as
+ neighbor 172.17.0.201 remote-as external
+ !
+ address-family ipv4 unicast
+  redistribute connected route-map RMAP4
+ !
+ address-family ipv6 unicast
+  redistribute connected route-map RMAP6
+  neighbor 172.17.0.201 activate
+ !
+
+ip prefix-list RANGE4 seq 10 permit 192.168.0.0/16 le 24
+ipv6 prefix-list RANGE6 seq 10 permit fd00:800::0/64
+
+route-map RMAP4 permit 10
+ match ip address prefix-list RANGE4
+!
+route-map RMAP6 permit 10
+ match ipv6 address prefix-list RANGE6

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/r8/zebra.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/r8/zebra.conf
@@ -1,0 +1,12 @@
+!
+interface eth-h3
+ ip address 192.168.8.2/24
+ ipv6 address fd00:800::2/64
+!
+interface eth-sw1
+ ip address 172.17.0.8/24
+ ipv6 address fd00:0:9::8/64
+!
+interface lo
+ ip address 192.0.2.8/32
+ ipv6 address 2001:db8::8/128

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/rr1/bgp_ipv4.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/rr1/bgp_ipv4.json
@@ -1,0 +1,58 @@
+{
+  "routes": {
+    "192.168.1.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65100",
+        "nexthops": [
+          {
+            "ip": "172.16.0.1",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      },
+      {
+        "valid": true,
+        "multipath": true,
+        "path": "65100",
+        "nexthops": [
+          {
+            "ip": "172.16.1.1",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.7.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65700",
+        "nexthops": [
+          {
+            "ip": "172.17.0.7",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "192.168.8.0/24": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65800",
+        "nexthops": [
+          {
+            "ip": "172.17.0.8",
+            "afi": "ipv4",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/rr1/bgp_ipv6_step1.json
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/rr1/bgp_ipv6_step1.json
@@ -1,0 +1,62 @@
+{
+  "routes": {
+    "fd00:100::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65100",
+        "nexthops": [
+          {
+            "ip": "fd00:0:1::1",
+            "afi": "ipv6",
+            "scope": "global",
+            "used": true
+          }
+        ]
+      },
+      {
+        "valid": true,
+        "multipath": true,
+        "path": "65100",
+        "nexthops": [
+          {
+            "ip": "fd00:0:2::1",
+            "afi": "ipv6",
+            "scope": "global",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:700::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65700",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::7",
+            "afi": "ipv6",
+            "scope": "global",
+            "used": true
+          }
+        ]
+      }
+    ],
+    "fd00:800::/64": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "path": "65800",
+        "nexthops": [
+          {
+            "ip": "fd00:0:9::8",
+            "scope": "global",
+            "afi": "ipv6",
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/rr1/bgpd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/rr1/bgpd.conf
@@ -1,0 +1,26 @@
+router bgp 65000
+ neighbor 192.0.2.2 remote-as internal
+ neighbor 192.0.2.3 remote-as internal
+ neighbor 192.0.2.4 remote-as internal
+ neighbor 192.0.2.5 remote-as internal
+ neighbor 192.0.2.6 remote-as internal
+ neighbor 192.0.2.2 update-source 192.0.2.101
+ neighbor 192.0.2.3 update-source 192.0.2.101
+ neighbor 192.0.2.4 update-source 192.0.2.101
+ neighbor 192.0.2.5 update-source 192.0.2.101
+ neighbor 192.0.2.6 update-source 192.0.2.101
+ !
+ address-family ipv4 unicast
+  neighbor 192.0.2.2 route-reflector-client
+  neighbor 192.0.2.3 route-reflector-client
+
+ !
+ address-family ipv6 unicast
+  neighbor 192.0.2.2 activate
+  neighbor 192.0.2.3 activate
+  neighbor 192.0.2.4 activate
+  neighbor 192.0.2.5 activate
+  neighbor 192.0.2.6 activate
+  neighbor 192.0.2.2 route-reflector-client
+  neighbor 192.0.2.3 route-reflector-client
+ !

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/rr1/isisd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/rr1/isisd.conf
@@ -1,0 +1,40 @@
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-r2
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r3
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r4
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+interface eth-r5
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+ isis network point-to-point
+!
+router isis 1
+ net 49.0000.0000.0000.0101.00
+ is-type level-1
+ lsp-gen-interval 1
+ topology ipv6-unicast
+!

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/rr1/zebra.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/rr1/zebra.conf
@@ -1,0 +1,21 @@
+!
+interface eth-r2
+ ip address 10.0.0.101/24
+ ipv6 address fd00:0:3::101/64
+!
+interface eth-r3
+ ip address 10.0.1.101/24
+ ipv6 address fd00:0:4::101/64
+!
+interface eth-r4
+ ip address 10.0.2.101/24
+ ipv6 address fd00:0:5::101/64
+!
+interface eth-r5
+ ip address 10.0.3.101/24
+ ipv6 address fd00:0:6::101/64
+!
+interface lo
+ ip address 192.0.2.101/32
+ ipv6 address 2001:db8::101/128
+

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/rs1/bgpd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/rs1/bgpd.conf
@@ -1,0 +1,21 @@
+router bgp 65200 view RS
+ bgp router-id 192.0.2.201
+ no bgp ebgp-requires-policy
+ neighbor 172.17.0.6 remote-as external
+ neighbor 172.17.0.7 remote-as external
+ neighbor 172.17.0.8 remote-as external
+ !
+ address-family ipv4 unicast
+  neighbor 172.17.0.6 route-server-client
+  neighbor 172.17.0.7 route-server-client
+  neighbor 172.17.0.8 route-server-client
+
+ !
+ address-family ipv6 unicast
+  neighbor 172.17.0.6 activate
+  neighbor 172.17.0.7 activate
+  neighbor 172.17.0.8 activate
+  neighbor 172.17.0.6 route-server-client
+  neighbor 172.17.0.7 route-server-client
+  neighbor 172.17.0.8 route-server-client
+ !

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/rs1/isisd.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/rs1/isisd.conf
@@ -1,0 +1,36 @@
+!
+interface lo
+ ip router isis 1
+ ipv6 router isis 1
+ isis passive
+!
+interface eth-r2
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+!
+interface eth-r3
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+!
+interface eth-r4
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+!
+interface eth-r5
+ ip router isis 1
+ ipv6 router isis 1
+ isis hello-interval 1
+ isis hello-multiplier 3
+!
+router isis 1
+ net 49.0000.0000.0000.0101.00
+ is-type level-1
+ lsp-gen-interval 1
+ topology ipv6-unicast
+!

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/rs1/zebra.conf
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/rs1/zebra.conf
@@ -1,0 +1,8 @@
+interface eth-sw1
+ ip address 172.17.0.201/24
+ ipv6 address fd00:0:9::201/64
+!
+interface lo
+ ip address 192.0.2.201/32
+ ipv6 address 2001:db8::201/128
+

--- a/tests/topotests/bgp_nexthop_mp_ipv4_6/test_nexthop_mp_ipv4_6.py
+++ b/tests/topotests/bgp_nexthop_mp_ipv4_6/test_nexthop_mp_ipv4_6.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2024 by 6WIND
+#
+
+"""
+Test BGP nexthop conformity with IPv4,6 MP-BGP over IPv4 peering
+"""
+
+import os
+import sys
+import json
+import functools
+from functools import partial
+import pytest
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from lib.checkping import check_ping
+from lib.bgp import verify_bgp_convergence_from_running_config
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.isisd]
+
+
+def build_topo(tgen):
+    """
+                 +---+
+                 | h1|
+                 +---+
+                   |
+                 +---+
+                 | r1|          AS 65100
+                 +---+
+                 /   \      _____________
+                /     \
+             +---+  +---+
+             | r2|  | r3|      rr1 is route-reflector
+             +---+  +---+        for r2 and r3
+                \     /
+                 \   /
+                 +---+
+                 |rr1|          AS 65000
+                 +---+
+                /   \
+               /     \
+             +---+  +---+
+             | r4|  | r5|    iBGP full-mesh between
+             +---+  +---+      rr1, r4, r5 and r6
+                \     /
+                 \   /
+                 +---+
+                 | r6|
+                 +---+
+                   |       _____________
+                   |
+                   |       +---+
+                 [sw1]-----|rs1|    AS 65200
+                  /\       +---+   rs1: route-server
+                 /  \
+                /    \     _____________
+             +---+  +---+
+             | r7|  | r8|        AS 65700 (r7)
+             +---+  +---+        AS 65800 (r8)
+               |      |
+             +---+  +---+
+             | h2|  | h3|
+             +---+  +---+
+    """
+
+    def connect_routers(tgen, left, right):
+        for rname in [left, right]:
+            if rname not in tgen.routers().keys():
+                tgen.add_router(rname)
+
+        switch = tgen.add_switch("s-{}-{}".format(left, right))
+        switch.add_link(tgen.gears[left], nodeif="eth-{}".format(right))
+        switch.add_link(tgen.gears[right], nodeif="eth-{}".format(left))
+
+    def connect_switchs(tgen, rname, switch):
+        if rname not in tgen.routers().keys():
+            tgen.add_router(rname)
+
+        switch.add_link(tgen.gears[rname], nodeif="eth-{}".format(switch.name))
+
+    connect_routers(tgen, "h1", "r1")
+    connect_routers(tgen, "r1", "r2")
+    connect_routers(tgen, "r1", "r3")
+    connect_routers(tgen, "r2", "rr1")
+    connect_routers(tgen, "r3", "rr1")
+    connect_routers(tgen, "rr1", "r4")
+    connect_routers(tgen, "rr1", "r5")
+    connect_routers(tgen, "r4", "r6")
+    connect_routers(tgen, "r5", "r6")
+
+    sw1 = tgen.add_switch("sw1")
+    connect_switchs(tgen, "r6", sw1)
+    connect_switchs(tgen, "rs1", sw1)
+    connect_switchs(tgen, "r7", sw1)
+    connect_switchs(tgen, "r8", sw1)
+
+    connect_routers(tgen, "r7", "h2")
+    connect_routers(tgen, "r8", "h3")
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+    logger.info("setup_module")
+
+    for rname, router in tgen.routers().items():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        if "h" in rname:
+            # hosts
+            continue
+
+        router.load_config(
+            TopoRouter.RD_BGP, os.path.join(CWD, "{}/bgpd.conf".format(rname))
+        )
+
+        if rname in ["r1", "r7", "r8", "rs1"]:
+            # external routers
+            continue
+
+        router.load_config(
+            TopoRouter.RD_ISIS, os.path.join(CWD, "{}/isisd.conf".format(rname))
+        )
+
+    # Initialize all routers.
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_convergence():
+    "Assert that BGP is converging."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("waiting for bgp peers to go up")
+
+    for rname in tgen.routers().keys():
+        if "h" in rname:
+            # hosts
+            continue
+        result = verify_bgp_convergence_from_running_config(tgen, dut=rname)
+        assert result is True, "BGP is not converging on {}".format(rname)
+
+
+def test_bgp_ipv4_nexthop_step1():
+    "Assert that BGP has correct ipv4 nexthops."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for rname, router in tgen.routers().items():
+        if "h" in rname:
+            # hosts
+            continue
+        if "rs1" in rname:
+            continue
+        ref_file = "{}/{}/bgp_ipv4.json".format(CWD, rname)
+        expected = json.loads(open(ref_file).read())
+        test_func = partial(
+            topotest.router_json_cmp,
+            router,
+            "show bgp ipv4 unicast json",
+            expected,
+        )
+        _, res = topotest.run_and_expect(test_func, None, count=30, wait=1)
+        assertmsg = "{}: BGP IPv4 Nexthop failure".format(rname)
+        assert res is None, assertmsg
+
+
+def test_bgp_ipv6_nexthop_step1():
+    "Assert that BGP has correct ipv6 nexthops."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for rname, router in tgen.routers().items():
+        if "h" in rname:
+            # hosts
+            continue
+        if "rs1" in rname:
+            continue
+        ref_file = "{}/{}/bgp_ipv6_step1.json".format(CWD, rname)
+        expected = json.loads(open(ref_file).read())
+        test_func = partial(
+            topotest.router_json_cmp,
+            router,
+            "show bgp ipv6 unicast json",
+            expected,
+        )
+        _, res = topotest.run_and_expect(test_func, None, count=30, wait=1)
+        assertmsg = "{}: BGP IPv6 Nexthop failure".format(rname)
+        assert res is None, assertmsg
+
+
+def test_bgp_ping_ok_step1():
+    "Check that h1 pings h2 and h3"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    check_ping("h1", "192.168.7.1", True, 5, 1)
+    check_ping("h1", "fd00:700::1", True, 5, 1)
+    check_ping("h1", "192.168.8.1", True, 5, 1)
+    check_ping("h1", "fd00:800::1", True, 5, 1)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
bgpd keeps on advertising IPv6 prefixes with a IPv6 link-local nexthop
after a valid IPv6 global appears.

At bgpd startup, the IPv6 global is announced by zebra after the
link-local. Only the link-local is advertised. Clearing the BGP sessions
make the global to to be announced.

Update the nexthops with the global IPv6 when available.