### PR TITLE
bgpd: enable vpn multipath

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -20615,6 +20615,17 @@ void bgp_vty_init(void)
 	install_element(BGP_IPV6L_NODE, &bgp_maxpaths_ibgp_cluster_cmd);
 	install_element(BGP_IPV6L_NODE, &no_bgp_maxpaths_ibgp_cmd);
 
+	install_element(BGP_VPNV4_NODE, &bgp_maxpaths_cmd);
+	install_element(BGP_VPNV4_NODE, &no_bgp_maxpaths_cmd);
+	install_element(BGP_VPNV4_NODE, &bgp_maxpaths_ibgp_cmd);
+	install_element(BGP_VPNV4_NODE, &bgp_maxpaths_ibgp_cluster_cmd);
+	install_element(BGP_VPNV4_NODE, &no_bgp_maxpaths_ibgp_cmd);
+	install_element(BGP_VPNV6_NODE, &bgp_maxpaths_cmd);
+	install_element(BGP_VPNV6_NODE, &no_bgp_maxpaths_cmd);
+	install_element(BGP_VPNV6_NODE, &bgp_maxpaths_ibgp_cmd);
+	install_element(BGP_VPNV6_NODE, &bgp_maxpaths_ibgp_cluster_cmd);
+	install_element(BGP_VPNV6_NODE, &no_bgp_maxpaths_ibgp_cmd);
+
 	/* "timers bgp" commands. */
 	install_element(BGP_NODE, &bgp_timers_cmd);
 	install_element(BGP_NODE, &no_bgp_timers_cmd);


### PR DESCRIPTION
Enable BGP multipath for ivp4 and ipv6 VPN. The code is ready for that.