### PR TITLE
zebra: update kernel routes with interface check

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2645,10 +2645,12 @@ static unsigned nexthop_active_check(struct route_node *rn,
 	 */
 	if (re->type == ZEBRA_ROUTE_KERNEL || re->type == ZEBRA_ROUTE_SYSTEM) {
 		struct interface *ifp;
+		int connected_if_count = 0;
 
 		ifp = if_lookup_by_index(nexthop->ifindex, nexthop->vrf_id);
+		connected_if_count = connected_count_by_family(ifp->connected, AF_INET) + connected_count_by_family(ifp->connected, AF_INET6);
 
-		if (ifp && ifp->vrf->vrf_id == vrf_id && if_is_up(ifp)) {
+		if (ifp && ifp->vrf->vrf_id == vrf_id && if_is_up(ifp) && connected_if_count) {
 			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 			goto skip_check;
 		}


### PR DESCRIPTION
https://github.com/FRRouting/frr/issues/13561

Kernel routes are not always properly updated in zebra. When an IP address is flushed from an interface route is still present in zebra.
Steps to reproduce: 
`ip link set dev eth0 up`
`ip -4 addr add 192.168.0.2/24 dev eth0`
`ip -4 route add default via 192.168.0.1`
`ip -4 addr flush dev eth0`

Current fix adds extra validation before setting NH Active.