### PR TITLE
bgpd:support of color extended community color-only types

### DIFF
--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -85,6 +85,7 @@
 
 /* Low-order octet of the Extended Communities type field for OPAQUE types */
 #define ECOMMUNITY_OPAQUE_SUBTYPE_ENCAP     0x0c
+#define ECOMMUNITY_OPAQUE_SUBTYPE_COLOR	    0x0b
 
 /* Extended communities attribute string format.  */
 #define ECOMMUNITY_FORMAT_ROUTE_MAP            0
@@ -328,26 +329,25 @@ static inline void encode_node_target(struct in_addr *node_id,
 
 /*
  * Encode BGP Color extended community
- * is's a transitive opaque Extended community (RFC 9012 4.3)
+ * is's a transitive opaque Extended community (RFC 9256  8.8.1)
  * flag is set to 0
- * RFC 9012 14.10: No values have currently been registered.
- *            4.3: this field MUST be set to zero by the originator
- *                 and ignored by the receiver;
  *
  */
-static inline void encode_color(uint32_t color_id, struct ecommunity_val *eval)
+static inline void encode_color(uint32_t color_id, uint32_t flags, struct ecommunity_val *eval)
 {
 	/*
 	 *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	 *  | 0x03         | Sub-Type(0x0b) |    Flags                      |
+	 *  | 0x03         | Sub-Type(0x0b) |CO |         Flags             |
 	 *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 	 *  |                          Color Value                          |
 	 *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *  https://datatracker.ietf.org/doc/rfc9256/, Section 8.8.1
+	 *  The CO bits can have 4 different values: 00 01 10 11
 	 */
 	memset(eval, 0, sizeof(*eval));
 	eval->val[0] = ECOMMUNITY_ENCODE_OPAQUE;
 	eval->val[1] = ECOMMUNITY_COLOR;
-	eval->val[2] = 0x00;
+	eval->val[2] = (flags << 6) & 0xff;
 	eval->val[3] = 0x00;
 	eval->val[4] = (color_id >> 24) & 0xff;
 	eval->val[5] = (color_id >> 16) & 0xff;

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2921,6 +2921,23 @@ BGP Extended Communities in Route Map
 
    This command sets colors values.
 
+:rfc:`9256`.
+
+``CO:COLOR``
+   This is a format to define colors value. ``CO`` part is always 00 (default),
+   it can be used to support the requirements of Color-Only steering when using 
+   a Null Endpoint in the SR-TE Policy as specified in Section 8.8 of [RFC9256].
+   The below shows in detail what the different combinations of ``CO`` bits can
+   match on to for the purpose of determining what type of SR-TE Policy Tunnel
+   a BGP route can resolve over, and it also shows the order for resolving the
+   BGP route if there are different tunnels.
+   - ``00`` Can match on a specific endpoint only which should be the nexthop
+     of the route(Default Setting).
+   - ``01`` Can match on a specific endpoint or a null endpoint.
+   - ``10`` Can match on a specific endpoint, null endpoint or any endpoint.
+   - ``11`` Reserved for future use and shuould not be used.
+
+
 .. clicmd:: set extcommunity bandwidth <(1-25600) | cumulative | num-multipaths> [non-transitive]
 
    This command sets the BGP link-bandwidth extended community for the prefix

--- a/tests/topotests/bgp_color_extcommunities/r1/bgpd.conf
+++ b/tests/topotests/bgp_color_extcommunities/r1/bgpd.conf
@@ -11,7 +11,7 @@ router bgp 65001
  exit-address-family
 !
 route-map rmap permit 10
- set extcommunity color 1
+ set extcommunity color 01:1
  set extcommunity rt 80:987
- set extcommunity color 100 55555 200
+ set extcommunity color 01:100 01:55555 01:200
 exit

--- a/tests/topotests/bgp_color_extcommunities/test_bgp_color_extcommunities.py
+++ b/tests/topotests/bgp_color_extcommunities/test_bgp_color_extcommunities.py
@@ -105,7 +105,7 @@ def test_bgp_color_extended_communities():
                     {
                         "valid": True,
                         "extendedCommunity": {
-                            "string": "RT:80:987 Color:100 Color:200 Color:55555"
+                            "string": "RT:80:987 Color:01:100 Color:01:200 Color:01:55555"
                         },
                     }
                 ],

--- a/yang/frr-bgp-route-map.yang
+++ b/yang/frr-bgp-route-map.yang
@@ -532,7 +532,7 @@ identity set-extcommunity-color {
 
   typedef color-list {
     type string {
-      pattern '((429496729[0-5]|42949672[0-8][0-9]|'
+      pattern '((00|01|10|11):(429496729[0-5]|42949672[0-8][0-9]|'
       +	    '4294967[0-1][0-9]{2}|429496[0-6][0-9]{3}|'
       +	    '42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|'
       +	    '429[0-3][0-9]{6}|42[0-8][0-9]{7}|'
@@ -540,10 +540,11 @@ identity set-extcommunity-color {
       +	    '[1-9][0-9]{0,8})(\s*))+';
     }
     description
-      "The color-list type represent a set of colors of value (1..4294967295)
+      "The color-list type represent a set of colors of value (examples 00:200 01:200 10:200)
        values are separated by white spaces";
     reference
-      "RFC 9012 - The BGP Tunnel Encapsulation Attribute";
+      "RFC 9012 - The BGP Tunnel Encapsulation Attribute.
+       RFC 9256 - Segment Routing Policy Architecture.";
   }
 
   augment "/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:rmap-match-condition/frr-route-map:match-condition" {


### PR DESCRIPTION
Add support of color extended community color-only types, RFC 9256.
The type only support 00 01 10.

configuration example:
!
frr version 10.3-dev-my-manual-build
frr defaults traditional
hostname router3
!
route-map color permit 1
 set extcommunity color 10:100 01:200 00:300
exit
!
vrf Vrf1
exit-vrf
!
interface lo
 ipv6 address 3::3/128
exit
!
router bgp 3
 bgp router-id 3.3.3.3
 bgp log-neighbor-changes
 no bgp ebgp-requires-policy
 no bgp default ipv4-unicast
 bgp bestpath as-path multipath-relax
 timers bgp 10 30
 neighbor 100.13.13.1 remote-as 1
 neighbor 100.13.13.1 advertisement-interval 0
 neighbor 100.23.23.2 remote-as 2
 neighbor 100.23.23.2 advertisement-interval 0
 neighbor 1000:3000::1 remote-as 1
 neighbor 1000:3000::1 ebgp-multihop
 neighbor 1000:3000::1 update-source 1000:3000::3
 neighbor 1000:3000::1 capability extended-nexthop
 neighbor 2000:3000::2 remote-as 2
 neighbor 2000:3000::2 ebgp-multihop
 neighbor 2000:3000::2 update-source 2000:3000::3
 neighbor 2000:3000::2 capability extended-nexthop
 !
 address-family ipv4 unicast
  neighbor 100.13.13.1 activate
  neighbor 100.23.23.2 activate
 exit-address-family
 !
 address-family ipv6 unicast
  redistribute connected route-map color
  neighbor 1000:3000::1 activate
  neighbor 2000:3000::2 activate
 exit-address-family
exit
!
end

router1# show bgp ipv6 unicast  3::3
BGP routing table entry for 3::3/128, version 4
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  1000:3000::3 1000:4000::4
  3
    1000:3000::3 from 1000:3000::3 (3.3.3.3)
    (fe80::a8c1:abff:fea8:81f) (used)
      Origin incomplete, metric 0, valid, external, best (First path received)
      Extended Community: Color:00:300 Color:01:200 Color:10:100
      Last update: Thu Oct 24 11:25:35 2024

