### PR TITLE
zebra: finish moving `ip[v6] forwarding` to NB/mgmtd

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -140,7 +140,6 @@ enum node_type {
 	PBRMAP_NODE,		 /* PBR map node. */
 	SMUX_NODE,		 /* SNMP configuration node. */
 	DUMP_NODE,		 /* Packet dump node. */
-	FORWARDING_NODE,	 /* IP forwarding node. */
 	PROTOCOL_NODE,		 /* protocol filtering node */
 	MPLS_NODE,		 /* MPLS config node */
 	PW_NODE,		 /* Pseudowire config node */

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -444,13 +444,6 @@ void vtysh_config_parse_line(void *arg, const char *line)
 			config = config_get(KEYCHAIN_NODE, line);
 		else if (strncmp(line, "line", strlen("line")) == 0)
 			config = config_get(VTY_NODE, line);
-		else if ((strncmp(line, "ipv6 forwarding",
-				  strlen("ipv6 forwarding"))
-			  == 0)
-			 || (strncmp(line, "ip forwarding",
-				     strlen("ip forwarding"))
-			     == 0))
-			config = config_get(FORWARDING_NODE, line);
 		else if (strncmp(line, "debug vrf", strlen("debug vrf")) == 0)
 			config = config_get(VRF_DEBUG_NODE, line);
 		else if (strncmp(line, "debug route-map",
@@ -520,15 +513,12 @@ void vtysh_config_parse_line(void *arg, const char *line)
 
 /* Macro to check delimiter is needed between each configuration line
  * or not. */
-#define NO_DELIMITER(I)                                                        \
-	((I) == AFFMAP_NODE || (I) == ACCESS_NODE || (I) == PREFIX_NODE ||     \
-	 (I) == IP_NODE || (I) == AS_LIST_NODE ||                              \
-	 (I) == COMMUNITY_LIST_NODE || (I) == COMMUNITY_ALIAS_NODE ||          \
-	 (I) == ACCESS_IPV6_NODE || (I) == ACCESS_MAC_NODE ||                  \
-	 (I) == PREFIX_IPV6_NODE || (I) == FORWARDING_NODE ||                  \
-	 (I) == DEBUG_NODE || (I) == AAA_NODE || (I) == VRF_DEBUG_NODE ||      \
-	 (I) == RMAP_DEBUG_NODE || (I) == RESOLVER_DEBUG_NODE ||               \
-	 (I) == MPLS_NODE || (I) == KEYCHAIN_KEY_NODE)
+#define NO_DELIMITER(I)                                                                             \
+	((I) == AFFMAP_NODE || (I) == ACCESS_NODE || (I) == PREFIX_NODE || (I) == IP_NODE ||        \
+	 (I) == AS_LIST_NODE || (I) == COMMUNITY_LIST_NODE || (I) == COMMUNITY_ALIAS_NODE ||        \
+	 (I) == ACCESS_IPV6_NODE || (I) == ACCESS_MAC_NODE || (I) == PREFIX_IPV6_NODE ||            \
+	 (I) == DEBUG_NODE || (I) == AAA_NODE || (I) == VRF_DEBUG_NODE || (I) == RMAP_DEBUG_NODE || \
+	 (I) == RESOLVER_DEBUG_NODE || (I) == MPLS_NODE || (I) == KEYCHAIN_KEY_NODE)
 
 static void configvec_dump(vector vec, bool nested)
 {

--- a/zebra/zebra_cli.c
+++ b/zebra/zebra_cli.c
@@ -45,6 +45,54 @@ static void zebra_ptm_enable_cli_write(struct vty *vty,
 }
 #endif
 
+DEFPY_YANG (ip_forwarding,
+	    ip_forwarding_cmd,
+	    "[no] ip forwarding",
+	    NO_STR
+	    IP_STR
+	    "Turn on IP forwarding\n")
+{
+	nb_cli_enqueue_change(vty, "/frr-zebra:zebra/ip-forwarding", NB_OP_MODIFY,
+			      no ? "false" : "true");
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+static void zebra_ip_forwarding_cli_write(struct vty *vty, const struct lyd_node *dnode,
+					  bool show_defaults)
+{
+	bool enabled = yang_dnode_get_bool(dnode, NULL);
+
+	if (!enabled)
+		vty_out(vty, "no ip forwrding\n");
+	else if (show_defaults)
+		vty_out(vty, "ip forwrding\n");
+}
+
+DEFPY_YANG (ipv6_forwarding,
+	    ipv6_forwarding_cmd,
+	    "[no] ipv6 forwarding",
+	    NO_STR
+	    IPV6_STR
+	    "Turn on IPv6 forwarding\n")
+{
+	nb_cli_enqueue_change(vty, "/frr-zebra:zebra/ipv6-forwarding", NB_OP_MODIFY,
+			      no ? "false" : "true");
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+static void zebra_ipv6_forwarding_cli_write(struct vty *vty, const struct lyd_node *dnode,
+					    bool show_defaults)
+{
+	bool enabled = yang_dnode_get_bool(dnode, NULL);
+
+	if (!enabled)
+		vty_out(vty, "no ipv6 forwrding\n");
+	else if (show_defaults)
+		vty_out(vty, "ipv6 forwrding\n");
+}
+
 DEFPY_YANG (zebra_route_map_timer,
        zebra_route_map_timer_cmd,
        "[no] zebra route-map delay-timer ![(0-600)$delay]",
@@ -2734,6 +2782,14 @@ const struct frr_yang_module_info frr_zebra_cli_info = {
 		},
 #endif
 		{
+			.xpath = "/frr-zebra:zebra/ip-forwarding",
+			.cbs.cli_show = zebra_ip_forwarding_cli_write,
+		},
+		{
+			.xpath = "/frr-zebra:zebra/ipv6-forwarding",
+			.cbs.cli_show = zebra_ipv6_forwarding_cli_write,
+		},
+		{
 			.xpath = "/frr-zebra:zebra/route-map-delay",
 			.cbs.cli_show = zebra_route_map_delay_cli_write,
 		},
@@ -3051,6 +3107,9 @@ void zebra_cli_init(void)
 #if HAVE_BFDD == 0
 	install_element(INTERFACE_NODE, &zebra_ptm_enable_if_cmd);
 #endif
+
+	install_element(CONFIG_NODE, &ip_forwarding_cmd);
+	install_element(CONFIG_NODE, &ipv6_forwarding_cmd);
 
 	install_element(CONFIG_NODE, &ip_router_id_cmd);
 	install_element(CONFIG_NODE, &router_id_cmd);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3849,19 +3849,6 @@ DEFUN (show_zebra,
 	return CMD_SUCCESS;
 }
 
-DEFPY_YANG (ip_forwarding,
-	    ip_forwarding_cmd,
-	    "[no] ip forwarding",
-	    NO_STR
-	    IP_STR
-	    "Turn on IP forwarding\n")
-{
-	nb_cli_enqueue_change(vty, "/frr-zebra:zebra/ip-forwarding", NB_OP_MODIFY,
-			      no ? "false" : "true");
-
-	return nb_cli_apply_changes(vty, NULL);
-}
-
 /* Only display ip forwarding is enabled or not. */
 DEFUN (show_ip_forwarding,
        show_ip_forwarding_cmd,
@@ -3908,19 +3895,6 @@ DEFUN (show_ipv6_forwarding,
 		break;
 	}
 	return CMD_SUCCESS;
-}
-
-DEFPY_YANG (ipv6_forwarding,
-	    ipv6_forwarding_cmd,
-	    "[no] ipv6 forwarding",
-	    NO_STR
-	    IPV6_STR
-	    "Turn on IPv6 forwarding\n")
-{
-	nb_cli_enqueue_change(vty, "/frr-zebra:zebra/ipv6-forwarding", NB_OP_MODIFY,
-			      no ? "false" : "true");
-
-	return nb_cli_apply_changes(vty, NULL);
 }
 
 /* Display dataplane info */
@@ -4019,17 +3993,6 @@ DEFUN (show_zebra_metaq_counters,
 	bool uj = use_json(argc, argv);
 
 	return zebra_show_metaq_counter(vty, uj);
-}
-
-/* IPForwarding configuration write function. */
-static int config_write_forwarding(struct vty *vty)
-{
-	if (!ipforward())
-		vty_out(vty, "no ip forwarding\n");
-	if (!ipforward_ipv6())
-		vty_out(vty, "no ipv6 forwarding\n");
-	vty_out(vty, "!\n");
-	return 0;
 }
 
 DEFUN_HIDDEN (show_frr,
@@ -4197,26 +4160,16 @@ static struct cmd_node protocol_node = {
 	.prompt = "",
 	.config_write = config_write_protocol,
 };
-static int config_write_forwarding(struct vty *vty);
-static struct cmd_node forwarding_node = {
-	.name = "forwarding",
-	.node = FORWARDING_NODE,
-	.prompt = "",
-	.config_write = config_write_forwarding,
-};
 
 /* Route VTY.  */
 void zebra_vty_init(void)
 {
 	/* Install configuration write function. */
-	install_node(&forwarding_node);
 
 	install_element(VIEW_NODE, &show_ip_forwarding_cmd);
-	install_element(CONFIG_NODE, &ip_forwarding_cmd);
 	install_element(ENABLE_NODE, &show_zebra_cmd);
 
 	install_element(VIEW_NODE, &show_ipv6_forwarding_cmd);
-	install_element(CONFIG_NODE, &ipv6_forwarding_cmd);
 
 	/* Route-map */
 	zebra_route_map_init();


### PR DESCRIPTION
Need to put the CLI handler in the file linked into mgmtd, also use NB yang CLI write function for config generation.