### PR TITLE
bgpd, zebra, tests: disable rtadv when bgp instance unconfiguration.

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4199,6 +4199,10 @@ int bgp_delete(struct bgp *bgp)
 
 	while (listcount(bgp->peer)) {
 		peer = listnode_head(bgp->peer);
+		if (peer->ifp || CHECK_FLAG(peer->flags, PEER_FLAG_CAPABILITY_ENHE))
+			bgp_zebra_terminate_radv(peer->bgp, peer);
+
+		peer_notify_unconfig(peer->connection);
 		peer_delete(peer);
 	}
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4202,8 +4202,15 @@ int bgp_delete(struct bgp *bgp)
 		if (peer->ifp || CHECK_FLAG(peer->flags, PEER_FLAG_CAPABILITY_ENHE))
 			bgp_zebra_terminate_radv(peer->bgp, peer);
 
-		peer_notify_unconfig(peer->connection);
-		peer_delete(peer);
+		if (BGP_PEER_GRACEFUL_RESTART_CAPABLE(peer)) {
+			if (bgp_debug_neighbor_events(peer))
+				zlog_debug("%pBP configured Graceful-Restart, skipping unconfig notification",
+					   peer);
+			peer_delete(peer);
+		} else {
+			peer_notify_unconfig(peer->connection);
+			peer_delete(peer);
+		}
 	}
 
 	if (bgp->peer_self && !IS_BGP_INSTANCE_HIDDEN(bgp)) {

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -40,8 +40,8 @@ DEFINE_MTYPE_STATIC(ZEBRA, ZINFO, "Zebra Interface Information");
 
 #define ZEBRA_PTM_SUPPORT
 
-DEFINE_HOOK(zebra_if_extra_info, (struct vty * vty, struct interface *ifp),
-	    (vty, ifp));
+DEFINE_HOOK(zebra_if_extra_info, (struct vty * vty, json_object *json_if, struct interface *ifp),
+	    (vty, json_if, ifp));
 
 DEFINE_MTYPE_STATIC(ZEBRA, ZIF_DESC, "Intf desc");
 
@@ -2846,7 +2846,7 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 				&iflp->rmt_ip, iflp->rmt_as);
 	}
 
-	hook_call(zebra_if_extra_info, vty, ifp);
+	hook_call(zebra_if_extra_info, vty, NULL, ifp);
 
 	if (listhead(ifp->nbr_connected))
 		vty_out(vty, "  Neighbor address(s):\n");
@@ -3251,6 +3251,8 @@ static void if_dump_vty_json(struct vty *vty, struct interface *ifp,
 						"%pI4", &iflp->rmt_ip);
 		json_object_int_add(json_te, "neighborAsbrAs", iflp->rmt_as);
 	}
+
+	hook_call(zebra_if_extra_info, vty, json_if, ifp);
 
 	if (listhead(ifp->nbr_connected)) {
 		json_object *json_nbr_addrs;

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -223,8 +223,8 @@ struct zebra_if {
 	char *desc;
 };
 
-DECLARE_HOOK(zebra_if_extra_info, (struct vty * vty, struct interface *ifp),
-	     (vty, ifp));
+DECLARE_HOOK(zebra_if_extra_info, (struct vty * vty, json_object *json_if, struct interface *ifp),
+	     (vty, json_if, ifp));
 
 #define IS_ZEBRA_IF_VRF(ifp)                                                   \
 	(((struct zebra_if *)(ifp->info))->zif_type == ZEBRA_IF_VRF)


### PR DESCRIPTION
If bgpd instance is removed, then the rtadv is not disabled.

Like it was done when a peer is unconfigured,
do the same at BGP unconfiguration: unregister rtadv before deleting a peer.

Add a rtadv json fields. Create a topotest to check that newly added json fields are present.