### PR TITLE
bgpd: remove useless calls to afi2family

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13325,8 +13325,6 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp, struct bgp_
 		return CMD_WARNING;
 	}
 
-	match.family = afi2family(afi);
-
 	if (use_json)
 		json = json_object_new_object();
 
@@ -16736,8 +16734,6 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 		vty_out(vty, "%% address is malformed\n");
 		return CMD_WARNING;
 	}
-
-	match.family = afi2family(afi);
 
 	if ((safi == SAFI_MPLS_VPN) || (safi == SAFI_ENCAP)
 	    || (safi == SAFI_EVPN)) {

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -11080,7 +11080,6 @@ static int bgp_clear_prefix(struct vty *vty, const char *view_name,
 		return CMD_WARNING;
 	}
 
-	match.family = afi2family(afi);
 	rib = bgp->rib[afi][safi];
 
 	if (safi == SAFI_MPLS_VPN) {


### PR DESCRIPTION
Remove useless calls to afi2family(). str2prefix() always sets the prefix family.