### PR TITLE
isisd: Do not leak a linked list in the circuit

### DIFF
--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -840,12 +840,10 @@ void isis_circuit_down(struct isis_circuit *circuit)
 		if (circuit->u.bc.adjdb[0]) {
 			circuit->u.bc.adjdb[0]->del = isis_delete_adj;
 			list_delete(&circuit->u.bc.adjdb[0]);
-			circuit->u.bc.adjdb[0] = NULL;
 		}
 		if (circuit->u.bc.adjdb[1]) {
 			circuit->u.bc.adjdb[1]->del = isis_delete_adj;
 			list_delete(&circuit->u.bc.adjdb[1]);
-			circuit->u.bc.adjdb[1] = NULL;
 		}
 		if (circuit->u.bc.is_dr[0]) {
 			isis_dr_resign(circuit, 1);

--- a/isisd/isis_events.c
+++ b/isisd/isis_events.c
@@ -83,7 +83,8 @@ static void circuit_commence_level(struct isis_circuit *circuit, int level)
 
 		send_hello_sched(circuit, level, TRIGGERED_IIH_DELAY);
 		circuit->u.bc.lan_neighs[level - 1] = list_new();
-		circuit->u.bc.adjdb[level - 1] = list_new();
+		if (!circuit->u.bc.adjdb[level - 1])
+			circuit->u.bc.adjdb[level - 1] = list_new();
 	}
 }
 


### PR DESCRIPTION
Address sanitizer was telling us that linked lists were being leaked.  No need to do so.