### PR TITLE
bgpd: bestpath failure when you have a singlepath not in holddown

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3198,15 +3198,23 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,
 			struct bgp_path_info *end =
 				bgp_dest_get_bgp_path_info(dest);
 
-			for (; end && end->next != NULL; end = end->next)
-				;
+			if (end && any_comparisons) {
+				for (; end && end->next != NULL; end = end->next)
+					;
 
-			if (end)
-				end->next = first;
-			else
+				if (end)
+					end->next = first;
+				else
+					bgp_dest_set_bgp_path_info(dest, first);
+				first->prev = end;
+				first->next = NULL;
+			} else {
 				bgp_dest_set_bgp_path_info(dest, first);
-			first->prev = end;
-			first->next = NULL;
+				if (end)
+					end->prev = first;
+				first->next = end;
+				first->prev = NULL;
+			}
 
 			dest->reason = first->reason;
 		} else {


### PR DESCRIPTION
When you have multiple paths to a particular route and a single path changes.  In addition of the other paths are either in hold down or not established or really just not selected you could end up with a situation where the bestpath choosen was a path that was in hold down.

Modify the code such that when there is nothing worse in bestpath selection for the choosen path, but were unable to do any sorting, just put the path on the top of the list and declare it the winner.  Else just
do the original and put it at the end.