### PR TITLE
bgpd: Clean address-family config on daemon restart

### DIFF
--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -831,6 +831,7 @@ extern void bgp_redistribute_withdraw(struct bgp *, afi_t, int, unsigned short);
 
 extern void bgp_static_add(struct bgp *);
 extern void bgp_static_delete(struct bgp *);
+extern void bgp_address_family_distance_delete(void);
 extern void bgp_static_redo_import_check(struct bgp *);
 extern void bgp_purge_static_redist_routes(struct bgp *bgp);
 extern void bgp_static_update(struct bgp *bgp, const struct prefix *p,

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4237,6 +4237,14 @@ int bgp_delete(struct bgp *bgp)
 		}
 	}
 
+	/* Clean BGP address family parameters */
+	bgp_mh_info->ead_evi_rx = BGP_EVPN_MH_EAD_EVI_RX_DEF;
+	bgp_evpn_switch_ead_evi_rx();
+	bgp_mh_info->ead_evi_tx = BGP_EVPN_MH_EAD_EVI_TX_DEF;
+	bgp_mh_info->evi_per_es_frag = BGP_EVPN_MAX_EVI_PER_ES_FRAG;
+
+	bgp_address_family_distance_delete();
+
 	return 0;
 }
 


### PR DESCRIPTION
When stopping and restarting BGP daemon part of the configuration remains. It should be cleared.
Particulary those are address-family parametes, like: distance, ead-es-frag, disable-ead-evi-rx, disable-ead-evi-tx.