### PR TITLE
bgpd: Fix bgp core with a possible Intf delete (backport)

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1232,9 +1232,10 @@ static bool update_ipv6nh_for_route_install(int nh_othervrf, struct bgp *nh_bgp,
 					ifindex =
 						pi->peer->nexthop.ifp->ifindex;
 			if (!ifindex) {
-				if (pi->peer->conf_if)
-					ifindex = pi->peer->ifp->ifindex;
-				else if (pi->peer->ifname)
+				if (pi->peer->conf_if) {
+					if (pi->peer->ifp)
+						ifindex = pi->peer->ifp->ifindex;
+				} else if (pi->peer->ifname)
 					ifindex = ifname2ifindex(
 						pi->peer->ifname,
 						pi->peer->bgp->vrf_id);


### PR DESCRIPTION
Although trigger unknown, based on the backtrace in one of the internal testing, we do see some delete in the Intf where we can have the peer ifp pointer null and we try to dereference it while trying to install the route leading to a crash

Skip updating the ifindex in such cases and since the nexthop is not properly updated, BGP skips sending it to zebra.

BackTrace:
0  0x00007faef05e7ebc in ?? () from /lib/x86_64-linux-gnu/libc.so.6 1  0x00007faef0598fb2 in raise () from /lib/x86_64-linux-gnu/libc.so.6 2  0x00007faef09900dc in core_handler (signo=11, siginfo=0x7ffdde8cb4b0, context=<optimized out>) at lib/sigevent.c:274 3  <signal handler called>
4  0x00005560aad4b7d8 in update_ipv6nh_for_route_install (api_nh=0x7ffdde8cbe94, is_evpn=false, best_pi=0x5560b21187d0, pi=0x5560b21187d0, ifindex=0, nexthop=0x5560b03cb0dc,
   nh_bgp=0x5560ace04df0, nh_othervrf=0) at bgpd/bgp_zebra.c:1273
5  bgp_zebra_announce_actual (dest=dest@entry=0x5560afcfa950, info=0x5560b21187d0, bgp=0x5560ace04df0) at bgpd/bgp_zebra.c:1521 6  0x00005560aad4bc85 in bgp_handle_route_announcements_to_zebra (e=<optimized out>) at bgpd/bgp_zebra.c:1896 7  0x00007faef09a1c0d in thread_call (thread=thread@entry=0x7ffdde8d7580) at lib/thread.c:2008 8  0x00007faef095a598 in frr_run (master=0x5560ac7e5190) at lib/libfrr.c:1223 9  0x00005560aac65db6 in main (argc=<optimized out>, argv=<optimized out>) at bgpd/bgp_main.c:557

(gdb) f 4
4  0x00005560aad4b7d8 in update_ipv6nh_for_route_install (api_nh=0x7ffdde8cbe94, is_evpn=false, best_pi=0x5560b21187d0, pi=0x5560b21187d0, ifindex=0, nexthop=0x5560b03cb0dc,
    nh_bgp=0x5560ace04df0, nh_othervrf=0) at bgpd/bgp_zebra.c:1273
1273	in bgpd/bgp_zebra.c
(gdb) p pi->peer->ifp
$26 = (struct interface *) 0x0

Ticket :#4203904