### PR TITLE
ospfd: fix DEREF_AFTER_NULL.EX in ospf_vty

### DIFF
--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -169,6 +169,10 @@ void ospf_interface_bfd_show(struct vty *vty, const struct interface *ifp,
 			     struct json_object *json)
 {
 	struct ospf_if_params *params = IF_DEF_PARAMS(ifp);
+
+	if (params == NULL)
+		return;
+
 	struct bfd_configuration *bfd_config = params->bfd_config;
 	struct json_object *json_bfd;
 


### PR DESCRIPTION
Found by the static analyzer Svace (ISP RAS): DEREF_AFTER_NULL.EX. 

After having been compared to a NULL value at ospf_vty.c:3913, pointer '(**ifp->info).def_params' is passed in call to function 'ospf_interface_bfd_show' at ospf_vty.c:3925, where it is dereferenced at ospf_bfd.c:172.

You need to check param for NULL in the same way inside the ospf_interface_bfd_show() function. Since there is a check before that, and if it is 0, then there may be UB during dereference.