### PR TITLE
zebra: fix nexthop rib out for duplicate nhg

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1189,11 +1189,12 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 			show_nexthop_json_helper(json_nexthops, nexthop, NULL,
 						 NULL);
 		} else {
-			if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
-				vty_out(vty, "          ");
-			else
+			if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE) ||
+			    CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
 				/* Make recursive nexthops a bit more clear */
 				vty_out(vty, "       ");
+			else
+				vty_out(vty, "          ");
 			show_route_nexthop_helper(vty, NULL, NULL, nexthop);
 		}
 
@@ -1256,15 +1257,12 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 				json_object_array_add(json_backup_nexthop_array,
 						      json_backup_nexthops);
 			} else {
-
-				if (!CHECK_FLAG(nexthop->flags,
-						NEXTHOP_FLAG_RECURSIVE))
-					vty_out(vty, "          ");
-				else
-					/* Make recursive nexthops a bit more
-					 * clear
-					 */
+				if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE) ||
+				    CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
+					/* Make recursive nexthops a bit more clear */
 					vty_out(vty, "       ");
+				else
+					vty_out(vty, "          ");
 				show_route_nexthop_helper(vty, NULL, NULL,
 							  nexthop);
 				vty_out(vty, "\n");


### PR DESCRIPTION
The duplicate nexthop is not displayed with proper alignment.

```
mlx-4700-44# show nexthop-group rib 580
ID: 580 (zebra)
     RefCnt: 1
     Uptime: 01:39:06
     VRF: default
     Valid, Installed
     Depends: (530) (564) (579)
        via 20.1.1.9 (vrf default) (recursive), weight 1
           via 20.1.1.2, swp1s0 (vrf default), weight 1
        via 30.1.2.9 (vrf default) (recursive), weight 1
           via 30.1.1.2, br_default.60 (vrf default), weight 1
           via 30.1.1.6, vlan70 (vrf default), weight 1
           via 30.1.1.10, bond1 (vrf default), weight 1
           via 20.1.1.2, swp1s0 (vrf default), weight 1 <<<<<<<<
```

With fix:
```
mlx-4700-44# show nexthop-group rib 580
ID: 580 (zebra)
     RefCnt: 1
     Uptime: 01:39:06
     VRF: default
     Valid, Installed
     Depends: (530) (564) (579)
        via 20.1.1.9 (vrf default) (recursive), weight 1
           via 20.1.1.2, swp1s0 (vrf default), weight 1
        via 30.1.2.9 (vrf default) (recursive), weight 1
           via 30.1.1.2, br_default.60 (vrf default), weight 1
           via 30.1.1.6, vlan70 (vrf default), weight 1
           via 30.1.1.10, bond1 (vrf default), weight 1
        via 20.1.1.2, swp1s0 (vrf default), weight 1

mlx-4700-44# show nexthop-group rib 530
ID: 530 (zebra)
     RefCnt: 17
     Uptime: 02:02:52
     VRF: default
     Valid, Installed
     Interface Index: 38
           via 20.1.1.2, swp1s0 (vrf default), weight 1
     Dependents: (576) (579) (580) (582)

show nexthop-group rib 580 json

  "580":{
    "type":"zebra",
    "refCount":1,
    "uptime":"02:01:33",
    "vrf":"default",
    "nhGrpUptimeEstablishedEpoch":1749708524,
    "valid":true,
    "installed":true,
    "depends":[
      530,
      564,
      579
    ],
    "nexthops":[
      {
        "flags":5,
        "ip":"20.1.1.9",
        "afi":"ipv4",
        "vrf":"default",
        "active":true,
        "recursive":true,
        "weight":1
      },
      {
        "flags":3,
        "fib":true,
        "ip":"20.1.1.2",
        "afi":"ipv4",
        "interfaceIndex":38,
        "interfaceName":"swp1s0",
        "vrf":"default",
        "resolver":true,
        "active":true,
        "weight":1
      },
      {
        "flags":19,
        "duplicate":true, <<<<
        "fib":true,
        "ip":"20.1.1.2",
        "afi":"ipv4",
        "interfaceIndex":38,
        "interfaceName":"swp1s0",
        "vrf":"default",
        "active":true,
        "weight":1
      }
    ]
  }
  ```
  
  Signed-off-by: Chirag Shah <chirag@nvidia.com