### PR TITLE
zebra: fix missing kernel routes

### DIFF
--- a/tests/topotests/zebra_multiple_connected/r1/ip_route_kernel_blackhole.json
+++ b/tests/topotests/zebra_multiple_connected/r1/ip_route_kernel_blackhole.json
@@ -1,0 +1,24 @@
+{
+  "0.0.0.0/0":[
+    {
+      "prefix":"0.0.0.0/0",
+      "prefixLen":0,
+      "protocol":"kernel",
+      "vrfName":"default",
+      "selected":true,
+      "destSelected":true,
+      "distance":0,
+      "metric":0,
+      "installed":true,
+      "table":254,
+      "nexthops":[
+        {
+          "fib":true,
+          "unreachable":true,
+          "blackhole":true,
+          "active":true
+        }
+      ]
+    }
+  ]
+}

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4549,7 +4549,7 @@ rib_update_handle_kernel_route_down_possibility(struct route_node *rn,
 		struct interface *ifp = if_lookup_by_index(nexthop->ifindex,
 							   nexthop->vrf_id);
 
-		if (ifp && if_is_up(ifp)) {
+		if ((ifp && if_is_up(ifp)) || nexthop->type == NEXTHOP_TYPE_BLACKHOLE) {
 			alive = true;
 			break;
 		}


### PR DESCRIPTION
The `rib_update_handle_kernel_route_down_possibility()` didn't consider the kernel routes ( blackhole )  without interface.  When some other interfaces are down, these kernel routes will be wrongly removed.