### PR TITLE
zebra: fix import of non zebra extern_learn neighbors

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -4609,13 +4609,14 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 	struct ipaddr ip;
 	char buf[ETHER_ADDR_STRLEN];
 	int mac_present = 0;
-	bool is_ext;
+	bool is_own;
 	bool is_router;
 	bool local_inactive;
 	uint32_t ext_flags = 0;
 	bool dp_static = false;
 	int l2_len = 0;
 	int cmd;
+	uint8_t rtprot = RTPROT_UNSPEC;
 
 	ndm = NLMSG_DATA(h);
 
@@ -4739,7 +4740,10 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 			memcpy(&mac, RTA_DATA(tb[NDA_LLADDR]), ETH_ALEN);
 		}
 
-		is_ext = !!(ndm->ndm_flags & NTF_EXT_LEARNED);
+		if (tb[NDA_PROTOCOL])
+			rtprot = *(__u8 *)RTA_DATA(tb[NDA_PROTOCOL]);
+
+		is_own = !!(ndm->ndm_flags & NTF_EXT_LEARNED) && rtprot == RTPROT_ZEBRA;
 		is_router = !!(ndm->ndm_flags & NTF_ROUTER);
 
 		if (tb[NDA_EXT_FLAGS]) {
@@ -4749,16 +4753,12 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 		}
 
 		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug(
-				"Rx %s family %s IF %s(%u) vrf %s(%u) IP %pIA MAC %s state 0x%x flags 0x%x ext_flags 0x%x",
-				nl_msg_type_to_str(h->nlmsg_type),
-				nl_family_to_str(ndm->ndm_family), ifp->name,
-				ndm->ndm_ifindex, ifp->vrf->name,
-				ifp->vrf->vrf_id, &ip,
-				mac_present
-					? prefix_mac2str(&mac, buf, sizeof(buf))
-					: "",
-				ndm->ndm_state, ndm->ndm_flags, ext_flags);
+			zlog_debug("Rx %s family %s IF %s(%u) vrf %s(%u) IP %pIA MAC %s state 0x%x flags 0x%x ext_flags 0x%x, proto %u",
+				   nl_msg_type_to_str(h->nlmsg_type),
+				   nl_family_to_str(ndm->ndm_family), ifp->name, ndm->ndm_ifindex,
+				   ifp->vrf->name, ifp->vrf->vrf_id, &ip,
+				   mac_present ? prefix_mac2str(&mac, buf, sizeof(buf)) : "",
+				   ndm->ndm_state, ndm->ndm_flags, ext_flags, rtprot);
 
 		/* If the neighbor state is valid for use, process as an add or
 		 * update
@@ -4778,16 +4778,16 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 				local_inactive = false;
 
 			/* Add local neighbors to the l3 interface database */
-			if (is_ext)
+			if (is_own)
 				zebra_neigh_del(ifp, &ip);
 			else
 				zebra_neigh_add(ifp, &ip, &mac);
 
 			if (link_if)
-				zebra_vxlan_handle_kernel_neigh_update(
-					ifp, link_if, &ip, &mac, ndm->ndm_state,
-					is_ext, is_router, local_inactive,
-					dp_static);
+				zebra_vxlan_handle_kernel_neigh_update(ifp, link_if, &ip, &mac,
+								       ndm->ndm_state, is_own,
+								       is_router, local_inactive,
+								       dp_static);
 			return 0;
 		}
 

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -4118,13 +4118,9 @@ int zebra_vxlan_handle_kernel_neigh_del(struct interface *ifp,
  * also be for a remote neighbor (e.g., ageout notification). It could
  * also be a "move" scenario.
  */
-int zebra_vxlan_handle_kernel_neigh_update(struct interface *ifp,
-					   struct interface *link_if,
-					   struct ipaddr *ip,
-					   struct ethaddr *macaddr,
-					   uint16_t state,
-					   bool is_ext,
-					   bool is_router,
+int zebra_vxlan_handle_kernel_neigh_update(struct interface *ifp, struct interface *link_if,
+					   struct ipaddr *ip, struct ethaddr *macaddr,
+					   uint16_t state, bool is_own, bool is_router,
 					   bool local_inactive, bool dp_static)
 {
 	struct zebra_evpn *zevpn = NULL;
@@ -4145,16 +4141,14 @@ int zebra_vxlan_handle_kernel_neigh_update(struct interface *ifp,
 		return 0;
 
 	if (IS_ZEBRA_DEBUG_VXLAN || IS_ZEBRA_DEBUG_EVPN_MH_NEIGH)
-		zlog_debug(
-			"Add/Update neighbor %pIA MAC %pEA intf %s(%u) state 0x%x %s%s%s%s-> L2-VNI %u",
-			ip, macaddr, ifp->name,
-			ifp->ifindex, state, is_ext ? "ext-learned " : "",
-			is_router ? "router " : "",
-			local_inactive ? "local_inactive " : "",
-			dp_static ? "peer_sync " : "", zevpn->vni);
+		zlog_debug("Add/Update neighbor %pIA MAC %pEA intf %s(%u) state 0x%x %s%s%s%s-> L2-VNI %u",
+			   ip, macaddr, ifp->name, ifp->ifindex, state,
+			   is_own ? "ext-learned proto zebra" : "", is_router ? "router " : "",
+			   local_inactive ? "local_inactive " : "", dp_static ? "peer_sync " : "",
+			   zevpn->vni);
 
 	/* Is this about a local neighbor or a remote one? */
-	if (!is_ext)
+	if (!is_own)
 		return zebra_evpn_local_neigh_update(zevpn, ifp, ip, macaddr,
 						     is_router, local_inactive,
 						     dp_static);

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -155,10 +155,10 @@ extern int zebra_vxlan_add_del_gw_macip(struct interface *ifp,
 extern int zebra_vxlan_svi_up(struct interface *ifp, struct interface *link_if);
 extern int zebra_vxlan_svi_down(struct interface *ifp,
 				struct interface *link_if);
-extern int zebra_vxlan_handle_kernel_neigh_update(
-	struct interface *ifp, struct interface *link_if, struct ipaddr *ip,
-	struct ethaddr *macaddr, uint16_t state, bool is_ext,
-	bool is_router, bool local_inactive, bool dp_static);
+extern int zebra_vxlan_handle_kernel_neigh_update(struct interface *ifp, struct interface *link_if,
+						  struct ipaddr *ip, struct ethaddr *macaddr,
+						  uint16_t state, bool is_own, bool is_router,
+						  bool local_inactive, bool dp_static);
 extern int zebra_vxlan_handle_kernel_neigh_del(struct interface *ifp,
 				       struct interface *link_if,
 				       struct ipaddr *ip);


### PR DESCRIPTION
"extern_learn" neighbor entries not created by zebra are not imported into EVPN, because zebra incorrectly assumes it originated them. For example:

> 192.168.0.1 dev br100 lladdr de:ed:01:d0:52:5f extern_learn REACHABLE

In contrast, entries created by zebra are explicitly marked with proto zebra:

> 192.168.0.2 dev br100 lladdr de:ed:01:dc:0e:62 extern_learn NOARP proto zebra

Only consider an entry as its own if it is marked with both extern_learn and proto zebra.