### PR TITLE
lib: fix static analysis error

### DIFF
--- a/lib/elf_py.c
+++ b/lib/elf_py.c
@@ -1306,8 +1306,8 @@ static PyObject *elffile_load(PyTypeObject *type, PyObject *args,
 		}
 	}
 #endif
-
-	w->sects = calloc(w->ehdr->e_shnum, sizeof(PyObject *));
+	if (w->ehdr->e_shnum > 0)
+		w->sects = calloc(w->ehdr->e_shnum, sizeof(PyObject *));
 	w->n_sect = w->ehdr->e_shnum;
 
 	return (PyObject *)w;


### PR DESCRIPTION
This PR addresses a set of fixes related to static errors in lib, zebra, pbrd, isisd, bgpd.

Each commit provides a description of the error that was present before and is attempted to be corrected.