### PR TITLE
doc: don't override automake builtin targets

### DIFF
--- a/doc/user/subdir.am
+++ b/doc/user/subdir.am
@@ -84,9 +84,9 @@ endif
 #
 
 .PHONY: info html pdf
-info: $(USERBUILD)/texinfo/frr.info
-html: $(USERBUILD)/html/.buildinfo
-pdf:  $(USERBUILD)/latexpdf
+info-local: $(USERBUILD)/texinfo/frr.info
+html-local: $(USERBUILD)/html/.buildinfo
+pdf-local:  $(USERBUILD)/latexpdf
 
 #
 # hook-ins for clean / install / doc
@@ -100,7 +100,7 @@ clean-userdocs:
 # INSTALL_INFO=install-info
 .PHONY: install-info uninstall-info install-html uninstall-html
 
-install-info: $(USERBUILD)/texinfo/frr.info
+install-info-local: $(USERBUILD)/texinfo/frr.info
 	$(MKDIR_P) "$(DESTDIR)$(infodir)"
 	$(INSTALL_DATA) "$<" "$(DESTDIR)$(infodir)"
 	[ -z "${DESTDIR}" ] && $(INSTALL_INFO) --info-dir="$(DESTDIR)$(infodir)" "$<" || true
@@ -108,7 +108,7 @@ uninstall-info: $(USERBUILD)/texinfo/frr.info
 	-rm -f "$(DESTDIR)$(infodir)/$<"
 	[ -z "${DESTDIR}" ] && $(INSTALL_INFO) --delete --info-dir="$(DESTDIR)$(infodir)" "$<" || true
 
-install-html: $(USERBUILD)/html/.buildinfo
+install-html-local: $(USERBUILD)/html/.buildinfo
 	$(MKDIR_P) "$(DESTDIR)$(htmldir)"
 	cp -r "$(USERBUILD)/html" "$(DESTDIR)$(htmldir)"
 uninstall-html:


### PR DESCRIPTION
Automake generates [default targets](https://www.gnu.org/software/automake/manual/automake.html#Texinfo) for `info`, `html`, `pdf` and corresponding `install-info` and `install-html` targets to install the artifacts generated by those rules. Prior to this change we are overriding those targets which results in automake warnings:

```
lib/subdir.am:545: warning: user target '.l.c' defined here ...
Makefile.am:178:   'lib/subdir.am' included from here
/nix/store/kwhvl2c4m4dfv91pamx4xxp7np0r1xwq-automake-1.16.5/share/automake-1.16/am/lex.am: ... overrides Automake target '.l.c' defined here
configure.ac: installing 'm4/ac/ylwrap'
lib/subdir.am:547: warning: user target '.y.c' defined here ...
Makefile.am:178:   'lib/subdir.am' included from here
/nix/store/kwhvl2c4m4dfv91pamx4xxp7np0r1xwq-automake-1.16.5/share/automake-1.16/am/yacc.am: ... overrides Automake target '.y.c' defined here
parallel-tests: installing 'm4/ac/test-driver'
doc/user/subdir.am:88: warning: user target 'html' defined here ...
Makefile.am:174:   'doc/user/subdir.am' included from here
automake: ... overrides Automake target 'html' defined here
doc/user/subdir.am:88: consider using html-local instead of html
Makefile.am:174:   'doc/user/subdir.am' included from here
doc/user/subdir.am:87: warning: user target 'info' defined here ...
Makefile.am:174:   'doc/user/subdir.am' included from here
automake: ... overrides Automake target 'info' defined here
doc/user/subdir.am:87: consider using info-local instead of info
Makefile.am:174:   'doc/user/subdir.am' included from here
doc/user/subdir.am:111: warning: user target 'install-html' defined here ...
Makefile.am:174:   'doc/user/subdir.am' included from here
automake: ... overrides Automake target 'install-html' defined here
doc/user/subdir.am:111: consider using install-html-local instead of install-html
Makefile.am:174:   'doc/user/subdir.am' included from here
doc/user/subdir.am:103: warning: user target 'install-info' defined here ...
Makefile.am:174:   'doc/user/subdir.am' included from here
automake: ... overrides Automake target 'install-info' defined here
doc/user/subdir.am:103: consider using install-info-local instead of install-info
Makefile.am:174:   'doc/user/subdir.am' included from here
doc/user/subdir.am:89: warning: user target 'pdf' defined here ...
Makefile.am:174:   'doc/user/subdir.am' included from here
automake: ... overrides Automake target 'pdf' defined here
doc/user/subdir.am:89: consider using pdf-local instead of pdf
Makefile.am:174:   'doc/user/subdir.am' included from here
```

The automake targets are designed to automatically build texinfo sources without requiring user-specified rules. We do not have texinfo sources so this functionality is not in use, but we are still overriding the built in targets which is considered poor form. Automake has [facilities](https://www.gnu.org/software/automake/manual/automake.html#Extending) to modify the built in targets in the form of `-local` rules; this patch renames the rules we had defined to use the `-local` ones.

The resulting targets generated by Automake look like this:

    html: html-am
    html-am: html-local

i.e. the final `html` target generated when using `html-local` to define our custom rules is identical to the one we get by overriding the built in `html` target. The same goes for the others.

So, the only effect this patch has is suppressing the warnings and bringing us in line with Automake best practice.