### PR TITLE
BMP Peer Distinguisher support

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -481,6 +481,9 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 		/* TODO: remove this when other RD and local instances supported */
 		peer_type = BMP_PEER_TYPE_GLOBAL_INSTANCE;
 
+	if (is_locrib == false)
+		peer_type = BMP_PEER_TYPE_GLOBAL_INSTANCE;
+
 #define BGP_BMP_MAX_PACKET_SIZE	1024
 #define BMP_PEERUP_INFO_TYPE_STRING 0
 	s = stream_new(BGP_MAX_PACKET_SIZE);
@@ -552,9 +555,7 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 
 		bmp_common_hdr(s, BMP_VERSION_3,
 				BMP_TYPE_PEER_DOWN_NOTIFICATION);
-		bmp_per_peer_hdr(s, peer->bgp, peer, 0,
-				 BMP_PEER_TYPE_GLOBAL_INSTANCE, 0,
-				 &uptime_real);
+		bmp_per_peer_hdr(s, peer->bgp, peer, 0, peer_type, 0, &uptime_real);
 
 		type_pos = stream_get_endp(s);
 		stream_putc(s, 0);	/* placeholder for down reason */

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -474,12 +474,6 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 	peer_type = bmp_get_peer_type(peer);
 	if (peer_type == BMP_PEER_TYPE_LOC_RIB_INSTANCE)
 		is_locrib = true;
-	else
-		/* TODO: remove this when other RD and local instances supported */
-		peer_type = BMP_PEER_TYPE_GLOBAL_INSTANCE;
-
-	if (is_locrib == false)
-		peer_type = BMP_PEER_TYPE_GLOBAL_INSTANCE;
 
 	if (bmp_get_peer_distinguisher(peer->bgp, AFI_UNSPEC, peer_type, &peer_distinguisher)) {
 		zlog_warn("skipping bmp message for peer %s: can't get peer distinguisher",

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -490,7 +490,7 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 
 		bmp_common_hdr(s, BMP_VERSION_3,
 				BMP_TYPE_PEER_UP_NOTIFICATION);
-		bmp_per_peer_hdr(s, peer->bgp, peer, 0, peer_type, 0, &uptime_real);
+		bmp_per_peer_hdr(s, peer->bgp, peer, 0, peer_type, peer_distinguisher, &uptime_real);
 
 		/* Local Address (16 bytes) */
 		if (is_locrib)
@@ -552,7 +552,7 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 
 		bmp_common_hdr(s, BMP_VERSION_3,
 				BMP_TYPE_PEER_DOWN_NOTIFICATION);
-		bmp_per_peer_hdr(s, peer->bgp, peer, 0, peer_type, 0, &uptime_real);
+		bmp_per_peer_hdr(s, peer->bgp, peer, 0, peer_type, peer_distinguisher, &uptime_real);
 
 		type_pos = stream_get_endp(s);
 		stream_putc(s, 0);	/* placeholder for down reason */

--- a/tests/topotests/bgp_bmp/bgpbmp.py
+++ b/tests/topotests/bgp_bmp/bgpbmp.py
@@ -206,6 +206,8 @@ def bmp_check_for_peer_message(
     # get the list of pairs (prefix, policy, seq) for the given message type
     peers = []
     for m in messages:
+        if is_rd_instance and m["peer_distinguisher"] == "0:0":
+            continue
         if (
             "peer_ip" in m.keys()
             and m["peer_ip"] != "0.0.0.0"

--- a/tests/topotests/bgp_bmp/bgpbmp.py
+++ b/tests/topotests/bgp_bmp/bgpbmp.py
@@ -187,7 +187,7 @@ def bmp_check_for_prefixes(
 
 
 def bmp_check_for_peer_message(
-    expected_peers, bmp_log_type, bmp_collector, bmp_log_file
+    expected_peers, bmp_log_type, bmp_collector, bmp_log_file, is_rd_instance=False
 ):
     """
     Check for the presence of a peer up message for the peer
@@ -211,6 +211,8 @@ def bmp_check_for_peer_message(
             and m["peer_ip"] != "0.0.0.0"
             and m["bmp_log_type"] == bmp_log_type
         ):
+            if is_rd_instance and m["peer_type"] != "route distinguisher instance":
+                continue
             peers.append(m["peer_ip"])
         elif m["policy"] == "loc-rib" and m["bmp_log_type"] == bmp_log_type:
             peers.append("0.0.0.0")

--- a/tests/topotests/bgp_bmp/bgpbmp.py
+++ b/tests/topotests/bgp_bmp/bgpbmp.py
@@ -164,18 +164,6 @@ def bmp_check_for_prefixes(
                 for k, v in sorted(m.items())
                 # filter out variable keys
                 if k not in ["timestamp", "seq", "nxhp_link-local"]
-                and (
-                    # When policy is loc-rib, the peer-distinguisher is 0:0
-                    # for the default VRF or the RD if any or the 0:<vrf_id>.
-                    # 0:<vrf_id> is used to distinguished. RFC7854 says: "If the
-                    # peer is a "Local Instance Peer", it is set to a unique,
-                    # locally defined value." The value is not tested because it
-                    # is variable.
-                    k != "peer_distinguisher"
-                    or policy != loc_rib
-                    or v == "0:0"
-                    or not v.startswith("0:")
-                )
             }
 
     # build expected JSON files

--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-loc-rib-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-loc-rib-step1.json
@@ -10,6 +10,7 @@
                 "origin": "IGP",
                 "peer_asn": 65501,
                 "peer_bgp_id": "192.168.0.1",
+                "peer_distinguisher": "444:1",
                 "peer_type": "loc-rib instance",
                 "policy": "loc-rib"
             },
@@ -23,6 +24,7 @@
                 "origin": "IGP",
                 "peer_asn": 65501,
                 "peer_bgp_id": "192.168.0.1",
+                "peer_distinguisher": "555:1",
                 "peer_type": "loc-rib instance",
                 "policy": "loc-rib",
                 "safi": 1

--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-post-policy-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-post-policy-step1.json
@@ -10,7 +10,7 @@
                 "origin": "IGP",
                 "peer_asn": 65502,
                 "peer_bgp_id": "192.168.0.2",
-                "peer_distinguisher": "0:0",
+                "peer_distinguisher": "444:1",
                 "peer_ip": "192.168.0.2",
                 "peer_type": "route distinguisher instance",
                 "policy": "post-policy"
@@ -25,7 +25,7 @@
                 "origin": "IGP",
                 "peer_asn": 65502,
                 "peer_bgp_id": "192.168.0.2",
-                "peer_distinguisher": "0:0",
+                "peer_distinguisher": "555:1",
                 "peer_ip": "192:168::2",
                 "peer_type": "route distinguisher instance",
                 "policy": "post-policy",

--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-post-policy-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-post-policy-step1.json
@@ -12,7 +12,7 @@
                 "peer_bgp_id": "192.168.0.2",
                 "peer_distinguisher": "0:0",
                 "peer_ip": "192.168.0.2",
-                "peer_type": "global instance",
+                "peer_type": "route distinguisher instance",
                 "policy": "post-policy"
             },
             "2111::1111/128": {
@@ -27,7 +27,7 @@
                 "peer_bgp_id": "192.168.0.2",
                 "peer_distinguisher": "0:0",
                 "peer_ip": "192:168::2",
-                "peer_type": "global instance",
+                "peer_type": "route distinguisher instance",
                 "policy": "post-policy",
                 "safi": 1
             }

--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-pre-policy-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-pre-policy-step1.json
@@ -10,7 +10,7 @@
                 "origin": "IGP",
                 "peer_asn": 65502,
                 "peer_bgp_id": "192.168.0.2",
-                "peer_distinguisher": "0:0",
+                "peer_distinguisher": "444:1",
                 "peer_ip": "192.168.0.2",
                 "peer_type": "route distinguisher instance",
                 "policy": "pre-policy"
@@ -25,7 +25,7 @@
                 "origin": "IGP",
                 "peer_asn": 65502,
                 "peer_bgp_id": "192.168.0.2",
-                "peer_distinguisher": "0:0",
+                "peer_distinguisher": "555:1",
                 "peer_ip": "192:168::2",
                 "peer_type": "route distinguisher instance",
                 "policy": "pre-policy",

--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-pre-policy-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-pre-policy-step1.json
@@ -12,7 +12,7 @@
                 "peer_bgp_id": "192.168.0.2",
                 "peer_distinguisher": "0:0",
                 "peer_ip": "192.168.0.2",
-                "peer_type": "global instance",
+                "peer_type": "route distinguisher instance",
                 "policy": "pre-policy"
             },
             "2111::1111/128": {
@@ -27,7 +27,7 @@
                 "peer_bgp_id": "192.168.0.2",
                 "peer_distinguisher": "0:0",
                 "peer_ip": "192:168::2",
-                "peer_type": "global instance",
+                "peer_type": "route distinguisher instance",
                 "policy": "pre-policy",
                 "safi": 1
             }

--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-withdraw-loc-rib-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-withdraw-loc-rib-step1.json
@@ -7,6 +7,7 @@
                 "is_filtered": false,
                 "peer_asn": 65501,
                 "peer_bgp_id": "192.168.0.1",
+                "peer_distinguisher": "444:1",
                 "peer_type": "loc-rib instance",
                 "policy": "loc-rib"
             },
@@ -17,6 +18,7 @@
                 "is_filtered": false,
                 "peer_asn": 65501,
                 "peer_bgp_id": "192.168.0.1",
+                "peer_distinguisher": "555:1",
                 "peer_type": "loc-rib instance",
                 "policy": "loc-rib",
                 "safi": 1

--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-withdraw-post-policy-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-withdraw-post-policy-step1.json
@@ -9,7 +9,7 @@
                 "peer_bgp_id": "192.168.0.2",
                 "peer_distinguisher": "0:0",
                 "peer_ip": "192.168.0.2",
-                "peer_type": "global instance",
+                "peer_type": "route distinguisher instance",
                 "policy": "post-policy"
             },
             "2111::1111/128": {
@@ -21,7 +21,7 @@
                 "peer_bgp_id": "192.168.0.2",
                 "peer_distinguisher": "0:0",
                 "peer_ip": "192:168::2",
-                "peer_type": "global instance",
+                "peer_type": "route distinguisher instance",
                 "policy": "post-policy",
                 "safi": 1
             }

--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-withdraw-post-policy-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-withdraw-post-policy-step1.json
@@ -7,7 +7,7 @@
                 "ipv6": false,
                 "peer_asn": 65502,
                 "peer_bgp_id": "192.168.0.2",
-                "peer_distinguisher": "0:0",
+                "peer_distinguisher": "444:1",
                 "peer_ip": "192.168.0.2",
                 "peer_type": "route distinguisher instance",
                 "policy": "post-policy"
@@ -19,7 +19,7 @@
                 "ipv6": true,
                 "peer_asn": 65502,
                 "peer_bgp_id": "192.168.0.2",
-                "peer_distinguisher": "0:0",
+                "peer_distinguisher": "555:1",
                 "peer_ip": "192:168::2",
                 "peer_type": "route distinguisher instance",
                 "policy": "post-policy",

--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-withdraw-pre-policy-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-withdraw-pre-policy-step1.json
@@ -7,7 +7,7 @@
                 "ipv6": false,
                 "peer_asn": 65502,
                 "peer_bgp_id": "192.168.0.2",
-                "peer_distinguisher": "0:0",
+                "peer_distinguisher": "444:1",
                 "peer_ip": "192.168.0.2",
                 "peer_type": "route distinguisher instance",
                 "policy": "pre-policy"
@@ -19,7 +19,7 @@
                 "ipv6": true,
                 "peer_asn": 65502,
                 "peer_bgp_id": "192.168.0.2",
-                "peer_distinguisher": "0:0",
+                "peer_distinguisher": "555:1",
                 "peer_ip": "192:168::2",
                 "peer_type": "route distinguisher instance",
                 "policy": "pre-policy",

--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-withdraw-pre-policy-step1.json
+++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-withdraw-pre-policy-step1.json
@@ -9,7 +9,7 @@
                 "peer_bgp_id": "192.168.0.2",
                 "peer_distinguisher": "0:0",
                 "peer_ip": "192.168.0.2",
-                "peer_type": "global instance",
+                "peer_type": "route distinguisher instance",
                 "policy": "pre-policy"
             },
             "2111::1111/128": {
@@ -21,7 +21,7 @@
                 "peer_bgp_id": "192.168.0.2",
                 "peer_distinguisher": "0:0",
                 "peer_ip": "192:168::2",
-                "peer_type": "global instance",
+                "peer_type": "route distinguisher instance",
                 "policy": "pre-policy",
                 "safi": 1
             }

--- a/tests/topotests/bgp_bmp/r1vrf/frr.conf
+++ b/tests/topotests/bgp_bmp/r1vrf/frr.conf
@@ -23,12 +23,14 @@ router bgp 65501 vrf vrf1
  exit
 !
  address-family ipv4 unicast
+  rd vpn export 444:1
   neighbor 192.168.0.2 activate
   neighbor 192.168.0.2 soft-reconfiguration inbound
   no neighbor 192:168::2 activate
  exit-address-family
 !
  address-family ipv6 unicast
+  rd vpn export 555:1
   neighbor 192:168::2 activate
   neighbor 192:168::2 soft-reconfiguration inbound
  exit-address-family

--- a/tests/topotests/bgp_bmp/test_bgp_bmp_2.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_2.py
@@ -210,6 +210,7 @@ def test_peer_up():
         "peer up",
         tgen.gears["bmp1vrf"],
         os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        is_rd_instance=True,
     )
     success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
     assert success, "Checking the updated prefixes has been failed !."
@@ -245,6 +246,7 @@ def test_peer_down():
         "peer down",
         tgen.gears["bmp1vrf"],
         os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        is_rd_instance=True,
     )
     success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
     assert success, "Checking the updated prefixes has been failed !."


### PR DESCRIPTION
Today, only global instance per peer header messages are used.
This set of commits makes possible to send per peer header on a VRF instance, and send RD instance messages instead with its proper peer distinguisher value.
