### PR TITLE
Add v4-via-v6 nexthop support to staticd

### DIFF
--- a/doc/user/static.rst
+++ b/doc/user/static.rst
@@ -46,8 +46,8 @@ a static prefix and gateway, with several possible forms.
    NETWORK is destination prefix with a valid v4 or v6 network based upon
    initial form of the command.
    
-   GATEWAY is the IP address to use as next-hop for the prefix. Currently, it must match
-   the v4 or v6 route type specified at the start of the command.
+   GATEWAY is the IP address to use as next-hop for the prefix. Routes of type v4 can use v4 and v6 next-hops,
+   v6 routes only support v6 next-hops.
 
    IFNAME is the name of the interface to use as next-hop. If only IFNAME is specified
    (without GATEWAY), a connected route will be created.


### PR DESCRIPTION
Routing v4 over an v6 nexthop is already well supported within zebra (and FRR). This adds support to staticd, allowing an IPv6 nexthop to be provided to ip route statements. For this the commands are extended and the address family is parsed from the parameter.

When receiving nht updates from zebra, both AFIs are checked because prefixes could exist in both. Additionally when route_node is known, family of prefix is used instead of nexthop.

see https://datatracker.ietf.org/doc/draft-chroboczek-intarea-v4-via-v6/