### PR TITLE
tools: Add missing keyword `encapsulation` in frr-reload

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -279,7 +279,7 @@ ctx_keywords = {
             "policy ": {"candidate-path ": {}},
             "pcep": {"pcc": {}, "pce ": {}, "pce-config ": {}},
         },
-        "srv6": {"locators": {"locator ": {}}},
+        "srv6": {"locators": {"locator ": {}}, "encapsulation": {}},
     },
     "nexthop-group ": {},
     "route-map ": {},


### PR DESCRIPTION
Consider the following scenario.

You start from the configuration below:

```
!
segment-routing
 srv6
  encapsulation
   source-address fc00:0:1::1
  !
 !
!
```

Then you change the source address:

```
r1# configure
r1(config)# segment-routing
r1(config-sr)# srv6
r1(config-srv6)# encapsulation
r1(config-srv6-encap) source-address 1::1
```

And finally, reload the configuration
`python3 frr-reload.py --reload /etc/frr/frr.conf`

frr-reload returns the error below:

```
Failed to execute segment-routing  srv6   no source-address 1::1  exit exit
"segment-routing --  srv6 --   no source-address 1::1 --  exit -- exit" we failed to remove this command
% Unknown command:   no source-address 1::1

[79975|mgmtd] sending configuration
line 3: % Unknown command[76]:   source-address fc00:0:1::1
[79975|mgmtd] Configuration file[/etc/frr/frr.conf] processing failure: 2
```

The reason is that the keyword `encapsulation` is missing in frr-reload.

This patch adds the missing keyword `encapsulation`.