### PR TITLE
bgpd: fix wrong match for routemap

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1916,6 +1916,7 @@ void vpn_leak_from_vrf_update(struct bgp *to_bgp,	     /* to */
 		memset(&info, 0, sizeof(info));
 		info.peer = to_bgp->peer_self;
 		info.attr = &static_attr;
+		info.type = path_vrf->type;
 		ret = route_map_apply(from_bgp->vpn_policy[afi]
 					      .rmap[BGP_VPN_POLICY_DIR_TOVPN],
 				      p, &info);
@@ -2522,6 +2523,7 @@ static void vpn_leak_to_vrf_update_onevrf(struct bgp *to_bgp,	/* to */
 		info.attr = &static_attr;
 		info.extra = path_vpn->extra; /* Used for source-vrf filter */
 		info.net = path_vpn->net;     /* Used to detect afi and safi */
+		info.type = path_vpn->type;
 		ret = route_map_apply(to_bgp->vpn_policy[afi]
 					      .rmap[BGP_VPN_POLICY_DIR_FROMVPN],
 				      p, &info);


### PR DESCRIPTION
When one `routemap` is used for `vpn/vrf`, the "source-protocol" match is wrongly not set. Just set it.