### PR TITLE
*: remove remaining `strncpy()` users

### DIFF
--- a/lib/csv.c
+++ b/lib/csv.c
@@ -573,7 +573,7 @@ void csv_decode(csv_t *csv, char *inbuf)
 				log_error("field str malloc failed\n");
 				return;
 			}
-			strncpy(rec->record, buf, pos - buf + 1);
+			memcpy(rec->record, buf, MIN(pos - buf + 1, csv->buflen - 1));
 		}
 		rec->rec_len = pos - buf + 1;
 		/* decode record into fields */

--- a/lib/ptm_lib.c
+++ b/lib/ptm_lib.c
@@ -454,7 +454,7 @@ ptm_lib_handle_t *ptm_lib_register(char *client_name, ptm_cmd_cb cmd_cb,
 	hdl = calloc(1, sizeof(*hdl));
 
 	if (hdl) {
-		strncpy(hdl->client_name, client_name, PTMLIB_MAXNAMELEN - 1);
+		strlcpy(hdl->client_name, client_name, sizeof(hdl->client_name));
 		hdl->cmd_cb = cmd_cb;
 		hdl->notify_cb = notify_cb;
 		hdl->response_cb = response_cb;

--- a/tests/helpers/c/prng.c
+++ b/tests/helpers/c/prng.c
@@ -49,16 +49,17 @@ const char *prng_fuzz(struct prng *prng, const char *string,
 		      const char *charset, unsigned int operations)
 {
 	static char buf[256];
-	unsigned int charset_len;
+	size_t charset_len = strlen(charset);
+	size_t str_len = strlen(string);
 	unsigned int i;
 	unsigned int offset;
 	unsigned int op;
 	unsigned int character;
 
-	assert(strlen(string) < sizeof(buf));
+	assert(str_len < sizeof(buf));
 
-	strncpy(buf, string, sizeof(buf));
-	charset_len = strlen(charset);
+	memset(buf, 0, sizeof(buf));
+	memcpy(buf, string, str_len);
 
 	for (i = 0; i < operations; i++) {
 		offset = prng_rand(prng) % strlen(buf);

--- a/tests/isisd/test_fuzz_isis_tlv.c
+++ b/tests/isisd/test_fuzz_isis_tlv.c
@@ -43,7 +43,7 @@ static char *sortlines(char *in)
 	}
 
 	if (line_count == 1) {
-		strncpy(rv, in, rv_len);
+		memcpy(rv, in, rv_len);
 		return rv;
 	}
 

--- a/tools/start-stop-daemon.c
+++ b/tools/start-stop-daemon.c
@@ -749,8 +749,7 @@ static void do_stop(int signal_nr, int quietmode, int *n_killed,
 
 static void set_what_stop(const char *str)
 {
-	strncpy(what_stop, str, sizeof(what_stop));
-	what_stop[sizeof(what_stop) - 1] = '\0';
+	strlcpy(what_stop, str, sizeof(what_stop));
 }
 
 static int run_stop_schedule(void)


### PR DESCRIPTION
the `checkpatch` warnings on unrelated PRs have pestered me enough to go remove the few `strncpy()` calls we have left :neutral_face:

Free overflow guard in the CSV code because it's not obvious to me that this strncpy (now memcpy) wasn't writing past the end of the allocated buffer… this CSV code has a bit of "code smell" tbh.