### PR TITLE
bgpd: fix radv interface disabled when bgp instance removed

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4199,6 +4199,11 @@ int bgp_delete(struct bgp *bgp)
 
 	while (listcount(bgp->peer)) {
 		peer = listnode_head(bgp->peer);
+		if (peer->ifp ||
+		    CHECK_FLAG(peer->flags, PEER_FLAG_CAPABILITY_ENHE))
+			bgp_zebra_terminate_radv(peer->bgp, peer);
+
+		peer_notify_unconfig(peer->connection);
 		peer_delete(peer);
 	}
 


### PR DESCRIPTION
If a peer uses radv for an interface, and bgp instance is removed, then the radv service is not disabled on the interface.

Fix this by doing the same at BGP unconfiguration. Like it has been done when a peer is unconfigured, call the radv unregistration before deleting the peer.

Fixes: b3a3290e2303 ("bgpd: turn off RAs when numbered peers are deleted")