### PR TITLE
*: expose and fix variable shadowing warnings

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -755,8 +755,10 @@ babel_interface_close_all(void)
     }
     /* Disable babel redistribution */
     for (type = 0; type < ZEBRA_ROUTE_MAX; type++) {
-        zclient_redistribute (ZEBRA_REDISTRIBUTE_DELETE, zclient, AFI_IP, type, 0, VRF_DEFAULT);
-        zclient_redistribute (ZEBRA_REDISTRIBUTE_DELETE, zclient, AFI_IP6, type, 0, VRF_DEFAULT);
+        zclient_redistribute(ZEBRA_REDISTRIBUTE_DELETE, babel_zclient, AFI_IP, type, 0,
+			     VRF_DEFAULT);
+        zclient_redistribute(ZEBRA_REDISTRIBUTE_DELETE, babel_zclient, AFI_IP6, type, 0,
+			     VRF_DEFAULT);
     }
 }
 
@@ -974,6 +976,7 @@ DEFUN (show_babel_route,
 {
     struct route_stream *routes = NULL;
     struct xroute_stream *xroutes = NULL;
+
     routes = route_stream(0);
     if(routes) {
         while(1) {

--- a/babeld/babel_zebra.c
+++ b/babeld/babel_zebra.c
@@ -19,7 +19,7 @@ void babelz_zebra_init(void);
 
 
 /* we must use a pointer because of zclient.c's functions (new, free). */
-struct zclient *zclient;
+struct zclient *babel_zclient;
 
 /* Debug types */
 static const struct {
@@ -94,9 +94,10 @@ DEFUN (babel_redistribute_type,
     }
 
     if (!negate)
-        zclient_redistribute (ZEBRA_REDISTRIBUTE_ADD, zclient, afi, type, 0, VRF_DEFAULT);
+        zclient_redistribute(ZEBRA_REDISTRIBUTE_ADD, babel_zclient, afi, type, 0, VRF_DEFAULT);
     else {
-        zclient_redistribute (ZEBRA_REDISTRIBUTE_DELETE, zclient, afi, type, 0, VRF_DEFAULT);
+        zclient_redistribute(ZEBRA_REDISTRIBUTE_DELETE, babel_zclient, afi, type, 0,
+			     VRF_DEFAULT);
         /* perhaps should we remove xroutes having the same type... */
     }
     return CMD_SUCCESS;
@@ -230,11 +231,11 @@ static zclient_handler *const babel_handlers[] = {
 
 void babelz_zebra_init(void)
 {
-    zclient = zclient_new(master, &zclient_options_default, babel_handlers,
-			  array_size(babel_handlers));
-    zclient_init(zclient, ZEBRA_ROUTE_BABEL, 0, &babeld_privs);
+    babel_zclient = zclient_new(master, &zclient_options_default, babel_handlers,
+				array_size(babel_handlers));
+    zclient_init(babel_zclient, ZEBRA_ROUTE_BABEL, 0, &babeld_privs);
 
-    zclient->zebra_connected = babel_zebra_connected;
+    babel_zclient->zebra_connected = babel_zebra_connected;
 
     install_element(BABEL_NODE, &babel_redistribute_type_cmd);
     install_element(ENABLE_NODE, &debug_babel_cmd);
@@ -248,6 +249,6 @@ void babelz_zebra_init(void)
 void
 babel_zebra_close_connexion(void)
 {
-    zclient_stop(zclient);
-    zclient_free(zclient);
+    zclient_stop(babel_zclient);
+    zclient_free(babel_zclient);
 }

--- a/babeld/babel_zebra.h
+++ b/babeld/babel_zebra.h
@@ -8,7 +8,7 @@ Copyright 2011 by Matthieu Boutier and Juliusz Chroboczek
 
 #include "vty.h"
 
-extern struct zclient *zclient;
+extern struct zclient *babel_zclient;
 
 void babelz_zebra_init(void);
 void babel_zebra_close_connexion(void);

--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -108,8 +108,8 @@ babel_config_write (struct vty *vty)
     /* list redistributed protocols */
     for (afi = AFI_IP; afi <= AFI_IP6; afi++) {
         for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
-		if (i != zclient->redist_default &&
-		    vrf_bitmap_check(&zclient->redist[afi][i], VRF_DEFAULT)) {
+		if (i != babel_zclient->redist_default &&
+		    vrf_bitmap_check(&babel_zclient->redist[afi][i], VRF_DEFAULT)) {
 			vty_out(vty, " redistribute %s %s\n",
 				(afi == AFI_IP) ? "ipv4" : "ipv6",
 				zebra_route_string(i));

--- a/babeld/kernel.c
+++ b/babeld/kernel.c
@@ -176,8 +176,7 @@ zebra_route(int add, int family, const unsigned char *pref, unsigned short plen,
     debugf(BABEL_DEBUG_ROUTE, "%s route (%s) to zebra",
            add ? "adding" : "removing",
            (family == AF_INET) ? "ipv4" : "ipv6");
-    return zclient_route_send (add ? ZEBRA_ROUTE_ADD : ZEBRA_ROUTE_DELETE,
-                               zclient, &api);
+    return zclient_route_send(add ? ZEBRA_ROUTE_ADD : ZEBRA_ROUTE_DELETE, babel_zclient, &api);
 }
 
 int

--- a/babeld/route.h
+++ b/babeld/route.h
@@ -38,7 +38,6 @@ struct babel_route {
 
 struct route_stream;
 
-extern struct babel_route **routes;
 extern int kernel_metric;
 extern enum babel_diversity diversity_kind;
 extern int diversity_factor;

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1444,11 +1444,11 @@ bgp_attr_malformed(struct bgp_attr_parser_args *args, uint8_t subcode,
 	uint8_t *notify_datap = (length > 0 ? args->startp : NULL);
 
 	if (bgp_debug_update(peer, NULL, NULL, 1)) {
-		char attr_str[BUFSIZ] = {0};
+		char str[BUFSIZ] = { 0 };
 
-		bgp_dump_attr(attr, attr_str, sizeof(attr_str));
+		bgp_dump_attr(attr, str, sizeof(str));
 
-		zlog_debug("%s: attributes: %s", __func__, attr_str);
+		zlog_debug("%s: attributes: %s", __func__, str);
 	}
 
 	/* Only relax error handling for eBGP peers */
@@ -2043,11 +2043,11 @@ static int bgp_attr_aggregator(struct bgp_attr_parser_args *args)
 			 peer->host, aspath_print(attr->aspath));
 
 		if (bgp_debug_update(peer, NULL, NULL, 1)) {
-			char attr_str[BUFSIZ] = {0};
+			char str[BUFSIZ] = { 0 };
 
-			bgp_dump_attr(attr, attr_str, sizeof(attr_str));
+			bgp_dump_attr(attr, str, sizeof(str));
 
-			zlog_debug("%s: attributes: %s", __func__, attr_str);
+			zlog_debug("%s: attributes: %s", __func__, str);
 		}
 	} else {
 		SET_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR));
@@ -2094,11 +2094,11 @@ bgp_attr_as4_aggregator(struct bgp_attr_parser_args *args,
 			 peer->host, aspath_print(attr->aspath));
 
 		if (bgp_debug_update(peer, NULL, NULL, 1)) {
-			char attr_str[BUFSIZ] = {0};
+			char str[BUFSIZ] = { 0 };
 
-			bgp_dump_attr(attr, attr_str, sizeof(attr_str));
+			bgp_dump_attr(attr, str, sizeof(str));
 
-			zlog_debug("%s: attributes: %s", __func__, attr_str);
+			zlog_debug("%s: attributes: %s", __func__, str);
 		}
 	} else {
 		SET_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_AS4_AGGREGATOR));

--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -30,7 +30,7 @@
 
 DEFINE_MTYPE_STATIC(BGPD, BFD_CONFIG, "BFD configuration data");
 
-extern struct zclient *zclient;
+extern struct zclient *bgp_zclient;
 
 static void bfd_session_status_update(struct bfd_session_params *bsp,
 				      const struct bfd_session_status *bss,
@@ -651,7 +651,7 @@ DEFUN(no_neighbor_bfd_profile, no_neighbor_bfd_profile_cmd,
 void bgp_bfd_init(struct event_loop *tm)
 {
 	/* Initialize BFD client functions */
-	bfd_protocol_integration_init(zclient, tm);
+	bfd_protocol_integration_init(bgp_zclient, tm);
 
 	/* "neighbor bfd" commands. */
 	install_element(BGP_NODE, &neighbor_bfd_cmd);

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -1441,14 +1441,14 @@ static char *_ecommunity_ecom2str(struct ecommunity *ecom, int format, int filte
 				snprintf(encbuf, sizeof(encbuf), "FS:action %s",
 					 action);
 			} else if (sub_type == ECOMMUNITY_TRAFFIC_RATE) {
-				union traffic_rate data;
+				union traffic_rate rate;
 
-				data.rate_byte[3] = *(pnt+2);
-				data.rate_byte[2] = *(pnt+3);
-				data.rate_byte[1] = *(pnt+4);
-				data.rate_byte[0] = *(pnt+5);
+				rate.rate_byte[3] = *(pnt + 2);
+				rate.rate_byte[2] = *(pnt + 3);
+				rate.rate_byte[1] = *(pnt + 4);
+				rate.rate_byte[0] = *(pnt + 5);
 				snprintf(encbuf, sizeof(encbuf), "FS:rate %f",
-					 data.rate_float);
+					 rate.rate_float);
 			} else if (sub_type == ECOMMUNITY_TRAFFIC_MARKING) {
 				snprintf(encbuf, sizeof(encbuf),
 					 "FS:marking %u", *(pnt + 5));

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -905,7 +905,7 @@ static enum zclient_send_status bgp_zebra_send_remote_macip(
 	bool esi_valid;
 
 	/* Check socket. */
-	if (!zclient || zclient->sock < 0) {
+	if (!bgp_zclient || bgp_zclient->sock < 0) {
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("%s: No zclient or zclient->sock exists",
 				   __func__);
@@ -923,7 +923,7 @@ static enum zclient_send_status bgp_zebra_send_remote_macip(
 
 	if (!esi)
 		esi = zero_esi;
-	s = zclient->obuf;
+	s = bgp_zclient->obuf;
 	stream_reset(s);
 
 	zclient_create_header(
@@ -984,7 +984,7 @@ static enum zclient_send_status bgp_zebra_send_remote_macip(
 	frrtrace(5, frr_bgp, evpn_mac_ip_zsend, add, vpn, p, remote_vtep_ip,
 		 esi);
 
-	return zclient_send_message(zclient);
+	return zclient_send_message(bgp_zclient);
 }
 
 /*
@@ -998,7 +998,7 @@ bgp_zebra_send_remote_vtep(struct bgp *bgp, struct bgpevpn *vpn,
 	struct stream *s;
 
 	/* Check socket. */
-	if (!zclient || zclient->sock < 0) {
+	if (!bgp_zclient || bgp_zclient->sock < 0) {
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("%s: No zclient or zclient->sock exists",
 				   __func__);
@@ -1014,7 +1014,7 @@ bgp_zebra_send_remote_vtep(struct bgp *bgp, struct bgpevpn *vpn,
 		return ZCLIENT_SEND_SUCCESS;
 	}
 
-	s = zclient->obuf;
+	s = bgp_zclient->obuf;
 	stream_reset(s);
 
 	zclient_create_header(
@@ -1041,7 +1041,7 @@ bgp_zebra_send_remote_vtep(struct bgp *bgp, struct bgpevpn *vpn,
 
 	frrtrace(3, frr_bgp, evpn_bum_vtep_zsend, add, vpn, p);
 
-	return zclient_send_message(zclient);
+	return zclient_send_message(bgp_zclient);
 }
 
 /*

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -1387,7 +1387,7 @@ bgp_zebra_send_remote_es_vtep(struct bgp *bgp, struct bgp_evpn_es_vtep *es_vtep,
 	uint32_t flags = 0;
 
 	/* Check socket. */
-	if (!zclient || zclient->sock < 0) {
+	if (!bgp_zclient || bgp_zclient->sock < 0) {
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("%s: No zclient or zclient->sock exists",
 				   __func__);
@@ -1405,7 +1405,7 @@ bgp_zebra_send_remote_es_vtep(struct bgp *bgp, struct bgp_evpn_es_vtep *es_vtep,
 	if (CHECK_FLAG(es_vtep->flags, BGP_EVPNES_VTEP_ESR))
 		SET_FLAG(flags, ZAPI_ES_VTEP_FLAG_ESR_RXED);
 
-	s = zclient->obuf;
+	s = bgp_zclient->obuf;
 	stream_reset(s);
 
 	zclient_create_header(s,
@@ -1427,7 +1427,7 @@ bgp_zebra_send_remote_es_vtep(struct bgp *bgp, struct bgp_evpn_es_vtep *es_vtep,
 
 	frrtrace(3, frr_bgp, evpn_mh_vtep_zsend, add, es, es_vtep);
 
-	return zclient_send_message(zclient);
+	return zclient_send_message(bgp_zclient);
 }
 
 static enum zclient_send_status bgp_evpn_es_vtep_re_eval_active(
@@ -2876,7 +2876,7 @@ static void bgp_evpn_l3nhg_zebra_add_v4_or_v6(struct bgp_evpn_es_vrf *es_vrf,
 	if (!api_nhg.nexthop_num)
 		return;
 
-	zclient_nhg_send(zclient, ZEBRA_NHG_ADD, &api_nhg);
+	zclient_nhg_send(bgp_zclient, ZEBRA_NHG_ADD, &api_nhg);
 }
 
 static bool bgp_evpn_l3nhg_zebra_ok(struct bgp_evpn_es_vrf *es_vrf)
@@ -2885,7 +2885,7 @@ static bool bgp_evpn_l3nhg_zebra_ok(struct bgp_evpn_es_vrf *es_vrf)
 		return false;
 
 	/* Check socket. */
-	if (!zclient || zclient->sock < 0)
+	if (!bgp_zclient || bgp_zclient->sock < 0)
 		return false;
 
 	return true;
@@ -2920,7 +2920,7 @@ static void bgp_evpn_l3nhg_zebra_del_v4_or_v6(struct bgp_evpn_es_vrf *es_vrf,
 	frrtrace(4, frr_bgp, evpn_mh_nhg_zsend, false, v4_nhg, api_nhg.id,
 		 es_vrf);
 
-	zclient_nhg_send(zclient, ZEBRA_NHG_DEL, &api_nhg);
+	zclient_nhg_send(bgp_zclient, ZEBRA_NHG_DEL, &api_nhg);
 }
 
 static void bgp_evpn_l3nhg_zebra_del(struct bgp_evpn_es_vrf *es_vrf)
@@ -4476,7 +4476,7 @@ static void bgp_evpn_nh_zebra_update_send(struct bgp_evpn_nh *nh, bool add)
 	struct bgp *bgp_vrf = nh->bgp_vrf;
 
 	/* Check socket. */
-	if (!zclient || zclient->sock < 0)
+	if (!bgp_zclient || bgp_zclient->sock < 0)
 		return;
 
 	/* Don't try to register if Zebra doesn't know of this instance. */
@@ -4487,7 +4487,7 @@ static void bgp_evpn_nh_zebra_update_send(struct bgp_evpn_nh *nh, bool add)
 		return;
 	}
 
-	s = zclient->obuf;
+	s = bgp_zclient->obuf;
 	stream_reset(s);
 
 	zclient_create_header(
@@ -4512,7 +4512,7 @@ static void bgp_evpn_nh_zebra_update_send(struct bgp_evpn_nh *nh, bool add)
 
 	frrtrace(2, frr_bgp, evpn_mh_nh_rmac_zsend, add, nh);
 
-	zclient_send_message(zclient);
+	zclient_send_message(bgp_zclient);
 }
 
 static void bgp_evpn_nh_zebra_update(struct bgp_evpn_nh *nh, bool add)

--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -673,8 +673,6 @@ static inline bool bgp_evpn_is_path_local(struct bgp *bgp,
 			&& pi->sub_type == BGP_ROUTE_STATIC);
 }
 
-extern struct zclient *zclient;
-
 extern void bgp_evpn_install_uninstall_default_route(struct bgp *bgp_vrf,
 						     afi_t afi, safi_t safi,
 						     bool add);

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -1462,22 +1462,22 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 				output_count++;
 
 			if (use_json && json_array) {
-				const struct prefix *p =
+				const struct prefix *pfx =
 					bgp_dest_get_prefix(rm);
 
 				json_prefix_info = json_object_new_object();
 
 				json_object_string_addf(json_prefix_info,
-							"prefix", "%pFX", p);
+							"prefix", "%pFX", pfx);
 
 				json_object_int_add(json_prefix_info,
-						    "prefixLen", p->prefixlen);
+						    "prefixLen", pfx->prefixlen);
 
 				json_object_object_add(json_prefix_info,
 					"paths", json_array);
 				json_object_object_addf(json_nroute,
 							json_prefix_info,
-							"%pFX", p);
+							"%pFX", pfx);
 				json_array = NULL;
 			}
 		}

--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -26,7 +26,7 @@
 #include "bgpd/bgp_debug.h"
 #include "bgpd/bgp_errors.h"
 
-extern struct zclient *zclient;
+extern struct zclient *bgp_zclient;
 
 
 /* MPLS Labels hash routines. */
@@ -157,7 +157,7 @@ int bgp_parse_fec_update(void)
 	afi_t afi;
 	safi_t safi;
 
-	s = zclient->ibuf;
+	s = bgp_zclient->ibuf;
 
 	memset(&p, 0, sizeof(p));
 	p.family = stream_getw(s);
@@ -249,7 +249,7 @@ static void bgp_send_fec_register_label_msg(struct bgp_dest *dest, bool reg,
 	p = bgp_dest_get_prefix(dest);
 
 	/* Check socket. */
-	if (!zclient || zclient->sock < 0)
+	if (!bgp_zclient || bgp_zclient->sock < 0)
 		return;
 
 	if (BGP_DEBUG(labelpool, LABELPOOL))
@@ -258,7 +258,7 @@ static void bgp_send_fec_register_label_msg(struct bgp_dest *dest, bool reg,
 	/* If the route node has a local_label assigned or the
 	 * path node has an MPLS SR label index allowing zebra to
 	 * derive the label, proceed with registration. */
-	s = zclient->obuf;
+	s = bgp_zclient->obuf;
 	stream_reset(s);
 	command = (reg) ? ZEBRA_FEC_REGISTER : ZEBRA_FEC_UNREGISTER;
 	zclient_create_header(s, command, VRF_DEFAULT);
@@ -288,7 +288,7 @@ static void bgp_send_fec_register_label_msg(struct bgp_dest *dest, bool reg,
 	if (reg)
 		stream_putw_at(s, flags_pos, flags);
 
-	zclient_send_message(zclient);
+	zclient_send_message(bgp_zclient);
 }
 
 /**

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -46,7 +46,7 @@ DEFINE_MTYPE_STATIC(BGPD, MPLSVPN_NH_LABEL_BIND_CACHE,
 /*
  * Definitions and external declarations.
  */
-extern struct zclient *zclient;
+extern struct zclient *bgp_zclient;
 
 extern int argv_find_and_parse_vpnvx(struct cmd_token **argv, int argc,
 				     int *index, afi_t *afi)
@@ -317,7 +317,7 @@ void vpn_leak_zebra_vrf_label_update(struct bgp *bgp, afi_t afi)
 
 	if (label == BGP_PREVENT_VRF_2_VRF_LEAK)
 		label = MPLS_LABEL_NONE;
-	zclient_send_vrf_label(zclient, bgp->vrf_id, afi, label, ZEBRA_LSP_BGP);
+	zclient_send_vrf_label(bgp_zclient, bgp->vrf_id, afi, label, ZEBRA_LSP_BGP);
 	bgp->vpn_policy[afi].tovpn_zebra_vrf_label_last_sent = label;
 }
 
@@ -344,7 +344,7 @@ void vpn_leak_zebra_vrf_label_withdraw(struct bgp *bgp, afi_t afi)
 			   bgp->name_pretty, bgp->vrf_id);
 	}
 
-	zclient_send_vrf_label(zclient, bgp->vrf_id, afi, label, ZEBRA_LSP_BGP);
+	zclient_send_vrf_label(bgp_zclient, bgp->vrf_id, afi, label, ZEBRA_LSP_BGP);
 	bgp->vpn_policy[afi].tovpn_zebra_vrf_label_last_sent = label;
 }
 
@@ -401,7 +401,7 @@ void vpn_leak_zebra_vrf_sid_update_per_af(struct bgp *bgp, afi_t afi)
 	ctx.table = vrf->data.l.table_id;
 	act = afi == AFI_IP ? ZEBRA_SEG6_LOCAL_ACTION_END_DT4
 		: ZEBRA_SEG6_LOCAL_ACTION_END_DT6;
-	zclient_send_localsid(zclient, tovpn_sid, bgp->vrf_id, act, &ctx);
+	zclient_send_localsid(bgp_zclient, tovpn_sid, bgp->vrf_id, act, &ctx);
 
 	tovpn_sid_ls = XCALLOC(MTYPE_BGP_SRV6_SID, sizeof(struct in6_addr));
 	*tovpn_sid_ls = *tovpn_sid;
@@ -457,7 +457,7 @@ void vpn_leak_zebra_vrf_sid_update_per_vrf(struct bgp *bgp)
 	}
 	ctx.table = vrf->data.l.table_id;
 	act = ZEBRA_SEG6_LOCAL_ACTION_END_DT46;
-	zclient_send_localsid(zclient, tovpn_sid, bgp->vrf_id, act, &ctx);
+	zclient_send_localsid(bgp_zclient, tovpn_sid, bgp->vrf_id, act, &ctx);
 
 	tovpn_sid_ls = XCALLOC(MTYPE_BGP_SRV6_SID, sizeof(struct in6_addr));
 	*tovpn_sid_ls = *tovpn_sid;
@@ -519,7 +519,7 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_af(struct bgp *bgp, afi_t afi)
 			bgp->vpn_policy[afi]
 				.tovpn_sid_locator->argument_bits_length;
 	}
-	zclient_send_localsid(zclient,
+	zclient_send_localsid(bgp_zclient,
 			      bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent,
 			      bgp->vrf_id, ZEBRA_SEG6_LOCAL_ACTION_UNSPEC,
 			      &seg6localctx);
@@ -564,7 +564,7 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_vrf(struct bgp *bgp)
 		seg6localctx.argument_len =
 			bgp->tovpn_sid_locator->argument_bits_length;
 	}
-	zclient_send_localsid(zclient, bgp->tovpn_zebra_vrf_sid_last_sent,
+	zclient_send_localsid(bgp_zclient, bgp->tovpn_zebra_vrf_sid_last_sent,
 			      bgp->vrf_id, ZEBRA_SEG6_LOCAL_ACTION_UNSPEC,
 			      &seg6localctx);
 	XFREE(MTYPE_BGP_SRV6_SID, bgp->tovpn_zebra_vrf_sid_last_sent);

--- a/bgpd/bgp_mplsvpn_snmp.c
+++ b/bgpd/bgp_mplsvpn_snmp.c
@@ -1460,14 +1460,14 @@ static struct bgp_path_info *bgpL3vpnRte_lookup(struct variable *v, oid name[],
 		pi = bgp_lookup_route_next(l3vpn_bgp, dest, &prefix, policy,
 					   &nexthop);
 		if (pi) {
-			uint8_t vrf_name_len =
-				strnlen((*l3vpn_bgp)->name, VRF_NAMSIZ);
 			const struct prefix *p = bgp_dest_get_prefix(*dest);
 			uint8_t oid_index;
 			bool v4 = (p->family == AF_INET);
 			uint8_t addr_len = v4 ? sizeof(struct in_addr)
 					      : sizeof(struct in6_addr);
 			struct attr *attr = pi->attr;
+
+			vrf_name_len = strnlen((*l3vpn_bgp)->name, VRF_NAMSIZ);
 
 			/* copy the index parameters */
 			oid_copy_str(&name[namelen], (*l3vpn_bgp)->name,

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -3148,8 +3148,6 @@ static void bgp_dynamic_capability_paths_limit(uint8_t *pnt, int action,
 		SET_FLAG(peer->cap, PEER_CAP_PATHS_LIMIT_RCV);
 
 		while (data + CAPABILITY_CODE_PATHS_LIMIT_LEN <= end) {
-			afi_t afi;
-			safi_t safi;
 			iana_afi_t pkt_afi;
 			iana_safi_t pkt_safi;
 			uint16_t paths_limit = 0;
@@ -3508,8 +3506,6 @@ static void bgp_dynamic_capability_llgr(uint8_t *pnt, int action,
 		SET_FLAG(peer->cap, PEER_CAP_LLGR_RCV);
 
 		while (data + BGP_CAP_LLGR_MIN_PACKET_LEN <= end) {
-			afi_t afi;
-			safi_t safi;
 			iana_afi_t pkt_afi;
 			iana_safi_t pkt_safi;
 			struct graceful_restart_af graf;
@@ -3616,8 +3612,6 @@ static void bgp_dynamic_capability_graceful_restart(uint8_t *pnt, int action,
 
 		while (data + GRACEFUL_RESTART_CAPABILITY_PER_AFI_SAFI_SIZE <=
 		       end) {
-			afi_t afi;
-			safi_t safi;
 			iana_afi_t pkt_afi;
 			iana_safi_t pkt_safi;
 			struct graceful_restart_af graf;

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -442,7 +442,7 @@ static bool bgp_pbr_extract(struct bgp_pbr_match_val list[],
 			    struct bgp_pbr_range_port *range)
 {
 	int i = 0;
-	bool exact_match = false;
+	bool match_p = false;
 
 	if (range)
 		memset(range, 0, sizeof(struct bgp_pbr_range_port));
@@ -457,9 +457,9 @@ static bool bgp_pbr_extract(struct bgp_pbr_match_val list[],
 			       OPERATOR_COMPARE_EQUAL_TO)) {
 			if (range)
 				range->min_port = list[i].value;
-			exact_match = true;
+			match_p = true;
 		}
-		if (exact_match && i > 0)
+		if (match_p && i > 0)
 			return false;
 		if (list[i].compare_operator ==
 		    (OPERATOR_COMPARE_GREATER_THAN +

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -151,8 +151,6 @@ struct bgp_pbr_config {
 	bool pbr_interface_any_ipv6;
 };
 
-extern struct bgp_pbr_config *bgp_pbr_cfg;
-
 struct bgp_pbr_rule {
 	uint32_t flags;
 	struct prefix src;

--- a/bgpd/bgp_routemap_nb_config.c
+++ b/bgpd/bgp_routemap_nb_config.c
@@ -1355,7 +1355,7 @@ lib_route_map_entry_match_condition_rmap_match_condition_comm_list_finish(
 {
 	struct routemap_hook_context *rhc;
 	const char *value;
-	bool exact_match = false;
+	bool match_p = false;
 	bool any = false;
 	char *argstr;
 	const char *condition;
@@ -1367,13 +1367,13 @@ lib_route_map_entry_match_condition_rmap_match_condition_comm_list_finish(
 	value = yang_dnode_get_string(args->dnode, "comm-list-name");
 
 	if (yang_dnode_exists(args->dnode, "comm-list-name-exact-match"))
-		exact_match = yang_dnode_get_bool(
+		match_p = yang_dnode_get_bool(
 			args->dnode, "./comm-list-name-exact-match");
 
 	if (yang_dnode_exists(args->dnode, "comm-list-name-any"))
 		any = yang_dnode_get_bool(args->dnode, "comm-list-name-any");
 
-	if (exact_match) {
+	if (match_p) {
 		argstr = XMALLOC(MTYPE_ROUTE_MAP_COMPILED,
 				 strlen(value) + strlen("exact-match") + 2);
 

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -967,10 +967,10 @@ static int update_group_show_walkcb(struct update_group *updgrp, void *arg)
 			if (ctx->uj) {
 				json_peers = json_object_new_array();
 				SUBGRP_FOREACH_PEER (subgrp, paf) {
-					json_object *peer =
+					json_object *jpeer =
 						json_object_new_string(
 							paf->peer->host);
-					json_object_array_add(json_peers, peer);
+					json_object_array_add(json_peers, jpeer);
 				}
 				json_object_object_add(json_subgrp, "peers",
 						       json_peers);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -11504,7 +11504,7 @@ DEFPY (show_bgp_vrfs,
 		json_vrfs = json_object_new_object();
 
 	for (ALL_LIST_ELEMENTS_RO(inst, node, bgp)) {
-		const char *name;
+		const char *bname;
 
 		/* Skip Views. */
 		if (bgp->inst_type == BGP_INSTANCE_TYPE_VIEW)
@@ -11523,18 +11523,18 @@ DEFPY (show_bgp_vrfs,
 			json_vrf = json_object_new_object();
 
 		if (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT) {
-			name = VRF_DEFAULT_NAME;
+			bname = VRF_DEFAULT_NAME;
 			type = "DFLT";
 		} else {
-			name = bgp->name;
+			bname = bgp->name;
 			type = "VRF";
 		}
 
-		show_bgp_vrfs_detail_common(vty, bgp, json_vrf, name, type,
+		show_bgp_vrfs_detail_common(vty, bgp, json_vrf, bname, type,
 					    false);
 
 		if (uj)
-			json_object_object_add(json_vrfs, name, json_vrf);
+			json_object_object_add(json_vrfs, bname, json_vrf);
 	}
 
 	if (uj) {

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -8,6 +8,9 @@
 
 #include "vxlan.h"
 
+/* The global zapi session handle */
+extern struct zclient *bgp_zclient;
+
 /* Macro to update bgp_original based on bpg_path_info */
 #define BGP_ORIGINAL_UPDATE(_bgp_orig, _mpinfo, _bgp)                          \
 	((_mpinfo->extra && _mpinfo->extra->vrfleak &&                        \

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -121,7 +121,7 @@ unsigned int bgp_suppress_fib_count;
 static void bgp_if_finish(struct bgp *bgp);
 static void peer_drop_dynamic_neighbor(struct peer *peer);
 
-extern struct zclient *zclient;
+extern struct zclient *bgp_zclient;
 
 /* handle main socket creation or deletion */
 static int bgp_check_main_socket(bool create, struct bgp *bgp)
@@ -447,9 +447,9 @@ void bm_wait_for_fib_set(bool set)
 			send_msg = true;
 	}
 
-	if (send_msg && zclient)
+	if (send_msg && bgp_zclient)
 		zebra_route_notify_send(ZEBRA_ROUTE_NOTIFY_REQUEST,
-					zclient, set);
+					bgp_zclient, set);
 
 	/*
 	 * If this is configed at a time when peers are already set
@@ -507,9 +507,9 @@ void bgp_suppress_fib_pending_set(struct bgp *bgp, bool set)
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("Sending ZEBRA_ROUTE_NOTIFY_REQUEST");
 
-		if (zclient)
+		if (bgp_zclient)
 			zebra_route_notify_send(ZEBRA_ROUTE_NOTIFY_REQUEST,
-					zclient, set);
+					bgp_zclient, set);
 	}
 
 	/*
@@ -3928,16 +3928,16 @@ static void bgp_zclient_set_redist(afi_t afi, int type, unsigned short instance,
 {
 	if (instance) {
 		if (set)
-			redist_add_instance(&zclient->mi_redist[afi][type],
+			redist_add_instance(&bgp_zclient->mi_redist[afi][type],
 					    instance);
 		else
-			redist_del_instance(&zclient->mi_redist[afi][type],
+			redist_del_instance(&bgp_zclient->mi_redist[afi][type],
 					    instance);
 	} else {
 		if (set)
-			vrf_bitmap_set(&zclient->redist[afi][type], vrf_id);
+			vrf_bitmap_set(&bgp_zclient->redist[afi][type], vrf_id);
 		else
-			vrf_bitmap_unset(&zclient->redist[afi][type], vrf_id);
+			vrf_bitmap_unset(&bgp_zclient->redist[afi][type], vrf_id);
 	}
 }
 
@@ -4289,8 +4289,7 @@ int bgp_delete(struct bgp *bgp)
 	FOREACH_AFI_SAFI (afi, safi) {
 		struct bgp_aggregate *aggregate = NULL;
 
-		for (struct bgp_dest *dest =
-			     bgp_table_top(bgp->aggregate[afi][safi]);
+		for (dest = bgp_table_top(bgp->aggregate[afi][safi]);
 		     dest; dest = bgp_route_next(dest)) {
 			aggregate = bgp_dest_get_bgp_aggregate_info(dest);
 			if (aggregate == NULL)

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -1352,11 +1352,11 @@ rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
 
 	bgp_attr_extcom_tunnel_type(bpi->attr, &tun_type);
 	if (tun_type == BGP_ENCAP_TYPE_MPLS) {
-		struct prefix p;
+		struct prefix pfx;
 		/* MPLS carries UN address in next hop */
-		rfapiNexthop2Prefix(bpi->attr, &p);
-		if (p.family != AF_UNSPEC) {
-			rfapiQprefix2Raddr(&p, &new->un_address);
+		rfapiNexthop2Prefix(bpi->attr, &pfx);
+		if (pfx.family != AF_UNSPEC) {
+			rfapiQprefix2Raddr(&pfx, &new->un_address);
 			have_vnc_tunnel_un = 1;
 		}
 	}
@@ -1773,7 +1773,7 @@ struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
 	 * Add non-withdrawn routes from less-specific prefix
 	 */
 	if (parent) {
-		const struct prefix *p = agg_node_get_prefix(parent);
+		p = agg_node_get_prefix(parent);
 
 		rib_rn = rfd_rib_table ? agg_node_get(rfd_rib_table, p) : NULL;
 		rfapiQprefix2Rprefix(p, &rprefix);
@@ -3224,7 +3224,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 				       __func__, rn);
 #endif
 		for (m = RFAPI_MONITOR_ENCAP(rn); m; m = m->next) {
-			const struct prefix *p;
+			const struct prefix *pfx;
 
 			/*
 			 * For each referenced bpi/route, copy the ENCAP route's
@@ -3252,9 +3252,9 @@ static void rfapiBgpInfoFilteredImportEncap(
 			 * list
 			 * per prefix.
 			 */
-			p = agg_node_get_prefix(m->node);
+			pfx = agg_node_get_prefix(m->node);
 			referenced_vpn_prefix =
-				agg_node_get(referenced_vpn_table, p);
+				agg_node_get(referenced_vpn_table, pfx);
 			assert(referenced_vpn_prefix);
 			for (mnext = referenced_vpn_prefix->info; mnext;
 			     mnext = mnext->next) {

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -338,13 +338,12 @@ static int process_unicast_route(struct bgp *bgp,		 /* in */
 	hattr = *attr;
 
 	if (rmap) {
-		struct bgp_path_info info;
+		struct bgp_path_info pinfo = {};
 		route_map_result_t ret;
 
-		memset(&info, 0, sizeof(info));
-		info.peer = peer;
-		info.attr = &hattr;
-		ret = route_map_apply(rmap, prefix, &info);
+		pinfo.peer = peer;
+		pinfo.attr = &hattr;
+		ret = route_map_apply(rmap, prefix, &pinfo);
 		if (ret == RMAP_DENYMATCH) {
 			bgp_attr_flush(&hattr);
 			vnc_zlog_debug_verbose(
@@ -768,13 +767,12 @@ static void vnc_import_bgp_add_route_mode_plain(struct bgp *bgp,
 	hattr = *attr;
 
 	if (rmap) {
-		struct bgp_path_info info;
+		struct bgp_path_info pinfo = {};
 		route_map_result_t ret;
 
-		memset(&info, 0, sizeof(info));
-		info.peer = peer;
-		info.attr = &hattr;
-		ret = route_map_apply(rmap, prefix, &info);
+		pinfo.peer = peer;
+		pinfo.attr = &hattr;
+		ret = route_map_apply(rmap, prefix, &pinfo);
 		if (ret == RMAP_DENYMATCH) {
 			bgp_attr_flush(&hattr);
 			vnc_zlog_debug_verbose(

--- a/configure.ac
+++ b/configure.ac
@@ -467,6 +467,7 @@ AC_C_FLAG([-Wbad-function-cast])
 AC_C_FLAG([-Wwrite-strings])
 AC_C_FLAG([-Wundef])
 AC_C_FLAG([-Wimplicit-fallthrough])
+AC_C_FLAG([-Wshadow])
 if test "$enable_gcc_ultra_verbose" = "yes" ; then
   AC_C_FLAG([-Wcast-qual])
   AC_C_FLAG([-Wmissing-noreturn])
@@ -474,7 +475,6 @@ if test "$enable_gcc_ultra_verbose" = "yes" ; then
   AC_C_FLAG([-Wunreachable-code])
   AC_C_FLAG([-Wpacked])
   AC_C_FLAG([-Wpadded])
-  AC_C_FLAG([-Wshadow])
 else
   AC_C_FLAG([-Wno-unused-result])
 fi

--- a/eigrpd/eigrp_northbound.c
+++ b/eigrpd/eigrp_northbound.c
@@ -739,7 +739,7 @@ static int eigrpd_instance_redistribute_create(struct nb_cb_create_args *args)
 		else
 			vrfid = VRF_DEFAULT;
 
-		if (vrf_bitmap_check(&zclient->redist[AFI_IP][proto], vrfid))
+		if (vrf_bitmap_check(&eigrp_zclient->redist[AFI_IP][proto], vrfid))
 			return NB_ERR_INCONSISTENCY;
 		break;
 	case NB_EV_PREPARE:

--- a/eigrpd/eigrp_vty.c
+++ b/eigrpd/eigrp_vty.c
@@ -280,14 +280,14 @@ DEFPY (show_ip_eigrp_neighbors,
 	struct eigrp *eigrp;
 
 	if (vrf && strncmp(vrf, "all", sizeof("all")) == 0) {
-		struct vrf *vrf;
+		struct vrf *tvrf;
 
-		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-			eigrp = eigrp_lookup(vrf->vrf_id);
+		RB_FOREACH (tvrf, vrf_name_head, &vrfs_by_name) {
+			eigrp = eigrp_lookup(tvrf->vrf_id);
 			if (!eigrp)
 				continue;
 
-			vty_out(vty, "VRF %s:\n", vrf->name);
+			vty_out(vty, "VRF %s:\n", tvrf->name);
 
 			eigrp_neighbors_helper(vty, eigrp, ifname, detail);
 		}

--- a/eigrpd/eigrpd.c
+++ b/eigrpd/eigrpd.c
@@ -52,7 +52,6 @@ static struct eigrp_master eigrp_master;
 
 struct eigrp_master *eigrp_om;
 
-extern struct zclient *zclient;
 extern struct in_addr router_id_zebra;
 
 int eigrp_master_hash_cmp(const struct eigrp *a, const struct eigrp *b)

--- a/eigrpd/eigrpd.h
+++ b/eigrpd/eigrpd.h
@@ -52,7 +52,7 @@ struct eigrp_master {
 };
 
 /* Extern variables. */
-extern struct zclient *zclient;
+extern struct zclient *eigrp_zclient;
 extern struct event_loop *master;
 extern struct eigrp_master *eigrp_om;
 extern struct zebra_privs_t eigrpd_privs;

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -653,7 +653,6 @@ void isis_adj_print_json(struct isis_adjacency *adj, struct json_object *json,
 			json_object_object_add(iface_json, "ipv6-link-local",
 					       ipv6_link_json);
 			for (unsigned int i = 0; i < adj->ll_ipv6_count; i++) {
-				char buf[INET6_ADDRSTRLEN];
 				inet_ntop(AF_INET6, &adj->ll_ipv6_addrs[i], buf,
 					  sizeof(buf));
 				json_object_string_add(ipv6_link_json, "ipv6",
@@ -666,7 +665,6 @@ void isis_adj_print_json(struct isis_adjacency *adj, struct json_object *json,
 					       ipv6_non_link_json);
 			for (unsigned int i = 0; i < adj->global_ipv6_count;
 			     i++) {
-				char buf[INET6_ADDRSTRLEN];
 				inet_ntop(AF_INET6, &adj->global_ipv6_addrs[i],
 					  buf, sizeof(buf));
 				json_object_string_add(ipv6_non_link_json,

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -211,7 +211,7 @@ static int bfd_handle_circuit_add_addr(struct isis_circuit *circuit)
 
 void isis_bfd_init(struct event_loop *tm)
 {
-	bfd_protocol_integration_init(zclient, tm);
+	bfd_protocol_integration_init(isis_zclient, tm);
 
 	hook_register(isis_adj_state_change_hook, bfd_handle_adj_state_change);
 	hook_register(isis_adj_ip_enabled_hook, bfd_handle_adj_ip_enabled);

--- a/isisd/isis_flags.c
+++ b/isisd/isis_flags.c
@@ -26,12 +26,14 @@ long int flags_get_index(struct flags *flags)
 {
 	struct listnode *node;
 	long int index;
+	const void *ptr;
 
 	if (flags->free_idcs == NULL || flags->free_idcs->count == 0) {
 		index = flags->maxindex++;
 	} else {
 		node = listhead(flags->free_idcs);
-		index = (long int)listgetdata(node);
+		ptr = listgetdata(node);
+		index = (long int)ptr;
 		listnode_delete(flags->free_idcs, (void *)index);
 		index--;
 	}

--- a/isisd/isis_ldp_sync.c
+++ b/isisd/isis_ldp_sync.c
@@ -40,9 +40,8 @@
 #include "isisd/isis_errors.h"
 #include "isisd/isis_tx_queue.h"
 #include "isisd/isis_nb.h"
+#include "isisd/isis_zebra.h"
 #include "isisd/isis_ldp_sync.h"
-
-extern struct zclient *zclient;
 
 /*
  * LDP-SYNC msg between IGP and LDP
@@ -122,8 +121,8 @@ void isis_ldp_sync_state_req_msg(struct isis_circuit *circuit)
 	request.proto = LDP_IGP_SYNC_IF_STATE_REQUEST;
 	request.ifindex = ifp->ifindex;
 
-	zclient_send_opaque(zclient, LDP_IGP_SYNC_IF_STATE_REQUEST,
-		(uint8_t *)&request, sizeof(request));
+	zclient_send_opaque(isis_zclient, LDP_IGP_SYNC_IF_STATE_REQUEST,
+			    (uint8_t *)&request, sizeof(request));
 }
 
 /*

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1125,7 +1125,6 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 		struct isis_router_cap *rcap;
 #ifndef FABRICD
 		struct isis_router_cap_fad *rcap_fad;
-		struct listnode *node;
 		struct flex_algo *fa;
 #endif /* ifndef FABRICD */
 

--- a/isisd/isis_route.c
+++ b/isisd/isis_route.c
@@ -240,7 +240,7 @@ isis_route_info_new(struct prefix *prefix, struct prefix_ipv6 *src_p,
 	for (ALL_LIST_ELEMENTS_RO(adjacencies, node, vadj)) {
 		struct isis_spf_adj *sadj = vadj->sadj;
 		struct isis_adjacency *adj = sadj->adj;
-		struct isis_sr_psid_info *sr = &vadj->sr;
+		struct isis_sr_psid_info *vsr = &vadj->sr;
 		struct mpls_label_stack *label_stack = vadj->label_stack;
 
 		/*
@@ -248,7 +248,7 @@ isis_route_info_new(struct prefix *prefix, struct prefix_ipv6 *src_p,
 		 * environment.
 		 */
 		if (CHECK_FLAG(im->options, F_ISIS_UNIT_TEST)) {
-			isis_route_add_dummy_nexthops(rinfo, sadj->id, sr,
+			isis_route_add_dummy_nexthops(rinfo, sadj->id, vsr,
 						      label_stack);
 			if (!allow_ecmp)
 				break;
@@ -260,7 +260,7 @@ isis_route_info_new(struct prefix *prefix, struct prefix_ipv6 *src_p,
 			       ISIS_CIRCUIT_FLAPPED_AFTER_SPF))
 			SET_FLAG(rinfo->flag, ISIS_ROUTE_FLAG_ZEBRA_RESYNC);
 
-		adjinfo2nexthop(prefix->family, rinfo->nexthops, adj, sr,
+		adjinfo2nexthop(prefix->family, rinfo->nexthops, adj, vsr,
 				label_stack);
 		if (!allow_ecmp)
 			break;

--- a/isisd/isis_snmp.c
+++ b/isisd/isis_snmp.c
@@ -692,15 +692,15 @@ static int isis_circuit_snmp_id_free(struct isis_circuit *circuit)
 static struct isis_circuit *isis_snmp_circuit_next(struct isis_circuit *circuit)
 {
 	uint32_t start;
-	uint32_t off;
+	uint32_t offset;
 
 	start = 1;
 
 	if (circuit != NULL)
 		start = circuit->snmp_id + 1;
 
-	for (off = start; off < SNMP_CIRCUITS_MAX; off++) {
-		circuit = snmp_circuits[off];
+	for (offset = start; offset < SNMP_CIRCUITS_MAX; offset++) {
+		circuit = snmp_circuits[offset];
 
 		if (circuit != NULL)
 			return circuit;
@@ -759,7 +759,7 @@ static int isis_snmp_get_level_match(int is_type, int level)
 static int isis_snmp_conv_exact(uint8_t *buf, size_t max_len, size_t *out_len,
 				const oid *idx, size_t idx_len)
 {
-	size_t off;
+	size_t offset;
 	size_t len;
 
 	/* Oid representation: length followed by bytes */
@@ -774,11 +774,11 @@ static int isis_snmp_conv_exact(uint8_t *buf, size_t max_len, size_t *out_len,
 	if (idx_len < len + 1)
 		return 0;
 
-	for (off = 0; off < len; off++) {
-		if (idx[off + 1] > 0xff)
+	for (offset = 0; offset < len; offset++) {
+		if (idx[offset + 1] > 0xff)
 			return 0;
 
-		buf[off] = (uint8_t)(idx[off + 1] & 0xff);
+		buf[offset] = (uint8_t)(idx[offset + 1] & 0xff);
 	}
 
 	*out_len = len;
@@ -789,7 +789,7 @@ static int isis_snmp_conv_exact(uint8_t *buf, size_t max_len, size_t *out_len,
 static int isis_snmp_conv_next(uint8_t *buf, size_t max_len, size_t *out_len,
 			       int *try_exact, const oid *idx, size_t idx_len)
 {
-	size_t off;
+	size_t offset;
 	size_t len;
 	size_t cmp_len;
 
@@ -809,15 +809,15 @@ static int isis_snmp_conv_next(uint8_t *buf, size_t max_len, size_t *out_len,
 	if ((idx_len - 1) < cmp_len)
 		cmp_len = idx_len - 1;
 
-	for (off = 0; off < cmp_len; off++) {
-		if (idx[off + 1] > 0xff) {
-			memset(buf + off, 0xff, len - off);
+	for (offset = 0; offset < cmp_len; offset++) {
+		if (idx[offset + 1] > 0xff) {
+			memset(buf + offset, 0xff, len - off);
 			*out_len = len;
 			*try_exact = 1;
 			return 1;
 		}
 
-		buf[off] = (uint8_t)(idx[off + 1] & 0xff);
+		buf[offset] = (uint8_t)(idx[offset + 1] & 0xff);
 	}
 
 	if (cmp_len < len)
@@ -983,7 +983,7 @@ static int isis_snmp_circuit_lookup_exact(oid *oid_idx, size_t oid_idx_len,
 static int isis_snmp_circuit_lookup_next(oid *oid_idx, size_t oid_idx_len,
 					 struct isis_circuit **ret_circuit)
 {
-	oid off;
+	oid offset;
 	oid start;
 	struct isis_circuit *circuit;
 
@@ -996,10 +996,10 @@ static int isis_snmp_circuit_lookup_next(oid *oid_idx, size_t oid_idx_len,
 		start = oid_idx[0];
 	}
 
-	for (off = start; off < SNMP_CIRCUITS_MAX; ++off) {
-		circuit = snmp_circuits[off];
+	for (offset = start; offset < SNMP_CIRCUITS_MAX; ++offset) {
+		circuit = snmp_circuits[offset];
 
-		if (circuit != NULL && off > start) {
+		if (circuit != NULL && offset > start) {
 			if (ret_circuit != NULL)
 				*ret_circuit = circuit;
 
@@ -1052,7 +1052,7 @@ static int isis_snmp_circuit_level_lookup_next(
 	oid *oid_idx, size_t oid_idx_len, int check_match,
 	struct isis_circuit **ret_circuit, int *ret_level)
 {
-	oid off;
+	oid offset;
 	oid start;
 	struct isis_circuit *circuit = NULL;
 	int level;
@@ -1066,13 +1066,13 @@ static int isis_snmp_circuit_level_lookup_next(
 		start = oid_idx[0];
 	}
 
-	for (off = start; off < SNMP_CIRCUITS_MAX; off++) {
-		circuit = snmp_circuits[off];
+	for (offset = start; offset < SNMP_CIRCUITS_MAX; offset++) {
+		circuit = snmp_circuits[offset];
 
 		if (circuit == NULL)
 			continue;
 
-		if (off > start || oid_idx_len < 2) {
+		if (offset > start || oid_idx_len < 2) {
 			/* Found and can use level 1 */
 			level = IS_LEVEL_1;
 			break;
@@ -1504,7 +1504,7 @@ static uint8_t *isis_snmp_find_man_area(struct variable *v, oid *name,
 	struct iso_address *area_addr = NULL;
 	oid *oid_idx;
 	size_t oid_idx_len;
-	size_t off = 0;
+	size_t offset = 0;
 
 	*write_method = NULL;
 
@@ -1539,8 +1539,8 @@ static uint8_t *isis_snmp_find_man_area(struct variable *v, oid *name,
 		/* Append index */
 		name[v->namelen] = area_addr->addr_len;
 
-		for (off = 0; off < area_addr->addr_len; off++)
-			name[v->namelen + 1 + off] = area_addr->area_addr[off];
+		for (offset = 0; offset < area_addr->addr_len; offset++)
+			name[v->namelen + 1 + offset] = area_addr->area_addr[offset];
 
 		*length = v->namelen + 1 + area_addr->addr_len;
 	}
@@ -1628,7 +1628,7 @@ static uint8_t *isis_snmp_find_router(struct variable *v, oid *name,
 	struct isis_dynhn *dyn = NULL;
 	oid *oid_idx;
 	size_t oid_idx_len;
-	size_t off = 0;
+	size_t offset = 0;
 	struct isis *isis = isis_lookup_by_vrfid(VRF_DEFAULT);
 
 	if (isis == NULL)
@@ -1729,8 +1729,8 @@ static uint8_t *isis_snmp_find_router(struct variable *v, oid *name,
 	/* Append index */
 	name[v->namelen] = ISIS_SYS_ID_LEN;
 
-	for (off = 0; off < ISIS_SYS_ID_LEN; off++)
-		name[v->namelen + 1 + off] = dyn->id[off];
+	for (offset = 0; offset < ISIS_SYS_ID_LEN; offset++)
+		name[v->namelen + 1 + off] = dyn->id[offset];
 
 	name[v->namelen + 1 + ISIS_SYS_ID_LEN] = (oid)dyn->level;
 
@@ -2803,8 +2803,8 @@ static int isis_snmp_init(struct event_loop *tm)
 	struct isis_func_to_prefix *h2f = isis_func_to_prefix_arr;
 	struct variable *v;
 
-	for (size_t off = 0; off < isis_var_count; off++) {
-		v = &isis_var_arr[off];
+	for (size_t offset = 0; offset < isis_var_count; offset++) {
+		v = &isis_var_arr[offset];
 
 		if (v->findVar != h2f->ihtp_func) {
 			/* Next table */
@@ -2858,7 +2858,7 @@ static int isis_snmp_db_overload_update(const struct isis_area *area)
 {
 	netsnmp_variable_list *notification_vars;
 	long val;
-	uint32_t off;
+	uint32_t offset;
 
 	if (!isis_snmp_trap_throttle(ISIS_TRAP_DB_OVERLOAD))
 		return 0;
@@ -2880,8 +2880,8 @@ static int isis_snmp_db_overload_update(const struct isis_area *area)
 		(uint8_t *)&val, sizeof(val));
 
 	/* Patch sys_level_state with proper index */
-	off = array_size(isis_snmp_trap_data_var_sys_level_state) - 1;
-	isis_snmp_trap_data_var_sys_level_state[off] = val;
+	offset = array_size(isis_snmp_trap_data_var_sys_level_state) - 1;
+	isis_snmp_trap_data_var_sys_level_state[offset] = val;
 
 	/* Prepare data */
 	if (area->overload_bit)

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1195,7 +1195,7 @@ end:
 	    && !spftree->area->attached_bit_rcv_ignore
 	    && (spftree->area->is_type & IS_LEVEL_1)
 	    && !isis_level2_adj_up(spftree->area)) {
-		struct prefix_pair ip_info = { {0} };
+		memset(&ip_info, 0, sizeof(ip_info));
 		if (IS_DEBUG_RTE_EVENTS)
 			zlog_debug("ISIS-Spf (%pLS): add default %s route",
 				   lsp->hdr.lsp_id,

--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -749,11 +749,11 @@ void sr_adj_sid_add_single(struct isis_adjacency *adj, int family, bool backup,
 
 		sra->backup_nexthops = list_new();
 		for (ALL_LIST_ELEMENTS_RO(nexthops, node, vadj)) {
-			struct isis_adjacency *adj = vadj->sadj->adj;
+			struct isis_adjacency *tadj = vadj->sadj->adj;
 			struct mpls_label_stack *label_stack;
 
 			label_stack = vadj->label_stack;
-			adjinfo2nexthop(family, sra->backup_nexthops, adj, NULL,
+			adjinfo2nexthop(family, sra->backup_nexthops, tadj, NULL,
 					label_stack);
 		}
 	}

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -704,15 +704,15 @@ static int isis_te_export(uint8_t type, void *link_state)
 	switch (type) {
 	case LS_MSG_TYPE_NODE:
 		ls_vertex2msg(&msg, (struct ls_vertex *)link_state);
-		rc = ls_send_msg(zclient, &msg, NULL);
+		rc = ls_send_msg(isis_zclient, &msg, NULL);
 		break;
 	case LS_MSG_TYPE_ATTRIBUTES:
 		ls_edge2msg(&msg, (struct ls_edge *)link_state);
-		rc = ls_send_msg(zclient, &msg, NULL);
+		rc = ls_send_msg(isis_zclient, &msg, NULL);
 		break;
 	case LS_MSG_TYPE_PREFIX:
 		ls_subnet2msg(&msg, (struct ls_subnet *)link_state);
-		rc = ls_send_msg(zclient, &msg, NULL);
+		rc = ls_send_msg(isis_zclient, &msg, NULL);
 		break;
 	default:
 		rc = -1;
@@ -1494,7 +1494,7 @@ static void isis_te_parse_lsp(struct mpls_te_area *mta, struct isis_lsp *lsp)
 
 	/* Clean remaining Orphan Edges or Subnets */
 	if (IS_EXPORT_TE(mta))
-		ls_vertex_clean(ted, vertex, zclient);
+		ls_vertex_clean(ted, vertex, isis_zclient);
 	else
 		ls_vertex_clean(ted, vertex, NULL);
 }
@@ -1653,7 +1653,7 @@ int isis_te_sync_ted(struct zapi_opaque_reg_info dst)
 			if (IS_MPLS_TE(mta) && IS_EXPORT_TE(mta)) {
 				te_debug("  |- Export TED from area %s",
 					 area->area_tag);
-				rc = ls_sync_ted(mta->ted, zclient, &dst);
+				rc = ls_sync_ted(mta->ted, isis_zclient, &dst);
 				if (rc != 0)
 					return rc;
 			}

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -518,7 +518,7 @@ static void format_item_asla_subtlvs(struct isis_asla_subtlvs *asla,
 			  asla->max_rsv_bw);
 	if (IS_SUBTLV(asla, EXT_UNRSV_BW)) {
 		sbuf_push(buf, indent + 2, "Unreserved Bandwidth:\n");
-		for (int j = 0; j < MAX_CLASS_TYPE; j += 2) {
+		for (j = 0; j < MAX_CLASS_TYPE; j += 2) {
 			sbuf_push(
 				buf, indent + 2,
 				"[%d]: %g (Bytes/sec),\t[%d]: %g (Bytes/sec)\n",
@@ -3209,7 +3209,7 @@ static struct isis_item *copy_item_lsp_entry(struct isis_item *i)
 }
 
 static void format_item_lsp_entry(uint16_t mtid, struct isis_item *i,
-				  struct sbuf *buf, struct json_object *json,
+				  struct sbuf *sbuf, struct json_object *json,
 				  int indent)
 {
 	struct isis_lsp_entry *e = (struct isis_lsp_entry *)i;
@@ -3229,10 +3229,9 @@ static void format_item_lsp_entry(uint16_t mtid, struct isis_item *i,
 		json_object_string_add(lsp_json, "chksum", buf);
 		json_object_int_add(lsp_json, "lifetime", e->checksum);
 	} else
-		sbuf_push(
-			buf, indent,
-			"LSP Entry: %s, seq 0x%08x, cksum 0x%04hx, lifetime %hus\n",
-			sys_id, e->seqno, e->checksum, e->rem_lifetime);
+		sbuf_push(sbuf, indent,
+			  "LSP Entry: %s, seq 0x%08x, cksum 0x%04hx, lifetime %hus\n",
+			  sys_id, e->seqno, e->checksum, e->rem_lifetime);
 }
 
 static void free_item_lsp_entry(struct isis_item *i)
@@ -3553,7 +3552,7 @@ static void copy_tlv_protocols_supported(struct isis_protocols_supported *src,
 }
 
 static void format_tlv_protocols_supported(struct isis_protocols_supported *p,
-					   struct sbuf *buf,
+					   struct sbuf *sbuf,
 					   struct json_object *json, int indent)
 {
 	if (!p || !p->count || !p->protocols)
@@ -3572,12 +3571,12 @@ static void format_tlv_protocols_supported(struct isis_protocols_supported *p,
 					       nlpid2str(p->protocols[i]));
 		}
 	} else {
-		sbuf_push(buf, indent, "Protocols Supported: ");
+		sbuf_push(sbuf, indent, "Protocols Supported: ");
 		for (uint8_t i = 0; i < p->count; i++) {
-			sbuf_push(buf, 0, "%s%s", nlpid2str(p->protocols[i]),
+			sbuf_push(sbuf, 0, "%s%s", nlpid2str(p->protocols[i]),
 				  (i + 1 < p->count) ? ", " : "");
 		}
-		sbuf_push(buf, 0, "\n");
+		sbuf_push(sbuf, 0, "\n");
 	}
 }
 
@@ -5275,9 +5274,9 @@ static int pack_tlv_router_cap(const struct isis_router_cap *router_cap,
 	/* Flex Algo Definitions */
 	for (int i = 0; i < SR_ALGORITHM_COUNT; i++) {
 		struct isis_router_cap_fad *fad;
-		size_t subtlv_len;
 		struct admin_group *ag;
 		uint32_t admin_group_length;
+		size_t j;
 
 		fad = router_cap->fads[i];
 		if (!fad)
@@ -5315,8 +5314,8 @@ static int pack_tlv_router_cap(const struct isis_router_cap *router_cap,
 		if (admin_group_length) {
 			stream_putc(s, ISIS_SUBTLV_FAD_SUBSUBTLV_EXCAG);
 			stream_putc(s, sizeof(uint32_t) * admin_group_length);
-			for (size_t i = 0; i < admin_group_length; i++)
-				stream_putl(s, admin_group_get_offset(ag, i));
+			for (j = 0; j < admin_group_length; j++)
+				stream_putl(s, admin_group_get_offset(ag, j));
 		}
 
 		ag = &fad->fad.admin_group_include_any;
@@ -5324,8 +5323,8 @@ static int pack_tlv_router_cap(const struct isis_router_cap *router_cap,
 		if (admin_group_length) {
 			stream_putc(s, ISIS_SUBTLV_FAD_SUBSUBTLV_INCANYAG);
 			stream_putc(s, sizeof(uint32_t) * admin_group_length);
-			for (size_t i = 0; i < admin_group_length; i++)
-				stream_putl(s, admin_group_get_offset(ag, i));
+			for (j = 0; j < admin_group_length; j++)
+				stream_putl(s, admin_group_get_offset(ag, j));
 		}
 
 		ag = &fad->fad.admin_group_include_all;
@@ -5333,8 +5332,8 @@ static int pack_tlv_router_cap(const struct isis_router_cap *router_cap,
 		if (admin_group_length) {
 			stream_putc(s, ISIS_SUBTLV_FAD_SUBSUBTLV_INCALLAG);
 			stream_putc(s, sizeof(uint32_t) * admin_group_length);
-			for (size_t i = 0; i < admin_group_length; i++)
-				stream_putl(s, admin_group_get_offset(ag, i));
+			for (j = 0; j < admin_group_length; j++)
+				stream_putl(s, admin_group_get_offset(ag, j));
 		}
 
 		if (fad->fad.flags != 0) {

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -45,7 +45,7 @@
 #include "isisd/isis_sr.h"
 #include "isisd/isis_ldp_sync.h"
 
-struct zclient *zclient;
+struct zclient *isis_zclient;
 static struct zclient *zclient_sync;
 
 /* Router-id update message from zebra. */
@@ -254,7 +254,7 @@ void isis_zebra_route_add_route(struct isis *isis, struct prefix *prefix,
 	struct zapi_route api;
 	int count = 0;
 
-	if (zclient->sock < 0)
+	if (isis_zclient->sock < 0)
 		return;
 
 	/* Uninstall the route if it doesn't have any valid nexthop. */
@@ -295,7 +295,7 @@ void isis_zebra_route_add_route(struct isis *isis, struct prefix *prefix,
 		return;
 	api.nexthop_num = count;
 
-	zclient_route_send(ZEBRA_ROUTE_ADD, zclient, &api);
+	zclient_route_send(ZEBRA_ROUTE_ADD, isis_zclient, &api);
 }
 
 void isis_zebra_route_del_route(struct isis *isis,
@@ -305,7 +305,7 @@ void isis_zebra_route_del_route(struct isis *isis,
 {
 	struct zapi_route api;
 
-	if (zclient->sock < 0)
+	if (isis_zclient->sock < 0)
 		return;
 
 	if (!CHECK_FLAG(route_info->flag, ISIS_ROUTE_FLAG_ZEBRA_SYNCED))
@@ -321,7 +321,7 @@ void isis_zebra_route_del_route(struct isis *isis,
 		SET_FLAG(api.message, ZAPI_MESSAGE_SRCPFX);
 	}
 
-	zclient_route_send(ZEBRA_ROUTE_DELETE, zclient, &api);
+	zclient_route_send(ZEBRA_ROUTE_DELETE, isis_zclient, &api);
 }
 
 /**
@@ -388,7 +388,7 @@ void isis_zebra_prefix_sid_install(struct isis_area *area,
 	}
 
 	/* Send message to zebra. */
-	(void)zebra_send_mpls_labels(zclient, ZEBRA_MPLS_LABELS_REPLACE, &zl);
+	(void)zebra_send_mpls_labels(isis_zclient, ZEBRA_MPLS_LABELS_REPLACE, &zl);
 }
 
 /**
@@ -415,7 +415,7 @@ void isis_zebra_prefix_sid_uninstall(struct isis_area *area,
 	zl.local_label = psid->label;
 
 	/* Send message to zebra. */
-	(void)zebra_send_mpls_labels(zclient, ZEBRA_MPLS_LABELS_DELETE, &zl);
+	(void)zebra_send_mpls_labels(isis_zclient, ZEBRA_MPLS_LABELS_DELETE, &zl);
 }
 
 /**
@@ -471,7 +471,7 @@ void isis_zebra_send_adjacency_sid(int cmd, const struct sr_adjacency *sra)
 		}
 	}
 
-	(void)zebra_send_mpls_labels(zclient, cmd, &zl);
+	(void)zebra_send_mpls_labels(isis_zclient, cmd, &zl);
 }
 
 static int isis_zebra_read(ZAPI_CALLBACK_ARGS)
@@ -523,9 +523,9 @@ void isis_zebra_redistribute_set(afi_t afi, int type, vrf_id_t vrf_id,
 {
 	if (type == DEFAULT_ROUTE)
 		zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_ADD,
-					     zclient, afi, vrf_id);
+					     isis_zclient, afi, vrf_id);
 	else
-		zclient_redistribute(ZEBRA_REDISTRIBUTE_ADD, zclient, afi, type,
+		zclient_redistribute(ZEBRA_REDISTRIBUTE_ADD, isis_zclient, afi, type,
 				     tableid, vrf_id);
 }
 
@@ -534,9 +534,9 @@ void isis_zebra_redistribute_unset(afi_t afi, int type, vrf_id_t vrf_id,
 {
 	if (type == DEFAULT_ROUTE)
 		zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_DELETE,
-					     zclient, afi, vrf_id);
+					     isis_zclient, afi, vrf_id);
 	else
-		zclient_redistribute(ZEBRA_REDISTRIBUTE_DELETE, zclient, afi,
+		zclient_redistribute(ZEBRA_REDISTRIBUTE_DELETE, isis_zclient, afi,
 				     type, tableid, vrf_id);
 }
 
@@ -549,7 +549,7 @@ int isis_zebra_rlfa_register(struct isis_spftree *spftree, struct rlfa *rlfa)
 	struct zapi_rlfa_request zr = {};
 	int ret;
 
-	if (!zclient)
+	if (!isis_zclient)
 		return 0;
 
 	zr.igp.vrf_id = area->isis->vrf_id;
@@ -565,7 +565,7 @@ int isis_zebra_rlfa_register(struct isis_spftree *spftree, struct rlfa *rlfa)
 	zlog_debug("ISIS-LFA: registering RLFA %pFX@%pI4 with LDP",
 		   &rlfa->prefix, &rlfa->pq_address);
 
-	ret = zclient_send_opaque_unicast(zclient, LDP_RLFA_REGISTER,
+	ret = zclient_send_opaque_unicast(isis_zclient, LDP_RLFA_REGISTER,
 					  ZEBRA_ROUTE_LDP, 0, 0,
 					  (const uint8_t *)&zr, sizeof(zr));
 	if (ret == ZCLIENT_SEND_FAILURE) {
@@ -585,8 +585,8 @@ void isis_zebra_rlfa_unregister_all(struct isis_spftree *spftree)
 	struct zapi_rlfa_igp igp = {};
 	int ret;
 
-	if (!zclient || spftree->type != SPF_TYPE_FORWARD
-	    || CHECK_FLAG(spftree->flags, F_SPFTREE_NO_ADJACENCIES))
+	if (!isis_zclient || spftree->type != SPF_TYPE_FORWARD ||
+	    CHECK_FLAG(spftree->flags, F_SPFTREE_NO_ADJACENCIES))
 		return;
 
 	if (IS_DEBUG_LFA)
@@ -599,7 +599,7 @@ void isis_zebra_rlfa_unregister_all(struct isis_spftree *spftree)
 	igp.isis.spf.level = spftree->level;
 	igp.isis.spf.run_id = spftree->runcount;
 
-	ret = zclient_send_opaque_unicast(zclient, LDP_RLFA_UNREGISTER_ALL,
+	ret = zclient_send_opaque_unicast(isis_zclient, LDP_RLFA_UNREGISTER_ALL,
 					  ZEBRA_ROUTE_LDP, 0, 0,
 					  (const uint8_t *)&igp, sizeof(igp));
 	if (ret == ZCLIENT_SEND_FAILURE)
@@ -774,27 +774,27 @@ int isis_zebra_label_manager_connect(void)
 
 void isis_zebra_vrf_register(struct isis *isis)
 {
-	if (!zclient || zclient->sock < 0 || !isis)
+	if (!isis_zclient || isis_zclient->sock < 0 || !isis)
 		return;
 
 	if (isis->vrf_id != VRF_UNKNOWN) {
 		if (IS_DEBUG_EVENTS)
 			zlog_debug("%s: Register VRF %s id %u", __func__,
 				   isis->name, isis->vrf_id);
-		zclient_send_reg_requests(zclient, isis->vrf_id);
+		zclient_send_reg_requests(isis_zclient, isis->vrf_id);
 	}
 }
 
 void isis_zebra_vrf_deregister(struct isis *isis)
 {
-	if (!zclient || zclient->sock < 0 || !isis)
+	if (!isis_zclient || isis_zclient->sock < 0 || !isis)
 		return;
 
 	if (isis->vrf_id != VRF_UNKNOWN) {
 		if (IS_DEBUG_EVENTS)
 			zlog_debug("%s: Deregister VRF %s id %u", __func__,
 				   isis->name, isis->vrf_id);
-		zclient_send_dereg_requests(zclient, isis->vrf_id);
+		zclient_send_dereg_requests(isis_zclient, isis->vrf_id);
 	}
 }
 
@@ -820,9 +820,9 @@ int isis_zebra_ls_register(bool up)
 	int rc;
 
 	if (up)
-		rc = ls_register(zclient, true);
+		rc = ls_register(isis_zclient, true);
 	else
-		rc = ls_unregister(zclient, true);
+		rc = ls_unregister(isis_zclient, true);
 
 	return rc;
 }
@@ -934,7 +934,7 @@ static void isis_zebra_send_localsid(int cmd, const struct in6_addr *sid,
 	memcpy(&api.prefix, &p, sizeof(p));
 
 	if (cmd == ZEBRA_ROUTE_DELETE)
-		return (void)zclient_route_send(ZEBRA_ROUTE_DELETE, zclient,
+		return (void)zclient_route_send(ZEBRA_ROUTE_DELETE, isis_zclient,
 						&api);
 
 	SET_FLAG(api.flags, ZEBRA_FLAG_ALLOW_RECURSION);
@@ -952,7 +952,7 @@ static void isis_zebra_send_localsid(int cmd, const struct in6_addr *sid,
 
 	api.nexthop_num = 1;
 
-	zclient_route_send(ZEBRA_ROUTE_ADD, zclient, &api);
+	zclient_route_send(ZEBRA_ROUTE_ADD, isis_zclient, &api);
 }
 
 /**
@@ -1372,7 +1372,7 @@ static int isis_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
  */
 int isis_zebra_srv6_manager_get_locator_chunk(const char *name)
 {
-	return srv6_manager_get_locator_chunk(zclient, name);
+	return srv6_manager_get_locator_chunk(isis_zclient, name);
 }
 
 
@@ -1385,7 +1385,7 @@ int isis_zebra_srv6_manager_get_locator_chunk(const char *name)
  */
 int isis_zebra_srv6_manager_release_locator_chunk(const char *name)
 {
-	return srv6_manager_release_locator_chunk(zclient, name);
+	return srv6_manager_release_locator_chunk(isis_zclient, name);
 }
 
 /**
@@ -1403,7 +1403,7 @@ int isis_zebra_srv6_manager_get_locator(const char *name)
 	 * Send the Get Locator request to the SRv6 Manager and return the
 	 * result
 	 */
-	return srv6_manager_get_locator(zclient, name);
+	return srv6_manager_get_locator(isis_zclient, name);
 }
 
 /**
@@ -1434,7 +1434,7 @@ bool isis_zebra_request_srv6_sid(const struct srv6_sid_ctx *ctx,
 	 * Send the Get SRv6 SID request to the SRv6 Manager and check the
 	 * result
 	 */
-	ret = srv6_manager_get_sid(zclient, ctx, sid_value, locator_name, NULL);
+	ret = srv6_manager_get_sid(isis_zclient, ctx, sid_value, locator_name, NULL);
 	if (ret < 0) {
 		zlog_warn("%s: error getting SRv6 SID!", __func__);
 		return false;
@@ -1462,7 +1462,7 @@ void isis_zebra_release_srv6_sid(const struct srv6_sid_ctx *ctx)
 	 * Send the Release SRv6 SID request to the SRv6 Manager and check the
 	 * result
 	 */
-	ret = srv6_manager_release_sid(zclient, ctx);
+	ret = srv6_manager_release_sid(isis_zclient, ctx);
 	if (ret < 0) {
 		zlog_warn("%s: error releasing SRv6 SID!", __func__);
 		return;
@@ -1631,16 +1631,16 @@ static zclient_handler *const isis_handlers[] = {
 	[ZEBRA_SRV6_SID_NOTIFY] = isis_zebra_srv6_sid_notify,
 };
 
-void isis_zebra_init(struct event_loop *master, int instance)
+void isis_zebra_init(struct event_loop *mst, int instance)
 {
 	/* Initialize asynchronous zclient. */
-	zclient = zclient_new(master, &zclient_options_default, isis_handlers,
+	isis_zclient = zclient_new(mst, &zclient_options_default, isis_handlers,
 			      array_size(isis_handlers));
-	zclient_init(zclient, PROTO_TYPE, 0, &isisd_privs);
-	zclient->zebra_connected = isis_zebra_connected;
+	zclient_init(isis_zclient, PROTO_TYPE, 0, &isisd_privs);
+	isis_zclient->zebra_connected = isis_zebra_connected;
 
 	/* Initialize special zclient for synchronous message exchanges. */
-	zclient_sync = zclient_new(master, &zclient_options_sync, NULL, 0);
+	zclient_sync = zclient_new(mst, &zclient_options_sync, NULL, 0);
 	zclient_sync->sock = -1;
 	zclient_sync->redist_default = ZEBRA_ROUTE_ISIS;
 	zclient_sync->instance = instance;
@@ -1654,11 +1654,11 @@ void isis_zebra_init(struct event_loop *master, int instance)
 
 void isis_zebra_stop(void)
 {
-	zclient_unregister_opaque(zclient, LDP_RLFA_LABELS);
-	zclient_unregister_opaque(zclient, LDP_IGP_SYNC_IF_STATE_UPDATE);
-	zclient_unregister_opaque(zclient, LDP_IGP_SYNC_ANNOUNCE_UPDATE);
+	zclient_unregister_opaque(isis_zclient, LDP_RLFA_LABELS);
+	zclient_unregister_opaque(isis_zclient, LDP_IGP_SYNC_IF_STATE_UPDATE);
+	zclient_unregister_opaque(isis_zclient, LDP_IGP_SYNC_ANNOUNCE_UPDATE);
 	zclient_stop(zclient_sync);
 	zclient_free(zclient_sync);
-	zclient_stop(zclient);
-	zclient_free(zclient);
+	zclient_stop(isis_zclient);
+	zclient_free(isis_zclient);
 }

--- a/isisd/isis_zebra.h
+++ b/isisd/isis_zebra.h
@@ -11,7 +11,7 @@
 
 #include "isisd.h"
 
-extern struct zclient *zclient;
+extern struct zclient *isis_zclient;
 
 struct label_chunk {
 	uint32_t start;

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -187,12 +187,12 @@ struct isis *isis_lookup_by_sysid(const uint8_t *sysid)
 	return NULL;
 }
 
-void isis_master_init(struct event_loop *master)
+void isis_master_init(struct event_loop *mst)
 {
 	memset(&isis_master, 0, sizeof(isis_master));
 	im = &isis_master;
 	im->isis = list_new();
-	im->master = master;
+	im->master = mst;
 }
 
 void isis_master_terminate(void)
@@ -694,24 +694,24 @@ static void isis_set_redist_vrf_bitmaps(struct isis *isis, bool set)
 						if (type == DEFAULT_ROUTE) {
 							if (set)
 								vrf_bitmap_set(
-									&zclient->default_information
+									&isis_zclient->default_information
 										 [afi],
 									isis->vrf_id);
 							else
 								vrf_bitmap_unset(
-									&zclient->default_information
+									&isis_zclient->default_information
 										 [afi],
 									isis->vrf_id);
 						} else {
 							if (set)
 								vrf_bitmap_set(
-									&zclient->redist
+									&isis_zclient->redist
 										 [afi]
 										 [type],
 									isis->vrf_id);
 							else
 								vrf_bitmap_unset(
-									&zclient->redist
+									&isis_zclient->redist
 										 [afi]
 										 [type],
 									isis->vrf_id);

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -538,8 +538,8 @@ static void lde_dispatch_parent(struct event *thread)
 			    sizeof(struct ldpd_init))
 				fatalx("INIT imsg with wrong len");
 
-			memcpy(&init, imsg.data, sizeof(init));
-			lde_init(&init);
+			memcpy(&ldp_init, imsg.data, sizeof(ldp_init));
+			lde_init(&ldp_init);
 			break;
 		case IMSG_AGENTX_ENABLED:
 			ldp_agentx_enabled();

--- a/ldpd/ldp_snmp.c
+++ b/ldpd/ldp_snmp.c
@@ -620,10 +620,10 @@ static uint8_t *ldpHelloAdjacencyTable(struct variable *v, oid name[], size_t *l
 		memcpy(name, v->name, v->namelen * sizeof(oid));
 
 		/* Append index */
-		struct in_addr entityLdpId = {.s_addr = 0};
+		entityLdpId.s_addr = 0;
 		entityLdpId.s_addr = ldp_rtr_id_get(leconf);
 
-		struct in_addr peerLdpId = ctl_adj->id;
+		peerLdpId = ctl_adj->id;
 
 		oid_copy_in_addr(name + v->namelen, &entityLdpId);
 		name[v->namelen + 4] = 0;

--- a/ldpd/ldp_vty_exec.c
+++ b/ldpd/ldp_vty_exec.c
@@ -1954,10 +1954,9 @@ ldp_vty_show_interface(struct vty *vty, const char *af_str, const char *json)
 	return (ldp_vty_dispatch(vty, &ibuf, SHOW_IFACE, &params));
 }
 
-int
-ldp_vty_show_capabilities(struct vty *vty, const char *json)
+int ldp_vty_show_capabilities(struct vty *vty, const char *use_json)
 {
-	if (json) {
+	if (use_json) {
 		json_object	*json;
 		json_object	*json_array;
 		json_object	*json_cap;

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -74,7 +74,7 @@ DEFINE_QOBJ_TYPE(ldpd_conf);
 const char		*log_procname;
 
 struct ldpd_global	 global;
-struct ldpd_init	 init;
+struct ldpd_init ldp_init;
 struct ldpd_conf	*ldpd_conf, *vty_conf;
 
 static struct imsgev	*iev_ldpe, *iev_ldpe_sync;
@@ -272,8 +272,8 @@ main(int argc, char *argv[])
 				 "%s/" LDPD_SOCK_NAME, optarg);
 			break;
 		case 'n':
-			init.instance = atoi(optarg);
-			if (init.instance < 1)
+			ldp_init.instance = atoi(optarg);
+			if (ldp_init.instance < 1)
 				exit(0);
 			break;
 		case 'L':
@@ -291,11 +291,11 @@ main(int argc, char *argv[])
 		snprintf(ctl_sock_path, sizeof(ctl_sock_path),
 			 "%s/" LDPD_SOCK_NAME, frr_runstatedir);
 
-	strlcpy(init.user, ldpd_privs.user, sizeof(init.user));
-	strlcpy(init.group, ldpd_privs.group, sizeof(init.group));
-	strlcpy(init.ctl_sock_path, ctl_sock_path, sizeof(init.ctl_sock_path));
-	strlcpy(init.zclient_serv_path, frr_zclientpath,
-	    sizeof(init.zclient_serv_path));
+	strlcpy(ldp_init.user, ldpd_privs.user, sizeof(ldp_init.user));
+	strlcpy(ldp_init.group, ldpd_privs.group, sizeof(ldp_init.group));
+	strlcpy(ldp_init.ctl_sock_path, ctl_sock_path, sizeof(ldp_init.ctl_sock_path));
+	strlcpy(ldp_init.zclient_serv_path, frr_zclientpath,
+		sizeof(ldp_init.zclient_serv_path));
 
 	argc -= optind;
 	if (argc > 0 || (lflag && eflag))
@@ -428,7 +428,7 @@ main(int argc, char *argv[])
 		fatal("could not establish imsg links");
 
 	main_imsg_compose_both(IMSG_DEBUG_UPDATE, &ldp_debug, sizeof(ldp_debug));
-	main_imsg_compose_both(IMSG_INIT, &init, sizeof(init));
+	main_imsg_compose_both(IMSG_INIT, &ldp_init, sizeof(ldp_init));
 	main_imsg_send_config(ldpd_conf);
 
 	if (CHECK_FLAG(ldpd_conf->ipv4.flags, F_LDPD_AF_ENABLED))

--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -739,7 +739,7 @@ struct ctl_ldp_sync {
 
 extern struct ldpd_conf		*ldpd_conf, *vty_conf;
 extern struct ldpd_global	 global;
-extern struct ldpd_init		 init;
+extern struct ldpd_init ldp_init;
 
 /* parse.y */
 struct ldpd_conf	*parse_config(char *);

--- a/ldpd/ldpe.c
+++ b/ldpd/ldpe.c
@@ -373,8 +373,8 @@ static void ldpe_dispatch_main(struct event *thread)
 			if (imsg.hdr.len != IMSG_HEADER_SIZE + sizeof(struct ldpd_init))
 				fatalx("INIT imsg with wrong len");
 
-			memcpy(&init, imsg.data, sizeof(init));
-			ldpe_init(&init);
+			memcpy(&ldp_init, imsg.data, sizeof(ldp_init));
+			ldpe_init(&ldp_init);
 			break;
 		case IMSG_AGENTX_ENABLED:
 			ldp_agentx_enabled();

--- a/lib/darr.h
+++ b/lib/darr.h
@@ -511,11 +511,11 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  */
 #define darr_pop(A)                                                            \
 	({                                                                     \
-		uint __len = _darr_len(A);                                     \
-		assert(__len);                                                 \
-		darr_remove(A, __len - 1);                                     \
+		uint __poplen = _darr_len(A);                                  \
+		assert(__poplen);                                              \
+		darr_remove(A, __poplen - 1);                                  \
 		/* count on fact that we don't resize */                       \
-		(A)[__len - 1];                                                \
+		(A)[__poplen - 1];                                             \
 	})
 
 /**

--- a/lib/elf_py.c
+++ b/lib/elf_py.c
@@ -518,12 +518,12 @@ static void elfsect_add_relocations(struct elfsect *w, Elf_Scn *rel,
 		relw->es = w;
 
 		if (relhdr->sh_type == SHT_REL) {
-			GElf_Rel _rel, *rel;
+			GElf_Rel _rel, *erel;
 
-			rel = gelf_getrel(reldata, i, &_rel);
+			erel = gelf_getrel(reldata, i, &_rel);
 			relw->rela = &relw->_rela;
-			relw->rela->r_offset = rel->r_offset;
-			relw->rela->r_info = rel->r_info;
+			relw->rela->r_offset = erel->r_offset;
+			relw->rela->r_info = erel->r_info;
 			relw->rela->r_addend = 0;
 			relw->relative = true;
 		} else
@@ -581,14 +581,14 @@ static PyObject *elfsect_wrap(struct elffile *ef, Elf_Scn *scn, size_t idx,
 	elfrelocs_init(&w->relocs);
 
 	for (i = 0; i < ef->ehdr->e_shnum; i++) {
-		Elf_Scn *scn = elf_getscn(ef->elf, i);
-		GElf_Shdr _shdr, *shdr = gelf_getshdr(scn, &_shdr);
+		Elf_Scn *escn = elf_getscn(ef->elf, i);
+		GElf_Shdr _shdr, *shdr = gelf_getshdr(escn, &_shdr);
 
 		if (shdr->sh_type != SHT_RELA && shdr->sh_type != SHT_REL)
 			continue;
 		if (shdr->sh_info && shdr->sh_info != idx)
 			continue;
-		elfsect_add_relocations(w, scn, shdr);
+		elfsect_add_relocations(w, escn, shdr);
 	}
 
 	return (PyObject *)w;

--- a/lib/frr_pthread.h
+++ b/lib/frr_pthread.h
@@ -233,10 +233,12 @@ int frr_pthread_non_controlled_startup(pthread_t thread, const char *name,
 		unused, cleanup(_frr_mtx_unlock))) = _frr_mtx_lock(mutex),     \
 	/* end */
 
-#define frr_with_mutex(...)                                                    \
-	for (pthread_mutex_t MACRO_REPEAT(_frr_with_mutex, ##__VA_ARGS__)      \
-	     *_once = NULL; _once == NULL; _once = (void *)1)                  \
+#define _frr_with_mutex_once(_once, ...)                                                           \
+	for (pthread_mutex_t MACRO_REPEAT(_frr_with_mutex, ##__VA_ARGS__)*_once = NULL;           \
+	     _once == NULL; _once = (void *)1)                                                     \
 	/* end */
+
+#define frr_with_mutex(...) _frr_with_mutex_once(NAMECTR(_once_), __VA_ARGS__)
 
 /* variant 2:
  * (more suitable for long blocks, no extra indentation)

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -1192,9 +1192,10 @@ void frr_detach(void)
 	frr_check_detach();
 }
 
-void frr_run(struct event_loop *master)
+void frr_run(struct event_loop *loop)
 {
 	char instanceinfo[64] = "";
+	struct event thread;
 
 	if (!(di->flags & FRR_MANUAL_VTY_START))
 		frr_vty_serv_start(false);
@@ -1212,7 +1213,7 @@ void frr_run(struct event_loop *master)
 		vty_stdio(frr_terminal_close);
 		if (daemon_ctl_sock != -1) {
 			set_nonblocking(daemon_ctl_sock);
-			event_add_read(master, frr_daemon_ctl, NULL,
+			event_add_read(loop, frr_daemon_ctl, NULL,
 				       daemon_ctl_sock, &daemon_ctl_thread);
 		}
 	} else if (di->daemon_mode) {
@@ -1242,8 +1243,7 @@ void frr_run(struct event_loop *master)
 	/* end fixed stderr startup logging */
 	zlog_startup_end();
 
-	struct event thread;
-	while (event_fetch(master, &thread))
+	while (event_fetch(loop, &thread))
 		event_call(&thread);
 }
 

--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -2555,9 +2555,9 @@ static void ls_show_edge_json(struct ls_edge *edge, struct json_object *json)
 	if (CHECK_FLAG(attr->flags, LS_ATTR_UNRSV_BW)) {
 		jbw = json_object_new_array();
 		json_object_object_add(jte, "unreserved-bandwidth", jbw);
-		for (int i = 0; i < MAX_CLASS_TYPE; i++) {
+		for (i = 0; i < MAX_CLASS_TYPE; i++) {
 			jobj = json_object_new_object();
-			snprintfrr(buf, 13, "class-type-%u", i);
+			snprintfrr(buf, 13, "class-type-%u", (unsigned int)i);
 			json_object_double_add(jobj, buf,
 					       attr->standard.unrsv_bw[i]);
 			json_object_array_add(jbw, jobj);
@@ -2599,7 +2599,7 @@ static void ls_show_edge_json(struct ls_edge *edge, struct json_object *json)
 	if (CHECK_FLAG(attr->flags, LS_ATTR_SRLG)) {
 		jsrlg = json_object_new_array();
 		json_object_object_add(jte, "srlgs", jsrlg);
-		for (int i = 1; i < attr->srlg_len; i++) {
+		for (i = 1; i < attr->srlg_len; i++) {
 			jobj = json_object_new_object();
 			json_object_int_add(jobj, "srlg", attr->srlgs[i]);
 			json_object_array_add(jsrlg, jobj);

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -67,7 +67,11 @@ struct list {
 #define listcount(X) ((X)->count)
 #define list_isempty(X) ((X)->head == NULL && (X)->tail == NULL)
 /* return X->data only if X and X->data are not NULL */
-#define listgetdata(X) (assert(X), assert((X)->data != NULL), (X)->data)
+static inline void *listgetdata(const struct listnode *X)
+{
+	assert((X != NULL) && ((X)->data != NULL));
+	return X->data;
+}
 /* App is going to manage listnode memory */
 #define listset_app_node_mem(X) ((X)->flags |= LINKLIST_FLAG_NODE_MEM_BY_APP)
 #define listnode_init(X, val) ((X)->data = (val))

--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -157,7 +157,8 @@ nb_op_create_yield_state(const char *xpath, struct yang_translator *translator,
 	/* remove trailing '/'s */
 	while (darr_len(ys->xpath) > 1 && ys->xpath[darr_len(ys->xpath) - 2] == '/') {
 		darr_setlen(ys->xpath, darr_len(ys->xpath) - 1);
-		*darr_last(ys->xpath) = 0;
+		if (darr_last(ys->xpath))
+			*darr_last(ys->xpath) = 0;
 	}
 	ys->xpath_orig = darr_strdup(xpath);
 	ys->translator = translator;

--- a/lib/printf/vfprintf.c
+++ b/lib/printf/vfprintf.c
@@ -556,23 +556,23 @@ reswitch:	switch (ch) {
 		case 'G':
 			if (flags & LONGDBL) {
 				long double arg = GETARG(long double);
-				char fmt[6] = "%.*L";
-				fmt[4] = ch;
-				fmt[5] = '\0';
+				char lfmt[6] = "%.*L";
+				lfmt[4] = ch;
+				lfmt[5] = '\0';
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
-				snprintf(buf, sizeof(buf), fmt, prec, arg);
+				snprintf(buf, sizeof(buf), lfmt, prec, arg);
 #pragma GCC diagnostic pop
 			} else {
 				double arg = GETARG(double);
-				char fmt[5] = "%.*";
-				fmt[3] = ch;
-				fmt[4] = '\0';
+				char lfmt[5] = "%.*";
+				lfmt[3] = ch;
+				lfmt[4] = '\0';
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
-				snprintf(buf, sizeof(buf), fmt, prec, arg);
+				snprintf(buf, sizeof(buf), lfmt, prec, arg);
 #pragma GCC diagnostic pop
 			}
 			cp = buf;

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -3014,7 +3014,7 @@ size_t zebra_interface_link_params_write(struct stream *s,
 	size_t w, nb_ext_adm_grp;
 	struct if_link_params *iflp;
 	int i;
-
+	size_t j;
 
 	if (s == NULL || ifp == NULL)
 		return 0;
@@ -3045,8 +3045,8 @@ size_t zebra_interface_link_params_write(struct stream *s,
 	/* Extended Administrative Group */
 	nb_ext_adm_grp = admin_group_nb_words(&iflp->ext_admin_grp);
 	w += stream_putc(s, nb_ext_adm_grp);
-	for (size_t i = 0; i < nb_ext_adm_grp; i++)
-		stream_putl(s, admin_group_get_offset(&iflp->ext_admin_grp, i));
+	for (j = 0; j < nb_ext_adm_grp; j++)
+		stream_putl(s, admin_group_get_offset(&iflp->ext_admin_grp, j));
 
 	w += stream_putl(s, iflp->rmt_as);
 	w += stream_put_in_addr(s, &iflp->rmt_ip);

--- a/mgmtd/mgmt_ds.c
+++ b/mgmtd/mgmt_ds.c
@@ -151,9 +151,9 @@ void mgmt_ds_reset_candidate(void)
 }
 
 
-int mgmt_ds_init(struct mgmt_master *mm)
+int mgmt_ds_init(struct mgmt_master *m)
 {
-	if (mgmt_ds_mm || mm->running_ds || mm->candidate_ds || mm->oper_ds)
+	if (mgmt_ds_mm || m->running_ds || m->candidate_ds || m->oper_ds)
 		assert(!"MGMTD: Call ds_init only once!");
 
 	/* Use Running DS from NB module??? */
@@ -178,10 +178,10 @@ int mgmt_ds_init(struct mgmt_master *mm)
 	oper.config_ds = false;
 	oper.ds_id = MGMTD_DS_OPERATIONAL;
 
-	mm->running_ds = &running;
-	mm->candidate_ds = &candidate;
-	mm->oper_ds = &oper;
-	mgmt_ds_mm = mm;
+	m->running_ds = &running;
+	m->candidate_ds = &candidate;
+	m->oper_ds = &oper;
+	mgmt_ds_mm = m;
 
 	return 0;
 }
@@ -195,16 +195,15 @@ void mgmt_ds_destroy(void)
 	oper.root.dnode_root = NULL;
 }
 
-struct mgmt_ds_ctx *mgmt_ds_get_ctx_by_id(struct mgmt_master *mm,
-					  Mgmtd__DatastoreId ds_id)
+struct mgmt_ds_ctx *mgmt_ds_get_ctx_by_id(struct mgmt_master *m, Mgmtd__DatastoreId ds_id)
 {
 	switch (ds_id) {
 	case MGMTD_DS_CANDIDATE:
-		return (mm->candidate_ds);
+		return (m->candidate_ds);
 	case MGMTD_DS_RUNNING:
-		return (mm->running_ds);
+		return (m->running_ds);
 	case MGMTD_DS_OPERATIONAL:
-		return (mm->oper_ds);
+		return (m->oper_ds);
 	case MGMTD_DS_NONE:
 	case MGMTD__DATASTORE_ID__STARTUP_DS:
 	case _MGMTD__DATASTORE_ID_IS_INT_SIZE:

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -1442,7 +1442,6 @@ static void fe_adapter_handle_get_data(struct mgmt_fe_session_ctx *session,
 	/* Check for yang-library shortcut */
 	if (nb_oper_is_yang_lib_query(msg->xpath)) {
 		struct lyd_node *ylib = NULL;
-		LY_ERR err;
 
 		err = ly_ctx_get_yanglib_data(ly_native_ctx, &ylib, "%u",
 					      ly_ctx_get_change_count(

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -1993,17 +1993,17 @@ static void mgmt_txn_register_event(struct mgmt_txn_ctx *txn,
 	}
 }
 
-int mgmt_txn_init(struct mgmt_master *mm, struct event_loop *tm)
+int mgmt_txn_init(struct mgmt_master *m, struct event_loop *loop)
 {
 	if (mgmt_txn_mm || mgmt_txn_tm)
 		assert(!"MGMTD TXN: Call txn_init() only once");
 
-	mgmt_txn_mm = mm;
-	mgmt_txn_tm = tm;
-	mgmt_txns_init(&mm->txn_list);
+	mgmt_txn_mm = m;
+	mgmt_txn_tm = loop;
+	mgmt_txns_init(&m->txn_list);
 	mgmt_txn_hash_init();
-	assert(!mm->cfg_txn);
-	mm->cfg_txn = NULL;
+	assert(!m->cfg_txn);
+	m->cfg_txn = NULL;
 
 	return 0;
 }

--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -515,8 +515,6 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 			summary->path.origin.id =
 				ADV_ROUTER_IN_PREFIX(&route->prefix);
 		} else {
-			struct ospf6_lsa *old;
-
 			summary->path.origin.type =
 				htons(OSPF6_LSTYPE_INTER_PREFIX);
 

--- a/ospf6d/ospf6_area.h
+++ b/ospf6d/ospf6_area.h
@@ -123,16 +123,16 @@ struct ospf6_area {
 
 #define OSPF6_CMD_AREA_GET(str, oa, ospf6)                                     \
 	{                                                                      \
-		uint32_t area_id;                                              \
-		int format, ret;                                               \
-		ret = str2area_id(str, &area_id, &format);                     \
-		if (ret) {                                                     \
+		uint32_t _area_id;                                             \
+		int _format, _ret;                                             \
+		_ret = str2area_id(str, &_area_id, &_format);                  \
+		if (_ret) {                                                    \
 			vty_out(vty, "Malformed Area-ID: %s\n", str);          \
 			return CMD_WARNING;                                    \
 		}                                                              \
-		oa = ospf6_area_lookup(area_id, ospf6);                        \
+		oa = ospf6_area_lookup(_area_id, ospf6);                       \
 		if (oa == NULL)                                                \
-			oa = ospf6_area_create(area_id, ospf6, format);        \
+			oa = ospf6_area_create(_area_id, ospf6, _format);      \
 	}
 
 /* prototypes */

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1899,7 +1899,7 @@ static void ospf6_redistribute_default_set(struct ospf6 *ospf6, int originate)
 		break;
 	case DEFAULT_ORIGINATE_ZEBRA:
 		zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_DELETE,
-					     zclient, AFI_IP6, ospf6->vrf_id);
+					     ospf6_zclient, AFI_IP6, ospf6->vrf_id);
 		ospf6_asbr_redistribute_remove(DEFAULT_ROUTE, 0,
 					       (struct prefix *)&p, ospf6);
 
@@ -1915,7 +1915,7 @@ static void ospf6_redistribute_default_set(struct ospf6 *ospf6, int originate)
 		break;
 	case DEFAULT_ORIGINATE_ZEBRA:
 		zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_ADD,
-					     zclient, AFI_IP6, ospf6->vrf_id);
+					     ospf6_zclient, AFI_IP6, ospf6->vrf_id);
 
 		break;
 	case DEFAULT_ORIGINATE_ALWAYS:

--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -27,8 +27,6 @@
 #include "ospf6_zebra.h"
 #include "ospf6_bfd.h"
 
-extern struct zclient *zclient;
-
 /*
  * ospf6_bfd_trigger_event - Neighbor is registered/deregistered with BFD when
  *                           neighbor state is changed to/from 2way.
@@ -280,7 +278,7 @@ DEFUN (no_ipv6_ospf6_bfd,
 
 void ospf6_bfd_init(void)
 {
-	bfd_protocol_integration_init(zclient, master);
+	bfd_protocol_integration_init(ospf6_zclient, master);
 
 	/* Install BFD command */
 	install_element(INTERFACE_NODE, &ipv6_ospf6_bfd_cmd);

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -104,9 +104,9 @@ static void __attribute__((noreturn)) ospf6_exit(int status)
 
 	vrf_terminate();
 
-	if (zclient) {
-		zclient_stop(zclient);
-		zclient_free(zclient);
+	if (ospf6_zclient) {
+		zclient_stop(ospf6_zclient);
+		zclient_free(ospf6_zclient);
 	}
 
 	ospf6_master_delete();

--- a/ospf6d/ospf6_snmp.c
+++ b/ospf6d/ospf6_snmp.c
@@ -1382,9 +1382,9 @@ static int ospf6TrapIfStateChange(struct ospf6_interface *oi, int next_state,
 }
 
 /* Register OSPFv3-MIB. */
-static int ospf6_snmp_init(struct event_loop *master)
+static int ospf6_snmp_init(struct event_loop *mstr)
 {
-	smux_init(master);
+	smux_init(mstr);
 	REGISTER_MIB("OSPFv3MIB", ospfv3_variables, variable, ospfv3_oid);
 	return 0;
 }

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -142,20 +142,20 @@ static void ospf6_set_redist_vrf_bitmaps(struct ospf6 *ospf6, bool set)
 				"%s: setting redist vrf %d bitmap for type %d",
 				__func__, ospf6->vrf_id, type);
 		if (set)
-			vrf_bitmap_set(&zclient->redist[AFI_IP6][type],
+			vrf_bitmap_set(&ospf6_zclient->redist[AFI_IP6][type],
 				       ospf6->vrf_id);
 		else
-			vrf_bitmap_unset(&zclient->redist[AFI_IP6][type],
+			vrf_bitmap_unset(&ospf6_zclient->redist[AFI_IP6][type],
 					 ospf6->vrf_id);
 	}
 
 	red_list = ospf6->redist[DEFAULT_ROUTE];
 	if (red_list) {
 		if (set)
-			vrf_bitmap_set(&zclient->default_information[AFI_IP6],
+			vrf_bitmap_set(&ospf6_zclient->default_information[AFI_IP6],
 				       ospf6->vrf_id);
 		else
-			vrf_bitmap_unset(&zclient->default_information[AFI_IP6],
+			vrf_bitmap_unset(&ospf6_zclient->default_information[AFI_IP6],
 					 ospf6->vrf_id);
 	}
 }
@@ -566,13 +566,13 @@ static void ospf6_disable(struct ospf6 *o)
 	}
 }
 
-void ospf6_master_init(struct event_loop *master)
+void ospf6_master_init(struct event_loop *mst)
 {
 	memset(&ospf6_master, 0, sizeof(ospf6_master));
 
 	om6 = &ospf6_master;
 	om6->ospf6 = list_new();
-	om6->master = master;
+	om6->master = mst;
 }
 
 void ospf6_master_delete(void)

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -231,7 +231,6 @@ DECLARE_QOBJ_TYPE(ospf6);
 #define OSPF6_STUB_ROUTER 0x02
 
 /* global pointer for OSPF top data structure */
-extern struct ospf6 *ospf6;
 extern struct ospf6_master *om6;
 
 /* prototypes */

--- a/ospf6d/ospf6_zebra.h
+++ b/ospf6d/ospf6_zebra.h
@@ -27,7 +27,7 @@ struct ospf6_distance {
 	char *access_list;
 };
 
-extern struct zclient *zclient;
+extern struct zclient *ospf6_zclient;
 struct ospf6;
 
 extern void ospf6_zebra_route_update_add(struct ospf6_route *request,
@@ -38,7 +38,7 @@ extern void ospf6_zebra_route_update_remove(struct ospf6_route *request,
 extern void ospf6_zebra_redistribute(int, vrf_id_t vrf_id);
 extern void ospf6_zebra_no_redistribute(int, vrf_id_t vrf_id);
 #define ospf6_zebra_is_redistribute(type, vrf_id)                              \
-	vrf_bitmap_check(&zclient->redist[AFI_IP6][type], vrf_id)
+	vrf_bitmap_check(&ospf6_zclient->redist[AFI_IP6][type], vrf_id)
 extern void ospf6_zebra_init(struct event_loop *tm);
 extern void ospf6_zebra_import_default_route(struct ospf6 *ospf6, bool unreg);
 extern void ospf6_zebra_add_discard(struct ospf6_route *request,

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -1408,13 +1408,13 @@ static void install_element_ospf6_debug_event(void)
 }
 
 /* Install ospf related commands. */
-void ospf6_init(struct event_loop *master)
+void ospf6_init(struct event_loop *mst)
 {
 	ospf6_top_init();
 	ospf6_area_init();
 	ospf6_interface_init();
 	ospf6_neighbor_init();
-	ospf6_zebra_init(master);
+	ospf6_zebra_init(mst);
 
 	ospf6_lsa_init();
 	ospf6_spf_init();

--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -312,7 +312,7 @@ DEFUN (no_ip_ospf_bfd,
 
 void ospf_bfd_init(struct event_loop *tm)
 {
-	bfd_protocol_integration_init(zclient, tm);
+	bfd_protocol_integration_init(ospf_zclient, tm);
 
 	/* Install BFD command */
 	install_element(INTERFACE_NODE, &ip_ospf_bfd_cmd);

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -33,8 +33,6 @@
 #include "ospfd/ospf_zebra.h"
 #include "ospfd/ospf_dump.h"
 
-extern struct zclient *zclient;
-
 /** @brief Function to refresh type-5 and type-7 DNA
  *	   LSAs when we receive an indication LSA.
  *  @param Ospf instance.
@@ -172,11 +170,11 @@ struct external_info *ospf_external_info_check(struct ospf *ospf,
 		redist_on =
 			is_default_prefix4(&p)
 				? vrf_bitmap_check(
-					  &zclient->default_information[AFI_IP],
+					  &ospf_zclient->default_information[AFI_IP],
 					  ospf->vrf_id)
-				: (zclient->mi_redist[AFI_IP][type].enabled ||
+				: (ospf_zclient->mi_redist[AFI_IP][type].enabled ||
 				   vrf_bitmap_check(
-					   &zclient->redist[AFI_IP][type],
+					   &ospf_zclient->redist[AFI_IP][type],
 					   ospf->vrf_id));
 		// Pending: check for MI above.
 		if (redist_on) {

--- a/ospfd/ospf_ldp_sync.c
+++ b/ospfd/ospf_ldp_sync.c
@@ -28,8 +28,6 @@
 #include "ospf_dump.h"
 #include "ospf_ism.h"
 
-extern struct zclient *zclient;
-
 /*
  * LDP-SYNC msg between IGP and LDP
  */
@@ -98,8 +96,8 @@ void ospf_ldp_sync_state_req_msg(struct interface *ifp)
 	request.proto = LDP_IGP_SYNC_IF_STATE_REQUEST;
 	request.ifindex = ifp->ifindex;
 
-	zclient_send_opaque(zclient, LDP_IGP_SYNC_IF_STATE_REQUEST,
-		(uint8_t *)&request, sizeof(request));
+	zclient_send_opaque(ospf_zclient, LDP_IGP_SYNC_IF_STATE_REQUEST,
+			    (uint8_t *)&request, sizeof(request));
 }
 
 /*
@@ -400,9 +398,9 @@ void ospf_ldp_sync_gbl_exit(struct ospf *ospf, bool remove)
 	 */
 	if (CHECK_FLAG(ospf->ldp_sync_cmd.flags, LDP_SYNC_FLAG_ENABLE)) {
 		/* unregister with opaque client to recv LDP-IGP Sync msgs */
-		zclient_unregister_opaque(zclient,
+		zclient_unregister_opaque(ospf_zclient,
 					  LDP_IGP_SYNC_IF_STATE_UPDATE);
-		zclient_unregister_opaque(zclient,
+		zclient_unregister_opaque(ospf_zclient,
 					  LDP_IGP_SYNC_ANNOUNCE_UPDATE);
 
 		/* disable LDP globally */
@@ -754,8 +752,8 @@ DEFPY (ospf_mpls_ldp_sync,
 	}
 
 	/* register with opaque client to recv LDP-IGP Sync msgs */
-	zclient_register_opaque(zclient, LDP_IGP_SYNC_IF_STATE_UPDATE);
-	zclient_register_opaque(zclient, LDP_IGP_SYNC_ANNOUNCE_UPDATE);
+	zclient_register_opaque(ospf_zclient, LDP_IGP_SYNC_IF_STATE_UPDATE);
+	zclient_register_opaque(ospf_zclient, LDP_IGP_SYNC_ANNOUNCE_UPDATE);
 
 	if (!CHECK_FLAG(ospf->ldp_sync_cmd.flags, LDP_SYNC_FLAG_ENABLE)) {
 		SET_FLAG(ospf->ldp_sync_cmd.flags, LDP_SYNC_FLAG_ENABLE);

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -4055,11 +4055,11 @@ void ospf_ls_ack_send_direct(struct ospf_neighbor *nbr, struct ospf_lsa *lsa)
 	 * ignored.
 	 */
 	if (oi->type == OSPF_IFTYPE_POINTOMULTIPOINT && !oi->p2mp_non_broadcast) {
-		struct ospf_lsa_list_entry *ls_ack_list_entry;
+		struct ospf_lsa_list_entry *ack_list_entry;
 		struct ospf_lsa *ack_queue_lsa;
 
-		frr_each (ospf_lsa_list, &oi->ls_ack_direct, ls_ack_list_entry) {
-			ack_queue_lsa = ls_ack_list_entry->lsa;
+		frr_each (ospf_lsa_list, &oi->ls_ack_direct, ack_list_entry) {
+			ack_queue_lsa = ack_list_entry->lsa;
 			if ((lsa == ack_queue_lsa) ||
 			    ((lsa->data->type == ack_queue_lsa->data->type) &&
 			     (lsa->data->id.s_addr ==

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -1709,15 +1709,15 @@ static int ospf_te_export(uint8_t type, void *link_state)
 	switch (type) {
 	case LS_MSG_TYPE_NODE:
 		ls_vertex2msg(&msg, (struct ls_vertex *)link_state);
-		rc = ls_send_msg(zclient, &msg, NULL);
+		rc = ls_send_msg(ospf_zclient, &msg, NULL);
 		break;
 	case LS_MSG_TYPE_ATTRIBUTES:
 		ls_edge2msg(&msg, (struct ls_edge *)link_state);
-		rc = ls_send_msg(zclient, &msg, NULL);
+		rc = ls_send_msg(ospf_zclient, &msg, NULL);
 		break;
 	case LS_MSG_TYPE_PREFIX:
 		ls_subnet2msg(&msg, (struct ls_subnet *)link_state);
-		rc = ls_send_msg(zclient, &msg, NULL);
+		rc = ls_send_msg(ospf_zclient, &msg, NULL);
 		break;
 	default:
 		rc = -1;
@@ -3113,7 +3113,7 @@ int ospf_te_sync_ted(struct zapi_opaque_reg_info dst)
 	if (!OspfMplsTE.enabled || !OspfMplsTE.export)
 		return rc;
 
-	rc = ls_sync_ted(OspfMplsTE.ted, zclient, &dst);
+	rc = ls_sync_ted(OspfMplsTE.ted, ospf_zclient, &dst);
 
 	return rc;
 }
@@ -4306,7 +4306,7 @@ DEFUN (ospf_mpls_te_export,
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 
 	if (OspfMplsTE.enabled) {
-		if (ls_register(zclient, true) != 0) {
+		if (ls_register(ospf_zclient, true) != 0) {
 			vty_out(vty, "Unable to register Link State\n");
 			return CMD_WARNING;
 		}
@@ -4330,7 +4330,7 @@ DEFUN (no_ospf_mpls_te_export,
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 
 	if (OspfMplsTE.export) {
-		if (ls_unregister(zclient, true) != 0) {
+		if (ls_unregister(ospf_zclient, true) != 0) {
 			vty_out(vty, "Unable to unregister Link State\n");
 			return CMD_WARNING;
 		}

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -12308,8 +12308,6 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 				else
 					vty_out(vty, " ip ospf");
 
-				char buf[INET_ADDRSTRLEN];
-
 				area_id2str(buf, sizeof(buf), &params->if_area,
 					    params->if_area_id_fmt);
 				vty_out(vty, " area %s", buf);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -59,9 +59,6 @@ struct ospf_master *om;
 
 unsigned short ospf_instance;
 
-extern struct zclient *zclient;
-extern struct zclient *zclient_sync;
-
 /* OSPF config processing timer thread */
 struct event *t_ospf_cfg;
 
@@ -648,8 +645,8 @@ void ospf_terminate(void)
 	 * One or more ospf_finish()'s may have deferred shutdown to a timer
 	 * thread
 	 */
-	zclient_stop(zclient);
-	zclient_free(zclient);
+	zclient_stop(ospf_zclient);
+	zclient_free(ospf_zclient);
 	zclient_stop(zclient_sync);
 	zclient_free(zclient_sync);
 
@@ -2214,13 +2211,13 @@ void ospf_update_bufsize(struct ospf *ospf, uint32_t recvsize,
 		ospf_sock_bufsize_update(ospf, ospf->fd, type);
 }
 
-void ospf_master_init(struct event_loop *master)
+void ospf_master_init(struct event_loop *mst)
 {
 	memset(&ospf_master, 0, sizeof(ospf_master));
 
 	om = &ospf_master;
 	om->ospf = list_new();
-	om->master = master;
+	om->master = mst;
 }
 
 /* Link OSPF instance to VRF. */
@@ -2273,20 +2270,20 @@ static void ospf_set_redist_vrf_bitmaps(struct ospf *ospf, bool set)
 				"%s: setting redist vrf %d bitmap for type %d",
 				__func__, ospf->vrf_id, type);
 		if (set)
-			vrf_bitmap_set(&zclient->redist[AFI_IP][type],
+			vrf_bitmap_set(&ospf_zclient->redist[AFI_IP][type],
 				       ospf->vrf_id);
 		else
-			vrf_bitmap_unset(&zclient->redist[AFI_IP][type],
+			vrf_bitmap_unset(&ospf_zclient->redist[AFI_IP][type],
 					 ospf->vrf_id);
 	}
 
 	red_list = ospf->redist[DEFAULT_ROUTE];
 	if (red_list) {
 		if (set)
-			vrf_bitmap_set(&zclient->default_information[AFI_IP],
+			vrf_bitmap_set(&ospf_zclient->default_information[AFI_IP],
 				       ospf->vrf_id);
 		else
-			vrf_bitmap_unset(&zclient->default_information[AFI_IP],
+			vrf_bitmap_unset(&ospf_zclient->default_information[AFI_IP],
 					 ospf->vrf_id);
 	}
 }

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -695,7 +695,8 @@ struct ospf_nbr_nbma {
 extern struct ospf_master *om;
 extern unsigned short ospf_instance;
 extern const int ospf_redistributed_proto_max;
-extern struct zclient *zclient;
+extern struct zclient *ospf_zclient;
+extern struct zclient *zclient_sync;
 extern struct event_loop *master;
 extern int ospf_zlog;
 extern struct zebra_privs_t ospfd_privs;

--- a/pceplib/pcep_utils_memory.c
+++ b/pceplib/pcep_utils_memory.c
@@ -44,15 +44,15 @@ void *PCEPLIB_INFRA = &pceplib_infra_mt;
 void *PCEPLIB_MESSAGES = &pceplib_messages_mt;
 
 /* Initialize memory function pointers and memory type pointers */
-bool pceplib_memory_initialize(void *pceplib_infra_mt,
-			       void *pceplib_messages_mt,
+bool pceplib_memory_initialize(void *infra_mt,
+			       void *messages_mt,
 			       pceplib_malloc_func mf, pceplib_calloc_func cf,
 			       pceplib_realloc_func rf, pceplib_strdup_func sf,
 			       pceplib_free_func ff)
 {
-	PCEPLIB_INFRA = (pceplib_infra_mt ? pceplib_infra_mt : PCEPLIB_INFRA);
+	PCEPLIB_INFRA = (infra_mt ? infra_mt : PCEPLIB_INFRA);
 	PCEPLIB_MESSAGES =
-		(pceplib_messages_mt ? pceplib_messages_mt : PCEPLIB_MESSAGES);
+		(messages_mt ? messages_mt : PCEPLIB_MESSAGES);
 
 	mfunc = (mf ? mf : mfunc);
 	cfunc = (cf ? cf : cfunc);

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -15,7 +15,7 @@
 #include "pim_upstream.h"
 #include "pim_vxlan.h"
 
-extern struct zclient *zclient;
+extern struct zclient *pim_zclient;
 
 #define PIM_MLAG_METADATA_LEN 4
 
@@ -925,7 +925,7 @@ static void pim_mlag_register_handler(struct event *thread)
 {
 	uint32_t bit_mask = 0;
 
-	if (!zclient)
+	if (!pim_zclient)
 		return;
 
 	SET_FLAG(bit_mask, (1 << MLAG_STATUS_UPDATE));
@@ -942,7 +942,7 @@ static void pim_mlag_register_handler(struct event *thread)
 		zlog_debug("%s: Posting Client Register to MLAG mask: 0x%x",
 			   __func__, bit_mask);
 
-	zclient_send_mlag_register(zclient, bit_mask);
+	zclient_send_mlag_register(pim_zclient, bit_mask);
 }
 
 void pim_mlag_register(void)
@@ -958,14 +958,14 @@ void pim_mlag_register(void)
 
 static void pim_mlag_deregister_handler(struct event *thread)
 {
-	if (!zclient)
+	if (!pim_zclient)
 		return;
 
 	if (PIM_DEBUG_MLAG)
 		zlog_debug("%s: Posting Client De-Register to MLAG from PIM",
 			   __func__);
 	router->connected_to_mlag = false;
-	zclient_send_mlag_deregister(zclient);
+	zclient_send_mlag_deregister(pim_zclient);
 }
 
 void pim_mlag_deregister(void)

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -780,7 +780,6 @@ bool pim_nht_bsr_rpf_check(struct pim_instance *pim, pim_addr bsr_addr,
 		 */
 		struct pim_zlookup_nexthop nexthop_tab[router->multipath];
 		ifindex_t i;
-		struct interface *ifp = NULL;
 		int num_ifindex;
 
 		memset(nexthop_tab, 0, sizeof(nexthop_tab));

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1624,8 +1624,7 @@ void pim_upstream_set_sptbit(struct pim_upstream *up,
 	if (!starup
 	    || up->rpf.source_nexthop
 			       .interface != starup->rpf.source_nexthop.interface) {
-		struct pim_upstream *starup = up->parent;
-
+		starup = up->parent;
 		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug(
 				"%s: %s RPF_interface(S) != RPF_interface(RP(G))",

--- a/pimd/pim_zpthread.c
+++ b/pimd/pim_zpthread.c
@@ -13,7 +13,7 @@
 #include "pim_mlag.h"
 #include "pim_zebra.h"
 
-extern struct zclient *zclient;
+extern struct zclient *pim_zclient;
 
 #define PIM_MLAG_POST_LIMIT 100
 
@@ -96,7 +96,7 @@ static void pim_mlag_zebra_flush_buffer(void)
 		}
 	}
 
-	zclient_send_mlag_data(zclient, router->mlag_stream);
+	zclient_send_mlag_data(pim_zclient, router->mlag_stream);
 stream_failure:
 	stream_reset(router->mlag_stream);
 	mlag_bulk_cnt = 0;

--- a/ripd/rip_bfd.c
+++ b/ripd/rip_bfd.c
@@ -15,7 +15,7 @@
 
 DEFINE_MTYPE(RIPD, RIP_BFD_PROFILE, "RIP BFD profile name");
 
-extern struct zclient *zclient;
+extern struct zclient *ripd_zclient;
 
 static const char *rip_bfd_interface_profile(struct rip_interface *ri)
 {
@@ -117,5 +117,5 @@ void rip_bfd_instance_update(struct rip *rip)
 
 void rip_bfd_init(struct event_loop *tm)
 {
-	bfd_protocol_integration_init(zclient, tm);
+	bfd_protocol_integration_init(ripd_zclient, tm);
 }

--- a/ripd/rip_snmp.c
+++ b/ripd/rip_snmp.c
@@ -553,11 +553,11 @@ static uint8_t *rip2PeerTable(struct variable *v, oid name[], size_t *length,
 }
 
 /* Register RIPv2-MIB. */
-static int rip_snmp_init(struct event_loop *master)
+static int rip_snmp_init(struct event_loop *mstr)
 {
 	rip_ifaddr_table = route_table_init();
 
-	smux_init(master);
+	smux_init(mstr);
 	REGISTER_MIB("mibII/rip", rip_variables, variable, rip_oid);
 	return 0;
 }

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -282,8 +282,14 @@ struct rip_info *rip_ecmp_replace(struct rip *rip, struct rip_info *rinfo_new)
  */
 struct rip_info *rip_ecmp_delete(struct rip *rip, struct rip_info *rinfo)
 {
-	struct route_node *rp = rinfo->rp;
-	struct list *list = (struct list *)rp->info;
+	struct route_node *rp;
+	struct list *list;
+
+	if (rinfo == NULL)
+		return NULL;
+
+	rp = rinfo->rp;
+	list = (struct list *)rp->info;
 
 	EVENT_OFF(rinfo->t_timeout);
 

--- a/tests/isisd/test_common.c
+++ b/tests/isisd/test_common.c
@@ -33,11 +33,11 @@ test_topology_find_node(const struct isis_topology *topology,
 }
 
 const struct isis_topology *
-test_topology_find(struct isis_topology *test_topologies, uint16_t number)
+test_topology_find(struct isis_topology *topologies, uint16_t number)
 {
-	for (size_t i = 0; test_topologies[i].number; i++)
-		if (test_topologies[i].number == number)
-			return &test_topologies[i];
+	for (size_t i = 0; topologies[i].number; i++)
+		if (topologies[i].number == number)
+			return &topologies[i];
 
 	return NULL;
 }

--- a/tests/isisd/test_fuzz_isis_tlv.c
+++ b/tests/isisd/test_fuzz_isis_tlv.c
@@ -161,7 +161,7 @@ static int test(FILE *input, FILE *output)
 	struct listnode *node;
 	for (ALL_LIST_ELEMENTS_RO(fragments, node, tlvs)) {
 		stream_reset(s);
-		int rv = isis_pack_tlvs(tlvs, s, (size_t)-1, false, false);
+		rv = isis_pack_tlvs(tlvs, s, (size_t)-1, false, false);
 		if (rv) {
 			fprintf(output, "Could not pack fragment, too large.\n");
 			assert(0);

--- a/tests/lib/test_darr.c
+++ b/tests/lib/test_darr.c
@@ -157,12 +157,17 @@ static void test_int(void)
 
 	assert(!memcmp(da2, a1, sizeof(a1)));
 
-	assert(darr_pop(da2) == 4);
-	assert(darr_pop(da2) == 3);
-	assert(darr_pop(da2) == 2);
+	i = darr_pop(da2);
+	assert(i == 4);
+	i = darr_pop(da2);
+	assert(i == 3);
+	i = darr_pop(da2);
+	assert(i == 2);
 	assert(darr_len(da2) == 2);
-	assert(darr_pop(da2) == 1);
-	assert(darr_pop(da2) == 0);
+	i = darr_pop(da2);
+	assert(i == 1);
+	i = darr_pop(da2);
+	assert(i == 0);
 	assert(darr_len(da2) == 0);
 
 	darr_free(da2);
@@ -323,38 +328,47 @@ static void test_string(void)
 	char *da2 = NULL;
 	const char **strings = NULL;
 	uint sum = 0;
+	uint i;
 
-	assert(darr_strlen(da1) == 0);
+	i = darr_strlen(da1);
+	assert(i == 0);
 
 	da1 = darr_strdup(src);
-	assert(darr_strlen(da1) == strlen(da1));
-	assert(darr_strlen(da1) == srclen);
+	i = darr_strlen(da1);
+	assert(i == strlen(da1));
+	i = darr_strlen(da1);
+	assert(i == srclen);
 	assert(darr_len(da1) == srclen + 1);
 	assert(darr_ilen(da1) == (int)srclen + 1);
 	assert(darr_cap(da1) >= 8);
 	assert(darr_last(da1) == darr_strnul(da1));
-	assert(darr_strnul(da1) == da1 + darr_strlen(da1));
+	i = darr_strlen(da1);
+	assert(darr_strnul(da1) == da1 + i);
 
 	da2 = da1;
 	darr_in_strdup(da1, src);
 	assert(da1 == da2);
-	assert(darr_strlen(da1) == strlen(da1));
-	assert(darr_strlen(da1) == srclen);
+	i = darr_strlen(da1);
+	assert(i == strlen(da1));
+	assert(i == srclen);
 	assert(darr_len(da1) == srclen + 1);
 	darr_free(da1);
 	assert(da1 == NULL);
 
 	da1 = darr_strdup_cap(src, 128);
-	assert(darr_strlen(da1) == srclen);
+	i = darr_strlen(da1);
+	assert(i == srclen);
 	assert(darr_cap(da1) >= 128);
 
 	darr_in_strdup_cap(da1, src, 256);
-	assert(darr_strlen(da1) == srclen);
+	i = darr_strlen(da1);
+	assert(i == srclen);
 	assert(darr_cap(da1) >= 256);
 	darr_free(da1);
 
 	da1 = darr_strdup_cap(add, 2);
-	assert(darr_strlen(da1) == addlen);
+	i = darr_strlen(da1);
+	assert(i == addlen);
 	assert(darr_cap(da1) >= 8);
 
 	darr_in_strdup(da1, "ab");
@@ -377,7 +391,8 @@ static void test_string(void)
 	da2 = darr_strdup(add);
 	darr_in_strcat_tail(da1, da2);
 	assert(!strcmp("abHIJ", da1));
-	assert(darr_strlen(da1) == 5);
+	i = darr_strlen(da1);
+	assert(i == 5);
 	assert(darr_len(da1) == 6);
 	darr_free(da1);
 	darr_free(da2);
@@ -386,14 +401,16 @@ static void test_string(void)
 	da2 = darr_strdup(add);
 	darr_in_strcat_tail(da1, da2);
 	assert(!strcmp("abcde", da1));
-	assert(darr_strlen(da1) == 5);
+	i = darr_strlen(da1);
+	assert(i == 5);
 	assert(darr_len(da1) == 6);
 	darr_free(da1);
 	darr_free(da2);
 
 	da1 = darr_sprintf("0123456789: %08X", 0xDEADBEEF);
 	assert(!strcmp(da1, "0123456789: DEADBEEF"));
-	assert(darr_strlen(da1) == 20);
+	i = darr_strlen(da1);
+	assert(i == 20);
 	assert(darr_cap(da1) == 128);
 	da2 = da1;
 	darr_in_sprintf(da1, "9876543210: %08x", 0x0BADF00D);
@@ -405,11 +422,13 @@ static void test_string(void)
 	da1 = NULL;
 	darr_in_sprintf(da1, "0123456789: %08X", 0xDEADBEEF);
 	assert(!strcmp(da1, "0123456789: DEADBEEF"));
-	assert(darr_strlen(da1) == 20);
+	i = darr_strlen(da1);
+	assert(i == 20);
 	assert(darr_cap(da1) == 128);
 
 	da1[5] = 0;
-	assert(darr_strlen_fixup(da1) == 5);
+	i = darr_strlen_fixup(da1);
+	assert(i == 5);
 	darr_free(da1);
 
 	da1 = darr_sprintf("0123456789: %08x", 0xDEADBEEF);

--- a/tests/lib/test_printfrr.c
+++ b/tests/lib/test_printfrr.c
@@ -107,7 +107,7 @@ static int printchk(const char *ref, const char *fmt, ...)
 		errors++;
 	}
 
-	for (size_t i = 0; i < fb.outpos_i; i++)
+	for (i = 0; i < fb.outpos_i; i++)
 		printf("\t[%zu: %u..%u] = \"%.*s\"\n", i,
 			outpos[i].off_start,
 			outpos[i].off_end,

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -152,7 +152,7 @@ void suid_off(void);
 /* Child process execution flag. */
 extern int execute_flag;
 
-extern struct vty *vty;
+extern struct vty *gvty;
 
 extern int user_mode;
 

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -558,19 +558,19 @@ static void configvec_dump(vector vec, bool nested)
 					continue;
 				}
 
-				vty_out(vty, "%s\n", config->name);
+				vty_out(gvty, "%s\n", config->name);
 
 				for (ALL_LIST_ELEMENTS(config->line, mnode,
 						       mnnode, line))
-					vty_out(vty, "%s\n", line);
+					vty_out(gvty, "%s\n", line);
 
 				configvec_dump(config->nested, true);
 
 				if (config->exit)
-					vty_out(vty, "%s\n", config->exit);
+					vty_out(gvty, "%s\n", config->exit);
 
 				if (!NO_DELIMITER(i))
-					vty_out(vty, "!\n");
+					vty_out(gvty, "!\n");
 
 				config_del(config);
 			}
@@ -579,7 +579,7 @@ static void configvec_dump(vector vec, bool nested)
 			XFREE(MTYPE_VTYSH_CONFIG, configuration);
 			vector_slot(vec, i) = NULL;
 			if (!nested && NO_DELIMITER(i))
-				vty_out(vty, "!\n");
+				vty_out(gvty, "!\n");
 		}
 }
 
@@ -589,11 +589,11 @@ void vtysh_config_dump(void)
 	char *line;
 
 	for (ALL_LIST_ELEMENTS(config_top, node, nnode, line))
-		vty_out(vty, "%s\n", line);
+		vty_out(gvty, "%s\n", line);
 
 	list_delete_all_node(config_top);
 
-	vty_out(vty, "!\n");
+	vty_out(gvty, "!\n");
 
 	configvec_dump(configvec, false);
 }
@@ -601,13 +601,13 @@ void vtysh_config_dump(void)
 /* Read up configuration file from file_name. */
 static int vtysh_read_file(FILE *confp, bool dry_run)
 {
-	struct vty *vty;
+	struct vty *lvty;
 	int ret;
 
-	vty = vty_new();
-	vty->wfd = STDERR_FILENO;
-	vty->type = VTY_TERM;
-	vty->node = CONFIG_NODE;
+	lvty = vty_new();
+	lvty->wfd = STDERR_FILENO;
+	lvty->type = VTY_TERM;
+	lvty->node = CONFIG_NODE;
 
 	vtysh_execute_no_pager("enable");
 	/*
@@ -622,7 +622,7 @@ static int vtysh_read_file(FILE *confp, bool dry_run)
 		vtysh_execute_no_pager("XFRR_start_configuration");
 
 	/* Execute configuration file. */
-	ret = vtysh_config_from_file(vty, confp);
+	ret = vtysh_config_from_file(lvty, confp);
 
 	if (!dry_run)
 		vtysh_execute_no_pager("XFRR_end_configuration");
@@ -630,7 +630,7 @@ static int vtysh_read_file(FILE *confp, bool dry_run)
 	vtysh_execute_no_pager("end");
 	vtysh_execute_no_pager("disable");
 
-	vty_close(vty);
+	vty_close(lvty);
 
 	return (ret);
 }

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -726,7 +726,7 @@ int main(int argc, char **argv, char **env)
 
 	vtysh_readline_init();
 
-	vty_hello(vty);
+	vty_hello(gvty);
 
 	/* Enter into enable node. */
 	if (!user_mode)

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1919,8 +1919,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 		if (zif_type == ZEBRA_IF_VRF && !vrf_is_backend_netns())
 			interface_vrf_change(op, ifindex, name, tableid, ns_id);
 	} else {
-		ifindex_t master_ifindex, bridge_ifindex, bond_ifindex,
-			link_ifindex;
+		ifindex_t master_ifindex, bridge_ifindex, link_ifindex;
 		enum zebra_slave_iftype zif_slave_type;
 		uint8_t bypass;
 		uint64_t flags;
@@ -2730,14 +2729,14 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 		}
 		if (gre_info->ifindex_link &&
 		    (gre_info->link_nsid != NS_UNKNOWN)) {
-			struct interface *ifp;
+			struct interface *nifp;
 
-			ifp = if_lookup_by_index_per_ns(
-					zebra_ns_lookup(gre_info->link_nsid),
-					gre_info->ifindex_link);
+			nifp = if_lookup_by_index_per_ns(
+				zebra_ns_lookup(gre_info->link_nsid),
+				gre_info->ifindex_link);
 			vty_out(vty, "  Link Interface %s\n",
-				ifp == NULL ? "Unknown" :
-				ifp->name);
+				nifp == NULL ? "Unknown" :
+				nifp->name);
 		}
 	}
 
@@ -3116,14 +3115,13 @@ static void if_dump_vty_json(struct vty *vty, struct interface *ifp,
 		}
 		if (gre_info->ifindex_link
 		    && (gre_info->link_nsid != NS_UNKNOWN)) {
-			struct interface *ifp;
+			struct interface *nifp;
 
-			ifp = if_lookup_by_index_per_ns(
+			nifp = if_lookup_by_index_per_ns(
 				zebra_ns_lookup(gre_info->link_nsid),
 				gre_info->ifindex_link);
 			json_object_string_add(json_if, "linkInterface",
-					       ifp == NULL ? "Unknown"
-							   : ifp->name);
+					       nifp == NULL ? "Unknown" : nifp->name);
 		}
 	}
 

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1054,7 +1054,7 @@ void rtm_read(struct rt_msghdr *rtm)
 	/*
 	 * Ignore our own messages.
 	 */
-	if (rtm->rtm_type != RTM_GET && rtm->rtm_pid == pid)
+	if (rtm->rtm_type != RTM_GET && rtm->rtm_pid == zebra_pid)
 		return;
 
 	if (dest.sa.sa_family == AF_INET) {

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -57,7 +57,7 @@
 char *zserv_path;
 
 /* process id. */
-pid_t pid;
+pid_t zebra_pid;
 
 /* Pacify zclient.o in libfrr, which expects this variable. */
 struct event_loop *master;
@@ -520,7 +520,7 @@ int main(int argc, char **argv)
 	 */
 
 	/* Needed for BSD routing socket. */
-	pid = getpid();
+	zebra_pid = getpid();
 
 	/* Start dataplane system */
 	zebra_dplane_start();

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -628,7 +628,7 @@ extern int rib_add_gr_run(afi_t afi, vrf_id_t vrf_id, uint8_t proto,
 extern void zebra_vty_init(void);
 extern uint32_t zebra_rib_dplane_results_count(void);
 
-extern pid_t pid;
+extern pid_t zebra_pid;
 
 extern uint32_t rt_table_main_id;
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -3139,13 +3139,11 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 				if (nh->nh_srv6->seg6local_action !=
 				    ZEBRA_SEG6_LOCAL_ACTION_UNSPEC) {
 					uint32_t action;
-					uint16_t encap;
-					struct rtattr *nest;
-					const struct seg6local_context *ctx;
+					const struct seg6local_context *ctx6;
 
 					req->nhm.nh_family = AF_INET6;
 					action = nh->nh_srv6->seg6local_action;
-					ctx = &nh->nh_srv6->seg6local_ctx;
+					ctx6 = &nh->nh_srv6->seg6local_ctx;
 					encap = LWTUNNEL_ENCAP_SEG6_LOCAL;
 					if (!nl_attr_put(&req->n, buflen,
 							 NHA_ENCAP_TYPE,
@@ -3174,7 +3172,7 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 							return 0;
 						if (!nl_attr_put(
 						    &req->n, buflen,
-						    SEG6_LOCAL_NH6, &ctx->nh6,
+						    SEG6_LOCAL_NH6, &ctx6->nh6,
 						    sizeof(struct in6_addr)))
 							return 0;
 						break;
@@ -3187,7 +3185,7 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 						if (!nl_attr_put32(
 						    &req->n, buflen,
 						    SEG6_LOCAL_TABLE,
-						    ctx->table))
+						    ctx6->table))
 							return 0;
 						break;
 					case SEG6_LOCAL_ACTION_END_DX4:
@@ -3198,7 +3196,7 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 							return 0;
 						if (!nl_attr_put(
 						    &req->n, buflen,
-						    SEG6_LOCAL_NH4, &ctx->nh4,
+						    SEG6_LOCAL_NH4, &ctx6->nh4,
 						    sizeof(struct in_addr)))
 							return 0;
 						break;
@@ -3210,7 +3208,7 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 							return 0;
 						if (!nl_attr_put(&req->n, buflen,
 								 SEG6_LOCAL_NH6,
-								 &ctx->nh6,
+								 &ctx6->nh6,
 								 sizeof(struct in6_addr)))
 							return 0;
 						break;
@@ -3223,7 +3221,7 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 						if (!nl_attr_put32(
 						    &req->n, buflen,
 						    SEG6_LOCAL_TABLE,
-						    ctx->table))
+						    ctx6->table))
 							return 0;
 						break;
 					case SEG6_LOCAL_ACTION_END_DT4:
@@ -3235,7 +3233,7 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 						if (!nl_attr_put32(
 							    &req->n, buflen,
 							    SEG6_LOCAL_VRFTABLE,
-							    ctx->table))
+							    ctx6->table))
 							return 0;
 						break;
 					case SEG6_LOCAL_ACTION_END_DT46:
@@ -3247,7 +3245,7 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 						if (!nl_attr_put32(
 							    &req->n, buflen,
 							    SEG6_LOCAL_VRFTABLE,
-							    ctx->table))
+							    ctx6->table))
 							return 0;
 						break;
 					default:
@@ -3268,7 +3266,6 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 				    !sid_zero(nh->nh_srv6->seg6_segs)) {
 					char tun_buf[4096];
 					ssize_t tun_len;
-					struct rtattr *nest;
 
 					if (!nl_attr_put16(&req->n, buflen,
 					    NHA_ENCAP_TYPE,

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -1602,8 +1602,6 @@ DEFPY(show_ipv6_nd_ra_if, show_ipv6_nd_ra_if_cmd,
 		struct vrf *vrf;
 
 		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-			struct zebra_vrf *zvrf;
-
 			zvrf = vrf->info;
 			if (!zvrf)
 				continue;

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -261,7 +261,7 @@ static int netlink_route_info_fill(struct netlink_route_info *ri, int cmd,
 	ri->prefix = rib_dest_prefix(dest);
 	ri->af = rib_dest_af(dest);
 
-	ri->nlmsg_pid = pid;
+	ri->nlmsg_pid = zebra_pid;
 
 	ri->nlmsg_type = cmd;
 	ri->rtm_protocol = RTPROT_UNSPEC;

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -317,9 +317,9 @@ static ssize_t printfrr_zebra_node(struct fbuf *buf, struct printfrr_eargs *ea,
 
 #define rnode_debug(node, vrf_id, msg, ...)                                    \
 	do {                                                                   \
-		struct vrf *vrf = vrf_lookup_by_id(vrf_id);                    \
+		struct vrf *_vrf = vrf_lookup_by_id(vrf_id);                    \
 		zlog_debug("%s: (%s:%pZNt):%pZN: " msg, __func__,              \
-			   VRF_LOGNAME(vrf), node, node, ##__VA_ARGS__);       \
+			   VRF_LOGNAME(_vrf), node, node, ##__VA_ARGS__);       \
 	} while (0)
 
 #define rnode_info(node, vrf_id, msg, ...)                                     \
@@ -1225,10 +1225,10 @@ static void rib_process(struct route_node *rn)
 	 * will not iterate so we are ok.
 	 */
 	if (IS_ZEBRA_DEBUG_RIB_DETAILED) {
-		struct route_entry *re = re_list_first(&dest->routes);
+		struct route_entry *rent = re_list_first(&dest->routes);
 
 		zlog_debug("%s(%u:%u:%u):%pRN: Processing rn %p", VRF_LOGNAME(vrf), vrf_id,
-			   re->table, safi, rn, rn);
+			   rent->table, safi, rn, rn);
 	}
 
 	old_fib = dest->selected_fib;

--- a/zebra/zebra_snmp.c
+++ b/zebra/zebra_snmp.c
@@ -418,11 +418,11 @@ static void get_fwtable_route_node(struct variable *v, oid objid[],
 	objid[v->namelen + 5] = policy;
 
 	{
-		struct nexthop *nexthop;
+		struct nexthop *nh;
 
-		nexthop = (*re)->nhe->nhg.nexthop;
-		if (nexthop) {
-			pnt = (uint8_t *)&nexthop->gate.ipv4;
+		nh = (*re)->nhe->nhg.nexthop;
+		if (nh) {
+			pnt = (uint8_t *)&nh->gate.ipv4;
 			for (i = 0; i < 4; i++)
 				objid[i + v->namelen + 6] = *pnt++;
 		}

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -210,7 +210,7 @@ DEFUN (show_srv6_locator_detail,
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(srv6->locators, node, locator)) {
-		struct listnode *node;
+		struct listnode *nnode;
 		struct srv6_locator_chunk *chunk;
 
 		if (strcmp(locator->name, locator_name) != 0)
@@ -247,8 +247,7 @@ DEFUN (show_srv6_locator_detail,
 		}
 
 		vty_out(vty, "Chunks:\n");
-		for (ALL_LIST_ELEMENTS_RO((struct list *)locator->chunks, node,
-					  chunk)) {
+		for (ALL_LIST_ELEMENTS_RO((struct list *)locator->chunks, nnode, chunk)) {
 			prefix2str(&chunk->prefix, str, sizeof(str));
 			vty_out(vty, "- prefix: %s, owner: %s\n", str,
 				zebra_route_string(chunk->proto));

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1490,8 +1490,6 @@ DEFPY(show_nexthop_group,
 		struct vrf *vrf;
 
 		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-			struct zebra_vrf *zvrf;
-
 			zvrf = vrf->info;
 			if (!zvrf)
 				continue;


### PR DESCRIPTION
Add the -Wshadow warning option for builds; this exposes variable-shadowing issues. This PR moves the -Wshadow compiler flag to the common list of flags so that it is included with all builds, and cleans up all of the existing warnings.
