### PR TITLE
bgpd: fix memory leak in bgp_process_queue

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3669,6 +3669,15 @@ static wq_item_status bgp_process_wq(struct work_queue *wq, void *data)
 static void bgp_processq_del(struct work_queue *wq, void *data)
 {
 	struct bgp_process_queue *pqnode = data;
+	struct bgp_dest *dest;
+
+	while (!STAILQ_EMPTY(&pqnode->pqueue)) {
+		dest = STAILQ_FIRST(&pqnode->pqueue);
+		STAILQ_REMOVE_HEAD(&pqnode->pqueue, pq);
+		STAILQ_NEXT(dest, pq) = NULL;
+		bgp_dest_unlock_node(dest);
+		bgp_table_unlock(bgp_dest_table(dest));
+	}
 
 	bgp_unlock(pqnode->bgp);
 


### PR DESCRIPTION
A lock is held on both bgp_dest and bgp_table each time a bgp_dest is added to the process queue. Upon deletion of a bgp vrf, work_queue_free_and_null() is called to release all bgp process queues in the work queue. However, the deletion logic does not check if any bgp_dest entries remain in the bgp process queue, leading to a memory leak.

To resolve this, clean the bgp process queue during deletion. If any remaining bgp_dest entries exist, unlock them to ensure proper resource release.