### PR TITLE
bgpd: Fix use-after-free in debug update for EVPN

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5347,11 +5347,10 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 			    peer->sort == BGP_PEER_EBGP &&
 			    CHECK_FLAG(pi->flags, BGP_PATH_HISTORY)) {
 				if (unlikely(bgp_debug_update(peer, p, NULL, 1))) {
-					bgp_debug_rdpfxpath2str(
-						afi, safi, prd, p, label,
-						num_labels, addpath_id ? 1 : 0,
-						addpath_id, evpn, pfx_buf,
-						sizeof(pfx_buf));
+					bgp_debug_rdpfxpath2str(afi, safi, prd, p, label,
+								num_labels, addpath_id ? 1 : 0,
+								addpath_id, attr_new->evpn_overlay,
+								pfx_buf, sizeof(pfx_buf));
 					zlog_debug("%pBP rcvd %s", peer,
 						   pfx_buf);
 				}
@@ -5373,11 +5372,10 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 						peer->rcvd_attr_printed = true;
 					}
 
-					bgp_debug_rdpfxpath2str(
-						afi, safi, prd, p, label,
-						num_labels, addpath_id ? 1 : 0,
-						addpath_id, evpn, pfx_buf,
-						sizeof(pfx_buf));
+					bgp_debug_rdpfxpath2str(afi, safi, prd, p, label,
+								num_labels, addpath_id ? 1 : 0,
+								addpath_id, attr_new->evpn_overlay,
+								pfx_buf, sizeof(pfx_buf));
 					zlog_debug(
 						"%pBP rcvd %s...duplicate ignored",
 						peer, pfx_buf);
@@ -5402,10 +5400,10 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 		/* Withdraw/Announce before we fully processed the withdraw */
 		if (CHECK_FLAG(pi->flags, BGP_PATH_REMOVED)) {
 			if (unlikely(bgp_debug_update(peer, p, NULL, 1))) {
-				bgp_debug_rdpfxpath2str(
-					afi, safi, prd, p, label, num_labels,
-					addpath_id ? 1 : 0, addpath_id, evpn,
-					pfx_buf, sizeof(pfx_buf));
+				bgp_debug_rdpfxpath2str(afi, safi, prd, p, label, num_labels,
+							addpath_id ? 1 : 0, addpath_id,
+							attr_new->evpn_overlay, pfx_buf,
+							sizeof(pfx_buf));
 				zlog_debug(
 					"%pBP rcvd %s, flapped quicker than processing",
 					peer, pfx_buf);
@@ -5430,10 +5428,9 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 
 		/* Received Logging. */
 		if (unlikely(bgp_debug_update(peer, p, NULL, 1))) {
-			bgp_debug_rdpfxpath2str(afi, safi, prd, p, label,
-						num_labels, addpath_id ? 1 : 0,
-						addpath_id, evpn, pfx_buf,
-						sizeof(pfx_buf));
+			bgp_debug_rdpfxpath2str(afi, safi, prd, p, label, num_labels,
+						addpath_id ? 1 : 0, addpath_id,
+						attr_new->evpn_overlay, pfx_buf, sizeof(pfx_buf));
 			zlog_debug("%pBP rcvd %s", peer, pfx_buf);
 		}
 
@@ -5661,9 +5658,9 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 			peer->rcvd_attr_printed = true;
 		}
 
-		bgp_debug_rdpfxpath2str(afi, safi, prd, p, label, num_labels,
-					addpath_id ? 1 : 0, addpath_id, evpn,
-					pfx_buf, sizeof(pfx_buf));
+		bgp_debug_rdpfxpath2str(afi, safi, prd, p, label, num_labels, addpath_id ? 1 : 0,
+					addpath_id, attr_new->evpn_overlay, pfx_buf,
+					sizeof(pfx_buf));
 		zlog_debug("%pBP rcvd %s", peer, pfx_buf);
 	}
 
@@ -5767,9 +5764,9 @@ filtered:
 			peer->rcvd_attr_printed = true;
 		}
 
-		bgp_debug_rdpfxpath2str(afi, safi, prd, p, label, num_labels,
-					addpath_id ? 1 : 0, addpath_id, evpn,
-					pfx_buf, sizeof(pfx_buf));
+		bgp_debug_rdpfxpath2str(afi, safi, prd, p, label, num_labels, addpath_id ? 1 : 0,
+					addpath_id, attr_new->evpn_overlay, pfx_buf,
+					sizeof(pfx_buf));
 		zlog_debug("%pBP rcvd UPDATE about %s -- DENIED due to: %s",
 			   peer, pfx_buf, reason);
 	}


### PR DESCRIPTION
bgp_debug_rdpfxpath2str used bgp_route_evpn evpn, which was already interned & freed. Changing evpn to internet attr_new->evpn_overlay.

fixes #18663 