### PR TITLE
staticd: Fix an issue where SRv6 SIDs may not be allocated on heavily loaded systems

### DIFF
--- a/staticd/static_srv6.c
+++ b/staticd/static_srv6.c
@@ -153,6 +153,15 @@ void delete_static_srv6_sid(void *val)
 	static_srv6_sid_free((struct static_srv6_sid *)val);
 }
 
+void static_zebra_request_srv6_sids()
+{
+	struct static_srv6_sid *sid;
+	struct listnode *node;
+
+	for (ALL_LIST_ELEMENTS_RO(srv6_sids, node, sid))
+		static_zebra_request_srv6_sid(sid);
+}
+
 /*
  * Initialize SRv6 data structures.
  */

--- a/staticd/static_srv6.c
+++ b/staticd/static_srv6.c
@@ -153,7 +153,7 @@ void delete_static_srv6_sid(void *val)
 	static_srv6_sid_free((struct static_srv6_sid *)val);
 }
 
-void static_zebra_request_srv6_sids()
+void static_zebra_request_srv6_sids(void)
 {
 	struct static_srv6_sid *sid;
 	struct listnode *node;

--- a/staticd/static_srv6.h
+++ b/staticd/static_srv6.h
@@ -101,6 +101,8 @@ struct static_srv6_locator *static_srv6_locator_lookup(const char *name);
 void delete_static_srv6_sid(void *val);
 void delete_static_srv6_locator(void *val);
 
+void static_zebra_request_srv6_sids(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -187,6 +187,8 @@ static void zebra_connected(struct zclient *zclient)
 	 * in.
 	 */
 	static_install_nexthops_on_startup();
+
+	static_zebra_request_srv6_sids();
 }
 
 /* API to check whether the configured nexthop address is

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -942,6 +942,11 @@ extern void static_zebra_request_srv6_sid(struct static_srv6_sid *sid)
 	if (!sid || !static_zebra_sid_locator_block_check(sid))
 		return;
 
+	if (!sid->locator) {
+		static_zebra_srv6_manager_get_locator(sid->locator_name);
+		return;
+	}
+
 	/* convert `srv6_endpoint_behavior_codepoint` to `seg6local_action_t` */
 	switch (sid->behavior) {
 	case SRV6_ENDPOINT_BEHAVIOR_END:


### PR DESCRIPTION
On a heavily loaded system, it may take some time to establish a connection between staticd and SRv6 SID Manager.
As a result, staticd might try to allocate SIDs in SID Manager before the connection is fully established, leading to a failure.

This issue is reflected in the log with the following error message:

```
2025/03/04 15:24:01 STATIC: [HR66R-TWQYD][EC 100663302] srv6_manager_get_locator: invalid zclient socket
```

In this scenario, SIDs are still kept in the staticd configuration, but not allocated and not installed in the RIB.

This commit fixes the issue by forcing staticd to retry to allocate the SIDs once the connection with SID Manager is successfully established.