### PR TITLE
lib: fix some other Null Pointer Dereference bugs

### DIFF
--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -323,6 +323,7 @@ static int __send_notification(struct mgmt_be_client *client, const char *xpath,
 	int ret = 0;
 
 	assert(op != NOTIFY_OP_NOTIFICATION || xpath || tree);
+	assert(xpath || tree);
 	debug_be_client("%s: sending %sYANG %snotification: %s", __func__,
 			op == NOTIFY_OP_DS_DELETE    ? "delete "
 			: op == NOTIFY_OP_DS_REPLACE ? "replace "

--- a/lib/pullwr.c
+++ b/lib/pullwr.c
@@ -137,7 +137,7 @@ static void pullwr_resize(struct pullwr *pullwr, size_t need)
 	}
 
 	niov = pullwr_iov(pullwr, iov);
-	if (niov >= 1) {
+	if (newbuf && niov >= 1) {
 		memcpy(newbuf, iov[0].iov_base, iov[0].iov_len);
 		if (niov >= 2)
 			memcpy(newbuf + iov[0].iov_len,

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -944,7 +944,6 @@ static int lib_vrf_create(struct nb_cb_create_args *args)
 		return NB_OK;
 
 	vrfp = vrf_get(VRF_UNKNOWN, vrfname);
-	
 	if (vrfp)
 		SET_FLAG(vrfp->status, VRF_CONFIGURED);
 	nb_running_set_entry(args->dnode, vrfp);

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -944,8 +944,9 @@ static int lib_vrf_create(struct nb_cb_create_args *args)
 		return NB_OK;
 
 	vrfp = vrf_get(VRF_UNKNOWN, vrfname);
-
-	SET_FLAG(vrfp->status, VRF_CONFIGURED);
+	
+	if (vrfp)
+		SET_FLAG(vrfp->status, VRF_CONFIGURED);
 	nb_running_set_entry(args->dnode, vrfp);
 
 	return NB_OK;


### PR DESCRIPTION
Dear Developers,

We found and fixed some other potential Null Pointer Dereference bugs similar to [18067](https://github.com/FRRouting/frr/pull/18067). Here are the details:

**1**
Function `mgmt_be_send_ds_delete_notification` passes a null value as the third argument to function `__send_notification` at line [371](https://github.com/FRRouting/frr/blob/2ef76a33506f39d98038d5239f0620e2bbf33d8c/lib/mgmt_be_client.c#L371). 
```c
return __send_notification(__be_client, path, patch, NOTIFY_OP_DS_PATCH);
```
Then, in function `__send_notification`, when both the 2nd parameter `xpath` and 3rd parameter `tree` are null, a null pointer dereference bug occurs at line [331](https://github.com/FRRouting/frr/blob/2ef76a33506f39d98038d5239f0620e2bbf33d8c/lib/mgmt_be_client.c#L331).
```c
	assert(op != NOTIFY_OP_NOTIFICATION || xpath || tree);
	debug_be_client("%s: sending %sYANG %snotification: %s", __func__,
			op == NOTIFY_OP_DS_DELETE    ? "delete "
			: op == NOTIFY_OP_DS_REPLACE ? "replace "
			: op == NOTIFY_OP_DS_PATCH   ? "patch "
						     : "",
			op == NOTIFY_OP_NOTIFICATION ? "" : "DS ", xpath ?: tree->schema->name);
``` 
To prevent this, we have added a check to ensure that xpath and tree are not both null simultaneously.


**2**
Function `vrf_get` can return NULL value at line [148](https://github.com/FRRouting/frr/blob/2ef76a33506f39d98038d5239f0620e2bbf33d8c/lib/vrf.c#L148). 
```c
	if (vrf && vrf_id != VRF_UNKNOWN
	    && vrf->vrf_id != VRF_UNKNOWN
	    && vrf->vrf_id != vrf_id) {
		zlog_debug("VRF_GET: avoid %s creation(%u), same name exists (%u)",
			   name, vrf_id, vrf->vrf_id);
		return NULL;
	}
``` 
Then in function `lib_vrf_create`, the return value from `vrf_get` is dereferenced at line [948](https://github.com/FRRouting/frr/blob/2ef76a33506f39d98038d5239f0620e2bbf33d8c/lib/vrf.c#L948) without null value check, causing a null pointer dereference bug. We noticed that other caller functions both check the return value before dereferencing it ([link](https://github.com/FRRouting/frr/blob/2ef76a33506f39d98038d5239f0620e2bbf33d8c/lib/vrf.c#L579)), thus we add the null value check in function `lib_vrf_create`.


**3**

Function `pullwr_resize`, when `need` is false and `pullwr->valid` is false, the pointer `newbuf` is set to NULL at line (130)[https://github.com/FRRouting/frr/blob/2ef76a33506f39d98038d5239f0620e2bbf33d8c/lib/pullwr.c#L130].
```c
	} else if (!pullwr->valid) {
		/* resize down, buffer empty */
		newsize = 0;
		newbuf = NULL;
	}
``` 
Then the pointer `newbuf` is passed as the first argument to function `memcpy`, causing a null pointer dereference bug.
```c
	niov = pullwr_iov(pullwr, iov);
	if (niov >= 1) {
		memcpy(newbuf, iov[0].iov_base, iov[0].iov_len);
		if (niov >= 2)
			memcpy(newbuf + iov[0].iov_len,
				iov[1].iov_base, iov[1].iov_len);
	}
``` 
Thus, we add a null value check before calling the function `memcpy`.