### PR TITLE
Update to munet release 0.15.5

### DIFF
--- a/tests/topotests/munet/base.py
+++ b/tests/topotests/munet/base.py
@@ -2730,12 +2730,6 @@ class BaseMunet(LinuxNamespace):
 
         self.hosts[name] = cls(name, unet=self, **kwargs)
 
-        # Create a new mounted FS for tracking nested network namespaces creatd by the
-        # user with `ip netns add`
-
-        # XXX why is this failing with podman???
-        # self.hosts[name].tmpfs_mount("/run/netns")
-
         return self.hosts[name]
 
     def add_link(self, node1, node2, if1, if2, mtu=None, **intf_constraints):

--- a/tests/topotests/munet/cli.py
+++ b/tests/topotests/munet/cli.py
@@ -182,9 +182,7 @@ def host_cmd_split(unet, line, toplevel):
     if not csplit:
         return hosts, "", "", True
 
-    i = line.index(csplit[0])
-    i += len(csplit[0])
-    return hosts, csplit[0], line[i:].strip(), banner
+    return hosts, csplit[0], ' '.join(csplit[1:]), banner
 
 
 def win_cmd_host_split(unet, cmd, kinds, defall):

--- a/tests/topotests/munet/munet-schema.json
+++ b/tests/topotests/munet/munet-schema.json
@@ -171,6 +171,9 @@
                   "initial-password": {
                     "type": "string"
                   },
+                  "prompt": {
+                    "type": "string"
+                  },
                   "expects": {
                     "type": "array",
                     "items": {
@@ -516,6 +519,9 @@
                         "type": "string"
                       },
                       "initial-password": {
+                        "type": "string"
+                      },
+                      "prompt": {
                         "type": "string"
                       },
                       "expects": {

--- a/tests/topotests/munet/mutest/__main__.py
+++ b/tests/topotests/munet/mutest/__main__.py
@@ -237,6 +237,10 @@ async def execute_test(
     try:
         passed, failed, e = tc.execute()
     except uapi.CLIOnErrorError as error:
+        if error.desc != "":
+            print(f"\n== CLI ON ERROR: {error.desc} ==")
+        else:
+            print("\n== CLI ON ERROR: *NO DESCRIPTION PROVIDED* ==")
         await async_cli(unet)
         passed, failed, e = 0, 0, error
 


### PR DESCRIPTION
Changes since 0.15.4:
mutest: update docs that no-description implies no error on !success mutest: print pause on empty desc
mutest: improve clarty of test pause
mutest: fix partial match for non dictionary items mutest: do even deeper inspection during DeepDiff for in-exect matching mutest: add control step, pause()
munet: replace %NAME% in prompt
munet: fix issue with adding namespaces in parallel runs munet: fix bug in cli.py
munet: cleanup p2p configuration
munet: Allow more than 256 nodes
docs: Alternate install instructions