### PR TITLE
Fix bug with oper-state queries including list node

### DIFF
--- a/lib/darr.h
+++ b/lib/darr.h
@@ -62,6 +62,7 @@
  *  - darr_strdup
  *  - darr_strdup_cap
  *  - darr_strlen
+ *  - darr_strlen_fixup
  *  - darr_strnul
  *  - darr_sprintf, darr_vsprintf
  */
@@ -750,6 +751,22 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
 			__size -= 1;                                           \
 		assert(!(S) || ((char *)(S))[__size] == 0);                    \
 		__size;                                                        \
+	})
+
+/**
+ * Fixup darr_len (and thus darr_strlen) for `S` based on its strlen(S)
+ * (i.e., scan for NUL byte). The dynamic array length will be set to strlen(S) + 1.
+ *
+ * Args:
+ *	S: The dynamic array with a NUL terminated string, cannot be NULL.
+ *
+ * Return:
+ *      The calculated strlen() value.
+ */
+#define darr_strlen_fixup(S)                                                                       \
+	({                                                                                         \
+		_darr_len(S) = strlen(S) + 1;                                                      \
+		darr_strlen(S);                                                                    \
 	})
 
 /**

--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -407,6 +407,7 @@ static enum nb_error nb_op_xpath_to_trunk(const char *xpath_in, char **xpath_out
 		ret = yang_xpath_pop_node(xpath);
 		if (ret != NB_OK)
 			break;
+		darr_strlen_fixup(xpath);
 	}
 	if (ret == NB_OK)
 		*xpath_out = xpath;

--- a/tests/lib/test_darr.c
+++ b/tests/lib/test_darr.c
@@ -48,6 +48,7 @@
  * [x] - darr_strdup
  * [x] - darr_strdup_cap
  * [x] - darr_strlen
+ * [x] - darr_strlen_fixup
  * [x] - darr_strnul
  * [ ] - darr_vsprintf
  */
@@ -406,6 +407,9 @@ static void test_string(void)
 	assert(!strcmp(da1, "0123456789: DEADBEEF"));
 	assert(darr_strlen(da1) == 20);
 	assert(darr_cap(da1) == 128);
+
+	da1[5] = 0;
+	assert(darr_strlen_fixup(da1) == 5);
 	darr_free(da1);
 
 	da1 = darr_sprintf("0123456789: %08x", 0xDEADBEEF);


### PR DESCRIPTION
lib: make sure we update the darr_strlen from pruned string.

This fixes a bug when handling of queries which include list nodes in
the xpath.
