### PR TITLE
BMP rework - 2 BMP fixes + some rework

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -3051,10 +3051,13 @@ static int bmp_route_update(struct bgp *bgp, afi_t afi, safi_t safi,
 		return 0;
 	}
 
-	struct bmp_bgp *bmpbgp = bmp_bgp_get(bgp);
+	struct bmp_bgp *bmpbgp = bmp_bgp_find(bgp);
 	struct peer *peer = updated_route->peer;
 	struct bmp_targets *bt;
 	struct bmp *bmp;
+
+	if (!bmpbgp)
+		return 0;
 
 	frr_each (bmp_targets, &bmpbgp->targets, bt) {
 		if (CHECK_FLAG(bt->afimon[afi][safi], BMP_MON_LOC_RIB)) {

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2009,7 +2009,8 @@ static void bmp_bgp_peer_vrf(struct bmp_bgp_peer *bbpeer, struct bgp *bgp)
 	memcpy(bbpeer->open_rx, s->data, open_len);
 
 	bbpeer->open_tx_len = open_len;
-	bbpeer->open_tx = bbpeer->open_rx;
+	bbpeer->open_tx = XMALLOC(MTYPE_BMP_OPEN, open_len);
+	memcpy(bbpeer->open_tx, s->data, open_len);
 
 	stream_free(s);
 }

--- a/bgpd/bgp_bmp.h
+++ b/bgpd/bgp_bmp.h
@@ -287,6 +287,8 @@ struct bmp_bgp {
 	size_t mirror_qsize, mirror_qsizemax;
 
 	size_t mirror_qsizelimit;
+
+	uint8_t refcount;
 };
 
 extern bool bmp_bgp_update_vrf_status(struct bmp_bgp *bmpbgp, enum bmp_vrf_state force);

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -1421,6 +1421,7 @@ void evaluate_paths(struct bgp_nexthop_cache *bnc)
 					vpn_leak_from_vrf_withdraw(
 						bgp_get_default(), bgp_path,
 						path);
+				bgp_process_hook(bgp_path, path->peer, dest, afi, safi);
 			} else {
 				/* Path becomes valid, set flag; also for EVPN
 				 * routes, import from VRFs if needed.
@@ -1439,6 +1440,8 @@ void evaluate_paths(struct bgp_nexthop_cache *bnc)
 					vpn_leak_from_vrf_update(
 						bgp_get_default(), bgp_path,
 						path);
+
+				bgp_process_hook(bgp_path, path->peer, dest, afi, safi);
 			}
 		}
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4182,6 +4182,12 @@ static void bgp_process_internal(struct bgp *bgp, struct bgp_dest *dest,
 	return;
 }
 
+void bgp_process_hook(struct bgp *bgp, struct peer *peer, struct bgp_dest *dest, afi_t afi,
+		      safi_t safi)
+{
+	hook_call(bgp_process, bgp, afi, safi, dest, peer, true);
+}
+
 void bgp_process(struct bgp *bgp, struct bgp_dest *dest,
 		 struct bgp_path_info *pi, afi_t afi, safi_t safi)
 {
@@ -4384,7 +4390,7 @@ void bgp_rib_remove(struct bgp_dest *dest, struct bgp_path_info *pi,
 		}
 	}
 
-	hook_call(bgp_process, peer->bgp, afi, safi, dest, peer, true);
+	bgp_process_hook(bgp, peer, dest, afi, safi);
 	bgp_process(peer->bgp, dest, pi, afi, safi);
 }
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -970,6 +970,8 @@ extern int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 			     struct bgp_maxpaths_cfg *mpath_cfg, bool debug,
 			     char *pfx_buf, afi_t afi, safi_t safi,
 			     enum bgp_path_selection_reason *reason);
+extern void bgp_process_hook(struct bgp *bgp, struct peer *peer, struct bgp_dest *dest, afi_t afi,
+			     safi_t safi);
 #define bgp_path_info_add(A, B)                                                \
 	bgp_path_info_add_with_caller(__func__, (A), (B))
 #define bgp_path_info_free(B) bgp_path_info_free_with_caller(__func__, (B))


### PR DESCRIPTION
A separate pull request will be put in place to add the following in BMP:
- ability to import BMP information from a separate BGP instance.
This will be useful for L3VPN setups.

- Some commits prepare the code for to this feature. It includes the ability to share the bgpbmp structure for various usages
- A commit to re-send post-policy BGP updates when nexthop reachability is changed.
- A commit related to an ASAN issue encountered with rx_open and tx_open buffers.

 