### PR TITLE
bgpd: fix a bug in peer_allowas_in_set()

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -6686,7 +6686,7 @@ int peer_allowas_in_set(struct peer *peer, afi_t afi, safi_t safi,
 				SET_FLAG(member->af_flags[afi][safi],
 					 PEER_FLAG_ALLOWAS_IN_ORIGIN);
 				member->allowas_in[afi][safi] = 0;
-				peer_on_policy_change(peer, afi, safi, 0);
+				peer_on_policy_change(member, afi, safi, 0);
 			}
 		} else {
 			if (member->allowas_in[afi][safi] != allow_num
@@ -6695,7 +6695,7 @@ int peer_allowas_in_set(struct peer *peer, afi_t afi, safi_t safi,
 				UNSET_FLAG(member->af_flags[afi][safi],
 					   PEER_FLAG_ALLOWAS_IN_ORIGIN);
 				member->allowas_in[afi][safi] = allow_num;
-				peer_on_policy_change(peer, afi, safi, 0);
+				peer_on_policy_change(member, afi, safi, 0);
 			}
 		}
 	}


### PR DESCRIPTION
Fix a bug in peer_allowas_in_set() so that the config takes effect for peer-group members.