### PR TITLE
bgpd: if bgp peer inherit group password, it should set md5

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -6952,7 +6952,10 @@ int peer_password_unset(struct peer *peer)
 
 		/* Attempt to uninstall password on socket. */
 		if (!BGP_CONNECTION_SU_UNSPEC(peer->connection))
-			bgp_md5_unset(peer->connection);
+			if (CHECK_FLAG(peer->flags, PEER_FLAG_PASSWORD))
+				bgp_md5_set(peer->connection);
+			else
+				bgp_md5_unset(peer->connection);
 		/* Skip peer-group mechanics for regular peers. */
 		return 0;
 	}


### PR DESCRIPTION
After the password of the neighbor is deleted, if the neighbor inherits the password from peer group, it still needs to call bgp_md5_set.