### PR TITLE
bgpd: Fixed crash upon bgp network import-check command

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7141,7 +7141,7 @@ void bgp_static_update(struct bgp *bgp, const struct prefix *p,
 						&pi->extra->labels->label[0]);
 			}
 #endif
-			if (pi->extra && pi->extra->vrfleak->bgp_orig)
+			if (pi->extra && pi->extra->vrfleak && pi->extra->vrfleak->bgp_orig)
 				bgp_nexthop = pi->extra->vrfleak->bgp_orig;
 
 			bgp_nexthop_reachability_check(afi, safi, pi, p, dest,


### PR DESCRIPTION
BT:
```
3  <signal handler called>
4  0x00005616837546fc in bgp_static_update (bgp=bgp@entry=0x5616865eac50, p=0x561686639e40,
    bgp_static=0x561686639f50, afi=afi@entry=AFI_IP6, safi=safi@entry=SAFI_UNICAST) at ../bgpd/bgp_route.c:7232
5  0x0000561683754ad0 in bgp_static_add (bgp=0x5616865eac50) at ../bgpd/bgp_table.h:413
6  0x0000561683785e2e in no_bgp_network_import_check (self=<optimized out>, vty=0x5616865e04c0,
    argc=<optimized out>, argv=<optimized out>) at ../bgpd/bgp_vty.c:4609
7  0x00007fdbcc294820 in cmd_execute_command_real (vline=vline@entry=0x561686663000,
```

The program encountered a SEG FAULT when attempting to access pi->extra->vrfleak->bgp_orig because pi->extra->vrfleak was NULL.
```
(gdb) p pi->extra->vrfleak
$1 = (struct bgp_path_info_extra_vrfleak *) 0x0
(gdb) p pi->extra->vrfleak->bgp_orig
Cannot access memory at address 0x8
```
Added NOT NULL check on pi->extra->vrfleak before accessing pi->extra->vrfleak->bgp_orig to prevent the segmentation fault.

