### PR TITLE
staticd: Do not log uninitialized `nexthop` variable

### DIFF
--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -1296,7 +1296,6 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_segment_routi
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
-		zlog_info("validating nexthop %pI6", &nexthop.ipaddr_v6);
 		yang_dnode_get_ip(&nexthop, args->dnode, "../next-hop");
 		if (!IS_IPADDR_V6(&nexthop)) {
 			snprintf(args->errmsg, args->errmsg_len,


### PR DESCRIPTION
When running valgrind, the following error is observed.

```
==2474568== Memcheck, a memory error detector
==2474568== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==2474568== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==2474568== Command: /usr/lib/frr/staticd --command-log-always --log file:staticd.log --log-level debug -d
==2474568== Parent PID: 2474525
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B32A: inet_ntop (ntop.c:105)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B334: inet_ntop (ntop.c:105)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B343: inet_ntop (ntop.c:105)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B34D: inet_ntop (ntop.c:105)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B35B: inet_ntop (ntop.c:105)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B367: inet_ntop (ntop.c:105)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B6B9: inet_ntop (ntop.c:105)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B6C6: inet_ntop (ntop.c:105)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B3AA: inet_ntop (ntop.c:105)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B708: inet_ntop (ntop.c:105)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B711: inet_ntop (ntop.c:105)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B3DE: inet_ntop (ntop.c:105)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B3E8: inet_ntop (ntop.c:105)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B499: puthex (ntop.c:64)
==2474568==    by 0x490B499: inet_ntop (ntop.c:150)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B73D: puthex (ntop.c:66)
==2474568==    by 0x490B73D: inet_ntop (ntop.c:150)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Conditional jump or move depends on uninitialised value(s)
==2474568==    at 0x490B747: puthex (ntop.c:68)
==2474568==    by 0x490B747: inet_ntop (ntop.c:150)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Use of uninitialised value of size 8
==2474568==    at 0x490B4D2: puthex (ntop.c:69)
==2474568==    by 0x490B4D2: inet_ntop (ntop.c:150)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Use of uninitialised value of size 8
==2474568==    at 0x490B4DD: puthex (ntop.c:70)
==2474568==    by 0x490B4DD: inet_ntop (ntop.c:150)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Use of uninitialised value of size 8
==2474568==    at 0x490B4A8: puthex (ntop.c:65)
==2474568==    by 0x490B4A8: inet_ntop (ntop.c:150)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== Use of uninitialised value of size 8
==2474568==    at 0x490B4BC: puthex (ntop.c:67)
==2474568==    by 0x490B4BC: inet_ntop (ntop.c:150)
==2474568==    by 0x49AB9CB: printfrr_i6 (prefix.c:1614)
==2474568==    by 0x4A24B19: printfrr_extp (glue.c:220)
==2474568==    by 0x4A2286E: vbprintfrr (vfprintf.c:626)
==2474568==    by 0x4A12AE2: zlog_msg_text (zlog.c:838)
==2474568==    by 0x4A11B83: vzlog_tls (zlog.c:497)
==2474568==    by 0x4A12561: vzlogx (zlog.c:722)
==2474568==    by 0x129AE8: zlog_ref (zlog.h:84)
==2474568==    by 0x12BD35: routing_control_plane_protocols_control_plane_protocol_staticd_segment_routing_srv6_local_sids_sid_paths_next_hop_modify (static_nb_config.c:1299)
==2474568==    by 0x498ABF8: nb_callback_modify (northbound.c:1579)
==2474568==    by 0x498BB35: nb_callback_configuration (northbound.c:1930)
==2474568==    by 0x498A03C: nb_candidate_validate_code (northbound.c:1287)
==2474568==    by 0x498A2C1: nb_candidate_commit_prepare (northbound.c:1358)
==2474568==    by 0x496F414: mgmt_be_txn_cfg_prepare (mgmt_be_client.c:579)
==2474568==    by 0x496FBB8: mgmt_be_process_cfgdata_req (mgmt_be_client.c:717)
==2474568==    by 0x49703A9: mgmt_be_client_handle_msg (mgmt_be_client.c:851)
==2474568==    by 0x49718B9: mgmt_be_client_process_msg (mgmt_be_client.c:1261)
==2474568==    by 0x4976810: mgmt_msg_procbufs (mgmt_msg.c:193)
==2474568==    by 0x497771A: msg_conn_proc_msgs (mgmt_msg.c:526)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568==
==2474568== HEAP SUMMARY:
==2474568==     in use at exit: 2,098 bytes in 8 blocks
==2474568==   total heap usage: 48,668 allocs, 48,660 frees, 15,837,383 bytes allocated
==2474568==
==2474568== 69 bytes in 1 blocks are still reachable in loss record 3 of 8
==2474568==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==2474568==    by 0x4D2058E: strdup (strdup.c:42)
==2474568==    by 0x496CA96: qstrdup (memory.c:118)
==2474568==    by 0x4A1DD4B: zlog_file_set_filename (zlog_targets.c:244)
==2474568==    by 0x4969ADA: set_log_file (log_vty.c:371)
==2474568==    by 0x4969CD0: command_setup_early_logging (log_vty.c:419)
==2474568==    by 0x49576FE: frr_init (libfrr.c:770)
==2474568==    by 0x1156C6: main (static_main.c:164)
==2474568==
==2474568== 69 bytes in 1 blocks are still reachable in loss record 4 of 8
==2474568==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==2474568==    by 0x4D2058E: strdup (strdup.c:42)
==2474568==    by 0x496CA96: qstrdup (memory.c:118)
==2474568==    by 0x4A1DD4B: zlog_file_set_filename (zlog_targets.c:244)
==2474568==    by 0x4969ADA: set_log_file (log_vty.c:371)
==2474568==    by 0x496A052: config_log_file_magic (log_vty.c:542)
==2474568==    by 0x496845F: config_log_file (log_vty_clippy.c:148)
==2474568==    by 0x4915E8B: cmd_execute_command_real (command.c:1003)
==2474568==    by 0x4916004: cmd_execute_command (command.c:1062)
==2474568==    by 0x49165B4: cmd_execute (command.c:1228)
==2474568==    by 0x49EB7EA: vty_command (vty.c:626)
==2474568==    by 0x49ED70E: vty_execute (vty.c:1389)
==2474568==    by 0x49EFF39: vtysh_read (vty.c:2408)
==2474568==    by 0x49E40E2: event_call (event.c:2019)
==2474568==    by 0x4958AD9: frr_run (libfrr.c:1246)
==2474568==    by 0x11581D: main (static_main.c:193)
==2474568==
==2474568== LEAK SUMMARY:
==2474568==    definitely lost: 0 bytes in 0 blocks
==2474568==    indirectly lost: 0 bytes in 0 blocks
==2474568==      possibly lost: 0 bytes in 0 blocks
==2474568==    still reachable: 138 bytes in 2 blocks
==2474568==         suppressed: 1,960 bytes in 6 blocks
==2474568==
==2474568== Use --track-origins=yes to see where uninitialised values come from
==2474568== For lists of detected and suppressed errors, rerun with: -s
==2474568== ERROR SUMMARY: 41 errors from 20 contexts (suppressed: 0 from 0)
```

The error is caused by staticd attempting to log the `nexthop` variable before it is initialized.

Since logging that variable currently does not work and would not provide any useful information anyway, this PR fixes the problem by changing the staticd code to not log that variable.