### PR TITLE
bgpd: LL next-hop capabilty fixes (round 2)

### DIFF
--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -551,8 +551,11 @@ struct stream *bpacket_reformat_for_peer(struct bpacket *pkt,
 		 * to the peer's link-local address, and not the `::`.
 		 * Here it comes as nhlen == 16 (not 32).
 		 */
-		if (nhlen == BGP_ATTR_NHLEN_IPV6_GLOBAL &&
-		    IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_local) && ll_nexthop_only) {
+		bool use_ll_nexthop_only = (nhlen == BGP_ATTR_NHLEN_IPV6_GLOBAL &&
+					    IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_local) &&
+					    ll_nexthop_only);
+
+		if (use_ll_nexthop_only) {
 			mod_v6nhl = &peer->nexthop.v6_local;
 			stream_put_in6_addr_at(s, offset_nhlocal, mod_v6nhl);
 		} else {
@@ -574,7 +577,7 @@ struct stream *bpacket_reformat_for_peer(struct bpacket *pkt,
 					(nhlen == BGP_ATTR_NHLEN_VPNV6_GLOBAL_AND_LL
 						 ? " and RD"
 						 : ""));
-			else if (nhlen == BGP_ATTR_NHLEN_IPV6_GLOBAL && ll_nexthop_only)
+			else if (use_ll_nexthop_only)
 				zlog_debug("u%" PRIu64 ":s%" PRIu64
 					   " %s send UPDATE w/ mp_nexthop (link-local only) %pI6",
 					   PAF_SUBGRP(paf)->update_group->id, PAF_SUBGRP(paf)->id,

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -551,9 +551,7 @@ struct stream *bpacket_reformat_for_peer(struct bpacket *pkt,
 		 * to the peer's link-local address, and not the `::`.
 		 * Here it comes as nhlen == 16 (not 32).
 		 */
-		bool use_ll_nexthop_only = (nhlen == BGP_ATTR_NHLEN_IPV6_GLOBAL &&
-					    IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_local) &&
-					    ll_nexthop_only);
+		bool use_ll_nexthop_only = (nhlen == BGP_ATTR_NHLEN_IPV6_GLOBAL && ll_nexthop_only);
 
 		if (use_ll_nexthop_only) {
 			mod_v6nhl = &peer->nexthop.v6_local;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -3138,9 +3138,10 @@ struct srv6_locator *bgp_srv6_locator_lookup(struct bgp *bgp_vrf, struct bgp *bg
 	 !(_afi == AFI_IP && _safi == SAFI_MPLS_VPN) &&                        \
 	 !(_afi == AFI_IP6 && _safi == SAFI_MPLS_VPN))
 
-#define PEER_HAS_LINK_LOCAL_CAPABILITY(_peer)                                                      \
-	(CHECK_FLAG(_peer->flags, PEER_FLAG_CAPABILITY_LINK_LOCAL) &&                              \
-	 CHECK_FLAG(_peer->cap, PEER_CAP_LINK_LOCAL_ADV) &&                                        \
-	 CHECK_FLAG(_peer->cap, PEER_CAP_LINK_LOCAL_RCV))
+#define PEER_HAS_LINK_LOCAL_CAPABILITY(_peer)                                                     \
+	(CHECK_FLAG(_peer->flags, PEER_FLAG_CAPABILITY_LINK_LOCAL) &&                             \
+	 CHECK_FLAG(_peer->cap, PEER_CAP_LINK_LOCAL_ADV) &&                                       \
+	 CHECK_FLAG(_peer->cap, PEER_CAP_LINK_LOCAL_RCV) &&                                       \
+	 IN6_IS_ADDR_LINKLOCAL(&_peer->nexthop.v6_local))
 
 #endif /* _QUAGGA_BGPD_H */

--- a/tests/topotests/bgp_ipv6_next_hop_self/r1/frr.conf
+++ b/tests/topotests/bgp_ipv6_next_hop_self/r1/frr.conf
@@ -4,7 +4,6 @@ frr defaults datacenter
 int r1-eth0
  ipv6 address 2001:db8:3::1/64
  ipv6 ospf6 area 0.0.0.0
- ipv6 ospf6 network point-to-point
  ipv6 ospf6 hello-interval 1
 !
 int r1-eth1
@@ -21,18 +20,20 @@ router bgp 65000
  bgp bestpath as-path multipath-relax
  neighbor 2001:db8:1::2 remote-as internal
  neighbor 2001:db8:1::2 update-source lo
+ neighbor 2001:db8:1::4 remote-as internal
+ neighbor 2001:db8:1::4 update-source lo
  neighbor 2001:db8:3:1::2 remote-as external
  !
  address-family ipv6 unicast
   network 2001:db8:1::1/128
   neighbor 2001:db8:1::2 activate
+  neighbor 2001:db8:1::4 activate
+  neighbor 2001:db8:1::4 route-reflector-client
   neighbor 2001:db8:3:1::2 activate
  exit-address-family
 exit
 !
 router ospf6
  ospf6 router-id 10.0.0.1
- timers lsa min-arrival 100
- timers throttle spf 10 50 500
 exit
 !

--- a/tests/topotests/bgp_ipv6_next_hop_self/r4/frr.conf
+++ b/tests/topotests/bgp_ipv6_next_hop_self/r4/frr.conf
@@ -1,32 +1,29 @@
 !
 frr defaults datacenter
 !
-int r2-eth0
- ipv6 address 2001:db8:3::2/64
+int r4-eth0
+ ipv6 address 2001:db8:3::4/64
  ipv6 ospf6 area 0.0.0.0
  ipv6 ospf6 hello-interval 1
 !
 int lo
- ipv6 address 2001:db8:1::2/128
+ ipv6 address 2001:db8:1::4/128
  ipv6 ospf6 area 0.0.0.0
 !
 router bgp 65000
- bgp router-id 10.0.0.2
+ bgp router-id 10.0.0.4
  timers bgp 1 3
  no bgp default ipv4-unicast
- no bgp network import-check
  bgp bestpath as-path multipath-relax
  neighbor 2001:db8:1::1 remote-as internal
  neighbor 2001:db8:1::1 update-source lo
  !
  address-family ipv6 unicast
-  network 2001:db8:1::2/128
-  network 2001:db8:1::22/128
   neighbor 2001:db8:1::1 activate
  exit-address-family
 exit
 !
 router ospf6
- ospf6 router-id 10.0.0.2
+ ospf6 router-id 10.0.0.4
 exit
 !


### PR DESCRIPTION
Found one more issue (using netlab, thank you @ipspace) when using route reflectors and IPv6 LL capability.