### PR TITLE
bgpd: fix peer up message for loc-rib not sent

### DIFF
--- a/tests/topotests/bgp_bmp/bgpbmp.py
+++ b/tests/topotests/bgp_bmp/bgpbmp.py
@@ -216,11 +216,16 @@ def bmp_check_for_peer_message(
     ]
 
     # get the list of pairs (prefix, policy, seq) for the given message type
-    peers = [
-        m["peer_ip"]
-        for m in messages
-        if "peer_ip" in m.keys() and m["bmp_log_type"] == bmp_log_type
-    ]
+    peers = []
+    for m in messages:
+        if (
+            "peer_ip" in m.keys()
+            and m["peer_ip"] != "0.0.0.0"
+            and m["bmp_log_type"] == bmp_log_type
+        ):
+            peers.append(m["peer_ip"])
+        elif m["policy"] == "loc-rib" and m["bmp_log_type"] == bmp_log_type:
+            peers.append("0.0.0.0")
 
     # check for prefixes
     for ep in expected_peers:

--- a/tests/topotests/bgp_bmp/test_bgp_bmp_1.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_1.py
@@ -192,7 +192,7 @@ def test_peer_up():
     """
 
     tgen = get_topogen()
-    peers = ["192.168.0.2", "192:168::2"]
+    peers = ["192.168.0.2", "192:168::2", "0.0.0.0"]
 
     logger.info("checking for BMP peers up messages")
 

--- a/tests/topotests/bgp_bmp/test_bgp_bmp_2.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_2.py
@@ -200,7 +200,7 @@ def test_peer_up():
     """
 
     tgen = get_topogen()
-    peers = ["192.168.0.2", "192:168::2"]
+    peers = ["192.168.0.2", "192:168::2", "0.0.0.0"]
 
     logger.info("checking for BMP peers up messages")
 


### PR DESCRIPTION
At startup, there is no peer up message for loc-rib instance peer. Instead, a global peer up message with address 0.0.0.0 is sent.

Such message is wrong, violates the RFC and should be dropped by a strict collector. Actually, the peer type message sent is wrong, and should be set to LOC-RIB peer type.

Fix this by changing the peer type of peer up message to either loc-rib or global instance peer type.

Fixes: 035304c25a38 ("bgpd: bmp loc-rib peer up/down for vrfs")