### PR TITLE
bgpd: Do not advertise aggregate routes to contributing ASes

### DIFF
--- a/bgpd/bgp_aspath.h
+++ b/bgpd/bgp_aspath.h
@@ -168,5 +168,6 @@ extern void bgp_remove_aspath_from_aggregate_hash(
 						struct aspath *aspath);
 
 extern void bgp_aggr_aspath_remove(void *arg);
+extern struct aspath *aspath_delete_as_set_seq(struct aspath *aspath);
 
 #endif /* _QUAGGA_BGP_ASPATH_H */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2614,15 +2614,32 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 	bgp_peer_remove_private_as(bgp, afi, safi, peer, attr);
 	bgp_peer_as_override(bgp, afi, safi, peer, attr);
 
-	/* draft-ietf-idr-deprecate-as-set-confed-set
-	 * Filter routes having AS_SET or AS_CONFED_SET in the path.
-	 * Eventually, This document (if approved) updates RFC 4271
-	 * and RFC 5065 by eliminating AS_SET and AS_CONFED_SET types,
-	 * and obsoletes RFC 6472.
-	 */
-	if (peer->bgp->reject_as_sets)
-		if (aspath_check_as_sets(attr->aspath))
+	/* draft-ietf-idr-deprecate-as-set-confed-set-16 */
+	if (peer->bgp->reject_as_sets && aspath_check_as_sets(attr->aspath)) {
+		struct aspath *aspath_new;
+
+		/* An aggregate prefix MUST NOT be announced to the contributing ASes */
+		if (pi->sub_type == BGP_ROUTE_AGGREGATE &&
+		    aspath_loop_check(attr->aspath, peer->as)) {
+			zlog_warn("%pBP [Update:SEND] %pFX is filtered by `bgp reject-as-sets`",
+				  peer, p);
 			return false;
+		}
+
+		/* When aggregating prefixes, network operators MUST use consistent brief
+		 * aggregation as described in Section 5.2. In consistent brief aggregation,
+		 * the AGGREGATOR and ATOMIC_AGGREGATE Path Attributes are included, but the
+		 * AS_PATH does not have AS_SET or AS_CONFED_SET path segment types.
+		 * The ATOMIC_AGGREGATE Path Attribute is subsequently attached to the BGP
+		 * route, if AS_SETs are dropped.
+		 */
+		if (attr->aspath->refcnt)
+			aspath_new = aspath_dup(attr->aspath);
+		else
+			aspath_new = attr->aspath;
+
+		attr->aspath = aspath_delete_as_set_seq(aspath_new);
+	}
 
 	/* If neighbor soo is configured, then check if the route has
 	 * SoO extended community and validate against the configured
@@ -8922,7 +8939,6 @@ static int bgp_aggregate_set(struct vty *vty, const char *prefix_str, afi_t afi,
 	struct prefix p;
 	struct bgp_dest *dest;
 	struct bgp_aggregate *aggregate;
-	uint8_t as_set_new = as_set;
 
 	if (suppress_map && summary_only) {
 		vty_out(vty,
@@ -8980,7 +8996,6 @@ static int bgp_aggregate_set(struct vty *vty, const char *prefix_str, afi_t afi,
 	 */
 	if (bgp->reject_as_sets) {
 		if (as_set == AGGREGATE_AS_SET) {
-			as_set_new = AGGREGATE_AS_UNSET;
 			zlog_warn(
 				"%s: Ignoring as-set because `bgp reject-as-sets` is enabled.",
 				__func__);
@@ -8989,7 +9004,7 @@ static int bgp_aggregate_set(struct vty *vty, const char *prefix_str, afi_t afi,
 		}
 	}
 
-	aggregate->as_set = as_set_new;
+	aggregate->as_set = as_set;
 
 	/* Override ORIGIN attribute if defined.
 	 * E.g.: Cisco and Juniper set ORIGIN for aggregated address

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -535,6 +535,13 @@ Reject routes with AS_SET or AS_CONFED_SET types
 
    This command enables rejection of incoming and outgoing routes having AS_SET or AS_CONFED_SET type.
 
+   The aggregated routes are not sent to the contributing neighbors.
+
+.. seealso::
+   https://datatracker.ietf.org/doc/html/draft-ietf-idr-deprecate-as-set-confed-set
+
+   Default: disabled.
+
 Enforce first AS
 ----------------
 
@@ -2938,7 +2945,7 @@ BGP Extended Communities in Route Map
 
 ``CO:COLOR``
    This is a format to define colors value. ``CO`` part is always 00 (default),
-   it can be used to support the requirements of Color-Only steering when using 
+   it can be used to support the requirements of Color-Only steering when using
    a Null Endpoint in the SR-TE Policy as specified in Section 8.8 of [RFC9256].
    The below shows in detail what the different combinations of ``CO`` bits can
    match on to for the purpose of determining what type of SR-TE Policy Tunnel

--- a/tests/topotests/bgp_reject_as_sets/r2/bgpd.conf
+++ b/tests/topotests/bgp_reject_as_sets/r2/bgpd.conf
@@ -6,6 +6,9 @@ router bgp 65002
   neighbor 192.168.255.2 timers 3 10
   neighbor 192.168.254.2 remote-as 65003
   neighbor 192.168.254.2 timers 3 10
+  neighbor 192.168.253.2 remote-as 65004
+  neighbor 192.168.253.2 timers 3 10
+  neighbor 192.168.253.2 solo
   address-family ipv4 unicast
     aggregate-address 172.16.0.0/16 as-set summary-only
   exit-address-family

--- a/tests/topotests/bgp_reject_as_sets/r2/zebra.conf
+++ b/tests/topotests/bgp_reject_as_sets/r2/zebra.conf
@@ -5,5 +5,8 @@ interface r2-eth0
 interface r2-eth1
  ip address 192.168.254.1/30
 !
+interface r2-eth2
+ ip address 192.168.253.1/30
+!
 ip forwarding
 !

--- a/tests/topotests/bgp_reject_as_sets/r4/bgpd.conf
+++ b/tests/topotests/bgp_reject_as_sets/r4/bgpd.conf
@@ -1,0 +1,6 @@
+!
+router bgp 65004
+ no bgp ebgp-requires-policy
+ neighbor 192.168.253.1 remote-as 65002
+ neighbor 192.168.253.1 timers 3 10
+!

--- a/tests/topotests/bgp_reject_as_sets/r4/zebra.conf
+++ b/tests/topotests/bgp_reject_as_sets/r4/zebra.conf
@@ -1,0 +1,6 @@
+!
+interface r4-eth0
+ ip address 192.168.253.2/30
+!
+ip forwarding
+!


### PR DESCRIPTION
=> updates according to https://datatracker.ietf.org/doc/html/draft-ietf-idr-deprecate-as-set-confed-set-16