### PR TITLE
staticd: Failed to register nexthop after networking restart

### DIFF
--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -53,6 +53,11 @@ void zebra_stable_node_cleanup(struct route_table *table,
 /* Install static path into rib. */
 void static_install_path(struct static_path *pn)
 {
+	struct static_nexthop *nh;
+
+	frr_each (static_nexthop_list, &pn->nexthop_list, nh)
+		static_zebra_nht_register(nh, true);
+
 	if (static_nexthop_list_count(&pn->nexthop_list))
 		static_zebra_route_add(pn, true);
 }


### PR DESCRIPTION
Problem:
After networking restart, staticd unregistered the nexthop but failed to register the nexthop again, which caused the nexthop to remain inactive in zebra for static route.

Fix:
Call to static_zebra_nht_register() from static_install_path() was removed in 3c05d53bf8defc36acdfe6e78064e068d60c649f. Adding it back so that staticd can register the nexthop for static routes.

Testing:
After networking restart trigger on h1:

Before fix:
```
h1# show ipv6 route vrf vrf1012
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIPng, O - OSPFv3, I - IS-IS, B - BGP, N - NHRP,
       T - Table, A - Babel, D - SHARP, F - PBR, f - OpenFabric,
       t - Table-Direct, Z - FRR,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

VRF vrf1012:
S   ::/0 [1/0] via 2003:7:2::1, swp1.2 inactive, weight 1, 00:00:39 ===> NH for static route is inactive
K>* ::/0 [255/8192] unreachable (ICMP unreachable) (vrf default), 00:00:39
L * 2000:9:12::3/128 is directly connected, vrf1012, 00:00:39
C>* 2000:9:12::3/128 is directly connected, vrf1012, 00:00:39
C>* 2003:7:2::/125 is directly connected, swp1.2, 00:00:37
L>* 2003:7:2::3/128 is directly connected, swp1.2, 00:00:37
C>* fe80::/64 is directly connected, swp1.2, 00:00:37
h1#
```

After fix:
```
h1# show ipv6 route vrf vrf1012

Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIPng, O - OSPFv3, I - IS-IS, B - BGP, N - NHRP,
       T - Table, A - Babel, D - SHARP, F - PBR, f - OpenFabric,
       t - Table-Direct, Z - FRR,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

VRF vrf1012:
S>* ::/0 [1/0] via 2003:7:2::1, swp1.2, weight 1, 00:00:15
K * ::/0 [255/8192] unreachable (ICMP unreachable) (vrf default), 00:00:17
L * 2000:9:12::3/128 is directly connected, vrf1012, 00:00:17
C>* 2000:9:12::3/128 is directly connected, vrf1012, 00:00:17
C>* 2003:7:2::/125 is directly connected, swp1.2, 00:00:15
L>* 2003:7:2::3/128 is directly connected, swp1.2, 00:00:15
```