### PR TITLE
zebra: DO NOT MERGE

### DIFF
--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1383,6 +1383,7 @@ DEFUN (show_zebra_client,
 {
 	struct zserv *client;
 
+	assert(0);
 	frr_each (zserv_client_list, &zrouter.client_list, client) {
 		zebra_show_client_detail(vty, client);
 		/* Show GR info if present */


### PR DESCRIPTION
This is a test to show that we have crashes that are not being decoded.