### PR TITLE
lib: Fix impossible situation with first variable

### DIFF
--- a/lib/srv6.c
+++ b/lib/srv6.c
@@ -150,7 +150,11 @@ static char *seg6local_flavors2str(char *str, size_t size,
 
 	len += snprintf(str + len, size - len, "(");
 	if (CHECK_SRV6_FLV_OP(flv_info->flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_PSP)) {
-		len += snprintf(str + len, size - len, "%sPSP", first ? "" : "/");
+		/*
+		 * First is never null for this one.  If you reorder ensure
+		 * that we properly touch first here in the snprintf
+		 */
+		len += snprintf(str + len, size - len, "%sPSP", "");
 		first = false;
 	}
 	if (CHECK_SRV6_FLV_OP(flv_info->flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_USP)) {


### PR DESCRIPTION
first is always true for the first if statement.  As such we do not need to take it into account.  Makes coverity happy, plus the note if someone comes in and changes things around they can fix it up right.