### PR TITLE
Bgp update optimizations

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2314,7 +2314,7 @@ static int bgp_update_receive(struct peer_connection *connection,
 	attr.label = MPLS_INVALID_LABEL;
 	memset(&nlris, 0, sizeof(nlris));
 	memset(peer->rcvd_attr_str, 0, BUFSIZ);
-	peer->rcvd_attr_printed = 0;
+	peer->rcvd_attr_printed = false;
 
 	s = peer->curr;
 	end = stream_pnt(s) + size;
@@ -2422,7 +2422,7 @@ static int bgp_update_receive(struct peer_connection *connection,
 		    BGP_DEBUG(update, UPDATE_DETAIL)) {
 			zlog_debug("%pBP rcvd UPDATE w/ attr: %s", peer,
 				   peer->rcvd_attr_str);
-			peer->rcvd_attr_printed = 1;
+			peer->rcvd_attr_printed = true;
 		}
 	}
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4667,11 +4667,12 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	bgp = peer->bgp;
 	dest = bgp_afi_node_get(bgp->rib[afi][safi], afi, safi, p, prd);
 
-	if ((afi == AFI_L2VPN && safi == SAFI_EVPN) ||
-	    bgp_is_valid_label(&label[0]))
+	if (num_labels &&
+	    ((afi == AFI_L2VPN && safi == SAFI_EVPN) || bgp_is_valid_label(&label[0]))) {
 		bgp_labels.num_labels = num_labels;
-	for (i = 0; i < bgp_labels.num_labels; i++)
-		bgp_labels.label[i] = label[i];
+		for (i = 0; i < bgp_labels.num_labels; i++)
+			bgp_labels.label[i] = label[i];
+	}
 
 	/* When peer's soft reconfiguration enabled.  Record input packet in
 	   Adj-RIBs-In.  */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4932,7 +4932,7 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 		goto filtered;
 	}
 
-	if (bgp_mac_entry_exists(p) || bgp_mac_exist(&attr->rmac)) {
+	if (safi == SAFI_EVPN && (bgp_mac_entry_exists(p) || bgp_mac_exist(&attr->rmac))) {
 		peer->stat_pfx_nh_invalid++;
 		reason = "self mac;";
 		bgp_attr_flush(&new_attr);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5063,7 +5063,7 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 							"%pBP rcvd UPDATE w/ attr: %s",
 							peer,
 							peer->rcvd_attr_str);
-						peer->rcvd_attr_printed = 1;
+						peer->rcvd_attr_printed = true;
 					}
 
 					bgp_debug_rdpfxpath2str(
@@ -5346,7 +5346,7 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 		if (!peer->rcvd_attr_printed) {
 			zlog_debug("%pBP rcvd UPDATE w/ attr: %s", peer,
 				   peer->rcvd_attr_str);
-			peer->rcvd_attr_printed = 1;
+			peer->rcvd_attr_printed = true;
 		}
 
 		bgp_debug_rdpfxpath2str(afi, safi, prd, p, label, num_labels,
@@ -5450,7 +5450,7 @@ filtered:
 		if (!peer->rcvd_attr_printed) {
 			zlog_debug("%pBP rcvd UPDATE w/ attr: %s", peer,
 				   peer->rcvd_attr_str);
-			peer->rcvd_attr_printed = 1;
+			peer->rcvd_attr_printed = true;
 		}
 
 		bgp_debug_rdpfxpath2str(afi, safi, prd, p, label, num_labels,

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1769,8 +1769,15 @@ struct peer {
 	/* Text description of last attribute rcvd */
 	char rcvd_attr_str[BUFSIZ];
 
-	/* Track if we printed the attribute in debugs */
-	int rcvd_attr_printed;
+	/*
+	 * Track if we printed the attribute in debugs
+	 *
+	 * These two rcvd_attr_str and rcvd_attr_printed are going to
+	 * be fun in the long term when we want to break up parsing
+	 * of data from the nlri in multiple pthreads or really
+	 * if we ever change order of things this will just break
+	 */
+	bool rcvd_attr_printed;
 
 	/* Accepted prefix count */
 	uint32_t pcount[AFI_MAX][SAFI_MAX];


### PR DESCRIPTION
Just a bunch of stuff to try to make bgp_update() more efficient.  It's the long poll in processing each bgp_path_info from a peer.  The more peers and routes you ahve the more time is spent in bgp_update().  These don't really provide a huge improvement, but it's incremental and I don't think anythng was done that is going to cause problems for understanding or maintainability