### PR TITLE
bgpd: fix route-distinguisher in vrf leak json cmd

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -16686,9 +16686,9 @@ static int bgp_show_route_leak_vty(struct vty *vty, const char *name,
 						json_object_new_string(vname));
 			json_object_object_add(json, "exportToVrfs",
 					       json_export_vrfs);
-			json_object_string_addf(
-				json, "routeDistinguisher", "%s",
-				bgp->vpn_policy[afi].tovpn_rd_pretty);
+			json_object_string_addf(json, "routeDistinguisher",
+						BGP_RD_AS_FORMAT(bgp->asnotation),
+						&bgp->vpn_policy[afi].tovpn_rd);
 			dir = BGP_VPN_POLICY_DIR_TOVPN;
 			if (bgp->vpn_policy[afi].rtlist[dir]) {
 				ecom_str = ecommunity_ecom2str(


### PR DESCRIPTION
For auto configured value RD value comes as NULL,
switching back to original change will ensure to cover for both auto and user configured RD value in JSON.

```
tor-11# show bgp vrf blue ipv4 unicast route-leak json {
  "vrf":"blue",
  "afiSafi":"ipv4Unicast",
  "importFromVrfs":[
    "purple"
  ],
  "importRts":"10.10.3.11:6",
  "exportToVrfs":[
    "purple"
  ],
  "routeDistinguisher":"(null)", <<<<<
  "exportRts":"10.10.3.11:10"
}
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>
