### PR TITLE
zebra: separate zebra ZAPI server open and accept

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -467,6 +467,9 @@ int main(int argc, char **argv)
 	zebra_if_init();
 	zebra_debug_init();
 
+	/* Open Zebra API server socket */
+	zserv_open(zserv_path);
+
 	/*
 	 * Initialize NS( and implicitly the VRF module), and make kernel
 	 * routing socket. */

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -57,6 +57,7 @@ extern struct zebra_privs_t zserv_privs;
 
 /* The listener socket for clients connecting to us */
 static int zsock;
+static bool started_p;
 
 /* The lock that protects access to zapi client objects */
 static pthread_mutex_t client_mutex;
@@ -929,9 +930,16 @@ void zserv_close(void)
 
 	/* Free client list's mutex */
 	pthread_mutex_destroy(&client_mutex);
+
+	started_p = false;
 }
 
-void zserv_start(char *path)
+
+/*
+ * Open zebra's ZAPI listener socket. This is done early during startup,
+ * before zebra is ready to listen and accept client connections.
+ */
+void zserv_open(const char *path)
 {
 	int ret;
 	mode_t old_mask;
@@ -973,6 +981,26 @@ void zserv_start(char *path)
 			     path, safe_strerror(errno));
 		close(zsock);
 		zsock = -1;
+	}
+
+	umask(old_mask);
+}
+
+/*
+ * Start listening for ZAPI client connections.
+ */
+void zserv_start(const char *path)
+{
+	int ret;
+
+	/* This may be called more than once during startup - potentially once
+	 * per netns - but only do this work once.
+	 */
+	if (started_p)
+		return;
+
+	if (zsock <= 0) {
+		flog_err_sys(EC_LIB_SOCKET, "Zserv socket open failed");
 		return;
 	}
 
@@ -986,7 +1014,7 @@ void zserv_start(char *path)
 		return;
 	}
 
-	umask(old_mask);
+	started_p = true;
 
 	zserv_event(NULL, ZSERV_ACCEPT);
 }

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -256,15 +256,24 @@ extern void zserv_init(void);
 extern void zserv_close(void);
 
 /*
- * Start Zebra API server.
+ * Open Zebra API server socket.
  *
- * Allocates resources, creates the server socket and begins listening on the
- * socket.
+ * Create and open the server socket.
  *
  * path
  *    where to place the Unix domain socket
  */
-extern void zserv_start(char *path);
+extern void zserv_open(const char *path);
+
+/*
+ * Start Zebra API server.
+ *
+ * Allocates resources and begins listening on the server socket.
+ *
+ * path
+ *    where to place the Unix domain socket
+ */
+extern void zserv_start(const char *path);
 
 /*
  * Send a message to a connected Zebra API client.


### PR DESCRIPTION
It sounds from #16747 as if it's possible for zebra to get privs wrong when it sets up its zapi server socket when running in privs-per-process mode. The current zserv code opens and starts listening on that server socket pretty late during startup, since zebra needs to be ready to do what clients start asking it to do.
This PR separates zebra's ZAPI server socket handling into two phases: an early phase that opens the socket, and a later phase that starts listening for client connections. The early 'open' phase is called quite early, before other zebra subsystems are started. The 'start' phase is still called later on.
