### PR TITLE
zebra: Re-install all route entries upon kernel NHG action/Quick intf flaps + NHG fixes and improvements

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -1683,7 +1683,7 @@ zebra Terminal Mode Commands
    total number of route nodes in the table.  Which will be higher than
    the actual number of routes that are held.
 
-.. clicmd:: show nexthop-group rib [ID] [vrf NAME] [singleton [ip|ip6]] [type] [json]
+.. clicmd:: show nexthop-group rib [ID [routes]] [vrf NAME] [singleton [ip|ip6]] [type] [json]
 
    Display nexthop groups created by zebra.  The [vrf NAME] option
    is only meaningful if you have started zebra with the --vrfwnetns
@@ -1694,7 +1694,9 @@ zebra Terminal Mode Commands
    that has `Initial Delay`, means that this nexthop group entry
    was not installed because no-one was using it at that point and
    Zebra can delay installing this route until it is used by something
-   else.
+   else. [``routes``] option after the NHG ID will show all the routes using
+   a particular NHG.
+
 
 .. clicmd:: show <ip|ipv6> zebra route dump [<vrf> VRFNAME]
 

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -155,11 +155,14 @@ static int _nexthop_cmp_no_labels(const struct nexthop *next1,
 	if (next1->vrf_id > next2->vrf_id)
 		return 1;
 
-	if (next1->type < next2->type)
-		return -1;
+	if (!(CHECK_FLAG(next1->flags, NEXTHOP_FLAG_RECURSIVE) ||
+	      CHECK_FLAG(next2->flags, NEXTHOP_FLAG_RECURSIVE))) {
+		if (next1->type < next2->type)
+			return -1;
 
-	if (next1->type > next2->type)
-		return 1;
+		if (next1->type > next2->type)
+			return 1;
+	}
 
 	if (use_weight) {
 		if (next1->weight < next2->weight)

--- a/tests/topotests/bgp_ecmp_topo1/test_bgp_ecmp_topo1.py
+++ b/tests/topotests/bgp_ecmp_topo1/test_bgp_ecmp_topo1.py
@@ -165,6 +165,282 @@ def test_bgp_ecmp():
     assert res is None, assertmsg
 
 
+def test_nhg_with_interface_flaps_and_nexthop_flush():
+    "Test static routes with multiple nexthops and verify BGP routes from peers"
+    tgen = get_topogen()
+
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+
+    # Configure static routes with multiple nexthops
+    router.vtysh_cmd(
+        """
+        configure terminal
+        # First set of routes - Static routes
+        ip route 10.1.1.0/24 r1-eth1
+        ip route 10.1.1.0/24 r1-eth2
+        ip route 10.1.2.0/24 r1-eth2
+        ip route 10.1.2.0/24 r1-eth3
+        ip route 10.1.3.0/24 r1-eth1
+        ip route 10.1.3.0/24 r1-eth3
+        ip route 10.1.4.0/24 r1-eth1
+        ip route 10.1.4.0/24 r1-eth2
+        ip route 10.1.4.0/24 r1-eth3
+        exit
+    """
+    )
+
+    # Verify static routes are installed
+    expect_static = {
+        "10.1.1.0/24": {
+            "nexthops": [
+                {"interfaceName": "r1-eth1", "active": True},
+                {"interfaceName": "r1-eth2", "active": True},
+            ]
+        },
+        "10.1.2.0/24": {
+            "nexthops": [
+                {"interfaceName": "r1-eth2", "active": True},
+                {"interfaceName": "r1-eth3", "active": True},
+            ]
+        },
+        "10.1.3.0/24": {
+            "nexthops": [
+                {"interfaceName": "r1-eth1", "active": True},
+                {"interfaceName": "r1-eth3", "active": True},
+            ]
+        },
+        "10.1.4.0/24": {
+            "nexthops": [
+                {"interfaceName": "r1-eth1", "active": True},
+                {"interfaceName": "r1-eth2", "active": True},
+                {"interfaceName": "r1-eth3", "active": True},
+            ]
+        },
+    }
+
+    def _check_static_routes():
+        output = router.vtysh_cmd("show ip route")
+        logger.info("Checking static routes. Output:\n%s", output)
+
+        for prefix, data in expect_static.items():
+            # Check if route exists
+            if prefix not in output:
+                logger.error("Static route %s not found in output", prefix)
+                return False
+
+            # Count nexthops for this prefix
+            nexthop_count = 0
+            for nh in data["nexthops"]:
+                if nh["interfaceName"] in output:
+                    nexthop_count += 1
+
+            if nexthop_count != len(data["nexthops"]):
+                logger.error(
+                    "Static route %s has wrong number of nexthops. Expected %d, got %d",
+                    prefix,
+                    len(data["nexthops"]),
+                    nexthop_count,
+                )
+                return False
+        return True
+
+    test_func = functools.partial(_check_static_routes)
+    _, res = topotest.run_and_expect(test_func, True, count=20, wait=3)
+    assertmsg = "Static routes with multiple nexthops not installed correctly"
+    assert res is True, assertmsg
+
+    # Expected BGP routes with their nexthops
+    expect_bgp = {
+        "10.201.0.0/24": {
+            "nexthops": [
+                {"interfaceName": "r1-eth1", "active": True},
+                {"interfaceName": "r1-eth2", "active": True},
+                {"interfaceName": "r1-eth3", "active": True},
+            ],
+            "protocol": "bgp",
+        },
+        "10.202.0.0/24": {
+            "nexthops": [
+                {"interfaceName": "r1-eth1", "active": True},
+                {"interfaceName": "r1-eth2", "active": True},
+                {"interfaceName": "r1-eth3", "active": True},
+            ],
+            "protocol": "bgp",
+        },
+        "10.203.0.0/24": {
+            "nexthops": [
+                {"interfaceName": "r1-eth1", "active": True},
+                {"interfaceName": "r1-eth2", "active": True},
+                {"interfaceName": "r1-eth3", "active": True},
+            ],
+            "protocol": "bgp",
+        },
+        "10.204.0.0/24": {
+            "nexthops": [
+                {"interfaceName": "r1-eth1", "active": True},
+                {"interfaceName": "r1-eth2", "active": True},
+                {"interfaceName": "r1-eth3", "active": True},
+            ],
+            "protocol": "bgp",
+        },
+    }
+
+    def _check_bgp_routes():
+        output = router.vtysh_cmd("show ip route")
+        logger.info("Checking BGP routes. Output:\n%s", output)
+
+        for prefix, data in expect_bgp.items():
+            # Check if route exists and is BGP
+            if prefix not in output or "B" not in output:  # B indicates BGP route
+                logger.error("BGP route %s not found or not a BGP route", prefix)
+                return False
+
+            # Find all nexthops for this prefix
+            found_nexthops = []
+            for nh in data["nexthops"]:
+                if nh["interfaceName"] in output:
+                    found_nexthops.append(nh["interfaceName"])
+
+            logger.info("Route %s: Found nexthops: %s", prefix, found_nexthops)
+
+            if len(found_nexthops) != len(data["nexthops"]):
+                logger.error(
+                    "BGP route %s has wrong number of nexthops. Expected %d (%s), got %d (%s)",
+                    prefix,
+                    len(data["nexthops"]),
+                    [nh["interfaceName"] for nh in data["nexthops"]],
+                    len(found_nexthops),
+                    found_nexthops,
+                )
+                return False
+        return True
+
+    # Wait for BGP routes to be installed
+    test_func = functools.partial(_check_bgp_routes)
+    _, res = topotest.run_and_expect(test_func, True, count=20, wait=3)
+    assertmsg = "BGP routes with multiple nexthops not installed correctly"
+    assert res is True, assertmsg
+
+    ## Validate route re-install post ip nexthop flush
+    logger.info("=" * 80)
+    logger.info("*** Validate route re-install post ip nexthop flush ***")
+    logger.info("=" * 80)
+    pre_route = router.cmd("ip route show | wc -l")
+    pre_route6 = router.cmd("ip -6 route show | wc -l")
+
+    post_out = router.cmd("ip next flush")
+
+    def _check_current_route_counts():
+        post_route = router.cmd("ip route show | wc -l")
+        post_route6 = router.cmd("ip -6 route show | wc -l")
+        if post_route != pre_route or post_route6 != pre_route6:
+            return False
+        return True
+
+    result_tuple = topotest.run_and_expect(
+        _check_current_route_counts, True, count=30, wait=1
+    )
+    _, result = result_tuple
+    if not result:
+        post_route = router.cmd("ip route show | wc -l")
+        post_route6 = router.cmd("ip -6 route show | wc -l")
+        assert (
+            False
+        ), "Expected same ipv6 routes(pre-{}: post-{}) and ipv4 route count(pre-{}:post-{}) after nexthop flush".format(
+            pre_route6, post_route6, pre_route, post_route
+        )
+
+    # Verify routes are still installed correctly after nexthop flush
+    test_func = functools.partial(_check_static_routes)
+    _, res = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assertmsg = "Static routes not reinstalled correctly after nexthop flush"
+    assert res is True, assertmsg
+
+    test_func = functools.partial(_check_bgp_routes)
+    _, res = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assertmsg = "BGP routes not reinstalled correctly after nexthop flush"
+    assert res is True, assertmsg
+
+    ## Validate route re-install after quick interface flaps
+    logger.info("=" * 80)
+    logger.info("*** Validate route re-install after quick interface flaps ***")
+    logger.info("=" * 80)
+    pre_route = router.cmd("ip route show | wc -l")
+    pre_route6 = router.cmd("ip -6 route show | wc -l")
+
+    # Use only the interfaces we want to test (eth1-eth3)
+    interfaces = [1, 2, 3]  # Explicitly list eth1, eth2, eth3
+    cmds = [f"ip link set r1-eth{i} down; ip link set r1-eth{i} up" for i in interfaces]
+    router.cmd(" ; ".join(cmds))
+
+    def _check_current_route_counts_after_flap():
+        post_route = router.cmd("ip route show | wc -l")
+        post_route6 = router.cmd("ip -6 route show | wc -l")
+        if post_route != pre_route or post_route6 != pre_route6:
+            return False
+        return True
+
+    result_tuple = topotest.run_and_expect(
+        _check_current_route_counts_after_flap, True, count=30, wait=1
+    )
+    _, result = result_tuple
+    if not result:
+        post_route = router.cmd("ip route show | wc -l")
+        post_route6 = router.cmd("ip -6 route show | wc -l")
+        assert (
+            False
+        ), "Expected same ipv6 routes(pre-{}: post-{}) and route count(pre-{}:post-{}) after quick interface flaps".format(
+            pre_route6, post_route6, pre_route, post_route
+        )
+
+    # Verify routes are still installed correctly after interface flaps
+    test_func = functools.partial(_check_static_routes)
+    _, res = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assertmsg = "Static routes not reinstalled correctly after interface flaps"
+    assert res is True, assertmsg
+
+    test_func = functools.partial(_check_bgp_routes)
+    _, res = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assertmsg = "BGP routes not reinstalled correctly after interface flaps"
+    assert res is True, assertmsg
+
+    # Cleanup: Remove all configured static routes
+    logger.info("*** Cleaning up static routes ***")
+    router.vtysh_cmd(
+        """
+        configure terminal
+        no ip route 10.1.1.0/24 r1-eth1
+        no ip route 10.1.1.0/24 r1-eth2
+        no ip route 10.1.2.0/24 r1-eth2
+        no ip route 10.1.2.0/24 r1-eth3
+        no ip route 10.1.3.0/24 r1-eth1
+        no ip route 10.1.3.0/24 r1-eth3
+        no ip route 10.1.4.0/24 r1-eth1
+        no ip route 10.1.4.0/24 r1-eth2
+        no ip route 10.1.4.0/24 r1-eth3
+        exit
+    """
+    )
+
+    # Verify routes are removed
+    def _check_routes_removed():
+        output = router.vtysh_cmd("show ip route")
+        for prefix in ["10.1.1.0/24", "10.1.2.0/24", "10.1.3.0/24", "10.1.4.0/24"]:
+            if prefix in output:
+                logger.error("Static route %s still present after cleanup", prefix)
+                return False
+        return True
+
+    test_func = functools.partial(_check_routes_removed)
+    _, res = topotest.run_and_expect(test_func, True, count=10, wait=1)
+    assertmsg = "Static routes not properly cleaned up"
+    assert res is True, assertmsg
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/tests/topotests/isis_tilfa_topo1/rt5/step10/show_ip_route.ref
+++ b/tests/topotests/isis_tilfa_topo1/rt5/step10/show_ip_route.ref
@@ -1,483 +1,507 @@
 {
-  "1.1.1.1\/32":[
+  "1.1.1.1/32": [
     {
-      "prefix":"1.1.1.1\/32",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":30,
-      "installed":true,
-      "nexthops":[
+      "prefix": "1.1.1.1/32",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 30,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.4.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-1",
-          "active":true,
-          "backupIndex":[
+          "fib": true,
+          "ip": "10.0.4.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-1",
+          "active": true,
+          "backupIndex": [
             0
           ],
-          "labels":[
+          "labels": [
             16010
           ]
         },
         {
-          "fib":true,
-          "ip":"10.0.5.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-2",
-          "active":true,
-          "backupIndex":[
+          "fib": true,
+          "ip": "10.0.5.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-2",
+          "active": true,
+          "backupIndex": [
             0
           ],
-          "labels":[
+          "labels": [
             16010
           ]
         }
       ],
-      "backupNexthops":[
+      "backupNexthops": [
         {
-          "ip":"10.0.6.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
+          "flags": 1,
+          "ip": "10.0.6.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16010
+          ],
+          "weight": 1
+        }
+      ]
+    }
+  ],
+  "2.2.2.2/32": [
+    {
+      "prefix": "2.2.2.2/32",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 30,
+      "installed": true,
+      "nexthops": [
+        {
+          "fib": true,
+          "ip": "10.0.4.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-1",
+          "active": true,
+          "labels": [
+            16020
+          ]
+        },
+        {
+          "fib": true,
+          "ip": "10.0.5.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-2",
+          "active": true,
+          "labels": [
+            16020
+          ]
+        },
+        {
+          "fib": true,
+          "ip": "10.0.6.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
+            16020
           ]
         }
       ]
     }
   ],
-  "2.2.2.2\/32":[
+  "3.3.3.3/32": [
     {
-      "prefix":"2.2.2.2\/32",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":30,
-      "installed":true,
-      "nexthops":[
+      "prefix": "3.3.3.3/32",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 20,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.4.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-1",
-          "active":true,
-          "labels":[
-            16020
-          ]
-        },
-        {
-          "fib":true,
-          "ip":"10.0.5.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-2",
-          "active":true,
-          "labels":[
-            16020
-          ]
-        },
-        {
-          "fib":true,
-          "ip":"10.0.6.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
-            16020
-          ]
-        }
-      ]
-    }
-  ],
-  "3.3.3.3\/32":[
-    {
-      "prefix":"3.3.3.3\/32",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":20,
-      "installed":true,
-      "nexthops":[
-        {
-          "fib":true,
-          "ip":"10.0.4.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-1",
-          "active":true,
-          "backupIndex":[
+          "fib": true,
+          "ip": "10.0.4.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-1",
+          "active": true,
+          "backupIndex": [
             0
           ],
-          "labels":[
+          "labels": [
             3
           ]
         },
         {
-          "fib":true,
-          "ip":"10.0.5.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-2",
-          "active":true,
-          "backupIndex":[
+          "fib": true,
+          "ip": "10.0.5.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-2",
+          "active": true,
+          "backupIndex": [
             0
           ],
-          "labels":[
+          "labels": [
             3
           ]
         }
       ],
-      "backupNexthops":[
+      "backupNexthops": [
         {
-          "ip":"10.0.6.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
+          "flags": 1,
+          "ip": "10.0.6.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16020,
             16030
-          ]
+          ],
+          "weight": 1
         }
       ]
     }
   ],
-  "4.4.4.4\/32":[
+  "4.4.4.4/32": [
     {
-      "prefix":"4.4.4.4\/32",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":20,
-      "installed":true,
-      "nexthops":[
+      "prefix": "4.4.4.4/32",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 20,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.6.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "backupIndex":[
+          "fib": true,
+          "ip": "10.0.6.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "backupIndex": [
             0
           ],
-          "labels":[
+          "labels": [
             3
           ]
         }
       ],
-      "backupNexthops":[
+      "backupNexthops": [
         {
-          "ip":"10.0.8.6",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt6",
-          "active":true,
-          "labels":[
+          "flags": 1,
+          "ip": "10.0.8.6",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt6",
+          "active": true,
+          "labels": [
             16040
-          ]
+          ],
+          "weight": 1
         }
       ]
     }
   ],
-  "6.6.6.6\/32":[
+  "6.6.6.6/32": [
     {
-      "prefix":"6.6.6.6\/32",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":30,
-      "installed":true,
-      "nexthops":[
+      "prefix": "6.6.6.6/32",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 30,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.6.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
+          "fib": true,
+          "ip": "10.0.6.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16060
           ]
         }
       ]
     }
   ],
-  "10.0.1.0\/24":[
+  "10.0.1.0/24": [
     {
-      "prefix":"10.0.1.0\/24",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":20,
-      "installed":true,
-      "nexthops":[
+      "prefix": "10.0.1.0/24",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 20,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.4.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-1",
-          "active":true,
-          "backupIndex":[
+          "fib": true,
+          "ip": "10.0.4.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-1",
+          "active": true,
+          "backupIndex": [
             0
           ]
         },
         {
-          "fib":true,
-          "ip":"10.0.5.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-2",
-          "active":true,
-          "backupIndex":[
+          "fib": true,
+          "ip": "10.0.5.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-2",
+          "active": true,
+          "backupIndex": [
             0
           ]
         }
       ],
-      "backupNexthops":[
+      "backupNexthops": [
         {
-          "ip":"10.0.6.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true
+          "flags": 1,
+          "ip": "10.0.6.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "weight": 1
         }
       ]
     }
   ],
-  "10.0.2.0\/24":[
+  "10.0.2.0/24": [
     {
-      "prefix":"10.0.2.0\/24",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":20,
-      "installed":true,
-      "nexthops":[
+      "prefix": "10.0.2.0/24",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 20,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.6.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "backupIndex":[
+          "fib": true,
+          "ip": "10.0.6.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "backupIndex": [
             0,
             1,
             2
           ]
         }
       ],
-      "backupNexthops":[
+      "backupNexthops": [
         {
-          "ip":"10.0.8.6",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt6",
-          "active":true
+          "flags": 1,
+          "ip": "10.0.8.6",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt6",
+          "active": true,
+          "weight": 1
         },
         {
-          "ip":"10.0.4.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-1",
-          "active":true
+          "flags": 1,
+          "ip": "10.0.4.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-1",
+          "active": true,
+          "weight": 1
         },
         {
-          "ip":"10.0.5.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-2",
-          "active":true
+          "flags": 1,
+          "ip": "10.0.5.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-2",
+          "active": true,
+          "weight": 1
         }
       ]
     }
   ],
-  "10.0.3.0\/24":[
+  "10.0.3.0/24": [
     {
-      "prefix":"10.0.3.0\/24",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":20,
-      "installed":true,
-      "nexthops":[
+      "prefix": "10.0.3.0/24",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 20,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.6.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "backupIndex":[
+          "fib": true,
+          "ip": "10.0.6.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "backupIndex": [
             0,
             1,
             2
           ]
         }
       ],
-      "backupNexthops":[
+      "backupNexthops": [
         {
-          "ip":"10.0.8.6",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt6",
-          "active":true
+          "flags": 1,
+          "ip": "10.0.8.6",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt6",
+          "active": true,
+          "weight": 1
         },
         {
-          "ip":"10.0.4.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-1",
-          "active":true
+          "flags": 1,
+          "ip": "10.0.4.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-1",
+          "active": true,
+          "weight": 1
         },
         {
-          "ip":"10.0.5.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-2",
-          "active":true
+          "flags": 1,
+          "ip": "10.0.5.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-2",
+          "active": true,
+          "weight": 1
         }
       ]
     }
   ],
-  "10.0.4.0\/24":[
+  "10.0.4.0/24": [
     {
-      "prefix":"10.0.4.0\/24",
-      "protocol":"isis",
-      "distance":115,
-      "metric":20,
-      "nexthops":[
+      "prefix": "10.0.4.0/24",
+      "protocol": "isis",
+      "distance": 115,
+      "metric": 20,
+      "nexthops": [
         {
-          "ip":"10.0.4.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-1",
-          "backupIndex":[
+          "ip": "10.0.4.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-1",
+          "backupIndex": [
             0
           ]
         },
         {
-          "ip":"10.0.5.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-2",
-          "active":true,
-          "backupIndex":[
+          "ip": "10.0.5.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-2",
+          "active": true,
+          "backupIndex": [
             0
           ]
         }
       ],
-      "backupNexthops":[
+      "backupNexthops": [
         {
-          "ip":"10.0.6.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
+          "flags": 1,
+          "ip": "10.0.6.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16020
-          ]
+          ],
+          "weight": 1
         }
       ]
     }
   ],
-  "10.0.5.0\/24":[
+  "10.0.5.0/24": [
     {
-      "prefix":"10.0.5.0\/24",
-      "protocol":"isis",
-      "distance":115,
-      "metric":20,
-      "nexthops":[
+      "prefix": "10.0.5.0/24",
+      "protocol": "isis",
+      "distance": 115,
+      "metric": 20,
+      "nexthops": [
         {
-          "ip":"10.0.4.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-1",
-          "active":true,
-          "backupIndex":[
+          "ip": "10.0.4.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-1",
+          "active": true,
+          "backupIndex": [
             0
           ]
         },
         {
-          "ip":"10.0.5.3",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt3-2",
-          "backupIndex":[
+          "ip": "10.0.5.3",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt3-2",
+          "backupIndex": [
             0
           ]
         }
       ],
-      "backupNexthops":[
+      "backupNexthops": [
         {
-          "ip":"10.0.6.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
+          "flags": 1,
+          "ip": "10.0.6.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16020
-          ]
+          ],
+          "weight": 1
         }
       ]
     }
   ],
-  "10.0.6.0\/24":[
+  "10.0.6.0/24": [
     {
-      "prefix":"10.0.6.0\/24",
-      "protocol":"isis",
-      "distance":115,
-      "metric":20,
-      "nexthops":[
+      "prefix": "10.0.6.0/24",
+      "protocol": "isis",
+      "distance": 115,
+      "metric": 20,
+      "nexthops": [
         {
-          "ip":"10.0.6.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "backupIndex":[
+          "ip": "10.0.6.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "backupIndex": [
             0
           ]
         }
       ],
-      "backupNexthops":[
+      "backupNexthops": [
         {
-          "ip":"10.0.8.6",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt6",
-          "active":true
+          "flags": 1,
+          "ip": "10.0.8.6",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt6",
+          "active": true,
+          "weight": 1
         }
       ]
     }
   ],
-  "10.0.7.0\/24":[
+  "10.0.7.0/24": [
     {
-      "prefix":"10.0.7.0\/24",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":20,
-      "installed":true,
-      "nexthops":[
+      "prefix": "10.0.7.0/24",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 20,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.6.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true
+          "fib": true,
+          "ip": "10.0.6.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true
         },
         {
-          "fib":true,
-          "ip":"10.0.8.6",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt6"
+          "ip": "10.0.8.6",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt6"
         }
       ]
     }
   ],
-  "10.0.8.0\/24":[
+  "10.0.8.0/24": [
     {
-      "prefix":"10.0.8.0\/24",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":30,
-      "installed":true,
-      "nexthops":[
+      "prefix": "10.0.8.0/24",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 30,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.6.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true
+          "fib": true,
+          "ip": "10.0.6.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true
         }
       ]
     }

--- a/tests/topotests/isis_tilfa_topo1/rt5/step10/show_ipv6_route.ref
+++ b/tests/topotests/isis_tilfa_topo1/rt5/step10/show_ipv6_route.ref
@@ -1,190 +1,196 @@
 {
-  "2001:db8:1000::1\/128":[
+  "2001:db8:1000::1/128": [
     {
-      "prefix":"2001:db8:1000::1\/128",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":30,
-      "installed":true,
-      "nexthops":[
+      "prefix": "2001:db8:1000::1/128",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 30,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt3-1",
-          "active":true,
-          "backupIndex":[
+          "fib": true,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt3-2",
+          "active": true,
+          "backupIndex": [
             0
           ],
-          "labels":[
+          "labels": [
             16011
           ]
         },
         {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt3-2",
-          "active":true,
-          "backupIndex":[
+          "fib": true,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt3-1",
+          "active": true,
+          "backupIndex": [
             0
           ],
-          "labels":[
+          "labels": [
             16011
           ]
         }
       ],
-      "backupNexthops":[
+      "backupNexthops": [
         {
-          "afi":"ipv6",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
+          "flags": 1,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16011
+          ],
+          "weight": 1
+        }
+      ]
+    }
+  ],
+  "2001:db8:1000::2/128": [
+    {
+      "prefix": "2001:db8:1000::2/128",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 30,
+      "installed": true,
+      "nexthops": [
+        {
+          "fib": true,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt3-2",
+          "active": true,
+          "labels": [
+            16021
+          ]
+        },
+        {
+          "fib": true,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt3-1",
+          "active": true,
+          "labels": [
+            16021
+          ]
+        },
+        {
+          "fib": true,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
+            16021
           ]
         }
       ]
     }
   ],
-  "2001:db8:1000::2\/128":[
+  "2001:db8:1000::3/128": [
     {
-      "prefix":"2001:db8:1000::2\/128",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":30,
-      "installed":true,
-      "nexthops":[
+      "prefix": "2001:db8:1000::3/128",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 20,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt3-1",
-          "active":true,
-          "labels":[
-            16021
-          ]
-        },
-        {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt3-2",
-          "active":true,
-          "labels":[
-            16021
-          ]
-        },
-        {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
-            16021
-          ]
-        }
-      ]
-    }
-  ],
-  "2001:db8:1000::3\/128":[
-    {
-      "prefix":"2001:db8:1000::3\/128",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":20,
-      "installed":true,
-      "nexthops":[
-        {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt3-1",
-          "active":true,
-          "backupIndex":[
+          "fib": true,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt3-2",
+          "active": true,
+          "backupIndex": [
             0
           ],
-          "labels":[
+          "labels": [
             3
           ]
         },
         {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt3-2",
-          "active":true,
-          "backupIndex":[
+          "fib": true,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt3-1",
+          "active": true,
+          "backupIndex": [
             0
           ],
-          "labels":[
+          "labels": [
             3
           ]
         }
       ],
-      "backupNexthops":[
+      "backupNexthops": [
         {
-          "afi":"ipv6",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
+          "flags": 1,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16021,
             16031
-          ]
+          ],
+          "weight": 1
         }
       ]
     }
   ],
-  "2001:db8:1000::4\/128":[
+  "2001:db8:1000::4/128": [
     {
-      "prefix":"2001:db8:1000::4\/128",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":20,
-      "installed":true,
-      "nexthops":[
+      "prefix": "2001:db8:1000::4/128",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 20,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "backupIndex":[
+          "fib": true,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "backupIndex": [
             0
           ],
-          "labels":[
+          "labels": [
             3
           ]
         }
       ],
-      "backupNexthops":[
+      "backupNexthops": [
         {
-          "afi":"ipv6",
-          "interfaceName":"eth-rt6",
-          "active":true,
-          "labels":[
+          "flags": 1,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt6",
+          "active": true,
+          "labels": [
             16041
-          ]
+          ],
+          "weight": 1
         }
       ]
     }
   ],
-  "2001:db8:1000::6\/128":[
+  "2001:db8:1000::6/128": [
     {
-      "prefix":"2001:db8:1000::6\/128",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":30,
-      "installed":true,
-      "nexthops":[
+      "prefix": "2001:db8:1000::6/128",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 30,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
+          "fib": true,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16061
           ]
         }

--- a/tests/topotests/isis_tilfa_topo1/rt6/step10/show_ip_route.ref
+++ b/tests/topotests/isis_tilfa_topo1/rt6/step10/show_ip_route.ref
@@ -1,352 +1,267 @@
 {
-  "1.1.1.1\/32":[
+  "1.1.1.1/32": [
     {
-      "prefix":"1.1.1.1\/32",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":40,
-      "installed":true,
-      "nexthops":[
+      "prefix": "1.1.1.1/32",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 40,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.7.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
+          "fib": true,
+          "ip": "10.0.7.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16010
-          ]
-        },
-        {
-          "fib":true,
-          "ip":"10.0.8.5",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt5",
-          "active":true,
-          "labels":[
-            30010
           ]
         }
       ]
     }
   ],
-  "2.2.2.2\/32":[
+  "2.2.2.2/32": [
     {
-      "prefix":"2.2.2.2\/32",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":30,
-      "installed":true,
-      "nexthops":[
+      "prefix": "2.2.2.2/32",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 30,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.7.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "backupIndex":[
-            0
-          ],
-          "labels":[
+          "fib": true,
+          "ip": "10.0.7.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16020
           ]
         }
-      ],
-      "backupNexthops":[
-        {
-          "ip":"10.0.8.5",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt5",
-          "active":true,
-          "labels":[
-            30020
-          ]
-        }
       ]
     }
   ],
-  "3.3.3.3\/32":[
+  "3.3.3.3/32": [
     {
-      "prefix":"3.3.3.3\/32",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":40,
-      "installed":true,
-      "nexthops":[
+      "prefix": "3.3.3.3/32",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 40,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.7.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
+          "fib": true,
+          "ip": "10.0.7.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16030
           ]
         }
       ]
     }
   ],
-  "4.4.4.4\/32":[
+  "4.4.4.4/32": [
     {
-      "prefix":"4.4.4.4\/32",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":20,
-      "installed":true,
-      "nexthops":[
+      "prefix": "4.4.4.4/32",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 20,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.7.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "backupIndex":[
-            0
-          ],
-          "labels":[
+          "fib": true,
+          "ip": "10.0.7.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             3
-          ]
-        }
-      ],
-      "backupNexthops":[
-        {
-          "ip":"10.0.8.5",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt5",
-          "active":true,
-          "labels":[
-            30040
           ]
         }
       ]
     }
   ],
-  "5.5.5.5\/32":[
+  "5.5.5.5/32": [
     {
-      "prefix":"5.5.5.5\/32",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":30,
-      "installed":true,
-      "nexthops":[
+      "prefix": "5.5.5.5/32",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 30,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.7.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
+          "fib": true,
+          "ip": "10.0.7.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16500
           ]
         }
       ]
     }
   ],
-  "10.0.1.0\/24":[
+  "10.0.1.0/24": [
     {
-      "prefix":"10.0.1.0\/24",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":30,
-      "installed":true,
-      "nexthops":[
+      "prefix": "10.0.1.0/24",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 30,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.7.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true
-        },
-        {
-          "fib":true,
-          "ip":"10.0.8.5",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt5",
-          "active":true
+          "fib": true,
+          "ip": "10.0.7.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true
         }
       ]
     }
   ],
-  "10.0.2.0\/24":[
+  "10.0.2.0/24": [
     {
-      "prefix":"10.0.2.0\/24",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":20,
-      "installed":true,
-      "nexthops":[
+      "prefix": "10.0.2.0/24",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 20,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.7.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "backupIndex":[
-            0
-          ]
-        }
-      ],
-      "backupNexthops":[
-        {
-          "ip":"10.0.8.5",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt5",
-          "active":true
+          "fib": true,
+          "ip": "10.0.7.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true
         }
       ]
     }
   ],
-  "10.0.3.0\/24":[
+  "10.0.3.0/24": [
     {
-      "prefix":"10.0.3.0\/24",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":20,
-      "installed":true,
-      "nexthops":[
+      "prefix": "10.0.3.0/24",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 20,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.7.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "backupIndex":[
-            0
-          ]
-        }
-      ],
-      "backupNexthops":[
-        {
-          "ip":"10.0.8.5",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt5",
-          "active":true
+          "fib": true,
+          "ip": "10.0.7.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true
         }
       ]
     }
   ],
-  "10.0.4.0\/24":[
+  "10.0.4.0/24": [
     {
-      "prefix":"10.0.4.0\/24",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":30,
-      "installed":true,
-      "nexthops":[
+      "prefix": "10.0.4.0/24",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 30,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.7.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true
+          "fib": true,
+          "ip": "10.0.7.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true
         }
       ]
     }
   ],
-  "10.0.5.0\/24":[
+  "10.0.5.0/24": [
     {
-      "prefix":"10.0.5.0\/24",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":30,
-      "installed":true,
-      "nexthops":[
+      "prefix": "10.0.5.0/24",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 30,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.7.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true
+          "fib": true,
+          "ip": "10.0.7.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true
         }
       ]
     }
   ],
-  "10.0.6.0\/24":[
+  "10.0.6.0/24": [
     {
-      "prefix":"10.0.6.0\/24",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":20,
-      "installed":true,
-      "nexthops":[
+      "prefix": "10.0.6.0/24",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 20,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.7.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true
-        },
-        {
-          "fib":true,
-          "ip":"10.0.8.5",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt5",
-          "active":true
+          "fib": true,
+          "ip": "10.0.7.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true
         }
       ]
     }
   ],
-  "10.0.7.0\/24":[
+  "10.0.7.0/24": [
     {
-      "prefix":"10.0.7.0\/24",
-      "protocol":"isis",
-      "distance":115,
-      "metric":20,
-      "nexthops":[
+      "prefix": "10.0.7.0/24",
+      "protocol": "isis",
+      "distance": 115,
+      "metric": 20,
+      "nexthops": [
         {
-          "ip":"10.0.7.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "backupIndex":[
-            0
-          ]
-        }
-      ],
-      "backupNexthops":[
-        {
-          "ip":"10.0.8.5",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt5",
-          "active":true
+          "ip": "10.0.7.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4"
         }
       ]
     }
   ],
-  "10.0.8.0\/24":[
+  "10.0.8.0/24": [
     {
-      "prefix":"10.0.8.0\/24",
-      "protocol":"isis",
-      "distance":115,
-      "metric":30,
-      "nexthops":[
+      "prefix": "10.0.8.0/24",
+      "protocol": "isis",
+      "distance": 115,
+      "metric": 30,
+      "nexthops": [
         {
-          "fib":true,
-          "ip":"10.0.7.4",
-          "afi":"ipv4",
-          "interfaceName":"eth-rt4",
-          "active":true
+          "fib": true,
+          "ip": "10.0.7.4",
+          "afi": "ipv4",
+          "interfaceName": "eth-rt4",
+          "active": true
         }
       ]
     }

--- a/tests/topotests/isis_tilfa_topo1/rt6/step10/show_ipv6_route.ref
+++ b/tests/topotests/isis_tilfa_topo1/rt6/step10/show_ipv6_route.ref
@@ -1,143 +1,108 @@
 {
-  "2001:db8:1000::1\/128":[
+  "2001:db8:1000::1/128": [
     {
-      "prefix":"2001:db8:1000::1\/128",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":40,
-      "installed":true,
-      "nexthops":[
+      "prefix": "2001:db8:1000::1/128",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 40,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt5",
-          "active":true,
-          "labels":[
-            30011
-          ]
-        },
-        {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
+          "fib": true,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16011
           ]
         }
       ]
     }
   ],
-  "2001:db8:1000::2\/128":[
+  "2001:db8:1000::2/128": [
     {
-      "prefix":"2001:db8:1000::2\/128",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":30,
-      "installed":true,
-      "nexthops":[
+      "prefix": "2001:db8:1000::2/128",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 30,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "backupIndex":[
-            0
-          ],
-          "labels":[
+          "fib": true,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16021
-          ]
-        }
-      ],
-      "backupNexthops":[
-        {
-          "afi":"ipv6",
-          "interfaceName":"eth-rt5",
-          "active":true,
-          "labels":[
-            30021
           ]
         }
       ]
     }
   ],
-  "2001:db8:1000::3\/128":[
+  "2001:db8:1000::3/128": [
     {
-      "prefix":"2001:db8:1000::3\/128",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":40,
-      "installed":true,
-      "nexthops":[
+      "prefix": "2001:db8:1000::3/128",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 40,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
+          "fib": true,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16031
           ]
         }
       ]
     }
   ],
-  "2001:db8:1000::4\/128":[
+  "2001:db8:1000::4/128": [
     {
-      "prefix":"2001:db8:1000::4\/128",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":20,
-      "installed":true,
-      "nexthops":[
+      "prefix": "2001:db8:1000::4/128",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 20,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "backupIndex":[
-            0
-          ],
-          "labels":[
+          "fib": true,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             3
-          ]
-        }
-      ],
-      "backupNexthops":[
-        {
-          "afi":"ipv6",
-          "interfaceName":"eth-rt5",
-          "active":true,
-          "labels":[
-            30041
           ]
         }
       ]
     }
   ],
-  "2001:db8:1000::5\/128":[
+  "2001:db8:1000::5/128": [
     {
-      "prefix":"2001:db8:1000::5\/128",
-      "protocol":"isis",
-      "selected":true,
-      "destSelected":true,
-      "distance":115,
-      "metric":30,
-      "installed":true,
-      "nexthops":[
+      "prefix": "2001:db8:1000::5/128",
+      "protocol": "isis",
+      "selected": true,
+      "destSelected": true,
+      "distance": 115,
+      "metric": 30,
+      "installed": true,
+      "nexthops": [
         {
-          "fib":true,
-          "afi":"ipv6",
-          "interfaceName":"eth-rt4",
-          "active":true,
-          "labels":[
+          "fib": true,
+          "afi": "ipv6",
+          "interfaceName": "eth-rt4",
+          "active": true,
+          "labels": [
             16501
           ]
         }

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -35,6 +35,7 @@
 #include "zebra/zebra_vxlan.h"
 #include "zebra/zebra_errors.h"
 #include "zebra/zebra_evpn_mh.h"
+#include "zebra/zebra_nhg.h"
 
 DEFINE_MTYPE_STATIC(ZEBRA, ZINFO, "Zebra Interface Information");
 
@@ -178,7 +179,7 @@ static void if_down_nhg_dependents(const struct interface *ifp)
 	struct zebra_if *zif = (struct zebra_if *)ifp->info;
 
 	frr_each(nhg_connected_tree, &zif->nhg_dependents, rb_node_dep)
-		zebra_nhg_check_valid(rb_node_dep->nhe);
+		zebra_nhg_check_valid_with_dependency_propagation(rb_node_dep->nhe, false);
 }
 
 static void if_nhg_dependents_release(const struct interface *ifp)
@@ -188,7 +189,7 @@ static void if_nhg_dependents_release(const struct interface *ifp)
 
 	frr_each(nhg_connected_tree, &zif->nhg_dependents, rb_node_dep) {
 		rb_node_dep->nhe->ifp = NULL; /* Null it out */
-		zebra_nhg_check_valid(rb_node_dep->nhe);
+		zebra_nhg_check_valid_with_dependency_propagation(rb_node_dep->nhe, false);
 		if (CHECK_FLAG(rb_node_dep->nhe->flags,
 			       NEXTHOP_GROUP_KEEP_AROUND) &&
 		    rb_node_dep->nhe->refcnt == 1)

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -80,6 +80,9 @@ struct route_entry {
 	/* Link list. */
 	struct re_list_item next;
 
+	/* Back pointer to route node */
+	struct route_node *rn;
+
 	/* Nexthop group, shared/refcounted, based on the nexthop(s)
 	 * provided by the owner of the route
 	 */

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -178,7 +178,34 @@ struct route_entry {
 	 */
 	struct nexthop_group fib_ng;
 	struct nexthop_group fib_backup_ng;
+
+	/* Selected re using an nhe are in its re RB tree */
+	struct nhe_re_tree_item re_item;
 };
+
+static int route_entry_cmp(const struct route_entry *re1, const struct route_entry *re2)
+{
+	/* Compare VRF first - most likely to be different */
+	if (re1->vrf_id != re2->vrf_id)
+		return (re1->vrf_id - re2->vrf_id);
+
+	/* Compare protocol type - next most likely differentiator */
+	if (re1->type != re2->type)
+		return (re1->type - re2->type);
+
+	/* Compare instance */
+	if (re1->instance != re2->instance)
+		return (re1->instance - re2->instance);
+
+	if (re1 > re2)
+		return 1;
+	else if (re1 < re2)
+		return -1;
+
+	return 0;
+}
+
+DECLARE_RBTREE_UNIQ(nhe_re_tree, struct route_entry, re_item, route_entry_cmp);
 
 #define RIB_SYSTEM_ROUTE(R) RSYSTEM_ROUTE((R)->type)
 
@@ -655,6 +682,9 @@ extern uint32_t zebra_rib_dplane_results_count(void);
 extern pid_t zebra_pid;
 
 extern uint32_t rt_table_main_id;
+
+extern void nhe_add_or_del_re_tree(struct nhg_hash_entry *nhe, struct route_entry *re_to_oper,
+				   const char *caller, bool is_del);
 
 void route_entry_dump_nh(const struct route_entry *re, const char *straddr,
 			 const struct vrf *re_vrf,

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -693,6 +693,8 @@ void route_entry_dump_nh(const struct route_entry *re, const char *straddr,
 /* Name of hook calls */
 #define ZEBRA_ON_RIB_PROCESS_HOOK_CALL "on_rib_process_dplane_results"
 
+extern char *_dump_re_status(const struct route_entry *re, char *buf, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -467,7 +467,7 @@ static void *zebra_nhg_hash_alloc(void *arg)
 		if (ifp)
 			zebra_nhg_set_if(nhe, ifp);
 		else {
-			if (IS_ZEBRA_DEBUG_NHG)
+			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 				zlog_debug(
 					"Failed to lookup an interface with ifindex=%d in vrf=%u for NHE %pNG",
 					nhe->nhg.nexthop->ifindex,
@@ -1744,8 +1744,8 @@ void zebra_nhg_free(struct nhg_hash_entry *nhe)
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL) {
 		/* Group or singleton? */
 		if (nhe->nhg.nexthop && nhe->nhg.nexthop->next)
-			zlog_debug("%s: nhe %p (%pNG), refcnt %d", __func__,
-				   nhe, nhe, nhe->refcnt);
+			zlog_debug("%s: nhe %p (%pNG) flags (0x%x), refcnt %d", __func__, nhe, nhe,
+				   nhe->flags, nhe->refcnt);
 		else
 			zlog_debug("%s: nhe %p (%pNG), refcnt %d, NH %pNHv",
 				   __func__, nhe, nhe, nhe->refcnt,
@@ -3313,8 +3313,9 @@ backups_done:
 								old_re->nhe);
 
 		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
-			zlog_debug("%s: re %p CHANGED: nhe %p (%pNG) => new_nhe %p (%pNG) rib_find_nhe returned %p (%pNG) refcnt: %d",
-				   __func__, re, re->nhe, re->nhe, new_nhe, new_nhe, remove, remove,
+			zlog_debug("%s: re %p CHANGED: nhe %p (%pNG) flags (0x%x) => new_nhe %p (%pNG) flags (0x%x) rib_find_nhe returned %p (%pNG) flags (0x%x) refcnt: %d",
+				   __func__, re, re->nhe, re->nhe, re->nhe->flags, new_nhe,
+				   new_nhe, new_nhe->flags, remove, remove, remove->flags,
 				   remove ? remove->refcnt : 0);
 
 		/*
@@ -3500,8 +3501,8 @@ void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe, uint8_t type)
 
 	if (zebra_nhg_set_valid_if_active(nhe)) {
 		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
-			zlog_debug("%s: valid flag set for nh %pNG", __func__,
-				   nhe);
+			zlog_debug("%s: valid flag set for nh %pNG flags (0x%x)", __func__, nhe,
+				   nhe->flags);
 	}
 
 	if ((type != ZEBRA_ROUTE_CONNECT && type != ZEBRA_ROUTE_LOCAL &&
@@ -3624,7 +3625,7 @@ void zebra_nhg_dplane_result(struct zebra_dplane_ctx *ctx)
 		nhe = zebra_nhg_lookup_id(id);
 
 		if (!nhe) {
-			if (IS_ZEBRA_DEBUG_NHG)
+			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 				zlog_debug("%s operation performed on Nexthop ID (%u) in the kernel, that we no longer have in our table",
 					   dplane_op2str(op), id);
 
@@ -4160,9 +4161,9 @@ void zebra_interface_nhg_reinstall(struct interface *ifp)
 
 		if (zebra_nhg_set_valid_if_active(rb_node_dep->nhe)) {
 			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
-				zlog_debug(
-					"%s: Setting the valid flag for nhe %pNG, interface: %s",
-					__func__, rb_node_dep->nhe, ifp->name);
+				zlog_debug("%s: Setting the valid flag for nhe %pNG flags (0x%x), interface: %s",
+					   __func__, rb_node_dep->nhe, rb_node_dep->nhe->flags,
+					   ifp->name);
 		}
 
 		/* Check for singleton NHG associated to interface */
@@ -4170,7 +4171,7 @@ void zebra_interface_nhg_reinstall(struct interface *ifp)
 		    zebra_nhg_depends_is_empty(rb_node_dep->nhe)) {
 			struct nhg_connected *rb_node_dependent;
 
-			if (IS_ZEBRA_DEBUG_NHG)
+			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 				zlog_debug(
 					"%s install nhe %pNG nh type %u flags 0x%x",
 					__func__, rb_node_dep->nhe, nh->type,
@@ -4200,10 +4201,11 @@ void zebra_interface_nhg_reinstall(struct interface *ifp)
 					SET_FLAG(nhop_dependent->flags,
 						 NEXTHOP_FLAG_ACTIVE);
 
-				if (IS_ZEBRA_DEBUG_NHG)
-					zlog_debug("%s dependent nhe %pNG Setting Reinstall flag",
-						   __func__,
-						   rb_node_dependent->nhe);
+				if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+					zlog_debug("%s dependent nhe (%pNG) flags (0x%x) Setting Reinstall flag",
+						   __func__, rb_node_dependent->nhe,
+						   rb_node_dependent->nhe->flags);
+
 				SET_FLAG(rb_node_dependent->nhe->flags,
 					 NEXTHOP_GROUP_REINSTALL);
 			}

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -458,8 +458,7 @@ static void *zebra_nhg_hash_alloc(void *arg)
 	 *
 	 * A proto-owned ID is always a group.
 	 */
-	if (!PROTO_OWNED(nhe) && nhe->nhg.nexthop && !nhe->nhg.nexthop->next
-	    && !nhe->nhg.nexthop->resolved && nhe->nhg.nexthop->ifindex) {
+	if (!PROTO_OWNED(nhe) && ZEBRA_NHG_IS_DIRECT_SINGLETON(nhe)) {
 		struct interface *ifp = NULL;
 
 		ifp = if_lookup_by_index(nhe->nhg.nexthop->ifindex,
@@ -835,8 +834,7 @@ static bool zebra_nhe_find(struct nhg_hash_entry **nhe, /* return value */
 	nh = backup_nhe->nhg.nexthop;
 
 	/* Singleton recursive NH */
-	if (nh->next == NULL &&
-	    CHECK_FLAG(nh->flags, NEXTHOP_FLAG_RECURSIVE)) {
+	if (ZEBRA_NHG_IS_RECURSIVE_SINGLETON(backup_nhe)) {
 		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 			zlog_debug("%s: backup depend NH %pNHv (R)",
 				   __func__, nh);
@@ -1150,13 +1148,8 @@ void zebra_nhg_check_valid(struct nhg_hash_entry *nhe)
 	struct nhg_connected *rb_node_dep = NULL;
 	bool valid = false;
 
-	/*
-	 * If I have other nhe's depending on me, or I have nothing
-	 * I am depending on then this is a
-	 * singleton nhe so set this nexthops flag as appropriate.
-	 */
-	if (nhg_connected_tree_count(&nhe->nhg_depends) ||
-	    nhg_connected_tree_count(&nhe->nhg_dependents) == 0) {
+	/* Singleton means it has no depends and has only dependents */
+	if (ZEBRA_NHG_IS_SINGLETON(nhe)) {
 		UNSET_FLAG(nhe->nhg.nexthop->flags, NEXTHOP_FLAG_FIB);
 		UNSET_FLAG(nhe->nhg.nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 	}
@@ -1742,14 +1735,13 @@ static void zebra_nhg_free_members(struct nhg_hash_entry *nhe)
 void zebra_nhg_free(struct nhg_hash_entry *nhe)
 {
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL) {
-		/* Group or singleton? */
-		if (nhe->nhg.nexthop && nhe->nhg.nexthop->next)
-			zlog_debug("%s: nhe %p (%pNG) flags (0x%x), refcnt %d", __func__, nhe, nhe,
-				   nhe->flags, nhe->refcnt);
-		else
+		if (ZEBRA_NHG_IS_SINGLETON(nhe))
 			zlog_debug("%s: nhe %p (%pNG), refcnt %d, NH %pNHv",
 				   __func__, nhe, nhe, nhe->refcnt,
 				   nhe->nhg.nexthop);
+		else
+			zlog_debug("%s: nhe %p (%pNG) flags (0x%x), refcnt %d", __func__, nhe, nhe,
+				   nhe->flags, nhe->refcnt);
 	}
 
 	event_cancel(&nhe->timer);
@@ -1773,14 +1765,13 @@ void zebra_nhg_hash_free(void *p)
 	struct nhg_hash_entry *nhe = p;
 
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL) {
-		/* Group or singleton? */
-		if (nhe->nhg.nexthop && nhe->nhg.nexthop->next)
-			zlog_debug("%s: nhe %p (%u), refcnt %d", __func__, nhe,
-				   nhe->id, nhe->refcnt);
-		else
+		if (ZEBRA_NHG_IS_SINGLETON(nhe))
 			zlog_debug("%s: nhe %p (%pNG), refcnt %d, NH %pNHv",
 				   __func__, nhe, nhe, nhe->refcnt,
 				   nhe->nhg.nexthop);
+		else
+			zlog_debug("%s: nhe %p (%u), refcnt %d", __func__, nhe, nhe->id,
+				   nhe->refcnt);
 	}
 
 	event_cancel(&nhe->timer);
@@ -4167,8 +4158,7 @@ void zebra_interface_nhg_reinstall(struct interface *ifp)
 		}
 
 		/* Check for singleton NHG associated to interface */
-		if (!nexthop_is_blackhole(nh) &&
-		    zebra_nhg_depends_is_empty(rb_node_dep->nhe)) {
+		if (!nexthop_is_blackhole(nh) && ZEBRA_NHG_IS_SINGLETON(rb_node_dep->nhe)) {
 			struct nhg_connected *rb_node_dependent;
 
 			if (IS_ZEBRA_DEBUG_NHG_DETAIL)

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -274,7 +274,7 @@ static void zebra_nhg_dependents_release(struct nhg_hash_entry *nhe)
 	frr_each_safe(nhg_connected_tree, &nhe->nhg_dependents, rb_node_dep) {
 		zebra_nhg_depends_del(rb_node_dep->nhe, nhe);
 		/* recheck validity of the dependent */
-		zebra_nhg_check_valid(rb_node_dep->nhe);
+		zebra_nhg_check_valid_with_dependency_propagation(rb_node_dep->nhe, false);
 	}
 }
 
@@ -1092,77 +1092,256 @@ static void zebra_nhg_unset_installed_for_routes(struct nhg_hash_entry *nhe, con
 	}
 }
 
-static void zebra_nhg_set_valid(struct nhg_hash_entry *nhe, bool valid)
+/*
+ * Helper func to propagate singleton nexthop state changes to a dependent NHG
+ * Walk all dependents of a singleton NHG and propagate ACTIVE and VALID flags.
+ * This function recursively walks through all NHGs that depend on the singleton
+ * and compares each nexthop with the singleton, propagating flags accordingly.
+ *
+ * For example, if singleton(91) has dependents: 90, 89, 111, etc.
+ * This function will:
+ * - Compare singleton(91) with nexthops in 90, 89, 111, etc.
+ * - Walk dependents of those dependents recursively
+ * - Propagate ACTIVE/INACTIVE and VALID/INVALID flags based on singleton state
+ */
+static void zebra_nhg_propagate_singleton_to_dependent(struct nhg_hash_entry *dependent_nhe,
+						       struct nexthop *singleton_nh,
+						       bool singleton_active)
 {
-	struct nhg_connected *rb_node_dep;
-	bool dependent_valid = valid;
+	struct nexthop *resolved_nh;
+	bool any_active = false;
+	bool was_modified = false;
 
-	if (valid)
-		SET_FLAG(nhe->flags, NEXTHOP_GROUP_VALID);
-	else {
-		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_VALID);
+	if (!dependent_nhe->nhg.nexthop)
+		return;
 
-		/* If we're in shutdown, this interface event needs to clean
-		 * up installed NHGs, so don't clear that flag directly.
-		 */
-		if (!zebra_router_in_shutdown()) {
-			UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
-			/* Handles route re-install for quick interface flaps */
-			zebra_nhg_unset_installed_for_routes(nhe, __func__);
-		}
-	}
+	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+		zlog_debug("%s: Propagating singleton's nexthop (%pNHv) state (active=%s) to %p (%pNG)",
+			   __func__, singleton_nh, singleton_active ? "yes" : "no", dependent_nhe,
+			   dependent_nhe);
 
-	/* Update validity of nexthops depending on it */
-	frr_each (nhg_connected_tree, &nhe->nhg_dependents, rb_node_dep) {
-		dependent_valid = valid;
-		if (!valid) {
-			/*
-			 * Grab the first nexthop from the depending nexthop group
-			 * then let's find the nexthop in that group that matches
-			 * my individual nexthop and mark it as no longer ACTIVE
-			 */
-			struct nexthop *nexthop = rb_node_dep->nhe->nhg.nexthop;
+	/* Compare singleton nexthop with all resolved nexthops in dependent */
+	for (ALL_NEXTHOPS(dependent_nhe->nhg, resolved_nh)) {
+		if (nexthop_same(resolved_nh, singleton_nh)) {
+			const char *action = NULL;
 
-			while (nexthop) {
-				if (nexthop_same(nexthop, nhe->nhg.nexthop)) {
-					/* Invalid Nexthop */
-					UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
-				} else {
-					/*
-					 * If other nexthops in the nexthop
-					 * group are valid then we can continue
-					 * to use this nexthop group as valid
-					 */
-					if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
-						dependent_valid = true;
+			/* Found matching nexthop - update its active state */
+			if (singleton_active) {
+				if (!CHECK_FLAG(resolved_nh->flags, NEXTHOP_FLAG_ACTIVE)) {
+					SET_FLAG(resolved_nh->flags, NEXTHOP_FLAG_ACTIVE);
+					action = "Setting";
 				}
-				nexthop = nexthop->next;
+			} else {
+				if (CHECK_FLAG(resolved_nh->flags, NEXTHOP_FLAG_ACTIVE)) {
+					UNSET_FLAG(resolved_nh->flags, NEXTHOP_FLAG_ACTIVE);
+					UNSET_FLAG(resolved_nh->flags, NEXTHOP_FLAG_FIB);
+					action = "Unsetting";
+				}
+			}
+
+			if (action) {
+				was_modified = true;
+				if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+					zlog_debug("%s: %s ACTIVE flag on matching nexthop (%pNHv) in %p (%pNG) flags (0x%x)",
+						   __func__, action, resolved_nh, dependent_nhe,
+						   dependent_nhe, dependent_nhe->flags);
 			}
 		}
-		zebra_nhg_set_valid(rb_node_dep->nhe, dependent_valid);
-	}
-}
-
-void zebra_nhg_check_valid(struct nhg_hash_entry *nhe)
-{
-	struct nhg_connected *rb_node_dep = NULL;
-	bool valid = false;
-
-	/* Singleton means it has no depends and has only dependents */
-	if (ZEBRA_NHG_IS_SINGLETON(nhe)) {
-		UNSET_FLAG(nhe->nhg.nexthop->flags, NEXTHOP_FLAG_FIB);
-		UNSET_FLAG(nhe->nhg.nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 	}
 
-	/* If anthing else in the group is valid, the group is valid */
-	frr_each(nhg_connected_tree, &nhe->nhg_depends, rb_node_dep) {
-		if (CHECK_FLAG(rb_node_dep->nhe->flags, NEXTHOP_GROUP_VALID)) {
-			valid = true;
+	/* Check if any nexthop in this dependent is still active (after updates) */
+	for (ALL_NEXTHOPS(dependent_nhe->nhg, resolved_nh)) {
+		if (CHECK_FLAG(resolved_nh->flags, NEXTHOP_FLAG_ACTIVE)) {
+			any_active = true;
 			break;
 		}
 	}
 
-	zebra_nhg_set_valid(nhe, valid);
+	/* For recursive/group NHGs, also check if any dependencies are valid */
+	bool any_depend_valid = false;
+
+	if (!ZEBRA_NHG_IS_SINGLETON(dependent_nhe)) {
+		struct nhg_connected *dep_node;
+
+		frr_each (nhg_connected_tree, &dependent_nhe->nhg_depends, dep_node) {
+			if (CHECK_FLAG(dep_node->nhe->flags, NEXTHOP_GROUP_VALID)) {
+				any_depend_valid = true;
+				break;
+			}
+		}
+	}
+
+	/* Update NHG validity based on both nexthop states and dependency validity */
+	bool should_be_valid = any_active &&
+			       (ZEBRA_NHG_IS_SINGLETON(dependent_nhe) || any_depend_valid);
+
+	const char *action = NULL;
+
+	if (!should_be_valid) {
+		if (CHECK_FLAG(dependent_nhe->flags, NEXTHOP_GROUP_VALID)) {
+			UNSET_FLAG(dependent_nhe->flags, NEXTHOP_GROUP_VALID);
+			if (!zebra_router_in_shutdown()) {
+				UNSET_FLAG(dependent_nhe->flags, NEXTHOP_GROUP_INSTALLED);
+				zebra_nhg_unset_installed_for_routes(dependent_nhe, __func__);
+			}
+			action = "Invalidated";
+		}
+	} else {
+		if (!CHECK_FLAG(dependent_nhe->flags, NEXTHOP_GROUP_VALID)) {
+			SET_FLAG(dependent_nhe->flags, NEXTHOP_GROUP_VALID);
+			action = "Validated";
+		}
+	}
+
+	if (action) {
+		was_modified = true;
+		if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+			zlog_debug("%s: %s %p (%pNG) flags (0x%x) (any_active=%s, any_depend_valid=%s)",
+				   __func__, action, dependent_nhe, dependent_nhe,
+				   dependent_nhe->flags, any_active ? "yes" : "no",
+				   any_depend_valid ? "yes" : "no");
+	}
+
+	/* If this dependent was modified, recursively propagate to its dependents */
+	if (was_modified) {
+		struct nhg_connected *rb_node_dep;
+
+		frr_each (nhg_connected_tree, &dependent_nhe->nhg_dependents, rb_node_dep) {
+			zebra_nhg_propagate_singleton_to_dependent(rb_node_dep->nhe, singleton_nh,
+								   singleton_active);
+		}
+	}
+}
+
+/* Updates the active/valid state of a nexthop group and recursively propagates
+ * these changes to all dependent nexthop groups in the dependency tree.
+ * It handles both singleton nexthops (direct) and group/recursive nexthops,
+ * ensuring route installation consistency when interface states change.
+ *
+ * Singletons, we go up the chain to propogate the ACTIVE(NH) and VALID(NHG).
+ * GROUPS, we go up the dependency chain to propogate VALID(NHG)
+ *
+ * Callers:
+ * CASE-1: For SINGLETON only (set_active True)
+ *    - zebra_interface_nhg_reinstall
+ * When intf comes up, we want to set the singelton NH ACTIVE and the NHG VALID.
+ * Propogate this throughtout the entire dependency chain accordingly
+ *
+ * CASE-2: For SINGLETON only (set_active false)
+ *    - if_down_nhg_dependents
+ *    - if_nhg_dependents_release
+ * Both these cases are when intf is deleted/down. Since the singleton will
+ * have ACTIVE(NH) & VALID(NHG) Unset, we propogate this to the entire
+ * dependency chain to unset the nexthops ACTIVE and unset VALID on NHG's if
+ * all NHs are not ACTIVE.
+ *
+ * CASE-3: For SINGLETON and GROUPS (set_active True)
+ *     - zebra_nhg_handle_install
+ * When a NHG is installed into the kernel, as part of handling the result, we
+ * try to install its dependents as well (if conditions are met).
+ * But before we try to install the dependents, we want to ensure we propogate
+ * the VALID flags up the dependency chain. Breaks the chain walk when we find
+ * some NHG which is already VALID.
+ *
+ * CASE-4: For SINGLETON and GROUPS (set_active false)
+ *    - zebra_nhg_dependents_release
+ * When a NHG is to be released, we can have a group or a Recursive singleton
+ * (Not direct singleton) when we come here.
+ *    4a) For Recursive singleton, we follow CASE-2
+ *    4b) For Groups, similar to CASE-3, except we check to see if any depends
+ *        is valid.
+ *        - If none are valid, we unset the VALID and continue propogation
+ *          until we hit a NHG in a chain which is VALID and stop.
+ *        Otherwise, do nothing and exit since the ones above in the dependency
+ *        chain must already be VALID.
+ */
+void zebra_nhg_check_valid_with_dependency_propagation(struct nhg_hash_entry *nhe, bool set_active)
+{
+	struct nhg_connected *rb_node_dep = NULL;
+
+	/* Process singleton NHGs first */
+	if (ZEBRA_NHG_IS_SINGLETON(nhe)) {
+		struct nexthop *nh = nhe->nhg.nexthop;
+
+		/* Set or unset the ACTIVE flag based on the parameter */
+		if (set_active) {
+			SET_FLAG(nh->flags, NEXTHOP_FLAG_ACTIVE);
+			SET_FLAG(nhe->flags, NEXTHOP_GROUP_VALID);
+			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+				zlog_debug("%s: Setting ACTIVE for nh (%pNHv)and VALID flags for singleton %p (%pNG) flags (0x%x)",
+					   __func__, nh, nhe, nhe, nhe->flags);
+		} else {
+			UNSET_FLAG(nh->flags, NEXTHOP_FLAG_FIB);
+			UNSET_FLAG(nh->flags, NEXTHOP_FLAG_ACTIVE);
+			/* When interface goes down, singleton is no longer installed in kernel */
+			UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_VALID);
+			if (!zebra_router_in_shutdown()) {
+				UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+				zebra_nhg_unset_installed_for_routes(nhe, __func__);
+			}
+
+			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+				zlog_debug("%s: Unsetting ACTIVE for nh (%pNHv) and INSTALLED flags for singleton %p (%pNG) flags (0x%x)",
+					   __func__, nh, nhe, nhe, nhe->flags);
+		}
+
+		/* Propagate singleton state changes to ALL dependents recursively */
+		frr_each (nhg_connected_tree, &nhe->nhg_dependents, rb_node_dep) {
+			zebra_nhg_propagate_singleton_to_dependent(rb_node_dep->nhe, nh,
+								   CHECK_FLAG(nh->flags,
+									      NEXTHOP_FLAG_ACTIVE));
+		}
+	} else {
+		/* For non-singletons (group/recursive), process the group itself first, then propagate */
+		bool valid = false;
+
+		if (set_active) {
+			if (!CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_VALID)) {
+				SET_FLAG(nhe->flags, NEXTHOP_GROUP_VALID);
+				if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+					zlog_debug("%s: Setting VALID flag for group %p (%pNG) flags (0x%x) (has valid dependencies)",
+						   __func__, nhe, nhe, nhe->flags);
+
+				/* Now recursively propagate to all dependents */
+				frr_each (nhg_connected_tree, &nhe->nhg_dependents, rb_node_dep)
+					zebra_nhg_check_valid_with_dependency_propagation(rb_node_dep
+												  ->nhe,
+											  set_active);
+			}
+		} else {
+			/* Check if any dependency is still valid to make this group valid */
+			frr_each (nhg_connected_tree, &nhe->nhg_depends, rb_node_dep) {
+				if (CHECK_FLAG(rb_node_dep->nhe->flags, NEXTHOP_GROUP_VALID)) {
+					valid = true;
+					break;
+				}
+			}
+
+			if (!valid) {
+				/* No valid dependencies left, invalidate this group */
+				UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_VALID);
+				if (!zebra_router_in_shutdown()) {
+					UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+					zebra_nhg_unset_installed_for_routes(nhe, __func__);
+				}
+
+				if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+					zlog_debug("%s: Unsetting VALID and INSTALLED flags for NHG %p (%pNG) flags (0x%x) (no valid dependencies)",
+						   __func__, nhe, nhe, nhe->flags);
+
+				/* Now recursively propagate to all dependents */
+				frr_each (nhg_connected_tree, &nhe->nhg_dependents, rb_node_dep)
+					zebra_nhg_check_valid_with_dependency_propagation(rb_node_dep
+												  ->nhe,
+											  set_active);
+			} else {
+				/* set_active = false but still have valid dependencies, keep this group valid */
+				if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+					zlog_debug("%s: Keeping NHG %p (%pNG) flags (0x%x) VALID (still has valid dependencies)",
+						   __func__, nhe, nhe, nhe->flags);
+			}
+		}
+	}
 }
 
 static void zebra_nhg_release_all_deps(struct nhg_hash_entry *nhe)
@@ -1228,7 +1407,7 @@ static void zebra_nhg_handle_install(struct nhg_hash_entry *nhe, bool install)
 	struct nhg_connected *rb_node_dep;
 
 	frr_each_safe (nhg_connected_tree, &nhe->nhg_dependents, rb_node_dep) {
-		zebra_nhg_set_valid(rb_node_dep->nhe, true);
+		zebra_nhg_check_valid_with_dependency_propagation(rb_node_dep->nhe, true);
 
 		/*
 		 * In case of singletons, set the flags such that the NHG dependents
@@ -4160,29 +4339,21 @@ void zebra_interface_nhg_reinstall(struct interface *ifp)
 
 	frr_each (nhg_connected_tree, &zif->nhg_dependents, rb_node_dep) {
 		/*
-		 * The nexthop associated with this was set as !ACTIVE
-		 * so we need to turn it back to active when we get to
-		 * this point again
+		 * The nexthop associated with this was set as !ACTIVE. So, we need to
+		 * turn it back to active when we get to this point again
+		 * Using dependency propogation for singletons to ensure proper flag
+		 * propogations.
 		 */
-		SET_FLAG(rb_node_dep->nhe->nhg.nexthop->flags, NEXTHOP_FLAG_ACTIVE);
+		zebra_nhg_check_valid_with_dependency_propagation(rb_node_dep->nhe, true);
 		nh = rb_node_dep->nhe->nhg.nexthop;
 
-		if (zebra_nhg_set_valid_if_active(rb_node_dep->nhe)) {
-			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
-				zlog_debug("%s: Setting the valid flag for nhe %pNG flags (0x%x), interface: %s",
-					   __func__, rb_node_dep->nhe, rb_node_dep->nhe->flags,
-					   ifp->name);
-		}
-
-		/* Check for singleton NHG associated to interface */
-		if (!nexthop_is_blackhole(nh) && ZEBRA_NHG_IS_SINGLETON(rb_node_dep->nhe)) {
+		if (!nexthop_is_blackhole(nh)) {
 			struct nhg_connected *rb_node_dependent;
 
 			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
-				zlog_debug(
-					"%s install nhe %pNG nh type %u flags 0x%x",
-					__func__, rb_node_dep->nhe, nh->type,
-					rb_node_dep->nhe->flags);
+				zlog_debug("%s install nhe %p %pNG nh type %u flags 0x%x",
+					   __func__, rb_node_dep->nhe, rb_node_dep->nhe, nh->type,
+					   rb_node_dep->nhe->flags);
 			zebra_nhg_install_kernel(rb_node_dep->nhe,
 						 ZEBRA_ROUTE_MAX);
 
@@ -4191,26 +4362,12 @@ void zebra_interface_nhg_reinstall(struct interface *ifp)
 				       NEXTHOP_GROUP_INSTALLED))
 				continue;
 
-			/* mark dependent uninstalled; when interface associated
-			 * singleton is installed, install dependent
-			 */
-			frr_each_safe (nhg_connected_tree,
-				       &rb_node_dep->nhe->nhg_dependents,
+			frr_each_safe (nhg_connected_tree, &rb_node_dep->nhe->nhg_dependents,
 				       rb_node_dependent) {
-				struct nexthop *nhop_dependent =
-					rb_node_dependent->nhe->nhg.nexthop;
-
-				while (nhop_dependent &&
-				       !nexthop_same(nhop_dependent, nh))
-					nhop_dependent = nhop_dependent->next;
-
-				if (nhop_dependent)
-					SET_FLAG(nhop_dependent->flags,
-						 NEXTHOP_FLAG_ACTIVE);
-
 				if (IS_ZEBRA_DEBUG_NHG_DETAIL)
-					zlog_debug("%s dependent nhe (%pNG) flags (0x%x) Setting Reinstall flag",
+					zlog_debug("%s dependent nhe %p (%pNG) flags (0x%x) Setting Reinstall flag",
 						   __func__, rb_node_dependent->nhe,
+						   rb_node_dependent->nhe,
 						   rb_node_dependent->nhe->flags);
 
 				SET_FLAG(rb_node_dependent->nhe->flags,

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -389,8 +389,9 @@ unsigned long zebra_nhg_score_proto(int type);
 extern void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe);
 extern void zebra_nhg_increment_ref(struct nhg_hash_entry *nhe);
 
-/* Check validity of nhe, if invalid will update dependents as well */
-extern void zebra_nhg_check_valid(struct nhg_hash_entry *nhe);
+/* Check validity with dependency propagation for NHGs(singleton/Group) */
+extern void zebra_nhg_check_valid_with_dependency_propagation(struct nhg_hash_entry *nhe,
+							      bool set_active);
 
 /* Convert nhe depends to a grp context that can be passed around safely */
 extern uint16_t zebra_nhg_nhe2grp(struct nh_grp *grp, struct nhg_hash_entry *nhe, int size);

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -26,6 +26,7 @@ struct nh_grp {
 };
 
 PREDECL_RBTREE_UNIQ(nhg_connected_tree);
+PREDECL_RBTREE_UNIQ(nhe_re_tree);
 
 /*
  * Hashtables containing nhg entries is in `zebra_router`.
@@ -171,6 +172,9 @@ struct nhg_hash_entry {
  * chooses this NHG then we can install it then.
  */
 #define NEXTHOP_GROUP_INITIAL_DELAY_INSTALL (1 << 9)
+
+	/* Head of rb_tree of route_entries(re's)*/
+	struct nhe_re_tree_head re_head;
 };
 
 /* Upper 4 bits of the NHG are reserved for indicating the NHG type */

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -194,6 +194,18 @@ enum nhg_type {
 
 #define PROTO_OWNED(NHE) (NHE->id >= ZEBRA_NHG_PROTO_LOWER)
 
+/* return TRUE if the NHG is Singleton */
+#define ZEBRA_NHG_IS_SINGLETON(NHE) (NHE->nhg.nexthop && !NHE->nhg.nexthop->next)
+
+/* return TRUE if the NHG is Direct Singleton */
+#define ZEBRA_NHG_IS_DIRECT_SINGLETON(NHE)                                                        \
+	(ZEBRA_NHG_IS_SINGLETON(NHE) && NHE->nhg.nexthop->ifindex &&                              \
+	 !CHECK_FLAG(NHE->nhg.nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
+
+/* return TRUE if the NHG is Recursive Singleton */
+#define ZEBRA_NHG_IS_RECURSIVE_SINGLETON(NHE)                                                     \
+	(ZEBRA_NHG_IS_SINGLETON(NHE) &&                                                           \
+	 CHECK_FLAG(NHE->nhg.nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
 /*
  * Backup nexthops: this is a group object itself, so
  * that the backup nexthops can use the same code as a normal object.

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -387,8 +387,7 @@ static ssize_t printfrr_zebra_node(struct fbuf *buf, struct printfrr_eargs *ea,
 			  VRF_LOGNAME(vrf), node, node, ##__VA_ARGS__);        \
 	} while (0)
 
-static char *_dump_re_status(const struct route_entry *re, char *buf,
-			     size_t len)
+char *_dump_re_status(const struct route_entry *re, char *buf, size_t len)
 {
 	if (re->status == 0) {
 		snprintfrr(buf, len, "None ");

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4159,6 +4159,7 @@ static void rib_link(struct route_node *rn, struct route_entry *re, int process)
 			rnode_debug(rn, re->vrf_id, "rn %p adding dest", rn);
 	}
 
+	re->rn = rn;
 	re_list_add_head(&dest->routes, re);
 
 	afi = (rn->p.family == AF_INET)
@@ -4215,6 +4216,7 @@ void rib_unlink(struct route_node *rn, struct route_entry *re)
 
 	dest = rib_dest_from_rnode(rn);
 
+	re->rn = NULL;
 	re_list_del(&dest->routes, re);
 
 	if (dest->selected_fib == re)
@@ -4488,6 +4490,7 @@ struct route_entry *zebra_rib_route_entry_new(vrf_id_t vrf_id, int type,
 	re->uptime = monotime(NULL);
 	re->tag = tag;
 	re->nhe_id = nhe_id;
+	re->rn = NULL;
 
 	return re;
 }

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1166,6 +1166,42 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 			else
 				vty_out(vty, ", Initial Delay");
 		}
+		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)) {
+			if (json)
+				json_object_boolean_true_add(json, "queued");
+			else
+				vty_out(vty, ", Queued");
+		}
+		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSIVE)) {
+			if (json)
+				json_object_boolean_true_add(json, "recursive");
+			else
+				vty_out(vty, ", Recursive");
+		}
+		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_BACKUP)) {
+			if (json)
+				json_object_boolean_true_add(json, "backup");
+			else
+				vty_out(vty, ", Backup");
+		}
+		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_PROTO_RELEASED)) {
+			if (json)
+				json_object_boolean_true_add(json, "protoReleased");
+			else
+				vty_out(vty, ", Proto Released");
+		}
+		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_KEEP_AROUND)) {
+			if (json)
+				json_object_boolean_true_add(json, "keepAround");
+			else
+				vty_out(vty, ", Keep Around");
+		}
+		if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_FPM)) {
+			if (json)
+				json_object_boolean_true_add(json, "fpm");
+			else
+				vty_out(vty, ", FPM");
+		}
 		if (!json)
 			vty_out(vty, "\n");
 	}

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -471,6 +471,17 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 
 		vty_out(vty, "  Last update %s ago\n", buf);
 
+		/* Display route flags and status */
+		char flags_buf[128];
+		char status_buf[128];
+
+		zclient_dump_route_flags(re->flags, flags_buf, sizeof(flags_buf));
+		_dump_re_status(re, status_buf, sizeof(status_buf));
+		if (flags_buf[0] != '\0')
+			vty_out(vty, "  Flags: %s\n", flags_buf);
+		if (status_buf[0] != '\0')
+			vty_out(vty, "  Status: %s\n", status_buf);
+
 		if (show_ng) {
 			vty_out(vty, "  Nexthop Group ID: %u\n", re->nhe_id);
 			if (re->nhe_installed_id != 0
@@ -746,7 +757,16 @@ static void vty_show_ip_route_detail_json(struct vty *vty,
 		 */
 		if (use_fib && re != dest->selected_fib)
 			continue;
+
 		vty_show_ip_route(vty, rn, re, json_prefix, use_fib, false);
+
+		/* Add flags and status to the last object */
+		json_object *json_route =
+			json_object_array_get_idx(json_prefix,
+						  json_object_array_length(json_prefix) - 1);
+
+		json_object_int_add(json_route, "flags", re->flags);
+		json_object_int_add(json_route, "status", re->status);
 	}
 
 	prefix2str(&rn->p, buf, sizeof(buf));


### PR DESCRIPTION
NHG improvements + fixes along with 

zebra: Re-install all route entries upon kernel NHG action/Quick intf flaps

When operations such as the below happens,
 - ip nexthop flush
 - ip nexthop del id <>
 - quick flap of interface

there are cases where the routes are re-installed when the nexthop-group
isnt yet installed. This will lead to route install failures which isnt
re-tried there by out of sync issues between kernel and zebra.

Take ip nexthop flush for example:
Say we have 10 routes using NHG 100 [50,60]. Upon flush, kernel cleans
up all the route + nexthop entries but notifies zebra only about the
nexthop delete event. Sequence of events could be
 - Kernel sends 100 NHG delete
 - Kernel sends 50 NHG delete
 - Kernel sends 60 NHG delete

When we receive NHG 100 delete, zebra immediately sees "Oh! routes still
point to it, let me reinstall NHG 100" but then kernel doesnt know about
the NHG 50 and 60 yet (so NHG 100 installation fails as expected)..
Only after the NHG's 50 and 60 are installed, the NHG 100 is installed
successfully. But in this timeframe, route installation(new/updated)
fails since NHG 100 was never installed and then it will never be
attempted to re-install.

Fix here is to maintain a rb tree of all the route-entries which uses
a nhe with the head of the tree in the struct nhg_hash_entry.
When the nhe is installed, we walk this tree and reinstall all the re's
which were SELECTED for install at that point in time. Post the NHG install,
the route installation will be successful as anyways.

It also takes care of unsetting the INSTALLED flag in re in case of
events where a NHG is to be reinstalled/going away.

For future purposes, we can use this nhe->re_head tree as per needed.


Also added a new show command
```
r1# sh nexthop-group rib 40 routes
Routes using nexthop group 40:
Route Entry                    Status          Protocol    AFI      SAFI
------------------------------ --------------- ----------  -------  -------
4.5.6.10/32                    installed       static        IPv4     unicast
4.5.6.11/32                    installed       static        IPv4     unicast
4.5.6.15/32                    not installed   static        IPv4     unicast
4.5.6.16/32                    installed       static        IPv4     unicast
4.5.6.17/32                    installed       static        IPv4     unicast
```