### PR TITLE
Add initial state dump on frontend datastore notify subscribe

### DIFF
--- a/lib/darr.c
+++ b/lib/darr.c
@@ -179,7 +179,12 @@ int _darr_search_floor(const void *a, size_t esize, const void *key, bool *equal
 #define _a_at(i) ((void *)((char *)a + ((i)*esize)))
 	while (low <= high) {
 		int mid = low + (high - low) / 2;
-		int cmp = cmpf(_a_at(mid), key);
+		int cmp;
+
+		if (cmpf)
+			cmp = cmpf(_a_at(mid), key);
+		else
+			cmp = memcmp(_a_at(mid), key, esize);
 
 		if (!cmp) {
 			if (equal)

--- a/lib/darr.h
+++ b/lib/darr.h
@@ -489,6 +489,28 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
 #define darr_pushz(A)	       (darr_appendz(A))
 #define darr_pushz_mt(A, MT)   (darr_appendz_mt(A, MT))
 
+#define darr_push_uniq_mt(A, E, MT)                                                                \
+	do {                                                                                       \
+		uint _dpu_i;                                                                       \
+                                                                                                   \
+		darr_foreach_i (A, _dpu_i) {                                                       \
+			if ((A)[_dpu_i] == (E))                                                    \
+				break;                                                             \
+		}                                                                                  \
+		if (_dpu_i == darr_len(A))                                                         \
+			(*darr_append_mt(A, MT) = (E));                                            \
+	} while (0)
+
+/**
+ * darr_push_uniq() - Append element if not present.
+ * @A: The dynamic array, can be NULL.
+ * @E: The element to push onto the array if missing.
+ *
+ * Append an element `E` onto the array `A`, extending it's length by 1. This is
+ * particularly useful for arrays of pointers.
+ */
+#define darr_push_uniq(A, E) darr_push_uniq_mt(A, E, MTYPE_DARR)
+
 
 /**
  * Pop the last `N` elements from the array decrementing the length by `N`.

--- a/lib/mgmt_be_client.h
+++ b/lib/mgmt_be_client.h
@@ -128,7 +128,8 @@ extern int mgmt_be_send_ds_patch_notification(const char *path, const struct lyd
 /**
  * mgmt_be_send_ds_replace_notification() - Send a datastore replace notification.
  */
-extern int mgmt_be_send_ds_replace_notification(const char *path, const struct lyd_node *tree);
+extern int mgmt_be_send_ds_replace_notification(const char *path, const struct lyd_node *tree,
+						uint64_t refer_id);
 
 /*
  * Initialize library vty (adds debug support).

--- a/lib/mgmt_msg_native.h
+++ b/lib/mgmt_msg_native.h
@@ -329,6 +329,7 @@ _Static_assert(sizeof(struct mgmt_msg_get_data) ==
 #define NOTIFY_OP_DS_REPLACE   1
 #define NOTIFY_OP_DS_DELETE    2
 #define NOTIFY_OP_DS_PATCH     3
+#define NOTIFY_OP_DS_GET_SYNC  4
 
 /**
  * struct mgmt_msg_notify_data - Message carrying notification data.
@@ -452,13 +453,23 @@ _Static_assert(sizeof(struct mgmt_msg_rpc_reply) ==
  * Add xpath prefix notification selectors to limit the notifications sent
  * to the front-end client.
  *
+ * Also used by mgmtd to the backend clients. In this case behavior depends on
+ * the @get_only boolean. If unset the backend filter set is updated
+ * accordingly, otherwise @get_only is true and a "get" operation is done within
+ * the notification stream using the given selectors, and the filter set in the
+ * backend is not modified. This is used so front-end clients can get an initial
+ * dump of the state followed by notifications w/o missing any changes to the
+ * state.
+ *
  * @selectors: the xpath prefixes to selectors notifications through.
  * @replace: if true replace existing selectors with `selectors`.
+ * @get_only: [backend-only]: if true do get op, don't change selectors.
  */
 struct mgmt_msg_notify_select {
 	struct mgmt_msg_header;
 	uint8_t replace;
-	uint8_t resv2[7];
+	uint8_t get_only;
+	uint8_t resv2[6];
 
 	alignas(8) char selectors[];
 };

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -1897,6 +1897,15 @@ void nb_notif_delete(const char *path);
  */
 extern void nb_notif_set_filters(const char **selectors, bool replace);
 
+
+/**
+ * nb_notif_get_state() - request state dump be sent to mgmtd
+ * @selectors: darr array of xpath strings to do get operations on returning
+ *		the state as notification data.
+ * @refer_id: send in the refer_id field of the returned notification data.
+ */
+extern void nb_notif_get_state(const char **selectors, uint64_t refer_id);
+
 /**
  * nb_notif_enable_multi_thread() - enable use of multiple threads with nb_notif
  *

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -675,8 +675,8 @@ int mgmt_be_send_native(enum mgmt_be_client_id id, void *msg)
 /*
  * Send notification to back-ends that subscribed for them.
  */
-static void mgmt_be_adapter_send_notify(struct mgmt_msg_notify_data *msg,
-					size_t msglen)
+static void mgmt_be_adapter_send_notify(struct mgmt_msg_notify_data *msg, size_t msglen,
+					struct mgmt_be_client_adapter *from_adapter)
 {
 	struct mgmt_be_client_adapter *adapter;
 	struct mgmt_be_xpath_map *map;
@@ -712,7 +712,7 @@ static void mgmt_be_adapter_send_notify(struct mgmt_msg_notify_data *msg,
 		}
 		FOREACH_BE_CLIENT_BITS (id, map->clients) {
 			adapter = mgmt_be_get_adapter_by_id(id);
-			if (!adapter)
+			if (!adapter || adapter == from_adapter)
 				continue;
 
 			msg_conn_send_msg(adapter->conn, MGMT_MSG_VERSION_NATIVE,
@@ -771,7 +771,7 @@ static void be_adapter_handle_native_msg(struct mgmt_be_client_adapter *adapter,
 		 */
 		notify_msg = (typeof(notify_msg))msg;
 		__dbg("Got NOTIFY from '%s'", adapter->name);
-		mgmt_be_adapter_send_notify(notify_msg, msg_len);
+		mgmt_be_adapter_send_notify(notify_msg, msg_len, adapter);
 		mgmt_fe_adapter_send_notify(notify_msg, msg_len);
 		break;
 	default:

--- a/mgmtd/mgmt_testc.c
+++ b/mgmtd/mgmt_testc.c
@@ -206,6 +206,9 @@ static void __ds_notification(struct nb_cb_notify_args *args)
 	case NOTIFY_OP_DS_PATCH:
 		printfrr("#OP=PATCH: %s\n", args->xpath);
 		break;
+	case NOTIFY_OP_DS_GET_SYNC:
+		printfrr("#OP=SYNC: %s\n", args->xpath);
+		break;
 	default:
 		printfrr("#OP=%u: unknown notify op\n", args->op);
 		quit(1);

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -2647,7 +2647,8 @@ int mgmt_txn_send_rpc(uint64_t txn_id, uint64_t req_id, uint64_t clients,
 	return 0;
 }
 
-int mgmt_txn_send_notify_selectors(uint64_t req_id, uint64_t clients, const char **selectors)
+int mgmt_txn_send_notify_selectors(uint64_t req_id, uint64_t session_id, uint64_t clients,
+				   const char **selectors)
 {
 	struct mgmt_msg_notify_select *msg;
 	char **all_selectors = NULL;
@@ -2657,10 +2658,11 @@ int mgmt_txn_send_notify_selectors(uint64_t req_id, uint64_t clients, const char
 
 	msg = mgmt_msg_native_alloc_msg(struct mgmt_msg_notify_select, 0,
 					MTYPE_MSG_NATIVE_NOTIFY_SELECT);
-	msg->refer_id = MGMTD_TXN_ID_NONE;
+	msg->refer_id = session_id;
 	msg->req_id = req_id;
 	msg->code = MGMT_MSG_CODE_NOTIFY_SELECT;
 	msg->replace = selectors == NULL;
+	msg->get_only = session_id != MGMTD_SESSION_ID_NONE;
 
 	if (selectors == NULL) {
 		/* Get selectors for all sessions */

--- a/mgmtd/mgmt_txn.h
+++ b/mgmtd/mgmt_txn.h
@@ -300,12 +300,16 @@ extern int mgmt_txn_send_rpc(uint64_t txn_id, uint64_t req_id, uint64_t clients,
 /**
  * mgmt_txn_send_notify_selectors() - Send NOTIFY SELECT request.
  * @req_id: FE client request identifier.
- * @clients: Bitmask of clients to send RPC to.
+ * @session_id: If non-zero the message will get sent as a `get_only` vs modifing
+ *	        the selectors in the backend, and the get result will be sent
+ *              back to the given session.
+ * @clients: Bitmask of backend clients to send message to.
  * @selectors: Array of selectors or NULL to resend all selectors to BE clients.
  *
  * Returns 0 on success.
  */
-extern int mgmt_txn_send_notify_selectors(uint64_t req_id, uint64_t clients, const char **selectors);
+extern int mgmt_txn_send_notify_selectors(uint64_t req_id, uint64_t session_id, uint64_t clients,
+					  const char **selectors);
 
 /*
  * Notifiy backend adapter on connection.

--- a/tests/topotests/mgmt_notif/test_notif.py
+++ b/tests/topotests/mgmt_notif/test_notif.py
@@ -115,7 +115,7 @@ def test_frontend_all_notification(tgen):
     try:
         # The first notifications is a frr-ripd:authentication-type-failure
         # All the rest are frr-ripd:authentication-failure so we check for both.
-        output = r1.cmd_raises(fe_client_path + " --listen /")
+        output = r1.cmd_raises(fe_client_path + " --listen")
         jsout = json.loads(output)
         expected = {
             "frr-ripd:authentication-type-failure": {"interface-name": "r1-eth0"}
@@ -128,7 +128,7 @@ def test_frontend_all_notification(tgen):
             result = json_cmp(jsout, expected)
         assert result is None
 
-        output = r1.cmd_raises(fe_client_path + " --use-protobuf --listen /")
+        output = r1.cmd_raises(fe_client_path + " --use-protobuf --listen")
         jsout = json.loads(output)
         expected = {"frr-ripd:authentication-failure": {"interface-name": "r1-eth0"}}
         result = json_cmp(jsout, expected)


### PR DESCRIPTION
To allow for correct syncing using notifications a client needs an initial dump of the state before receiving notifications without missing any notifications after this initial dump. Implement this initial state dump using the notification code to support this functionality.

Also, Add notify_format field to the session creation message. When sending notification messages back to front-end, convert data to the format the session requested when it was created.
