### PR TITLE
bgpd: Do not reset peers on suppress-fib toggling

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -463,6 +463,10 @@ void bgp_suppress_fib_pending_set(struct bgp *bgp, bool set)
 	if (bgp->inst_type == BGP_INSTANCE_TYPE_VIEW)
 		return;
 
+	/* Do nothing if already in a desired state */
+	if (set == !!CHECK_FLAG(bgp->flags, BGP_FLAG_SUPPRESS_FIB_PENDING))
+		return;
+
 	if (set) {
 		SET_FLAG(bgp->flags, BGP_FLAG_SUPPRESS_FIB_PENDING);
 		/* Send msg to zebra for the first instance of bgp enabled


### PR DESCRIPTION
Closes https://github.com/FRRouting/frr/issues/17485