### PR TITLE
staticd: Fix SRv6 SID installation and deletion

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -1153,6 +1153,7 @@ void nexthop_json_helper(json_object *json_nexthop,
 	json_object *json_backups = NULL;
 	json_object *json_seg6local = NULL;
 	json_object *json_seg6local_context = NULL;
+	json_object *json_srv6_sid_structure = NULL;
 	json_object *json_seg6 = NULL;
 	json_object *json_segs = NULL;
 	int i;
@@ -1327,6 +1328,10 @@ void nexthop_json_helper(json_object *json_nexthop,
 				       json_seg6local_context);
 		json_object_object_add(json_nexthop, "seg6localContext",
 				       json_seg6local_context);
+
+		json_srv6_sid_structure = json_object_new_object();
+		srv6_sid_structure2json(&nexthop->nh_srv6->seg6local_ctx, json_srv6_sid_structure);
+		json_object_object_add(json_seg6local, "sidStructure", json_srv6_sid_structure);
 
 		if (nexthop->nh_srv6->seg6_segs &&
 		    nexthop->nh_srv6->seg6_segs->num_segs == 1) {

--- a/lib/srv6.c
+++ b/lib/srv6.c
@@ -71,6 +71,14 @@ int snprintf_seg6_segs(char *str,
 	return strlen(str);
 }
 
+void srv6_sid_structure2json(const struct seg6local_context *ctx, json_object *json)
+{
+	json_object_int_add(json, "blockLen", ctx->block_len);
+	json_object_int_add(json, "nodeLen", ctx->node_len);
+	json_object_int_add(json, "funcLen", ctx->function_len);
+	json_object_int_add(json, "argLen", ctx->argument_len);
+}
+
 void seg6local_context2json(const struct seg6local_context *ctx,
 			    uint32_t action, json_object *json)
 {

--- a/lib/srv6.h
+++ b/lib/srv6.h
@@ -363,6 +363,7 @@ const char *seg6local_context2str(char *str, size_t size,
 				  uint32_t action);
 void seg6local_context2json(const struct seg6local_context *ctx,
 			    uint32_t action, json_object *json);
+void srv6_sid_structure2json(const struct seg6local_context *ctx, json_object *json);
 
 static inline const char *srv6_sid_ctx2str(char *str, size_t size,
 					   const struct srv6_sid_ctx *ctx)

--- a/tests/topotests/static_srv6_sids/expected_srv6_sids.json
+++ b/tests/topotests/static_srv6_sids/expected_srv6_sids.json
@@ -25,7 +25,13 @@
 					"active": true,
 					"weight": 1,
 					"seg6local": {
-						"action": "End"
+						"action": "End",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 0,
+							"argLen": 0
+						}
 					},
 					"seg6localContext": {
 
@@ -60,7 +66,13 @@
 					"active": true,
 					"weight": 1,
 					"seg6local": {
-						"action": "End.DT4"
+						"action": "End.DT4",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
 					},
 					"seg6localContext": {
 						"table": 10
@@ -95,7 +107,13 @@
 					"active": true,
 					"weight": 1,
 					"seg6local": {
-						"action": "End.DT6"
+						"action": "End.DT6",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
 					},
 					"seg6localContext": {
 						"table": 20
@@ -130,7 +148,13 @@
 					"active": true,
 					"weight": 1,
 					"seg6local": {
-						"action": "End.DT46"
+						"action": "End.DT46",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
 					},
 					"seg6localContext": {
 						"table": 30

--- a/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_delete_1.json
+++ b/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_delete_1.json
@@ -25,7 +25,13 @@
 					"active": true,
 					"weight": 1,
 					"seg6local": {
-						"action": "End.DT4"
+						"action": "End.DT4",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
 					},
 					"seg6localContext": {
 						"table": 10
@@ -60,7 +66,13 @@
 					"active": true,
 					"weight": 1,
 					"seg6local": {
-						"action": "End.DT6"
+						"action": "End.DT6",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
 					},
 					"seg6localContext": {
 						"table": 20
@@ -95,7 +107,13 @@
 					"active": true,
 					"weight": 1,
 					"seg6local": {
-						"action": "End.DT46"
+						"action": "End.DT46",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
 					},
 					"seg6localContext": {
 						"table": 30

--- a/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_delete_2.json
+++ b/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_delete_2.json
@@ -25,7 +25,13 @@
 					"active": true,
 					"weight": 1,
 					"seg6local": {
-						"action": "End.DT4"
+						"action": "End.DT4",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
 					},
 					"seg6localContext": {
 						"table": 10
@@ -60,7 +66,13 @@
 					"active": true,
 					"weight": 1,
 					"seg6local": {
-						"action": "End.DT46"
+						"action": "End.DT46",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
 					},
 					"seg6localContext": {
 						"table": 30


### PR DESCRIPTION
The SRv6 support in staticd (PR #16894) does not set the correct SID parameters (block length, node length, function length).

This PR fixes the issue and computes the correct parameters.

The bug was reported by SONiC testing.