### PR TITLE
Ospf6 json output fix

### DIFF
--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -1100,6 +1100,7 @@ void ospf6_route_show(struct vty *vty, struct ospf6_route *route,
 	json_object *json_route = NULL;
 	json_object *json_array_next_hops = NULL;
 	json_object *json_next_hop;
+	json_object *json_routes_array = NULL;
 	vrf_id_t vrf_id = route->ospf6->vrf_id;
 
 	monotime(&now);
@@ -1167,7 +1168,17 @@ void ospf6_route_show(struct vty *vty, struct ospf6_route *route,
 	if (use_json) {
 		json_object_object_add(json_route, "nextHops",
 				       json_array_next_hops);
-		json_object_object_add(json_routes, destination, json_route);
+
+		/* Check if we already have an array for this destination */
+		json_routes_array = json_object_object_get(json_routes, destination);
+		if (json_routes_array == NULL) {
+			/* First route for this destination, create new array */
+			json_routes_array = json_object_new_array();
+			json_object_object_add(json_routes, destination, json_routes_array);
+		}
+
+		/* Add this route to the array */
+		json_object_array_add(json_routes_array, json_route);
 	}
 }
 
@@ -1185,6 +1196,7 @@ void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route,
 	json_object *json_route = NULL;
 	json_object *json_array_next_hops = NULL;
 	json_object *json_next_hop;
+	json_object *json_routes_array = NULL;
 	vrf_id_t vrf_id = route->ospf6->vrf_id;
 
 	monotime(&now);
@@ -1355,7 +1367,17 @@ void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route,
 	if (use_json) {
 		json_object_object_add(json_route, "nextHops",
 				       json_array_next_hops);
-		json_object_object_add(json_routes, destination, json_route);
+
+		/* Check if we already have an array for this destination */
+		json_routes_array = json_object_object_get(json_routes, destination);
+		if (json_routes_array == NULL) {
+			/* First route for this destination, create new array */
+			json_routes_array = json_object_new_array();
+			json_object_object_add(json_routes, destination, json_routes_array);
+		}
+
+		/* Add this route to the array */
+		json_object_array_add(json_routes_array, json_route);
 	} else
 		vty_out(vty, "\n");
 }

--- a/tests/topotests/lib/ospf.py
+++ b/tests/topotests/lib/ospf.py
@@ -1771,23 +1771,30 @@ def verify_ospf6_rib(
                             st_found = True
                             found_routes.append(st_rt)
 
+                            # Get the route data - now it's an array, so get the first element
+                            route_data = ospf_rib_json[st_rt]
+                            if isinstance(route_data, list) and len(route_data) > 0:
+                                route_data = route_data[0]
+
                             if fib and next_hop:
                                 if type(next_hop) is not list:
                                     next_hop = [next_hop]
 
-                                for mnh in range(0, len(ospf_rib_json[st_rt])):
-                                    if (
-                                        "fib"
-                                        in ospf_rib_json[st_rt][mnh]["nextHops"][0]
-                                    ):
-                                        found_hops.append(
-                                            [
-                                                rib_r["ip"]
-                                                for rib_r in ospf_rib_json[st_rt][mnh][
-                                                    "nextHops"
+                                # Handle the case where ospf_rib_json[st_rt] is now an array
+                                if isinstance(ospf_rib_json[st_rt], list):
+                                    for mnh in range(0, len(ospf_rib_json[st_rt])):
+                                        if (
+                                            "fib"
+                                            in ospf_rib_json[st_rt][mnh]["nextHops"][0]
+                                        ):
+                                            found_hops.append(
+                                                [
+                                                    rib_r["ip"]
+                                                    for rib_r in ospf_rib_json[st_rt][
+                                                        mnh
+                                                    ]["nextHops"]
                                                 ]
-                                            ]
-                                        )
+                                            )
 
                                 if found_hops[0]:
                                     missing_list_of_nexthops = set(
@@ -1822,10 +1829,13 @@ def verify_ospf6_rib(
                             elif next_hop and fib is None:
                                 if type(next_hop) is not list:
                                     next_hop = [next_hop]
-                                found_hops = [
-                                    rib_r["nextHop"]
-                                    for rib_r in ospf_rib_json[st_rt]["nextHops"]
-                                ]
+
+                                # Handle the case where ospf_rib_json[st_rt] is now an array
+                                if isinstance(ospf_rib_json[st_rt], list):
+                                    found_hops = [
+                                        rib_r["nextHop"]
+                                        for rib_r in ospf_rib_json[st_rt][0]["nextHops"]
+                                    ]
 
                                 if found_hops:
                                     missing_list_of_nexthops = set(
@@ -1854,13 +1864,13 @@ def verify_ospf6_rib(
                                     else:
                                         nh_found = True
                             if _rtype:
-                                if "destinationType" not in ospf_rib_json[st_rt]:
+                                if "destinationType" not in route_data:
                                     errormsg = (
                                         "[DUT: {}]: destinationType missing"
                                         "for route {} in OSPF RIB \n".format(dut, st_rt)
                                     )
                                     return errormsg
-                                elif _rtype != ospf_rib_json[st_rt]["destinationType"]:
+                                elif _rtype != route_data["destinationType"]:
                                     errormsg = (
                                         "[DUT: {}]: destinationType mismatch"
                                         "for route {} in OSPF RIB \n".format(dut, st_rt)
@@ -1872,7 +1882,7 @@ def verify_ospf6_rib(
                                         "for route {}".format(dut, _rtype, st_rt)
                                     )
                             if tag:
-                                if "tag" not in ospf_rib_json[st_rt]:
+                                if "tag" not in route_data:
                                     errormsg = (
                                         "[DUT: {}]: tag is not"
                                         " present for"
@@ -1880,7 +1890,7 @@ def verify_ospf6_rib(
                                     )
                                     return errormsg
 
-                                if _tag != ospf_rib_json[st_rt]["tag"]:
+                                if _tag != route_data["tag"]:
                                     errormsg = (
                                         "[DUT: {}]: tag value {}"
                                         " is not matched for"
@@ -1893,7 +1903,7 @@ def verify_ospf6_rib(
                                     return errormsg
 
                             if metric is not None:
-                                if "metricCostE2" not in ospf_rib_json[st_rt]:
+                                if "metricCostE2" not in route_data:
                                     errormsg = (
                                         "[DUT: {}]: metric is"
                                         " not present for"
@@ -1901,7 +1911,7 @@ def verify_ospf6_rib(
                                     )
                                     return errormsg
 
-                                if metric != ospf_rib_json[st_rt]["metricCostE2"]:
+                                if metric != route_data["metricCostE2"]:
                                     errormsg = (
                                         "[DUT: {}]: metric value "
                                         "{} is not matched for "

--- a/tests/topotests/ospf6_gr_topo1/rt1/show_ipv6_ospf_route.json
+++ b/tests/topotests/ospf6_gr_topo1/rt1/show_ipv6_ospf_route.json
@@ -1,6 +1,6 @@
 {
   "routes":{
-    "2001:db8:1000::1\/128":{
+    "2001:db8:1000::1\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -9,8 +9,8 @@
           "interfaceName":"lo"
         }
       ]
-    },
-    "2001:db8:1000::2\/128":{
+    }],
+    "2001:db8:1000::2\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -19,8 +19,8 @@
           "interfaceName":"eth-rt2"
         }
       ]
-    },
-    "2001:db8:1000::3\/128":{
+    }],
+    "2001:db8:1000::3\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -29,8 +29,8 @@
           "interfaceName":"eth-rt2"
         }
       ]
-    },
-    "2001:db8:1000::4\/128":{
+    }],
+    "2001:db8:1000::4\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -39,8 +39,8 @@
           "interfaceName":"eth-rt2"
         }
       ]
-    },
-    "2001:db8:1000::5\/128":{
+    }],
+    "2001:db8:1000::5\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -49,8 +49,8 @@
           "interfaceName":"eth-rt2"
         }
       ]
-    },
-    "2001:db8:1000::6\/128":{
+    }],
+    "2001:db8:1000::6\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -59,8 +59,8 @@
           "interfaceName":"eth-rt2"
         }
       ]
-    },
-    "2001:db8:1000::7\/128":{
+    }],
+    "2001:db8:1000::7\/128":[{
       "isBestRoute":false,
       "destinationType":"N",
       "pathType":"E2",
@@ -69,6 +69,6 @@
           "interfaceName":"eth-rt2"
         }
       ]
-    }
+    }]
   }
 }

--- a/tests/topotests/ospf6_gr_topo1/rt2/show_ipv6_ospf_route.json
+++ b/tests/topotests/ospf6_gr_topo1/rt2/show_ipv6_ospf_route.json
@@ -1,6 +1,6 @@
 {
   "routes":{
-    "2001:db8:1000::1\/128":{
+    "2001:db8:1000::1\/128":[{
       "isBestRoute":false,
       "destinationType":"N",
       "pathType":"E2",
@@ -9,8 +9,8 @@
           "interfaceName":"eth-rt1"
         }
       ]
-    },
-    "2001:db8:1000::2\/128":{
+    }],
+    "2001:db8:1000::2\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -19,8 +19,8 @@
           "interfaceName":"lo"
         }
       ]
-    },
-    "2001:db8:1000::3\/128":{
+    }],
+    "2001:db8:1000::3\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -29,8 +29,8 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    },
-    "2001:db8:1000::4\/128":{
+    }],
+    "2001:db8:1000::4\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -39,8 +39,8 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    },
-    "2001:db8:1000::5\/128":{
+    }],
+    "2001:db8:1000::5\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -49,8 +49,8 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    },
-    "2001:db8:1000::6\/128":{
+    }],
+    "2001:db8:1000::6\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -59,8 +59,8 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    },
-    "2001:db8:1000::7\/128":{
+    }],
+    "2001:db8:1000::7\/128":[{
       "isBestRoute":false,
       "destinationType":"N",
       "pathType":"E2",
@@ -69,6 +69,6 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    }
+    }]
   }
 }

--- a/tests/topotests/ospf6_gr_topo1/rt3/show_ipv6_ospf_route.json
+++ b/tests/topotests/ospf6_gr_topo1/rt3/show_ipv6_ospf_route.json
@@ -1,6 +1,6 @@
 {
   "routes":{
-    "2001:db8:1000::1\/128":{
+    "2001:db8:1000::1\/128":[{
       "isBestRoute":false,
       "destinationType":"N",
       "pathType":"E2",
@@ -9,8 +9,8 @@
           "interfaceName":"eth-rt2"
         }
       ]
-    },
-    "2001:db8:1000::2\/128":{
+    }],
+    "2001:db8:1000::2\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -19,8 +19,8 @@
           "interfaceName":"eth-rt2"
         }
       ]
-    },
-    "2001:db8:1000::3\/128":{
+    }],
+    "2001:db8:1000::3\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -29,8 +29,8 @@
           "interfaceName":"lo"
         }
       ]
-    },
-    "2001:db8:1000::4\/128":{
+    }],
+    "2001:db8:1000::4\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -39,8 +39,8 @@
           "interfaceName":"eth-rt4"
         }
       ]
-    },
-    "2001:db8:1000::5\/128":{
+    }],
+    "2001:db8:1000::5\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -49,8 +49,8 @@
           "interfaceName":"eth-rt4"
         }
       ]
-    },
-    "2001:db8:1000::6\/128":{
+    }],
+    "2001:db8:1000::6\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -59,8 +59,8 @@
           "interfaceName":"eth-rt6"
         }
       ]
-    },
-    "2001:db8:1000::7\/128":{
+    }],
+    "2001:db8:1000::7\/128":[{
       "isBestRoute":false,
       "destinationType":"N",
       "pathType":"E2",
@@ -69,6 +69,6 @@
           "interfaceName":"eth-rt6"
         }
       ]
-    }
+    }]
   }
 }

--- a/tests/topotests/ospf6_gr_topo1/rt4/show_ipv6_ospf_route.json
+++ b/tests/topotests/ospf6_gr_topo1/rt4/show_ipv6_ospf_route.json
@@ -1,6 +1,6 @@
 {
   "routes":{
-    "2001:db8:1000::1\/128":{
+    "2001:db8:1000::1\/128":[{
       "isBestRoute":false,
       "destinationType":"N",
       "pathType":"E2",
@@ -9,8 +9,8 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    },
-    "2001:db8:1000::2\/128":{
+    }],
+    "2001:db8:1000::2\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -19,8 +19,8 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    },
-    "2001:db8:1000::3\/128":{
+    }],
+    "2001:db8:1000::3\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -29,8 +29,8 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    },
-    "2001:db8:1000::4\/128":{
+    }],
+    "2001:db8:1000::4\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -39,8 +39,8 @@
           "interfaceName":"lo"
         }
       ]
-    },
-    "2001:db8:1000::5\/128":{
+    }],
+    "2001:db8:1000::5\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -49,8 +49,8 @@
           "interfaceName":"eth-rt5"
         }
       ]
-    },
-    "2001:db8:1000::6\/128":{
+    }],
+    "2001:db8:1000::6\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -59,8 +59,8 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    },
-    "2001:db8:1000::7\/128":{
+    }],
+    "2001:db8:1000::7\/128":[{
       "isBestRoute":false,
       "destinationType":"N",
       "pathType":"E2",
@@ -69,6 +69,6 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    }
+    }]
   }
 }

--- a/tests/topotests/ospf6_gr_topo1/rt5/show_ipv6_ospf_route.json
+++ b/tests/topotests/ospf6_gr_topo1/rt5/show_ipv6_ospf_route.json
@@ -1,6 +1,6 @@
 {
   "routes":{
-    "2001:db8:1000::1\/128":{
+    "2001:db8:1000::1\/128":[{
       "isBestRoute":false,
       "destinationType":"N",
       "pathType":"E2",
@@ -9,8 +9,8 @@
           "interfaceName":"eth-rt4"
         }
       ]
-    },
-    "2001:db8:1000::2\/128":{
+    }],
+    "2001:db8:1000::2\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -19,8 +19,8 @@
           "interfaceName":"eth-rt4"
         }
       ]
-    },
-    "2001:db8:1000::3\/128":{
+    }],
+    "2001:db8:1000::3\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -29,8 +29,8 @@
           "interfaceName":"eth-rt4"
         }
       ]
-    },
-    "2001:db8:1000::4\/128":{
+    }],
+    "2001:db8:1000::4\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -39,8 +39,8 @@
           "interfaceName":"eth-rt4"
         }
       ]
-    },
-    "2001:db8:1000::5\/128":{
+    }],
+    "2001:db8:1000::5\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -49,8 +49,8 @@
           "interfaceName":"lo"
         }
       ]
-    },
-    "2001:db8:1000::6\/128":{
+    }],
+    "2001:db8:1000::6\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -59,8 +59,8 @@
           "interfaceName":"eth-rt4"
         }
       ]
-    },
-    "2001:db8:1000::7\/128":{
+    }],
+    "2001:db8:1000::7\/128":[{
       "isBestRoute":false,
       "destinationType":"N",
       "pathType":"E2",
@@ -69,6 +69,6 @@
           "interfaceName":"eth-rt4"
         }
       ]
-    }
+    }]
   }
 }

--- a/tests/topotests/ospf6_gr_topo1/rt6/show_ipv6_ospf_route.json
+++ b/tests/topotests/ospf6_gr_topo1/rt6/show_ipv6_ospf_route.json
@@ -1,6 +1,6 @@
 {
   "routes":{
-    "2001:db8:1000::1\/128":{
+    "2001:db8:1000::1\/128":[{
       "isBestRoute":false,
       "destinationType":"N",
       "pathType":"E2",
@@ -9,8 +9,8 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    },
-    "2001:db8:1000::2\/128":{
+    }],
+    "2001:db8:1000::2\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -19,8 +19,8 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    },
-    "2001:db8:1000::3\/128":{
+    }],
+    "2001:db8:1000::3\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -29,8 +29,8 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    },
-    "2001:db8:1000::4\/128":{
+    }],
+    "2001:db8:1000::4\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -39,8 +39,8 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    },
-    "2001:db8:1000::5\/128":{
+    }],
+    "2001:db8:1000::5\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -49,8 +49,8 @@
           "interfaceName":"eth-rt3"
         }
       ]
-    },
-    "2001:db8:1000::6\/128":{
+    }],
+    "2001:db8:1000::6\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -59,8 +59,8 @@
           "interfaceName":"lo"
         }
       ]
-    },
-    "2001:db8:1000::7\/128":{
+    }],
+    "2001:db8:1000::7\/128":[{
       "isBestRoute":false,
       "destinationType":"N",
       "pathType":"E2",
@@ -69,6 +69,6 @@
           "interfaceName":"eth-rt7"
         }
       ]
-    }
+    }]
   }
 }

--- a/tests/topotests/ospf6_gr_topo1/rt7/show_ipv6_ospf_route.json
+++ b/tests/topotests/ospf6_gr_topo1/rt7/show_ipv6_ospf_route.json
@@ -1,6 +1,6 @@
 {
   "routes":{
-    "2001:db8:1000::1\/128":{
+    "2001:db8:1000::1\/128":[{
       "isBestRoute":false,
       "destinationType":"N",
       "pathType":"E2",
@@ -9,8 +9,8 @@
           "interfaceName":"eth-rt6"
         }
       ]
-    },
-    "2001:db8:1000::2\/128":{
+    }],
+    "2001:db8:1000::2\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -19,8 +19,8 @@
           "interfaceName":"eth-rt6"
         }
       ]
-    },
-    "2001:db8:1000::3\/128":{
+    }],
+    "2001:db8:1000::3\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -29,8 +29,8 @@
           "interfaceName":"eth-rt6"
         }
       ]
-    },
-    "2001:db8:1000::4\/128":{
+    }],
+    "2001:db8:1000::4\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -39,8 +39,8 @@
           "interfaceName":"eth-rt6"
         }
       ]
-    },
-    "2001:db8:1000::5\/128":{
+    }],
+    "2001:db8:1000::5\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -49,8 +49,8 @@
           "interfaceName":"eth-rt6"
         }
       ]
-    },
-    "2001:db8:1000::6\/128":{
+    }],
+    "2001:db8:1000::6\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IE",
@@ -59,8 +59,8 @@
           "interfaceName":"eth-rt6"
         }
       ]
-    },
-    "2001:db8:1000::7\/128":{
+    }],
+    "2001:db8:1000::7\/128":[{
       "isBestRoute":true,
       "destinationType":"N",
       "pathType":"IA",
@@ -69,6 +69,6 @@
           "interfaceName":"lo"
         }
       ]
-    }
+    }]
   }
 }

--- a/tests/topotests/ospf6_gr_topo1/test_ospf6_gr_topo1.py
+++ b/tests/topotests/ospf6_gr_topo1/test_ospf6_gr_topo1.py
@@ -233,7 +233,7 @@ def check_routers(initial_convergence=False, exiting=None, restarting=None):
             if initial_convergence == True or restarting == rname:
                 tries = 120
             else:
-                tries = 15
+                tries = 20
             router_compare_json_output(
                 rname,
                 "show ipv6 ospf database json",

--- a/tests/topotests/ospf6_point_to_multipoint/test_ospf6_point_to_multipoint.py
+++ b/tests/topotests/ospf6_point_to_multipoint/test_ospf6_point_to_multipoint.py
@@ -76,7 +76,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.ospf6d]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf6_topo1/test_ospf6_topo1.py
+++ b/tests/topotests/ospf6_topo1/test_ospf6_topo1.py
@@ -76,7 +76,7 @@ from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.ospf6d]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospf6_topo1_vrf/test_ospf6_topo1_vrf.py
+++ b/tests/topotests/ospf6_topo1_vrf/test_ospf6_topo1_vrf.py
@@ -79,7 +79,7 @@ from lib.topotest import iproute2_is_vrf_capable
 from lib.common_config import required_linux_kernel_version
 
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.ospf6d]
 
 
 def build_topo(tgen):

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_asbr_summary_topo1.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_asbr_summary_topo1.py
@@ -52,7 +52,7 @@ from lib.ospf import (
     verify_ospf_summary,
 )
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.ospf6d, pytest.mark.staticd]
 
 # Global variables
 topo = None

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp.py
@@ -46,7 +46,7 @@ from lib.ospf import (
 )
 
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.ospf6d, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp_lan.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_ecmp_lan.py
@@ -45,7 +45,7 @@ from lib.ospf import (
 )
 
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.ospf6d, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa.py
@@ -23,7 +23,7 @@ sys.path.append(os.path.join(CWD, "../lib/"))
 
 # pylint: disable=C0413
 
-pytestmark = [pytest.mark.ospfd]
+pytestmark = [pytest.mark.ospf6d]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa2.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_nssa2.py
@@ -44,7 +44,7 @@ from lib.topojson import build_config_from_json
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.ospf6d, pytest.mark.staticd]
 
 # Global variables
 topo = None

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_routemaps.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_routemaps.py
@@ -46,7 +46,7 @@ from lib.ospf import (
 )
 
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.ospf6d, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_rte_calc.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_rte_calc.py
@@ -51,7 +51,7 @@ from lib.ospf import (
 )
 
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.ospf6d, pytest.mark.staticd]
 
 
 # Global variables

--- a/tests/topotests/ospfv3_basic_functionality/test_ospfv3_single_area.py
+++ b/tests/topotests/ospfv3_basic_functionality/test_ospfv3_single_area.py
@@ -51,7 +51,7 @@ from lib.ospf import (
 
 from ipaddress import IPv6Address
 
-pytestmark = [pytest.mark.ospfd, pytest.mark.staticd]
+pytestmark = [pytest.mark.ospf6d, pytest.mark.staticd]
 
 
 # Global variables


### PR DESCRIPTION
See individual commits but the problem boils down to the fact that the ospf6 `show ipv6 ospf6 route json` output is wrong and needs to be adjusted to an array.  This of course results in a decent number of test changes in order for the tests to continue to work.