### PR TITLE
fix(vrrp): display vrrp version by default

### DIFF
--- a/vrrpd/vrrp_vty.c
+++ b/vrrpd/vrrp_vty.c
@@ -66,8 +66,7 @@ void cli_show_vrrp(struct vty *vty, const struct lyd_node *dnode, bool show_defa
 	const char *ver = yang_dnode_get_string(dnode, "version");
 
 	vty_out(vty, " vrrp %s", vrid);
-	if (show_defaults || !yang_dnode_is_default(dnode, "version"))
-		vty_out(vty, " version %s", ver);
+	vty_out(vty, " version %s", ver);
 	vty_out(vty, "\n");
 }
 


### PR DESCRIPTION
Make the VRRP version information always visible in the running configuration output, regardless of whether it's the default value (version 3) or not.

**_Problem_**
When using frr-reload.py to apply configuration changes, VRRP instances were being unnecessarily reinitialized even when no actual configuration changes were made. This occurred because:
The cli_show_vrrp function in vrrpd/vrrp_vty.c does not display the VRRP version in the show running-config output when it's the default value (version 3).
Configuration files often explicitly specify vrrp X version 3 even though it's the default.
When frr-reload.py compares the explicit configuration with the running configuration, it detects a difference and generates commands to remove and recreate the VRRP instance.

For example： 
original  /etc/frr/frr.conf  as below: 
`
interface ens4
 vrrp 50 version 3
 vrrp 50 priority 254
 vrrp 50 advertisement-interval 300
 vrrp 50 ip 192.168.188.244
exit
`

while run frr-reload.py --test dry run configruration update (without vrrp update) , result as below:

```
Lines To Delete
===============
interface ens4
 no vrrp 50
exit

Lines To Add
============
interface ens4
 vrrp 50 version 3
exit
``` 
Generated unexpected vrrp delete && add operations.


**_Solution_**
This patch modifies the cli_show_vrrp function to unconditionally display the VRRP version, regardless of whether it's the default value or the show_defaults parameter is set. By making the version information explicit in all cases, we ensure consistent configuration comparison in frr-reload.py, preventing unnecessary VRRP reinitialization and associated network disruptions.

**_Impact_**
This change improves operational stability by preventing unnecessary BGP session disruptions that were occurring during configuration reloads. It maintains backward compatibility while ensuring more consistent behavior during configuration management operations.