### PR TITLE
lib: delay the free of vty pointer upon vty_close()

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -12466,6 +12466,13 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t sa
 			continue;
 
 		display = 0;
+
+		if (vty->status == VTY_CLOSE)
+			/* if an error happens during vty_out, a rescheduling
+			 * must be forced. stop the loop asap by leaving the calling command
+			 */
+			break;
+
 		if (use_json)
 			json_paths = json_object_new_array();
 		else

--- a/lib/command.c
+++ b/lib/command.c
@@ -1397,7 +1397,7 @@ static int root_on_exit(struct vty *vty)
 	if (vty_shell(vty))
 		exit(0);
 	else
-		vty_close(vty);
+		vty_event_closed(vty);
 	return 0;
 }
 
@@ -1735,7 +1735,7 @@ static int file_write_config(struct vty *vty)
 	vty_time_print(file_vty, 1);
 	vty_out(file_vty, "!\n");
 	vty_write_config(file_vty);
-	vty_close(file_vty);
+	vty_event_closed(file_vty);
 
 	if (stat(config_file, &conf_stat) >= 0) {
 		if (unlink(config_file_sav) != 0)

--- a/lib/command.c
+++ b/lib/command.c
@@ -1397,7 +1397,7 @@ static int root_on_exit(struct vty *vty)
 	if (vty_shell(vty))
 		exit(0);
 	else
-		vty->status = VTY_CLOSE;
+		vty_close(vty);
 	return 0;
 }
 

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -808,7 +808,7 @@ static int nb_write_config(struct nb_config *config, enum nb_cfg_format format,
 	if (config)
 		ret = nb_cli_show_config(file_vty, config, format, translator,
 					 false);
-	vty_close(file_vty);
+	vty_event_closed(file_vty);
 
 	return ret;
 }

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -1884,6 +1884,7 @@ void vty_stdio_close(void)
 {
 	if (!stdio_vty)
 		return;
+	/* keep syncro vty closure to avoid mem leak */
 	vty_close(stdio_vty);
 }
 
@@ -3481,6 +3482,7 @@ void vty_reset(void)
 	frr_each_safe (vtys, vty_sessions, vty) {
 		buffer_reset(vty->lbuf);
 		buffer_reset(vty->obuf);
+		/* keep syncro vty closure to avoid mem leak */
 		vty_close(vty);
 	}
 
@@ -4168,6 +4170,7 @@ void vty_terminate(void)
 	frr_each_safe (vtys, vtysh_sessions, vty) {
 		buffer_reset(vty->lbuf);
 		buffer_reset(vty->obuf);
+		/* keep syncro vty closure to avoid mem leak */
 		vty_close(vty);
 	}
 

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -1784,7 +1784,6 @@ static struct vty *vty_create(int vty_sock, union sockunion *su)
 		/* Vty is not available if password isn't set. */
 		if (host.password == NULL && host.password_encrypt == NULL) {
 			vty_out(vty, "Vty password is not set.\n");
-			vty->status = VTY_CLOSE;
 			vty_close(vty);
 			return NULL;
 		}
@@ -2636,7 +2635,6 @@ static void vty_timeout(struct event *thread)
 	vty_out(vty, "\nVty connection is timed out.\n");
 
 	/* Close connection. */
-	vty->status = VTY_CLOSE;
 	vty_close(vty);
 }
 
@@ -3479,7 +3477,6 @@ void vty_reset(void)
 	frr_each_safe (vtys, vty_sessions, vty) {
 		buffer_reset(vty->lbuf);
 		buffer_reset(vty->obuf);
-		vty->status = VTY_CLOSE;
 		vty_close(vty);
 	}
 
@@ -4167,7 +4164,6 @@ void vty_terminate(void)
 	frr_each_safe (vtys, vtysh_sessions, vty) {
 		buffer_reset(vty->lbuf);
 		buffer_reset(vty->obuf);
-		vty->status = VTY_CLOSE;
 		vty_close(vty);
 	}
 

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -197,7 +197,7 @@ void vty_mgmt_resume_response(struct vty *vty, int ret)
 	}
 
 	if (vty->status == VTY_CLOSE)
-		vty_close(vty);
+		return;
 	else if (vty->type != VTY_FILE)
 		vty_event(VTYSH_READ, vty);
 	else
@@ -1402,8 +1402,6 @@ static int vty_execute(struct vty *vty)
 
 	if (status != VTY_CLOSE && vty->status != VTY_CLOSE)
 		vty_prompt(vty);
-	else if (status == VTY_CLOSE)
-		vty_close(vty);
 
 	return ret;
 }
@@ -2478,9 +2476,7 @@ static void vtysh_read(struct event *thread)
 		}
 	}
 
-	if (vty->status == VTY_CLOSE)
-		vty_close(vty);
-	else
+	if (vty->status != VTY_CLOSE)
 		vty_event(VTYSH_READ, vty);
 }
 

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -1643,7 +1643,7 @@ static void vty_read(struct event *thread)
 
 	/* Check status. */
 	if (status == VTY_CLOSE)
-		vty_close(vty);
+		vty_event(VTY_CLOSED, vty);
 	else {
 		vty_event(VTY_WRITE, vty);
 		vty_event(VTY_READ, vty);
@@ -1787,7 +1787,7 @@ static struct vty *vty_create(int vty_sock, union sockunion *su)
 		/* Vty is not available if password isn't set. */
 		if (host.password == NULL && host.password_encrypt == NULL) {
 			vty_out(vty, "Vty password is not set.\n");
-			vty_close(vty);
+			vty_event(VTY_CLOSED, vty);
 			return NULL;
 		}
 	}
@@ -2344,7 +2344,7 @@ bool mgmt_vty_read_configs(void)
 
 	if (count)
 		vty_read_file_finish(vty, NULL);
-	vty_close(vty);
+	vty_event(VTY_CLOSED, vty);
 
 	zlog_info("mgmtd: finished reading config files");
 
@@ -2390,7 +2390,7 @@ static void vtysh_read(struct event *thread)
 		}
 		buffer_reset(vty->lbuf);
 		buffer_reset(vty->obuf);
-		vty_close(vty);
+		vty_event(VTY_CLOSED, vty);
 #ifdef VTYSH_DEBUG
 		printf("close vtysh\n");
 #endif /* VTYSH_DEBUG */
@@ -2636,7 +2636,7 @@ static void vty_timeout(struct event *thread)
 	vty_out(vty, "\nVty connection is timed out.\n");
 
 	/* Close connection. */
-	vty_close(vty);
+	vty_event(VTY_CLOSED, vty);
 }
 
 /* Read up configuration file from file_name. */
@@ -2668,7 +2668,7 @@ void vty_read_file(struct nb_config *config, FILE *confp)
 	(void)config_from_file(vty, confp, &line_num);
 
 	vty_read_file_finish(vty, config);
-	vty_close(vty);
+	vty_event(VTY_CLOSED, vty);
 }
 
 static void vty_read_file_finish(struct vty *vty, struct nb_config *config)
@@ -3047,7 +3047,7 @@ int vty_config_node_exit(struct vty *vty)
 	 */
 	if (vty->type == VTY_FILE && vty->status != VTY_CLOSE) {
 		vty_out(vty, "exit from config node while reading config file");
-		vty_close(vty);
+		vty_event(VTY_CLOSED, vty);
 	}
 
 	return 1;
@@ -3595,7 +3595,7 @@ static void vty_mgmt_session_notify(struct mgmt_fe_client *client,
 		vty->mgmt_session_id = 0;
 		/* We may come here by way of vty_close() and short-circuits */
 		if (vty->status != VTY_CLOSE)
-			vty_close(vty);
+			vty_event(VTY_CLOSED, vty);
 	}
 }
 

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -3051,7 +3051,7 @@ int vty_config_node_exit(struct vty *vty)
 	 */
 	if (vty->type == VTY_FILE && vty->status != VTY_CLOSE) {
 		vty_out(vty, "exit from config node while reading config file");
-		vty->status = VTY_CLOSE;
+		vty_close(vty);
 	}
 
 	return 1;

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -3128,6 +3128,11 @@ static void vty_event(enum vty_event event, struct vty *vty)
 	}
 }
 
+void vty_event_closed(struct vty *vty)
+{
+	vty_event(VTY_CLOSED, vty);
+}
+
 DEFUN_NOSH (config_who,
        config_who_cmd,
        "who",

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -45,6 +45,14 @@ struct vty_cfg_change {
 
 PREDECL_DLIST(vtys);
 
+enum vty_status {
+	VTY_NORMAL,
+	VTY_CLOSE,
+	VTY_MORE,
+	VTY_MORELINE,
+	VTY_PASSFD,
+};
+
 /* VTY struct. */
 struct vty {
 	struct vtys_item itm;
@@ -161,13 +169,7 @@ struct vty {
 	unsigned char escape;
 
 	/* Current vty status. */
-	enum {
-		VTY_NORMAL,
-		VTY_CLOSE,
-		VTY_MORE,
-		VTY_MORELINE,
-		VTY_PASSFD,
-	} status;
+	enum vty_status status;
 
 	/* vtysh socket/fd passing (for terminal monitor) */
 	int pass_fd;

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -434,6 +434,7 @@ extern int vty_mgmt_send_rpc_req(struct vty *vty, LYD_FORMAT request_type,
 				 const char *xpath, const char *data);
 extern int vty_mgmt_send_lockds_req(struct vty *vty, enum mgmt_ds_id ds_id, bool lock, bool scok);
 extern void vty_mgmt_resume_response(struct vty *vty, int ret);
+extern void vty_event_closed(struct vty *vty);
 
 static inline bool vty_needs_implicit_commit(struct vty *vty)
 {

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -208,6 +208,7 @@ struct vty {
 	/* Timeout seconds and thread. */
 	unsigned long v_timeout;
 	struct event *t_timeout;
+	struct event *t_close;
 
 	/* What address is this vty comming from. */
 	char address[SU_ADDRSTRLEN];

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -395,7 +395,6 @@ extern FILE *vty_open_config(const char *config_file, char *config_default_dir);
 extern bool vty_read_config(struct nb_config *config, const char *config_file,
 			    char *config_default_dir);
 extern void vty_read_file(struct nb_config *config, FILE *confp);
-extern void vty_read_file_finish(struct vty *vty, struct nb_config *config);
 extern void vty_time_print(struct vty *, int);
 extern void vty_serv_start(const char *, unsigned short, const char *);
 extern void vty_serv_stop(void);

--- a/tests/bgpd/test_peer_attr.c
+++ b/tests/bgpd/test_peer_attr.c
@@ -931,6 +931,7 @@ static void test_finish(struct test *test)
 
 	/* Cleanup allocated memory. */
 	if (test->vty) {
+		/* keep syncro vty closure to avoid mem leak */
 		vty_close(test->vty);
 		test->vty = NULL;
 	}

--- a/tests/lib/cli/test_commands.c
+++ b/tests/lib/cli/test_commands.c
@@ -396,6 +396,7 @@ int main(int argc, char **argv)
 	}
 	fprintf(stderr, "\nDone.\n");
 
+	/* keep syncro vty closure to avoid mem leak */
 	vty_close(vty);
 	prng_free(prng);
 	test_terminate();

--- a/tests/lib/test_grpc.cpp
+++ b/tests/lib/test_grpc.cpp
@@ -147,6 +147,7 @@ static void static_startup(void)
 static void static_shutdown(void)
 {
 	hook_call(test_grpc_fini);
+	/* keep syncro vty closure to avoid mem leak */
 	vty_close(vty);
 	vrf_terminate();
 	vty_terminate();

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -799,28 +799,28 @@ int vtysh_mark_file(const char *filename)
 				fprintf(stderr, "line %d: Warning...: %s\n",
 					lineno, vty->buf);
 			fclose(confp);
-			vty_close(vty);
+			vty_event_closed(vty);
 			XFREE(MTYPE_VTYSH_CMD, vty_buf_copy);
 			return ret;
 		case CMD_ERR_AMBIGUOUS:
 			fprintf(stderr, "line %d: %% Ambiguous command: %s\n",
 				lineno, vty->buf);
 			fclose(confp);
-			vty_close(vty);
+			vty_event_closed(vty);
 			XFREE(MTYPE_VTYSH_CMD, vty_buf_copy);
 			return CMD_ERR_AMBIGUOUS;
 		case CMD_ERR_NO_MATCH:
 			fprintf(stderr, "line %d: %% Unknown command: %s\n",
 				lineno, vty->buf);
 			fclose(confp);
-			vty_close(vty);
+			vty_event_closed(vty);
 			XFREE(MTYPE_VTYSH_CMD, vty_buf_copy);
 			return CMD_ERR_NO_MATCH;
 		case CMD_ERR_INCOMPLETE:
 			fprintf(stderr, "line %d: %% Command incomplete: %s\n",
 				lineno, vty->buf);
 			fclose(confp);
-			vty_close(vty);
+			vty_event_closed(vty);
 			XFREE(MTYPE_VTYSH_CMD, vty_buf_copy);
 			return CMD_ERR_INCOMPLETE;
 		case CMD_SUCCESS:
@@ -846,7 +846,7 @@ int vtysh_mark_file(const char *filename)
 	}
 	/* This is the end */
 	vty_out(vty, "\nend\n");
-	vty_close(vty);
+	vty_event_closed(vty);
 	XFREE(MTYPE_VTYSH_CMD, vty_buf_copy);
 
 	if (closefp)

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -625,6 +625,7 @@ static int vtysh_read_file(FILE *confp, bool dry_run)
 	vtysh_execute_no_pager("end");
 	vtysh_execute_no_pager("disable");
 
+	/* keep syncro vty closure to avoid : lib/event.c:1108: _event_add_event(): assertion (m != NULL) failed */
 	vty_close(lvty);
 
 	return (saved_ret);


### PR DESCRIPTION
If the 'show bgp ipv4 vpn' command is interrupted during the dump of the whole entries, then a heap use after free may appear.

> May 15 16:08:14 vRR-DUT bgpd[1647]: [N9HHH-F8H1M] %ADJCHANGE: neighbor 3.3.1.232(taastpap-scale-1) in vrf default Up
> May 15 16:08:14 vRR-DUT bgpd[1647]: [GJPH1-W8PZV] Resetting peer 3.3.1.232 due to change in addpath config
> May 15 16:08:14 vRR-DUT bgpd[1647]: [YAF85-253AP][EC 100663299] buffer_flush_available: write error on fd 70: Broken pipe
> May 15 16:08:14 vRR-DUT bgpd[1647]: [THHDB-YPEY6][EC 100663299] vtysh_flush: write error to fd 70, closing
> May 15 16:08:14 vRR-DUT bgpd[1647]: =================================================================
> May 15 16:08:14 vRR-DUT bgpd[1647]: ==1647==ERROR: AddressSanitizer: heap-use-after-free on address 0x62b001d65238 at pc 0x7efd46b83fa0 bp 0x7ffd4d598>
> May 15 16:08:14 vRR-DUT bgpd[1647]: READ of size 1 at 0x62b001d65238 thread T0
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #0 0x7efd46b83f9f in vty_out (/lib/x86_64-linux-gnu/libfrr.so.0+0x383f9f)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #1 0x5570c0a4e7d2 in aspath_print_vty /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_aspath.c:2308
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #2 0x5570c08a8ce6 in route_vty_out /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_route.c:9565
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #3 0x5570c08b5b65 in bgp_show_table /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_route.c:11751
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #4 0x5570c08b677f in bgp_show_table_rd /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_route.c:11915
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #5 0x5570c08b6d1c in bgp_show /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_route.c:11964
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #6 0x5570c08bcb03 in show_ip_bgp_magic /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_route.c:13134
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #7 0x5570c086f616 in show_ip_bgp bgpd/bgp_route_clippy.c:514
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #8 0x7efd469b38b6  (/lib/x86_64-linux-gnu/libfrr.so.0+0x1b38b6)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #9 0x7efd469b3c43 in cmd_execute_command (/lib/x86_64-linux-gnu/libfrr.so.0+0x1b3c43)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #10 0x7efd469b4915 in cmd_execute (/lib/x86_64-linux-gnu/libfrr.so.0+0x1b4915)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #11 0x7efd46b8581a  (/lib/x86_64-linux-gnu/libfrr.so.0+0x38581a)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #12 0x7efd46b8a6ff  (/lib/x86_64-linux-gnu/libfrr.so.0+0x38a6ff)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #13 0x7efd46b90f90  (/lib/x86_64-linux-gnu/libfrr.so.0+0x390f90)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #14 0x7efd46b75257 in event_call (/lib/x86_64-linux-gnu/libfrr.so.0+0x375257)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #15 0x7efd46a42ecf in frr_run (/lib/x86_64-linux-gnu/libfrr.so.0+0x242ecf)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #16 0x5570c06bf804 in main /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_main.c:545
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #17 0x7efd46429d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #18 0x7efd46429e3f in __libc_start_main_impl ../csu/libc-start.c:392
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #19 0x5570c06bc384 in _start (/usr/bin/bgpd+0x272384)
> May 15 16:08:14 vRR-DUT bgpd[1647]: 0x62b001d65238 is located 56 bytes inside of 26536-byte region [0x62b001d65200,0x62b001d6b9a8)
> May 15 16:08:14 vRR-DUT bgpd[1647]: freed by thread T0 here:
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #0 0x7efd470b4537 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:127
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #1 0x7efd46a6f930 in qfree (/lib/x86_64-linux-gnu/libfrr.so.0+0x26f930)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #2 0x7efd46b92467 in vty_close (/lib/x86_64-linux-gnu/libfrr.so.0+0x392467)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #3 0x7efd46b8fd4c  (/lib/x86_64-linux-gnu/libfrr.so.0+0x38fd4c)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #4 0x7efd46b83f60 in vty_out (/lib/x86_64-linux-gnu/libfrr.so.0+0x383f60)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #5 0x5570c0a4e7d2 in aspath_print_vty /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_aspath.c:2308
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #6 0x5570c08a8ce6 in route_vty_out /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_route.c:9565
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #7 0x5570c08b5b65 in bgp_show_table /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_route.c:11751
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #8 0x5570c08b677f in bgp_show_table_rd /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_route.c:11915
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #9 0x5570c08b6d1c in bgp_show /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_route.c:11964
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #10 0x5570c08bcb03 in show_ip_bgp_magic /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_route.c:13134
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #11 0x5570c086f616 in show_ip_bgp bgpd/bgp_route_clippy.c:514
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #12 0x7efd469b38b6  (/lib/x86_64-linux-gnu/libfrr.so.0+0x1b38b6)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #13 0x7efd469b3c43 in cmd_execute_command (/lib/x86_64-linux-gnu/libfrr.so.0+0x1b3c43)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #14 0x7efd469b4915 in cmd_execute (/lib/x86_64-linux-gnu/libfrr.so.0+0x1b4915)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #15 0x7efd46b8581a  (/lib/x86_64-linux-gnu/libfrr.so.0+0x38581a)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #16 0x7efd46b8a6ff  (/lib/x86_64-linux-gnu/libfrr.so.0+0x38a6ff)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #17 0x7efd46b90f90  (/lib/x86_64-linux-gnu/libfrr.so.0+0x390f90)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #18 0x7efd46b75257 in event_call (/lib/x86_64-linux-gnu/libfrr.so.0+0x375257)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #19 0x7efd46a42ecf in frr_run (/lib/x86_64-linux-gnu/libfrr.so.0+0x242ecf)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #20 0x5570c06bf804 in main /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_main.c:545
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #21 0x7efd46429d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
> May 15 16:08:14 vRR-DUT bgpd[1647]: previously allocated by thread T0 here:
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #0 0x7efd470b4a57 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #1 0x7efd46a6f7de in qcalloc (/lib/x86_64-linux-gnu/libfrr.so.0+0x26f7de)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #2 0x7efd46b8c5ba in vty_new (/lib/x86_64-linux-gnu/libfrr.so.0+0x38c5ba)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #3 0x7efd46b8f0fe  (/lib/x86_64-linux-gnu/libfrr.so.0+0x38f0fe)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #4 0x7efd46b75257 in event_call (/lib/x86_64-linux-gnu/libfrr.so.0+0x375257)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #5 0x7efd46a42ecf in frr_run (/lib/x86_64-linux-gnu/libfrr.so.0+0x242ecf)
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #6 0x5570c06bf804 in main /build/make-pkg/output/_packages/cp-routing/src/bgpd/bgp_main.c:545
> May 15 16:08:14 vRR-DUT bgpd[1647]:     #7 0x7efd46429d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
> May 15 16:08:14 vRR-DUT bgpd[1647]: SUMMARY: AddressSanitizer: heap-use-after-free (/lib/x86_64-linux-gnu/libfrr.so.0+0x383f9f) in vty_out
> May 15 16:08:14 vRR-DUT bgpd[1647]: Shadow bytes around the buggy address:
> May 15 16:08:14 vRR-DUT bgpd[1647]:   0x0c56803a49f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
> May 15 16:08:14 vRR-DUT bgpd[1647]:   0x0c56803a4a00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
> May 15 16:08:14 vRR-DUT bgpd[1647]:   0x0c56803a4a10: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
> May 15 16:08:14 vRR-DUT bgpd[1647]:   0x0c56803a4a20: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
> May 15 16:08:14 vRR-DUT bgpd[1647]:   0x0c56803a4a30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
> May 15 16:08:14 vRR-DUT bgpd[1647]: =>0x0c56803a4a40: fd fd fd fd fd fd fd[fd]fd fd fd fd fd fd fd fd
> May 15 16:08:14 vRR-DUT bgpd[1647]:   0x0c56803a4a50: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
> May 15 16:08:14 vRR-DUT bgpd[1647]:   0x0c56803a4a60: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
> May 15 16:08:14 vRR-DUT bgpd[1647]:   0x0c56803a4a70: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
> May 15 16:08:14 vRR-DUT bgpd[1647]:   0x0c56803a4a80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
> May 15 16:08:14 vRR-DUT bgpd[1647]:   0x0c56803a4a90: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
> May 15 16:08:14 vRR-DUT bgpd[1647]: Shadow byte legend (one shadow byte represents 8 application bytes):
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Addressable:           00
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Partially addressable: 01 02 03 04 05 06 07
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Heap left redzone:       fa
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Freed heap region:       fd
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Stack left redzone:      f1
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Stack mid redzone:       f2
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Stack right redzone:     f3
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Stack after return:      f5
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Stack use after scope:   f8
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Global redzone:          f9
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Global init order:       f6
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Poisoned by user:        f7
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Container overflow:      fc
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Array cookie:            ac
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Intra object redzone:    bb
> May 15 16:08:14 vRR-DUT bgpd[1647]:   ASan internal:           fe
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Left alloca redzone:     ca
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Right alloca redzone:    cb
> May 15 16:08:14 vRR-DUT bgpd[1647]:   Shadow gap:              cc
> May 15 16:08:14 vRR-DUT bgpd[1647]: ==1647==ABORTING

The vty_out() function detects a BROKEN PIPE error durint the call of vty_flush(), and closes the vty pointer. Consequently, the next vty_out() calls may use an invalid vty pointer.

Propose to delay the removal of the vty pointer at the next scheduling. Until that event, keep the vty structure at CLOSE state. The show function will eventually detect the invalid vty status, and will anticipate the end of the show command.