### PR TITLE
ospf6d: remove redundant null ptr check in ospf6_link_lsa_get_prefix_str() - CID 1599957

### DIFF
--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -578,7 +578,7 @@ static char *ospf6_link_lsa_get_prefix_str(struct ospf6_lsa *lsa, char *buf,
 	struct ospf6_prefix *prefix = nth_prefix(lsa->header, pos);
 	struct in6_addr in6 = { 0 };
 
-	if (!lsa || !prefix || !buf || buflen < (1 + INET6_ADDRSTRLEN))
+	if (!prefix || !buf || buflen < (1 + INET6_ADDRSTRLEN))
 		return NULL;
 
 	/* position zero is used for the lladdr in the body of the LSA */


### PR DESCRIPTION
Fix defect flagged by Coverity:

```
*** CID 1599957:  Null pointer dereferences  (REVERSE_INULL) /ospf6d/ospf6_intra.c: 581 in ospf6_link_lsa_get_prefix_str()
575                                                int buflen, int pos)
576     {
577             struct ospf6_link_lsa *link_lsa = lsa_after_header(lsa->header);
578             struct ospf6_prefix *prefix = nth_prefix(lsa->header, pos);
579             struct in6_addr in6 = { 0 };
580
>>>     CID 1599957:  Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "lsa" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
581             if (!lsa || !prefix || !buf || buflen < (1 + INET6_ADDRSTRLEN))
582                     return NULL;
583
584             /* position zero is used for the lladdr in the body of the LSA */
585             if (pos == 0) {
586                     inet_ntop(AF_INET6, &link_lsa->linklocal_addr, buf, buflen);
```

The check for lsa being not-null happens in ospf6_lsdb_show() and first dereference happens in ospf6_lsa_show_summary()