### PR TITLE
SRv6: Allow configuring node-len 0

### DIFF
--- a/tests/topotests/srv6_locator_custom_bits_length/expected_locators8.json
+++ b/tests/topotests/srv6_locator_custom_bits_length/expected_locators8.json
@@ -1,0 +1,109 @@
+{
+	"locators": [
+		{
+			"name": "loc1",
+			"prefix": "2001:db8:3::/48",
+			"blockBitsLength": 32,
+			"nodeBitsLength": 16,
+			"functionBitsLength": 16,
+			"argumentBitsLength": 0,
+			"statusUp": true,
+			"chunks": [
+				{
+					"prefix": "2001:db8:3::/48",
+					"proto": "system"
+				}
+			]
+		},
+		{
+			"name": "loc2",
+			"prefix": "2001:db8:3::/48",
+			"blockBitsLength": 48,
+			"nodeBitsLength": 0,
+			"functionBitsLength": 16,
+			"argumentBitsLength": 0,
+			"statusUp": true,
+			"chunks": [
+				{
+					"prefix": "2001:db8:3::/48",
+					"proto": "system"
+				}
+			]
+		},
+		{
+			"name": "loc3",
+			"prefix": "2001:db8:3::/48",
+			"blockBitsLength": 48,
+			"nodeBitsLength": 0,
+			"functionBitsLength": 16,
+			"argumentBitsLength": 0,
+			"statusUp": true,
+			"chunks": [
+				{
+					"prefix": "2001:db8:3::/48",
+					"proto": "system"
+				}
+			]
+		},
+		{
+			"name": "loc4",
+			"prefix": "2001:db8:3::/48",
+			"blockBitsLength": 32,
+			"nodeBitsLength": 16,
+			"functionBitsLength": 16,
+			"argumentBitsLength": 0,
+			"statusUp": true,
+			"chunks": [
+				{
+					"prefix": "2001:db8:3::/48",
+					"proto": "system"
+				}
+			]
+		},
+		{
+			"name": "loc5",
+			"prefix": "2001:db8:3::/48",
+			"blockBitsLength": 24,
+			"nodeBitsLength": 24,
+			"functionBitsLength": 16,
+			"argumentBitsLength": 0,
+			"statusUp": true,
+			"chunks": [
+				{
+					"prefix": "2001:db8:3::/48",
+					"proto": "system"
+				}
+			]
+		},
+		{
+			"name": "loc6",
+			"prefix": "2001:db8::/32",
+			"blockBitsLength": 16,
+			"nodeBitsLength": 16,
+			"functionBitsLength": 0,
+			"argumentBitsLength": 0,
+			"statusUp": true,
+			"chunks": [
+				{
+					"prefix": "2001:db8:3::/48",
+					"proto": "system"
+				}
+			]
+		},
+		{
+			"name": "loc7",
+			"prefix": "2001::/16",
+			"blockBitsLength": 16,
+			"nodeBitsLength": 0,
+			"functionBitsLength": 16,
+			"argumentBitsLength": 0,
+			"statusUp": true,
+			"chunks": [
+				{
+					"prefix": "2001:db8:3::/48",
+					"proto": "system"
+				}
+			]
+		}
+	]
+}

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -786,7 +786,7 @@ DEFUN (no_srv6_locator,
 DEFPY (locator_prefix,
        locator_prefix_cmd,
        "prefix X:X::X:X/M$prefix [block-len (16-64)$block_bit_len]  \
-	        [node-len (16-64)$node_bit_len] [func-bits (0-64)$func_bit_len]",
+	        [node-len (0-64)$node_bit_len] [func-bits (0-64)$func_bit_len]",
        "Configure SRv6 locator prefix\n"
        "Specify SRv6 locator prefix\n"
        "Configure SRv6 locator block length in bits\n"
@@ -802,11 +802,15 @@ DEFPY (locator_prefix,
 	uint8_t expected_prefixlen;
 	struct srv6_sid_format *format;
 	int idx = 0;
+	bool node_bit_not_conf = false;
 
 	locator->prefix = *prefix;
 	/* Only set default if func_bit_len was not provided in command */
 	if (func_bit_len == 0 && !argv_find(argv, argc, "func-bits", &idx))
 		func_bit_len = ZEBRA_SRV6_FUNCTION_LENGTH;
+
+	if (node_bit_len == 0 && !argv_find(argv, argc, "node-len", &idx))
+		node_bit_not_conf = true;
 
 	expected_prefixlen = prefix->prefixlen;
 	format = locator->sid_format;
@@ -830,13 +834,13 @@ DEFPY (locator_prefix,
 	}
 
 	/* Resolve optional arguments */
-	if (block_bit_len == 0 && node_bit_len == 0) {
+	if (block_bit_len == 0 && node_bit_not_conf) {
 		block_bit_len = prefix->prefixlen -
 				ZEBRA_SRV6_LOCATOR_NODE_LENGTH;
 		node_bit_len = ZEBRA_SRV6_LOCATOR_NODE_LENGTH;
 	} else if (block_bit_len == 0) {
 		block_bit_len = prefix->prefixlen - node_bit_len;
-	} else if (node_bit_len == 0) {
+	} else if (node_bit_not_conf) {
 		node_bit_len = prefix->prefixlen - block_bit_len;
 	} else {
 		if (block_bit_len + node_bit_len != prefix->prefixlen) {


### PR DESCRIPTION
Zebra: Allow configuring node-len 0

Currently the node-len for a locator can only be configured between the range 16-64. However, as per the RFC draft
https://datatracker.ietf.org/doc/html/draft-ietf-spring-srv6-srh-compression-23#name-recommended-installation-of

```
The SID 2001:db8:b1:f123:: bound to the End.X behavior for its local IGP adjacency 123 with the NEXT-CSID flavor is instantiated from LIB with
Locator-Block length (LBL) = 48 (Locator-Block value 0x20010db800b1),
Locator-Node length (LNL) = 0,
Function length (FL) = 16 (Function value 0xf123), and
Argument length (AL) = 64.
```

End.X should be able to handle 0 node length.

Fixing this by allowing the user to configure the node-len 0-64. Also distinguishing the not configured node-len and node-len 0 configuration.
