### PR TITLE
pimd: Fix for crash during networking restart

### DIFF
--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -271,6 +271,8 @@ void pim_vrf_terminate(void)
 	}
 
 	vrf_terminate();
+	/* Delete the vxlan_info.work_list as all the VRFs are deleted*/
+	pim_vxlan_work_list_delete();
 }
 
 bool pim_msdp_log_neighbor_events(const struct pim_instance *pim)

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -1249,9 +1249,14 @@ void pim_vxlan_exit(struct pim_instance *pim)
 {
 	hash_clean_and_free(&pim->vxlan.sg_hash,
 			    (void (*)(void *))pim_vxlan_sg_del_item);
+}
 
-	if (vxlan_info.work_list)
+void pim_vxlan_work_list_delete(void)
+{
+	if (vxlan_info.work_list) {
 		list_delete(&vxlan_info.work_list);
+		UNSET_FLAG(vxlan_info.flags, PIM_VXLANF_WORK_INITED);
+	}
 }
 
 void pim_vxlan_terminate(void)

--- a/pimd/pim_vxlan_instance.h
+++ b/pimd/pim_vxlan_instance.h
@@ -33,5 +33,6 @@ struct pim_vxlan_instance {
 
 extern void pim_vxlan_init(struct pim_instance *pim);
 extern void pim_vxlan_exit(struct pim_instance *pim);
+void pim_vxlan_work_list_delete(void);
 
 #endif /* PIM_VXLAN_INSTANCE_H */


### PR DESCRIPTION
During vrf delete, the vxlan_info.work_list
linked list was deleted which is a global list
containing the SGs for all the VRFs.

If two vrfs are configured, vrf a and vrf b and
both has SGs assocaited with them which are
inserted in the vxlan_info.work_list. Now if
vrf a is deleted, it deletes the work_list also.
Due to this when any SG add or del comes for vrf b it tries to access the work_list and crashes.

Fix
Delete the vxlan_info.work_list only when all the
VRFs are terminated and unset the vxlan_info.flags so if new add cmd comes it re-allocates the work_list.