### PR TITLE
bgpd: fix do not use import|export vpn when import vrf command used

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10754,6 +10754,11 @@ DEFPY (bgp_imexport_vpn,
 
 	if (argv_find(argv, argc, "no", &idx))
 		yes = false;
+	else {
+		afi = vpn_policy_getafi(vty, bgp, false);
+		if (afi == AFI_MAX)
+			return CMD_WARNING_CONFIG_FAILED;
+	}
 
 	if (BGP_INSTANCE_TYPE_VRF != bgp->inst_type &&
 		BGP_INSTANCE_TYPE_DEFAULT != bgp->inst_type) {


### PR DESCRIPTION
The following error happens:

> red1(config)# router bgp 500 vrf RED_B
> red1(config-router)#  address-family ipv4 unicast
> red1(config-router-af)# import vrf default
> red1(config-router-af)# import vpn
> red1(config-router-af)# import vrf afz
> % error: Please unconfigure vpn to vrf commands before using import vrf commands

Do not use the import|export vpn command while vrf command is used.