### PR TITLE
lib,pimd,bgpd,bfdd: Fix clang 18 warnings

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -2518,7 +2518,7 @@ void sbfd_reflector_free(const uint32_t discr)
 	return;
 }
 
-void sbfd_reflector_flush()
+void sbfd_reflector_flush(void)
 {
 	sbfd_discr_iterate(_sbfd_reflector_free, NULL);
 	return;

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -3542,7 +3542,6 @@ static int bmp_bgp_attribute_updated(struct bgp *bgp, bool withdraw)
 	struct bmp_targets *bt;
 	struct listnode *node;
 	struct bmp_imported_bgp *bib;
-	int ret = 0;
 	struct stream *s = bmp_peerstate(bgp->peer_self, withdraw);
 	struct bmp *bmp;
 	afi_t afi;
@@ -3553,8 +3552,8 @@ static int bmp_bgp_attribute_updated(struct bgp *bgp, bool withdraw)
 
 	if (bmpbgp) {
 		frr_each (bmp_targets, &bmpbgp->targets, bt) {
-			ret = bmp_bgp_attribute_updated_instance(bt, &bmpbgp->vrf_state, bgp,
-								 withdraw, s);
+			bmp_bgp_attribute_updated_instance(bt, &bmpbgp->vrf_state, bgp,
+							   withdraw, s);
 			if (withdraw)
 				continue;
 			frr_each (bmp_session, &bt->sessions, bmp) {
@@ -3575,8 +3574,8 @@ static int bmp_bgp_attribute_updated(struct bgp *bgp, bool withdraw)
 			frr_each (bmp_imported_bgps, &bt->imported_bgps, bib) {
 				if (bgp_lookup_by_name(bib->name) != bgp)
 					continue;
-				ret += bmp_bgp_attribute_updated_instance(bt, &bib->vrf_state, bgp,
-									  withdraw, s);
+				bmp_bgp_attribute_updated_instance(bt, &bib->vrf_state, bgp,
+								   withdraw, s);
 				if (withdraw)
 					continue;
 				frr_each (bmp_session, &bt->sessions, bmp) {

--- a/lib/command_parse.y
+++ b/lib/command_parse.y
@@ -158,6 +158,14 @@
   ctx->docstr_start = ctx->docstr;
 }
 
+%{
+#ifdef __clang__
+# if __clang_major__ > 12
+#  pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+# endif
+#endif
+%}
+
 %%
 
 start:

--- a/pimd/pim_autorp.c
+++ b/pimd/pim_autorp.c
@@ -283,8 +283,8 @@ static bool autorp_recv_announcement(struct pim_autorp *autorp, uint8_t rpcnt, u
 		/* Ignore RP's limited to PIM version 1 or with an unknown version */
 		if (rp->pimver == AUTORP_PIM_V1 || rp->pimver == AUTORP_PIM_VUNKNOWN) {
 			if (PIM_DEBUG_AUTORP)
-				zlog_debug("%s: Ignoring unsupported PIM version (%u) in AutoRP Announcement for RP %pI4",
-					   __func__, rp->pimver, (in_addr_t *)&(rp->addr));
+				zlog_debug("%s: Ignoring unsupported PIM version (%u) in AutoRP Announcement for RP %pPA",
+					   __func__, rp->pimver, &rp_addr);
 			/* Update the offset to skip past the groups advertised for this RP */
 			offset += (AUTORP_GRPLEN * rp->grpcnt);
 			continue;
@@ -293,14 +293,14 @@ static bool autorp_recv_announcement(struct pim_autorp *autorp, uint8_t rpcnt, u
 		if (rp->grpcnt == 0) {
 			/* No groups?? */
 			if (PIM_DEBUG_AUTORP)
-				zlog_debug("%s: Announcement message has no groups for RP %pI4",
-					   __func__, (in_addr_t *)&(rp->addr));
+				zlog_debug("%s: Announcement message has no groups for RP %pPA",
+					   __func__, &rp_addr);
 			continue;
 		}
 
 		if ((buf_size - offset) < AUTORP_GRPLEN) {
-			zlog_warn("%s: Buffer underrun parsing groups for RP %pI4", __func__,
-				  (in_addr_t *)&(rp->addr));
+			zlog_warn("%s: Buffer underrun parsing groups for RP %pPA", __func__,
+				  &rp_addr);
 			return false;
 		}
 
@@ -765,14 +765,14 @@ static bool autorp_recv_discovery(struct pim_autorp *autorp, uint8_t rpcnt, uint
 		rp_addr.s_addr = rp->addr;
 
 		if (PIM_DEBUG_AUTORP)
-			zlog_debug("%s: Parsing RP %pI4 (grpcnt=%u)", __func__,
-				   (in_addr_t *)&rp->addr, rp->grpcnt);
+			zlog_debug("%s: Parsing RP %pPA (grpcnt=%u)", __func__, &rp_addr,
+				   rp->grpcnt);
 
 		/* Ignore RP's limited to PIM version 1 or with an unknown version */
 		if (rp->pimver == AUTORP_PIM_V1 || rp->pimver == AUTORP_PIM_VUNKNOWN) {
 			if (PIM_DEBUG_AUTORP)
 				zlog_debug("%s: Ignoring unsupported PIM version in AutoRP Discovery for RP %pI4",
-					   __func__, (in_addr_t *)&(rp->addr));
+					   __func__, &rp_addr);
 			/* Update the offset to skip past the groups advertised for this RP */
 			offset += (AUTORP_GRPLEN * rp->grpcnt);
 			continue;
@@ -781,17 +781,16 @@ static bool autorp_recv_discovery(struct pim_autorp *autorp, uint8_t rpcnt, uint
 		if (rp->grpcnt == 0) {
 			/* No groups?? */
 			if (PIM_DEBUG_AUTORP)
-				zlog_debug("%s: Discovery message has no groups for RP %pI4",
-					   __func__, (in_addr_t *)&(rp->addr));
+				zlog_debug("%s: Discovery message has no groups for RP %pPA",
+					   __func__, &rp_addr);
 			continue;
 		}
 
 		/* Make sure there is enough buffer to parse all the groups */
 		if ((buf_size - offset) < (AUTORP_GRPLEN * rp->grpcnt)) {
 			if (PIM_DEBUG_AUTORP)
-				zlog_debug("%s: Buffer underrun parsing groups for RP %pI4 (%u < %u)",
-					   __func__, (in_addr_t *)&(rp->addr),
-					   (uint32_t)(buf_size - offset),
+				zlog_debug("%s: Buffer underrun parsing groups for RP %pPA (%u < %u)",
+					   __func__, &rp_addr, (uint32_t)(buf_size - offset),
 					   (uint32_t)(AUTORP_GRPLEN * rp->grpcnt));
 			return false;
 		}
@@ -809,8 +808,7 @@ static bool autorp_recv_discovery(struct pim_autorp *autorp, uint8_t rpcnt, uint
 
 			if (PIM_DEBUG_AUTORP)
 				zlog_debug("%s: Parsing group %s%pFX for RP %pI4", __func__,
-					   (grp->negprefix ? "!" : ""), &grppfix,
-					   (in_addr_t *)&rp->addr);
+					   (grp->negprefix ? "!" : ""), &grppfix, &rp_addr);
 
 			if (!pim_autorp_add_rp(autorp, rp_addr, grppfix, NULL, holdtime))
 				success = false;
@@ -856,9 +854,9 @@ static bool autorp_recv_discovery(struct pim_autorp *autorp, uint8_t rpcnt, uint
 				prefix_list_entry_update_finish(ple);
 
 				if (PIM_DEBUG_AUTORP)
-					zlog_debug("%s: Parsing group %s%pFX for RP %pI4", __func__,
+					zlog_debug("%s: Parsing group %s%pFX for RP %pPA", __func__,
 						   (grp->negprefix ? "!" : ""), &ple->prefix,
-						   (in_addr_t *)&rp->addr);
+						   &rp_addr);
 			}
 
 			if (!pim_autorp_add_rp(autorp, rp_addr, grppfix, plname, holdtime))

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -1562,8 +1562,7 @@ int pim_bsm_process(struct interface *ifp, pim_sgaddr *sg, uint8_t *buf,
 		    (buf + PIM_BSM_HDR_LEN + PIM_MSG_HEADER_LEN),
 		    (buf_size - PIM_BSM_HDR_LEN - PIM_MSG_HEADER_LEN),
 		    frag_tag)) {
-		zlog_warn("BSM from %pPA failed to parse",
-			  (pim_addr *)&bshdr->bsr_addr.addr);
+		zlog_warn("BSM from %pPA failed to parse", &bsr_addr);
 		pim->bsm_dropped++;
 		return -1;
 	}
@@ -1802,7 +1801,7 @@ bool cand_addrsel_update(struct cand_addrsel *asel, struct vrf *vrf)
 
 	case CAND_ADDR_ANY:
 		is_any = true;
-		/* fallthru */
+		fallthrough;
 	case CAND_ADDR_LO:
 		FOR_ALL_INTERFACES (vrf, ifp) {
 			if (!if_is_up(ifp))


### PR DESCRIPTION
Clean up a variety of clang-18 warnings so that we can build with newer clangs.
