### PR TITLE
bgpd: optimize the memory usage by stream during route add

### DIFF
--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -1158,7 +1158,7 @@ zclient_send_rnh(struct zclient *zclient, int command, const struct prefix *p,
 		 vrf_id_t vrf_id);
 int zapi_nexthop_encode(struct stream *s, const struct zapi_nexthop *api_nh,
 			uint32_t api_flags, uint32_t api_message);
-extern int zapi_redistribute_stream_size(struct zapi_route *api);
+extern int zapi_route_stream_size(struct zapi_route *api);
 extern int zapi_route_encode(uint8_t, struct stream *, struct zapi_route *);
 extern int zapi_route_decode(struct stream *s, struct zapi_route *api);
 extern int zapi_nexthop_decode(struct stream *s, struct zapi_nexthop *api_nh,

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -610,7 +610,7 @@ int zsend_redistribute_route(int cmd, struct zserv *client, const struct route_n
 	SET_FLAG(api.message, ZAPI_MESSAGE_MTU);
 	api.mtu = re->mtu;
 
-	stream_size = zapi_redistribute_stream_size(&api);
+	stream_size = zapi_route_stream_size(&api);
 	struct stream *s = stream_new(stream_size);
 
 	/* Encode route and send. */


### PR DESCRIPTION
Currently, bgpd uses the stream size that is depending on the size of the zapi_route which would include
MULTIPATH_NUM * (nexthops + backup_nexthops).
We end up allocating the stream for 512 NHs even though the route being installed is having a single NH.

Fix: allocating the stream size based on the nexthops of a route being installed.