### PR TITLE
bgpd: Fix flag issue in delete_vrf_tovpn_sid_per_vrf

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -992,7 +992,7 @@ void delete_vrf_tovpn_sid_per_vrf(struct bgp *bgp_vpn, struct bgp *bgp_vrf)
 
 	tovpn_sid_index = bgp_vrf->tovpn_sid_index;
 	tovpn_sid_auto =
-		CHECK_FLAG(bgp_vrf->vrf_flags, BGP_VPN_POLICY_TOVPN_SID_AUTO);
+		CHECK_FLAG(bgp_vrf->vrf_flags, BGP_VRF_TOVPN_SID_AUTO);
 	is_tovpn_sid_explicit = CHECK_FLAG(bgp_vrf->vrf_flags, BGP_VRF_TOVPN_SID_EXPLICIT);
 
 	/* skip when VPN is configured on vrf-instance */


### PR DESCRIPTION
We use `BGP_VRF_TOVPN_SID_AUTO` to indicate auto-mode for tovpn sid in per_vrf case,
and use `BGP_VPN_POLICY_TOVPN_SID_AUTO` in per_af.

Hence, in delete_vrf_tovpn_sid_per_vrf, we should use the former.
Let's fix it.