### PR TITLE
zebra: fix stale NHG in kernel

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -210,6 +210,9 @@ static void sigint(void)
 	 * with the 'finalize' function.
 	 */
 	zebra_dplane_finish();
+
+	/* Clean up if any stale NHGs present */
+	zebra_nhg_sweep_table(zrouter.nhgs_id, true);
 }
 
 /*

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -4050,6 +4050,14 @@ void zebra_interface_nhg_reinstall(struct interface *ifp)
 
 	frr_each (nhg_connected_tree, &zif->nhg_dependents, rb_node_dep) {
 		/*
+		 * If this nhe has 'initial delay' flag set, we should not install this
+		 * in kernel in case of any interface events. Zebra created this entry
+		 * while processing the kernel/connected routes, just to pretend
+		 * the successful kernel install of this NHG
+		 */
+		if (CHECK_FLAG(rb_node_dep->nhe->flags, NEXTHOP_GROUP_INITIAL_DELAY_INSTALL))
+			continue;
+		/*
 		 * The nexthop associated with this was set as !ACTIVE
 		 * so we need to turn it back to active when we get to
 		 * this point again

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -390,7 +390,7 @@ extern void zebra_nhg_dplane_result(struct zebra_dplane_ctx *ctx);
 
 
 /* Sweep the nhg hash tables for old entries on restart */
-extern void zebra_nhg_sweep_table(struct hash *hash);
+extern void zebra_nhg_sweep_table(struct hash *hash, bool stale_sweep);
 
 /*
  * We are shutting down but the nexthops should be kept

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -180,7 +180,7 @@ void zebra_router_sweep_route(void)
 
 void zebra_router_sweep_nhgs(void)
 {
-	zebra_nhg_sweep_table(zrouter.nhgs_id);
+	zebra_nhg_sweep_table(zrouter.nhgs_id, false);
 }
 
 static void zebra_router_free_table(struct zebra_router_table *zrt)


### PR DESCRIPTION
Fixing stale NHG issue in kernel.

**Issue1:**
1. zebra creates an nhe and sets 'initial delay' flag for the nexthop received along with kernel/connected route and this routes is a v6 route.
2. Later zebra receives intf_address event for the interface that belongs to the same nhe created above. but this is v4 event. Then zebra iterates through the nhe set linked to this interface and eventually it will end up installing this nhe in kernel

So, we install the NHG in kernel for connected/kernel routes and that looks to be deviating from the expected behaviour. All this happens when we receive interface event, we attempt a reinstall for all the NHGs associated with that intf. But if the 'initial delay' is already set for an NHG, we can skip that.
Fixing the same.

**Issue2:**
During FRR restart nexthop-group entries are not getting cleaned up in
below scenario.
1. Let's say an NHG refcnt is getting decremented and it becomes zero. we
add a timer for this NHG before deleting it in zebra/kernel.
so this NHG will be intact in kernel until the timer expires.
2. Now, the timer is running and frr is getting restarted. All the
NHGs are getting cleaned up in kernel but the one that has timer
running is still installed in the kernel.

Check if any NHG has timer running during zebra shutdown and remove from
kernel.