### PR TITLE
isisd: fix duplicate rfc8919 defines

### DIFF
--- a/isisd/isis_tlvs.h
+++ b/isisd/isis_tlvs.h
@@ -777,12 +777,6 @@ struct list *isis_fragment_tlvs(struct isis_tlvs *tlvs, size_t size);
 #define ISIS_MT_AT_MASK        0x4000
 #endif
 
-/* RFC 8919 */
-#define ISIS_SABM_FLAG_R 0x80 /* RSVP-TE */
-#define ISIS_SABM_FLAG_S 0x40 /* Segment Routing Policy */
-#define ISIS_SABM_FLAG_L 0x20 /* Loop-Free Alternate */
-#define ISIS_SABM_FLAG_X 0x10 /* Flex-Algorithm - RFC9350 */
-
 void isis_tlvs_add_auth(struct isis_tlvs *tlvs, struct isis_passwd *passwd);
 void isis_tlvs_add_area_addresses(struct isis_tlvs *tlvs,
 				  struct list *addresses);


### PR DESCRIPTION
The application specific defines from rfc8919 were defined twice in the isis tlv headers. Remove the second one.

Fixes: 5749ac83a8ad ("isisd: add ASLA support")