### PR TITLE
doc: fix LaTex warnings, add documentation to build docs

### DIFF
--- a/doc/developer/building-doc.rst
+++ b/doc/developer/building-doc.rst
@@ -1,0 +1,62 @@
+Building Documentation
+======================
+
+To build FRR documentation, first install the dependencies.
+Notice that if you plan to only build html documenation, you only
+need the package ``python3-sphinx``.
+
+.. code-block:: console
+
+   sudo apt-get install -y python3-sphinx \
+      texlive-latex-base texlive-latex-extra latexmk
+
+To prepate for building both user and developer documentation, do:
+
+.. code-block:: console
+
+   cd doc
+   make
+
+User documentation
+------------------
+
+To build html user documentation:
+
+.. code-block:: console
+
+   cd user
+   make html
+
+This will generate html documentation files under ``_build/html/``.
+With the main page named ``index.html``.
+
+PFD can then be built by:
+
+.. code-block:: console
+
+   cd user
+   make pdf
+
+The generated PDF file will be saved at ``_build/latex/FRR.pdf``
+
+Developer documentation
+-----------------------
+
+To build the developer documentation:
+
+.. code-block:: console
+
+   cd developer
+   make html
+
+This will generate html documentation files under ``_build/html/``.
+With the main page named ``index.html``.
+
+PFD can then be built by:
+
+.. code-block:: console
+
+   cd developer
+   make pdf
+
+The generated PDF file will be saved at ``_build/latex/FRR.pdf``

--- a/doc/developer/subdir.am
+++ b/doc/developer/subdir.am
@@ -28,6 +28,7 @@ dev_RSTFILES = \
 	doc/developer/building-frr-for-ubuntu1804.rst \
 	doc/developer/building-frr-for-ubuntu2004.rst \
 	doc/developer/building-frr-for-ubuntu2204.rst \
+	doc/developer/building-doc.rst \
 	doc/developer/building-libunwind-note.rst \
 	doc/developer/building-libyang.rst \
 	doc/developer/building.rst \

--- a/doc/user/_static/overrides.js
+++ b/doc/user/_static/overrides.js
@@ -5,7 +5,7 @@
  */
 $(document).ready(function() {
     $("span.mark:contains('Y')" ).addClass("mark-y"  ).parent("td").addClass("mark");
-    $("span.mark:contains('≥')" ).addClass("mark-geq").parent("td").addClass("mark");
+    $("span.mark:contains('>=')").addClass("mark-geq").parent("td").addClass("mark");
     $("span.mark:contains('N')" ).addClass("mark-n"  ).parent("td").addClass("mark");
     $("span.mark:contains('CP')").addClass("mark-cp" ).parent("td").addClass("mark");
     $("span.mark:contains('†')" ).addClass("mark-dag").parent("td").addClass("mark");

--- a/doc/user/about.rst
+++ b/doc/user/about.rst
@@ -153,7 +153,7 @@ feature you're interested in, it should be supported on your platform.
 
 .. comment - the :mark:`X` pieces mesh with a little bit of JavaScript and
    CSS in _static/overrides.{js,css} respectively.  The JS code looks at the
-   presence of the 'Y' 'N' '≥' '†' or 'CP' strings.  This seemed to be the
+   presence of the 'Y' 'N' '>=' '†' or 'CP' strings.  This seemed to be the
    best / least intrusive way of getting a nice table in HTML.  The table
    will look somewhat shoddy on other sphinx targets like PDF or info (but
    should still be readable.)
@@ -165,9 +165,9 @@ feature you're interested in, it should be supported on your platform.
 +-----------------------------------+----------------+--------------+------------+------------+
 | `zebra`                           | :mark:`Y`      | :mark:`Y`    | :mark:`Y`  | :mark:`Y`  |
 +-----------------------------------+----------------+--------------+------------+------------+
-|    VRF                            | :mark:`≥4.8`   | :mark:`N`    | :mark:`N`  | :mark:`N`  |
+|    VRF                            | :mark:`>=4.8`  | :mark:`N`    | :mark:`N`  | :mark:`N`  |
 +-----------------------------------+----------------+--------------+------------+------------+
-|    MPLS                           | :mark:`≥4.5`   | :mark:`Y`    | :mark:`N`  | :mark:`N`  |
+|    MPLS                           | :mark:`>=4.5`  | :mark:`Y`    | :mark:`N`  | :mark:`N`  |
 +-----------------------------------+----------------+--------------+------------+------------+
 | `pbrd` (Policy Routing)           | :mark:`Y`      | :mark:`N`    | :mark:`N`  | :mark:`N`  |
 +-----------------------------------+----------------+--------------+------------+------------+
@@ -175,21 +175,21 @@ feature you're interested in, it should be supported on your platform.
 +-----------------------------------+----------------+--------------+------------+------------+
 | `bgpd` (BGP)                      | :mark:`Y`      | :mark:`Y`    | :mark:`Y`  | :mark:`Y`  |
 +-----------------------------------+----------------+--------------+------------+------------+
-|    VRF / L3VPN                    | :mark:`≥4.8`   | :mark:`CP`   | :mark:`CP` | :mark:`CP` |
+|    VRF / L3VPN                    | :mark:`>=4.8`  | :mark:`CP`   | :mark:`CP` | :mark:`CP` |
 |                                   | :mark:`†4.3`   |              |            |            |
 +-----------------------------------+----------------+--------------+------------+------------+
-|    EVPN                           | :mark:`≥4.18`  | :mark:`CP`   | :mark:`CP` | :mark:`CP` |
+|    EVPN                           | :mark:`>=4.18` | :mark:`CP`   | :mark:`CP` | :mark:`CP` |
 |                                   | :mark:`†4.9`   |              |            |            |
 +-----------------------------------+----------------+--------------+------------+------------+
 |    VNC (Virtual Network Control)  | :mark:`CP`     | :mark:`CP`   | :mark:`CP` | :mark:`CP` |
 +-----------------------------------+----------------+--------------+------------+------------+
 |    Flowspec                       | :mark:`CP`     | :mark:`CP`   | :mark:`CP` | :mark:`CP` |
 +-----------------------------------+----------------+--------------+------------+------------+
-| `ldpd` (LDP)                      | :mark:`≥4.5`   | :mark:`Y`    | :mark:`N`  | :mark:`N`  |
+| `ldpd` (LDP)                      | :mark:`>=4.5`  | :mark:`Y`    | :mark:`N`  | :mark:`N`  |
 +-----------------------------------+----------------+--------------+------------+------------+
-|    VPWS / PW                      | :mark:`N`      | :mark:`≥5.8` | :mark:`N`  | :mark:`N`  |
+|    VPWS / PW                      | :mark:`N`      | :mark:`>=5.8`| :mark:`N`  | :mark:`N`  |
 +-----------------------------------+----------------+--------------+------------+------------+
-|    VPLS                           | :mark:`N`      | :mark:`≥5.8` | :mark:`N`  | :mark:`N`  |
+|    VPLS                           | :mark:`N`      | :mark:`>=5.8`| :mark:`N`  | :mark:`N`  |
 +-----------------------------------+----------------+--------------+------------+------------+
 | `nhrpd` (NHRP)                    | :mark:`Y`      | :mark:`N`    | :mark:`N`  | :mark:`N`  |
 +-----------------------------------+----------------+--------------+------------+------------+
@@ -197,7 +197,7 @@ feature you're interested in, it should be supported on your platform.
 +-----------------------------------+----------------+--------------+------------+------------+
 | `ospfd` (OSPFv2)                  | :mark:`Y`      | :mark:`Y`    | :mark:`Y`  | :mark:`Y`  |
 +-----------------------------------+----------------+--------------+------------+------------+
-|    Segment Routing                | :mark:`≥4.12`  | :mark:`N`    | :mark:`N`  | :mark:`N`  |
+|    Segment Routing                | :mark:`>=4.12` | :mark:`N`    | :mark:`N`  | :mark:`N`  |
 +-----------------------------------+----------------+--------------+------------+------------+
 | `ospf6d` (OSPFv3)                 | :mark:`Y`      | :mark:`Y`    | :mark:`Y`  | :mark:`Y`  |
 +-----------------------------------+----------------+--------------+------------+------------+
@@ -215,21 +215,21 @@ feature you're interested in, it should be supported on your platform.
 +-----------------------------------+----------------+--------------+------------+------------+
 | **Multicast Routing**             |                |              |            |            |
 +-----------------------------------+----------------+--------------+------------+------------+
-| `pimd` (PIM)                      | :mark:`≥4.19`  | :mark:`N`    | :mark:`Y`  | :mark:`Y`  |
+| `pimd` (PIM)                      | :mark:`>=4.19` | :mark:`N`    | :mark:`Y`  | :mark:`Y`  |
 +-----------------------------------+----------------+--------------+------------+------------+
 |    SSM (Source Specific)          | :mark:`Y`      | :mark:`N`    | :mark:`Y`  | :mark:`Y`  |
 +-----------------------------------+----------------+--------------+------------+------------+
 |    ASM (Any Source)               | :mark:`Y`      | :mark:`N`    | :mark:`N`  | :mark:`N`  |
 +-----------------------------------+----------------+--------------+------------+------------+
-|    EVPN BUM Forwarding            | :mark:`≥5.0`   | :mark:`N`    | :mark:`N`  | :mark:`N`  |
+|    EVPN BUM Forwarding            | :mark:`>=5.0`  | :mark:`N`    | :mark:`N`  | :mark:`N`  |
 +-----------------------------------+----------------+--------------+------------+------------+
-| `vrrpd` (VRRP)                    | :mark:`≥5.1`   | :mark:`N`    | :mark:`N`  | :mark:`N`  |
+| `vrrpd` (VRRP)                    | :mark:`>=5.1`  | :mark:`N`    | :mark:`N`  | :mark:`N`  |
 +-----------------------------------+----------------+--------------+------------+------------+
 
 The indicators have the following semantics:
 
 * :mark:`Y` - daemon/feature fully functional
-* :mark:`≥X.X` - fully functional with kernel version X.X or newer
+* :mark:`>=X.X` - fully functional with kernel version X.X or newer
 * :mark:`†X.X` - restricted functionality or impaired performance with kernel version X.X or newer
 * :mark:`CP` - control plane only (i.e. BGP route server / route reflector)
 * :mark:`N` - daemon/feature not supported by operating system


### PR DESCRIPTION
LaTex doesn't like the Unicon character `≥` which should be represented by the special sequnce `$\leq$`. Since this is buried all in Sphinx, and we also have a scrip that look for the character, the easiest fix is to just use `>=` instead which works without warnings, and without asking to ignore every warning about the use of every instance of the special char.