### PR TITLE
zebra: fix wrong nexthop status for kernel routes

### DIFF
--- a/tests/topotests/zebra_multiple_connected/r1/ip_route_kernel_interface_down.json
+++ b/tests/topotests/zebra_multiple_connected/r1/ip_route_kernel_interface_down.json
@@ -1,0 +1,20 @@
+{
+  "5.5.6.7/32":[
+    {
+      "prefix":"5.5.6.7/32",
+      "prefixLen":32,
+      "protocol":"kernel",
+      "vrfName":"default",
+      "internalFlags":0,
+      "internalNextHopNum":1,
+      "internalNextHopActiveNum":0,
+      "nexthops":[
+        {
+          "flags":0,
+          "interfaceName":"r1-eth2"
+        }
+      ]
+
+    }
+  ]
+}

--- a/tests/topotests/zebra_multiple_connected/r1/ip_route_kernel_interface_up.json
+++ b/tests/topotests/zebra_multiple_connected/r1/ip_route_kernel_interface_up.json
@@ -1,0 +1,21 @@
+{
+  "5.5.6.7/32":[
+    {
+      "prefix":"5.5.6.7/32",
+      "prefixLen":32,
+      "protocol":"kernel",
+      "vrfName":"default",
+      "internalFlags":8,
+      "internalNextHopNum":1,
+      "internalNextHopActiveNum":1,
+      "nexthops":[
+        {
+          "flags":3,
+          "fib":true,
+          "interfaceName":"r1-eth2",
+          "active":true
+        }
+      ]
+    }
+  ]
+}

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -972,6 +972,8 @@ void if_up(struct interface *ifp, bool install_connected)
 	event_ignore_late_timer(zif->speed_update);
 
 	if_addr_wakeup(ifp);
+
+	rib_update_handle_vrf_all(RIB_UPDATE_KERNEL, ZEBRA_ROUTE_KERNEL);
 }
 
 /* Interface goes down.  We have to manage different behavior of based

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2648,7 +2648,7 @@ static unsigned nexthop_active_check(struct route_node *rn,
 
 		ifp = if_lookup_by_index(nexthop->ifindex, nexthop->vrf_id);
 
-		if (ifp && ifp->vrf->vrf_id == vrf_id && if_is_up(ifp)) {
+		if (ifp && ifp->vrf->vrf_id == vrf_id && if_is_up(ifp) && if_is_operative(ifp)) {
 			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 			goto skip_check;
 		}

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1480,7 +1480,7 @@ static void rib_process(struct route_node *rn)
 		rib_process_update_fib(zvrf, rn, old_fib, new_fib);
 	else if (new_fib)
 		rib_process_add_fib(zvrf, rn, new_fib);
-	else if (old_fib)
+	else if (old_fib && !RIB_SYSTEM_ROUTE(old_fib))
 		rib_process_del_fib(zvrf, rn, old_fib);
 
 	/* Remove all RE entries queued for removal */


### PR DESCRIPTION
The kernel routes are wronlgy active even the nexthop interface is linkdown.                                                                                                 
                                                                                                                                                                             
Use `ip link set dev <interface> down` on the other box to set the box's                                                                                                     
nexthop interface linkdown. The kernel routes will be kept as `linkdown`,                                                                                                    
but are still with active nexthop in `zebra`.                                                                                                                                
                                                                                                                                                                             
Add three changes for kernel routes in this commit:                                                                                                                          
                                                                                                                                                                             
1) The active nexthop should be the operative interface.                                                                                                                     
2) Don't uninstall the kernel routes from `zebra` even no active nexthops.                                                                                                   
   (It doesn't affect the kernel routes' deletion from kernel netlink messages.)                                                                                             
3) Update the kernel routes when the nexthop interface becomes up.                                                                                                           
                                                                                                                                                                             
Before: (during nexthop interface is linkdown)                                                                                                                               
```                                                                                                                                                                          
K>* 3.3.3.3/32 [0/0] via 88.88.88.1, enp2s0, weight 1, 00:00:14                                                                                                              
```                                                                                                                                                                          
                                                                                                                                                                             
After: (during nexthop interface is linkdown)                                                                                                                                
```                                                                                                                                                                          
K   3.3.3.3/32 [0/0] via 88.88.88.1, enp2s0 inactive, weight 1, 00:00:07                                                                                                     
```  