### PR TITLE
zebra: fix EVPN check vxlan oper up in vlan mapping

### DIFF
--- a/tools/frr_babeltrace.py
+++ b/tools/frr_babeltrace.py
@@ -18,6 +18,7 @@ import sys
 
 import babeltrace
 
+
 ########################### common parsers - start ############################
 def print_ip_addr(field_val):
     """
@@ -48,11 +49,13 @@ def print_mac(field_val):
     """
     return ":".join("%02x" % fb for fb in field_val)
 
+
 def print_net_ipv4_addr(field_val):
     """
     pretty print ctf_integer_network ipv4
     """
     return str(ipaddress.IPv4Address(field_val))
+
 
 def print_esi(field_val):
     """
@@ -60,11 +63,13 @@ def print_esi(field_val):
     """
     return ":".join("%02x" % fb for fb in field_val)
 
+
 def get_field_list(event):
     """
     only fetch fields added via the TP, skip metadata etc.
     """
     return event.field_list_with_scope(babeltrace.CTFScope.EVENT_FIELDS)
+
 
 def parse_event(event, field_parsers):
     """
@@ -103,6 +108,7 @@ def print_family_str(field_val):
 
 ############################ common parsers - end #############################
 
+
 ############################ evpn parsers - start #############################
 def parse_frr_bgp_evpn_mac_ip_zsend(event):
     """
@@ -114,12 +120,15 @@ def parse_frr_bgp_evpn_mac_ip_zsend(event):
     ctf_integer_network_hex(unsigned int, vtep, vtep.s_addr)
     ctf_array(unsigned char, esi, esi, sizeof(esi_t))
     """
-    field_parsers = {"ip": print_ip_addr,
-                     "mac": print_mac,
-                     "esi": print_esi,
-                     "vtep": print_net_ipv4_addr}
+    field_parsers = {
+        "ip": print_ip_addr,
+        "mac": print_mac,
+        "esi": print_esi,
+        "vtep": print_net_ipv4_addr,
+    }
 
     parse_event(event, field_parsers)
+
 
 def parse_frr_bgp_evpn_bum_vtep_zsend(event):
     """
@@ -132,6 +141,7 @@ def parse_frr_bgp_evpn_bum_vtep_zsend(event):
 
     parse_event(event, field_parsers)
 
+
 def parse_frr_bgp_evpn_mh_nh_rmac_send(event):
     """
     bgp evpn nh-rmac parser; raw format -
@@ -141,16 +151,17 @@ def parse_frr_bgp_evpn_mh_nh_rmac_send(event):
 
     parse_event(event, field_parsers)
 
+
 def parse_frr_bgp_evpn_mh_local_es_add_zrecv(event):
     """
     bgp evpn local-es parser; raw format -
     ctf_array(unsigned char, esi, esi, sizeof(esi_t))
     ctf_integer_network_hex(unsigned int, vtep, vtep.s_addr)
     """
-    field_parsers = {"esi": print_esi,
-                     "vtep": print_net_ipv4_addr}
+    field_parsers = {"esi": print_esi, "vtep": print_net_ipv4_addr}
 
     parse_event(event, field_parsers)
+
 
 def parse_frr_bgp_evpn_mh_local_es_del_zrecv(event):
     """
@@ -161,6 +172,7 @@ def parse_frr_bgp_evpn_mh_local_es_del_zrecv(event):
 
     parse_event(event, field_parsers)
 
+
 def parse_frr_bgp_evpn_mh_local_es_evi_add_zrecv(event):
     """
     bgp evpn local-es-evi parser; raw format -
@@ -170,6 +182,7 @@ def parse_frr_bgp_evpn_mh_local_es_evi_add_zrecv(event):
 
     parse_event(event, field_parsers)
 
+
 def parse_frr_bgp_evpn_mh_local_es_evi_del_zrecv(event):
     """
     bgp evpn local-es-evi parser; raw format -
@@ -178,6 +191,7 @@ def parse_frr_bgp_evpn_mh_local_es_evi_del_zrecv(event):
     field_parsers = {"esi": print_esi}
 
     parse_event(event, field_parsers)
+
 
 def parse_frr_bgp_evpn_mh_es_evi_vtep_add(event):
     """
@@ -189,6 +203,7 @@ def parse_frr_bgp_evpn_mh_es_evi_vtep_add(event):
 
     parse_event(event, field_parsers)
 
+
 def parse_frr_bgp_evpn_mh_es_evi_vtep_del(event):
     """
     bgp evpn remote ead evi remote vtep del; raw format -
@@ -198,6 +213,7 @@ def parse_frr_bgp_evpn_mh_es_evi_vtep_del(event):
                      "vtep": print_net_ipv4_addr}
 
     parse_event(event, field_parsers)
+
 
 def parse_frr_bgp_evpn_mh_local_ead_es_evi_route_upd(event):
     """
@@ -209,6 +225,7 @@ def parse_frr_bgp_evpn_mh_local_ead_es_evi_route_upd(event):
 
     parse_event(event, field_parsers)
 
+
 def parse_frr_bgp_evpn_mh_local_ead_es_evi_route_del(event):
     """
     bgp evpn local ead evi vtep del; raw format -
@@ -218,6 +235,7 @@ def parse_frr_bgp_evpn_mh_local_ead_es_evi_route_del(event):
                      "vtep": print_net_ipv4_addr}
 
     parse_event(event, field_parsers)
+
 
 def parse_frr_bgp_evpn_local_vni_add_zrecv(event):
     """
@@ -230,6 +248,7 @@ def parse_frr_bgp_evpn_local_vni_add_zrecv(event):
 
     parse_event(event, field_parsers)
 
+
 def parse_frr_bgp_evpn_local_l3vni_add_zrecv(event):
     """
     bgp evpn local-l3vni parser; raw format -
@@ -237,11 +256,14 @@ def parse_frr_bgp_evpn_local_l3vni_add_zrecv(event):
     ctf_array(unsigned char, svi_rmac, svi_rmac, sizeof(struct ethaddr))
     ctf_array(unsigned char, vrr_rmac, vrr_rmac, sizeof(struct ethaddr))
     """
-    field_parsers = {"vtep": print_net_ipv4_addr,
-                     "svi_rmac": print_mac,
-                     "vrr_rmac": print_mac}
+    field_parsers = {
+        "vtep": print_net_ipv4_addr,
+        "svi_rmac": print_mac,
+        "vrr_rmac": print_mac,
+    }
 
     parse_event(event, field_parsers)
+
 
 def parse_frr_bgp_evpn_local_macip_add_zrecv(event):
     """
@@ -256,6 +278,7 @@ def parse_frr_bgp_evpn_local_macip_add_zrecv(event):
 
     parse_event(event, field_parsers)
 
+
 def parse_frr_bgp_evpn_local_macip_del_zrecv(event):
     """
     bgp evpn local-mac-ip del parser; raw format -
@@ -267,15 +290,19 @@ def parse_frr_bgp_evpn_local_macip_del_zrecv(event):
 
     parse_event(event, field_parsers)
 
+
 def parse_frr_bgp_evpn_advertise_type5(event):
     """
     local originated type-5 route
     """
-    field_parsers = {"ip": print_ip_addr,
-                     "rmac": print_mac,
-                     "vtep": print_net_ipv4_addr}
+    field_parsers = {
+        "ip": print_ip_addr,
+        "rmac": print_mac,
+        "vtep": print_net_ipv4_addr,
+    }
 
     parse_event(event, field_parsers)
+
 
 def parse_frr_bgp_evpn_withdraw_type5(event):
     """
@@ -285,7 +312,9 @@ def parse_frr_bgp_evpn_withdraw_type5(event):
 
     parse_event(event, field_parsers)
 
+
 ############################ evpn parsers - end *#############################
+
 
 def main():
     """
@@ -340,6 +369,7 @@ def main():
             event_parser(event)
         else:
             parse_event(event, {})
+
 
 if __name__ == "__main__":
     main()

--- a/tools/frr_babeltrace.py
+++ b/tools/frr_babeltrace.py
@@ -79,6 +79,28 @@ def parse_event(event, field_parsers):
         else:
             field_info[field] = event.get(field)
     print(event.name, field_info)
+
+
+def print_family_str(field_val):
+    """
+    pretty print kernel family to string
+    """
+    if field_val == socket.AF_INET:
+        cmd_str = "ipv4"
+    elif field_val == socket.AF_INET6:
+        cmd_str = "ipv6"
+    elif field_val == socket.AF_BRIDGE:
+        cmd_str = "bridge"
+    elif field_val == 128:  # RTNL_FAMILY_IPMR:
+        cmd_str = "ipv4MR"
+    elif field_val == 129:  # RTNL_FAMILY_IP6MR:
+        cmd_str = "ipv6MR"
+    else:
+        cmd_str = "Invalid family"
+
+    return cmd_str
+
+
 ############################ common parsers - end #############################
 
 ############################ evpn parsers - start #############################

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -3683,6 +3683,13 @@ netlink_vxlan_flood_update_ctx(const struct zebra_dplane_ctx *ctx, int cmd,
 	if (dplane_ctx_get_type(ctx) != 0)
 		proto = zebra2proto(dplane_ctx_get_type(ctx));
 
+	if (IS_ZEBRA_DEBUG_KERNEL)
+		zlog_debug("Tx %s family %s IF %s(%u) VNI %u MAC %pEA VTEP %pIA vid %u",
+			   nl_msg_type_to_str(cmd), nl_family_to_str(PF_BRIDGE),
+			   dplane_ctx_get_ifname(ctx), dplane_ctx_get_ifindex(ctx),
+			   dplane_ctx_neigh_get_vni(ctx), &dst_mac,
+			   dplane_ctx_neigh_get_ipaddr(ctx), dplane_ctx_mac_get_vlan(ctx));
+
 	return netlink_neigh_update_msg_encode(
 		ctx, cmd, (const void *)&dst_mac, ETH_ALEN,
 		dplane_ctx_neigh_get_ipaddr(ctx), false, PF_BRIDGE, 0, NTF_SELF,

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -4755,8 +4755,14 @@ void zebra_vxlan_remote_vtep_add(vrf_id_t vrf_id, vni_t vni,
 	zif = ifp->info;
 
 	/* If down or not mapped to a bridge, we're done. */
-	if (!if_is_operative(ifp) || !zif->brslave_info.br_if)
+	if (!if_is_operative(ifp) || !zif->brslave_info.br_if) {
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug(
+				"%s VNI %u VTEP %pI4 ifp %s oper %u br_if %u skipping update",
+				__func__, zevpn->vni, &vtep_ip, ifp->name,
+				if_is_operative(ifp), !zif->brslave_info.br_if);
 		return;
+	}
 
 	zvtep = zebra_evpn_vtep_find(zevpn, &vtep_ip);
 	if (zvtep) {

--- a/zebra/zebra_vxlan_if.c
+++ b/zebra/zebra_vxlan_if.c
@@ -1032,7 +1032,13 @@ int zebra_vxlan_if_vni_up(struct interface *ifp, struct zebra_vxlan_vni *vnip)
 		/* If part of a bridge, inform BGP about this VNI. */
 		/* Also, read and populate local MACs and neighbors. */
 		if (zif->brslave_info.br_if) {
-			zebra_evpn_send_add_to_client(zevpn);
+			if (if_is_operative(zevpn->vxlan_if)) {
+				zebra_evpn_send_add_to_client(zevpn);
+			} else {
+				if (IS_ZEBRA_DEBUG_KERNEL || IS_ZEBRA_DEBUG_VXLAN)
+					zlog_debug("%s VNI %u vxlan_if %s oper down skipping vni up to client",
+						  __func__, zevpn->vni, zevpn->vxlan_if->name);
+			}
 			zebra_evpn_read_mac_neigh(zevpn, ifp);
 		}
 	}


### PR DESCRIPTION

The issue is when bridge flap lead to failure of Type-2/Type-3 route installation.
Upon VxLAN device flap, the associated vlan-vni mapping is processed
before the VxLAN device up netlink notification.

Fix:
When VLAN-VNI mapping is updated, do not set the L2VNI up event
if the associated VXLAN device is not up. This may result in bgp
synced remote routes to skip installing in Zebra and onwards (Kernel).


Signed-off-by: Chirag Shah <chirag@nvidia.com>