### PR TITLE
bgpd: Free up leaked memory in case where routemap is not used

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2610,11 +2610,13 @@ route_set_aspath_exclude(void *rule, const struct prefix *dummy, void *object)
 			aspath_filter_exclude(new_path, ase->aspath);
 	else if (ase->exclude_all)
 		path->attr->aspath = aspath_filter_exclude_all(new_path);
-
 	else if (ase->exclude_aspath_acl)
 		path->attr->aspath =
 			aspath_filter_exclude_acl(new_path,
 						  ase->exclude_aspath_acl);
+	else
+		aspath_free(new_path);
+
 	return RMAP_OKAY;
 }
 


### PR DESCRIPTION
Direct leak of 48 byte(s) in 1 object(s) allocated from:
    0 0x7ff0084b83b7 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:77
    1 0x7ff00803a36d in qcalloc lib/memory.c:106
    2 0x55b99cded6ba in aspath_dup bgpd/bgp_aspath.c:703
    3 0x55b99cc7ed00 in route_set_aspath_exclude bgpd/bgp_routemap.c:2604
    4 0x7ff0080a8f4c in route_map_apply_ext lib/routemap.c:2708
    5 0x55b99cc0f5b5 in bgp_input_modifier bgpd/bgp_route.c:1925
    6 0x55b99cc391ae in bgp_update bgpd/bgp_route.c:5205
    7 0x55b99cc3ebd5 in bgp_nlri_parse_ip bgpd/bgp_route.c:7271
    8 0x55b99cbe9be7 in bgp_nlri_parse bgpd/bgp_packet.c:338
    9 0x55b99cbebf87 in bgp_update_receive bgpd/bgp_packet.c:2448
    10 0x55b99cbfa9d2 in bgp_process_packet bgpd/bgp_packet.c:4046
    11 0x7ff0080f0112 in event_call lib/event.c:2019
    12 0x7ff00801b2b3 in frr_run lib/libfrr.c:1247
    13 0x55b99caec8d7 in main bgpd/bgp_main.c:557
    14 0x7ff007b0c249 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Memory is being leaked in this call path.  Upon debugging it was found that the ase is not a aspath or exclude_all or exclude_aspath_acl.