### PR TITLE
Gather vtysh return codes up to report to operator

### DIFF
--- a/tests/topotests/bgp_local_asn/test_bgp_local_asn_topo1.py
+++ b/tests/topotests/bgp_local_asn/test_bgp_local_asn_topo1.py
@@ -767,12 +767,6 @@ def test_verify_bgp_local_as_GR_EBGP_p0(request):
             }
         }
 
-        logger.info("Configure static routes")
-        result = create_static_routes(tgen, input_dict_static_route)
-        assert result is True, "Testcase {} : Failed \n Error: {}".format(
-            tc_name, result
-        )
-
         step("configure redistribute static in Router BGP in R1")
         input_dict_static_route_redist = {
             "r1": {

--- a/tests/topotests/bgp_local_asn_dot/test_bgp_local_asn_dot_topo1.py
+++ b/tests/topotests/bgp_local_asn_dot/test_bgp_local_asn_dot_topo1.py
@@ -784,12 +784,6 @@ def test_verify_bgp_local_as_GR_EBGP_p0(request):
             }
         }
 
-        logger.info("Configure static routes")
-        result = create_static_routes(tgen, input_dict_static_route)
-        assert result is True, "Testcase {} : Failed \n Error: {}".format(
-            tc_name, result
-        )
-
         step("configure redistribute static in Router BGP in R1")
         input_dict_static_route_redist = {
             "r1": {
@@ -1473,12 +1467,6 @@ def test_verify_bgp_local_as_in_EBGP_aspath_p0(request):
             }
         }
 
-        logger.info("Configure static routes")
-        result = create_static_routes(tgen, input_static_r1)
-        assert result is True, "Testcase {} : Failed \n Error: {}".format(
-            tc_name, result
-        )
-
         step("configure redistribute static in Router BGP in R1")
 
         input_static_redist_r1 = {
@@ -1739,12 +1727,6 @@ def test_verify_bgp_local_as_in_iBGP_p0(request):
                 ]
             }
         }
-
-        logger.info("Configure static routes")
-        result = create_static_routes(tgen, input_dict_static_route)
-        assert result is True, "Testcase {} : Failed \n Error: {}".format(
-            tc_name, result
-        )
 
         step("configure redistribute static in Router BGP in R1")
         input_dict_static_route_redist = {
@@ -2055,12 +2037,6 @@ def test_verify_bgp_local_as_allow_as_in_iBGP_p0(request):
                 ]
             }
         }
-
-        logger.info("Configure static routes")
-        result = create_static_routes(tgen, input_dict_static_route)
-        assert result is True, "Testcase {} : Failed \n Error: {}".format(
-            tc_name, result
-        )
 
         step("configure redistribute static in Router BGP in R1")
         input_dict_static_route_redist = {
@@ -2574,12 +2550,6 @@ def test_verify_bgp_local_as_in_EBGP_port_reset_p0(request):
             }
         }
 
-        logger.info("Configure static routes")
-        result = create_static_routes(tgen, input_static_r1)
-        assert result is True, "Testcase {} : Failed \n Error: {}".format(
-            tc_name, result
-        )
-
         step("configure redistribute static in Router BGP in R1")
         input_static_redist_r1 = {
             "r1": {
@@ -2919,12 +2889,6 @@ def test_verify_bgp_local_as_in_EBGP_negative2_p0(request):
             }
         }
 
-        logger.info("Configure static routes")
-        result = create_static_routes(tgen, input_static_r1)
-        assert result is True, "Testcase {} : Failed \n Error: {}".format(
-            tc_name, result
-        )
-
         step("configure redistribute static in Router BGP in R1")
 
         input_static_redist_r1 = {
@@ -3263,12 +3227,6 @@ def test_verify_bgp_local_as_in_EBGP_negative3_p0(request):
             }
         }
 
-        logger.info("Configure static routes")
-        result = create_static_routes(tgen, input_static_r1)
-        assert result is True, "Testcase {} : Failed \n Error: {}".format(
-            tc_name, result
-        )
-
         step("configure redistribute static in Router BGP in R1")
 
         input_static_redist_r1 = {
@@ -3455,12 +3413,6 @@ def test_verify_bgp_local_as_in_EBGP_restart_daemons_p0(request):
                 ]
             }
         }
-
-        logger.info("Configure static routes")
-        result = create_static_routes(tgen, input_static_r1)
-        assert result is True, "Testcase {} : Failed \n Error: {}".format(
-            tc_name, result
-        )
 
         step("configure redistribute static in Router BGP in R1")
         input_static_redist_r1 = {

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -4084,11 +4084,15 @@ DEFUN_HIDDEN(end_config, end_config_cmd, "XFRR_end_configuration",
 {
 	unsigned int i;
 	char line[] = "XFRR_end_configuration";
+	int ret, err_gathered = CMD_SUCCESS;
 
-	for (i = 0; i < array_size(vtysh_client); i++)
-		vtysh_client_execute(&vtysh_client[i], line);
+	for (i = 0; i < array_size(vtysh_client); i++) {
+		ret = vtysh_client_execute(&vtysh_client[i], line);
+		if (ret != CMD_SUCCESS)
+			err_gathered = ret;
+	}
 
-	return CMD_SUCCESS;
+	return err_gathered;
 }
 
 static bool want_config_integrated(void)

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -602,7 +602,7 @@ void vtysh_config_dump(void)
 static int vtysh_read_file(FILE *confp, bool dry_run)
 {
 	struct vty *lvty;
-	int ret;
+	int ret, saved_ret = CMD_SUCCESS;
 
 	lvty = vty_new();
 	lvty->wfd = STDERR_FILENO;
@@ -623,16 +623,21 @@ static int vtysh_read_file(FILE *confp, bool dry_run)
 
 	/* Execute configuration file. */
 	ret = vtysh_config_from_file(lvty, confp);
+	if (ret != CMD_SUCCESS)
+		saved_ret = ret;
 
-	if (!dry_run)
-		vtysh_execute_no_pager("XFRR_end_configuration");
+	if (!dry_run) {
+		ret = vtysh_execute_no_pager("XFRR_end_configuration");
+		if (ret != CMD_SUCCESS)
+			saved_ret = ret;
+	}
 
 	vtysh_execute_no_pager("end");
 	vtysh_execute_no_pager("disable");
 
 	vty_close(lvty);
 
-	return (ret);
+	return (saved_ret);
 }
 
 /*


### PR DESCRIPTION
In some instances the return codes from failed configuration is not gathered up to report to the operator.
