### PR TITLE
lib: print ipv4 mapped ipv6 address in mixed notation

### DIFF
--- a/lib/ipaddr.h
+++ b/lib/ipaddr.h
@@ -86,14 +86,6 @@ static inline int str2ipaddr(const char *str, struct ipaddr *ip)
 	return -1;
 }
 
-static inline char *ipaddr2str(const struct ipaddr *ip, char *buf, int size)
-{
-	buf[0] = '\0';
-	if (ip)
-		inet_ntop(ip->ipa_type, &ip->ip.addr, buf, size);
-	return buf;
-}
-
 #define IS_MAPPED_IPV6(A)                                                      \
 	((A)->s6_addr32[0] == 0x00000000                                       \
 		 ? ((A)->s6_addr32[1] == 0x00000000                            \
@@ -125,6 +117,29 @@ static inline void ipv4_mapped_ipv6_to_ipv4(const struct in6_addr *in6,
 {
 	memset(in, 0, sizeof(struct in_addr));
 	memcpy(in, (char *)in6 + 12, sizeof(struct in_addr));
+}
+
+static inline char *ipaddr2str(const struct ipaddr *ip, char *buf, int size)
+{
+	buf[0] = '\0';
+	if (ip) {
+		if (IS_IPADDR_V6(ip) && IN6_IS_ADDR_V4MAPPED(&ip->ipaddr_v6)) {
+			/* Handle IPv4-mapped IPv6 addresses specially */
+			struct in_addr ipv4;
+			/*
+			 * Extract the IPv4 address from the mapped IPv6 address.
+			 * Per RFC 5952 section 5, it is RECOMMENDED to represent
+			 * IPv4-mapped IPv6 addresses using "mixed notation" with the
+			 * IPv4 part in dot-decimal format: ::ffff:192.0.2.1
+			 * instead of ::ffff:c000:0201
+			 */
+			ipv4_mapped_ipv6_to_ipv4(&ip->ipaddr_v6, &ipv4);
+			snprintfrr(buf, size, "::ffff:%pI4", &ipv4);
+		} else {
+			inet_ntop(ipaddr_family(ip), &ip->ip.addr, buf, size);
+		}
+	}
+	return buf;
 }
 
 /*
@@ -177,6 +192,7 @@ static inline bool ipaddr_is_same(const struct ipaddr *ip1,
 /* clang-format off */
 #ifdef _FRR_ATTRIBUTE_PRINTFRR
 #pragma FRR printfrr_ext "%pIA"  (struct ipaddr *)
+#pragma FRR printfrr_ext "%pI4"  (struct in_addr *)
 #endif
 /* clang-format on */
 

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1075,33 +1075,66 @@ static const char *prefixevpn2str(const struct prefix_evpn *p, char *str,
 	return str;
 }
 
+/* Helper function to format the prefix length in the format /xx */
+static size_t format_prefixlen(char *buf, size_t l, int prefixlen, size_t buf_size)
+{
+	int byte, tmp, a, b;
+	bool z = false;
+
+	/*
+	 * Ensure buffer has enough space for the maximum prefix length case.
+	 * For IPv6 with prefix length 128, we need:
+	 * - 1 byte for '/'
+	 * - 1 byte for '1' (hundreds place)
+	 * - 1 byte for '2' (tens place)
+	 * - 1 byte for '8' (ones place)
+	 * - 1 byte for the null terminator
+	 * Total: 5 bytes from the current position
+	 */
+	if (l + 4 >= buf_size)
+		return l;
+
+	buf[l++] = '/';
+	byte = prefixlen;
+	tmp = prefixlen - 100;
+	if (tmp >= 0) {
+		buf[l++] = '1';
+		z = true;
+		byte = tmp;
+	}
+	b = byte % 10;
+	a = byte / 10;
+	if (a || z)
+		buf[l++] = '0' + a;
+	buf[l++] = '0' + b;
+
+	buf[l] = '\0';
+	return l;
+}
+
 const char *prefix2str(union prefixconstptr pu, char *str, int size)
 {
 	const struct prefix *p = pu.p;
 	char buf[PREFIX2STR_BUFFER];
-	int byte, tmp, a, b;
-	bool z = false;
-	size_t l;
 
 	switch (p->family) {
 	case AF_INET:
-	case AF_INET6:
 		inet_ntop(p->family, &p->u.prefix, buf, sizeof(buf));
-		l = strlen(buf);
-		buf[l++] = '/';
-		byte = p->prefixlen;
-		tmp = p->prefixlen - 100;
-		if (tmp >= 0) {
-			buf[l++] = '1';
-			z = true;
-			byte = tmp;
+		format_prefixlen(buf, strlen(buf), p->prefixlen, sizeof(buf));
+		strlcpy(str, buf, size);
+		break;
+
+	case AF_INET6:
+		if (IN6_IS_ADDR_V4MAPPED(&p->u.prefix6)) {
+			struct in_addr ipv4;
+
+			ipv4_mapped_ipv6_to_ipv4(&p->u.prefix6, &ipv4);
+			snprintfrr(buf, size, "::ffff:%pI4", &ipv4);
+		} else {
+			inet_ntop(p->family, &p->u.prefix, buf, sizeof(buf));
 		}
-		b = byte % 10;
-		a = byte / 10;
-		if (a || z)
-			buf[l++] = '0' + a;
-		buf[l++] = '0' + b;
-		buf[l] = '\0';
+
+		format_prefixlen(buf, strlen(buf), p->prefixlen, sizeof(buf));
 		strlcpy(str, buf, size);
 		break;
 
@@ -1614,7 +1647,18 @@ static ssize_t printfrr_i6(struct fbuf *buf, struct printfrr_eargs *ea,
 	if (use_star && !memcmp(ptr, &zero, sizeof(zero)))
 		return bputch(buf, '*');
 
-	inet_ntop(AF_INET6, ptr, cbuf, sizeof(cbuf));
+	/* Handle IPv4-mapped IPv6 addresses specially */
+	const struct in6_addr *addr = ptr;
+
+	if (IN6_IS_ADDR_V4MAPPED(addr)) {
+		struct in_addr ipv4;
+
+		ipv4_mapped_ipv6_to_ipv4(addr, &ipv4);
+		snprintfrr(cbuf, sizeof(cbuf), "::ffff:%pI4", &ipv4);
+	} else {
+		inet_ntop(AF_INET6, ptr, cbuf, sizeof(cbuf));
+	}
+
 	return bputs(buf, cbuf);
 }
 

--- a/tests/topotests/bgp_ipv4_mapped_ipv6/r1/frr.conf
+++ b/tests/topotests/bgp_ipv4_mapped_ipv6/r1/frr.conf
@@ -1,0 +1,31 @@
+ip forwarding
+ipv6 forwarding
+!
+interface lo
+ ip address 10.254.254.1/32
+ ipv6 address 2001:db8:f::1/128
+!
+interface r1-eth0
+ ip address 192.168.1.1/24
+ ipv6 address 2001:db8:1::1/64
+!
+router bgp 65001
+ bgp router-id 10.254.254.1
+ no bgp default ipv4-unicast
+ !
+ address-family ipv6
+  redistribute connected
+ exit-address-family
+ !
+ neighbor 2001:db8:1::2 remote-as 65002
+ !
+ address-family ipv6 unicast
+  neighbor 2001:db8:1::2 activate
+  network ::ffff:200.100.222.111/128
+  network ::ffff:192.168.2.1/128
+ exit-address-family
+!
+ipv6 route ::ffff:200.100.222.111/128 blackhole
+ipv6 route ::ffff:192.168.2.1/128 blackhole
+!
+line vty

--- a/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_bgp_ipv6_unicast.json.ref
+++ b/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_bgp_ipv6_unicast.json.ref
@@ -1,0 +1,60 @@
+{
+  "routes": {
+    "::ffff:192.168.2.1/128": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "selectionReason": "First path received",
+        "pathFrom": "external",
+        "prefix": "::ffff:192.168.2.1",
+        "prefixLen": 128,
+        "network": "::ffff:192.168.2.1/128",
+        "version": 2,
+        "metric": 0,
+        "weight": 32768,
+        "peerId": "(unspec)",
+        "path": "",
+        "origin": "IGP",
+        "nexthops": [
+          {
+            "ip": "::",
+            "hostname": "r1",
+            "afi": "ipv6",
+            "scope": "global",
+            "linkLocalOnly": false,
+            "length": 16,
+            "used": true
+          }
+        ]
+      }
+    ],
+    "::ffff:200.100.222.111/128": [
+      {
+        "valid": true,
+        "bestpath": true,
+        "selectionReason": "First path received",
+        "pathFrom": "external",
+        "prefix": "::ffff:200.100.222.111",
+        "prefixLen": 128,
+        "network": "::ffff:200.100.222.111/128",
+        "version": 1,
+        "metric": 0,
+        "weight": 32768,
+        "peerId": "(unspec)",
+        "path": "",
+        "origin": "IGP",
+        "nexthops": [
+          {
+            "ip": "::",
+            "hostname": "r1",
+            "afi": "ipv6",
+            "scope": "global",
+            "linkLocalOnly": false,
+            "length": 16,
+            "used": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_bgp_ipv6_unicast.ref
+++ b/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_bgp_ipv6_unicast.ref
@@ -1,0 +1,14 @@
+BGP table version is 1, local router ID is 10.254.254.1, vrf id 0
+Default local pref 100, local AS 65001
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*> ::ffff:192.168.2.1/128
+                    ::                       0         32768 i
+*> ::ffff:200.100.222.111/128
+                    ::                       0         32768 i
+
+Displayed 2 routes and 2 total paths

--- a/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_bgp_ipv6_unicast_specific.json.ref
+++ b/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_bgp_ipv6_unicast_specific.json.ref
@@ -1,0 +1,41 @@
+{
+  "prefix": "::ffff:200.100.222.111/128",
+  "version": 1,
+  "paths": [
+    {
+      "aspath": {
+        "string": "Local",
+        "segments": [],
+        "length": 0
+      },
+      "origin": "IGP",
+      "metric": 0,
+      "weight": 32768,
+      "valid": true,
+      "version": 1,
+      "sourced": true,
+      "local": true,
+      "bestpath": {
+        "overall": true,
+        "selectionReason": "First path received"
+      },
+      "nexthops": [
+        {
+          "ip": "::",
+          "hostname": "r1",
+          "afi": "ipv6",
+          "scope": "global",
+          "linkLocalOnly": false,
+          "length": 16,
+          "metric": 0,
+          "accessible": true,
+          "used": true
+        }
+      ],
+      "peer": {
+        "peerId": "::",
+        "routerId": "10.254.254.1"
+      }
+    }
+  ]
+}

--- a/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_bgp_ipv6_unicast_specific.ref
+++ b/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_bgp_ipv6_unicast_specific.ref
@@ -1,0 +1,8 @@
+BGP routing table entry for ::ffff:200.100.222.111/128, version 1
+Paths: (1 available, best #1, table default)
+  Advertised to non peer-group peers:
+  2001:db8:1::2
+  Local
+    :: from 0.0.0.0 (10.254.254.1)
+      Origin IGP, metric 0, localpref 100, weight 32768, valid, sourced, best
+      Last update: 01:23:45

--- a/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_ipv6_route.json.ref
+++ b/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_ipv6_route.json.ref
@@ -1,0 +1,17 @@
+{
+  "::ffff:192.168.2.1/128": [
+    {
+      "prefix": "::ffff:192.168.2.1/128",
+      "prefixLen": 128,
+      "p": 1,
+      "internalNextHopActiveNum": 1,
+    }
+  ],
+  "::ffff:200.100.222.111/128": [
+    {
+      "prefix": "::ffff:200.100.222.111/128",
+      "prefixLen": 128,
+      "internalNextHopActiveNum": 1,
+    }
+  ]
+}

--- a/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_ipv6_route.ref
+++ b/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_ipv6_route.ref
@@ -1,0 +1,16 @@
+Codes: K - kernel route, C - connected, L - local, S - static,
+       R - RIPng, O - OSPFv3, I - IS-IS, B - BGP, N - NHRP,
+       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
+       f - OpenFabric, t - Table-Direct,
+       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
+       t - trapped, o - offload failure
+
+IPv6 unicast VRF default:
+S>* ::ffff:192.168.2.1/128 [1/0] unreachable (blackhole), weight 1
+S>* ::ffff:200.100.222.111/128 [1/0] unreachable (blackhole), weight 1
+
+K>* ::/0 via ::, lo, 01:23:45
+C>* 2001:db8:1::/64 via ::, r1-eth0, 01:23:45
+C>* 2001:db8:f::1/128 via ::, lo, 01:23:45
+B>* ::ffff:192.168.2.1/128 via ::, lo, 01:23:45
+B>* ::ffff:200.100.222.111/128 via ::, lo, 01:23:45

--- a/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_ipv6_route_specific.json.ref
+++ b/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_ipv6_route_specific.json.ref
@@ -1,0 +1,31 @@
+{
+  "::ffff:192.168.2.1/128": [
+    {
+      "prefix": "::ffff:192.168.2.1/128",
+      "prefixLen": 128,
+      "protocol": "static",
+      "vrfId": 0,
+      "vrfName": "default",
+      "selected": true,
+      "destSelected": true,
+      "distance": 1,
+      "metric": 0,
+      "installed": true,
+      "table": 254,
+      "internalStatus": 16,
+      "internalFlags": 73,
+      "internalNextHopNum": 1,
+      "internalNextHopActiveNum": 1,
+      "nexthops": [
+        {
+          "flags": 3,
+          "fib": true,
+          "unreachable": true,
+          "blackhole": true,
+          "active": true,
+          "weight": 1
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_ipv6_route_specific.ref
+++ b/tests/topotests/bgp_ipv4_mapped_ipv6/r1/show_ipv6_route_specific.ref
@@ -1,0 +1,4 @@
+Routing entry for ::ffff:192.168.2.1/128
+  Known via "static", distance 1, metric 0, best
+  Last update 00:00:48 ago
+  * unreachable (blackhole), weight 1

--- a/tests/topotests/bgp_ipv4_mapped_ipv6/r2/frr.conf
+++ b/tests/topotests/bgp_ipv4_mapped_ipv6/r2/frr.conf
@@ -1,0 +1,27 @@
+ip forwarding
+ipv6 forwarding
+!
+interface lo
+ ip address 10.254.254.2/32
+ ipv6 address 2001:db8:f::2/128
+!
+interface r2-eth0
+ ip address 192.168.1.2/24
+ ipv6 address 2001:db8:1::2/64
+!
+router bgp 65002
+ bgp router-id 10.254.254.2
+ no bgp default ipv4-unicast
+ !
+ address-family ipv6
+  redistribute connected
+ exit-address-family
+ !
+ neighbor 2001:db8:1::1 remote-as 65001
+ !
+ address-family ipv6 unicast
+  neighbor 2001:db8:1::1 activate
+ exit-address-family
+!
+line vty
+

--- a/tests/topotests/bgp_ipv4_mapped_ipv6/test_bgp_ipv4_mapped_ipv6.dot
+++ b/tests/topotests/bgp_ipv4_mapped_ipv6/test_bgp_ipv4_mapped_ipv6.dot
@@ -1,0 +1,23 @@
+graph test_bgp_ipv4_mapped_ipv6 {
+    label="BGP IPv4-mapped IPv6 Test Topology";
+
+    # Network nodes
+    r1 [
+        shape=doubleoctagon,
+        label="r1\nAS65001",
+        fillcolor="#f08080",
+        style=filled,
+    ];
+    r2 [
+        shape=doubleoctagon,
+        label="r2\nAS65002",
+        fillcolor="#f08080",
+        style=filled,
+    ];
+
+    # Network connections
+    r1 -- r2 [label="eth0\n192.168.1.0/24\n2001:db8:1::/64"];
+
+    # Network info
+    label="BGP IPv4-mapped IPv6 Test Topology: \nr1 advertises IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)";
+}

--- a/tests/topotests/bgp_ipv4_mapped_ipv6/test_bgp_ipv4_mapped_ipv6.py
+++ b/tests/topotests/bgp_ipv4_mapped_ipv6/test_bgp_ipv4_mapped_ipv6.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python
+
+#
+# Copyright (c) 2024 by
+# NVIDIA CORPORATION
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+# REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+# INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+# LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+# OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+# PERFORMANCE OF THIS SOFTWARE.
+#
+
+"""
+Test IPv4-mapped IPv6 address representation in mixed notation:
+Per RFC 5952 section 5, IPv4-mapped IPv6 addresses should use
+a special mixed representation with the IPv4 part in dot-decimal
+notation: ::ffff:192.0.2.1 instead of ::ffff:c000:0201
+"""
+
+import os
+import sys
+import json
+import pytest
+import re
+import functools
+import time
+import logging
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.common_config import step
+from lib.bgp import verify_bgp_convergence_from_running_config
+
+pytestmark = [pytest.mark.bgpd]
+
+# Global variables
+BGP_CONVERGENCE = False
+
+def build_topo(tgen):
+    """Build function"""
+
+    # Create 2 routers
+    for routern in range(1, 3):
+        tgen.add_router("r{}".format(routern))
+
+    # Create a switch with a connection to r1
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+def setup_module(mod):
+    """Setup topology and node configuration"""
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    # Configure routers
+    for i, (rname, router) in enumerate(router_list.items(), 1):
+        # Load the complete FRR configuration
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+    # Check BGP convergence
+    global BGP_CONVERGENCE
+    BGP_CONVERGENCE = verify_bgp_convergence_from_running_config(tgen)
+    assert BGP_CONVERGENCE is True, "setup_module :Failed \n Error: {}".format(
+        BGP_CONVERGENCE
+    )
+
+def teardown_module(_mod):
+    """Teardown the test topology"""
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+def test_bgp_convergence():
+    """Test that BGP converges correctly"""
+    tgen = get_topogen()
+    global BGP_CONVERGENCE
+
+    if tgen.routers_have_failure():
+        pytest.skip("Skipped because of router(s) failure")
+
+    if BGP_CONVERGENCE is not True:
+        # First check if BGP is running
+        r1 = tgen.gears["r1"]
+        bgp_status = r1.vtysh_cmd("show bgp summary")
+        if not bgp_status:
+            pytest.fail("BGP is not running on r1")
+
+        # Try without VRF first
+        result = verify_bgp_convergence_from_running_config(tgen, dut="r1")
+        if not result:
+            # If that fails, try with VRF
+            result = verify_bgp_convergence_from_running_config(tgen, dut="r1", vrf="all")
+
+        assert result is True, "BGP is not converging"
+        BGP_CONVERGENCE = True
+
+def test_bgp_ipv4_mapped_ipv6_representation():
+    """
+    Test that the IPv4-mapped IPv6 addresses are displayed in mixed notation
+    format (::ffff:a.b.c.d) instead of pure IPv6 format.
+
+    The test verifies the representation in multiple contexts:
+    1. BGP IPv6 unicast table (both full table and specific route)
+    2. IPv6 route table (both full table and specific route)
+    3. JSON output format for all commands
+    4. Format consistency (ensuring no hex format is used)
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip("Skipped because of router(s) failure")
+
+    if BGP_CONVERGENCE is not True:
+        pytest.skip("Skipped because of BGP Convergence failure")
+
+    r1 = tgen.gears["r1"]
+
+    # Define the IPv4-mapped IPv6 addresses we expect to see in mixed notation
+    ipv4_mapped_addresses = [
+        "::ffff:200.100.222.111",
+        "::ffff:192.168.2.1"
+    ]
+
+    # ============================================================
+    # 1. BGP IPv6 Unicast Table Checks
+    # ============================================================
+
+    # 1.1 Full BGP IPv6 unicast table (plain text)
+    step("Check 'show bgp ipv6 unicast' for IPv4-mapped IPv6 addresses in mixed notation")
+    output = r1.vtysh_cmd("show bgp ipv6 unicast")
+    for addr in ipv4_mapped_addresses:
+        assert addr in output, f"IPv4-mapped IPv6 address {addr} not found in mixed notation in BGP IPv6 table"
+
+    # 1.2 Specific BGP IPv6 unicast route (plain text)
+    step("Check specific BGP IPv6 unicast route details")
+    route_output = r1.vtysh_cmd("show bgp ipv6 unicast ::ffff:200.100.222.111/128")
+    assert "::ffff:200.100.222.111/128" in route_output, \
+        "IPv4-mapped IPv6 address not shown correctly in route details"
+
+    # 1.3 Full BGP IPv6 unicast table (JSON)
+    step("Check 'show bgp ipv6 unicast json' for IPv4-mapped IPv6 addresses")
+    json_output = r1.vtysh_cmd("show bgp ipv6 unicast json", isjson=True)
+    assert isinstance(json_output, dict), "JSON output is not a dictionary"
+    assert "routes" in json_output, "JSON output missing 'routes' key"
+    for addr in ipv4_mapped_addresses:
+        route_key = f"{addr}/128"
+        assert route_key in json_output["routes"], f"Route {route_key} not found in JSON output"
+        route_list = json_output["routes"][route_key]
+        assert isinstance(route_list, list) and len(route_list) > 0, f"No route entries found for {route_key}"
+        route = route_list[0]
+        # Compare the prefix without the /128 suffix since JSON output doesn't include it
+        assert route["prefix"] == addr, f"Prefix mismatch for route {route_key}"
+
+    # 1.4 Specific BGP IPv6 unicast route (JSON)
+    step("Check specific BGP IPv6 unicast route details in JSON format")
+    json_route_output = r1.vtysh_cmd("show bgp ipv6 unicast ::ffff:200.100.222.111/128 json", isjson=True)
+    assert isinstance(json_route_output, dict), "Specific route JSON output is not a dictionary"
+    assert "prefix" in json_route_output, "Specific route JSON missing 'prefix' key"
+    assert json_route_output["prefix"] == "::ffff:200.100.222.111/128", "Prefix mismatch in specific route JSON"
+
+    # ============================================================
+    # 2. IPv6 Route Table Checks
+    # ============================================================
+
+    # 2.1 Full IPv6 route table (plain text)
+    step("Check 'show ipv6 route' for IPv4-mapped IPv6 addresses in mixed notation")
+    route_output = r1.vtysh_cmd("show ipv6 route")
+    for addr in ipv4_mapped_addresses:
+        assert addr in route_output, f"IPv4-mapped IPv6 address {addr} not found in mixed notation in IPv6 route table"
+
+    # 2.2 Specific IPv6 route (plain text)
+    step("Check specific IPv6 route details")
+    specific_route_output = r1.vtysh_cmd("show ipv6 route ::ffff:192.168.2.1/128")
+    assert "::ffff:192.168.2.1/128" in specific_route_output, \
+        "IPv4-mapped IPv6 address not shown correctly in specific route details"
+
+    # 2.3 Full IPv6 route table (JSON)
+    step("Check 'show ipv6 route json' for IPv4-mapped IPv6 addresses")
+    json_route_output = r1.vtysh_cmd("show ipv6 route json", isjson=True)
+    for addr in ipv4_mapped_addresses:
+        route_key = f"{addr}/128"
+        assert route_key in json_route_output, f"IPv4-mapped IPv6 route {route_key} not found in JSON output"
+        route_list = json_route_output[route_key]
+        assert isinstance(route_list, list) and len(route_list) > 0, f"No route entries found for {route_key}"
+        route = route_list[0]
+        assert route["prefix"] == route_key, f"Prefix mismatch for route {route_key}"
+
+    # 2.4 Specific IPv6 route (JSON)
+    step("Check specific IPv6 route details in JSON format")
+    specific_json_output = r1.vtysh_cmd("show ipv6 route ::ffff:192.168.2.1/128 json", isjson=True)
+    assert "::ffff:192.168.2.1/128" in specific_json_output, \
+        "IPv4-mapped IPv6 address not found in specific route JSON output"
+    route_list = specific_json_output["::ffff:192.168.2.1/128"]
+    assert isinstance(route_list, list) and len(route_list) > 0, "No route entries found in specific route JSON"
+    route = route_list[0]
+    assert route["prefix"] == "::ffff:192.168.2.1/128", "Prefix mismatch in specific route JSON"
+
+    # ============================================================
+    # 3. Format Consistency Check
+    # ============================================================
+    step("Verify no hex-format IPv4-mapped addresses are present")
+    hex_pattern = re.compile(r"::ffff:[0-9a-f]{4}:[0-9a-f]{4}")
+    assert not hex_pattern.search(output), "Found hex-format IPv4-mapped IPv6 addresses, should be in mixed notation"
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Per RFC 5952 section 5, https://datatracker.ietf.org/doc/html/rfc5952#section-5 it is RECOMMENDED to represent IPv4-mapped IPv6 addresses using "mixed notation" with the IPv4 part in dot-decimal format: ::ffff:192.0.2.1 instead of ::ffff:c000:0201

It just improves the readability.

Testing:

```
root@leaf:~# vtysh -c "show bgp ipv6 unicast" | grep 200.100.222.111
*> ::ffff:200.100.222.111/128

leaf# show bgp ipv6 unicast ::ffff:200.100.222.111/128
BGP routing table entry for ::ffff:200.100.222.111/128, version 488

root@leaf:~# vtysh -c "show ipv6 route" | grep 200.100.222.111
B>* ::ffff:200.100.222.111/128 [20/0] via 2220:10::4:0:1, swp1s1, weight 255, 00:01:15

root@leaf:~# ip -6 route show ::ffff:200.100.222.111/128
::ffff:200.100.222.111 nhid 150 proto bgp metric 20 pref medium

```