### PR TITLE
tools: revert "tools: add KeepEmptyLinesAtEOF to clang-format"

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -161,7 +161,6 @@ IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
-KeepEmptyLinesAtEOF: true
 MacroBlockBegin: ''
 MacroBlockEnd: ''
 ## Linux: MaxEmptyLinesToKeep: 1


### PR DESCRIPTION
Looks like yesterday's clang-format change isn't as compatible as I hoped. clang fails for unknown configs, and it sounds like there are still widely-used versions of clang that don't support this config option.

This reverts commit 2d6e66689197f5ff4272ed13ba61c11bccb4f9f8.