### PR TITLE
tests: fix grpc_basic tests

### DIFF
--- a/tests/topotests/grpc_basic/test_basic_grpc.py
+++ b/tests/topotests/grpc_basic/test_basic_grpc.py
@@ -108,7 +108,7 @@ def test_capabilities(tgen):
     logging.debug("grpc output: %s", output)
 
     modules = sorted(re.findall('name: "([^"]+)"', output))
-    expected = ["frr-backend", "frr-interface", "frr-routing", "frr-staticd", "frr-vrf"]
+    expected = ["frr-backend", "frr-host", "frr-interface", "frr-logging", "frr-routing", "frr-staticd", "frr-vrf", "ietf-srv6-types", "ietf-syslog-types"]
     assert modules == expected
 
     encodings = sorted(re.findall("supported_encodings: (.*)", output))
@@ -149,10 +149,17 @@ def test_get_config(tgen):
         }
       }
     ]
+  },
+  "frr-logging:logging": {
+    "file": {
+      "filename": "mgmtd.log"
+    },
+    "record-priority": true,
+    "timestamp-precision": 6
   }
 } """
     )
-    result = json_cmp(out_json, expect, exact=True)
+    result = json_cmp(out_json, expect, exact=False)
     assert result is None
 
 


### PR DESCRIPTION
A few new backends have been added + a "frr-logging" json object.