### PR TITLE
lib:fix stream_get out of bounds

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2377,7 +2377,7 @@ static bool zapi_nexthop_update_decode(struct stream *s, struct prefix *match,
 	STREAM_GETW(s, nhr->nexthop_num);
 
 	for (i = 0; i < nhr->nexthop_num; i++) {
-		if (zapi_nexthop_decode(s, &(nhr->nexthops[i]), 0, 0) != 0)
+		if (zapi_nexthop_decode(s, &(nhr->nexthops[i]), 0, nhr->message) != 0)
 			return false;
 	}
 


### PR DESCRIPTION
Description
If nexthop has ‘srte_color', zapi_nexthop_decode must have 'message' parameter, or stream_get will out of bounds.

Version
 show version
FRRouting 10.3-dev-my-manual-build (router1) on Linux(4.15.0-213-generic).
Copyright 1996-2005 Kunihiro Ishiguro, et al.


2024/11/27 09:38:54 BGP: [S48XV-GT1WC][EC 100663311] stream_getw2: Attempt to get  out of bounds
2024/11/27 09:38:54 BGP: [RF6RD-ZCBTC][EC 100663311] &(struct stream): 0x562aa0765690, size: 41112, getp: 66, endp: 67
2024/11/27 09:38:54 BGP: Backtrace for 11 stack frames:
2024/11/27 09:38:54 BGP: [bt 0] /lib/libfrr.so.0(zlog_backtrace+0x4a) [0x7fd14ab4dd97]
2024/11/27 09:38:54 BGP: [bt 1] /lib/libfrr.so.0(stream_getw2+0x252) [0x7fd14abeade7]
2024/11/27 09:38:54 BGP: [bt 2] /lib/libfrr.so.0(+0x272b35) [0x7fd14ac40b35]
2024/11/27 09:38:54 BGP: [bt 3] /lib/libfrr.so.0(+0x27bc82) [0x7fd14ac49c82]
2024/11/27 09:38:54 BGP: [bt 4] /lib/libfrr.so.0(+0x27c497) [0x7fd14ac4a497]
2024/11/27 09:38:54 BGP: [bt 5] /lib/libfrr.so.0(event_call+0x137) [0x7fd14ac06d62]
2024/11/27 09:38:54 BGP: [bt 6] /lib/libfrr.so.0(frr_run+0x488) [0x7fd14ab37e6f]
2024/11/27 09:38:54 BGP: [bt 7] /usr/lib/frr/bgpd(main+0x97a) [0x562a9e0f23ac]
2024/11/27 09:38:54 BGP: [bt 8] /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7fd14a697d90]
2024/11/27 09:38:54 BGP: [bt 9] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7fd14a697e40]
2024/11/27 09:38:54 BGP: [bt 10] /usr/lib/frr/bgpd(_start+0x25) [0x562a9e0ef265]
2024/11/27 09:38:54 BGP: [SR3FZ-3N08V] failed to decode nexthop update
2024/11/27 09:38:55 BGP: [M59KS-A3ZXZ] bgp_update_receive: rcvd End-of-RIB for IPv4 VPN from 1::1 in vrf default