### PR TITLE
bgpd: fix misused rfapi conditional

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -8972,7 +8972,7 @@ void bgp_terminate(void)
 	EVENT_OFF(bm->t_bgp_zebra_l3_vni);
 
 	bgp_mac_finish();
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	rfapi_terminate();
 #endif
 }


### PR DESCRIPTION
```
bgpd/bgpd.c:8975:5: error: "ENABLE_BGP_VNC" is not defined, evaluates to 0 [-Werror=undef]
 8975 | #if ENABLE_BGP_VNC
```

Fixes: FRRouting#18546
Fixes: 1629c05924fe9 ("bgpd: rfapi: track outstanding rib and import timers, free mem at exit")
Cc: @gpziemba