### PR TITLE
bgpd: fix uninitialized bgp_labels

### DIFF
--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -38,7 +38,7 @@ static void *bgp_labels_hash_alloc(void *p)
 	struct bgp_labels *new;
 	uint8_t i;
 
-	new = XMALLOC(MTYPE_BGP_LABELS, sizeof(struct bgp_labels));
+	new = XCALLOC(MTYPE_BGP_LABELS, sizeof(struct bgp_labels));
 
 	new->num_labels = labels->num_labels;
 	for (i = 0; i < labels->num_labels; i++)

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1613,8 +1613,8 @@ void vpn_leak_from_vrf_update(struct bgp *to_bgp,	     /* to */
 	struct attr static_attr = {0};
 	struct attr *new_attr = NULL;
 	safi_t safi = SAFI_MPLS_VPN;
-	mpls_label_t label_val;
-	mpls_label_t label;
+	mpls_label_t label_val = { 0 };
+	mpls_label_t label = { 0 };
 	struct bgp_dest *bn;
 	const char *debugmsg;
 	int nexthop_self_flag = 0;


### PR DESCRIPTION
Fixes for valgrind issues in https://github.com/FRRouting/frr/issues/17144

Closes https://github.com/FRRouting/frr/issues/17144