### PR TITLE
*: Fix MULTIPATH_NUM check in nhg encode

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1275,8 +1275,8 @@ static int zapi_nhg_encode(struct stream *s, int cmd, struct zapi_nhg *api_nhg)
 		return -1;
 	}
 
-	if (api_nhg->nexthop_num >= MULTIPATH_NUM ||
-	    api_nhg->backup_nexthop_num >= MULTIPATH_NUM) {
+	if (api_nhg->nexthop_num > MULTIPATH_NUM ||
+	    api_nhg->backup_nexthop_num > MULTIPATH_NUM) {
 		flog_err(EC_LIB_ZAPI_ENCODE,
 			 "%s: zapi NHG encode with invalid input", __func__);
 		return -1;

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -542,7 +542,7 @@ void nhg_add(uint32_t id, const struct nexthop_group *nhg,
 	api_nhg.resilience = nhg->nhgr;
 
 	for (ALL_NEXTHOPS_PTR(nhg, nh)) {
-		if (api_nhg.nexthop_num >= MULTIPATH_NUM) {
+		if (api_nhg.nexthop_num > MULTIPATH_NUM) {
 			zlog_warn(
 				"%s: number of nexthops greater than max multipath size, truncating",
 				__func__);
@@ -576,7 +576,7 @@ void nhg_add(uint32_t id, const struct nexthop_group *nhg,
 
 	if (backup_nhg) {
 		for (ALL_NEXTHOPS_PTR(backup_nhg, nh)) {
-			if (api_nhg.backup_nexthop_num >= MULTIPATH_NUM) {
+			if (api_nhg.backup_nexthop_num > MULTIPATH_NUM) {
 				zlog_warn(
 					"%s: number of backup nexthops greater than max multipath size, truncating",
 					__func__);


### PR DESCRIPTION
In zapi_nhg_encode and in sharpd we check if number of paths are >= MULTIPATH_NUM, the condition should be just checking if it is > not >=