### PR TITLE
bgpd: avoid BGP port opening for VRF instances

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -4718,6 +4718,32 @@ static struct peer_group *listen_range_exists(struct bgp *bgp,
 	return NULL;
 }
 
+/*
+ * Check if there is no neighbors nor listening range on bgp
+ */
+static void bgp_may_stop_listening(struct bgp *bgp, struct vty *vty)
+{
+	struct listnode *node, *nnode;
+	struct peer_group *group;
+	struct vrf *vrf;
+	afi_t afi;
+
+	for (ALL_LIST_ELEMENTS(bgp->group, node, nnode, group)) {
+		for (afi = AFI_IP; afi < AFI_MAX; afi++) {
+			if (!list_isempty(group->listen_range[afi]))
+				return;
+		}
+	}
+
+	if (!list_isempty(bgp->peer))
+		return;
+
+	vrf = bgp_vrf_lookup_by_instance_type(bgp);
+	bgp_handle_socket(bgp, vrf, VRF_UNKNOWN, false);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_VRF_MAY_LISTEN);
+}
+
+
 static void bgp_need_listening(struct bgp *bgp, struct vty *vty)
 {
 	struct listnode *node;
@@ -4857,6 +4883,12 @@ DEFUN (no_bgp_listen_range,
 	}
 
 	ret = peer_group_listen_range_del(group, &range);
+
+	/*
+	 * if need stop listening
+	 */
+	bgp_may_stop_listening(bgp, vty);
+
 	return bgp_vty_return(vty, ret);
 }
 
@@ -5399,6 +5431,10 @@ DEFUN (no_neighbor,
 		}
 	}
 
+	/*
+	 * if need stop listening
+	 */
+	bgp_may_stop_listening(bgp, vty);
 	return CMD_SUCCESS;
 }
 
@@ -5464,6 +5500,10 @@ DEFUN (no_neighbor_peer_group,
 		}
 		peer_group_notify_unconfig(group);
 		peer_group_delete(group);
+		/*
+		 * if need stop listening
+		 */
+		bgp_may_stop_listening(bgp, vty);
 	} else {
 		vty_out(vty, "%% Create the peer-group first\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -5838,6 +5878,11 @@ DEFUN (no_neighbor_set_peer_group,
 
 	peer_notify_unconfig(peer->connection);
 	ret = peer_delete(peer);
+
+	/*
+	 * if need stop listening
+	 */
+	bgp_may_stop_listening(bgp, vty);
 
 	return bgp_vty_return(vty, ret);
 }

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3308,6 +3308,7 @@ int peer_group_listen_range_del(struct peer_group *group, struct prefix *range)
 	if (group->conf->password)
 		bgp_md5_unset_prefix(group->bgp, prefix);
 
+	prefix_free(&prefix);
 	return 0;
 }
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -133,7 +133,8 @@ static bool bgp_has_remaining_instances(const struct bgp *bgp)
 			continue;
 		if (bgp->vrf_id != bgp_next->vrf_id)
 			continue;
-
+		if (!CHECK_FLAG(bgp->flags, BGP_FLAG_VRF_MAY_LISTEN))
+			continue;
 		return true;
 	}
 
@@ -3800,6 +3801,8 @@ int bgp_handle_socket(struct bgp *bgp, struct vrf *vrf, vrf_id_t old_vrf_id,
 		}
 		if (vrf == NULL)
 			return BGP_ERR_INVALID_VALUE;
+		if (!CHECK_FLAG(bgp->flags, BGP_FLAG_VRF_MAY_LISTEN))
+			return 0;
 		/* do nothing
 		 * if vrf_id did not change
 		 */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -667,6 +667,7 @@ struct bgp {
 #define BGP_FLAG_L3VNI_SCHEDULE_FOR_INSTALL (1ULL << 41)
 #define BGP_FLAG_L3VNI_SCHEDULE_FOR_DELETE  (1ULL << 42)
 #define BGP_FLAG_LINK_LOCAL_CAPABILITY	    (1ULL << 43)
+#define BGP_FLAG_VRF_MAY_LISTEN		    (1ULL << 44)
 
 	/* BGP default address-families.
 	 * New peers inherit enabled afi/safis from bgp instance.

--- a/tests/topotests/bgp_listen_l3vrf/r1/frr.conf
+++ b/tests/topotests/bgp_listen_l3vrf/r1/frr.conf
@@ -1,0 +1,26 @@
+log stdout
+interface lo
+ ip address 192.0.2.1/32
+!
+interface r1-eth0
+ ip address 172.31.10.1/24
+!
+interface r1-eth1
+# ip address 172.31.0.1/24
+!
+ip route 192.0.2.3/32 172.31.10.3
+!
+
+router bgp 64500
+ bgp router-id 192.0.2.1
+ no bgp ebgp-requires-policy
+ neighbor rrserver peer-group
+ neighbor rrserver remote-as 64500
+ neighbor rrserver update-source lo
+ neighbor rrserver timers connect 2
+ neighbor 192.0.2.3 peer-group rrserver
+ address-family ipv4 unicast
+  neighbor rrserver next-hop-self
+  neighbor rrserver activate
+  exit-address-family
+!

--- a/tests/topotests/bgp_listen_l3vrf/r3/frr.conf
+++ b/tests/topotests/bgp_listen_l3vrf/r3/frr.conf
@@ -1,0 +1,27 @@
+log stdout
+interface lo
+ ip address 192.0.2.3/32
+!
+interface r3-eth0
+ ip address 172.31.10.3/24
+!
+interface r3-eth1
+!
+ip route 192.0.2.1/32 172.31.10.1
+!
+router bgp 64500 view one
+ bgp router-id 192.0.2.3
+ neighbor rr peer-group
+ neighbor rr remote-as 64500
+ neighbor rr update-source lo
+ neighbor 192.0.2.1 peer-group rr
+ !
+ neighbor rlisten peer-group
+ neighbor rlisten remote-as 64600
+ neighbor rlisten update-source lo
+ !
+
+ address-family ipv4 unicast
+  neighbor rlisten activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_listen_l3vrf/test_bgp_listen_l3vrf.py
+++ b/tests/topotests/bgp_listen_l3vrf/test_bgp_listen_l3vrf.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python
+
+#
+# test_bgp_listen_l3vrf.py
+#
+# Copyright 2025 6WIND S.A.
+#
+
+"""
+ test_bgp_listen_l3vrf.py:
+ Check that the FRR BGP daemon on r1 open and close BGP port for
+ non VRF instances accordingly to needs
+
+
++---+----+          +---+----+
+|        |          |        +
+|  r1    +----------+  r3    +
+|        |          |        +
++++-+----+          +--------+
+
+
+"""
+
+import os
+import sys
+import json
+from functools import partial
+import pytest
+import functools
+import time
+import re
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.common_check import ip_check_path_selection, iproute2_check_path_selection
+from lib.common_config import step
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+
+from lib.bgp import (
+    verify_bgp_convergence_from_running_config,
+)
+
+# Required to instantiate the topology builder class.
+
+
+def check_port_179_open(vrf):
+    tgen = get_topogen()
+    r1 = tgen.gears["r1"]
+    output = r1.cmd("ss -tuplen | grep :179 ")
+    logger.info(output)
+    if vrf == "default":
+        match = re.search("0.0.0.0", output)
+    else:
+        match = re.search(vrf, output)
+    logger.info(match)
+    if match is not None:
+       return match.group()
+    else:
+       return None
+
+
+def build_topo(tgen):
+    "Build function"
+
+    # Create 2 PE routers.
+    tgen.add_router("r1")
+    tgen.add_router("r3")
+
+    # switch
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r3"])
+
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r3"])
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for rname, router in router_list.items():
+        logger.info("Loading router %s" % rname)
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    # Initialize all routers.
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def check_bgp_convergence():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    bgp_convergence = verify_bgp_convergence_from_running_config(tgen)
+
+    assertmsg = "BGP didn't converge"
+    assert bgp_convergence is True, assertmsg
+
+
+def test_add_vrf():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    check_bgp_convergence()
+
+    r1 = tgen.gears["r1"]
+    r3 = tgen.gears["r3"]
+    logger.info("test r1-cust before and after l3vrf add")
+
+    step("create r1-cust l3vrf with iproute 2")
+
+    test_func = functools.partial(check_port_179_open, "r1-cust")
+    _, res = topotest.run_and_expect(test_func, "r1_cust", count=15, wait=1)
+    assertmsg = """
+                BGP port related to r1-cust is listening when r1-cust \
+                is not created
+                """
+    assert res is None, assertmsg
+
+    # create vrf
+    r1.cmd("ip link add r1-cust type vrf table 10")
+    r1.cmd("ip link set dev r1-cust up")
+
+    r1.cmd("ip link add link r1-eth1 dev r1-eth1.100 type vlan id 100")
+    r1.cmd("ip link set dev r1-eth1.100 up")
+    r1.cmd("ip link set  dev r1-eth1.100 master r1-cust")
+
+    r1.cmd("ip link add r1-loop1 type dummy")
+    r1.cmd("ip link set dev r1-loop1 up")
+    r1.cmd("ip link set  dev r1-loop1 master r1-cust")
+
+    r3.cmd("ip link add link r3-eth1 dev r3-eth1.100 type vlan id 100")
+    r3.cmd("ip link set dev r3-eth1.100 up")
+
+    r3.vtysh_cmd(
+        """
+        configure terminal
+        interface r3-eth1.100
+         ip address 172.31.0.3/24
+        ip route 192.0.102.1/32 172.31.0.1
+        """
+    )
+
+    test_func = functools.partial(check_port_179_open, "r1-cust")
+    _, res = topotest.run_and_expect(test_func, "r1-cust", count=15, wait=1)
+    assertmsg = "BGP port listening on vrf r1-cust when vrf address not set"
+    assert res is None, assertmsg
+
+    step("setting r1-cust up")
+    r1.vtysh_cmd(
+        """
+        configure terminal
+         interface r1-loop1 vrf r1-cust
+          ip  address 192.0.102.1/32
+         interface r1-eth1.100 vrf r1-cust
+          ip address 172.31.0.1/24
+        ip route 192.0.2.3/32 172.31.0.3 vrf r1-cust
+        """
+    )
+
+    test_func = functools.partial(check_port_179_open, "r1-cust")
+    _, res = topotest.run_and_expect(test_func, "r1-cust", count=15, wait=1)
+    assertmsg = "BGP port related to r1-cust is listening when r1-cust is set up"
+    assert res is None, assertmsg
+
+    step("setting bgp on r1-cust")
+
+    r3.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 64500 view one
+           neighbor 192.0.102.1 peer-group rlisten
+        """
+    )
+    r1.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 64600 vrf r1-cust
+          bgp router-id 192.0.102.1
+          no bgp ebgp-requires-policy
+          no bgp network import-check
+        """
+    )
+
+    test_func = functools.partial(check_port_179_open, "r1-cust")
+    _, res = topotest.run_and_expect(test_func, "r1-cust", count=15, wait=1)
+    assertmsg = """
+                BGP port related to r1-cust listening when \
+                neighbor or listen are not set
+                """
+    assert res is None, assertmsg
+
+    step("add a neighbor on r1-cust BGP")
+
+    r1.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 64600 vrf r1-cust
+         neighbor 192.0.2.3 remote-as 64500
+        """
+    )
+
+    check_bgp_convergence()
+
+    test_func = functools.partial(check_port_179_open, "r1-cust")
+    _, res = topotest.run_and_expect(test_func, "r1-cust", count=30, wait=1)
+    assertmsg = "BGP port related to r1-cust not listening when a neighbor is set"
+    assert res == 'r1-cust', assertmsg
+
+    step("remove the neighbor from r1-cust")
+
+    r1.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 64600 vrf r1-cust
+         no neighbor 192.0.2.3 remote-as 64600
+        """
+    )
+
+    test_func = functools.partial(check_port_179_open,"r1-cust")
+    _, res = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assertmsg = "BGP port related to r1-cust listening when neighbor is removed"
+    assert res is None, assertmsg
+
+    step("add a neighbor on r1-cust BGP for the second time")
+
+    r1.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 64600 vrf r1-cust
+         neighbor 192.0.2.4 remote-as 64600
+        """
+    )
+
+    test_func = functools.partial(check_port_179_open, "r1-cust")
+    _, res = topotest.run_and_expect(test_func, "r1-cust", count=30, wait=1)
+    assertmsg = "BGP port related to r1-cust not listening when a neighbor is set for the second time"
+    assert res == 'r1-cust', assertmsg
+
+    step("remove the neighbor from r1-cust for the second time")
+
+    r1.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 64600 vrf r1-cust
+         no neighbor 192.0.2.4 remote-as 64600
+        """
+    )
+
+    test_func = functools.partial(check_port_179_open, "r1-cust")
+    _, res = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assertmsg = "BGP port related to r1-cust listening when neighbor is removed for the second time"
+    assert res is None, assertmsg
+
+    step("add a listen range  ot r1-cust")
+
+    r1.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 64600 vrf r1-cust
+          neighbor rlisten peer-group
+          neighbor rlisten remote-as 64500
+          bgp listen range 192.0.2.0/24 peer-group rlisten
+        """
+    )
+
+    test_func = functools.partial(check_port_179_open, "r1-cust")
+    _, res = topotest.run_and_expect(test_func, "r1-cust", count=30, wait=1)
+    assertmsg = "BGP port related to r1-cust not listening when a listen range is set "
+    assert res == 'r1-cust', assertmsg
+
+    step("remove the listen range on r1-cust")
+
+    r1.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 64600 vrf r1-cust
+          no bgp listen range 192.0.2.0/24 peer-group rlisten
+        """
+    )
+
+    test_func = functools.partial(check_port_179_open, "r1-cust")
+    _, res = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assertmsg = "BGP port related to r1-cust listening when listen range is removed"
+    assert res is None, assertmsg
+
+
+    step("remove bgp on vrf default")
+
+    test_func = functools.partial(check_port_179_open, "default")
+    _, res = topotest.run_and_expect(test_func, "0.0.0.0", count=15, wait=1)
+    assertmsg = "default BGP port not listening when default bgp is set"
+    assert res == '0.0.0.0', assertmsg
+
+
+    r1.vtysh_cmd(
+        """
+        configure terminal
+         no router bgp 64500
+        """
+    )
+
+    test_func = functools.partial(check_port_179_open,"default")
+    _, res = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assertmsg = "default BGP port listening when default bgp is removed"
+    assert res is None , assertmsg
+
+    step("add one bgp view")
+
+    r1.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 64700 view V_ONE
+         bgp router-id 192.0.2.1
+         no bgp ebgp-requires-policy
+         neighbor rrserver peer-group
+         neighbor rrserver remote-as 64500
+         neighbor rrserver update-source lo
+         neighbor rrserver timers connect 2
+         neighbor 192.0.2.3 peer-group rrserver
+        """
+    )
+
+    test_func = functools.partial(check_port_179_open, "default")
+    _, res = topotest.run_and_expect(test_func, "0.0.0.0", count=30, wait=1)
+    assertmsg = "default BGP port not listening when one bgp view set"
+    assert res == '0.0.0.0', assertmsg
+
+    step("add second bgp view")
+
+    r1.vtysh_cmd(
+        """
+        configure terminal
+         router bgp 64800 view V_TWO
+         bgp router-id 192.0.2.1
+         no bgp ebgp-requires-policy
+         neighbor rrserver peer-group
+         neighbor rrserver remote-as 64500
+         neighbor rrserver update-source lo
+         neighbor rrserver timers connect 2
+         neighbor 192.0.2.3 peer-group rrserver
+        """
+    )
+
+    test_func = functools.partial(check_port_179_open, "default")
+    _, res = topotest.run_and_expect(test_func, "0.0.0.0", count=15, wait=1)
+    assertmsg = "default BGP port not listening when two bgp view set"
+    assert res == '0.0.0.0', assertmsg
+
+
+    step("remove neighbor on first bgp view")
+
+    r1.vtysh_cmd(
+        """
+        configure terminal
+          no router bgp 64700 view V_ONE
+        """
+    )
+
+    test_func = functools.partial(check_port_179_open, "default")
+    _, res = topotest.run_and_expect(test_func, "0.0.0.0", count=30, wait=1)
+    assertmsg = "default BGP port not listening when one of two bgp view removed"
+    assert res == '0.0.0.0', assertmsg
+
+    step("remove second  bgp view")
+
+    r1.vtysh_cmd(
+        """
+        configure terminal
+          router bgp 64800 view V_TWO
+          no neighbor 192.0.2.3 peer-group rrserver
+        """
+    )
+
+    test_func = functools.partial(check_port_179_open, "default")
+    _, res = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assertmsg = "default BGP port listening when the two bgp view are removed"
+    assert res is None, assertmsg
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Currently bgpd open a listening port for every existing bgp instance.
This leads to have open port (identified as a security leak) for l3vrf without neigbhors.

Now only default VRF is opening is BGP port at starting
other VRF wait for neigbhor creation or listening-range command 