### PR TITLE
yang: Limit eigrp to just 1 instance per vrf

### DIFF
--- a/yang/frr-eigrpd.yang
+++ b/yang/frr-eigrpd.yang
@@ -112,7 +112,7 @@ module frr-eigrpd {
     list instance {
       key "asn vrf";
       description "EIGRP autonomous system instance";
-
+      must "count(../instance[vrf =current()/vrf]) = 1";
       leaf asn {
         type autonomous-system;
         description "Autonomous System Number";


### PR DESCRIPTION
Currently EIGRP has built in yang code that expects only 1 ASN used per vrf.  Let's just limit the operator from putting themselves in a bad position by allowing something like this:

router eigrp 33
....
!
router eigrp 99
...
!

no router eigrp 99 would crash because of assumptions made in the yang processing.

Let's just hard code that assumption into the EIGRP yang at the moment such that it will not allow you to enter a `router eigrp 99` instance at all.

This is purely a software limitation to prevent the code from violating it's current assumptions.  I do not see much need to support this at this point in time so I fixed the problem this way instead of having to possibly touch a bunch of code.