### PR TITLE
Replace use of `__` as identifier prefix

### DIFF
--- a/lib/darr.c
+++ b/lib/darr.c
@@ -54,7 +54,7 @@ static size_t darr_size(uint count, size_t esize)
 	return count * esize + sizeof(struct darr_metadata);
 }
 
-char *__darr_in_vsprintf(char **sp, bool concat, const char *fmt, va_list ap)
+char *_darr__in_vsprintf(char **sp, bool concat, const char *fmt, va_list ap)
 {
 	size_t inlen = concat ? darr_strlen(*sp) : 0;
 	size_t capcount = strlen(fmt) + MIN(inlen + 64, 128);
@@ -84,18 +84,18 @@ again:
 	return *sp;
 }
 
-char *__darr_in_sprintf(char **sp, bool concat, const char *fmt, ...)
+char *_darr__in_sprintf(char **sp, bool concat, const char *fmt, ...)
 {
 	va_list ap;
 
 	va_start(ap, fmt);
-	(void)__darr_in_vsprintf(sp, concat, fmt, ap);
+	(void)_darr__in_vsprintf(sp, concat, fmt, ap);
 	va_end(ap);
 	return *sp;
 }
 
 
-void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mtype)
+void *_darr__resize(void *a, uint count, size_t esize, struct memtype *mtype)
 {
 	uint ncount = darr_next_count(count, esize);
 	size_t osz = (a == NULL) ? 0 : darr_size(darr_cap(a), esize);
@@ -115,14 +115,13 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mtype)
 }
 
 
-void *__darr_insert_n(void *a, uint at, uint count, size_t esize, bool zero,
-		      struct memtype *mtype)
+void *_darr__insert_n(void *a, uint at, uint count, size_t esize, bool zero, struct memtype *mtype)
 {
 	struct darr_metadata *dm;
 	uint olen, nlen;
 
 	if (!a)
-		a = __darr_resize(NULL, at + count, esize, mtype);
+		a = _darr__resize(NULL, at + count, esize, mtype);
 	dm = (struct darr_metadata *)a - 1;
 	olen = dm->len;
 
@@ -137,7 +136,7 @@ void *__darr_insert_n(void *a, uint at, uint count, size_t esize, bool zero,
 		nlen = olen + count;
 
 	if (nlen > dm->cap) {
-		a = __darr_resize(a, nlen, esize, mtype);
+		a = _darr__resize(a, nlen, esize, mtype);
 		dm = (struct darr_metadata *)a - 1;
 	}
 

--- a/lib/darr.h
+++ b/lib/darr.h
@@ -95,22 +95,16 @@ struct darr_metadata {
 	struct memtype *mtype;
 };
 
-void *__darr_insert_n(void *a, uint at, uint count, size_t esize, bool zero,
-		      struct memtype *mt);
-char *__darr_in_sprintf(char **sp, bool concat, const char *fmt, ...)
-	PRINTFRR(3, 4);
-char *__darr_in_vsprintf(char **sp, bool concat, const char *fmt, va_list ap)
-	PRINTFRR(3, 0);
-void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
-
+void *_darr__insert_n(void *a, uint at, uint count, size_t esize, bool zero, struct memtype *mt);
+char *_darr__in_sprintf(char **sp, bool concat, const char *fmt, ...) PRINTFRR(3, 4);
+char *_darr__in_vsprintf(char **sp, bool concat, const char *fmt, va_list ap) PRINTFRR(3, 0);
+void *_darr__resize(void *a, uint count, size_t esize, struct memtype *mt);
 
 #define _darr_esize(A) sizeof((A)[0])
-#define darr_esize(A)  sizeof((A)[0])
 #define _darr_len(A)   _darr_meta(A)->len
 #define _darr_meta(A)  (((struct darr_metadata *)(A)) - 1)
-#define _darr_resize_mt(A, C, MT)                                              \
-	({ (A) = __darr_resize(A, C, _darr_esize(A), MT); })
-#define _darr_resize(A, C) _darr_resize_mt(A, C, MTYPE_DARR)
+#define _darr_resize_mt(A, C, MT) ({ (A) = _darr__resize(A, C, _darr_esize(A), MT); })
+#define _darr_resize(A, C)	  _darr_resize_mt(A, C, MTYPE_DARR)
 
 /* Get the current capacity of the array */
 #define darr_cap(A) (((A) == NULL) ? 0 : _darr_meta(A)->cap)
@@ -214,13 +208,13 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  *	A: The dynamic array, can be NULL.
  */
 
-#define darr_free(A)                                                           \
-	do {                                                                   \
-		if ((A)) {                                                     \
-			struct darr_metadata *__meta = _darr_meta(A);          \
-			XFREE(__meta->mtype, __meta);                          \
-			(A) = NULL;                                            \
-		}                                                              \
+#define darr_free(A)                                                                               \
+	do {                                                                                       \
+		if ((A)) {                                                                         \
+			struct darr_metadata *_d__meta = _darr_meta(A);                            \
+			XFREE(_d__meta->mtype, _d__meta);                                          \
+			(A) = NULL;                                                                \
+		}                                                                                  \
 	} while (0)
 
 /**
@@ -230,15 +224,14 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Args:
  *	A: The dynamic array, can be NULL.
  */
-#define darr_free_free(A)                                                      \
-	do {                                                                   \
-		for (uint __i = 0; __i < darr_len(A); __i++)                   \
-			if ((A)[__i]) {                                        \
-				struct darr_metadata *__meta =                 \
-					_darr_meta((A)[__i]);                  \
-				XFREE(__meta->mtype, __meta);                  \
-			}                                                      \
-		darr_free(A);                                                  \
+#define darr_free_free(A)                                                                          \
+	do {                                                                                       \
+		for (uint _d__i = 0; _d__i < darr_len(A); _d__i++)                                 \
+			if ((A)[_d__i]) {                                                          \
+				struct darr_metadata *_d__meta = _darr_meta((A)[_d__i]);           \
+				XFREE(_d__meta->mtype, _d__meta);                                  \
+			}                                                                          \
+		darr_free(A);                                                                      \
 	} while (0)
 
 /**
@@ -250,12 +243,12 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  *	F: The function to call for each element.
  */
 
-#define darr_free_func(A, F)                                                   \
-	do {                                                                   \
-		for (uint __i = 0; __i < darr_len(A); __i++) {                 \
-			F((A)[__i]);                                           \
-		}                                                              \
-		darr_free(A);                                                  \
+#define darr_free_func(A, F)                                                                       \
+	do {                                                                                       \
+		for (uint _d__i = 0; _d__i < darr_len(A); _d__i++) {                               \
+			F((A)[_d__i]);                                                             \
+		}                                                                                  \
+		darr_free(A);                                                                      \
 	} while (0)
 
 /**
@@ -274,13 +267,12 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Return:
  *      A pointer to the (possibly moved) array.
  */
-#define darr_ensure_avail_mt(A, S, MT)                                         \
-	({                                                                     \
-		ssize_t __dea_need = (ssize_t)(S) -                            \
-				     (ssize_t)(darr_cap(A) - darr_len(A));     \
-		if (__dea_need > 0)                                            \
-			_darr_resize_mt((A), darr_cap(A) + __dea_need, MT);    \
-		(A);                                                           \
+#define darr_ensure_avail_mt(A, S, MT)                                                             \
+	({                                                                                         \
+		ssize_t _dea_need = (ssize_t)(S) - (ssize_t)(darr_cap(A) - darr_len(A));           \
+		if (_dea_need > 0)                                                                 \
+			_darr_resize_mt((A), darr_cap(A) + _dea_need, MT);                         \
+		(A);                                                                               \
 	})
 #define darr_ensure_avail(A, S) darr_ensure_avail_mt(A, S, MTYPE_DARR)
 
@@ -302,13 +294,13 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Return:
  *      A pointer to the (possibly moved) array.
  */
-#define darr_ensure_cap_mt(A, C, MT)                                           \
-	({                                                                     \
-		/* Cast to avoid warning when C == 0 */                        \
-		uint __dec_c = (C) > 0 ? (C) : 1;                              \
-		if ((size_t)darr_cap(A) < __dec_c)                             \
-			_darr_resize_mt((A), __dec_c, MT);                     \
-		(A);                                                           \
+#define darr_ensure_cap_mt(A, C, MT)                                                               \
+	({                                                                                         \
+		/* Cast to avoid warning when C == 0 */                                            \
+		uint _dec_c = (C) > 0 ? (C) : 1;                                                   \
+		if ((size_t)darr_cap(A) < _dec_c)                                                  \
+			_darr_resize_mt((A), _dec_c, MT);                                          \
+		(A);                                                                               \
 	})
 #define darr_ensure_cap(A, C) darr_ensure_cap_mt(A, C, MTYPE_DARR)
 
@@ -330,16 +322,16 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Return:
  *      A pointer to the (I)th element in `A`
  */
-#define darr_ensure_i_mt(A, I, MT)                                             \
-	({                                                                     \
-		assert((int)(I) >= 0 && (uint)(I) <= INT_MAX);                 \
-		int _i = (int)(I);                                             \
-		if (_i > darr_maxi(A))                                         \
-			_darr_resize_mt((A), _i + 1, MT);                      \
-		assert((A) != NULL);                                           \
-		if ((uint)_i + 1 > _darr_len(A))                               \
-			_darr_len(A) = _i + 1;                                 \
-		&(A)[_i];                                                      \
+#define darr_ensure_i_mt(A, I, MT)                                                                 \
+	({                                                                                         \
+		assert((int)(I) >= 0 && (uint)(I) <= INT_MAX);                                     \
+		int _d__i = (int)(I);                                                              \
+		if (_d__i > darr_maxi(A))                                                          \
+			_darr_resize_mt((A), _d__i + 1, MT);                                       \
+		assert((A) != NULL);                                                               \
+		if ((uint)_d__i + 1 > _darr_len(A))                                                \
+			_darr_len(A) = _d__i + 1;                                                  \
+		&(A)[_d__i];                                                                       \
 	})
 #define darr_ensure_i(A, I) darr_ensure_i_mt(A, I, MTYPE_DARR)
 
@@ -347,7 +339,7 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
 	({                                                                                         \
 		uint _ins_i = (I);                                                                 \
 		uint _ins_n = (N);                                                                 \
-		(A) = __darr_insert_n(A, _ins_i, _ins_n, _darr_esize(A), Z, MT);                   \
+		(A) = _darr__insert_n(A, _ins_i, _ins_n, _darr_esize(A), Z, MT);                   \
 		&(A)[_ins_i];                                                                      \
 	})
 /**
@@ -405,19 +397,19 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Args:
  *	A: The dynamic array, can be NULL.
  */
-#define darr_remove_n(A, I, N)                                                 \
-	do {                                                                   \
-		uint __i = (I);                                                \
-		uint __n = (N);                                                \
-		uint __len = darr_len(A);                                      \
-		if (!__len)                                                    \
-			break;                                                 \
-		else if (__i + __n < __len) {                                  \
-			memmove(&(A)[__i], &(A)[__i + __n],                    \
-				_darr_esize(A) * (__len - (__i + __n)));       \
-			_darr_len(A) = __len - __n;                            \
-		} else                                                         \
-			_darr_len(A) = __i;                                    \
+#define darr_remove_n(A, I, N)                                                                     \
+	do {                                                                                       \
+		uint _d__i = (I);                                                                  \
+		uint _d__n = (N);                                                                  \
+		uint _d__len = darr_len(A);                                                        \
+		if (!_d__len)                                                                      \
+			break;                                                                     \
+		else if (_d__i + _d__n < _d__len) {                                                \
+			memmove(&(A)[_d__i], &(A)[_d__i + _d__n],                                  \
+				_darr_esize(A) * (_d__len - (_d__i + _d__n)));                     \
+			_darr_len(A) = _d__len - _d__n;                                            \
+		} else                                                                             \
+			_darr_len(A) = _d__i;                                                      \
 	} while (0)
 
 /**
@@ -432,14 +424,14 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
 #define darr_remove(A, I) darr_remove_n(A, I, 1)
 
 
-#define _darr_append_n(A, N, Z, MT)                                            \
-	({                                                                     \
-		uint __da_len = darr_len(A);                                   \
-		darr_ensure_cap_mt(A, __da_len + (N), MT);                     \
-		_darr_len(A) = __da_len + (N);                                 \
-		if (Z)                                                         \
-			memset(&(A)[__da_len], 0, (N)*_darr_esize(A));         \
-		&(A)[__da_len];                                                \
+#define _darr_append_n(A, N, Z, MT)                                                                \
+	({                                                                                         \
+		uint _da_len = darr_len(A);                                                        \
+		darr_ensure_cap_mt(A, _da_len + (N), MT);                                          \
+		_darr_len(A) = _da_len + (N);                                                      \
+		if (Z)                                                                             \
+			memset(&(A)[_da_len], 0, (N)*_darr_esize(A));                              \
+		&(A)[_da_len];                                                                     \
 	})
 /**
  * Extending the array's length by N.
@@ -536,13 +528,13 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Return:
  *      The element just popped.
  */
-#define darr_pop(A)                                                            \
-	({                                                                     \
-		uint __poplen = _darr_len(A);                                  \
-		assert(__poplen);                                              \
-		darr_remove(A, __poplen - 1);                                  \
-		/* count on fact that we don't resize */                       \
-		(A)[__poplen - 1];                                             \
+#define darr_pop(A)                                                                                \
+	({                                                                                         \
+		uint _d__poplen = _darr_len(A);                                                    \
+		assert(_d__poplen);                                                                \
+		darr_remove(A, _d__poplen - 1);                                                    \
+		/* count on fact that we don't resize */                                           \
+		(A)[_d__poplen - 1];                                                               \
 	})
 
 /**
@@ -568,10 +560,10 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  *      A pointer to the last element of the array or NULL if the array is
  *      empty.
  */
-#define darr_last(A)                                                           \
-	({                                                                     \
-		uint __len = darr_len(A);                                      \
-		((__len > 0) ? &(A)[__len - 1] : NULL);                        \
+#define darr_last(A)                                                                               \
+	({                                                                                         \
+		uint _d__len = darr_len(A);                                                        \
+		((_d__len > 0) ? &(A)[_d__len - 1] : NULL);                                        \
 	})
 #define darr_strnul(S) darr_last(S)
 
@@ -586,7 +578,7 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Return:
  *	The dynamic_array D with the new string content.
  */
-#define darr_in_sprintf(D, F, ...) __darr_in_sprintf(&(D), 0, F, __VA_ARGS__)
+#define darr_in_sprintf(D, F, ...) _darr__in_sprintf(&(D), 0, F, __VA_ARGS__)
 
 
 /**
@@ -601,14 +593,14 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  */
 #define darr_in_strcat(D, S)                                                                       \
 	({                                                                                         \
-		uint __dlen = darr_strlen(D);                                                      \
-		uint __slen = strlen(S);                                                           \
-		darr_ensure_cap_mt(D, __dlen + __slen + 1, MTYPE_DARR_STR);                        \
+		uint _d__dlen = darr_strlen(D);                                                    \
+		uint _d__slen = strlen(S);                                                         \
+		darr_ensure_cap_mt(D, _d__dlen + _d__slen + 1, MTYPE_DARR_STR);                    \
 		if (darr_len(D) == 0)                                                              \
 			*darr_append(D) = 0;                                                       \
-		memcpy(&(D)[darr_strlen(D)] /* darr_last(D) clangSA :( */, (S), __slen + 1);       \
-		_darr_len(D) += __slen;                                                            \
-		D;                                                                                 \
+		memcpy(&(D)[darr_strlen(D)] /* darr_last(D) clangSA :( */, (S), _d__slen + 1);     \
+		_darr_len(D) += _d__slen;                                                          \
+		(D);                                                                               \
 	})
 
 /**
@@ -621,8 +613,7 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Return:
  *	The dynamic_array D with the new string content.
  */
-#define darr_in_strcatf(D, F, ...)                                             \
-	__darr_in_sprintf(&(D), true, (F), __VA_ARGS__)
+#define darr_in_strcatf(D, F, ...) _darr__in_sprintf(&(D), true, (F), __VA_ARGS__)
 
 /**
  * darr_in_strcat_tail() - copies end of one darr str to another.
@@ -649,21 +640,21 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Return:
  *	The dynamic_array D with the extended string content.
  */
-#define darr_in_strcat_tail(D, S)                                              \
-	({                                                                     \
-		int __dsize, __ssize, __extra;                                 \
-									       \
-		if (darr_len(D) == 0)                                          \
-			*darr_append(D) = 0;                                   \
-		__dsize = darr_ilen(D);                                        \
-		__ssize = darr_ilen(S);                                        \
-		__extra = __ssize - __dsize;                                   \
-		if (__extra > 0) {                                             \
-			darr_ensure_cap_mt(D, (uint)__ssize, MTYPE_DARR_STR);  \
-			memcpy(darr_last(D), (S) + __dsize - 1, __extra + 1);  \
-			_darr_len(D) += __extra;                               \
-		}                                                              \
-		D;                                                             \
+#define darr_in_strcat_tail(D, S)                                                                  \
+	({                                                                                         \
+		int _d__dsize, _d__ssize, _d__extra;                                               \
+                                                                                                   \
+		if (darr_len(D) == 0)                                                              \
+			*darr_append(D) = 0;                                                       \
+		_d__dsize = darr_ilen(D);                                                          \
+		_d__ssize = darr_ilen(S);                                                          \
+		_d__extra = _d__ssize - _d__dsize;                                                 \
+		if (_d__extra > 0) {                                                               \
+			darr_ensure_cap_mt(D, (uint)_d__ssize, MTYPE_DARR_STR);                    \
+			memcpy(darr_last(D), (S) + _d__dsize - 1, _d__extra + 1);                  \
+			_darr_len(D) += _d__extra;                                                 \
+		}                                                                                  \
+		(D);                                                                               \
 	})
 
 /**
@@ -678,17 +669,15 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Return:
  *	The dynamic_array D with the duplicated string.
  */
-#define darr_in_strdup_cap(D, S, C)                                            \
-	({                                                                     \
-		size_t __size = strlen(S) + 1;                                 \
-		darr_reset(D);                                                 \
-		darr_ensure_cap_mt(D,                                          \
-				   ((size_t)(C) > __size) ? (size_t)(C)        \
-							  : __size,            \
-				   MTYPE_DARR_STR);                            \
-		strlcpy(D, (S), darr_cap(D));                                  \
-		darr_setlen((D), (size_t)__size);                              \
-		D;                                                             \
+#define darr_in_strdup_cap(D, S, C)                                                                \
+	({                                                                                         \
+		size_t _d__size = strlen(S) + 1;                                                   \
+		darr_reset(D);                                                                     \
+		darr_ensure_cap_mt(D, ((size_t)(C) > _d__size) ? (size_t)(C) : _d__size,           \
+				   MTYPE_DARR_STR);                                                \
+		strlcpy(D, (S), darr_cap(D));                                                      \
+		darr_setlen((D), (size_t)_d__size);                                                \
+		(D);                                                                               \
 	})
 #define darr_in_strdup(D, S) darr_in_strdup_cap(D, S, 1)
 
@@ -703,7 +692,7 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Return:
  *	The dynamic_array D with the new string content.
  */
-#define darr_in_vsprintf(D, F, A) __darr_in_vsprintf(&(D), 0, F, A)
+#define darr_in_vsprintf(D, F, A) _darr__in_vsprintf(&(D), 0, F, A)
 
 /**
  * darr_in_vstrcatf() - concat a formatted string into a darr string.
@@ -716,7 +705,7 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Return:
  *	The dynamic_array D with the new string content.
  */
-#define darr_in_vstrcatf(D, F, A) __darr_in_vsprintf(&(D), true, (F), (A))
+#define darr_in_vstrcatf(D, F, A) __darr__in_vsprintf(&(D), true, (F), (A))
 
 /**
  * darr_sprintf() - sprintf into a new dynamic array.
@@ -728,11 +717,11 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Return:
  *	A char * dynamic_array with the new string content.
  */
-#define darr_sprintf(F, ...)                                                   \
-	({                                                                     \
-		char *d = NULL;                                                \
-		__darr_in_sprintf(&d, false, F, __VA_ARGS__);                  \
-		d;                                                             \
+#define darr_sprintf(F, ...)                                                                       \
+	({                                                                                         \
+		char *_d__d = NULL;                                                                \
+		_darr__in_sprintf(&_d__d, false, F, __VA_ARGS__);                                  \
+		_d__d;                                                                             \
 	})
 
 /**
@@ -746,19 +735,17 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Return:
  *	The dynamic_array with the duplicated string.
  */
-#define darr_strdup_cap(S, C)                                                  \
-	({                                                                     \
-		size_t __size = strlen(S) + 1;                                 \
-		char *__s = NULL;                                              \
-		/* Cast to ssize_t to avoid warning when C == 0 */             \
-		darr_ensure_cap_mt(__s,                                        \
-				   ((ssize_t)(C) > (ssize_t)__size)            \
-					   ? (size_t)(C)                       \
-					   : __size,                           \
-				   MTYPE_DARR_STR);                            \
-		strlcpy(__s, (S), darr_cap(__s));                              \
-		darr_setlen(__s, (size_t)__size);                              \
-		__s;                                                           \
+#define darr_strdup_cap(S, C)                                                                      \
+	({                                                                                         \
+		size_t _d__size = strlen(S) + 1;                                                   \
+		char *_d__s = NULL;                                                                \
+		/* Cast to ssize_t to avoid warning when C == 0 */                                 \
+		darr_ensure_cap_mt(_d__s,                                                          \
+				   ((ssize_t)(C) > (ssize_t)_d__size) ? (size_t)(C) : _d__size,    \
+				   MTYPE_DARR_STR);                                                \
+		strlcpy(_d__s, (S), darr_cap(_d__s));                                              \
+		darr_setlen(_d__s, (size_t)_d__size);                                              \
+		_d__s;                                                                             \
 	})
 #define darr_strdup(S) darr_strdup_cap(S, 0)
 
@@ -771,13 +758,13 @@ void *__darr_resize(void *a, uint count, size_t esize, struct memtype *mt);
  * Return:
  *	The length of the NUL terminated string in @S
  */
-#define darr_strlen(S)                                                         \
-	({                                                                     \
-		uint __size = darr_len(S);                                     \
-		if (__size)                                                    \
-			__size -= 1;                                           \
-		assert(!(S) || ((char *)(S))[__size] == 0);                    \
-		__size;                                                        \
+#define darr_strlen(S)                                                                             \
+	({                                                                                         \
+		uint _d__size = darr_len(S);                                                       \
+		if (_d__size)                                                                      \
+			_d__size -= 1;                                                             \
+		assert(!(S) || ((char *)(S))[_d__size] == 0);                                      \
+		_d__size;                                                                          \
 	})
 
 /**

--- a/lib/mgmt_msg_native.h
+++ b/lib/mgmt_msg_native.h
@@ -576,12 +576,10 @@ extern int vmgmt_msg_native_send_error(struct msg_conn *conn,
  *
  * Return: A `msg_type` object created using a dynamic_array.
  */
-#define mgmt_msg_native_alloc_msg(msg_type, var_len, mem_type)                 \
-	({                                                                     \
-		uint8_t *__nam_buf = NULL;                                     \
-		(msg_type *)darr_append_nz_mt(__nam_buf,                       \
-					      sizeof(msg_type) + (var_len),    \
-					      mem_type);                       \
+#define mgmt_msg_native_alloc_msg(msg_type, var_len, mem_type)                                     \
+	({                                                                                         \
+		uint8_t *_nam_buf = NULL;                                                          \
+		(msg_type *)darr_append_nz_mt(_nam_buf, sizeof(msg_type) + (var_len), mem_type);   \
 	})
 
 /**
@@ -612,12 +610,12 @@ extern int vmgmt_msg_native_send_error(struct msg_conn *conn,
  *
  * Return: a pointer to the newly appended data.
  */
-#define mgmt_msg_native_append(msg, data, len)                                 \
-	({                                                                     \
-		uint8_t **__na_darrp = mgmt_msg_native_get_darrp(msg);         \
-		uint8_t *__na_p = darr_append_n(*__na_darrp, len);             \
-		memcpy(__na_p, data, len);                                     \
-		__na_p;							       \
+#define mgmt_msg_native_append(msg, data, len)                                                     \
+	({                                                                                         \
+		uint8_t **_na_darrp = mgmt_msg_native_get_darrp(msg);                              \
+		uint8_t *_na_p = darr_append_n(*_na_darrp, len);                                   \
+		memcpy(_na_p, data, len);                                                          \
+		_na_p;                                                                             \
 	})
 
 /**
@@ -633,10 +631,10 @@ extern int vmgmt_msg_native_send_error(struct msg_conn *conn,
  * message to fit the new data. Any other pointers into the old message should
  * be discarded.
  */
-#define mgmt_msg_native_add_str(msg, s)                                        \
-	do {                                                                   \
-		int __nas_len = strlen(s) + 1;                                 \
-		mgmt_msg_native_append(msg, s, __nas_len);                     \
+#define mgmt_msg_native_add_str(msg, s)                                                            \
+	do {                                                                                       \
+		int _nas_len = strlen(s) + 1;                                                      \
+		mgmt_msg_native_append(msg, s, _nas_len);                                          \
 	} while (0)
 
 /**
@@ -706,11 +704,11 @@ extern int vmgmt_msg_native_send_error(struct msg_conn *conn,
  * the first half of the encoding, after which one can simply append the
  * secondary data to the message.
  */
-#define mgmt_msg_native_xpath_encode(msg, xpath)                               \
-	do {                                                                   \
-		size_t __slen = strlen(xpath) + 1;                             \
-		mgmt_msg_native_append(msg, xpath, __slen);                    \
-		(msg)->vsplit = __slen;                                        \
+#define mgmt_msg_native_xpath_encode(msg, xpath)                                                   \
+	do {                                                                                       \
+		size_t _m__slen = strlen(xpath) + 1;                                               \
+		mgmt_msg_native_append(msg, xpath, _m__slen);                                      \
+		(msg)->vsplit = _m__slen;                                                          \
 	} while (0)
 
 /**
@@ -727,17 +725,17 @@ extern int vmgmt_msg_native_send_error(struct msg_conn *conn,
  *	The xpath string or NULL if there was an error decoding (i.e., the
  *	message is corrupt).
  */
-#define mgmt_msg_native_xpath_data_decode(msg, msglen, __data)                                     \
+#define mgmt_msg_native_xpath_data_decode(msg, msglen, _data)                                      \
 	({                                                                                         \
-		size_t __len = (msglen) - sizeof(*msg);                                            \
-		const char *__s = NULL;                                                            \
-		(__data) = NULL;                                                                   \
-		if (msg->vsplit && msg->vsplit <= __len && msg->data[msg->vsplit - 1] == 0) {      \
-			if (msg->vsplit < __len)                                                   \
-				(__data) = msg->data + msg->vsplit;                                \
-			__s = msg->data;                                                           \
+		size_t _m__len = (msglen) - sizeof(*msg);                                          \
+		const char *_m__s = NULL;                                                          \
+		(_data) = NULL;                                                                    \
+		if (msg->vsplit && msg->vsplit <= _m__len && msg->data[msg->vsplit - 1] == 0) {    \
+			if (msg->vsplit < _m__len)                                                 \
+				(_data) = msg->data + msg->vsplit;                                 \
+			_m__s = msg->data;                                                         \
 		}                                                                                  \
-		__s;                                                                               \
+		_m__s;                                                                             \
 	})
 
 /**
@@ -753,14 +751,13 @@ extern int vmgmt_msg_native_send_error(struct msg_conn *conn,
  *	The xpath string or NULL if there was an error decoding (i.e., the
  *	message is corrupt).
  */
-#define mgmt_msg_native_xpath_decode(msg, msglen)                              \
-	({                                                                     \
-		size_t __len = (msglen) - sizeof(*msg);                        \
-		const char *__s = msg->data;                                   \
-		if (!msg->vsplit || msg->vsplit > __len ||                     \
-		    __s[msg->vsplit - 1] != 0)                                 \
-			__s = NULL;                                            \
-		__s;                                                           \
+#define mgmt_msg_native_xpath_decode(msg, msglen)                                                  \
+	({                                                                                         \
+		size_t _m__len = (msglen) - sizeof(*msg);                                          \
+		const char *_m__s = msg->data;                                                     \
+		if (!msg->vsplit || msg->vsplit > _m__len || _m__s[msg->vsplit - 1] != 0)          \
+			_m__s = NULL;                                                              \
+		_m__s;                                                                             \
 	})
 
 /**
@@ -776,13 +773,13 @@ extern int vmgmt_msg_native_send_error(struct msg_conn *conn,
  *	The secondary data or NULL if there was an error decoding (i.e., the
  *	message is corrupt).
  */
-#define mgmt_msg_native_data_decode(msg, msglen)                               \
-	({                                                                     \
-		size_t __len = (msglen) - sizeof(*msg);                        \
-		const char *__data = msg->data + msg->vsplit;                  \
-		if (!msg->vsplit || msg->vsplit > __len || __data[-1] != 0)    \
-			__data = NULL;                                         \
-		__data;                                                        \
+#define mgmt_msg_native_data_decode(msg, msglen)                                                   \
+	({                                                                                         \
+		size_t _m__len = (msglen) - sizeof(*msg);                                          \
+		const char *_m__data = msg->data + msg->vsplit;                                    \
+		if (!msg->vsplit || msg->vsplit > _m__len || _m__data[-1] != 0)                    \
+			_m__data = NULL;                                                           \
+		_m__data;                                                                          \
 	})
 
 /**

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -50,10 +50,9 @@ struct nb_yang_xpath {
 	} tags[NB_MAX_NUM_XPATH_TAGS];
 };
 
-#define NB_YANG_XPATH_KEY(__xpath, __indx1, __indx2)                           \
-	((__xpath->num_tags > __indx1) &&                                      \
-			 (__xpath->tags[__indx1].num_keys > __indx2)           \
-		 ? &__xpath->tags[__indx1].keys[__indx2]                       \
+#define NB_YANG_XPATH_KEY(_xpath, _indx1, _indx2)                                                  \
+	(((_xpath)->num_tags > (_indx1)) && ((_xpath)->tags[(_indx1)].num_keys > (_indx2))         \
+		 ? &(_xpath)->tags[(_indx1)].keys[(_indx2)]                                        \
 		 : NULL)
 
 /* Northbound events. */

--- a/lib/northbound_notif.c
+++ b/lib/northbound_notif.c
@@ -12,8 +12,8 @@
 #include "northbound.h"
 #include "mgmt_be_client.h"
 
-#define __dbg(fmt, ...)	    DEBUGD(&nb_dbg_notif, "NB_OP_CHANGE: %s: " fmt, __func__, ##__VA_ARGS__)
-#define __log_err(fmt, ...) zlog_err("NB_OP_CHANGE: %s: ERROR: " fmt, __func__, ##__VA_ARGS__)
+#define _dbg(fmt, ...)	   DEBUGD(&nb_dbg_notif, "NB_OP_CHANGE: %s: " fmt, __func__, ##__VA_ARGS__)
+#define _log_err(fmt, ...) zlog_err("NB_OP_CHANGE: %s: ERROR: " fmt, __func__, ##__VA_ARGS__)
 
 #define NB_NOTIF_TIMER_MSEC (10) /* 10msec */
 
@@ -177,7 +177,7 @@ static struct op_changes_group *__op_changes_group_push(uint64_t refer_id)
 	if (RB_EMPTY(op_changes, &nb_notif_adds) && RB_EMPTY(op_changes, &nb_notif_dels))
 		return NULL;
 
-	__dbg("pushing current oper changes onto queue");
+	_dbg("pushing current oper changes onto queue");
 
 	changes = XCALLOC(MTYPE_OP_CHANGES_GROUP, sizeof(*changes));
 	changes->adds = nb_notif_adds;
@@ -241,8 +241,8 @@ static void __drop_eq_or_more_specific(struct op_changes *head, const char *path
 		/* if the prefix no longer matches we are done */
 		if (pathncmp(path, e->path, plen))
 			break;
-		__dbg("dropping more specific %s: %s", head == &nb_notif_adds ? "add" : "delete",
-		      e->path);
+		_dbg("dropping more specific %s: %s", head == &nb_notif_adds ? "add" : "delete",
+		     e->path);
 		next = RB_NEXT(op_changes, e);
 		RB_REMOVE(op_changes, head, e);
 		op_change_free(e);
@@ -259,14 +259,14 @@ static void __op_change_add_del(const char *path, struct op_changes *this_head,
 	struct op_change *next, *e;
 	int plen;
 
-	__dbg("processing oper %s change path: %s", op, path);
+	_dbg("processing oper %s change path: %s", op, path);
 
 	/*
 	 * See if we are already covered by a more general `op`.
 	 */
 	e = __find_less_specific(this_head, note);
 	if (e) {
-		__dbg("%s path already covered by: %s", op, e->path);
+		_dbg("%s path already covered by: %s", op, e->path);
 		op_change_free(note);
 		return;
 	}
@@ -282,7 +282,7 @@ static void __op_change_add_del(const char *path, struct op_changes *this_head,
 			 * more-specific delete as the add-replace will remove
 			 * this missing state.
 			 */
-			__dbg("delete path already covered add-replace: %s", e->path);
+			_dbg("delete path already covered add-replace: %s", e->path);
 		} else {
 			/*
 			 * If we have a less-specific delete, convert the delete
@@ -292,7 +292,7 @@ static void __op_change_add_del(const char *path, struct op_changes *this_head,
 			 * any other existing state that was to be deleted will
 			 * still be deleted (unless it also returns) by the replace.
 			 */
-			__dbg("add covered, converting covering delete to add-replace: %s", e->path);
+			_dbg("add covered, converting covering delete to add-replace: %s", e->path);
 			RB_REMOVE(op_changes, other_head, e);
 			__op_change_add_del(e->path, &nb_notif_adds, &nb_notif_dels);
 			op_change_free(e);
@@ -303,12 +303,12 @@ static void __op_change_add_del(const char *path, struct op_changes *this_head,
 
 	e = RB_INSERT(op_changes, this_head, note);
 	if (e) {
-		__dbg("path already in %s tree: %s", op, path);
+		_dbg("path already in %s tree: %s", op, path);
 		op_change_free(note);
 		return;
 	}
 
-	__dbg("scanning for subsumed or subsuming: %s", path);
+	_dbg("scanning for subsumed or subsuming: %s", path);
 
 	plen = strlen(path);
 
@@ -355,7 +355,7 @@ struct lyd_node *nb_op_update(struct lyd_node *tree, const char *path, const cha
 	struct lyd_node *dnode;
 	const char *abs_path = NULL;
 
-	__dbg("updating path: %s with value: %s", path, value);
+	_dbg("updating path: %s with value: %s", path, value);
 
 	dnode = yang_state_new(tree, path, value);
 
@@ -376,7 +376,7 @@ void nb_op_update_delete(struct lyd_node *tree, const char *path)
 {
 	char *abs_path = NULL;
 
-	__dbg("deleting path: %s", path);
+	_dbg("deleting path: %s", path);
 
 	if (path && path[0] == '/')
 		abs_path = (char *)path;
@@ -531,7 +531,7 @@ static struct op_change *__next_change(struct op_changes_group *group)
 
 static struct op_changes_group *__next_group(struct op_changes_group *group)
 {
-	__dbg("done with oper-path collection for group");
+	_dbg("done with oper-path collection for group");
 	op_changes_group_free(group);
 	return op_changes_group_next();
 }
@@ -546,16 +546,16 @@ static enum nb_error oper_walk_done(const struct lyd_node *tree, void *arg, enum
 	assert(ret != NB_YIELD);
 
 	if (ret == NB_ERR_NOT_FOUND) {
-		__dbg("Path not found while walking oper tree: %s", path);
+		_dbg("Path not found while walking oper tree: %s", path);
 		ret = NB_OK;
 	} else if (ret != NB_OK) {
 error:
-		__log_err("Error notifying for datastore path: %s: %s", path, nb_err_name(ret));
+		_log_err("Error notifying for datastore path: %s: %s", path, nb_err_name(ret));
 
 		timer_walk_abort(args);
 		goto done;
 	} else {
-		__dbg("Done with oper-path collection for path: %s", path);
+		_dbg("Done with oper-path collection for path: %s", path);
 
 		/* Do we need this? */
 		while (tree->parent)
@@ -563,7 +563,7 @@ error:
 
 		/* Send the add (replace) notification */
 		if (mgmt_be_send_ds_replace_notification(path, tree, group->refer_id)) {
-			__log_err("Error sending notification message for path: %s", path);
+			_log_err("Error sending notification message for path: %s", path);
 			ret = NB_ERR;
 			goto error;
 		}
@@ -598,8 +598,8 @@ static int nb_notify_delete_changes(struct nb_notif_walk_args *args)
 	group->cur_change = RB_MIN(op_changes, group->cur_changes);
 	while (group->cur_change) {
 		if (mgmt_be_send_ds_delete_notification(group->cur_change->path)) {
-			__log_err("Error sending delete notification message for path: %s",
-				  group->cur_change->path);
+			_log_err("Error sending delete notification message for path: %s",
+				 group->cur_change->path);
 			return 1;
 		}
 		group->cur_change = __next_change(group);
@@ -639,7 +639,7 @@ static void timer_walk_continue(struct event *event)
 	}
 
 	path = group->cur_change->path;
-	__dbg("starting next oper-path replace walk for path: %s", path);
+	_dbg("starting next oper-path replace walk for path: %s", path);
 	nb_notif_walk = nb_oper_walk(path, NULL, 0, false, NULL, NULL, oper_walk_done, args);
 }
 
@@ -648,11 +648,11 @@ static void timer_walk_start(struct event *event)
 	struct op_changes_group *group;
 	struct nb_notif_walk_args *args;
 
-	__dbg("oper-state change notification timer fires");
+	_dbg("oper-state change notification timer fires");
 
 	group = op_changes_group_next();
 	if (!group) {
-		__dbg("no oper changes to notify");
+		_dbg("no oper changes to notify");
 		return;
 	}
 
@@ -665,16 +665,16 @@ static void timer_walk_start(struct event *event)
 
 static void timer_walk_abort(struct nb_notif_walk_args *args)
 {
-	__dbg("Failed notifying datastore changes, will retry");
+	_dbg("Failed notifying datastore changes, will retry");
 
-	__dbg("oper-state notify setting retry timer to fire in: %d msec ", NB_NOTIF_TIMER_MSEC);
+	_dbg("oper-state notify setting retry timer to fire in: %d msec ", NB_NOTIF_TIMER_MSEC);
 	event_add_timer_msec(nb_notif_master, timer_walk_continue, args, NB_NOTIF_TIMER_MSEC,
 			     &nb_notif_timer);
 }
 
 static void timer_walk_done(struct nb_notif_walk_args *args)
 {
-	__dbg("Finished notifying for all datastore changes");
+	_dbg("Finished notifying for all datastore changes");
 	assert(!args->group);
 	XFREE(MTYPE_NB_NOTIF_WALK_ARGS, args);
 }
@@ -682,15 +682,15 @@ static void timer_walk_done(struct nb_notif_walk_args *args)
 static void nb_notif_set_walk_timer(void)
 {
 	if (nb_notif_walk) {
-		__dbg("oper-state walk already in progress.");
+		_dbg("oper-state walk already in progress.");
 		return;
 	}
 	if (event_is_scheduled(nb_notif_timer)) {
-		__dbg("oper-state notification timer already set.");
+		_dbg("oper-state notification timer already set.");
 		return;
 	}
 
-	__dbg("oper-state notification setting timer to fire in: %d msec ", NB_NOTIF_TIMER_MSEC);
+	_dbg("oper-state notification setting timer to fire in: %d msec ", NB_NOTIF_TIMER_MSEC);
 	event_add_timer_msec(nb_notif_master, timer_walk_start, NULL, NB_NOTIF_TIMER_MSEC,
 			     &nb_notif_timer);
 }
@@ -761,7 +761,7 @@ void nb_notif_terminate(void)
 	struct nb_notif_walk_args *args = nb_notif_timer ? EVENT_ARG(nb_notif_timer) : NULL;
 	struct op_changes_group *group;
 
-	__dbg("terminating: timer: %p timer arg: %p walk %p", nb_notif_timer, args, nb_notif_walk);
+	_dbg("terminating: timer: %p timer arg: %p walk %p", nb_notif_timer, args, nb_notif_walk);
 
 	event_cancel(&nb_notif_timer);
 

--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -289,9 +289,9 @@ static uint nb_op_get_position_predicate(struct nb_op_yield_state *ys, struct nb
 }
 
 /**
- * __move_back_to_next() - move back to the next lookup-next schema
+ * _move_back_to_next() - move back to the next lookup-next schema
  */
-static bool __move_back_to_next(struct nb_op_yield_state *ys, int i)
+static bool _move_back_to_next(struct nb_op_yield_state *ys, int i)
 {
 	struct nb_op_node_info *ni;
 	int j;
@@ -324,7 +324,7 @@ static bool __move_back_to_next(struct nb_op_yield_state *ys, int i)
 	ni->list_entry = NULL;
 
 	/*
-	 * Leave the empty-of-data node_info on top, __walk will deal with
+	 * Leave the empty-of-data node_info on top, _walk will deal with
 	 * this, by doing a lookup-next with the keys which we still have.
 	 */
 
@@ -375,7 +375,7 @@ static void nb_op_resume_data_tree(struct nb_op_yield_state *ys)
 			 * container with last lookup_next list node
 			 * (which may be this one) and get next.
 			 */
-			if (!__move_back_to_next(ys, i))
+			if (!_move_back_to_next(ys, i))
 				DEBUGD(&nb_dbg_events,
 				       "%s: Nothing to resume after delete during walk (yield)",
 				       __func__);
@@ -674,13 +674,13 @@ static enum nb_error nb_op_ys_init_node_infos(struct nb_op_yield_state *ys)
 /* End of init code */
 /* ================ */
 
-static const char *__module_name(const struct nb_node *nb_node)
+static const char *_module_name(const struct nb_node *nb_node)
 {
 	return nb_node->snode->module->name;
 }
 
-static get_tree_locked_cb __get_get_tree_funcs(const char *module_name,
-					       unlock_tree_cb *unlock_func_pp)
+static get_tree_locked_cb _get_get_tree_funcs(const char *module_name,
+					      unlock_tree_cb *unlock_func_pp)
 {
 	struct yang_module *module = yang_module_find(module_name);
 
@@ -691,15 +691,15 @@ static get_tree_locked_cb __get_get_tree_funcs(const char *module_name,
 	return module->frr_info->get_tree_locked;
 }
 
-static const struct lyd_node *__get_tree(struct nb_op_yield_state *ys,
-					 const struct nb_node *nb_node, const char *xpath)
+static const struct lyd_node *_get_tree(struct nb_op_yield_state *ys, const struct nb_node *nb_node,
+					const char *xpath)
 {
 	get_tree_locked_cb get_tree_cb;
 
 	if (ys->user_tree)
 		return ys->user_tree;
 
-	get_tree_cb = __get_get_tree_funcs(__module_name(nb_node), &ys->user_tree_unlock);
+	get_tree_cb = _get_get_tree_funcs(_module_name(nb_node), &ys->user_tree_unlock);
 	assert(get_tree_cb);
 
 	ys->user_tree = get_tree_cb(xpath, &ys->user_tree_lock);
@@ -714,7 +714,7 @@ static enum nb_error nb_op_libyang_cb_get(struct nb_op_yield_state *ys,
 					  const char *xpath)
 {
 	const struct lysc_node *snode = nb_node->snode;
-	const struct lyd_node *tree = __get_tree(ys, nb_node, xpath);
+	const struct lyd_node *tree = _get_tree(ys, nb_node, xpath);
 	struct lyd_node *node;
 	LY_ERR err;
 
@@ -735,7 +735,7 @@ static enum nb_error nb_op_libyang_cb_get_leaflist(struct nb_op_yield_state *ys,
 						   struct lyd_node *parent, const char *xpath)
 {
 	const struct lysc_node *snode = nb_node->snode;
-	const struct lyd_node *tree = __get_tree(ys, nb_node, xpath);
+	const struct lyd_node *tree = _get_tree(ys, nb_node, xpath);
 	struct ly_set *set = NULL;
 	LY_ERR err;
 	int ret = NB_OK;
@@ -759,10 +759,10 @@ static enum nb_error nb_op_libyang_cb_get_leaflist(struct nb_op_yield_state *ys,
 	return ret;
 }
 
-static const struct lyd_node *__get_node_other_tree(const struct lyd_node *tree,
-						    const struct lyd_node *parent_node,
-						    const struct lysc_node *schema,
-						    const struct yang_list_keys *keys)
+static const struct lyd_node *_get_node_other_tree(const struct lyd_node *tree,
+						   const struct lyd_node *parent_node,
+						   const struct lysc_node *schema,
+						   const struct yang_list_keys *keys)
 {
 	char xpath[XPATH_MAXLEN];
 	struct lyd_node *node;
@@ -825,21 +825,21 @@ static const void *nb_op_list_lookup_entry(struct nb_op_yield_state *ys, struct 
 		}
 		keys = &_keys;
 	}
-	tree = __get_tree(ys, nb_node, NULL);
+	tree = _get_tree(ys, nb_node, NULL);
 	parent_node = pni ? pni->inner : NULL;
-	return __get_node_other_tree(tree, parent_node, nb_node->snode, keys);
+	return _get_node_other_tree(tree, parent_node, nb_node->snode, keys);
 }
 
-static const void *__get_next(struct nb_op_yield_state *ys, struct nb_node *nb_node,
-			      const struct nb_op_node_info *pni, const void *list_entry)
+static const void *_get_next(struct nb_op_yield_state *ys, struct nb_node *nb_node,
+			     const struct nb_op_node_info *pni, const void *list_entry)
 {
 	const struct lysc_node *snode = nb_node->snode;
-	const struct lyd_node *tree = __get_tree(ys, nb_node, NULL);
+	const struct lyd_node *tree = _get_tree(ys, nb_node, NULL);
 	const struct lyd_node *parent_node = pni ? pni->inner : NULL;
 	const struct lyd_node *node = list_entry;
 
 	if (!node)
-		return __get_node_other_tree(tree, parent_node, snode, NULL);
+		return _get_node_other_tree(tree, parent_node, snode, NULL);
 
 	node = node->next;
 	LY_LIST_FOR (node, node) {
@@ -854,7 +854,7 @@ static const void *nb_op_list_get_next(struct nb_op_yield_state *ys, struct nb_n
 {
 	if (!CHECK_FLAG(nb_node->flags, F_NB_NODE_HAS_GET_TREE))
 		return nb_callback_get_next(nb_node, pni ? pni->list_entry : NULL, list_entry);
-	return __get_next(ys, nb_node, pni, list_entry);
+	return _get_next(ys, nb_node, pni, list_entry);
 }
 
 static enum nb_error nb_op_list_get_keys(struct nb_op_yield_state *ys, struct nb_node *nb_node,
@@ -1080,20 +1080,20 @@ static char *nb_op_get_child_path(const char *xpath_parent,
 	return xpath_child;
 }
 
-static bool __is_yielding_node(const struct lysc_node *snode)
+static bool _is_yielding_node(const struct lysc_node *snode)
 {
 	struct nb_node *nn = snode->priv;
 
 	return nn->cbs.lookup_next != NULL;
 }
 
-static const struct lysc_node *__sib_next(bool yn, const struct lysc_node *sib)
+static const struct lysc_node *_sib_next(bool yn, const struct lysc_node *sib)
 {
 	for (; sib; sib = sib->next) {
 		/* Always skip keys. */
 		if (lysc_is_key(sib))
 			continue;
-		if (yn == __is_yielding_node(sib))
+		if (yn == _is_yielding_node(sib))
 			return sib;
 	}
 	return NULL;
@@ -1110,7 +1110,7 @@ static const struct lysc_node *nb_op_sib_next(struct nb_op_yield_state *ys,
 					      const struct lysc_node *sib)
 {
 	struct lysc_node *parent = sib->parent;
-	bool yn = __is_yielding_node(sib);
+	bool yn = _is_yielding_node(sib);
 
 	/*
 	 * If the node info stack is shorter than the schema path then we are
@@ -1139,12 +1139,12 @@ static const struct lysc_node *nb_op_sib_next(struct nb_op_yield_state *ys,
 			return NULL;
 	}
 
-	sib = __sib_next(yn, sib->next);
+	sib = _sib_next(yn, sib->next);
 	if (sib)
 		return sib;
 	if (yn)
 		return NULL;
-	return __sib_next(true, lysc_node_child(parent));
+	return _sib_next(true, lysc_node_child(parent));
 }
 /*
  * sib_walk((struct lyd_node *)ni->inner->node.parent->parent->parent->parent->parent->parent->parent)
@@ -1194,8 +1194,8 @@ static const struct lysc_node *nb_op_sib_first(struct nb_op_yield_state *ys,
 
 	/* Return non-yielding node's first */
 	first_sib = sib;
-	if (__is_yielding_node(sib)) {
-		sib = __sib_next(false, sib);
+	if (_is_yielding_node(sib)) {
+		sib = _sib_next(false, sib);
 		if (sib)
 			return sib;
 	}
@@ -1234,7 +1234,7 @@ static const struct lysc_node *nb_op_sib_first(struct nb_op_yield_state *ys,
  *                             Schema Leaf C: 7,10,13
  *                             Schema Leaf D: 8,11,14
  */
-static enum nb_error __walk(struct nb_op_yield_state *ys, bool is_resume)
+static enum nb_error _walk(struct nb_op_yield_state *ys, bool is_resume)
 {
 	const struct lysc_node *walk_stem_tip = ys_get_walk_stem_tip(ys);
 	const struct lysc_node *sib;
@@ -1867,7 +1867,7 @@ static void nb_op_walk_continue(struct event *thread)
 	assert(darr_last(ys->node_infos) &&
 	       darr_last(ys->node_infos)->has_lookup_next);
 
-	ret = __walk(ys, true);
+	ret = _walk(ys, true);
 	if (ret == NB_YIELD) {
 		ret = nb_op_yield(ys);
 		if (ret == NB_OK)
@@ -1879,7 +1879,7 @@ finish:
 	nb_op_free_yield_state(ys, false);
 }
 
-static void __free_siblings(struct lyd_node *this)
+static void _free_siblings(struct lyd_node *this)
 {
 	struct lyd_node *next, *sib;
 	uint count = 0;
@@ -1922,13 +1922,13 @@ static void nb_op_trim_yield_state(struct nb_op_yield_state *ys)
 	assert(ni->has_lookup_next);
 
 	DEBUGD(&nb_dbg_events, "NB oper-state: deleting tree at level %d", i);
-	__free_siblings(ni->inner);
+	_free_siblings(ni->inner);
 	ys_free_inner(ys, ni);
 
 	while (--i > 0) {
 		DEBUGD(&nb_dbg_events,
 		       "NB oper-state: deleting siblings at level: %d", i);
-		__free_siblings(ys->node_infos[i].inner);
+		_free_siblings(ys->node_infos[i].inner);
 	}
 	DEBUGD(&nb_dbg_events, "NB oper-state: stop trimming: new top: %d",
 	       (int)darr_lasti(ys->node_infos));
@@ -2119,7 +2119,7 @@ static enum nb_error nb_op_walk_start(struct nb_op_yield_state *ys)
 	if (ret != NB_OK)
 		return ret;
 
-	return __walk(ys, false);
+	return _walk(ys, false);
 }
 
 bool nb_oper_is_yang_lib_query(const char *xpath)
@@ -2217,7 +2217,7 @@ enum nb_error nb_oper_iterate_legacy(const char *xpath,
 	return ret;
 }
 
-static const char *__adjust_ptr(struct lysc_node_leaf *lsnode, const char *valuep, size_t *size)
+static const char *_adjust_ptr(struct lysc_node_leaf *lsnode, const char *valuep, size_t *size)
 {
 	switch (lsnode->type->basetype) {
 	case LY_TYPE_INT8:
@@ -2273,7 +2273,7 @@ enum nb_error nb_oper_uint64_get(const struct nb_node *nb_node, const void *pare
 	const char *valuep;
 	size_t size;
 
-	valuep = __adjust_ptr(lsnode, (const char *)&ubigval, &size);
+	valuep = _adjust_ptr(lsnode, (const char *)&ubigval, &size);
 	if (lyd_new_term_bin(parent, snode->module, snode->name, valuep, size, LYD_NEW_PATH_UPDATE,
 			     NULL))
 		return NB_ERR_RESOURCE;
@@ -2291,7 +2291,7 @@ enum nb_error nb_oper_uint32_get(const struct nb_node *nb_node, const void *pare
 	const char *valuep;
 	size_t size;
 
-	valuep = __adjust_ptr(lsnode, (const char *)&ubigval, &size);
+	valuep = _adjust_ptr(lsnode, (const char *)&ubigval, &size);
 	if (lyd_new_term_bin(parent, snode->module, snode->name, valuep, size, LYD_NEW_PATH_UPDATE,
 			     NULL))
 		return NB_ERR_RESOURCE;

--- a/lib/yang_wrappers.c
+++ b/lib/yang_wrappers.c
@@ -15,24 +15,26 @@
 #include "printfrr.h"
 
 
-#define YANG_DNODE_XPATH_GET_VALUE(dnode, xpath_fmt)                           \
-	({                                                                     \
-		va_list __ap;                                                  \
-		va_start(__ap, (xpath_fmt));                                   \
-		const struct lyd_value *__dvalue =                             \
-			yang_dnode_xpath_get_value(dnode, xpath_fmt, __ap);    \
-		va_end(__ap);                                                  \
-		__dvalue;                                                      \
+#define YANG_DNODE_XPATH_GET_VALUE(dnode, xpath_fmt)                                               \
+	({                                                                                         \
+		const struct lyd_value *_y__dvalue;                                                \
+		va_list _Y__ap;                                                                    \
+                                                                                                   \
+		va_start(_Y__ap, (xpath_fmt));                                                     \
+		_y__dvalue = yang_dnode_xpath_get_value(dnode, xpath_fmt, _Y__ap);                 \
+		va_end(_Y__ap);                                                                    \
+		_y__dvalue;                                                                        \
 	})
 
-#define YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt)                           \
-	({                                                                     \
-		va_list __ap;                                                  \
-		va_start(__ap, (xpath_fmt));                                   \
-		const char *__canon =                                          \
-			yang_dnode_xpath_get_canon(dnode, xpath_fmt, __ap);    \
-		va_end(__ap);                                                  \
-		__canon;                                                       \
+#define YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt)                                               \
+	({                                                                                         \
+		const char *_y__canon;                                                             \
+		va_list _y__ap;                                                                    \
+                                                                                                   \
+		va_start(_y__ap, (xpath_fmt));                                                     \
+		_y__canon = yang_dnode_xpath_get_canon(dnode, xpath_fmt, _y__ap);                  \
+		va_end(_y__ap);                                                                    \
+		_y__canon;                                                                         \
 	})
 
 #define YANG_DNODE_GET_ASSERT(dnode, xpath)                                    \
@@ -50,17 +52,17 @@ static inline const char *
 yang_dnode_xpath_get_canon(const struct lyd_node *dnode, const char *xpath_fmt,
 			   va_list ap)
 {
-	const struct lyd_node_term *__dleaf =
-		(const struct lyd_node_term *)dnode;
-	assert(__dleaf);
+	const struct lyd_node_term *dleaf = (const struct lyd_node_term *)dnode;
+
+	assert(dleaf);
 	if (xpath_fmt) {
-		char __xpath[XPATH_MAXLEN];
-		vsnprintf(__xpath, sizeof(__xpath), xpath_fmt, ap);
-		__dleaf = (const struct lyd_node_term *)yang_dnode_get(dnode,
-								       __xpath);
-		YANG_DNODE_GET_ASSERT(__dleaf, __xpath);
+		char xpath[XPATH_MAXLEN];
+
+		vsnprintf(xpath, sizeof(xpath), xpath_fmt, ap);
+		dleaf = (const struct lyd_node_term *)yang_dnode_get(dnode, xpath);
+		YANG_DNODE_GET_ASSERT(dleaf, xpath);
 	}
-	return lyd_get_value(&__dleaf->node);
+	return lyd_get_value(&dleaf->node);
 }
 
 PRINTFRR(2, 0)
@@ -68,20 +70,22 @@ static inline const struct lyd_value *
 yang_dnode_xpath_get_value(const struct lyd_node *dnode, const char *xpath_fmt,
 			   va_list ap)
 {
-	const struct lyd_node_term *__dleaf =
-		(const struct lyd_node_term *)dnode;
-	assert(__dleaf);
+	const struct lyd_node_term *dleaf = (const struct lyd_node_term *)dnode;
+	const struct lyd_value *dvalue;
+
+	assert(dleaf);
 	if (xpath_fmt) {
-		char __xpath[XPATH_MAXLEN];
-		vsnprintf(__xpath, sizeof(__xpath), xpath_fmt, ap);
-		__dleaf = (const struct lyd_node_term *)yang_dnode_get(dnode,
-								       __xpath);
-		YANG_DNODE_GET_ASSERT(__dleaf, __xpath);
+		char _xpath[XPATH_MAXLEN];
+
+		vsnprintf(_xpath, sizeof(_xpath), xpath_fmt, ap);
+		dleaf = (const struct lyd_node_term *)yang_dnode_get(dnode, _xpath);
+		YANG_DNODE_GET_ASSERT(dleaf, _xpath);
 	}
-	const struct lyd_value *__dvalue = &__dleaf->value;
-	if (__dvalue->realtype->basetype == LY_TYPE_UNION)
-		__dvalue = &__dvalue->subvalue->value;
-	return __dvalue;
+	dvalue = &dleaf->value;
+
+	if (dvalue->realtype->basetype == LY_TYPE_UNION)
+		dvalue = &dvalue->subvalue->value;
+	return dvalue;
 }
 
 static const char *yang_get_default_value(const char *xpath)

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -22,10 +22,8 @@
 #include "mgmt_be_client.h"
 #include "mgmtd/mgmt_be_adapter.h"
 
-#define __dbg(fmt, ...)                                                        \
-	DEBUGD(&mgmt_debug_be, "BE-ADAPTER: %s: " fmt, __func__, ##__VA_ARGS__)
-#define __log_err(fmt, ...)                                                    \
-	zlog_err("BE-ADAPTER: %s: ERROR: " fmt, __func__, ##__VA_ARGS__)
+#define _dbg(fmt, ...)	   DEBUGD(&mgmt_debug_be, "BE-ADAPTER: %s: " fmt, __func__, ##__VA_ARGS__)
+#define _log_err(fmt, ...) zlog_err("BE-ADAPTER: %s: ERROR: " fmt, __func__, ##__VA_ARGS__)
 
 #define FOREACH_ADAPTER_IN_LIST(adapter)                                       \
 	frr_each_safe (mgmt_be_adapters, &mgmt_be_adapters, (adapter))
@@ -307,42 +305,42 @@ static void mgmt_be_xpath_map_init(void)
 	enum mgmt_be_client_id id;
 	const char *const *init;
 
-	__dbg("Init XPath Maps");
+	_dbg("Init XPath Maps");
 
 	FOREACH_MGMTD_BE_CLIENT_ID (id) {
 		/* Initialize the common config init map */
 		for (init = be_client_config_xpaths[id]; init && *init; init++) {
-			__dbg(" - CFG XPATH: '%s'", *init);
+			_dbg(" - CFG XPATH: '%s'", *init);
 			mgmt_register_client_xpath(id, *init,
 						   MGMT_BE_XPATH_SUBSCR_TYPE_CFG);
 		}
 
 		/* Initialize the common oper init map */
 		for (init = be_client_oper_xpaths[id]; init && *init; init++) {
-			__dbg(" - OPER XPATH: '%s'", *init);
+			_dbg(" - OPER XPATH: '%s'", *init);
 			mgmt_register_client_xpath(id, *init,
 						   MGMT_BE_XPATH_SUBSCR_TYPE_OPER);
 		}
 
 		/* Initialize the common NOTIF init map */
 		for (init = be_client_notif_xpaths[id]; init && *init; init++) {
-			__dbg(" - NOTIF XPATH: '%s'", *init);
+			_dbg(" - NOTIF XPATH: '%s'", *init);
 			mgmt_register_client_xpath(id, *init,
 						   MGMT_BE_XPATH_SUBSCR_TYPE_NOTIF);
 		}
 
 		/* Initialize the common RPC init map */
 		for (init = be_client_rpc_xpaths[id]; init && *init; init++) {
-			__dbg(" - RPC XPATH: '%s'", *init);
+			_dbg(" - RPC XPATH: '%s'", *init);
 			mgmt_register_client_xpath(id, *init,
 						   MGMT_BE_XPATH_SUBSCR_TYPE_RPC);
 		}
 	}
 
-	__dbg("Total Cfg XPath Maps: %u", darr_len(be_cfg_xpath_map));
-	__dbg("Total Oper XPath Maps: %u", darr_len(be_oper_xpath_map));
-	__dbg("Total Notif XPath Maps: %u", darr_len(be_notif_xpath_map));
-	__dbg("Total RPC XPath Maps: %u", darr_len(be_rpc_xpath_map));
+	_dbg("Total Cfg XPath Maps: %u", darr_len(be_cfg_xpath_map));
+	_dbg("Total Oper XPath Maps: %u", darr_len(be_oper_xpath_map));
+	_dbg("Total Notif XPath Maps: %u", darr_len(be_notif_xpath_map));
+	_dbg("Total RPC XPath Maps: %u", darr_len(be_rpc_xpath_map));
 }
 
 static void mgmt_be_xpath_map_cleanup(void)
@@ -394,7 +392,7 @@ static bool mgmt_be_xpath_prefix(const char *path, const char *xpath)
 
 static void mgmt_be_adapter_delete(struct mgmt_be_client_adapter *adapter)
 {
-	__dbg("deleting client adapter '%s'", adapter->name);
+	_dbg("deleting client adapter '%s'", adapter->name);
 
 	/*
 	 * Notify about disconnect for appropriate cleanup
@@ -413,7 +411,7 @@ static int mgmt_be_adapter_notify_disconnect(struct msg_conn *conn)
 {
 	struct mgmt_be_client_adapter *adapter = conn->user;
 
-	__dbg("notify disconnect for client adapter '%s'", adapter->name);
+	_dbg("notify disconnect for client adapter '%s'", adapter->name);
 
 	mgmt_be_adapter_delete(adapter);
 
@@ -431,8 +429,8 @@ mgmt_be_adapter_cleanup_old_conn(struct mgmt_be_client_adapter *adapter)
 			/*
 			 * We have a Zombie lingering around
 			 */
-			__dbg("Client '%s' (FD:%d) seems to have reconnected. Removing old connection (FD:%d)!",
-			      adapter->name, adapter->conn->fd, old->conn->fd);
+			_dbg("Client '%s' (FD:%d) seems to have reconnected. Removing old connection (FD:%d)!",
+			     adapter->name, adapter->conn->fd, old->conn->fd);
 			/* this will/should delete old */
 			msg_conn_disconnect(old->conn, false);
 		}
@@ -461,8 +459,7 @@ static int mgmt_be_send_subscr_reply(struct mgmt_be_client_adapter *adapter,
 	be_msg.message_case = MGMTD__BE_MESSAGE__MESSAGE_SUBSCR_REPLY;
 	be_msg.subscr_reply = &reply;
 
-	__dbg("Sending SUBSCR_REPLY client: %s success: %u", adapter->name,
-	      success);
+	_dbg("Sending SUBSCR_REPLY client: %s success: %u", adapter->name, success);
 
 	return mgmt_be_adapter_send_msg(adapter, &be_msg);
 }
@@ -480,20 +477,18 @@ mgmt_be_adapter_handle_msg(struct mgmt_be_client_adapter *adapter,
 	 */
 	switch ((int)be_msg->message_case) {
 	case MGMTD__BE_MESSAGE__MESSAGE_SUBSCR_REQ:
-		__dbg("Got SUBSCR_REQ from '%s' to register xpaths config: %zu oper: %zu notif: %zu rpc: %zu",
-		      be_msg->subscr_req->client_name,
-		      be_msg->subscr_req->n_config_xpaths,
-		      be_msg->subscr_req->n_oper_xpaths,
-		      be_msg->subscr_req->n_notif_xpaths,
-		      be_msg->subscr_req->n_rpc_xpaths);
+		_dbg("Got SUBSCR_REQ from '%s' to register xpaths config: %zu oper: %zu notif: %zu rpc: %zu",
+		     be_msg->subscr_req->client_name, be_msg->subscr_req->n_config_xpaths,
+		     be_msg->subscr_req->n_oper_xpaths, be_msg->subscr_req->n_notif_xpaths,
+		     be_msg->subscr_req->n_rpc_xpaths);
 
 		if (strlen(be_msg->subscr_req->client_name)) {
 			strlcpy(adapter->name, be_msg->subscr_req->client_name,
 				sizeof(adapter->name));
 			adapter->id = mgmt_be_client_name2id(adapter->name);
 			if (adapter->id >= MGMTD_BE_CLIENT_ID_MAX) {
-				__log_err("Unable to resolve adapter '%s' to a valid ID. Disconnecting!",
-					  adapter->name);
+				_log_err("Unable to resolve adapter '%s' to a valid ID. Disconnecting!",
+					 adapter->name);
 				/* this will/should delete old */
 				msg_conn_disconnect(adapter->conn, false);
 				break;
@@ -536,10 +531,9 @@ mgmt_be_adapter_handle_msg(struct mgmt_be_client_adapter *adapter,
 		mgmt_be_send_subscr_reply(adapter, true);
 		break;
 	case MGMTD__BE_MESSAGE__MESSAGE_TXN_REPLY:
-		__dbg("Got %s TXN_REPLY from '%s' txn-id %" PRIx64 " with '%s'",
-		      be_msg->txn_reply->create ? "Create" : "Delete",
-		      adapter->name, be_msg->txn_reply->txn_id,
-		      be_msg->txn_reply->success ? "success" : "failure");
+		_dbg("Got %s TXN_REPLY from '%s' txn-id %" PRIx64 " with '%s'",
+		     be_msg->txn_reply->create ? "Create" : "Delete", adapter->name,
+		     be_msg->txn_reply->txn_id, be_msg->txn_reply->success ? "success" : "failure");
 		/*
 		 * Forward the TXN_REPLY to txn module.
 		 */
@@ -549,11 +543,10 @@ mgmt_be_adapter_handle_msg(struct mgmt_be_client_adapter *adapter,
 			be_msg->txn_reply->success, adapter);
 		break;
 	case MGMTD__BE_MESSAGE__MESSAGE_CFG_DATA_REPLY:
-		__dbg("Got CFGDATA_REPLY from '%s' txn-id %" PRIx64 " err:'%s'",
-		      adapter->name, be_msg->cfg_data_reply->txn_id,
-		      be_msg->cfg_data_reply->error_if_any
-			      ? be_msg->cfg_data_reply->error_if_any
-			      : "None");
+		_dbg("Got CFGDATA_REPLY from '%s' txn-id %" PRIx64 " err:'%s'", adapter->name,
+		     be_msg->cfg_data_reply->txn_id,
+		     be_msg->cfg_data_reply->error_if_any ? be_msg->cfg_data_reply->error_if_any
+							  : "None");
 		/*
 		 * Forward the CGFData-create reply to txn module.
 		 */
@@ -563,13 +556,11 @@ mgmt_be_adapter_handle_msg(struct mgmt_be_client_adapter *adapter,
 			be_msg->cfg_data_reply->error_if_any, adapter);
 		break;
 	case MGMTD__BE_MESSAGE__MESSAGE_CFG_APPLY_REPLY:
-		__dbg("Got %s CFG_APPLY_REPLY from '%s' txn-id %" PRIx64
-		      " err:'%s'",
-		      be_msg->cfg_apply_reply->success ? "successful" : "failed",
-		      adapter->name, be_msg->cfg_apply_reply->txn_id,
-		      be_msg->cfg_apply_reply->error_if_any
-			      ? be_msg->cfg_apply_reply->error_if_any
-			      : "None");
+		_dbg("Got %s CFG_APPLY_REPLY from '%s' txn-id %" PRIx64 " err:'%s'",
+		     be_msg->cfg_apply_reply->success ? "successful" : "failed", adapter->name,
+		     be_msg->cfg_apply_reply->txn_id,
+		     be_msg->cfg_apply_reply->error_if_any ? be_msg->cfg_apply_reply->error_if_any
+							   : "None");
 		/*
 		 * Forward the CGFData-apply reply to txn module.
 		 */
@@ -614,7 +605,7 @@ int mgmt_be_send_txn_req(struct mgmt_be_client_adapter *adapter,
 	be_msg.message_case = MGMTD__BE_MESSAGE__MESSAGE_TXN_REQ;
 	be_msg.txn_req = &txn_req;
 
-	__dbg("Sending TXN_REQ to '%s' txn-id: %" PRIu64, adapter->name, txn_id);
+	_dbg("Sending TXN_REQ to '%s' txn-id: %" PRIu64, adapter->name, txn_id);
 
 	return mgmt_be_adapter_send_msg(adapter, &be_msg);
 }
@@ -637,8 +628,8 @@ int mgmt_be_send_cfgdata_req(struct mgmt_be_client_adapter *adapter,
 	be_msg.message_case = MGMTD__BE_MESSAGE__MESSAGE_CFG_DATA_REQ;
 	be_msg.cfg_data_req = &cfgdata_req;
 
-	__dbg("Sending CFGDATA_CREATE_REQ to '%s' txn-id: %" PRIu64 " last: %s",
-	      adapter->name, txn_id, end_of_data ? "yes" : "no");
+	_dbg("Sending CFGDATA_CREATE_REQ to '%s' txn-id: %" PRIu64 " last: %s", adapter->name,
+	     txn_id, end_of_data ? "yes" : "no");
 
 	return mgmt_be_adapter_send_msg(adapter, &be_msg);
 }
@@ -656,8 +647,7 @@ int mgmt_be_send_cfgapply_req(struct mgmt_be_client_adapter *adapter,
 	be_msg.message_case = MGMTD__BE_MESSAGE__MESSAGE_CFG_APPLY_REQ;
 	be_msg.cfg_apply_req = &apply_req;
 
-	__dbg("Sending CFG_APPLY_REQ to '%s' txn-id: %" PRIu64, adapter->name,
-	      txn_id);
+	_dbg("Sending CFG_APPLY_REQ to '%s' txn-id: %" PRIu64, adapter->name, txn_id);
 
 	return mgmt_be_adapter_send_msg(adapter, &be_msg);
 }
@@ -690,7 +680,7 @@ static void mgmt_be_adapter_send_notify(struct mgmt_msg_notify_data *msg, size_t
 
 	notif = mgmt_msg_native_xpath_decode(msg, msglen);
 	if (!notif) {
-		__log_err("Corrupt notify msg");
+		_log_err("Corrupt notify msg");
 		return;
 	}
 
@@ -698,7 +688,7 @@ static void mgmt_be_adapter_send_notify(struct mgmt_msg_notify_data *msg, size_t
 	if (!is_root) {
 		nb_node = nb_node_find(notif);
 		if (!nb_node) {
-			__log_err("No schema found for notification: %s", notif);
+			_log_err("No schema found for notification: %s", notif);
 			return;
 		}
 	}
@@ -739,8 +729,7 @@ static void be_adapter_handle_native_msg(struct mgmt_be_client_adapter *adapter,
 	switch (msg->code) {
 	case MGMT_MSG_CODE_ERROR:
 		error_msg = (typeof(error_msg))msg;
-		__dbg("Got ERROR from '%s' txn-id %" PRIx64, adapter->name,
-		      msg->refer_id);
+		_dbg("Got ERROR from '%s' txn-id %" PRIx64, adapter->name, msg->refer_id);
 
 		/* Forward the reply to the txn module */
 		mgmt_txn_notify_error(adapter, msg->refer_id, msg->req_id,
@@ -750,8 +739,7 @@ static void be_adapter_handle_native_msg(struct mgmt_be_client_adapter *adapter,
 	case MGMT_MSG_CODE_TREE_DATA:
 		/* tree data from a backend client */
 		tree_msg = (typeof(tree_msg))msg;
-		__dbg("Got TREE_DATA from '%s' txn-id %" PRIx64, adapter->name,
-		      msg->refer_id);
+		_dbg("Got TREE_DATA from '%s' txn-id %" PRIx64, adapter->name, msg->refer_id);
 
 		/* Forward the reply to the txn module */
 		mgmt_txn_notify_tree_data_reply(adapter, tree_msg, msg_len);
@@ -759,8 +747,7 @@ static void be_adapter_handle_native_msg(struct mgmt_be_client_adapter *adapter,
 	case MGMT_MSG_CODE_RPC_REPLY:
 		/* RPC reply from a backend client */
 		rpc_msg = (typeof(rpc_msg))msg;
-		__dbg("Got RPC_REPLY from '%s' txn-id %" PRIx64, adapter->name,
-		      msg->refer_id);
+		_dbg("Got RPC_REPLY from '%s' txn-id %" PRIx64, adapter->name, msg->refer_id);
 
 		/* Forward the reply to the txn module */
 		mgmt_txn_notify_rpc_reply(adapter, rpc_msg, msg_len);
@@ -770,15 +757,14 @@ static void be_adapter_handle_native_msg(struct mgmt_be_client_adapter *adapter,
 		 * Handle notify message from a back-end client
 		 */
 		notify_msg = (typeof(notify_msg))msg;
-		__dbg("Got NOTIFY from '%s'", adapter->name);
+		_dbg("Got NOTIFY from '%s'", adapter->name);
 		mgmt_be_adapter_send_notify(notify_msg, msg_len, adapter);
 		mgmt_fe_adapter_send_notify(notify_msg, msg_len);
 		break;
 	default:
-		__log_err("unknown native message txn-id %" PRIu64
-			  " req-id %" PRIu64
-			  " code %u from BE client for adapter %s",
-			  msg->refer_id, msg->req_id, msg->code, adapter->name);
+		_log_err("unknown native message txn-id %" PRIu64 " req-id %" PRIu64
+			 " code %u from BE client for adapter %s",
+			 msg->refer_id, msg->req_id, msg->code, adapter->name);
 		break;
 	}
 }
@@ -796,19 +782,17 @@ static void mgmt_be_adapter_process_msg(uint8_t version, uint8_t *data,
 		if (len >= sizeof(*msg))
 			be_adapter_handle_native_msg(adapter, msg, len);
 		else
-			__log_err("native message to adapter %s too short %zu",
-				  adapter->name, len);
+			_log_err("native message to adapter %s too short %zu", adapter->name, len);
 		return;
 	}
 
 	be_msg = mgmtd__be_message__unpack(NULL, len, data);
 	if (!be_msg) {
-		__dbg("Failed to decode %zu bytes for adapter: %s", len,
-		      adapter->name);
+		_dbg("Failed to decode %zu bytes for adapter: %s", len, adapter->name);
 		return;
 	}
-	__dbg("Decoded %zu bytes of message: %u for adapter: %s", len,
-	      be_msg->message_case, adapter->name);
+	_dbg("Decoded %zu bytes of message: %u for adapter: %s", len, be_msg->message_case,
+	     adapter->name);
 	(void)mgmt_be_adapter_handle_msg(adapter, be_msg);
 	mgmtd__be_message__free_unpacked(be_msg, NULL);
 }
@@ -942,7 +926,7 @@ struct msg_conn *mgmt_be_create_adapter(int conn_fd, union sockunion *from)
 
 	adapter->conn->debug = DEBUG_MODE_CHECK(&mgmt_debug_be, DEBUG_MODE_ALL);
 
-	__dbg("Added new MGMTD Backend adapter '%s'", adapter->name);
+	_dbg("Added new MGMTD Backend adapter '%s'", adapter->name);
 
 	return adapter->conn;
 }
@@ -1024,15 +1008,14 @@ uint64_t mgmt_be_interested_clients(const char *xpath,
 
 	clients = 0;
 
-	__dbg("XPATH: '%s'", xpath);
+	_dbg("XPATH: '%s'", xpath);
 	darr_foreach_p (maps, map)
 		if (mgmt_be_xpath_prefix(map->xpath_prefix, xpath))
 			clients |= map->clients;
 
 	if (DEBUG_MODE_CHECK(&mgmt_debug_be, DEBUG_MODE_ALL)) {
 		FOREACH_BE_CLIENT_BITS (id, clients)
-			__dbg("Cient: %s: subscribed",
-			      mgmt_be_client_id2name(id));
+			_dbg("Cient: %s: subscribed", mgmt_be_client_id2name(id));
 	}
 	return clients;
 }
@@ -1056,16 +1039,15 @@ static bool be_is_client_interested(const char *xpath, enum mgmt_be_client_id id
 
 	assert(id < MGMTD_BE_CLIENT_ID_MAX);
 
-	__dbg("Checking client: %s for xpath: '%s'", mgmt_be_client_id2name(id),
-	      xpath);
+	_dbg("Checking client: %s for xpath: '%s'", mgmt_be_client_id2name(id), xpath);
 
 	clients = mgmt_be_interested_clients(xpath, type);
 	if (IS_IDBIT_SET(clients, id)) {
-		__dbg("client: %s: interested", mgmt_be_client_id2name(id));
+		_dbg("client: %s: interested", mgmt_be_client_id2name(id));
 		return true;
 	}
 
-	__dbg("client: %s: not interested", mgmt_be_client_id2name(id));
+	_dbg("client: %s: not interested", mgmt_be_client_id2name(id));
 	return false;
 }
 

--- a/mgmtd/mgmt_be_adapter.h
+++ b/mgmtd/mgmt_be_adapter.h
@@ -113,21 +113,19 @@ DECLARE_LIST(mgmt_be_adapters, struct mgmt_be_client_adapter, list_linkage);
 #define IS_IDBIT_SET(v, id)   (!IS_IDBIT_UNSET(v, id))
 #define IS_IDBIT_UNSET(v, id) (!((v) & (1ull << (id))))
 
-#define __GET_NEXT_SET(id, bits)                                               \
-	({                                                                     \
-		enum mgmt_be_client_id __id = (id);                            \
-									       \
-		for (; __id < MGMTD_BE_CLIENT_ID_MAX &&                        \
-		       IS_IDBIT_UNSET(bits, __id);                             \
-		     __id++)                                                   \
-			;                                                      \
-		__id;                                                          \
+#define _GET_NEXT_SET(id, bits)                                                                    \
+	({                                                                                         \
+		enum mgmt_be_client_id _gns_id = (id);                                             \
+                                                                                                   \
+		for (; _gns_id < MGMTD_BE_CLIENT_ID_MAX && IS_IDBIT_UNSET(bits, _gns_id);          \
+		     _gns_id++)                                                                    \
+			;                                                                          \
+		_gns_id;                                                                           \
 	})
 
-#define FOREACH_BE_CLIENT_BITS(id, bits)                                       \
-	for ((id) = __GET_NEXT_SET(MGMTD_BE_CLIENT_ID_MIN, bits);              \
-	     (id) < MGMTD_BE_CLIENT_ID_MAX;                                    \
-	     (id) = __GET_NEXT_SET((id) + 1, bits))
+#define FOREACH_BE_CLIENT_BITS(id, bits)                                                           \
+	for ((id) = _GET_NEXT_SET(MGMTD_BE_CLIENT_ID_MIN, bits); (id) < MGMTD_BE_CLIENT_ID_MAX;    \
+	     (id) = _GET_NEXT_SET((id) + 1, bits))
 
 /* ---------- */
 /* Prototypes */

--- a/mgmtd/mgmt_ds.c
+++ b/mgmtd/mgmt_ds.c
@@ -15,9 +15,8 @@
 #include "mgmtd/mgmt_txn.h"
 #include "libyang/libyang.h"
 
-#define __dbg(fmt, ...)                                                        \
-	DEBUGD(&mgmt_debug_ds, "DS: %s: " fmt, __func__, ##__VA_ARGS__)
-#define __log_err(fmt, ...) zlog_err("%s: ERROR: " fmt, __func__, ##__VA_ARGS__)
+#define _dbg(fmt, ...)	   DEBUGD(&mgmt_debug_ds, "DS: %s: " fmt, __func__, ##__VA_ARGS__)
+#define _log_err(fmt, ...) zlog_err("%s: ERROR: " fmt, __func__, ##__VA_ARGS__)
 
 struct mgmt_ds_ctx {
 	Mgmtd__DatastoreId ds_id;
@@ -79,8 +78,7 @@ static int ds_copy(struct mgmt_ds_ctx *dst, struct mgmt_ds_ctx *src)
 	if (!src || !dst)
 		return -1;
 
-	__dbg("Replacing %s with %s", mgmt_ds_id2name(dst->ds_id),
-	      mgmt_ds_id2name(src->ds_id));
+	_dbg("Replacing %s with %s", mgmt_ds_id2name(dst->ds_id), mgmt_ds_id2name(src->ds_id));
 
 	if (src->config_ds && dst->config_ds)
 		nb_config_replace(dst->root.cfg_root, src->root.cfg_root, true);
@@ -101,7 +99,7 @@ static int ds_merge(struct mgmt_ds_ctx *dst, struct mgmt_ds_ctx *src)
 	if (!src || !dst)
 		return -1;
 
-	__dbg("Merging DS %d with %d", dst->ds_id, src->ds_id);
+	_dbg("Merging DS %d with %d", dst->ds_id, src->ds_id);
 	if (src->config_ds && dst->config_ds)
 		ret = nb_config_merge(dst->root.cfg_root, src->root.cfg_root,
 				      true);
@@ -111,7 +109,7 @@ static int ds_merge(struct mgmt_ds_ctx *dst, struct mgmt_ds_ctx *src)
 					 src->root.dnode_root, 0);
 	}
 	if (ret != 0) {
-		__log_err("merge failed with err: %d", ret);
+		_log_err("merge failed with err: %d", ret);
 		return ret;
 	}
 
@@ -295,7 +293,7 @@ static int mgmt_walk_ds_nodes(
 
 	assert(mgmt_ds_node_iter_fn);
 
-	__dbg(" -- START: base xpath: '%s'", base_xpath);
+	_dbg(" -- START: base xpath: '%s'", base_xpath);
 
 	if (!base_dnode)
 		/*
@@ -306,9 +304,8 @@ static int mgmt_walk_ds_nodes(
 	if (!base_dnode)
 		return -1;
 
-	__dbg("           search base schema: '%s'",
-	      lysc_path(base_dnode->schema, LYSC_PATH_LOG, xpath,
-			sizeof(xpath)));
+	_dbg("           search base schema: '%s'",
+	     lysc_path(base_dnode->schema, LYSC_PATH_LOG, xpath, sizeof(xpath)));
 
 	nbnode = (struct nb_node *)base_dnode->schema->priv;
 	(*mgmt_ds_node_iter_fn)(base_xpath, base_dnode, nbnode, ctx);
@@ -331,7 +328,7 @@ static int mgmt_walk_ds_nodes(
 
 		(void)lyd_path(dnode, LYD_PATH_STD, xpath, sizeof(xpath));
 
-		__dbg(" -- Child xpath: %s", xpath);
+		_dbg(" -- Child xpath: %s", xpath);
 
 		ret = mgmt_walk_ds_nodes(root, xpath, dnode,
 					 mgmt_ds_node_iter_fn, ctx);
@@ -339,7 +336,7 @@ static int mgmt_walk_ds_nodes(
 			break;
 	}
 
-	__dbg(" -- END: base xpath: '%s'", base_xpath);
+	_dbg(" -- END: base xpath: '%s'", base_xpath);
 
 	return ret;
 }
@@ -403,7 +400,7 @@ int mgmt_ds_load_config_from_file(struct mgmt_ds_ctx *dst,
 		return -1;
 
 	if (mgmt_ds_load_cfg_from_file(file_path, &iter) != 0) {
-		__log_err("Failed to load config from the file %s", file_path);
+		_log_err("Failed to load config from the file %s", file_path);
 		return -1;
 	}
 
@@ -446,7 +443,7 @@ int mgmt_ds_iter_data(Mgmtd__DatastoreId ds_id, struct nb_config *root,
 	 * Oper-state should be kept in mind though for the prefix walk
 	 */
 
-	__dbg(" -- START DS walk for DSid: %d", ds_id);
+	_dbg(" -- START DS walk for DSid: %d", ds_id);
 
 	/* If the base_xpath is empty then crawl the sibblings */
 	if (xpath[0] == 0) {

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -1301,10 +1301,10 @@ fe_adapter_native_send_session_reply(struct mgmt_fe_client_adapter *adapter,
  * @msg_raw: the message data.
  * @msg_len: the length of the message data.
  */
-static void fe_adapter_handle_session_req(struct mgmt_fe_client_adapter *adapter,
-					  void *__msg, size_t msg_len)
+static void fe_adapter_handle_session_req(struct mgmt_fe_client_adapter *adapter, void *_msg,
+					  size_t msg_len)
 {
-	struct mgmt_msg_session_req *msg = __msg;
+	struct mgmt_msg_session_req *msg = _msg;
 	struct mgmt_fe_session_ctx *session;
 	uint64_t client_id;
 
@@ -1364,10 +1364,10 @@ static void fe_adapter_handle_session_req(struct mgmt_fe_client_adapter *adapter
  * @msg_raw: the message data.
  * @msg_len: the length of the message data.
  */
-static void fe_adapter_handle_get_data(struct mgmt_fe_session_ctx *session,
-				       void *__msg, size_t msg_len)
+static void fe_adapter_handle_get_data(struct mgmt_fe_session_ctx *session, void *_msg,
+				       size_t msg_len)
 {
-	struct mgmt_msg_get_data *msg = __msg;
+	struct mgmt_msg_get_data *msg = _msg;
 	const struct lysc_node **snodes = NULL;
 	uint64_t req_id = msg->req_id;
 	Mgmtd__DatastoreId ds_id;
@@ -1504,10 +1504,9 @@ done:
 	darr_free(snodes);
 }
 
-static void fe_adapter_handle_edit(struct mgmt_fe_session_ctx *session,
-				   void *__msg, size_t msg_len)
+static void fe_adapter_handle_edit(struct mgmt_fe_session_ctx *session, void *_msg, size_t msg_len)
 {
-	struct mgmt_msg_edit *msg = __msg;
+	struct mgmt_msg_edit *msg = _msg;
 	Mgmtd__DatastoreId ds_id, rds_id;
 	struct mgmt_ds_ctx *ds_ctx, *rds_ctx;
 	const char *xpath, *data;
@@ -1615,13 +1614,13 @@ static void fe_adapter_handle_edit(struct mgmt_fe_session_ctx *session,
 /**
  * fe_adapter_handle_notify_select() - Handle an Notify Select message.
  * @session: the client session.
- * @__msg: the message data.
+ * @_msg: the message data.
  * @msg_len: the length of the message data.
  */
-static void fe_adapter_handle_notify_select(struct mgmt_fe_session_ctx *session, void *__msg,
+static void fe_adapter_handle_notify_select(struct mgmt_fe_session_ctx *session, void *_msg,
 					    size_t msg_len)
 {
-	struct mgmt_msg_notify_select *msg = __msg;
+	struct mgmt_msg_notify_select *msg = _msg;
 	uint64_t req_id = msg->req_id;
 	struct nb_node **nb_nodes;
 	const char **selectors = NULL;
@@ -1743,13 +1742,12 @@ done:
 /**
  * fe_adapter_handle_rpc() - Handle an RPC message from an FE client.
  * @session: the client session.
- * @__msg: the message data.
+ * @_msg: the message data.
  * @msg_len: the length of the message data.
  */
-static void fe_adapter_handle_rpc(struct mgmt_fe_session_ctx *session,
-				  void *__msg, size_t msg_len)
+static void fe_adapter_handle_rpc(struct mgmt_fe_session_ctx *session, void *_msg, size_t msg_len)
 {
-	struct mgmt_msg_rpc *msg = __msg;
+	struct mgmt_msg_rpc *msg = _msg;
 	const struct lysc_node *snode;
 	const char *xpath, *data;
 	uint64_t req_id = msg->req_id;

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -24,10 +24,8 @@
 #include "mgmtd/mgmt_memory.h"
 #include "mgmtd/mgmt_fe_adapter.h"
 
-#define __dbg(fmt, ...)                                                        \
-	DEBUGD(&mgmt_debug_fe, "FE-ADAPTER: %s: " fmt, __func__, ##__VA_ARGS__)
-#define __log_err(fmt, ...)                                                    \
-	zlog_err("FE-ADAPTER: %s: ERROR: " fmt, __func__, ##__VA_ARGS__)
+#define _dbg(fmt, ...)	   DEBUGD(&mgmt_debug_fe, "FE-ADAPTER: %s: " fmt, __func__, ##__VA_ARGS__)
+#define _log_err(fmt, ...) zlog_err("FE-ADAPTER: %s: ERROR: " fmt, __func__, ##__VA_ARGS__)
 
 #define FOREACH_ADAPTER_IN_LIST(adapter)                                       \
 	frr_each_safe (mgmt_fe_adapters, &mgmt_fe_adapters, (adapter))
@@ -184,18 +182,14 @@ mgmt_fe_session_write_lock_ds(Mgmtd__DatastoreId ds_id,
 			  session->session_id, mgmt_ds_id2name(ds_id));
 	else {
 		if (mgmt_ds_lock(ds_ctx, session->session_id)) {
-			__dbg("Failed to lock the DS:%s for session-id: %" PRIu64
-			      " from %s!",
-			      mgmt_ds_id2name(ds_id), session->session_id,
-			      session->adapter->name);
+			_dbg("Failed to lock the DS:%s for session-id: %" PRIu64 " from %s!",
+			     mgmt_ds_id2name(ds_id), session->session_id, session->adapter->name);
 			return -1;
 		}
 
 		session->ds_locked[ds_id] = true;
-		__dbg("Write-Locked the DS:%s for session-id: %" PRIu64
-		      " from %s",
-		      mgmt_ds_id2name(ds_id), session->session_id,
-		      session->adapter->name);
+		_dbg("Write-Locked the DS:%s for session-id: %" PRIu64 " from %s",
+		     mgmt_ds_id2name(ds_id), session->session_id, session->adapter->name);
 	}
 
 	return 0;
@@ -211,10 +205,8 @@ static void mgmt_fe_session_unlock_ds(Mgmtd__DatastoreId ds_id,
 
 	session->ds_locked[ds_id] = false;
 	mgmt_ds_unlock(ds_ctx);
-	__dbg("Unlocked DS:%s write-locked earlier by session-id: %" PRIu64
-	      " from %s",
-	      mgmt_ds_id2name(ds_id), session->session_id,
-	      session->adapter->name);
+	_dbg("Unlocked DS:%s write-locked earlier by session-id: %" PRIu64 " from %s",
+	     mgmt_ds_id2name(ds_id), session->session_id, session->adapter->name);
 }
 
 static void
@@ -304,13 +296,12 @@ mgmt_fe_find_session_by_client_id(struct mgmt_fe_client_adapter *adapter,
 
 	FOREACH_SESSION_IN_LIST (adapter, session) {
 		if (session->client_id == client_id) {
-			__dbg("Found session-id %" PRIu64
-			      " using client-id %" PRIu64,
-			      session->session_id, client_id);
+			_dbg("Found session-id %" PRIu64 " using client-id %" PRIu64,
+			     session->session_id, client_id);
 			return session;
 		}
 	}
-	__dbg("Session not found using client-id %" PRIu64, client_id);
+	_dbg("Session not found using client-id %" PRIu64, client_id);
 	return NULL;
 }
 
@@ -427,8 +418,7 @@ static int fe_adapter_send_session_reply(struct mgmt_fe_client_adapter *adapter,
 	fe_msg.message_case = MGMTD__FE_MESSAGE__MESSAGE_SESSION_REPLY;
 	fe_msg.session_reply = &session_reply;
 
-	__dbg("Sending SESSION_REPLY message to MGMTD Frontend client '%s'",
-	      adapter->name);
+	_dbg("Sending SESSION_REPLY message to MGMTD Frontend client '%s'", adapter->name);
 
 	return fe_adapter_send_msg(adapter, &fe_msg, true);
 }
@@ -457,8 +447,8 @@ static int fe_adapter_send_lockds_reply(struct mgmt_fe_session_ctx *session,
 	fe_msg.message_case = MGMTD__FE_MESSAGE__MESSAGE_LOCKDS_REPLY;
 	fe_msg.lockds_reply = &lockds_reply;
 
-	__dbg("Sending LOCK_DS_REPLY message to MGMTD Frontend client '%s' scok: %d",
-	      session->adapter->name, scok);
+	_dbg("Sending LOCK_DS_REPLY message to MGMTD Frontend client '%s' scok: %d",
+	     session->adapter->name, scok);
 
 	return fe_adapter_send_msg(session->adapter, &fe_msg, scok);
 }
@@ -491,8 +481,7 @@ static int fe_adapter_send_set_cfg_reply(struct mgmt_fe_session_ctx *session,
 	fe_msg.message_case = MGMTD__FE_MESSAGE__MESSAGE_SETCFG_REPLY;
 	fe_msg.setcfg_reply = &setcfg_reply;
 
-	__dbg("Sending SETCFG_REPLY message to MGMTD Frontend client '%s'",
-	      session->adapter->name);
+	_dbg("Sending SETCFG_REPLY message to MGMTD Frontend client '%s'", session->adapter->name);
 
 	if (implicit_commit) {
 		if (mm->perf_stats_en)
@@ -536,8 +525,8 @@ static int fe_adapter_send_commit_cfg_reply(
 	fe_msg.message_case = MGMTD__FE_MESSAGE__MESSAGE_COMMCFG_REPLY;
 	fe_msg.commcfg_reply = &commcfg_reply;
 
-	__dbg("Sending COMMIT_CONFIG_REPLY message to MGMTD Frontend client '%s'",
-	      session->adapter->name);
+	_dbg("Sending COMMIT_CONFIG_REPLY message to MGMTD Frontend client '%s'",
+	     session->adapter->name);
 
 	/*
 	 * Cleanup the CONFIG transaction associated with this session.
@@ -577,8 +566,7 @@ static int fe_adapter_send_get_reply(struct mgmt_fe_session_ctx *session,
 	fe_msg.message_case = MGMTD__FE_MESSAGE__MESSAGE_GET_REPLY;
 	fe_msg.get_reply = &get_reply;
 
-	__dbg("Sending GET_REPLY message to MGMTD Frontend client '%s'",
-	      session->adapter->name);
+	_dbg("Sending GET_REPLY message to MGMTD Frontend client '%s'", session->adapter->name);
 
 	/*
 	 * Cleanup the SHOW transaction associated with this session.
@@ -685,7 +673,7 @@ mgmt_fe_find_adapter_by_fd(int conn_fd)
 static void mgmt_fe_adapter_delete(struct mgmt_fe_client_adapter *adapter)
 {
 	struct mgmt_fe_session_ctx *session;
-	__dbg("deleting client adapter '%s'", adapter->name);
+	_dbg("deleting client adapter '%s'", adapter->name);
 
 	/* TODO: notify about client disconnect for appropriate cleanup */
 	FOREACH_SESSION_IN_LIST (adapter, session)
@@ -700,7 +688,7 @@ static int mgmt_fe_adapter_notify_disconnect(struct msg_conn *conn)
 {
 	struct mgmt_fe_client_adapter *adapter = conn->user;
 
-	__dbg("notify disconnect for client adapter '%s'", adapter->name);
+	_dbg("notify disconnect for client adapter '%s'", adapter->name);
 
 	mgmt_fe_adapter_delete(adapter);
 
@@ -721,8 +709,8 @@ mgmt_fe_adapter_cleanup_old_conn(struct mgmt_fe_client_adapter *adapter)
 		if (strncmp(adapter->name, old->name, sizeof(adapter->name)))
 			continue;
 
-		__dbg("Client '%s' (FD:%d) seems to have reconnected. Removing old connection (FD:%d)",
-		      adapter->name, adapter->conn->fd, old->conn->fd);
+		_dbg("Client '%s' (FD:%d) seems to have reconnected. Removing old connection (FD:%d)",
+		     adapter->name, adapter->conn->fd, old->conn->fd);
 		msg_conn_disconnect(old->conn, false);
 	}
 }
@@ -775,10 +763,8 @@ mgmt_fe_session_handle_lockds_req_msg(struct mgmt_fe_session_ctx *session,
 	if (fe_adapter_send_lockds_reply(session, lockds_req->ds_id,
 					 lockds_req->req_id, lockds_req->lock,
 					 true, NULL) != 0) {
-		__dbg("Failed to send LOCK_DS_REPLY for DS %u session-id: %" PRIu64
-		      " from %s",
-		      lockds_req->ds_id, session->session_id,
-		      session->adapter->name);
+		_dbg("Failed to send LOCK_DS_REPLY for DS %u session-id: %" PRIu64 " from %s",
+		     lockds_req->ds_id, session->session_id, session->adapter->name);
 	}
 
 	return 0;
@@ -845,13 +831,11 @@ mgmt_fe_session_handle_setcfg_req_msg(struct mgmt_fe_session_ctx *session,
 		}
 		txn_created = true;
 
-		__dbg("Created new Config txn-id: %" PRIu64
-		      " for session-id %" PRIu64,
-		      session->cfg_txn_id, session->session_id);
+		_dbg("Created new Config txn-id: %" PRIu64 " for session-id %" PRIu64,
+		     session->cfg_txn_id, session->session_id);
 	} else {
-		__dbg("Config txn-id: %" PRIu64 " for session-id: %" PRIu64
-		      " already created",
-		      session->cfg_txn_id, session->session_id);
+		_dbg("Config txn-id: %" PRIu64 " for session-id: %" PRIu64 " already created",
+		     session->cfg_txn_id, session->session_id);
 
 		if (setcfg_req->implicit_commit) {
 			/*
@@ -916,15 +900,13 @@ static int mgmt_fe_session_handle_get_req_msg(struct mgmt_fe_session_ctx *sessio
 			return -1;
 		}
 
-		__dbg("Created new show txn-id: %" PRIu64
-		      " for session-id: %" PRIu64,
-		      session->txn_id, session->session_id);
+		_dbg("Created new show txn-id: %" PRIu64 " for session-id: %" PRIu64,
+		     session->txn_id, session->session_id);
 	} else {
 		fe_adapter_send_get_reply(session, ds_id, req_id, false, NULL,
 					  "Request processing for GET failed!");
-		__dbg("Transaction in progress txn-id: %" PRIu64
-		      " for session-id: %" PRIu64,
-		      session->txn_id, session->session_id);
+		_dbg("Transaction in progress txn-id: %" PRIu64 " for session-id: %" PRIu64,
+		     session->txn_id, session->session_id);
 		return -1;
 	}
 
@@ -1011,9 +993,8 @@ static int mgmt_fe_session_handle_commit_config_req_msg(
 				"Failed to create a Configuration session!");
 			return 0;
 		}
-		__dbg("Created txn-id: %" PRIu64 " for session-id %" PRIu64
-		      " for COMMIT-CFG-REQ",
-		      session->cfg_txn_id, session->session_id);
+		_dbg("Created txn-id: %" PRIu64 " for session-id %" PRIu64 " for COMMIT-CFG-REQ",
+		     session->cfg_txn_id, session->session_id);
 	}
 
 	/*
@@ -1049,8 +1030,7 @@ mgmt_fe_adapter_handle_msg(struct mgmt_fe_client_adapter *adapter,
 	 */
 	switch ((int)fe_msg->message_case) {
 	case MGMTD__FE_MESSAGE__MESSAGE_REGISTER_REQ:
-		__dbg("Got REGISTER_REQ from '%s'",
-		      fe_msg->register_req->client_name);
+		_dbg("Got REGISTER_REQ from '%s'", fe_msg->register_req->client_name);
 
 		if (strlen(fe_msg->register_req->client_name)) {
 			strlcpy(adapter->name,
@@ -1063,10 +1043,8 @@ mgmt_fe_adapter_handle_msg(struct mgmt_fe_client_adapter *adapter,
 		if (fe_msg->session_req->create
 		    && fe_msg->session_req->id_case
 			== MGMTD__FE_SESSION_REQ__ID_CLIENT_CONN_ID) {
-			__dbg("Got SESSION_REQ (create) for client-id %" PRIu64
-			      " from '%s'",
-			      fe_msg->session_req->client_conn_id,
-			      adapter->name);
+			_dbg("Got SESSION_REQ (create) for client-id %" PRIu64 " from '%s'",
+			     fe_msg->session_req->client_conn_id, adapter->name);
 
 			session = mgmt_fe_create_session(adapter, DEFAULT_NOTIFY_FORMAT,
 							 fe_msg->session_req->client_conn_id);
@@ -1077,9 +1055,8 @@ mgmt_fe_adapter_handle_msg(struct mgmt_fe_client_adapter *adapter,
 			!fe_msg->session_req->create
 			&& fe_msg->session_req->id_case
 				== MGMTD__FE_SESSION_REQ__ID_SESSION_ID) {
-			__dbg("Got SESSION_REQ (destroy) for session-id %" PRIu64
-			      "from '%s'",
-			      fe_msg->session_req->session_id, adapter->name);
+			_dbg("Got SESSION_REQ (destroy) for session-id %" PRIu64 "from '%s'",
+			     fe_msg->session_req->session_id, adapter->name);
 
 			session = mgmt_session_id2ctx(
 				fe_msg->session_req->session_id);
@@ -1091,11 +1068,10 @@ mgmt_fe_adapter_handle_msg(struct mgmt_fe_client_adapter *adapter,
 	case MGMTD__FE_MESSAGE__MESSAGE_LOCKDS_REQ:
 		session = mgmt_session_id2ctx(
 				fe_msg->lockds_req->session_id);
-		__dbg("Got LOCKDS_REQ (%sLOCK) for DS:%s for session-id %" PRIu64
-		      " from '%s'",
-		      fe_msg->lockds_req->lock ? "" : "UN",
-		      mgmt_ds_id2name(fe_msg->lockds_req->ds_id),
-		      fe_msg->lockds_req->session_id, adapter->name);
+		_dbg("Got LOCKDS_REQ (%sLOCK) for DS:%s for session-id %" PRIu64 " from '%s'",
+		     fe_msg->lockds_req->lock ? "" : "UN",
+		     mgmt_ds_id2name(fe_msg->lockds_req->ds_id), fe_msg->lockds_req->session_id,
+		     adapter->name);
 		mgmt_fe_session_handle_lockds_req_msg(
 			session, fe_msg->lockds_req);
 		break;
@@ -1103,12 +1079,12 @@ mgmt_fe_adapter_handle_msg(struct mgmt_fe_client_adapter *adapter,
 		session = mgmt_session_id2ctx(
 				fe_msg->setcfg_req->session_id);
 		session->adapter->setcfg_stats.set_cfg_count++;
-		__dbg("Got SETCFG_REQ (%d Xpaths, Implicit:%c) on DS:%s for session-id %" PRIu64
-		      " from '%s'",
-		      (int)fe_msg->setcfg_req->n_data,
-		      fe_msg->setcfg_req->implicit_commit ? 'T' : 'F',
-		      mgmt_ds_id2name(fe_msg->setcfg_req->ds_id),
-		      fe_msg->setcfg_req->session_id, adapter->name);
+		_dbg("Got SETCFG_REQ (%d Xpaths, Implicit:%c) on DS:%s for session-id %" PRIu64
+		     " from '%s'",
+		     (int)fe_msg->setcfg_req->n_data,
+		     fe_msg->setcfg_req->implicit_commit ? 'T' : 'F',
+		     mgmt_ds_id2name(fe_msg->setcfg_req->ds_id), fe_msg->setcfg_req->session_id,
+		     adapter->name);
 
 		mgmt_fe_session_handle_setcfg_req_msg(
 			session, fe_msg->setcfg_req);
@@ -1116,28 +1092,26 @@ mgmt_fe_adapter_handle_msg(struct mgmt_fe_client_adapter *adapter,
 	case MGMTD__FE_MESSAGE__MESSAGE_COMMCFG_REQ:
 		session = mgmt_session_id2ctx(
 				fe_msg->commcfg_req->session_id);
-		__dbg("Got COMMCFG_REQ for src-DS:%s dst-DS:%s (Abort:%c) on session-id %" PRIu64
-		      " from '%s'",
-		      mgmt_ds_id2name(fe_msg->commcfg_req->src_ds_id),
-		      mgmt_ds_id2name(fe_msg->commcfg_req->dst_ds_id),
-		      fe_msg->commcfg_req->abort ? 'T' : 'F',
-		      fe_msg->commcfg_req->session_id, adapter->name);
+		_dbg("Got COMMCFG_REQ for src-DS:%s dst-DS:%s (Abort:%c) on session-id %" PRIu64
+		     " from '%s'",
+		     mgmt_ds_id2name(fe_msg->commcfg_req->src_ds_id),
+		     mgmt_ds_id2name(fe_msg->commcfg_req->dst_ds_id),
+		     fe_msg->commcfg_req->abort ? 'T' : 'F', fe_msg->commcfg_req->session_id,
+		     adapter->name);
 		mgmt_fe_session_handle_commit_config_req_msg(
 			session, fe_msg->commcfg_req);
 		break;
 	case MGMTD__FE_MESSAGE__MESSAGE_GET_REQ:
 		session = mgmt_session_id2ctx(fe_msg->get_req->session_id);
-		__dbg("Got GET_REQ for DS:%s (xpaths: %d) on session-id %" PRIu64
-		      " from '%s'",
-		      mgmt_ds_id2name(fe_msg->get_req->ds_id),
-		      (int)fe_msg->get_req->n_data, fe_msg->get_req->session_id,
-		      adapter->name);
+		_dbg("Got GET_REQ for DS:%s (xpaths: %d) on session-id %" PRIu64 " from '%s'",
+		     mgmt_ds_id2name(fe_msg->get_req->ds_id), (int)fe_msg->get_req->n_data,
+		     fe_msg->get_req->session_id, adapter->name);
 		mgmt_fe_session_handle_get_req_msg(session, fe_msg->get_req);
 		break;
 	case MGMTD__FE_MESSAGE__MESSAGE_NOTIFY_DATA_REQ:
 	case MGMTD__FE_MESSAGE__MESSAGE_REGNOTIFY_REQ:
-		__log_err("Got unhandled message of type %u from '%s'",
-			  fe_msg->message_case, adapter->name);
+		_log_err("Got unhandled message of type %u from '%s'", fe_msg->message_case,
+			 adapter->name);
 		/*
 		 * TODO: Add handling code in future.
 		 */
@@ -1202,17 +1176,17 @@ static int fe_adapter_send_tree_data(struct mgmt_fe_session_ctx *session,
 	ret = yang_print_tree_append(darrp, tree, result_type,
 				     (wd_options | LYD_PRINT_WITHSIBLINGS));
 	if (ret != LY_SUCCESS) {
-		__log_err("Error building get-tree result for client %s session-id %" PRIu64
-			  " req-id %" PRIu64 " scok %d result type %u",
-			  session->adapter->name, session->session_id, req_id,
-			  short_circuit_ok, result_type);
+		_log_err("Error building get-tree result for client %s session-id %" PRIu64
+			 " req-id %" PRIu64 " scok %d result type %u",
+			 session->adapter->name, session->session_id, req_id, short_circuit_ok,
+			 result_type);
 		goto done;
 	}
 
-	__dbg("Sending get-tree result from adapter %s to session-id %" PRIu64
-	      " req-id %" PRIu64 " scok %d result type %u len %u",
-	      session->adapter->name, session->session_id, req_id,
-	      short_circuit_ok, result_type, mgmt_msg_native_get_msg_len(msg));
+	_dbg("Sending get-tree result from adapter %s to session-id %" PRIu64 " req-id %" PRIu64
+	     " scok %d result type %u len %u",
+	     session->adapter->name, session->session_id, req_id, short_circuit_ok, result_type,
+	     mgmt_msg_native_get_msg_len(msg));
 
 	ret = fe_adapter_send_native_msg(session->adapter, msg,
 					 mgmt_msg_native_get_msg_len(msg),
@@ -1242,18 +1216,15 @@ static int fe_adapter_send_rpc_reply(struct mgmt_fe_session_ctx *session,
 		darrp = mgmt_msg_native_get_darrp(msg);
 		ret = yang_print_tree_append(darrp, result, result_type, 0);
 		if (ret != LY_SUCCESS) {
-			__log_err("Error building rpc-reply result for client %s session-id %" PRIu64
-				  " req-id %" PRIu64 " result type %u",
-				  session->adapter->name, session->session_id,
-				  req_id, result_type);
+			_log_err("Error building rpc-reply result for client %s session-id %" PRIu64
+				 " req-id %" PRIu64 " result type %u",
+				 session->adapter->name, session->session_id, req_id, result_type);
 			goto done;
 		}
 	}
 
-	__dbg("Sending rpc-reply from adapter %s to session-id %" PRIu64
-	      " req-id %" PRIu64 " len %u",
-	      session->adapter->name, session->session_id, req_id,
-	      mgmt_msg_native_get_msg_len(msg));
+	_dbg("Sending rpc-reply from adapter %s to session-id %" PRIu64 " req-id %" PRIu64 " len %u",
+	     session->adapter->name, session->session_id, req_id, mgmt_msg_native_get_msg_len(msg));
 
 	ret = fe_adapter_send_native_msg(session->adapter, msg,
 					 mgmt_msg_native_get_msg_len(msg),
@@ -1285,10 +1256,10 @@ static int fe_adapter_send_edit_reply(struct mgmt_fe_session_ctx *session,
 	if (data)
 		mgmt_msg_native_append(msg, data, strlen(data) + 1);
 
-	__dbg("Sending edit-reply from adapter %s to session-id %" PRIu64
-	      " req-id %" PRIu64 " changed %u created %u len %u",
-	      session->adapter->name, session->session_id, req_id, changed,
-	      created, mgmt_msg_native_get_msg_len(msg));
+	_dbg("Sending edit-reply from adapter %s to session-id %" PRIu64 " req-id %" PRIu64
+	     " changed %u created %u len %u",
+	     session->adapter->name, session->session_id, req_id, changed, created,
+	     mgmt_msg_native_get_msg_len(msg));
 
 	ret = fe_adapter_send_native_msg(session->adapter, msg,
 					 mgmt_msg_native_get_msg_len(msg),
@@ -1313,10 +1284,9 @@ fe_adapter_native_send_session_reply(struct mgmt_fe_client_adapter *adapter,
 	msg->code = MGMT_MSG_CODE_SESSION_REPLY;
 	msg->created = created;
 
-	__dbg("Sending session-reply from adapter %s to session-id %" PRIu64
-	      " req-id %" PRIu64 " len %u",
-	      adapter->name, session_id, req_id,
-	      mgmt_msg_native_get_msg_len(msg));
+	_dbg("Sending session-reply from adapter %s to session-id %" PRIu64 " req-id %" PRIu64
+	     " len %u",
+	     adapter->name, session_id, req_id, mgmt_msg_native_get_msg_len(msg));
 
 	ret = fe_adapter_send_native_msg(adapter, msg,
 					 mgmt_msg_native_get_msg_len(msg),
@@ -1338,8 +1308,8 @@ static void fe_adapter_handle_session_req(struct mgmt_fe_client_adapter *adapter
 	struct mgmt_fe_session_ctx *session;
 	uint64_t client_id;
 
-	__dbg("Got session-req is create %u req-id %Lu for refer-id %Lu notify-fmt %u from '%s'",
-	      msg->refer_id == 0, msg->req_id, msg->refer_id, msg->notify_format, adapter->name);
+	_dbg("Got session-req is create %u req-id %Lu for refer-id %Lu notify-fmt %u from '%s'",
+	     msg->refer_id == 0, msg->req_id, msg->refer_id, msg->notify_format, adapter->name);
 
 	if (msg->refer_id) {
 		uint64_t session_id = msg->refer_id;
@@ -1378,7 +1348,7 @@ static void fe_adapter_handle_session_req(struct mgmt_fe_client_adapter *adapter
 				client_id);
 			return;
 		}
-		__dbg("Set client-name to '%s'", msg->client_name);
+		_dbg("Set client-name to '%s'", msg->client_name);
 		strlcpy(adapter->name, msg->client_name, sizeof(adapter->name));
 	}
 
@@ -1407,9 +1377,8 @@ static void fe_adapter_handle_get_data(struct mgmt_fe_session_ctx *session,
 	LY_ERR err;
 	int ret;
 
-	__dbg("Received get-data request from client %s for session-id %" PRIu64
-	      " req-id %" PRIu64,
-	      session->adapter->name, session->session_id, msg->req_id);
+	_dbg("Received get-data request from client %s for session-id %" PRIu64 " req-id %" PRIu64,
+	     session->adapter->name, session->session_id, msg->req_id);
 
 	if (!MGMT_MSG_VALIDATE_NUL_TERM(msg, msg_len)) {
 		fe_adapter_send_error(session, req_id, false, -EINVAL,
@@ -1501,9 +1470,8 @@ static void fe_adapter_handle_get_data(struct mgmt_fe_session_ctx *session,
 	clients = mgmt_be_interested_clients(msg->xpath,
 					     MGMT_BE_XPATH_SUBSCR_TYPE_OPER);
 	if (!clients && !CHECK_FLAG(msg->flags, GET_DATA_FLAG_CONFIG)) {
-		__dbg("No backends provide xpath: %s for txn-id: %" PRIu64
-		      " session-id: %" PRIu64,
-		      msg->xpath, session->txn_id, session->session_id);
+		_dbg("No backends provide xpath: %s for txn-id: %" PRIu64 " session-id: %" PRIu64,
+		     msg->xpath, session->txn_id, session->session_id);
 
 		fe_adapter_send_tree_data(session, req_id, false,
 					  msg->result_type, wd_options, NULL, 0);
@@ -1519,8 +1487,8 @@ static void fe_adapter_handle_get_data(struct mgmt_fe_session_ctx *session,
 		goto done;
 	}
 
-	__dbg("Created new show txn-id: %" PRIu64 " for session-id: %" PRIu64,
-	      session->txn_id, session->session_id);
+	_dbg("Created new show txn-id: %" PRIu64 " for session-id: %" PRIu64, session->txn_id,
+	     session->session_id);
 
 	/* Create a GET-TREE request under the transaction */
 	ret = mgmt_txn_send_get_tree_oper(session->txn_id, req_id, clients,
@@ -1623,8 +1591,8 @@ static void fe_adapter_handle_edit(struct mgmt_fe_session_ctx *session,
 		return;
 	}
 
-	__dbg("Created new config txn-id: %" PRIu64 " for session-id: %" PRIu64,
-	      session->cfg_txn_id, session->session_id);
+	_dbg("Created new config txn-id: %" PRIu64 " for session-id: %" PRIu64, session->cfg_txn_id,
+	     session->session_id);
 
 	ret = mgmt_txn_send_edit(session->cfg_txn_id, msg->req_id, ds_id,
 				 ds_ctx, rds_id, rds_ctx, lock, commit,
@@ -1705,8 +1673,8 @@ static void fe_adapter_handle_notify_select(struct mgmt_fe_session_ctx *session,
 		new = darr_append_nz(session->notify_xpaths, darr_len(selectors));
 		memcpy(new, selectors, darr_len(selectors) * sizeof(*selectors));
 	} else {
-		__log_err("Invalid msg from session-id: %Lu: no selectors present in non-replace msg",
-			  session->session_id);
+		_log_err("Invalid msg from session-id: %Lu: no selectors present in non-replace msg",
+			 session->session_id);
 		darr_free_free(selectors);
 		selectors = NULL;
 		goto done;
@@ -1716,8 +1684,8 @@ static void fe_adapter_handle_notify_select(struct mgmt_fe_session_ctx *session,
 	if (session->notify_xpaths && DEBUG_MODE_CHECK(&mgmt_debug_fe, DEBUG_MODE_ALL)) {
 		const char **sel = session->notify_xpaths;
 		char *s = frrstr_join(sel, darr_len(sel), ", ");
-		__dbg("New NOTIF %d selectors '%s' (replace: %d) for session-id: %Lu",
-		      darr_len(sel), s, msg->replace, session->session_id);
+		_dbg("New NOTIF %d selectors '%s' (replace: %d) for session-id: %Lu", darr_len(sel),
+		     s, msg->replace, session->session_id);
 		XFREE(MTYPE_TMP, s);
 	}
 
@@ -1732,13 +1700,13 @@ static void fe_adapter_handle_notify_select(struct mgmt_fe_session_ctx *session,
 						 session, &all_matched);
 
 	if (!(all_matched | rm_clients)) {
-		__dbg("No backends publishing for selectors: '%s' session-id: %Lu", selstr,
-		      session->session_id);
+		_dbg("No backends publishing for selectors: '%s' session-id: %Lu", selstr,
+		     session->session_id);
 		goto done;
 	}
 	if (!(clients | rm_clients)) {
-		__dbg("No backends to newly notify for selectors: '%s' session-id: %Lu", selstr,
-		      session->session_id);
+		_dbg("No backends to newly notify for selectors: '%s' session-id: %Lu", selstr,
+		     session->session_id);
 	} else {
 		/*
 		 * First send a message to set the selectors on the changed clients.
@@ -1755,7 +1723,7 @@ static void fe_adapter_handle_notify_select(struct mgmt_fe_session_ctx *session,
 	if (ret != NB_OK || !all_matched || !selectors)
 		goto done;
 
-	__dbg("Created new push for session-id: %Lu", session->session_id);
+	_dbg("Created new push for session-id: %Lu", session->session_id);
 
 	/*
 	 * Send a second message requesting a full state dump
@@ -1788,9 +1756,8 @@ static void fe_adapter_handle_rpc(struct mgmt_fe_session_ctx *session,
 	uint64_t clients;
 	int ret;
 
-	__dbg("Received RPC request from client %s for session-id %" PRIu64
-	      " req-id %" PRIu64,
-	      session->adapter->name, session->session_id, msg->req_id);
+	_dbg("Received RPC request from client %s for session-id %" PRIu64 " req-id %" PRIu64,
+	     session->adapter->name, session->session_id, msg->req_id);
 
 	xpath = mgmt_msg_native_xpath_data_decode(msg, msg_len, data);
 	if (!xpath) {
@@ -1823,9 +1790,8 @@ static void fe_adapter_handle_rpc(struct mgmt_fe_session_ctx *session,
 	clients = mgmt_be_interested_clients(xpath,
 					     MGMT_BE_XPATH_SUBSCR_TYPE_RPC);
 	if (!clients) {
-		__dbg("No backends implement xpath: %s for txn-id: %" PRIu64
-		      " session-id: %" PRIu64,
-		      xpath, session->txn_id, session->session_id);
+		_dbg("No backends implement xpath: %s for txn-id: %" PRIu64 " session-id: %" PRIu64,
+		     xpath, session->txn_id, session->session_id);
 
 		fe_adapter_send_error(session, req_id, false, -ENOENT,
 				      "No backends implement xpath: %s", xpath);
@@ -1841,8 +1807,8 @@ static void fe_adapter_handle_rpc(struct mgmt_fe_session_ctx *session,
 		return;
 	}
 
-	__dbg("Created new rpc txn-id: %" PRIu64 " for session-id: %" PRIu64,
-	      session->txn_id, session->session_id);
+	_dbg("Created new rpc txn-id: %" PRIu64 " for session-id: %" PRIu64, session->txn_id,
+	     session->session_id);
 
 	/* Create an RPC request under the transaction */
 	ret = mgmt_txn_send_rpc(session->txn_id, req_id, clients,
@@ -1868,60 +1834,55 @@ static void fe_adapter_handle_native_msg(struct mgmt_fe_client_adapter *adapter,
 
 	if (msg_len < min_size) {
 		if (!min_size)
-			__log_err("adapter %s: recv msg refer-id %" PRIu64
-				  " unknown message type %u",
-				  adapter->name, msg->refer_id, msg->code);
+			_log_err("adapter %s: recv msg refer-id %" PRIu64 " unknown message type %u",
+				 adapter->name, msg->refer_id, msg->code);
 		else
-			__log_err("adapter %s: recv msg refer-id %" PRIu64
-				  " short (%zu<%zu) msg for type %u",
-				  adapter->name, msg->refer_id, msg_len,
-				  min_size, msg->code);
+			_log_err("adapter %s: recv msg refer-id %" PRIu64
+				 " short (%zu<%zu) msg for type %u",
+				 adapter->name, msg->refer_id, msg_len, min_size, msg->code);
 		return;
 	}
 
 	if (msg->code == MGMT_MSG_CODE_SESSION_REQ) {
-		__dbg("adapter %s: session-id %" PRIu64
-		      " received SESSION_REQ message",
-		      adapter->name, msg->refer_id);
+		_dbg("adapter %s: session-id %" PRIu64 " received SESSION_REQ message",
+		     adapter->name, msg->refer_id);
 		fe_adapter_handle_session_req(adapter, msg, msg_len);
 		return;
 	}
 
 	session = mgmt_session_id2ctx(msg->refer_id);
 	if (!session) {
-		__log_err("adapter %s: recv msg unknown session-id %" PRIu64,
-			  adapter->name, msg->refer_id);
+		_log_err("adapter %s: recv msg unknown session-id %" PRIu64, adapter->name,
+			 msg->refer_id);
 		return;
 	}
 	assert(session->adapter == adapter);
 
 	switch (msg->code) {
 	case MGMT_MSG_CODE_EDIT:
-		__dbg("adapter %s: session-id %" PRIu64 " received EDIT message",
-		      adapter->name, msg->refer_id);
+		_dbg("adapter %s: session-id %" PRIu64 " received EDIT message", adapter->name,
+		     msg->refer_id);
 		fe_adapter_handle_edit(session, msg, msg_len);
 		break;
 	case MGMT_MSG_CODE_NOTIFY_SELECT:
-		__dbg("adapter %s: session-id %" PRIu64
-		      " received NOTIFY_SELECT message",
-		      adapter->name, msg->refer_id);
+		_dbg("adapter %s: session-id %" PRIu64 " received NOTIFY_SELECT message",
+		     adapter->name, msg->refer_id);
 		fe_adapter_handle_notify_select(session, msg, msg_len);
 		break;
 	case MGMT_MSG_CODE_GET_DATA:
-		__dbg("adapter %s: session-id %" PRIu64
-		      " received GET_DATA message",
-		      adapter->name, msg->refer_id);
+		_dbg("adapter %s: session-id %" PRIu64 " received GET_DATA message", adapter->name,
+		     msg->refer_id);
 		fe_adapter_handle_get_data(session, msg, msg_len);
 		break;
 	case MGMT_MSG_CODE_RPC:
-		__dbg("adapter %s: session-id %" PRIu64 " received RPC message",
-		      adapter->name, msg->refer_id);
+		_dbg("adapter %s: session-id %" PRIu64 " received RPC message", adapter->name,
+		     msg->refer_id);
 		fe_adapter_handle_rpc(session, msg, msg_len);
 		break;
 	default:
-		__log_err("unknown native message session-id %" PRIu64
-			  " req-id %" PRIu64 " code %u to FE adapter %s",
-			  msg->refer_id, msg->req_id, msg->code, adapter->name);
+		_log_err("unknown native message session-id %" PRIu64 " req-id %" PRIu64
+			 " code %u to FE adapter %s",
+			 msg->refer_id, msg->req_id, msg->code, adapter->name);
 		break;
 	}
 }
@@ -1939,19 +1900,17 @@ static void mgmt_fe_adapter_process_msg(uint8_t version, uint8_t *data,
 		if (len >= sizeof(*msg))
 			fe_adapter_handle_native_msg(adapter, msg, len);
 		else
-			__log_err("native message to adapter %s too short %zu",
-				  adapter->name, len);
+			_log_err("native message to adapter %s too short %zu", adapter->name, len);
 		return;
 	}
 
 	fe_msg = mgmtd__fe_message__unpack(NULL, len, data);
 	if (!fe_msg) {
-		__dbg("Failed to decode %zu bytes for adapter: %s", len,
-		      adapter->name);
+		_dbg("Failed to decode %zu bytes for adapter: %s", len, adapter->name);
 		return;
 	}
-	__dbg("Decoded %zu bytes of message: %u from adapter: %s", len,
-	      fe_msg->message_case, adapter->name);
+	_dbg("Decoded %zu bytes of message: %u from adapter: %s", len, fe_msg->message_case,
+	     adapter->name);
 	(void)mgmt_fe_adapter_handle_msg(adapter, fe_msg);
 	mgmtd__fe_message__free_unpacked(fe_msg, NULL);
 }
@@ -1972,7 +1931,7 @@ static struct mgmt_msg_notify_data *assure_notify_msg_cache(const struct mgmt_ms
 	if (cache[format])
 		return cache[format];
 
-	__dbg("creating notify msg cache for format %u", format);
+	_dbg("creating notify msg cache for format %u", format);
 
 	xpath = mgmt_msg_native_xpath_data_decode(msg, msglen, data);
 
@@ -2022,7 +1981,7 @@ static void cleanup_notify_msg_cache(struct mgmt_msg_notify_data *msg, struct ly
 
 	for (uint i = 0; i <= MGMT_MSG_FORMAT_LAST; i++) {
 		if (cache[i] && cache[i] != msg) {
-			__dbg("freeing notify msg cache for format %u", i);
+			_dbg("freeing notify msg cache for format %u", i);
 			mgmt_msg_native_free_msg(cache[i]);
 		}
 	}
@@ -2046,7 +2005,7 @@ void mgmt_fe_adapter_send_notify(struct mgmt_msg_notify_data *msg, size_t msglen
 
 	notif = mgmt_msg_native_xpath_decode(msg, msglen);
 	if (!notif) {
-		__log_err("Corrupt notify msg");
+		_log_err("Corrupt notify msg");
 		return;
 	}
 
@@ -2059,7 +2018,7 @@ void mgmt_fe_adapter_send_notify(struct mgmt_msg_notify_data *msg, size_t msglen
 	 */
 	nb_node = nb_node_find(notif);
 	if (!nb_node) {
-		__log_err("No schema found for notification: %s", notif);
+		_log_err("No schema found for notification: %s", notif);
 		return;
 	}
 
@@ -2070,7 +2029,7 @@ void mgmt_fe_adapter_send_notify(struct mgmt_msg_notify_data *msg, size_t msglen
 	if (msg->refer_id != MGMTD_SESSION_ID_NONE) {
 		session = mgmt_session_id2ctx(msg->refer_id);
 		if (!session || !session->notify_xpaths) {
-			__dbg("No session listening for notify 'get' data: %Lu", msg->refer_id);
+			_dbg("No session listening for notify 'get' data: %Lu", msg->refer_id);
 			return;
 		}
 
@@ -2190,10 +2149,9 @@ static FRR_NORETURN void mgmt_fe_abort_if_session(void *data)
 {
 	struct mgmt_fe_session_ctx *session = data;
 
-	__log_err("found orphaned session id %" PRIu64 " client id %" PRIu64
-		  " adapter %s",
-		  session->session_id, session->client_id,
-		  session->adapter ? session->adapter->name : "NULL");
+	_log_err("found orphaned session id %" PRIu64 " client id %" PRIu64 " adapter %s",
+		 session->session_id, session->client_id,
+		 session->adapter ? session->adapter->name : "NULL");
 	abort();
 }
 
@@ -2244,7 +2202,7 @@ struct msg_conn *mgmt_fe_create_adapter(int conn_fd, union sockunion *from)
 
 		adapter->setcfg_stats.min_tm = ULONG_MAX;
 		adapter->cmt_stats.min_tm = ULONG_MAX;
-		__dbg("Added new MGMTD Frontend adapter '%s'", adapter->name);
+		_dbg("Added new MGMTD Frontend adapter '%s'", adapter->name);
 	}
 	return adapter->conn;
 }
@@ -2260,9 +2218,9 @@ int mgmt_fe_send_set_cfg_reply(uint64_t session_id, uint64_t txn_id,
 	session = mgmt_session_id2ctx(session_id);
 	if (!session || session->cfg_txn_id != txn_id) {
 		if (session)
-			__log_err("txn-id doesn't match, session txn-id is %" PRIu64
-				  " current txnid: %" PRIu64,
-				  session->cfg_txn_id, txn_id);
+			_log_err("txn-id doesn't match, session txn-id is %" PRIu64
+				 " current txnid: %" PRIu64,
+				 session->cfg_txn_id, txn_id);
 		return -1;
 	}
 
@@ -2405,9 +2363,7 @@ int mgmt_fe_adapter_txn_error(uint64_t txn_id, uint64_t req_id,
 
 	session = fe_adapter_session_by_txn_id(txn_id);
 	if (!session) {
-		__log_err("failed sending error for txn-id %" PRIu64
-			  " session not found",
-			  txn_id);
+		_log_err("failed sending error for txn-id %" PRIu64 " session not found", txn_id);
 		return -ENOENT;
 	}
 

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -17,9 +17,8 @@
 #include "mgmtd/mgmt_memory.h"
 #include "mgmtd/mgmt_txn.h"
 
-#define __dbg(fmt, ...)                                                        \
-	DEBUGD(&mgmt_debug_txn, "TXN: %s: " fmt, __func__, ##__VA_ARGS__)
-#define __log_err(fmt, ...) zlog_err("%s: ERROR: " fmt, __func__, ##__VA_ARGS__)
+#define _dbg(fmt, ...)	   DEBUGD(&mgmt_debug_txn, "TXN: %s: " fmt, __func__, ##__VA_ARGS__)
+#define _log_err(fmt, ...) zlog_err("%s: ERROR: " fmt, __func__, ##__VA_ARGS__)
 
 #define MGMTD_TXN_LOCK(txn)   mgmt_txn_lock(txn, __FILE__, __LINE__)
 #define MGMTD_TXN_UNLOCK(txn, in_hash_free) mgmt_txn_unlock(txn, in_hash_free, __FILE__, __LINE__)
@@ -340,7 +339,7 @@ static void mgmt_txn_cfg_batch_free(struct mgmt_txn_be_cfg_batch **batch)
 	size_t indx;
 	struct mgmt_commit_cfg_req *cmtcfg_req;
 
-	__dbg(" freeing batch txn-id %" PRIu64, (*batch)->txn->txn_id);
+	_dbg(" freeing batch txn-id %" PRIu64, (*batch)->txn->txn_id);
 
 	assert((*batch)->txn && (*batch)->txn->type == MGMTD_TXN_TYPE_CONFIG);
 
@@ -397,15 +396,15 @@ static struct mgmt_txn_req *mgmt_txn_req_alloc(struct mgmt_txn_ctx *txn,
 					       sizeof(struct mgmt_set_cfg_req));
 		assert(txn_req->req.set_cfg);
 		mgmt_txn_reqs_add_tail(&txn->set_cfg_reqs, txn_req);
-		__dbg("Added a new SETCFG req-id: %" PRIu64 " txn-id: %" PRIu64
-		      ", session-id: %" PRIu64,
-		      txn_req->req_id, txn->txn_id, txn->session_id);
+		_dbg("Added a new SETCFG req-id: %" PRIu64 " txn-id: %" PRIu64
+		     ", session-id: %" PRIu64,
+		     txn_req->req_id, txn->txn_id, txn->session_id);
 		break;
 	case MGMTD_TXN_PROC_COMMITCFG:
 		txn->commit_cfg_req = txn_req;
-		__dbg("Added a new COMMITCFG req-id: %" PRIu64
-		      " txn-id: %" PRIu64 " session-id: %" PRIu64,
-		      txn_req->req_id, txn->txn_id, txn->session_id);
+		_dbg("Added a new COMMITCFG req-id: %" PRIu64 " txn-id: %" PRIu64
+		     " session-id: %" PRIu64,
+		     txn_req->req_id, txn->txn_id, txn->session_id);
 
 		FOREACH_MGMTD_BE_CLIENT_ID (id) {
 			txn_req->req.commit_cfg.be_phase[id] =
@@ -422,26 +421,25 @@ static struct mgmt_txn_req *mgmt_txn_req_alloc(struct mgmt_txn_ctx *txn,
 				sizeof(struct mgmt_get_data_req));
 		assert(txn_req->req.get_data);
 		mgmt_txn_reqs_add_tail(&txn->get_cfg_reqs, txn_req);
-		__dbg("Added a new GETCFG req-id: %" PRIu64 " txn-id: %" PRIu64
-		      " session-id: %" PRIu64,
-		      txn_req->req_id, txn->txn_id, txn->session_id);
+		_dbg("Added a new GETCFG req-id: %" PRIu64 " txn-id: %" PRIu64
+		     " session-id: %" PRIu64,
+		     txn_req->req_id, txn->txn_id, txn->session_id);
 		break;
 	case MGMTD_TXN_PROC_GETTREE:
 		txn_req->req.get_tree = XCALLOC(MTYPE_MGMTD_TXN_GETTREE_REQ,
 						sizeof(struct txn_req_get_tree));
 		mgmt_txn_reqs_add_tail(&txn->get_tree_reqs, txn_req);
-		__dbg("Added a new GETTREE req-id: %" PRIu64 " txn-id: %" PRIu64
-		      " session-id: %" PRIu64,
-		      txn_req->req_id, txn->txn_id, txn->session_id);
+		_dbg("Added a new GETTREE req-id: %" PRIu64 " txn-id: %" PRIu64
+		     " session-id: %" PRIu64,
+		     txn_req->req_id, txn->txn_id, txn->session_id);
 		break;
 	case MGMTD_TXN_PROC_RPC:
 		txn_req->req.rpc = XCALLOC(MTYPE_MGMTD_TXN_RPC_REQ,
 					   sizeof(struct txn_req_rpc));
 		assert(txn_req->req.rpc);
 		mgmt_txn_reqs_add_tail(&txn->rpc_reqs, txn_req);
-		__dbg("Added a new RPC req-id: %" PRIu64 " txn-id: %" PRIu64
-		      " session-id: %" PRIu64,
-		      txn_req->req_id, txn->txn_id, txn->session_id);
+		_dbg("Added a new RPC req-id: %" PRIu64 " txn-id: %" PRIu64 " session-id: %" PRIu64,
+		     txn_req->req_id, txn->txn_id, txn->session_id);
 		break;
 	case MGMTD_TXN_COMMITCFG_TIMEOUT:
 		break;
@@ -470,13 +468,13 @@ static void mgmt_txn_req_free(struct mgmt_txn_req **txn_req)
 				free((void *)set_cfg->cfg_changes[indx].value);
 		}
 		req_list = &(*txn_req)->txn->set_cfg_reqs;
-		__dbg("Deleting SETCFG req-id: %" PRIu64 " txn-id: %" PRIu64,
-		      (*txn_req)->req_id, (*txn_req)->txn->txn_id);
+		_dbg("Deleting SETCFG req-id: %" PRIu64 " txn-id: %" PRIu64, (*txn_req)->req_id,
+		     (*txn_req)->txn->txn_id);
 		XFREE(MTYPE_MGMTD_TXN_SETCFG_REQ, (*txn_req)->req.set_cfg);
 		break;
 	case MGMTD_TXN_PROC_COMMITCFG:
-		__dbg("Deleting COMMITCFG req-id: %" PRIu64 " txn-id: %" PRIu64,
-		      (*txn_req)->req_id, (*txn_req)->txn->txn_id);
+		_dbg("Deleting COMMITCFG req-id: %" PRIu64 " txn-id: %" PRIu64, (*txn_req)->req_id,
+		     (*txn_req)->txn->txn_id);
 
 		ccreq = &(*txn_req)->req.commit_cfg;
 		cleanup = (ccreq->phase >= MGMTD_COMMIT_PHASE_TXN_CREATE &&
@@ -514,8 +512,8 @@ static void mgmt_txn_req_free(struct mgmt_txn_req **txn_req)
 					     ->req.get_data->xpaths[indx]);
 		}
 		req_list = &(*txn_req)->txn->get_cfg_reqs;
-		__dbg("Deleting GETCFG req-id: %" PRIu64 " txn-id: %" PRIu64,
-		      (*txn_req)->req_id, (*txn_req)->txn->txn_id);
+		_dbg("Deleting GETCFG req-id: %" PRIu64 " txn-id: %" PRIu64, (*txn_req)->req_id,
+		     (*txn_req)->txn->txn_id);
 		if ((*txn_req)->req.get_data->reply)
 			XFREE(MTYPE_MGMTD_TXN_GETDATA_REPLY,
 			      (*txn_req)->req.get_data->reply);
@@ -526,16 +524,16 @@ static void mgmt_txn_req_free(struct mgmt_txn_req **txn_req)
 		XFREE(MTYPE_MGMTD_TXN_GETDATA_REQ, (*txn_req)->req.get_data);
 		break;
 	case MGMTD_TXN_PROC_GETTREE:
-		__dbg("Deleting GETTREE req-id: %" PRIu64 " of txn-id: %" PRIu64,
-		      (*txn_req)->req_id, (*txn_req)->txn->txn_id);
+		_dbg("Deleting GETTREE req-id: %" PRIu64 " of txn-id: %" PRIu64, (*txn_req)->req_id,
+		     (*txn_req)->txn->txn_id);
 		req_list = &(*txn_req)->txn->get_tree_reqs;
 		lyd_free_all((*txn_req)->req.get_tree->client_results);
 		XFREE(MTYPE_MGMTD_XPATH, (*txn_req)->req.get_tree->xpath);
 		XFREE(MTYPE_MGMTD_TXN_GETTREE_REQ, (*txn_req)->req.get_tree);
 		break;
 	case MGMTD_TXN_PROC_RPC:
-		__dbg("Deleting RPC req-id: %" PRIu64 " txn-id: %" PRIu64,
-		      (*txn_req)->req_id, (*txn_req)->txn->txn_id);
+		_dbg("Deleting RPC req-id: %" PRIu64 " txn-id: %" PRIu64, (*txn_req)->req_id,
+		     (*txn_req)->txn->txn_id);
 		req_list = &(*txn_req)->txn->rpc_reqs;
 		lyd_free_all((*txn_req)->req.rpc->client_results);
 		XFREE(MTYPE_MGMTD_ERR, (*txn_req)->req.rpc->errstr);
@@ -548,8 +546,8 @@ static void mgmt_txn_req_free(struct mgmt_txn_req **txn_req)
 
 	if (req_list) {
 		mgmt_txn_reqs_del(req_list, *txn_req);
-		__dbg("Removed req-id: %" PRIu64 " from request-list (left:%zu)",
-		      (*txn_req)->req_id, mgmt_txn_reqs_count(req_list));
+		_dbg("Removed req-id: %" PRIu64 " from request-list (left:%zu)", (*txn_req)->req_id,
+		     mgmt_txn_reqs_count(req_list));
 	}
 
 	MGMTD_TXN_UNLOCK(&(*txn_req)->txn, false);
@@ -574,10 +572,8 @@ static void mgmt_txn_process_set_cfg(struct event *thread)
 	assert(txn);
 	cmt_stats = mgmt_fe_get_session_commit_stats(txn->session_id);
 
-	__dbg("Processing %zu SET_CONFIG requests txn-id:%" PRIu64
-	      " session-id: %" PRIu64,
-	      mgmt_txn_reqs_count(&txn->set_cfg_reqs), txn->txn_id,
-	      txn->session_id);
+	_dbg("Processing %zu SET_CONFIG requests txn-id:%" PRIu64 " session-id: %" PRIu64,
+	     mgmt_txn_reqs_count(&txn->set_cfg_reqs), txn->txn_id, txn->session_id);
 
 	FOREACH_TXN_REQ_IN_LIST (&txn->set_cfg_reqs, txn_req) {
 		assert(txn_req->req_event == MGMTD_TXN_PROC_SETCFG);
@@ -629,11 +625,10 @@ static void mgmt_txn_process_set_cfg(struct event *thread)
 			/* We expect the user to have locked the DST DS */
 			if (!mgmt_ds_is_locked(txn_req->req.set_cfg->dst_ds_ctx,
 					       txn->session_id)) {
-				__log_err("DS %u not locked for implicit commit txn-id: %" PRIu64
-					  " session-id: %" PRIu64 " err: %s",
-					  txn_req->req.set_cfg->dst_ds_id,
-					  txn->txn_id, txn->session_id,
-					  strerror(ret));
+				_log_err("DS %u not locked for implicit commit txn-id: %" PRIu64
+					 " session-id: %" PRIu64 " err: %s",
+					 txn_req->req.set_cfg->dst_ds_id, txn->txn_id,
+					 txn->session_id, strerror(ret));
 				mgmt_fe_send_set_cfg_reply(
 					txn->session_id, txn->txn_id,
 					txn_req->req.set_cfg->ds_id,
@@ -665,9 +660,9 @@ static void mgmt_txn_process_set_cfg(struct event *thread)
 						      txn_req->req_id,
 						      MGMTD_SUCCESS, NULL,
 						      false) != 0) {
-			__log_err("Failed to send SET_CONFIG_REPLY txn-id %" PRIu64
-				  " session-id: %" PRIu64,
-				  txn->txn_id, txn->session_id);
+			_log_err("Failed to send SET_CONFIG_REPLY txn-id %" PRIu64
+				 " session-id: %" PRIu64,
+				 txn->txn_id, txn->session_id);
 		}
 
 mgmt_txn_process_set_cfg_done:
@@ -684,8 +679,8 @@ mgmt_txn_process_set_cfg_done:
 
 	left = mgmt_txn_reqs_count(&txn->set_cfg_reqs);
 	if (left) {
-		__dbg("Processed maximum number of Set-Config requests (%d/%d/%d). Rescheduling for rest.",
-		      num_processed, MGMTD_TXN_MAX_NUM_SETCFG_PROC, (int)left);
+		_dbg("Processed maximum number of Set-Config requests (%d/%d/%d). Rescheduling for rest.",
+		     num_processed, MGMTD_TXN_MAX_NUM_SETCFG_PROC, (int)left);
 		mgmt_txn_register_event(txn, MGMTD_TXN_PROC_SETCFG);
 	}
 }
@@ -717,9 +712,9 @@ static int mgmt_txn_send_commit_cfg_reply(struct mgmt_txn_ctx *txn,
 					  txn->commit_cfg_req->req.commit_cfg
 						  .validate_only,
 					  result, error_if_any) != 0) {
-		__log_err("Failed to send COMMIT-CONFIG-REPLY txn-id: %" PRIu64
-			  " session-id: %" PRIu64,
-			  txn->txn_id, txn->session_id);
+		_log_err("Failed to send COMMIT-CONFIG-REPLY txn-id: %" PRIu64
+			 " session-id: %" PRIu64,
+			 txn->txn_id, txn->session_id);
 	}
 
 	if (!txn->commit_cfg_req->req.commit_cfg.edit &&
@@ -732,9 +727,8 @@ static int mgmt_txn_send_commit_cfg_reply(struct mgmt_txn_ctx *txn,
 				       success ? MGMTD_SUCCESS
 					       : MGMTD_INTERNAL_ERROR,
 				       error_if_any, true) != 0) {
-		__log_err("Failed to send SET-CONFIG-REPLY txn-id: %" PRIu64
-			  " session-id: %" PRIu64,
-			  txn->txn_id, txn->session_id);
+		_log_err("Failed to send SET-CONFIG-REPLY txn-id: %" PRIu64 " session-id: %" PRIu64,
+			 txn->txn_id, txn->session_id);
 	}
 
 	if (txn->commit_cfg_req->req.commit_cfg.edit &&
@@ -749,9 +743,8 @@ static int mgmt_txn_send_commit_cfg_reply(struct mgmt_txn_ctx *txn,
 						    .edit->xpath_created,
 					    success ? 0 : -1,
 					    error_if_any) != 0) {
-		__log_err("Failed to send EDIT-REPLY txn-id: %" PRIu64
-			  " session-id: %" PRIu64,
-			  txn->txn_id, txn->session_id);
+		_log_err("Failed to send EDIT-REPLY txn-id: %" PRIu64 " session-id: %" PRIu64,
+			 txn->txn_id, txn->session_id);
 	}
 
 	if (success) {
@@ -836,8 +829,7 @@ mgmt_try_move_commit_to_next_phase(struct mgmt_txn_ctx *txn,
 {
 	enum mgmt_be_client_id id;
 
-	__dbg("txn-id: %" PRIu64 ", Phase '%s'", txn->txn_id,
-	      mgmt_txn_commit_phase_str(txn));
+	_dbg("txn-id: %" PRIu64 ", Phase '%s'", txn->txn_id, mgmt_txn_commit_phase_str(txn));
 
 	/*
 	 * Check if all clients has moved to next phase or not.
@@ -863,8 +855,8 @@ mgmt_try_move_commit_to_next_phase(struct mgmt_txn_ctx *txn,
 	 */
 	cmtcfg_req->phase++;
 
-	__dbg("Move entire txn-id: %" PRIu64 " to phase '%s'", txn->txn_id,
-	      mgmt_txn_commit_phase_str(txn));
+	_dbg("Move entire txn-id: %" PRIu64 " to phase '%s'", txn->txn_id,
+	     mgmt_txn_commit_phase_str(txn));
 
 	mgmt_txn_register_event(txn, MGMTD_TXN_PROC_COMMITCFG);
 
@@ -910,7 +902,7 @@ static int mgmt_txn_create_config_batches(struct mgmt_txn_req *txn_req,
 		if (!value)
 			value = (char *)MGMTD_BE_CONTAINER_NODE_VAL;
 
-		__dbg("XPATH: %s, Value: '%s'", xpath, value ? value : "NIL");
+		_dbg("XPATH: %s, Value: '%s'", xpath, value ? value : "NIL");
 
 		clients =
 			mgmt_be_interested_clients(xpath,
@@ -970,16 +962,14 @@ static int mgmt_txn_create_config_batches(struct mgmt_txn_req *txn_req,
 			batch->value[batch->num_cfg_data].encoded_str_val =
 				value;
 
-			__dbg(" -- %s, batch item:%d", adapter->name,
-			      (int)batch->num_cfg_data);
+			_dbg(" -- %s, batch item:%d", adapter->name, (int)batch->num_cfg_data);
 
 			batch->num_cfg_data++;
 			num_chgs++;
 		}
 
 		if (!chg_clients)
-			__dbg("Daemons interested in XPATH are not currently connected: %s",
-			      xpath);
+			_dbg("Daemons interested in XPATH are not currently connected: %s", xpath);
 
 		cmtcfg_req->clients |= chg_clients;
 
@@ -1199,8 +1189,8 @@ static int mgmt_txn_send_be_txn_create(struct mgmt_txn_ctx *txn)
 	 * come back.
 	 */
 
-	__dbg("txn-id: %" PRIu64 " session-id: %" PRIu64 " Phase '%s'",
-	      txn->txn_id, txn->session_id, mgmt_txn_commit_phase_str(txn));
+	_dbg("txn-id: %" PRIu64 " session-id: %" PRIu64 " Phase '%s'", txn->txn_id, txn->session_id,
+	     mgmt_txn_commit_phase_str(txn));
 
 	return 0;
 }
@@ -1233,9 +1223,8 @@ static int mgmt_txn_send_be_cfg_data(struct mgmt_txn_ctx *txn,
 			(void)mgmt_txn_send_commit_cfg_reply(
 				txn, MGMTD_INTERNAL_ERROR,
 				"Internal Error! Could not send config data to backend!");
-			__log_err("Could not send CFGDATA_CREATE txn-id: %" PRIu64
-				  " to client '%s",
-				  txn->txn_id, adapter->name);
+			_log_err("Could not send CFGDATA_CREATE txn-id: %" PRIu64 " to client '%s",
+				 txn->txn_id, adapter->name);
 			return -1;
 		}
 
@@ -1276,8 +1265,7 @@ static void mgmt_txn_cfg_commit_timedout(struct event *thread)
 	if (!txn->commit_cfg_req)
 		return;
 
-	__log_err("Backend timeout txn-id: %" PRIu64 " aborting commit",
-		  txn->txn_id);
+	_log_err("Backend timeout txn-id: %" PRIu64 " aborting commit", txn->txn_id);
 
 	/*
 	 * Send a COMMIT_CONFIG_REPLY with failure.
@@ -1329,9 +1317,9 @@ static int txn_get_tree_data_done(struct mgmt_txn_ctx *txn,
 	mgmt_txn_req_free(&txn_req);
 
 	if (ret) {
-		__log_err("Error sending the results of GETTREE for txn-id %" PRIu64
-			  " req_id %" PRIu64 " to requested type %u",
-			  txn->txn_id, req_id, get_tree->result_type);
+		_log_err("Error sending the results of GETTREE for txn-id %" PRIu64
+			 " req_id %" PRIu64 " to requested type %u",
+			 txn->txn_id, req_id, get_tree->result_type);
 
 		(void)mgmt_fe_adapter_txn_error(txn->txn_id, req_id, false,
 						errno_from_nb_error(ret),
@@ -1355,9 +1343,9 @@ static int txn_rpc_done(struct mgmt_txn_ctx *txn, struct mgmt_txn_req *txn_req)
 	else if (mgmt_fe_adapter_send_rpc_reply(txn->session_id, txn->txn_id,
 						req_id, rpc->result_type,
 						rpc->client_results)) {
-		__log_err("Error sending the results of RPC for txn-id %" PRIu64
-			  " req_id %" PRIu64 " to requested type %u",
-			  txn->txn_id, req_id, rpc->result_type);
+		_log_err("Error sending the results of RPC for txn-id %" PRIu64 " req_id %" PRIu64
+			 " to requested type %u",
+			 txn->txn_id, req_id, rpc->result_type);
 
 		(void)mgmt_fe_adapter_txn_error(txn->txn_id, req_id, false,
 						-EINVAL,
@@ -1382,8 +1370,7 @@ static void txn_get_tree_timeout(struct event *thread)
 	assert(txn->type == MGMTD_TXN_TYPE_SHOW);
 
 
-	__log_err("Backend timeout txn-id: %" PRIu64 " ending get-tree",
-		  txn->txn_id);
+	_log_err("Backend timeout txn-id: %" PRIu64 " ending get-tree", txn->txn_id);
 
 	/*
 	 * Send a get-tree data reply.
@@ -1407,7 +1394,7 @@ static void txn_rpc_timeout(struct event *thread)
 	assert(txn);
 	assert(txn->type == MGMTD_TXN_TYPE_RPC);
 
-	__log_err("Backend timeout txn-id: %" PRIu64 " ending rpc", txn->txn_id);
+	_log_err("Backend timeout txn-id: %" PRIu64 " ending rpc", txn->txn_id);
 
 	/*
 	 * Send a get-tree data reply.
@@ -1481,9 +1468,8 @@ static void mgmt_txn_process_commit_cfg(struct event *thread)
 	txn = (struct mgmt_txn_ctx *)EVENT_ARG(thread);
 	assert(txn);
 
-	__dbg("Processing COMMIT_CONFIG for txn-id: %" PRIu64
-	      " session-id: %" PRIu64 " Phase '%s'",
-	      txn->txn_id, txn->session_id, mgmt_txn_commit_phase_str(txn));
+	_dbg("Processing COMMIT_CONFIG for txn-id: %" PRIu64 " session-id: %" PRIu64 " Phase '%s'",
+	     txn->txn_id, txn->session_id, mgmt_txn_commit_phase_str(txn));
 
 	assert(txn->commit_cfg_req);
 	cmtcfg_req = &txn->commit_cfg_req->req.commit_cfg;
@@ -1586,8 +1572,8 @@ static void mgmt_txn_send_getcfg_reply_data(struct mgmt_txn_req *txn_req,
 	data_reply->next_indx = (!get_reply->last_batch ? get_req->total_reply
 							: -1);
 
-	__dbg("Sending %zu Get-Config/Data replies next-index:%" PRId64,
-	      data_reply->n_data, data_reply->next_indx);
+	_dbg("Sending %zu Get-Config/Data replies next-index:%" PRId64, data_reply->n_data,
+	     data_reply->next_indx);
 
 	switch (txn_req->req_event) {
 	case MGMTD_TXN_PROC_GETCFG:
@@ -1595,10 +1581,9 @@ static void mgmt_txn_send_getcfg_reply_data(struct mgmt_txn_req *txn_req,
 					   txn_req->txn->txn_id, get_req->ds_id,
 					   txn_req->req_id, MGMTD_SUCCESS,
 					   data_reply, NULL) != 0) {
-			__log_err("Failed to send GET-CONFIG-REPLY txn-id: %" PRIu64
-				  " session-id: %" PRIu64 " req-id: %" PRIu64,
-				  txn_req->txn->txn_id,
-				  txn_req->txn->session_id, txn_req->req_id);
+			_log_err("Failed to send GET-CONFIG-REPLY txn-id: %" PRIu64
+				 " session-id: %" PRIu64 " req-id: %" PRIu64,
+				 txn_req->txn->txn_id, txn_req->txn->session_id, txn_req->req_id);
 		}
 		break;
 	case MGMTD_TXN_PROC_SETCFG:
@@ -1606,7 +1591,7 @@ static void mgmt_txn_send_getcfg_reply_data(struct mgmt_txn_req *txn_req,
 	case MGMTD_TXN_PROC_GETTREE:
 	case MGMTD_TXN_PROC_RPC:
 	case MGMTD_TXN_COMMITCFG_TIMEOUT:
-		__log_err("Invalid Txn-Req-Event %u", txn_req->req_event);
+		_log_err("Invalid Txn-Req-Event %u", txn_req->req_event);
 		break;
 	}
 
@@ -1649,8 +1634,8 @@ static void txn_iter_get_config_data_cb(const char *xpath, struct lyd_node *node
 
 	get_reply->num_reply++;
 	get_req->total_reply++;
-	__dbg(" [%d] XPATH: '%s', Value: '%s'", get_req->total_reply,
-	      data->xpath, data_value->encoded_str_val);
+	_dbg(" [%d] XPATH: '%s', Value: '%s'", get_req->total_reply, data->xpath,
+	     data_value->encoded_str_val);
 
 	if (get_reply->num_reply == MGMTD_MAX_NUM_DATA_REPLY_IN_BATCH)
 		mgmt_txn_send_getcfg_reply_data(txn_req, get_req);
@@ -1684,8 +1669,7 @@ static int mgmt_txn_get_config(struct mgmt_txn_ctx *txn,
 	 */
 	get_reply = get_data->reply;
 	for (indx = 0; indx < get_data->num_xpaths; indx++) {
-		__dbg("Trying to get all data under '%s'",
-		      get_data->xpaths[indx]);
+		_dbg("Trying to get all data under '%s'", get_data->xpaths[indx]);
 		mgmt_init_get_data_reply(get_reply);
 		/*
 		 * mgmt_ds_iter_data works on path prefixes, but the user may
@@ -1696,15 +1680,15 @@ static int mgmt_txn_get_config(struct mgmt_txn_ctx *txn,
 				      get_data->xpaths[indx],
 				      txn_iter_get_config_data_cb,
 				      (void *)txn_req) == -1) {
-			__dbg("Invalid Xpath '%s", get_data->xpaths[indx]);
+			_dbg("Invalid Xpath '%s", get_data->xpaths[indx]);
 			mgmt_fe_send_get_reply(txn->session_id, txn->txn_id,
 					       get_data->ds_id, txn_req->req_id,
 					       MGMTD_INTERNAL_ERROR, NULL,
 					       "Invalid xpath");
 			goto mgmt_txn_get_config_failed;
 		}
-		__dbg("Got %d remaining data-replies for xpath '%s'",
-		      get_reply->num_reply, get_data->xpaths[indx]);
+		_dbg("Got %d remaining data-replies for xpath '%s'", get_reply->num_reply,
+		     get_data->xpaths[indx]);
 		get_reply->last_batch = true;
 		mgmt_txn_send_getcfg_reply_data(txn_req, get_data);
 	}
@@ -1731,10 +1715,8 @@ static void mgmt_txn_process_get_cfg(struct event *thread)
 	txn = (struct mgmt_txn_ctx *)EVENT_ARG(thread);
 	assert(txn);
 
-	__dbg("Processing %zu GET_CONFIG requests txn-id: %" PRIu64
-	      " session-id: %" PRIu64,
-	      mgmt_txn_reqs_count(&txn->get_cfg_reqs), txn->txn_id,
-	      txn->session_id);
+	_dbg("Processing %zu GET_CONFIG requests txn-id: %" PRIu64 " session-id: %" PRIu64,
+	     mgmt_txn_reqs_count(&txn->get_cfg_reqs), txn->txn_id, txn->session_id);
 
 	FOREACH_TXN_REQ_IN_LIST (&txn->get_cfg_reqs, txn_req) {
 		error = false;
@@ -1743,10 +1725,10 @@ static void mgmt_txn_process_get_cfg(struct event *thread)
 		assert(cfg_root);
 
 		if (mgmt_txn_get_config(txn, txn_req, cfg_root) != 0) {
-			__log_err("Unable to retrieve config from DS %d txn-id: %" PRIu64
-				  " session-id: %" PRIu64 " req-id: %" PRIu64,
-				  txn_req->req.get_data->ds_id, txn->txn_id,
-				  txn->session_id, txn_req->req_id);
+			_log_err("Unable to retrieve config from DS %d txn-id: %" PRIu64
+				 " session-id: %" PRIu64 " req-id: %" PRIu64,
+				 txn_req->req.get_data->ds_id, txn->txn_id, txn->session_id,
+				 txn_req->req_id);
 			error = true;
 		}
 
@@ -1769,8 +1751,8 @@ static void mgmt_txn_process_get_cfg(struct event *thread)
 	}
 
 	if (mgmt_txn_reqs_count(&txn->get_cfg_reqs)) {
-		__dbg("Processed maximum number of Get-Config requests (%d/%d). Rescheduling for rest.",
-		      num_processed, MGMTD_TXN_MAX_NUM_GETCFG_PROC);
+		_dbg("Processed maximum number of Get-Config requests (%d/%d). Rescheduling for rest.",
+		     num_processed, MGMTD_TXN_MAX_NUM_GETCFG_PROC);
 		mgmt_txn_register_event(txn, MGMTD_TXN_PROC_GETCFG);
 	}
 }
@@ -1818,8 +1800,7 @@ static struct mgmt_txn_ctx *mgmt_txn_create_new(uint64_t session_id,
 		txn->txn_id = mgmt_txn_mm->next_txn_id++;
 		hash_get(mgmt_txn_mm->txn_hash, txn, hash_alloc_intern);
 
-		__dbg("Added new '%s' txn-id: %" PRIu64,
-		      mgmt_txn_type2str(type), txn->txn_id);
+		_dbg("Added new '%s' txn-id: %" PRIu64, mgmt_txn_type2str(type), txn->txn_id);
 
 		if (type == MGMTD_TXN_TYPE_CONFIG)
 			mgmt_txn_mm->cfg_txn = txn;
@@ -1901,8 +1882,8 @@ uint64_t mgmt_txn_get_session_id(uint64_t txn_id)
 static void mgmt_txn_lock(struct mgmt_txn_ctx *txn, const char *file, int line)
 {
 	txn->refcount++;
-	__dbg("%s:%d --> Lock %s txn-id: %" PRIu64 " refcnt: %d", file, line,
-	      mgmt_txn_type2str(txn->type), txn->txn_id, txn->refcount);
+	_dbg("%s:%d --> Lock %s txn-id: %" PRIu64 " refcnt: %d", file, line,
+	     mgmt_txn_type2str(txn->type), txn->txn_id, txn->refcount);
 }
 
 static void mgmt_txn_unlock(struct mgmt_txn_ctx **txn, bool in_hash_free, const char *file, int line)
@@ -1910,8 +1891,8 @@ static void mgmt_txn_unlock(struct mgmt_txn_ctx **txn, bool in_hash_free, const 
 	assert(*txn && (*txn)->refcount);
 
 	(*txn)->refcount--;
-	__dbg("%s:%d --> Unlock %s txn-id: %" PRIu64 " refcnt: %d", file, line,
-	      mgmt_txn_type2str((*txn)->type), (*txn)->txn_id, (*txn)->refcount);
+	_dbg("%s:%d --> Unlock %s txn-id: %" PRIu64 " refcnt: %d", file, line,
+	     mgmt_txn_type2str((*txn)->type), (*txn)->txn_id, (*txn)->refcount);
 	if (!(*txn)->refcount) {
 		if ((*txn)->type == MGMTD_TXN_TYPE_CONFIG)
 			if (mgmt_txn_mm->cfg_txn == *txn)
@@ -1926,9 +1907,8 @@ static void mgmt_txn_unlock(struct mgmt_txn_ctx **txn, bool in_hash_free, const 
 
 		mgmt_txns_del(&mgmt_txn_mm->txn_list, *txn);
 
-		__dbg("Deleted %s txn-id: %" PRIu64 " session-id: %" PRIu64,
-		      mgmt_txn_type2str((*txn)->type), (*txn)->txn_id,
-		      (*txn)->session_id);
+		_dbg("Deleted %s txn-id: %" PRIu64 " session-id: %" PRIu64,
+		     mgmt_txn_type2str((*txn)->type), (*txn)->txn_id, (*txn)->session_id);
 
 		XFREE(MTYPE_MGMTD_TXN, *txn);
 	}
@@ -2056,8 +2036,7 @@ int mgmt_txn_send_set_config_req(uint64_t txn_id, uint64_t req_id,
 		return -1;
 
 	if (implicit_commit && mgmt_txn_reqs_count(&txn->set_cfg_reqs)) {
-		__log_err(
-			"For implicit commit config only one SETCFG-REQ can be allowed!");
+		_log_err("For implicit commit config only one SETCFG-REQ can be allowed!");
 		return -1;
 	}
 
@@ -2099,11 +2078,10 @@ int mgmt_txn_send_set_config_req(uint64_t txn_id, uint64_t req_id,
 			continue;
 		}
 
-		__dbg("XPath: '%s', Value: '%s'", cfg_req[indx]->data->xpath,
-		      (cfg_req[indx]->data->value &&
-				       cfg_req[indx]->data->value->encoded_str_val
-			       ? cfg_req[indx]->data->value->encoded_str_val
-			       : "NULL"));
+		_dbg("XPath: '%s', Value: '%s'", cfg_req[indx]->data->xpath,
+		     (cfg_req[indx]->data->value && cfg_req[indx]->data->value->encoded_str_val
+			      ? cfg_req[indx]->data->value->encoded_str_val
+			      : "NULL"));
 		strlcpy(cfg_chg->xpath, cfg_req[indx]->data->xpath,
 			sizeof(cfg_chg->xpath));
 		cfg_chg->value =
@@ -2113,8 +2091,7 @@ int mgmt_txn_send_set_config_req(uint64_t txn_id, uint64_t req_id,
 						  ->data->value->encoded_str_val)
 				 : NULL);
 		if (cfg_chg->value)
-			__dbg("Allocated value at %p ==> '%s'", cfg_chg->value,
-			      cfg_chg->value);
+			_dbg("Allocated value at %p ==> '%s'", cfg_chg->value, cfg_chg->value);
 
 		(*num_chgs)++;
 	}
@@ -2144,9 +2121,9 @@ int mgmt_txn_send_commit_config_req(uint64_t txn_id, uint64_t req_id,
 		return -1;
 
 	if (txn->commit_cfg_req) {
-		__log_err("Commit already in-progress txn-id: %" PRIu64
-			  " session-id: %" PRIu64 ". Cannot start another",
-			  txn->txn_id, txn->session_id);
+		_log_err("Commit already in-progress txn-id: %" PRIu64 " session-id: %" PRIu64
+			 ". Cannot start another",
+			 txn->txn_id, txn->session_id);
 		return -1;
 	}
 
@@ -2206,15 +2183,15 @@ int mgmt_txn_notify_be_adapter_conn(struct mgmt_be_client_adapter *adapter,
 		 */
 		txn = mgmt_txn_create_new(0, MGMTD_TXN_TYPE_CONFIG);
 		if (!txn) {
-			__log_err("Failed to create CONFIG Transaction for downloading CONFIGs for client '%s'",
-				  adapter->name);
+			_log_err("Failed to create CONFIG Transaction for downloading CONFIGs for client '%s'",
+				 adapter->name);
 			mgmt_ds_unlock(ds_ctx);
 			nb_config_diff_del_changes(adapter_cfgs);
 			return -1;
 		}
 
-		__dbg("Created initial txn-id: %" PRIu64 " for BE client '%s'",
-		      txn->txn_id, adapter->name);
+		_dbg("Created initial txn-id: %" PRIu64 " for BE client '%s'", txn->txn_id,
+		     adapter->name);
 		/*
 		 * Set the changeset for transaction to commit and trigger the
 		 * commit request.
@@ -2316,10 +2293,8 @@ int mgmt_txn_notify_be_cfgdata_reply(uint64_t txn_id, bool success,
 	cmtcfg_req = &txn->commit_cfg_req->req.commit_cfg;
 
 	if (!success) {
-		__log_err("CFGDATA_CREATE_REQ sent to '%s' failed txn-id: %" PRIu64
-			  " err: %s",
-			  adapter->name, txn->txn_id,
-			  error_if_any ? error_if_any : "None");
+		_log_err("CFGDATA_CREATE_REQ sent to '%s' failed txn-id: %" PRIu64 " err: %s",
+			 adapter->name, txn->txn_id, error_if_any ? error_if_any : "None");
 		mgmt_txn_send_commit_cfg_reply(
 			txn, MGMTD_INTERNAL_ERROR,
 			error_if_any
@@ -2328,9 +2303,8 @@ int mgmt_txn_notify_be_cfgdata_reply(uint64_t txn_id, bool success,
 		return 0;
 	}
 
-	__dbg("CFGDATA_CREATE_REQ sent to '%s' was successful txn-id: %" PRIu64
-	      " err: %s",
-	      adapter->name, txn->txn_id, error_if_any ? error_if_any : "None");
+	_dbg("CFGDATA_CREATE_REQ sent to '%s' was successful txn-id: %" PRIu64 " err: %s",
+	     adapter->name, txn->txn_id, error_if_any ? error_if_any : "None");
 
 	cmtcfg_req->be_phase[adapter->id] = MGMTD_COMMIT_PHASE_APPLY_CFG;
 
@@ -2353,10 +2327,8 @@ int mgmt_txn_notify_be_cfg_apply_reply(uint64_t txn_id, bool success,
 	cmtcfg_req = &txn->commit_cfg_req->req.commit_cfg;
 
 	if (!success) {
-		__log_err("CFGDATA_APPLY_REQ sent to '%s' failed txn-id: %" PRIu64
-			  " err: %s",
-			  adapter->name, txn->txn_id,
-			  error_if_any ? error_if_any : "None");
+		_log_err("CFGDATA_APPLY_REQ sent to '%s' failed txn-id: %" PRIu64 " err: %s",
+			 adapter->name, txn->txn_id, error_if_any ? error_if_any : "None");
 		mgmt_txn_send_commit_cfg_reply(
 			txn, MGMTD_INTERNAL_ERROR,
 			error_if_any
@@ -2401,7 +2373,7 @@ int mgmt_txn_send_get_req(uint64_t txn_id, uint64_t req_id,
 	for (indx = 0;
 	     indx < num_reqs && indx < MGMTD_MAX_NUM_DATA_REPLY_IN_BATCH;
 	     indx++) {
-		__dbg("XPath: '%s'", data_req[indx]->data->xpath);
+		_dbg("XPath: '%s'", data_req[indx]->data->xpath);
 		txn_req->req.get_data->xpaths[indx] =
 			strdup(data_req[indx]->data->xpath);
 		txn_req->req.get_data->num_xpaths++;
@@ -2515,13 +2487,12 @@ state:
 	FOREACH_BE_CLIENT_BITS (id, clients) {
 		ret = mgmt_be_send_native(id, msg);
 		if (ret) {
-			__log_err("Could not send get-tree message to backend client %s",
-				  mgmt_be_client_id2name(id));
+			_log_err("Could not send get-tree message to backend client %s",
+				 mgmt_be_client_id2name(id));
 			continue;
 		}
 
-		__dbg("Sent get-tree req to backend client %s",
-		      mgmt_be_client_id2name(id));
+		_dbg("Sent get-tree req to backend client %s", mgmt_be_client_id2name(id));
 
 		/* record that we sent the request to the client */
 		get_tree->sent_clients |= (1u << id);
@@ -2624,13 +2595,12 @@ int mgmt_txn_send_rpc(uint64_t txn_id, uint64_t req_id, uint64_t clients,
 	FOREACH_BE_CLIENT_BITS (id, clients) {
 		ret = mgmt_be_send_native(id, msg);
 		if (ret) {
-			__log_err("Could not send rpc message to backend client %s",
-				  mgmt_be_client_id2name(id));
+			_log_err("Could not send rpc message to backend client %s",
+				 mgmt_be_client_id2name(id));
 			continue;
 		}
 
-		__dbg("Sent rpc req to backend client %s",
-		      mgmt_be_client_id2name(id));
+		_dbg("Sent rpc req to backend client %s", mgmt_be_client_id2name(id));
 
 		/* record that we sent the request to the client */
 		rpc->sent_clients |= (1u << id);
@@ -2680,12 +2650,12 @@ int mgmt_txn_send_notify_selectors(uint64_t req_id, uint64_t session_id, uint64_
 			continue;
 		ret = mgmt_be_send_native(id, msg);
 		if (ret) {
-			__log_err("Could not send notify-select message to backend client %s",
-				  mgmt_be_client_id2name(id));
+			_log_err("Could not send notify-select message to backend client %s",
+				 mgmt_be_client_id2name(id));
 			continue;
 		}
 
-		__dbg("Sent notify-select req to backend client %s", mgmt_be_client_id2name(id));
+		_dbg("Sent notify-select req to backend client %s", mgmt_be_client_id2name(id));
 	}
 	mgmt_msg_native_free_msg(msg);
 
@@ -2709,8 +2679,7 @@ int mgmt_txn_notify_error(struct mgmt_be_client_adapter *adapter,
 	struct mgmt_txn_req *txn_req;
 
 	if (!txn) {
-		__log_err("Error reply from %s cannot find txn-id %" PRIu64,
-			  adapter->name, txn_id);
+		_log_err("Error reply from %s cannot find txn-id %" PRIu64, adapter->name, txn_id);
 		return -1;
 	}
 
@@ -2723,14 +2692,13 @@ int mgmt_txn_notify_error(struct mgmt_be_client_adapter *adapter,
 			if (txn_req->req_id == req_id)
 				break;
 	if (!txn_req) {
-		__log_err("Error reply from %s for txn-id %" PRIu64
-			  " cannot find req_id %" PRIu64,
-			  adapter->name, txn_id, req_id);
+		_log_err("Error reply from %s for txn-id %" PRIu64 " cannot find req_id %" PRIu64,
+			 adapter->name, txn_id, req_id);
 		return -1;
 	}
 
-	__log_err("Error reply from %s for txn-id %" PRIu64 " req_id %" PRIu64,
-		  adapter->name, txn_id, req_id);
+	_log_err("Error reply from %s for txn-id %" PRIu64 " req_id %" PRIu64, adapter->name,
+		 txn_id, req_id);
 
 	switch (txn_req->req_event) {
 	case MGMTD_TXN_PROC_GETTREE:
@@ -2783,8 +2751,8 @@ int mgmt_txn_notify_tree_data_reply(struct mgmt_be_client_adapter *adapter,
 	LY_ERR err;
 
 	if (!txn) {
-		__log_err("GETTREE reply from %s for a missing txn-id %" PRIu64,
-			  adapter->name, txn_id);
+		_log_err("GETTREE reply from %s for a missing txn-id %" PRIu64, adapter->name,
+			 txn_id);
 		return -1;
 	}
 
@@ -2793,9 +2761,8 @@ int mgmt_txn_notify_tree_data_reply(struct mgmt_be_client_adapter *adapter,
 		if (txn_req->req_id == req_id)
 			break;
 	if (!txn_req) {
-		__log_err("GETTREE reply from %s for txn-id %" PRIu64
-			  " missing req_id %" PRIu64,
-			  adapter->name, txn_id, req_id);
+		_log_err("GETTREE reply from %s for txn-id %" PRIu64 " missing req_id %" PRIu64,
+			 adapter->name, txn_id, req_id);
 		return -1;
 	}
 
@@ -2807,9 +2774,9 @@ int mgmt_txn_notify_tree_data_reply(struct mgmt_be_client_adapter *adapter,
 				 LYD_PARSE_STRICT | LYD_PARSE_ONLY,
 				 0 /*LYD_VALIDATE_OPERATIONAL*/, &tree);
 	if (err) {
-		__log_err("GETTREE reply from %s for txn-id %" PRIu64
-			  " req_id %" PRIu64 " error parsing result of type %u",
-			  adapter->name, txn_id, req_id, data_msg->result_type);
+		_log_err("GETTREE reply from %s for txn-id %" PRIu64 " req_id %" PRIu64
+			 " error parsing result of type %u",
+			 adapter->name, txn_id, req_id, data_msg->result_type);
 	}
 	if (!err) {
 		/* TODO: we could merge ly_errs here if it's not binary */
@@ -2820,9 +2787,9 @@ int mgmt_txn_notify_tree_data_reply(struct mgmt_be_client_adapter *adapter,
 			err = lyd_merge_siblings(&get_tree->client_results,
 						 tree, LYD_MERGE_DESTRUCT);
 		if (err) {
-			__log_err("GETTREE reply from %s for txn-id %" PRIu64
-				  " req_id %" PRIu64 " error merging result",
-				  adapter->name, txn_id, req_id);
+			_log_err("GETTREE reply from %s for txn-id %" PRIu64 " req_id %" PRIu64
+				 " error merging result",
+				 adapter->name, txn_id, req_id);
 		}
 	}
 	if (!get_tree->partial_error)
@@ -2855,8 +2822,7 @@ int mgmt_txn_notify_rpc_reply(struct mgmt_be_client_adapter *adapter,
 	LY_ERR err = LY_SUCCESS;
 
 	if (!txn) {
-		__log_err("RPC reply from %s for a missing txn-id %" PRIu64,
-			  adapter->name, txn_id);
+		_log_err("RPC reply from %s for a missing txn-id %" PRIu64, adapter->name, txn_id);
 		return -1;
 	}
 
@@ -2865,9 +2831,8 @@ int mgmt_txn_notify_rpc_reply(struct mgmt_be_client_adapter *adapter,
 		if (txn_req->req_id == req_id)
 			break;
 	if (!txn_req) {
-		__log_err("RPC reply from %s for txn-id %" PRIu64
-			  " missing req_id %" PRIu64,
-			  adapter->name, txn_id, req_id);
+		_log_err("RPC reply from %s for txn-id %" PRIu64 " missing req_id %" PRIu64,
+			 adapter->name, txn_id, req_id);
 		return -1;
 	}
 
@@ -2878,10 +2843,9 @@ int mgmt_txn_notify_rpc_reply(struct mgmt_be_client_adapter *adapter,
 		err = yang_parse_rpc(rpc->xpath, reply_msg->result_type,
 				     reply_msg->data, true, &tree);
 	if (err) {
-		__log_err("RPC reply from %s for txn-id %" PRIu64
-			  " req_id %" PRIu64 " error parsing result of type %u: %s",
-			  adapter->name, txn_id, req_id, reply_msg->result_type,
-			  ly_strerrcode(err));
+		_log_err("RPC reply from %s for txn-id %" PRIu64 " req_id %" PRIu64
+			 " error parsing result of type %u: %s",
+			 adapter->name, txn_id, req_id, reply_msg->result_type, ly_strerrcode(err));
 	}
 	if (!err && tree) {
 		if (!rpc->client_results)
@@ -2890,10 +2854,9 @@ int mgmt_txn_notify_rpc_reply(struct mgmt_be_client_adapter *adapter,
 			err = lyd_merge_siblings(&rpc->client_results, tree,
 						 LYD_MERGE_DESTRUCT);
 		if (err) {
-			__log_err("RPC reply from %s for txn-id %" PRIu64
-				  " req_id %" PRIu64 " error merging result: %s",
-				  adapter->name, txn_id, req_id,
-				  ly_strerrcode(err));
+			_log_err("RPC reply from %s for txn-id %" PRIu64 " req_id %" PRIu64
+				 " error merging result: %s",
+				 adapter->name, txn_id, req_id, ly_strerrcode(err));
 		}
 	}
 	if (err) {
@@ -2966,12 +2929,11 @@ int mgmt_txn_rollback_trigger_cfg_apply(struct mgmt_ds_ctx *src_ds_ctx,
 	 */
 	txn = mgmt_txn_create_new(0, MGMTD_TXN_TYPE_CONFIG);
 	if (!txn) {
-		__log_err(
-			"Failed to create CONFIG Transaction for downloading CONFIGs");
+		_log_err("Failed to create CONFIG Transaction for downloading CONFIGs");
 		return -1;
 	}
 
-	__dbg("Created rollback txn-id: %" PRIu64, txn->txn_id);
+	_dbg("Created rollback txn-id: %" PRIu64, txn->txn_id);
 
 	/*
 	 * Set the changeset for transaction to commit and trigger the commit

--- a/tools/checkpatch.pl
+++ b/tools/checkpatch.pl
@@ -3806,8 +3806,9 @@ sub process {
 
 # at the beginning of a line any tabs must come first and anything
 # more than $tabsize must use tabs.
-		if ($rawline =~ /^\+\s* \t\s*\S/ ||
-		    $rawline =~ /^\+\s*        \s*/) {
+		if (($rawline =~ /^\+\s* \t\s*\S/ ||
+                     $rawline =~ /^\+\s*        \s*/) &&
+                    $rawline !~ /^\+\s*\\$/)) {
 			my $herevet = "$here\n" . cat_vet($rawline) . "\n";
 			$rpt_cleaners = 1;
 			if (ERROR("CODE_INDENT",
@@ -4053,7 +4054,10 @@ sub process {
 #  1) within comments
 #  2) indented preprocessor commands
 #  3) hanging labels
+#  4) empty lines in multi-line macros
+#    if ($rawline =~ /^\+ / && $line !~ /^\+ *(?:$;|#|$Ident:)/ &&
 		if ($rawline =~ /^\+ / && $line !~ /^\+ *(?:$;|#|$Ident:)/)  {
+			$rawline !~ /^\+\s+\\$/) {
 			my $herevet = "$here\n" . cat_vet($rawline) . "\n";
 			if (WARN("LEADING_SPACE",
 				 "please, no spaces at the start of a line\n" . $herevet) &&


### PR DESCRIPTION
Replace all incorrect uses of `__` as prefix for identifier as this is reserved for the C implementation.