### PR TITLE
ripd: fix no ip rip split-horizon poisoned-reverse command

### DIFF
--- a/ripd/rip_cli.c
+++ b/ripd/rip_cli.c
@@ -681,9 +681,9 @@ DEFPY_YANG (ip_rip_split_horizon,
 {
 	const char *value;
 
-	if (no)
+	if (no && poisoned_reverse == NULL)
 		value = "disabled";
-	else if (poisoned_reverse)
+	else if (poisoned_reverse && no == NULL)
 		value = "poison-reverse";
 	else
 		value = "simple";


### PR DESCRIPTION
`no ip rip split-horizon poisoned-reverse` command will undo poisoned-reverse and set default behavior which is split-horizon. Currently, this command inadvertently disables split-horizon, which is inappropriate.

By contrast, `no ip rip split-horizon` will undo interface's split-horizon behavior.