### PR TITLE
pimd: MSDP originador ID configuration

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -518,6 +518,10 @@ Commands available for MSDP
 
       To apply it immediately call `clear ip msdp peer A.B.C.D`.
 
+.. clicmd:: msdp originator-id A.B.C.D
+
+   Use the specified originator ID instead of the multicast RP group.
+
 .. clicmd:: msdp shutdown
 
    Shutdown the MSDP sessions in this PIM instance.

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -7616,6 +7616,24 @@ DEFPY(msdp_peer_sa_limit, msdp_peer_sa_limit_cmd,
 	return nb_cli_apply_changes(vty, "%s", xpath);
 }
 
+DEFPY(msdp_originator_id, msdp_originator_id_cmd,
+      "[no] msdp originator-id ![A.B.C.D$originator_id]",
+      NO_STR
+      CFG_MSDP_STR
+      "Configure MSDP RP originator\n"
+      "MSDP RP originator identifier\n")
+{
+	char xpath_value[XPATH_MAXLEN];
+
+	snprintf(xpath_value, sizeof(xpath_value), "./msdp/originator-id");
+	if (no)
+		nb_cli_enqueue_change(vty, xpath_value, NB_OP_DESTROY, NULL);
+	else
+		nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, originator_id_str);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
 static void ip_msdp_show_mesh_group(struct vty *vty, struct pim_msdp_mg *mg,
 				    struct json_object *json)
 {
@@ -9012,6 +9030,7 @@ void pim_cmd_init(void)
 	install_element(PIM_NODE, &msdp_log_sa_changes_cmd);
 	install_element(PIM_NODE, &msdp_shutdown_cmd);
 	install_element(PIM_NODE, &msdp_peer_sa_limit_cmd);
+	install_element(PIM_NODE, &msdp_originator_id_cmd);
 
 	install_element(PIM_NODE, &pim_bsr_candidate_rp_cmd);
 	install_element(PIM_NODE, &pim_bsr_candidate_rp_group_cmd);

--- a/pimd/pim_msdp.h
+++ b/pimd/pim_msdp.h
@@ -341,6 +341,16 @@ void pim_msdp_peer_restart(struct pim_msdp_peer *mp);
  */
 void pim_msdp_shutdown(struct pim_instance *pim, bool state);
 
+/**
+ * Get the configured originator ID for the SA RP field or the RP for the group.
+ *
+ * \param[in] pim PIM instance that MSDP connection belongs to.
+ * \param[in] group Multicast group.
+ * \param[out] originator_id Originator output value.
+ */
+void pim_msdp_originator_id(struct pim_instance *pim, const struct prefix *group,
+			    struct in_addr *originator_id);
+
 extern bool pim_msdp_log_neighbor_events(const struct pim_instance *pim);
 extern bool pim_msdp_log_sa_events(const struct pim_instance *pim);
 

--- a/pimd/pim_msdp_packet.c
+++ b/pimd/pim_msdp_packet.c
@@ -409,7 +409,6 @@ static void pim_msdp_pkt_sa_gen(struct pim_instance *pim,
 {
 	struct listnode *sanode;
 	struct pim_msdp_sa *sa;
-	struct rp_info *rp_info;
 	struct prefix group_all;
 	struct in_addr rp;
 	int sa_count;
@@ -420,14 +419,8 @@ static void pim_msdp_pkt_sa_gen(struct pim_instance *pim,
 		zlog_debug("  sa gen  %d", local_cnt);
 	}
 
-	rp = pim->msdp.originator_id;
-	if (pim_get_all_mcast_group(&group_all)) {
-	    rp_info = pim_rp_find_match_group(pim, &group_all);
-	    if (rp_info) {
-	        rp = rp_info->rp.rpf_addr;
-	    }
-	}
-
+	pim_get_all_mcast_group(&group_all);
+	pim_msdp_originator_id(pim, &group_all, &rp);
 	local_cnt = pim_msdp_pkt_sa_fill_hdr(pim, local_cnt, rp);
 
 	for (ALL_LIST_ELEMENTS_RO(pim->msdp.sa_list, sanode, sa)) {
@@ -457,8 +450,7 @@ static void pim_msdp_pkt_sa_gen(struct pim_instance *pim,
 				zlog_debug("  sa gen for remainder %d",
 					   local_cnt);
 			}
-			local_cnt = pim_msdp_pkt_sa_fill_hdr(
-				pim, local_cnt, rp);
+			local_cnt = pim_msdp_pkt_sa_fill_hdr(pim, local_cnt, rp);
 		}
 	}
 

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -142,6 +142,13 @@ const struct frr_yang_module_info frr_pim_info = {
 			}
 		},
 		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/msdp/originator-id",
+			.cbs = {
+				.modify = pim_msdp_originator_id_modify,
+				.destroy = pim_msdp_originator_id_destroy,
+			}
+		},
+		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/msdp/shutdown",
 			.cbs = {
 				.modify = pim_msdp_shutdown_modify,

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -56,6 +56,8 @@ int pim_msdp_keep_alive_modify(struct nb_cb_modify_args *args);
 int pim_msdp_connection_retry_modify(struct nb_cb_modify_args *args);
 int pim_msdp_log_neighbor_events_modify(struct nb_cb_modify_args *args);
 int pim_msdp_log_sa_events_modify(struct nb_cb_modify_args *args);
+int pim_msdp_originator_id_modify(struct nb_cb_modify_args *args);
+int pim_msdp_originator_id_destroy(struct nb_cb_destroy_args *args);
 int pim_msdp_shutdown_modify(struct nb_cb_modify_args *args);
 int pim_msdp_mesh_group_create(struct nb_cb_create_args *args);
 int pim_msdp_mesh_group_destroy(struct nb_cb_destroy_args *args);

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -1037,6 +1037,8 @@ pim6_msdp_err(pim_msdp_peer_authentication_key_modify, nb_cb_modify_args);
 pim6_msdp_err(pim_msdp_peer_authentication_key_destroy, nb_cb_destroy_args);
 pim6_msdp_err(pim_msdp_log_neighbor_events_modify, nb_cb_modify_args);
 pim6_msdp_err(pim_msdp_log_sa_events_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_originator_id_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_originator_id_destroy, nb_cb_destroy_args);
 pim6_msdp_err(pim_msdp_shutdown_modify, nb_cb_modify_args);
 
 #if PIM_IPV != 6
@@ -1165,6 +1167,50 @@ int pim_msdp_log_sa_events_modify(struct nb_cb_modify_args *args)
 			SET_FLAG(pim->log_flags, PIM_MSDP_LOG_SA_EVENTS);
 		else
 			UNSET_FLAG(pim->log_flags, PIM_MSDP_LOG_SA_EVENTS);
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath:
+ * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/msdp/originator-id
+ */
+int pim_msdp_originator_id_modify(struct nb_cb_modify_args *args)
+{
+	struct pim_instance *pim;
+	struct vrf *vrf;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		vrf = nb_running_get_entry(args->dnode, NULL, true);
+		pim = vrf->info;
+		yang_dnode_get_ipv4(&pim->msdp.originator_id, args->dnode, NULL);
+		break;
+	}
+
+	return NB_OK;
+}
+
+int pim_msdp_originator_id_destroy(struct nb_cb_destroy_args *args)
+{
+	struct pim_instance *pim;
+	struct vrf *vrf;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		vrf = nb_running_get_entry(args->dnode, NULL, true);
+		pim = vrf->info;
+		pim->msdp.originator_id.s_addr = INADDR_ANY;
 		break;
 	}
 

--- a/tests/topotests/msdp_topo3/r1/frr.conf
+++ b/tests/topotests/msdp_topo3/r1/frr.conf
@@ -1,0 +1,31 @@
+log commands
+!
+interface r1-eth0
+ ip address 192.168.1.1/24
+ ip pim
+!
+interface r1-eth1
+ ip address 192.168.100.1/24
+ ip igmp
+ ip pim passive
+!
+interface lo
+ ip address 10.254.254.1/32
+ ip pim
+ ip pim use-source 10.254.254.1
+!
+router bgp 65100
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.1.2 remote-as 65200
+ !
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+!
+router pim
+ msdp originator-id 10.254.254.1
+ msdp log sa-events
+ msdp peer 192.168.1.2 source 192.168.1.1
+ rp 192.168.1.1
+!

--- a/tests/topotests/msdp_topo3/r2/frr.conf
+++ b/tests/topotests/msdp_topo3/r2/frr.conf
@@ -1,0 +1,28 @@
+log commands
+!
+interface r2-eth0
+ ip address 192.168.1.2/24
+ ip pim
+!
+interface r2-eth1
+ ip address 192.168.101.1/24
+ ip igmp
+ ip pim passive
+!
+interface lo
+ ip address 10.254.254.2/32
+!
+router bgp 65200
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.1.1 remote-as 65100
+ !
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+!
+router pim
+ msdp log sa-events
+ msdp peer 192.168.1.1 source 192.168.1.2
+ rp 192.168.1.2
+!

--- a/tests/topotests/msdp_topo3/test_msdp_topo3.py
+++ b/tests/topotests/msdp_topo3/test_msdp_topo3.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_msdp_topo3.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2024 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+
+"""
+test_msdp_topo3.py: Test the FRR PIM MSDP peer.
+"""
+
+import os
+import sys
+import json
+from functools import partial
+import re
+import pytest
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+
+# Required to instantiate the topology builder class.
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+from lib.pim import McastTesterHelper
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.pimd]
+
+app_helper = McastTesterHelper()
+
+
+def build_topo(tgen):
+    """
+    +----+     +----+     +----+     +----+
+    | h1 | <-> | r1 | <-> | r2 | <-> | h2 |
+    +----+     +----+     +----+     +----+
+
+          -------------------------->
+
+    Multicast traffic SG(192.168.100.100, 229.1.1.1)
+    """
+
+    # Create 2 routers
+    for routern in range(1, 3):
+        tgen.add_router(f"r{routern}")
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # Create a host connected and direct at r1:
+    switch = tgen.add_switch("s2")
+    tgen.add_host("h1", "192.168.100.100/24", "via 192.168.100.1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["h1"])
+
+    # Create a host connected and direct at r2:
+    switch = tgen.add_switch("s3")
+    tgen.add_host("h2", "192.168.101.100/24", "via 192.168.101.1")
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["h2"])
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for _, router in router_list.items():
+        router.load_frr_config(os.path.join(CWD, f"{router.name}/frr.conf"))
+
+    # Initialize all routers.
+    tgen.start_router()
+
+    app_helper.init(tgen)
+
+
+def teardown_module():
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    app_helper.cleanup()
+    tgen.stop_topology()
+
+
+def test_bgp_convergence():
+    "Wait for BGP protocol convergence"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("waiting for protocols to converge")
+
+    def expect_loopback_route(router, iptype, route, proto):
+        "Wait until route is present on RIB for protocol."
+        logger.info("waiting route {} in {}".format(route, router))
+        test_func = partial(
+            topotest.router_json_cmp,
+            tgen.gears[router],
+            "show {} route json".format(iptype),
+            {route: [{"protocol": proto}]},
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=130, wait=1)
+        assertmsg = '"{}" convergence failure'.format(router)
+        assert result is None, assertmsg
+
+    # Wait for R1
+    expect_loopback_route("r1", "ip", "10.254.254.2/32", "bgp")
+
+    # Wait for R2
+    expect_loopback_route("r2", "ip", "10.254.254.1/32", "bgp")
+
+
+def test_sa_learn():
+    """
+    Test that the learned SA uses the configured originator ID instead
+    of the configured RP.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    MCAST_ADDRESS = "229.1.1.1"
+    app_helper.run("h1", ["--send=0.7", MCAST_ADDRESS, "h1-eth0"])
+    app_helper.run("h2", [MCAST_ADDRESS, "h2-eth0"])
+
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears["r2"],
+        "show ip msdp sa json",
+        {
+            "229.1.1.1": {
+                "192.168.100.100": {
+                    "rp": "10.254.254.1",
+                    "local": "no",
+                }
+            }
+        }
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=100, wait=1)
+    assert result is None, 'r2 SA convergence failure'
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -269,6 +269,14 @@ module frr-pim {
           "Log all MSDP SA related events.";
       }
 
+      leaf originator-id {
+        type inet:ip-address;
+        description
+          "Configure the RP address for the SAs.
+
+           By default the local system RP address will be used.";
+      }
+
       leaf shutdown {
         type boolean;
         default false;


### PR DESCRIPTION
Add new MSDP knob to let user override the SA RP: `msdp originator-id A.B.C.D`. With this configuration MSDP will not use the configured RP for the group, but the manual address provided by originator-id (usually the RP interface address).