### PR TITLE
Bgp bmp and its ilk

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -151,7 +151,7 @@ void bgp_peer_config_apply(struct peer *p, struct peer_group *pg)
 
 void bgp_peer_bfd_update_source(struct peer *p)
 {
-	struct bfd_session_params *session = p->bfd_config->session;
+	struct bfd_session_params *session;
 	const union sockunion *source = NULL;
 	bool changed = false;
 	int family;
@@ -162,6 +162,10 @@ void bgp_peer_bfd_update_source(struct peer *p)
 	struct interface *ifp;
 	union sockunion addr;
 
+	if (!p->bfd_config)
+		return;
+
+	session = p->bfd_config->session;
 	/* Nothing to do for groups. */
 	if (CHECK_FLAG(p->sflags, PEER_STATUS_GROUP))
 		return;

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1826,7 +1826,7 @@ static void bgp_connect_in_progress_update_connection(struct peer *peer)
 static enum bgp_fsm_state_progress bgp_start(struct peer_connection *connection)
 {
 	struct peer *peer = connection->peer;
-	int status;
+	enum connect_result status;
 
 	bgp_peer_conf_if_to_su_update(connection);
 

--- a/bgpd/bgp_network.h
+++ b/bgpd/bgp_network.h
@@ -21,7 +21,7 @@ extern int bgp_socket(struct bgp *bgp, unsigned short port,
 		      const char *address);
 extern void bgp_close_vrf_socket(struct bgp *bgp);
 extern void bgp_close(void);
-extern int bgp_connect(struct peer_connection *connection);
+extern enum connect_result bgp_connect(struct peer_connection *connection);
 extern int bgp_getsockname(struct peer *peer);
 extern void bgp_updatesockname(struct peer *peer);
 

--- a/tests/topotests/zebra_fec_nexthop_resolution/r1/bgpd.conf
+++ b/tests/topotests/zebra_fec_nexthop_resolution/r1/bgpd.conf
@@ -1,5 +1,6 @@
 !
 router bgp 65500
+ timers bgp 3 9
  bgp router-id 192.0.2.1
  neighbor 192.0.2.3 remote-as 65500
  neighbor 192.0.2.3 update-source lo
@@ -7,6 +8,7 @@ router bgp 65500
  neighbor 192.0.2.7 ttl-security hops 10
  neighbor 192.0.2.7 disable-connected-check
  neighbor 192.0.2.7 update-source lo
+ neighbor 192.0.2.7 timers connect 5
  !
  address-family ipv4 unicast
   network 192.0.2.1/32

--- a/tests/topotests/zebra_fec_nexthop_resolution/r2/bgpd.conf
+++ b/tests/topotests/zebra_fec_nexthop_resolution/r2/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65500
+ timers bgp 3 9
  bgp router-id 192.0.2.2
  neighbor 192.0.2.1 remote-as 65500
  neighbor 192.0.2.1 update-source lo

--- a/tests/topotests/zebra_fec_nexthop_resolution/r3/bgpd.conf
+++ b/tests/topotests/zebra_fec_nexthop_resolution/r3/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65500
+ timers bgp 3 9
  bgp router-id 192.0.2.3
  neighbor 192.0.2.1 remote-as 65500
  neighbor 192.0.2.1 update-source lo

--- a/tests/topotests/zebra_fec_nexthop_resolution/r4/bgpd.conf
+++ b/tests/topotests/zebra_fec_nexthop_resolution/r4/bgpd.conf
@@ -1,5 +1,6 @@
 !
 router bgp 65500
+ timers bgp 3 9
  bgp router-id 192.0.2.4
  neighbor 192.0.2.1 remote-as 65500
  neighbor 192.0.2.1 ttl-security hops 10

--- a/tests/topotests/zebra_fec_nexthop_resolution/r5/bgpd.conf
+++ b/tests/topotests/zebra_fec_nexthop_resolution/r5/bgpd.conf
@@ -1,4 +1,5 @@
 router bgp 65500
+ timers bgp 3 9
  bgp router-id 192.0.2.5
  neighbor 192.0.2.3 remote-as 65500
  neighbor 192.0.2.3 update-source lo

--- a/tests/topotests/zebra_fec_nexthop_resolution/r7/bgpd.conf
+++ b/tests/topotests/zebra_fec_nexthop_resolution/r7/bgpd.conf
@@ -1,10 +1,12 @@
 !
 router bgp 65500
+ timers bgp 3 9
  bgp router-id 192.0.2.7
  neighbor 192.0.2.1 remote-as 65500
  neighbor 192.0.2.1 ttl-security hops 10
  neighbor 192.0.2.1 disable-connected-check
  neighbor 192.0.2.1 update-source lo
+ neighbor 192.0.2.1 timers connect 5
  neighbor 192.0.2.5 remote-as 65500
  neighbor 192.0.2.5 update-source lo
  !

--- a/tests/topotests/zebra_fec_nexthop_resolution/test_zebra_fec_nexthop_resolution.py
+++ b/tests/topotests/zebra_fec_nexthop_resolution/test_zebra_fec_nexthop_resolution.py
@@ -156,15 +156,16 @@ def test_zebra_fec_nexthop_resolution_bgp():
     def _check_bgp_session():
         r1 = tgen.gears["r1"]
 
-        tgen.gears["r3"].vtysh_cmd("config \n no mpls fec nexthop-resolution \n end")
-        tgen.gears["r3"].vtysh_cmd("config \n mpls fec nexthop-resolution \n end")
-        tgen.gears["r5"].vtysh_cmd("config \n no mpls fec nexthop-resolution \n end")
-        tgen.gears["r5"].vtysh_cmd("config \n mpls fec nexthop-resolution \n end")
         output = json.loads(r1.vtysh_cmd("show bgp summary json"))
 
         if output["ipv4Unicast"]["peers"]["192.0.2.7"]["state"] == "Established":
             return None
         return False
+
+    tgen.gears["r3"].vtysh_cmd("config \n no mpls fec nexthop-resolution \n end")
+    tgen.gears["r3"].vtysh_cmd("config \n mpls fec nexthop-resolution \n end")
+    tgen.gears["r5"].vtysh_cmd("config \n no mpls fec nexthop-resolution \n end")
+    tgen.gears["r5"].vtysh_cmd("config \n mpls fec nexthop-resolution \n end")
 
     test_func1 = functools.partial(_check_bgp_session)
     _, result1 = topotest.run_and_expect(test_func1, None, count=60, wait=0.5)


### PR DESCRIPTION
a) bgp_connect is returning values that are not handled in bgp_fsm.c.  Fix this
b) zebra_fec_nexthop_resolution is not using timers that allow for quicker reconvergence in case of a failure on startup
c) bgp is not properly setting up a bfd session when it knows about a bfd peer before it has learned about the interfaces addresses.  This is purely a timing issue on startup.