### PR TITLE
Ipforwarding modify

### DIFF
--- a/tests/topotests/zebra_operational_data/test_zebra_operational.py
+++ b/tests/topotests/zebra_operational_data/test_zebra_operational.py
@@ -48,13 +48,13 @@ def test_zebra_operationalr(tgen):
 
     r1 = tgen.gears["r1"]
 
-    output = json.loads(r1.vtysh_cmd("show mgmt get-data /frr-zebra:zebra"))
+    output = json.loads(r1.vtysh_cmd("show mgmt get-data /frr-zebra:zebra/state"))
 
     logger.info("Output")
     logger.info(output)
 
     logger.info("Ensuring that the max-multipath value is returned")
-    assert "max-multipath" in output["frr-zebra:zebra"].keys()
+    assert "max-multipath" in output["frr-zebra:zebra"]["state"].keys()
 
     logger.info("Checking IP forwarding states")
     state = output["frr-zebra:zebra"]["state"]

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -3080,17 +3080,6 @@ module frr-zebra {
   container zebra {
     description
       "Data model for the Zebra daemon.";
-    leaf max-multipath {
-      type uint16 {
-        range "1..65535";
-      }
-      config false;
-      description
-        "The maximum number of nexthops for a route.  At this point it
-         is unlikely that a multipath number will ever get larger then
-         1024 but to allow for future expansions, the yang returns a
-         16 bit number";
-    }
     leaf ip-forwarding {
       type boolean;
       description
@@ -3193,6 +3182,16 @@ module frr-zebra {
       config false;
       description
         "Operational data.";
+      leaf max-multipath {
+        type uint16 {
+          range "1..65535";
+        }
+        description
+          "The maximum number of nexthops for a route.  At this point it
+           is unlikely that a multipath number will ever get larger then
+           1024 but to allow for future expansions, the yang returns a
+           16 bit number";
+      }
       leaf ip-forwarding {
         type boolean;
         description

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -26,7 +26,7 @@ const struct frr_yang_module_info frr_zebra_info = {
 	.features = features,
 	.nodes = {
 		{
-			.xpath = "/frr-zebra:zebra/max-multipath",
+			.xpath = "/frr-zebra:zebra/state/max-multipath",
 			.cbs = {
 				.get_elem = zebra_max_multipath_get_elem,
 			}

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -76,13 +76,21 @@ int zebra_ip_forwarding_destroy(struct nb_cb_destroy_args *args)
  */
 int zebra_ipv6_forwarding_modify(struct nb_cb_modify_args *args)
 {
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
+	bool forwarding;
+	int ret;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	forwarding = yang_dnode_get_bool(args->dnode, NULL);
+	ret = ipforward_ipv6();
+
+	if (ret == 0) {
+		if (forwarding)
+			ipforward_ipv6_on();
+	} else {
+		if (!forwarding)
+			ipforward_ipv6_off();
 	}
 
 	return NB_OK;

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -30,19 +30,28 @@
 #include "zebra/zebra_routemap.h"
 #include "zebra/zebra_rnh.h"
 #include "zebra/table_manager.h"
+#include "zebra/ipforward.h"
 
 /*
  * XPath: /frr-zebra:zebra/ip-forwarding
  */
 int zebra_ip_forwarding_modify(struct nb_cb_modify_args *args)
 {
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
+	bool forwarding;
+	int ret;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	forwarding = yang_dnode_get_bool(args->dnode, NULL);
+
+	ret = ipforward();
+	if (ret == 0) {
+		if (forwarding)
+			ipforward_on();
+	} else {
+		if (!forwarding)
+			ipforward_off();
 	}
 
 	return NB_OK;

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -1177,7 +1177,7 @@ lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_nexthop_weight_get_elem(
 
 /*
  * XPath:
- * /frr-zebra:zebra/max-multipath
+ * /frr-zebra:zebra/state/max-multipath
  */
 struct yang_data *zebra_max_multipath_get_elem(struct nb_cb_get_elem_args *args)
 {

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3910,45 +3910,17 @@ DEFUN (show_ipv6_forwarding,
 	return CMD_SUCCESS;
 }
 
-DEFUN (ipv6_forwarding,
-       ipv6_forwarding_cmd,
-       "ipv6 forwarding",
-       IPV6_STR
-       "Turn on IPv6 forwarding\n")
+DEFPY_YANG (ipv6_forwarding,
+	    ipv6_forwarding_cmd,
+	    "[no] ipv6 forwarding",
+	    NO_STR
+	    IPV6_STR
+	    "Turn on IPv6 forwarding\n")
 {
-	int ret;
+	nb_cli_enqueue_change(vty, "/frr-zebra:zebra/ipv6-forwarding", NB_OP_MODIFY,
+			      no ? "false" : "true");
 
-	ret = ipforward_ipv6();
-	if (ret == 0)
-		ret = ipforward_ipv6_on();
-
-	if (ret == 0) {
-		vty_out(vty, "Can't turn on IPv6 forwarding\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_ipv6_forwarding,
-       no_ipv6_forwarding_cmd,
-       "no ipv6 forwarding",
-       NO_STR
-       IPV6_STR
-       "Turn off IPv6 forwarding\n")
-{
-	int ret;
-
-	ret = ipforward_ipv6();
-	if (ret != 0)
-		ret = ipforward_ipv6_off();
-
-	if (ret != 0) {
-		vty_out(vty, "Can't turn off IPv6 forwarding\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	return CMD_SUCCESS;
+	return nb_cli_apply_changes(vty, NULL);
 }
 
 /* Display dataplane info */
@@ -4245,7 +4217,6 @@ void zebra_vty_init(void)
 
 	install_element(VIEW_NODE, &show_ipv6_forwarding_cmd);
 	install_element(CONFIG_NODE, &ipv6_forwarding_cmd);
-	install_element(CONFIG_NODE, &no_ipv6_forwarding_cmd);
 
 	/* Route-map */
 	zebra_route_map_init();

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3849,45 +3849,17 @@ DEFUN (show_zebra,
 	return CMD_SUCCESS;
 }
 
-DEFUN (ip_forwarding,
-       ip_forwarding_cmd,
-       "ip forwarding",
-       IP_STR
-       "Turn on IP forwarding\n")
+DEFPY_YANG (ip_forwarding,
+	    ip_forwarding_cmd,
+	    "[no] ip forwarding",
+	    NO_STR
+	    IP_STR
+	    "Turn on IP forwarding\n")
 {
-	int ret;
+	nb_cli_enqueue_change(vty, "/frr-zebra:zebra/ip-forwarding", NB_OP_MODIFY,
+			      no ? "false" : "true");
 
-	ret = ipforward();
-	if (ret == 0)
-		ret = ipforward_on();
-
-	if (ret == 0) {
-		vty_out(vty, "Can't turn on IP forwarding\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_ip_forwarding,
-       no_ip_forwarding_cmd,
-       "no ip forwarding",
-       NO_STR
-       IP_STR
-       "Turn off IP forwarding\n")
-{
-	int ret;
-
-	ret = ipforward();
-	if (ret != 0)
-		ret = ipforward_off();
-
-	if (ret != 0) {
-		vty_out(vty, "Can't turn off IP forwarding\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	return CMD_SUCCESS;
+	return nb_cli_apply_changes(vty, NULL);
 }
 
 /* Only display ip forwarding is enabled or not. */
@@ -4269,7 +4241,6 @@ void zebra_vty_init(void)
 
 	install_element(VIEW_NODE, &show_ip_forwarding_cmd);
 	install_element(CONFIG_NODE, &ip_forwarding_cmd);
-	install_element(CONFIG_NODE, &no_ip_forwarding_cmd);
 	install_element(ENABLE_NODE, &show_zebra_cmd);
 
 	install_element(VIEW_NODE, &show_ipv6_forwarding_cmd);


### PR DESCRIPTION
a) Move max-multicast to a state value
b) Convert `ip forwarding` to yang
c) Convert `ipv6 forwarding` to yang

I am doing something wrong with this conversion, in that I am not seeing the config values reflected in yang when I ask for it.  I do not know what I am missing or doing wrong and would like some help figuring it out.  When I issue:

`show mgmt get-data /frr-zebra:zebra with-defaults all`
`show mgmt get-data /frr-zebra:zebra with-config`
`show mgmt get-data /frr-zebra:zebra only-config` 

I do not see the ip|ipv6 forwarding yang show up there.  

When I issue the
`show mgmt get-config /frr-zebra:zebra` I only see the default values as defined in yang

I do know that yang-conversion is being accepted by the system as that I can toggle forwarding on/off. 

I also see this problem with the zapi packets command as well.  It is accepted, `show run` reflects it and I can
stop the code and see that it is working, I just cannot get the yang data to show it.
