### PR TITLE
tools: add KeepEmptyLinesAtEOF to clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -161,6 +161,7 @@ IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLinesAtEOF: true
 MacroBlockBegin: ''
 MacroBlockEnd: ''
 ## Linux: MaxEmptyLinesToKeep: 1


### PR DESCRIPTION
Looks like there's a clang-format control to keep terminal newlines; add that to our .clang-format