### PR TITLE
isisd: Fix the issue where redistributed routes do not change when th…

### DIFF
--- a/isisd/isis_redist.c
+++ b/isisd/isis_redist.c
@@ -44,6 +44,17 @@ static int redist_protocol(int family)
 	return 0;
 }
 
+int afi_skt_for_redist_protocol(int protocol)
+{
+	if (protocol == 0)
+		return AF_INET;
+	if (protocol == 1)
+		return AF_INET6;
+
+	assert(!"Unknown redist protocol!");
+	return AF_INET;
+}
+
 afi_t afi_for_redist_protocol(int protocol)
 {
 	if (protocol == 0)
@@ -427,6 +438,41 @@ void isis_redist_free(struct isis *isis)
 
 		route_table_finish(isis->ext_info[i]);
 		isis->ext_info[i] = NULL;
+	}
+}
+
+void isis_redist_update(struct isis_area *area, int level, int family, int type, uint16_t table)
+{
+	struct isis_redist *redist;
+	struct route_table *ei_table;
+	struct route_node *rn;
+	struct isis_ext_info *info;
+
+	redist = isis_redist_lookup(area, family, type, level, table);
+	if (!redist)
+		return;
+
+	ei_table = get_ext_info(area->isis, family);
+	for (rn = route_top(ei_table); rn; rn = srcdest_route_next(rn)) {
+		if (!rn->info)
+			continue;
+		info = rn->info;
+
+		const struct prefix *p, *src_p;
+
+		srcdest_rnode_prefixes(rn, &p, &src_p);
+
+		if (type == DEFAULT_ROUTE) {
+			if (!is_default_prefix(p) || (src_p && src_p->prefixlen)) {
+				continue;
+			}
+		} else {
+			if (info->origin != type)
+				continue;
+		}
+
+		isis_redist_update_ext_reach(area, level, redist, p,
+					     (const struct prefix_ipv6 *)src_p, info);
 	}
 }
 

--- a/isisd/isis_redist.h
+++ b/isisd/isis_redist.h
@@ -43,6 +43,7 @@ struct prefix;
 struct prefix_ipv6;
 struct vty;
 
+int afi_skt_for_redist_protocol(int protocol);
 afi_t afi_for_redist_protocol(int protocol);
 
 struct route_table *get_ext_reach(struct isis_area *area, int family,
@@ -60,6 +61,7 @@ void isis_redist_area_finish(struct isis_area *area);
 void isis_redist_set(struct isis_area *area, int level, int family, int type,
 		     uint32_t metric, const char *routemap, int originate_type,
 		     uint16_t table);
+void isis_redist_update(struct isis_area *area, int level, int family, int type, uint16_t table);
 void isis_redist_unset(struct isis_area *area, int level, int family, int type,
 		       uint16_t table);
 

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -56,6 +56,7 @@ static const bool fabricd = false;
 extern void isis_cli_init(void);
 #endif
 
+
 #define ISIS_FIND_VRF_ARGS(argv, argc, idx_vrf, vrf_name, all_vrf)             \
 	if (argv_find(argv, argc, "vrf", &idx_vrf)) {                          \
 		vrf_name = argv[idx_vrf + 1]->arg;                             \


### PR DESCRIPTION
Currently, both OSPF and GBP support dynamic updates when redistribute routes through a route-map. When the filtering conditions in the route-map change, this is also reflected in the OSPF code. However, IS-IS does not refresh redistribute routes. Although the documentation provides a simple description of  redistribute route introduction, objectively speaking, it is unreasonable for redistribute routes not to refresh when the route-map changes.



Usage example:
`
service integrated-vtysh-config
!
ip prefix-list prefix seq 5 permit 1.0.0.0/8 le 32
!
route-map vpn permit 1
 match ip address prefix-list prefix
exit
!
debug isis route-events
debug isis events
!
debug route-map
!
interface br-d16a50899912
 ip router isis 1
exit
!
router isis 1
 net 49.0000.0000.0001.00
 lsp-timers gen-interval 1 refresh-interval 2 max-lifetime 1200
 redistribute ipv4 kernel level-2 route-map vpn
exit

`


old: Routes will not be refreshed automatically.


![image](https://github.com/user-attachments/assets/9392f84f-8a89-40cb-89da-44b95ee5ce8a)


new: Immediate change.
![image](https://github.com/user-attachments/assets/89c14940-c5aa-4164-befc-f7b3761ff9a6)
