### PR TITLE
bgpd: fix uninitialized labels (backport 10.0)

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1558,8 +1558,8 @@ void vpn_leak_from_vrf_update(struct bgp *to_bgp,	     /* to */
 	struct attr static_attr = {0};
 	struct attr *new_attr = NULL;
 	safi_t safi = SAFI_MPLS_VPN;
-	mpls_label_t label_val;
-	mpls_label_t label;
+	mpls_label_t label_val = { 0 };
+	mpls_label_t label = { 0 };
 	struct bgp_dest *bn;
 	const char *debugmsg;
 	int nexthop_self_flag = 0;


### PR DESCRIPTION
Fix uninitialized labels that cause multiple valgrind issues.

> ==3729602== Use of uninitialised value of size 8
> ==3729602==    at 0x492B493: hash_get (hash.c:140)
> ==3729602==    by 0x2629D2: bgp_labels_intern (bgp_label.c:98)
> ==3729602==    by 0x2E6C92: bgp_adj_out_set_subgroup (bgp_updgrp_adv.c:622)
> ==3729602==    by 0x2A6810: subgroup_process_announce_selected (bgp_route.c:3340)
> ==3729602==    by 0x2E5FF6: group_announce_route_walkcb (bgp_updgrp_adv.c:260)
> ==3729602==    by 0x2E3E28: update_group_walkcb (bgp_updgrp.c:1759)
> ==3729602==    by 0x492B9A0: hash_walk (hash.c:270)
> ==3729602==    by 0x2E498C: update_group_af_walk (bgp_updgrp.c:2090)
> ==3729602==    by 0x2E7C0D: group_announce_route (bgp_updgrp_adv.c:1119)
> ==3729602==    by 0x2A796E: bgp_process_main_one (bgp_route.c:3865)
> ==3729602==    by 0x2A808A: bgp_process_wq (bgp_route.c:3991)
> ==3729602==    by 0x49CC7CF: work_queue_run (workqueue.c:282)
> ==3729602==    by 0x49BBF25: event_call (event.c:2019)
> ==3729602==    by 0x49413CA: frr_run (libfrr.c:1238)
> ==3729602==    by 0x1FD1D3: main (bgp_main.c:555)

> ==2604268== Use of uninitialised value of size 8
> ==2604268==    at 0x4943016: hash_get (hash.c:159)
> ==2604268==    by 0x26EFC1: bgp_labels_intern (bgp_label.c:97)
> ==2604268==    by 0x28077B: leak_update (bgp_mplsvpn.c:1298)
> ==2604268==    by 0x2824A3: vpn_leak_from_vrf_update (bgp_mplsvpn.c:1932)
> ==2604268==    by 0x2C281C: bgp_static_update (bgp_route.c:6974)
> ==2604268==    by 0x2C366F: bgp_static_set (bgp_route.c:7263)
> ==2604268==    by 0x2C435B: bgp_network_magic (bgp_route.c:7556)
> ==2604268==    by 0x2ACF09: bgp_network (bgp_route_clippy.c:86)
> ==2604268==    by 0x4914EE7: cmd_execute_command_real (command.c:1003)
> ==2604268==    by 0x4915060: cmd_execute_command (command.c:1062)
> ==2604268==    by 0x4915610: cmd_execute (command.c:1228)
> ==2604268==    by 0x49E7C32: vty_command (vty.c:625)
> ==2604268==    by 0x49E9B56: vty_execute (vty.c:1388)
> ==2604268==    by 0x49EC331: vtysh_read (vty.c:2400)
> ==2604268==    by 0x49E06F1: event_call (event.c:2001)
> ==2604268==    by 0x495AB8B: frr_run (libfrr.c:1238)
> ==2604268==    by 0x200C4B: main (bgp_main.c:555)

Fixes: ddb5b4880b ("bgpd: vpn-vrf route leaking")