### PR TITLE
bgpd: Ensure addpath does not withdraw selected route in some situations

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -143,9 +143,13 @@ subgrp_announce_addpath_best_selected(struct bgp_dest *dest,
 			if (listnode_lookup(list, pi))
 				subgroup_process_announce_selected(
 					subgrp, pi, dest, afi, safi, id);
-			else
+			else {
+				if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
+					continue;
+
 				subgroup_process_announce_selected(
 					subgrp, NULL, dest, afi, safi, id);
+			}
 		} else {
 			/* No Paths-Limit involved */
 			if (!paths_limit) {


### PR DESCRIPTION
Currently when configuring bgp to send up to 6 additional routes after the selected, there exists a timing window where it can decide to send a withdrawal for the selected.  Thus leaving a non-selected on the sent to router.  The code loops over the paths in the start of the function, skipping the best path and finding up to X additional paths to send.  When this is done, it looks at the list generated compared to all the paths and sends withdrawals for all those no-longer possibly selected.  Since bestpath sending is elsewhere we end up with a situation where it's possible to send a withdrawal for the selected.  Modify the code in the second loop to no longer send a withdrawal in this case for the selected.