### PR TITLE
bgpd: use igpmetric in bgp_aigp_metric_total()

### DIFF
--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -604,10 +604,11 @@ static inline uint64_t bgp_aigp_metric_total(struct bgp_path_info *bpi)
 {
 	uint64_t aigp = bgp_attr_get_aigp_metric(bpi->attr);
 
-	if (bpi->nexthop)
-		return aigp + bpi->nexthop->metric;
-	else
+	/* Don't increment if it's locally sourced */
+	if (bpi->peer == bpi->peer->bgp->peer_self)
 		return aigp;
+
+	return bpi->extra ? (aigp + bpi->extra->igpmetric) : aigp;
 }
 
 static inline void bgp_attr_set_med(struct attr *attr, uint32_t med)


### PR DESCRIPTION
Use igpmetric from bgp_path_info in bgp_igp_metric_total() to be consistent with all other cases, e.g., as in bgp_path_info_cmp().