### PR TITLE
pim6d: fix wrong residual entry

### DIFF
--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -623,6 +623,7 @@ static bool gm_packet_sg_drop(struct gm_packet_sg *item)
 			continue;
 
 		gm_packet_sg_subs_del(excl_item->sg->subs_negative, excl_item);
+		gm_sg_update(excl_item->sg, true);
 		excl_item->sg = NULL;
 		pkt->n_active--;
 


### PR DESCRIPTION
A few entries are created for EXCLUDE record: <Sx,G> (x=1, 2, 3, ...) and <*,G>. <*,G> can be expired, but <Sx,G> can't. Just let <Sx,G> expired as expected.

```
anlan# show ipv6 mld joins
ff99::99                        *                               JOIN                00:00:01           -    00:00:01 <- Can be expired
ff99::99                        2001::99                        PRUNE                      -           -    00:00:01 <- Can't be expired
```