### PR TITLE
bgpd : backpressure - Fix to pop items off zebra_announce FIFO for few EVPN triggers

### DIFF
--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -199,4 +199,5 @@ bool bgp_evpn_skip_vrf_import_of_local_es(struct bgp *bgp_vrf, const struct pref
 					  struct bgp_path_info *pi, int install);
 int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf, const struct prefix_evpn *evp,
 				      struct bgp_path_info *parent_pi);
+extern void bgp_zebra_evpn_pop_items_from_announce_fifo(struct bgpevpn *vpn);
 #endif /* _QUAGGA_BGP_EVPN_H */


### PR DESCRIPTION
In cases such as 'no advertise-all-vni' and L2 VNI DELETE, we need to pop all the VPN routes present in the bgp_zebra_announce FIFO yet to be processed regardless of VNI is configured or not.

NOTE: NO need to pop the VPN routes in two cases
 1) In free_vni_entry
   - Called by bgp_free()->bgp_evpn_cleanup().
   - Since bgp_delete is called before bgp_free and we pop all the dest pertaining to bgp under delete. 2) evpn_delete_vni() when user configures "no vni" since the withdraw of all routes happen in normal cycle.

Fixes: a07df6f7548f6bd1b92acbb7a10c3823de33fe5f
("bgpd : backpressure - Handle BGP-Zebra(EPVN) Install evt Creation")

Ticket :#4163611