### PR TITLE
bgpd: Check if as_type is not specified when peer is a peer-group member

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2158,8 +2158,7 @@ int peer_remote_as(struct bgp *bgp, union sockunion *su, const char *conf_if,
 		/* When this peer is a member of peer-group.  */
 		if (peer->group) {
 			/* peer-group already has AS number/internal/external */
-			if (peer->group->conf->as
-			    || peer->group->conf->as_type) {
+			if (peer->group->conf->as || peer->group->conf->as_type != AS_UNSPECIFIED) {
 				/* Return peer group's AS number.  */
 				*as = peer->group->conf->as;
 				return BGP_ERR_PEER_GROUP_MEMBER;


### PR DESCRIPTION
Closes https://github.com/FRRouting/frr/issues/17602