### PR TITLE
bgpd: Skip EVPN MAC processing for non-EVPN peers

### DIFF
--- a/bgpd/bgp_mac.c
+++ b/bgpd/bgp_mac.c
@@ -219,6 +219,9 @@ static void bgp_mac_rescan_evpn_table(struct bgp *bgp, struct ethaddr *macaddr)
 		if (!peer_established(peer->connection))
 			continue;
 
+		if (!peer->afc[afi][safi])
+			continue;
+
 		if (bgp_debug_update(peer, NULL, NULL, 1))
 			zlog_debug(
 				"Processing EVPN MAC interface change on peer %s %s",


### PR DESCRIPTION
Issue:
"Processing EVPN MAC interface change on peer" log message is printed even when the peer didnt have EVPN address family.

Fix:
Process only if the peer is in EVPN address family

Ticket: #17890