### PR TITLE
tests: Fixed NameError at bmpserver.py

### DIFF
--- a/tests/topotests/lib/bmp_collector/bmpserver.py
+++ b/tests/topotests/lib/bmp_collector/bmpserver.py
@@ -73,7 +73,7 @@ def savepid():
             pid = open(pid_file, "r").readline().strip()
             if check_pid(int(pid)):
                 timestamp_print(
-                    "PID file already exists and program still running %s\n" % pid_file
+                    f"PID file already exists and program still running {pid_file}\n"
                 )
                 return False
             else:
@@ -81,8 +81,7 @@ def savepid():
                 fd = os.open(pid_file, flags ^ os.O_EXCL, mode)
         except (OSError, IOError, ValueError):
             timestamp_print(
-                "issue accessing PID file %s (most likely permission or ownership)\n"
-                % pid_file
+                f"issue accessing PID file {pid_file} (most likely permission or ownership)\n"
             )
             return False
 
@@ -93,9 +92,9 @@ def savepid():
         f.close()
         saved_pid = True
     except IOError:
-        timestamp_print("Can not create PID file %s\n" % pid_file)
+        timestamp_print(f"Can not create PID file {pid_file}\n")
         return False
-    timestamp_print("Created PID file %s with value %d\n" % (pid_file, ownid))
+    timestamp_print(f"Created PID file {pid_file} with value {ownid}\n")
     return True
 
 
@@ -106,9 +105,9 @@ def removepid():
         if exc.errno == errno.ENOENT:
             pass
         else:
-            timestamp_print("Can not remove PID file %s\n" % pid_file)
+            timestamp_print(f"Can not remove PID file {pid_file}\n")
             return
-    timestamp_print("Removed PID file %s\n" % pid_file)
+    timestamp_print(f"Removed PID file {pid_file}\n")
 
 
 def main():
@@ -168,7 +167,7 @@ def main():
                 timestamp_print(f"TCP session closed with {client_address}")
                 connection.close()
         except socket.error as sock_err:
-            timestamp_print(f"Socket error: {e}")
+            timestamp_print(f"Socket error: {sock_err}")
         except Exception as e:
             timestamp_print(f"{e}")
         finally:


### PR DESCRIPTION
Fixed NameError at bmpserver.py

        except socket.error as sock_err:
            timestamp_print(f"Socket error: {e}")  <---- NameError 