### PR TITLE
pimd: filter neighbors by address

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -391,6 +391,10 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
    reports on the interface. Refer to the next `ip igmp` command for IGMP
    management.
 
+.. clicmd:: ip pim allowed-neighbors prefix-list PREFIX_LIST
+
+   Only establish sessions with PIM neighbors allowed by the prefix-list.
+
 .. clicmd:: ip pim use-source A.B.C.D
 
    If you have multiple addresses configured on a particular interface

--- a/doc/user/pimv6.rst
+++ b/doc/user/pimv6.rst
@@ -214,6 +214,10 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
    reports on the interface. Refer to the next ``ipv6 mld`` command for MLD
    management.
 
+.. clicmd:: ipv6 pim allowed-neighbors prefix-list PREFIX_LIST
+
+   Only establish sessions with PIM neighbors allowed by the prefix-list.
+
 .. clicmd:: ipv6 pim use-source X:X::X:X
 
    If you have multiple addresses configured on a particular interface

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1803,6 +1803,34 @@ DEFPY (interface_no_ipv6_mld_last_member_query_interval,
 	return gm_process_no_last_member_query_interval_cmd(vty);
 }
 
+DEFPY_YANG(interface_ipv6_pim_neighbor_prefix_list,
+           interface_ipv6_pim_neighbor_prefix_list_cmd,
+           "[no] ipv6 pim allowed-neighbors prefix-list PREFIXLIST6_NAME$prefix_list",
+           NO_STR
+           IP_STR
+           PIM_STR
+           "Restrict allowed PIM neighbors\n"
+           "Use prefix-list to filter neighbors\n"
+           "Name of a prefix-list\n")
+{
+	if (no)
+		nb_cli_enqueue_change(vty, "./neighbor-filter-prefix-list", NB_OP_DESTROY, NULL);
+	else
+		nb_cli_enqueue_change(vty, "./neighbor-filter-prefix-list", NB_OP_MODIFY,
+				      prefix_list);
+
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH, FRR_PIM_AF_XPATH_VAL);
+}
+
+ALIAS(interface_ipv6_pim_neighbor_prefix_list,
+      interface_no_ipv6_pim_neighbor_prefix_list_cmd,
+      "no ipv6 pim allowed-neighbors [prefix-list]",
+      NO_STR
+      IP_STR
+      PIM_STR
+      "Restrict allowed PIM neighbors\n"
+      "Use prefix-list to filter neighbors\n")
+
 DEFPY (show_ipv6_pim_rp,
        show_ipv6_pim_rp_cmd,
        "show ipv6 pim [vrf NAME] rp-info [X:X::X:X/M$group] [json$json]",
@@ -2973,6 +3001,8 @@ void pim_cmd_init(void)
 			&interface_ipv6_mld_last_member_query_interval_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_no_ipv6_mld_last_member_query_interval_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_pim_neighbor_prefix_list_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_pim_neighbor_prefix_list_cmd);
 
 	install_element(VIEW_NODE, &show_ipv6_pim_rp_cmd);
 	install_element(VIEW_NODE, &show_ipv6_pim_rp_vrf_all_cmd);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6035,6 +6035,34 @@ DEFPY (interface_ip_igmp_proxy,
 }
 
 
+DEFPY_YANG(interface_ip_pim_neighbor_prefix_list,
+           interface_ip_pim_neighbor_prefix_list_cmd,
+           "[no] ip pim allowed-neighbors prefix-list WORD",
+           NO_STR
+           IP_STR
+           "pim multicast routing\n"
+           "Restrict allowed PIM neighbors\n"
+           "Use prefix-list to filter neighbors\n"
+           "Name of a prefix-list\n")
+{
+	if (no)
+		nb_cli_enqueue_change(vty, "./neighbor-filter-prefix-list", NB_OP_DESTROY, NULL);
+	else
+		nb_cli_enqueue_change(vty, "./neighbor-filter-prefix-list", NB_OP_MODIFY,
+				      prefix_list);
+
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH, FRR_PIM_AF_XPATH_VAL);
+}
+
+ALIAS (interface_ip_pim_neighbor_prefix_list,
+       interface_no_ip_pim_neighbor_prefix_list_cmd,
+       "no ip pim allowed-neighbors [prefix-list]",
+       NO_STR
+       IP_STR
+       "pim multicast routing\n"
+       "Restrict allowed PIM neighbors\n"
+       "Use prefix-list to filter neighbors\n")
+
 DEFUN (debug_igmp,
        debug_igmp_cmd,
        "debug igmp",
@@ -9169,6 +9197,8 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &interface_no_ip_pim_boundary_oil_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_pim_boundary_acl_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_igmp_query_generate_cmd);
+	install_element(INTERFACE_NODE, &interface_ip_pim_neighbor_prefix_list_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ip_pim_neighbor_prefix_list_cmd);
 
 	// Static mroutes NEB
 	install_element(INTERFACE_NODE, &interface_ip_mroute_cmd);

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -218,6 +218,7 @@ void pim_if_delete(struct interface *ifp)
 	if (pim_ifp->bfd_config.profile)
 		XFREE(MTYPE_TMP, pim_ifp->bfd_config.profile);
 
+	XFREE(MTYPE_PIM_PLIST_NAME, pim_ifp->nbr_plist);
 	XFREE(MTYPE_PIM_INTERFACE, pim_ifp);
 
 	ifp->info = NULL;

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -121,6 +121,7 @@ struct pim_interface {
 	uint32_t pim_generation_id;
 	uint16_t pim_propagation_delay_msec; /* config */
 	uint16_t pim_override_interval_msec; /* config */
+	char *nbr_plist;
 	struct list *pim_neighbor_list;      /* list of struct pim_neighbor */
 	struct list *upstream_switch_list;
 	struct pim_ifchannel_rb ifchannel_rb;

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -315,6 +315,13 @@ const struct frr_yang_module_info frr_pim_info = {
 			}
 		},
 		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/neighbor-filter-prefix-list",
+			.cbs = {
+				.modify = lib_interface_pim_address_family_nbr_plist_modify,
+				.destroy = lib_interface_pim_address_family_nbr_plist_destroy,
+			}
+		},
+		{
 			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/bfd",
 			.cbs = {
 				.create = lib_interface_pim_address_family_bfd_create,

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -110,6 +110,8 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_mc
 	struct nb_cb_modify_args *args);
 int lib_interface_pim_address_family_dr_priority_modify(
 	struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_nbr_plist_modify(struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_nbr_plist_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_pim_address_family_create(struct nb_cb_create_args *args);
 int lib_interface_pim_address_family_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_pim_address_family_pim_enable_modify(

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2163,6 +2163,55 @@ int lib_interface_pim_address_family_hello_holdtime_destroy(
 
 	return NB_OK;
 }
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/neighbor-filter-prefix-list
+ */
+int lib_interface_pim_address_family_nbr_plist_modify(struct nb_cb_modify_args *args)
+{
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+	const char *plist;
+
+	plist = yang_dnode_get_string(args->dnode, NULL);
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_ABORT:
+	case NB_EV_PREPARE:
+		break;
+	case NB_EV_APPLY:
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
+		pim_ifp = ifp->info;
+
+		XFREE(MTYPE_PIM_PLIST_NAME, pim_ifp->nbr_plist);
+		pim_ifp->nbr_plist = XSTRDUP(MTYPE_PIM_PLIST_NAME, plist);
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_pim_address_family_nbr_plist_destroy(struct nb_cb_destroy_args *args)
+{
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_ABORT:
+	case NB_EV_PREPARE:
+		break;
+	case NB_EV_APPLY:
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
+		pim_ifp = ifp->info;
+		XFREE(MTYPE_PIM_PLIST_NAME, pim_ifp->nbr_plist);
+		break;
+	}
+
+	return NB_OK;
+}
+
 /*
  * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bfd
  */

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -477,6 +477,12 @@ int pim_config_write(struct vty *vty, int writes, struct interface *ifp,
 		++writes;
 	}
 
+	if (pim_ifp->nbr_plist) {
+		vty_out(vty, " " PIM_AF_NAME " pim allowed-neighbors prefix-list %s\n",
+			pim_ifp->nbr_plist);
+		++writes;
+	}
+
 	/* IF ip pim drpriority */
 	if (pim_ifp->pim_dr_priority != PIM_DEFAULT_DR_PRIORITY) {
 		vty_out(vty, " " PIM_AF_NAME " pim drpriority %u\n",

--- a/tests/topotests/multicast_features/r1/frr.conf
+++ b/tests/topotests/multicast_features/r1/frr.conf
@@ -1,5 +1,8 @@
 log commands
 !
+!ip prefix-list pim-eth0-neighbors permit 192.168.2.0/24
+!ipv6 prefix-list pimv6-eth0-neighbors permit 2001:db8:2::/64
+!
 interface r1-eth0
  ip address 192.168.1.1/24
  ip pim
@@ -9,8 +12,10 @@ interface r1-eth0
 interface r1-eth1
  ip address 192.168.2.1/24
  ip pim
+ ip pim allowed-neighbors prefix-list pim-eth0-neighbors
  ipv6 address 2001:db8:2::1/64
  ipv6 pim
+ ipv6 pim allowed-neighbors prefix-list pimv6-eth0-neighbors
 !
 interface r1-eth2
  ip address 192.168.100.1/24

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -516,6 +516,12 @@ module frr-pim {
         "Hello holdtime";
     }
 
+    leaf neighbor-filter-prefix-list {
+      type plist-ref;
+      description
+        "Prefix-List to filter allowed PIM neighbors.";
+    }
+
     container bfd {
       presence
         "Enable BFD support on the interface.";


### PR DESCRIPTION
This is a new PIM feature to filter undesired PIM neighbors from establishing sessions.