### PR TITLE
doc: correct `ip rip split-horizon` command in the documentation

### DIFF
--- a/doc/user/ripd.rst
+++ b/doc/user/ripd.rst
@@ -149,12 +149,12 @@ RIP Configuration
 
    The default is to be passive on all interfaces.
 
-.. clicmd:: ip split-horizon [poisoned-reverse]
+.. clicmd:: ip rip split-horizon [poisoned-reverse]
 
 
-   Control split-horizon on the interface. Default is `ip split-horizon`. If
+   Control split-horizon on the interface. Default is `ip rip split-horizon`. If
    you don't perform split-horizon on the interface, please specify `no ip
-   split-horizon`.
+   rip split-horizon`.
 
    If `poisoned-reverse` is also set, the router sends the poisoned routes
    with highest metric back to the sending router.


### PR DESCRIPTION
The previous version incorrectly spelled the command as `ip split-horizon`. The correct command is `ip rip split-horizon`, as indicated in the code at line 675 of rip_cli.c.