### PR TITLE
isisd: Correct edge insertion into TED

### DIFF
--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -1193,32 +1193,18 @@ static int lsp_to_edge_cb(const uint8_t *id, uint32_t metric, bool old_metric,
 			"    |- Link Edge (Unknown) to destination vertex (%s)",
 			print_sys_hostname(id));
 
+	/* Then search if there is a reverse Edge to link them */
 	dst = ls_find_edge_by_destination(args->ted, edge->attributes);
 	if (dst) {
 		/* Attach remote link if not set */
-		if (edge->source && dst->destination == NULL) {
-			vertex = edge->source;
-			if (vertex->incoming_edges)
-				listnode_add_sort_nodup(vertex->incoming_edges,
-							dst);
+		if (dst->destination == NULL) {
+			listnode_add_sort_nodup(vertex->incoming_edges, dst);
 			dst->destination = vertex;
 		}
 		/* and destination vertex to this edge if not set */
-		if (dst->source && edge->destination == NULL) {
-			vertex = dst->source;
-			if (vertex->incoming_edges)
-				listnode_add_sort_nodup(vertex->incoming_edges,
-							edge);
-			edge->destination = vertex;
-		}
-	} else {
-		/* Search dst. Vertex by Extended Reach. ID if not found */
 		if (edge->destination == NULL) {
-			vertex = ls_find_vertex_by_key(args->ted,
-						       sysid_to_key(id));
-			if (vertex && vertex->incoming_edges)
-				listnode_add_sort_nodup(vertex->incoming_edges,
-							edge);
+			vertex = dst->source;
+			listnode_add_sort_nodup(vertex->incoming_edges, edge);
 			edge->destination = vertex;
 		}
 	}


### PR DESCRIPTION
Edges are not correctly linked to Vertices during LSP processing. In function lsp_to_edge_cb(), once edge created or updated from the LSP TLVs, the code try to link the edge to destination vertices. In case the revert edge is not found, the code try to found a destination vertex to link to. But, the sys_id used for this operation corresponds to the source vertex. As a result, the edge is attached as source and destination of the vertex. When Traffic Engineering is stopped, TED is deleted which result into a double free of the edge attributes. This cause a crash when attempt to free extended admin groupi the second time.

This patch removed wrong code which link twice the edge to the source vertex.