### PR TITLE
vtysh: fix `find` and `list` commands

### DIFF
--- a/python/xref2vtysh.py
+++ b/python/xref2vtysh.py
@@ -450,9 +450,11 @@ class CommandEntry:
 	graph_delete_node(node->cmdgraph, vector_slot(node->cmdgraph->nodes, 0));
 	vector_free(node->cmdgraph->nodes);
 	node->cmdgraph->nodes = &gvec_{node};
-{'}'}
 """
         )
+        for cmdel in sorted(cmdels):
+            ofd.write(f"\tvector_set(node->cmd_vector, &{cmdel}_vtysh);\n")
+        ofd.write("}\n")
 
         return [node]
 


### PR DESCRIPTION
I simply missed that `node->cmd_vector` is needed for `find` and `list` to work correctly.

---
Fixes: #17043
Fixes: 4bc41193e810 ("vtysh, lib: preprocess CLI graphs")