### PR TITLE
bgpd: check rmac and nh of evpn imported routes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3947,8 +3947,10 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 			 * we need to withdraw the route first to clear
 			 * the nh neigh and the RMAC entry.
 			 */
-			if (old_select &&
-			    is_route_parent_evpn(old_select))
+			if (old_select && is_route_parent_evpn(old_select) &&
+			    old_select->attr->nexthop.s_addr != new_select->attr->nexthop.s_addr &&
+			    !memcmp(&old_select->attr->rmac, &new_select->attr->rmac,
+				    sizeof(struct ethaddr)))
 				bgp_zebra_withdraw_actual(dest, old_select, bgp);
 
 			bgp_zebra_route_install(dest, new_select, bgp, true,


### PR DESCRIPTION
Fix for an issue which has been described here: https://github.com/FRRouting/frr/issues/18240
Basically in a setup where multiple peers advertise identical evpn type-5 rotues, if we clear session with any of them (and at least one is still up), we observe route withdrawals from kernel (even though we receive those routes from remaining peers). If the amount of routes is significant it causes a noticeable downtime before routes are readded to kernel. 

I'd appreciate a feedback on why a route withdrawal is necessary in such case (per the comment above I can assume that rmac entry/nh might be lingering somewhere, but where? Change which introduced withdrawal has been merged long time ago, is it still necessary?)

Also menitoned behavior (where routes are being withdrawn immediately even if other peers advertise them) has started to occur after backpressure bgp zebra client https://github.com/FRRouting/frr/pull/15524. 
