### PR TITLE
tests: add another directory to search path for pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-init-hook="import sys; sys.path.insert(0, '..')"
+init-hook="import sys; sys.path.extend(['..', 'tests/topotests']);"
 signature-mutators=common_config.retry,retry
 
 [FORMAT]


### PR DESCRIPTION
Some IDEs (e.g., emacs+lsp) run pylint from the root directory and so we need to add `tests/topotests` so that `lib` and `munet` are found by pylint when used in imports