### PR TITLE
staticd, bgp: fix srv6 encap-value displayed with _ instead of .

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -20113,7 +20113,7 @@ int bgp_config_write(struct vty *vty)
 					bgp->srv6_locator_name);
 			if (bgp->srv6_encap_behavior != SRV6_HEADEND_BEHAVIOR_H_ENCAPS)
 				vty_out(vty, "  encap-behavior %s\n",
-					srv6_headend_behavior2str(bgp->srv6_encap_behavior));
+					srv6_headend_behavior2str(bgp->srv6_encap_behavior, true));
 			vty_endframe(vty, " exit\n");
 		}
 

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -1398,8 +1398,9 @@ void nexthop_json_helper(json_object *json_nexthop,
 							 ->seg[0]);
 			json_object_object_add(json_nexthop, "seg6", json_seg6);
 			json_object_string_add(json_nexthop, "srv6EncapBehavior",
-					       srv6_headend_behavior2str(
-						       nexthop->nh_srv6->seg6_segs->encap_behavior));
+					       srv6_headend_behavior2str(nexthop->nh_srv6->seg6_segs
+										 ->encap_behavior,
+									 false));
 		} else {
 			if (nexthop->nh_srv6->seg6_segs) {
 				json_segs = json_object_new_array();
@@ -1417,9 +1418,10 @@ void nexthop_json_helper(json_object *json_nexthop,
 				json_object_object_add(json_nexthop, "seg6",
 						       json_segs);
 				json_object_string_add(json_nexthop, "srv6EncapBehavior",
-						       srv6_headend_behavior2str(
-							       nexthop->nh_srv6->seg6_segs
-								       ->encap_behavior));
+						       srv6_headend_behavior2str(nexthop->nh_srv6
+											 ->seg6_segs
+											 ->encap_behavior,
+										 false));
 			}
 		}
 	}
@@ -1553,8 +1555,9 @@ void nexthop_vty_helper(struct vty *vty, const struct nexthop *nexthop,
 			if (nexthop->nh_srv6->seg6_segs->encap_behavior !=
 			    SRV6_HEADEND_BEHAVIOR_H_ENCAPS)
 				vty_out(vty, ", encap behavior %s",
-					srv6_headend_behavior2str(
-						nexthop->nh_srv6->seg6_segs->encap_behavior));
+					srv6_headend_behavior2str(nexthop->nh_srv6->seg6_segs
+									  ->encap_behavior,
+								  false));
 		}
 	}
 

--- a/lib/srv6.h
+++ b/lib/srv6.h
@@ -380,19 +380,20 @@ struct srv6_sid_ctx {
 	ifindex_t ifindex;
 };
 
-static inline const char *srv6_headend_behavior2str(enum srv6_headend_behavior behavior)
+static inline const char *srv6_headend_behavior2str(enum srv6_headend_behavior behavior,
+						    bool running_conf)
 {
 	switch (behavior) {
 	case SRV6_HEADEND_BEHAVIOR_H_INSERT:
-		return "H.Insert";
+		return running_conf ? "H_Insert" : "H.Insert";
 	case SRV6_HEADEND_BEHAVIOR_H_ENCAPS:
-		return "H.Encaps";
+		return running_conf ? "H_Encaps" : "H.Encaps";
 	case SRV6_HEADEND_BEHAVIOR_H_ENCAPS_RED:
-		return "H.Encaps.Red";
+		return running_conf ? "H_Encaps_Red" : "H.Encaps.Red";
 	case SRV6_HEADEND_BEHAVIOR_H_ENCAPS_L2:
-		return "H.Encaps.L2";
+		return running_conf ? "H_Encaps_L2" : "H.Encaps.L2";
 	case SRV6_HEADEND_BEHAVIOR_H_ENCAPS_L2_RED:
-		return "H.Encaps.L2.Red";
+		return running_conf ? "H_Encaps_L2_Red" : "H.Encaps.L2.Red";
 	}
 
 	return "unknown";

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -1612,7 +1612,7 @@ static void nexthop_cli_show(struct vty *vty, const struct lyd_node *route,
 
 		if (srv6_encap_behavior != SRV6_HEADEND_BEHAVIOR_H_ENCAPS || show_defaults)
 			vty_out(vty, " encap-behavior %s",
-				srv6_headend_behavior2str(srv6_encap_behavior));
+				srv6_headend_behavior2str(srv6_encap_behavior, true));
 	}
 
 	nexthop_vrf = yang_dnode_get_string(nexthop, "vrf");


### PR DESCRIPTION
When configuring an srv6 route with encap option, the displayed option in running config differs:

> ubuntu2404(config)# ipv6 route 5::6/128 loop0 segments 1::1 encap-behavior H_Encaps_Red
> ubuntu2404(config)# do show ipv6 route
> [..]
> S>* 5::6/128 [1/0] is directly connected, loop0, seg6 1::1, encap behavior H.Encaps.Red, weight 1, 00:00:02
> ubuntu2404(config)# do show running-config
> [..]
> ipv6 route 5::6/128 loop0 segments 1::1 encap-behavior H.Encaps.Red

Modify output in running-config wherever the encap-behavior is used. Use _ instead.

Fixes: 5323ad0d1fec ("staticd: Add SRv6 encap behavior in show running-config")
Fixes: dbd77b184f1a ("bgpd: add encap red support to L3VPN seg6 routes")