### PR TITLE
zebra: changes to include ecn bits in tos value while creating ip rule in kernel

### DIFF
--- a/zebra/rule_netlink.c
+++ b/zebra/rule_netlink.c
@@ -119,9 +119,13 @@ static ssize_t netlink_rule_msg_encode(
 			return 0;
 	}
 
-	/* dsfield, if specified; mask off the ECN bits */
+	/* dscp, if specified; mask off the ECN bits */
 	if (filter_bm & PBR_FILTER_DSCP)
 		req->frh.tos = dsfield & PBR_DSFIELD_DSCP;
+
+	/* add ECN bits to tos if specified */
+	if (filter_bm & PBR_FILTER_ECN)
+		req->frh.tos = req->frh.tos | (dsfield & PBR_DSFIELD_ECN);
 
 	/* protocol to match on */
 	if (filter_bm & PBR_FILTER_IP_PROTOCOL)


### PR DESCRIPTION
zebra: changes to include ecn bits in tos value
while creating ip rule in kernel.

Issue - pbr rules created with ecn match conditions are 
not synced to kernel,since tos value at the
time of ip rule creation has only dscp bits.

Signed-off-by - Aprathi K <aprathik@nvidia.com>