### PR TITLE
zebra: Return error if v6 prefix is passed to show ip route

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1789,9 +1789,24 @@ DEFPY (show_route_detail,
 	rib_dest_t *dest;
 	bool network_found = false;
 	bool show_ng = !!ng;
+	int idx = 0;
+
+	/*
+	 * Return error if V6 address/prefix is passed as an argument to
+	 * "show ip route" cmd.
+	 *
+	 * When "show ip route <X:X::X:X|X:X::X:X/M>" is queried,
+	 * argv[idx]->text will be set to "ipv6" but argv[idx]->arg will be set
+	 * to "ip".
+	 */
+	if (argv_find(argv, argc, "ipv6", &idx) && !strcmp(argv[idx]->arg, "ip")) {
+		vty_out(vty, "%% Cannot specify IPv6 address/prefix for IPv4 table\n");
+		return CMD_WARNING;
+	}
 
 	if (address_str)
 		prefix_str = address_str;
+
 	if (str2prefix(prefix_str, &p) < 0) {
 		vty_out(vty, "%% Malformed address\n");
 		return CMD_WARNING;


### PR DESCRIPTION
Return error if IPv6 address or prefix is passed as an argument to "show ip route" command.

UT:
------
Before fix:
```
r1# 
r1# show ipv6 route 200.0.20.1/32
% Unknown command: show ipv6 route 200.0.20.1/32
r1# 
r1# show ip route 2::3/128 ===> v4  CMD accepts v6 prefix
Routing entry for 2::3/128
  Known via "bgp", distance 20, metric 0, best
  Last update 00:02:30 ago
  * fe80::5493:4ff:fe30:55fd, via r1-r2-eth0, weight 1

r1# show ip route 2::3 ===> v4  CMD accepts v6 address
Routing entry for 2::3/128
  Known via "bgp", distance 20, metric 0, best
  Last update 00:15:16 ago
  * fe80::5493:4ff:fe30:55fd, via r1-r2-eth0, weight 1

r1# show ip route 2::
r1# show ip route 2:
% Unknown command: show ip route 2:
r1# 
```



After fix:
```
r1# show ip route 2::3/128
% Cannot specify IPv6 address or prefix with IPv4 AFI ===> Returned error
r1# 
r1# show ip route 2::3
% Cannot specify IPv6 address or prefix with IPv4 AFI ===> Returned error
r1# 
r1# 
r1# show ipv6 route 2::3
Routing entry for 2::3/128
  Known via "bgp", distance 20, metric 0, best
  Last update 00:01:17 ago
  * fe80::859:d5ff:feab:c1a4, via r1-r2-eth0, weight 1

r1# show ipv6 route 2::3/128
Routing entry for 2::3/128
  Known via "bgp", distance 20, metric 0, best
  Last update 00:01:23 ago
  * fe80::859:d5ff:feab:c1a4, via r1-r2-eth0, weight 1

r1# show ipv6 route 200.0.20.1/32
% Unknown command: show ipv6 route 200.0.20.1/32
r1# 
```