### PR TITLE
Bmp locrib bgp open message

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -3544,11 +3544,16 @@ static int bmp_bgp_attribute_updated(struct bgp *bgp, bool withdraw)
 	struct bmp_targets *bt;
 	struct listnode *node;
 	struct bmp_imported_bgp *bib;
-	struct stream *s = bmp_peerstate(bgp->peer_self, withdraw);
+	struct stream *s;
 	struct bmp *bmp;
 	afi_t afi;
 	safi_t safi;
 
+	/* update peer_self->router_id */
+	if (withdraw == false)
+		bgp->peer_self->local_id = bgp->router_id;
+
+	s = bmp_peerstate(bgp->peer_self, withdraw);
 	if (!s)
 		return 0;
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3536,7 +3536,10 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 	if (cmd_domainname_get())
 		bgp->peer_self->domainname =
 			XSTRDUP(MTYPE_BGP_PEER_HOST, cmd_domainname_get());
-	/* for BMP LOC-RIB, enable AS4B encoding */
+	/* for BMP LOC-RIB */
+	/* copy bgp as to peer as */
+	bgp->peer_self->local_as = bgp->as;
+	/* enable AS4B encoding */
 	SET_FLAG(bgp->peer_self->cap, PEER_CAP_AS4_RCV);
 	SET_FLAG(bgp->peer_self->cap, PEER_CAP_AS4_ADV);
 

--- a/tests/topotests/bgp_bmp/bgpbmp.py
+++ b/tests/topotests/bgp_bmp/bgpbmp.py
@@ -202,6 +202,8 @@ def bmp_check_for_peer_message(
     is_rd_instance=False,
     peer_bgp_id=None,
     peer_distinguisher=None,
+    bgp_open_as=None,
+    bgp_open_bgp_id=None,
 ):
     """
     Check for the presence of a peer up message for the peer
@@ -227,6 +229,25 @@ def bmp_check_for_peer_message(
             continue
         if peer_bgp_id and m["peer_bgp_id"] != peer_bgp_id:
             continue
+        if bgp_open_as:
+            if not m.get("open_tx", {}).get("my_as", None):
+                continue
+            if m["open_tx"]["my_as"] != bgp_open_as:
+                continue
+            if not m.get("open_rx", {}).get("my_as", None):
+                continue
+            if m["open_rx"]["my_as"] != bgp_open_as:
+                continue
+
+        if bgp_open_bgp_id:
+            if not m.get("open_tx", {}).get("bgp_id", None):
+                continue
+            if m["open_tx"]["bgp_id"] != bgp_open_bgp_id:
+                continue
+            if not m.get("open_rx", {}).get("bgp_id", None):
+                continue
+            if m["open_rx"]["bgp_id"] != bgp_open_bgp_id:
+                continue
         if (
             "peer_ip" in m.keys()
             and m["peer_ip"] != "0.0.0.0"

--- a/tests/topotests/bgp_bmp/test_bgp_bmp_3.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_3.py
@@ -563,6 +563,8 @@ def test_bgp_routerid_changed():
         os.path.join(tgen.logdir, "bmp1import", "bmp.log"),
         is_rd_instance=True,
         peer_bgp_id="192.168.1.77",
+        bgp_open_as=65501,
+        bgp_open_bgp_id="192.168.1.77",
     )
     success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
     assert (

--- a/tests/topotests/lib/bmp_collector/bgp/open/__init__.py
+++ b/tests/topotests/lib/bmp_collector/bgp/open/__init__.py
@@ -31,6 +31,6 @@ class BGPOpen:
             "version": version,
             "my_as": my_as,
             "hold_time": hold_time,
-            "bgp_id": ipaddress.ip_address(bgp_id),
+            "bgp_id": str(ipaddress.IPv4Address(bgp_id)),
             "optional_params_len": optional_params_len,
         }

--- a/tests/topotests/lib/bmp_collector/bmp.py
+++ b/tests/topotests/lib/bmp_collector/bmp.py
@@ -18,6 +18,7 @@ import sys
 
 from datetime import datetime
 
+from bgp.open import BGPOpen
 from bgp.update import BGPUpdate
 from bgp.update.rd import RouteDistinguisher
 
@@ -384,6 +385,7 @@ class BMPPeerUpNotification(BMPPerPeerMessage):
 
         (local_addr, local_port, remote_port) = struct.unpack_from(cls.UNPACK_STR, data)
 
+        data = data[struct.calcsize(cls.UNPACK_STR) :]
         msg = {
             **peer_msg,
             **{
@@ -393,8 +395,10 @@ class BMPPeerUpNotification(BMPPerPeerMessage):
                 "remote_port": int(remote_port),
             },
         }
-
-        # XXX: dissect the bgp open message
+        data, msg_open = BGPOpen.dissect(data)
+        msg["open_tx"] = msg_open
+        data, msg_open = BGPOpen.dissect(data)
+        msg["open_rx"] = msg_open
 
         return msg
 


### PR DESCRIPTION
2 Fixes related to how BGP open messages are forged for LOC-RIB notification messages.
Actually all fields are set to 0, but this is not what is usually expected.

Use the settings of the current BGP instance for AS value and router-id.