### PR TITLE
zebra: Fix nh6 used for SRv6 behavior uA installation

### DIFF
--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -1780,19 +1780,30 @@ int get_srv6_sid(struct zebra_srv6_sid **sid, struct srv6_sid_ctx *ctx,
 
 		if (!found) {
 			zebra_if = ifp->info;
-
 			frr_each (nhg_connected_tree, &zebra_if->nhg_dependents, rb_node_dep) {
 				for (ALL_NEXTHOPS(rb_node_dep->nhe->nhg, nexthop)) {
-					/* skip non link-local addresses */
-					if (!IPV6_ADDR_SAME(&nexthop->gate.ipv6, &in6addr_any)) {
+					if ((nexthop->type == NEXTHOP_TYPE_IPV6 ||
+					     nexthop->type == NEXTHOP_TYPE_IPV6_IFINDEX) &&
+					    !IPV6_ADDR_SAME(&nexthop->gate.ipv6, &in6addr_any)) {
+						/* This is an IPv6 nexthop, use gate.ipv6 */
 						ctx->nh6 = nexthop->gate.ipv6;
+						found = true;
+						break;
+					} else if ((nexthop->type == NEXTHOP_TYPE_IPV4 ||
+						    nexthop->type == NEXTHOP_TYPE_IPV4_IFINDEX) &&
+						   nexthop->gate.ipv4.s_addr != INADDR_ANY) {
+						/* This is an IPv4 nexthop, convert to IPv4-mapped IPv6 */
+						ipv4_to_ipv4_mapped_ipv6(&ctx->nh6,
+									 nexthop->gate.ipv4);
 						found = true;
 						break;
 					}
 				}
+
 				if (found)
 					break;
 			}
+
 			if (!found) {
 				zlog_err("%s: cannot get SID, interface (ifindex %u) not found",
 					 __func__, ctx->ifindex);


### PR DESCRIPTION
Currently when we configure a static SRv6 sid with behaviour uA with only interface, the idea is to find LL, if not non LL.

However if we only have a v4 address, we need to have a v4 mapped v6 addr. s a NH6 for uA SRv6 sid installation.

Example config:

```
segment-routing
 srv6
  static-sids
   sid fcbb:bbbb:11::/48 locator raja behavior uA interface r1-eth0
 srv6
  locators
   locator raja
    prefix fcbb:bbbb:11::/48 block-len 32 node-len 16
```

**Without Fix:**
root@r1:/tmp/topotests/bgp_bestpath_reason.test_bgp_bestpath_reason/r1# ip -6 -d route unicast fcbb:bbbb:11::/48 nhid 16  encap seg6local action End.X nh6 c010:202:: dev r1-eth0 proto 196 scope global metric 20 pref medium

**With Fix:**
root@r1:/tmp/topotests/bgp_bestpath_reason.test_bgp_bestpath_reason/r1# ip -6 -d route unicast fcbb:bbbb:11::/48 nhid 16  encap seg6local action End.X nh6 ::ffff:192.16.2.2 dev r1-eth0 proto 196 scope global metric 20 pref medium

Ticket :#4503980