### PR TITLE
DRAFT: Always enable Protobuf in packages and add Protobuf files to distro

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -143,9 +143,11 @@ module_LTLIBRARIES =
 pkginclude_HEADERS =
 nodist_pkginclude_HEADERS =
 dist_yangmodels_DATA =
+dist_proto_DATA =
 man_MANS =
 vtysh_daemons =
 clippy_scan =
+protodir = $(pkglibdir)
 
 ## libtool, the self-made GNU scourge
 ## ... this should fix relinking

--- a/debian/frr-grpc.install
+++ b/debian/frr-grpc.install
@@ -1,2 +1,3 @@
 usr/lib/*/frr/libfrrgrpc_pb.*
 usr/lib/*/frr/modules/grpc.so
+usr/lib/*/frr/frr/*.proto /usr/lib/frr

--- a/debian/frr-test-tools.install
+++ b/debian/frr-test-tools.install
@@ -1,1 +1,2 @@
 usr/lib/frr/fpm_listener
+usr/lib/frr/mgmtd_testc

--- a/debian/frr.install
+++ b/debian/frr.install
@@ -8,6 +8,8 @@ usr/bin/vtysh
 usr/lib/*/frr/libfrr.*
 usr/lib/*/frr/libfrrcares.*
 usr/lib/*/frr/libfrrospfapiclient.*
+usr/lib/*/frr/libfrr_pb.*
+usr/lib/*/frr/libfrrfpm_pb.*
 usr/lib/*/frr/libmgmt_be_nb.*
 usr/lib/*/frr/modules/bgpd_bmp.so
 usr/lib/*/frr/modules/dplane_fpm_nl.so

--- a/debian/frr.lintian-overrides
+++ b/debian/frr.lintian-overrides
@@ -7,3 +7,6 @@ manpage-without-executable
 
 # personal name
 spelling-error-in-copyright Ang And
+
+# Protobuf Lib not linked against libc
+frr: library-not-linked-against-libc

--- a/debian/rules
+++ b/debian/rules
@@ -58,18 +58,19 @@ override_dh_auto_configure:
 		$(CONF_LUA) \
 		$(CONF_PIM6) \
 		$(CONF_GRPC) \
+		--with-protobuf \
 		--with-libpam \
 		--enable-doc \
 		--enable-doc-html \
 		--enable-snmp \
 		--enable-fpm \
-		--disable-protobuf \
 		--disable-zeromq \
 		--enable-ospfapi \
 		--enable-bgp-vnc \
 		--enable-multipath=256 \
 		--enable-pcre2posix \
-		\
+		--enable-mgmtd-test-be-client \
+		--enable-fpm-listener \
 		--enable-user=frr \
 		--enable-group=frr \
 		--enable-vty-group=frrvty \
@@ -96,6 +97,12 @@ override_dh_auto_install:
 	cp -r tools/etc/* debian/tmp/etc/
 	-rm debian/tmp/etc/frr/daemons.conf
 
+# install proto files to /usr/lib/frr
+#ifneq ($(filter pkg.frr.grpc,$(DEB_BUILD_PROFILES)),)
+#	cp usr/lib/x86_64-linux-gnu/frr/frr/mgmt.proto debian/tmp/usr/lib/frr/
+#	mv usr/lib/x86_64-linux-gnu/frr/frr/*.proto debian/tmp/usr/lib/frr/
+#endif
+	
 # drop dev-only files
 	find debian/tmp -name '*.la' -o -name '*.a' -o -name 'lib*.so' | xargs rm -f
 	rm -rf debian/tmp/usr/include

--- a/fpm/subdir.am
+++ b/fpm/subdir.am
@@ -25,4 +25,6 @@ CLEANFILES += \
 	fpm/fpm.pb-c.h \
 	# end
 
-EXTRA_DIST += fpm/fpm.proto
+dist_proto_DATA += \
+        fpm/fpm.proto \
+        # end

--- a/grpc/subdir.am
+++ b/grpc/subdir.am
@@ -23,7 +23,9 @@ CLEANFILES += \
 	grpc/frr-northbound.grpc.pb.h \
 	# end
 
-EXTRA_DIST += grpc/frr-northbound.proto
+dist_proto_DATA += \
+        grpc/frr-northbound.proto \
+        # end
 
 AM_V_PROTOC = $(am__v_PROTOC_$(V))
 am__v_PROTOC_ = $(am__v_PROTOC_$(AM_DEFAULT_VERBOSITY))

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -556,6 +556,7 @@ EXTRA_DIST += \
 	lib/gitversion.pl \
 	lib/route_types.pl \
 	lib/route_types.txt \
+	lib/mgmt.proto \
 	# end
 
 BUILT_SOURCES += \

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -556,8 +556,11 @@ EXTRA_DIST += \
 	lib/gitversion.pl \
 	lib/route_types.pl \
 	lib/route_types.txt \
-	lib/mgmt.proto \
 	# end
+
+dist_proto_DATA += \
+	lib/mgmt.proto \
+        # end
 
 BUILT_SOURCES += \
 	lib/gitversion.h \

--- a/mlag/subdir.am
+++ b/mlag/subdir.am
@@ -17,4 +17,6 @@ CLEANFILES += \
 	mlag/mlag.pb-c.h \
 	# end
 
-EXTRA_DIST += mlag/mlag.proto
+dist_proto_DATA += \
+        mlag/mlag.proto \
+        # end

--- a/qpb/subdir.am
+++ b/qpb/subdir.am
@@ -28,4 +28,6 @@ CLEANFILES += \
 	qpb/qpb.pb-c.h \
 	# end
 
-EXTRA_DIST += qpb/qpb.proto
+dist_proto_DATA += \
+        qpb/qpb.proto \
+        # end

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -469,11 +469,10 @@ Adds FRR test tools, used in testing FRR.
 %endif
 %if %{with_grpc}
     --enable-grpc \
-    --enable-protobuf \
 %else
     --disable-grpc \
-    --disable-protobuf \
 %endif
+    --enable-protobuf \
     --enable-snmp \
     --enable-pcre2posix \
     # end
@@ -782,8 +781,6 @@ fi
 %if %{with_grpc}
     %exclude %{_libdir}/libfrrgrpc_pb.so*
     %exclude %{_libdir}/frr/modules/grpc.so
-    %exclude %{_libdir}/libfrr_pb.so*
-    %exclude %{_libdir}/libfrrfpm_pb.so*
 %endif
 %exclude %{_libdir}/frr/*.proto
 %config(noreplace) %{configdir}/[!v]*.conf*
@@ -863,8 +860,6 @@ sed -i 's/ -M rpki//' %{_sysconfdir}/frr/daemons
 %files grpc
 %{_libdir}/libfrrgrpc_pb.so*
 %{_libdir}/frr/modules/grpc.so
-%{_libdir}/libfrr_pb.so*
-%{_libdir}/libfrrfpm_pb.so*
 %{_sbindir}/*.proto
 %endif
 

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -333,6 +333,16 @@ Requires: %{name} = %{version}-%{release}
 Adds GRPC support to the individual FRR daemons.
 %endif
 
+
+%package test-tools
+Summary: Testing Tools for FRR daemons
+Group: System Environment/Daemons
+Requires: %{name} = %{version}-%{release}
+
+%description test-tools
+Adds FRR test tools, used in testing FRR.
+
+
 %prep
 %setup -q -n frr-%{frrversion}
 
@@ -355,9 +365,7 @@ Adds GRPC support to the individual FRR daemons.
     --localstatedir=%{_localstatedir} \
     --disable-static \
     --disable-werror \
-%if %{with_mgmtd_test_be_client}
     --enable-mgmtd-test-be-client \
-%endif
 %if %{with_multipath}
     --enable-multipath=%{with_multipath} \
 %endif
@@ -461,8 +469,10 @@ Adds GRPC support to the individual FRR daemons.
 %endif
 %if %{with_grpc}
     --enable-grpc \
+    --enable-protobuf \
 %else
     --disable-grpc \
+    --disable-protobuf \
 %endif
     --enable-snmp \
     --enable-pcre2posix \
@@ -721,11 +731,7 @@ fi
 %{_sbindir}/ripd
 %{_sbindir}/bgpd
 %{_sbindir}/mgmtd
-%if %{with_mgmtd_test_be_client}
-    %{_sbindir}/mgmtd_testc
-%endif
 %exclude %{_sbindir}/ssd
-%exclude %{_sbindir}/fpm_listener
 %if %{with_watchfrr}
     %{_sbindir}/watchfrr
 %endif
@@ -835,9 +841,19 @@ sed -i 's/ -M rpki//' %{_sysconfdir}/frr/daemons
 %endif
 
 
+%files test-tools
+%{_sbindir}/mgmtd_testc
+%{_sbindir}/fpm_listener
+
+
 %changelog
 
-* Thu Oct 10  2024 Jafar Al-Gharaibeh <jafar@atcorp.com> - %{version}
+* Tue Feb 11 2025 Jafar Al-Gharaibeh <jafar@atcorp.com> - %{version}
+
+* Tue Feb 11 2025 Martin Winter <mwinter@opensourcerouting.org> 10.4-dev
+- Added new test-tools subpackage
+-   Moved mgmtd_testc to test-tools subpackage to make consistent with debian
+-   Added fpm_listener to test-tools package
 
 * Thu Oct 10 2024 Jafar Al-Gharaibeh <jafar@atcorp.com> - 10.3-dev
 - FRR 10.3 Development

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -523,6 +523,11 @@ mkdir -p %{buildroot}%{_initddir}
 ln -s %{_sbindir}/frrinit.sh %{buildroot}%{_initddir}/frr
 %endif
 
+# install proto files
+%if %{with_grpc}
+    mv %{buildroot}%{_libdir}/frr/*.proto %{buildroot}/usr/lib/frr/
+%endif
+
 install %{zeb_src}/tools/etc/frr/daemons %{buildroot}%{_sysconfdir}/frr
 install %{zeb_src}/tools/etc/frr/frr.conf %{buildroot}%{_sysconfdir}/frr/frr.conf.template
 install -m644 %{zeb_rh_src}/frr.pam %{buildroot}%{_sysconfdir}/pam.d/frr
@@ -772,7 +777,15 @@ fi
 %{_libdir}/libfrr*.so*
 %{_libdir}/frr/modules/*.so
 %{_libdir}/libmgmt_be_nb.so*
+%exclude %{_sbindir}/*.proto
 %{_bindir}/*
+%if %{with_grpc}
+    %exclude %{_libdir}/libfrrgrpc_pb.so*
+    %exclude %{_libdir}/frr/modules/grpc.so
+    %exclude %{_libdir}/libfrr_pb.so*
+    %exclude %{_libdir}/libfrrfpm_pb.so*
+%endif
+%exclude %{_libdir}/frr/*.proto
 %config(noreplace) %{configdir}/[!v]*.conf*
 %config(noreplace) %attr(750,%{frr_user},%{frr_user}) %{configdir}/daemons
 %if "%{initsystem}" == "systemd"
@@ -844,6 +857,16 @@ sed -i 's/ -M rpki//' %{_sysconfdir}/frr/daemons
 %files test-tools
 %{_sbindir}/mgmtd_testc
 %{_sbindir}/fpm_listener
+
+
+%if %{with_grpc}
+%files grpc
+%{_libdir}/libfrrgrpc_pb.so*
+%{_libdir}/frr/modules/grpc.so
+%{_libdir}/libfrr_pb.so*
+%{_libdir}/libfrrfpm_pb.so*
+%{_sbindir}/*.proto
+%endif
 
 
 %changelog

--- a/tests/topotests/lib/fe_client.py
+++ b/tests/topotests/lib/fe_client.py
@@ -28,7 +28,7 @@ try:
     sys.path.append(os.path.dirname(CWD))
     from munet.base import commander
 
-    commander.cmd_raises(f"protoc --python_out={CWD} -I {CWD}/../../../lib mgmt.proto")
+    commander.cmd_raises(f"protoc --python_out={CWD} -I {CWD}/../../../lib -I /usr/lib/frr mgmt.proto")
 except Exception as error:
     logging.error("can't create protobuf definition modules %s", error)
     raise

--- a/tests/topotests/lib/grpc-query.py
+++ b/tests/topotests/lib/grpc-query.py
@@ -32,7 +32,7 @@ try:
         commander.cmd_raises(
             "python3 -m grpc_tools.protoc"
             f" --python_out={tmpdir} --grpc_python_out={tmpdir}"
-            f" -I {CWD}/../../../grpc frr-northbound.proto"
+            f" -I {CWD}/../../../grpc -I /usr/lib/frr frr-northbound.proto"
         )
     except Exception as error:
         logging.error("can't create proto definition modules %s", error)


### PR DESCRIPTION
Opening this as a s draft to get some comments. Personally, I'm not convinced that this is the right way to do it, but can't get an idea for some better solution. Comments are appreciated.
Main feedback initially would be appreciated on what I did (so we can agree there) and I can work on potentially cleaning up the work after we agreed there

The main motivation which started this was to get Topotests working for the protobuf tests with package builds.

Changes done:
- Changed Makefiles to install the *.proto files (into generic bindir, ie /usr/lib/frr by default)
- Always enabling protobuf in the package build. Initially, I wanted to make protobuf into a additional sub-package, but the base binaries (ie zebra) are different built with and without protobuf. As we require now protobuf for mgmtd, I opted to always build with protobuf
- Wasn't sure where to install the *.proto files - I've now decided to install them into the main frr binary directory (default the /usr/lib/frr). This was after some discussion with Equi on where proto files should go and we couldn't find a good location
- Added a grpc sub-package to RedHat distros. We have a similar package in Debian for some time. Wanted to keep it consistent
- Added test-tools sub-package to RedHat distros. We have a similar package in Debian for some time. Wanted to keep it consistent
- Added mgmtd_testc to test-tools subpackages
- Finally changed the topotest fe_client.py test lib for the protobuf tests to add an additional search path to look at the /usr/lib/frr location for the proto files

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>