### PR TITLE
lib: fix 2 Null Pointer Dereference bugs

### DIFF
--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -323,6 +323,9 @@ static int __send_notification(struct mgmt_be_client *client, const char *xpath,
 	int ret = 0;
 
 	assert(op != NOTIFY_OP_NOTIFICATION || xpath || tree);
+	if (!xpath && !tree){
+		return ret;
+	}
 	debug_be_client("%s: sending %sYANG %snotification: %s", __func__,
 			op == NOTIFY_OP_DS_DELETE    ? "delete "
 			: op == NOTIFY_OP_DS_REPLACE ? "replace "

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -944,7 +944,9 @@ static int lib_vrf_create(struct nb_cb_create_args *args)
 		return NB_OK;
 
 	vrfp = vrf_get(VRF_UNKNOWN, vrfname);
-
+	if (!vrfp){
+		return NB_ERR;
+	}
 	SET_FLAG(vrfp->status, VRF_CONFIGURED);
 	nb_running_set_entry(args->dnode, vrfp);
 


### PR DESCRIPTION
Modified Fix for #18072 

We found and fixed 2 NPD bugs in `lib` directory. This PR has removed the superfluous commits of previous PR #18072 .

Thanks for your patience.