### PR TITLE
bgpd: Fix crash in bgp_labelpool

### DIFF
--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -387,6 +387,8 @@ void bgp_reg_dereg_for_label(struct bgp_dest *dest, struct bgp_path_info *pi,
 			 */
 			if (!have_label_to_reg) {
 				SET_FLAG(dest->flags, BGP_NODE_LABEL_REQUESTED);
+				struct bgp_table *table;
+
 				if (BGP_DEBUG(labelpool, LABELPOOL))
 					zlog_debug(
 						"%s: Requesting label from LP for %pFX",
@@ -396,7 +398,9 @@ void bgp_reg_dereg_for_label(struct bgp_dest *dest, struct bgp_path_info *pi,
 				 * the pool. This means we'll never register
 				 * FECs withoutvalid labels.
 				 */
-				bgp_lp_get(LP_TYPE_BGP_LU, dest,
+				table = bgp_dest_table(dest);
+
+				bgp_lp_get(LP_TYPE_BGP_LU, dest, table->bgp->vrf_id,
 					   bgp_reg_for_label_callback);
 				return;
 			}

--- a/bgpd/bgp_labelpool.h
+++ b/bgpd/bgp_labelpool.h
@@ -35,8 +35,8 @@ struct labelpool {
 
 extern void bgp_lp_init(struct event_loop *master, struct labelpool *pool);
 extern void bgp_lp_finish(void);
-extern void bgp_lp_get(int type, void *labelid,
-	int (*cbfunc)(mpls_label_t label, void *labelid, bool allocated));
+extern void bgp_lp_get(int type, void *labelid, vrf_id_t vrf_id,
+		       int (*cbfunc)(mpls_label_t label, void *labelid, bool allocated));
 extern void bgp_lp_release(int type, void *labelid, mpls_label_t label);
 extern void bgp_lp_event_chunk(uint32_t first, uint32_t last);
 extern void bgp_lp_event_zebra_down(void);

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1450,7 +1450,7 @@ _vpn_leak_from_vrf_get_per_nexthop_label(struct bgp_path_info *pi,
 		/* request a label to zebra for this nexthop
 		 * the response from zebra will trigger the callback
 		 */
-		bgp_lp_get(LP_TYPE_NEXTHOP, blnc,
+		bgp_lp_get(LP_TYPE_NEXTHOP, blnc, from_bgp->vrf_id,
 			   bgp_mplsvpn_get_label_per_nexthop_cb);
 	}
 
@@ -1490,7 +1490,8 @@ static mpls_label_t bgp_mplsvpn_get_vpn_label(struct vpn_policy *bgp_policy)
 {
 	if (bgp_policy->tovpn_label == MPLS_LABEL_NONE &&
 	    CHECK_FLAG(bgp_policy->flags, BGP_VPN_POLICY_TOVPN_LABEL_AUTO)) {
-		bgp_lp_get(LP_TYPE_VRF, bgp_policy, vpn_leak_label_callback);
+		bgp_lp_get(LP_TYPE_VRF, bgp_policy, bgp_policy->bgp->vrf_id,
+			   vpn_leak_label_callback);
 		return MPLS_INVALID_LABEL;
 	}
 	return bgp_policy->tovpn_label;
@@ -4387,7 +4388,7 @@ void bgp_mplsvpn_nh_label_bind_register_local_label(struct bgp *bgp,
 						     label);
 		bmnc->bgp_vpn = bgp;
 		bmnc->allocation_in_progress = true;
-		bgp_lp_get(LP_TYPE_BGP_L3VPN_BIND, bmnc,
+		bgp_lp_get(LP_TYPE_BGP_L3VPN_BIND, bmnc, bgp->vrf_id,
 			   bgp_mplsvpn_nh_label_bind_get_local_label_cb);
 	}
 


### PR DESCRIPTION
The bgp labelpool code is grabbing the vpn policy data structure. This vpn_policy has a pointer to the bgp data structure.  If a item placed on the bgp label pool workqueue happens to sit there for the microsecond or so and the operator issues a `no router bgp...` command that corresponds to the vpn_policy bgp pointer, when the workqueue is run it will crash because the bgp pointer is now freed and something else owns it.

Modify the labelpool code to store the vrf id associated with the request on the workqueue.  When you wake up if the vrf id still has a bgp pointer allow the request to continue, else drop it.