### PR TITLE
bgpd: do not crash when labels are empty

### DIFF
--- a/bgpd/bgp_errors.c
+++ b/bgpd/bgp_errors.c
@@ -486,6 +486,12 @@ static struct log_ref ferr_bgp_err[] = {
 		.suggestion = "Check connectivity to the peer and that it is not overloaded",
 	},
 	{
+		.code = EC_BGP_PATH_WITHOUT_LABEL,
+		.title = "Label not found for path",
+		.description = "BGP could not find the label for the specified path_info",
+		.suggestion = "Most likely a bug. This should never happen. Please try to build a reproducer and report.",
+	},
+	{
 		.code = END_FERR,
 	}
 };

--- a/bgpd/bgp_errors.h
+++ b/bgpd/bgp_errors.h
@@ -92,6 +92,7 @@ enum bgp_log_refs {
 	EC_BGP_NO_LL_ADDRESS_AVAILABLE,
 	EC_BGP_SENDQ_STUCK_WARN,
 	EC_BGP_SENDQ_STUCK_PROPER,
+	EC_BGP_PATH_WITHOUT_LABEL,
 };
 
 extern void bgp_error_init(void);

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -8135,8 +8135,13 @@ vni_t bgp_evpn_path_info_get_l3vni(const struct bgp_path_info *pi)
 
 	mpls_label_t *label = bgp_evpn_path_info_labels_get_l3vni(pi->extra->labels->label,
 								  pi->extra->labels->num_labels);
-	if (!label)
+	if (!label) {
+		/* Shouldn't happen: label not found in pi->extra */
+		flog_err(EC_BGP_PATH_WITHOUT_LABEL,
+			 "%s: path_info without label stack, label=%p, num_labels=%d", __func__,
+			 pi->extra->labels->label, pi->extra->labels->num_labels);
 		return 0;
+	}
 
 	return label2vni(label);
 }


### PR DESCRIPTION
bgp_evpn_path_info_get_l3vni() tries to find out l3vni associated with the path. However, under some circumstances, function bgp_evpn_path_info_labels_get_l3vni() may return NULL, and if it is passed to label2vni(), it causes abort(). bgpd crashes and is then restarted, which may lead to several seconds of lost connectivity to the host, until the daemon gets restarted and BGP sessions are reestablished.

This behaviour was observed in real life.  Here is a partial stack trace:

```
/usr/lib/x86_64-linux-gnu/frr/libfrr.so.0(_zlog_assert_failed+0xe9) [0x7f60dbff5299]
/usr/lib/frr/bgpd(bgp_evpn_mpath_has_dvni+0x90) [0x5649d89a9140]
/usr/lib/frr/bgpd(bgp_evpn_path_es_use_nhg+0x10b) [0x5649d89b12fb]
/usr/lib/frr/bgpd(bgp_zebra_announce+0x234) [0x5649d8a68214]
```
Bug-URL: #18678