### PR TITLE
Add support to import alternate URIB tables into the main MRIB

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -1287,6 +1287,25 @@ IPv6 example for OSPFv3.
    Set the delay before any route-maps are processed in zebra.  The
    default time for this is 5 seconds.
 
+
+.. _zebra-table-import:
+
+zebra Table Import
+==================
+
+Zebra supports importing an alternate routing table into the main unicast RIB (URIB).
+An imported table will continously sync all changes to the main URIB as routes are
+added or deleted from the alternate table.
+Zebra also supports importing into the main multicast RIB (MRIB) which can be used
+to affect how multicast RPF lookups are performed as described in :ref: `_pim-multicast-rib`.
+
+.. clicmd:: ip import-table (1-252) [mrib] [distance (1-255)] [route-map RMAP_NAME]
+
+   Import table, by given table id, into the main URIB (or MRIB). Optional distance can override
+   the default distance when importing routes from the alternate table. An optional route map
+   can be provided to filter routes that are imported into the main table.
+
+
 .. _zebra-fib-push-interface:
 
 zebra FIB push interface

--- a/tests/topotests/zebra_rib/r1/frr-import.conf
+++ b/tests/topotests/zebra_rib/r1/frr-import.conf
@@ -1,0 +1,18 @@
+!
+hostname r1
+password zebra
+log file /tmp/r1-frr.log
+!
+interface r1-eth0
+ ip address 10.0.0.1/24
+!
+interface r1-eth1
+ ip address 10.10.0.1/24
+!
+ip route 10.1.0.0/24 10.0.0.2 table 10
+ip route 10.2.0.0/24 10.0.0.2 table 10
+ip route 10.3.0.0/24 10.10.0.2 table 10
+ip route 10.4.0.0/24 10.10.0.2 table 10
+!
+ip forwarding
+!

--- a/tests/topotests/zebra_rib/r1/import_init_mrib_table.json
+++ b/tests/topotests/zebra_rib/r1/import_init_mrib_table.json
@@ -1,0 +1,126 @@
+{
+    "10.0.0.0/24": [
+        {
+            "prefix": "10.0.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.0.0.1/32": [
+        {
+            "prefix": "10.0.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.0/24": [
+        {
+            "prefix": "10.10.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.1/32": [
+        {
+            "prefix": "10.10.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/zebra_rib/r1/import_init_table.json
+++ b/tests/topotests/zebra_rib/r1/import_init_table.json
@@ -1,0 +1,126 @@
+{
+    "10.0.0.0/24": [
+        {
+            "prefix": "10.0.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.0.0.1/32": [
+        {
+            "prefix": "10.0.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.0/24": [
+        {
+            "prefix": "10.10.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.1/32": [
+        {
+            "prefix": "10.10.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/zebra_rib/r1/import_mrib_table_2.json
+++ b/tests/topotests/zebra_rib/r1/import_mrib_table_2.json
@@ -1,0 +1,258 @@
+{
+    "10.0.0.0/24": [
+        {
+            "prefix": "10.0.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.0.0.1/32": [
+        {
+            "prefix": "10.0.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.1.0.0/24": [
+        {
+            "prefix": "10.1.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 7,
+            "installedNexthopGroupId": 7,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.0.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.2.0.0/24": [
+        {
+            "prefix": "10.2.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 7,
+            "installedNexthopGroupId": 7,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.0.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.3.0.0/24": [
+        {
+            "prefix": "10.3.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 8,
+            "installedNexthopGroupId": 8,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.10.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.4.0.0/24": [
+        {
+            "prefix": "10.4.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 8,
+            "installedNexthopGroupId": 8,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.10.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.0/24": [
+        {
+            "prefix": "10.10.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.1/32": [
+        {
+            "prefix": "10.10.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/zebra_rib/r1/import_mrib_table_3.json
+++ b/tests/topotests/zebra_rib/r1/import_mrib_table_3.json
@@ -1,0 +1,291 @@
+{
+    "10.0.0.0/24": [
+        {
+            "prefix": "10.0.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.0.0.1/32": [
+        {
+            "prefix": "10.0.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.1.0.0/24": [
+        {
+            "prefix": "10.1.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 7,
+            "installedNexthopGroupId": 7,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.0.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.2.0.0/24": [
+        {
+            "prefix": "10.2.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 7,
+            "installedNexthopGroupId": 7,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.0.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.3.0.0/24": [
+        {
+            "prefix": "10.3.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 8,
+            "installedNexthopGroupId": 8,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.10.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.4.0.0/24": [
+        {
+            "prefix": "10.4.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 8,
+            "installedNexthopGroupId": 8,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.10.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.0/24": [
+        {
+            "prefix": "10.10.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.1/32": [
+        {
+            "prefix": "10.10.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.20.0.0/24": [
+        {
+            "prefix": "10.20.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 8,
+            "installedNexthopGroupId": 8,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.10.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/zebra_rib/r1/import_mrib_table_4.json
+++ b/tests/topotests/zebra_rib/r1/import_mrib_table_4.json
@@ -1,0 +1,258 @@
+{
+    "10.0.0.0/24": [
+        {
+            "prefix": "10.0.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.0.0.1/32": [
+        {
+            "prefix": "10.0.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.1.0.0/24": [
+        {
+            "prefix": "10.1.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 123,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 7,
+            "installedNexthopGroupId": 7,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.0.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.2.0.0/24": [
+        {
+            "prefix": "10.2.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 123,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 7,
+            "installedNexthopGroupId": 7,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.0.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.3.0.0/24": [
+        {
+            "prefix": "10.3.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 123,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 8,
+            "installedNexthopGroupId": 8,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.10.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.4.0.0/24": [
+        {
+            "prefix": "10.4.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 123,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 8,
+            "installedNexthopGroupId": 8,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.10.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.0/24": [
+        {
+            "prefix": "10.10.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.1/32": [
+        {
+            "prefix": "10.10.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/zebra_rib/r1/import_table_2.json
+++ b/tests/topotests/zebra_rib/r1/import_table_2.json
@@ -1,0 +1,258 @@
+{
+    "10.0.0.0/24": [
+        {
+            "prefix": "10.0.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.0.0.1/32": [
+        {
+            "prefix": "10.0.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.1.0.0/24": [
+        {
+            "prefix": "10.1.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 7,
+            "installedNexthopGroupId": 7,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.0.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.2.0.0/24": [
+        {
+            "prefix": "10.2.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 7,
+            "installedNexthopGroupId": 7,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.0.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.3.0.0/24": [
+        {
+            "prefix": "10.3.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 8,
+            "installedNexthopGroupId": 8,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.10.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.4.0.0/24": [
+        {
+            "prefix": "10.4.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 8,
+            "installedNexthopGroupId": 8,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.10.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.0/24": [
+        {
+            "prefix": "10.10.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.1/32": [
+        {
+            "prefix": "10.10.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/zebra_rib/r1/import_table_3.json
+++ b/tests/topotests/zebra_rib/r1/import_table_3.json
@@ -1,0 +1,291 @@
+{
+    "10.0.0.0/24": [
+        {
+            "prefix": "10.0.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.0.0.1/32": [
+        {
+            "prefix": "10.0.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.1.0.0/24": [
+        {
+            "prefix": "10.1.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 7,
+            "installedNexthopGroupId": 7,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.0.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.2.0.0/24": [
+        {
+            "prefix": "10.2.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 7,
+            "installedNexthopGroupId": 7,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.0.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.3.0.0/24": [
+        {
+            "prefix": "10.3.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 8,
+            "installedNexthopGroupId": 8,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.10.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.4.0.0/24": [
+        {
+            "prefix": "10.4.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 8,
+            "installedNexthopGroupId": 8,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.10.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.0/24": [
+        {
+            "prefix": "10.10.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.1/32": [
+        {
+            "prefix": "10.10.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.20.0.0/24": [
+        {
+            "prefix": "10.20.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 15,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 8,
+            "installedNexthopGroupId": 8,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.10.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/zebra_rib/r1/import_table_4.json
+++ b/tests/topotests/zebra_rib/r1/import_table_4.json
@@ -1,0 +1,258 @@
+{
+    "10.0.0.0/24": [
+        {
+            "prefix": "10.0.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.0.0.1/32": [
+        {
+            "prefix": "10.0.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 3,
+            "installedNexthopGroupId": 3,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.1.0.0/24": [
+        {
+            "prefix": "10.1.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 123,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 7,
+            "installedNexthopGroupId": 7,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.0.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.2.0.0/24": [
+        {
+            "prefix": "10.2.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 123,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 7,
+            "installedNexthopGroupId": 7,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.0.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth0",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.3.0.0/24": [
+        {
+            "prefix": "10.3.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 123,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 8,
+            "installedNexthopGroupId": 8,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.10.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.4.0.0/24": [
+        {
+            "prefix": "10.4.0.0/24",
+            "prefixLen": 24,
+            "protocol": "table",
+            "instance": 10,
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 123,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 8,
+            "installedNexthopGroupId": 8,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.10.0.2",
+                    "afi": "ipv4",
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.0/24": [
+        {
+            "prefix": "10.10.0.0/24",
+            "prefixLen": 24,
+            "protocol": "connected",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ],
+    "10.10.0.1/32": [
+        {
+            "prefix": "10.10.0.1/32",
+            "prefixLen": 32,
+            "protocol": "local",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 0,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 1,
+            "internalNextHopActiveNum": 1,
+            "nexthopGroupId": 4,
+            "installedNexthopGroupId": 4,
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "directlyConnected": true,
+                    "interfaceName": "r1-eth1",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/zebra_rib/test_zebra_import.py
+++ b/tests/topotests/zebra_rib/test_zebra_import.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_zebra_import.py
+#
+# Copyright (c) 2024 ATCorp
+# Nathan Bahr
+#
+
+import os
+import sys
+from functools import partial
+import pytest
+import json
+import platform
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+from lib.common_config import step, write_test_header
+
+"""
+test_zebra_import.py: Test zebra table import functionality
+"""
+
+TOPOLOGY = """
+    Single router zebra functionality
+
+                 +---+---+
+    10.0.0.1/24  |       |  10.10.0.1/24
+            <--->+  R1   +<--->
+                 |       |
+                 +---+---+
+"""
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+pytestmark = [pytest.mark.sharpd]
+krel = platform.release()
+
+def build_topo(tgen):
+    "Build function"
+
+    tgen.add_router("r1")
+    sw1 = tgen.add_switch("sw1")
+    sw2 = tgen.add_switch("sw2")
+    sw1.add_link(tgen.gears["r1"], "r1-eth0")
+    sw2.add_link(tgen.gears["r1"], "r1-eth1")
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        logger.info("Loading router %s" % rname)
+        router.load_frr_config(os.path.join(CWD, "{}/frr-import.conf".format(rname)))
+
+    # Initialize all routers.
+    tgen.start_router()
+    for router in router_list.values():
+        if router.has_version("<", "4.0"):
+            tgen.set_error("unsupported version")
+
+
+def teardown_module():
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_zebra_urib_import(request):
+    "Verify router starts with the initial URIB"
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    step("Verify initial main routing table")
+    initial_json_file = "{}/r1/import_init_table.json".format(CWD)
+    expected = json.loads(open(initial_json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, '"r1" JSON output mismatches'
+
+    r1.vtysh_cmd(
+        """
+        conf term
+         ip import-table 10 
+        """)
+    
+    import_json_file = "{}/r1/import_table_2.json".format(CWD)
+    expected = json.loads(open(import_json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, '"r1" JSON output mismatches'
+
+    step("Add a new static route and verify it gets added")
+    r1.vtysh_cmd(
+        """
+        conf term
+         ip route 10.20.0.0/24 10.10.0.2 table 10
+        """
+    )
+
+    sync_json_file = "{}/r1/import_table_3.json".format(CWD)
+    expected = json.loads(open(sync_json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, '"r1" JSON output mismatches'
+
+    step("Remove the static route and verify it gets removed")
+    r1.vtysh_cmd(
+        """
+        conf term
+         no ip route 10.20.0.0/24 10.10.0.2 table 10
+        """
+    )
+
+    expected = json.loads(open(import_json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, '"r1" JSON output mismatches'
+
+    step("Disable table import and verify it goes back to the initial table")
+    r1.vtysh_cmd(
+        """
+        conf term
+         no ip import-table 10 
+        """
+    )
+
+    expected = json.loads(open(initial_json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, '"r1" JSON output mismatches'
+
+    step("Re-import with distance and verify correct distance")
+    r1.vtysh_cmd(
+        """
+        conf term
+         ip import-table 10 distance 123
+        """)
+    
+    import_json_file = "{}/r1/import_table_4.json".format(CWD)
+    expected = json.loads(open(import_json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, '"r1" JSON output mismatches'
+
+def test_zebra_mrib_import(request):
+    "Verify router starts with the initial MRIB"
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    step("Verify initial main MRIB routing table")
+    initial_json_file = "{}/r1/import_init_mrib_table.json".format(CWD)
+    expected = json.loads(open(initial_json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip rpf json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, '"r1" JSON output mismatches'
+
+    r1.vtysh_cmd(
+        """
+        conf term
+         ip import-table 10 mrib
+        """)
+    
+    import_json_file = "{}/r1/import_mrib_table_2.json".format(CWD)
+    expected = json.loads(open(import_json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip rpf json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, '"r1" JSON output mismatches'
+
+    step("Add a new static route and verify it gets added")
+    r1.vtysh_cmd(
+        """
+        conf term
+         ip route 10.20.0.0/24 10.10.0.2 table 10
+        """
+    )
+
+    sync_json_file = "{}/r1/import_mrib_table_3.json".format(CWD)
+    expected = json.loads(open(sync_json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip rpf json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, '"r1" JSON output mismatches'
+
+    step("Remove the static route and verify it gets removed")
+    r1.vtysh_cmd(
+        """
+        conf term
+         no ip route 10.20.0.0/24 10.10.0.2 table 10
+        """
+    )
+
+    expected = json.loads(open(import_json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip rpf json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, '"r1" JSON output mismatches'
+
+    step("Disable table import and verify it goes back to the initial table")
+    r1.vtysh_cmd(
+        """
+        conf term
+         no ip import-table 10 mrib
+        """
+    )
+
+    expected = json.loads(open(initial_json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip rpf json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, '"r1" JSON output mismatches'
+
+    step("Re-import with distance and verify correct distance")
+    r1.vtysh_cmd(
+        """
+        conf term
+         ip import-table 10 mrib distance 123
+        """)
+    
+    import_json_file = "{}/r1/import_mrib_table_4.json".format(CWD)
+    expected = json.loads(open(import_json_file).read())
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip rpf json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None)
+    assert result is None, '"r1" JSON output mismatches'
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/redistribute.h
+++ b/zebra/redistribute.h
@@ -56,19 +56,14 @@ extern void zebra_interface_vrf_update_del(struct interface *ifp,
 extern void zebra_interface_vrf_update_add(struct interface *ifp,
 					   vrf_id_t old_vrf_id);
 
-extern int zebra_import_table(afi_t afi, vrf_id_t vrf_id,
-			      uint32_t table_id, uint32_t distance,
-			      const char *rmap_name, int add);
+extern int zebra_import_table(afi_t afi, safi_t safi, vrf_id_t vrf_id, uint32_t table_id,
+			      uint32_t distance, const char *rmap_name, bool add);
 
-extern int zebra_add_import_table_entry(struct zebra_vrf *zvrf,
-					struct route_node *rn,
-					struct route_entry *re,
-					const char *rmap_name);
-extern int zebra_del_import_table_entry(struct zebra_vrf *zvrf,
-					struct route_node *rn,
+extern int zebra_add_import_table_entry(struct zebra_vrf *zvrf, safi_t safi, struct route_node *rn,
+					struct route_entry *re, const char *rmap_name);
+extern int zebra_del_import_table_entry(struct zebra_vrf *zvrf, safi_t safi, struct route_node *rn,
 					struct route_entry *re);
-extern int is_zebra_import_table_enabled(afi_t, vrf_id_t vrf_id,
-					 uint32_t table_id);
+extern int is_zebra_import_table_enabled(afi_t, safi_t safi, vrf_id_t vrf_id, uint32_t table_id);
 
 extern int zebra_import_table_config(struct vty *, vrf_id_t vrf_id);
 

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -29,7 +29,7 @@
 
 static uint32_t zebra_rmap_update_timer = ZEBRA_RMAP_DEFAULT_UPDATE_TIMER;
 static struct event *zebra_t_rmap_update = NULL;
-char *zebra_import_table_routemap[AFI_MAX][ZEBRA_KERNEL_TABLE_MAX];
+char *zebra_import_table_routemap[AFI_MAX][SAFI_MAX][ZEBRA_KERNEL_TABLE_MAX];
 
 struct zebra_rmap_obj {
 	struct nexthop *nexthop;
@@ -1235,21 +1235,19 @@ route_map_result_t zebra_route_map_check(afi_t family, struct route_entry *re,
 	return (ret);
 }
 
-char *zebra_get_import_table_route_map(afi_t afi, uint32_t table)
+char *zebra_get_import_table_route_map(afi_t afi, safi_t safi, uint32_t table)
 {
-	return zebra_import_table_routemap[afi][table];
+	return zebra_import_table_routemap[afi][safi][table];
 }
 
-void zebra_add_import_table_route_map(afi_t afi, const char *rmap_name,
-				      uint32_t table)
+void zebra_add_import_table_route_map(afi_t afi, safi_t safi, const char *rmap_name, uint32_t table)
 {
-	zebra_import_table_routemap[afi][table] =
-		XSTRDUP(MTYPE_ROUTE_MAP_NAME, rmap_name);
+	zebra_import_table_routemap[afi][safi][table] = XSTRDUP(MTYPE_ROUTE_MAP_NAME, rmap_name);
 }
 
-void zebra_del_import_table_route_map(afi_t afi, uint32_t table)
+void zebra_del_import_table_route_map(afi_t afi, safi_t safi, uint32_t table)
 {
-	XFREE(MTYPE_ROUTE_MAP_NAME, zebra_import_table_routemap[afi][table]);
+	XFREE(MTYPE_ROUTE_MAP_NAME, zebra_import_table_routemap[afi][safi][table]);
 }
 
 route_map_result_t zebra_import_table_route_map_check(int family,

--- a/zebra/zebra_routemap.h
+++ b/zebra/zebra_routemap.h
@@ -14,10 +14,10 @@ extern "C" {
 #endif
 
 extern void zebra_route_map_init(void);
-extern char *zebra_get_import_table_route_map(afi_t afi, uint32_t table);
-extern void zebra_add_import_table_route_map(afi_t afi, const char *rmap_name,
+extern char *zebra_get_import_table_route_map(afi_t afi, safi_t safi, uint32_t table);
+extern void zebra_add_import_table_route_map(afi_t afi, safi_t safi, const char *rmap_name,
 					     uint32_t table);
-extern void zebra_del_import_table_route_map(afi_t afi, uint32_t table);
+extern void zebra_del_import_table_route_map(afi_t afi, safi_t safi, uint32_t table);
 
 extern route_map_result_t zebra_import_table_route_map_check(
 	int family, struct route_entry *re, const struct prefix *p,


### PR DESCRIPTION
Added a mrib flag to the `import-table ...` command to allow importing into the main MRIB table. Piped through specifying the safi in the import code rather than assuming/hardcoding the unicast safi.