### PR TITLE
tests: Modify isis_srv6_topo1 to allow some ping failures

### DIFF
--- a/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
+++ b/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
@@ -238,17 +238,34 @@ def router_compare_json_output(rname, command, reference):
 
 
 def check_ping6(name, dest_addr, expect_connected):
-    def _check(name, dest_addr, match):
+    def _check(name, dest_addr, expect_connected):
         tgen = get_topogen()
-        output = tgen.gears[name].run("ping6 {} -c 1 -w 1".format(dest_addr))
+        output = tgen.gears[name].run("ping6 {} -c 20".format(dest_addr))
         logger.info(output)
-        if match not in output:
-            return "ping fail"
 
-    match = "{} packet loss".format(", 0%" if expect_connected else ", 100%")
-    logger.info("[+] check {} {} {}".format(name, dest_addr, match))
+        # Extract packet loss percentage from output
+        import re
+
+        loss_match = re.search(r"(\d+)% packet loss", output)
+        if not loss_match:
+            return "ping fail - could not parse packet loss"
+
+        loss_percent = int(loss_match.group(1))
+
+        if expect_connected:
+            # When expecting connectivity, allow at most 10% packet loss
+            return None if loss_percent <= 10 else "ping fail - too much packet loss"
+        else:
+            # When expecting no connectivity, allow at most 90% packet loss
+            return None if loss_percent <= 90 else "ping fail - unexpected connectivity"
+
+    logger.info(
+        "[+] check {} {} (expect_connected: {})".format(
+            name, dest_addr, expect_connected
+        )
+    )
     tgen = get_topogen()
-    func = functools.partial(_check, name, dest_addr, match)
+    func = functools.partial(_check, name, dest_addr, expect_connected)
     _, result = topotest.run_and_expect(func, None, count=10, wait=1)
     assert result is None, "Failed"
 


### PR DESCRIPTION
I'm getting some ping failures locally due to busy system. Let's give 20 pings and allow more than a little failure as long as something goes through.