### PR TITLE
staticd: Fix a crash that occurs when modifying an SRv6 SID

### DIFF
--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -1112,6 +1112,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_segment_routi
 	yang_dnode_get_ipv6p(&sid_value, args->dnode, "sid");
 	sid = static_srv6_sid_alloc(&sid_value);
 	nb_running_set_entry(args->dnode, sid);
+	listnode_add(srv6_sids, sid);
 
 	return NB_OK;
 }
@@ -1145,13 +1146,11 @@ void routing_control_plane_protocols_control_plane_protocol_staticd_segment_rout
 		       "%s: Locator %s not found, trying to get locator information from zebra",
 		       __func__, sid->locator_name);
 		static_zebra_srv6_manager_get_locator(sid->locator_name);
-		listnode_add(srv6_sids, sid);
 		return;
 	}
 
 	sid->locator = locator;
 
-	listnode_add(srv6_sids, sid);
 	static_zebra_request_srv6_sid(sid);
 }
 

--- a/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_modify.json
+++ b/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_modify.json
@@ -1,0 +1,201 @@
+{
+	"fcbb:bbbb:1::/48": [
+		{
+			"prefix": "fcbb:bbbb:1::/48",
+			"prefixLen": 48,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "End",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 0,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe10::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe10::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "Vrf10",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "End.DT4",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 10
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe20::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe20::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "Vrf40",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "End.DT46",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 40
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe30::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe30::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "Vrf30",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "End.DT46",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 30
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe40::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe40::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "End.X"
+					},
+					"seg6localContext": {
+						"nh6": "2001::2"
+					}
+				}
+			]
+		}
+	]
+}

--- a/tests/topotests/static_srv6_sids/r1/setup.sh
+++ b/tests/topotests/static_srv6_sids/r1/setup.sh
@@ -10,4 +10,7 @@ ip link set Vrf20 up
 ip link add Vrf30 type vrf table 30
 ip link set Vrf30 up
 
+ip link add Vrf40 type vrf table 40
+ip link set Vrf40 up
+
 sysctl -w net.vrf.strict_mode=1


### PR DESCRIPTION
When the user modifies an SRv6 SID and then removes all SIDs, staticd crashes:

```
2025/03/23 08:37:22.691860 STATIC: lib/memory.c:74: mt_count_free(): assertion (mt->n_alloc) failed
STATIC: Received signal 6 at 1742715442 (si_addr 0x8200007cf0); aborting...
STATIC: zlog_signal+0x390                  fcc704a844b8     ffffd7450390 /usr/lib/frr/libfrr.so.0 (mapped at 0xfcc704800000)
STATIC: core_handler+0x1f8                 fcc704b79990     ffffd7450590 /usr/lib/frr/libfrr.so.0 (mapped at 0xfcc704800000)
STATIC:     ---- signal ----
STATIC: ?                                  fcc705c008f8     ffffd74507a0 linux-vdso.so.1 (mapped at 0xfcc705c00000)
STATIC: pthread_key_delete+0x1a0           fcc70458f1f0     ffffd7451a00 /lib/aarch64-linux-gnu/libc.so.6 (mapped at 0xfcc704510000)
STATIC: raise+0x1c                         fcc70454a67c     ffffd7451ad0 /lib/aarch64-linux-gnu/libc.so.6 (mapped at 0xfcc704510000)
STATIC: abort+0xe4                         fcc704537130     ffffd7451af0 /lib/aarch64-linux-gnu/libc.so.6 (mapped at 0xfcc704510000)
STATIC: _zlog_assert_failed+0x3c4          fcc704c407c8     ffffd7451c40 /usr/lib/frr/libfrr.so.0 (mapped at 0xfcc704800000)
STATIC: mt_count_free+0x12c                fcc704a93c74     ffffd7451dc0 /usr/lib/frr/libfrr.so.0 (mapped at 0xfcc704800000)
STATIC: qfree+0x28                         fcc704a93fa0     ffffd7451e70 /usr/lib/frr/libfrr.so.0 (mapped at 0xfcc704800000)
STATIC: static_srv6_sid_free+0x1c          adc1df8fa544     ffffd7451e90 /usr/lib/frr/staticd (mapped at 0xadc1df8a0000)
STATIC: delete_static_srv6_sid+0x14        adc1df8faafc     ffffd7451eb0 /usr/lib/frr/staticd (mapped at 0xadc1df8a0000)
STATIC: list_delete_all_node+0x104         fcc704a60eec     ffffd7451ed0 /usr/lib/frr/libfrr.so.0 (mapped at 0xfcc704800000)
STATIC: list_delete+0x8c                   fcc704a61054     ffffd7451f00 /usr/lib/frr/libfrr.so.0 (mapped at 0xfcc704800000)
STATIC: static_srv6_cleanup+0x20           adc1df8fabdc     ffffd7451f20 /usr/lib/frr/staticd (mapped at 0xadc1df8a0000)
STATIC: sigint+0x40                        adc1df8be544     ffffd7451f30 /usr/lib/frr/staticd (mapped at 0xadc1df8a0000)
STATIC: frr_sigevent_process+0x148         fcc704b79460     ffffd7451f40 /usr/lib/frr/libfrr.so.0 (mapped at 0xfcc704800000)
STATIC: event_fetch+0x1c4                  fcc704bc0834     ffffd7451f60 /usr/lib/frr/libfrr.so.0 (mapped at 0xfcc704800000)
STATIC: frr_run+0x650                      fcc704a5d230     ffffd7452080 /usr/lib/frr/libfrr.so.0 (mapped at 0xfcc704800000)
STATIC: main+0x1d0                         adc1df8be75c     ffffd7452270 /usr/lib/frr/staticd (mapped at 0xadc1df8a0000)
STATIC: __libc_init_first+0x7c             fcc7045373fc     ffffd74522b0 /lib/aarch64-linux-gnu/libc.so.6 (mapped at 0xfcc704510000)
STATIC: __libc_start_main+0x98             fcc7045374cc     ffffd74523c0 /lib/aarch64-linux-gnu/libc.so.6 (mapped at 0xfcc704510000)
STATIC: _start+0x30                        adc1df8be0f0     ffffd7452420 /usr/lib/frr/staticd (mapped at 0xadc1df8a0000)
```

Tracking this down, the crash occurs because every time we modify a SID, staticd executes some callbacks to modify the SID and finally it calls `apply_finish`, which re-adds the SID to the list `srv6_sids`.

This leads to having the same SID multiple times in the `srv6_sids` list. When we delete all SIDs, staticd attempts to deallocate the same SID multiple times, which leads to the crash.

This commit fixes the issue by moving the code that adds the SID to the list from the `apply_finish` callback to the `create` callback. This ensures that the SID is inserted into the list only once, when it is created. For all subsequent modifications, the SID is modified but not added to the list.