### PR TITLE
lib (+bfd): improve late timer warnings

### DIFF
--- a/bfdd/event.c
+++ b/bfdd/event.c
@@ -107,6 +107,7 @@ void sbfd_init_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 	tv_normalize(&tv);
 
 	event_add_timer_tv(master, sbfd_init_xmt_cb, bs, &tv, &bs->xmttimer_ev);
+	event_set_tardy_threshold(bs->xmttimer_ev, bs->xmt_TO / 2);
 }
 
 void sbfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
@@ -123,6 +124,7 @@ void sbfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 	tv_normalize(&tv);
 
 	event_add_timer_tv(master, sbfd_echo_xmt_cb, bs, &tv, &bs->echo_xmttimer_ev);
+	event_set_tardy_threshold(bs->echo_xmttimer_ev, bs->echo_xmt_TO / 2);
 }
 
 void bfd_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
@@ -140,6 +142,7 @@ void bfd_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 	tv_normalize(&tv);
 
 	event_add_timer_tv(master, bfd_xmt_cb, bs, &tv, &bs->xmttimer_ev);
+	event_set_tardy_threshold(bs->xmttimer_ev, bs->xmt_TO / 2);
 }
 
 void bfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
@@ -158,6 +161,7 @@ void bfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 
 	event_add_timer_tv(master, bfd_echo_xmt_cb, bs, &tv,
 			   &bs->echo_xmttimer_ev);
+	event_set_tardy_threshold(bs->echo_xmttimer_ev, bs->echo_xmt_TO / 2);
 }
 
 void bfd_recvtimer_delete(struct bfd_session *bs)

--- a/lib/event.c
+++ b/lib/event.c
@@ -2180,9 +2180,9 @@ static ssize_t printfrr_thread_dbg(struct fbuf *buf, struct printfrr_eargs *ea,
 	char info[16] = "";
 
 	if (!thread)
-		return bputs(buf, "{(thread *)NULL}");
+		return bputs(buf, "{(event *)NULL}");
 
-	rv += bprintfrr(buf, "{(thread *)%p arg=%p", thread, thread->arg);
+	rv += bprintfrr(buf, "{(event *)%p arg=%p", thread, thread->arg);
 
 	if (thread->type < array_size(types) && types[thread->type])
 		rv += bprintfrr(buf, " %-6s", types[thread->type]);


### PR DESCRIPTION
Refactor the "timer getting executed too late" warning:

- warning threshold is now adjustable
- check is performed when event actually executes, rather than when it's thrown on ready list (makes more sense really)
- ignore_late_timer replaced with threshold = 0
- system load averages printed in log message
- warning ratelimited to once per 10s rather than once per poll()

+ use it for BFD TX timers (sets the threshold to half TX interval)

+ freebie `thread` → `event` in user-visible formatting

Among other things this is intended to distinguish BFD failures in CI due to high system load. Doesn't fix the issue but at least makes clear what is going on.

Example warning now looks like this:
```
2025/02/11 11:54:31 ZEBRA: [ZXB3P-3AVT0][EC 100663315] CPU starvation: {(event *)0x7ffd081b2600 arg=0x55acad04e020 ready               rtadv_timer() &rtadv->ra_timer from zebra/rtadv.c:1741} getting called 7169ms late, warning threshold 4000ms. System load: 1.11, 2.95, 2.68
```

(System load average is the thing printed in `uptime`. The `%pTHD` output is a bit lengthy, but better to have that info.)