### PR TITLE
lib: fix a Memory Leak bug in ptm_lib.c

### DIFF
--- a/lib/ptm_lib.c
+++ b/lib/ptm_lib.c
@@ -429,6 +429,7 @@ int ptm_lib_process_msg(ptm_lib_handle_t *hdl, int fd, char *inbuf, int inlen,
 			hdl->response_cb(arg, p_ctxt);
 		break;
 	default:
+		free(p_ctxt);
 		return -1;
 	}
 


### PR DESCRIPTION
Dear Developers,

We found a potential memory leak bug in function [`ptm_lib_process_msg`](https://github.com/FRRouting/frr/blob/2ef76a33506f39d98038d5239f0620e2bbf33d8c/lib/ptm_lib.c#L329C5-L329C24). At line [405](https://github.com/FRRouting/frr/blob/2ef76a33506f39d98038d5239f0620e2bbf33d8c/lib/ptm_lib.c#L405), a memory object is allocated and stored in pointer `p_ctxt`. 
```c
p_ctxt = calloc(1, sizeof(*p_ctxt));
``` 
However, when function returns at line `https://github.com/FRRouting/frr/blob/2ef76a33506f39d98038d5239f0620e2bbf33d8c/lib/ptm_lib.c#L431`, the memory object is neither freed nor referenced elsewhere, causing a memory leak bug.
```c
	default:
		return -1;
	}
``` 
Thus, we add a `free` operation before the return statement.