### PR TITLE
bgpd: Remove unnecessary stream_new/stream_copies in bgp_open_make

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -658,17 +658,12 @@ struct stream *bgp_open_make(struct peer *peer, uint16_t send_holdtime, as_t loc
 		ext_opt_params = true;
 		(void)bgp_open_capability(s, peer, ext_opt_params);
 	} else {
-		struct stream *tmp = stream_new(STREAM_SIZE(s));
+		size_t endp = stream_get_endp(s);
 
-		stream_copy(tmp, s);
-		if (bgp_open_capability(tmp, peer, ext_opt_params) >
-		    BGP_OPEN_NON_EXT_OPT_LEN) {
-			stream_free(tmp);
+		if (bgp_open_capability(s, peer, ext_opt_params) > BGP_OPEN_NON_EXT_OPT_LEN) {
+			stream_set_endp(s, endp);
 			ext_opt_params = true;
 			(void)bgp_open_capability(s, peer, ext_opt_params);
-		} else {
-			stream_copy(s, tmp);
-			stream_free(tmp);
 		}
 	}
 


### PR DESCRIPTION
The call into bgp_open_capability can return that it wrote more than BGP_OPEN_NON_EXT_OPT_LEN bytes, in that case the open part needs to be written again with ext_opt_params set to true to allow extended parameters to be written thus keeping the len < 255 bytes.  The code to do this was first creating a new stream and then copying into it the stream, trying to call bgp_open_capability() and if it succeeded recopying the tmp stream back onto the original.

Let's change this around such that we save the current spot in the stream of where we are writing and if the change does not work reset the pointer and try again with the correct parameter.  This removes the stream and multiple copies and eventual free of the temporary stream.