### PR TITLE
Docker: Add the ability to override the FRR UID during docker creation

### DIFF
--- a/docker/ubuntu-ci/Dockerfile
+++ b/docker/ubuntu-ci/Dockerfile
@@ -84,10 +84,11 @@ RUN apt update && apt upgrade -y && \
     python3 -m pip install xmltodict && \
     python3 -m pip install git+https://github.com/Exa-Networks/exabgp@0659057837cd6c6351579e9f0fa47e9fb7de7311
 
+ARG UID=1000
 RUN groupadd -r -g 92 frr && \
       groupadd -r -g 85 frrvty && \
       adduser --system --ingroup frr --home /home/frr \
-              --gecos "FRR suite" --shell /bin/bash frr && \
+              --gecos "FRR suite" -u $UID --shell /bin/bash frr && \
       usermod -a -G frrvty frr && \
       useradd -d /var/run/exabgp/ -s /bin/false exabgp && \
       echo 'frr ALL = NOPASSWD: ALL' | tee /etc/sudoers.d/frr && \


### PR DESCRIPTION
This PR adds the ability to override the UID of the FRR user with the additional docker argument `--build-arg=UID=$(id -u)`.

When using docker containers to develop FRR, it is much easier to manage copying files in and out of the container if the UID of the FRR user is also the same as the user that created the container.

For reference, I use the following commands to create my local development container:
```
docker build -t $(whoami)-$(basename `/bin/pwd`)-frr-ubuntu20:latest --build-arg=UBUNTU_VERSION=20.04 --build-arg=UID=$(id -u) -f docker/ubuntu20-ci/Dockerfile .

docker run --init -it --privileged --name $(whoami)-$(basename `/bin/pwd`)-frr-ubuntu20 -v /lib/modules:/lib/modules -v `/bin/pwd`:/home/frr/frr $(whoami)-$(basename `/bin/pwd`)-frr-ubuntu20:latest bash

docker start $(whoami)-$(basename `/bin/pwd`)-frr-ubuntu20
```