### PR TITLE
*: Remove unneeded IPV6_JOIN|LEAVE_GROUP

### DIFF
--- a/ospf6d/ospf6d.h
+++ b/ospf6d/ospf6d.h
@@ -18,22 +18,6 @@ extern struct event_loop *master;
 /* OSPF config processing timer thread */
 extern struct event *t_ospf6_cfg;
 
-/* Historical for KAME.  */
-#ifndef IPV6_JOIN_GROUP
-#ifdef IPV6_ADD_MEMBERSHIP
-#define IPV6_JOIN_GROUP IPV6_ADD_MEMBERSHIP
-#endif /* IPV6_ADD_MEMBERSHIP. */
-#ifdef IPV6_JOIN_MEMBERSHIP
-#define IPV6_JOIN_GROUP  IPV6_JOIN_MEMBERSHIP
-#endif /* IPV6_JOIN_MEMBERSHIP. */
-#endif /* ! IPV6_JOIN_GROUP*/
-
-#ifndef IPV6_LEAVE_GROUP
-#ifdef IPV6_DROP_MEMBERSHIP
-#define IPV6_LEAVE_GROUP IPV6_DROP_MEMBERSHIP
-#endif /* IPV6_DROP_MEMBERSHIP */
-#endif /* ! IPV6_LEAVE_GROUP */
-
 #define MSG_OK    0
 #define MSG_NG    1
 

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -26,14 +26,6 @@
 #include "ripngd/ripngd.h"
 #include "ripngd/ripng_debug.h"
 
-/* If RFC2133 definition is used. */
-#ifndef IPV6_JOIN_GROUP
-#define IPV6_JOIN_GROUP  IPV6_ADD_MEMBERSHIP
-#endif
-#ifndef IPV6_LEAVE_GROUP
-#define IPV6_LEAVE_GROUP IPV6_DROP_MEMBERSHIP
-#endif
-
 DEFINE_MTYPE_STATIC(RIPNGD, RIPNG_IF, "ripng interface");
 
 /* Static utility function. */

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -47,14 +47,6 @@ DEFINE_MTYPE_STATIC(ZEBRA, ADV_IF, "Advertised Interface");
 #include <netinet/icmp6.h>
 #endif
 
-/* If RFC2133 definition is used. */
-#ifndef IPV6_JOIN_GROUP
-#define IPV6_JOIN_GROUP  IPV6_ADD_MEMBERSHIP
-#endif
-#ifndef IPV6_LEAVE_GROUP
-#define IPV6_LEAVE_GROUP IPV6_DROP_MEMBERSHIP
-#endif
-
 #define ALLNODE   "ff02::1"
 #define ALLROUTER "ff02::2"
 


### PR DESCRIPTION
Headers include this stuff now.  No need for it
in our code base.