### PR TITLE
bgpd: Show bgp <afi> <safi> shouldn't display peers in groups

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12768,6 +12768,9 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 	 * though then we must display Advertised to on a path-by-path basis. */
 	if (!bgp_addpath_is_addpath_used(&bgp->tx_addpath, afi, safi)) {
 		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
+			if (peer->group)
+				continue;
+
 			if (bgp_adj_out_lookup(peer, dest, 0)) {
 				if (json && !json_adv_to)
 					json_adv_to = json_object_new_object();


### PR DESCRIPTION
The command `show bgp <afi> <safi>` has this output:

r1# show bgp ipv4 uni 10.0.0.0
BGP routing table entry for 10.0.0.0/32, version 1 Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  r1-eth0 r1-eth1 r1-eth2 r1-eth3
  ....

It specifically states `Advertised to non peer-group peers:` yet the code is not filtering those out.