### PR TITLE
bgpd: fix resolvedPrefix in show nexthop json output

### DIFF
--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -1001,7 +1001,7 @@ static void bgp_show_nexthop(struct vty *vty, struct bgp *bgp,
 			if (bnc->is_evpn_gwip_nexthop)
 				json_object_boolean_true_add(json_nexthop,
 							     "isEvpnGatewayIp");
-			json_object_string_addf(json, "resolvedPrefix", "%pFX",
+			json_object_string_addf(json_nexthop, "resolvedPrefix", "%pFX",
 						&bnc->resolved_prefix);
 		} else {
 			vty_out(vty, " %s valid [IGP metric %d], #paths %d",


### PR DESCRIPTION
While populating  the nexthop info for "show bgp nexthop json", resolvedPrefix is added in parent json object instead of json_nexthop object. This results in displaying wrong resolvedPrefix for nexthops. Fixing the same by adding resolvedPrefix to json_nexthop object, so that the proper resolvedPrefix would be displayed for the respective nexthop