### PR TITLE
pimd: implement MSDP shutdown command

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -478,6 +478,10 @@ Commands available for MSDP
 
       To apply it immediately call `clear ip msdp peer A.B.C.D`.
 
+.. clicmd:: msdp shutdown
+
+   Shutdown the MSDP sessions in this PIM instance.
+
 
 .. _show-pim-information:
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -7560,6 +7560,24 @@ DEFPY_ATTR(no_ip_pim_msdp_mesh_group,
 	return ret;
 }
 
+DEFPY(msdp_shutdown,
+      msdp_shutdown_cmd,
+      "[no] msdp shutdown",
+      NO_STR
+      CFG_MSDP_STR
+      "Shutdown MSDP operation\n")
+{
+	char xpath_value[XPATH_MAXLEN];
+
+	snprintf(xpath_value, sizeof(xpath_value), "./msdp/shutdown");
+	if (no)
+		nb_cli_enqueue_change(vty, xpath_value, NB_OP_DESTROY, NULL);
+	else
+		nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, "true");
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
 static void ip_msdp_show_mesh_group(struct vty *vty, struct pim_msdp_mg *mg,
 				    struct json_object *json)
 {
@@ -8954,6 +8972,7 @@ void pim_cmd_init(void)
 	install_element(PIM_NODE, &no_pim_msdp_mesh_group_cmd);
 	install_element(PIM_NODE, &msdp_log_neighbor_changes_cmd);
 	install_element(PIM_NODE, &msdp_log_sa_changes_cmd);
+	install_element(PIM_NODE, &msdp_shutdown_cmd);
 
 	install_element(PIM_NODE, &pim_bsr_candidate_rp_cmd);
 	install_element(PIM_NODE, &pim_bsr_candidate_rp_group_cmd);

--- a/pimd/pim_msdp.h
+++ b/pimd/pim_msdp.h
@@ -216,6 +216,9 @@ struct pim_msdp {
 	uint32_t keep_alive;
 	/** MSDP global connection retry period. */
 	uint32_t connection_retry;
+
+	/** MSDP operation state. */
+	bool shutdown;
 };
 
 #define PIM_MSDP_PEER_READ_ON(mp)                                              \
@@ -327,6 +330,14 @@ void pim_msdp_peer_change_source(struct pim_msdp_peer *mp,
  */
 void pim_msdp_peer_restart(struct pim_msdp_peer *mp);
 
+/**
+ * Toggle MSDP functionality administrative state.
+ *
+ * \param pim PIM instance we want to shutdown.
+ * \param state shutdown state.
+ */
+void pim_msdp_shutdown(struct pim_instance *pim, bool state);
+
 #else /* PIM_IPV == 6 */
 static inline void pim_msdp_init(struct pim_instance *pim,
 				 struct event_loop *master)
@@ -369,6 +380,10 @@ static inline bool pim_msdp_peer_config_write(struct vty *vty,
 					      struct pim_instance *pim)
 {
 	return false;
+}
+
+static inline void pim_msdp_shutdown(struct pim_instance *pim, bool state)
+{
 }
 #endif /* PIM_IPV == 6 */
 

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -142,6 +142,12 @@ const struct frr_yang_module_info frr_pim_info = {
 			}
 		},
 		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/msdp/shutdown",
+			.cbs = {
+				.modify = pim_msdp_shutdown_modify,
+			}
+		},
+		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/msdp-mesh-groups",
 			.cbs = {
 				.create = pim_msdp_mesh_group_create,

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -56,6 +56,7 @@ int pim_msdp_keep_alive_modify(struct nb_cb_modify_args *args);
 int pim_msdp_connection_retry_modify(struct nb_cb_modify_args *args);
 int pim_msdp_log_neighbor_events_modify(struct nb_cb_modify_args *args);
 int pim_msdp_log_sa_events_modify(struct nb_cb_modify_args *args);
+int pim_msdp_shutdown_modify(struct nb_cb_modify_args *args);
 int pim_msdp_mesh_group_create(struct nb_cb_create_args *args);
 int pim_msdp_mesh_group_destroy(struct nb_cb_destroy_args *args);
 int pim_msdp_mesh_group_members_create(struct nb_cb_create_args *args);

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -1098,6 +1098,7 @@ pim6_msdp_err(pim_msdp_peer_authentication_key_modify, nb_cb_modify_args);
 pim6_msdp_err(pim_msdp_peer_authentication_key_destroy, nb_cb_destroy_args);
 pim6_msdp_err(pim_msdp_log_neighbor_events_modify, nb_cb_modify_args);
 pim6_msdp_err(pim_msdp_log_sa_events_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_shutdown_modify, nb_cb_modify_args);
 
 #if PIM_IPV != 6
 /*
@@ -1152,6 +1153,32 @@ int pim_msdp_log_sa_events_modify(struct nb_cb_modify_args *args)
 			SET_FLAG(pim->log_flags, PIM_MSDP_LOG_SA_EVENTS);
 		else
 			UNSET_FLAG(pim->log_flags, PIM_MSDP_LOG_SA_EVENTS);
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath:
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/msdp/shutdown
+ */
+int pim_msdp_shutdown_modify(struct nb_cb_modify_args *args)
+{
+	struct pim_instance *pim;
+	struct vrf *vrf;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		/* NOTHING */
+		break;
+
+	case NB_EV_APPLY:
+		vrf = nb_running_get_entry(args->dnode, NULL, true);
+		pim = vrf->info;
+		pim_msdp_shutdown(pim, yang_dnode_get_bool(args->dnode, NULL));
 		break;
 	}
 

--- a/tests/topotests/msdp_topo1/test_msdp_topo1.py
+++ b/tests/topotests/msdp_topo1/test_msdp_topo1.py
@@ -521,13 +521,56 @@ def test_msdp_log_events():
     r1_log = tgen.gears["r1"].net.getLog("log", "pimd")
 
     # Look up for informational messages that should have been enabled.
-    match = re.search(
-        "MSDP peer 192.168.1.2 state changed to established", r1_log)
+    match = re.search("MSDP peer 192.168.1.2 state changed to established", r1_log)
     assert match is not None
 
-    match = re.search(
-        r"MSDP SA \(192.168.10.100\,229.1.2.3\) created", r1_log)
+    match = re.search(r"MSDP SA \(192.168.10.100\,229.1.2.3\) created", r1_log)
     assert match is not None
+
+
+def test_msdp_shutdown():
+    "Shutdown MSDP sessions between r1, r2, r3, then check the state."
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    tgen.gears["r1"].vtysh_cmd(
+        """
+    configure terminal
+    router pim
+     msdp shutdown
+    """
+    )
+
+    r1_expect = {
+        "192.168.0.2": {
+            "state": "inactive",
+        },
+        "192.168.1.2": {
+            "state": "inactive",
+        },
+    }
+    r2_expect = {
+        "192.168.0.1": {
+            "state": "listen",
+        }
+    }
+    r3_expect = {
+        "192.168.1.1": {
+            "state": "listen",
+        }
+    }
+    for router in [("r1", r1_expect), ("r2", r2_expect), ("r3", r3_expect)]:
+        test_func = partial(
+            topotest.router_json_cmp,
+            tgen.gears[router[0]],
+            "show ip msdp peer json",
+            router[1],
+        )
+        logger.info("Waiting for {} msdp peer data".format(router[0]))
+        _, val = topotest.run_and_expect(test_func, None, count=30, wait=1)
+        assert val is None, "multicast route convergence failure"
 
 
 def test_memory_leak():

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -264,6 +264,13 @@ module frr-pim {
         description
           "Log all MSDP SA related events.";
       }
+
+      leaf shutdown {
+        type boolean;
+        default false;
+        description
+          "Shutdown MSDP functionality.";
+      }
     }
 
     list msdp-mesh-groups {


### PR DESCRIPTION
Allow user to temporarily shutdown MSDP sessions without removing any configuration.