### PR TITLE
packaging: Use PCRE2 for .deb/.rpm builds

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -68,6 +68,7 @@ override_dh_auto_configure:
 		--enable-ospfapi \
 		--enable-bgp-vnc \
 		--enable-multipath=256 \
+		--enable-pcre2posix \
 		\
 		--enable-user=frr \
 		--enable-group=frr \

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -189,6 +189,7 @@ BuildRequires:  ncurses-devel
 BuildRequires:  readline-devel
 BuildRequires:  texinfo
 BuildRequires:  libyang-devel >= 2.1.128
+BuildRequires:  pcre2-devel
 %if 0%{?rhel} && 0%{?rhel} < 7
 #python27-devel is available from ius community repo for RedHat/CentOS 6
 BuildRequires:  python27-devel
@@ -448,7 +449,8 @@ Adds GRPC support to the individual FRR daemons.
 %else
     --disable-grpc \
 %endif
-    --enable-snmp
+    --enable-snmp \
+    --enable-pcre2posix \
     # end
 
 make %{?_smp_mflags} MAKEINFO="makeinfo --no-split"


### PR DESCRIPTION
Closes https://github.com/FRRouting/frr/issues/17365