### PR TITLE
bgpd: fix add label support to EVPN AD routes

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -1201,6 +1201,7 @@ int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 	mpls_label_t label;
 	struct in_addr vtep_ip;
 	struct prefix_evpn p;
+	uint8_t num_labels = 0;
 
 	if (psize != BGP_EVPN_TYPE1_PSIZE) {
 		flog_err(EC_BGP_EVPN_ROUTE_INVALID,
@@ -1225,6 +1226,7 @@ int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 	pfx += EVPN_ETH_TAG_BYTES;
 
 	memcpy(&label, pfx, BGP_LABEL_BYTES);
+	num_labels++;
 
 	/* EAD route prefix doesn't include the nexthop in the global
 	 * table
@@ -1233,12 +1235,11 @@ int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 	build_evpn_type1_prefix(&p, eth_tag, &esi, vtep_ip);
 	/* Process the route. */
 	if (attr) {
-		bgp_update(peer, (struct prefix *)&p, addpath_id, attr, afi,
-			   safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, NULL,
-			   0, 0, NULL);
+		bgp_update(peer, (struct prefix *)&p, addpath_id, attr, afi, safi, ZEBRA_ROUTE_BGP,
+			   BGP_ROUTE_NORMAL, &prd, &label, num_labels, 0, NULL);
 	} else {
-		bgp_withdraw(peer, (struct prefix *)&p, addpath_id, afi, safi,
-			     ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, NULL, 0);
+		bgp_withdraw(peer, (struct prefix *)&p, addpath_id, afi, safi, ZEBRA_ROUTE_BGP,
+			     BGP_ROUTE_NORMAL, &prd, &label, num_labels);
 	}
 	return 0;
 }


### PR DESCRIPTION
When peering with an EVPN device from other vendor, FRR acting as route reflector is not able to read nor transmit the label value.

Actually, EVPN AD routes completely ignore the label value in the code, whereas in some functionalities like evpn-vpws, it is authorised to carry and propagate label value.

Fix this by handling the label value.