### PR TITLE
yang: add yang type for dummy interface type

### DIFF
--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -161,6 +161,12 @@ module frr-zebra {
       "Zebra interface type gre.";
   }
 
+  identity zif-dummy {
+    base zebra-interface-type;
+    description
+      "Zebra interface type dummy.";
+  }
+
   // End of ip6-route
   /*
    * VxLAN Network Identifier type


### PR DESCRIPTION
Added yang type to model the dummy interface type. This threw an error on dummy interfaces when accessing through grpc.

Fixes: 80e96712e47b ("zebra: add ZEBRA_IF_DUMMY flag for dummy interfaces")