### PR TITLE
bgpd: Do not start BGP session if BGP identifier is not set (backport)

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -600,6 +600,7 @@ const char *const peer_down_str[] = {
 	"Socket Error",
 	"Admin. shutdown (RTT)",
 	"Suppress Fib Turned On or Off",
+	"Router ID is missing",
 };
 
 static void bgp_graceful_restart_timer_off(struct peer_connection *connection,

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -568,7 +568,7 @@ static void bgp_accept(struct event *thread)
 
 	/* Do not try to reconnect if the peer reached maximum
 	 * prefixes, restart timer is still running or the peer
-	 * is shutdown.
+	 * is shutdown, or BGP identifier is not set (0.0.0.0).
 	 */
 	if (BGP_PEER_START_SUPPRESSED(peer1)) {
 		if (bgp_debug_neighbor_events(peer1)) {
@@ -581,6 +581,14 @@ static void bgp_accept(struct event *thread)
 					"[Event] Incoming BGP connection rejected from %s due to maximum-prefix or shutdown",
 					peer1->host);
 		}
+		close(bgp_sock);
+		return;
+	}
+
+	if (peer1->bgp->router_id.s_addr == INADDR_ANY) {
+		zlog_warn("[Event] Incoming BGP connection rejected from %s due missing BGP identifier, set it with `bgp router-id`",
+			  peer1->host);
+		peer1->last_reset = PEER_DOWN_ROUTER_ID_ZERO;
 		close(bgp_sock);
 		return;
 	}
@@ -769,6 +777,13 @@ int bgp_connect(struct peer_connection *connection)
 	assert(!CHECK_FLAG(connection->thread_flags, PEER_THREAD_WRITES_ON));
 	assert(!CHECK_FLAG(connection->thread_flags, PEER_THREAD_READS_ON));
 	ifindex_t ifindex = 0;
+
+	if (peer->bgp->router_id.s_addr == INADDR_ANY) {
+		peer->last_reset = PEER_DOWN_ROUTER_ID_ZERO;
+		zlog_warn("%s: BGP identifier is missing for peer %s, set it with `bgp router-id`",
+			  __func__, peer->host);
+		return connect_error;
+	}
 
 	if (peer->conf_if && BGP_CONNECTION_SU_UNSPEC(connection)) {
 		if (bgp_debug_neighbor_events(peer))

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1768,6 +1768,7 @@ struct peer {
 #define PEER_DOWN_SOCKET_ERROR          34U /* Some socket error happened */
 #define PEER_DOWN_RTT_SHUTDOWN          35U /* Automatically shutdown due to RTT */
 #define PEER_DOWN_SUPPRESS_FIB_PENDING	 36U /* Suppress fib pending changed */
+#define PEER_DOWN_ROUTER_ID_ZERO	 37U /* router-id is 0.0.0.0 */
 	/*
 	 * Remember to update peer_down_str in bgp_fsm.c when you add
 	 * a new value to the last_reset reason


### PR DESCRIPTION
If we have IPv6-only network and no IPv4 addresses at all, then by default 0.0.0.0 is created which is treated as malformed according to RFC 6286.