### PR TITLE
bgpd: fix PEER_FLAG_CONFIG_DAMPENING to be ULL

### DIFF
--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1774,7 +1774,7 @@ struct peer {
 #define PEER_FLAG_SOO (1ULL << 28)
 #define PEER_FLAG_SEND_EXT_COMMUNITY_RPKI (1ULL << 29)
 #define PEER_FLAG_ADDPATH_RX_PATHS_LIMIT (1ULL << 30)
-#define PEER_FLAG_CONFIG_DAMPENING (1U << 31)
+#define PEER_FLAG_CONFIG_DAMPENING (1ULL << 31)
 #define PEER_FLAG_ACCEPT_OWN (1ULL << 63)
 
 	enum bgp_addpath_strat addpath_type[AFI_MAX][SAFI_MAX];


### PR DESCRIPTION
Proof reading. All the flags are ULL.