### PR TITLE
bgpd: update AS value of a hidden bgp instance

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3412,12 +3412,27 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 	afi_t afi;
 	safi_t safi;
 
-	if (hidden) {
+	if (hidden)
 		bgp = bgp_old;
-		goto peer_init;
-	}
+	else
+		bgp = XCALLOC(MTYPE_BGP, sizeof(struct bgp));
 
-	bgp = XCALLOC(MTYPE_BGP, sizeof(struct bgp));
+	bgp->as = *as;
+	if (bgp->as_pretty)
+		XFREE(MTYPE_BGP_NAME, bgp->as_pretty);
+	if (as_pretty)
+		bgp->as_pretty = XSTRDUP(MTYPE_BGP_NAME, as_pretty);
+	else
+		bgp->as_pretty = XSTRDUP(MTYPE_BGP_NAME, asn_asn2asplain(*as));
+
+	if (asnotation != ASNOTATION_UNDEFINED) {
+		bgp->asnotation = asnotation;
+		SET_FLAG(bgp->config, BGP_CONFIG_ASNOTATION);
+	} else
+		asn_str2asn_notation(bgp->as_pretty, NULL, &bgp->asnotation);
+
+	if (hidden)
+		goto peer_init;
 
 	if (BGP_DEBUG(zebra, ZEBRA)) {
 		if (inst_type == BGP_INSTANCE_TYPE_DEFAULT)

--- a/tests/topotests/bgp_router_vrf_cross_import/r1/frr.conf
+++ b/tests/topotests/bgp_router_vrf_cross_import/r1/frr.conf
@@ -1,0 +1,23 @@
+!
+int r1-eth0
+ ip address 10.255.0.1/24
+!
+vrf D
+exit-vrf
+!
+router bgp 65001 vrf D
+ !
+ bgp router-id 10.255.0.1
+ address-family ipv4 unicast
+  import vrf default
+ exit-address-family
+exit
+!
+router bgp 65001
+ !
+ bgp router-id 10.255.0.1
+ address-family ipv4 unicast
+  import vrf D
+ exit-address-family
+exit
+!

--- a/tests/topotests/bgp_router_vrf_cross_import/test_cross_import.py
+++ b/tests/topotests/bgp_router_vrf_cross_import/test_cross_import.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+import functools, json, os, pytest, re, sys
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1")}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for _, (rname, router) in enumerate(router_list.items(), 1):
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr.conf".format(rname))
+        )
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_vrf_cross_import():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _bgp_router_vrf_custom():
+        output = json.loads(
+            r1.vtysh_cmd("show bgp vrf D detail json")
+        )
+        expected = {
+	    "vrfName": "D",
+            "localAS": 65001
+        }
+
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(
+        _bgp_router_vrf_custom,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "bgp router 65001 vrf D failed"
+
+    def _bgp_router_vrf_default():
+        output = json.loads(
+            r1.vtysh_cmd("show bgp detail json")
+        )
+        expected = {
+	    "vrfName": "default",
+            "localAS": 65001
+        }
+
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(
+        _bgp_router_vrf_default,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "bgp router 65001 failed in default vrf"
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
'import vrf CUSTOM' could define a hidden bgp instance with the default AS_UNSPECIFIED (i.e. = 1) value.
When a
	router bgp AS vrf CUSTOM
gets configured later on, replace this AS_UNSPECIFIED setting with a requested value.