### PR TITLE
isisd: fix bit flag collision in options field

### DIFF
--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -76,9 +76,9 @@ struct isis_master {
 	struct event_loop *master;
 	/* Various global options */
 	uint8_t options;
-#define ISIS_OPT_DUMMY_AS_LOOPBACK (1 << 0)
+#define F_ISIS_UNIT_TEST	   (1 << 0)
+#define ISIS_OPT_DUMMY_AS_LOOPBACK (1 << 1)
 };
-#define F_ISIS_UNIT_TEST 0x01
 
 #define ISIS_DEFAULT_MAX_AREA_ADDRESSES 3
 


### PR DESCRIPTION
Resolve conflict between F_ISIS_UNIT_TEST and ISIS_OPT_DUMMY_AS_LOOPBACK (introduced in #18242) which were both using the same bit value (0x01). This collision caused unit test mode to be unintentionally enabled when DUMMY_AS_LOOPBACK was set.

