### PR TITLE
Cid 1636504

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -1201,7 +1201,6 @@ int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 	mpls_label_t label;
 	struct in_addr vtep_ip;
 	struct prefix_evpn p;
-	uint8_t num_labels = 0;
 
 	if (psize != BGP_EVPN_TYPE1_PSIZE) {
 		flog_err(EC_BGP_EVPN_ROUTE_INVALID,
@@ -1226,7 +1225,6 @@ int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 	pfx += EVPN_ETH_TAG_BYTES;
 
 	memcpy(&label, pfx, BGP_LABEL_BYTES);
-	num_labels++;
 
 	/* EAD route prefix doesn't include the nexthop in the global
 	 * table
@@ -1236,10 +1234,10 @@ int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 	/* Process the route. */
 	if (attr) {
 		bgp_update(peer, (struct prefix *)&p, addpath_id, attr, afi, safi, ZEBRA_ROUTE_BGP,
-			   BGP_ROUTE_NORMAL, &prd, &label, num_labels, 0, NULL);
+			   BGP_ROUTE_NORMAL, &prd, &label, 1, 0, NULL);
 	} else {
 		bgp_withdraw(peer, (struct prefix *)&p, addpath_id, afi, safi, ZEBRA_ROUTE_BGP,
-			     BGP_ROUTE_NORMAL, &prd, &label, num_labels);
+			     BGP_ROUTE_NORMAL, &prd, &label, 1);
 	}
 	return 0;
 }

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -1198,7 +1198,7 @@ int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 	struct prefix_rd prd;
 	esi_t esi;
 	uint32_t eth_tag;
-	mpls_label_t label;
+	mpls_label_t label[BGP_MAX_LABELS] = {};
 	struct in_addr vtep_ip;
 	struct prefix_evpn p;
 
@@ -1224,7 +1224,7 @@ int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 	eth_tag = ntohl(eth_tag);
 	pfx += EVPN_ETH_TAG_BYTES;
 
-	memcpy(&label, pfx, BGP_LABEL_BYTES);
+	memcpy(&label[0], pfx, BGP_LABEL_BYTES);
 
 	/* EAD route prefix doesn't include the nexthop in the global
 	 * table
@@ -1234,10 +1234,10 @@ int bgp_evpn_type1_route_process(struct peer *peer, afi_t afi, safi_t safi,
 	/* Process the route. */
 	if (attr) {
 		bgp_update(peer, (struct prefix *)&p, addpath_id, attr, afi, safi, ZEBRA_ROUTE_BGP,
-			   BGP_ROUTE_NORMAL, &prd, &label, 1, 0, NULL);
+			   BGP_ROUTE_NORMAL, &prd, &label[0], 1, 0, NULL);
 	} else {
 		bgp_withdraw(peer, (struct prefix *)&p, addpath_id, afi, safi, ZEBRA_ROUTE_BGP,
-			     BGP_ROUTE_NORMAL, &prd, &label, 1);
+			     BGP_ROUTE_NORMAL, &prd, &label[0], 1);
 	}
 	return 0;
 }


### PR DESCRIPTION
The following static analysis can be seen :

```
> *** CID 1636504:    (ARRAY_VS_SINGLETON)
> /bgpd/bgp_evpn_mh.c: 1241 in bgp_evpn_type1_route_process()
> 1235            build_evpn_type1_prefix(&p, eth_tag, &esi, vtep_ip);
> 1236            /* Process the route. */
> 1237            if (attr) {
> 1238                    bgp_update(peer, (struct prefix *)&p, addpath_id, attr, afi, safi, ZEBRA_ROUTE_BGP,
> 1239                               BGP_ROUTE_NORMAL, &prd, &label, num_labels, 0, NULL);
> 1240            } else {
> >>>     CID 1636504:    (ARRAY_VS_SINGLETON)
> >>>     Passing "&label" to function "bgp_withdraw" which uses it as an array. This might corrupt or misinterpret adjacent memory locations.
> 1241                    bgp_withdraw(peer, (struct prefix *)&p, addpath_id, afi, safi, ZEBRA_ROUTE_BGP,
> 1242                                 BGP_ROUTE_NORMAL, &prd, &label, num_labels);
> 1243            }
> 1244            return 0;
> 1245     }
> 1246     
> /bgpd/bgp_evpn_mh.c: 1238 in bgp_evpn_type1_route_process()
> 1232             * table
> 1233             */
> 1234            vtep_ip.s_addr = INADDR_ANY;
> 1235            build_evpn_type1_prefix(&p, eth_tag, &esi, vtep_ip);
> 1236            /* Process the route. */
> 1237            if (attr) {
> >>>     CID 1636504:    (ARRAY_VS_SINGLETON)
> >>>     Passing "&label" to function "bgp_update" which uses it as an array. This might corrupt or misinterpret adjacent memory locations.
> 1238                    bgp_update(peer, (struct prefix *)&p, addpath_id, attr, afi, safi, ZEBRA_ROUTE_BGP,
> 1239                               BGP_ROUTE_NORMAL, &prd, &label, num_labels, 0, NULL);
> 1240            } else {
> 1241                    bgp_withdraw(peer, (struct prefix *)&p, addpath_id, afi, safi, ZEBRA_ROUTE_BGP,
> 1242                                 BGP_ROUTE_NORMAL, &prd, &label, num_labels);
> 1243            }
```

Fix this by declaring a label array instead of a single array.
