### PR TITLE
bgpd: fix display of local label in show bgp

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12329,7 +12329,7 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 
 	mpls_lse_decode(dest->local_label, &label, &ttl, &exp, &bos);
 
-	has_valid_label = bgp_is_valid_label(&label);
+	has_valid_label = bgp_is_valid_label(&dest->local_label);
 
 	if (safi == SAFI_EVPN) {
 		if (!json) {


### PR DESCRIPTION
Fix the display of the local label in show bgp.

> r1# show bgp ipv4 labeled-unicast 172.16.2.2/32
> BGP routing table entry for 172.16.2.2/32, version 2
> Local label: 16 <---- MISSING
> Paths: (1 available, best #1, table default, vrf (null))
>   Advertised to non peer-group peers:
>  192.168.1.2
>  65501
>    192.168.1.2 from 192.168.1.2 (172.16.2.2)
>      Origin IGP, metric 0, valid, external, best (First path received)
>      Remote label: 3
>      Last update: Fri Oct 25 17:55:45 2024

Fixes: 67f67ba481 ("bgpd: Drop label_ntop/label_pton functions")