### PR TITLE
End psp flavor

### DIFF
--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -203,6 +203,8 @@ keyword. At present, no sharp commands will be preserved in the config.
    router# sharp install seg6local-routes 1::9 nexthop-seg6local dum0 uN usid-block-length 40 usid-function-length 8 1
    router# sharp install seg6local-routes 1::10 nexthop-seg6local dum0 uA 2001::1 usid-block-length 40 usid-function-length 8 1
    router# sharp install seg6local-routes 1::11 nexthop-seg6local dum0 End_B6_Encap nexthop-seg6 2001::5 encap 2001:a::b:c 2001:a::d:e 1
+   router# sharp install seg6local-routes 1::12 nexthop-seg6local dum0 End psp 1
+   router# sharp install seg6local-routes 1::13 nexthop-seg6local dum0 uN psp 1
 
    router# show ipv6 route
    D>* 1::1/128 [150/0] is directly connected, dum0, seg6local End -, weight 1, 00:00:05
@@ -216,6 +218,8 @@ keyword. At present, no sharp commands will be preserved in the config.
    D>* 1::9/128 [150/0] is directly connected, dum0, seg6local End -, weight 1, 00:00:12
    D>* 1::10/128 [150/0] is directly connected, dum0, seg6local End.X nh6 2001::1, weight 1, 00:00:05
    D>* 1::11/128 [150/0] is directly connected, dum0, seg6local End.B6.Encap nh6 2001::5, seg6 2001:a::b:c,2001:a::d:e, weight 1, 00:00:04
+   D>* 1::12/128 [150/0] is directly connected, dum0, seg6local End (PSP), weight 1, 00:11:40
+   D>* 1::13/128 [150/0] is directly connected, dum0, seg6local uN (PSP), weight 1, 00:11:21
 
    bash# ip -6 route
    1::1  encap seg6local action End dev dum0 proto 194 metric 20 pref medium
@@ -229,6 +233,8 @@ keyword. At present, no sharp commands will be preserved in the config.
    1::9  encap seg6local action End flavors next-csid lblen 40 nflen 8 dev dum0 proto 194 metric 20 pref medium
    1::10  encap seg6local action End.X nh6 2001::1 flavors next-csid lblen 40 nflen 8 dev dum0 proto 194 metric 20 pref medium
    1::11  encap seg6local action End.B6.Encaps segs 2 [ 2001:a::b:c 2001:a::d:e ] via 2001::5 dev dum0 proto 194 metric 20 pref medium
+   1::12  encap seg6local action End flavors psp dev dum0 proto 194 metric 20 pref medium
+   1::13  encap seg6local action End flavors psp,next-csid lblen 32 nflen 16 dev dum0 proto 194 metric 20 pref medium
 
 
 .. clicmd:: show sharp segment-routing srv6

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -1554,11 +1554,8 @@ static int isis_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 				}
 
 				/* Allocate new SRv6 End SID */
-				behavior =
-					(CHECK_FLAG(locator->flags,
-						    SRV6_LOCATOR_USID))
-						? SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID
-						: SRV6_ENDPOINT_BEHAVIOR_END;
+				behavior = SRV6_BEHAVIOR_CODEPOINT(SRV6_ENDPOINT_BEHAVIOR_END,
+								   locator->flags);
 				sid = isis_srv6_sid_alloc(area,
 							  area->srv6db
 								  .srv6_locator,

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -981,12 +981,25 @@ void isis_zebra_srv6_sid_install(struct isis_area *area,
 		action = ZEBRA_SEG6_LOCAL_ACTION_END;
 		prefixlen = IPV6_MAX_BITLEN;
 		break;
+	case SRV6_ENDPOINT_BEHAVIOR_END_PSP:
+		action = ZEBRA_SEG6_LOCAL_ACTION_END;
+		prefixlen = IPV6_MAX_BITLEN;
+		SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_PSP);
+		break;
 	case SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID:
 		action = ZEBRA_SEG6_LOCAL_ACTION_END;
 		prefixlen = sid->locator->block_bits_length +
 			    sid->locator->node_bits_length;
 		SET_SRV6_FLV_OP(ctx.flv.flv_ops,
 				ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
+		ctx.flv.lcblock_len = sid->locator->block_bits_length;
+		ctx.flv.lcnode_func_len = sid->locator->node_bits_length;
+		break;
+	case SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP:
+		action = ZEBRA_SEG6_LOCAL_ACTION_END;
+		prefixlen = sid->locator->block_bits_length + sid->locator->node_bits_length;
+		SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
+		SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_PSP);
 		ctx.flv.lcblock_len = sid->locator->block_bits_length;
 		ctx.flv.lcnode_func_len = sid->locator->node_bits_length;
 		break;
@@ -1000,9 +1013,7 @@ void isis_zebra_srv6_sid_install(struct isis_area *area,
 	case SRV6_ENDPOINT_BEHAVIOR_END_DT4_USID:
 	case SRV6_ENDPOINT_BEHAVIOR_END_DT46_USID:
 	case SRV6_ENDPOINT_BEHAVIOR_OPAQUE:
-	case SRV6_ENDPOINT_BEHAVIOR_END_PSP:
 	case SRV6_ENDPOINT_BEHAVIOR_END_PSP_USD:
-	case SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP:
 	case SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP_USD:
 	case SRV6_ENDPOINT_BEHAVIOR_END_X_PSP:
 	case SRV6_ENDPOINT_BEHAVIOR_END_X_PSP_USD:
@@ -1053,9 +1064,11 @@ void isis_zebra_srv6_sid_uninstall(struct isis_area *area,
 
 	switch (sid->behavior) {
 	case SRV6_ENDPOINT_BEHAVIOR_END:
+	case SRV6_ENDPOINT_BEHAVIOR_END_PSP:
 		prefixlen = IPV6_MAX_BITLEN;
 		break;
 	case SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID:
+	case SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP:
 		prefixlen = sid->locator->block_bits_length +
 			    sid->locator->node_bits_length;
 		break;
@@ -1069,9 +1082,7 @@ void isis_zebra_srv6_sid_uninstall(struct isis_area *area,
 	case SRV6_ENDPOINT_BEHAVIOR_END_DT4_USID:
 	case SRV6_ENDPOINT_BEHAVIOR_END_DT46_USID:
 	case SRV6_ENDPOINT_BEHAVIOR_OPAQUE:
-	case SRV6_ENDPOINT_BEHAVIOR_END_PSP:
 	case SRV6_ENDPOINT_BEHAVIOR_END_PSP_USD:
-	case SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP:
 	case SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP_USD:
 	case SRV6_ENDPOINT_BEHAVIOR_END_X_PSP:
 	case SRV6_ENDPOINT_BEHAVIOR_END_X_PSP_USD:

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -1502,12 +1502,12 @@ void nexthop_vty_helper(struct vty *vty, const struct nexthop *nexthop,
 				      nexthop->nh_srv6->seg6local_action);
 		if (nexthop->nh_srv6->seg6local_action !=
 		    ZEBRA_SEG6_LOCAL_ACTION_UNSPEC)
-			vty_out(vty, ", seg6local %s %s",
+			vty_out(vty, ", seg6local %s%s%s",
 				seg6local_action2str_with_next_csid(nexthop->nh_srv6->seg6local_action,
 								    seg6local_has_next_csid(
 									    &nexthop->nh_srv6
 										     ->seg6local_ctx)),
-				buf);
+				buf[0] == '\0' ? "" : " ", buf);
 		if (nexthop->nh_srv6->seg6_segs &&
 		    IPV6_ADDR_CMP(&nexthop->nh_srv6->seg6_segs->seg[0],
 				  &in6addr_any)) {

--- a/lib/srv6.c
+++ b/lib/srv6.c
@@ -148,7 +148,7 @@ static char *seg6local_flavors2str(char *str, size_t size,
 							  ZEBRA_SEG6_LOCAL_FLV_OP_USD))
 		return str;
 
-	len += snprintf(str + len, size - len, " (");
+	len += snprintf(str + len, size - len, "(");
 	if (CHECK_SRV6_FLV_OP(flv_info->flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_PSP)) {
 		len += snprintf(str + len, size - len, "%sPSP", first ? "" : "/");
 		first = false;

--- a/lib/srv6.h
+++ b/lib/srv6.h
@@ -214,6 +214,26 @@ enum srv6_endpoint_behavior_codepoint {
 	SRV6_ENDPOINT_BEHAVIOR_OPAQUE           = 0xFFFF,
 };
 
+macro_inline uint16_t srv6_behavior_codepoint_get(enum srv6_endpoint_behavior_codepoint _codepoint,
+						  uint8_t _flags)
+{
+	if (_codepoint == SRV6_ENDPOINT_BEHAVIOR_END) {
+		if (CHECK_FLAG(_flags, SRV6_LOCATOR_USID)) {
+			if (CHECK_FLAG(_flags, SRV6_LOCATOR_PSP))
+				return SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID_PSP;
+			else
+				return SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID;
+		}
+		if (CHECK_FLAG(_flags, SRV6_LOCATOR_PSP))
+			return SRV6_ENDPOINT_BEHAVIOR_END_PSP;
+		return SRV6_ENDPOINT_BEHAVIOR_END;
+	}
+	return _codepoint;
+}
+
+#define SRV6_BEHAVIOR_CODEPOINT(_codepoint, _flags)                                                \
+	srv6_behavior_codepoint_get((_codepoint), (_flags))
+
 /*
  * Return true if next-csid behavior is used, false otherwise
  */

--- a/lib/srv6.h
+++ b/lib/srv6.h
@@ -147,6 +147,7 @@ struct srv6_locator {
 
 	uint8_t flags;
 #define SRV6_LOCATOR_USID (1 << 0) /* The SRv6 Locator is a uSID Locator */
+#define SRV6_LOCATOR_PSP  (1 << 1) /* The SRv6 Locator has the PSP flavor */
 
 	/* Pointer to the SID format. */
 	struct srv6_sid_format *sid_format;

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -558,6 +558,7 @@ DEFPY (install_seg6local_routes,
 	      End_DT46$seg6l_enddt46 (1-4294967295)$seg6l_enddt46_table|\
 	      uDT46$seg6l_micro_enddt46 (1-4294967295)$seg6l_micro_enddt46_table>\
 	      [usid-block-length (1-128)$lcblen] [usid-function-length (1-128)$lcfunclen] \
+	      [psp-flavor$psp_flavor] \
 	  (1-1000000)$routes [repeat (2-1000)$rpt]",
        "Sharp routing Protocol\n"
        "install some routes\n"
@@ -601,6 +602,7 @@ DEFPY (install_seg6local_routes,
        "Value in bits\n"
        "uSID node Function length\n"
        "Value in bits\n"
+       "Add the PSP flavor\n"
        "How many to create\n"
        "Should we repeat this command\n"
        "How many times to repeat this command\n")
@@ -693,8 +695,13 @@ DEFPY (install_seg6local_routes,
 	} else if (seg6l_micro_end) {
 		action = ZEBRA_SEG6_LOCAL_ACTION_END;
 		SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
-	} else
+		if (psp_flavor)
+			SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_PSP);
+	} else {
 		action = ZEBRA_SEG6_LOCAL_ACTION_END;
+		if (psp_flavor)
+			SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_PSP);
+	}
 
 	if (CHECK_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID)) {
 		if (lcblen)

--- a/tests/topotests/isis_srv6_topo1/rt1/step1/show_ipv6_route.ref
+++ b/tests/topotests/isis_srv6_topo1/rt1/step1/show_ipv6_route.ref
@@ -218,6 +218,9 @@
           "active":true,
           "seg6local":{
             "action":"uN"
+          },
+          "seg6localContext":{
+            "flavors":["psp"]
           }
         }
       ]

--- a/tests/topotests/isis_srv6_topo1/rt1/zebra.conf
+++ b/tests/topotests/isis_srv6_topo1/rt1/zebra.conf
@@ -19,6 +19,7 @@ segment-routing
    locator loc1
     prefix fc00:0:1::/48 block-len 32 node-len 16 func-bits 16
     behavior usid
+    flavor psp
   !
  !
 !

--- a/tests/topotests/isis_srv6_topo1/rt2/step1/show_ipv6_route.ref
+++ b/tests/topotests/isis_srv6_topo1/rt2/step1/show_ipv6_route.ref
@@ -254,6 +254,9 @@
           "active":true,
           "seg6local":{
             "action":"uN"
+          },
+          "seg6localContext":{
+            "flavors":["psp"]
           }
         }
       ]

--- a/tests/topotests/isis_srv6_topo1/rt2/zebra.conf
+++ b/tests/topotests/isis_srv6_topo1/rt2/zebra.conf
@@ -25,6 +25,7 @@ segment-routing
    locator loc1
     prefix fc00:0:2::/48 block-len 32 node-len 16 func-bits 16
     behavior usid
+    flavor psp
   !
  !
 !

--- a/tests/topotests/isis_srv6_topo1/rt3/step1/show_ipv6_route.ref
+++ b/tests/topotests/isis_srv6_topo1/rt3/step1/show_ipv6_route.ref
@@ -254,6 +254,9 @@
           "active":true,
           "seg6local":{
             "action":"uN"
+          },
+          "seg6localContext":{
+            "flavors":["psp"]
           }
         }
       ]

--- a/tests/topotests/isis_srv6_topo1/rt3/zebra.conf
+++ b/tests/topotests/isis_srv6_topo1/rt3/zebra.conf
@@ -24,6 +24,7 @@ segment-routing
    locator loc1
     prefix fc00:0:3::/48 block-len 32 node-len 16 func-bits 16
     behavior usid
+    flavor psp
   !
  !
 !

--- a/tests/topotests/isis_srv6_topo1/rt4/step1/show_ipv6_route.ref
+++ b/tests/topotests/isis_srv6_topo1/rt4/step1/show_ipv6_route.ref
@@ -254,6 +254,9 @@
           "active":true,
           "seg6local":{
             "action":"uN"
+          },
+          "seg6localContext":{
+            "flavors":["psp"]
           }
         }
       ]

--- a/tests/topotests/isis_srv6_topo1/rt4/zebra.conf
+++ b/tests/topotests/isis_srv6_topo1/rt4/zebra.conf
@@ -27,6 +27,7 @@ segment-routing
    locator loc1
     prefix fc00:0:4::/48 block-len 32 node-len 16 func-bits 16
     behavior usid
+    flavor psp
   !
  !
 !

--- a/tests/topotests/isis_srv6_topo1/rt5/step1/show_ipv6_route.ref
+++ b/tests/topotests/isis_srv6_topo1/rt5/step1/show_ipv6_route.ref
@@ -254,6 +254,9 @@
           "active":true,
           "seg6local":{
             "action":"uN"
+          },
+          "seg6localContext":{
+            "flavors":["psp"]
           }
         }
       ]

--- a/tests/topotests/isis_srv6_topo1/rt5/zebra.conf
+++ b/tests/topotests/isis_srv6_topo1/rt5/zebra.conf
@@ -27,6 +27,7 @@ segment-routing
    locator loc1
     prefix fc00:0:5::/48 block-len 32 node-len 16 func-bits 16
     behavior usid
+    flavor psp
   !
  !
 !

--- a/tests/topotests/isis_srv6_topo1/rt6/step1/show_ipv6_route.ref
+++ b/tests/topotests/isis_srv6_topo1/rt6/step1/show_ipv6_route.ref
@@ -218,6 +218,9 @@
           "active":true,
           "seg6local":{
             "action":"uN"
+          },
+          "seg6localContext":{
+            "flavors":["psp"]
           }
         }
       ]

--- a/tests/topotests/isis_srv6_topo1/rt6/zebra.conf
+++ b/tests/topotests/isis_srv6_topo1/rt6/zebra.conf
@@ -25,6 +25,7 @@ segment-routing
    locator loc1
     prefix fc00:0:6::/48 block-len 32 node-len 16 func-bits 16
     behavior usid
+    flavor psp
   !
  !
 !


### PR DESCRIPTION
Add FRRouting support for PSP flavor to End behavior.
Unfortunately, kernel does not have PSP flavor for other behaviors.
So lets just support End for now.