### PR TITLE
zebra: Cleanup early route Q when removing routes.

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -211,6 +211,8 @@ static void connected_remove_kernel_for_connected(afi_t afi, safi_t safi, struct
 
 	rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_KERNEL, 0, 0, p, NULL, nh, 0,
 		   zvrf->table_id, 0, 0, false);
+
+	rib_meta_queue_early_route_cleanup(p, ZEBRA_ROUTE_KERNEL);
 }
 
 /* Called from if_up(). */

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -480,6 +480,7 @@ int zebra_rib_queue_evpn_rem_vtep_del(vrf_id_t vrf_id, vni_t vni,
 
 extern void meta_queue_free(struct meta_queue *mq, struct zebra_vrf *zvrf);
 extern int zebra_rib_labeled_unicast(struct route_entry *re);
+extern void rib_meta_queue_early_route_cleanup(const struct prefix *p, int route_type);
 extern struct route_table *rib_table_ipv6;
 
 extern uint32_t zebra_rib_meta_queue_size(void);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4451,6 +4451,37 @@ static int rib_meta_queue_early_route_add(struct meta_queue *mq, void *data)
 	return 0;
 }
 
+void rib_meta_queue_early_route_cleanup(const struct prefix *p, int route_type)
+{
+	struct listnode *node, *nnode;
+	struct zebra_early_route *ere;
+
+	/* Iterate through the early route subqueue */
+	for (ALL_LIST_ELEMENTS(zrouter.mq->subq[META_QUEUE_EARLY_ROUTE], node, nnode, ere)) {
+		/* Check if this entry matches the prefix and route type */
+		if (prefix_same(&ere->p, p) && ere->re->type == route_type) {
+			/* Remove from the list */
+			list_delete_node(zrouter.mq->subq[META_QUEUE_EARLY_ROUTE], node);
+
+			/* Update counters */
+			zrouter.mq->size--;
+			atomic_fetch_sub_explicit(&zrouter.mq->total_metaq, 1,
+						  memory_order_relaxed);
+			atomic_fetch_sub_explicit(&zrouter.mq->total_subq[META_QUEUE_EARLY_ROUTE],
+						  1, memory_order_relaxed);
+
+			/* Free the early route memory */
+			early_route_memory_free(ere);
+
+			if (IS_ZEBRA_DEBUG_RIB_DETAILED) {
+				struct vrf *vrf = vrf_lookup_by_id(ere->re->vrf_id);
+				zlog_debug("Route %pFX(%s) type %d removed from early route queue",
+					   p, VRF_LOGNAME(vrf), route_type);
+			}
+		}
+	}
+}
+
 int rib_add_gr_run(afi_t afi, vrf_id_t vrf_id, uint8_t proto, uint8_t instance,
 		   time_t restart_time)
 {


### PR DESCRIPTION
It's possible due to ordering of events that a kernel route has not been processed yet, yet we have received a connected route for the same kernel route that needs to be deleted and as such it is on the early route Q. Let's write a bit of code that allows us to search the early Route Q and remove the data.