### PR TITLE
bgpd: fix show bgp vpn rd json

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12846,6 +12846,17 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t sa
 	return CMD_SUCCESS;
 }
 
+static struct bgp_dest *bgp_route_find_prd_match(struct bgp_dest *curr, struct prefix_rd *match)
+{
+	const struct prefix *curr_p = bgp_dest_get_prefix(curr);
+
+	while (curr && match && memcmp(curr_p->u.val, match->val, 8) != 0) {
+		curr = bgp_route_next(curr);
+		curr_p = bgp_dest_get_prefix(curr);
+	}
+	return curr;
+}
+
 int bgp_show_table_rd(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 		      struct bgp_table *table, struct prefix_rd *prd_match,
 		      enum bgp_show_type type, void *output_arg,
@@ -12861,12 +12872,10 @@ int bgp_show_table_rd(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 
 	show_msg = (!use_json && type == bgp_show_type_normal);
 
-	for (dest = bgp_table_top(table); dest; dest = next) {
+	for (dest = bgp_route_find_prd_match(bgp_table_top(table), prd_match); dest; dest = next) {
 		const struct prefix *dest_p = bgp_dest_get_prefix(dest);
 
-		next = bgp_route_next(dest);
-		if (prd_match && memcmp(dest_p->u.val, prd_match->val, 8) != 0)
-			continue;
+		next = bgp_route_find_prd_match(bgp_route_next(dest), prd_match);
 
 		itable = bgp_dest_get_bgp_table_info(dest);
 		if (itable != NULL) {


### PR DESCRIPTION
"show bgp vpn rd RD json" returns in invalid JSON unless RD is the last
route-distinguisher in the table. A trailing "," is present.

> r1# sh bgp ipv4 vpn rd 102:1 json
> {
>  "vrfId": 0,
>  "vrfName": "default",
>  "tableVersion": 2,
>  "routerId": "192.0.2.1",
>  "defaultLocPrf": 100,
>  "localAS": 65001,
>  "routes": {  "routeDistinguishers" : { "102:1" : { "2.2.2.2/32": [{"valid":true,"bestpath":true,"selectionReason":"First path received","pathFrom":"external","prefix":"2.2.2.2","prefixLen":32,"network":"2.2.2.2/32","version":1,"metric":0,"weight":0,"peerId":"192.0.2.2","path":"65002","origin":"incomplete","nexthops":[{"ip":"192.0.2.2","hostname":"r2","afi":"ipv4","used":true}]
> }]
> ,"192.0.2.2/32": [{"pathFrom":"external","prefix":"192.0.2.2","prefixLen":32,"network":"192.0.2.2/32","version":0,"metric":0,"weight":0,"peerId":"192.0.2.2","path":"65002","origin":"incomple
> te","nexthops":[{"ip":"192.0.2.2","hostname":"r2","afi":"ipv4","used":true}]}]
> ,"192.0.2.8/32": [{"valid":true,"bestpath":true,"selectionReason":"First path received","pathFrom":"external","prefix":"192.0.2.8","prefixLen":32,"network":"192.0.2.8/32","version":2,"metric
> ":0,"weight":0,"peerId":"192.0.2.2","path":"65002","origin":"incomplete","nexthops":[{"ip":"192.0.2.2","hostname":"r2","afi":"ipv4","used":true}]}]
>  }, r1#

When there is another rd, "next" is set although it refers to another rd
that won't be displayed. And "next" is used to set the "is_last"
variable of bgp_show_table() that instructs whether to add a trailing ","

Do not set next if there no more rd to display.

Fixes: https://github.com/FRRouting/frr/commit/1ae44dfcbac301d66c89e46b2f1b257f9bab9b2d ("bgpd: unify 'show bgp' with RD with normal unicast bgp show")
Signed-off-by: Maxime Gouin <maxime.gouin@6wind.com>
Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>