### PR TITLE
build: check for libunwind.h, not unwind.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2596,7 +2596,7 @@ if test "$enable_backtrace" != "no" ; then
   ])
 
   if test "$backtrace_ok" = "no"; then
-    AC_CHECK_HEADER([unwind.h], [
+    AC_CHECK_HEADER([libunwind.h], [
       AC_SEARCH_LIBS([unw_getcontext], [unwind], [
         AC_DEFINE([HAVE_LIBUNWIND], [1], [libunwind])
         backtrace_ok=yes


### PR DESCRIPTION
For extra confusion, unwind.h is also provided by the various libunwind implementations, but it provides a different API.  And in some cases, they ship unwind.h but not libunwind.h, and then this check incorrectly detects as positive...

This is a separate commit because it should probably be backported. (A larger rework of the backtrace configure option is following.)