### PR TITLE
ospf6d: remove redundant null ptr check

### DIFF
--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -772,7 +772,7 @@ static char *ospf6_intra_prefix_lsa_get_prefix_str(struct ospf6_lsa *lsa,
 	char tbuf[16];
 
 	/* ensure buflen >= INET6_ADDRSTRLEN + '/128\0' */
-	if (!lsa || !prefix || !buf || buflen < (5 + INET6_ADDRSTRLEN))
+	if (!prefix || !buf || buflen < (5 + INET6_ADDRSTRLEN))
 		return NULL;
 
 	memcpy(&in6, OSPF6_PREFIX_BODY(prefix),


### PR DESCRIPTION
Fix defect flagged by Coverity:

```
*** CID 1599962:  Null pointer dereferences  (REVERSE_INULL) /ospf6d/ospf6_intra.c: 775 in ospf6_intra_prefix_lsa_get_prefix_str()
769     {
770             struct ospf6_prefix *prefix = nth_prefix(lsa->header, pos);
771             struct in6_addr in6 = { 0 };
772             char tbuf[16];
773
774             /* ensure buflen >= INET6_ADDRSTRLEN + '/128\0' */
>>>     CID 1599962:  Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "lsa" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
775             if (!lsa || !prefix || !buf || buflen < (5 + INET6_ADDRSTRLEN))
776                     return NULL;
777
778             memcpy(&in6, OSPF6_PREFIX_BODY(prefix),
779                    OSPF6_PREFIX_SPACE(prefix->prefix_length));
780             inet_ntop(AF_INET6, &in6, buf, buflen);
```

The check for lsa being not-null happens in ospf6_lsdb_show() and first dereference happens in ospf6_lsa_show_summary()