### PR TITLE
lib: fix mis-done endian check

### DIFF
--- a/isisd/isis_dlpi.c
+++ b/isisd/isis_dlpi.c
@@ -52,13 +52,13 @@ static unsigned short pf_filter[] = {
 	ISO_SAP | (ISO_SAP << 8),
 	ENF_PUSHWORD + 1,      /* Get the control value */
 	ENF_PUSHLIT | ENF_AND, /* Isolate it */
-#ifdef _BIG_ENDIAN
+#if BYTE_ORDER == BIG_ENDIAN
 	0xFF00,
 #else
 	0x00FF,
 #endif
 	ENF_PUSHLIT | ENF_CAND, /* Test for expected value */
-#ifdef _BIG_ENDIAN
+#if BYTE_ORDER == BIG_ENDIAN
 	0x0300
 #else
 	0x0003

--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -2353,21 +2353,21 @@ static const char *_adjust_ptr(struct lysc_node_leaf *lsnode, const char *valuep
 	switch (lsnode->type->basetype) {
 	case LY_TYPE_INT8:
 	case LY_TYPE_UINT8:
-#ifdef BIG_ENDIAN
+#if BYTE_ORDER == BIG_ENDIAN
 		valuep += 7;
 #endif
 		*size = 1;
 		break;
 	case LY_TYPE_INT16:
 	case LY_TYPE_UINT16:
-#ifdef BIG_ENDIAN
+#if BYTE_ORDER == BIG_ENDIAN
 		valuep += 6;
 #endif
 		*size = 2;
 		break;
 	case LY_TYPE_INT32:
 	case LY_TYPE_UINT32:
-#ifdef BIG_ENDIAN
+#if BYTE_ORDER == BIG_ENDIAN
 		valuep += 4;
 #endif
 		*size = 4;

--- a/pimd/pim_autorp.h
+++ b/pimd/pim_autorp.h
@@ -31,14 +31,14 @@ PREDECL_SORTLIST_UNIQ(pim_autorp_rp);
 PREDECL_SORTLIST_UNIQ(pim_autorp_grppfix);
 
 struct autorp_pkt_grp {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if BYTE_ORDER == LITTLE_ENDIAN
 	uint8_t negprefix : 1;
 	uint8_t reserved : 7;
-#elif __BYTE_ORDER == __BIG_ENDIAN
+#elif BYTE_ORDER == BIG_ENDIAN
 	uint8_t reserved : 7;
 	uint8_t negprefix : 1;
 #else
-#error "Please fix <bits/endian.h>"
+#error "Please fix <endian.h>"
 #endif
 	uint8_t masklen;
 	uint32_t addr;
@@ -46,27 +46,27 @@ struct autorp_pkt_grp {
 
 struct autorp_pkt_rp {
 	uint32_t addr;
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if BYTE_ORDER == LITTLE_ENDIAN
 	uint8_t pimver : 2;
 	uint8_t reserved : 6;
-#elif __BYTE_ORDER == __BIG_ENDIAN
+#elif BYTE_ORDER == BIG_ENDIAN
 	uint8_t reserved : 6;
 	uint8_t pimver : 2;
 #else
-#error "Please fix <bits/endian.h>"
+#error "Please fix <endian.h>"
 #endif
 	uint8_t grpcnt;
 } __attribute__((__packed__));
 
 struct autorp_pkt_hdr {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if BYTE_ORDER == LITTLE_ENDIAN
 	uint8_t type : 4;
 	uint8_t version : 4;
-#elif __BYTE_ORDER == __BIG_ENDIAN
+#elif BYTE_ORDER == BIG_ENDIAN
 	uint8_t version : 4;
 	uint8_t type : 4;
 #else
-#error "Please fix <bits/endian.h>"
+#error "Please fix <endian.h>"
 #endif
 	uint8_t rpcnt;
 	uint16_t holdtime;


### PR DESCRIPTION
`BIG_ENDIAN` is a number define, not a "is it defined?" define.  It's actually 4321.  And `LITTLE_ENDIAN` is 1234, and then `BYTE_ORDER` is one of them.  (Or `PDP_ENDIAN`, which is 3412.)  This unfortunately means that `BIG_ENDIAN` is always defined, so this code was taking the big-endian path even on little endian machines.

---

Plus 2 non-bugfix endian-related cleanups for consistency. (The `isisd` one is unused by way of being Solaris specific, the `pimd` one is just using nonstandard macro names.)