### PR TITLE
bfdd: Check for passive mode with zero discriminator

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -415,6 +415,11 @@ static int ptm_bfd_process_echo_pkt(struct bfd_vrf_global *bvrf, int s)
 
 void ptm_bfd_snd(struct bfd_session *bfd, int fbit)
 {
+	/* Check for passive mode with zero discriminator */
+	if (bfd->discrs.remote_discr == 0 && 
+		CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_PASSIVE))
+		return;
+
 	struct bfd_pkt cp = {};
 
 	/* Set fields according to section 6.5.7 */


### PR DESCRIPTION
RFC 5880 6.8.7:  A system MUST NOT transmit BFD Control packets if bfd.RemoteDiscr is zero and the system is taking the Passive role.