### PR TITLE
bgpd: Not advertised to any peer in peer-group

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11110,9 +11110,8 @@ static void flap_route_vty_out(struct vty *vty, const struct prefix *p,
 	}
 }
 
-static void route_vty_out_advertised_to(struct vty *vty, struct peer *peer,
-					int *first, const char *header,
-					json_object *json_adv_to)
+static void route_vty_out_advertised_to(struct vty *vty, struct peer *peer, int *first,
+					const char *header, json_object *json_adv_to)
 {
 	json_object *json_peer = NULL;
 
@@ -13186,17 +13185,13 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 	 * though then we must display Advertised to on a path-by-path basis. */
 	if (!bgp_addpath_is_addpath_used(&bgp->tx_addpath, afi, safi)) {
 		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-			if (peer->group)
-				continue;
-
 			if (bgp_adj_out_lookup(peer, dest, 0)) {
 				if (json && !json_adv_to)
 					json_adv_to = json_object_new_object();
 
-				route_vty_out_advertised_to(
-					vty, peer, &first,
-					"  Advertised to non peer-group peers:\n ",
-					json_adv_to);
+				route_vty_out_advertised_to(vty, peer, &first,
+							    "  Advertised to peers:\n ",
+							    json_adv_to);
 			}
 		}
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11110,8 +11110,9 @@ static void flap_route_vty_out(struct vty *vty, const struct prefix *p,
 	}
 }
 
-static void route_vty_out_advertised_to(struct vty *vty, struct peer *peer, int *first,
-					const char *header, json_object *json_adv_to)
+static void route_vty_out_advertised_to(struct vty *vty, struct peer *peer,
+					int *first, const char *header,
+					json_object *json_adv_to)
 {
 	json_object *json_peer = NULL;
 
@@ -11127,6 +11128,10 @@ static void route_vty_out_advertised_to(struct vty *vty, struct peer *peer, int 
 		if (peer->hostname)
 			json_object_string_add(json_peer, "hostname",
 					       peer->hostname);
+
+		/* Add peerGroup information when the peer belongs to a group */
+		if (peer->group)
+			json_object_string_add(json_peer, "peerGroup", peer->group->name);
 
 		if (peer->conf_if)
 			json_object_object_add(json_adv_to, peer->conf_if,

--- a/tests/topotests/bgp_peer_group/test_bgp_peer-group.py
+++ b/tests/topotests/bgp_peer_group/test_bgp_peer-group.py
@@ -17,6 +17,8 @@ import sys
 import json
 import pytest
 import functools
+import re
+import json
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
@@ -177,6 +179,111 @@ def test_bgp_peer_group_remote_as_del_readd():
     test_func = functools.partial(_bgp_peer_group_remoteas_add)
     _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assert result is None, "Failed bgp convergence in r1"
+
+
+def test_bgp_peer_group_with_non_peer_group_peer():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    logger.info("Change a peer r1-eth0 to be non peer group and PG2 to have two peers")
+    r1.vtysh_cmd(
+        """
+    configure terminal
+      router bgp 65001
+        no bgp ebgp-requires-policy
+        no neighbor 192.168.251.2 peer-group PG1
+        neighbor PG2 remote-as external
+        neighbor 192.168.251.2 peer-group PG2
+        no neighbor r1-eth0 interface peer-group PG
+        neighbor r1-eth0 interface remote-as external
+        address-family ipv4 unicast
+          redistribute connected
+    """
+    )
+
+    # Function to check if the route is properly advertised to all expected peers
+    def _check_route_advertisement():
+        output_str = r1.vtysh_cmd("show bgp ipv4 unicast 192.168.251.0/30 json")
+        output = json.loads(output_str)
+
+        # Define the expected structure based on the exact JSON format shared
+        expected = {
+            "advertisedTo": {
+                "192.168.255.3": {"peerGroup": "PG"},
+                "192.168.251.2": {"peerGroup": "PG2"},
+                "192.168.252.2": {"peerGroup": "PG2"},
+                "r1-eth0": {},  # Just verify existence, content will vary
+            }
+        }
+
+        # Return any differences between expected and actual output
+        return topotest.json_cmp(output, expected)
+
+    # Wait for the route to be properly advertised to all peers
+    test_func = functools.partial(_check_route_advertisement)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, "Route 192.168.251.0/30 not properly advertised to all peers"
+
+    # Now get the text BGP output for pattern matching
+    show_bgp_adv_str = r1.vtysh_cmd("show bgp ipv4 unicast 192.168.251.0/30").rstrip()
+
+    # Part 1: Check text output format
+    # Check for "Advertised to peers:" section
+    adv_to_peers_pattern = r"Advertised to peers:"
+    adv_to_peers_match = re.search(adv_to_peers_pattern, show_bgp_adv_str)
+    assert adv_to_peers_match is not None, "Missing 'Advertised to peers:' section"
+
+    # Check for specific peers
+    pg_peer_pattern = r"192\.168\.255\.3"
+    pg_peer_match = re.search(pg_peer_pattern, show_bgp_adv_str)
+    assert pg_peer_match is not None, "Missing peer 192.168.255.3"
+
+    pg2_peer1_pattern = r"192\.168\.251\.2"
+    pg2_peer1_match = re.search(pg2_peer1_pattern, show_bgp_adv_str)
+    assert pg2_peer1_match is not None, "Missing peer 192.168.251.2"
+
+    pg2_peer2_pattern = r"192\.168\.252\.2"
+    pg2_peer2_match = re.search(pg2_peer2_pattern, show_bgp_adv_str)
+    assert pg2_peer2_match is not None, "Missing peer 192.168.252.2"
+
+    # Check for the non-peer-group peer
+    non_pg_peer_pattern = r"r1-eth0"
+    non_pg_peer_match = re.search(non_pg_peer_pattern, show_bgp_adv_str)
+    assert non_pg_peer_match is not None, "Missing peer r1-eth0"
+
+    # Verify the complete advertised peers line
+    # Check that all peers appear after the "Advertised to peers:" line
+    peers_line_pattern = r"Advertised to peers:[\r\n]+\s+.*(192\.168\.255\.3).*"
+    peers_line_match = re.search(peers_line_pattern, show_bgp_adv_str, re.DOTALL)
+    assert (
+        peers_line_match is not None
+    ), "The 'Advertised to peers:' section doesn't contain the peers"
+
+    # Verify all expected peers are in the peers line
+    all_peers_pattern = r"Advertised to peers:[\r\n]+\s+.*192\.168\.255\.3.*192\.168\.251\.2.*192\.168\.252\.2.*r1-eth0"
+    all_peers_match = re.search(all_peers_pattern, show_bgp_adv_str, re.DOTALL)
+    assert (
+        all_peers_match is not None
+    ), "Not all expected peers appear in the advertised peers list"
+
+    logger.info("Rollback config change")
+    r1.vtysh_cmd(
+        """
+    configure terminal
+      router bgp 65001
+        bgp ebgp-requires-policy
+        no neighbor 192.168.251.2 peer-group PG2
+        no neighbor PG2 remote-as external
+        neighbor 192.168.251.2 peer-group PG1
+        no neighbor r1-eth0 interface remote-as external
+        neighbor r1-eth0 interface peer-group PG
+        address-family ipv4 unicast
+          no redistribute connected
+    """
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Issue:
When we have bgp peer-group, and prefix are advertised to the peers in it correctly, it still shows Not advertised to any peer.

leaf-1# sh bgp ipv6 unicast 2051:51:1:168::/64

BGP routing table entry for 2051:51:1:168::/64, version 69

Paths: (1 available, best #1, table default)

  Not advertised to any peer<<<<<<<<<Wrong state.

  Local

    ::(leaf-1) from :: (6.0.0.17)

      Origin incomplete, metric 0, weight 32768, valid, sourced, bestpath-from-AS Local, best (First path received)

      Last update: Tue Apr  1 18:19:09 2025


Fix:
1)Changed advertised statement to "Advertised to peers:" which is applicable for peer in peer group or non-peer-group
2)Added peer group information in show bgp  json output
3)added testcase
BGP routing table entry for 192.168.251.0/30, version 1
Paths: (1 available, best #1, table default)
  Advertised to peers:
  192.168.255.3 192.168.251.2 192.168.252.2 r1-eth0
  Local
    0.0.0.0 from 0.0.0.0 (192.168.255.1)
      Origin incomplete, metric 0, weight 32768, valid, sourced, best (First path received)
      Last update: Tue Apr 29 17:28:02 2025


BGP advertisement output json:
{
  "prefix":"192.168.251.0/30",
  "version":1,
  "advertisedTo":{
    "192.168.255.3":{
      "hostname":"r3",
      "peerGroup":"PG"
    },
    "192.168.251.2":{
      "hostname":"r2",
      "peerGroup":"PG2"
    },
    "192.168.252.2":{
      "hostname":"r4",
      "peerGroup":"PG2"
    },
    "r1-eth0":{
      "hostname":"r2"
    }
  },
  "paths":[
    {
      "aspath":{
        "string":"Local",
        "segments":[
        ],
        "length":0
      },
      "origin":"incomplete",
      "metric":0,
      "weight":32768,
      "valid":true,
      "version":1,
      "sourced":true,
      "bestpath":{
        "overall":true,
        "selectionReason":"First path received"
      },
      "lastUpdate":{
        "epoch":1744926043,
        "string":"Thu Apr 17 21:40:43 2025"
      },
      "fibInstalled":true,
      "nexthops":[
        {
          "ip":"0.0.0.0",
          "hostname":"r1",
          "afi":"ipv4",
          "metric":0,
          "accessible":true,
          "used":true
        }
      ],
      "peer":{
        "peerId":"0.0.0.0",
        "routerId":"192.168.255.1"
      }
    }
  ]
}
