### PR TITLE
Revert "bgpd: When shutting down do not clear self peers"

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1267,7 +1267,7 @@ void bgp_fsm_change_status(struct peer_connection *connection,
 	/* Transition into Clearing or Deleted must /always/ clear all routes..
 	 * (and must do so before actually changing into Deleted..
 	 */
-	if (status >= Clearing && (peer->established || peer != bgp->peer_self)) {
+	if (status >= Clearing && (peer->established || peer == bgp->peer_self)) {
 		bgp_clear_route_all(peer);
 
 		/* If no route was queued for the clear-node processing,


### PR DESCRIPTION
This reverts commit 06480c0c81471d4e00aee669f78e426a083cb759.

The original check aimed to skip iterating over the route table for peers that were never established, addressing the issue described in the link below.

With this change, any peer that is not BGP itself enters this condition regardless of its establishment count, leading to a regression.

Note: the only time to delete this peer_self is when shutting  bgp  by `bgp_delete`.

Link: https://github.com/FRRouting/frr/pull/16271