### PR TITLE
*: SPDX license spring cleaning

### DIFF
--- a/lib/admin_group.c
+++ b/lib/admin_group.c
@@ -1,23 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * Administrative-group library (RFC3630, RFC5305, RFC5329, RFC7308)
  *
  * Copyright 2022 Hiroki Shirokura, LINE Corporation
  * Copyright 2022 Masakazu Asama
  * Copyright 2022 6WIND S.A.
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 2 of the License, or (at your option)
- * any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; see the file COPYING; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #include "admin_group.h"

--- a/lib/admin_group.h
+++ b/lib/admin_group.h
@@ -1,23 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * Administrative-group library (RFC3630, RFC5305, RFC5329, RFC7308)
  *
  * Copyright 2022 Hiroki Shirokura, LINE Corporation
  * Copyright 2022 Masakazu Asama
  * Copyright 2022 6WIND S.A.
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 2 of the License, or (at your option)
- * any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; see the file COPYING; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #ifndef _FRR_ADMIN_GROUP_H

--- a/lib/affinitymap.c
+++ b/lib/affinitymap.c
@@ -1,25 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * Affinity map function.
  *
  * Copyright 2022 Hiroki Shirokura, LINE Corporation
  * Copyright 2022 Masakazu Asama
  * Copyright 2022 6WIND S.A.
- *
- * This file is part of Free Range Routing (FRR).
- *
- * FRR is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any
- * later version.
- *
- * FRR is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; see the file COPYING; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #include <zebra.h>

--- a/lib/affinitymap.h
+++ b/lib/affinitymap.h
@@ -1,25 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * Affinity-map function.
  *
  * Copyright 2022 Hiroki Shirokura, LINE Corporation
  * Copyright 2022 Masakazu Asama
  * Copyright 2022 6WIND S.A.
- *
- * This file is part of Free Range Routing (FRR).
- *
- * FRR is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any
- * later version.
- *
- * FRR is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; see the file COPYING; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #ifndef _ZEBRA_AFFINITYMAP_H

--- a/lib/affinitymap_cli.c
+++ b/lib/affinitymap_cli.c
@@ -1,26 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * Affinity map northbound CLI implementation.
  *
  * Copyright 2022 Hiroki Shirokura, LINE Corporation
  * Copyright 2022 Masakazu Asama
  * Copyright 2022 6WIND S.A.
- *
- *
- * This file is part of Free Range Routing (FRR).
- *
- * FRR is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any
- * later version.
- *
- * FRR is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; see the file COPYING; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #include <zebra.h>

--- a/lib/affinitymap_northbound.c
+++ b/lib/affinitymap_northbound.c
@@ -1,25 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * affinity map northbound implementation.
  *
  * Copyright 2022 Hiroki Shirokura, LINE Corporation
  * Copyright 2022 Masakazu Asama
  * Copyright 2022 6WIND S.A.
- *
- * This file is part of Free Range Routing (FRR).
- *
- * FRR is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any
- * later version.
- *
- * FRR is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; see the file COPYING; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #include <zebra.h>

--- a/lib/asn.c
+++ b/lib/asn.c
@@ -1,21 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * ASN functions
  *
  * Copyright 2022 6WIND
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 2 of the License, or (at your option)
- * any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; see the file COPYING; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include <zebra.h>
 #include "log.h"

--- a/lib/asn.h
+++ b/lib/asn.h
@@ -1,22 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * AS number structure
  * Copyright 2022 6WIND
- *
- * This file is part of GNU Zebra.
- *
- * GNU Zebra is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published
- * by the Free Software Foundation; either version 2, or (at your
- * option) any later version.
- *
- * GNU Zebra is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; see the file COPYING; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #ifndef _FRR_ASN_H

--- a/lib/iso.c
+++ b/lib/iso.c
@@ -1,25 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * ISO Network functions - iso_net.c
  *
  * Author: Olivier Dugeon <olivier.dugeon@orange.com>
  *
  * Copyright (C) 2023 Orange http://www.orange.com
- *
- * This file is part of Free Range Routing (FRR).
- *
- * FRR is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any
- * later version.
- *
- * FRR is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; see the file COPYING; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #ifdef HAVE_CONFIG_H

--- a/lib/iso.h
+++ b/lib/iso.h
@@ -1,25 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * ISO Network definition - iso_net.h
  *
  * Author: Olivier Dugeon <olivier.dugeon@orange.com>
  *
  * Copyright (C) 2023 Orange http://www.orange.com
- *
- * This file is part of Free Range Routing (FRR).
- *
- * FRR is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any
- * later version.
- *
- * FRR is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; see the file COPYING; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #ifndef LIB_ISO_H_

--- a/lib/keychain_cli.c
+++ b/lib/keychain_cli.c
@@ -3,20 +3,6 @@
  * February 22 2024, Christian Hopps <chopps@labn.net>
  *
  * Copyright (C) 2024 LabN Consulting, L.L.C.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; see the file COPYING; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include <zebra.h>
 #include "command.h"

--- a/lib/keychain_nb.c
+++ b/lib/keychain_nb.c
@@ -3,20 +3,6 @@
  * February 22 2024, Christian Hopps <chopps@labn.net>
  *
  * Copyright (C) 2024 LabN Consulting, L.L.C.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; see the file COPYING; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include <zebra.h>
 #include "lib_errors.h"

--- a/m4/ax_lua.m4
+++ b/m4/ax_lua.m4
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-or-later WITH Autoconf-exception-macro
 # ===========================================================================
 #          https://www.gnu.org/software/autoconf-archive/ax_lua.html
 # ===========================================================================

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-or-later WITH Autoconf-exception-macro
 # ===========================================================================
 #        http://www.gnu.org/software/autoconf-archive/ax_pthread.html
 # ===========================================================================

--- a/m4/pkg.m4
+++ b/m4/pkg.m4
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-or-later WITH Autoconf-exception-generic
+#
 # pkg.m4 - Macros to locate and utilise pkg-config.            -*- Autoconf -*-
 # serial 1 (pkg-config-0.24)
 # 

--- a/python/makefile.py
+++ b/python/makefile.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: ISC
 #
 # FRR extended automake/Makefile functionality helper
 #

--- a/python/makevars.py
+++ b/python/makevars.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: ISC
 #
 # helper class to grab variables from FRR's Makefile
 #

--- a/python/runtests.py
+++ b/python/runtests.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import pytest
 import sys
 import os

--- a/tests/bgpd/test_aspath.py
+++ b/tests/bgpd/test_aspath.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 import re
 

--- a/tests/bgpd/test_bgp_table.py
+++ b/tests/bgpd/test_bgp_table.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/bgpd/test_capability.py
+++ b/tests/bgpd/test_capability.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/bgpd/test_ecommunity.py
+++ b/tests/bgpd/test_ecommunity.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/bgpd/test_mp_attr.py
+++ b/tests/bgpd/test_mp_attr.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/isisd/test_fuzz_isis_tlv.c
+++ b/tests/isisd/test_fuzz_isis_tlv.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/tests/isisd/test_isis_lspdb.c
+++ b/tests/isisd/test_isis_lspdb.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 #include <zebra.h>
 
 #include "isisd/isis_lsp.c"

--- a/tests/isisd/test_isis_lspdb.py
+++ b/tests/isisd/test_isis_lspdb.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/isisd/test_isis_spf.py
+++ b/tests/isisd/test_isis_spf.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/isisd/test_isis_vertex_queue.c
+++ b/tests/isisd/test_isis_vertex_queue.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 #include <zebra.h>
 
 #include "isisd/isis_spf.c"

--- a/tests/isisd/test_isis_vertex_queue.py
+++ b/tests/isisd/test_isis_vertex_queue.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/cli/test_cli.py
+++ b/tests/lib/cli/test_cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/cli/test_commands.py
+++ b/tests/lib/cli/test_commands.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 import pytest
 import os

--- a/tests/lib/northbound/test_oper_data.py
+++ b/tests/lib/northbound/test_oper_data.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/northbound/test_oper_exists.py
+++ b/tests/lib/northbound/test_oper_exists.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_assert.py
+++ b/tests/lib/test_assert.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: ISC
 import frrtest
 import os
 import re

--- a/tests/lib/test_atomlist.py
+++ b/tests/lib/test_atomlist.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: ISC
 import frrtest
 
 

--- a/tests/lib/test_darr.py
+++ b/tests/lib/test_darr.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_graph.py
+++ b/tests/lib/test_graph.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_idalloc.py
+++ b/tests/lib/test_idalloc.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_nexthop.py
+++ b/tests/lib/test_nexthop.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_nexthop_iter.py
+++ b/tests/lib/test_nexthop_iter.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_ntop.py
+++ b/tests/lib/test_ntop.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: ISC
 import frrtest
 
 

--- a/tests/lib/test_prefix2str.py
+++ b/tests/lib/test_prefix2str.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_printfrr.py
+++ b/tests/lib/test_printfrr.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: ISC
 import frrtest
 
 

--- a/tests/lib/test_ringbuf.py
+++ b/tests/lib/test_ringbuf.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_srcdest_table.py
+++ b/tests/lib/test_srcdest_table.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_stream.py
+++ b/tests/lib/test_stream.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_table.py
+++ b/tests/lib/test_table.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_timer_correctness.py
+++ b/tests/lib/test_timer_correctness.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_ttable.py
+++ b/tests/lib/test_ttable.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_typelist.py
+++ b/tests/lib/test_typelist.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: ISC
 import frrtest
 
 

--- a/tests/lib/test_versioncmp.py
+++ b/tests/lib/test_versioncmp.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_xref.py
+++ b/tests/lib/test_xref.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: ISC
 import frrtest
 
 class TestXref(frrtest.TestMultiOut):

--- a/tests/lib/test_zlog.py
+++ b/tests/lib/test_zlog.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/lib/test_zmq.py
+++ b/tests/lib/test_zmq.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 import pytest
 import os

--- a/tests/ospf6d/test_lsdb.py
+++ b/tests/ospf6d/test_lsdb.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tests/ospfd/common.c
+++ b/tests/ospfd/common.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 #include <zebra.h>
 
 #include "lib/stream.h"

--- a/tests/ospfd/common.h
+++ b/tests/ospfd/common.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 #ifndef _COMMON_OSPF_H
 #define _COMMON_OSPF_H
 

--- a/tests/ospfd/test_ospf_spf.c
+++ b/tests/ospfd/test_ospf_spf.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 #include <zebra.h>
 #include <sys/stat.h>
 

--- a/tests/ospfd/test_ospf_spf.py
+++ b/tests/ospfd/test_ospf_spf.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 class TestOspfSPF(frrtest.TestRefOut):

--- a/tests/ospfd/topologies.c
+++ b/tests/ospfd/topologies.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 #include <zebra.h>
 
 #include "mpls.h"

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import pytest
 import sys
 import os

--- a/tests/zebra/test_lm_plugin.py
+++ b/tests/zebra/test_lm_plugin.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import frrtest
 
 

--- a/tools/gcc-plugins/format-test.c
+++ b/tools/gcc-plugins/format-test.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 #include <stddef.h>
 #include <stdlib.h>
 #include <netinet/in.h>

--- a/tools/gcc-plugins/format-test.py
+++ b/tools/gcc-plugins/format-test.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 import subprocess
 import sys
 import shlex

--- a/tools/git-reindent-branch.py
+++ b/tools/git-reindent-branch.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: ISC
 # -*- coding: utf-8 -*-
 
 import sys, os

--- a/tools/releasedate.py
+++ b/tools/releasedate.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: ISC
 #
 # print FRR release schedule dates
 

--- a/version.h
+++ b/version.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 #include "lib/compiler.h"
 CPP_NOTICE("Trying to include version.h.  Please fix to use lib/version.h.")
 #include "lib/version.h"

--- a/yang/frr-affinity-map.yang
+++ b/yang/frr-affinity-map.yang
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-2-Clause
 module frr-affinity-map {
   yang-version 1.1;
   namespace "http://frrouting.org/yang/affinity-map";

--- a/yang/frr-bgp-common.yang
+++ b/yang/frr-bgp-common.yang
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-2-Clause
 submodule frr-bgp-common {
   yang-version 1.1;
 

--- a/yang/frr-pim-candidate.yang
+++ b/yang/frr-pim-candidate.yang
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-2-Clause
 module frr-pim-candidate {
   yang-version "1.1";
   namespace "http://frrouting.org/yang/pim-candidate";

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-2-Clause
 module frr-zebra {
   yang-version 1.1;
   namespace "http://frrouting.org/yang/zebra";

--- a/yang/ietf/ietf-interfaces.yang
+++ b/yang/ietf/ietf-interfaces.yang
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 module ietf-interfaces {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-interfaces";

--- a/yang/ietf/ietf-key-chain.yang
+++ b/yang/ietf/ietf-key-chain.yang
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 module ietf-key-chain {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-key-chain";

--- a/yang/ietf/ietf-netconf-acm.yang
+++ b/yang/ietf/ietf-netconf-acm.yang
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 module ietf-netconf-acm {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-netconf-acm";

--- a/yang/ietf/ietf-netconf-with-defaults.yang
+++ b/yang/ietf/ietf-netconf-with-defaults.yang
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 module ietf-netconf-with-defaults {
 
    namespace "urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults";

--- a/yang/ietf/ietf-netconf.yang
+++ b/yang/ietf/ietf-netconf.yang
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 module ietf-netconf {
 
   // the namespace for NETCONF XML definitions is unchanged

--- a/yang/ietf/ietf-routing-types.yang
+++ b/yang/ietf/ietf-routing-types.yang
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 module ietf-routing-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-routing-types";
   prefix rt-types;

--- a/yang/ietf/ietf-srv6-types.yang
+++ b/yang/ietf/ietf-srv6-types.yang
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 module ietf-srv6-types {
   yang-version 1.1;
 

--- a/zebra/zebra_affinitymap.c
+++ b/zebra/zebra_affinitymap.c
@@ -1,23 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * zebra affinity-map.
  *
  * Copyright 2022 6WIND S.A.
- *
- * This file is part of Free Range Routing (FRR).
- *
- * FRR is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any
- * later version.
- *
- * FRR is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; see the file COPYING; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #include <zebra.h>

--- a/zebra/zebra_affinitymap.h
+++ b/zebra/zebra_affinitymap.h
@@ -1,23 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * Zebra affinity-map header
  *
  * Copyright 2022 6WIND S.A.
- *
- * This file is part of Free Range Routing (FRR).
- *
- * FRR is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any
- * later version.
- *
- * FRR is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; see the file COPYING; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #ifndef __ZEBRA_AFFINITYMAP_H__

--- a/zebra/zebra_l2_bridge_if.c
+++ b/zebra/zebra_l2_bridge_if.c
@@ -1,20 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * Zebra L2 bridge interface handling
  *
  * Copyright (C) 2021 Cumulus Networks, Inc.
  * Sharath Ramamurthy
- *
- * This file is part of FRR.
- *
- * FRR is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any
- * later version.
- *
- * FRR is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
  */
 
 #include <zebra.h>

--- a/zebra/zebra_l2_bridge_if.h
+++ b/zebra/zebra_l2_bridge_if.h
@@ -1,25 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * Zebra L2 bridge interface data structures and definitions
  * These are public definitions referenced by other files.
  * Copyright (C) 2021 Cumulus Networks, Inc.
  * Sharath Ramamurthy
- *
- * This file is part of FRR.
- *
- * FRR is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any
- * later version.
- *
- * FRR is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with FRR; see the file COPYING.  If not, write to the Free
- * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
- * 02111-1307, USA.
  */
 
 #ifndef _ZEBRA_L2_BRIDGE_IF_H

--- a/zebra/zebra_vxlan_if.c
+++ b/zebra/zebra_vxlan_if.c
@@ -1,20 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * Zebra EVPN for VxLAN interface handling
  *
  * Copyright (C) 2021 Cumulus Networks, Inc.
  * Vivek Venkatraman, Stephen Worley, Sharath Ramamurthy
- *
- * This file is part of FRR.
- *
- * FRR is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any
- * later version.
- *
- * FRR is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
  */
 
 #include <zebra.h>

--- a/zebra/zebra_vxlan_if.h
+++ b/zebra/zebra_vxlan_if.h
@@ -1,25 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * Zebra VxLAN (EVPN) interface data structures and definitions
  * These are public definitions referenced by other files.
  * Copyright (C) 2021 Cumulus Networks, Inc.
  * Sharath Ramamurthy
- *
- * This file is part of FRR.
- *
- * FRR is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any
- * later version.
- *
- * FRR is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with FRR; see the file COPYING.  If not, write to the Free
- * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
- * 02111-1307, USA.
  */
 
 #ifndef _ZEBRA_VXLAN_IF_H


### PR DESCRIPTION
Some files had redundant text, some were missing the SPDX license identifier for the license that followed.  Do a quick cleaning pass. (...we should probably have frrbot check for this at some point.) Some of these even said `GNU Zebra`… 🙄

Another 2 commits throw SPDX IDs on files where I can "legally" do so.

Last one throws SPDX IDs on a bunch of files that are unquestionably trivial.