### PR TITLE
build: fail on docstring problems

### DIFF
--- a/lib/command_graph.h
+++ b/lib/command_graph.h
@@ -123,7 +123,12 @@ extern void cmd_token_varname_set(struct cmd_token *token, const char *varname);
 extern void cmd_token_varname_seqappend(struct graph_node *n);
 extern void cmd_token_varname_join(struct graph_node *n, const char *varname);
 
-extern void cmd_graph_parse(struct graph *graph, const struct cmd_element *cmd);
+enum cmd_graph_parse_errors {
+	CMD_GRAPH_PARSE_DOCSTRING_MISSING = (1 << 0),
+	CMD_GRAPH_PARSE_DOCSTRING_EXTRA = (1 << 1),
+};
+
+extern uint32_t cmd_graph_parse(struct graph *graph, const struct cmd_element *cmd);
 extern void cmd_graph_names(struct graph *graph);
 extern void cmd_graph_merge(struct graph *old, struct graph *n,
 			    int direction);

--- a/lib/command_py.c
+++ b/lib/command_py.c
@@ -63,6 +63,7 @@ struct wrap_graph {
 		char *definition;
 	struct graph *graph;
 	size_t n_nodewrappers;
+	unsigned long errors;
 	struct wrap_graph_node **nodewrappers;
 };
 
@@ -352,6 +353,7 @@ static PyObject *graph_to_pyobj_idx(struct wrap_graph *wgraph, size_t i)
 	}
 static PyMemberDef members_graph[] = {
 	member(definition, T_STRING),
+	member(errors, T_ULONG),
 	{},
 };
 #undef member
@@ -457,7 +459,7 @@ static PyObject *graph_parse(PyTypeObject *type, PyObject *args, PyObject *kwds)
 		struct cmd_element cmd = { .string = def, .doc = doc };
 		struct graph_node *last;
 
-		cmd_graph_parse(graph, &cmd);
+		gwrap->errors = cmd_graph_parse(graph, &cmd);
 		cmd_graph_names(graph);
 
 		last = vector_slot(graph->nodes,
@@ -514,10 +516,12 @@ PyMODINIT_FUNC command_py_init(void)
 	if (!pymod)
 		initret(NULL);
 
-	if (PyModule_AddIntMacro(pymod, CMD_ATTR_YANG)
-	    || PyModule_AddIntMacro(pymod, CMD_ATTR_HIDDEN)
-	    || PyModule_AddIntMacro(pymod, CMD_ATTR_DEPRECATED)
-	    || PyModule_AddIntMacro(pymod, CMD_ATTR_NOSH))
+	if (PyModule_AddIntMacro(pymod, CMD_ATTR_YANG) ||
+	    PyModule_AddIntMacro(pymod, CMD_ATTR_HIDDEN) ||
+	    PyModule_AddIntMacro(pymod, CMD_ATTR_DEPRECATED) ||
+	    PyModule_AddIntMacro(pymod, CMD_ATTR_NOSH) ||
+	    PyModule_AddIntMacro(pymod, CMD_GRAPH_PARSE_DOCSTRING_MISSING) ||
+	    PyModule_AddIntMacro(pymod, CMD_GRAPH_PARSE_DOCSTRING_EXTRA))
 		initret(NULL);
 
 	Py_INCREF(&typeobj_graph_node);

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -523,7 +523,7 @@ vtysh_cmd_split = \
 
 # dependencies added in python/makefile.py
 frr.xref:
-	$(AM_V_XRELFO) $(CLIPPY) $(top_srcdir)/python/xrelfo.py -o $@ $^ \
+	$(AM_V_XRELFO) $(CLIPPY) $(top_srcdir)/python/xrelfo.py $(WERROR) -o $@ $^ \
 		-c vtysh/vtysh_cmd.c $(vtysh_cmd_split)
 all-am: frr.xref
 


### PR DESCRIPTION
The docstring warning for too short/long docstrings was getting printed from the C code as a zlog_warn, but the Python code was entirely unaware of that and as such build just continued...

(This doesn't work for `DEFUN_NOSH`, because this is in the code path for vtysh commands... but 99% is better than 0%.)