### PR TITLE
bgpd: fix view deletion and main socket deletion

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1710,7 +1710,7 @@ DEFUN (no_router_bgp,
 				argv[idx_asn]->arg);
 			return CMD_WARNING_CONFIG_FAILED;
 		}
-		if (argc > 4 && strncmp(argv[4]->arg, "vrf", 3) == 0) {
+		if (argc > 4 && (strmatch(argv[4]->arg, "vrf") || strmatch(argv[4]->arg, "view"))) {
 			name = argv[idx_vrf]->arg;
 			if (strmatch(argv[idx_vrf - 1]->text, "vrf")
 			    && strmatch(name, VRF_DEFAULT_NAME))


### PR DESCRIPTION
This PR addresses two issues:
1. Fix views removal with the command `no router bgp ASN view WORD`

   This commit broke the ability to unconfigure BGP views: https://github.com/FRRouting/frr/commit/4d0e7a49cf8d4311a485281fa50bbff6ee8ca6cc

2. Fix BGP main socket removal when removing BGP views

   When two or more views are configured and one of them is removed the main socket is closed causing BGP to no longer accept new connections (see commit description for more information)