### PR TITLE
 zebra: Allow multiple Explicit Sids support with behavior uN

### DIFF
--- a/tests/topotests/static_srv6_sids/expected_srv6_sids_multi_uN.json
+++ b/tests/topotests/static_srv6_sids/expected_srv6_sids_multi_uN.json
@@ -1,0 +1,216 @@
+{
+	"fcbb:bbbb:1::/48": [
+		{
+			"prefix": "fcbb:bbbb:1::/48",
+			"prefixLen": 48,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uN"
+					},
+					"seg6localContext": {
+						"flavors": []
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe10::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe10::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "Vrf10",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT4"
+					},
+					"seg6localContext": {
+						"flavors": [],
+						"table": 10
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe20::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe20::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "Vrf20",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT6"
+					},
+					"seg6localContext": {
+						"flavors": [],
+						"table": 20
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe30::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe30::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "Vrf30",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT46"
+					},
+					"seg6localContext": {
+						"flavors": [],
+						"table": 30
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe40::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe40::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uA"
+					},
+					"seg6localContext": {
+						"flavors": [],
+						"nh6": "2001::2"
+					}
+				}
+			]
+		}
+	],
+	"fcbb:cccc:1::/48": [
+		{
+			"prefix": "fcbb:cccc:1::/48",
+			"prefixLen": 48,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uN"
+					},
+					"seg6localContext": {
+						"flavors": []
+					}
+				}
+			]
+		}
+	]
+}

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -1523,13 +1523,13 @@ static int get_srv6_sid_explicit(struct zebra_srv6_sid **sid,
 
 			/*
 			 * It is not allowed to allocate an explicit SID for a given context if the context
-			 * is already associated with an explicit SID
+			 * is already associated with an explicit SID (Except uN)
 			 */
-			if (s->sid->alloc_mode == SRV6_SID_ALLOC_MODE_EXPLICIT) {
+			if (s->sid->alloc_mode == SRV6_SID_ALLOC_MODE_EXPLICIT &&
+			    ctx->behavior != ZEBRA_SEG6_LOCAL_ACTION_END) {
 				zlog_err("%s: cannot alloc SID %pI6 for ctx %s: ctx already associated with SID %pI6",
 					 __func__, sid_value,
-					 srv6_sid_ctx2str(buf, sizeof(buf),
-							  &s->ctx),
+					 srv6_sid_ctx2str(buf, sizeof(buf), &s->ctx),
 					 &s->sid->value);
 				return -1;
 			}


### PR DESCRIPTION
In the current code, we cannot allocate more than one explicit Sid for same uN behavior even if they are from different/same(with differente node len) locator blocks.

    For example, if we have the following config
        segment-routing
         srv6
          static-sids
           sid fcbb:bbbb:1::/48 locator MAIN behavior uN
           sid 1234:5678:1::/48 locator RAJA behavior uN
         srv6
          locators
           locator MAIN
            prefix fcbb:bbbb:1::/48 block-len 32 node-len 16 func-bits 16
           locator RAJA
            prefix 1234:5678:1::/48 block-len 32 node-len 16 func-bits 16

Although the locators blocks are different, and staticd request to allocate multiple sid seems valid, zebra allocates only the first static-sid and returns the below error for others.

    ZEBRA: [NGMNY-JWMWQ] get_srv6_sid_explicit: cannot alloc SID 1234:5678:1:: for ctx End USP: ctx already associated with SID fcbb:bbbb:1::

    But we should allow a node behave as a multiple Endpoints expecially if we have a topology where the node resides at the intersection of multiple zones/domain.

Fix is to skip the 'if' condition check to bail out of the behavior is END.

    With fix:

    ip -6 route show
    1234:5678:1::/48 nhid 9  encap seg6local action End dev sr0 proto 196 metric 20 pref medium
    fcbb:bbbb:1::/48 nhid 9  encap seg6local action End dev sr0 proto 196 metric 20 pref medium

    Signed-off-by: Rajasekar Raja <rajasekarr@nvidia.com>
