### PR TITLE
bgpd: fix "delete in progress" flag on default instance

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3799,6 +3799,7 @@ int bgp_lookup_by_as_name_type(struct bgp **bgp_val, as_t *as, const char *as_pr
 						   hidden);
 					UNSET_FLAG(bgp->flags,
 						   BGP_FLAG_INSTANCE_HIDDEN);
+					UNSET_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS);
 				} else {
 					bgp->as = *as;
 					if (force_config == false)


### PR DESCRIPTION
Since https://github.com/FRRouting/frr/commit/4d0e7a49cf8d4311a485281fa50bbff6ee8ca6cc ("bgpd: VRF-Lite fix default BGP delete"), upon deletion
of the default instance, it is marked as hidden and the "deletion
in progress" flag is set. When the instance is restored, some routes
are not installed due to the presence of this flag.