### PR TITLE
lib: nb: call child destroy CBs when YANG container is deleted

### DIFF
--- a/lib/keychain_nb.c
+++ b/lib/keychain_nb.c
@@ -587,9 +587,9 @@ static int key_chains_key_chain_key_crypto_algorithm_destroy(
 	if (args->event != NB_EV_APPLY)
 		return NB_OK;
 
-	name = yang_dnode_get_string(args->dnode, "../../../name");
+	name = yang_dnode_get_string(args->dnode, "../../name");
 	keychain = keychain_lookup(name);
-	index = (uint32_t)yang_dnode_get_uint64(args->dnode, "../../key-id");
+	index = (uint32_t)yang_dnode_get_uint64(args->dnode, "../key-id");
 	key = key_lookup(keychain, index);
 	key->hash_algo = KEYCHAIN_ALGO_NULL;
 	keychain_touch(keychain);

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -386,6 +386,11 @@ struct nb_callbacks {
 	int (*destroy)(struct nb_cb_destroy_args *args);
 
 	/*
+	 * Flags to control the how northbound callbacks are invoked.
+	 */
+	uint flags;
+
+	/*
 	 * Configuration callback.
 	 *
 	 * A list entry or leaf-list entry has been moved. Only applicable when
@@ -621,6 +626,12 @@ struct nb_callbacks {
 	 */
 	void (*cli_show_end)(struct vty *vty, const struct lyd_node *dnode);
 };
+
+/*
+ * Flag indicating the northbound should recurse destroy the children of this
+ * node when it is destroyed.
+ */
+#define F_NB_CB_DESTROY_RECURSE 0x01
 
 struct nb_dependency_callbacks {
 	void (*get_dependant_xpath)(const struct lyd_node *dnode, char *xpath);


### PR DESCRIPTION
Previously the code was only calling the child destroy callbacks if the target deleted node was a non-presence container. We now add a flag to the callback structure to instruct northbound to perform the rescursive delete.

- Fix wrong relative path lookup in keychain destroy callback