### PR TITLE
zebra: fix wrong linkdown flag

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2903,8 +2903,10 @@ static bool zebra_nhg_set_valid_if_active(struct nhg_hash_entry *nhe)
 
 		if (!ifp || !if_is_operative(ifp))
 			valid = false;
-		else
+		else {
+			UNSET_FLAG(nhe->nhg.nexthop->flags, NEXTHOP_FLAG_LINKDOWN);
 			valid = true;
+		}
 	}
 
 done:


### PR DESCRIPTION
Add this one line command to one down interface (mask is 192.168.0.0/24):
```
ip link set dev enp2s0 up;ip route add 3.3.3.3/32 via 192.168.0.1 dev enp2s0 proto kernel onlink
```

Before:
```
K>* 3.3.3.3/32 [0/0] via 192.168.0.1, enp2s0 onlink linkdown, weight 1, 00:00:02
```

After:
```
K>* 3.3.3.3/32 [0/0] via 192.168.0.1, enp2s0 onlink, weight 1, 00:00:02
```

It's only display problem, just correct this linkdown flag.