### PR TITLE
bgpd: Fix showing default `timers bgp x y`

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -93,18 +93,6 @@ FRR_CFG_DEFAULT_BOOL(BGP_DETERMINISTIC_MED,
 	{ .val_bool = true, .match_profile = "datacenter", },
 	{ .val_bool = false },
 );
-FRR_CFG_DEFAULT_ULONG(BGP_CONNECT_RETRY,
-	{ .val_ulong = 10, .match_profile = "datacenter", },
-	{ .val_ulong = BGP_DEFAULT_CONNECT_RETRY },
-);
-FRR_CFG_DEFAULT_ULONG(BGP_HOLDTIME,
-	{ .val_ulong = 9, .match_profile = "datacenter", },
-	{ .val_ulong = BGP_DEFAULT_KEEPALIVE },
-);
-FRR_CFG_DEFAULT_ULONG(BGP_KEEPALIVE,
-	{ .val_ulong = 3, .match_profile = "datacenter", },
-	{ .val_ulong = BGP_DEFAULT_KEEPALIVE },
-);
 FRR_CFG_DEFAULT_BOOL(BGP_EBGP_REQUIRES_POLICY,
 	{ .val_bool = false, .match_profile = "datacenter", },
 	{ .val_bool = false, .match_version = "< 7.4", },

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -10,6 +10,19 @@
 #include "stream.h"
 struct bgp;
 
+FRR_CFG_DEFAULT_ULONG(BGP_KEEPALIVE,
+	{ .val_ulong = 3, .match_profile = "datacenter", },
+	{ .val_ulong = BGP_DEFAULT_KEEPALIVE },
+);
+FRR_CFG_DEFAULT_ULONG(BGP_HOLDTIME,
+	{ .val_ulong = 9, .match_profile = "datacenter", },
+	{ .val_ulong = BGP_DEFAULT_HOLDTIME },
+);
+FRR_CFG_DEFAULT_ULONG(BGP_CONNECT_RETRY,
+	{ .val_ulong = 10, .match_profile = "datacenter", },
+	{ .val_ulong = BGP_DEFAULT_CONNECT_RETRY },
+);
+
 #define BGP_INSTANCE_HELP_STR "BGP view\nBGP VRF\nView/VRF name\n"
 #define BGP_INSTANCE_ALL_HELP_STR "BGP view\nBGP VRF\nAll Views/VRFs\n"
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -583,9 +583,9 @@ void bgp_timers_set(struct vty *vty, struct bgp *bgp, uint32_t keepalive,
 /* mostly for completeness - CLI uses its own defaults */
 void bgp_timers_unset(struct bgp *bgp)
 {
-	bgp->default_keepalive = BGP_DEFAULT_KEEPALIVE;
-	bgp->default_holdtime = BGP_DEFAULT_HOLDTIME;
-	bgp->default_connect_retry = BGP_DEFAULT_CONNECT_RETRY;
+	bgp->default_keepalive = DFLT_BGP_KEEPALIVE;
+	bgp->default_holdtime = DFLT_BGP_HOLDTIME;
+	bgp->default_connect_retry = DFLT_BGP_CONNECT_RETRY;
 	bgp->default_delayopen = BGP_DEFAULT_DELAYOPEN;
 }
 


### PR DESCRIPTION
`frrbot` was intentionally skipped because we already prefer such formatting.