### PR TITLE
isid, lib: Fix gcc 15 warnings

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -6983,7 +6983,7 @@ static void update_auth_hmac_md5(struct isis_auth *auth, struct stream *s,
 				 bool is_lsp)
 {
 	uint8_t digest[16];
-	uint16_t checksum, rem_lifetime;
+	uint16_t checksum = 0, rem_lifetime = 0;
 
 	if (is_lsp)
 		safe_auth_md5(s, &checksum, &rem_lifetime);

--- a/lib/yang_wrappers.c
+++ b/lib/yang_wrappers.c
@@ -15,28 +15,6 @@
 #include "printfrr.h"
 
 
-#define YANG_DNODE_XPATH_GET_VALUE(dnode, xpath_fmt)                                               \
-	({                                                                                         \
-		const struct lyd_value *_y__dvalue;                                                \
-		va_list _Y__ap;                                                                    \
-                                                                                                   \
-		va_start(_Y__ap, (xpath_fmt));                                                     \
-		_y__dvalue = yang_dnode_xpath_get_value(dnode, xpath_fmt, _Y__ap);                 \
-		va_end(_Y__ap);                                                                    \
-		_y__dvalue;                                                                        \
-	})
-
-#define YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt)                                               \
-	({                                                                                         \
-		const char *_y__canon;                                                             \
-		va_list _y__ap;                                                                    \
-                                                                                                   \
-		va_start(_y__ap, (xpath_fmt));                                                     \
-		_y__canon = yang_dnode_xpath_get_canon(dnode, xpath_fmt, _y__ap);                  \
-		va_end(_y__ap);                                                                    \
-		_y__canon;                                                                         \
-	})
-
 #define YANG_DNODE_GET_ASSERT(dnode, xpath)                                    \
 	do {                                                                   \
 		if ((dnode) == NULL) {                                         \
@@ -46,6 +24,23 @@
 			abort();                                               \
 		}                                                              \
 	} while (0)
+
+/* Wrappers for repetitive varargs stanzas */
+#define YANG_DNODE_GET_VALUE                                                   \
+	va_list ap;                                                            \
+                                                                               \
+	va_start(ap, xpath_fmt);                                               \
+	dvalue = yang_dnode_xpath_get_value(dnode, xpath_fmt, ap);             \
+	va_end(ap);
+
+
+#define YANG_DNODE_GET_CANON                                                   \
+	va_list ap;                                                            \
+                                                                               \
+	va_start(ap, xpath_fmt);                                               \
+	canon = yang_dnode_xpath_get_canon(dnode, xpath_fmt, ap);              \
+	va_end(ap);
+
 
 PRINTFRR(2, 0)
 static inline const char *
@@ -124,8 +119,11 @@ bool yang_dnode_get_bool(const struct lyd_node *dnode, const char *xpath_fmt,
 			 ...)
 {
 	const struct lyd_value *dvalue;
-	dvalue = YANG_DNODE_XPATH_GET_VALUE(dnode, xpath_fmt);
+
+	YANG_DNODE_GET_VALUE;
+
 	assert(dvalue->realtype->basetype == LY_TYPE_BOOL);
+
 	return dvalue->boolean;
 }
 
@@ -178,7 +176,8 @@ double yang_dnode_get_dec64(const struct lyd_node *dnode, const char *xpath_fmt,
 	const struct lysc_type_dec *dectype;
 	const struct lyd_value *dvalue;
 
-	dvalue = YANG_DNODE_XPATH_GET_VALUE(dnode, xpath_fmt);
+	YANG_DNODE_GET_VALUE;
+
 	dectype = (const struct lysc_type_dec *)dvalue->realtype;
 	assert(dectype->basetype == LY_TYPE_DEC64);
 	assert(dectype->fraction_digits < sizeof(denom) / sizeof(*denom));
@@ -276,7 +275,8 @@ int yang_dnode_get_enum(const struct lyd_node *dnode, const char *xpath_fmt,
 {
 	const struct lyd_value *dvalue;
 
-	dvalue = YANG_DNODE_XPATH_GET_VALUE(dnode, xpath_fmt);
+	YANG_DNODE_GET_VALUE;
+
 	assert(dvalue->realtype->basetype == LY_TYPE_ENUM);
 	assert(dvalue->enum_item->flags & LYS_SET_VALUE);
 	return dvalue->enum_item->value;
@@ -316,7 +316,9 @@ int8_t yang_dnode_get_int8(const struct lyd_node *dnode, const char *xpath_fmt,
 			   ...)
 {
 	const struct lyd_value *dvalue;
-	dvalue = YANG_DNODE_XPATH_GET_VALUE(dnode, xpath_fmt);
+
+	YANG_DNODE_GET_VALUE;
+
 	assert(dvalue->realtype->basetype == LY_TYPE_INT8);
 	return dvalue->int8;
 }
@@ -355,7 +357,9 @@ int16_t yang_dnode_get_int16(const struct lyd_node *dnode,
 			     const char *xpath_fmt, ...)
 {
 	const struct lyd_value *dvalue;
-	dvalue = YANG_DNODE_XPATH_GET_VALUE(dnode, xpath_fmt);
+
+	YANG_DNODE_GET_VALUE;
+
 	assert(dvalue->realtype->basetype == LY_TYPE_INT16);
 	return dvalue->int16;
 }
@@ -394,7 +398,9 @@ int32_t yang_dnode_get_int32(const struct lyd_node *dnode,
 			     const char *xpath_fmt, ...)
 {
 	const struct lyd_value *dvalue;
-	dvalue = YANG_DNODE_XPATH_GET_VALUE(dnode, xpath_fmt);
+
+	YANG_DNODE_GET_VALUE;
+
 	assert(dvalue->realtype->basetype == LY_TYPE_INT32);
 	return dvalue->int32;
 }
@@ -433,7 +439,9 @@ int64_t yang_dnode_get_int64(const struct lyd_node *dnode,
 			     const char *xpath_fmt, ...)
 {
 	const struct lyd_value *dvalue;
-	dvalue = YANG_DNODE_XPATH_GET_VALUE(dnode, xpath_fmt);
+
+	YANG_DNODE_GET_VALUE;
+
 	assert(dvalue->realtype->basetype == LY_TYPE_INT64);
 	return dvalue->int64;
 }
@@ -472,7 +480,9 @@ uint8_t yang_dnode_get_uint8(const struct lyd_node *dnode,
 			     const char *xpath_fmt, ...)
 {
 	const struct lyd_value *dvalue;
-	dvalue = YANG_DNODE_XPATH_GET_VALUE(dnode, xpath_fmt);
+
+	YANG_DNODE_GET_VALUE;
+
 	assert(dvalue->realtype->basetype == LY_TYPE_UINT8);
 	return dvalue->uint8;
 }
@@ -511,7 +521,9 @@ uint16_t yang_dnode_get_uint16(const struct lyd_node *dnode,
 			       const char *xpath_fmt, ...)
 {
 	const struct lyd_value *dvalue;
-	dvalue = YANG_DNODE_XPATH_GET_VALUE(dnode, xpath_fmt);
+
+	YANG_DNODE_GET_VALUE;
+
 	assert(dvalue->realtype->basetype == LY_TYPE_UINT16);
 	return dvalue->uint16;
 }
@@ -550,7 +562,9 @@ uint32_t yang_dnode_get_uint32(const struct lyd_node *dnode,
 			       const char *xpath_fmt, ...)
 {
 	const struct lyd_value *dvalue;
-	dvalue = YANG_DNODE_XPATH_GET_VALUE(dnode, xpath_fmt);
+
+	YANG_DNODE_GET_VALUE;
+
 	assert(dvalue->realtype->basetype == LY_TYPE_UINT32);
 	return dvalue->uint32;
 }
@@ -589,7 +603,9 @@ uint64_t yang_dnode_get_uint64(const struct lyd_node *dnode,
 			       const char *xpath_fmt, ...)
 {
 	const struct lyd_value *dvalue;
-	dvalue = YANG_DNODE_XPATH_GET_VALUE(dnode, xpath_fmt);
+
+	YANG_DNODE_GET_VALUE;
+
 	assert(dvalue->realtype->basetype == LY_TYPE_UINT64);
 	return dvalue->uint64;
 }
@@ -621,14 +637,21 @@ struct yang_data *yang_data_new_string(const char *xpath, const char *value)
 const char *yang_dnode_get_string(const struct lyd_node *dnode,
 				  const char *xpath_fmt, ...)
 {
-	return YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt);
+	const char *canon;
+
+	YANG_DNODE_GET_CANON;
+
+	return canon;
 }
 
 void yang_dnode_get_string_buf(char *buf, size_t size,
 			       const struct lyd_node *dnode,
 			       const char *xpath_fmt, ...)
 {
-	const char *canon = YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt);
+	const char *canon;
+
+	YANG_DNODE_GET_CANON;
+
 	if (strlcpy(buf, canon, size) >= size) {
 		char xpath[XPATH_MAXLEN];
 
@@ -705,7 +728,8 @@ size_t yang_dnode_get_binary_buf(char *buf, size_t size,
 	char *value_str;
 	struct base64_decodestate s;
 
-	canon = YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt);
+	YANG_DNODE_GET_CANON;
+
 	cannon_len = strlen(canon);
 	decode_len = cannon_len + 1;
 	value_str = (char *)malloc(decode_len);
@@ -780,14 +804,16 @@ void yang_dnode_get_prefix(struct prefix *prefix, const struct lyd_node *dnode,
 			   const char *xpath_fmt, ...)
 {
 	const char *canon;
+
+	/* XXX ip_prefix is a native type now in ly2, leverage? */
+	YANG_DNODE_GET_CANON;
+
 	/*
 	 * Initialize prefix to avoid static analyzer complaints about
 	 * uninitialized memory.
 	 */
 	memset(prefix, 0, sizeof(*prefix));
 
-	/* XXX ip_prefix is a native type now in ly2, leverage? */
-	canon = YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt);
 	(void)str2prefix(canon, prefix);
 }
 
@@ -825,8 +851,11 @@ struct yang_data *yang_data_new_ipv4(const char *xpath,
 void yang_dnode_get_ipv4(struct in_addr *addr, const struct lyd_node *dnode,
 			 const char *xpath_fmt, ...)
 {
+	const char *canon;
+
 	/* XXX libyang2 IPv4 address is a native type now in ly2 */
-	const char *canon = YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt);
+	YANG_DNODE_GET_CANON;
+
 	(void)inet_pton(AF_INET, canon, addr);
 }
 
@@ -868,8 +897,11 @@ void yang_dnode_get_ipv4p(union prefixptr prefix, const struct lyd_node *dnode,
 			  const char *xpath_fmt, ...)
 {
 	struct prefix_ipv4 *prefix4 = prefix.p4;
+	const char *canon;
+
+	YANG_DNODE_GET_CANON;
+
 	/* XXX libyang2: ipv4/6 address is a native type now in ly2 */
-	const char *canon = YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt);
 	(void)str2prefix_ipv4(canon, prefix4);
 }
 
@@ -907,8 +939,11 @@ struct yang_data *yang_data_new_ipv6(const char *xpath,
 void yang_dnode_get_ipv6(struct in6_addr *addr, const struct lyd_node *dnode,
 			 const char *xpath_fmt, ...)
 {
+	const char *canon;
+
 	/* XXX libyang2: IPv6 address is a native type now, leverage. */
-	const char *canon = YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt);
+	YANG_DNODE_GET_CANON;
+
 	(void)inet_pton(AF_INET6, canon, addr);
 }
 
@@ -950,9 +985,11 @@ void yang_dnode_get_ipv6p(union prefixptr prefix, const struct lyd_node *dnode,
 			  const char *xpath_fmt, ...)
 {
 	struct prefix_ipv6 *prefix6 = prefix.p6;
+	const char *canon;
 
 	/* XXX IPv6 address is a native type now in ly2 -- can we leverage? */
-	const char *canon = YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt);
+	YANG_DNODE_GET_CANON;
+
 	(void)str2prefix_ipv6(canon, prefix6);
 }
 
@@ -990,8 +1027,11 @@ struct yang_data *yang_data_new_ip(const char *xpath, const struct ipaddr *addr)
 void yang_dnode_get_ip(struct ipaddr *addr, const struct lyd_node *dnode,
 		       const char *xpath_fmt, ...)
 {
+	const char *canon;
+
 	/* XXX IPv4 address could be a plugin type now in ly2, leverage? */
-	const char *canon = YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt);
+	YANG_DNODE_GET_CANON;
+
 	(void)str2ipaddr(canon, addr);
 }
 
@@ -1026,7 +1066,10 @@ void yang_str2mac(const char *value, struct ethaddr *mac)
 void yang_dnode_get_mac(struct ethaddr *mac, const struct lyd_node *dnode,
 			const char *xpath_fmt, ...)
 {
-	const char *canon = YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt);
+	const char *canon;
+
+	YANG_DNODE_GET_CANON;
+
 	(void)prefix_str2mac(canon, mac);
 }
 
@@ -1053,9 +1096,11 @@ struct yang_data *yang_data_new_date_and_time(const char *xpath, time_t time, bo
 struct timespec yang_dnode_get_date_and_timespec(const struct lyd_node *dnode,
 						 const char *xpath_fmt, ...)
 {
-	const char *canon = YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt);
+	const char *canon;
 	struct timespec ts;
 	LY_ERR err;
+
+	YANG_DNODE_GET_CANON;
 
 	err = ly_time_str2ts(canon, &ts);
 	assert(!err);
@@ -1066,9 +1111,11 @@ struct timespec yang_dnode_get_date_and_timespec(const struct lyd_node *dnode,
 time_t yang_dnode_get_date_and_time(const struct lyd_node *dnode,
 				    const char *xpath_fmt, ...)
 {
-	const char *canon = YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt);
+	const char *canon;
 	time_t time;
 	LY_ERR err;
+
+	YANG_DNODE_GET_CANON;
 
 	err = ly_time_str2time(canon, &time, NULL);
 	assert(!err);
@@ -1079,8 +1126,10 @@ time_t yang_dnode_get_date_and_time(const struct lyd_node *dnode,
 float yang_dnode_get_bandwidth_ieee_float32(const struct lyd_node *dnode,
 					    const char *xpath_fmt, ...)
 {
-	const char *canon = YANG_DNODE_XPATH_GET_CANON(dnode, xpath_fmt);
+	const char *canon;
 	float value;
+
+	YANG_DNODE_GET_CANON;
 
 	assert(sscanf(canon, "%a", &value) == 1);
 


### PR DESCRIPTION
Clean up few more gcc-15 warnings: init locals in isisd module, replace variadic-ish macros in yang_wrappers.c with simple-minded macros.

Fixes: #18793