### PR TITLE
bgpd: add rpki current state

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11975,14 +11975,13 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t sa
 					continue;
 			}
 
-			if (type == bgp_show_type_rpki) {
-				if (dest_p->family == AF_INET
-				    || dest_p->family == AF_INET6)
-					rpki_curr_state = hook_call(
-						bgp_rpki_prefix_status,
-						pi->peer, pi->attr, dest_p);
-				if (rpki_target_state != RPKI_NOT_BEING_USED
-				    && rpki_curr_state != rpki_target_state)
+			if ((dest_p->family == AF_INET || dest_p->family == AF_INET6) &&
+			    (detail_routes || detail_json || type == bgp_show_type_rpki)) {
+				rpki_curr_state = hook_call(bgp_rpki_prefix_status, pi->peer,
+							    pi->attr, dest_p);
+				if (type == bgp_show_type_rpki &&
+				    rpki_target_state != RPKI_NOT_BEING_USED &&
+				    rpki_curr_state != rpki_target_state)
 					continue;
 			}
 
@@ -12213,7 +12212,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t sa
 
 					route_vty_out_detail(vty, bgp, dest, dest_p, pi,
 							     family2afi(dest_p->family), safi,
-							     RPKI_NOT_BEING_USED, json_paths, NULL);
+							     rpki_curr_state, json_paths, NULL);
 				} else {
 					route_vty_out(vty, dest_p, pi, display,
 						      safi, json_paths, wide);

--- a/tests/topotests/bgp_rpki_topo1/r2/bgp_rpki_valid.json
+++ b/tests/topotests/bgp_rpki_topo1/r2/bgp_rpki_valid.json
@@ -1,0 +1,70 @@
+{
+    "vrfId": 0,
+    "vrfName": "default",
+    "tableVersion": 3,
+    "routerId": "192.0.2.2",
+    "defaultLocPrf": 100,
+    "localAS": 65002,
+    "routes": {
+        "198.51.100.0/24": [
+            {
+                "origin": "IGP",
+                "metric": 0,
+                "valid": true,
+                "version": 2,
+                "rpkiValidationState": "valid",
+                "bestpath": {
+                    "overall": true,
+                    "selectionReason": "First path received"
+                },
+                "nexthops": [
+                    {
+                        "ip": "192.0.2.1",
+                        "hostname": "r1",
+                        "afi": "ipv4",
+                        "metric": 0,
+                        "accessible": true,
+                        "used": true
+                    }
+                ],
+                "peer": {
+                    "peerId": "192.0.2.1",
+                    "routerId": "192.0.2.1",
+                    "hostname": "r1",
+                    "type": "external"
+                }
+            }
+        ],
+        "203.0.113.0/24": [
+            {
+                "origin": "IGP",
+                "metric": 0,
+                "valid": true,
+                "version": 3,
+                "rpkiValidationState": "valid",
+                "bestpath": {
+                    "overall": true,
+                    "selectionReason": "First path received"
+                },
+                "nexthops": [
+                    {
+                        "ip": "192.0.2.1",
+                        "hostname": "r1",
+                        "afi": "ipv4",
+                        "metric": 0,
+                        "accessible": true,
+                        "used": true
+                    }
+                ],
+                "peer": {
+                    "peerId": "192.0.2.1",
+                    "routerId": "192.0.2.1",
+                    "hostname": "r1",
+                    "type": "external"
+                }
+            }
+        ]
+    },
+    "totalRoutes": 3,
+    "totalPaths": 3
+}


### PR DESCRIPTION
Display rpki_curr_state in the output and provide a topotest to theck the json field:

```
                "version": 2,
                "rpkiValidationState": "valid",
                "bestpath": {
                    "overall": true,
                    "selectionReason": "First path received"
                },
```