### PR TITLE
tools: Fix `frr-reload.py` error related to `static-sids`

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -290,6 +290,7 @@ ctx_keywords = {
         },
         "srv6": {
             "locators": {"locator ": {}},
+            "static-sids": {},
             "encapsulation": {},
             "formats": {"format": {}},
         },


### PR DESCRIPTION
```
[...]
segment-routing
 srv6
  static-sids
   sid fcbb:bbbb:1::/48 locator MAIN behavior uN
   sid fcbb:bbbb:1:fe10::/64 locator MAIN behavior uDT4 vrf Vrf10
   sid fcbb:bbbb:1:fe20::/64 locator MAIN behavior uDT6 vrf Vrf20
   sid fcbb:bbbb:1:fe30::/64 locator MAIN behavior uDT46 vrf Vrf30
   sid fcbb:bbbb:1:fe40::/64 locator MAIN behavior uA interface sr0 nexthop 2001::2
[...]
```

When the user has a configuration like the one above and runs the command `frr-reload.py --reload`, the following error occurs:

```
[1129654|mgmtd] sending configuration
line 17: % Unknown command[76]:   sid fcbb:bbbb:1::/48 locator MAIN behavior uN
line 23: % Unknown command[76]:   sid fcbb:bbbb:1:fe10::/64 locator MAIN behavior uDT4 vrf Vrf10
line 29: % Unknown command[76]:   sid fcbb:bbbb:1:fe20::/64 locator MAIN behavior uDT6 vrf Vrf20
line 35: % Unknown command[76]:   sid fcbb:bbbb:1:fe30::/64 locator MAIN behavior uDT46 vrf Vrf30
line 41: % Unknown command[76]:   sid fcbb:bbbb:1:fe40::/64 locator MAIN behavior uA interface sr0 nexthop 2001::2
```
---
The problem is that in `frr-reload-py` all commands that start a new multi-line context must be included in the `ctx_keyword` dictionary. However, the `static-sids` command is not part of the `ctx_keyword` dictionary.

This PR fixes the problem by adding `static-sids` to `ctx_keyword`.