### PR TITLE
isisd: properly display srv6 algorithm

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -7993,7 +7993,7 @@ struct isis_router_cap *isis_tlvs_init_router_capability(struct isis_tlvs *tlvs)
 	tlvs->router_cap = XCALLOC(MTYPE_ISIS_TLV, sizeof(*tlvs->router_cap));
 
 	/* init SR algo list content to the default value */
-	for (int i = 0; i < SR_ALGORITHM_COUNT; i++)
+	for (int i = 1; i < SR_ALGORITHM_COUNT; i++)
 		tlvs->router_cap->algo[i] = SR_ALGORITHM_UNSET;
 
 	return tlvs->router_cap;


### PR DESCRIPTION
When the segment-routing ipv6 is configured, the SPF algoritm shows S-SPF is used:

> rt1# show isis segment-routing srv6 node
> Area 1:
>  IS-IS L1 SRv6-Nodes:
>
> System ID       Algorithm  SRH Max SL  SRH Max End Pop  SRH Max H.encaps  SRH Max End D
> -----------------------------------------------------------------------------------------
> 0000.0000.0001  S-SPF        3           3                2                 5

Actually, the segment-routing ipv6 algo capabilities displayed from router_capability_tlv. Display the segment-routing ipv6 algo capabilities from locator_tlv

Initialize sub tlv "algorithm" in the "locator" tlv with SR_ALGORITHM_SPF value.

> rt1# show isis segment-routing srv6 node
> Area 1:
>  IS-IS L1 SRv6-Nodes:
>
> System ID       Algorithm  SRH Max SL  SRH Max End Pop  SRH Max H.encaps  SRH Max End D
> -----------------------------------------------------------------------------------------
> 0000.0000.0001  SPF        3           3                2                 5