### PR TITLE
babeld: fix interface_recalculate function, initializing ipv4 field

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -580,6 +580,7 @@ interface_recalculate(struct interface *ifp)
     int mtu, rc;
     struct ipv6_mreq mreq;
     babel_interface_nfo *babel_ifp = babel_get_if_nfo(ifp);
+    struct connected *connected;
     assert (babel_ifp != NULL);
 
     if (!IS_ENABLE(ifp))
@@ -588,6 +589,14 @@ interface_recalculate(struct interface *ifp)
     if (!if_is_operative(ifp) || !CHECK_FLAG(ifp->flags, IFF_RUNNING)) {
         interface_reset(ifp);
         return -1;
+    }
+
+    babel_ifp->ipv4 = malloc(4);
+    frr_each (if_connected, ifp->connected, connected) {
+	    if (connected->address->family == AF_INET) {
+            memcpy(babel_ifp->ipv4, &connected->address->u.prefix4, 4);
+            break;
+        }
     }
 
     SET_FLAG(babel_ifp->flags, BABEL_IF_IS_UP);


### PR DESCRIPTION
In interface_recalculate function, one should initialize babel_ifp->ipv4 field.
CLOSES https://github.com/FRRouting/frr/issues/18492