### PR TITLE
bgpd: fix evpn mh route import upon session flap

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3910,6 +3910,13 @@ int bgp_evpn_route_entry_install_if_vrf_match(struct bgp *bgp_vrf,
 	const struct prefix_evpn *evp =
 		(const struct prefix_evpn *)bgp_dest_get_prefix(pi->net);
 
+	/* Consider "valid" remote routes applicable for
+	 * this VRF.
+	 */
+	if (!(CHECK_FLAG(pi->flags, BGP_PATH_VALID) && pi->type == ZEBRA_ROUTE_BGP &&
+	      pi->sub_type == BGP_ROUTE_NORMAL))
+		return 0;
+
 	if (is_route_matching_for_vrf(bgp_vrf, pi)) {
 		if (bgp_evpn_route_rmac_self_check(bgp_vrf, evp, pi))
 			return 0;


### PR DESCRIPTION
As part of the L3VNI batching process, a specific code block checks whether the path is valid and
imports EVPN routes into the tenant VRF.
This step is critical during BGP session flaps, as it triggers a Type-1 withdrawal that re-evaluates the global route and its associated path into the tenant VRF

The validation check ensures that only a valid path is imported into the tenant VRF. This logic was originally introduced in commit 58bff4d12e (upstream ID) as part of the remote Ethernet Segment (ES) flap event handling feature in multi-homing (MH).
It plays a crucial role during BGP session flaps,
where a Type-1 withdrawal triggers re-evaluation of the global route and its associated path for reinsertion into the tenant VRF.

The path validation check was removed as part of the L3VNI batched processing update in
commit 0f2cb27310 (upstream ID).
However, this check is also essential within the batched processing flow to ensure that only valid path information is used when installing remote routes. Reinstating the check is therefore crucial to maintain route integrity and prevent invalid paths from propagating into the tenant VRF.



Testing:

In Evpn MH deployment:
Have L2VNI/L3VNI with tenant vrf
Have remote VTEP advertise Type-1 and Type-2 routes Local tenant vrf imports route in ipv4 af
Initiate BGP session flap, resulting into
tenant vrf end up importing a route with multiple paths (path info).

**Before fix:**

Upon BGP session flap, the remote nexthop would not sync to zebra as path count would not goto 0 on down event.

Only partial nexthops synced
```
DUT# show evpn next-hops vni all

VNI 300011 #Next-Hops 10

IP              RMAC
::ffff:6.0.0.16 00:01:00:00:10:04
::ffff:6.0.0.14 00:01:00:00:0e:06
::ffff:6.0.0.26 00:01:00:00:1a:06
6.0.0.14        00:01:00:00:0e:06
```

**With fix:**

Upon remote ESI flap, only import VALID paths for a route into tenant vrf table.

Below output captures #paths which valid
```
DUT# show bgp l2vpn evpn next-hops
VRF             IP              RMAC              #Paths     Base Path
VRF tenant1     6.0.0.20        00:01:00:00:14:05 12
21.1.0.11/32
VRF tenant1     ::ffff:6.0.0.14 00:01:00:00:0e:06 4
2020:0:1:2::/64
VRF tenant1     6.0.0.16        00:01:00:00:10:04 4          21.2.0.0/16
VRF tenant1     ::ffff:6.0.0.18 00:01:00:00:12:07 20
2020:0:1:1::b/128
VRF tenant1     6.0.0.19        00:01:00:00:13:06 16
21.1.0.11/32
VRF tenant1     6.0.0.18        00:01:00:00:12:07 20
21.1.0.11/32

DUT# show evpn next-hops vni all

VNI 300011 #Next-Hops 20

IP              RMAC
6.0.0.20        00:01:00:00:14:05
::ffff:6.0.0.16 00:01:00:00:10:04
::ffff:6.0.0.14 00:01:00:00:0e:06
::ffff:6.0.0.26 00:01:00:00:1a:06
6.0.0.14        00:01:00:00:0e:06
::ffff:6.0.0.19 00:01:00:00:13:06
6.0.0.18        00:01:00:00:12:07
6.0.0.19        00:01:00:00:13:06
...
```


Signed-off-by: Manpreet Kaur <manpreetk@nvidia.com>
Signed-off-by: Chirag Shah <chirag@nvidia.com>
