### PR TITLE
zebra: Cancel new client accept events after zsock is closed

### DIFF
--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -895,19 +895,20 @@ void zserv_release_client(struct zserv *client)
  */
 static void zserv_accept(struct event *thread)
 {
-	int accept_sock;
 	int client_sock;
 	struct sockaddr_in client;
 	socklen_t len;
 
-	accept_sock = EVENT_FD(thread);
+	if (zsock < 0) {
+		/* Return if this event pops after zsock is closed. */
+		return;
+	}
 
 	/* Reregister myself. */
 	zserv_event(NULL, ZSERV_ACCEPT);
 
 	len = sizeof(struct sockaddr_in);
-	client_sock = accept(accept_sock, (struct sockaddr *)&client, &len);
-
+	client_sock = accept(zsock, (struct sockaddr *)&client, &len);
 	if (client_sock < 0) {
 		flog_err_sys(EC_LIB_SOCKET, "Can't accept zebra socket: %s",
 			     safe_strerror(errno));


### PR DESCRIPTION
Problem:
Zebra crashed while going down. This happened because zebra was trying to process a new client accept request after closing ZAPI's listener socket zsock and setting it to -1.

Fix:
Cancel all the new client accept requests before closing ZAPI's listener socket in signal handler. Inorder to achieve this, a new list has been created to store all the accept events. Before closing ZAPI's listener socket, zebra will go over this list of accept events and cancel it.

crash bt:
```
#0  0x00007f0e81ce1eec in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f0e81c92fb2 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007f0e821002ec in core_handler (signo=6, siginfo=0x7ffed863d170, context=<optimized out>) at ../lib/sigevent.c:261
#3  <signal handler called>
#4  0x00007f0e81ce1eec in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#5  0x00007f0e81c92fb2 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#6  0x00007f0e81c7d472 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#7  0x00007f0e82130e19 in _zlog_assert_failed (xref=xref@entry=0x7f0e821e6020 <_xref.53>, extra=extra@entry=0x0) at ../lib/zlog.c:672
#8  0x00007f0e821112ae in _event_add_read_write (xref=<optimized out>, m=<optimized out>, func=0x558ec2cafa80 <zserv_accept>, arg=0x0, fd=-1, 
    t_ptr=<optimized out>) at ../lib/event.c:976
#9  0x0000558ec2cafac9 in zserv_event (event=ZSERV_ACCEPT, client=0x0) at ../zebra/zserv.c:1018
#10 zserv_accept (thread=<optimized out>) at ../zebra/zserv.c:894
#11 0x00007f0e82112791 in event_call (thread=thread@entry=0x7ffed863e0f0) at ../lib/event.c:2034
#12 0x00007f0e820bc8d0 in frr_run (master=0x558ece4f9000) at ../lib/libfrr.c:1243
#13 0x0000558ec2be61ad in main (argc=14, argv=0x7ffed863e418) at ../zebra/main.c:584
(gdb) f 9
#9  0x0000558ec2cafac9 in zserv_event (event=ZSERV_ACCEPT, client=0x0) at ../zebra/zserv.c:1018
1018	../zebra/zserv.c: No such file or directory.
(gdb) p zsock
$1 = -1
(gdb) p started_p
$2 = false
(gdb) 
```