### PR TITLE
babeld: Missing Validation for AE=0 and Plen!=0

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -706,6 +706,11 @@ parse_packet(const unsigned char *from, struct interface *ifp,
 			      "Received source-specific wildcard request.");
                     goto done;
                 }
+                if(message[3] != 0) {
+                    flog_err(EC_BABEL_PACKET,
+                             "Ignoring request with AE=0 and non-zero Plen");
+                    goto done;
+                }
                 /* If a neighbour is requesting a full route dump from us,
                    we might as well send it an IHU. */
                 send_ihu(neigh, NULL);


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc8966#name-route-request:
A Request TLV with AE set to 0 and Plen not set to 0 MUST be ignored.
