### PR TITLE
bgpd: Treat the peer as not active due to BFD down only if established (backport #18562)

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4693,7 +4693,7 @@ bool peer_active(struct peer_connection *connection)
 		return false;
 
 	if (peer->bfd_config) {
-		if (bfd_session_is_down(peer->bfd_config->session))
+		if (peer_established(peer->connection) && bfd_session_is_down(peer->bfd_config->session))
 			return false;
 	}
 


### PR DESCRIPTION
backporting this to 10.3, since the regression was introduced in 10.2 and is also present in 10.3, but the commit doesn't apply since there has been some refactoring done in bgpd.c in the meanwhile.