### PR TITLE
pimd: Prevent t_join_timer thread from being canceled multiple times

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -332,7 +332,14 @@ static void join_timer_stop(struct pim_upstream *up)
 {
 	struct pim_neighbor *nbr = NULL;
 
-	EVENT_OFF(up->t_join_timer);
+    if (up->t_join_timer) {
+        EVENT_OFF(up->t_join_timer);
+    } else {
+		if (PIM_DEBUG_PIM_EVENTS) {
+			zlog_debug(
+				"%s: join timer thread already canceled",__func__);
+		}
+    }
 
 	if (up->rpf.source_nexthop.interface)
 		nbr = pim_neighbor_find(up->rpf.source_nexthop.interface,


### PR DESCRIPTION
Issue:
We stop all PIM timers during instance shutdown. Simultaneously, if there are any changes to the next hop (ZEBRA_NEXTHOP_UPDATE), it triggers an RPF update to the upstream next hop based on the new update received from Zebra.
This leads to stop an already stopped timer.

Fix:
Ensure that join_timer_stop is not called on an already canceled thread.

signed-off-by: Rajesh Varatharaj<rvaratharaj@nvidia.com>