### PR TITLE
doc: Create html_context before setting READTHEDOCS

### DIFF
--- a/doc/developer/conf.py
+++ b/doc/developer/conf.py
@@ -71,6 +71,7 @@ release = "?.?-?"
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
 # Tell Jinja2 templates the build is running on Read the Docs
+html_context = {}
 if os.environ.get("READTHEDOCS", "") == "True":
     html_context["READTHEDOCS"] = True
 

--- a/doc/user/conf.py
+++ b/doc/user/conf.py
@@ -73,9 +73,9 @@ release = "?.?-?"
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
 # Tell Jinja2 templates the build is running on Read the Docs
+html_context = {}
 if os.environ.get("READTHEDOCS", "") == "True":
     html_context["READTHEDOCS"] = True
-
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/frrouting/envs/latest/lib/python3.11/site-packages/sphinx/config.py", line 529, in eval_config_file
    exec(code, namespace)  # NoQA: S102
    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/frrouting/checkouts/latest/doc/user/conf.py", line 77, in <module>
    html_context["READTHEDOCS"] = True
    ^^^^^^^^^^^^
NameError: name 'html_context' is not defined