### PR TITLE
doc: state correct default behaviour of VTYSH_PAGER env if unset (vtysh manpage)

### DIFF
--- a/doc/manpages/vtysh.rst
+++ b/doc/manpages/vtysh.rst
@@ -79,7 +79,7 @@ OPTIONS available for the vtysh command:
 ENVIRONMENT VARIABLES
 =====================
 VTYSH_PAGER
-   This should be the name of the pager to use. Default is more.
+   This should be the name of the pager to use. Default is *more*.
 
 VTYSH_HISTFILE
    Override the history file for vtysh commands. Logging can be turned off using ``VTYSH_HISTFILE=/dev/null vtysh``.

--- a/doc/user/vtysh.rst
+++ b/doc/user/vtysh.rst
@@ -70,8 +70,7 @@ and the :clicmd:`terminal paginate` command:
    (particularly waiting at the end of output) tends to be annoying to the
    user.  Using ``less -EFX`` is recommended for a better user experience.
 
-   If this environment variable is unset, *vtysh* defaults to not using any
-   pager.
+   If this environment variable is unset, *vtysh* defaults to using *more*.
 
    This variable should be set by the user according to their preferences,
    in their :file:`~/.profile` file.


### PR DESCRIPTION
Modified section about environment variable VTYSH_PAGER in manpage about vtysh to reflect the default configuration for this env as described inside the FRR User Docs (https://docs.frrouting.org/en/latest/vtysh.html#envvar-VTYSH_PAGER)