### PR TITLE
bgpd,lib,zebra: permit table-direct on VRFs

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -17598,12 +17598,6 @@ DEFUN (bgp_redistribute_ipv4_ospf,
 	if (strncmp(argv[idx_ospf_table]->arg, "o", 1) == 0)
 		protocol = ZEBRA_ROUTE_OSPF;
 	else {
-		if (bgp->vrf_id != VRF_DEFAULT) {
-			vty_out(vty,
-				"%% Only default BGP instance can use '%s'\n",
-				argv[idx_ospf_table]->arg);
-			return CMD_WARNING_CONFIG_FAILED;
-		}
 		if (strncmp(argv[idx_ospf_table]->arg, "table-direct",
 			    strlen("table-direct")) == 0) {
 			protocol = ZEBRA_ROUTE_TABLE_DIRECT;
@@ -17657,12 +17651,6 @@ DEFUN (bgp_redistribute_ipv4_ospf_rmap,
 	if (strncmp(argv[idx_ospf_table]->arg, "o", 1) == 0)
 		protocol = ZEBRA_ROUTE_OSPF;
 	else {
-		if (bgp->vrf_id != VRF_DEFAULT) {
-			vty_out(vty,
-				"%% Only default BGP instance can use '%s'\n",
-				argv[idx_ospf_table]->arg);
-			return CMD_WARNING_CONFIG_FAILED;
-		}
 		if (strncmp(argv[idx_ospf_table]->arg, "table-direct",
 			    strlen("table-direct")) == 0) {
 			protocol = ZEBRA_ROUTE_TABLE_DIRECT;
@@ -17720,12 +17708,6 @@ DEFUN (bgp_redistribute_ipv4_ospf_metric,
 	if (strncmp(argv[idx_ospf_table]->arg, "o", 1) == 0)
 		protocol = ZEBRA_ROUTE_OSPF;
 	else {
-		if (bgp->vrf_id != VRF_DEFAULT) {
-			vty_out(vty,
-				"%% Only default BGP instance can use '%s'\n",
-				argv[idx_ospf_table]->arg);
-			return CMD_WARNING_CONFIG_FAILED;
-		}
 		if (strncmp(argv[idx_ospf_table]->arg, "table-direct",
 			    strlen("table-direct")) == 0) {
 			protocol = ZEBRA_ROUTE_TABLE_DIRECT;
@@ -17790,12 +17772,6 @@ DEFUN (bgp_redistribute_ipv4_ospf_rmap_metric,
 	if (strncmp(argv[idx_ospf_table]->arg, "o", 1) == 0)
 		protocol = ZEBRA_ROUTE_OSPF;
 	else {
-		if (bgp->vrf_id != VRF_DEFAULT) {
-			vty_out(vty,
-				"%% Only default BGP instance can use '%s'\n",
-				argv[idx_ospf_table]->arg);
-			return CMD_WARNING_CONFIG_FAILED;
-		}
 		if (strncmp(argv[idx_ospf_table]->arg, "table-direct",
 			    strlen("table-direct")) == 0) {
 			protocol = ZEBRA_ROUTE_TABLE_DIRECT;
@@ -17865,13 +17841,7 @@ DEFUN (bgp_redistribute_ipv4_ospf_metric_rmap,
 	if (strncmp(argv[idx_ospf_table]->arg, "o", 1) == 0)
 		protocol = ZEBRA_ROUTE_OSPF;
 	else {
-		if (bgp->vrf_id != VRF_DEFAULT) {
-			vty_out(vty,
-				"%% Only default BGP instance can use '%s'\n",
-				argv[idx_ospf_table]->arg);
-			return CMD_WARNING_CONFIG_FAILED;
-		} else if (strncmp(argv[idx_ospf_table]->arg, "table-direct",
-				   strlen("table-direct")) == 0) {
+		if (strncmp(argv[idx_ospf_table]->arg, "table-direct", strlen("table-direct")) == 0) {
 			protocol = ZEBRA_ROUTE_TABLE_DIRECT;
 			if (instance == RT_TABLE_MAIN ||
 			    instance == RT_TABLE_LOCAL) {
@@ -17934,12 +17904,6 @@ DEFUN (no_bgp_redistribute_ipv4_ospf,
 	if (strncmp(argv[idx_ospf_table]->arg, "o", 1) == 0)
 		protocol = ZEBRA_ROUTE_OSPF;
 	else {
-		if (bgp->vrf_id != VRF_DEFAULT) {
-			vty_out(vty,
-				"%% Only default BGP instance can use '%s'\n",
-				argv[idx_ospf_table]->arg);
-			return CMD_WARNING_CONFIG_FAILED;
-		}
 		if (strncmp(argv[idx_ospf_table]->arg, "table-direct",
 			    strlen("table-direct")) == 0) {
 			protocol = ZEBRA_ROUTE_TABLE_DIRECT;

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2043,6 +2043,18 @@ int bgp_redistribute_set(struct bgp *bgp, afi_t afi, int type,
 	/* Return if already redistribute flag is set. */
 	if (instance) {
 		if (type == ZEBRA_ROUTE_TABLE_DIRECT) {
+			/*
+			 * When redistribution type is `table-direct` the
+			 * instance means `table identification`.
+			 *
+			 * `table_id` support 32bit integers, however since
+			 * `instance` is being overloaded to `table_id` it
+			 * will only be possible to use the first 65535
+			 * entries.
+			 *
+			 * Also the ZAPI must also support `int`
+			 * (see `zebra_redistribute_add`).
+			 */
 			struct redist_table_direct table = {
 				.table_id = instance,
 				.vrf_id = bgp->vrf_id,

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -4774,6 +4774,16 @@ static void zclient_redistribute_table_direct(struct zclient *zclient, vrf_id_t 
 void zclient_redistribute(int command, struct zclient *zclient, afi_t afi,
 			  int type, unsigned short instance, vrf_id_t vrf_id)
 {
+	/*
+	 * When asking for table-direct redistribution the parameter
+	 * `instance` has a different meaning: it means table
+	 * identification.
+	 *
+	 * The table identification information is stored in
+	 * `zclient->mi_redist` along with the VRF identification
+	 * information in a pair (different from the usual single protocol
+	 * instance value).
+	 */
 	if (type == ZEBRA_ROUTE_TABLE_DIRECT) {
 		zclient_redistribute_table_direct(zclient, vrf_id, afi, instance, command);
 		return;

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -31,6 +31,7 @@
 
 DEFINE_MTYPE_STATIC(LIB, ZCLIENT, "Zclient");
 DEFINE_MTYPE_STATIC(LIB, REDIST_INST, "Redistribution instance IDs");
+DEFINE_MTYPE_STATIC(LIB, REDIST_TABLE_DIRECT, "Redistribution table direct");
 
 /* Zebra client events. */
 enum zclient_event { ZCLIENT_SCHEDULE, ZCLIENT_READ, ZCLIENT_CONNECT };
@@ -152,6 +153,87 @@ void redist_del_instance(struct redist_proto *red, unsigned short instance)
 	listnode_delete(red->instances, id);
 	red->instances->del(id);
 	if (!red->instances->count) {
+		red->enabled = 0;
+		list_delete(&red->instances);
+	}
+}
+
+static void redist_free_table_direct(void *data)
+{
+	XFREE(MTYPE_REDIST_TABLE_DIRECT, data);
+}
+
+struct redist_table_direct *redist_lookup_table_direct(const struct redist_proto *red,
+						       const struct redist_table_direct *table)
+{
+	struct redist_table_direct *ntable;
+	struct listnode *node;
+
+	if (red->instances == NULL)
+		return NULL;
+
+	for (ALL_LIST_ELEMENTS_RO(red->instances, node, ntable)) {
+		if (table->vrf_id != ntable->vrf_id)
+			continue;
+		if (table->table_id != ntable->table_id)
+			continue;
+
+		return ntable;
+	}
+
+	return NULL;
+}
+
+bool redist_table_direct_has_id(const struct redist_proto *red, int table_id)
+{
+	struct redist_table_direct *table;
+	struct listnode *node;
+
+	if (red->instances == NULL)
+		return false;
+
+	for (ALL_LIST_ELEMENTS_RO(red->instances, node, table)) {
+		if (table->table_id != table_id)
+			continue;
+
+		return true;
+	}
+
+	return false;
+}
+
+void redist_add_table_direct(struct redist_proto *red, const struct redist_table_direct *table)
+{
+	struct redist_table_direct *ntable;
+
+	ntable = redist_lookup_table_direct(red, table);
+	if (ntable != NULL)
+		return;
+
+	if (red->instances == NULL) {
+		red->instances = list_new();
+		red->instances->del = redist_free_table_direct;
+	}
+
+	red->enabled = 1;
+
+	ntable = XCALLOC(MTYPE_REDIST_TABLE_DIRECT, sizeof(*ntable));
+	ntable->vrf_id = table->vrf_id;
+	ntable->table_id = table->table_id;
+	listnode_add(red->instances, ntable);
+}
+
+void redist_del_table_direct(struct redist_proto *red, const struct redist_table_direct *table)
+{
+	struct redist_table_direct *ntable;
+
+	ntable = redist_lookup_table_direct(red, table);
+	if (ntable == NULL)
+		return;
+
+	listnode_delete(red->instances, ntable);
+	red->instances->del(ntable);
+	if (red->instances->count == 0) {
 		red->enabled = 0;
 		list_delete(&red->instances);
 	}
@@ -483,6 +565,17 @@ enum zclient_send_status zclient_send_localsid(struct zclient *zclient,
 	return zclient_route_send(ZEBRA_ROUTE_ADD, zclient, &api);
 }
 
+static void zclient_send_table_direct(struct zclient *zclient, afi_t afi, int type)
+{
+	struct redist_table_direct *table;
+	struct redist_proto *red = &zclient->mi_redist[afi][ZEBRA_ROUTE_TABLE_DIRECT];
+	struct listnode *node;
+
+	for (ALL_LIST_ELEMENTS_RO(red->instances, node, table))
+		zebra_redistribute_send(type, zclient, afi, ZEBRA_ROUTE_TABLE_DIRECT,
+					table->table_id, table->vrf_id);
+}
+
 /* Send register requests to zebra daemon for the information in a VRF. */
 void zclient_send_reg_requests(struct zclient *zclient, vrf_id_t vrf_id)
 {
@@ -515,6 +608,12 @@ void zclient_send_reg_requests(struct zclient *zclient, vrf_id_t vrf_id)
 			for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
 				if (!zclient->mi_redist[afi][i].enabled)
 					continue;
+
+				if (i == ZEBRA_ROUTE_TABLE_DIRECT) {
+					zclient_send_table_direct(zclient, afi,
+								  ZEBRA_REDISTRIBUTE_ADD);
+					continue;
+				}
 
 				struct listnode *node;
 				unsigned short *id;
@@ -582,6 +681,12 @@ void zclient_send_dereg_requests(struct zclient *zclient, vrf_id_t vrf_id)
 			for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
 				if (!zclient->mi_redist[afi][i].enabled)
 					continue;
+
+				if (i == ZEBRA_ROUTE_TABLE_DIRECT) {
+					zclient_send_table_direct(zclient, afi,
+								  ZEBRA_REDISTRIBUTE_DELETE);
+					continue;
+				}
 
 				struct listnode *node;
 				unsigned short *id;
@@ -4637,9 +4742,42 @@ static void zclient_read(struct event *thread)
 	zclient_event(ZCLIENT_READ, zclient);
 }
 
+static void zclient_redistribute_table_direct(struct zclient *zclient, vrf_id_t vrf_id, afi_t afi,
+					      int instance, int command)
+{
+	struct redist_proto *red = &zclient->mi_redist[afi][ZEBRA_ROUTE_TABLE_DIRECT];
+	bool has_table;
+	struct redist_table_direct table = {
+		.vrf_id = vrf_id,
+		.table_id = instance,
+	};
+
+	has_table = redist_lookup_table_direct(red, &table);
+
+	if (command == ZEBRA_REDISTRIBUTE_ADD) {
+		if (has_table)
+			return;
+
+		redist_add_table_direct(red, &table);
+	} else {
+		if (!has_table)
+			return;
+
+		redist_del_table_direct(red, &table);
+	}
+
+	if (zclient->sock > 0)
+		zebra_redistribute_send(command, zclient, afi, ZEBRA_ROUTE_TABLE_DIRECT, instance,
+					vrf_id);
+}
+
 void zclient_redistribute(int command, struct zclient *zclient, afi_t afi,
 			  int type, unsigned short instance, vrf_id_t vrf_id)
 {
+	if (type == ZEBRA_ROUTE_TABLE_DIRECT) {
+		zclient_redistribute_table_direct(zclient, vrf_id, afi, instance, command);
+		return;
+	}
 
 	if (instance) {
 		if (command == ZEBRA_REDISTRIBUTE_ADD) {

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -271,6 +271,12 @@ struct redist_proto {
 /**
  * Redistribute table direct instance data structure: keeps the VRF
  * that subscribed to the table ID.
+ *
+ * **NOTE**
+ * `table_id` is an integer because that is what the netlink interface
+ * uses for route attribute RTA_TABLE (32bit int), however the whole
+ * zclient API uses `unsigned short` (and CLI commands) so it will be
+ * limited to the range 1 to 65535.
  */
 struct redist_table_direct {
 	vrf_id_t vrf_id;

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -268,6 +268,15 @@ struct redist_proto {
 	struct list *instances;
 };
 
+/**
+ * Redistribute table direct instance data structure: keeps the VRF
+ * that subscribed to the table ID.
+ */
+struct redist_table_direct {
+	vrf_id_t vrf_id;
+	int table_id;
+};
+
 struct zclient_capabilities {
 	uint32_t ecmp;
 	bool mpls_enabled;
@@ -923,6 +932,15 @@ extern unsigned short *redist_check_instance(struct redist_proto *,
 extern void redist_add_instance(struct redist_proto *, unsigned short);
 extern void redist_del_instance(struct redist_proto *, unsigned short);
 extern void redist_del_all_instances(struct redist_proto *red);
+
+extern struct redist_table_direct *
+redist_lookup_table_direct(const struct redist_proto *red, const struct redist_table_direct *table);
+extern bool redist_table_direct_has_id(const struct redist_proto *red, int table_id);
+extern void redist_add_table_direct(struct redist_proto *red,
+				    const struct redist_table_direct *table);
+extern void redist_del_table_direct(struct redist_proto *red,
+				    const struct redist_table_direct *table);
+
 
 /*
  * Send to zebra that the specified vrf is using label to resolve

--- a/tests/topotests/bgp_table_direct_topo1/r1/frr.conf
+++ b/tests/topotests/bgp_table_direct_topo1/r1/frr.conf
@@ -1,0 +1,31 @@
+log commands
+!
+debug bgp zebra
+debug zebra events
+!
+ip route 10.254.254.1/32 lo table 2000
+ip route 10.254.254.2/32 lo table 2000
+ip route 10.254.254.3/32 lo table 2000
+!
+interface r1-eth0
+ ip address 192.168.10.1/24
+!
+interface r1-eth1 vrf blue
+ ip address 192.168.20.1/24
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.10.2 remote-as external
+ address-family ipv4 unicast
+  redistribute table-direct 2000
+ exit-address-family
+!
+router bgp 65001 vrf blue
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.20.2 remote-as external
+ address-family ipv4 unicast
+  redistribute table-direct 2000
+ exit-address-family
+!

--- a/tests/topotests/bgp_table_direct_topo1/r2/frr.conf
+++ b/tests/topotests/bgp_table_direct_topo1/r2/frr.conf
@@ -1,0 +1,10 @@
+log commands
+!
+interface r2-eth0
+ ip address 192.168.10.2/24
+!
+router bgp 65002
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.10.1 remote-as external
+!

--- a/tests/topotests/bgp_table_direct_topo1/r3/frr.conf
+++ b/tests/topotests/bgp_table_direct_topo1/r3/frr.conf
@@ -1,0 +1,10 @@
+log commands
+!
+interface r3-eth0
+ ip address 192.168.20.2/24
+!
+router bgp 65003
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.20.1 remote-as external
+!

--- a/tests/topotests/bgp_table_direct_topo1/test_bgp_table_direct_topo1.py
+++ b/tests/topotests/bgp_table_direct_topo1/test_bgp_table_direct_topo1.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_bgp_table_direct_topo1.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2025 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+
+"""
+test_bgp_table_direct_topo1.py: Test the FRR PIM MSDP peer.
+"""
+
+import os
+import sys
+import json
+from functools import partial
+import re
+import pytest
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+
+# Required to instantiate the topology builder class.
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+from lib.pim import McastTesterHelper
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.pimd]
+
+app_helper = McastTesterHelper()
+
+
+def build_topo(tgen):
+    """
+    +----+     +----+
+    | r1 | <-> | r2 |
+    +----+     +----+
+       |
+       |       +----+
+       --------| r3 |
+               +----+
+    """
+
+    # Create 3 routers
+    for routern in range(1, 4):
+        tgen.add_router(f"r{routern}")
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r3"])
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for _, router in router_list.items():
+        router.load_frr_config(os.path.join(CWD, f"{router.name}/frr.conf"))
+
+    tgen.gears["r1"].run("ip link add blue type vrf table 10")
+    tgen.gears["r1"].run("ip link set blue up")
+    tgen.gears["r1"].run("ip link set r1-eth1 master blue")
+
+    # Initialize all routers.
+    tgen.start_router()
+
+    app_helper.init(tgen)
+
+
+def teardown_module():
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    app_helper.cleanup()
+    tgen.stop_topology()
+
+
+def expect_bgp_route(router, iptype, route, missing=False):
+    "Wait until route is present on RIB for protocol."
+    if missing:
+        logger.info("waiting route {} go missing in {}".format(route, router))
+    else:
+        logger.info("waiting route {} in {}".format(route, router))
+
+    tgen = get_topogen()
+    expected_output = {route: [{"protocol": "bgp"}]}
+    wait_time = 130
+    if missing:
+        expected_output = {route: None}
+        wait_time = 5
+
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears[router],
+        "show {} route json".format(iptype),
+        expected_output
+    )
+
+    _, result = topotest.run_and_expect(test_func, None, count=130, wait=1)
+    assertmsg = f'"{router}" convergence failure'
+    assert result is None, assertmsg
+
+
+def test_bgp_convergence():
+    "Wait for BGP protocol convergence"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("waiting for protocols to converge")
+
+    # Wait for R2
+    expect_bgp_route("r2", "ip", "10.254.254.1/32")
+    expect_bgp_route("r2", "ip", "10.254.254.2/32")
+    expect_bgp_route("r2", "ip", "10.254.254.3/32")
+
+    # Wait for R3
+    expect_bgp_route("r3", "ip", "10.254.254.1/32")
+    expect_bgp_route("r3", "ip", "10.254.254.2/32")
+    expect_bgp_route("r3", "ip", "10.254.254.3/32")
+
+
+def test_route_change_convergence():
+    "Change routes in table 2000 to test zebra redistribution."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    tgen.gears["r1"].vtysh_cmd("""
+        configure terminal
+        no ip route 10.254.254.2/32 lo table 2000
+        ip route 10.254.254.10/32 lo table 2000
+    """)
+
+    # Check R2
+    expect_bgp_route("r2", "ip", "10.254.254.2/32", missing=True)
+    expect_bgp_route("r2", "ip", "10.254.254.10/32")
+
+    # Check R3
+    expect_bgp_route("r3", "ip", "10.254.254.2/32", missing=True)
+    expect_bgp_route("r3", "ip", "10.254.254.10/32")
+
+
+def test_configuration_removal_convergence():
+    "Remove table direct configuration and check if routes went missing."
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    tgen.gears["r1"].vtysh_cmd("""
+        configure terminal
+        router bgp 65001
+         address-family ipv4 unicast
+          no redistribute table-direct 2000
+         exit-address-family
+        exit
+
+        router bgp 65001 vrf blue
+         address-family ipv4 unicast
+          no redistribute table-direct 2000
+         exit-address-family
+        exit
+    """)
+
+    # Check R2
+    expect_bgp_route("r2", "ip", "10.254.254.1/32", missing=True)
+    expect_bgp_route("r2", "ip", "10.254.254.3/32", missing=True)
+    expect_bgp_route("r2", "ip", "10.254.254.10/32", missing=True)
+
+    # Check R3
+    expect_bgp_route("r3", "ip", "10.254.254.1/32", missing=True)
+    expect_bgp_route("r3", "ip", "10.254.254.3/32", missing=True)
+    expect_bgp_route("r3", "ip", "10.254.254.10/32", missing=True)
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -51,10 +51,8 @@ extern void nbr_connected_delete_ipv6(struct interface *ifp,
 				      struct in6_addr *address);
 extern int zsend_interface_update(int cmd, struct zserv *client,
 				  struct interface *ifp);
-extern int zsend_redistribute_route(int cmd, struct zserv *zclient,
-				    const struct route_node *rn,
-				    const struct route_entry *re,
-				    bool is_table_direct);
+extern int zsend_redistribute_route(int cmd, struct zserv *zclient, const struct route_node *rn,
+				    const struct route_entry *re, vrf_id_t *to_vrf);
 
 extern int zsend_router_id_update(struct zserv *zclient, afi_t afi,
 				  struct prefix *p, vrf_id_t vrf_id);


### PR DESCRIPTION
This PR implements the mechanism in `lib` and `zebra` to differentiate `table-direct` from different protocol VRF instances.