### PR TITLE
bgpd: fix crash when replacing aspath exclude

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2566,12 +2566,14 @@ static void route_aspath_exclude_free(void *rule)
 	struct as_list *acl;
 
 	/* manage references to that rule*/
-	if (ase->exclude_aspath_acl) {
-		acl = ase->exclude_aspath_acl;
-		as_list_list_del(&acl->exclude_rule, ase);
-	} else if (ase->exclude_aspath_acl_name) {
-		/* no ref to acl, this aspath exclude is orphan */
-		as_exclude_remove_orphan(ase);
+	if (ase->exclude_aspath_acl_name) {
+		if (ase->exclude_aspath_acl) {
+			acl = ase->exclude_aspath_acl;
+			as_list_list_del(&acl->exclude_rule, ase);
+		} else if (ase->exclude_aspath_acl_name) {
+			/* no ref to acl, this aspath exclude is orphan */
+			as_exclude_remove_orphan(ase);
+		}
 	}
 
 	aspath_free(ase->aspath);


### PR DESCRIPTION
To reproduce:
router bgp1
exit
route-map routemaptest deny 1  
set as-path exclude 33 34 35  
exit
route-map routemaptest deny 1 
set as-path exclude as-path-access-list test 
exit