### PR TITLE
staticd: Add CLI to support steering of IPv4 traffic over SRv6 SID list

### DIFF
--- a/doc/user/static.rst
+++ b/doc/user/static.rst
@@ -177,6 +177,20 @@ multiple segments instructions.
   [..]
   S>* 2005::/64 [1/0] is directly connected, ens3, seg6 2001:db8:aaaa::7,2002::4,2002::3,2002::2, weight 1, 00:00:06
 
+STATIC also supports steering of IPv4 traffic over an SRv6 SID list, as shown in the example below.
+
+.. code-block:: frr
+
+  ip route A.B.C.D <A.B.C.D|nexthop> segments U:U::U:U/Y:Y::Y:Y/Z:Z::Z:Z
+
+::
+
+  router(config)# ip route 10.0.0.0/24 sr0 segments fcbb:bbbb:1:2:3:fe00::
+
+  router# show ip route
+  [..]
+  S>* 10.0.0.0/24 [1/0] is directly connected, sr0, seg6 fcbb:bbbb:1:2:3:fe00::, weight 1, 00:00:06
+
 SRv6 Static SIDs Commands
 =========================
 

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -771,6 +771,7 @@ DEFPY_YANG(ip_route_vrf,
 	  |nexthop-vrf NAME                            \
 	  |color (1-4294967295)                        \
 	  |bfd$bfd [{multi-hop$bfd_multi_hop|source A.B.C.D$bfd_source|profile BFDPROF$bfd_profile}] \
+	  |segments WORD \
           }]",
       NO_STR IP_STR
       "Establish static routes\n"
@@ -794,7 +795,9 @@ DEFPY_YANG(ip_route_vrf,
       BFD_INTEGRATION_SOURCE_STR
       BFD_INTEGRATION_SOURCEV4_STR
       BFD_PROFILE_STR
-      BFD_PROFILE_NAME_STR)
+      BFD_PROFILE_NAME_STR
+      "Steer this route over an SRv6 SID list\n"
+      "SRv6 SID list\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -815,6 +818,7 @@ DEFPY_YANG(ip_route_vrf,
 		.bfd_multi_hop = !!bfd_multi_hop,
 		.bfd_source = bfd_source_str,
 		.bfd_profile = bfd_profile,
+		.segs = segments,
 	};
 
 	return static_route_nb_run(vty, &args);

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -704,6 +704,7 @@ DEFPY_YANG(ip_route,
 	  |nexthop-vrf NAME                            \
 	  |color (1-4294967295)                        \
 	  |bfd$bfd [{multi-hop$bfd_multi_hop|source A.B.C.D$bfd_source|profile BFDPROF$bfd_profile}] \
+	  |segments WORD \
           }]",
       NO_STR IP_STR
       "Establish static routes\n"
@@ -728,7 +729,9 @@ DEFPY_YANG(ip_route,
       BFD_INTEGRATION_SOURCE_STR
       BFD_INTEGRATION_SOURCEV4_STR
       BFD_PROFILE_STR
-      BFD_PROFILE_NAME_STR)
+      BFD_PROFILE_NAME_STR
+      "Steer this route over an SRv6 SID list\n"
+      "SRv6 SID list\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -749,6 +752,7 @@ DEFPY_YANG(ip_route,
 		.bfd_multi_hop = !!bfd_multi_hop,
 		.bfd_source = bfd_source_str,
 		.bfd_profile = bfd_profile,
+		.segs = segments,
 	};
 
 	return static_route_nb_run(vty, &args);

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -564,6 +564,7 @@ DEFPY_YANG(ip_route_address_interface,
 	  |onlink$onlink                               \
 	  |color (1-4294967295)                        \
 	  |bfd$bfd [{multi-hop$bfd_multi_hop|source A.B.C.D$bfd_source|profile BFDPROF$bfd_profile}] \
+	  |segments WORD \
           }]",
       NO_STR IP_STR
       "Establish static routes\n"
@@ -589,7 +590,9 @@ DEFPY_YANG(ip_route_address_interface,
       BFD_INTEGRATION_SOURCE_STR
       BFD_INTEGRATION_SOURCEV4_STR
       BFD_PROFILE_STR
-      BFD_PROFILE_NAME_STR)
+      BFD_PROFILE_NAME_STR
+      "Steer this route over an SRv6 SID list\n"
+      "SRv6 SID list\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -611,6 +614,7 @@ DEFPY_YANG(ip_route_address_interface,
 		.bfd_multi_hop = !!bfd_multi_hop,
 		.bfd_source = bfd_source_str,
 		.bfd_profile = bfd_profile,
+		.segs = segments,
 	};
 
 	return static_route_nb_run(vty, &args);

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -635,6 +635,7 @@ DEFPY_YANG(ip_route_address_interface_vrf,
 	  |onlink$onlink                               \
 	  |color (1-4294967295)                        \
 	  |bfd$bfd [{multi-hop$bfd_multi_hop|source A.B.C.D$bfd_source|profile BFDPROF$bfd_profile}] \
+	  |segments WORD \
 	  }]",
       NO_STR IP_STR
       "Establish static routes\n"
@@ -659,7 +660,9 @@ DEFPY_YANG(ip_route_address_interface_vrf,
       BFD_INTEGRATION_SOURCE_STR
       BFD_INTEGRATION_SOURCEV4_STR
       BFD_PROFILE_STR
-      BFD_PROFILE_NAME_STR)
+      BFD_PROFILE_NAME_STR
+      "Steer this route over an SRv6 SID list\n"
+      "SRv6 SID list\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -681,6 +684,7 @@ DEFPY_YANG(ip_route_address_interface_vrf,
 		.bfd_multi_hop = !!bfd_multi_hop,
 		.bfd_source = bfd_source_str,
 		.bfd_profile = bfd_profile,
+		.segs = segments,
 	};
 
 	return static_route_nb_run(vty, &args);

--- a/tests/topotests/srv6_static_route_ipv4/expected_srv6_route.json
+++ b/tests/topotests/srv6_static_route_ipv4/expected_srv6_route.json
@@ -1,0 +1,28 @@
+{
+	"192.0.2.0/24": [
+		{
+			"prefix": "192.0.2.0/24",
+			"prefixLen": 24,
+			"protocol": "static",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"nexthops": [
+				{
+					"directlyConnected": true,
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "unspec"
+					},
+					"seg6": [
+						"fcbb:bbbb:1:2:3:4:5:6",
+						"fcbb:bbbb:7:8:fe00::"
+					]
+				}
+			]
+		}
+	]
+}

--- a/tests/topotests/srv6_static_route_ipv4/r1/frr.conf
+++ b/tests/topotests/srv6_static_route_ipv4/r1/frr.conf
@@ -1,0 +1,7 @@
+hostname r1
+!
+log stdout notifications
+log commands
+!
+ipv6 route fcbb:bbbb:1::/48 sr0
+ip route 192.0.2.0/24 sr0 segments fcbb:bbbb:1:2:3:4:5:6/fcbb:bbbb:7:8:fe00::

--- a/tests/topotests/srv6_static_route_ipv4/r1/setup.sh
+++ b/tests/topotests/srv6_static_route_ipv4/r1/setup.sh
@@ -1,0 +1,2 @@
+ip link add sr0 type dummy
+ip link set sr0 up

--- a/tests/topotests/srv6_static_route_ipv4/test_srv6_route.py
+++ b/tests/topotests/srv6_static_route_ipv4/test_srv6_route.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_srv6_static_route_ipv4.py
+#
+# Copyright 2025
+# Carmine Scarpitta <cscarpit.@cisco.com>
+#
+
+"""
+test_srv6_static_route_ipv4.py:
+Test for SRv6 static route on zebra
+"""
+
+import os
+import sys
+import json
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.staticd]
+
+
+def open_json_file(filename):
+    try:
+        with open(filename, "r") as f:
+            return json.load(f)
+    except IOError:
+        assert False, "Could not read file {}".format(filename)
+
+
+def setup_module(mod):
+    tgen = Topogen({None: "r1"}, mod.__name__)
+    tgen.start_topology()
+    for rname, router in tgen.routers().items():
+        router.run("/bin/bash {}/{}/setup.sh".format(CWD, rname))
+        router.load_frr_config("frr.conf")
+    tgen.start_router()
+
+
+def teardown_module():
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_srv6_static_route():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    router = tgen.gears["r1"]
+
+    def _check_srv6_static_route(router, expected_route_file):
+        logger.info("checking zebra srv6 static route with multiple segs status")
+        output = json.loads(router.vtysh_cmd("show ip route static json"))
+        expected = open_json_file("{}/{}".format(CWD, expected_route_file))
+        return topotest.json_cmp(output, expected)
+
+    def check_srv6_static_route(router, expected_file):
+        func = functools.partial(_check_srv6_static_route, router, expected_file)
+        _, result = topotest.run_and_expect(func, None, count=15, wait=1)
+        assert result is None, "Failed"
+
+    # FOR DEVELOPER:
+    # If you want to stop some specific line and start interactive shell,
+    # please use tgen.mininet_cli() to start it.
+
+    logger.info("Test for srv6 route configuration")
+    check_srv6_static_route(router, "expected_srv6_route.json")
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
staticd already has a CLI to steer IPv6 traffic over a given SRv6 SID list:

```
ipv6 route 2001:db8:1:1::/64 sr0 segments fcbb:bbbb:1:2:3:fe00::
```

This PR extends the existing CLI `ip route` to support steering of IPv4 traffic over an SRv6 SID list.

```
ip route 10.0.0.0/24 sr0 segments fcbb:bbbb:1:2:3:fe00::
```
