### PR TITLE
tools: Allow support bundles to generate output from ip commands

### DIFF
--- a/tools/etc/frr/support_bundle_commands.conf
+++ b/tools/etc/frr/support_bundle_commands.conf
@@ -3,6 +3,9 @@
 # PROC_NAME, CMD_LIST_START and CMD_LIST_END
 # Add the new command for each process between
 # CMD_LIST_START and CMD_LIST_END lines
+#
+# For system-level ip commands, use CMD_LIST_IP_START and CMD_LIST_IP_END
+# These commands will be executed directly with the 'ip' command
 
 # BGP Support Bundle Command List
 PROC_NAME:bgp
@@ -95,6 +98,17 @@ show event timers
 show daemons
 show version
 CMD_LIST_END
+
+# System IP Commands for Zebra (example)
+PROC_NAME:zebra
+CMD_LIST_IP_START
+link show
+addr show
+route show table all
+-6 route show table all
+neigh show
+rule show
+CMD_LIST_IP_END
 
 # OSPF Support Bundle Command List
 PROC_NAME:ospf

--- a/tools/generate_support_bundle.py
+++ b/tools/generate_support_bundle.py
@@ -38,9 +38,10 @@ def main():
     args = parser.parse_args()
 
     collecting = False  # file format has sentinels (seem superfluous)
-    proc_cmds = {}
+    proc_cmds = {}  # Dictionary to store command lists for each process
     proc = None
     temp = None
+    cmd_type = None  # Track whether we're collecting vtysh or ip commands
 
     # Collect all the commands for each daemon
     try:
@@ -54,12 +55,19 @@ def main():
                 proc = cmd_line[1]
                 temp = tempfile.NamedTemporaryFile("w+")
                 collecting = False
+                cmd_type = None
             elif cmd_line[0] == "CMD_LIST_START":
                 collecting = True
-            elif cmd_line[0] == "CMD_LIST_END":
+                cmd_type = "vtysh"
+            elif cmd_line[0] == "CMD_LIST_IP_START":
+                collecting = True
+                cmd_type = "ip"
+            elif cmd_line[0] == "CMD_LIST_END" or cmd_line[0] == "CMD_LIST_IP_END":
                 collecting = False
                 temp.flush()
-                proc_cmds[proc] = open(temp.name)
+                if proc not in proc_cmds:
+                    proc_cmds[proc] = {}
+                proc_cmds[proc][cmd_type] = open(temp.name)
                 temp.close()
             elif collecting:
                 temp.write(line + "\n")
@@ -69,26 +77,65 @@ def main():
         logging.fatal("Cannot read config file: %s: %s", args.config, str(error))
         return
 
-    # Spawn a vtysh to fetch each set of commands
+    # Spawn processes to fetch each set of commands
     procs = []
     for proc in proc_cmds:
-        if args.pathspace:
-            ofn = os.path.join(args.log_dir, args.pathspace + "_" + proc + "_support_bundle.log")
-            p = subprocess.Popen(
-                ["/usr/bin/env", "vtysh", "-t", "-N", args.pathspace],
-                stdin=proc_cmds[proc],
-                stdout=open_with_backup(ofn),
-                stderr=subprocess.STDOUT,
-            )
-        else:
-            ofn = os.path.join(args.log_dir, proc + "_support_bundle.log")
-            p = subprocess.Popen(
-                ["/usr/bin/env", "vtysh", "-t"],
-                stdin=proc_cmds[proc],
-                stdout=open_with_backup(ofn),
-                stderr=subprocess.STDOUT,
-            )
-        procs.append(p)
+        for cmd_type, cmd_file in proc_cmds[proc].items():
+            if args.pathspace:
+                ofn = os.path.join(
+                    args.log_dir,
+                    args.pathspace
+                    + "_"
+                    + proc
+                    + "_"
+                    + cmd_type
+                    + "_support_bundle.log",
+                )
+            else:
+                ofn = os.path.join(
+                    args.log_dir, proc + "_" + cmd_type + "_support_bundle.log"
+                )
+
+            if cmd_type == "vtysh":
+                if args.pathspace:
+                    p = subprocess.Popen(
+                        ["/usr/bin/env", "vtysh", "-t", "-N", args.pathspace],
+                        stdin=cmd_file,
+                        stdout=open_with_backup(ofn),
+                        stderr=subprocess.STDOUT,
+                    )
+                else:
+                    p = subprocess.Popen(
+                        ["/usr/bin/env", "vtysh", "-t"],
+                        stdin=cmd_file,
+                        stdout=open_with_backup(ofn),
+                        stderr=subprocess.STDOUT,
+                    )
+            elif cmd_type == "ip":
+                # For ip commands, create a shell script that executes each ip command
+                cmd_file.seek(0)  # Reset file pointer to beginning
+                ip_script = tempfile.NamedTemporaryFile(mode="w+")
+                ip_script.write("#!/bin/bash\n")
+                ip_script.write("set -e\n")
+                for cmd in cmd_file:
+                    cmd = cmd.strip()
+                    if cmd:
+                        ip_script.write(f"echo '=== Command: ip {cmd} ==='\n")
+                        ip_script.write(
+                            f"ip {cmd} || echo 'Command failed with exit code: $?'\n"
+                        )
+                        ip_script.write("echo '=== Return code: $? ==='\n")
+                        ip_script.write("echo\n")
+                ip_script.flush()
+                os.chmod(ip_script.name, 0o755)
+
+                p = subprocess.Popen(
+                    ["/bin/bash", ip_script.name],
+                    stdout=open_with_backup(ofn),
+                    stderr=subprocess.STDOUT,
+                )
+
+            procs.append(p)
 
     for p in procs:
         p.wait()


### PR DESCRIPTION
When something has gone wrong, lets generate a support bundle that has ip output to see what has gone wrong, if any, at the kernel level.