### PR TITLE
ospfd: Correct invalid SR-MPLS output label

### DIFF
--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -1334,6 +1334,12 @@ static void update_out_nhlfe(struct hash_bucket *bucket, void *args)
 			continue;
 
 		for (ALL_LIST_ELEMENTS_RO(srp->route->paths, pnode, path)) {
+			/* Compute NHFLE if path has not been initialized */
+			if (!path->srni.nexthop) {
+				compute_prefix_nhlfe(srp);
+				continue;
+			}
+
 			/* Skip path that has not next SR-Node as nexthop */
 			if (path->srni.nexthop != srnext)
 				continue;


### PR DESCRIPTION
When OSPFd starts, there is 2 possible scenarios for Segment Routing: 1/ Routes associated to Prefixes are not yet available i.e. Segment Routing LSA are received before LSA Type 1. In this case, the function ospf_sr_nhlfe_update() is triggered when a new SPF is launch. Thus, neighbors and output label are always synchronise with the routing table. 2/ Routes are already available i.e. LSA Type 1 are received before Segment Routing LSA, in particular the Router Information which contains the SRGB. During nhlfe computation, perfixes are leave with incomplete configuration, in particular, the SR nexthop is set to NULL. If this scenario is handle through the function update_out_nhlfe (triggered when SRGB is received or modified from a neighbor node), the output label is not correctly configured as the nexthop SR node associated to the prefix has been leave to NULL.

This patch correct this problem by calling the function compute_nhlfe() when the nexthop SR Node associated to the prefix is NULL within the update_out_nhlfe() function. Thus, we guarantee that the SR prefix is always correctly configuration indpedently of the scenario i.e. arrival of the different LSA.