### PR TITLE
bgpd: remove duplicated gr timer value

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -13676,11 +13676,6 @@ static void bgp_show_neighbor_graceful_restart_time(struct vty *vty,
 			vty_out(vty, "      Restart Time Remaining(sec): %ld\n",
 				event_timer_remain_second(
 					p->connection->t_gr_restart));
-		if (p->connection->t_gr_restart != NULL) {
-			vty_out(vty, "      Restart Time Remaining(sec): %ld\n",
-				event_timer_remain_second(
-					p->connection->t_gr_restart));
-		}
 	}
 }
 


### PR DESCRIPTION
Remove a duplicated GR timer value from a show command - looks like we had two of the same value?