### PR TITLE
pimd,pim6d: implement PIM join filtering

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -224,6 +224,22 @@ PIM Routers
    never do SM over. This command is vrf aware, to configure for a vrf, specify
    the vrf in the router pim block.
 
+.. clicmd:: join-filter route-map RMAP_NAME
+
+   Specify a route-map name to use for filtering incoming PIM joins.
+
+   The following route-map match statements can be used:
+
+   * match ip multicast-group A.B.C.D
+
+   * match ip multicast-group prefix-list IPV4-PREFIX-LIST
+
+   * match ip multicast-source A.B.C.D
+
+   * match ip multicast-source prefix-list IPV4-PREFIX-LIST
+
+   * match multicast-interface INTERFACE-NAME
+
 .. clicmd:: rpf-lookup-mode MODE [group-list PREFIX_LIST] [source-list PREFIX_LIST]
 
    MODE sets the method used to perform RPF lookups. Supported modes:

--- a/doc/user/pimv6.rst
+++ b/doc/user/pimv6.rst
@@ -198,6 +198,22 @@ PIMv6 Router
    never do SM over. This command is vrf aware, to configure for a vrf, specify
    the vrf in the router pim block.
 
+.. clicmd:: join-filter route-map RMAP_NAME
+
+   Specify a route-map name to use for filtering incoming PIM joins.
+
+   The following route-map match statements can be used:
+
+   * match ipv6 multicast-group X:X::X:X
+
+   * match ipv6 multicast-group prefix-list IPV6-PREFIX-LIST
+
+   * match ipv6 multicast-source X:X::X:X
+
+   * match ipv6 multicast-source prefix-list IPV6-PREFIX-LIST
+
+   * match multicast-interface INTERFACE-NAME
+
 .. clicmd:: ssmpingd [X:X::X:X]
 
    Enable ipv6 ssmpingd configuration. A network level management tool

--- a/lib/routemap_cli.c
+++ b/lib/routemap_cli.c
@@ -908,7 +908,7 @@ void route_map_condition_show(struct vty *vty, const struct lyd_node *dnode,
 			yang_dnode_get_string(dnode,
 					      "./rmap-match-condition/frr-pim-route-map:list-name"));
 	} else if (IS_MATCH_MULTICAST_INTERFACE(condition)) {
-		vty_out(vty, " match ipv6 multicast-interface %s\n",
+		vty_out(vty, " match multicast-interface %s\n",
 			yang_dnode_get_string(
 				dnode,
 				"./rmap-match-condition/frr-pim-route-map:multicast-interface"));

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -3010,6 +3010,24 @@ DEFPY (debug_pimv6_bsm,
 	return CMD_SUCCESS;
 }
 
+DEFPY_YANG(pim6_join_filter_route_map, pim6_join_filter_route_map_cmd,
+	   "[no] join-filter route-map ![RMAP_NAME]$rmap",
+	   NO_STR
+	   "PIM join filter configuration\n"
+	   "Filter PIM joins via route-map\n"
+	   "Route-map name\n")
+{
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), "./pim-join-route-map");
+	if (no)
+		nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+	else
+		nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, rmap);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
 struct cmd_node pim6_node = {
 	.name = "pim6",
 	.node = PIM6_NODE,
@@ -3091,6 +3109,8 @@ void pim_cmd_init(void)
 	install_element(PIM6_NODE, &pim6_bsr_candidate_rp_cmd);
 	install_element(PIM6_NODE, &pim6_bsr_candidate_rp_group_cmd);
 	install_element(PIM6_NODE, &pim6_bsr_candidate_bsr_cmd);
+
+	install_element(PIM6_NODE, &pim6_join_filter_route_map_cmd);
 
 	install_element(CONFIG_NODE, &ipv6_mld_group_watermark_cmd);
 	install_element(VRF_NODE, &ipv6_mld_group_watermark_cmd);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -9217,6 +9217,24 @@ DEFPY_YANG(pim_rpf_lookup_mode, pim_rpf_lookup_mode_cmd,
 				    (grp_list ? grp_list : ""), (src_list ? src_list : ""));
 }
 
+DEFPY_YANG(pim_join_filter_route_map, pim_join_filter_route_map_cmd,
+	   "[no] join-filter route-map ![RMAP_NAME]$rmap",
+	   NO_STR
+	   "PIM join filter configuration\n"
+	   "Filter PIM joins via route-map\n"
+	   "Route-map name\n")
+{
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), "./pim-join-route-map");
+	if (no)
+		nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+	else
+		nb_cli_enqueue_change(vty, xpath, NB_OP_MODIFY, rmap);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
 struct cmd_node pim_node = {
 	.name = "pim",
 	.node = PIM_NODE,
@@ -9386,6 +9404,7 @@ void pim_cmd_init(void)
 	install_element(PIM_NODE, &pim_dm_prefix_list_cmd);
 
 	install_element(PIM_NODE, &pim_rpf_lookup_mode_cmd);
+	install_element(PIM_NODE, &pim_join_filter_route_map_cmd);
 
 	install_element(INTERFACE_NODE, &interface_ip_igmp_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ip_igmp_cmd);

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -71,6 +71,8 @@ static void pim_instance_terminate(struct pim_instance *pim)
 	XFREE(MTYPE_PIM_PLIST_NAME, pim->spt.plist);
 	XFREE(MTYPE_PIM_PLIST_NAME, pim->register_plist);
 
+	pim_filter_ref_fini(&pim->join_filter);
+
 	pim->vrf = NULL;
 	XFREE(MTYPE_PIM_PIM_INSTANCE, pim);
 }
@@ -132,6 +134,8 @@ static struct pim_instance *pim_instance_init(struct vrf *vrf)
 #if PIM_IPV == 4
 	pim_autorp_init(pim);
 #endif
+
+	pim_filter_ref_init(&pim->join_filter);
 
 	return pim;
 }

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -15,6 +15,7 @@
 #include "pim_bsm.h"
 #include "pim_vxlan_instance.h"
 #include "pim_oil.h"
+#include "pim_routemap.h"
 #include "pim_upstream.h"
 #include "pim_mroute.h"
 #include "pim_autorp.h"
@@ -210,6 +211,9 @@ struct pim_instance {
 #define PIM_MSDP_LOG_NEIGHBOR_EVENTS 0x01
 /** Log SA event messages. */
 #define PIM_MSDP_LOG_SA_EVENTS 0x02
+
+	/* Filter on received PIM joins */
+	struct pim_filter_ref join_filter;
 
 	bool stopping;
 

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -279,6 +279,13 @@ const struct frr_yang_module_info frr_pim_info = {
 			}
 		},
 		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/pim-join-route-map",
+			.cbs = {
+				.modify = pim_join_route_map_modify,
+				.destroy = pim_join_route_map_detroy,
+			}
+		},
+		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/mcast-rpf-lookup",
 			.cbs = {
 				.create = routing_control_plane_protocols_control_plane_protocol_pim_address_family_mcast_rpf_lookup_create,

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -109,6 +109,8 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_re
 	struct nb_cb_modify_args *args);
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_register_accept_list_destroy(
 	struct nb_cb_destroy_args *args);
+int pim_join_route_map_modify(struct nb_cb_modify_args *args);
+int pim_join_route_map_detroy(struct nb_cb_destroy_args *args);
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_mcast_rpf_lookup_create(
 	struct nb_cb_create_args *args);
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_mcast_rpf_lookup_destroy(

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2013,6 +2013,51 @@ int routing_control_plane_protocols_control_plane_protocol_pim_address_family_re
 }
 
 /*
+ * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/pim-join-route-map
+ */
+int pim_join_route_map_modify(struct nb_cb_modify_args *args)
+{
+	struct vrf *vrf;
+	struct pim_instance *pim;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+
+	case NB_EV_APPLY:
+		vrf = nb_running_get_entry(args->dnode, NULL, true);
+		pim = vrf->info;
+		pim_filter_ref_set_rmap(&pim->join_filter,
+					yang_dnode_get_string(args->dnode, NULL));
+		break;
+	}
+
+	return NB_OK;
+}
+
+int pim_join_route_map_detroy(struct nb_cb_destroy_args *args)
+{
+	struct vrf *vrf;
+	struct pim_instance *pim;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		vrf = nb_running_get_entry(args->dnode, NULL, true);
+		pim = vrf->info;
+		pim_filter_ref_set_rmap(&pim->join_filter, NULL);
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
  * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-pim:pim/address-family/mcast-rpf-lookup
  */
 int routing_control_plane_protocols_control_plane_protocol_pim_address_family_mcast_rpf_lookup_create(

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -283,6 +283,11 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 
 	writes += pim_lookup_mode_write(pim, vty);
 
+	if (pim->join_filter.rmapname) {
+		vty_out(vty, " join-filter route-map %s\n", pim->join_filter.rmapname);
+		++writes;
+	}
+
 	return writes;
 }
 

--- a/tests/topotests/multicast_pim_route_map_topo1/r1/frr.conf
+++ b/tests/topotests/multicast_pim_route_map_topo1/r1/frr.conf
@@ -1,0 +1,39 @@
+log commands
+!
+interface r1-eth0
+ ip address 192.168.100.1/24
+ ip ospf area 0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
+ ip pim
+ ipv6 address 2001:db8:100::1/64
+ ipv6 ospf6 area 0
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 8
+ ipv6 pim
+exit
+!
+interface r1-eth1
+ ip address 192.168.200.1/24
+ ip igmp
+ ip pim passive
+ ipv6 address 2001:db8:200::1/64
+ ipv6 mld
+ ipv6 pim passive
+exit
+!
+router ospf
+ redistribute connected
+exit
+!
+router pim
+ rp 10.254.254.2
+exit
+!
+router ospf6
+ redistribute connected
+exit
+!
+router pim6
+ rp 2001:db8:ffff::2
+exit

--- a/tests/topotests/multicast_pim_route_map_topo1/r2/frr.conf
+++ b/tests/topotests/multicast_pim_route_map_topo1/r2/frr.conf
@@ -1,0 +1,95 @@
+log commands
+!
+interface r2-eth0
+ ip address 192.168.100.2/24
+ ip ospf area 0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
+ ip pim
+ ipv6 address 2001:db8:100::2/64
+ ipv6 ospf6 area 0
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 8
+ ipv6 pim
+exit
+!
+interface r2-eth1
+ ip address 192.168.101.2/24
+ ip pim
+ ip ospf area 0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
+ ipv6 address 2001:db8:101::2/64
+ ipv6 ospf6 area 0
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 8
+ ipv6 pim
+exit
+!
+interface lo
+ ip address 10.254.254.2/32
+ ip igmp
+ ip pim passive
+ ipv6 address 2001:db8:ffff::2/128
+ ipv6 mld
+ ipv6 pim passive
+!
+router ospf
+ redistribute connected
+exit
+!
+router pim
+ rp 10.254.254.2
+ join-filter route-map pim-filter
+exit
+!
+router ospf6
+ redistribute connected
+exit
+!
+router pim6
+ rp 2001:db8:ffff::2
+ join-filter route-map pim6-filter
+exit
+!
+ip prefix-list allowed-pim-groups seq 5 permit 225.0.0.1/32 le 32
+ip prefix-list allowed-pim-groups seq 10 permit 225.0.0.2/32 le 32
+!
+route-map pim-filter permit 100
+ match ip multicast-group prefix-list allowed-pim-groups
+exit
+!
+route-map pim-filter permit 110
+ match ip multicast-group 225.0.0.100
+exit
+!
+route-map pim-filter permit 120
+ match ip multicast-group 225.0.0.200
+ match multicast-interface r2-eth1
+exit
+!
+route-map pim-filter permit 130
+ match ip multicast-group 232.0.1.1
+ match ip multicast-source 192.168.101.10
+exit
+!
+ipv6 prefix-list allowed-pim6-groups seq 5 permit ff05::100/128 le 128
+ipv6 prefix-list allowed-pim6-groups seq 10 permit ff05::200/128 le 128
+!
+route-map pim6-filter permit 100
+ match ipv6 multicast-group prefix-list allowed-pim6-groups
+exit
+!
+route-map pim6-filter permit 110
+ match ipv6 multicast-group ff05::1000
+exit
+!
+route-map pim6-filter permit 120
+ match ipv6 multicast-group ff05::2000
+ match multicast-interface r2-eth1
+exit
+!
+route-map pim6-filter permit 130
+ match ipv6 multicast-group ff35::100
+ match ipv6 multicast-source 2001:db8:101::100
+exit

--- a/tests/topotests/multicast_pim_route_map_topo1/r3/frr.conf
+++ b/tests/topotests/multicast_pim_route_map_topo1/r3/frr.conf
@@ -1,0 +1,39 @@
+log commands
+!
+interface r3-eth0
+ ip address 192.168.101.1/24
+ ip ospf area 0
+ ip ospf hello-interval 2
+ ip ospf dead-interval 8
+ ip pim
+ ipv6 address 2001:db8:101::1/64
+ ipv6 ospf6 area 0
+ ipv6 ospf6 hello-interval 2
+ ipv6 ospf6 dead-interval 8
+ ipv6 pim
+exit
+!
+interface r3-eth1
+ ip address 192.168.201.1/24
+ ip igmp
+ ip pim passive
+ ipv6 address 2001:db8:201::1/64
+ ipv6 mld
+ ipv6 pim passive
+exit
+!
+router ospf
+ redistribute connected
+exit
+!
+router pim
+ rp 10.254.254.2
+exit
+!
+router ospf6
+ redistribute connected
+exit
+!
+router pim6
+ rp 2001:db8:ffff::2
+exit

--- a/tests/topotests/multicast_pim_route_map_topo1/test_multicast_pim_route_map_topo1.py
+++ b/tests/topotests/multicast_pim_route_map_topo1/test_multicast_pim_route_map_topo1.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_multicast_pim_route_map_topo1.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2025 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+
+"""
+test_multicast_pim_route_map_topo1.py: Test the FRR PIM multicast route map.
+"""
+
+import os
+import sys
+from functools import partial
+import pytest
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+
+# Required to instantiate the topology builder class.
+from lib.topogen import Topogen, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.ospfd, pytest.mark.pimd]
+
+
+def build_topo(tgen):
+    """
+              +----+     +----+
+    dummy <-> | r1 | <-> | r2 |
+              +----+     +----+
+                           ^
+              +----+       |
+    dummy <-> | r3 | <-----+
+              +----+
+    """
+
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+    tgen.add_router("r3")
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["r2"])
+
+    switch = tgen.add_switch("s3")
+    switch.add_link(tgen.gears["r1"])
+
+    switch = tgen.add_switch("s4")
+    switch.add_link(tgen.gears["r3"])
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    tgen.gears["r1"].load_frr_config(os.path.join(CWD, "r1/frr.conf"))
+    tgen.gears["r2"].load_frr_config(os.path.join(CWD, "r2/frr.conf"))
+    tgen.gears["r3"].load_frr_config(os.path.join(CWD, "r3/frr.conf"))
+    tgen.start_router()
+
+
+def teardown_module():
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def expect_ospf_routes(router, command, expected):
+    tgen = get_topogen()
+
+    test_func = partial(topotest.router_json_cmp, tgen.gears[router], command, expected)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, f'"{router}" convergence failure'
+
+
+def test_ospf_convergence():
+    "Check for OSPF convergence"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    expect_ospf_routes('r1', 'show ip route ospf json', {
+        '10.254.254.2/32': [],
+        '192.168.100.0/24': [],
+        '192.168.101.0/24': [],
+        '192.168.201.0/24': [],
+    })
+    expect_ospf_routes('r1', 'show ipv6 route ospf6 json', {
+        '2001:db8:100::/64': [],
+        '2001:db8:101::/64': [],
+        '2001:db8:201::/64': [],
+        '2001:db8:ffff::2/128': [],
+    })
+
+    expect_ospf_routes('r2', 'show ip route ospf json', {
+        '192.168.100.0/24': [],
+        '192.168.101.0/24': [],
+        '192.168.200.0/24': [],
+        '192.168.201.0/24': [],
+    })
+    expect_ospf_routes('r2', 'show ipv6 route ospf6 json', {
+        '2001:db8:100::/64': [],
+        '2001:db8:101::/64': [],
+        '2001:db8:200::/64': [],
+        '2001:db8:201::/64': [],
+    })
+
+    expect_ospf_routes('r3', 'show ip route ospf json', {
+        '10.254.254.2/32': [],
+        '192.168.100.0/24': [],
+        '192.168.101.0/24': [],
+        '192.168.200.0/24': [],
+    })
+    expect_ospf_routes('r3', 'show ipv6 route ospf6 json', {
+        '2001:db8:100::/64': [],
+        '2001:db8:101::/64': [],
+        '2001:db8:200::/64': [],
+        '2001:db8:ffff::2/128': [],
+    })
+
+
+def expect_pim_state(router, interface, source, group, exists=True, expected=None):
+    "Check if PIM state exists in router"
+    if exists:
+        logger.info(f"Waiting for PIM state SG({source}, {group}) in {router} interface {interface}")
+        expected = {
+            interface: {
+                group: {
+                    source: {
+                        "protocolPim": 1,
+                    }
+                }
+            }
+        }
+    else:
+        logger.info(f"Waiting for PIM state SG({source}, {group}) not in {router} interface {interface}")
+
+    tgen = get_topogen()
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears[router],
+        "show ip pim join json",
+        expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assertmsg = f'"{router}" convergence failure'
+    assert result is None, assertmsg
+
+
+def test_pim_route_map():
+    "Test PIM route map filtering"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    tgen.gears["r1"].vtysh_cmd("""
+    configure terminal
+    interface r1-eth1
+     ip igmp join 225.0.0.1
+     ip igmp join 225.0.0.2
+     ip igmp join 225.0.0.3
+     ip igmp join 225.0.0.100
+     ip igmp join 225.0.0.200
+     ip igmp join 232.0.1.1 192.168.101.10
+     ip igmp join 232.0.1.1 192.168.101.11
+    """)
+
+    tgen.gears["r3"].vtysh_cmd("""
+    configure terminal
+    interface r3-eth1
+     ip igmp join 225.0.0.200
+    """)
+
+    pim_states = [
+        {
+            "interface": "r2-eth0",
+            "group": "225.0.0.1",
+            "source": "*",
+            "exists": True,
+        },
+        {
+            "interface": "r2-eth0",
+            "group": "225.0.0.2",
+            "source": "*",
+            "exists": True,
+        },
+        {
+            "interface": "r2-eth0",
+            "group": "225.0.0.3",
+            "source": "*",
+            "exists": False,
+            "expected": {
+                "r2-eth0": {
+                    "225.0.0.3": None
+                }
+            }
+        },
+        {
+            "interface": "r2-eth0",
+            "group": "225.0.0.100",
+            "source": "*",
+            "exists": True,
+        },
+        {
+            "interface": "r2-eth0",
+            "group": "232.0.1.1",
+            "source": "192.168.101.10",
+            "exists": True,
+        },
+        {
+            "interface": "r2-eth0",
+            "group": "232.0.1.1",
+            "source": "192.168.101.11",
+            "exists": False,
+            "expected": {
+                "r2-eth0": {
+                    "232.0.1.1": {
+                        "192.168.101.11": None
+                    }
+                }
+            }
+        },
+        {
+            "interface": "r2-eth0",
+            "group": "225.0.0.200",
+            "source": "*",
+            "exists": False,
+            "expected": {
+                "r2-eth0": {
+                    "225.0.0.200": None
+                }
+            }
+        },
+        {
+            "interface": "r2-eth1",
+            "group": "225.0.0.200",
+            "source": "*",
+            "exists": True,
+        },
+    ]
+    for state in pim_states:
+        expect_pim_state("r2", state["interface"], state["source"], state["group"], state["exists"], state.get("expected"))
+
+
+def expect_pim6_state(router, interface, source, group, exists=True, expected=None):
+    "Check if PIMv6 state exists in router"
+    if exists:
+        logger.info(f"Waiting for PIMv6 state SG({source}, {group}) in {router} interface {interface}")
+        expected = {
+            interface: {
+                group: {
+                    source: {
+                        "protocolPim": 1,
+                    }
+                }
+            }
+        }
+    else:
+        logger.info(f"Waiting for PIMv6 state SG({source}, {group}) not in {router} interface {interface}")
+
+    tgen = get_topogen()
+    test_func = partial(
+        topotest.router_json_cmp,
+        tgen.gears[router],
+        "show ipv6 pim join json",
+        expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=360, wait=1)
+    assertmsg = f'"{router}" convergence failure'
+    assert result is None, assertmsg
+
+
+def test_pim6_route_map():
+    "Test PIMv6 route map filtering"
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    tgen.gears["r1"].vtysh_cmd("""
+    configure terminal
+    interface r1-eth1
+     ipv6 mld join ff05::100
+     ipv6 mld join ff05::200
+     ipv6 mld join ff05::300
+     ipv6 mld join ff05::1000
+     ipv6 mld join ff05::2000
+     ipv6 mld join ff35::100 2001:db8:101::100
+     ipv6 mld join ff35::100 2001:db8:101::200
+    """)
+
+    tgen.gears["r3"].vtysh_cmd("""
+    configure terminal
+    interface r3-eth1
+     ipv6 mld join ff05::2000
+    """)
+
+    pim_states = [
+        {
+            "interface": "r2-eth0",
+            "group": "ff05::100",
+            "source": "*",
+            "exists": True,
+        },
+        {
+            "interface": "r2-eth0",
+            "group": "ff05::200",
+            "source": "*",
+            "exists": True,
+        },
+        {
+            "interface": "r2-eth0",
+            "group": "ff05::300",
+            "source": "*",
+            "exists": False,
+            "expected": {
+                "r2-eth0": {
+                    "ff05::300": None
+                }
+            }
+        },
+        {
+            "interface": "r2-eth0",
+            "group": "ff05::1000",
+            "source": "*",
+            "exists": True,
+        },
+        {
+            "interface": "r2-eth0",
+            "group": "ff35::100",
+            "source": "2001:db8:101::100",
+            "exists": True,
+        },
+        {
+            "interface": "r2-eth0",
+            "group": "ff35::100",
+            "source": "2001:db8:101::200",
+            "exists": False,
+            "expected": {
+                "r2-eth0": {
+                    "ff35::100": {
+                        "2001:db8:101::200": None
+                    }
+                }
+            }
+        },
+        {
+            "interface": "r2-eth0",
+            "group": "ff05::2000",
+            "source": "*",
+            "exists": False,
+            "expected": {
+                "r2-eth0": {
+                    "ff05::2000": None
+                }
+            }
+        },
+        {
+            "interface": "r2-eth1",
+            "group": "ff05::2000",
+            "source": "*",
+            "exists": True,
+        },
+    ]
+    for state in pim_states:
+        expect_pim6_state("r2", state["interface"], state["source"], state["group"], state["exists"], state.get("expected"))
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -13,6 +13,10 @@ module frr-pim {
     prefix frr-interface;
   }
 
+  import frr-route-map {
+    prefix frr-route-map;
+  }
+
   import frr-routing {
     prefix "frr-rt";
   }
@@ -488,6 +492,12 @@ module frr-pim {
         type plist-ref;
         description
           "Only accept registers from a specific source prefix list.";
+    }
+
+    leaf pim-join-route-map {
+      type frr-route-map:route-map-ref;
+      description
+        "Pass PIM joins through specified route-map.";
     }
   } // global-pim-config-attributes
 


### PR DESCRIPTION
This PR is a continuation of #18955 .

The previous PR implemented the route-map infrastructure code in PIM and its first use for filtering IGMP / MLD joins, now in this continuation we further build on that code to filter PIM joins (the one that happens between PIM routers).