### PR TITLE
isisd: fix erroneous srv6 information in database

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -1053,9 +1053,8 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 							       adj->algorithm));
 				json_object_int_add(srv6_endx_sid_json,
 						    "weight", adj->weight);
-				json_object_string_add(srv6_endx_sid_json,
-						       "behavior",
-						       seg6local_action2str(
+				json_object_string_add(srv6_endx_sid_json, "behavior",
+						       srv6_endpoint_behavior_codepoint2str(
 							       adj->behavior));
 				json_object_boolean_add(
 					srv6_endx_sid_json, "flagB",
@@ -1081,22 +1080,17 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 			for (adj = (struct isis_srv6_endx_sid_subtlv *)
 					   exts->srv6_endx_sid.head;
 			     adj; adj = adj->next) {
-				sbuf_push(
-					buf, indent,
-					"SRv6 End.X SID: %pI6, Algorithm: %s, Weight: %hhu, Endpoint Behavior: %s, Flags: B:%c, S:%c, P:%c\n",
-					&adj->sid,
-					sr_algorithm_string(adj->algorithm),
-					adj->weight,
-					seg6local_action2str(adj->behavior),
-					adj->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_BFLG
-						? '1'
-						: '0',
-					adj->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_SFLG
-						? '1'
-						: '0',
-					adj->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_PFLG
-						? '1'
-						: '0');
+				sbuf_push(buf, indent,
+					  "SRv6 End.X SID: %pI6, Algorithm: %s, Weight: %hhu, Endpoint Behavior: %s, Flags: B:%c, S:%c, P:%c\n",
+					  &adj->sid, sr_algorithm_string(adj->algorithm),
+					  adj->weight,
+					  srv6_endpoint_behavior_codepoint2str(adj->behavior),
+					  adj->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_BFLG ? '1'
+											  : '0',
+					  adj->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_SFLG ? '1'
+											  : '0',
+					  adj->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_PFLG ? '1'
+											  : '0');
 				if (adj->subsubtlvs)
 					isis_format_subsubtlvs(adj->subsubtlvs,
 							       buf, NULL,
@@ -1131,9 +1125,8 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 							       lan->algorithm));
 				json_object_int_add(srv6_lan_endx_sid_json,
 						    "weight", lan->weight);
-				json_object_string_add(srv6_lan_endx_sid_json,
-						       "behavior",
-						       seg6local_action2str(
+				json_object_string_add(srv6_lan_endx_sid_json, "behavior",
+						       srv6_endpoint_behavior_codepoint2str(
 							       lan->behavior));
 				json_object_boolean_add(
 					srv6_lan_endx_sid_json, "flagB",
@@ -1162,24 +1155,19 @@ static void format_item_ext_subtlvs(struct isis_ext_subtlvs *exts,
 			for (lan = (struct isis_srv6_lan_endx_sid_subtlv *)
 					   exts->srv6_lan_endx_sid.head;
 			     lan; lan = lan->next) {
-				sbuf_push(
-					buf, indent,
-					"SRv6 Lan End.X SID: %pI6, Algorithm: %s, Weight: %hhu, Endpoint Behavior: %s, Flags: B:%c, S:%c, P:%c "
-					"Neighbor-ID: %pSY\n",
-					&lan->sid,
-					sr_algorithm_string(lan->algorithm),
-					lan->weight,
-					seg6local_action2str(lan->behavior),
-					lan->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_BFLG
-						? '1'
-						: '0',
-					lan->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_SFLG
-						? '1'
-						: '0',
-					lan->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_PFLG
-						? '1'
-						: '0',
-					lan->neighbor_id);
+				sbuf_push(buf, indent,
+					  "SRv6 Lan End.X SID: %pI6, Algorithm: %s, Weight: %hhu, Endpoint Behavior: %s, Flags: B:%c, S:%c, P:%c "
+					  "Neighbor-ID: %pSY\n",
+					  &lan->sid, sr_algorithm_string(lan->algorithm),
+					  lan->weight,
+					  srv6_endpoint_behavior_codepoint2str(lan->behavior),
+					  lan->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_BFLG ? '1'
+											  : '0',
+					  lan->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_SFLG ? '1'
+											  : '0',
+					  lan->flags & EXT_SUBTLV_LINK_SRV6_ENDX_SID_PFLG ? '1'
+											  : '0',
+					  lan->neighbor_id);
 				if (lan->subsubtlvs)
 					isis_format_subsubtlvs(lan->subsubtlvs,
 							       buf, NULL,
@@ -2823,7 +2811,7 @@ static void format_item_srv6_end_sid(uint16_t mtid, struct isis_item *i,
 		sid_json = json_object_new_object();
 		json_object_object_add(json, "srv6EndSid", sid_json);
 		json_object_string_add(sid_json, "endpointBehavior",
-				       seg6local_action2str(sid->behavior));
+				       srv6_endpoint_behavior_codepoint2str(sid->behavior));
 		json_object_string_addf(sid_json, "sidValue", "%pI6", &sid->sid);
 		if (sid->subsubtlvs) {
 			struct json_object *subtlvs_json;
@@ -2836,7 +2824,7 @@ static void format_item_srv6_end_sid(uint16_t mtid, struct isis_item *i,
 	} else {
 		sbuf_push(buf, indent, "SRv6 End SID ");
 		sbuf_push(buf, 0, "Endpoint Behavior: %s, ",
-			  seg6local_action2str(sid->behavior));
+			  srv6_endpoint_behavior_codepoint2str(sid->behavior));
 		sbuf_push(buf, 0, "SID value: %pI6\n", &sid->sid);
 
 		if (sid->subsubtlvs) {


### PR DESCRIPTION
The show isis database detail command dumps invalid srv6 information:
>  SRv6 Locator: fc00:0:6::/64 (Metric: 0) ipv6-unicast
>    Sub-TLVs:
>      SRv6 End SID Endpoint Behavior: unknown, SID value: fc00:0:6:0:1::
>
>  MT Reachability: 0123.6452.1973.03 (Metric: 10) ipv6-unicast
>    Local Interface IPv6 Address(es): 192::4:3
>    SRv6 Lan End.X SID: fc00:0:3:0:43::, Algorithm: SPF, Weight: 0, Endpoint Behavior: End.DX6, Flags: B:0, S:0, P:0 Neighbor-ID: 0123.6452.1975
>        SRv6 SID Structure Locator Block length: 40, Locator Node length: 24, Function length: 16, Argument length: 0,

The behavior codepoint should use the IANA definitions to display the correct value. Fix this by calling the appropriate convert function.