### PR TITLE
isisd: Request SRv6 locator after zebra connection

### DIFF
--- a/isisd/isis_srv6.c
+++ b/isisd/isis_srv6.c
@@ -658,6 +658,27 @@ int isis_srv6_ifp_up_notify(struct interface *ifp)
 }
 
 /**
+ * Request SRv6 locator info from the SID Manager for all IS-IS areas where SRv6
+ * is enabled and a locator has been configured.
+ * This function is called as soon as the connection with Zebra is established
+ * to get information about all configured locators.
+ */
+void isis_srv6_locators_request(void)
+{
+	struct isis *isis = isis_lookup_by_vrfid(VRF_DEFAULT);
+	struct listnode *node;
+	struct isis_area *area;
+
+	if (!isis)
+		return;
+
+	for (ALL_LIST_ELEMENTS_RO(isis->area_list, node, area))
+		if (area->srv6db.config.enabled &&
+		    area->srv6db.config.srv6_locator_name[0] != '\0' && !area->srv6db.srv6_locator)
+			isis_zebra_srv6_manager_get_locator(area->srv6db.config.srv6_locator_name);
+}
+
+/**
  * IS-IS SRv6 initialization for given area.
  *
  * @param area	IS-IS area

--- a/isisd/isis_srv6.h
+++ b/isisd/isis_srv6.h
@@ -155,6 +155,8 @@ isis_srv6_sid_alloc(struct isis_area *area, struct srv6_locator *locator,
 		    struct in6_addr *sid_value);
 extern void isis_srv6_sid_free(struct isis_srv6_sid *sid);
 
+void isis_srv6_locators_request(void);
+
 extern void isis_srv6_area_init(struct isis_area *area);
 extern void isis_srv6_area_term(struct isis_area *area);
 

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -805,6 +805,7 @@ static void isis_zebra_connected(struct zclient *zclient)
 	zclient_register_opaque(zclient, LDP_IGP_SYNC_IF_STATE_UPDATE);
 	zclient_register_opaque(zclient, LDP_IGP_SYNC_ANNOUNCE_UPDATE);
 	bfd_client_sendmsg(zclient, ZEBRA_BFD_CLIENT_REGISTER, VRF_DEFAULT);
+	isis_srv6_locators_request();
 }
 
 /**


### PR DESCRIPTION
When SRv6 is enabled and an SRv6 locator is specified in the IS-IS configuration, IS-IS may attempt to request SRv6 locator information from zebra before the connection is fully established. If this occurs, the request fails with the following error:

```
2025/02/14 21:41:20 ISIS: [HR66R-TWQYD][EC 100663302] srv6_manager_get_locator: invalid zclient socket
````

As a result, IS-IS is unable to obtain the locator information, preventing SRv6 from working.

This PR fixes the issue by ensuring IS-IS requests SRv6 locator information once the connection with zebra is successfully established.