### PR TITLE
fabricd: add option to treat dummy interfaces as loopback interfaces

### DIFF
--- a/doc/manpages/frr-fabricd.rst
+++ b/doc/manpages/frr-fabricd.rst
@@ -21,6 +21,10 @@ OPTIONS available for the |DAEMON| command:
 
 .. include:: common-options.rst
 
+.. option:: --dummy_as_loopback
+
+   Treat dummy interfaces as loopback interfaces.
+
 FILES
 =====
 

--- a/doc/user/fabricd.rst
+++ b/doc/user/fabricd.rst
@@ -15,11 +15,18 @@ FRR implements OpenFabric in a daemon called *fabricd*
 Configuring fabricd
 ===================
 
-There are no *fabricd* specific options. Common options can be specified
-(:ref:`common-invocation-options`) to *fabricd*. *fabricd* needs to acquire
-interface information from *zebra* in order to function. Therefore *zebra* must
-be running before invoking *fabricd*. Also, if *zebra* is restarted then *fabricd*
-must be too.
+*fabricd* accepts all common invocations (:ref:`common-invocation-options`) and
+the following specific options.
+
+.. program:: fabricd
+
+.. option:: --dummy_as_loopback
+
+   Treat dummy interfaces as loopback interfaces.
+
+*fabricd* needs to acquire interface information from *zebra* in order to
+function. Therefore *zebra* must be running before invoking *fabricd*. Also, if
+*zebra* is restarted then *fabricd* must be too.
 
 Like other daemons, *fabricd* configuration is done in an OpenFabric specific
 configuration file :file:`fabricd.conf`.

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -491,16 +491,17 @@ void isis_circuit_if_add(struct isis_circuit *circuit, struct interface *ifp)
 {
 	struct connected *conn;
 
-	if (if_is_broadcast(ifp)) {
+	if (if_is_loopback(ifp) || (isis_option_check(ISIS_OPT_DUMMY_AS_LOOPBACK) &&
+				    CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_DUMMY))) {
+		circuit->circ_type = CIRCUIT_T_LOOPBACK;
+		circuit->is_passive = 1;
+	} else if (if_is_broadcast(ifp)) {
 		if (fabricd || circuit->circ_type_config == CIRCUIT_T_P2P)
 			circuit->circ_type = CIRCUIT_T_P2P;
 		else
 			circuit->circ_type = CIRCUIT_T_BROADCAST;
 	} else if (if_is_pointopoint(ifp)) {
 		circuit->circ_type = CIRCUIT_T_P2P;
-	} else if (if_is_loopback(ifp)) {
-		circuit->circ_type = CIRCUIT_T_LOOPBACK;
-		circuit->is_passive = 1;
 	} else {
 		/* It's normal in case of loopback etc. */
 		if (IS_DEBUG_EVENTS)

--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -80,9 +80,12 @@ struct zebra_privs_t isisd_privs = {
 	.cap_num_p = array_size(_caps_p),
 	.cap_num_i = 0};
 
+#define OPTION_DUMMY_AS_LOOPBACK 2000
+
 /* isisd options */
 static const struct option longopts[] = {
 	{"int_num", required_argument, NULL, 'I'},
+	{"dummy_as_loopback", no_argument, NULL, OPTION_DUMMY_AS_LOOPBACK},
 	{0}};
 
 /* Master of threads. */
@@ -269,15 +272,16 @@ int main(int argc, char **argv, char **envp)
 {
 	int opt;
 	int instance = 1;
+	bool dummy_as_loopback = false;
 
 #ifdef FABRICD
 	frr_preinit(&fabricd_di, argc, argv);
 #else
 	frr_preinit(&isisd_di, argc, argv);
 #endif
-	frr_opt_add(
-		"I:", longopts,
-		"  -I, --int_num      Set instance number (label-manager)\n");
+	frr_opt_add("I:", longopts,
+		"  -I, --int_num		Set instance number (label-manager).\n"
+		"      --dummy_as_loopback      Treat dummy interfaces like loopback interfaces.\n");
 
 	/* Command line argument treatment. */
 	while (1) {
@@ -295,6 +299,9 @@ int main(int argc, char **argv, char **envp)
 				zlog_err("Instance %i out of range (1..%u)",
 					 instance, (unsigned short)-1);
 			break;
+		case OPTION_DUMMY_AS_LOOPBACK:
+			dummy_as_loopback = true;
+			break;
 		default:
 			frr_help_exit(1);
 		}
@@ -311,6 +318,9 @@ int main(int argc, char **argv, char **envp)
 	/* thread master */
 	isis_master_init(frr_init());
 	master = im->master;
+	if (dummy_as_loopback)
+		isis_option_set(ISIS_OPT_DUMMY_AS_LOOPBACK);
+
 	/*
 	 *  initializations
 	 */

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -116,6 +116,25 @@ int show_isis_neighbor_common(struct vty *, struct json_object *json,
 int clear_isis_neighbor_common(struct vty *, const char *id,
 			       const char *vrf_name, bool all_vrf);
 
+
+/* ISIS global flag manipulation.  */
+int isis_option_set(int flag)
+{
+	switch (flag) {
+	case ISIS_OPT_DUMMY_AS_LOOPBACK:
+		SET_FLAG(im->options, flag);
+		break;
+	default:
+		return -1;
+	}
+	return 0;
+}
+
+int isis_option_check(int flag)
+{
+	return CHECK_FLAG(im->options, flag);
+}
+
 /* Link ISIS instance to VRF. */
 void isis_vrf_link(struct isis *isis, struct vrf *vrf)
 {

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -74,7 +74,9 @@ struct isis_master {
 	struct list *isis;
 	/* ISIS thread master. */
 	struct event_loop *master;
+	/* Various global options */
 	uint8_t options;
+#define ISIS_OPT_DUMMY_AS_LOOPBACK (1 << 0)
 };
 #define F_ISIS_UNIT_TEST 0x01
 
@@ -269,6 +271,8 @@ DECLARE_HOOK(isis_area_overload_bit_update, (struct isis_area * area), (area));
 void isis_terminate(void);
 void isis_master_init(struct event_loop *master);
 void isis_master_terminate(void);
+int isis_option_set(int flag);
+int isis_option_check(int flag);
 void isis_vrf_link(struct isis *isis, struct vrf *vrf);
 void isis_vrf_unlink(struct isis *isis, struct vrf *vrf);
 struct isis *isis_lookup_by_vrfid(vrf_id_t vrf_id);

--- a/lib/if.h
+++ b/lib/if.h
@@ -242,6 +242,7 @@ struct interface {
 #define ZEBRA_INTERFACE_SUB        (1 << 1)
 #define ZEBRA_INTERFACE_LINKDETECTION (1 << 2)
 #define ZEBRA_INTERFACE_VRF_LOOPBACK (1 << 3)
+#define ZEBRA_INTERFACE_DUMMY (1 << 4)
 
 	/* Interface flags. */
 	uint64_t flags;

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -221,6 +221,8 @@ static void netlink_determine_zebra_iftype(const char *kind,
 		*zif_type = ZEBRA_IF_BOND;
 	else if (strcmp(kind, "gre") == 0)
 		*zif_type = ZEBRA_IF_GRE;
+	else if (strcmp(kind, "dummy") == 0)
+		*zif_type = ZEBRA_IF_DUMMY;
 }
 
 static void netlink_vrf_change(struct nlmsghdr *h, struct rtattr *tb,
@@ -576,6 +578,7 @@ static void netlink_interface_update_l2info(struct zebra_dplane_ctx *ctx,
 	case ZEBRA_IF_MACVLAN:
 	case ZEBRA_IF_VETH:
 	case ZEBRA_IF_BOND:
+	case ZEBRA_IF_DUMMY:
 		break;
 	}
 }

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -548,6 +548,9 @@ void if_add_update(struct interface *ifp)
 
 	zebra_interface_add_update(ifp);
 
+	if (IS_ZEBRA_IF_DUMMY(ifp))
+		SET_FLAG(ifp->status, ZEBRA_INTERFACE_DUMMY);
+
 	if (!CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE)) {
 		SET_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE);
 
@@ -1616,6 +1619,7 @@ static void interface_update_l2info(struct zebra_dplane_ctx *ctx,
 	case ZEBRA_IF_MACVLAN:
 	case ZEBRA_IF_VETH:
 	case ZEBRA_IF_BOND:
+	case ZEBRA_IF_DUMMY:
 		break;
 	}
 }
@@ -2368,6 +2372,9 @@ static const char *zebra_ziftype_2str(enum zebra_iftype zif_type)
 
 	case ZEBRA_IF_GRE:
 		return "GRE";
+
+	case ZEBRA_IF_DUMMY:
+		return "dummy";
 
 	default:
 		return "Unknown";

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -39,7 +39,8 @@ enum zebra_iftype {
 	ZEBRA_IF_MACVLAN,   /* MAC VLAN interface*/
 	ZEBRA_IF_VETH,      /* VETH interface*/
 	ZEBRA_IF_BOND,	    /* Bond */
-	ZEBRA_IF_GRE,      /* GRE interface */
+	ZEBRA_IF_GRE,       /* GRE interface */
+	ZEBRA_IF_DUMMY,     /* Dummy interface */
 };
 
 /* Zebra "slave" interface type */
@@ -245,6 +246,9 @@ DECLARE_HOOK(zebra_if_extra_info, (struct vty * vty, struct interface *ifp),
 
 #define IS_ZEBRA_IF_GRE(ifp)                                               \
 	(((struct zebra_if *)(ifp->info))->zif_type == ZEBRA_IF_GRE)
+
+#define IS_ZEBRA_IF_DUMMY(ifp)                                               \
+	(((struct zebra_if *)(ifp->info))->zif_type == ZEBRA_IF_DUMMY)
 
 #define IS_ZEBRA_IF_BRIDGE_SLAVE(ifp)					\
 	(((struct zebra_if *)(ifp->info))->zif_slave_type                      \

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -87,6 +87,9 @@ lib_interface_zebra_state_zif_type_get_elem(struct nb_cb_get_elem_args *args)
 	case ZEBRA_IF_GRE:
 		type = "frr-zebra:zif-gre";
 		break;
+	case ZEBRA_IF_DUMMY:
+		type = "frr-zebra:zif-dummy";
+		break;
 	}
 
 	if (!type)


### PR DESCRIPTION
Add interface status flag for interfaces of type "dummy" [0]. Add fabricd option to treat dummy interfaces as loopback interfaces.

This is a (kind of) continuation of  #10679.
This patch enables dummy-interfaces to be used as router-id interfaces in openfabric networks. This allows us to have multiple openfabric routers with different router-id's on a single node when using a ip unnumbered setup (interfaces without ip's configured). Previously we were limited by only having a single loopback interface, meaning only a single openfabric router was possible.

[0]: https://github.com/torvalds/linux/blob/master/drivers/net/dummy.c

