### PR TITLE
bgpd: fix second router-id of loc-rib peer-up message set to 0.0.0.0

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2240,7 +2240,8 @@ static void bmp_bgp_peer_vrf(struct bmp_bgp_peer *bbpeer, struct bgp *bgp)
 
 	stream_free(s);
 
-	s = bgp_open_make(peer, send_holdtime, bgp->as, &bgp->router_id);
+	/* rfc9069#section-5.2 : Received OPEN Message: Repeat of the same sent OPEN message */
+	s = bgp_open_make(peer, send_holdtime, local_as, &peer->local_id);
 	open_len = stream_get_endp(s);
 	bbpeer->open_tx_len = open_len;
 	if (bbpeer->open_tx)


### PR DESCRIPTION
The RFC9069 stipulates in chapter 5.2 that send and received OPEN message should be the same. The AS number and the BGP identifier should be the same.

Link: https://datatracker.ietf.org/doc/html/rfc9069#section-5.2
Fixes: a3ef2fc62b3a ("bgpd: fix loc-rib open message should use router-id")