### PR TITLE
add total path count for bgp net in json output

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -13219,6 +13219,14 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 			}
 			vty_out(vty, "\n");
 		}
+
+		if (json) {
+			if (incremental_print) {
+				vty_out(vty, "\"pathCount\": %d", count);
+				vty_out(vty, ",");
+			} else
+				json_object_int_add(json, "pathCount", count);
+		}
 	}
 }
 


### PR DESCRIPTION
bgpd: add total path count for bgp net in json output
Currently only vty output shows total path count for a
BGP net. This fix add that information in josn output too.


sh bgp ipv4 unicast 172.16.16.254/32 json 
{
  "prefix":"172.16.16.254/32",
  "version":4,
  "advertisedTo":{
    "192.168.1.2":{
      "hostname":"r2"
    }
  },
  "pathCount":2,<<<<<<<new key value added
  "paths":[
    {
      "aspath":{
        "string":"65002 65005",
        "segments":[
          {
            "type":"as-sequence",
            "list":[
              65002,
              65005
            ]
          }
        ],
        "length":2
      },
      "origin":"incomplete",
      "valid":true,
      "version":4,
      "multipath":true,
      "bestpath":{
        "overall":true,
        "selectionReason":"Older Path"
      },
      "addpathRxId":6,
      "addpathTxId":0,
      "addpathTxIdAll":0,
      "addpathTxIdBestPerAS":0,
      "addpathTxIdBestSelected":0,
      "lastUpdate":{
        "epoch":1746080990,
        "string":"Thu May  1 06:29:50 2025"
      },
      "nexthops":[
        {
          "ip":"192.168.1.2",
          "hostname":"r2",
          "afi":"ipv4",
          "metric":0,
          "accessible":true,
          "used":true
        }
      ],
      "peer":{
        "peerId":"192.168.1.2",
        "routerId":"192.168.7.2",
        "hostname":"r2",
        "type":"external"
      }
    },
    {
      "aspath":{
        "string":"65002 65006",
        "segments":[
          {
            "type":"as-sequence",
            "list":[
              65002,
              65006
            ]
          }
        ],
        "length":2
      },
      "origin":"incomplete",
      "valid":true,
      "version":4,
      "multipath":true,
      "addpathRxId":8,
      "addpathTxId":0,
      "addpathTxIdAll":0,
      "addpathTxIdBestPerAS":0,
      "addpathTxIdBestSelected":0,
      "lastUpdate":{
        "epoch":1746080990,
        "string":"Thu May  1 06:29:50 2025"
      },
      "nexthops":[
        {
          "ip":"192.168.1.2",
          "hostname":"r2",
          "afi":"ipv4",
          "metric":0,
          "accessible":true,
          "used":true
        }
      ],
      "peer":{
        "peerId":"192.168.1.2",
        "routerId":"192.168.7.2",
        "hostname":"r2",
        "type":"external"
      }
    }
  ]
}

