### PR TITLE
pimd,pim6d: optimize multicast prefix generation and fix coverity scan defect

### DIFF
--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -480,9 +480,7 @@ static void pim_instate_pend_list(struct bsgrp_node *bsgrp_node)
 
 	pend = bsm_rpinfos_first(bsgrp_node->partial_bsrp_list);
 
-	if (!pim_get_all_mcast_group(&group_all))
-		return;
-
+	pim_get_all_mcast_group(&group_all);
 	rp_all = pim_rp_find_match_group(pim, &group_all);
 	rn = route_node_lookup(pim->rp_table, &bsgrp_node->group);
 
@@ -729,9 +727,7 @@ void pim_bsm_clear(struct pim_instance *pim)
 
 		pim_delete_tracked_nexthop(pim, nht_p, NULL, rp_info);
 
-		if (!pim_get_all_mcast_group(&g_all))
-			return;
-
+		pim_get_all_mcast_group(&g_all);
 		rp_all = pim_rp_find_match_group(pim, &g_all);
 
 		if (rp_all == rp_info) {

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2825,13 +2825,7 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp
 		else if (yang_dnode_get(args->dnode, "prefix-list")) {
 			plist = yang_dnode_get_string(args->dnode,
 					"./prefix-list");
-			if (!pim_get_all_mcast_group(&group)) {
-				flog_err(
-					EC_LIB_DEVELOPMENT,
-					"Unable to convert 224.0.0.0/4 to prefix");
-				return NB_ERR_INCONSISTENCY;
-			}
-
+			pim_get_all_mcast_group(&group);
 			result = pim_no_rp_cmd_worker(pim, rp_addr, group,
 						      plist, args->errmsg,
 						      args->errmsg_len);
@@ -2923,11 +2917,7 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp
 		pim = vrf->info;
 		plist = yang_dnode_get_string(args->dnode, NULL);
 		yang_dnode_get_pimaddr(&rp_addr, args->dnode, "../rp-address");
-		if (!pim_get_all_mcast_group(&group)) {
-			flog_err(EC_LIB_DEVELOPMENT,
-				 "Unable to convert 224.0.0.0/4 to prefix");
-			return NB_ERR_INCONSISTENCY;
-		}
+		pim_get_all_mcast_group(&group);
 		return pim_rp_cmd_worker(pim, rp_addr, group, plist,
 					 args->errmsg, args->errmsg_len);
 	}
@@ -2954,11 +2944,7 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp
 		pim = vrf->info;
 		yang_dnode_get_pimaddr(&rp_addr, args->dnode, "../rp-address");
 		plist = yang_dnode_get_string(args->dnode, NULL);
-		if (!pim_get_all_mcast_group(&group)) {
-			flog_err(EC_LIB_DEVELOPMENT,
-				 "Unable to convert 224.0.0.0/4 to prefix");
-			return NB_ERR_INCONSISTENCY;
-		}
+		pim_get_all_mcast_group(&group);
 		return pim_no_rp_cmd_worker(pim, rp_addr, group, plist,
 					    args->errmsg, args->errmsg_len);
 		break;

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -97,14 +97,7 @@ void pim_rp_init(struct pim_instance *pim)
 
 	rp_info = XCALLOC(MTYPE_PIM_RP, sizeof(*rp_info));
 
-	if (!pim_get_all_mcast_group(&rp_info->group)) {
-		flog_err(EC_LIB_DEVELOPMENT,
-			 "Unable to convert all-multicast prefix");
-		list_delete(&pim->rp_list);
-		route_table_finish(pim->rp_table);
-		XFREE(MTYPE_PIM_RP, rp_info);
-		return;
-	}
+	pim_get_all_mcast_group(&rp_info->group);
 	rp_info->rp.rpf_addr = PIMADDR_ANY;
 
 	listnode_add(pim->rp_list, rp_info);
@@ -524,11 +517,7 @@ int pim_rp_new(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 
 		rp_info->plist = XSTRDUP(MTYPE_PIM_FILTER_NAME, plist);
 	} else {
-
-		if (!pim_get_all_mcast_group(&group_all)) {
-			XFREE(MTYPE_PIM_RP, rp_info);
-			return PIM_GROUP_BAD_ADDRESS;
-		}
+		pim_get_all_mcast_group(&group_all);
 		rp_all = pim_rp_find_match_group(pim, &group_all);
 
 		/*
@@ -708,9 +697,10 @@ void pim_rp_del_config(struct pim_instance *pim, pim_addr rp_addr,
 	struct prefix group;
 	int result;
 
-	if (group_range == NULL)
-		result = pim_get_all_mcast_group(&group);
-	else
+	if (group_range == NULL) {
+		result = 0;
+		pim_get_all_mcast_group(&group);
+	} else
 		result = str2prefix(group_range, &group);
 
 	if (!result) {
@@ -789,9 +779,7 @@ int pim_rp_del(struct pim_instance *pim, pim_addr rp_addr, struct prefix group,
 			   &nht_p);
 	pim_delete_tracked_nexthop(pim, nht_p, NULL, rp_info);
 
-	if (!pim_get_all_mcast_group(&g_all))
-		return PIM_RP_BAD_ADDRESS;
-
+	pim_get_all_mcast_group(&g_all);
 	rp_all = pim_rp_find_match_group(pim, &g_all);
 
 	if (rp_all == rp_info) {

--- a/pimd/pim_util.c
+++ b/pimd/pim_util.c
@@ -213,16 +213,21 @@ bool pim_is_group_filtered(struct pim_interface *pim_ifp, pim_addr *grp, pim_add
 
 
 /* This function returns all multicast group */
-int pim_get_all_mcast_group(struct prefix *prefix)
+void pim_get_all_mcast_group(struct prefix *prefix)
 {
+	memset(prefix, 0, sizeof(*prefix));
+
 #if PIM_IPV == 4
-	if (!str2prefix("224.0.0.0/4", prefix))
-		return 0;
+	/* Precomputed version of: `str2prefix("224.0.0.0/4", prefix);` */
+	prefix->family = AF_INET;
+	prefix->prefixlen = 4;
+	prefix->u.prefix4.s_addr = htonl(0xe0000000);
 #else
-	if (!str2prefix("FF00::0/8", prefix))
-		return 0;
+	/* Precomputed version of: `str2prefix("FF00::0/8", prefix)` */
+	prefix->family = AF_INET6;
+	prefix->prefixlen = 8;
+	prefix->u.prefix6.s6_addr[0] = 0xff;
 #endif
-	return 1;
 }
 
 bool pim_addr_is_multicast(pim_addr addr)

--- a/pimd/pim_util.h
+++ b/pimd/pim_util.h
@@ -26,6 +26,6 @@ int pim_is_group_224_4(struct in_addr group_addr);
 enum filter_type pim_access_list_apply(struct access_list *access, const struct in_addr *source,
 				       const struct in_addr *group);
 bool pim_is_group_filtered(struct pim_interface *pim_ifp, pim_addr *grp, pim_addr *src);
-int pim_get_all_mcast_group(struct prefix *prefix);
+void pim_get_all_mcast_group(struct prefix *prefix);
 bool pim_addr_is_multicast(pim_addr addr);
 #endif /* PIM_UTIL_H */


### PR DESCRIPTION
Fix Coverity Scan CID 1602463: make it impossible for the function to fail.

Hardcode the multicast prefix generation instead of calling [`str2prefix()`](https://github.com/FRRouting/frr/blob/master/lib/prefix.c#L618) which caused unnecessary memory allocations and returned error values.