### PR TITLE
zebra: bump the dplane api version for FRR 10.4

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -46,7 +46,7 @@ DEFINE_MTYPE(ZEBRA, VLAN_CHANGE_ARR, "Vlan Change Array");
  * are made. The minor version (at least) should be updated when new APIs
  * are introduced.
  */
-static uint32_t zdplane_version = MAKE_FRRVERSION(2, 0, 0);
+static uint32_t zdplane_version = MAKE_FRRVERSION(2, 1, 0);
 
 /* Control for collection of extra interface info with route updates; a plugin
  * can enable the extra info via a dplane api.


### PR DESCRIPTION
Bump the minor dplane api version for the 10.4 release.