### PR TITLE
*: Allow returns to work with --enable-undefined-behavior

### DIFF
--- a/bgpd/bgp_addpath.c
+++ b/bgpd/bgp_addpath.c
@@ -175,6 +175,7 @@ bool bgp_addpath_tx_path(enum bgp_addpath_strat strat, struct bgp_path_info *pi)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return false;
 }
 
 static void bgp_addpath_flush_type_rn(struct bgp *bgp, afi_t afi, safi_t safi,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13305,6 +13305,7 @@ const struct prefix_rd *bgp_rd_from_dest(const struct bgp_dest *dest,
 	}
 
 	assert(!"Reached end of function when we were not expecting it");
+	return NULL;
 }
 
 /* Display specified route of BGP table. */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -594,6 +594,7 @@ static const char *get_bgp_default_af_flag(afi_t afi, safi_t safi)
 	/* all AFIs are accounted for above, so this shouldn't happen */
 
 	assert(!"Reached end of function where we did not expect to");
+	return "DEV ESCAPE";
 }
 
 int bgp_get_vty(struct bgp **bgp, as_t *as, const char *name,

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1210,6 +1210,7 @@ const char *bgp_peer_get_connection_direction(struct peer_connection *connection
 	}
 
 	assert(!"DEV Escape: Expected switch to take care of this state");
+	return "DEV ESCAPE";
 }
 
 struct peer_connection *bgp_peer_connection_new(struct peer *peer)

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2847,6 +2847,7 @@ static inline int afindex(afi_t afi, safi_t safi)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return BGP_AF_MAX;
 }
 
 /* If the peer is not a peer-group but is bound to a peer-group return 1 */

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -3844,6 +3844,7 @@ rfapiBgpInfoFilteredImportFunction(safi_t safi)
 	}
 
 	assert(!"Reached end of function when we were not expecting to");
+	return NULL;
 }
 
 void rfapiProcessUpdate(struct peer *peer,

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -486,6 +486,7 @@ const char *isis_adj_yang_state(enum isis_adj_state state)
 	}
 
 	assert(!"Reached end of function where we are not expecting to");
+	return "DEV ESCAPE";
 }
 
 void isis_adj_expire(struct event *thread)
@@ -944,4 +945,5 @@ int isis_adj_usage2levels(enum isis_adj_usage usage)
 	}
 
 	assert(!"Reached end of function where we are not expecting to");
+	return -1;
 }

--- a/isisd/isis_pdu_counter.c
+++ b/isisd/isis_pdu_counter.c
@@ -69,6 +69,7 @@ static const char *pdu_counter_index_to_name(enum pdu_counter_index index)
 	}
 
 	assert(!"Reached end of function where we were not expecting to");
+	return "DEV ESCAPE";
 }
 
 void pdu_counter_count(pdu_counter_t counter, uint8_t pdu_type)

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -2379,6 +2379,7 @@ static const char *pdu_counter_index_to_name_json(enum pdu_counter_index index)
 	}
 
 	assert(!"Reached end of function where we are not expecting to");
+	return "DEV ESCAPE";
 }
 
 static void common_isis_summary_json(struct json_object *json,

--- a/ldpd/lde_lib.c
+++ b/ldpd/lde_lib.c
@@ -1008,6 +1008,8 @@ lde_wildcard_apply(struct map *wcard, struct fec *fec, struct lde_map *me)
 	default:
 		fatalx("lde_wildcard_apply: unexpected fec type");
 	}
+
+	return -1;
 }
 
 /* gabage collector timer: timer to remove dead entries from the LIB */

--- a/lib/command_graph.c
+++ b/lib/command_graph.c
@@ -274,6 +274,7 @@ static bool cmd_nodes_equal(struct graph_node *ga, struct graph_node *gb)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return false;
 }
 
 static void cmd_fork_bump_attr(struct graph_node *gn, struct graph_node *join,

--- a/lib/command_match.c
+++ b/lib/command_match.c
@@ -547,6 +547,7 @@ static enum match_type min_match_level(enum cmd_token_type type)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return no_match;
 }
 
 /**
@@ -582,6 +583,7 @@ static int score_precedence(enum cmd_token_type type)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return -1;
 }
 
 /**
@@ -712,6 +714,7 @@ static enum match_type match_token(struct cmd_token *token, char *input_token)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return no_match;
 }
 
 #define IPV4_ADDR_STR   "0123456789."

--- a/lib/ipaddr.h
+++ b/lib/ipaddr.h
@@ -61,6 +61,7 @@ static inline int ipaddr_family(const struct ipaddr *ip)
 	}
 
 	assert(!"Reached end of function where we should never hit");
+	return AF_UNSPEC;
 }
 
 static inline int str2ipaddr(const char *str, struct ipaddr *ip)
@@ -151,6 +152,7 @@ static inline int ipaddr_cmp(const struct ipaddr *a, const struct ipaddr *b)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return -1;
 }
 
 static inline bool ipaddr_is_zero(const struct ipaddr *ip)

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -1102,6 +1102,7 @@ const char *nb_operation_name(enum nb_operation operation)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return "DEV ESCAPE";
 }
 
 bool nb_is_operation_allowed(struct nb_node *nb_node, enum nb_operation oper)
@@ -2620,6 +2621,7 @@ const char *nb_event_name(enum nb_event event)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return "DEV ESCAPE";
 }
 
 const char *nb_cb_operation_name(enum nb_cb_operation operation)
@@ -2654,6 +2656,7 @@ const char *nb_cb_operation_name(enum nb_cb_operation operation)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return "DEV ESCAPE";
 }
 
 const char *nb_err_name(enum nb_error error)
@@ -2682,6 +2685,7 @@ const char *nb_err_name(enum nb_error error)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return "DEV ESCAPE";
 }
 
 const char *nb_client_name(enum nb_client client)
@@ -2704,6 +2708,7 @@ const char *nb_client_name(enum nb_client client)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return "DEV ESCAPE";
 }
 
 static void nb_load_callbacks(const struct frr_yang_module_info *module)

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -138,6 +138,7 @@ const char *afi2str_lower(afi_t afi)
 	}
 
 	assert(!"Reached end of function we should never reach");
+	return "DEV ESCAPE";
 }
 
 const char *afi2str(afi_t afi)
@@ -155,6 +156,7 @@ const char *afi2str(afi_t afi)
 	}
 
 	assert(!"Reached end of function we should never reach");
+	return "DEV ESCAPE";
 }
 
 const char *safi2str(safi_t safi)
@@ -180,6 +182,7 @@ const char *safi2str(safi_t safi)
 	}
 
 	assert(!"Reached end of function we should never reach");
+	return "DEV ESCAPE";
 }
 
 /* If n includes p prefix then return 1 else return 0. */

--- a/pathd/path_cli.c
+++ b/pathd/path_cli.c
@@ -1077,6 +1077,7 @@ static const char *objfun_type_name(enum objfun_type type)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return "DEV ESCAPE";
 }
 
 DEFPY_NOSH(show_debugging_pathd, show_debugging_pathd_cmd,

--- a/pathd/path_pcep_config.c
+++ b/pathd/path_pcep_config.c
@@ -483,6 +483,7 @@ status_int_to_ext(enum srte_policy_status status)
 	}
 
 	assert(!"Reached end of function where we are not expecting to");
+	return PCEP_LSP_OPERATIONAL_DOWN;
 }
 
 enum pcep_sr_subobj_nai pcep_nai_type(enum srte_segment_nai_type type)
@@ -536,4 +537,5 @@ enum srte_segment_nai_type srte_nai_type(enum pcep_sr_subobj_nai type)
 	}
 
 	assert(!"Reached end of function where we were not expecting to");
+	return SRTE_SEGMENT_NAI_TYPE_NONE;
 }

--- a/pathd/path_pcep_controller.c
+++ b/pathd/path_pcep_controller.c
@@ -1071,6 +1071,7 @@ const char *timer_type_name(enum pcep_ctrl_timer_type type)
 	}
 
 	assert(!"Reached end of function where we did not expect to");
+	return "DEV ESCAPE";
 }
 
 const char *timeout_type_name(enum pcep_ctrl_timeout_type type)
@@ -1085,4 +1086,5 @@ const char *timeout_type_name(enum pcep_ctrl_timeout_type type)
 	}
 
 	assert(!"Reached end of function where we did not expect to");
+	return "DEV ESCAPE";
 }

--- a/pathd/path_pcep_debug.c
+++ b/pathd/path_pcep_debug.c
@@ -80,6 +80,7 @@ const char *pcc_status_name(enum pcc_status status)
 	}
 
 	assert(!"Reached end of function where we do not expect to");
+	return "DEV ESCAPE";
 }
 
 const char *pcep_event_type_name(pcep_event_type event_type)
@@ -112,6 +113,7 @@ const char *pcep_event_type_name(pcep_event_type event_type)
 	}
 
 	assert(!"Reached end of function where we do not expect to");
+	return "DEV ESCAPE";
 }
 
 const char *pcep_error_type_name(enum pcep_error_type error_type)
@@ -636,6 +638,7 @@ const char *pcep_message_type_name(enum pcep_message_types pcep_message_type)
 	}
 
 	assert(!"Reached end of function where we are not expecting to");
+	return "DEV ESCAPE";
 }
 
 const char *pcep_object_class_name(enum pcep_object_classes obj_class)
@@ -692,6 +695,7 @@ const char *pcep_object_class_name(enum pcep_object_classes obj_class)
 	}
 
 	assert(!"Reached end of function where we are not expecting to");
+	return "DEV ESCAPE";
 }
 
 const char *pcep_object_type_name(enum pcep_object_classes obj_class,
@@ -767,6 +771,7 @@ const char *pcep_lsp_status_name(enum pcep_lsp_operational_status status)
 	}
 
 	assert(!"Reached end of function where we do not expect to");
+	return "DEV ESCAPE";
 }
 
 
@@ -818,6 +823,7 @@ const char *pcep_tlv_type_name(enum pcep_object_tlv_types tlv_type)
 	}
 
 	assert(!"Reached end of function where we do not expect to");
+	return "DEV ESCAPE";
 }
 
 const char *pcep_ro_type_name(enum pcep_ro_subobj_types ro_type)
@@ -841,6 +847,7 @@ const char *pcep_ro_type_name(enum pcep_ro_subobj_types ro_type)
 	}
 
 	assert(!"Reached end of function where we do not expect to");
+	return "DEV ESCAPE";
 }
 
 const char *pcep_nai_type_name(enum pcep_sr_subobj_nai nai_type)
@@ -865,6 +872,7 @@ const char *pcep_nai_type_name(enum pcep_sr_subobj_nai nai_type)
 	}
 
 	assert(!"Reached end of function where we do not expect to");
+	return "DEV ESCAPE";
 }
 
 const char *pcep_metric_type_name(enum pcep_metric_types type)

--- a/pathd/path_pcep_pcc.c
+++ b/pathd/path_pcep_pcc.c
@@ -441,6 +441,7 @@ int pcep_pcc_disable(struct ctrl_state *ctrl_state, struct pcc_state *pcc_state)
 	}
 
 	assert(!"Reached end of function where we are not expecting to");
+	return -1;
 }
 
 void pcep_pcc_sync_path(struct ctrl_state *ctrl_state,
@@ -1955,6 +1956,7 @@ static uint32_t hash_nbkey(const struct lsp_nb_key *nbkey)
 	}
 
 	assert(!"Reached end of function where we were not expecting to");
+	return 0;
 }
 
 static int cmp_nbkey(const struct lsp_nb_key *a, const struct lsp_nb_key *b)

--- a/pathd/pathd.c
+++ b/pathd/pathd.c
@@ -1030,6 +1030,7 @@ static uint32_t filter_type_to_flag(enum affinity_filter_type type)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return 0;
 }
 
 static const char *filter_type_name(enum affinity_filter_type type)
@@ -1046,6 +1047,7 @@ static const char *filter_type_name(enum affinity_filter_type type)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return "DEV ESCAPE";
 }
 
 /**
@@ -1277,6 +1279,7 @@ const char *srte_origin2str(enum srte_protocol_origin origin)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return "DEV ESCAPE";
 }
 
 void pathd_shutdown(void)

--- a/ripd/rip_nb_state.c
+++ b/ripd/rip_nb_state.c
@@ -392,6 +392,7 @@ struct yang_data *ripd_instance_state_routes_route_next_hop_get_elem(
 	}
 
 	assert(!"Reached end of function where we do not expect to reach");
+	return NULL;
 }
 
 /*
@@ -418,6 +419,7 @@ struct yang_data *ripd_instance_state_routes_route_interface_get_elem(
 	}
 
 	assert(!"Reached end of function where we do not expect to reach");
+	return NULL;
 }
 
 /*

--- a/zebra/router-id.c
+++ b/zebra/router-id.c
@@ -107,6 +107,7 @@ int router_id_get(afi_t afi, struct prefix *p, struct zebra_vrf *zvrf)
 	}
 
 	assert(!"Reached end of function we should never hit");
+	return -1;
 }
 
 int router_id_set(afi_t afi, struct prefix *p, struct zebra_vrf *zvrf)


### PR DESCRIPTION
If you have undefined behavior compilation checking gcc starts to complain about a bunch of places that do not have return's.  When most of them actually do and we have the assert's to prove it.  I'm just doing this to make the compiler happy for me, so I can continue to do work.