### PR TITLE
bgpd: fix `set evpn gateway-ip ipv[46]` route-map

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5165,7 +5165,8 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	 * attr->evpn_overlay with evpn directly. Instead memcpy
 	 * evpn to new_atr.evpn_overlay before it is interned.
 	 */
-	if (soft_reconfig && evpn && afi == AFI_L2VPN) {
+	if (evpn && afi == AFI_L2VPN &&
+	    (soft_reconfig || !CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG))) {
 		bgp_attr_set_evpn_overlay(&new_attr, evpn);
 		p_evpn = NULL;
 	}

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1441,7 +1441,7 @@ route_set_evpn_gateway_ip(void *rule, const struct prefix *prefix, void *object)
 
 	/* Set gateway-ip value. */
 	bre->type = OVERLAY_INDEX_GATEWAY_IP;
-	memcpy(&bre->gw_ip, &gw_ip->ip.addr, IPADDRSZ(gw_ip));
+	bre->gw_ip = *gw_ip;
 	bgp_attr_set_evpn_overlay(path->attr, bre);
 
 	return RMAP_OKAY;

--- a/tests/topotests/bgp_evpn_route_map_set/c1/frr.conf
+++ b/tests/topotests/bgp_evpn_route_map_set/c1/frr.conf
@@ -1,0 +1,22 @@
+int lo
+ ip address 10.10.10.10/32
+!
+int c1-eth0
+ ip address 10.0.0.1/31
+!
+router bgp 65000
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ !
+ neighbor 10.0.0.0 remote-as external
+ neighbor 10.0.0.0 timers 1 3
+ neighbor 10.0.0.0 timers connect 1
+ !
+ address-family ipv4 unicast
+  neighbor 10.0.0.0 activate
+  redistribute connected route-map allow-lo
+ exit-address-family
+!
+route-map allow-lo permit 10
+ match interface lo
+!

--- a/tests/topotests/bgp_evpn_route_map_set/r1/frr.conf
+++ b/tests/topotests/bgp_evpn_route_map_set/r1/frr.conf
@@ -1,0 +1,38 @@
+! This router advertises as EVPN type-5 routes those received in a plain
+! ipv4 unicast session
+!
+vni 10
+!
+int r1-eth0
+ ip address 10.0.0.0/31
+!
+int r1-eth1
+ ip address 10.0.0.2/31
+!
+router bgp 64000
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ !
+ neighbor 10.0.0.1 remote-as external
+ neighbor 10.0.0.1 timers 1 3
+ neighbor 10.0.0.1 timers connect 1
+ !
+ address-family ipv4 unicast
+  neighbor 10.0.0.1 activate
+ !
+ neighbor 10.0.0.3 remote-as internal
+ neighbor 10.0.0.3 timers 1 3
+ neighbor 10.0.0.3 timers connect 1
+ !
+ address-family l2vpn evpn
+  neighbor 10.0.0.3 activate
+  neighbor 10.0.0.3 route-map set-gw-ip out
+  !
+  advertise-all-vni
+  !
+  advertise ipv4 unicast
+ exit-address-family
+!
+route-map set-gw-ip permit 10
+ set evpn gateway-ip ipv4 10.10.10.10
+!

--- a/tests/topotests/bgp_evpn_route_map_set/r2/frr.conf
+++ b/tests/topotests/bgp_evpn_route_map_set/r2/frr.conf
@@ -12,9 +12,6 @@ router bgp 64000
  !
  address-family l2vpn evpn
   neighbor 10.0.0.2 activate
-  ! workaround for now, as frr drops some evpn attributes like gw-ip if soft
-  ! reconf is not enabled for inbound routes
-  neighbor 10.0.0.2 soft-reconfiguration inbound
   !
   advertise-all-vni
  exit-address-family

--- a/tests/topotests/bgp_evpn_route_map_set/r2/frr.conf
+++ b/tests/topotests/bgp_evpn_route_map_set/r2/frr.conf
@@ -1,0 +1,21 @@
+vni 10
+!
+int r2-eth0
+ ip address 10.0.0.3/31
+!
+router bgp 64000
+ no bgp default ipv4-unicast
+ !
+ neighbor 10.0.0.2 remote-as internal
+ neighbor 10.0.0.2 timers 1 3
+ neighbor 10.0.0.2 timers connect 1
+ !
+ address-family l2vpn evpn
+  neighbor 10.0.0.2 activate
+  ! workaround for now, as frr drops some evpn attributes like gw-ip if soft
+  ! reconf is not enabled for inbound routes
+  neighbor 10.0.0.2 soft-reconfiguration inbound
+  !
+  advertise-all-vni
+ exit-address-family
+!

--- a/tests/topotests/bgp_evpn_route_map_set/test_bgp_evpn_route_map_set.py
+++ b/tests/topotests/bgp_evpn_route_map_set/test_bgp_evpn_route_map_set.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Copyright (c) 2025 Tuetuopay <tuetuopay@me.com>
+
+"""
+Test if route-map set for EVPN fields works.
+"""
+
+import os
+import sys
+import json
+import pytest
+import functools
+
+pytestmark = [pytest.mark.bgpd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import TopoRouter, Topogen, get_topogen
+from lib.topolog import logger
+
+def setup_module(mod):
+    topodef = {"s1": ("c1", "r1"), "s2": ("r1", "r2")}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    tgen.net["r1"].cmd(
+        """
+ip link add br10 up type bridge
+ip link add vxlan10 up master br10 type vxlan id 10 dstport 4789 local 10.0.0.2 nolearning
+        """
+    )
+    tgen.net["r2"].cmd(
+        """
+ip link add br10 up type bridge
+ip link add vxlan10 up master br10 type vxlan id 10 dstport 4789 local 10.0.0.3 nolearning
+        """
+    )
+
+    for name, router in tgen.routers().items():
+        router.load_frr_config(os.path.join(CWD, f"{name}/frr.conf"))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    get_topogen().stop_topology()
+
+
+def test_bgp_evpn_route_map_set_gateway_ip():
+    tgen: Topogen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2: TopoRouter = tgen.gears["r2"]
+    def _bgp_converge():
+        output = json.loads(r2.vtysh_cmd("show bgp l2vpn evpn all overlay json"))
+        expected = {
+            "10.0.0.2:1": {
+                "[5]:[0]:[32]:[10.10.10.10]": {
+                    "paths": [
+                        {
+                            "valid": True,
+                            "overlay": {
+                                "gw": "10.10.10.10",
+                            },
+                        },
+                    ],
+                },
+            },
+            "numPrefix": 1,
+        }
+        return topotest.json_cmp(output, expected)
+
+    logger.info("Check route type-5 gateway-ip")
+    test_func = functools.partial(_bgp_converge)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, "EVPN Route with gateway-ip should be advertised"
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
The `route_set_evpn_gateway_ip` function copies `gw_ip->ip.addr` in the route's gateway ip. In a nutshell, this skips the `ipa_type` field, writing the actual IP in the IP type. This later rightfully trips asserts about unknown IP types.

The following route-map...

```
route-map test permit 10
    set evpn gateway-ip ipv4 1.1.1.1
```

...will make the following gateway IP in the route:

```
(gdb) p/x a1->evpn_overlay->gw_ip
$11 = {ipa_type = 0x1010101, ip = {addr = 0x0, addrbytes = {
      0x0 <repeats 16 times>}, _v4_addr = {s_addr = 0x0}, _v6_addr = {
      __in6_u = {__u6_addr8 = {0x0 <repeats 16 times>}, __u6_addr16 = {0x0,
          0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, __u6_addr32 = {0x0, 0x0, 0x0,
          0x0}}}}}
```

We do indeed see the IP Address in the `ipa_type` field.

Fix by starting the memcpy at the root of `struct ipaddr` instead of skipping the `ipa_type` field.

Fixes: d0a4ee6010a ("bgpd: Add "set evpn gateway-ip" clause for route-map")