### PR TITLE
build: the war against `config.h` continues, 1 of ∞

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1799,16 +1799,13 @@ AC_CHECK_MEMBERS([struct utsname.domainname], [], [], [#include <sys/utsname.h>]
 dnl ------------------
 dnl IPv6 header checks
 dnl ------------------
-AC_CHECK_HEADERS([netinet6/in6.h netinet/in6_var.h \
+AC_CHECK_HEADERS([netinet/in6_var.h \
 	netinet6/in6_var.h netinet6/nd6.h], [], [],
 	FRR_INCLUDES)
 
 m4_define([FRR_INCLUDES],dnl
 FRR_INCLUDES
-[#ifdef HAVE_NETINET6_IN6_H
-#include <netinet6/in6.h>
-#endif
-#ifdef HAVE_NETINET_IN6_VAR_H
+[#ifdef HAVE_NETINET_IN6_VAR_H
 #include <netinet/in6_var.h>
 #endif
 #include <netinet/icmp6.h>

--- a/configure.ac
+++ b/configure.ac
@@ -1130,7 +1130,7 @@ dnl -------------------------
 dnl Check other header files.
 dnl -------------------------
 AC_CHECK_HEADERS([stropts.h \
-	linux/version.h asm/types.h sys/endian.h])
+	asm/types.h sys/endian.h])
 
 AC_CHECK_HEADER([endian.h], [], [
   AC_MSG_ERROR([missing endian.h])

--- a/configure.ac
+++ b/configure.ac
@@ -1129,7 +1129,7 @@ fi
 dnl -------------------------
 dnl Check other header files.
 dnl -------------------------
-AC_CHECK_HEADERS([stropts.h sys/ksym.h \
+AC_CHECK_HEADERS([stropts.h \
 	linux/version.h asm/types.h sys/endian.h])
 
 AC_CHECK_HEADER([endian.h], [], [

--- a/configure.ac
+++ b/configure.ac
@@ -2310,7 +2310,7 @@ AC_CHECK_TYPES([
 	struct sockaddr_dl,
 	struct vifctl, struct mfcctl, struct sioc_sg_req,
 	vifi_t, struct sioc_vif_req, struct igmpmsg,
-	struct ifaliasreq, struct if6_aliasreq, struct in6_aliasreq,
+	struct ifaliasreq, struct in6_aliasreq,
 	struct nd_opt_adv_interval,
 	struct nd_opt_homeagent_info, struct nd_opt_adv_interval,
 	struct nd_opt_rdnss, struct nd_opt_dnssl],
@@ -2319,7 +2319,6 @@ AC_CHECK_TYPES([
 AC_CHECK_MEMBERS([struct sockaddr.sa_len,
 	struct sockaddr_in.sin_len, struct sockaddr_un.sun_len,
 	struct sockaddr_dl.sdl_len,
-	struct if6_aliasreq.ifra_lifetime,
 	struct nd_opt_adv_interval.nd_opt_ai_type],
 	[], [], FRR_INCLUDES)
 

--- a/configure.ac
+++ b/configure.ac
@@ -1129,7 +1129,7 @@ fi
 dnl -------------------------
 dnl Check other header files.
 dnl -------------------------
-AC_CHECK_HEADERS([stropts.h \
+AC_CHECK_HEADERS([ \
 	asm/types.h sys/endian.h])
 
 AC_CHECK_HEADER([endian.h], [], [

--- a/configure.ac
+++ b/configure.ac
@@ -1265,7 +1265,7 @@ FRR_INCLUDES
 ])dnl
 
 AC_CHECK_HEADERS([netinet/in_var.h \
-	net/if_dl.h net/netopt.h \
+	net/if_dl.h \
 	netinet/ip_icmp.h \
 	sys/sysctl.h sys/sockio.h sys/conf.h],
 	[], [], [FRR_INCLUDES])
@@ -1299,9 +1299,6 @@ FRR_INCLUDES
 #endif
 #ifdef HAVE_NET_IF_DL_H
 # include <net/if_dl.h>
-#endif
-#ifdef HAVE_NET_NETOPT_H
-# include <net/netopt.h>
 #endif
 #include <net/route.h>
 #include <arpa/inet.h>

--- a/configure.ac
+++ b/configure.ac
@@ -1799,16 +1799,13 @@ AC_CHECK_MEMBERS([struct utsname.domainname], [], [], [#include <sys/utsname.h>]
 dnl ------------------
 dnl IPv6 header checks
 dnl ------------------
-AC_CHECK_HEADERS([netinet/in6_var.h \
+AC_CHECK_HEADERS([ \
 	netinet6/in6_var.h netinet6/nd6.h], [], [],
 	FRR_INCLUDES)
 
 m4_define([FRR_INCLUDES],dnl
 FRR_INCLUDES
-[#ifdef HAVE_NETINET_IN6_VAR_H
-#include <netinet/in6_var.h>
-#endif
-#include <netinet/icmp6.h>
+[#include <netinet/icmp6.h>
 #ifdef HAVE_NETINET6_IN6_VAR_H
 # include <netinet6/in6_var.h>
 #endif

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -90,10 +90,6 @@
 #include <netinet6/in6_var.h>
 #endif /* HAVE_NETINET6_IN6_VAR_H */
 
-#ifdef HAVE_NETINET_IN6_VAR_H
-#include <netinet/in6_var.h>
-#endif /* HAVE_NETINET_IN6_VAR_H */
-
 #ifdef HAVE_NETINET6_IN_H
 #include <netinet6/in.h>
 #endif /* HAVE_NETINET6_IN_H */

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -60,10 +60,6 @@
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
 
-#ifdef HAVE_NET_NETOPT_H
-#include <net/netopt.h>
-#endif /* HAVE_NET_NETOPT_H */
-
 #include <net/if.h>
 
 #ifdef HAVE_NET_IF_DL_H

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -32,9 +32,6 @@
 #ifdef HAVE_SYS_CONF_H
 #include <sys/conf.h>
 #endif /* HAVE_SYS_CONF_H */
-#ifdef HAVE_SYS_KSYM_H
-#include <sys/ksym.h>
-#endif /* HAVE_SYS_KSYM_H */
 #include <sys/time.h>
 #include <time.h>
 #include <inttypes.h>

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -17,9 +17,6 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <ctype.h>
-#ifdef HAVE_STROPTS_H
-#include <stropts.h>
-#endif /* HAVE_STROPTS_H */
 #include <sys/types.h>
 #include <sys/param.h>
 #ifdef HAVE_SYS_SYSCTL_H

--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -575,11 +575,6 @@ static int if_set_prefix6_ctx(const struct zebra_dplane_ctx *ctx)
 	addreq.ifra_lifetime.ia6t_vltime = 0xffffffff;
 	addreq.ifra_lifetime.ia6t_pltime = 0xffffffff;
 
-#ifdef HAVE_STRUCT_IF6_ALIASREQ_IFRA_LIFETIME
-	addreq.ifra_lifetime.ia6t_pltime = ND6_INFINITE_LIFETIME;
-	addreq.ifra_lifetime.ia6t_vltime = ND6_INFINITE_LIFETIME;
-#endif
-
 	ret = if_ioctl_ipv6(SIOCAIFADDR_IN6, (caddr_t)&addreq);
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
This one is removing a whole bunch of dead checks/defines. The last one (`stropts.h`) is speculative in that I'm just going to throw it into CI and see if it passes. The file apparently exists on old Linux (≤2019) but it shouldn't be doing anything. The other ones are just bogus/ancient/…