### PR TITLE
docker: install correct python protobuf in ubuntu docker images

### DIFF
--- a/docker/ubuntu-ci/Dockerfile
+++ b/docker/ubuntu-ci/Dockerfile
@@ -80,7 +80,7 @@ RUN apt update && apt upgrade -y && \
     wget https://raw.githubusercontent.com/FRRouting/frr-mibs/main/ietf/IPATM-IPMC-MIB -O /usr/share/snmp/mibs/ietf/IPATM-IPMC-MIB && \
     rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED && \
     python3 -m pip install wheel && \
-    python3 -m pip install protobuf grpcio grpcio-tools && \
+    bash -c "PV=($(pkg-config --modversion protobuf | tr '.' ' ')); if (( PV[0] == 3 && PV[1] < 19 )); then python3 -m pip install 'protobuf<4' grpcio grpcio-tools; else python3 -m pip install 'protobuf>=4' grpcio grpcio-tools; fi" && \
     python3 -m pip install 'pytest>=6.2.4' 'pytest-xdist>=2.3.0' && \
     python3 -m pip install 'scapy>=2.4.5' && \
     python3 -m pip install xmltodict && \

--- a/tests/topotests/lib/fe_client.py
+++ b/tests/topotests/lib/fe_client.py
@@ -18,14 +18,14 @@ import sys
 import time
 from pathlib import Path
 
-from munet.base import Timeout
-
 CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.dirname(CWD))
+
+from munet.base import Timeout
 
 # This is painful but works if you have installed protobuf would be better if we
 # actually built and installed these but ... python packaging.
 try:
-    sys.path.append(os.path.dirname(CWD))
     from munet.base import commander
 
     commander.cmd_raises(f"protoc --python_out={CWD} -I {CWD}/../../../lib mgmt.proto")


### PR DESCRIPTION
Also fix fe_client.py test script to include munet path prior to importing from munet.

This will enable running of tests that count on fe_client.py working (e.g., mgmt_notif).