### PR TITLE
bgpd: Fix dead code in bgp_route.c #1637664

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3281,11 +3281,8 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,
 			if (worse->prev)
 				worse->prev->next = first;
 			first->next = worse;
-			if (worse) {
-				first->prev = worse->prev;
-				worse->prev = first;
-			} else
-				first->prev = NULL;
+			first->prev = worse->prev;
+			worse->prev = first;
 
 			if (dest->info == worse) {
 				bgp_dest_set_bgp_path_info(dest, first);


### PR DESCRIPTION
Coverity rightly points out that the worse pointer cannot be null in this section of code.  Fix it.