### PR TITLE
staticd: Fix wrong xpath in `no sid X:X::X:X/M`

### DIFF
--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -1273,8 +1273,8 @@ DEFPY_YANG(no_srv6_sid, no_srv6_sid_cmd,
 {
 	char xpath[XPATH_MAXLEN + 37];
 
-	snprintf(xpath, sizeof(xpath), FRR_STATIC_SRV6_INFO_KEY_XPATH, "frr-staticd:staticd",
-		 "staticd", VRF_DEFAULT_NAME);
+	snprintf(xpath, sizeof(xpath), FRR_STATIC_SRV6_SID_KEY_XPATH, "frr-staticd:staticd",
+		 "staticd", VRF_DEFAULT_NAME, sid_str);
 
 	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 

--- a/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_delete_1.json
+++ b/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_delete_1.json
@@ -1,0 +1,107 @@
+{
+	"fcbb:bbbb:1:fe10::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe10::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "Vrf10",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "End.DT4"
+					},
+					"seg6localContext": {
+						"table": 10
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe20::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe20::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "Vrf20",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "End.DT6"
+					},
+					"seg6localContext": {
+						"table": 20
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe30::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe30::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "Vrf30",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "End.DT46"
+					},
+					"seg6localContext": {
+						"table": 30
+					}
+				}
+			]
+		}
+	]
+}

--- a/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_delete_2.json
+++ b/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_delete_2.json
@@ -1,0 +1,72 @@
+{
+	"fcbb:bbbb:1:fe10::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe10::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "Vrf10",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "End.DT4"
+					},
+					"seg6localContext": {
+						"table": 10
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe30::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe30::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "Vrf30",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "End.DT46"
+					},
+					"seg6localContext": {
+						"table": 30
+					}
+				}
+			]
+		}
+	]
+}

--- a/tests/topotests/static_srv6_sids/test_static_srv6_sids.py
+++ b/tests/topotests/static_srv6_sids/test_static_srv6_sids.py
@@ -133,6 +133,45 @@ def test_srv6_static_sids_sid_delete():
     check_srv6_static_sids(router, "expected_srv6_sids_sid_delete_2.json")
 
 
+def test_srv6_static_sids_sid_readd():
+    """
+    Re-add the static SID and verify the routing table
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    router = tgen.gears["r1"]
+
+    def _check_srv6_static_sids(router, expected_route_file):
+        logger.info("checking zebra srv6 static sids")
+        output = json.loads(router.vtysh_cmd("show ipv6 route static json"))
+        expected = open_json_file("{}/{}".format(CWD, expected_route_file))
+        return topotest.json_cmp(output, expected)
+
+    def check_srv6_static_sids(router, expected_file):
+        func = functools.partial(_check_srv6_static_sids, router, expected_file)
+        _, result = topotest.run_and_expect(func, None, count=15, wait=1)
+        assert result is None, "Failed"
+
+    router.vtysh_cmd(
+        """
+        configure terminal
+         segment-routing
+          srv6
+           static-sids
+            sid fcbb:bbbb:1::/48 locator MAIN behavior uN
+            sid fcbb:bbbb:1:fe20::/64 locator MAIN behavior uDT6 vrf Vrf20
+        """
+    )
+
+    # FOR DEVELOPER:
+    # If you want to stop some specific line and start interactive shell,
+    # please use tgen.mininet_cli() to start it.
+
+    logger.info("Test for srv6 sids configuration")
+    check_srv6_static_sids(router, "expected_srv6_sids.json")
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))


### PR DESCRIPTION
When a user wants to delete a specific SRv6 SID, he executes the `no sid X:X::X:X/M` command.
However, by mistake, in addition to deleting the SID requested by the user, this command also removes all other SIDs.

This happens because `no sid X:X::X:X/M` triggers a destroy operation on the wrong xpath `frr-staticd:staticd/segment-routing/srv6`.

This commit fixes the issue by replacing the wrong xpath `frr-staticd:staticd/segment-routing/srv6` with the correct xpath `frr-staticd:staticd/segment-routing/srv6/static-sids/sid[sid='%s']`.

This ensures that the `no sid X:X::X:X/M` command only deletes the SID that was requested by the user.