### PR TITLE
lib: fix coverity defect CID 1643927

### DIFF
--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -448,12 +448,13 @@ static bool be_client_change_edit_config(struct nb_config *candidate_config, con
 	const char *actions;
 	const char *xpath;
 	const char *value;
+	uint end = darr_len(changes);
 	bool error = false;
-	uint end = darr_lasti(changes);
 	uint i = 0;
 
-	actions = changes[end];
 	assert(end > 0);
+	end -= 1;
+	actions = changes[end]; /* action string in last element */
 	while (i < end) {
 		char action = *actions++;
 


### PR DESCRIPTION
Asserting too late to guarantee correctness, instead just use ssize_t to avoid overflow of uint on `-1` return. We assert later that the value must never actually be -1.