### PR TITLE
2 unit-test fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1054,6 +1054,11 @@ AC_MSG_FAILURE([Please specify a number from 0-12 for log precision ARG])
 ;;
 esac
 with_log_timestamp_precision=${with_log_timestamp_precision:-0}
+if test "${with_log_timestamp_precision}" != 0; then
+AC_SUBST([LOG_TIMESTAMP_PRECISION_CLI], ["
+log timestamp precision ${with_log_timestamp_precision}"])
+AM_SUBST_NOTMAKE([LOG_TIMESTAMP_PRECISION_CLI])
+fi
 AC_DEFINE_UNQUOTED([LOG_TIMESTAMP_PRECISION], [${with_log_timestamp_precision}], [Startup zlog timestamp precision])
 
 AC_DEFINE_UNQUOTED([VTYSH_PAGER], ["$VTYSH_PAGER"], [What pager to use])

--- a/tests/lib/cli/test_cli.refout.in
+++ b/tests/lib/cli/test_cli.refout.in
@@ -405,7 +405,7 @@ frr version @PACKAGE_VERSION@
 frr defaults @DFLT_NAME@
 !
 hostname test
-domainname test.domain
+domainname test.domain@LOG_TIMESTAMP_PRECISION_CLI@
 !
 !
 !
@@ -420,7 +420,7 @@ frr version @PACKAGE_VERSION@
 frr defaults @DFLT_NAME@
 !
 hostname foohost
-domainname test.domain
+domainname test.domain@LOG_TIMESTAMP_PRECISION_CLI@
 !
 !
 !

--- a/tests/lib/northbound/test_oper_exists.c
+++ b/tests/lib/northbound/test_oper_exists.c
@@ -157,13 +157,15 @@ const char *data_json = "\n"
 	"}\n";
 
 
-static const struct lyd_node *test_oper_get_tree_locked(const char *xpath)
+static const struct lyd_node *test_oper_get_tree_locked(const char *xpath __attribute__((unused)),
+							void **lock __attribute__((unused)))
 {
 	++data_tree_lock;
 	return data_tree;
 }
 
-static void test_oper_unlock_tree(const struct lyd_node *tree __attribute__((unused)))
+static void test_oper_unlock_tree(const struct lyd_node *tree __attribute__((unused)),
+				  void *lock __attribute__((unused)))
 {
 	data_tree_lock--;
 }


### PR DESCRIPTION
- fix `make check` when user overrides --log-timestamp-precision in configure
- fix a compile warning