### PR TITLE
yang: Default value for a key leaf to be ignored

### DIFF
--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -520,7 +520,6 @@ module frr-bfdd {
 
           leaf bfd-name {
             type string;
-            default "";
             description "Bfd session name.";
           }
 
@@ -582,7 +581,6 @@ module frr-bfdd {
 
           leaf bfd-name {
             type string;
-            default "";
             description "Bfd session name.";
           }
 


### PR DESCRIPTION
Default value for a key leaf to be ignored
In YANG, key leaves are used to uniquely identify list entries, and they cannot have default values