### PR TITLE
lib: fix coverity use after free issue: CID 1620101

### DIFF
--- a/lib/northbound_notif.c
+++ b/lib/northbound_notif.c
@@ -600,6 +600,7 @@ static void timer_walk_continue(struct event *event)
 			timer_walk_done(args);
 			return;
 		}
+		group = args->group;
 	}
 
 	path = group->cur_change->path;


### PR DESCRIPTION
The code doesn't push more than one group (currently) so wouldn't hit the bug yet, nice catch by coverity.