### PR TITLE
pathd: fix compare function overflow

### DIFF
--- a/lib/srte.h
+++ b/lib/srte.h
@@ -30,8 +30,11 @@ static inline int sr_policy_compare(const struct ipaddr *a_endpoint,
 		return -1;
 	if (ret > 0)
 		return 1;
-
-	return a_color - b_color;
+	if (a_color > b_color)
+		return 1;
+	if (a_color < b_color)
+		return -1;
+	return 0;
 }
 
 #ifdef __cplusplus

--- a/pathd/path_pcep_pcc.c
+++ b/pathd/path_pcep_pcc.c
@@ -143,7 +143,11 @@ DECLARE_HASH(req_map, struct req_map_data, mi, req_map_cmp, req_map_hash);
 static inline int req_entry_compare(const struct req_entry *a,
 				    const struct req_entry *b)
 {
-	return a->path->req_id - b->path->req_id;
+	if (a->path->req_id > b->path->req_id)
+		return 1;
+	if (a->path->req_id < b->path->req_id)
+		return -1;
+	return 0;
 }
 RB_GENERATE(req_entry_head, req_entry, entry, req_entry_compare)
 

--- a/pathd/pathd.c
+++ b/pathd/pathd.c
@@ -59,7 +59,11 @@ static void srte_unset_metric(struct srte_metric *metric);
 static inline int srte_segment_entry_compare(const struct srte_segment_entry *a,
 					     const struct srte_segment_entry *b)
 {
-	return a->index - b->index;
+	if (a->index > b->index)
+		return 1;
+	if (a->index < b->index)
+		return -1;
+	return 0;
 }
 RB_GENERATE(srte_segment_entry_head, srte_segment_entry, entry,
 	    srte_segment_entry_compare)
@@ -80,7 +84,11 @@ struct srte_segment_list_head srte_segment_lists =
 static inline int srte_candidate_compare(const struct srte_candidate *a,
 					 const struct srte_candidate *b)
 {
-	return a->preference - b->preference;
+	if (a->preference > b->preference)
+		return 1;
+	if (a->preference < b->preference)
+		return -1;
+	return 0;
 }
 RB_GENERATE(srte_candidate_head, srte_candidate, entry, srte_candidate_compare)
 


### PR DESCRIPTION
Test code:
```
int compare(uint32_t x, uint32_t y) {
    return x - y;
}

void print_compare(uint32_t x, uint32_t y) {
    int ret = compare(x, y);
    if (ret < 0) {
        printf("%u < %u\n", x, y);
    } else if (ret > 0) {
        printf("%u > %u\n", x, y);
    } else {
        printf("%u = %u\n", x, y);
    }
}

int main(void) {
    uint32_t a = 2;
    uint32_t b = 0x80000001u;
    uint32_t c = 0xffffffffu;
    print_compare(a, b);
    print_compare(b, c);
    print_compare(c, a);

    uint32_t x = 7;
    uint32_t y = 0x80000007u;
    print_compare(x, y);
    print_compare(y, x);
    return 0;
}
```
Output:
```
2 < 2147483649
2147483649 < 4294967295
4294967295 < 2
```