### PR TITLE
zebra: add dplane plugin for Grout (RFC)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2163,6 +2163,18 @@ if test "$enable_dp_dpdk" = "yes"; then
   ])
 fi
 
+dnl ---------
+dnl GROUT
+dnl ---------
+if test "$enable_dp_grout" = "yes"; then
+  AC_CHECK_HEADER([gr_api.h], [
+    AC_DEFINE([HAVE_GROUT], [1], [Enable Grout backend])
+    GROUT=true
+  ], [
+    AC_MSG_ERROR([configuration specifies --enable-dp-grout but GROUT libs were not found])
+  ])
+fi
+
 dnl -----
 dnl LTTng
 dnl -----
@@ -2837,6 +2849,7 @@ AM_CONDITIONAL([VRRPD], [test "$enable_vrrpd" != "no"])
 AM_CONDITIONAL([PATHD], [test "$enable_pathd" != "no"])
 AM_CONDITIONAL([PATHD_PCEP], [test "$enable_pathd" != "no"])
 AM_CONDITIONAL([DP_DPDK], [test "$enable_dp_dpdk" = "yes"])
+AM_CONDITIONAL([DP_GROUT], [test "$enable_dp_grout" = "yes"])
 
 
 AM_CONDITIONAL([PYTHON_RUNTIME_DEPENDENCY], [test "$enable_python_runtime" != "no"])

--- a/zebra/debug.c
+++ b/zebra/debug.c
@@ -23,6 +23,7 @@ unsigned long zebra_debug_vxlan;
 unsigned long zebra_debug_pw;
 unsigned long zebra_debug_dplane;
 unsigned long zebra_debug_dplane_dpdk;
+unsigned long zebra_debug_dplane_grout;
 unsigned long zebra_debug_mlag;
 unsigned long zebra_debug_nexthop;
 unsigned long zebra_debug_evpn_mh;
@@ -100,6 +101,10 @@ DEFUN_NOSH (show_debugging_zebra,
 			"  Zebra detailed dpdk dataplane debugging is on\n");
 	else if (IS_ZEBRA_DEBUG_DPLANE_DPDK)
 		vty_out(vty, "  Zebra dataplane dpdk debugging is on\n");
+	if (IS_ZEBRA_DEBUG_DPLANE_GROUT_DETAIL)
+		vty_out(vty, "  Zebra detailed grout dataplane debugging is on\n");
+	else if (IS_ZEBRA_DEBUG_DPLANE_GROUT)
+		vty_out(vty, "  Zebra dataplane grout debugging is on\n");
 	if (IS_ZEBRA_DEBUG_MLAG)
 		vty_out(vty, "  Zebra mlag debugging is on\n");
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
@@ -333,6 +338,27 @@ DEFPY(debug_zebra_dplane_dpdk, debug_zebra_dplane_dpdk_cmd,
 		if (detail)
 			SET_FLAG(zebra_debug_dplane_dpdk,
 				 ZEBRA_DEBUG_DPLANE_DPDK_DETAIL);
+	}
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(debug_zebra_dplane_grout, debug_zebra_dplane_grout_cmd,
+      "[no$no] debug zebra dplane grout [detailed$detail]",
+      NO_STR DEBUG_STR
+      "Zebra configuration\n"
+      "Debug zebra dataplane events\n"
+      "Detailed debug information\n"
+      "\n")
+{
+	if (no) {
+		UNSET_FLAG(zebra_debug_dplane_grout, ZEBRA_DEBUG_DPLANE_GROUT);
+		UNSET_FLAG(zebra_debug_dplane_grout, ZEBRA_DEBUG_DPLANE_GROUT_DETAIL);
+	} else {
+		SET_FLAG(zebra_debug_dplane_grout, ZEBRA_DEBUG_DPLANE_GROUT);
+
+		if (detail)
+			SET_FLAG(zebra_debug_dplane_grout, ZEBRA_DEBUG_DPLANE_GROUT_DETAIL);
 	}
 
 	return CMD_SUCCESS;
@@ -755,6 +781,14 @@ static int config_write_debug(struct vty *vty)
 		write++;
 	}
 
+	if (CHECK_FLAG(zebra_debug_dplane_grout, ZEBRA_DEBUG_DPLANE_GROUT_DETAIL)) {
+		vty_out(vty, "debug zebra dplane grout detailed\n");
+		write++;
+	} else if (CHECK_FLAG(zebra_debug_dplane_grout, ZEBRA_DEBUG_DPLANE_GROUT)) {
+		vty_out(vty, "debug zebra dplane grout\n");
+		write++;
+	}
+
 	if (CHECK_FLAG(zebra_debug_nexthop, ZEBRA_DEBUG_NHG_DETAILED)) {
 		vty_out(vty, "debug zebra nexthop detail\n");
 		write++;
@@ -793,6 +827,7 @@ void zebra_debug_init(void)
 	zebra_debug_pw = 0;
 	zebra_debug_dplane = 0;
 	zebra_debug_dplane_dpdk = 0;
+	zebra_debug_dplane_grout = 0;
 	zebra_debug_mlag = 0;
 	zebra_debug_evpn_mh = 0;
 	zebra_debug_nht = 0;
@@ -824,6 +859,7 @@ void zebra_debug_init(void)
 	install_element(ENABLE_NODE, &debug_zebra_neigh_cmd);
 	install_element(ENABLE_NODE, &debug_zebra_tc_cmd);
 	install_element(ENABLE_NODE, &debug_zebra_dplane_dpdk_cmd);
+	install_element(ENABLE_NODE, &debug_zebra_dplane_grout_cmd);
 	install_element(ENABLE_NODE, &no_debug_zebra_events_cmd);
 	install_element(ENABLE_NODE, &no_debug_zebra_nht_cmd);
 	install_element(ENABLE_NODE, &no_debug_zebra_mpls_cmd);
@@ -853,6 +889,7 @@ void zebra_debug_init(void)
 	install_element(CONFIG_NODE, &debug_zebra_fpm_cmd);
 	install_element(CONFIG_NODE, &debug_zebra_dplane_cmd);
 	install_element(CONFIG_NODE, &debug_zebra_dplane_dpdk_cmd);
+	install_element(CONFIG_NODE, &debug_zebra_dplane_grout_cmd);
 	install_element(CONFIG_NODE, &debug_zebra_nexthop_cmd);
 	install_element(CONFIG_NODE, &debug_zebra_pbr_cmd);
 	install_element(CONFIG_NODE, &debug_zebra_neigh_cmd);

--- a/zebra/debug.h
+++ b/zebra/debug.h
@@ -46,6 +46,9 @@ extern "C" {
 #define ZEBRA_DEBUG_DPLANE_DPDK 0x01
 #define ZEBRA_DEBUG_DPLANE_DPDK_DETAIL 0x02
 
+#define ZEBRA_DEBUG_DPLANE_GROUT	0x01
+#define ZEBRA_DEBUG_DPLANE_GROUT_DETAIL 0x02
+
 #define ZEBRA_DEBUG_MLAG    0x01
 
 #define ZEBRA_DEBUG_NHG             0x01
@@ -101,6 +104,9 @@ extern "C" {
 	(zebra_debug_dplane_dpdk & ZEBRA_DEBUG_DPLANE_DPDK)
 #define IS_ZEBRA_DEBUG_DPLANE_DPDK_DETAIL                                      \
 	(zebra_debug_dplane_dpdk & ZEBRA_DEBUG_DPLANE_DPDK_DETAIL)
+#define IS_ZEBRA_DEBUG_DPLANE_GROUT (zebra_debug_dplane_grout & ZEBRA_DEBUG_DPLANE_GROUT)
+#define IS_ZEBRA_DEBUG_DPLANE_GROUT_DETAIL                                                         \
+	(zebra_debug_dplane_dpdk & ZEBRA_DEBUG_DPLANE_GROUT_DETAIL)
 
 #define IS_ZEBRA_DEBUG_MLAG (zebra_debug_mlag & ZEBRA_DEBUG_MLAG)
 
@@ -137,6 +143,7 @@ extern unsigned long zebra_debug_vxlan;
 extern unsigned long zebra_debug_pw;
 extern unsigned long zebra_debug_dplane;
 extern unsigned long zebra_debug_dplane_dpdk;
+extern unsigned long zebra_debug_dplane_grout;
 extern unsigned long zebra_debug_mlag;
 extern unsigned long zebra_debug_nexthop;
 extern unsigned long zebra_debug_evpn_mh;

--- a/zebra/grout/if_grout.c
+++ b/zebra/grout/if_grout.c
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Grout interface
+ *
+ * Copyright (c) 2025 Maxime Leroy, Free Mobile
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h" /* Include this explicitly */
+#endif
+#include <net/if.h>
+#ifdef GNU_LINUX
+#include <linux/if.h>
+#endif /* GNU_LINUX */
+
+#include <gr_ip4.h>
+#include <gr_ip6.h>
+
+#include "zebra/interface.h"
+
+#include "log_grout.h"
+#include "zebra_dplane_grout.h"
+#include "if_grout.h"
+
+/* ugly hack to avoid collision with ifindex kernel */
+#define GROUT_INDEX_OFFSET 32000
+#define GROUT_NS	   NS_DEFAULT
+
+uint64_t gr_if_flags_to_netlink(struct gr_iface *gr_if, enum zebra_link_type link_type)
+{
+	uint64_t frr_if_flags = 0;
+
+	if (link_type == ZEBRA_LLT_LOOPBACK)
+		frr_if_flags |= IFF_LOOPBACK;
+
+	if (gr_if->base.flags & GR_IFACE_F_UP)
+		frr_if_flags |= IFF_UP;
+	if (gr_if->base.flags & GR_IFACE_F_PROMISC)
+		frr_if_flags |= IFF_PROMISC;
+	if (gr_if->base.flags & GR_IFACE_F_ALLMULTI)
+		frr_if_flags |= IFF_ALLMULTI;
+	if (gr_if->base.state & GR_IFACE_S_RUNNING)
+		frr_if_flags |= IFF_RUNNING | IFF_LOWER_UP;
+
+	/* Force BROADCAST and MULTICAST */
+	if (link_type == ZEBRA_LLT_ETHER)
+		frr_if_flags |= IFF_BROADCAST | IFF_MULTICAST;
+
+	return frr_if_flags;
+}
+
+void grout_link_change(struct gr_iface *gr_if, bool new, bool startup)
+{
+	struct zebra_dplane_ctx *ctx = dplane_ctx_alloc();
+	enum zebra_link_type link_type = ZEBRA_LLT_UNKNOWN;
+	enum zebra_iftype zif_type = ZEBRA_IF_OTHER;
+	const struct gr_iface_info_vlan *gr_vlan = NULL;
+	const struct gr_iface_info_port *gr_port = NULL;
+	ifindex_t link_ifindex = IFINDEX_INTERNAL;
+	const struct rte_ether_addr *mac = NULL;
+	uint32_t txqlen = 1000;
+
+	switch (gr_if->base.type) {
+	case GR_IFACE_TYPE_VLAN:
+		gr_vlan = (const struct gr_iface_info_vlan *)&gr_if->info;
+		mac = &gr_vlan->mac;
+		link_ifindex = gr_vlan->parent_id + GROUT_INDEX_OFFSET;
+		zif_type = ZEBRA_IF_VLAN;
+		link_type = ZEBRA_LLT_ETHER;
+		break;
+	case GR_IFACE_TYPE_PORT:
+		gr_port = (struct gr_iface_info_port *)&gr_if->info;
+		txqlen = gr_port->base.txq_size;
+		mac = &gr_port->base.mac;
+		link_type = ZEBRA_LLT_ETHER;
+		break;
+	case GR_IFACE_TYPE_IPIP:
+		link_type = ZEBRA_LLT_IPIP;
+		break;
+	case GR_IFACE_TYPE_LOOPBACK:
+		link_type = ZEBRA_LLT_LOOPBACK;
+		break;
+	case GR_IFACE_TYPE_UNDEF:
+	default:
+		gr_log_err("iface '%s' unkown type (%u) can not be sync", gr_if->name,
+			   gr_if->base.type);
+		return;
+	}
+
+	dplane_ctx_set_ns_id(ctx, GROUT_NS);
+	dplane_ctx_set_ifp_link_nsid(ctx, GROUT_NS);
+	dplane_ctx_set_ifp_zif_type(ctx, zif_type);
+	dplane_ctx_set_ifindex(ctx, gr_if->base.id + GROUT_INDEX_OFFSET);
+	dplane_ctx_set_ifname(ctx, gr_if->name);
+	dplane_ctx_set_ifp_startup(ctx, startup);
+	dplane_ctx_set_ifp_family(ctx, AF_UNSPEC);
+	dplane_ctx_set_intf_txqlen(ctx, txqlen);
+
+	if (new) {
+		dplane_ctx_set_ifp_link_ifindex(ctx, link_ifindex);
+		dplane_ctx_set_op(ctx, DPLANE_OP_INTF_INSTALL);
+		dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_QUEUED);
+		dplane_ctx_set_ifp_mtu(ctx, gr_if->base.mtu);
+
+		/* No VRF support */
+		if (gr_if->base.vrf_id != 0) {
+			gr_log_err("VRF are not supported, interface %s on vrf %u can not be sync",
+				   gr_if->name, gr_if->base.vrf_id);
+			dplane_ctx_fini(&ctx);
+			return;
+		}
+
+		/* no bond/bridge support in grout */
+		dplane_ctx_set_ifp_zif_slave_type(ctx, ZEBRA_IF_SLAVE_NONE);
+		dplane_ctx_set_ifp_vrf_id(ctx, 0);
+		dplane_ctx_set_ifp_master_ifindex(ctx, IFINDEX_INTERNAL);
+		dplane_ctx_set_ifp_bridge_ifindex(ctx, IFINDEX_INTERNAL);
+		dplane_ctx_set_ifp_bond_ifindex(ctx, IFINDEX_INTERNAL);
+		dplane_ctx_set_ifp_bypass(ctx, 0);
+		dplane_ctx_set_ifp_zltype(ctx, link_type);
+
+		if (vrf_is_backend_netns())
+			dplane_ctx_set_ifp_vrf_id(ctx, GROUT_NS);
+
+		dplane_ctx_set_ifp_flags(ctx, gr_if_flags_to_netlink(gr_if, link_type));
+		dplane_ctx_set_ifp_protodown_set(ctx, false);
+
+		if (mac)
+			dplane_ctx_set_ifp_hw_addr(ctx, sizeof(struct rte_ether_addr),
+						   (uint8_t *)mac);
+
+		/* Extract and save L2 interface information, take
+		 * additional actions.
+		 */
+		if (gr_vlan) {
+			struct zebra_l2info_vlan vlan_info = {};
+
+			vlan_info.vid = gr_vlan->vlan_id;
+			dplane_ctx_set_ifp_vlan_info(ctx, &vlan_info);
+		}
+	} else {
+		dplane_ctx_set_op(ctx, DPLANE_OP_INTF_DELETE);
+		dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_QUEUED);
+	}
+
+	dplane_provider_enqueue_to_zebra(ctx);
+}
+
+void grout_interface_addr_dplane(struct gr_nexthop *gr_nh, bool new)
+{
+	struct zebra_dplane_ctx *ctx = dplane_ctx_alloc();
+	struct prefix p = {};
+
+	if (gr_nh->vrf_id != 0) {
+		gr_log_err("VRF are not supported");
+		dplane_ctx_fini(&ctx);
+		return;
+	}
+
+	if (new)
+		dplane_ctx_set_op(ctx, DPLANE_OP_INTF_ADDR_ADD);
+	else
+		dplane_ctx_set_op(ctx, DPLANE_OP_INTF_ADDR_DEL);
+
+	dplane_ctx_set_ifindex(ctx, gr_nh->iface_id + GROUT_INDEX_OFFSET);
+	dplane_ctx_set_ns_id(ctx, GROUT_NS);
+
+	/* Convert addr to prefix */
+	p.prefixlen = gr_nh->prefixlen;
+	if (gr_nh->type == GR_NH_IPV4) {
+		p.family = AF_INET;
+		p.u.prefix4 = *(struct in_addr *)&gr_nh->ipv4;
+	} else {
+		p.family = AF_INET6;
+		p.u.prefix6 = *(struct in6_addr *)&gr_nh->ipv6;
+	}
+	dplane_ctx_set_intf_addr(ctx, &p);
+	dplane_ctx_set_intf_metric(ctx, METRIC_MAX);
+
+	/* Enqueue ctx for main pthread to process */
+	dplane_provider_enqueue_to_zebra(ctx);
+}
+
+enum zebra_dplane_result grout_add_del_address(struct zebra_dplane_ctx *ctx)
+{
+	int gr_iface_id = dplane_ctx_get_ifindex(ctx) - GROUT_INDEX_OFFSET;
+	const struct prefix *p = dplane_ctx_get_intf_addr(ctx);
+	union {
+		struct gr_ip4_addr_add_req ip4_add;
+		struct gr_ip4_addr_del_req ip4_del;
+		struct gr_ip6_addr_add_req ip6_add;
+		struct gr_ip6_addr_del_req ip6_del;
+	} req;
+	uint32_t req_type;
+	size_t req_len;
+
+	if (dplane_ctx_get_vrf(ctx) != 0) {
+		gr_log_err("impossible to add/del address on vrf %u (vrf not supported)",
+			   dplane_ctx_get_vrf(ctx));
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
+	}
+
+	if (p->family != AF_INET && p->family != AF_INET6) {
+		gr_log_err("impossible to add/del address with family %u (not supported)",
+			   p->family);
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
+	}
+
+	if (p->family == AF_INET) {
+		struct gr_ip4_ifaddr *ip4_addr;
+
+		if (dplane_ctx_get_op(ctx) == DPLANE_OP_ADDR_INSTALL) {
+			req.ip4_add = (struct gr_ip4_addr_add_req){ .exist_ok = true };
+
+			req_type = GR_IP4_ADDR_ADD;
+			req_len = sizeof(struct gr_ip4_addr_add_req);
+
+			ip4_addr = &req.ip4_add.addr;
+		} else {
+			req.ip4_del = (struct gr_ip4_addr_del_req){ .missing_ok = true };
+
+			req_type = GR_IP4_ADDR_DEL;
+			req_len = sizeof(struct gr_ip4_addr_del_req);
+
+			ip4_addr = &req.ip4_del.addr;
+		}
+
+		ip4_addr->addr.ip = p->u.prefix4.s_addr;
+		ip4_addr->addr.prefixlen = p->prefixlen;
+		ip4_addr->iface_id = gr_iface_id;
+	} else {
+		struct gr_ip6_ifaddr *ip6_addr;
+
+		if (dplane_ctx_get_op(ctx) == DPLANE_OP_ADDR_INSTALL) {
+			req.ip6_add = (struct gr_ip6_addr_add_req){ .exist_ok = true };
+
+			req_type = GR_IP6_ADDR_ADD;
+			req_len = sizeof(struct gr_ip6_addr_add_req);
+
+			ip6_addr = &req.ip6_add.addr;
+		} else {
+			req.ip6_del = (struct gr_ip6_addr_del_req){ .missing_ok = true };
+
+			req_type = GR_IP6_ADDR_DEL;
+			req_len = sizeof(struct gr_ip6_addr_del_req);
+
+			ip6_addr = &req.ip6_del.addr;
+		}
+
+		memcpy(ip6_addr->addr.ip.a, p->u.prefix6.s6_addr, sizeof(ip6_addr->addr.ip.a));
+		ip6_addr->addr.prefixlen = p->prefixlen;
+		ip6_addr->iface_id = gr_iface_id;
+	}
+
+	if (grout_client_send_recv(req_type, req_len, &req, NULL) < 0)
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
+
+	return ZEBRA_DPLANE_REQUEST_SUCCESS;
+}

--- a/zebra/grout/if_grout.h
+++ b/zebra/grout/if_grout.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Grout Interface
+ *
+ * Copyright (C) 2025 Free Mobile
+ * Maxime Leroy
+ */
+#ifndef _IF_GROUT_H
+#define _IF_GROUT_H
+
+#include <gr_infra.h>
+#include <gr_nexthop.h>
+
+#include "zebra/zebra_dplane.h"
+
+enum zebra_dplane_result grout_add_del_address(struct zebra_dplane_ctx *ctx);
+
+void grout_interface_addr_dplane(struct gr_nexthop *gr_nh, bool new);
+void grout_link_change(struct gr_iface *gr_if, bool new, bool startup);
+
+#endif /* _IF_GROUT_H */

--- a/zebra/grout/log_grout.h
+++ b/zebra/grout/log_grout.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Grout Log helper
+ *
+ * Copyright (C) 2025 Free Mobile
+ * Maxime Leroy
+ */
+
+#ifndef _LOG_GROUT_H
+#define _LOG_GROUT_H
+
+#include "lib/zlog.h"
+#include "zebra/debug.h"
+
+#define gr_log(priority, fmt, ...) zlog(priority, "GROUT: " fmt, ##__VA_ARGS__)
+#define gr_log_err(fmt, ...)	   gr_log(LOG_ERR, fmt, ##__VA_ARGS__)
+#define gr_log_debug(fmt, ...)                                                                     \
+	do {                                                                                       \
+		if (IS_ZEBRA_DEBUG_DPLANE_GROUT)                                                   \
+			gr_log(LOG_DEBUG, "%s: " fmt, __func__, ##__VA_ARGS__);                    \
+	} while (0)
+
+#endif /* _LOG_GROUT_H */

--- a/zebra/grout/rt_grout.c
+++ b/zebra/grout/rt_grout.c
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Grout routing tables
+ *
+ * Copyright (c) 2025 Maxime Leroy, Free Mobile
+ */
+
+#include "zebra/rib.h"
+#include "zebra/table_manager.h"
+
+#include "log_grout.h"
+#include "zebra_dplane_grout.h"
+#include "rt_grout.h"
+
+static inline bool is_selfroute(gr_rt_origin_t origin)
+{
+	switch (origin) {
+	case GR_RT_ORIGIN_ZEBRA:
+	case GR_RT_ORIGIN_BABEL:
+	case GR_RT_ORIGIN_BGP:
+	case GR_RT_ORIGIN_ISIS:
+	case GR_RT_ORIGIN_OSPF:
+	case GR_RT_ORIGIN_RIP:
+	case GR_RT_ORIGIN_RIPNG:
+	case GR_RT_ORIGIN_NHRP:
+	case GR_RT_ORIGIN_EIGRP:
+	case GR_RT_ORIGIN_LDP:
+	case GR_RT_ORIGIN_SHARP:
+	case GR_RT_ORIGIN_PBR:
+	case GR_RT_ORIGIN_ZSTATIC:
+	case GR_RT_ORIGIN_OPENFABRIC:
+	case GR_RT_ORIGIN_SRTE:
+		return true;
+	default:
+		return false;
+	}
+}
+
+gr_rt_origin_t zebra2origin(int proto)
+{
+	gr_rt_origin_t origin;
+
+	switch (proto) {
+	case ZEBRA_ROUTE_BABEL:
+		origin = GR_RT_ORIGIN_BABEL;
+		break;
+	case ZEBRA_ROUTE_BGP:
+		origin = GR_RT_ORIGIN_BGP;
+		break;
+	case ZEBRA_ROUTE_OSPF:
+	case ZEBRA_ROUTE_OSPF6:
+		origin = GR_RT_ORIGIN_OSPF;
+		break;
+	case ZEBRA_ROUTE_STATIC:
+		origin = GR_RT_ORIGIN_ZSTATIC;
+		break;
+	case ZEBRA_ROUTE_ISIS:
+		origin = GR_RT_ORIGIN_ISIS;
+		break;
+	case ZEBRA_ROUTE_RIP:
+		origin = GR_RT_ORIGIN_RIP;
+		break;
+	case ZEBRA_ROUTE_RIPNG:
+		origin = GR_RT_ORIGIN_RIPNG;
+		break;
+	case ZEBRA_ROUTE_NHRP:
+		origin = GR_RT_ORIGIN_NHRP;
+		break;
+	case ZEBRA_ROUTE_EIGRP:
+		origin = GR_RT_ORIGIN_EIGRP;
+		break;
+	case ZEBRA_ROUTE_LDP:
+		origin = GR_RT_ORIGIN_LDP;
+		break;
+	case ZEBRA_ROUTE_SHARP:
+		origin = GR_RT_ORIGIN_SHARP;
+		break;
+	case ZEBRA_ROUTE_PBR:
+		origin = GR_RT_ORIGIN_PBR;
+		break;
+	case ZEBRA_ROUTE_OPENFABRIC:
+		origin = GR_RT_ORIGIN_OPENFABRIC;
+		break;
+	case ZEBRA_ROUTE_SRTE:
+		origin = GR_RT_ORIGIN_SRTE;
+		break;
+	case ZEBRA_ROUTE_TABLE:
+	case ZEBRA_ROUTE_NHG:
+		origin = GR_RT_ORIGIN_ZEBRA;
+		break;
+	case ZEBRA_ROUTE_CONNECT:
+	case ZEBRA_ROUTE_LOCAL:
+	case ZEBRA_ROUTE_KERNEL:
+		origin = GR_RT_ORIGIN_LINK;
+		break;
+	default:
+		/*
+		 * When a user adds a new protocol this will show up
+		 * to let them know to do something about it.  This
+		 * is intentionally a warn because we should see
+		 * this as part of development of a new protocol
+		 */
+		gr_log_debug("Please add this protocol(%d) to grout", proto);
+		origin = GR_RT_ORIGIN_ZEBRA;
+		break;
+	}
+
+	return origin;
+}
+
+static inline int origin2zebra(gr_rt_origin_t origin, int family, bool is_nexthop)
+{
+	int proto;
+
+	switch (origin) {
+	case GR_RT_ORIGIN_BABEL:
+		proto = ZEBRA_ROUTE_BABEL;
+		break;
+	case GR_RT_ORIGIN_BGP:
+		proto = ZEBRA_ROUTE_BGP;
+		break;
+	case GR_RT_ORIGIN_OSPF:
+		proto = (family == AF_INET) ? ZEBRA_ROUTE_OSPF : ZEBRA_ROUTE_OSPF6;
+		break;
+	case GR_RT_ORIGIN_ISIS:
+		proto = ZEBRA_ROUTE_ISIS;
+		break;
+	case GR_RT_ORIGIN_RIP:
+		proto = ZEBRA_ROUTE_RIP;
+		break;
+	case GR_RT_ORIGIN_RIPNG:
+		proto = ZEBRA_ROUTE_RIPNG;
+		break;
+	case GR_RT_ORIGIN_NHRP:
+		proto = ZEBRA_ROUTE_NHRP;
+		break;
+	case GR_RT_ORIGIN_EIGRP:
+		proto = ZEBRA_ROUTE_EIGRP;
+		break;
+	case GR_RT_ORIGIN_LDP:
+		proto = ZEBRA_ROUTE_LDP;
+		break;
+	case GR_RT_ORIGIN_ZSTATIC:
+		proto = ZEBRA_ROUTE_STATIC;
+		break;
+	case GR_RT_ORIGIN_SHARP:
+		proto = ZEBRA_ROUTE_SHARP;
+		break;
+	case GR_RT_ORIGIN_PBR:
+		proto = ZEBRA_ROUTE_PBR;
+		break;
+	case GR_RT_ORIGIN_OPENFABRIC:
+		proto = ZEBRA_ROUTE_OPENFABRIC;
+		break;
+	case GR_RT_ORIGIN_SRTE:
+		proto = ZEBRA_ROUTE_SRTE;
+		break;
+	case GR_RT_ORIGIN_USER:
+	case GR_RT_ORIGIN_UNSPEC:
+	case GR_RT_ORIGIN_REDIRECT:
+	case GR_RT_ORIGIN_LINK:
+	case GR_RT_ORIGIN_BOOT:
+	case GR_RT_ORIGIN_GATED:
+	case GR_RT_ORIGIN_RA:
+	case GR_RT_ORIGIN_MRT:
+	case GR_RT_ORIGIN_BIRD:
+	case GR_RT_ORIGIN_DNROUTED:
+	case GR_RT_ORIGIN_XORP:
+	case GR_RT_ORIGIN_NTK:
+	case GR_RT_ORIGIN_MROUTED:
+	case GR_RT_ORIGIN_KEEPALIVED:
+	case GR_RT_ORIGIN_OPENR:
+		proto = ZEBRA_ROUTE_KERNEL;
+		break;
+	case GR_RT_ORIGIN_ZEBRA:
+		if (is_nexthop) {
+			proto = ZEBRA_ROUTE_NHG;
+			break;
+		}
+		proto = ZEBRA_ROUTE_KERNEL;
+		break;
+	default:
+		/*
+		 * When a user adds a new protocol this will show up
+		 * to let them know to do something about it.  This
+		 * is intentionally a warn because we should see
+		 * this as part of development of a new protocol
+		 */
+		gr_log_debug("Please add this protocol(%d) to grout", proto);
+		proto = ZEBRA_ROUTE_KERNEL;
+		break;
+	}
+	return proto;
+}
+
+static void grout_route_change(bool new, uint16_t vrf_id, gr_rt_origin_t origin, uint16_t family,
+			       void *nh_addr, void *dest_addr, uint8_t dest_prefixlen)
+{
+	int tableid = RT_TABLE_ID_MAIN; /* no table support for now */
+	int proto = ZEBRA_ROUTE_KERNEL;
+	struct nexthop nh = {};
+	uint32_t flags = 0;
+	struct prefix p;
+	bool selfroute;
+	int index = 0;
+	size_t sz;
+	afi_t afi;
+
+	if (vrf_id != VRF_DEFAULT) {
+		gr_log_debug("no vrf support for route, route not sync");
+		return;
+	}
+
+	if (family == AF_INET)
+		gr_log_debug("get notifcation '%s route %pI4/%u (origin %s)'", new ? "add" : "del",
+			     dest_addr, dest_prefixlen, gr_rt_origin_name(origin));
+	else
+		gr_log_debug("get notifcation '%s route %pI6/%u (origin %s)'", new ? "add" : "del",
+			     dest_addr, dest_prefixlen, gr_rt_origin_name(origin));
+
+	if (new && is_selfroute(origin)) {
+		gr_log_debug("'%s' route received that we think we have originated, ignoring",
+			     gr_rt_origin_name(origin));
+		return;
+	}
+
+	if (origin == GR_RT_ORIGIN_LINK) {
+		gr_log_debug("'%s' route intentionally ignoring", gr_rt_origin_name(origin));
+		return;
+	}
+
+	/* A method to ignore our own messages. selfroute ? */
+	memset(&nh, 0, sizeof(nh));
+	nh.vrf_id = VRF_DEFAULT;
+
+	if (family == AF_INET) {
+		afi = AFI_IP;
+		p.family = AF_INET;
+		sz = 4;
+
+		memcpy(&p.u.prefix4, dest_addr, sz);
+		p.prefixlen = dest_prefixlen;
+
+		/* FIX IFINDEX CASE */
+		nh.type = NEXTHOP_TYPE_IPV4;
+		memcpy(&nh.gate.ipv4, nh_addr, sz);
+	} else {
+		afi = AFI_IP6;
+		p.family = AF_INET6;
+		sz = 16;
+
+		memcpy(&p.u.prefix6, dest_addr, sz);
+		p.prefixlen = dest_prefixlen;
+
+		/* FIX IFINDEX CASE */
+		nh.type = NEXTHOP_TYPE_IPV6;
+		memcpy(&nh.gate.ipv6, nh_addr, sz);
+	}
+
+	proto = origin2zebra(origin, family, false);
+
+	if (new)
+		rib_add(afi, SAFI_UNICAST, VRF_DEFAULT, proto, 0, flags, &p, NULL, &nh, 0, tableid,
+			0, 0, 0, 0, false);
+	else
+		rib_delete(afi, SAFI_UNICAST, VRF_DEFAULT, proto, 0, flags, &p, NULL, &nh, 0,
+			   tableid, 0, 0, true);
+}
+
+void grout_route4_change(bool new, struct gr_ip4_route *gr_r4)
+{
+	grout_route_change(new, gr_r4->vrf_id, gr_r4->origin, AF_INET, (void *)&gr_r4->nh,
+			   (void *)&gr_r4->dest.ip, gr_r4->dest.prefixlen);
+}
+
+void grout_route6_change(bool new, struct gr_ip6_route *gr_r6)
+{
+	grout_route_change(new, gr_r6->vrf_id, gr_r6->origin, AF_INET6, (void *)&gr_r6->nh,
+			   (void *)&gr_r6->dest.ip, gr_r6->dest.prefixlen);
+}
+
+enum zebra_dplane_result grout_add_del_route(struct zebra_dplane_ctx *ctx)
+{
+	union {
+		struct gr_ip4_route_add_req r4_add;
+		struct gr_ip4_route_del_req r4_del;
+		struct gr_ip6_route_add_req r6_add;
+		struct gr_ip6_route_del_req r6_del;
+	} req;
+	const struct nexthop_group *ng;
+	enum nexthop_types_t nt = 0;
+	const struct prefix *p;
+	gr_rt_origin_t origin;
+	uint32_t req_type;
+	size_t req_len;
+	bool new;
+
+	if (dplane_ctx_get_vrf(ctx) != 0) {
+		gr_log_err("impossssible to add/del route on vrf %u (vrf not supported)",
+			   dplane_ctx_get_vrf(ctx));
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
+	}
+
+	p = dplane_ctx_get_dest(ctx);
+	if (p->family != AF_INET && p->family != AF_INET6) {
+		gr_log_err("impossssible to add/del route with family %u (not supported)",
+			   p->family);
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
+	}
+	if (dplane_ctx_get_src(ctx) != NULL) {
+		gr_log_err("impossssible to add/del route with src (not supported)");
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
+	}
+	ng = dplane_ctx_get_ng(ctx);
+	if (nexthop_group_nexthop_num(ng) > 1) {
+		gr_log_err("impossssible to add/del route with several nexthop (not supported)");
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
+	}
+	if (nexthop_group_nexthop_num(ng) == 0) {
+		gr_log_err("impossssible to add/del route with no nexthop (not supported)");
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
+	}
+	nt = ng->nexthop->type;
+	if (nt == NEXTHOP_TYPE_BLACKHOLE) {
+		gr_log_err("impossssible to add/del route with nexthope type = %u (not supported)",
+			   nt);
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
+	}
+	/* TODO: other check for metric, distance, and so-on */
+
+	origin = zebra2origin(dplane_ctx_get_type(ctx));
+	new = dplane_ctx_get_op(ctx) != DPLANE_OP_ROUTE_DELETE;
+	if (p->family == AF_INET) {
+		struct ip4_net *dest;
+
+		if (nt == NEXTHOP_TYPE_IPV6 || nt == NEXTHOP_TYPE_IPV6_IFINDEX) {
+			gr_log_err("impossssible to add/del ipv4 route with nexthope type = %u (not supported)",
+				   nt);
+			return ZEBRA_DPLANE_REQUEST_FAILURE;
+		}
+
+		if (new) {
+			req.r4_add = (struct gr_ip4_route_add_req){ .exist_ok = true, .vrf_id = 0 };
+
+			req_type = GR_IP4_ROUTE_ADD;
+			req_len = sizeof(struct gr_ip4_route_add_req);
+
+			if (nt == NEXTHOP_TYPE_IFINDEX || nt == NEXTHOP_TYPE_IPV4_IFINDEX)
+				/* TOFIX with next API in grout */
+				req.r4_add.nh = p->u.prefix4.s_addr;
+			if (nt == NEXTHOP_TYPE_IPV4 || nt == NEXTHOP_TYPE_IPV4_IFINDEX)
+				req.r4_add.nh = ng->nexthop->gate.ipv4.s_addr;
+			req.r4_add.origin = origin;
+			dest = &req.r4_add.dest;
+		} else {
+			req.r4_del = (struct gr_ip4_route_del_req){ .missing_ok = true,
+								    .vrf_id = 0 };
+			req_type = GR_IP4_ROUTE_DEL;
+			req_len = sizeof(struct gr_ip4_route_del_req);
+
+			dest = &req.r4_del.dest;
+			new = false;
+		}
+
+		dest->ip = p->u.prefix4.s_addr;
+		dest->prefixlen = p->prefixlen;
+
+		gr_log_debug("%s route %pI4/%u (origin %s)", new ? "add" : "del", &dest->ip,
+			     dest->prefixlen, gr_rt_origin_name(origin));
+	} else {
+		struct ip6_net *dest;
+
+		if (nt == NEXTHOP_TYPE_IPV4 || nt == NEXTHOP_TYPE_IPV4_IFINDEX) {
+			gr_log_err("impossssible to add/del ipv6 route with nexthope type = %u (not supported)",
+				   nt);
+			return ZEBRA_DPLANE_REQUEST_FAILURE;
+		}
+
+		if (new) {
+			req.r6_add = (struct gr_ip6_route_add_req){ .exist_ok = true, .vrf_id = 0 };
+
+			req_type = GR_IP6_ROUTE_ADD;
+			req_len = sizeof(struct gr_ip6_route_add_req);
+
+			if (nt == NEXTHOP_TYPE_IFINDEX || nt == NEXTHOP_TYPE_IPV6_IFINDEX)
+				/* TOFIX with next API in grout */
+				memcpy(req.r6_add.nh.a, p->u.prefix6.s6_addr,
+				       sizeof(req.r6_add.nh));
+			req.r4_add.nh = p->u.prefix4.s_addr;
+			if (nt == NEXTHOP_TYPE_IPV6 || nt == NEXTHOP_TYPE_IPV6_IFINDEX)
+				memcpy(req.r6_add.nh.a, ng->nexthop->gate.ipv6.s6_addr,
+				       sizeof(req.r6_add.nh));
+			req.r6_add.origin = origin;
+			dest = &req.r6_add.dest;
+		} else {
+			req.r6_del = (struct gr_ip6_route_del_req){ .missing_ok = true,
+								    .vrf_id = 0 };
+
+			req_type = GR_IP6_ROUTE_ADD;
+			req_len = sizeof(struct gr_ip6_route_add_req);
+
+			dest = &req.r6_del.dest;
+			new = false;
+		}
+
+		memcpy(dest->ip.a, p->u.prefix6.s6_addr, sizeof(dest->ip.a));
+		dest->prefixlen = p->prefixlen;
+
+		gr_log_debug("%s route %pI6/%u (origin %s)", new ? "add" : "del", &dest->ip,
+			     dest->prefixlen, gr_rt_origin_name(origin));
+	}
+
+	if (!is_selfroute(origin)) {
+		gr_log_debug("no frr route, skip it");
+		return ZEBRA_DPLANE_REQUEST_SUCCESS;
+	}
+
+	if (grout_client_send_recv(req_type, req_len, &req, NULL) < 0)
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
+
+	return ZEBRA_DPLANE_REQUEST_SUCCESS;
+}

--- a/zebra/grout/rt_grout.h
+++ b/zebra/grout/rt_grout.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Grout routing tables
+ *
+ * Copyright (C) 2025 Free Mobile
+ * Maxime Leroy
+ */
+#ifndef _RT_GROUT_H
+#define _RT_GROUT_H
+
+#include <gr_ip4.h>
+#include <gr_ip6.h>
+
+#include "zebra/zebra_dplane.h"
+
+void grout_route4_change(bool new, struct gr_ip4_route *gr_r4);
+void grout_route6_change(bool new, struct gr_ip6_route *gr_r6);
+enum zebra_dplane_result grout_add_del_route(struct zebra_dplane_ctx *ctx);
+
+#endif /* _RT_GROUT_H */

--- a/zebra/grout/zebra_dplane_grout.c
+++ b/zebra/grout/zebra_dplane_grout.c
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Zebra dataplane plugin for Grout
+ *
+ * Copyright (c) 2024 Christophe Fontaine, Red Hat
+ * Copyright (c) 2025 Maxime Leroy, Free Mobile
+ */
+#include <gr_api_client_impl.h>
+
+#include "lib/libfrr.h"
+#include "lib/frr_pthread.h"
+
+#include "zebra/zebra_dplane.h"
+#include "zebra/zebra_router.h"
+
+#include "log_grout.h"
+#include "rt_grout.h"
+#include "if_grout.h"
+#include "zebra_dplane_grout.h"
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+#define TOSTRING(x)   #x
+
+struct grout_ctx_t {
+	struct gr_api_client *client;
+	struct gr_api_client *dplane_notifs;
+	struct gr_api_client *zebra_notifs;
+
+	/* Event/'thread' pointer for queued updates */
+	struct event *dg_t_zebra_update;
+	struct event *dg_t_dplane_update;
+};
+
+struct grout_ctx_t grout_ctx = { 0 };
+static const char *plugin_name = "zebra_dplane_grout";
+
+static void dplane_read_notifications(struct event *event);
+static void zebra_read_notifications(struct event *event);
+static void zd_grout_port_sync(void);
+
+static int grout_notif_subscribe(struct gr_api_client **pgr_client, uint32_t *ev_types,
+				 unsigned int nb_ev_types)
+{
+	struct gr_event_subscribe_req req;
+	unsigned int i;
+
+	*pgr_client = gr_api_client_connect(GR_DEFAULT_SOCK_PATH);
+	if (*pgr_client == NULL)
+		return -1;
+
+	for (i = 0; i < nb_ev_types; i++) {
+		req.ev_type = ev_types[i];
+
+		if (gr_api_client_send_recv(*pgr_client, GR_MAIN_EVENT_SUBSCRIBE, sizeof(req), &req,
+					    NULL) < 0) {
+			gr_api_client_disconnect(*pgr_client);
+			*pgr_client = NULL;
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+static void dplane_grout_connect(struct event *t)
+{
+	struct event_loop *dg_master = dplane_get_thread_master();
+	uint32_t ev_types[] = { GR_EVENT_IFACE_POST_ADD,    GR_EVENT_IFACE_STATUS_UP,
+				GR_EVENT_IFACE_STATUS_DOWN, GR_EVENT_IFACE_POST_RECONFIG,
+				GR_EVENT_IFACE_PRE_REMOVE,  GR_EVENT_IP_ADDR_ADD,
+				GR_EVENT_IP6_ADDR_ADD,	    GR_EVENT_IP_ADDR_DEL,
+				GR_EVENT_IP6_ADDR_DEL };
+
+	if (grout_notif_subscribe(&grout_ctx.dplane_notifs, ev_types, ARRAY_SIZE(ev_types)) < 0)
+		goto reschedule_connect;
+
+	event_add_read(dg_master, dplane_read_notifications, NULL, grout_ctx.dplane_notifs->sock_fd,
+		       &grout_ctx.dg_t_dplane_update);
+
+	return;
+
+reschedule_connect:
+	event_add_timer(dg_master, dplane_grout_connect, NULL, 1, &grout_ctx.dg_t_dplane_update);
+}
+
+static void zebra_grout_connect(struct event *t)
+{
+	uint32_t ev_types[] = {
+		GR_EVENT_IP_ROUTE_ADD,
+		GR_EVENT_IP_ROUTE_DEL,
+	};
+
+	if (grout_notif_subscribe(&grout_ctx.zebra_notifs, ev_types, ARRAY_SIZE(ev_types)) < 0)
+		goto reschedule_connect;
+
+	event_add_read(zrouter.master, zebra_read_notifications, NULL,
+		       grout_ctx.zebra_notifs->sock_fd, &grout_ctx.dg_t_zebra_update);
+	return;
+
+reschedule_connect:
+	event_add_timer(zrouter.master, zebra_grout_connect, NULL, 1, &grout_ctx.dg_t_zebra_update);
+}
+
+static const char *gr_req_type_to_str(uint32_t e)
+{
+	switch (e) {
+	case GR_IP4_ADDR_ADD:
+		return TOSTRING(GR_IP4_ADDR_ADD);
+	case GR_IP4_ADDR_DEL:
+		return TOSTRING(GR_IP4_ADDR_DEL);
+	case GR_IP6_ADDR_ADD:
+		return TOSTRING(GR_IP6_ADDR_ADD);
+	case GR_IP6_ADDR_DEL:
+		return TOSTRING(GR_IP6_ADDR_DEL);
+	case GR_IP4_ROUTE_ADD:
+		return TOSTRING(GR_IP4_ROUTE_ADD);
+	case GR_IP4_ROUTE_DEL:
+		return TOSTRING(GR_IP4_ROUTE_DEL);
+	case GR_IP6_ROUTE_ADD:
+		return TOSTRING(GR_IP6_ROUTE_ADD);
+	case GR_IP6_ROUTE_DEL:
+		return TOSTRING(GR_IP6_ROUTE_DEL);
+	default:
+		return "unknown";
+	}
+}
+
+int grout_client_send_recv(uint32_t req_type, size_t tx_len, const void *tx_data, void **rx_data)
+{
+	bool first = true;
+	int ret;
+
+retry:
+	ret = gr_api_client_send_recv(grout_ctx.client, req_type, tx_len, tx_data, rx_data);
+	if (!first || ret == 0) {
+		if (ret < 0)
+			gr_log_err("'%s' request has failed (errno=%s)",
+				   gr_req_type_to_str(req_type), strerror(errno));
+		else
+			gr_log_debug("'%s' request has success", gr_req_type_to_str(req_type));
+
+		return ret;
+	}
+
+	if (!grout_ctx.client || errno == ECONNRESET || errno == EPIPE || errno == ENOTCONN) {
+		if (grout_ctx.client) {
+			gr_api_client_disconnect(grout_ctx.client);
+			grout_ctx.client = NULL;
+		}
+
+		grout_ctx.client = gr_api_client_connect(GR_DEFAULT_SOCK_PATH);
+		if (!grout_ctx.client) {
+			gr_log_debug("connect failed on grout sock for '%s' request",
+				     gr_req_type_to_str(req_type));
+			return -1;
+		}
+
+		first = false;
+		goto retry;
+	}
+
+	return ret;
+}
+
+static const char *gr_evt_to_str(uint32_t e)
+{
+	switch (e) {
+	case GR_EVENT_IFACE_POST_ADD:
+		return TOSTRING(GR_EVENT_IFACE_POST_ADD);
+	case GR_EVENT_IFACE_PRE_REMOVE:
+		return TOSTRING(GR_EVENT_IFACE_PRE_REMOVE);
+	case GR_EVENT_IFACE_STATUS_UP:
+		return TOSTRING(GR_EVENT_IFACE_STATUS_UP);
+	case GR_EVENT_IFACE_STATUS_DOWN:
+		return TOSTRING(GR_EVENT_IFACE_STATUS_DOWN);
+	case GR_EVENT_IFACE_POST_RECONFIG:
+		return TOSTRING(GR_EVENT_IFACE_POST_RECONFIG);
+	case GR_EVENT_IP_ADDR_ADD:
+		return TOSTRING(GR_EVENT_IP_ADDR_ADD);
+	case GR_EVENT_IP_ADDR_DEL:
+		return TOSTRING(GR_EVENT_IP_ADDR_DEL);
+	case GR_EVENT_IP6_ADDR_ADD:
+		return TOSTRING(GR_EVENT_IP6_ADDR_ADD);
+	case GR_EVENT_IP6_ADDR_DEL:
+		return TOSTRING(GR_EVENT_IP6_ADDR_DEL);
+	default:
+		return "unknown";
+	}
+}
+
+static void dplane_read_notifications(struct event *event)
+{
+	struct event_loop *dg_master = dplane_get_thread_master();
+	struct gr_infra_iface_get_resp *gr_p;
+	struct gr_api_event *gr_e = NULL;
+	struct gr_nexthop *gr_nh;
+	struct interface *iface;
+	bool new = false;
+	int ret;
+
+	if (gr_api_client_event_recv(grout_ctx.dplane_notifs, &gr_e) < 0 || gr_e == NULL) {
+		/* On any error, reconnect */
+		gr_api_client_disconnect(grout_ctx.dplane_notifs);
+		grout_ctx.dplane_notifs = NULL;
+		event_add_timer(dg_master, dplane_grout_connect, NULL, 1,
+				&grout_ctx.dg_t_dplane_update);
+		return;
+	}
+
+	switch (gr_e->ev_type) {
+	case GR_EVENT_IFACE_POST_ADD:
+	case GR_EVENT_IFACE_STATUS_UP:
+	case GR_EVENT_IFACE_STATUS_DOWN:
+	case GR_EVENT_IFACE_POST_RECONFIG:
+		new = true;
+	case GR_EVENT_IFACE_PRE_REMOVE:
+		gr_p = PAYLOAD(gr_e);
+
+		gr_log_debug("%s iface %s notification (%s)", new ? "add" : "del", gr_p->iface.name,
+			     gr_evt_to_str(gr_e->ev_type));
+
+		grout_link_change(&gr_p->iface, new, false);
+		break;
+	case GR_EVENT_IP_ADDR_ADD:
+	case GR_EVENT_IP6_ADDR_ADD:
+		new = true;
+	case GR_EVENT_IP_ADDR_DEL:
+	case GR_EVENT_IP6_ADDR_DEL:
+		gr_nh = PAYLOAD(gr_e);
+
+		if (gr_nh->type == GR_NH_IPV4)
+			gr_log_debug("%s addr %pI4 notification (%s)", new ? "add" : "del",
+				     &gr_nh->ipv4, gr_evt_to_str(gr_e->ev_type));
+		else
+			gr_log_debug("%s addr %pI6 notification (%s)", new ? "add" : "del",
+				     &gr_nh->ipv6, gr_evt_to_str(gr_e->ev_type));
+
+		grout_interface_addr_dplane(gr_nh, new);
+		break;
+	default:
+		gr_log_debug("Unknown notification %s (0x%x) received",
+			     gr_evt_to_str(gr_e->ev_type), gr_e->ev_type);
+		break;
+	}
+
+	free(gr_e);
+
+	event_add_read(dg_master, dplane_read_notifications, NULL, grout_ctx.dplane_notifs->sock_fd,
+		       &grout_ctx.dg_t_dplane_update);
+}
+
+static void zebra_read_notifications(struct event *event)
+{
+	struct gr_infra_iface_get_resp *gr_p;
+	struct gr_api_event *gr_e = NULL;
+	struct gr_ip4_route *gr_r4;
+	struct gr_ip6_route *gr_r6;
+	struct interface *iface;
+	bool new = false;
+	int ret;
+
+	if (gr_api_client_event_recv(grout_ctx.zebra_notifs, &gr_e) < 0 || gr_e == NULL) {
+		/* On any error, reconnect */
+		gr_api_client_disconnect(grout_ctx.zebra_notifs);
+		grout_ctx.zebra_notifs = NULL;
+		event_add_timer(zrouter.master, zebra_grout_connect, NULL, 1,
+				&grout_ctx.dg_t_zebra_update);
+		return;
+	}
+
+	switch (gr_e->ev_type) {
+	case GR_EVENT_IP_ROUTE_ADD:
+		new = true;
+	case GR_EVENT_IP_ROUTE_DEL:
+		gr_r4 = PAYLOAD(gr_e);
+
+		gr_log_debug("%s route %pI4/%u notification (%s)", new ? "add" : "del",
+			     &gr_r4->dest.ip, gr_r4->dest.prefixlen, gr_evt_to_str(gr_e->ev_type));
+
+		grout_route4_change(new, gr_r4);
+		break;
+	case GR_EVENT_IP6_ROUTE_ADD:
+		new = true;
+	case GR_EVENT_IP6_ROUTE_DEL:
+		gr_r6 = PAYLOAD(gr_e);
+
+		gr_log_debug("%s route %pI6/%u notification (%s)", new ? "add" : "del",
+			     &gr_r6->dest.ip, gr_r6->dest.prefixlen, gr_evt_to_str(gr_e->ev_type));
+
+		grout_route6_change(new, gr_r6);
+		break;
+	default:
+		gr_log_debug("Unknown notification %s (0x%x) received",
+			     gr_evt_to_str(gr_e->ev_type), gr_e->ev_type);
+		break;
+	}
+
+	free(gr_e);
+
+	event_add_read(zrouter.master, zebra_read_notifications, NULL,
+		       grout_ctx.zebra_notifs->sock_fd, &grout_ctx.dg_t_zebra_update);
+}
+
+/* Grout provider callback. */
+static enum zebra_dplane_result zd_grout_process_update(struct zebra_dplane_ctx *ctx)
+{
+	switch (dplane_ctx_get_op(ctx)) {
+	case DPLANE_OP_ADDR_INSTALL:
+	case DPLANE_OP_ADDR_UNINSTALL:
+		return grout_add_del_address(ctx);
+
+	case DPLANE_OP_ROUTE_INSTALL:
+	case DPLANE_OP_ROUTE_UPDATE:
+	case DPLANE_OP_ROUTE_DELETE:
+		return grout_add_del_route(ctx);
+
+	case DPLANE_OP_NH_INSTALL:
+	case DPLANE_OP_NH_UPDATE:
+	case DPLANE_OP_NH_DELETE:
+		/* As netlink_put_nexthop_update_msg when kernel doesn't support nexthop objects. */
+		return ZEBRA_DPLANE_REQUEST_SUCCESS;
+
+	case DPLANE_OP_NONE:
+		return ZEBRA_DPLANE_REQUEST_SUCCESS;
+
+	default:
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
+	}
+}
+
+static int zd_grout_process(struct zebra_dplane_provider *prov)
+{
+	struct zebra_dplane_ctx *ctx;
+	enum zebra_dplane_result ret;
+	int counter, limit;
+
+	limit = dplane_provider_get_work_limit(prov);
+
+	for (counter = 0; counter < limit; counter++) {
+		ctx = dplane_provider_dequeue_in_ctx(prov);
+		if (ctx == NULL)
+			break;
+
+		gr_log_debug("dplane provider '%s': op %s", dplane_provider_get_name(prov),
+			     dplane_op2str(dplane_ctx_get_op(ctx)));
+		ret = zd_grout_process_update(ctx);
+		dplane_ctx_set_status(ctx, ret);
+		dplane_ctx_set_skip_kernel(ctx);
+		dplane_provider_enqueue_out_ctx(prov, ctx);
+	}
+
+	gr_log_debug("dplane provider '%s': processed %d", dplane_provider_get_name(prov), counter);
+
+	/* Ensure that we'll run the work loop again if there's still
+	 * more work to do.
+	 */
+	if (counter >= limit)
+		dplane_provider_work_ready();
+
+	return 0;
+}
+
+static int zd_grout_start(struct zebra_dplane_provider *prov)
+{
+	struct event_loop *dg_master = dplane_get_thread_master();
+
+	event_add_timer(dg_master, dplane_grout_connect, NULL, 1, NULL);
+	event_add_timer(zrouter.master, zebra_grout_connect, NULL, 1, NULL);
+
+	gr_log_debug("%s start", dplane_provider_get_name(prov));
+
+	return 0;
+}
+
+static int zd_grout_finish(struct zebra_dplane_provider *prov, bool early)
+{
+	event_cancel(&grout_ctx.dg_t_dplane_update);
+	event_cancel_async(zrouter.master, &grout_ctx.dg_t_zebra_update, NULL);
+
+	gr_api_client_disconnect(grout_ctx.client);
+	gr_api_client_disconnect(grout_ctx.dplane_notifs);
+	gr_api_client_disconnect(grout_ctx.zebra_notifs);
+	grout_ctx.dplane_notifs = NULL;
+	grout_ctx.zebra_notifs = NULL;
+	grout_ctx.client = NULL;
+	return 0;
+}
+
+static int zd_grout_plugin_init(struct event_loop *tm)
+{
+	int ret;
+
+	ret = dplane_provider_register(plugin_name, DPLANE_PRIO_PRE_KERNEL,
+				       DPLANE_PROV_FLAGS_DEFAULT, zd_grout_start, zd_grout_process,
+				       zd_grout_finish, &grout_ctx, NULL);
+
+	if (ret != 0)
+		gr_log_err("Unable to register grout dplane provider: %d", ret);
+
+	gr_log_debug("%s register status %d", plugin_name, ret);
+
+	return 0;
+}
+
+static int zd_grout_module_init(void)
+{
+	hook_register(frr_late_init, zd_grout_plugin_init);
+	return 0;
+}
+
+FRR_MODULE_SETUP(.name = "dplane_grout", .version = "0.0.1",
+		 .description = "Data plane plugin using grout",
+		 .init = zd_grout_module_init);

--- a/zebra/grout/zebra_dplane_grout.h
+++ b/zebra/grout/zebra_dplane_grout.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Zebra dataplane plugin for Grout
+ *
+ * Copyright (C) 2024 Red Hat
+ * Christophe Fontaine
+ */
+
+#ifndef _ZEBRA_DPLANE_GROUT_H
+#define _ZEBRA_DPLANE_GROUT_H
+
+#include <zebra.h>
+
+int grout_client_send_recv(uint32_t req_type, size_t tx_len, const void *tx_data, void **rx_data);
+
+#endif

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -266,3 +266,15 @@ zebra_zebra_dplane_dpdk_la_SOURCES = zebra/dpdk/zebra_dplane_dpdk.c zebra/dpdk/z
 zebra_zebra_dplane_dpdk_la_LDFLAGS = -avoid-version -module -shared -export-dynamic -L/usr/local/lib -v
 zebra_zebra_dplane_dpdk_la_CFLAGS = $(DPDK_CFLAGS)
 zebra_zebra_dplane_dpdk_la_LIBADD  = $(DPDK_LIBS)
+
+if DP_GROUT
+module_LTLIBRARIES += zebra/zebra_dplane_grout.la
+endif
+zebra_zebra_dplane_grout_la_SOURCES = \
+	zebra/grout/zebra_dplane_grout.c \
+	zebra/grout/rt_grout.c \
+	zebra/grout/if_grout.c \
+	# end
+zebra_zebra_dplane_grout_la_LDFLAGS = -avoid-version -module -shared -export-dynamic -L/usr/local/lib -v
+zebra_zebra_dplane_grout_la_CFLAGS = $(GROUT_CFLAGS) -I/usr/include/grout
+zebra_zebra_dplane_grout_la_LIBADD  = $(GROUT_LIBS)


### PR DESCRIPTION
This commit introduces an RFC-level dataplane plugin for Grout [1]  a high-performance, user-space L3 router built on top of DPDK [2]. It is not intended for merging at this stage — the primary goal is to gather feedback from the FRR community.

The plugin integrates Grout with FRR using the dplane plugin API. It supports:
- Synchronization of routes and addresses from FRR to Grout.
- Synchronization of interfaces, routes, and addresses from Grout to FRR.

Grout operates entirely in user space and does not rely on the Linux kernel's networking stack. Grout processes all ingress/egress traffic without involving the kernel.

Current Challenges:
- Netlink monitoring: There is currently no way to disable kernel netlink monitoring in FRR. As a result, Linux interfaces are still created in FRR, even when the Grout dataplane is active. This can lead to ifindex collisions between Linux and Grout interfaces. As a temporary workaround, we apply an hardcoded offset to Grout ifindexes to reduce the risk of conflict.
- Feature capability discovery: Unlike the Linux kernel, Grout may not support all expected features. It’s not yet clear if the dplane framework supports capability discovery mechanisms.

Any feedback or suggestions are welcome!

[1] https://github.com/DPDK/grout
[2] https://github.com/DPDK/dpdk
Signed-off-by: Christophe Fontaine <cfontain@redhat.com>
Signed-off-by: Maxime Leroy <maxime@leroys.fr>