### PR TITLE
build: the war on `config.h` is a war of attrition, 2 of ∞

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1251,19 +1251,6 @@ m4_define([FRR_INCLUDES],
 #include <net/if.h>
 ])dnl
 
-dnl Same applies for HAVE_NET_IF_VAR_H, which HAVE_NETINET6_ND6_H and
-dnl HAVE_NETINET_IN_VAR_H depend upon. But if_var.h depends on if.h, hence
-dnl an additional round for it.
-
-AC_CHECK_HEADERS([net/if_var.h], [], [], [FRR_INCLUDES])
-
-m4_define([FRR_INCLUDES],
-FRR_INCLUDES
-[#ifdef HAVE_NET_IF_VAR_H
-# include <net/if_var.h>
-#endif
-])dnl
-
 AC_CHECK_HEADERS([netinet/in_var.h \
 	net/if_dl.h \
 	netinet/ip_icmp.h \

--- a/configure.ac
+++ b/configure.ac
@@ -1267,7 +1267,7 @@ FRR_INCLUDES
 AC_CHECK_HEADERS([netinet/in_var.h \
 	net/if_dl.h \
 	netinet/ip_icmp.h \
-	sys/sysctl.h sys/sockio.h sys/conf.h],
+	sys/sockio.h sys/conf.h],
 	[], [], [FRR_INCLUDES])
 
 AC_CHECK_HEADERS([ucontext.h], [], [],

--- a/configure.ac
+++ b/configure.ac
@@ -1251,7 +1251,6 @@ m4_define([FRR_INCLUDES],
 ])dnl
 
 AC_CHECK_HEADERS([netinet/in_var.h \
-	net/if_dl.h \
 	netinet/ip_icmp.h],
 	[], [], [FRR_INCLUDES])
 
@@ -1282,7 +1281,7 @@ FRR_INCLUDES
 #ifdef HAVE_NETINET_IN_VAR_H
 # include <netinet/in_var.h>
 #endif
-#ifdef HAVE_NET_IF_DL_H
+#ifndef __linux__
 # include <net/if_dl.h>
 #endif
 #include <net/route.h>

--- a/configure.ac
+++ b/configure.ac
@@ -1797,15 +1797,12 @@ dnl ------------------
 dnl IPv6 header checks
 dnl ------------------
 AC_CHECK_HEADERS([ \
-	netinet6/in6_var.h netinet6/nd6.h], [], [],
+	netinet6/nd6.h], [], [],
 	FRR_INCLUDES)
 
 m4_define([FRR_INCLUDES],dnl
 FRR_INCLUDES
 [#include <netinet/icmp6.h>
-#ifdef HAVE_NETINET6_IN6_VAR_H
-# include <netinet6/in6_var.h>
-#endif
 #ifdef HAVE_NETINET6_ND6_H
 # include <netinet6/nd6.h>
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -2310,7 +2310,7 @@ AC_CHECK_TYPES([
 	struct sockaddr_dl,
 	struct vifctl, struct mfcctl, struct sioc_sg_req,
 	vifi_t, struct sioc_vif_req, struct igmpmsg,
-	struct ifaliasreq, struct in6_aliasreq,
+	struct ifaliasreq,
 	struct nd_opt_adv_interval,
 	struct nd_opt_homeagent_info, struct nd_opt_adv_interval,
 	struct nd_opt_rdnss, struct nd_opt_dnssl],

--- a/configure.ac
+++ b/configure.ac
@@ -1240,7 +1240,6 @@ m4_define([FRR_INCLUDES],
 #include <stdlib.h>
 #include <stddef.h>
 #include <sys/types.h>
-/* sys/conf.h depends on param.h on FBSD at least */
 #include <sys/param.h>
 /* Required for MAXSIG */
 #include <signal.h>
@@ -1253,8 +1252,7 @@ m4_define([FRR_INCLUDES],
 
 AC_CHECK_HEADERS([netinet/in_var.h \
 	net/if_dl.h \
-	netinet/ip_icmp.h \
-	sys/sockio.h sys/conf.h],
+	netinet/ip_icmp.h],
 	[], [], [FRR_INCLUDES])
 
 AC_CHECK_HEADERS([ucontext.h], [], [],

--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -12,6 +12,10 @@
 
 #include <zebra.h>
 
+#ifndef __linux__
+#include <net/if_dl.h>
+#endif
+
 #include "frrevent.h"
 #include "memory.h"
 #include "linklist.h"

--- a/ldpd/packet.c
+++ b/ldpd/packet.c
@@ -9,6 +9,10 @@
 
 #include <zebra.h>
 
+#ifndef __linux__
+#include <net/if_dl.h>
+#endif
+
 #include "ldpd.h"
 #include "ldpe.h"
 #include "log.h"

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -7,7 +7,7 @@
 #ifndef _ZEBRA_PREFIX_H
 #define _ZEBRA_PREFIX_H
 
-#ifdef GNU_LINUX
+#ifdef __linux__
 #include <net/ethernet.h>
 #else
 #include <netinet/if_ether.h>

--- a/lib/sockopt.c
+++ b/lib/sockopt.c
@@ -5,6 +5,10 @@
 
 #include <zebra.h>
 
+#ifndef __linux__
+#include <net/if_dl.h>
+#endif
+
 #include "log.h"
 #include "sockopt.h"
 #include "sockunion.h"

--- a/lib/sockunion.c
+++ b/lib/sockunion.c
@@ -5,6 +5,10 @@
 
 #include <zebra.h>
 
+#ifndef __linux__
+#include <net/if_dl.h>
+#endif
+
 #include "prefix.h"
 #include "vty.h"
 #include "sockunion.h"

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -76,10 +76,6 @@
 #include <netinet/in_var.h>
 #endif /* HAVE_NETINET_IN_VAR_H */
 
-#ifdef HAVE_NETINET6_IN6_VAR_H
-#include <netinet6/in6_var.h>
-#endif /* HAVE_NETINET6_IN6_VAR_H */
-
 #ifdef HAVE_NETINET6_IN_H
 #include <netinet6/in.h>
 #endif /* HAVE_NETINET6_IN_H */

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -53,10 +53,6 @@
 #include <net/if_dl.h>
 #endif /* HAVE_NET_IF_DL_H */
 
-#ifdef HAVE_NET_IF_VAR_H
-#include <net/if_var.h>
-#endif /* HAVE_NET_IF_VAR_H */
-
 #ifndef HAVE_NETLINK
 #define RT_TABLE_MAIN		0
 #define RT_TABLE_LOCAL		RT_TABLE_MAIN

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -19,9 +19,6 @@
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/param.h>
-#ifdef HAVE_SYS_CONF_H
-#include <sys/conf.h>
-#endif /* HAVE_SYS_CONF_H */
 #include <sys/time.h>
 #include <time.h>
 #include <inttypes.h>
@@ -36,10 +33,6 @@
 /* network include group */
 
 #include <sys/socket.h>
-
-#ifdef HAVE_SYS_SOCKIO_H
-#include <sys/sockio.h>
-#endif /* HAVE_SYS_SOCKIO_H */
 
 #include "openbsd-tree.h"
 

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -42,10 +42,6 @@
 
 #include <net/if.h>
 
-#ifdef HAVE_NET_IF_DL_H
-#include <net/if_dl.h>
-#endif /* HAVE_NET_IF_DL_H */
-
 #ifndef HAVE_NETLINK
 #define RT_TABLE_MAIN		0
 #define RT_TABLE_LOCAL		RT_TABLE_MAIN

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -19,13 +19,6 @@
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/param.h>
-#ifdef HAVE_SYS_SYSCTL_H
-#ifdef GNU_LINUX
-#include <linux/types.h>
-#else
-#include <sys/sysctl.h>
-#endif
-#endif /* HAVE_SYS_SYSCTL_H */
 #ifdef HAVE_SYS_CONF_H
 #include <sys/conf.h>
 #endif /* HAVE_SYS_CONF_H */

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -5,6 +5,10 @@
 
 #include <zebra.h>
 
+#ifndef __linux__
+#include <net/if_dl.h>
+#endif
+
 #include "memory.h"
 #include "if.h"
 #include "log.h"

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -6,6 +6,10 @@
 
 #include <zebra.h>
 
+#ifndef __linux__
+#include <net/if_dl.h>
+#endif
+
 #include "monotime.h"
 #include "frrevent.h"
 #include "memory.h"

--- a/pceplib/pcep.h
+++ b/pceplib/pcep.h
@@ -15,7 +15,7 @@
 #include "config.h"
 #endif
 
-#if defined(linux) || defined(GNU_LINUX)
+#ifdef __linux__
 
 #define ipv6_u __in6_u
 #else

--- a/zebra/if_sysctl.c
+++ b/zebra/if_sysctl.c
@@ -10,6 +10,8 @@
 
 #if !defined(GNU_LINUX) && !defined(OPEN_BSD)
 
+#include <sys/sysctl.h>
+
 #include "if.h"
 #include "sockunion.h"
 #include "prefix.h"

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -7,6 +7,10 @@
 #ifndef _ZEBRA_INTERFACE_H
 #define _ZEBRA_INTERFACE_H
 
+#ifndef __linux__
+#include <net/if_dl.h>
+#endif
+
 #include "redistribute.h"
 #include "vrf.h"
 #include "hook.h"

--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -535,10 +535,6 @@ int if_unset_flags(struct interface *ifp, uint64_t flags)
 #ifndef LINUX_IPV6 /* Netlink has its own code */
 
 #ifdef HAVE_STRUCT_IN6_ALIASREQ
-#ifndef ND6_INFINITE_LIFETIME
-#define ND6_INFINITE_LIFETIME 0xffffffffL
-#endif /* ND6_INFINITE_LIFETIME */
-
 /*
  * Helper for interface-addr install, non-netlink
  */
@@ -613,11 +609,6 @@ static int if_unset_prefix6_ctx(const struct zebra_dplane_ctx *ctx)
 	mask.sin6_len = sizeof(struct sockaddr_in6);
 #endif
 	memcpy(&addreq.ifra_prefixmask, &mask, sizeof(struct sockaddr_in6));
-
-#ifdef HAVE_STRUCT_IF6_ALIASREQ_IFRA_LIFETIME
-	addreq.ifra_lifetime.ia6t_pltime = ND6_INFINITE_LIFETIME;
-	addreq.ifra_lifetime.ia6t_vltime = ND6_INFINITE_LIFETIME;
-#endif
 
 	ret = if_ioctl_ipv6(SIOCDIFADDR_IN6, (caddr_t)&addreq);
 	if (ret < 0)

--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -7,6 +7,9 @@
 #include <zebra.h>
 
 #include <sys/ioctl.h>
+#ifndef __linux__
+#include <netinet6/in6_var.h>
+#endif
 
 #include "linklist.h"
 #include "if.h"

--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -533,8 +533,6 @@ int if_unset_flags(struct interface *ifp, uint64_t flags)
 }
 
 #ifndef LINUX_IPV6 /* Netlink has its own code */
-
-#ifdef HAVE_STRUCT_IN6_ALIASREQ
 /*
  * Helper for interface-addr install, non-netlink
  */
@@ -615,19 +613,4 @@ static int if_unset_prefix6_ctx(const struct zebra_dplane_ctx *ctx)
 		return ret;
 	return 0;
 }
-#else
-/* The old, pre-dataplane code here just returned, so we're retaining that
- * choice.
- */
-static int if_set_prefix6_ctx(const struct zebra_dplane_ctx *ctx)
-{
-	return 0;
-}
-
-static int if_unset_prefix6_ctx(const struct zebra_dplane_ctx *ctx)
-{
-	return 0;
-}
-#endif /* HAVE_STRUCT_IN6_ALIASREQ */
-
 #endif /* LINUX_IPV6 */

--- a/zebra/ipforward_sysctl.c
+++ b/zebra/ipforward_sysctl.c
@@ -7,6 +7,8 @@
 
 #if !defined(GNU_LINUX)
 
+#include <sys/sysctl.h>
+
 #include "privs.h"
 #include "zebra/ipforward.h"
 #include "zebra/zebra_errors.h"

--- a/zebra/rtread_sysctl.c
+++ b/zebra/rtread_sysctl.c
@@ -10,6 +10,8 @@
 
 #if !defined(GNU_LINUX)
 
+#include <sys/sysctl.h>
+
 #include "memory.h"
 #include "log.h"
 #include "vrf.h"

--- a/zebra/table_manager.h
+++ b/zebra/table_manager.h
@@ -21,7 +21,7 @@ extern "C" {
 /* routing table identifiers
  *
  */
-#if !defined(GNU_LINUX)
+#ifndef __linux__
 /* BSD systems
  */
 #define RT_TABLE_ID_MAIN 0
@@ -33,7 +33,7 @@ extern "C" {
 #define RT_TABLE_ID_DEFAULT 253
 #define RT_TABLE_ID_COMPAT  252
 #define RT_TABLE_ID_UNSPEC  0
-#endif /* !def(GNU_LINUX) */
+#endif /* !__linux__ */
 
 /*
  * Table chunk struct


### PR DESCRIPTION
Another stack of `config.h` related cleanups.

On the TODO list of things needed for using our headers without `config.h` (#18807):

- `HAVE_CLOCK_THREAD_CPUTIME_ID` needs to go (because it changes the layout of `struct event`)
    - easy, because it's set on all of our supported platforms. It's only missing on Apple, which is a pandora's box for another day…
- `HAVE_SECTION_SYMS` might affect things
    - easy again, because it's set on all of our supported platforms. This one was for Solaris primarily (and Apple is screwed regardless, being a non-ELF platform)
- `HAVE_MALLOC_USABLE_SIZE` & `HAVE_MALLOC_SIZE` need something, because they affect the layout of `struct mtype`
- `MULTIPATH_NUM` will just need to be exported in the `.pc` file, i.e. it'll have `-DMULTIPATH_NUM=1234`
- needs investigation: `HAVE_NETLINK` (struct layouts?)
- needs investigation: `HAVE_RTADV` (struct layouts again)
- needs investigation: `HAVE_BFDD` (conditionals in zebra?)

The other `#if` checks should be "benign", as in, shouldn't break anything if they're just not set.