### PR TITLE
bgpd: fix to show exist/non-exist-map in 'show run' properly

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -18478,12 +18478,23 @@ static bool peergroup_filter_check(struct peer *peer, afi_t afi, safi_t safi,
 				   uint8_t type, int direct)
 {
 	struct bgp_filter *filter;
+	filter = &peer->filter[afi][safi];
 
-	if (peer_group_active(peer))
+	if (peer_group_active(peer)) {
+		/* This is required because the filter_override stores only the filter type.
+		 * To determine whether exist-map or non-exist-map is configured along with adv-map filter,
+		 * 'advmap.condition == direct' is evaluated where 'direct' should be passed appropriately by the caller */
+		if (type == PEER_FT_ADVERTISE_MAP) {
+			if (CHECK_FLAG(peer->filter_override[afi][safi][RMAP_OUT], type)) {
+				/* Only return true if the condition matches what we're checking for */
+				return (filter->advmap.condition == direct);
+			}
+			return false;
+		}
 		return !!CHECK_FLAG(peer->filter_override[afi][safi][direct],
 				    type);
+	}
 
-	filter = &peer->filter[afi][safi];
 	switch (type) {
 	case PEER_FT_DISTRIBUTE_LIST:
 		return !!(filter->dlist[direct].name);

--- a/tests/topotests/bgp_peer_group/test_bgp_peer-group.py
+++ b/tests/topotests/bgp_peer_group/test_bgp_peer-group.py
@@ -286,6 +286,89 @@ def test_bgp_peer_group_with_non_peer_group_peer():
     )
 
 
+def test_bgp_advertise_map_peer_group_config():
+    """
+    Test that advertise-map configurations show correctly in running config
+    when a peer is part of a peer group. Tests both exist-map and non-exist-map.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Create route-maps
+    r1.vtysh_cmd(
+        """
+        configure terminal
+          route-map EXIST-MAP permit 10
+          route-map ADV-MAP permit 10
+        """
+    )
+
+    # First verify the peer is part of a peer group
+    output = r1.vtysh_cmd("show bgp neighbor 192.168.252.2 json")
+    json_output = json.loads(output)
+    assert (
+        "peerGroup" in json_output["192.168.252.2"]
+    ), "Peer is not part of a peer group"
+
+    # Test 1: Configure advertise-map with exist-map
+    r1.vtysh_cmd(
+        """
+        configure terminal
+          router bgp 65001
+            address-family ipv4 unicast
+              neighbor 192.168.252.2 advertise-map ADV-MAP exist-map EXIST-MAP
+        """
+    )
+
+    output = r1.vtysh_cmd("show running-config")
+    exist_map_config = (
+        "neighbor 192.168.252.2 advertise-map ADV-MAP exist-map EXIST-MAP"
+    )
+
+    assert exist_map_config in output, (
+        f"Exist-map configuration not found or incorrect in running config. "
+        f"Expected: '{exist_map_config}'"
+    )
+
+    # Test 2: Configure advertise-map with non-exist-map
+    r1.vtysh_cmd(
+        """
+        configure terminal
+          router bgp 65001
+            address-family ipv4 unicast
+              neighbor 192.168.252.2 advertise-map ADV-MAP non-exist-map EXIST-MAP
+        """
+    )
+
+    output = r1.vtysh_cmd("show running-config")
+    non_exist_map_config = (
+        "neighbor 192.168.252.2 advertise-map ADV-MAP non-exist-map EXIST-MAP"
+    )
+
+    assert non_exist_map_config in output, (
+        f"Non-exist-map configuration not found or incorrect in running config. "
+        f"Expected: '{non_exist_map_config}'"
+    )
+
+    logger.info("exist/non-exist-map configuration correctly shown in running config")
+
+    # cleanup
+    r1.vtysh_cmd(
+        """
+        configure terminal
+          router bgp 65001
+            address-family ipv4 unicast
+              no neighbor 192.168.252.2 advertise-map ADV-MAP non-exist-map EXIST-MAP
+          no route-map EXIST-MAP permit 10
+          no route-map ADV-MAP permit 10
+        """
+    )
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))


### PR DESCRIPTION
Currently, peergroup_filter_check() does not check whether exist-map or non-exist-map is configured along with advertise-map. This check is missing only when the peer is part of peergroup and having the exist/non-exist-map. So the 'show run' does not show the configured exist/non-exist-map as expected.

This new check is needed because, unlike other filter type the adv-map can have exist/non-exist-map additionally and we don't store this in the filter_override but store only the adv-map. So, a specific check is required to account the exist/non-exist-map while printing the adv-map config. Fixing the same by adding a check.