### PR TITLE
ospfd: Replace LSDB callbacks with LSA Update/Delete hooks.

### DIFF
--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -1284,76 +1284,67 @@ Debugging OSPF
 
 .. clicmd:: debug ospf [(1-65535)] client-api
 
-   Show debug information for the OSPF opaque data client API.
+   Enable or disable debugging for the OSPF opaque data client API.
 
 .. clicmd:: debug ospf [(1-65535)] default-information
 
-   Show debug information of default information
+   Enable or disable debugging of default information origination
 
 .. clicmd:: debug ospf [(1-65535)] packet (hello|dd|ls-request|ls-update|ls-ack|all) (send|recv) [detail]
 
-
-   Dump Packet for debugging
+   Enable or disable debugging for received and transmitted OSPF packets
 
 .. clicmd:: debug ospf [(1-65535)] ism [status|events|timers]
 
-
-
-   Show debug information of Interface State Machine
+   Enable or disable debugging of Interface State Machine
 
 .. clicmd:: debug ospf [(1-65535)] nsm [status|events|timers]
 
-
-
-   Show debug information of Network State Machine
+   Enable or disable debugging of Neighbor State Machine transitions
 
 .. clicmd:: debug ospf [(1-65535)] event
 
-
-   Show debug information of OSPF event
+   Enable or disable debugging of OSPF events
 
 .. clicmd:: debug ospf [(1-65535)] nssa
 
-
-   Show debug information about Not So Stub Area
+   Enable or disable debugging about Not-So-Stubby-Areas (NSSAs)
 
 .. clicmd:: debug ospf [(1-65535)] ldp-sync
 
-   Show debug information about LDP-Sync
+   Enable or disable debugging about LDP-Sync
 
 .. clicmd:: debug ospf [(1-65535)] lsa [aggregate|flooding|generate|install|refresh]
 
-
-
-   Show debug detail of Link State messages
+   Enable or disable detail debuggin of Link State Advertisements (LSAs)
 
 .. clicmd:: debug ospf [(1-65535)] sr
 
-   Show debug information about Segment Routing
+   Enable or disable debugging about Segment Routing
 
 .. clicmd:: debug ospf [(1-65535)] te
 
-
-   Show debug information about Traffic Engineering LSA
+   Enable or disable debugging about MPLS Traffic Engineering LSA
 
 .. clicmd:: debug ospf [(1-65535)] ti-lfa
 
-   Show debug information about SR TI-LFA
+   Enable or disable debugging about SR TI-LFA
 
 .. clicmd:: debug ospf [(1-65535)] zebra [interface|redistribute]
 
-
-
-   Show debug information of ZEBRA API
+   Enable or disable debugging of ZEBRA API
 
 .. clicmd:: debug ospf [(1-65535)] graceful-restart
 
+   Enable or disable debugying for OSPF Graceful Restart Helper
 
-   Enable/disable debug information for OSPF Graceful Restart Helper
+.. clicmd:: debug ospf [(1-65535)] graceful-restart
+
+   Enable or disable debugging for OSPF Opaque LSA processing
 
 .. clicmd:: show debugging ospf
 
-
+   Show enabled OSPF debugging options
 
 Sample Configuration
 ====================

--- a/ospfd/ospf_dump.h
+++ b/ospfd/ospf_dump.h
@@ -55,6 +55,8 @@
 
 #define OSPF_DEBUG_CLIENT_API 0x01
 
+#define OSPF_DEBUG_OPAQUE_LSA 0x01
+
 /* Macro for setting debug option. */
 #define CONF_DEBUG_PACKET_ON(a, b)	    conf_debug_ospf_packet[a] |= (b)
 #define CONF_DEBUG_PACKET_OFF(a, b)	    conf_debug_ospf_packet[a] &= ~(b)
@@ -106,6 +108,7 @@
 #define IS_DEBUG_OSPF_LDP_SYNC IS_DEBUG_OSPF(ldp_sync, LDP_SYNC)
 #define IS_DEBUG_OSPF_GR IS_DEBUG_OSPF(gr, GR)
 #define IS_DEBUG_OSPF_CLIENT_API IS_DEBUG_OSPF(client_api, CLIENT_API)
+#define IS_DEBUG_OSPF_OPAQUE_LSA IS_DEBUG_OSPF(opaque_lsa, OPAQUE_LSA)
 
 #define IS_CONF_DEBUG_OSPF_PACKET(a, b)                                        \
 	(conf_debug_ospf_packet[a] & OSPF_DEBUG_##b)
@@ -131,6 +134,7 @@ extern unsigned long term_debug_ospf_ldp_sync;
 extern unsigned long term_debug_ospf_gr;
 extern unsigned long term_debug_ospf_bfd;
 extern unsigned long term_debug_ospf_client_api;
+extern unsigned long term_debug_ospf_opaque_lsa;
 
 /* Message Strings. */
 extern char *ospf_lsa_type_str[];

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -363,4 +363,10 @@ static inline bool ospf_check_indication_lsa(struct ospf_lsa *lsa)
 
 	return false;
 }
+
+/*
+ * LSA Update and Delete Hook LSAs.
+ */
+DECLARE_HOOK(ospf_lsa_update, (struct ospf_lsa *lsa), (lsa));
+DECLARE_HOOK(ospf_lsa_delete, (struct ospf_lsa *lsa), (lsa));
 #endif /* _ZEBRA_OSPF_LSA_H */

--- a/ospfd/ospf_lsdb.c
+++ b/ospfd/ospf_lsdb.c
@@ -147,10 +147,6 @@ static void ospf_lsdb_delete_entry(struct ospf_lsdb *lsdb,
 
 	rn->info = NULL;
 	route_unlock_node(rn);
-#ifdef MONITOR_LSDB_CHANGE
-	if (lsdb->del_lsa_hook != NULL)
-		(*lsdb->del_lsa_hook)(lsa);
-#endif			       /* MONITOR_LSDB_CHANGE */
 	ospf_lsa_unlock(&lsa); /* lsdb */
 	return;
 }
@@ -187,10 +183,6 @@ void ospf_lsdb_add(struct ospf_lsdb *lsdb, struct ospf_lsa *lsa)
 	    CHECK_FLAG(lsa->data->options, OSPF_OPTION_DC))
 		lsa->area->fr_info.router_lsas_recv_dc_bit++;
 
-#ifdef MONITOR_LSDB_CHANGE
-	if (lsdb->new_lsa_hook != NULL)
-		(*lsdb->new_lsa_hook)(lsa);
-#endif /* MONITOR_LSDB_CHANGE */
 	lsdb->type[lsa->data->type].checksum += ntohs(lsa->data->checksum);
 	rn->info = ospf_lsa_lock(lsa); /* lsdb */
 }

--- a/ospfd/ospf_lsdb.h
+++ b/ospfd/ospf_lsdb.h
@@ -19,12 +19,6 @@ struct ospf_lsdb {
 		struct route_table *db;
 	} type[OSPF_MAX_LSA];
 	unsigned long total;
-#define MONITOR_LSDB_CHANGE 1 /* XXX */
-#ifdef MONITOR_LSDB_CHANGE
-	/* Hooks for callback functions to catch every add/del event. */
-	int (*new_lsa_hook)(struct ospf_lsa *);
-	int (*del_lsa_hook)(struct ospf_lsa *);
-#endif /* MONITOR_LSDB_CHANGE */
 };
 
 /* Macros. */


### PR DESCRIPTION
Replace the LSDB callbacks with LSA update and delete hooks using the
the FRR hook mechanism. Remove redundant callbacks by placing the LSA
update and delete hooks in a single place so that deletes don't need
to be handled by the update hook. Simplify existing OSPF TE and OSPF
API Server callbacks now that there is no ambiguity or redundancy.
Also cleanup the debugging by separating out opaque-lsa debugging
from the overloaded event debugging.