### PR TITLE
tests: Fix bgp_bmp tests

### DIFF
--- a/tests/topotests/bgp_bmp/test_bgp_bmp_1.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_1.py
@@ -39,6 +39,7 @@ from lib import topotest
 from lib.bgp import verify_bgp_convergence_from_running_config
 from lib.bgp import bgp_configure_prefixes
 from .bgpbmp import (
+    BMPSequenceContext,
     bmp_check_for_prefixes,
     bmp_check_for_peer_message,
     bmp_update_seq,
@@ -54,6 +55,9 @@ LOC_RIB = "loc-rib"
 
 UPDATE_EXPECTED_JSON = False
 DEBUG_PCAP = False
+
+# Create a sequence context for this test run
+bmp_seq_context = BMPSequenceContext()
 
 
 def build_topo(tgen):
@@ -126,7 +130,11 @@ def _test_prefixes(policy, vrf=None, step=0):
     prefixes = ["172.31.0.15/32", "2001::1111/128"]
 
     for type in ("update", "withdraw"):
-        bmp_update_seq(tgen.gears["bmp1"], os.path.join(tgen.logdir, "bmp1", "bmp.log"))
+        bmp_update_seq(
+            tgen.gears["bmp1"],
+            os.path.join(tgen.logdir, "bmp1", "bmp.log"),
+            bmp_seq_context,
+        )
 
         bgp_configure_prefixes(
             tgen.gears["r2"],
@@ -170,6 +178,7 @@ def _test_prefixes(policy, vrf=None, step=0):
             f"{CWD}/bmp1",
             UPDATE_EXPECTED_JSON,
             LOC_RIB,
+            bmp_seq_context,
         )
         success, res = topotest.run_and_expect(test_func, None, count=30, wait=1)
         assert success, "Checking the updated prefixes has failed ! %s" % res
@@ -209,6 +218,7 @@ def test_peer_up():
         "peer up",
         tgen.gears["bmp1"],
         os.path.join(tgen.logdir, "bmp1", "bmp.log"),
+        bmp_seq_context,
     )
     success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
     assert success, "Checking the updated prefixes has been failed !."
@@ -254,6 +264,7 @@ def test_peer_down():
         "peer down",
         tgen.gears["bmp1"],
         os.path.join(tgen.logdir, "bmp1", "bmp.log"),
+        bmp_seq_context,
     )
     success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
     assert success, "Checking the updated prefixes has been failed !."

--- a/tests/topotests/bgp_bmp/test_bgp_bmp_2.py
+++ b/tests/topotests/bgp_bmp/test_bgp_bmp_2.py
@@ -44,6 +44,7 @@ from .bgpbmp import (
     bmp_check_for_peer_message,
     bmp_update_seq,
     bmp_reset_seq,
+    BMPSequenceContext,
 )
 
 
@@ -58,6 +59,9 @@ LOC_RIB = "loc-rib"
 
 UPDATE_EXPECTED_JSON = False
 DEBUG_PCAP = False
+
+# Create a global BMP sequence context for this test module
+bmp_seq_context = BMPSequenceContext()
 
 
 def build_topo(tgen):
@@ -83,7 +87,7 @@ ip link set vrf1 up
 ip link set r1vrf-eth1 master vrf1
 """
     )
-    bmp_reset_seq()
+    bmp_reset_seq(bmp_seq_context)
     if DEBUG_PCAP:
         pcap_file = os.path.join(tgen.logdir, "r1vrf/bmp.pcap")
         tgen.gears["r1vrf"].run(
@@ -130,7 +134,9 @@ def _test_prefixes(policy, step=1):
 
     for type in ("update", "withdraw"):
         bmp_update_seq(
-            tgen.gears["bmp1vrf"], os.path.join(tgen.logdir, "bmp1vrf", "bmp.log")
+            tgen.gears["bmp1vrf"],
+            os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+            bmp_seq_context,
         )
 
         # add prefixes
@@ -171,6 +177,7 @@ def _test_prefixes(policy, step=1):
             f"{CWD}/bmp1vrf",
             UPDATE_EXPECTED_JSON,
             LOC_RIB,
+            bmp_seq_context,
         )
         success, res = topotest.run_and_expect(test_func, None, count=30, wait=1)
         assert success, "Checking the updated prefixes has failed ! %s" % res
@@ -210,6 +217,7 @@ def test_peer_up():
         "peer up",
         tgen.gears["bmp1vrf"],
         os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        bmp_seq_context,
         is_rd_instance=True,
     )
     success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
@@ -246,6 +254,7 @@ def test_peer_down():
         "peer down",
         tgen.gears["bmp1vrf"],
         os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        bmp_seq_context,
         is_rd_instance=True,
     )
     success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
@@ -269,6 +278,7 @@ def test_bgp_instance_flapping():
         "peer down",
         tgen.gears["bmp1vrf"],
         os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        bmp_seq_context,
         is_rd_instance=True,
     )
     success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
@@ -283,6 +293,7 @@ def test_bgp_instance_flapping():
         "peer up",
         tgen.gears["bmp1vrf"],
         os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        bmp_seq_context,
         is_rd_instance=True,
     )
     success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
@@ -314,6 +325,7 @@ def test_bgp_routerid_changed():
         "peer down",
         tgen.gears["bmp1vrf"],
         os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        bmp_seq_context,
         is_rd_instance=True,
     )
     success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
@@ -330,6 +342,7 @@ def test_bgp_routerid_changed():
         "peer up",
         tgen.gears["bmp1vrf"],
         os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        bmp_seq_context,
         is_rd_instance=True,
         peer_bgp_id="192.168.1.77",
     )
@@ -346,7 +359,9 @@ def test_reconfigure_route_distinguisher_vrf1():
     tgen = get_topogen()
 
     bmp_update_seq(
-        tgen.gears["bmp1vrf"], os.path.join(tgen.logdir, "bmp1vrf", "bmp.log")
+        tgen.gears["bmp1vrf"],
+        os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        bmp_seq_context,
     )
     peers = ["0.0.0.0"]
 
@@ -370,6 +385,7 @@ def test_reconfigure_route_distinguisher_vrf1():
         "peer down",
         tgen.gears["bmp1vrf"],
         os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        bmp_seq_context,
         is_rd_instance=True,
         peer_distinguisher="444:1",
     )
@@ -387,6 +403,7 @@ def test_reconfigure_route_distinguisher_vrf1():
         "peer up",
         tgen.gears["bmp1vrf"],
         os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        bmp_seq_context,
         is_rd_instance=True,
         peer_bgp_id="192.168.1.77",
         peer_distinguisher="666:22",
@@ -406,6 +423,7 @@ def test_reconfigure_route_distinguisher_vrf1():
         "peer up",
         tgen.gears["bmp1vrf"],
         os.path.join(tgen.logdir, "bmp1vrf", "bmp.log"),
+        bmp_seq_context,
         is_rd_instance=True,
         peer_distinguisher="666:22",
     )


### PR DESCRIPTION
The bgp_bmp tests have a global SEQ number that was being shared across all tests running at the same time.  As such if one of the 3 tests was running at the same time as the other 2, you could end up in a situation where the SEQ number from one test would affect a different test, thus causing it to get out of sync and fail the test.

I saw this when I added log output to display the starting sequence number and in the failing tests, the sequence number that was being started with was 87.  This fixes the issue by creating a sequence context that needs to be passed in for each function that bgpbmp.py supports.