### PR TITLE
*: c23 noreturn compliant

### DIFF
--- a/babeld/babel_main.c
+++ b/babeld/babel_main.c
@@ -34,9 +34,9 @@ Copyright 2011 by Matthieu Boutier and Juliusz Chroboczek
 #include "babel_zebra.h"
 #include "babel_errors.h"
 
-static FRR_NORETURN void babel_fail(void);
+FRR_NORETURN static void babel_fail(void);
 static void babel_init_random(void);
-static FRR_NORETURN void babel_exit_properly(void);
+FRR_NORETURN static void babel_exit_properly(void);
 static void babel_save_state_file(void);
 
 
@@ -85,7 +85,7 @@ struct zebra_privs_t babeld_privs =
     .cap_num_i = 0
 };
 
-static FRR_NORETURN void babel_sigexit(void)
+FRR_NORETURN static void babel_sigexit(void)
 {
     zlog_notice("Terminating on signal");
 
@@ -207,7 +207,7 @@ main(int argc, char **argv)
     return 0;
 }
 
-static FRR_NORETURN void babel_fail(void)
+FRR_NORETURN static void babel_fail(void)
 {
     exit(1);
 }
@@ -295,7 +295,7 @@ fini:
     return ;
 }
 
-static FRR_NORETURN void babel_exit_properly(void)
+FRR_NORETURN static void babel_exit_properly(void)
 {
     debugf(BABEL_DEBUG_COMMON, "Exiting...");
     usleep(roughly(10000));

--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -57,7 +57,7 @@ static void sigusr1_handler(void)
 	zlog_rotate();
 }
 
-static FRR_NORETURN void sigterm_handler(void)
+FRR_NORETURN static void sigterm_handler(void)
 {
 	bglobal.bg_shutdown = true;
 

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -148,7 +148,7 @@ void sighup(void)
 }
 
 /* SIGINT handler. */
-__attribute__((__noreturn__)) void sigint(void)
+FRR_NORETURN void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 	assert(bm->terminating == false);
@@ -185,7 +185,7 @@ void sigusr1(void)
   Zebra route removal and protocol teardown are not meant to be done here.
   For example, "retain_mode" may be set.
 */
-static __attribute__((__noreturn__)) void bgp_exit(int status)
+static void bgp_exit(int status)
 {
 	struct bgp *bgp, *bgp_default, *bgp_evpn;
 	struct listnode *node, *nnode;

--- a/eigrpd/eigrp_main.c
+++ b/eigrpd/eigrp_main.c
@@ -92,7 +92,7 @@ static void sighup(void)
 }
 
 /* SIGINT / SIGTERM handler. */
-static FRR_NORETURN void sigint(void)
+FRR_NORETURN static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 

--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -100,7 +100,7 @@ void sigterm(void);
 void sigusr1(void);
 
 
-static __attribute__((__noreturn__)) void terminate(int i)
+FRR_NORETURN static void terminate(int i)
 {
 	isis_terminate();
 	isis_sr_term();
@@ -140,13 +140,13 @@ void sighup(void)
 
 #endif
 
-__attribute__((__noreturn__)) void sigint(void)
+FRR_NORETURN void sigint(void)
 {
 	zlog_notice("Terminating on signal SIGINT");
 	terminate(0);
 }
 
-__attribute__((__noreturn__)) void sigterm(void)
+FRR_NORETURN void sigterm(void)
 {
 	zlog_notice("Terminating on signal SIGTERM");
 	terminate(0);

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -176,7 +176,7 @@ lde_init(struct ldpd_init *init)
 	zclient_sync_init();
 }
 
-static FRR_NORETURN void lde_shutdown(void)
+FRR_NORETURN static void lde_shutdown(void)
 {
 	/* close pipes */
 	if (iev_ldpe) {

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -443,7 +443,7 @@ main(int argc, char *argv[])
 	return (0);
 }
 
-static FRR_NORETURN void ldpd_shutdown(void)
+FRR_NORETURN static void ldpd_shutdown(void)
 {
 	pid_t		 pid;
 	int		 status;

--- a/ldpd/ldpe.c
+++ b/ldpd/ldpe.c
@@ -25,7 +25,7 @@
 #include "libfrr.h"
 #include "zlog_live.h"
 
-static FRR_NORETURN void ldpe_shutdown(void);
+FRR_NORETURN static void ldpe_shutdown(void);
 static void ldpe_dispatch_main(struct event *thread);
 static void ldpe_dispatch_lde(struct event *thread);
 #ifdef __OpenBSD__
@@ -66,7 +66,7 @@ struct zebra_privs_t ldpe_privs =
 };
 
 /* SIGINT / SIGTERM handler. */
-static FRR_NORETURN void sigint(void)
+FRR_NORETURN static void sigint(void)
 {
 	ldpe_shutdown();
 }
@@ -181,7 +181,7 @@ ldpe_init(struct ldpd_init *init)
 	accept_init();
 }
 
-static FRR_NORETURN void ldpe_shutdown(void)
+FRR_NORETURN static void ldpe_shutdown(void)
 {
 	struct if_addr		*if_addr;
 	struct adj		*adj;

--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -462,7 +462,11 @@ _Static_assert(sizeof(_uint64_t) == 8 && sizeof(_int64_t) == 8,
 #endif
 
 /* Wrapper for the 'noreturn' metadata */
-#define FRR_NORETURN __attribute__((noreturn))
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(noreturn)
+#  define FRR_NORETURN [[noreturn]]
+#else
+#  define FRR_NORETURN __attribute__((noreturn))
+#endif
 
 #ifdef __cplusplus
 }

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -410,7 +410,7 @@ void frr_opt_add(const char *optstr, const struct option *longopts,
 	opt_extend(&main_opts);
 }
 
-void frr_help_exit(int status)
+FRR_NORETURN void frr_help_exit(int status)
 {
 	FILE *target = status ? stderr : stdout;
 
@@ -868,7 +868,7 @@ static void rcv_signal(int signum)
 	/* poll() is interrupted by the signal; handled below */
 }
 
-static FRR_NORETURN void frr_daemon_wait(int fd)
+FRR_NORETURN static void frr_daemon_wait(int fd)
 {
 	struct pollfd pfd[1];
 	int ret;

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -188,7 +188,7 @@ extern void frr_opt_add(const char *optstr, const struct option *longopts,
 			const char *helpstr);
 extern int frr_getopt(int argc, char *const argv[], int *longindex);
 
-extern __attribute__((__noreturn__)) void frr_help_exit(int status);
+FRR_NORETURN extern void frr_help_exit(int status);
 
 extern struct event_loop *frr_init(void);
 extern const char *frr_get_progname(void);

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -183,7 +183,7 @@ typedef int qmem_walk_fn(void *arg, struct memgroup *mg, struct memtype *mt);
 extern int qmem_walk(qmem_walk_fn *func, void *arg);
 extern int log_memstats(const char *daemon_name, bool enabled);
 
-extern FRR_NORETURN void memory_oom(size_t size, const char *name);
+FRR_NORETURN extern void memory_oom(size_t size, const char *name);
 
 #ifdef __cplusplus
 }

--- a/lib/sigevent.c
+++ b/lib/sigevent.c
@@ -206,7 +206,7 @@ static void *program_counter(void *context)
 	return NULL;
 }
 
-static void FRR_NORETURN exit_handler(int signo, siginfo_t *siginfo,
+FRR_NORETURN static void exit_handler(int signo, siginfo_t *siginfo,
 				      void *context)
 {
 	void *pc = program_counter(context);
@@ -215,7 +215,7 @@ static void FRR_NORETURN exit_handler(int signo, siginfo_t *siginfo,
 	_exit(128 + signo);
 }
 
-static void FRR_NORETURN core_handler(int signo, siginfo_t *siginfo,
+FRR_NORETURN static void core_handler(int signo, siginfo_t *siginfo,
 				      void *context)
 {
 	void *pc = program_counter(context);

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -2143,7 +2143,7 @@ void mgmt_fe_adapter_init(struct event_loop *tm)
 	}
 }
 
-static FRR_NORETURN void mgmt_fe_abort_if_session(void *data)
+FRR_NORETURN static void mgmt_fe_abort_if_session(void *data)
 {
 	struct mgmt_fe_session_ctx *session = data;
 

--- a/mgmtd/mgmt_main.c
+++ b/mgmtd/mgmt_main.c
@@ -82,7 +82,7 @@ static void sighup(void)
 }
 
 /* SIGINT handler. */
-static __attribute__((__noreturn__)) void sigint(void)
+FRR_NORETURN static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 	assert(mm->terminating == false);
@@ -108,7 +108,7 @@ static void sigusr1(void)
  * Zebra route removal and protocol teardown are not meant to be done here.
  * For example, "retain_mode" may be set.
  */
-static __attribute__((__noreturn__)) void mgmt_exit(int status)
+FRR_NORETURN static void mgmt_exit(int status)
 {
 	/* it only makes sense for this to be called on a clean exit */
 	assert(status == 0);

--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -78,7 +78,7 @@ static void nhrp_sigusr1(void)
 	zlog_rotate();
 }
 
-static FRR_NORETURN void nhrp_request_stop(void)
+FRR_NORETURN static void nhrp_request_stop(void)
 {
 	debugf(NHRP_DEBUG_COMMON, "Exiting...");
 	frr_early_fini();

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -70,7 +70,7 @@ struct option longopts[] = {{0}};
 /* Master of threads. */
 struct event_loop *master;
 
-static void __attribute__((noreturn)) ospf6_exit(int status)
+FRR_NORETURN static void ospf6_exit(int status)
 {
 	struct vrf *vrf;
 	struct interface *ifp;
@@ -125,14 +125,14 @@ static void sighup(void)
 }
 
 /* SIGINT handler. */
-static FRR_NORETURN void sigint(void)
+FRR_NORETURN static void sigint(void)
 {
 	zlog_notice("Terminating on signal SIGINT");
 	ospf6_exit(0);
 }
 
 /* SIGTERM handler. */
-static FRR_NORETURN void sigterm(void)
+FRR_NORETURN static void sigterm(void)
 {
 	zlog_notice("Terminating on signal SIGTERM");
 	ospf6_exit(0);

--- a/ospfd/ospf_main.c
+++ b/ospfd/ospf_main.c
@@ -99,7 +99,7 @@ static void sighup(void)
 }
 
 /* SIGINT / SIGTERM handler. */
-static FRR_NORETURN void sigint(void)
+FRR_NORETURN static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 	bfd_protocol_integration_set_shutdown(true);

--- a/pathd/path_main.c
+++ b/pathd/path_main.c
@@ -55,7 +55,7 @@ static void sighup(void)
 }
 
 /* SIGINT / SIGTERM handler. */
-static FRR_NORETURN void sigint(void)
+FRR_NORETURN static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 	zlog_notice("Unregister from opaque,etc ");

--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -65,7 +65,7 @@ static void sighup(void)
 }
 
 /* SIGINT / SIGTERM handler. */
-static FRR_NORETURN void sigint(void)
+FRR_NORETURN static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 

--- a/pimd/pim6_main.c
+++ b/pimd/pim6_main.c
@@ -56,14 +56,14 @@ static void pim6_sighup(void)
 	zlog_info("SIGHUP received, ignoring");
 }
 
-static FRR_NORETURN void pim6_sigint(void)
+FRR_NORETURN static void pim6_sigint(void)
 {
 	zlog_notice("Terminating on signal SIGINT");
 	pim6_terminate();
 	exit(1);
 }
 
-static FRR_NORETURN void pim6_sigterm(void)
+FRR_NORETURN static void pim6_sigterm(void)
 {
 	zlog_notice("Terminating on signal SIGTERM");
 	pim6_terminate();

--- a/pimd/pim_signals.c
+++ b/pimd/pim_signals.c
@@ -25,14 +25,14 @@ static void pim_sighup(void)
 	zlog_info("SIGHUP received, ignoring");
 }
 
-static FRR_NORETURN void pim_sigint(void)
+FRR_NORETURN static void pim_sigint(void)
 {
 	zlog_notice("Terminating on signal SIGINT");
 	pim_terminate();
 	exit(1);
 }
 
-static FRR_NORETURN void pim_sigterm(void)
+FRR_NORETURN static void pim_sigterm(void)
 {
 	zlog_notice("Terminating on signal SIGTERM");
 	pim_terminate();

--- a/ripd/rip_main.c
+++ b/ripd/rip_main.c
@@ -69,7 +69,7 @@ static void sighup(void)
 }
 
 /* SIGINT handler. */
-static FRR_NORETURN void sigint(void)
+FRR_NORETURN static void sigint(void)
 {
 	struct vrf *vrf;
 

--- a/ripngd/ripng_main.c
+++ b/ripngd/ripng_main.c
@@ -67,7 +67,7 @@ static void sighup(void)
 }
 
 /* SIGINT handler. */
-static FRR_NORETURN void sigint(void)
+FRR_NORETURN static void sigint(void)
 {
 	struct vrf *vrf;
 

--- a/sharpd/sharp_main.c
+++ b/sharpd/sharp_main.c
@@ -90,7 +90,7 @@ static void sighup(void)
 }
 
 /* SIGINT / SIGTERM handler. */
-static FRR_NORETURN void sigint(void)
+FRR_NORETURN static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 

--- a/staticd/static_main.c
+++ b/staticd/static_main.c
@@ -65,7 +65,7 @@ static void sighup(void)
 }
 
 /* SIGINT / SIGTERM handler. */
-static FRR_NORETURN void sigint(void)
+FRR_NORETURN static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 

--- a/tools/gen_northbound_callbacks.c
+++ b/tools/gen_northbound_callbacks.c
@@ -18,7 +18,7 @@
 static bool f_static_cbs;
 static bool f_new_cbs;
 
-static void __attribute__((noreturn)) usage(int status)
+FRR_NORETURN static void usage(int status)
 {
 	extern const char *__progname;
 	fprintf(stderr, "usage: %s [-h] [-n] [-s] [-p path]* MODULE\n", __progname);

--- a/tools/gen_yang_deviations.c
+++ b/tools/gen_yang_deviations.c
@@ -13,7 +13,7 @@
 #include "yang.h"
 #include "northbound.h"
 
-static void __attribute__((noreturn)) usage(int status)
+FRR_NORETURN static void  usage(int status)
 {
 	fprintf(stderr, "usage: gen_yang_deviations [-h] MODULE\n");
 	exit(status);

--- a/vrrpd/vrrp_main.c
+++ b/vrrpd/vrrp_main.c
@@ -64,7 +64,7 @@ static void sighup(void)
 }
 
 /* SIGINT / SIGTERM handler. */
-static void __attribute__((noreturn)) sigint(void)
+FRR_NORETURN static void  sigint(void)
 {
 	zlog_notice("Terminating on signal");
 

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -156,7 +156,7 @@ static void vtysh_signal_init(void)
 }
 
 /* Help information display. */
-static FRR_NORETURN void usage(int status)
+FRR_NORETURN static void usage(int status)
 {
 	if (status != 0)
 		fprintf(stderr, "Try `%s --help' for more information.\n",

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -1090,7 +1090,7 @@ void watchfrr_status(struct vty *vty)
 	}
 }
 
-static FRR_NORETURN void sigint(void)
+FRR_NORETURN static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 	systemd_send_stopping();

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -216,7 +216,7 @@ static void sigint(void)
  * Final shutdown step for the zebra main thread. This is run after all
  * async update processing has completed.
  */
-void zebra_finalize(struct event *dummy)
+FRR_NORETURN void zebra_finalize(struct event *dummy)
 {
 	zlog_info("Zebra final shutdown");
 

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -401,7 +401,7 @@ void zserv_log_message(const char *errmsg, struct stream *msg,
 		       struct zmsghdr *hdr);
 
 /* TODO */
-__attribute__((__noreturn__)) void zebra_finalize(struct event *event);
+FRR_NORETURN void zebra_finalize(struct event *event);
 
 /*
  * Graceful restart functions.


### PR DESCRIPTION
Apply the generic attribute which becomes generic. The former FRR code was based on a gcc-ish attribute format.

See https://en.cppreference.com/w/c/language/attributes/noreturn

For the review, see `lib/compiler.h` first which introduces
```
[[noreturn]]
```

Down the road, the `FRR_NORETURN` should be removed in order to use only `[[noreturn]]`