### PR TITLE
tests: Fix markers in `srv6_static_route` topotest

### DIFF
--- a/tests/topotests/srv6_static_route/test_srv6_route.py
+++ b/tests/topotests/srv6_static_route/test_srv6_route.py
@@ -27,7 +27,7 @@ from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
-pytestmark = [pytest.mark.bgpd, pytest.mark.sharpd]
+pytestmark = [pytest.mark.staticd]
 
 
 def open_json_file(filename):


### PR DESCRIPTION
`srv6_static_route` is a pure staticd topotest. It does not have any dependency on bgpd and sharpd.

Let's fix the pytestmark to include only staticd.