### PR TITLE
Rajasekarr/bfd memleak intf flaps

### DIFF
--- a/zebra/zebra_ptm_redistribute.c
+++ b/zebra/zebra_ptm_redistribute.c
@@ -62,6 +62,10 @@ void zebra_interface_bfd_update(struct interface *ifp, struct prefix *dp,
 		if (!IS_BFD_ENABLED_PROTOCOL(client->proto))
 			continue;
 
+		/* Do not send unsolicited messages to synchronous clients. */
+		if (client->synchronous)
+			continue;
+
 		/* Notify to the protocol daemons. */
 		zsend_interface_bfd_update(ZEBRA_INTERFACE_BFD_DEST_UPDATE,
 					   client, ifp, dp, sp, status, vrf_id);
@@ -89,6 +93,10 @@ void zebra_bfd_peer_replay_req(void)
 
 	frr_each (zserv_client_list, &zrouter.client_list, client) {
 		if (!IS_BFD_ENABLED_PROTOCOL(client->proto))
+			continue;
+
+		/* Do not send unsolicited messages to synchronous clients. */
+		if (client->synchronous)
 			continue;
 
 		/* Notify to the protocol daemons. */

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -573,8 +573,10 @@ static void zserv_process_messages(struct event *thread)
 int zserv_send_message(struct zserv *client, struct stream *msg)
 {
 	/* Don't continue if zclient is being freed/shut */
-	if (client->pthread == NULL)
+	if (client->pthread == NULL) {
+		stream_free(msg);
 		goto done;
+	}
 
 	frr_with_mutex (&client->obuf_mtx) {
 		stream_fifo_push(client->obuf_fifo, msg);


### PR DESCRIPTION
Two issue addressed here.. 

ISSUE-1:
zebra: fix memory leak by preventing BFD updates to synchronous clients

When user is flapping 256 interfaces with BFD enabled on all interfaces, the zebra memory is leaking.

Issue:
BGP maintains two connections to Zebra:
- Primary connection for normal routing
- Secondary connection (bgp [1]) for label management

The secondary BGP connection (zclient_sync) is marked as synchronous but was still receiving unsolicited BFD interface updates and peer replay messages, causing a memory leak as these messages accumulated in the client's buffer.

Fix:
- zebra_interface_bfd_update(): skip sending BFD interface updates
- zebra_bfd_peer_replay_req(): skip sending BFD peer replay messages

This prevents the synchronous secondary BGP connection from receiving unsolicited BFD messages that it doesn't need, resolving the memory leak issue.
```
    Trigger: 20 iter (256 intf down + 20sec sleep + 256 intf up + 20sec sleep)

    Before:
    root@spine1:mgmt:/var/home/cumulus# ps --noheader -o %cpu,rss:1 307063
     7.6 135924

    vtysh -c "sh mem zebra"
    System allocator statistics:
      Total heap allocated:  22 MiB
      Used ordinary blocks:  16 MiB
      Free small blocks:     4304 bytes
      Free ordinary blocks:  6004 KiB
      Ordinary blocks:       481
      Small blocks:          87
    Stream                        :       42 variable   1114608      324   3873376
    Stream FIFO                   :        7     72         504       10       720

    After:
    root@spine1:mgmt:/var/home/cumulus# ps --noheader -o %cpu,rss:1 307063
     5.9 176692 >>>>>>>>>>>>>>>>~40MB leak

    vtysh -c "sh mem zebra"
    System allocator statistics:
      Total heap allocated:  62 MiB
      Used ordinary blocks:  57 MiB
      Free small blocks:     3472 bytes
      Free ordinary blocks:  5901 KiB
      Ordinary blocks:       386
      Small blocks:          89
    Stream                        :     2602 variable  43160048     2674  43406000
    Stream FIFO                   :        7     72         504       10       720

    WITH FIX:
    Before:
    root@spine1:mgmt:/var/home/cumulus# ps --noheader -o %cpu,rss:1 466521
     7.4 136352

    After:
    root@spine1:mgmt:/var/log/frr# ps --noheader -o %cpu,rss:1 466521
     6.5 137032
```

ISSUE-2:
    zebra: prevent message queuing for clients without pthreads

Some zebra clients may not have an associated pthread, which causes messages sent to them to accumulate in memory without being processed, leading to memory leaks.

Fix by adding a check in zserv_send_message() to free the message stream immediately if client->pthread is NULL, preventing memory leak from unprocessed messages.