### PR TITLE
lib: fix use after free in `clear event cpu`

### DIFF
--- a/lib/frrevent.h
+++ b/lib/frrevent.h
@@ -139,6 +139,10 @@ struct cpu_event_history {
 	struct cpu_records_item item;
 
 	void (*func)(struct event *e);
+
+	/* fields between the pair of these two are nulled on "clear event cpu" */
+	char _clear_begin[0];
+
 	atomic_size_t total_cpu_warn;
 	atomic_size_t total_wall_warn;
 	atomic_size_t total_starv_warn;
@@ -149,6 +153,10 @@ struct cpu_event_history {
 	} real;
 	struct time_stats cpu;
 	atomic_uint_fast32_t types;
+
+	/* end of cleared region */
+	char _clear_end[0];
+
 	const char *funcname;
 };
 


### PR DESCRIPTION
Freeing any item here means freeing someone's `event->hist`, leaving a dangling pointer there.  Which will immediately be written to because we're executing in a CLI function under the `vty_read` event, whose `event->hist` is then updated.

Deallocating `event->hist` anywhere other than shutting down the whole event loop is a bad idea to begin with, just zero out the stats instead.

Fixes: FRRouting/frr#16419