### PR TITLE
babeld: Add next hop initialization

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -441,6 +441,14 @@ parse_packet(const unsigned char *from, struct interface *ifp,
         return;
     }
 
+    if (v4mapped(from)) {
+        memcpy(v4_nh, from, 16);
+        have_v4_nh = 1;
+    } else {
+        memcpy(v6_nh, from, 16);
+        have_v6_nh = 1;
+    }
+
     i = 0;
     while(i < bodylen) {
         message = packet + 4 + i;


### PR DESCRIPTION
Missing next hop initialization:
    The implementation does not initialize the next hop parser state from the source address at packet start, as required by RFC 8966 section 4.5 (https://www.rfc-editor.org/rfc/rfc8966#name-parser-state-and-encoding-o):

> for each address family (IPv4 or IPv6), the current next hop: this is the source address of the enclosing packet for the matching address family at the start of a packet
