### PR TITLE
static: [SRv6] Fixing uninstall and reinstall uA Sids upon Intf flaps

### DIFF
--- a/staticd/static_srv6.c
+++ b/staticd/static_srv6.c
@@ -50,6 +50,9 @@ void static_ifp_srv6_sids_update(struct interface *ifp, bool is_up)
 	 */
 	for (ALL_LIST_ELEMENTS_RO(srv6_sids, node, sid)) {
 		if ((strcmp(sid->attributes.vrf_name, ifp->name) == 0) ||
+		    ((sid->behavior == SRV6_ENDPOINT_BEHAVIOR_END_X ||
+		      sid->behavior == SRV6_ENDPOINT_BEHAVIOR_END_X_NEXT_CSID) &&
+		     strcmp(sid->attributes.ifname, ifp->name) == 0) ||
 		    (strncmp(ifp->name, DEFAULT_SRV6_IFNAME, sizeof(ifp->name)) == 0 &&
 		     (sid->behavior == SRV6_ENDPOINT_BEHAVIOR_END ||
 		      sid->behavior == SRV6_ENDPOINT_BEHAVIOR_END_NEXT_CSID))) {

--- a/tests/topotests/static_srv6_sids/expected_srv6_sids_interface_down.json
+++ b/tests/topotests/static_srv6_sids/expected_srv6_sids_interface_down.json
@@ -1,0 +1,68 @@
+{
+	"fcbb:bbbb:1:fe10::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe10::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"nexthops": [
+				{
+					"directlyConnected": true,
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT4"
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe20::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe20::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"nexthops": [
+				{
+					"directlyConnected": true,
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT6"
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe30::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe30::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"nexthops": [
+				{
+					"directlyConnected": true,
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT46"
+					}
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Static daemons in the current code does not remove/add SRv6 sids configured with behavior uA on an interface when it receives the interface events.

Fixing this.

```
Initial state:
ip -6 -d route  | grep End.X
unicast fcbb:bbbb:fe5::/48 nhid 16  encap seg6local action End.X nh6 fe80::c0f9:81ff:fe68:6455 dev r1-eth1 proto 196 scope global metric 20 pref medium vtysh -c "sh ipv6 route" | grep seg6
S>* fcbb:bbbb:fe5::/48 [1/0] is directly connected, r1-eth1, seg6local uA nh6 fe80::c0f9:81ff:fe68:6455, weight 1, 00:00:20

ip link set down r1-eth1
vtysh -c "sh ipv6 route" | grep seg6
S>  fcbb:bbbb:fe5::/48 [1/0] is directly connected, r1-eth1 inactive, seg6local uA nh6 fe80::c0f9:81ff:fe68:6455, weight 1, 00:00:28 ip -6 -d route  | grep End.X

ip link set up r1-eth1
vtysh -c "sh ipv6 route" | grep seg6
S>* fcbb:bbbb:fe5::/48 [1/0] is directly connected, r1-eth1, seg6local uA nh6 fe80::c0f9:81ff:fe68:6455, weight 1, 00:00:41 ip -6 -d route  | grep End.X
```