### PR TITLE
bfdd: Set bfd.LocalDiag when transitioning to AdminDown

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1564,6 +1564,7 @@ void bfd_set_shutdown(struct bfd_session *bs, bool shutdown)
 			return;
 
 		SET_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
+		bs->local_diag = BD_ADMIN_DOWN;
 
 		/* Handle data plane shutdown case. */
 		if (bs->bdc) {


### PR DESCRIPTION
RFC 5880 6.8.16, need to set LocalDiag when transitioning to AdminDown state.