### PR TITLE
bgpd: fix unconfigure asdot neighbor (backport)

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5042,7 +5042,7 @@ DEFUN (neighbor_peer_group,
 
 DEFUN (no_neighbor,
        no_neighbor_cmd,
-       "no neighbor <WORD|<A.B.C.D|X:X::X:X> [remote-as <(1-4294967295)|internal|external>]>",
+       "no neighbor <WORD|<A.B.C.D|X:X::X:X> [remote-as <ASNUM|internal|external>]>",
        NO_STR
        NEIGHBOR_STR
        NEIGHBOR_ADDR_STR2
@@ -5109,7 +5109,7 @@ DEFUN (no_neighbor,
 
 DEFUN (no_neighbor_interface_config,
        no_neighbor_interface_config_cmd,
-       "no neighbor WORD interface [v6only] [peer-group PGNAME] [remote-as <(1-4294967295)|internal|external>]",
+       "no neighbor WORD interface [v6only] [peer-group PGNAME] [remote-as <ASNUM|internal|external>]",
        NO_STR
        NEIGHBOR_STR
        "Interface name\n"


### PR DESCRIPTION
The below command is not successfull on an existing as dot peer

> no neighbor 10.0.0.2 remote-as 1.1
> % Create the peer-group or interface first

Handle the case where the remote-as argument can be an ASNUM.

Fixes: 8079a4138d61 ("lib, bgp: add initial support for asdot format")