### PR TITLE
bgpd: do not accept a host route that matches a local address

### DIFF
--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -584,6 +584,14 @@ bool bgp_nexthop_self(struct bgp *bgp, afi_t afi, uint8_t type,
 	return false;
 }
 
+bool bgp_hostroute_self(struct bgp *bgp, const struct prefix *p)
+{
+	struct bgp_addr tmp;
+
+	tmp.p = *p;
+	return hash_lookup(bgp->address_hash, &tmp) ? true : false;
+}
+
 bool bgp_multiaccess_check_v4(struct in_addr nexthop, struct peer *peer)
 {
 	struct bgp_dest *dest1;

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -134,6 +134,7 @@ extern int bgp_config_write_scan_time(struct vty *);
 extern bool bgp_nexthop_self(struct bgp *bgp, afi_t afi, uint8_t type,
 			     uint8_t sub_type, struct attr *attr,
 			     struct bgp_dest *dest);
+extern bool bgp_hostroute_self(struct bgp *bgp, const struct prefix *p);
 extern struct bgp_nexthop_cache *bnc_new(struct bgp_nexthop_cache_head *tree,
 					 struct prefix *prefix,
 					 uint32_t srte_color,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5103,6 +5103,14 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 			goto filtered;
 		}
 
+	/* Do not accept a host route that matches a local address. */
+	if (((safi == SAFI_UNICAST) || (safi == SAFI_LABELED_UNICAST)) && is_host_route(p)) {
+		if (bgp_hostroute_self(bgp, p)) {
+			reason = "host route matches a local address";
+			goto filtered;
+		}
+	}
+
 	/* Apply incoming filter.  */
 	if (bgp_input_filter(peer, p, attr, afi, orig_safi) == FILTER_DENY) {
 		peer->stat_pfx_filter++;

--- a/tests/topotests/bgp_l3vpn_to_bgp_direct/scripts/check_routes.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_direct/scripts/check_routes.py
@@ -3,21 +3,21 @@ from lib.lutil import luCommand
 luCommand(
     "ce1",
     'vtysh -c "show bgp ipv4 uni"',
-    "7 routes and 7",
+    "6 routes and 6",
     "wait",
     "Local and remote routes",
 )
 luCommand(
     "ce2",
     'vtysh -c "show bgp ipv4 uni"',
-    "7 routes and 9",
+    "6 routes and 8",
     "wait",
     "Local and remote routes",
 )
 luCommand(
     "ce3",
     'vtysh -c "show bgp ipv4 uni"',
-    "7 routes and 7",
+    "6 routes and 6",
     "wait",
     "Local and remote routes",
 )


### PR DESCRIPTION
Accepting a host route from a BGP peer for a local address would result in inconsistency between BGP and RIB/FIB.