### PR TITLE
pimd: allow resolving bsr via directly connected secondary address (backport)

### DIFF
--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -313,7 +313,19 @@ bool pim_nht_bsr_rpf_check(struct pim_instance *pim, pim_addr bsr_addr,
 			if (!nbr)
 				continue;
 
-			return znh->ifindex == src_ifp->ifindex;
+			/* Are we on the correct interface? */
+			if (znh->ifindex == src_ifp->ifindex) {
+				/* Do we have the correct NH ? */
+				if (!pim_addr_cmp(znh->nexthop_addr, src_ip))
+					return true;
+				/*
+				 * check If the packet came from the neighbor,
+				 * and the dst is a secondary address on the connected interface
+				 */
+				return (!pim_addr_cmp(nbr->source_addr, src_ip) &&
+					pim_if_connected_to_source(ifp, znh->nexthop_addr));
+			}
+			return false;
 		}
 		return false;
 	}
@@ -380,7 +392,19 @@ bool pim_nht_bsr_rpf_check(struct pim_instance *pim, pim_addr bsr_addr,
 		if (!nbr)
 			continue;
 
-		return nh->ifindex == src_ifp->ifindex;
+		/* Are we on the correct interface? */
+		if (nh->ifindex == src_ifp->ifindex) {
+			/* Do we have the correct NH ? */
+			if (!pim_addr_cmp(nhaddr, src_ip))
+				return true;
+			/*
+			 * check If the packet came from the neighbor,
+			 * and the dst is a secondary address on the connected interface
+			 */
+			return (!pim_addr_cmp(nbr->source_addr, src_ip) &&
+				pim_if_connected_to_source(ifp, nhaddr));
+		}
+		return false;
 	}
 	return false;
 }


### PR DESCRIPTION
This only matters to single hop nodes that are adjacent to the bsr. More common with IPv6 where LL address is used in PIM as the primary address. If the BSR IP happens to be an address on the same interface, the receiving pim router rejects the BSR address because it expects the BSR IP to resolve via the LL address even if we have a connected route for the same BSR IP subnet. Effectively, we want to allow rpf to be resolved via secondary IPs with connected routes on the same interface, and not limit them to primary addresses.