### PR TITLE
pimd: During prefix-list update, behave as PIM_UPSTREAM_NOTJOINED sta…

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -643,6 +643,12 @@ void pim_upstream_update_use_rpt(struct pim_upstream *up,
 	if (pim_addr_is_any(up->sg.src))
 		return;
 
+	/* Ignore RP mapping when the upsteam state
+	 * is NOT Joined on a FHR
+	 */
+	if (up->join_state == PIM_UPSTREAM_NOTJOINED && PIM_UPSTREAM_FLAG_TEST_FHR(up->flags))
+		return;
+
 	old_use_rpt = !!PIM_UPSTREAM_FLAG_TEST_USE_RPT(up->flags);
 
 	/* We will use the SPT (IIF=RPF_interface(S) if -


### PR DESCRIPTION
…te (conformance issue)

Issue:
If there are any changes to the prefix list, we perform a re-lookup to map the correct RP for the group. Even if the S,G entry is PIM_UPSTREAM_NOTJOINED and in FHR, In the case of IGMPv3, an S,G entry can be created with no joins. this is not necessary.
 https://www.rfc-editor.org/rfc/rfc4601#section-4.5.7 says no op in case of NOTJOINED

Solution:
To solve this issue, Stop RP mapping when the state is NOTJOINED

Ticket: #3496931