### PR TITLE
lib: fix routemap crash

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -2463,8 +2463,8 @@ static void route_map_pentry_process_dependency(struct hash_bucket *bucket,
 			continue;
 
 		for (match = match_list->head; match; match = match->next) {
-			if (strcmp(match->rule_str, pentry_dep->plist_name)
-			    == 0) {
+			if (match->rule_str &&
+			    strcmp(match->rule_str, pentry_dep->plist_name) == 0) {
 				if (IS_RULE_IPv4_PREFIX_LIST(match->cmd->str)
 				    && family == AF_INET) {
 					route_map_pentry_update(


### PR DESCRIPTION
The `match->rule_str` may is NULL, like:
```
ip prefix-list plist1 deny any
route-map rm1 deny 10
 match evpn default-route
```

The stack:
```
 #0  __strcmp_sse42 () at ../sysdeps/x86_64/multiarch/strcmp-sse4_2.S:173
 #1  0x00007ffff7e5a7ea in route_map_pentry_process_dependency (
     bucket=0x5555561fb270, data=0x7fffffff96e0) at ../lib/routemap.c:2466
 #2  0x00007ffff7de983d in hash_iterate (hash=0x555556208e50,
     func=0x7ffff7e5a6f3 <route_map_pentry_process_dependency>, arg=0x7fffffff96e0)
     at ../lib/hash.c:252
 #3  0x00007ffff7e5a99d in route_map_notify_pentry_dependencies (
     affected_name=0x5555561fb720 "plist1", pentry=0x555556201040,
     event=RMAP_EVENT_PLIST_ADDED) at ../lib/routemap.c:2513
 #4  0x00007ffff7e4a275 in prefix_list_entry_update_finish (ple=0x555556201040)
     at ../lib/plist.c:697
 #5  0x00007ffff7de38c9 in lib_prefix_list_entry_apply_finish (args=0x7fffffff97b0)
     at ../lib/filter_nb.c:1233
 #6  0x00007ffff7e3228a in nb_callback_apply_finish (context=0x555556204970,
     nb_node=0x555555b51860, dnode=0x5555561e47b0, errmsg=0x7fffffff9d00 "",
    errmsg_len=8192) at ../lib/northbound.c:1772
```