### PR TITLE
staticd: Install known nexthops upon connection with zebra

### DIFF
--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -264,6 +264,7 @@ extern void static_bfd_initialize(struct zclient *zc, struct event_loop *tm);
 
 extern void static_bfd_show(struct vty *vty, bool isjson);
 
+extern void static_install_nexthops_on_startup(void);
 #ifdef __cplusplus
 }
 #endif

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -181,6 +181,12 @@ static void zebra_connected(struct zclient *zclient)
 	vrf = vrf_lookup_by_id(VRF_DEFAULT);
 	assert(vrf);
 	static_fixup_vrf_ids(vrf);
+
+	/*
+	 * It's possible that staticd connected after config was read
+	 * in.
+	 */
+	static_install_nexthops_on_startup();
 }
 
 /* API to check whether the configured nexthop address is


### PR DESCRIPTION
CI tests are showing cases where staticd is connecting to zebra after config is read in and the nexthops are never being registered w/ zebra:

2025/03/11 15:39:44 STATIC: [T83RR-8SM5G] staticd 10.4-dev starting: vty@2616
2025/03/11 15:39:45 STATIC: [GH3PB-C7X4Y] Static Route to 13.13.13.13/32 not installed currently because dependent config not fully available
2025/03/11 15:39:45 STATIC: [RHJK1-M5FAR] static_zebra_nht_register: Failure to send nexthop 1.1.1.2/32 for 11.11.11.11/32 to zebra
2025/03/11 15:39:45 STATIC: [M7Q4P-46WDR] vty[14]@> enable

Zebra shows connection time as:

2025/03/11 15:39:45.933343 ZEBRA: [V98V0-MTWPF] client 5 says hello and bids fair to announce only static routes vrf=0

As a result staticd never installs the route because it has no nexthop tracking to say that the route could be installed.

Modify staticd on startup to go through it's nexthops and dump them to zebra to allow the staticd state machine to get to work.