### PR TITLE
redhat: Add Workaround for inet_ntop replacement which breaks rpms

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -338,8 +338,11 @@ Adds GRPC support to the individual FRR daemons.
 
 %build
 
+# Fix issue with D_FORTIFY_SOURCE on newer glibc (See Issue #18575)
+CFLAGS="%{optflags} -DINET_NTOP_NO_OVERRIDE"
+
 # For standard gcc verbosity, uncomment these lines:
-#CFLAGS="%{optflags} -Wall -Wsign-compare -Wpointer-arith"
+#CFLAGS="%{CFLAGS} -Wall -Wsign-compare -Wpointer-arith"
 #CFLAGS="${CFLAGS} -Wbad-function-cast -Wwrite-strings"
 
 # For ultra gcc verbosity, uncomment these lines also:


### PR DESCRIPTION
Newer glibc on RedHat 9 fail with _FORTIFY_SOURCE on the frr replacement of the inet_ntop. Fixes https://github.com/FRRouting/frr/issues/18575