### PR TITLE
lib: fix false context information for SRv6 route

### DIFF
--- a/lib/srv6.c
+++ b/lib/srv6.c
@@ -76,7 +76,6 @@ void seg6local_context2json(const struct seg6local_context *ctx,
 {
 	switch (action) {
 	case ZEBRA_SEG6_LOCAL_ACTION_END:
-		json_object_boolean_add(json, "USP", true);
 		return;
 	case ZEBRA_SEG6_LOCAL_ACTION_END_X:
 	case ZEBRA_SEG6_LOCAL_ACTION_END_DX6:
@@ -116,7 +115,7 @@ const char *seg6local_context2str(char *str, size_t size,
 	switch (action) {
 
 	case ZEBRA_SEG6_LOCAL_ACTION_END:
-		snprintf(str, size, "USP");
+		snprintf(str, size, "-");
 		return str;
 
 	case ZEBRA_SEG6_LOCAL_ACTION_END_X:


### PR DESCRIPTION
The seg6local route dumped by 'show ipv6 route' makes think that the USP flavor is supported, whereas it is not the case. This information is a context information, and for End, the context information should be empty.

> # show ipv6 route
> [..]
> I>* fc00:0:4::/128 [115/0] is directly connected, sr0, seg6local End USP, weight 1, 00:49:01

Fix this by suppressing the USP information from the output.

Fixes: e496b4203055 ("bgpd: prefix-sid srv6 l3vpn service tlv")