### PR TITLE
zebra: Fix incorrect debug macros

### DIFF
--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -1305,7 +1305,7 @@ static bool alloc_srv6_sid_func_explicit(struct zebra_srv6_sid_block *block,
 		block->u.uncompressed.num_func_allocated++;
 	}
 
-	if (ZEBRA_DEBUG_SRV6)
+	if (IS_ZEBRA_DEBUG_SRV6)
 		zlog_debug("%s: allocated explicit SID function %u from block %pFX",
 			   __func__, sid_func, &block->prefix);
 

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -1918,7 +1918,7 @@ static bool release_srv6_sid_func_explicit(struct zebra_srv6_sid_block *block,
 		zebra_srv6_sid_func_free(sid_func_ptr);
 	}
 
-	if (ZEBRA_DEBUG_SRV6)
+	if (IS_ZEBRA_DEBUG_SRV6)
 		zlog_debug("%s: released explicit SRv6 SID function %u from block %pFX",
 			   __func__, sid_func, &block->prefix);
 

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -1159,7 +1159,7 @@ static bool alloc_srv6_sid_func_explicit(struct zebra_srv6_sid_block *block,
 
 	format = block->sid_format;
 
-	if (ZEBRA_DEBUG_SRV6)
+	if (IS_ZEBRA_DEBUG_SRV6)
 		zlog_debug("%s: trying to allocate explicit SID function %u from block %pFX",
 			   __func__, sid_func, &block->prefix);
 

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -1465,7 +1465,7 @@ static bool alloc_srv6_sid_func_dynamic(struct zebra_srv6_sid_block *block,
 		block->u.uncompressed.num_func_allocated++;
 	}
 
-	if (ZEBRA_DEBUG_SRV6)
+	if (IS_ZEBRA_DEBUG_SRV6)
 		zlog_debug("%s: allocated dynamic SID function %u from block %pFX",
 			   __func__, *sid_func, &block->prefix);
 

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -1331,7 +1331,7 @@ static bool alloc_srv6_sid_func_dynamic(struct zebra_srv6_sid_block *block,
 
 	format = block->sid_format;
 
-	if (ZEBRA_DEBUG_SRV6)
+	if (IS_ZEBRA_DEBUG_SRV6)
 		zlog_debug("%s: trying to allocate dynamic SID function from block %pFX",
 			   __func__, &block->prefix);
 

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -1944,7 +1944,7 @@ static int release_srv6_sid_func_dynamic(struct zebra_srv6_sid_block *block,
 
 	format = block->sid_format;
 
-	if (ZEBRA_DEBUG_SRV6)
+	if (IS_ZEBRA_DEBUG_SRV6)
 		zlog_debug("%s: trying to release dynamic SRv6 SID function %u from block %pFX",
 			   __func__, sid_func, &block->prefix);
 

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -1794,7 +1794,7 @@ static bool release_srv6_sid_func_explicit(struct zebra_srv6_sid_block *block,
 
 	format = block->sid_format;
 
-	if (ZEBRA_DEBUG_SRV6)
+	if (IS_ZEBRA_DEBUG_SRV6)
 		zlog_debug("%s: trying to release explicit SRv6 SID function %u from block %pFX",
 			   __func__, sid_func, &block->prefix);
 

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -2107,7 +2107,7 @@ static int release_srv6_sid_func_dynamic(struct zebra_srv6_sid_block *block,
 		}
 	}
 
-	if (ZEBRA_DEBUG_SRV6)
+	if (IS_ZEBRA_DEBUG_SRV6)
 		zlog_debug("%s: released dynamic SRv6 SID function %u from block %pFX",
 			   __func__, sid_func, &block->prefix);
 


### PR DESCRIPTION
`ZEBRA_DEBUG_SRV6` is not the correct macro to evaluate if SRv6 debug is enabled or not.
The correct macro is `IS_ZEBRA_DEBUG_SRV6`.

Fix this by replacing `ZEBRA_DEBUG_SRV6` with `IS_ZEBRA_DEBUG_SRV6`.
