### PR TITLE
ripngd: Access and Prefix lists are being leaked on shutdown

### DIFF
--- a/ripngd/ripng_main.c
+++ b/ripngd/ripng_main.c
@@ -90,6 +90,9 @@ static void sigint(void)
 
 	route_map_finish();
 
+	access_list_reset();
+	prefix_list_reset();
+
 	frr_fini();
 	exit(0);
 }


### PR DESCRIPTION
ripngd:     Access List                   :      1 *         56
ripngd:     Access List Str               :      1 *          3
ripngd:     Access Filter                 :      1 *        112
ripngd:     Prefix List                   :      1 *         88
ripngd:     Prefix List Str               :      1 *          3
ripngd:     Prefix List Entry             :      1 *        136
ripngd:     Prefix List Trie Table        :      4 *       4096

This is now fixed.