### PR TITLE
Fix Rocky 8 RPMs, add options to build without rpki and docs (default is to include)

### DIFF
--- a/doc/developer/packaging-redhat.rst
+++ b/doc/developer/packaging-redhat.rst
@@ -3,7 +3,7 @@
 Packaging Red Hat
 =================
 
-Tested on CentOS 6, CentOS 7, CentOS 8 and Fedora 24.
+Tested on CentOS 6, CentOS 7, Rocky 8 and Fedora 24.
 
 1. On CentOS 6, refer to :ref:`building-centos6` for details on installing
    sufficiently up-to-date package versions to enable building FRR.
@@ -18,14 +18,14 @@ Tested on CentOS 6, CentOS 7, CentOS 8 and Fedora 24.
 
       yum install rpm-build net-snmp-devel pam-devel libcap-devel
 
-   For CentOS 7 and CentOS 8, the package will be built using python3
+   For CentOS 7 and Rocky 8, the package will be built using python3
    and requires additional python3 packages::
 
        yum install python3-devel python3-sphinx
 
    .. note::
 
-     For CentOS 8 you need to install ``platform-python-devel`` package
+     For Rocky 8 you need to install ``platform-python-devel`` package
      to provide ``/usr/bin/pathfix.py``::
 
        yum install platform-python-devel
@@ -33,7 +33,7 @@ Tested on CentOS 6, CentOS 7, CentOS 8 and Fedora 24.
 
    If ``yum`` is not present on your system, use ``dnf`` instead.
 
-   You should enable ``PowerTools`` repo if using CentOS 8 which
+   You should enable ``PowerTools`` repo if using Rocky 8 which
    is disabled by default.
 
 4. Checkout FRR::
@@ -88,10 +88,17 @@ Tested on CentOS 6, CentOS 7, CentOS 8 and Fedora 24.
       %{!?with_watchfrr:      %global  with_watchfrr      1 }
       %{!?with_pathd:         %global  with_pathd         1 }
       %{!?with_grpc:          %global  with_grpc          0 }
+      %{!?with_rpki:          %global  with_rpki          1 }
+      %{!?with_docs:          %global  with_docs          1 }
 
 8. Build the RPM::
 
       rpmbuild --define "_topdir `pwd`/rpmbuild" -ba rpmbuild/SPECS/frr.spec
+
+   To override :file:`rpm/SPECS/frr.spec` defaults on the rpmbuild
+   commandline with:
+
+      rpmbuild --define 'variable value'
 
    If building with RPKI, then download and install the additional RPKI
    packages from

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -31,6 +31,8 @@
 %{!?with_watchfrr:      %global  with_watchfrr      1 }
 %{!?with_pathd:         %global  with_pathd         1 }
 %{!?with_grpc:          %global  with_grpc          0 }
+%{!?with_rpki:          %global  with_rpki          1 }
+%{!?with_docs:          %global  with_docs          1 }
 
 # user and group
 %{!?frr_user:           %global  frr_user           frr }
@@ -193,14 +195,20 @@ BuildRequires:  pcre2-devel
 %if 0%{?rhel} && 0%{?rhel} < 7
 #python27-devel is available from ius community repo for RedHat/CentOS 6
 BuildRequires:  python27-devel
+%if %{with_docs}
 BuildRequires:  python27-sphinx
+%endif
 %else
 %if %{use_python2}
 BuildRequires:  python-devel >= 2.7
+%if %{with_docs}
 BuildRequires:  python-sphinx
+%endif
 %else
 BuildRequires:  python3-devel
+%if %{with_docs}
 BuildRequires:  python3-sphinx
+%endif
 %endif
 %endif
 %if %{with_grpc}
@@ -283,6 +291,7 @@ The frr-devel package contains the header and object files necessary for
 developing OSPF-API and frr applications.
 
 
+%if %{with_rpki}
 %package rpki-rtrlib
 Summary: BGP RPKI support (rtrlib)
 Group: System Environment/Daemons
@@ -295,6 +304,7 @@ against cryptographic information stored in WHOIS databases.  This is
 used to prevent hijacking of networks on the wider internet.  It is only
 relevant to internet service providers using their own autonomous system
 number.
+%endif
 
 
 %package snmp
@@ -433,7 +443,9 @@ Adds GRPC support to the individual FRR daemons.
     --disable-bgp-vnc \
 %endif
     --enable-isisd \
+%if %{with_rpki}
     --enable-rpki \
+%endif
 %if %{with_bfdd}
     --enable-bfdd \
 %else
@@ -465,9 +477,11 @@ sed -e '1c #!/usr/bin/python3' -i %{zeb_src}/tools/frr-reload.py
 sed -e '1c #!/usr/bin/python3' -i %{zeb_src}/tools/generate_support_bundle.py
 %endif
 
+%if %{with_docs}
 pushd doc
 make info
 popd
+%endif
 
 
 %install
@@ -605,7 +619,9 @@ zebra_spec_add_service fabricd	2618/tcp "Fabricd vty"
     %__sed -i 's|watchfrr_enable=no|watchfrr_enable=yes|g' %{configdir}/daemons 2> /dev/null || true
 %endif
 
+%if %{with_docs}
 /sbin/install-info %{_infodir}/frr.info.gz %{_infodir}/dir
+%endif
 
 # Create dummy config file if they don't exist so basic functions can be used.
 if [ ! -e %{configdir}/frr.conf ] && [ ! -e %{configdir}/zebra.conf ]; then
@@ -673,7 +689,9 @@ fi
         /sbin/chkconfig --del frr
     fi
 %endif
+%if %{with_docs}
 /sbin/install-info --delete %{_infodir}/frr.info.gz %{_infodir}/dir
+%endif
 
 
 %files
@@ -690,8 +708,10 @@ fi
     %dir %attr(755,root,root) %{_localstatedir}/log/frr
     %dir %attr(750,root,root) %{_runstatedir}/frr
 %endif
-%{_infodir}/frr.info.gz
-%{_mandir}/man*/*
+%if %{with_docs}
+    %{_infodir}/frr.info.gz
+    %{_mandir}/man*/*
+%endif
 %{_sbindir}/zebra
 %{_sbindir}/staticd
 %{_sbindir}/ospfd
@@ -739,19 +759,9 @@ fi
 %endif
 %if %{with_pathd}
     %{_sbindir}/pathd
-    %{_libdir}/frr/modules/pathd_pcep.so
 %endif
-%{_libdir}/libfrr.so*
-%{_libdir}/libfrrcares*
-%{_libdir}/libfrrospf*
-%if %{with_fpm}
-    %{_libdir}/frr/modules/zebra_fpm.so
-%endif
-%{_libdir}/frr/modules/zebra_cumulus_mlag.so
-%{_libdir}/frr/modules/dplane_fpm_nl.so
-%{_libdir}/frr/modules/bgpd_bmp.so
-%{_libdir}/libfrr_pb.so*
-%{_libdir}/libfrrfpm_pb.so*
+%{_libdir}/libfrr*.so*
+%{_libdir}/frr/modules/*.so
 %{_libdir}/libmgmt_be_nb.so*
 %{_bindir}/*
 %config(noreplace) %{configdir}/[!v]*.conf*
@@ -791,6 +801,7 @@ fi
 %endif
 
 
+%if %{with_rpki}
 %post rpki-rtrlib
 # add rpki module to daemons
 sed -i -e 's/^\(bgpd_options=\)\(.*\)\(".*\)/\1\2 -M rpki\3/' %{_sysconfdir}/frr/daemons
@@ -798,21 +809,8 @@ sed -i -e 's/^\(bgpd_options=\)\(.*\)\(".*\)/\1\2 -M rpki\3/' %{_sysconfdir}/frr
 %postun rpki-rtrlib
 # remove rpki module from daemons
 sed -i 's/ -M rpki//' %{_sysconfdir}/frr/daemons
-
-%files rpki-rtrlib
-%{_libdir}/frr/modules/bgpd_rpki.so
-
-
-%files snmp
-%{_libdir}/libfrrsnmp.so*
-%{_libdir}/frr/modules/*snmp.so
-
-
-%if %{with_grpc}
-%files grpc
-%{_libdir}/libfrrgrpc_pb.*
-%{_libdir}/frr/modules/grpc.so
 %endif
+
 
 %files devel
 %{_libdir}/lib*.so


### PR DESCRIPTION
fix generation of rpms for RHEL/Rocky8. default behavior is not changed by addition of new rpmbuild (command line) options.