### PR TITLE
lib, zebra: Keep `zebra on-rib-process script` in frr.conf (backport #17160)

### DIFF
--- a/lib/frrscript.c
+++ b/lib/frrscript.c
@@ -25,6 +25,16 @@ DEFINE_MTYPE_STATIC(LIB, SCRIPT, "Scripting");
 
 struct frrscript_names_head frrscript_names_hash;
 
+void frrscript_names_config_write(struct vty *vty)
+{
+	struct frrscript_names_entry *lua_script_entry;
+
+	frr_each (frrscript_names, &frrscript_names_hash, lua_script_entry)
+		if (lua_script_entry->script_name[0] != '\0')
+			vty_out(vty, "zebra on-rib-process script %s\n",
+				lua_script_entry->script_name);
+}
+
 /*
  * Wrapper for frrscript_names_add
  * Use this to register hook calls when a daemon starts up

--- a/lib/frrscript.h
+++ b/lib/frrscript.h
@@ -44,6 +44,8 @@ struct frrscript_names_entry {
 
 extern struct frrscript_names_head frrscript_names_hash;
 
+extern void frrscript_names_config_write(struct vty *vty);
+
 int frrscript_names_hash_cmp(const struct frrscript_names_entry *snhe1,
 			     const struct frrscript_names_entry *snhe2);
 uint32_t frrscript_names_hash_key(const struct frrscript_names_entry *snhe);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -4017,6 +4017,10 @@ static int config_write_protocol(struct vty *vty)
 	if (!zebra_nhg_recursive_use_backups())
 		vty_out(vty, "no zebra nexthop resolve-via-backup\n");
 
+#ifdef HAVE_SCRIPTING
+	frrscript_names_config_write(vty);
+#endif
+
 	if (rnh_get_hide_backups())
 		vty_out(vty, "ip nht hide-backup-events\n");
 


### PR DESCRIPTION
After the change:

```
$ grep on-rib-process /etc/frr/frr.conf
zebra on-rib-process script script4

$ systemctl restart frr

$ vtysh -c 'show run' | grep on-rib-process
zebra on-rib-process script script4
```