### PR TITLE
ospf6d: Remove dead code

### DIFF
--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -603,90 +603,9 @@ void ospf6_zebra_delete_discard(struct ospf6_route *request,
 	}
 }
 
-static struct ospf6_distance *ospf6_distance_new(void)
-{
-	return XCALLOC(MTYPE_OSPF6_DISTANCE, sizeof(struct ospf6_distance));
-}
-
 static void ospf6_distance_free(struct ospf6_distance *odistance)
 {
 	XFREE(MTYPE_OSPF6_DISTANCE, odistance);
-}
-
-int ospf6_distance_set(struct vty *vty, struct ospf6 *o,
-		       const char *distance_str, const char *ip_str,
-		       const char *access_list_str)
-{
-	int ret;
-	struct prefix_ipv6 p;
-	uint8_t distance;
-	struct route_node *rn;
-	struct ospf6_distance *odistance;
-
-	ret = str2prefix_ipv6(ip_str, &p);
-	if (ret == 0) {
-		vty_out(vty, "Malformed prefix\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	distance = atoi(distance_str);
-
-	/* Get OSPF6 distance node. */
-	rn = route_node_get(o->distance_table, (struct prefix *)&p);
-	if (rn->info) {
-		odistance = rn->info;
-		route_unlock_node(rn);
-	} else {
-		odistance = ospf6_distance_new();
-		rn->info = odistance;
-	}
-
-	/* Set distance value. */
-	odistance->distance = distance;
-
-	/* Reset access-list configuration. */
-	if (odistance->access_list) {
-		free(odistance->access_list);
-		odistance->access_list = NULL;
-	}
-	if (access_list_str)
-		odistance->access_list = strdup(access_list_str);
-
-	return CMD_SUCCESS;
-}
-
-int ospf6_distance_unset(struct vty *vty, struct ospf6 *o,
-			 const char *distance_str, const char *ip_str,
-			 const char *access_list_str)
-{
-	int ret;
-	struct prefix_ipv6 p;
-	struct route_node *rn;
-	struct ospf6_distance *odistance;
-
-	ret = str2prefix_ipv6(ip_str, &p);
-	if (ret == 0) {
-		vty_out(vty, "Malformed prefix\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	rn = route_node_lookup(o->distance_table, (struct prefix *)&p);
-	if (!rn) {
-		vty_out(vty, "Cant't find specified prefix\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	odistance = rn->info;
-
-	if (odistance->access_list)
-		free(odistance->access_list);
-	ospf6_distance_free(odistance);
-
-	rn->info = NULL;
-	route_unlock_node(rn);
-	route_unlock_node(rn);
-
-	return CMD_SUCCESS;
 }
 
 void ospf6_distance_reset(struct ospf6 *o)

--- a/ospf6d/ospf6_zebra.h
+++ b/ospf6d/ospf6_zebra.h
@@ -53,12 +53,6 @@ extern uint8_t ospf6_distance_apply(struct prefix_ipv6 *p,
 
 extern int ospf6_zebra_gr_enable(struct ospf6 *ospf6, uint32_t stale_time);
 extern int ospf6_zebra_gr_disable(struct ospf6 *ospf6);
-extern int ospf6_distance_set(struct vty *vty, struct ospf6 *ospf6,
-			      const char *distance_str, const char *ip_str,
-			      const char *access_list_str);
-extern int ospf6_distance_unset(struct vty *vty, struct ospf6 *ospf6,
-				const char *distance_str, const char *ip_str,
-				const char *access_list_str);
 
 extern int config_write_ospf6_debug_zebra(struct vty *vty);
 extern void install_element_ospf6_debug_zebra(void);

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1881,90 +1881,9 @@ static void ospf_prefix_list_update(struct prefix_list *plist)
 	}
 }
 
-static struct ospf_distance *ospf_distance_new(void)
-{
-	return XCALLOC(MTYPE_OSPF_DISTANCE, sizeof(struct ospf_distance));
-}
-
 static void ospf_distance_free(struct ospf_distance *odistance)
 {
 	XFREE(MTYPE_OSPF_DISTANCE, odistance);
-}
-
-int ospf_distance_set(struct vty *vty, struct ospf *ospf,
-		      const char *distance_str, const char *ip_str,
-		      const char *access_list_str)
-{
-	int ret;
-	struct prefix_ipv4 p;
-	uint8_t distance;
-	struct route_node *rn;
-	struct ospf_distance *odistance;
-
-	ret = str2prefix_ipv4(ip_str, &p);
-	if (ret == 0) {
-		vty_out(vty, "Malformed prefix\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	distance = atoi(distance_str);
-
-	/* Get OSPF distance node. */
-	rn = route_node_get(ospf->distance_table, (struct prefix *)&p);
-	if (rn->info) {
-		odistance = rn->info;
-		route_unlock_node(rn);
-	} else {
-		odistance = ospf_distance_new();
-		rn->info = odistance;
-	}
-
-	/* Set distance value. */
-	odistance->distance = distance;
-
-	/* Reset access-list configuration. */
-	if (odistance->access_list) {
-		free(odistance->access_list);
-		odistance->access_list = NULL;
-	}
-	if (access_list_str)
-		odistance->access_list = strdup(access_list_str);
-
-	return CMD_SUCCESS;
-}
-
-int ospf_distance_unset(struct vty *vty, struct ospf *ospf,
-			const char *distance_str, const char *ip_str,
-			char const *access_list_str)
-{
-	int ret;
-	struct prefix_ipv4 p;
-	struct route_node *rn;
-	struct ospf_distance *odistance;
-
-	ret = str2prefix_ipv4(ip_str, &p);
-	if (ret == 0) {
-		vty_out(vty, "Malformed prefix\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	rn = route_node_lookup(ospf->distance_table, (struct prefix *)&p);
-	if (!rn) {
-		vty_out(vty, "Can't find specified prefix\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	odistance = rn->info;
-
-	if (odistance->access_list)
-		free(odistance->access_list);
-	ospf_distance_free(odistance);
-
-	rn->info = NULL;
-	route_unlock_node(rn);
-	route_unlock_node(rn);
-
-	return CMD_SUCCESS;
 }
 
 void ospf_distance_reset(struct ospf *ospf)

--- a/ospfd/ospf_zebra.h
+++ b/ospfd/ospf_zebra.h
@@ -79,10 +79,6 @@ extern void ospf_routemap_set(struct ospf_redist *, const char *);
 extern void ospf_routemap_unset(struct ospf_redist *);
 extern int ospf_zebra_gr_enable(struct ospf *ospf, uint32_t stale_time);
 extern int ospf_zebra_gr_disable(struct ospf *ospf);
-extern int ospf_distance_set(struct vty *, struct ospf *, const char *,
-			     const char *, const char *);
-extern int ospf_distance_unset(struct vty *, struct ospf *, const char *,
-			       const char *, const char *);
 extern void ospf_zebra_init(struct event_loop *m, unsigned short instance);
 extern void ospf_zebra_vrf_register(struct ospf *ospf);
 extern void ospf_zebra_vrf_deregister(struct ospf *ospf);


### PR DESCRIPTION
The ospf6_distance_set and ospf6_distance_unset functions were introduced in 2014 and they were effectively dead code on that day.  Let's just remove this code.