### PR TITLE
(10.1 backport) bgpd: add `bgp ipv6-auto-ra` command

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -647,11 +647,12 @@ static void bgp_process_nexthop_update(struct bgp_nexthop_cache *bnc,
 			 * we receive from bgp.  This is to allow us
 			 * to work with v4 routing over v6 nexthops
 			 */
-			if (peer && !peer->ifp
-			    && CHECK_FLAG(peer->flags,
-					  PEER_FLAG_CAPABILITY_ENHE)
-			    && nhr->prefix.family == AF_INET6
-			    && nexthop->type != NEXTHOP_TYPE_BLACKHOLE) {
+			if (peer && !peer->ifp &&
+			    CHECK_FLAG(peer->flags, PEER_FLAG_CAPABILITY_ENHE) &&
+			    !CHECK_FLAG(bnc->bgp->flags,
+					BGP_FLAG_IPV6_NO_AUTO_RA) &&
+			    nhr->prefix.family == AF_INET6 &&
+			    nexthop->type != NEXTHOP_TYPE_BLACKHOLE) {
 				struct interface *ifp;
 
 				ifp = if_lookup_by_index(nexthop->ifindex,
@@ -1520,6 +1521,10 @@ void bgp_nht_reg_enhe_cap_intfs(struct peer *peer)
 		return;
 
 	bgp = peer->bgp;
+
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_IPV6_NO_AUTO_RA))
+		return;
+
 	if (!sockunion2hostprefix(&peer->connection->su, &p)) {
 		zlog_warn("%s: Unable to convert sockunion to prefix for %s",
 			  __func__, peer->host);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -4916,6 +4916,27 @@ DEFUN(no_bgp_fast_convergence, no_bgp_fast_convergence_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY (bgp_ipv6_auto_ra,
+       bgp_ipv6_auto_ra_cmd,
+       "[no] bgp ipv6-auto-ra",
+       NO_STR
+       BGP_STR
+       "Allow enabling IPv6 ND RA sending\n")
+{
+	if (vty->node == CONFIG_NODE) {
+		struct listnode *node, *nnode;
+		struct bgp *bgp;
+
+		COND_FLAG(bm->flags, BM_FLAG_IPV6_NO_AUTO_RA, no);
+		for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp))
+			COND_FLAG(bgp->flags, BGP_FLAG_IPV6_NO_AUTO_RA, no);
+	} else {
+		VTY_DECLVAR_CONTEXT(bgp, bgp);
+		COND_FLAG(bgp->flags, BGP_FLAG_IPV6_NO_AUTO_RA, no);
+	}
+	return CMD_SUCCESS;
+}
+
 static int peer_conf_interface_get(struct vty *vty, const char *conf_if,
 				   int v6only,
 				   const char *peer_group_name,
@@ -19217,6 +19238,9 @@ int bgp_config_write(struct vty *vty)
 	if (CHECK_FLAG(bm->flags, BM_FLAG_SEND_EXTRA_DATA_TO_ZEBRA))
 		vty_out(vty, "bgp send-extra-data zebra\n");
 
+	if (CHECK_FLAG(bm->flags, BM_FLAG_IPV6_NO_AUTO_RA))
+		vty_out(vty, "no bgp ipv6-auto-ra\n");
+
 	/* DSCP value for outgoing packets in BGP connections */
 	if (bm->ip_tos != IPTOS_PREC_INTERNETCONTROL)
 		vty_out(vty, "bgp session-dscp %u\n", bm->ip_tos >> 2);
@@ -19620,6 +19644,11 @@ int bgp_config_write(struct vty *vty)
 		/* BGP instance administrative shutdown */
 		if (CHECK_FLAG(bgp->flags, BGP_FLAG_SHUTDOWN))
 			vty_out(vty, " bgp shutdown\n");
+
+		/* Automatic RA enabling by BGP */
+		if (!CHECK_FLAG(bm->flags, BM_FLAG_IPV6_NO_AUTO_RA))
+			if (CHECK_FLAG(bgp->flags, BGP_FLAG_IPV6_NO_AUTO_RA))
+				vty_out(vty, " no bgp ipv6-auto-ra\n");
 
 		if (bgp->allow_martian)
 			vty_out(vty, " bgp allow-martian-nexthop\n");
@@ -20160,6 +20189,12 @@ void bgp_vty_init(void)
 	/* bgp fast-convergence command */
 	install_element(BGP_NODE, &bgp_fast_convergence_cmd);
 	install_element(BGP_NODE, &no_bgp_fast_convergence_cmd);
+
+	/* global bgp ipv6-auto-ra command */
+	install_element(CONFIG_NODE, &bgp_ipv6_auto_ra_cmd);
+
+	/* bgp ipv6-auto-ra command */
+	install_element(BGP_NODE, &bgp_ipv6_auto_ra_cmd);
 
 	/* global bgp update-delay command */
 	install_element(CONFIG_NODE, &bgp_global_update_delay_cmd);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2326,6 +2326,9 @@ void bgp_zebra_initiate_radv(struct bgp *bgp, struct peer *peer)
 {
 	uint32_t ra_interval = BGP_UNNUM_DEFAULT_RA_INTERVAL;
 
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_IPV6_NO_AUTO_RA))
+		return;
+
 	/* Don't try to initiate if we're not connected to Zebra */
 	if (zclient->sock < 0)
 		return;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1394,6 +1394,9 @@ int bgp_global_gr_init(struct bgp *bgp)
 	bgp->global_gr_present_state = GLOBAL_HELPER;
 	bgp->present_zebra_gr_state = ZEBRA_GR_DISABLE;
 
+	if (CHECK_FLAG(bm->flags, BM_FLAG_IPV6_NO_AUTO_RA))
+		SET_FLAG(bgp->flags, BGP_FLAG_IPV6_NO_AUTO_RA);
+
 	return BGP_GR_SUCCESS;
 }
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -163,6 +163,7 @@ struct bgp_master {
 	uint32_t flags;
 #define BM_FLAG_GRACEFUL_SHUTDOWN        (1 << 0)
 #define BM_FLAG_SEND_EXTRA_DATA_TO_ZEBRA (1 << 1)
+#define BM_FLAG_IPV6_NO_AUTO_RA		 (1 << 8)
 
 	bool terminating;	/* global flag that sigint terminate seen */
 
@@ -532,6 +533,8 @@ struct bgp {
 #define BGP_FLAG_ENFORCE_FIRST_AS (1ULL << 36)
 #define BGP_FLAG_DYNAMIC_CAPABILITY (1ULL << 37)
 #define BGP_FLAG_VNI_DOWN		 (1ULL << 38)
+/* Prohibit BGP from enabling IPv6 RA on interfaces */
+#define BGP_FLAG_IPV6_NO_AUTO_RA (1ULL << 40)
 
 	/* BGP default address-families.
 	 * New peers inherit enabled afi/safis from bgp instance.

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1230,6 +1230,13 @@ IPv6 Support
    address family is enabled by default for all new neighbors.
 
 
+.. clicmd:: bgp ipv6-auto-ra
+
+   By default, bgpd can ask Zebra to enable sending IPv6 router advertisement
+   messages on interfaces. For example, this happens for unnumbered peers
+   support or when extended-nexthop capability is used. The ``no`` form of this
+   command disables such behaviour.
+
 .. _bgp-route-aggregation:
 
 Route Aggregation

--- a/doc/user/ipv6.rst
+++ b/doc/user/ipv6.rst
@@ -25,7 +25,8 @@ Router Advertisement
 .. clicmd:: ipv6 nd suppress-ra
 
    Don't send router advertisement messages. The ``no`` form of this command
-   enables sending RA messages.
+   enables sending RA messages. Note that while being suppressed, RA messages
+   might still be enabled by other daemons, such as bgpd or vrrpd.
 
 .. clicmd:: ipv6 nd prefix ipv6prefix [valid-lifetime] [preferred-lifetime] [off-link] [no-autoconfig] [router-address]
 


### PR DESCRIPTION
Introduce a command to stop bgpd from enabling IPv6 router advertisement messages sending on interfaces.

---
manual backport of #16354