### PR TITLE
lib,bgpd: clean up clang warnings

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -3995,7 +3995,7 @@ void bgp_process_packet(struct event *thread)
 	uint32_t processed = 0, curr_connection_processed = 0;
 	bool more_work = false;
 	size_t count;
-	uint32_t total_packets_to_process, total_processed = 0;
+	uint32_t total_packets_to_process;
 
 	frr_with_mutex (&bm->peer_connection_mtx)
 		connection = peer_connection_fifo_pop(&bm->connection_fifo);
@@ -4011,7 +4011,6 @@ void bgp_process_packet(struct event *thread)
 	fsm_update_result = 0;
 
 	while ((processed < total_packets_to_process) && connection) {
-		total_processed++;
 		/* Guard against scheduled events that occur after peer deletion. */
 		if (connection->status == Deleted || connection->status == Clearing) {
 			frr_with_mutex (&bm->peer_connection_mtx)

--- a/lib/resolver.c
+++ b/lib/resolver.c
@@ -282,7 +282,7 @@ static void resolver_cb_literal(struct event *t)
 	callback = query->callback;
 	query->callback = NULL;
 
-	callback(query, ARES_SUCCESS, 1, &query->literal_addr);
+	callback(query, NULL, 1, &query->literal_addr);
 }
 
 void resolver_resolve(struct resolver_query *query, int af, vrf_id_t vrf_id,


### PR DESCRIPTION
Clean up a couple of clang compiler warnings (this was clang 18)
