### PR TITLE
lib: Fix privs syscaps (pset_t) allocation

### DIFF
--- a/lib/privs.c
+++ b/lib/privs.c
@@ -179,7 +179,7 @@ static pset_t *zcaps2sys(zebra_capabilities_t *zcaps, int num)
 	for (i = 0; i < num; i++)
 		count += cap_map[zcaps[i]].num;
 
-	if ((syscaps = XCALLOC(MTYPE_PRIVS, (sizeof(pset_t) * num))) == NULL) {
+	if ((syscaps = XCALLOC(MTYPE_PRIVS, sizeof(pset_t))) == NULL) {
 		fprintf(stderr, "%s: could not allocate syscaps!", __func__);
 		return NULL;
 	}


### PR DESCRIPTION
Don't over-allocate syscaps in zcaps2sys(): This is just a single struct (pset_t) with a count and a pointer to an array of capabilities, not an array. So only allocate a single pset_t, not num copies of it.

The allocation size of syscaps->caps then needs to be based on the number of Linux capabilities (count), but that is already handled properly a few lines below.

Note that this fix is mostly cosmetic and for correctness. There was no potential for memory corruption, because num is guaranteed to be nonzero. So at least the one required pset_t was always allocated (but potentially much more).