### PR TITLE
bgpd: On shutdown free up table for static routes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8005,6 +8005,8 @@ void bgp_static_delete(struct bgp *bgp)
 					rm = bgp_dest_unlock_node(rm);
 					assert(rm);
 				}
+
+				bgp_table_unlock(table);
 			} else {
 				bgp_static = bgp_dest_get_bgp_static_info(dest);
 				bgp_static_withdraw(bgp,


### PR DESCRIPTION
Indirect leak of 56 byte(s) in 1 object(s) allocated from:
    0 0x7fdaf6cb83b7 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:77
    1 0x7fdaf683a480 in qcalloc lib/memory.c:106
    2 0x7fdaf68dd706 in route_table_init_with_delegate lib/table.c:38
    3 0x5649b22c05b0 in bgp_table_init bgpd/bgp_table.c:139
    4 0x5649b2273da0 in bgp_static_set bgpd/bgp_route.c:7779
    5 0x5649b21eba58 in vpnv4_network bgpd/bgp_mplsvpn.c:3244
    6 0x7fdaf67b6d61 in cmd_execute_command_real lib/command.c:1003
    7 0x7fdaf67b7080 in cmd_execute_command lib/command.c:1062
    8 0x7fdaf67b75ac in cmd_execute lib/command.c:1228
    9 0x7fdaf68ffb20 in vty_command lib/vty.c:626
    10 0x7fdaf6900073 in vty_execute lib/vty.c:1389
    11 0x7fdaf6903e24 in vtysh_read lib/vty.c:2408
    12 0x7fdaf68f0222 in event_call lib/event.c:2019
    13 0x7fdaf681b3c6 in frr_run lib/libfrr.c:1247
    14 0x5649b211c903 in main bgpd/bgp_main.c:565
    15 0x7fdaf630c249 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Table was being created but never deleted.  Let's delete it.