### PR TITLE
doc: remove dead link to quagga website

### DIFF
--- a/doc/user/index.rst
+++ b/doc/user/index.rst
@@ -15,7 +15,7 @@ FRR is distributed under GPLv2, with development modeled after the Linux
 kernel. Anyone may contribute features, bug fixes, tools, documentation
 updates, or anything else.
 
-FRR is a fork of `Quagga <http://www.quagga.net/>`_.
+FRR is a fork of the Quagga project.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
The quagga site is dead; remove the link from our docs.
Fixes FRRouting/frr-www#83
