### PR TITLE
bgpd: Unset TOVPN_SID_EXPLICIT flag to ensure BGP can release SRv6 SIDs

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4145,6 +4145,7 @@ int bgp_delete(struct bgp *bgp)
 	 */
 	bgp->tovpn_sid_index = 0;
 	UNSET_FLAG(bgp->vrf_flags, BGP_VRF_TOVPN_SID_AUTO);
+	UNSET_FLAG(bgp->vrf_flags, BGP_VRF_TOVPN_SID_EXPLICIT);
 	delete_vrf_tovpn_sid_per_vrf(bgp_default, bgp);
 	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
 		bgp->vpn_policy[afi].tovpn_sid_index = 0;


### PR DESCRIPTION
When a BGP instance is about to be destroyed, we call delete_vrf_tovpn_sid_per_vrf() to release SRv6 SIDs.

This function checks that there are no BGP_VRF_TOVPN_SID_* flags set for this BGP instance. If there are, then it assumes that this BGP instance is still using SRv6, and returns early without releasing the SIDs.

This PR makes sure the BGP_VRF_TOVPN_SID_EXPLICIT flag is unset before calling delete_vrf_tovpn_sid_per_vrf(), so that the delete_vrf_tovpn_sid_per_vrf() can do its job and release the SIDs.