### PR TITLE
pim: Fix vrf binding of autorp and mroute socket (backport #18226)

### DIFF
--- a/pimd/pim_autorp.c
+++ b/pimd/pim_autorp.c
@@ -508,10 +508,19 @@ static bool pim_autorp_socket_enable(struct pim_autorp *autorp)
 			return false;
 		}
 
+		if (vrf_bind(autorp->pim->vrf->vrf_id, fd, NULL)) {
+			zlog_warn("Could not bind autorp socket to vrf fd=%d: vrf_id=%d: errno=%d: %s",
+				  fd, autorp->pim->vrf->vrf_id, errno, safe_strerror(errno));
+			close(fd);
+			return false;
+		}
+
 		autorp->sock = fd;
+
 		if (!pim_autorp_setup(autorp)) {
-			zlog_warn("Could not setup autorp socket fd=%d: errno=%d: %s",
-				  fd, errno, safe_strerror(errno));
+			zlog_warn("Could not setup autorp socket fd=%d: errno=%d: %s", fd, errno,
+				  safe_strerror(errno));
+
 			close(fd);
 			autorp->sock = -1;
 			return false;
@@ -1042,7 +1051,10 @@ void pim_autorp_init(struct pim_instance *pim)
 
 	if (PIM_DEBUG_AUTORP)
 		zlog_debug("%s: AutoRP Initialized", __func__);
+}
 
+void pim_autorp_enable(struct pim_instance *pim)
+{
 	/* Start AutoRP discovery by default on startup */
 	pim_autorp_start_discovery(pim);
 }

--- a/pimd/pim_autorp.h
+++ b/pimd/pim_autorp.h
@@ -150,6 +150,7 @@ void pim_autorp_rm_ifp(struct interface *ifp);
 void pim_autorp_start_discovery(struct pim_instance *pim);
 void pim_autorp_stop_discovery(struct pim_instance *pim);
 void pim_autorp_init(struct pim_instance *pim);
+void pim_autorp_enable(struct pim_instance *pim);
 void pim_autorp_finish(struct pim_instance *pim);
 int pim_autorp_config_write(struct pim_instance *pim, struct vty *vty);
 void pim_autorp_show_autorp(struct vty *vty, struct pim_instance *pim,

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -188,6 +188,10 @@ static int pim_vrf_enable(struct vrf *vrf)
 
 	pim_mroute_socket_enable(pim);
 
+#if PIM_IPV == 4
+	pim_autorp_enable(pim);
+#endif
+
 	FOR_ALL_INTERFACES (vrf, ifp) {
 		if (!ifp->info)
 			continue;

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -864,17 +864,11 @@ int pim_mroute_socket_enable(struct pim_instance *pim)
 				pim->vrf->name);
 #endif
 
-#ifdef SO_BINDTODEVICE
-		if (pim->vrf->vrf_id != VRF_DEFAULT
-		    && setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE,
-				  pim->vrf->name, strlen(pim->vrf->name))) {
-			zlog_warn("Could not setsockopt SO_BINDTODEVICE: %s",
-				  safe_strerror(errno));
+		if (vrf_bind(pim->vrf->vrf_id, fd, NULL)) {
+			zlog_warn("Could not bind to vrf: %s", safe_strerror(errno));
 			close(fd);
 			return -3;
 		}
-#endif
-
 	}
 
 	pim->mroute_socket = fd;


### PR DESCRIPTION
Bind the autorp socket to the vrf device.
Also fixed mroute socket to use vrf_bind instead of directly setting the socket option.

This is an automatic backport of pull request https://github.com/FRRouting/frr/pull/18226 done by [Mergify](https://mergify.com/).