### PR TITLE
isisd: fix crash when switching P2P after shutdowning LAN circuit

### DIFF
--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -851,11 +851,13 @@ void isis_circuit_down(struct isis_circuit *circuit)
 			isis_dr_resign(circuit, 1);
 			circuit->u.bc.is_dr[0] = 0;
 		}
+		circuit->u.bc.run_dr_elect[0] = 0;
 		memset(circuit->u.bc.l1_desig_is, 0, ISIS_SYS_ID_LEN + 1);
 		if (circuit->u.bc.is_dr[1]) {
 			isis_dr_resign(circuit, 2);
 			circuit->u.bc.is_dr[1] = 0;
 		}
+		circuit->u.bc.run_dr_elect[1] = 0;
 		memset(circuit->u.bc.l2_desig_is, 0, ISIS_SYS_ID_LEN + 1);
 		memset(circuit->u.bc.snpa, 0, ETH_ALEN);
 


### PR DESCRIPTION
When shutdown a LAN-type circuit, and if the current device is not the DIS (assuming it is a level-1 device), the isis_circuit_down() function will not call the isis_dr_resign() function to clear the circuit->u.bc.run_dr_elect[0] bit (this bit is set on interfaces in the isis_run_dr() function). After switching the link to a P2P type, since u.p2p and u.bc form a union, and circuit->u.bc.snpa = "\000\000\000\000\000" and circuit->u.bc.run_dr_elect = "\001", this results in circuit->u.p2p.neighbor = 0x1000000000000. Consequently, the value of adj->sysid accesses a wild pointer, causing the current crash.

The backtrace is as follows:
(gdb) bt
#0  0x00007fbd30e55fe1 in raise () from /lib/x86_64-linux-gnu/libpthread.so.0 #1  0x00007fbd30f76b29 in core_handler (signo=11, siginfo=0x7ffc60b7a270, 
    context=0x7ffc60b7a140) at ../lib/sigevent.c:261
#2  <signal handler called>
#3  0x00007fbd30dddba4 in ?? () from /lib/x86_64-linux-gnu/libc.so.6 #4  0x0000562aec46617f in isis_spf_run_lfa (area=0x562aee3a56d0, spftree=0x562aee3a51a0)
    at ../isisd/isis_lfa.c:2403
#5  0x0000562aec483854 in isis_run_spf_with_protection (area=0x562aee3a56d0, 
    spftree=0x562aee3a51a0) at ../isisd/isis_spf.c:1891
#6  0x0000562aec483b05 in isis_run_spf_cb (thread=0x7ffc60b7b000)
    at ../isisd/isis_spf.c:1953
#7  0x00007fbd30f900bb in thread_call (thread=0x7ffc60b7b000) at ../lib/thread.c:1990 #8  0x00007fbd30f2897b in frr_run (master=0x562aee0833c0) at ../lib/libfrr.c:1198 #9  0x0000562aec454d6d in main (argc=5, argv=0x7ffc60b7b228, envp=0x7ffc60b7b258)
    at ../isisd/isis_main.c:273
(gdb) f 4
#4  0x0000562aec46617f in isis_spf_run_lfa (area=0x562aee3a56d0, spftree=0x562aee3a51a0)
    at ../isisd/isis_lfa.c:2403
2403    ../isisd/isis_lfa.c: No such file or directory.
(gdb) p circuit->u.p2p.neighbor
$1 = (struct isis_adjacency *) 0x1000000000000
(gdb) p adj->sysid
Cannot access memory at address 0x1000000000006
(gdb) p circuit->u.bc  
$2 = {snpa = "\000\000\000\000\000", run_dr_elect = "\001", t_run_dr = {0x0, 0x0}, 
  t_send_lan_hello = {0x0, 0x0}, adjdb = {0x0, 0x0}, lan_neighs = {0x0, 0x0}, 
  is_dr = "\000", l1_desig_is = "\000\000\000\000\000\000", 
  l2_desig_is = "\000\000\000\000\000\000", t_refresh_pseudo_lsp = {0x0, 0x0}}
(gdb) 

The backtrace provided above pertains to version 8.5.4, but it seems that the same issue exists in the code of the master branch as well.