### PR TITLE
tools: fix daemon starting order for debian packages

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -36,7 +36,7 @@ FRR_DEFAULT_PROFILE="@DFLT_NAME@" # traditional / datacenter
 # - keep zebra first
 # - watchfrr does NOT belong in this list
 
-DAEMONS="zebra mgmtd bgpd ripd ripngd ospfd ospf6d isisd babeld pimd pim6d ldpd nhrpd eigrpd sharpd pbrd staticd bfdd fabricd vrrpd pathd"
+DAEMONS="mgmtd zebra bgpd ripd ripngd ospfd ospf6d isisd babeld pimd pim6d ldpd nhrpd eigrpd sharpd pbrd staticd bfdd fabricd vrrpd pathd"
 RELOAD_SCRIPT="$D_PATH/frr-reload.py"
 
 #


### PR DESCRIPTION
Currently the management daemon (mgmtd) starts only after Zebra is started, which causes Zebra to throw some errors as described here [0]. The problem is, when the MGMTD was introduced [1], the order in tools/frr.in was adjusted correctly, but not in tools/frrcommon.sh.in. We are therefore now also changing it in frrcommon.sh.in.

[0] https://github.com/FRRouting/frr/issues/17931
[1] https://github.com/FRRouting/frr/pull/13059/commits/1c84efe4fa8585df58a9b53459f94c47934f0786