### PR TITLE
bgpd: fix DEREF_AFTER_FREE in bgp_route

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9820,9 +9820,9 @@ void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 
 		bgp_path_info_add(bn, new);
 		bgp_aggregate_increment(bgp, p, new, afi, SAFI_UNICAST);
-		bgp_dest_unlock_node(bn);
 		SET_FLAG(bn->flags, BGP_NODE_FIB_INSTALLED);
 		bgp_process(bgp, bn, new, afi, SAFI_UNICAST);
+		bgp_dest_unlock_node(bn);
 
 		if ((bgp->inst_type == BGP_INSTANCE_TYPE_VRF)
 		    || (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT)) {


### PR DESCRIPTION
Found by the static analyzer Svace (ISP RAS): DEREF_AFTER_FREE. 
Pointer '&bn->flags' is dereferenced at bgp_route.c:9813 after the referenced memory was deallocated at bgp_table.c:91 by passing as 1st parameter to function 'bgp_dest_unlock_node' at bgp_route.c:9812.

I suggest moving the memory release 2 lines lower.