### PR TITLE
lib: Create VRF if needed

### DIFF
--- a/lib/routing_nb_config.c
+++ b/lib/routing_nb_config.c
@@ -47,7 +47,7 @@ int routing_control_plane_protocols_control_plane_protocol_create(
 		 */
 		if (nb_node_has_dependency(args->dnode->schema->priv)) {
 			vrfname = yang_dnode_get_string(args->dnode, "vrf");
-			vrf = vrf_lookup_by_name(vrfname);
+			vrf = vrf_get(VRF_UNKNOWN, vrfname);
 			assert(vrf);
 			nb_running_set_entry(args->dnode, vrf);
 		}


### PR DESCRIPTION
When creating a control plane protocol through NB, create the vrf if needed instead of only looking up and asserting if it doesn't exist yet.
Fixes #18429.