### PR TITLE
bgpd: Connect retry timer backoff

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -95,15 +95,15 @@ FRR_CFG_DEFAULT_BOOL(BGP_DETERMINISTIC_MED,
 );
 FRR_CFG_DEFAULT_ULONG(BGP_CONNECT_RETRY,
 	{ .val_ulong = 10, .match_profile = "datacenter", },
-	{ .val_ulong = 120 },
+	{ .val_ulong = BGP_DEFAULT_CONNECT_RETRY },
 );
 FRR_CFG_DEFAULT_ULONG(BGP_HOLDTIME,
 	{ .val_ulong = 9, .match_profile = "datacenter", },
-	{ .val_ulong = 180 },
+	{ .val_ulong = BGP_DEFAULT_KEEPALIVE },
 );
 FRR_CFG_DEFAULT_ULONG(BGP_KEEPALIVE,
 	{ .val_ulong = 3, .match_profile = "datacenter", },
-	{ .val_ulong = 60 },
+	{ .val_ulong = BGP_DEFAULT_KEEPALIVE },
 );
 FRR_CFG_DEFAULT_BOOL(BGP_EBGP_REQUIRES_POLICY,
 	{ .val_bool = false, .match_profile = "datacenter", },

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2106,6 +2106,7 @@ struct bgp_nlri {
 #define BGP_DEFAULT_HOLDTIME                   180
 #define BGP_DEFAULT_KEEPALIVE                   60
 #define BGP_DEFAULT_CONNECT_RETRY               30
+#define BGP_MAX_CONNECT_RETRY                  120
 
 #define BGP_DEFAULT_EBGP_ROUTEADV                0
 #define BGP_DEFAULT_IBGP_ROUTEADV                0

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2105,7 +2105,7 @@ struct bgp_nlri {
  */
 #define BGP_DEFAULT_HOLDTIME                   180
 #define BGP_DEFAULT_KEEPALIVE                   60
-#define BGP_DEFAULT_CONNECT_RETRY              120
+#define BGP_DEFAULT_CONNECT_RETRY               30
 
 #define BGP_DEFAULT_EBGP_ROUTEADV                0
 #define BGP_DEFAULT_IBGP_ROUTEADV                0

--- a/tests/topotests/bgp_minimum_holdtime/test_bgp_minimum_holdtime.py
+++ b/tests/topotests/bgp_minimum_holdtime/test_bgp_minimum_holdtime.py
@@ -76,7 +76,7 @@ def test_bgp_minimum_holdtime():
         return topotest.json_cmp(output, expected)
 
     test_func = functools.partial(_bgp_neighbor_check_if_notification_sent)
-    _, result = topotest.run_and_expect(test_func, None, count=40, wait=0.5)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assert result is None, "Failed to send notification message\n"
 
 


### PR DESCRIPTION
120 seconds (default) is a bit of something like "are you from the past?". Let's see if we can have a lower value with some backoff...