### PR TITLE
lib, zebra: mark singleton nexthops inactive/active on link state changes for wecmp

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -483,6 +483,17 @@ bool nexthop_same_no_labels(const struct nexthop *nh1,
 	return true;
 }
 
+bool nexthop_same_no_weight(const struct nexthop *nh1, const struct nexthop *nh2)
+{
+	if (nh1 == nh2)
+		return true;
+
+	if (!nh1 || !nh2)
+		return false;
+
+	return (nexthop_cmp_no_weight(nh1, nh2) == 0);
+}
+
 /*
  * Allocate a new nexthop object and initialize it from various args.
  */

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -241,6 +241,7 @@ extern bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2);
 extern bool nexthop_same_no_ifindex(const struct nexthop *nh1, const struct nexthop *nh2);
 extern bool nexthop_same_no_labels(const struct nexthop *nh1,
 				   const struct nexthop *nh2);
+extern bool nexthop_same_no_weight(const struct nexthop *nh1, const struct nexthop *nh2);
 extern int nexthop_cmp(const struct nexthop *nh1, const struct nexthop *nh2);
 extern int nexthop_cmp_no_weight(const struct nexthop *nh1,
 				 const struct nexthop *nh2);

--- a/tests/topotests/two_layer_wucmp/README.md
+++ b/tests/topotests/two_layer_wucmp/README.md
@@ -1,0 +1,161 @@
+# Two-Layer WECMP Nexthop Group Test
+
+## Overview
+
+This test validates nexthop group behavior with WECMP (Weighted Equal Cost Multi-Path) in a high-density CLOS topology. The test specifically focuses on verifying the fix for weight mismatch issues in dependent nexthop groups when interfaces go down/up.
+
+## Problem Statement
+
+The test addresses a bug where singleton nexthops (weight=1) were not properly matched with nexthop group nexthops (weight=255), causing improper inactive/active marking of nexthops. This led to issues where:
+
+- Nexthops were incorrectly marked as inactive when they should remain active
+- New nexthop groups were unnecessarily created instead of reusing existing ones
+- Weight mismatches caused routing inconsistencies
+
+## Topology
+
+High-density 2-layer CLOS topology with:
+
+```
+    spine1 (AS 65100)    spine2 (AS 65100)
+      |  \                 /  |
+      |   \               /   |
+      |    \             /    |
+      |     \           /     |
+      |      \         /      |
+      |       \       /       |
+      |        \     /        |
+      |         \   /         |
+   leaf1 (AS 65001)        leaf2 (AS 65002)
+```
+
+### Link Details
+- **Leaf1 ↔ Spine1**: 32 parallel links (leaf1-eth0 to leaf1-eth31)
+- **Leaf1 ↔ Spine2**: 32 parallel links (leaf1-eth32 to leaf1-eth63)
+- **Leaf2 ↔ Spine1**: 32 parallel links (leaf2-eth0 to leaf2-eth31)
+- **Leaf2 ↔ Spine2**: 32 parallel links (leaf2-eth32 to leaf2-eth63)
+
+Total: 64 links per leaf (32 to each spine)
+
+### BGP Configuration
+- **Leaf1**: AS 65001, BGP neighbors to both spines
+- **Leaf2**: AS 65002, BGP neighbors to both spines, 1000 routes injected via sharpd
+- **Spine1**: AS 65100, BGP neighbors to both leafs
+- **Spine2**: AS 65100, BGP neighbors to both leafs
+
+## Test Cases
+
+### 1. Single Link Down
+**Purpose**: Test behavior when a single interface goes down
+
+**Actions**:
+- Bring down `leaf1-eth0` interface
+- Verify NHG behavior
+
+**Expected Results**:
+- Same NHG ID is retained (no new NHG created)
+- Exactly 1 nexthop marked as inactive
+- 63 nexthops remain active (64-1)
+- All routes continue to use the same NHG ID
+- NHG is not marked for deletion
+
+### 2. Single Link Up
+**Purpose**: Test behavior when the downed interface comes back up
+
+**Actions**:
+- Bring up `leaf1-eth0` interface
+- Verify NHG behavior
+
+**Expected Results**:
+- Same NHG ID is retained
+- All 64 nexthops are active again
+- All routes continue to use the same NHG ID
+
+### 3. Partial Links Down (16 out of 32 to Spine1)
+**Purpose**: Test behavior when multiple interfaces to spine1 go down simultaneously
+
+**Actions**:
+- Bring down 16 interfaces (leaf1-eth0 to leaf1-eth15) using `ip -batch`
+- Verify NHG behavior
+
+**Expected Results**:
+- Same NHG ID is retained
+- Exactly 16 nexthops marked as inactive
+- 48 nexthops remain active (64-16)
+- All routes continue to use the same NHG ID
+
+### 4. Partial Links Up (16 out of 32 to Spine1)
+**Purpose**: Test behavior when the downed interfaces come back up
+
+**Actions**:
+- Bring up 16 interfaces (leaf1-eth0 to leaf1-eth15) using `ip -batch`
+- Verify NHG behavior
+
+**Expected Results**:
+- Same NHG ID is retained
+- All 64 nexthops are active again
+- All routes continue to use the same NHG ID
+
+## Verification Commands
+
+The test uses JSON-based commands for robust verification:
+
+### Linux Kernel Commands
+```bash
+# Get nexthop groups
+ip -j nexthop show group
+
+# Get routes with nexthop information
+ip -j route show
+```
+
+### FRR Commands
+```bash
+# Get detailed nexthop group information
+show nexthop-group rib <id> json
+
+# Get BGP summary
+show bgp ipv4 unicast summary json
+```
+
+## Key Validation Points
+
+1. **NHG Persistence**: The same nexthop group ID must be maintained throughout all link state changes
+2. **Route Consistency**: All BGP routes must continue pointing to the same NHG ID
+3. **Nexthop State**: Nexthops must be correctly marked as active/inactive based on interface state
+4. **No Unnecessary NHGs**: New nexthop groups should not be created when existing ones can be reused
+5. **Weight Matching**: Singleton nexthops and NHG nexthops must have consistent weight handling
+
+## Configuration Files
+
+- **leaf1/frr.conf**: Basic BGP configuration with 64 neighbors (32 to each spine)
+- **leaf2/frr.conf**: BGP configuration with redistribute sharp for route injection
+- **spine1/frr.conf**: BGP configuration as route reflector
+- **spine2/frr.conf**: BGP configuration as route reflector
+
+## Dependencies
+
+- FRR with nexthop group support
+- Linux kernel with nexthop group support
+- BGP WECMP functionality
+- JSON output support for verification commands
+
+## Test Execution
+
+```bash
+# Run the specific test
+python3 test_two_layer_wuecmp.py
+
+# Run with pytest
+pytest test_two_layer_wuecmp.py -v
+```
+
+## Expected Outcomes
+
+This test validates that NHG logic in W-ECMP scenarios.
+- Proper matching of singleton and NHG nexthops regardless of weight differences
+- Correct active/inactive marking of nexthops during link state changes
+- Prevention of unnecessary nexthop group creation
+- Maintenance of routing consistency during network events
+
+The test ensures that there is no NHG churn upon local link failures when using WECMP in high-density topologies where many parallel links exist between routers.

--- a/tests/topotests/two_layer_wucmp/leaf1/frr.conf
+++ b/tests/topotests/two_layer_wucmp/leaf1/frr.conf
@@ -1,0 +1,401 @@
+int lo
+  ip addr 10.0.0.1/32
+
+route-map wcmp permit 10
+  set extcommunity bandwidth num-multipaths
+
+# Interfaces to spine1 (leaf1-eth0 to leaf1-eth31)
+int leaf1-eth0
+  ip addr 10.1.0.1/30
+  ipv6 address 2001:db8:1:0::1/64
+  no shut
+int leaf1-eth1
+  ip addr 10.1.1.1/30
+  ipv6 address 2001:db8:1:1::1/64
+  no shut
+int leaf1-eth2
+  ip addr 10.1.2.1/30
+  ipv6 address 2001:db8:1:2::1/64
+  no shut
+int leaf1-eth3
+  ip addr 10.1.3.1/30
+  ipv6 address 2001:db8:1:3::1/64
+  no shut
+int leaf1-eth4
+  ip addr 10.1.4.1/30
+  ipv6 address 2001:db8:1:4::1/64
+  no shut
+int leaf1-eth5
+  ip addr 10.1.5.1/30
+  ipv6 address 2001:db8:1:5::1/64
+  no shut
+int leaf1-eth6
+  ip addr 10.1.6.1/30
+  ipv6 address 2001:db8:1:6::1/64
+  no shut
+int leaf1-eth7
+  ip addr 10.1.7.1/30
+  ipv6 address 2001:db8:1:7::1/64
+  no shut
+int leaf1-eth8
+  ip addr 10.1.8.1/30
+  ipv6 address 2001:db8:1:8::1/64
+  no shut
+int leaf1-eth9
+  ip addr 10.1.9.1/30
+  ipv6 address 2001:db8:1:9::1/64
+  no shut
+int leaf1-eth10
+  ip addr 10.1.10.1/30
+  ipv6 address 2001:db8:1:10::1/64
+  no shut
+int leaf1-eth11
+  ip addr 10.1.11.1/30
+  ipv6 address 2001:db8:1:11::1/64
+  no shut
+int leaf1-eth12
+  ip addr 10.1.12.1/30
+  ipv6 address 2001:db8:1:12::1/64
+  no shut
+int leaf1-eth13
+  ip addr 10.1.13.1/30
+  ipv6 address 2001:db8:1:13::1/64
+  no shut
+int leaf1-eth14
+  ip addr 10.1.14.1/30
+  ipv6 address 2001:db8:1:14::1/64
+  no shut
+int leaf1-eth15
+  ip addr 10.1.15.1/30
+  ipv6 address 2001:db8:1:15::1/64
+  no shut
+int leaf1-eth16
+  ip addr 10.1.16.1/30
+  ipv6 address 2001:db8:1:16::1/64
+  no shut
+int leaf1-eth17
+  ip addr 10.1.17.1/30
+  ipv6 address 2001:db8:1:17::1/64
+  no shut
+int leaf1-eth18
+  ip addr 10.1.18.1/30
+  ipv6 address 2001:db8:1:18::1/64
+  no shut
+int leaf1-eth19
+  ip addr 10.1.19.1/30
+  ipv6 address 2001:db8:1:19::1/64
+  no shut
+int leaf1-eth20
+  ip addr 10.1.20.1/30
+  ipv6 address 2001:db8:1:20::1/64
+  no shut
+int leaf1-eth21
+  ip addr 10.1.21.1/30
+  ipv6 address 2001:db8:1:21::1/64
+  no shut
+int leaf1-eth22
+  ip addr 10.1.22.1/30
+  ipv6 address 2001:db8:1:22::1/64
+  no shut
+int leaf1-eth23
+  ip addr 10.1.23.1/30
+  ipv6 address 2001:db8:1:23::1/64
+  no shut
+int leaf1-eth24
+  ip addr 10.1.24.1/30
+  ipv6 address 2001:db8:1:24::1/64
+  no shut
+int leaf1-eth25
+  ip addr 10.1.25.1/30
+  ipv6 address 2001:db8:1:25::1/64
+  no shut
+int leaf1-eth26
+  ip addr 10.1.26.1/30
+  ipv6 address 2001:db8:1:26::1/64
+  no shut
+int leaf1-eth27
+  ip addr 10.1.27.1/30
+  ipv6 address 2001:db8:1:27::1/64
+  no shut
+int leaf1-eth28
+  ip addr 10.1.28.1/30
+  ipv6 address 2001:db8:1:28::1/64
+  no shut
+int leaf1-eth29
+  ip addr 10.1.29.1/30
+  ipv6 address 2001:db8:1:29::1/64
+  no shut
+int leaf1-eth30
+  ip addr 10.1.30.1/30
+  ipv6 address 2001:db8:1:30::1/64
+  no shut
+int leaf1-eth31
+  ip addr 10.1.31.1/30
+  ipv6 address 2001:db8:1:31::1/64
+  no shut
+
+# Interfaces to spine2 (leaf1-eth32 to leaf1-eth63)
+int leaf1-eth32
+  ip addr 10.2.0.1/30
+  ipv6 address 2001:db8:2:0::1/64
+  no shut
+int leaf1-eth33
+  ip addr 10.2.1.1/30
+  ipv6 address 2001:db8:2:1::1/64
+  no shut
+int leaf1-eth34
+  ip addr 10.2.2.1/30
+  ipv6 address 2001:db8:2:2::1/64
+  no shut
+int leaf1-eth35
+  ip addr 10.2.3.1/30
+  ipv6 address 2001:db8:2:3::1/64
+  no shut
+int leaf1-eth36
+  ip addr 10.2.4.1/30
+  ipv6 address 2001:db8:2:4::1/64
+  no shut
+int leaf1-eth37
+  ip addr 10.2.5.1/30
+  ipv6 address 2001:db8:2:5::1/64
+  no shut
+int leaf1-eth38
+  ip addr 10.2.6.1/30
+  ipv6 address 2001:db8:2:6::1/64
+  no shut
+int leaf1-eth39
+  ip addr 10.2.7.1/30
+  ipv6 address 2001:db8:2:7::1/64
+  no shut
+int leaf1-eth40
+  ip addr 10.2.8.1/30
+  ipv6 address 2001:db8:2:8::1/64
+  no shut
+int leaf1-eth41
+  ip addr 10.2.9.1/30
+  ipv6 address 2001:db8:2:9::1/64
+  no shut
+int leaf1-eth42
+  ip addr 10.2.10.1/30
+  ipv6 address 2001:db8:2:10::1/64
+  no shut
+int leaf1-eth43
+  ip addr 10.2.11.1/30
+  ipv6 address 2001:db8:2:11::1/64
+  no shut
+int leaf1-eth44
+  ip addr 10.2.12.1/30
+  ipv6 address 2001:db8:2:12::1/64
+  no shut
+int leaf1-eth45
+  ip addr 10.2.13.1/30
+  ipv6 address 2001:db8:2:13::1/64
+  no shut
+int leaf1-eth46
+  ip addr 10.2.14.1/30
+  ipv6 address 2001:db8:2:14::1/64
+  no shut
+int leaf1-eth47
+  ip addr 10.2.15.1/30
+  ipv6 address 2001:db8:2:15::1/64
+  no shut
+int leaf1-eth48
+  ip addr 10.2.16.1/30
+  ipv6 address 2001:db8:2:16::1/64
+  no shut
+int leaf1-eth49
+  ip addr 10.2.17.1/30
+  ipv6 address 2001:db8:2:17::1/64
+  no shut
+int leaf1-eth50
+  ip addr 10.2.18.1/30
+  ipv6 address 2001:db8:2:18::1/64
+  no shut
+int leaf1-eth51
+  ip addr 10.2.19.1/30
+  ipv6 address 2001:db8:2:19::1/64
+  no shut
+int leaf1-eth52
+  ip addr 10.2.20.1/30
+  ipv6 address 2001:db8:2:20::1/64
+  no shut
+int leaf1-eth53
+  ip addr 10.2.21.1/30
+  ipv6 address 2001:db8:2:21::1/64
+  no shut
+int leaf1-eth54
+  ip addr 10.2.22.1/30
+  ipv6 address 2001:db8:2:22::1/64
+  no shut
+int leaf1-eth55
+  ip addr 10.2.23.1/30
+  ipv6 address 2001:db8:2:23::1/64
+  no shut
+int leaf1-eth56
+  ip addr 10.2.24.1/30
+  ipv6 address 2001:db8:2:24::1/64
+  no shut
+int leaf1-eth57
+  ip addr 10.2.25.1/30
+  ipv6 address 2001:db8:2:25::1/64
+  no shut
+int leaf1-eth58
+  ip addr 10.2.26.1/30
+  ipv6 address 2001:db8:2:26::1/64
+  no shut
+int leaf1-eth59
+  ip addr 10.2.27.1/30
+  ipv6 address 2001:db8:2:27::1/64
+  no shut
+int leaf1-eth60
+  ip addr 10.2.28.1/30
+  ipv6 address 2001:db8:2:28::1/64
+  no shut
+int leaf1-eth61
+  ip addr 10.2.29.1/30
+  ipv6 address 2001:db8:2:29::1/64
+  no shut
+int leaf1-eth62
+  ip addr 10.2.30.1/30
+  ipv6 address 2001:db8:2:30::1/64
+  no shut
+int leaf1-eth63
+  ip addr 10.2.31.1/30
+  ipv6 address 2001:db8:2:31::1/64
+  no shut
+
+router bgp 65001
+  bgp bestpath as-path multipath-relax
+  bgp router-id 10.0.0.1
+  no bgp ebgp-requires-policy
+  timers bgp 5 60
+  neighbor leaf1-eth0 interface remote-as external
+  neighbor leaf1-eth1 interface remote-as external
+  neighbor leaf1-eth2 interface remote-as external
+  neighbor leaf1-eth3 interface remote-as external
+  neighbor leaf1-eth4 interface remote-as external
+  neighbor leaf1-eth5 interface remote-as external
+  neighbor leaf1-eth6 interface remote-as external
+  neighbor leaf1-eth7 interface remote-as external
+  neighbor leaf1-eth8 interface remote-as external
+  neighbor leaf1-eth9 interface remote-as external
+  neighbor leaf1-eth10 interface remote-as external
+  neighbor leaf1-eth11 interface remote-as external
+  neighbor leaf1-eth12 interface remote-as external
+  neighbor leaf1-eth13 interface remote-as external
+  neighbor leaf1-eth14 interface remote-as external
+  neighbor leaf1-eth15 interface remote-as external
+  neighbor leaf1-eth16 interface remote-as external
+  neighbor leaf1-eth17 interface remote-as external
+  neighbor leaf1-eth18 interface remote-as external
+  neighbor leaf1-eth19 interface remote-as external
+  neighbor leaf1-eth20 interface remote-as external
+  neighbor leaf1-eth21 interface remote-as external
+  neighbor leaf1-eth22 interface remote-as external
+  neighbor leaf1-eth23 interface remote-as external
+  neighbor leaf1-eth24 interface remote-as external
+  neighbor leaf1-eth25 interface remote-as external
+  neighbor leaf1-eth26 interface remote-as external
+  neighbor leaf1-eth27 interface remote-as external
+  neighbor leaf1-eth28 interface remote-as external
+  neighbor leaf1-eth29 interface remote-as external
+  neighbor leaf1-eth30 interface remote-as external
+  neighbor leaf1-eth31 interface remote-as external
+  neighbor leaf1-eth32 interface remote-as external
+  neighbor leaf1-eth33 interface remote-as external
+  neighbor leaf1-eth34 interface remote-as external
+  neighbor leaf1-eth35 interface remote-as external
+  neighbor leaf1-eth36 interface remote-as external
+  neighbor leaf1-eth37 interface remote-as external
+  neighbor leaf1-eth38 interface remote-as external
+  neighbor leaf1-eth39 interface remote-as external
+  neighbor leaf1-eth40 interface remote-as external
+  neighbor leaf1-eth41 interface remote-as external
+  neighbor leaf1-eth42 interface remote-as external
+  neighbor leaf1-eth43 interface remote-as external
+  neighbor leaf1-eth44 interface remote-as external
+  neighbor leaf1-eth45 interface remote-as external
+  neighbor leaf1-eth46 interface remote-as external
+  neighbor leaf1-eth47 interface remote-as external
+  neighbor leaf1-eth48 interface remote-as external
+  neighbor leaf1-eth49 interface remote-as external
+  neighbor leaf1-eth50 interface remote-as external
+  neighbor leaf1-eth51 interface remote-as external
+  neighbor leaf1-eth52 interface remote-as external
+  neighbor leaf1-eth53 interface remote-as external
+  neighbor leaf1-eth54 interface remote-as external
+  neighbor leaf1-eth55 interface remote-as external
+  neighbor leaf1-eth56 interface remote-as external
+  neighbor leaf1-eth57 interface remote-as external
+  neighbor leaf1-eth58 interface remote-as external
+  neighbor leaf1-eth59 interface remote-as external
+  neighbor leaf1-eth60 interface remote-as external
+  neighbor leaf1-eth61 interface remote-as external
+  neighbor leaf1-eth62 interface remote-as external
+  neighbor leaf1-eth63 interface remote-as external
+ address-family ipv4 uni
+  neighbor leaf1-eth0 route-map wcmp out
+  neighbor leaf1-eth1 route-map wcmp out
+  neighbor leaf1-eth2 route-map wcmp out
+  neighbor leaf1-eth3 route-map wcmp out
+  neighbor leaf1-eth4 route-map wcmp out
+  neighbor leaf1-eth5 route-map wcmp out
+  neighbor leaf1-eth6 route-map wcmp out
+  neighbor leaf1-eth7 route-map wcmp out
+  neighbor leaf1-eth8 route-map wcmp out
+  neighbor leaf1-eth9 route-map wcmp out
+  neighbor leaf1-eth10 route-map wcmp out
+  neighbor leaf1-eth11 route-map wcmp out
+  neighbor leaf1-eth12 route-map wcmp out
+  neighbor leaf1-eth13 route-map wcmp out
+  neighbor leaf1-eth14 route-map wcmp out
+  neighbor leaf1-eth15 route-map wcmp out
+  neighbor leaf1-eth16 route-map wcmp out
+  neighbor leaf1-eth17 route-map wcmp out
+  neighbor leaf1-eth18 route-map wcmp out
+  neighbor leaf1-eth19 route-map wcmp out
+  neighbor leaf1-eth20 route-map wcmp out
+  neighbor leaf1-eth21 route-map wcmp out
+  neighbor leaf1-eth22 route-map wcmp out
+  neighbor leaf1-eth23 route-map wcmp out
+  neighbor leaf1-eth24 route-map wcmp out
+  neighbor leaf1-eth25 route-map wcmp out
+  neighbor leaf1-eth26 route-map wcmp out
+  neighbor leaf1-eth27 route-map wcmp out
+  neighbor leaf1-eth28 route-map wcmp out
+  neighbor leaf1-eth29 route-map wcmp out
+  neighbor leaf1-eth30 route-map wcmp out
+  neighbor leaf1-eth31 route-map wcmp out
+  neighbor leaf1-eth32 route-map wcmp out
+  neighbor leaf1-eth33 route-map wcmp out
+  neighbor leaf1-eth34 route-map wcmp out
+  neighbor leaf1-eth35 route-map wcmp out
+  neighbor leaf1-eth36 route-map wcmp out
+  neighbor leaf1-eth37 route-map wcmp out
+  neighbor leaf1-eth38 route-map wcmp out
+  neighbor leaf1-eth39 route-map wcmp out
+  neighbor leaf1-eth40 route-map wcmp out
+  neighbor leaf1-eth41 route-map wcmp out
+  neighbor leaf1-eth42 route-map wcmp out
+  neighbor leaf1-eth43 route-map wcmp out
+  neighbor leaf1-eth44 route-map wcmp out
+  neighbor leaf1-eth45 route-map wcmp out
+  neighbor leaf1-eth46 route-map wcmp out
+  neighbor leaf1-eth47 route-map wcmp out
+  neighbor leaf1-eth48 route-map wcmp out
+  neighbor leaf1-eth49 route-map wcmp out
+  neighbor leaf1-eth50 route-map wcmp out
+  neighbor leaf1-eth51 route-map wcmp out
+  neighbor leaf1-eth52 route-map wcmp out
+  neighbor leaf1-eth53 route-map wcmp out
+  neighbor leaf1-eth54 route-map wcmp out
+  neighbor leaf1-eth55 route-map wcmp out
+  neighbor leaf1-eth56 route-map wcmp out
+  neighbor leaf1-eth57 route-map wcmp out
+  neighbor leaf1-eth58 route-map wcmp out
+  neighbor leaf1-eth59 route-map wcmp out
+  neighbor leaf1-eth60 route-map wcmp out
+  neighbor leaf1-eth61 route-map wcmp out
+  neighbor leaf1-eth62 route-map wcmp out
+  neighbor leaf1-eth63 route-map wcmp out
+ exit 

--- a/tests/topotests/two_layer_wucmp/leaf2/frr.conf
+++ b/tests/topotests/two_layer_wucmp/leaf2/frr.conf
@@ -1,0 +1,403 @@
+int lo
+  ip addr 10.0.0.2/32
+
+route-map wcmp permit 10
+  set extcommunity bandwidth num-multipaths
+
+# Interfaces to spine1 (leaf2-eth0 to leaf2-eth31)
+int leaf2-eth0
+  ip addr 10.3.0.1/30
+  ipv6 address 2001:db8:3:0::1/64
+  no shut
+int leaf2-eth1
+  ip addr 10.3.1.1/30
+  ipv6 address 2001:db8:3:1::1/64
+  no shut
+int leaf2-eth2
+  ip addr 10.3.2.1/30
+  ipv6 address 2001:db8:3:2::1/64
+  no shut
+int leaf2-eth3
+  ip addr 10.3.3.1/30
+  ipv6 address 2001:db8:3:3::1/64
+  no shut
+int leaf2-eth4
+  ip addr 10.3.4.1/30
+  ipv6 address 2001:db8:3:4::1/64
+  no shut
+int leaf2-eth5
+  ip addr 10.3.5.1/30
+  ipv6 address 2001:db8:3:5::1/64
+  no shut
+int leaf2-eth6
+  ip addr 10.3.6.1/30
+  ipv6 address 2001:db8:3:6::1/64
+  no shut
+int leaf2-eth7
+  ip addr 10.3.7.1/30
+  ipv6 address 2001:db8:3:7::1/64
+  no shut
+int leaf2-eth8
+  ip addr 10.3.8.1/30
+  ipv6 address 2001:db8:3:8::1/64
+  no shut
+int leaf2-eth9
+  ip addr 10.3.9.1/30
+  ipv6 address 2001:db8:3:9::1/64
+  no shut
+int leaf2-eth10
+  ip addr 10.3.10.1/30
+  ipv6 address 2001:db8:3:10::1/64
+  no shut
+int leaf2-eth11
+  ip addr 10.3.11.1/30
+  ipv6 address 2001:db8:3:11::1/64
+  no shut
+int leaf2-eth12
+  ip addr 10.3.12.1/30
+  ipv6 address 2001:db8:3:12::1/64
+  no shut
+int leaf2-eth13
+  ip addr 10.3.13.1/30
+  ipv6 address 2001:db8:3:13::1/64
+  no shut
+int leaf2-eth14
+  ip addr 10.3.14.1/30
+  ipv6 address 2001:db8:3:14::1/64
+  no shut
+int leaf2-eth15
+  ip addr 10.3.15.1/30
+  ipv6 address 2001:db8:3:15::1/64
+  no shut
+int leaf2-eth16
+  ip addr 10.3.16.1/30
+  ipv6 address 2001:db8:3:16::1/64
+  no shut
+int leaf2-eth17
+  ip addr 10.3.17.1/30
+  ipv6 address 2001:db8:3:17::1/64
+  no shut
+int leaf2-eth18
+  ip addr 10.3.18.1/30
+  ipv6 address 2001:db8:3:18::1/64
+  no shut
+int leaf2-eth19
+  ip addr 10.3.19.1/30
+  ipv6 address 2001:db8:3:19::1/64
+  no shut
+int leaf2-eth20
+  ip addr 10.3.20.1/30
+  ipv6 address 2001:db8:3:20::1/64
+  no shut
+int leaf2-eth21
+  ip addr 10.3.21.1/30
+  ipv6 address 2001:db8:3:21::1/64
+  no shut
+int leaf2-eth22
+  ip addr 10.3.22.1/30
+  ipv6 address 2001:db8:3:22::1/64
+  no shut
+int leaf2-eth23
+  ip addr 10.3.23.1/30
+  ipv6 address 2001:db8:3:23::1/64
+  no shut
+int leaf2-eth24
+  ip addr 10.3.24.1/30
+  ipv6 address 2001:db8:3:24::1/64
+  no shut
+int leaf2-eth25
+  ip addr 10.3.25.1/30
+  ipv6 address 2001:db8:3:25::1/64
+  no shut
+int leaf2-eth26
+  ip addr 10.3.26.1/30
+  ipv6 address 2001:db8:3:26::1/64
+  no shut
+int leaf2-eth27
+  ip addr 10.3.27.1/30
+  ipv6 address 2001:db8:3:27::1/64
+  no shut
+int leaf2-eth28
+  ip addr 10.3.28.1/30
+  ipv6 address 2001:db8:3:28::1/64
+  no shut
+int leaf2-eth29
+  ip addr 10.3.29.1/30
+  ipv6 address 2001:db8:3:29::1/64
+  no shut
+int leaf2-eth30
+  ip addr 10.3.30.1/30
+  ipv6 address 2001:db8:3:30::1/64
+  no shut
+int leaf2-eth31
+  ip addr 10.3.31.1/30
+  ipv6 address 2001:db8:3:31::1/64
+  no shut
+
+# Interfaces to spine2 (leaf2-eth32 to leaf2-eth63)
+int leaf2-eth32
+  ip addr 10.4.0.1/30
+  ipv6 address 2001:db8:4:0::1/64
+  no shut
+int leaf2-eth33
+  ip addr 10.4.1.1/30
+  ipv6 address 2001:db8:4:1::1/64
+  no shut
+int leaf2-eth34
+  ip addr 10.4.2.1/30
+  ipv6 address 2001:db8:4:2::1/64
+  no shut
+int leaf2-eth35
+  ip addr 10.4.3.1/30
+  ipv6 address 2001:db8:4:3::1/64
+  no shut
+int leaf2-eth36
+  ip addr 10.4.4.1/30
+  ipv6 address 2001:db8:4:4::1/64
+  no shut
+int leaf2-eth37
+  ip addr 10.4.5.1/30
+  ipv6 address 2001:db8:4:5::1/64
+  no shut
+int leaf2-eth38
+  ip addr 10.4.6.1/30
+  ipv6 address 2001:db8:4:6::1/64
+  no shut
+int leaf2-eth39
+  ip addr 10.4.7.1/30
+  ipv6 address 2001:db8:4:7::1/64
+  no shut
+int leaf2-eth40
+  ip addr 10.4.8.1/30
+  ipv6 address 2001:db8:4:8::1/64
+  no shut
+int leaf2-eth41
+  ip addr 10.4.9.1/30
+  ipv6 address 2001:db8:4:9::1/64
+  no shut
+int leaf2-eth42
+  ip addr 10.4.10.1/30
+  ipv6 address 2001:db8:4:10::1/64
+  no shut
+int leaf2-eth43
+  ip addr 10.4.11.1/30
+  ipv6 address 2001:db8:4:11::1/64
+  no shut
+int leaf2-eth44
+  ip addr 10.4.12.1/30
+  ipv6 address 2001:db8:4:12::1/64
+  no shut
+int leaf2-eth45
+  ip addr 10.4.13.1/30
+  ipv6 address 2001:db8:4:13::1/64
+  no shut
+int leaf2-eth46
+  ip addr 10.4.14.1/30
+  ipv6 address 2001:db8:4:14::1/64
+  no shut
+int leaf2-eth47
+  ip addr 10.4.15.1/30
+  ipv6 address 2001:db8:4:15::1/64
+  no shut
+int leaf2-eth48
+  ip addr 10.4.16.1/30
+  ipv6 address 2001:db8:4:16::1/64
+  no shut
+int leaf2-eth49
+  ip addr 10.4.17.1/30
+  ipv6 address 2001:db8:4:17::1/64
+  no shut
+int leaf2-eth50
+  ip addr 10.4.18.1/30
+  ipv6 address 2001:db8:4:18::1/64
+  no shut
+int leaf2-eth51
+  ip addr 10.4.19.1/30
+  ipv6 address 2001:db8:4:19::1/64
+  no shut
+int leaf2-eth52
+  ip addr 10.4.20.1/30
+  ipv6 address 2001:db8:4:20::1/64
+  no shut
+int leaf2-eth53
+  ip addr 10.4.21.1/30
+  ipv6 address 2001:db8:4:21::1/64
+  no shut
+int leaf2-eth54
+  ip addr 10.4.22.1/30
+  ipv6 address 2001:db8:4:22::1/64
+  no shut
+int leaf2-eth55
+  ip addr 10.4.23.1/30
+  ipv6 address 2001:db8:4:23::1/64
+  no shut
+int leaf2-eth56
+  ip addr 10.4.24.1/30
+  ipv6 address 2001:db8:4:24::1/64
+  no shut
+int leaf2-eth57
+  ip addr 10.4.25.1/30
+  ipv6 address 2001:db8:4:25::1/64
+  no shut
+int leaf2-eth58
+  ip addr 10.4.26.1/30
+  ipv6 address 2001:db8:4:26::1/64
+  no shut
+int leaf2-eth59
+  ip addr 10.4.27.1/30
+  ipv6 address 2001:db8:4:27::1/64
+  no shut
+int leaf2-eth60
+  ip addr 10.4.28.1/30
+  ipv6 address 2001:db8:4:28::1/64
+  no shut
+int leaf2-eth61
+  ip addr 10.4.29.1/30
+  ipv6 address 2001:db8:4:29::1/64
+  no shut
+int leaf2-eth62
+  ip addr 10.4.30.1/30
+  ipv6 address 2001:db8:4:30::1/64
+  no shut
+int leaf2-eth63
+  ip addr 10.4.31.1/30
+  ipv6 address 2001:db8:4:31::1/64
+  no shut
+
+router bgp 65002
+  bgp bestpath as-path multipath-relax
+  bgp router-id 10.0.0.2
+  no bgp ebgp-requires-policy
+  timers bgp 5 60
+  neighbor leaf2-eth0 interface remote-as external
+  neighbor leaf2-eth1 interface remote-as external
+  neighbor leaf2-eth2 interface remote-as external
+  neighbor leaf2-eth3 interface remote-as external
+  neighbor leaf2-eth4 interface remote-as external
+  neighbor leaf2-eth5 interface remote-as external
+  neighbor leaf2-eth6 interface remote-as external
+  neighbor leaf2-eth7 interface remote-as external
+  neighbor leaf2-eth8 interface remote-as external
+  neighbor leaf2-eth9 interface remote-as external
+  neighbor leaf2-eth10 interface remote-as external
+  neighbor leaf2-eth11 interface remote-as external
+  neighbor leaf2-eth12 interface remote-as external
+  neighbor leaf2-eth13 interface remote-as external
+  neighbor leaf2-eth14 interface remote-as external
+  neighbor leaf2-eth15 interface remote-as external
+  neighbor leaf2-eth16 interface remote-as external
+  neighbor leaf2-eth17 interface remote-as external
+  neighbor leaf2-eth18 interface remote-as external
+  neighbor leaf2-eth19 interface remote-as external
+  neighbor leaf2-eth20 interface remote-as external
+  neighbor leaf2-eth21 interface remote-as external
+  neighbor leaf2-eth22 interface remote-as external
+  neighbor leaf2-eth23 interface remote-as external
+  neighbor leaf2-eth24 interface remote-as external
+  neighbor leaf2-eth25 interface remote-as external
+  neighbor leaf2-eth26 interface remote-as external
+  neighbor leaf2-eth27 interface remote-as external
+  neighbor leaf2-eth28 interface remote-as external
+  neighbor leaf2-eth29 interface remote-as external
+  neighbor leaf2-eth30 interface remote-as external
+  neighbor leaf2-eth31 interface remote-as external
+  neighbor leaf2-eth32 interface remote-as external
+  neighbor leaf2-eth33 interface remote-as external
+  neighbor leaf2-eth34 interface remote-as external
+  neighbor leaf2-eth35 interface remote-as external
+  neighbor leaf2-eth36 interface remote-as external
+  neighbor leaf2-eth37 interface remote-as external
+  neighbor leaf2-eth38 interface remote-as external
+  neighbor leaf2-eth39 interface remote-as external
+  neighbor leaf2-eth40 interface remote-as external
+  neighbor leaf2-eth41 interface remote-as external
+  neighbor leaf2-eth42 interface remote-as external
+  neighbor leaf2-eth43 interface remote-as external
+  neighbor leaf2-eth44 interface remote-as external
+  neighbor leaf2-eth45 interface remote-as external
+  neighbor leaf2-eth46 interface remote-as external
+  neighbor leaf2-eth47 interface remote-as external
+  neighbor leaf2-eth48 interface remote-as external
+  neighbor leaf2-eth49 interface remote-as external
+  neighbor leaf2-eth50 interface remote-as external
+  neighbor leaf2-eth51 interface remote-as external
+  neighbor leaf2-eth52 interface remote-as external
+  neighbor leaf2-eth53 interface remote-as external
+  neighbor leaf2-eth54 interface remote-as external
+  neighbor leaf2-eth55 interface remote-as external
+  neighbor leaf2-eth56 interface remote-as external
+  neighbor leaf2-eth57 interface remote-as external
+  neighbor leaf2-eth58 interface remote-as external
+  neighbor leaf2-eth59 interface remote-as external
+  neighbor leaf2-eth60 interface remote-as external
+  neighbor leaf2-eth61 interface remote-as external
+  neighbor leaf2-eth62 interface remote-as external
+  neighbor leaf2-eth63 interface remote-as external
+
+ address-family ipv4 uni
+  redistribute sharp
+  neighbor leaf2-eth0 route-map wcmp out
+  neighbor leaf2-eth1 route-map wcmp out
+  neighbor leaf2-eth2 route-map wcmp out
+  neighbor leaf2-eth3 route-map wcmp out
+  neighbor leaf2-eth4 route-map wcmp out
+  neighbor leaf2-eth5 route-map wcmp out
+  neighbor leaf2-eth6 route-map wcmp out
+  neighbor leaf2-eth7 route-map wcmp out
+  neighbor leaf2-eth8 route-map wcmp out
+  neighbor leaf2-eth9 route-map wcmp out
+  neighbor leaf2-eth10 route-map wcmp out
+  neighbor leaf2-eth11 route-map wcmp out
+  neighbor leaf2-eth12 route-map wcmp out
+  neighbor leaf2-eth13 route-map wcmp out
+  neighbor leaf2-eth14 route-map wcmp out
+  neighbor leaf2-eth15 route-map wcmp out
+  neighbor leaf2-eth16 route-map wcmp out
+  neighbor leaf2-eth17 route-map wcmp out
+  neighbor leaf2-eth18 route-map wcmp out
+  neighbor leaf2-eth19 route-map wcmp out
+  neighbor leaf2-eth20 route-map wcmp out
+  neighbor leaf2-eth21 route-map wcmp out
+  neighbor leaf2-eth22 route-map wcmp out
+  neighbor leaf2-eth23 route-map wcmp out
+  neighbor leaf2-eth24 route-map wcmp out
+  neighbor leaf2-eth25 route-map wcmp out
+  neighbor leaf2-eth26 route-map wcmp out
+  neighbor leaf2-eth27 route-map wcmp out
+  neighbor leaf2-eth28 route-map wcmp out
+  neighbor leaf2-eth29 route-map wcmp out
+  neighbor leaf2-eth30 route-map wcmp out
+  neighbor leaf2-eth31 route-map wcmp out
+  neighbor leaf2-eth32 route-map wcmp out
+  neighbor leaf2-eth33 route-map wcmp out
+  neighbor leaf2-eth34 route-map wcmp out
+  neighbor leaf2-eth35 route-map wcmp out
+  neighbor leaf2-eth36 route-map wcmp out
+  neighbor leaf2-eth37 route-map wcmp out
+  neighbor leaf2-eth38 route-map wcmp out
+  neighbor leaf2-eth39 route-map wcmp out
+  neighbor leaf2-eth40 route-map wcmp out
+  neighbor leaf2-eth41 route-map wcmp out
+  neighbor leaf2-eth42 route-map wcmp out
+  neighbor leaf2-eth43 route-map wcmp out
+  neighbor leaf2-eth44 route-map wcmp out
+  neighbor leaf2-eth45 route-map wcmp out
+  neighbor leaf2-eth46 route-map wcmp out
+  neighbor leaf2-eth47 route-map wcmp out
+  neighbor leaf2-eth48 route-map wcmp out
+  neighbor leaf2-eth49 route-map wcmp out
+  neighbor leaf2-eth50 route-map wcmp out
+  neighbor leaf2-eth51 route-map wcmp out
+  neighbor leaf2-eth52 route-map wcmp out
+  neighbor leaf2-eth53 route-map wcmp out
+  neighbor leaf2-eth54 route-map wcmp out
+  neighbor leaf2-eth55 route-map wcmp out
+  neighbor leaf2-eth56 route-map wcmp out
+  neighbor leaf2-eth57 route-map wcmp out
+  neighbor leaf2-eth58 route-map wcmp out
+  neighbor leaf2-eth59 route-map wcmp out
+  neighbor leaf2-eth60 route-map wcmp out
+  neighbor leaf2-eth61 route-map wcmp out
+  neighbor leaf2-eth62 route-map wcmp out
+  neighbor leaf2-eth63 route-map wcmp out
+ exit

--- a/tests/topotests/two_layer_wucmp/spine1/frr.conf
+++ b/tests/topotests/two_layer_wucmp/spine1/frr.conf
@@ -1,0 +1,404 @@
+int lo
+  ip addr 10.0.0.3/32
+
+route-map w-ecmp-cumulative permit 10
+ set extcommunity bandwidth cumulative
+
+# Interfaces to leaf1 (spine1-eth0 to spine1-eth31)
+int spine1-eth0
+  ip addr 10.1.0.2/30
+  ipv6 address 2001:db8:1:0::2/64
+  no shut
+int spine1-eth1
+  ip addr 10.1.1.2/30
+  ipv6 address 2001:db8:1:1::2/64
+  no shut
+int spine1-eth2
+  ip addr 10.1.2.2/30
+  ipv6 address 2001:db8:1:2::2/64
+  no shut
+int spine1-eth3
+  ip addr 10.1.3.2/30
+  ipv6 address 2001:db8:1:3::2/64
+  no shut
+int spine1-eth4
+  ip addr 10.1.4.2/30
+  ipv6 address 2001:db8:1:4::2/64
+  no shut
+int spine1-eth5
+  ip addr 10.1.5.2/30
+  ipv6 address 2001:db8:1:5::2/64
+  no shut
+int spine1-eth6
+  ip addr 10.1.6.2/30
+  ipv6 address 2001:db8:1:6::2/64
+  no shut
+int spine1-eth7
+  ip addr 10.1.7.2/30
+  ipv6 address 2001:db8:1:7::2/64
+  no shut
+int spine1-eth8
+  ip addr 10.1.8.2/30
+  ipv6 address 2001:db8:1:8::2/64
+  no shut
+int spine1-eth9
+  ip addr 10.1.9.2/30
+  ipv6 address 2001:db8:1:9::2/64
+  no shut
+int spine1-eth10
+  ip addr 10.1.10.2/30
+  ipv6 address 2001:db8:1:10::2/64
+  no shut
+int spine1-eth11
+  ip addr 10.1.11.2/30
+  ipv6 address 2001:db8:1:11::2/64
+  no shut
+int spine1-eth12
+  ip addr 10.1.12.2/30
+  ipv6 address 2001:db8:1:12::2/64
+  no shut
+int spine1-eth13
+  ip addr 10.1.13.2/30
+  ipv6 address 2001:db8:1:13::2/64
+  no shut
+int spine1-eth14
+  ip addr 10.1.14.2/30
+  ipv6 address 2001:db8:1:14::2/64
+  no shut
+int spine1-eth15
+  ip addr 10.1.15.2/30
+  ipv6 address 2001:db8:1:15::2/64
+  no shut
+int spine1-eth16
+  ip addr 10.1.16.2/30
+  ipv6 address 2001:db8:1:16::2/64
+  no shut
+int spine1-eth17
+  ip addr 10.1.17.2/30
+  ipv6 address 2001:db8:1:17::2/64
+  no shut
+int spine1-eth18
+  ip addr 10.1.18.2/30
+  ipv6 address 2001:db8:1:18::2/64
+  no shut
+int spine1-eth19
+  ip addr 10.1.19.2/30
+  ipv6 address 2001:db8:1:19::2/64
+  no shut
+int spine1-eth20
+  ip addr 10.1.20.2/30
+  ipv6 address 2001:db8:1:20::2/64
+  no shut
+int spine1-eth21
+  ip addr 10.1.21.2/30
+  ipv6 address 2001:db8:1:21::2/64
+  no shut
+int spine1-eth22
+  ip addr 10.1.22.2/30
+  ipv6 address 2001:db8:1:22::2/64
+  no shut
+int spine1-eth23
+  ip addr 10.1.23.2/30
+  ipv6 address 2001:db8:1:23::2/64
+  no shut
+int spine1-eth24
+  ip addr 10.1.24.2/30
+  ipv6 address 2001:db8:1:24::2/64
+  no shut
+int spine1-eth25
+  ip addr 10.1.25.2/30
+  ipv6 address 2001:db8:1:25::2/64
+  no shut
+int spine1-eth26
+  ip addr 10.1.26.2/30
+  ipv6 address 2001:db8:1:26::2/64
+  no shut
+int spine1-eth27
+  ip addr 10.1.27.2/30
+  ipv6 address 2001:db8:1:27::2/64
+  no shut
+int spine1-eth28
+  ip addr 10.1.28.2/30
+  ipv6 address 2001:db8:1:28::2/64
+  no shut
+int spine1-eth29
+  ip addr 10.1.29.2/30
+  ipv6 address 2001:db8:1:29::2/64
+  no shut
+int spine1-eth30
+  ip addr 10.1.30.2/30
+  ipv6 address 2001:db8:1:30::2/64
+  no shut
+int spine1-eth31
+  ip addr 10.1.31.2/30
+  ipv6 address 2001:db8:1:31::2/64
+  no shut
+
+# Interfaces to leaf2 (spine1-eth32 to spine1-eth63)
+int spine1-eth32
+  ip addr 10.3.0.2/30
+  ipv6 address 2001:db8:3:0::2/64
+  no shut
+int spine1-eth33
+  ip addr 10.3.1.2/30
+  ipv6 address 2001:db8:3:1::2/64
+  no shut
+int spine1-eth34
+  ip addr 10.3.2.2/30
+  ipv6 address 2001:db8:3:2::2/64
+  no shut
+int spine1-eth35
+  ip addr 10.3.3.2/30
+  ipv6 address 2001:db8:3:3::2/64
+  no shut
+int spine1-eth36
+  ip addr 10.3.4.2/30
+  ipv6 address 2001:db8:3:4::2/64
+  no shut
+int spine1-eth37
+  ip addr 10.3.5.2/30
+  ipv6 address 2001:db8:3:5::2/64
+  no shut
+int spine1-eth38
+  ip addr 10.3.6.2/30
+  ipv6 address 2001:db8:3:6::2/64
+  no shut
+int spine1-eth39
+  ip addr 10.3.7.2/30
+  ipv6 address 2001:db8:3:7::2/64
+  no shut
+int spine1-eth40
+  ip addr 10.3.8.2/30
+  ipv6 address 2001:db8:3:8::2/64
+  no shut
+int spine1-eth41
+  ip addr 10.3.9.2/30
+  ipv6 address 2001:db8:3:9::2/64
+  no shut
+int spine1-eth42
+  ip addr 10.3.10.2/30
+  ipv6 address 2001:db8:3:10::2/64
+  no shut
+int spine1-eth43
+  ip addr 10.3.11.2/30
+  ipv6 address 2001:db8:3:11::2/64
+  no shut
+int spine1-eth44
+  ip addr 10.3.12.2/30
+  ipv6 address 2001:db8:3:12::2/64
+  no shut
+int spine1-eth45
+  ip addr 10.3.13.2/30
+  ipv6 address 2001:db8:3:13::2/64
+  no shut
+int spine1-eth46
+  ip addr 10.3.14.2/30
+  ipv6 address 2001:db8:3:14::2/64
+  no shut
+int spine1-eth47
+  ip addr 10.3.15.2/30
+  ipv6 address 2001:db8:3:15::2/64
+  no shut
+int spine1-eth48
+  ip addr 10.3.16.2/30
+  ipv6 address 2001:db8:3:16::2/64
+  no shut
+int spine1-eth49
+  ip addr 10.3.17.2/30
+  ipv6 address 2001:db8:3:17::2/64
+  no shut
+int spine1-eth50
+  ip addr 10.3.18.2/30
+  ipv6 address 2001:db8:3:18::2/64
+  no shut
+int spine1-eth51
+  ip addr 10.3.19.2/30
+  ipv6 address 2001:db8:3:19::2/64
+  no shut
+int spine1-eth52
+  ip addr 10.3.20.2/30
+  ipv6 address 2001:db8:3:20::2/64
+  no shut
+int spine1-eth53
+  ip addr 10.3.21.2/30
+  ipv6 address 2001:db8:3:21::2/64
+  no shut
+int spine1-eth54
+  ip addr 10.3.22.2/30
+  ipv6 address 2001:db8:3:22::2/64
+  no shut
+int spine1-eth55
+  ip addr 10.3.23.2/30
+  ipv6 address 2001:db8:3:23::2/64
+  no shut
+int spine1-eth56
+  ip addr 10.3.24.2/30
+  ipv6 address 2001:db8:3:24::2/64
+  no shut
+int spine1-eth57
+  ip addr 10.3.25.2/30
+  ipv6 address 2001:db8:3:25::2/64
+  no shut
+int spine1-eth58
+  ip addr 10.3.26.2/30
+  ipv6 address 2001:db8:3:26::2/64
+  no shut
+int spine1-eth59
+  ip addr 10.3.27.2/30
+  ipv6 address 2001:db8:3:27::2/64
+  no shut
+int spine1-eth60
+  ip addr 10.3.28.2/30
+  ipv6 address 2001:db8:3:28::2/64
+  no shut
+int spine1-eth61
+  ip addr 10.3.29.2/30
+  ipv6 address 2001:db8:3:29::2/64
+  no shut
+int spine1-eth62
+  ip addr 10.3.30.2/30
+  ipv6 address 2001:db8:3:30::2/64
+  no shut
+int spine1-eth63
+  ip addr 10.3.31.2/30
+  ipv6 address 2001:db8:3:31::2/64
+  no shut
+
+router bgp 65100
+  bgp bestpath as-path multipath-relax
+  no bgp ebgp-requires-policy
+  timers bgp 5 60
+  bgp router-id 10.0.0.3
+  neighbor spine1-eth0 interface remote-as external
+  neighbor spine1-eth1 interface remote-as external
+  neighbor spine1-eth2 interface remote-as external
+  neighbor spine1-eth3 interface remote-as external
+  neighbor spine1-eth4 interface remote-as external
+  neighbor spine1-eth5 interface remote-as external
+  neighbor spine1-eth6 interface remote-as external
+  neighbor spine1-eth7 interface remote-as external
+  neighbor spine1-eth8 interface remote-as external
+  neighbor spine1-eth9 interface remote-as external
+  neighbor spine1-eth10 interface remote-as external
+  neighbor spine1-eth11 interface remote-as external
+  neighbor spine1-eth12 interface remote-as external
+  neighbor spine1-eth13 interface remote-as external
+  neighbor spine1-eth14 interface remote-as external
+  neighbor spine1-eth15 interface remote-as external
+  neighbor spine1-eth16 interface remote-as external
+  neighbor spine1-eth17 interface remote-as external
+  neighbor spine1-eth18 interface remote-as external
+  neighbor spine1-eth19 interface remote-as external
+  neighbor spine1-eth20 interface remote-as external
+  neighbor spine1-eth21 interface remote-as external
+  neighbor spine1-eth22 interface remote-as external
+  neighbor spine1-eth23 interface remote-as external
+  neighbor spine1-eth24 interface remote-as external
+  neighbor spine1-eth25 interface remote-as external
+  neighbor spine1-eth26 interface remote-as external
+  neighbor spine1-eth27 interface remote-as external
+  neighbor spine1-eth28 interface remote-as external
+  neighbor spine1-eth29 interface remote-as external
+  neighbor spine1-eth30 interface remote-as external
+  neighbor spine1-eth31 interface remote-as external
+  neighbor spine1-eth32 interface remote-as external
+  neighbor spine1-eth33 interface remote-as external
+  neighbor spine1-eth34 interface remote-as external
+  neighbor spine1-eth35 interface remote-as external
+  neighbor spine1-eth36 interface remote-as external
+  neighbor spine1-eth37 interface remote-as external
+  neighbor spine1-eth38 interface remote-as external
+  neighbor spine1-eth39 interface remote-as external
+  neighbor spine1-eth40 interface remote-as external
+  neighbor spine1-eth41 interface remote-as external
+  neighbor spine1-eth42 interface remote-as external
+  neighbor spine1-eth43 interface remote-as external
+  neighbor spine1-eth44 interface remote-as external
+  neighbor spine1-eth45 interface remote-as external
+  neighbor spine1-eth46 interface remote-as external
+  neighbor spine1-eth47 interface remote-as external
+  neighbor spine1-eth48 interface remote-as external
+  neighbor spine1-eth49 interface remote-as external
+  neighbor spine1-eth50 interface remote-as external
+  neighbor spine1-eth51 interface remote-as external
+  neighbor spine1-eth52 interface remote-as external
+  neighbor spine1-eth53 interface remote-as external
+  neighbor spine1-eth54 interface remote-as external
+  neighbor spine1-eth55 interface remote-as external
+  neighbor spine1-eth56 interface remote-as external
+  neighbor spine1-eth57 interface remote-as external
+  neighbor spine1-eth58 interface remote-as external
+  neighbor spine1-eth59 interface remote-as external
+  neighbor spine1-eth60 interface remote-as external
+  neighbor spine1-eth61 interface remote-as external
+  neighbor spine1-eth62 interface remote-as external
+  neighbor spine1-eth63 interface remote-as external
+ address-family ipv4 uni
+  neighbor spine1-eth0 route-map w-ecmp-cumulative out
+  neighbor spine1-eth1 route-map w-ecmp-cumulative out
+  neighbor spine1-eth2 route-map w-ecmp-cumulative out
+  neighbor spine1-eth3 route-map w-ecmp-cumulative out
+  neighbor spine1-eth4 route-map w-ecmp-cumulative out
+  neighbor spine1-eth5 route-map w-ecmp-cumulative out
+  neighbor spine1-eth6 route-map w-ecmp-cumulative out
+  neighbor spine1-eth7 route-map w-ecmp-cumulative out
+  neighbor spine1-eth8 route-map w-ecmp-cumulative out
+  neighbor spine1-eth9 route-map w-ecmp-cumulative out
+  neighbor spine1-eth10 route-map w-ecmp-cumulative out
+  neighbor spine1-eth11 route-map w-ecmp-cumulative out
+  neighbor spine1-eth12 route-map w-ecmp-cumulative out
+  neighbor spine1-eth13 route-map w-ecmp-cumulative out
+  neighbor spine1-eth14 route-map w-ecmp-cumulative out
+  neighbor spine1-eth15 route-map w-ecmp-cumulative out
+  neighbor spine1-eth16 route-map w-ecmp-cumulative out
+  neighbor spine1-eth17 route-map w-ecmp-cumulative out
+  neighbor spine1-eth18 route-map w-ecmp-cumulative out
+  neighbor spine1-eth19 route-map w-ecmp-cumulative out
+  neighbor spine1-eth20 route-map w-ecmp-cumulative out
+  neighbor spine1-eth21 route-map w-ecmp-cumulative out
+  neighbor spine1-eth22 route-map w-ecmp-cumulative out
+  neighbor spine1-eth23 route-map w-ecmp-cumulative out
+  neighbor spine1-eth24 route-map w-ecmp-cumulative out
+  neighbor spine1-eth25 route-map w-ecmp-cumulative out
+  neighbor spine1-eth26 route-map w-ecmp-cumulative out
+  neighbor spine1-eth27 route-map w-ecmp-cumulative out
+  neighbor spine1-eth28 route-map w-ecmp-cumulative out
+  neighbor spine1-eth29 route-map w-ecmp-cumulative out
+  neighbor spine1-eth30 route-map w-ecmp-cumulative out
+  neighbor spine1-eth31 route-map w-ecmp-cumulative out
+  neighbor spine1-eth32 route-map w-ecmp-cumulative out
+  neighbor spine1-eth33 route-map w-ecmp-cumulative out
+  neighbor spine1-eth34 route-map w-ecmp-cumulative out
+  neighbor spine1-eth35 route-map w-ecmp-cumulative out
+  neighbor spine1-eth36 route-map w-ecmp-cumulative out
+  neighbor spine1-eth37 route-map w-ecmp-cumulative out
+  neighbor spine1-eth38 route-map w-ecmp-cumulative out
+  neighbor spine1-eth39 route-map w-ecmp-cumulative out
+  neighbor spine1-eth40 route-map w-ecmp-cumulative out
+  neighbor spine1-eth41 route-map w-ecmp-cumulative out
+  neighbor spine1-eth42 route-map w-ecmp-cumulative out
+  neighbor spine1-eth43 route-map w-ecmp-cumulative out
+  neighbor spine1-eth44 route-map w-ecmp-cumulative out
+  neighbor spine1-eth45 route-map w-ecmp-cumulative out
+  neighbor spine1-eth46 route-map w-ecmp-cumulative out
+  neighbor spine1-eth47 route-map w-ecmp-cumulative out
+  neighbor spine1-eth48 route-map w-ecmp-cumulative out
+  neighbor spine1-eth49 route-map w-ecmp-cumulative out
+  neighbor spine1-eth50 route-map w-ecmp-cumulative out
+  neighbor spine1-eth51 route-map w-ecmp-cumulative out
+  neighbor spine1-eth52 route-map w-ecmp-cumulative out
+  neighbor spine1-eth53 route-map w-ecmp-cumulative out
+  neighbor spine1-eth54 route-map w-ecmp-cumulative out
+  neighbor spine1-eth55 route-map w-ecmp-cumulative out
+  neighbor spine1-eth56 route-map w-ecmp-cumulative out
+  neighbor spine1-eth57 route-map w-ecmp-cumulative out
+  neighbor spine1-eth58 route-map w-ecmp-cumulative out
+  neighbor spine1-eth59 route-map w-ecmp-cumulative out
+  neighbor spine1-eth60 route-map w-ecmp-cumulative out
+  neighbor spine1-eth61 route-map w-ecmp-cumulative out
+  neighbor spine1-eth62 route-map w-ecmp-cumulative out
+  neighbor spine1-eth63 route-map w-ecmp-cumulative out
+ exit
+ !
+ 
+!

--- a/tests/topotests/two_layer_wucmp/spine2/frr.conf
+++ b/tests/topotests/two_layer_wucmp/spine2/frr.conf
@@ -1,0 +1,405 @@
+int lo
+  ip addr 10.0.0.4/32
+
+route-map w-ecmp-cumulative permit 10
+ set extcommunity bandwidth cumulative
+
+# Interfaces to leaf1 (spine2-eth0 to spine2-eth31)
+int spine2-eth0
+  ip addr 10.2.0.2/30
+  ipv6 address 2001:db8:2:0::2/64
+  no shut
+int spine2-eth1
+  ip addr 10.2.1.2/30
+  ipv6 address 2001:db8:2:1::2/64
+  no shut
+int spine2-eth2
+  ip addr 10.2.2.2/30
+  ipv6 address 2001:db8:2:2::2/64
+  no shut
+int spine2-eth3
+  ip addr 10.2.3.2/30
+  ipv6 address 2001:db8:2:3::2/64
+  no shut
+int spine2-eth4
+  ip addr 10.2.4.2/30
+  ipv6 address 2001:db8:2:4::2/64
+  no shut
+int spine2-eth5
+  ip addr 10.2.5.2/30
+  ipv6 address 2001:db8:2:5::2/64
+  no shut
+int spine2-eth6
+  ip addr 10.2.6.2/30
+  ipv6 address 2001:db8:2:6::2/64
+  no shut
+int spine2-eth7
+  ip addr 10.2.7.2/30
+  ipv6 address 2001:db8:2:7::2/64
+  no shut
+int spine2-eth8
+  ip addr 10.2.8.2/30
+  ipv6 address 2001:db8:2:8::2/64
+  no shut
+int spine2-eth9
+  ip addr 10.2.9.2/30
+  ipv6 address 2001:db8:2:9::2/64
+  no shut
+int spine2-eth10
+  ip addr 10.2.10.2/30
+  ipv6 address 2001:db8:2:10::2/64
+  no shut
+int spine2-eth11
+  ip addr 10.2.11.2/30
+  ipv6 address 2001:db8:2:11::2/64
+  no shut
+int spine2-eth12
+  ip addr 10.2.12.2/30
+  ipv6 address 2001:db8:2:12::2/64
+  no shut
+int spine2-eth13
+  ip addr 10.2.13.2/30
+  ipv6 address 2001:db8:2:13::2/64
+  no shut
+int spine2-eth14
+  ip addr 10.2.14.2/30
+  ipv6 address 2001:db8:2:14::2/64
+  no shut
+int spine2-eth15
+  ip addr 10.2.15.2/30
+  ipv6 address 2001:db8:2:15::2/64
+  no shut
+int spine2-eth16
+  ip addr 10.2.16.2/30
+  ipv6 address 2001:db8:2:16::2/64
+  no shut
+int spine2-eth17
+  ip addr 10.2.17.2/30
+  ipv6 address 2001:db8:2:17::2/64
+  no shut
+int spine2-eth18
+  ip addr 10.2.18.2/30
+  ipv6 address 2001:db8:2:18::2/64
+  no shut
+int spine2-eth19
+  ip addr 10.2.19.2/30
+  ipv6 address 2001:db8:2:19::2/64
+  no shut
+int spine2-eth20
+  ip addr 10.2.20.2/30
+  ipv6 address 2001:db8:2:20::2/64
+  no shut
+int spine2-eth21
+  ip addr 10.2.21.2/30
+  ipv6 address 2001:db8:2:21::2/64
+  no shut
+int spine2-eth22
+  ip addr 10.2.22.2/30
+  ipv6 address 2001:db8:2:22::2/64
+  no shut
+int spine2-eth23
+  ip addr 10.2.23.2/30
+  ipv6 address 2001:db8:2:23::2/64
+  no shut
+int spine2-eth24
+  ip addr 10.2.24.2/30
+  ipv6 address 2001:db8:2:24::2/64
+  no shut
+int spine2-eth25
+  ip addr 10.2.25.2/30
+  ipv6 address 2001:db8:2:25::2/64
+  no shut
+int spine2-eth26
+  ip addr 10.2.26.2/30
+  ipv6 address 2001:db8:2:26::2/64
+  no shut
+int spine2-eth27
+  ip addr 10.2.27.2/30
+  ipv6 address 2001:db8:2:27::2/64
+  no shut
+int spine2-eth28
+  ip addr 10.2.28.2/30
+  ipv6 address 2001:db8:2:28::2/64
+  no shut
+int spine2-eth29
+  ip addr 10.2.29.2/30
+  ipv6 address 2001:db8:2:29::2/64
+  no shut
+int spine2-eth30
+  ip addr 10.2.30.2/30
+  ipv6 address 2001:db8:2:30::2/64
+  no shut
+int spine2-eth31
+  ip addr 10.2.31.2/30
+  ipv6 address 2001:db8:2:31::2/64
+  no shut
+
+# Interfaces to leaf2 (spine2-eth32 to spine2-eth63)
+int spine2-eth32
+  ip addr 10.4.0.2/30
+  ipv6 address 2001:db8:4:0::2/64
+  no shut
+int spine2-eth33
+  ip addr 10.4.1.2/30
+  ipv6 address 2001:db8:4:1::2/64
+  no shut
+int spine2-eth34
+  ip addr 10.4.2.2/30
+  ipv6 address 2001:db8:4:2::2/64
+  no shut
+int spine2-eth35
+  ip addr 10.4.3.2/30
+  ipv6 address 2001:db8:4:3::2/64
+  no shut
+int spine2-eth36
+  ip addr 10.4.4.2/30
+  ipv6 address 2001:db8:4:4::2/64
+  no shut
+int spine2-eth37
+  ip addr 10.4.5.2/30
+  ipv6 address 2001:db8:4:5::2/64
+  no shut
+int spine2-eth38
+  ip addr 10.4.6.2/30
+  ipv6 address 2001:db8:4:6::2/64
+  no shut
+int spine2-eth39
+  ip addr 10.4.7.2/30
+  ipv6 address 2001:db8:4:7::2/64
+  no shut
+int spine2-eth40
+  ip addr 10.4.8.2/30
+  ipv6 address 2001:db8:4:8::2/64
+  no shut
+int spine2-eth41
+  ip addr 10.4.9.2/30
+  ipv6 address 2001:db8:4:9::2/64
+  no shut
+int spine2-eth42
+  ip addr 10.4.10.2/30
+  ipv6 address 2001:db8:4:10::2/64
+  no shut
+int spine2-eth43
+  ip addr 10.4.11.2/30
+  ipv6 address 2001:db8:4:11::2/64
+  no shut
+int spine2-eth44
+  ip addr 10.4.12.2/30
+  ipv6 address 2001:db8:4:12::2/64
+  no shut
+int spine2-eth45
+  ip addr 10.4.13.2/30
+  ipv6 address 2001:db8:4:13::2/64
+  no shut
+int spine2-eth46
+  ip addr 10.4.14.2/30
+  ipv6 address 2001:db8:4:14::2/64
+  no shut
+int spine2-eth47
+  ip addr 10.4.15.2/30
+  ipv6 address 2001:db8:4:15::2/64
+  no shut
+int spine2-eth48
+  ip addr 10.4.16.2/30
+  ipv6 address 2001:db8:4:16::2/64
+  no shut
+int spine2-eth49
+  ip addr 10.4.17.2/30
+  ipv6 address 2001:db8:4:17::2/64
+  no shut
+int spine2-eth50
+  ip addr 10.4.18.2/30
+  ipv6 address 2001:db8:4:18::2/64
+  no shut
+int spine2-eth51
+  ip addr 10.4.19.2/30
+  ipv6 address 2001:db8:4:19::2/64
+  no shut
+int spine2-eth52
+  ip addr 10.4.20.2/30
+  ipv6 address 2001:db8:4:20::2/64
+  no shut
+int spine2-eth53
+  ip addr 10.4.21.2/30
+  ipv6 address 2001:db8:4:21::2/64
+  no shut
+int spine2-eth54
+  ip addr 10.4.22.2/30
+  ipv6 address 2001:db8:4:22::2/64
+  no shut
+int spine2-eth55
+  ip addr 10.4.23.2/30
+  ipv6 address 2001:db8:4:23::2/64
+  no shut
+int spine2-eth56
+  ip addr 10.4.24.2/30
+  ipv6 address 2001:db8:4:24::2/64
+  no shut
+int spine2-eth57
+  ip addr 10.4.25.2/30
+  ipv6 address 2001:db8:4:25::2/64
+  no shut
+int spine2-eth58
+  ip addr 10.4.26.2/30
+  ipv6 address 2001:db8:4:26::2/64
+  no shut
+int spine2-eth59
+  ip addr 10.4.27.2/30
+  ipv6 address 2001:db8:4:27::2/64
+  no shut
+int spine2-eth60
+  ip addr 10.4.28.2/30
+  ipv6 address 2001:db8:4:28::2/64
+  no shut
+int spine2-eth61
+  ip addr 10.4.29.2/30
+  ipv6 address 2001:db8:4:29::2/64
+  no shut
+int spine2-eth62
+  ip addr 10.4.30.2/30
+  ipv6 address 2001:db8:4:30::2/64
+  no shut
+int spine2-eth63
+  ip addr 10.4.31.2/30
+  ipv6 address 2001:db8:4:31::2/64
+  no shut
+
+router bgp 65100
+  bgp bestpath as-path multipath-relax
+  bgp router-id 10.0.0.4
+  no bgp ebgp-requires-policy
+  timers bgp 5 60
+  neighbor spine2-eth0 interface remote-as external
+  neighbor spine2-eth1 interface remote-as external
+  neighbor spine2-eth2 interface remote-as external
+  neighbor spine2-eth3 interface remote-as external
+  neighbor spine2-eth4 interface remote-as external
+  neighbor spine2-eth5 interface remote-as external
+  neighbor spine2-eth6 interface remote-as external
+  neighbor spine2-eth7 interface remote-as external
+  neighbor spine2-eth8 interface remote-as external
+  neighbor spine2-eth9 interface remote-as external
+  neighbor spine2-eth10 interface remote-as external
+  neighbor spine2-eth11 interface remote-as external
+  neighbor spine2-eth12 interface remote-as external
+  neighbor spine2-eth13 interface remote-as external
+  neighbor spine2-eth14 interface remote-as external
+  neighbor spine2-eth15 interface remote-as external
+  neighbor spine2-eth16 interface remote-as external
+  neighbor spine2-eth17 interface remote-as external
+  neighbor spine2-eth18 interface remote-as external
+  neighbor spine2-eth19 interface remote-as external
+  neighbor spine2-eth20 interface remote-as external
+  neighbor spine2-eth21 interface remote-as external
+  neighbor spine2-eth22 interface remote-as external
+  neighbor spine2-eth23 interface remote-as external
+  neighbor spine2-eth24 interface remote-as external
+  neighbor spine2-eth25 interface remote-as external
+  neighbor spine2-eth26 interface remote-as external
+  neighbor spine2-eth27 interface remote-as external
+  neighbor spine2-eth28 interface remote-as external
+  neighbor spine2-eth29 interface remote-as external
+  neighbor spine2-eth30 interface remote-as external
+  neighbor spine2-eth31 interface remote-as external
+  neighbor spine2-eth32 interface remote-as external
+  neighbor spine2-eth33 interface remote-as external
+  neighbor spine2-eth34 interface remote-as external
+  neighbor spine2-eth35 interface remote-as external
+  neighbor spine2-eth36 interface remote-as external
+  neighbor spine2-eth37 interface remote-as external
+  neighbor spine2-eth38 interface remote-as external
+  neighbor spine2-eth39 interface remote-as external
+  neighbor spine2-eth40 interface remote-as external
+  neighbor spine2-eth41 interface remote-as external
+  neighbor spine2-eth42 interface remote-as external
+  neighbor spine2-eth43 interface remote-as external
+  neighbor spine2-eth44 interface remote-as external
+  neighbor spine2-eth45 interface remote-as external
+  neighbor spine2-eth46 interface remote-as external
+  neighbor spine2-eth47 interface remote-as external
+  neighbor spine2-eth48 interface remote-as external
+  neighbor spine2-eth49 interface remote-as external
+  neighbor spine2-eth50 interface remote-as external
+  neighbor spine2-eth51 interface remote-as external
+  neighbor spine2-eth52 interface remote-as external
+  neighbor spine2-eth53 interface remote-as external
+  neighbor spine2-eth54 interface remote-as external
+  neighbor spine2-eth55 interface remote-as external
+  neighbor spine2-eth56 interface remote-as external
+  neighbor spine2-eth57 interface remote-as external
+  neighbor spine2-eth58 interface remote-as external
+  neighbor spine2-eth59 interface remote-as external
+  neighbor spine2-eth60 interface remote-as external
+  neighbor spine2-eth61 interface remote-as external
+  neighbor spine2-eth62 interface remote-as external
+  neighbor spine2-eth63 interface remote-as external
+
+ address-family ipv4 uni
+  neighbor spine2-eth0 route-map w-ecmp-cumulative out
+  neighbor spine2-eth1 route-map w-ecmp-cumulative out
+  neighbor spine2-eth2 route-map w-ecmp-cumulative out
+  neighbor spine2-eth3 route-map w-ecmp-cumulative out
+  neighbor spine2-eth4 route-map w-ecmp-cumulative out
+  neighbor spine2-eth5 route-map w-ecmp-cumulative out
+  neighbor spine2-eth6 route-map w-ecmp-cumulative out
+  neighbor spine2-eth7 route-map w-ecmp-cumulative out
+  neighbor spine2-eth8 route-map w-ecmp-cumulative out
+  neighbor spine2-eth9 route-map w-ecmp-cumulative out
+  neighbor spine2-eth10 route-map w-ecmp-cumulative out
+  neighbor spine2-eth11 route-map w-ecmp-cumulative out
+  neighbor spine2-eth12 route-map w-ecmp-cumulative out
+  neighbor spine2-eth13 route-map w-ecmp-cumulative out
+  neighbor spine2-eth14 route-map w-ecmp-cumulative out
+  neighbor spine2-eth15 route-map w-ecmp-cumulative out
+  neighbor spine2-eth16 route-map w-ecmp-cumulative out
+  neighbor spine2-eth17 route-map w-ecmp-cumulative out
+  neighbor spine2-eth18 route-map w-ecmp-cumulative out
+  neighbor spine2-eth19 route-map w-ecmp-cumulative out
+  neighbor spine2-eth20 route-map w-ecmp-cumulative out
+  neighbor spine2-eth21 route-map w-ecmp-cumulative out
+  neighbor spine2-eth22 route-map w-ecmp-cumulative out
+  neighbor spine2-eth23 route-map w-ecmp-cumulative out
+  neighbor spine2-eth24 route-map w-ecmp-cumulative out
+  neighbor spine2-eth25 route-map w-ecmp-cumulative out
+  neighbor spine2-eth26 route-map w-ecmp-cumulative out
+  neighbor spine2-eth27 route-map w-ecmp-cumulative out
+  neighbor spine2-eth28 route-map w-ecmp-cumulative out
+  neighbor spine2-eth29 route-map w-ecmp-cumulative out
+  neighbor spine2-eth30 route-map w-ecmp-cumulative out
+  neighbor spine2-eth31 route-map w-ecmp-cumulative out
+  neighbor spine2-eth32 route-map w-ecmp-cumulative out
+  neighbor spine2-eth33 route-map w-ecmp-cumulative out
+  neighbor spine2-eth34 route-map w-ecmp-cumulative out
+  neighbor spine2-eth35 route-map w-ecmp-cumulative out
+  neighbor spine2-eth36 route-map w-ecmp-cumulative out
+  neighbor spine2-eth37 route-map w-ecmp-cumulative out
+  neighbor spine2-eth38 route-map w-ecmp-cumulative out
+  neighbor spine2-eth39 route-map w-ecmp-cumulative out
+  neighbor spine2-eth40 route-map w-ecmp-cumulative out
+  neighbor spine2-eth41 route-map w-ecmp-cumulative out
+  neighbor spine2-eth42 route-map w-ecmp-cumulative out
+  neighbor spine2-eth43 route-map w-ecmp-cumulative out
+  neighbor spine2-eth44 route-map w-ecmp-cumulative out
+  neighbor spine2-eth45 route-map w-ecmp-cumulative out
+  neighbor spine2-eth46 route-map w-ecmp-cumulative out
+  neighbor spine2-eth47 route-map w-ecmp-cumulative out
+  neighbor spine2-eth48 route-map w-ecmp-cumulative out
+  neighbor spine2-eth49 route-map w-ecmp-cumulative out
+  neighbor spine2-eth50 route-map w-ecmp-cumulative out
+  neighbor spine2-eth51 route-map w-ecmp-cumulative out
+  neighbor spine2-eth52 route-map w-ecmp-cumulative out
+  neighbor spine2-eth53 route-map w-ecmp-cumulative out
+  neighbor spine2-eth54 route-map w-ecmp-cumulative out
+  neighbor spine2-eth55 route-map w-ecmp-cumulative out
+  neighbor spine2-eth56 route-map w-ecmp-cumulative out
+  neighbor spine2-eth57 route-map w-ecmp-cumulative out
+  neighbor spine2-eth58 route-map w-ecmp-cumulative out
+  neighbor spine2-eth59 route-map w-ecmp-cumulative out
+  neighbor spine2-eth60 route-map w-ecmp-cumulative out
+  neighbor spine2-eth61 route-map w-ecmp-cumulative out
+  neighbor spine2-eth62 route-map w-ecmp-cumulative out
+  neighbor spine2-eth63 route-map w-ecmp-cumulative out
+ exit
+
+!
+

--- a/tests/topotests/two_layer_wucmp/test_two_layer_wuecmp.py
+++ b/tests/topotests/two_layer_wucmp/test_two_layer_wuecmp.py
@@ -1,0 +1,776 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# test_two_layer_wuecmp.py
+#
+# Copyright (c) 2025 by
+# Nvidia Corporation
+# Karthikeya Venkat Muppalla <kmuppalla@nvidia.com>
+#
+
+import os
+import sys
+import json
+import re
+from functools import partial
+import pytest
+import re
+import tempfile
+import time
+import logging
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from lib.bgp import verify_bgp_convergence, verify_bgp_convergence_from_running_config
+from lib.common_config import step
+
+
+"""
+test_nexthop_group_wecmp.py: Test nexthop group behavior with WECMP (Weighted ECMP) 
+in a high-density CLOS topology with many parallel links.
+"""
+
+TOPOLOGY = """
+High-density 2-layer CLOS topology with:
+- Spines (2): spine1 (AS 65100), spine2 (AS 65100)
+- Leafs (2): leaf1 (AS 65001), leaf2 (AS 65002)
+
+Each leaf connects to each spine with 32 parallel links:
+- leaf1 <-> spine1: 32 links (leaf1-eth0 to leaf1-eth31)
+- leaf1 <-> spine2: 32 links (leaf1-eth32 to leaf1-eth63)
+- leaf2 <-> spine1: 32 links (leaf2-eth0 to leaf2-eth31)
+- leaf2 <-> spine2: 32 links (leaf2-eth32 to leaf2-eth63)
+
+Routes are injected via sharpd on leaf2 and redistributed via BGP.
+This topology tests nexthop group (NHG) stability with W-ECMP during link state changes:
+
+Test scenarios:
+
+Single link down:
+- Trigger: 1 link down (leaf1-eth0)
+- Expectation: Link nexthop in that NHID is marked inactive, NHID is retained and not 
+  marked for deletion, routes continue pointing to the same NHID, no new NHID is created,
+  no per-route programming occurs since NHID did not change, ECMP adjusts to 63 paths
+
+Single link up:
+- Trigger: 1 link up (leaf1-eth0) 
+- Expectation: Link nexthop in that NHID is marked active, NHID is retained, routes
+  continue pointing to the same NHID, no new NHID is created, no per-route programming
+  occurs since NHID did not change, ECMP adjusts back to 64 paths
+
+16 out of 32 links towards spine1 down:
+- Trigger: 16 out of 32 links to spine1 down (leaf1-eth0 to leaf1-eth15)
+- Expectation: 16 link nexthops in that NHID are marked inactive, NHID is retained and
+  not marked for deletion, routes continue pointing to the same NHID, no new NHID is
+  created, no per-route programming occurs since NHID did not change, W-ECMP adjusts to 48 paths
+
+16 out of 32 links towards spine1 up:
+- Trigger: 16 out of 32 links to spine1 up (leaf1-eth0 to leaf1-eth15)
+- Expectation: 16 link nexthops in that NHID are marked active, NHID is retained, routes
+  continue pointing to the same NHID, no new NHID is created, no per-route programming
+  occurs since NHID did not change, W-ECMP adjusts back to 64 paths
+
+Key expectation: No new NHID should be created during local link state changes. Instead,
+only the ECMP nexthop paths within the existing NHG should be updated. Since the
+NHID remains unchanged, all routes continue pointing to the same NHID and no route
+reprogramming occurs - avoiding unnecessary dataplane churn.
+
+This addresses weight mismatch issues in dependent NHGs where link state changes
+previously caused unnecessary NHG deletion/recreation, triggering expensive route
+reprogramming and potential forwarding disruptions in high-density CLOS topologies.
+"""
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# Required to instantiate the topology builder class.
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.sharpd]
+
+# Constants
+LINKS_PER_SPINE = 32  # 32 links between each leaf and each spine
+TOTAL_LINKS_PER_LEAF = LINKS_PER_SPINE * 2  # 64 total links per leaf
+
+# Global variables to store state between tests
+INITIAL_NHG_ID = None
+INITIAL_BGP_ROUTES_COUNT = 0
+
+logger = logging.getLogger(__name__)
+
+def verify_nhg_and_routes(net, description="", expected_ecmp_paths=None, show_detailed_rib=False):
+    """Focused verification of NHG stability for 39.99.x routes only"""
+    logger.info(f"=== NHG STABILITY CHECK {description} ===")
+    
+    # 1. Count all 39.99 routes with nhid in kernel (should be 1000)
+    total_nhid_routes = net["leaf1"].cmd('ip route show | grep nhid | grep "39\\.99" | wc -l').strip()
+    
+    # 2. Get unique NHIDs used by 39.99 routes (should be only 1)
+    unique_nhids_output = net["leaf1"].cmd('ip route show | grep nhid | grep "39\\.99" | awk \'{for(i=1;i<=NF;i++) if($i=="nhid") print $(i+1)}\' | sort | uniq')
+    unique_nhids = [nhid.strip() for nhid in unique_nhids_output.split('\n') if nhid.strip()]
+    
+    # 3. Verify only one NHID is used
+    if len(unique_nhids) == 1:
+        primary_nhid = unique_nhids[0]
+        logger.info(f" All 1000 routes use same NHID: {primary_nhid}")
+    else:
+        logger.info(f" FAILURE: Multiple NHIDs found: {unique_nhids}")
+        primary_nhid = unique_nhids[0] if unique_nhids else None
+        
+    # 4. Verify route count
+    expected_routes = 1000
+    route_count = int(total_nhid_routes) if total_nhid_routes.isdigit() else 0
+    if route_count == expected_routes:
+        logger.info(f" Route count correct: {route_count}")
+    else:
+        logger.info(f" Route count mismatch: {route_count}/{expected_routes}")
+    
+    # 5. Analyze ONLY the NHG used by 39.99.x routes
+    if primary_nhid:
+        logger.info(f"Analyzing NHID {primary_nhid} (used by 39.99.x routes):")
+        
+        # Get NHG details from RIB
+        rib_output = net["leaf1"].cmd(f'vtysh -c "show nexthop-group rib {primary_nhid}"')
+        
+        # Extract key information
+        import re
+        refcnt_match = re.search(r'RefCnt: (\d+)', rib_output)
+        refcnt = int(refcnt_match.group(1)) if refcnt_match else 0
+        
+        # Count active ECMP paths
+        ecmp_count = net["leaf1"].cmd(f'vtysh -c "show nexthop-group rib {primary_nhid}" | grep "via" | grep -v "inactive" | wc -l').strip()
+        total_ecmp_paths = int(ecmp_count) if ecmp_count.isdigit() else 0
+        
+        # Count paths via each spine
+        spine1_paths = net["leaf1"].cmd(f'vtysh -c "show nexthop-group rib {primary_nhid}" | grep "via" | grep -v "inactive" | grep "10\\.1\\." | wc -l').strip()
+        spine2_paths = net["leaf1"].cmd(f'vtysh -c "show nexthop-group rib {primary_nhid}" | grep "via" | grep -v "inactive" | grep "10\\.2\\." | wc -l').strip()
+        
+        spine1_count = int(spine1_paths) if spine1_paths.isdigit() else 0
+        spine2_count = int(spine2_paths) if spine2_paths.isdigit() else 0
+        
+        logger.info(f"  - Active ECMP paths: {total_ecmp_paths}")
+        logger.info(f"  - Paths via spine1: {spine1_count}")
+        logger.info(f"  - Paths via spine2: {spine2_count}")
+        
+        # Use context-aware expected ECMP paths (default to 64 if not specified)
+        if expected_ecmp_paths is None:
+            expected_ecmp_paths = 64
+            
+        if total_ecmp_paths == expected_ecmp_paths:
+            logger.info(f"✓ ECMP structure correct: {total_ecmp_paths}/{expected_ecmp_paths} paths")
+        else:
+            logger.info(f"✗ ECMP structure incorrect: {total_ecmp_paths}/{expected_ecmp_paths} paths")
+            
+        # Show detailed RIB output if requested
+        if show_detailed_rib:
+            logger.info(f"=== DETAILED NHG ANALYSIS FOR NHID {primary_nhid} ===")
+            
+            # 1. FRR RIB view
+            logger.info(f"FRR RIB view (show nexthop-group rib {primary_nhid}):")
+            logger.info(f"{rib_output}")
+            
+            # 2. Kernel NHG view
+            logger.info(f"Kernel NHG view (ip nexthop show id {primary_nhid}):")
+            kernel_nhg_output = net["leaf1"].cmd(f"ip nexthop show id {primary_nhid}")
+            logger.info(f"{kernel_nhg_output}")
+            
+            # 3. Route count verification
+            logger.info(f"Route count verification (ip route show | grep 'nhid {primary_nhid}' | wc -l):")
+            route_count_cmd = net["leaf1"].cmd(f'ip route show | grep "nhid {primary_nhid}" | wc -l').strip()
+            logger.info(f"Routes using NHID {primary_nhid}: {route_count_cmd} (expected: 1000)")
+            
+            logger.info(f"=== END DETAILED ANALYSIS ===")
+            logger.info("")
+    else:
+        logger.info("✗ No NHID found for 39.99.x routes")
+        total_ecmp_paths = 0
+    
+    # 6. Return verification results
+    return primary_nhid, route_count, len(unique_nhids), total_ecmp_paths
+
+def build_topo(tgen):
+    "Build function for high-density topology"
+
+    # Create the routers
+    tgen.add_router("spine1")
+    tgen.add_router("spine2")
+    tgen.add_router("leaf1")
+    tgen.add_router("leaf2")
+
+    switch_id = 1
+
+    # Connect leaf1 to spine1 (32 links: leaf1-eth0 to leaf1-eth31)
+    for i in range(LINKS_PER_SPINE):
+        switch = tgen.add_switch(f"s{switch_id}")
+        switch.add_link(tgen.gears["leaf1"])
+        switch.add_link(tgen.gears["spine1"])
+        switch_id += 1
+
+    # Connect leaf1 to spine2 (32 links: leaf1-eth32 to leaf1-eth63)
+    for i in range(LINKS_PER_SPINE):
+        switch = tgen.add_switch(f"s{switch_id}")
+        switch.add_link(tgen.gears["leaf1"])
+        switch.add_link(tgen.gears["spine2"])
+        switch_id += 1
+
+    # Connect leaf2 to spine1 (32 links: leaf2-eth0 to leaf2-eth31)
+    for i in range(LINKS_PER_SPINE):
+        switch = tgen.add_switch(f"s{switch_id}")
+        switch.add_link(tgen.gears["leaf2"])
+        switch.add_link(tgen.gears["spine1"])
+        switch_id += 1
+
+    # Connect leaf2 to spine2 (32 links: leaf2-eth32 to leaf2-eth63)
+    for i in range(LINKS_PER_SPINE):
+        switch = tgen.add_switch(f"s{switch_id}")
+        switch.add_link(tgen.gears["leaf2"])
+        switch.add_link(tgen.gears["spine2"])
+        switch_id += 1
+
+    # Add host connections
+    switch = tgen.add_switch(f"s{switch_id}")
+    switch.add_link(tgen.gears["leaf1"])
+    switch_id += 1
+
+    switch = tgen.add_switch(f"s{switch_id}")
+    switch.add_link(tgen.gears["leaf2"])
+
+
+def setup_module(mod):
+    logger.info("Create a topology:\n {}".format(TOPOLOGY))
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    # Starting Routers
+    router_list = tgen.routers()
+
+    for rname, router in router_list.items():
+        logger.info("Loading router %s" % rname)
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr.conf".format(rname)),
+            [
+                (TopoRouter.RD_ZEBRA, None),
+                (TopoRouter.RD_BGP, None),
+                (TopoRouter.RD_SHARP, None),
+                (TopoRouter.RD_STATIC, None),
+            ],
+        )
+
+    # Initialize all routers.
+    tgen.start_router()
+
+def teardown_module(mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+# Old individual test functions removed - now combined into test_topology_setup()
+
+
+def test_topology_setup():
+    """Complete topology setup: BGP convergence, route installation, and steady state verification"""
+    tgen = get_topogen()
+    net = tgen.net
+    global INITIAL_NHG_ID, INITIAL_BGP_ROUTES_COUNT
+    expected_route_count = 1000
+    
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # === PHASE 1: BGP CONVERGENCE ===
+    step("STEP 1: Establishing BGP sessions")
+    
+    def check_bgp_peer():
+        output = net["leaf1"].cmd('vtysh -c "show bgp ipv4 uni summary json"')
+        try:
+            bgp_summary = json.loads(output)
+            non_established_peers = bgp_summary.get("failedPeers", 0)
+            total_peers = bgp_summary.get("totalPeers", 0)
+            
+            logger.info(f"BGP Status: {total_peers} total peers, {non_established_peers} not yet established")
+            
+            if non_established_peers != 0:
+                logger.info(f"Peers not yet established: {non_established_peers} (waiting for BGP convergence)")
+                return False
+
+            # Must have exactly 64 peers
+            peers = bgp_summary.get("peers", {})
+            if len(peers) != 64:
+                logger.info(f"Expected exactly 64 peers, found {len(peers)} (waiting for BGP convergence)")
+                return False
+
+            logger.info(f"All 64 BGP peers established successfully")
+            return True
+
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.info(f"JSON parsing error: {e} (waiting for BGP convergence)")
+            return False
+
+    success, result = topotest.run_and_expect(
+        check_bgp_peer,
+        True,
+        count=60,  # Wait up to 60 tries
+        wait=1,    # 1 second between tries
+    )
+    
+    assert success, "BGP session establishment failed"
+
+    # === PHASE 2: ROUTE INSTALLATION ===
+    step("STEP 2: Installing sharp routes and waiting for convergence")
+    
+    # Extract IPv4 from leaf2 loopback
+    lo_output = net["leaf2"].cmd("vtysh -c 'show interface lo'")
+    ipv4_match = re.search(r"inet (\d+\.\d+\.\d+\.\d+)/\d+", lo_output)
+
+    if not ipv4_match:
+        assert False, "Could not find IPv4 address on loopback interface"
+
+    ipv4_nexthop = ipv4_match.group(1)
+    logger.info(f"Using nexthop for sharp routes: IPv4={ipv4_nexthop}")
+
+    # Install IPv4 routes  
+    ipv4_cmd = f"vtysh -c 'sharp install routes 39.99.0.0 nexthop {ipv4_nexthop} {expected_route_count}'"
+    logger.info(f"Installing {expected_route_count} routes with command: {ipv4_cmd}")
+    net["leaf2"].cmd(ipv4_cmd)
+    
+    # Verify routes appear in BGP
+    def check_leaf1_routes():
+        route_count = (
+            net["leaf1"]
+            .cmd('vtysh -c "show bgp ipv4 unicast" | grep "*>" | grep "39\\.99" | wc -l')
+            .rstrip()
+        )
+        try:
+            count = int(route_count)
+            if count == expected_route_count:
+                logger.info(f"Found {count} BGP routes with 39.99.x prefix on leaf1 (target: {expected_route_count})")
+            else:
+                logger.info(f"Still waiting... Found {count}/{expected_route_count} BGP routes with 39.99.x prefix")
+            return count
+        except ValueError:
+            return 0
+
+    success, result = topotest.run_and_expect(
+        check_leaf1_routes,
+        expected_route_count,
+        count=60,  # Wait up to 60 tries
+        wait=1,    # 1 second between tries
+    )
+
+    assert success, f"Expected {expected_route_count} routes on leaf1 but found {result}"
+
+    # CRITICAL: Wait for full topology convergence across all links
+    logger.info("=== WAITING FOR FULL TOPOLOGY CONVERGENCE ===")
+    
+    def check_full_convergence():
+        """Verify routes are learned from both spine1 and spine2 with proper ECMP"""
+        
+        # 1. Verify routes exist in kernel with NHID
+        kernel_routes = net["leaf1"].cmd('ip route show | grep nhid | grep "39\\.99" | wc -l').strip()
+        try:
+            kernel_count = int(kernel_routes)
+            if kernel_count != expected_route_count:
+                logger.info(f"Kernel routes: {kernel_count}/{expected_route_count} (waiting for convergence)")
+                return False
+        except ValueError:
+            logger.info("Failed to parse kernel route count (waiting for convergence)")
+            return False
+            
+        # 2. Verify we have exactly one NHID for all routes
+        unique_nhids = net["leaf1"].cmd('ip route show | grep nhid | grep "39\\.99" | awk \'{for(i=1;i<=NF;i++) if($i=="nhid") print $(i+1)}\' | sort | uniq | wc -l').strip()
+        try:
+            nhid_count = int(unique_nhids)
+            if nhid_count != 1:
+                logger.info(f"Multiple NHIDs found: {nhid_count} (expected 1, waiting for convergence)")
+                return False
+        except ValueError:
+            logger.info("Failed to parse NHID count (waiting for convergence)")
+            return False
+            
+        # 3. Get the NHID and verify ECMP structure
+        nhid = net["leaf1"].cmd('ip route show | grep nhid | grep "39\\.99" | head -1 | awk \'{for(i=1;i<=NF;i++) if($i=="nhid") print $(i+1)}\'').strip()
+        if not nhid:
+            logger.info("Could not extract NHID (waiting for convergence)")
+            return False
+            
+        # 4. Count active ECMP paths (excluding inactive)
+        ecmp_count = net["leaf1"].cmd(f'vtysh -c "show nexthop-group rib {nhid}" | grep "via" | grep -v "inactive" | wc -l').strip()
+        try:
+            ecmp_paths = int(ecmp_count)
+            if ecmp_paths != 64:  # Expect all 64 paths active
+                logger.info(f"ECMP paths: {ecmp_paths}/64 active (waiting for convergence)")
+                return False
+        except ValueError:
+            logger.info("Failed to parse ECMP count (waiting for convergence)")
+            return False
+            
+        # 5. Verify routes are learned from both spine1 and spine2
+        spine1_paths = net["leaf1"].cmd(f'vtysh -c "show nexthop-group rib {nhid}" | grep "via" | grep -v "inactive" | grep "10\\.1\\." | wc -l').strip()
+        spine2_paths = net["leaf1"].cmd(f'vtysh -c "show nexthop-group rib {nhid}" | grep "via" | grep -v "inactive" | grep "10\\.2\\." | wc -l').strip()
+        
+        try:
+            spine1_count = int(spine1_paths)
+            spine2_count = int(spine2_paths)
+            
+            if spine1_count != 32:
+                logger.info(f"Spine1 paths: {spine1_count}/32 (waiting for convergence)")
+                return False
+            if spine2_count != 32:
+                logger.info(f"Spine2 paths: {spine2_count}/32 (waiting for convergence)")
+                return False
+                
+        except ValueError:
+            logger.info("Failed to parse spine path counts (waiting for convergence)")
+            return False
+            
+        logger.info(f"Full convergence: {kernel_count} routes, NHID {nhid}, {ecmp_paths} ECMP paths ({spine1_count} via spine1, {spine2_count} via spine2)")
+        return True
+
+    # Wait for full convergence with longer timeout
+    convergence_success, convergence_result = topotest.run_and_expect(
+        check_full_convergence,
+        True,
+        count=120,  # Wait up to 120 tries (2 minutes)
+        wait=1,     # 1 second between tries
+    )
+    
+    if not convergence_success:
+        logger.info("CONVERGENCE TIMEOUT - Final diagnostic information:")
+        
+        # Show final state for debugging
+        final_kernel_routes = net["leaf1"].cmd('ip route show | grep nhid | grep "39\\.99" | wc -l').strip()
+        logger.info(f"Final kernel routes: {final_kernel_routes}/{expected_route_count}")
+        
+        final_nhids = net["leaf1"].cmd('ip route show | grep nhid | grep "39\\.99" | awk \'{for(i=1;i<=NF;i++) if($i=="nhid") print $(i+1)}\' | sort | uniq | wc -l').strip()
+        logger.info(f"Final NHID count: {final_nhids} (expected 1)")
+        
+        # Get NHID for ECMP analysis
+        nhid = net["leaf1"].cmd('ip route show | grep nhid | grep "39\\.99" | head -1 | awk \'{for(i=1;i<=NF;i++) if($i=="nhid") print $(i+1)}\'').strip()
+        if nhid:
+            final_ecmp = net["leaf1"].cmd(f'vtysh -c "show nexthop-group rib {nhid}" | grep "via" | grep -v "inactive" | wc -l').strip()
+            logger.info(f"Final ECMP paths: {final_ecmp}/64")
+        
+        assert False, "Full topology convergence failed - routes not properly learned from both spines after 2 minutes"
+
+    # === PHASE 3: STEADY STATE VERIFICATION ===
+    step("STEP 3: Verifying steady state nexthop group")
+
+    def check_nhg_present():
+        nhg_output = net["leaf1"].cmd("ip -j nexthop show group")
+        try:
+            nhg_groups = json.loads(nhg_output)
+            logger.info(f"Found {len(nhg_groups)} nexthop groups")
+            return len(nhg_groups) >= 1
+        except json.JSONDecodeError:
+            return False
+
+    success, result = topotest.run_and_expect(
+        check_nhg_present,
+        True,
+        count=60,
+        wait=1,
+    )
+    
+    assert success, "Expected at least 1 nexthop group in steady state"
+    
+    # Comprehensive verification of NHG and routes
+    primary_nhid, route_count, nhid_count, ecmp_paths = verify_nhg_and_routes(net, "INITIAL STATE", expected_ecmp_paths=64)
+    
+    # Store initial state for other tests
+    INITIAL_NHG_ID = int(primary_nhid) if primary_nhid else None
+    INITIAL_BGP_ROUTES_COUNT = route_count
+    
+    logger.info(f"Initial State Summary:")
+    logger.info(f"  - Primary NHG ID: {INITIAL_NHG_ID}")
+    logger.info(f"  - BGP routes using this NHG: {INITIAL_BGP_ROUTES_COUNT}")
+    logger.info(f"  - Number of different NHIDs: {nhid_count}")
+    logger.info(f"  - ECMP paths in NHG: {ecmp_paths}")
+    
+    # Verify we have proper state before proceeding
+    if nhid_count != 1:
+        pytest.fail(f"Expected exactly 1 NHID, found {nhid_count}")
+    if route_count != 1000:
+        pytest.fail(f"Expected 1000 routes, found {route_count}")
+    if ecmp_paths != 64:
+        pytest.fail(f"Expected 64 ECMP paths, found {ecmp_paths}")
+    
+    logger.info("=== TOPOLOGY SETUP COMPLETE ===")
+    logger.info("Ready for link state change tests")
+
+
+def test_single_link_down():
+    """Bring down a single link and verify NHG behavior"""
+    tgen = get_topogen()
+    net = tgen.net
+    global INITIAL_NHG_ID, INITIAL_BGP_ROUTES_COUNT
+    
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    if not INITIAL_NHG_ID:
+        pytest.skip("Initial NHG ID not available")
+
+    step("Test case 1: Single link down")
+
+    # Verify before link down
+    primary_nhid_before, route_count_before, nhid_count_before, ecmp_paths_before = verify_nhg_and_routes(net, "BEFORE LINK DOWN", expected_ecmp_paths=64)
+    
+    # Bring down interface
+    logger.info("Bringing down interface: leaf1-eth0")
+    down_output = net["leaf1"].cmd("ip link set leaf1-eth0 down")
+    
+    def verify_after_link_down():
+        # Get current NHG state
+        primary_nhid_after, route_count_after, nhid_count_after, ecmp_paths_after = verify_nhg_and_routes(net, "AFTER LINK DOWN CHECK", expected_ecmp_paths=63)
+        
+        # Check if NHG ID is stable
+        if primary_nhid_after != str(INITIAL_NHG_ID):
+            logger.info(f"NHG ID changed: {INITIAL_NHG_ID} -> {primary_nhid_after}")
+            return False
+        
+        # Check if route count is stable
+        if route_count_after != INITIAL_BGP_ROUTES_COUNT:
+            logger.info(f"Route count changed: {INITIAL_BGP_ROUTES_COUNT} -> {route_count_after}")
+            return False
+        
+        # Check if ECMP paths reduced by 1 (one link down)
+        expected_ecmp_after = 63  # 64 - 1 link down
+        if ecmp_paths_after != expected_ecmp_after:
+            logger.info(f"ECMP paths unexpected: expected {expected_ecmp_after}, got {ecmp_paths_after}")
+            return False
+        
+        logger.info(f"NHG {INITIAL_NHG_ID} stable with {route_count_after} routes and {ecmp_paths_after} ECMP paths after link down")
+        return True
+
+    success, result = topotest.run_and_expect(
+        verify_after_link_down,
+        True,
+        count=60,
+        wait=1,
+    )
+    
+    # Final verification after link down
+    verify_nhg_and_routes(net, "FINAL STATE AFTER LINK DOWN", expected_ecmp_paths=63, show_detailed_rib=True)
+    
+    assert success, "Single link down verification failed"
+
+
+def test_single_link_up():
+    """Bring up the previously downed link"""
+    tgen = get_topogen()
+    net = tgen.net
+    global INITIAL_NHG_ID, INITIAL_BGP_ROUTES_COUNT
+    
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    if not INITIAL_NHG_ID:
+        pytest.skip("Initial NHG ID not available")
+
+    step("Test case 2: Single link up")
+
+    # Verify before link up  
+    verify_nhg_and_routes(net, "BEFORE LINK UP", expected_ecmp_paths=63)
+    
+    # Bring up interface
+    logger.info("Bringing up interface: leaf1-eth0")
+    net["leaf1"].cmd("ip link set leaf1-eth0 up")
+    
+    def verify_after_link_up():
+        primary_nhid_after, route_count_after, nhid_count_after, ecmp_paths_after = verify_nhg_and_routes(net, "AFTER LINK UP CHECK", expected_ecmp_paths=64)
+        
+        if primary_nhid_after != str(INITIAL_NHG_ID):
+            logger.info(f"NHG ID changed: {INITIAL_NHG_ID} -> {primary_nhid_after}")
+            return False
+        
+        if route_count_after != INITIAL_BGP_ROUTES_COUNT:
+            logger.info(f"Route count changed: {INITIAL_BGP_ROUTES_COUNT} -> {route_count_after}")
+            return False
+        
+        # Check if ECMP paths are back to full (64 paths after link up)
+        expected_ecmp_after = 64  # All links should be up
+        if ecmp_paths_after != expected_ecmp_after:
+            logger.info(f"ECMP paths unexpected: expected {expected_ecmp_after}, got {ecmp_paths_after}")
+            return False
+            
+        logger.info(f"NHG {INITIAL_NHG_ID} stable with {route_count_after} routes and {ecmp_paths_after} ECMP paths after link up")
+        return True
+
+    success, result = topotest.run_and_expect(
+        verify_after_link_up,
+        True,
+        count=60,
+        wait=1,
+    )
+    
+    # Final verification
+    verify_nhg_and_routes(net, "FINAL STATE AFTER LINK UP", expected_ecmp_paths=64, show_detailed_rib=True)
+    
+    assert success, "Single link up verification failed"
+
+
+def test_partial_links_towards_spine1_down():
+    """Bring down 16 out of 32 links towards spine1 and verify NHG behavior"""
+    tgen = get_topogen()
+    net = tgen.net
+    global INITIAL_NHG_ID, INITIAL_BGP_ROUTES_COUNT
+    
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    if not INITIAL_NHG_ID:
+        pytest.skip("Initial NHG ID not available")
+
+    step("Test case 3: Partial links down (16/32 to spine1)")
+
+    # Verify before partial links down
+    verify_nhg_and_routes(net, "BEFORE PARTIAL LINKS TOWARDS SPINE1 DOWN", expected_ecmp_paths=64)
+    
+    # Bring down 16 interfaces towards spine1
+    logger.info("Bringing down 16 interfaces towards spine1: leaf1-eth0 to leaf1-eth15")
+    for i in range(16):
+        net["leaf1"].cmd(f"ip link set leaf1-eth{i} down")
+    
+    def verify_after_partial_links_down():
+        primary_nhid_after, route_count_after, nhid_count_after, ecmp_paths_after = verify_nhg_and_routes(net, "AFTER PARTIAL LINKS TOWARDS SPINE1 DOWN CHECK", expected_ecmp_paths=48)
+        
+        if primary_nhid_after != str(INITIAL_NHG_ID):
+            logger.info(f"NHG ID changed: {INITIAL_NHG_ID} -> {primary_nhid_after}")
+            return False
+        
+        if route_count_after != INITIAL_BGP_ROUTES_COUNT:
+            logger.info(f"Route count changed: {INITIAL_BGP_ROUTES_COUNT} -> {route_count_after}")
+            return False
+        
+        # Check if ECMP paths reduced by 16 (16 links down)
+        expected_ecmp_after = 48  # 64 - 16 links down
+        if ecmp_paths_after != expected_ecmp_after:
+            logger.info(f"ECMP paths unexpected: expected {expected_ecmp_after}, got {ecmp_paths_after}")
+            return False
+            
+        logger.info(f"NHG {INITIAL_NHG_ID} stable with {route_count_after} routes and {ecmp_paths_after} ECMP paths after partial links towards spine1 down")
+        return True
+
+    success, result = topotest.run_and_expect(
+        verify_after_partial_links_down,
+        True,
+        count=60,
+        wait=1,
+    )
+    
+    # Final verification
+    verify_nhg_and_routes(net, "FINAL STATE AFTER PARTIAL LINKS TOWARDS SPINE1 DOWN", expected_ecmp_paths=48, show_detailed_rib=True)
+    
+    assert success, "Partial links towards spine1 down verification failed"
+
+
+def test_partial_links_towards_spine1_up():
+    """Bring up the 16 out of 32 previously downed links towards spine1"""
+    tgen = get_topogen()
+    net = tgen.net
+    global INITIAL_NHG_ID, INITIAL_BGP_ROUTES_COUNT
+    
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    if not INITIAL_NHG_ID:
+        pytest.skip("Initial NHG ID not available")
+
+    step("Test case 4: Partial links up (16/32 to spine1)")
+
+    # Verify before partial links up
+    verify_nhg_and_routes(net, "BEFORE PARTIAL LINKS UP", expected_ecmp_paths=48)
+    
+    # Bring up 16 interfaces towards spine1
+    logger.info("Bringing up 16 interfaces towards spine1: leaf1-eth0 to leaf1-eth15")
+    for i in range(16):
+        net["leaf1"].cmd(f"ip link set leaf1-eth{i} up")
+    
+    def verify_after_partial_links_up():
+        primary_nhid_after, route_count_after, nhid_count_after, ecmp_paths_after = verify_nhg_and_routes(net, "AFTER PARTIAL LINKS UP CHECK", expected_ecmp_paths=64)
+        
+        if primary_nhid_after != str(INITIAL_NHG_ID):
+            logger.info(f"NHG ID changed: {INITIAL_NHG_ID} -> {primary_nhid_after}")
+            return False
+        
+        if route_count_after != INITIAL_BGP_ROUTES_COUNT:
+            logger.info(f"Route count changed: {INITIAL_BGP_ROUTES_COUNT} -> {route_count_after}")
+            return False
+        
+        # Check if ECMP paths are back to full (64 paths after partial links up)
+        expected_ecmp_after = 64  # All links should be up
+        if ecmp_paths_after != expected_ecmp_after:
+            logger.info(f"ECMP paths unexpected: expected {expected_ecmp_after}, got {ecmp_paths_after}")
+            return False
+            
+        logger.info(f"NHG {INITIAL_NHG_ID} stable with {route_count_after} routes and {ecmp_paths_after} ECMP paths after partial links up")
+        return True
+
+    success, result = topotest.run_and_expect(
+        verify_after_partial_links_up,
+        True,
+        count=60,
+        wait=1,
+    )
+    
+    # Final verification
+    verify_nhg_and_routes(net, "FINAL STATE AFTER PARTIAL LINKS UP", expected_ecmp_paths=64, show_detailed_rib=True)
+    
+    assert success, "Partial links up verification failed"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def cleanup_sharp_routes():
+    """Fixture to clean up sharp routes after all tests"""
+    yield  # This runs before tests
+    
+    # This runs after all tests
+    tgen = get_topogen()
+    if tgen and not tgen.routers_have_failure():
+        net = tgen.net
+        logger.info("Cleaning up sharp routes to prevent memory leaks")
+        
+        try:
+            # Remove the 1000 sharp routes we installed
+            net["leaf2"].cmd('vtysh -c "sharp remove routes 39.99.0.0 1000"')
+            
+            # Wait for routes to be removed from BGP (shorter timeout since it's cleanup)
+            def check_routes_removed():
+                route_count = (
+                    net["leaf1"]
+                    .cmd('vtysh -c "show bgp ipv4 unicast" | grep "*>" | grep "39\\.99" | wc -l')
+                    .rstrip()
+                )
+                try:
+                    count = int(route_count)
+                    logger.info(f"Routes remaining: {count} (waiting for removal)")
+                    return count == 0
+                except ValueError:
+                    return False
+
+            success, result = topotest.run_and_expect(
+                check_routes_removed,
+                True,
+                count=15,  # Shorter timeout for cleanup
+                wait=1,    
+            )
+
+            if success:
+                logger.info("All sharp routes successfully removed")
+            else:
+                logger.info("Some routes may still remain, but continuing with teardown")
+                
+        except Exception as e:
+            logger.info(f"Cleanup encountered error (continuing): {e}")
+
+
+# Cleanup moved to pytest fixture above
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1088,7 +1088,7 @@ static void zebra_nhg_set_valid(struct nhg_hash_entry *nhe, bool valid)
 			struct nexthop *nexthop = rb_node_dep->nhe->nhg.nexthop;
 
 			while (nexthop) {
-				if (nexthop_same(nexthop, nhe->nhg.nexthop)) {
+				if (nexthop_same_no_weight(nexthop, nhe->nhg.nexthop)) {
 					/* Invalid Nexthop */
 					UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 				} else {
@@ -4116,8 +4116,7 @@ void zebra_interface_nhg_reinstall(struct interface *ifp)
 				struct nexthop *nhop_dependent =
 					rb_node_dependent->nhe->nhg.nexthop;
 
-				while (nhop_dependent &&
-				       !nexthop_same(nhop_dependent, nh))
+				while (nhop_dependent && !nexthop_same_no_weight(nhop_dependent, nh))
 					nhop_dependent = nhop_dependent->next;
 
 				if (nhop_dependent)


### PR DESCRIPTION
With W-ECMP, when an interface goes down, we mark the singleton nexthop as INACTIVE. We then process the dependents (NHG groups containing this singleton nexthop) and attempt to mark them as INACTIVE as well.

During this process, we compare all singleton nexthops in the nexthop group with the singleton nexthop that went down using nexthop_same() in zebra_nhg_set_valid().

However, there's a weight mismatch issue:
- The standalone singleton nexthop has weight = 1
- The same singleton nexthop when part of an NHG has weight = 255 This weight mismatch causes nexthop_same() to return FALSE, preventing proper matching.

Testing:

```
Before fix:

ID: 76 (zebra)
     RefCnt: 20
     Uptime: 00:00:59
     VRF: default
     Valid, Installed
     Interface Index: 46
           via 22.64.0.18, swp43 (vrf default), weight 1          <<<< weight 1 for swp43
     Dependents: (74)
ID: 74 (zebra)
     RefCnt: 19
     Uptime: 00:00:59
     VRF: default
     Valid, Installed
     Depends: (75) (76) (77) (78)
           via 22.64.0.16, swp42 (vrf default), weight 255
           via 22.64.0.18, swp43 (vrf default), weight 255       <<<<< weight 255 for swp43
           via 22.64.0.20, swp44 (vrf default), weight 255
           via 22.64.0.22, swp45 (vrf default), weight 255

root@leaf:mgmt:~# ip link set swp43 down                  <<<<< trigger bring down swp43
root@leaf:mgmt:~#
root@leaf:mgmt:~# vtysh -c "show nexthop-group rib 74"
ID: 74 (zebra)
     RefCnt: 1 Time to Deletion: 00:02:54                        <<<< marked for deletion
     Uptime: 00:02:53
     VRF: default
     Valid, Installed
     Depends: (75) (76) (77) (78)
           via 22.64.0.16, swp42 (vrf default), weight 255
           via 22.64.0.18, swp43 (vrf default), weight 255        <<< swp43 not marked inactive (nexthop_same fails due to wt check)
           via 22.64.0.20, swp44 (vrf default), weight 255
           via 22.64.0.22, swp45 (vrf default), weight 255

After fix:

root@leaf:mgmt:/var/log/frr# vtysh -c "show nexthop-group rib 69"
ID: 69 (zebra)
     RefCnt: 19
     Uptime: 00:01:11
     VRF: default
     Valid, Installed
     Depends: (70) (71) (72)
           via 22.64.0.16, swp42 (vrf default), weight 255
           via 22.64.0.20, swp44 (vrf default), weight 255
           via 22.64.0.22, swp45 (vrf default), weight 255

root@leaf:mgmt:/var/log/frr# ip link set swp44 down                    <<< trigger bring swp44 down
root@leaf:mgmt:/var/log/frr#
root@leaf:mgmt:/var/log/frr# vtysh -c "show nexthop-group rib 69"      <<< NHG 69 not marked for deletion
ID: 69 (zebra)
     RefCnt: 19
     Uptime: 00:02:41
     VRF: default
     Valid, Installed
     Depends: (70) (71) (72)
           via 22.64.0.16, swp42 (vrf default), weight 255
           via 22.64.0.20, swp44 (vrf default) inactive, weight 255           <<< swp44 marked as inactive
           via 22.64.0.22, swp45 (vrf default), weight 255

```
      
Ticket: #