### PR TITLE
implement SBFD

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -657,11 +657,13 @@ void bfd_echo_recvtimer_cb(struct event *t)
 	}
 }
 
-struct bfd_session *bfd_session_new(void)
+struct bfd_session *bfd_session_new(enum bfd_mode_type mode)
 {
 	struct bfd_session *bs;
 
-	bs = XCALLOC(MTYPE_BFDD_CONFIG, sizeof(*bs));
+	bs = XCALLOC(MTYPE_BFDD_CONFIG, sizeof(struct bfd_session));
+	bs->segnum = 0;
+	bs->bfd_mode = mode;
 
 	/* Set peer session defaults. */
 	bfd_profile_set_default(&bs->peer_profile);
@@ -799,7 +801,7 @@ struct bfd_session *ptm_bfd_sess_new(struct bfd_peer_cfg *bpc)
 	}
 
 	/* Get BFD session storage with its defaults. */
-	bfd = bfd_session_new();
+	bfd = bfd_session_new(BFD_MODE_TYPE_BFD);
 
 	/*
 	 * Store interface/VRF name in case we need to delay session

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -580,13 +580,21 @@ typedef void (*bfd_ev_cb)(struct event *t);
 
 void bfd_recvtimer_update(struct bfd_session *bs);
 void bfd_echo_recvtimer_update(struct bfd_session *bs);
+void sbfd_init_recvtimer_update(struct bfd_session *bs);
+void sbfd_echo_recvtimer_update(struct bfd_session *bs);
 void bfd_xmttimer_update(struct bfd_session *bs, uint64_t jitter);
 void bfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter);
+void sbfd_init_xmttimer_update(struct bfd_session *bs, uint64_t jitter);
+void sbfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter);
 
 void bfd_xmttimer_delete(struct bfd_session *bs);
 void bfd_echo_xmttimer_delete(struct bfd_session *bs);
+void sbfd_init_xmttimer_delete(struct bfd_session *bs);
+void sbfd_echo_xmttimer_delete(struct bfd_session *bs);
 void bfd_recvtimer_delete(struct bfd_session *bs);
 void bfd_echo_recvtimer_delete(struct bfd_session *bs);
+void sbfd_init_recvtimer_delete(struct bfd_session *bs);
+void sbfd_echo_recvtimer_delete(struct bfd_session *bs);
 
 void bfd_recvtimer_assign(struct bfd_session *bs, bfd_ev_cb cb, int sd);
 void bfd_echo_recvtimer_assign(struct bfd_session *bs, bfd_ev_cb cb, int sd);
@@ -609,6 +617,9 @@ void ptm_bfd_echo_stop(struct bfd_session *bfd);
 void ptm_bfd_echo_start(struct bfd_session *bfd);
 void ptm_bfd_xmt_TO(struct bfd_session *bfd, int fbit);
 void ptm_bfd_start_xmt_timer(struct bfd_session *bfd, bool is_echo);
+void ptm_sbfd_init_xmt_TO(struct bfd_session *bfd, int fbit);
+void ptm_sbfd_init_reset(struct bfd_session *bfd);
+void ptm_sbfd_echo_reset(struct bfd_session *bfd);
 struct bfd_session *ptm_bfd_sess_find(struct bfd_pkt *cp,
 				      struct sockaddr_any *peer,
 				      struct sockaddr_any *local,
@@ -642,6 +653,7 @@ const struct bfd_session *bfd_session_next(const struct bfd_session *bs, bool mh
 					   uint32_t bfd_mode);
 void bfd_sessions_remove_manual(void);
 void bfd_profiles_remove(void);
+void bs_sbfd_echo_timer_handler(struct bfd_session *bs);
 void bfd_rtt_init(struct bfd_session *bfd);
 
 extern void bfd_vrf_toggle_echo(struct bfd_vrf_global *bfd_vrf);
@@ -711,6 +723,11 @@ void bfd_recvtimer_cb(struct event *t);
 void bfd_echo_recvtimer_cb(struct event *t);
 void bfd_xmt_cb(struct event *t);
 void bfd_echo_xmt_cb(struct event *t);
+
+void sbfd_init_recvtimer_cb(struct event *t);
+void sbfd_echo_recvtimer_cb(struct event *t);
+void sbfd_init_xmt_cb(struct event *t);
+void sbfd_echo_xmt_cb(struct event *t);
 
 extern struct in6_addr zero_addr;
 
@@ -852,4 +869,12 @@ struct sbfd_reflector *sbfd_reflector_new(const uint32_t discr, struct in6_addr 
 void sbfd_reflector_free(const uint32_t discr);
 void sbfd_reflector_flush(void);
 
+/*sbfd*/
+void ptm_sbfd_echo_sess_dn(struct bfd_session *bfd, uint8_t diag);
+void ptm_sbfd_init_sess_dn(struct bfd_session *bfd, uint8_t diag);
+void ptm_sbfd_sess_up(struct bfd_session *bfd);
+void sbfd_echo_state_handler(struct bfd_session *bs, int nstate);
+void sbfd_initiator_state_handler(struct bfd_session *bs, int nstate);
+
+struct bfd_session *bfd_session_get_by_name(const char *name);
 #endif /* _BFD_H_ */

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -235,6 +235,12 @@ enum bfd_session_flags {
 	BFD_SESS_FLAG_MAC_SET = 1 << 11, /* MAC of peer known */
 };
 
+enum bfd_mode_type {
+	BFD_MODE_TYPE_BFD = 0,
+	BFD_MODE_TYPE_SBFD_ECHO = 1,
+	BFD_MODE_TYPE_SBFD_INIT = 2,
+};
+
 /*
  * BFD session hash key.
  *

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -152,7 +152,6 @@ struct bfd_echo_pkt {
 	uint64_t time_sent_usec;
 };
 
-
 /* Macros for manipulating control packets */
 #define BFD_VERMASK 0x07
 #define BFD_DIAGMASK 0x1F
@@ -470,9 +469,10 @@ struct bfd_vrf_global {
 	int bg_mhop6;
 	int bg_echo;
 	int bg_echov6;
+	int bg_initv6;
 	struct vrf *vrf;
 
-	struct event *bg_ev[6];
+	struct event *bg_ev[7];
 };
 
 /* Forward declaration of data plane context struct. */

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -615,7 +615,7 @@ void bs_to_bpc(struct bfd_session *bs, struct bfd_peer_cfg *bpc);
 
 void gen_bfd_key(struct bfd_key *key, struct sockaddr_any *peer, struct sockaddr_any *local,
 		 bool mhop, const char *ifname, const char *vrfname, const char *bfdname);
-struct bfd_session *bfd_session_new(void);
+struct bfd_session *bfd_session_new(enum bfd_mode_type mode);
 struct bfd_session *bs_registrate(struct bfd_session *bs);
 void bfd_session_free(struct bfd_session *bs);
 const struct bfd_session *bfd_session_next(const struct bfd_session *bs, bool mhop,

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -19,6 +19,7 @@
 #include "lib/qobj.h"
 #include "lib/queue.h"
 #include "lib/vrf.h"
+#include "lib/bfd.h"
 
 #ifdef BFD_DEBUG
 #define BFDD_JSON_CONV_OPTIONS (JSON_C_TO_STRING_PRETTY)
@@ -86,6 +87,10 @@ struct bfd_peer_cfg {
 
 	bool bpc_has_profile;
 	char bpc_profile[64];
+
+	vrf_id_t vrf_id;
+	char bfd_name[BFD_NAME_SIZE + 1];
+	uint8_t bfd_name_len;
 };
 
 /* bfd Authentication Type. */
@@ -260,6 +265,7 @@ struct bfd_key {
 	struct in6_addr local;
 	char ifname[IFNAMSIZ];
 	char vrfname[VRF_NAMSIZ];
+	char bfdname[BFD_NAME_SIZE + 1];
 } __attribute__((packed));
 
 struct bfd_session_stats {
@@ -381,6 +387,9 @@ struct bfd_session {
 	uint8_t rtt_valid;	    /* number of valid samples */
 	uint8_t rtt_index;	    /* last index added */
 	uint64_t rtt[BFD_RTT_SAMPLE]; /* RRT in usec for echo to be looped */
+	char bfd_name[BFD_NAME_SIZE + 1];
+
+	uint32_t bfd_mode;
 };
 
 struct bfd_diag_str_list {
@@ -604,14 +613,13 @@ void bs_observer_del(struct bfd_session_observer *bso);
 
 void bs_to_bpc(struct bfd_session *bs, struct bfd_peer_cfg *bpc);
 
-void gen_bfd_key(struct bfd_key *key, struct sockaddr_any *peer,
-		 struct sockaddr_any *local, bool mhop, const char *ifname,
-		 const char *vrfname);
+void gen_bfd_key(struct bfd_key *key, struct sockaddr_any *peer, struct sockaddr_any *local,
+		 bool mhop, const char *ifname, const char *vrfname, const char *bfdname);
 struct bfd_session *bfd_session_new(void);
 struct bfd_session *bs_registrate(struct bfd_session *bs);
 void bfd_session_free(struct bfd_session *bs);
-const struct bfd_session *bfd_session_next(const struct bfd_session *bs,
-					   bool mhop);
+const struct bfd_session *bfd_session_next(const struct bfd_session *bs, bool mhop,
+					   uint32_t bfd_mode);
 void bfd_sessions_remove_manual(void);
 void bfd_profiles_remove(void);
 void bfd_rtt_init(struct bfd_session *bfd);

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -411,6 +411,11 @@ struct bfd_session_observer {
 };
 TAILQ_HEAD(obslist, bfd_session_observer);
 
+/*sbfd reflector struct*/
+struct sbfd_reflector {
+	uint32_t discr;
+	struct in6_addr local;
+};
 
 /* States defined per 4.1 */
 #define PTM_BFD_ADM_DOWN 0
@@ -667,18 +672,22 @@ void bfd_vrf_terminate(void);
 struct bfd_vrf_global *bfd_vrf_look_by_session(struct bfd_session *bfd);
 struct bfd_session *bfd_id_lookup(uint32_t id);
 struct bfd_session *bfd_key_lookup(struct bfd_key key);
-
+struct sbfd_reflector *sbfd_discr_lookup(uint32_t discr);
 struct bfd_session *bfd_id_delete(uint32_t id);
 struct bfd_session *bfd_key_delete(struct bfd_key key);
+struct sbfd_reflector *sbfd_discr_delete(uint32_t discr);
 
 bool bfd_id_insert(struct bfd_session *bs);
 bool bfd_key_insert(struct bfd_session *bs);
+bool sbfd_discr_insert(struct sbfd_reflector *sr);
 
 typedef void (*hash_iter_func)(struct hash_bucket *hb, void *arg);
 void bfd_id_iterate(hash_iter_func hif, void *arg);
 void bfd_key_iterate(hash_iter_func hif, void *arg);
+void sbfd_discr_iterate(hash_iter_func hif, void *arg);
 
 unsigned long bfd_get_session_count(void);
+unsigned long sbfd_discr_get_count(void);
 
 /* Export callback functions for `event.c`. */
 extern struct event_loop *master;
@@ -822,5 +831,10 @@ int bfd_dplane_delete_session(struct bfd_session *bs);
 int bfd_dplane_update_session_counters(struct bfd_session *bs);
 
 void bfd_dplane_show_counters(struct vty *vty);
+
+/*sbfd relfector*/
+struct sbfd_reflector *sbfd_reflector_new(const uint32_t discr, struct in6_addr *sip);
+void sbfd_reflector_free(const uint32_t discr);
+void sbfd_reflector_flush(void);
 
 #endif /* _BFD_H_ */

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -65,11 +65,11 @@ static int bp_raw_sbfd_red_send(int sd, uint8_t *data, size_t datalen, uint16_t 
 				struct in6_addr *out_sip, struct in6_addr *sip,
 				struct in6_addr *dip, uint16_t src_port, uint16_t dst_port,
 				uint8_t seg_num, struct in6_addr *segment_list);
-ssize_t bfd_recv_ipv4_fp(int sd, uint8_t *msgbuf, size_t msgbuflen,
-			 uint8_t *ttl, ifindex_t *ifindex,
-			 struct sockaddr_any *local, struct sockaddr_any *peer);
-void bfd_peer_mac_set(int sd, struct bfd_session *bfd,
-		      struct sockaddr_any *peer, struct interface *ifp);
+static ssize_t bfd_recv_ipv4_fp(int sd, uint8_t *msgbuf, size_t msgbuflen, uint8_t *ttl,
+				ifindex_t *ifindex, struct sockaddr_any *local,
+				struct sockaddr_any *peer);
+static void bfd_peer_mac_set(int sd, struct bfd_session *bfd, struct sockaddr_any *peer,
+			     struct interface *ifp);
 int bp_udp_send_fp(int sd, uint8_t *data, size_t datalen,
 		   struct bfd_session *bfd);
 ssize_t bfd_recv_fp_echo(int sd, uint8_t *msgbuf, size_t msgbuflen,
@@ -470,9 +470,9 @@ void ptm_bfd_snd(struct bfd_session *bfd, int fbit)
 /*
  * receive the ipv4 echo packet that was loopback in the peers forwarding plane
  */
-ssize_t bfd_recv_ipv4_fp(int sd, uint8_t *msgbuf, size_t msgbuflen,
-			 uint8_t *ttl, ifindex_t *ifindex,
-			 struct sockaddr_any *local, struct sockaddr_any *peer)
+static ssize_t bfd_recv_ipv4_fp(int sd, uint8_t *msgbuf, size_t msgbuflen, uint8_t *ttl,
+				ifindex_t *ifindex, struct sockaddr_any *local,
+				struct sockaddr_any *peer)
 {
 	ssize_t mlen;
 	struct sockaddr_ll msgaddr;
@@ -1808,8 +1808,8 @@ int bp_echov6_socket(const struct vrf *vrf)
 /* get peer's mac address to be used with Echo packets when they are looped in
  * peers forwarding plane
  */
-void bfd_peer_mac_set(int sd, struct bfd_session *bfd,
-		      struct sockaddr_any *peer, struct interface *ifp)
+static void bfd_peer_mac_set(int sd, struct bfd_session *bfd, struct sockaddr_any *peer,
+			     struct interface *ifp)
 {
 	struct arpreq arpreq_;
 

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -2107,16 +2107,18 @@ int bp_peer_srh_socketv6(struct bfd_session *bs)
 		close(sd);
 		return -1;
 	}
-#if defined(HAVE_IPV6_HDRINCL)
+#ifdef IPV6_HDRINCL
 	int on = 1;
 
 	/*manage the IP6 header all on own onwn*/
 	if (setsockopt(sd, IPPROTO_IPV6, IPV6_HDRINCL, &on, sizeof(on))) {
+#else
+	if (true) {
+#endif
 		zlog_err("setsockopt IPV6_HDRINCL error: %s", strerror(errno));
 		close(sd);
 		return -1;
 	}
-#endif
 
 	return sd;
 }

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -11,8 +11,12 @@
 #include "lib/command.h"
 #include "lib/log.h"
 #include "lib/northbound_cli.h"
+#include "lib/termtable.h"
+#include "lib/ipaddr.h"
 
+#ifndef VTYSH_EXTRACT_PL
 #include "bfdd/bfdd_cli_clippy.c"
+#endif /* VTYSH_EXTRACT_PL */
 
 #include "bfd.h"
 #include "bfdd_nb.h"
@@ -31,6 +35,10 @@
 #define LOCAL_INTF_STR "Configure local interface name to use\n"
 #define VRF_STR "Configure VRF\n"
 #define VRF_NAME_STR "Configure VRF name\n"
+#define SESSION_NAME_STR       "Specify bfd session name\n"
+#define SET_SESSION_NAME_STR   "bfd session name\n"
+#define SESSION_MODE_STR       "Specify bfd session mode\n"
+#define APPLY_SESSION_MODE_STR "Enable bfd mode\n"
 
 /*
  * Prototypes.
@@ -40,6 +48,12 @@ bfd_cli_is_single_hop(struct vty *vty)
 {
 	return strstr(VTY_CURR_XPATH, "/single-hop") != NULL;
 }
+
+static bool bfd_cli_is_sbfd_echo(struct vty *vty)
+{
+	return strstr(VTY_CURR_XPATH, "/sbfd-echo") != NULL;
+}
+
 
 static bool
 bfd_cli_is_profile(struct vty *vty)
@@ -215,45 +229,486 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
-static void _bfd_cli_show_peer(struct vty *vty, const struct lyd_node *dnode,
-			       bool show_defaults __attribute__((__unused__)),
-			       bool mhop)
+DEFPY_YANG_NOSH(
+	sbfd_echo_peer_enter, sbfd_echo_peer_enter_cmd,
+	"peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-echo bfd-name BFDNAME$bfdname \
+	[multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] \
+	srv6-source-ipv6 X:X::X:X srv6-encap-data X:X::X:X...",
+	PEER_STR
+	PEER_IPV4_STR
+	PEER_IPV6_STR
+	SESSION_MODE_STR
+	"Enable sbfd-echo mode\n"
+	SESSION_NAME_STR
+	SET_SESSION_NAME_STR
+	MHOP_STR
+	LOCAL_STR
+	LOCAL_IPV4_STR
+	LOCAL_IPV6_STR
+	VRF_STR
+	VRF_NAME_STR
+	"Configure source ipv6 address for srv6 encap\n"
+	LOCAL_IPV6_STR
+	"Configure sidlist data for srv6 encap\n"
+	"X:X::X:X IPv6 sid address\n")
 {
-	const char *vrf = yang_dnode_get_string(dnode, "vrf");
+	int ret, slen, data_idx = 11;
+	char xpath[XPATH_MAXLEN], xpath_sl[XPATH_MAXLEN + 32], xpath_mh[XPATH_MAXLEN + 32];
 
-	vty_out(vty, " peer %s",
-		yang_dnode_get_string(dnode, "dest-addr"));
-
-	if (mhop)
-		vty_out(vty, " multihop");
-
-	if (yang_dnode_exists(dnode, "source-addr"))
-		vty_out(vty, " local-address %s",
-			yang_dnode_get_string(dnode, "source-addr"));
-
-	if (strcmp(vrf, VRF_DEFAULT_NAME))
-		vty_out(vty, " vrf %s", vrf);
-
-	if (!mhop) {
-		const char *ifname =
-			yang_dnode_get_string(dnode, "interface");
-		if (strcmp(ifname, "*"))
-			vty_out(vty, " interface %s", ifname);
+	if (!bfdname) {
+		vty_out(vty, "%% ERROR: bfd name is required\n");
+		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	vty_out(vty, "\n");
+	if (strcmp(peer_str, local_address_str)) {
+		vty_out(vty,
+			"%% ERROR: peer and local-address must be the same in sbfd-echo mode\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	slen = snprintf(xpath, sizeof(xpath),
+			"/frr-bfdd:bfdd/bfd/sessions/sbfd-echo[source-addr='%s'][bfd-name='%s']",
+			local_address_str, bfdname);
+
+	if (vrf) {
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", vrf);
+		data_idx += 2;
+	} else
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", VRF_DEFAULT_NAME);
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+
+	if (multihop) {
+		snprintf(xpath_mh, sizeof(xpath_mh), "%s/multi-hop", xpath);
+		nb_cli_enqueue_change(vty, xpath_mh, NB_OP_MODIFY, "true");
+		data_idx += 1;
+	}
+
+	for (int i = data_idx; i < argc; i++) {
+		snprintf(xpath_sl, sizeof(xpath_sl), "%s/srv6-encap-data", xpath);
+		nb_cli_enqueue_change(vty, xpath_sl, NB_OP_CREATE, argv[i]->arg);
+	}
+
+	snprintf(xpath_sl, sizeof(xpath_sl), "%s/srv6-source-ipv6", xpath);
+	nb_cli_enqueue_change(vty, xpath_sl, NB_OP_MODIFY, srv6_source_ipv6_str);
+
+	snprintf(xpath_sl, sizeof(xpath_sl), "%s/dest-addr", xpath);
+	nb_cli_enqueue_change(vty, xpath_sl, NB_OP_MODIFY, peer_str);
+
+	/* Apply settings immediately. */
+	ret = nb_cli_apply_changes(vty, NULL);
+	if (ret == CMD_SUCCESS)
+		VTY_PUSH_XPATH(BFD_PEER_NODE, xpath);
+
+	return ret;
+}
+
+DEFPY_YANG(
+	sbfd_echo_no_peer, sbfd_echo_no_peer_cmd,
+	"no peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-echo bfd-name BFDNAME$bfdname \
+	[multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] \
+	srv6-source-ipv6 X:X::X:X srv6-encap-data X:X::X:X...",
+	NO_STR
+	PEER_STR
+	PEER_IPV4_STR
+	PEER_IPV6_STR
+	SESSION_MODE_STR
+	"Enable sbfd-echo mode\n"
+	SESSION_NAME_STR
+	SET_SESSION_NAME_STR
+	MHOP_STR
+	LOCAL_STR
+	LOCAL_IPV4_STR
+	LOCAL_IPV6_STR
+	VRF_STR
+	VRF_NAME_STR
+	"Configure source ipv6 address for srv6 encap\n"
+	LOCAL_IPV6_STR
+	"Configure sidlist data for srv6 encap\n"
+	"X:X::X:X IPv6 sid address\n")
+{
+	int slen;
+	char xpath[XPATH_MAXLEN];
+
+	slen = snprintf(xpath, sizeof(xpath),
+			"/frr-bfdd:bfdd/bfd/sessions/sbfd-echo[source-addr='%s'][bfd-name='%s']",
+			local_address_str, bfdname);
+
+	if (vrf)
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", vrf);
+	else
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", VRF_DEFAULT_NAME);
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+
+	/* Apply settings immediatly. */
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+
+DEFPY_YANG_NOSH(
+	sbfd_init_peer_enter, sbfd_init_peer_enter_cmd,
+	"peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-init bfd-name BFDNAME$bfdname \
+	[multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] \
+	remote-discr (1-4294967295)$discr srv6-source-ipv6 X:X::X:X srv6-encap-data X:X::X:X...",
+	PEER_STR
+	PEER_IPV4_STR
+	PEER_IPV6_STR
+	SESSION_MODE_STR
+	"Enable sbfd-init mode\n"
+	SESSION_NAME_STR
+	SET_SESSION_NAME_STR
+	MHOP_STR
+	LOCAL_STR
+	LOCAL_IPV4_STR
+	LOCAL_IPV6_STR
+	VRF_STR
+	VRF_NAME_STR
+	"Configure bfd session remote discriminator\n"
+	"Configure remote discriminator\n"
+	"Configure source ipv6 address for srv6 encap\n"
+	LOCAL_IPV6_STR
+	"Configure sidlist data for srv6 encap\n"
+	"X:X::X:X IPv6 sid address\n")
+{
+	int ret, slen, data_idx = 13;
+	char xpath[XPATH_MAXLEN], xpath_sl[XPATH_MAXLEN + 32], xpath_rd[XPATH_MAXLEN + 32],
+		xpath_mh[XPATH_MAXLEN + 32];
+	struct ipaddr peer_addr = { 0 };
+	struct ipaddr local_addr = { 0 };
+
+	if (!bfdname) {
+		vty_out(vty, "%% ERROR: bfd name is required\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	str2ipaddr(peer_str, &peer_addr);
+	if (peer_addr.ipa_type == AF_UNSPEC) {
+		vty_out(vty, "%% ERROR: peer is invalid address\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	str2ipaddr(local_address_str, &local_addr);
+	if (local_addr.ipa_type == AF_UNSPEC) {
+		vty_out(vty, "%% ERROR: local_address is invalid address\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	if (peer_addr.ipa_type != local_addr.ipa_type) {
+		vty_out(vty, "%% ERROR: peer and local_address are not the same ip version\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	slen = snprintf(xpath, sizeof(xpath),
+			"/frr-bfdd:bfdd/bfd/sessions/sbfd-init[source-addr='%s'][dest-addr='%s'][bfd-name='%s']",
+			local_address_str, peer_str, bfdname);
+
+	if (vrf) {
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", vrf);
+		data_idx += 2;
+	} else
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", VRF_DEFAULT_NAME);
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+
+	if (multihop) {
+		snprintf(xpath_mh, sizeof(xpath_mh), "%s/multi-hop", xpath);
+		nb_cli_enqueue_change(vty, xpath_mh, NB_OP_MODIFY, "true");
+		data_idx += 1;
+	}
+
+	if (srv6_source_ipv6_str) {
+		for (int i = data_idx; i < argc; i++) {
+			snprintf(xpath_sl, sizeof(xpath_sl), "%s/srv6-encap-data", xpath);
+			nb_cli_enqueue_change(vty, xpath_sl, NB_OP_CREATE, argv[i]->arg);
+		}
+
+		snprintf(xpath_sl, sizeof(xpath_sl), "%s/srv6-source-ipv6", xpath);
+		nb_cli_enqueue_change(vty, xpath_sl, NB_OP_MODIFY, srv6_source_ipv6_str);
+	}
+
+	snprintf(xpath_rd, sizeof(xpath_rd), "%s/remote-discr", xpath);
+	nb_cli_enqueue_change(vty, xpath_rd, NB_OP_MODIFY, discr_str);
+
+	/* Apply settings immediately. */
+	ret = nb_cli_apply_changes(vty, NULL);
+	if (ret == CMD_SUCCESS)
+		VTY_PUSH_XPATH(BFD_PEER_NODE, xpath);
+
+	return ret;
+}
+
+DEFPY_YANG(
+	sbfd_init_no_peer, sbfd_init_no_peer_cmd,
+	"no peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-init bfd-name BFDNAME$bfdname \
+	[multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] \
+	remote-discr (0-4294967295)$discr srv6-source-ipv6 X:X::X:X srv6-encap-data X:X::X:X...",
+	NO_STR
+	PEER_STR
+	PEER_IPV4_STR
+	PEER_IPV6_STR
+	SESSION_MODE_STR
+	"Enable sbfd-init mode\n"
+	SESSION_NAME_STR
+	SET_SESSION_NAME_STR
+	MHOP_STR
+	LOCAL_STR
+	LOCAL_IPV4_STR
+	LOCAL_IPV6_STR
+	VRF_STR
+	VRF_NAME_STR
+	"Configure bfd session remote discriminator\n"
+	"Configure remote discriminator\n"
+	"Configure source ipv6 address for srv6 encap\n"
+	LOCAL_IPV6_STR
+	"Configure sidlist data for srv6 encap\n"
+	"X:X::X:X IPv6 sid address\n")
+{
+	int slen;
+	char xpath[XPATH_MAXLEN];
+
+	slen = snprintf(xpath, sizeof(xpath),
+			"/frr-bfdd:bfdd/bfd/sessions/sbfd-init[source-addr='%s'][dest-addr='%s'][bfd-name='%s']",
+			local_address_str, peer_str, bfdname);
+
+	if (vrf)
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", vrf);
+	else
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", VRF_DEFAULT_NAME);
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+
+	/* Apply settings immediatly. */
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG_NOSH(
+	sbfd_init_peer_raw_enter, sbfd_init_peer_raw_enter_cmd,
+	"peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-init bfd-name BFDNAME$bfdname \
+	[multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] \
+	remote-discr (1-4294967295)$discr",
+	PEER_STR
+	PEER_IPV4_STR
+	PEER_IPV6_STR
+	SESSION_MODE_STR
+	"Enable sbfd-init mode\n"
+	SESSION_NAME_STR
+	SET_SESSION_NAME_STR
+	MHOP_STR
+	LOCAL_STR
+	LOCAL_IPV4_STR
+	LOCAL_IPV6_STR
+	VRF_STR
+	VRF_NAME_STR
+	"Configure bfd session remote discriminator\n"
+	"Configure remote discriminator\n")
+{
+	int ret, slen;
+	char xpath[XPATH_MAXLEN], xpath_rd[XPATH_MAXLEN + 32], xpath_mh[XPATH_MAXLEN + 32];
+	struct ipaddr peer_addr = { 0 };
+	struct ipaddr local_addr = { 0 };
+
+	if (!bfdname) {
+		vty_out(vty, "%% ERROR: bfd name is required\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	str2ipaddr(peer_str, &peer_addr);
+	if (peer_addr.ipa_type == AF_UNSPEC) {
+		vty_out(vty, "%% ERROR: peer is invalid address\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	str2ipaddr(local_address_str, &local_addr);
+	if (local_addr.ipa_type == AF_UNSPEC) {
+		vty_out(vty, "%% ERROR: local_address is invalid address\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	if (peer_addr.ipa_type != local_addr.ipa_type) {
+		vty_out(vty, "%% ERROR: peer and local_address are not the same ip version\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	slen = snprintf(xpath, sizeof(xpath),
+			"/frr-bfdd:bfdd/bfd/sessions/sbfd-init[source-addr='%s'][dest-addr='%s'][bfd-name='%s']",
+			local_address_str, peer_str, bfdname);
+
+	if (vrf)
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", vrf);
+	else
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", VRF_DEFAULT_NAME);
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+
+	if (multihop) {
+		snprintf(xpath_mh, sizeof(xpath_mh), "%s/multi-hop", xpath);
+		nb_cli_enqueue_change(vty, xpath_mh, NB_OP_MODIFY, "true");
+	}
+
+	snprintf(xpath_rd, sizeof(xpath_rd), "%s/remote-discr", xpath);
+	nb_cli_enqueue_change(vty, xpath_rd, NB_OP_MODIFY, discr_str);
+
+	/* Apply settings immediately. */
+	ret = nb_cli_apply_changes(vty, NULL);
+	if (ret == CMD_SUCCESS)
+		VTY_PUSH_XPATH(BFD_PEER_NODE, xpath);
+
+	return ret;
+}
+
+DEFPY_YANG(
+	sbfd_init_no_peer_raw, sbfd_init_no_peer_raw_cmd,
+	"no peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-init bfd-name BFDNAME$bfdname \
+	[multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] \
+	remote-discr (0-4294967295)$discr",
+	NO_STR
+	PEER_STR
+	PEER_IPV4_STR
+	PEER_IPV6_STR
+	SESSION_MODE_STR
+	"Enable sbfd-init mode\n"
+	SESSION_NAME_STR
+	SET_SESSION_NAME_STR
+	MHOP_STR
+	LOCAL_STR
+	LOCAL_IPV4_STR
+	LOCAL_IPV6_STR
+	VRF_STR
+	VRF_NAME_STR
+	"Configure bfd session remote discriminator\n"
+	"Configure remote discriminator\n")
+{
+	int slen;
+	char xpath[XPATH_MAXLEN];
+
+	slen = snprintf(xpath, sizeof(xpath),
+			"/frr-bfdd:bfdd/bfd/sessions/sbfd-init[source-addr='%s'][dest-addr='%s'][bfd-name='%s']",
+			local_address_str, peer_str, bfdname);
+
+	if (vrf)
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", vrf);
+	else
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", VRF_DEFAULT_NAME);
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+
+	/* Apply settings immediatly. */
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+static const char *_bfd_cli_bfd_mode_type_to_string(enum bfd_mode_type mode)
+{
+	switch (mode) {
+	case BFD_MODE_TYPE_BFD:
+		return "bfd";
+	case BFD_MODE_TYPE_SBFD_ECHO:
+		return "sbfd-echo";
+	case BFD_MODE_TYPE_SBFD_INIT:
+		return "sbfd-init";
+	default:
+		return "Unknown";
+	}
+}
+
+struct sidlist_show_iter {
+	char buf[INET6_ADDRSTRLEN * SRV6_MAX_SEGS];
+};
+
+static int sidlist_show_iter_cb(const struct lyd_node *dnode, void *arg)
+{
+	struct sidlist_show_iter *iter = arg;
+	const char *addr;
+
+	addr = yang_dnode_get_string(dnode, NULL);
+
+	strlcat(iter->buf, addr, INET6_ADDRSTRLEN * SRV6_MAX_SEGS);
+	strlcat(iter->buf, " ", INET6_ADDRSTRLEN * SRV6_MAX_SEGS);
+
+	return YANG_ITER_CONTINUE;
+}
+
+static void _bfd_cli_show_peer(struct vty *vty, const struct lyd_node *dnode,
+			       bool show_defaults __attribute__((__unused__)), bool mhop,
+			       uint32_t bfd_mode)
+{
+	const char *vrf = yang_dnode_get_string(dnode, "vrf");
+	struct sidlist_show_iter iter = { 0 };
+
+	vty_out(vty, " peer %s", yang_dnode_get_string(dnode, "./dest-addr"));
+	if (bfd_mode == BFD_MODE_TYPE_BFD) {
+		if (mhop)
+			vty_out(vty, " multihop");
+
+		if (yang_dnode_exists(dnode, "./source-addr"))
+			vty_out(vty, " local-address %s",
+				yang_dnode_get_string(dnode, "./source-addr"));
+
+		if (strcmp(vrf, VRF_DEFAULT_NAME))
+			vty_out(vty, " vrf %s", vrf);
+
+		if (!mhop) {
+			const char *ifname = yang_dnode_get_string(dnode, "./interface");
+
+			if (strcmp(ifname, "*"))
+				vty_out(vty, " interface %s", ifname);
+		}
+		vty_out(vty, "\n");
+	} else if (bfd_mode == BFD_MODE_TYPE_SBFD_ECHO || bfd_mode == BFD_MODE_TYPE_SBFD_INIT) {
+		vty_out(vty, " bfd-mode %s", _bfd_cli_bfd_mode_type_to_string(bfd_mode));
+
+		if (yang_dnode_exists(dnode, "bfd-name"))
+			vty_out(vty, " bfd-name %s", yang_dnode_get_string(dnode, "bfd-name"));
+
+		if (mhop)
+			vty_out(vty, " multihop");
+
+		if (yang_dnode_exists(dnode, "source-addr"))
+			vty_out(vty, " local-address %s",
+				yang_dnode_get_string(dnode, "source-addr"));
+
+		if (strcmp(vrf, VRF_DEFAULT_NAME))
+			vty_out(vty, " vrf %s", vrf);
+
+		if (bfd_mode == BFD_MODE_TYPE_SBFD_INIT) {
+			if (yang_dnode_exists(dnode, "remote-discr"))
+				vty_out(vty, " remote-discr %u",
+					yang_dnode_get_uint32(dnode, "remote-discr"));
+		}
+
+		if (yang_dnode_exists(dnode, "srv6-source-ipv6"))
+			vty_out(vty, " srv6-source-ipv6 %s",
+				yang_dnode_get_string(dnode, "srv6-source-ipv6"));
+
+		if (yang_dnode_exists(dnode, "srv6-encap-data")) {
+			yang_dnode_iterate(sidlist_show_iter_cb, &iter, dnode, "./srv6-encap-data");
+			vty_out(vty, " srv6-encap-data %s", iter.buf);
+		}
+
+		vty_out(vty, "\n");
+	}
 }
 
 void bfd_cli_show_single_hop_peer(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults)
 {
-	_bfd_cli_show_peer(vty, dnode, show_defaults, false);
+	_bfd_cli_show_peer(vty, dnode, show_defaults, false, BFD_MODE_TYPE_BFD);
 }
 
 void bfd_cli_show_multi_hop_peer(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults)
 {
-	_bfd_cli_show_peer(vty, dnode, show_defaults, true);
+	_bfd_cli_show_peer(vty, dnode, show_defaults, true, BFD_MODE_TYPE_BFD);
+}
+
+void bfd_cli_show_sbfd_echo_peer(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	_bfd_cli_show_peer(vty, dnode, show_defaults, false, BFD_MODE_TYPE_SBFD_ECHO);
+}
+
+void bfd_cli_show_sbfd_init_peer(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	_bfd_cli_show_peer(vty, dnode, show_defaults, true, BFD_MODE_TYPE_SBFD_INIT);
 }
 
 void bfd_cli_show_peer_end(struct vty *vty, const struct lyd_node *dnode
@@ -446,8 +901,9 @@ DEFPY_YANG(
 {
 	char value[32];
 
-	if (!bfd_cli_is_profile(vty) && !bfd_cli_is_single_hop(vty)) {
-		vty_out(vty, "%% Echo mode is only available for single hop sessions.\n");
+	if (!bfd_cli_is_profile(vty) && !bfd_cli_is_single_hop(vty) && !bfd_cli_is_sbfd_echo(vty)) {
+		vty_out(vty,
+			"%% Echo mode is only available for single hop or sbfd echo sessions.\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
@@ -470,8 +926,9 @@ DEFPY_YANG(
 {
 	char value[32];
 
-	if (!bfd_cli_is_profile(vty) && !bfd_cli_is_single_hop(vty)) {
-		vty_out(vty, "%% Echo mode is only available for single hop sessions.\n");
+	if (!bfd_cli_is_profile(vty) && !bfd_cli_is_single_hop(vty) && !bfd_cli_is_sbfd_echo(vty)) {
+		vty_out(vty,
+			"%% Echo mode is only available for single hop or sbfd echo sessions.\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
@@ -501,10 +958,12 @@ DEFPY_YANG(
 {
 	char value[32];
 
-	if (!bfd_cli_is_profile(vty) && !bfd_cli_is_single_hop(vty)) {
-		vty_out(vty, "%% Echo mode is only available for single hop sessions.\n");
+	if (!bfd_cli_is_profile(vty) && !bfd_cli_is_single_hop(vty) && !bfd_cli_is_sbfd_echo(vty)) {
+		vty_out(vty,
+			"%% Echo mode is only available for single hop or sbfd echo sessions.\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
+
 
 	if (disabled)
 		snprintf(value, sizeof(value), "0");
@@ -657,6 +1116,160 @@ DEFPY_YANG(bfd_peer_profile, bfd_peer_profile_cmd,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
+DEFPY(
+	sbfd_reflector, sbfd_reflector_cmd,
+	"sbfd reflector source-address X:X::X:X$srcip discriminator WORD...",
+    "seamless BFD\n"
+    "sbfd reflector\n"
+	"binding source ip address\n"
+	IPV6_STR
+	"discriminator\n"
+	"discriminator value or range (e.g. 100 or 100 200 300 or 100-300)\n")
+{
+	int idx_discr = 5;
+	int i;
+	uint32_t j;
+	uint32_t discr = 0;
+	uint32_t discr_from = 0;
+	uint32_t discr_to = 0;
+
+	for (i = idx_discr; i < argc; i++) {
+		/* check validity*/
+		char *pstr = argv[i]->arg;
+
+		/*single discr*/
+		if (strspn(pstr, "0123456789") == strlen(pstr)) {
+			discr = atol(pstr);
+			sbfd_reflector_new(discr, &srcip);
+		}
+		/*discr segment*/
+		else if (strspn(pstr, "0123456789-") == strlen(pstr)) {
+			char *token = strtok(argv[i]->arg, "-");
+
+			if (token)
+				discr_from = atol(token);
+
+			token = strtok(NULL, "-");
+			if (token)
+				discr_to = atol(token);
+
+			if (discr_from >= discr_to) {
+				vty_out(vty, "input discriminator range %u-%u is illegal\n",
+					discr_from, discr_to);
+			}
+
+			for (j = discr_from; j <= discr_to; j++)
+				sbfd_reflector_new(j, &srcip);
+		}
+		/*illegal input*/
+		else
+			vty_out(vty, "input discriminator %s is illegal\n", (char *)argv[i]);
+	}
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(
+	no_sbfd_reflector_all, no_sbfd_reflector_all_cmd,
+	"no sbfd reflector [all]",
+	NO_STR
+    "seamless BFD\n"
+    "sbfd reflector\n"
+	"all\n")
+{
+	sbfd_reflector_flush();
+
+	if (sbfd_discr_get_count()) {
+		vty_out(vty, "delete all reflector discriminator failed.\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(
+	no_sbfd_reflector, no_sbfd_reflector_cmd,
+	"no sbfd reflector (0-4294967295)$start_discr [(0-4294967295)$end_discr]",
+	NO_STR
+    "seamless BFD\n"
+    "sbfd reflector\n"
+	"start discriminator\n"
+	"end discriminator\n")
+{
+	struct sbfd_reflector *sr;
+	int32_t i;
+
+	if (end_discr == 0) {
+		if (start_discr == 0) {
+			vty_out(vty, "input reflector discriminator is illegal.\n");
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+
+		sr = sbfd_discr_lookup(start_discr);
+		if (!sr) {
+			vty_out(vty, "input reflector discriminator does not exist.\n");
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+
+		// notify bfdsyncd
+		//bfd_fpm_sbfd_reflector_sendmsg(sr, false);
+		sbfd_reflector_free(start_discr);
+
+	} else {
+		if (end_discr <= start_discr) {
+			vty_out(vty, "input reflector discriminator is illegal.\n");
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+
+		for (i = start_discr; i <= end_discr; i++) {
+			sr = sbfd_discr_lookup(i);
+			if (sr) {
+				// notify bfdsyncd
+				//bfd_fpm_sbfd_reflector_sendmsg(sr, false);
+				sbfd_reflector_free(i);
+			}
+		}
+	}
+
+	return CMD_SUCCESS;
+}
+
+static void _sbfd_reflector_show(struct hash_bucket *hb, void *arg)
+{
+	struct sbfd_reflector *sr = hb->data;
+	struct ttable *tt;
+	char buf[INET6_ADDRSTRLEN];
+
+	tt = (struct ttable *)arg;
+
+	ttable_add_row(tt, "%u|%s|%s|%s", sr->discr,
+		       inet_ntop(AF_INET6, &sr->local, buf, sizeof(buf)), "Active", "Software");
+}
+
+DEFPY(
+	sbfd_reflector_show_info, sbfd_reflector_show_info_cmd,
+	"show sbfd reflector",
+	"show\n"
+    "seamless BFD\n"
+    "sbfd reflector\n")
+{
+	struct ttable *tt;
+	char *out;
+
+	vty_out(vty, "sbfd reflector discriminator :\n");
+	tt = ttable_new(&ttable_styles[TTSTYLE_BLANK]);
+	ttable_add_row(tt, "SBFD-Discr|SourceIP|State|CreateType");
+	ttable_rowseps(tt, 0, BOTTOM, true, '-');
+
+	sbfd_discr_iterate(_sbfd_reflector_show, tt);
+
+	out = ttable_dump(tt, "\n");
+	vty_out(vty, "%s", out);
+	XFREE(MTYPE_TMP, out);
+	ttable_del(tt);
+
+	return CMD_SUCCESS;
+}
 void bfd_cli_peer_profile_show(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults)
 {
@@ -694,6 +1307,18 @@ bfdd_cli_init(void)
 	install_element(BFD_NODE, &bfd_peer_enter_cmd);
 	install_element(BFD_NODE, &bfd_no_peer_cmd);
 
+	install_element(BFD_NODE, &sbfd_echo_peer_enter_cmd);
+	install_element(BFD_NODE, &sbfd_echo_no_peer_cmd);
+
+	install_element(BFD_NODE, &sbfd_init_peer_enter_cmd);
+	install_element(BFD_NODE, &sbfd_init_no_peer_cmd);
+	install_element(BFD_NODE, &sbfd_init_peer_raw_enter_cmd);
+	install_element(BFD_NODE, &sbfd_init_no_peer_raw_cmd);
+
+	install_element(BFD_NODE, &sbfd_reflector_cmd);
+	install_element(BFD_NODE, &no_sbfd_reflector_all_cmd);
+	install_element(BFD_NODE, &no_sbfd_reflector_cmd);
+	install_element(VIEW_NODE, &sbfd_reflector_show_info_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_shutdown_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_mult_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_rx_cmd);

--- a/bfdd/bfdd_nb.c
+++ b/bfdd/bfdd_nb.c
@@ -484,6 +484,459 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			}
 		},
 		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo",
+			.cbs = {
+				.create = bfdd_bfd_sessions_sbfd_echo_create,
+				.destroy = bfdd_bfd_sessions_sbfd_echo_destroy,
+				.get_next = bfdd_bfd_sessions_sbfd_echo_get_next,
+				.get_keys = bfdd_bfd_sessions_sbfd_echo_get_keys,
+				.lookup_entry = bfdd_bfd_sessions_sbfd_echo_lookup_entry,
+				.cli_show = bfd_cli_show_sbfd_echo_peer, /* TODO */
+				.cli_show_end = bfd_cli_show_peer_end, /* TODO */
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/dest-addr",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_sbfd_echo_dest_addr_modify,
+				.destroy = bfdd_bfd_sessions_sbfd_echo_dest_addr_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/srv6-source-ipv6",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_sbfd_srv6_source_ipv6_modify,
+				.destroy = bfdd_bfd_sessions_sbfd_srv6_source_ipv6_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/profile",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_profile_modify,
+				.destroy = bfdd_bfd_sessions_single_hop_profile_destroy,
+				.cli_show = bfd_cli_peer_profile_show,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/detection-multiplier",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_detection_multiplier_modify,
+				.cli_show = bfd_cli_show_mult,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/desired-transmission-interval",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify,
+				.cli_show = bfd_cli_show_tx,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/required-receive-interval",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_required_receive_interval_modify,
+				.cli_show = bfd_cli_show_rx,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/echo-mode",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_sbfd_echo_mode_modify,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/desired-echo-transmission-interval",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_desired_echo_transmission_interval_modify,
+				.cli_show = bfd_cli_show_desired_echo_transmission_interval,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/required-echo-receive-interval",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_required_echo_receive_interval_modify,
+				.cli_show = bfd_cli_show_required_echo_receive_interval,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/administrative-down",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_administrative_down_modify,
+				.cli_show = bfd_cli_show_shutdown,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/passive-mode",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_passive_mode_modify,
+				.cli_show = bfd_cli_show_passive,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/bfd-mode",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_bfd_mode_modify,
+				.destroy = bfdd_bfd_sessions_bfd_mode_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/srv6-encap-data",
+			.cbs = {
+				.create = bfdd_bfd_sessions_segment_list_create,
+				.destroy = bfdd_bfd_sessions_segment_list_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/minimum-ttl",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_multi_hop_minimum_ttl_modify,
+				.cli_show = bfd_cli_show_minimum_ttl,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/multi-hop",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_sbfd_multi_hop_modify,
+				.destroy = bfdd_bfd_sessions_sbfd_multi_hop_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/local-discriminator",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_discriminator_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/local-state",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_state_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/local-diagnostic",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_diagnostic_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/local-multiplier",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_multiplier_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/remote-discriminator",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_discriminator_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/remote-state",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_state_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/remote-diagnostic",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_diagnostic_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/remote-multiplier",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_multiplier_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/negotiated-transmission-interval",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_transmission_interval_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/negotiated-receive-interval",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_receive_interval_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/detection-mode",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/last-down-time",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_last_down_time_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/last-up-time",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_last_up_time_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/session-down-count",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_session_down_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/session-up-count",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_session_up_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/control-packet-input-count",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/control-packet-output-count",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/negotiated-echo-transmission-interval",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_echo_transmission_interval_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/echo-packet-input-count",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_input_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/stats/echo-packet-output-count",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_output_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init",
+			.cbs = {
+				.create = bfdd_bfd_sessions_sbfd_init_create,
+				.destroy = bfdd_bfd_sessions_sbfd_init_destroy,
+				.get_next = bfdd_bfd_sessions_sbfd_init_get_next,
+				.get_keys = bfdd_bfd_sessions_sbfd_init_get_keys,
+				.lookup_entry = bfdd_bfd_sessions_sbfd_init_lookup_entry,
+				.cli_show = bfd_cli_show_sbfd_init_peer, /* TODO */
+				.cli_show_end = bfd_cli_show_peer_end, /* TODO */
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/srv6-source-ipv6",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_sbfd_srv6_source_ipv6_modify,
+				.destroy = bfdd_bfd_sessions_sbfd_srv6_source_ipv6_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/remote-discr",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_sbfd_init_remote_discr_modify,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/profile",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_profile_modify,
+				.destroy = bfdd_bfd_sessions_single_hop_profile_destroy,
+				.cli_show = bfd_cli_peer_profile_show,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/detection-multiplier",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_detection_multiplier_modify,
+				.cli_show = bfd_cli_show_mult,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/desired-transmission-interval",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify,
+				.cli_show = bfd_cli_show_tx,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/required-receive-interval",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_required_receive_interval_modify,
+				.cli_show = bfd_cli_show_rx,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/administrative-down",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_administrative_down_modify,
+				.cli_show = bfd_cli_show_shutdown,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/passive-mode",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_passive_mode_modify,
+				.cli_show = bfd_cli_show_passive,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/bfd-mode",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_bfd_mode_modify,
+				.destroy = bfdd_bfd_sessions_bfd_mode_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/srv6-encap-data",
+			.cbs = {
+				.create = bfdd_bfd_sessions_segment_list_create,
+				.destroy = bfdd_bfd_sessions_segment_list_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/minimum-ttl",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_multi_hop_minimum_ttl_modify,
+				.cli_show = bfd_cli_show_minimum_ttl,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/multi-hop",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_sbfd_multi_hop_modify,
+				.destroy = bfdd_bfd_sessions_sbfd_multi_hop_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/local-discriminator",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_discriminator_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/local-state",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_state_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/local-diagnostic",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_diagnostic_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/local-multiplier",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_multiplier_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/remote-discriminator",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_discriminator_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/remote-state",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_state_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/remote-diagnostic",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_diagnostic_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/remote-multiplier",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_multiplier_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/negotiated-transmission-interval",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_transmission_interval_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/negotiated-receive-interval",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_receive_interval_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/detection-mode",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/last-down-time",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_last_down_time_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/last-up-time",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_last_up_time_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/session-down-count",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_session_down_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/session-up-count",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_session_up_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/control-packet-input-count",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/control-packet-output-count",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/negotiated-echo-transmission-interval",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_echo_transmission_interval_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/echo-packet-input-count",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_input_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/stats/echo-packet-output-count",
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_output_count_get_elem,
+			}
+		},
+		{
 			.xpath = NULL,
 		},
 	}

--- a/bfdd/bfdd_nb.h
+++ b/bfdd/bfdd_nb.h
@@ -112,6 +112,26 @@ bfdd_bfd_sessions_single_hop_stats_echo_packet_output_count_get_elem(
 	struct nb_cb_get_elem_args *args);
 int bfdd_bfd_sessions_multi_hop_create(struct nb_cb_create_args *args);
 int bfdd_bfd_sessions_multi_hop_destroy(struct nb_cb_destroy_args *args);
+int bfdd_bfd_sessions_sbfd_echo_create(struct nb_cb_create_args *args);
+int bfdd_bfd_sessions_sbfd_echo_destroy(struct nb_cb_destroy_args *args);
+int bfdd_bfd_sessions_sbfd_echo_dest_addr_modify(struct nb_cb_modify_args *args);
+int bfdd_bfd_sessions_sbfd_echo_mode_modify(struct nb_cb_modify_args *args);
+int bfdd_bfd_sessions_sbfd_echo_dest_addr_destroy(struct nb_cb_destroy_args *args);
+int bfdd_bfd_sessions_sbfd_srv6_source_ipv6_modify(struct nb_cb_modify_args *args);
+int bfdd_bfd_sessions_sbfd_srv6_source_ipv6_destroy(struct nb_cb_destroy_args *args);
+int bfdd_bfd_sessions_sbfd_init_remote_discr_modify(struct nb_cb_modify_args *args);
+int bfdd_bfd_sessions_sbfd_multi_hop_modify(struct nb_cb_modify_args *args);
+int bfdd_bfd_sessions_sbfd_multi_hop_destroy(struct nb_cb_destroy_args *args);
+
+int bfdd_bfd_sessions_sbfd_init_create(struct nb_cb_create_args *args);
+int bfdd_bfd_sessions_sbfd_init_destroy(struct nb_cb_destroy_args *args);
+const void *bfdd_bfd_sessions_sbfd_echo_get_next(struct nb_cb_get_next_args *args);
+int bfdd_bfd_sessions_sbfd_echo_get_keys(struct nb_cb_get_keys_args *args);
+const void *bfdd_bfd_sessions_sbfd_echo_lookup_entry(struct nb_cb_lookup_entry_args *args);
+const void *bfdd_bfd_sessions_sbfd_init_get_next(struct nb_cb_get_next_args *args);
+int bfdd_bfd_sessions_sbfd_init_get_keys(struct nb_cb_get_keys_args *args);
+const void *bfdd_bfd_sessions_sbfd_init_lookup_entry(struct nb_cb_lookup_entry_args *args);
+
 const void *
 bfdd_bfd_sessions_multi_hop_get_next(struct nb_cb_get_next_args *args);
 int bfdd_bfd_sessions_multi_hop_get_keys(struct nb_cb_get_keys_args *args);
@@ -185,6 +205,8 @@ void bfd_cli_show_single_hop_peer(struct vty *vty, const struct lyd_node *dnode,
 				  bool show_defaults);
 void bfd_cli_show_multi_hop_peer(struct vty *vty, const struct lyd_node *dnode,
 				 bool show_defaults);
+void bfd_cli_show_sbfd_echo_peer(struct vty *vty, const struct lyd_node *dnode, bool show_defaults);
+void bfd_cli_show_sbfd_init_peer(struct vty *vty, const struct lyd_node *dnode, bool show_defaults);
 void bfd_cli_show_peer_end(struct vty *vty, const struct lyd_node *dnode);
 void bfd_cli_show_mult(struct vty *vty, const struct lyd_node *dnode,
 		       bool show_defaults);
@@ -209,5 +231,11 @@ void bfd_cli_show_passive(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults);
 void bfd_cli_show_minimum_ttl(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults);
+
+int bfdd_bfd_sessions_bfd_mode_modify(struct nb_cb_modify_args *args);
+int bfdd_bfd_sessions_bfd_mode_destroy(struct nb_cb_destroy_args *args);
+
+int bfdd_bfd_sessions_segment_list_create(struct nb_cb_create_args *args);
+int bfdd_bfd_sessions_segment_list_destroy(struct nb_cb_destroy_args *args);
 
 #endif /* _FRR_BFDD_NB_H_ */

--- a/bfdd/bfdd_nb_config.c
+++ b/bfdd/bfdd_nb_config.c
@@ -904,6 +904,45 @@ int bfdd_bfd_sessions_single_hop_passive_mode_modify(
 }
 
 /*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/sbfd-init/bfd-mode
+ *        /frr-bfdd:bfdd/bfd/sessions/sbfd-echo/bfd-mode
+ */
+int bfdd_bfd_sessions_bfd_mode_modify(struct nb_cb_modify_args *args)
+{
+	uint32_t bfd_mode = yang_dnode_get_uint32(args->dnode, NULL);
+	struct bfd_session *bs;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+		if ((bfd_mode != BFD_MODE_TYPE_BFD) && (bfd_mode != BFD_MODE_TYPE_SBFD_ECHO) &&
+		    (bfd_mode != BFD_MODE_TYPE_SBFD_INIT)) {
+			snprintf(args->errmsg, args->errmsg_len, "bfd mode is invalid.");
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	case NB_EV_PREPARE:
+		return NB_OK;
+
+	case NB_EV_APPLY:
+		break;
+
+	case NB_EV_ABORT:
+		return NB_OK;
+	}
+
+	bs = nb_running_get_entry(args->dnode, NULL, true);
+	bs->bfd_mode = bfd_mode;
+	bfd_session_apply(bs);
+
+	return NB_OK;
+}
+
+int bfdd_bfd_sessions_bfd_mode_destroy(struct nb_cb_destroy_args *args)
+{
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/echo-mode
  */
 int bfdd_bfd_sessions_single_hop_echo_mode_modify(
@@ -1032,5 +1071,108 @@ int bfdd_bfd_sessions_multi_hop_minimum_ttl_modify(
 	bs->peer_profile.minimum_ttl = yang_dnode_get_uint8(args->dnode, NULL);
 	bfd_session_apply(bs);
 
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/sbfd-echo
+ */
+int bfdd_bfd_sessions_sbfd_echo_create(struct nb_cb_create_args *args)
+{
+	return bfd_session_create(args, yang_dnode_exists(args->dnode, "multi-hop"),
+				  BFD_MODE_TYPE_SBFD_ECHO);
+}
+
+int bfdd_bfd_sessions_sbfd_echo_destroy(struct nb_cb_destroy_args *args)
+{
+	return bfd_session_destroy(args->event, args->dnode,
+				   yang_dnode_exists(args->dnode, "multi-hop"),
+				   BFD_MODE_TYPE_SBFD_ECHO);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/sbfd-echo/srv6-encap-data
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/sbfd-init/srv6-encap-data
+ */
+int bfdd_bfd_sessions_segment_list_create(struct nb_cb_create_args *args)
+{
+	return NB_OK;
+}
+
+int bfdd_bfd_sessions_segment_list_destroy(struct nb_cb_destroy_args *args)
+{
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/sbfd-echo/dest-addr
+ */
+int bfdd_bfd_sessions_sbfd_echo_dest_addr_modify(struct nb_cb_modify_args *args)
+{
+	return NB_OK;
+}
+
+int bfdd_bfd_sessions_sbfd_echo_dest_addr_destroy(struct nb_cb_destroy_args *args)
+{
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/sbfd-echo/echo-mode
+ */
+int bfdd_bfd_sessions_sbfd_echo_mode_modify(struct nb_cb_modify_args *args)
+{
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/sbfd-echo/srv6-source-ipv6
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/sbfd-init/srv6-source-ipv6
+ */
+int bfdd_bfd_sessions_sbfd_srv6_source_ipv6_modify(struct nb_cb_modify_args *args)
+{
+	return NB_OK;
+}
+
+int bfdd_bfd_sessions_sbfd_srv6_source_ipv6_destroy(struct nb_cb_destroy_args *args)
+{
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/sbfd-init
+ */
+int bfdd_bfd_sessions_sbfd_init_create(struct nb_cb_create_args *args)
+{
+	return bfd_session_create(args, yang_dnode_exists(args->dnode, "multi-hop"),
+				  BFD_MODE_TYPE_SBFD_INIT);
+}
+
+int bfdd_bfd_sessions_sbfd_init_destroy(struct nb_cb_destroy_args *args)
+{
+	return bfd_session_destroy(args->event, args->dnode,
+				   yang_dnode_exists(args->dnode, "multi-hop"),
+				   BFD_MODE_TYPE_SBFD_INIT);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/sbfd-init/remote-discr
+ */
+int bfdd_bfd_sessions_sbfd_init_remote_discr_modify(struct nb_cb_modify_args *args)
+{
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/sbfd-echo/multi-hop
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/sbfd-init/multi-hop
+ */
+int bfdd_bfd_sessions_sbfd_multi_hop_modify(struct nb_cb_modify_args *args)
+{
+	return NB_OK;
+}
+
+int bfdd_bfd_sessions_sbfd_multi_hop_destroy(struct nb_cb_destroy_args *args)
+{
 	return NB_OK;
 }

--- a/bfdd/bfdd_nb_state.c
+++ b/bfdd/bfdd_nb_state.c
@@ -20,7 +20,7 @@
 const void *
 bfdd_bfd_sessions_single_hop_get_next(struct nb_cb_get_next_args *args)
 {
-	return bfd_session_next(args->list_entry, false);
+	return bfd_session_next(args->list_entry, false, BFD_MODE_TYPE_BFD);
 }
 
 int bfdd_bfd_sessions_single_hop_get_keys(struct nb_cb_get_keys_args *args)
@@ -50,7 +50,7 @@ bfdd_bfd_sessions_single_hop_lookup_entry(struct nb_cb_lookup_entry_args *args)
 
 	strtosa(dest_addr, &psa);
 	memset(&lsa, 0, sizeof(lsa));
-	gen_bfd_key(&bk, &psa, &lsa, false, ifname, vrf);
+	gen_bfd_key(&bk, &psa, &lsa, false, ifname, vrf, NULL);
 
 	return bfd_key_lookup(bk);
 }
@@ -323,7 +323,7 @@ bfdd_bfd_sessions_single_hop_stats_echo_packet_output_count_get_elem(
 const void *
 bfdd_bfd_sessions_multi_hop_get_next(struct nb_cb_get_next_args *args)
 {
-	return bfd_session_next(args->list_entry, true);
+	return bfd_session_next(args->list_entry, true, BFD_MODE_TYPE_BFD);
 }
 
 int bfdd_bfd_sessions_multi_hop_get_keys(struct nb_cb_get_keys_args *args)
@@ -354,7 +354,7 @@ bfdd_bfd_sessions_multi_hop_lookup_entry(struct nb_cb_lookup_entry_args *args)
 
 	strtosa(dest_addr, &psa);
 	strtosa(source_addr, &lsa);
-	gen_bfd_key(&bk, &psa, &lsa, true, NULL, vrf);
+	gen_bfd_key(&bk, &psa, &lsa, true, NULL, vrf, NULL);
 
 	return bfd_key_lookup(bk);
 }

--- a/bfdd/bfdd_nb_state.c
+++ b/bfdd/bfdd_nb_state.c
@@ -358,3 +358,83 @@ bfdd_bfd_sessions_multi_hop_lookup_entry(struct nb_cb_lookup_entry_args *args)
 
 	return bfd_key_lookup(bk);
 }
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/sbfd-echo
+ */
+const void *bfdd_bfd_sessions_sbfd_echo_get_next(struct nb_cb_get_next_args *args)
+{
+	return bfd_session_next(args->list_entry, true, BFD_MODE_TYPE_SBFD_ECHO);
+}
+
+int bfdd_bfd_sessions_sbfd_echo_get_keys(struct nb_cb_get_keys_args *args)
+{
+	const struct bfd_session *bs = args->list_entry;
+	char srcbuf[INET6_ADDRSTRLEN];
+
+	inet_ntop(bs->key.family, &bs->key.local, srcbuf, sizeof(srcbuf));
+
+	args->keys->num = 3;
+	strlcpy(args->keys->key[0], srcbuf, sizeof(args->keys->key[0]));
+	strlcpy(args->keys->key[1], bs->key.bfdname, sizeof(args->keys->key[1]));
+	strlcpy(args->keys->key[2], bs->key.vrfname, sizeof(args->keys->key[2]));
+
+	return NB_OK;
+}
+
+const void *bfdd_bfd_sessions_sbfd_echo_lookup_entry(struct nb_cb_lookup_entry_args *args)
+{
+	const char *source_addr = args->keys->key[0];
+	const char *bfdname = args->keys->key[1];
+	const char *vrf = args->keys->key[2];
+	struct sockaddr_any psa, lsa;
+	struct bfd_key bk;
+
+	strtosa(source_addr, &lsa);
+	memset(&psa, 0, sizeof(psa));
+	gen_bfd_key(&bk, &psa, &lsa, true, NULL, vrf, bfdname);
+
+	return bfd_key_lookup(bk);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/sbfd-init
+ */
+const void *bfdd_bfd_sessions_sbfd_init_get_next(struct nb_cb_get_next_args *args)
+{
+	return bfd_session_next(args->list_entry, true, BFD_MODE_TYPE_SBFD_INIT);
+}
+
+int bfdd_bfd_sessions_sbfd_init_get_keys(struct nb_cb_get_keys_args *args)
+{
+	const struct bfd_session *bs = args->list_entry;
+	char srcbuf[INET6_ADDRSTRLEN];
+	char dstbuf[INET6_ADDRSTRLEN];
+
+	inet_ntop(bs->key.family, &bs->key.local, srcbuf, sizeof(srcbuf));
+	inet_ntop(bs->key.family, &bs->key.peer, dstbuf, sizeof(dstbuf));
+
+	args->keys->num = 4;
+	strlcpy(args->keys->key[0], srcbuf, sizeof(args->keys->key[0]));
+	strlcpy(args->keys->key[1], dstbuf, sizeof(args->keys->key[1]));
+	strlcpy(args->keys->key[2], bs->key.bfdname, sizeof(args->keys->key[2]));
+	strlcpy(args->keys->key[3], bs->key.vrfname, sizeof(args->keys->key[3]));
+
+	return NB_OK;
+}
+
+const void *bfdd_bfd_sessions_sbfd_init_lookup_entry(struct nb_cb_lookup_entry_args *args)
+{
+	const char *source_addr = args->keys->key[0];
+	const char *dest_addr = args->keys->key[1];
+	const char *bfdname = args->keys->key[2];
+	const char *vrf = args->keys->key[3];
+	struct sockaddr_any psa, lsa;
+	struct bfd_key bk;
+
+	strtosa(source_addr, &lsa);
+	strtosa(dest_addr, &psa);
+	gen_bfd_key(&bk, &psa, &lsa, true, NULL, vrf, bfdname);
+
+	return bfd_key_lookup(bk);
+}

--- a/bfdd/event.c
+++ b/bfdd/event.c
@@ -58,6 +58,73 @@ void bfd_echo_recvtimer_update(struct bfd_session *bs)
 			   &bs->echo_recvtimer_ev);
 }
 
+void sbfd_init_recvtimer_update(struct bfd_session *bs)
+{
+	struct timeval tv = { .tv_sec = 0, .tv_usec = bs->detect_TO };
+
+	/* Remove previous schedule if any. */
+	sbfd_init_recvtimer_delete(bs);
+
+	/* Don't add event if peer is deactivated. */
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) || bs->sock == -1)
+		return;
+
+	tv_normalize(&tv);
+#ifdef BFD_EVENT_DEBUG
+	log_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec, tv.tv_usec);
+#endif /* BFD_EVENT_DEBUG */
+
+	event_add_timer_tv(master, sbfd_init_recvtimer_cb, bs, &tv, &bs->recvtimer_ev);
+}
+
+void sbfd_echo_recvtimer_update(struct bfd_session *bs)
+{
+	struct timeval tv = { .tv_sec = 0, .tv_usec = bs->echo_detect_TO };
+
+	/* Remove previous schedule if any. */
+	sbfd_echo_recvtimer_delete(bs);
+
+	/* Don't add event if peer is deactivated. */
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) || bs->sock == -1)
+		return;
+
+	tv_normalize(&tv);
+
+	event_add_timer_tv(master, sbfd_echo_recvtimer_cb, bs, &tv, &bs->echo_recvtimer_ev);
+}
+
+void sbfd_init_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
+{
+	struct timeval tv = { .tv_sec = 0, .tv_usec = jitter };
+
+	/* Remove previous schedule if any. */
+	sbfd_init_xmttimer_delete(bs);
+
+	/* Don't add event if peer is deactivated. */
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) || bs->sock == -1)
+		return;
+
+	tv_normalize(&tv);
+
+	event_add_timer_tv(master, sbfd_init_xmt_cb, bs, &tv, &bs->xmttimer_ev);
+}
+
+void sbfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
+{
+	struct timeval tv = { .tv_sec = 0, .tv_usec = jitter };
+
+	/* Remove previous schedule if any. */
+	sbfd_echo_xmttimer_delete(bs);
+
+	/* Don't add event if peer is deactivated. */
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) || bs->sock == -1)
+		return;
+
+	tv_normalize(&tv);
+
+	event_add_timer_tv(master, sbfd_echo_xmt_cb, bs, &tv, &bs->echo_xmttimer_ev);
+}
+
 void bfd_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 {
 	struct timeval tv = {.tv_sec = 0, .tv_usec = jitter};
@@ -109,6 +176,26 @@ void bfd_xmttimer_delete(struct bfd_session *bs)
 }
 
 void bfd_echo_xmttimer_delete(struct bfd_session *bs)
+{
+	EVENT_OFF(bs->echo_xmttimer_ev);
+}
+
+void sbfd_init_recvtimer_delete(struct bfd_session *bs)
+{
+	EVENT_OFF(bs->recvtimer_ev);
+}
+
+void sbfd_echo_recvtimer_delete(struct bfd_session *bs)
+{
+	EVENT_OFF(bs->echo_recvtimer_ev);
+}
+
+void sbfd_init_xmttimer_delete(struct bfd_session *bs)
+{
+	EVENT_OFF(bs->xmttimer_ev);
+}
+
+void sbfd_echo_xmttimer_delete(struct bfd_session *bs)
 {
 	EVENT_OFF(bs->echo_xmttimer_ev);
 }

--- a/doc/developer/sbfd.rst
+++ b/doc/developer/sbfd.rst
@@ -1,0 +1,140 @@
+.. _sbfd:
+
+****
+SBFD
+****
+
+:abbr:`SBFD (Seamless Bidirectional Forwarding Detection)` is:
+
+   Seamless Bidirectional Forwarding Detection, a simplified mechanism for using BFD with a large
+   proportion of negotiation aspects eliminated, thus providing benefits
+   such as quick provisioning, as well as improved control and
+   flexibility for network nodes initiating path monitoring.
+
+  -- :rfc:`7880`
+
+It is described and extended by the following RFCs:
+
+* :rfc:`7880`
+* :rfc:`7881`
+
+.. _sbfd-sate-machine:
+
+SBFD state machine
+==================
+
+SBFD takes the same data packet format as BFD, but with a much simpler state machine.
+According to RFC7880, SBFD has a stateless SBFDReflector and a stateful SBFDInitiator with the state machine as below:
+
+::
+   
+                       +--+
+          ADMIN DOWN,  |  |
+          TIMER        |  V
+                     +------+   UP                +------+
+                     |      |-------------------->|      |----+
+                     | DOWN |                     |  UP  |    | UP
+                     |      |<--------------------|      |<---+
+                     +------+   ADMIN DOWN,       +------+
+                                TIMER
+
+               Figure 1: SBFDInitiator Finite State Machine
+
+.. _sbfd-extention:
+
+SBFD extension - SRv6 encapsulation
+===================================
+
+SBFDInitiator periodically send packets to monitor the connection to SBFDReflector. We set up an SBFD connection between the source and the destination node of a path,
+with the source node serving as Initiator and the destination node as Reflector. The communicated SBFD packets should also follow every exact hop in the path,
+from the source to the destination, which could be achieved by segment routing. This requirement extends the node verification to the path verification.
+
+.. _sbfd-implement:
+
+implementation
+===============
+
+Some considerations when implementing sbfd.
+
+
+
+.. _sbfd-implement-coexist:
+
+SBFD Co-exist with BFD
+--------------------------
+
+Both SBFD and Classical BFD have their unique discriminator, SBFD can co-exist with BFD since they sharing a same discriminator pool in bfdd.
+Also in bfdd SBFD and BFD can share most code logic, SBFD packet and BFD packet are demultiplexed by different discriminators.
+
+
+.. _sbfd-implement-bfdname:
+
+SBFD name
+---------
+
+We introduced a bfd-name for every sbfd session. A unique bfd-name can be used to identify a sbfd session quickly. This is quite useful in our Srv6 deployment for path protection case.
+A bfd-name is always associated with a TE path, for example if we use the sbfd session to protect the path A-B-D, we would assign the name 'path-a-b-d' or 'a-b-d' to the session.
+
+Meanwhile bfdd will notify the sbfd status to the Pathd, we should add the bfd-name field in PTM bfd notify message ZEBRA_BFD_DEST_REPLAY:
+
+::
+	 * Message format:
+	 * - header: command, vrf
+	 * - l: interface index
+	 * - c: family
+	 *   - AF_INET:
+	 *     - 4 bytes: ipv4
+	 *   - AF_INET6:
+	 *     - 16 bytes: ipv6
+	 *   - c: prefix length
+	 * - l: bfd status
+	 * - c: family
+	 *   - AF_INET:
+	 *     - 4 bytes: ipv4
+	 *   - AF_INET6:
+	 *     - 16 bytes: ipv6
+	 *   - c: prefix length
+	 * - c: cbit
+	 * - c: bfd name len               <---- new field
+	 * - Xbytes: bfd name              <---- new field
+	 *
+	 * Commands: ZEBRA_BFD_DEST_REPLAY
+	 *
+	 * q(64), l(32), w(16), c(8)
+
+
+
+.. _sbfd-implement-port:
+
+SBFD UDP port
+-------------
+
+According to RFC7881, SBFD Control packet dst port should be 7784, src port can be any but NOT 7784. In our implementation, the UDP ports in packet are set as:
+
+
+::
+   UDP(sport=4784, dport=7784)/BFD() or UDP(sport=3784, dport=7784)/BFD()
+
+if "multihop" is specified for sbfd initiator we choose the 4784 as the source port, so the reflected packet will take 4784 as the dst port, this is a local BFD_MULTI_HOP_PORT so the reflected packet can be handled by the existing bfd_recv_cb function.
+if "multihop" is not specified for sbfd initiator we choose the 3784 as the source port, this is a local BFD_DEFDESTPORT so the reflected packet can be handled by the existing bfd_recv_cb function.
+
+
+For echo SBFD with SRv6 encapsulation case, we re-use the BFD Echo port, the UDP ports in packet are set as:
+
+::
+   UDP(sport=3785, dport=3785)/BFD()
+
+
+we choose the 3785 as the source port, so the echo back packet will take 3785 as the dst port, this is a local BFD_DEF_ECHO_PORT so the packet can be handled by the existing bfd_recv_cb function.
+
+
+.. _sbfd-not-implemented:
+
+Todo list for SBFD
+------------------
+
+   Currently some features are not yet implemented for SBFD, will add it in future:
+   1) SBFD in IPv4 only packet
+   2) The ADMIN DOWN logic
+   3) SBFD echo function in a initiator session
+   4) SBFD over MPLS

--- a/doc/developer/subdir.am
+++ b/doc/developer/subdir.am
@@ -82,6 +82,7 @@ dev_RSTFILES = \
 	doc/developer/northbound/transactional-cli.rst \
 	doc/developer/northbound/yang-module-translator.rst \
 	doc/developer/northbound/yang-tools.rst \
+	doc/developer/sbfd.rst \
 	# end
 
 EXTRA_DIST += \

--- a/doc/user/sbfd.rst
+++ b/doc/user/sbfd.rst
@@ -1,0 +1,304 @@
+.. _sbfd:
+
+****
+SBFD
+****
+
+:abbr:`SBFD (Seamless Bidirectional Forwarding Detection)` is:
+
+   Seamless Bidirectional Forwarding Detection, a simplified mechanism for using BFD with a large
+   proportion of negotiation aspects eliminated, thus providing benefits
+   such as quick provisioning, as well as improved control and
+   flexibility for network nodes initiating path monitoring.
+
+  -- :rfc:`7880`
+
+It is described and extended by the following RFCs:
+
+* :rfc:`7880`
+* :rfc:`7881`
+
+.. _sbfd-sate-machine:
+
+SBFD state machine
+==================
+
+SBFD takes the same data packet format as BFD, but with a much simpler state machine.
+According to RFC7880, SBFD has a stateless SBFDReflector and a stateful SBFDInitiator with the state machine as below:
+
+::
+   
+                       +--+
+          ADMIN DOWN,  |  |
+          TIMER        |  V
+                     +------+   UP                +------+
+                     |      |-------------------->|      |----+
+                     | DOWN |                     |  UP  |    | UP
+                     |      |<--------------------|      |<---+
+                     +------+   ADMIN DOWN,       +------+
+                                TIMER
+
+               Figure 1: SBFDInitiator Finite State Machine
+
+* If SBFDInitiator doesn't receive the response packet in time, session is DOWN.
+* If SBFDInitiator receives the response packet in time: reponse state is ADMINDOWN, session goes DOWN; reponse state is UP, session goes UP.
+
+.. note::
+
+   SBFDReflector is stateless, it just transmit a packet in response to a received S-BFD packet having a valid S-BFD Discriminator in the Your Discriminator field.
+
+
+.. _sbfd-extention:
+
+SBFD extension - SRv6 encapsulation
+===================================
+
+SBFDInitiator periodically send packets to monitor the connection to SBFDReflector. We set up an SBFD connection between the source and the destination node of a path,
+with the source node serving as Initiator and the destination node as Reflector. The communicated SBFD packets should also follow every exact hop in the path,
+from the source to the destination, which could be achieved by segment routing. This requirement extends the node verification to the path verification.
+In the following example, we set up a sbfd session to monitor the path A-B-D (all nodes in the topo are SRv6 ready, which can decap and forward SRv6 packets).
+
+::
+
+                        +------------C-----------+
+                       /                           \
+                     A---------------B---------------D
+                     ^               ^               ^
+                     |               |               |
+               End: 100::A       End: 100::B        End: 100::D
+          Loopback: 200::A                     Loopback: 200::D
+       BFD Discrim: 123                     BFD Discrim: 456
+   
+
+A is the SBFDInitiator, and D is the SBFDReflector, A will trasmit the SBFD packet to B as the format:
+
+::
+   IPv6(src="200::A", dst="100::B", nh=43)/IPv6ExtHdrSegmentRouting(addresses=["100::D"], nh=41, segleft=1)/IPv6(src="200::A", dst="200::D")/UDP(dport=7784)/BFD(my_dis=123, your_disc=456, state=UP)
+
+
+Upon receiving the packet, B will take the Srv6 End action since the dst ip 100::B is the End address, B will the shift the dst address according to Srv6 spec, then trasmit the SBFD packet to D as the format:
+
+::
+   IPv6(src="200::A", dst="100::D", nh=41)/IPv6(src="200::A", dst="200::D")/UDP(dport=7784)/BFD(my_dis=123, your_disc=456, state=UP)
+
+
+After D receive the packet, It will decap the outer IPv6 header since the dst ip 100::D is the End address, the decapped packet is:
+
+::
+   IPv6(src="200::A", dst="200::D")/UDP(dport=7784)/BFD(my_dis=123, your_disc=456, state=UP)
+
+
+This packet will be routed to kernel stack of D since its dst is 200::D. Then the SBFDReflector service on D will get the packet and Reflect it. The response packet will be:
+
+::
+   IPv6(src="200::D", dst="200::A")/UDP(sport=7784)/BFD(my_dis=456, your_disc=123, state=UP)
+
+
+This packet will be routed in the topo according to the dst ip 200::A, it will go back to A by D-B-A or D-C-A in this case.
+
+
+
+   In this example, Command used to configure the SBFDInitiator on A is:
+
+.. clicmd:: peer 200::D bfd-mode sbfd-init bfd-name a-b-d multihop local-address 200::A remote-discr 456 srv6-source-ipv6 200::A srv6-encap-data 100::B 100::D
+
+
+   Command used to configure the SBFDReflector on D is:
+
+.. clicmd:: sbfd reflector source-address 200::D discriminator 456
+
+
+.. _sbfd-echo:
+
+Echo SBFD with SRv6 encapsulation
+=================================
+
+The SBFD Initiator-Reflector mode requires the configuration on both source and destination nodes. It can not work if the remote node has no SBD feature supported, especial on some third-party devices.
+The Echo SBFD can solve this kind of deployment issue since it only requires the configuration on source node. This is also known as One-Arm BFD Echo or unaffiliated BFD Echo.
+For example, we use Echo SBFD session to protect Srv6 path: A-B-D
+
+::
+
+                        +------------C-----------+
+                       /                           \
+                     A---------------B---------------D
+                     ^               ^               ^
+                     |               |               |
+               End: 100::A       End: 100::B        End: 100::D
+          Loopback: 200::A                     Loopback: 200::D
+       BFD Discrim: 123
+
+
+A is also the SBFDInitiator, and B, C, D is Srv6 ready nodes, A will trasmit the SBFD packet to B as the format:
+
+::
+   IPv6(src="200::A", dst="100::B", nh=43)/IPv6ExtHdrSegmentRouting(addresses=["100::D"], nh=41, segleft=1)/IPv6(src="200::A", dst="200::A")/UDP(dport=3785)/BFD(my_dis=123, your_disc=123, state=UP)
+
+
+Upon receiving the packet, B will take the Srv6 End action since the dst ip 100::B is the End address, B will the shift the dst address according to Srv6 spec, then trasmit the SBFD packet to D as the format:
+
+::
+   IPv6(src="200::A", dst="100::D", nh=41)/IPv6(src="200::A", dst="200::A")/UDP(dport=3785)/BFD(my_dis=123, your_disc=123, state=UP)
+
+
+After D receive the packet, It will decap the outer IPv6 header since the dst ip 100::D is the End address, the decapped packet is:
+
+::
+   IPv6(src="200::A", dst="200::A")/UDP(dport=3785)/BFD(my_dis=123, your_disc=123, state=UP)
+
+
+This packet will be routed in the topo according to the dst ip 200::A, it will go back to A by D-B-A or D-C-A in this case.
+
+
+
+   In this example, Command used to configure the SBFDInitiator on A is:
+
+.. clicmd:: peer 200::A bfd-mode sbfd-echo bfd-name a-b-d local-address 200::A srv6-source-ipv6 200::A srv6-encap-data 100::B 100::D
+
+
+   no configuration needed on D.
+
+
+.. _sbfd-normal:
+
+normal SBFD with no SRv6 encapsulation
+======================================
+
+We can also configure a SBFD Initiator-Reflector session based on simple IPv6/IPv4 packet, no Srv6 involved in this case.  
+
+::
+
+                        +------------C-----------+
+                       /                           \
+                     A---------------B---------------D
+                     ^               ^               ^
+                     |               |               |
+          Loopback: 200::A                     Loopback: 200::D
+       BFD Discrim: 123                     BFD Discrim: 456
+
+
+
+A is the SBFDInitiator, and D is the SBFDReflector, A will trasmit the SBFD packet to B or C as the format: 
+
+::
+   IPv6(src="200::A", dst="200::D")/UDP(dport=7784)/BFD(my_dis=123, your_disc=456, state=UP)
+
+
+Upon receiving the packet, B/C will route the packet to D according to the dst ip 200::D.
+
+After D receive the packet, packet will be sent to kernel stack of D since its dst is 200::D. Then the SBFDReflector service on D will get the packet and reflect it. The response packet will be:
+
+::
+   IPv6(src="200::D", dst="200::A")/UDP(sport=7784)/BFD(my_dis=456, your_disc=123, state=UP)
+
+
+This packet will be routed in the topo according to the dst ip 200::A, it will go back to A by D-B-A or D-C-A in this case.
+
+
+   In this example, Command used to configure the SBFDInitiator on A is:
+
+.. clicmd:: peer 200::D bfd-mode sbfd-init bfd-name a-d local-address 200::A remote-discr 456
+
+
+   Command used to configure the SBFDReflector on D is:
+
+.. clicmd:: sbfd reflector source-address 200::D discriminator 456
+
+
+.. note::
+
+   Currently some features are not yet implemented:
+   1) SBFD in IPv4 only packet
+   2) The ADMIN DOWN logic
+   3) SBFD echo function in a initiator session
+   4) SBFD over MPLS
+
+
+.. _sbfd-show:
+
+show command
+============
+
+The exsiting bfd show command is also appliable to SBFD sessions, for example: 
+This command will show all the BFD and SBFD sessions in the bfdd:
+
+.. clicmd:: show bfd peers
+
+
+::
+   BFD Peers:
+           peer 200::D bfd-mode sbfd-init bfd-name a-d multihop local-address 200::A vrf default remote-discr 456
+                ID: 1421669725
+                Remote ID: 456
+                Active mode
+                Minimum TTL: 254
+                Status: up
+                Uptime: 5 hour(s), 48 minute(s), 39 second(s)
+                Diagnostics: ok
+                Remote diagnostics: ok
+                Peer Type: sbfd initiator
+                Local timers:
+                        Detect-multiplier: 3
+                        Receive interval: 300ms
+                        Transmission interval: 1000ms
+                        Echo receive interval: 50ms
+                        Echo transmission interval: disabled
+                Remote timers:
+                        Detect-multiplier: -
+                        Receive interval: -
+                        Transmission interval: -
+                        Echo receive interval: -
+
+This command will show all the BFD and SBFD session packet counters:
+
+.. clicmd:: show bfd peers counters
+
+::
+   BFD Peers:
+        peer 200::A bfd-mode sbfd-echo bfd-name a-b-d local-address 200::A vrf default srv6-source-ipv6 200::A srv6-encap-data 100::B 100::D
+                Control packet input: 0 packets
+                Control packet output: 0 packets
+                Echo packet input: 23807 packets
+                Echo packet output: 23807 packets
+                Session up events: 1
+                Session down events: 0
+                Zebra notifications: 1
+                Tx fail packet: 0
+
+        peer 200::D bfd-mode sbfd-init bfd-name a-d local-address 200::A vrf default remote-discr 456
+                Control packet input: 25289 packets
+                Control packet output: 51812 packets
+                Echo packet input: 0 packets
+                Echo packet output: 0 packets
+                Session up events: 5
+                Session down events: 4
+                Zebra notifications: 9
+                Tx fail packet: 0
+
+
+we also implemented a new show command to display BFD sessions with a bfd-name, the bfd-name is the key to search the sessioon.
+
+.. clicmd:: show bfd bfd-name a-b-d
+
+::
+   BFD Peers:
+        peer 200::A bfd-mode sbfd-echo bfd-name a-b-d local-address 200::A vrf default srv6-source-ipv6 200::A srv6-encap-data 100::B 100::D
+                ID: 123
+                Remote ID: 123
+                Active mode
+                Status: up
+                Uptime: 5 hour(s), 39 minute(s), 34 second(s)
+                Diagnostics: ok
+                Remote diagnostics: ok
+                Peer Type: echo
+                Local timers:
+                        Detect-multiplier: 3
+                        Receive interval: 300ms
+                        Transmission interval: 300ms
+                        Echo receive interval: 300ms
+                        Echo transmission interval: 1000ms
+                Remote timers:
+                        Detect-multiplier: -
+                        Receive interval: -
+                        Transmission interval: -
+                        Echo receive interval: -

--- a/doc/user/subdir.am
+++ b/doc/user/subdir.am
@@ -55,6 +55,7 @@ user_RSTFILES = \
 	doc/user/watchfrr.rst \
 	doc/user/wecmp_linkbw.rst \
 	doc/user/mgmtd.rst \
+	doc/user/sbfd.rst \
 	# end
 
 EXTRA_DIST += \

--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -374,7 +374,6 @@ int zclient_bfd_command(struct zclient *zc, struct bfd_session_arg *args)
 	stream_putc(s, args->profilelen);
 	if (args->profilelen)
 		stream_put(s, args->profile, args->profilelen);
-
 #else /* PTM BFD */
 	/* Encode timers if this is a registration message. */
 	if (args->command != ZEBRA_BFD_DEST_DEREGISTER) {
@@ -751,7 +750,6 @@ void bfd_sess_install(struct bfd_session_params *bsp)
 	bsp->lastev = BSE_INSTALL;
 	event_add_event(bsglobal.tm, _bfd_sess_send, bsp, 0, &bsp->installev);
 }
-
 
 void bfd_sess_uninstall(struct bfd_session_params *bsp)
 {

--- a/lib/bfd.h
+++ b/lib/bfd.h
@@ -26,6 +26,8 @@ extern "C" {
 
 #define BFD_PROFILE_NAME_LEN 64
 
+#define BFD_NAME_SIZE 255
+
 const char *bfd_get_status_str(int status);
 
 extern void bfd_client_sendmsg(struct zclient *zclient, int command,
@@ -409,6 +411,8 @@ struct bfd_session_arg {
 	uint32_t min_tx;
 	/** Detection multiplier. */
 	uint32_t detection_multiplier;
+	/* bfd session name*/
+	char bfd_name[BFD_NAME_SIZE + 1];
 };
 
 /**

--- a/tests/topotests/sbfd_topo1/r1/frr.conf
+++ b/tests/topotests/sbfd_topo1/r1/frr.conf
@@ -1,0 +1,8 @@
+ip forwarding
+ipv6 forwarding
+!
+
+interface r1-eth0
+ ipv6 address 2001::10/64
+!
+!

--- a/tests/topotests/sbfd_topo1/r2/frr.conf
+++ b/tests/topotests/sbfd_topo1/r2/frr.conf
@@ -1,0 +1,8 @@
+ip forwarding
+ipv6 forwarding
+!
+
+interface r2-eth0
+ ipv6 address 2001::20/64
+!
+!

--- a/tests/topotests/sbfd_topo1/sbfd_topo1.dot
+++ b/tests/topotests/sbfd_topo1/sbfd_topo1.dot
@@ -1,0 +1,45 @@
+## Color coding:
+#########################
+##  Main FRR: #f08080  red
+##  Switches: #d0e0d0  gray
+##  RIP:      #19e3d9  Cyan
+##  RIPng:    #fcb314  dark yellow
+##  OSPFv2:   #32b835  Green
+##  OSPFv3:   #19e3d9  Cyan
+##  ISIS IPv4 #fcb314  dark yellow
+##  ISIS IPv6 #9a81ec  purple
+##  BGP IPv4  #eee3d3  beige
+##  BGP IPv6  #fdff00  yellow
+##### Colors (see http://www.color-hex.com/)
+
+graph template {
+	label="template";
+
+	# Routers
+	r1 [
+		shape=doubleoctagon,
+		label="A\nAS 100\n1.1.1.1",
+		fillcolor="#f08080",
+		style=filled,
+	];
+	r2 [
+		shape=doubleoctagon
+		label="B\nAS 200\n1.1.1.2",
+		fillcolor="#f08080",
+		style=filled,
+	];
+
+	# Switches
+	s1 [
+		shape=oval,
+		label="s1\n192.168.0.0/24",
+		fillcolor="#d0e0d0",
+		style=filled,
+	];
+
+
+	# Connections
+	r1 -- s1 [label="A-eth0"];
+	r2 -- s1 [label="B-eth0"];
+
+}

--- a/tests/topotests/sbfd_topo1/test_sbfd_topo1.py
+++ b/tests/topotests/sbfd_topo1/test_sbfd_topo1.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python
+
+#
+# test_sbfd_topo1.py
+# basic test cases for sbfd initiator and reflector
+#
+# Copyright (c) 2025 by Alibaba, Inc.
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+<template>.py: Test <template>.
+"""
+
+import os
+import sys
+import pytest
+import json
+import re
+import time
+import pdb
+from functools import partial
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, '../'))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from lib.common_config import required_linux_kernel_version
+
+"""
+test_sbfd_topo1.py: test simple sbfd with IPv6 encap. RT1 is sbfd Initiator, RT2 is sbfd Reflector
+
+ +----+----+        +----+----+
+ |         |        |         |
+ |   RT1   |   1    |   RT2   |
+ |         +--------+         |
+ | 2001::10|        | 2001::20|
+ +----+----+        +----+----+
+
+"""
+pytestmark = [pytest.mark.bfdd, pytest.mark.sbfd]
+
+def show_bfd_check(router, status, type='echo', encap=None):
+    output = router.cmd("vtysh -c 'show bfd peers'")
+    if encap:
+        # check encap data if any
+        pattern1 = re.compile(r'encap-data {}'.format(encap))
+        ret = pattern1.findall(output)
+        if len(ret) <= 0:
+            logger.info("encap-data not match")
+            return False
+
+    # check  status
+    pattern2 = re.compile(r'Status: {}'.format(status))
+    ret = pattern2.findall(output)
+    if len(ret) <= 0:
+        logger.info("Status not match")
+        return False
+
+    # check type
+    pattern3 = re.compile(r'Peer Type: {}'.format(type))
+    ret = pattern3.findall(output)
+    if len(ret) <= 0:
+        logger.info("Peer Type not match")
+        return False
+
+    logger.info("all check passed")
+    return True
+
+def build_topo(tgen):
+    "Test topology builder"
+
+    # This function only purpose is to define allocation and relationship
+    # between routers, switches and hosts.
+    #
+    # Example
+    #
+    # Create 2 routers
+    for routern in range(1, 3):
+        tgen.add_router('r{}'.format(routern))
+
+    # Create a switch with just one router connected to it to simulate a
+    # empty network.
+    switch = tgen.add_switch('s1')
+    switch.add_link(tgen.gears['r1'])
+    switch.add_link(tgen.gears['r2'])
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    # This function initiates the topology build with Topogen...
+    tgen = Topogen(build_topo, mod.__name__)
+    # ... and here it calls Mininet initialization functions.
+    tgen.start_topology()
+
+    # This is a sample of configuration loading.
+    router_list = tgen.routers()
+
+    for rname, router in router_list.items():
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr.conf".format(rname)),
+            [(TopoRouter.RD_ZEBRA, None), (TopoRouter.RD_BFD, None)])
+
+    # After loading the configurations, this function loads configured daemons.
+    tgen.start_router()
+
+    # Verify that we are using the proper version and that the BFD
+    # daemon exists.
+    for router in router_list.values():
+        # Check for Version
+        if router.has_version('<', '5.1'):
+            tgen.set_error('Unsupported FRR version')
+            break
+
+def teardown_module(mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    # This function tears down the whole topology.
+    tgen.stop_topology()
+
+
+# step 1 : config sbfd Initiator and reflector
+def test_sbfd_config_check():
+    "Assert that config sbfd and check sbfd status."
+    # Required linux kernel version for this suite to run.
+    result = required_linux_kernel_version("4.5")
+    if result is not True:
+        pytest.skip("Kernel requirements are not met")
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # config sbfd
+    r1 = tgen.net['r1']
+    r1.cmd("ping -c 5 2001::20")
+    r1.cmd("vtysh -c 'config t' -c 'bfd' -c 'peer 2001::20 bfd-mode sbfd-init bfd-name 2-44 local-address 2001::10 remote-discr 1234'")
+
+    r2 = tgen.net['r2']
+    r2.cmd("vtysh -c 'config t' -c 'bfd' -c 'sbfd reflector source-address 2001::20 discriminator 1234'")
+
+    check_func = partial(
+        show_bfd_check, r1, 'up', type='sbfd initiator'
+    )
+    success, _ = topotest.run_and_expect(check_func, True, count=15, wait=1)
+    assert success is True, "sbfd not up in 15 seconds"
+
+# step 2: shutdown if and no shutdown if then check sbfd status
+def test_sbfd_updown_interface():
+    "Assert that updown interface then check sbfd status."
+    # Required linux kernel version for this suite to run.
+    result = required_linux_kernel_version("4.5")
+    if result is not True:
+        pytest.skip("Kernel requirements are not met")
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.net['r1']
+    r2 = tgen.net['r2']
+
+    # shutdown interface
+    r2.cmd("vtysh -c 'config t' -c 'interface r2-eth0' -c 'shutdown'")
+
+    check_func = partial(
+        show_bfd_check, r1, 'down', type='sbfd initiator'
+    )
+    success, _ = topotest.run_and_expect(check_func, True, count=15, wait=1)
+    assert success is True, "sbfd not down in 15 seconds after shut"
+
+    # up interface
+    r2.cmd("vtysh -c 'config t' -c 'interface r2-eth0' -c 'no shutdown'")
+    check_func = partial(
+        show_bfd_check, r1, 'up', type='sbfd initiator'
+    )
+    success, _ = topotest.run_and_expect(check_func, True, count=15, wait=1)
+    assert success is True, "sbfd not up in 15 seconds after no shut"
+
+# step 3: change transmit-interval and check sbfd status according to the interval time
+def test_sbfd_change_transmit_interval():
+    "Assert that sbfd status changes align with transmit-interval."
+    # Required linux kernel version for this suite to run.
+    result = required_linux_kernel_version("4.5")
+    if result is not True:
+        pytest.skip("Kernel requirements are not met")
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.net['r1']
+    r2 = tgen.net['r2']
+
+    r1.cmd("vtysh -c 'config t' -c 'bfd' -c 'peer 2001::20 bfd-mode sbfd-init bfd-name 2-44 local-address 2001::10 remote-discr 1234' -c 'transmit-interval 3000'")
+    #wait sometime for polling finish
+    time.sleep(1)
+
+    # shutdown interface
+    r2.cmd("vtysh -c 'config t' -c 'interface r2-eth0' -c 'shutdown'")
+
+    #wait enough time for timeout
+    check_func = partial(
+        show_bfd_check, r1, 'down', type='sbfd initiator'
+    )
+    success, _ = topotest.run_and_expect(check_func, True, count=5, wait=3)
+    assert success is True, "sbfd not down as expected"
+
+    r2.cmd("vtysh -c 'config t' -c 'interface r2-eth0' -c 'no shutdown'")
+    check_func = partial(
+        show_bfd_check, r1, 'up', type='sbfd initiator'
+    )
+    success, _ = topotest.run_and_expect(check_func, True, count=15, wait=1)
+    assert success is True, "sbfd not up in 15 seconds after no shut"
+
+    r1.cmd("vtysh -c 'config t' -c 'bfd' -c 'no peer 2001::20 bfd-mode sbfd-init bfd-name 2-44 local-address 2001::10 remote-discr 1234'")
+    success = show_bfd_check(r1, 'up', type='sbfd initiator')
+    assert success is False, "sbfd not deleted as unexpected"
+
+# Memory leak test template
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip('Memory leak test/report is disabled')
+
+    tgen.report_memory_leaks()
+
+if __name__ == '__main__':
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2385,6 +2385,79 @@ DEFUNSH(VTYSH_BFDD, bfd_peer_enter, bfd_peer_enter_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFUNSH(VTYSH_BFDD, sbfd_echo_peer_enter, sbfd_echo_peer_enter_cmd,
+	"peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-echo bfd-name BFDNAME [multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] srv6-source-ipv6 X:X::X:X srv6-encap-data X:X::X:X...",
+	"Configure peer\n"
+	"IPv4 peer address\n"
+	"IPv6 peer address\n"
+	"Specify bfd session mode\n"
+	"Enable sbfd-echo mode\n"
+	"Specify bfd session name\n"
+	"bfd session name\n"
+	"Configure multihop\n"
+	"Configure local\n"
+	"IPv4 local address\n"
+	"IPv6 local address\n"
+	"Configure VRF\n"
+	"Configure VRF name\n"
+	"Configure source ipv6 address for srv6 encap\n"
+	"IPv6 local address\n"
+	"Configure sidlist data for srv6 encap\n"
+	"X:X::X:X IPv6 sid address\n")
+{
+	vty->node = BFD_PEER_NODE;
+	return CMD_SUCCESS;
+}
+
+DEFUNSH(VTYSH_BFDD, sbfd_init_peer_enter, sbfd_init_peer_enter_cmd,
+	"peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-init bfd-name BFDNAME [multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] remote-discr (1-4294967295) srv6-source-ipv6 X:X::X:X srv6-encap-data X:X::X:X...",
+	"Configure peer\n"
+	"IPv4 peer address\n"
+	"IPv6 peer address\n"
+	"Specify bfd session mode\n"
+	"Enable sbfd-init mode\n"
+	"Specify bfd session name\n"
+	"bfd session name\n"
+	"Configure multihop\n"
+	"Configure local\n"
+	"IPv4 local address\n"
+	"IPv6 local address\n"
+	"Configure VRF\n"
+	"Configure VRF name\n"
+	"Configure bfd session remote discriminator\n"
+	"Configure remote discriminator\n"
+	"Configure source ipv6 address for srv6 encap\n"
+	"IPv6 local address\n"
+	"Configure sidlist data for srv6 encap\n"
+	"X:X::X:X IPv6 sid address\n"
+	)
+{
+	vty->node = BFD_PEER_NODE;
+	return CMD_SUCCESS;
+}
+
+DEFUNSH(VTYSH_BFDD, sbfd_init_peer_raw_enter, sbfd_init_peer_raw_enter_cmd,
+	"peer <A.B.C.D|X:X::X:X> bfd-mode sbfd-init bfd-name BFDNAME [multihop$multihop] local-address <A.B.C.D|X:X::X:X> [vrf NAME] remote-discr (1-4294967295)",
+	"Configure peer\n"
+	"IPv4 peer address\n"
+	"IPv6 peer address\n"
+	"Specify bfd session mode\n"
+	"Enable sbfd-init mode\n"
+	"Specify bfd session name\n"
+	"bfd session name\n"
+	"Configure multihop\n"
+	"Configure local\n"
+	"IPv4 local address\n"
+	"IPv6 local address\n"
+	"Configure VRF\n"
+	"Configure VRF name\n"
+	"Configure bfd session remote discriminator\n"
+	"Configure remote discriminator\n")
+{
+	vty->node = BFD_PEER_NODE;
+	return CMD_SUCCESS;
+}
+
 DEFUNSH(VTYSH_BFDD, bfd_profile_enter, bfd_profile_enter_cmd,
 	"profile BFDPROF",
 	BFD_PROFILE_STR
@@ -5272,6 +5345,9 @@ void vtysh_init_vty(void)
 	install_element(BFD_NODE, &vtysh_end_all_cmd);
 
 	install_element(BFD_NODE, &bfd_peer_enter_cmd);
+	install_element(BFD_NODE, &sbfd_init_peer_enter_cmd);
+	install_element(BFD_NODE, &sbfd_init_peer_raw_enter_cmd);
+	install_element(BFD_NODE, &sbfd_echo_peer_enter_cmd);
 	install_element(BFD_PEER_NODE, &vtysh_exit_bfdd_cmd);
 	install_element(BFD_PEER_NODE, &vtysh_quit_bfdd_cmd);
 	install_element(BFD_PEER_NODE, &vtysh_end_all_cmd);

--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -503,6 +503,136 @@ module frr-bfdd {
             config false;
           }
         }
+
+        list sbfd-echo {
+          key "source-addr bfd-name vrf";
+          description "support a special echo SBFD session in RFC7880, and enhanced with SRv6 encapsulation";
+
+          leaf source-addr {
+            type inet:ip-address;
+            description "Local IP address";
+          }
+
+          leaf dest-addr {
+            type inet:ip-address;
+            description "IP address of the peer";
+          }
+
+          leaf bfd-name {
+            type string;
+            default "";
+            description "Bfd session name.";
+          }
+
+          leaf vrf {
+            type frr-vrf:vrf-ref;
+            description "Virtual Routing Domain name";
+          }
+
+          leaf profile {
+            type profile-ref;
+            description "Override defaults with profile.";
+          }
+
+          leaf-list srv6-encap-data {
+            type inet:ipv6-address;
+            max-elements 6;
+
+            description "segment list ipv6 addresses for srv6 encapsulation";
+          }
+
+          leaf srv6-source-ipv6 {
+            type inet:ipv6-address;
+            description "source ipv6 address for srv6 encapsulation";
+          }
+
+          leaf bfd-mode {
+            type uint32;
+            description "Bfd session mode.";
+          }
+
+          leaf multi-hop {
+            type boolean;
+            description "Use multi hop session instead of single hop.";
+          }
+
+          uses session-common;
+          uses session-multi-hop;
+          uses session-echo;
+
+          container stats {
+            uses session-states;
+            config false;
+          }
+        }
+
+        list sbfd-init {
+          key "source-addr dest-addr bfd-name vrf";
+          description "support SBFD session in RFC7880, and optional with SRv6 encapsulation";
+
+          leaf source-addr {
+            type inet:ip-address;
+            description "Local IP address";
+          }
+
+          leaf dest-addr {
+            type inet:ip-address;
+            description "IP address of the peer";
+          }
+
+          leaf bfd-name {
+            type string;
+            default "";
+            description "Bfd session name.";
+          }
+
+          leaf vrf {
+            type frr-vrf:vrf-ref;
+            description "Virtual Routing Domain name";
+          }
+
+          leaf profile {
+            type profile-ref;
+            description "Override defaults with profile.";
+          }
+
+          leaf-list srv6-encap-data {
+            type inet:ipv6-address;
+            max-elements 6;
+
+            description "segment list ipv6 addresses for srv6 encapsulation";
+          }
+
+          leaf srv6-source-ipv6 {
+            type inet:ip-address;
+            description "source ipv6 address for srv6 encapsulation";
+          }
+
+          leaf remote-discr {
+            type uint32;
+            default 0;
+            description
+              "Remote session identifier";
+          }
+
+          leaf bfd-mode {
+            type uint32;
+            description "Bfd session mode.";
+          }
+
+          leaf multi-hop {
+            type boolean;
+            description "Use multi hop session instead of single hop.";
+          }
+
+          uses session-common;
+          uses session-multi-hop;
+
+          container stats {
+            uses session-states;
+            config false;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
implementing the SBFD feature (RFC7880, RFC7881) in FRR. 

**What is the motivation for this PR?**
The PhoenixWing project aims to implement SRv6 features into the SONiC community. In PhoenixWing traffic engineering case, we use  SBFD to protect SRv6 TE paths.

**How did you do it?**
SBFD HLD in SoNiC community: https://github.com/sonic-net/SONiC/pull/1766

use SBFD to protect TE path, two types of configs are supported:
1) SBFD echo mode, which mainly used in Our SRv6 TE case. Only need to config at local side: 
   configure terminal->
   bfd -> 
   peer X::X bfd-mode sbfd-echo bfd-name name local-address X::X encap-type SRv6 encap-data X::X source-ipv6 X::X
2) SBFD initiator and reflector mode, Need to config at local side and remote side:
   2.1) local config:
   configure terminal->
   bfd -> 
   peer X::X bfd-mode sbfd-init bfd-name name local-address X::X encap-type SRv6 encap-data X::X source-ipv6 X::X remote-discr 12345
   2.2) remote config:
   configure terminal ->
   bfd ->
   sbfd reflector source-address X::X discriminator 12345
  


