### PR TITLE
bfdd: Fix demultiplexing to rely solely on Your Discriminator 

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -755,26 +755,7 @@ void ptm_sbfd_echo_sess_dn(struct bfd_session *bfd, uint8_t diag)
 static struct bfd_session *bfd_find_disc(struct sockaddr_any *sa,
 					 uint32_t ldisc)
 {
-	struct bfd_session *bs;
-
-	bs = bfd_id_lookup(ldisc);
-	if (bs == NULL)
-		return NULL;
-
-	switch (bs->key.family) {
-	case AF_INET:
-		if (memcmp(&sa->sa_sin.sin_addr, &bs->key.peer,
-			   sizeof(sa->sa_sin.sin_addr)))
-			return NULL;
-		break;
-	case AF_INET6:
-		if (memcmp(&sa->sa_sin6.sin6_addr, &bs->key.peer,
-			   sizeof(sa->sa_sin6.sin6_addr)))
-			return NULL;
-		break;
-	}
-
-	return bs;
+	return bfd_id_lookup(ldisc);
 }
 
 struct bfd_session *ptm_bfd_sess_find(struct bfd_pkt *cp,


### PR DESCRIPTION
According to RFC 5880 Section 6.3, once the remote peer reflects back the local discriminator, the receiver MUST demultiplex subsequent BFD packets based solely on the Your Discriminator field. The source IP or interface MUST NOT be used in demultiplexing once the session is established.

The current implementation incorrectly verifies the source address in
`bfd_find_disc()` even after the discriminator is known, which violates
the spec and can prevent valid packets from matching established sessions
(e.g., if the source IP or interface changes).

This patch removes the peer address check from `bfd_find_disc()`, ensuring
compliance with the RFC and supporting demultiplexing using only the Your
Discriminator field after session establishment.