### PR TITLE
bgpd: remove special code block for clang SA

### DIFF
--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -518,13 +518,7 @@ static uint16_t bgp_read(struct peer_connection *connection, int *code_p)
 
 	readsize = MIN(ibuf_work_space, sizeof(ibuf_scratch));
 
-#ifdef __clang_analyzer__
-	/* clang-SA doesn't want you to call read() while holding a mutex */
-	(void)readsize;
-	nbytes = 0;
-#else
 	nbytes = read(connection->fd, ibuf_scratch, readsize);
-#endif
 
 	/* EAGAIN or EWOULDBLOCK; come back later */
 	if (nbytes < 0 && ERRNO_IO_RETRY(errno)) {


### PR DESCRIPTION
Remove a special ifdef block; it looks like current clang understands this code now. Let's try a CI run and see...