### PR TITLE
pimd: Skip RPF check for SA message from mesh group peer

### DIFF
--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -1028,10 +1028,11 @@ struct pim_msdp_peer *pim_msdp_peer_add(struct pim_instance *pim,
 	mp->peer = *peer;
 	pim_inet4_dump("<peer?>", mp->peer, mp->key_str, sizeof(mp->key_str));
 	mp->local = *local;
-	if (mesh_group_name)
+	if (mesh_group_name) {
 		mp->mesh_group_name =
 			XSTRDUP(MTYPE_PIM_MSDP_MG_NAME, mesh_group_name);
-
+		SET_FLAG(mp->flags, PIM_MSDP_PEERF_IN_GROUP);
+	}
 	mp->state = PIM_MSDP_INACTIVE;
 	mp->fd = -1;
 	mp->auth_listen_sock = -1;


### PR DESCRIPTION
According to RFC 3618 section 10.2
If a member R of a mesh-group M receives a SA message from an MSDP peer that is also a member of mesh-group M, R accepts the SA message and forwards it to all of its peers that are not part of mesh-group M.  R MUST NOT forward the SA message to other members of mesh-group M.
https://datatracker.ietf.org/doc/html/rfc3618#section-10.2

With the changes in this commit, if the SA message is received from a peer that is the part of same mesh group, the RPF check will be skipped and the SA will be processed. The SA message will be forwarded to only those peer that do not belong to the mesh-group of the originator SA packet