### PR TITLE
zebra: fix showing nexthop vrf for ipv6 blackhole

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1271,7 +1271,7 @@ void show_nexthop_json_helper(json_object *json_nexthop,
 	bool display_vrfid = false;
 	uint8_t rn_family;
 
-	if (re == NULL || nexthop->vrf_id != re->vrf_id)
+	if ((re == NULL || nexthop->vrf_id != re->vrf_id) && nexthop->type != NEXTHOP_TYPE_BLACKHOLE)
 		display_vrfid = true;
 
 	if (rn)
@@ -1292,7 +1292,7 @@ void show_route_nexthop_helper(struct vty *vty, const struct route_node *rn,
 	bool display_vrfid = false;
 	uint8_t rn_family;
 
-	if (re == NULL || nexthop->vrf_id != re->vrf_id)
+	if ((re == NULL || nexthop->vrf_id != re->vrf_id) && nexthop->type != NEXTHOP_TYPE_BLACKHOLE)
 		display_vrfid = true;
 
 	if (rn)

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -370,7 +370,7 @@ static void show_nexthop_detail_helper(struct vty *vty,
 		break;
 	}
 
-	if (re->vrf_id != nexthop->vrf_id) {
+	if (re->vrf_id != nexthop->vrf_id && nexthop->type != NEXTHOP_TYPE_BLACKHOLE) {
 		struct vrf *vrf = vrf_lookup_by_id(nexthop->vrf_id);
 
 		vty_out(vty, "(vrf %s)", VRF_LOGNAME(vrf));


### PR DESCRIPTION
For some reasons the Linux kernel associates the ipv6 blackhole of non default table the lo interface.

> root@r1# ip -6 route show table 100
> root@r1# ip -6 route add unreachable default metric 4278198272 table 100
> root@r1# ip -6 route show table 100
> unreachable default dev lo metric 4278198272 pref medium

As a consequence, the VRF default that owns the lo interface is shown as the nexthop VRF:

> r1# show ipv6 route table 20
> Table 20:
> K>* ::/0 [255/8192] unreachable (ICMP unreachable) (vrf default), 00:18:12

Do not display the nexthop VRF of a blackhole. It does not make sense for a blackhole and it was not displayed in the past.