### PR TITLE
babel: Clean babel config on babel daemon stop

### DIFF
--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -304,6 +304,12 @@ void babel_clean_routing_process(void)
     flush_all_routes();
     babel_interface_close_all();
 
+    /* Clean babel config */
+    diversity_kind = DIVERSITY_NONE;
+    diversity_factor = BABEL_DEFAULT_DIVERSITY_FACTOR;
+    resend_delay = BABEL_DEFAULT_RESEND_DELAY;
+    change_smoothing_half_life(BABEL_DEFAULT_SMOOTHING_HALF_LIFE);
+
     /* cancel events */
     event_cancel(&babel_routing_process->t_read);
     event_cancel(&babel_routing_process->t_update);


### PR DESCRIPTION
When deactivating babel no router babel and later re-enabling it router babel the previous configuration is still in place.

Steps to reproduce:
 - Enable babel
 - Configure babel
 - Disable babel with "no router babel"
 - Verify config

Expected correct behavior: No config present