### PR TITLE
lib: mutexes don't need no shadow

### DIFF
--- a/lib/frr_pthread.h
+++ b/lib/frr_pthread.h
@@ -233,10 +233,12 @@ int frr_pthread_non_controlled_startup(pthread_t thread, const char *name,
 		unused, cleanup(_frr_mtx_unlock))) = _frr_mtx_lock(mutex),     \
 	/* end */
 
-#define frr_with_mutex(...)                                                    \
-	for (pthread_mutex_t MACRO_REPEAT(_frr_with_mutex, ##__VA_ARGS__)      \
-	     *_once = NULL; _once == NULL; _once = (void *)1)                  \
+#define _frr_with_mutex_once(_once, ...)                                                           \
+	for (pthread_mutex_t MACRO_REPEAT(_frr_with_mutex, ##__VA_ARGS__) *_once = NULL;           \
+	     _once == NULL; _once = (void *)1)                                                     \
 	/* end */
+
+#define frr_with_mutex(...) _frr_with_mutex_once(NAMECTR(_once_), __VA_ARGS__)
 
 /* variant 2:
  * (more suitable for long blocks, no extra indentation)


### PR DESCRIPTION
The `_once` loop variable will result in a `-Wshadow` warning when that is turned on.  Use `__COUNTER__` to give these variables distinct names, like is already done with `_mtx_`.

(and because I touched it, clang-format wants it reformatted... ohwell.)