### PR TITLE
lib: fix false context information for SRv6 route (backport #18023 for 10.1)

### DIFF
--- a/lib/srv6.c
+++ b/lib/srv6.c
@@ -75,7 +75,7 @@ const char *seg6local_context2str(char *str, size_t size,
 	switch (action) {
 
 	case ZEBRA_SEG6_LOCAL_ACTION_END:
-		snprintf(str, size, "USP");
+		snprintf(str, size, "-");
 		return str;
 
 	case ZEBRA_SEG6_LOCAL_ACTION_END_X:


### PR DESCRIPTION
Manual backport of https://github.com/FRRouting/frr/pull/18023 for FRR 10.1