### PR TITLE
zebra: Allow nhg's to be reused when multiple interfaces are going amuck

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -145,7 +145,7 @@ static int _nexthop_source_cmp(const struct nexthop *nh1,
 }
 
 static int _nexthop_cmp_no_labels(const struct nexthop *next1,
-				  const struct nexthop *next2, bool use_weight)
+				  const struct nexthop *next2, bool use_weight, bool use_ifindex)
 {
 	int ret = 0;
 
@@ -181,6 +181,8 @@ static int _nexthop_cmp_no_labels(const struct nexthop *next1,
 		ret = _nexthop_gateway_cmp(next1, next2);
 		if (ret != 0)
 			return ret;
+		if (!use_ifindex)
+			break;
 		fallthrough;
 	case NEXTHOP_TYPE_IFINDEX:
 		if (next1->ifindex < next2->ifindex)
@@ -236,11 +238,11 @@ done:
 }
 
 static int nexthop_cmp_internal(const struct nexthop *next1,
-				const struct nexthop *next2, bool use_weight)
+				const struct nexthop *next2, bool use_weight, bool use_ifindex)
 {
 	int ret = 0;
 
-	ret = _nexthop_cmp_no_labels(next1, next2, use_weight);
+	ret = _nexthop_cmp_no_labels(next1, next2, use_weight, use_ifindex);
 	if (ret != 0)
 		return ret;
 
@@ -255,13 +257,13 @@ static int nexthop_cmp_internal(const struct nexthop *next1,
 
 int nexthop_cmp(const struct nexthop *next1, const struct nexthop *next2)
 {
-	return nexthop_cmp_internal(next1, next2, true);
+	return nexthop_cmp_internal(next1, next2, true, true);
 }
 
 int nexthop_cmp_no_weight(const struct nexthop *next1,
 			  const struct nexthop *next2)
 {
-	return nexthop_cmp_internal(next1, next2, false);
+	return nexthop_cmp_internal(next1, next2, false, true);
 }
 
 /*
@@ -432,6 +434,20 @@ void nexthops_free(struct nexthop *nexthop)
 	}
 }
 
+bool nexthop_same_no_ifindex(const struct nexthop *nh1, const struct nexthop *nh2)
+{
+	if (nh1 && !nh2)
+		return false;
+
+	if (!nh1 && nh2)
+		return false;
+
+	if (nh1 == nh2)
+		return true;
+
+	return nexthop_cmp_internal(nh1, nh2, true, false);
+}
+
 bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2)
 {
 	if (nh1 && !nh2)
@@ -461,7 +477,7 @@ bool nexthop_same_no_labels(const struct nexthop *nh1,
 	if (nh1 == nh2)
 		return true;
 
-	if (_nexthop_cmp_no_labels(nh1, nh2, true) != 0)
+	if (_nexthop_cmp_no_labels(nh1, nh2, true, true) != 0)
 		return false;
 
 	return true;

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -238,6 +238,7 @@ struct nexthop *nexthop_from_blackhole(enum blackhole_type bh_type,
 uint32_t nexthop_hash(const struct nexthop *nexthop);
 
 extern bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2);
+extern bool nexthop_same_no_ifindex(const struct nexthop *nh1, const struct nexthop *nh2);
 extern bool nexthop_same_no_labels(const struct nexthop *nh1,
 				   const struct nexthop *nh2);
 extern int nexthop_cmp(const struct nexthop *nh1, const struct nexthop *nh2);

--- a/tests/topotests/zebra_nhg_check/r1/frr.conf
+++ b/tests/topotests/zebra_nhg_check/r1/frr.conf
@@ -1,0 +1,786 @@
+int lo
+ ip addr 192.168.1.1/32
+ ipv6 address 2001:db8::1/128
+!
+interface r1-eth0
+ ip address 10.1.1.1/30
+ ipv6 address 2001:db8:1:1::1/64
+ no shutdown
+!
+interface r1-eth1
+ ip address 10.1.2.1/30
+ ipv6 address 2001:db8:1:2::1/64
+ no shutdown
+!
+interface r1-eth2
+ ip address 10.1.3.1/30
+ ipv6 address 2001:db8:1:3::1/64
+ no shutdown
+!
+interface r1-eth3
+ ip address 10.1.4.1/30
+ ipv6 address 2001:db8:1:4::1/64
+ no shutdown
+!
+interface r1-eth4
+ ip address 10.1.5.1/30
+ ipv6 address 2001:db8:1:5::1/64
+ no shutdown
+!
+interface r1-eth5
+ ip address 10.1.6.1/30
+ ipv6 address 2001:db8:1:6::1/64
+ no shutdown
+!
+interface r1-eth6
+ ip address 10.1.7.1/30
+ ipv6 address 2001:db8:1:7::1/64
+ no shutdown
+!
+interface r1-eth7
+ ip address 10.1.8.1/30
+ ipv6 address 2001:db8:1:8::1/64
+ no shutdown
+!
+interface r1-eth8
+ ip address 10.1.9.1/30
+ ipv6 address 2001:db8:1:9::1/64
+ no shutdown
+!
+interface r1-eth9
+ ip address 10.1.10.1/30
+ ipv6 address 2001:db8:1:10::1/64
+ no shutdown
+!
+interface r1-eth10
+ ip address 10.1.11.1/30
+ ipv6 address 2001:db8:1:11::1/64
+ no shutdown
+!
+interface r1-eth11
+ ip address 10.1.12.1/30
+ ipv6 address 2001:db8:1:12::1/64
+ no shutdown
+!
+interface r1-eth12
+ ip address 10.1.13.1/30
+ ipv6 address 2001:db8:1:13::1/64
+ no shutdown
+!
+interface r1-eth13
+ ip address 10.1.14.1/30
+ ipv6 address 2001:db8:1:14::1/64
+ no shutdown
+!
+interface r1-eth14
+ ip address 10.1.15.1/30
+ ipv6 address 2001:db8:1:15::1/64
+ no shutdown
+!
+interface r1-eth15
+ ip address 10.1.16.1/30
+ ipv6 address 2001:db8:1:16::1/64
+ no shutdown
+!
+interface r1-eth16
+ ip address 10.1.17.1/30
+ ipv6 address 2001:db8:1:17::1/64
+ no shutdown
+!
+interface r1-eth17
+ ip address 10.1.18.1/30
+ ipv6 address 2001:db8:1:18::1/64
+ no shutdown
+!
+interface r1-eth18
+ ip address 10.1.19.1/30
+ ipv6 address 2001:db8:1:19::1/64
+ no shutdown
+!
+interface r1-eth19
+ ip address 10.1.20.1/30
+ ipv6 address 2001:db8:1:20::1/64
+ no shutdown
+!
+interface r1-eth20
+ ip address 10.1.21.1/30
+ ipv6 address 2001:db8:1:21::1/64
+ no shutdown
+!
+interface r1-eth21
+ ip address 10.1.22.1/30
+ ipv6 address 2001:db8:1:22::1/64
+ no shutdown
+!
+interface r1-eth22
+ ip address 10.1.23.1/30
+ ipv6 address 2001:db8:1:23::1/64
+ no shutdown
+!
+interface r1-eth23
+ ip address 10.1.24.1/30
+ ipv6 address 2001:db8:1:24::1/64
+ no shutdown
+!
+interface r1-eth24
+ ip address 10.1.25.1/30
+ ipv6 address 2001:db8:1:25::1/64
+ no shutdown
+!
+interface r1-eth25
+ ip address 10.1.26.1/30
+ ipv6 address 2001:db8:1:26::1/64
+ no shutdown
+!
+interface r1-eth26
+ ip address 10.1.27.1/30
+ ipv6 address 2001:db8:1:27::1/64
+ no shutdown
+!
+interface r1-eth27
+ ip address 10.1.28.1/30
+ ipv6 address 2001:db8:1:28::1/64
+ no shutdown
+!
+interface r1-eth28
+ ip address 10.1.29.1/30
+ ipv6 address 2001:db8:1:29::1/64
+ no shutdown
+!
+interface r1-eth29
+ ip address 10.1.30.1/30
+ ipv6 address 2001:db8:1:30::1/64
+ no shutdown
+!
+interface r1-eth30
+ ip address 10.1.31.1/30
+ ipv6 address 2001:db8:1:31::1/64
+ no shutdown
+!
+interface r1-eth31
+ ip address 10.1.32.1/30
+ ipv6 address 2001:db8:1:32::1/64
+ no shutdown
+!
+interface r1-eth32
+ ip address 10.1.33.1/30
+ ipv6 address 2001:db8:1:33::1/64
+ no shutdown
+!
+interface r1-eth33
+ ip address 10.1.34.1/30
+ ipv6 address 2001:db8:1:34::1/64
+ no shutdown
+!
+interface r1-eth34
+ ip address 10.1.35.1/30
+ ipv6 address 2001:db8:1:35::1/64
+ no shutdown
+!
+interface r1-eth35
+ ip address 10.1.36.1/30
+ ipv6 address 2001:db8:1:36::1/64
+ no shutdown
+!
+interface r1-eth36
+ ip address 10.1.37.1/30
+ ipv6 address 2001:db8:1:37::1/64
+ no shutdown
+!
+interface r1-eth37
+ ip address 10.1.38.1/30
+ ipv6 address 2001:db8:1:38::1/64
+ no shutdown
+!
+interface r1-eth38
+ ip address 10.1.39.1/30
+ ipv6 address 2001:db8:1:39::1/64
+ no shutdown
+!
+interface r1-eth39
+ ip address 10.1.40.1/30
+ ipv6 address 2001:db8:1:40::1/64
+ no shutdown
+!
+interface r1-eth40
+ ip address 10.1.41.1/30
+ ipv6 address 2001:db8:1:41::1/64
+ no shutdown
+!
+interface r1-eth41
+ ip address 10.1.42.1/30
+ ipv6 address 2001:db8:1:42::1/64
+ no shutdown
+!
+interface r1-eth42
+ ip address 10.1.43.1/30
+ ipv6 address 2001:db8:1:43::1/64
+ no shutdown
+!
+interface r1-eth43
+ ip address 10.1.44.1/30
+ ipv6 address 2001:db8:1:44::1/64
+ no shutdown
+!
+interface r1-eth44
+ ip address 10.1.45.1/30
+ ipv6 address 2001:db8:1:45::1/64
+ no shutdown
+!
+interface r1-eth45
+ ip address 10.1.46.1/30
+ ipv6 address 2001:db8:1:46::1/64
+ no shutdown
+!
+interface r1-eth46
+ ip address 10.1.47.1/30
+ ipv6 address 2001:db8:1:47::1/64
+ no shutdown
+!
+interface r1-eth47
+ ip address 10.1.48.1/30
+ ipv6 address 2001:db8:1:48::1/64
+ no shutdown
+!
+interface r1-eth48
+ ip address 10.1.49.1/30
+ ipv6 address 2001:db8:1:49::1/64
+ no shutdown
+!
+interface r1-eth49
+ ip address 10.1.50.1/30
+ ipv6 address 2001:db8:1:50::1/64
+ no shutdown
+!
+interface r1-eth50
+ ip address 10.1.51.1/30
+ ipv6 address 2001:db8:1:51::1/64
+ no shutdown
+!
+interface r1-eth51
+ ip address 10.1.52.1/30
+ ipv6 address 2001:db8:1:52::1/64
+ no shutdown
+!
+interface r1-eth52
+ ip address 10.1.53.1/30
+ ipv6 address 2001:db8:1:53::1/64
+ no shutdown
+!
+interface r1-eth53
+ ip address 10.1.54.1/30
+ ipv6 address 2001:db8:1:54::1/64
+ no shutdown
+!
+interface r1-eth54
+ ip address 10.1.55.1/30
+ ipv6 address 2001:db8:1:55::1/64
+ no shutdown
+!
+interface r1-eth55
+ ip address 10.1.56.1/30
+ ipv6 address 2001:db8:1:56::1/64
+ no shutdown
+!
+interface r1-eth56
+ ip address 10.1.57.1/30
+ ipv6 address 2001:db8:1:57::1/64
+ no shutdown
+!
+interface r1-eth57
+ ip address 10.1.58.1/30
+ ipv6 address 2001:db8:1:58::1/64
+ no shutdown
+!
+interface r1-eth58
+ ip address 10.1.59.1/30
+ ipv6 address 2001:db8:1:59::1/64
+ no shutdown
+!
+interface r1-eth59
+ ip address 10.1.60.1/30
+ ipv6 address 2001:db8:1:60::1/64
+ no shutdown
+!
+interface r1-eth60
+ ip address 10.1.61.1/30
+ ipv6 address 2001:db8:1:61::1/64
+ no shutdown
+!
+interface r1-eth61
+ ip address 10.1.62.1/30
+ ipv6 address 2001:db8:1:62::1/64
+ no shutdown
+!
+interface r1-eth62
+ ip address 10.1.63.1/30
+ ipv6 address 2001:db8:1:63::1/64
+ no shutdown
+!
+interface r1-eth63
+ ip address 10.1.64.1/30
+ ipv6 address 2001:db8:1:64::1/64
+ no shutdown
+!
+interface r1-eth64
+ ip address 10.1.65.1/30
+ ipv6 address 2001:db8:1:65::1/64
+ no shutdown
+!
+interface r1-eth65
+ ip address 10.1.66.1/30
+ ipv6 address 2001:db8:1:66::1/64
+ no shutdown
+!
+interface r1-eth66
+ ip address 10.1.67.1/30
+ ipv6 address 2001:db8:1:67::1/64
+ no shutdown
+!
+interface r1-eth67
+ ip address 10.1.68.1/30
+ ipv6 address 2001:db8:1:68::1/64
+ no shutdown
+!
+interface r1-eth68
+ ip address 10.1.69.1/30
+ ipv6 address 2001:db8:1:69::1/64
+ no shutdown
+!
+interface r1-eth69
+ ip address 10.1.70.1/30
+ ipv6 address 2001:db8:1:70::1/64
+ no shutdown
+!
+interface r1-eth70
+ ip address 10.1.71.1/30
+ ipv6 address 2001:db8:1:71::1/64
+ no shutdown
+!
+interface r1-eth71
+ ip address 10.1.72.1/30
+ ipv6 address 2001:db8:1:72::1/64
+ no shutdown
+!
+interface r1-eth72
+ ip address 10.1.73.1/30
+ ipv6 address 2001:db8:1:73::1/64
+ no shutdown
+!
+interface r1-eth73
+ ip address 10.1.74.1/30
+ ipv6 address 2001:db8:1:74::1/64
+ no shutdown
+!
+interface r1-eth74
+ ip address 10.1.75.1/30
+ ipv6 address 2001:db8:1:75::1/64
+ no shutdown
+!
+interface r1-eth75
+ ip address 10.1.76.1/30
+ ipv6 address 2001:db8:1:76::1/64
+ no shutdown
+!
+interface r1-eth76
+ ip address 10.1.77.1/30
+ ipv6 address 2001:db8:1:77::1/64
+ no shutdown
+!
+interface r1-eth77
+ ip address 10.1.78.1/30
+ ipv6 address 2001:db8:1:78::1/64
+ no shutdown
+!
+interface r1-eth78
+ ip address 10.1.79.1/30
+ ipv6 address 2001:db8:1:79::1/64
+ no shutdown
+!
+interface r1-eth79
+ ip address 10.1.80.1/30
+ ipv6 address 2001:db8:1:80::1/64
+ no shutdown
+!
+interface r1-eth80
+ ip address 10.1.81.1/30
+ ipv6 address 2001:db8:1:81::1/64
+ no shutdown
+!
+interface r1-eth81
+ ip address 10.1.82.1/30
+ ipv6 address 2001:db8:1:82::1/64
+ no shutdown
+!
+interface r1-eth82
+ ip address 10.1.83.1/30
+ ipv6 address 2001:db8:1:83::1/64
+ no shutdown
+!
+interface r1-eth83
+ ip address 10.1.84.1/30
+ ipv6 address 2001:db8:1:84::1/64
+ no shutdown
+!
+interface r1-eth84
+ ip address 10.1.85.1/30
+ ipv6 address 2001:db8:1:85::1/64
+ no shutdown
+!
+interface r1-eth85
+ ip address 10.1.86.1/30
+ ipv6 address 2001:db8:1:86::1/64
+ no shutdown
+!
+interface r1-eth86
+ ip address 10.1.87.1/30
+ ipv6 address 2001:db8:1:87::1/64
+ no shutdown
+!
+interface r1-eth87
+ ip address 10.1.88.1/30
+ ipv6 address 2001:db8:1:88::1/64
+ no shutdown
+!
+interface r1-eth88
+ ip address 10.1.89.1/30
+ ipv6 address 2001:db8:1:89::1/64
+ no shutdown
+!
+interface r1-eth89
+ ip address 10.1.90.1/30
+ ipv6 address 2001:db8:1:90::1/64
+ no shutdown
+!
+interface r1-eth90
+ ip address 10.1.91.1/30
+ ipv6 address 2001:db8:1:91::1/64
+ no shutdown
+!
+interface r1-eth91
+ ip address 10.1.92.1/30
+ ipv6 address 2001:db8:1:92::1/64
+ no shutdown
+!
+interface r1-eth92
+ ip address 10.1.93.1/30
+ ipv6 address 2001:db8:1:93::1/64
+ no shutdown
+!
+interface r1-eth93
+ ip address 10.1.94.1/30
+ ipv6 address 2001:db8:1:94::1/64
+ no shutdown
+!
+interface r1-eth94
+ ip address 10.1.95.1/30
+ ipv6 address 2001:db8:1:95::1/64
+ no shutdown
+!
+interface r1-eth95
+ ip address 10.1.96.1/30
+ ipv6 address 2001:db8:1:96::1/64
+ no shutdown
+!
+interface r1-eth96
+ ip address 10.1.97.1/30
+ ipv6 address 2001:db8:1:97::1/64
+ no shutdown
+!
+interface r1-eth97
+ ip address 10.1.98.1/30
+ ipv6 address 2001:db8:1:98::1/64
+ no shutdown
+!
+interface r1-eth98
+ ip address 10.1.99.1/30
+ ipv6 address 2001:db8:1:99::1/64
+ no shutdown
+!
+interface r1-eth99
+ ip address 10.1.100.1/30
+ ipv6 address 2001:db8:1:100::1/64
+ no shutdown
+!
+interface r1-eth100
+ ip address 10.1.101.1/30
+ ipv6 address 2001:db8:1:101::1/64
+ no shutdown
+!
+interface r1-eth101
+ ip address 10.1.102.1/30
+ ipv6 address 2001:db8:1:102::1/64
+ no shutdown
+!
+interface r1-eth102
+ ip address 10.1.103.1/30
+ ipv6 address 2001:db8:1:103::1/64
+ no shutdown
+!
+interface r1-eth103
+ ip address 10.1.104.1/30
+ ipv6 address 2001:db8:1:104::1/64
+ no shutdown
+!
+interface r1-eth104
+ ip address 10.1.105.1/30
+ ipv6 address 2001:db8:1:105::1/64
+ no shutdown
+!
+interface r1-eth105
+ ip address 10.1.106.1/30
+ ipv6 address 2001:db8:1:106::1/64
+ no shutdown
+!
+interface r1-eth106
+ ip address 10.1.107.1/30
+ ipv6 address 2001:db8:1:107::1/64
+ no shutdown
+!
+interface r1-eth107
+ ip address 10.1.108.1/30
+ ipv6 address 2001:db8:1:108::1/64
+ no shutdown
+!
+interface r1-eth108
+ ip address 10.1.109.1/30
+ ipv6 address 2001:db8:1:109::1/64
+ no shutdown
+!
+interface r1-eth109
+ ip address 10.1.110.1/30
+ ipv6 address 2001:db8:1:110::1/64
+ no shutdown
+!
+interface r1-eth110
+ ip address 10.1.111.1/30
+ ipv6 address 2001:db8:1:111::1/64
+ no shutdown
+!
+interface r1-eth111
+ ip address 10.1.112.1/30
+ ipv6 address 2001:db8:1:112::1/64
+ no shutdown
+!
+interface r1-eth112
+ ip address 10.1.113.1/30
+ ipv6 address 2001:db8:1:113::1/64
+ no shutdown
+!
+interface r1-eth113
+ ip address 10.1.114.1/30
+ ipv6 address 2001:db8:1:114::1/64
+ no shutdown
+!
+interface r1-eth114
+ ip address 10.1.115.1/30
+ ipv6 address 2001:db8:1:115::1/64
+ no shutdown
+!
+interface r1-eth115
+ ip address 10.1.116.1/30
+ ipv6 address 2001:db8:1:116::1/64
+ no shutdown
+!
+interface r1-eth116
+ ip address 10.1.117.1/30
+ ipv6 address 2001:db8:1:117::1/64
+ no shutdown
+!
+interface r1-eth117
+ ip address 10.1.118.1/30
+ ipv6 address 2001:db8:1:118::1/64
+ no shutdown
+!
+interface r1-eth118
+ ip address 10.1.119.1/30
+ ipv6 address 2001:db8:1:119::1/64
+ no shutdown
+!
+interface r1-eth119
+ ip address 10.1.120.1/30
+ ipv6 address 2001:db8:1:120::1/64
+ no shutdown
+!
+interface r1-eth120
+ ip address 10.1.121.1/30
+ ipv6 address 2001:db8:1:121::1/64
+ no shutdown
+!
+interface r1-eth121
+ ip address 10.1.122.1/30
+ ipv6 address 2001:db8:1:122::1/64
+ no shutdown
+!
+interface r1-eth122
+ ip address 10.1.123.1/30
+ ipv6 address 2001:db8:1:123::1/64
+ no shutdown
+!
+interface r1-eth123
+ ip address 10.1.124.1/30
+ ipv6 address 2001:db8:1:124::1/64
+ no shutdown
+!
+interface r1-eth124
+ ip address 10.1.125.1/30
+ ipv6 address 2001:db8:1:125::1/64
+ no shutdown
+!
+interface r1-eth125
+ ip address 10.1.126.1/30
+ ipv6 address 2001:db8:1:126::1/64
+ no shutdown
+!
+interface r1-eth126
+ ip address 10.1.127.1/30
+ ipv6 address 2001:db8:1:127::1/64
+ no shutdown
+!
+interface r1-eth127
+ ip address 10.1.128.1/30
+ ipv6 address 2001:db8:1:128::1/64
+ no shutdown
+!
+interface r1-eth128
+ ip address 10.1.129.1/30
+ ipv6 address 2001:db8:1:129::1/64
+ no shutdown
+!
+router bgp 1001
+  timers bgp 5 60
+  no bgp ebgp-requires-policy
+  read-quanta 1
+  neighbor r1-eth0 interface remote-as external
+  neighbor r1-eth1 interface remote-as external
+  neighbor r1-eth2 interface remote-as external
+  neighbor r1-eth3 interface remote-as external
+  neighbor r1-eth4 interface remote-as external
+  neighbor r1-eth5 interface remote-as external
+  neighbor r1-eth6 interface remote-as external
+  neighbor r1-eth7 interface remote-as external
+  neighbor r1-eth8 interface remote-as external
+  neighbor r1-eth9 interface remote-as external
+  neighbor r1-eth10 interface remote-as external
+  neighbor r1-eth11 interface remote-as external
+  neighbor r1-eth12 interface remote-as external
+  neighbor r1-eth13 interface remote-as external
+  neighbor r1-eth14 interface remote-as external
+  neighbor r1-eth15 interface remote-as external
+  neighbor r1-eth16 interface remote-as external
+  neighbor r1-eth17 interface remote-as external
+  neighbor r1-eth18 interface remote-as external
+  neighbor r1-eth19 interface remote-as external
+  neighbor r1-eth20 interface remote-as external
+  neighbor r1-eth21 interface remote-as external
+  neighbor r1-eth22 interface remote-as external
+  neighbor r1-eth23 interface remote-as external
+  neighbor r1-eth24 interface remote-as external
+  neighbor r1-eth25 interface remote-as external
+  neighbor r1-eth26 interface remote-as external
+  neighbor r1-eth27 interface remote-as external
+  neighbor r1-eth28 interface remote-as external
+  neighbor r1-eth29 interface remote-as external
+  neighbor r1-eth30 interface remote-as external
+  neighbor r1-eth31 interface remote-as external
+  neighbor r1-eth32 interface remote-as external
+  neighbor r1-eth33 interface remote-as external
+  neighbor r1-eth34 interface remote-as external
+  neighbor r1-eth35 interface remote-as external
+  neighbor r1-eth36 interface remote-as external
+  neighbor r1-eth37 interface remote-as external
+  neighbor r1-eth38 interface remote-as external
+  neighbor r1-eth39 interface remote-as external
+  neighbor r1-eth40 interface remote-as external
+  neighbor r1-eth41 interface remote-as external
+  neighbor r1-eth42 interface remote-as external
+  neighbor r1-eth43 interface remote-as external
+  neighbor r1-eth44 interface remote-as external
+  neighbor r1-eth45 interface remote-as external
+  neighbor r1-eth46 interface remote-as external
+  neighbor r1-eth47 interface remote-as external
+  neighbor r1-eth48 interface remote-as external
+  neighbor r1-eth49 interface remote-as external
+  neighbor r1-eth50 interface remote-as external
+  neighbor r1-eth51 interface remote-as external
+  neighbor r1-eth52 interface remote-as external
+  neighbor r1-eth53 interface remote-as external
+  neighbor r1-eth54 interface remote-as external
+  neighbor r1-eth55 interface remote-as external
+  neighbor r1-eth56 interface remote-as external
+  neighbor r1-eth57 interface remote-as external
+  neighbor r1-eth58 interface remote-as external
+  neighbor r1-eth59 interface remote-as external
+  neighbor r1-eth60 interface remote-as external
+  neighbor r1-eth61 interface remote-as external
+  neighbor r1-eth62 interface remote-as external
+  neighbor r1-eth63 interface remote-as external
+  neighbor r1-eth64 interface remote-as external
+  neighbor r1-eth65 interface remote-as external
+  neighbor r1-eth66 interface remote-as external
+  neighbor r1-eth67 interface remote-as external
+  neighbor r1-eth68 interface remote-as external
+  neighbor r1-eth69 interface remote-as external
+  neighbor r1-eth70 interface remote-as external
+  neighbor r1-eth71 interface remote-as external
+  neighbor r1-eth72 interface remote-as external
+  neighbor r1-eth73 interface remote-as external
+  neighbor r1-eth74 interface remote-as external
+  neighbor r1-eth75 interface remote-as external
+  neighbor r1-eth76 interface remote-as external
+  neighbor r1-eth77 interface remote-as external
+  neighbor r1-eth78 interface remote-as external
+  neighbor r1-eth79 interface remote-as external
+  neighbor r1-eth80 interface remote-as external
+  neighbor r1-eth81 interface remote-as external
+  neighbor r1-eth82 interface remote-as external
+  neighbor r1-eth83 interface remote-as external
+  neighbor r1-eth84 interface remote-as external
+  neighbor r1-eth85 interface remote-as external
+  neighbor r1-eth86 interface remote-as external
+  neighbor r1-eth87 interface remote-as external
+  neighbor r1-eth88 interface remote-as external
+  neighbor r1-eth89 interface remote-as external
+  neighbor r1-eth90 interface remote-as external
+  neighbor r1-eth91 interface remote-as external
+  neighbor r1-eth92 interface remote-as external
+  neighbor r1-eth93 interface remote-as external
+  neighbor r1-eth94 interface remote-as external
+  neighbor r1-eth95 interface remote-as external
+  neighbor r1-eth96 interface remote-as external
+  neighbor r1-eth97 interface remote-as external
+  neighbor r1-eth98 interface remote-as external
+  neighbor r1-eth99 interface remote-as external
+  neighbor r1-eth100 interface remote-as external
+  neighbor r1-eth101 interface remote-as external
+  neighbor r1-eth102 interface remote-as external
+  neighbor r1-eth103 interface remote-as external
+  neighbor r1-eth104 interface remote-as external
+  neighbor r1-eth105 interface remote-as external
+  neighbor r1-eth106 interface remote-as external
+  neighbor r1-eth107 interface remote-as external
+  neighbor r1-eth108 interface remote-as external
+  neighbor r1-eth109 interface remote-as external
+  neighbor r1-eth110 interface remote-as external
+  neighbor r1-eth111 interface remote-as external
+  neighbor r1-eth112 interface remote-as external
+  neighbor r1-eth113 interface remote-as external
+  neighbor r1-eth114 interface remote-as external
+  neighbor r1-eth115 interface remote-as external
+  neighbor r1-eth116 interface remote-as external
+  neighbor r1-eth117 interface remote-as external
+  neighbor r1-eth118 interface remote-as external
+  neighbor r1-eth119 interface remote-as external
+  neighbor r1-eth120 interface remote-as external
+  neighbor r1-eth121 interface remote-as external
+  neighbor r1-eth122 interface remote-as external
+  neighbor r1-eth123 interface remote-as external
+  neighbor r1-eth124 interface remote-as external
+  neighbor r1-eth125 interface remote-as external
+  neighbor r1-eth126 interface remote-as external
+  neighbor r1-eth127 interface remote-as external
+  neighbor r1-eth128 interface remote-as external
+
+  address-family ipv4 uni
+   redistribute sharp
+exit

--- a/tests/topotests/zebra_nhg_check/r2/frr.conf
+++ b/tests/topotests/zebra_nhg_check/r2/frr.conf
@@ -1,0 +1,778 @@
+int lo
+ ip addr 192.168.1.2/32
+ ipv6 address 2001:db8::2/128
+!
+interface r2-eth0
+ ip address 10.1.1.2/30
+ ipv6 address 2001:db8:1:1::2/64
+ no shutdown
+!
+interface r2-eth1
+ ip address 10.1.2.2/30
+ ipv6 address 2001:db8:1:2::2/64
+ no shutdown
+!
+interface r2-eth2
+ ip address 10.1.3.2/30
+ ipv6 address 2001:db8:1:3::2/64
+ no shutdown
+!
+interface r2-eth3
+ ip address 10.1.4.2/30
+ ipv6 address 2001:db8:1:4::2/64
+ no shutdown
+!
+interface r2-eth4
+ ip address 10.1.5.2/30
+ ipv6 address 2001:db8:1:5::2/64
+ no shutdown
+!
+interface r2-eth5
+ ip address 10.1.6.2/30
+ ipv6 address 2001:db8:1:6::2/64
+ no shutdown
+!
+interface r2-eth6
+ ip address 10.1.7.2/30
+ ipv6 address 2001:db8:1:7::2/64
+ no shutdown
+!
+interface r2-eth7
+ ip address 10.1.8.2/30
+ ipv6 address 2001:db8:1:8::2/64
+ no shutdown
+!
+interface r2-eth8
+ ip address 10.1.9.2/30
+ ipv6 address 2001:db8:1:9::2/64
+ no shutdown
+!
+interface r2-eth9
+ ip address 10.1.10.2/30
+ ipv6 address 2001:db8:1:10::2/64
+ no shutdown
+!
+interface r2-eth10
+ ip address 10.1.11.2/30
+ ipv6 address 2001:db8:1:11::2/64
+ no shutdown
+!
+interface r2-eth11
+ ip address 10.1.12.2/30
+ ipv6 address 2001:db8:1:12::2/64
+ no shutdown
+!
+interface r2-eth12
+ ip address 10.1.13.2/30
+ ipv6 address 2001:db8:1:13::2/64
+ no shutdown
+!
+interface r2-eth13
+ ip address 10.1.14.2/30
+ ipv6 address 2001:db8:1:14::2/64
+ no shutdown
+!
+interface r2-eth14
+ ip address 10.1.15.2/30
+ ipv6 address 2001:db8:1:15::2/64
+ no shutdown
+!
+interface r2-eth15
+ ip address 10.1.16.2/30
+ ipv6 address 2001:db8:1:16::2/64
+ no shutdown
+!
+interface r2-eth16
+ ip address 10.1.17.2/30
+ ipv6 address 2001:db8:1:17::2/64
+ no shutdown
+!
+interface r2-eth17
+ ip address 10.1.18.2/30
+ ipv6 address 2001:db8:1:18::2/64
+ no shutdown
+!
+interface r2-eth18
+ ip address 10.1.19.2/30
+ ipv6 address 2001:db8:1:19::2/64
+ no shutdown
+!
+interface r2-eth19
+ ip address 10.1.20.2/30
+ ipv6 address 2001:db8:1:20::2/64
+ no shutdown
+!
+interface r2-eth20
+ ip address 10.1.21.2/30
+ ipv6 address 2001:db8:1:21::2/64
+ no shutdown
+!
+interface r2-eth21
+ ip address 10.1.22.2/30
+ ipv6 address 2001:db8:1:22::2/64
+ no shutdown
+!
+interface r2-eth22
+ ip address 10.1.23.2/30
+ ipv6 address 2001:db8:1:23::2/64
+ no shutdown
+!
+interface r2-eth23
+ ip address 10.1.24.2/30
+ ipv6 address 2001:db8:1:24::2/64
+ no shutdown
+!
+interface r2-eth24
+ ip address 10.1.25.2/30
+ ipv6 address 2001:db8:1:25::2/64
+ no shutdown
+!
+interface r2-eth25
+ ip address 10.1.26.2/30
+ ipv6 address 2001:db8:1:26::2/64
+ no shutdown
+!
+interface r2-eth26
+ ip address 10.1.27.2/30
+ ipv6 address 2001:db8:1:27::2/64
+ no shutdown
+!
+interface r2-eth27
+ ip address 10.1.28.2/30
+ ipv6 address 2001:db8:1:28::2/64
+ no shutdown
+!
+interface r2-eth28
+ ip address 10.1.29.2/30
+ ipv6 address 2001:db8:1:29::2/64
+ no shutdown
+!
+interface r2-eth29
+ ip address 10.1.30.2/30
+ ipv6 address 2001:db8:1:30::2/64
+ no shutdown
+!
+interface r2-eth30
+ ip address 10.1.31.2/30
+ ipv6 address 2001:db8:1:31::2/64
+ no shutdown
+!
+interface r2-eth31
+ ip address 10.1.32.2/30
+ ipv6 address 2001:db8:1:32::2/64
+ no shutdown
+!
+interface r2-eth32
+ ip address 10.1.33.2/30
+ ipv6 address 2001:db8:1:33::2/64
+ no shutdown
+!
+interface r2-eth33
+ ip address 10.1.34.2/30
+ ipv6 address 2001:db8:1:34::2/64
+ no shutdown
+!
+interface r2-eth34
+ ip address 10.1.35.2/30
+ ipv6 address 2001:db8:1:35::2/64
+ no shutdown
+!
+interface r2-eth35
+ ip address 10.1.36.2/30
+ ipv6 address 2001:db8:1:36::2/64
+ no shutdown
+!
+interface r2-eth36
+ ip address 10.1.37.2/30
+ ipv6 address 2001:db8:1:37::2/64
+ no shutdown
+!
+interface r2-eth37
+ ip address 10.1.38.2/30
+ ipv6 address 2001:db8:1:38::2/64
+ no shutdown
+!
+interface r2-eth38
+ ip address 10.1.39.2/30
+ ipv6 address 2001:db8:1:39::2/64
+ no shutdown
+!
+interface r2-eth39
+ ip address 10.1.40.2/30
+ ipv6 address 2001:db8:1:40::2/64
+ no shutdown
+!
+interface r2-eth40
+ ip address 10.1.41.2/30
+ ipv6 address 2001:db8:1:41::2/64
+ no shutdown
+!
+interface r2-eth41
+ ip address 10.1.42.2/30
+ ipv6 address 2001:db8:1:42::2/64
+ no shutdown
+!
+interface r2-eth42
+ ip address 10.1.43.2/30
+ ipv6 address 2001:db8:1:43::2/64
+ no shutdown
+!
+interface r2-eth43
+ ip address 10.1.44.2/30
+ ipv6 address 2001:db8:1:44::2/64
+ no shutdown
+!
+interface r2-eth44
+ ip address 10.1.45.2/30
+ ipv6 address 2001:db8:1:45::2/64
+ no shutdown
+!
+interface r2-eth45
+ ip address 10.1.46.2/30
+ ipv6 address 2001:db8:1:46::2/64
+ no shutdown
+!
+interface r2-eth46
+ ip address 10.1.47.2/30
+ ipv6 address 2001:db8:1:47::2/64
+ no shutdown
+!
+interface r2-eth47
+ ip address 10.1.48.2/30
+ ipv6 address 2001:db8:1:48::2/64
+ no shutdown
+!
+interface r2-eth48
+ ip address 10.1.49.2/30
+ ipv6 address 2001:db8:1:49::2/64
+ no shutdown
+!
+interface r2-eth49
+ ip address 10.1.50.2/30
+ ipv6 address 2001:db8:1:50::2/64
+ no shutdown
+!
+interface r2-eth50
+ ip address 10.1.51.2/30
+ ipv6 address 2001:db8:1:51::2/64
+ no shutdown
+!
+interface r2-eth51
+ ip address 10.1.52.2/30
+ ipv6 address 2001:db8:1:52::2/64
+ no shutdown
+!
+interface r2-eth52
+ ip address 10.1.53.2/30
+ ipv6 address 2001:db8:1:53::2/64
+ no shutdown
+!
+interface r2-eth53
+ ip address 10.1.54.2/30
+ ipv6 address 2001:db8:1:54::2/64
+ no shutdown
+!
+interface r2-eth54
+ ip address 10.1.55.2/30
+ ipv6 address 2001:db8:1:55::2/64
+ no shutdown
+!
+interface r2-eth55
+ ip address 10.1.56.2/30
+ ipv6 address 2001:db8:1:56::2/64
+ no shutdown
+!
+interface r2-eth56
+ ip address 10.1.57.2/30
+ ipv6 address 2001:db8:1:57::2/64
+ no shutdown
+!
+interface r2-eth57
+ ip address 10.1.58.2/30
+ ipv6 address 2001:db8:1:58::2/64
+ no shutdown
+!
+interface r2-eth58
+ ip address 10.1.59.2/30
+ ipv6 address 2001:db8:1:59::2/64
+ no shutdown
+!
+interface r2-eth59
+ ip address 10.1.60.2/30
+ ipv6 address 2001:db8:1:60::2/64
+ no shutdown
+!
+interface r2-eth60
+ ip address 10.1.61.2/30
+ ipv6 address 2001:db8:1:61::2/64
+ no shutdown
+!
+interface r2-eth61
+ ip address 10.1.62.2/30
+ ipv6 address 2001:db8:1:62::2/64
+ no shutdown
+!
+interface r2-eth62
+ ip address 10.1.63.2/30
+ ipv6 address 2001:db8:1:63::2/64
+ no shutdown
+!
+interface r2-eth63
+ ip address 10.1.64.2/30
+ ipv6 address 2001:db8:1:64::2/64
+ no shutdown
+!
+interface r2-eth64
+ ip address 10.1.65.2/30
+ ipv6 address 2001:db8:1:65::2/64
+ no shutdown
+!
+interface r2-eth65
+ ip address 10.1.66.2/30
+ ipv6 address 2001:db8:1:66::2/64
+ no shutdown
+!
+interface r2-eth66
+ ip address 10.1.67.2/30
+ ipv6 address 2001:db8:1:67::2/64
+ no shutdown
+!
+interface r2-eth67
+ ip address 10.1.68.2/30
+ ipv6 address 2001:db8:1:68::2/64
+ no shutdown
+!
+interface r2-eth68
+ ip address 10.1.69.2/30
+ ipv6 address 2001:db8:1:69::2/64
+ no shutdown
+!
+interface r2-eth69
+ ip address 10.1.70.2/30
+ ipv6 address 2001:db8:1:70::2/64
+ no shutdown
+!
+interface r2-eth70
+ ip address 10.1.71.2/30
+ ipv6 address 2001:db8:1:71::2/64
+ no shutdown
+!
+interface r2-eth71
+ ip address 10.1.72.2/30
+ ipv6 address 2001:db8:1:72::2/64
+ no shutdown
+!
+interface r2-eth72
+ ip address 10.1.73.2/30
+ ipv6 address 2001:db8:1:73::2/64
+ no shutdown
+!
+interface r2-eth73
+ ip address 10.1.74.2/30
+ ipv6 address 2001:db8:1:74::2/64
+ no shutdown
+!
+interface r2-eth74
+ ip address 10.1.75.2/30
+ ipv6 address 2001:db8:1:75::2/64
+ no shutdown
+!
+interface r2-eth75
+ ip address 10.1.76.2/30
+ ipv6 address 2001:db8:1:76::2/64
+ no shutdown
+!
+interface r2-eth76
+ ip address 10.1.77.2/30
+ ipv6 address 2001:db8:1:77::2/64
+ no shutdown
+!
+interface r2-eth77
+ ip address 10.1.78.2/30
+ ipv6 address 2001:db8:1:78::2/64
+ no shutdown
+!
+interface r2-eth78
+ ip address 10.1.79.2/30
+ ipv6 address 2001:db8:1:79::2/64
+ no shutdown
+!
+interface r2-eth79
+ ip address 10.1.80.2/30
+ ipv6 address 2001:db8:1:80::2/64
+ no shutdown
+!
+interface r2-eth80
+ ip address 10.1.81.2/30
+ ipv6 address 2001:db8:1:81::2/64
+ no shutdown
+!
+interface r2-eth81
+ ip address 10.1.82.2/30
+ ipv6 address 2001:db8:1:82::2/64
+ no shutdown
+!
+interface r2-eth82
+ ip address 10.1.83.2/30
+ ipv6 address 2001:db8:1:83::2/64
+ no shutdown
+!
+interface r2-eth83
+ ip address 10.1.84.2/30
+ ipv6 address 2001:db8:1:84::2/64
+ no shutdown
+!
+interface r2-eth84
+ ip address 10.1.85.2/30
+ ipv6 address 2001:db8:1:85::2/64
+ no shutdown
+!
+interface r2-eth85
+ ip address 10.1.86.2/30
+ ipv6 address 2001:db8:1:86::2/64
+ no shutdown
+!
+interface r2-eth86
+ ip address 10.1.87.2/30
+ ipv6 address 2001:db8:1:87::2/64
+ no shutdown
+!
+interface r2-eth87
+ ip address 10.1.88.2/30
+ ipv6 address 2001:db8:1:88::2/64
+ no shutdown
+!
+interface r2-eth88
+ ip address 10.1.89.2/30
+ ipv6 address 2001:db8:1:89::2/64
+ no shutdown
+!
+interface r2-eth89
+ ip address 10.1.90.2/30
+ ipv6 address 2001:db8:1:90::2/64
+ no shutdown
+!
+interface r2-eth90
+ ip address 10.1.91.2/30
+ ipv6 address 2001:db8:1:91::2/64
+ no shutdown
+!
+interface r2-eth91
+ ip address 10.1.92.2/30
+ ipv6 address 2001:db8:1:92::2/64
+ no shutdown
+!
+interface r2-eth92
+ ip address 10.1.93.2/30
+ ipv6 address 2001:db8:1:93::2/64
+ no shutdown
+!
+interface r2-eth93
+ ip address 10.1.94.2/30
+ ipv6 address 2001:db8:1:94::2/64
+ no shutdown
+!
+interface r2-eth94
+ ip address 10.1.95.2/30
+ ipv6 address 2001:db8:1:95::2/64
+ no shutdown
+!
+interface r2-eth95
+ ip address 10.1.96.2/30
+ ipv6 address 2001:db8:1:96::2/64
+ no shutdown
+!
+interface r2-eth96
+ ip address 10.1.97.2/30
+ ipv6 address 2001:db8:1:97::2/64
+ no shutdown
+!
+interface r2-eth97
+ ip address 10.1.98.2/30
+ ipv6 address 2001:db8:1:98::2/64
+ no shutdown
+!
+interface r2-eth98
+ ip address 10.1.99.2/30
+ ipv6 address 2001:db8:1:99::2/64
+ no shutdown
+!
+interface r2-eth99
+ ip address 10.1.100.2/30
+ ipv6 address 2001:db8:1:100::2/64
+ no shutdown
+!
+interface r2-eth100
+ ip address 10.1.101.2/30
+ ipv6 address 2001:db8:1:101::2/64
+ no shutdown
+!
+interface r2-eth101
+ ip address 10.1.102.2/30
+ ipv6 address 2001:db8:1:102::2/64
+ no shutdown
+!
+interface r2-eth102
+ ip address 10.1.103.2/30
+ ipv6 address 2001:db8:1:103::2/64
+ no shutdown
+!
+interface r2-eth103
+ ip address 10.1.104.2/30
+ ipv6 address 2001:db8:1:104::2/64
+ no shutdown
+!
+interface r2-eth104
+ ip address 10.1.105.2/30
+ ipv6 address 2001:db8:1:105::2/64
+ no shutdown
+!
+interface r2-eth105
+ ip address 10.1.106.2/30
+ ipv6 address 2001:db8:1:106::2/64
+ no shutdown
+!
+interface r2-eth106
+ ip address 10.1.107.2/30
+ ipv6 address 2001:db8:1:107::2/64
+ no shutdown
+!
+interface r2-eth107
+ ip address 10.1.108.2/30
+ ipv6 address 2001:db8:1:108::2/64
+ no shutdown
+!
+interface r2-eth108
+ ip address 10.1.109.2/30
+ ipv6 address 2001:db8:1:109::2/64
+ no shutdown
+!
+interface r2-eth109
+ ip address 10.1.110.2/30
+ ipv6 address 2001:db8:1:110::2/64
+ no shutdown
+!
+interface r2-eth110
+ ip address 10.1.111.2/30
+ ipv6 address 2001:db8:1:111::2/64
+ no shutdown
+!
+interface r2-eth111
+ ip address 10.1.112.2/30
+ ipv6 address 2001:db8:1:112::2/64
+ no shutdown
+!
+interface r2-eth112
+ ip address 10.1.113.2/30
+ ipv6 address 2001:db8:1:113::2/64
+ no shutdown
+!
+interface r2-eth113
+ ip address 10.1.114.2/30
+ ipv6 address 2001:db8:1:114::2/64
+ no shutdown
+!
+interface r2-eth114
+ ip address 10.1.115.2/30
+ ipv6 address 2001:db8:1:115::2/64
+ no shutdown
+!
+interface r2-eth115
+ ip address 10.1.116.2/30
+ ipv6 address 2001:db8:1:116::2/64
+ no shutdown
+!
+interface r2-eth116
+ ip address 10.1.117.2/30
+ ipv6 address 2001:db8:1:117::2/64
+ no shutdown
+!
+interface r2-eth117
+ ip address 10.1.118.2/30
+ ipv6 address 2001:db8:1:118::2/64
+ no shutdown
+!
+interface r2-eth118
+ ip address 10.1.119.2/30
+ ipv6 address 2001:db8:1:119::2/64
+ no shutdown
+!
+interface r2-eth119
+ ip address 10.1.120.2/30
+ ipv6 address 2001:db8:1:120::2/64
+ no shutdown
+!
+interface r2-eth120
+ ip address 10.1.121.2/30
+ ipv6 address 2001:db8:1:121::2/64
+ no shutdown
+!
+interface r2-eth121
+ ip address 10.1.122.2/30
+ ipv6 address 2001:db8:1:122::2/64
+ no shutdown
+!
+interface r2-eth122
+ ip address 10.1.123.2/30
+ ipv6 address 2001:db8:1:123::2/64
+ no shutdown
+!
+interface r2-eth123
+ ip address 10.1.124.2/30
+ ipv6 address 2001:db8:1:124::2/64
+ no shutdown
+!
+interface r2-eth124
+ ip address 10.1.125.2/30
+ ipv6 address 2001:db8:1:125::2/64
+ no shutdown
+!
+interface r2-eth125
+ ip address 10.1.126.2/30
+ ipv6 address 2001:db8:1:126::2/64
+ no shutdown
+!
+interface r2-eth126
+ ip address 10.1.127.2/30
+ ipv6 address 2001:db8:1:127::2/64
+ no shutdown
+!
+interface r2-eth127
+ ip address 10.1.128.2/30
+ ipv6 address 2001:db8:1:128::2/64
+ no shutdown
+!
+router bgp 1002
+  timers bgp 5 60
+  no bgp ebgp-requires-policy
+  read-quanta 1
+  neighbor r2-eth0 interface remote-as external
+  neighbor r2-eth1 interface remote-as external
+  neighbor r2-eth2 interface remote-as external
+  neighbor r2-eth3 interface remote-as external
+  neighbor r2-eth4 interface remote-as external
+  neighbor r2-eth5 interface remote-as external
+  neighbor r2-eth6 interface remote-as external
+  neighbor r2-eth7 interface remote-as external
+  neighbor r2-eth8 interface remote-as external
+  neighbor r2-eth9 interface remote-as external
+  neighbor r2-eth10 interface remote-as external
+  neighbor r2-eth11 interface remote-as external
+  neighbor r2-eth12 interface remote-as external
+  neighbor r2-eth13 interface remote-as external
+  neighbor r2-eth14 interface remote-as external
+  neighbor r2-eth15 interface remote-as external
+  neighbor r2-eth16 interface remote-as external
+  neighbor r2-eth17 interface remote-as external
+  neighbor r2-eth18 interface remote-as external
+  neighbor r2-eth19 interface remote-as external
+  neighbor r2-eth20 interface remote-as external
+  neighbor r2-eth21 interface remote-as external
+  neighbor r2-eth22 interface remote-as external
+  neighbor r2-eth23 interface remote-as external
+  neighbor r2-eth24 interface remote-as external
+  neighbor r2-eth25 interface remote-as external
+  neighbor r2-eth26 interface remote-as external
+  neighbor r2-eth27 interface remote-as external
+  neighbor r2-eth28 interface remote-as external
+  neighbor r2-eth29 interface remote-as external
+  neighbor r2-eth30 interface remote-as external
+  neighbor r2-eth31 interface remote-as external
+  neighbor r2-eth32 interface remote-as external
+  neighbor r2-eth33 interface remote-as external
+  neighbor r2-eth34 interface remote-as external
+  neighbor r2-eth35 interface remote-as external
+  neighbor r2-eth36 interface remote-as external
+  neighbor r2-eth37 interface remote-as external
+  neighbor r2-eth38 interface remote-as external
+  neighbor r2-eth39 interface remote-as external
+  neighbor r2-eth40 interface remote-as external
+  neighbor r2-eth41 interface remote-as external
+  neighbor r2-eth42 interface remote-as external
+  neighbor r2-eth43 interface remote-as external
+  neighbor r2-eth44 interface remote-as external
+  neighbor r2-eth45 interface remote-as external
+  neighbor r2-eth46 interface remote-as external
+  neighbor r2-eth47 interface remote-as external
+  neighbor r2-eth48 interface remote-as external
+  neighbor r2-eth49 interface remote-as external
+  neighbor r2-eth50 interface remote-as external
+  neighbor r2-eth51 interface remote-as external
+  neighbor r2-eth52 interface remote-as external
+  neighbor r2-eth53 interface remote-as external
+  neighbor r2-eth54 interface remote-as external
+  neighbor r2-eth55 interface remote-as external
+  neighbor r2-eth56 interface remote-as external
+  neighbor r2-eth57 interface remote-as external
+  neighbor r2-eth58 interface remote-as external
+  neighbor r2-eth59 interface remote-as external
+  neighbor r2-eth60 interface remote-as external
+  neighbor r2-eth61 interface remote-as external
+  neighbor r2-eth62 interface remote-as external
+  neighbor r2-eth63 interface remote-as external
+  neighbor r2-eth64 interface remote-as external
+  neighbor r2-eth65 interface remote-as external
+  neighbor r2-eth66 interface remote-as external
+  neighbor r2-eth67 interface remote-as external
+  neighbor r2-eth68 interface remote-as external
+  neighbor r2-eth69 interface remote-as external
+  neighbor r2-eth70 interface remote-as external
+  neighbor r2-eth71 interface remote-as external
+  neighbor r2-eth72 interface remote-as external
+  neighbor r2-eth73 interface remote-as external
+  neighbor r2-eth74 interface remote-as external
+  neighbor r2-eth75 interface remote-as external
+  neighbor r2-eth76 interface remote-as external
+  neighbor r2-eth77 interface remote-as external
+  neighbor r2-eth78 interface remote-as external
+  neighbor r2-eth79 interface remote-as external
+  neighbor r2-eth80 interface remote-as external
+  neighbor r2-eth81 interface remote-as external
+  neighbor r2-eth82 interface remote-as external
+  neighbor r2-eth83 interface remote-as external
+  neighbor r2-eth84 interface remote-as external
+  neighbor r2-eth85 interface remote-as external
+  neighbor r2-eth86 interface remote-as external
+  neighbor r2-eth87 interface remote-as external
+  neighbor r2-eth88 interface remote-as external
+  neighbor r2-eth89 interface remote-as external
+  neighbor r2-eth90 interface remote-as external
+  neighbor r2-eth91 interface remote-as external
+  neighbor r2-eth92 interface remote-as external
+  neighbor r2-eth93 interface remote-as external
+  neighbor r2-eth94 interface remote-as external
+  neighbor r2-eth95 interface remote-as external
+  neighbor r2-eth96 interface remote-as external
+  neighbor r2-eth97 interface remote-as external
+  neighbor r2-eth98 interface remote-as external
+  neighbor r2-eth99 interface remote-as external
+  neighbor r2-eth100 interface remote-as external
+  neighbor r2-eth101 interface remote-as external
+  neighbor r2-eth102 interface remote-as external
+  neighbor r2-eth103 interface remote-as external
+  neighbor r2-eth104 interface remote-as external
+  neighbor r2-eth105 interface remote-as external
+  neighbor r2-eth106 interface remote-as external
+  neighbor r2-eth107 interface remote-as external
+  neighbor r2-eth108 interface remote-as external
+  neighbor r2-eth109 interface remote-as external
+  neighbor r2-eth110 interface remote-as external
+  neighbor r2-eth111 interface remote-as external
+  neighbor r2-eth112 interface remote-as external
+  neighbor r2-eth113 interface remote-as external
+  neighbor r2-eth114 interface remote-as external
+  neighbor r2-eth115 interface remote-as external
+  neighbor r2-eth116 interface remote-as external
+  neighbor r2-eth117 interface remote-as external
+  neighbor r2-eth118 interface remote-as external
+  neighbor r2-eth119 interface remote-as external
+  neighbor r2-eth120 interface remote-as external
+  neighbor r2-eth121 interface remote-as external
+  neighbor r2-eth122 interface remote-as external
+  neighbor r2-eth123 interface remote-as external
+  neighbor r2-eth124 interface remote-as external
+  neighbor r2-eth125 interface remote-as external
+  neighbor r2-eth126 interface remote-as external
+  neighbor r2-eth127 interface remote-as external
+exit-address-family
+exit

--- a/tests/topotests/zebra_nhg_check/test_zebra_nhg.py
+++ b/tests/topotests/zebra_nhg_check/test_zebra_nhg.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_high_ecmp.py
+#
+# Copyright (c) 2025 by
+# Nvidia Corporation
+# Donald Sharp
+#
+
+"""
+test_high_ecmp.py: Testing two routers with 256 interfaces and BGP setup
+                   on it.
+
+"""
+
+import os
+import re
+import sys
+import pytest
+import json
+from time import sleep
+
+from lib.common_config import (
+    kill_router_daemons,
+    start_router_daemons,
+)
+
+pytestmark = [pytest.mark.bgpd]
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from lib.common_config import step
+
+# Required to instantiate the topology builder class.
+
+#####################################################
+##
+##   Network Topology Definition
+##
+#####################################################
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    # Let's create 257 interfaces between the two switches
+    for switch in range(1, 129):
+        switch = tgen.add_switch("sw{}".format(switch))
+        switch.add_link(r1)
+        switch.add_link(r2)
+
+
+#####################################################
+##
+##   Tests starting
+##
+#####################################################
+
+
+def setup_module(module):
+    "Setup topology"
+    tgen = Topogen(build_topo, module.__name__)
+    tgen.start_topology()
+
+    # This is a sample of configuration loading.
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr.conf".format(rname)),
+            [
+                (TopoRouter.RD_ZEBRA, "-s 180000000"),
+                (TopoRouter.RD_BGP, None),
+                (TopoRouter.RD_SHARP, None),
+                (TopoRouter.RD_STATIC, None),
+                (TopoRouter.RD_OSPF, None),
+                (TopoRouter.RD_OSPF6, None),
+                (TopoRouter.RD_PIM, None),
+            ],
+        )
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+
+    # This function tears down the whole topology.
+    tgen.stop_topology()
+
+
+def test_bgp_route_install_r1():
+    failures = 0
+    tgen = get_topogen()
+    net = tgen.net
+    expected_route_count = 2000
+
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Test that BGP routes are installed on r1")
+    # First, extract IPv4 from r1
+    lo_output = net["r1"].cmd("vtysh -c 'show interface lo'")
+
+    # Extract IPv4 from the output
+    ipv4_match = re.search(r"inet (\d+\.\d+\.\d+\.\d+)/\d+", lo_output)
+
+    if not ipv4_match:
+        assert False, "Could not find IPv4 address on loopback interface"
+
+    ipv4_nexthop = ipv4_match.group(1)
+
+    print(f"\nUsing nexthops: IPv4={ipv4_nexthop}")
+
+    # Install IPv4 routes
+    ipv4_cmd = f"vtysh -c 'sharp install routes 39.99.0.0 nexthop {ipv4_nexthop} {expected_route_count}'"
+    net["r1"].cmd(ipv4_cmd)
+
+    # Initialize actual counts
+    ipv4_actual_count = 0
+    max_attempts = 12  # 60 seconds max (12 * 5)
+    attempt = 0
+
+    # Wait until IPv4 routes are installed
+    while (ipv4_actual_count != expected_route_count) and attempt < max_attempts:
+        sleep(5)
+        attempt += 1
+
+        # Get current IPv4 route count
+        ipv4_count_str = (
+            net["r2"]
+            .cmd('vtysh -c "show bgp ipv4 unicast" | grep "39.99" | wc -l')
+            .rstrip()
+        )
+
+        try:
+            ipv4_actual_count = int(ipv4_count_str)
+        except ValueError:
+            ipv4_actual_count = 0
+
+        print(f"Attempt {attempt}")
+        print(f"IPv4 Routes found: {ipv4_actual_count} / {expected_route_count}")
+
+    # Verify we have the expected number of routes
+    if ipv4_actual_count != expected_route_count:
+        sys.stderr.write(
+            f"Failed to install expected IPv4 routes: got {ipv4_actual_count}, expected {expected_route_count}\n"
+        )
+        failures += 1
+    else:
+        print("IPv4 routes successfully installed")
+
+
+def test_bgp_established():
+    "Test that BGP session between r1 and r2 is established"
+    tgen = get_topogen()
+    net = tgen.net
+
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Test that BGP session between r1 and r2 is established")
+    # Create a function to check BGP peer status on r1
+    def check_bgp_peer():
+        output = net["r2"].cmd('vtysh -c "show bgp ipv4 uni summary json"')
+        try:
+            bgp_summary = json.loads(output)
+            # Check if r2's peer is in Established state
+            # logger.info(f"BGP summary: {bgp_summary}")
+            logger.info("Failed peers: {}".format(bgp_summary["failedPeers"]))
+            if bgp_summary.get("failedPeers") != 0:
+                logger.info(f"Failed peers: {bgp_summary.get('failedPeers')}")
+                return False
+
+            # Check that each peer has received 2000 prefixes
+            for peer, peer_data in bgp_summary.get("peers", {}).items():
+                pfx_rcvd = peer_data.get("pfxRcd", 0)
+                if pfx_rcvd != 2000:
+                    logger.info(
+                        f"Peer {peer} has received {pfx_rcvd} prefixes, expected 2000"
+                    )
+                    return False
+
+            return True
+        except (json.JSONDecodeError, KeyError):
+            return False
+
+    # Use run_and_expect to wait for BGP session to be established
+    success, result = topotest.run_and_expect(
+        check_bgp_peer,
+        True,
+        count=60,  # Wait up to 60 tries
+        wait=1,  # 1 second between tries
+    )
+
+    assert success, "BGP session between r1 and r2 failed to establish"
+
+
+def test_bgp_routes_on_r2():
+    "Test that routes installed on r1 are properly received by r2"
+    tgen = get_topogen()
+    net = tgen.net
+    expected_route_count = 2000
+
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Test that routes installed on r1 are properly received by r2")
+    # Create a function to check the route count on r2
+    def check_r2_routes():
+        route_count = (
+            net["r2"]
+            .cmd('vtysh -c "show bgp ipv4 unicast" | grep "39.99" | wc -l')
+            .rstrip()
+        )
+        try:
+            return int(route_count)
+        except ValueError:
+            return 0
+
+    # Use run_and_expect to wait for the routes to appear on r2
+    success, result = topotest.run_and_expect(
+        check_r2_routes,
+        expected_route_count,
+        count=60,  # Wait up to 60 tries
+        wait=1,  # 1 second between tries
+    )
+
+    assert success, f"Expected {expected_route_count} routes on r2 but found {result}"
+
+    step("Test that all routes are installed in the FIB")
+    # Create a function to check the FIB route count
+    def check_fib_routes():
+        output = net["r2"].cmd('vtysh -c "show ip route summary"')
+        try:
+            # Extract the eBGP route count from the summary
+            for line in output.splitlines():
+                if "ebgp" in line:
+                    # Split on whitespace and get the FIB count (last number)
+                    parts = line.split()
+                    fib_count = int(parts[-1])
+                    logger.info(f"eBGP FIB route count: {fib_count}")
+                    return fib_count
+            return 0
+        except (ValueError, IndexError):
+            return 0
+
+    # Use run_and_expect to wait for all routes to be installed in the FIB
+    success, result = topotest.run_and_expect(
+        check_fib_routes,
+        expected_route_count,
+        count=60,  # Wait up to 60 tries
+        wait=1,  # 1 second between tries
+    )
+
+    assert success, f"Expected {expected_route_count} routes in FIB but found {result}"
+
+    step("Verify that the nexthop group for 39.99.0.0 routes has 128 members")
+    # Create a function to check the nexthop group member count
+    def check_nhg_members():
+        output = net["r2"].cmd('vtysh -c "show ip route 39.99.0.0 json"')
+        try:
+            route_data = json.loads(output)
+            # Find the first 39.99.0.0 route to get its nexthop group ID
+            nhg_id = None
+            for prefix, routes in route_data.items():
+                if prefix.startswith("39.99.0.0"):
+                    for route in routes:
+                        if route.get("protocol") == "bgp":
+                            nhg_id = route.get("nexthopGroupId")
+                            break
+                    if nhg_id:
+                        break
+
+            if not nhg_id:
+                logger.info("Could not find nexthop group ID for 39.99.0.0 routes")
+                return -1
+
+            # Get the nexthop group details
+            nhg_output = net["r2"].cmd(
+                f'vtysh -c "show nexthop-group rib {nhg_id} json"'
+            )
+            nhg_data = json.loads(nhg_output)
+
+            # The nexthop group data is nested under the nhg_id key
+            nhg_info = nhg_data.get(str(nhg_id), {})
+            member_count = len(nhg_info.get("nexthops", []))
+            logger.info(f"Nexthop group {nhg_id} has {member_count} members")
+            if (member_count != 128):
+                logger.info(net["r2"].cmd(f'vtysh -c "show nexthop-group rib {nhg_id}" -c "show bgp ipv4 uni" -c "show ip route 33.99.0.0 nexthop-group"'))
+            return member_count
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.info(f"Error checking nexthop group members: {e}")
+            return -1
+
+    # Use run_and_expect to verify the nexthop group has 128 members
+    success, result = topotest.run_and_expect(
+        check_nhg_members,
+        128,  # Expect 128 members
+        count=60,  # Wait up to 60 tries
+        wait=1,  # 1 second between tries
+    )
+
+    assert success, f"Expected 128 nexthop group members but found {result}"
+
+
+def test_bgp_shutdown_some_links():
+    "Test that shutting down interfaces r2-eth30-49 results in 20 failed BGP peers"
+    tgen = get_topogen()
+    net = tgen.net
+    first_nhg = None
+
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Test that all BGP routes are using the same nexthop group")
+
+    logger.info(net["r2"].cmd('vtysh -c "show ip route bgp nexthop"'))
+    logger.info(net["r2"].cmd('vtysh -c "show nexthop-group rib"'))
+
+    # First check that all BGP routes are using the same nexthop group
+    def check_nhg_consistency():
+        nonlocal first_nhg
+        output = net["r2"].cmd('vtysh -c "show ip route bgp json"')
+        try:
+            nhg_data = json.loads(output)
+            # logger.info(f"Nexthop group data: {nhg_data}")
+
+            for prefix, routes in nhg_data.items():
+                for route in routes:
+                    if route.get("protocol") == "bgp":
+                        current_nhg = route.get("nexthopGroupId")
+                        if first_nhg is None:
+                            first_nhg = current_nhg
+                            if not first_nhg:
+                                logger.info("First BGP route has no nexthop group")
+                                return False
+                        elif current_nhg != first_nhg:
+                            logger.info(
+                                f"Found different nexthop groups: {first_nhg} vs {current_nhg}"
+                            )
+                            return False
+
+            if first_nhg is None:
+                logger.info("No BGP routes found")
+                return False
+
+            logger.info(f"All BGP routes using nexthop group: {first_nhg}")
+            return True
+        except json.JSONDecodeError:
+            logger.error("Failed to parse nexthop group data")
+            return False
+
+    # Use run_and_expect to verify nexthop group consistency
+    success, result = topotest.run_and_expect(
+        check_nhg_consistency,
+        True,
+        count=60,
+        wait=1,
+    )
+
+    assert success, "BGP routes are not using the same nexthop group"
+
+    # Shutdown interfaces r2-eth30 through r2-eth49
+    step("Shutdown interfaces r2-eth30 through r2-eth49")
+    for i in range(30, 50):
+        net["r2"].cmd(f"ip link set r2-eth{i} down")
+
+    step("Test that 20 BGP peers are failed")
+    # Create a function to check BGP peer status on r2
+    def check_failed_peers():
+        output = net["r2"].cmd('vtysh -c "show bgp ipv4 uni summary json"')
+        try:
+            bgp_summary = json.loads(output)
+            # failed_peers = bgp_summary.get("failedPeers", 0)
+            failed_peers = 0
+            # Check that peers r2-eth[30-49] are not in Established or Clearing state
+            for peer, peer_data in bgp_summary.get("peers", {}).items():
+                # Check if peer name matches r2-eth[30-49]
+                if peer.startswith("r2-eth"):
+                    try:
+                        eth_num = int(peer.split("r2-eth")[1])
+                        if 30 <= eth_num <= 49:
+                            state = peer_data.get("state", "")
+                            if state in ["Established", "Clearing"]:
+                                logger.info(f"Peer {peer} is in {state} state")
+                                return -1
+                            else:
+                                failed_peers += 1
+                    except (ValueError, IndexError):
+                        continue
+
+            logger.info(f"Current failed peers: {failed_peers}")
+            return failed_peers
+        except (json.JSONDecodeError, KeyError):
+            return -1
+
+    # Use run_and_expect to wait for exactly 20 failed peers
+    success, result = topotest.run_and_expect(
+        check_failed_peers,
+        20,  # Expect exactly 20 failed peers
+        count=60,  # Wait up to 60 tries
+        wait=1,  # 1 second between tries
+    )
+
+    assert success, f"Expected 20 failed BGP peers but found {result}"
+
+    step("Verify that the nexthop group ID hasn't changed")
+    # Verify that the nexthop group ID hasn't changed
+    def verify_nhg_unchanged():
+        output = net["r2"].cmd('vtysh -c "show ip route bgp json"')
+        try:
+            nhg_data = json.loads(output)
+            for prefix, routes in nhg_data.items():
+                for route in routes:
+                    if route.get("protocol") == "bgp":
+                        current_nhg = route.get("nexthopGroupId")
+                        if current_nhg != first_nhg:
+                            logger.info(
+                                f"Nexthop group changed from {first_nhg} to {current_nhg}, trying again"
+                            )
+                            return False
+            return True
+        except json.JSONDecodeError:
+            logger.error("Failed to parse nexthop group data")
+            return False
+
+    # Use run_and_expect to verify nexthop group consistency
+    success, result = topotest.run_and_expect(
+        verify_nhg_unchanged,
+        True,
+        count=60,
+        wait=1,
+    )
+
+    assert success, "Nexthop group ID changed after interface shutdowns"
+
+    step("Bring interfaces r2-eth30 through r2-eth49 back up")
+    # Bring interfaces r2-eth30 through r2-eth49 back up
+    for i in range(30, 50):
+        net["r2"].cmd(f"ip link set r2-eth{i} up")
+
+    step("Test that all BGP peers are established")
+    # Create a function to check that all BGP peers are established
+    def check_all_peers_established():
+        output = net["r2"].cmd('vtysh -c "show bgp ipv4 uni summary json"')
+        try:
+            bgp_summary = json.loads(output)
+            failed_peers = bgp_summary.get("failedPeers", 0)
+            logger.info(f"Current failed peers: {failed_peers}")
+
+            # Check that each peer has received 2000 prefixes
+            for peer, peer_data in bgp_summary.get("peers", {}).items():
+                pfx_rcvd = peer_data.get("pfxRcd", 0)
+                if pfx_rcvd != 2000:
+                    logger.info(
+                        f"Peer {peer} has received {pfx_rcvd} prefixes, expected 2000"
+                    )
+                    return -1
+
+            return failed_peers
+        except (json.JSONDecodeError, KeyError):
+            return -1
+
+    # Use run_and_expect to wait for all peers to be established
+    success, result = topotest.run_and_expect(
+        check_all_peers_established,
+        0,  # Expect 0 failed peers
+        count=60,  # Wait up to 60 tries
+        wait=1,  # 1 second between tries
+    )
+
+    assert success, f"Expected 0 failed BGP peers but found {result}"
+
+    step("Verify that the original nexthop group is still being used")
+    # Final verification that the original nexthop group is still being used
+    def verify_final_nhg():
+        output = net["r2"].cmd('vtysh -c "show ip route bgp json"')
+        try:
+            nhg_data = json.loads(output)
+            for prefix, routes in nhg_data.items():
+                for route in routes:
+                    if route.get("protocol") == "bgp":
+                        current_nhg = route.get("nexthopGroupId")
+                        if current_nhg != first_nhg:
+                            logger.error(
+                                f"Nexthop group changed from {first_nhg} to {current_nhg}"
+                            )
+                            return False
+            logger.info(
+                f"All BGP routes still using original nexthop group: {first_nhg}"
+            )
+            return True
+        except json.JSONDecodeError:
+            logger.error("Failed to parse nexthop group data")
+            return False
+
+    # Use run_and_expect to verify final nexthop group consistency
+    success, result = topotest.run_and_expect(
+        verify_final_nhg,
+        True,
+        count=60,
+        wait=1,
+    )
+
+    assert success, "Nexthop group ID changed after interfaces were brought back up"
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2814,8 +2814,14 @@ static bool zebra_nhg_set_valid_if_active(struct nhg_hash_entry *nhe)
 	}
 
 	/* should be fully resolved singleton at this point */
-	if (CHECK_FLAG(nhe->nhg.nexthop->flags, NEXTHOP_FLAG_ACTIVE))
-		valid = true;
+	if (CHECK_FLAG(nhe->nhg.nexthop->flags, NEXTHOP_FLAG_ACTIVE)) {
+		struct interface *ifp = if_lookup_by_index(nhe->nhg.nexthop->ifindex, nhe->vrf_id);
+
+		if (!ifp || !if_is_operative(ifp))
+			valid = false;
+		else
+			valid = true;
+	}
 
 done:
 	if (valid)

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4241,12 +4241,13 @@ void route_entry_dump_nh(const struct route_entry *re, const char *straddr,
 	struct interface *ifp;
 	struct vrf *vrf = vrf_lookup_by_id(nexthop->vrf_id);
 
+	ifp = if_lookup_by_index(nexthop->ifindex, nexthop->vrf_id);
+
 	switch (nexthop->type) {
 	case NEXTHOP_TYPE_BLACKHOLE:
 		snprintf(nhname, sizeof(nhname), "Blackhole");
 		break;
 	case NEXTHOP_TYPE_IFINDEX:
-		ifp = if_lookup_by_index(nexthop->ifindex, nexthop->vrf_id);
 		snprintf(nhname, sizeof(nhname), "%s",
 			 ifp ? ifp->name : "Unknown");
 		break;
@@ -4284,9 +4285,9 @@ void route_entry_dump_nh(const struct route_entry *re, const char *straddr,
 	if (nexthop->weight)
 		snprintf(wgt_str, sizeof(wgt_str), "wgt %d,", nexthop->weight);
 
-	zlog_debug("%s(%s): %s %s[%u] %svrf %s(%u) %s%s with flags %s%s%s%s%s%s%s%s%s",
+	zlog_debug("%s(%s): %s %s[%s:%d] %svrf %s(%u) %s%s with flags %s%s%s%s%s%s%s%s%s",
 		   straddr, VRF_LOGNAME(re_vrf),
-		   (nexthop->rparent ? "  NH" : "NH"), nhname, nexthop->ifindex,
+		   (nexthop->rparent ? "  NH" : "NH"), nhname, ifp ? ifp->name : "Unknown", nexthop->ifindex,
 		   label_str, vrf ? vrf->name : "Unknown", nexthop->vrf_id,
 		   wgt_str, backup_str,
 		   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE) ? "ACTIVE "

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2167,6 +2167,7 @@ static void show_ip_route_dump_vty(struct vty *vty, struct route_table *table, a
 					 tm.tm_hour);
 
 			vty_out(vty, "   status: %u\n", re->status);
+			vty_out(vty, "   nexthop_group_id: %u\n", re->nhe->id);
 			vty_out(vty, "   nexthop_num: %u\n",
 				nexthop_group_nexthop_num(&(re->nhe->nhg)));
 			vty_out(vty, "   nexthop_active_num: %u\n",


### PR DESCRIPTION
Currently if there are multiple interfaces going down it is possible to have a ships in the night situation with trying to reuse a nhg.

Imagine that you have a route w/ 4 way ecmp
  nexthop A interface a
  nexthop B interface b
  nexthop C interface c
  nexthop D interface d

Suppose interface a goes down, zebra receives this data marks singleton nexthop A down and then recurses up the tree to the 4 way ecmp and sets nexthop A as inactive. Zebra then will notify the upper level protocol.

The upper level protocol will refigure the route and send it down with 3 way ecmp.  At the same time if interface b goes down and zebra handles that interface down event before the new route installation, then when
zebra_nhg_rib_compare_old_nhe is called it will not match the old and new ones up as that the old will be:

  nexthop A  <inactive>
  nexthop B  <inactive>
  nexthop C
  nexthop D

New will be:

   nexthop B  <inactive>
   nexthop C
   nexthop D

Currently zebra_nhg_nexthop_compare on the old skips all the inactive but it never skips the nexthops at are inactive on the new.

Modify the code to allow the new nhop to be skipped if it is the same nexthop being looked at as the old and it is not active as well.  This allows zebra to choose the same nhg in the above case to continue working.