### PR TITLE
topotests: improve test reliability

### DIFF
--- a/tests/topotests/msdp_topo3/r1/frr.conf
+++ b/tests/topotests/msdp_topo3/r1/frr.conf
@@ -27,5 +27,6 @@ router pim
  msdp originator-id 10.254.254.1
  msdp log sa-events
  msdp peer 192.168.1.2 source 192.168.1.1
+ msdp timers 10 20 3
  rp 192.168.1.1
 !

--- a/tests/topotests/msdp_topo3/r2/frr.conf
+++ b/tests/topotests/msdp_topo3/r2/frr.conf
@@ -24,5 +24,6 @@ router bgp 65200
 router pim
  msdp log sa-events
  msdp peer 192.168.1.1 source 192.168.1.2
+ msdp timers 10 20 3
  rp 192.168.1.2
 !


### PR DESCRIPTION
Decrease the protocol timers, wait for peers to connect (and test it) then finally wait a bit more for SAs to be propagated.