### PR TITLE
yang: Corrected range format in YANG

### DIFF
--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -219,7 +219,7 @@ module frr-bfdd {
 
     leaf required-echo-receive-interval {
       type uint32 {
-          range "0 | 10000..max";
+          range "0..10000 | 10000..max";
       }
       units microseconds;
       default 50000;


### PR DESCRIPTION
The range statement should specify a continuous range of values