### PR TITLE
bgpd: compare aigp after local route check in bgp_path_info_cmp()

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -160,15 +160,15 @@ bottom until one of the factors can be used.
 
    Prefer higher local preference routes to lower.
 
+3. **Local route check**
+
+   Prefer local routes (statics, aggregates, redistributed) to received routes.
+
    If ``bgp bestpath aigp`` is enabled, and both paths that are compared have
    AIGP attribute, BGP uses AIGP tie-breaking unless both of the paths have the
    AIGP metric attribute. This means that the AIGP attribute is not evaluated
    during the best path selection process between two paths when one path does
    not have the AIGP attribute.
-
-3. **Local route check**
-
-   Prefer local routes (statics, aggregates, redistributed) to received routes.
 
 4. **AS path length check**
 

--- a/tests/topotests/bgp_aigp_rr/r1/bgpd.conf
+++ b/tests/topotests/bgp_aigp_rr/r1/bgpd.conf
@@ -18,10 +18,15 @@ router bgp 65001
  neighbor 10.0.0.4 timers connect 1
  neighbor 10.0.0.4 route-reflector-client
  address-family ipv4
+  network 10.0.1.2/32 route-map set-aigp
   neighbor 10.0.0.4 route-map set-nexthop out
  exit-address-family
 !
 route-map set-nexthop permit 10
  set ip next-hop peer-address
 exit
+!
+route-map set-aigp permit 10
+ set aigp 50
+ set weight 0
 !

--- a/tests/topotests/bgp_aigp_rr/r2/bgpd.conf
+++ b/tests/topotests/bgp_aigp_rr/r2/bgpd.conf
@@ -7,6 +7,7 @@ router bgp 65001
  neighbor 10.0.0.1 timers connect 1
  address-family ipv4
   redistribute connected route-map connected-to-bgp
+  network 10.0.1.2/32 route-map set-aigp
   neighbor 10.0.0.1 next-hop-self
  exit-address-family
 !
@@ -15,4 +16,7 @@ ip prefix-list p22 seq 5 permit 10.0.2.2/32
 route-map connected-to-bgp permit 10
  match ip address prefix-list p22
  set aigp 2
+!
+route-map set-aigp permit 10
+ set aigp 10
 !


### PR DESCRIPTION
For consistency between RIB and BGP, the aigp comparison should be made after the local route check in bgp bestpath selection.

As a reference, that's exactly what Cisco IOS does:

https://www.cisco.com/c/en/us/support/docs/ip/border-gateway-protocol-bgp/119001-configure-aigp-00.html