### PR TITLE
lib: compute link-state zapi message size

### DIFF
--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -1678,6 +1678,20 @@ static int ls_format_msg(struct stream *s, struct ls_message *msg)
 	return -1;
 }
 
+/* Help to compute zapi message size based on the ls_xxx structs' data */
+static size_t get_max_ls_msg_size(void)
+{
+	size_t max = sizeof(struct ls_node);
+
+	if (max < sizeof(struct ls_attributes))
+		max = sizeof(struct ls_attributes);
+
+	if (max < sizeof(struct ls_prefix))
+		max = sizeof(struct ls_prefix);
+
+	return max;
+}
+
 int ls_send_msg(struct zclient *zclient, struct ls_message *msg,
 		struct zapi_opaque_reg_info *dst)
 {
@@ -1690,7 +1704,7 @@ int ls_send_msg(struct zclient *zclient, struct ls_message *msg,
 
 	/* Check buffer size */
 	if (STREAM_SIZE(zclient->obuf) <
-	    (ZEBRA_HEADER_SIZE + sizeof(uint32_t) + sizeof(msg)))
+	    (ZEBRA_HEADER_SIZE + sizeof(uint32_t) + get_max_ls_msg_size()))
 		return -1;
 
 	/* Init the message, then encode the data inline. */

--- a/lib/link_state.h
+++ b/lib/link_state.h
@@ -877,6 +877,10 @@ struct ls_message {
 	uint8_t event;		/* Message Event: Sync, Add, Update, Delete */
 	uint8_t type;		/* Message Data Type: Node, Attribute, Prefix */
 	struct ls_node_id remote_id;	/* Remote Link State Node ID */
+
+	/* Please update the get_max_ls_msg_size() helper if you add a new
+	 * struct to this message container.
+	 */
 	union {
 		struct ls_node *node;		/* Link State Node */
 		struct ls_attributes *attr;	/* Link State Attributes */


### PR DESCRIPTION
improve the computation of the size needed to carry a link-state zapi message; use the actual message struct sizes as a guide/limit. the existing code was using `sizeof` a pointer, so it didn't really perform a useful check.
