### PR TITLE
bgpd: fix evpn path info get api

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -4737,7 +4737,7 @@ bgp_evpn_path_nh_info_new(struct bgp_path_info *pi)
 	struct bgp_path_mh_info *mh_info;
 	struct bgp_path_evpn_nh_info *nh_info;
 
-	e = bgp_path_info_extra_get(pi);
+	e = bgp_evpn_path_info_extra_get(pi);
 
 	/* If mh_info doesn't exist allocate it */
 	mh_info = e->evpn->mh_info;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -328,6 +328,19 @@ struct bgp_path_info_extra *bgp_path_info_extra_get(struct bgp_path_info *pi)
 	return pi->extra;
 }
 
+/* Get bgp_path_info extra along with evpn information for the given bgp_path_info.
+ * This is used for EVPN imported routes like Type-5.
+ */
+struct bgp_path_info_extra *bgp_evpn_path_info_extra_get(struct bgp_path_info *pi)
+{
+	if (!pi->extra)
+		pi->extra = bgp_path_info_extra_new();
+	if (!pi->extra->evpn)
+		pi->extra->evpn = XCALLOC(MTYPE_BGP_ROUTE_EXTRA_EVPN,
+					  sizeof(struct bgp_path_info_extra_evpn));
+	return pi->extra;
+}
+
 bool bgp_path_info_has_valid_label(const struct bgp_path_info *path)
 {
 	if (!BGP_PATH_INFO_NUM_LABELS(path))

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -801,6 +801,7 @@ extern void bgp_path_info_delete(struct bgp_dest *dest,
 				 struct bgp_path_info *pi);
 extern struct bgp_path_info_extra *
 bgp_path_info_extra_get(struct bgp_path_info *path);
+extern struct bgp_path_info_extra *bgp_evpn_path_info_extra_get(struct bgp_path_info *path);
 extern bool bgp_path_info_has_valid_label(const struct bgp_path_info *path);
 extern void bgp_path_info_set_flag(struct bgp_dest *dest,
 				   struct bgp_path_info *path, uint32_t flag);


### PR DESCRIPTION
EVPN imported routes AF is not AF_EVPN, in that case the path info extra with EVPN is nver created.
In order to create evpn info under path extra, define new api which does not specifically check for AF_EVPN afi type.


Signed-off-by: Chirag Shah <chirag@nvidia.com>