### PR TITLE
ospfd:fix syntax of some ospf no commands

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -1264,7 +1264,7 @@ DEFUN (ospf_area_vlink_intervals,
 
 DEFUN (no_ospf_area_vlink_intervals,
        no_ospf_area_vlink_intervals_cmd,
-       "no area <A.B.C.D|(0-4294967295)> virtual-link A.B.C.D {hello-interval (1-65535)|retransmit-interval (1-65535)|retransmit-window (20-1000)|transmit-delay (1-65535)|dead-interval (1-65535)}",
+       "no area <A.B.C.D|(0-4294967295)> virtual-link A.B.C.D {hello-interval [(1-65535)]|retransmit-interval [(1-65535)]|retransmit-window [(20-1000)]|transmit-delay [(1-65535)]|dead-interval [(1-65535)]}",
        NO_STR
        VLINK_HELPSTR_IPADDR
        VLINK_HELPSTR_TIME_PARAM)
@@ -1581,7 +1581,7 @@ DEFPY (no_ospf_area_nssa,
        "no area <A.B.C.D|(0-4294967295)>$area_str nssa\
          [{\
 	   <translate-candidate|translate-never|translate-always>\
-	   |default-information-originate [{metric (0-16777214)|metric-type (1-2)}]\
+	   |default-information-originate [{metric [(0-16777214)]|metric-type [(1-2)]}]\
 	   |no-summary\
 	   |suppress-fa\
 	 }]",
@@ -1662,7 +1662,7 @@ DEFPY (ospf_area_nssa_range,
 
 DEFPY (no_ospf_area_nssa_range,
        no_ospf_area_nssa_range_cmd,
-       "no area <A.B.C.D|(0-4294967295)>$area_str nssa range A.B.C.D/M$prefix [<not-advertise|cost (0-16777215)>]",
+       "no area <A.B.C.D|(0-4294967295)>$area_str nssa range A.B.C.D/M$prefix [<not-advertise|cost [(0-16777215)]>]",
        NO_STR
        "OSPF area parameters\n"
        "OSPF area ID in IP address format\n"
@@ -1741,7 +1741,7 @@ DEFUN (ospf_area_default_cost,
 
 DEFUN (no_ospf_area_default_cost,
        no_ospf_area_default_cost_cmd,
-       "no area <A.B.C.D|(0-4294967295)> default-cost (0-16777215)",
+       "no area <A.B.C.D|(0-4294967295)> default-cost [(0-16777215)]",
        NO_STR
        "OSPF area parameters\n"
        "OSPF area ID in IP address format\n"
@@ -2589,7 +2589,7 @@ ALIAS(ospf_write_multiplier, write_multiplier_cmd, "write-multiplier (1-100)",
 
 DEFUN (no_ospf_write_multiplier,
        no_ospf_write_multiplier_cmd,
-       "no ospf write-multiplier (1-100)",
+       "no ospf write-multiplier [(1-100)]",
        NO_STR
        "OSPF specific commands\n"
        "Write multiplier\n"
@@ -9558,7 +9558,7 @@ DEFUN (ospf_default_information_originate,
 
 DEFUN (no_ospf_default_information_originate,
        no_ospf_default_information_originate_cmd,
-       "no default-information originate [{always|metric (0-16777214)|metric-type (1-2)|route-map RMAP_NAME}]",
+       "no default-information originate [{always|metric [(0-16777214)]|metric-type [(1-2)]|route-map [RMAP_NAME]}]",
        NO_STR
        "Control distribution of default information\n"
        "Distribute a default route\n"
@@ -9642,7 +9642,7 @@ DEFUN (ospf_distance,
 
 DEFUN (no_ospf_distance,
        no_ospf_distance_cmd,
-       "no distance (1-255)",
+       "no distance [(1-255)]",
        NO_STR
        "Administrative distance\n"
        "OSPF Administrative distance\n")


### PR DESCRIPTION
Fix syntax of some no commands:
1. `no area virtual link A.B.C.D hello-interval <NUM>`, `<NUM>` can be omitted.
2. `no area nssa default-information-originate metric <NUM>`, `<NUM>` can be omitted.
3. `no area nssa range cost <NUM>`, `<NUM>` can be omitted.
4. `no area default cost <NUM>`, `<NUM>` can be omitted.
5. `no ospf write-multiplier <NUM>`, `<NUM>` can be omitted.
6. `no default-information originate metric <NUM>`, `<NUM>` can be omitted.
7.  `no distance <NUM>`, `<NUM>` can be omitted.