### PR TITLE
Fix SRv6 SID Manager

### DIFF
--- a/tests/topotests/static_srv6_sids/expected_srv6_sids.json
+++ b/tests/topotests/static_srv6_sids/expected_srv6_sids.json
@@ -1,4 +1,39 @@
 {
+	"fcbb:bbbb:1::/48": [
+		{
+			"prefix": "fcbb:bbbb:1::/48",
+			"prefixLen": 48,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "End"
+					},
+					"seg6localContext": {
+
+					}
+				}
+			]
+		}
+	],
 	"fcbb:bbbb:1:fe10::/64": [
 		{
 			"prefix": "fcbb:bbbb:1:fe10::/64",

--- a/tests/topotests/static_srv6_sids/r1/frr.conf
+++ b/tests/topotests/static_srv6_sids/r1/frr.conf
@@ -8,6 +8,7 @@ segment-routing
    !
   !
   static-sids
+   sid fcbb:bbbb:1::/48 locator MAIN behavior uN
    sid fcbb:bbbb:1:fe10::/64 locator MAIN behavior uDT4 vrf Vrf10
    sid fcbb:bbbb:1:fe20::/64 locator MAIN behavior uDT6 vrf Vrf20
    sid fcbb:bbbb:1:fe30::/64 locator MAIN behavior uDT46 vrf Vrf30


### PR DESCRIPTION
The SRv6 SID Manager does not allow allocating an SRv6 End/uN function even though it is already supported by staticd.