### PR TITLE
lib: fix a Null Pointer Dereference bug in sockopt.c

### DIFF
--- a/lib/sockopt.c
+++ b/lib/sockopt.c
@@ -179,6 +179,8 @@ static int getsockopt_ipv6_ifindex(struct msghdr *msgh)
 
 	pktinfo = getsockopt_cmsg_data(msgh, IPPROTO_IPV6, IPV6_PKTINFO);
 
+	if (pktinfo == NULL)
+		return 0;
 	return pktinfo->ipi6_ifindex;
 }
 


### PR DESCRIPTION
Dear Developers,

We found a potential Null Pointer Dereference bug in file `lib/sockopt.c`. Here are the details:

The function `getsockopt_cmsg_data` can return a NULL.
```c
static void *getsockopt_cmsg_data(struct msghdr *msgh, int level, int type)
{
	struct cmsghdr *cmsg;

	for (cmsg = CMSG_FIRSTHDR(msgh); cmsg != NULL;
	     cmsg = CMSG_NXTHDR(msgh, cmsg))
		if (cmsg->cmsg_level == level && cmsg->cmsg_type == type)
			return CMSG_DATA(cmsg);

	return NULL;
}
``` 
The null value returned by function `getsockopt_cmsg_data` is dereferenced in function [`getsockopt_ipv6_ifindex`](https://github.com/FRRouting/frr/blob/2ef76a33506f39d98038d5239f0620e2bbf33d8c/lib/sockopt.c#L182)
```c
static int getsockopt_ipv6_ifindex(struct msghdr *msgh)
{
	struct in6_pktinfo *pktinfo;

	pktinfo = getsockopt_cmsg_data(msgh, IPPROTO_IPV6, IPV6_PKTINFO);

	return pktinfo->ipi6_ifindex;
}
``` 


Thus, we add a null value check and return 0 if pointer `pktinfo` is null.