### PR TITLE
lib: Remove wheel name it is no longer used

### DIFF
--- a/lib/wheel.c
+++ b/lib/wheel.c
@@ -18,7 +18,7 @@ static int debug_timer_wheel = 0;
 
 static void wheel_timer_thread(struct event *t);
 
-static void wheel_timer_thread_helper(struct event *t)
+static void wheel_timer_thread(struct event *t)
 {
 	struct listnode *node, *nextnode;
 	unsigned long long curr_slot;
@@ -51,15 +51,6 @@ static void wheel_timer_thread_helper(struct event *t)
 			     wheel->nexttime * slots_to_skip, &wheel->timer);
 }
 
-static void wheel_timer_thread(struct event *t)
-{
-	struct timer_wheel *wheel;
-
-	wheel = EVENT_ARG(t);
-
-	event_execute(wheel->master, wheel_timer_thread_helper, wheel, 0, NULL);
-}
-
 struct timer_wheel *wheel_init(struct event_loop *master, int period,
 			       size_t slots,
 			       unsigned int (*slot_key)(const void *),
@@ -70,7 +61,6 @@ struct timer_wheel *wheel_init(struct event_loop *master, int period,
 
 	wheel = XCALLOC(MTYPE_TIMER_WHEEL, sizeof(struct timer_wheel));
 
-	wheel->name = XSTRDUP(MTYPE_TIMER_WHEEL, run_name);
 	wheel->slot_key = slot_key;
 	wheel->slot_run = slot_run;
 
@@ -101,7 +91,6 @@ void wheel_delete(struct timer_wheel *wheel)
 
 	EVENT_OFF(wheel->timer);
 	XFREE(MTYPE_TIMER_WHEEL_LIST, wheel->wheel_slot_lists);
-	XFREE(MTYPE_TIMER_WHEEL, wheel->name);
 	XFREE(MTYPE_TIMER_WHEEL, wheel);
 }
 

--- a/lib/wheel.h
+++ b/lib/wheel.h
@@ -12,7 +12,6 @@ extern "C" {
 #endif
 
 struct timer_wheel {
-	char *name;
 	struct event_loop *master;
 	int slots;
 	long long curr_slot;


### PR DESCRIPTION
With commit:
60a3efec2458d9a1531f8204d0e4a91729d3fc00

The ability for the wheel code to display the name of what wheel was actually being run was removed from the system. Since we can no longer do this and it's been 4 years since it's been in, let's just remove this bit of dead code.