### PR TITLE
ospfd: Fix opaque LSA refresh interval and modify LSA cmds.

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -200,6 +200,44 @@ To start OSPF process you have to specify the OSPF router.
    This command supersedes the *timers spf* command in previous FRR
    releases.
 
+.. clicmd:: timers throttle lsa all (0-5000)
+
+   This command sets the minumum interval between originations of the
+   same LSA or the `minimum LSA refresh interval`. The time is specified
+   in milliseconds and the default is 5 seconds (5000 milliseconds) consistent
+   with the architectual constant MinLSInterval specified in Appendix D of
+   RFC 2328. When a self-originated LSA needs to be reoriginated, it may be
+   delayed for up to this interval.
+
+   .. code-block:: frr
+
+      router ospf
+       timers throttle lsa all 1000
+
+
+   In this example, the `mininum LSA refresh interval` is set to 1000ms. This
+   command reduces the delay between successive originations of a self-originated
+   LSA from 5000 milliseconds to 1000 milliseconds.
+
+.. clicmd:: timers lsa min-arrival (0-5000)
+
+   This command sets the minumum interval between receptions of instances of
+   the same LSA or the `minimum LSA arrival interval`. The time is specified in
+   milliseconds and the default is 1 second (1000 milliseconds) consistent with
+   the architectual constant MinLSArrival specified in Appendix D of RFC 2328. If a
+   newer instance of the same LSA is received in less than this interval, it is
+   ignored.
+
+   .. code-block:: frr
+
+      router ospf
+       timers lsa min-arrival 50
+
+
+   In this example, the `minimum LSA arrival interval` is set to 50ms. This
+   command reduces the minimum interval required between instances of the same
+   LSA from 1000 milliseconds to 50 milliseconds.
+
 .. clicmd:: max-metric router-lsa [on-startup (5-86400)|on-shutdown (5-100)]
 
 .. clicmd:: max-metric router-lsa administrative

--- a/lib/libospf.h
+++ b/lib/libospf.h
@@ -27,8 +27,9 @@ extern "C" {
 #else
 #define OSPF_LS_REFRESH_TIME                  1800
 #endif
-#define OSPF_MIN_LS_INTERVAL                  5000     /* msec */
-#define OSPF_MIN_LS_ARRIVAL                   1000     /* in milliseconds */
+#define OSPF_MIN_LS_INTERVAL			 5000	/* milliseconds */
+#define OSPF_MIN_LS_ARRIVAL			 1000	/* milliseconds */
+#define OSPF_MIN_LS_ARRIVAL_MAX			 5000	/* milliseconds */
 #define OSPF_LSA_INITIAL_AGE                     0	/* useful for debug */
 #define OSPF_LSA_MAXAGE                       3600
 #define OSPF_CHECK_AGE                         300

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -225,12 +225,14 @@ enum lsid_status { LSID_AVAILABLE = 0, LSID_CHANGE, LSID_NOT_AVAILABLE };
 /* Prototypes. */
 /* XXX: Eek, time functions, similar are in lib/thread.c */
 extern struct timeval int2tv(int);
+
 extern struct timeval msec2tv(int a);
+extern int tv2msec(struct timeval tv);
 
 extern int get_age(struct ospf_lsa *lsa);
 extern uint16_t ospf_lsa_checksum(struct lsa_header *lsah);
 extern int ospf_lsa_checksum_valid(struct lsa_header *lsah);
-extern int ospf_lsa_refresh_delay(struct ospf_lsa *lsa);
+extern int ospf_lsa_refresh_delay(struct ospf *ospf, struct ospf_lsa *lsa);
 
 extern const char *dump_lsa_key(struct ospf_lsa *lsa);
 extern uint32_t lsa_seqnum_increment(struct ospf_lsa *lsa);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2305,34 +2305,9 @@ static int ospf_timers_spf_set(struct vty *vty, unsigned int delay,
 	return CMD_SUCCESS;
 }
 
-DEFUN (ospf_timers_min_ls_interval,
+DEFPY (ospf_timers_min_ls_interval,
        ospf_timers_min_ls_interval_cmd,
-       "timers throttle lsa all (0-5000)",
-       "Adjust routing timers\n"
-       "Throttling adaptive timer\n"
-       "LSA delay between transmissions\n"
-       "All LSA types\n"
-       "Delay (msec) between sending LSAs\n")
-{
-	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
-	int idx_number = 4;
-	unsigned int interval;
-
-	if (argc < 5) {
-		vty_out(vty, "Insufficient arguments\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	interval = strtoul(argv[idx_number]->arg, NULL, 10);
-
-	ospf->min_ls_interval = interval;
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_ospf_timers_min_ls_interval,
-       no_ospf_timers_min_ls_interval_cmd,
-       "no timers throttle lsa all [(0-5000)]",
+       "[no] timers throttle lsa all ![(0-5000)]$lsa_refresh_interval",
        NO_STR
        "Adjust routing timers\n"
        "Throttling adaptive timer\n"
@@ -2341,7 +2316,11 @@ DEFUN (no_ospf_timers_min_ls_interval,
        "Delay (msec) between sending LSAs\n")
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
-	ospf->min_ls_interval = OSPF_MIN_LS_INTERVAL;
+
+	if (no)
+		ospf->min_ls_interval = OSPF_MIN_LS_INTERVAL;
+	else
+		ospf->min_ls_interval = strtoul(lsa_refresh_interval_str, NULL, 10);
 
 	return CMD_SUCCESS;
 }
@@ -2390,40 +2369,35 @@ DEFUN (no_ospf_timers_throttle_spf,
 }
 
 
-DEFUN (ospf_timers_lsa_min_arrival,
+DEFPY (ospf_timers_lsa_min_arrival,
        ospf_timers_lsa_min_arrival_cmd,
-       "timers lsa min-arrival (0-600000)",
-       "Adjust routing timers\n"
-       "OSPF LSA timers\n"
-       "Minimum delay in receiving new version of a LSA\n"
-       "Delay in milliseconds\n")
-{
-	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
-	ospf->min_ls_arrival = strtoul(argv[argc - 1]->arg, NULL, 10);
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_ospf_timers_lsa_min_arrival,
-       no_ospf_timers_lsa_min_arrival_cmd,
-       "no timers lsa min-arrival [(0-600000)]",
+       "[no] timers lsa min-arrival ![(0-5000)]$min_arrival",
        NO_STR
        "Adjust routing timers\n"
        "OSPF LSA timers\n"
-       "Minimum delay in receiving new version of a LSA\n"
+       "Minimum delay in receiving new version of an LSA\n"
        "Delay in milliseconds\n")
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
-	unsigned int minarrival;
+	if (no)
+		ospf->min_ls_arrival = OSPF_MIN_LS_ARRIVAL;
+	else
+		ospf->min_ls_arrival = strtoul(min_arrival_str, NULL, 10);
+	return CMD_SUCCESS;
+}
 
-	if (argc > 4) {
-		minarrival = strtoul(argv[argc - 1]->arg, NULL, 10);
-
-		if (ospf->min_ls_arrival != minarrival
-		    || minarrival == OSPF_MIN_LS_ARRIVAL)
-			return CMD_SUCCESS;
-	}
-
-	ospf->min_ls_arrival = OSPF_MIN_LS_ARRIVAL;
+DEFPY_HIDDEN (ospf_timers_lsa_min_arrival_deprecated,
+	      ospf_timers_lsa_min_arrival_deprecated_cmd,
+	      "timers lsa min-arrival [(5001-60000)]$min_arrival",
+	      "Adjust routing timers\n"
+	      "OSPF LSA timers\n"
+	      "Minimum delay in receiving new version of an LSA\n"
+	      "Deprecated delay in milliseconds - delays in this range default to 5000 msec\n")
+{
+	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
+	vty_out(vty, "%% OSPF `timers lsa min-arrival` set to the maximum of %u milliseconds\n",
+		OSPF_MIN_LS_ARRIVAL_MAX);
+	ospf->min_ls_arrival = OSPF_MIN_LS_ARRIVAL_MAX;
 
 	return CMD_SUCCESS;
 }
@@ -13710,9 +13684,8 @@ void ospf_vty_init(void)
 
 	/* LSA timers commands */
 	install_element(OSPF_NODE, &ospf_timers_min_ls_interval_cmd);
-	install_element(OSPF_NODE, &no_ospf_timers_min_ls_interval_cmd);
 	install_element(OSPF_NODE, &ospf_timers_lsa_min_arrival_cmd);
-	install_element(OSPF_NODE, &no_ospf_timers_lsa_min_arrival_cmd);
+	install_element(OSPF_NODE, &ospf_timers_lsa_min_arrival_deprecated_cmd);
 
 	/* refresh timer commands */
 	install_element(OSPF_NODE, &ospf_refresh_timer_cmd);


### PR DESCRIPTION
The configured OSPF refresh interval was not being used for opaque LSA (it always used the constant). Also, modified the timers lsa min-arrival command to have a maximum of 5000 msecs as well as providing a path for backward command compatibility.

Added missing user documentation for both timers lsa min-arrival and timers throttle lsa all.