### PR TITLE
    bgpd: fix "neighbor <n> local-as (null)" in running-config

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -6955,6 +6955,7 @@ int peer_local_as_set(struct peer *peer, as_t as, bool no_prepend,
 	struct bgp *bgp = peer->bgp;
 	struct peer *member;
 	struct listnode *node, *nnode;
+	bool same_as_str = false;
 
 	if (bgp->as == as)
 		return BGP_ERR_CANNOT_HAVE_LOCAL_AS_SAME_AS;
@@ -6972,8 +6973,11 @@ int peer_local_as_set(struct peer *peer, as_t as, bool no_prepend,
 	peer_flag_modify(peer, PEER_FLAG_LOCAL_AS_REPLACE_AS, replace_as);
 	peer_flag_modify(peer, PEER_FLAG_DUAL_AS, dual_as);
 
+	same_as_str = as_str && peer->change_local_as_pretty &&
+		      !strcmp(as_str, peer->change_local_as_pretty);
+
 	if (peer->change_local_as == as && old_no_prepend == no_prepend &&
-	    old_replace_as == replace_as && old_dual_as == dual_as)
+	    old_replace_as == replace_as && old_dual_as == dual_as && same_as_str)
 		return 0;
 	peer->change_local_as = as;
 	if (as_str) {

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7021,9 +7021,12 @@ int peer_local_as_set(struct peer *peer, as_t as, bool no_prepend,
 			  replace_as);
 		COND_FLAG(member->flags, PEER_FLAG_DUAL_AS, dual_as);
 		member->change_local_as = as;
-		if (as_str)
+		if (as_str) {
+			if (member->change_local_as_pretty)
+				XFREE(MTYPE_BGP_NAME, member->change_local_as_pretty);
 			member->change_local_as_pretty = XSTRDUP(MTYPE_BGP_NAME,
 								 as_str);
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
    Issue:

    The vtysh running-config will incorrectly show
    bgp neighbor local-as value as (null) with this config sequence -

    1.configure bgp peer-group p1 with local-as as1
    2.configure bgp neighbor n1, assign peer-group pg1 to it.
    3.set local-as of neighbor n1 to as1

    RC:

    peer->change_local_as_pretty(having string value of local-as) is not set for bgp neighbor,
    when new configured local-as value is same as its current local-as value.

    This will skip setting peer->change_local_as_pretty,
    when neighbor that inherited local-as from peer-group is configured with same local-as as its peer-group.

    Fix:

    1.Set peer->change_local_as_pretty to the input as_string value,
    if both values dont match.

    2.prevent peer->change_local_as_pretty memleak in bgp peer when local-as is changed
    in its associated peer-group

    Testing:

    router bgp 65011 vrf yellow
     bgp router-id 10.0.0.1
     neighbor pg2 peer-group
     neighbor pg2 remote-as external
     neighbor pg2 local-as 55104
     neighbor pg2 advertisement-interval 0
     neighbor pg2 timers 3 9
     neighbor pg2 timers connect 10
     neighbor swp1 interface peer-group pg2
     neighbor swp1 advertisement-interval 0
     neighbor swp1 timers 3 9
     neighbor swp1 timers connect 1
    exit
    !
    end
    leaf12# co
    leaf12(config)# router bgp 65011 vrf yellow
    leaf12(config-router)# neighbor swp1 local-as 55104
    leaf12(config-router)# end

    Before fix --

    leaf12# sh running-config | include swp1
     neighbor swp1 interface peer-group pg2
     neighbor swp1 local-as (null)           <<<<<
     neighbor swp1 advertisement-interval 0
     neighbor swp1 timers 3 9
     neighbor swp1 timers connect 1

    After fix --

    leaf12# sh running-config | include swp1
     neighbor swp1 interface peer-group pg2
     neighbor swp1 local-as 55104            <<<<<
     neighbor swp1 advertisement-interval 0
     neighbor swp1 timers 3 9
     neighbor swp1 timers connect 1