### PR TITLE
lib: Substitute poll APIs with epoll APIs in thread management routine

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1599,6 +1599,26 @@ AC_CHECK_FUNCS([pollts], [
   AC_DEFINE([HAVE_POLLTS], [1], [have NetBSD pollts()])
 ])
 
+AC_ARG_ENABLE([epoll],
+  [AS_HELP_STRING([--enable-epoll], [Enable epoll support])],
+  [enable_epoll=yes],
+  [enable_epoll=no])
+
+if test "x$enable_epoll" = "xyes"; then
+    AC_CHECK_FUNC([epoll_wait], [AC_DEFINE([HAVE_EPOLL_WAIT], [1], [Define if you have epoll_wait])])
+    AC_CHECK_FUNC([epoll_pwait], [AC_DEFINE([HAVE_EPOLL_PWAIT], [1], [Define if you have epoll_pwait])])
+    AC_CHECK_FUNC([epoll_pwait2], [AC_DEFINE([HAVE_EPOLL_PWAIT2], [1], [Define if you have epoll_pwait2])])
+
+    # Define USE_EPOLL if any of the above is found
+    AC_MSG_CHECKING([for any epoll API support])
+    if test "x$ac_cv_func_epoll_wait" = "xyes" || test "x$ac_cv_func_epoll_pwait" = "xyes" || test "x$ac_cv_func_epoll_pwait2" = "xyes"; then
+        AC_DEFINE([USE_EPOLL], [1], [Define if any epoll API is supported])
+        AC_MSG_RESULT([yes])
+    else
+        AC_MSG_RESULT([no])
+    fi
+fi
+
 AC_CHECK_HEADER([asm-generic/unistd.h],
                 [AC_CHECK_DECL(__NR_setns,
                                AC_DEFINE([HAVE_NETNS], [1], [Have netns]),,

--- a/lib/event.c
+++ b/lib/event.c
@@ -9,6 +9,7 @@
 
 #include <signal.h>
 #include <sys/resource.h>
+#include <sys/stat.h>
 
 #include "frrevent.h"
 #include "memory.h"
@@ -29,6 +30,9 @@ DEFINE_MTYPE_STATIC(LIB, THREAD, "Thread");
 DEFINE_MTYPE_STATIC(LIB, EVENT_MASTER, "Thread master");
 DEFINE_MTYPE_STATIC(LIB, EVENT_POLL, "Thread Poll Info");
 DEFINE_MTYPE_STATIC(LIB, EVENT_STATS, "Thread stats");
+#if EPOLL_ENABLED
+DEFINE_MTYPE_STATIC(LIB, EVENT_EPOLL, "Thread epoll events");
+#endif
 
 DECLARE_LIST(event_list, struct event, eventitem);
 
@@ -370,6 +374,71 @@ DEFPY (service_walltime_warning,
 	return CMD_SUCCESS;
 }
 
+#if EPOLL_ENABLED
+struct show_event_poll_helper_iter_arg_t {
+	struct vty *vty;
+	struct event_loop *master;
+};
+
+static void show_event_poll_helper_iter(struct hash_bucket *hb, void *arg)
+{
+	struct epoll_event *ev = hb->data;
+	struct show_event_poll_helper_iter_arg_t *iter_arg = arg;
+	struct vty *vty = iter_arg->vty;
+	struct event_loop *m = iter_arg->master;
+	struct event *thread;
+
+	vty_out(vty, "\t fd:%6d events:%2d\t\t", ev->data.fd, ev->events);
+
+	if (ev->events & EPOLLIN) {
+		thread = m->read[ev->data.fd];
+
+		if (!thread)
+			vty_out(vty, "ERROR ");
+		else
+			vty_out(vty, "%s ", thread->xref->funcname);
+	} else
+		vty_out(vty, " ");
+
+	if (ev->events & EPOLLOUT) {
+		thread = m->write[ev->data.fd];
+
+		if (!thread)
+			vty_out(vty, "ERROR\n");
+		else
+			vty_out(vty, "%s\n", thread->xref->funcname);
+	} else
+		vty_out(vty, "\n");
+}
+
+static void show_event_poll_helper(struct vty *vty, struct event_loop *m)
+{
+	const char *name = m->name ? m->name : "main";
+	char underline[strlen(name) + 1];
+	struct show_event_poll_helper_iter_arg_t iter_arg = { .vty = vty,
+							      .master = m };
+
+	memset(underline, '-', sizeof(underline));
+	underline[sizeof(underline) - 1] = '\0';
+
+	vty_out(vty, "\nShowing epoll FD's count for %s\n", name);
+	vty_out(vty, "----------------------%s\n", underline);
+	for (int i = 0; i < m->handler.eventsize; i++) {
+		if (m->handler.fd_poll_counter[i] > 0)
+			vty_out(vty, "\tfd: %d, event count: %lu\n", i,
+				m->handler.fd_poll_counter[i]);
+	}
+
+	vty_out(vty, "\nShowing epoll FD's for %s\n", name);
+	vty_out(vty, "----------------------%s\n", underline);
+	vty_out(vty, "Count: %u/%d\n",
+		(uint32_t)(m->handler.regular_revent_count +
+			   hashcount(m->handler.epoll_event_hash)),
+		m->fd_limit);
+	hash_iterate(m->handler.epoll_event_hash, show_event_poll_helper_iter,
+		     &iter_arg);
+}
+#else
 static void show_event_poll_helper(struct vty *vty, struct event_loop *m)
 {
 	const char *name = m->name ? m->name : "main";
@@ -410,6 +479,7 @@ static void show_event_poll_helper(struct vty *vty, struct event_loop *m)
 			vty_out(vty, "\n");
 	}
 }
+#endif
 
 DEFUN_NOSH (show_event_poll,
             show_event_poll_cmd,
@@ -515,11 +585,63 @@ static void initializer(void)
 	pthread_key_create(&thread_current, NULL);
 }
 
+#if EPOLL_ENABLED
+static struct epoll_event *epoll_event_new(int fd, uint32_t events)
+{
+	struct epoll_event *ev = XMALLOC(MTYPE_EVENT_EPOLL,
+					 sizeof(struct epoll_event));
+	ev->data.fd = fd;
+	ev->events = events;
+	return ev;
+}
+
+static void epoll_event_del(void *ev)
+{
+	XFREE(MTYPE_EVENT_EPOLL, ev);
+}
+
+static bool epoll_event_hash_cmp(const void *f, const void *s)
+{
+	const struct epoll_event *e1 = f;
+	const struct epoll_event *e2 = s;
+
+	return e1->data.fd == e2->data.fd;
+}
+
+static unsigned int epoll_event_hash_key(const void *arg)
+{
+	const struct epoll_event *e = arg;
+
+	return e->data.fd;
+}
+
+static void get_fd_stat(int fd, struct stat *fd_stat, bool *fd_closed)
+{
+	assert(fd_stat != NULL);
+	if (fstat(fd, fd_stat) == -1) {
+		/* fd is probably already closed */
+		if (errno == EBADF) {
+			if (fd_closed != NULL)
+				*fd_closed = true;
+			return;
+		}
+		zlog_debug("[!] In %s, fstat failed unexpectedly, fd: %d, errno: %d)",
+			   __func__, fd, errno);
+	}
+	if (fd_closed != NULL)
+		*fd_closed = false;
+}
+#endif
+
 #define STUPIDLY_LARGE_FD_SIZE 100000
+
 struct event_loop *event_master_create(const char *name)
 {
 	struct event_loop *rv;
 	struct rlimit limit;
+#if EPOLL_ENABLED
+	struct epoll_event pipe_read_ev;
+#endif
 
 	pthread_once(&init_once, &initializer);
 
@@ -587,6 +709,34 @@ struct event_loop *event_master_create(const char *name)
 	set_nonblocking(rv->io_pipe[0]);
 	set_nonblocking(rv->io_pipe[1]);
 
+#if EPOLL_ENABLED
+	/* Initailize data structures for epoll */
+	rv->handler.epoll_fd = epoll_create1(0);
+	rv->handler.epoll_event_hash = hash_create(epoll_event_hash_key,
+						   epoll_event_hash_cmp,
+						   "Epoll event hash");
+	rv->handler.eventsize = rv->fd_limit;
+	rv->handler.revents =
+		XCALLOC(MTYPE_EVENT_MASTER,
+			sizeof(struct epoll_event) * rv->handler.eventsize);
+	rv->handler.regular_revents =
+		XCALLOC(MTYPE_EVENT_MASTER,
+			sizeof(struct epoll_event) * rv->handler.eventsize);
+	rv->handler.regular_revent_count = 0;
+	memset(&pipe_read_ev, 0, sizeof(pipe_read_ev));
+	pipe_read_ev.data.fd = rv->io_pipe[0];
+	pipe_read_ev.events = EPOLLIN;
+	if (-1 == epoll_ctl(rv->handler.epoll_fd, EPOLL_CTL_ADD, rv->io_pipe[0],
+			    &pipe_read_ev)) {
+		flog_err(EC_LIB_NO_THREAD,
+			 "Attempting to call epoll_ctl to add io_pipe[0] but failed, fd: %d!",
+			 rv->io_pipe[0]);
+		exit(1);
+	}
+	rv->handler.fd_poll_counter =
+		XCALLOC(MTYPE_EVENT_MASTER,
+			sizeof(unsigned long) * rv->handler.eventsize);
+#else
 	/* Initialize data structures for poll() */
 	rv->handler.pfdsize = rv->fd_limit;
 	rv->handler.pfdcount = 0;
@@ -594,6 +744,7 @@ struct event_loop *event_master_create(const char *name)
 				   sizeof(struct pollfd) * rv->handler.pfdsize);
 	rv->handler.copy = XCALLOC(MTYPE_EVENT_MASTER,
 				   sizeof(struct pollfd) * rv->handler.pfdsize);
+#endif
 
 	/* add to list of threadmasters */
 	frr_with_mutex (&masters_mtx) {
@@ -693,8 +844,16 @@ void event_master_free(struct event_loop *m)
 	cpu_records_fini(m->cpu_records);
 
 	XFREE(MTYPE_EVENT_MASTER, m->name);
+#if EPOLL_ENABLED
+	close(m->handler.epoll_fd);
+	hash_clean_and_free(&(m->handler.epoll_event_hash), epoll_event_del);
+	XFREE(MTYPE_EVENT_MASTER, m->handler.revents);
+	XFREE(MTYPE_EVENT_MASTER, m->handler.regular_revents);
+	XFREE(MTYPE_EVENT_MASTER, m->handler.fd_poll_counter);
+#else
 	XFREE(MTYPE_EVENT_MASTER, m->handler.pfds);
 	XFREE(MTYPE_EVENT_MASTER, m->handler.copy);
+#endif
 	XFREE(MTYPE_EVENT_MASTER, m);
 }
 
@@ -816,7 +975,11 @@ static int fd_poll(struct event_loop *m, const struct timeval *timer_wait,
 {
 	sigset_t origsigs;
 	unsigned char trash[64];
+#if EPOLL_ENABLED
+	unsigned long count = hashcount(m->handler.epoll_event_hash);
+#else
 	nfds_t count = m->handler.copycount;
+#endif
 
 	/*
 	 * If timer_wait is null here, that means poll() should block
@@ -837,6 +1000,10 @@ static int fd_poll(struct event_loop *m, const struct timeval *timer_wait,
 		/* use the default value */
 		timeout = (timer_wait->tv_sec * 1000)
 			  + (timer_wait->tv_usec / 1000);
+#if EPOLL_ENABLED
+	} else if (m->handler.regular_revent_count > 0) {
+		timeout = 0;
+#endif
 	} else if (m->selectpoll_timeout > 0) {
 		/* use the user's timeout */
 		timeout = m->selectpoll_timeout;
@@ -844,16 +1011,24 @@ static int fd_poll(struct event_loop *m, const struct timeval *timer_wait,
 		/* effect a poll (return immediately) */
 		timeout = 0;
 	}
+#if EPOLL_ENABLED && defined(HAVE_EPOLL_PWAIT2) ||                             \
+	!EPOLL_ENABLED && defined(HAVE_PPOLL)
+	struct timespec ts, *tsp;
+
+	msec_to_timespec(timeout, ts, tsp);
+#endif
 
 	zlog_tls_buffer_flush();
 	rcu_read_unlock();
 	rcu_assert_read_unlocked();
 
+#if !EPOLL_ENABLED
 	/* add poll pipe poker */
 	assert(count + 1 < m->handler.pfdsize);
 	m->handler.copy[count].fd = m->io_pipe[0];
 	m->handler.copy[count].events = POLLIN;
 	m->handler.copy[count].revents = 0x00;
+#endif
 
 	/* We need to deal with a signal-handling race here: we
 	 * don't want to miss a crucial signal, such as SIGTERM or SIGINT,
@@ -877,17 +1052,20 @@ static int fd_poll(struct event_loop *m, const struct timeval *timer_wait,
 		/* Don't make any changes for the non-main pthreads */
 		pthread_sigmask(SIG_SETMASK, NULL, &origsigs);
 	}
-
-#if defined(HAVE_PPOLL)
-	struct timespec ts, *tsp;
-
-	if (timeout >= 0) {
-		ts.tv_sec = timeout / 1000;
-		ts.tv_nsec = (timeout % 1000) * 1000000;
-		tsp = &ts;
-	} else
-		tsp = NULL;
-
+#if defined(USE_EPOLL) && defined(HAVE_EPOLL_PWAIT2)
+	num = epoll_pwait2(m->handler.epoll_fd, m->handler.revents, count, tsp,
+			   &origsigs);
+	pthread_sigmask(SIG_SETMASK, &origsigs, NULL);
+#elif defined(USE_EPOLL) && defined(HAVE_EPOLL_PWAIT)
+	num = epoll_pwait(m->handler.epoll_fd, m->handler.revents, count,
+			  timeout, &origsigs);
+	pthread_sigmask(SIG_SETMASK, &origsigs, NULL);
+#elif defined(USE_EPOLL) && defined(HAVE_EPOLL_WAIT)
+	/* Not ideal - there is a race after we restore the signal mask */
+	pthread_sigmask(SIG_SETMASK, &origsigs, NULL);
+	num = epoll_wait(m->handler.epoll_fd, m->handler.revents, count,
+			 timeout);
+#elif defined(HAVE_PPOLL)
 	num = ppoll(m->handler.copy, count + 1, tsp, &origsigs);
 	pthread_sigmask(SIG_SETMASK, &origsigs, NULL);
 #else
@@ -901,9 +1079,35 @@ done:
 	if (num < 0 && errno == EINTR)
 		*eintr_p = true;
 
-	if (num > 0 && m->handler.copy[count].revents != 0 && num--)
-		while (read(m->io_pipe[0], &trash, sizeof(trash)) > 0)
-			;
+	/* Drain the pipe */
+	while (read(m->io_pipe[0], &trash, sizeof(trash)) > 0)
+		;
+
+		/* When poll() is used, we need to remove the io_pipe[0]
+		 * from m->handler.copy and decreate "num" as fast as
+		 * possible. Otherwise, when current thread is awakened,
+		 * even if there is no ready I/O task, thread_process_io
+		 * will still iterate over m->handler.copy until io_pipe[0]
+		 * is find, which is inefficient.
+		 *
+		 * When epoll-APIs are used, we can postpone handling of
+		 * io_pipe[0] in thread_process_io. In the case mentioned
+		 * above, thread_process_io just need to iterate over a
+		 * single-element m->handler.revents, which is much faster
+		 * than poll() case (thanks to epoll_wait's behavior). Of
+		 * course, removing io_pipe[0] from m->handler.revents is
+		 * still a feasible choice. However, it is not as easy as
+		 * removing the last element of m->handler.copy before, since
+		 * we don't know where io_pipe[0] is located in m->handler.revents
+		 * now. Only by traversing through m->handler.revents can we
+		 * find io_pipe[0] and remove it. So, why don't we just postpone
+		 * this traverse to thread_process_io to avoid an additional
+		 * traverse?
+		 */
+#if !EPOLL_ENABLED
+	if (num > 0 && m->handler.copy[count].revents != 0)
+		num--;
+#endif
 
 	rcu_read_lock();
 
@@ -937,13 +1141,103 @@ void _event_add_read_write(const struct xref_eventsched *xref,
 		if (t_ptr && *t_ptr)
 			break;
 
+#if EPOLL_ENABLED
+		/* placeholder struct epoll_event for fast hash lookup */
+		struct epoll_event set_ev;
+		struct epoll_event *hash_ev;
+		struct stat fd_stat;
+		bool fd_closed;
+		int i;
+
+		memset(&set_ev, 0, sizeof(set_ev));
+		set_ev.data.fd = fd;
+		set_ev.events = (dir == EVENT_READ ? EPOLLIN : EPOLLOUT);
+
+		get_fd_stat(fd, &fd_stat, &fd_closed);
+		hash_ev = hash_lookup(m->handler.epoll_event_hash, &set_ev);
+
+		if (hash_ev) {
+			/* Existing fd */
+			set_ev.events |= hash_ev->events;
+			if (S_ISREG(fd_stat.st_mode)) {
+				/* Regular file, modify the entry in m->handler.regular_events */
+				for (i = 0; i < m->handler.regular_revent_count;
+				     i++) {
+					if (m->handler.regular_revents[i]
+						    .data.fd == fd)
+						break;
+				}
+				if (i < m->handler.regular_revent_count) {
+					m->handler.regular_revents[i].events =
+						set_ev.events;
+				} else {
+					zlog_debug("%s: A regular file I/O event registered in epoll_event_hash, but not in regular_event",
+						   __func__);
+					zlog_debug("[!] threadmaster: %s | fd: %d",
+						   m->name ? m->name : "", fd);
+				}
+			} else if (-1 == epoll_ctl(m->handler.epoll_fd,
+						   EPOLL_CTL_MOD, fd, &set_ev)) {
+				/* Not regular file, modify the entry in the epoll set */
+				if (errno == 2) {
+					/* The fd is already closed and removed from epoll set,
+					 * but still in the hash table (fd is a zombie)
+					 */
+					set_ev.events =
+						(dir == EVENT_READ
+							 ? EPOLLIN
+							 : EPOLLOUT); // reset .events of new set_ev
+					if (-1 == epoll_ctl(m->handler.epoll_fd,
+							    EPOLL_CTL_ADD, fd,
+							    &set_ev)) {
+						/* Not regular file, add into the epoll set */
+						zlog_debug("%s: EPOLL_CTL_MOD and EPOLL_CTL_ADD error, errno: %d",
+							   __func__, errno);
+						zlog_debug("[!] threadmaster: %s | fd: %d",
+							   m->name ? m->name
+								   : "",
+							   fd);
+					}
+				} else {
+					zlog_debug("%s: EPOLL_CTL_MOD error, errno: %d",
+						   __func__, errno);
+					zlog_debug("[!] threadmaster: %s | fd: %d",
+						   m->name ? m->name : "", fd);
+				}
+			}
+			/* Modify existing hash element */
+			hash_ev->events = set_ev.events;
+		} else {
+			/* New fd */
+			if (S_ISREG(fd_stat.st_mode)) {
+				/* Regular file, add into m->handler.regular_events */
+				assert(m->handler.regular_revent_count <
+				       m->handler.eventsize);
+				m->handler
+					.regular_revents[m->handler.regular_revent_count]
+					.data.fd = fd;
+				m->handler
+					.regular_revents[m->handler.regular_revent_count]
+					.events = set_ev.events;
+				m->handler.regular_revent_count++;
+			} else if (-1 == epoll_ctl(m->handler.epoll_fd,
+						   EPOLL_CTL_ADD, fd, &set_ev)) {
+				/* Not regular file, add into the epoll set */
+				if (errno == 2) {
+					zlog_debug("%s: EPOLL_CTL_ADD error, errno: %d",
+						   __func__, errno);
+					zlog_debug("[!] threadmaster: %s | fd: %d",
+						   m->name ? m->name : "", fd);
+				}
+			}
+			/* Add hash element */
+			hash_ev = epoll_event_new(fd, set_ev.events);
+			(void)hash_get(m->handler.epoll_event_hash, hash_ev,
+				       hash_alloc_intern);
+		}
+#else
 		/* default to a new pollfd */
 		nfds_t queuepos = m->handler.pfdcount;
-
-		if (dir == EVENT_READ)
-			thread_array = m->read;
-		else
-			thread_array = m->write;
 
 		/*
 		 * if we already have a pollfd for our file descriptor, find and
@@ -952,15 +1246,6 @@ void _event_add_read_write(const struct xref_eventsched *xref,
 		for (nfds_t i = 0; i < m->handler.pfdcount; i++) {
 			if (m->handler.pfds[i].fd == fd) {
 				queuepos = i;
-
-#ifdef DEV_BUILD
-				/*
-				 * What happens if we have a thread already
-				 * created for this event?
-				 */
-				if (thread_array[fd])
-					assert(!"Thread already scheduled for file descriptor");
-#endif
 				break;
 			}
 			/*
@@ -976,14 +1261,29 @@ void _event_add_read_write(const struct xref_eventsched *xref,
 		/* make sure we have room for this fd + pipe poker fd */
 		assert(queuepos + 1 < m->handler.pfdsize);
 
-		thread = thread_get(m, dir, func, arg, xref);
-
 		m->handler.pfds[queuepos].fd = fd;
 		m->handler.pfds[queuepos].events |=
 			(dir == EVENT_READ ? POLLIN : POLLOUT);
 
 		if (queuepos == m->handler.pfdcount)
 			m->handler.pfdcount++;
+#endif
+
+		if (dir == EVENT_READ)
+			thread_array = m->read;
+		else
+			thread_array = m->write;
+
+#ifdef DEV_BUILD
+		/*
+		 * What happens if we have a thread already
+		 * created for this event?
+		 */
+		if (thread_array[fd])
+			assert(!"Thread already scheduled for file descriptor");
+#endif
+
+		thread = thread_get(m, dir, func, arg, xref);
 
 		if (thread) {
 			frr_with_mutex (&thread->mtx) {
@@ -1140,9 +1440,110 @@ void _event_add_event(const struct xref_eventsched *xref, struct event_loop *m,
  * @param fd
  * @param state the event to cancel. One or more (OR'd together) of the
  * following:
- *   - POLLIN
- *   - POLLOUT
+ *   - POLLIN/EPOLLIN
+ *   - POLLOUT/EPOLLOUT
  */
+#if EPOLL_ENABLED
+static void event_cancel_rw(struct event_loop *master, int fd, short state,
+			    int idx_hint)
+{
+	struct epoll_event set_ev;
+	struct epoll_event *hash_ev;
+	struct stat fd_stat;
+	bool fd_closed;
+	int i;
+
+	get_fd_stat(fd, &fd_stat, &fd_closed);
+
+	memset(&set_ev, 0, sizeof(set_ev));
+	set_ev.data.fd = fd;
+	hash_ev = hash_lookup(master->handler.epoll_event_hash, &set_ev);
+	if (!hash_ev) {
+		zlog_debug(
+			"[!] Received cancellation request for nonexistent rw job");
+		zlog_debug("[!] threadmaster: %s | fd: %d",
+			   master->name ? master->name : "", fd);
+		return;
+	}
+
+	/* NOT out event. */
+	set_ev.events = hash_ev->events &= ~(state);
+
+	if (set_ev.events == 0) {
+		/* All events are canceled, unregister the fd */
+		if (S_ISREG(fd_stat.st_mode)) {
+			/* Regular file, remove the fd from m->handler.regular_events */
+			for (i = 0; i < master->handler.regular_revent_count;
+			     i++) {
+				if (master->handler.regular_revents[i].data.fd ==
+				    fd)
+					break;
+			}
+			if (i >= master->handler.regular_revent_count) {
+				zlog_debug("%s: A regular file I/O event registered in epoll_event_hash, but not in regular_event",
+					   __func__);
+				zlog_debug("[!] threadmaster: %s | fd: %d",
+					   master->name ? master->name : "", fd);
+			}
+			memmove(master->handler.regular_revents + i,
+				master->handler.regular_revents + i + 1,
+				(master->handler.regular_revent_count - i - 1) *
+					sizeof(struct epoll_event));
+			master->handler.regular_revent_count--;
+			master->handler
+				.regular_revents[master->handler.regular_revent_count]
+				.data.fd = 0;
+			master->handler
+				.regular_revents[master->handler.regular_revent_count]
+				.events = 0;
+		} else if (!fd_closed &&
+			   -1 == epoll_ctl(master->handler.epoll_fd,
+					   EPOLL_CTL_DEL, fd, NULL)) {
+			/* Not regular file, remove the fd from the epoll set */
+			zlog_debug("%s: EPOLL_CTL_DEL error, errno: %d",
+				   __func__, errno);
+			zlog_debug("[!] threadmaster: %s | fd: %d",
+				   master->name ? master->name : "", fd);
+		}
+		/* Remove fd from hash table */
+		hash_release(master->handler.epoll_event_hash, hash_ev);
+
+	} else {
+		/* Not all events are canceled */
+		if (S_ISREG(fd_stat.st_mode)) {
+			/* Regular file, update the fd's events in
+			 * m->handler.regular_events
+			 */
+			for (i = 0; i < master->handler.regular_revent_count;
+			     i++) {
+				if (master->handler.regular_revents[i].data.fd ==
+				    fd)
+					break;
+			}
+			if (i < master->handler.regular_revent_count) {
+				master->handler.regular_revents[i].events =
+					set_ev.events;
+			} else {
+				zlog_debug("%s: A regular file I/O event registered in epoll_event_hash, but not in regular_event",
+					   __func__);
+				zlog_debug("[!] threadmaster: %s | fd: %d",
+					   master->name ? master->name : "", fd);
+			}
+		} else if (-1 == epoll_ctl(master->handler.epoll_fd,
+					   EPOLL_CTL_MOD, fd, &set_ev)) {
+			/* Not regular file, update the fd's events
+			 * from the epoll set
+			 */
+			zlog_debug("%s: EPOLL_CTL_MOD error, errno: %d",
+				   __func__, errno);
+			zlog_debug("[!] threadmaster: %s | fd: %d",
+				   master->name ? master->name : "", fd);
+		}
+		/* update the fd's events in the hash table. */
+		hash_ev->events = set_ev.events;
+	}
+}
+#else
 static void event_cancel_rw(struct event_loop *master, int fd, short state,
 			    int idx_hint)
 {
@@ -1206,6 +1607,48 @@ static void event_cancel_rw(struct event_loop *master, int fd, short state,
 		master->handler.copy[master->handler.copycount].events = 0;
 	}
 }
+#endif
+
+#if EPOLL_ENABLED
+struct cr_rw_iter_arg_t {
+	struct event_loop *master;
+	struct cancel_req *cr;
+};
+
+static void cr_rw_iter(struct hash_bucket *hb, void *arg)
+{
+	struct epoll_event *ev = hb->data;
+	struct cr_rw_iter_arg_t *cr_iter_arg = arg;
+	struct event_loop *master = cr_iter_arg->master;
+	struct cancel_req *cr = cr_iter_arg->cr;
+	struct event *t;
+	int fd;
+
+	fd = ev->data.fd;
+	if (fd == master->io_pipe[0] || fd == master->io_pipe[1])
+		return;
+
+	if (ev->events & EPOLLIN)
+		t = master->read[fd];
+	else
+		t = master->write[fd];
+
+	if (t && t->arg == cr->eventobj) {
+		/* Found a match to cancel: clean up fd arrays */
+		event_cancel_rw(master, fd, ev->events, -1);
+
+		/* Clean up thread arrays */
+		master->read[fd] = NULL;
+		master->write[fd] = NULL;
+
+		/* Clear caller's ref */
+		if (t->ref)
+			*t->ref = NULL;
+
+		thread_add_unuse(master, t);
+	}
+}
+#endif
 
 /*
  * Process task cancellation given a task argument: iterate through the
@@ -1215,9 +1658,15 @@ static void cancel_arg_helper(struct event_loop *master,
 			      const struct cancel_req *cr)
 {
 	struct event *t;
+#if EPOLL_ENABLED
+	struct cr_rw_iter_arg_t cr_rw_iter_arg = {
+		.master = master, .cr = (struct cancel_req *)cr
+	};
+#else
 	nfds_t i;
 	int fd;
 	struct pollfd *pfd;
+#endif
 
 	/* We're only processing arg-based cancellations here. */
 	if (cr->eventobj == NULL)
@@ -1247,6 +1696,10 @@ static void cancel_arg_helper(struct event_loop *master,
 		return;
 
 	/* Check the io tasks */
+#if EPOLL_ENABLED
+	hash_iterate(master->handler.epoll_event_hash, cr_rw_iter,
+		     &cr_rw_iter_arg);
+#else
 	for (i = 0; i < master->handler.pfdcount;) {
 		pfd = master->handler.pfds + i;
 
@@ -1285,6 +1738,7 @@ static void cancel_arg_helper(struct event_loop *master,
 		} else
 			i++;
 	}
+#endif
 
 	/* Check the timer tasks */
 	t = event_timer_list_first(&master->timer);
@@ -1348,11 +1802,19 @@ static void do_event_cancel(struct event_loop *master)
 		/* Determine the appropriate queue to cancel the thread from */
 		switch (thread->type) {
 		case EVENT_READ:
+#if EPOLL_ENABLED
+			event_cancel_rw(master, thread->u.fd, EPOLLIN, -1);
+#else
 			event_cancel_rw(master, thread->u.fd, POLLIN, -1);
+#endif
 			thread_array = master->read;
 			break;
 		case EVENT_WRITE:
+#if EPOLL_ENABLED
+			event_cancel_rw(master, thread->u.fd, EPOLLOUT, -1);
+#else
 			event_cancel_rw(master, thread->u.fd, POLLOUT, -1);
+#endif
 			thread_array = master->write;
 			break;
 		case EVENT_TIMER:
@@ -1562,6 +2024,154 @@ static struct event *thread_run(struct event_loop *m, struct event *thread,
 	return fetch;
 }
 
+#if EPOLL_ENABLED
+static int thread_process_io_helper(struct event_loop *m, struct event *thread,
+				    short state, short actual_state, int i,
+				    int fd, struct stat *fd_stat,
+				    struct epoll_event *hash_ev)
+{
+	struct event **thread_array;
+	struct epoll_event set_ev;
+
+	/*
+	 * Clear the events corresponding to "state" in
+	 * regular_revents/epoll set, and hash table.
+	 *
+	 * This cleans up a possible infinite loop where we refuse
+	 * to respond to a epoll event but epoll is insistent that
+	 * we should.
+	 */
+	memset(&set_ev, 0, sizeof(set_ev));
+	set_ev.data.fd = fd;
+	set_ev.events = hash_ev->events & ~(state);
+
+	if (S_ISREG(fd_stat->st_mode)) {
+		/* Regular file, update the fd's events in
+		 * m->handler.regular_events
+		 */
+		m->handler.regular_revents[i].events = set_ev.events;
+	} else if (-1 ==
+		   epoll_ctl(m->handler.epoll_fd, EPOLL_CTL_MOD, fd, &set_ev)) {
+		/* Not regular file, update the fd's events
+		 * from the epoll set
+		 */
+		zlog_debug("%s: EPOLL_CTL_MOD error, errno: %d", __func__,
+			   errno);
+		zlog_debug("[!] threadmaster: %s | fd: %d",
+			   m->name ? m->name : "", fd);
+	}
+	/* update the fd's events in the hash table. */
+	hash_ev->events = set_ev.events;
+
+	if (!thread) {
+		if ((actual_state & (EPOLLHUP | EPOLLIN)) != EPOLLHUP)
+			flog_err(EC_LIB_NO_THREAD,
+				 "Attempting to process an I/O event but for fd: %d(%d) no thread to handle this!",
+				 fd, actual_state);
+		return 0;
+	}
+
+	if (thread->type == EVENT_READ)
+		thread_array = m->read;
+	else
+		thread_array = m->write;
+
+	thread_array[thread->u.fd] = NULL;
+	event_list_add_tail(&m->ready, thread);
+	thread->type = EVENT_READY;
+
+	return 1;
+}
+
+static inline void thread_process_io_inner_loop(struct event_loop *m,
+						struct epoll_event *revents,
+						int *i)
+{
+	struct epoll_event *hash_ev;
+	struct epoll_event set_ev;
+	int fd;
+	struct stat fd_stat;
+	bool fd_closed;
+
+	fd = revents[*i].data.fd;
+	m->handler.fd_poll_counter[fd] += 1;
+	if (fd == m->io_pipe[0])
+		return;
+
+	get_fd_stat(fd, &fd_stat, &fd_closed);
+
+	memset(&set_ev, 0, sizeof(set_ev));
+	set_ev.data.fd = fd;
+	hash_ev = hash_lookup(m->handler.epoll_event_hash, &set_ev);
+	assert(hash_ev);
+
+	/* Process the I/O event */
+	if (revents[*i].events & (EPOLLIN | EPOLLHUP | EPOLLERR)) {
+		thread_process_io_helper(m, m->read[fd], EPOLLIN,
+					 revents[*i].events, *i, fd, &fd_stat,
+					 hash_ev);
+	}
+	if (revents[*i].events & (EPOLLOUT)) {
+		thread_process_io_helper(m, m->write[fd], EPOLLOUT,
+					 revents[*i].events, *i, fd, &fd_stat,
+					 hash_ev);
+	}
+
+	/*
+	 * if one of our file descriptors is garbage, remove the fd
+	 * from regular_revents/epoll set, and hash table.
+	 */
+	if (fd_closed || (revents[*i].events & (EPOLLHUP | EPOLLERR))) {
+		if (S_ISREG(fd_stat.st_mode)) {
+			/* Regular file, remove the fd from m->handler.regular_events */
+			memmove(m->handler.regular_revents + *i,
+				m->handler.regular_revents + *i + 1,
+				(m->handler.regular_revent_count - *i - 1) *
+					sizeof(struct epoll_event));
+			m->handler.regular_revent_count--;
+			m->handler
+				.regular_revents[m->handler.regular_revent_count]
+				.data.fd = 0;
+			m->handler
+				.regular_revents[m->handler.regular_revent_count]
+				.events = 0;
+			/* regular_revents is modified when iterating on it, rollback */
+			*i = *i - 1;
+		} else if (!fd_closed &&
+			   -1 == epoll_ctl(m->handler.epoll_fd, EPOLL_CTL_DEL,
+					   fd, NULL)) {
+			/* Not regular file, remove the fd from the epoll set */
+			zlog_debug("%s: EPOLL_CTL_DEL error, errno: %d",
+				   __func__, errno);
+			zlog_debug("[!] threadmaster: %s | fd: %d",
+				   m->name ? m->name : "", fd);
+		}
+		/* Remove fd from hash table */
+		hash_release(m->handler.epoll_event_hash, hash_ev);
+	}
+}
+
+/**
+ * Process I/O events.
+ *
+ * @param m the thread master
+ * @param num return value of epoll_wait()
+ */
+static void thread_process_io(struct event_loop *m, int num)
+{
+	int i;
+
+	/* First, handle regular file I/O events in m->handler.regular_revents. */
+	for (i = 0; i < m->handler.regular_revent_count; ++i)
+		thread_process_io_inner_loop(m, m->handler.regular_revents, &i);
+
+	/* Second, handle I/O events in m->handler.revents which are returned by
+	 * epoll_wait().
+	 */
+	for (i = 0; i < num; ++i)
+		thread_process_io_inner_loop(m, m->handler.revents, &i);
+}
+#else
 static int thread_process_io_helper(struct event_loop *m, struct event *thread,
 				    short state, short actual_state, int pos)
 {
@@ -1687,6 +2297,7 @@ static void thread_process_io(struct event_loop *m, unsigned int num)
 
 	m->last_read++;
 }
+#endif
 
 /* Add all timers that have popped to the ready list. */
 static unsigned int thread_process_timers(struct event_loop *m,
@@ -1722,11 +2333,10 @@ static unsigned int thread_process(struct event_list_head *list)
 	return ready;
 }
 
-
-/* Fetch next ready thread. */
-struct event *event_fetch(struct event_loop *m, struct event *fetch)
+static void event_fetch_inner_loop(struct event_loop *m, struct event *thread,
+				   struct event *fetch, bool *broken,
+				   bool *continued)
 {
-	struct event *thread = NULL;
 	struct timeval now;
 	struct timeval zerotime = {0, 0};
 	struct timeval tv;
@@ -1734,110 +2344,145 @@ struct event *event_fetch(struct event_loop *m, struct event *fetch)
 	bool eintr_p = false;
 	int num = 0;
 
+	/* Handle signals if any */
+	if (m->handle_signals)
+		frr_sigevent_process();
+
+	pthread_mutex_lock(&m->mtx);
+
+	/* Process any pending cancellation requests */
+	do_event_cancel(m);
+
+	/*
+	 * Attempt to flush ready queue before going into poll().
+	 * This is performance-critical. Think twice before modifying.
+	 */
+	if ((thread = event_list_pop(&m->ready))) {
+		fetch = thread_run(m, thread, fetch);
+		if (fetch->ref)
+			*fetch->ref = NULL;
+		pthread_mutex_unlock(&m->mtx);
+		if (!m->ready_run_loop)
+			GETRUSAGE(&m->last_getrusage);
+		m->ready_run_loop = true;
+		*broken = true;
+		return;
+	}
+
+	m->ready_run_loop = false;
+	/* otherwise, tick through scheduling sequence */
+
+	/*
+	 * Post events to ready queue. This must come before the
+	 * following block since events should occur immediately
+	 */
+	thread_process(&m->event);
+
+	/*
+	 * If there are no tasks on the ready queue, we will poll()
+	 * until a timer expires or we receive I/O, whichever comes
+	 * first. The strategy for doing this is:
+	 *
+	 * - If there are events pending, set the poll() timeout to zero
+	 * - If there are no events pending, but there are timers
+	 * pending, set the timeout to the smallest remaining time on
+	 * any timer.
+	 * - If there are neither timers nor events pending, but there
+	 * are file descriptors pending, block indefinitely in poll()
+	 * - If nothing is pending, it's time for the application to die
+	 *
+	 * In every case except the last, we need to hit poll() at least
+	 * once per loop to avoid starvation by events
+	 */
+	if (!event_list_count(&m->ready))
+		tw = thread_timer_wait(&m->timer, &tv);
+
+	if (event_list_count(&m->ready) || (tw && !timercmp(tw, &zerotime, >)))
+		tw = &zerotime;
+
+#if EPOLL_ENABLED
+	if (!tw && m->handler.regular_revent_count == 0 &&
+	    hashcount(m->handler.epoll_event_hash) == 0) { /* die */
+		pthread_mutex_unlock(&m->mtx);
+		fetch = NULL;
+		*broken = true;
+		return;
+	}
+#else
+	if (!tw && m->handler.pfdcount == 0) { /* die */
+		pthread_mutex_unlock(&m->mtx);
+		fetch = NULL;
+		*broken = true;
+		return;
+	}
+#endif
+
+#if !EPOLL_ENABLED
+	/*
+	 * Copy pollfd array + # active pollfds in it. Not necessary to
+	 * copy the array size as this is fixed.
+	 */
+	m->handler.copycount = m->handler.pfdcount;
+	memcpy(m->handler.copy, m->handler.pfds,
+	       m->handler.copycount * sizeof(struct pollfd));
+#endif
+
+	pthread_mutex_unlock(&m->mtx);
+	{
+		eintr_p = false;
+		num = fd_poll(m, tw, &eintr_p);
+	}
+	pthread_mutex_lock(&m->mtx);
+
+	/* Handle any errors received in poll()/epoll_wait() */
+	if (num < 0) {
+		if (eintr_p) {
+			pthread_mutex_unlock(&m->mtx);
+			/* loop around to signal handler */
+			*continued = true;
+			return;
+		}
+
+		/* else die */
+#if EPOLL_ENABLED
+		flog_err(EC_LIB_SYSTEM_CALL, "epoll_wait() error: %s",
+			 safe_strerror(errno));
+#else
+		flog_err(EC_LIB_SYSTEM_CALL, "poll() error: %s",
+			 safe_strerror(errno));
+#endif
+		pthread_mutex_unlock(&m->mtx);
+		fetch = NULL;
+		*broken = true;
+		return;
+	}
+
+	/* Post timers to ready queue. */
+	monotime(&now);
+	thread_process_timers(m, &now);
+
+	/* Post I/O to ready queue. */
+	if (num > 0)
+		thread_process_io(m, num);
+
+	pthread_mutex_unlock(&m->mtx);
+}
+
+/* Fetch next ready thread. */
+struct event *event_fetch(struct event_loop *m, struct event *fetch)
+{
+	struct event *thread = NULL;
+	bool broken = false;
+	bool continued = false;
+
 	do {
-		/* Handle signals if any */
-		if (m->handle_signals)
-			frr_sigevent_process();
-
-		pthread_mutex_lock(&m->mtx);
-
-		/* Process any pending cancellation requests */
-		do_event_cancel(m);
-
-		/*
-		 * Attempt to flush ready queue before going into poll().
-		 * This is performance-critical. Think twice before modifying.
-		 */
-		if ((thread = event_list_pop(&m->ready))) {
-			fetch = thread_run(m, thread, fetch);
-			if (fetch->ref)
-				*fetch->ref = NULL;
-			pthread_mutex_unlock(&m->mtx);
-			if (!m->ready_run_loop)
-				GETRUSAGE(&m->last_getrusage);
-			m->ready_run_loop = true;
+		broken = false;
+		continued = false;
+		event_fetch_inner_loop(m, thread, fetch, &broken, &continued);
+		if (broken)
 			break;
-		}
-
-		m->ready_run_loop = false;
-		/* otherwise, tick through scheduling sequence */
-
-		/*
-		 * Post events to ready queue. This must come before the
-		 * following block since events should occur immediately
-		 */
-		thread_process(&m->event);
-
-		/*
-		 * If there are no tasks on the ready queue, we will poll()
-		 * until a timer expires or we receive I/O, whichever comes
-		 * first. The strategy for doing this is:
-		 *
-		 * - If there are events pending, set the poll() timeout to zero
-		 * - If there are no events pending, but there are timers
-		 * pending, set the timeout to the smallest remaining time on
-		 * any timer.
-		 * - If there are neither timers nor events pending, but there
-		 * are file descriptors pending, block indefinitely in poll()
-		 * - If nothing is pending, it's time for the application to die
-		 *
-		 * In every case except the last, we need to hit poll() at least
-		 * once per loop to avoid starvation by events
-		 */
-		if (!event_list_count(&m->ready))
-			tw = thread_timer_wait(&m->timer, &tv);
-
-		if (event_list_count(&m->ready) ||
-		    (tw && !timercmp(tw, &zerotime, >)))
-			tw = &zerotime;
-
-		if (!tw && m->handler.pfdcount == 0) { /* die */
-			pthread_mutex_unlock(&m->mtx);
-			fetch = NULL;
-			break;
-		}
-
-		/*
-		 * Copy pollfd array + # active pollfds in it. Not necessary to
-		 * copy the array size as this is fixed.
-		 */
-		m->handler.copycount = m->handler.pfdcount;
-		memcpy(m->handler.copy, m->handler.pfds,
-		       m->handler.copycount * sizeof(struct pollfd));
-
-		pthread_mutex_unlock(&m->mtx);
-		{
-			eintr_p = false;
-			num = fd_poll(m, tw, &eintr_p);
-		}
-		pthread_mutex_lock(&m->mtx);
-
-		/* Handle any errors received in poll() */
-		if (num < 0) {
-			if (eintr_p) {
-				pthread_mutex_unlock(&m->mtx);
-				/* loop around to signal handler */
-				continue;
-			}
-
-			/* else die */
-			flog_err(EC_LIB_SYSTEM_CALL, "poll() error: %s",
-				 safe_strerror(errno));
-			pthread_mutex_unlock(&m->mtx);
-			fetch = NULL;
-			break;
-		}
-
-		/* Post timers to ready queue. */
-		monotime(&now);
-		thread_process_timers(m, &now);
-
-		/* Post I/O to ready queue. */
-		if (num > 0)
-			thread_process_io(m, num);
-
-		pthread_mutex_unlock(&m->mtx);
-
+		if (continued)
+			continue;
 	} while (!thread && m->spin);
 
 	return fetch;

--- a/lib/frrevent.h
+++ b/lib/frrevent.h
@@ -6,10 +6,21 @@
 #ifndef _ZEBRA_THREAD_H
 #define _ZEBRA_THREAD_H
 
+#if defined(USE_EPOLL) &&                                                      \
+	(defined(HAVE_EPOLL_WAIT) || defined(HAVE_EPOLL_PWAIT) ||              \
+	 defined(HAVE_EPOLL_PWAIT2))
+#define EPOLL_ENABLED 1
+#else
+#define EPOLL_ENABLED 0
+#endif
+
 #include <signal.h>
 #include <zebra.h>
 #include <pthread.h>
 #include <poll.h>
+#if EPOLL_ENABLED
+#include <sys/epoll.h>
+#endif
 #include "monotime.h"
 #include "frratomic.h"
 #include "typesafe.h"
@@ -43,6 +54,34 @@ struct rusage_t {
 PREDECL_LIST(event_list);
 PREDECL_HEAP(event_timer_list);
 
+#if EPOLL_ENABLED
+struct fd_handler {
+	/* The epoll set file descriptor */
+	int epoll_fd;
+
+	/* A hash table in which monitored I/O file descrpitors and events
+	 * are registered
+	 */
+	struct hash *epoll_event_hash;
+
+	/* Maximum size of .revents and .regular_revents arrays */
+	int eventsize;
+
+	/* The buffer which stores the results of epoll_wait */
+	struct epoll_event *revents;
+
+	/* Vtysh might redirect stdin/stdout to regular files. However,
+	 * regular files can't be added into epoll set and need special
+	 * treatment. I/O events from/to regular file will be directly
+	 * added to regular_revents, but not into epoll set, whereby
+	 * sidesteping epoll_wait.
+	 */
+	struct epoll_event *regular_revents;
+	int regular_revent_count;
+
+	unsigned long *fd_poll_counter;
+};
+#else
 struct fd_handler {
 	/* number of pfd that fit in the allocated space of pfds. This is a
 	 * constant and is the same for both pfds and copy.
@@ -59,6 +98,7 @@ struct fd_handler {
 	/* number of pollfds stored in copy */
 	nfds_t copycount;
 };
+#endif
 
 struct xref_eventsched {
 	struct xref xref;
@@ -91,7 +131,9 @@ struct event_loop {
 	pthread_mutex_t mtx;
 	pthread_t owner;
 
+#if !EPOLL_ENABLED
 	nfds_t last_read;
+#endif
 
 	bool ready_run_loop;
 	RUSAGE_T last_getrusage;

--- a/lib/monotime.h
+++ b/lib/monotime.h
@@ -59,6 +59,18 @@ struct printfrr_eargs;
 	} while (0)
 #endif
 
+#ifndef msec_to_timespec
+#define msec_to_timespec(ms, ts, tsp)                                          \
+	do {                                                                   \
+		if ((ms) >= 0) {                                               \
+			(ts).tv_sec = (ms) / 1000;                             \
+			(ts).tv_nsec = ((ms) % 1000) * 1000000;                \
+			(tsp) = &(ts);                                         \
+		} else                                                         \
+			(tsp) = NULL;                                          \
+	} while (0)
+#endif
+
 static inline time_t monotime(struct timeval *tvo)
 {
 	struct timespec ts;


### PR DESCRIPTION
This commit substitutes poll APIs with epoll APIs for better performace. Note that epoll APIs are only available for Linux platforms. For BSD platforms which do not support epoll APIs, poll APIs are still used.