### PR TITLE
lib: fix a Null Pointer Dereference bug.

### DIFF
--- a/lib/elf_py.c
+++ b/lib/elf_py.c
@@ -693,7 +693,8 @@ static PyObject *elffile_secbyidx(struct elffile *w, Elf_Scn *scn, size_t idx)
 	}
 
 	ret = w->sects[idx];
-	Py_INCREF(ret);
+	if (ret)
+		Py_INCREF(ret);
 	return ret;
 }
 


### PR DESCRIPTION
The function `elfsect_wrap` can return a NULL value when allocation fails at line [573](https://github.com/FRRouting/frr/blob/2ef76a33506f39d98038d5239f0620e2bbf33d8c/lib/elf_py.c#L573C3-L573C15).
```c
	w = (struct elfsect *)typeobj_elfsect.tp_alloc(&typeobj_elfsect, 0);
	if (!w)
		return NULL;
``` 
The null value returned by function `elfsect_wrap` is saved to `w->sects[idx]` and further assigned to pointer `ret`. Then the pointer `ptr` is passed to function [`Py_INCREF`](https://github.com/FRRouting/frr/blob/2ef76a33506f39d98038d5239f0620e2bbf33d8c/lib/elf_py.c#L692) at line , where it can be dereferenced.
```c
		w->sects[idx] = elfsect_wrap(w, scn, idx, name);
	}

	ret = w->sects[idx];
	Py_INCREF(ret);
	return ret;
``` 
The definition of function `Py_INCREF` can be found here: [link](https://github.com/python/cpython/blob/a1417b211f0bb9582b00f7b82d0a43a3bcc9ed05/Include/refcount.h#L261)
```c
uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
``` 

Thus, we add a null value check before calling the function `Py_INCREF`.
