### PR TITLE
tools: Add missing rpki keyword to vrf in frr-reload

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -270,7 +270,7 @@ ctx_keywords = {
     "mpls ldp": {"address-family ": {"interface ": {}}},
     "l2vpn ": {"member pseudowire ": {}},
     "key chain ": {"key ": {}},
-    "vrf ": {},
+    "vrf ": {"rpki": {}},
     "interface ": {"link-params": {}},
     "pseudowire ": {},
     "segment-routing": {


### PR DESCRIPTION
When reloading the following configuration:
```
vrf red
 rpki
  rpki cache tcp 172.65.0.2 8282 preference 1
 exit
exit-vrf
```
frr-reload.py does not properly enter the `rpki` context within a `vrf`. Because of this, it fails to apply RPKI configurations.