### PR TITLE
debian: Remove libjs-sphinxdoc as a runtime install requirement

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,8 @@ Build-Depends: bison,
 	       libgrpc++-dev (>=1.16.1) <pkg.frr.grpc>,
 	       protobuf-compiler (>=3.6.1) <pkg.frr.grpc>,
 	       protobuf-compiler-grpc (>=1.16.1) <pkg.frr.grpc>,
-               libprotobuf-dev (>=3.6.1) <pkg.frr.grpc>
+               libprotobuf-dev (>=3.6.1) <pkg.frr.grpc>,
+               libjs-sphinxdoc
 Standards-Version: 4.5.0.3
 Homepage: https://www.frrouting.org/
 Vcs-Browser: https://github.com/FRRouting/frr/tree/debian/master
@@ -120,7 +121,6 @@ Section: doc
 Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends},
-         ${sphinxdoc:Depends}
 Suggests: frr
 Conflicts: quagga-doc
 Description: FRRouting suite - user manual


### PR DESCRIPTION
The libjs-sphinxdoc is a runtime installation requirement for the frr-doc debian:

 new Debian package, version 2.0.
 size 1909178 bytes: control archive=4195 bytes.
     525 bytes,    17 lines      control
   12020 bytes,   157 lines      md5sums
 Package: frr-doc
 Source: frr
 Version: 10.0~dev-1
 Architecture: all
 Maintainer: David Lamparter <equinox-debian@diac24.net>
 Installed-Size: 6659
 Depends: libjs-sphinxdoc (>= 4.3)
 Suggests: frr
 Conflicts: quagga-doc
 Section: doc
 Priority: optional
 Multi-Arch: foreign
 Homepage: https://www.frrouting.org/
 Description: FRRouting suite - user manual
  This provides the FRR user manual in HTML form.  This is the official
  manual maintained as part of the package and is also available online
  at https://frrouting.readthedocs.io/

This is not actually needed for installation, just for building of the entire package.  Modify the debian build system to make it required to build but not to install.