### PR TITLE
bgpd: rfapi: fix mem leak when killed

### DIFF
--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -4067,9 +4067,15 @@ static void rfapiProcessPeerDownRt(struct peer *peer,
 						bpi, import_table, afi, -1);
 					import_table->holddown_count[afi] += 1;
 				}
-				rfapiBiStartWithdrawTimer(import_table, rn, bpi,
-							  afi, safi,
-							  timer_service_func);
+				if (bm->terminating) {
+					if (safi == SAFI_MPLS_VPN)
+						rfapiExpireVpnNow(import_table, rn, bpi, 1);
+					else
+						rfapiExpireEncapNow(import_table, rn, bpi);
+
+				} else
+					rfapiBiStartWithdrawTimer(import_table, rn, bpi, afi, safi,
+								  timer_service_func);
 			}
 		}
 	}


### PR DESCRIPTION
Something changed in the bgpd termination sequence, leading to rfapi objects not being freed via their usual timed expiration pathway. This change frees rfapi peer BPIs immediately instead of expiring via timer when bgp is terminating.
