### PR TITLE
Stabilize 10.1 branch

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -325,7 +325,7 @@ static int bgp_vrf_disable(struct vrf *vrf)
 	if (BGP_DEBUG(zebra, ZEBRA))
 		zlog_debug("VRF disable %s id %d", vrf->name, vrf->vrf_id);
 
-	bgp = bgp_lookup_by_name_filter(vrf->name, false);
+	bgp = bgp_lookup_by_name(vrf->name);
 	if (bgp) {
 
 		vpn_leak_zebra_vrf_label_withdraw(bgp, AFI_IP);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10440,7 +10440,7 @@ DEFPY(bgp_imexport_vrf, bgp_imexport_vrf_cmd,
 		}
 	}
 
-	vrf_bgp = bgp_lookup_by_name_filter(import_name, false);
+	vrf_bgp = bgp_lookup_by_name(import_name);
 	if (!vrf_bgp) {
 		if (strcmp(import_name, VRF_DEFAULT_NAME) == 0) {
 			vrf_bgp = bgp_default;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3623,24 +3623,19 @@ struct bgp *bgp_lookup(as_t as, const char *name)
 }
 
 /* Lookup BGP structure by view name. */
-static struct bgp *bgp_lookup_by_name_filter(const char *name, bool filter_auto)
+struct bgp *bgp_lookup_by_name(const char *name)
 {
 	struct bgp *bgp;
 	struct listnode *node, *nnode;
 
 	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
-		if (filter_auto && CHECK_FLAG(bgp->vrf_flags, BGP_VRF_AUTO))
+		if (CHECK_FLAG(bgp->vrf_flags, BGP_VRF_AUTO))
 			continue;
 		if ((bgp->name == NULL && name == NULL)
 		    || (bgp->name && name && strcmp(bgp->name, name) == 0))
 			return bgp;
 	}
 	return NULL;
-}
-
-struct bgp *bgp_lookup_by_name(const char *name)
-{
-	return bgp_lookup_by_name_filter(name, true);
 }
 
 /* Lookup BGP instance based on VRF id. */
@@ -3735,7 +3730,7 @@ int bgp_lookup_by_as_name_type(struct bgp **bgp_val, as_t *as, const char *name,
 
 	/* Multiple instance check. */
 	if (name)
-		bgp = bgp_lookup_by_name_filter(name, false);
+		bgp = bgp_lookup_by_name(name);
 	else
 		bgp = bgp_get_default();
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3623,19 +3623,24 @@ struct bgp *bgp_lookup(as_t as, const char *name)
 }
 
 /* Lookup BGP structure by view name. */
-struct bgp *bgp_lookup_by_name(const char *name)
+struct bgp *bgp_lookup_by_name_filter(const char *name, bool filter_auto)
 {
 	struct bgp *bgp;
 	struct listnode *node, *nnode;
 
 	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
-		if (CHECK_FLAG(bgp->vrf_flags, BGP_VRF_AUTO))
+		if (filter_auto && CHECK_FLAG(bgp->vrf_flags, BGP_VRF_AUTO))
 			continue;
 		if ((bgp->name == NULL && name == NULL)
 		    || (bgp->name && name && strcmp(bgp->name, name) == 0))
 			return bgp;
 	}
 	return NULL;
+}
+
+struct bgp *bgp_lookup_by_name(const char *name)
+{
+	return bgp_lookup_by_name_filter(name, true);
 }
 
 /* Lookup BGP instance based on VRF id. */
@@ -3730,7 +3735,7 @@ int bgp_lookup_by_as_name_type(struct bgp **bgp_val, as_t *as, const char *name,
 
 	/* Multiple instance check. */
 	if (name)
-		bgp = bgp_lookup_by_name(name);
+		bgp = bgp_lookup_by_name_filter(name, false);
 	else
 		bgp = bgp_get_default();
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3623,24 +3623,19 @@ struct bgp *bgp_lookup(as_t as, const char *name)
 }
 
 /* Lookup BGP structure by view name. */
-struct bgp *bgp_lookup_by_name_filter(const char *name, bool filter_auto)
+struct bgp *bgp_lookup_by_name(const char *name)
 {
 	struct bgp *bgp;
 	struct listnode *node, *nnode;
 
 	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
-		if (filter_auto && CHECK_FLAG(bgp->vrf_flags, BGP_VRF_AUTO))
+		if (CHECK_FLAG(bgp->vrf_flags, BGP_VRF_AUTO))
 			continue;
 		if ((bgp->name == NULL && name == NULL)
 		    || (bgp->name && name && strcmp(bgp->name, name) == 0))
 			return bgp;
 	}
 	return NULL;
-}
-
-struct bgp *bgp_lookup_by_name(const char *name)
-{
-	return bgp_lookup_by_name_filter(name, true);
 }
 
 /* Lookup BGP instance based on VRF id. */

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3623,7 +3623,7 @@ struct bgp *bgp_lookup(as_t as, const char *name)
 }
 
 /* Lookup BGP structure by view name. */
-struct bgp *bgp_lookup_by_name_filter(const char *name, bool filter_auto)
+static struct bgp *bgp_lookup_by_name_filter(const char *name, bool filter_auto)
 {
 	struct bgp *bgp;
 	struct listnode *node, *nnode;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2225,7 +2225,6 @@ extern void bgp_zclient_reset(void);
 extern struct bgp *bgp_get_default(void);
 extern struct bgp *bgp_lookup(as_t, const char *);
 extern struct bgp *bgp_lookup_by_name(const char *);
-extern struct bgp *bgp_lookup_by_name_filter(const char *name, bool filter_auto);
 extern struct bgp *bgp_lookup_by_vrf_id(vrf_id_t);
 extern struct bgp *bgp_get_evpn(void);
 extern void bgp_set_evpn(struct bgp *bgp);


### PR DESCRIPTION
Revert recent accidental merges (failed).

=> frrbot can be ignored, it does not understand `Reapply` commit prefix.