### PR TITLE
Revert "lib: Attach stdout to child only if --log=stdout and stdout F…

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -1126,12 +1126,9 @@ static void frr_terminal_close(int isexit)
 		 * don't redirect when stdout is set with --log stdout
 		 */
 		for (fd = 2; fd >= 0; fd--)
-			if (logging_to_stdout && isatty(fd) &&
-			    fd == STDOUT_FILENO) {
-				/* Do nothing. */
-			} else {
+			if (isatty(fd) &&
+			    (fd != STDOUT_FILENO || !logging_to_stdout))
 				dup2(nullfd, fd);
-			}
 		close(nullfd);
 	}
 }
@@ -1217,12 +1214,9 @@ void frr_run(struct event_loop *master)
 			 * stdout
 			 */
 			for (fd = 2; fd >= 0; fd--)
-				if (logging_to_stdout && isatty(fd) &&
-				    fd == STDOUT_FILENO) {
-					/* Do nothing. */
-				} else {
+				if (isatty(fd) &&
+				    (fd != STDOUT_FILENO || !logging_to_stdout))
 					dup2(nullfd, fd);
-				}
 			close(nullfd);
 		}
 


### PR DESCRIPTION
…D is a tty"

This reverts commit 0e3c5e8e5907321b35201f0985c1d3f4a1b0e639.