### PR TITLE
build: improve readability of `Makefile.am`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -304,12 +304,10 @@ am__v_LLVM_LD_ = $(am__v_LLVM_LD_$(AM_DEFAULT_VERBOSITY))
 am__v_LLVM_LD_0 = @echo "  LLVM.LD " $@;
 am__v_LLVM_LD_1 = 
 
-SUFFIXES += .lo.bc .o.bc
-
-.o.o.bc:
-	$(AM_V_LLVM_BC)$(COMPILE) -emit-llvm -c -o $@ $(patsubst %.o,%.c,$<)
-.lo.lo.bc:
-	$(AM_V_LLVM_BC)$(COMPILE) -emit-llvm -c -o $@ $(patsubst %.lo,%.c,$<)
+%.o.bc: %.o
+	$(AM_V_LLVM_BC)$(COMPILE) -emit-llvm -c -o $@ $*.c
+%.lo.bc: %.lo
+	$(AM_V_LLVM_BC)$(COMPILE) -emit-llvm -c -o $@ $*.c
 
 %.cg.json: %.bc tools/frr-llvm-cg
 	tools/frr-llvm-cg -o $@ $<


### PR DESCRIPTION
### Why?
Hello committers,

Thanks for maintaining the project; this is my first (up to date) contribution. I would like to understand how are implemented routing protocols.

This PR improves the readability of `Makefile.am`.

Thank you,

### How?

* replaced [suffix rules](https://www.gnu.org/software/make/manual/html_node/Suffix-Rules.html) rules by [pattern rules](https://www.gnu.org/s/make/manual/html_node/Pattern-Rules.html)
* such pattern rules are [already used in `Makefile.am`](https://github.com/FRRouting/frr/blob/22746b8d59e6e6cb77ced61bc9e0cff2ead227b5/Makefile.am#L314-L322)
* so doing, the suffixes `.lo.bc` & `.o.bc` are no more needed in `SUFFIXES`.