### PR TITLE
babeld: Hop Count must not be 0.

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -734,6 +734,10 @@ parse_packet(const unsigned char *from, struct interface *ifp,
                    format_prefix(prefix, plen),
                    format_address(from), ifp->name,
                    format_eui64(message + 8), seqno);
+            if(message[6] == 0) {
+                debugf(BABEL_DEBUG_COMMON, "Received request with invalid hop count 0");
+                goto done;
+            }
             handle_request(neigh, prefix, plen, message[6], seqno, message + 8);
         } else {
             debugf(BABEL_DEBUG_COMMON,"Received unknown packet type %d from %s on %s.",


### PR DESCRIPTION
According to RFC 8966:
Hop Count The maximum number of times that this TLV may be forwarded, plus 1. This MUST NOT be 0.
Signed-off-by: zmw12306 <zmw12306@gmail.com>