### PR TITLE
bgpd: fix bgp vrf instance creation from implicit

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3418,17 +3418,6 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 	}
 
 	bgp = XCALLOC(MTYPE_BGP, sizeof(struct bgp));
-	bgp->as = *as;
-	if (as_pretty)
-		bgp->as_pretty = XSTRDUP(MTYPE_BGP_NAME, as_pretty);
-	else
-		bgp->as_pretty = XSTRDUP(MTYPE_BGP_NAME, asn_asn2asplain(*as));
-
-	if (asnotation != ASNOTATION_UNDEFINED) {
-		bgp->asnotation = asnotation;
-		SET_FLAG(bgp->config, BGP_CONFIG_ASNOTATION);
-	} else
-		asn_str2asn_notation(bgp->as_pretty, NULL, &bgp->asnotation);
 
 	if (BGP_DEBUG(zebra, ZEBRA)) {
 		if (inst_type == BGP_INSTANCE_TYPE_DEFAULT)
@@ -3472,6 +3461,18 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 	bgp->peer = list_new();
 
 peer_init:
+	bgp->as = *as;
+	if (as_pretty)
+		bgp->as_pretty = XSTRDUP(MTYPE_BGP_NAME, as_pretty);
+	else
+		bgp->as_pretty = XSTRDUP(MTYPE_BGP_NAME, asn_asn2asplain(*as));
+
+	if (asnotation != ASNOTATION_UNDEFINED) {
+		bgp->asnotation = asnotation;
+		SET_FLAG(bgp->config, BGP_CONFIG_ASNOTATION);
+	} else
+		asn_str2asn_notation(bgp->as_pretty, NULL, &bgp->asnotation);
+
 	bgp->peer->cmp = (int (*)(void *, void *))peer_cmp;
 	bgp->peerhash = hash_create(peer_hash_key_make, peer_hash_same,
 				    "BGP Peer Hash");


### PR DESCRIPTION
In bgp route leak, when import vrf x is executed,
it creates bgp instance as hidden with asn value as unspecified.

When router bgp x is configured ensure the correct as, asnotation is applied otherwise running config shows asn value as 0.

This can lead to frr-reload failure when any FRR config change.

Fix:
Move asn and asnotiation, as_pretty value in common done section, so when bgp_create gets existing instance but before returning update asn and required fields in common section.

In bgp_create(): when returning for hidden at least update asn and required when bgp instance created implicitly due to vrf leak.
```
if (hidden) {
    bgp = bgp_old;
    goto peer_init; <<<
}
```
**Before fix:**
show running:

```
router bgp 0 vrf purple
 bgp router-id 10.10.3.11
 !
 address-family ipv4 unicast
  redistribute static
  import vrf blue
 exit-address-family
 !
 address-family ipv6 unicast
  import vrf blue
 exit-address-family
 !
 address-family l2vpn evpn
  advertise ipv4 unicast
  advertise ipv6 unicast
 exit-address-family
exit
```

**Testing:**

1) following snippet config:
```
router bgp 63420 vrf blue
 import vrf purple
router bgp 63420 vrf purple
 import vrf blue
 ```
 
2) **Restart frr leads to the running config with 0 asn value.**

Signed-off-by: Chirag Shah <chirag@nvidia.com>