### PR TITLE
pimd: Fix PIM VRF support (send register/register stop in VRF)

### DIFF
--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -181,6 +181,9 @@ static int pim_vrf_enable(struct vrf *vrf)
 
 	zlog_debug("%s: for %s %u", __func__, vrf->name, vrf->vrf_id);
 
+	if (vrf_bind(vrf->vrf_id, pim->reg_sock, NULL) < 0)
+		zlog_warn("Failed to bind register socket to VRF %s", vrf->name);
+
 	pim_mroute_socket_enable(pim);
 
 	FOR_ALL_INTERFACES (vrf, ifp) {


### PR DESCRIPTION
In 946195391406269003275850e1a4d550ea8db38b and
8ebcc02328c6b63ecf85e44fdfbf3365be27c127, transmission of PIM register and register stop messages was changed to use a separate socket. However, that socket is not bound to a possible VRF, so the messages were sent in the default VRF instead. Call vrf_bind() once after socket creation and when the VRF is ready to ensure transmission in the correct VRF. vrf_bind() handles the non-VRF case (i.e. VRF_DEFAULT) automatically, so it may be called unconditionally.