### PR TITLE
pimd: clean up MSDP code

### DIFF
--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -53,7 +53,9 @@ static void pim_instance_terminate(struct pim_instance *pim)
 
 	pim_oil_terminate(pim);
 
+#if PIM_IPV == 4
 	pim_msdp_exit(pim);
+#endif /* PIM_IPV == 4 */
 
 	close(pim->reg_sock);
 
@@ -91,7 +93,9 @@ static struct pim_instance *pim_instance_init(struct vrf *vrf)
 	pim->spt.switchover = PIM_SPT_IMMEDIATE;
 	pim->spt.plist = NULL;
 
+#if PIM_IPV == 4
 	pim_msdp_init(pim, router->master);
+#endif /* PIM_IPV == 4 */
 	pim_vxlan_init(pim);
 
 	snprintf(hash_name, sizeof(hash_name), "PIM %s RPF Hash", vrf->name);

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -126,11 +126,6 @@ static struct pim_instance *pim_instance_init(struct vrf *vrf)
 	if (pim->reg_sock < 0)
 		assert(0);
 
-	/* MSDP global timer defaults. */
-	pim->msdp.hold_time = PIM_MSDP_PEER_HOLD_TIME;
-	pim->msdp.keep_alive = PIM_MSDP_PEER_KA_TIME;
-	pim->msdp.connection_retry = PIM_MSDP_PEER_CONNECT_RETRY_TIME;
-
 #if PIM_IPV == 4
 	pim_autorp_init(pim);
 #endif

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -150,7 +150,9 @@ struct pim_instance {
 
 	struct rb_pim_oil_head channel_oil_head;
 
+#if PIM_IPV == 4
 	struct pim_msdp msdp;
+#endif /* PIM_IPV == 4 */
 	struct pim_vxlan_instance vxlan;
 
 	struct pim_autorp *autorp;
@@ -224,8 +226,5 @@ void pim_vrf_terminate(void);
 extern struct pim_router *router;
 
 struct pim_instance *pim_get_pim_instance(vrf_id_t vrf_id);
-
-extern bool pim_msdp_log_neighbor_events(const struct pim_instance *pim);
-extern bool pim_msdp_log_sa_events(const struct pim_instance *pim);
 
 #endif

--- a/pimd/pim_msdp.h
+++ b/pimd/pim_msdp.h
@@ -235,8 +235,6 @@ struct pim_msdp {
 #define PIM_MSDP_PEER_READ_OFF(mp) event_cancel(&mp->t_read)
 #define PIM_MSDP_PEER_WRITE_OFF(mp) event_cancel(&mp->t_write)
 
-#if PIM_IPV != 6
-// struct pim_msdp *msdp;
 struct pim_instance;
 void pim_msdp_init(struct pim_instance *pim, struct event_loop *master);
 void pim_msdp_exit(struct pim_instance *pim);
@@ -262,6 +260,8 @@ void pim_msdp_up_join_state_changed(struct pim_instance *pim,
 void pim_msdp_up_del(struct pim_instance *pim, pim_sgaddr *sg);
 enum pim_msdp_err pim_msdp_mg_del(struct pim_instance *pim,
 				  const char *mesh_group_name);
+
+extern void pim_upstream_msdp_reg_timer_start(struct pim_upstream *up);
 
 /**
  * Allocates a new mesh group data structure under PIM instance.
@@ -341,53 +341,7 @@ void pim_msdp_peer_restart(struct pim_msdp_peer *mp);
  */
 void pim_msdp_shutdown(struct pim_instance *pim, bool state);
 
-#else /* PIM_IPV == 6 */
-static inline void pim_msdp_init(struct pim_instance *pim,
-				 struct event_loop *master)
-{
-}
-
-static inline void pim_msdp_exit(struct pim_instance *pim)
-{
-}
-
-static inline void pim_msdp_i_am_rp_changed(struct pim_instance *pim)
-{
-}
-
-static inline void pim_msdp_up_join_state_changed(struct pim_instance *pim,
-						  struct pim_upstream *xg_up)
-{
-}
-
-static inline void pim_msdp_up_del(struct pim_instance *pim, pim_sgaddr *sg)
-{
-}
-
-static inline void pim_msdp_sa_local_update(struct pim_upstream *up)
-{
-}
-
-static inline void pim_msdp_sa_local_del(struct pim_instance *pim,
-					 pim_sgaddr *sg)
-{
-}
-
-static inline int pim_msdp_config_write(struct pim_instance *pim,
-					struct vty *vty)
-{
-	return 0;
-}
-
-static inline bool pim_msdp_peer_config_write(struct vty *vty,
-					      struct pim_instance *pim)
-{
-	return false;
-}
-
-static inline void pim_msdp_shutdown(struct pim_instance *pim, bool state)
-{
-}
-#endif /* PIM_IPV == 6 */
+extern bool pim_msdp_log_neighbor_events(const struct pim_instance *pim);
+extern bool pim_msdp_log_sa_events(const struct pim_instance *pim);
 
 #endif

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -1008,6 +1008,38 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ss
 	return NB_OK;
 }
 
+pim6_msdp_err(pim_msdp_hold_time_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_keep_alive_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_connection_retry_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_mesh_group_destroy, nb_cb_destroy_args);
+pim6_msdp_err(pim_msdp_mesh_group_create, nb_cb_create_args);
+pim6_msdp_err(pim_msdp_mesh_group_source_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_mesh_group_source_destroy, nb_cb_destroy_args);
+pim6_msdp_err(pim_msdp_mesh_group_members_create, nb_cb_create_args);
+pim6_msdp_err(pim_msdp_mesh_group_members_destroy, nb_cb_destroy_args);
+pim6_msdp_err(pim_msdp_peer_sa_filter_in_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_peer_sa_filter_in_destroy, nb_cb_destroy_args);
+pim6_msdp_err(pim_msdp_peer_sa_filter_out_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_peer_sa_filter_out_destroy, nb_cb_destroy_args);
+pim6_msdp_err(pim_msdp_peer_sa_limit_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_peer_sa_limit_destroy, nb_cb_destroy_args);
+pim6_msdp_err(
+	routing_control_plane_protocols_control_plane_protocol_pim_address_family_msdp_peer_source_ip_modify,
+	nb_cb_modify_args);
+pim6_msdp_err(
+	routing_control_plane_protocols_control_plane_protocol_pim_address_family_msdp_peer_destroy,
+	nb_cb_destroy_args);
+pim6_msdp_err(
+	routing_control_plane_protocols_control_plane_protocol_pim_address_family_msdp_peer_create,
+	nb_cb_create_args);
+pim6_msdp_err(pim_msdp_peer_authentication_type_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_peer_authentication_key_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_peer_authentication_key_destroy, nb_cb_destroy_args);
+pim6_msdp_err(pim_msdp_log_neighbor_events_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_log_sa_events_modify, nb_cb_modify_args);
+pim6_msdp_err(pim_msdp_shutdown_modify, nb_cb_modify_args);
+
+#if PIM_IPV != 6
 /*
  * XPath:
  * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/msdp/hold-time
@@ -1081,26 +1113,6 @@ int pim_msdp_connection_retry_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
-pim6_msdp_err(pim_msdp_mesh_group_destroy, nb_cb_destroy_args);
-pim6_msdp_err(pim_msdp_mesh_group_create, nb_cb_create_args);
-pim6_msdp_err(pim_msdp_mesh_group_source_modify, nb_cb_modify_args);
-pim6_msdp_err(pim_msdp_mesh_group_source_destroy, nb_cb_destroy_args);
-pim6_msdp_err(pim_msdp_mesh_group_members_create, nb_cb_create_args);
-pim6_msdp_err(pim_msdp_mesh_group_members_destroy, nb_cb_destroy_args);
-pim6_msdp_err(routing_control_plane_protocols_control_plane_protocol_pim_address_family_msdp_peer_source_ip_modify,
-	      nb_cb_modify_args);
-pim6_msdp_err(routing_control_plane_protocols_control_plane_protocol_pim_address_family_msdp_peer_destroy,
-	      nb_cb_destroy_args);
-pim6_msdp_err(routing_control_plane_protocols_control_plane_protocol_pim_address_family_msdp_peer_create,
-	      nb_cb_create_args);
-pim6_msdp_err(pim_msdp_peer_authentication_type_modify, nb_cb_modify_args);
-pim6_msdp_err(pim_msdp_peer_authentication_key_modify, nb_cb_modify_args);
-pim6_msdp_err(pim_msdp_peer_authentication_key_destroy, nb_cb_destroy_args);
-pim6_msdp_err(pim_msdp_log_neighbor_events_modify, nb_cb_modify_args);
-pim6_msdp_err(pim_msdp_log_sa_events_modify, nb_cb_modify_args);
-pim6_msdp_err(pim_msdp_shutdown_modify, nb_cb_modify_args);
-
-#if PIM_IPV != 6
 /*
  * XPath:
  * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/msdp/log-neighbor-events
@@ -1489,7 +1501,6 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_ms
 
 	return NB_OK;
 }
-#endif /* PIM_IPV != 6 */
 
 /*
  * XPath:
@@ -1620,6 +1631,7 @@ int pim_msdp_peer_sa_limit_destroy(struct nb_cb_destroy_args *args)
 
 	return NB_OK;
 }
+#endif /* PIM_IPV != 6 */
 
 /*
  * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/mlag

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -709,7 +709,10 @@ int pim_register_recv(struct interface *ifp, pim_addr dest_addr,
 			// inherited_olist(S,G,rpt)
 			// This is taken care of by the kernel for us
 		}
+
+#if PIM_IPV == 4
 		pim_upstream_msdp_reg_timer_start(upstream);
+#endif /* PIM_IPV == 4 */
 	} else {
 		if (PIM_DEBUG_PIM_REG) {
 			if (!i_am_rp)

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -343,7 +343,9 @@ struct rp_info *pim_rp_find_match_group(struct pim_instance *pim,
  */
 void pim_rp_refresh_group_to_rp_mapping(struct pim_instance *pim)
 {
+#if PIM_IPV == 4
 	pim_msdp_i_am_rp_changed(pim);
+#endif /* PIM_IPV == 4 */
 	pim_upstream_reeval_use_rpt(pim);
 }
 
@@ -1030,7 +1032,9 @@ void pim_rp_check_on_if_add(struct pim_interface *pim_ifp)
 	}
 
 	if (i_am_rp_changed) {
+#if PIM_IPV == 4
 		pim_msdp_i_am_rp_changed(pim);
+#endif /* PIM_IPV == 4 */
 		pim_upstream_reeval_use_rpt(pim);
 	}
 }
@@ -1072,7 +1076,9 @@ void pim_i_am_rp_re_evaluate(struct pim_instance *pim)
 	}
 
 	if (i_am_rp_changed) {
+#if PIM_IPV == 4
 		pim_msdp_i_am_rp_changed(pim);
+#endif /* PIM_IPV == 4 */
 		pim_upstream_reeval_use_rpt(pim);
 	}
 }

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -178,7 +178,9 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 {
 	struct listnode *node, *nnode;
 	struct pim_ifchannel *ch;
+#if PIM_IPV == 4
 	bool notify_msdp = false;
+#endif /* PIM_IPV == 4 */
 
 	if (PIM_DEBUG_PIM_TRACE)
 		zlog_debug(
@@ -206,12 +208,14 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 	if (up->join_state == PIM_UPSTREAM_JOINED) {
 		pim_jp_agg_single_upstream_send(&up->rpf, up, 0);
 
+#if PIM_IPV == 4
 		if (pim_addr_is_any(up->sg.src)) {
 			/* if a (*, G) entry in the joined state is being
 			 * deleted we
 			 * need to notify MSDP */
 			notify_msdp = true;
 		}
+#endif /* PIM_IPV == 4 */
 	}
 
 	join_timer_stop(up);
@@ -221,7 +225,9 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 	if (!pim_addr_is_any(up->sg.src)) {
 		if (pim->upstream_sg_wheel)
 			wheel_remove_item(pim->upstream_sg_wheel, up);
+#if PIM_IPV == 4
 		notify_msdp = true;
+#endif /* PIM_IPV == 4 */
 	}
 
 	pim_mroute_del(up->channel_oil, __func__);
@@ -241,9 +247,11 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 
 	rb_pim_upstream_del(&pim->upstream_head, up);
 
+#if PIM_IPV == 4
 	if (notify_msdp) {
 		pim_msdp_up_del(pim, &up->sg);
 	}
+#endif /* PIM_IPV == 4 */
 
 	/* When RP gets deleted, pim_rp_del() deregister addr with Zebra NHT
 	 * and assign up->upstream_addr as INADDR_ANY.
@@ -723,7 +731,9 @@ void pim_upstream_switch(struct pim_instance *pim, struct pim_upstream *up,
 		if (old_state != PIM_UPSTREAM_JOINED) {
 			int old_fhr = PIM_UPSTREAM_FLAG_TEST_FHR(up->flags);
 
+#if PIM_IPV == 4
 			pim_msdp_up_join_state_changed(pim, up);
+#endif /* PIM_IPV == 4 */
 			if (pim_upstream_could_register(up)) {
 				PIM_UPSTREAM_FLAG_SET_FHR(up->flags);
 				if (!old_fhr
@@ -753,8 +763,10 @@ void pim_upstream_switch(struct pim_instance *pim, struct pim_upstream *up,
 		if (!pim_addr_is_any(up->sg.src))
 			up->sptbit = PIM_UPSTREAM_SPTBIT_FALSE;
 
+#if PIM_IPV == 4
 		if (old_state == PIM_UPSTREAM_JOINED)
 			pim_msdp_up_join_state_changed(pim, up);
+#endif /* PIM_IPV == 4 */
 
 		if (old_state != new_state) {
 			old_use_rpt =
@@ -1424,8 +1436,10 @@ struct pim_upstream *pim_upstream_keep_alive_timer_proc(
 		 */
 	}
 
+#if PIM_IPV == 4
 	/* source is no longer active - pull the SA from MSDP's cache */
 	pim_msdp_sa_local_del(pim, &up->sg);
+#endif /* PIM_IPV == 4 */
 
 	/* JoinDesired can change when KAT is started or stopped */
 	pim_upstream_update_join_desired(pim, up);
@@ -1493,30 +1507,13 @@ void pim_upstream_keep_alive_timer_start(struct pim_upstream *up, uint32_t time)
 	event_add_timer(router->master, pim_upstream_keep_alive_timer, up, time,
 			&up->t_ka_timer);
 
+#if PIM_IPV == 4
 	/* any time keepalive is started against a SG we will have to
 	 * re-evaluate our active source database */
 	pim_msdp_sa_local_update(up);
+#endif /* PIM_IPV == 4 */
 	/* JoinDesired can change when KAT is started or stopped */
 	pim_upstream_update_join_desired(up->pim, up);
-}
-
-/* MSDP on RP needs to know if a source is registerable to this RP */
-static void pim_upstream_msdp_reg_timer(struct event *t)
-{
-	struct pim_upstream *up = EVENT_ARG(t);
-	struct pim_instance *pim = up->channel_oil->pim;
-
-	/* source is no longer active - pull the SA from MSDP's cache */
-	pim_msdp_sa_local_del(pim, &up->sg);
-}
-
-void pim_upstream_msdp_reg_timer_start(struct pim_upstream *up)
-{
-	EVENT_OFF(up->t_msdp_reg_timer);
-	event_add_timer(router->master, pim_upstream_msdp_reg_timer, up,
-			PIM_MSDP_REG_RXED_PERIOD, &up->t_msdp_reg_timer);
-
-	pim_msdp_sa_local_update(up);
 }
 
 /*

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -350,7 +350,6 @@ int pim_upstream_inherited_olist(struct pim_instance *pim,
 int pim_upstream_empty_inherited_olist(struct pim_upstream *up);
 
 void pim_upstream_find_new_rpf(struct pim_instance *pim);
-void pim_upstream_msdp_reg_timer_start(struct pim_upstream *up);
 
 void pim_upstream_init(struct pim_instance *pim);
 void pim_upstream_terminate(struct pim_instance *pim);

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -180,8 +180,10 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 	int writes = 0;
 	struct pim_ssm *ssm = pim->ssm_info;
 
+#if PIM_IPV == 4
 	writes += pim_msdp_peer_config_write(vty, pim);
 	writes += pim_msdp_config_write(pim, vty);
+#endif /* PIM_IPV == 4 */
 
 	if (!pim->send_v6_secondary) {
 		vty_out(vty, " no send-v6-secondary\n");
@@ -271,17 +273,6 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 			vty_out(vty, " ssmpingd %pPA\n", &ss->source_addr);
 			++writes;
 		}
-	}
-
-	if (pim->msdp.hold_time != PIM_MSDP_PEER_HOLD_TIME
-	    || pim->msdp.keep_alive != PIM_MSDP_PEER_KA_TIME
-	    || pim->msdp.connection_retry != PIM_MSDP_PEER_CONNECT_RETRY_TIME) {
-		vty_out(vty, " msdp timers %u %u", pim->msdp.hold_time,
-			pim->msdp.keep_alive);
-		if (pim->msdp.connection_retry
-		    != PIM_MSDP_PEER_CONNECT_RETRY_TIME)
-			vty_out(vty, " %u", pim->msdp.connection_retry);
-		vty_out(vty, "\n");
 	}
 
 	return writes;


### PR DESCRIPTION
Move all MSDP code possible to its own files and guard MSDP code from being compiled in PIMv6.