### PR TITLE
tools: Add missing formats keyword to segment-routing in frr-reload

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -279,7 +279,11 @@ ctx_keywords = {
             "policy ": {"candidate-path ": {}},
             "pcep": {"pcc": {}, "pce ": {}, "pce-config ": {}},
         },
-        "srv6": {"locators": {"locator ": {}}, "encapsulation": {}},
+        "srv6": {
+            "locators": {"locator ": {}},
+            "encapsulation": {},
+            "formats": {"format": {}},
+        },
     },
     "nexthop-group ": {},
     "route-map ": {},


### PR DESCRIPTION
When reloading the following configuration:
```
segment-routing
 srv6
  formats
   format usid-f3216
     wide-local-id-block explicit start 100
   exit
   !
   format uncompressed-f4024
   exit
   !
  exit
  !
 exit
 !
exit
```
frr-reload.py does not properly enter the `formats` context. Because of this, it fails with an unknown command error when applying new or updating format configuration.