### PR TITLE
bgpd: fix import all adj-rib-in and loc-rib after bmp connects

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1254,7 +1254,7 @@ static struct bgp *bmp_get_next_bgp(struct bmp_targets *bt, struct bgp *bgp, afi
 
 	if (bgp == NULL && bt->bgp_request_sync[afi][safi])
 		return bt->bgp;
-	if (bgp == NULL)
+	if (bgp == NULL || bgp == bt->bgp)
 		get_first = true;
 	frr_each (bmp_imported_bgps, &bt->imported_bgps, bib) {
 		bgp_inst = bgp_lookup_by_name(bib->name);

--- a/tests/topotests/bgp_bmp/bgpbmp.py
+++ b/tests/topotests/bgp_bmp/bgpbmp.py
@@ -13,9 +13,17 @@ from lib.topolog import logger
 SEQ = 0
 
 
-def bmp_reset_seq():
+def bmp_reset_seq(seq_param=0):
     global SEQ
-    SEQ = 0
+    SEQ = seq_param
+
+
+def bmp_get_seq():
+    return SEQ
+
+
+def bmp_display_seq():
+    logger.info(f"SEQ is {SEQ}")
 
 
 def get_bmp_messages(bmp_collector, bmp_log_file):

--- a/tests/topotests/bgp_bmp/bmp2import/bmp-update-loc-rib-step1.json
+++ b/tests/topotests/bgp_bmp/bmp2import/bmp-update-loc-rib-step1.json
@@ -1,0 +1,34 @@
+{
+    "loc-rib": {
+        "update": {
+            "172.31.0.77/32": {
+                "as_path": "",
+                "bgp_nexthop": "192.168.1.3",
+                "bmp_log_type": "update",
+                "ip_prefix": "172.31.0.77/32",
+                "is_filtered": false,
+                "origin": "IGP",
+                "peer_asn": 65501,
+                "peer_bgp_id": "192.168.0.1",
+                "peer_distinguisher": "444:1",
+                "peer_type": "loc-rib instance",
+                "policy": "loc-rib"
+            },
+            "2001::1125/128": {
+                "afi": 2,
+                "as_path": "",
+                "bmp_log_type": "update",
+                "ip_prefix": "2001::1125/128",
+                "is_filtered": false,
+                "nxhp_ip": "192:167::3",
+                "origin": "IGP",
+                "peer_asn": 65501,
+                "peer_bgp_id": "192.168.0.1",
+                "peer_distinguisher": "555:1",
+                "peer_type": "loc-rib instance",
+                "policy": "loc-rib",
+                "safi": 1
+            }
+        }
+    }
+}

--- a/tests/topotests/bgp_bmp/bmp2import/bmp-update-post-policy-step1.json
+++ b/tests/topotests/bgp_bmp/bmp2import/bmp-update-post-policy-step1.json
@@ -1,0 +1,36 @@
+{
+    "post-policy": {
+        "update": {
+            "172.31.0.77/32": {
+                "as_path": "",
+                "bgp_nexthop": "192.168.1.3",
+                "bmp_log_type": "update",
+                "ip_prefix": "172.31.0.77/32",
+                "ipv6": false,
+                "origin": "IGP",
+                "peer_asn": 65501,
+                "peer_bgp_id": "192.168.1.3",
+                "peer_distinguisher": "444:1",
+                "peer_ip": "192.168.1.3",
+                "peer_type": "route distinguisher instance",
+                "policy": "post-policy"
+            },
+            "2001::1125/128": {
+                "afi": 2,
+                "as_path": "",
+                "bmp_log_type": "update",
+                "ip_prefix": "2001::1125/128",
+                "ipv6": true,
+                "nxhp_ip": "192:167::3",
+                "origin": "IGP",
+                "peer_asn": 65501,
+                "peer_bgp_id": "192.168.1.3",
+                "peer_distinguisher": "555:1",
+                "peer_ip": "192:167::3",
+                "peer_type": "route distinguisher instance",
+                "policy": "post-policy",
+                "safi": 1
+            }
+        }
+    }
+}

--- a/tests/topotests/bgp_bmp/bmp2import/bmp-update-pre-policy-step1.json
+++ b/tests/topotests/bgp_bmp/bmp2import/bmp-update-pre-policy-step1.json
@@ -1,0 +1,36 @@
+{
+    "pre-policy": {
+        "update": {
+            "172.31.0.77/32": {
+                "as_path": "",
+                "bgp_nexthop": "192.168.1.3",
+                "bmp_log_type": "update",
+                "ip_prefix": "172.31.0.77/32",
+                "ipv6": false,
+                "origin": "IGP",
+                "peer_asn": 65501,
+                "peer_bgp_id": "192.168.1.3",
+                "peer_distinguisher": "444:1",
+                "peer_ip": "192.168.1.3",
+                "peer_type": "route distinguisher instance",
+                "policy": "pre-policy"
+            },
+            "2001::1125/128": {
+                "afi": 2,
+                "as_path": "",
+                "bmp_log_type": "update",
+                "ip_prefix": "2001::1125/128",
+                "ipv6": true,
+                "nxhp_ip": "192:167::3",
+                "origin": "IGP",
+                "peer_asn": 65501,
+                "peer_bgp_id": "192.168.1.3",
+                "peer_distinguisher": "555:1",
+                "peer_ip": "192:167::3",
+                "peer_type": "route distinguisher instance",
+                "policy": "pre-policy",
+                "safi": 1
+            }
+        }
+    }
+}

--- a/tests/topotests/lib/bmp_collector/bmpserver.py
+++ b/tests/topotests/lib/bmp_collector/bmpserver.py
@@ -18,7 +18,8 @@ from datetime import datetime
 
 from bmp import BMPMsg
 
-BGP_MAX_SIZE = 4096
+# RFC8654 : max packet size is 65535 bytes
+BGP_MAX_SIZE = 65535
 
 # Global variable to track shutdown signal
 shutdown = False


### PR DESCRIPTION
When BMP client connects to a BMP collector, the RIB entries from an imported VRF are not sent to that collector. After reconnecting the BMP client, only the RIB entries of the default VRF where BMP is configured are sent.

> 2025/05/19 14:33:11.863970 BGP: [KXFT6-AKP4X] bmp[192.0.2.10:1789] connection established
> 2025/05/19 14:33:11.864027 BGP: [Y3NW5-Y5P0A] bmp[192.0.2.10:1789] IPv4 unicast sending table (BGP VRF default)
> 2025/05/19 14:33:11.864059 BGP: [MC9C8-MQZT1] bmp[192.0.2.10:1789] IPv4 unicast table completed (EoR) (BGP VRF default)
> 2025/05/19 14:33:11.864066 BGP: [Y3NW5-Y5P0A] bmp[192.0.2.10:1789] IPv6 unicast sending table (BGP VRF default)
> 2025/05/19 14:33:11.864076 BGP: [MC9C8-MQZT1] bmp[192.0.2.10:1789] IPv6 unicast table completed (EoR) (BGP VRF default)

The BGP traces do not indicate that the bgp vrf1 instance is synced. The algorithm parses for each addres-family, the BGP instances available, but the bmp_get_next_bgp() function does not handle the case where the next BGP instance is the next close to the default one. Fix this by setting get_first local variable properly.

The resulting traces and captured packets now show that at reconnect, all RIB entries from VRF1 are sent.

> 2025/05/19 14:53:47.202956 BGP: [Y3NW5-Y5P0A] bmp[192.0.2.10:1789] IPv4 unicast sending table (BGP VRF default)
> 2025/05/19 14:53:47.202976 BGP: [MC9C8-MQZT1] bmp[192.0.2.10:1789] IPv4 unicast table completed (EoR) (BGP VRF default)
> 2025/05/19 14:53:47.202981 BGP: [MC9C8-MQZT1] bmp[192.0.2.10:1789] IPv4 unicast table completed (EoR) (BGP VRF vrf1)
> 2025/05/19 14:53:47.202986 BGP: [Y3NW5-Y5P0A] bmp[192.0.2.10:1789] IPv6 unicast sending table (BGP VRF default)
> 2025/05/19 14:53:47.202997 BGP: [MC9C8-MQZT1] bmp[192.0.2.10:1789] IPv6 unicast table completed (EoR) (BGP VRF default)
> 2025/05/19 14:53:47.203002 BGP: [MC9C8-MQZT1] bmp[192.0.2.10:1789] IPv6 unicast table completed (EoR) (BGP VRF vrf1)

Fixes: b79574b5c6ad ("bgpd: add sync for monitored afi/safi of imported bgps")