### PR TITLE
tests: high_ecmp creates 2 update groups

### DIFF
--- a/tests/topotests/high_ecmp/r1/frr.conf
+++ b/tests/topotests/high_ecmp/r1/frr.conf
@@ -2572,3 +2572,8 @@ interface r1-eth513
  ipv6 address 2001:db8:3:4::1/64
  no shutdown
 !
+interface r1-eth514
+ ip address 10.3.5.1/30
+ ipv6 address 2001:db8:3:5::1/64
+ no shut
+!

--- a/tests/topotests/high_ecmp/r2/frr.conf
+++ b/tests/topotests/high_ecmp/r2/frr.conf
@@ -2572,4 +2572,8 @@ interface r2-eth513
  ipv6 address 2001:db8:3:4::2/64
  no shutdown
 !
-
+interface r2-eth514
+ ip address 10.3.5.2/30
+ ipv6 address 2001:db8:3:5::2/64
+ no shutdown
+!


### PR DESCRIPTION
The high_ecmp test was creating 2 update groups, where 513 of the neighbors are in 1 and the remaining is in another.  They should just all be in 1 update group. Modify the test creation such that interfaces r1-eth514 and r2-eth514 have v4 and v6 addresses.