### PR TITLE
zebra: Display nhg's afi as `No Afi`

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -66,6 +66,14 @@ static void depends_decrement_free(struct nhg_connected_tree_head *head);
 static struct nhg_backup_info *
 nhg_backup_copy(const struct nhg_backup_info *orig);
 
+const char *zebra_nhg_afi2str(struct nhg_hash_entry *nhe)
+{
+	if (nhe->afi == AFI_UNSPEC)
+		return "No AFI";
+
+	return afi2str(nhe->afi);
+}
+
 /* Helper function for getting the next allocatable ID */
 static uint32_t nhg_get_next_id(void)
 {

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -405,6 +405,8 @@ extern void nexthop_vrf_update(struct route_node *rn, struct route_entry *re, vr
 extern int nexthop_active_update(struct route_node *rn, struct route_entry *re,
 				 struct route_entry *old_re);
 
+extern const char *zebra_nhg_afi2str(struct nhg_hash_entry *nhe);
+
 #ifdef _FRR_ATTRIBUTE_PRINTFRR
 #pragma FRR printfrr_ext "%pNG" (const struct nhg_hash_entry *)
 #endif

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1091,7 +1091,7 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 		json_object_string_add(json, "uptime", up_str);
 		json_object_string_add(json, "vrf",
 				       vrf_id_to_name(nhe->vrf_id));
-		json_object_string_add(json, "afi", afi2str(nhe->afi));
+		json_object_string_add(json, "afi", zebra_nhg_afi2str(nhe));
 
 	} else {
 		vty_out(vty, "ID: %u (%s)\n", nhe->id,
@@ -1106,7 +1106,7 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 
 		vty_out(vty, "     Uptime: %s\n", up_str);
 		vty_out(vty, "     VRF: %s(%s)\n", vrf_id_to_name(nhe->vrf_id),
-			afi2str(nhe->afi));
+			zebra_nhg_afi2str(nhe));
 	}
 
 	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_VALID)) {


### PR DESCRIPTION
When displaying `show nexthop-group rib` the afi
displayed for Nexthop Groups ( not singletons ) is `bad-value` which while true to the specific of
the AFI it's not necessarily what we want to display to the end operator.  Add a wrapper function for
nhg's to do the right thing.