### PR TITLE
tests: Add additional debug data for bgp_gr_notification test

### DIFF
--- a/tests/topotests/bgp_gr_notification/r1/bgpd.conf
+++ b/tests/topotests/bgp_gr_notification/r1/bgpd.conf
@@ -1,3 +1,6 @@
+debug bgp graceful-restart
+debug bgp neighbor-events
+!
 router bgp 65001
  no bgp ebgp-requires-policy
  bgp graceful-restart


### PR DESCRIPTION
The bgp_br_notification test is failing regularly and after looking at the log files on upstream runs, I cannot determine what is going on.  I've added an additional stage to gather data, as well as turned on debugs in bgp in order to help me figure out what is going wrong.

I cannot make this fail locally, hence doing it this way.