### PR TITLE
More connection cleanup

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1974,14 +1974,12 @@ bgp_reconnect(struct peer_connection *connection)
 static enum bgp_fsm_state_progress
 bgp_fsm_open(struct peer_connection *connection)
 {
-	struct peer *peer = connection->peer;
-
 	/* If DelayOpen is active, we may still need to send an open message */
 	if ((connection->status == Connect) || (connection->status == Active))
 		bgp_open_send(connection);
 
 	/* Send keepalive and make keepalive timer */
-	bgp_keepalive_send(peer);
+	bgp_keepalive_send(connection);
 
 	return BGP_FSM_SUCCESS;
 }

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -108,7 +108,7 @@ static void peer_process(struct hash_bucket *hb, void *arg)
 			zlog_debug("%s [FSM] Timer (keepalive timer expire)",
 				   pkat->peer->host);
 
-		bgp_keepalive_send(pkat->peer);
+		bgp_keepalive_send(pkat->peer->connection);
 		monotime(&pkat->last);
 		memset(&elapsed, 0, sizeof(elapsed));
 		diff = ka;

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -31,7 +31,7 @@ DEFINE_MTYPE_STATIC(BGPD, BGP_MUTEX, "BGP Peer pthread Mutex");
  */
 struct pkat {
 	/* the peer to send keepalives to */
-	struct peer *peer;
+	struct peer_connection *connection;
 	/* absolute time of last keepalive sent */
 	struct timeval last;
 };
@@ -41,10 +41,10 @@ static pthread_mutex_t *peerhash_mtx;
 static pthread_cond_t *peerhash_cond;
 static struct hash *peerhash;
 
-static struct pkat *pkat_new(struct peer *peer)
+static struct pkat *pkat_new(struct peer_connection *connection)
 {
 	struct pkat *pkat = XMALLOC(MTYPE_BGP_PKAT, sizeof(struct pkat));
-	pkat->peer = peer;
+	pkat->connection = connection;
 	monotime(&pkat->last);
 	return pkat;
 }
@@ -53,7 +53,6 @@ static void pkat_del(void *pkat)
 {
 	XFREE(MTYPE_BGP_PKAT, pkat);
 }
-
 
 /*
  * Callback for hash_iterate. Determines if a peer needs a keepalive and if so,
@@ -77,7 +76,7 @@ static void pkat_del(void *pkat)
 static void peer_process(struct hash_bucket *hb, void *arg)
 {
 	struct pkat *pkat = hb->data;
-
+	struct peer *peer = pkat->connection->peer;
 	struct timeval *next_update = arg;
 
 	static struct timeval elapsed;  // elapsed time since keepalive
@@ -86,8 +85,7 @@ static void peer_process(struct hash_bucket *hb, void *arg)
 
 	static const struct timeval tolerance = {0, 100000};
 
-	uint32_t v_ka = atomic_load_explicit(&pkat->peer->v_keepalive,
-					     memory_order_relaxed);
+	uint32_t v_ka = atomic_load_explicit(&peer->v_keepalive, memory_order_relaxed);
 
 	/* 0 keepalive timer means no keepalives */
 	if (v_ka == 0)
@@ -104,11 +102,10 @@ static void peer_process(struct hash_bucket *hb, void *arg)
 		elapsed.tv_sec >= ka.tv_sec || timercmp(&diff, &tolerance, <);
 
 	if (send_keepalive) {
-		if (bgp_debug_keepalive(pkat->peer))
-			zlog_debug("%s [FSM] Timer (keepalive timer expire)",
-				   pkat->peer->host);
+		if (bgp_debug_keepalive(peer))
+			zlog_debug("%s [FSM] Timer (keepalive timer expire)", peer->host);
 
-		bgp_keepalive_send(pkat->peer->connection);
+		bgp_keepalive_send(pkat->connection);
 		monotime(&pkat->last);
 		memset(&elapsed, 0, sizeof(elapsed));
 		diff = ka;
@@ -124,13 +121,13 @@ static bool peer_hash_cmp(const void *f, const void *s)
 	const struct pkat *p1 = f;
 	const struct pkat *p2 = s;
 
-	return p1->peer == p2->peer;
+	return p1->connection == p2->connection;
 }
 
 static unsigned int peer_hash_key(const void *arg)
 {
 	const struct pkat *pkat = arg;
-	return (uintptr_t)pkat->peer;
+	return (uintptr_t)pkat->connection;
 }
 
 /* Cleanup handler / deinitializer. */
@@ -248,9 +245,9 @@ void bgp_keepalives_on(struct peer_connection *connection)
 	assert(peerhash_mtx);
 
 	frr_with_mutex (peerhash_mtx) {
-		holder.peer = peer;
+		holder.connection = connection;
 		if (!hash_lookup(peerhash, &holder)) {
-			struct pkat *pkat = pkat_new(peer);
+			struct pkat *pkat = pkat_new(connection);
 			(void)hash_get(peerhash, pkat, hash_alloc_intern);
 			peer_lock(peer);
 		}
@@ -279,7 +276,7 @@ void bgp_keepalives_off(struct peer_connection *connection)
 	assert(peerhash_mtx);
 
 	frr_with_mutex (peerhash_mtx) {
-		holder.peer = peer;
+		holder.connection = connection;
 		struct pkat *res = hash_release(peerhash, &holder);
 		if (res) {
 			pkat_del(res);

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -396,7 +396,7 @@ static void bgp_accept(struct event *thread)
 	int accept_sock;
 	union sockunion su;
 	struct bgp_listener *listener = EVENT_ARG(thread);
-	struct peer *doppelganger, *peer1;
+	struct peer *doppelganger, *peer;
 	struct peer_connection *connection, *incoming;
 	char buf[SU_ADDRSTRLEN];
 	struct bgp *bgp = NULL;
@@ -475,9 +475,9 @@ static void bgp_accept(struct event *thread)
 	bgp_update_setsockopt_tcp_keepalive(bgp, bgp_sock);
 
 	/* Check remote IP address */
-	peer1 = peer_lookup(bgp, &su);
+	peer = peer_lookup(bgp, &su);
 
-	if (!peer1) {
+	if (!peer) {
 		struct peer *dynamic_peer = peer_lookup_dynamic_neighbor(bgp, &su);
 
 		if (dynamic_peer) {
@@ -519,7 +519,7 @@ static void bgp_accept(struct event *thread)
 		}
 	}
 
-	if (!peer1) {
+	if (!peer) {
 		if (bgp_debug_neighbor_events(NULL)) {
 			zlog_debug(
 				"[Event] %s connection rejected(%s:%u:%s) - not configured and not valid for dynamic",
@@ -530,10 +530,12 @@ static void bgp_accept(struct event *thread)
 		return;
 	}
 
-	connection = peer1->connection;
-	if (CHECK_FLAG(peer1->flags, PEER_FLAG_SHUTDOWN)
-	    || CHECK_FLAG(peer1->bgp->flags, BGP_FLAG_SHUTDOWN)) {
-		if (bgp_debug_neighbor_events(peer1))
+	/* bgp pointer may be null, but since we have a peer data structure we know we have it */
+	bgp = peer->bgp;
+	connection = peer->connection;
+	if (CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN) ||
+	    CHECK_FLAG(peer->bgp->flags, BGP_FLAG_SHUTDOWN)) {
+		if (bgp_debug_neighbor_events(peer))
 			zlog_debug(
 				"[Event] connection from %s rejected(%s:%u:%s) due to admin shutdown",
 				inet_sutop(&su, buf), bgp->name_pretty, bgp->as,
@@ -549,20 +551,18 @@ static void bgp_accept(struct event *thread)
 	 * block incoming connection in Deleted state.
 	 */
 	if (connection->status == Clearing || connection->status == Deleted) {
-		if (bgp_debug_neighbor_events(peer1))
-			zlog_debug("[Event] Closing incoming conn for %s (%p) state %d",
-				   peer1->host, peer1,
-				   connection->status);
+		if (bgp_debug_neighbor_events(peer))
+			zlog_debug("[Event] Closing incoming conn for %s (%p) state %d", peer->host,
+				   peer, connection->status);
 		close(bgp_sock);
 		return;
 	}
 
 	/* Check that at least one AF is activated for the peer. */
 	if (!peer_active(connection)) {
-		if (bgp_debug_neighbor_events(peer1))
-			zlog_debug(
-				"%s - incoming conn rejected - no AF activated for peer",
-				peer1->host);
+		if (bgp_debug_neighbor_events(peer))
+			zlog_debug("%s - incoming conn rejected - no AF activated for peer",
+				   peer->host);
 		close(bgp_sock);
 		return;
 	}
@@ -571,54 +571,50 @@ static void bgp_accept(struct event *thread)
 	 * prefixes, restart timer is still running or the peer
 	 * is shutdown, or BGP identifier is not set (0.0.0.0).
 	 */
-	if (BGP_PEER_START_SUPPRESSED(peer1)) {
-		if (bgp_debug_neighbor_events(peer1)) {
-			if (peer1->shut_during_cfg)
-				zlog_debug(
-					"[Event] Incoming BGP connection rejected from %s due to configuration being currently read in",
-					peer1->host);
+	if (BGP_PEER_START_SUPPRESSED(peer)) {
+		if (bgp_debug_neighbor_events(peer)) {
+			if (peer->shut_during_cfg)
+				zlog_debug("[Event] Incoming BGP connection rejected from %s due to configuration being currently read in",
+					   peer->host);
 			else
-				zlog_debug(
-					"[Event] Incoming BGP connection rejected from %s due to maximum-prefix or shutdown",
-					peer1->host);
+				zlog_debug("[Event] Incoming BGP connection rejected from %s due to maximum-prefix or shutdown",
+					   peer->host);
 		}
 		close(bgp_sock);
 		return;
 	}
 
-	if (peer1->bgp->router_id.s_addr == INADDR_ANY) {
+	if (peer->bgp->router_id.s_addr == INADDR_ANY) {
 		zlog_warn("[Event] Incoming BGP connection rejected from %s due missing BGP identifier, set it with `bgp router-id`",
-			  peer1->host);
-		peer1->last_reset = PEER_DOWN_ROUTER_ID_ZERO;
+			  peer->host);
+		peer->last_reset = PEER_DOWN_ROUTER_ID_ZERO;
 		close(bgp_sock);
 		return;
 	}
 
-	if (bgp_debug_neighbor_events(peer1))
+	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("[Event] connection from %s fd %d, active peer status %d fd %d",
 			   inet_sutop(&su, buf), bgp_sock, connection->status, connection->fd);
 
-	if (peer1->doppelganger) {
+	if (peer->doppelganger) {
 		/* We have an existing connection. Kill the existing one and run
 		   with this one.
 		*/
-		if (bgp_debug_neighbor_events(peer1))
-			zlog_debug(
-				"[Event] New active connection from peer %s, Killing previous active connection",
-				peer1->host);
-		peer_delete(peer1->doppelganger);
+		if (bgp_debug_neighbor_events(peer))
+			zlog_debug("[Event] New active connection from peer %s, Killing previous active connection",
+				   peer->host);
+		peer_delete(peer->doppelganger);
 	}
 
-	doppelganger = peer_create(&su, peer1->conf_if, peer1->bgp, peer1->local_as, peer1->as,
-				   peer1->as_type, NULL, false, NULL);
+	doppelganger = peer_create(&su, peer->conf_if, bgp, peer->local_as, peer->as, peer->as_type,
+				   NULL, false, NULL);
 
 	incoming = doppelganger->connection;
 
-	peer_xfer_config(doppelganger, peer1);
+	peer_xfer_config(doppelganger, peer);
 	bgp_peer_gr_flags_update(doppelganger);
 
-	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(doppelganger->bgp,
-							  doppelganger->bgp->peer);
+	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(bgp, bgp->peer);
 
 	if (bgp_peer_gr_mode_get(doppelganger) == PEER_DISABLE) {
 		UNSET_FLAG(doppelganger->sflags, PEER_STATUS_NSF_MODE);
@@ -628,8 +624,8 @@ static void bgp_accept(struct event *thread)
 		}
 	}
 
-	doppelganger->doppelganger = peer1;
-	peer1->doppelganger = doppelganger;
+	doppelganger->doppelganger = peer;
+	peer->doppelganger = doppelganger;
 
 	incoming->fd = bgp_sock;
 	incoming->dir = CONNECTION_INCOMING;
@@ -642,7 +638,7 @@ static void bgp_accept(struct event *thread)
 				   doppelganger->host);
 
 	frr_with_privs(&bgpd_privs) {
-		vrf_bind(doppelganger->bgp->vrf_id, bgp_sock, bgp_get_bound_name(incoming));
+		vrf_bind(bgp->vrf_id, bgp_sock, bgp_get_bound_name(incoming));
 	}
 	bgp_peer_reg_with_nht(doppelganger);
 	bgp_fsm_change_status(incoming, Active);
@@ -650,20 +646,18 @@ static void bgp_accept(struct event *thread)
 
 	SET_FLAG(doppelganger->sflags, PEER_STATUS_ACCEPT_PEER);
 	/* Make dummy peer until read Open packet. */
-	if (peer_established(connection) &&
-	    CHECK_FLAG(peer1->sflags, PEER_STATUS_NSF_MODE)) {
+	if (peer_established(connection) && CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_MODE)) {
 		/* If we have an existing established connection with graceful
 		 * restart
 		 * capability announced with one or more address families, then
 		 * drop
 		 * existing established connection and move state to connect.
 		 */
-		peer1->last_reset = PEER_DOWN_NSF_CLOSE_SESSION;
+		peer->last_reset = PEER_DOWN_NSF_CLOSE_SESSION;
 
-		if (CHECK_FLAG(peer1->flags, PEER_FLAG_GRACEFUL_RESTART)
-		    || CHECK_FLAG(peer1->flags,
-				  PEER_FLAG_GRACEFUL_RESTART_HELPER))
-			SET_FLAG(peer1->sflags, PEER_STATUS_NSF_WAIT);
+		if (CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART) ||
+		    CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART_HELPER))
+			SET_FLAG(peer->sflags, PEER_STATUS_NSF_WAIT);
 
 		bgp_event_update(connection, TCP_connection_closed);
 	}

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -483,6 +483,7 @@ static void bgp_accept(struct event *thread)
 			connection1 = peer1->connection;
 			/* Dynamic neighbor has been created, let it proceed */
 			connection1->fd = bgp_sock;
+			connection1->dir = CONNECTION_INCOMING;
 
 			connection1->su_local = sockunion_getsockname(connection1->fd);
 			connection1->su_remote = sockunion_dup(&su);
@@ -636,6 +637,7 @@ static void bgp_accept(struct event *thread)
 	peer1->doppelganger = peer;
 
 	connection->fd = bgp_sock;
+	connection->dir = CONNECTION_INCOMING;
 	connection->su_local = sockunion_getsockname(connection->fd);
 	connection->su_remote = sockunion_dup(&su);
 
@@ -801,6 +803,7 @@ enum connect_result bgp_connect(struct peer_connection *connection)
 		connection->fd =
 			vrf_sockunion_socket(&connection->su, peer->bgp->vrf_id,
 					     bgp_get_bound_name(connection));
+		connection->dir = CONNECTION_OUTGOING;
 	}
 	if (connection->fd < 0) {
 		peer->last_reset = PEER_DOWN_SOCKET_ERROR;

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -613,7 +613,7 @@ void bgp_generate_updgrp_packets(struct event *thread)
 /*
  * Creates a BGP Keepalive packet and appends it to the peer's output queue.
  */
-void bgp_keepalive_send(struct peer *peer)
+void bgp_keepalive_send(struct peer_connection *connection)
 {
 	struct stream *s;
 
@@ -628,13 +628,13 @@ void bgp_keepalive_send(struct peer *peer)
 	/* Dump packet if debug option is set. */
 	/* bgp_packet_dump (s); */
 
-	if (bgp_debug_keepalive(peer))
-		zlog_debug("%s sending KEEPALIVE", peer->host);
+	if (bgp_debug_keepalive(connection->peer))
+		zlog_debug("%s sending KEEPALIVE", connection->peer->host);
 
 	/* Add packet to the peer. */
-	bgp_packet_add(peer->connection, peer, s);
+	bgp_packet_add(connection, connection->peer, s);
 
-	bgp_writes_on(peer->connection);
+	bgp_writes_on(connection);
 }
 
 struct stream *bgp_open_make(struct peer *peer, uint16_t send_holdtime, as_t local_as,

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -48,7 +48,7 @@ DECLARE_HOOK(bgp_packet_send,
 	} while (0)
 
 /* Packet send and receive function prototypes. */
-extern void bgp_keepalive_send(struct peer *peer);
+extern void bgp_keepalive_send(struct peer_connection *connection);
 extern struct stream *bgp_open_make(struct peer *peer, uint16_t send_holdtime, as_t local_as,
 				    struct in_addr *id);
 extern void bgp_open_send(struct peer_connection *connection);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1180,6 +1180,22 @@ void bgp_peer_connection_free(struct peer_connection **connection)
 	connection = NULL;
 }
 
+const char *bgp_peer_get_connection_direction(struct peer_connection *connection)
+{
+	switch (connection->dir) {
+	case UNKNOWN:
+		return "Unknown";
+	case CONNECTION_INCOMING:
+		return "Incoming";
+	case CONNECTION_OUTGOING:
+		return "Outgoing";
+	case ESTABLISHED:
+		return "Established";
+	}
+
+	assert(!"DEV Escape: Expected switch to take care of this state");
+}
+
 struct peer_connection *bgp_peer_connection_new(struct peer *peer)
 {
 	struct peer_connection *connection;
@@ -1527,6 +1543,7 @@ struct peer *peer_new(struct bgp *bgp)
 
 	/* Create buffers. */
 	peer->connection = bgp_peer_connection_new(peer);
+	peer->connection->dir = CONNECTION_OUTGOING;
 
 	/* Set default value. */
 	peer->v_start = BGP_INIT_START_TIMER;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1213,8 +1213,28 @@ struct addpath_paths_limit {
 	uint16_t receive;
 };
 
+/*
+ * The peer data structure has a incoming and outgoing peer connection
+ * variables.  In the early stage of the FSM, it is possible to have
+ * both a incoming and outgoing connection at the same time.  These
+ * connections both have events scheduled to happen that both produce
+ * logs.  It is very hard to tell these debugs apart when looking at
+ * the log files so the debugs are now adding direction strings to
+ * help figure out what is going on.  At a later stage in the FSM
+ * one of the connections will be closed and the other one kept.
+ * The one being kept is moved to the ESTABLISHED connection direction
+ * so that debugs can be figured out.
+ */
+enum connection_direction {
+	UNKNOWN,
+	CONNECTION_INCOMING,
+	CONNECTION_OUTGOING,
+	ESTABLISHED,
+};
+
 struct peer_connection {
 	struct peer *peer;
+	enum connection_direction dir;
 
 	/* Status of the peer connection. */
 	enum bgp_fsm_status status;
@@ -1263,6 +1283,7 @@ struct peer_connection {
 	union sockunion *su_local;  /* Sockunion of local address. */
 	union sockunion *su_remote; /* Sockunion of remote address. */
 };
+const char *bgp_peer_get_connection_direction(struct peer_connection *connection);
 extern struct peer_connection *bgp_peer_connection_new(struct peer *peer);
 extern void bgp_peer_connection_free(struct peer_connection **connection);
 extern void bgp_peer_connection_buffers_free(struct peer_connection *connection);


### PR DESCRIPTION
See individual commits.  But the gist of these commits is to further cleanup usages of the connection instead of the peer.  Additionally clean up bgp_accept to have a better naming convention.