### PR TITLE
ospfd: avoid the redundant timers

### DIFF
--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -1145,8 +1145,7 @@ static void ospf_external_aggr_timer(struct ospf *ospf,
 	aggr->action = operation;
 
 	if (ospf->t_external_aggr) {
-		if (ospf->aggr_action == OSPF_ROUTE_AGGR_ADD) {
-
+		if (ospf->aggr_action == OSPF_ROUTE_AGGR_ADD || operation != OSPF_ROUTE_AGGR_ADD) {
 			if (IS_DEBUG_OSPF(lsa, EXTNL_LSA_AGGR))
 				zlog_debug("%s: Not required to restart timer,set is already added.",
 					   __func__);


### PR DESCRIPTION
```
(config-router)# no summary-address 9.9.9.0/24
(config-router)# no summary-address 9.9.9.0/24
(config-router)# no summary-address 9.9.9.0/24
(config-router)# no summary-address 9.9.9.0/24
(config-router)# no summary-address 9.9.9.0/24

2025/01/09 09:30:10 OSPF: [S5BD4-3G5QX] ospf_external_aggr_timer: Start Aggregator delay timer 5(in seconds).
2025/01/09 09:30:11 OSPF: [S5BD4-3G5QX] ospf_external_aggr_timer: Start Aggregator delay timer 5(in seconds).
2025/01/09 09:30:11 OSPF: [S5BD4-3G5QX] ospf_external_aggr_timer: Start Aggregator delay timer 5(in seconds).
2025/01/09 09:30:11 OSPF: [S5BD4-3G5QX] ospf_external_aggr_timer: Start Aggregator delay timer 5(in seconds).
2025/01/09 09:30:12 OSPF: [S5BD4-3G5QX] ospf_external_aggr_timer: Start Aggregator delay timer 5(in seconds).
```

Since the timer thread for ```OSPF_ROUTE_AGGR_DEL``` has been created, the subsequent "no summary-address" commands shouldn't trigger redundant timers.

