### PR TITLE
babeld: fix incorrect type assignment in parse_request_subtlv

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -290,7 +290,7 @@ parse_request_subtlv(int ae, const unsigned char *a, int alen,
     int have_src_prefix = 0;
 
     while(i < alen) {
-        type = a[0];
+        type = a[i];
         if(type == SUBTLV_PAD1) {
             i++;
             continue;


### PR DESCRIPTION
parse_request_subtlv accesses type using fixed offset instead of the current position.