### PR TITLE
isisd:IS-IS hello packets not sent with configured hello timer

### DIFF
--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -232,6 +232,9 @@ ferr_r isis_circuit_passwd_hmac_md5_set(struct isis_circuit *circuit,
 int isis_circuit_mt_enabled_set(struct isis_circuit *circuit, uint16_t mtid,
 				bool enabled);
 
+/* Reset ISIS hello timer and send immediate hello */
+void isis_reset_hello_timer(struct isis_circuit *circuit);
+
 #ifdef FABRICD
 DECLARE_HOOK(isis_circuit_config_write,
 	    (struct isis_circuit *circuit, struct vty *vty),

--- a/isisd/isis_vty_fabricd.c
+++ b/isisd/isis_vty_fabricd.c
@@ -879,8 +879,16 @@ DEFUN (isis_hello_interval,
 	if (!circuit)
 		return CMD_ERR_NO_MATCH;
 
+	uint32_t old_interval_l1 = circuit->hello_interval[0];
+	uint32_t old_interval_l2 = circuit->hello_interval[1];
+
 	circuit->hello_interval[0] = interval;
 	circuit->hello_interval[1] = interval;
+
+	/* if interval changed, reset hello timer */
+	if (old_interval_l1 != interval || old_interval_l2 != interval) {
+		isis_reset_hello_timer(circuit);
+	}
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
When working with the ISIS protocol, I noticed the same issue occurring as previously addressed in #9092  The root cause is: "Sending a Hello message before restarting the hello timer to avoid session flaps in case of larger hello interval configurations."