### PR TITLE
bgpd : Fix compilation error in bgpd module: Update TP_ARGS for bgp

### DIFF
--- a/bgpd/bgp_trace.h
+++ b/bgpd/bgp_trace.h
@@ -135,7 +135,8 @@ TRACEPOINT_LOGLEVEL(frr_bgp, bmp_mirror_packet, TRACE_INFO)
 TRACEPOINT_EVENT(
 	frr_bgp,
 	bmp_eor,
-	TP_ARGS(afi_t, afi, safi_t, safi, uint8_t, flags, uint8_t, peer_type_flag, bgp),
+	TP_ARGS(afi_t, afi, safi_t, safi, uint8_t, flags, uint8_t, peer_type_flag,
+		struct bgp *, bgp),
 	TP_FIELDS(
 		ctf_integer(afi_t, afi, afi)
 		ctf_integer(safi_t, safi, safi)


### PR DESCRIPTION
In the bgpd module, the `TP_ARGS` macro was causing a compilation error due to an incorrect argument type for `bgp`. This commit updates the macro to use `struct bgp *` instead of `bgp`, resolving the issue.

No issue related.