### PR TITLE
tests: bgp_evpn_rt5 add route-reflector

### DIFF
--- a/tests/topotests/bgp_evpn_rt5/r1/bgp_l2vpn_evpn_routes.json
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgp_l2vpn_evpn_routes.json
@@ -20,13 +20,13 @@
                     "metric":0,
                     "locPrf":100,
                     "weight":0,
-                    "peerId":"192.168.0.2",
+                    "peerId":"192.168.1.101",
                     "path":"",
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.2",
-                            "hostname":"r2",
+                            "ip":"192.168.2.2",
+                            "hostname":"rr",
                             "afi":"ipv4",
                             "used":true
                         }
@@ -50,13 +50,13 @@
                     "metric":0,
                     "locPrf":100,
                     "weight":0,
-                    "peerId":"192.168.0.2",
+                    "peerId":"192.168.1.101",
                     "path":"",
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.2",
-                            "hostname":"r2",
+                            "ip":"192.168.2.2",
+                            "hostname":"rr",
                             "afi":"ipv4",
                             "used":true
                         }
@@ -87,7 +87,7 @@
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.1",
+                            "ip":"192.168.1.1",
                             "hostname":"r1",
                             "afi":"ipv4",
                             "used":true
@@ -116,7 +116,7 @@
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.1",
+                            "ip":"192.168.1.1",
                             "hostname":"r1",
                             "afi":"ipv4",
                             "used":true
@@ -144,13 +144,13 @@
                     "metric":0,
                     "locPrf":100,
                     "weight":0,
-                    "peerId":"192.168.0.2",
+                    "peerId":"192.168.1.101",
                     "path":"",
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.2",
-                            "hostname":"r2",
+                            "ip":"192.168.2.2",
+                            "hostname":"rr",
                             "afi":"ipv4",
                             "used":true
                         }
@@ -174,13 +174,13 @@
                     "metric":0,
                     "locPrf":100,
                     "weight":0,
-                    "peerId":"192.168.0.2",
+                    "peerId":"192.168.1.101",
                     "path":"",
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.2",
-                            "hostname":"r2",
+                            "ip":"192.168.2.2",
+                            "hostname":"rr",
                             "afi":"ipv4",
                             "used":true
                         }
@@ -211,7 +211,7 @@
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.1",
+                            "ip":"192.168.1.1",
                             "hostname":"r1",
                             "afi":"ipv4",
                             "used":true
@@ -240,7 +240,7 @@
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.1",
+                            "ip":"192.168.1.1",
                             "hostname":"r1",
                             "afi":"ipv4",
                             "used":true

--- a/tests/topotests/bgp_evpn_rt5/r1/bgp_l2vpn_evpn_routes_all.json
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgp_l2vpn_evpn_routes_all.json
@@ -20,13 +20,13 @@
                     "metric":0,
                     "locPrf":100,
                     "weight":0,
-                    "peerId":"192.168.0.2",
+                    "peerId":"192.168.1.101",
                     "path":"",
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.2",
-                            "hostname":"r2",
+                            "ip":"192.168.2.2",
+                            "hostname":"rr",
                             "afi":"ipv4",
                             "used":true
                         }
@@ -50,13 +50,13 @@
                     "metric":0,
                     "locPrf":100,
                     "weight":0,
-                    "peerId":"192.168.0.2",
+                    "peerId":"192.168.1.101",
                     "path":"",
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.2",
-                            "hostname":"r2",
+                            "ip":"192.168.2.2",
+                            "hostname":"rr",
                             "afi":"ipv4",
                             "used":true
                         }
@@ -80,13 +80,13 @@
                     "metric":0,
                     "locPrf":100,
                     "weight":0,
-                    "peerId":"192.168.0.2",
+                    "peerId":"192.168.1.101",
                     "path":"",
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.2",
-                            "hostname":"r2",
+                            "ip":"192.168.2.2",
+                            "hostname":"rr",
                             "afi":"ipv4",
                             "used":true
                         }
@@ -110,13 +110,13 @@
                     "metric":0,
                     "locPrf":100,
                     "weight":0,
-                    "peerId":"192.168.0.2",
+                    "peerId":"192.168.1.101",
                     "path":"",
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.2",
-                            "hostname":"r2",
+                            "ip":"192.168.2.2",
+                            "hostname":"rr",
                             "afi":"ipv4",
                             "used":true
                         }
@@ -147,7 +147,7 @@
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.1",
+                            "ip":"192.168.1.1",
                             "hostname":"r1",
                             "afi":"ipv4",
                             "used":true
@@ -176,7 +176,7 @@
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.1",
+                            "ip":"192.168.1.1",
                             "hostname":"r1",
                             "afi":"ipv4",
                             "used":true
@@ -204,13 +204,13 @@
                     "metric":0,
                     "locPrf":100,
                     "weight":0,
-                    "peerId":"192.168.0.2",
+                    "peerId":"192.168.1.101",
                     "path":"",
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.2",
-                            "hostname":"r2",
+                            "ip":"192.168.2.2",
+                            "hostname":"rr",
                             "afi":"ipv4",
                             "used":true
                         }
@@ -234,13 +234,13 @@
                     "metric":0,
                     "locPrf":100,
                     "weight":0,
-                    "peerId":"192.168.0.2",
+                    "peerId":"192.168.1.101",
                     "path":"",
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.2",
-                            "hostname":"r2",
+                            "ip":"192.168.2.2",
+                            "hostname":"rr",
                             "afi":"ipv4",
                             "used":true
                         }
@@ -271,7 +271,7 @@
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.1",
+                            "ip":"192.168.1.1",
                             "hostname":"r1",
                             "afi":"ipv4",
                             "used":true
@@ -300,7 +300,7 @@
                     "origin":"IGP",
                     "nexthops":[
                         {
-                            "ip":"192.168.0.1",
+                            "ip":"192.168.1.1",
                             "hostname":"r1",
                             "afi":"ipv4",
                             "used":true

--- a/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_101_ipv4_routes_detail.json
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_101_ipv4_routes_detail.json
@@ -11,8 +11,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "192.168.0.2",
-                        "hostname": "r2",
+                        "ip": "192.168.2.2",
+                        "hostname": "rr",
                         "afi": "ipv4",
                         "used": true
                     }

--- a/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_101_ipv4_routes_detail_import.json
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_101_ipv4_routes_detail_import.json
@@ -11,8 +11,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "192.168.0.2",
-                        "hostname": "r2",
+                        "ip": "192.168.2.2",
+                        "hostname": "rr",
                         "afi": "ipv4",
                         "used": true
                     }
@@ -27,8 +27,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "192.168.0.2",
-                        "hostname": "r2",
+                        "ip": "192.168.2.2",
+                        "hostname": "rr",
                         "afi": "ipv4",
                         "used": true
                     }

--- a/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_101_ipv6_routes_detail.json
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_101_ipv6_routes_detail.json
@@ -11,8 +11,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "::ffff:192.168.0.2",
-                        "hostname": "r2",
+                        "ip": "::ffff:192.168.2.2",
+                        "hostname": "rr",
                         "afi": "ipv6",
                         "scope": "global",
                         "used": true

--- a/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_101_ipv6_routes_detail_import.json
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_101_ipv6_routes_detail_import.json
@@ -11,8 +11,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "::ffff:192.168.0.2",
-                        "hostname": "r2",
+                        "ip": "::ffff:192.168.2.2",
+                        "hostname": "rr",
                         "afi": "ipv6",
                         "scope": "global",
                         "used": true
@@ -28,8 +28,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "::ffff:192.168.0.2",
-                        "hostname": "r2",
+                        "ip": "::ffff:192.168.2.2",
+                        "hostname": "rr",
                         "afi": "ipv6",
                         "scope": "global",
                         "used": true

--- a/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_102_ipv4_routes_detail.json
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_102_ipv4_routes_detail.json
@@ -11,8 +11,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "192.168.0.2",
-                        "hostname": "r2",
+                        "ip": "192.168.2.2",
+                        "hostname": "rr",
                         "afi": "ipv4",
                         "used": true
                     }

--- a/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_102_ipv4_routes_detail_import.json
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_102_ipv4_routes_detail_import.json
@@ -11,8 +11,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "192.168.0.2",
-                        "hostname": "r2",
+                        "ip": "192.168.2.2",
+                        "hostname": "rr",
                         "afi": "ipv4",
                         "used": true
                     }
@@ -27,8 +27,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "192.168.0.2",
-                        "hostname": "r2",
+                        "ip": "192.168.2.2",
+                        "hostname": "rr",
                         "afi": "ipv4",
                         "used": true
                     }

--- a/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_102_ipv6_routes_detail.json
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_102_ipv6_routes_detail.json
@@ -11,8 +11,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "::ffff:192.168.0.2",
-                        "hostname": "r2",
+                        "ip": "::ffff:192.168.2.2",
+                        "hostname": "rr",
                         "afi": "ipv6",
                         "scope": "global",
                         "used": true

--- a/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_102_ipv6_routes_detail_import.json
+++ b/tests/topotests/bgp_evpn_rt5/r1/bgp_vrf_102_ipv6_routes_detail_import.json
@@ -11,8 +11,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "::ffff:192.168.0.2",
-                        "hostname": "r2",
+                        "ip": "::ffff:192.168.2.2",
+                        "hostname": "rr",
                         "afi": "ipv6",
                         "scope": "global",
                         "used": true
@@ -28,8 +28,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "::ffff:192.168.0.2",
-                        "hostname": "r2",
+                        "ip": "::ffff:192.168.2.2",
+                        "hostname": "rr",
                         "afi": "ipv6",
                         "scope": "global",
                         "used": true

--- a/tests/topotests/bgp_evpn_rt5/r1/frr.conf
+++ b/tests/topotests/bgp_evpn_rt5/r1/frr.conf
@@ -14,6 +14,7 @@ vrf vrf-102
  vni 102
  exit-vrf
 !
+
 interface loop101 vrf vrf-101
  ip address 10.0.101.1/32
  ipv6 address fd01::1/128
@@ -22,20 +23,25 @@ interface loop102 vrf vrf-102
  ip address 10.0.102.1/32
  ipv6 address fd02::1/128
 !
-interface r1-eth0
- ip address 192.168.0.1/24
+int lo
+ ip address 192.168.0.1/32
+!
+interface eth-rr
+ ip address 192.168.1.1/24
+!
+ip route 0.0.0.0/0 192.168.1.101
 !
 router bgp 65000
  bgp router-id 192.168.0.1
  bgp log-neighbor-changes
  no bgp default ipv4-unicast
  no bgp ebgp-requires-policy
- neighbor 192.168.0.2 remote-as 65000
- neighbor 192.168.0.2 capability extended-nexthop
+ neighbor 192.168.1.101 remote-as 65000
+ neighbor 192.168.1.101 capability extended-nexthop
  !
  address-family l2vpn evpn
-  neighbor 192.168.0.2 activate
-  neighbor 192.168.0.2 route-map rmap_r1 in
+  neighbor 192.168.1.101 activate
+  neighbor 192.168.1.101 route-map rmap_r1 in
   advertise-all-vni
  exit-address-family
 !

--- a/tests/topotests/bgp_evpn_rt5/r2/bgp_l2vpn_evpn_routes.json
+++ b/tests/topotests/bgp_evpn_rt5/r2/bgp_l2vpn_evpn_routes.json
@@ -24,10 +24,10 @@
                     "origin": "IGP",
                     "nexthops": [
                         {
-                            "ip": "192.168.0.2",
-                            "hostname": "r2",
-                            "afi": "ipv4",
-                            "used": true
+                            "ip":"192.168.2.2",
+                            "hostname":"r2",
+                            "afi":"ipv4",
+                            "used":true
                         }
                     ]
                 }
@@ -53,10 +53,10 @@
                     "origin": "IGP",
                     "nexthops": [
                         {
-                            "ip": "192.168.0.2",
-                            "hostname": "r2",
-                            "afi": "ipv4",
-                            "used": true
+                            "ip":"192.168.2.2",
+                            "hostname":"r2",
+                            "afi":"ipv4",
+                            "used":true
                         }
                     ]
                 }
@@ -81,13 +81,13 @@
                     "metric": 0,
                     "locPrf": 100,
                     "weight": 0,
-                    "peerId": "192.168.0.1",
+                    "peerId": "192.168.2.101",
                     "path": "",
                     "origin": "IGP",
                     "nexthops": [
                         {
-                            "ip": "192.168.0.1",
-                            "hostname": "r1",
+                            "ip":"192.168.1.1",
+                            "hostname":"rr",
                             "afi": "ipv4",
                             "used": true
                         }
@@ -111,13 +111,13 @@
                     "metric": 0,
                     "locPrf": 100,
                     "weight": 0,
-                    "peerId": "192.168.0.1",
+                    "peerId": "192.168.2.101",
                     "path": "",
                     "origin": "IGP",
                     "nexthops": [
                         {
-                            "ip": "192.168.0.1",
-                            "hostname": "r1",
+                            "ip":"192.168.1.1",
+                            "hostname":"rr",
                             "afi": "ipv4",
                             "used": true
                         }
@@ -148,7 +148,7 @@
                     "origin": "IGP",
                     "nexthops": [
                         {
-                            "ip": "192.168.0.2",
+                            "ip": "192.168.2.2",
                             "hostname": "r2",
                             "afi": "ipv4",
                             "used": true
@@ -177,7 +177,7 @@
                     "origin": "IGP",
                     "nexthops": [
                         {
-                            "ip": "192.168.0.2",
+                            "ip": "192.168.2.2",
                             "hostname": "r2",
                             "afi": "ipv4",
                             "used": true
@@ -205,13 +205,13 @@
                     "metric": 0,
                     "locPrf": 100,
                     "weight": 0,
-                    "peerId": "192.168.0.1",
+                    "peerId": "192.168.2.101",
                     "path": "",
                     "origin": "IGP",
                     "nexthops": [
                         {
-                            "ip": "192.168.0.1",
-                            "hostname": "r1",
+                            "ip": "192.168.1.1",
+                            "hostname": "rr",
                             "afi": "ipv4",
                             "used": true
                         }
@@ -235,13 +235,13 @@
                     "metric": 0,
                     "locPrf": 100,
                     "weight": 0,
-                    "peerId": "192.168.0.1",
+                    "peerId": "192.168.2.101",
                     "path": "",
                     "origin": "IGP",
                     "nexthops": [
                         {
-                            "ip": "192.168.0.1",
-                            "hostname": "r1",
+                            "ip": "192.168.1.1",
+                            "hostname": "rr",
                             "afi": "ipv4",
                             "used": true
                         }

--- a/tests/topotests/bgp_evpn_rt5/r2/bgp_vrf_101_ipv4_routes_detail.json
+++ b/tests/topotests/bgp_evpn_rt5/r2/bgp_vrf_101_ipv4_routes_detail.json
@@ -11,8 +11,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "192.168.0.1",
-                        "hostname": "r1",
+                        "ip": "192.168.1.1",
+                        "hostname": "rr",
                         "afi": "ipv4",
                         "used": true
                     }

--- a/tests/topotests/bgp_evpn_rt5/r2/bgp_vrf_101_ipv6_routes_detail.json
+++ b/tests/topotests/bgp_evpn_rt5/r2/bgp_vrf_101_ipv6_routes_detail.json
@@ -11,8 +11,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "::ffff:192.168.0.1",
-                        "hostname": "r1",
+                        "ip": "::ffff:192.168.1.1",
+                        "hostname": "rr",
                         "afi": "ipv6",
                         "scope": "global",
                         "used": true

--- a/tests/topotests/bgp_evpn_rt5/r2/bgp_vrf_102_ipv4_routes_detail.json
+++ b/tests/topotests/bgp_evpn_rt5/r2/bgp_vrf_102_ipv4_routes_detail.json
@@ -11,8 +11,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "192.168.0.1",
-                        "hostname": "r1",
+                        "ip": "192.168.1.1",
+                        "hostname": "rr",
                         "afi": "ipv4",
                         "used": true
                     }

--- a/tests/topotests/bgp_evpn_rt5/r2/bgp_vrf_102_ipv6_routes_detail.json
+++ b/tests/topotests/bgp_evpn_rt5/r2/bgp_vrf_102_ipv6_routes_detail.json
@@ -11,8 +11,8 @@
                 "extendedCommunity": null,
                 "nexthops": [
                     {
-                        "ip": "::ffff:192.168.0.1",
-                        "hostname": "r1",
+                        "ip": "::ffff:192.168.1.1",
+                        "hostname": "rr",
                         "afi": "ipv6",
                         "scope": "global",
                         "used": true

--- a/tests/topotests/bgp_evpn_rt5/r2/frr.conf
+++ b/tests/topotests/bgp_evpn_rt5/r2/frr.conf
@@ -19,19 +19,24 @@ interface loop102 vrf vrf-102
  ip address 10.0.102.2/32
  ipv6 address fd02::2/128
 !
-interface r2-eth0
- ip address 192.168.0.2/24
+int lo
+ ip address 192.168.0.2/32
+!
+interface eth-rr
+ ip address 192.168.2.2/24
+!
+ip route 0.0.0.0/0 192.168.2.101
 !
 router bgp 65000
  bgp router-id 192.168.0.2
  bgp log-neighbor-changes
  no bgp default ipv4-unicast
- neighbor 192.168.0.1 peer-group
- neighbor 192.168.0.1 remote-as 65000
- neighbor 192.168.0.1 capability extended-nexthop
+ neighbor 192.168.2.101 peer-group
+ neighbor 192.168.2.101 remote-as 65000
+ neighbor 192.168.2.101 capability extended-nexthop
  !
  address-family l2vpn evpn
-  neighbor 192.168.0.1 activate
+  neighbor 192.168.2.101 activate
   advertise-all-vni
  exit-address-family
 !

--- a/tests/topotests/bgp_evpn_rt5/rr/frr.conf
+++ b/tests/topotests/bgp_evpn_rt5/rr/frr.conf
@@ -1,0 +1,25 @@
+int lo
+ ip address 192.168.1.101/32
+!
+interface eth-r1
+ ip address 192.168.1.101/24
+!
+interface eth-r2
+ ip address 192.168.2.101/24
+!
+router bgp 65000
+ bgp log-neighbor-changes
+ no bgp default ipv4-unicast
+ neighbor 192.168.1.1 remote-as 65000
+ neighbor 192.168.1.1 capability extended-nexthop
+ neighbor 192.168.2.2 remote-as 65000
+ neighbor 192.168.2.2 capability extended-nexthop
+ !
+ address-family l2vpn evpn
+  neighbor 192.168.1.1 activate
+  neighbor 192.168.1.1 route-reflector-client
+  neighbor 192.168.2.2 activate
+  neighbor 192.168.2.2 route-reflector-client
+ exit-address-family
+
+


### PR DESCRIPTION
ec06de8403 ("zebra: use nexthop instead of route vrf_id for EVPN") fixed the reflection of EVPN RT5 routes.

Add route-reflector into bgp_evpn_rt5 topology.

Fixes: https://github.com/FRRouting/frr/issues/18371