### PR TITLE
Add new oper state get callback

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -1649,90 +1649,90 @@ static int lib_interface_description_destroy(struct nb_cb_destroy_args *args)
 	return NB_OK;
 }
 
+static enum nb_error __return_ok(const struct nb_node *nb_node, const void *list_entry,
+				 struct lyd_node *parent)
+{
+	return NB_OK;
+}
+
 /*
  * XPath: /frr-interface:lib/interface/vrf
  */
-static struct yang_data *
-lib_interface_vrf_get_elem(struct nb_cb_get_elem_args *args)
+static enum nb_error lib_interface_vrf_get(const struct nb_node *nb_node, const void *list_entry,
+					   struct lyd_node *parent)
 {
-	const struct interface *ifp = args->list_entry;
+	const struct lysc_node *snode = nb_node->snode;
+	const struct interface *ifp = list_entry;
 
-	return yang_data_new_string(args->xpath, ifp->vrf->name);
+	if (lyd_new_term(parent, snode->module, snode->name, ifp->vrf->name, LYD_NEW_PATH_UPDATE,
+			 NULL))
+		return NB_ERR_RESOURCE;
+	return NB_OK;
 }
 
 /*
  * XPath: /frr-interface:lib/interface/state/if-index
  */
-static struct yang_data *
-lib_interface_state_if_index_get_elem(struct nb_cb_get_elem_args *args)
+static enum nb_error lib_interface_state_if_index_get(const struct nb_node *nb_node,
+						      const void *list_entry,
+						      struct lyd_node *parent)
 {
-	const struct interface *ifp = args->list_entry;
+	const struct lysc_node *snode = nb_node->snode;
+	const struct interface *ifp = list_entry;
+	int32_t value = ifp->ifindex;
 
-	return yang_data_new_int32(args->xpath, ifp->ifindex);
+	if (lyd_new_term_bin(parent, snode->module, snode->name, &value, sizeof(value),
+			     LYD_NEW_PATH_UPDATE, NULL))
+		return NB_ERR_RESOURCE;
+	return NB_OK;
 }
 
 /*
- * XPath: /frr-interface:lib/interface/state/mtu
+ * XPath: /frr-interface:lib/interface/state/mtu[6]
  */
-static struct yang_data *
-lib_interface_state_mtu_get_elem(struct nb_cb_get_elem_args *args)
+static enum nb_error lib_interface_state_mtu_get(const struct nb_node *nb_node,
+						 const void *list_entry, struct lyd_node *parent)
 {
-	const struct interface *ifp = args->list_entry;
+	const struct lysc_node *snode = nb_node->snode;
+	const struct interface *ifp = list_entry;
+	uint32_t value = ifp->mtu;
 
-	return yang_data_new_uint32(args->xpath, ifp->mtu);
-}
-
-/*
- * XPath: /frr-interface:lib/interface/state/mtu6
- */
-static struct yang_data *
-lib_interface_state_mtu6_get_elem(struct nb_cb_get_elem_args *args)
-{
-	const struct interface *ifp = args->list_entry;
-
-	return yang_data_new_uint32(args->xpath, ifp->mtu6);
+	if (lyd_new_term_bin(parent, snode->module, snode->name, &value, sizeof(value),
+			     LYD_NEW_PATH_UPDATE, NULL))
+		return NB_ERR_RESOURCE;
+	return NB_OK;
 }
 
 /*
  * XPath: /frr-interface:lib/interface/state/speed
  */
-static struct yang_data *
-lib_interface_state_speed_get_elem(struct nb_cb_get_elem_args *args)
+static enum nb_error lib_interface_state_speed_get(const struct nb_node *nb_node,
+						   const void *list_entry, struct lyd_node *parent)
 {
-	const struct interface *ifp = args->list_entry;
+	const struct lysc_node *snode = nb_node->snode;
+	const struct interface *ifp = list_entry;
+	uint32_t value = ifp->speed;
 
-	return yang_data_new_uint32(args->xpath, ifp->speed);
+	if (lyd_new_term_bin(parent, snode->module, snode->name, &value, sizeof(value),
+			     LYD_NEW_PATH_UPDATE, NULL))
+		return NB_ERR_RESOURCE;
+	return NB_OK;
 }
 
 /*
  * XPath: /frr-interface:lib/interface/state/metric
  */
-static struct yang_data *
-lib_interface_state_metric_get_elem(struct nb_cb_get_elem_args *args)
+static enum nb_error lib_interface_state_metric_get(const struct nb_node *nb_node,
+						    const void *list_entry, struct lyd_node *parent)
 {
-	const struct interface *ifp = args->list_entry;
+	const struct lysc_node *snode = nb_node->snode;
+	const struct interface *ifp = list_entry;
+	uint32_t value = ifp->metric;
 
-	return yang_data_new_uint32(args->xpath, ifp->metric);
-}
-
-/*
- * XPath: /frr-interface:lib/interface/state/flags
- */
-static struct yang_data *
-lib_interface_state_flags_get_elem(struct nb_cb_get_elem_args *args)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath: /frr-interface:lib/interface/state/type
- */
-static struct yang_data *
-lib_interface_state_type_get_elem(struct nb_cb_get_elem_args *args)
-{
-	/* TODO: implement me. */
-	return NULL;
+	if (lyd_new_term_bin(parent, snode->module, snode->name, &value, sizeof(value),
+			     LYD_NEW_PATH_UPDATE, NULL))
+		return NB_ERR_RESOURCE;
+	return NB_OK;
 }
 
 /*
@@ -1779,49 +1779,49 @@ const struct frr_yang_module_info frr_interface_info = {
 		{
 			.xpath = "/frr-interface:lib/interface/vrf",
 			.cbs = {
-				.get_elem = lib_interface_vrf_get_elem,
+				.get = lib_interface_vrf_get,
 			}
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/state/if-index",
 			.cbs = {
-				.get_elem = lib_interface_state_if_index_get_elem,
+				.get = lib_interface_state_if_index_get,
 			}
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/state/mtu",
 			.cbs = {
-				.get_elem = lib_interface_state_mtu_get_elem,
+				.get = lib_interface_state_mtu_get,
 			}
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/state/mtu6",
 			.cbs = {
-				.get_elem = lib_interface_state_mtu6_get_elem,
+				.get = lib_interface_state_mtu_get,
 			}
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/state/speed",
 			.cbs = {
-				.get_elem = lib_interface_state_speed_get_elem,
+				.get = lib_interface_state_speed_get,
 			}
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/state/metric",
 			.cbs = {
-				.get_elem = lib_interface_state_metric_get_elem,
+				.get = lib_interface_state_metric_get,
 			}
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/state/flags",
 			.cbs = {
-				.get_elem = lib_interface_state_flags_get_elem,
+				.get = __return_ok,
 			}
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/state/type",
 			.cbs = {
-				.get_elem = lib_interface_state_type_get_elem,
+				.get = __return_ok,
 			}
 		},
 		{

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -273,9 +273,11 @@ static unsigned int nb_node_validate_cbs(const struct nb_node *nb_node)
 	error += nb_node_validate_cb(nb_node, NB_CB_APPLY_FINISH,
 				     !!nb_node->cbs.apply_finish, true);
 	error += nb_node_validate_cb(nb_node, NB_CB_GET_ELEM,
-				     !!nb_node->cbs.get_elem, false);
+				     (nb_node->cbs.get_elem || nb_node->cbs.get), false);
 	error += nb_node_validate_cb(nb_node, NB_CB_GET_NEXT,
-				     !!nb_node->cbs.get_next, false);
+				     (nb_node->cbs.get_next ||
+				      (nb_node->snode->nodetype == LYS_LEAFLIST && nb_node->cbs.get)),
+				     false);
 	error += nb_node_validate_cb(nb_node, NB_CB_GET_KEYS,
 				     !!nb_node->cbs.get_keys, false);
 	error += nb_node_validate_cb(nb_node, NB_CB_LOOKUP_ENTRY,

--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -584,6 +584,10 @@ static enum nb_error nb_op_iter_leaf(struct nb_op_yield_state *ys,
 	if (lysc_is_key(snode))
 		return NB_OK;
 
+	/* Check for new simple get */
+	if (nb_node->cbs.get)
+		return nb_node->cbs.get(nb_node, ni->list_entry, ni->inner);
+
 	data = nb_callback_get_elem(nb_node, xpath, ni->list_entry);
 	if (data == NULL)
 		return NB_OK;
@@ -616,6 +620,10 @@ static enum nb_error nb_op_iter_leaflist(struct nb_op_yield_state *ys,
 
 	if (CHECK_FLAG(snode->flags, LYS_CONFIG_W))
 		return NB_OK;
+
+	/* Check for new simple get */
+	if (nb_node->cbs.get)
+		return nb_node->cbs.get(nb_node, ni->list_entry, ni->inner);
 
 	do {
 		struct yang_data *data;

--- a/tests/lib/northbound/test_oper_data.c
+++ b/tests/lib/northbound/test_oper_data.c
@@ -120,6 +120,26 @@ static const void *frr_test_module_vrfs_vrf_interfaces_interface_get_next(
 }
 
 /*
+ * XPath: /frr-test-module:frr-test-module/vrfs/vrf/interfaces/interface-new
+ */
+static enum nb_error frr_test_module_vrfs_vrf_interfaces_interface_new_get(
+	const struct nb_node *nb_node, const void *parent_list_entry, struct lyd_node *parent)
+{
+	const struct lysc_node *snode = nb_node->snode;
+	const struct tvrf *vrf;
+	struct listnode *node;
+	const char *interface;
+	LY_ERR err;
+
+	vrf = listgetdata((struct listnode *)parent_list_entry);
+	for (ALL_LIST_ELEMENTS_RO(vrf->interfaces, node, interface)) {
+		err = lyd_new_term(parent, snode->module, snode->name, interface, false, NULL);
+		assert(err == LY_SUCCESS);
+	}
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-test-module:frr-test-module/vrfs/vrf/routes/route
  */
 static const void *
@@ -228,10 +248,19 @@ frr_test_module_c1value_get_elem(struct nb_cb_get_elem_args *args)
 /*
  * XPath: /frr-test-module:frr-test-module/c2cont/c2value
  */
-static struct yang_data *
-frr_test_module_c2cont_c2value_get_elem(struct nb_cb_get_elem_args *args)
+static enum nb_error frr_test_module_c2cont_c2value_get(const struct nb_node *nb_node,
+							const void *parent_list_entry,
+							struct lyd_node *parent)
 {
-	return yang_data_new_uint32(args->xpath, 0xAB010203);
+	const struct lysc_node *snode = nb_node->snode;
+	uint32_t value = 0xAB010203;
+	LY_ERR err;
+
+	err = lyd_new_term_bin(parent, snode->module, snode->name, &value, sizeof(value),
+			       LYD_NEW_PATH_UPDATE, NULL);
+	assert(err == LY_SUCCESS);
+
+	return NB_OK;
 }
 
 /* clang-format off */
@@ -252,6 +281,10 @@ const struct frr_yang_module_info frr_test_module_info = {
 			.xpath = "/frr-test-module:frr-test-module/vrfs/vrf/interfaces/interface",
 			.cbs.get_elem = frr_test_module_vrfs_vrf_interfaces_interface_get_elem,
 			.cbs.get_next = frr_test_module_vrfs_vrf_interfaces_interface_get_next,
+		},
+		{
+			.xpath = "/frr-test-module:frr-test-module/vrfs/vrf/interfaces/interface-new",
+			.cbs.get = frr_test_module_vrfs_vrf_interfaces_interface_new_get,
 		},
 		{
 			.xpath = "/frr-test-module:frr-test-module/vrfs/vrf/routes/route",
@@ -287,7 +320,7 @@ const struct frr_yang_module_info frr_test_module_info = {
 		},
 		{
 			.xpath = "/frr-test-module:frr-test-module/c2cont/c2value",
-			.cbs.get_elem = frr_test_module_c2cont_c2value_get_elem,
+			.cbs.get = frr_test_module_c2cont_c2value_get,
 		},
 		{
 			.xpath = NULL,

--- a/tests/lib/northbound/test_oper_data.refout
+++ b/tests/lib/northbound/test_oper_data.refout
@@ -11,6 +11,12 @@ test# show yang operational-data /frr-test-module:frr-test-module
               "eth1",
               "eth2",
               "eth3"
+            ],
+            "interface-new": [
+              "eth0",
+              "eth1",
+              "eth2",
+              "eth3"
             ]
           },
           "routes": {
@@ -61,6 +67,12 @@ test# show yang operational-data /frr-test-module:frr-test-module
           "name": "vrf1",
           "interfaces": {
             "interface": [
+              "eth0",
+              "eth1",
+              "eth2",
+              "eth3"
+            ],
+            "interface-new": [
               "eth0",
               "eth1",
               "eth2",

--- a/yang/frr-test-module.yang
+++ b/yang/frr-test-module.yang
@@ -60,6 +60,9 @@ module frr-test-module {
           leaf-list interface {
             type frr-interface:interface-ref;
           }
+          leaf-list interface-new {
+            type frr-interface:interface-ref;
+          }
         }
         container routes {
           list route {


### PR DESCRIPTION
Current get_elem callback allocates and initializes a `struct yang_data` which is an xpath and value, then immediately uses this to create a libyang `struct lyd_node` and free's the `yang_data`.

Add a new get callback that simply creates the libyang `struct lyd_node` directly avoiding xpath creations and allocations.