### PR TITLE
bgpd: Soft-reconfig should not completely stall bestpath processing

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4473,14 +4473,6 @@ static void bgp_process_internal(struct bgp *bgp, struct bgp_dest *dest,
 		return;
 	}
 
-	if (CHECK_FLAG(dest->flags, BGP_NODE_SOFT_RECONFIG)) {
-		if (BGP_DEBUG(update, UPDATE_OUT))
-			zlog_debug(
-				"Soft reconfigure table in progress for route %p",
-				dest);
-		return;
-	}
-
 	if (CHECK_FLAG(dest->flags, BGP_NODE_NHT_RESOLVED_NODE)) {
 		if (BGP_DEBUG(update, UPDATE_OUT))
 			zlog_debug("Early route processing triggered by NHT for route %pBD",


### PR DESCRIPTION
Currently there is a dest flag `BGP_NODE_SOFT_RECONFIG` that when set completely stops processing of the path, because it is assumed that when running through all of those adjacency in's that the node will be reprocessed.

Imagine this series of events:

a) route-map change that causes a soft-adjacency run to be triggered for the dest.
b) Schedule all dests associated with the adjacency in's to be processed in the future
c) Some other event that causes a need for processing of that node.  This can be, but is not limited to:
     1) NHT change and we need to reprocess the node
     2) Receive a update for a dest that does not have soft
        adjacency turned on( but some other path_info for the
        node does.
d) Current best path processing sees that the node has a SOFT_RECONFIG flag on it, this stops processing.
e) The SOFT_RECONFIG task wakes up and re runs the filter mechanism and decides that the path is filtered.  BGP then stops processing for that node and does nothing. f) We are left with a situation where the soft-reconfig has caused a update that should be processed from being processed.

Modify the code to not abort the best path run when the flag is set.  Just let it happen.  Yeah we are doing a bit more processing but the end state will be correct.