### PR TITLE
zebra: Ensure on exit that log buffers are flushed

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -1498,3 +1498,10 @@ bool frr_is_daemon(void)
 
 	return false;
 }
+
+FRR_NORETURN void frr_exit_with_buffer_flush(int status)
+{
+	zlog_tls_buffer_flush();
+	exit(status);
+}
+

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -285,6 +285,8 @@ extern bool debug_memstats_at_exit;
 
 const char *frr_vers2str(uint32_t version, char *buf, int buflen);
 
+void frr_exit_with_buffer_flush(int status);
+
 #ifdef __cplusplus
 }
 #endif

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1469,14 +1469,14 @@ static void interface_vrf_change(enum dplane_op_e op, ifindex_t ifindex,
 				flog_err(EC_ZEBRA_VRF_NOT_FOUND,
 					 "VRF %s id %u does not exist", name,
 					 ifindex);
-				exit(-1);
+				frr_exit_with_buffer_flush(-1);
 			}
 
 			if (vrf && strcmp(name, vrf->name)) {
 				flog_err(EC_ZEBRA_VRF_MISCONFIGURED,
 					 "VRF %s id %u table id overlaps existing vrf %s(%d), misconfiguration exiting",
 					 name, ifindex, vrf->name, vrf->vrf_id);
-				exit(-1);
+				frr_exit_with_buffer_flush(-1);
 			}
 		}
 

--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -51,7 +51,7 @@ int if_ioctl(unsigned long request, caddr_t buffer)
 		if (sock < 0) {
 			zlog_err("Cannot create UDP socket: %s",
 				 safe_strerror(errno));
-			exit(1);
+			frr_exit_with_buffer_flush(1);
 		}
 		if ((ret = ioctl(sock, request, buffer)) < 0)
 			err = errno;
@@ -78,7 +78,7 @@ int vrf_if_ioctl(unsigned long request, caddr_t buffer, vrf_id_t vrf_id)
 		if (sock < 0) {
 			zlog_err("Cannot create UDP socket: %s",
 				 safe_strerror(errno));
-			exit(1);
+			frr_exit_with_buffer_flush(1);
 		}
 		ret = vrf_ioctl(vrf_id, sock, request, buffer);
 		if (ret < 0)
@@ -105,7 +105,7 @@ static int if_ioctl_ipv6(unsigned long request, caddr_t buffer)
 		if (sock < 0) {
 			zlog_err("Cannot create IPv6 datagram socket: %s",
 				 safe_strerror(errno));
-			exit(1);
+			frr_exit_with_buffer_flush(1);
 		}
 
 		if ((ret = ioctl(sock, request, buffer)) < 0)

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -940,7 +940,7 @@ static int netlink_recv_msg(struct nlsock *nl, struct msghdr *msg)
 		 * In this case we are screwed. There is no good way to recover
 		 * zebra at this point.
 		 */
-		exit(-1);
+		frr_exit_with_buffer_flush(-1);
 	}
 
 	if (status == 0) {
@@ -1794,7 +1794,7 @@ void kernel_init(struct zebra_ns *zns)
 			   NETLINK_ROUTE) < 0) {
 		zlog_err("Failure to create %s socket",
 			 zns->netlink.name);
-		exit(-1);
+		frr_exit_with_buffer_flush(-1);
 	}
 
 	kernel_netlink_nlsock_insert(&zns->netlink);
@@ -1806,7 +1806,7 @@ void kernel_init(struct zebra_ns *zns)
 			   NETLINK_ROUTE) < 0) {
 		zlog_err("Failure to create %s socket",
 			 zns->netlink_cmd.name);
-		exit(-1);
+		frr_exit_with_buffer_flush(-1);
 	}
 
 	kernel_netlink_nlsock_insert(&zns->netlink_cmd);
@@ -1820,7 +1820,7 @@ void kernel_init(struct zebra_ns *zns)
 			   NETLINK_ROUTE) < 0) {
 		zlog_err("Failure to create %s socket",
 			 zns->netlink_dplane_out.name);
-		exit(-1);
+		frr_exit_with_buffer_flush(-1);
 	}
 
 	kernel_netlink_nlsock_insert(&zns->netlink_dplane_out);
@@ -1834,7 +1834,7 @@ void kernel_init(struct zebra_ns *zns)
 			   zns->ns_id, NETLINK_ROUTE) < 0) {
 		zlog_err("Failure to create %s socket",
 			 zns->netlink_dplane_in.name);
-		exit(-1);
+		frr_exit_with_buffer_flush(-1);
 	}
 
 	kernel_netlink_nlsock_insert(&zns->netlink_dplane_in);

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1346,7 +1346,7 @@ static void kernel_read(struct event *thread)
 			 *  There is no good way to
 			 *  recover zebra at this point.
 			 */
-			exit(-1);
+			frr_exit_with_buffer_flush(-1);
 #endif
 		}
 		if (errno != EAGAIN && errno != EWOULDBLOCK)

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -2282,6 +2282,6 @@ void rtadv_init(void)
 		zlog_debug("%s: RTADV_ADATA_SIZE chosen will not work on this platform, please use a larger size",
 			   __func__);
 
-		exit(-1);
+		frr_exit_with_buffer_flush(-1);
 	}
 }

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2367,7 +2367,7 @@ static int nexthop_active(struct nexthop *nexthop, struct nhg_hash_entry *nhe,
 			flog_err(EC_LIB_DEVELOPMENT,
 				 "%s: unknown address-family: %u", __func__,
 				 afi);
-			exit(1);
+			frr_exit_with_buffer_flush(1);
 		}
 
 		policy = zebra_sr_policy_find(nexthop->srte_color, &endpoint);

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -422,7 +422,7 @@ int zebra_ns_init(void)
 	if (!default_ns) {
 		flog_err(EC_ZEBRA_NS_NO_DEFAULT,
 			 "%s: failed to find default ns", __func__);
-		exit(EXIT_FAILURE); /* This is non-recoverable */
+		frr_exit_with_buffer_flush(EXIT_FAILURE); /* This is non-recoverable */
 	}
 
 	/* Do any needed per-NS data structure allocation. */

--- a/zebra/zebra_srte.c
+++ b/zebra/zebra_srte.c
@@ -129,7 +129,7 @@ static int zebra_sr_policy_notify_update_client(struct zebra_sr_policy *policy,
 		flog_warn(EC_LIB_DEVELOPMENT,
 			  "%s: unknown policy endpoint address family: %u",
 			  __func__, policy->endpoint.ipa_type);
-		exit(1);
+		frr_exit_with_buffer_flush(1);
 	}
 	stream_putl(s, policy->color);
 
@@ -191,7 +191,7 @@ static void zebra_sr_policy_notify_update(struct zebra_sr_policy *policy)
 		flog_warn(EC_LIB_DEVELOPMENT,
 			  "%s: unknown policy endpoint address family: %u",
 			  __func__, policy->endpoint.ipa_type);
-		exit(1);
+		frr_exit_with_buffer_flush(1);
 	}
 
 	rnh = zebra_lookup_rnh(&p, zvrf_id(zvrf), SAFI_UNICAST);


### PR DESCRIPTION
I'm seeing cases of tests failing in the CI system where zebra just is not running and there are no
dumps of the backtrace.  In the past it's not
uncommon for exit to be called when zebra just
dissapears.  Let's see if we get a bit more data
in this case when it happens if we initiate a buffer flush.