### PR TITLE
Fix topotest to wait for zebra connection

### DIFF
--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -2356,8 +2356,8 @@ class Router(Node):
         _check_daemons_running(check_daemon_files)
 
         if check_daemon_files:
-            assert False, "Timeout({}) waiting for {} to appear on {}".format(
-                wait_time, check_daemon_files[0], self.name
+            assert False, "Timeout waiting for {} to appear on {}".format(
+                check_daemon_files[0], self.name
             )
 
         # Update the permissions on the log files


### PR DESCRIPTION
See individual commits, but allow for zebra to be up and individual daemons to be attached to the daemon before a unified config is read in.