### PR TITLE
bgpd: Rename bgp_path_info_delete to bgp_path_info_mark_for_delete

### DIFF
--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -383,7 +383,7 @@ void bgp_damp_info_free(struct bgp_damp_info *bdi, struct reuselist *list,
 	bgp_path_info_unset_flag(dest, bpi, BGP_PATH_HISTORY | BGP_PATH_DAMPED);
 	if (bdi->lastrecord == BGP_RECORD_WITHDRAW && withdraw) {
 		bgp_aggregate_decrement(bgp, p, bpi, afi, SAFI_UNICAST);
-		bgp_path_info_delete(dest, bpi);
+		bgp_path_info_mark_for_delete(dest, bpi);
 		bgp_process(bgp, dest, bpi, afi, safi);
 	}
 

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -1438,7 +1438,7 @@ static void evpn_delete_old_local_route(struct bgp *bgp, struct bgpevpn *vpn,
 	}
 
 	/* Delete route entry in the VNI route table, caller to remove. */
-	bgp_path_info_delete(dest, old_local);
+	bgp_path_info_mark_for_delete(dest, old_local);
 }
 
 /*
@@ -2415,7 +2415,7 @@ void delete_evpn_route_entry(struct bgp *bgp, afi_t afi, safi_t safi,
 
 	/* Mark route for delete. */
 	if (tmp_pi)
-		bgp_path_info_delete(dest, tmp_pi);
+		bgp_path_info_mark_for_delete(dest, tmp_pi);
 }
 
 /* Delete EVPN type5 route */
@@ -2489,7 +2489,7 @@ static int delete_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
 	 */
 	delete_evpn_route_entry(bgp, afi, safi, dest, &pi);
 	if (pi) {
-		bgp_path_info_delete(dest, pi);
+		bgp_path_info_mark_for_delete(dest, pi);
 		evpn_route_select_install(bgp, vpn, dest, pi);
 	}
 
@@ -2817,7 +2817,7 @@ static void delete_all_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
 		for (pi = bgp_dest_get_bgp_path_info(dest);
 		     (pi != NULL) && (nextpi = pi->next, 1); pi = nextpi) {
 			bgp_evpn_remote_ip_hash_del(vpn, pi);
-			bgp_path_info_delete(dest, pi);
+			bgp_path_info_mark_for_delete(dest, pi);
 			dest = bgp_path_info_reap(dest, pi);
 
 			assert(dest);
@@ -2828,7 +2828,7 @@ static void delete_all_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
 	     dest = bgp_route_next(dest)) {
 		for (pi = bgp_dest_get_bgp_path_info(dest);
 		     (pi != NULL) && (nextpi = pi->next, 1); pi = nextpi) {
-			bgp_path_info_delete(dest, pi);
+			bgp_path_info_mark_for_delete(dest, pi);
 			dest = bgp_path_info_reap(dest, pi);
 
 			assert(dest);
@@ -3386,7 +3386,7 @@ static int uninstall_evpn_route_entry_in_vni_common(
 	bgp_evpn_remote_ip_hash_del(vpn, pi);
 
 	/* Mark entry for deletion */
-	bgp_path_info_delete(dest, pi);
+	bgp_path_info_mark_for_delete(dest, pi);
 
 	/* Perform route selection and update zebra, if required. */
 	ret = evpn_route_select_install(bgp, vpn, dest, pi);
@@ -3590,7 +3590,7 @@ int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf, const struct prefix_e
 	SET_FLAG(dest->flags, BGP_NODE_PROCESS_CLEAR);
 
 	/* Mark entry for deletion */
-	bgp_path_info_delete(dest, pi);
+	bgp_path_info_mark_for_delete(dest, pi);
 
 	/* Unlink path to evpn nexthop */
 	bgp_evpn_path_nh_del(bgp_vrf, pi);

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -274,7 +274,7 @@ static int bgp_evpn_es_route_uninstall(struct bgp *bgp, struct bgp_evpn_es *es,
 	}
 
 	/* Mark entry for deletion */
-	bgp_path_info_delete(dest, pi);
+	bgp_path_info_mark_for_delete(dest, pi);
 
 	/* Perform route selection and update zebra, if required. */
 	ret = bgp_evpn_es_route_select_install(bgp, es, dest, pi);
@@ -327,7 +327,7 @@ static void bgp_evpn_es_route_del_all(struct bgp *bgp, struct bgp_evpn_es *es)
 	     dest = bgp_route_next(dest)) {
 		for (pi = bgp_dest_get_bgp_path_info(dest);
 		     (pi != NULL) && (nextpi = pi->next, 1); pi = nextpi) {
-			bgp_path_info_delete(dest, pi);
+			bgp_path_info_mark_for_delete(dest, pi);
 			dest = bgp_path_info_reap(dest, pi);
 
 			assert(dest);

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1264,7 +1264,7 @@ leak_update(struct bgp *to_bgp, struct bgp_dest *bn,
 				vpn_leak_to_vrf_withdraw(bpi);
 				bgp_aggregate_decrement(to_bgp, p, bpi, afi,
 							safi);
-				bgp_path_info_delete(bn, bpi);
+				bgp_path_info_mark_for_delete(bn, bpi);
 			}
 		}
 
@@ -2085,7 +2085,7 @@ void vpn_leak_from_vrf_withdraw(struct bgp *to_bgp,		/* to */
 		vpn_leak_to_vrf_withdraw(bpi);
 
 		bgp_aggregate_decrement(to_bgp, p, bpi, afi, safi);
-		bgp_path_info_delete(bn, bpi);
+		bgp_path_info_mark_for_delete(bn, bpi);
 		bgp_process(to_bgp, bn, bpi, afi, safi);
 	}
 	bgp_dest_unlock_node(bn);
@@ -2142,7 +2142,7 @@ void vpn_leak_from_vrf_withdraw_all(struct bgp *to_bgp, struct bgp *from_bgp,
 					bgp_aggregate_decrement(
 						to_bgp, bgp_dest_get_prefix(bn),
 						bpi, afi, safi);
-					bgp_path_info_delete(bn, bpi);
+					bgp_path_info_mark_for_delete(bn, bpi);
 					bgp_process(to_bgp, bn, bpi, afi, safi);
 					bgp_mplsvpn_path_nh_label_unlink(
 						bpi->extra->vrfleak->parent);
@@ -2319,7 +2319,7 @@ static void vpn_leak_to_vrf_update_onevrf(struct bgp *to_bgp,	/* to */
 				zlog_debug("%s: blocking import of %p, as-path match",
 					   __func__, bpi);
 			bgp_aggregate_decrement(to_bgp, p, bpi, afi, safi);
-			bgp_path_info_delete(bn, bpi);
+			bgp_path_info_mark_for_delete(bn, bpi);
 			bgp_process(to_bgp, bn, bpi, afi, safi);
 		}
 		bgp_dest_unlock_node(bn);
@@ -2683,7 +2683,7 @@ void vpn_leak_to_vrf_withdraw(struct bgp_path_info *path_vpn)
 				zlog_debug("%s: deleting bpi %p", __func__,
 					   bpi);
 			bgp_aggregate_decrement(bgp, p, bpi, afi, safi);
-			bgp_path_info_delete(bn, bpi);
+			bgp_path_info_mark_for_delete(bn, bpi);
 			bgp_process(bgp, bn, bpi, afi, safi);
 		}
 		bgp_dest_unlock_node(bn);
@@ -2714,7 +2714,7 @@ void vpn_leak_to_vrf_withdraw_all(struct bgp *to_bgp, afi_t afi)
 				bgp_aggregate_decrement(to_bgp,
 							bgp_dest_get_prefix(bn),
 							bpi, afi, safi);
-				bgp_path_info_delete(bn, bpi);
+				bgp_path_info_mark_for_delete(bn, bpi);
 				bgp_process(to_bgp, bn, bpi, afi, safi);
 			}
 		}

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -800,8 +800,7 @@ extern void bgp_path_info_add(struct bgp_dest *dest, struct bgp_path_info *pi);
 extern void bgp_path_info_extra_free(struct bgp_path_info_extra **extra);
 extern struct bgp_dest *bgp_path_info_reap(struct bgp_dest *dest,
 					   struct bgp_path_info *pi);
-extern void bgp_path_info_delete(struct bgp_dest *dest,
-				 struct bgp_path_info *pi);
+extern void bgp_path_info_mark_for_delete(struct bgp_dest *dest, struct bgp_path_info *pi);
 extern struct bgp_path_info_extra *
 bgp_path_info_extra_get(struct bgp_path_info *path);
 extern struct bgp_path_info_extra *bgp_evpn_path_info_extra_get(struct bgp_path_info *path);

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -462,7 +462,7 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 			list_delete(&bpi->extra->vnc->vnc.export.local_nexthops);
 
 		bgp_aggregate_decrement(bgp, p, bpi, afi, safi);
-		bgp_path_info_delete(bn, bpi);
+		bgp_path_info_mark_for_delete(bn, bpi);
 		bgp_process(bgp, bn, bpi, afi, safi);
 	} else {
 		vnc_zlog_debug_verbose(


### PR DESCRIPTION
This function does not actually delete the path info.  Let's call it what it really does, which is just mark it for deletion in the future.