### PR TITLE
lib,bgpd,ospf6d,zebra: Free json objects in error paths

### DIFF
--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -108,6 +108,7 @@ void bgp_capability_vty_out(struct vty *vty, struct peer *peer, bool use_json,
 	struct capability_mp_data mpc;
 	struct capability_header *hdr;
 	json_object *json_cap = NULL;
+	bool status_ok = true;
 
 	if (use_json)
 		json_cap = json_object_new_object();
@@ -116,12 +117,16 @@ void bgp_capability_vty_out(struct vty *vty, struct peer *peer, bool use_json,
 	end = pnt + peer->notify.length;
 
 	while (pnt < end) {
-		if (pnt + sizeof(struct capability_mp_data) + 2 > end)
-			return;
+		if (pnt + sizeof(struct capability_mp_data) + 2 > end) {
+			status_ok = false;
+			break;
+		}
 
 		hdr = (struct capability_header *)pnt;
-		if (pnt + hdr->length + 2 > end)
-			return;
+		if (pnt + hdr->length + 2 > end) {
+			status_ok = false;
+			break;
+		}
 
 		memcpy(&mpc, pnt + 2, sizeof(struct capability_mp_data));
 
@@ -283,9 +288,14 @@ void bgp_capability_vty_out(struct vty *vty, struct peer *peer, bool use_json,
 		}
 		pnt += hdr->length + 2;
 	}
-	if (use_json)
-		json_object_object_add(json_neigh, "capabilityErrors",
-				       json_cap);
+
+	if (status_ok) {
+		if (use_json)
+			json_object_object_add(json_neigh, "capabilityErrors",
+					       json_cap);
+	} else if (json_cap) {
+		json_object_free(json_cap);
+	}
 }
 
 static void bgp_capability_mp_data(struct stream *s,

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -1087,7 +1087,9 @@ static int vty_show_prefix_list(struct vty *vty, afi_t afi, const char *name,
 	if (name) {
 		plist = prefix_list_lookup(afi, name);
 		if (!plist) {
-			if (!uj)
+			if (uj)
+				json_object_free(json);
+			else
 				vty_out(vty,
 					"%% Can't find specified prefix-list\n");
 			return CMD_WARNING;

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -1410,14 +1410,15 @@ static int ospf6_neighbor_show_common(struct vty *vty, int argc,
 	json_object *json = NULL;
 
 	showfunc = ospf6_neighbor_show_detail;
-	if (uj)
-		json = json_object_new_object();
 
 	if ((inet_pton(AF_INET, argv[idx_ipv4]->arg, &router_id)) != 1) {
 		vty_out(vty, "Router-ID is not parsable: %s\n",
 			argv[idx_ipv4]->arg);
 		return CMD_SUCCESS;
 	}
+
+	if (uj)
+		json = json_object_new_object();
 
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, i, oa))
 		for (ALL_LIST_ELEMENTS_RO(oa->if_list, j, oi))

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -1557,9 +1557,6 @@ int ospf6_route_table_show(struct vty *vty, int argc_start, int argc,
 
 	memset(&prefix, 0, sizeof(prefix));
 
-	if (use_json)
-		json = json_object_new_object();
-
 	for (i = argc_start; i < arg_end; i++) {
 		if (strmatch(argv[i]->text, "summary")) {
 			summary++;
@@ -1603,14 +1600,14 @@ int ospf6_route_table_show(struct vty *vty, int argc_start, int argc,
 				slash++;
 			continue;
 		}
-		if (use_json)
-			json_object_string_add(json, "malformedArgument",
-					       argv[i]->arg);
-		else
+		if (!use_json)
 			vty_out(vty, "Malformed argument: %s\n", argv[i]->arg);
 
 		return CMD_SUCCESS;
 	}
+
+	if (use_json)
+		json = json_object_new_object();
 
 	/* Give summary of this route table */
 	if (summary) {

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -746,11 +746,7 @@ void ospf6_spf_display_subtree(struct vty *vty, const char *prefix, int rest,
 	}
 
 	len = strlen(prefix) + 4;
-	next_prefix = (char *)malloc(len);
-	if (next_prefix == NULL) {
-		vty_out(vty, "malloc failed\n");
-		return;
-	}
+	next_prefix = XMALLOC(MTYPE_TMP, len);
 	snprintf(next_prefix, len, "%s%s", prefix, (rest ? "|  " : "   "));
 
 	restnum = listcount(v->child_list);
@@ -776,7 +772,7 @@ void ospf6_spf_display_subtree(struct vty *vty, const char *prefix, int rest,
 		else
 			json_object_free(json_childs);
 	}
-	free(next_prefix);
+	XFREE(MTYPE_TMP, next_prefix);
 }
 
 DEFUN (debug_ospf6_spf_process,

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -846,15 +846,15 @@ void zebra_evpn_print_mac_hash(struct hash_bucket *bucket, void *ctxt)
 
 	prefix_mac2str(&mac->macaddr, buf1, sizeof(buf1));
 
-	if (json_mac_hdr)
-		json_mac = json_object_new_object();
-
 	if (CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL)) {
 		struct interface *ifp;
 		vlanid_t vid;
 
 		if (wctx->flags & SHOW_REMOTE_MAC_FROM_VTEP)
 			return;
+
+		if (json_mac_hdr)
+			json_mac = json_object_new_object();
 
 		zebra_evpn_mac_get_access_info(mac, &ifp, &vid);
 		if (json_mac_hdr == NULL) {
@@ -922,6 +922,8 @@ void zebra_evpn_print_mac_hash(struct hash_bucket *bucket, void *ctxt)
 				mac->es ? mac->es->esi_str : addr_buf, "",
 				mac->loc_seq, mac->rem_seq);
 		} else {
+			json_mac = json_object_new_object();
+
 			json_object_string_add(json_mac, "type", "remote");
 			if (mac->es)
 				json_object_string_add(json_mac, "remoteEs",

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -1919,9 +1919,6 @@ void zebra_evpn_print_neigh_hash(struct hash_bucket *bucket, void *ctxt)
 	json_evpn = wctx->json;
 	n = (struct zebra_neigh *)bucket->data;
 
-	if (json_evpn)
-		json_row = json_object_new_object();
-
 	prefix_mac2str(&n->emac, buf1, sizeof(buf1));
 	ipaddr2str(&n->ip, buf2, sizeof(buf2));
 	state_str = IS_ZEBRA_NEIGH_ACTIVE(n) ? "active" : "inactive";
@@ -1936,6 +1933,8 @@ void zebra_evpn_print_neigh_hash(struct hash_bucket *bucket, void *ctxt)
                     sizeof(flags_buf)), state_str, buf1,
                     "", n->loc_seq, n->rem_seq);
 		} else {
+			json_row = json_object_new_object();
+
 			json_object_string_add(json_row, "type", "local");
 			json_object_string_add(json_row, "state", state_str);
 			json_object_string_add(json_row, "mac", buf1);
@@ -1977,6 +1976,8 @@ void zebra_evpn_print_neigh_hash(struct hash_bucket *bucket, void *ctxt)
 				n->mac->es ? n->mac->es->esi_str : addr_buf,
 				n->loc_seq, n->rem_seq);
 		} else {
+			json_row = json_object_new_object();
+
 			json_object_string_add(json_row, "type", "remote");
 			json_object_string_add(json_row, "state", state_str);
 			json_object_string_add(json_row, "mac", buf1);

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -197,8 +197,13 @@ static int show_nht_rm(struct vty *vty, int af_type, const char *vrf_all,
 		       const char *vrf_name, bool use_json)
 {
 	struct zebra_vrf *zvrf;
+	vrf_id_t vrf_id = VRF_DEFAULT;
 	json_object *json = NULL;
 	json_object *json_vrfs = NULL;
+
+	/* Check for single vrf name. Note that this macro returns on error. */
+	if (vrf_all == NULL && vrf_name != NULL)
+		VRF_GET_ID(vrf_id, vrf_name, false);
 
 	if (use_json) {
 		json = json_object_new_object();
@@ -236,10 +241,6 @@ static int show_nht_rm(struct vty *vty, int af_type, const char *vrf_all,
 	} else {
 		json_object *json_proto = NULL;
 		json_object *json_vrf = NULL;
-		vrf_id_t vrf_id = VRF_DEFAULT;
-
-		if (vrf_name)
-			VRF_GET_ID(vrf_id, vrf_name, false);
 
 		zvrf = zebra_vrf_lookup_by_id(vrf_id);
 		if (!zvrf) {

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -474,6 +474,7 @@ static void zevpn_print_mac_hash_all_evpn(struct hash_bucket *bucket, void *ctxt
 
 	if (!num_macs) {
 		if (json) {
+			json_object_free(json_mac); /* Unused */
 			json_object_int_add(json_evpn, "numMacs", num_macs);
 			json_object_object_add(json, vni_str, json_evpn);
 		}
@@ -494,6 +495,8 @@ static void zevpn_print_mac_hash_all_evpn(struct hash_bucket *bucket, void *ctxt
 	if (json) {
 		if (wctx->count)
 			json_object_object_add(json_evpn, "macs", json_mac);
+		else
+			json_object_free(json_mac);
 		json_object_object_add(json, vni_str, json_evpn);
 	}
 }


### PR DESCRIPTION
Cleanup some allocated json objects in several components; generally ensuring that objects are freed in error cases.

Fixes #19151
