### PR TITLE
Bgp dual as fixes

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1654,6 +1654,9 @@ static int bgp_collision_detect(struct peer_connection *connection,
 	 */
 	if (peer_established(other) ||
 	    other->status == Clearing) {
+		if (bgp_debug_neighbor_events(peer))
+			zlog_debug("New connection starting from %pI4 but a competing connection is already in established or clearing",
+				   &remote_id.s_addr);
 		bgp_notify_send(connection, BGP_NOTIFY_CEASE,
 				BGP_NOTIFY_CEASE_COLLISION_RESOLUTION);
 		return -1;
@@ -1691,6 +1694,9 @@ static int bgp_collision_detect(struct peer_connection *connection,
 					BGP_NOTIFY_CEASE_COLLISION_RESOLUTION);
 			return 1;
 		} else {
+			if (bgp_debug_neighbor_events(peer))
+				zlog_debug("New Connection received, but existing connection from %pI4 will win collision detection so dropping this new connection",
+					   &remote_id.s_addr);
 			bgp_notify_send(connection, BGP_NOTIFY_CEASE,
 					BGP_NOTIFY_CEASE_COLLISION_RESOLUTION);
 			return -1;

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1877,7 +1877,10 @@ Configuring Peers
 
    The ``dual-as`` keyword is used to configure the neighbor to establish a peering
    session using the real autonomous-system number (``router bgp ASN``) or by using
-   the autonomous system number configured with the ``local-as``.
+   the autonomous system number configured with the ``local-as``.  If ``dual-as`` is
+   used be aware of connection collision ordering and attempt to configure this system
+   with a higher ip address so that this connection is preferred.  As that the other
+   side will reject the incoming connection.
 
    This command is only allowed for eBGP peers.
 

--- a/tests/topotests/bgp_dual_as/r1/frr.conf
+++ b/tests/topotests/bgp_dual_as/r1/frr.conf
@@ -1,6 +1,6 @@
 !
 interface r1-eth0
- ip address 10.0.0.1/24
+ ip address 10.0.0.3/24
 !
 router bgp 65000
  no bgp ebgp-requires-policy

--- a/tests/topotests/bgp_dual_as/r2/frr.conf
+++ b/tests/topotests/bgp_dual_as/r2/frr.conf
@@ -4,7 +4,7 @@ interface r2-eth0
 !
 router bgp 65002
  no bgp ebgp-requires-policy
- neighbor 10.0.0.1 remote-as 65000
- neighbor 10.0.0.1 timers 3 10
- neighbor 10.0.0.1 timers connect 1
+ neighbor 10.0.0.3 remote-as 65000
+ neighbor 10.0.0.3 timers 3 10
+ neighbor 10.0.0.3 timers connect 1
 !


### PR DESCRIPTION
See individual commits.  But the tl;dr -> the bgp_dual_as test is sometimes failing because of how the test was setup.  Let's change the test to negate this from happening in the future.  Add some additional debugs to bgp and add some verbiage to the documentation to help operators from getting into this situation.