### PR TITLE
zebra: Allow `show ip route table X A.B.C.D/M` to work

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -650,7 +650,7 @@ Single Vxlan Device Support
 FRR supports configuring VLAN-to-VNI mappings for EVPN-VXLAN,
 when working with the Linux kernel. In this new way, the mapping of a VLAN
 to a VNI is configured against a container VXLAN interface which is referred
-to as a ‘Single VXLAN device (SVD)’. Multiple VLAN to VNI mappings can be
+to as a 'Single VXLAN device (SVD)'. Multiple VLAN to VNI mappings can be
 configured against the same SVD. This allows for a significant scaling of
 the number of VNIs since a separate VXLAN interface is no longer required
 for each VNI. Sample configuration of SVD with VLAN to VNI mappings is shown
@@ -1571,6 +1571,50 @@ zebra Terminal Mode Commands
 
    Display detailed information about a route. If [nexthop-group] is
    included, it will display the nexthop group ID the route is using as well.
+
+.. clicmd:: show [ip|ipv6] route [vrf NAME|all|table TABLENO] [A.B.C.D|A.B.C.D/M|X:X::X:X|X:X::X:X/M] [json] [nexthop-group]
+
+   Display detailed information about routes in the routing table. This command provides comprehensive information about specific routes, including their attributes, nexthops, and other routing details.
+
+   Options:
+
+   - ``vrf NAME|all``: Display routes for a specific VRF or all VRFs
+   - ``table TABLENO``: Display routes from a specific routing table (1-4294967295)
+   - ``A.B.C.D|A.B.C.D/M``: Display detailed information for a specific IPv4 address or prefix
+   - ``X:X::X:X|X:X::X:X/M``: Display detailed information for a specific IPv6 address or prefix
+   - ``json``: Display output in JSON format
+   - ``nexthop-group``: Include nexthop group information in the output
+
+   The detailed output includes:
+
+   - Route prefix and mask
+   - Route type and protocol
+   - Administrative distance and metric
+   - Nexthop information including:
+     - Interface name
+     - Nexthop IP address
+     - Nexthop type (direct, recursive, etc.)
+     - Nexthop group ID (if applicable)
+   - Route tags
+   - Route timers
+   - Route status flags
+   - Additional protocol-specific attributes
+
+   Example output:
+
+   ::
+
+      Router# show ip route 192.168.1.0/24 detail
+      Routing entry for 192.168.1.0/24
+        Known via "ospf", distance 110, metric 20, type intra area
+        Last update from 10.0.0.1 on eth0, 00:05:23 ago
+        Routing Descriptor Blocks:
+        * 10.0.0.1, from 10.0.0.1, via eth0
+            Route metric is 20, traffic share count is 1
+            Nexthop group ID: 5
+            Backup nexthop: 10.0.0.2 via eth1
+
+   When using the JSON output format, the information is structured in a hierarchical JSON object containing all the route details in a machine-readable format.
 
 .. clicmd:: show [ip|ipv6] route summary
 

--- a/tests/topotests/all_protocol_startup/r1/ip_nht.ref
+++ b/tests/topotests/all_protocol_startup/r1/ip_nht.ref
@@ -56,11 +56,19 @@ VRF default:
 192.168.0.2
  resolved via connected, prefix 192.168.0.0/24
  is directly connected, r1-eth0 (vrf default), weight 1
- Client list: static(fd XX)
+ Client list: static(fd XX) pbr(fd XX)
 192.168.0.4
  resolved via connected, prefix 192.168.0.0/24
  is directly connected, r1-eth0 (vrf default), weight 1
  Client list: static(fd XX)
+192.168.1.2
+ resolved via connected, prefix 192.168.1.0/26
+ is directly connected, r1-eth1 (vrf default), weight 1
+ Client list: pbr(fd XX)
+192.168.2.2
+ resolved via connected, prefix 192.168.2.0/26
+ is directly connected, r1-eth2 (vrf default), weight 1
+ Client list: pbr(fd XX)
 192.168.7.10
  resolved via connected, prefix 192.168.7.0/26
  is directly connected, r1-eth7 (vrf default), weight 1

--- a/tests/topotests/all_protocol_startup/r1/pbrd.conf
+++ b/tests/topotests/all_protocol_startup/r1/pbrd.conf
@@ -1,6 +1,12 @@
 log file pbrd.log
 
+int r1-eth9
+  pbr-policy FOO
+
 nexthop-group A
+  nexthop 192.168.0.2
+  nexthop 192.168.1.2
+  nexthop 192.168.2.2
   nexthop 192.168.161.4
 !
 pbr-map FOO seq 10

--- a/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
+++ b/tests/topotests/all_protocol_startup/test_all_protocol_startup.py
@@ -1826,6 +1826,28 @@ def test_interface_stuff():
     assert rc == 0
 
 
+def test_pbr_table():
+    global fatal_error
+    net = get_topogen().net
+
+    # Skip if previous fatal error condition is raised
+    if fatal_error != "":
+        pytest.skip(fatal_error)
+
+    print("\n\n** Verifying PBR table default route")
+    print("******************************************\n")
+
+    # Get the route table output
+    output = net["r1"].cmd('vtysh -c "show ip route table 10000 nexthop"').rstrip()
+
+    # Check for default route (0.0.0.0/0)
+    if "0.0.0.0/0" not in output:
+        fatal_error = "Default route not found in PBR table 10000"
+        assert False, fatal_error
+
+    print("Default route found in PBR table 10000")
+
+
 def test_shutdown_check_stderr():
     global fatal_error
     net = get_topogen().net

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1749,6 +1749,7 @@ DEFPY (show_route_detail,
            [{\
             mrib$mrib\
             |vrf <NAME$vrf_name|all$vrf_all>\
+			|table <(1-4294967295)$table_id>\
            }]\
            <\
             A.B.C.D$address\
@@ -1758,6 +1759,7 @@ DEFPY (show_route_detail,
            [{\
             mrib$mrib\
             |vrf <NAME$vrf_name|all$vrf_all>\
+			|table <(1-4294967295)$table_id>\
            }]\
            <\
             X:X::X:X$address\
@@ -1771,6 +1773,8 @@ DEFPY (show_route_detail,
        "IP routing table\n"
        "Multicast SAFI table\n"
        VRF_FULL_CMD_HELP_STR
+	   "Table to display\n"
+	   "The table number to display\n"
        "Network in the IP routing table to display\n"
        "IP prefix <network>/<length>, e.g., 35.0.0.0/8\n"
        IP6_STR
@@ -1778,6 +1782,8 @@ DEFPY (show_route_detail,
        "IPv6 routing table\n"
        "Multicast SAFI table\n"
        VRF_FULL_CMD_HELP_STR
+	   "Table to display\n"
+	   "The table number to display\n"
        "IPv6 Address\n"
        "IPv6 prefix\n"
        JSON_STR
@@ -1866,7 +1872,11 @@ DEFPY (show_route_detail,
 		if (vrf_name)
 			VRF_GET_ID(vrf_id, vrf_name, false);
 
-		table = zebra_vrf_table(afi, safi, vrf_id);
+		if (table_id)
+			table = zebra_vrf_lookup_table_with_table_id(afi, safi, vrf_id, table_id);
+		else
+			table = zebra_vrf_table(afi, safi, vrf_id);
+
 		if (!table)
 			return CMD_SUCCESS;
 


### PR DESCRIPTION
Prior to this change a `show ip route table X A.B.C.D/M longer-prefix` command was the only command accepted.  Additionally it would not dump data about the nexthops or nexthop groups.  With PBR this useful data to have.

New ability:

r1# show ip route table 10000 0.0.0.0/0
Routing entry for 0.0.0.0/0
  Known via "pbr", distance 200, metric 0, best
  Last update 00:00:16 ago
    192.168.3.7 (recursive), weight 1
  *   192.168.1.1, via r1-eth0, weight 1
  *   192.168.1.2, via r1-eth0, weight 1
  *   192.168.1.3, via r1-eth0, weight 1
    192.168.4.1 (recursive), weight 1
  *   192.168.2.1, via r1-eth1, weight 1
    192.168.1.1, via r1-eth0 (duplicate nexthop removed), weight 1
    192.168.1.2, via r1-eth0 (duplicate nexthop removed), weight 1