### PR TITLE
lib: `show route-map` should not print (null)

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1019,7 +1019,7 @@ static void vty_show_route_map_entry(struct vty *vty, struct route_map *map,
 				char buf[BUFSIZ];
 
 				snprintf(buf, sizeof(buf), "%s %s",
-					 rule->cmd->str, rule->rule_str);
+					 rule->cmd->str, rule->rule_str ? rule->rule_str : "");
 				json_array_string_add(json_sets, buf);
 			}
 
@@ -1064,7 +1064,7 @@ static void vty_show_route_map_entry(struct vty *vty, struct route_map *map,
 			for (rule = index->set_list.head; rule;
 			     rule = rule->next)
 				vty_out(vty, "    %s %s\n", rule->cmd->str,
-					rule->rule_str);
+					rule->rule_str ? rule->rule_str : "");
 
 			/* Call clause */
 			vty_out(vty, "  Call clause:\n");


### PR DESCRIPTION
This command:
route-map FOOBAR permit 10
 set ipv6 next-hop prefer-global
 set community 5060:12345 additive
!

When you issue a `show route-map ...` command displays this:

route-map: FOOBAR Invoked: 0 (0 milliseconds total) Optimization: enabled Processed Change: false
 permit, sequence 5 Invoked 0 (0 milliseconds total)
  Match clauses:
  Set clauses:
    ipv6 next-hop prefer-global (null)
    community 5060:12345 additive
  Call clause:
  Action:
    Exit routemap

Modify the code so that it no longer displays the NULL when there is nothing to display.