### PR TITLE
bfdd: retain remote dplane client socket

### DIFF
--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -948,6 +948,9 @@ static void bfd_dplane_client_connect(struct event *t)
 		_bfd_dplane_client_bootstrap(bdc);
 	}
 
+	/* Continue with the connection */
+	return;
+
 reschedule_connect:
 	EVENT_OFF(bdc->inbufev);
 	EVENT_OFF(bdc->outbufev);


### PR DESCRIPTION
When using bfd in remote-dataplane client mode, don't close a new client socket if we're going to try to use it. It looks to me as if client-mode remote dataplane won't work without something like this?
