### PR TITLE
bgpd: fix filtered_routes_count

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4540,6 +4540,8 @@ static uint32_t bgp_filtered_routes_count(struct peer *peer, afi_t afi,
 
 			attr = *ain->attr;
 
+			filtered = false;
+
 			if (bgp_input_filter(peer, rn_p, &attr, afi, safi)
 			    == FILTER_DENY)
 				filtered = true;


### PR DESCRIPTION
Reset the boolean used in counting filtered routes - looks like if it was ever set "true", it stayed set.
