### PR TITLE
topotests: improve embedded RP test reliability

### DIFF
--- a/tests/topotests/pim_embedded_rp/test_pim_embedded_rp.py
+++ b/tests/topotests/pim_embedded_rp/test_pim_embedded_rp.py
@@ -115,7 +115,7 @@ def test_ospfv3_convergence():
 def expect_pim_rp(router, rp, group, interface=None, missing=False):
     "Wait until RP is present."
     tgen = get_topogen()
-    maximum_wait = 15
+    maximum_wait = 30
     log_message = f"waiting RP {rp} for {group} in {router}"
     if missing:
         log_message += \
@@ -163,14 +163,15 @@ def test_embedded_rp_mld_join():
         "ff75:130:2001:db8:ffff::301",
         "ff75:130:2001:db8:ffff::302",
     ]
+    counter = 0
     for group in groups:
+        counter += 1
         app_helper.run("h1", [group, "h1-eth0"])
-        topotest.sleep(2, "Waiting MLD join to be sent")
-
-    expect_pim_rp("r2", "2001:db8:ffff::1", groups[0], interface="r2-eth0")
-    expect_pim_rp("r2", "2001:db8:ffff::1", groups[1], interface="r2-eth0")
-    # Over the limit entry
-    expect_pim_rp("r2", "2001:db8:ffff::1", groups[2], missing=True)
+        if counter == 3:
+            # Item that exceeded the count of 3 should not show up
+            expect_pim_rp("r2", "2001:db8:ffff::1", group, missing=True)
+        else:
+            expect_pim_rp("r2", "2001:db8:ffff::1", group, interface="r2-eth0")
 
     app_helper.stop_all_hosts()
 

--- a/tests/topotests/pim_embedded_rp/test_pim_embedded_rp.py
+++ b/tests/topotests/pim_embedded_rp/test_pim_embedded_rp.py
@@ -118,8 +118,7 @@ def expect_pim_rp(router, rp, group, interface=None, missing=False):
     maximum_wait = 30
     log_message = f"waiting RP {rp} for {group} in {router}"
     if missing:
-        log_message += \
-            f" to be missing ({maximum_wait} seconds maximum)"
+        log_message += f" to be missing ({maximum_wait} seconds maximum)"
 
     logger.info(log_message)
 
@@ -131,10 +130,9 @@ def expect_pim_rp(router, rp, group, interface=None, missing=False):
         topotest.router_json_cmp,
         tgen.gears[router],
         f"show ipv6 pim rp-info json",
-        expected
+        expected,
     )
-    _, result = topotest.run_and_expect(
-        test_func, None, count=maximum_wait, wait=1)
+    _, result = topotest.run_and_expect(test_func, None, count=maximum_wait, wait=1)
     if missing:
         assert result is not None, f'"{router}" convergence failure'
     else:
@@ -223,7 +221,7 @@ def test_embedded_rp_spt_switch():
         topotest.router_json_cmp,
         tgen.gears["r1"],
         f"show ipv6 pim state json",
-        {group: {"*": {}, source: {}}}
+        {group: {"*": {}, source: {}}},
     )
     _, result = topotest.run_and_expect(test_func, None, count=10, wait=8)
     assert result is None, '"r1" convergence failure'
@@ -234,7 +232,7 @@ def test_embedded_rp_spt_switch():
         topotest.router_json_cmp,
         tgen.gears["r2"],
         f"show ipv6 pim state json",
-        {group: {source: {"r2-eth2": {"r2-eth1": {}}}}}
+        {group: {source: {"r2-eth2": {"r2-eth1": {}}}}},
     )
     _, result = topotest.run_and_expect(test_func, None, count=10, wait=8)
     assert result is None, '"r2" convergence failure'
@@ -245,7 +243,7 @@ def test_embedded_rp_spt_switch():
         topotest.router_json_cmp,
         tgen.gears["r3"],
         f"show ipv6 pim state json",
-        {group: {source: {"r3-eth1": {"r3-eth2": {}}}}}
+        {group: {source: {"r3-eth1": {"r3-eth2": {}}}}},
     )
     _, result = topotest.run_and_expect(test_func, None, count=10, wait=8)
     assert result is None, '"r3" convergence failure'


### PR DESCRIPTION
Two changes in Embedded RP topology test:
- When testing the learned embedded RP limit ensure that the groups are learned in a particular order so we always pick the correct filtered group
- Increase the amount of wait time for multicast state convergence.