### PR TITLE
Add interface altname support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2015,6 +2015,12 @@ else
   AC_DEFINE([DISABLE_BGP_ANNOUNCE], [0], [Disable BGP installation to zebra])
 fi
 
+if test "$enable_transparent_altnames" = "yes";then
+  AC_DEFINE([ENABLE_TRANSPARENT_ALTNAMES], [1], [Enable transparent interface altnames])
+else
+  AC_DEFINE([ENABLE_TRANSPARENT_ALTNAMES], [0], [Disable transparent interface altnames])
+fi
+
 if test "$enable_bgp_vnc" != "no";then
   AC_DEFINE([ENABLE_BGP_VNC], [1], [Enable BGP VNC support])
 fi

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -155,6 +155,11 @@ Standard Commands
 
 .. clicmd:: interface IFNAME
 
+.. note::
+
+   When configuring and building FRR with the `--enable-transparent-altnames`
+   flag the interface command will also match on interface altnames.
+
 
 .. clicmd:: interface IFNAME vrf VRF
 

--- a/lib/if.c
+++ b/lib/if.c
@@ -489,28 +489,71 @@ ifindex_t ifname2ifindex(const char *name, vrf_id_t vrf_id)
 		       : IFINDEX_INTERNAL;
 }
 
+static struct interface *if_lookup_by_altname_vrf(const char *name, struct vrf *vrf)
+{
+	struct interface *ifp;
+
+	RB_FOREACH (ifp, if_name_head, &vrf->ifaces_by_name) {
+		struct altname altname;
+
+		strlcpy(altname.name, name, sizeof(altname.name));
+		/* Check altnames */
+		struct altname *result = RB_FIND(altnames_head, &ifp->altnames, &altname);
+
+		if (result != NULL)
+			return ifp;
+	}
+	return NULL;
+}
+
 /* Interface existence check by interface name. */
 struct interface *if_lookup_by_name(const char *name, vrf_id_t vrf_id)
 {
 	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 	struct interface if_tmp;
+	struct interface *ifp;
 
-	if (!vrf || !name || strnlen(name, IFNAMSIZ) == IFNAMSIZ)
+	if (!vrf || !name || (!ENABLE_TRANSPARENT_ALTNAMES && strnlen(name, IFNAMSIZ) == IFNAMSIZ))
 		return NULL;
 
 	strlcpy(if_tmp.name, name, sizeof(if_tmp.name));
-	return RB_FIND(if_name_head, &vrf->ifaces_by_name, &if_tmp);
+
+	/* Search by the primary name of the interface */
+	ifp = RB_FIND(if_name_head, &vrf->ifaces_by_name, &if_tmp);
+
+	if (ifp)
+		return ifp;
+
+	if (ENABLE_TRANSPARENT_ALTNAMES) {
+		/* If nothing has been found, search through all altnames */
+		return if_lookup_by_altname_vrf(name, vrf);
+	} else {
+		return NULL;
+	}
 }
 
 struct interface *if_lookup_by_name_vrf(const char *name, struct vrf *vrf)
 {
 	struct interface if_tmp;
+	struct interface *ifp;
 
-	if (!name || strnlen(name, IFNAMSIZ) == IFNAMSIZ)
+	if (!name || (!ENABLE_TRANSPARENT_ALTNAMES && strnlen(name, IFNAMSIZ) == IFNAMSIZ))
 		return NULL;
 
 	strlcpy(if_tmp.name, name, sizeof(if_tmp.name));
-	return RB_FIND(if_name_head, &vrf->ifaces_by_name, &if_tmp);
+
+	/* Search by the primary name of the interface */
+	ifp = RB_FIND(if_name_head, &vrf->ifaces_by_name, &if_tmp);
+
+	if (ifp)
+		return ifp;
+
+	if (ENABLE_TRANSPARENT_ALTNAMES) {
+		/* If nothing has been found, search through all altnames */
+		return if_lookup_by_altname_vrf(name, vrf);
+	} else {
+		return NULL;
+	}
 }
 
 static struct interface *if_lookup_by_name_all_vrf(const char *name)
@@ -518,7 +561,7 @@ static struct interface *if_lookup_by_name_all_vrf(const char *name)
 	struct vrf *vrf;
 	struct interface *ifp;
 
-	if (!name || strnlen(name, IFNAMSIZ) == IFNAMSIZ)
+	if (!name || (!ENABLE_TRANSPARENT_ALTNAMES && strnlen(name, IFNAMSIZ) == IFNAMSIZ))
 		return NULL;
 
 	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
@@ -1283,6 +1326,16 @@ static int vrfname_by_ifname(const char *ifname, const char **vrfname)
 			if (strmatch(ifp->name, ifname)) {
 				*vrfname = vrf->name;
 				count++;
+				continue;
+			}
+			if (ENABLE_TRANSPARENT_ALTNAMES) {
+				struct altname altname;
+				/* Check altnames */
+				strlcpy(altname.name, ifname, sizeof(altname.name));
+				struct altname *result = RB_FIND(altnames_head, &ifp->altnames, &altname);
+
+				if (result != NULL)
+					count++;
 			}
 		}
 	}
@@ -1580,7 +1633,7 @@ static int lib_interface_create(struct nb_cb_create_args *args)
 
 			netns_ifname_split(ifname, ifname_ns, vrfname_ns);
 
-			if (strlen(ifname_ns) > 16) {
+			if (!ENABLE_TRANSPARENT_ALTNAMES && strlen(ifname_ns) > 16) {
 				snprintf(
 					args->errmsg, args->errmsg_len,
 					"Maximum interface name length is 16 characters");
@@ -1593,7 +1646,7 @@ static int lib_interface_create(struct nb_cb_create_args *args)
 				return NB_ERR_VALIDATION;
 			}
 		} else {
-			if (strlen(ifname) > 16) {
+			if (!ENABLE_TRANSPARENT_ALTNAMES && strlen(ifname) > 16) {
 				snprintf(
 					args->errmsg, args->errmsg_len,
 					"Maximum interface name length is 16 characters");

--- a/lib/if.c
+++ b/lib/if.c
@@ -39,6 +39,7 @@ DEFINE_MTYPE_STATIC(LIB, CONNECTED, "Connected");
 DEFINE_MTYPE_STATIC(LIB, NBR_CONNECTED, "Neighbor Connected");
 DEFINE_MTYPE(LIB, CONNECTED_LABEL, "Connected interface label");
 DEFINE_MTYPE_STATIC(LIB, IF_LINK_PARAMS, "Informational Link Parameters");
+DEFINE_MTYPE(LIB, LIB_ALTNAME, "Interface altname");
 
 static void if_set_name(struct interface *ifp, const char *name);
 static struct interface *if_lookup_by_ifindex(ifindex_t ifindex,
@@ -48,6 +49,7 @@ static int if_cmp_index_func(const struct interface *ifp1,
 			     const struct interface *ifp2);
 RB_GENERATE(if_name_head, interface, name_entry, if_cmp_func);
 RB_GENERATE(if_index_head, interface, index_entry, if_cmp_index_func);
+RB_GENERATE(altnames_head, altname, entry, altname_cmp_func);
 
 DEFINE_QOBJ_TYPE(interface);
 
@@ -138,6 +140,11 @@ int if_cmp_name_func(const char *p1, const char *p2)
 int if_cmp_func(const struct interface *ifp1, const struct interface *ifp2)
 {
 	return if_cmp_name_func(ifp1->name, ifp2->name);
+}
+
+int altname_cmp_func(const struct altname *alt1, const struct altname *alt2)
+{
+	return strcmp(alt1->name, alt2->name);
 }
 
 static int if_cmp_index_func(const struct interface *ifp1,
@@ -375,6 +382,7 @@ void if_delete(struct interface **ifp)
 {
 	struct interface *ptr = *ifp;
 	struct vrf *vrf = ptr->vrf;
+	struct altname *item;
 
 	IFNAME_RB_REMOVE(vrf, ptr);
 	if (ptr->ifindex != IFINDEX_INTERNAL)
@@ -388,6 +396,13 @@ void if_delete(struct interface **ifp)
 	if_link_params_free(ptr);
 
 	XFREE(MTYPE_IFDESC, ptr->desc);
+
+	/* Clean up altnames list */
+	while (!RB_EMPTY(altnames_head, &ptr->altnames)) {
+		item = RB_ROOT(altnames_head, &ptr->altnames);
+		RB_REMOVE(altnames_head, &ptr->altnames, item);
+		XFREE(MTYPE_LIB_ALTNAME, item);
+	}
 
 	if_update_state_remove(ptr);
 
@@ -1828,6 +1843,25 @@ static enum nb_error lib_interface_state_metric_get(const struct nb_node *nb_nod
 }
 
 /*
+ * XPath: /frr-interface:lib/interface/state/altnames
+ */
+static enum nb_error lib_interface_state_altnames_get(const struct nb_node *nb_node,
+						      const void *list_entry,
+						      struct lyd_node *parent)
+{
+	const struct lysc_node *snode = nb_node->snode;
+	const struct interface *ifp = list_entry;
+	struct altname *altname;
+
+	RB_FOREACH(altname, altnames_head, (struct altnames_head *)&ifp->altnames) {
+		if (lyd_new_term(parent, snode->module, snode->name, altname->name,
+				 LYD_NEW_PATH_UPDATE, NULL))
+			return NB_ERR_RESOURCE;
+	}
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-interface:lib/interface/state/phy-address
  */
 static struct yang_data *
@@ -1914,6 +1948,12 @@ const struct frr_yang_module_info frr_interface_info = {
 			.xpath = "/frr-interface:lib/interface/state/type",
 			.cbs = {
 				.get = __return_ok,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/state/altnames",
+			.cbs = {
+				.get = lib_interface_state_altnames_get,
 			}
 		},
 		{

--- a/lib/if.h
+++ b/lib/if.h
@@ -18,6 +18,7 @@ extern "C" {
 #endif
 
 DECLARE_MTYPE(CONNECTED_LABEL);
+DECLARE_MTYPE(LIB_ALTNAME);
 
 /* Interface link-layer type, if known. Derived from:
  *
@@ -222,6 +223,23 @@ struct if_link_params {
 #define HAS_LINK_PARAMS(ifp)  ((ifp)->link_params != NULL)
 
 PREDECL_DLIST(if_connected);
+PREDECL_LIST(altnames_dplane);
+
+/* Length of interface altname.*/
+#define IF_ALTNAMESIZE 128
+
+struct altname {
+	RB_ENTRY(altname) entry;
+	struct altnames_dplane_item list_entry;
+
+	char name[IF_ALTNAMESIZE];
+};
+
+extern int altname_cmp_func(const struct altname *alt1, const struct altname *alt2);
+
+RB_HEAD(altnames_head, altname);
+RB_PROTOTYPE(altnames_head, altname, entry, altname_cmp_func)
+DECLARE_QOBJ_TYPE(altname);
 
 /* Interface structure */
 struct interface {
@@ -296,6 +314,9 @@ struct interface {
 
 	/* description of the interface. */
 	char *desc;
+
+	/* Altnames for this interface */
+	struct altnames_head altnames;
 
 	/* Connected address list. */
 	struct if_connected_head connected[1];

--- a/yang/frr-interface.yang
+++ b/yang/frr-interface.yang
@@ -294,6 +294,15 @@ module frr-interface {
       description
         "The interface's MAC address.";
     }
+
+    leaf-list altnames {
+      type string {
+        length "1..127";
+      }
+      config false;
+      description
+        "Alternative interface names.";
+    }
   }
 
   container lib {

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -64,6 +64,7 @@
 #include "zebra/netconf_netlink.h"
 #include "zebra/zebra_trace.h"
 #include "lib/netlink_parser.h"
+#include "zebra/zebra_dplane.h"
 
 extern struct zebra_privs_t zserv_privs;
 
@@ -1486,6 +1487,25 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	dplane_ctx_set_ifp_startup(ctx, startup);
 	dplane_ctx_set_ifp_family(ctx, ifi->ifi_family);
 	dplane_ctx_set_intf_txqlen(ctx, txqlen);
+	dplane_ctx_set_ifp_altnames(ctx);
+
+	if (tb[IFLA_PROP_LIST]) {
+		struct rtattr *i, *proplist = tb[IFLA_PROP_LIST];
+		int rem = RTA_PAYLOAD(proplist);
+
+
+		for (i = RTA_DATA(proplist); RTA_OK(i, rem); i = RTA_NEXT(i, rem)) {
+			const char *altname;
+
+			if (i->rta_type != IFLA_ALT_IFNAME)
+				continue;
+
+			altname = (const char *)RTA_DATA(i);
+
+			dplane_ctx_add_ifp_altname(ctx, altname);
+		}
+	}
+
 
 	/* We are interested in some AF_BRIDGE notifications. */
 #ifndef AF_BRIDGE

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -36,6 +36,7 @@
 #include "zebra/zebra_evpn_mh.h"
 #include "zebra/zebra_trace.h"
 #include "zebra/zebra_l2.h"
+#include "zebra/zebra_dplane.h"
 
 DEFINE_MTYPE_STATIC(ZEBRA, ZINFO, "Zebra Interface Information");
 
@@ -207,6 +208,8 @@ static int if_zebra_delete_hook(struct interface *ifp)
 {
 	struct zebra_if *zebra_if;
 	struct zebra_l2info_bond *bond;
+	struct altname *item;
+
 
 	if (ifp->info) {
 		zebra_if = ifp->info;
@@ -238,6 +241,13 @@ static int if_zebra_delete_hook(struct interface *ifp)
 		zebra_ns_unlink_ifp(ifp);
 
 		XFREE(MTYPE_ZIF_DESC, zebra_if->desc);
+
+		/* Clean up altnames list */
+		while (!RB_EMPTY(altnames_head, &ifp->altnames)) {
+			item = RB_ROOT(altnames_head, &ifp->altnames);
+			RB_REMOVE(altnames_head, &ifp->altnames, item);
+			XFREE(MTYPE_LIB_ALTNAME, item);
+		}
 
 		event_cancel(&zebra_if->speed_update);
 
@@ -2033,6 +2043,9 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 		char *desc;
 		uint8_t family;
 		uint64_t change_flags;
+		struct altname *item;
+		struct altname *current_name;
+		struct altnames_dplane_head altnames;
 
 		/* If VRF, create or update the VRF structure itself. */
 		if (zif_type == ZEBRA_IF_VRF && !vrf_is_backend_netns())
@@ -2346,6 +2359,32 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 						IS_ZEBRA_IF_BRIDGE_VLAN_AWARE(
 							zif));
 			}
+		}
+		/* Update altnames */
+		altnames = dplane_ctx_get_ifp_altnames(ctx);
+
+		/* Clean up altnames list */
+		while (!RB_EMPTY(altnames_head, &ifp->altnames)) {
+			item = RB_ROOT(altnames_head, &ifp->altnames);
+			RB_REMOVE(altnames_head, &ifp->altnames, item);
+			XFREE(MTYPE_LIB_ALTNAME, item);
+		}
+
+		RB_INIT(altnames_head, &ifp->altnames);
+
+		frr_each_safe(altnames_dplane, &altnames, current_name) {
+			struct altname *to_insert;
+			struct altname *altname_inserted;
+
+			to_insert = XCALLOC(MTYPE_LIB_ALTNAME, sizeof(*to_insert));
+			strlcpy(to_insert->name, current_name->name, sizeof(to_insert->name));
+
+			altname_inserted = RB_INSERT(altnames_head, &ifp->altnames,
+								     to_insert);
+			if (altname_inserted)
+				flog_err(EC_LIB_INTERFACE,
+					 "%s(%s): corruption detected -- altname with this name exists already in interface %s!",
+					 __func__, to_insert->name, ifp->name);
 		}
 
 		zif = ifp->info;
@@ -2855,6 +2894,21 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 		vty_out(vty, "\n");
 	}
 
+	/* Display altnames if any */
+	if (!RB_EMPTY(altnames_head, &ifp->altnames)) {
+		struct altname *altname;
+		bool first = true;
+
+		vty_out(vty, "  Altnames: ");
+		RB_FOREACH (altname, altnames_head, &ifp->altnames) {
+			if (!first)
+				vty_out(vty, ", ");
+			vty_out(vty, "%s", altname->name);
+			first = false;
+		}
+		vty_out(vty, "\n");
+	}
+
 	/* Bandwidth in Mbps */
 	if (ifp->bandwidth != 0) {
 		vty_out(vty, "  bandwidth %u Mbps", ifp->bandwidth);
@@ -3267,6 +3321,17 @@ static void if_dump_vty_json(struct vty *vty, struct interface *ifp,
 			strlcat(hwbuf, buf, sizeof(hwbuf));
 		}
 		json_object_string_add(json_if, "hardwareAddress", hwbuf);
+	}
+
+	/* Display altnames if any */
+	if (!RB_EMPTY(altnames_head, &ifp->altnames)) {
+		json_object *json_altnames = json_object_new_array();
+		struct altname *altname;
+
+		RB_FOREACH (altname, altnames_head, &ifp->altnames)
+			json_object_array_add(json_altnames, json_object_new_string(altname->name));
+
+		json_object_object_add(json_if, "altNames", json_altnames);
 	}
 
 	/* Bandwidth in Mbps */

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -13,6 +13,7 @@
 #include "lib/libfrr.h"
 #include "lib/debug.h"
 #include "lib/lib_errors.h"
+#include "lib/if.h"
 #include "lib/frratomic.h"
 #include "lib/frr_pthread.h"
 #include "lib/memory.h"
@@ -36,6 +37,7 @@ DEFINE_MTYPE_STATIC(ZEBRA, DP_INTF, "Zebra DPlane Intf");
 DEFINE_MTYPE_STATIC(ZEBRA, DP_PROV, "Zebra DPlane Provider");
 DEFINE_MTYPE_STATIC(ZEBRA, DP_NETFILTER, "Zebra Netfilter Internal Object");
 DEFINE_MTYPE_STATIC(ZEBRA, DP_NS, "DPlane NSes");
+DEFINE_MTYPE_STATIC(ZEBRA, ZEBRA_ALTNAME, "Altname");
 
 DEFINE_MTYPE(ZEBRA, VLAN_CHANGE_ARR, "Vlan Change Array");
 
@@ -242,6 +244,9 @@ struct dplane_intf_info {
 	bool protodown;
 	bool protodown_set;
 	bool pd_reason_val;
+
+	/* Altnames for this interface */
+	struct altnames_dplane_head altnames;
 
 #define DPLANE_INTF_CONNECTED   (1 << 0) /* Connected peer, p2p */
 #define DPLANE_INTF_SECONDARY   (1 << 1)
@@ -750,6 +755,8 @@ void dplane_enable_sys_route_notifs(void)
 static void dplane_ctx_free_internal(struct zebra_dplane_ctx *ctx)
 {
 	struct dplane_intf_extra *if_extra;
+	struct altname *item;
+	struct altname *delete_item;
 
 	/*
 	 * Some internal allocations may need to be freed, depending on
@@ -900,8 +907,20 @@ static void dplane_ctx_free_internal(struct zebra_dplane_ctx *ctx)
 			XFREE(MTYPE_TMP, ctx->u.intf.vniarray);
 		if (ctx->u.intf.bvarray)
 			XFREE(MTYPE_TMP, ctx->u.intf.bvarray);
+
+		while (altnames_dplane_count(&ctx->u.intf.altnames) != 0) {
+			item = altnames_dplane_pop(&ctx->u.intf.altnames);
+			XFREE(MTYPE_ZEBRA_ALTNAME, item);
+		}
+		altnames_dplane_fini(&ctx->u.intf.altnames);
 		break;
 	case DPLANE_OP_INTF_DELETE:
+		while (altnames_dplane_count(&ctx->u.intf.altnames) != 0) {
+			delete_item = altnames_dplane_pop(&ctx->u.intf.altnames);
+			XFREE(MTYPE_ZEBRA_ALTNAME, delete_item);
+		}
+		altnames_dplane_fini(&ctx->u.intf.altnames);
+		break;
 	case DPLANE_OP_TC_QDISC_INSTALL:
 	case DPLANE_OP_TC_QDISC_UNINSTALL:
 	case DPLANE_OP_TC_CLASS_ADD:
@@ -1383,6 +1402,32 @@ dplane_ctx_get_ifp_bridge_vlan_info_array(const struct zebra_dplane_ctx *ctx)
 	DPLANE_CTX_VALID(ctx);
 
 	return ctx->u.intf.bvarray;
+}
+
+void dplane_ctx_set_ifp_altnames(struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	altnames_dplane_init(&ctx->u.intf.altnames);
+}
+
+void dplane_ctx_add_ifp_altname(struct zebra_dplane_ctx *ctx, const char *altname)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	struct altname *to_insert;
+
+	to_insert = XCALLOC(MTYPE_ZEBRA_ALTNAME, sizeof(*to_insert));
+	strlcpy(to_insert->name, altname, sizeof(to_insert->name));
+
+	altnames_dplane_add_tail(&ctx->u.intf.altnames, to_insert);
+}
+
+struct altnames_dplane_head dplane_ctx_get_ifp_altnames(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.intf.altnames;
 }
 
 void dplane_ctx_set_ifp_vxlan_vni_array(struct zebra_dplane_ctx *ctx,

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -481,6 +481,13 @@ void dplane_ctx_set_ifp_bridge_vlan_info_array(
 const struct zebra_dplane_bridge_vlan_info_array *
 dplane_ctx_get_ifp_bridge_vlan_info_array(const struct zebra_dplane_ctx *ctx);
 
+/* Interface alternative names */
+DECLARE_LIST(altnames_dplane, struct altname, list_entry);
+
+void dplane_ctx_set_ifp_altnames(struct zebra_dplane_ctx *ctx);
+void dplane_ctx_add_ifp_altname(struct zebra_dplane_ctx *ctx, const char *altname);
+struct altnames_dplane_head dplane_ctx_get_ifp_altnames(const struct zebra_dplane_ctx *ctx);
+
 /* Retrieve last/current provider id */
 uint32_t dplane_ctx_get_provider(const struct zebra_dplane_ctx *ctx);
 

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -145,6 +145,8 @@ struct interface *zebra_ns_lookup_ifp_name(struct zebra_ns *zns, const char *ifn
 static int lookup_ifp_name_cb(struct interface *ifp, void *arg)
 {
 	struct ifp_name_ctx *pctx = arg;
+	struct altname altname;
+	struct altname *result;
 
 	if (strcmp(ifp->name, pctx->ifname) == 0) {
 		pctx->ifp = ifp;

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -142,15 +142,30 @@ struct interface *zebra_ns_lookup_ifp_name(struct zebra_ns *zns, const char *ifn
 	return ctx.ifp;
 }
 
+/* Callback function to lookup interface by name (or altname if ENABLE_TRANSPARENT_ALTNAMES is enabled) */
 static int lookup_ifp_name_cb(struct interface *ifp, void *arg)
 {
 	struct ifp_name_ctx *pctx = arg;
-	struct altname altname;
-	struct altname *result;
 
+	/* Check primary name first */
 	if (strcmp(ifp->name, pctx->ifname) == 0) {
 		pctx->ifp = ifp;
 		return NS_WALK_STOP;
+	}
+
+	/* Check altnames */
+	if (ENABLE_TRANSPARENT_ALTNAMES) {
+		struct altname altname;
+		struct altname *result;
+
+		strlcpy(altname.name, pctx->ifname, sizeof(altname.name));
+
+		result = RB_FIND(altnames_head, &ifp->altnames, &altname);
+
+		if (result != NULL) {
+			pctx->ifp = ifp;
+			return NS_WALK_STOP;
+		}
 	}
 
 	return NS_WALK_CONTINUE;


### PR DESCRIPTION
The linux kernel added interface altnames a few years back: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=7a56493f0620.

Now each interface can have multiple altnames, and all these names, including the primary ones, must be unique. While the normal interface names are limited to 16 bytes, altnames can be up to 128 bytes long.

This update allows FRR to configure interfaces using these altnames. Zebra uses a red-black tree (RB tree) to store interfaces, which allows for quick lookups using the primary interface name. However, with the addition of altnames, this method isn't sufficient because we now have extra names for each interface.

To handle this, the system first checks for the primary name by quickly traversing the RB tree. If no primary name matches, it then goes through all interfaces one by one to check for matching altnames. This way, we maintain efficiency while support altnames.

Fixes: #6786