### PR TITLE
bgpd: use AS4B format for BGP loc-rib messages.

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3542,6 +3542,10 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 	if (cmd_domainname_get())
 		bgp->peer_self->domainname =
 			XSTRDUP(MTYPE_BGP_PEER_HOST, cmd_domainname_get());
+	/* for BMP LOC-RIB, enable AS4B encoding */
+	SET_FLAG(bgp->peer_self->cap, PEER_CAP_AS4_RCV);
+	SET_FLAG(bgp->peer_self->cap, PEER_CAP_AS4_ADV);
+
 	bgp->peer = list_new();
 
 peer_init:


### PR DESCRIPTION
An incoming BGP prefix encapsulated in LOC-RIB BMP message, encodes AS-Paths information in AS2B. This is not what the RFC9069, ch.5.4.1:

> Loc-RIB Route Monitoring messages MUST use a 4-byte ASN encoding as
> indicated in the Peer Up sent OPEN message (Section 5.2) capability.

Set the appropriate flags in the peer_self structure, to encode AS information for loc-rib in AS4B format.