### PR TITLE
Revert "tools: ignore spaces only in macro empty line."

### DIFF
--- a/tools/checkpatch.pl
+++ b/tools/checkpatch.pl
@@ -3806,9 +3806,8 @@ sub process {
 
 # at the beginning of a line any tabs must come first and anything
 # more than $tabsize must use tabs.
-		if (($rawline =~ /^\+\s* \t\s*\S/ ||
-                     $rawline =~ /^\+\s*        \s*/) &&
-                    $rawline !~ /^\+\s*\\$/)) {
+		if ($rawline =~ /^\+\s* \t\s*\S/ ||
+		    $rawline =~ /^\+\s*        \s*/) {
 			my $herevet = "$here\n" . cat_vet($rawline) . "\n";
 			$rpt_cleaners = 1;
 			if (ERROR("CODE_INDENT",
@@ -4054,10 +4053,7 @@ sub process {
 #  1) within comments
 #  2) indented preprocessor commands
 #  3) hanging labels
-#  4) empty lines in multi-line macros
-#    if ($rawline =~ /^\+ / && $line !~ /^\+ *(?:$;|#|$Ident:)/ &&
 		if ($rawline =~ /^\+ / && $line !~ /^\+ *(?:$;|#|$Ident:)/)  {
-			$rawline !~ /^\+\s+\\$/) {
 			my $herevet = "$here\n" . cat_vet($rawline) . "\n";
 			if (WARN("LEADING_SPACE",
 				 "please, no spaces at the start of a line\n" . $herevet) &&


### PR DESCRIPTION
This reverts commit 010fb27df1ebb4176c270caa09ca4a8469c197a8.

This commit has broken the run of checkpatch.pl that checkpatch.sh does.