### PR TITLE
ospfclient: fix crash due to streamwriter garbage collect

### DIFF
--- a/ospfclient/ospfclient.py
+++ b/ospfclient/ospfclient.py
@@ -306,7 +306,7 @@ class OspfApiClient:
         self._s = None
         self._as = None
         self._ls = None
-        self._ar = self._r = self._w = None
+        self._ar = self._r = self._aw = self._w = None
         self.server = server
         self.handlers = handlers if handlers is not None else dict()
         self.write_lock = Lock()
@@ -345,7 +345,7 @@ class OspfApiClient:
 
         logging.debug("%s: success", self)
         self._r, self._w = await asyncio.open_connection(sock=self._s)
-        self._ar, _ = await asyncio.open_connection(sock=self._as)
+        self._ar, self._aw = await asyncio.open_connection(sock=self._as)
         self._seq = 1
 
     async def connect(self):


### PR DESCRIPTION
The `ospfclient.py` script crashes immediately in python >3.11 due to  [this change](https://github.com/python/cpython/pull/107650) to fix a memory leak in the Python sockets API. It causes garbage collected `StreamWriter` instances to call `.close()`, which in-turn causes the `ospfclient.py` script to incorrectly call `.close()` on the async socket immediately after opening it, since it is currently using a throwaway `_` variable to store this writer, which immediately goes out of scope.

## Before this patch

```
> python3.12 ospfclient.py -v
2024-12-20 19:48:28,548 INFO: CLIENT: root ospfclient: starting
2024-12-20 19:48:28,548 DEBUG: CLIENT: asyncio Using selector: EpollSelector
2024-12-20 19:48:28,549 DEBUG: CLIENT: root OspfApiClient(localhost): binding to ports 49152, 49153
2024-12-20 19:48:28,549 DEBUG: CLIENT: root OspfApiClient(localhost): connect to OSPF API
2024-12-20 19:48:28,549 DEBUG: CLIENT: root OspfApiClient(localhost): connecting sync socket to server
2024-12-20 19:48:28,553 DEBUG: CLIENT: root OspfApiClient(localhost): accepting connect from server
2024-12-20 19:48:28,556 DEBUG: CLIENT: root OspfApiClient(localhost): success
2024-12-20 19:48:28,556 DEBUG: CLIENT: root SEND: OspfApiClient(localhost): request LSDB events
2024-12-20 19:48:28,557 DEBUG: CLIENT: root SEND: OspfApiClient(localhost): sending REGISTER_EVENT seq 0x1
2024-12-20 19:48:28,557 DEBUG: CLIENT: root entering async msg handling loop
2024-12-20 19:48:28,557 INFO: CLIENT: root Got EOF from OSPF API server on async notify socket
2024-12-20 19:48:28,557 DEBUG: CLIENT: root SEND: OspfApiClient(localhost): request LSDB sync
2024-12-20 19:48:28,557 DEBUG: CLIENT: root SEND: OspfApiClient(localhost): sending SYNC_LSDB seq 0x2
2024-12-20 19:48:28,559 DEBUG: CLIENT: root SEND: OspfApiClient(localhost): request reachable changes
2024-12-20 19:48:28,559 DEBUG: CLIENT: root SEND: OspfApiClient(localhost): sending MSG_SYNC_REACHABLE seq 0x3
2024-12-20 19:48:28,559 DEBUG: CLIENT: root OspfApiClient(localhost): closing
2024-12-20 19:48:28,559 ERROR: CLIENT: root async_main: unexpected error:
Traceback (most recent call last):
  File "/home/ubuntu/frr/ospfclient/ospfclient.py", line 397, in _msg_read
    mh = await r.readexactly(FMT_APIMSGHDR_SIZE)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/streams.py", line 750, in readexactly
    raise exceptions.IncompleteReadError(incomplete, n)
asyncio.exceptions.IncompleteReadError: 0 bytes read on a total of 8 expected bytes

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ubuntu/frr/ospfclient/ospfclient.py", line 1117, in async_main
    await c.req_reachable_routers()
  File "/home/ubuntu/frr/ospfclient/ospfclient.py", line 531, in req_reachable_routers
    await self.msg_send_raises(MSG_SYNC_REACHABLE)
  File "/home/ubuntu/frr/ospfclient/ospfclient.py", line 469, in msg_send_raises
    ecode = await self.msg_send(mt, mp)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/frr/ospfclient/ospfclient.py", line 443, in msg_send
    mt, mp = await OspfApiClient._msg_read(self._r, seq)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/frr/ospfclient/ospfclient.py", line 408, in _msg_read
    raise EOFError
EOFError
2024-12-20 19:48:28,561 INFO: CLIENT: root ospfclient: clean exit
```

## After this patch

```
> python3.12 ospfclient.py -v
2024-12-20 19:50:53,680 INFO: CLIENT: root ospfclient: starting
2024-12-20 19:50:53,680 DEBUG: CLIENT: asyncio Using selector: EpollSelector
2024-12-20 19:50:53,681 DEBUG: CLIENT: root OspfApiClient(localhost): binding to ports 49152, 49153
2024-12-20 19:50:53,681 DEBUG: CLIENT: root OspfApiClient(localhost): connect to OSPF API
2024-12-20 19:50:53,681 DEBUG: CLIENT: root OspfApiClient(localhost): connecting sync socket to server
2024-12-20 19:50:53,684 DEBUG: CLIENT: root OspfApiClient(localhost): accepting connect from server
2024-12-20 19:50:53,687 DEBUG: CLIENT: root OspfApiClient(localhost): success
2024-12-20 19:50:53,687 DEBUG: CLIENT: root SEND: OspfApiClient(localhost): request LSDB events
2024-12-20 19:50:53,687 DEBUG: CLIENT: root SEND: OspfApiClient(localhost): sending REGISTER_EVENT seq 0x1
2024-12-20 19:50:53,688 DEBUG: CLIENT: root entering async msg handling loop
2024-12-20 19:50:53,688 DEBUG: CLIENT: root SEND: OspfApiClient(localhost): request LSDB sync
2024-12-20 19:50:53,688 DEBUG: CLIENT: root SEND: OspfApiClient(localhost): sending SYNC_LSDB seq 0x2
2024-12-20 19:50:53,689 DEBUG: CLIENT: root _msg_read: got seq: 0x2 on async read
2024-12-20 19:50:53,690 DEBUG: CLIENT: root RECV: OspfApiClient(localhost): calling handler for LSA_UPDATE_NOTIFY
2024-12-20 19:50:53,690 INFO: CLIENT: root RECV: LSA update msg for LSA 10.10.10.10 in area 0.0.0.0 seq 0x8000db78 len 36 age 5
2024-12-20 19:50:53,690 DEBUG: CLIENT: root _msg_read: got seq: 0x2 on async read
...
```