### PR TITLE
doc:Fix bgp doc warning

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2931,6 +2931,7 @@ BGP Extended Communities in Route Map
    match on to for the purpose of determining what type of SR-TE Policy Tunnel
    a BGP route can resolve over, and it also shows the order for resolving the
    BGP route if there are different tunnels.
+
    - ``00`` Can match on a specific endpoint only which should be the nexthop
      of the route(Default Setting).
    - ``01`` Can match on a specific endpoint or a null endpoint.


### PR DESCRIPTION
Fix: doc build issues

Introduces these new doc build issues:

```
/home/sharpd/frr4/doc/user/bgp.rst:2942: WARNING: Unexpected indentation.
/home/sharpd/frr4/doc/user/bgp.rst:2943: WARNING: Block quote ends without a blank line; unexpected unindent.
```