### PR TITLE
lib: crash handlers must be allowed on threads

### DIFF
--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -20,6 +20,7 @@
 #include "zlog.h"
 #include "libfrr.h"
 #include "libfrr_trace.h"
+#include "sigevent.h"
 
 DEFINE_MTYPE_STATIC(LIB, FRR_PTHREAD, "FRR POSIX Thread");
 DEFINE_MTYPE_STATIC(LIB, PTHREAD_PRIM, "POSIX sync primitives");
@@ -185,10 +186,9 @@ int frr_pthread_run(struct frr_pthread *fpt, const pthread_attr_t *attr)
 
 	assert(frr_is_after_fork || !"trying to start thread before fork()");
 
-	/* Ensure we never handle signals on a background thread by blocking
-	 * everything here (new thread inherits signal mask)
-	 */
-	sigfillset(&blocksigs);
+	sigemptyset(&blocksigs);
+	frr_sigset_add_mainonly(&blocksigs);
+	/* new thread inherits mask */
 	pthread_sigmask(SIG_BLOCK, &blocksigs, &oldsigs);
 
 	frrtrace(1, frr_libfrr, frr_pthread_run, fpt->name);

--- a/lib/sigevent.h
+++ b/lib/sigevent.h
@@ -45,6 +45,33 @@ bool frr_sigevent_check(sigset_t *setp);
 /* check whether there are signals to handle, process any found */
 extern int frr_sigevent_process(void);
 
+/* Ensure we don't handle "application-type" signals on a secondary thread by
+ * blocking these signals when creating threads
+ *
+ * NB: SIGSEGV, SIGABRT, etc. must be allowed on all threads or we get no
+ * crashlogs.  Since signals vary a little bit between platforms, below is a
+ * list of known things to go to the main thread.  Any unknown signals should
+ * stay thread-local.
+ */
+static inline void frr_sigset_add_mainonly(sigset_t *blocksigs)
+{
+	/* signals we actively handle */
+	sigaddset(blocksigs, SIGHUP);
+	sigaddset(blocksigs, SIGINT);
+	sigaddset(blocksigs, SIGTERM);
+	sigaddset(blocksigs, SIGUSR1);
+
+	/* signals we don't actively use but that semantically belong */
+	sigaddset(blocksigs, SIGUSR2);
+	sigaddset(blocksigs, SIGQUIT);
+	sigaddset(blocksigs, SIGCHLD);
+	sigaddset(blocksigs, SIGPIPE);
+	sigaddset(blocksigs, SIGTSTP);
+	sigaddset(blocksigs, SIGTTIN);
+	sigaddset(blocksigs, SIGTTOU);
+	sigaddset(blocksigs, SIGWINCH);
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
You can have the prettiest crash handler on the planet, if you go and mask SIGSEGV on a thread before it segfaults… YOU GET NOTHING, YOU LOSE, GOOD DAY SIR.

(The process just up and hard exits.)

…let's see which of our CI systems don't recognize which of the signals I listed in here…