### PR TITLE
redhat: make FRR RPM build to work on RedHat 10

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -525,7 +525,11 @@ install -d -m750 %{buildroot}%{_runstatedir}/frr
 
 %if 0%{?rhel} > 7 || 0%{?fedora} > 29
 # avoid `ERROR: ambiguous python shebang in` errors
+%if 0%{?rhel} < 10
 pathfix.py -pni "%{__python3} %{py3_shbang_opts}" %{buildroot}/usr/lib/frr/*.py
+%else
+%py3_shebang_fix %{buildroot}/usr/lib/frr/*.py
+%endif
 %py_byte_compile %{__python3} %{buildroot}/usr/lib/frr/*.py
 %else
 # remove ospfclient.py (if present) as it requires > python36

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -53,7 +53,7 @@
 
 #### Version String tweak
 # Remove invalid characters form version string and replace with _
-%{expand: %%global rpmversion %(echo '@VERSION@' | tr [:blank:]- _ )}
+%{expand: %%global frrmajorversion %(echo '@VERSION@' | tr [:blank:]- _ )}
 %define         frrversion   @VERSION@
 
 #### Check for systemd or init.d (upstart)
@@ -169,7 +169,7 @@
 
 Summary: Routing daemon
 Name:           frr
-Version:        %{rpmversion}
+Version:        %{frrmajorversion}
 Release:        %{release_rev}%{?dist}
 License:        GPLv2+
 Group:          System Environment/Daemons


### PR DESCRIPTION
Changes to make FRR RPM build to work on RedHat 10

- We used rpmversion as the major version variable. This is now a reserved system variable in the rpm package system with RPM shipped on RedHat 10. Rename it to frrmajorversion
- RedHat 10 doesn't have the pathfix.py for the shebang fix in pythonv - need to use py3_shebang_fix macro instead