### PR TITLE
ospfd: Use router_id what Zebra has if we remove a static router_id

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -339,6 +339,12 @@ DEFPY (no_ospf_router_id,
 	return CMD_SUCCESS;
 }
 
+ALIAS_HIDDEN (no_ospf_router_id,
+              no_router_id_cmd,
+              "no router-id [A.B.C.D]",
+              NO_STR
+              "router-id for the OSPF process\n"
+              "OSPF router-id in IP address format\n")
 
 static void ospf_passive_interface_default_update(struct ospf *ospf,
 						  uint8_t newval)
@@ -13629,6 +13635,7 @@ void ospf_vty_init(void)
 	install_element(OSPF_NODE, &ospf_router_id_cmd);
 	install_element(OSPF_NODE, &ospf_router_id_old_cmd);
 	install_element(OSPF_NODE, &no_ospf_router_id_cmd);
+	install_element(OSPF_NODE, &no_router_id_cmd);
 
 	/* "passive-interface" commands. */
 	install_element(OSPF_NODE, &ospf_passive_interface_default_cmd);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -147,15 +147,10 @@ void ospf_process_refresh_data(struct ospf *ospf, bool reset)
 
 	/* Select the router ID based on these priorities:
 	     1. Statically assigned router ID is always the first choice.
-	     2. If there is no statically assigned router ID, then try to stick
-		with the most recent value, since changing router ID's is very
-		disruptive.
-	     3. Last choice: just go with whatever the zebra daemon recommends.
+	     2. Just go with whatever the zebra daemon recommends.
 	*/
 	if (ospf->router_id_static.s_addr != INADDR_ANY)
 		router_id = ospf->router_id_static;
-	else if (ospf->router_id.s_addr != INADDR_ANY)
-		router_id = ospf->router_id;
 	else
 		router_id = ospf->router_id_zebra;
 


### PR DESCRIPTION
Closes https://github.com/FRRouting/frr/issues/17299