### PR TITLE
zebra: zebra core with v6 RA

### DIFF
--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -1400,7 +1400,6 @@ static void rtadv_start_interface_events(struct zebra_vrf *zvrf,
 	adv_if = adv_if_add(zvrf, zif->ifp->name);
 	if (adv_if != NULL) {
 		rtadv_send_packet(zvrf->rtadv.sock, zif->ifp, RA_ENABLE);
-		wheel_add_item(zrouter.ra_wheel, zif->ifp);
 		return; /* Already added */
 	}
 
@@ -1588,12 +1587,16 @@ void rtadv_stop_ra(struct interface *ifp, bool if_down_event)
 {
 	struct zebra_if *zif;
 	struct zebra_vrf *zvrf;
+	struct adv_if *adv_if = NULL;
 
 	/*Try to delete from ra wheels */
 	wheel_remove_item(zrouter.ra_wheel, ifp);
 
 	zif = ifp->info;
 	zvrf = rtadv_interface_get_zvrf(ifp);
+	adv_if = adv_if_del(zvrf, ifp->name);
+	if (adv_if != NULL)
+		adv_if_free(adv_if);
 
 	/*Turn off event for ICMPv6 join*/
 	event_cancel(&zif->icmpv6_join_timer);


### PR DESCRIPTION
Following core/BT was seen in internal code

Program terminated with signal SIGSEGV, Segmentation fault. [Current thread is 1 (Thread 0x7fcd750c9540 (LWP 30999))] (gdb) bt
0  0x00007fcd7596feec in ?? () from /lib/x86_64-linux-gnu/libc.so.6 1  0x00007fcd75920fb2 in raise () from /lib/x86_64-linux-gnu/libc.so.6 2  0x00007fcd75d008dc in core_handler (signo=11, siginfo=0x7ffd92dcb4f0, context=<optimized out>) at ../lib/sigevent.c:261 3  <signal handler called>
4  process_rtadv (arg=0x560287b66120) at ../zebra/rtadv.c:511 5  0x00007fcd75d1fa37 in wheel_timer_thread (t=<optimized out>) at ../lib/wheel.c:42 6  0x00007fcd75d13681 in event_call (thread=thread@entry=0x7ffd92dcbb60) at ../lib/event.c:2034 7  0x00007fcd75cbcb00 in frr_run (master=0x56028789ce00) at ../lib/libfrr.c:1242 8  0x0000560272e3945d in main (argc=14, argv=0x7ffd92dcbe88) at ../zebra/main.c:584 (gdb)

Paths to crash(Different occurrence):
Interface uplink_2 got added to wheel timer 1st time, at end of rtadv_start_interface_events() 1)2025-06-07T05:01:23.802459+00:00 mlx-5600-33 zebra[229165]: [SEY8W-2M6VH]  debug rtadv_start_interface_events, loc 2>>>>>::ifp::0x55a3281b1990::uplink_2

About each 1 sec, wheel timer process the interface uplink_2 Log from process_rtadv()
2025-06-07T05:01:29.870749+00:00 mlx-5600-33 zebra[229165]: [H1EZX-2D8SA]  debug <<>>>>>>::ifp::0x55a3281b1990::uplink_2 2025-06-07T05:01:30.870767+00:00 mlx-5600-33 zebra[229165]: [H1EZX-2D8SA]  debug <<>>>>>>::ifp::0x55a3281b1990::uplink_2 2025-06-07T05:01:31.870783+00:00 mlx-5600-33 zebra[229165]: [H1EZX-2D8SA]  debug <<>>>>>>::ifp::0x55a3281b1990::uplink_2 2025-06-07T05:01:32.870794+00:00 mlx-5600-33 zebra[229165]: [H1EZX-2D8SA]  debug <<>>>>>>::ifp::0x55a3281b1990::uplink_2 2025-06-07T05:01:33.870809+00:00 mlx-5600-33 zebra[229165]: [H1EZX-2D8SA]  debug <<>>>>>>::ifp::0x55a3281b1990::uplink_2 2025-06-07T05:01:34.870836+00:00 mlx-5600-33 zebra[229165]: [H1EZX-2D8SA]  debug <<>>>>>>::ifp::0x55a3281b1990::uplink_2

Now 2nd addition to wheel timer for same interface uplink_2  in rtadv_start_interface_events
>>if (adv_if != NULL) {
        rtadv_send_packet(zvrf->rtadv.sock, zif->ifp, RA_ENABLE);
        wheel_add_item(zrouter.ra_wheel, zif->ifp);<<<duplicate gets added
        return; /* Already added */
    }

2)2025-06-07T05:03:44.642871+00:00 mlx-5600-33 zebra[229165]: [G63V5-AKC5D]  debug in rtadv_start_interface_events, loc 1 >>>>>::ifp::0x55a3281b1990::uplink_2

Now, about each 1 sec, wheel timer process the interface uplink_2, twice back to back, which proves that indeed there are duplicate entries for uplink_2 in wheel timer
 Log from process_rtadv()
2025-06-07T05:03:44.878999+00:00 mlx-5600-33 zebra[229165]: [H1EZX-2D8SA]  debug <<>>>>>>::ifp::0x55a3281b1990::uplink_2 2025-06-07T05:03:44.879076+00:00 mlx-5600-33 zebra[229165]: [H1EZX-2D8SA]  debug <<>>>>>>::ifp::0x55a3281b1990::uplink_2 2025-06-07T05:03:45.879096+00:00 mlx-5600-33 zebra[229165]: [H1EZX-2D8SA]  debug <<>>>>>>::ifp::0x55a3281b1990::uplink_2 2025-06-07T05:03:45.879169+00:00 mlx-5600-33 zebra[229165]: [H1EZX-2D8SA]  debug <<>>>>>>::ifp::0x55a3281b1990::uplink_2 2025-06-07T05:03:46.879187+00:00 mlx-5600-33 zebra[229165]: [H1EZX-2D8SA]  debug <<>>>>>>::ifp::0x55a3281b1990::uplink_2 2025-06-07T05:03:46.879240+00:00 mlx-5600-33 zebra[229165]: [H1EZX-2D8SA]  debug <<>>>>>>::ifp::0x55a3281b1990::uplink_2

3)Now suppose the interface iuplink_2 s shutdown/removed, it will remove one instance for the interface from the wheel timer, another will still stay there 4)Interface uplink_2 memory is freed up
5)Now wheel timer tries to process uplink_2, it will crash