### PR TITLE
pimd: Fix Register-Stop state machine logic to align with RFC7761

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1966,8 +1966,18 @@ static void pim_upstream_register_probe_timer(struct event *t)
 		if (PIM_DEBUG_PIM_REG)
 			zlog_debug("cannot send Null register for %pSG, no path to RP",
 				   &up->sg);
-	} else
+	} else {
+		up->reg_state = PIM_REG_JOIN_PENDING;
+		if (PIM_DEBUG_PIM_TRACE) {
+			char state_str[PIM_REG_STATE_STR_LEN];
+			zlog_debug("%s: (S,G)=%s Sending null register, reg_state=%s",
+				   __func__, up->sg_str,
+				   pim_reg_state2str(up->reg_state,
+						     state_str,
+						     sizeof(state_str)));
+		}
 		pim_null_register_send(up);
+	}
 
 	pim_upstream_start_register_stop_timer(up);
 }


### PR DESCRIPTION
The previous implementation of the PIM DR Register state machine did not immediately transition to Join-Pending after the suppression timer expired. This caused a 5-second "deaf period" where new Register-Stop messages were ignored.

This patch corrects the logic by:
- Updating the state to PIM_REG_JOIN_PENDING immediately upon suppression timer expiry, as per [RFC7761 Figure 1](https://www.rfc-editor.org/rfc/inline-errata/rfc7761.html#:~:text=Figure%201%3A%20Per%2D(S%2CG)%20Register%20State%20Machine%20at%20a%20DR).
- Ensuring Register-Stop messages are handled correctly in the Join-Pending state.
- Fix a redundant Null-Register transmission.

This change makes the PIM-SM implementation more robust and compliant.