### PR TITLE
zebra: Do not show SRv6 locator params when they are set to default

### DIFF
--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -1409,7 +1409,7 @@ static int zebra_sr_config(struct vty *vty)
 			if (locator->block_bits_length)
 				vty_out(vty, " block-len %u",
 					locator->block_bits_length);
-			if (locator->node_bits_length)
+			if (locator->node_bits_length != ZEBRA_SRV6_LOCATOR_NODE_LENGTH)
 				vty_out(vty, " node-len %u",
 					locator->node_bits_length);
 

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -1406,7 +1406,8 @@ static int zebra_sr_config(struct vty *vty)
 			vty_out(vty, "   locator %s\n", locator->name);
 			vty_out(vty, "    prefix %s/%u", str,
 				locator->prefix.prefixlen);
-			if (locator->block_bits_length)
+			if (locator->block_bits_length !=
+			    locator->prefix.prefixlen - ZEBRA_SRV6_LOCATOR_NODE_LENGTH)
 				vty_out(vty, " block-len %u",
 					locator->block_bits_length);
 			if (locator->node_bits_length != ZEBRA_SRV6_LOCATOR_NODE_LENGTH)


### PR DESCRIPTION
In `show running-config`, normally we don't show parameters that are set to the default value.

However, currently the `block-len` and `node-len` parameters of an SRv6 locator do not follow this rule, and are shown even when they are set to the default values.

The following example shows the issue:

```
router# configure
router(config)# segment-routing
router(config-sr)# srv6
router(config-srv6)# locators
router(config-locators)# locator MAIN
router(config-locator)# prefix fcbb:bb01:1::/48

router# show running-config
[...]
segment-routing
 srv6
  locators
   locator MAIN
    prefix fcbb:bb01:1::/48 block-len 24 node-len 24
[...]

```

This PR fixes the issue by hiding the `block-len` and `node-len` parameters when they are set to default.