### PR TITLE
tests: Remove warning about passive command

### DIFF
--- a/tests/topotests/ospf_sr_te_topo1/rt1/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt1/ospfd.conf
@@ -10,6 +10,7 @@ log file ospfd.log
 !
 interface lo
  ip ospf area 0.0.0.0
+ ip ospf passive
 !
 interface eth-sw1
   ip ospf network point-to-point
@@ -27,7 +28,6 @@ router ospf
  mpls-te export
  mpls-te router-address 1.1.1.1
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_sr_te_topo1/rt2/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt2/ospfd.conf
@@ -9,6 +9,7 @@ log file ospfd.log
 !
 interface lo
  ip ospf area 0.0.0.0
+ ip ospf passive
 !
 interface eth-sw1
   ip ospf network point-to-point
@@ -38,7 +39,6 @@ router ospf
  !mpls-te export
  mpls-te router-address 2.2.2.2
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_sr_te_topo1/rt4/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt4/ospfd.conf
@@ -9,6 +9,7 @@ log file ospfd.log
 !
 interface lo
  ip ospf area 0.0.0.0
+ ip ospf passive
 !
 interface eth-rt2-1
   ip ospf network point-to-point
@@ -44,7 +45,6 @@ router ospf
  !mpls-te export
  mpls-te router-address 4.4.4.4
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_sr_te_topo1/rt5/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt5/ospfd.conf
@@ -9,6 +9,7 @@ log file ospfd.log
 !
 interface lo
  ip ospf area 0.0.0.0
+ ip ospf passive
 !
 interface eth-rt3-1
   ip ospf network point-to-point
@@ -44,7 +45,6 @@ router ospf
 ! mpls-te export
  mpls-te router-address 5.5.5.5
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_sr_te_topo1/rt6/ospfd.conf
+++ b/tests/topotests/ospf_sr_te_topo1/rt6/ospfd.conf
@@ -9,6 +9,7 @@ log file ospfd.log
 !
 interface lo
  ip ospf area 0.0.0.0
+ ip ospf passive
 !
 interface eth-rt4
   ip ospf network point-to-point
@@ -32,7 +33,6 @@ router ospf
  mpls-te export
  mpls-te router-address 6.6.6.6
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_sr_topo1/rt1/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt1/ospfd.conf
@@ -9,6 +9,7 @@ log file ospfd.log
 ! debug ospf zebra
 !
 interface lo
+  ip ospf passive
 !
 interface eth-sw1
  ip ospf network broadcast
@@ -23,7 +24,6 @@ router ospf
  mpls-te on
  mpls-te router-address 1.1.1.1
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_sr_topo1/rt2/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt2/ospfd.conf
@@ -9,6 +9,7 @@ log file ospfd.log
 ! debug ospf zebra
 !
 interface lo
+  ip ospf passive
 !
 interface eth-sw1
  ip ospf network broadcast
@@ -33,7 +34,6 @@ router ospf
  mpls-te on
  mpls-te router-address 2.2.2.2
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_sr_topo1/rt3/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt3/ospfd.conf
@@ -9,6 +9,7 @@ log file ospfd.log
 ! debug ospf zebra
 !
 interface lo
+  ip ospf passive
 !
 interface eth-sw1
  ip ospf network broadcast
@@ -33,7 +34,6 @@ router ospf
  mpls-te on
  mpls-te router-address 3.3.3.3
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 17000 24999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_sr_topo1/rt4/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt4/ospfd.conf
@@ -9,6 +9,7 @@ log file ospfd.log
 ! debug ospf zebra
 !
 interface lo
+  ip ospf passive
 !
 interface eth-rt2-1
  ip ospf network point-to-point
@@ -38,7 +39,6 @@ router ospf
  mpls-te on
  mpls-te router-address 4.4.4.4
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_sr_topo1/rt5/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt5/ospfd.conf
@@ -9,6 +9,7 @@ log file ospfd.log
 ! debug ospf zebra
 !
 interface lo
+  ip ospf passive
 !
 interface eth-rt3-1
  ip ospf network point-to-point
@@ -38,7 +39,6 @@ router ospf
  mpls-te on
  mpls-te router-address 5.5.5.5
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_sr_topo1/rt6/ospfd.conf
+++ b/tests/topotests/ospf_sr_topo1/rt6/ospfd.conf
@@ -9,6 +9,7 @@ log file ospfd.log
 ! debug ospf zebra
 !
 interface lo
+  ip ospf passive
 !
 interface eth-rt4
  ip ospf network point-to-point
@@ -28,7 +29,6 @@ router ospf
  mpls-te on
  mpls-te router-address 6.6.6.6
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_tilfa_topo1/rt1/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt1/ospfd.conf
@@ -2,6 +2,7 @@
 ! debug ospf ti-lfa
 !
 interface lo
+  ip ospf passive
 !
 interface eth-rt2
  ip ospf network point-to-point
@@ -19,7 +20,6 @@ router ospf
  mpls-te on
  mpls-te router-address 1.1.1.1
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_tilfa_topo1/rt2/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt2/ospfd.conf
@@ -2,6 +2,7 @@
 ! debug ospf ti-lfa
 !
 interface lo
+  ip ospf passive
 !
 interface eth-rt1
  ip ospf network point-to-point
@@ -19,7 +20,6 @@ router ospf
  mpls-te on
  mpls-te router-address 1.1.1.2
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_tilfa_topo1/rt3/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt3/ospfd.conf
@@ -2,6 +2,7 @@
 ! debug ospf ti-lfa
 !
 interface lo
+  ip ospf passive
 !
 interface eth-rt1
  ip ospf network point-to-point
@@ -19,7 +20,6 @@ router ospf
  mpls-te on
  mpls-te router-address 1.1.1.3
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_tilfa_topo1/rt4/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt4/ospfd.conf
@@ -2,6 +2,7 @@
 ! debug ospf ti-lfa
 !
 interface lo
+  ip ospf passive
 !
 interface eth-rt2
  ip ospf network point-to-point
@@ -19,7 +20,6 @@ router ospf
  mpls-te on
  mpls-te router-address 1.1.1.4
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/ospf_tilfa_topo1/rt5/ospfd.conf
+++ b/tests/topotests/ospf_tilfa_topo1/rt5/ospfd.conf
@@ -2,6 +2,7 @@
 ! debug ospf ti-lfa
 !
 interface lo
+  ip ospf passive
 !
 interface eth-rt3
  ip ospf network point-to-point
@@ -19,7 +20,6 @@ router ospf
  mpls-te on
  mpls-te router-address 1.1.1.5
  router-info area 0.0.0.0
- passive-interface lo
  segment-routing on
  segment-routing global-block 16000 23999
  segment-routing node-msd 8

--- a/tests/topotests/pim_acl/r1/ospfd.conf
+++ b/tests/topotests/pim_acl/r1/ospfd.conf
@@ -2,6 +2,9 @@ hostname r1
 !
 ! debug ospf event
 !
+interface r1-eth0
+  ip ospf passive
+!
 interface r1-eth1
  ip ospf hello-interval 2
  ip ospf dead-interval 10
@@ -9,7 +12,6 @@ interface r1-eth1
 !
 router ospf
  ospf router-id 192.168.0.1
- passive-interface r1-eth0
  network 192.168.0.1/32 area 0
  network 192.168.100.0/24 area 0
  network 192.168.101.0/24 area 0


### PR DESCRIPTION
Several tests have warnings about the passive
command and how to use it.  Let's address this.