### PR TITLE
BMP handling of BGP configuration changes

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2017,7 +2017,8 @@ static void bmp_bgp_peer_vrf(struct bmp_bgp_peer *bbpeer, struct bgp *bgp)
 	memcpy(bbpeer->open_rx, s->data, open_len);
 
 	bbpeer->open_tx_len = open_len;
-	bbpeer->open_tx = bbpeer->open_rx;
+	bbpeer->open_tx = XMALLOC(MTYPE_BMP_OPEN, open_len);
+	memcpy(bbpeer->open_tx, s->data, open_len);
 
 	stream_free(s);
 }

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -3117,10 +3117,13 @@ static int bmp_route_update(struct bgp *bgp, afi_t afi, safi_t safi,
 		return 0;
 	}
 
-	struct bmp_bgp *bmpbgp = bmp_bgp_get(bgp);
+	struct bmp_bgp *bmpbgp = bmp_bgp_find(bgp);
 	struct peer *peer = updated_route->peer;
 	struct bmp_targets *bt;
 	struct bmp *bmp;
+
+	if (!bmpbgp)
+		return 0;
 
 	frr_each (bmp_targets, &bmpbgp->targets, bt) {
 		if (CHECK_FLAG(bt->afimon[afi][safi], BMP_MON_LOC_RIB)) {

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -28,6 +28,7 @@
 #include "bgpd/bgp_table.h"
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_route.h"
+#include "bgpd/bgp_nht.h"
 #include "bgpd/bgp_attr.h"
 #include "bgpd/bgp_dump.h"
 #include "bgpd/bgp_errors.h"
@@ -1708,6 +1709,26 @@ static int bmp_process(struct bgp *bgp, afi_t afi, safi_t safi,
 	return 0;
 }
 
+static int bmp_nht_path_valid(struct bgp *bgp, struct bgp_path_info *path, bool valid)
+{
+	struct bgp_dest *dest = path->net;
+	struct bgp_table *table;
+
+	if (frrtrace_enabled(frr_bgp, bmp_nht_path_valid)) {
+		char pfxprint[PREFIX2STR_BUFFER];
+
+		prefix2str(&dest->rn->p, pfxprint, sizeof(pfxprint));
+		frrtrace(4, frr_bgp, bmp_nht_path_valid, bgp, pfxprint, path, valid);
+	}
+	if (bgp->peer_self == path->peer)
+		/* self declared networks or redistributed networks are not relevant for bmp */
+		return 0;
+
+	table = bgp_dest_table(dest);
+
+	return bmp_process(bgp, table->afi, table->safi, dest, path->peer, !valid);
+}
+
 static void bmp_stat_put_u32(struct stream *s, size_t *cnt, uint16_t type,
 		uint32_t value)
 {
@@ -3195,6 +3216,7 @@ static int bgp_bmp_module_init(void)
 	hook_register(peer_status_changed, bmp_peer_status_changed);
 	hook_register(peer_backward_transition, bmp_peer_backward);
 	hook_register(bgp_process, bmp_process);
+	hook_register(bgp_nht_path_update, bmp_nht_path_valid);
 	hook_register(bgp_inst_config_write, bmp_config_write);
 	hook_register(bgp_inst_delete, bmp_bgp_del);
 	hook_register(frr_late_init, bgp_bmp_init);

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2034,10 +2034,14 @@ static void bmp_bgp_peer_vrf(struct bmp_bgp_peer *bbpeer, struct bgp *bgp)
 	size_t open_len = stream_get_endp(s);
 
 	bbpeer->open_rx_len = open_len;
+	if (bbpeer->open_rx)
+		XFREE(MTYPE_BMP_OPEN, bbpeer->open_rx);
 	bbpeer->open_rx = XMALLOC(MTYPE_BMP_OPEN, open_len);
 	memcpy(bbpeer->open_rx, s->data, open_len);
 
 	bbpeer->open_tx_len = open_len;
+	if (bbpeer->open_tx)
+		XFREE(MTYPE_BMP_OPEN, bbpeer->open_tx);
 	bbpeer->open_tx = XMALLOC(MTYPE_BMP_OPEN, open_len);
 	memcpy(bbpeer->open_tx, s->data, open_len);
 
@@ -2079,6 +2083,7 @@ bool bmp_bgp_update_vrf_status(struct bmp_bgp *bmpbgp, enum bmp_vrf_state force)
 		} else {
 			bbpeer = bmp_bgp_peer_find(peer->qobj_node.nid);
 			if (bbpeer) {
+				XFREE(MTYPE_BMP_OPEN, bbpeer->open_tx);
 				XFREE(MTYPE_BMP_OPEN, bbpeer->open_rx);
 				bmp_peerh_del(&bmp_peerh, bbpeer);
 				XFREE(MTYPE_BMP_PEER, bbpeer);

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -3180,7 +3180,7 @@ static int bgp_bmp_early_fini(void)
 }
 
 /* called when the routerid of an instance changes */
-static int bmp_routerid_update(struct bgp *bgp, bool withdraw)
+static int bmp_bgp_attribute_updated(struct bgp *bgp, bool withdraw)
 {
 	struct bmp_bgp *bmpbgp = bmp_bgp_find(bgp);
 
@@ -3200,6 +3200,15 @@ static int bmp_routerid_update(struct bgp *bgp, bool withdraw)
 	return 1;
 }
 
+static int bmp_routerid_update(struct bgp *bgp, bool withdraw)
+{
+	return bmp_bgp_attribute_updated(bgp, withdraw);
+}
+
+static int bmp_route_distinguisher_update(struct bgp *bgp, afi_t afi, bool preconfig)
+{
+	return bmp_bgp_attribute_updated(bgp, preconfig);
+}
 
 /* called when a bgp instance goes up/down, implying that the underlying VRF
  * has been created or deleted in zebra
@@ -3255,6 +3264,7 @@ static int bgp_bmp_module_init(void)
 	hook_register(bgp_instance_state, bmp_vrf_state_changed);
 	hook_register(bgp_vrf_status_changed, bmp_vrf_itf_state_changed);
 	hook_register(bgp_routerid_update, bmp_routerid_update);
+	hook_register(bgp_route_distinguisher_update, bmp_route_distinguisher_update);
 	return 0;
 }
 

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -199,7 +199,7 @@ static int read_ibuf_work(struct peer_connection *connection)
 	assert(ringbuf_get(ibw, pkt->data, pktsize) == pktsize);
 	stream_set_endp(pkt, pktsize);
 
-	frrtrace(2, frr_bgp, packet_read, connection->peer, pkt);
+	frrtrace(2, frr_bgp, packet_read, connection, pkt);
 	frr_with_mutex (&connection->io_mtx) {
 		stream_fifo_push(connection->ibuf, pkt);
 	}

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -41,6 +41,9 @@ static void unregister_zebra_rnh(struct bgp_nexthop_cache *bnc);
 static int make_prefix(int afi, struct bgp_path_info *pi, struct prefix *p);
 static void bgp_nht_ifp_initial(struct event *thread);
 
+DEFINE_HOOK(bgp_nht_path_update, (struct bgp *bgp, struct bgp_path_info *pi, bool valid),
+	    (bgp, pi, valid));
+
 static int bgp_isvalid_nexthop(struct bgp_nexthop_cache *bnc)
 {
 	return (bgp_zebra_num_connects() == 0
@@ -1448,6 +1451,9 @@ void evaluate_paths(struct bgp_nexthop_cache *bnc)
 						path);
 			}
 		}
+
+		if (path_valid != bnc_is_valid_nexthop)
+			hook_call(bgp_nht_path_update, bgp_path, path, bnc_is_valid_nexthop);
 
 		bgp_process(bgp_path, dest, path, afi, safi);
 	}

--- a/bgpd/bgp_nht.h
+++ b/bgpd/bgp_nht.h
@@ -83,4 +83,9 @@ extern void bgp_nht_ifp_up(struct interface *ifp);
 extern void bgp_nht_ifp_down(struct interface *ifp);
 
 extern void bgp_nht_interface_events(struct peer *peer);
+
+/* called when a path becomes valid or invalid, because of nexthop tracking */
+DECLARE_HOOK(bgp_nht_path_update, (struct bgp *bgp, struct bgp_path_info *pi, bool valid),
+	     (bgp, pi, valid));
+
 #endif /* _BGP_NHT_H */

--- a/bgpd/bgp_trace.h
+++ b/bgpd/bgp_trace.h
@@ -211,6 +211,24 @@ TRACEPOINT_EVENT(
 TRACEPOINT_LOGLEVEL(frr_bgp, bmp_process, TRACE_DEBUG)
 
 /*
+ * BMP is hooked for a nexthop tracking event
+ */
+TRACEPOINT_EVENT(
+	frr_bgp,
+	bmp_nht_path_valid,
+	TP_ARGS(struct bgp *, bgp, char *, pfx, struct bgp_path_info *,
+		path, bool, valid),
+	TP_FIELDS(
+		ctf_string(bgp, bgp->name_pretty)
+		ctf_string(prefix, pfx)
+		ctf_string(path, PEER_HOSTNAME(path->peer))
+		ctf_integer(bool, valid, valid)
+	)
+)
+
+TRACEPOINT_LOGLEVEL(frr_bgp, bmp_nht_path_valid, TRACE_DEBUG)
+
+/*
  * bgp_dest_lock/bgp_dest_unlock
  */
 TRACEPOINT_EVENT(

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -86,6 +86,7 @@ DEFINE_QOBJ_TYPE(bgp);
 DEFINE_QOBJ_TYPE(peer);
 DEFINE_HOOK(bgp_inst_delete, (struct bgp *bgp), (bgp));
 DEFINE_HOOK(bgp_instance_state, (struct bgp *bgp), (bgp));
+DEFINE_HOOK(bgp_routerid_update, (struct bgp *bgp, bool withdraw), (bgp, withdraw));
 
 /* BGP process wide configuration.  */
 static struct bgp_master bgp_master;
@@ -301,6 +302,8 @@ static int bgp_router_id_set(struct bgp *bgp, const struct in_addr *id,
 
 	vpn_handle_router_id_update(bgp, true, is_config);
 
+	hook_call(bgp_routerid_update, bgp, true);
+
 	IPV4_ADDR_COPY(&bgp->router_id, id);
 
 	/* Set all peer's local identifier with this value. */
@@ -318,6 +321,7 @@ static int bgp_router_id_set(struct bgp *bgp, const struct in_addr *id,
 
 	vpn_handle_router_id_update(bgp, false, is_config);
 
+	hook_call(bgp_routerid_update, bgp, false);
 	return 0;
 }
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -907,6 +907,7 @@ DECLARE_HOOK(bgp_config_end, (struct bgp *bgp), (bgp));
 DECLARE_HOOK(bgp_hook_vrf_update, (struct vrf *vrf, bool enabled),
 	     (vrf, enabled));
 DECLARE_HOOK(bgp_instance_state, (struct bgp *bgp), (bgp));
+DECLARE_HOOK(bgp_routerid_update, (struct bgp *bgp, bool withdraw), (bgp, withdraw));
 
 /* Thread callback information */
 struct afi_safi_info {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -908,6 +908,8 @@ DECLARE_HOOK(bgp_hook_vrf_update, (struct vrf *vrf, bool enabled),
 	     (vrf, enabled));
 DECLARE_HOOK(bgp_instance_state, (struct bgp *bgp), (bgp));
 DECLARE_HOOK(bgp_routerid_update, (struct bgp *bgp, bool withdraw), (bgp, withdraw));
+DECLARE_HOOK(bgp_route_distinguisher_update, (struct bgp *bgp, afi_t afi, bool preconfig),
+	     (bgp, afi, preconfig));
 
 /* Thread callback information */
 struct afi_safi_info {

--- a/tests/topotests/bgp_bmp/bgpbmp.py
+++ b/tests/topotests/bgp_bmp/bgpbmp.py
@@ -187,7 +187,12 @@ def bmp_check_for_prefixes(
 
 
 def bmp_check_for_peer_message(
-    expected_peers, bmp_log_type, bmp_collector, bmp_log_file, is_rd_instance=False
+    expected_peers,
+    bmp_log_type,
+    bmp_collector,
+    bmp_log_file,
+    is_rd_instance=False,
+    peer_bgp_id=None,
 ):
     """
     Check for the presence of a peer up message for the peer
@@ -208,6 +213,8 @@ def bmp_check_for_peer_message(
     peers = []
     for m in messages:
         if is_rd_instance and m["peer_distinguisher"] == "0:0":
+            continue
+        if peer_bgp_id and m["peer_bgp_id"] != peer_bgp_id:
             continue
         if (
             "peer_ip" in m.keys()

--- a/tests/topotests/bgp_bmp/bgpbmp.py
+++ b/tests/topotests/bgp_bmp/bgpbmp.py
@@ -193,6 +193,7 @@ def bmp_check_for_peer_message(
     bmp_log_file,
     is_rd_instance=False,
     peer_bgp_id=None,
+    peer_distinguisher=None,
 ):
     """
     Check for the presence of a peer up message for the peer
@@ -213,6 +214,8 @@ def bmp_check_for_peer_message(
     peers = []
     for m in messages:
         if is_rd_instance and m["peer_distinguisher"] == "0:0":
+            continue
+        if peer_distinguisher and m["peer_distinguisher"] != peer_distinguisher:
             continue
         if peer_bgp_id and m["peer_bgp_id"] != peer_bgp_id:
             continue

--- a/tests/topotests/bgp_bmp/test_bgp_bmp_2.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_2.py
@@ -339,6 +339,82 @@ def test_bgp_routerid_changed():
     ), "Checking the BMP peer up LOC-RIB message with router-id set to 192.168.1.77 failed !."
 
 
+def test_reconfigure_route_distinguisher_vrf1():
+    """
+    Checking for BMP peers down messages
+    """
+    tgen = get_topogen()
+
+    bmp_update_seq(
+        tgen.gears["bmp1vrf"], os.path.join(tgen.logdir, "bmp1vrf", "bmp.log")
+    )
+    peers = ["0.0.0.0"]
+
+    tgen.gears["r1vrf"].vtysh_cmd(
+        """
+        configure terminal
+        router bgp 65501 vrf vrf1
+        address-family ipv4 unicast
+        rd vpn export 666:22
+        exit-address-family
+        address-family ipv6 unicast
+        rd vpn export 666:22
+        """
+    )
+    logger.info(
+        "checking for BMP peer down LOC-RIB message with route-distinguisher set to 444:1"
+    )
+    test_func = partial(
+        bmp_check_for_peer_message,
+        peers,
+        "peer down",
+        tgen.gears["bmp1vrf"],
+        os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        is_rd_instance=True,
+        peer_distinguisher="444:1",
+    )
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert (
+        success
+    ), "Checking the BMP peer down LOC-RIB message with route-distinguisher set to 444:1 failed !."
+
+    logger.info(
+        "checking for BMP peer up LOC-RIB messages with route-distinguisher set to 666:22"
+    )
+    test_func = partial(
+        bmp_check_for_peer_message,
+        peers,
+        "peer up",
+        tgen.gears["bmp1vrf"],
+        os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        is_rd_instance=True,
+        peer_bgp_id="192.168.1.77",
+        peer_distinguisher="666:22",
+    )
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert (
+        success
+    ), "Checking the BMP peer up LOC-RIB message with route-distinguisher set to 666:22 failed !."
+
+    logger.info(
+        "checking for BMP peer up messages with route-distinguisher set to 666:22"
+    )
+    peers = ["192.168.0.2", "192:168::2"]
+    test_func = partial(
+        bmp_check_for_peer_message,
+        peers,
+        "peer up",
+        tgen.gears["bmp1vrf"],
+        os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        is_rd_instance=True,
+        peer_distinguisher="666:22",
+    )
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert (
+        success
+    ), "Checking the BMP peer up messages with route-distinguisher set to 666:22 failed !."
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/tests/topotests/bgp_bmp/test_bgp_bmp_2.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_2.py
@@ -252,6 +252,43 @@ def test_peer_down():
     assert success, "Checking the updated prefixes has been failed !."
 
 
+def test_bgp_instance_flapping():
+    """
+    Checking for BGP loc-rib up messages
+    """
+    tgen = get_topogen()
+
+    # create flapping at BMP
+    tgen.net["r1vrf"].cmd("ip link set dev vrf1 down")
+
+    peers = ["0.0.0.0"]
+    logger.info("checking for BMP peer down LOC-RIB message.")
+    test_func = partial(
+        bmp_check_for_peer_message,
+        peers,
+        "peer down",
+        tgen.gears["bmp1vrf"],
+        os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        is_rd_instance=True,
+    )
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, "Checking the BMP peer down LOC-RIB message failed !."
+
+    tgen.net["r1vrf"].cmd("ip link set dev vrf1 up")
+
+    logger.info("checking for BMP peer up LOC-RIB message.")
+    test_func = partial(
+        bmp_check_for_peer_message,
+        peers,
+        "peer up",
+        tgen.gears["bmp1vrf"],
+        os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        is_rd_instance=True,
+    )
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, "Checking the BMP peer up LOC-RIB message failed !."
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/tests/topotests/lib/bmp_collector/bgp/update/rd.py
+++ b/tests/topotests/lib/bmp_collector/bgp/update/rd.py
@@ -4,6 +4,7 @@
 # Authored by Farid Mihoub <farid.mihoub@6wind.com>
 #
 import ipaddress
+import socket
 import struct
 
 
@@ -45,9 +46,11 @@ class RouteDistinguisher:
             self.repr_str = f"{self.as_number}:{self.assigned_sp}"
 
         elif rd_type == 1:
-            (self.admin_ipv4, self.assigned_sp) = struct.unpack_from("!IH", self.rd[2:])
-            ipv4 = str(ipaddress.IPv4Address(self.admin_ipv4))
-            self.repr_str = f"{self.as_number}:{self.assigned_sp}"
+            (self.admin_ipv4, self.assigned_sp) = struct.unpack_from(
+                "!4sH", self.rd[2:]
+            )
+            ipv4_str = socket.inet_ntoa(self.admin_ipv4)
+            self.repr_str = f"{ipv4_str}:{self.assigned_sp}"
 
         elif rd_type == 2:
             (self.four_bytes_as, self.assigned_sp) = struct.unpack_from(


### PR DESCRIPTION
Update BMP per peer header messages according to the various configuration changes:
- router-id
- route distinguisher
- vrf interface flapping

it replaces https://github.com/FRRouting/frr/pull/17373