### PR TITLE
pimd: Only create and bind the autorp socket when really needed

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -2017,11 +2017,11 @@ void pim_pim_interface_delete(struct interface *ifp)
 	if (!pim_ifp)
 		return;
 
+	pim_ifp->pim_enable = false;
+
 #if PIM_IPV == 4
 	pim_autorp_rm_ifp(ifp);
 #endif
-
-	pim_ifp->pim_enable = false;
 
 	pim_if_membership_clear(ifp);
 

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -3285,7 +3285,6 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp
 {
 	struct vrf *vrf;
 	struct pim_instance *pim;
-	bool enabled;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -3295,10 +3294,8 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_rp
 	case NB_EV_APPLY:
 		vrf = nb_running_get_entry(args->dnode, NULL, true);
 		pim = vrf->info;
-		enabled = yang_dnode_get_bool(args->dnode, NULL);
 		/* Run AutoRP discovery by default */
-		if (!enabled)
-			pim_autorp_start_discovery(pim);
+		pim_autorp_start_discovery(pim);
 		break;
 	}
 


### PR DESCRIPTION
Previously, the autorp socket would get created and bind if needed by autorp configuration.
This update limits it further to also require pim enabled interfaces in the vrf before the socket is created and bind.
So now the socket will automatically close if there are no pim enabled interfaces left, or if autorp is turned off. It will automatically turn on if autorp is turned on and there are pim enabled interfaces in the vrf.