### PR TITLE
lib: Prevent crash in getting label chunk

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -3664,7 +3664,7 @@ int lm_get_label_chunk(struct zclient *zclient, uint8_t keep, uint32_t base,
 	if (zclient_debug)
 		zlog_debug("Getting Label Chunk");
 
-	if (zclient->sock < 0)
+	if (!zclient || zclient->sock < 0)
 		return -1;
 
 	/* send request */


### PR DESCRIPTION
ldpd has this crash:

(gdb) bt
0  __pthread_kill_implementation (no_tid=0, signo=11, threadid=140329211443648) at ./nptl/pthread_kill.c:44 1  __pthread_kill_internal (signo=11, threadid=140329211443648) at ./nptl/pthread_kill.c:78 2  __GI___pthread_kill (threadid=140329211443648, signo=signo@entry=11) at ./nptl/pthread_kill.c:89 3  0x00007fa0f0642476 in __GI_raise (sig=11) at ../sysdeps/posix/raise.c:26 4  0x00007fa0f0b51944 in core_handler (signo=11, siginfo=0x7fff562810b0, context=0x7fff56280f80) at lib/sigevent.c:268 5  <signal handler called>
6  0x00007fa0f0b9534d in lm_get_label_chunk (zclient=0x0, keep=0 '\000', base=0, chunk_size=64, start=0x7fff56281bdc, end=0x7fff56281be0) at lib/zclient.c:3667 7  0x0000564e0d1c011e in lde_get_label_chunk () at ldpd/lde.c:2211 8  0x0000564e0d1c05f8 in lde_get_next_label () at ldpd/lde.c:2318 9  0x0000564e0d1bcb29 in lde_update_label (fn=0x564e16653050) at ldpd/lde.c:783 10 0x0000564e0d1c1fbe in lde_kernel_update (fec=0x7fff56281cb0) at ldpd/lde_lib.c:422 11 0x0000564e0d1b96c0 in l2vpn_pw_init (pw=0x564e165d1fa0) at ldpd/l2vpn.c:242 12 0x0000564e0d1b2d32 in merge_l2vpn (xconf=0x564e166424f0, l2vpn=0x564e166160a0, xl=0x564e165eabb0) at ldpd/ldpd.c:1883 13 0x0000564e0d1b28ea in merge_l2vpns (conf=0x564e166424f0, xconf=0x564e16653650) at ldpd/ldpd.c:1813 14 0x0000564e0d1b1244 in merge_config (conf=0x564e166424f0, xconf=0x564e16653650) at ldpd/ldpd.c:1321 15 0x0000564e0d1bc485 in lde_dispatch_parent (thread=0x7fff56282060) at ldpd/lde.c:611 16 0x00007fa0f0b6cebc in event_call (thread=0x7fff56282060) at lib/event.c:2019 17 0x0000564e0d1baee7 in lde () at ldpd/lde.c:155
18 0x0000564e0d1ae4b8 in main (argc=0, argv=0x7fff56282298) at ldpd/ldpd.c:312 (gdb)

Since it is possible to be asking for label data before the zclient has been connected, let's just return -1 in the case where zclient is not initialized yet either, since this is effectively the same thing as the sock being < 0.