### PR TITLE
lib/clippy: pointer offsets are signed

### DIFF
--- a/python/xrelfo.py
+++ b/python/xrelfo.py
@@ -385,11 +385,11 @@ class Xrelfo(dict):
             endian = ">" if edf._elffile.bigendian else "<"
             mem = edf._elffile[note]
             if edf._elffile.elfclass == 64:
-                start, end = struct.unpack(endian + "QQ", mem)
+                start, end = struct.unpack(endian + "qq", mem)
                 start += note.start
                 end += note.start + 8
             else:
-                start, end = struct.unpack(endian + "II", mem)
+                start, end = struct.unpack(endian + "ii", mem)
                 start += note.start
                 end += note.start + 4
 


### PR DESCRIPTION
Fedora 42 has some new GCC/ld combination that has negative offsets from the .note.FRR to the xref pointers.  (This is completely fine, those offsets are supposed to be signed.)  Clippy decoded them as unsigned, resulting in off-by-2^64 offset values (which Python cheerfully processes, due to its builtin "large integer" support... in C code it would've just wrapped in an uint64_t and made no difference...)

Read the values as signed like they should be.