### PR TITLE
bgpd: ensure that bgp_generate_updgrp_packets shares nicely

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -601,8 +601,8 @@ void bgp_generate_updgrp_packets(struct event *thread)
 			bgp_packet_add(connection, peer, s);
 			bpacket_queue_advance_peer(paf);
 		}
-	} while (s && (++generated < wpq) &&
-		 (connection->obuf->count <= bm->outq_limit));
+	} while (s && (++generated < wpq) && (connection->obuf->count <= bm->outq_limit) &&
+		 !event_should_yield(thread));
 
 	if (generated)
 		bgp_writes_on(connection);


### PR DESCRIPTION
The bgp_generate_updgrp_packet function will attempt to write up to `write quanta 64` packets at one time.  This is extremely expensive at scale and is causing CPU_HOGS as well as STARVATION messages.  Check to see if we should yield the CPU to allow something else in BGP to continue working.