### PR TITLE
bgpd: fix bfd with update-source in peer-group

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -114,6 +114,10 @@ void bgp_peer_config_apply(struct peer *p, struct peer_group *pg)
 	 */
 	gconfig = pg->conf;
 
+	if (CHECK_FLAG(gconfig->flags, PEER_FLAG_UPDATE_SOURCE) ||
+	    CHECK_FLAG(p->flags_override, PEER_FLAG_UPDATE_SOURCE))
+		bgp_peer_bfd_update_source(p);
+
 	/*
 	 * If using default control plane independent configuration,
 	 * then prefer group's (e.g. it means it wasn't manually configured).

--- a/tests/topotests/bgp_bfd_session/r1/frr.conf
+++ b/tests/topotests/bgp_bfd_session/r1/frr.conf
@@ -11,4 +11,16 @@ router bgp 65000
  neighbor 192.168.1.3 bfd
  neighbor 192.168.1.3 ebgp-multihop 20
  neighbor 192.168.1.3 update-source r1-eth0
+ neighbor PG peer-group
+ neighbor PG remote-as auto
+ neighbor PG bfd
+ neighbor PG ebgp-multihop 15
+ neighbor PG update-source 10.0.0.1
+ neighbor 192.168.1.4 peer-group PG
+ neighbor PG2 peer-group
+ neighbor PG2 remote-as auto
+ neighbor PG2 bfd
+ neighbor PG2 ebgp-multihop 25
+ neighbor 192.168.1.5 peer-group PG2
+ neighbor 192.168.1.5 update-source 10.0.0.1
 exit

--- a/tests/topotests/bgp_bfd_session/test_bgp_bfd_session.py
+++ b/tests/topotests/bgp_bfd_session/test_bgp_bfd_session.py
@@ -85,7 +85,29 @@ def test_bgp_bfd_session():
                 "diagnostic": "ok",
                 "remote-diagnostic": "ok",
                 "type": "dynamic",
-            }
+            },
+            {
+                "multihop": True,
+                "peer": "192.168.1.4",
+                "local": "10.0.0.1",
+                "vrf": "default",
+                "minimum-ttl": 241,
+                "status": "down",
+                "diagnostic": "ok",
+                "remote-diagnostic": "ok",
+                "type": "dynamic",
+            },
+            {
+                "multihop": True,
+                "peer": "192.168.1.5",
+                "local": "10.0.0.1",
+                "vrf": "default",
+                "minimum-ttl": 231,
+                "status": "down",
+                "diagnostic": "ok",
+                "remote-diagnostic": "ok",
+                "type": "dynamic",
+            },
         ]
         return topotest.json_cmp(output, expected)
 


### PR DESCRIPTION
Fix BFD session not created when the peer is in update-group with the update-source option.
    
