### PR TITLE
bgpd: Recent failed backports for 10.1

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -1202,6 +1202,7 @@ int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 	mpls_label_t label;
 	struct in_addr vtep_ip;
 	struct prefix_evpn p;
+	uint8_t num_labels = 0;
 
 	if (psize != BGP_EVPN_TYPE1_PSIZE) {
 		flog_err(EC_BGP_EVPN_ROUTE_INVALID,
@@ -1226,6 +1227,7 @@ int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 	pfx += EVPN_ETH_TAG_BYTES;
 
 	memcpy(&label, pfx, BGP_LABEL_BYTES);
+	num_labels++;
 
 	/* EAD route prefix doesn't include the nexthop in the global
 	 * table
@@ -1234,13 +1236,11 @@ int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 	build_evpn_type1_prefix(&p, eth_tag, &esi, vtep_ip);
 	/* Process the route. */
 	if (attr) {
-		bgp_update(peer, (struct prefix *)&p, addpath_id, attr, afi,
-			   safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, NULL,
-			   0, 0, NULL);
+		bgp_update(peer, (struct prefix *)&p, addpath_id, attr, afi, safi, ZEBRA_ROUTE_BGP,
+			   BGP_ROUTE_NORMAL, &prd, &label, num_labels, 0, NULL);
 	} else {
-		bgp_withdraw(peer, (struct prefix *)&p, addpath_id, afi, safi,
-			     ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, NULL, 0,
-			     NULL);
+		bgp_withdraw(peer, (struct prefix *)&p, addpath_id, afi, safi, ZEBRA_ROUTE_BGP,
+			     BGP_ROUTE_NORMAL, &prd, &label, num_labels, NULL);
 	}
 	return 0;
 }

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -603,6 +603,7 @@ const char *const peer_down_str[] = {
 	"Socket Error",
 	"Admin. shutdown (RTT)",
 	"Suppress Fib Turned On or Off",
+	"Router ID is missing",
 };
 
 static void bgp_graceful_restart_timer_off(struct peer_connection *connection,

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -568,7 +568,7 @@ static void bgp_accept(struct event *thread)
 
 	/* Do not try to reconnect if the peer reached maximum
 	 * prefixes, restart timer is still running or the peer
-	 * is shutdown.
+	 * is shutdown, or BGP identifier is not set (0.0.0.0).
 	 */
 	if (BGP_PEER_START_SUPPRESSED(peer1)) {
 		if (bgp_debug_neighbor_events(peer1)) {
@@ -581,6 +581,14 @@ static void bgp_accept(struct event *thread)
 					"[Event] Incoming BGP connection rejected from %s due to maximum-prefix or shutdown",
 					peer1->host);
 		}
+		close(bgp_sock);
+		return;
+	}
+
+	if (peer1->bgp->router_id.s_addr == INADDR_ANY) {
+		zlog_warn("[Event] Incoming BGP connection rejected from %s due missing BGP identifier, set it with `bgp router-id`",
+			  peer1->host);
+		peer1->last_reset = PEER_DOWN_ROUTER_ID_ZERO;
 		close(bgp_sock);
 		return;
 	}
@@ -769,6 +777,13 @@ int bgp_connect(struct peer_connection *connection)
 	assert(!CHECK_FLAG(connection->thread_flags, PEER_THREAD_WRITES_ON));
 	assert(!CHECK_FLAG(connection->thread_flags, PEER_THREAD_READS_ON));
 	ifindex_t ifindex = 0;
+
+	if (peer->bgp->router_id.s_addr == INADDR_ANY) {
+		peer->last_reset = PEER_DOWN_ROUTER_ID_ZERO;
+		zlog_warn("%s: BGP identifier is missing for peer %s, set it with `bgp router-id`",
+			  __func__, peer->host);
+		return connect_error;
+	}
 
 	if (peer->conf_if && BGP_CONNECTION_SU_UNSPEC(connection)) {
 		if (bgp_debug_neighbor_events(peer))

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3623,19 +3623,24 @@ struct bgp *bgp_lookup(as_t as, const char *name)
 }
 
 /* Lookup BGP structure by view name. */
-struct bgp *bgp_lookup_by_name(const char *name)
+struct bgp *bgp_lookup_by_name_filter(const char *name, bool filter_auto)
 {
 	struct bgp *bgp;
 	struct listnode *node, *nnode;
 
 	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
-		if (CHECK_FLAG(bgp->vrf_flags, BGP_VRF_AUTO))
+		if (filter_auto && CHECK_FLAG(bgp->vrf_flags, BGP_VRF_AUTO))
 			continue;
 		if ((bgp->name == NULL && name == NULL)
 		    || (bgp->name && name && strcmp(bgp->name, name) == 0))
 			return bgp;
 	}
 	return NULL;
+}
+
+struct bgp *bgp_lookup_by_name(const char *name)
+{
+	return bgp_lookup_by_name_filter(name, true);
 }
 
 /* Lookup BGP instance based on VRF id. */

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3623,24 +3623,19 @@ struct bgp *bgp_lookup(as_t as, const char *name)
 }
 
 /* Lookup BGP structure by view name. */
-struct bgp *bgp_lookup_by_name_filter(const char *name, bool filter_auto)
+struct bgp *bgp_lookup_by_name(const char *name)
 {
 	struct bgp *bgp;
 	struct listnode *node, *nnode;
 
 	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
-		if (filter_auto && CHECK_FLAG(bgp->vrf_flags, BGP_VRF_AUTO))
+		if (CHECK_FLAG(bgp->vrf_flags, BGP_VRF_AUTO))
 			continue;
 		if ((bgp->name == NULL && name == NULL)
 		    || (bgp->name && name && strcmp(bgp->name, name) == 0))
 			return bgp;
 	}
 	return NULL;
-}
-
-struct bgp *bgp_lookup_by_name(const char *name)
-{
-	return bgp_lookup_by_name_filter(name, true);
 }
 
 /* Lookup BGP instance based on VRF id. */
@@ -3735,7 +3730,7 @@ int bgp_lookup_by_as_name_type(struct bgp **bgp_val, as_t *as, const char *name,
 
 	/* Multiple instance check. */
 	if (name)
-		bgp = bgp_lookup_by_name_filter(name, false);
+		bgp = bgp_lookup_by_name(name);
 	else
 		bgp = bgp_get_default();
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1801,6 +1801,7 @@ struct peer {
 #define PEER_DOWN_SOCKET_ERROR          34U /* Some socket error happened */
 #define PEER_DOWN_RTT_SHUTDOWN          35U /* Automatically shutdown due to RTT */
 #define PEER_DOWN_SUPPRESS_FIB_PENDING	 36U /* Suppress fib pending changed */
+#define PEER_DOWN_ROUTER_ID_ZERO	 37U /* router-id is 0.0.0.0 */
 	/*
 	 * Remember to update peer_down_str in bgp_fsm.c when you add
 	 * a new value to the last_reset reason


### PR DESCRIPTION
=> Reverted https://github.com/FRRouting/frr/pull/18016/commits/daa68852a2a78acf103e8ae1127953b2870c6772 because it was merged with failed status.