### PR TITLE
zebra: Resolve tableid for dataplane route notifications

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5039,7 +5039,7 @@ static inline void zebra_rib_translate_ctx_from_dplane(struct zebra_dplane_ctx *
 	if (vrfid == VRF_UNKNOWN)
 		dplane_ctx_set_vrf(ctx, zebra_vrf_lookup_by_table(tableid, nsid));
 	else if ((op == DPLANE_OP_ROUTE_INSTALL || op == DPLANE_OP_ROUTE_UPDATE ||
-		  op == DPLANE_OP_ROUTE_DELETE) &&
+		  op == DPLANE_OP_ROUTE_DELETE || op == DPLANE_OP_ROUTE_NOTIFY) &&
 		 tableid == ZEBRA_ROUTE_TABLE_UNKNOWN)
 		dplane_ctx_set_table(ctx, zebra_vrf_lookup_tableid(vrfid, nsid));
 }


### PR DESCRIPTION
The context sent up from the dplane may not contain the tableid. For this reason, when the context hits the master pthread, the master pthread first calls `zebra_rib_translate_ctx_from_dplane` to resolve the tableid, and then it processes the context.

Currently, `zebra_rib_translate_ctx_from_dplane` does not handle some of the dplane route context operations supported in FRR.

It handles the following dplane operations:
- `DPLANE_OP_ROUTE_INSTALL`
- `DPLANE_OP_ROUTE_UPDATE`
- `DPLANE_OP_ROUTE_DELETE`

But it does not handle this:
- `DPLANE_OP_ROUTE_NOTIFY`

Because of this, when the master pthread receives a dplane context with `DPLANE_OP_ROUTE_NOTIFY` operation and tableid unknown, the pthread does not resolve the tableid, and at some point during processing the context is dropped because the tableid is invalid.

This patch extends `zebra_rib_translate_ctx_from_dplane` to handle the `DPLANE_OP_ROUTE_NOTIFY` operation and resolve the tableid.