### PR TITLE
bgpd: Fix up memory leak in processing eoiu marker

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4120,6 +4120,9 @@ static void process_eoiu_marker(struct bgp_dest *dest)
 			   subqueue2str(META_QUEUE_EOIU_MARKER));
 
 	bgp_process_main_one(info->bgp, NULL, 0, 0);
+
+	XFREE(MTYPE_BGP_EOIU_MARKER_INFO, info);
+	XFREE(MTYPE_BGP_NODE, dest);
 }
 
 /*
@@ -4310,6 +4313,7 @@ static void eoiu_marker_queue_free(struct meta_queue *mq, struct bgp_dest_queue 
 		XFREE(MTYPE_BGP_EOIU_MARKER_INFO, dest->info);
 		STAILQ_REMOVE_HEAD(l, pq);
 		STAILQ_NEXT(dest, pq) = NULL; /* complete unlink */
+		XFREE(MTYPE_BGP_NODE, dest);
 		mq->size--;
 	}
 }


### PR DESCRIPTION
Memory is being leaked when processing the eoiu marker. BGP is creating a dummy dest to contain the data but it was never freed.  As well as the eoiu info was
not being freed either.