### PR TITLE
tests: clear `-Wcalloc-transposed-args` warnings

### DIFF
--- a/tests/helpers/c/prng.c
+++ b/tests/helpers/c/prng.c
@@ -24,7 +24,7 @@ struct prng {
 
 struct prng *prng_new(unsigned long long seed)
 {
-	struct prng *rv = calloc(sizeof(*rv), 1);
+	struct prng *rv = calloc(1, sizeof(*rv));
 	assert(rv);
 
 	rv->state = seed;

--- a/tests/isisd/test_isis_lspdb.c
+++ b/tests/isisd/test_isis_lspdb.c
@@ -16,7 +16,7 @@ static void test_lsp_build_list_nonzero_ht(void)
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00
 	};
 
-	struct isis_area *area = calloc(sizeof(*area), 1);
+	struct isis_area *area = calloc(1, sizeof(*area));
 
 	area->lsp_mtu = 1500;
 
@@ -75,7 +75,7 @@ static void test_lsp_build_list_nonzero_ht(void)
 int main(int argc, char **argv)
 {
 	struct isis *isis = NULL;
-	isis = calloc(sizeof(*isis), 1);
+	isis = calloc(1, sizeof(*isis));
 	test_lsp_build_list_nonzero_ht();
 	return 0;
 }

--- a/tests/lib/test_nexthop_iter.c
+++ b/tests/lib/test_nexthop_iter.c
@@ -62,7 +62,7 @@ static struct nexthop_chain *nexthop_chain_new(void)
 {
 	struct nexthop_chain *rv;
 
-	rv = calloc(sizeof(*rv), 1);
+	rv = calloc(1, sizeof(*rv));
 	assert(rv);
 	return rv;
 }
@@ -71,7 +71,7 @@ static void nexthop_chain_add_top(struct nexthop_chain *nc)
 {
 	struct nexthop *nh;
 
-	nh = calloc(sizeof(*nh), 1);
+	nh = calloc(1, sizeof(*nh));
 	assert(nh);
 
 	if (nc->head.nexthop) {
@@ -109,7 +109,7 @@ static void nexthop_chain_add_recursive(struct nexthop_chain *nc)
 {
 	struct nexthop *nh;
 
-	nh = calloc(sizeof(*nh), 1);
+	nh = calloc(1, sizeof(*nh));
 	assert(nh);
 
 	assert(nc->current_top);
@@ -128,7 +128,7 @@ static void nexthop_chain_add_recursive_level(struct nexthop_chain *nc)
 {
 	struct nexthop *nh;
 
-	nh = calloc(sizeof(*nh), 1);
+	nh = calloc(1, sizeof(*nh));
 	assert(nh);
 
 	assert(nc->current_top);


### PR DESCRIPTION
* order of arguments was swapped; not consistent with [`calloc` signature](https://man7.org/linux/man-pages/man3/calloc.3p.html)
* therefore producing [`-Wcalloc-transposed-args`](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html) during compilation.