### PR TITLE
lib: `debug memstats-at-exit` improvements

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -1269,7 +1269,21 @@ void frr_fini(void)
 	event_master_free(master);
 	master = NULL;
 	zlog_tls_buffer_fini();
-	zlog_fini();
+
+	if (0) {
+		/* this is intentionally disabled.  zlog remains running until
+		 * exit(), so even the very last item done during shutdown can
+		 * have its zlog() messages written out.
+		 *
+		 * Yes this causes memory leaks.  They are explicitly marked
+		 * with DEFINE_MGROUP_ACTIVEATEXIT, which is only used for
+		 * log target memory allocations, and excluded from leak
+		 * reporting at shutdown.  This is strongly preferable over
+		 * just discarding error messages at shutdown.
+		 */
+		zlog_fini();
+	}
+
 	/* frrmod_init -> nothing needed / hooks */
 	rcu_shutdown();
 

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -1245,10 +1245,6 @@ void frr_early_fini(void)
 
 void frr_fini(void)
 {
-	FILE *fp;
-	char filename[128];
-	int have_leftovers = 0;
-
 	hook_call(frr_fini);
 
 	vty_terminate();
@@ -1289,26 +1285,7 @@ void frr_fini(void)
 
 	frrmod_terminate();
 
-	/* also log memstats to stderr when stderr goes to a file*/
-	if (debug_memstats_at_exit || !isatty(STDERR_FILENO))
-		have_leftovers = log_memstats(stderr, di->name);
-
-	/* in case we decide at runtime that we want exit-memstats for
-	 * a daemon
-	 * (only do this if we actually have something to print though)
-	 */
-	if (!debug_memstats_at_exit || !have_leftovers)
-		return;
-
-	snprintf(filename, sizeof(filename), "/tmp/frr-memstats-%s-%llu-%llu",
-		 di->name, (unsigned long long)getpid(),
-		 (unsigned long long)time(NULL));
-
-	fp = fopen(filename, "w");
-	if (fp) {
-		log_memstats(fp, di->name);
-		fclose(fp);
-	}
+	log_memstats(di->name, debug_memstats_at_exit);
 }
 
 struct json_object *frr_daemon_state_load(void)

--- a/lib/log.c
+++ b/lib/log.c
@@ -306,7 +306,7 @@ void memory_oom(size_t size, const char *name)
 	     "out of memory: failed to allocate %zu bytes for %s object",
 	     size, name);
 	zlog_backtrace(LOG_CRIT);
-	log_memstats(stderr, "log");
+	log_memstats(zlog_progname, true);
 	abort();
 }
 

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -181,8 +181,7 @@ static inline size_t mtype_stats_alloc(struct memtype *mt)
  * last value from qmem_walk_fn. */
 typedef int qmem_walk_fn(void *arg, struct memgroup *mg, struct memtype *mt);
 extern int qmem_walk(qmem_walk_fn *func, void *arg);
-extern int log_memstats(FILE *fp, const char *);
-#define log_memstats_stderr(prefix) log_memstats(stderr, prefix)
+extern int log_memstats(const char *daemon_name, bool enabled);
 
 extern __attribute__((__noreturn__)) void memory_oom(size_t size,
 						     const char *name);

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -67,6 +67,8 @@ struct memgroup {
  *         but MGROUP_* aren't.
  */
 
+/* clang-format off */
+
 #define DECLARE_MGROUP(name) extern struct memgroup _mg_##name
 #define _DEFINE_MGROUP(mname, desc, ...)                                       \
 	struct memgroup _mg_##mname _DATA_SECTION("mgroups") = {               \
@@ -75,6 +77,7 @@ struct memgroup {
 		.next = NULL,                                                  \
 		.insert = NULL,                                                \
 		.ref = NULL,                                                   \
+		__VA_ARGS__                                                    \
 	};                                                                     \
 	static void _mginit_##mname(void) __attribute__((_CONSTRUCTOR(1000))); \
 	static void _mginit_##mname(void)                                      \
@@ -135,6 +138,8 @@ struct memgroup {
 #define DEFINE_MTYPE_STATIC(group, name, desc)                                 \
 	DEFINE_MTYPE_ATTR(group, name, static, desc)                           \
 	/* end */
+
+/* clang-format on */
 
 DECLARE_MGROUP(LIB);
 DECLARE_MTYPE(TMP);

--- a/lib/sigevent.c
+++ b/lib/sigevent.c
@@ -237,8 +237,18 @@ core_handler(int signo, siginfo_t *siginfo, void *context)
 
 	zlog_signal(signo, "aborting...", siginfo, pc);
 
-	/* dump memory stats on core */
-	log_memstats(stderr, "core_handler");
+	/* there used to be a log_memstats() call here, to dump MTYPE counters
+	 * on a coredump.  This is not possible since log_memstats is not
+	 * AS-Safe, as it calls fopen(), fprintf(), and cousins.  This can
+	 * lead to a deadlock depending on where we crashed - very much not a
+	 * good thing if the process just hangs there after a crash.
+	 *
+	 * The alarm(1) above tries to alleviate this, but that's really a
+	 * last resort recovery.  Stick with AS-safe calls here.
+	 *
+	 * If the fprintf() calls are removed from log_memstats(), this can be
+	 * added back in, since writing to log with zlog_sigsafe() is AS-safe.
+	 */
 
 	/*
 	 * This is a buffer flush because FRR is going down

--- a/tests/isisd/test_fuzz_isis_tlv.c
+++ b/tests/isisd/test_fuzz_isis_tlv.c
@@ -22,7 +22,7 @@ static bool atexit_registered;
 
 static void show_meminfo_at_exit(void)
 {
-	log_memstats(stderr, "isis fuzztest");
+	log_memstats(NULL, true);
 }
 
 static int comp_line(const void *p1, const void *p2)

--- a/tests/isisd/test_isis_spf.c
+++ b/tests/isisd/test_isis_spf.c
@@ -475,7 +475,7 @@ static void vty_do_exit(int isexit)
 	yang_terminate();
 	event_master_free(master);
 
-	log_memstats(stderr, "test-isis-spf");
+	log_memstats(NULL, true);
 	if (!isexit)
 		exit(0);
 }

--- a/tests/lib/cli/common_cli.c
+++ b/tests/lib/cli/common_cli.c
@@ -43,7 +43,7 @@ static void vty_do_exit(int isexit)
 	yang_terminate();
 	event_master_free(master);
 
-	log_memstats(stderr, "testcli");
+	log_memstats(NULL, true);
 	if (!isexit)
 		exit(0);
 }

--- a/tests/lib/northbound/test_oper_data.c
+++ b/tests/lib/northbound/test_oper_data.c
@@ -427,7 +427,7 @@ static void vty_do_exit(int isexit)
 	yang_terminate();
 	event_master_free(master);
 
-	log_memstats(stderr, "test-nb-oper-data");
+	log_memstats(NULL, true);
 	if (!isexit)
 		exit(0);
 }

--- a/tests/lib/test_typelist.c
+++ b/tests/lib/test_typelist.c
@@ -156,6 +156,6 @@ int main(int argc, char **argv)
 	test_ATOMSORT_UNIQ();
 	test_ATOMSORT_NONUNIQ();
 
-	log_memstats_stderr("test: ");
+	log_memstats(NULL, true);
 	return 0;
 }

--- a/tests/lib/test_zmq.c
+++ b/tests/lib/test_zmq.c
@@ -285,7 +285,7 @@ static void run_server(int syncfd)
 	zmq_close(zmqsock);
 	frrzmq_finish();
 	event_master_free(master);
-	log_memstats_stderr("test");
+	log_memstats(NULL, true);
 }
 
 int main(void)


### PR DESCRIPTION
Refactor the `debug memstats-at-exit` code a little bit:

* `DEFINE_MGROUP_ACTIVEATEXIT` now works correctly to mark MTYPEs that are intentionally leaked at exit (this is only used for the logging subsystem, so we can log until the process really dies.)
  * also add a comment explaining this
* actually use the logging subsystem to log the memstats themselves (kinda the point of keeping the logging subsystem active) ⇒ memstats can now be found in the same place as the regular logs
  * existing locations for memstats (`stderr`, `/tmp/frr-memstats-…`) still work as before
* remove memstats from SEGV/crashlogs (it can hang if we're crashing in a bad place, e.g. inside `malloc()`)
   * also add a comment explaining this