### PR TITLE
Bgp suppressed attribute

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10951,6 +10951,12 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct bgp_dest *bn,
 		else
 			vty_out(vty, ", (stale)");
 	}
+	if (bgp_path_suppressed(path)) {
+		if (json_paths)
+			json_object_boolean_true_add(json_path, "suppressed");
+		else
+			vty_out(vty, ", (suppressed)");
+	}
 
 	if (CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR))) {
 		if (json_paths) {

--- a/tests/topotests/bgp_aggregate_address_topo1/r1/bgp_192_168_0_1.json
+++ b/tests/topotests/bgp_aggregate_address_topo1/r1/bgp_192_168_0_1.json
@@ -1,0 +1,41 @@
+{
+  "prefix":"192.168.0.1/32",
+  "paths":[
+    {
+      "aspath":{
+        "string":"65001",
+        "segments":[
+          {
+            "type":"as-sequence",
+            "list":[
+              65001
+            ]
+          }
+        ],
+        "length":1
+      },
+      "suppressed":true,
+      "origin":"IGP",
+      "metric":10,
+      "valid":true,
+      "bestpath":{
+        "overall":true,
+        "selectionReason":"First path received"
+      },
+      "nexthops":[
+        {
+          "ip":"10.0.0.2",
+          "afi":"ipv4",
+          "metric":0,
+          "accessible":true,
+          "used":true
+        }
+      ],
+      "peer":{
+        "peerId":"10.0.0.2",
+        "routerId":"10.254.254.3",
+        "type":"external"
+      }
+    }
+  ]
+}

--- a/tests/topotests/bgp_aggregate_address_topo1/test_bgp_aggregate_address_topo1.py
+++ b/tests/topotests/bgp_aggregate_address_topo1/test_bgp_aggregate_address_topo1.py
@@ -13,6 +13,7 @@
 Test BGP aggregate address features.
 """
 
+import json
 import os
 import sys
 import pytest
@@ -263,6 +264,24 @@ match ip address acl-sup-three
             "192.168.2.3/32": None,
         },
     )
+
+
+def test_check_bgp_attribute():
+    "Dump the suppressed attribute of the 192.168.0.1/32 prefix in r1."
+    tgen = get_topogen()
+
+    logger.info("Test that the BGP path to 192.168.0.1 is as expected.")
+    expected = json.loads(open("{}/r1/bgp_192_168_0_1.json".format(CWD)).read())
+
+    test_func = functools.partial(
+        topotest.router_json_cmp,
+        tgen.gears["r1"],
+        "show bgp ipv4 192.168.0.1/32 json",
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assertmsg = '"r1" BGP 192.168.0.1 route output failed'
+    assert result is None, assertmsg
 
 
 def test_memory_leak():


### PR DESCRIPTION
There is an inconsistency between the vty output and its json output: there is a missing information about the suppressed information. Fix this by adding and testing a new json attribute.