### PR TITLE
Backport missing frr config to 10.1

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -1292,6 +1292,15 @@ Example:
            router.load_config(TopoRouter.RD_ZEBRA, "zebra.conf")
            router.load_config(TopoRouter.RD_OSPF)
 
+or using unified config (specifying which daemons to run is optional):
+
+.. code:: py
+
+      for _, (rname, router) in enumerate(router_list.items(), 1):
+         router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)), [
+            (TopoRouter.RD_ZEBRA, "-s 90000000"),
+            (TopoRouter.RD_MGMTD, None),
+            (TopoRouter.RD_BGP, None)]
 
 - The topology definition or build function
 

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -832,10 +832,10 @@ class TopoRouter(TopoGear):
             for daemon in self.RD:
                 # This will not work for all daemons
                 daemonstr = self.RD.get(daemon).rstrip("d")
-                if daemonstr == "pim":
-                    grep_cmd = "grep 'ip {}' {}".format(daemonstr, source_path)
+                if daemonstr == "path":
+                    grep_cmd = "grep 'candidate-path' {}".format(source_path)
                 else:
-                    grep_cmd = "grep 'router {}' {}".format(daemonstr, source_path)
+                    grep_cmd = "grep -w '{}' {}".format(daemonstr, source_path)
                 result = self.run(grep_cmd, warn=False).strip()
                 if result:
                     self.load_config(daemon, "")

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -824,6 +824,8 @@ class TopoRouter(TopoGear):
         Loads the unified configuration file source
         Start the daemons in the list
         If daemons is None, try to infer daemons from the config file
+        `daemons` is a tuple (daemon, param) of daemons to start, e.g.:
+        (TopoRouter.RD_ZEBRA, "-s 90000000").
         """
         source_path = self.load_config(self.RD_FRR, source)
         if not daemons:
@@ -840,8 +842,9 @@ class TopoRouter(TopoGear):
                 if result:
                     self.load_config(daemon, "")
         else:
-            for daemon in daemons:
-                self.load_config(daemon, "")
+            for item in daemons:
+                daemon, param = item
+                self.load_config(daemon, "", param)
 
     def load_config(self, daemon, source=None, param=None):
         """Loads daemon configuration from the specified source

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -1406,7 +1406,7 @@ class Router(Node):
         self.daemondir = None
         self.hasmpls = False
         self.routertype = "frr"
-        self.unified_config = None
+        self.unified_config = False
         self.daemons = {
             "zebra": 0,
             "ripd": 0,
@@ -1629,7 +1629,7 @@ class Router(Node):
         # print "Daemons before:", self.daemons
         if daemon in self.daemons.keys() or daemon == "frr":
             if daemon == "frr":
-                self.unified_config = 1
+                self.unified_config = True
             else:
                 self.daemons[daemon] = 1
             if param is not None:


### PR DESCRIPTION
Backport some missing topotest infrastructure changes so that the v6_nexthop_group_recursive_resolution test can properly run on this branch.