### PR TITLE
pimd: Close AutoRP socket when not needed (backport #17934)

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -608,26 +608,14 @@ int pim_process_no_rp_plist_cmd(struct vty *vty, const char *rp_str,
 
 int pim_process_autorp_cmd(struct vty *vty)
 {
-	char xpath[XPATH_MAXLEN];
-
-	snprintf(xpath, sizeof(xpath), "%s/%s", FRR_PIM_AUTORP_XPATH,
-		 "discovery-enabled");
-
-	nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, "true");
-
-	return nb_cli_apply_changes(vty, NULL);
+	nb_cli_enqueue_change(vty, "./discovery-enabled", NB_OP_MODIFY, "true");
+	return nb_cli_apply_changes(vty, "%s", FRR_PIM_AUTORP_XPATH);
 }
 
 int pim_process_no_autorp_cmd(struct vty *vty)
 {
-	char xpath[XPATH_MAXLEN];
-
-	snprintf(xpath, sizeof(xpath), "%s/%s", FRR_PIM_AUTORP_XPATH,
-		 "discovery-enabled");
-
-	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
-
-	return nb_cli_apply_changes(vty, NULL);
+	nb_cli_enqueue_change(vty, "./discovery-enabled", NB_OP_MODIFY, "false");
+	return nb_cli_apply_changes(vty, "%s", FRR_PIM_AUTORP_XPATH);
 }
 
 int pim_process_autorp_candidate_rp_cmd(struct vty *vty, bool no,


### PR DESCRIPTION
Don't leave the socket open if we are not enabled for discovery or announcements.

Signed-off-by: Nathan Bahr <nbahr@atcorp.com>
(cherry picked from commit 5d102a0a7014e9c526381bacc398a9b06a64ca24)