### PR TITLE
build: `autoconf` cleanup pass

### DIFF
--- a/buildtest.sh
+++ b/buildtest.sh
@@ -5,7 +5,7 @@
 # builds some git commit of FRR in some different configurations
 # usage: buildtest.sh [commit [configurations...]]
 
-basecfg="--prefix=/usr --enable-user=frr --enable-group=frr --enable-vty-group=frr --enable-configfile-mask=0660 --enable-logfile-mask=0640 --enable-vtysh --sysconfdir=/etc --localstatedir=/var --libdir=/usr/lib64/frr  --enable-rtadv --disable-static --enable-isisd --enable-multipath=0 --enable-pimd --enable-werror"
+basecfg="--prefix=/usr --enable-user=frr --enable-group=frr --enable-vty-group=frr --enable-configfile-mask=0660 --enable-logfile-mask=0640 --enable-vtysh --sysconfdir=/etc --localstatedir=/var --libdir=/usr/lib64/frr  --disable-static --enable-isisd --enable-multipath=0 --enable-pimd --enable-werror"
 
 configs_base="gcc|$basecfg"
 

--- a/configure.ac
+++ b/configure.ac
@@ -2596,7 +2596,7 @@ if test "$enable_backtrace" != "no" ; then
   ])
 
   if test "$backtrace_ok" = "no"; then
-    AC_CHECK_HEADER([unwind.h], [
+    AC_CHECK_HEADER([libunwind.h], [
       AC_SEARCH_LIBS([unw_getcontext], [unwind], [
         AC_DEFINE([HAVE_LIBUNWIND], [1], [libunwind])
         backtrace_ok=yes

--- a/configure.ac
+++ b/configure.ac
@@ -846,7 +846,9 @@ AC_ARG_ENABLE([capabilities],
 AC_ARG_ENABLE([gcc_ultra_verbose],
   AS_HELP_STRING([--enable-gcc-ultra-verbose], [enable ultra verbose GCC warnings]))
 AC_ARG_ENABLE([backtrace],
-  AS_HELP_STRING([--disable-backtrace], [disable crash backtraces (default autodetect)]))
+  AS_HELP_STRING([--disable-backtrace], [disable crash backtraces (default autodetect)])
+AS_HELP_STRING([--enable-backtrace=<execinfo|libunwind>], [select specific backtrace library])
+)
 AC_ARG_ENABLE([pcreposix],
   AS_HELP_STRING([--enable-pcreposix], [enable using PCRE Posix libs for regex functions]))
 AC_ARG_ENABLE([pcre2posix],
@@ -2586,36 +2588,47 @@ AC_SUBST([LIBCAP])
 dnl ---------------------------
 dnl check for glibc 'backtrace'
 dnl ---------------------------
+backtrace_ok=false
 if test "$enable_backtrace" != "no" ; then
-  backtrace_ok=no
-  PKG_CHECK_MODULES([UNWIND], [libunwind], [
-    AC_DEFINE([HAVE_LIBUNWIND], [1], [libunwind])
-    backtrace_ok=yes
-  ], [
-    true
-  ])
-
-  if test "$backtrace_ok" = "no"; then
-    AC_CHECK_HEADER([libunwind.h], [
-      AC_SEARCH_LIBS([unw_getcontext], [unwind], [
-        AC_DEFINE([HAVE_LIBUNWIND], [1], [libunwind])
-        backtrace_ok=yes
+  case "x$enable_backtrace" in
+  x|xyes|xexecinfo|xlibunwind)
+    ;;
+  *)
+    AC_MSG_FAILURE([invalid argument ${enable_backtrace} for --enable-backtrace])
+    ;;
+  esac
+  if test "$enable_backtrace" != "execinfo"; then
+    PKG_CHECK_MODULES([UNWIND], [libunwind], [
+      AC_DEFINE([HAVE_LIBUNWIND], [1], [libunwind])
+      backtrace_ok=true
+    ], [
+      AC_CHECK_HEADER([libunwind.h], [
+        AC_SEARCH_LIBS([unw_getcontext], [unwind], [
+          AC_DEFINE([HAVE_LIBUNWIND], [1], [libunwind])
+          backtrace_ok=true
+        ])
       ])
     ])
+    if test "$enable_backtrace" = "libunwind" -a "$backtrace_ok" = "false"; then
+      AC_MSG_FAILURE([libunwind backtraces explicitly requested but not found])
+    fi
   fi
 
-  if test "$backtrace_ok" = "no"; then
+  if test "$backtrace_ok" = "false"; then
     AC_CHECK_HEADER([execinfo.h], [
       AC_SEARCH_LIBS([backtrace], [execinfo], [
         AC_DEFINE([HAVE_GLIBC_BACKTRACE], [1], [Glibc backtrace])
-        backtrace_ok=yes
-      ],, [-lm])
+        backtrace_ok=true
+      ], [], [-lm])
     ])
+    if test "$enable_backtrace" = "execinfo" -a "$backtrace_ok" = "false"; then
+      AC_MSG_FAILURE([glibc/execinfo backtraces explicitly requested but not found])
+    fi
   fi
 
-  if test "$enable_backtrace" = "yes" -a "$backtrace_ok" = "no"; then
+  if test "$enable_backtrace" != "" -a "$backtrace_ok" = "false"; then
     dnl user explicitly requested backtrace but we failed to find support
-    AC_MSG_FAILURE([failed to find backtrace or libunwind support])
+    AC_MSG_FAILURE([failed to find glibc/execinfo backtrace or libunwind])
   fi
 fi
 
@@ -2929,6 +2942,10 @@ if test "$enable_doc" != "no" -a "$frr_py_mod_sphinx" = "false"; then
 fi
 if test "$frr_py_mod_pytest" = "false"; then
   AC_MSG_WARN([pytest is missing, unit tests cannot be performed])
+fi
+if test "$backtrace_ok" = "false"; then
+  AC_MSG_WARN([^])
+  AC_MSG_WARN([building FRR without crash/assert backtraces. This is NOT RECOMMENDED.])
 fi
 
 if $path_warn_banner; then

--- a/configure.ac
+++ b/configure.ac
@@ -837,8 +837,6 @@ AC_ARG_ENABLE([logfile_mask],
   AS_HELP_STRING([--enable-logfile-mask=ARG], [set mask for log files]))
 AC_ARG_ENABLE([realms],
   AS_HELP_STRING([--enable-realms], [enable REALMS support under Linux]))
-AC_ARG_ENABLE([rtadv],
-  AS_HELP_STRING([--disable-rtadv], [disable IPV6 router advertisement feature]))
 AC_ARG_ENABLE([irdp],
   AS_HELP_STRING([--enable-irdp], [enable IRDP server support in zebra]))
 AC_ARG_ENABLE([capabilities],
@@ -1004,14 +1002,6 @@ AC_SUBST([PYSPHINX])
 #
 if test "$enable_oldvpn_commands" = "yes"; then
    AC_DEFINE([KEEP_OLD_VPN_COMMANDS], [1], [Define for compiling with old vpn commands])
-fi
-
-AC_MSG_CHECKING([if zebra should be configurable to send Route Advertisements])
-if test "$enable_rtadv" != "no"; then
-  AC_MSG_RESULT([yes])
-  AC_DEFINE([HAVE_RTADV], [1], [Enable IPv6 Routing Advertisement support])
-else
-  AC_MSG_RESULT([no])
 fi
 
 if test "$enable_user" = "no"; then

--- a/configure.ac
+++ b/configure.ac
@@ -2014,42 +2014,38 @@ dnl ##########################################################################
 dnl ------------------
 dnl check Net-SNMP library
 dnl ------------------
+SNMP=false
 if test "$enable_snmp" != "" -a "$enable_snmp" != "no"; then
-   AC_PATH_TOOL([NETSNMP_CONFIG], [net-snmp-config], [no])
-   if test "$NETSNMP_CONFIG" = "no"; then
-      AC_MSG_ERROR([--enable-snmp given but unable to find net-snmp-config])
-   fi
-   SNMP_LIBS="`${NETSNMP_CONFIG} --agent-libs`"
-   SNMP_CFLAGS="`${NETSNMP_CONFIG} --base-cflags`"
-   # net-snmp lists all of its own dependencies.  we absolutely do not want that
-   # among other things we avoid a GPL vs. OpenSSL license conflict here
-   for removelib in crypto ssl sensors pci wrap; do
-     SNMP_LIBS="`echo $SNMP_LIBS | sed -e 's/-l'$removelib'/ /g'`"
-   done
-   AC_MSG_CHECKING([whether we can link to Net-SNMP])
-   AC_LINK_IFELSE_FLAGS([$SNMP_CFLAGS], [$SNMP_LIBS], [AC_LANG_PROGRAM([
+  PKG_CHECK_MODULES([SNMP], [netsnmp-agent], [
+    dnl all set, nothing to do
+  ], [
+    AC_PATH_TOOL([NETSNMP_CONFIG], [net-snmp-config], [no])
+    if test "$NETSNMP_CONFIG" = "no"; then
+      AC_MSG_ERROR([--enable-snmp given but unable to find netsnmp-agent pkgconfig or net-snmp-config])
+    fi
+    SNMP_LIBS="`${NETSNMP_CONFIG} --agent-libs`"
+    SNMP_CFLAGS="`${NETSNMP_CONFIG} --base-cflags`"
+    # net-snmp lists all of its own dependencies.  we absolutely do not want that
+    # among other things we avoid a GPL vs. OpenSSL license conflict here
+    for removelib in crypto ssl sensors pci wrap; do
+      SNMP_LIBS="`echo $SNMP_LIBS | sed -e 's/-l'$removelib'/ /g'`"
+    done
+    AC_MSG_CHECKING([whether we can link to Net-SNMP])
+    AC_LINK_IFELSE_FLAGS([$SNMP_CFLAGS], [$SNMP_LIBS], [
+      AC_LANG_PROGRAM([
 int main(void);
-],
-[
+], [
 {
   return 0;
 }
-])], [
-     AC_MSG_RESULT([no])
-     AC_MSG_ERROR([--enable-snmp given but not usable])])
-   case "${enable_snmp}" in
-     yes)
-      SNMP_METHOD=agentx
-      ;;
-     agentx)
-      SNMP_METHOD="${enable_snmp}"
-      ;;
-     *)
-      AC_MSG_ERROR([--enable-snmp given with an unknown method (${enable_snmp}). Use yes or agentx])
-      ;;
-   esac
-   AH_TEMPLATE([SNMP_AGENTX], [Use SNMP AgentX to interface with snmpd])
-   AC_DEFINE_UNQUOTED(AS_TR_CPP(SNMP_${SNMP_METHOD}),,[SNMP method to interface with snmpd])
+])
+    ], [
+      AC_MSG_RESULT([no])
+      AC_MSG_ERROR([SNMP libraries found but failed to link])
+    ])
+  ])
+  SNMP=true
+  AC_DEFINE([SNMP_AGENTX], [1], [Enable AgentX SNMP modules])
 fi
 AC_SUBST([SNMP_LIBS])
 AC_SUBST([SNMP_CFLAGS])
@@ -2766,7 +2762,7 @@ AM_CONDITIONAL([GRPC], [test "$enable_grpc" = "yes"])
 AM_CONDITIONAL([ZEROMQ], [test "$ZEROMQ" = "true"])
 dnl plugins
 AM_CONDITIONAL([RPKI], [test "$RPKI" = "true"])
-AM_CONDITIONAL([SNMP], [test "$SNMP_METHOD" = "agentx"])
+AM_CONDITIONAL([SNMP], [$SNMP])
 AM_CONDITIONAL([IRDP], [$IRDP])
 AM_CONDITIONAL([FPM], [test "$enable_fpm" = "yes"])
 AM_CONDITIONAL([HAVE_PROTOBUF], [test "$enable_protobuf" != "no"])

--- a/doc/developer/building-frr-for-centos6.rst
+++ b/doc/developer/building-frr-for-centos6.rst
@@ -165,7 +165,7 @@ an example.)
         --libexecdir=/usr/lib/frr \
         --with-moduledir=/usr/lib/frr/modules \
         --disable-pimd \
-        --enable-snmp=agentx \
+        --enable-snmp \
         --enable-multipath=64 \
         --enable-user=frr \
         --enable-group=frr \

--- a/doc/developer/building-frr-for-centos7.rst
+++ b/doc/developer/building-frr-for-centos7.rst
@@ -61,7 +61,7 @@ an example.)
         --libdir=/usr/lib/frr \
         --libexecdir=/usr/lib/frr \
         --with-moduledir=/usr/lib/frr/modules \
-        --enable-snmp=agentx \
+        --enable-snmp \
         --enable-multipath=64 \
         --enable-user=frr \
         --enable-group=frr \

--- a/doc/developer/building-frr-for-centos8.rst
+++ b/doc/developer/building-frr-for-centos8.rst
@@ -55,7 +55,7 @@ an example.)
         --libdir=/usr/lib/frr \
         --libexecdir=/usr/lib/frr \
         --with-moduledir=/usr/lib/frr/modules \
-        --enable-snmp=agentx \
+        --enable-snmp \
         --enable-multipath=64 \
         --enable-user=frr \
         --enable-group=frr \

--- a/doc/developer/include-compile.rst
+++ b/doc/developer/include-compile.rst
@@ -19,7 +19,7 @@ obtained by running ``./configure -h``. The options shown below are examples.
        --with-moduledir=\${prefix}/lib/frr/modules \
        --enable-configfile-mask=0640 \
        --enable-logfile-mask=0640 \
-       --enable-snmp=agentx \
+       --enable-snmp \
        --enable-multipath=64 \
        --enable-user=frr \
        --enable-group=frr \

--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -404,7 +404,7 @@ for ``master`` branch:
        --localstatedir=/var \
        --sbindir=/usr/lib/frr --bindir=/usr/lib/frr \
        --with-moduledir=/usr/lib/frr/modules \
-       --enable-multipath=0 --enable-rtadv \
+       --enable-multipath=0 \
        --enable-tcp-zebra --enable-fpm --enable-pimd \
        --enable-sharpd
    make

--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -140,7 +140,7 @@ If you prefer to manually build FRR, then use the following suggested config:
        --enable-user=frr \
        --enable-group=frr \
        --enable-vty-group=frrvty \
-       --enable-snmp=agentx \
+       --enable-snmp \
        --with-pkg-extra-version=-my-manual-build
 
 And create ``frr`` user and ``frrvty`` group as follows:

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -252,12 +252,22 @@ options from the list below.
    compiler is detected as gcc, but giving an explicit enable/disable is
    suggested.
 
+.. option:: --enable-backtrace[=<execinfo|libunwind>]
+
+   Select a specific backtrace library (recommended for building packages,
+   to avoid accidentally using the other one without noticing.) ``execinfo``
+   refers to glibc's ``backtrace()`` call, which is also available on some BSD
+   systems as ``libexecinfo``. Of ``libunwind``, multiple variants exist; the
+   standalone one originally created by HP is recommended but the version
+   included in LLVM should also work.
+
+   Default is to enable backtraces, look for libunwind first and fall back to
+   execinfo if libunwind is unavailable.
+
 .. option:: --disable-backtrace
 
-   Controls backtrace support for the crash handlers. This is autodetected by
-   default. Using the switch will enforce the requested behaviour, failing with
-   an error if support is requested but not available.  On BSD systems, this
-   needs libexecinfo, while on glibc support for this is part of libc itself.
+   Explicitly disable support for built-in backtraces on crashes/assert
+   failures.  This is **not recommended**.
 
 .. option:: --enable-dev-build
 

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -241,10 +241,6 @@ options from the list below.
 
    Enable IRDP server support. This is deprecated.
 
-.. option:: --disable-rtadv
-
-   Disable support IPV6 router advertisement in zebra.
-
 .. option:: --enable-gcc-rdynamic
 
    Pass the ``-rdynamic`` option to the linker driver.  This is in most cases

--- a/doc/user/snmp.rst
+++ b/doc/user/snmp.rst
@@ -68,7 +68,7 @@ AgentX configuration
 .. program:: configure
 
 To enable AgentX protocol support, FRR must have been build with the
-:option:`--enable-snmp` or `--enable-snmp=agentx` option. Both the
+:option:`--enable-snmp` option. Both the
 master SNMP agent (snmpd) and each of the FRR daemons must be configured. In
 :file:`/etc/snmp/snmpd.conf`, the ``master agentx`` directive should be added.
 In each of the FRR daemons, ``agentx`` command will enable AgentX support.

--- a/docker/ubi8-minimal/Dockerfile
+++ b/docker/ubi8-minimal/Dockerfile
@@ -67,7 +67,7 @@ RUN echo '%_smp_mflags %( echo "-j$(/usr/bin/getconf _NPROCESSORS_ONLN)"; )' >> 
     && ./configure \
 	--enable-multipath=256 \
         --enable-rpki \
-        --enable-snmp=agentx \
+        --enable-snmp \
         --enable-numeric-version \
         --with-pkg-extra-version="_git$PKGVER" \
     && make dist \

--- a/docker/ubuntu-ci/Dockerfile
+++ b/docker/ubuntu-ci/Dockerfile
@@ -125,7 +125,7 @@ RUN cd ~/frr && \
        --enable-config-rollbacks \
        --enable-grpc \
        --enable-vty-group=frrvty \
-       --enable-snmp=agentx \
+       --enable-snmp \
        --enable-scripting \
        --with-pkg-extra-version=-my-manual-build && \
     make -j $(nproc) && \

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -27,7 +27,6 @@
 %{!?with_pimd:          %global  with_pimd          1 }
 %{!?with_pim6d:         %global  with_pim6d         1 }
 %{!?with_vrrpd:         %global  with_vrrpd         1 }
-%{!?with_rtadv:         %global  with_rtadv         1 }
 %{!?with_watchfrr:      %global  with_watchfrr      1 }
 %{!?with_pathd:         %global  with_pathd         1 }
 %{!?with_grpc:          %global  with_grpc          0 }
@@ -373,11 +372,6 @@ CFLAGS="%{optflags} -DINET_NTOP_NO_OVERRIDE"
     --enable-ospfapi \
 %else
     --disable-ospfapi \
-%endif
-%if %{with_rtadv}
-    --enable-rtadv \
-%else
-    --disable-rtadv \
 %endif
 %if %{with_ldpd}
     --enable-ldpd \

--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -368,7 +368,6 @@ parts:
             - --enable-ospfclient=yes
             - --enable-ospfapi=yes
             - --enable-multipath=64
-            - --enable-rtadv
             - --enable-user=root
             - --enable-group=root
             - --enable-pimd

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -51,8 +51,6 @@ static uint32_t interfaces_configured_for_ra_from_bgp;
 
 #define MAX_CHARS_PER_LINE 1024
 
-#if defined(HAVE_RTADV)
-
 #include "zebra/rtadv_clippy.c"
 
 DEFINE_MTYPE_STATIC(ZEBRA, RTADV_PREFIX, "Router Advertisement Prefix");
@@ -2269,38 +2267,6 @@ bool rtadv_compiled_in(void)
 {
 	return true;
 }
-
-#else /* !HAVE_RTADV */
-/*
- * If the end user does not have RADV enabled we should
- * handle this better
- */
-void zebra_interface_radv_disable(ZAPI_HANDLER_ARGS)
-{
-	if (IS_ZEBRA_DEBUG_PACKET)
-		zlog_debug(
-			"Received %s command, but ZEBRA is not compiled with Router Advertisements on",
-			zserv_command_string(hdr->command));
-
-	return;
-}
-
-void zebra_interface_radv_enable(ZAPI_HANDLER_ARGS)
-{
-	if (IS_ZEBRA_DEBUG_PACKET)
-		zlog_debug(
-			"Received %s command, but ZEBRA is not compiled with Router Advertisements on",
-			zserv_command_string(hdr->command));
-
-	return;
-}
-
-bool rtadv_compiled_in(void)
-{
-	return false;
-}
-
-#endif /* HAVE_RTADV */
 
 uint32_t rtadv_get_interfaces_configured_from_bgp(void)
 {

--- a/zebra/rtadv.h
+++ b/zebra/rtadv.h
@@ -20,8 +20,6 @@ extern "C" {
 struct interface;
 struct zebra_if;
 
-#if defined(HAVE_RTADV)
-
 PREDECL_SORTLIST_UNIQ(adv_if_list);
 /* Structure which hold status of router advertisement. */
 struct rtadv {
@@ -456,51 +454,6 @@ void rtadv_pref64_reset(struct zebra_if *zif, struct pref64_adv *item);
 void ipv6_nd_suppress_ra_set(struct interface *ifp,
 			     enum ipv6_nd_suppress_ra_status status);
 void ipv6_nd_interval_set(struct interface *ifp, uint32_t interval);
-
-#else /* !HAVE_RTADV */
-struct rtadv {
-	/* empty structs aren't valid ISO C */
-	char dummy;
-};
-
-struct rtadvconf {
-	/* same again, empty structs aren't valid ISO C */
-	char dummy;
-};
-
-static inline void rtadv_vrf_init(struct zebra_vrf *zvrf)
-{
-}
-static inline void rtadv_vrf_terminate(struct zebra_vrf *zvrf)
-{
-}
-static inline void rtadv_cmd_init(void)
-{
-}
-static inline void rtadv_if_init(struct zebra_if *zif)
-{
-}
-static inline void rtadv_if_up(struct zebra_if *zif)
-{
-}
-static inline void rtadv_if_fini(struct zebra_if *zif)
-{
-}
-static inline void rtadv_add_prefix(struct zebra_if *zif,
-				    const struct prefix_ipv6 *p)
-{
-}
-static inline void rtadv_delete_prefix(struct zebra_if *zif,
-				       const struct prefix *p)
-{
-}
-static inline void rtadv_stop_ra(struct interface *ifp, bool if_down_event)
-{
-}
-static inline void rtadv_stop_ra_all(void)
-{
-}
-#endif
 
 extern void zebra_interface_radv_disable(ZAPI_HANDLER_ARGS);
 extern void zebra_interface_radv_enable(ZAPI_HANDLER_ARGS);

--- a/zebra/zebra_cli.c
+++ b/zebra/zebra_cli.c
@@ -1183,7 +1183,6 @@ static void lib_interface_zebra_evpn_mh_uplink_cli_write(
 		vty_out(vty, " no evpn mh uplink\n");
 }
 
-#if defined(HAVE_RTADV)
 DEFPY_YANG (ipv6_nd_ra_fast_retrans,
 	ipv6_nd_ra_fast_retrans_cmd,
 	"[no] ipv6 nd ra-fast-retrans",
@@ -1924,7 +1923,6 @@ static void lib_interface_zebra_ipv6_router_advertisements_pref64_pref64_prefix_
 
 	vty_out(vty, "\n");
 }
-#endif /* HAVE_RTADV */
 
 #if HAVE_BFDD == 0
 DEFPY_YANG (zebra_ptm_enable_if,
@@ -2763,9 +2761,7 @@ const char *features[] = {
 #if HAVE_BFDD == 0
 	"ptm-bfd",
 #endif
-#if defined(HAVE_RTADV)
 	"ipv6-router-advertisements",
-#endif
 	NULL
 };
 
@@ -2910,7 +2906,6 @@ const struct frr_yang_module_info frr_zebra_cli_info = {
 			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/evpn-mh/uplink",
 			.cbs.cli_show = lib_interface_zebra_evpn_mh_uplink_cli_write,
 		},
-#if defined(HAVE_RTADV)
 		{
 			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ipv6-router-advertisements/send-advertisements",
 			.cbs.cli_show = lib_interface_zebra_ipv6_router_advertisements_send_advertisements_cli_write,
@@ -2987,7 +2982,6 @@ const struct frr_yang_module_info frr_zebra_cli_info = {
 			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ipv6-router-advertisements/pref64/pref64-prefix",
 			.cbs.cli_show = lib_interface_zebra_ipv6_router_advertisements_pref64_pref64_prefix_cli_write,
 		},
-#endif /* defined(HAVE_RTADV) */
 #if HAVE_BFDD == 0
 		{
 			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ptm-enable",
@@ -3083,7 +3077,6 @@ void zebra_cli_init(void)
 	install_element(INTERFACE_NODE, &zebra_evpn_es_bypass_cmd);
 	install_element(INTERFACE_NODE, &zebra_evpn_mh_uplink_cmd);
 
-#if defined(HAVE_RTADV)
 	install_element(INTERFACE_NODE, &ipv6_nd_ra_fast_retrans_cmd);
 	install_element(INTERFACE_NODE, &ipv6_nd_ra_retrans_interval_cmd);
 	install_element(INTERFACE_NODE, &ipv6_nd_ra_hop_limit_cmd);
@@ -3103,7 +3096,6 @@ void zebra_cli_init(void)
 	install_element(INTERFACE_NODE, &ipv6_nd_rdnss_cmd);
 	install_element(INTERFACE_NODE, &ipv6_nd_dnssl_cmd);
 	install_element(INTERFACE_NODE, &ipv6_nd_pref64_cmd);
-#endif
 #if HAVE_BFDD == 0
 	install_element(INTERFACE_NODE, &zebra_ptm_enable_if_cmd);
 #endif

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -14,9 +14,7 @@ const char *features[] = {
 #if HAVE_BFDD == 0
 	"ptm-bfd",
 #endif
-#if defined(HAVE_RTADV)
 	"ipv6-router-advertisements",
-#endif
 	NULL
 };
 
@@ -603,7 +601,6 @@ const struct frr_yang_module_info frr_zebra_info = {
 				.modify = lib_interface_zebra_evpn_mh_uplink_modify,
 			}
 		},
-#if defined(HAVE_RTADV)
 		{
 			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ipv6-router-advertisements/send-advertisements",
 			.cbs = {
@@ -777,7 +774,6 @@ const struct frr_yang_module_info frr_zebra_info = {
 				.destroy = lib_interface_zebra_ipv6_router_advertisements_pref64_pref64_prefix_lifetime_destroy,
 			}
 		},
-#endif /* defined(HAVE_RTADV) */
 #if HAVE_BFDD == 0
 		{
 			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ptm-enable",

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -200,7 +200,6 @@ int lib_interface_zebra_evpn_mh_df_preference_modify(
 	struct nb_cb_modify_args *args);
 int lib_interface_zebra_evpn_mh_bypass_modify(struct nb_cb_modify_args *args);
 int lib_interface_zebra_evpn_mh_uplink_modify(struct nb_cb_modify_args *args);
-#if defined(HAVE_RTADV)
 int lib_interface_zebra_ipv6_router_advertisements_send_advertisements_modify(
 	struct nb_cb_modify_args *args);
 int lib_interface_zebra_ipv6_router_advertisements_max_rtr_adv_interval_modify(
@@ -277,7 +276,6 @@ int lib_interface_zebra_ipv6_router_advertisements_pref64_pref64_prefix_lifetime
 	struct nb_cb_modify_args *args);
 int lib_interface_zebra_ipv6_router_advertisements_pref64_pref64_prefix_lifetime_destroy(
 	struct nb_cb_destroy_args *args);
-#endif /* defined(HAVE_RTADV) */
 #if HAVE_BFDD == 0
 int lib_interface_zebra_ptm_enable_modify(struct nb_cb_modify_args *args);
 #endif

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -2543,7 +2543,6 @@ int lib_interface_zebra_evpn_mh_uplink_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
-#if defined(HAVE_RTADV)
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ipv6-router-advertisements/send-advertisements
  */
@@ -3345,7 +3344,6 @@ int lib_interface_zebra_ipv6_router_advertisements_pref64_pref64_prefix_lifetime
 	rtadv_pref64_update(ifp->info, entry, PREF64_LIFETIME_AUTO);
 	return NB_OK;
 }
-#endif /* defined(HAVE_RTADV) */
 
 #if HAVE_BFDD == 0
 /*


### PR DESCRIPTION
- includes #18912 (DO NOT MERGE before #18912 is merged, so that one can be backported without the other ones here)
- rework `--enable-backtrace` option to have explicit `--enable-backtrace=libunwind` option
- simplify SNMP checks (use `pkg-config` if available, remove multi-variant SMUX leftovers)
- remove `--disable-rtadv` option (why did we even have this?)

Adding `do not merge` tag until #18912 is merged (can be removed after #18912 is in — I can't separate that commit out from this PR because it would immediately conflict on the libunwind change.)

If you want to have a laugh, read the commit text on the SNMP change :grin: