### PR TITLE
bgpd: release manual vpn label on instance deletion

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4071,8 +4071,18 @@ int bgp_delete(struct bgp *bgp)
 		vpn_leak_zebra_vrf_sid_withdraw(bgp, afi);
 	}
 
+	/* release auto vpn labels */
 	bgp_vpn_release_label(bgp, AFI_IP, true);
 	bgp_vpn_release_label(bgp, AFI_IP6, true);
+
+	/* release manual vpn labels */
+	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
+		if (!CHECK_FLAG(bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_LABEL_MANUAL_REG))
+			continue;
+		bgp_zebra_release_label_range(bgp->vpn_policy[afi].tovpn_label,
+					      bgp->vpn_policy[afi].tovpn_label);
+		UNSET_FLAG(bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_LABEL_MANUAL_REG);
+	}
 
 	hook_call(bgp_inst_delete, bgp);
 


### PR DESCRIPTION
When a BGP instance with a manually assigned VPN label is deleted, the label is not released from the Zebra label registry. As a result, reapplying a configuration with the same manual label leads to VPN prefix export failures.

For example, with the following configuration:

> router bgp 65000 vrf BLUE
>  address-family ipv4 unicast
>   label vpn export <int>

Release zebra label registry on unconfiguration.

Fixes: d162d5f6f5 ("bgpd: fix hardset l3vpn label available in mpls pool")