### PR TITLE
*: Remove deprecated EVENT_OFF macro

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -2434,13 +2434,13 @@ static int bfd_vrf_disable(struct vrf *vrf)
 		zlog_debug("VRF disable %s id %d", vrf->name, vrf->vrf_id);
 
 	/* Disable read/write poll triggering. */
-	EVENT_OFF(bvrf->bg_ev[0]);
-	EVENT_OFF(bvrf->bg_ev[1]);
-	EVENT_OFF(bvrf->bg_ev[2]);
-	EVENT_OFF(bvrf->bg_ev[3]);
-	EVENT_OFF(bvrf->bg_ev[4]);
-	EVENT_OFF(bvrf->bg_ev[5]);
-	EVENT_OFF(bvrf->bg_ev[6]);
+	event_cancel(&bvrf->bg_ev[0]);
+	event_cancel(&bvrf->bg_ev[1]);
+	event_cancel(&bvrf->bg_ev[2]);
+	event_cancel(&bvrf->bg_ev[3]);
+	event_cancel(&bvrf->bg_ev[4]);
+	event_cancel(&bvrf->bg_ev[5]);
+	event_cancel(&bvrf->bg_ev[6]);
 
 	/* Close all descriptors. */
 	socket_close(&bvrf->bg_echo);

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -738,31 +738,31 @@ ssize_t bfd_recv_ipv6(int sd, uint8_t *msgbuf, size_t msgbuflen, uint8_t *ttl,
 static void bfd_sd_reschedule(struct bfd_vrf_global *bvrf, int sd)
 {
 	if (sd == bvrf->bg_shop) {
-		EVENT_OFF(bvrf->bg_ev[0]);
+		event_cancel(&bvrf->bg_ev[0]);
 		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_shop,
 			       &bvrf->bg_ev[0]);
 	} else if (sd == bvrf->bg_mhop) {
-		EVENT_OFF(bvrf->bg_ev[1]);
+		event_cancel(&bvrf->bg_ev[1]);
 		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_mhop,
 			       &bvrf->bg_ev[1]);
 	} else if (sd == bvrf->bg_shop6) {
-		EVENT_OFF(bvrf->bg_ev[2]);
+		event_cancel(&bvrf->bg_ev[2]);
 		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_shop6,
 			       &bvrf->bg_ev[2]);
 	} else if (sd == bvrf->bg_mhop6) {
-		EVENT_OFF(bvrf->bg_ev[3]);
+		event_cancel(&bvrf->bg_ev[3]);
 		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_mhop6,
 			       &bvrf->bg_ev[3]);
 	} else if (sd == bvrf->bg_echo) {
-		EVENT_OFF(bvrf->bg_ev[4]);
+		event_cancel(&bvrf->bg_ev[4]);
 		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_echo,
 			       &bvrf->bg_ev[4]);
 	} else if (sd == bvrf->bg_echov6) {
-		EVENT_OFF(bvrf->bg_ev[5]);
+		event_cancel(&bvrf->bg_ev[5]);
 		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_echov6,
 			       &bvrf->bg_ev[5]);
 	} else if (sd == bvrf->bg_initv6) {
-		EVENT_OFF(bvrf->bg_ev[6]);
+		event_cancel(&bvrf->bg_ev[6]);
 		event_add_read(master, bfd_recv_cb, bvrf, bvrf->bg_initv6, &bvrf->bg_ev[6]);
 	}
 }

--- a/bfdd/event.c
+++ b/bfdd/event.c
@@ -166,40 +166,40 @@ void bfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 
 void bfd_recvtimer_delete(struct bfd_session *bs)
 {
-	EVENT_OFF(bs->recvtimer_ev);
+	event_cancel(&bs->recvtimer_ev);
 }
 
 void bfd_echo_recvtimer_delete(struct bfd_session *bs)
 {
-	EVENT_OFF(bs->echo_recvtimer_ev);
+	event_cancel(&bs->echo_recvtimer_ev);
 }
 
 void bfd_xmttimer_delete(struct bfd_session *bs)
 {
-	EVENT_OFF(bs->xmttimer_ev);
+	event_cancel(&bs->xmttimer_ev);
 }
 
 void bfd_echo_xmttimer_delete(struct bfd_session *bs)
 {
-	EVENT_OFF(bs->echo_xmttimer_ev);
+	event_cancel(&bs->echo_xmttimer_ev);
 }
 
 void sbfd_init_recvtimer_delete(struct bfd_session *bs)
 {
-	EVENT_OFF(bs->recvtimer_ev);
+	event_cancel(&bs->recvtimer_ev);
 }
 
 void sbfd_echo_recvtimer_delete(struct bfd_session *bs)
 {
-	EVENT_OFF(bs->echo_recvtimer_ev);
+	event_cancel(&bs->echo_recvtimer_ev);
 }
 
 void sbfd_init_xmttimer_delete(struct bfd_session *bs)
 {
-	EVENT_OFF(bs->xmttimer_ev);
+	event_cancel(&bs->xmttimer_ev);
 }
 
 void sbfd_echo_xmttimer_delete(struct bfd_session *bs)
 {
-	EVENT_OFF(bs->echo_xmttimer_ev);
+	event_cancel(&bs->echo_xmttimer_ev);
 }

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2136,7 +2136,7 @@ static void bmp_close(struct bmp *bmp)
 	struct bmp_queue_entry *bqe;
 	struct bmp_mirrorq *bmq;
 
-	EVENT_OFF(bmp->t_read);
+	event_cancel(&bmp->t_read);
 
 	if (bmp->active)
 		bmp_active_disconnected(bmp->active);
@@ -2151,7 +2151,7 @@ static void bmp_close(struct bmp *bmp)
 		if (!bqe->refcount)
 			XFREE(MTYPE_BMP_QUEUE, bqe);
 
-	EVENT_OFF(bmp->t_read);
+	event_cancel(&bmp->t_read);
 	pullwr_del(bmp->pullwr);
 	close(bmp->socket);
 }
@@ -2371,7 +2371,7 @@ static void bmp_targets_put(struct bmp_targets *bt)
 	struct bmp_active *ba;
 	struct bmp_imported_bgp *bib;
 
-	EVENT_OFF(bt->t_stats);
+	event_cancel(&bt->t_stats);
 
 	frr_each_safe (bmp_actives, &bt->actives, ba)
 		bmp_active_put(ba);
@@ -2527,7 +2527,7 @@ out_sock:
 
 static void bmp_listener_stop(struct bmp_listener *bl)
 {
-	EVENT_OFF(bl->t_accept);
+	event_cancel(&bl->t_accept);
 
 	if (bl->sock != -1)
 		close(bl->sock);
@@ -2566,9 +2566,9 @@ static struct bmp_active *bmp_active_get(struct bmp_targets *bt,
 
 static void bmp_active_put(struct bmp_active *ba)
 {
-	EVENT_OFF(ba->t_timer);
-	EVENT_OFF(ba->t_read);
-	EVENT_OFF(ba->t_write);
+	event_cancel(&ba->t_timer);
+	event_cancel(&ba->t_read);
+	event_cancel(&ba->t_write);
 
 	bmp_actives_del(&ba->targets->actives, ba);
 
@@ -2709,9 +2709,9 @@ static void bmp_active_thread(struct event *t)
 
 	/* all 3 end up here, though only timer or read+write are active
 	 * at a time */
-	EVENT_OFF(ba->t_timer);
-	EVENT_OFF(ba->t_read);
-	EVENT_OFF(ba->t_write);
+	event_cancel(&ba->t_timer);
+	event_cancel(&ba->t_read);
+	event_cancel(&ba->t_write);
 
 	ba->last_err = NULL;
 
@@ -2765,9 +2765,9 @@ static void bmp_active_disconnected(struct bmp_active *ba)
 
 static void bmp_active_setup(struct bmp_active *ba)
 {
-	EVENT_OFF(ba->t_timer);
-	EVENT_OFF(ba->t_read);
-	EVENT_OFF(ba->t_write);
+	event_cancel(&ba->t_timer);
+	event_cancel(&ba->t_read);
+	event_cancel(&ba->t_write);
 
 	if (ba->bmp)
 		return;
@@ -3048,7 +3048,7 @@ DEFPY(bmp_stats_cfg,
 {
 	VTY_DECLVAR_CONTEXT_SUB(bmp_targets, bt);
 
-	EVENT_OFF(bt->t_stats);
+	event_cancel(&bt->t_stats);
 	if (no)
 		bt->stat_msec = 0;
 	else if (interval_str)

--- a/bgpd/bgp_conditional_adv.c
+++ b/bgpd/bgp_conditional_adv.c
@@ -354,7 +354,7 @@ void bgp_conditional_adv_disable(struct peer *peer, afi_t afi, safi_t safi)
 	}
 
 	/* Last filter removed. So cancel conditional routes polling thread. */
-	EVENT_OFF(bgp->t_condition_check);
+	event_cancel(&bgp->t_condition_check);
 }
 
 static void peer_advertise_map_filter_update(struct peer *peer, afi_t afi,

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -519,7 +519,7 @@ void bgp_damp_info_clean(struct bgp *bgp, struct bgp_damp_config *bdc,
 	XFREE(MTYPE_BGP_DAMP_ARRAY, bdc->reuse_list);
 	bdc->reuse_list_size = 0;
 
-	EVENT_OFF(bdc->t_reuse);
+	event_cancel(&bdc->t_reuse);
 }
 
 /* Disable route flap dampening for a bgp instance.
@@ -540,7 +540,7 @@ int bgp_damp_disable(struct bgp *bgp, afi_t afi, safi_t safi)
 		return 0;
 
 	/* Cancel reuse event. */
-	EVENT_OFF(bdc->t_reuse);
+	event_cancel(&bdc->t_reuse);
 
 	/* Clean BGP dampening information.  */
 	bgp_damp_info_clean(bgp, bdc, afi, safi);

--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -698,7 +698,7 @@ static int bgp_dump_unset(struct bgp_dump *bgp_dump)
 	}
 
 	/* Removing interval event. */
-	EVENT_OFF(bgp_dump->t_interval);
+	event_cancel(&bgp_dump->t_interval);
 
 	bgp_dump->interval = 0;
 

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -5014,7 +5014,7 @@ void bgp_evpn_mh_finish(void)
 		bgp_evpn_es_local_info_clear(es, true);
 	}
 	if (bgp_mh_info->t_cons_check)
-		EVENT_OFF(bgp_mh_info->t_cons_check);
+		event_cancel(&bgp_mh_info->t_cons_check);
 	list_delete(&bgp_mh_info->local_es_list);
 	list_delete(&bgp_mh_info->pend_es_list);
 	list_delete(&bgp_mh_info->ead_es_export_rtl);

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -17,7 +17,7 @@
 #include "network.h"		// for ERRNO_IO_RETRY
 #include "stream.h"		// for stream_get_endp, stream_getw_from, str...
 #include "ringbuf.h"		// for ringbuf_remain, ringbuf_peek, ringbuf_...
-#include "frrevent.h"		// for EVENT_OFF, EVENT_ARG, thread...
+#include "frrevent.h"		// for event, EVENT_ARG, thread...
 
 #include "bgpd/bgp_io.h"
 #include "bgpd/bgp_debug.h"	// for bgp_debug_neighbor_events, bgp_type_str
@@ -68,7 +68,7 @@ void bgp_writes_off(struct peer_connection *connection)
 	assert(fpt->running);
 
 	event_cancel_async(fpt->master, &connection->t_write, NULL);
-	EVENT_OFF(connection->t_generate_updgrp_packets);
+	event_cancel(&connection->t_generate_updgrp_packets);
 
 	UNSET_FLAG(peer->connection->thread_flags, PEER_THREAD_WRITES_ON);
 }

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -166,7 +166,7 @@ __attribute__((__noreturn__)) void sigint(void)
 	 * from the connection_fifo
 	 */
 	peer_connection_fifo_fini(&bm->connection_fifo);
-	EVENT_OFF(bm->e_process_packet);
+	event_cancel(&bm->e_process_packet);
 	pthread_mutex_destroy(&bm->peer_connection_mtx);
 
 	exit(0);

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -461,7 +461,7 @@ static void bgp_accept(struct event *thread)
 				"[Error] accept() failed with error \"%s\" on BGP listener socket %d for BGP instance in VRF \"%s\"; refreshing socket",
 				safe_strerror(save_errno), accept_sock,
 				VRF_LOGNAME(vrf));
-			EVENT_OFF(listener->thread);
+			event_cancel(&listener->thread);
 		} else {
 			flog_err_sys(
 				EC_LIB_SOCKET,
@@ -524,7 +524,7 @@ static void bgp_accept(struct event *thread)
 			}
 			bgp_peer_reg_with_nht(dynamic_peer);
 			bgp_fsm_change_status(incoming, Active);
-			EVENT_OFF(incoming->t_start);
+			event_cancel(&incoming->t_start);
 
 			if (peer_active(incoming) == BGP_PEER_ACTIVE) {
 				if (CHECK_FLAG(dynamic_peer->flags, PEER_FLAG_TIMER_DELAYOPEN))
@@ -661,7 +661,7 @@ static void bgp_accept(struct event *thread)
 	}
 	bgp_peer_reg_with_nht(doppelganger);
 	bgp_fsm_change_status(incoming, Active);
-	EVENT_OFF(incoming->t_start); /* created in peer_create() */
+	event_cancel(&incoming->t_start); /* created in peer_create() */
 
 	SET_FLAG(doppelganger->sflags, PEER_STATUS_ACCEPT_PEER);
 	/* Make dummy peer until read Open packet. */
@@ -1074,7 +1074,7 @@ void bgp_close_vrf_socket(struct bgp *bgp)
 
 	for (ALL_LIST_ELEMENTS(bm->listen_sockets, node, next, listener)) {
 		if (listener->bgp == bgp) {
-			EVENT_OFF(listener->thread);
+			event_cancel(&listener->thread);
 			close(listener->fd);
 			listnode_delete(bm->listen_sockets, listener);
 			XFREE(MTYPE_BGP_LISTENER, listener->name);
@@ -1096,7 +1096,7 @@ void bgp_close(void)
 	for (ALL_LIST_ELEMENTS(bm->listen_sockets, node, next, listener)) {
 		if (listener->bgp)
 			continue;
-		EVENT_OFF(listener->thread);
+		event_cancel(&listener->thread);
 		close(listener->fd);
 		listnode_delete(bm->listen_sockets, listener);
 		XFREE(MTYPE_BGP_LISTENER, listener->name);

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2531,7 +2531,7 @@ static int bgp_update_receive(struct peer_connection *connection,
 							gr_info->t_select_deferral);
 						XFREE(MTYPE_TMP, info);
 					}
-					EVENT_OFF(gr_info->t_select_deferral);
+					event_cancel(&gr_info->t_select_deferral);
 					gr_info->eor_required = 0;
 					gr_info->eor_received = 0;
 					/* Best path selection */
@@ -3055,7 +3055,7 @@ static int bgp_route_refresh_receive(struct peer_connection *connection,
 			return BGP_PACKET_NOOP;
 		}
 
-		EVENT_OFF(peer->t_refresh_stalepath);
+		event_cancel(&peer->t_refresh_stalepath);
 
 		SET_FLAG(peer->af_sflags[afi][safi], PEER_STATUS_EORR_RECEIVED);
 		UNSET_FLAG(peer->af_sflags[afi][safi],

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4019,7 +4019,7 @@ void bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi)
 
 		thread_info = EVENT_ARG(t);
 		XFREE(MTYPE_TMP, thread_info);
-		EVENT_OFF(bgp->gr_info[afi][safi].t_route_select);
+		event_cancel(&bgp->gr_info[afi][safi].t_route_select);
 	}
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART)) {
@@ -5914,7 +5914,7 @@ void bgp_stop_announce_route_timer(struct peer_af *paf)
 	if (!paf->t_announce_route)
 		return;
 
-	EVENT_OFF(paf->t_announce_route);
+	event_cancel(&paf->t_announce_route);
 }
 
 /*
@@ -6183,7 +6183,7 @@ void bgp_soft_reconfig_table_task_cancel(const struct bgp *bgp,
 
 		list_delete(&ntable->soft_reconfig_peers);
 		bgp_soft_reconfig_table_flag(ntable, false);
-		EVENT_OFF(ntable->soft_reconfig_thread);
+		event_cancel(&ntable->soft_reconfig_thread);
 	}
 }
 

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -4934,7 +4934,7 @@ static void bgp_route_map_mark_update(const char *rmap_name)
 	/* If new update is received before the current timer timed out,
 	 * turn it off and start a new timer.
 	 */
-	EVENT_OFF(bm->t_rmap_update);
+	event_cancel(&bm->t_rmap_update);
 
 	/* rmap_update_timer of 0 means don't do route updates */
 	if (bm->rmap_update_timer) {

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -924,7 +924,7 @@ static void stop(struct rpki_vrf *rpki_vrf)
 {
 	rpki_vrf->rtr_is_stopping = true;
 	if (is_running(rpki_vrf)) {
-		EVENT_OFF(rpki_vrf->t_rpki_sync);
+		event_cancel(&rpki_vrf->t_rpki_sync);
 		rtr_mgr_stop(rpki_vrf->rtr_config);
 		rtr_mgr_free(rpki_vrf->rtr_config);
 		rpki_vrf->rtr_is_running = false;

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1158,8 +1158,8 @@ static void update_subgroup_delete(struct update_subgroup *subgrp)
 	if (subgrp->update_group)
 		UPDGRP_INCR_STAT(subgrp->update_group, subgrps_deleted);
 
-	EVENT_OFF(subgrp->t_merge_check);
-	EVENT_OFF(subgrp->t_coalesce);
+	event_cancel(&subgrp->t_merge_check);
+	event_cancel(&subgrp->t_coalesce);
 
 	bpacket_queue_cleanup(SUBGRP_PKTQ(subgrp));
 	subgroup_clear_table(subgrp);
@@ -2149,7 +2149,7 @@ void update_group_refresh_default_originate_route_map(struct event *thread)
 	bgp = EVENT_ARG(thread);
 	update_group_walk(bgp, update_group_default_originate_route_map_walkcb,
 			  reason);
-	EVENT_OFF(bgp->t_rmap_def_originate_eval);
+	event_cancel(&bgp->t_rmap_def_originate_eval);
 }
 
 /*

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -419,7 +419,7 @@ static void subgroup_coalesce_timer(struct event *thread)
 			peer = PAF_PEER(paf);
 			struct peer_connection *connection = peer->connection;
 
-			EVENT_OFF(connection->t_routeadv);
+			event_cancel(&connection->t_routeadv);
 			BGP_TIMER_ON(connection->t_routeadv, bgp_routeadv_timer,
 				     0);
 		}

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2286,7 +2286,7 @@ DEFUN (no_bgp_maxmed_onstartup,
 
 	/* Cancel max-med onstartup if its on */
 	if (bgp->t_maxmed_onstartup) {
-		EVENT_OFF(bgp->t_maxmed_onstartup);
+		event_cancel(&bgp->t_maxmed_onstartup);
 		bgp->maxmed_onstartup_over = 1;
 	}
 
@@ -8093,7 +8093,7 @@ DEFUN (bgp_set_route_map_delay_timer,
 		 * fired.
 		 */
 		if (!rmap_delay_timer && bm->t_rmap_update) {
-			EVENT_OFF(bm->t_rmap_update);
+			event_cancel(&bm->t_rmap_update);
 			event_execute(bm->master, bgp_route_map_update_timer,
 				      NULL, 0, NULL);
 		}
@@ -8505,7 +8505,7 @@ DEFPY (bgp_def_originate_eval,
 	bgp->rmap_def_originate_eval_timer = no ? 0 : timer;
 
 	if (bgp->t_rmap_def_originate_eval)
-		EVENT_OFF(bgp->t_rmap_def_originate_eval);
+		event_cancel(&bgp->t_rmap_def_originate_eval);
 
 	return CMD_SUCCESS;
 }
@@ -20293,7 +20293,7 @@ static void bgp_config_end_timeout(struct event *t)
 
 static void bgp_config_start(void)
 {
-	EVENT_OFF(t_bgp_cfg);
+	event_cancel(&t_bgp_cfg);
 	event_add_timer(bm->master, bgp_config_end_timeout, NULL,
 			BGP_PRE_CONFIG_MAX_WAIT_SECONDS, &t_bgp_cfg);
 }
@@ -20317,7 +20317,7 @@ static void bgp_config_end(void)
 	if (!bgp_config_inprocess())
 		return;
 
-	EVENT_OFF(t_bgp_cfg);
+	event_cancel(&t_bgp_cfg);
 
 	/* Start a new timer to make sure we don't send EoR
 	 * before route-maps are processed.

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2672,16 +2672,16 @@ void peer_nsf_stop(struct peer *peer)
 
 	FOREACH_AFI_SAFI_NSF (afi, safi) {
 		peer->nsf[afi][safi] = 0;
-		EVENT_OFF(peer->t_llgr_stale[afi][safi]);
+		event_cancel(&peer->t_llgr_stale[afi][safi]);
 	}
 
 	if (peer->connection->t_gr_restart) {
-		EVENT_OFF(peer->connection->t_gr_restart);
+		event_cancel(&peer->connection->t_gr_restart);
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%pBP graceful restart timer stopped", peer);
 	}
 	if (peer->connection->t_gr_stale) {
-		EVENT_OFF(peer->connection->t_gr_stale);
+		event_cancel(&peer->connection->t_gr_stale);
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug(
 				"%pBP graceful restart stalepath timer stopped",
@@ -4009,7 +4009,7 @@ void bgp_instance_down(struct bgp *bgp)
 
 	/* Stop timers. */
 	if (bgp->t_rmap_def_originate_eval)
-		EVENT_OFF(bgp->t_rmap_def_originate_eval);
+		event_cancel(&bgp->t_rmap_def_originate_eval);
 
 	/* Bring down peers, so corresponding routes are purged. */
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, next, peer)) {
@@ -4147,14 +4147,14 @@ int bgp_delete(struct bgp *bgp)
 	hook_call(bgp_inst_delete, bgp);
 
 	FOREACH_AFI_SAFI (afi, safi)
-		EVENT_OFF(bgp->t_revalidate[afi][safi]);
+		event_cancel(&bgp->t_revalidate[afi][safi]);
 
-	EVENT_OFF(bgp->t_condition_check);
-	EVENT_OFF(bgp->t_startup);
-	EVENT_OFF(bgp->t_maxmed_onstartup);
-	EVENT_OFF(bgp->t_update_delay);
-	EVENT_OFF(bgp->t_establish_wait);
-	EVENT_OFF(bgp->clearing_end);
+	event_cancel(&bgp->t_condition_check);
+	event_cancel(&bgp->t_startup);
+	event_cancel(&bgp->t_maxmed_onstartup);
+	event_cancel(&bgp->t_update_delay);
+	event_cancel(&bgp->t_establish_wait);
+	event_cancel(&bgp->clearing_end);
 
 	/* Set flag indicating bgp instance delete in progress */
 	SET_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS);
@@ -4172,7 +4172,7 @@ int bgp_delete(struct bgp *bgp)
 
 			XFREE(MTYPE_TMP, info);
 		}
-		EVENT_OFF(gr_info->t_select_deferral);
+		event_cancel(&gr_info->t_select_deferral);
 
 		t = gr_info->t_route_select;
 		if (t) {
@@ -4180,7 +4180,7 @@ int bgp_delete(struct bgp *bgp)
 
 			XFREE(MTYPE_TMP, info);
 		}
-		EVENT_OFF(gr_info->t_route_select);
+		event_cancel(&gr_info->t_route_select);
 	}
 
 	/* Delete route flap dampening configuration */
@@ -4218,7 +4218,7 @@ int bgp_delete(struct bgp *bgp)
 
 	/* Stop timers. */
 	if (bgp->t_rmap_def_originate_eval)
-		EVENT_OFF(bgp->t_rmap_def_originate_eval);
+		event_cancel(&bgp->t_rmap_def_originate_eval);
 
 	/* Inform peers we're going down. */
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, next, peer))
@@ -4273,7 +4273,7 @@ int bgp_delete(struct bgp *bgp)
 	update_bgp_group_free(bgp);
 
 	/* Cancel peer connection errors event */
-	EVENT_OFF(bgp->t_conn_errors);
+	event_cancel(&bgp->t_conn_errors);
 
 	/* Cleanup for peer connection batching */
 	while ((cinfo = bgp_clearing_info_pop(&bgp->clearing_list)) != NULL)
@@ -5052,7 +5052,7 @@ static void peer_flag_modify_action(struct peer *peer, uint64_t flag)
 			UNSET_FLAG(peer->sflags, PEER_STATUS_PREFIX_OVERFLOW);
 
 			if (peer->connection->t_pmax_restart) {
-				EVENT_OFF(peer->connection->t_pmax_restart);
+				event_cancel(&peer->connection->t_pmax_restart);
 				if (bgp_debug_neighbor_events(peer))
 					zlog_debug(
 						"%pBP Maximum-prefix restart timer canceled",
@@ -8040,7 +8040,7 @@ static bool peer_maximum_prefix_clear_overflow(struct peer *peer)
 
 	UNSET_FLAG(peer->sflags, PEER_STATUS_PREFIX_OVERFLOW);
 	if (peer->connection->t_pmax_restart) {
-		EVENT_OFF(peer->connection->t_pmax_restart);
+		event_cancel(&peer->connection->t_pmax_restart);
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug(
 				"%pBP Maximum-prefix restart timer cancelled",
@@ -8964,12 +8964,12 @@ void bgp_terminate(void)
 	if (bm->listen_sockets)
 		list_delete(&bm->listen_sockets);
 
-	EVENT_OFF(bm->t_rmap_update);
-	EVENT_OFF(bm->t_bgp_sync_label_manager);
-	EVENT_OFF(bm->t_bgp_start_label_manager);
-	EVENT_OFF(bm->t_bgp_zebra_route);
-	EVENT_OFF(bm->t_bgp_zebra_l2_vni);
-	EVENT_OFF(bm->t_bgp_zebra_l3_vni);
+	event_cancel(&bm->t_rmap_update);
+	event_cancel(&bm->t_bgp_sync_label_manager);
+	event_cancel(&bm->t_bgp_start_label_manager);
+	event_cancel(&bm->t_bgp_zebra_route);
+	event_cancel(&bm->t_bgp_zebra_l2_vni);
+	event_cancel(&bm->t_bgp_zebra_l3_vni);
 
 	bgp_mac_finish();
 #ifdef ENABLE_BGP_VNC
@@ -9184,7 +9184,7 @@ void bgp_clearing_batch_end_event_start(struct bgp *bgp)
 	if (!event_is_scheduled(bgp->clearing_end))
 		bgp_lock(bgp);
 
-	EVENT_OFF(bgp->clearing_end);
+	event_cancel(&bgp->clearing_end);
 	event_add_timer_msec(bm->master, bgp_clearing_batch_end_event, bgp, 100, &bgp->clearing_end);
 }
 

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -850,7 +850,7 @@ static void rfapiBgpInfoChainFree(struct bgp_path_info *bpi)
 
 			rwcb_del(&_rwcbhash, wcb);
 			XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
-			EVENT_OFF(bpi->extra->vnc->vnc.import.timer);
+			event_cancel(&bpi->extra->vnc->vnc.import.timer);
 		}
 
 		next = bpi->next;
@@ -3088,7 +3088,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 
 					rwcb_del(&_rwcbhash, wcb);
 					XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
-					EVENT_OFF(bpi->extra->vnc->vnc.import
+					event_cancel(&bpi->extra->vnc->vnc.import
 							  .timer);
 				}
 
@@ -3182,7 +3182,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 
 			rwcb_del(&_rwcbhash, wcb);
 			XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
-			EVENT_OFF(bpi->extra->vnc->vnc.import.timer);
+			event_cancel(&bpi->extra->vnc->vnc.import.timer);
 		}
 		rfapiExpireEncapNow(import_table, rn, bpi);
 	}
@@ -3545,7 +3545,7 @@ void rfapiBgpInfoFilteredImportVPN(
 
 					rwcb_del(&_rwcbhash, wcb);
 					XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
-					EVENT_OFF(bpi->extra->vnc->vnc.import
+					event_cancel(&bpi->extra->vnc->vnc.import
 							  .timer);
 
 					import_table->holddown_count[afi] -= 1;
@@ -3765,7 +3765,7 @@ void rfapiBgpInfoFilteredImportVPN(
 
 			rwcb_del(&_rwcbhash, wcb);
 			XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
-			EVENT_OFF(bpi->extra->vnc->vnc.import.timer);
+			event_cancel(&bpi->extra->vnc->vnc.import.timer);
 		}
 		rfapiExpireVpnNow(import_table, rn, bpi, 0);
 	}
@@ -4518,7 +4518,7 @@ static void rfapiDeleteRemotePrefixesIt(
 						rwcb_del(&_rwcbhash, wcb);
 						XFREE(MTYPE_RFAPI_WITHDRAW,
 						      wcb);
-						EVENT_OFF(bpi->extra->vnc->vnc
+						event_cancel(&bpi->extra->vnc->vnc
 								  .import.timer);
 					}
 				} else {
@@ -4862,7 +4862,7 @@ void rfapi_import_terminate(void)
 	while ((wcb = rwcb_pop(&_rwcbhash))) {
 		bpi = wcb->info;
 		assert(wcb == EVENT_ARG(bpi->extra->vnc->vnc.import.timer));
-		EVENT_OFF(bpi->extra->vnc->vnc.import.timer);
+		event_cancel(&bpi->extra->vnc->vnc.import.timer);
 
 		timer_service_func = wcb->timer_service_func;
 		memset(&t, 0, sizeof(t));

--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -619,7 +619,7 @@ void rfapiMonitorDel(struct bgp *bgp, struct rfapi_descriptor *rfd,
 		rfapiMonitorDetachImport(m);
 	}
 
-	EVENT_OFF(m->timer);
+	event_cancel(&m->timer);
 
 	/*
 	 * remove from rfd list
@@ -656,7 +656,7 @@ int rfapiMonitorDelHd(struct rfapi_descriptor *rfd)
 					rfapiMonitorDetachImport(m);
 				}
 
-				EVENT_OFF(m->timer);
+				event_cancel(&m->timer);
 
 				XFREE(MTYPE_RFAPI_MONITOR, m);
 				rn->info = NULL;
@@ -690,7 +690,7 @@ int rfapiMonitorDelHd(struct rfapi_descriptor *rfd)
 #endif
 			}
 
-			EVENT_OFF(mon_eth->timer);
+			event_cancel(&mon_eth->timer);
 
 			/*
 			 * remove from rfd list
@@ -753,7 +753,7 @@ static void rfapiMonitorTimerRestart(struct rfapi_monitor_vpn *m)
 	if (m->rfd->response_lifetime - remain < 2)
 		return;
 
-	EVENT_OFF(m->timer);
+	event_cancel(&m->timer);
 
 	{
 		char buf[BUFSIZ];
@@ -1061,7 +1061,7 @@ static void rfapiMonitorEthTimerRestart(struct rfapi_monitor_eth *m)
 	if (m->rfd->response_lifetime - remain < 2)
 		return;
 
-	EVENT_OFF(m->timer);
+	event_cancel(&m->timer);
 
 	{
 		char buf[BUFSIZ];
@@ -1399,7 +1399,7 @@ void rfapiMonitorEthDel(struct bgp *bgp, struct rfapi_descriptor *rfd,
 		rfapiMonitorEthDetachImport(bgp, val);
 	}
 
-	EVENT_OFF(val->timer);
+	event_cancel(&val->timer);
 
 	/*
 	 * remove from rfd list

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -292,7 +292,7 @@ static void rfapi_info_free(struct rfapi_info *goner)
 #if DEBUG_CLEANUP
 			zlog_debug("%s: ri %p, tcb %p", __func__, goner, tcb);
 #endif
-			EVENT_OFF(goner->timer);
+			event_cancel(&goner->timer);
 			rrtcb_del(&_rrtcbhash, tcb);
 			XFREE(MTYPE_RFAPI_RECENT_DELETE, tcb);
 		}
@@ -357,7 +357,7 @@ static void rfapiRibStartTimer(struct rfapi_descriptor *rfd,
 
 	if (ri->timer) {
 		tcb = EVENT_ARG(ri->timer);
-		EVENT_OFF(ri->timer);
+		event_cancel(&ri->timer);
 	} else {
 		tcb = XCALLOC(MTYPE_RFAPI_RECENT_DELETE,
 			      sizeof(struct rfapi_rib_tcb));
@@ -554,7 +554,7 @@ void rfapiRibClear(struct rfapi_descriptor *rfd)
 
 							tcb = EVENT_ARG(
 								ri->timer);
-							EVENT_OFF(ri->timer);
+							event_cancel(&ri->timer);
 							rrtcb_del(&_rrtcbhash, tcb);
 							XFREE(MTYPE_RFAPI_RECENT_DELETE,
 							      tcb);
@@ -938,7 +938,7 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 					struct rfapi_rib_tcb *tcb;
 
 					tcb = EVENT_ARG(ri->timer);
-					EVENT_OFF(ri->timer);
+					event_cancel(&ri->timer);
 					rrtcb_del(&_rrtcbhash, tcb);
 					XFREE(MTYPE_RFAPI_RECENT_DELETE, tcb);
 				}
@@ -1024,7 +1024,7 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 					struct rfapi_rib_tcb *tcb;
 
 					tcb = EVENT_ARG(ori->timer);
-					EVENT_OFF(ori->timer);
+					event_cancel(&ori->timer);
 					rrtcb_del(&_rrtcbhash, tcb);
 					XFREE(MTYPE_RFAPI_RECENT_DELETE, tcb);
 				}
@@ -1360,7 +1360,7 @@ callback:
 					struct rfapi_rib_tcb *tcb;
 
 					tcb = EVENT_ARG(ri->timer);
-					EVENT_OFF(ri->timer);
+					event_cancel(&ri->timer);
 					rrtcb_del(&_rrtcbhash, tcb);
 					XFREE(MTYPE_RFAPI_RECENT_DELETE, tcb);
 				}
@@ -2466,7 +2466,7 @@ void rfapi_rib_terminate(void)
 	 */
 	while ((tcb = rrtcb_pop(&_rrtcbhash))) {
 		assert(tcb == EVENT_ARG(tcb->ri->timer));
-		EVENT_OFF(tcb->ri->timer);
+		event_cancel(&tcb->ri->timer);
 		_rfapiRibExpireTimer(tcb); /* deletes hash entry, frees tcb */
 	}
 }

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -1689,7 +1689,7 @@ void vnc_direct_bgp_rh_add_route(struct bgp *bgp, afi_t afi,
 	 * export expiration timer is already running on
 	 * this route: cancel it
 	 */
-	EVENT_OFF(eti->timer);
+	event_cancel(&eti->timer);
 
 	bgp_update(peer, prefix, /* prefix */
 		   0,		 /* addpath_id */
@@ -1918,7 +1918,7 @@ void vnc_direct_bgp_rh_vpn_enable(struct bgp *bgp, afi_t afi)
 					 * already running on
 					 * this route: cancel it
 					 */
-					EVENT_OFF(eti->timer);
+					event_cancel(&eti->timer);
 
 					vnc_zlog_debug_verbose(
 						"%s: calling bgp_update",
@@ -1987,7 +1987,7 @@ void vnc_direct_bgp_rh_vpn_disable(struct bgp *bgp, afi_t afi)
 					ZEBRA_ROUTE_VNC_DIRECT_RH,
 					BGP_ROUTE_REDISTRIBUTE);
 				if (eti) {
-					EVENT_OFF(eti->timer);
+					event_cancel(&eti->timer);
 					vnc_eti_delete(eti);
 				}
 

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -338,7 +338,7 @@ int eigrp_if_down(struct eigrp_interface *ei)
 		return 0;
 
 	/* Shutdown packet reception and sending */
-	EVENT_OFF(ei->t_hello);
+	event_cancel(&ei->t_hello);
 
 	eigrp_if_stream_unset(ei);
 

--- a/eigrpd/eigrp_neighbor.c
+++ b/eigrpd/eigrp_neighbor.c
@@ -177,7 +177,7 @@ void eigrp_nbr_delete(struct eigrp_neighbor *nbr)
 	event_cancel_event(master, nbr);
 	eigrp_fifo_free(nbr->multicast_queue);
 	eigrp_fifo_free(nbr->retrans_queue);
-	EVENT_OFF(nbr->t_holddown);
+	event_cancel(&nbr->t_holddown);
 
 	if (nbr->ei)
 		eigrp_nbr_hash_del(&nbr->ei->nbr_hash_head, nbr);
@@ -220,7 +220,7 @@ void eigrp_nbr_state_set(struct eigrp_neighbor *nbr, uint8_t state)
 
 		// hold time..
 		nbr->v_holddown = EIGRP_HOLD_INTERVAL_DEFAULT;
-		EVENT_OFF(nbr->t_holddown);
+		event_cancel(&nbr->t_holddown);
 
 		/* out with the old */
 		if (nbr->multicast_queue)
@@ -262,7 +262,7 @@ void eigrp_nbr_state_update(struct eigrp_neighbor *nbr)
 	switch (nbr->state) {
 	case EIGRP_NEIGHBOR_DOWN: {
 		/*Start Hold Down Timer for neighbor*/
-		//     EVENT_OFF(nbr->t_holddown);
+		//     event_cancel(&nbr->t_holddown);
 		//     EVENT_TIMER_ON(master, nbr->t_holddown,
 		//     holddown_timer_expired,
 		//     nbr, nbr->v_holddown);
@@ -270,14 +270,14 @@ void eigrp_nbr_state_update(struct eigrp_neighbor *nbr)
 	}
 	case EIGRP_NEIGHBOR_PENDING: {
 		/*Reset Hold Down Timer for neighbor*/
-		EVENT_OFF(nbr->t_holddown);
+		event_cancel(&nbr->t_holddown);
 		event_add_timer(master, holddown_timer_expired, nbr,
 				nbr->v_holddown, &nbr->t_holddown);
 		break;
 	}
 	case EIGRP_NEIGHBOR_UP: {
 		/*Reset Hold Down Timer for neighbor*/
-		EVENT_OFF(nbr->t_holddown);
+		event_cancel(&nbr->t_holddown);
 		event_add_timer(master, holddown_timer_expired, nbr,
 				nbr->v_holddown, &nbr->t_holddown);
 		break;

--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -923,7 +923,7 @@ void eigrp_packet_free(struct eigrp_packet *ep)
 	if (ep->s)
 		stream_free(ep->s);
 
-	EVENT_OFF(ep->t_retrans_timer);
+	event_cancel(&ep->t_retrans_timer);
 
 	XFREE(MTYPE_EIGRP_PACKET, ep);
 }

--- a/eigrpd/eigrpd.c
+++ b/eigrpd/eigrpd.c
@@ -266,8 +266,8 @@ void eigrp_finish_final(struct eigrp *eigrp)
 		eigrp_if_delete_hook(ei->ifp);
 	}
 
-	EVENT_OFF(eigrp->t_write);
-	EVENT_OFF(eigrp->t_read);
+	event_cancel(&eigrp->t_write);
+	event_cancel(&eigrp->t_read);
 	close(eigrp->fd);
 
 	eigrp_interface_hash_fini(&eigrp->eifs);

--- a/isisd/fabricd.c
+++ b/isisd/fabricd.c
@@ -225,11 +225,11 @@ struct fabricd *fabricd_new(struct isis_area *area)
 
 void fabricd_finish(struct fabricd *f)
 {
-	EVENT_OFF(f->initial_sync_timeout);
+	event_cancel(&f->initial_sync_timeout);
 
-	EVENT_OFF(f->tier_calculation_timer);
+	event_cancel(&f->tier_calculation_timer);
 
-	EVENT_OFF(f->tier_set_timer);
+	event_cancel(&f->tier_set_timer);
 
 	isis_spftree_del(f->spftree);
 	neighbor_lists_clear(f);
@@ -325,7 +325,7 @@ void fabricd_initial_sync_finish(struct isis_area *area)
 		  f->initial_sync_circuit->interface->name);
 	f->initial_sync_state = FABRICD_SYNC_COMPLETE;
 	f->initial_sync_circuit = NULL;
-	EVENT_OFF(f->initial_sync_timeout);
+	event_cancel(&f->initial_sync_timeout);
 }
 
 static void fabricd_bump_tier_calculation_timer(struct fabricd *f);
@@ -420,14 +420,14 @@ static void fabricd_bump_tier_calculation_timer(struct fabricd *f)
 {
 	/* Cancel timer if we already know our tier */
 	if (f->tier != ISIS_TIER_UNDEFINED || f->tier_set_timer) {
-		EVENT_OFF(f->tier_calculation_timer);
+		event_cancel(&f->tier_calculation_timer);
 		return;
 	}
 
 	/* If we need to calculate the tier, wait some
 	 * time for the topology to settle before running
 	 * the calculation */
-	EVENT_OFF(f->tier_calculation_timer);
+	event_cancel(&f->tier_calculation_timer);
 
 	event_add_timer(master, fabricd_tier_calculation_cb, f,
 			2 * f->area->lsp_gen_interval[ISIS_LEVEL2 - 1],
@@ -712,7 +712,7 @@ void fabricd_trigger_csnp(struct isis_area *area, bool circuit_scoped)
 		if (!circuit->t_send_csnp[1])
 			continue;
 
-		EVENT_OFF(circuit->t_send_csnp[ISIS_LEVEL2 - 1]);
+		event_cancel(&circuit->t_send_csnp[ISIS_LEVEL2 - 1]);
 		event_add_timer_msec(master, send_l2_csnp, circuit,
 				     isis_jitter(f->csnp_delay, CSNP_JITTER),
 				     &circuit->t_send_csnp[ISIS_LEVEL2 - 1]);

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -149,7 +149,7 @@ void isis_delete_adj(void *arg)
 	/* Remove self from snmp list without walking the list*/
 	list_delete_node(adj->circuit->snmp_adj_list, adj->snmp_list_node);
 
-	EVENT_OFF(adj->t_expire);
+	event_cancel(&adj->t_expire);
 	if (adj->adj_state != ISIS_ADJ_DOWN)
 		adj->adj_state = ISIS_ADJ_DOWN;
 

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -860,12 +860,12 @@ void isis_circuit_down(struct isis_circuit *circuit)
 		memset(circuit->u.bc.l2_desig_is, 0, ISIS_SYS_ID_LEN + 1);
 		memset(circuit->u.bc.snpa, 0, ETH_ALEN);
 
-		EVENT_OFF(circuit->u.bc.t_send_lan_hello[0]);
-		EVENT_OFF(circuit->u.bc.t_send_lan_hello[1]);
-		EVENT_OFF(circuit->u.bc.t_run_dr[0]);
-		EVENT_OFF(circuit->u.bc.t_run_dr[1]);
-		EVENT_OFF(circuit->u.bc.t_refresh_pseudo_lsp[0]);
-		EVENT_OFF(circuit->u.bc.t_refresh_pseudo_lsp[1]);
+		event_cancel(&circuit->u.bc.t_send_lan_hello[0]);
+		event_cancel(&circuit->u.bc.t_send_lan_hello[1]);
+		event_cancel(&circuit->u.bc.t_run_dr[0]);
+		event_cancel(&circuit->u.bc.t_run_dr[1]);
+		event_cancel(&circuit->u.bc.t_refresh_pseudo_lsp[0]);
+		event_cancel(&circuit->u.bc.t_refresh_pseudo_lsp[1]);
 		circuit->lsp_regenerate_pending[0] = 0;
 		circuit->lsp_regenerate_pending[1] = 0;
 
@@ -875,7 +875,7 @@ void isis_circuit_down(struct isis_circuit *circuit)
 	} else if (circuit->circ_type == CIRCUIT_T_P2P) {
 		isis_delete_adj(circuit->u.p2p.neighbor);
 		circuit->u.p2p.neighbor = NULL;
-		EVENT_OFF(circuit->u.p2p.t_send_p2p_hello);
+		event_cancel(&circuit->u.p2p.t_send_p2p_hello);
 	}
 
 	/*
@@ -888,11 +888,11 @@ void isis_circuit_down(struct isis_circuit *circuit)
 	circuit->snmp_adj_idx_gen = 0;
 
 	/* Cancel all active threads */
-	EVENT_OFF(circuit->t_send_csnp[0]);
-	EVENT_OFF(circuit->t_send_csnp[1]);
-	EVENT_OFF(circuit->t_send_psnp[0]);
-	EVENT_OFF(circuit->t_send_psnp[1]);
-	EVENT_OFF(circuit->t_read);
+	event_cancel(&circuit->t_send_csnp[0]);
+	event_cancel(&circuit->t_send_csnp[1]);
+	event_cancel(&circuit->t_send_psnp[0]);
+	event_cancel(&circuit->t_send_psnp[1]);
+	event_cancel(&circuit->t_read);
 
 	if (circuit->tx_queue) {
 		isis_tx_queue_free(circuit->tx_queue);
@@ -1674,7 +1674,7 @@ void isis_reset_hello_timer(struct isis_circuit *circuit)
 			send_hello(circuit, IS_LEVEL_1);
 
 			/* reset level-1 hello timer */
-			EVENT_OFF(circuit->u.bc.t_send_lan_hello[0]);
+			event_cancel(&circuit->u.bc.t_send_lan_hello[0]);
 			if (circuit->area && (circuit->area->is_type & IS_LEVEL_1))
 				send_hello_sched(circuit, IS_LEVEL_1,
 						 isis_jitter(circuit->hello_interval[0],
@@ -1686,7 +1686,7 @@ void isis_reset_hello_timer(struct isis_circuit *circuit)
 			send_hello(circuit, IS_LEVEL_2);
 
 			/* reset level-2 hello timer */
-			EVENT_OFF(circuit->u.bc.t_send_lan_hello[1]);
+			event_cancel(&circuit->u.bc.t_send_lan_hello[1]);
 			if (circuit->area && (circuit->area->is_type & IS_LEVEL_2))
 				send_hello_sched(circuit, IS_LEVEL_2,
 						 isis_jitter(circuit->hello_interval[1],
@@ -1697,7 +1697,7 @@ void isis_reset_hello_timer(struct isis_circuit *circuit)
 		send_hello(circuit, IS_LEVEL_1);
 
 		/* reset hello timer */
-		EVENT_OFF(circuit->u.p2p.t_send_p2p_hello);
+		event_cancel(&circuit->u.p2p.t_send_p2p_hello);
 		send_hello_sched(circuit, 0, isis_jitter(circuit->hello_interval[0], IIH_JITTER));
 	}
 }

--- a/isisd/isis_dr.c
+++ b/isisd/isis_dr.c
@@ -211,8 +211,8 @@ int isis_dr_resign(struct isis_circuit *circuit, int level)
 
 	circuit->u.bc.is_dr[level - 1] = 0;
 	circuit->u.bc.run_dr_elect[level - 1] = 0;
-	EVENT_OFF(circuit->u.bc.t_run_dr[level - 1]);
-	EVENT_OFF(circuit->u.bc.t_refresh_pseudo_lsp[level - 1]);
+	event_cancel(&circuit->u.bc.t_run_dr[level - 1]);
+	event_cancel(&circuit->u.bc.t_refresh_pseudo_lsp[level - 1]);
 	circuit->lsp_regenerate_pending[level - 1] = 0;
 
 	memcpy(id, circuit->isis->sysid, ISIS_SYS_ID_LEN);
@@ -236,7 +236,7 @@ int isis_dr_resign(struct isis_circuit *circuit, int level)
 				&circuit->t_send_psnp[1]);
 	}
 
-	EVENT_OFF(circuit->t_send_csnp[level - 1]);
+	event_cancel(&circuit->t_send_csnp[level - 1]);
 
 	event_add_timer(master, isis_run_dr, &circuit->level_arg[level - 1],
 			2 * circuit->hello_interval[level - 1],

--- a/isisd/isis_dynhn.c
+++ b/isisd/isis_dynhn.c
@@ -44,7 +44,7 @@ void dyn_cache_finish(struct isis *isis)
 	struct listnode *node, *nnode;
 	struct isis_dynhn *dyn;
 
-	EVENT_OFF(isis->t_dync_clean);
+	event_cancel(&isis->t_dync_clean);
 
 	for (ALL_LIST_ELEMENTS(isis->dyn_cache, node, nnode, dyn)) {
 		list_delete_node(isis->dyn_cache, node);

--- a/isisd/isis_events.c
+++ b/isisd/isis_events.c
@@ -98,13 +98,13 @@ static void circuit_resign_level(struct isis_circuit *circuit, int level)
 			circuit->area->area_tag, circuit->circuit_id,
 			circuit->interface->name, level);
 
-	EVENT_OFF(circuit->t_send_csnp[idx]);
-	EVENT_OFF(circuit->t_send_psnp[idx]);
+	event_cancel(&circuit->t_send_csnp[idx]);
+	event_cancel(&circuit->t_send_psnp[idx]);
 
 	if (circuit->circ_type == CIRCUIT_T_BROADCAST) {
-		EVENT_OFF(circuit->u.bc.t_send_lan_hello[idx]);
-		EVENT_OFF(circuit->u.bc.t_run_dr[idx]);
-		EVENT_OFF(circuit->u.bc.t_refresh_pseudo_lsp[idx]);
+		event_cancel(&circuit->u.bc.t_send_lan_hello[idx]);
+		event_cancel(&circuit->u.bc.t_run_dr[idx]);
+		event_cancel(&circuit->u.bc.t_refresh_pseudo_lsp[idx]);
 		circuit->lsp_regenerate_pending[idx] = 0;
 		circuit->u.bc.run_dr_elect[idx] = 0;
 		circuit->u.bc.is_dr[idx] = 0;

--- a/isisd/isis_ldp_sync.c
+++ b/isisd/isis_ldp_sync.c
@@ -170,7 +170,7 @@ void isis_ldp_sync_if_complete(struct isis_circuit *circuit)
 		if (ldp_sync_info->state == LDP_IGP_SYNC_STATE_REQUIRED_NOT_UP)
 			ldp_sync_info->state = LDP_IGP_SYNC_STATE_REQUIRED_UP;
 
-		EVENT_OFF(ldp_sync_info->t_holddown);
+		event_cancel(&ldp_sync_info->t_holddown);
 
 		isis_ldp_sync_set_if_metric(circuit, true);
 	}
@@ -190,7 +190,7 @@ void isis_ldp_sync_ldp_fail(struct isis_circuit *circuit)
 	if (ldp_sync_info &&
 	    ldp_sync_info->enabled == LDP_IGP_SYNC_ENABLED &&
 	    ldp_sync_info->state != LDP_IGP_SYNC_STATE_NOT_REQUIRED) {
-		EVENT_OFF(ldp_sync_info->t_holddown);
+		event_cancel(&ldp_sync_info->t_holddown);
 		ldp_sync_info->state = LDP_IGP_SYNC_STATE_REQUIRED_NOT_UP;
 		isis_ldp_sync_set_if_metric(circuit, true);
 	}
@@ -515,7 +515,7 @@ void isis_if_ldp_sync_disable(struct isis_circuit *circuit)
 	if (!CHECK_FLAG(area->ldp_sync_cmd.flags, LDP_SYNC_FLAG_ENABLE))
 		return;
 
-	EVENT_OFF(ldp_sync_info->t_holddown);
+	event_cancel(&ldp_sync_info->t_holddown);
 	ldp_sync_info->state = LDP_IGP_SYNC_STATE_NOT_REQUIRED;
 	isis_ldp_sync_set_if_metric(circuit, true);
 }

--- a/isisd/isis_lfa.c
+++ b/isisd/isis_lfa.c
@@ -1513,7 +1513,7 @@ int isis_rlfa_activate(struct isis_spftree *spftree, struct rlfa *rlfa,
 			  spftree->route_table_backup);
 	spftree->lfa.protection_counters.rlfa[vertex->N.ip.priority] += 1;
 
-	EVENT_OFF(area->t_rlfa_rib_update);
+	event_cancel(&area->t_rlfa_rib_update);
 	event_add_timer(master, isis_area_verify_routes_cb, area, 2,
 			&area->t_rlfa_rib_update);
 
@@ -1532,7 +1532,7 @@ void isis_rlfa_deactivate(struct isis_spftree *spftree, struct rlfa *rlfa)
 	isis_route_delete(area, rn, spftree->route_table_backup);
 	spftree->lfa.protection_counters.rlfa[vertex->N.ip.priority] -= 1;
 
-	EVENT_OFF(area->t_rlfa_rib_update);
+	event_cancel(&area->t_rlfa_rib_update);
 	event_add_timer(master, isis_area_verify_routes_cb, area, 2,
 			&area->t_rlfa_rib_update);
 }

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1520,7 +1520,7 @@ int lsp_generate(struct isis_area *area, int level)
 
 	refresh_time = lsp_refresh_time(newlsp, rem_lifetime);
 
-	EVENT_OFF(area->t_lsp_refresh[level - 1]);
+	event_cancel(&area->t_lsp_refresh[level - 1]);
 	area->lsp_regenerate_pending[level - 1] = 0;
 	event_add_timer(master, lsp_refresh, &area->lsp_refresh_arg[level - 1],
 			refresh_time, &area->t_lsp_refresh[level - 1]);
@@ -1729,7 +1729,7 @@ int _lsp_regenerate_schedule(struct isis_area *area, int level,
 			"ISIS (%s): Will schedule regen timer. Last run was: %lld, Now is: %lld",
 			area->area_tag, (long long)lsp->last_generated,
 			(long long)now);
-		EVENT_OFF(area->t_lsp_refresh[lvl - 1]);
+		event_cancel(&area->t_lsp_refresh[lvl - 1]);
 		diff = now - lsp->last_generated;
 		if (diff < area->lsp_gen_interval[lvl - 1]
 		    && !(area->bfd_signalled_down)) {
@@ -1915,7 +1915,7 @@ int lsp_generate_pseudo(struct isis_circuit *circuit, int level)
 	lsp_flood(lsp, NULL);
 
 	refresh_time = lsp_refresh_time(lsp, rem_lifetime);
-	EVENT_OFF(circuit->u.bc.t_refresh_pseudo_lsp[level - 1]);
+	event_cancel(&circuit->u.bc.t_refresh_pseudo_lsp[level - 1]);
 	circuit->lsp_regenerate_pending[level - 1] = 0;
 	if (level == IS_LEVEL_1)
 		event_add_timer(master, lsp_l1_refresh_pseudo, circuit,
@@ -2104,7 +2104,7 @@ int lsp_regenerate_schedule_pseudo(struct isis_circuit *circuit, int level)
 			"ISIS (%s): Will schedule PSN regen timer. Last run was: %lld, Now is: %lld",
 			area->area_tag, (long long)lsp->last_generated,
 			(long long)now);
-		EVENT_OFF(circuit->u.bc.t_refresh_pseudo_lsp[lvl - 1]);
+		event_cancel(&circuit->u.bc.t_refresh_pseudo_lsp[lvl - 1]);
 		diff = now - lsp->last_generated;
 		if (diff < circuit->area->lsp_gen_interval[lvl - 1]) {
 			timeout =

--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -216,7 +216,7 @@ static void isis_config_end_timeout(struct event *t)
 
 static void isis_config_start(void)
 {
-	EVENT_OFF(t_isis_cfg);
+	event_cancel(&t_isis_cfg);
 	event_add_timer(im->master, isis_config_end_timeout, NULL,
 			ISIS_PRE_CONFIG_MAX_WAIT_SECONDS, &t_isis_cfg);
 }
@@ -229,7 +229,7 @@ static void isis_config_end(void)
 	if (!event_is_scheduled(t_isis_cfg))
 		return;
 
-	EVENT_OFF(t_isis_cfg);
+	event_cancel(&t_isis_cfg);
 	isis_config_finish(t_isis_cfg);
 }
 

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -265,7 +265,7 @@ static int process_p2p_hello(struct iih_info *iih)
 				      adj);
 
 	/* lets take care of the expiry */
-	EVENT_OFF(adj->t_expire);
+	event_cancel(&adj->t_expire);
 	event_add_timer(master, isis_adj_expire, adj, (long)adj->hold_time,
 			&adj->t_expire);
 
@@ -528,7 +528,7 @@ static int process_lan_hello(struct iih_info *iih)
 				      adj);
 
 	/* lets take care of the expiry */
-	EVENT_OFF(adj->t_expire);
+	event_cancel(&adj->t_expire);
 	event_add_timer(master, isis_adj_expire, adj, (long)adj->hold_time,
 			&adj->t_expire);
 
@@ -2116,7 +2116,7 @@ static void _send_hello_sched(struct isis_circuit *circuit,
 		if (event_timer_remain_msec(*threadp) < (unsigned long)delay)
 			return;
 
-		EVENT_OFF(*threadp);
+		event_cancel(&*threadp);
 	}
 
 	event_add_timer_msec(master, send_hello_cb,

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -2178,7 +2178,7 @@ int _isis_spf_schedule(struct isis_area *area, int level,
 			area->area_tag, level, diff, func, file, line);
 	}
 
-	EVENT_OFF(area->t_rlfa_rib_update);
+	event_cancel(&area->t_rlfa_rib_update);
 	if (area->spf_delay_ietf[level - 1]) {
 		/* Need to call schedule function also if spf delay is running
 		 * to

--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -1274,7 +1274,7 @@ void isis_sr_stop(struct isis_area *area)
 		 area->area_tag);
 
 	/* Disable any re-attempt to connect to Label Manager */
-	EVENT_OFF(srdb->t_start_lm);
+	event_cancel(&srdb->t_start_lm);
 
 	/* Uninstall all local Adjacency-SIDs. */
 	for (ALL_LIST_ELEMENTS(area->srdb.adj_sids, node, nnode, sra))

--- a/isisd/isis_tx_queue.c
+++ b/isisd/isis_tx_queue.c
@@ -79,7 +79,7 @@ static void tx_queue_element_free(void *element)
 {
 	struct isis_tx_queue_entry *e = element;
 
-	EVENT_OFF(e->retry);
+	event_cancel(&e->retry);
 
 	XFREE(MTYPE_TX_QUEUE_ENTRY, e);
 }
@@ -147,7 +147,7 @@ void _isis_tx_queue_add(struct isis_tx_queue *queue,
 
 	e->type = type;
 
-	EVENT_OFF(e->retry);
+	event_cancel(&e->retry);
 	event_add_event(master, tx_queue_send_event, e, 0, &e->retry);
 
 	e->is_retry = false;
@@ -169,7 +169,7 @@ void _isis_tx_queue_del(struct isis_tx_queue *queue, struct isis_lsp *lsp,
 			   func, file, line);
 	}
 
-	EVENT_OFF(e->retry);
+	event_cancel(&e->retry);
 
 	hash_release(queue->hash, e);
 	XFREE(MTYPE_TX_QUEUE_ENTRY, e);

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -582,10 +582,10 @@ void isis_area_destroy(struct isis_area *area)
 
 	if (area->spf_timer[0])
 		isis_spf_timer_free(EVENT_ARG(area->spf_timer[0]));
-	EVENT_OFF(area->spf_timer[0]);
+	event_cancel(&area->spf_timer[0]);
 	if (area->spf_timer[1])
 		isis_spf_timer_free(EVENT_ARG(area->spf_timer[1]));
-	EVENT_OFF(area->spf_timer[1]);
+	event_cancel(&area->spf_timer[1]);
 
 	spf_backoff_free(area->spf_delay_ietf[0]);
 	spf_backoff_free(area->spf_delay_ietf[1]);
@@ -614,10 +614,10 @@ void isis_area_destroy(struct isis_area *area)
 	isis_lfa_tiebreakers_clear(area, ISIS_LEVEL1);
 	isis_lfa_tiebreakers_clear(area, ISIS_LEVEL2);
 
-	EVENT_OFF(area->t_tick);
-	EVENT_OFF(area->t_lsp_refresh[0]);
-	EVENT_OFF(area->t_lsp_refresh[1]);
-	EVENT_OFF(area->t_rlfa_rib_update);
+	event_cancel(&area->t_tick);
+	event_cancel(&area->t_lsp_refresh[0]);
+	event_cancel(&area->t_lsp_refresh[1]);
+	event_cancel(&area->t_rlfa_rib_update);
 
 	event_cancel_event(master, area);
 
@@ -3210,12 +3210,12 @@ static void area_resign_level(struct isis_area *area, int level)
 	if (area->spf_timer[level - 1])
 		isis_spf_timer_free(EVENT_ARG(area->spf_timer[level - 1]));
 
-	EVENT_OFF(area->spf_timer[level - 1]);
+	event_cancel(&area->spf_timer[level - 1]);
 
 	sched_debug(
 		"ISIS (%s): Resigned from L%d - canceling LSP regeneration timer.",
 		area->area_tag, level);
-	EVENT_OFF(area->t_lsp_refresh[level - 1]);
+	event_cancel(&area->t_lsp_refresh[level - 1]);
 	area->lsp_regenerate_pending[level - 1] = 0;
 }
 
@@ -3304,7 +3304,7 @@ void isis_area_overload_bit_set(struct isis_area *area, bool overload_bit)
 		} else {
 			/* Cancel overload on startup timer if it's running */
 			if (area->t_overload_on_startup_timer) {
-				EVENT_OFF(area->t_overload_on_startup_timer);
+				event_cancel(&area->t_overload_on_startup_timer);
 				area->t_overload_on_startup_timer = NULL;
 			}
 		}

--- a/ldpd/accept.c
+++ b/ldpd/accept.c
@@ -61,7 +61,7 @@ accept_del(int fd)
 	LIST_FOREACH(av, &accept_queue.queue, entry)
 		if (av->fd == fd) {
 			log_debug("%s: %d removed from queue", __func__, fd);
-			EVENT_OFF(av->ev);
+			event_cancel(&av->ev);
 			LIST_REMOVE(av, entry);
 			free(av);
 			return;
@@ -81,7 +81,7 @@ accept_unpause(void)
 {
 	if (accept_queue.evt != NULL) {
 		log_debug(__func__);
-		EVENT_OFF(accept_queue.evt);
+		event_cancel(&accept_queue.evt);
 		accept_arm();
 	}
 }
@@ -100,7 +100,7 @@ accept_unarm(void)
 {
 	struct accept_ev	*av;
 	LIST_FOREACH(av, &accept_queue.queue, entry)
-		EVENT_OFF(av->ev);
+		event_cancel(&av->ev);
 }
 
 static void accept_cb(struct event *thread)

--- a/ldpd/adjacency.c
+++ b/ldpd/adjacency.c
@@ -185,7 +185,7 @@ static void adj_itimer(struct event *thread)
 void
 adj_start_itimer(struct adj *adj)
 {
-	EVENT_OFF(adj->inactivity_timer);
+	event_cancel(&adj->inactivity_timer);
 	adj->inactivity_timer = NULL;
 	event_add_timer(master, adj_itimer, adj, adj->holdtime,
 			&adj->inactivity_timer);
@@ -194,7 +194,7 @@ adj_start_itimer(struct adj *adj)
 void
 adj_stop_itimer(struct adj *adj)
 {
-	EVENT_OFF(adj->inactivity_timer);
+	event_cancel(&adj->inactivity_timer);
 }
 
 /* targeted neighbors */
@@ -343,7 +343,7 @@ static void tnbr_hello_timer(struct event *thread)
 static void
 tnbr_start_hello_timer(struct tnbr *tnbr)
 {
-	EVENT_OFF(tnbr->hello_timer);
+	event_cancel(&tnbr->hello_timer);
 	tnbr->hello_timer = NULL;
 	event_add_timer(master, tnbr_hello_timer, tnbr,
 			tnbr_get_hello_interval(tnbr), &tnbr->hello_timer);
@@ -352,7 +352,7 @@ tnbr_start_hello_timer(struct tnbr *tnbr)
 static void
 tnbr_stop_hello_timer(struct tnbr *tnbr)
 {
-	EVENT_OFF(tnbr->hello_timer);
+	event_cancel(&tnbr->hello_timer);
 }
 
 struct ctl_adj *

--- a/ldpd/control.c
+++ b/ldpd/control.c
@@ -169,8 +169,8 @@ control_close(int fd)
 	msgbuf_clear(&c->iev.ibuf.w);
 	TAILQ_REMOVE(&ctl_conns, c, entry);
 
-	EVENT_OFF(c->iev.ev_read);
-	EVENT_OFF(c->iev.ev_write);
+	event_cancel(&c->iev.ev_read);
+	event_cancel(&c->iev.ev_write);
 	close(c->iev.ibuf.fd);
 	accept_unpause();
 	free(c);

--- a/ldpd/interface.c
+++ b/ldpd/interface.c
@@ -454,7 +454,7 @@ static void if_hello_timer(struct event *thread)
 static void
 if_start_hello_timer(struct iface_af *ia)
 {
-	EVENT_OFF(ia->hello_timer);
+	event_cancel(&ia->hello_timer);
 	event_add_timer(master, if_hello_timer, ia, if_get_hello_interval(ia),
 			&ia->hello_timer);
 }
@@ -462,7 +462,7 @@ if_start_hello_timer(struct iface_af *ia)
 static void
 if_stop_hello_timer(struct iface_af *ia)
 {
-	EVENT_OFF(ia->hello_timer);
+	event_cancel(&ia->hello_timer);
 }
 
 struct ctl_iface *
@@ -728,7 +728,7 @@ static void start_wait_for_ldp_sync_timer(struct iface *iface)
 	if (iface->ldp_sync.wait_for_sync_timer)
 		return;
 
-	EVENT_OFF(iface->ldp_sync.wait_for_sync_timer);
+	event_cancel(&iface->ldp_sync.wait_for_sync_timer);
 	event_add_timer(master, iface_wait_for_ldp_sync_timer, iface,
 			if_get_wait_for_sync_interval(),
 			&iface->ldp_sync.wait_for_sync_timer);
@@ -736,7 +736,7 @@ static void start_wait_for_ldp_sync_timer(struct iface *iface)
 
 static void stop_wait_for_ldp_sync_timer(struct iface *iface)
 {
-	EVENT_OFF(iface->ldp_sync.wait_for_sync_timer);
+	event_cancel(&iface->ldp_sync.wait_for_sync_timer);
 }
 
 static int

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -399,8 +399,8 @@ static void lde_dispatch_imsg(struct event *thread)
 		imsg_event_add(iev);
 	else {
 		/* this pipe is dead, so remove the event handlers and exit */
-		EVENT_OFF(iev->ev_read);
-		EVENT_OFF(iev->ev_write);
+		event_cancel(&iev->ev_read);
+		event_cancel(&iev->ev_write);
 		lde_shutdown();
 	}
 }
@@ -677,8 +677,8 @@ static void lde_dispatch_parent(struct event *thread)
 		imsg_event_add(iev);
 	else {
 		/* this pipe is dead, so remove the event handlers and exit */
-		EVENT_OFF(iev->ev_read);
-		EVENT_OFF(iev->ev_write);
+		event_cancel(&iev->ev_read);
+		event_cancel(&iev->ev_write);
 		lde_shutdown();
 	}
 }

--- a/ldpd/lde_lib.c
+++ b/ldpd/lde_lib.c
@@ -1044,12 +1044,12 @@ void lde_gc_timer(struct event *thread)
 void
 lde_gc_start_timer(void)
 {
-	EVENT_OFF(gc_timer);
+	event_cancel(&gc_timer);
 	event_add_timer(master, lde_gc_timer, NULL, LDE_GC_INTERVAL, &gc_timer);
 }
 
 void
 lde_gc_stop_timer(void)
 {
-	EVENT_OFF(gc_timer);
+	event_cancel(&gc_timer);
 }

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -622,8 +622,8 @@ static void main_dispatch_ldpe(struct event *thread)
 		imsg_event_add(iev);
 	else {
 		/* this pipe is dead, so remove the event handlers and exit */
-		EVENT_OFF(iev->ev_read);
-		EVENT_OFF(iev->ev_write);
+		event_cancel(&iev->ev_read);
+		event_cancel(&iev->ev_write);
 		ldpe_pid = 0;
 
 		if (lde_pid == 0)
@@ -728,8 +728,8 @@ static void main_dispatch_lde(struct event *thread)
 		imsg_event_add(iev);
 	else {
 		/* this pipe is dead, so remove the event handlers and exit */
-		EVENT_OFF(iev->ev_read);
-		EVENT_OFF(iev->ev_write);
+		event_cancel(&iev->ev_read);
+		event_cancel(&iev->ev_write);
 		lde_pid = 0;
 		if (ldpe_pid == 0)
 			ldpd_shutdown();
@@ -751,8 +751,8 @@ void ldp_write_handler(struct event *thread)
 		fatal("msgbuf_write");
 	if (n == 0) {
 		/* this pipe is dead, so remove the event handlers */
-		EVENT_OFF(iev->ev_read);
-		EVENT_OFF(iev->ev_write);
+		event_cancel(&iev->ev_read);
+		event_cancel(&iev->ev_write);
 		return;
 	}
 
@@ -841,7 +841,7 @@ void evbuf_init(struct evbuf *eb, int fd, void (*handler)(struct event *),
 void
 evbuf_clear(struct evbuf *eb)
 {
-	EVENT_OFF(eb->ev);
+	event_cancel(&eb->ev);
 	msgbuf_clear(&eb->wbuf);
 	eb->wbuf.fd = -1;
 }

--- a/ldpd/ldpe.c
+++ b/ldpd/ldpe.c
@@ -203,7 +203,7 @@ static FRR_NORETURN void ldpe_shutdown(void)
 
 #ifdef __OpenBSD__
 	if (sysdep.no_pfkey == 0) {
-		EVENT_OFF(pfkey_ev);
+		event_cancel(&pfkey_ev);
 		close(global.pfkeysock);
 	}
 #endif
@@ -604,8 +604,8 @@ static void ldpe_dispatch_main(struct event *thread)
 		imsg_event_add(iev);
 	else {
 		/* this pipe is dead, so remove the event handlers and exit */
-		EVENT_OFF(iev->ev_read);
-		EVENT_OFF(iev->ev_write);
+		event_cancel(&iev->ev_read);
+		event_cancel(&iev->ev_write);
 		ldpe_shutdown();
 	}
 }
@@ -737,8 +737,8 @@ static void ldpe_dispatch_lde(struct event *thread)
 		imsg_event_add(iev);
 	else {
 		/* this pipe is dead, so remove the event handlers and exit */
-		EVENT_OFF(iev->ev_read);
-		EVENT_OFF(iev->ev_write);
+		event_cancel(&iev->ev_read);
+		event_cancel(&iev->ev_write);
 		ldpe_shutdown();
 	}
 }
@@ -788,14 +788,14 @@ ldpe_close_sockets(int af)
 	af_global = ldp_af_global_get(&global, af);
 
 	/* discovery socket */
-	EVENT_OFF(af_global->disc_ev);
+	event_cancel(&af_global->disc_ev);
 	if (af_global->ldp_disc_socket != -1) {
 		close(af_global->ldp_disc_socket);
 		af_global->ldp_disc_socket = -1;
 	}
 
 	/* extended discovery socket */
-	EVENT_OFF(af_global->edisc_ev);
+	event_cancel(&af_global->edisc_ev);
 	if (af_global->ldp_edisc_socket != -1) {
 		close(af_global->ldp_edisc_socket);
 		af_global->ldp_edisc_socket = -1;

--- a/ldpd/neighbor.c
+++ b/ldpd/neighbor.c
@@ -293,7 +293,7 @@ nbr_del(struct nbr *nbr)
 	nbr->auth.method = AUTH_NONE;
 
 	if (nbr_pending_connect(nbr))
-		EVENT_OFF(nbr->ev_connect);
+		event_cancel(&nbr->ev_connect);
 	nbr_stop_ktimer(nbr);
 	nbr_stop_ktimeout(nbr);
 	nbr_stop_itimeout(nbr);
@@ -420,7 +420,7 @@ nbr_start_ktimer(struct nbr *nbr)
 
 	/* send three keepalives per period */
 	secs = nbr->keepalive / KEEPALIVE_PER_PERIOD;
-	EVENT_OFF(nbr->keepalive_timer);
+	event_cancel(&nbr->keepalive_timer);
 	nbr->keepalive_timer = NULL;
 	event_add_timer(master, nbr_ktimer, nbr, secs, &nbr->keepalive_timer);
 }
@@ -428,7 +428,7 @@ nbr_start_ktimer(struct nbr *nbr)
 void
 nbr_stop_ktimer(struct nbr *nbr)
 {
-	EVENT_OFF(nbr->keepalive_timer);
+	event_cancel(&nbr->keepalive_timer);
 }
 
 /* Keepalive timeout: if the nbr hasn't sent keepalive */
@@ -447,7 +447,7 @@ static void nbr_ktimeout(struct event *thread)
 static void
 nbr_start_ktimeout(struct nbr *nbr)
 {
-	EVENT_OFF(nbr->keepalive_timeout);
+	event_cancel(&nbr->keepalive_timeout);
 	nbr->keepalive_timeout = NULL;
 	event_add_timer(master, nbr_ktimeout, nbr, nbr->keepalive,
 			&nbr->keepalive_timeout);
@@ -456,7 +456,7 @@ nbr_start_ktimeout(struct nbr *nbr)
 void
 nbr_stop_ktimeout(struct nbr *nbr)
 {
-	EVENT_OFF(nbr->keepalive_timeout);
+	event_cancel(&nbr->keepalive_timeout);
 }
 
 /* Session initialization timeout: if nbr got stuck in the initialization FSM */
@@ -476,7 +476,7 @@ nbr_start_itimeout(struct nbr *nbr)
 	int		 secs;
 
 	secs = INIT_FSM_TIMEOUT;
-	EVENT_OFF(nbr->init_timeout);
+	event_cancel(&nbr->init_timeout);
 	nbr->init_timeout = NULL;
 	event_add_timer(master, nbr_itimeout, nbr, secs, &nbr->init_timeout);
 }
@@ -484,7 +484,7 @@ nbr_start_itimeout(struct nbr *nbr)
 void
 nbr_stop_itimeout(struct nbr *nbr)
 {
-	EVENT_OFF(nbr->init_timeout);
+	event_cancel(&nbr->init_timeout);
 }
 
 /* Init delay timer: timer to retry to iniziatize session */
@@ -513,7 +513,7 @@ nbr_start_idtimer(struct nbr *nbr)
 		nbr->idtimer_cnt++;
 	}
 
-	EVENT_OFF(nbr->initdelay_timer);
+	event_cancel(&nbr->initdelay_timer);
 	nbr->initdelay_timer = NULL;
 	event_add_timer(master, nbr_idtimer, nbr, secs, &nbr->initdelay_timer);
 }
@@ -521,7 +521,7 @@ nbr_start_idtimer(struct nbr *nbr)
 void
 nbr_stop_idtimer(struct nbr *nbr)
 {
-	EVENT_OFF(nbr->initdelay_timer);
+	event_cancel(&nbr->initdelay_timer);
 }
 
 int

--- a/ldpd/packet.c
+++ b/ldpd/packet.c
@@ -627,7 +627,7 @@ session_shutdown(struct nbr *nbr, uint32_t status, uint32_t msg_id,
 	switch (nbr->state) {
 	case NBR_STA_PRESENT:
 		if (nbr_pending_connect(nbr))
-			EVENT_OFF(nbr->ev_connect);
+			event_cancel(&nbr->ev_connect);
 		break;
 	case NBR_STA_INITIAL:
 	case NBR_STA_OPENREC:
@@ -731,7 +731,7 @@ tcp_close(struct tcp_conn *tcp)
 	evbuf_clear(&tcp->wbuf);
 
 	if (tcp->nbr) {
-		EVENT_OFF(tcp->rev);
+		event_cancel(&tcp->rev);
 		free(tcp->rbuf);
 		tcp->nbr->tcp = NULL;
 	}
@@ -763,7 +763,7 @@ pending_conn_new(int fd, int af, union ldpd_addr *addr)
 void
 pending_conn_del(struct pending_conn *pconn)
 {
-	EVENT_OFF(pconn->ev_timeout);
+	event_cancel(&pconn->ev_timeout);
 	TAILQ_REMOVE(&global.pending_conns, pconn, entry);
 	free(pconn);
 }

--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -548,7 +548,7 @@ static void _bfd_sess_send(struct event *t)
 static void _bfd_sess_remove(struct bfd_session_params *bsp)
 {
 	/* Cancel any pending installation request. */
-	EVENT_OFF(bsp->installev);
+	event_cancel(&bsp->installev);
 
 	/* Not installed, nothing to do. */
 	if (!bsp->installed)
@@ -905,7 +905,7 @@ int zclient_bfd_session_replay(ZAPI_CALLBACK_ARGS)
 		bsp->installed = false;
 
 		/* Cancel any pending installation request. */
-		EVENT_OFF(bsp->installev);
+		event_cancel(&bsp->installev);
 
 		/* Ask for installation. */
 		bsp->lastev = BSE_INSTALL;

--- a/lib/frrevent.h
+++ b/lib/frrevent.h
@@ -187,15 +187,6 @@ static inline unsigned long timeval_elapsed(struct timeval a, struct timeval b)
 #define EVENT_VAL(X) ((X)->u.val)
 
 /*
- * Please consider this macro deprecated, and do not use it in new code.
- */
-#define EVENT_OFF(thread)                                                      \
-	do {                                                                   \
-		if ((thread))                                                  \
-			event_cancel(&(thread));                               \
-	} while (0)
-
-/*
  * Macro wrappers to generate xrefs for all thread add calls.  Includes
  * file/line/function info for debugging/tracing.
  */

--- a/lib/ldp_sync.c
+++ b/lib/ldp_sync.c
@@ -66,7 +66,7 @@ bool ldp_sync_if_down(struct ldp_sync_info *ldp_sync_info)
 	 *   update state
 	 */
 	if (ldp_sync_info && ldp_sync_info->enabled == LDP_IGP_SYNC_ENABLED) {
-		EVENT_OFF(ldp_sync_info->t_holddown);
+		event_cancel(&ldp_sync_info->t_holddown);
 
 		if (ldp_sync_info->state == LDP_IGP_SYNC_STATE_REQUIRED_UP)
 			ldp_sync_info->state =

--- a/lib/mgmt_msg.c
+++ b/lib/mgmt_msg.c
@@ -641,9 +641,9 @@ void msg_conn_cleanup(struct msg_conn *conn)
 		conn->fd = -1;
 	}
 
-	EVENT_OFF(conn->read_ev);
-	EVENT_OFF(conn->write_ev);
-	EVENT_OFF(conn->proc_msg_ev);
+	event_cancel(&conn->read_ev);
+	event_cancel(&conn->write_ev);
+	event_cancel(&conn->proc_msg_ev);
 
 	mgmt_msg_destroy(ms);
 }
@@ -796,7 +796,7 @@ void msg_client_cleanup(struct msg_client *client)
 {
 	assert(client->conn.is_client);
 
-	EVENT_OFF(client->conn_retry_tmr);
+	event_cancel(&client->conn_retry_tmr);
 	free(client->sopath);
 
 	msg_conn_cleanup(&client->conn);
@@ -910,7 +910,7 @@ void msg_server_cleanup(struct msg_server *server)
 	DEBUGD(server->debug, "Closing %s server", server->idtag);
 
 	if (server->listen_ev)
-		EVENT_OFF(server->listen_ev);
+		event_cancel(&server->listen_ev);
 
 	msg_server_list_del(&msg_servers, server);
 

--- a/lib/northbound_notif.c
+++ b/lib/northbound_notif.c
@@ -735,7 +735,7 @@ void nb_notif_terminate(void)
 
 	__dbg("terminating: timer: %p timer arg: %p walk %p", nb_notif_timer, args, nb_notif_walk);
 
-	EVENT_OFF(nb_notif_timer);
+	event_cancel(&nb_notif_timer);
 
 	if (nb_notif_walk) {
 		/* Grab walk args from walk if active. */

--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -183,7 +183,7 @@ static inline void nb_op_free_yield_state(struct nb_op_yield_state *ys,
 	if (ys) {
 		if (ys->user_tree && ys->user_tree_unlock)
 			ys->user_tree_unlock(ys->user_tree, ys->user_tree_lock);
-		EVENT_OFF(ys->walk_ev);
+		event_cancel(&ys->walk_ev);
 		nb_op_walks_del(&nb_op_walks, ys);
 		/* if we have a branch then free up it's libyang tree */
 		if (!nofree_tree && ys_root_node(ys))

--- a/lib/northbound_sysrepo.c
+++ b/lib/northbound_sysrepo.c
@@ -625,7 +625,7 @@ static int frr_sr_finish(void)
 		if (!module->sr_subscription)
 			continue;
 		sr_unsubscribe(module->sr_subscription);
-		EVENT_OFF(module->sr_thread);
+		event_cancel(&module->sr_thread);
 	}
 
 	if (session)

--- a/lib/pullwr.c
+++ b/lib/pullwr.c
@@ -63,7 +63,7 @@ struct pullwr *_pullwr_new(struct event_loop *tm, int fd, void *arg,
 
 void pullwr_del(struct pullwr *pullwr)
 {
-	EVENT_OFF(pullwr->writer);
+	event_cancel(&pullwr->writer);
 
 	XFREE(MTYPE_PULLWR_BUF, pullwr->buffer);
 	XFREE(MTYPE_PULLWR_HEAD, pullwr);

--- a/lib/resolver.c
+++ b/lib/resolver.c
@@ -116,7 +116,7 @@ static void resolver_cb_socket_readable(struct event *t)
 	event_add_read(r->master, resolver_cb_socket_readable, resfd, resfd->fd,
 		       &resfd->t_read);
 	/* ^ ordering important:
-	 * ares_process_fd may transitively call EVENT_OFF(resfd->t_read)
+	 * ares_process_fd may transitively call event_cancel(&resfd->t_read)
 	 * combined with resolver_fd_drop_maybe, so resfd may be free'd after!
 	 */
 	ares_process_fd(r->channel, resfd->fd, ARES_SOCKET_BAD);
@@ -131,7 +131,7 @@ static void resolver_cb_socket_writable(struct event *t)
 	event_add_write(r->master, resolver_cb_socket_writable, resfd,
 			resfd->fd, &resfd->t_write);
 	/* ^ ordering important:
-	 * ares_process_fd may transitively call EVENT_OFF(resfd->t_write)
+	 * ares_process_fd may transitively call event_cancel(&resfd->t_write)
 	 * combined with resolver_fd_drop_maybe, so resfd may be free'd after!
 	 */
 	ares_process_fd(r->channel, ARES_SOCKET_BAD, resfd->fd);
@@ -142,7 +142,7 @@ static void resolver_update_timeouts(struct resolver_state *r)
 {
 	struct timeval *tv, tvbuf;
 
-	EVENT_OFF(r->timeout);
+	event_cancel(&r->timeout);
 	tv = ares_timeout(r->channel, NULL, &tvbuf);
 	if (tv) {
 		unsigned int timeoutms = tv->tv_sec * 1000 + tv->tv_usec / 1000;
@@ -165,13 +165,13 @@ static void ares_socket_cb(void *data, ares_socket_t fd, int readable,
 	assert(resfd->state == r);
 
 	if (!readable)
-		EVENT_OFF(resfd->t_read);
+		event_cancel(&resfd->t_read);
 	else if (!resfd->t_read)
 		event_add_read(r->master, resolver_cb_socket_readable, resfd,
 			       fd, &resfd->t_read);
 
 	if (!writable)
-		EVENT_OFF(resfd->t_write);
+		event_cancel(&resfd->t_write);
 	else if (!resfd->t_write)
 		event_add_write(r->master, resolver_cb_socket_writable, resfd,
 				fd, &resfd->t_write);

--- a/lib/spf_backoff.c
+++ b/lib/spf_backoff.c
@@ -117,7 +117,7 @@ static void spf_backoff_holddown_elapsed(struct event *thread)
 {
 	struct spf_backoff *backoff = EVENT_ARG(thread);
 
-	EVENT_OFF(backoff->t_timetolearn);
+	event_cancel(&backoff->t_timetolearn);
 	timerclear(&backoff->first_event_time);
 	backoff->state = SPF_BACKOFF_QUIET;
 	backoff_debug("SPF Back-off(%s) HOLDDOWN elapsed, move to state %s",

--- a/lib/wheel.c
+++ b/lib/wheel.c
@@ -89,7 +89,7 @@ void wheel_delete(struct timer_wheel *wheel)
 		list_delete(&wheel->wheel_slot_lists[i]);
 	}
 
-	EVENT_OFF(wheel->timer);
+	event_cancel(&wheel->timer);
 	XFREE(MTYPE_TIMER_WHEEL_LIST, wheel->wheel_slot_lists);
 	XFREE(MTYPE_TIMER_WHEEL, wheel);
 }

--- a/lib/workqueue.c
+++ b/lib/workqueue.c
@@ -96,7 +96,7 @@ void work_queue_free_and_null(struct work_queue **wqp)
 {
 	struct work_queue *wq = *wqp;
 
-	EVENT_OFF(wq->thread);
+	event_cancel(&wq->thread);
 
 	while (!work_queue_empty(wq)) {
 		struct work_queue_item *item = work_queue_last_item(wq);
@@ -213,7 +213,7 @@ void workqueue_cmd_init(void)
  */
 void work_queue_plug(struct work_queue *wq)
 {
-	EVENT_OFF(wq->thread);
+	event_cancel(&wq->thread);
 
 	UNSET_FLAG(wq->flags, WQ_UNPLUGGED);
 }

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -257,9 +257,9 @@ void zclient_stop(struct zclient *zclient)
 		zlog_debug("zclient %p stopped", zclient);
 
 	/* Stop threads. */
-	EVENT_OFF(zclient->t_read);
-	EVENT_OFF(zclient->t_connect);
-	EVENT_OFF(zclient->t_write);
+	event_cancel(&zclient->t_read);
+	event_cancel(&zclient->t_connect);
+	event_cancel(&zclient->t_write);
 
 	/* Reset streams. */
 	stream_reset(zclient->ibuf);
@@ -393,7 +393,7 @@ enum zclient_send_status zclient_send_message(struct zclient *zclient)
 			 __func__, zclient->sock);
 		return zclient_failed(zclient);
 	case BUFFER_EMPTY:
-		EVENT_OFF(zclient->t_write);
+		event_cancel(&zclient->t_write);
 		return ZCLIENT_SEND_SUCCESS;
 	case BUFFER_PENDING:
 		event_add_write(zclient->master, zclient_flush_data, zclient,

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -869,7 +869,7 @@ extern void mgmt_be_adapter_unlock(struct mgmt_be_client_adapter **adapter)
 
 	if (!--a->refcount) {
 		mgmt_be_adapters_del(&mgmt_be_adapters, a);
-		EVENT_OFF(a->conn_init_ev);
+		event_cancel(&a->conn_init_ev);
 		msg_server_conn_delete(a->conn);
 		XFREE(MTYPE_MGMTD_BE_ADPATER, a);
 	}

--- a/mgmtd/mgmt_testc.c
+++ b/mgmtd/mgmt_testc.c
@@ -157,7 +157,7 @@ static void sigusr1(void)
 
 static void quit(int exit_code)
 {
-	EVENT_OFF(event_timeout);
+	event_cancel(&event_timeout);
 	darr_free(__client_cbs.notif_xpaths);
 	darr_free(__client_cbs.rpc_xpaths);
 

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -757,7 +757,7 @@ static int mgmt_txn_send_commit_cfg_reply(struct mgmt_txn_ctx *txn,
 	if (success) {
 		/* Stop the commit-timeout timer */
 		/* XXX why only on success? */
-		EVENT_OFF(txn->comm_cfg_timeout);
+		event_cancel(&txn->comm_cfg_timeout);
 
 		create_cmt_info_rec =
 			(result != MGMTD_NO_CFG_CHANGES &&
@@ -1299,7 +1299,7 @@ static int txn_get_tree_data_done(struct mgmt_txn_ctx *txn,
 	int ret = NB_OK;
 
 	/* cancel timer and send reply onward */
-	EVENT_OFF(txn->get_tree_timeout);
+	event_cancel(&txn->get_tree_timeout);
 
 	if (!get_tree->simple_xpath && get_tree->client_results) {
 		/*
@@ -1347,7 +1347,7 @@ static int txn_rpc_done(struct mgmt_txn_ctx *txn, struct mgmt_txn_req *txn_req)
 	uint64_t req_id = txn_req->req_id;
 
 	/* cancel timer and send reply onward */
-	EVENT_OFF(txn->rpc_timeout);
+	event_cancel(&txn->rpc_timeout);
 
 	if (rpc->errstr)
 		mgmt_fe_adapter_txn_error(txn->txn_id, req_id, false, -EINVAL,
@@ -1522,7 +1522,7 @@ static void mgmt_txn_process_commit_cfg(struct event *thread)
 		 * cleanup. Please see mgmt_fe_send_commit_cfg_reply() for
 		 * more details.
 		 */
-		EVENT_OFF(txn->comm_cfg_timeout);
+		event_cancel(&txn->comm_cfg_timeout);
 		mgmt_txn_send_commit_cfg_reply(txn, MGMTD_SUCCESS, NULL);
 		break;
 	case MGMTD_COMMIT_PHASE_MAX:
@@ -1916,11 +1916,11 @@ static void mgmt_txn_unlock(struct mgmt_txn_ctx **txn, bool in_hash_free, const 
 		if ((*txn)->type == MGMTD_TXN_TYPE_CONFIG)
 			if (mgmt_txn_mm->cfg_txn == *txn)
 				mgmt_txn_mm->cfg_txn = NULL;
-		EVENT_OFF((*txn)->proc_get_cfg);
-		EVENT_OFF((*txn)->proc_get_data);
-		EVENT_OFF((*txn)->proc_comm_cfg);
-		EVENT_OFF((*txn)->comm_cfg_timeout);
-		EVENT_OFF((*txn)->get_tree_timeout);
+		event_cancel(&(*txn)->proc_get_cfg);
+		event_cancel(&(*txn)->proc_get_data);
+		event_cancel(&(*txn)->proc_comm_cfg);
+		event_cancel(&(*txn)->comm_cfg_timeout);
+		event_cancel(&(*txn)->get_tree_timeout);
 		if (!in_hash_free)
 			hash_release(mgmt_txn_mm->txn_hash, *txn);
 

--- a/nhrpd/nhrp_cache.c
+++ b/nhrpd/nhrp_cache.c
@@ -74,8 +74,8 @@ static void nhrp_cache_free(struct nhrp_cache *c)
 		nhrp_peer_notify_del(c->cur.peer, &c->peer_notifier);
 	nhrp_peer_unref(c->cur.peer);
 	nhrp_peer_unref(c->new.peer);
-	EVENT_OFF(c->t_timeout);
-	EVENT_OFF(c->t_auth);
+	event_cancel(&c->t_timeout);
+	event_cancel(&c->t_auth);
 	XFREE(MTYPE_NHRP_CACHE, c);
 }
 
@@ -312,7 +312,7 @@ static void nhrp_cache_peer_notifier(struct notifier_block *n,
 
 static void nhrp_cache_reset_new(struct nhrp_cache *c)
 {
-	EVENT_OFF(c->t_auth);
+	event_cancel(&c->t_auth);
 	if (notifier_list_anywhere(&c->newpeer_notifier))
 		nhrp_peer_notify_del(c->new.peer, &c->newpeer_notifier);
 	nhrp_peer_unref(c->new.peer);
@@ -322,7 +322,7 @@ static void nhrp_cache_reset_new(struct nhrp_cache *c)
 
 static void nhrp_cache_update_timers(struct nhrp_cache *c)
 {
-	EVENT_OFF(c->t_timeout);
+	event_cancel(&c->t_timeout);
 
 	switch (c->cur.type) {
 	case NHRP_CACHE_INVALID:

--- a/nhrpd/nhrp_event.c
+++ b/nhrpd/nhrp_event.c
@@ -31,8 +31,8 @@ static void evmgr_reconnect(struct event *t);
 
 static void evmgr_connection_error(struct event_manager *evmgr)
 {
-	EVENT_OFF(evmgr->t_read);
-	EVENT_OFF(evmgr->t_write);
+	event_cancel(&evmgr->t_read);
+	event_cancel(&evmgr->t_write);
 	zbuf_reset(&evmgr->ibuf);
 	zbufq_reset(&evmgr->obuf);
 

--- a/nhrpd/nhrp_multicast.c
+++ b/nhrpd/nhrp_multicast.c
@@ -194,7 +194,7 @@ static void netlink_mcast_log_register(int fd, int group)
 void netlink_mcast_set_nflog_group(int nlgroup)
 {
 	if (netlink_mcast_log_fd >= 0) {
-		EVENT_OFF(netlink_mcast_log_thread);
+		event_cancel(&netlink_mcast_log_thread);
 		close(netlink_mcast_log_fd);
 		netlink_mcast_log_fd = -1;
 		debugf(NHRP_DEBUG_COMMON, "De-register nflog group");

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -43,8 +43,8 @@ static void nhrp_peer_check_delete(struct nhrp_peer *p)
 	debugf(NHRP_DEBUG_COMMON, "Deleting peer ref:%d remote:%pSU local:%pSU",
 	       p->ref, &p->vc->remote.nbma, &p->vc->local.nbma);
 
-	EVENT_OFF(p->t_fallback);
-	EVENT_OFF(p->t_timer);
+	event_cancel(&p->t_fallback);
+	event_cancel(&p->t_timer);
 	if (nifp->peer_hash)
 		hash_release(nifp->peer_hash, p);
 	nhrp_interface_notify_del(p->ifp, &p->ifp_notifier);
@@ -77,7 +77,7 @@ static void __nhrp_peer_check(struct nhrp_peer *p)
 
 	online = nifp->enabled && (!nifp->ipsec_profile || vc->ipsec);
 	if (p->online != online) {
-		EVENT_OFF(p->t_fallback);
+		event_cancel(&p->t_fallback);
 		if (online && notifier_active(&p->notifier_list)) {
 			/* If we requested the IPsec connection, delay
 			 * the up notification a bit to allow things
@@ -279,7 +279,7 @@ static void nhrp_peer_defer_vici_request(struct event *t)
 	struct interface *ifp = p->ifp;
 	struct nhrp_interface *nifp = ifp->info;
 
-	EVENT_OFF(p->t_timer);
+	event_cancel(&p->t_timer);
 
 	if (p->online) {
 		debugf(NHRP_DEBUG_COMMON,

--- a/nhrpd/vici.c
+++ b/nhrpd/vici.c
@@ -71,8 +71,8 @@ static void vici_connection_error(struct vici_conn *vici)
 {
 	nhrp_vc_reset();
 
-	EVENT_OFF(vici->t_read);
-	EVENT_OFF(vici->t_write);
+	event_cancel(&vici->t_read);
+	event_cancel(&vici->t_write);
 	zbuf_reset(&vici->ibuf);
 	zbufq_reset(&vici->obuf);
 

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -435,8 +435,8 @@ void ospf6_area_disable(struct ospf6_area *oa)
 	ospf6_spf_table_finish(oa->spf_table);
 	ospf6_route_remove_all(oa->route_table);
 
-	EVENT_OFF(oa->thread_router_lsa);
-	EVENT_OFF(oa->thread_intra_prefix_lsa);
+	event_cancel(&oa->thread_router_lsa);
+	event_cancel(&oa->thread_intra_prefix_lsa);
 }
 
 

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -3117,7 +3117,7 @@ static void ospf6_aggr_handle_external_info(void *data)
 			if (IS_OSPF6_DEBUG_AGGR)
 				zlog_debug("%s: LSA found, refresh it",
 					   __func__);
-			EVENT_OFF(lsa->refresh);
+			event_cancel(&lsa->refresh);
 			event_add_event(master, ospf6_lsa_refresh, lsa, 0,
 					&lsa->refresh);
 			return;
@@ -3319,7 +3319,7 @@ static void ospf6_handle_exnl_rt_after_aggr_del(struct ospf6 *ospf6,
 	lsa = ospf6_find_external_lsa(ospf6, &rt->prefix);
 
 	if (lsa) {
-		EVENT_OFF(lsa->refresh);
+		event_cancel(&lsa->refresh);
 		event_add_event(master, ospf6_lsa_refresh, lsa, 0,
 				&lsa->refresh);
 	} else {
@@ -3468,7 +3468,7 @@ ospf6_start_asbr_summary_delay_timer(struct ospf6 *ospf6,
 			if (IS_OSPF6_DEBUG_AGGR)
 				zlog_debug("%s, Restarting Aggregator delay timer.",
 							__func__);
-			EVENT_OFF(ospf6->t_external_aggr);
+			event_cancel(&ospf6->t_external_aggr);
 		}
 	}
 

--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -103,7 +103,7 @@ static void ospf6_bfd_callback(struct bfd_session_params *bsp,
 
 	if (bss->state == BFD_STATUS_DOWN
 	    && bss->previous_state == BFD_STATUS_UP) {
-		EVENT_OFF(on->inactivity_timer);
+		event_cancel(&on->inactivity_timer);
 		event_add_event(master, inactivity_timer, on, 0, NULL);
 	}
 }

--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -104,7 +104,7 @@ void ospf6_lsa_originate(struct ospf6 *ospf6, struct ospf6_lsa *lsa)
 	lsdb_self = ospf6_get_scoped_lsdb_self(lsa);
 	ospf6_lsdb_add(ospf6_lsa_copy(lsa), lsdb_self);
 
-	EVENT_OFF(lsa->refresh);
+	event_cancel(&lsa->refresh);
 	event_add_timer(master, ospf6_lsa_refresh, lsa, OSPF_LS_REFRESH_TIME,
 			&lsa->refresh);
 
@@ -169,8 +169,8 @@ void ospf6_lsa_purge(struct ospf6_lsa *lsa)
 	self = ospf6_lsdb_lookup(lsa->header->type, lsa->header->id,
 				 lsa->header->adv_router, lsdb_self);
 	if (self) {
-		EVENT_OFF(self->expire);
-		EVENT_OFF(self->refresh);
+		event_cancel(&self->expire);
+		event_cancel(&self->refresh);
 		ospf6_lsdb_remove(self, lsdb_self);
 	}
 
@@ -251,8 +251,8 @@ void ospf6_install_lsa(struct ospf6_lsa *lsa)
 					   lsa->name);
 			lsa->external_lsa_id = old->external_lsa_id;
 		}
-		EVENT_OFF(old->expire);
-		EVENT_OFF(old->refresh);
+		event_cancel(&old->expire);
+		event_cancel(&old->refresh);
 		ospf6_flood_clear(old);
 	}
 
@@ -524,7 +524,7 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 	} else {
 		/* reschedule retransmissions to all neighbors */
 		for (ALL_LIST_ELEMENTS(oi->neighbor_list, node, nnode, on)) {
-			EVENT_OFF(on->thread_send_lsupdate);
+			event_cancel(&on->thread_send_lsupdate);
 			event_add_event(master, ospf6_lsupdate_send_neighbor,
 					on, 0, &on->thread_send_lsupdate);
 		}

--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -172,7 +172,7 @@ static void ospf6_gr_restart_exit(struct ospf6 *ospf6, const char *reason)
 	ospf6->gr_info.finishing_restart = true;
 	XFREE(MTYPE_TMP, ospf6->gr_info.exit_reason);
 	ospf6->gr_info.exit_reason = XSTRDUP(MTYPE_TMP, reason);
-	EVENT_OFF(ospf6->gr_info.t_grace_period);
+	event_cancel(&ospf6->gr_info.t_grace_period);
 
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, onode, area)) {
 		struct ospf6_interface *oi;
@@ -194,7 +194,7 @@ static void ospf6_gr_restart_exit(struct ospf6 *ospf6, const char *reason)
 			/* Disable hello delay. */
 			if (oi->gr.hello_delay.t_grace_send) {
 				oi->gr.hello_delay.elapsed_seconds = 0;
-				EVENT_OFF(oi->gr.hello_delay.t_grace_send);
+				event_cancel(&oi->gr.hello_delay.t_grace_send);
 				event_add_event(master, ospf6_hello_send, oi, 0,
 						&oi->thread_send_hello);
 			}

--- a/ospf6d/ospf6_gr_helper.c
+++ b/ospf6d/ospf6_gr_helper.c
@@ -383,7 +383,7 @@ int ospf6_process_grace_lsa(struct ospf6 *ospf6, struct ospf6_lsa *lsa,
 	}
 
 	if (OSPF6_GR_IS_ACTIVE_HELPER(restarter)) {
-		EVENT_OFF(restarter->gr_helper_info.t_grace_timer);
+		event_cancel(&restarter->gr_helper_info.t_grace_timer);
 
 		if (ospf6->ospf6_helper_cfg.active_restarter_cnt > 0)
 			ospf6->ospf6_helper_cfg.active_restarter_cnt--;
@@ -471,7 +471,7 @@ void ospf6_gr_helper_exit(struct ospf6_neighbor *nbr,
 	 * expiry, stop the grace timer.
 	 */
 	if (reason != OSPF6_GR_HELPER_GRACE_TIMEOUT)
-		EVENT_OFF(nbr->gr_helper_info.t_grace_timer);
+		event_cancel(&nbr->gr_helper_info.t_grace_timer);
 
 	if (ospf6->ospf6_helper_cfg.active_restarter_cnt <= 0) {
 		zlog_err(

--- a/ospf6d/ospf6_intra.h
+++ b/ospf6d/ospf6_intra.h
@@ -142,7 +142,7 @@ enum stub_router_mode {
 
 #define OSPF6_NETWORK_LSA_EXECUTE(oi)                                          \
 	do {                                                                   \
-		EVENT_OFF((oi)->thread_network_lsa);                           \
+		event_cancel(&(oi)->thread_network_lsa);                           \
 		event_execute(master, ospf6_network_lsa_originate, oi, 0,      \
 			      NULL);                                           \
 	} while (0)
@@ -156,7 +156,7 @@ enum stub_router_mode {
 
 #define OSPF6_INTRA_PREFIX_LSA_EXECUTE_TRANSIT(oi)                             \
 	do {                                                                   \
-		EVENT_OFF((oi)->thread_intra_prefix_lsa);                      \
+		event_cancel(&(oi)->thread_intra_prefix_lsa);                      \
 		event_execute(master,                                          \
 			      ospf6_intra_prefix_lsa_originate_transit, oi,    \
 			      0, NULL);                                        \
@@ -164,7 +164,7 @@ enum stub_router_mode {
 
 #define OSPF6_AS_EXTERN_LSA_EXECUTE(oi)                                        \
 	do {                                                                   \
-		EVENT_OFF((oi)->thread_as_extern_lsa);                         \
+		event_cancel(&(oi)->thread_as_extern_lsa);                         \
 		event_execute(master, ospf6_orig_as_external_lsa, oi, 0, NULL);\
 	} while (0)
 

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -379,8 +379,8 @@ void ospf6_lsa_premature_aging(struct ospf6_lsa *lsa)
 	if (IS_OSPF6_DEBUG_LSA_TYPE(lsa->header->type))
 		zlog_debug("LSA: Premature aging: %s", lsa->name);
 
-	EVENT_OFF(lsa->expire);
-	EVENT_OFF(lsa->refresh);
+	event_cancel(&lsa->expire);
+	event_cancel(&lsa->refresh);
 
 	/*
 	 * We clear the LSA from the neighbor retx lists now because it
@@ -837,8 +837,8 @@ void ospf6_lsa_delete(struct ospf6_lsa *lsa)
 	assert(lsa->lock == 0);
 
 	/* cancel threads */
-	EVENT_OFF(lsa->expire);
-	EVENT_OFF(lsa->refresh);
+	event_cancel(&lsa->expire);
+	event_cancel(&lsa->refresh);
 
 	/* do free */
 	XFREE(MTYPE_OSPF6_LSA_HEADER, lsa->header);

--- a/ospf6d/ospf6_lsdb.c
+++ b/ospf6d/ospf6_lsdb.c
@@ -396,7 +396,7 @@ int ospf6_lsdb_maxage_remover(struct ospf6_lsdb *lsdb)
 				htonl(OSPF_MAX_SEQUENCE_NUMBER + 1);
 			ospf6_lsa_checksum(lsa->header);
 
-			EVENT_OFF(lsa->refresh);
+			event_cancel(&lsa->refresh);
 			event_execute(master, ospf6_lsa_refresh, lsa, 0, NULL);
 		} else {
 			if (IS_OSPF6_DEBUG_LSA_TYPE(lsa->header->type))

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -214,7 +214,7 @@ static void ospf6_config_start(void)
 {
 	if (IS_OSPF6_DEBUG_EVENT)
 		zlog_debug("ospf6d config start received");
-	EVENT_OFF(t_ospf6_cfg);
+	event_cancel(&t_ospf6_cfg);
 	event_add_timer(master, ospf6_config_finish, NULL,
 			OSPF6_PRE_CONFIG_MAX_WAIT_SECONDS, &t_ospf6_cfg);
 }
@@ -224,7 +224,7 @@ static void ospf6_config_end(void)
 	if (IS_OSPF6_DEBUG_EVENT)
 		zlog_debug("ospf6d config end received");
 
-	EVENT_OFF(t_ospf6_cfg);
+	event_cancel(&t_ospf6_cfg);
 }
 
 /* Main routine of ospf6d. Treatment of argument and starting ospf finite

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -822,7 +822,7 @@ static void ospf6_dbdesc_recv_master(struct ospf6_header *oh,
 		event_add_event(master, ospf6_lsreq_send, on, 0,
 				&on->thread_send_lsreq);
 
-	EVENT_OFF(on->thread_send_dbdesc);
+	event_cancel(&on->thread_send_dbdesc);
 
 	/* More bit check */
 	if (!CHECK_FLAG(dbdesc->bits, OSPF6_DBDESC_MBIT)
@@ -907,7 +907,7 @@ static void ospf6_dbdesc_recv_slave(struct ospf6_header *oh,
 			if (IS_OSPF6_DEBUG_MESSAGE(oh->type, RECV_HDR))
 				zlog_debug(
 					"Duplicated dbdesc causes retransmit");
-			EVENT_OFF(on->thread_send_dbdesc);
+			event_cancel(&on->thread_send_dbdesc);
 			event_add_event(master, ospf6_dbdesc_send, on, 0,
 					&on->thread_send_dbdesc);
 			return;
@@ -960,7 +960,7 @@ static void ospf6_dbdesc_recv_slave(struct ospf6_header *oh,
 			if (IS_OSPF6_DEBUG_MESSAGE(oh->type, RECV_HDR))
 				zlog_debug(
 					"Duplicated dbdesc causes retransmit");
-			EVENT_OFF(on->thread_send_dbdesc);
+			event_cancel(&on->thread_send_dbdesc);
 			event_add_event(master, ospf6_dbdesc_send, on, 0,
 					&on->thread_send_dbdesc);
 			return;
@@ -1034,7 +1034,7 @@ static void ospf6_dbdesc_recv_slave(struct ospf6_header *oh,
 		event_add_event(master, ospf6_lsreq_send, on, 0,
 				&on->thread_send_lsreq);
 
-	EVENT_OFF(on->thread_send_dbdesc);
+	event_cancel(&on->thread_send_dbdesc);
 	event_add_event(master, ospf6_dbdesc_send_newone, on, 0,
 			&on->thread_send_dbdesc);
 
@@ -1168,7 +1168,7 @@ static void ospf6_lsreq_recv(struct in6_addr *src, struct in6_addr *dst,
 	assert(p == OSPF6_MESSAGE_END(oh));
 
 	/* schedule send lsupdate */
-	EVENT_OFF(on->thread_send_lsupdate);
+	event_cancel(&on->thread_send_lsupdate);
 	event_add_event(master, ospf6_lsupdate_send_neighbor, on, 0,
 			&on->thread_send_lsupdate);
 }
@@ -3000,7 +3000,7 @@ static uint16_t ospf6_make_lsack_interface(struct ospf6_interface *oi,
 		    > ospf6_packet_max(oi)) {
 			/* if we run out of packet size/space here,
 			   better to try again soon. */
-			EVENT_OFF(oi->thread_send_lsack);
+			event_cancel(&oi->thread_send_lsack);
 			event_add_event(master, ospf6_lsack_send_interface, oi,
 					0, &oi->thread_send_lsack);
 

--- a/ospf6d/ospf6_nssa.c
+++ b/ospf6d/ospf6_nssa.c
@@ -1079,7 +1079,7 @@ static void ospf6_ase_lsa_refresh(struct ospf6 *o)
 					route->path.origin.id, o->router_id,
 					o->lsdb);
 		if (old) {
-			EVENT_OFF(old->refresh);
+			event_cancel(&old->refresh);
 			event_add_event(master, ospf6_lsa_refresh, old, 0,
 					&old->refresh);
 		} else {
@@ -1154,7 +1154,7 @@ void ospf6_area_nssa_update(struct ospf6_area *area)
 						   lsa)) {
 				if (IS_OSPF6_DEBUG_NSSA)
 					ospf6_lsa_header_print(lsa);
-				EVENT_OFF(lsa->refresh);
+				event_cancel(&lsa->refresh);
 				event_add_event(master, ospf6_lsa_refresh, lsa,
 						0, &lsa->refresh);
 			}

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -722,7 +722,7 @@ void ospf6_spf_schedule(struct ospf6 *ospf6, unsigned int reason)
 	if (IS_OSPF6_DEBUG_SPF(PROCESS) || IS_OSPF6_DEBUG_SPF(TIME))
 		zlog_debug("SPF: Rescheduling in %ld msec", delay);
 
-	EVENT_OFF(ospf6->t_spf_calc);
+	event_cancel(&ospf6->t_spf_calc);
 	event_add_timer_msec(master, ospf6_spf_calculation_thread, ospf6, delay,
 			     &ospf6->t_spf_calc);
 }

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -554,15 +554,15 @@ static void ospf6_disable(struct ospf6 *o)
 		ospf6_route_remove_all(o->route_table);
 		ospf6_route_remove_all(o->brouter_table);
 
-		EVENT_OFF(o->maxage_remover);
-		EVENT_OFF(o->t_spf_calc);
-		EVENT_OFF(o->t_ase_calc);
-		EVENT_OFF(o->t_distribute_update);
-		EVENT_OFF(o->t_ospf6_receive);
-		EVENT_OFF(o->t_external_aggr);
-		EVENT_OFF(o->gr_info.t_grace_period);
-		EVENT_OFF(o->t_write);
-		EVENT_OFF(o->t_abr_task);
+		event_cancel(&o->maxage_remover);
+		event_cancel(&o->t_spf_calc);
+		event_cancel(&o->t_ase_calc);
+		event_cancel(&o->t_distribute_update);
+		event_cancel(&o->t_ospf6_receive);
+		event_cancel(&o->t_external_aggr);
+		event_cancel(&o->gr_info.t_grace_period);
+		event_cancel(&o->t_write);
+		event_cancel(&o->t_abr_task);
 	}
 }
 

--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -1739,7 +1739,7 @@ static void ospf_abr_announce_non_dna_routers(struct event *thread)
 	struct listnode *node;
 	struct ospf *ospf = EVENT_ARG(thread);
 
-	EVENT_OFF(ospf->t_abr_fr);
+	event_cancel(&ospf->t_abr_fr);
 
 	if (!IS_OSPF_ABR(ospf))
 		return;

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -310,12 +310,12 @@ void ospf_apiserver_free(struct ospf_apiserver *apiserv)
 	struct listnode *node;
 
 	/* Cancel read and write threads. */
-	EVENT_OFF(apiserv->t_sync_read);
+	event_cancel(&apiserv->t_sync_read);
 #ifdef USE_ASYNC_READ
-	EVENT_OFF(apiserv->t_async_read);
+	event_cancel(&apiserv->t_async_read);
 #endif /* USE_ASYNC_READ */
-	EVENT_OFF(apiserv->t_sync_write);
-	EVENT_OFF(apiserv->t_async_write);
+	event_cancel(&apiserv->t_sync_write);
+	event_cancel(&apiserv->t_async_write);
 
 	/* Unregister all opaque types that application registered
 	   and flush opaque LSAs if still in LSDB. */

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -1157,7 +1157,7 @@ static void ospf_external_aggr_timer(struct ospf *ospf,
 				zlog_debug(
 					"%s, Restarting Aggregator delay timer.",
 					__func__);
-			EVENT_OFF(ospf->t_external_aggr);
+			event_cancel(&ospf->t_external_aggr);
 		}
 	}
 

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -1237,7 +1237,7 @@ void ospf_ls_retransmit_set_timer(struct ospf_neighbor *nbr)
 	struct ospf_lsa_list_entry *ls_rxmt_list_entry;
 
 	if (nbr->t_ls_rxmt)
-		EVENT_OFF(nbr->t_ls_rxmt);
+		event_cancel(&nbr->t_ls_rxmt);
 
 	ls_rxmt_list_entry = ospf_lsa_list_first(&nbr->ls_rxmt_list);
 	if (ls_rxmt_list_entry) {

--- a/ospfd/ospf_gr.c
+++ b/ospfd/ospf_gr.c
@@ -225,7 +225,7 @@ static void ospf_gr_restart_exit(struct ospf *ospf, const char *reason)
 		zlog_debug("GR: exiting graceful restart: %s", reason);
 
 	ospf->gr_info.restart_in_progress = false;
-	EVENT_OFF(ospf->gr_info.t_grace_period);
+	event_cancel(&ospf->gr_info.t_grace_period);
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->areas, onode, area)) {
 		struct ospf_interface *oi;
@@ -241,7 +241,7 @@ static void ospf_gr_restart_exit(struct ospf *ospf, const char *reason)
 			/* Disable hello delay. */
 			if (oi->gr.hello_delay.t_grace_send) {
 				oi->gr.hello_delay.elapsed_seconds = 0;
-				EVENT_OFF(oi->gr.hello_delay.t_grace_send);
+				event_cancel(&oi->gr.hello_delay.t_grace_send);
 				OSPF_ISM_TIMER_MSEC_ON(oi->t_hello,
 						       ospf_hello_timer, 1);
 			}

--- a/ospfd/ospf_gr_helper.c
+++ b/ospfd/ospf_gr_helper.c
@@ -500,7 +500,7 @@ int ospf_process_grace_lsa(struct ospf *ospf, struct ospf_lsa *lsa,
 
 	if (OSPF_GR_IS_ACTIVE_HELPER(restarter)) {
 		if (restarter->gr_helper_info.t_grace_timer)
-			EVENT_OFF(restarter->gr_helper_info.t_grace_timer);
+			event_cancel(&restarter->gr_helper_info.t_grace_timer);
 
 		if (ospf->active_restarter_cnt > 0)
 			ospf->active_restarter_cnt--;
@@ -699,7 +699,7 @@ void ospf_gr_helper_exit(struct ospf_neighbor *nbr,
 	 * expiry, stop the grace timer.
 	 */
 	if (reason != OSPF_GR_HELPER_GRACE_TIMEOUT)
-		EVENT_OFF(nbr->gr_helper_info.t_grace_timer);
+		event_cancel(&nbr->gr_helper_info.t_grace_timer);
 
 	/* check exit triggered due to successful completion
 	 * of graceful restart.

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -336,7 +336,7 @@ void ospf_if_cleanup(struct ospf_interface *oi)
 	/* oi->nbrs and oi->nbr_nbma should be deleted on InterfaceDown event */
 	/* delete all static neighbors attached to this interface */
 	for (ALL_LIST_ELEMENTS(oi->nbr_nbma, node, nnode, nbr_nbma)) {
-		EVENT_OFF(nbr_nbma->t_poll);
+		event_cancel(&nbr_nbma->t_poll);
 
 		if (nbr_nbma->nbr) {
 			nbr_nbma->nbr->nbr_nbma = NULL;
@@ -526,7 +526,7 @@ void ospf_interface_fifo_flush(struct ospf_interface *oi)
 	if (oi->on_write_q) {
 		listnode_delete(ospf->oi_write_q, oi);
 		if (list_isempty(ospf->oi_write_q))
-			EVENT_OFF(ospf->t_write);
+			event_cancel(&ospf->t_write);
 		oi->on_write_q = 0;
 	}
 }
@@ -1576,7 +1576,7 @@ void ospf_reset_hello_timer(struct interface *ifp, struct in_addr addr,
 			ospf_hello_send(oi);
 
 			/* Restart hello timer for this interface */
-			EVENT_OFF(oi->t_hello);
+			event_cancel(&oi->t_hello);
 			OSPF_HELLO_TIMER_ON(oi);
 		}
 
@@ -1600,7 +1600,7 @@ void ospf_reset_hello_timer(struct interface *ifp, struct in_addr addr,
 		ospf_hello_send(oi);
 
 		/* Restart the hello timer. */
-		EVENT_OFF(oi->t_hello);
+		event_cancel(&oi->t_hello);
 		OSPF_HELLO_TIMER_ON(oi);
 	}
 }

--- a/ospfd/ospf_ism.c
+++ b/ospfd/ospf_ism.c
@@ -283,18 +283,18 @@ static void ism_timer_set(struct ospf_interface *oi)
 		   interface parameters must be set to initial values, and
 		   timers are
 		   reset also. */
-		EVENT_OFF(oi->t_hello);
-		EVENT_OFF(oi->t_wait);
-		EVENT_OFF(oi->t_ls_ack_delayed);
-		EVENT_OFF(oi->gr.hello_delay.t_grace_send);
+		event_cancel(&oi->t_hello);
+		event_cancel(&oi->t_wait);
+		event_cancel(&oi->t_ls_ack_delayed);
+		event_cancel(&oi->gr.hello_delay.t_grace_send);
 		break;
 	case ISM_Loopback:
 		/* In this state, the interface may be looped back and will be
 		   unavailable for regular data traffic. */
-		EVENT_OFF(oi->t_hello);
-		EVENT_OFF(oi->t_wait);
-		EVENT_OFF(oi->t_ls_ack_delayed);
-		EVENT_OFF(oi->gr.hello_delay.t_grace_send);
+		event_cancel(&oi->t_hello);
+		event_cancel(&oi->t_wait);
+		event_cancel(&oi->t_ls_ack_delayed);
+		event_cancel(&oi->gr.hello_delay.t_grace_send);
 		break;
 	case ISM_Waiting:
 		/* The router is trying to determine the identity of DRouter and
@@ -304,7 +304,7 @@ static void ism_timer_set(struct ospf_interface *oi)
 		OSPF_ISM_TIMER_MSEC_ON(oi->t_hello, ospf_hello_timer, 1);
 		OSPF_ISM_TIMER_ON(oi->t_wait, ospf_wait_timer,
 				  OSPF_IF_PARAM(oi, v_wait));
-		EVENT_OFF(oi->t_ls_ack_delayed);
+		event_cancel(&oi->t_ls_ack_delayed);
 		break;
 	case ISM_PointToPoint:
 		/* The interface connects to a physical Point-to-point network
@@ -313,7 +313,7 @@ static void ism_timer_set(struct ospf_interface *oi)
 		   neighboring router. Hello packets are also sent. */
 		/* send first hello immediately */
 		OSPF_ISM_TIMER_MSEC_ON(oi->t_hello, ospf_hello_timer, 1);
-		EVENT_OFF(oi->t_wait);
+		event_cancel(&oi->t_wait);
 		break;
 	case ISM_DROther:
 		/* The network type of the interface is broadcast or NBMA
@@ -321,21 +321,21 @@ static void ism_timer_set(struct ospf_interface *oi)
 		   and the router itself is neither Designated Router nor
 		   Backup Designated Router. */
 		OSPF_HELLO_TIMER_ON(oi);
-		EVENT_OFF(oi->t_wait);
+		event_cancel(&oi->t_wait);
 		break;
 	case ISM_Backup:
 		/* The network type of the interface is broadcast os NBMA
 		   network,
 		   and the router is Backup Designated Router. */
 		OSPF_HELLO_TIMER_ON(oi);
-		EVENT_OFF(oi->t_wait);
+		event_cancel(&oi->t_wait);
 		break;
 	case ISM_DR:
 		/* The network type of the interface is broadcast or NBMA
 		   network,
 		   and the router is Designated Router. */
 		OSPF_HELLO_TIMER_ON(oi);
-		EVENT_OFF(oi->t_wait);
+		event_cancel(&oi->t_wait);
 		break;
 	}
 }

--- a/ospfd/ospf_ldp_sync.c
+++ b/ospfd/ospf_ldp_sync.c
@@ -188,7 +188,7 @@ void ospf_ldp_sync_if_complete(struct interface *ifp)
 	if (ldp_sync_info && ldp_sync_info->enabled == LDP_IGP_SYNC_ENABLED) {
 		if (ldp_sync_info->state == LDP_IGP_SYNC_STATE_REQUIRED_NOT_UP)
 			ldp_sync_info->state = LDP_IGP_SYNC_STATE_REQUIRED_UP;
-		EVENT_OFF(ldp_sync_info->t_holddown);
+		event_cancel(&ldp_sync_info->t_holddown);
 		ospf_if_recalculate_output_cost(ifp);
 	}
 }
@@ -239,7 +239,7 @@ void ospf_ldp_sync_ldp_fail(struct interface *ifp)
 	if (ldp_sync_info &&
 	    ldp_sync_info->enabled == LDP_IGP_SYNC_ENABLED &&
 	    ldp_sync_info->state != LDP_IGP_SYNC_STATE_NOT_REQUIRED) {
-		EVENT_OFF(ldp_sync_info->t_holddown);
+		event_cancel(&ldp_sync_info->t_holddown);
 		ldp_sync_info->state = LDP_IGP_SYNC_STATE_REQUIRED_NOT_UP;
 		ospf_if_recalculate_output_cost(ifp);
 	}
@@ -303,7 +303,7 @@ void ospf_ldp_sync_if_remove(struct interface *ifp, bool remove)
 	 */
 	ols_debug("%s: Removed from if %s", __func__, ifp->name);
 
-	EVENT_OFF(ldp_sync_info->t_holddown);
+	event_cancel(&ldp_sync_info->t_holddown);
 
 	ldp_sync_info->state = LDP_IGP_SYNC_STATE_NOT_REQUIRED;
 	ospf_if_recalculate_output_cost(ifp);
@@ -902,7 +902,7 @@ DEFPY (no_mpls_ldp_sync,
 	UNSET_FLAG(ldp_sync_info->flags, LDP_SYNC_FLAG_IF_CONFIG);
 	ldp_sync_info->enabled = LDP_IGP_SYNC_DEFAULT;
 	ldp_sync_info->state = LDP_IGP_SYNC_STATE_NOT_REQUIRED;
-	EVENT_OFF(ldp_sync_info->t_holddown);
+	event_cancel(&ldp_sync_info->t_holddown);
 	ospf_if_recalculate_output_cost(ifp);
 
 	return CMD_SUCCESS;

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -3791,7 +3791,7 @@ void ospf_flush_self_originated_lsas_now(struct ospf *ospf)
 	 * without conflicting to other threads.
 	 */
 	if (ospf->t_maxage != NULL) {
-		EVENT_OFF(ospf->t_maxage);
+		event_cancel(&ospf->t_maxage);
 		event_execute(master, ospf_maxage_lsa_remover, ospf, 0, NULL);
 	}
 

--- a/ospfd/ospf_main.c
+++ b/ospfd/ospf_main.c
@@ -182,7 +182,7 @@ static void ospf_config_finish(struct event *t)
 
 static void ospf_config_start(void)
 {
-	EVENT_OFF(t_ospf_cfg);
+	event_cancel(&t_ospf_cfg);
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("ospfd config start callback received.");
 	event_add_timer(master, ospf_config_finish, NULL,
@@ -194,7 +194,7 @@ static void ospf_config_end(void)
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("ospfd config end callback received.");
 
-	EVENT_OFF(t_ospf_cfg);
+	event_cancel(&t_ospf_cfg);
 }
 
 /* OSPFd main routine. */

--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -127,17 +127,17 @@ void ospf_nbr_free(struct ospf_neighbor *nbr)
 	}
 
 	/* Cancel all timers. */
-	EVENT_OFF(nbr->t_inactivity);
-	EVENT_OFF(nbr->t_db_desc);
-	EVENT_OFF(nbr->t_ls_req);
-	EVENT_OFF(nbr->t_ls_rxmt);
+	event_cancel(&nbr->t_inactivity);
+	event_cancel(&nbr->t_db_desc);
+	event_cancel(&nbr->t_ls_req);
+	event_cancel(&nbr->t_ls_rxmt);
 
 	/* Cancel all events. */ /* Thread lookup cost would be negligible. */
 	event_cancel_event(master, nbr);
 
 	bfd_sess_free(&nbr->bfd_session);
 
-	EVENT_OFF(nbr->gr_helper_info.t_grace_timer);
+	event_cancel(&nbr->gr_helper_info.t_grace_timer);
 
 	nbr->oi = NULL;
 	XFREE(MTYPE_OSPF_NEIGHBOR, nbr);
@@ -443,7 +443,7 @@ static struct ospf_neighbor *ospf_nbr_add(struct ospf_interface *oi,
 				nbr->nbr_nbma = nbr_nbma;
 
 				if (nbr_nbma->t_poll)
-					EVENT_OFF(nbr_nbma->t_poll);
+					event_cancel(&nbr_nbma->t_poll);
 
 				nbr->state_change = nbr_nbma->state_change + 1;
 			}

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -105,30 +105,30 @@ static void nsm_timer_set(struct ospf_neighbor *nbr)
 	switch (nbr->state) {
 	case NSM_Deleted:
 	case NSM_Down:
-		EVENT_OFF(nbr->t_inactivity);
-		EVENT_OFF(nbr->t_hello_reply);
+		event_cancel(&nbr->t_inactivity);
+		event_cancel(&nbr->t_hello_reply);
 		fallthrough;
 	case NSM_Attempt:
 	case NSM_Init:
 	case NSM_TwoWay:
-		EVENT_OFF(nbr->t_db_desc);
-		EVENT_OFF(nbr->t_ls_rxmt);
-		EVENT_OFF(nbr->t_ls_req);
+		event_cancel(&nbr->t_db_desc);
+		event_cancel(&nbr->t_ls_rxmt);
+		event_cancel(&nbr->t_ls_req);
 		break;
 	case NSM_ExStart:
 		OSPF_NSM_TIMER_ON(nbr->t_db_desc, ospf_db_desc_timer,
 				  nbr->v_db_desc);
-		EVENT_OFF(nbr->t_ls_rxmt);
-		EVENT_OFF(nbr->t_ls_req);
+		event_cancel(&nbr->t_ls_rxmt);
+		event_cancel(&nbr->t_ls_req);
 		break;
 	case NSM_Exchange:
 		if (!IS_SET_DD_MS(nbr->dd_flags))
-			EVENT_OFF(nbr->t_db_desc);
+			event_cancel(&nbr->t_db_desc);
 		break;
 	case NSM_Loading:
 	case NSM_Full:
 	default:
-		EVENT_OFF(nbr->t_db_desc);
+		event_cancel(&nbr->t_db_desc);
 		break;
 	}
 }
@@ -159,13 +159,13 @@ int nsm_should_adj(struct ospf_neighbor *nbr)
 static int nsm_hello_received(struct ospf_neighbor *nbr)
 {
 	/* Start or Restart Inactivity Timer. */
-	EVENT_OFF(nbr->t_inactivity);
+	event_cancel(&nbr->t_inactivity);
 
 	OSPF_NSM_TIMER_ON(nbr->t_inactivity, ospf_inactivity_timer,
 			  nbr->v_inactivity);
 
 	if (OSPF_IF_NON_BROADCAST(nbr->oi) && nbr->nbr_nbma != NULL)
-		EVENT_OFF(nbr->nbr_nbma->t_poll);
+		event_cancel(&nbr->nbr_nbma->t_poll);
 
 	/* Send proactive ARP requests */
 	if (nbr->state < NSM_Exchange)
@@ -177,9 +177,9 @@ static int nsm_hello_received(struct ospf_neighbor *nbr)
 static int nsm_start(struct ospf_neighbor *nbr)
 {
 	if (nbr->nbr_nbma)
-		EVENT_OFF(nbr->nbr_nbma->t_poll);
+		event_cancel(&nbr->nbr_nbma->t_poll);
 
-	EVENT_OFF(nbr->t_inactivity);
+	event_cancel(&nbr->t_inactivity);
 
 	OSPF_NSM_TIMER_ON(nbr->t_inactivity, ospf_inactivity_timer,
 			  nbr->v_inactivity);

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -142,7 +142,7 @@ int ospf_opaque_type9_lsa_init(struct ospf_interface *oi)
 
 void ospf_opaque_type9_lsa_term(struct ospf_interface *oi)
 {
-	EVENT_OFF(oi->t_opaque_lsa_self);
+	event_cancel(&oi->t_opaque_lsa_self);
 	if (oi->opaque_lsa_self != NULL)
 		list_delete(&oi->opaque_lsa_self);
 	oi->opaque_lsa_self = NULL;
@@ -171,7 +171,7 @@ void ospf_opaque_type10_lsa_term(struct ospf_area *area)
 	hook_unregister(ospf_lsa_delete, ospf_opaque_lsa_delete_hook);
 	ospf_opaque_lsa_hooks_registered = false;
 
-	EVENT_OFF(area->t_opaque_lsa_self);
+	event_cancel(&area->t_opaque_lsa_self);
 	if (area->opaque_lsa_self != NULL)
 		list_delete(&area->opaque_lsa_self);
 	return;
@@ -191,7 +191,7 @@ int ospf_opaque_type11_lsa_init(struct ospf *top)
 
 void ospf_opaque_type11_lsa_term(struct ospf *top)
 {
-	EVENT_OFF(top->t_opaque_lsa_self);
+	event_cancel(&top->t_opaque_lsa_self);
 	if (top->opaque_lsa_self != NULL)
 		list_delete(&top->opaque_lsa_self);
 	return;
@@ -631,7 +631,7 @@ static void free_opaque_info_per_type(struct opaque_info_per_type *oipt,
 		ospf_opaque_lsa_flush_schedule(lsa);
 	}
 
-	EVENT_OFF(oipt->t_opaque_lsa_self);
+	event_cancel(&oipt->t_opaque_lsa_self);
 	list_delete(&oipt->id_list);
 	if (cleanup_owner) {
 		/* Remove from its owner's self-originated LSA list. */
@@ -747,7 +747,7 @@ static void free_opaque_info_per_id(void *val)
 {
 	struct opaque_info_per_id *oipi = (struct opaque_info_per_id *)val;
 
-	EVENT_OFF(oipi->t_opaque_lsa_self);
+	event_cancel(&oipi->t_opaque_lsa_self);
 	if (oipi->lsa != NULL)
 		ospf_lsa_unlock(&oipi->lsa);
 	XFREE(MTYPE_OPAQUE_INFO_PER_ID, oipi);

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -288,7 +288,7 @@ static void ospf_ls_req_timer(struct event *thread)
 
 void ospf_ls_req_event(struct ospf_neighbor *nbr)
 {
-	EVENT_OFF(nbr->t_ls_req);
+	event_cancel(&nbr->t_ls_req);
 	event_add_event(master, ospf_ls_req_timer, nbr, 0, &nbr->t_ls_req);
 }
 
@@ -3863,7 +3863,7 @@ void ospf_ls_upd_queue_send(struct ospf_interface *oi, struct list *update,
 		 * is actually turned off.
 		 */
 		if (list_isempty(oi->ospf->oi_write_q))
-			EVENT_OFF(oi->ospf->t_write);
+			event_cancel(&oi->ospf->t_write);
 	} else {
 		/* Hook thread to write packet. */
 		OSPF_ISM_WRITE_ON(oi->ospf);

--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -565,7 +565,7 @@ static void ospf_sr_stop(void)
 	osr_debug("SR (%s): Stop Segment Routing", __func__);
 
 	/* Disable any re-attempt to connect to Label Manager */
-	EVENT_OFF(OspfSR.t_start_lm);
+	event_cancel(&OspfSR.t_start_lm);
 
 	/* Release SRGB if active */
 	sr_global_block_delete();

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8838,7 +8838,7 @@ DEFPY (no_ip_ospf_gr_hdelay,
 			continue;
 
 		oi->gr.hello_delay.elapsed_seconds = 0;
-		EVENT_OFF(oi->gr.hello_delay.t_grace_send);
+		event_cancel(&oi->gr.hello_delay.t_grace_send);
 	}
 
 	return CMD_SUCCESS;
@@ -10032,7 +10032,7 @@ DEFUN (no_ospf_max_metric_router_lsa_startup,
 	for (ALL_LIST_ELEMENTS_RO(ospf->areas, ln, area)) {
 		SET_FLAG(area->stub_router_state,
 			 OSPF_AREA_WAS_START_STUB_ROUTED);
-		EVENT_OFF(area->t_stub_router);
+		event_cancel(&area->t_stub_router);
 
 		/* Don't trample on admin stub routed */
 		if (!CHECK_FLAG(area->stub_router_state,
@@ -13380,7 +13380,7 @@ DEFPY_HIDDEN(ospf_maxage_delay_timer, ospf_maxage_delay_timer_cmd,
 	else
 		ospf->maxage_delay = value;
 
-	EVENT_OFF(ospf->t_maxage);
+	event_cancel(&ospf->t_maxage);
 	OSPF_TIMER_ON(ospf->t_maxage, ospf_maxage_lsa_remover,
 		      ospf->maxage_delay);
 

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -535,7 +535,7 @@ static void assert_timer_off(struct pim_ifchannel *ch)
 				__func__, ch->sg_str, ch->interface->name);
 		}
 	}
-	EVENT_OFF(ch->t_ifassert_timer);
+	event_cancel(&ch->t_ifassert_timer);
 }
 
 static void pim_assert_timer_set(struct pim_ifchannel *ch, int interval)

--- a/pimd/pim_bsr_rpdb.c
+++ b/pimd/pim_bsr_rpdb.c
@@ -428,7 +428,7 @@ void pim_crp_nht_update(struct pim_instance *pim, struct pim_nexthop_cache *pnc)
 
 static void pim_crp_free(struct pim_instance *pim, struct bsr_crp_rp *rp)
 {
-	EVENT_OFF(rp->t_hold);
+	event_cancel(&rp->t_hold);
 	pim_nht_candrp_del(pim, rp->addr);
 	bsr_crp_rp_groups_fini(rp->groups);
 
@@ -553,7 +553,7 @@ int pim_crp_process(struct interface *ifp, pim_sgaddr *src_dst, uint8_t *buf,
 	rp->seen_last = monotime(NULL);
 	rp->holdtime = ntohs(crp_hdr->rp_holdtime);
 
-	EVENT_OFF(rp->t_hold);
+	event_cancel(&rp->t_hold);
 	event_add_timer(router->master, pim_crp_expire, rp,
 			ntohs(crp_hdr->rp_holdtime), &rp->t_hold);
 

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -379,7 +379,7 @@ void pim_igmp_other_querier_timer_on(struct gm_sock *igmp)
 				"Querier %s resetting TIMER event for Other-Querier-Present",
 				ifaddr_str);
 		}
-		EVENT_OFF(igmp->t_other_querier_timer);
+		event_cancel(&igmp->t_other_querier_timer);
 	} else {
 		/*
 		  We are the current querier, then stop sending general queries:
@@ -441,7 +441,7 @@ void pim_igmp_other_querier_timer_off(struct gm_sock *igmp)
 				ifaddr_str, igmp->fd, igmp->interface->name);
 		}
 	}
-	EVENT_OFF(igmp->t_other_querier_timer);
+	event_cancel(&igmp->t_other_querier_timer);
 }
 
 int igmp_validate_checksum(char *igmp_msg, int igmp_msg_len)
@@ -885,7 +885,7 @@ void pim_igmp_general_query_off(struct gm_sock *igmp)
 				ifaddr_str, igmp->fd, igmp->interface->name);
 		}
 	}
-	EVENT_OFF(igmp->t_igmp_query_timer);
+	event_cancel(&igmp->t_igmp_query_timer);
 }
 
 /* Issue IGMP general query */
@@ -955,7 +955,7 @@ static void sock_close(struct gm_sock *igmp)
 				igmp->interface->name);
 		}
 	}
-	EVENT_OFF(igmp->t_igmp_read);
+	event_cancel(&igmp->t_igmp_read);
 
 	if (close(igmp->fd)) {
 		flog_err(
@@ -1047,7 +1047,7 @@ void igmp_group_delete(struct gm_group *group)
 		igmp_source_delete(src);
 	}
 
-	EVENT_OFF(group->t_group_query_retransmit_timer);
+	event_cancel(&group->t_group_query_retransmit_timer);
 
 	group_timer_off(group);
 	igmp_group_count_decr(pim_ifp);
@@ -1350,7 +1350,7 @@ static void group_timer_off(struct gm_group *group)
 		zlog_debug("Cancelling TIMER event for group %s on %s",
 			   group_str, group->interface->name);
 	}
-	EVENT_OFF(group->t_group_timer);
+	event_cancel(&group->t_group_timer);
 }
 
 void igmp_group_timer_on(struct gm_group *group, long interval_msec,

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -189,7 +189,7 @@ static void source_timer_off(struct gm_group *group, struct gm_source *source)
 			group_str, source_str, group->interface->name);
 	}
 
-	EVENT_OFF(source->t_source_timer);
+	event_cancel(&source->t_source_timer);
 }
 
 static void igmp_source_timer_on(struct gm_group *group,

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -331,9 +331,9 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 				if (PIM_IF_FLAG_TEST_S_G_RPT(child->flags)) {
 					if (child->ifjoin_state
 					    == PIM_IFJOIN_PRUNE_PENDING_TMP)
-						EVENT_OFF(
+						event_cancel(&
 							child->t_ifjoin_prune_pending_timer);
-					EVENT_OFF(child->t_ifjoin_expiry_timer);
+					event_cancel(&child->t_ifjoin_expiry_timer);
 					PIM_IF_FLAG_UNSET_S_G_RPT(child->flags);
 					child->ifjoin_state = PIM_IFJOIN_NOINFO;
 					delete_on_noinfo(child);

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -834,7 +834,7 @@ static void mroute_read_on(struct pim_instance *pim)
 
 static void mroute_read_off(struct pim_instance *pim)
 {
-	EVENT_OFF(pim->thread);
+	event_cancel(&pim->thread);
 }
 
 int pim_mroute_socket_enable(struct pim_instance *pim)

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -80,7 +80,7 @@ static void pim_msdp_sa_adv_timer_cb(struct event *t)
 
 static void pim_msdp_sa_adv_timer_setup(struct pim_instance *pim, bool start)
 {
-	EVENT_OFF(pim->msdp.sa_adv_timer);
+	event_cancel(&pim->msdp.sa_adv_timer);
 	if (start) {
 		event_add_timer(pim->msdp.master, pim_msdp_sa_adv_timer_cb, pim,
 				PIM_MSDP_SA_ADVERTISMENT_TIME,
@@ -103,7 +103,7 @@ static void pim_msdp_sa_state_timer_cb(struct event *t)
 
 static void pim_msdp_sa_state_timer_setup(struct pim_msdp_sa *sa, bool start)
 {
-	EVENT_OFF(sa->sa_state_timer);
+	event_cancel(&sa->sa_state_timer);
 	if (start) {
 		event_add_timer(sa->pim->msdp.master,
 				pim_msdp_sa_state_timer_cb, sa,
@@ -897,7 +897,7 @@ static void pim_msdp_peer_hold_timer_cb(struct event *t)
 static void pim_msdp_peer_hold_timer_setup(struct pim_msdp_peer *mp, bool start)
 {
 	struct pim_instance *pim = mp->pim;
-	EVENT_OFF(mp->hold_timer);
+	event_cancel(&mp->hold_timer);
 	if (start) {
 		event_add_timer(pim->msdp.master, pim_msdp_peer_hold_timer_cb,
 				mp, pim->msdp.hold_time, &mp->hold_timer);
@@ -921,7 +921,7 @@ static void pim_msdp_peer_ka_timer_cb(struct event *t)
 
 static void pim_msdp_peer_ka_timer_setup(struct pim_msdp_peer *mp, bool start)
 {
-	EVENT_OFF(mp->ka_timer);
+	event_cancel(&mp->ka_timer);
 	if (start) {
 		event_add_timer(mp->pim->msdp.master, pim_msdp_peer_ka_timer_cb,
 				mp, mp->pim->msdp.keep_alive, &mp->ka_timer);
@@ -983,7 +983,7 @@ static void pim_msdp_peer_cr_timer_cb(struct event *t)
 
 static void pim_msdp_peer_cr_timer_setup(struct pim_msdp_peer *mp, bool start)
 {
-	EVENT_OFF(mp->cr_timer);
+	event_cancel(&mp->cr_timer);
 	if (start) {
 		event_add_timer(mp->pim->msdp.master, pim_msdp_peer_cr_timer_cb,
 				mp, mp->pim->msdp.connection_retry,
@@ -1500,7 +1500,7 @@ static void pim_upstream_msdp_reg_timer(struct event *t)
 
 void pim_upstream_msdp_reg_timer_start(struct pim_upstream *up)
 {
-	EVENT_OFF(up->t_msdp_reg_timer);
+	event_cancel(&up->t_msdp_reg_timer);
 	event_add_timer(router->master, pim_upstream_msdp_reg_timer, up, PIM_MSDP_REG_RXED_PERIOD,
 			&up->t_msdp_reg_timer);
 

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -222,7 +222,7 @@ void pim_neighbor_timer_reset(struct pim_neighbor *neigh, uint16_t holdtime)
 {
 	neigh->holdtime = holdtime;
 
-	EVENT_OFF(neigh->t_expire_timer);
+	event_cancel(&neigh->t_expire_timer);
 
 	/*
 	  0xFFFF is request for no holdtime
@@ -261,7 +261,7 @@ static void on_neighbor_jp_timer(struct event *t)
 
 static void pim_neighbor_start_jp_timer(struct pim_neighbor *neigh)
 {
-	EVENT_OFF(neigh->jp_timer);
+	event_cancel(&neigh->jp_timer);
 	event_add_timer(router->master, on_neighbor_jp_timer, neigh,
 			router->t_periodic, &neigh->jp_timer);
 }
@@ -377,7 +377,7 @@ void pim_neighbor_free(struct pim_neighbor *neigh)
 	delete_prefix_list(neigh);
 
 	list_delete(&neigh->upstream_jp_agg);
-	EVENT_OFF(neigh->jp_timer);
+	event_cancel(&neigh->jp_timer);
 
 	bfd_sess_free(&neigh->bfd_session);
 
@@ -581,7 +581,7 @@ void pim_neighbor_delete(struct interface *ifp, struct pim_neighbor *neigh,
 	zlog_notice("PIM NEIGHBOR DOWN: neighbor %pPA on interface %s: %s",
 		    &neigh->source_addr, ifp->name, delete_message);
 
-	EVENT_OFF(neigh->t_expire_timer);
+	event_cancel(&neigh->t_expire_timer);
 
 	pim_if_assert_on_neighbor_down(ifp, neigh->source_addr);
 

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -167,7 +167,7 @@ void pim_clear_nocache_state(struct pim_interface *pim_ifp)
 		if (*oil_incoming_vif(c_oil) != pim_ifp->mroute_vif_index)
 			continue;
 
-		EVENT_OFF(c_oil->up->t_ka_timer);
+		event_cancel(&c_oil->up->t_ka_timer);
 		PIM_UPSTREAM_FLAG_UNSET_SRC_NOCACHE(c_oil->up->flags);
 		PIM_UPSTREAM_FLAG_UNSET_SRC_STREAM(c_oil->up->flags);
 		pim_upstream_del(pim_ifp->pim, c_oil->up, __func__);

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -69,7 +69,7 @@ static void sock_close(struct interface *ifp)
 				pim_ifp->pim_sock_fd, ifp->name);
 		}
 	}
-	EVENT_OFF(pim_ifp->t_pim_sock_read);
+	event_cancel(&pim_ifp->t_pim_sock_read);
 
 	if (PIM_DEBUG_PIM_TRACE) {
 		if (pim_ifp->t_pim_hello_timer) {
@@ -78,7 +78,7 @@ static void sock_close(struct interface *ifp)
 				ifp->name);
 		}
 	}
-	EVENT_OFF(pim_ifp->t_pim_hello_timer);
+	event_cancel(&pim_ifp->t_pim_hello_timer);
 
 	if (PIM_DEBUG_PIM_TRACE) {
 		zlog_debug("Deleting PIM socket fd=%d on interface %s",
@@ -881,7 +881,7 @@ static void hello_resched(struct interface *ifp)
 		zlog_debug("Rescheduling %d sec hello on interface %s",
 			   pim_ifp->pim_hello_period, ifp->name);
 	}
-	EVENT_OFF(pim_ifp->t_pim_hello_timer);
+	event_cancel(&pim_ifp->t_pim_hello_timer);
 	event_add_timer(router->master, on_pim_hello_send, ifp,
 			pim_ifp->pim_hello_period, &pim_ifp->t_pim_hello_timer);
 }
@@ -983,7 +983,7 @@ void pim_hello_restart_triggered(struct interface *ifp)
 			return;
 		}
 
-		EVENT_OFF(pim_ifp->t_pim_hello_timer);
+		event_cancel(&pim_ifp->t_pim_hello_timer);
 	}
 
 	random_msec = triggered_hello_delay_msec;

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -756,7 +756,7 @@ void pim_reg_del_on_couldreg_fail(struct interface *ifp)
 		    && (up->reg_state != PIM_REG_NOINFO)) {
 			pim_channel_del_oif(up->channel_oil, pim->regiface,
 					    PIM_OIF_FLAG_PROTO_PIM, __func__);
-			EVENT_OFF(up->t_rs_timer);
+			event_cancel(&up->t_rs_timer);
 			up->reg_state = PIM_REG_NOINFO;
 			PIM_UPSTREAM_FLAG_UNSET_FHR(up->flags);
 		}

--- a/pimd/pim_ssmpingd.c
+++ b/pimd/pim_ssmpingd.c
@@ -205,7 +205,7 @@ static void ssmpingd_delete(struct ssmpingd_sock *ss)
 {
 	assert(ss);
 
-	EVENT_OFF(ss->t_sock_read);
+	event_cancel(&ss->t_sock_read);
 
 	if (close(ss->sock_fd)) {
 		zlog_warn(

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -167,10 +167,10 @@ static void upstream_channel_oil_detach(struct pim_upstream *up)
 
 static void pim_upstream_timers_stop(struct pim_upstream *up)
 {
-	EVENT_OFF(up->t_ka_timer);
-	EVENT_OFF(up->t_rs_timer);
-	EVENT_OFF(up->t_msdp_reg_timer);
-	EVENT_OFF(up->t_join_timer);
+	event_cancel(&up->t_ka_timer);
+	event_cancel(&up->t_rs_timer);
+	event_cancel(&up->t_msdp_reg_timer);
+	event_cancel(&up->t_join_timer);
 }
 
 struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
@@ -332,7 +332,7 @@ static void join_timer_stop(struct pim_upstream *up)
 {
 	struct pim_neighbor *nbr = NULL;
 
-	EVENT_OFF(up->t_join_timer);
+	event_cancel(&up->t_join_timer);
 
 	if (up->rpf.source_nexthop.interface)
 		nbr = pim_neighbor_find(up->rpf.source_nexthop.interface,
@@ -362,7 +362,7 @@ void join_timer_start(struct pim_upstream *up)
 	if (nbr)
 		pim_jp_agg_add_group(nbr->upstream_jp_agg, up, 1, nbr);
 	else {
-		EVENT_OFF(up->t_join_timer);
+		event_cancel(&up->t_join_timer);
 		event_add_timer(router->master, on_join_timer, up,
 				router->t_periodic, &up->t_join_timer);
 	}
@@ -379,7 +379,7 @@ void join_timer_start(struct pim_upstream *up)
 void pim_upstream_join_timer_restart(struct pim_upstream *up,
 				     struct pim_rpf *old)
 {
-	// EVENT_OFF(up->t_join_timer);
+	// event_cancel(&up->t_join_timer);
 	join_timer_start(up);
 }
 
@@ -391,7 +391,7 @@ static void pim_upstream_join_timer_restart_msec(struct pim_upstream *up,
 			   __func__, interval_msec, up->sg_str);
 	}
 
-	EVENT_OFF(up->t_join_timer);
+	event_cancel(&up->t_join_timer);
 	event_add_timer_msec(router->master, on_join_timer, up, interval_msec,
 			     &up->t_join_timer);
 }
@@ -1386,7 +1386,7 @@ static void pim_upstream_fhr_kat_expiry(struct pim_instance *pim,
 			   up->sg_str);
 
 	/* stop reg-stop timer */
-	EVENT_OFF(up->t_rs_timer);
+	event_cancel(&up->t_rs_timer);
 	/* remove regiface from the OIL if it is there*/
 	pim_channel_del_oif(up->channel_oil, pim->regiface,
 			    PIM_OIF_FLAG_PROTO_PIM, __func__);
@@ -1509,7 +1509,7 @@ void pim_upstream_keep_alive_timer_start(struct pim_upstream *up, uint32_t time)
 			zlog_debug("kat start on %s with no stream reference",
 				   up->sg_str);
 	}
-	EVENT_OFF(up->t_ka_timer);
+	event_cancel(&up->t_ka_timer);
 	event_add_timer(router->master, pim_upstream_keep_alive_timer, up, time,
 			&up->t_ka_timer);
 
@@ -1760,7 +1760,7 @@ static void pim_upstream_start_register_stop_timer(struct pim_upstream *up)
 {
 	uint32_t time;
 
-	EVENT_OFF(up->t_rs_timer);
+	event_cancel(&up->t_rs_timer);
 
 	time = router->register_probe_time;
 
@@ -1790,7 +1790,7 @@ void pim_upstream_start_register_probe_timer(struct pim_upstream *up)
 {
 	uint32_t time;
 
-	EVENT_OFF(up->t_rs_timer);
+	event_cancel(&up->t_rs_timer);
 
 	uint32_t lower = (0.5 * router->register_suppress_time);
 	uint32_t upper = (1.5 * router->register_suppress_time);

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -239,7 +239,7 @@ void pim_vxlan_update_sg_reg_state(struct pim_instance *pim,
 			zlog_debug("Received Register stop for %s",
 				   vxlan_sg->sg_str);
 
-		EVENT_OFF(vxlan_sg->null_register);
+		event_cancel(&vxlan_sg->null_register);
 		pim_vxlan_del_work(vxlan_sg);
 	}
 }
@@ -253,7 +253,7 @@ static void pim_vxlan_work_timer_cb(struct event *t)
 /* global 1second timer used for periodic processing */
 static void pim_vxlan_work_timer_setup(bool start)
 {
-	EVENT_OFF(vxlan_info.work_timer);
+	event_cancel(&vxlan_info.work_timer);
 	if (start)
 		event_add_timer(router->master, pim_vxlan_work_timer_cb, NULL,
 				PIM_VXLAN_WORK_TIME, &vxlan_info.work_timer);
@@ -300,7 +300,7 @@ static void pim_vxlan_orig_mr_up_del(struct pim_vxlan_sg *vxlan_sg)
 		 * if there are no other references.
 		 */
 		if (PIM_UPSTREAM_FLAG_TEST_SRC_STREAM(up->flags)) {
-			EVENT_OFF(up->t_ka_timer);
+			event_cancel(&up->t_ka_timer);
 			up = pim_upstream_keep_alive_timer_proc(up);
 		} else {
 			/* this is really unexpected as we force vxlan
@@ -842,7 +842,7 @@ static void pim_vxlan_sg_del_item(struct pim_vxlan_sg *vxlan_sg)
 {
 	vxlan_sg->flags |= PIM_VXLAN_SGF_DEL_IN_PROG;
 
-	EVENT_OFF(vxlan_sg->null_register);
+	event_cancel(&vxlan_sg->null_register);
 	pim_vxlan_del_work(vxlan_sg);
 
 	if (pim_vxlan_is_orig_mroute(vxlan_sg))

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -114,7 +114,7 @@ static void zclient_lookup_failed(struct zclient *zlookup)
 
 void zclient_lookup_free(void)
 {
-	EVENT_OFF(zlookup_read);
+	event_cancel(&zlookup_read);
 	zclient_stop(pim_zlookup);
 	zclient_free(pim_zlookup);
 	pim_zlookup = NULL;

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -383,7 +383,7 @@ static void rip_interface_clean(struct rip_interface *ri)
 	ri->enable_interface = 0;
 	ri->running = 0;
 
-	EVENT_OFF(ri->t_wakeup);
+	event_cancel(&ri->t_wakeup);
 }
 
 void rip_interfaces_clean(struct rip *rip)
@@ -443,7 +443,7 @@ int rip_if_down(struct interface *ifp)
 
 	ri = ifp->info;
 
-	EVENT_OFF(ri->t_wakeup);
+	event_cancel(&ri->t_wakeup);
 
 	rip = ri->rip;
 	if (rip) {

--- a/ripd/rip_nb_rpcs.c
+++ b/ripd/rip_nb_rpcs.c
@@ -51,8 +51,8 @@ static void clear_rip_route(struct rip *rip)
 		}
 
 		if (rinfo) {
-			EVENT_OFF(rinfo->t_timeout);
-			EVENT_OFF(rinfo->t_garbage_collect);
+			event_cancel(&rinfo->t_timeout);
+			event_cancel(&rinfo->t_garbage_collect);
 			listnode_delete(list, rinfo);
 			rip_info_free(rinfo);
 		}

--- a/ripd/rip_peer.c
+++ b/ripd/rip_peer.c
@@ -27,7 +27,7 @@ static struct rip_peer *rip_peer_new(void)
 void rip_peer_free(struct rip_peer *peer)
 {
 	bfd_sess_free(&peer->bfd_session);
-	EVENT_OFF(peer->t_timeout);
+	event_cancel(&peer->t_timeout);
 	XFREE(MTYPE_RIP_PEER, peer);
 }
 
@@ -74,7 +74,7 @@ static struct rip_peer *rip_peer_get(struct rip *rip, struct rip_interface *ri,
 	peer = rip_peer_lookup(rip, addr);
 
 	if (peer) {
-		EVENT_OFF(peer->t_timeout);
+		event_cancel(&peer->t_timeout);
 	} else {
 		peer = rip_peer_new();
 		peer->rip = rip;
@@ -189,8 +189,8 @@ void rip_peer_delete_routes(const struct rip_peer *peer)
 				continue;
 
 			if (listcount(list) == 1) {
-				EVENT_OFF(route_entry->t_timeout);
-				EVENT_OFF(route_entry->t_garbage_collect);
+				event_cancel(&route_entry->t_timeout);
+				event_cancel(&route_entry->t_garbage_collect);
 				listnode_delete(list, route_entry);
 				if (list_isempty(list)) {
 					list_delete((struct list **)&route_node

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -137,7 +137,7 @@ static void rip_garbage_collect(struct event *t)
 	rinfo = EVENT_ARG(t);
 
 	/* Off timeout timer. */
-	EVENT_OFF(rinfo->t_timeout);
+	event_cancel(&rinfo->t_timeout);
 
 	/* Get route_node pointer. */
 	rp = rinfo->rp;
@@ -249,14 +249,14 @@ struct rip_info *rip_ecmp_replace(struct rip *rip, struct rip_info *rinfo_new)
 		if (tmp_rinfo == rinfo)
 			continue;
 
-		EVENT_OFF(tmp_rinfo->t_timeout);
-		EVENT_OFF(tmp_rinfo->t_garbage_collect);
+		event_cancel(&tmp_rinfo->t_timeout);
+		event_cancel(&tmp_rinfo->t_garbage_collect);
 		list_delete_node(list, node);
 		rip_info_free(tmp_rinfo);
 	}
 
-	EVENT_OFF(rinfo->t_timeout);
-	EVENT_OFF(rinfo->t_garbage_collect);
+	event_cancel(&rinfo->t_timeout);
+	event_cancel(&rinfo->t_garbage_collect);
 	memcpy(rinfo, rinfo_new, sizeof(struct rip_info));
 
 	if (rip_route_rte(rinfo)) {
@@ -291,12 +291,12 @@ struct rip_info *rip_ecmp_delete(struct rip *rip, struct rip_info *rinfo)
 	rp = rinfo->rp;
 	list = (struct list *)rp->info;
 
-	EVENT_OFF(rinfo->t_timeout);
+	event_cancel(&rinfo->t_timeout);
 
 	if (listcount(list) > 1) {
 		/* Some other ECMP entries still exist. Just delete this entry.
 		 */
-		EVENT_OFF(rinfo->t_garbage_collect);
+		event_cancel(&rinfo->t_garbage_collect);
 		listnode_delete(list, rinfo);
 		if (rip_route_rte(rinfo)
 		    && CHECK_FLAG(rinfo->flags, RIP_RTF_FIB))
@@ -342,7 +342,7 @@ static void rip_timeout(struct event *t)
 static void rip_timeout_update(struct rip *rip, struct rip_info *rinfo)
 {
 	if (rinfo->metric != RIP_METRIC_INFINITY) {
-		EVENT_OFF(rinfo->t_timeout);
+		event_cancel(&rinfo->t_timeout);
 		event_add_timer(master, rip_timeout, rinfo, rip->timeout_time,
 				&rinfo->t_timeout);
 	}
@@ -687,8 +687,8 @@ static void rip_rte_process(struct rte *rte, struct sockaddr_in *from,
 					assert(newinfo.metric
 					       != RIP_METRIC_INFINITY);
 
-					EVENT_OFF(rinfo->t_timeout);
-					EVENT_OFF(rinfo->t_garbage_collect);
+					event_cancel(&rinfo->t_timeout);
+					event_cancel(&rinfo->t_garbage_collect);
 					memcpy(rinfo, &newinfo,
 					       sizeof(struct rip_info));
 					rip_timeout_update(rip, rinfo);
@@ -1651,7 +1651,7 @@ void rip_redistribute_delete(struct rip *rip, int type, int sub_type,
 				RIP_TIMER_ON(rinfo->t_garbage_collect,
 					     rip_garbage_collect,
 					     rip->garbage_time);
-				EVENT_OFF(rinfo->t_timeout);
+				event_cancel(&rinfo->t_timeout);
 				rinfo->flags |= RIP_RTF_CHANGED;
 
 				if (IS_RIP_DEBUG_EVENT)
@@ -2542,7 +2542,7 @@ static void rip_update(struct event *t)
 
 	/* Triggered updates may be suppressed if a regular update is due by
 	   the time the triggered update would be sent. */
-	EVENT_OFF(rip->t_triggered_interval);
+	event_cancel(&rip->t_triggered_interval);
 	rip->trigger = 0;
 
 	/* Register myself. */
@@ -2589,7 +2589,7 @@ static void rip_triggered_update(struct event *t)
 	int interval;
 
 	/* Cancel interval timer. */
-	EVENT_OFF(rip->t_triggered_interval);
+	event_cancel(&rip->t_triggered_interval);
 	rip->trigger = 0;
 
 	/* Logging triggered update. */
@@ -2639,7 +2639,7 @@ void rip_redistribute_withdraw(struct rip *rip, int type)
 		rinfo->metric = RIP_METRIC_INFINITY;
 		RIP_TIMER_ON(rinfo->t_garbage_collect, rip_garbage_collect,
 			     rip->garbage_time);
-		EVENT_OFF(rinfo->t_timeout);
+		event_cancel(&rinfo->t_timeout);
 		rinfo->flags |= RIP_RTF_CHANGED;
 
 		if (IS_RIP_DEBUG_EVENT) {
@@ -2850,7 +2850,7 @@ void rip_event(struct rip *rip, enum rip_event event, int sock)
 		event_add_read(master, rip_read, rip, sock, &rip->t_read);
 		break;
 	case RIP_UPDATE_EVENT:
-		EVENT_OFF(rip->t_update);
+		event_cancel(&rip->t_update);
 		jitter = rip_update_jitter(rip->update_time);
 		event_add_timer(master, rip_update, rip,
 				sock ? 2 : rip->update_time + jitter,
@@ -2975,8 +2975,8 @@ void rip_ecmp_disable(struct rip *rip)
 			if (tmp_rinfo == rinfo)
 				continue;
 
-			EVENT_OFF(tmp_rinfo->t_timeout);
-			EVENT_OFF(tmp_rinfo->t_garbage_collect);
+			event_cancel(&tmp_rinfo->t_timeout);
+			event_cancel(&tmp_rinfo->t_garbage_collect);
 			list_delete_node(list, node);
 			rip_info_free(tmp_rinfo);
 		}
@@ -3530,8 +3530,8 @@ static void rip_instance_disable(struct rip *rip)
 			rip_zebra_ipv4_delete(rip, rp);
 
 		for (ALL_LIST_ELEMENTS_RO(list, listnode, rinfo)) {
-			EVENT_OFF(rinfo->t_timeout);
-			EVENT_OFF(rinfo->t_garbage_collect);
+			event_cancel(&rinfo->t_timeout);
+			event_cancel(&rinfo->t_garbage_collect);
 			rip_info_free(rinfo);
 		}
 		list_delete(&list);
@@ -3543,12 +3543,12 @@ static void rip_instance_disable(struct rip *rip)
 	rip_redistribute_disable(rip);
 
 	/* Cancel RIP related timers. */
-	EVENT_OFF(rip->t_update);
-	EVENT_OFF(rip->t_triggered_update);
-	EVENT_OFF(rip->t_triggered_interval);
+	event_cancel(&rip->t_update);
+	event_cancel(&rip->t_triggered_update);
+	event_cancel(&rip->t_triggered_interval);
 
 	/* Cancel read thread. */
-	EVENT_OFF(rip->t_read);
+	event_cancel(&rip->t_read);
 
 	/* Close RIP socket. */
 	close(rip->sock);

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -146,7 +146,7 @@ static int ripng_if_down(struct interface *ifp)
 
 	ri = ifp->info;
 
-	EVENT_OFF(ri->t_wakeup);
+	event_cancel(&ri->t_wakeup);
 
 	ripng = ri->ripng;
 
@@ -267,7 +267,7 @@ void ripng_interface_clean(struct ripng *ripng)
 		ri->enable_interface = 0;
 		ri->running = 0;
 
-		EVENT_OFF(ri->t_wakeup);
+		event_cancel(&ri->t_wakeup);
 	}
 }
 

--- a/ripngd/ripng_nb_rpcs.c
+++ b/ripngd/ripng_nb_rpcs.c
@@ -53,8 +53,8 @@ static void clear_ripng_route(struct ripng *ripng)
 		}
 
 		if (rinfo) {
-			EVENT_OFF(rinfo->t_timeout);
-			EVENT_OFF(rinfo->t_garbage_collect);
+			event_cancel(&rinfo->t_timeout);
+			event_cancel(&rinfo->t_garbage_collect);
 			listnode_delete(list, rinfo);
 			ripng_info_free(rinfo);
 		}

--- a/ripngd/ripng_peer.c
+++ b/ripngd/ripng_peer.c
@@ -29,7 +29,7 @@ static struct ripng_peer *ripng_peer_new(void)
 
 static void ripng_peer_free(struct ripng_peer *peer)
 {
-	EVENT_OFF(peer->t_timeout);
+	event_cancel(&peer->t_timeout);
 	XFREE(MTYPE_RIPNG_PEER, peer);
 }
 
@@ -79,7 +79,7 @@ static struct ripng_peer *ripng_peer_get(struct ripng *ripng,
 	peer = ripng_peer_lookup(ripng, addr);
 
 	if (peer) {
-		EVENT_OFF(peer->t_timeout);
+		event_cancel(&peer->t_timeout);
 	} else {
 		peer = ripng_peer_new();
 		peer->ripng = ripng;

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -416,7 +416,7 @@ static void ripng_garbage_collect(struct event *t)
 	rinfo = EVENT_ARG(t);
 
 	/* Off timeout timer. */
-	EVENT_OFF(rinfo->t_timeout);
+	event_cancel(&rinfo->t_timeout);
 
 	/* Get route_node pointer. */
 	rp = rinfo->rp;
@@ -563,14 +563,14 @@ struct ripng_info *ripng_ecmp_replace(struct ripng *ripng,
 	/* Re-use the first entry, and delete the others. */
 	for (ALL_LIST_ELEMENTS(list, node, nextnode, tmp_rinfo))
 		if (tmp_rinfo != rinfo) {
-			EVENT_OFF(tmp_rinfo->t_timeout);
-			EVENT_OFF(tmp_rinfo->t_garbage_collect);
+			event_cancel(&tmp_rinfo->t_timeout);
+			event_cancel(&tmp_rinfo->t_garbage_collect);
 			list_delete_node(list, node);
 			ripng_info_free(tmp_rinfo);
 		}
 
-	EVENT_OFF(rinfo->t_timeout);
-	EVENT_OFF(rinfo->t_garbage_collect);
+	event_cancel(&rinfo->t_timeout);
+	event_cancel(&rinfo->t_garbage_collect);
 	memcpy(rinfo, rinfo_new, sizeof(struct ripng_info));
 
 	if (ripng_route_rte(rinfo)) {
@@ -602,7 +602,7 @@ struct ripng_info *ripng_ecmp_delete(struct ripng *ripng,
 	struct agg_node *rp = rinfo->rp;
 	struct list *list = (struct list *)rp->info;
 
-	EVENT_OFF(rinfo->t_timeout);
+	event_cancel(&rinfo->t_timeout);
 
 	if (rinfo->metric != RIPNG_METRIC_INFINITY)
 		ripng_aggregate_decrement(rp, rinfo);
@@ -610,7 +610,7 @@ struct ripng_info *ripng_ecmp_delete(struct ripng *ripng,
 	if (listcount(list) > 1) {
 		/* Some other ECMP entries still exist. Just delete this entry.
 		 */
-		EVENT_OFF(rinfo->t_garbage_collect);
+		event_cancel(&rinfo->t_garbage_collect);
 		listnode_delete(list, rinfo);
 		if (ripng_route_rte(rinfo) &&
 		    CHECK_FLAG(rinfo->flags, RIPNG_RTF_FIB))
@@ -656,7 +656,7 @@ static void ripng_timeout(struct event *t)
 static void ripng_timeout_update(struct ripng *ripng, struct ripng_info *rinfo)
 {
 	if (rinfo->metric != RIPNG_METRIC_INFINITY) {
-		EVENT_OFF(rinfo->t_timeout);
+		event_cancel(&rinfo->t_timeout);
 		event_add_timer(master, ripng_timeout, rinfo,
 				ripng->timeout_time, &rinfo->t_timeout);
 	}
@@ -1064,7 +1064,7 @@ void ripng_redistribute_delete(struct ripng *ripng, int type, int sub_type,
 				RIPNG_TIMER_ON(rinfo->t_garbage_collect,
 					       ripng_garbage_collect,
 					       ripng->garbage_time);
-				EVENT_OFF(rinfo->t_timeout);
+				event_cancel(&rinfo->t_timeout);
 
 				/* Aggregate count decrement. */
 				ripng_aggregate_decrement(rp, rinfo);
@@ -1103,7 +1103,7 @@ void ripng_redistribute_withdraw(struct ripng *ripng, int type)
 				RIPNG_TIMER_ON(rinfo->t_garbage_collect,
 					       ripng_garbage_collect,
 					       ripng->garbage_time);
-				EVENT_OFF(rinfo->t_timeout);
+				event_cancel(&rinfo->t_timeout);
 
 				/* Aggregate count decrement. */
 				ripng_aggregate_decrement(rp, rinfo);
@@ -1487,7 +1487,7 @@ static void ripng_update(struct event *t)
 
 	/* Triggered updates may be suppressed if a regular update is due by
 	   the time the triggered update would be sent. */
-	EVENT_OFF(ripng->t_triggered_interval);
+	event_cancel(&ripng->t_triggered_interval);
 	ripng->trigger = 0;
 
 	/* Reset flush event. */
@@ -1514,7 +1514,7 @@ void ripng_triggered_update(struct event *t)
 	int interval;
 
 	/* Cancel interval timer. */
-	EVENT_OFF(ripng->t_triggered_interval);
+	event_cancel(&ripng->t_triggered_interval);
 	ripng->trigger = 0;
 
 	/* Logging triggered update. */
@@ -1958,7 +1958,7 @@ void ripng_event(struct ripng *ripng, enum ripng_event event, int sock)
 		event_add_read(master, ripng_read, ripng, sock, &ripng->t_read);
 		break;
 	case RIPNG_UPDATE_EVENT:
-		EVENT_OFF(ripng->t_update);
+		event_cancel(&ripng->t_update);
 
 		/* Update timer jitter. */
 		jitter = ripng_update_jitter(ripng->update_time);
@@ -2254,8 +2254,8 @@ void ripng_ecmp_disable(struct ripng *ripng)
 			/* Drop all other entries, except the first one. */
 			for (ALL_LIST_ELEMENTS(list, node, nextnode, tmp_rinfo))
 				if (tmp_rinfo != rinfo) {
-					EVENT_OFF(tmp_rinfo->t_timeout);
-					EVENT_OFF(tmp_rinfo->t_garbage_collect);
+					event_cancel(&tmp_rinfo->t_timeout);
+					event_cancel(&tmp_rinfo->t_garbage_collect);
 					list_delete_node(list, node);
 					ripng_info_free(tmp_rinfo);
 				}
@@ -2532,8 +2532,8 @@ static void ripng_instance_disable(struct ripng *ripng)
 				ripng_zebra_ipv6_delete(ripng, rp);
 
 			for (ALL_LIST_ELEMENTS_RO(list, listnode, rinfo)) {
-				EVENT_OFF(rinfo->t_timeout);
-				EVENT_OFF(rinfo->t_garbage_collect);
+				event_cancel(&rinfo->t_timeout);
+				event_cancel(&rinfo->t_garbage_collect);
 				ripng_info_free(rinfo);
 			}
 			list_delete(&list);
@@ -2552,12 +2552,12 @@ static void ripng_instance_disable(struct ripng *ripng)
 	ripng_redistribute_disable(ripng);
 
 	/* Cancel the RIPng timers */
-	EVENT_OFF(ripng->t_update);
-	EVENT_OFF(ripng->t_triggered_update);
-	EVENT_OFF(ripng->t_triggered_interval);
+	event_cancel(&ripng->t_update);
+	event_cancel(&ripng->t_triggered_update);
+	event_cancel(&ripng->t_triggered_interval);
 
 	/* Cancel the read thread */
-	EVENT_OFF(ripng->t_read);
+	event_cancel(&ripng->t_read);
 
 	/* Close the RIPng socket */
 	if (ripng->sock >= 0) {

--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -899,7 +899,7 @@ static int vrrp_recv_advertisement(struct vrrp_router *r, struct ipaddr *src,
 
 		if (pkt->hdr.priority == 0) {
 			vrrp_send_advertisement(r);
-			EVENT_OFF(r->t_adver_timer);
+			event_cancel(&r->t_adver_timer);
 			event_add_timer_msec(master, vrrp_adver_timer_expire, r,
 					     r->vr->advertisement_interval *
 						     CS2MS,
@@ -912,13 +912,13 @@ static int vrrp_recv_advertisement(struct vrrp_router *r, struct ipaddr *src,
 				"Received advertisement from %s w/ priority %hhu; switching to Backup",
 				r->vr->vrid, family2str(r->family), sipstr,
 				pkt->hdr.priority);
-			EVENT_OFF(r->t_adver_timer);
+			event_cancel(&r->t_adver_timer);
 			if (r->vr->version == 3) {
 				r->master_adver_interval =
 					htons(pkt->hdr.v3.adver_int);
 			}
 			vrrp_recalculate_timers(r);
-			EVENT_OFF(r->t_master_down_timer);
+			event_cancel(&r->t_master_down_timer);
 			event_add_timer_msec(master,
 					     vrrp_master_down_timer_expire, r,
 					     r->master_down_interval * CS2MS,
@@ -935,7 +935,7 @@ static int vrrp_recv_advertisement(struct vrrp_router *r, struct ipaddr *src,
 		break;
 	case VRRP_STATE_BACKUP:
 		if (pkt->hdr.priority == 0) {
-			EVENT_OFF(r->t_master_down_timer);
+			event_cancel(&r->t_master_down_timer);
 			event_add_timer_msec(
 				master, vrrp_master_down_timer_expire, r,
 				r->skew_time * CS2MS, &r->t_master_down_timer);
@@ -946,7 +946,7 @@ static int vrrp_recv_advertisement(struct vrrp_router *r, struct ipaddr *src,
 					ntohs(pkt->hdr.v3.adver_int);
 			}
 			vrrp_recalculate_timers(r);
-			EVENT_OFF(r->t_master_down_timer);
+			event_cancel(&r->t_master_down_timer);
 			event_add_timer_msec(master,
 					     vrrp_master_down_timer_expire, r,
 					     r->master_down_interval * CS2MS,
@@ -1416,7 +1416,7 @@ static void vrrp_change_state_backup(struct vrrp_router *r)
 		vrrp_zebra_radv_set(r, false);
 
 	/* Disable Adver_Timer */
-	EVENT_OFF(r->t_adver_timer);
+	event_cancel(&r->t_adver_timer);
 
 	r->advert_pending = false;
 	r->garp_pending = false;
@@ -1643,10 +1643,10 @@ static int vrrp_shutdown(struct vrrp_router *r)
 	}
 
 	/* Cancel all timers */
-	EVENT_OFF(r->t_adver_timer);
-	EVENT_OFF(r->t_master_down_timer);
-	EVENT_OFF(r->t_read);
-	EVENT_OFF(r->t_write);
+	event_cancel(&r->t_adver_timer);
+	event_cancel(&r->t_master_down_timer);
+	event_cancel(&r->t_read);
+	event_cancel(&r->t_write);
 
 	/* Protodown macvlan */
 	if (r->mvl_ifp)

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -4400,7 +4400,7 @@ static void vtysh_log_read(struct event *thread)
 				"log monitor connection closed unexpectedly");
 		buf.hdr.textlen = strlen(buf.text);
 
-		EVENT_OFF(vclient->log_reader);
+		event_cancel(&vclient->log_reader);
 		close(vclient->log_fd);
 		vclient->log_fd = -1;
 
@@ -4522,7 +4522,7 @@ DEFPY (no_vtysh_terminal_monitor,
 			 * a close notification...
 			 */
 			if (vclient->log_fd != -1) {
-				EVENT_OFF(vclient->log_reader);
+				event_cancel(&vclient->log_reader);
 
 				close(vclient->log_fd);
 				vclient->log_fd = -1;

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -594,7 +594,7 @@ static void restart_done(struct daemon *dmn)
 			dmn->name, state_str[dmn->state]);
 		return;
 	}
-	EVENT_OFF(dmn->t_wakeup);
+	event_cancel(&dmn->t_wakeup);
 
 	if (try_connect(dmn) < 0)
 		SET_WAKEUP_DOWN(dmn);
@@ -622,9 +622,9 @@ static void daemon_down(struct daemon *dmn, const char *why)
 		close(dmn->fd);
 		dmn->fd = -1;
 	}
-	EVENT_OFF(dmn->t_read);
-	EVENT_OFF(dmn->t_write);
-	EVENT_OFF(dmn->t_wakeup);
+	event_cancel(&dmn->t_read);
+	event_cancel(&dmn->t_write);
+	event_cancel(&dmn->t_wakeup);
 	if (try_connect(dmn) < 0)
 		SET_WAKEUP_DOWN(dmn);
 
@@ -750,7 +750,7 @@ static void daemon_up(struct daemon *dmn, const char *why)
 	if (gs.numdown == 0) {
 		daemon_send_ready(0);
 
-		EVENT_OFF(gs.t_operational);
+		event_cancel(&gs.t_operational);
 
 		event_add_timer(master, daemon_restarting_operational, NULL,
 				gs.operational_timeout, &gs.t_operational);
@@ -948,7 +948,7 @@ static void phase_check(void)
 					gs.start_command, 1, 0);
 		}
 		gs.phase = PHASE_NONE;
-		EVENT_OFF(gs.t_phase_hanging);
+		event_cancel(&gs.t_phase_hanging);
 		zlog_notice("Phased global restart has completed.");
 		break;
 	}

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -560,8 +560,8 @@ static void fpm_reconnect(struct fpm_nl_ctx *fnc)
 
 	stream_reset(fnc->ibuf);
 	stream_reset(fnc->obuf);
-	EVENT_OFF(fnc->t_read);
-	EVENT_OFF(fnc->t_write);
+	event_cancel(&fnc->t_read);
+	event_cancel(&fnc->t_write);
 
 	/* Reset the barrier value */
 	cleaning_p = true;
@@ -1572,7 +1572,7 @@ static void fpm_process_queue(struct event *t)
 		event_add_timer(fnc->fthread->master, fpm_process_wedged, fnc,
 				DPLANE_FPM_NL_WEDGIE_TIME, &fnc->t_wedged);
 	} else
-		EVENT_OFF(fnc->t_wedged);
+		event_cancel(&fnc->t_wedged);
 
 	/*
 	 * Let the dataplane thread know if there are items in the
@@ -1685,16 +1685,16 @@ static int fpm_nl_finish_early(struct fpm_nl_ctx *fnc)
 		return 0;
 
 	/* Disable all events and close socket. */
-	EVENT_OFF(fnc->t_lspreset);
-	EVENT_OFF(fnc->t_lspwalk);
-	EVENT_OFF(fnc->t_nhgreset);
-	EVENT_OFF(fnc->t_nhgwalk);
-	EVENT_OFF(fnc->t_ribreset);
-	EVENT_OFF(fnc->t_ribwalk);
-	EVENT_OFF(fnc->t_rmacreset);
-	EVENT_OFF(fnc->t_rmacwalk);
-	EVENT_OFF(fnc->t_event);
-	EVENT_OFF(fnc->t_nhg);
+	event_cancel(&fnc->t_lspreset);
+	event_cancel(&fnc->t_lspwalk);
+	event_cancel(&fnc->t_nhgreset);
+	event_cancel(&fnc->t_nhgwalk);
+	event_cancel(&fnc->t_ribreset);
+	event_cancel(&fnc->t_ribwalk);
+	event_cancel(&fnc->t_rmacreset);
+	event_cancel(&fnc->t_rmacwalk);
+	event_cancel(&fnc->t_event);
+	event_cancel(&fnc->t_nhg);
 	event_cancel_async(fnc->fthread->master, &fnc->t_read, NULL);
 	event_cancel_async(fnc->fthread->master, &fnc->t_write, NULL);
 	event_cancel_async(fnc->fthread->master, &fnc->t_connect, NULL);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -233,7 +233,7 @@ static int if_zebra_delete_hook(struct interface *ifp)
 
 		XFREE(MTYPE_ZIF_DESC, zebra_if->desc);
 
-		EVENT_OFF(zebra_if->speed_update);
+		event_cancel(&zebra_if->speed_update);
 
 		XFREE(MTYPE_ZINFO, zebra_if);
 	}

--- a/zebra/irdp_main.c
+++ b/zebra/irdp_main.c
@@ -242,7 +242,7 @@ void irdp_advert_off(struct interface *ifp)
 	if (!irdp)
 		return;
 
-	EVENT_OFF(irdp->t_advertise);
+	event_cancel(&irdp->t_advertise);
 
 	frr_each (if_connected, ifp->connected, ifc) {
 		p = ifc->address;
@@ -279,7 +279,7 @@ void process_solicit(struct interface *ifp)
 		return;
 
 	irdp->flags |= IF_SOLICIT;
-	EVENT_OFF(irdp->t_advertise);
+	event_cancel(&irdp->t_advertise);
 
 	timer = (frr_weak_random() % MAX_RESPONSE_DELAY) + 1;
 

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1983,7 +1983,7 @@ static void kernel_nlsock_fini(struct nlsock *nls)
 
 void kernel_terminate(struct zebra_ns *zns, bool complete)
 {
-	EVENT_OFF(zns->t_netlink);
+	event_cancel(&zns->t_netlink);
 
 	kernel_nlsock_fini(&zns->netlink);
 

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -1593,7 +1593,7 @@ void rtadv_stop_ra(struct interface *ifp)
 	wheel_remove_item(zrouter.ra_wheel, ifp);
 
 	/*Turn off event for ICMPv6 join*/
-	EVENT_OFF(zif->icmpv6_join_timer);
+	event_cancel(&zif->icmpv6_join_timer);
 
 	if (zif->rtadv.AdvSendAdvertisements)
 		rtadv_send_packet(zvrf->rtadv.sock, ifp, RA_SUPPRESS);
@@ -1980,8 +1980,8 @@ static void rtadv_event(struct zebra_vrf *zvrf, enum rtadv_event event, int val)
 
 		break;
 	case RTADV_STOP:
-		EVENT_OFF(rtadv->ra_timer);
-		EVENT_OFF(rtadv->ra_read);
+		event_cancel(&rtadv->ra_timer);
+		event_cancel(&rtadv->ra_read);
 		break;
 	case RTADV_TIMER:
 		event_add_timer(zrouter.master, rtadv_timer, zvrf, val,

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -7331,8 +7331,8 @@ static void dplane_check_shutdown_status(struct event *event)
 		zns_info_list_del(&zdplane_info.dg_zns_list, zi);
 
 		if (zdplane_info.dg_master) {
-			EVENT_OFF(zi->t_read);
-			EVENT_OFF(zi->t_request);
+			event_cancel(&zi->t_read);
+			event_cancel(&zi->t_request);
 		}
 
 		XFREE(MTYPE_DP_NS, zi);

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -570,7 +570,7 @@ static void zebra_evpn_dup_addr_detect_for_mac(struct zebra_vrf *zvrf,
 		}
 
 		/* Start auto recovery timer for this MAC */
-		EVENT_OFF(mac->dad_mac_auto_recovery_timer);
+		event_cancel(&mac->dad_mac_auto_recovery_timer);
 		if (zvrf->dad_freeze && zvrf->dad_freeze_time) {
 			if (IS_ZEBRA_DEBUG_VXLAN) {
 				char mac_buf[MAC_BUF_SIZE];
@@ -1134,7 +1134,7 @@ int zebra_evpn_mac_del(struct zebra_evpn *zevpn, struct zebra_mac *mac)
 	zebra_evpn_mac_stop_hold_timer(mac);
 
 	/* Cancel auto recovery */
-	EVENT_OFF(mac->dad_mac_auto_recovery_timer);
+	event_cancel(&mac->dad_mac_auto_recovery_timer);
 
 	/* If the MAC is freed before the neigh we will end up
 	 * with a stale pointer against the neigh.
@@ -1562,7 +1562,7 @@ void zebra_evpn_mac_stop_hold_timer(struct zebra_mac *mac)
 							  sizeof(mac_buf)));
 	}
 
-	EVENT_OFF(mac->hold_timer);
+	event_cancel(&mac->hold_timer);
 }
 
 void zebra_evpn_sync_mac_del(struct zebra_mac *mac)

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -2345,7 +2345,7 @@ static void zebra_evpn_es_local_info_clear(struct zebra_evpn_es **esp)
 
 	es->flags &= ~(ZEBRA_EVPNES_LOCAL | ZEBRA_EVPNES_READY_FOR_BGP);
 
-	EVENT_OFF(es->df_delay_timer);
+	event_cancel(&es->df_delay_timer);
 
 	/* clear EVPN protodown flags on the access port */
 	zebra_evpn_mh_clear_protodown_es(es);
@@ -3741,7 +3741,7 @@ static void zebra_evpn_mh_startup_delay_timer_start(const char *rc)
 	if (zmh_info->startup_delay_timer) {
 		if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
 			zlog_debug("startup-delay timer cancelled");
-		EVENT_OFF(zmh_info->startup_delay_timer);
+		event_cancel(&zmh_info->startup_delay_timer);
 	}
 
 	if (zmh_info->startup_delay_time) {

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -580,7 +580,7 @@ int zebra_evpn_neigh_del(struct zebra_evpn *zevpn, struct zebra_neigh *n)
 		listnode_delete(n->mac->neigh_list, n);
 
 	/* Cancel auto recovery */
-	EVENT_OFF(n->dad_ip_auto_recovery_timer);
+	event_cancel(&n->dad_ip_auto_recovery_timer);
 
 	/* Cancel proxy hold timer */
 	zebra_evpn_neigh_stop_hold_timer(n);
@@ -1223,7 +1223,7 @@ static void zebra_evpn_dup_addr_detect_for_neigh(
 		nbr->dad_dup_detect_time = monotime(NULL);
 
 		/* Start auto recovery timer for this IP */
-		EVENT_OFF(nbr->dad_ip_auto_recovery_timer);
+		event_cancel(&nbr->dad_ip_auto_recovery_timer);
 		if (zvrf->dad_freeze && zvrf->dad_freeze_time) {
 			if (IS_ZEBRA_DEBUG_VXLAN)
 				zlog_debug(
@@ -1683,7 +1683,7 @@ void zebra_evpn_clear_dup_neigh_hash(struct hash_bucket *bucket, void *ctxt)
 	nbr->detect_start_time.tv_sec = 0;
 	nbr->detect_start_time.tv_usec = 0;
 	nbr->dad_dup_detect_time = 0;
-	EVENT_OFF(nbr->dad_ip_auto_recovery_timer);
+	event_cancel(&nbr->dad_ip_auto_recovery_timer);
 
 	if (CHECK_FLAG(nbr->flags, ZEBRA_NEIGH_LOCAL)) {
 		zebra_evpn_neigh_send_add_to_client(zevpn->vni, &nbr->ip,

--- a/zebra/zebra_evpn_neigh.h
+++ b/zebra/zebra_evpn_neigh.h
@@ -158,7 +158,7 @@ static inline void zebra_evpn_neigh_stop_hold_timer(struct zebra_neigh *n)
 	if (IS_ZEBRA_DEBUG_EVPN_MH_NEIGH)
 		zlog_debug("sync-neigh vni %u ip %pIA mac %pEA 0x%x hold stop",
 			   n->zevpn->vni, &n->ip, &n->emac, n->flags);
-	EVENT_OFF(n->hold_timer);
+	event_cancel(&n->hold_timer);
 }
 
 void zebra_evpn_sync_neigh_static_chg(struct zebra_neigh *n, bool old_n_static,

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -485,7 +485,7 @@ static inline void zfpm_write_on(void)
  */
 static inline void zfpm_read_off(void)
 {
-	EVENT_OFF(zfpm_g->t_read);
+	event_cancel(&zfpm_g->t_read);
 }
 
 /*
@@ -493,17 +493,17 @@ static inline void zfpm_read_off(void)
  */
 static inline void zfpm_write_off(void)
 {
-	EVENT_OFF(zfpm_g->t_write);
+	event_cancel(&zfpm_g->t_write);
 }
 
 static inline void zfpm_connect_off(void)
 {
-	EVENT_OFF(zfpm_g->t_connect);
+	event_cancel(&zfpm_g->t_connect);
 }
 
 static inline void zfpm_conn_down_off(void)
 {
-	EVENT_OFF(zfpm_g->t_conn_down);
+	event_cancel(&zfpm_g->t_conn_down);
 }
 
 /*
@@ -577,7 +577,7 @@ static void zfpm_connection_up(const char *detail)
 	/*
 	 * Start thread to push existing routes to the FPM.
 	 */
-	EVENT_OFF(zfpm_g->t_conn_up);
+	event_cancel(&zfpm_g->t_conn_up);
 
 	zfpm_rnodes_iter_init(&zfpm_g->t_conn_up_state.iter);
 	zfpm_g->fpm_mac_dump_done = false;
@@ -1703,7 +1703,7 @@ static void zfpm_stop_stats_timer(void)
 		return;
 
 	zfpm_debug("Stopping existing stats timer");
-	EVENT_OFF(zfpm_g->t_stats);
+	event_cancel(&zfpm_g->t_stats);
 }
 
 /*

--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -77,7 +77,7 @@ void zebra_gr_stale_client_cleanup(void)
 
 			/* Cancel the stale timer */
 			if (info->t_stale_removal != NULL) {
-				EVENT_OFF(info->t_stale_removal);
+				event_cancel(&info->t_stale_removal);
 				info->do_delete = true;
 				/* Process the stale routes */
 				event_execute(
@@ -115,7 +115,7 @@ static void zebra_gr_client_info_delete(struct zserv *client,
 
 	TAILQ_REMOVE(&(client->gr_info_queue), info, gr_info);
 
-	EVENT_OFF(info->t_stale_removal);
+	event_cancel(&info->t_stale_removal);
 
 	LOG_GR("%s: Instance info is being deleted for client %s vrf %s(%u)",
 	       __func__, zebra_route_string(client->proto), VRF_LOGNAME(vrf),
@@ -669,7 +669,7 @@ static void zebra_gr_process_client_stale_routes(struct zserv *client,
 		LOG_GR("%s: Client %s route update complete for all AFI/SAFI in vrf %s(%d)",
 		       __func__, zebra_route_string(client->proto),
 		       VRF_LOGNAME(vrf), info->vrf_id);
-		EVENT_OFF(info->t_stale_removal);
+		event_cancel(&info->t_stale_removal);
 	}
 }
 

--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -459,7 +459,7 @@ void zebra_ns_notify_close(void)
 		fd = zebra_netns_notify_current->u.fd;
 
 	if (zebra_netns_notify_current->master != NULL)
-		EVENT_OFF(zebra_netns_notify_current);
+		event_cancel(&zebra_netns_notify_current);
 
 	/* auto-removal of notify items */
 	if (fd > 0)

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1711,7 +1711,7 @@ void zebra_nhg_free(struct nhg_hash_entry *nhe)
 				   nhe->nhg.nexthop);
 	}
 
-	EVENT_OFF(nhe->timer);
+	event_cancel(&nhe->timer);
 
 	zebra_nhg_free_members(nhe);
 
@@ -1736,7 +1736,7 @@ void zebra_nhg_hash_free(void *p)
 				   nhe->nhg.nexthop);
 	}
 
-	EVENT_OFF(nhe->timer);
+	event_cancel(&nhe->timer);
 
 	nexthops_free(nhe->nhg.nexthop);
 
@@ -1821,7 +1821,7 @@ void zebra_nhg_increment_ref(struct nhg_hash_entry *nhe)
 	nhe->refcnt++;
 
 	if (event_is_scheduled(nhe->timer)) {
-		EVENT_OFF(nhe->timer);
+		event_cancel(&nhe->timer);
 		nhe->refcnt--;
 		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_KEEP_AROUND);
 	}
@@ -3847,7 +3847,7 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 
 			/* Dont call the dec API, we dont want to uninstall the ID */
 			old->refcnt = 0;
-			EVENT_OFF(old->timer);
+			event_cancel(&old->timer);
 			zebra_nhg_free(old);
 			old = NULL;
 		}

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -140,9 +140,9 @@ void zebra_ptm_finish(void)
 		free(ptm_cb.in_data);
 
 	/* Cancel events. */
-	EVENT_OFF(ptm_cb.t_read);
-	EVENT_OFF(ptm_cb.t_write);
-	EVENT_OFF(ptm_cb.t_timer);
+	event_cancel(&ptm_cb.t_read);
+	event_cancel(&ptm_cb.t_write);
+	event_cancel(&ptm_cb.t_timer);
 
 	if (ptm_cb.wb)
 		buffer_free(ptm_cb.wb);
@@ -196,7 +196,7 @@ static int zebra_ptm_send_message(char *data, int size)
 				ptm_cb.reconnect_time, &ptm_cb.t_timer);
 		return -1;
 	case BUFFER_EMPTY:
-		EVENT_OFF(ptm_cb.t_write);
+		event_cancel(&ptm_cb.t_write);
 		break;
 	case BUFFER_PENDING:
 		event_add_write(zrouter.master, zebra_ptm_flush_messages, NULL,

--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -89,7 +89,7 @@ void zebra_pw_del(struct zebra_vrf *zvrf, struct zebra_pw *pw)
 		dplane_pw_uninstall(pw);
 	}
 
-	EVENT_OFF(pw->install_retry_timer);
+	event_cancel(&pw->install_retry_timer);
 
 	/* unlink and release memory */
 	RB_REMOVE(zebra_pw_head, &zvrf->pseudowires, pw);
@@ -232,7 +232,7 @@ void zebra_pw_install_failure(struct zebra_pw *pw, int pwstatus)
 			pw->vrf_id, pw->ifname, PW_INSTALL_RETRY_INTERVAL);
 
 	/* schedule to retry later */
-	EVENT_OFF(pw->install_retry_timer);
+	event_cancel(&pw->install_retry_timer);
 	event_add_timer(zrouter.master, zebra_pw_install_retry, pw,
 			PW_INSTALL_RETRY_INTERVAL, &pw->install_retry_timer);
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4832,7 +4832,7 @@ void rib_update_finish(void)
 			ctx = EVENT_ARG(t_rib_update_threads[i]);
 
 			rib_update_ctx_fini(&ctx);
-			EVENT_OFF(t_rib_update_threads[i]);
+			event_cancel(&t_rib_update_threads[i]);
 		}
 	}
 }
@@ -5302,7 +5302,7 @@ void zebra_rib_terminate(void)
 {
 	struct zebra_dplane_ctx *ctx;
 
-	EVENT_OFF(t_dplane);
+	event_cancel(&t_dplane);
 
 	ctx = dplane_ctx_dequeue(&rib_dplane_q);
 	while (ctx) {

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1183,7 +1183,7 @@ void zebra_route_map_set_delay_timer(uint32_t value)
 	if (!value && zebra_t_rmap_update) {
 		/* Event driven route map updates is being disabled */
 		/* But there's a pending timer. Fire it off now */
-		EVENT_OFF(zebra_t_rmap_update);
+		event_cancel(&zebra_t_rmap_update);
 		zebra_route_map_update_timer(NULL);
 	}
 }
@@ -1193,7 +1193,7 @@ void zebra_routemap_finish(void)
 	/* Set zebra_rmap_update_timer to 0 so that it wont schedule again */
 	zebra_rmap_update_timer = 0;
 	/* Thread off if any scheduled already */
-	EVENT_OFF(zebra_t_rmap_update);
+	event_cancel(&zebra_t_rmap_update);
 	route_map_finish();
 }
 
@@ -1295,7 +1295,7 @@ static void zebra_route_map_mark_update(const char *rmap_name)
 {
 	/* rmap_update_timer of 0 means don't do route updates */
 	if (zebra_rmap_update_timer)
-		EVENT_OFF(zebra_t_rmap_update);
+		event_cancel(&zebra_t_rmap_update);
 
 	event_add_timer(zrouter.master, zebra_route_map_update_timer, NULL,
 			zebra_rmap_update_timer, &zebra_t_rmap_update);

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -237,7 +237,7 @@ void zebra_router_terminate(void)
 		zrouter.ra_wheel = NULL;
 	}
 
-	EVENT_OFF(zrouter.t_rib_sweep);
+	event_cancel(&zrouter.t_rib_sweep);
 
 	RB_FOREACH_SAFE (zrt, zebra_router_table_head, &zrouter.tables, tmp)
 		zebra_router_free_table(zrt);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -3515,7 +3515,7 @@ int zebra_vxlan_clear_dup_detect_vni_mac(struct zebra_vrf *zvrf, vni_t vni,
 	mac->detect_start_time.tv_sec = 0;
 	mac->detect_start_time.tv_usec = 0;
 	mac->dad_dup_detect_time = 0;
-	EVENT_OFF(mac->dad_mac_auto_recovery_timer);
+	event_cancel(&mac->dad_mac_auto_recovery_timer);
 
 	/* warn-only action return */
 	if (!zvrf->dad_freeze)
@@ -3597,7 +3597,7 @@ int zebra_vxlan_clear_dup_detect_vni_ip(struct zebra_vrf *zvrf, vni_t vni,
 	nbr->detect_start_time.tv_sec = 0;
 	nbr->detect_start_time.tv_usec = 0;
 	nbr->dad_dup_detect_time = 0;
-	EVENT_OFF(nbr->dad_ip_auto_recovery_timer);
+	event_cancel(&nbr->dad_ip_auto_recovery_timer);
 
 	if (!!CHECK_FLAG(nbr->flags, ZEBRA_NEIGH_LOCAL)) {
 		zebra_evpn_neigh_send_add_to_client(zevpn->vni, ip, &nbr->emac,
@@ -3632,7 +3632,7 @@ static void zevpn_clear_dup_mac_hash(struct hash_bucket *bucket, void *ctxt)
 	mac->detect_start_time.tv_sec = 0;
 	mac->detect_start_time.tv_usec = 0;
 	mac->dad_dup_detect_time = 0;
-	EVENT_OFF(mac->dad_mac_auto_recovery_timer);
+	event_cancel(&mac->dad_mac_auto_recovery_timer);
 
 	/* Remove all IPs as duplicate associcated with this MAC */
 	for (ALL_LIST_ELEMENTS_RO(mac->neigh_list, node, nbr)) {

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -190,8 +190,8 @@ static void zserv_client_fail(struct zserv *client)
 	atomic_store_explicit(&client->pthread->running, false,
 			      memory_order_relaxed);
 
-	EVENT_OFF(client->t_read);
-	EVENT_OFF(client->t_write);
+	event_cancel(&client->t_read);
+	event_cancel(&client->t_write);
 	zserv_event(client, ZSERV_HANDLE_CLIENT_FAIL);
 }
 
@@ -718,8 +718,8 @@ void zserv_close_client(struct zserv *client)
 				   zebra_route_string(client->proto));
 
 		event_cancel_event(zrouter.master, client);
-		EVENT_OFF(client->t_cleanup);
-		EVENT_OFF(client->t_process);
+		event_cancel(&client->t_cleanup);
+		event_cancel(&client->t_process);
 
 		/* destroy pthread */
 		frr_pthread_destroy(client->pthread);


### PR DESCRIPTION
We've had a macro in the event library that's been carrying a "don't use this macro" comment for ... a long time. This PR removes the macro, and uses the "event_cancel" api in its place. We've talked recently about enhancing that api so that it aligns more closely with the "event_add" and "cancel_async" apis, so this seemed like a step in that direction too.