### PR TITLE
docker: Build with 256 way ecmp

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -39,6 +39,7 @@ ARG PKGVER
 RUN cd /src \
 	&& ./bootstrap.sh \
 	&& ./configure \
+		--enable-multipath=256 \
 		--enable-numeric-version \
 		--with-pkg-extra-version="_git$PKGVER" \
 	&& make dist

--- a/docker/centos-7/Dockerfile
+++ b/docker/centos-7/Dockerfile
@@ -18,6 +18,7 @@ RUN echo '%_smp_mflags %( echo "-j$(/usr/bin/getconf _NPROCESSORS_ONLN)"; )' >> 
     && cd /src \
     && ./bootstrap.sh \
     && ./configure \
+	--enable-multipath=256 \
         --enable-rpki \
         --enable-numeric-version \
         --with-pkg-extra-version="_git$PKGVER" \

--- a/docker/centos-8/Dockerfile
+++ b/docker/centos-8/Dockerfile
@@ -23,6 +23,7 @@ RUN echo '%_smp_mflags %( echo "-j$(/usr/bin/getconf _NPROCESSORS_ONLN)"; )' >> 
     && cd /src \
     && ./bootstrap.sh \
     && ./configure \
+	--enable-multipath=256 \
         --enable-rpki \
         --enable-numeric-version \
         --with-pkg-extra-version="_git$PKGVER" \

--- a/docker/ubi8-minimal/Dockerfile
+++ b/docker/ubi8-minimal/Dockerfile
@@ -65,6 +65,7 @@ RUN echo '%_smp_mflags %( echo "-j$(/usr/bin/getconf _NPROCESSORS_ONLN)"; )' >> 
     && cd /src \
     && ./bootstrap.sh \
     && ./configure \
+	--enable-multipath=256 \
         --enable-rpki \
         --enable-snmp=agentx \
         --enable-numeric-version \

--- a/docker/ubuntu-ci/Dockerfile
+++ b/docker/ubuntu-ci/Dockerfile
@@ -119,7 +119,7 @@ RUN cd ~/frr && \
        --enable-mgmtd-test-be-client \
        --enable-rpki \
        --enable-sharpd \
-       --enable-multipath=64 \
+       --enable-multipath=256 \
        --enable-user=frr \
        --enable-group=frr \
        --enable-config-rollbacks \


### PR DESCRIPTION
Our topotests are assuming that there is 128 way ecmp at the moment Let's just build with 256