### PR TITLE
bgpd: Clean extended communities for VRF routes imported from EVPN

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -863,6 +863,9 @@ unsigned int attrhash_key_make(const void *p)
 	key = jhash(attr->mp_nexthop_local.s6_addr, IPV6_MAX_BYTELEN, key);
 	MIX3(attr->nh_ifindex, attr->nh_lla_ifindex, attr->distance);
 	MIX3(attr->bh_type, attr->otc, bgp_attr_get_aigp_metric(attr));
+	MIX3(attr->mm_seqnum, attr->df_alg, attr->df_pref);
+	MIX(attr->encap_tunneltype);
+	key = jhash(&attr->rmac, sizeof(attr->rmac), key);
 
 	return key;
 }
@@ -912,6 +915,7 @@ bool attrhash_cmp(const void *p1, const void *p2)
 		    overlay_index_same(attr1, attr2) &&
 		    !memcmp(&attr1->esi, &attr2->esi, sizeof(esi_t)) &&
 		    attr1->es_flags == attr2->es_flags &&
+		    attr1->mm_seqnum == attr2->mm_seqnum &&
 		    attr1->mm_sync_seqnum == attr2->mm_sync_seqnum &&
 		    attr1->df_pref == attr2->df_pref &&
 		    attr1->df_alg == attr2->df_alg &&
@@ -923,7 +927,9 @@ bool attrhash_cmp(const void *p1, const void *p2)
 		    srv6_vpn_same(attr1->srv6_vpn, attr2->srv6_vpn) &&
 		    attr1->srte_color == attr2->srte_color &&
 		    attr1->nh_type == attr2->nh_type &&
-		    attr1->bh_type == attr2->bh_type && attr1->otc == attr2->otc)
+		    attr1->bh_type == attr2->bh_type &&
+		    attr1->otc == attr2->otc &&
+		    !memcmp(&attr1->rmac, &attr2->rmac, sizeof(struct ethaddr)))
 			return true;
 	}
 

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -405,6 +405,9 @@ extern bool ecommunity_strip(struct ecommunity *ecom, uint8_t type,
 			     uint8_t subtype);
 extern struct ecommunity *ecommunity_new(void);
 extern bool ecommunity_strip_non_transitive(struct ecommunity *ecom);
+extern struct ecommunity *ecommunity_filter(struct ecommunity *ecom,
+					    bool (*filter)(uint8_t *val, uint8_t usize, void *arg),
+					    void *arg);
 extern bool ecommunity_del_val(struct ecommunity *ecom,
 			       struct ecommunity_val *eval);
 struct bgp_pbr_entry_action;

--- a/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_ipv4_routes_detail.json
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_ipv4_routes_detail.json
@@ -1,0 +1,23 @@
+{
+    "vrfName": "r1-vrf-101",
+    "routerId": "192.168.102.21",
+    "localAS": 65000,
+    "routes": {
+        "192.168.101.41/32": [
+            {
+                "importedFrom": "65000:201",
+                "vni": "101",
+                "valid": true,
+                "extendedCommunity": null,
+                "nexthops": [
+                    {
+                        "ip": "192.168.100.41",
+                        "hostname": "r2",
+                        "afi": "ipv4",
+                        "used": true
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_ipv6_routes_detail.json
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_ipv6_routes_detail.json
@@ -1,0 +1,24 @@
+{
+    "vrfName": "r1-vrf-101",
+    "routerId": "192.168.102.21",
+    "localAS": 65000,
+    "routes": {
+        "fd00::2/128": [
+            {
+                "importedFrom": "65000:201",
+                "vni": "101",
+                "valid": true,
+                "extendedCommunity": null,
+                "nexthops": [
+                    {
+                        "ip": "::ffff:192.168.100.41",
+                        "hostname": "r2",
+                        "afi": "ipv6",
+                        "scope": "global",
+                        "used": true
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/topotests/bgp_evpn_rt5/r2/bgp_vrf_ipv4_routes_detail.json
+++ b/tests/topotests/bgp_evpn_rt5/r2/bgp_vrf_ipv4_routes_detail.json
@@ -1,0 +1,23 @@
+{
+    "vrfName": "r2-vrf-101",
+    "routerId": "192.168.101.41",
+    "localAS": 65000,
+    "routes": {
+        "192.168.102.21/32": [
+            {
+                "importedFrom": "65000:101",
+                "vni": "101",
+                "valid": true,
+                "extendedCommunity": null,
+                "nexthops": [
+                    {
+                        "ip": "192.168.100.21",
+                        "hostname": "r1",
+                        "afi": "ipv4",
+                        "used": true
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/topotests/bgp_evpn_rt5/r2/bgp_vrf_ipv6_routes_detail.json
+++ b/tests/topotests/bgp_evpn_rt5/r2/bgp_vrf_ipv6_routes_detail.json
@@ -1,0 +1,24 @@
+{
+    "vrfName": "r2-vrf-101",
+    "routerId": "192.168.101.41",
+    "localAS": 65000,
+    "routes": {
+        "fd00::1/128": [
+            {
+                "importedFrom": "65000:101",
+                "vni": "101",
+                "valid": true,
+                "extendedCommunity": null,
+                "nexthops": [
+                    {
+                        "ip": "::ffff:192.168.100.21",
+                        "hostname": "r1",
+                        "afi": "ipv6",
+                        "scope": "global",
+                        "used": true
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/topotests/bgp_evpn_rt5/test_bgp_evpn.py
+++ b/tests/topotests/bgp_evpn_rt5/test_bgp_evpn.py
@@ -280,6 +280,37 @@ def test_protocols_dump_info():
     logger.info(output)
 
 
+def test_bgp_vrf_routes():
+    """
+    Check routes are correctly imported to VRF
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    for rname in ("r1", "r2"):
+        router = tgen.gears[rname]
+        for af in ("ipv4", "ipv6"):
+            json_file = "{}/{}/bgp_vrf_{}_routes_detail.json".format(
+                CWD, router.name, af
+            )
+            if not os.path.isfile(json_file):
+                assert 0, "bgp vrf routes file not found"
+
+            expected = json.loads(open(json_file).read())
+            test_func = partial(
+                topotest.router_json_cmp,
+                router,
+                "show bgp vrf {}-vrf-101 {} unicast detail json".format(
+                    router.name, af
+                ),
+                expected,
+            )
+            _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+            assertmsg = '"{}" JSON output mismatches'.format(router.name)
+            assert result is None, assertmsg
+
+
 def test_router_check_ip():
     """
     Check routes are correctly installed


### PR DESCRIPTION
According to draft-ietf-bess-evpn-ipvpn-interworking-13 §5.2 [1], strip
the following extended communities for VRF routes imported from EVPN.

- BGP Encapsulation extended communities.
- Route Target extended communities.
- All the extended communities of type EVPN.

[1] https://datatracker.ietf.org/doc/html/draft-ietf-bess-evpn-ipvpn-interworking-13#section-5.2-3.4.1