### PR TITLE
pimd,pim6d: feature parity and show SSM entries

### DIFF
--- a/doc/user/pimv6.rst
+++ b/doc/user/pimv6.rst
@@ -175,6 +175,12 @@ PIMv6 Router
    notifications to the kernel. This command is vrf aware, to configure for a
    vrf, specify the vrf in the router pim6 block.
 
+.. clicmd:: ssm prefix-list WORD
+
+   Specify a range of group addresses via a prefix-list that forces pim to
+   never do SM over. This command is vrf aware, to configure for a vrf, specify
+   the vrf in the router pim block.
+
 .. clicmd:: ssmpingd [X:X::X:X]
 
    Enable ipv6 ssmpingd configuration. A network level management tool

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1465,6 +1465,26 @@ DEFPY_ATTR(no_ipv6_ssmpingd,
 	return ret;
 }
 
+DEFPY_YANG(ipv6_pim_ssm,
+           ipv6_pim_ssm_cmd,
+           "[no] ssm prefix-list PREFIXLIST6_NAME$plist",
+           NO_STR
+           "Source Specific Multicast\n"
+           "Group range prefix-list filter\n"
+           "Name of a prefix-list\n")
+{
+	char ssm_plist_xpath[XPATH_MAXLEN];
+
+	snprintf(ssm_plist_xpath, sizeof(ssm_plist_xpath), "./ssm-prefix-list");
+
+	if (no)
+		nb_cli_enqueue_change(vty, ssm_plist_xpath, NB_OP_DESTROY, NULL);
+	else
+		nb_cli_enqueue_change(vty, ssm_plist_xpath, NB_OP_MODIFY, plist);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
 DEFPY_YANG_HIDDEN (interface_ipv6_mld_join,
                    interface_ipv6_mld_join_cmd,
                    "[no] ipv6 mld join X:X::X:X$grp [X:X::X:X]$src",
@@ -2943,6 +2963,7 @@ void pim_cmd_init(void)
 	install_element(PIM6_NODE, &pim6_embedded_rp_group_list_cmd);
 	install_element(PIM6_NODE, &pim6_embedded_rp_limit_cmd);
 
+	install_element(PIM6_NODE, &ipv6_pim_ssm_cmd);
 	install_element(PIM6_NODE, &pim6_ssmpingd_cmd);
 	install_element(PIM6_NODE, &no_pim6_ssmpingd_cmd);
 	install_element(PIM6_NODE, &pim6_bsr_candidate_rp_cmd);

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -1183,6 +1183,86 @@ int pim_rp_config_write(struct pim_instance *pim, struct vty *vty)
 	return count;
 }
 
+static void pim_rp_show_info_ssm_plist(struct vty *vty, struct ttable *tt, struct pim_ssm *ssm,
+				       json_object *json, struct prefix *range)
+{
+	struct prefix_list_entry *pentry;
+	struct prefix_list *plist;
+	struct prefix *p = NULL;
+	json_object *json_rp_rows = NULL;
+	json_object *json_row = NULL;
+#if PIM_IPV == 4
+	const char *no_rp = "0.0.0.0";
+#else
+	const char *no_rp = "::";
+#endif
+	const char *source = "Static";
+	const char *type = "SSM";
+	char buf[PREFIX_STRLEN];
+
+	if (ssm->plist_name) {
+		plist = prefix_list_lookup(PIM_AFI, ssm->plist_name);
+		if (!plist)
+			return;
+
+		for (pentry = plist->head; pentry; pentry = pentry->next) {
+			if (pentry->any)
+				continue;
+
+			p = &pentry->prefix;
+			prefix2str(p, buf, sizeof(buf));
+
+			if (range && !prefix_match(p, range))
+				continue;
+
+			if (!json)
+				ttable_add_row(tt, "%s|%s|%s|%s|%s|%s", no_rp, buf, "Unknown", "no",
+					       source, type);
+			else {
+				json_row = json_object_new_object();
+				if (!json_object_object_get_ex(json, no_rp, &json_rp_rows)) {
+					json_rp_rows = json_object_new_array();
+					json_object_object_add(json, no_rp, json_rp_rows);
+				}
+
+				json_object_string_add(json_row, "rpAddress", no_rp);
+				json_object_string_add(json_row, "outboundInterface", "Unknown");
+				json_object_boolean_false_add(json_row, "iAmRP");
+				json_object_string_add(json_row, "group", buf);
+				json_object_string_add(json_row, "source", source);
+				json_object_string_add(json_row, "groupType", type);
+				json_object_array_add(json_rp_rows, json_row);
+			}
+		}
+	} else {
+		struct prefix p_match;
+		(void)str2prefix(PIM_SSM_STANDARD_RANGE, &p_match);
+		apply_mask(&p_match);
+
+		if (range && !prefix_match(&p_match, range))
+			return;
+
+		if (!json)
+			ttable_add_row(tt, "%s|%s|%s|%s|%s|%s", no_rp, PIM_SSM_STANDARD_RANGE,
+				       "Unknown", "no", source, type);
+		else {
+			json_row = json_object_new_object();
+			if (!json_object_object_get_ex(json, no_rp, &json_rp_rows)) {
+				json_rp_rows = json_object_new_array();
+				json_object_object_add(json, no_rp, json_rp_rows);
+			}
+
+			json_object_string_add(json_row, "rpAddress", no_rp);
+			json_object_string_add(json_row, "outboundInterface", "Unknown");
+			json_object_boolean_false_add(json_row, "iAmRP");
+			json_object_string_add(json_row, "group", PIM_SSM_STANDARD_RANGE);
+			json_object_string_add(json_row, "source", source);
+			json_object_string_add(json_row, "groupType", type);
+			json_object_array_add(json_rp_rows, json_row);
+		}
+	}
+}
+
 void pim_rp_show_information(struct pim_instance *pim, struct prefix *range,
 			     struct vty *vty, json_object *json)
 {
@@ -1300,6 +1380,8 @@ void pim_rp_show_information(struct pim_instance *pim, struct prefix *range,
 		}
 		prev_rp_info = rp_info;
 	}
+
+	pim_rp_show_info_ssm_plist(vty, tt, (struct pim_ssm *)pim->ssm_info, json, range);
 
 	/* Dump the generated table. */
 	if (!json) {

--- a/pimd/pim_ssm.h
+++ b/pimd/pim_ssm.h
@@ -6,7 +6,11 @@
 #ifndef PIM_SSM_H
 #define PIM_SSM_H
 
+#if PIM_IPV == 4
 #define PIM_SSM_STANDARD_RANGE "232.0.0.0/8"
+#else
+#define PIM_SSM_STANDARD_RANGE "FF30::/96"
+#endif
 
 struct pim_instance;
 


### PR DESCRIPTION
This PR adds the command `ssm prefix-list PREFIXLIST6_NAME` for PIMv6 for feature parity with PIM(v4) and implements the code to show `SSM` entries in `show ip(v6) pim rp-info`.