### PR TITLE
pimd: Fix memory leak on shutdown

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -194,8 +194,17 @@ void pim_if_delete(struct interface *ifp)
 	assert(pim_ifp);
 
 	pim_ifp->pim->mcast_if_count--;
-	if (pim_ifp->gm_join_list)
+	if (pim_ifp->gm_join_list) {
 		pim_if_gm_join_del_all(ifp);
+		/*
+		 * Sometimes gm_join_del_all does not delete them all
+		 * and as such it's not actually freed.  Let's
+		 * just clean this up if it wasn't to prevent
+		 * the problem.
+		 */
+		if (pim_ifp->gm_join_list)
+			list_delete(&pim_ifp->gm_join_list);
+	}
 
 	if (pim_ifp->static_group_list)
 		pim_if_static_group_del_all(ifp);
@@ -1436,10 +1445,8 @@ int pim_if_gm_join_del(struct interface *ifp, pim_addr group_addr,
 	}
 	listnode_delete(pim_ifp->gm_join_list, ij);
 	gm_join_free(ij);
-	if (listcount(pim_ifp->gm_join_list) < 1) {
+	if (listcount(pim_ifp->gm_join_list) < 1)
 		list_delete(&pim_ifp->gm_join_list);
-		pim_ifp->gm_join_list = 0;
-	}
 
 	return 0;
 }


### PR DESCRIPTION
The gm_join_list has a setup where it attempts to only create the list upon need and deletes it when the list is empty.  On interface shutdown it was calling the function to empty the list but it was not empty so the list was being left at the end.  Just add a bit of code to really clean up the list in the shutdown case.

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    0 0x7f84850b83b7 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:77
    1 0x7f8484c391c4 in qcalloc lib/memory.c:106
    2 0x7f8484c1ad36 in list_new lib/linklist.c:49
    3 0x55d982827252 in pim_if_gm_join_add pimd/pim_iface.c:1354
    4 0x55d982852b59 in lib_interface_gmp_address_family_join_group_create pimd/pim_nb_config.c:4499
    5 0x7f8484c6a5d3 in nb_callback_create lib/northbound.c:1512
    6 0x7f8484c6a5d3 in nb_callback_configuration lib/northbound.c:1910
    7 0x7f8484c6bb51 in nb_transaction_process lib/northbound.c:2042
    8 0x7f8484c6c164 in nb_candidate_commit_apply lib/northbound.c:1381
    9 0x7f8484c6c39f in nb_candidate_commit lib/northbound.c:1414
    10 0x7f8484c6cf1c in nb_cli_classic_commit lib/northbound_cli.c:57
    11 0x7f8484c72f67 in nb_cli_apply_changes_internal lib/northbound_cli.c:195
    12 0x7f8484c73a2e in nb_cli_apply_changes lib/northbound_cli.c:251
    13 0x55d9828bd30f in interface_ip_igmp_join_magic pimd/pim_cmd.c:5436
    14 0x55d9828bd30f in interface_ip_igmp_join pimd/pim_cmd_clippy.c:6366
    15 0x7f8484bb5cbd in cmd_execute_command_real lib/command.c:1003
    16 0x7f8484bb5fdc in cmd_execute_command lib/command.c:1062
    17 0x7f8484bb6508 in cmd_execute lib/command.c:1228
    18 0x7f8484cfb6ec in vty_command lib/vty.c:626
    19 0x7f8484cfbc3f in vty_execute lib/vty.c:1389
    20 0x7f8484cff9f0 in vtysh_read lib/vty.c:2408
    21 0x7f8484cec846 in event_call lib/event.c:1984
    22 0x7f8484c1a10a in frr_run lib/libfrr.c:1246
    23 0x55d9828fc765 in main pimd/pim_main.c:166
    24 0x7f848470c249 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h: