### PR TITLE
bgpd: Fix leaked memory when showing some bgp routes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -15352,11 +15352,15 @@ static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
 				} else {
 					json_object_object_add(json_ar, rd_str, json_routes);
 				}
-			}
+			} else if (json_routes)
+				json_object_free(json_routes);
 
 			output_count += output_count_per_rd;
 			filtered_count += filtered_count_per_rd;
 		}
+		if (json_ar &&
+		    (type == bgp_show_adj_route_advertised || type == bgp_show_adj_route_received))
+			json_object_free(json_ar);
 		if (first == false && json_routes)
 			vty_out(vty, "}");
 	} else {


### PR DESCRIPTION
The two memory leaks:

==387155== 744 (48 direct, 696 indirect) bytes in 1 blocks are definitely lost in loss record 222 of 262
==387155==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==387155==    by 0x4C1B982: json_object_new_object (in /usr/lib/x86_64-linux-gnu/libjson-c.so.5.1.0)
==387155==    by 0x2E4146: peer_adj_routes (bgp_route.c:15245)
==387155==    by 0x2E4F1A: show_ip_bgp_instance_neighbor_advertised_route_magic (bgp_route.c:15549)
==387155==    by 0x2B982B: show_ip_bgp_instance_neighbor_advertised_route (bgp_route_clippy.c:722)
==387155==    by 0x4915E6F: cmd_execute_command_real (command.c:1003)
==387155==    by 0x4915FE8: cmd_execute_command (command.c:1062)
==387155==    by 0x4916598: cmd_execute (command.c:1228)
==387155==    by 0x49EB858: vty_command (vty.c:626)
==387155==    by 0x49ED77C: vty_execute (vty.c:1389)
==387155==    by 0x49EFFA7: vtysh_read (vty.c:2408)
==387155==    by 0x49E4156: event_call (event.c:2019)
==387155==    by 0x4958ABD: frr_run (libfrr.c:1247)
==387155==    by 0x206A68: main (bgp_main.c:557)
==387155==
==387155== 2,976 (192 direct, 2,784 indirect) bytes in 4 blocks are definitely lost in loss record 240 of 262
==387155==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==387155==    by 0x4C1B982: json_object_new_object (in /usr/lib/x86_64-linux-gnu/libjson-c.so.5.1.0)
==387155==    by 0x2E45CA: peer_adj_routes (bgp_route.c:15325)
==387155==    by 0x2E4F1A: show_ip_bgp_instance_neighbor_advertised_route_magic (bgp_route.c:15549)
==387155==    by 0x2B982B: show_ip_bgp_instance_neighbor_advertised_route (bgp_route_clippy.c:722)
==387155==    by 0x4915E6F: cmd_execute_command_real (command.c:1003)
==387155==    by 0x4915FE8: cmd_execute_command (command.c:1062)
==387155==    by 0x4916598: cmd_execute (command.c:1228)
==387155==    by 0x49EB858: vty_command (vty.c:626)
==387155==    by 0x49ED77C: vty_execute (vty.c:1389)
==387155==    by 0x49EFFA7: vtysh_read (vty.c:2408)
==387155==    by 0x49E4156: event_call (event.c:2019)
==387155==    by 0x4958ABD: frr_run (libfrr.c:1247)
==387155==    by 0x206A68: main (bgp_main.c:557)

For the 1st one, if the operator issues a advertised-routes command, the json_ar variable was never being freed.

For the 2nd one, if the operator issued a command where the output_count_per_rd is 0, we need to free the json_routes value.