### PR TITLE
pim6d: fix crash on clear ipv6 mroute

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -449,7 +449,7 @@ static void gm_sg_update(struct gm_sg *sg, bool has_expired)
 		 * this data structure.
 		 */
 		if (sg->oil)
-			pim_channel_oil_del(sg->oil, __func__);
+			sg->oil = pim_channel_oil_del(sg->oil, __func__);
 
 		/* multiple paths can lead to the last state going away;
 		 * t_sg_expire can still be running if we're arriving from

--- a/pimd/pim_tib.c
+++ b/pimd/pim_tib.c
@@ -115,13 +115,8 @@ bool tib_sg_gm_join(struct pim_instance *pim, pim_sgaddr sg,
 		return false;
 	}
 
-	if (!*oilp) {
+	if (!*oilp)
 		*oilp = tib_sg_oil_setup(pim, sg, oif);
-#if PIM_IPV == 6
-		if (pim_embedded_rp_is_embedded(&sg.grp))
-			(*oilp)->oil_ref_count--;
-#endif /* PIM_IPV == 6 */
-	}
 	if (!*oilp)
 		return false;
 


### PR DESCRIPTION
Fix crash on `clear ipv6 mroute` when using embedded RP.

Explanation: revert change to decrement reference count on embedded RP for channel_oil and always update the MLD group oil pointer.