### PR TITLE
zebra: V6 RA not sent anymore after interface up-down-up

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -990,6 +990,7 @@ void if_down(struct interface *ifp)
 	zif->down_count++;
 	frr_timestamp(2, zif->down_last, sizeof(zif->down_last));
 
+	rtadv_stop_ra(ifp, true);
 	if_down_nhg_dependents(ifp);
 
 	/* Handle interface down for specific types for EVPN. Non-VxLAN
@@ -3706,7 +3707,7 @@ int if_shutdown(struct interface *ifp)
 
 	if (ifp->ifindex != IFINDEX_INTERNAL) {
 		/* send RA lifetime of 0 before stopping. rfc4861/6.2.5 */
-		rtadv_stop_ra(ifp);
+		rtadv_stop_ra(ifp, false);
 		if (if_unset_flags(ifp, IFF_UP) < 0) {
 			zlog_debug("Can't shutdown interface %s", ifp->name);
 			return -1;

--- a/zebra/rtadv.h
+++ b/zebra/rtadv.h
@@ -404,7 +404,7 @@ enum ipv6_nd_suppress_ra_status {
 
 extern void rtadv_vrf_init(struct zebra_vrf *zvrf);
 extern void rtadv_vrf_terminate(struct zebra_vrf *zvrf);
-extern void rtadv_stop_ra(struct interface *ifp);
+extern void rtadv_stop_ra(struct interface *ifp, bool if_down_event);
 extern void rtadv_stop_ra_all(void);
 extern void rtadv_cmd_init(void);
 extern void rtadv_if_init(struct zebra_if *zif);
@@ -494,7 +494,7 @@ static inline void rtadv_delete_prefix(struct zebra_if *zif,
 				       const struct prefix *p)
 {
 }
-static inline void rtadv_stop_ra(struct interface *ifp)
+static inline void rtadv_stop_ra(struct interface *ifp, bool if_down_event)
 {
 }
 static inline void rtadv_stop_ra_all(void)


### PR DESCRIPTION
zebra: V6 RA not sent anymore after interface up-down-up

Issue:
Once interface is shutdown, the interface is removed from
wheel timer. Now when the interface is up again, current code
won't add the interface to wheel timer again, so it won't send RA
anymore for that interface

Fix:
Moved wheel_add for interface inside rtadv_start_interface_events
This is more common function which gets triggered for both
RA enable and interface up event

Also on any kind of interface activation event, we try to send
RA as soon as possible. This is to satisfy requirement where
quick RA is needed, especially for some convergence, dependent on
RA.

Testing:
Did ineterface up to down to up
Added debug log for RA, checked it is getting advertised preodically
after when up at up state

show bgp summary for 512 bgp peers for bgp bgp unnumbered works fine.

Signed-off-by: Soumya Roy <souroy@nvidia.com>