### PR TITLE
bgpd: fix add prefix sent in 'show bgp neighbor'

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -14089,9 +14089,14 @@ static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
 					? "Advertise"
 					: "Withdraw");
 
-		/* Receive prefix count */
-		vty_out(vty, "  %u accepted prefixes\n",
-			p->pcount[afi][safi]);
+		/* Receive and sent prefix count, if available */
+		paf = peer_af_find(p, afi, safi);
+		if (paf && PAF_SUBGRP(paf))
+			vty_out(vty, "  %u accepted, %u sent prefixes\n",
+				p->pcount[afi][safi], PAF_SUBGRP(paf)->scount);
+		else
+			vty_out(vty, "  %u accepted prefixes\n",
+				p->pcount[afi][safi]);
 
 		/* maximum-prefix-out */
 		if (CHECK_FLAG(p->af_flags[afi][safi],


### PR DESCRIPTION
The 'acceptedPrefixCounter' is available in 'show bgp neighbor json', but there is no equivalent when using the non json output. Add it.

> # show bgp neighbor
> [..]
>  Community attribute sent to this neighbor(all)
>  0 accepted prefixes, 1 sent prefixes

Fixes: 856ca177c4bb ("Added json formating support to show-...-neighbors-... bgp commands.")