### PR TITLE
zebra: Fix coverity issues

### DIFF
--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -1847,25 +1847,23 @@ static int get_srv6_sid_explicit(struct zebra_srv6_sid **sid, struct srv6_sid_ct
 		 * If we already have a SID associated with this context, we need to
 		 * deallocate the current SID function before allocating the new one
 		 */
-		if (zctx->sid) {
-			if (IS_ZEBRA_DEBUG_SRV6)
-				zlog_debug("%s: ctx %s already associated with SID %u, releasing SID",
-					   __func__, srv6_sid_ctx2str(buf, sizeof(buf), ctx),
-					   zctx->sid->func);
+		if (IS_ZEBRA_DEBUG_SRV6)
+			zlog_debug("%s: ctx %s already associated with SID %u, releasing SID",
+				   __func__, srv6_sid_ctx2str(buf, sizeof(buf), ctx),
+				   zctx->sid->func);
 
-			release_srv6_sid_func(zctx);
+		release_srv6_sid_func(zctx);
 
-			zebra_srv6_sid_clients_release_notify_all(zctx->sid);
-			zebra_srv6_sid_entry_delete_all(zctx->sid);
+		zebra_srv6_sid_clients_release_notify_all(zctx->sid);
+		zebra_srv6_sid_entry_delete_all(zctx->sid);
 
-			zctx->sid->block = block;
-			zctx->sid->func = sid_func;
-			zctx->sid->wide_func = sid_func_wide;
-			zctx->sid->alloc_mode = SRV6_SID_ALLOC_MODE_EXPLICIT;
+		zctx->sid->block = block;
+		zctx->sid->func = sid_func;
+		zctx->sid->wide_func = sid_func_wide;
+		zctx->sid->alloc_mode = SRV6_SID_ALLOC_MODE_EXPLICIT;
 
-			*sid = zctx->sid;
-			(*sid)->ctx = zctx;
-		}
+		*sid = zctx->sid;
+		(*sid)->ctx = zctx;
 	} else {
 		/* Allocate an explicit SID function for the SID */
 		if (ctx->behavior != ZEBRA_SEG6_LOCAL_ACTION_END)

--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -2747,6 +2747,9 @@ static int srv6_manager_release_sid_internal(struct zserv *client, struct srv6_s
 			if (zctx->sid) {
 				entry = zebra_srv6_sid_entry_lookup(zctx->sid, locator->name,
 								    is_localonly);
+				if (!entry)
+					break;
+
 				sid_value = entry->sid_value;
 			}
 

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -700,7 +700,7 @@ DEFPY (show_srv6_sid,
 				break;
 			}
 		}
-		if (!sid_ctx->sid || !found) {
+		if (!found) {
 			if (uj)
 				vty_json(vty, json); /* Return empty json */
 			else


### PR DESCRIPTION
Fix three coverity issues.

```
** CID 1644860:       Null pointer dereferences  (NULL_RETURNS)
/zebra/zebra_srv6.c: 2750           in srv6_manager_release_sid_internal()


_____________________________________________________________________________________________
*** CID 1644860:         Null pointer dereferences  (NULL_RETURNS)
/zebra/zebra_srv6.c: 2750             in srv6_manager_release_sid_internal()
2744     	/* Lookup Zebra SID context and release it */
2745     	frr_each_safe (zebra_srv6_sid_ctx_list, &block->sids, zctx)
2746     		if (memcmp(&zctx->ctx, ctx, sizeof(struct srv6_sid_ctx)) == 0) {
2747     			if (zctx->sid) {
2748     				entry = zebra_srv6_sid_entry_lookup(zctx->sid, locator->name,
2749     								    is_localonly);
>>>     CID 1644860:         Null pointer dereferences  (NULL_RETURNS)
>>>     Dereferencing "entry", which is known to be "NULL".
2750     				sid_value = entry->sid_value;
2751     			}
2752     
2753     			ret = release_srv6_sid(client, zctx, locator, is_localonly);
2754     			break;
2755     		}

** CID 1644859:       Null pointer dereferences  (REVERSE_INULL)
/zebra/zebra_srv6_vty.c: 703           in show_srv6_sid_magic()


_____________________________________________________________________________________________
*** CID 1644859:         Null pointer dereferences  (REVERSE_INULL)
/zebra/zebra_srv6_vty.c: 703             in show_srv6_sid_magic()
697     		frr_each_safe (zebra_srv6_sid_entry_list, &sid_ctx->sid->entries, entry) {
698     			if (entry->locator == locator) {
699     				found = true;
700     				break;
701     			}
702     		}
>>>     CID 1644859:         Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "sid_ctx->sid" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
703     		if (!sid_ctx->sid || !found) {
704     			if (uj)
705     				vty_json(vty, json); /* Return empty json */
706     			else
707     				vty_out(vty, "%% Can't find the SRv6 SID in the provided locator\n");
708     			return CMD_WARNING;

** CID 1644858:       Null pointer dereferences  (REVERSE_INULL)
/zebra/zebra_srv6.c: 1850           in get_srv6_sid_explicit()


_____________________________________________________________________________________________
*** CID 1644858:         Null pointer dereferences  (REVERSE_INULL)
/zebra/zebra_srv6.c: 1850             in get_srv6_sid_explicit()
1844     			}
1845     
1846     		/*
1847     		 * If we already have a SID associated with this context, we need to
1848     		 * deallocate the current SID function before allocating the new one
1849     		 */
>>>     CID 1644858:         Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "zctx->sid" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
1850     		if (zctx->sid) {
1851     			if (IS_ZEBRA_DEBUG_SRV6)
1852     				zlog_debug("%s: ctx %s already associated with SID %u, releasing SID",
1853     					   __func__, srv6_sid_ctx2str(buf, sizeof(buf), ctx),
1854     					   zctx->sid->func);
1855     
```
  