### PR TITLE
bgpd: Fix DEREF_OF_NULL.EX.COND in bgp_updgrp_packet

### DIFF
--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2909,6 +2909,7 @@ static inline bool peer_dynamic_neighbor_no_nsf(struct peer *peer)
 
 static inline int peer_cap_enhe(struct peer *peer, afi_t afi, safi_t safi)
 {
+	assert(peer);
 	return (CHECK_FLAG(peer->af_cap[afi][safi], PEER_CAP_ENHE_AF_NEGO));
 }
 


### PR DESCRIPTION
Found by the static analyzer Svace (ISP RAS): DEREF_OF_NULL.EX.COND. After having been assigned to a NULL value at bgp_updgrp_packet.c:717, pointer 'from' is passed as 9th parameter in call to function 'bgp_packet_attribute' at bgp_updgrp_packet.c:746, where it is dereferenced at bgp_attr.c:4638.