### PR TITLE
bgpd: CLI Changes

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -17333,20 +17333,23 @@ DEFUN (show_bgp_instance_all_ipv6_updgrps,
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_bgp_l2vpn_evpn_updgrps,
-	show_bgp_l2vpn_evpn_updgrps_cmd,
-	"show [ip] bgp l2vpn evpn update-groups",
-	SHOW_STR
-	IP_STR
-	BGP_STR
-	"l2vpn address family\n"
-	"evpn sub-address family\n"
-	"Detailed info about dynamic update groups\n")
+DEFPY(show_bgp_l2vpn_evpn_updgrps,
+      show_bgp_l2vpn_evpn_updgrps_cmd,
+      "show [ip] bgp l2vpn evpn update-groups [subgroup-id (1-1000)$subgrpid] [json$json]",
+      SHOW_STR
+      IP_STR
+      BGP_STR
+      "l2vpn address family\n"
+      "evpn sub-address family\n"
+      "Detailed info about dynamic update groups\n"
+      "Specific subgroup to display detailed info\n"
+      "Subgroup identifier\n"
+      JSON_STR)
 {
 	char *vrf = NULL;
-	uint64_t subgrp_id = 0;
+	bool uj = !!json;
 
-	bgp_show_update_groups(vty, vrf, AFI_L2VPN, SAFI_EVPN, subgrp_id, 0);
+	bgp_show_update_groups(vty, vrf, AFI_L2VPN, SAFI_EVPN, subgrpid, uj);
 	return CMD_SUCCESS;
 }
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -13589,9 +13589,8 @@ static void bgp_show_neighbor_graceful_restart_capability_per_afi_safi(
 			 */
 			if (CHECK_FLAG(peer->flags,
 				       PEER_FLAG_GRACEFUL_RESTART)) {
-				json_object_int_add(json_timer,
-						    "selectionDeferralTimer",
-						    peer->bgp->stalepath_time);
+				json_object_int_add(json_timer, "selectionDeferralTimer",
+						    peer->bgp->select_defer_time);
 			}
 
 			if (peer->bgp->gr_info[afi][safi].t_select_deferral !=

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -5002,6 +5002,12 @@ Displaying Update Group Information
 
    Display Information about update-group events in FRR.
 
+.. clicmd:: show [ip] bgp l2vpn evpn update-groups [subgroup-id (1-1000)] [json]
+
+   Display information about L2VPN EVPN update-groups being used.
+   If subgroup-id is specified, only display information about that particular
+   subgroup. The optional json parameter formats the output as JSON.
+
 Displaying Nexthop Information
 ------------------------------
 .. clicmd:: show [ip] bgp [<view|vrf> VIEWVRFNAME] nexthop ipv4 [A.B.C.D] [detail] [json]


### PR DESCRIPTION
This PR has below changes
* Add new json CLI “show ip bgp l2vpn evpn update-groups json”
* Add command to display EVPN type-5 per-prefix
* Fixed selectionDeferralTimer JSON field as it was displaying stalepath timer value instead of select_defer_time