### PR TITLE
zebra: avoid race between FPM pthread and zebra main pthread in netlink encode/decode

### DIFF
--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -587,6 +587,7 @@ static void fpm_read(struct event *t)
 	struct zebra_dplane_ctx *ctx;
 	size_t available_bytes;
 	size_t hdr_available_bytes;
+	int ival;
 
 	/* Let's ignore the input at the moment. */
 	rv = stream_read_try(fnc->ibuf, fnc->socket,
@@ -715,17 +716,28 @@ static void fpm_read(struct event *t)
 				break;
 			}
 
+			/* Parse the route data into a dplane ctx, then
+			 * enqueue it to zebra for processing.
+			 */
 			ctx = dplane_ctx_alloc();
 			dplane_ctx_route_init(ctx, DPLANE_OP_ROUTE_NOTIFY, NULL,
 					      NULL);
-			if (netlink_route_change_read_unicast_internal(
-				    hdr, 0, false, ctx) != 1) {
-				dplane_ctx_fini(&ctx);
-				stream_pulldown(fnc->ibuf);
+
+			if (netlink_route_notify_read_ctx(hdr, 0, ctx) >= 0) {
+				/* In the FPM encoding, the vrfid is present */
+				ival = dplane_ctx_get_table(ctx);
+				dplane_ctx_set_vrf(ctx, ival);
+				dplane_ctx_set_table(ctx,
+						     ZEBRA_ROUTE_TABLE_UNKNOWN);
+
+				dplane_provider_enqueue_to_zebra(ctx);
+			} else {
 				/*
 				 * Let's continue to read other messages
 				 * Even if we ignore this one.
 				 */
+				dplane_ctx_fini(&ctx);
+				stream_pulldown(fnc->ibuf);
 			}
 			break;
 		default:

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -3288,9 +3288,8 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 nexthop_done:
 
 			if (IS_ZEBRA_DEBUG_KERNEL)
-				zlog_debug("%s: ID (%u): %pNHv(%d) vrf %s(%u) %s ",
+				zlog_debug("%s: ID (%u): %pNHv(%d) vrf %u %s ",
 					   __func__, id, nh, nh->ifindex,
-					   vrf_id_to_name(nh->vrf_id),
 					   nh->vrf_id, label_buf);
 		}
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1857,12 +1857,9 @@ static bool _netlink_route_build_singlepath(const struct prefix *p,
 {
 
 	char label_buf[256];
-	struct vrf *vrf;
 	char addrstr[INET6_ADDRSTRLEN];
 
 	assert(nexthop);
-
-	vrf = vrf_lookup_by_id(nexthop->vrf_id);
 
 	if (!_netlink_route_encode_label_info(nexthop, nlmsg, req_size, rtmsg,
 					      label_buf, sizeof(label_buf)))
@@ -2024,10 +2021,10 @@ static bool _netlink_route_build_singlepath(const struct prefix *p,
 		}
 
 		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug("%s: 5549 (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
+			zlog_debug("%s: 5549 (%s): %pFX nexthop via %s %s if %u vrf %u",
 				   __func__, routedesc, p, ipv4_ll_buf,
 				   label_buf, nexthop->ifindex,
-				   VRF_LOGNAME(vrf), nexthop->vrf_id);
+				   nexthop->vrf_id);
 		return true;
 	}
 
@@ -2050,10 +2047,9 @@ static bool _netlink_route_build_singlepath(const struct prefix *p,
 		if (IS_ZEBRA_DEBUG_KERNEL) {
 			inet_ntop(AF_INET, &nexthop->gate.ipv4, addrstr,
 				  sizeof(addrstr));
-			zlog_debug("%s: (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
+			zlog_debug("%s: (%s): %pFX nexthop via %s %s if %u vrf %u",
 				   __func__, routedesc, p, addrstr, label_buf,
-				   nexthop->ifindex, VRF_LOGNAME(vrf),
-				   nexthop->vrf_id);
+				   nexthop->ifindex, nexthop->vrf_id);
 		}
 	}
 
@@ -2074,10 +2070,9 @@ static bool _netlink_route_build_singlepath(const struct prefix *p,
 		if (IS_ZEBRA_DEBUG_KERNEL) {
 			inet_ntop(AF_INET6, &nexthop->gate.ipv6, addrstr,
 				  sizeof(addrstr));
-			zlog_debug("%s: (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
+			zlog_debug("%s: (%s): %pFX nexthop via %s %s if %u vrf %u",
 				   __func__, routedesc, p, addrstr, label_buf,
-				   nexthop->ifindex, VRF_LOGNAME(vrf),
-				   nexthop->vrf_id);
+				   nexthop->ifindex, nexthop->vrf_id);
 		}
 	}
 
@@ -2099,9 +2094,9 @@ static bool _netlink_route_build_singlepath(const struct prefix *p,
 		}
 
 		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug("%s: (%s): %pFX nexthop via if %u vrf %s(%u)",
+			zlog_debug("%s: (%s): %pFX nexthop via if %u vrf %u",
 				   __func__, routedesc, p, nexthop->ifindex,
-				   VRF_LOGNAME(vrf), nexthop->vrf_id);
+				   nexthop->vrf_id);
 	}
 
 	return true;
@@ -2185,7 +2180,6 @@ static bool _netlink_route_build_multipath(const struct prefix *p,
 					   route_tag_t tag, bool fpm)
 {
 	char label_buf[256];
-	struct vrf *vrf;
 	struct rtnexthop *rtnh;
 
 	rtnh = nl_attr_rtnh(nlmsg, req_size);
@@ -2193,8 +2187,6 @@ static bool _netlink_route_build_multipath(const struct prefix *p,
 		return false;
 
 	assert(nexthop);
-
-	vrf = vrf_lookup_by_id(nexthop->vrf_id);
 
 	if (!_netlink_route_encode_label_info(nexthop, nlmsg, req_size, rtmsg,
 					      label_buf, sizeof(label_buf)))
@@ -2218,10 +2210,9 @@ static bool _netlink_route_build_multipath(const struct prefix *p,
 
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug(
-				"%s: 5549 (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
+				"%s: 5549 (%s): %pFX nexthop via %s %s if %u vrf %u",
 				__func__, routedesc, p, ipv4_ll_buf, label_buf,
-				nexthop->ifindex, VRF_LOGNAME(vrf),
-				nexthop->vrf_id);
+				nexthop->ifindex, nexthop->vrf_id);
 		nl_attr_rtnh_end(nlmsg, rtnh);
 		return true;
 	}
@@ -2239,10 +2230,9 @@ static bool _netlink_route_build_multipath(const struct prefix *p,
 			*src = &nexthop->src;
 
 		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug("%s: (%s): %pFX nexthop via %pI4 %s if %u vrf %s(%u)",
+			zlog_debug("%s: (%s): %pFX nexthop via %pI4 %s if %u vrf %u",
 				   __func__, routedesc, p, &nexthop->gate.ipv4,
-				   label_buf, nexthop->ifindex,
-				   VRF_LOGNAME(vrf), nexthop->vrf_id);
+				   label_buf, nexthop->ifindex, nexthop->vrf_id);
 	}
 	if (nexthop->type == NEXTHOP_TYPE_IPV6
 	    || nexthop->type == NEXTHOP_TYPE_IPV6_IFINDEX) {
@@ -2257,10 +2247,9 @@ static bool _netlink_route_build_multipath(const struct prefix *p,
 			*src = &nexthop->src;
 
 		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug("%s: (%s): %pFX nexthop via %pI6 %s if %u vrf %s(%u)",
+			zlog_debug("%s: (%s): %pFX nexthop via %pI6 %s if %u vrf %u",
 				   __func__, routedesc, p, &nexthop->gate.ipv6,
-				   label_buf, nexthop->ifindex,
-				   VRF_LOGNAME(vrf), nexthop->vrf_id);
+				   label_buf, nexthop->ifindex, nexthop->vrf_id);
 	}
 
 	/*
@@ -2279,9 +2268,9 @@ static bool _netlink_route_build_multipath(const struct prefix *p,
 			*src = &nexthop->src;
 
 		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug("%s: (%s): %pFX nexthop via if %u vrf %s(%u)",
+			zlog_debug("%s: (%s): %pFX nexthop via if %u vrf %u",
 				   __func__, routedesc, p, nexthop->ifindex,
-				   VRF_LOGNAME(vrf), nexthop->vrf_id);
+				   nexthop->vrf_id);
 	}
 
 	if (nexthop->weight)

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -64,6 +64,15 @@ extern ssize_t netlink_macfdb_update_ctx(struct zebra_dplane_ctx *ctx,
 extern int netlink_route_change(struct nlmsghdr *h, ns_id_t ns_id, int startup);
 extern int netlink_route_read(struct zebra_ns *zns);
 
+/*
+ * Public api for parsing a route notification message: this notification
+ * only parses the top-level route attributes, and doesn't include nexthops.
+ * FPM, for example, is a user.
+ * Returns <0 if the message should be ignored/skipped.
+ */
+int netlink_route_notify_read_ctx(struct nlmsghdr *h, ns_id_t ns_id,
+				  struct zebra_dplane_ctx *ctx);
+
 extern int netlink_nexthop_change(struct nlmsghdr *h, ns_id_t ns_id,
 				  int startup);
 extern int netlink_nexthop_read(struct zebra_ns *zns);
@@ -108,10 +117,6 @@ extern enum netlink_msg_status
 netlink_put_lsp_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx);
 extern enum netlink_msg_status
 netlink_put_pw_update_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx);
-
-int netlink_route_change_read_unicast_internal(struct nlmsghdr *h,
-					       ns_id_t ns_id, int startup,
-					       struct zebra_dplane_ctx *ctx);
 
 #ifdef NETLINK_DEBUG
 const char *nlmsg_type2str(uint16_t type);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -6998,20 +6998,6 @@ kernel_dplane_process_ipset_entry(struct zebra_dplane_provider *prov,
 	dplane_provider_enqueue_out_ctx(prov, ctx);
 }
 
-void dplane_rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
-			      struct prefix_ipv6 *src_p, struct route_entry *re,
-			      struct nexthop_group *ng, int startup,
-			      struct zebra_dplane_ctx *ctx)
-{
-	if (!ctx)
-		rib_add_multipath(afi, safi, p, src_p, re, ng, startup);
-	else {
-		dplane_ctx_route_init_basic(ctx, dplane_ctx_get_op(ctx), re, p,
-					    src_p, afi, safi);
-		dplane_provider_enqueue_to_zebra(ctx);
-	}
-}
-
 /*
  * Kernel provider callback
  */

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -150,6 +150,11 @@ struct dplane_route_info {
 
 	/* Optional list of extra interface info */
 	struct dplane_intf_extra_list_head intf_extra_list;
+
+	/* Route-level info that aligns with some netlink route data */
+	enum blackhole_type zd_bh_type;
+	struct ipaddr zd_prefsrc;
+	struct ipaddr zd_gateway;
 };
 
 /*
@@ -1906,6 +1911,12 @@ void dplane_ctx_set_flags(struct zebra_dplane_ctx *ctx, uint32_t flags)
 	ctx->u.rinfo.zd_flags = flags;
 }
 
+void dplane_ctx_set_route_metric(struct zebra_dplane_ctx *ctx, uint32_t metric)
+{
+	DPLANE_CTX_VALID(ctx);
+	ctx->u.rinfo.zd_metric = metric;
+}
+
 uint32_t dplane_ctx_get_metric(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
@@ -1925,6 +1936,12 @@ uint32_t dplane_ctx_get_mtu(const struct zebra_dplane_ctx *ctx)
 	DPLANE_CTX_VALID(ctx);
 
 	return ctx->u.rinfo.zd_mtu;
+}
+
+void dplane_ctx_set_route_mtu(struct zebra_dplane_ctx *ctx, uint32_t mtu)
+{
+	DPLANE_CTX_VALID(ctx);
+	ctx->u.rinfo.zd_mtu = mtu;
 }
 
 uint32_t dplane_ctx_get_nh_mtu(const struct zebra_dplane_ctx *ctx)
@@ -1953,6 +1970,58 @@ uint8_t dplane_ctx_get_old_distance(const struct zebra_dplane_ctx *ctx)
 	DPLANE_CTX_VALID(ctx);
 
 	return ctx->u.rinfo.zd_old_distance;
+}
+
+/* Route blackhole type */
+enum blackhole_type dplane_ctx_get_route_bhtype(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.rinfo.zd_bh_type;
+}
+
+void dplane_ctx_set_route_bhtype(struct zebra_dplane_ctx *ctx,
+				 enum blackhole_type bhtype)
+{
+	DPLANE_CTX_VALID(ctx);
+	ctx->u.rinfo.zd_bh_type = bhtype;
+}
+
+/* IP 'preferred source', at route-level */
+const struct ipaddr *dplane_ctx_get_route_prefsrc(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	if (ctx->u.rinfo.zd_prefsrc.ipa_type != 0)
+		return &(ctx->u.rinfo.zd_prefsrc);
+	else
+		return NULL;
+}
+
+void dplane_ctx_set_route_prefsrc(struct zebra_dplane_ctx *ctx,
+				  const struct ipaddr *addr)
+{
+	DPLANE_CTX_VALID(ctx);
+	if (addr)
+		ctx->u.rinfo.zd_prefsrc = *addr;
+	else
+		memset(&ctx->u.rinfo.zd_prefsrc, 0,
+		       sizeof(ctx->u.rinfo.zd_prefsrc));
+}
+
+/* Route-level 'gateway' */
+const struct ipaddr *dplane_ctx_get_route_gw(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return &(ctx->u.rinfo.zd_gateway);
+}
+
+void dplane_ctx_set_route_gw(struct zebra_dplane_ctx *ctx, const struct ipaddr *gw)
+{
+	DPLANE_CTX_VALID(ctx);
+	if (gw)
+		ctx->u.rinfo.zd_gateway = *gw;
+	else
+		memset(&ctx->u.rinfo.zd_gateway, 0, sizeof(ctx->u.rinfo.zd_gateway));
 }
 
 int dplane_ctx_tc_qdisc_get_kind(const struct zebra_dplane_ctx *ctx)
@@ -2177,6 +2246,12 @@ uint32_t dplane_ctx_get_nhg_id(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
 	return ctx->u.rinfo.zd_nhg_id;
+}
+
+void dplane_ctx_set_nhg_id(struct zebra_dplane_ctx *ctx, uint32_t nhgid)
+{
+	DPLANE_CTX_VALID(ctx);
+	ctx->u.rinfo.zd_nhg_id = nhgid;
 }
 
 const struct nexthop_group *dplane_ctx_get_ng(

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -524,11 +524,26 @@ uint32_t dplane_ctx_get_flags(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_flags(struct zebra_dplane_ctx *ctx, uint32_t flags);
 uint32_t dplane_ctx_get_metric(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_get_old_metric(const struct zebra_dplane_ctx *ctx);
+void dplane_ctx_set_route_metric(struct zebra_dplane_ctx *ctx, uint32_t metric);
+void dplane_ctx_set_route_mtu(struct zebra_dplane_ctx *ctx, uint32_t mtu);
 uint32_t dplane_ctx_get_mtu(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_get_nh_mtu(const struct zebra_dplane_ctx *ctx);
 uint8_t dplane_ctx_get_distance(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_distance(struct zebra_dplane_ctx *ctx, uint8_t distance);
 uint8_t dplane_ctx_get_old_distance(const struct zebra_dplane_ctx *ctx);
+/* Route blackhole type */
+enum blackhole_type dplane_ctx_get_route_bhtype(
+	const struct zebra_dplane_ctx *ctx);
+void dplane_ctx_set_route_bhtype(struct zebra_dplane_ctx *ctx,
+				 enum blackhole_type bhtype);
+/* IPv4 'preferred source', at route-level */
+const struct ipaddr *dplane_ctx_get_route_prefsrc(
+	const struct zebra_dplane_ctx *ctx);
+void dplane_ctx_set_route_prefsrc(struct zebra_dplane_ctx *ctx,
+				  const struct ipaddr *addr);
+/* Route 'gateway', at route-level */
+const struct ipaddr *dplane_ctx_get_route_gw(const struct zebra_dplane_ctx *ctx);
+void dplane_ctx_set_route_gw(struct zebra_dplane_ctx *ctx, const struct ipaddr *gw);
 
 /* Accessors for traffic control context */
 int dplane_ctx_tc_qdisc_get_kind(const struct zebra_dplane_ctx *ctx);
@@ -572,6 +587,7 @@ void dplane_ctx_set_nexthops(struct zebra_dplane_ctx *ctx, struct nexthop *nh);
 void dplane_ctx_set_backup_nhg(struct zebra_dplane_ctx *ctx,
 			       const struct nexthop_group *nhg);
 
+void dplane_ctx_set_nhg_id(struct zebra_dplane_ctx *ctx, uint32_t nhgid);
 uint32_t dplane_ctx_get_nhg_id(const struct zebra_dplane_ctx *ctx);
 const struct nexthop_group *dplane_ctx_get_ng(
 	const struct zebra_dplane_ctx *ctx);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -1272,16 +1272,6 @@ void zebra_dplane_shutdown(void);
 void zebra_dplane_startup_stage(struct zebra_ns *zns,
 				enum zebra_dplane_startup_notifications spot);
 
-/*
- * decision point for sending a routing update through the old
- * straight to zebra master pthread or through the dplane to
- * the master pthread for handling
- */
-void dplane_rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
-			      struct prefix_ipv6 *src_p, struct route_entry *re,
-			      struct nexthop_group *ng, int startup,
-			      struct zebra_dplane_ctx *ctx);
-
 enum zebra_dplane_startup_notifications
 dplane_ctx_get_startup_spot(struct zebra_dplane_ctx *ctx);
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4033,10 +4033,10 @@ static void rib_link(struct route_node *rn, struct route_entry *re, int process)
 
 	dest = rib_dest_from_rnode(rn);
 	if (!dest) {
+		dest = zebra_rib_create_dest(rn);
+
 		if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 			rnode_debug(rn, re->vrf_id, "rn %p adding dest", rn);
-
-		dest = zebra_rib_create_dest(rn);
 	}
 
 	re_list_add_head(&dest->routes, re);

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -417,6 +417,25 @@ vrf_id_t zebra_vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id)
 	return VRF_DEFAULT;
 }
 
+/*
+ * Lookup tableid by vrfid; handle vrf-lite and vrf-netns cases
+ */
+int zebra_vrf_lookup_tableid(vrf_id_t vrf_id, ns_id_t ns_id)
+{
+	struct zebra_vrf *zvrf;
+
+	/* Handle vrf-lite and vrf-netns */
+	if (vrf_is_backend_netns())
+		zvrf = vrf_info_lookup(ns_id);
+	else
+		zvrf = vrf_info_lookup(vrf_id);
+
+	if (zvrf)
+		return zvrf->table_id;
+	else
+		return ZEBRA_ROUTE_TABLE_UNKNOWN;
+}
+
 /* Lookup VRF by identifier.  */
 struct zebra_vrf *zebra_vrf_lookup_by_id(vrf_id_t vrf_id)
 {

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -24,6 +24,8 @@ FRR_CFG_DEFAULT_BOOL(ZEBRA_IP_NHT_RESOLVE_VIA_DEFAULT,
 	{ .val_bool = false },
 );
 
+#define ZEBRA_ROUTE_TABLE_UNKNOWN 0
+
 /* MPLS (Segment Routing) global block */
 struct mpls_srgb {
 	uint32_t start_label;
@@ -247,6 +249,7 @@ extern struct zebra_vrf *zebra_vrf_lookup_by_name(const char *);
 extern vrf_id_t zebra_vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id);
 extern struct zebra_vrf *zebra_vrf_alloc(struct vrf *vrf);
 extern struct route_table *zebra_vrf_table(afi_t, safi_t, vrf_id_t);
+int zebra_vrf_lookup_tableid(vrf_id_t vrf_id, ns_id_t ns_id);
 
 /*
  * API to associate a VRF with a NETNS.


### PR DESCRIPTION
The current FPM dataplane plugin uses some zebra netlink message encode and decode apis. That seems to have been done to avoid duplication - but there are races present because FPM uses its own pthread, the netlink code touches zebra internal datastructures, and that is not thread-safe. This PR attempts to re-work the netlink apis so that they become safe for FPM use.