### PR TITLE
bgpd: fix blank line in running-config with bmp listener cmd

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2988,8 +2988,7 @@ static int bmp_config_write(struct bgp *bgp, struct vty *vty)
 					afi2str_lower(afi), safi2str(safi));
 		}
 		frr_each (bmp_listeners, &bt->listeners, bl)
-			vty_out(vty, " \n  bmp listener %pSU port %d\n",
-				&bl->addr, bl->port);
+			vty_out(vty, "   bmp listener %pSU port %d\n", &bl->addr, bl->port);
 
 		frr_each (bmp_actives, &bt->actives, ba) {
 			vty_out(vty, "  bmp connect %s port %u min-retry %u max-retry %u",


### PR DESCRIPTION
An extra blank line is added in show running-config with BMP:

> ubuntu2204hwe(config)# router bgp 65500
> ubuntu2204hwe(config-router)# bmp targets tgt
> ubuntu2204hwe(config-bgp-bmp)# bmp monitor ipv4 unicast pre-policy
> ubuntu2204hwe(config-bgp-bmp)# bmp listener 192.0.2.100 port 44
> ubuntu2204hwe(config-bgp-bmp)# do show running-config
>
> router bgp 65500
> [..]
>  bmp targets tgt
>   bmp monitor ipv4 unicast pre-policy
>                                       <-- blank line
>   bmp listener 192.0.2.100 port 44
>  exit

Remove the blank line.

Fixes: ed18356f1f2d ("bgpd/bmp: BMP implementation")