### PR TITLE
debian: Add missing libprotobuf-dev to grpc profile

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,8 @@ Build-Depends: bison,
 	       libgrpc-dev (>=1.16.1) <pkg.frr.grpc>,
 	       libgrpc++-dev (>=1.16.1) <pkg.frr.grpc>,
 	       protobuf-compiler (>=3.6.1) <pkg.frr.grpc>,
-	       protobuf-compiler-grpc (>=1.16.1) <pkg.frr.grpc>
+	       protobuf-compiler-grpc (>=1.16.1) <pkg.frr.grpc>,
+               libprotobuf-dev (>=3.6.1) <pkg.frr.grpc>
 Standards-Version: 4.5.0.3
 Homepage: https://www.frrouting.org/
 Vcs-Browser: https://github.com/FRRouting/frr/tree/debian/master


### PR DESCRIPTION
Configure fails without libprotobuf-dev package. protobuf-compiler package recommends libprotobuf-dev, but this is a soft-dependency, so it needs to be added explicitly.

Also correct tabs/spaces issues introduced by the original patch.