### PR TITLE
lib: incremental vty output, restored

### DIFF
--- a/lib/vty.h
+++ b/lib/vty.h
@@ -43,6 +43,15 @@ struct vty_cfg_change {
 	const char *value;
 };
 
+/* Current vty status. */
+enum vty_status {
+	VTY_NORMAL,
+	VTY_CLOSE,
+	VTY_MORE,
+	VTY_MORELINE,
+	VTY_PASSFD,
+};
+
 PREDECL_DLIST(vtys);
 
 /* VTY struct. */
@@ -161,13 +170,7 @@ struct vty {
 	unsigned char escape;
 
 	/* Current vty status. */
-	enum {
-		VTY_NORMAL,
-		VTY_CLOSE,
-		VTY_MORE,
-		VTY_MORELINE,
-		VTY_PASSFD,
-	} status;
+	enum vty_status status;
 
 	/* vtysh socket/fd passing (for terminal monitor) */
 	int pass_fd;
@@ -228,6 +231,13 @@ struct vty {
 	uintptr_t mgmt_req_pending_data;
 	bool mgmt_locked_candidate_ds;
 	bool mgmt_locked_running_ds;
+	/* Incremental write/flush limit and current accumulator. When
+	 * producing large outputs, we try to avoid buffering the entire
+	 * output, sending incremental output periodically
+	 * as the application code produces it.
+	 */
+	size_t vty_buf_threshold;
+	size_t vty_buf_size_accum;
 };
 
 static inline void vty_push_context(struct vty *vty, int node, uint64_t id)
@@ -425,9 +435,16 @@ extern int vty_mgmt_send_rpc_req(struct vty *vty, LYD_FORMAT request_type,
 extern int vty_mgmt_send_lockds_req(struct vty *vty, enum mgmt_ds_id ds_id, bool lock, bool scok);
 extern void vty_mgmt_resume_response(struct vty *vty, int ret);
 
-static inline bool vty_needs_implicit_commit(struct vty *vty)
+static inline bool vty_needs_implicit_commit(const struct vty *vty)
 {
 	return frr_get_cli_mode() == FRR_CLI_CLASSIC && !vty->pending_allowed;
+}
+
+/* Applications can check vty status */
+static inline bool vty_is_closed(const struct vty *vty)
+{
+	return (vty == NULL || vty->status == VTY_CLOSE || vty->fd < 0 ||
+		vty->wfd < 0);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Send incremental results periodically, instead of buffering large vty output streams. 

This restores a version of the work done in commits from these two earlier PRs:

#16672  lib: Memory spike reduction for sh cmds at scale
9112fb367b1ae0168b4e7a81f41c2ca621979199

#17571  lib,vtysh: Use backoff setsockopt option for freebsd
959dbe27cde21ab212f6566b30865b2da418b4d2

That work was reverted by #19109  because error-handling during the incremental output flush, if the remote vtysh exited e.g., would lead to an application crash. This version tries to recognize that an error has occurred, but defer closing the application's vty object until after the application callback has completed and the vty is no longer being used.