### PR TITLE
tools: Add missing keywords in frr-reload

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -255,7 +255,9 @@ ctx_keywords = {
     },
     "router rip": {},
     "router ripng": {},
-    "router isis ": {},
+    "router isis ": {
+        "segment-routing srv6": {},
+    },
     "router openfabric ": {},
     "router ospf": {},
     "router ospf6": {},

--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -256,7 +256,9 @@ ctx_keywords = {
     "router rip": {},
     "router ripng": {},
     "router isis ": {
-        "segment-routing srv6": {},
+        "segment-routing srv6": {
+            "node-msd": {},
+        },
     },
     "router openfabric ": {},
     "router ospf": {},


### PR DESCRIPTION
Add missing keywords `segment-routing srv6` and `node-msd` in  frr-reload.

Fix the errors below:

```
[58564|mgmtd] sending configuration
[58565|zebra] sending configuration,
line 10: % Unknown command[52]:  node-msd
[58573|isisd] sending configuration
[58565|zebra] Configuration file[/etc/frr/frr.conf] processing failure: 2
```

```
[58564|mgmtd] sending configuration
[58565|zebra] sending configuration,
line 14: % Unknown command[52]:  max-segs-left 3
line 18: % Unknown command[52]:  max-end-pop 3
line 22: % Unknown command[52]:  max-h-encaps 2
line 26: % Unknown command[52]:  max-end-d 5
[58573|isisd] sending configuration
[58565|zebra] Configuration file[/etc/frr/frr.conf] processing failure: 2
```