### PR TITLE
Revert l3vni optimization

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -7300,14 +7300,6 @@ int bgp_evpn_local_l3vni_del(vni_t l3vni, vrf_id_t vrf_id)
 		return -1;
 	}
 
-	if (!bgp_vrf->l3vni) {
-		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_debug("Returning from %s since VNI %u is already deleted", __func__,
-				   l3vni);
-
-		return -1;
-	}
-
 	/*
 	 * Move all the l3vni_delete operation post the remote route
 	 * installation processing i.e. add the L3VNI DELETE item on the

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -210,5 +210,4 @@ int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf, const struct prefix_e
 				      struct bgp_path_info *parent_pi);
 extern void bgp_zebra_evpn_pop_items_from_announce_fifo(struct bgpevpn *vpn);
 extern int install_uninstall_routes_for_vni(struct bgp *bgp, struct bgpevpn *vpn, bool install);
-extern int install_uninstall_routes_for_vrf(struct bgp *bgp_vrf, bool install);
 #endif /* _QUAGGA_BGP_EVPN_H */

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -216,7 +216,6 @@ static FRR_NORETURN void bgp_exit(int status)
 
 	zebra_announce_fini(&bm->zebra_announce_head);
 	zebra_l2_vni_fini(&bm->zebra_l2_vni_head);
-	zebra_l3_vni_fini(&bm->zebra_l3_vni_head);
 
 	/* reverse bgp_dump_init */
 	bgp_dump_finish();

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1705,13 +1705,7 @@ DEFUN (no_router_bgp,
 		}
 
 		if (bgp->l3vni) {
-			if (CHECK_FLAG(bgp->flags, BGP_FLAG_L3VNI_SCHEDULE_FOR_DELETE))
-				vty_out(vty,
-					"%% L3VNI %u is scheduled to be deleted. Please give it few secs and retry the command\n",
-					bgp->l3vni);
-			else
-				vty_out(vty, "%% Please unconfigure l3vni %u\n", bgp->l3vni);
-
+			vty_out(vty, "%% Please unconfigure l3vni %u\n", bgp->l3vni);
 			return CMD_WARNING_CONFIG_FAILED;
 		}
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3146,31 +3146,6 @@ void bgp_zebra_process_remote_routes_for_l2vni(struct event *e)
 				     20, &bm->t_bgp_zebra_l2_vni);
 }
 
-void bgp_zebra_process_remote_routes_for_l3vrf(struct event *e)
-{
-	/*
-	 * Install/Uninstall all remote routes belonging to l3vni
-	 *
-	 * NOTE:
-	 *  - At this point it does not matter whether we call
-	 *    install_routes_for_vrf/uninstall_routes_for_vrf.
-	 *  - Since we pass struct bgp as NULL,
-	 *      * we iterate the bm FIFO list
-	 *      * the second variable (true) is ignored as well and
-	 *        calculated based on the BGP-VRFs flags for ADD/DELETE.
-	 */
-	install_uninstall_routes_for_vrf(NULL, true);
-
-	/*
-	 * If there are L3VNIs still pending to be processed, schedule them
-	 * after a small sleep so that CPU can be used for other purposes.
-	 */
-	if (zebra_l3_vni_count(&bm->zebra_l3_vni_head)) {
-		event_add_timer_msec(bm->master, bgp_zebra_process_remote_routes_for_l3vrf, NULL,
-				     20, &bm->t_bgp_zebra_l3_vni);
-	}
-}
-
 static int bgp_zebra_process_local_es_add(ZAPI_CALLBACK_ARGS)
 {
 	esi_t esi;

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -152,5 +152,4 @@ extern enum zclient_send_status
 bgp_zebra_withdraw_actual(struct bgp_dest *dest, struct bgp_path_info *info,
 			  struct bgp *bgp);
 extern void bgp_zebra_process_remote_routes_for_l2vni(struct event *e);
-extern void bgp_zebra_process_remote_routes_for_l3vrf(struct event *e);
 #endif /* _QUAGGA_BGP_ZEBRA_H */

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4107,13 +4107,11 @@ int bgp_delete(struct bgp *bgp)
 	struct bgp_dest *dest_next = NULL;
 	struct bgp_table *dest_table = NULL;
 	struct graceful_restart_info *gr_info;
-	uint32_t b_ann_cnt = 0, b_l2_cnt = 0, b_l3_cnt = 0;
-	uint32_t a_ann_cnt = 0, a_l2_cnt = 0, a_l3_cnt = 0;
-	struct bgp *bgp_to_proc = NULL;
-	struct bgp *bgp_to_proc_next = NULL;
 	struct bgp *bgp_default = bgp_get_default();
 	struct bgp_clearing_info *cinfo;
 	struct peer_connection *connection;
+	uint32_t b_ann_cnt = 0, b_l2_cnt = 0;
+	uint32_t a_ann_cnt = 0, a_l2_cnt = 0;
 
 	assert(bgp);
 
@@ -4147,21 +4145,11 @@ int bgp_delete(struct bgp *bgp)
 		}
 	}
 
-	b_l3_cnt = zebra_l3_vni_count(&bm->zebra_l3_vni_head);
-	for (bgp_to_proc = zebra_l3_vni_first(&bm->zebra_l3_vni_head); bgp_to_proc;
-	     bgp_to_proc = bgp_to_proc_next) {
-		bgp_to_proc_next = zebra_l3_vni_next(&bm->zebra_l3_vni_head, bgp_to_proc);
-		if (bgp_to_proc == bgp)
-			zebra_l3_vni_del(&bm->zebra_l3_vni_head, bgp_to_proc);
-	}
-
 	if (BGP_DEBUG(zebra, ZEBRA)) {
 		a_ann_cnt = zebra_announce_count(&bm->zebra_announce_head);
 		a_l2_cnt = zebra_l2_vni_count(&bm->zebra_l2_vni_head);
-		a_l3_cnt = zebra_l3_vni_count(&bm->zebra_l3_vni_head);
-		zlog_debug("BGP %s deletion FIFO cnt Zebra_Ann before %u after %u, L2_VNI before %u after, %u L3_VNI before %u after %u",
-			   bgp->name_pretty, b_ann_cnt, a_ann_cnt, b_l2_cnt, a_l2_cnt, b_l3_cnt,
-			   a_l3_cnt);
+		zlog_debug("FIFO Cleanup Count during BGP %s deletion :: Zebra Announce - before %u after %u :: BGP L2_VNI - before %u after %u",
+			   bgp->name_pretty, b_ann_cnt, a_ann_cnt, b_l2_cnt, a_l2_cnt);
 	}
 
 	/* Cleanup for peer connection batching */
@@ -8772,7 +8760,6 @@ void bgp_master_init(struct event_loop *master, const int buffer_size,
 
 	zebra_announce_init(&bm->zebra_announce_head);
 	zebra_l2_vni_init(&bm->zebra_l2_vni_head);
-	zebra_l3_vni_init(&bm->zebra_l3_vni_head);
 	bm->bgp = list_new();
 	bm->listen_sockets = list_new();
 	bm->port = BGP_PORT_DEFAULT;
@@ -8797,7 +8784,6 @@ void bgp_master_init(struct event_loop *master, const int buffer_size,
 	bm->select_defer_time = BGP_DEFAULT_SELECT_DEFERRAL_TIME;
 	bm->rib_stale_time = BGP_DEFAULT_RIB_STALE_TIME;
 	bm->t_bgp_zebra_l2_vni = NULL;
-	bm->t_bgp_zebra_l3_vni = NULL;
 
 	bm->peer_clearing_batch_id = 1;
 	/* TODO -- make these configurable */
@@ -9052,7 +9038,6 @@ void bgp_terminate(void)
 	event_cancel(&bm->t_bgp_start_label_manager);
 	event_cancel(&bm->t_bgp_zebra_route);
 	event_cancel(&bm->t_bgp_zebra_l2_vni);
-	event_cancel(&bm->t_bgp_zebra_l3_vni);
 
 	bgp_mac_finish();
 #ifdef ENABLE_BGP_VNC

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -20,7 +20,6 @@
 
 PREDECL_LIST(zebra_announce);
 PREDECL_LIST(zebra_l2_vni);
-PREDECL_LIST(zebra_l3_vni);
 
 /* For union sockunion.  */
 #include "queue.h"
@@ -222,10 +221,6 @@ struct bgp_master {
 	struct event *t_bgp_zebra_l2_vni;
 	/* To preserve ordering of processing of L2 VNIs in BGP */
 	struct zebra_l2_vni_head zebra_l2_vni_head;
-
-	struct event *t_bgp_zebra_l3_vni;
-	/* To preserve ordering of processing of BGP-VRFs for L3 VNIs */
-	struct zebra_l3_vni_head zebra_l3_vni_head;
 
 	/* ID value for peer clearing batches */
 	uint32_t peer_clearing_batch_id;
@@ -665,9 +660,7 @@ struct bgp {
 #define BGP_FLAG_VNI_DOWN		 (1ULL << 38)
 #define BGP_FLAG_INSTANCE_HIDDEN	 (1ULL << 39)
 /* Prohibit BGP from enabling IPv6 RA on interfaces */
-#define BGP_FLAG_IPV6_NO_AUTO_RA (1ULL << 40)
-#define BGP_FLAG_L3VNI_SCHEDULE_FOR_INSTALL (1ULL << 41)
-#define BGP_FLAG_L3VNI_SCHEDULE_FOR_DELETE  (1ULL << 42)
+#define BGP_FLAG_IPV6_NO_AUTO_RA	    (1ULL << 40)
 #define BGP_FLAG_LINK_LOCAL_CAPABILITY	    (1ULL << 43)
 #define BGP_FLAG_VRF_MAY_LISTEN		    (1ULL << 44)
 
@@ -1004,13 +997,9 @@ struct bgp {
 	uint64_t node_already_on_queue;
 	uint64_t node_deferred_on_queue;
 
-	struct zebra_l3_vni_item zl3vni;
-
 	QOBJ_FIELDS;
 };
 DECLARE_QOBJ_TYPE(bgp);
-
-DECLARE_LIST(zebra_l3_vni, struct bgp, zl3vni);
 
 struct bgp_interface {
 #define BGP_INTERFACE_MPLS_BGP_FORWARDING (1 << 0)

--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_chaos_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_chaos_topo1.py
@@ -21,8 +21,6 @@ import sys
 import time
 import pytest
 import platform
-import functools
-from lib import topotest
 from copy import deepcopy
 
 
@@ -540,16 +538,6 @@ def test_RT_verification_auto_p0(request):
     }
     result = create_vrf_cfg(tgen, topo, input_dict=input_dict_vni)
     assert result is True, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
-
-    expected = {"numL3Vnis": 0}
-    test_func = functools.partial(
-        topotest.router_json_cmp,
-        tgen.gears["e1"],
-        "show bgp l2vpn evpn vni json",
-        expected,
-    )
-    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
-    assert result is None, "Testcase {} :Failed \n Error: {}".format(tc_name, result)
 
     input_dict_2 = {}
     for dut in ["e1"]:

--- a/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
+++ b/tests/topotests/evpn_type5_test_topo1/test_evpn_type5_topo1.py
@@ -25,8 +25,6 @@ import sys
 import time
 import pytest
 import platform
-import functools
-from lib import topotest
 from copy import deepcopy
 
 
@@ -2048,18 +2046,6 @@ def test_bgp_attributes_for_evpn_address_family_p1(request, attribute):
         }
         result = create_vrf_cfg(tgen, topo, input_dict=input_dict_vni)
         assert result is True, "Testcase {} :Failed \n Error: {}".format(
-            tc_name, result
-        )
-
-        expected = {"numL3Vnis": 0}
-        test_func = functools.partial(
-            topotest.router_json_cmp,
-            tgen.gears["d1"],
-            "show bgp l2vpn evpn vni json",
-            expected,
-        )
-        _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
-        assert result is None, "Testcase {} :Failed \n Error: {}".format(
             tc_name, result
         )
 


### PR DESCRIPTION
    There is an issue in this L3vni optimization design. With the current
    optimization, we have two issues.
     1) Overwriting the states (ADD/Withdraw) leading to inconsistencies
        between Zebra and BGP.
     2) Post processing handling in the delete

    - When BGP receives a L3VNI add
           * Pre-processes (update RDs, tunnel ip etc..)
           * Schedule the remote route processing for global walk
           * No post processing
    - However, in case of L3VNI del
           * No pre-processing
           * Schedules the remote route processing for global walk
           * Post-processing: handle the delete/memset portion of code

    Imagine the below situation
    T0: L3VNI Up in zebra
    T1: L3VNI added in BGP via Zebra
    T2: BGP imports type-5 route in the tenant VRF for this L3VNI based on
        import RTs
    T3: VRF routes runs best path and programmed in zebra
    T4: Before Zebra gets a chance to process this routes L3VNI is
        oper down (due to SVI down or some other reason)
    T5: When the route does get processed in zebra, nexthop_active marks
        this as in-active based on the DVNI/SVD check
    T6: L3VNI oper down goes down to BGP
    T7: L3VNI comes up, this trigger masks the l3vni down in BGP
    T8: BGP does not unimport/import the routes again and zebra is in stale state

    The right fix for this is
     1) DO NOT overwrite the updates (ADD/DELETE)
     2) Queue the entire handling i.e. pre-processing + remote-route +
        post-processing for later and not chunks of it.

    Note: L2VNI optimization still remains intact (zebra cleansup the state
    + no post processing). This issues is specific to L3vni optimization
    only because of post-processing in the DELETE handling.