### PR TITLE
Add Testing for community and Extended community match limit zero

### DIFF
--- a/tests/topotests/bgp_comm_list_match/test_bgp_comm_list_match.py
+++ b/tests/topotests/bgp_comm_list_match/test_bgp_comm_list_match.py
@@ -154,6 +154,11 @@ def test_bgp_comm_list_limit_match():
             "vrfName": "default",
             "routerId": "192.168.1.3",
             "localAS": 65003,
+            "routes": {
+                "172.16.255.2/32": [{"prefix": "172.16.255.2", "prefixLen": 32}],
+                "172.16.255.5/32": [{"prefix": "172.16.255.5", "prefixLen": 32}],
+                "192.168.0.0/24": [{"prefix": "192.168.0.0", "prefixLen": 24}],
+            },
             "totalRoutes": 3,
             "totalPaths": 3,
         }
@@ -163,6 +168,42 @@ def test_bgp_comm_list_limit_match():
     test_func = functools.partial(_bgp_count)
     _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
     assert result is None, "Failed to check that 3 routes have been received on R3"
+
+
+def test_bgp_comm_list_limit_match_no_community():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r3"]
+    router.vtysh_cmd(
+        """
+        configure terminal
+        route-map r1 permit 20
+        match community-limit 0
+        """
+    )
+
+    def _bgp_count():
+        output = json.loads(router.vtysh_cmd("show bgp ipv4 json"))
+        expected = {
+            "vrfName": "default",
+            "routerId": "192.168.1.3",
+            "localAS": 65003,
+            "routes": {
+                "172.16.255.2/32": [{"prefix": "172.16.255.2", "prefixLen": 32}],
+                "192.168.0.0/24": [{"prefix": "192.168.0.0", "prefixLen": 24}],
+            },
+            "totalRoutes": 2,
+            "totalPaths": 2,
+        }
+        return topotest.json_cmp(output, expected)
+
+    step("Check that 2 routes have been received on R3")
+    test_func = functools.partial(_bgp_count)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to check that 2 routes have been received on R3"
 
 
 def test_bgp_comm_list_reset_limit_match():

--- a/tests/topotests/bgp_ecomm_list_match/test_bgp_ecomm_list_match.py
+++ b/tests/topotests/bgp_ecomm_list_match/test_bgp_ecomm_list_match.py
@@ -150,6 +150,11 @@ def test_bgp_extcomm_list_limit_match():
             "vrfName": "default",
             "routerId": "192.168.1.3",
             "localAS": 65003,
+            "routes": {
+                "172.16.255.2/32": [{"prefix": "172.16.255.2", "prefixLen": 32}],
+                "172.16.255.5/32": [{"prefix": "172.16.255.5", "prefixLen": 32}],
+                "192.168.0.0/24": [{"prefix": "192.168.0.0", "prefixLen": 24}],
+            },
             "totalRoutes": 3,
             "totalPaths": 3,
         }
@@ -161,7 +166,43 @@ def test_bgp_extcomm_list_limit_match():
     assert result is None, "Failed to check that 3 routes have been received on R3"
 
 
-def test_bgp_comm_list_reset_limit_match():
+def test_bgp_extcomm_list_limit_match_no_community():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r3"]
+    router.vtysh_cmd(
+        """
+        configure terminal
+        route-map r1 permit 20
+        match extcommunity-limit 0
+        """
+    )
+
+    def _bgp_count():
+        output = json.loads(router.vtysh_cmd("show bgp ipv4 json"))
+        expected = {
+            "vrfName": "default",
+            "routerId": "192.168.1.3",
+            "localAS": 65003,
+            "routes": {
+                "172.16.255.2/32": [{"prefix": "172.16.255.2", "prefixLen": 32}],
+                "192.168.0.0/24": [{"prefix": "192.168.0.0", "prefixLen": 24}],
+            },
+            "totalRoutes": 2,
+            "totalPaths": 2,
+        }
+        return topotest.json_cmp(output, expected)
+
+    step("Check that 2 routes have been received on R3")
+    test_func = functools.partial(_bgp_count)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Failed to check that 2 routes have been received on R3"
+
+
+def test_bgp_extcomm_list_reset_limit_match():
     tgen = get_topogen()
 
     if tgen.routers_have_failure():


### PR DESCRIPTION
Add some more testing for when the community limit and extcommunity limit commands over the route-map are set to 0.