### PR TITLE
tests: Change up start order of bmp tests

### DIFF
--- a/tests/topotests/bgp_bmp/r1/frr.conf
+++ b/tests/topotests/bgp_bmp/r1/frr.conf
@@ -6,12 +6,6 @@ interface r1-eth1
  ipv6 address 192:168::1/64
 !
 router bgp 65501
- bgp router-id 192.168.0.1
- bgp log-neighbor-changes
- no bgp ebgp-requires-policy
- neighbor 192.168.0.2 remote-as 65502
- neighbor 192:168::2 remote-as 65502
-!
  bmp targets bmp1
   bmp connect 192.0.2.10 port 1789 min-retry 100 max-retry 10000
    bmp monitor ipv4 unicast pre-policy
@@ -27,6 +21,16 @@ router bgp 65501
    bmp monitor ipv4 vpn loc-rib
    bmp monitor ipv6 vpn loc-rib
  exit
+!
+router bgp 65501
+ timers bgp 1 10
+ bgp router-id 192.168.0.1
+ bgp log-neighbor-changes
+ no bgp ebgp-requires-policy
+ neighbor 192.168.0.2 remote-as 65502
+ neighbor 192.168.0.2 timers delayopen 5
+ neighbor 192:168::2 remote-as 65502
+ neighbor 192:168::2 timers delayopen 5
 !
  address-family ipv4 vpn
   neighbor 192.168.0.2 activate

--- a/tests/topotests/bgp_bmp/r2/frr.conf
+++ b/tests/topotests/bgp_bmp/r2/frr.conf
@@ -7,12 +7,15 @@ interface r2-eth1
  ipv6 address 172:31::2/64
 !
 router bgp 65502
+ timers bgp 1 10
  bgp router-id 192.168.0.2
  bgp log-neighbor-changes
  no bgp ebgp-requires-policy
  no bgp network import-check
  neighbor 192.168.0.1 remote-as 65501
+ neighbor 192.168.0.1 timers delayopen 5
  neighbor 192:168::1 remote-as 65501
+ neighbor 192:168::1 timers delayopen 5
 !
  address-family ipv4 unicast
   neighbor 192.168.0.1 activate

--- a/tests/topotests/bgp_bmp/r3/frr.conf
+++ b/tests/topotests/bgp_bmp/r3/frr.conf
@@ -3,6 +3,7 @@ interface r3-eth0
  ipv6 address 192:167::3/64
 !
 router bgp 65501
+ timers bgp 1 10
  bgp router-id 192.168.1.3
  bgp log-neighbor-changes
  no bgp network import-check


### PR DESCRIPTION
Currently the tests appear to do this:
a) Start the neighbors
b) Start the bmp server connection
c) Look for the neighbors up
d) Look for the neighbor up messages in the bmp log

This is not great from a testing perspective in that even though we started a) first it may not happen
until after b) happens.  Or even worse if it is
partially up ( 1 of the 2 peers ) then the dump
will have the neighbor connecting after parts
of the table.  This doesn't work too well because
the SEQ number is something that is kept and compared to to make sure only new data is being looked at.

Let's modify the startup configuration to start
the bmp server first and then have a delayopen
on the bgp neighbor statements so that the bmp
peering can come up first.