### PR TITLE
zebra: Initialize RB tree for router tables

### DIFF
--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -291,6 +291,9 @@ void zebra_router_init(bool asic_offload, bool notify_on_ack,
 
 	zrouter.nhg_keep = ZEBRA_DEFAULT_NHG_KEEP_TIMER;
 
+	/* Initialize the red-black tree for router tables */
+	RB_INIT(zebra_router_table_head, &zrouter.tables);
+
 	/*Init V6 RA batching stuffs*/
 	zrouter.ra_wheel = wheel_init(zrouter.master, RTADV_TIMER_WHEEL_PERIOD_MS,
 				      RTADV_TIMER_WHEEL_SLOTS_NO, interface_hash_key, process_rtadv,


### PR DESCRIPTION
RB tree for router table is not initializes and can have garbage values leading to crashes when zebra boots.

```
==52257== Invalid read of size 4
==52257==    at 0x24A683: zebra_router_table_entry_compare (zebra_router.c:46)
==52257==    by 0x24A683: zebra_router_table_head_RB_COMPARE (zebra_router.c:38)
==52257==    by 0x494859F: _rb_find (openbsd-tree.c:415)
==52257==    by 0x24AA44: zebra_router_table_head_RB_FIND (zebra_router.h:39)
==52257==    by 0x24AA44: zebra_router_get_table (zebra_router.c:131)
==52257==    by 0x268AB8: zebra_vrf_table_create (zebra_vrf.c:432)
==52257==    by 0x268AB8: zebra_vrf_enable (zebra_vrf.c:140)
==52257==    by 0x4977036: vrf_enable (vrf.c:286)
==52257==    by 0x4977036: vrf_enable (vrf.c:275)
==52257==    by 0x497797D: vrf_init (vrf.c:554)
==52257==    by 0x269854: zebra_vrf_init (zebra_vrf.c:645)
==52257==    by 0x237315: zebra_ns_init (zebra_ns.c:252)
==52257==    by 0x1BF284: main (main.c:469)
==52257==  Address 0x56415741e5894875 is not stack'd, malloc'd or (recently) free'd
==52257==
==52257==
==52257== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==52257==    at 0x4D07EEC: __pthread_kill_implementation (pthread_kill.c:44)
==52257==    by 0x4CB8FB1: raise (raise.c:26)
==52257==    by 0x4961BFB: core_handler (sigevent.c:261)
==52257==    by 0x4CB904F: ??? (in /usr/lib/x86_64-linux-gnu/libc.so.6)
==52257==    by 0x24A682: zebra_router_table_entry_compare (zebra_router.c:46)
==52257==    by 0x24A682: zebra_router_table_head_RB_COMPARE (zebra_router.c:38)
==52257==    by 0x494859F: _rb_find (openbsd-tree.c:415)
==52257==    by 0x24AA44: zebra_router_table_head_RB_FIND (zebra_router.h:39)
==52257==    by 0x24AA44: zebra_router_get_table (zebra_router.c:131)
==52257==    by 0x268AB8: zebra_vrf_table_create (zebra_vrf.c:432)
==52257==    by 0x268AB8: zebra_vrf_enable (zebra_vrf.c:140)
==52257==    by 0x4977036: vrf_enable (vrf.c:286)
==52257==    by 0x4977036: vrf_enable (vrf.c:275)
==52257==    by 0x497797D: vrf_init (vrf.c:554)
==52257==    by 0x269854: zebra_vrf_init (zebra_vrf.c:645)
==52257==    by 0x237315: zebra_ns_init (zebra_ns.c:252)
==52257==
```

Ticket :#4502759