### PR TITLE
configure.ac: fix sed failure on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2046,7 +2046,7 @@ if test "$enable_snmp" != "" -a "$enable_snmp" != "no"; then
    # net-snmp lists all of its own dependencies.  we absolutely do not want that
    # among other things we avoid a GPL vs. OpenSSL license conflict here
    for removelib in crypto ssl sensors pci wrap; do
-     SNMP_LIBS="`echo $SNMP_LIBS | sed -e 's/\(^\|\s\)-l'$removelib'\b/ /g' -e 's/\(^\|\s\)\([^\s]*\/\)\?lib'$removelib'\.[^\s]\+\b/ /g'`"
+     SNMP_LIBS="`echo $SNMP_LIBS | sed -e 's/-l'$removelib'/ /g'`"
    done
    AC_MSG_CHECKING([whether we can link to Net-SNMP])
    AC_LINK_IFELSE_FLAGS([$SNMP_CFLAGS], [$SNMP_LIBS], [AC_LANG_PROGRAM([


### PR DESCRIPTION
Fixes #14875

Simplify the sed expression to make sure it works on all platforms.

The previous expression failed on FreeBSD and it caused the SNMP_LIBS variable to be empty. When SNMP_LIBS is empty it will cause binaries and/or libraries to not link against the correct libraries.

---

**NOTE** I removed the `lib$removelib` part of the expression (the parameter for second `-e`) since I didn't find any in my output nor samples of it.

Original commit that introduced this: https://github.com/FRRouting/frr/commit/e5563f877811c1e8ef68990e27a590c4483d06ca