### PR TITLE
bgpd: correct no form commands

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -9354,12 +9354,15 @@ DEFUN (no_neighbor_addpath_tx_all_paths,
 {
 	int idx_peer = 2;
 	struct peer *peer;
+	safi_t safi = bgp_node_safi(vty);
 
 	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	if (peer->addpath_type[bgp_node_afi(vty)][bgp_node_safi(vty)] != BGP_ADDPATH_ALL) {
+	if (safi == SAFI_LABELED_UNICAST)
+		safi = SAFI_UNICAST;
+	if (peer->addpath_type[bgp_node_afi(vty)][safi] != BGP_ADDPATH_ALL) {
 		vty_out(vty,
 			"%% Peer not currently configured to transmit all paths.");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -9451,13 +9454,15 @@ DEFUN (no_neighbor_addpath_tx_bestpath_per_as,
 {
 	int idx_peer = 2;
 	struct peer *peer;
+	safi_t safi = bgp_node_safi(vty);
 
 	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	if (peer->addpath_type[bgp_node_afi(vty)][bgp_node_safi(vty)]
-	    != BGP_ADDPATH_BEST_PER_AS) {
+	if (safi == SAFI_LABELED_UNICAST)
+		safi = SAFI_UNICAST;
+	if (peer->addpath_type[bgp_node_afi(vty)][safi] != BGP_ADDPATH_BEST_PER_AS) {
 		vty_out(vty,
 			"%% Peer not currently configured to transmit all best path per as.");
 		return CMD_WARNING_CONFIG_FAILED;


### PR DESCRIPTION
Before:
```
anlan(config-router-af)# neighbor 22::22 addpath-tx-all-paths
anlan(config-router-af)# no neighbor 22::22 addpath-tx-all-paths
% Peer not currently configured to transmit all paths.anlan(config-router-af)#
```

After:
```
anlan(config-router)# address-family ipv6 labeled-unicast
anlan(config-router-af)# neighbor 22::22 addpath-tx-all-paths
anlan(config-router-af)# no neighbor 22::22 addpath-tx-all-paths
```

`bgp_addpath_set_peer_type()` changes from `SAFI_LABELED_UNICAST` to `SAFI_UNICAST`, so we need the same change during the early check.