### PR TITLE
lib: Correct handling of /frr-vrf:lib/vrf/state/active

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -1044,7 +1044,7 @@ static const void *lib_vrf_lookup_next(struct nb_cb_lookup_entry_args *args)
 }
 
 /*
- * XPath: /frr-vrf:lib/vrf/id
+ * XPath: /frr-vrf:lib/vrf/state/id
  */
 static struct yang_data *
 lib_vrf_state_id_get_elem(struct nb_cb_get_elem_args *args)
@@ -1055,17 +1055,14 @@ lib_vrf_state_id_get_elem(struct nb_cb_get_elem_args *args)
 }
 
 /*
- * XPath: /frr-vrf:lib/vrf/active
+ * XPath: /frr-vrf:lib/vrf/state/active
  */
 static struct yang_data *
 lib_vrf_state_active_get_elem(struct nb_cb_get_elem_args *args)
 {
 	struct vrf *vrfp = (struct vrf *)args->list_entry;
 
-	if (vrfp->status == VRF_ACTIVE)
-		return yang_data_new_bool(args->xpath, true);
-
-	return NULL;
+	return yang_data_new_bool(args->xpath, vrfp->status == VRF_ACTIVE ? true : false);
 }
 
 /* clang-format off */


### PR DESCRIPTION
This value in the yang tree was returning NULL for when the state of the vrf was not active.  It should return a false.

Before:

eva# show mgmt get-data /frr-vrf:lib/vrf[name="vrf1"] {
  "frr-vrf:lib": {
    "vrf": [
      {
        "name": "vrf1",
        "state": {
          "id": 4294967295
        }
eva# show mgmt get-data /frr-vrf:lib/vrf[name="BLUE"] {
  "frr-vrf:lib": {
    "vrf": [
      {
        "name": "BLUE",
        "state": {
          "id": 68,
          "active": true
        },

After:

eva# show mgmt get-data /frr-vrf:lib/vrf[name="vrf1"] {
  "frr-vrf:lib": {
    "vrf": [
      {
        "name": "vrf1",
        "state": {
          "id": 4294967295,
          "active": false
        }

eva# show mgmt get-data /frr-vrf:lib/vrf[name="BLUE"] {
  "frr-vrf:lib": {
    "vrf": [
      {
        "name": "BLUE",
        "state": {
          "id": 68,
          "active": true
        },