### PR TITLE
bgpd, lib: Include SID structure in seg6local nexthop (backport for 8.4)

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -395,6 +395,12 @@ void vpn_leak_zebra_vrf_sid_update(struct bgp *bgp, afi_t afi)
 	if (!vrf)
 		return;
 
+	if (bgp->vpn_policy[afi].tovpn_sid_locator) {
+		ctx.block_len = BGP_PREFIX_SID_SRV6_LOCATOR_BLOCK_LENGTH;
+		ctx.node_len = BGP_PREFIX_SID_SRV6_LOCATOR_NODE_LENGTH;
+		ctx.function_len = BGP_PREFIX_SID_SRV6_FUNCTION_LENGTH;
+		ctx.argument_len = BGP_PREFIX_SID_SRV6_ARGUMENT_LENGTH;
+	}
 	ctx.table = vrf->data.l.table_id;
 	act = afi == AFI_IP ? ZEBRA_SEG6_LOCAL_ACTION_END_DT4
 		: ZEBRA_SEG6_LOCAL_ACTION_END_DT6;

--- a/lib/srv6.h
+++ b/lib/srv6.h
@@ -71,6 +71,10 @@ struct seg6local_context {
 	struct in_addr nh4;
 	struct in6_addr nh6;
 	uint32_t table;
+	uint8_t block_len;
+	uint8_t node_len;
+	uint8_t function_len;
+	uint8_t argument_len;
 };
 
 struct srv6_locator {


### PR DESCRIPTION
Manual backport of https://github.com/FRRouting/frr/pull/16835 for FRR 8.4