### PR TITLE
isisd: Remove unneeded modify functions

### DIFF
--- a/isisd/isis_nb.c
+++ b/isisd/isis_nb.c
@@ -561,12 +561,6 @@ const struct frr_yang_module_info frr_isisd_info = {
 			}
 		},
 		{
-			.xpath = "/frr-isisd:isis/instance/fast-reroute/level-1/lfa/tiebreaker/type",
-			.cbs = {
-				.modify = isis_instance_fast_reroute_level_1_lfa_tiebreaker_type_modify,
-			}
-		},
-		{
 			.xpath = "/frr-isisd:isis/instance/fast-reroute/level-1/remote-lfa/prefix-list",
 			.cbs = {
 				.cli_show = cli_show_isis_frr_remote_lfa_plist,
@@ -595,12 +589,6 @@ const struct frr_yang_module_info frr_isisd_info = {
 				.cli_show = cli_show_isis_frr_lfa_tiebreaker,
 				.create = isis_instance_fast_reroute_level_2_lfa_tiebreaker_create,
 				.destroy = isis_instance_fast_reroute_level_2_lfa_tiebreaker_destroy,
-			}
-		},
-		{
-			.xpath = "/frr-isisd:isis/instance/fast-reroute/level-2/lfa/tiebreaker/type",
-			.cbs = {
-				.modify = isis_instance_fast_reroute_level_2_lfa_tiebreaker_type_modify,
 			}
 		},
 		{

--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -1763,26 +1763,6 @@ int isis_instance_fast_reroute_level_1_lfa_tiebreaker_destroy(
 }
 
 /*
- * XPath: /frr-isisd:isis/instance/fast-reroute/level-1/lfa/tiebreaker/type
- */
-int isis_instance_fast_reroute_level_1_lfa_tiebreaker_type_modify(
-	struct nb_cb_modify_args *args)
-{
-	struct lfa_tiebreaker *tie_b;
-	struct isis_area *area;
-
-	if (args->event != NB_EV_APPLY)
-		return NB_OK;
-
-	tie_b = nb_running_get_entry(args->dnode, NULL, true);
-	area = tie_b->area;
-	tie_b->type = yang_dnode_get_enum(args->dnode, NULL);
-	lsp_regenerate_schedule(area, area->is_type, 0);
-
-	return NB_OK;
-}
-
-/*
  * XPath: /frr-isisd:isis/instance/fast-reroute/level-1/remote-lfa/prefix-list
  */
 int isis_instance_fast_reroute_level_1_remote_lfa_prefix_list_modify(
@@ -1906,26 +1886,6 @@ int isis_instance_fast_reroute_level_2_lfa_tiebreaker_destroy(
 	tie_b = nb_running_unset_entry(args->dnode);
 	area = tie_b->area;
 	isis_lfa_tiebreaker_delete(area, ISIS_LEVEL2, tie_b);
-	lsp_regenerate_schedule(area, area->is_type, 0);
-
-	return NB_OK;
-}
-
-/*
- * XPath: /frr-isisd:isis/instance/fast-reroute/level-2/lfa/tiebreaker/type
- */
-int isis_instance_fast_reroute_level_2_lfa_tiebreaker_type_modify(
-	struct nb_cb_modify_args *args)
-{
-	struct lfa_tiebreaker *tie_b;
-	struct isis_area *area;
-
-	if (args->event != NB_EV_APPLY)
-		return NB_OK;
-
-	tie_b = nb_running_get_entry(args->dnode, NULL, true);
-	area = tie_b->area;
-	tie_b->type = yang_dnode_get_enum(args->dnode, NULL);
 	lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;


### PR DESCRIPTION
Our infrastructure was complaining about this:

2025/02/05 19:38:42 ISIS: [ZKB8W-3S2Q4][EC 100663330] unneeded 'modify' callback for '/frr-isisd:isis/instance/fast-reroute/level-1/lfa/tiebreaker/type'
2025/02/05 19:38:42 ISIS: [ZKB8W-3S2Q4][EC 100663330] unneeded 'modify' callback for '/frr-isisd:isis/instance/fast-reroute/level-2/lfa/tiebreaker/type'

Seems we don't need it.  Let's just remove it.