### PR TITLE
lib: avoid creating invalid vrf yang states

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -186,11 +186,6 @@ struct vrf *vrf_get(vrf_id_t vrf_id, const char *name)
 	} else if (name && vrf->name[0] == '\0') {
 		strlcpy(vrf->name, name, sizeof(vrf->name));
 		RB_INSERT(vrf_name_head, &vrfs_by_name, vrf);
-
-		/* We have a name now so we can have state */
-		if (vrf_notify_oper_changes)
-			vrf->state = nb_op_update_pathf(NULL, "/frr-vrf:lib/vrf[name=\"%s\"]/state",
-							NULL, vrf->name);
 	}
 	/* Update state before hook call */
 	if (vrf->state)
@@ -1051,7 +1046,10 @@ lib_vrf_state_id_get_elem(struct nb_cb_get_elem_args *args)
 {
 	struct vrf *vrfp = (struct vrf *)args->list_entry;
 
-	return yang_data_new_uint32(args->xpath, vrfp->vrf_id);
+	if (vrfp && vrfp->vrf_id != VRF_UNKNOWN)
+		return yang_data_new_uint32(args->xpath, vrfp->vrf_id);
+
+	return NULL;
 }
 
 /*
@@ -1062,7 +1060,10 @@ lib_vrf_state_active_get_elem(struct nb_cb_get_elem_args *args)
 {
 	struct vrf *vrfp = (struct vrf *)args->list_entry;
 
-	return yang_data_new_bool(args->xpath, vrfp->status == VRF_ACTIVE ? true : false);
+	if (vrfp && vrfp->vrf_id != VRF_UNKNOWN)
+		return yang_data_new_bool(args->xpath, CHECK_FLAG(vrfp->status, VRF_ACTIVE));
+
+	return NULL;
 }
 
 /* clang-format off */


### PR DESCRIPTION
At startup this error is visible even with an empty config and no vrfs present:

    Jul 22 08:36:09 pve1 zebra[845]: libyang Invalid boolean value "". (/frr-vrf:lib/vrf/state/active)
    Jul 22 08:36:09 pve1 zebra[845]: libyang Invalid type uint32 empty value. (/frr-vrf:lib/vrf/state/id)

This happens because we want to create a yang state object of the default vrf, which doesn't have a name (or at least not a valid name). Fix this by not creating a yang state object when an invalid name is given. Also add some basic checks to ensure that an invalid (or the default) vrf doesn't have a state.

This error appeared at every reboot (not frr-restart) and is fixed by this patch and making the frr systemd service dependent on `networking.service`.