### PR TITLE
ospf6d: Fix OSPFv3 SNMP interface state mapping

### DIFF
--- a/ospf6d/ospf6_snmp.c
+++ b/ospf6d/ospf6_snmp.c
@@ -1023,6 +1023,36 @@ static uint8_t *ospfv3WwLsdbEntry(struct variable *v, oid *name, size_t *length,
 	return NULL;
 }
 
+/*
+ * Map OSPFv3 internal interface states to OSPFv3 MIB state values
+ *
+ * This function converts the internal interface state values used by OSPFv3
+ * into the corresponding values defined in the OSPFv3 Management Information
+ * Base (MIB). The MIB defines specific states for interfaces, which are
+ * used by SNMP to monitor and manage OSPFv3 networks.
+ */
+static uint8_t ospf6_snmp_interface_state(uint8_t state)
+{
+	switch (state) {
+	case OSPF6_INTERFACE_DOWN:
+		return 1;
+	case OSPF6_INTERFACE_LOOPBACK:
+		return 2;
+	case OSPF6_INTERFACE_WAITING:
+		return 3;
+	case OSPF6_INTERFACE_POINTTOPOINT:
+		return 4;
+	case OSPF6_INTERFACE_DR:
+		return 5;
+	case OSPF6_INTERFACE_BDR:
+		return 6;
+	case OSPF6_INTERFACE_DROTHER:
+		return 7;
+	default:
+		return 8;
+	}
+}
+
 static uint8_t *ospfv3IfEntry(struct variable *v, oid *name, size_t *length,
 			      int exact, size_t *var_len,
 			      WriteMethod **write_method)
@@ -1144,7 +1174,7 @@ static uint8_t *ospfv3IfEntry(struct variable *v, oid *name, size_t *length,
 		/* No support for NBMA */
 		break;
 	case OSPFv3IFSTATE:
-		return SNMP_INTEGER(oi->state);
+		return SNMP_INTEGER(ospf6_snmp_interface_state(oi->state));
 	case OSPFv3IFDESIGNATEDROUTER:
 		return SNMP_INTEGER(ntohl(oi->drouter));
 	case OSPFv3IFBACKUPDESIGNATEDROUTER:


### PR DESCRIPTION
The OSPFv3 SNMP implementation was incorrectly returning internal state values directly without mapping them to the OSPFv3 MIB state values defined in RFC 5643. This caused a mismatch between the SNMP output and the actual interface states.

Added a mapping function to convert internal OSPFv3 interface states to their corresponding OSPFv3 MIB state values:
- OSPF6_INTERFACE_DOWN (1) -> down(1)
- OSPF6_INTERFACE_LOOPBACK (2) -> loopback(2)
- OSPF6_INTERFACE_WAITING (3) -> waiting(3)
- OSPF6_INTERFACE_POINTTOPOINT (4) -> pointToPoint(4)
- OSPF6_INTERFACE_DR (7) -> designatedRouter(5)
- OSPF6_INTERFACE_BDR (6) -> backupDesignatedRouter(6)
- OSPF6_INTERFACE_DROTHER (5) -> otherDesignatedRouter(7)

This ensures that SNMP queries return the correct state values according to the OSPFv3 MIB specification.

Ticket: #4402285
Ticket: #4362862