### PR TITLE
zebra: fix pbr_iptable memory leak

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -3872,7 +3872,7 @@ static inline void zebra_neigh_ip_del(ZAPI_HANDLER_ARGS)
 static inline void zread_iptable(ZAPI_HANDLER_ARGS)
 {
 	struct zebra_pbr_iptable *zpi =
-		XCALLOC(MTYPE_PBR_OBJ, sizeof(struct zebra_pbr_iptable));
+		XCALLOC(MTYPE_PBR_IPTABLE, sizeof(struct zebra_pbr_iptable));
 	struct stream *s;
 
 	s = msg;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -3878,6 +3878,7 @@ static inline void zread_iptable(ZAPI_HANDLER_ARGS)
 	s = msg;
 
 	zpi->interface_name_list = list_new();
+	zpi->interface_name_list->del = zebra_pbr_iptable_interface_name_list_free;
 	zpi->sock = client->sock;
 	zpi->vrf_id = zvrf->vrf->vrf_id;
 	STREAM_GETL(s, zpi->unique);

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -1047,13 +1047,13 @@ void zebra_pbr_del_iptable(struct zebra_pbr_iptable *iptable)
 		char *name;
 
 		hash_release(zrouter.iptable_hash, lookup);
-		for (ALL_LIST_ELEMENTS(iptable->interface_name_list,
+		for (ALL_LIST_ELEMENTS(lookup->interface_name_list,
 				       node, nnode, name)) {
 			XFREE(MTYPE_PBR_IPTABLE_IFNAME, name);
-			list_delete_node(iptable->interface_name_list,
+			list_delete_node(lookup->interface_name_list,
 					 node);
 		}
-		list_delete(&iptable->interface_name_list);
+		list_delete(&lookup->interface_name_list);
 		XFREE(MTYPE_PBR_IPTABLE, lookup);
 	} else
 		zlog_debug("%s: IPTable being deleted we know nothing about",

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -196,6 +196,8 @@ struct zebra_pbr_ipset *zebra_pbr_lookup_ipset_pername(char *ipsetname);
 void zebra_pbr_add_ipset_entry(struct zebra_pbr_ipset_entry *ipset);
 void zebra_pbr_del_ipset_entry(struct zebra_pbr_ipset_entry *ipset);
 
+void zebra_pbr_iptable_interface_name_list_free(void *arg);
+
 void zebra_pbr_add_iptable(struct zebra_pbr_iptable *iptable);
 void zebra_pbr_del_iptable(struct zebra_pbr_iptable *iptable);
 void zebra_pbr_process_iptable(struct zebra_dplane_ctx *ctx);

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -21,7 +21,8 @@ extern "C" {
 #endif
 
 /* Memory type for PBR objects. */
-DECLARE_MTYPE(PBR_OBJ);
+DECLARE_MTYPE(PBR_IPTABLE);
+
 
 struct zebra_pbr_action {
 	afi_t afi;


### PR DESCRIPTION
We are obviously doing deleting on wrong object.

> Direct leak of 40 byte(s) in 1 object(s) allocated from:
>     #0 0x7fcf718b4a57 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
>     #1 0x7fcf7126f8dd in qcalloc lib/memory.c:105
>     #2 0x7fcf7124401a in list_new lib/linklist.c:49
>     #3 0x55771621d86d in pbr_iptable_alloc_intern zebra/zebra_pbr.c:1015
>     #4 0x7fcf71217d79 in hash_get lib/hash.c:147
>     #5 0x55771621dad3 in zebra_pbr_add_iptable zebra/zebra_pbr.c:1030
>     #6 0x55771614d00c in zread_iptable zebra/zapi_msg.c:4131
>     #7 0x55771614e586 in zserv_handle_commands zebra/zapi_msg.c:4424
>     #8 0x5577162dae2c in zserv_process_messages zebra/zserv.c:521
>     #9 0x7fcf7137798e in event_call lib/event.c:2011
>     #10 0x7fcf71242ff1 in frr_run lib/libfrr.c:1216
>     #11 0x5577160e4d6d in main zebra/main.c:540
>     #12 0x7fcf70c29d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
>
> Indirect leak of 24 byte(s) in 1 object(s) allocated from:
>     #0 0x7fcf718b4a57 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
>     #1 0x7fcf7126f8dd in qcalloc lib/memory.c:105
>     #2 0x7fcf71244129 in listnode_new lib/linklist.c:71
>     #3 0x7fcf71244238 in listnode_add lib/linklist.c:92
>     #4 0x55771621d938 in pbr_iptable_alloc_intern zebra/zebra_pbr.c:1019
>     #5 0x7fcf71217d79 in hash_get lib/hash.c:147
>     #6 0x55771621dad3 in zebra_pbr_add_iptable zebra/zebra_pbr.c:1030
>     #7 0x55771614d00c in zread_iptable zebra/zapi_msg.c:4131
>     #8 0x55771614e586 in zserv_handle_commands zebra/zapi_msg.c:4424
>     #9 0x5577162dae2c in zserv_process_messages zebra/zserv.c:521
>     #10 0x7fcf7137798e in event_call lib/event.c:2011
>     #11 0x7fcf71242ff1 in frr_run lib/libfrr.c:1216
>     #12 0x5577160e4d6d in main zebra/main.c:540
>     #13 0x7fcf70c29d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Fixes: f80ec7e3d6 ("zebra: handle iptable list of interfaces")
Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>