### PR TITLE
tests: Fix typo when configuring delayopen timer

### DIFF
--- a/tests/topotests/bgp_gr_notification/test_bgp_gr_notification.py
+++ b/tests/topotests/bgp_gr_notification/test_bgp_gr_notification.py
@@ -195,14 +195,14 @@ def test_bgp_administrative_reset_gr():
     step("Reset and delay the session establishement for R1")
     r1.vtysh_cmd(
         """
-        configure terminal"
+        configure terminal
         router bgp
          neighbor 192.168.255.2 timers delayopen 60
         """
     )
     r2.vtysh_cmd(
         """
-        configure terminal"
+        configure terminal
         router bgp
          neighbor 192.168.255.1 timers delayopen 60
         """


### PR DESCRIPTION
`"` was accidentally added, and random tests failures happening.

Fixes: a4f61b78dd382c438ff4fec2fda7450ecc890edf ("tests: Check if routes are marked as stale and retained with N-bit for GR")