### PR TITLE
bgpd:  fix crash when polling bgp4v2PathAttrTable

### DIFF
--- a/bgpd/bgp_snmp_bgp4v2.c
+++ b/bgpd/bgp_snmp_bgp4v2.c
@@ -933,7 +933,9 @@ static uint8_t *bgp4v2PathAttrTable(struct variable *v, oid name[],
 		else
 			return SNMP_IPADDRESS(bgp_empty_addr);
 	case BGP4V2_NLRI_AS_PATH_CALC_LENGTH:
-		return SNMP_INTEGER(path->attr->aspath->segments->length);
+		return SNMP_INTEGER((path->attr->aspath && path->attr->aspath->segments)
+					    ? path->attr->aspath->segments->length
+					    : 0);
 	case BGP4V2_NLRI_AS_PATH:
 		return aspath_snmp_pathseg(path->attr->aspath, var_len);
 	case BGP4V2_NLRI_PATH_ATTR_UNKNOWN:


### PR DESCRIPTION
we have

(gdb) p *path->attr->aspath
$1 = {refcnt = 3, segments = 0x0, json = 0x0, str = 0x55723d0b7470 "", str_len = 0, asnotation = ASNOTATION_PLAIN}

It looks like this aspath is empty, resulting in a size 0 and NULL pointer for path->attr->aspath->segments which leads to the SIGSEGV

fixe: return 0 when segments is null.