### PR TITLE
tools: fix frr-reload for nbr deletion of no form cmds

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -948,10 +948,14 @@ def bgp_remove_neighbor_cfg(lines_to_del, del_nbr_dict):
     lines_to_del_to_del = []
 
     for ctx_keys, line in lines_to_del:
+        # lines_to_del has following
+        # (('router bgp 100',), 'neighbor swp1.10 interface peer-group dpeergrp_2'),
+        # (('router bgp 100',), 'neighbor swp1.10 advertisement-interval 1'),
+        # (('router bgp 100',), 'no neighbor swp1.10 capability dynamic'),
         if (
             ctx_keys[0].startswith("router bgp")
             and line
-            and line.startswith("neighbor ")
+            and ((line.startswith("neighbor ") or line.startswith("no neighbor ")))
         ):
             if ctx_keys[0] in del_nbr_dict:
                 for nbr in del_nbr_dict[ctx_keys[0]]:


### PR DESCRIPTION
When a bgp neighbor removed from associated to peer-group, the neighbor is fully deleted, subsequent deletion of any configuration related to the neighbor leads to failure in frr-reload.
Handle any 'no neighbor ...' part of lines_to_del list

Testing:
Below first line would delete the neighbor swp1.10, the existing code before the change handles to remove config starts with 'neighbor swp1.10 ...' but not
'no neighbor swp1.10 ...'.

(Pdb) (lines_to_del)
 (('router bgp 100',), 'neighbor swp1.10 interface peer-group dpeergrp_2'),
 (('router bgp 100',), 'neighbor swp1.10 advertisement-interval 1'),
 (('router bgp 100',), 'neighbor swp1.10 timers 3 9'),
 (('router bgp 100',), 'neighbor swp1.10 timers connect 1'),
 (('router bgp 100',), 'no neighbor swp1.10 capability dynamic'),

**Before fix:**

```
(Pdb) (lines_to_del)
[(('router bgp 100',), 'neighbor swp1.10 interface peer-group dpeergrp_2'),
 (('router bgp 100',), 'no neighbor swp1.10 capability dynamic')]
```

frr-reload log:
```
2025-01-13 05:13:11,172  INFO: Executed "router bgp 100  no neighbor swp1.10 interface peer-group dpeergrp_2 exit" 2025-01-13 05:13:11,227 ERROR: Failed to execute router bgp 100  neighbor swp1.10 capability dynamic exit 2025-01-13 05:13:11,228 ERROR: "router bgp 100 --  neighbor swp1.10 capability dynamic -- exit" we failed to remove this command
```

**After fix:**
```
(Pdb)(lines_to_del)
 [(('router bgp 100',), 'neighbor swp1.10 interface peer-group dpeergrp_2')]
 ```
 
 Signed-off-by: Chirag Shah <chirag@nvidia.com>