### PR TITLE
python: clear out syntax warnings

### DIFF
--- a/python/makefile.py
+++ b/python/makefile.py
@@ -52,7 +52,7 @@ if args.dev_build:
                 "grep",
                 "-l",
                 "-P",
-                "^#\s*include.*_clippy.c",
+                r"^#\s*include.*_clippy.c",
                 "--",
                 "**.c",
             ]


### PR DESCRIPTION
Hello committers,

Thanks for maintaining the project; this is my first ever contribution. I would like to understand how are implemented routing protocols.

This PR clears out a warning seen in compilation: [non-escaped sequences now produce warnings](https://docs.python.org/fr/3/library/re.html#module-re).

Thank you,

```shell
python/makefile.py:55: SyntaxWarning: invalid escape sequence '\s'
  "^#\s*include.*_clippy.c",
```