### PR TITLE
topotests: test bfd when bgp is passive

### DIFF
--- a/tests/topotests/bfd_bgp_cbit_topo3/r1/bgpd.conf
+++ b/tests/topotests/bfd_bgp_cbit_topo3/r1/bgpd.conf
@@ -5,20 +5,24 @@ router bgp 101
  no bgp network import-check
  timers bgp 3 10
  bgp graceful-restart
- neighbor 2001:db8:4::1 remote-as 102
- neighbor 2001:db8:4::1 timers 3 10
- neighbor 2001:db8:4::1 timers connect 1
- neighbor 2001:db8:4::1 remote-as external
- neighbor 2001:db8:4::1 bfd
- neighbor 2001:db8:4::1 bfd check-control-plane-failure
- neighbor 2001:db8:4::1 update-source 2001:db8:1::1
- neighbor 2001:db8:4::1 ebgp-multihop 5
+ neighbor pgroup peer-group
+ neighbor pgroup remote-as 102
+ neighbor pgroup timers 3 10
+ neighbor pgroup timers connect 1
+ neighbor pgroup remote-as external
+ neighbor pgroup bfd
+ neighbor pgroup bfd check-control-plane-failure
+ neighbor pgroup update-source 2001:db8:1::1
+ neighbor pgroup ebgp-multihop 5
+ !
+ bgp listen range 2001:db8:4::/48 peer-group pgroup
+ !
  address-family ipv4 unicast
-  no neighbor 2001:db8:4::1 activate
+  no neighbor pgroup activate
  exit-address-family
  address-family ipv6 unicast
   network 2001:db8:8::/64
   network 2001:db8:9::/64
-  neighbor 2001:db8:4::1 activate
+  neighbor pgroup activate
  exit-address-family
 !

--- a/tests/topotests/bfd_bgp_cbit_topo3/r1/peers_down.json
+++ b/tests/topotests/bfd_bgp_cbit_topo3/r1/peers_down.json
@@ -1,15 +1,1 @@
-[
-    {
-        "multihop":true,
-        "peer":"2001:db8:4::1",
-        "local":"2001:db8:1::1",
-        "status":"init",
-        "receive-interval":300,
-        "transmit-interval":300,
-        "echo-receive-interval":50,
-        "echo-transmit-interval":0,
-        "remote-receive-interval":1000,
-        "remote-transmit-interval":1000,
-        "remote-echo-receive-interval":50
-    }
-]
+[]


### PR DESCRIPTION
Some versions between 10.0 and 10.3.1 had BFD not working if one of BGP peers was in "passive mode", i.e. instead of peers with addresses, a `peer-group` was defined to be matched by `bgp listen` statement. This problem went unnoticed because there was no test for bfd in such mode.

This commit modifies one of existing bfd tests to run bgp session "passively". It passes against 10.3.1