### PR TITLE
bgpd: Fix holdtime not working properly when busy

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -521,9 +521,11 @@ static void bgp_holdtime_timer(struct event *thread)
 	 */
 	inq_count = atomic_load_explicit(&connection->ibuf->count,
 					 memory_order_relaxed);
-	if (inq_count)
+	if (inq_count) {
 		BGP_TIMER_ON(connection->t_holdtime, bgp_holdtime_timer,
 			     peer->v_holdtime);
+		return;
+	}
 
 	EVENT_VAL(thread) = Hold_Timer_expired;
 	bgp_event(thread); /* bgp_event unlocks peer */


### PR DESCRIPTION
Commit:  cc9f21da2218d95567eff1501482ce58e6600f54

Modified the bgp_fsm code to dissallow the extension of the hold time when the system is under extremely heavy load.  This was a attempt to remove the return code but it was too aggressive and messed up this bit of code.

Put the behavior back that was introduced in:
d0874d195d0127009a7d9c06920c52c95319eff9