### PR TITLE
tests: add new /run/netns tmpfs to each topotest router namespace

### DIFF
--- a/tests/topotests/lib/micronet_compat.py
+++ b/tests/topotests/lib/micronet_compat.py
@@ -33,6 +33,10 @@ class Node(LinuxNamespace):
 
         super().__init__(name, **nkwargs)
 
+        # Create a new mounted FS for tracking nested network namespaces created by the
+        # user with `ip netns add`
+        self.tmpfs_mount("/run/netns")
+
         self.rundir = self.unet.rundir.joinpath(self.name)
 
     def cmd(self, cmd, **kwargs):


### PR DESCRIPTION
This is required for correct parallel execution when tests add new namespaces with `add_netns()` which uses `ip netns add` command which tracks them using `/run/netns`.