### PR TITLE
build: remove C++ version restriction for grpc build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2087,7 +2087,6 @@ dnl gRPC
 dnl ---------------
 if test "$enable_grpc" = "yes"; then
   AC_LANG_PUSH([C++])
-  AX_CXX_COMPILE_STDCXX([11], [ext])
   PKG_CHECK_MODULES([GRPC], [grpc >= 6.0.0 grpc++ >= 1.16.1 protobuf >= 3.6.1 ], [
     AC_CHECK_PROGS([PROTOC], [protoc], [/bin/false])
     if test "$PROTOC" = "/bin/false"; then


### PR DESCRIPTION
Abseil [0] sets a hard lower-limit on the C++ version [1]. As we also hard-code the version here, we should relax it and just use the highest version the installed compiler supports.

The previous code breaks Debian Trixie, where the abseil package needs C++14 (and g++ supports it), but we set C++11 as the standard.

[0]: https://github.com/abseil/abseil-cpp
[1]: https://github.com/abseil/abseil-cpp/blob/483951bb49b4ca91510b94884ee2436d79c74bef/absl/base/policy_checks.h#L81