### PR TITLE
zebra: reduce memory usage by streams when redistributing routes

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1326,6 +1326,24 @@ enum zclient_send_status zclient_nhg_send(struct zclient *zclient, int cmd,
 	return zclient_send_message(zclient);
 }
 
+/* size needed by a stream for redistributing a route */
+int zapi_redistribute_stream_size(struct zapi_route *api)
+{
+	size_t msg_size = 0;
+	size_t nh_size = sizeof(struct zapi_nexthop);
+
+	msg_size = sizeof(struct zapi_route);
+	/* remove unused nexthop structures */
+	msg_size -= (MULTIPATH_NUM - api->nexthop_num) * nh_size;
+	/* remove unused backup nexthop structures */
+	msg_size -= (MULTIPATH_NUM - api->backup_nexthop_num) * nh_size;
+	/* remove unused opaque values */
+	msg_size -= ZAPI_MESSAGE_OPAQUE_LENGTH - api->opaque.length;
+
+	return msg_size;
+}
+
+
 int zapi_route_encode(uint8_t cmd, struct stream *s, struct zapi_route *api)
 {
 	struct zapi_nexthop *api_nh;

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -1158,6 +1158,7 @@ zclient_send_rnh(struct zclient *zclient, int command, const struct prefix *p,
 		 vrf_id_t vrf_id);
 int zapi_nexthop_encode(struct stream *s, const struct zapi_nexthop *api_nh,
 			uint32_t api_flags, uint32_t api_message);
+extern int zapi_redistribute_stream_size(struct zapi_route *api);
 extern int zapi_route_encode(uint8_t, struct stream *, struct zapi_route *);
 extern int zapi_route_decode(struct stream *s, struct zapi_route *api);
 extern int zapi_nexthop_decode(struct stream *s, struct zapi_nexthop *api_nh,

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -518,8 +518,7 @@ int zsend_redistribute_route(int cmd, struct zserv *client, const struct route_n
 	const struct prefix *p, *src_p;
 	uint16_t count = 0;
 	afi_t afi;
-	size_t stream_size =
-		MAX(ZEBRA_MAX_PACKET_SIZ, sizeof(struct zapi_route));
+	size_t stream_size = 0;
 
 	srcdest_rnode_prefixes(rn, &p, &src_p);
 	memset(&api, 0, sizeof(api));
@@ -611,6 +610,7 @@ int zsend_redistribute_route(int cmd, struct zserv *client, const struct route_n
 	SET_FLAG(api.message, ZAPI_MESSAGE_MTU);
 	api.mtu = re->mtu;
 
+	stream_size = zapi_redistribute_stream_size(&api);
 	struct stream *s = stream_new(stream_size);
 
 	/* Encode route and send. */


### PR DESCRIPTION
required stream size is evaluated as a fix part and variable one. the variable one depend on the number of nexthops.