### PR TITLE
bgpd: fix to show exist/non-exist-map in 'show run' properly

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -18348,12 +18348,23 @@ static bool peergroup_filter_check(struct peer *peer, afi_t afi, safi_t safi,
 				   uint8_t type, int direct)
 {
 	struct bgp_filter *filter;
+	filter = &peer->filter[afi][safi];
 
-	if (peer_group_active(peer))
+	if (peer_group_active(peer)) {
+		/* This is required because the filter_override stores only the filter type.
+		 * To determine whether exist-map or non-exist-map is configured along with adv-map filter,
+		 * 'advmap.condition == direct' is evaluated where 'direct' should be passed appropriately by the caller */
+		if (type == PEER_FT_ADVERTISE_MAP) {
+			if (CHECK_FLAG(peer->filter_override[afi][safi][RMAP_OUT], type)) {
+				/* Only return true if the condition matches what we're checking for */
+				return (filter->advmap.condition == direct);
+			}
+			return false;
+		}
 		return !!CHECK_FLAG(peer->filter_override[afi][safi][direct],
 				    type);
+	}
 
-	filter = &peer->filter[afi][safi];
 	switch (type) {
 	case PEER_FT_DISTRIBUTE_LIST:
 		return !!(filter->dlist[direct].name);


### PR DESCRIPTION
Currently, peergroup_filter_check() does not check whether exist-map or non-exist-map is configured along with advertise-map. This check is missing only when the peer is part of peergroup and having the exist/non-exist-map. So the 'show run' does not show the configured exist/non-exist-map as expected.

This new check is needed because, unlike other filter type the adv-map can have exist/non-exist-map additionally and we don't store this in the filter_override but store only the adv-map. So, a specific check is required to account the exist/non-exist-map while printing the adv-map config. Fixing the same by adding a check.