### PR TITLE
babeld: Request forwarding does not prioritize feasible routes

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -1905,8 +1905,14 @@ handle_request(struct neighbour *neigh, const unsigned char *prefix,
         /* We were about to forward a request to its requestor.  Try to
            find a different neighbour to forward the request to. */
         struct babel_route *other_route;
+        /* First try feasible routes as required by RFC */
+        other_route = find_best_route(prefix, plen, 1, neigh);
 
-        other_route = find_best_route(prefix, plen, 0, neigh);
+        if(!other_route || route_metric(other_route) >= INFINITY) {
+            /* If no feasible route found, try non-feasible routes */
+            other_route = find_best_route(prefix, plen, 0, neigh);
+        }
+        
         if(other_route && route_metric(other_route) < INFINITY)
             successor = other_route->neigh;
     }


### PR DESCRIPTION

The RFC https://www.rfc-editor.org/rfc/rfc8966#name-seqno-requests states:
>  if the node has one or more feasible routes towards the requested
      prefix with a next hop that is not the requesting node, then the
      node MUST forward the request to the next hop of one such route;

Modify route selection to check feasibility first, then fall back to non-feasible routes as per SHOULD requirement.

