### PR TITLE
isisd: The command "'show isis vrf all summary json" has no output.

### DIFF
--- a/tests/topotests/isis_topo1/test_isis_topo1.py
+++ b/tests/topotests/isis_topo1/test_isis_topo1.py
@@ -237,9 +237,9 @@ def test_isis_summary_json():
         assertmsg = "Test isis summary json failed in '{}' data '{}'".format(
             rname, json_output
         )
-        assert json_output["vrf"] == "default", assertmsg
-        assert json_output["areas"][0]["area"] == "1", assertmsg
-        assert json_output["areas"][0]["levels"][0]["id"] != "3", assertmsg
+        assert json_output["vrfs"][0]["vrf"] == "default", assertmsg
+        assert json_output["vrfs"][0]["areas"][0]["area"] == "1", assertmsg
+        assert json_output["vrfs"][0]["areas"][0]["levels"][0]["id"] != "3", assertmsg
 
 
 def test_isis_interface_json():


### PR DESCRIPTION
Modify the implementation by referring to the "show isis vrf all interface json" command, mainly by adding vrfs nodes in the JSON.