### PR TITLE
bgpd: fix do not send twice peer up/down messages

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2451,7 +2451,7 @@ static void bmp_send_all_bgp(struct peer *peer, bool down)
 		if (!bmpbgp)
 			continue;
 		frr_each (bmp_targets, &bmpbgp->targets, bt) {
-			if (bgp_vrf != peer->bgp && !bmp_imported_bgp_find(bt, peer->bgp->name))
+			if (bgp_vrf == peer->bgp || !bmp_imported_bgp_find(bt, peer->bgp->name))
 				continue;
 			bmp_send_bt(bt, s);
 		}


### PR DESCRIPTION
With recent BMP code, on a standard BMP config, the peer up and peer down messages related to a BGP peer are sent twice, whereas they should be send only once.

Fix this by better controlling the condition.

Fixes: f8a693311145 ("bgpd: bmp, handle imported bgp instances for peer up/down events")