### PR TITLE
pimd: Prevent crash of pim when auto-rp's socket is not initialized (backport #17578)

### DIFF
--- a/pimd/pim_autorp.c
+++ b/pimd/pim_autorp.c
@@ -1014,12 +1014,13 @@ void pim_autorp_init(struct pim_instance *pim)
 	autorp->announce_interval = DEFAULT_ANNOUNCE_INTERVAL;
 	autorp->announce_holdtime = DEFAULT_ANNOUNCE_HOLDTIME;
 
+	pim->autorp = autorp;
+
 	if (!pim_autorp_socket_enable(autorp)) {
-		zlog_err("%s: AutoRP failed to initialize", __func__);
+		zlog_err("%s: AutoRP failed to initialize, feature will not work correctly", __func__);
 		return;
 	}
 
-	pim->autorp = autorp;
 	if (PIM_DEBUG_AUTORP)
 		zlog_debug("%s: AutoRP Initialized", __func__);
 


### PR DESCRIPTION
If the socket associated with the auto-rp fails to initialize then the memory for the auto-rp is just dropped on the floor.  Additionally any type of attempt at using the feature will just cause pimd to crash, when the pointer is derefed.  Since it is derefed all over the place without checking.

Clearly if you cannot bind/use the socket let's allow continuation.

Fixes: #17540