### PR TITLE
zebra: Fix ip protocol route-map issue.

### DIFF
--- a/lib/route_types.txt
+++ b/lib/route_types.txt
@@ -88,7 +88,7 @@ ZEBRA_ROUTE_VRRP,       vrrp,      vrrpd,  '-', 0, 0, 0,     "VRRP",          vr
 ZEBRA_ROUTE_NHG,        zebra,     none,   '-', 0, 0, 0,     "Nexthop Group", none
 ZEBRA_ROUTE_SRTE,       srte,      none,   '-', 0, 0, 0,     "SR-TE",         none
 ZEBRA_ROUTE_TABLE_DIRECT,      table-direct,     zebra,  't', 1, 1, 1,     "Table-Direct",         zebra
-ZEBRA_ROUTE_ALL,        wildcard,  none,   '-', 0, 0, 0,     "-",             none
+ZEBRA_ROUTE_ALL,        any,       none,   '-', 0, 0, 0,     "-",             none
 
 
 ## help strings

--- a/tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py
+++ b/tests/topotests/bgp_suppress_fib/test_bgp_suppress_fib.py
@@ -232,6 +232,20 @@ def test_local_vs_non_local():
             assert False, "Route 60.0.0.0/24 should not have fibPending"
 
 
+def test_ip_protocol_any_fib_filter():
+    #    "Filtered route of source protocol any should not get installed in fib"
+
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+    r2.vtysh_cmd("conf\nno ip protocol bgp")
+    r2.vtysh_cmd("conf\nip protocol any route-map LIMIT")
+    test_bgp_route()
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -3375,10 +3375,7 @@ int lib_vrf_zebra_filter_protocol_create(struct nb_cb_create_args *args)
 	const char *proto = yang_dnode_get_string(args->dnode, "protocol");
 	int rtype;
 
-	if (strcasecmp(proto, "any") == 0)
-		rtype = ZEBRA_ROUTE_MAX;
-	else
-		rtype = proto_name2num(proto);
+	rtype = proto_name2num(proto);
 
 	if (args->event == NB_EV_VALIDATE)
 		if (rtype < 0) {
@@ -3404,10 +3401,7 @@ int lib_vrf_zebra_filter_protocol_destroy(struct nb_cb_destroy_args *args)
 
 	yang_afi_safi_identity2value(afi_safi, &afi, &safi);
 
-	if (strcasecmp(proto, "any") == 0)
-		rtype = ZEBRA_ROUTE_MAX;
-	else
-		rtype = proto_name2num(proto);
+	rtype = proto_name2num(proto);
 
 	/* deleting an existing entry, it can't be invalid */
 	assert(rtype >= 0);
@@ -3435,10 +3429,7 @@ void lib_vrf_zebra_filter_protocol_apply_finish(
 
 	yang_afi_safi_identity2value(afi_safi, &afi, &safi);
 
-	if (strcasecmp(proto, "any") == 0)
-		rtype = ZEBRA_ROUTE_MAX;
-	else
-		rtype = proto_name2num(proto);
+	rtype = proto_name2num(proto);
 
 	/* finishing apply for a validated entry, it can't be invalid */
 	assert(rtype >= 0);

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -114,11 +114,6 @@ static void show_vrf_proto_rm(struct vty *vty, struct zebra_vrf *zvrf,
 			vty_out(vty, "%-24s  : none\n", zebra_route_string(i));
 	}
 
-	if (PROTO_RM_NAME(zvrf, af_type, i))
-		vty_out(vty, "%-24s  : %-10s\n", "any",
-			PROTO_RM_NAME(zvrf, af_type, i));
-	else
-		vty_out(vty, "%-24s  : none\n", "any");
 }
 
 static void show_vrf_nht_rm(struct vty *vty, struct zebra_vrf *zvrf,
@@ -1222,8 +1217,8 @@ route_map_result_t zebra_route_map_check(afi_t family, struct route_entry *re,
 			return RMAP_DENYMATCH;
 	}
 	if (!rmap) {
-		rm_name = PROTO_RM_NAME(zvrf, family, ZEBRA_ROUTE_MAX);
-		rmap = PROTO_RM_MAP(zvrf, family, ZEBRA_ROUTE_MAX);
+		rm_name = PROTO_RM_NAME(zvrf, family, ZEBRA_ROUTE_ALL);
+		rmap = PROTO_RM_MAP(zvrf, family, ZEBRA_ROUTE_ALL);
 
 		if (rm_name && !rmap)
 			return RMAP_DENYMATCH;


### PR DESCRIPTION
"ip/ipv6 protocol any route-map <route map>" cli is setting wrong route type (ZEBRA_ROUTE_MAX), It should set route type ZEBRA_ROUTE_ALL.

After executing the above CLI, routes are not scheduled for processing with routemap. 
Reason: CLI set route-type=ZEBRA_ROUTE_MAX but Zebra checks ZEBRA_ROUTE_ALL in rib_update_route_node(). 
FRR restart solves the issue, and filter works as expected, because restart route install flow is different and its checks are proper.
After this code change all the api's are in synced, and right FLAG is used.
CLI, rib_update_route_node() , zebra_route_map_check ()

Ticket: #4101560