### PR TITLE
lib: revert addition of vtysh_flush() call in vty_out()

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -346,17 +346,8 @@ int vty_out(struct vty *vty, const char *format, ...)
 	case VTY_SHELL_SERV:
 	case VTY_FILE:
 	default:
-		vty->vty_buf_size_accumulated += strlen(filtered);
 		/* print without crlf replacement */
 		buffer_put(vty->obuf, (uint8_t *)filtered, strlen(filtered));
-		/* For every chunk of memory, we invoke vtysh_flush where we
-		 * put the data of collective vty->obuf Linked List items on the
-		 * socket and free the vty->obuf data.
-		 */
-		if (vty->vty_buf_size_accumulated >= VTY_MAX_INTERMEDIATE_FLUSH) {
-			vty->vty_buf_size_accumulated = 0;
-			vtysh_flush(vty);
-		}
 		break;
 	}
 
@@ -2253,7 +2244,6 @@ static int vtysh_flush(struct vty *vty)
 		vty_close(vty);
 		return -1;
 	case BUFFER_EMPTY:
-		vty->vty_buf_size_accumulated = 0;
 		break;
 	}
 	return 0;

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -353,7 +353,7 @@ int vty_out(struct vty *vty, const char *format, ...)
 		 * put the data of collective vty->obuf Linked List items on the
 		 * socket and free the vty->obuf data.
 		 */
-		if (vty->vty_buf_size_accumulated >= vty->buf_size_intermediate) {
+		if (vty->vty_buf_size_accumulated >= VTY_MAX_INTERMEDIATE_FLUSH) {
 			vty->vty_buf_size_accumulated = 0;
 			vtysh_flush(vty);
 		}
@@ -2174,13 +2174,6 @@ static void vtysh_accept(struct event *thread)
 #endif /* VTYSH_DEBUG */
 
 	vty = vty_new();
-
-	vty->buf_size_set = ret;
-	if (vty->buf_size_set < VTY_MAX_INTERMEDIATE_FLUSH)
-		vty->buf_size_intermediate = vty->buf_size_set / 2;
-	else
-		vty->buf_size_intermediate = VTY_MAX_INTERMEDIATE_FLUSH;
-
 	vty->fd = sock;
 	vty->wfd = sock;
 	vty->type = VTY_SHELL_SERV;

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -229,9 +229,6 @@ struct vty {
 	bool mgmt_locked_candidate_ds;
 	bool mgmt_locked_running_ds;
 	uint64_t vty_buf_size_accumulated;
-
-	int buf_size_set;
-	uint64_t buf_size_intermediate;
 };
 
 static inline void vty_push_context(struct vty *vty, int node, uint64_t id)

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -228,7 +228,6 @@ struct vty {
 	uintptr_t mgmt_req_pending_data;
 	bool mgmt_locked_candidate_ds;
 	bool mgmt_locked_running_ds;
-	uint64_t vty_buf_size_accumulated;
 };
 
 static inline void vty_push_context(struct vty *vty, int node, uint64_t id)
@@ -333,9 +332,6 @@ struct vty_arg {
 
 /* Vty max send buffer size */
 #define VTY_SEND_BUF_MAX 16777216
-
-/* Vty flush intermediate size */
-#define VTY_MAX_INTERMEDIATE_FLUSH 131072
 
 /* Directory separator. */
 #ifndef DIRECTORY_SEP


### PR DESCRIPTION
This reverts the `vtysh_flush()` part of #16672 since it is just plain not permissible to do that. There's a cascaded partial revert of #17571, but that was only a minor adjustment and it remains intact in the general sense.

A better/correct fix would be to do something like engineering a `vtysh_try_flush()` function; but I'd prefer to not do that on stable versions, so here's a revert to get back to functionally correct before we take another go at the memory spike problem.

cf.  #19040 for related discussion (this revert should make that PR unnecessary)