### PR TITLE
tests: Increase timeout for any test that uses the @retry mechanism

### DIFF
--- a/tests/topotests/bgp_tcp_ip_transparent/test_bgp_tcp_ip_transparent.py
+++ b/tests/topotests/bgp_tcp_ip_transparent/test_bgp_tcp_ip_transparent.py
@@ -139,7 +139,7 @@ def teardown_module(mod):
     logger.info("=" * 40)
 
 
-@retry(retry_timeout=8)
+@retry(retry_timeout=30)
 def verify_bgp_transparent(tgen, topo=None, dut=None):
 
     if topo is None:

--- a/tests/topotests/example_munet/test_munet.py
+++ b/tests/topotests/example_munet/test_munet.py
@@ -8,7 +8,7 @@
 from munet.testing.util import retry
 
 
-@retry(retry_timeout=10)
+@retry(retry_timeout=15)
 def wait_for_route(r, p):
     o = r.cmd_raises(f"ip route show {p}")
     assert p in o

--- a/tests/topotests/isis_topo1/test_isis_topo1.py
+++ b/tests/topotests/isis_topo1/test_isis_topo1.py
@@ -760,7 +760,7 @@ def _check_isis_neighbor_exist(self, neighbor):
     )
 
 
-@retry(retry_timeout=5)
+@retry(retry_timeout=30)
 def _check_isis_neighbor_state(self, neighbor, neighbor_state_expected):
     tgen = get_topogen()
     router = tgen.gears[self]
@@ -784,7 +784,7 @@ def _check_isis_neighbor_state(self, neighbor, neighbor_state_expected):
     )
 
 
-@retry(retry_timeout=10)
+@retry(retry_timeout=30)
 def check_last_iih_packet_for_padding(router, expect_padding):
     logfilename = "{}/{}".format(router.gearlogdir, "isisd.log")
     last_hello_packet_line = None
@@ -819,7 +819,7 @@ def check_last_iih_packet_for_padding(router, expect_padding):
     )
 
 
-@retry(retry_timeout=5)
+@retry(retry_timeout=30)
 def check_advertised_prefixes(router, lsp_id, expected_prefixes):
     output = router.vtysh_cmd("show isis database detail {}".format(lsp_id))
     prefixes = set(re.findall(r"IP(?:v6)? Reachability: (.*) \(Metric: 10\)", output))

--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -1261,7 +1261,7 @@ def modify_bgp_config_when_bgpd_down(tgen, topo, input_dict):
 #############################################
 # Verification APIs
 #############################################
-@retry(retry_timeout=8)
+@retry(retry_timeout=30)
 def verify_router_id(tgen, topo, input_dict, expected=True):
     """
     Running command "show ip bgp json" for DUT and reading router-id
@@ -1705,7 +1705,7 @@ def modify_as_number(tgen, topo, input_dict):
     return result
 
 
-@retry(retry_timeout=8)
+@retry(retry_timeout=30)
 def verify_as_numbers(tgen, topo, input_dict, expected=True):
     """
     This API is to verify AS numbers for given DUT by running
@@ -2516,7 +2516,7 @@ def verify_bgp_attributes(
     return True
 
 
-@retry(retry_timeout=8)
+@retry(retry_timeout=30)
 def verify_best_path_as_per_bgp_attribute(
     tgen, addr_type, router, input_dict, attribute, expected=True
 ):
@@ -2722,7 +2722,7 @@ def verify_best_path_as_per_bgp_attribute(
     return True
 
 
-@retry(retry_timeout=10)
+@retry(retry_timeout=30)
 def verify_best_path_as_per_admin_distance(
     tgen, addr_type, router, input_dict, attribute, expected=True, vrf=None
 ):
@@ -3155,7 +3155,7 @@ def verify_bgp_rib(
     return True
 
 
-@retry(retry_timeout=10)
+@retry(retry_timeout=30)
 def verify_graceful_restart(
     tgen, topo, addr_type, input_dict, dut, peer, expected=True
 ):
@@ -3454,7 +3454,7 @@ def verify_graceful_restart(
     return True
 
 
-@retry(retry_timeout=10)
+@retry(retry_timeout=30)
 def verify_r_bit(tgen, topo, addr_type, input_dict, dut, peer, expected=True):
     """
     This API is to verify r_bit in the BGP gr capability advertised
@@ -3574,7 +3574,7 @@ def verify_r_bit(tgen, topo, addr_type, input_dict, dut, peer, expected=True):
     return True
 
 
-@retry(retry_timeout=10)
+@retry(retry_timeout=30)
 def verify_eor(tgen, topo, addr_type, input_dict, dut, peer, expected=True):
     """
     This API is to verify EOR
@@ -3736,7 +3736,7 @@ def verify_eor(tgen, topo, addr_type, input_dict, dut, peer, expected=True):
     return True
 
 
-@retry(retry_timeout=8)
+@retry(retry_timeout=30)
 def verify_f_bit(tgen, topo, addr_type, input_dict, dut, peer, expected=True):
     """
     This API is to verify f_bit in the BGP gr capability advertised
@@ -3877,7 +3877,7 @@ def verify_f_bit(tgen, topo, addr_type, input_dict, dut, peer, expected=True):
     return True
 
 
-@retry(retry_timeout=10)
+@retry(retry_timeout=30)
 def verify_graceful_restart_timers(tgen, topo, addr_type, input_dict, dut, peer):
     """
     This API is to verify graceful restart timers, configured and received
@@ -4004,7 +4004,7 @@ def verify_graceful_restart_timers(tgen, topo, addr_type, input_dict, dut, peer)
     return True
 
 
-@retry(retry_timeout=8)
+@retry(retry_timeout=30)
 def verify_gr_address_family(
     tgen, topo, addr_type, addr_family, dut, peer, expected=True
 ):
@@ -4501,7 +4501,7 @@ def verify_attributes_for_evpn_routes(
     return False
 
 
-@retry(retry_timeout=10)
+@retry(retry_timeout=30)
 def verify_evpn_routes(
     tgen, topo, dut, input_dict, routeType=5, EthTag=0, next_hop=None, expected=True
 ):
@@ -4648,7 +4648,7 @@ def verify_evpn_routes(
     return False
 
 
-@retry(retry_timeout=10)
+@retry(retry_timeout=30)
 def verify_bgp_bestpath(tgen, addr_type, input_dict):
     """
     Verifies bgp next hop values in best-path output
@@ -4903,7 +4903,7 @@ def get_prefix_count_route(
             logger.error("ERROR...! Unknown dut {} in topolgy".format(dut))
 
 
-@retry(retry_timeout=5)
+@retry(retry_timeout=30)
 def verify_rib_default_route(
     tgen,
     topo,
@@ -5255,7 +5255,7 @@ def verify_rib_default_route(
         return False
 
 
-@retry(retry_timeout=5)
+@retry(retry_timeout=30)
 def verify_fib_default_route(tgen, topo, dut, routes, expected_nexthop):
     """
     API to verify the the 'Default route" in FIB
@@ -5339,7 +5339,7 @@ def verify_fib_default_route(tgen, topo, dut, routes, expected_nexthop):
         return False
 
 
-@retry(retry_timeout=5)
+@retry(retry_timeout=30)
 def verify_bgp_advertised_routes_from_neighbor(tgen, topo, dut, peer, expected_routes):
     """
     APi is verifies the the routes that are advertised from dut to peer
@@ -5475,7 +5475,7 @@ def verify_bgp_advertised_routes_from_neighbor(tgen, topo, dut, peer, expected_r
         return False
 
 
-@retry(retry_timeout=5)
+@retry(retry_timeout=30)
 def verify_bgp_received_routes_from_neighbor(tgen, topo, dut, peer, expected_routes):
     """
     API to verify the bgp received routes

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -1940,7 +1940,7 @@ def verify_ospf6_rib(
     return result
 
 
-@retry(retry_timeout=6)
+@retry(retry_timeout=30)
 def verify_ospf6_interface(tgen, topo=None, dut=None, lan=False, input_dict=None):
     """
     This API is to verify ospf routes by running

--- a/tests/topotests/log_config/basic.py
+++ b/tests/topotests/log_config/basic.py
@@ -69,7 +69,7 @@ def _update_snaps(logs):
         log.last_snap_mark = len(log.content)
 
 
-@retry(retry_timeout=8, retry_sleep=0.1)
+@retry(retry_timeout=30, retry_sleep=0.1)
 def scan_log(logs, regex):
     """Scan the WatchLog `log` for a regex match."""
     # Get latest content since last snapshot for all logs

--- a/tests/topotests/mgmt_debug_flags/test_debug.py
+++ b/tests/topotests/mgmt_debug_flags/test_debug.py
@@ -51,7 +51,7 @@ def test_client_debug_enable(tgen):
     def __test_debug(r1, on):
         time.sleep(1)
 
-        @retry(retry_timeout=10, retry_sleep=0.25)
+        @retry(retry_timeout=30, retry_sleep=0.25)
         def __scan_log(log, items):
             log.update_content()
             content = log.from_mark(log.last_snap_mark)

--- a/tests/topotests/mgmt_rpc/test_rpc.py
+++ b/tests/topotests/mgmt_rpc/test_rpc.py
@@ -42,7 +42,7 @@ def tgen(request):
 
 
 # Verify the backend test client has connected
-@retry(retry_timeout=10)
+@retry(retry_timeout=30)
 def check_client_connect(r1):
     out = r1.vtysh_cmd("show mgmt backend-adapter all")
     assert "mgmtd-testc" in out

--- a/tests/topotests/mgmt_startup/util.py
+++ b/tests/topotests/mgmt_startup/util.py
@@ -22,7 +22,7 @@ def check_vtysh_up(router):
     return None if not rc else proc_error(rc, o, e)
 
 
-@retry(retry_timeout=3, initial_wait=0.1)
+@retry(retry_timeout=30, initial_wait=0.1)
 def check_kernel(r1, prefix, expected=True):
     net = ipaddress.ip_network(prefix)
     if net.version == 6:

--- a/tests/topotests/nhrp_topo/test_nhrp_topo.py
+++ b/tests/topotests/nhrp_topo/test_nhrp_topo.py
@@ -370,7 +370,7 @@ def test_route_install():
 # here we are testing that all of the expected
 # retries are sent and logged before a
 # shortcut is purged
-@retry(retry_timeout=10, initial_wait=30)
+@retry(retry_timeout=30, initial_wait=30)
 def check_retry_debug_info(pingspoke=None):
     tgen = get_topogen()
     r1 = tgen.gears["r1"]
@@ -391,7 +391,7 @@ def check_retry_debug_info(pingspoke=None):
 # you are expecting to find a complete shortcut
 # (True) or incomplete shortcut (False) as a
 # result of the ping
-@retry(retry_timeout=10, initial_wait=10)
+@retry(retry_timeout=30, initial_wait=10)
 def create_shortcut(expect_successful_shortcut=True, pingspoke=None, peer_addr=None):
     tgen = get_topogen()
     r1 = tgen.gears["r1"]

--- a/tests/topotests/send_log/test_send_log.py
+++ b/tests/topotests/send_log/test_send_log.py
@@ -33,7 +33,7 @@ def tgen(request):
     tgen.stop_topology()
 
 
-@retry(retry_timeout=10)
+@retry(retry_timeout=30)
 def scan_log(log, regex):
     log.update_content()
     new_content = log.from_mark(log.last_snap_mark)

--- a/tests/topotests/static_vrf/test_static_vrf.py
+++ b/tests/topotests/static_vrf/test_static_vrf.py
@@ -44,7 +44,7 @@ def tgen(request):
     tgen.stop_topology()
 
 
-@retry(retry_timeout=1, initial_wait=0.1)
+@retry(retry_timeout=30, initial_wait=0.1)
 def check_kernel(r1, prefix, nexthops, vrf, expected_p=True, expected_nh=True):
     vrfstr = f" vrf {vrf}" if vrf else ""
 

--- a/tests/topotests/zebra_received_nhe_kept/test_zebra_received_nhe_kept.py
+++ b/tests/topotests/zebra_received_nhe_kept/test_zebra_received_nhe_kept.py
@@ -65,7 +65,7 @@ def test_zebra_received_nhe_kept():
 
     r1 = tgen.gears["r1"]
 
-    @retry(retry_timeout=10, retry_sleep=0.25)
+    @retry(retry_timeout=30, retry_sleep=0.25)
     def _check_zebra_routes():
         # Get the route information
         route_info = r1.vtysh_cmd("show ip route json")


### PR DESCRIPTION
Test is showing this on failure in the logs:

2025-07-09 11:28:15,614  INFO: topo: Function raised exception: "AssertionError("Failed to find \n  '192.0.2.130'\n   in \n  '198.51.100.1 nhid 25 via 192.0.2.2 dev r1-eth0 proto 196 metric 20 \n  '\nassert '192.0.2.130' in '198.51.100.1 nhid 25 via 192.0.2.2 dev r1-eth0 proto 196 metric 20 \\n'")"
2025-07-09 11:28:15,614  INFO: topo: Retry timeout of 1s reached
2025-07-09 11:28:15,615  INFO: topo: Spawn collection of support bundle for r1
2025-07-09 11:28:15,615 DEBUG: r1: cmd_status("/bin/bash -c 'mkdir -p /tmp/topotests/static_vrf.test_static_vrf/worker-logs/gw4/r1/support_bundles/test_static_vrf'")
2025-07-09 11:28:15,618 DEBUG: r1: popen("/usr/lib/frr/generate_support_bundle.py --log-dir=/tmp/topotests/static_vrf.test_static_vrf/worker-logs/gw4/r1/support_bundles/test_static_vrf")
2025-07-09 11:28:15,618 DEBUG: topo: Waiting on support bundle for r1
2025-07-09 11:28:15,666 DEBUG: topo: RETRY DIAG: [failure] Sleeping 2s until next retry with -0.7 retry time left - too see if timeout was too short
2025-07-09 11:28:17,670 DEBUG: r1: cmd_status("/bin/bash -c 'ip -4 route show 198.51.100.1'")
2025-07-09 11:28:17,911 DEBUG: r1:
        stdout: 198.51.100.1 nhid 40 proto 196 metric 20...
2025-07-09 11:28:17,912 DEBUG: topo: Function returned None
2025-07-09 11:28:17,912  WARN: topo: RETRY DIAGNOSTIC: SUCCEED after FAILED with requested timeout of 1.0s; however, succeeded in 4.9s, investigate timeout timing

This code is giving only 1 second after a configuration change to have it reflected.  Heavy load makes this hard to do sometimes.  Give it more grace.