### PR TITLE
bgpd: fix `set evpn gateway-ip ipv[46]` route-map

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1256,8 +1256,7 @@ route_set_evpn_gateway_ip(void *rule, const struct prefix *prefix, void *object)
 
 	/* Set gateway-ip value. */
 	path->attr->evpn_overlay.type = OVERLAY_INDEX_GATEWAY_IP;
-	memcpy(&path->attr->evpn_overlay.gw_ip, &gw_ip->ip.addr,
-	       IPADDRSZ(gw_ip));
+	path->attr->evpn_overlay.gw_ip = *gw_ip;
 
 	return RMAP_OKAY;
 }


### PR DESCRIPTION
The `route_set_evpn_gateway_ip` function copies `gw_ip->ip.addr` in the route's gateway ip. In a nutshell, this skips the `ipa_type` field, writing the actual IP in the IP type. This later rightfully trips asserts about unknown IP types.

The following route-map...

```
route-map test permit 10
    set evpn gateway-ip ipv4 1.1.1.1
```

...will make the following gateway IP in the route:

```
(gdb) p/x a1->evpn_overlay->gw_ip
$11 = {ipa_type = 0x1010101, ip = {addr = 0x0, addrbytes = {
      0x0 <repeats 16 times>}, _v4_addr = {s_addr = 0x0}, _v6_addr = {
      __in6_u = {__u6_addr8 = {0x0 <repeats 16 times>}, __u6_addr16 = {0x0,
          0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, __u6_addr32 = {0x0, 0x0, 0x0,
          0x0}}}}}
```

We do indeed see the IP Address in the `ipa_type` field.

Fix by starting the memcpy at the root of `struct ipaddr` instead of skipping the `ipa_type` field.

Fixes: d0a4ee6010a ("bgpd: Add "set evpn gateway-ip" clause for route-map")
Signed-off-by: Tuetuopay <tuetuopay@me.com>
(cherry picked from commit 0b0e7015971a788c14dd1dc9b5bac8cb66175c29)