### PR TITLE
Add sharp support for seg6local routes with uSID flavor

### DIFF
--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -202,6 +202,7 @@ keyword. At present, no sharp commands will be preserved in the config.
    router# sharp install seg6local-routes 1::8 nexthop-seg6local dum0 uA 2001::1 1
    router# sharp install seg6local-routes 1::9 nexthop-seg6local dum0 uN usid-block-length 40 usid-function-length 8 1
    router# sharp install seg6local-routes 1::10 nexthop-seg6local dum0 uA 2001::1 usid-block-length 40 usid-function-length 8 1
+   router# sharp install seg6local-routes 1::11 nexthop-seg6local dum0 End_B6_Encap nexthop-seg6 2001::5 encap 2001:a::b:c 2001:a::d:e 1
 
    router# show ipv6 route
    D>* 1::1/128 [150/0] is directly connected, dum0, seg6local End -, weight 1, 00:00:05
@@ -214,6 +215,7 @@ keyword. At present, no sharp commands will be preserved in the config.
    D>* 1::8/128 [150/0] is directly connected, dum0, seg6local End.X nh6 2001::1, weight 1, 00:01:17
    D>* 1::9/128 [150/0] is directly connected, dum0, seg6local End -, weight 1, 00:00:12
    D>* 1::10/128 [150/0] is directly connected, dum0, seg6local End.X nh6 2001::1, weight 1, 00:00:05
+   D>* 1::11/128 [150/0] is directly connected, dum0, seg6local End.B6.Encap nh6 2001::5, seg6 2001:a::b:c,2001:a::d:e, weight 1, 00:00:04
 
    bash# ip -6 route
    1::1  encap seg6local action End dev dum0 proto 194 metric 20 pref medium
@@ -226,6 +228,7 @@ keyword. At present, no sharp commands will be preserved in the config.
    1::8  encap seg6local action End.X nh6 2001::1 flavors next-csid lblen 32 nflen 16 dev dum0 proto 194 metric 20 pref medium
    1::9  encap seg6local action End flavors next-csid lblen 40 nflen 8 dev dum0 proto 194 metric 20 pref medium
    1::10  encap seg6local action End.X nh6 2001::1 flavors next-csid lblen 40 nflen 8 dev dum0 proto 194 metric 20 pref medium
+   1::11  encap seg6local action End.B6.Encaps segs 2 [ 2001:a::b:c 2001:a::d:e ] via 2001::5 dev dum0 proto 194 metric 20 pref medium
 
 
 .. clicmd:: show sharp segment-routing srv6

--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -200,6 +200,8 @@ keyword. At present, no sharp commands will be preserved in the config.
    router# sharp install seg6local-routes 1::6 nexthop-seg6local dum0 End_DT46 10 1
    router# sharp install seg6local-routes 1::7 nexthop-seg6local dum0 uN 1
    router# sharp install seg6local-routes 1::8 nexthop-seg6local dum0 uA 2001::1 1
+   router# sharp install seg6local-routes 1::9 nexthop-seg6local dum0 uN usid-block-length 40 usid-function-length 8 1
+   router# sharp install seg6local-routes 1::10 nexthop-seg6local dum0 uA 2001::1 usid-block-length 40 usid-function-length 8 1
 
    router# show ipv6 route
    D>* 1::1/128 [150/0] is directly connected, dum0, seg6local End -, weight 1, 00:00:05
@@ -210,6 +212,8 @@ keyword. At present, no sharp commands will be preserved in the config.
    D>* 1::6/128 [150/0] is directly connected, dum0, seg6local End.DT46 table 10, weight 1, 00:00:05
    D>* 1::7/128 [150/0] is directly connected, dum0, seg6local End -, weight 1, 00:00:05
    D>* 1::8/128 [150/0] is directly connected, dum0, seg6local End.X nh6 2001::1, weight 1, 00:01:17
+   D>* 1::9/128 [150/0] is directly connected, dum0, seg6local End -, weight 1, 00:00:12
+   D>* 1::10/128 [150/0] is directly connected, dum0, seg6local End.X nh6 2001::1, weight 1, 00:00:05
 
    bash# ip -6 route
    1::1  encap seg6local action End dev dum0 proto 194 metric 20 pref medium
@@ -220,6 +224,8 @@ keyword. At present, no sharp commands will be preserved in the config.
    1::6  encap seg6local action End.DT46 table 10 dev dum0 proto 194 metric 20 pref medium
    1::7  encap seg6local action End flavors next-csid lblen 32 nflen 16 dev dum0 proto 194 metric 20 pref medium
    1::8  encap seg6local action End.X nh6 2001::1 flavors next-csid lblen 32 nflen 16 dev dum0 proto 194 metric 20 pref medium
+   1::9  encap seg6local action End flavors next-csid lblen 40 nflen 8 dev dum0 proto 194 metric 20 pref medium
+   1::10  encap seg6local action End.X nh6 2001::1 flavors next-csid lblen 40 nflen 8 dev dum0 proto 194 metric 20 pref medium
 
 
 .. clicmd:: show sharp segment-routing srv6

--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -198,14 +198,18 @@ keyword. At present, no sharp commands will be preserved in the config.
    router# sharp install seg6local-routes 1::4 nexthop-seg6local dum0 End_DX4 10.0.0.1 1
    router# sharp install seg6local-routes 1::5 nexthop-seg6local dum0 End_DT6 10 1
    router# sharp install seg6local-routes 1::6 nexthop-seg6local dum0 End_DT46 10 1
+   router# sharp install seg6local-routes 1::7 nexthop-seg6local dum0 uN 1
+   router# sharp install seg6local-routes 1::8 nexthop-seg6local dum0 uA 2001::1 1
 
    router# show ipv6 route
-   D>* 1::1/128 [150/0] is directly connected, dum0, seg6local End USP, weight 1, 00:00:05
+   D>* 1::1/128 [150/0] is directly connected, dum0, seg6local End -, weight 1, 00:00:05
    D>* 1::2/128 [150/0] is directly connected, dum0, seg6local End.X nh6 2001::1, weight 1, 00:00:05
    D>* 1::3/128 [150/0] is directly connected, dum0, seg6local End.T table 10, weight 1, 00:00:05
    D>* 1::4/128 [150/0] is directly connected, dum0, seg6local End.DX4 nh4 10.0.0.1, weight 1, 00:00:05
    D>* 1::5/128 [150/0] is directly connected, dum0, seg6local End.DT6 table 10, weight 1, 00:00:05
    D>* 1::6/128 [150/0] is directly connected, dum0, seg6local End.DT46 table 10, weight 1, 00:00:05
+   D>* 1::7/128 [150/0] is directly connected, dum0, seg6local End -, weight 1, 00:00:05
+   D>* 1::8/128 [150/0] is directly connected, dum0, seg6local End.X nh6 2001::1, weight 1, 00:01:17
 
    bash# ip -6 route
    1::1  encap seg6local action End dev dum0 proto 194 metric 20 pref medium
@@ -214,6 +218,9 @@ keyword. At present, no sharp commands will be preserved in the config.
    1::4  encap seg6local action End.DX4 nh4 10.0.0.1 dev dum0 proto 194 metric 20 pref medium
    1::5  encap seg6local action End.DT6 table 10 dev dum0 proto 194 metric 20 pref medium
    1::6  encap seg6local action End.DT46 table 10 dev dum0 proto 194 metric 20 pref medium
+   1::7  encap seg6local action End flavors next-csid lblen 32 nflen 16 dev dum0 proto 194 metric 20 pref medium
+   1::8  encap seg6local action End.X nh6 2001::1 flavors next-csid lblen 32 nflen 16 dev dum0 proto 194 metric 20 pref medium
+
 
 .. clicmd:: show sharp segment-routing srv6
 

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -460,6 +460,7 @@ DEFPY (install_seg6local_routes,
 	      uDT4$seg6l_micro_enddt4 (1-4294967295)$seg6l_micro_enddt4_table|\
 	      End_DT46$seg6l_enddt46 (1-4294967295)$seg6l_enddt46_table|\
 	      uDT46$seg6l_micro_enddt46 (1-4294967295)$seg6l_micro_enddt46_table>\
+	      [usid-block-length (1-128)$lcblen] [usid-function-length (1-128)$lcfunclen] \
 	  (1-1000000)$routes [repeat (2-1000)$rpt]",
        "Sharp routing Protocol\n"
        "install some routes\n"
@@ -499,6 +500,10 @@ DEFPY (install_seg6local_routes,
        "Redirect table id to use\n"
        "SRv6 uDT46 function to use\n"
        "Redirect table id to use\n"
+       "uSID locator block length\n"
+       "Value in bits\n"
+       "uSID node Function length\n"
+       "Value in bits\n"
        "How many to create\n"
        "Should we repeat this command\n"
        "How many times to repeat this command\n")
@@ -594,6 +599,12 @@ DEFPY (install_seg6local_routes,
 	} else
 		action = ZEBRA_SEG6_LOCAL_ACTION_END;
 
+	if (CHECK_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID)) {
+		if (lcblen)
+			ctx.flv.lcblock_len = lcblen;
+		if (lcfunclen)
+			ctx.flv.lcnode_func_len = lcfunclen;
+	}
 	sg.r.nhop.type = NEXTHOP_TYPE_IFINDEX;
 	sg.r.nhop.ifindex = ifname2ifindex(seg6l_oif, vrf->vrf_id);
 	sg.r.nhop.vrf_id = vrf->vrf_id;

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -445,13 +445,21 @@ DEFPY (install_seg6local_routes,
 	  X:X::X:X$start6\
 	  nexthop-seg6local NAME$seg6l_oif\
 	     <End$seg6l_end|\
+	      uN$seg6l_micro_end|\
 	      End_X$seg6l_endx X:X::X:X$seg6l_endx_nh6|\
+	      uA$seg6l_micro_endx X:X::X:X$seg6l_micro_endx_nh6|\
 	      End_T$seg6l_endt (1-4294967295)$seg6l_endt_table|\
+	      uDT$seg6l_micro_endt (1-4294967295)$seg6l_micro_endt_table|\
 	      End_DX4$seg6l_enddx4 A.B.C.D$seg6l_enddx4_nh4|\
+	      uDX4$seg6l_micro_enddx4 A.B.C.D$seg6l_micro_enddx4_nh4|\
 	      End_DX6$seg6l_enddx6 X:X::X:X$seg6l_enddx6_nh6|\
+	      uDX6$seg6l_micro_enddx6 X:X::X:X$seg6l_micro_enddx6_nh6|\
 	      End_DT6$seg6l_enddt6 (1-4294967295)$seg6l_enddt6_table|\
+	      uDT6$seg6l_micro_enddt6 (1-4294967295)$seg6l_micro_enddt6_table|\
 	      End_DT4$seg6l_enddt4 (1-4294967295)$seg6l_enddt4_table|\
-	      End_DT46$seg6l_enddt46 (1-4294967295)$seg6l_enddt46_table>\
+	      uDT4$seg6l_micro_enddt4 (1-4294967295)$seg6l_micro_enddt4_table|\
+	      End_DT46$seg6l_enddt46 (1-4294967295)$seg6l_enddt46_table|\
+	      uDT46$seg6l_micro_enddt46 (1-4294967295)$seg6l_micro_enddt46_table>\
 	  (1-1000000)$routes [repeat (2-1000)$rpt]",
        "Sharp routing Protocol\n"
        "install some routes\n"
@@ -462,19 +470,34 @@ DEFPY (install_seg6local_routes,
        "Nexthop-seg6local to use\n"
        "Output device to use\n"
        "SRv6 End function to use\n"
+       "SRv6 uN function to use\n"
        "SRv6 End.X function to use\n"
+       "V6 Nexthop address to use\n"
+       "SRv6 uA function to use\n"
        "V6 Nexthop address to use\n"
        "SRv6 End.T function to use\n"
        "Redirect table id to use\n"
+       "SRv6 uDT function to use\n"
+       "Redirect table id to use\n"
        "SRv6 End.DX4 function to use\n"
+       "V4 Nexthop address to use\n"
+       "SRv6 uDX4 function to use\n"
        "V4 Nexthop address to use\n"
        "SRv6 End.DX6 function to use\n"
        "V6 Nexthop address to use\n"
+       "SRv6 uDX6 function to use\n"
+       "V6 Nexthop address to use\n"
        "SRv6 End.DT6 function to use\n"
+       "Redirect table id to use\n"
+       "SRv6 uDT6 function to use\n"
        "Redirect table id to use\n"
        "SRv6 End.DT4 function to use\n"
        "Redirect table id to use\n"
+       "SRv6 uDT4 function to use\n"
+       "Redirect table id to use\n"
        "SRv6 End.DT46 function to use\n"
+       "Redirect table id to use\n"
+       "SRv6 uDT46 function to use\n"
        "Redirect table id to use\n"
        "How many to create\n"
        "Should we repeat this command\n"
@@ -519,27 +542,57 @@ DEFPY (install_seg6local_routes,
 	if (seg6l_enddx4) {
 		action = ZEBRA_SEG6_LOCAL_ACTION_END_DX4;
 		ctx.nh4 = seg6l_enddx4_nh4;
+	} else if (seg6l_micro_enddx4) {
+		action = ZEBRA_SEG6_LOCAL_ACTION_END_DX4;
+		ctx.nh4 = seg6l_micro_enddx4_nh4;
+		SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
 	} else if (seg6l_enddx6) {
 		action = ZEBRA_SEG6_LOCAL_ACTION_END_DX6;
 		ctx.nh6 = seg6l_enddx6_nh6;
+	} else if (seg6l_micro_enddx6) {
+		action = ZEBRA_SEG6_LOCAL_ACTION_END_DX6;
+		ctx.nh6 = seg6l_enddx6_nh6;
+		SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
 	} else if (seg6l_endx) {
 		action = ZEBRA_SEG6_LOCAL_ACTION_END_X;
 		ctx.nh6 = seg6l_endx_nh6;
+	} else if (seg6l_micro_endx) {
+		action = ZEBRA_SEG6_LOCAL_ACTION_END_X;
+		ctx.nh6 = seg6l_micro_endx_nh6;
+		SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
 	} else if (seg6l_endt) {
 		action = ZEBRA_SEG6_LOCAL_ACTION_END_T;
 		ctx.table = seg6l_endt_table;
+	} else if (seg6l_micro_endt) {
+		action = ZEBRA_SEG6_LOCAL_ACTION_END_T;
+		ctx.table = seg6l_micro_endt_table;
+		SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
 	} else if (seg6l_enddt6) {
 		action = ZEBRA_SEG6_LOCAL_ACTION_END_DT6;
 		ctx.table = seg6l_enddt6_table;
+	} else if (seg6l_micro_enddt6) {
+		action = ZEBRA_SEG6_LOCAL_ACTION_END_DT6;
+		ctx.table = seg6l_micro_enddt6_table;
+		SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
 	} else if (seg6l_enddt4) {
 		action = ZEBRA_SEG6_LOCAL_ACTION_END_DT4;
 		ctx.table = seg6l_enddt4_table;
+	} else if (seg6l_micro_enddt4) {
+		action = ZEBRA_SEG6_LOCAL_ACTION_END_DT4;
+		ctx.table = seg6l_micro_enddt4_table;
+		SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
 	} else if (seg6l_enddt46) {
 		action = ZEBRA_SEG6_LOCAL_ACTION_END_DT46;
 		ctx.table = seg6l_enddt46_table;
-	} else {
+	} else if (seg6l_micro_enddt46) {
+		action = ZEBRA_SEG6_LOCAL_ACTION_END_DT46;
+		ctx.table = seg6l_micro_enddt46_table;
+		SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
+	} else if (seg6l_micro_end) {
 		action = ZEBRA_SEG6_LOCAL_ACTION_END;
-	}
+		SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
+	} else
+		action = ZEBRA_SEG6_LOCAL_ACTION_END;
 
 	sg.r.nhop.type = NEXTHOP_TYPE_IFINDEX;
 	sg.r.nhop.ifindex = ifname2ifindex(seg6l_oif, vrf->vrf_id);


### PR DESCRIPTION
Add to sharp VTY extensions to add srv6 route installation:
- add support for microSID instruction
- add support for End.B6.Encap instruction