### PR TITLE
isisd: fix change flex-algorithm number from uint32 to uint8

### DIFF
--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -2015,12 +2015,12 @@ void cli_show_isis_prefix_sid_algorithm(struct vty *vty,
 	const char *sid_value_type;
 	const char *sid_value;
 	bool n_flag_clear;
-	uint32_t algorithm;
+	uint8_t algorithm;
 
 	prefix = yang_dnode_get_string(dnode, "prefix");
 	sid_value_type = yang_dnode_get_string(dnode, "sid-value-type");
 	sid_value = yang_dnode_get_string(dnode, "sid-value");
-	algorithm = yang_dnode_get_uint32(dnode, "algo");
+	algorithm = yang_dnode_get_uint8(dnode, "algo");
 	lh_behavior = yang_dnode_get_string(dnode, "last-hop-behavior");
 	n_flag_clear = yang_dnode_get_bool(dnode, "n-flag-clear");
 

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -2633,14 +2633,14 @@ int isis_instance_segment_routing_algorithm_prefix_sid_create(
 	struct isis_area *area;
 	struct prefix prefix;
 	struct sr_prefix_cfg *pcfg;
-	uint32_t algorithm;
+	uint8_t algorithm;
 
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
 	area = nb_running_get_entry(args->dnode, NULL, true);
 	yang_dnode_get_prefix(&prefix, args->dnode, "prefix");
-	algorithm = yang_dnode_get_uint32(args->dnode, "algo");
+	algorithm = yang_dnode_get_uint8(args->dnode, "algo");
 
 	pcfg = isis_sr_cfg_prefix_add(area, &prefix, algorithm);
 	pcfg->algorithm = algorithm;

--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -1922,7 +1922,7 @@ module frr-isisd {
                if set to disable, ISISEXPLICITNULLFlag
                will override the value of ISISPHPFlag";
             leaf algo {
-              type uint32 {
+              type uint8 {
                 range "128..255";
               }
               description


### PR DESCRIPTION
The algorithm number is encoded on 8 bits and does not require an unsigned 32 bit value to store the value.

Fixes: cc4926c1284e ("isisd,yang: add algorithm-prefix-sid configuration tree")