### PR TITLE
Use ipv4 class E addresses (240.0.0.0/4) as connected routes by default

### DIFF
--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -331,12 +331,9 @@ Basic Config Commands
 
 .. clicmd:: allow-reserved-ranges
 
-   Allow using IPv4 reserved (Class E) IP ranges for daemons. E.g.: setting
-   IPv4 addresses for interfaces or allowing reserved ranges in BGP next-hops.
-
-   If you need multiple FRR instances (or FRR + any other daemon) running in a
-   single router and peering via 127.0.0.0/8, it's also possible to use this
-   knob if turned on.
+   Allow peering via loopback addresses (127.0.0.0/8). This is necessary in case
+   of multiple FRR instances (or FRR + any other daemon) peering via loopback
+   interfaces running on the same router.
 
    Default: off.
 

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1439,10 +1439,13 @@ bool ipv4_unicast_valid(const struct in_addr *addr)
 {
 	in_addr_t ip = ntohl(addr->s_addr);
 
+	if (IPV4_CLASS_E(ip))
+		return true;
+
 	if (IPV4_CLASS_D(ip))
 		return false;
 
-	if (IPV4_NET0(ip) || IPV4_NET127(ip) || IPV4_CLASS_E(ip)) {
+	if (IPV4_NET0(ip) || IPV4_NET127(ip)) {
 		if (cmd_allow_reserved_ranges_get())
 			return true;
 		else

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -391,11 +391,10 @@ int zebra_check_addr(const struct prefix *p)
 	if (p->family == AF_INET) {
 		uint32_t addr;
 
-		addr = p->u.prefix4.s_addr;
-		addr = ntohl(addr);
+		addr = ntohl(p->u.prefix4.s_addr);
 
-		if (IPV4_NET127(addr) || IN_CLASSD(addr)
-		    || IPV4_LINKLOCAL(addr))
+		if (IPV4_NET127(addr) || IN_CLASSD(addr) ||
+		    (IPV4_LINKLOCAL(addr) && !IPV4_CLASS_E(addr)))
 			return 0;
 	}
 	if (p->family == AF_INET6) {


### PR DESCRIPTION
Changes allow ipv4 class E addresses in the 240.0.0.0/4 range to be displayed and used as connected routes in zebra by default.

Reason for changes are cloud providers (with customers still using obsolete ipv4 protocol, i.e. Azure, AWS) running out of ip space and abusing class E for addressing instances (announced via BGP) over tunneling connections back to customers on premise infrastructure.

Kernel routing table:
```
root@frr:~# ip route
default via 192.168.1.1 dev enp10s0 
192.168.1.0/24 dev enp10s0 proto kernel scope link src 192.168.1.111
192.168.122.0/24 dev enp9s0 proto kernel scope link src 192.168.122.253
240.12.12.0/24 dev enp1s0 proto kernel scope link src 240.12.12.12 <---
240.80.45.0/24 dev enp1s0 proto kernel scope link src 240.80.45.1 <---
```

Without patch:
```
frr# show ip route
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

IPv4 unicast VRF default:
K>* 0.0.0.0/0 [0/0] via 192.168.1.1, enp10s0, weight 1, 00:00:14
C>* 192.168.1.0/24 is directly connected, enp10s0, weight 1, 00:00:14
L>* 192.168.1.111/32 is directly connected, enp10s0, weight 1, 00:00:14
C>* 192.168.122.0/24 is directly connected, enp9s0, weight 1, 00:00:14
L>* 192.168.122.253/32 is directly connected, enp9s0, weight 1, 00:00:14
K>* 240.12.12.0/24 [0/0] is directly connected, enp1s0, weight 1, 00:00:14 <---
K>* 240.80.45.0/24 [0/0] is directly connected, enp1s0, weight 1, 00:00:14 <---
```

With patch:
```
frr# show ip route
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

IPv4 unicast VRF default:
K>* 0.0.0.0/0 [0/0] via 192.168.1.1, enp10s0, weight 1, 00:00:16
C>* 192.168.1.0/24 is directly connected, enp10s0, weight 1, 00:00:16
L>* 192.168.1.111/32 is directly connected, enp10s0, weight 1, 00:00:16
C>* 192.168.122.0/24 is directly connected, enp9s0, weight 1, 00:00:16
L>* 192.168.122.253/32 is directly connected, enp9s0, weight 1, 00:00:16
C>* 240.12.12.0/24 is directly connected, enp1s0, weight 1, 00:00:16 <---
L>* 240.12.12.12/32 is directly connected, enp1s0, weight 1, 00:00:16 <---
C>* 240.80.45.0/24 is directly connected, enp1s0, weight 1, 00:00:16 <---
L>* 240.80.45.1/32 is directly connected, enp1s0, weight 1, 00:00:16 <---
```

Related issues:
https://github.com/FRRouting/frr/issues/16326
https://github.com/FRRouting/frr/issues/17942