### PR TITLE
mgmtd: recreate: failure of locking at startup in master

### DIFF
--- a/lib/mgmt_fe_client.c
+++ b/lib/mgmt_fe_client.c
@@ -48,10 +48,9 @@ struct mgmt_fe_client {
 #define FOREACH_SESSION_IN_LIST(client, session)                               \
 	frr_each_safe (mgmt_sessions, &(client)->sessions, (session))
 
-struct debug mgmt_dbg_fe_client = {
-	.conf = "debug mgmt client frontend",
-	.desc = "Management frontend client operations"
-};
+struct debug mgmt_dbg_fe_client = { .flags = DEBUG_MODE_ALL,
+				    .conf = "debug mgmt client frontend",
+				    .desc = "Management frontend client operations" };
 
 /* NOTE: only one client per proc for now. */
 static struct mgmt_fe_client *__fe_client;

--- a/mgmtd/mgmt.c
+++ b/mgmtd/mgmt.c
@@ -15,13 +15,17 @@
 #include "mgmtd/mgmt_history.h"
 #include "mgmtd/mgmt_memory.h"
 
-struct debug mgmt_debug_be = { .conf = "debug mgmt backend",
+struct debug mgmt_debug_be = { .flags = DEBUG_MODE_ALL,
+			       .conf = "debug mgmt backend",
 			       .desc = "Management backend adapter" };
-struct debug mgmt_debug_ds = { .conf = "debug mgmt datastore",
+struct debug mgmt_debug_ds = { .flags = DEBUG_MODE_ALL,
+			       .conf = "debug mgmt datastore",
 			       .desc = "Management datastore" };
-struct debug mgmt_debug_fe = { .conf = "debug mgmt frontend",
+struct debug mgmt_debug_fe = { .flags = DEBUG_MODE_ALL,
+			       .conf = "debug mgmt frontend",
 			       .desc = "Management frontend adapter" };
-struct debug mgmt_debug_txn = { .conf = "debug mgmt transaction",
+struct debug mgmt_debug_txn = { .flags = DEBUG_MODE_ALL,
+				.conf = "debug mgmt transaction",
 				.desc = "Management transaction" };
 
 /* MGMTD process wide configuration.  */

--- a/mgmtd/mgmt_ds.c
+++ b/mgmtd/mgmt_ds.c
@@ -227,8 +227,14 @@ int mgmt_ds_lock(struct mgmt_ds_ctx *ds_ctx, uint64_t session_id)
 {
 	assert(ds_ctx);
 
-	if (ds_ctx->locked)
+	if (ds_ctx->locked) {
+		zlog_err("%s: ERROR: lock already taken on DS:%s by session-id %Lu", __func__,
+			 mgmt_ds_id2name(ds_ctx->ds_id), ds_ctx->vty_session_id);
 		return EBUSY;
+	}
+
+	zlog_debug("%s: DEBUG: XXX obtaining lock on DS:%s for session-id %Lu", __func__,
+		   mgmt_ds_id2name(ds_ctx->ds_id), session_id);
 
 	ds_ctx->locked = true;
 	ds_ctx->vty_session_id = session_id;

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -182,8 +182,10 @@ mgmt_fe_session_write_lock_ds(Mgmtd__DatastoreId ds_id,
 			  session->session_id, mgmt_ds_id2name(ds_id));
 	else {
 		if (mgmt_ds_lock(ds_ctx, session->session_id)) {
-			_dbg("Failed to lock the DS:%s for session-id: %" PRIu64 " from %s!",
-			     mgmt_ds_id2name(ds_id), session->session_id, session->adapter->name);
+			_log_err("Failed to lock the DS:%s for session-id: %" PRIu64 " from %s!",
+				 mgmt_ds_id2name(ds_id), session->session_id,
+				 session->adapter->name);
+			assert(false);
 			return -1;
 		}
 


### PR DESCRIPTION
This needs to be run many many times to repro but eventually will hti the added assert.

while sudo -E pytest -n80 --dist=loadfile mgmt_notif mgmt_tests mgmt_config \
    mgmt_oper mgmt_fe_client mgmt_rpc mgmt_startup ; do \
    echo "== SLEEPING ==" && sleep 2; \
done