### PR TITLE
bgpd: Fix incorrect stripping of transitive extended communities due …

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -1664,7 +1664,7 @@ bool ecommunity_strip(struct ecommunity *ecom, uint8_t type,
 static bool ecommunity_non_transitive(uint8_t type)
 {
 	return (CHECK_FLAG(type, ECOMMUNITY_FLAG_NON_TRANSITIVE) ||
-		CHECK_FLAG(type, ECOMMUNITY_ENCODE_IP_NON_TRANS) ||
+		type == ECOMMUNITY_ENCODE_IP_NON_TRANS ||
 		type == ECOMMUNITY_ENCODE_OPAQUE_NON_TRANS);
 }
 


### PR DESCRIPTION
…to bad type match

The ecommunity_non_transitive() helper incorrectly used CHECK_FLAG() to test against ECOMMUNITY_ENCODE_IP_NON_TRANS (0x41), which is a full type code, not a bitmask. As a result, type 0x03 (transitive opaque), used for encapsulation (e.g., VXLAN), was mistakenly matched and stripped during re-announcement.

This patch replaces the incorrect CHECK_FLAG() with a direct equality check.

Bug caused stripping of valid VXLAN encapsulation communities (type 0x03) on reflected UPDATEs.