### PR TITLE
bgpd: fix use single whitespace when displaying flowspec entries

### DIFF
--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -441,7 +441,7 @@ int bgp_show_table_flowspec(struct vty *vty, struct bgp *bgp, afi_t afi,
 	}
 	if (total_count && !use_json)
 		vty_out(vty,
-			"\nDisplayed  %ld flowspec entries\n",
+			"\nDisplayed %ld flowspec entries\n",
 			total_count);
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
There is an extra space in the 'Displayed' line of show bgp command, that should not be present.
Fix this by being consistent with the output of the other address families.

Fixes: ("a1baf9e84f71") bgpd: Use single whitespace when displaying show bgp summary