### PR TITLE
babeld: Hop Count must not be 0.

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -693,6 +693,10 @@ parse_packet(const unsigned char *from, struct interface *ifp,
                 memcpy(src_prefix, zeroes, 16);
                 src_plen = 0;
             }
+            if(message[6] == 0) {
+                debugf(BABEL_DEBUG_COMMON, "Received seqno request with invalid hop count 0");
+                goto done;
+            }
             rc = parse_request_subtlv(message[2], message + 4 + rc,
                                       len - 2 - rc, src_prefix, &src_plen);
             if(rc < 0)


### PR DESCRIPTION
[RFC 8966](https://www.rfc-editor.org/rfc/rfc8966#section-4.6.11-4.12):
Hop Count The maximum number of times that this TLV may be forwarded, plus 1. This MUST NOT be 0.