### PR TITLE
bgpd: allow value 0 in aigp-metric setting

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -7255,7 +7255,7 @@ DEFUN_YANG (no_set_atomic_aggregate,
 
 DEFPY_YANG (set_aigp_metric,
 	    set_aigp_metric_cmd,
-	    "set aigp-metric <igp-metric|(1-4294967295)>$aigp_metric",
+	    "set aigp-metric <igp-metric|(0-4294967295)>$aigp_metric",
 	    SET_STR
 	    "BGP AIGP attribute (AIGP Metric TLV)\n"
 	    "AIGP Metric value from IGP protocol\n"
@@ -7275,7 +7275,7 @@ DEFPY_YANG (set_aigp_metric,
 
 DEFPY_YANG (no_set_aigp_metric,
 	    no_set_aigp_metric_cmd,
-	    "no set aigp-metric [<igp-metric|(1-4294967295)>]",
+	    "no set aigp-metric [<igp-metric|(0-4294967295)>]",
 	    NO_STR
 	    SET_STR
 	    "BGP AIGP attribute (AIGP Metric TLV)\n"

--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -331,7 +331,7 @@ Route Map Set Command
 
    Set the maximum metric for the route.
 
-.. clicmd:: set aigp-metric <igp-metric|(1-4294967295)>
+.. clicmd:: set aigp-metric <igp-metric|(0-4294967295)>
 
    Set the BGP attribute AIGP to a specific value. If ``igp-metric`` is specified,
    then the value is taken from the IGP protocol, otherwise an arbitrary value.


### PR DESCRIPTION
The value of 0 is accepted from peers, and can also be set by the route-map "set aigp-metric igp-metric". For consistency, it should be allowed in "set aigp-metric <value>" as well.