### PR TITLE
bgpd: add total path count for bgp net in json output (backport)

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12456,6 +12456,14 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 			}
 			vty_out(vty, "\n");
 		}
+
+		if (json) {
+			if (incremental_print) {
+				vty_out(vty, "\"pathCount\": %d", count);
+				vty_out(vty, ",");
+			} else
+				json_object_int_add(json, "pathCount", count);
+		}
 	}
 }
 


### PR DESCRIPTION
Currently only vty output shows total path count for a BGP net. This fix add that information in josn output too.

cherry-picked-from: be3c6d3d3d6220d6ef8600c966f9fca838e10521