### PR TITLE
tests: respect RLIMIT_CORE hard limit

### DIFF
--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -522,9 +522,14 @@ def pytest_configure(config):
         is_xdist = True
         is_worker = True
 
-    resource.setrlimit(
-        resource.RLIMIT_CORE, (resource.RLIM_INFINITY, resource.RLIM_INFINITY)
-    )
+    try:
+        resource.setrlimit(
+            resource.RLIMIT_CORE, (resource.RLIM_INFINITY, resource.RLIM_INFINITY)
+        )
+    except ValueError:
+        # The hard limit cannot be raised. Raise the soft limit to previous hard limit
+        core_rlimits = resource.getrlimit(resource.RLIMIT_CORE)
+        resource.setrlimit(resource.RLIMIT_CORE, (core_rlimits[1], core_rlimits[1]))
     # -----------------------------------------------------
     # Set some defaults for the pytest.ini [pytest] section
     # ---------------------------------------------------


### PR DESCRIPTION
In the case that that hard limit of `RLIMIT_CORE` cannot be increased (e.g. in this case can't be changed to `RLIM_INFINITY`), `setrlimit` will throw an unhandled `ValueError` that prematurely ends pytest. This commit catches the error, and then attempts to maximize the soft limit while respecting the hard limit value that it can't exceed.