### PR TITLE
bgpd: remove unused safi in bgp_aggregate structure

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8948,7 +8948,7 @@ static int bgp_aggregate_set(struct vty *vty, const char *prefix_str, afi_t afi,
 	}
 
 	aggregate->as_set = as_set_new;
-	aggregate->safi = safi;
+
 	/* Override ORIGIN attribute if defined.
 	 * E.g.: Cisco and Juniper set ORIGIN for aggregated address
 	 * to IGP which is not what rfc4271 says.

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -492,9 +492,6 @@ struct bgp_aggregate {
 	/* Aggregate route's as-path. */
 	struct aspath *aspath;
 
-	/* SAFI configuration. */
-	safi_t safi;
-
 	/** MED value found in current group. */
 	uint32_t med_matched_value;
 


### PR DESCRIPTION
Remove the unused safi field in bgp_aggregate structure.