### PR TITLE
mgmtd: remove bogus "hedge" code which corrupted active candidate DS

### DIFF
--- a/mgmtd/mgmt_ds.c
+++ b/mgmtd/mgmt_ds.c
@@ -74,8 +74,7 @@ static int mgmt_ds_dump_in_memory(struct mgmt_ds_ctx *ds_ctx,
 	return 0;
 }
 
-static int mgmt_ds_replace_dst_with_src_ds(struct mgmt_ds_ctx *src,
-					   struct mgmt_ds_ctx *dst)
+static int ds_copy(struct mgmt_ds_ctx *dst, struct mgmt_ds_ctx *src)
 {
 	if (!src || !dst)
 		return -1;
@@ -95,8 +94,7 @@ static int mgmt_ds_replace_dst_with_src_ds(struct mgmt_ds_ctx *src,
 	return 0;
 }
 
-static int mgmt_ds_merge_src_with_dst_ds(struct mgmt_ds_ctx *src,
-					 struct mgmt_ds_ctx *dst)
+static int ds_merge(struct mgmt_ds_ctx *dst, struct mgmt_ds_ctx *src)
 {
 	int ret;
 
@@ -251,14 +249,13 @@ void mgmt_ds_unlock(struct mgmt_ds_ctx *ds_ctx)
 	ds_ctx->locked = 0;
 }
 
-int mgmt_ds_copy_dss(struct mgmt_ds_ctx *src_ds_ctx,
-		     struct mgmt_ds_ctx *dst_ds_ctx, bool updt_cmt_rec)
+int mgmt_ds_copy_dss(struct mgmt_ds_ctx *dst, struct mgmt_ds_ctx *src, bool updt_cmt_rec)
 {
-	if (mgmt_ds_replace_dst_with_src_ds(src_ds_ctx, dst_ds_ctx) != 0)
+	if (ds_copy(dst, src) != 0)
 		return -1;
 
-	if (updt_cmt_rec && dst_ds_ctx->ds_id == MGMTD_DS_RUNNING)
-		mgmt_history_new_record(dst_ds_ctx);
+	if (updt_cmt_rec && dst->ds_id == MGMTD_DS_RUNNING)
+		mgmt_history_new_record(dst);
 
 	return 0;
 }
@@ -416,9 +413,9 @@ int mgmt_ds_load_config_from_file(struct mgmt_ds_ctx *dst,
 	parsed.ds_id = dst->ds_id;
 
 	if (merge)
-		mgmt_ds_merge_src_with_dst_ds(&parsed, dst);
+		ds_merge(dst, &parsed);
 	else
-		mgmt_ds_replace_dst_with_src_ds(&parsed, dst);
+		ds_copy(dst, &parsed);
 
 	nb_config_free(parsed.root.cfg_root);
 

--- a/mgmtd/mgmt_ds.h
+++ b/mgmtd/mgmt_ds.h
@@ -196,11 +196,11 @@ extern void mgmt_ds_unlock(struct mgmt_ds_ctx *ds_ctx);
 /*
  * Copy from source to destination datastore.
  *
- * src_ds
- *    Source datastore handle (ds to be copied from).
- *
- * dst_ds
+ * dst
  *    Destination datastore handle (ds to be copied to).
+ *
+ * src
+ *    Source datastore handle (ds to be copied from).
  *
  * update_cmd_rec
  *    TRUE if need to update commit record, FALSE otherwise.
@@ -208,9 +208,7 @@ extern void mgmt_ds_unlock(struct mgmt_ds_ctx *ds_ctx);
  * Returns:
  *    0 on success, -1 on failure.
  */
-extern int mgmt_ds_copy_dss(struct mgmt_ds_ctx *src_ds_ctx,
-			    struct mgmt_ds_ctx *dst_ds_ctx,
-			    bool update_cmt_rec);
+extern int mgmt_ds_copy_dss(struct mgmt_ds_ctx *dst, struct mgmt_ds_ctx *src, bool update_cmt_rec);
 
 /*
  * Fetch northbound configuration for a given datastore context.

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -217,12 +217,6 @@ static void
 mgmt_fe_session_cfg_txn_cleanup(struct mgmt_fe_session_ctx *session)
 {
 	/*
-	 * Ensure any uncommitted changes in Candidate DS
-	 * is discarded.
-	 */
-	mgmt_ds_copy_dss(mm->running_ds, mm->candidate_ds, false);
-
-	/*
 	 * Destroy the actual transaction created earlier.
 	 */
 	if (session->cfg_txn_id != MGMTD_TXN_ID_NONE)


### PR DESCRIPTION
Say you have 2 mgmtd frontend sessions (2 vtysh's) the first one is long
running and is actively changing the global candidate datastore (DS),
the second one starts and exits, this code would then copy running
back over the candidate, blowing away any changes made by the first
session.

(the long running session could technically be any user)

Instead we need to trust the various cleanup code that already exits.
For example in the commit_cfg_reply on success candidate is copied to
running, and on failure *for implicit commit* running is copied back to
candidate clearing the change. This leaves the non-implicit
configuration changes in this case we actually want candidate to keep
it's changes in transactional cases, in the other case of pending commit
during a file read the code restores candidate (if needed) on exit from
"config terminal", with this call stack:

```c
 vty_config_node_exit()
   nb_cli_pending_commit_check()
     nb_cli_classic_commit()
       nb_candidate_commit_prepare() [fail] -> copy running -> candidate
       nb_candidate_commit_apply() -> copy candidate -> running
```

fixes https://github.com/FRRouting/frr/issues/18541