### PR TITLE
bfdd: Add "log-session-changes" command to BFD configuration and operational state via YANG Northbound API. 

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -84,6 +84,7 @@ struct bfd_peer_cfg {
 
 	bool bpc_cbit;
 	bool bpc_passive;
+	bool bpc_log_session_changes;
 
 	bool bpc_has_profile;
 	char bpc_profile[64];
@@ -224,21 +225,22 @@ enum bfd_diagnosticis {
 /* BFD session flags */
 enum bfd_session_flags {
 	BFD_SESS_FLAG_NONE = 0,
-	BFD_SESS_FLAG_ECHO = 1 << 0,	/* BFD Echo functionality */
-	BFD_SESS_FLAG_ECHO_ACTIVE = 1 << 1, /* BFD Echo Packets are being sent
+	BFD_SESS_FLAG_ECHO = 1 << 0,		     /* BFD Echo functionality */
+	BFD_SESS_FLAG_ECHO_ACTIVE = 1 << 1,	     /* BFD Echo Packets are being sent
 					     * actively
 					     */
-	BFD_SESS_FLAG_MH = 1 << 2,	  /* BFD Multi-hop session */
-	BFD_SESS_FLAG_IPV6 = 1 << 4,	/* BFD IPv6 session */
-	BFD_SESS_FLAG_SEND_EVT_ACTIVE = 1 << 5, /* send event timer active */
-	BFD_SESS_FLAG_SEND_EVT_IGNORE = 1 << 6, /* ignore send event when timer
+	BFD_SESS_FLAG_MH = 1 << 2,		     /* BFD Multi-hop session */
+	BFD_SESS_FLAG_IPV6 = 1 << 4,		     /* BFD IPv6 session */
+	BFD_SESS_FLAG_SEND_EVT_ACTIVE = 1 << 5,	     /* send event timer active */
+	BFD_SESS_FLAG_SEND_EVT_IGNORE = 1 << 6,	     /* ignore send event when timer
 						 * expires
 						 */
-	BFD_SESS_FLAG_SHUTDOWN = 1 << 7,	/* disable BGP peer function */
-	BFD_SESS_FLAG_CONFIG = 1 << 8, /* Session configured with bfd NB API */
-	BFD_SESS_FLAG_CBIT = 1 << 9,   /* CBIT is set */
-	BFD_SESS_FLAG_PASSIVE = 1 << 10, /* Passive mode */
-	BFD_SESS_FLAG_MAC_SET = 1 << 11, /* MAC of peer known */
+	BFD_SESS_FLAG_SHUTDOWN = 1 << 7,	     /* disable BGP peer function */
+	BFD_SESS_FLAG_CONFIG = 1 << 8,		     /* Session configured with bfd NB API */
+	BFD_SESS_FLAG_CBIT = 1 << 9,		     /* CBIT is set */
+	BFD_SESS_FLAG_PASSIVE = 1 << 10,	     /* Passive mode */
+	BFD_SESS_FLAG_MAC_SET = 1 << 11,	     /* MAC of peer known */
+	BFD_SESS_FLAG_LOG_SESSION_CHANGES = 1 << 12, /* Log session changes */
 };
 
 enum bfd_mode_type {
@@ -297,6 +299,8 @@ struct bfd_profile {
 	bool admin_shutdown;
 	/** Passive mode. */
 	bool passive;
+	/** Log session changes. */
+	bool log_session_changes;
 	/** Minimum expected TTL value. */
 	uint8_t minimum_ttl;
 
@@ -681,6 +685,14 @@ void bfd_set_shutdown(struct bfd_session *bs, bool shutdown);
  * \param passive the passive mode.
  */
 void bfd_set_passive_mode(struct bfd_session *bs, bool passive);
+
+/**
+ * Set the BFD session to log or not log session changes.
+ *
+ * \param bs the BFD session.
+ * \param log_session indicates whether or not to log session changes.
+ */
+void bfd_set_log_session_changes(struct bfd_session *bs, bool log_session);
 
 /**
  * Picks the BFD session configuration from the appropriated source:

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -754,6 +754,21 @@ void bfd_cli_show_passive(struct vty *vty, const struct lyd_node *dnode,
 		yang_dnode_get_bool(dnode, NULL) ? "" : "no ");
 }
 
+DEFPY_YANG(bfd_peer_log_session_changes, bfd_peer_log_session_changes_cmd,
+	   "[no] log-session-changes",
+	   NO_STR
+	   "Log Up/Down changes for the session\n")
+{
+	nb_cli_enqueue_change(vty, "./log-session-changes", NB_OP_MODIFY, no ? "false" : "true");
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+void bfd_cli_show_log_session_changes(struct vty *vty, const struct lyd_node *dnode,
+				      bool show_defaults)
+{
+	vty_out(vty, "  %slog-session-changes\n", yang_dnode_get_bool(dnode, NULL) ? "" : "no ");
+}
+
 DEFPY_YANG(
 	bfd_peer_minimum_ttl, bfd_peer_minimum_ttl_cmd,
 	"[no] minimum-ttl (1-254)$ttl",
@@ -1063,6 +1078,9 @@ ALIAS_YANG(bfd_peer_passive, bfd_profile_passive_cmd,
       NO_STR
       "Don't attempt to start sessions\n")
 
+ALIAS_YANG(bfd_peer_log_session_changes, bfd_profile_log_session_changes_cmd,
+	   "[no] log-session-changes", NO_STR "Log Up/Down session changes in the profile\n")
+
 ALIAS_YANG(bfd_peer_minimum_ttl, bfd_profile_minimum_ttl_cmd,
       "[no] minimum-ttl (1-254)$ttl",
       NO_STR
@@ -1329,6 +1347,7 @@ bfdd_cli_init(void)
 	install_element(BFD_PEER_NODE, &bfd_peer_echo_receive_interval_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_profile_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_passive_cmd);
+	install_element(BFD_PEER_NODE, &bfd_peer_log_session_changes_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_minimum_ttl_cmd);
 	install_element(BFD_PEER_NODE, &no_bfd_peer_minimum_ttl_cmd);
 
@@ -1350,6 +1369,7 @@ bfdd_cli_init(void)
 	install_element(BFD_PROFILE_NODE, &bfd_profile_echo_transmit_interval_cmd);
 	install_element(BFD_PROFILE_NODE, &bfd_profile_echo_receive_interval_cmd);
 	install_element(BFD_PROFILE_NODE, &bfd_profile_passive_cmd);
+	install_element(BFD_PROFILE_NODE, &bfd_profile_log_session_changes_cmd);
 	install_element(BFD_PROFILE_NODE, &bfd_profile_minimum_ttl_cmd);
 	install_element(BFD_PROFILE_NODE, &no_bfd_profile_minimum_ttl_cmd);
 }

--- a/bfdd/bfdd_nb.c
+++ b/bfdd/bfdd_nb.c
@@ -70,6 +70,13 @@ const struct frr_yang_module_info frr_bfdd_info = {
 				.cli_show = bfd_cli_show_passive,
                         }
                 },
+                {
+                        .xpath = "/frr-bfdd:bfdd/bfd/profile/log-session-changes",
+                        .cbs = {
+                                .modify = bfdd_bfd_profile_log_session_changes_modify,
+				.cli_show = bfd_cli_show_log_session_changes,
+                        }
+                },
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/profile/minimum-ttl",
 			.cbs = {
@@ -158,6 +165,13 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			.cbs = {
 				.modify = bfdd_bfd_sessions_single_hop_passive_mode_modify,
 				.cli_show = bfd_cli_show_passive,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/log-session-changes",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_log_session_changes_modify,
+				.cli_show = bfd_cli_show_log_session_changes,
 			}
 		},
 		{
@@ -354,6 +368,13 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			.cbs = {
 				.modify = bfdd_bfd_sessions_single_hop_passive_mode_modify,
 				.cli_show = bfd_cli_show_passive,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/log-session-changes",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_log_session_changes_modify,
+				.cli_show = bfd_cli_show_log_session_changes,
 			}
 		},
 		{
@@ -573,6 +594,13 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			}
 		},
 		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/log-session-changes",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_log_session_changes_modify,
+				.cli_show = bfd_cli_show_log_session_changes,
+			}
+		},
+		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-echo/bfd-mode",
 			.cbs = {
 				.modify = bfdd_bfd_sessions_bfd_mode_modify,
@@ -786,6 +814,13 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			.cbs = {
 				.modify = bfdd_bfd_sessions_single_hop_passive_mode_modify,
 				.cli_show = bfd_cli_show_passive,
+			}
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/sbfd-init/log-session-changes",
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_log_session_changes_modify,
+				.cli_show = bfd_cli_show_log_session_changes,
 			}
 		},
 		{

--- a/bfdd/bfdd_nb.h
+++ b/bfdd/bfdd_nb.h
@@ -24,6 +24,7 @@ int bfdd_bfd_profile_required_receive_interval_modify(
 	struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_administrative_down_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_passive_mode_modify(struct nb_cb_modify_args *args);
+int bfdd_bfd_profile_log_session_changes_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_minimum_ttl_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_echo_mode_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_profile_desired_echo_transmission_interval_modify(
@@ -54,6 +55,7 @@ int bfdd_bfd_sessions_single_hop_administrative_down_modify(
 	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_single_hop_passive_mode_modify(
 	struct nb_cb_modify_args *args);
+int bfdd_bfd_sessions_single_hop_log_session_changes_modify(struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_single_hop_echo_mode_modify(
 	struct nb_cb_modify_args *args);
 int bfdd_bfd_sessions_single_hop_desired_echo_transmission_interval_modify(
@@ -229,6 +231,8 @@ void bfd_cli_peer_profile_show(struct vty *vty, const struct lyd_node *dnode,
 			       bool show_defaults);
 void bfd_cli_show_passive(struct vty *vty, const struct lyd_node *dnode,
 			  bool show_defaults);
+void bfd_cli_show_log_session_changes(struct vty *vty, const struct lyd_node *dnode,
+				      bool show_defaults);
 void bfd_cli_show_minimum_ttl(struct vty *vty, const struct lyd_node *dnode,
 			      bool show_defaults);
 

--- a/bfdd/bfdd_nb_config.c
+++ b/bfdd/bfdd_nb_config.c
@@ -596,6 +596,23 @@ int bfdd_bfd_profile_passive_mode_modify(struct nb_cb_modify_args *args)
 }
 
 /*
+ * XPath: /frr-bfdd:bfdd/bfd/profile/log-session-changes
+ */
+int bfdd_bfd_profile_log_session_changes_modify(struct nb_cb_modify_args *args)
+{
+	struct bfd_profile *bp;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	bp = nb_running_get_entry(args->dnode, NULL, true);
+	bp->log_session_changes = yang_dnode_get_bool(args->dnode, NULL);
+	bfd_profile_update(bp);
+
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-bfdd:bfdd/bfd/profile/minimum-ttl
  */
 int bfdd_bfd_profile_minimum_ttl_modify(struct nb_cb_modify_args *args)
@@ -898,6 +915,38 @@ int bfdd_bfd_sessions_single_hop_passive_mode_modify(
 
 	bs = nb_running_get_entry(args->dnode, NULL, true);
 	bs->peer_profile.passive = passive;
+	bfd_session_apply(bs);
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/log-session-changes
+ *        /frr-bfdd:bfdd/bfd/sessions/multi-hop/log-session-changes
+ *        /frr-bfdd:bfdd/bfd/sessions/sbfd_echo/log-session-changes
+ *        /frr-bfdd:bfdd/bfd/sessions/sbfd_init/log-session-changes
+ */
+int bfdd_bfd_sessions_single_hop_log_session_changes_modify(struct nb_cb_modify_args *args)
+{
+	struct bfd_session *bs;
+	bool log_session_changes;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+		return NB_OK;
+
+	case NB_EV_APPLY:
+		break;
+
+	case NB_EV_ABORT:
+		return NB_OK;
+	}
+
+	log_session_changes = yang_dnode_get_bool(args->dnode, NULL);
+
+	bs = nb_running_get_entry(args->dnode, NULL, true);
+	bs->peer_profile.log_session_changes = log_session_changes;
 	bfd_session_apply(bs);
 
 	return NB_OK;

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -164,9 +164,10 @@ static void _display_peer(struct vty *vty, struct bfd_session *bs)
 		vty_out(vty, "\t\tPassive mode\n");
 	else
 		vty_out(vty, "\t\tActive mode\n");
+	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_LOG_SESSION_CHANGES))
+		vty_out(vty, "\t\tLog session changes\n");
 	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH))
 		vty_out(vty, "\t\tMinimum TTL: %d\n", bs->mh_ttl);
-
 	vty_out(vty, "\t\tStatus: ");
 	switch (bs->ses_state) {
 	case PTM_BFD_ADM_DOWN:
@@ -289,6 +290,8 @@ static struct json_object *__display_peer_json(struct bfd_session *bs)
 	json_object_int_add(jo, "remote-id", bs->discrs.remote_discr);
 	json_object_boolean_add(jo, "passive-mode",
 				CHECK_FLAG(bs->flags, BFD_SESS_FLAG_PASSIVE));
+	json_object_boolean_add(jo, "log-session-changes",
+				CHECK_FLAG(bs->flags, BFD_SESS_FLAG_LOG_SESSION_CHANGES));
 	if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH))
 		json_object_int_add(jo, "minimum-ttl", bs->mh_ttl);
 
@@ -1194,6 +1197,7 @@ static int bfd_configure_peer(struct bfd_peer_cfg *bpc, bool mhop,
 
 	/* Defaults */
 	bpc->bpc_shutdown = false;
+	bpc->bpc_log_session_changes = false;
 	bpc->bpc_detectmultiplier = BPC_DEF_DETECTMULTIPLIER;
 	bpc->bpc_recvinterval = BPC_DEF_RECEIVEINTERVAL;
 	bpc->bpc_txinterval = BPC_DEF_TRANSMITINTERVAL;

--- a/bfdd/dplane.c
+++ b/bfdd/dplane.c
@@ -384,10 +384,15 @@ bfd_dplane_session_state_change(struct bfd_dplane_ctx *bdc,
 		break;
 	}
 
-	if (bglobal.debug_peer_event)
+	if (bglobal.debug_peer_event) {
 		zlog_debug("state-change: [data plane: %s] %s -> %s",
 			   bs_to_string(bs), state_list[old_state].str,
 			   state_list[bs->ses_state].str);
+		if (CHECK_FLAG(bs->flags, BFD_SESS_FLAG_LOG_SESSION_CHANGES) &&
+		    old_state != bs->ses_state)
+			zlog_notice("Session-Change: [data plane: %s] %s -> %s", bs_to_string(bs),
+				    state_list[old_state].str, state_list[bs->ses_state].str);
+	}
 }
 
 /**

--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -215,6 +215,11 @@ BFD peers and profiles share the same BFD session configuration commands.
    The default value is 254 (which means we only expect one hop between
    this system and the peer).
 
+.. clicmd:: log-session-changes
+
+   Enables or disables logging of session state transitions into Up
+   state or when the session transitions from Up state to Down state.
+
 
 BFD Peer Specific Commands
 --------------------------

--- a/tests/topotests/bfd_topo1/r1/bfdd.conf
+++ b/tests/topotests/bfd_topo1/r1/bfdd.conf
@@ -5,6 +5,7 @@
 !
 bfd
  peer 192.168.0.2
+  log-session-changes
   echo-mode
   no shutdown
  !

--- a/tests/topotests/bfd_topo1/r2/bfdd.conf
+++ b/tests/topotests/bfd_topo1/r2/bfdd.conf
@@ -4,11 +4,14 @@
 ! debug bfd zebra
 !
 bfd
- peer 192.168.0.1
+ profile bfd-profile
   receive-interval 1000
   transmit-interval 500
   echo-mode
   no shutdown
+  log-session-changes
+ peer 192.168.0.1
+  profile bfd-profile
  !
  peer 192.168.1.1
   echo-mode

--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -24,7 +24,7 @@ module frr-bfdd {
   description
     "This module defines a model for managing FRR bfdd daemon.
 
-     Copyright 2020 FRRouting
+     Copyright 2025 FRRouting
 
      Redistribution and use in source and binary forms, with or without
      modification, are permitted provided that the following conditions
@@ -58,6 +58,14 @@ module frr-bfdd {
        RFC 5883: Bidirectional Forwarding Detection (BFD) for Multihop Paths.";
   }
 
+  revision 2025-03-03 {
+    description "Add log-sessio-changes leaf";
+    reference
+      "RFC 5880: Bidirectional Forwarding Detection (BFD).
+       RFC 5881: Bidirectional Forwarding Detection (BFD)
+                 for IPv4 and IPv6 (Single Hop).
+       RFC 5883: Bidirectional Forwarding Detection (BFD) for Multihop Paths.";
+  }
 
   /*
    * BFD types declaration.
@@ -197,6 +205,13 @@ module frr-bfdd {
       description
         "Don't attempt to start session establishment.";
     }
+
+    leaf log-session-changes {
+      type boolean;
+      default false;
+      description "Log session changes from/to Up state to/from Down state";
+    }
+
   }
 
   grouping session-echo {


### PR DESCRIPTION
This PR includes changes to:
bfdd: Add feature support for "log-session-changes" command and operational state via frr-bfd.yang model and northbound API.
yang:  Add log-session-changes leaf to session-common in frr-bfdd.yang model.
tests: Add "log-session-changes" to a couple configs. 
doc: Add "log-session-changes" command to BFD user documentation.
 