### PR TITLE
mgmtd: remove unfinished and unneeded yang-validate code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1816,13 +1816,7 @@ AS_IF([test "$enable_bgpd" != "no"], [
 ])
 
 AS_IF([test "$enable_mgmtd" != "no"], [
-
   AC_DEFINE([HAVE_MGMTD], [1], [mgmtd])
-
-  # Enable MGMTD local validations
-  AS_IF([test "$enable_mgmtd_local_validations" == "yes"], [
-    AC_DEFINE([MGMTD_LOCAL_VALIDATIONS_ENABLED], [1], [Enable mgmtd local validations.])
-  ])
 ])
 
 AS_IF([test "$enable_mgmtd_test_be_client" = "yes"], [

--- a/lib/mgmt_be_client.c
+++ b/lib/mgmt_be_client.c
@@ -529,11 +529,7 @@ static int mgmt_be_txn_cfg_prepare(struct mgmt_be_txn_ctx *txn, const char **con
 	gettimeofday(&prep_nb_cfg_start, NULL);
 	err = nb_candidate_commit_prepare(nb_ctx, client_ctx->candidate_config,
 					  "MGMTD Backend Txn", &txn->nb_txn,
-#ifdef MGMTD_LOCAL_VALIDATIONS_ENABLED
-					  true, true,
-#else
 					  false, true,
-#endif
 					  err_buf, sizeof(err_buf) - 1);
 	if (err != NB_OK) {
 		err_buf[sizeof(err_buf) - 1] = 0;

--- a/mgmtd/mgmt_fe_adapter.c
+++ b/mgmtd/mgmt_fe_adapter.c
@@ -1934,12 +1934,6 @@ mgmt_fe_adapter_cmt_stats_write(struct vty *vty,
 				mgmt_realtime_to_string(
 					&adapter->cmt_stats.last_start, buf,
 					sizeof(buf)));
-#ifdef MGMTD_LOCAL_VALIDATIONS_ENABLED
-			vty_out(vty, "        Config-Validate Start: \t\t%s\n",
-				mgmt_realtime_to_string(
-					&adapter->cmt_stats.validate_start, buf,
-					sizeof(buf)));
-#endif
 			vty_out(vty, "        Prep-Config Start: \t\t%s\n",
 				mgmt_realtime_to_string(
 					&adapter->cmt_stats.prep_cfg_start, buf,

--- a/mgmtd/mgmt_fe_adapter.h
+++ b/mgmtd/mgmt_fe_adapter.h
@@ -19,9 +19,6 @@ struct mgmt_master;
 
 struct mgmt_commit_stats {
 	struct timeval last_start;
-#ifdef MGMTD_LOCAL_VALIDATIONS_ENABLED
-	struct timeval validate_start;
-#endif
 	struct timeval prep_cfg_start;
 	struct timeval txn_create_start;
 	struct timeval apply_cfg_start;

--- a/mgmtd/mgmt_txn.c
+++ b/mgmtd/mgmt_txn.c
@@ -717,38 +717,6 @@ static int mgmt_txn_prepare_config(struct mgmt_txn_ctx *txn)
 		goto mgmt_txn_prepare_config_done;
 	}
 
-#ifdef MGMTD_LOCAL_VALIDATIONS_ENABLED
-	if (mm->perf_stats_en)
-		gettimeofday(&txn->commit_cfg_req->req.commit_cfg.cmt_stats
-				      ->validate_start,
-			     NULL);
-	/*
-	 * Perform application level validations locally on the MGMTD
-	 * process by calling application specific validation routines
-	 * loaded onto MGMTD process using libraries.
-	 */
-	nb_ctx.client = NB_CLIENT_MGMTD_SERVER;
-	nb_ctx.user = (void *)txn;
-	ret = nb_candidate_validate_code(&nb_ctx, nb_config, &changes, err_buf,
-					 sizeof(err_buf) - 1);
-	if (ret != NB_OK) {
-		if (strncmp(err_buf, " ", strlen(err_buf)) == 0)
-			strlcpy(err_buf, "Validation failed", sizeof(err_buf));
-		(void)mgmt_txn_send_commit_cfg_reply(txn, MGMTD_INVALID_PARAM,
-						     err_buf);
-		ret = -1;
-		goto mgmt_txn_prepare_config_done;
-	}
-
-	if (txn->commit_cfg_req->req.commit_cfg.validate_only) {
-		/*
-		 * This was a validate-only COMMIT request return success.
-		 */
-		(void)mgmt_txn_send_commit_cfg_reply(txn, MGMTD_SUCCESS, NULL);
-		goto mgmt_txn_prepare_config_done;
-	}
-#endif /* ifdef MGMTD_LOCAL_VALIDATIONS_ENABLED */
-
 mgmt_txn_prep_config_validation_done:
 
 	if (mm->perf_stats_en)

--- a/mgmtd/mgmt_txn.h
+++ b/mgmtd/mgmt_txn.h
@@ -27,20 +27,6 @@
 
 #define MGMTD_TXN_ID_NONE 0
 
-/*
- * The following definition enables local validation of config
- * on the MGMTD process by loading client-defined NB callbacks
- * and calling them locally before sening CNFG_APPLY_REQ to
- * backend for actual apply of configuration on internal state
- * of the backend application.
- *
- * #define MGMTD_LOCAL_VALIDATIONS_ENABLED
- *
- * Note: Enabled by default in configure.ac, if this needs to be
- * disabled then pass --enable-mgmtd-local-validations=no to
- * the list of arguments passed to ./configure
- */
-
 PREDECL_LIST(mgmt_txns);
 
 struct mgmt_master;


### PR DESCRIPTION
This didn't end up being needed. It requires embedding daemon specific semantic validation functions inside mgmtd. This would require another yang info structure mapping xpaths to the daemon specific validation.

In reality we do little of this type of validation, and there's almost no overlap between daemons (i.e., multiple daemons aren't doing the same validation) so we don't save on processing here to just do it once in the daemon vs once in mgmtd.