### PR TITLE
Handling of L3VRF outgoing SRv6 packets

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1222,11 +1222,11 @@ static bool bgp_zebra_use_nhop_weighted(struct bgp *bgp, struct attr *attr,
 	return true;
 }
 
-static void bgp_zebra_announce_parse_nexthop(
-	struct bgp_path_info *info, const struct prefix *p, struct bgp *bgp,
-	struct zapi_route *api, unsigned int *valid_nh_count, afi_t afi,
-	safi_t safi, uint32_t *nhg_id, uint32_t *metric, route_tag_t *tag,
-	bool *allow_recursion)
+static void bgp_zebra_announce_parse_nexthop(struct bgp_path_info *info, const struct prefix *p,
+					     struct bgp *bgp, struct zapi_route *api,
+					     unsigned int *valid_nh_count, afi_t afi, safi_t safi,
+					     uint32_t *nhg_id, uint32_t *metric, route_tag_t *tag,
+					     bool *allow_recursion, int *srv6_nh_index)
 {
 	struct zapi_nexthop *api_nh;
 	int nh_family;
@@ -1436,10 +1436,49 @@ static void bgp_zebra_announce_parse_nexthop(
 
 			api_nh->seg_num = 1;
 			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_SEG6);
+			if (srv6_nh_index)
+				*srv6_nh_index = *valid_nh_count;
 		}
 
 		(*valid_nh_count)++;
 	}
+}
+
+static bool bgp_zebra_has_srv6_sid_nexthop(struct bgp_dest *dest, struct bgp_path_info *info,
+					   struct bgp *bgp, struct in6_addr *sid)
+{
+	struct zapi_route api = { 0 };
+	struct zapi_nexthop *api_nh;
+	unsigned int valid_nh_count;
+	struct bgp_table *table = bgp_dest_table(dest);
+	const struct prefix *p = bgp_dest_get_prefix(dest);
+	uint32_t nhg_id = 0;
+	struct peer *peer;
+	bool allow_recursion = false;
+	route_tag_t tag;
+	uint32_t metric;
+	int srv6_nh_index = -1;
+
+	peer = info->peer;
+	tag = info->attr->tag;
+
+	if ((peer->sort == BGP_PEER_EBGP && peer->ttl != BGP_DEFAULT_TTL) ||
+	    CHECK_FLAG(peer->flags, PEER_FLAG_DISABLE_CONNECTED_CHECK) ||
+	    CHECK_FLAG(bgp->flags, BGP_FLAG_DISABLE_NH_CONNECTED_CHK))
+		allow_recursion = true;
+
+	/* Metric is currently based on the best-path only */
+	metric = info->attr->med;
+
+	bgp_zebra_announce_parse_nexthop(info, p, bgp, &api, &valid_nh_count, table->afi,
+					 table->safi, &nhg_id, &metric, &tag, &allow_recursion,
+					 &srv6_nh_index);
+	if (srv6_nh_index < 0)
+		return false;
+	api_nh = &api.nexthops[srv6_nh_index];
+	memcpy(sid, &api_nh->seg6_segs[0], sizeof(struct in6_addr));
+
+	return true;
 }
 
 static void bgp_debug_zebra_nh(struct zapi_route *api)
@@ -1523,6 +1562,9 @@ bgp_zebra_announce_actual(struct bgp_dest *dest, struct bgp_path_info *info,
 	uint32_t nhg_id = 0;
 	struct bgp_table *table = bgp_dest_table(dest);
 	const struct prefix *p = bgp_dest_get_prefix(dest);
+	enum zclient_send_status ret;
+	int srv6_nh_index = -1;
+	struct zapi_nexthop *api_nh;
 
 	if (table->safi == SAFI_FLOWSPEC) {
 		bgp_pbr_update_entry(bgp, p, info, table->afi, table->safi,
@@ -1569,9 +1611,9 @@ bgp_zebra_announce_actual(struct bgp_dest *dest, struct bgp_path_info *info,
 	/* Metric is currently based on the best-path only */
 	metric = info->attr->med;
 
-	bgp_zebra_announce_parse_nexthop(info, p, bgp, &api, &valid_nh_count,
-					 table->afi, table->safi, &nhg_id,
-					 &metric, &tag, &allow_recursion);
+	bgp_zebra_announce_parse_nexthop(info, p, bgp, &api, &valid_nh_count, table->afi,
+					 table->safi, &nhg_id, &metric, &tag, &allow_recursion,
+					 &srv6_nh_index);
 
 	if (CHECK_FLAG(bm->flags, BM_FLAG_SEND_EXTRA_DATA_TO_ZEBRA)) {
 		struct bgp_zebra_opaque bzo = {};
@@ -1638,8 +1680,37 @@ bgp_zebra_announce_actual(struct bgp_dest *dest, struct bgp_path_info *info,
 		zlog_debug("%s: %pFX: announcing to zebra (recursion %sset)",
 			   __func__, p, (allow_recursion ? "" : "NOT "));
 	}
+	ret = zclient_route_send(ZEBRA_ROUTE_ADD, bgp_zclient, &api);
+	if (ret == ZCLIENT_SEND_FAILURE)
+		return ret;
+	if (srv6_nh_index >= 0) {
+		/* SRv6 encapsulation : after SRv6 encapsulation,
+		 * A route lookup on the same vrf looks for a path for the SID
+		 * Append a second route to reach that SID address.
+		 */
+		api_nh = &api.nexthops[srv6_nh_index];
+		memcpy(&api.prefix.u.prefix6, &api_nh->seg6_segs[0], sizeof(struct in6_addr));
 
-	return zclient_route_send(ZEBRA_ROUTE_ADD, bgp_zclient, &api);
+		api.prefix.family = AF_INET6;
+		api.prefix.prefixlen = IPV6_MAX_BITLEN;
+		api_nh->seg_num = 0;
+		api_nh->label_num = 0;
+		UNSET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_SEG6);
+		UNSET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_LABEL);
+
+		if (bgp_debug_zebra(p)) {
+			zlog_debug("Tx route add %s (table id %u) %pFX metric %u tag %" ROUTE_TAG_PRI
+				   " count %d nhg %d",
+				   bgp->name_pretty, api.tableid, &api.prefix, api.metric, api.tag,
+				   api.nexthop_num, nhg_id);
+			bgp_debug_zebra_nh(&api);
+
+			zlog_debug("%s: %pFX: announcing to zebra (recursion %sset)", __func__, p,
+				   (allow_recursion ? "" : "NOT "));
+		}
+		ret = zclient_route_send(ZEBRA_ROUTE_ADD, bgp_zclient, &api);
+	}
+	return ret;
 }
 
 
@@ -1713,6 +1784,8 @@ enum zclient_send_status bgp_zebra_withdraw_actual(struct bgp_dest *dest,
 	struct peer *peer;
 	struct bgp_table *table = bgp_dest_table(dest);
 	const struct prefix *p = bgp_dest_get_prefix(dest);
+	enum zclient_send_status status;
+	struct in6_addr sid = { 0 };
 
 	if (table->safi == SAFI_FLOWSPEC) {
 		peer = info->peer;
@@ -1736,7 +1809,17 @@ enum zclient_send_status bgp_zebra_withdraw_actual(struct bgp_dest *dest,
 		zlog_debug("Tx route delete %s (table id %u) %pFX",
 			   bgp->name_pretty, api.tableid, &api.prefix);
 
-	return zclient_route_send(ZEBRA_ROUTE_DELETE, bgp_zclient, &api);
+	status = zclient_route_send(ZEBRA_ROUTE_DELETE, bgp_zclient, &api);
+	if (status != ZCLIENT_SEND_FAILURE && bgp_zebra_has_srv6_sid_nexthop(dest, info, bgp, &sid)) {
+		memcpy(&api.prefix.u.prefix6, &sid, sizeof(sid));
+		api.prefix.family = AF_INET6;
+		api.prefix.prefixlen = IPV6_MAX_BITLEN;
+		if (bgp_debug_zebra(p))
+			zlog_debug("Tx route delete %s (table id %u) %pFX", bgp->name_pretty,
+				   api.tableid, &api.prefix);
+		status = zclient_route_send(ZEBRA_ROUTE_DELETE, bgp_zclient, &api);
+	}
+	return status;
 }
 
 /*

--- a/tests/topotests/isis_srv6_topo1/cpe-dst/zebra.conf
+++ b/tests/topotests/isis_srv6_topo1/cpe-dst/zebra.conf
@@ -1,0 +1,17 @@
+log file zebra.log
+!
+hostname cpe-dst
+!
+! debug zebra kernel
+! debug zebra packet
+!
+interface eth-rt6
+ ip address 10.200.0.100/24
+ ipv6 address fd00:200::100/64
+!
+ip route 0.0.0.0/0 10.200.0.6
+ipv6 route 0::0/0 fd00:200::6
+ip forwarding
+!
+line vty
+!

--- a/tests/topotests/isis_srv6_topo1/cpe-src/zebra.conf
+++ b/tests/topotests/isis_srv6_topo1/cpe-src/zebra.conf
@@ -1,0 +1,17 @@
+log file zebra.log
+!
+hostname cpe-src
+!
+! debug zebra kernel
+! debug zebra packet
+!
+interface eth-rt1
+ ip address 10.100.0.100/24
+ ipv6 address fd00:100::100/64
+!
+ip route 0.0.0.0/0 10.100.0.1
+ipv6 route 0::0/0 fd00:100::1
+ip forwarding
+!
+line vty
+!

--- a/tests/topotests/isis_srv6_topo1/rt1/bgpd.conf
+++ b/tests/topotests/isis_srv6_topo1/rt1/bgpd.conf
@@ -1,0 +1,45 @@
+no bgp send-extra-data zebra
+router bgp 65500
+ bgp router-id 1.1.1.1
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ neighbor fc00:0:6::1 remote-as 65501
+ neighbor fc00:0:6::1 disable-connected-check
+ neighbor fc00:0:6::1 ebgp-multihop 10
+ neighbor fc00:0:6::1 capability extended-nexthop
+ neighbor fc00:0:6::1 update-source fc00:0:1::1
+ neighbor fc00:0:6::1 timers 3 10
+ neighbor fc00:0:6::1 timers connect 1
+ !
+ address-family ipv4 vpn
+  neighbor fc00:0:6::1 activate
+ exit-address-family
+ address-family ipv6 vpn
+  neighbor fc00:0:6::1 activate
+ exit-address-family
+ !
+ segment-routing srv6
+  locator loc1
+ !
+!
+router bgp 65500 vrf vrf10
+ bgp router-id 1.1.1.1
+ no bgp ebgp-requires-policy
+ !
+ address-family ipv4 unicast
+  redistribute connected
+  sid vpn export 10
+  rd vpn export 65500:1
+  rt vpn both 99:99
+  import vpn
+  export vpn
+ exit-address-family
+ address-family ipv6 unicast
+  redistribute connected
+  sid vpn export 11
+  rd vpn export 65500:2
+  rt vpn both 99:99
+  import vpn
+  export vpn
+ exit-address-family
+!

--- a/tests/topotests/isis_srv6_topo1/rt1/zebra.conf
+++ b/tests/topotests/isis_srv6_topo1/rt1/zebra.conf
@@ -13,6 +13,10 @@ interface eth-sw1
  ip address 10.0.1.1/24
  ipv6 address 2001:db8:1::1/64
 !
+interface eth-cpe-src vrf vrf10
+ ip address 10.100.0.1/24
+ ipv6 address fd00:100::1/64
+!
 segment-routing
  srv6
   locators

--- a/tests/topotests/isis_srv6_topo1/rt6/bgpd.conf
+++ b/tests/topotests/isis_srv6_topo1/rt6/bgpd.conf
@@ -1,0 +1,45 @@
+no bgp send-extra-data zebra
+router bgp 65501
+ bgp router-id 6.6.6.6
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ neighbor fc00:0:1::1 remote-as 65500
+ neighbor fc00:0:1::1 disable-connected-check
+ neighbor fc00:0:1::1 ebgp-multihop 10
+ neighbor fc00:0:1::1 capability extended-nexthop
+ neighbor fc00:0:1::1 update-source fc00:0:6::1 
+ neighbor fc00:0:1::1 timers 3 10
+ neighbor fc00:0:1::1 timers connect 1
+ !
+ address-family ipv4 vpn
+  neighbor fc00:0:1::1 activate
+ exit-address-family
+ address-family ipv6 vpn
+  neighbor fc00:0:1::1 activate
+ exit-address-family
+ !
+ segment-routing srv6
+  locator loc1
+ !
+!
+router bgp 65501 vrf vrf10
+ bgp router-id 6.6.6.6
+ no bgp ebgp-requires-policy
+ !
+ address-family ipv4 unicast
+  redistribute connected
+  sid vpn export 60
+  rd vpn export 65501:10
+  rt vpn both 99:99
+  import vpn
+  export vpn
+ exit-address-family
+ address-family ipv6 unicast
+  redistribute connected
+  sid vpn export 61
+  rd vpn export 65501:11
+  rt vpn both 99:99
+  import vpn
+  export vpn
+ exit-address-family
+!

--- a/tests/topotests/isis_srv6_topo1/rt6/zebra.conf
+++ b/tests/topotests/isis_srv6_topo1/rt6/zebra.conf
@@ -19,6 +19,10 @@ interface eth-dst
  ip address 10.0.10.1/24
  ip address 2001:db8:10::1/64
 !
+interface eth-cpe-dst vrf vrf10
+ ip address 10.200.0.6/24
+ ipv6 address fd00:200::6/64
+!
 segment-routing
  srv6
   locators

--- a/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
+++ b/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
@@ -71,6 +71,7 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
+from lib.checkping import check_ping
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.common_config import (
@@ -1170,6 +1171,23 @@ def test_ping_step9():
         pytest.skip(tgen.errors)
 
     check_ping6("rt1", "fc00:0:9::1", True)
+
+
+def test_ping_step10():
+    logger.info("Test (step 9): verify ping between VPN")
+    tgen = get_topogen()
+
+    # Required linux kernel version for this suite to run.
+    result = required_linux_kernel_version("6.1")
+    if result is not True:
+        pytest.skip("Kernel requirements are not met, kernel version should be >=6.1")
+
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    check_ping6("cpe-src", "fd00:200::100", True)
+    check_ping("cpe-src", "10.200.0.100", True, 10, 0.5)
 
 
 # Memory leak test template


### PR DESCRIPTION
Today, if a L3VRF has its default route blackholed, then when BGP creates an srv6 seg route due to an incoming BGP L3VPN Srv6 update, then the traffic is dropped, despite the SRv6 segment route is created.

Actually, when forging outgoing SRv6 packet, that packet is submitted against the L3VRF routing table. If no specific route that tells how to reach the remote SID, then packet is dropped.

The BGP patch attempts to solve this by creating two additional route entries that tell how to leak the new SRv6 packet to the default L3VRF. Having that BGP patch is not natural, since for instance, this BGP route may be redistributed to remote peers, and this is not what any operator would expect. The solution is still in draft mode.

