### PR TITLE
pimd: MSDP per peer SA limit

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -467,6 +467,10 @@ Commands available for MSDP
       The filtering will only take effect starting from the command
       application.
 
+.. clicmd:: msdp peer A.B.C.D sa-limit <AMOUNT>
+
+   Configure the maximum number of SAs to learn from peer.
+
 .. clicmd:: msdp peer A.B.C.D password WORD
 
    Use MD5 authentication to connect with the remote peer.

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -7578,6 +7578,29 @@ DEFPY(msdp_shutdown,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
+DEFPY(msdp_peer_sa_limit, msdp_peer_sa_limit_cmd,
+      "[no] msdp peer A.B.C.D$peer sa-limit ![(1-4294967294)$sa_limit]",
+      NO_STR
+      CFG_MSDP_STR
+      "Configure MSDP peer\n"
+      "MSDP peer address\n"
+      "Limit amount of SA\n"
+      "Maximum number of SA\n")
+{
+	const struct lyd_node *peer_node;
+	char xpath[XPATH_MAXLEN + 24];
+
+	snprintf(xpath, sizeof(xpath), "%s/msdp-peer[peer-ip='%s']", VTY_CURR_XPATH, peer_str);
+	peer_node = yang_dnode_get(vty->candidate_config->dnode, xpath);
+	if (peer_node == NULL) {
+		vty_out(vty, "%% MSDP peer %s not yet configured\n", peer_str);
+		return CMD_SUCCESS;
+	}
+
+	nb_cli_enqueue_change(vty, "./sa-limit", NB_OP_MODIFY, sa_limit_str);
+	return nb_cli_apply_changes(vty, "%s", xpath);
+}
+
 static void ip_msdp_show_mesh_group(struct vty *vty, struct pim_msdp_mg *mg,
 				    struct json_object *json)
 {
@@ -8973,6 +8996,7 @@ void pim_cmd_init(void)
 	install_element(PIM_NODE, &msdp_log_neighbor_changes_cmd);
 	install_element(PIM_NODE, &msdp_log_sa_changes_cmd);
 	install_element(PIM_NODE, &msdp_shutdown_cmd);
+	install_element(PIM_NODE, &msdp_peer_sa_limit_cmd);
 
 	install_element(PIM_NODE, &pim_bsr_candidate_rp_cmd);
 	install_element(PIM_NODE, &pim_bsr_candidate_rp_group_cmd);

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -359,6 +359,15 @@ void pim_msdp_sa_ref(struct pim_instance *pim, struct pim_msdp_peer *mp,
 	struct rp_info *rp_info;
 	struct prefix grp;
 
+	/* Check peer SA limit. */
+	if (mp && mp->sa_limit && mp->sa_cnt >= mp->sa_limit) {
+		if (pim_msdp_log_sa_events(pim))
+			zlog_debug("MSDP peer %pI4 reject SA (%pI4, %pI4): SA limit %u of %u",
+				   &mp->peer, &sg->src, &sg->grp, mp->sa_cnt, mp->sa_limit);
+
+		return;
+	}
+
 	sa = pim_msdp_sa_add(pim, sg, rp);
 	if (!sa) {
 		return;
@@ -1315,6 +1324,9 @@ bool pim_msdp_peer_config_write(struct vty *vty, struct pim_instance *pim)
 		if (mp->acl_out)
 			vty_out(vty, " msdp peer %pI4 sa-filter %s out\n",
 				&mp->peer, mp->acl_out);
+
+		if (mp->sa_limit)
+			vty_out(vty, " msdp peer %pI4 sa-limit %u\n", &mp->peer, mp->sa_limit);
 
 		written = true;
 	}

--- a/pimd/pim_msdp.h
+++ b/pimd/pim_msdp.h
@@ -152,6 +152,9 @@ struct pim_msdp_peer {
 	char *acl_in;
 	/** SA output access list name. */
 	char *acl_out;
+
+	/** SA maximum amount. */
+	uint32_t sa_limit;
 };
 
 struct pim_msdp_mg_mbr {

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -209,6 +209,13 @@ const struct frr_yang_module_info frr_pim_info = {
 			}
 		},
 		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/msdp-peer/sa-limit",
+			.cbs = {
+				.modify = pim_msdp_peer_sa_limit_modify,
+				.destroy = pim_msdp_peer_sa_limit_destroy,
+			}
+		},
+		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/mlag",
 			.cbs = {
 				.create = routing_control_plane_protocols_control_plane_protocol_pim_address_family_mlag_create,

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -76,6 +76,8 @@ int pim_msdp_peer_sa_filter_out_destroy(struct nb_cb_destroy_args *args);
 int pim_msdp_peer_authentication_type_modify(struct nb_cb_modify_args *args);
 int pim_msdp_peer_authentication_key_modify(struct nb_cb_modify_args *args);
 int pim_msdp_peer_authentication_key_destroy(struct nb_cb_destroy_args *args);
+int pim_msdp_peer_sa_limit_modify(struct nb_cb_modify_args *args);
+int pim_msdp_peer_sa_limit_destroy(struct nb_cb_destroy_args *args);
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_mlag_create(
 	struct nb_cb_create_args *args);
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_mlag_destroy(

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -1595,7 +1595,7 @@ int pim_msdp_peer_sa_limit_modify(struct nb_cb_modify_args *args)
 		break;
 	case NB_EV_APPLY:
 		mp = nb_running_get_entry(args->dnode, NULL, true);
-		/* TODO: apply limitation. */
+		mp->sa_limit = yang_dnode_get_uint32(args->dnode, NULL);
 		break;
 	}
 
@@ -1614,7 +1614,7 @@ int pim_msdp_peer_sa_limit_destroy(struct nb_cb_destroy_args *args)
 		break;
 	case NB_EV_APPLY:
 		mp = nb_running_get_entry(args->dnode, NULL, true);
-		/* TODO: remove limitation. */
+		mp->sa_limit = 0;
 		break;
 	}
 

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -1580,6 +1580,48 @@ int pim_msdp_peer_sa_filter_out_destroy(struct nb_cb_destroy_args *args)
 }
 
 /*
+ * XPath:
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/msdp-peer/sa-limit
+ */
+int pim_msdp_peer_sa_limit_modify(struct nb_cb_modify_args *args)
+{
+	struct pim_msdp_peer *mp;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		/* NOTHING */
+		break;
+	case NB_EV_APPLY:
+		mp = nb_running_get_entry(args->dnode, NULL, true);
+		/* TODO: apply limitation. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int pim_msdp_peer_sa_limit_destroy(struct nb_cb_destroy_args *args)
+{
+	struct pim_msdp_peer *mp;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		/* NOTHING */
+		break;
+	case NB_EV_APPLY:
+		mp = nb_running_get_entry(args->dnode, NULL, true);
+		/* TODO: remove limitation. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/mlag
  */
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_mlag_create(

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -337,6 +337,12 @@ module frr-pim {
       }
 
       uses msdp-authentication;
+
+      leaf sa-limit {
+        type uint32;
+        description
+          "Peer SA maximum limit.";
+      }
     }
 
     container mlag {


### PR DESCRIPTION
MSDP feature to help limit the amount of SAs a peer can learn. This is useful to keep the amount of SAs to a certain amount or to handle misconfigured peers.