### PR TITLE
libs: return from change_caps if no caps

### DIFF
--- a/lib/privs.c
+++ b/lib/privs.c
@@ -210,10 +210,11 @@ int zprivs_change_caps(zebra_privs_ops_t op)
 {
 	cap_flag_value_t cflag;
 
-	/* should be no possibility of being called without valid caps */
-	assert(zprivs_state.syscaps_p && zprivs_state.caps);
-	if (!(zprivs_state.syscaps_p && zprivs_state.caps))
-		exit(1);
+	/* Called without valid caps - just return. Not every daemon needs
+	 * privs.
+	 */
+	if (zprivs_state.syscaps_p == NULL || zprivs_state.caps == NULL)
+		return 0;
 
 	if (op == ZPRIVS_RAISE)
 		cflag = CAP_SET;


### PR DESCRIPTION
When called without caps/privs, just return from "change_caps" instead of exiting - it's possible that a process may not need privs, but a lib (for example) may use the api.
