### PR TITLE
mgmtd simplify frontend CLI config path

### DIFF
--- a/lib/lib_vty.c
+++ b/lib/lib_vty.c
@@ -252,7 +252,7 @@ DEFUN_NOSH(end_config, end_config_cmd, "XFRR_end_configuration",
 	 * to apply all those commands at once.
 	 */
 	if (vty->mgmt_num_pending_setcfg && vty_mgmt_fe_enabled())
-		vty_mgmt_send_commit_config(vty, false, false);
+		vty_mgmt_send_commit_config(vty, false, false, false);
 
 	if (callback.end_config)
 		(*callback.end_config)();

--- a/lib/mgmt.proto
+++ b/lib/mgmt.proto
@@ -148,6 +148,7 @@ message FeCommitConfigReq {
   required uint64 req_id = 4;
   required bool validate_only = 5;
   required bool abort = 6;
+  required bool unlock = 7;
 }
 
 message FeCommitConfigReply {
@@ -158,7 +159,8 @@ message FeCommitConfigReply {
   required bool validate_only = 5;
   required bool success = 6;
   required bool abort = 7;
-  optional string error_if_any = 8;
+  required bool unlock = 8;
+  optional string error_if_any = 9;
 }
 
 message FeGetReq {

--- a/lib/mgmt_fe_client.h
+++ b/lib/mgmt_fe_client.h
@@ -84,14 +84,11 @@ struct mgmt_fe_client_cbs {
 				  Mgmtd__DatastoreId ds_id, bool implcit_commit,
 				  char *errmsg_if_any);
 
-	void (*commit_config_notify)(struct mgmt_fe_client *client,
-				     uintptr_t user_data, uint64_t client_id,
-				     uintptr_t session_id,
-				     uintptr_t user_session_client,
-				     uint64_t req_id, bool success,
-				     Mgmtd__DatastoreId src_ds_id,
-				     Mgmtd__DatastoreId dst_ds_id,
-				     bool validate_only, char *errmsg_if_any);
+	void (*commit_config_notify)(struct mgmt_fe_client *client, uintptr_t user_data,
+				     uint64_t client_id, uintptr_t session_id,
+				     uintptr_t user_session_client, uint64_t req_id, bool success,
+				     Mgmtd__DatastoreId src_ds_id, Mgmtd__DatastoreId dst_ds_id,
+				     bool validate_only, bool unlock, char *errmsg_if_any);
 
 	int (*get_data_notify)(struct mgmt_fe_client *client,
 			       uintptr_t user_data, uint64_t client_id,
@@ -301,14 +298,16 @@ extern int mgmt_fe_send_setcfg_req(struct mgmt_fe_client *client,
  * abort
  *    TRUE if need to restore Src DS back to Dest DS, FALSE otherwise.
  *
+ * unlock
+ *    Passed through to the resulting reply.
+ *
  * Returns:
  *    0 on success, otherwise msg_conn_send_msg() return values.
  */
-extern int mgmt_fe_send_commitcfg_req(struct mgmt_fe_client *client,
-				      uint64_t session_id, uint64_t req_id,
-				      Mgmtd__DatastoreId src_ds_id,
-				      Mgmtd__DatastoreId dst_ds_id,
-				      bool validate_only, bool abort);
+extern int mgmt_fe_send_commitcfg_req(struct mgmt_fe_client *client, uint64_t session_id,
+				      uint64_t req_id, Mgmtd__DatastoreId src_ds_id,
+				      Mgmtd__DatastoreId dst_ds_id, bool validate_only, bool abort,
+				      bool unlock);
 
 /*
  * Send GET_REQ to MGMTD for one or more config data item(s).

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -4025,8 +4025,63 @@ int vty_mgmt_send_lockds_req(struct vty *vty, Mgmtd__DatastoreId ds_id,
 	return 0;
 }
 
+#if 1
 int vty_mgmt_send_config_data(struct vty *vty, const char *xpath_base,
 			      bool implicit_commit)
+{
+	char err_buf[BUFSIZ];
+	bool error = false;
+
+	/* ADD this: candidate is locked or error */
+
+	if (implicit_commit) {
+		assert(vty->mgmt_client_id && vty->mgmt_session_id);
+
+		if (vty_mgmt_lock_candidate_inline(vty)) {
+			vty_out(vty, "%% could not lock candidate DS\n");
+			return CMD_WARNING_CONFIG_FAILED;
+		} else if (vty_mgmt_lock_running_inline(vty)) {
+			vty_out(vty, "%% could not lock running DS\n");
+			vty_mgmt_unlock_candidate_inline(vty);
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	}
+
+	nb_candidate_edit_config_changes(vty->candidate_config, vty->cfg_changes,
+					 vty->num_cfg_changes, xpath_base, false, err_buf,
+					 sizeof(err_buf), &error);
+	if (error) {
+		/*
+		 * Failure to edit the candidate configuration should never
+		 * happen in practice, unless there's a bug in the code. When
+		 * that happens, log the error but otherwise ignore it.
+		 */
+		vty_out(vty, "%% Couldn't apply changes: %s", err_buf);
+
+#if 0 // or do we expect the caller to do this?
+		/* the candidate is no longer valid so restore it */
+		nb_config_replace(vty->candidate_config, running_config, true);
+#endif
+error:
+		if (implicit_commit) {
+			vty_mgmt_unlock_running_inline(vty);
+			vty_mgmt_unlock_candidate_inline(vty);
+		}
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	if (!implicit_commit)
+		return CMD_SUCCESS;
+
+	assert(vty->mgmt_client_id && vty->mgmt_session_id);
+	if (vty_mgmt_send_commit_config(vty, false, false) < 0)
+		goto error;
+
+	// return CMD_SUSPEND;???
+	return CMD_SUCCESS;
+}
+#else
+int vty_mgmt_send_config_data(struct vty *vty, const char *xpath_base, bool implicit_commit)
 {
 	Mgmtd__YangDataValue value[VTY_MAXCFGCHANGES];
 	Mgmtd__YangData cfg_data[VTY_MAXCFGCHANGES];
@@ -4152,6 +4207,7 @@ int vty_mgmt_send_config_data(struct vty *vty, const char *xpath_base,
 
 	return 0;
 }
+#endif
 
 int vty_mgmt_send_commit_config(struct vty *vty, bool validate_only, bool abort)
 {

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -3647,11 +3647,12 @@ static void vty_mgmt_set_config_result_notified(
 					      : CMD_WARNING_CONFIG_FAILED);
 }
 
-static void vty_mgmt_commit_config_result_notified(
-	struct mgmt_fe_client *client, uintptr_t usr_data, uint64_t client_id,
-	uintptr_t session_id, uintptr_t session_ctx, uint64_t req_id,
-	bool success, Mgmtd__DatastoreId src_ds_id,
-	Mgmtd__DatastoreId dst_ds_id, bool validate_only, char *errmsg_if_any)
+static void vty_mgmt_commit_config_result_notified(struct mgmt_fe_client *client, uintptr_t usr_data,
+						   uint64_t client_id, uintptr_t session_id,
+						   uintptr_t session_ctx, uint64_t req_id,
+						   bool success, Mgmtd__DatastoreId src_ds_id,
+						   Mgmtd__DatastoreId dst_ds_id, bool validate_only,
+						   bool unlock, char *errmsg_if_any)
 {
 	struct vty *vty;
 
@@ -3669,8 +3670,14 @@ static void vty_mgmt_commit_config_result_notified(
 				" req-id %" PRIu64 " was successfull%s%s",
 				client_id, req_id, errmsg_if_any ? ": " : "",
 				errmsg_if_any ?: "");
-		if (errmsg_if_any)
+		if (!unlock && errmsg_if_any)
 			vty_out(vty, "MGMTD: %s\n", errmsg_if_any);
+	}
+
+	if (unlock) {
+		/* we locked these when we sent the commit, unlock now */
+		vty_mgmt_unlock_candidate_inline(vty);
+		vty_mgmt_unlock_running_inline(vty);
 	}
 
 	vty_mgmt_resume_response(vty, success ? CMD_SUCCESS
@@ -4036,7 +4043,6 @@ int vty_mgmt_send_config_data(struct vty *vty, const char *xpath_base,
 
 	if (implicit_commit) {
 		assert(vty->mgmt_client_id && vty->mgmt_session_id);
-
 		if (vty_mgmt_lock_candidate_inline(vty)) {
 			vty_out(vty, "%% could not lock candidate DS\n");
 			return CMD_WARNING_CONFIG_FAILED;
@@ -4074,10 +4080,9 @@ error:
 		return CMD_SUCCESS;
 
 	assert(vty->mgmt_client_id && vty->mgmt_session_id);
-	if (vty_mgmt_send_commit_config(vty, false, false) < 0)
+	if (vty_mgmt_send_commit_config(vty, false, false, true) < 0)
 		goto error;
 
-	// return CMD_SUSPEND;???
 	return CMD_SUCCESS;
 }
 #else
@@ -4209,14 +4214,13 @@ int vty_mgmt_send_config_data(struct vty *vty, const char *xpath_base, bool impl
 }
 #endif
 
-int vty_mgmt_send_commit_config(struct vty *vty, bool validate_only, bool abort)
+int vty_mgmt_send_commit_config(struct vty *vty, bool validate_only, bool abort, bool unlock)
 {
 	if (mgmt_fe_client && vty->mgmt_session_id) {
 		vty->mgmt_req_id++;
-		if (mgmt_fe_send_commitcfg_req(
-			    mgmt_fe_client, vty->mgmt_session_id,
-			    vty->mgmt_req_id, MGMTD_DS_CANDIDATE,
-			    MGMTD_DS_RUNNING, validate_only, abort)) {
+		if (mgmt_fe_send_commitcfg_req(mgmt_fe_client, vty->mgmt_session_id,
+					       vty->mgmt_req_id, MGMTD_DS_CANDIDATE,
+					       MGMTD_DS_RUNNING, validate_only, abort, unlock)) {
 			zlog_err("Failed sending COMMIT-REQ req-id %" PRIu64,
 				 vty->mgmt_req_id);
 			vty_out(vty, "Failed to send COMMIT-REQ to MGMTD!\n");

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -428,8 +428,7 @@ extern bool vty_mgmt_should_process_cli_apply_changes(struct vty *vty);
 extern bool mgmt_vty_read_configs(void);
 extern int vty_mgmt_send_config_data(struct vty *vty, const char *xpath_base,
 				     bool implicit_commit);
-extern int vty_mgmt_send_commit_config(struct vty *vty, bool validate_only,
-				       bool abort);
+extern int vty_mgmt_send_commit_config(struct vty *vty, bool validate_only, bool abort, bool unlock);
 extern int vty_mgmt_send_get_req(struct vty *vty, bool is_config,
 				 Mgmtd__DatastoreId datastore,
 				 const char **xpath_list, int num_req);

--- a/mgmtd/mgmt_fe_adapter.h
+++ b/mgmtd/mgmt_fe_adapter.h
@@ -123,10 +123,10 @@ extern int mgmt_fe_send_set_cfg_reply(uint64_t session_id, uint64_t txn_id,
 /*
  * Send commit-config reply to the frontend client.
  */
-extern int mgmt_fe_send_commit_cfg_reply(
-	uint64_t session_id, uint64_t txn_id, Mgmtd__DatastoreId src_ds_id,
-	Mgmtd__DatastoreId dst_ds_id, uint64_t req_id, bool validate_only,
-	enum mgmt_result result, const char *error_if_any);
+extern int mgmt_fe_send_commit_cfg_reply(uint64_t session_id, uint64_t txn_id,
+					 Mgmtd__DatastoreId src_ds_id, Mgmtd__DatastoreId dst_ds_id,
+					 uint64_t req_id, bool validate_only, bool unlock,
+					 enum mgmt_result result, const char *error_if_any);
 
 /*
  * Send get-config/get-data reply to the frontend client.

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -2168,8 +2168,8 @@ int mgmt_txn_notify_be_cfg_reply(uint64_t txn_id, bool success, const char *erro
 	cmtcfg_req = &txn->commit_cfg_req->req.commit_cfg;
 
 	if (!success) {
-		_log_err("CFGDATA_CREATE_REQ sent to '%s' failed txn-id: %" PRIu64 " err: %s",
-			 adapter->name, txn->txn_id, error_if_any ? error_if_any : "None");
+		_log_err("CFG_REQ sent to '%s' failed txn-id: %" PRIu64 " err: %s", adapter->name,
+			 txn->txn_id, error_if_any ? error_if_any : "None");
 		mgmt_txn_send_commit_cfg_reply(
 			txn, MGMTD_INTERNAL_ERROR,
 			error_if_any ? error_if_any
@@ -2177,8 +2177,8 @@ int mgmt_txn_notify_be_cfg_reply(uint64_t txn_id, bool success, const char *erro
 		return 0;
 	}
 
-	_dbg("CFGDATA_CREATE_REQ sent to '%s' was successful txn-id: %" PRIu64 " err: %s",
-	     adapter->name, txn->txn_id, error_if_any ? error_if_any : "None");
+	_dbg("CFG_REQ sent to '%s' was successful txn-id: %" PRIu64 " err: %s", adapter->name,
+	     txn->txn_id, error_if_any ? error_if_any : "None");
 
 	cmtcfg_req->be_phase[adapter->id] = MGMTD_COMMIT_PHASE_APPLY_CFG;
 

--- a/mgmtd/mgmt_txn.h
+++ b/mgmtd/mgmt_txn.h
@@ -204,17 +204,20 @@ extern int mgmt_txn_send_set_config_req(uint64_t txn_id, uint64_t req_id,
  * implicit
  *    TRUE if the commit is implicit, FALSE otherwise.
  *
+ * unlock
+ *    pass back in the commit config reply
+ *
  * edit
  *    Additional info when triggered from native edit request.
  *
  * Returns:
  *    0 on success, -1 on failures.
  */
-extern int mgmt_txn_send_commit_config_req(
-	uint64_t txn_id, uint64_t req_id, Mgmtd__DatastoreId src_ds_id,
-	struct mgmt_ds_ctx *dst_ds_ctx, Mgmtd__DatastoreId dst_ds_id,
-	struct mgmt_ds_ctx *src_ds_ctx, bool validate_only, bool abort,
-	bool implicit, struct mgmt_edit_req *edit);
+extern int
+mgmt_txn_send_commit_config_req(uint64_t txn_id, uint64_t req_id, Mgmtd__DatastoreId src_ds_id,
+				struct mgmt_ds_ctx *dst_ds_ctx, Mgmtd__DatastoreId dst_ds_id,
+				struct mgmt_ds_ctx *src_ds_ctx, bool validate_only, bool abort,
+				bool implicit, bool unlock, struct mgmt_edit_req *edit);
 
 /*
  * Send get-{cfg,data} request to be processed later in transaction.

--- a/mgmtd/mgmt_vty.c
+++ b/mgmtd/mgmt_vty.c
@@ -147,7 +147,7 @@ DEFPY(mgmt_commit,
 	bool validate_only = type[0] == 'c';
 	bool abort = type[1] == 'b';
 
-	if (vty_mgmt_send_commit_config(vty, validate_only, abort) != 0)
+	if (vty_mgmt_send_commit_config(vty, validate_only, abort, false) != 0)
 		return CMD_WARNING_CONFIG_FAILED;
 	return CMD_SUCCESS;
 }

--- a/mgmtd/mgmt_vty.c
+++ b/mgmtd/mgmt_vty.c
@@ -165,8 +165,7 @@ DEFPY(mgmt_create_config_data, mgmt_create_config_data_cmd,
 	vty->cfg_changes[0].operation = NB_OP_CREATE_EXCL;
 	vty->num_cfg_changes = 1;
 
-	vty_mgmt_send_config_data(vty, NULL, false);
-	return CMD_SUCCESS;
+	return vty_mgmt_send_config_data(vty, NULL, false);
 }
 
 DEFPY(mgmt_set_config_data, mgmt_set_config_data_cmd,
@@ -182,8 +181,7 @@ DEFPY(mgmt_set_config_data, mgmt_set_config_data_cmd,
 	vty->cfg_changes[0].operation = NB_OP_MODIFY;
 	vty->num_cfg_changes = 1;
 
-	vty_mgmt_send_config_data(vty, NULL, false);
-	return CMD_SUCCESS;
+	return vty_mgmt_send_config_data(vty, NULL, false);
 }
 
 DEFPY(mgmt_delete_config_data, mgmt_delete_config_data_cmd,
@@ -199,8 +197,7 @@ DEFPY(mgmt_delete_config_data, mgmt_delete_config_data_cmd,
 	vty->cfg_changes[0].operation = NB_OP_DELETE;
 	vty->num_cfg_changes = 1;
 
-	vty_mgmt_send_config_data(vty, NULL, false);
-	return CMD_SUCCESS;
+	return vty_mgmt_send_config_data(vty, NULL, false);
 }
 
 DEFPY(mgmt_remove_config_data, mgmt_remove_config_data_cmd,
@@ -216,8 +213,7 @@ DEFPY(mgmt_remove_config_data, mgmt_remove_config_data_cmd,
 	vty->cfg_changes[0].operation = NB_OP_DESTROY;
 	vty->num_cfg_changes = 1;
 
-	vty_mgmt_send_config_data(vty, NULL, false);
-	return CMD_SUCCESS;
+	return vty_mgmt_send_config_data(vty, NULL, false);
 }
 
 DEFPY(mgmt_replace_config_data, mgmt_replace_config_data_cmd,
@@ -234,8 +230,7 @@ DEFPY(mgmt_replace_config_data, mgmt_replace_config_data_cmd,
 	vty->cfg_changes[0].operation = NB_OP_REPLACE;
 	vty->num_cfg_changes = 1;
 
-	vty_mgmt_send_config_data(vty, NULL, false);
-	return CMD_SUCCESS;
+	return vty_mgmt_send_config_data(vty, NULL, false);
 }
 
 DEFPY(mgmt_edit, mgmt_edit_cmd,
@@ -291,9 +286,8 @@ DEFPY(mgmt_edit, mgmt_edit_cmd,
 	if (commit)
 		flags |= EDIT_FLAG_IMPLICIT_COMMIT;
 
-	vty_mgmt_send_edit_req(vty, MGMT_MSG_DATASTORE_CANDIDATE, format, flags,
-			       operation, xpath, data);
-	return CMD_SUCCESS;
+	return vty_mgmt_send_edit_req(vty, MGMT_MSG_DATASTORE_CANDIDATE, format, flags, operation,
+				      xpath, data);
 }
 
 DEFPY(mgmt_rpc, mgmt_rpc_cmd,
@@ -307,8 +301,7 @@ DEFPY(mgmt_rpc, mgmt_rpc_cmd,
 {
 	LYD_FORMAT format = (fmt && fmt[0] == 'x') ? LYD_XML : LYD_JSON;
 
-	vty_mgmt_send_rpc_req(vty, format, xpath, data);
-	return CMD_SUCCESS;
+	return vty_mgmt_send_rpc_req(vty, format, xpath, data);
 }
 
 DEFPY(show_mgmt_get_config, show_mgmt_get_config_cmd,

--- a/tests/topotests/config_timing/r1/frr.conf
+++ b/tests/topotests/config_timing/r1/frr.conf
@@ -1,5 +1,12 @@
 log timestamp precision 3
 
+! debug northbound notifications
+! debug northbound libyang
+! debug northbound events
+! debug northbound callbacks
+! debug mgmt backend datastore frontend transaction
+debug mgmt datastore frontend transaction
+
 ip prefix-list ANY permit 0.0.0.0/0 le 32
 ipv6 prefix-list ANY seq 10 permit any
 

--- a/tests/topotests/config_timing/r1/staticd.conf
+++ b/tests/topotests/config_timing/r1/staticd.conf
@@ -1,1 +1,0 @@
-log timestamp precision 3

--- a/tests/topotests/mgmt_config/r1/mgmtd.conf
+++ b/tests/topotests/mgmt_config/r1/mgmtd.conf
@@ -1,5 +1,5 @@
 debug northbound notifications
-debug northbound libyang
+! debug northbound libyang
 debug northbound events
 debug northbound callbacks
 debug mgmt backend datastore frontend transaction

--- a/tests/topotests/mgmt_debug_flags/test_debug.py
+++ b/tests/topotests/mgmt_debug_flags/test_debug.py
@@ -60,8 +60,8 @@ def test_client_debug_enable(tgen):
         new_mgmt_logs = watch_mgmtd_log.snapshot()
         new_be_logs = watch_staticd_log.snapshot()
 
-        fe_cl_msg = "Sending SET_CONFIG_REQ"
-        fe_ad_msg = "Got SETCFG_REQ"
+        fe_cl_msg = "Sending COMMIT_CONFIG_REQ"
+        fe_ad_msg = "Got COMMCFG_REQ"
         be_ad_msg = "Sending CFG_REQ"
         be_cl_msg = "Got CFG_APPLY_REQ"
 


### PR DESCRIPTION
mgmtd: eliminate use of SETCFG_REQ message.

Since external clients are going to use the native EDIT message, there's no reason to force the CLI to use the old protobuf "set config" message to send config changes to itself (from vty code to message handling), just do it directly.

Things get a "little" faster too:

```
config_timing topotest before:

topo: added 10000 ipv4 static routes under 10.0.0.0/8 in 11.185793s (limit: 0s)
topo: added 10000 ipv4 static routes under 11.0.0.0/8 in 13.454671s (limit: 33.557379s)
topo: added 10000 ipv4 static routes under 10.0.0.0/8 in 9.397964s (limit: 33.557379s)
topo: removed 5000 ipv4 static routes under 10.0.0.0/8 in 4.867958s (limit: 33.557379s)
topo: added 10000 ipv4 static routes under 10.0.0.0/8 in 12.056481s (limit: 33.557379s)
topo: removed 10000 ipv4 static routes under 10.0.0.0/8 in 7.41793s (limit: 33.557379s)
topo: removed 10000 ipv4 static routes under 11.0.0.0/8 in 5.925018s (limit: 33.557379s)
topo: added 10000 ipv6 static routes under 2100:1111:2220::/44 in 12.920107s (limit: 0s)
topo: added 10000 ipv6 static routes under 2100:3333:4440::/44 in 14.284481s (limit: 38.760321s)
topo: added 10000 ipv6 static routes under 2100:1111:2220::/44 in 9.894705s (limit: 38.760321s)
topo: removed 5000 ipv6 static routes under 2100:1111:2220::/44 in 4.934615s (limit: 38.760321s)
topo: added 10000 ipv6 static routes under 2100:1111:2220::/44 in 12.739976s (limit: 38.760321s)
topo: removed 10000 ipv6 static routes under 2100:1111:2220::/44 in 7.856064s (limit: 38.760321s)
topo: removed 10000 ipv6 static routes under 2100:3333:4440::/44 in 6.514963s (limit: 38.760321s)

After:

topo: added 10000 ipv4 static routes under 10.0.0.0/8 in 6.05344s (limit: 0s)
topo: added 10000 ipv4 static routes under 11.0.0.0/8 in 5.709452s (limit: 18.16032s)
topo: added 10000 ipv4 static routes under 10.0.0.0/8 in 6.580549s (limit: 18.16032s)
topo: removed 5000 ipv4 static routes under 10.0.0.0/8 in 1.230361s (limit: 18.16032s)
topo: added 10000 ipv4 static routes under 10.0.0.0/8 in 6.533048s (limit: 18.16032s)
topo: removed 10000 ipv4 static routes under 10.0.0.0/8 in 2.573207s (limit: 18.16032s)
topo: removed 10000 ipv4 static routes under 11.0.0.0/8 in 2.595122s (limit: 18.16032s)
topo: added 10000 ipv6 static routes under 2100:1111:2220::/44 in 6.418079s (limit: 0s)
topo: added 10000 ipv6 static routes under 2100:3333:4440::/44 in 6.351478s (limit: 19.254237s)
topo: added 10000 ipv6 static routes under 2100:1111:2220::/44 in 7.327785s (limit: 19.254237s)
topo: removed 5000 ipv6 static routes under 2100:1111:2220::/44 in 1.284248s (limit: 19.254237s)
topo: added 10000 ipv6 static routes under 2100:1111:2220::/44 in 7.09974s (limit: 19.254237s)
topo: removed 10000 ipv6 static routes under 2100:1111:2220::/44 in 2.767427s (limit: 19.254237s)
topo: removed 10000 ipv6 static routes under 2100:3333:4440::/44 in 2.588926s (limit: 19.254237s)
```