### PR TITLE
Move where nhe_installed_id is set in zebra

### DIFF
--- a/tests/topotests/zebra_recursive_nhg_installed/r1/frr.conf
+++ b/tests/topotests/zebra_recursive_nhg_installed/r1/frr.conf
@@ -1,0 +1,11 @@
+!
+hostname r1
+!
+service integrated-vtysh-config
+!
+interface r1-eth0
+ ip address 192.168.1.1/24
+!
+ip route 10.1.1.1/32 192.168.1.1
+ip route 10.1.1.2/32 10.1.1.1
+!

--- a/tests/topotests/zebra_recursive_nhg_installed/test_zebra_recursive_nhg_installed.py
+++ b/tests/topotests/zebra_recursive_nhg_installed/test_zebra_recursive_nhg_installed.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_zebra_recursive_nhg_installed.py
+#
+# Copyright (c) 2024 by Donald Sharp, Nvidia Inc.
+#
+
+"""
+test_zebra_recursive_nhg_installed.py: Test recursive next-hop group installation
+"""
+
+import os
+import sys
+import json
+import pytest
+import functools
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from lib.common_config import step
+
+
+pytestmark = [pytest.mark.staticd]
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    # Single router with one interface
+    topodef = {"r1": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr.conf".format(rname)),
+            [
+                (TopoRouter.RD_ZEBRA, None),
+                (TopoRouter.RD_STATIC, None),
+            ],
+        )
+
+    # Initialize all routers.
+    tgen.start_router()
+
+
+def teardown_module():
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_zebra_recursive_nhg_installed():
+    "Test recursive next-hop group installation"
+    step("Test recursive next-hop group installation")
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    r1 = tgen.gears["r1"]
+
+    # Check that routes are installed
+    step("Check that routes are installed")
+
+    def check_routes_installed():
+        output = r1.vtysh_cmd("show ip route json")
+        output_json = json.loads(output)
+
+        # Check 10.1.1.1/32 route
+        if "10.1.1.1/32" not in output_json:
+            return "10.1.1.1/32 route not found"
+        route1 = output_json["10.1.1.1/32"][0]
+        if not route1.get("installed", False):
+            return "10.1.1.1/32 route not installed"
+
+        # Check 10.1.1.2/32 route
+        if "10.1.1.2/32" not in output_json:
+            return "10.1.1.2/32 route not found"
+        route2 = output_json["10.1.1.2/32"][0]
+        if not route2.get("installed", False):
+            return "10.1.1.2/32 route not installed"
+
+        return None
+
+    _, result = topotest.run_and_expect(check_routes_installed, None, count=30, wait=1)
+    assert result is None, f"Routes not installed: {result}"
+
+
+def test_zebra_recursive_nhg_nexthop_group():
+    "Test recursive next-hop group ID"
+    step("Test recursive next-hop group ID")
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip("skipped because of router(s) failure")
+
+    r1 = tgen.gears["r1"]
+
+    def check_nexthop_group_id():
+        output = r1.vtysh_cmd("show ip route json")
+        output_json = json.loads(output)
+
+        # Get the nexthop group ID for 10.1.1.1/32 route
+        if "10.1.1.1/32" not in output_json:
+            return "10.1.1.1/32 route not found"
+        route1 = output_json["10.1.1.1/32"][0]
+        nhg_id = route1["nexthopGroupId"]
+
+        # Check that 10.1.1.2/32 route uses the same nexthop group ID
+        if "10.1.1.2/32" not in output_json:
+            return "10.1.1.2/32 route not found"
+        route2 = output_json["10.1.1.2/32"][0]
+        if "installedNexthopGroupId" not in route2:
+            return "10.1.1.2/32 route has no nexthop group ID"
+        if route2["installedNexthopGroupId"] != nhg_id:
+            return f"10.1.1.2/32 route nexthop group ID {route2['installedNexthopGroupId']} does not match 10.1.1.1/32 route ID {nhg_id}"
+        else:
+            logger.info(
+                f"10.1.1.2/32 route Installed Nexthop group ID {route2['installedNexthopGroupId']} matches 10.1.1.1/32 route NHG ID {nhg_id}"
+            )
+
+        return None
+
+    _, result = topotest.run_and_expect(check_nexthop_group_id, None, count=30, wait=1)
+    assert result is None, f"Nexthop group ID mismatch: {result}"

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -85,10 +85,22 @@ struct route_entry {
 	 */
 	struct nhg_hash_entry *nhe;
 
-	/* Nexthop group hash entry IDs. The "installed" id is the id
-	 * used in linux/netlink, if available.
+	/*
+	 * Nexthop group hash entry IDs.
+	 * Since the nhe_id is used as a temporary holder
+	 * of the nexthop group id ( say the route was learned
+	 * from the kernel and it had a nhg_id, this value will
+	 * need to stay for the moment, until we untangle
+	 * route reception from handling of nexthop groups a bit more
 	 */
 	uint32_t nhe_id;
+	/*
+	 * The installed id is the id of the nexthop group
+	 * that is installed in the FIB.  This can be different
+	 * a great example is a recursive singleton through
+	 * another singleton.  See the test_zebra_recursive_nhg_installed
+	 * for more details on how to setup this situation.
+	 */
 	uint32_t nhe_installed_id;
 
 	/* Type of this route. */

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3602,8 +3602,6 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 		     !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED) &&
 		     !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_QUEUED)))
 			return ENOENT;
-
-		re->nhe_installed_id = nhe->id;
 	}
 #endif /* HAVE_NETLINK */
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2129,6 +2129,16 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 							rn);
 				}
 
+				/*
+				 * The nhe_installed_id stores the actually installed
+				 * nhg id.  This can be different than the nhe_id in
+				 * that if you have a recursive singleton through another
+				 * singleton it can show this.  See the
+				 * zebra_recursive_nhg_installed topotest for examples
+				 * of how we got here
+				 */
+				re->nhe_installed_id = dplane_ctx_get_nhe_id(ctx);
+
 				/* Redistribute if this is the selected re */
 				if (dest && re == dest->selected_fib)
 					redistribute_update(rn, re, old_re);


### PR DESCRIPTION
See individual commits.

a) Add a test to show that nhe_installed_id is useful and accurately tracks the actually installed nexthop group id.
b) Move where nhe_installed_id is set
c) Document rib.h a bit better since I couldn't remember wtf was going on.