### PR TITLE
nhrpd: Incomplete uniqueness bit handling

### DIFF
--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -629,6 +629,8 @@ static void nhrp_handle_registration_request(struct nhrp_packet_parser *p)
 	int holdtime, prefix_len, hostprefix_len, natted = 0;
 	size_t paylen;
 	void *pay;
+	bool is_unique = p->hdr->flags & htons(NHRP_FLAG_REGISTRATION_UNIQUE);
+	int cie_count = 0;
 
 	debugf(NHRP_DEBUG_COMMON, "Parsing and replying to Registration Req");
 	hostprefix_len = 8 * sockunion_get_addrlen(&p->if_ad->addr);
@@ -656,7 +658,21 @@ static void nhrp_handle_registration_request(struct nhrp_packet_parser *p)
 
 	while ((cie = nhrp_cie_pull(&payload, hdr, &cie_nbma, &cie_proto))
 	       != NULL) {
+		cie_count++;
+
+		if (cie_count > 1 && is_unique) {
+			debugf(NHRP_DEBUG_COMMON, "RFC violation: More than one CIE in unique registration");
+			cie->code = NHRP_CODE_ADMINISTRATIVELY_PROHIBITED;
+			continue;
+		}
+
 		prefix_len = cie->prefix_length;
+		if (is_unique && prefix_len != 0xFF) {
+			debugf(NHRP_DEBUG_COMMON, "RFC violation: Prefix length must be 0xFF for unique registration");
+			cie->code = NHRP_CODE_ADMINISTRATIVELY_PROHIBITED;
+			continue;
+		}
+
 		if (prefix_len == 0 || prefix_len >= hostprefix_len)
 			prefix_len = hostprefix_len;
 


### PR DESCRIPTION
According to https://datatracker.ietf.org/doc/html/rfc2332.html#section-5.2.3
No storage/checking of uniqueness flag. No rejection of duplicate unique registrations



Another violation: "Any attempt to register a binding between the protocol address and an NBMA address when this bit is set MUST be rejected with a Code of '14 - Unique Internetworking Layer Address Already Registered' if the replying NHS already has a cache entry for the protocol address and the cache entry has the 'uniqueness' bit set."

I didn't resolve this because it may require large modifications, including struct nhrp_cache, nhrp_cache_update_binding, caller functions to nhrp_cache_update_binding and also nhrp_handle_registration_request...