### PR TITLE
zebra: Add missing new line for help string

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -341,7 +341,7 @@ int main(int argc, char **argv)
 		    "  -e, --ecmp                Specify ECMP to use.\n"
 		    "  -r, --retain              When program terminates, retain added route by zebra.\n"
 		    "  -A, --asic-offload        FRR is interacting with an asic underneath the linux kernel\n"
-		    "      --v6-with-v4-nexthops Underlying dataplane supports v6 routes with v4 nexthops"
+		    "      --v6-with-v4-nexthops Underlying dataplane supports v6 routes with v4 nexthops\n"
 #ifdef HAVE_NETLINK
 		    "  -s, --nl-bufsize          Set netlink receive buffer size\n"
 		    "  -n, --vrfwnetns           Use NetNS as VRF backend\n"


### PR DESCRIPTION
```
  -A, --asic-offload        FRR is interacting with an asic underneath the linux kernel
      --v6-with-v4-nexthops Underlying dataplane supports v6 routes with v4 nexthops  -s, --nl-bufsize          Set netlink receive buffer size
```

Fixes: 1f5611c06d1c243b42279748788f0627793ead9c ("zebra: Allow zebra cli to accept v6 routes with v4 nexthops")