### PR TITLE
bgpd: Fix for local interface MAC cache issue in 'bgp mac hash' table

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3375,11 +3375,14 @@ static int bgp_ifp_create(struct interface *ifp)
 		zlog_debug("Rx Intf add VRF %s IF %s", ifp->vrf->name,
 			   ifp->name);
 
+	/* We don't need to check for vrf->bgp link to add this local MAC
+	 * to the hash table as the tenant VRF might not have the BGP instance.
+	 */
+	bgp_mac_add_mac_entry(ifp);
+
 	bgp = ifp->vrf->info;
 	if (!bgp)
 		return 0;
-
-	bgp_mac_add_mac_entry(ifp);
 
 	bgp_update_interface_nbrs(bgp, ifp, ifp);
 	hook_call(bgp_vrf_status_changed, bgp, ifp);


### PR DESCRIPTION
Issue:
During FRR restart, we fail to add some of the local interface's MAC to the 'bgp mac hash'. Not having local MAC in the hash table can cause lookup issues while receiving EVPN RT-2.

Currently, we have code to add local MAC(bgp_mac_add_mac_entry) while handling interface add/up events in BGP(bgp_ifp_up/bgp_ifp_create). But the code 'bgp_mac_add_mac_entry' in bgp_ifp_create is not getting invoked as it is placed under a specific check(vrf->bgp link check).

Fix:
We can skip this check 'vrf->bgp link existence' as the tenant VRF might not have BGP instance but still we want to cache the tenant VRF local MACs. So keeping this check in bgp_ifp_create inline with bgp_ifp_up.

Ticket: #4204154