### PR TITLE
bgpd: Fix color extended community parsing

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -766,8 +766,6 @@ static const char *ecommunity_gettoken(const char *str, void *eval_ptr,
 				if (*endptr != '\0' || tmp_as > BGP_AS4_MAX ||
 				    errno)
 					goto error;
-				if (*token == ecommunity_token_color && as > 3)
-					goto error;
 				as = (as_t)tmp_as;
 			}
 		} else if (*p == '.') {


### PR DESCRIPTION
Previous work to separate out 'color' ecomm parsing made a test unreachable; coverity SA reported it.