### PR TITLE
staticd: fix route installation on same next hop with inactive routes

### DIFF
--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -365,9 +365,13 @@ void static_zebra_nht_register(struct static_nexthop *nh, bool reg)
 			return;
 		}
 
-		if (nhtd->registered)
+		if (nhtd->registered) {
 			/* have no data, but did send register */
+			afi_t afi = prefix_afi(&lookup.nh);
+			static_nht_update(p, src_p, &nhtd->nh, nhtd->nh_num, afi, si->safi,
+					  nh->nh_vrf_id);
 			return;
+		}
 
 		cmd = ZEBRA_NEXTHOP_REGISTER;
 		DEBUGD(&static_dbg_route, "Registering nexthop(%pFX) for %pRN",


### PR DESCRIPTION
Fixes #18321.

When two routes have the same inactive next hop the second (third and so on) route installation won't happen, because a global next hop reference already exists. Add the code to install the route in case global next hop entry already exists and the next hop is inactive.

(Credits: Changes done by Rafael Zalamena - Just opening the PR for him as he is on vacation)
