### PR TITLE
bgpd: fix version attribute is an int, not a string

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12318,8 +12318,7 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 		} else {
 			if (incremental_print) {
 				vty_out(vty, "\"prefix\": \"%pFX\",\n", p);
-				vty_out(vty, "\"version\": \"%" PRIu64 "\",",
-					dest->version);
+				vty_out(vty, "\"version\": %" PRIu64 ",", dest->version);
 			} else {
 				json_object_string_addf(json, "prefix", "%pFX",
 							p);


### PR DESCRIPTION
The json display of the version attribute is originally an integer. It has changed, most probably mistakenly.

> {
>   "vrfId": 7,
>   "vrfName": "vrf1",
>   "tableVersion": 3,
>   "routerId": "192.0.2.1",
>   "defaultLocPrf": 100,
>   "localAS": 65500,
>   "routes": {
>     "172.31.0.1/32": {
>       "prefix": "172.31.0.1/32",
>       "version": "1",		<--- int or string ??

Let us fix it, by using the integer display instead.

Fixes: f9f2d188e398 ("bgpd: fix 'json detail' output structure")