### PR TITLE
tools: Fix frr-reload for ebgp-multihop TTL reconfiguration.

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -237,6 +237,14 @@ def get_normalized_interface_vrf(line):
     return line
 
 
+def get_normalized_ebgp_multihop_line(line):
+    obj = re.search(r"(.*)ebgp-multihop\s+255", line)
+    if obj:
+        line = obj.group(1) + "ebgp-multihop"
+
+    return line
+
+
 # This dictionary contains a tree of all commands that we know start a
 # new multi-line context. All other commands are treated either as
 # commands inside a multi-line context or as single-line contexts. This
@@ -381,6 +389,9 @@ class Config(object):
 
             if ":" in line:
                 line = get_normalized_mac_ip_line(line)
+
+            if "ebgp-multihop" in line:
+                line = get_normalized_ebgp_multihop_line(line)
 
             # vrf static routes can be added in two ways. The old way is:
             #


### PR DESCRIPTION
In ebgp-multihop, there is a difference in reload behavior when TTL is unspecified (meaning default 255) and when 255 is explicitly specified. For example, when reloading with 'neighbor <neighbor> ebgp-multihop 255' in the config, the following difference is created. This commit fixes that.

    Lines To Delete
    ===============
    router bgp 65001
     no neighbor 10.0.0.4 ebgp-multihop
    exit

    Lines To Add
    ============
    router bgp 65001
     neighbor 10.0.0.4 ebgp-multihop 255
    exit

The commit 767aaa3a8048 is not sufficient and frr-reload needs to be fixed to handle both unspecified and specified cases.

----

## How to reproduce the issue on master branch

```
cat <<EOF > /etc/frr/frr.conf
router bgp 65001
 bgp router-id 10.0.0.1
 neighbor 10.0.0.4 remote-as 65002
 neighbor 10.0.0.4 ebgp-multihop 255
exit
!
end
EOF

systemctl start frr
./tools/frr-reload.py --debug --test /etc/frr/frr.conf
```

These commands above shows the diff as below:

```txt
Lines To Delete
===============
router bgp 65001
 no neighbor 10.0.0.4 ebgp-multihop
exit

Lines To Add
============
router bgp 65001
 neighbor 10.0.0.4 ebgp-multihop 255
exit
```