### PR TITLE
bgpd: fix DEREF_OF_NULL.EX.COND in community_list_dup_check

### DIFF
--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -896,7 +896,7 @@ static bool community_list_dup_check(struct community_list *list,
 		case COMMUNITY_LIST_EXPANDED:
 		case EXTCOMMUNITY_LIST_EXPANDED:
 		case LARGE_COMMUNITY_LIST_EXPANDED:
-			if (strcmp(entry->config, new->config) == 0)
+			if (new->config && (strcmp(entry->config, new->config) == 0))
 				return true;
 			break;
 		default:


### PR DESCRIPTION
Found by the static analyzer Svace (ISP RAS).

After having been assigned to a NULL value at bgp_clist.c:1241, pointer 'entry->config' is passed in call to function 'community_list_dup_check' at bgp_clist.c:1244, where it is dereferenced at bgp_clist.c:899.