### PR TITLE
L3VNI should not be attached to Mac only type-2 routes

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2182,17 +2182,15 @@ evpn_cleanup_local_non_best_route(struct bgp *bgp, struct bgpevpn *vpn,
 	return bgp_path_info_reap(dest, local_pi);
 }
 
-static inline bool bgp_evpn_route_add_l3_ecomm_ok(struct bgpevpn *vpn,
-						  const struct prefix_evpn *p,
+static inline bool bgp_evpn_route_add_l3_attrs_ok(struct bgpevpn *vpn, const struct prefix_evpn *p,
 						  esi_t *esi)
 {
-	return p->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE
-	       && (is_evpn_prefix_ipaddr_v4(p)
-		   || (is_evpn_prefix_ipaddr_v6(p)
-		       && !IN6_IS_ADDR_LINKLOCAL(
-			       &p->prefix.macip_addr.ip.ipaddr_v6)))
-	       && CHECK_FLAG(vpn->flags, VNI_FLAG_USE_TWO_LABELS)
-	       && bgpevpn_get_l3vni(vpn) && bgp_evpn_es_add_l3_ecomm_ok(esi);
+	return p->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE &&
+	       (is_evpn_prefix_ipaddr_v4(p) ||
+		(is_evpn_prefix_ipaddr_v6(p) &&
+		 !IN6_IS_ADDR_LINKLOCAL(&p->prefix.macip_addr.ip.ipaddr_v6))) &&
+	       CHECK_FLAG(vpn->flags, VNI_FLAG_USE_TWO_LABELS) && bgpevpn_get_l3vni(vpn) &&
+	       bgp_evpn_es_add_l3_attrs_ok(esi);
 }
 
 /*
@@ -2206,7 +2204,7 @@ static int update_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
 	struct bgp_dest *dest;
 	struct attr attr;
 	struct attr *attr_new;
-	int add_l3_ecomm = 0;
+	bool add_l3_attrs = false;
 	struct bgp_path_info *pi;
 	afi_t afi = AFI_L2VPN;
 	safi_t safi = SAFI_EVPN;
@@ -2266,22 +2264,20 @@ static int update_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
 
 	vni2label(vpn->vni, &(attr.label));
 
-	/* Include L3 VNI related RTs and RMAC for type-2 routes, if they're
-	 * IPv4 or IPv6 global addresses and we're advertising L3VNI with
-	 * these routes.
+	/* Include L3 VNI related attributes (RTs, RMAC and MPLS Label2)
+	 * for type-2 routes, if they're IPv4 or IPv6 global addresses and
+	 * we're advertising L3VNI with these routes.
 	 */
-	add_l3_ecomm =
-		bgp_evpn_route_add_l3_ecomm_ok(vpn, p,
-					       CHECK_FLAG(attr.es_flags,
-							  ATTR_ES_IS_LOCAL)
-						       ? &attr.esi
-						       : NULL);
+	add_l3_attrs = bgp_evpn_route_add_l3_attrs_ok(vpn, p,
+						      CHECK_FLAG(attr.es_flags, ATTR_ES_IS_LOCAL)
+							      ? &attr.esi
+							      : NULL);
 
 	if (bgp->evpn_info)
 		macvrf_soo = bgp->evpn_info->soo;
 
 	/* Set up extended community. */
-	build_evpn_route_extcomm(vpn, &attr, add_l3_ecomm, macvrf_soo);
+	build_evpn_route_extcomm(vpn, &attr, add_l3_attrs, macvrf_soo);
 
 	/* First, create (or fetch) route node within the VNI.
 	 * NOTE: There is no RD here.
@@ -2494,7 +2490,7 @@ void bgp_evpn_update_type2_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 	struct attr attr;
 	struct attr *attr_new;
 	uint32_t seq;
-	int add_l3_ecomm = 0;
+	bool add_l3_attrs = false;
 	struct bgp_dest *global_dest;
 	struct bgp_path_info *global_pi;
 	struct prefix_evpn evp;
@@ -2544,18 +2540,16 @@ void bgp_evpn_update_type2_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 	/* Add L3 VNI RTs and RMAC for non IPv6 link-local if
 	 * using L3 VNI for type-2 routes also.
 	 */
-	add_l3_ecomm =
-		bgp_evpn_route_add_l3_ecomm_ok(vpn, &evp,
-					       CHECK_FLAG(attr.es_flags,
-							  ATTR_ES_IS_LOCAL)
-						       ? &attr.esi
-						       : NULL);
+	add_l3_attrs = bgp_evpn_route_add_l3_attrs_ok(vpn, &evp,
+						      CHECK_FLAG(attr.es_flags, ATTR_ES_IS_LOCAL)
+							      ? &attr.esi
+							      : NULL);
 
 	if (bgp->evpn_info)
 		macvrf_soo = bgp->evpn_info->soo;
 
 	/* Set up extended community. */
-	build_evpn_route_extcomm(vpn, &attr, add_l3_ecomm, macvrf_soo);
+	build_evpn_route_extcomm(vpn, &attr, add_l3_attrs, macvrf_soo);
 	seq = mac_mobility_seqnum(local_pi->attr);
 
 	if (bgp_debug_zebra(NULL)) {

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -2063,7 +2063,7 @@ static void bgp_evpn_es_remote_info_re_eval(struct bgp_evpn_es *es)
 /* If ES is present and local it needs to be active/oper-up for
  * including L3 EC
  */
-bool bgp_evpn_es_add_l3_ecomm_ok(esi_t *esi)
+bool bgp_evpn_es_add_l3_attrs_ok(esi_t *esi)
 {
 	struct bgp_evpn_es *es;
 

--- a/bgpd/bgp_evpn_mh.h
+++ b/bgpd/bgp_evpn_mh.h
@@ -448,7 +448,7 @@ extern void bgp_evpn_es_vrf_show(struct vty *vty, bool uj,
 				 struct bgp_evpn_es *es);
 extern void bgp_evpn_es_vrf_show_esi(struct vty *vty, esi_t *esi, bool uj);
 extern void bgp_evpn_switch_ead_evi_rx(void);
-extern bool bgp_evpn_es_add_l3_ecomm_ok(esi_t *esi);
+extern bool bgp_evpn_es_add_l3_attrs_ok(esi_t *esi);
 extern void bgp_evpn_es_vrf_use_nhg(struct bgp *bgp_vrf, esi_t *esi,
 				    bool *use_l3nhg, bool *is_l3nhg_active,
 				    struct bgp_evpn_es_vrf **es_vrf_p);


### PR DESCRIPTION
Mac only EVPN type-2 routes should not be advertised with the MPLS
Label2 (L3VNI).

Only mac-ipv4 and mac-ipv6-global routes should be advertised with the
second label. This check is already performed for attaching the Extended
community such as RMAC and L3VNI RTs. The same check applies to the
second label as well.
