### PR TITLE
Revert "ospfd: update ospf_asbr_status when using no_area_nssa command"

### DIFF
--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -1730,8 +1730,6 @@ int ospf_area_nssa_unset(struct ospf *ospf, struct in_addr area_id)
 	area->no_summary = 0;
 	area->suppress_fa = 0;
 	area->NSSATranslatorRole = OSPF_NSSA_ROLE_CANDIDATE;
-	if (area->NSSATranslatorState == OSPF_NSSA_TRANSLATE_ENABLED)
-		ospf_asbr_status_update(ospf, --ospf->redistribute);
 	area->NSSATranslatorState = OSPF_NSSA_TRANSLATE_DISABLED;
 	area->NSSATranslatorStabilityInterval = OSPF_NSSA_TRANS_STABLE_DEFAULT;
 	ospf_area_type_set(area, OSPF_AREA_DEFAULT);


### PR DESCRIPTION
This reverts commit 71aa5ab7f6f166065e3b869e3c33ba5b7a57fccb.

This commit was causing frequent master ci run failures.  Author has not responded and since I do not know which of the two problems we have here is better, I would rather go with the known original problem