### PR TITLE
pimd: fix null memory access on IGMP source limit

### DIFF
--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -843,7 +843,7 @@ static void toex_incl(struct gm_group *group, int num_sources,
 
 		/* Lookup reported source (B) */
 		source = igmp_get_source_by_addr(group, *src_addr, &new);
-		if (!new) {
+		if (!new && source != NULL) {
 			/* If found, clear deletion flag: (A*B) */
 			IGMP_SOURCE_DONT_DELETE(source->source_flags);
 			/* and set SEND flag (A*B) */


### PR DESCRIPTION
When the IGMP group source limit is reached the function `igmp_get_source_by_addr` won't return a `struct gm_source` so we must test for that condition before attempting to access its fields.

Fixes coverity scan issue 1637406.