### PR TITLE
bgpd: Fix for match source-protocol in route-map for redistribute cmd

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9056,6 +9056,7 @@ void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 			memset(&rmap_path, 0, sizeof(rmap_path));
 			rmap_path.peer = bgp->peer_self;
 			rmap_path.attr = &attr_new;
+			rmap_path.type = type;
 
 			SET_FLAG(bgp->peer_self->rmap_type,
 				 PEER_RMAP_TYPE_REDISTRIBUTE);


### PR DESCRIPTION
A redistribute cmd can have a route-map attached to it and adding the match source-protocol to that route-map means BGP to filter which protocol routes to accept among the bunch of routes zebra is sending.

Fixing this since this wasnt implemented earlier.

Ticket :#4119692