### PR TITLE
watchfrr: Allow -w option to be ignored

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -175,7 +175,12 @@ daemon_start() {
 	instopt="${inst:+-n $inst}"
 	eval args="\$${daemon}_options"
 
-	cmd="$all_wrap $wrap $bin $nsopt -d $frr_global_options $instopt $args"
+	if [ "$daemon" = "watchfrr" ]; then
+		cmd="$all_wrap $wrap $bin $nsopt -d $instopt $args"
+	else
+		cmd="$all_wrap $wrap $bin $nsopt -d $frr_global_options $instopt $args"
+	fi
+
 	log_success_msg "Starting $daemon with command: '$cmd'"
 	if eval "$cmd"; then
 		log_success_msg "Started $dmninst"


### PR DESCRIPTION
Our startup scripts allow the passing of a cli command to all daemons started.  Recently -w was added to handle namespaces better, but watchfrr was not included.  This caused people using startup scripts to be a bit unhappy. Let's get them rolling by adding a quick and dirty ignoring of that flag to watchfrr.

Fixes: #18107