### PR TITLE
bgpd, lib: Include SID structure in seg6local nexthop (backport for 9.1)

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -482,6 +482,7 @@ void vpn_leak_zebra_vrf_sid_update(struct bgp *bgp, afi_t afi)
 void vpn_leak_zebra_vrf_sid_withdraw_per_af(struct bgp *bgp, afi_t afi)
 {
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_LABEL);
+	struct seg6local_context seg6localctx = {};
 
 	if (bgp->vrf_id == VRF_UNKNOWN) {
 		if (debug)
@@ -494,9 +495,16 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_af(struct bgp *bgp, afi_t afi)
 		zlog_debug("%s: deleting sid for vrf %s afi (id=%d)", __func__,
 			   bgp->name_pretty, bgp->vrf_id);
 
-	zclient_send_localsid(zclient,
-		bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent,
-		bgp->vrf_id, ZEBRA_SEG6_LOCAL_ACTION_UNSPEC, NULL);
+	if (bgp->vpn_policy[afi].tovpn_sid_locator) {
+		seg6localctx.block_len = bgp->vpn_policy[afi].tovpn_sid_locator->block_bits_length;
+		seg6localctx.node_len = bgp->vpn_policy[afi].tovpn_sid_locator->node_bits_length;
+		seg6localctx.function_len =
+			bgp->vpn_policy[afi].tovpn_sid_locator->function_bits_length;
+		seg6localctx.argument_len =
+			bgp->vpn_policy[afi].tovpn_sid_locator->argument_bits_length;
+	}
+	zclient_send_localsid(zclient, bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent,
+			      bgp->vrf_id, ZEBRA_SEG6_LOCAL_ACTION_UNSPEC, &seg6localctx);
 	XFREE(MTYPE_BGP_SRV6_SID,
 	      bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent);
 	bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent = NULL;

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -381,6 +381,12 @@ void vpn_leak_zebra_vrf_sid_update_per_af(struct bgp *bgp, afi_t afi)
 	if (!vrf)
 		return;
 
+	if (bgp->vpn_policy[afi].tovpn_sid_locator) {
+		ctx.block_len = bgp->vpn_policy[afi].tovpn_sid_locator->block_bits_length;
+		ctx.node_len = bgp->vpn_policy[afi].tovpn_sid_locator->node_bits_length;
+		ctx.function_len = bgp->vpn_policy[afi].tovpn_sid_locator->function_bits_length;
+		ctx.argument_len = bgp->vpn_policy[afi].tovpn_sid_locator->argument_bits_length;
+	}
 	ctx.table = vrf->data.l.table_id;
 	act = afi == AFI_IP ? ZEBRA_SEG6_LOCAL_ACTION_END_DT4
 		: ZEBRA_SEG6_LOCAL_ACTION_END_DT6;

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -438,6 +438,12 @@ void vpn_leak_zebra_vrf_sid_update_per_vrf(struct bgp *bgp)
 	if (!vrf)
 		return;
 
+	if (bgp->tovpn_sid_locator) {
+		ctx.block_len = bgp->tovpn_sid_locator->block_bits_length;
+		ctx.node_len = bgp->tovpn_sid_locator->node_bits_length;
+		ctx.function_len = bgp->tovpn_sid_locator->function_bits_length;
+		ctx.argument_len = bgp->tovpn_sid_locator->argument_bits_length;
+	}
 	ctx.table = vrf->data.l.table_id;
 	act = ZEBRA_SEG6_LOCAL_ACTION_END_DT46;
 	zclient_send_localsid(zclient, tovpn_sid, bgp->vrf_id, act, &ctx);

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -517,6 +517,7 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_af(struct bgp *bgp, afi_t afi)
 void vpn_leak_zebra_vrf_sid_withdraw_per_vrf(struct bgp *bgp)
 {
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_LABEL);
+	struct seg6local_context seg6localctx = {};
 
 	if (bgp->vrf_id == VRF_UNKNOWN) {
 		if (debug)
@@ -530,9 +531,14 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_vrf(struct bgp *bgp)
 		zlog_debug("%s: deleting sid for vrf %s (id=%d)", __func__,
 			   bgp->name_pretty, bgp->vrf_id);
 
-	zclient_send_localsid(zclient, bgp->tovpn_zebra_vrf_sid_last_sent,
-			      bgp->vrf_id, ZEBRA_SEG6_LOCAL_ACTION_UNSPEC,
-			      NULL);
+	if (bgp->tovpn_sid_locator) {
+		seg6localctx.block_len = bgp->tovpn_sid_locator->block_bits_length;
+		seg6localctx.node_len = bgp->tovpn_sid_locator->node_bits_length;
+		seg6localctx.function_len = bgp->tovpn_sid_locator->function_bits_length;
+		seg6localctx.argument_len = bgp->tovpn_sid_locator->argument_bits_length;
+	}
+	zclient_send_localsid(zclient, bgp->tovpn_zebra_vrf_sid_last_sent, bgp->vrf_id,
+			      ZEBRA_SEG6_LOCAL_ACTION_UNSPEC, &seg6localctx);
 	XFREE(MTYPE_BGP_SRV6_SID, bgp->tovpn_zebra_vrf_sid_last_sent);
 	bgp->tovpn_zebra_vrf_sid_last_sent = NULL;
 }

--- a/lib/srv6.h
+++ b/lib/srv6.h
@@ -104,6 +104,10 @@ struct seg6local_context {
 	struct in6_addr nh6;
 	uint32_t table;
 	struct seg6local_flavors_info flv;
+	uint8_t block_len;
+	uint8_t node_len;
+	uint8_t function_len;
+	uint8_t argument_len;
 };
 
 struct srv6_locator {


### PR DESCRIPTION
Manual backport of https://github.com/FRRouting/frr/pull/16835 for FRR 9.1