### PR TITLE
bgpd: optimize attrhash_cmp calls

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2062,8 +2062,7 @@ static int update_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 		bgp_path_info_add(dest, tmp_pi);
 	} else {
 		tmp_pi = local_pi;
-		if (attrhash_cmp(tmp_pi->attr, attr)
-		    && !CHECK_FLAG(tmp_pi->flags, BGP_PATH_REMOVED))
+		if (!CHECK_FLAG(tmp_pi->flags, BGP_PATH_REMOVED) && attrhash_cmp(tmp_pi->attr, attr))
 			route_change = 0;
 		else {
 			/*
@@ -3154,8 +3153,7 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 		pi = bgp_create_evpn_bgp_path_info(parent_pi, dest, &attr);
 		new_pi = true;
 	} else {
-		if (attrhash_cmp(pi->attr, &attr)
-		    && !CHECK_FLAG(pi->flags, BGP_PATH_REMOVED)) {
+		if (!CHECK_FLAG(pi->flags, BGP_PATH_REMOVED) && attrhash_cmp(pi->attr, &attr)) {
 			bgp_dest_unlock_node(dest);
 			return 0;
 		}
@@ -3278,8 +3276,8 @@ static int install_evpn_route_entry_in_vni_common(
 		 * install_evpn_route_entry_in_vni_mac() or
 		 * install_evpn_route_entry_in_vni_ip()
 		 */
-		if (attrhash_cmp(pi->attr, parent_pi->attr) &&
-		    !CHECK_FLAG(pi->flags, BGP_PATH_REMOVED))
+		if (!CHECK_FLAG(pi->flags, BGP_PATH_REMOVED) &&
+		    attrhash_cmp(pi->attr, parent_pi->attr))
 			return 0;
 		/* The attribute has changed. */
 		/* Add (or update) attribute to hash. */

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -212,8 +212,8 @@ static int bgp_evpn_es_route_install(struct bgp *bgp,
 		bgp_dest_lock_node((struct bgp_dest *)parent_pi->net);
 		bgp_path_info_add(dest, pi);
 	} else {
-		if (attrhash_cmp(pi->attr, parent_pi->attr)
-				&& !CHECK_FLAG(pi->flags, BGP_PATH_REMOVED)) {
+		if (!CHECK_FLAG(pi->flags, BGP_PATH_REMOVED) &&
+		    attrhash_cmp(pi->attr, parent_pi->attr)) {
 			bgp_dest_unlock_node(dest);
 			return 0;
 		}
@@ -421,8 +421,7 @@ int bgp_evpn_mh_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
 		bgp_path_info_add(dest, tmp_pi);
 	} else {
 		tmp_pi = local_pi;
-		if (attrhash_cmp(tmp_pi->attr, attr)
-				&& !CHECK_FLAG(tmp_pi->flags, BGP_PATH_REMOVED))
+		if (!CHECK_FLAG(tmp_pi->flags, BGP_PATH_REMOVED) && attrhash_cmp(tmp_pi->attr, attr))
 			*route_changed = 0;
 		else {
 			/* The attribute has changed.

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1207,8 +1207,8 @@ leak_update(struct bgp *to_bgp, struct bgp_dest *bn,
 			return NULL;
 		}
 
-		if (attrhash_cmp(bpi->attr, new_attr) && labelssame &&
-		    !CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED) &&
+		if (labelssame && !CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED) &&
+		    attrhash_cmp(bpi->attr, new_attr) &&
 		    leak_update_nexthop_valid(to_bgp, bn, new_attr, afi, safi, source_bpi, bpi,
 					      bgp_orig, p,
 					      debug) == !!CHECK_FLAG(bpi->flags, BGP_PATH_VALID)) {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7505,9 +7505,9 @@ void bgp_static_update(struct bgp *bgp, const struct prefix *p,
 			break;
 
 	if (pi) {
-		if (attrhash_cmp(pi->attr, attr_new)
-		    && !CHECK_FLAG(pi->flags, BGP_PATH_REMOVED)
-		    && !CHECK_FLAG(bgp->flags, BGP_FLAG_FORCE_STATIC_PROCESS)) {
+		if (!CHECK_FLAG(pi->flags, BGP_PATH_REMOVED) &&
+		    !CHECK_FLAG(bgp->flags, BGP_FLAG_FORCE_STATIC_PROCESS) &&
+		    attrhash_cmp(pi->attr, attr_new)) {
 			bgp_dest_unlock_node(dest);
 			bgp_attr_unintern(&attr_new);
 			aspath_unintern(&attr.aspath);
@@ -9759,8 +9759,8 @@ void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 		if (bpi) {
 			/* Ensure the (source route) type is updated. */
 			bpi->type = type;
-			if (attrhash_cmp(bpi->attr, new_attr)
-			    && !CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {
+			if (!CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED) &&
+			    attrhash_cmp(bpi->attr, new_attr)) {
 				bgp_attr_unintern(&new_attr);
 				aspath_unintern(&attr.aspath);
 				bgp_dest_unlock_node(bn);

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -946,8 +946,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 			}
 		}
 
-		if (attrhash_cmp(bpi->attr, new_attr)
-		    && !CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {
+		if (!CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED) && attrhash_cmp(bpi->attr, new_attr)) {
 			bgp_attr_unintern(&new_attr);
 			bgp_dest_unlock_node(bn);
 


### PR DESCRIPTION
Only call attrhash_cmp when necessary.