### PR TITLE
Topotest startup order

### DIFF
--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1960,7 +1960,13 @@ class Router(Node):
                 )
             else:
                 binary = os.path.join(self.daemondir, daemon)
-                check_daemon_files.extend([runbase + ".pid", runbase + ".vty"])
+                if daemon == "zebra":
+                    zapi_base = "/var/run/{}/zserv.api".format(self.routertype)
+                    check_daemon_files.extend(
+                        [runbase + ".pid", runbase + ".vty", zapi_base]
+                    )
+                else:
+                    check_daemon_files.extend([runbase + ".pid", runbase + ".vty"])
 
                 cmdenv = "ASAN_OPTIONS="
                 if asan_abort:


### PR DESCRIPTION
Topotests startup by starting mgmtd/zebra/staticd then everything else.  Unfortunately the problem is that under heavy system load other daemons can get ahead of zebra( and probably mgmtd too ) and attempt to connect to zebra before it is ready.  If this happens there tests can and are thrown off because some daemons don't have great recovery mechanisms for reconnection to zebra.  

Modify the tests so that mgmtd and zebra are actually ensured that they are up and ready before continuing on with the other daemons.