### PR TITLE
nhrpd: fix crash when accessing invalid memory zone

### DIFF
--- a/nhrpd/nhrp_packet.c
+++ b/nhrpd/nhrp_packet.c
@@ -182,7 +182,8 @@ struct nhrp_cie_header *nhrp_cie_pull(struct zbuf *zb,
 	if (!cie)
 		return NULL;
 
-	if (cie->nbma_address_len + cie->nbma_subaddress_len > 0) {
+	if (cie->nbma_address_len + cie->nbma_subaddress_len > 0 &&
+	    cie->nbma_address_len + cie->nbma_subaddress_len <= zbuf_used(zb)) {
 		sockunion_set(nbma, afi2family(htons(hdr->afnum)),
 			      zbuf_pulln(zb,
 					 cie->nbma_address_len
@@ -192,7 +193,7 @@ struct nhrp_cie_header *nhrp_cie_pull(struct zbuf *zb,
 		sockunion_family(nbma) = AF_UNSPEC;
 	}
 
-	if (cie->protocol_address_len) {
+	if (cie->protocol_address_len && cie->protocol_address_len <= zbuf_used(zb)) {
 		sockunion_set(proto, proto2family(htons(hdr->protocol_type)),
 			      zbuf_pulln(zb, cie->protocol_address_len),
 			      cie->protocol_address_len);


### PR DESCRIPTION
A crash is detected on an invalid memory access to the 0x0 address zone.

> #0  __pthread_kill_implementation (no_tid=0, signo=11, threadid=130889386464320)
>     at ./nptl/pthread_kill.c:44
> #1  __pthread_kill_internal (signo=11, threadid=130889386464320) at ./nptl/pthread_kill.c:78
> #2  __GI___pthread_kill (threadid=130889386464320, signo=signo@entry=11) at ./nptl/pthread_kill.c:89
> #3  0x0000770b0f042476 in __GI_raise (sig=11) at ../sysdeps/posix/raise.c:26
> #4  0x0000770b0f507846 in core_handler (signo=11, siginfo=0x7ffd4f7ec9f0, context=0x7ffd4f7ec8c0)
>     at /build/make-pkg/output/_packages/cp-routing/src/lib/sigevent.c:262
> #5  <signal handler called>
> #6  __memmove_evex_unaligned_erms () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:339
> #7  0x0000770b0f50bb54 in sockunion_set (su=0x7ffd4f7ed7b0, family=2, addr=0x0, bytes=4)
>     at /build/make-pkg/output/_packages/cp-routing/src/lib/sockunion.c:500
> #8  0x00005f75d5430817 in nhrp_cie_pull (zb=0x5f75f262c4d0, hdr=0x5f75f2627dd8, nbma=0x7ffd4f7ed6d0,
>     proto=0x7ffd4f7ed7b0) at /build/make-pkg/output/_packages/cp-routing/src/nhrpd/nhrp_packet.c:180
> #9  0x00005f75d5434652 in nhrp_peer_forward (p=0x5f75f2605f30, pp=0x7ffd4f7ed8c0)
>     at /build/make-pkg/output/_packages/cp-routing/src/nhrpd/nhrp_peer.c:1050
> #10 0x00005f75d54356cb in nhrp_peer_recv (p=0x5f75f2605f30, zb=0x5f75f2627da0)
>     at /build/make-pkg/output/_packages/cp-routing/src/nhrpd/nhrp_peer.c:1341
> #11 0x00005f75d5430d8e in nhrp_packet_recvraw (t=0x7ffd4f7ede80)
>     at /build/make-pkg/output/_packages/cp-routing/src/nhrpd/nhrp_packet.c:332
> #12 0x0000770b0f521188 in thread_call (thread=0x7ffd4f7ede80)
>     at /build/make-pkg/output/_packages/cp-routing/src/lib/thread.c:1825
> #13 0x0000770b0f4b7737 in frr_run (master=0x5f75f2440570)
>     at /build/make-pkg/output/_packages/cp-routing/src/lib/libfrr.c:1155
> #14 0x00005f75d542d2b4 in main (argc=3, argv=0x7ffd4f7ee0b8)
>     at /build/make-pkg/output/_packages/cp-routing/src/nhrpd/nhrp_main.c:317

The incoming nhrp packet is too short, and the call to sockunion_set() uses a 0x0 memory zone, because the whole nhrp packet has been parsed, and the zbuf length used was 0. Fix this by detecting the zbuf remaining length before calling sockunion_set.