### PR TITLE
Convert logging config to YANG/mgmtd, and add missing mgmtd functionality

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -490,7 +490,6 @@ static int config_write_host(struct vty *vty)
 				vty_out(vty, "enable password %s\n",
 					host.enable);
 		}
-		log_config_write(vty);
 
 		if (!cputime_enabled)
 			vty_out(vty, "no service cputime-stats\n");

--- a/lib/command.h
+++ b/lib/command.h
@@ -664,6 +664,8 @@ extern void cmd_show_lib_debugs(struct vty *vty);
 extern const struct frr_yang_module_info frr_host_cli_info;
 extern void host_cli_init(void);
 
+extern void log_cli_init(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -821,8 +821,10 @@ struct event_loop *frr_init(void)
 		cmd_init(-1);
 	else {
 		cmd_init(1);
-		if (!(di->flags & FRR_MGMTD_BACKEND))
+		if (!(di->flags & FRR_MGMTD_BACKEND)) {
 			host_cli_init();
+			log_cli_init();
+		}
 	}
 
 	vty_init(master, di->log_always);

--- a/lib/log.h
+++ b/lib/log.h
@@ -173,7 +173,8 @@ struct timestamp_control {
 	"Local use\n"
 
 
-extern const struct frr_yang_module_info frr_logging_nb_info;
+extern struct frr_yang_module_info frr_logging_nb_info;
+extern void frr_logging_merge_cli_to_nb_info(void);
 
 #ifdef __cplusplus
 }

--- a/lib/log.h
+++ b/lib/log.h
@@ -172,6 +172,9 @@ struct timestamp_control {
 	"Local use\n"                                                          \
 	"Local use\n"
 
+
+extern const struct frr_yang_module_info frr_logging_nb_info;
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/log_cli.c
+++ b/lib/log_cli.c
@@ -493,7 +493,7 @@ static void logging_uid_backtrace_cli_write(struct vty *vty, const struct lyd_no
 	vty_out(vty, "debug unique-id %s backtrace\n", yang_dnode_get_string(dnode, "uid"));
 }
 
-const struct frr_yang_module_info frr_logging_cli_info = {
+struct frr_yang_module_info frr_logging_cli_info = {
 	.name = "frr-logging",
 	.ignore_cfg_cbs = true,
 	.nodes = {
@@ -515,3 +515,19 @@ const struct frr_yang_module_info frr_logging_cli_info = {
 		{ .xpath = NULL },
 	}
 };
+
+void frr_logging_merge_cli_to_nb_info(void)
+{
+	int i, j;
+
+	for (i = 0; frr_logging_cli_info.nodes[i].xpath != NULL; i++) {
+		for (j = 0; frr_logging_nb_info.nodes[j].xpath != NULL; j++) {
+			if (!strcmp(frr_logging_cli_info.nodes[i].xpath, frr_logging_nb_info.nodes[j].xpath)) {
+				frr_logging_nb_info.nodes[j].cbs.cli_show = frr_logging_cli_info.nodes[i].cbs.cli_show;
+				break;
+			}
+		}
+		/* Make sure we found one */
+		assert(frr_logging_nb_info.nodes[j].xpath != NULL);
+	}
+}

--- a/lib/log_cli.c
+++ b/lib/log_cli.c
@@ -1,0 +1,492 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * June 8 2025, Christian Hopps <chopps@labn.net>
+ *
+ * Copyright (c) 2025, LabN Consulting, L.L.C.
+ */
+#include <zebra.h>
+#include <pwd.h>
+#include <grp.h>
+#include "command.h"
+#include "log.h"
+#include "log_vty.h"
+#include "northbound.h"
+#include "northbound_cli.h"
+#include "lib/vtysh_daemons.h"
+
+#include "lib/log_cli_clippy.c"
+
+/* ======================= */
+/* Basic logging CLI code. */
+/* ======================= */
+
+DEFPY_YANG (config_log_stdout,
+	    config_log_stdout_cmd,
+	    "[no] log stdout [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>$levelarg]",
+	    NO_STR
+	    "Logging control\n"
+	    "Set stdout logging level\n"
+	    LOG_LEVEL_DESC)
+{
+	if (no)
+		nb_cli_enqueue_change(vty, "/frr-logging:logging/stdout", NB_OP_DESTROY, NULL);
+	else {
+		nb_cli_enqueue_change(vty, "/frr-logging:logging/stdout", NB_OP_CREATE, NULL);
+		if (levelarg)
+			nb_cli_enqueue_change(vty, "/frr-logging:logging/stdout/level",
+					      NB_OP_MODIFY, log_lev2sev(levelarg));
+		else
+			nb_cli_enqueue_change(vty, "/frr-logging:logging/stdout/level",
+					      NB_OP_DESTROY, NULL);
+	}
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_HIDDEN (config_log_monitor,
+       config_log_monitor_cmd,
+       "[no] log monitor [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>]",
+       NO_STR
+       "Logging control\n"
+       "Set terminal line (monitor) logging level\n"
+       LOG_LEVEL_DESC)
+{
+	vty_out(vty, "%% \"log monitor\" is deprecated and does nothing.\n");
+	return CMD_SUCCESS;
+}
+
+DEFPY_YANG_NOSH (debug_uid_backtrace,
+            debug_uid_backtrace_cmd,
+            "[no] debug unique-id UID backtrace",
+            NO_STR
+            DEBUG_STR
+            "Options per individual log message, by unique ID\n"
+            "Log message unique ID (XXXXX-XXXXX)\n"
+            "Add backtrace to log when message is printed\n")
+{
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), "/frr-logging:logging/uid-backtrace[uid='%s']", uid);
+	nb_cli_enqueue_change(vty, xpath, no ? NB_OP_DESTROY : NB_OP_CREATE, NULL);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+/* Per-daemon log file config */
+DEFUN_YANG (config_log_dmn_file,
+	    config_log_dmn_file_cmd,
+            "log daemon " DAEMONS_LIST " file FILENAME [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>$levelarg]",
+	    "Logging control\n"
+	    "Specific daemon\n"
+	    DAEMONS_STR
+	    "Logging to file\n"
+	    "Logging filename\n"
+	    LOG_LEVEL_DESC)
+{
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), "/frr-logging:logging/daemon-file[daemon='%s']/filename",
+		 argv[2]->text);
+	nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, argv[4]->arg);
+	snprintf(xpath, sizeof(xpath), "/frr-logging:logging/daemon-file[daemon='%s']/level",
+		 argv[2]->text);
+	if (argc < 6)
+		nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+	else
+		nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, log_lev2sev(argv[5]->text));
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+/* Per-daemon no log file */
+DEFUN_YANG (no_config_log_dmn_file,
+	    no_config_log_dmn_file_cmd,
+	    "no log daemon " DAEMONS_LIST " file [FILENAME [LEVEL]]",
+	    NO_STR
+	    "Logging control\n"
+	    "Specific daemon\n"
+	    DAEMONS_STR
+	    "Cancel logging to file\n"
+	    "Logging file name\n"
+	    "Logging level\n")
+{
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), "/frr-logging:logging/daemon-file[daemon='%s']",
+		 argv[3]->text);
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (config_log_file,
+	    config_log_file_cmd,
+	    "[no] log file ![FILENAME [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>$levelarg]]",
+	    NO_STR
+	    "Logging control\n"
+	    "Logging to file\n"
+	    "Logging filename\n"
+	    LOG_LEVEL_DESC)
+{
+	if (no)
+		nb_cli_enqueue_change(vty, "/frr-logging:logging/file", NB_OP_DESTROY, NULL);
+	else {
+		nb_cli_enqueue_change(vty, "/frr-logging:logging/file/filename", NB_OP_MODIFY,
+				      filename);
+		if (levelarg)
+			nb_cli_enqueue_change(vty, "/frr-logging:logging/file/level", NB_OP_MODIFY,
+					      log_lev2sev(levelarg));
+		else
+			nb_cli_enqueue_change(vty, "/frr-logging:logging/file/level",
+					      NB_OP_DESTROY, NULL);
+	}
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (config_log_syslog,
+	    config_log_syslog_cmd,
+       "log syslog [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>$levelarg]",
+       "Logging control\n"
+       "Set syslog logging level\n"
+       LOG_LEVEL_DESC)
+{
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/syslog", NB_OP_CREATE, NULL);
+	if (levelarg)
+		nb_cli_enqueue_change(vty, "/frr-logging:logging/syslog/level", NB_OP_MODIFY,
+				      log_lev2sev(levelarg));
+	else
+		nb_cli_enqueue_change(vty, "/frr-logging:logging/syslog/level", NB_OP_DESTROY,
+				      NULL);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (no_config_log_syslog,
+       no_config_log_syslog_cmd,
+       "no log syslog [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>]",
+       NO_STR
+       "Logging control\n"
+       "Cancel logging to syslog\n"
+       LOG_LEVEL_DESC)
+{
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/syslog", NB_OP_DESTROY, NULL);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (config_log_facility,
+       config_log_facility_cmd,
+       "log facility <kern|user|mail|daemon|auth|syslog|lpr|news|uucp|cron|local0|local1|local2|local3|local4|local5|local6|local7>$facilityarg",
+       "Logging control\n"
+       "Facility parameter for syslog messages\n"
+       LOG_FACILITY_DESC)
+{
+	char buf[64];
+
+	snprintf(buf, sizeof(buf), "ietf-syslog-types:%s", facilityarg);
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/facility", NB_OP_MODIFY, buf);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (no_config_log_facility,
+       no_config_log_facility_cmd,
+       "no log facility [<kern|user|mail|daemon|auth|syslog|lpr|news|uucp|cron|local0|local1|local2|local3|local4|local5|local6|local7>] [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>]",
+       NO_STR
+       "Logging control\n"
+       "Reset syslog facility to default (daemon)\n"
+       LOG_FACILITY_DESC
+       LOG_LEVEL_DESC)
+{
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/facility", NB_OP_DESTROY, NULL);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (config_log_record_priority,
+       config_log_record_priority_cmd,
+       "[no] log record-priority",
+	NO_STR
+       "Logging control\n"
+       "Log the priority of the message within the message\n")
+{
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/record-priority", NB_OP_MODIFY,
+			      no ? "false" : "true");
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (config_log_timestamp_precision,
+       config_log_timestamp_precision_cmd,
+       "log timestamp precision (0-6)",
+       "Logging control\n"
+       "Timestamp configuration\n"
+       "Set the timestamp precision\n"
+       "Number of subsecond digits\n")
+{
+	char buf[8];
+
+	snprintf(buf, sizeof(buf), "%u", (uint)precision);
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/timestamp-precision", NB_OP_MODIFY, buf);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (no_config_log_timestamp_precision,
+       no_config_log_timestamp_precision_cmd,
+       "no log timestamp precision [(0-6)]",
+       NO_STR
+       "Logging control\n"
+       "Timestamp configuration\n"
+       "Reset the timestamp precision to the default value of 0\n"
+       "Number of subsecond digits\n")
+{
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/timestamp-precision", NB_OP_DESTROY, NULL);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (config_log_ec,
+       config_log_ec_cmd,
+       "[no] log error-category",
+       NO_STR
+       "Logging control\n"
+       "Prefix log message text with [EC 9999] code\n")
+{
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/error-category", NB_OP_MODIFY,
+			      no ? "false" : "true");
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (config_log_xid,
+       config_log_xid_cmd,
+       "[no] log unique-id",
+       NO_STR
+       "Logging control\n"
+       "Prefix log message text with [XXXXX-XXXXX] identifier\n")
+{
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/unique-id", NB_OP_MODIFY,
+			      no ? "false" : "true");
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (config_log_filterfile,
+       config_log_filterfile_cmd,
+       "log filtered-file FILENAME [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>$levelarg]",
+       "Logging control\n"
+       "Logging to file with string filter\n"
+       "Logging filename\n"
+       LOG_LEVEL_DESC)
+{
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/filtered-file", NB_OP_CREATE, NULL);
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/filtered-file/filename", NB_OP_MODIFY,
+			      filename);
+	if (levelarg)
+		nb_cli_enqueue_change(vty, "/frr-logging:logging/filtered-file/level",
+				      NB_OP_MODIFY, log_lev2sev(levelarg));
+	else
+		nb_cli_enqueue_change(vty, "/frr-logging:logging/filtered-file/level",
+				      NB_OP_DESTROY, NULL);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (no_config_log_filterfile,
+       no_config_log_filterfile_cmd,
+       "no log filtered-file [FILENAME [LEVEL]]",
+       NO_STR
+       "Logging control\n"
+       "Cancel logging to file with string filter\n"
+       "Logging file name\n"
+       "Logging level\n")
+{
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/filtered-file", NB_OP_DESTROY, NULL);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY_YANG (log_filter,
+       log_filter_cmd,
+       "[no] log filter-text WORD$filter",
+       NO_STR
+       "Logging control\n"
+       FILTER_LOG_STR
+       "String to filter by\n")
+{
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/filter-text",
+			      no ? NB_OP_DESTROY : NB_OP_CREATE, filter);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+/* Clear all log filters */
+DEFPY_YANG (log_filter_clear,
+       log_filter_clear_cmd,
+       "clear log filter-text",
+       CLEAR_STR
+       "Logging control\n"
+       FILTER_LOG_STR)
+{
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/filter-text", NB_OP_DESTROY, NULL);
+	return nb_cli_apply_changes(vty, NULL);
+	/* zlog_filter_clear(); */
+	return CMD_SUCCESS;
+}
+
+/* Enable/disable 'immediate' mode, with no output buffering */
+DEFPY_YANG (log_immediate_mode,
+       log_immediate_mode_cmd,
+       "[no] log immediate-mode",
+       NO_STR
+       "Logging control\n"
+       "Output immediately, without buffering\n")
+{
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/immediate-mode", NB_OP_MODIFY,
+			      no ? "false" : "true");
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+void log_cli_init(void)
+{
+	install_element(CONFIG_NODE, &config_log_stdout_cmd);
+	install_element(CONFIG_NODE, &config_log_monitor_cmd);
+	install_element(CONFIG_NODE, &config_log_file_cmd);
+	install_element(CONFIG_NODE, &config_log_dmn_file_cmd);
+	install_element(CONFIG_NODE, &no_config_log_dmn_file_cmd);
+	install_element(CONFIG_NODE, &config_log_syslog_cmd);
+	install_element(CONFIG_NODE, &no_config_log_syslog_cmd);
+	install_element(CONFIG_NODE, &config_log_facility_cmd);
+	install_element(CONFIG_NODE, &no_config_log_facility_cmd);
+	install_element(CONFIG_NODE, &config_log_record_priority_cmd);
+	install_element(CONFIG_NODE, &config_log_timestamp_precision_cmd);
+	install_element(CONFIG_NODE, &no_config_log_timestamp_precision_cmd);
+	install_element(CONFIG_NODE, &config_log_ec_cmd);
+	install_element(CONFIG_NODE, &config_log_xid_cmd);
+
+	install_element(CONFIG_NODE, &log_filter_cmd);
+	install_element(CONFIG_NODE, &log_filter_clear_cmd);
+	install_element(CONFIG_NODE, &config_log_filterfile_cmd);
+	install_element(CONFIG_NODE, &no_config_log_filterfile_cmd);
+	install_element(CONFIG_NODE, &log_immediate_mode_cmd);
+
+	install_element(CONFIG_NODE, &debug_uid_backtrace_cmd);
+}
+
+
+/* clang-format off */
+static void logging_stdout_cli_write(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	int level = log_level_match(yang_dnode_get_string(dnode, "level"));
+
+	if (level != LOG_DEBUG || show_defaults)
+		vty_out(vty, "log stdout %s\n", zlog_priority_str(level));
+	else
+		vty_out(vty, "log stdout\n");
+}
+
+static void logging_syslog_cli_write(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	int level = log_level_match(yang_dnode_get_string(dnode, "level"));
+
+	if (level != LOG_DEBUG || show_defaults)
+		vty_out(vty, "log syslog %s\n", zlog_priority_str(level));
+	else
+		vty_out(vty, "log syslog\n");
+}
+
+static void logging_file_filename_cli_write(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	const char *fname = yang_dnode_get_string(dnode, NULL);
+	int level = log_level_match(yang_dnode_get_string(dnode, "../level"));
+
+	if (level != LOG_DEBUG  || show_defaults)
+		vty_out(vty, "log file %s %s\n", fname, zlog_priority_str(level));
+	else
+		vty_out(vty, "log file %s\n", fname);
+}
+
+static void logging_filtered_file_filename_cli_write(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	const char *fname = yang_dnode_get_string(dnode, NULL);
+	int level = log_level_match(yang_dnode_get_string(dnode, "../level"));
+
+	if (level != LOG_DEBUG || show_defaults)
+		vty_out(vty, "log filtered-file %s %s\n", fname, zlog_priority_str(level));
+	else
+		vty_out(vty, "log filtered-file %s\n", fname);
+}
+
+static void logging_daemon_file_filename_cli_write(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	const char *fname = yang_dnode_get_string(dnode, NULL);
+	const char *daemon = yang_dnode_get_string(dnode, "../daemon");
+	int level = log_level_match(yang_dnode_get_string(dnode, "../level"));
+
+	if (level != LOG_DEBUG || show_defaults)
+		vty_out(vty, "log daemon %s file %s %s\n", daemon, fname, zlog_priority_str(level));
+	else
+		vty_out(vty, "log daemon %s file %s\n", daemon, fname);
+}
+
+static void logging_facility_cli_write(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	vty_out(vty, "log facility %s\n", yang_dnode_get_string(dnode, NULL));
+}
+
+static void logging_record_priority_cli_write(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	bool enable = yang_dnode_get_bool(dnode, NULL);
+
+	if (enable)
+		vty_out(vty, "log record-priority\n");
+	else if (show_defaults)
+		vty_out(vty, "no log record-priority\n");
+}
+static void logging_timestamp_precision_cli_write(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	const char *prec = yang_dnode_get_string(dnode, NULL);
+
+	if (strcmp(prec, "0") || show_defaults)
+		vty_out(vty, "log timestamp precision %s\n", prec);
+}
+static void logging_error_category_cli_write(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	bool enable = yang_dnode_get_bool(dnode, NULL);
+
+	if (!enable)
+		vty_out(vty, "no log error-category\n");
+	else if (show_defaults)
+		vty_out(vty, "log record-category\n");
+}
+static void logging_unique_id_cli_write(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	bool enable = yang_dnode_get_bool(dnode, NULL);
+
+	if (!enable)
+		vty_out(vty, "no log unique-id\n");
+	else if (show_defaults)
+		vty_out(vty, "log unique-id\n");
+}
+static void logging_immediate_mode_cli_write(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	bool enable = yang_dnode_get_bool(dnode, NULL);
+
+	if (enable)
+		vty_out(vty, "log immediate-mode\n");
+	else if (show_defaults)
+		vty_out(vty, "no log immediate-mode\n");
+}
+
+static void logging_uid_backtrace_cli_write(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	vty_out(vty, "debug unique-id %s backtrace\n", yang_dnode_get_string(dnode, "uid"));
+}
+
+const struct frr_yang_module_info frr_logging_cli_info = {
+	.name = "frr-logging",
+	.ignore_cfg_cbs = true,
+	.nodes = {
+		{ .xpath = "/frr-logging:logging/stdout", .cbs.cli_show = logging_stdout_cli_write },
+		{ .xpath = "/frr-logging:logging/syslog", .cbs.cli_show = logging_syslog_cli_write },
+		{ .xpath = "/frr-logging:logging/file/filename", .cbs.cli_show = logging_file_filename_cli_write },
+		{ .xpath = "/frr-logging:logging/filtered-file/filename", .cbs.cli_show = logging_filtered_file_filename_cli_write },
+		/* This is not saved, but may be the future. */
+		/* { .xpath = "/frr-logging:logging/filter-text", .cbs.cli_show = logging_filter_text_cli_write }, */
+		{ .xpath = "/frr-logging:logging/daemon-file/filename", .cbs.cli_show = logging_daemon_file_filename_cli_write },
+		{ .xpath = "/frr-logging:logging/facility", .cbs.cli_show = logging_facility_cli_write },
+		{ .xpath = "/frr-logging:logging/record-priority", .cbs.cli_show = logging_record_priority_cli_write },
+		{ .xpath = "/frr-logging:logging/timestamp-precision", .cbs.cli_show = logging_timestamp_precision_cli_write },
+		{ .xpath = "/frr-logging:logging/error-category", .cbs.cli_show = logging_error_category_cli_write },
+		{ .xpath = "/frr-logging:logging/unique-id", .cbs.cli_show = logging_unique_id_cli_write },
+		{ .xpath = "/frr-logging:logging/immediate-mode", .cbs.cli_show = logging_immediate_mode_cli_write },
+		{ .xpath = "/frr-logging:logging/uid-backtrace", .cbs.cli_show = logging_uid_backtrace_cli_write },
+		{ .xpath = NULL },
+	}
+};

--- a/lib/log_cli.c
+++ b/lib/log_cli.c
@@ -208,6 +208,18 @@ DEFPY_YANG (config_log_record_priority,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
+DEFPY_YANG (config_log_record_severity,
+       config_log_record_severity_cmd,
+       "[no] log record-severity",
+	NO_STR
+       "Logging control\n"
+       "Log the severity of the message within the message\n")
+{
+	nb_cli_enqueue_change(vty, "/frr-logging:logging/record-severity", NB_OP_MODIFY,
+			      no ? "false" : "true");
+	return nb_cli_apply_changes(vty, NULL);
+}
+
 DEFPY_YANG (config_log_timestamp_precision,
        config_log_timestamp_precision_cmd,
        "log timestamp precision (0-6)",
@@ -345,6 +357,7 @@ void log_cli_init(void)
 	install_element(CONFIG_NODE, &config_log_facility_cmd);
 	install_element(CONFIG_NODE, &no_config_log_facility_cmd);
 	install_element(CONFIG_NODE, &config_log_record_priority_cmd);
+	install_element(CONFIG_NODE, &config_log_record_severity_cmd);
 	install_element(CONFIG_NODE, &config_log_timestamp_precision_cmd);
 	install_element(CONFIG_NODE, &no_config_log_timestamp_precision_cmd);
 	install_element(CONFIG_NODE, &config_log_ec_cmd);
@@ -429,6 +442,17 @@ static void logging_record_priority_cli_write(struct vty *vty, const struct lyd_
 	else if (show_defaults)
 		vty_out(vty, "no log record-priority\n");
 }
+
+static void logging_record_severity_cli_write(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
+{
+	bool enable = yang_dnode_get_bool(dnode, NULL);
+
+	if (enable)
+		vty_out(vty, "log record-severity\n");
+	else if (show_defaults)
+		vty_out(vty, "no log record-severity\n");
+}
+
 static void logging_timestamp_precision_cli_write(struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
 {
 	const char *prec = yang_dnode_get_string(dnode, NULL);
@@ -482,6 +506,7 @@ const struct frr_yang_module_info frr_logging_cli_info = {
 		{ .xpath = "/frr-logging:logging/daemon-file/filename", .cbs.cli_show = logging_daemon_file_filename_cli_write },
 		{ .xpath = "/frr-logging:logging/facility", .cbs.cli_show = logging_facility_cli_write },
 		{ .xpath = "/frr-logging:logging/record-priority", .cbs.cli_show = logging_record_priority_cli_write },
+		{ .xpath = "/frr-logging:logging/record-severity", .cbs.cli_show = logging_record_severity_cli_write },
 		{ .xpath = "/frr-logging:logging/timestamp-precision", .cbs.cli_show = logging_timestamp_precision_cli_write },
 		{ .xpath = "/frr-logging:logging/error-category", .cbs.cli_show = logging_error_category_cli_write },
 		{ .xpath = "/frr-logging:logging/unique-id", .cbs.cli_show = logging_unique_id_cli_write },

--- a/lib/log_nb.c
+++ b/lib/log_nb.c
@@ -659,7 +659,7 @@ static int logging_uid_backtrace_destroy(struct nb_cb_destroy_args *args)
 }
 
 /* clang-format off */
-const struct frr_yang_module_info frr_logging_nb_info = {
+struct frr_yang_module_info frr_logging_nb_info = {
 	.name = "frr-logging",
 	.nodes = {
 		{

--- a/lib/log_nb.c
+++ b/lib/log_nb.c
@@ -1,0 +1,767 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * June 8 2025, Christian Hopps <chopps@labn.net>
+ *
+ * Copyright (c) 2025, LabN Consulting, L.L.C.
+ *
+ */
+#include <zebra.h>
+#include "lib/command.h"
+#include "lib/northbound.h"
+#include "lib/lib_errors.h"
+#include "lib/log.h"
+#include "lib/log_vty.h"
+#include "lib/vty.h"
+// #include "lib/zlog_targets.h"
+#include "lib/zlog_5424.h"
+
+#define ZLOG_MAXLVL(a, b) MAX(a, b)
+
+/* Default logging level in the YANG model */
+const int log_default_lvl = LOG_DEBUG;
+
+void log_stdout_apply_level(void)
+{
+	int maxlvl;
+
+	maxlvl = ZLOG_MAXLVL(log_config_stdout_lvl, log_cmdline_stdout_lvl);
+
+	if (stdout_journald_in_use) {
+		if (zt_stdout_journald.prio_min == maxlvl)
+			return;
+		zt_stdout_journald.prio_min = maxlvl;
+		zlog_5424_apply_meta(&zt_stdout_journald);
+	} else {
+		if (zt_stdout_file.prio_min == maxlvl)
+			return;
+		zt_stdout_file.prio_min = maxlvl;
+		zlog_file_set_other(&zt_stdout_file);
+	}
+}
+
+static int set_log_file(struct zlog_cfg_file *target, struct vty *vty, const char *fname,
+			int loglevel)
+{
+	char path[MAXPATHLEN + 1];
+	const char *fullpath;
+	bool ok;
+
+	/* Path detection. */
+	if (!IS_DIRECTORY_SEP(*fname)) {
+		char cwd[MAXPATHLEN + 1];
+		int pr;
+
+		cwd[MAXPATHLEN] = '\0';
+
+		if (getcwd(cwd, MAXPATHLEN) == NULL) {
+			flog_err_sys(EC_LIB_SYSTEM_CALL, "config_log_file: Unable to alloc mem!");
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+
+		pr = snprintf(path, sizeof(path), "%s/%s", cwd, fname);
+		if (pr < 0 || (unsigned int)pr >= sizeof(path)) {
+			flog_err_sys(EC_LIB_SYSTEM_CALL,
+				     "%s: Path too long ('%s/%s'); system maximum is %u", __func__,
+				     cwd, fname, MAXPATHLEN);
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+
+		fullpath = path;
+	} else
+		fullpath = fname;
+
+	target->prio_min = loglevel;
+	ok = zlog_file_set_filename(target, fullpath);
+
+	if (!ok) {
+		if (vty)
+			vty_out(vty, "can't open logfile %s\n", fname);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+	return CMD_SUCCESS;
+}
+
+void command_setup_early_logging(const char *dest, const char *level)
+{
+	int nlevel;
+	char *sep;
+	int len;
+	char type[8];
+
+	if (level) {
+		nlevel = log_level_match(level);
+
+		if (nlevel == ZLOG_DISABLED) {
+			fprintf(stderr, "invalid log level \"%s\"\n", level);
+			exit(1);
+		}
+	} else
+		nlevel = log_default_lvl;
+
+	if (!dest)
+		return;
+
+	sep = strchr(dest, ':');
+	len = sep ? (int)(sep - dest) : (int)strlen(dest);
+
+	snprintfrr(type, sizeof(type), "%.*s", len, dest);
+
+	if (strcmp(type, "stdout") == 0) {
+		log_cmdline_stdout_lvl = nlevel;
+		log_stdout_apply_level();
+		return;
+	}
+	if (strcmp(type, "syslog") == 0) {
+		log_cmdline_syslog_lvl = nlevel;
+		zlog_syslog_set_prio_min(
+			ZLOG_MAXLVL(log_config_syslog_lvl, log_cmdline_syslog_lvl));
+		return;
+	}
+	if (strcmp(type, "file") == 0 && sep) {
+		sep++;
+		set_log_file(&zt_file_cmdline, NULL, sep, nlevel);
+		return;
+	}
+	if (strcmp(type, "monitor") == 0 && sep) {
+		struct zlog_live_cfg cfg = {};
+		unsigned long fd;
+		char *endp;
+
+		sep++;
+		fd = strtoul(sep, &endp, 10);
+		if (!*sep || *endp) {
+			fprintf(stderr, "invalid monitor fd \"%s\"\n", sep);
+			exit(1);
+		}
+
+		zlog_live_open_fd(&cfg, nlevel, fd);
+		zlog_live_disown(&cfg);
+		return;
+	}
+
+	fprintf(stderr, "invalid log target \"%s\" (\"%s\")\n", type, dest);
+	exit(1);
+}
+
+static int _get_level_value(const struct lyd_node *dnode, const char *xpath)
+{
+	const struct lyd_node *level_node;
+	const char *level_str;
+
+	assert(dnode);
+
+	if (!xpath)
+		level_node = dnode;
+	else if (yang_dnode_exists(dnode, xpath))
+		level_node = yang_dnode_get(dnode, xpath);
+	else
+		/* If we change the YANG level defaults this needs to look those up */
+		return log_default_lvl;
+	assert(level_node);
+
+	level_str = lyd_get_value(level_node);
+	assert(level_str);
+
+	return log_level_match(level_str);
+}
+
+/*
+ * XPath: /frr-logging:logging/stdout
+ */
+static int logging_stdout_create(struct nb_cb_create_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	log_config_stdout_lvl = _get_level_value(args->dnode, "level");
+	log_stdout_apply_level();
+	return NB_OK;
+}
+
+
+static int logging_stdout_destroy(struct nb_cb_destroy_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	log_config_stdout_lvl = ZLOG_DISABLED;
+	log_stdout_apply_level();
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-logging:logging/stdout/level
+ */
+static int logging_stdout_level_modify(struct nb_cb_modify_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	log_config_stdout_lvl = _get_level_value(args->dnode, NULL);
+	log_stdout_apply_level();
+	return NB_OK;
+}
+
+
+/*
+ * XPath: /frr-logging:logging/syslog
+ */
+static int logging_syslog_create(struct nb_cb_create_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	log_config_syslog_lvl = _get_level_value(args->dnode, "level");
+	zlog_syslog_set_prio_min(ZLOG_MAXLVL(log_config_syslog_lvl, log_cmdline_syslog_lvl));
+	return NB_OK;
+}
+
+
+static int logging_syslog_destroy(struct nb_cb_destroy_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	log_config_syslog_lvl = ZLOG_DISABLED;
+	zlog_syslog_set_prio_min(ZLOG_MAXLVL(log_config_syslog_lvl, log_cmdline_syslog_lvl));
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-logging:logging/syslog/level
+ */
+static int logging_syslog_level_modify(struct nb_cb_modify_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	log_config_syslog_lvl = _get_level_value(args->dnode, NULL);
+	zlog_syslog_set_prio_min(ZLOG_MAXLVL(log_config_syslog_lvl, log_cmdline_syslog_lvl));
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-logging:logging/file/filename
+ */
+static int logging_file_filename_modify(struct nb_cb_modify_args *args)
+{
+	const char *fname;
+	int level;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	/* XXX Need to check to see if daemon specific if set and ignore if so */
+
+	fname = yang_dnode_get_string(args->dnode, NULL);
+	level = _get_level_value(args->dnode, "../level");
+	if (set_log_file(&zt_file, NULL, fname, level) != CMD_SUCCESS) {
+		snprintf(args->errmsg, args->errmsg_len, "%% Can't open log file %s", fname);
+		return NB_ERR_INCONSISTENCY;
+	}
+	return NB_OK;
+}
+
+static int logging_file_filename_destroy(struct nb_cb_destroy_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	/* XXX Need to check to see if daemon specific if set and ignore if so */
+
+	zt_file.prio_min = ZLOG_DISABLED;
+	zlog_file_set_other(&zt_file);
+	return NB_OK;
+}
+
+
+/*
+ * XPath: /frr-logging:logging/file/level
+ */
+static int logging_file_level_modify(struct nb_cb_modify_args *args)
+{
+	const char *fname = NULL;
+	int level;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	/* XXX Need to check to see if daemon specific if set and ignore if so */
+
+	if (yang_dnode_exists(args->dnode, "../filename"))
+		fname = yang_dnode_get_string(args->dnode, "../filename");
+	if (!fname)
+		fname = zt_file.filename;
+	level = _get_level_value(args->dnode, NULL);
+	if (set_log_file(&zt_file, NULL, fname, level) != CMD_SUCCESS)
+		return NB_ERR_INCONSISTENCY;
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-logging:logging/filtered-file/filename
+ */
+static int logging_filtered_file_filename_modify(struct nb_cb_modify_args *args)
+{
+	const char *fname;
+	int level;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	fname = yang_dnode_get_string(args->dnode, NULL);
+	level = _get_level_value(args->dnode, "../level");
+	if (set_log_file(&zt_filterfile.parent, NULL, fname, level) != CMD_SUCCESS)
+		return NB_ERR_INCONSISTENCY;
+	return NB_OK;
+}
+
+static int logging_filtered_file_filename_destroy(struct nb_cb_destroy_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	zt_filterfile.parent.prio_min = ZLOG_DISABLED;
+	zlog_file_set_other(&zt_filterfile.parent);
+	return NB_OK;
+}
+
+
+/*
+ * XPath: /frr-logging:logging/filtered-file/level
+ */
+static int logging_filtered_file_level_modify(struct nb_cb_modify_args *args)
+{
+	const char *fname = NULL;
+	int level;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	if (yang_dnode_exists(args->dnode, "../filename"))
+		fname = yang_dnode_get_string(args->dnode, "../filename");
+	if (!fname)
+		fname = zt_file.filename;
+	level = _get_level_value(args->dnode, NULL);
+	if (set_log_file(&zt_filterfile.parent, NULL, fname, level) != CMD_SUCCESS)
+		return NB_ERR_INCONSISTENCY;
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-logging:logging/filter-text
+ */
+static int logging_filter_text_create(struct nb_cb_create_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	zlog_filter_add(yang_dnode_get_string(args->dnode, NULL));
+
+	return NB_OK;
+}
+
+
+static int logging_filter_text_destroy(struct nb_cb_destroy_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	zlog_filter_del(yang_dnode_get_string(args->dnode, NULL));
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-logging:logging/daemon-file
+ */
+static int logging_daemon_file_create(struct nb_cb_create_args *args)
+{
+	const char *daemon, *fname;
+	int level;
+
+	/* XXX Revist this and how it interacts with log file */
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	daemon = yang_dnode_get_string(args->dnode, "daemon");
+	if (!strmatch(daemon, frr_get_progname()))
+		return NB_OK;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	fname = yang_dnode_get_string(args->dnode, "filename");
+	level = _get_level_value(args->dnode, "level");
+	if (set_log_file(&zt_file, NULL, fname, level) != CMD_SUCCESS)
+		return NB_ERR_INCONSISTENCY;
+	return NB_OK;
+}
+
+
+static int logging_daemon_file_destroy(struct nb_cb_destroy_args *args)
+{
+	const char *daemon;
+
+	/* XXX Revist this and how it interacts with log file */
+	/* Probably need to restore the /frr-logging:logging/file config */
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	daemon = yang_dnode_get_string(args->dnode, "daemon");
+	if (!strmatch(daemon, frr_get_progname()))
+		return NB_OK;
+
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-logging:logging/daemon-file/filename
+ */
+static int logging_daemon_file_filename_modify(struct nb_cb_modify_args *args)
+{
+	const char *daemon;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	/* XXX Revist this and how it interacts with log file */
+
+	daemon = yang_dnode_get_string(args->dnode, "../daemon");
+	if (!strmatch(daemon, frr_get_progname()))
+		return NB_OK;
+
+	return NB_OK;
+}
+
+
+/*
+ * XPath: /frr-logging:logging/daemon-file/level
+ */
+static int logging_daemon_file_level_modify(struct nb_cb_modify_args *args)
+{
+	const char *daemon, *fname;
+	int level;
+
+	/* XXX Revist this and how it interacts with log file */
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	daemon = yang_dnode_get_string(args->dnode, "../daemon");
+	if (!strmatch(daemon, frr_get_progname()))
+		return NB_OK;
+
+	fname = yang_dnode_get_string(args->dnode, "../filename");
+	level = _get_level_value(args->dnode, NULL);
+	if (set_log_file(&zt_file, NULL, fname, level) != CMD_SUCCESS)
+		return NB_ERR_INCONSISTENCY;
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-logging:logging/facility
+ */
+static int logging_facility_modify(struct nb_cb_modify_args *args)
+{
+	const char *fs, *s;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	s = yang_dnode_get_string(args->dnode, NULL);
+	fs = strchr(s, ':');
+	if (fs)
+		s = fs + 1;
+
+	zlog_syslog_set_facility(facility_match(s));
+
+	return NB_OK;
+}
+
+
+/*
+ * XPath: /frr-logging:logging/record-priority
+ */
+static int logging_record_priority_modify(struct nb_cb_modify_args *args)
+{
+	bool val;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	val = yang_dnode_get_bool(args->dnode, NULL);
+	zt_file.record_priority = val;
+	zlog_file_set_other(&zt_file);
+	if (!stdout_journald_in_use) {
+		zt_stdout_file.record_priority = val;
+		zlog_file_set_other(&zt_stdout_file);
+	}
+	zt_filterfile.parent.record_priority = val;
+	zlog_file_set_other(&zt_filterfile.parent);
+
+	return NB_OK;
+}
+
+
+/*
+ * XPath: /frr-logging:logging/timestamp-precision
+ */
+static int logging_timestamp_precision_modify(struct nb_cb_modify_args *args)
+{
+	uint8_t val;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	val = yang_dnode_get_uint8(args->dnode, NULL);
+	zt_file.ts_subsec = val;
+	zlog_file_set_other(&zt_file);
+	if (!stdout_journald_in_use) {
+		zt_stdout_file.ts_subsec = val;
+		zlog_file_set_other(&zt_stdout_file);
+	}
+	zt_filterfile.parent.ts_subsec = val;
+	zlog_file_set_other(&zt_filterfile.parent);
+	return NB_OK;
+}
+
+
+/*
+ * XPath: /frr-logging:logging/error-category
+ */
+static int logging_error_category_modify(struct nb_cb_modify_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	zlog_set_prefix_ec(yang_dnode_get_bool(args->dnode, NULL));
+
+	return NB_OK;
+}
+
+
+/*
+ * XPath: /frr-logging:logging/unique-id
+ */
+static int logging_unique_id_modify(struct nb_cb_modify_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	zlog_set_prefix_xid(yang_dnode_get_bool(args->dnode, NULL));
+
+	return NB_OK;
+}
+
+
+/*
+ * XPath: /frr-logging:logging/immediate-mode
+ */
+static int logging_immediate_mode_modify(struct nb_cb_modify_args *args)
+{
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	zlog_set_immediate(yang_dnode_get_bool(args->dnode, NULL));
+
+	return NB_OK;
+}
+
+
+/*
+ * XPath: /frr-logging:logging/uid-backtrace
+ */
+static int logging_uid_backtrace_create(struct nb_cb_create_args *args)
+{
+	struct xrefdata search, *xrd;
+	struct xrefdata_logmsg *xrdl;
+	const char *uid;
+
+	if (args->event != NB_EV_APPLY && args->event != NB_EV_VALIDATE)
+		return NB_OK;
+
+	/* XXX need to put some limits on the value in the YANG model */
+	uid = yang_dnode_get_string(args->dnode, "uid");
+	strlcpy(search.uid, uid, sizeof(search.uid));
+	xrd = xrefdata_uid_find(&xrefdata_uid, &search);
+
+	if (args->event == NB_EV_VALIDATE) {
+		if (!xrd || xrd->xref->type != XREFT_LOGMSG) {
+			if (args->errmsg && args->errmsg_len)
+				snprintfrr(args->errmsg, args->errmsg_len,
+					   "UID '%s' does not identify a log messages", uid);
+			return NB_ERR_VALIDATION;
+		}
+		return NB_OK;
+	}
+
+	/* This was done in the validation step */
+	assert(xrd && xrd->xref->type == XREFT_LOGMSG);
+	xrdl = container_of(xrd, struct xrefdata_logmsg, xrefdata);
+	if (!(xrdl->fl_print_bt & LOGMSG_FLAG_PERSISTENT)) {
+		xrdl->fl_print_bt |= LOGMSG_FLAG_PERSISTENT;
+		logmsgs_with_persist_bt++;
+	}
+
+	return NB_OK;
+}
+
+
+static int logging_uid_backtrace_destroy(struct nb_cb_destroy_args *args)
+{
+	struct xrefdata search, *xrd;
+	struct xrefdata_logmsg *xrdl;
+	const char *uid;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	uid = yang_dnode_get_string(args->dnode, "uid");
+	strlcpy(search.uid, uid, sizeof(search.uid));
+	xrd = xrefdata_uid_find(&xrefdata_uid, &search);
+	if (!xrd || xrd->xref->type != XREFT_LOGMSG)
+		return NB_OK;
+
+	xrdl = container_of(xrd, struct xrefdata_logmsg, xrefdata);
+	if (xrdl->fl_print_bt & LOGMSG_FLAG_PERSISTENT) {
+		xrdl->fl_print_bt &= ~LOGMSG_FLAG_PERSISTENT;
+		logmsgs_with_persist_bt--;
+	}
+
+	return NB_OK;
+}
+
+/* clang-format off */
+const struct frr_yang_module_info frr_logging_nb_info = {
+	.name = "frr-logging",
+	.nodes = {
+		{
+			.xpath = "/frr-logging:logging/stdout",
+			.cbs = {
+				.create = logging_stdout_create,
+				.destroy = logging_stdout_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/stdout/level",
+			.cbs = {
+				.modify = logging_stdout_level_modify,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/syslog",
+			.cbs = {
+				.create = logging_syslog_create,
+				.destroy = logging_syslog_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/syslog/level",
+			.cbs = {
+				.modify = logging_syslog_level_modify,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/file/filename",
+			.cbs = {
+				.modify = logging_file_filename_modify,
+				.destroy = logging_file_filename_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/file/level",
+			.cbs = {
+				.modify = logging_file_level_modify,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/filtered-file/filename",
+			.cbs = {
+				.modify = logging_filtered_file_filename_modify,
+				.destroy = logging_filtered_file_filename_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/filtered-file/level",
+			.cbs = {
+				.modify = logging_filtered_file_level_modify,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/filter-text",
+			.cbs = {
+				.create = logging_filter_text_create,
+				.destroy = logging_filter_text_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/daemon-file",
+			.cbs = {
+				.create = logging_daemon_file_create,
+				.destroy = logging_daemon_file_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/daemon-file/filename",
+			.cbs = {
+				.modify = logging_daemon_file_filename_modify,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/daemon-file/level",
+			.cbs = {
+				.modify = logging_daemon_file_level_modify,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/facility",
+			.cbs = {
+				.modify = logging_facility_modify,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/record-priority",
+			.cbs = {
+				.modify = logging_record_priority_modify,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/timestamp-precision",
+			.cbs = {
+				.modify = logging_timestamp_precision_modify,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/error-category",
+			.cbs = {
+				.modify = logging_error_category_modify,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/unique-id",
+			.cbs = {
+				.modify = logging_unique_id_modify,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/immediate-mode",
+			.cbs = {
+				.modify = logging_immediate_mode_modify,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/uid-backtrace",
+			.cbs = {
+				.create = logging_uid_backtrace_create,
+				.destroy = logging_uid_backtrace_destroy,
+			}
+		},
+		{
+			.xpath = NULL,
+		},
+	}
+};

--- a/lib/log_nb.c
+++ b/lib/log_nb.c
@@ -506,6 +506,29 @@ static int logging_record_priority_modify(struct nb_cb_modify_args *args)
 	return NB_OK;
 }
 
+/*
+ * XPath: /frr-logging:logging/record-severity
+ */
+static int logging_record_severity_modify(struct nb_cb_modify_args *args)
+{
+	bool val;
+
+	if (args->event != NB_EV_APPLY)
+		return NB_OK;
+
+	val = yang_dnode_get_bool(args->dnode, NULL);
+	zt_file.record_severity = val;
+	zlog_file_set_other(&zt_file);
+	if (!stdout_journald_in_use) {
+		zt_stdout_file.record_severity = val;
+		zlog_file_set_other(&zt_stdout_file);
+	}
+	zt_filterfile.parent.record_severity = val;
+	zlog_file_set_other(&zt_filterfile.parent);
+
+	return NB_OK;
+}
+
 
 /*
  * XPath: /frr-logging:logging/timestamp-precision
@@ -727,6 +750,12 @@ const struct frr_yang_module_info frr_logging_nb_info = {
 			.xpath = "/frr-logging:logging/record-priority",
 			.cbs = {
 				.modify = logging_record_priority_modify,
+			}
+		},
+		{
+			.xpath = "/frr-logging:logging/record-severity",
+			.cbs = {
+				.modify = logging_record_severity_modify,
 			}
 		},
 		{

--- a/lib/log_vty.c
+++ b/lib/log_vty.c
@@ -264,6 +264,7 @@ DEFUN_NOSH (show_logging,
 	vty_out(vty, "Protocol name: %s\n", zlog_protoname);
 	vty_out(vty, "Record priority: %s\n",
 		(zt_file.record_priority ? "enabled" : "disabled"));
+	vty_out(vty, "Record severity: %s\n", (zt_file.record_severity ? "enabled" : "disabled"));
 	vty_out(vty, "Timestamp precision: %d\n", zt_file.ts_subsec);
 
 	hook_call(zlog_cli_show, vty);

--- a/lib/log_vty.c
+++ b/lib/log_vty.c
@@ -24,24 +24,22 @@
 DEFINE_HOOK(zlog_rotate, (), ());
 DEFINE_HOOK(zlog_cli_show, (struct vty * vty), (vty));
 
-static unsigned logmsgs_with_persist_bt;
+uint logmsgs_with_persist_bt;
 
-static const int log_default_lvl = LOG_DEBUG;
+int log_config_stdout_lvl = ZLOG_DISABLED;
+int log_config_syslog_lvl = ZLOG_DISABLED;
+int log_cmdline_stdout_lvl = ZLOG_DISABLED;
+int log_cmdline_syslog_lvl = ZLOG_DISABLED;
 
-static int log_config_stdout_lvl = ZLOG_DISABLED;
-static int log_config_syslog_lvl = ZLOG_DISABLED;
-static int log_cmdline_stdout_lvl = ZLOG_DISABLED;
-static int log_cmdline_syslog_lvl = ZLOG_DISABLED;
-
-static struct zlog_cfg_file zt_file_cmdline = {
+struct zlog_cfg_file zt_file_cmdline = {
 	.prio_min = ZLOG_DISABLED,
 	.ts_subsec = LOG_TIMESTAMP_PRECISION,
 };
-static struct zlog_cfg_file zt_file = {
+struct zlog_cfg_file zt_file = {
 	.prio_min = ZLOG_DISABLED,
 	.ts_subsec = LOG_TIMESTAMP_PRECISION,
 };
-static struct zlog_cfg_filterfile zt_filterfile = {
+struct zlog_cfg_filterfile zt_filterfile = {
 	.parent =
 		{
 			.prio_min = ZLOG_DISABLED,
@@ -49,11 +47,11 @@ static struct zlog_cfg_filterfile zt_filterfile = {
 		},
 };
 
-static struct zlog_cfg_file zt_stdout_file = {
+struct zlog_cfg_file zt_stdout_file = {
 	.prio_min = ZLOG_DISABLED,
 	.ts_subsec = LOG_TIMESTAMP_PRECISION,
 };
-static struct zlog_cfg_5424 zt_stdout_journald = {
+struct zlog_cfg_5424 zt_stdout_journald = {
 	.prio_min = ZLOG_DISABLED,
 
 	.fmt = ZLOG_FMT_JOURNALD,
@@ -70,7 +68,7 @@ static struct zlog_cfg_5424 zt_stdout_journald = {
 	.kw_ec = true,
 	.kw_args = true,
 };
-static bool stdout_journald_in_use;
+bool stdout_journald_in_use;
 
 const char *zlog_progname;
 static const char *zlog_protoname;
@@ -104,9 +102,13 @@ static const struct facility_map {
 	{0, NULL, 0},
 };
 
-static const char * const zlog_priority[] = {
-	"emergencies",   "alerts",	"critical",  "errors", "warnings",
+const char *const zlog_priority[] = {
+	"emergencies",	 "alerts",	  "critical",  "errors", "warnings",
 	"notifications", "informational", "debugging", NULL,
+};
+
+const char *const syslog_severity[] = {
+	"emergency", "alert", "critical", "error", "warning", "notice", "info", "debug", NULL,
 };
 
 const char *zlog_priority_str(int priority)
@@ -144,6 +146,16 @@ int log_level_match(const char *s)
 		if (!strncmp(s, zlog_priority[level], 2))
 			return level;
 	return ZLOG_DISABLED;
+}
+
+const char *log_lev2sev(const char *level_name)
+{
+	int level = log_level_match(level_name);
+
+	if (level == ZLOG_DISABLED)
+		return "emergency";
+
+	return syslog_severity[level];
 }
 
 void zlog_rotate(void)
@@ -258,77 +270,6 @@ DEFUN_NOSH (show_logging,
 	return CMD_SUCCESS;
 }
 
-static void log_stdout_apply_level(void)
-{
-	int maxlvl;
-
-	maxlvl = ZLOG_MAXLVL(log_config_stdout_lvl, log_cmdline_stdout_lvl);
-
-	if (stdout_journald_in_use) {
-		zt_stdout_journald.prio_min = maxlvl;
-		zlog_5424_apply_meta(&zt_stdout_journald);
-	} else {
-		zt_stdout_file.prio_min = maxlvl;
-		zlog_file_set_other(&zt_stdout_file);
-	}
-}
-
-DEFPY (config_log_stdout,
-       config_log_stdout_cmd,
-       "log stdout [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>$levelarg]",
-       "Logging control\n"
-       "Set stdout logging level\n"
-       LOG_LEVEL_DESC)
-{
-	int level;
-
-	if (levelarg) {
-		level = log_level_match(levelarg);
-		if (level == ZLOG_DISABLED)
-			return CMD_ERR_NO_MATCH;
-	} else
-		level = log_default_lvl;
-
-	log_config_stdout_lvl = level;
-	log_stdout_apply_level();
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_config_log_stdout,
-       no_config_log_stdout_cmd,
-       "no log stdout [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>]",
-       NO_STR
-       "Logging control\n"
-       "Cancel logging to stdout\n"
-       LOG_LEVEL_DESC)
-{
-	log_config_stdout_lvl = ZLOG_DISABLED;
-	log_stdout_apply_level();
-	return CMD_SUCCESS;
-}
-
-DEFUN_HIDDEN (config_log_monitor,
-       config_log_monitor_cmd,
-       "log monitor [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>]",
-       "Logging control\n"
-       "Set terminal line (monitor) logging level\n"
-       LOG_LEVEL_DESC)
-{
-	vty_out(vty, "%% \"log monitor\" is deprecated and does nothing.\n");
-	return CMD_SUCCESS;
-}
-
-DEFUN_HIDDEN (no_config_log_monitor,
-       no_config_log_monitor_cmd,
-       "no log monitor [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>]",
-       NO_STR
-       "Logging control\n"
-       "Disable terminal line (monitor) logging\n"
-       LOG_LEVEL_DESC)
-{
-	return CMD_SUCCESS;
-}
-
 DEFPY_NOSH (debug_uid_backtrace,
 	    debug_uid_backtrace_cmd,
 	    "[no] debug unique-id UID backtrace",
@@ -366,112 +307,6 @@ DEFPY_NOSH (debug_uid_backtrace,
 	return CMD_SUCCESS;
 }
 
-static int set_log_file(struct zlog_cfg_file *target, struct vty *vty,
-			const char *fname, int loglevel)
-{
-	char path[MAXPATHLEN + 1];
-	const char *fullpath;
-	bool ok;
-
-
-	/* Path detection. */
-	if (!IS_DIRECTORY_SEP(*fname)) {
-		char cwd[MAXPATHLEN + 1];
-
-		cwd[MAXPATHLEN] = '\0';
-
-		if (getcwd(cwd, MAXPATHLEN) == NULL) {
-			flog_err_sys(EC_LIB_SYSTEM_CALL,
-				     "config_log_file: Unable to alloc mem!");
-			return CMD_WARNING_CONFIG_FAILED;
-		}
-
-		int pr = snprintf(path, sizeof(path), "%s/%s", cwd, fname);
-		if (pr < 0 || (unsigned int)pr >= sizeof(path)) {
-			flog_err_sys(
-				EC_LIB_SYSTEM_CALL,
-				"%s: Path too long ('%s/%s'); system maximum is %u",
-				__func__, cwd, fname, MAXPATHLEN);
-			return CMD_WARNING_CONFIG_FAILED;
-		}
-
-		fullpath = path;
-	} else
-		fullpath = fname;
-
-	target->prio_min = loglevel;
-	ok = zlog_file_set_filename(target, fullpath);
-
-	if (!ok) {
-		if (vty)
-			vty_out(vty, "can't open logfile %s\n", fname);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-	return CMD_SUCCESS;
-}
-
-void command_setup_early_logging(const char *dest, const char *level)
-{
-	int nlevel;
-	char *sep;
-	int len;
-	char type[8];
-
-	if (level) {
-		nlevel = log_level_match(level);
-
-		if (nlevel == ZLOG_DISABLED) {
-			fprintf(stderr, "invalid log level \"%s\"\n", level);
-			exit(1);
-		}
-	} else
-		nlevel = log_default_lvl;
-
-	if (!dest)
-		return;
-
-	sep = strchr(dest, ':');
-	len = sep ? (int)(sep - dest) : (int)strlen(dest);
-
-	snprintfrr(type, sizeof(type), "%.*s", len, dest);
-
-	if (strcmp(type, "stdout") == 0) {
-		log_cmdline_stdout_lvl = nlevel;
-		log_stdout_apply_level();
-		return;
-	}
-	if (strcmp(type, "syslog") == 0) {
-		log_cmdline_syslog_lvl = nlevel;
-		zlog_syslog_set_prio_min(ZLOG_MAXLVL(log_config_syslog_lvl,
-						     log_cmdline_syslog_lvl));
-		return;
-	}
-	if (strcmp(type, "file") == 0 && sep) {
-		sep++;
-		set_log_file(&zt_file_cmdline, NULL, sep, nlevel);
-		return;
-	}
-	if (strcmp(type, "monitor") == 0 && sep) {
-		struct zlog_live_cfg cfg = {};
-		unsigned long fd;
-		char *endp;
-
-		sep++;
-		fd = strtoul(sep, &endp, 10);
-		if (!*sep || *endp) {
-			fprintf(stderr, "invalid monitor fd \"%s\"\n", sep);
-			exit(1);
-		}
-
-		zlog_live_open_fd(&cfg, nlevel, fd);
-		zlog_live_disown(&cfg);
-		return;
-	}
-
-	fprintf(stderr, "invalid log target \"%s\" (\"%s\")\n", type, dest);
-	exit(1);
-}
-
 DEFUN (clear_log_cmdline,
        clear_log_cmdline_cmd,
        "clear log cmdline-targets",
@@ -489,333 +324,6 @@ DEFUN (clear_log_cmdline,
 	log_cmdline_stdout_lvl = ZLOG_DISABLED;
 	log_stdout_apply_level();
 
-	return CMD_SUCCESS;
-}
-
-/* Per-daemon log file config */
-DEFUN (config_log_dmn_file,
-       config_log_dmn_file_cmd,
-       "log daemon " DAEMONS_LIST " file FILENAME [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>$levelarg]",
-       "Logging control\n"
-       "Specific daemon\n"
-       DAEMONS_STR
-       "Logging to file\n"
-       "Logging filename\n"
-       LOG_LEVEL_DESC)
-{
-	int level = log_default_lvl;
-	int idx = 0;
-	const char *d_str;
-	const char *filename;
-	const char *levelarg = NULL;
-
-	d_str = argv[2]->text;
-
-	/* Ignore if not for this daemon */
-	if (!strmatch(d_str, frr_get_progname()))
-		return CMD_SUCCESS;
-
-	if (argv_find(argv, argc, "file", &idx))
-		filename = argv[idx + 1]->arg;
-	else
-		return CMD_SUCCESS;
-
-	if (argc > 5)
-		levelarg = argv[5]->text;
-
-	if (levelarg) {
-		level = log_level_match(levelarg);
-		if (level == ZLOG_DISABLED)
-			return CMD_ERR_NO_MATCH;
-	}
-	return set_log_file(&zt_file, vty, filename, level);
-}
-
-/* Per-daemon no log file */
-DEFUN (no_config_log_dmn_file,
-       no_config_log_dmn_file_cmd,
-       "no log daemon " DAEMONS_LIST " file [FILENAME [LEVEL]]",
-       NO_STR
-       "Logging control\n"
-       "Specific daemon\n"
-       DAEMONS_STR
-       "Cancel logging to file\n"
-       "Logging file name\n"
-       "Logging level\n")
-{
-	const char *d_str;
-
-	d_str = argv[3]->text;
-
-	/* Ignore if not for this daemon */
-	if (!strmatch(d_str, frr_get_progname()))
-		return CMD_SUCCESS;
-
-	zt_file.prio_min = ZLOG_DISABLED;
-	zlog_file_set_other(&zt_file);
-	return CMD_SUCCESS;
-}
-
-DEFPY (config_log_file,
-       config_log_file_cmd,
-       "log file FILENAME [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>$levelarg]",
-       "Logging control\n"
-       "Logging to file\n"
-       "Logging filename\n"
-       LOG_LEVEL_DESC)
-{
-	int level = log_default_lvl;
-
-	if (levelarg) {
-		level = log_level_match(levelarg);
-		if (level == ZLOG_DISABLED)
-			return CMD_ERR_NO_MATCH;
-	}
-	return set_log_file(&zt_file, vty, filename, level);
-}
-
-DEFUN (no_config_log_file,
-       no_config_log_file_cmd,
-       "no log file [FILENAME [LEVEL]]",
-       NO_STR
-       "Logging control\n"
-       "Cancel logging to file\n"
-       "Logging file name\n"
-       "Logging level\n")
-{
-	zt_file.prio_min = ZLOG_DISABLED;
-	zlog_file_set_other(&zt_file);
-	return CMD_SUCCESS;
-}
-
-DEFPY (config_log_syslog,
-       config_log_syslog_cmd,
-       "log syslog [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>$levelarg]",
-       "Logging control\n"
-       "Set syslog logging level\n"
-       LOG_LEVEL_DESC)
-{
-	int level;
-
-	if (levelarg) {
-		level = log_level_match(levelarg);
-
-		if (level == ZLOG_DISABLED)
-			return CMD_ERR_NO_MATCH;
-	} else
-		level = log_default_lvl;
-
-	log_config_syslog_lvl = level;
-	zlog_syslog_set_prio_min(ZLOG_MAXLVL(log_config_syslog_lvl,
-					     log_cmdline_syslog_lvl));
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_config_log_syslog,
-       no_config_log_syslog_cmd,
-       "no log syslog [<kern|user|mail|daemon|auth|syslog|lpr|news|uucp|cron|local0|local1|local2|local3|local4|local5|local6|local7>] [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>]",
-       NO_STR
-       "Logging control\n"
-       "Cancel logging to syslog\n"
-       LOG_FACILITY_DESC
-       LOG_LEVEL_DESC)
-{
-	log_config_syslog_lvl = ZLOG_DISABLED;
-	zlog_syslog_set_prio_min(ZLOG_MAXLVL(log_config_syslog_lvl,
-					     log_cmdline_syslog_lvl));
-	return CMD_SUCCESS;
-}
-
-DEFPY (config_log_facility,
-       config_log_facility_cmd,
-       "log facility <kern|user|mail|daemon|auth|syslog|lpr|news|uucp|cron|local0|local1|local2|local3|local4|local5|local6|local7>$facilityarg",
-       "Logging control\n"
-       "Facility parameter for syslog messages\n"
-       LOG_FACILITY_DESC)
-{
-	int facility = facility_match(facilityarg);
-
-	zlog_syslog_set_facility(facility);
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_config_log_facility,
-       no_config_log_facility_cmd,
-       "no log facility [<kern|user|mail|daemon|auth|syslog|lpr|news|uucp|cron|local0|local1|local2|local3|local4|local5|local6|local7>]",
-       NO_STR
-       "Logging control\n"
-       "Reset syslog facility to default (daemon)\n"
-       LOG_FACILITY_DESC)
-{
-	zlog_syslog_set_facility(LOG_DAEMON);
-	return CMD_SUCCESS;
-}
-
-DEFUN (config_log_record_priority,
-       config_log_record_priority_cmd,
-       "log record-priority",
-       "Logging control\n"
-       "Log the priority of the message within the message\n")
-{
-	zt_file.record_priority = true;
-	zlog_file_set_other(&zt_file);
-	if (!stdout_journald_in_use) {
-		zt_stdout_file.record_priority = true;
-		zlog_file_set_other(&zt_stdout_file);
-	}
-	zt_filterfile.parent.record_priority = true;
-	zlog_file_set_other(&zt_filterfile.parent);
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_config_log_record_priority,
-       no_config_log_record_priority_cmd,
-       "no log record-priority",
-       NO_STR
-       "Logging control\n"
-       "Do not log the priority of the message within the message\n")
-{
-	zt_file.record_priority = false;
-	zlog_file_set_other(&zt_file);
-	if (!stdout_journald_in_use) {
-		zt_stdout_file.record_priority = false;
-		zlog_file_set_other(&zt_stdout_file);
-	}
-	zt_filterfile.parent.record_priority = false;
-	zlog_file_set_other(&zt_filterfile.parent);
-	return CMD_SUCCESS;
-}
-
-DEFPY (config_log_timestamp_precision,
-       config_log_timestamp_precision_cmd,
-       "log timestamp precision (0-6)",
-       "Logging control\n"
-       "Timestamp configuration\n"
-       "Set the timestamp precision\n"
-       "Number of subsecond digits\n")
-{
-	zt_file.ts_subsec = precision;
-	zlog_file_set_other(&zt_file);
-	if (!stdout_journald_in_use) {
-		zt_stdout_file.ts_subsec = precision;
-		zlog_file_set_other(&zt_stdout_file);
-	}
-	zt_filterfile.parent.ts_subsec = precision;
-	zlog_file_set_other(&zt_filterfile.parent);
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_config_log_timestamp_precision,
-       no_config_log_timestamp_precision_cmd,
-       "no log timestamp precision [(0-6)]",
-       NO_STR
-       "Logging control\n"
-       "Timestamp configuration\n"
-       "Reset the timestamp precision to the default value of 0\n"
-       "Number of subsecond digits\n")
-{
-	zt_file.ts_subsec = 0;
-	zlog_file_set_other(&zt_file);
-	if (!stdout_journald_in_use) {
-		zt_stdout_file.ts_subsec = 0;
-		zlog_file_set_other(&zt_stdout_file);
-	}
-	zt_filterfile.parent.ts_subsec = 0;
-	zlog_file_set_other(&zt_filterfile.parent);
-	return CMD_SUCCESS;
-}
-
-DEFPY (config_log_ec,
-       config_log_ec_cmd,
-       "[no] log error-category",
-       NO_STR
-       "Logging control\n"
-       "Prefix log message text with [EC 9999] code\n")
-{
-	zlog_set_prefix_ec(!no);
-	return CMD_SUCCESS;
-}
-
-DEFPY (config_log_xid,
-       config_log_xid_cmd,
-       "[no] log unique-id",
-       NO_STR
-       "Logging control\n"
-       "Prefix log message text with [XXXXX-XXXXX] identifier\n")
-{
-	zlog_set_prefix_xid(!no);
-	return CMD_SUCCESS;
-}
-
-DEFPY (config_log_filterfile,
-       config_log_filterfile_cmd,
-       "log filtered-file FILENAME [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>$levelarg]",
-       "Logging control\n"
-       "Logging to file with string filter\n"
-       "Logging filename\n"
-       LOG_LEVEL_DESC)
-{
-	int level = log_default_lvl;
-
-	if (levelarg) {
-		level = log_level_match(levelarg);
-		if (level == ZLOG_DISABLED)
-			return CMD_ERR_NO_MATCH;
-	}
-	return set_log_file(&zt_filterfile.parent, vty, filename, level);
-}
-
-DEFUN (no_config_log_filterfile,
-       no_config_log_filterfile_cmd,
-       "no log filtered-file [FILENAME [LEVEL]]",
-       NO_STR
-       "Logging control\n"
-       "Cancel logging to file with string filter\n"
-       "Logging file name\n"
-       "Logging level\n")
-{
-	zt_filterfile.parent.prio_min = ZLOG_DISABLED;
-	zlog_file_set_other(&zt_filterfile.parent);
-	return CMD_SUCCESS;
-}
-
-DEFPY (log_filter,
-       log_filter_cmd,
-       "[no] log filter-text WORD$filter",
-       NO_STR
-       "Logging control\n"
-       FILTER_LOG_STR
-       "String to filter by\n")
-{
-	int ret = 0;
-
-	if (no)
-		ret = zlog_filter_del(filter);
-	else
-		ret = zlog_filter_add(filter);
-
-	if (ret == 1) {
-		vty_out(vty, "%% filter table full\n");
-		return CMD_WARNING;
-	} else if (ret != 0) {
-		vty_out(vty, "%% failed to %s log filter\n",
-			(no ? "remove" : "apply"));
-		return CMD_WARNING;
-	}
-
-	vty_out(vty, " %s\n", filter);
-	return CMD_SUCCESS;
-}
-
-/* Clear all log filters */
-DEFPY (log_filter_clear,
-       log_filter_clear_cmd,
-       "clear log filter-text",
-       CLEAR_STR
-       "Logging control\n"
-       FILTER_LOG_STR)
-{
-	zlog_filter_clear();
 	return CMD_SUCCESS;
 }
 
@@ -841,119 +349,6 @@ DEFPY (show_log_filter,
 		vty_out(vty, "%s", log_filters);
 
 	return CMD_SUCCESS;
-}
-
-/* Enable/disable 'immediate' mode, with no output buffering */
-DEFPY (log_immediate_mode,
-       log_immediate_mode_cmd,
-       "[no] log immediate-mode",
-       NO_STR
-       "Logging control\n"
-       "Output immediately, without buffering\n")
-{
-	zlog_set_immediate(!no);
-	return CMD_SUCCESS;
-}
-
-void log_config_write(struct vty *vty)
-{
-	bool show_cmdline_hint = false;
-
-	if (zt_file.prio_min != ZLOG_DISABLED && zt_file.filename) {
-		vty_out(vty, "log file %s", zt_file.filename);
-
-		if (zt_file.prio_min != log_default_lvl)
-			vty_out(vty, " %s", zlog_priority[zt_file.prio_min]);
-		vty_out(vty, "\n");
-	}
-
-	if (zt_filterfile.parent.prio_min != ZLOG_DISABLED
-	    && zt_filterfile.parent.filename) {
-		vty_out(vty, "log filtered-file %s",
-			zt_filterfile.parent.filename);
-
-		if (zt_filterfile.parent.prio_min != log_default_lvl)
-			vty_out(vty, " %s",
-				zlog_priority[zt_filterfile.parent.prio_min]);
-		vty_out(vty, "\n");
-	}
-
-	if (log_config_stdout_lvl != ZLOG_DISABLED) {
-		vty_out(vty, "log stdout");
-
-		if (log_config_stdout_lvl != log_default_lvl)
-			vty_out(vty, " %s",
-				zlog_priority[log_config_stdout_lvl]);
-		vty_out(vty, "\n");
-	}
-
-	if (log_config_syslog_lvl != ZLOG_DISABLED) {
-		vty_out(vty, "log syslog");
-
-		if (log_config_syslog_lvl != log_default_lvl)
-			vty_out(vty, " %s",
-				zlog_priority[log_config_syslog_lvl]);
-		vty_out(vty, "\n");
-	}
-
-	if (log_cmdline_syslog_lvl != ZLOG_DISABLED) {
-		vty_out(vty,
-			"! \"log syslog %s\" enabled by \"--log\" startup option\n",
-			zlog_priority[log_cmdline_syslog_lvl]);
-		show_cmdline_hint = true;
-	}
-	if (log_cmdline_stdout_lvl != ZLOG_DISABLED) {
-		vty_out(vty,
-			"! \"log stdout %s\" enabled by \"--log\" startup option\n",
-			zlog_priority[log_cmdline_stdout_lvl]);
-		show_cmdline_hint = true;
-	}
-	if (zt_file_cmdline.prio_min != ZLOG_DISABLED) {
-		vty_out(vty,
-			"! \"log file %s %s\" enabled by \"--log\" startup option\n",
-			zt_file_cmdline.filename,
-			zlog_priority[zt_file_cmdline.prio_min]);
-		show_cmdline_hint = true;
-	}
-	if (show_cmdline_hint)
-		vty_out(vty,
-			"! use \"clear log cmdline-targets\" to remove this target\n");
-
-	if (zlog_syslog_get_facility() != LOG_DAEMON)
-		vty_out(vty, "log facility %s\n",
-			facility_name(zlog_syslog_get_facility()));
-
-	if (zt_file.record_priority == 1)
-		vty_out(vty, "log record-priority\n");
-
-	if (zt_file.ts_subsec > 0)
-		vty_out(vty, "log timestamp precision %d\n",
-			zt_file.ts_subsec);
-
-	if (!zlog_get_prefix_ec())
-		vty_out(vty, "no log error-category\n");
-	if (!zlog_get_prefix_xid())
-		vty_out(vty, "no log unique-id\n");
-	if (zlog_get_immediate_mode())
-		vty_out(vty, "log immediate-mode\n");
-
-	if (logmsgs_with_persist_bt) {
-		struct xrefdata *xrd;
-		struct xrefdata_logmsg *xrdl;
-
-		vty_out(vty, "!\n");
-
-		frr_each (xrefdata_uid, &xrefdata_uid, xrd) {
-			if (xrd->xref->type != XREFT_LOGMSG)
-				continue;
-
-			xrdl = container_of(xrd, struct xrefdata_logmsg,
-					    xrefdata);
-			if (xrdl->fl_print_bt & LOGMSG_FLAG_PERSISTENT)
-				vty_out(vty, "debug unique-id %s backtrace\n",
-					xrd->uid);
-		}
-	}
 }
 
 static int log_vty_fini(void)
@@ -998,35 +393,8 @@ void log_cmd_init(void)
 	install_element(VIEW_NODE, &send_log_cmd);
 	install_element(VIEW_NODE, &show_logging_cmd);
 	install_element(ENABLE_NODE, &clear_log_cmdline_cmd);
-
-	install_element(CONFIG_NODE, &config_log_stdout_cmd);
-	install_element(CONFIG_NODE, &no_config_log_stdout_cmd);
-	install_element(CONFIG_NODE, &config_log_monitor_cmd);
-	install_element(CONFIG_NODE, &no_config_log_monitor_cmd);
-	install_element(CONFIG_NODE, &config_log_file_cmd);
-	install_element(CONFIG_NODE, &config_log_dmn_file_cmd);
-	install_element(CONFIG_NODE, &no_config_log_dmn_file_cmd);
-	install_element(CONFIG_NODE, &no_config_log_file_cmd);
-	install_element(CONFIG_NODE, &config_log_syslog_cmd);
-	install_element(CONFIG_NODE, &no_config_log_syslog_cmd);
-	install_element(CONFIG_NODE, &config_log_facility_cmd);
-	install_element(CONFIG_NODE, &no_config_log_facility_cmd);
-	install_element(CONFIG_NODE, &config_log_record_priority_cmd);
-	install_element(CONFIG_NODE, &no_config_log_record_priority_cmd);
-	install_element(CONFIG_NODE, &config_log_timestamp_precision_cmd);
-	install_element(CONFIG_NODE, &no_config_log_timestamp_precision_cmd);
-	install_element(CONFIG_NODE, &config_log_ec_cmd);
-	install_element(CONFIG_NODE, &config_log_xid_cmd);
-
 	install_element(VIEW_NODE, &show_log_filter_cmd);
-	install_element(CONFIG_NODE, &log_filter_cmd);
-	install_element(CONFIG_NODE, &log_filter_clear_cmd);
-	install_element(CONFIG_NODE, &config_log_filterfile_cmd);
-	install_element(CONFIG_NODE, &no_config_log_filterfile_cmd);
-	install_element(CONFIG_NODE, &log_immediate_mode_cmd);
-
 	install_element(ENABLE_NODE, &debug_uid_backtrace_cmd);
-	install_element(CONFIG_NODE, &debug_uid_backtrace_cmd);
 
 	log_5424_cmd_init();
 }

--- a/lib/log_vty.h
+++ b/lib/log_vty.h
@@ -48,7 +48,7 @@ extern bool stdout_journald_in_use;
 
 void log_stdout_apply_level(void);
 
-extern const struct frr_yang_module_info frr_logging_cli_info;
+extern struct frr_yang_module_info frr_logging_cli_info;
 
 #ifdef __cplusplus
 }

--- a/lib/log_vty.h
+++ b/lib/log_vty.h
@@ -20,6 +20,7 @@ extern void log_cmd_init(void);
 extern void log_config_write(struct vty *vty);
 extern int log_level_match(const char *s);
 extern void log_show_syslog(struct vty *vty);
+extern const char *log_lev2sev(const char *level);
 
 extern int facility_match(const char *str);
 extern const char *facility_name(int facility);
@@ -28,6 +29,26 @@ DECLARE_HOOK(zlog_rotate, (), ());
 extern void zlog_rotate(void);
 
 DECLARE_HOOK(zlog_cli_show, (struct vty * vty), (vty));
+
+/* Default logging level in the YANG model */
+extern const int log_default_lvl;
+
+/* Internal logging state */
+extern uint logmsgs_with_persist_bt;
+extern int log_config_stdout_lvl;
+extern int log_config_syslog_lvl;
+extern int log_cmdline_stdout_lvl;
+extern int log_cmdline_syslog_lvl;
+extern struct zlog_cfg_file zt_file_cmdline;
+extern struct zlog_cfg_file zt_file;
+extern struct zlog_cfg_filterfile zt_filterfile;
+extern struct zlog_cfg_file zt_stdout_file;
+extern struct zlog_cfg_5424 zt_stdout_journald;
+extern bool stdout_journald_in_use;
+
+void log_stdout_apply_level(void);
+
+extern const struct frr_yang_module_info frr_logging_cli_info;
 
 #ifdef __cplusplus
 }

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -2756,7 +2756,7 @@ void nb_init(struct event_loop *tm,
 	     const struct frr_yang_module_info *const modules[],
 	     size_t nmodules, bool db_enabled, bool load_library)
 {
-	struct yang_module *loaded[nmodules + 1];
+	struct yang_module *loaded[nmodules + 2];
 
 	/*
 	 * Currently using this explicit compile feature in libyang2 leads to
@@ -2772,6 +2772,9 @@ void nb_init(struct event_loop *tm,
 
 	yang_init(true, explicit_compile, load_library);
 
+	/* needed for frr-logging */
+	assert(yang_module_load("ietf-syslog-types", NULL));
+
 	/* Load YANG modules and their corresponding northbound callbacks. */
 	for (size_t i = 0; i < nmodules; i++) {
 		DEBUGD(&nb_dbg_events, "northbound: loading %s.yang",
@@ -2784,6 +2787,13 @@ void nb_init(struct event_loop *tm,
 	if (!yang_module_find("frr-host")) {
 		loaded[nmodules] = yang_module_load("frr-host", NULL);
 		loaded[nmodules]->frr_info = &frr_host_nb_info;
+		nmodules++;
+	}
+
+	/* Load the host module if it is not already. */
+	if (!yang_module_find("frr-logging")) {
+		loaded[nmodules] = yang_module_load("frr-logging", NULL);
+		loaded[nmodules]->frr_info = &frr_logging_nb_info;
 		nmodules++;
 	}
 

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -738,7 +738,7 @@ struct frr_yang_module_info {
 	void (*unlock_tree)(const struct lyd_node *tree, void *user_lock);
 
 	/* Northbound callbacks. */
-	const struct {
+	struct {
 		/* Data path of this YANG node. */
 		const char *xpath;
 
@@ -1391,6 +1391,17 @@ extern int nb_candidate_commit_prepare(struct nb_context context,
 				       bool skip_validate,
 				       bool ignore_zero_change, char *errmsg,
 				       size_t errmsg_len);
+
+
+/*
+ * This function is used externally by mgmtd which has already calculated
+ * changes and just needs to run the process for itself without interacting with
+ * it's own candidate config which has all the backend client changes in it.
+ */
+extern int nb_changes_commit_prepare(struct nb_context context, struct nb_config_cbs changes,
+				     const char *comment, struct nb_config *candidate_config,
+				     struct nb_transaction **transaction, char *errmsg,
+				     size_t errmsg_len);
 
 /*
  * Abort a previously created configuration transaction, releasing all resources

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -66,7 +66,9 @@ lib_libfrr_la_SOURCES = \
 	lib/linklist.c \
 	lib/link_state.c \
 	lib/log.c \
+	lib/log_cli.c \
 	lib/log_filter.c \
+	lib/log_nb.c \
 	lib/log_vty.c \
 	lib/md5.c \
 	lib/memory.c \
@@ -181,6 +183,7 @@ clippy_scan += \
 	lib/filter_cli.c \
 	lib/if_rmap.c \
 	lib/keychain_cli.c \
+	lib/log_cli.c \
 	lib/log_vty.c \
 	lib/mgmt_be_client.c \
 	lib/mgmt_fe_client.c \

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -152,6 +152,7 @@ nodist_lib_libfrr_la_SOURCES = \
 	yang/frr-host.yang.c \
 	yang/frr-if-rmap.yang.c \
 	yang/frr-interface.yang.c \
+	yang/frr-logging.yang.c \
 	yang/frr-route-map.yang.c \
 	yang/frr-route-types.yang.c \
 	yang/frr-vrf.yang.c \
@@ -159,6 +160,7 @@ nodist_lib_libfrr_la_SOURCES = \
 	yang/frr-nexthop.yang.c \
 	yang/ietf/frr-deviations-ietf-key-chain.yang.c \
 	yang/ietf/ietf-routing-types.yang.c \
+	yang/ietf/ietf-syslog-types.yang.c \
 	yang/ietf/ietf-netconf-acm.yang.c \
 	yang/ietf/ietf-key-chain.yang.c \
 	yang/ietf/ietf-interfaces.yang.c \

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -99,6 +99,7 @@ static const char *const frr_native_modules[] = {
 	"frr-host",
 	"frr-interface",
 	"frr-isisd",
+	"frr-logging",
 	"frr-nexthop",
 	"frr-pathd",
 	"frr-ripd",
@@ -108,6 +109,7 @@ static const char *const frr_native_modules[] = {
 	"frr-vrf",
 	"frr-vrrpd",
 	"frr-zebra",
+	"ietf-syslog-types",
 };
 /* clang-format on */
 

--- a/lib/zlog_targets.c
+++ b/lib/zlog_targets.c
@@ -35,8 +35,15 @@ struct zlt_fd {
 
 	char ts_subsec;
 	bool record_priority;
+	bool record_severity;
 
 	struct rcu_head_close head_close;
+};
+
+static const char *const severity_names[] = {
+	[LOG_EMERG] = "EMERG: ", [LOG_ALERT] = "ALERT: ",  [LOG_CRIT] = "CRIT: ",
+	[LOG_ERR] = "ERROR: ",	 [LOG_WARNING] = "WARN: ", [LOG_NOTICE] = "NOTICE: ",
+	[LOG_INFO] = "INFO: ",	 [LOG_DEBUG] = "DEBUG: ",
 };
 
 static const char * const prionames[] = {
@@ -85,6 +92,13 @@ void zlog_fd(struct zlog_target *zt, struct zlog_msg *msgs[], size_t nmsgs)
 
 			iovpos++;
 
+			if (zte->record_severity) {
+				iov[iovpos].iov_base = (char *)severity_names[prio];
+				iov[iovpos].iov_len = strlen(iov[iovpos].iov_base);
+
+				iovpos++;
+			}
+
 			if (zte->record_priority) {
 				iov[iovpos].iov_base = (char *)prionames[prio];
 				iov[iovpos].iov_len =
@@ -127,24 +141,31 @@ static void zlog_fd_sigsafe(struct zlog_target *zt, const char *text,
 			    size_t len)
 {
 	struct zlt_fd *zte = container_of(zt, struct zlt_fd, zt);
-	struct iovec iov[4];
-	int fd;
+	struct iovec iov[5];
+	int fd, i = 0;
 
-	iov[0].iov_base = (char *)prionames[LOG_CRIT];
-	iov[0].iov_len = zte->record_priority ? strlen(iov[0].iov_base) : 0;
+	if (zte->record_severity) {
+		iov[i].iov_base = (char *)severity_names[LOG_CRIT];
+		iov[i++].iov_len = strlen(iov[0].iov_base);
+	}
 
-	iov[1].iov_base = zlog_prefix;
-	iov[1].iov_len = zlog_prefixsz;
+	if (zte->record_priority) {
+		iov[i].iov_base = (char *)prionames[LOG_CRIT];
+		iov[i++].iov_len = strlen(iov[0].iov_base);
+	}
 
-	iov[2].iov_base = (char *)text;
-	iov[2].iov_len = len;
+	iov[i].iov_base = zlog_prefix;
+	iov[i++].iov_len = zlog_prefixsz;
 
-	iov[3].iov_base = (char *)"\n";
-	iov[3].iov_len = 1;
+	iov[i].iov_base = (char *)text;
+	iov[i++].iov_len = len;
+
+	iov[i].iov_base = (char *)"\n";
+	iov[i++].iov_len = 1;
 
 	fd = atomic_load_explicit(&zte->fd, memory_order_relaxed);
 
-	writev(fd, iov, array_size(iov));
+	writev(fd, iov, i);
 }
 
 /*
@@ -215,6 +236,7 @@ static bool zlog_file_cycle(struct zlog_cfg_file *zcf)
 
 		zlt->fd = fd;
 		zlt->record_priority = zcf->record_priority;
+		zlt->record_severity = zcf->record_severity;
 		zlt->ts_subsec = zcf->ts_subsec;
 
 		zlt->zt.prio_min = zcf->prio_min;

--- a/lib/zlog_targets.h
+++ b/lib/zlog_targets.h
@@ -27,6 +27,7 @@ struct zlog_cfg_file {
 	int prio_min;
 	char ts_subsec;
 	bool record_priority;
+	bool record_severity;
 
 	/* call zlog_file_set_filename/fd() to change this */
 	char *filename;

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -68,6 +68,7 @@ static const char *const zebra_config_xpaths[] = {
 	"/frr-affinity-map:lib",
 	"/frr-filter:lib",
 	"/frr-host:host",
+	"/frr-logging:logging",
 	"/frr-route-map:lib",
 	"/frr-zebra:zebra",
 	"/frr-interface:lib",
@@ -94,6 +95,7 @@ static const char *const mgmtd_testc_oper_xpaths[] = {
 static const char *const ripd_config_xpaths[] = {
 	"/frr-filter:lib",
 	"/frr-host:host",
+	"/frr-logging:logging",
 	"/frr-interface:lib/interface",
 	"/frr-ripd:ripd",
 	"/frr-route-map:lib",
@@ -117,6 +119,7 @@ static const char *const ripd_rpc_xpaths[] = {
 static const char *const ripngd_config_xpaths[] = {
 	"/frr-filter:lib",
 	"/frr-host:host",
+	"/frr-logging:logging",
 	"/frr-interface:lib/interface",
 	"/frr-ripngd:ripngd",
 	"/frr-route-map:lib",
@@ -137,6 +140,7 @@ static const char *const ripngd_rpc_xpaths[] = {
 #ifdef HAVE_STATICD
 static const char *const staticd_config_xpaths[] = {
 	"/frr-host:host",
+	"/frr-logging:logging",
 	"/frr-vrf:lib",
 	"/frr-interface:lib",
 	"/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd",

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -217,6 +217,14 @@ static struct mgmt_be_adapters_head mgmt_be_adapters;
 static struct mgmt_be_client_adapter
 	*mgmt_be_adapters_by_id[MGMTD_BE_CLIENT_ID_MAX];
 
+/*
+ * Mgmtd has it's own special "interested-in" xpath maps since it's not actually
+ * a backend client of itself.
+ */
+static const char *const mgmtd_config_xpaths[] = {
+	"/frr-logging:logging",
+};
+
 
 /* Forward declarations */
 static void
@@ -937,6 +945,20 @@ uint64_t mgmt_be_interested_clients(const char *xpath,
 			_dbg("Cient: %s: subscribed", mgmt_be_client_id2name(id));
 	}
 	return clients;
+}
+
+bool mgmt_is_mgmtd_interested(const char *xpath)
+{
+	const char *const *match = mgmtd_config_xpaths;
+	const char *const *ematch = match + array_size(mgmtd_config_xpaths);
+
+	for (; match < ematch; match++) {
+		if (mgmt_be_xpath_prefix(*match, xpath)) {
+			_dbg("mgmtd: subscribed to %s", xpath);
+			return true;
+		}
+	}
+	return false;
 }
 
 /**

--- a/mgmtd/mgmt_be_adapter.h
+++ b/mgmtd/mgmt_be_adapter.h
@@ -64,6 +64,7 @@ struct mgmt_be_client_adapter {
 	 * config items has been applied onto the backend.
 	 */
 	struct nb_config_cbs cfg_chgs;
+	struct mgmt_commit_stats cfg_stats;
 
 	struct mgmt_be_adapters_item list_linkage;
 };
@@ -233,5 +234,10 @@ extern void mgmt_fe_adapter_send_notify(struct mgmt_msg_notify_data *msg,
  * Dump backend client information for a given xpath to vty.
  */
 extern void mgmt_be_show_xpath_registries(struct vty *vty, const char *xpath);
+
+/*
+ * Specials for mgmtd internally handling BE like behaviors
+ */
+extern bool mgmt_is_mgmtd_interested(const char *xpath);
 
 #endif /* _FRR_MGMTD_BE_ADAPTER_H_ */

--- a/mgmtd/mgmt_main.c
+++ b/mgmtd/mgmt_main.c
@@ -7,20 +7,21 @@
  */
 
 #include <zebra.h>
-#include "lib/version.h"
-#include "routemap.h"
+#include "affinitymap.h"
 #include "filter.h"
-#include "keychain.h"
-#include "libfrr.h"
 #include "frr_pthread.h"
+#include "keychain.h"
+#include "lib/version.h"
+#include "libfrr.h"
+#include "log_vty.h"
 #include "mgmtd/mgmt.h"
 #include "mgmtd/mgmt_ds.h"
 #include "ripd/rip_nb.h"
 #include "ripngd/ripng_nb.h"
+#include "routemap.h"
 #include "routing_nb.h"
-#include "affinitymap.h"
-#include "zebra/zebra_cli.h"
 #include "srv6.h"
+#include "zebra/zebra_cli.h"
 
 /* mgmt options, we use GNU getopt library. */
 static const struct option longopts[] = {
@@ -180,6 +181,7 @@ static const struct frr_yang_module_info *const mgmt_yang_modules[] = {
 	&frr_filter_cli_info,
 	&frr_host_cli_info,
 	&frr_interface_cli_info,
+	&frr_logging_cli_info,
 	&frr_route_map_cli_info,
 	&frr_routing_cli_info,
 	&frr_vrf_cli_info,

--- a/mgmtd/mgmt_main.c
+++ b/mgmtd/mgmt_main.c
@@ -181,7 +181,7 @@ static const struct frr_yang_module_info *const mgmt_yang_modules[] = {
 	&frr_filter_cli_info,
 	&frr_host_cli_info,
 	&frr_interface_cli_info,
-	&frr_logging_cli_info,
+	&frr_logging_nb_info,
 	&frr_route_map_cli_info,
 	&frr_routing_cli_info,
 	&frr_vrf_cli_info,
@@ -241,6 +241,8 @@ int main(int argc, char **argv)
 {
 	int opt;
 	int buffer_size = MGMTD_SOCKET_BUF_SIZE;
+
+	frr_logging_merge_cli_to_nb_info();
 
 	frr_preinit(&mgmtd_di, argc, argv);
 	frr_opt_add("s:n" DEPRECATED_OPTIONS, longopts,

--- a/python/xref2vtysh.py
+++ b/python/xref2vtysh.py
@@ -42,6 +42,7 @@ daemon_flags = {
     "lib/mgmt_be_client.c": "VTYSH_MGMT_BACKEND",
     "lib/mgmt_fe_client.c": "VTYSH_MGMT_FRONTEND",
     "lib/lib_vty.c": "VTYSH_ALL",
+    "lib/log_cli.c": "VTYSH_NON_MGMTD",
     "lib/log_vty.c": "VTYSH_ALL",
     "lib/nexthop_group.c": "VTYSH_NH_GROUP",
     "lib/resolver.c": "VTYSH_NHRPD|VTYSH_BGPD",

--- a/tests/topotests/log_config/basic.py
+++ b/tests/topotests/log_config/basic.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+#
+# June 16 2025, Christian Hopps <chopps@labn.net>
+#
+# Copyright (c) 2025, LabN Consulting, L.L.C.
+#
+"""Common tests and utils for testing log output."""
+import logging
+import os
+import re
+import time
+
+import pytest
+from lib.common_config import step
+from munet.testing.util import readline, retry
+from munet.watchlog import WatchLog
+
+our_pid = os.getpid()
+daemons = ["mgmtd", "ospfd", "staticd"]
+stdout_logs = {}
+stderr_logs = {}
+daemon_logs = {}
+file_logs = {}
+
+
+class WatchSyslog(WatchLog):
+    """An object for watching the syslog (journalctl)."""
+
+    def __init__(self, host, extra_args="", encoding="utf-8"):
+        """Watch the syslog (journalctl)."""
+        self.content = ""
+        super().__init__("None", encoding)
+        self.host = host
+        self.p = host.popen(f"journalctl --follow --quiet --since=now {extra_args}")
+        self.snapshot()
+
+    def update_content(self):
+        """Update our content with the output from journalctl."""
+        self.host.cmd_raises("journalctl --sync --flush")
+        newcontent = ""
+        while True:
+            s = readline(self.p.stdout, 1)
+            if s is None:
+                break
+            newcontent += s
+        self.content += newcontent
+        return newcontent
+
+
+def setup_test(munet):
+    """Initialize watchlogs for the test."""
+    r1 = munet.hosts["r1"]
+
+    logging.debug("%s rundir is %s", r1.name, r1.rundir)
+    for daemon in daemons:
+        stdout_logs[daemon] = WatchLog(r1.rundir / f"{daemon}.out")
+        stderr_logs[daemon] = WatchLog(r1.rundir / f"{daemon}.err")
+        daemon_logs[daemon] = WatchLog(r1.rundir / f"{daemon}.log")
+
+
+def _update_content(logs):
+    for daemon in logs:
+        logs[daemon].update_content()
+    return {k: v.from_mark(v.last_snap_mark) for k, v in logs.items()}
+
+
+def _update_snaps(logs):
+    for log in logs.values():
+        log.last_snap_mark = len(log.content)
+
+
+@retry(retry_timeout=8, retry_sleep=0.1)
+def scan_log(logs, regex):
+    """Scan the WatchLog `log` for a regex match."""
+    # Get latest content since last snapshot for all logs
+    contents = _update_content(logs)
+
+    # Check for regex match in each log
+    if hasattr(contents, "items"):
+        for daemon, content in contents.items():
+            if re.search(regex, content):
+                break
+        else:
+            return f"{regex} not found in daemon logs: {contents}"
+    else:
+        if not re.search(regex, contents):
+            return f"{regex} not found in '{contents}'"
+
+
+def scan_log_notfound(logs, regex):
+    """Scan the WatchLogs `logs` for no regex match."""
+    # Get latest content since last snapshot for all logs
+    contents = _update_content(logs)
+
+    # Check for regex match in each log
+    for daemon in contents:
+        if re.search(regex, contents[daemon]):
+            logging.debug(
+                "%s found in %s log content: '%s'", regex, daemon, contents[daemon]
+            )
+            return f"{regex} found in {daemon} log '{contents[daemon]}'"
+
+
+def _do_test_log_notfound(r1, s, logs, level="", delay=2):
+    cmd = f"send log level {level}" if level else "send log"
+    regex = f"(?<!{cmd} )" + re.escape(s)
+
+    # Check log first before sending command
+    error = scan_log_notfound(logs, regex)
+    assert not error
+
+    # Log `s` and verify it still doesn't appear
+    r1.cmd_raises(f"vtysh -c '{cmd} {s}'")
+
+    # Wait delay seconds to give a chance for the looked for item to show up. Normally
+    # non-retry delays are bad, but in the negative check case we need to wait.
+    time.sleep(delay)
+
+    error = scan_log_notfound(logs, regex)
+    if not error:
+        _update_snaps(logs)
+    assert not error, "Found the match"
+
+
+def _do_test_log(r1, s, logs, level=""):
+    cmd = f"send log level {level}" if level else "send log"
+    regex = f"(?<!{cmd} )" + re.escape(s)
+
+    # Verify `s` not in the logs to-date.
+    contents = _update_content(logs)
+    for daemon in contents:
+        assert not re.search(regex, contents[daemon])
+
+    # Log `s` and verify it appears in each of the logs
+    # Log `s` and verify it still doesn't appear
+    r1.cmd_raises(f"vtysh -c '{cmd} {s}'")
+
+    error = scan_log(logs, regex)
+    if not error:
+        _update_snaps(logs)
+    assert not error, f"Error: {error}"
+
+
+def do_test_log(unet, topotest_started=False):
+    """Test logging functionality."""
+    r1 = unet.hosts["r1"]
+
+    if topotest_started:
+        # Need this until topotest stops clearing cmdline targets and resetting per
+        # daemon logfiles
+        r1.cmd_raises('vtysh -c "conf\nlog file frr.log"')
+
+    r1.cmd_raises('vtysh -c "conf\nno log stdout\nno log commands"')
+
+    # Test logfiles
+    step("Testing logging", reset=True)
+
+    step("Testing common frr.log from startup config")
+    common_log = {"common": WatchLog(r1.rundir / "frr.log")}
+    s = f"LOGFILE-0-{our_pid}-MARK"
+    _do_test_log(r1, s, common_log)
+
+    if not topotest_started:
+        # topotest launch will clear the log files, until fixed only munet launch works
+        step("Testing daemon logfiles from cmdline")
+        s = f"LOGFILE-1-{our_pid}-MARK"
+        _do_test_log(r1, s, daemon_logs)
+
+    # Clear cmdline targets which will have the --log=file:daemon.log setup
+    # which we just tested
+    step("Clearing cmdline log targets")
+    r1.cmd_raises('vtysh -c "clear log cmdline-targets"')
+
+    step("Testing daemon logfiles from cmdline no longer used")
+    s = f"LOGFILE-2-{our_pid}-MARK"
+    _do_test_log_notfound(r1, s, daemon_logs)
+
+    # Test stdout
+    step("Testing stdout")
+    r1.cmd_raises('vtysh -c "conf" -c "log stdout"')
+
+    s = f"STDOUT-0-{our_pid}-MARK"
+    _do_test_log(r1, s, stdout_logs)
+
+    # Test disable stdout
+    step("Testing NO stdout")
+    r1.cmd_raises('vtysh -c "conf" -c "no log stdout"')
+
+    s = f"STDOUT-1-{our_pid}-MARK"
+    _do_test_log_notfound(r1, s, stdout_logs)
+
+    # Test new common logfile
+    step("Testing new common logfile frr2.log")
+
+    r1.cmd_raises('vtysh -c "conf\nlog file frr2.log"')
+    common_log = {"common": WatchLog(r1.rundir / "frr2.log")}
+
+    s = f"LOGFILE-4-{our_pid}-MARK"
+    _do_test_log(r1, s, common_log)
+
+    step("Testing new daemon logfile staticd2.log")
+
+    r1.cmd_raises('vtysh -c "conf\nlog daemon staticd file staticd2.log"')
+    staticd_log = {"staticd": WatchLog(r1.rundir / "staticd2.log")}
+    s = f"LOGFILE-5-{our_pid}-MARK"
+    _do_test_log(r1, s, staticd_log)
+
+
+def do_test_filter_file(unet):
+    """Test filtered logging functionality."""
+    r1 = unet.hosts["r1"]
+
+    # Test new filtered logfile
+    step("Testing filtered logfile frr-filtered.log")
+    r1.cmd_raises('vtysh -c "conf\nlog filtered-file frr-filtered.log"')
+    r1.cmd_raises('vtysh -c "conf\nlog filter-text MARK-FOO"')
+    filtered_log = {"filtered": WatchLog(r1.rundir / "frr-filtered.log")}
+
+    s = f"LOGFILTER-0-{our_pid}-MARK-FOO"
+    _do_test_log(r1, s, filtered_log)
+    s = f"LOGFILTER-1-{our_pid}-MARK-BAR"
+    _do_test_log_notfound(r1, s, filtered_log)
+
+
+def do_test_syslog(unet):
+    """Test syslo functionality."""
+    r1 = unet.hosts["r1"]
+
+    if not r1.get_exec_path_host("journalctl"):
+        pytest.skip("Skipping syslog test as journalctl not found")
+        return
+
+    step("Testing logging with syslog", reset=True)
+
+    #
+    # Watch all sys
+    #
+    logs = {"syslog": WatchSyslog(r1)}
+
+    # Test syslog
+    step("Testing syslog")
+    r1.cmd_raises('vtysh -c "conf" -c "log syslog"')
+
+    s = f"SYSLOG-0-{our_pid}-MARK"
+    _do_test_log(r1, s, logs)
+
+    # Test disable syslog
+    step("Testing NO syslog")
+    r1.cmd_raises('vtysh -c "conf" -c "no log syslog"')
+
+    s = f"SYSLOG-1-{our_pid}-MARK"
+    _do_test_log_notfound(r1, s, logs)
+
+    #
+    # switch to watching only severity >= info
+    #
+
+    step("Testing syslog send and filter to 'info'")
+    s = f"SYSLOG-2-{our_pid}-MARK"
+    r1.cmd_raises('vtysh -c "conf" -c "log syslog info"')
+    _do_test_log(r1, s, logs, "info")
+
+    step("Testing syslog send 'debug' and filter to 'info'")
+    s = f"SYSLOG-3-{our_pid}-MARK"
+    _do_test_log_notfound(r1, s, logs, "debug")
+
+    step("Testing set syslog filter level to 'debug'")
+    s = f"SYSLOG-4-{our_pid}-MARK"
+    r1.cmd_raises('vtysh -c "conf" -c "log syslog debug"')
+    _do_test_log(r1, s, logs, "debug")
+
+    step("Testing set syslog to default filter level")
+    s = f"SYSLOG-5-{our_pid}-MARK"
+    r1.cmd_raises('vtysh -c "conf" -c "log syslog"')
+    _do_test_log(r1, s, logs)
+
+    #
+    # switch to watching only syslog facility user
+    #
+    logs = {"syslog": WatchSyslog(r1, extra_args="--facility=user")}
+
+    step("Testing syslog facility 'user' (capturing facility 'user')")
+    s = f"SYSLOG-6-{our_pid}-MARK"
+    # r1.cmd_raises('vtysh -c "conf" -c "log facility user" -c "log syslog"')
+    r1.cmd_raises('vtysh -c "conf" -c "log syslog"  -c "log facility user"')
+    _do_test_log(r1, s, logs)
+
+    step("Testing syslog facility 'daemon'")
+    s = f"SYSLOG-7-{our_pid}-MARK"
+    r1.cmd_raises('vtysh -c "conf" -c "no log facility"')
+    _do_test_log_notfound(r1, s, logs)

--- a/tests/topotests/log_config/munet.yaml
+++ b/tests/topotests/log_config/munet.yaml
@@ -1,0 +1,26 @@
+version: 1
+topology:
+  ipv6-enable: false
+  networks-autonumber: true
+  networks:
+    - name: net1
+  nodes:
+    - name: r1
+      connections: ["net1"]
+      ready-cmd: |
+        # Wait for log files to show up
+        test -e %RUNDIR%/mgmtd.log
+        test -e %RUNDIR%/ospfd.log
+        test -e %RUNDIR%/staticd.log
+        test -e %RUNDIR%/zebra.log
+      cmd: |
+        chown frr:frr -R %RUNDIR%
+        chown frr:frr -R /var/run/frr
+        chown frr:frr -R /var/log/frr
+        /usr/lib/frr/frrinit.sh start
+      cleanup-cmd: |
+        /usr/lib/frr/frrinit.sh stop
+      volumes:
+        - "./%NAME%:/etc/frr"
+        - "%RUNDIR%/test-mount:/var/tmp/frr"
+        - "%RUNDIR%/var.log.frr:/var/log/frr"

--- a/tests/topotests/log_config/r1/daemons
+++ b/tests/topotests/log_config/r1/daemons
@@ -1,0 +1,10 @@
+ospfd=1
+staticd=1
+vtysh_enable=1
+watchfrr_enable=1
+zebra=1
+
+mgmtd_options="--log=file:mgmtd.log     > mgmtd.out   2> mgmtd.err"
+ospfd_options="--log=file:ospfd.log     > ospfd.out   2> ospfd.err"
+staticd_options="--log=file:staticd.log > staticd.out 2> staticd.err"
+zebra_options="--log=file:zebra.log     > zebra.out   2> zebra.err"

--- a/tests/topotests/log_config/r1/frr.conf
+++ b/tests/topotests/log_config/r1/frr.conf
@@ -1,0 +1,26 @@
+log timestamp precision 6
+log file frr.log
+
+
+debug northbound notifications
+!! debug northbound libyang
+debug northbound events
+debug northbound callbacks
+
+debug mgmt backend datastore frontend transaction
+debug mgmt client frontend
+debug mgmt client backend
+
+no debug memstats-at-exit
+
+interface eth0
+  ip ospf hello-interval 2
+  ip ospf dead-interval 7
+  ip ospf area 0.0.0.0
+exit
+
+ip route 11.11.11.11/32 lo
+
+router ospf
+  ospf router-id 1.1.1.1
+!

--- a/tests/topotests/log_config/r1/vtysh.conf
+++ b/tests/topotests/log_config/r1/vtysh.conf
@@ -1,0 +1,1 @@
+service integrated-vtysh-config

--- a/tests/topotests/log_config/test_log_config.py
+++ b/tests/topotests/log_config/test_log_config.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: ISC
+#
+# June 13 2025, Christian Hopps <chopps@labn.net>
+#
+# Copyright (c) 2025, LabN Consulting, L.L.C.
+#
+"""
+Test Logging Config
+"""
+import logging
+import re
+
+import pytest
+from basic import do_test_filter_file, do_test_log, do_test_syslog, setup_test
+from lib.topogen import Topogen
+
+pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+
+#
+# OSPFd is unconverted daemon
+# MGMTd is special daemon that is modern but not a mgmtd backend
+# StaticD is a modern converted-to mgmtd backend
+#
+# Test all three
+#
+
+
+@pytest.fixture(scope="module")
+def tgen(request):
+    "Setup/Teardown the environment and provide tgen argument to tests"
+
+    topodef = {
+        "s1": ("r1",),
+    }
+
+    tgen = Topogen(topodef, request.module.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for _, router in router_list.items():
+        router.load_frr_config("frr.conf")
+
+    tgen.start_router()
+    yield tgen
+    tgen.stop_topology()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_watchlogs(tgen):
+    setup_test(tgen.net)
+
+
+def test_log(tgen):
+    do_test_log(tgen.net, topotest_started=True)
+
+
+def test_filter_file(tgen):
+    do_test_filter_file(tgen.net)

--- a/tests/topotests/log_config/test_munet.py
+++ b/tests/topotests/log_config/test_munet.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: ISC
+#
+# June 13 2025, Christian Hopps <chopps@labn.net>
+#
+# Copyright (c) 2025, LabN Consulting, L.L.C.
+#
+"""
+Test Logging Config
+"""
+import pytest
+from basic import do_test_filter_file, do_test_log, do_test_syslog, setup_test
+
+pytestmark = [pytest.mark.staticd, pytest.mark.mgmtd]
+
+try:
+    from munet.testing.fixtures import rundir_module
+except ImportError:
+    pytest.skip("munet.testing.fixtures not available", allow_module_level=True)
+
+#
+# OSPFd is unconverted daemon
+# MGMTd is special daemon that is modern but not a mgmtd backend
+# StaticD is a modern converted-to mgmtd backend
+#
+# Test all three
+#
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_watchlogs(unet):
+    setup_test(unet)
+
+
+# Running with munet currently is not placing support files under /tmp/topotest so it
+# makes debugging remote results impossible. Need to fix this before re-enabling these
+# tests.
+
+
+def _test_log(unet):
+    do_test_log(unet)
+
+
+def _test_filter_file(unet):
+    do_test_filter_file(unet)
+
+
+def _test_syslog(unet):
+    do_test_syslog(unet)

--- a/tests/topotests/mgmt_oper/root-results/result-candidate-only-config.json
+++ b/tests/topotests/mgmt_oper/root-results/result-candidate-only-config.json
@@ -39,6 +39,12 @@
       }
     ]
   },
+  "frr-logging:logging": {
+    "file": {
+      "filename": "frr.log"
+    },
+    "timestamp-precision": 6
+  },
   "frr-routing:routing": {
     "control-plane-protocols": {
       "control-plane-protocol": [

--- a/tests/topotests/mgmt_oper/root-results/result-candidate-with-config.json
+++ b/tests/topotests/mgmt_oper/root-results/result-candidate-with-config.json
@@ -39,6 +39,12 @@
       }
     ]
   },
+  "frr-logging:logging": {
+    "file": {
+      "filename": "frr.log"
+    },
+    "timestamp-precision": 6
+  },
   "frr-routing:routing": {
     "control-plane-protocols": {
       "control-plane-protocol": [

--- a/tests/topotests/mgmt_oper/root-results/result-only-config.json
+++ b/tests/topotests/mgmt_oper/root-results/result-only-config.json
@@ -39,6 +39,12 @@
       }
     ]
   },
+  "frr-logging:logging": {
+    "file": {
+      "filename": "frr.log"
+    },
+    "timestamp-precision": 6
+  },
   "frr-routing:routing": {
     "control-plane-protocols": {
       "control-plane-protocol": [

--- a/tests/topotests/mgmt_oper/root-results/result-operational-only-config.json
+++ b/tests/topotests/mgmt_oper/root-results/result-operational-only-config.json
@@ -39,6 +39,12 @@
       }
     ]
   },
+  "frr-logging:logging": {
+    "file": {
+      "filename": "frr.log"
+    },
+    "timestamp-precision": 6
+  },
   "frr-routing:routing": {
     "control-plane-protocols": {
       "control-plane-protocol": [

--- a/tests/topotests/mgmt_oper/root-results/result-operational-with-config.json
+++ b/tests/topotests/mgmt_oper/root-results/result-operational-with-config.json
@@ -110,6 +110,12 @@
       }
     ]
   },
+  "frr-logging:logging": {
+    "file": {
+      "filename": "frr.log"
+    },
+    "timestamp-precision": 6
+  },
   "frr-routing:routing": {
     "control-plane-protocols": {
       "control-plane-protocol": [
@@ -213,6 +219,11 @@
             "namespace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"
           },
           {
+            "name": "ietf-syslog-types",
+            "revision": "rubout",
+            "namespace": "urn:ietf:params:xml:ns:yang:ietf-syslog-types"
+          },
+          {
             "name": "frr-filter",
             "revision": "rubout",
             "namespace": "http://frrouting.org/yang/filter"
@@ -231,6 +242,11 @@
             "name": "frr-host",
             "revision": "rubout",
             "namespace": "http://frrouting.org/yang/host"
+          },
+          {
+            "name": "frr-logging",
+            "revision": "rubout",
+            "namespace": "http://frrouting.org/yang/frr-logging"
           },
           {
             "name": "frr-route-map",
@@ -379,7 +395,7 @@
         ]
       }
     ],
-    "content-id": "109"
+    "content-id": "114"
   },
   "ietf-yang-library:modules-state": {
     "module-set-id": "rubout",
@@ -433,6 +449,12 @@
         "conformance-type": "implement"
       },
       {
+        "name": "ietf-syslog-types",
+        "revision": "rubout",
+        "namespace": "urn:ietf:params:xml:ns:yang:ietf-syslog-types",
+        "conformance-type": "implement"
+      },
+      {
         "name": "frr-filter",
         "revision": "rubout",
         "namespace": "http://frrouting.org/yang/filter",
@@ -460,6 +482,12 @@
         "name": "frr-host",
         "revision": "rubout",
         "namespace": "http://frrouting.org/yang/host",
+        "conformance-type": "implement"
+      },
+      {
+        "name": "frr-logging",
+        "revision": "rubout",
+        "namespace": "http://frrouting.org/yang/frr-logging",
         "conformance-type": "implement"
       },
       {

--- a/tests/topotests/mgmt_oper/root-results/result-operational.json
+++ b/tests/topotests/mgmt_oper/root-results/result-operational.json
@@ -124,6 +124,11 @@
             "namespace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"
           },
           {
+            "name": "ietf-syslog-types",
+            "revision": "rubout",
+            "namespace": "urn:ietf:params:xml:ns:yang:ietf-syslog-types"
+          },
+          {
             "name": "frr-filter",
             "revision": "rubout",
             "namespace": "http://frrouting.org/yang/filter"
@@ -142,6 +147,11 @@
             "name": "frr-host",
             "revision": "rubout",
             "namespace": "http://frrouting.org/yang/host"
+          },
+          {
+            "name": "frr-logging",
+            "revision": "rubout",
+            "namespace": "http://frrouting.org/yang/frr-logging"
           },
           {
             "name": "frr-route-map",
@@ -290,7 +300,7 @@
         ]
       }
     ],
-    "content-id": "109"
+    "content-id": "114"
   },
   "ietf-yang-library:modules-state": {
     "module-set-id": "rubout",
@@ -344,6 +354,12 @@
         "conformance-type": "implement"
       },
       {
+        "name": "ietf-syslog-types",
+        "revision": "rubout",
+        "namespace": "urn:ietf:params:xml:ns:yang:ietf-syslog-types",
+        "conformance-type": "implement"
+      },
+      {
         "name": "frr-filter",
         "revision": "rubout",
         "namespace": "http://frrouting.org/yang/filter",
@@ -371,6 +387,12 @@
         "name": "frr-host",
         "revision": "rubout",
         "namespace": "http://frrouting.org/yang/host",
+        "conformance-type": "implement"
+      },
+      {
+        "name": "frr-logging",
+        "revision": "rubout",
+        "namespace": "http://frrouting.org/yang/frr-logging",
         "conformance-type": "implement"
       },
       {

--- a/tests/topotests/mgmt_oper/root-results/result-running-only-config.json
+++ b/tests/topotests/mgmt_oper/root-results/result-running-only-config.json
@@ -39,6 +39,12 @@
       }
     ]
   },
+  "frr-logging:logging": {
+    "file": {
+      "filename": "frr.log"
+    },
+    "timestamp-precision": 6
+  },
   "frr-routing:routing": {
     "control-plane-protocols": {
       "control-plane-protocol": [

--- a/tests/topotests/mgmt_oper/root-results/result-running-with-config.json
+++ b/tests/topotests/mgmt_oper/root-results/result-running-with-config.json
@@ -39,6 +39,12 @@
       }
     ]
   },
+  "frr-logging:logging": {
+    "file": {
+      "filename": "frr.log"
+    },
+    "timestamp-precision": 6
+  },
   "frr-routing:routing": {
     "control-plane-protocols": {
       "control-plane-protocol": [

--- a/tests/topotests/mgmt_oper/root-results/result-with-config.json
+++ b/tests/topotests/mgmt_oper/root-results/result-with-config.json
@@ -110,6 +110,12 @@
       }
     ]
   },
+  "frr-logging:logging": {
+    "file": {
+      "filename": "frr.log"
+    },
+    "timestamp-precision": 6
+  },
   "frr-routing:routing": {
     "control-plane-protocols": {
       "control-plane-protocol": [
@@ -213,6 +219,11 @@
             "namespace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"
           },
           {
+            "name": "ietf-syslog-types",
+            "revision": "rubout",
+            "namespace": "urn:ietf:params:xml:ns:yang:ietf-syslog-types"
+          },
+          {
             "name": "frr-filter",
             "revision": "rubout",
             "namespace": "http://frrouting.org/yang/filter"
@@ -231,6 +242,11 @@
             "name": "frr-host",
             "revision": "rubout",
             "namespace": "http://frrouting.org/yang/host"
+          },
+          {
+            "name": "frr-logging",
+            "revision": "rubout",
+            "namespace": "http://frrouting.org/yang/frr-logging"
           },
           {
             "name": "frr-route-map",
@@ -379,7 +395,7 @@
         ]
       }
     ],
-    "content-id": "109"
+    "content-id": "114"
   },
   "ietf-yang-library:modules-state": {
     "module-set-id": "rubout",
@@ -433,6 +449,12 @@
         "conformance-type": "implement"
       },
       {
+        "name": "ietf-syslog-types",
+        "revision": "rubout",
+        "namespace": "urn:ietf:params:xml:ns:yang:ietf-syslog-types",
+        "conformance-type": "implement"
+      },
+      {
         "name": "frr-filter",
         "revision": "rubout",
         "namespace": "http://frrouting.org/yang/filter",
@@ -460,6 +482,12 @@
         "name": "frr-host",
         "revision": "rubout",
         "namespace": "http://frrouting.org/yang/host",
+        "conformance-type": "implement"
+      },
+      {
+        "name": "frr-logging",
+        "revision": "rubout",
+        "namespace": "http://frrouting.org/yang/frr-logging",
         "conformance-type": "implement"
       },
       {

--- a/tests/topotests/mgmt_oper/root-results/result.json
+++ b/tests/topotests/mgmt_oper/root-results/result.json
@@ -124,6 +124,11 @@
             "namespace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"
           },
           {
+            "name": "ietf-syslog-types",
+            "revision": "rubout",
+            "namespace": "urn:ietf:params:xml:ns:yang:ietf-syslog-types"
+          },
+          {
             "name": "frr-filter",
             "revision": "rubout",
             "namespace": "http://frrouting.org/yang/filter"
@@ -142,6 +147,11 @@
             "name": "frr-host",
             "revision": "rubout",
             "namespace": "http://frrouting.org/yang/host"
+          },
+          {
+            "name": "frr-logging",
+            "revision": "rubout",
+            "namespace": "http://frrouting.org/yang/frr-logging"
           },
           {
             "name": "frr-route-map",
@@ -290,7 +300,7 @@
         ]
       }
     ],
-    "content-id": "109"
+    "content-id": "114"
   },
   "ietf-yang-library:modules-state": {
     "module-set-id": "rubout",
@@ -344,6 +354,12 @@
         "conformance-type": "implement"
       },
       {
+        "name": "ietf-syslog-types",
+        "revision": "rubout",
+        "namespace": "urn:ietf:params:xml:ns:yang:ietf-syslog-types",
+        "conformance-type": "implement"
+      },
+      {
         "name": "frr-filter",
         "revision": "rubout",
         "namespace": "http://frrouting.org/yang/filter",
@@ -371,6 +387,12 @@
         "name": "frr-host",
         "revision": "rubout",
         "namespace": "http://frrouting.org/yang/host",
+        "conformance-type": "implement"
+      },
+      {
+        "name": "frr-logging",
+        "revision": "rubout",
+        "namespace": "http://frrouting.org/yang/frr-logging",
         "conformance-type": "implement"
       },
       {

--- a/tests/topotests/send_log/test_send_log.py
+++ b/tests/topotests/send_log/test_send_log.py
@@ -36,7 +36,8 @@ def tgen(request):
 @retry(retry_timeout=10)
 def scan_log(log, regex):
     log.update_content()
-    assert re.search(regex, log.from_mark(log.last_snap_mark))
+    new_content = log.from_mark(log.last_snap_mark)
+    assert re.search(regex, new_content)
 
 
 def test_log(tgen):

--- a/yang/frr-logging.yang
+++ b/yang/frr-logging.yang
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: BSD-2-Clause
+module frr-logging {
+  yang-version 1.1;
+  namespace "http://frrouting.org/yang/frr-logging";
+  prefix frr-logging;
+
+  import ietf-syslog-types {
+    prefix syslogtypes;
+  }
+
+  organization
+    "FRRouting";
+  contact
+    "FRR Users List:       <mailto:frog@lists.frrouting.org>
+     FRR Development List: <mailto:dev@lists.frrouting.org>";
+  description
+    "This module defines logging configuration for FRR.
+
+     Copyright 2025 LabN Consulting L.L.C
+
+     Redistribution and use in source and binary forms, with or without
+     modification, are permitted provided that the following conditions
+     are met:
+
+     1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+     \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+     LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+     A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+     HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+     SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+     LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+     DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.";
+
+  revision 2025-06-07 {
+    description "Initial revision.";
+    reference "FRRouting";
+  }
+
+  typedef syslog-format {
+    type enumeration {
+      enum rfc5424 {
+        description "RFC5424 syslog format.";
+      }
+      enum rfc3164 {
+        description "RFC3164 syslog format.";
+      }
+      enum local-syslogd {
+        description "Local syslogd format without hostname.";
+      }
+      enum journald {
+        description "systemd journald native format.";
+      }
+    }
+    description "Log message formatting.";
+  }
+
+  container logging {
+    description "Logging configuration.";
+
+    container stdout {
+      presence "Enable stdout logging";
+      description "Logging to stdout.";
+      leaf level {
+        type syslogtypes:severity;
+        default debug;
+        description "Lowest level for which to log to stdout.";
+      }
+    }
+
+    container syslog {
+      presence "Enable syslog logging";
+      description "Logging to syslog.";
+      leaf level {
+        type syslogtypes:severity;
+        default debug;
+        description "Lowest level for which to log to syslog.";
+      }
+    }
+
+    container file {
+      description "Logging to a file.";
+      leaf filename {
+        type string;
+        description "Log filename.";
+      }
+      leaf level {
+        type syslogtypes:severity;
+        default debug;
+        description "Lowest level for which to log to the file.";
+      }
+    }
+
+    container filtered-file {
+      description
+        "Log messages to a file, filtering out messages that match any of the
+         filter-text entries.";
+      leaf filename {
+        type string;
+        description "Log filename.";
+      }
+      leaf level {
+        type syslogtypes:severity;
+        default debug;
+        description "Lowest level for which to log to the filtered file.";
+      }
+    }
+
+    leaf-list filter-text {
+      type string;
+      description "Log message filters.";
+    }
+
+    list daemon-file {
+      key daemon;
+      description "Per-daemon log files.";
+      leaf daemon {
+        type string;
+        description "Name of the daemon.";
+      }
+      leaf filename {
+        type string;
+        mandatory true;
+        description "Log filename.";
+      }
+      leaf level {
+        type syslogtypes:severity;
+        default debug;
+        description "Lowest level for which to log to the daemon log file.";
+      }
+    }
+
+    leaf facility {
+      type identityref {
+        base syslogtypes:syslog-facility;
+      }
+      default syslogtypes:daemon;
+      description "Syslog facility.";
+    }
+
+    leaf record-priority {
+      type boolean;
+      default false;
+      description "Include priority tag in non-syslog messages.";
+    }
+
+    leaf record-severity {
+      type boolean;
+      default false;
+      description "Include severity tag in non-syslog messages.";
+    }
+
+    leaf timestamp-precision {
+      type uint8 {
+        range 0..6;
+      }
+      default 0;
+      description "Timestamp precision for log messages.";
+    }
+
+    leaf error-category {
+      type boolean;
+      default true;
+      description "Prefix log messages with error category.";
+    }
+
+    leaf unique-id {
+      type boolean;
+      default true;
+      description "Prefix log messages with unique identifier.";
+    }
+
+    leaf immediate-mode {
+      type boolean;
+      default false;
+      description "Use unbuffered log output.";
+    }
+
+    list uid-backtrace {
+      key uid;
+      description "Log message IDs with backtraces enabled.";
+      leaf uid {
+        type string;
+        description "Unique log message identifier.";
+      }
+    }
+  }
+}

--- a/yang/ietf/ietf-syslog-types.yang
+++ b/yang/ietf/ietf-syslog-types.yang
@@ -1,0 +1,240 @@
+module ietf-syslog-types {
+  namespace "urn:ietf:params:xml:ns:yang:ietf-syslog-types";
+  prefix syslogtypes;
+
+  organization "IETF NETMOD (NETCONF Data Modeling Language) Working
+                Group";
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     WG Chair: Tom Nadeau
+               <mailto:tnadeau@lucidvision.com>
+
+     WG Chair: Kent Watson
+               <mailto:kwatsen@juniper.net>
+
+     Editor:   Ladislav Lhotka
+               <mailto:lhotka@nic.cz>";
+  description
+    "This module contains a collection of YANG type definitions for
+     SYSLOG.";
+
+  revision 2015-10-14 {
+    description
+      "Initial Revision";
+    reference
+      "This model references RFC 5424 - The Syslog Protocol,
+       and RFC 5848 - Signed Syslog Messages.";
+  }
+
+  typedef severity {
+    type enumeration {
+      enum "emergency" {
+        value 0;
+        description
+          "Emergency Level Msg";
+      }
+      enum "alert" {
+        value 1;
+        description
+          "Alert Level Msg";
+      }
+      enum "critical" {
+        value 2;
+        description
+          "Critical Level Msg";
+      }
+      enum "error" {
+        value 3;
+        description
+          "Error Level Msg";
+      }
+      enum "warning" {
+        value 4;
+        description
+          "Warning Level Msg";
+      }
+      enum "notice" {
+        value 5;
+        description
+          "Notification Level Msg";
+      }
+      enum "info" {
+        value 6;
+        description
+          "Informational Level Msg";
+      }
+      enum "debug" {
+        value 7;
+        description
+          "Debugging Level Msg";
+      }
+    }
+    description
+      "The definitions for Syslog message severity as per RFC 5424.";
+  }
+
+  identity syslog-facility {
+    description
+      "The base identity to represent syslog facilities";
+  }
+
+  identity kern {
+    base syslog-facility;
+    description
+      "The facility for kernel messages as defined in RFC 5424.";
+  }
+
+  identity user {
+    base syslog-facility;
+    description
+      "The facility for user-level messages as defined in RFC 5424.";
+  }
+
+  identity mail {
+    base syslog-facility;
+    description
+      "The facility for the mail system as defined in RFC 5424.";
+  }
+
+  identity daemon {
+    base syslog-facility;
+    description
+      "The facility for the system daemons as defined in RFC 5424.";
+   }
+
+  identity auth {
+    base syslog-facility;
+    description
+      "The facility for security/authorization messages as defined
+       in RFC 5424.";
+  }
+
+  identity syslog {
+    base syslog-facility;
+    description
+      "The facility for messages generated internally by syslogd
+       facility as defined in RFC 5424.";
+  }
+
+  identity lpr {
+    base syslog-facility;
+    description
+      "The facility for the line printer subsystem as defined in
+       RFC 5424.";
+  }
+
+  identity news {
+    base syslog-facility;
+    description
+      "The facility for the network news subsystem as defined in
+       RFC 5424.";
+  }
+
+  identity uucp {
+    base syslog-facility;
+    description
+      "The facility for the UUCP subsystem as defined in RFC 5424.";
+  }
+
+  identity cron {
+    base syslog-facility;
+    description
+      "The facility for the clock daemon as defined in RFC 5424.";
+  }
+
+  identity authpriv {
+    base syslog-facility;
+    description
+      "The facility for privileged security/authorization messages
+       as defined in RFC 5424.";
+  }
+
+  identity ftp {
+    base syslog-facility;
+    description
+      "The facility for the FTP daemon as defined in RFC 5424.";
+  }
+
+  identity ntp {
+    base syslog-facility;
+    description
+      "The facility for the NTP subsystem as defined in RFC 5424.";
+  }
+
+  identity audit {
+    base syslog-facility;
+    description
+      "The facility for log audit messages as defined in RFC 5424.";
+  }
+
+  identity console {
+    base syslog-facility;
+    description
+      "The facility for log alert messages as defined in RFC 5424.";
+  }
+
+  identity cron2 {
+    base syslog-facility;
+    description
+      "The facility for the second clock daemon as defined in
+       RFC 5424.";
+  }
+
+  identity local0 {
+    base syslog-facility;
+    description
+      "The facility for local use 0 messages as defined in
+       RFC 5424.";
+  }
+
+  identity local1 {
+    base syslog-facility;
+    description
+      "The facility for local use 1 messages as defined in
+       RFC 5424.";
+  }
+
+  identity local2 {
+    base syslog-facility;
+    description
+      "The facility for local use 2 messages as defined in
+       RFC 5424.";
+  }
+
+  identity local3 {
+    base syslog-facility;
+    description
+      "The facility for local use 3 messages as defined in
+       RFC 5424.";
+  }
+
+  identity local4 {
+    base syslog-facility;
+    description
+      "The facility for local use 4 messages as defined in
+       RFC 5424.";
+  }
+
+  identity local5 {
+    base syslog-facility;
+    description
+      "The facility for local use 5 messages as defined in
+       RFC 5424.";
+  }
+
+  identity local6 {
+    base syslog-facility;
+    description
+      "The facility for local use 6 messages as defined in
+       RFC 5424.";
+  }
+
+  identity local7 {
+    base syslog-facility;
+    description
+      "The facility for local use 7 messages as defined in
+       RFC 5424.";
+  }
+}

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -23,6 +23,7 @@ dist_yangmodels_DATA += yang/frr-affinity-map.yang
 dist_yangmodels_DATA += yang/frr-backend.yang
 dist_yangmodels_DATA += yang/frr-filter.yang
 dist_yangmodels_DATA += yang/frr-host.yang
+dist_yangmodels_DATA += yang/frr-logging.yang
 dist_yangmodels_DATA += yang/frr-module-translator.yang
 dist_yangmodels_DATA += yang/frr-nexthop.yang
 dist_yangmodels_DATA += yang/frr-test-module.yang
@@ -46,6 +47,7 @@ dist_yangmodels_DATA += yang/ietf/ietf-netconf-acm.yang
 dist_yangmodels_DATA += yang/ietf/ietf-netconf.yang
 dist_yangmodels_DATA += yang/ietf/ietf-netconf-with-defaults.yang
 dist_yangmodels_DATA += yang/ietf/ietf-srv6-types.yang
+dist_yangmodels_DATA += yang/ietf/ietf-syslog-types.yang
 
 if BFDD
 dist_yangmodels_DATA += yang/frr-bfdd.yang


### PR DESCRIPTION
Add a frr-logging.yang module, and implement it converting to Mgmtd/YANG.

Add a topotest for logging config.

This is the penultimate conversion to be done for lib/*. logging 5424 is the only remaining functionality not converted, and this appears to not actually be used.

Prior to this PR mgmtd was a YANG broker only, it didn't actually process
any YANG configuration for itself. These changes add support for configuring
mgmtd with YANG in addition to the backend cilents.

Finally add a `log record-severity` to add syslog standard tags to file/consol logs (i.e., DEBUG, INFO, ...).