### PR TITLE
tests: cleanup ospf6 ecmp inter area

### DIFF
--- a/tests/topotests/ospf6_ecmp_inter_area/r1/show_ipv6_routes_ospf6-1.json
+++ b/tests/topotests/ospf6_ecmp_inter_area/r1/show_ipv6_routes_ospf6-1.json
@@ -1,0 +1,155 @@
+{
+  "2001:db8:2::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:3::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth1",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:4::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:5::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:6::/64": [
+    {
+      "internalNextHopActiveNum": 2,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        },
+        {
+          "fib": true,
+          "interfaceName": "r1-eth1",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:7::/64": [
+    {
+      "internalNextHopActiveNum": 3,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        },
+        {
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        },
+        {
+          "fib": true,
+          "interfaceName": "r1-eth1",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:8::/64": [
+    {
+      "internalNextHopActiveNum": 3,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        },
+        {
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        },
+        {
+          "fib": true,
+          "interfaceName": "r1-eth1",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:8007::/64": [
+    {
+      "internalNextHopActiveNum": 3,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        },
+        {
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        },
+        {
+          "fib": true,
+          "interfaceName": "r1-eth1",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:8008::/64": [
+    {
+      "internalNextHopActiveNum": 3,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        },
+        {
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        },
+        {
+          "fib": true,
+          "interfaceName": "r1-eth1",
+          "active": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/ospf6_ecmp_inter_area/r1/show_ipv6_routes_ospf6-2.json
+++ b/tests/topotests/ospf6_ecmp_inter_area/r1/show_ipv6_routes_ospf6-2.json
@@ -1,0 +1,130 @@
+{
+  "2001:db8:2::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:3::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth1",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:4::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:5::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:6::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:7::/64": [
+    {
+      "internalNextHopActiveNum": 2,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        },
+        {
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:8::/64": [
+    {
+      "internalNextHopActiveNum": 2,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        },
+        {
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:8007::/64": [
+    {
+      "internalNextHopActiveNum": 2,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        },
+        {
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:8008::/64": [
+    {
+      "internalNextHopActiveNum": 2,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        },
+        {
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/ospf6_ecmp_inter_area/r1/show_ipv6_routes_ospf6-3.json
+++ b/tests/topotests/ospf6_ecmp_inter_area/r1/show_ipv6_routes_ospf6-3.json
@@ -1,0 +1,110 @@
+{
+  "2001:db8:2::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:3::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth1",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:4::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:5::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:6::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:7::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:8::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:8007::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "2001:db8:8008::/64": [
+    {
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "fib": true,
+          "interfaceName": "r1-eth2",
+          "active": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/ospf6_ecmp_inter_area/r7/ospf6d.conf
+++ b/tests/topotests/ospf6_ecmp_inter_area/r7/ospf6d.conf
@@ -13,9 +13,6 @@ interface r7-eth2
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
 !
-interface r7-eth3
- shutdown
-!
 router ospf6
  ospf6 router-id 10.254.254.7
  redistribute connected

--- a/tests/topotests/ospf6_ecmp_inter_area/r8/ospf6d.conf
+++ b/tests/topotests/ospf6_ecmp_inter_area/r8/ospf6d.conf
@@ -13,9 +13,6 @@ interface r8-eth2
  ipv6 ospf6 hello-interval 2
  ipv6 ospf6 dead-interval 10
 !
-interface r8-eth3
- shutdown
-!
 router ospf6
  ospf6 router-id 10.254.254.8
  redistribute connected


### PR DESCRIPTION
Replaces/supersedes #16811. Addresses all review comments.

Compare JSON routes to check for success instead of counting nexthops. Also fix bad interface shutdown config.

Note that like #16811, this does not fix intermittent test case failures. These are actual ospf6d errors, not test case bugs. See https://github.com/FRRouting/frr/issues/16197 for details, in particular comments starting at https://github.com/FRRouting/frr/issues/16197#issuecomment-2293383832
