### PR TITLE
lib,zebra: store resolving nexthop-group id with recursive nexthops

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -23,6 +23,9 @@
 DEFINE_MTYPE_STATIC(LIB, NEXTHOP, "Nexthop");
 DEFINE_MTYPE_STATIC(LIB, NH_LABEL, "Nexthop label");
 DEFINE_MTYPE_STATIC(LIB, NH_SRV6, "Nexthop srv6");
+DEFINE_MTYPE_STATIC(LIB, NH_RESINFO, "NH resolved");
+
+static void nexthop_copy_res_info(struct nexthop *nh, const struct nh_res_info *info);
 
 static int _nexthop_labels_cmp(const struct nexthop *nh1,
 			       const struct nexthop *nh2)
@@ -438,6 +441,12 @@ bool nexthop_labels_match(const struct nexthop *nh1, const struct nexthop *nh2)
 	return true;
 }
 
+void nexthop_free_res_info(struct nexthop *nexthop)
+{
+	/* Note that 'res_info' will be set to NULL */
+	XFREE(MTYPE_NH_RESINFO, nexthop->res_info);
+}
+
 struct nexthop *nexthop_new(void)
 {
 	struct nexthop *nh;
@@ -467,6 +476,7 @@ void nexthop_free(struct nexthop *nexthop)
 	nexthop_del_srv6_seg6(nexthop);
 	if (nexthop->resolved)
 		nexthops_free(nexthop->resolved);
+	nexthop_free_res_info(nexthop);
 	XFREE(MTYPE_NEXTHOP, nexthop);
 }
 
@@ -941,7 +951,9 @@ void nexthop_copy_no_recurse(struct nexthop *copy,
 		memcpy(copy->backup_idx, nexthop->backup_idx, copy->backup_num);
 
 	copy->srte_color = nexthop->srte_color;
-	copy->resolved_via = nexthop->resolved_via;
+	if (nexthop->res_info)
+		nexthop_copy_res_info(copy, nexthop->res_info);
+
 	memcpy(&copy->gate, &nexthop->gate, sizeof(nexthop->gate));
 	memcpy(&copy->src, &nexthop->src, sizeof(nexthop->src));
 	memcpy(&copy->rmap_src, &nexthop->rmap_src, sizeof(nexthop->rmap_src));
@@ -1484,8 +1496,13 @@ void nexthop_json_helper(json_object *json_nexthop, const struct nexthop *nextho
 		}
 	}
 
-	if (nexthop->resolved_via > 0)
-		json_object_int_add(json_nexthop, "resolvedVia", nexthop->resolved_via);
+	if (nexthop->res_info) {
+		json_object_int_add(json_nexthop, "resolvedVia", nexthop->res_info->id);
+		json_object_string_addf(json_nexthop, "resolvedPrefix", "%pIA",
+					&(nexthop->res_info->addr));
+		json_object_int_add(json_nexthop, "resolvedPrefixLen",
+				    nexthop->res_info->pfxlen);
+	}
 }
 
 /*
@@ -1638,4 +1655,31 @@ void nexthop_vty_helper(struct vty *vty, const struct nexthop *nexthop,
 		for (i = 1; i < nexthop->backup_num; i++)
 			vty_out(vty, ",%d", nexthop->backup_idx[i]);
 	}
+}
+
+/*
+ * Maintain recursive resolution data (zebra only for now)
+ */
+void nexthop_set_res_info(struct nexthop *nh, uint32_t id, const struct prefix *pfx)
+{
+	if (nh->res_info == NULL)
+		nh->res_info = XCALLOC(MTYPE_NH_RESINFO, sizeof(struct nh_res_info));
+
+	nh->res_info->id = id;
+	if (pfx->family == AF_INET) {
+		SET_IPADDR_V4(&nh->res_info->addr);
+		nh->res_info->addr.ipaddr_v4 = pfx->u.prefix4;
+	} else {
+		SET_IPADDR_V6(&nh->res_info->addr);
+		nh->res_info->addr.ipaddr_v6 = pfx->u.prefix6;
+	}
+	nh->res_info->pfxlen = pfx->prefixlen;
+}
+
+static void nexthop_copy_res_info(struct nexthop *nh, const struct nh_res_info *info)
+{
+	if (nh->res_info == NULL)
+		nh->res_info = XCALLOC(MTYPE_NH_RESINFO, sizeof(struct nh_res_info));
+
+	*nh->res_info = *info;
 }

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -941,6 +941,7 @@ void nexthop_copy_no_recurse(struct nexthop *copy,
 		memcpy(copy->backup_idx, nexthop->backup_idx, copy->backup_num);
 
 	copy->srte_color = nexthop->srte_color;
+	copy->resolved_via = nexthop->resolved_via;
 	memcpy(&copy->gate, &nexthop->gate, sizeof(nexthop->gate));
 	memcpy(&copy->src, &nexthop->src, sizeof(nexthop->src));
 	memcpy(&copy->rmap_src, &nexthop->rmap_src, sizeof(nexthop->rmap_src));

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -1483,6 +1483,9 @@ void nexthop_json_helper(json_object *json_nexthop, const struct nexthop *nextho
 			}
 		}
 	}
+
+	if (nexthop->resolved_via > 0)
+		json_object_int_add(json_nexthop, "resolvedVia", nexthop->resolved_via);
 }
 
 /*

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -942,6 +942,9 @@ void nexthop_copy_no_recurse(struct nexthop *copy,
 
 	copy->srte_color = nexthop->srte_color;
 	copy->resolved_via = nexthop->resolved_via;
+	copy->resolved_addr = nexthop->resolved_addr;
+	copy->resolved_len = nexthop->resolved_len;
+
 	memcpy(&copy->gate, &nexthop->gate, sizeof(nexthop->gate));
 	memcpy(&copy->src, &nexthop->src, sizeof(nexthop->src));
 	memcpy(&copy->rmap_src, &nexthop->rmap_src, sizeof(nexthop->rmap_src));
@@ -1484,8 +1487,13 @@ void nexthop_json_helper(json_object *json_nexthop, const struct nexthop *nextho
 		}
 	}
 
-	if (nexthop->resolved_via > 0)
+	if (nexthop->resolved_via > 0) {
 		json_object_int_add(json_nexthop, "resolvedVia", nexthop->resolved_via);
+		json_object_string_addf(json_nexthop, "resolvedPrefix", "%pIA",
+					&(nexthop->resolved_addr));
+		json_object_int_add(json_nexthop, "resolvedPrefixLen",
+				    nexthop->resolved_len);
+	}
 }
 
 /*
@@ -1638,4 +1646,8 @@ void nexthop_vty_helper(struct vty *vty, const struct nexthop *nexthop,
 		for (i = 1; i < nexthop->backup_num; i++)
 			vty_out(vty, ",%d", nexthop->backup_idx[i]);
 	}
+
+	if (nexthop->resolved_via > 0)
+		vty_out(vty, ", res via %pIA/%d (%u)", &(nexthop->resolved_addr),
+			nexthop->resolved_len, nexthop->resolved_via);
 }

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -159,6 +159,9 @@ struct nexthop {
 	/* SR-TE color used for matching SR-TE policies */
 	uint32_t srte_color;
 
+	/* If resolved (by zebra typically), the NHG ID of the resolver */
+	uint32_t resolved_via;
+
 	/* SRv6 information */
 	struct nexthop_srv6 *nh_srv6;
 };

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -52,6 +52,13 @@ enum nh_encap_type {
 /* Backup index value is limited */
 #define NEXTHOP_BACKUP_IDX_MAX 255
 
+struct nh_res_info {
+	/* If resolved (by zebra typically), the resolving NHG ID and prefix */
+	uint32_t id;
+	struct ipaddr addr;
+	uint8_t pfxlen;
+};
+
 /* Nexthop structure. */
 struct nexthop {
 	struct nexthop *next;
@@ -135,6 +142,9 @@ struct nexthop {
 	/* Recursive parent */
 	struct nexthop *rparent;
 
+	/* If resolved (by zebra typically), the resolving NHG ID and prefix */
+	struct nh_res_info *res_info;
+
 	/* Label(s) associated with this nexthop. */
 	struct mpls_label_stack *nh_label;
 
@@ -158,9 +168,6 @@ struct nexthop {
 
 	/* SR-TE color used for matching SR-TE policies */
 	uint32_t srte_color;
-
-	/* If resolved (by zebra typically), the NHG ID of the resolver */
-	uint32_t resolved_via;
 
 	/* SRv6 information */
 	struct nexthop_srv6 *nh_srv6;
@@ -295,6 +302,10 @@ extern bool nexthop_is_blackhole(const struct nexthop *nh);
  */
 int nexthop_str2backups(const char *str, int *num_backups,
 			uint8_t *backups);
+
+/* Maintain recursive resolution data */
+void nexthop_set_res_info(struct nexthop *nh, uint32_t id, const struct prefix *pfx);
+void nexthop_free_res_info(struct nexthop *nexthop);
 
 void nexthop_json_helper(struct json_object *json_nexthop, const struct nexthop *nexthop,
 			 bool display_vrfid, uint8_t rn_family, bool brief);

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -159,8 +159,10 @@ struct nexthop {
 	/* SR-TE color used for matching SR-TE policies */
 	uint32_t srte_color;
 
-	/* If resolved (by zebra typically), the NHG ID of the resolver */
+	/* If resolved (by zebra typically), the resolving NHG ID and prefix */
 	uint32_t resolved_via;
+	struct ipaddr resolved_addr;
+	uint8_t resolved_len;
 
 	/* SRv6 information */
 	struct nexthop_srv6 *nh_srv6;

--- a/tests/topotests/bgp_redistribute_table/test_bgp_redistribute_table.py
+++ b/tests/topotests/bgp_redistribute_table/test_bgp_redistribute_table.py
@@ -117,6 +117,12 @@ def _router_json_cmp_exact_filter(router, cmd, expected):
                     nexthop.pop("flags")
                 if "interfaceIndex" in nexthop:
                     nexthop.pop("interfaceIndex")
+                if "resolvedVia" in nexthop:
+                    nexthop.pop("resolvedVia")
+                if "resolvedPrefix" in nexthop:
+                    nexthop.pop("resolvedPrefix")
+                if "resolvedPrefixLen" in nexthop:
+                    nexthop.pop("resolvedPrefixLen")
 
     return topotest.json_cmp(json_output, expected, exact=True)
 

--- a/zebra/kernel_netlink.h
+++ b/zebra/kernel_netlink.h
@@ -31,6 +31,18 @@ struct zebra_ns;
 #define NL_RCV_PKT_BUF_SIZE     (34 * 1024)
 #define NL_PKT_BUF_SIZE         8192
 
+/* FPM Attributes */
+
+/* FPM Attributes for the nexthop/nexthop-group messages.
+ * We pick a starting value well beyond the current OS/netlink values.
+ */
+enum fpm_nha_attrs {
+	/* Resolved-via nexthop group id; uint32 */
+	NHA_FPM_RESOLVED_VIA = 30,
+
+	NHA_FPM_MAX
+};
+
 extern void netlink_parse_rtattr_flags(struct rtattr **tb, int max,
 				 struct rtattr *rta, int len,
 				 unsigned short flags);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -3380,6 +3380,16 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 				}
 			}
 
+			/* FPM-specific nexthop-group attributes */
+			if (fpm) {
+				if (nh->resolved_via > 0) {
+					if (!nl_attr_put32(&req->n, buflen,
+							   NHA_FPM_RESOLVED_VIA,
+							   nh->resolved_via))
+						return 0;
+				}
+			}
+
 nexthop_done:
 
 			if (IS_ZEBRA_DEBUG_KERNEL)

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -3382,10 +3382,10 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 
 			/* FPM-specific nexthop-group attributes */
 			if (fpm) {
-				if (nh->resolved_via > 0) {
+				if (nh->res_info) {
 					if (!nl_attr_put32(&req->n, buflen,
 							   NHA_FPM_RESOLVED_VIA,
-							   nh->resolved_via))
+							   nh->res_info->id))
 						return 0;
 				}
 			}

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2674,6 +2674,12 @@ static int nexthop_active(struct nexthop *nexthop, struct nhg_hash_entry *nhe,
 				resolver = nexthop_set_resolved(afi, newhop, nexthop, NULL, flags);
 				resolved = 1;
 
+				/* Capture the NHG ID used to resolve the
+				 * nexthop.
+				 */
+				if (resolver)
+					resolver->resolved_via = match->nhe_id;
+
 				/* If there are backup nexthops, capture
 				 * that info with the resolving nexthop.
 				 */

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1099,6 +1099,7 @@ void nhg_ctx_free(struct nhg_ctx **ctx)
 	nexthop_del_labels(nh);
 	nexthop_del_srv6_seg6local(nh);
 	nexthop_del_srv6_seg6(nh);
+	nexthop_free_res_info(nh);
 
 done:
 	XFREE(MTYPE_NHG_CTX, *ctx);
@@ -1582,6 +1583,7 @@ static struct nhg_hash_entry *depends_find_singleton(const struct nexthop *nh,
 	nexthop_del_labels(&lookup);
 	nexthop_del_srv6_seg6local(&lookup);
 	nexthop_del_srv6_seg6(&lookup);
+	nexthop_free_res_info(&lookup);
 
 	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
 		zlog_debug("%s: nh %pNHv => %p (%pNG)", __func__, nh, nhe, nhe);
@@ -2346,6 +2348,37 @@ zebra_nhg_connected_ifindex(struct route_node *rn, struct route_entry *match,
 }
 
 /*
+ * Locate NHG info for use as the "resolver" for a recursive route. This
+ * may mean navigating some of the NHG hierarchy; some levels of the NHG hierarchy
+ * are not installed through the dataplane, and aren't "visible" outside zebra.
+ */
+static void set_resolving_info(struct nexthop *nh, const struct route_node *rn,
+			       const struct route_entry *match)
+{
+	uint32_t id = match->nhe_id;
+	const struct nhg_hash_entry *nhe;
+	const struct nhg_connected *node;
+
+	nhe = match->nhe;
+
+	/* If the resolving nhg is itself recursive, it won't be installed. Walk
+	 * down the tree a bit to find the installed id value.
+	 */
+	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSIVE) &&
+	    !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED)) {
+		frr_each (nhg_connected_tree_const, &nhe->nhg_depends, node) {
+			if (CHECK_FLAG(node->nhe->flags, NEXTHOP_GROUP_INSTALLED)) {
+				id = node->nhe->id;
+				break;
+			}
+		}
+	}
+
+	/* Capture resolving prefix */
+	nexthop_set_res_info(nh, id, &(rn->p));
+}
+
+/*
  * Given a nexthop we need to properly recursively resolve,
  * do a table lookup to find and match if at all possible.
  * Set the nexthop->ifindex and resolution info as appropriate.
@@ -2611,6 +2644,9 @@ static int nexthop_active(struct nexthop *nexthop, struct nhg_hash_entry *nhe,
 					"%s: CONNECT match %p (%pNG), newhop %pNHv",
 					__func__, match, match->nhe, newhop);
 
+			/* TODO -- resolving info for this path too? */
+			set_resolving_info(nexthop, rn, match);
+
 			return 1;
 		} else if (match && CHECK_FLAG(flags, ZEBRA_FLAG_ALLOW_RECURSION)) {
 			struct nexthop_group *nhg;
@@ -2673,13 +2709,12 @@ static int nexthop_active(struct nexthop *nexthop, struct nhg_hash_entry *nhe,
 				SET_FLAG(nexthop->flags,
 					 NEXTHOP_FLAG_RECURSIVE);
 				resolver = nexthop_set_resolved(afi, newhop, nexthop, NULL, flags);
-				resolved = 1;
 
-				/* Capture the NHG ID used to resolve the
-				 * nexthop.
-				 */
-				if (resolver)
-					resolver->resolved_via = match->nhe_id;
+				/* Capture the NHG info used to resolve the nexthop. */
+				if (!resolved)
+					set_resolving_info(nexthop, rn, match);
+
+				resolved = 1;
 
 				/* If there are backup nexthops, capture
 				 * that info with the resolving nexthop.

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2675,6 +2675,12 @@ static int nexthop_active(struct nexthop *nexthop, struct nhg_hash_entry *nhe,
 				resolver = nexthop_set_resolved(afi, newhop, nexthop, NULL, flags);
 				resolved = 1;
 
+				/* Capture the NHG ID used to resolve the
+				 * nexthop.
+				 */
+				if (resolver)
+					resolver->resolved_via = match->nhe_id;
+
 				/* If there are backup nexthops, capture
 				 * that info with the resolving nexthop.
 				 */

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2345,6 +2345,46 @@ zebra_nhg_connected_ifindex(struct route_node *rn, struct route_entry *match,
 }
 
 /*
+ * Locate NHG info for use as the "resolver" for a recursive route. This
+ * may mean navigating some of the NHG hierarchy; some levels of the NHG hierarchy
+ * are not installed through the dataplane, and aren't "visible" outside zebra.
+ */
+static void get_resolving_info(struct nexthop *nh, const struct route_node *rn,
+			       const struct route_entry *match)
+{
+	uint32_t id = match->nhe_id;
+	const struct nhg_hash_entry *nhe;
+	const struct nhg_connected *node;
+
+	nhe = match->nhe;
+
+	/* If the resolving nhg is itself recursive, it won't be installed. Walk
+	 * down the tree a bit to find the installed id value.
+	 */
+	if (CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSIVE) &&
+	    !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED)) {
+		frr_each (nhg_connected_tree_const, &nhe->nhg_depends, node) {
+			if (CHECK_FLAG(node->nhe->flags, NEXTHOP_GROUP_INSTALLED)) {
+				id = node->nhe->id;
+				break;
+			}
+		}
+	}
+
+	nh->resolved_via = id;
+
+	/* Capture resolving prefix */
+	if (rn->p.family == AF_INET) {
+		SET_IPADDR_V4(&nh->resolved_addr);
+		nh->resolved_addr.ipaddr_v4 = rn->p.u.prefix4;
+	} else {
+		SET_IPADDR_V6(&nh->resolved_addr);
+		nh->resolved_addr.ipaddr_v6 = rn->p.u.prefix6;
+	}
+	nh->resolved_len = rn->p.prefixlen;
+}
+
+/*
  * Given a nexthop we need to properly recursively resolve,
  * do a table lookup to find and match if at all possible.
  * Set the nexthop->ifindex and resolution info as appropriate.
@@ -2674,11 +2714,9 @@ static int nexthop_active(struct nexthop *nexthop, struct nhg_hash_entry *nhe,
 				resolver = nexthop_set_resolved(afi, newhop, nexthop, NULL, flags);
 				resolved = 1;
 
-				/* Capture the NHG ID used to resolve the
-				 * nexthop.
-				 */
+				/* Capture the NHG ID used to resolve the nexthop. */
 				if (resolver)
-					resolver->resolved_via = match->nhe_id;
+					get_resolving_info(resolver, rn, match);
 
 				/* If there are backup nexthops, capture
 				 * that info with the resolving nexthop.

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -325,6 +325,9 @@ static void show_nexthop_detail_helper(struct vty *vty,
 		for (i = 1; i < nexthop->backup_num; i++)
 			vty_out(vty, ",%d", nexthop->backup_idx[i]);
 	}
+
+	if (nexthop->resolved_via > 0)
+		vty_out(vty, ", res via %u", nexthop->resolved_via);
 }
 
 static void zebra_show_ip_route_opaque(struct vty *vty, struct route_entry *re,

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -327,7 +327,8 @@ static void show_nexthop_detail_helper(struct vty *vty,
 	}
 
 	if (nexthop->resolved_via > 0)
-		vty_out(vty, ", res via %u", nexthop->resolved_via);
+		vty_out(vty, ", res via %pIA/%d (%u)", &(nexthop->resolved_addr),
+			nexthop->resolved_len, nexthop->resolved_via);
 }
 
 static void zebra_show_ip_route_opaque(struct vty *vty, struct route_entry *re,

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -326,8 +326,9 @@ static void show_nexthop_detail_helper(struct vty *vty,
 			vty_out(vty, ",%d", nexthop->backup_idx[i]);
 	}
 
-	if (nexthop->resolved_via > 0)
-		vty_out(vty, ", res via %u", nexthop->resolved_via);
+	if (nexthop->res_info)
+		vty_out(vty, ", res via %pIA/%d (%u)", &(nexthop->res_info->addr),
+			nexthop->res_info->pfxlen, nexthop->res_info->id);
 }
 
 static void zebra_show_ip_route_opaque(struct vty *vty, struct route_entry *re,


### PR DESCRIPTION
When resolving recursive nexthops in zebra, capture the route prefix and id of the nhg used to resolve each nexthop. The goal of this is mainly to offer better support for FIB managers living in the NOS hosting FRR/zebra. Zebra forms fully-resolved  or "flattened" nexthop objects, and those objects contain contributions from both the original nexthop (sent by the owning protocol daemon) and from the resolving nexthop. A FIB manager can use the resolved-via id to distinguish the contributions from the various possible sources. That might be of use on a platform that supports a hierarchical FIB, for example. The sonic OS is expecting to take advantage of this information as its FIB manager evolves, we believe.
