### PR TITLE
tests: Ensure connected routes are installed before continuing

### DIFF
--- a/tests/topotests/ospf_instance_redistribute/test_ospf_instance_redistribute.py
+++ b/tests/topotests/ospf_instance_redistribute/test_ospf_instance_redistribute.py
@@ -82,6 +82,37 @@ def test_install_sharp_instance_routes():
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
 
+    r1 = tgen.gears["r1"]
+    logger.info("Ensure that connected routes are actually installed")
+    expected = {
+        "192.168.100.0/24": [
+            {
+                "prefix": "192.168.100.0/24",
+                "prefixLen": 24,
+                "protocol": "connected",
+                "vrfName": "default",
+                "selected": True,
+                "destSelected": True,
+                "installed": True,
+                "nexthops": [
+                    {
+                        "fib": True,
+                        "directlyConnected": True,
+                        "interfaceName": "lo",
+                        "active": True,
+                        "weight": 1,
+                    }
+                ],
+            }
+        ]
+    }
+
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip route connected json", expected
+    )
+
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
     logger.info("Installing sharp routes")
     r1 = tgen.gears["r1"]
     r1.vtysh_cmd("sharp install route 4.5.6.7 nexthop 192.168.100.2 1")


### PR DESCRIPTION
Upon high load the ospf_instance_redistribute test can attempt to install routes with sharpd before the connected routes have fully baked themselves into zebra.  Since sharpd intentionally has no retry mechanism we need to ensure that the test is waiting a small bit.