### PR TITLE
lib, zebra: Vty show yield/resume, use for "show ip route"

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -246,6 +246,7 @@ struct cmd_node {
 #define CMD_NOT_MY_INSTANCE	14
 #define CMD_NO_LEVEL_UP 15
 #define CMD_ERR_NO_DAEMON 16
+#define CMD_YIELD 17 /* Command has yielded but is not complete yet */
 
 /* Argc max counts. */
 #define CMD_ARGC_MAX   256

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -83,6 +83,9 @@ int (*nb_cli_apply_changes_mgmt_cb)(struct vty *vty, const char *xpath_base_abs)
 int (*nb_cli_rpc_mgmt_cb)(struct vty *vty, const char *xpath, const struct lyd_node *input);
 
 
+/* Master of the tasks. */
+static struct event_loop *vty_master;
+
 PREDECL_DLIST(vtyservs);
 
 struct vty_serv {
@@ -139,22 +142,27 @@ void vty_resume_response(struct vty *vty, int ret)
 	uint8_t header[4] = {0, 0, 0, 0};
 
 	if (vty->type != VTY_FILE) {
+		/* Send end-of-output marker */
 		header[3] = ret;
 		buffer_put(vty->obuf, header, 4);
-		if (!event_is_scheduled(vty->t_write) && (vtysh_flush(vty) < 0)) {
-			zlog_err("failed to vtysh_flush");
-			/* Try to flush results; exit if a write error occurs */
-			return;
+
+		/* Try to flush results; exit if a write error occurs */
+		if (!event_is_scheduled(vty->t_write)) {
+			if (vtysh_flush(vty) < 0) {
+				zlog_err("failed to vtysh_flush");
+				return;
+			}
 		}
 	}
 
+	/* Resume reading if possible */
 	if (vty->status == VTY_CLOSE)
 		vty_close(vty);
 	else if (vty->type != VTY_FILE)
 		vty_event(VTYSH_READ, vty);
 	else
 		/* should we assert here? */
-		zlog_err("mgmtd: unexpected resume while reading config file");
+		zlog_err("vty: unexpected resume while reading config file");
 }
 
 void vty_frame(struct vty *vty, const char *format, ...)
@@ -173,6 +181,86 @@ void vty_endframe(struct vty *vty, const char *endtext)
 	if (vty->frame_pos == 0 && endtext)
 		vty_out(vty, "%s", endtext);
 	vty->frame_pos = 0;
+}
+
+/*
+ * Callback function for yield/resume; call through to application's
+ * callback.
+ */
+static void yield_resume_cb(struct event *event)
+{
+	struct vty *vty = EVENT_ARG(event);
+	struct vty_yield_resume_s ctx;
+
+	/* Capture application callback info */
+	ctx = vty->yield_resume;
+
+	/* Clear vty's yield callback info before calling into the application:
+	 * the application may call the "finish" or the "yield" api, so we can't
+	 * make any assumptions about the state of the 'vty' info after calling in.
+	 */
+	vty->yield_resume.app_cb = NULL;
+	vty->yield_resume.arg = NULL;
+
+	/* Call through to application */
+	ctx.app_cb(vty, ctx.arg);
+}
+
+/*
+ * Application process wants to yield while sending results/replies.
+ * We'll schedule a task to resume, and call the application's callback.
+ */
+bool vty_yield(struct vty *vty, void (*func)(struct vty *vty, void *arg),
+	       void *arg)
+{
+	vty->yield_resume.app_cb = func;
+	vty->yield_resume.arg = arg;
+
+	event_add_event(vty_master, yield_resume_cb, vty, 0,
+			&vty->yield_resume.t_resume);
+
+	/* Ensure reading new input is disabled */
+	event_cancel(&vty->t_read);
+
+	/* Try to send buffered output */
+	if (vty->type == VTY_SHELL_SERV)
+		vtysh_flush(vty);
+	else
+		vty_event(VTY_WRITE, vty);
+
+	return true;
+}
+
+/*
+ *
+ */
+static void yield_finish_internal(struct vty *vty)
+{
+	event_cancel(&(vty->yield_resume.t_resume));
+
+	/* Clear vty's yield/resume callback info */
+	vty->yield_resume.app_cb = NULL;
+	vty->yield_resume.arg = NULL;
+}
+
+/*
+ * Yield/resume is complete; cancel any scheduled resume task, and return
+ * to normal vty operation (turn on reads, e.g.)
+ */
+void vty_yield_finish(struct vty *vty, int retcode)
+{
+	if (vty->status != VTY_CLOSE) {
+		if (vty->type == VTY_SHELL_SERV) {
+
+			/* Send end-of-output marker and resume normal processing */
+			vty_resume_response(vty, retcode);
+			vty_event(VTYSH_READ, vty);
+		} else {
+			vty_event(VTY_READ, vty);
+		}
+
+		yield_finish_internal(vty);
+	}
 }
 
 bool vty_set_include(struct vty *vty, const char *regexp)
@@ -1618,7 +1706,7 @@ static void vty_flush(struct event *event)
 	buffer_status_t flushrc;
 	struct vty *vty = EVENT_ARG(event);
 
-	/* Tempolary disable read event. */
+	/* Temporarily disable reads. */
 	if (vty->lines == 0)
 		event_cancel(&vty->t_read);
 
@@ -2300,10 +2388,11 @@ static void vtysh_read(struct event *event)
 			if (*p == '\0') {
 				/* Pass this line to parser. */
 				ret = vty_execute(vty);
-/* Note that vty_execute clears the command buffer and resets
-   vty->length to 0. */
+				/* Note that vty_execute clears the command buffer and
+				 * resets vty->length to 0.
+				 */
 
-/* Return result. */
+				/* Return result. */
 #ifdef VTYSH_DEBUG
 				printf("result: %d\n", ret);
 				printf("vtysh node: %d\n", vty->node);
@@ -2352,6 +2441,12 @@ static void vtysh_read(struct event *event)
 					return;
 				}
 
+				/* If the application has asked to yield during
+				 * processing, don't continue reading.
+				 */
+				if (event_is_scheduled(vty->yield_resume.t_resume))
+					break;
+
 				/* warning: watchfrr hardcodes this result write
 				 */
 				header[3] = ret;
@@ -2368,6 +2463,12 @@ static void vtysh_read(struct event *event)
 			}
 		}
 	}
+
+	/* If the application has asked to yield during
+	 * processing, don't continue reading.
+	 */
+	if (event_is_scheduled(vty->yield_resume.t_resume))
+		return;
 
 	if (vty->status == VTY_CLOSE)
 		vty_close(vty);
@@ -2427,6 +2528,14 @@ void vty_close(struct vty *vty)
 	bool was_stdio = false;
 
 	vty->status = VTY_CLOSE;
+
+	/* If application was doing yield/resume, notify it by calling
+	 * its callback with a NULL vty argument.
+	 */
+	if (vty->yield_resume.app_cb) {
+		(vty->yield_resume.app_cb)(NULL, vty->yield_resume.arg);
+		yield_finish_internal(vty);
+	}
 
 	/*
 	 * If we reach here with pending config to commit we will be losing it
@@ -2753,6 +2862,7 @@ FILE *vty_open_config(const char *config_file, char *config_default_dir)
 		}
 #endif /* VTYSH */
 		confp = fopen(config_default_dir, "r");
+
 		if (confp == NULL) {
 			flog_err(
 				EC_LIB_SYSTEM_CALL,
@@ -2910,9 +3020,6 @@ int vty_config_node_exit(struct vty *vty)
 
 	return 1;
 }
-
-/* Master of the threads. */
-static struct event_loop *vty_master;
 
 static void vty_event_serv(enum vty_event event, struct vty_serv *vty_serv)
 {

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -54,6 +54,22 @@ enum vty_status {
 
 PREDECL_DLIST(vtys);
 
+/* Data for yield/resume of large show outputs. Application handlers can
+ * call the yield api before returning; this will schedule the resume callback.
+ * When the handler returns, the vty library code will try to avoid reading
+ * any new input.
+ * When the application is done with the yield/resume cycles, it calls the finish
+ * api, and resumes normal processing.
+ */
+struct vty_yield_resume_s {
+	/* Application callback and argument */
+	void *arg;
+	void (*app_cb)(struct vty *vty, void *arg);
+
+	/* Event to schedule the resume callback */
+	struct event *t_resume;
+};
+
 /* VTY struct. */
 struct vty {
 	struct vtys_item itm;
@@ -231,6 +247,7 @@ struct vty {
 	uintptr_t mgmt_req_pending_data;
 	bool mgmt_locked_candidate_ds;
 	bool mgmt_locked_running_ds;
+
 	/* Incremental write/flush limit and current accumulator. When
 	 * producing large outputs, we try to avoid buffering the entire
 	 * output, sending incremental output periodically
@@ -238,6 +255,9 @@ struct vty {
 	 */
 	size_t vty_buf_threshold;
 	size_t vty_buf_size_accum;
+
+	/* Data for yield/resume of large show outputs */
+	struct vty_yield_resume_s yield_resume;
 };
 
 static inline void vty_push_context(struct vty *vty, int node, uint64_t id)
@@ -449,6 +469,25 @@ extern void (*vty_config_node_exit_mgmt_cb)(struct vty *vty);
 extern int (*nb_cli_apply_changes_mgmt_cb)(struct vty *vty, const char *xpath_base_abs);
 extern int (*nb_cli_rpc_mgmt_cb)(struct vty *vty, const char *xpath, const struct lyd_node *input);
 
+/*
+ * Application process wants to yield while sending results/replies.
+ * We'll schedule a task to resume, and call the application's callback
+ * with the 'vty' and its 'arg'. We won't restart reads on the vty until
+ * the application tells us to.
+ * If the vty is being closed or deleted, we'll call the callback with a NULL
+ * 'vty', so the application can clean up, free memory, if necessary.
+ */
+bool vty_yield(struct vty *vty, void (*func)(struct vty *vty, void *arg),
+	       void *arg);
+
+/*
+ * Yield/resume is complete; cancel any scheduled resume task, and return
+ * to normal vty operation (turn on reads, e.g.). For clients of vtysh,
+ * send 'retcode' to signal that output is complete.
+ * Called from the application, so we expect the application to have
+ * cleaned-up any context, memory, etc.
+ */
+void vty_yield_finish(struct vty *vty, int retcode);
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -58,9 +58,12 @@
 /* context to manage show output in multiple tables or vrfs */
 struct route_show_ctx {
 	bool multi;       /* dump multiple tables or vrf */
+	bool all_table;
+	bool all_vrf;
 	bool header_done; /* common header already displayed */
 	bool brief;	  /* brief json output */
 	bool allocated;	  /* malloc'd (vs on-stack) */
+	uint32_t yield_count;
 
 	safi_t safi;
 	afi_t afi;
@@ -94,8 +97,7 @@ struct route_show_ctx {
 	uint32_t total_counter;
 	uint32_t curr_counter;
 
-	afi_t last_afi;
-	safi_t last_safi;
+	bool top_level_json;
 	vrf_id_t last_vrfid;
 	uint32_t last_tableid;
 	bool last_first_json;
@@ -111,12 +113,8 @@ static struct route_show_ctx *resume_show_ctx;
 /* Max routes to show before yielding */
 uint32_t show_yield_limit = 1000;
 
-static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi, safi_t safi,
-			    bool use_fib, bool use_json, route_tag_t tag,
-			    const struct prefix *longer_prefix_p, bool supernets_only, int type,
-			    unsigned short ospf_instance_id, uint32_t tableid, bool show_ng,
-			    bool show_nhg_summary, bool ecmp_gt, bool ecmp_lt, bool ecmp_eq,
-			    uint16_t ecmp_count, bool failed_only, struct route_show_ctx *ctx);
+static int do_show_ip_route_ctx(struct vty *vty, struct zebra_vrf *zvrf,
+				struct route_show_ctx *ctx);
 static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 				     int mcast, bool use_fib, bool show_ng);
 static void vty_show_ip_route_summary(struct vty *vty, struct route_table *table,
@@ -140,6 +138,11 @@ static void show_ip_route_nht_dump(struct vty *vty,
 				   const struct route_node *rn,
 				   const struct route_entry *re,
 				   unsigned int num);
+/* Yield/resume show output */
+static int do_show_ip_route_all_ctx(struct vty *vty, struct route_show_ctx *ctx);
+static void zebra_vty_yield_finish(struct vty *vty, int retcode);
+static void show_route_ctx_update_zvrf(struct route_show_ctx *ctx, struct zebra_vrf *zvrf);
+
 
 static char re_status_output_char(const struct route_entry *re,
 				  const struct nexthop *nhop,
@@ -834,11 +837,95 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn, struct rou
 }
 
 /*
- * Callback for yield/resume cycles during show command output.
+ * Resume show output for all-vrf variants
+ */
+static void do_show_route_vrf_all(struct vty *vty, struct route_show_ctx *ctx)
+{
+	int ret = CMD_SUCCESS;
+	struct vrf *vrf;
+	struct vrf finder = {};
+	struct zebra_vrf *zvrf;
+
+	if (ctx->resuming) {
+		/* Recover vrf */
+		strlcpy(finder.name, ctx->vrf_name, sizeof(finder.name));
+		vrf = RB_NFIND(vrf_name_head, &vrfs_by_name, &finder);
+		if (vrf == NULL || vrf->vrf_id != ctx->last_vrfid) {
+			ret = CMD_WARNING;
+			goto done;
+		}
+	} else {
+		ctx->top_level_json = true;
+		vrf = RB_MIN(vrf_name_head, &vrfs_by_name);
+	}
+
+	while (vrf) {
+		if ((zvrf = vrf->info) == NULL || (zvrf->table[ctx->afi][ctx->safi] == NULL))
+			continue;
+
+		show_route_ctx_update_zvrf(ctx, zvrf);
+
+		/* There's an outer layer of container for json output */
+		if (ctx->use_json)
+			vty_json_key(vty, zvrf_name(zvrf), &ctx->top_level_json);
+
+		/* All route tables or one/main table? */
+		if (ctx->all_table)
+			ret = do_show_ip_route_all_ctx(vty, ctx);
+		else
+			ret = do_show_ip_route_ctx(vty, zvrf, ctx);
+
+		if (ret != CMD_SUCCESS)
+			break;
+
+		vrf = RB_NEXT(vrf_name_head, vrf);
+	}
+
+	/* Close top-level json container on success */
+	if (ret == CMD_SUCCESS && ctx->use_json)
+		vty_json_close(vty, ctx->top_level_json);
+
+done:
+	/* If we're not yielding, we're done */
+	if (ret != CMD_YIELD)
+		zebra_vty_yield_finish(vty, ret);
+}
+
+/*
+ * Resume show output for single-vrf variants
+ */
+static void resume_show_one_vrf(struct vty *vty, struct route_show_ctx *ctx)
+{
+	int ret = CMD_SUCCESS;
+	struct zebra_vrf *zvrf;
+
+	/* Support all-tables and single afi/safi variants within the vrf */
+	if (ctx->all_table) {
+		ret = do_show_ip_route_all_ctx(vty, ctx);
+	} else {
+		/* Need to lookup vrf - can't continue if it's been deleted */
+		zvrf = zebra_vrf_lookup_by_name(ctx->vrf_name);
+		if (zvrf == NULL) {
+			ret = CMD_WARNING;
+			goto done;
+		}
+
+		ret = do_show_ip_route_ctx(vty, zvrf, ctx);
+	}
+
+done:
+	/* If we're not yielding, we're done */
+	if (ret != CMD_YIELD)
+		zebra_vty_yield_finish(vty, ret);
+}
+
+/*
+ * Callback from vty lib for yield/resume cycles during show command output. This
+ * dispatches to various handlers, who are responsible for cleanup.
  */
 static void show_resume_cb(struct vty *vty, void *arg)
 {
-	/* Check 'vty' - will be NULL if this is a cleanup notification */
+	/* Check 'vty' - will be NULL if this is an error/cleanup notification */
 	if (vty == NULL) {
 		if (arg == resume_show_ctx)
 			resume_show_ctx = NULL;
@@ -847,7 +934,29 @@ static void show_resume_cb(struct vty *vty, void *arg)
 	}
 
 	/* Ok to continue */
+	assert(arg == resume_show_ctx);
 
+	resume_show_ctx->resuming = true;
+
+	if (resume_show_ctx->all_vrf)
+		do_show_route_vrf_all(vty, resume_show_ctx);
+	else
+		resume_show_one_vrf(vty, resume_show_ctx);
+
+	/* At this point, the callback just returns: the handler has either
+	 * scheduled a yield, or has finished processing.
+	 */
+}
+
+/*
+ * Check for and clean up at the end of a yield/resume sequence
+ */
+static void zebra_vty_yield_finish(struct vty *vty, int retcode)
+{
+	if (resume_show_ctx && resume_show_ctx->yield_count > 0) {
+		vty_yield_finish(vty, retcode);
+		XFREE(MTYPE_TMP, resume_show_ctx);
+	}
 }
 
 /*
@@ -916,6 +1025,7 @@ static void zebra_vty_display_vrf_header(struct vty *vty, struct zebra_vrf *zvrf
 	}
 }
 
+/* TODO -- convert to using 'ctx' struct */
 static int do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 				struct route_table *table, afi_t afi, safi_t safi, bool use_fib,
 				route_tag_t tag, const struct prefix *longer_prefix_p,
@@ -927,13 +1037,12 @@ static int do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 	struct route_node *rn;
 	struct route_entry *re;
 	bool first_json = true;
-	int first = 1;
+	bool first = true;
 	rib_dest_t *dest;
 	json_object *json_prefix = NULL;
 	uint32_t addr;
 	char buf[BUFSIZ];
 	const struct rib_table_info *zinfo = table->info;
-	const struct prefix_ipv6 *src_pfx;
 	const struct prefix *pfx;
 	int ret = CMD_SUCCESS;
 
@@ -950,18 +1059,22 @@ static int do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 
 	/* Determine whether we're resuming an iteration, or starting one */
 	if (ctx->resuming) {
-		src_pfx = NULL;
-		if (ctx->last_src_prefix.prefixlen > 0)
-			src_pfx = &(ctx->last_src_prefix);
-		rn = srcdest_rnode_lookup(table, &(ctx->last_prefix), src_pfx);
-		/* TODO -- decide whether to advance to "next" here or not */
+		rn = srcdest_table_get_next(table, &(ctx->last_prefix),
+					    &(ctx->last_src_prefix));
 
+		first_json = ctx->last_first_json;
+
+		/* Reset */
+		ctx->resuming = false;
+
+		/* Don't emit header line(s) */
+		first = false;
 	} else {
 		rn = route_top(table);
 	}
 
 	/* Show all routes. */
-	for ( ; rn; rn = srcdest_route_next(rn)) {
+	for (; rn; rn = srcdest_route_next(rn)) {
 		dest = rib_dest_from_rnode(rn);
 
 		if (longer_prefix_p && !prefix_match(longer_prefix_p, &rn->p))
@@ -1015,7 +1128,7 @@ static int do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 					vty_out(vty, "\n");
 				zebra_vty_display_vrf_header(vty, zvrf, tableid, afi, safi);
 				ctx->header_done = true;
-				first = 0;
+				first = false;
 			}
 
 			vty_show_ip_route(vty, rn, re, json_prefix, use_fib, show_ng,
@@ -1023,6 +1136,9 @@ static int do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 					  ctx->brief);
 			ctx->curr_counter++;
 		} /* for each re in rn */
+
+		/* Counting prefixes */
+		ctx->curr_counter++;
 
 		if (json_prefix) {
 			/* Only output if array has elements */
@@ -1044,15 +1160,11 @@ static int do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 
 			/* Capture info needed for resume */
 			if (ctx != resume_show_ctx) {
-				resume_show_ctx =
-					XCALLOC(MTYPE_TMP,
-						sizeof(struct route_show_ctx));
-
+				resume_show_ctx = XCALLOC(MTYPE_TMP,
+							  sizeof(struct route_show_ctx));
 				*resume_show_ctx = *ctx;
 			}
 
-			resume_show_ctx->last_afi = afi;
-			resume_show_ctx->last_safi = SAFI_UNICAST;
 			resume_show_ctx->last_vrfid = zvrf->vrf->vrf_id;
 			resume_show_ctx->last_tableid = zinfo->table_id;
 			resume_show_ctx->last_first_json = first_json;
@@ -1065,6 +1177,10 @@ static int do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 				       sizeof(resume_show_ctx->last_src_prefix));
 
 			ret = CMD_YIELD;
+
+			/* Must un-ref the route-node */
+			route_unlock_node(rn);
+
 			break;
 		}
 	} /* for each rn in table */
@@ -1080,71 +1196,49 @@ static int do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 	return ret;
 }
 
-static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf, afi_t afi, safi_t safi,
-				 bool use_fib, bool use_json, route_tag_t tag,
-				 const struct prefix *longer_prefix_p, bool supernets_only,
-				 int type, unsigned short ospf_instance_id, bool show_ng,
-				 bool show_nhg_summary, bool ecmp_gt, bool ecmp_lt, bool ecmp_eq,
-				 uint16_t ecmp_count, bool failed_only, struct route_show_ctx *ctx)
-{
-	struct zebra_router_table *zrt;
-	struct rib_table_info *info;
-
-	RB_FOREACH (zrt, zebra_router_table_head,
-		    &zrouter.tables) {
-		info = route_table_get_info(zrt->table);
-
-		if (zvrf != info->zvrf)
-			continue;
-		if (zrt->afi != afi || zrt->safi != safi)
-			continue;
-
-		do_show_ip_route(vty, zvrf_name(zvrf), afi, safi, use_fib, use_json, tag,
-				 longer_prefix_p, supernets_only, type, ospf_instance_id,
-				 zrt->tableid, show_ng, show_nhg_summary, ecmp_gt, ecmp_lt,
-				 ecmp_eq, ecmp_count, failed_only, ctx);
-	}
-}
-
 /*
  * Show routes for all tables in the vrf indicated by 'ctx'
  */
-static void do_show_ip_route_all_ctx(struct vty *vty, struct route_show_ctx *ctx)
+static int do_show_ip_route_all_ctx(struct vty *vty, struct route_show_ctx *ctx)
 {
 	struct zebra_router_table *zrt;
 	struct rib_table_info *info;
-	const struct prefix *longer_prefix_p = NULL;
 	struct zebra_router_table finder = {};
-	int ret = CMD_SUCCESS;
-
-	if (ctx->longer_prefix.prefixlen > 0)
-		longer_prefix_p = &ctx->longer_prefix;
+	struct zebra_vrf *zvrf;
+	int ret = CMD_WARNING;
 
 	/* Locate starting point if we're resuming an iteration; otherwise start
 	 * with the first table.
 	 */
 	if (ctx->resuming) {
+		/* Need to lookup vrf - can't continue if it's been deleted */
+		zvrf = zebra_vrf_lookup_by_name(ctx->vrf_name);
+		if (zvrf == NULL)
+			goto done;
+
+		/* Locate table; can't continue if table doesn't exist */
 		finder.tableid = ctx->last_tableid;
 		zrt = RB_NFIND(zebra_router_table_head, &zrouter.tables, &finder);
+		if (zrt == NULL || zrt->tableid != ctx->last_tableid)
+			goto done;
 	} else {
+		zvrf = ctx->zvrf;
 		zrt = RB_MIN(zebra_router_table_head, &zrouter.tables);
 	}
 
+	/* Reset status */
+	ret = CMD_SUCCESS;
+
+	/* Iterate through route tables until we finish, or yield */
 	while (zrt != NULL) {
 		info = route_table_get_info(zrt->table);
 
-		if (ctx->zvrf != info->zvrf)
+		if (zvrf != info->zvrf)
 			continue;
-		if (zrt->afi != ctx->afi || zrt->safi != SAFI_UNICAST)
+		if (zrt->afi != ctx->afi || zrt->safi != ctx->safi)
 			continue;
 
-		ret = do_show_ip_route(vty, zvrf_name(ctx->zvrf), ctx->afi,
-				       ctx->safi, ctx->use_fib, ctx->use_json,
-				       ctx->tag, longer_prefix_p, ctx->supernets_only,
-				       ctx->type, ctx->ospf_instance_id, zrt->tableid,
-				       ctx->show_nhg, ctx->show_nhg_summary, ctx->ecmp_gt,
-				       ctx->ecmp_lt, ctx->ecmp_eq, ctx->ecmp_count,
-				       ctx->failed_only, ctx);
+		ret = do_show_ip_route_ctx(vty, zvrf, ctx);
 
 		if (ret != CMD_SUCCESS)
 			break;
@@ -1152,14 +1246,25 @@ static void do_show_ip_route_all_ctx(struct vty *vty, struct route_show_ctx *ctx
 		zrt = RB_NEXT(zebra_router_table_head, zrt);
 	}
 
-	/* Capture iteration context if we're going to yield */
-	if (ret == CMD_YIELD) {
-		/* Schedule the yield - the lower level of the iteration needs to have
-		 * set up the resume params like last table, last vrf,
-		 * last prefix seen, etc.
-		 */
-		vty_yield(vty, show_resume_cb, resume_show_ctx);
+done:
+	if (ret != CMD_YIELD) {
+		/* Clean up context if we're done */
+		zebra_vty_yield_finish(vty, ret);
 	}
+
+	return ret;
+}
+
+/*
+ * Update current vrf in vty show context
+ */
+static void show_route_ctx_update_zvrf(struct route_show_ctx *ctx, struct zebra_vrf *zvrf)
+{
+	ctx->zvrf = zvrf;
+	if (zvrf)
+		strlcpy(ctx->vrf_name, zvrf->vrf->name, sizeof(ctx->vrf_name));
+	else
+		ctx->vrf_name[0] = '\0';
 }
 
 /*
@@ -1187,7 +1292,6 @@ static void show_route_ctx_setup(struct route_show_ctx *ctx,
 	ctx->ospf_instance_id = instance_id;
 	ctx->tableid = tableid;
 	ctx->show_nhg = show_nhg;
-	ctx->zvrf = zvrf;
 	ctx->show_nhg_summary = show_nhg_summary;
 	ctx->ecmp_gt = ecmp_gt;
 	ctx->ecmp_lt = ecmp_lt;
@@ -1195,53 +1299,83 @@ static void show_route_ctx_setup(struct route_show_ctx *ctx,
 	ctx->ecmp_count = ecmp_count;
 	ctx->failed_only = failed_only;
 
+	show_route_ctx_update_zvrf(ctx, zvrf);
+
 	if (longer_prefix_p)
 		prefix_copy(&(ctx->longer_prefix), longer_prefix_p);
 
 }
 
-static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi, safi_t safi,
-			    bool use_fib, bool use_json, route_tag_t tag,
-			    const struct prefix *longer_prefix_p, bool supernets_only, int type,
-			    unsigned short ospf_instance_id, uint32_t tableid, bool show_ng,
-			    bool show_nhg_summary, bool ecmp_gt, bool ecmp_lt, bool ecmp_eq,
-			    uint16_t ecmp_count, bool failed_only, struct route_show_ctx *ctx)
+/*
+ * Show one table, using the params in 'ctx' to filter what's displayed
+ */
+static int do_show_ip_route_ctx(struct vty *vty, struct zebra_vrf *zvrf,
+				struct route_show_ctx *ctx)
 {
 	struct route_table *table;
-	struct zebra_vrf *zvrf = NULL;
+	const struct prefix *longer_prefix_p = NULL;
+	int ret;
 
-	if (!(zvrf = zebra_vrf_lookup_by_name(vrf_name))) {
-		if (use_json)
+	/* Locate starting point if we're resuming an iteration; otherwise start
+	 * with the first table.
+	 */
+
+	/* TODO -- error handling in resume path: deleted/inactive vrf, deleted table */
+
+	if (zvrf == NULL) {
+		if (ctx->use_json)
 			vty_out(vty, "{}\n");
 		else
-			vty_out(vty, "vrf %s not defined\n", vrf_name);
+			vty_out(vty, "vrf not defined\n");
 		return CMD_SUCCESS;
 	}
 
 	if (zvrf_id(zvrf) == VRF_UNKNOWN) {
-		if (use_json)
+		if (ctx->use_json)
 			vty_out(vty, "{}\n");
 		else
-			vty_out(vty, "vrf %s inactive\n", vrf_name);
+			vty_out(vty, "vrf %s inactive\n", zvrf_name(zvrf));
 		return CMD_SUCCESS;
 	}
 
-	if (tableid)
-		table = zebra_router_find_table(zvrf, tableid, afi, safi);
+	if (ctx->tableid != 0)
+		table = zebra_router_find_table(zvrf, ctx->tableid, ctx->afi, ctx->safi);
 	else
-		table = zebra_vrf_table(afi, safi, zvrf_id(zvrf));
+		table = zebra_vrf_table(ctx->afi, ctx->safi, zvrf_id(zvrf));
+
 	if (!table) {
-		if (use_json)
+		if (ctx->use_json)
 			vty_out(vty, "{}\n");
 		return CMD_SUCCESS;
 	}
 
-	do_show_route_helper(vty, zvrf, table, afi, safi, use_fib, tag, longer_prefix_p,
-			     supernets_only, type, ospf_instance_id, use_json, tableid, show_ng,
-			     show_nhg_summary, ecmp_gt, ecmp_lt, ecmp_eq, ecmp_count, failed_only,
-			     ctx);
+	if (ctx->longer_prefix.prefixlen > 0)
+		longer_prefix_p = &ctx->longer_prefix;
 
-	return CMD_SUCCESS;
+	/* TODO -- convert to using only 'ctx' */
+	ret = do_show_route_helper(vty, zvrf, table, ctx->afi, ctx->safi, ctx->use_fib,
+				   ctx->tag, longer_prefix_p,
+				   ctx->supernets_only, ctx->type, ctx->ospf_instance_id,
+				   ctx->use_json, ctx->tableid, ctx->show_nhg,
+				   ctx->show_nhg_summary, ctx->ecmp_gt, ctx->ecmp_lt,
+				   ctx->ecmp_eq, ctx->ecmp_count, ctx->failed_only, ctx);
+
+	/* Capture iteration context if we're going to yield */
+	if (ret == CMD_YIELD) {
+		/* Schedule the yield - the lower level of the iteration needs to have
+		 * set up the resume params like last table, last vrf,
+		 * last prefix seen, etc.
+		 */
+		resume_show_ctx->yield_count++;
+		vty_yield(vty, show_resume_cb, resume_show_ctx);
+	} else if (ctx->all_table || ctx->all_vrf) {
+		/* Outer loop will handle */
+	} else {
+		/* Done with this vrf loop, finish */
+		zebra_vty_yield_finish(vty, CMD_SUCCESS);
+	}
+
+	return ret;
 }
 
 DEFPY (show_ip_nht,
@@ -2013,14 +2147,11 @@ DEFPY (show_route,
 {
 	afi_t afi = ipv4 ? AFI_IP : AFI_IP6;
 	safi_t safi = mrib ? SAFI_MULTICAST : SAFI_UNICAST;
-	bool first_vrf_json = true;
 	struct vrf *vrf;
 	uint8_t type = 0;
 	struct zebra_vrf *zvrf;
-	struct route_show_ctx ctx = {
-		.multi = vrf_all || table_all,
-		.brief = !!brief,
-	};
+	vrf_id_t vrf_id = VRF_DEFAULT;
+	struct route_show_ctx ctx = {};
 
 	if (!vrf_is_backend_netns()) {
 		if ((vrf_all || vrf_name) && (table || table_all)) {
@@ -2041,98 +2172,22 @@ DEFPY (show_route,
 		}
 	}
 
-	/* Handle nexthop-group summary separately */
-	if (ng && ng_summary) {
-		if (vrf_all) {
-			RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-				zvrf = vrf->info;
-				if (zvrf == NULL || zvrf->table[afi][safi] == NULL)
-					continue;
+	/* Set up show context struct with parameters from cli */
+	show_route_ctx_setup(&ctx, NULL, afi, safi, !!fib, !!json, tag,
+			     (prefix_str ? prefix : NULL), !!supernets_only, type,
+			     ospf_instance_id, table, !!ng, !!ng_summary, !!ecmp_gt, !!ecmp_lt,
+			     !!ecmp_eq, ecmp_count ? ecmp_count : 0, !!failed);
+	ctx.brief = !!brief;
+	ctx.multi = (vrf_all || table_all);
+	if (table_all)
+		ctx.all_table = true;
 
-				if (json)
-					vty_json_key(vty, zvrf_name(zvrf), &first_vrf_json);
-
-				if (table_all)
-					do_show_ip_route_all(vty, zvrf, afi, safi, !!fib, !!json,
-							     tag, prefix_str ? prefix : NULL,
-							     !!supernets_only, type,
-							     ospf_instance_id, !!ng, true,
-							     !!ecmp_gt, !!ecmp_lt, !!ecmp_eq,
-							     ecmp_count ? ecmp_count : 0, !!failed,
-							     &ctx);
-				else
-					do_show_ip_route(vty, zvrf_name(zvrf), afi, safi, !!fib,
-							 !!json, tag, prefix_str ? prefix : NULL,
-							 !!supernets_only, type, ospf_instance_id,
-							 table, false, true, !!ecmp_gt, !!ecmp_lt,
-							 !!ecmp_eq, ecmp_count ? ecmp_count : 0,
-							 !!failed, &ctx);
-			}
-			if (json)
-				vty_json_close(vty, first_vrf_json);
-		} else {
-			vrf_id_t vrf_id = VRF_DEFAULT;
-
-			if (vrf_name) {
-				if (!vrf_get_id(vty, &vrf_id, vrf_name, !!json))
-					return CMD_WARNING;
-			}
-			vrf = vrf_lookup_by_id(vrf_id);
-			if (!vrf)
-				return CMD_SUCCESS;
-
-			zvrf = vrf->info;
-			if (!zvrf)
-				return CMD_SUCCESS;
-
-			if (table_all)
-				do_show_ip_route_all(vty, zvrf, afi, safi, !!fib, !!json, tag,
-						     prefix_str ? prefix : NULL, !!supernets_only,
-						     type, ospf_instance_id, !!ng, true, !!ecmp_gt,
-						     !!ecmp_lt, !!ecmp_eq,
-						     ecmp_count ? ecmp_count : 0, !!failed, &ctx);
-			else
-				do_show_ip_route(vty, vrf->name, afi, safi, !!fib, !!json, tag,
-						 prefix_str ? prefix : NULL, !!supernets_only,
-						 type, ospf_instance_id, table, false, true,
-						 !!ecmp_gt, !!ecmp_lt, !!ecmp_eq,
-						 ecmp_count ? ecmp_count : 0, !!failed, &ctx);
-		}
-
-		return CMD_SUCCESS;
-	}
-
-	/* Normal route display */
 	if (vrf_all) {
-		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-			zvrf = vrf->info;
-			if (zvrf == NULL || zvrf->table[afi][safi] == NULL)
-				continue;
-			if (json)
-				vty_json_key(vty, zvrf_name(zvrf),
-					     &first_vrf_json);
-			if (table_all) {
-				show_route_ctx_setup(
-					&ctx, zvrf, afi, safi, !!fib,
-					!!json,	tag, (prefix_str ? prefix : NULL),
-					!!supernets_only, type,	ospf_instance_id,
-					0, !!ng, false, false, false, false, 0, !!failed);
+		ctx.all_vrf = true;
 
-				ctx.multi = (vrf_all || table_all);
-
-				do_show_ip_route_all_ctx(vty, &ctx);
-			} else {
-				do_show_ip_route(vty, zvrf_name(zvrf), afi, safi, !!fib, !!json,
-						 tag, prefix_str ? prefix : NULL, !!supernets_only,
-						 type, ospf_instance_id, table, !!ng, false, false,
-						 false, false, 0, !!failed, &ctx);
-			}
-		}
-		if (json)
-			vty_json_close(vty, first_vrf_json);
+		/* This handler deals with vrf iteration, and with yield/resume */
+		do_show_route_vrf_all(vty, &ctx);
 	} else {
-		vrf_id_t vrf_id = VRF_DEFAULT;
-
 		if (vrf_name) {
 			if (!vrf_get_id(vty, &vrf_id, vrf_name, !!json))
 				return CMD_WARNING;
@@ -2145,16 +2200,12 @@ DEFPY (show_route,
 		if (!zvrf)
 			return CMD_SUCCESS;
 
+		show_route_ctx_update_zvrf(&ctx, zvrf);
+
 		if (table_all)
-			do_show_ip_route_all(vty, zvrf, afi, safi, !!fib, !!json, tag,
-					     prefix_str ? prefix : NULL, !!supernets_only, type,
-					     ospf_instance_id, !!ng, false, false, false, false, 0,
-					     !!failed, &ctx);
+			do_show_ip_route_all_ctx(vty, &ctx);
 		else
-			do_show_ip_route(vty, vrf->name, afi, safi, !!fib, !!json, tag,
-					 prefix_str ? prefix : NULL, !!supernets_only, type,
-					 ospf_instance_id, table, !!ng, false, false, false, false,
-					 0, !!failed, &ctx);
+			do_show_ip_route_ctx(vty, zvrf, &ctx);
 	}
 
 	return CMD_SUCCESS;

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -55,12 +55,61 @@
 #include "zebra/zebra_neigh.h"
 #include "zebra/zebra_ptm.h"
 
-/* context to manage dumps in multiple tables or vrfs */
+/* context to manage show output in multiple tables or vrfs */
 struct route_show_ctx {
 	bool multi;       /* dump multiple tables or vrf */
 	bool header_done; /* common header already displayed */
 	bool brief;	  /* brief json output */
+	bool allocated;	  /* malloc'd (vs on-stack) */
+
+	safi_t safi;
+	afi_t afi;
+	uint32_t tableid;
+	route_tag_t tag;
+	int type;
+	unsigned short ospf_instance_id;
+
+	/* Filter/specifier arguments from show command */
+	bool supernets_only;
+	bool use_fib;
+	bool use_json;
+	bool show_nhg;
+	bool show_nhg_summary;
+	bool ecmp_gt;
+	bool ecmp_lt;
+	bool ecmp_eq;
+	bool failed_only;
+	uint16_t ecmp_count;
+
+	struct vty *vty;
+	char vrf_name[VRF_NAMSIZ];
+	struct zebra_vrf *zvrf;
+	struct route_table *table;
+	struct prefix longer_prefix;
+
+	struct json_object *json_obj;
+
+	/* For yield/resume */
+	bool resuming;
+	uint32_t total_counter;
+	uint32_t curr_counter;
+
+	afi_t last_afi;
+	safi_t last_safi;
+	vrf_id_t last_vrfid;
+	uint32_t last_tableid;
+	bool last_first_json;
+	struct prefix last_prefix;
+	struct prefix_ipv6 last_src_prefix;
 };
+
+/* If we're yielding/resuming large show output, we'll allocate a context
+ * struct and use it until we're done with the entire operation.
+ */
+static struct route_show_ctx *resume_show_ctx;
+
+/* Max routes to show before yielding */
+uint32_t show_yield_limit = 1000;
 
 static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi, safi_t safi,
 			    bool use_fib, bool use_json, route_tag_t tag,
@@ -76,6 +125,7 @@ static void vty_show_ip_route_summary_prefix(struct vty *vty,
 					     struct route_table *table,
 					     json_object *vrf_json,
 					     bool use_json);
+
 /* Helper api to format a nexthop in the 'detailed' output path. */
 static void show_nexthop_detail_helper(struct vty *vty,
 				       const struct route_node *rn,
@@ -783,6 +833,26 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn, struct rou
 
 }
 
+/*
+ * Callback for yield/resume cycles during show command output.
+ */
+static void show_resume_cb(struct vty *vty, void *arg)
+{
+	/* Check 'vty' - will be NULL if this is a cleanup notification */
+	if (vty == NULL) {
+		if (arg == resume_show_ctx)
+			resume_show_ctx = NULL;
+		XFREE(MTYPE_TMP, arg);
+		return;
+	}
+
+	/* Ok to continue */
+
+}
+
+/*
+ *
+ */
 static void vty_show_ip_route_detail_json(struct vty *vty,
 					  struct route_node *rn, bool use_fib)
 {
@@ -846,13 +916,13 @@ static void zebra_vty_display_vrf_header(struct vty *vty, struct zebra_vrf *zvrf
 	}
 }
 
-static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
-				 struct route_table *table, afi_t afi, safi_t safi, bool use_fib,
-				 route_tag_t tag, const struct prefix *longer_prefix_p,
-				 bool supernets_only, int type, unsigned short ospf_instance_id,
-				 bool use_json, uint32_t tableid, bool show_ng,
-				 bool show_nhg_summary, bool ecmp_gt, bool ecmp_lt, bool ecmp_eq,
-				 uint16_t ecmp_count, bool failed_only, struct route_show_ctx *ctx)
+static int do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
+				struct route_table *table, afi_t afi, safi_t safi, bool use_fib,
+				route_tag_t tag, const struct prefix *longer_prefix_p,
+				bool supernets_only, int type, unsigned short ospf_instance_id,
+				bool use_json, uint32_t tableid, bool show_ng,
+				bool show_nhg_summary, bool ecmp_gt, bool ecmp_lt, bool ecmp_eq,
+				uint16_t ecmp_count, bool failed_only, struct route_show_ctx *ctx)
 {
 	struct route_node *rn;
 	struct route_entry *re;
@@ -862,6 +932,10 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 	json_object *json_prefix = NULL;
 	uint32_t addr;
 	char buf[BUFSIZ];
+	const struct rib_table_info *zinfo = table->info;
+	const struct prefix_ipv6 *src_pfx;
+	const struct prefix *pfx;
+	int ret = CMD_SUCCESS;
 
 	/*
 	 * ctx->multi indicates if we are dumping multiple tables or vrfs.
@@ -874,8 +948,20 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 	 *   => display the VRF and table if specific
 	 */
 
+	/* Determine whether we're resuming an iteration, or starting one */
+	if (ctx->resuming) {
+		src_pfx = NULL;
+		if (ctx->last_src_prefix.prefixlen > 0)
+			src_pfx = &(ctx->last_src_prefix);
+		rn = srcdest_rnode_lookup(table, &(ctx->last_prefix), src_pfx);
+		/* TODO -- decide whether to advance to "next" here or not */
+
+	} else {
+		rn = route_top(table);
+	}
+
 	/* Show all routes. */
-	for (rn = route_top(table); rn; rn = srcdest_route_next(rn)) {
+	for ( ; rn; rn = srcdest_route_next(rn)) {
 		dest = rib_dest_from_rnode(rn);
 
 		if (longer_prefix_p && !prefix_match(longer_prefix_p, &rn->p))
@@ -935,7 +1021,8 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 			vty_show_ip_route(vty, rn, re, json_prefix, use_fib, show_ng,
 					  show_nhg_summary, ecmp_gt, ecmp_lt, ecmp_eq, ecmp_count,
 					  ctx->brief);
-		}
+			ctx->curr_counter++;
+		} /* for each re in rn */
 
 		if (json_prefix) {
 			/* Only output if array has elements */
@@ -949,10 +1036,48 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 
 			json_prefix = NULL;
 		}
+
+		/* Time to yield? */
+		if (ctx->curr_counter > show_yield_limit) {
+			ctx->total_counter += ctx->curr_counter;
+			ctx->curr_counter = 0;
+
+			/* Capture info needed for resume */
+			if (ctx != resume_show_ctx) {
+				resume_show_ctx =
+					XCALLOC(MTYPE_TMP,
+						sizeof(struct route_show_ctx));
+
+				*resume_show_ctx = *ctx;
+			}
+
+			resume_show_ctx->last_afi = afi;
+			resume_show_ctx->last_safi = SAFI_UNICAST;
+			resume_show_ctx->last_vrfid = zvrf->vrf->vrf_id;
+			resume_show_ctx->last_tableid = zinfo->table_id;
+			resume_show_ctx->last_first_json = first_json;
+			prefix_copy(&(resume_show_ctx->last_prefix), &(rn->p));
+			srcdest_rnode_prefixes(rn, NULL, &pfx);
+			if (pfx)
+				prefix_copy(&(resume_show_ctx->last_src_prefix), pfx);
+			else
+				memset(&(resume_show_ctx->last_src_prefix), 0,
+				       sizeof(resume_show_ctx->last_src_prefix));
+
+			ret = CMD_YIELD;
+			break;
+		}
+	} /* for each rn in table */
+
+	if (ret == CMD_SUCCESS) {
+		/* Finished with this table */
+		if (use_json)
+			vty_json_close(vty, first_json);
+	} else {
+
 	}
 
-	if (use_json)
-		vty_json_close(vty, first_json);
+	return ret;
 }
 
 static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf, afi_t afi, safi_t safi,
@@ -979,6 +1104,100 @@ static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf, afi_t 
 				 zrt->tableid, show_ng, show_nhg_summary, ecmp_gt, ecmp_lt,
 				 ecmp_eq, ecmp_count, failed_only, ctx);
 	}
+}
+
+/*
+ * Show routes for all tables in the vrf indicated by 'ctx'
+ */
+static void do_show_ip_route_all_ctx(struct vty *vty, struct route_show_ctx *ctx)
+{
+	struct zebra_router_table *zrt;
+	struct rib_table_info *info;
+	const struct prefix *longer_prefix_p = NULL;
+	struct zebra_router_table finder = {};
+	int ret = CMD_SUCCESS;
+
+	if (ctx->longer_prefix.prefixlen > 0)
+		longer_prefix_p = &ctx->longer_prefix;
+
+	/* Locate starting point if we're resuming an iteration; otherwise start
+	 * with the first table.
+	 */
+	if (ctx->resuming) {
+		finder.tableid = ctx->last_tableid;
+		zrt = RB_NFIND(zebra_router_table_head, &zrouter.tables, &finder);
+	} else {
+		zrt = RB_MIN(zebra_router_table_head, &zrouter.tables);
+	}
+
+	while (zrt != NULL) {
+		info = route_table_get_info(zrt->table);
+
+		if (ctx->zvrf != info->zvrf)
+			continue;
+		if (zrt->afi != ctx->afi || zrt->safi != SAFI_UNICAST)
+			continue;
+
+		ret = do_show_ip_route(vty, zvrf_name(ctx->zvrf), ctx->afi,
+				       ctx->safi, ctx->use_fib, ctx->use_json,
+				       ctx->tag, longer_prefix_p, ctx->supernets_only,
+				       ctx->type, ctx->ospf_instance_id, zrt->tableid,
+				       ctx->show_nhg, ctx->show_nhg_summary, ctx->ecmp_gt,
+				       ctx->ecmp_lt, ctx->ecmp_eq, ctx->ecmp_count,
+				       ctx->failed_only, ctx);
+
+		if (ret != CMD_SUCCESS)
+			break;
+
+		zrt = RB_NEXT(zebra_router_table_head, zrt);
+	}
+
+	/* Capture iteration context if we're going to yield */
+	if (ret == CMD_YIELD) {
+		/* Schedule the yield - the lower level of the iteration needs to have
+		 * set up the resume params like last table, last vrf,
+		 * last prefix seen, etc.
+		 */
+		vty_yield(vty, show_resume_cb, resume_show_ctx);
+	}
+}
+
+/*
+ * Copy various route show params into a single 'show context' object
+ */
+static void show_route_ctx_setup(struct route_show_ctx *ctx,
+				 struct zebra_vrf *zvrf, afi_t afi, safi_t safi,
+				 bool use_fib, bool use_json, route_tag_t tag,
+				 const struct prefix *longer_prefix_p,
+				 bool supernets_only, int type,
+				 unsigned short instance_id, uint32_t tableid,
+				 bool show_nhg, bool show_nhg_summary, bool ecmp_gt,
+				 bool ecmp_lt, bool ecmp_eq, uint16_t ecmp_count,
+				 bool failed_only)
+{
+	memset(ctx, 0, sizeof(struct route_show_ctx));
+
+	ctx->afi = afi;
+	ctx->safi = safi;
+	ctx->use_fib = use_fib;
+	ctx->use_json = use_json;
+	ctx->tag = tag;
+	ctx->supernets_only = supernets_only;
+	ctx->type = type;
+	ctx->ospf_instance_id = instance_id;
+	ctx->tableid = tableid;
+	ctx->show_nhg = show_nhg;
+	ctx->zvrf = zvrf;
+	ctx->show_nhg_summary = show_nhg_summary;
+	ctx->ecmp_gt = ecmp_gt;
+	ctx->ecmp_lt = ecmp_lt;
+	ctx->ecmp_eq = ecmp_eq;
+	ctx->ecmp_count = ecmp_count;
+	ctx->failed_only = failed_only;
+
+	if (longer_prefix_p)
+		prefix_copy(&(ctx->longer_prefix), longer_prefix_p);
+
 }
 
 static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi, safi_t safi,
@@ -1892,16 +2111,22 @@ DEFPY (show_route,
 			if (json)
 				vty_json_key(vty, zvrf_name(zvrf),
 					     &first_vrf_json);
-			if (table_all)
-				do_show_ip_route_all(vty, zvrf, afi, safi, !!fib, !!json, tag,
-						     prefix_str ? prefix : NULL, !!supernets_only,
-						     type, ospf_instance_id, !!ng, false, false,
-						     false, false, 0, !!failed, &ctx);
-			else
+			if (table_all) {
+				show_route_ctx_setup(
+					&ctx, zvrf, afi, safi, !!fib,
+					!!json,	tag, (prefix_str ? prefix : NULL),
+					!!supernets_only, type,	ospf_instance_id,
+					0, !!ng, false, false, false, false, 0, !!failed);
+
+				ctx.multi = (vrf_all || table_all);
+
+				do_show_ip_route_all_ctx(vty, &ctx);
+			} else {
 				do_show_ip_route(vty, zvrf_name(zvrf), afi, safi, !!fib, !!json,
 						 tag, prefix_str ? prefix : NULL, !!supernets_only,
 						 type, ospf_instance_id, table, !!ng, false, false,
 						 false, false, 0, !!failed, &ctx);
+			}
 		}
 		if (json)
 			vty_json_close(vty, first_vrf_json);


### PR DESCRIPTION
This is some preliminary work towards support for yield/resume during long-running show commands - such as "show ip route" or the high-scale bgp show commands. I understand there's been some interest in that area that may appear in a PR ... soon, and I wanted to offer some of the vty library ideas in case that aspect is useful.
This PR adds library support, and converts the "show ip[X] route" commands in zebra so that they can use the yield/resume features.

The main zebra change is converting the series of apis that locates vrfs and route-tables and then iterates for the all-vrfs and all-tables forms of the clis. These apis now use a common show "context" struct that captures the incoming cli parameters, such as afi/safi and various filters. The context struct also includes fields to capture the last-processed key data from zebra's route-nodes and route-entries; that data is then used after yielding when resuming iteration.

A question for reviewers would be: which error cases should be treated as failure, and which should be handled gracefully? For example, if a vrf or route-table is deleted before a show iteration resumes, should the show command just fail and stop? or should it terminate data from the deleted vrf (for json particularly) and move on to the next object in the iteration?
