### PR TITLE
staticd: add routes via dhcp-gateway of interface

### DIFF
--- a/doc/user/static.rst
+++ b/doc/user/static.rst
@@ -29,7 +29,7 @@ a static prefix and gateway, with several possible forms.
 
 .. clicmd:: ip route NETWORK GATEWAY [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
-.. clicmd:: ip route NETWORK IFNAME [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK [dhcp-gateway] IFNAME [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
 .. clicmd:: ip route NETWORK GATEWAY IFNAME [DISTANCE] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
@@ -76,6 +76,37 @@ a static prefix and gateway, with several possible forms.
    that destination longest-prefix match is "more important" than source
    LPM, e.g.  ``2001:db8:1::/64 from 2001:db8::/48`` will win over
    ``2001:db8::/48 from 2001:db8:1::/64`` if both match.
+
+   If ``dhcp-gateway`` is specified, nexthop will be the DHCP router gateway of IFNAME interface.
+   Currently only dhclient is supported. For this to work properly set lease path prefix and
+   suffix:
+
+   .. code-block:: frr
+
+       static-route-dhcp-gateway dhclient-lease-path-prefix LEASEPREFIX
+       static-route-dhcp-gateway dhclient-lease-path-suffix LEASESUFFIX
+
+   Lease file than has path `LEASEPREFIX IFNAME LEASESUFFIX`. E. g. with
+   LEASEPREFIX = `/var/run/dhclient/dhclient_` and suffix LEASESUFFIX =
+   `.lease` (these values are defaults) the resulting lease file path for
+   interface `eth0` will be `/var/run/dhclient/dhclient_eth0.lease`.
+
+   There are two options how FRR can watch for updates of DHCP gateway IP.
+
+   Dhclient hook can call FRR command
+
+   .. code-block:: frr
+
+      static-route-dhcp-gateway update
+
+   Or periodic polling can be set up via option:
+
+   .. code-block:: frr
+
+      static-route-dhcp-gateway poll-period PERIOD-SECONDS
+
+   If PERIOD-SECONDS is 0, polling is disabled (default)
+
 
 .. _multiple-route-command:
 

--- a/staticd/sample-dhclient-hook
+++ b/staticd/sample-dhclient-hook
@@ -1,0 +1,13 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# DHCP gateway related functions
+# Copyright (C) 2025 VyOS Inc.
+# Kyrylo Yatsenko
+
+# Try to inform FRR of any events that can change ip or DHCP state
+case "${reason}" in
+    BOUND|RENEW|REBIND|REBOOT|EXPIRE|FAIL|STOP|RELEASE)
+        vtysh -c 'static-route-dhcp-gateway update'
+        ;;
+esac

--- a/staticd/static_bfd.c
+++ b/staticd/static_bfd.c
@@ -58,16 +58,13 @@ static inline int
 static_next_hop_type_to_family(const struct static_nexthop *sn)
 {
 	switch (sn->type) {
+	case STATIC_IPV4_IFNAME_DHCP_GATEWAY:
 	case STATIC_IPV4_GATEWAY_IFNAME:
-	case STATIC_IPV6_GATEWAY_IFNAME:
 	case STATIC_IPV4_GATEWAY:
+		return AF_INET;
+	case STATIC_IPV6_GATEWAY_IFNAME:
 	case STATIC_IPV6_GATEWAY:
-		if (sn->type == STATIC_IPV4_GATEWAY ||
-		    sn->type == STATIC_IPV4_GATEWAY_IFNAME)
-			return AF_INET;
-		else
-			return AF_INET6;
-		break;
+		return AF_INET6;
 	case STATIC_IFNAME:
 	case STATIC_BLACKHOLE:
 	default:
@@ -102,8 +99,8 @@ void static_next_hop_bfd_monitor_enable(struct static_nexthop *sn,
 	if (family == AF_UNSPEC)
 		return;
 
-	if (sn->type == STATIC_IPV4_GATEWAY_IFNAME ||
-	    sn->type == STATIC_IPV6_GATEWAY_IFNAME)
+	if (sn->type == STATIC_IPV4_GATEWAY_IFNAME || sn->type == STATIC_IPV6_GATEWAY_IFNAME ||
+	    sn->type == STATIC_IPV4_IFNAME_DHCP_GATEWAY)
 		use_interface = true;
 
 	/* Reconfigure or allocate new memory. */
@@ -232,7 +229,8 @@ static void static_bfd_show_nexthop_json(struct vty *vty,
 	json_object_boolean_add(jo_nh, "installed", !sn->path_down);
 
 	/* Add peer address based on nexthop type */
-	if (sn->type == STATIC_IPV4_GATEWAY || sn->type == STATIC_IPV4_GATEWAY_IFNAME)
+	if (sn->type == STATIC_IPV4_GATEWAY || sn->type == STATIC_IPV4_GATEWAY_IFNAME ||
+	    sn->type == STATIC_IPV4_IFNAME_DHCP_GATEWAY)
 		json_object_string_addf(jo_nh, "peer", "%pI4", &sn->addr.ipv4);
 	else if (sn->type == STATIC_IPV6_GATEWAY || sn->type == STATIC_IPV6_GATEWAY_IFNAME)
 		json_object_string_addf(jo_nh, "peer", "%pI6", &sn->addr.ipv6);
@@ -311,8 +309,8 @@ static void static_bfd_show_nexthop(struct vty *vty,
 		return;
 	}
 
-	if (sn->type == STATIC_IPV4_GATEWAY ||
-	    sn->type == STATIC_IPV4_GATEWAY_IFNAME)
+	if (sn->type == STATIC_IPV4_GATEWAY || sn->type == STATIC_IPV4_GATEWAY_IFNAME ||
+	    sn->type == STATIC_IPV4_IFNAME_DHCP_GATEWAY)
 		vty_out(vty, " peer %pI4", &sn->addr.ipv4);
 	else if (sn->type == STATIC_IPV6_GATEWAY ||
 		 sn->type == STATIC_IPV6_GATEWAY_IFNAME)

--- a/staticd/static_dhcpgw.c
+++ b/staticd/static_dhcpgw.c
@@ -1,0 +1,468 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * DHCP gateway related functions
+ * Copyright (C) 2025 VyOS Inc.
+ * Kyrylo Yatsenko
+ */
+
+#include <zebra.h>
+
+#include <sys/stat.h>
+#include <time.h>
+
+#include "lib/command.h"
+#include "lib/debug.h"
+#include "lib/bfd.h"
+
+#include "static_dhcpgw.h"
+
+DEFINE_MGROUP(STATIC_DHCPGW, "staticd-dhcp-gateway");
+
+DEFINE_MTYPE_STATIC(STATIC_DHCPGW, STATIC_DHCPGW_NEXTHOP, "Static DHCP Gateway Nexthop");
+DEFINE_MTYPE_STATIC(STATIC_DHCPGW, STATIC_DHCPGW_INTERFACE, "Static DHCP Gateway Interface");
+
+/* Default values */
+#define DHCLIENT_DEFAULT_LEASE_PATH_PREFIX "/var/run/dhclient/dhclient_"
+#define DHCLIENT_DEFAULT_LEASE_PATH_SUFFIX ".lease"
+#define DHCLIENT_DEFAULT_UPDATE_PERIOD_S   0L
+
+/* Options */
+static unsigned long poll_period_seconds = DHCLIENT_DEFAULT_UPDATE_PERIOD_S;
+static char lease_path_prefix[MAXPATHLEN] = DHCLIENT_DEFAULT_LEASE_PATH_PREFIX;
+static char lease_path_suffix[MAXPATHLEN] = DHCLIENT_DEFAULT_LEASE_PATH_SUFFIX;
+
+/* Master event loop, used to create events */
+static struct event_loop *master;
+
+
+/*
+ * List of nexthops to watch
+ */
+PREDECL_SORTLIST_UNIQ(static_dhcpgw_nexthop_list);
+
+struct static_dhcpgw_nexthop {
+	/* For linked list. */
+	struct static_dhcpgw_nexthop_list_item list;
+
+	struct static_nexthop *nh;
+};
+
+static int cmp_static_dhcpgw_nexthop(const struct static_dhcpgw_nexthop *a,
+				     const struct static_dhcpgw_nexthop *b)
+{
+	return (int)(a->nh - b->nh);
+}
+
+DECLARE_SORTLIST_UNIQ(static_dhcpgw_nexthop_list, struct static_dhcpgw_nexthop, list,
+		      cmp_static_dhcpgw_nexthop);
+
+
+/*
+ * List of interface lease files with cached data to watch
+ */
+PREDECL_SORTLIST_UNIQ(static_dhcpgw_interface_list);
+
+struct static_dhcpgw_interface {
+	/* For linked list. */
+	struct static_dhcpgw_interface_list_item list;
+
+	char ifname[IFNAMSIZ + 1];    /* Main key of item - which interface is watched */
+	char lease_path[MAXPATHLEN];  /* Cached path to lease file */
+	struct timespec last_st_mtim; /* Last seen modification time of lease file */
+	bool last_valid;	      /* Last cached is interface valid */
+	struct in_addr last_addr;     /* Last cached address for interface */
+	int nh_count;		      /* Counter of nexthops that use this interface */
+};
+
+static int cmp_static_dhcpgw_interface(const struct static_dhcpgw_interface *a,
+				       const struct static_dhcpgw_interface *b)
+{
+	return strcmp(a->ifname, b->ifname);
+}
+
+DECLARE_SORTLIST_UNIQ(static_dhcpgw_interface_list, struct static_dhcpgw_interface, list,
+		      cmp_static_dhcpgw_interface);
+
+
+/*
+ * Basic functionality section
+ */
+
+/* List of watched nexthops */
+static struct static_dhcpgw_nexthop_list_head nexthops_list_head;
+
+/* Helper when lease path prefix or suffix updated */
+static void static_dhcpgw_update_lease_path_helper(void);
+
+/* Update all watched nexthops */
+static void static_dhcpgw_update_nexthops(void);
+
+/*
+ * Updates one static_nexthop IP and nh_valid values
+ *
+ * Uses cached values from interfaces_list_head
+ *
+ * nh
+ *      Nexthop to update
+ *
+ * install
+ *      If true, make call of static_install_path to install nexthop, if any
+ *      change took place
+ *
+ * force_update
+ *      Ignore interfaces_list_head `has_updates` field - compare
+ *      address/valid anyway
+ */
+static void static_dhcpgw_update_nexthop(struct static_nexthop *nh, bool install,
+					 bool force_update);
+
+/*
+ * Dhclient specific - reads lease data from lease file
+ */
+
+/*
+ * Get DHCP gateway ipv4 address by lease path
+ * Reads dhclient lease file
+ *
+ * out_addr
+ *    Parsed IP address. 0.0.0.0 if no DHCP gateway
+ *
+ * out_valid
+ *    Is there gateway for this lease file
+ *
+ * leasepath
+ *    Path to dhclient lease file
+ */
+static void get_dhcpgw_dhclient_ipv4_address(struct in_addr *out_addr, bool *out_valid,
+					     const char *lease_path);
+
+/*
+ * Lease files cache functions
+ *
+ * Store list of static_dhcpgw_interface, one per each interface
+ * that is used in any of watched nexthops.
+ *
+ * Each list item stores path, last modification date, last address
+ * and last validness. Also it stores counter of nexthops with the interface
+ * to remove item from list when there are none.
+ */
+
+/* List of interfaces */
+static struct static_dhcpgw_interface_list_head interfaces_list_head;
+
+/* Initialize interface after allocation */
+static void static_dhcpgw_interface_init(struct static_dhcpgw_interface *pif,
+					 struct static_nexthop *nh);
+/* Update interface lease path using prefix and suffix, call static_dhcpgw_interface_update */
+static void static_dhcpgw_interface_update_path(struct static_dhcpgw_interface *pif);
+/* Update interface data - reread lease file if it is modified */
+static void static_dhcpgw_interface_update(struct static_dhcpgw_interface *pif);
+/* Helper - return interface from list by ifname as key */
+static struct static_dhcpgw_interface *get_dhcpgw_interface_by_ifname(const char *ifname);
+/* Create interface item if needed, increment counter */
+static void static_dhcpgw_interfaces_on_add_nexthop(struct static_nexthop *nh);
+/* Delete interface item if needed, decrement counter */
+static void static_dhcpgw_interfaces_on_del_nexthop(struct static_nexthop *nh);
+
+
+/*
+ * Polling timer section
+ */
+struct event *dhcpgw_timer;
+
+static void static_dhcpgw_start_timer_if_needed(void);
+static void static_dhcpgw_timer_event_cb(struct event *ev);
+
+
+/*
+ * IMPLEMENTATION
+ */
+
+extern void static_dhcpgw_init(struct event_loop *m)
+{
+	master = m;
+	static_dhcpgw_nexthop_list_init(&nexthops_list_head);
+	static_dhcpgw_interface_list_init(&interfaces_list_head);
+}
+
+extern void static_dhcpgw_close(void)
+{
+	static_dhcpgw_set_poll_period_seconds(0);
+	/* lists should be emptied by calls of static_dhcpgw_del_nexthop_watch for
+	 * each nexthop
+	 */
+}
+
+extern void static_dhcpgw_add_nexthop_watch(struct static_nexthop *nh)
+{
+	struct static_dhcpgw_nexthop dgnh;
+
+	dgnh.nh = nh;
+	/* Check if this nexthop is already watched */
+	if (!static_dhcpgw_nexthop_list_find(&nexthops_list_head, &dgnh)) {
+		struct static_dhcpgw_nexthop *p = XCALLOC(MTYPE_STATIC_DHCPGW_NEXTHOP,
+							  sizeof(struct static_dhcpgw_nexthop));
+		p->nh = nh;
+		static_dhcpgw_nexthop_list_add(&nexthops_list_head, p);
+		static_dhcpgw_interfaces_on_add_nexthop(nh);
+		static_dhcpgw_update_nexthop(nh, false, true);
+		static_dhcpgw_start_timer_if_needed();
+	}
+}
+
+extern void static_dhcpgw_del_nexthop_watch(struct static_nexthop *nh)
+{
+	struct static_dhcpgw_nexthop dgnh;
+	struct static_dhcpgw_nexthop *p;
+
+	dgnh.nh = nh;
+	p = static_dhcpgw_nexthop_list_find(&nexthops_list_head, &dgnh);
+	if (!p)
+		return;
+	static_dhcpgw_nexthop_list_del(&nexthops_list_head, &dgnh);
+	static_dhcpgw_interfaces_on_del_nexthop(nh);
+	XFREE(MTYPE_STATIC_DHCPGW_NEXTHOP, p);
+}
+
+extern void static_dhcpgw_set_poll_period_seconds(unsigned long seconds)
+{
+	poll_period_seconds = seconds;
+
+	/* If previous poll period was bigger than current and time left till
+	 * event is bigger than new poll period, cancel previous event
+	 * Also cancels event if poll_period_seconds == 0 with meaning that polling is disabled
+	 */
+	if (dhcpgw_timer && event_timer_remain_second(dhcpgw_timer) > poll_period_seconds)
+		event_cancel(&dhcpgw_timer);
+
+	static_dhcpgw_start_timer_if_needed();
+}
+
+extern void static_dhcpgw_set_lease_path_prefix(const char *prefix)
+{
+	strlcpy(lease_path_prefix, prefix, sizeof(lease_path_prefix));
+
+	static_dhcpgw_update_lease_path_helper();
+}
+
+extern void static_dhcpgw_set_lease_path_suffix(const char *suffix)
+{
+	strlcpy(lease_path_suffix, suffix, sizeof(lease_path_suffix));
+
+	static_dhcpgw_update_lease_path_helper();
+}
+
+extern void static_dhcpgw_update(void)
+{
+	static_dhcpgw_update_nexthops();
+}
+
+void static_dhcpgw_update_lease_path_helper(void)
+{
+	struct static_dhcpgw_interface *dgif;
+
+	frr_each (static_dhcpgw_interface_list, &interfaces_list_head, dgif) {
+		static_dhcpgw_interface_update_path(dgif);
+	}
+	static_dhcpgw_update();
+}
+
+static void static_dhcpgw_update_nexthops(void)
+{
+	struct static_dhcpgw_interface *dgif;
+	struct static_dhcpgw_nexthop *dgnh;
+
+	frr_each (static_dhcpgw_interface_list, &interfaces_list_head, dgif) {
+		static_dhcpgw_interface_update(dgif);
+	}
+
+	frr_each (static_dhcpgw_nexthop_list, &nexthops_list_head, dgnh) {
+		static_dhcpgw_update_nexthop(dgnh->nh, true, false);
+	}
+}
+
+static void static_dhcpgw_update_nexthop(struct static_nexthop *nh, bool install, bool force_update)
+{
+	struct static_dhcpgw_interface dgif;
+	struct static_dhcpgw_interface *pif;
+
+	strlcpy(dgif.ifname, nh->ifname, sizeof(dgif.ifname));
+
+	pif = get_dhcpgw_interface_by_ifname(nh->ifname);
+	if (!pif) {
+		zlog_warn("%s: couldn't get interface data for interface %s", __func__, nh->ifname);
+		return;
+	}
+
+	if (force_update)
+		static_dhcpgw_interface_update(pif);
+
+	/* TODO some better comparison?.. */
+	/* Is update needed? */
+	if (nh->nh_valid == pif->last_valid && nh->addr.ipv4.s_addr == pif->last_addr.s_addr) {
+		/* No */
+		return;
+	}
+
+	/* Yes */
+	nh->nh_valid = pif->last_valid;
+	nh->addr.ipv4 = pif->last_addr;
+	if (install)
+		static_install_path(nh->pn);
+}
+
+static void get_dhcpgw_dhclient_ipv4_address(struct in_addr *out_addr, bool *out_valid,
+					     const char *leasepath)
+{
+#define DHCLIENT_LEASE_NEW_ROUTERS_PREFIX "new_routers='"
+
+	out_addr->s_addr = 0;
+	*out_valid = false;
+
+	char buf[BUFSIZ];
+	char *ip = NULL;
+	char *ipend = NULL;
+
+	FILE *fp = fopen(leasepath, "r");
+
+	if (!fp) {
+		zlog_warn("%s: couldn't open lease file %s", __func__, leasepath);
+		return;
+	}
+
+	while (fgets(buf, BUFSIZ, fp)) {
+		/*
+		 * Line format in case of available gateway IP:
+		 *     new_routers='10.1.1.1'
+		 * In case of no working DHCP:
+		 *     new_routers=''
+		 */
+		if (strncmp(buf, DHCLIENT_LEASE_NEW_ROUTERS_PREFIX,
+			    sizeof(DHCLIENT_LEASE_NEW_ROUTERS_PREFIX) - 1)) {
+			continue;
+		}
+
+
+		ip = buf + sizeof(DHCLIENT_LEASE_NEW_ROUTERS_PREFIX) - 1;
+
+		ipend = strchr(ip, '\'');
+		if (!ipend)
+			continue;
+
+		*ipend = '\0';
+
+		break;
+	}
+	fclose(fp);
+
+	if (!ip) {
+		zlog_warn("%s: couldn't find ip in lease file %s", __func__, leasepath);
+		return;
+	}
+
+	if (strlen(ip) == 0) {
+		// no lease, normal situation
+		return;
+	}
+
+	if (inet_pton(AF_INET, ip, out_addr) != 1) {
+		zlog_warn("%s: couldn't parse ip '%s' with inet_pton, from lease file '%s'",
+			  __func__, ip, leasepath);
+		return;
+	}
+
+	*out_valid = true;
+}
+
+static void static_dhcpgw_interface_init(struct static_dhcpgw_interface *pif,
+					 struct static_nexthop *nh)
+{
+	strlcpy(pif->ifname, nh->ifname, sizeof(pif->ifname));
+	static_dhcpgw_interface_update_path(pif);
+	pif->nh_count = 0;
+}
+
+static void static_dhcpgw_interface_update_path(struct static_dhcpgw_interface *pif)
+{
+	strlcpy(pif->lease_path, lease_path_prefix, sizeof(pif->lease_path));
+	strlcat(pif->lease_path, pif->ifname, sizeof(pif->lease_path));
+	strlcat(pif->lease_path, lease_path_suffix, sizeof(pif->lease_path));
+	pif->last_st_mtim.tv_sec = 0;
+	pif->last_st_mtim.tv_nsec = 0;
+	static_dhcpgw_interface_update(pif);
+}
+
+static void static_dhcpgw_interface_update(struct static_dhcpgw_interface *pif)
+{
+	struct stat statbuf;
+
+	if (stat(pif->lease_path, &statbuf)) {
+		zlog_warn("%s: calling stat for %s failed", __func__, pif->lease_path);
+		return;
+	}
+
+	/* Compare modification time. No standard function seems to exist for this */
+	if (statbuf.st_mtim.tv_sec < pif->last_st_mtim.tv_sec)
+		return;
+	if (statbuf.st_mtim.tv_sec == pif->last_st_mtim.tv_sec)
+		if (statbuf.st_mtim.tv_nsec <= pif->last_st_mtim.tv_nsec)
+			return;
+
+	pif->last_st_mtim = statbuf.st_mtim;
+
+	get_dhcpgw_dhclient_ipv4_address(&pif->last_addr, &pif->last_valid, pif->lease_path);
+}
+
+static struct static_dhcpgw_interface *get_dhcpgw_interface_by_ifname(const char *ifname)
+{
+	struct static_dhcpgw_interface dgif;
+
+	strlcpy(dgif.ifname, ifname, sizeof(dgif.ifname));
+
+	return static_dhcpgw_interface_list_find(&interfaces_list_head, &dgif);
+}
+
+static void static_dhcpgw_interfaces_on_add_nexthop(struct static_nexthop *nh)
+{
+	struct static_dhcpgw_interface *pif = get_dhcpgw_interface_by_ifname(nh->ifname);
+
+	if (!pif) {
+		pif = XCALLOC(MTYPE_STATIC_DHCPGW_INTERFACE,
+			      sizeof(struct static_dhcpgw_interface));
+
+		static_dhcpgw_interface_init(pif, nh);
+
+		static_dhcpgw_interface_list_add(&interfaces_list_head, pif);
+	}
+	pif->nh_count++;
+}
+
+static void static_dhcpgw_interfaces_on_del_nexthop(struct static_nexthop *nh)
+{
+	struct static_dhcpgw_interface *pif = get_dhcpgw_interface_by_ifname(nh->ifname);
+
+	if (!pif) {
+		zlog_warn("%s: couldn't get interface data for interface %s", __func__, nh->ifname);
+		return;
+	}
+	pif->nh_count--;
+	if (!pif->nh_count) {
+		static_dhcpgw_interface_list_del(&interfaces_list_head, pif);
+		XFREE(MTYPE_STATIC_DHCPGW_INTERFACE, pif);
+	}
+}
+
+static void static_dhcpgw_start_timer_if_needed(void)
+{
+	if (poll_period_seconds && !dhcpgw_timer &&
+	    static_dhcpgw_nexthop_list_first(&nexthops_list_head)) {
+		event_add_timer(master, static_dhcpgw_timer_event_cb, NULL, poll_period_seconds,
+				&dhcpgw_timer);
+	}
+}
+
+static void static_dhcpgw_timer_event_cb(struct event *ev)
+{
+	static_dhcpgw_update_nexthops();
+	static_dhcpgw_start_timer_if_needed();
+}

--- a/staticd/static_dhcpgw.h
+++ b/staticd/static_dhcpgw.h
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * DHCP gateway related functions
+ * Copyright (C) 2025 VyOS Inc.
+ * Kyrylo Yatsenko
+ */
+/*
+ * static_dhcpgw.h provides functionality of static routes with
+ * dhcp-gateway as gateway e.g.
+ * ip route 10.1.2.7 dhcp-gateway eth0
+ * This command adds route to 10.1.2.7 via whatever gateway on interface eth0
+ * was received by DHCP.
+ *
+ * Currently only dhclient is supported.
+ *
+ * For this to work first static_dhcpgw_init must be called
+ * and for each nexthop of type
+ *		STATIC_IPV4_IFNAME_DHCP_GATEWAY
+ * static_dhcpgw_add_nexthop_watch must be called on creation
+ * and static_dhcpgw_del_nexthop_watch on deletion
+ *
+ * There are two options of updates of DHCP leases: polling and by external command.
+ *
+ * Command
+ * `static-route-dhcp-gateway update`
+ * Rereads leases, it can be used in external scripts e.g. dhclient hook.
+ * See staticd/sample-dhclient-hook
+ *
+ * If polling is desired, set polling period via
+ * `static-route-dhcp-gateway poll-period PERIOD-SECONDS`
+ * Setting PERIOD-SECONDS to 0 disables polling, this is default.
+ *
+ * You can setup lease path by options:
+ * `static-route-dhcp-gateway dhclient-lease-path-prefix LEASEPREFIX`
+ * `static-route-dhcp-gateway dhclient-lease-path-suffix LEASESUFFIX`
+ *
+ * Lease path will be LEASEPREFIX{interface}LEASESUFFIX.
+ * Default prefix is "/var/run/dhclient/dhclient_", default suffix ".lease"
+ */
+
+#ifndef _STATIC_DHCP_GATEWAY_H
+#define _STATIC_DHCP_GATEWAY_H
+
+#include <zebra.h>
+
+#include "staticd/static_routes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Initialize static_dhcpgw
+ *
+ * master
+ *    Needs event_loop to add reaction to events (timer)
+ */
+void static_dhcpgw_init(struct event_loop *master);
+
+/*
+ * Free all resources
+ */
+void static_dhcpgw_close(void);
+
+/*
+ * Start watching nexthop
+ *
+ * nh
+ *      DHCP Gateway nexthop
+ */
+void static_dhcpgw_add_nexthop_watch(struct static_nexthop *nh);
+
+/*
+ * Stop watching nexthop
+ *
+ * nh
+ *      DHCP Gateway nexthop
+ */
+void static_dhcpgw_del_nexthop_watch(struct static_nexthop *nh);
+
+/*
+ * Set poll period or disable polling
+ *
+ * seconds
+ *      Poll period in seconds, 0 - disabled
+ */
+void static_dhcpgw_set_poll_period_seconds(unsigned long seconds);
+
+/*
+ * Set prefix of path to dhclient lease file
+ *
+ * prefix
+ *      prefix
+ */
+void static_dhcpgw_set_lease_path_prefix(const char *prefix);
+
+/*
+ * Set suffix of path to dhclient lease file
+ *
+ * suffix
+ *      suffix
+ */
+void static_dhcpgw_set_lease_path_suffix(const char *suffix);
+
+/*
+ * Check current addresses of DHCP gateways,
+ * update routes accordingly
+ */
+void static_dhcpgw_update(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _STATIC_DHCP_GATEWAY_H */

--- a/staticd/static_main.c
+++ b/staticd/static_main.c
@@ -25,6 +25,7 @@
 #include "static_routes.h"
 #include "static_zebra.h"
 #include "static_debug.h"
+#include "static_dhcpgw.h"
 #include "static_nb.h"
 #include "static_srv6.h"
 
@@ -73,6 +74,8 @@ static FRR_NORETURN void sigint(void)
 	bfd_protocol_integration_set_shutdown(true);
 
 	mgmt_be_client_destroy(mgmt_be_client);
+
+	static_dhcpgw_close();
 
 	static_vrf_terminate();
 
@@ -184,6 +187,8 @@ int main(int argc, char **argv, char **envp)
 		      routing_control_plane_protocols_staticd_create);
 	hook_register(routing_destroy,
 		      routing_control_plane_protocols_staticd_destroy);
+
+	static_dhcpgw_init(master);
 
 	/*
 	 * We set FRR_NO_SPLIT_CONFIG flag to avoid reading our config, but we

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -468,8 +468,9 @@ static int static_nexthop_onlink_modify(struct nb_cb_modify_args *args)
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 		nh_type = yang_dnode_get_enum(args->dnode, "../nh-type");
-		if ((nh_type != STATIC_IPV4_GATEWAY_IFNAME)
-		    && (nh_type != STATIC_IPV6_GATEWAY_IFNAME)) {
+		if ((nh_type != STATIC_IPV4_GATEWAY_IFNAME) &&
+		    (nh_type != STATIC_IPV6_GATEWAY_IFNAME) &&
+		    (nh_type != STATIC_IPV4_IFNAME_DHCP_GATEWAY)) {
 			snprintf(
 				args->errmsg, args->errmsg_len,
 				"nexthop type is not the ipv4 or ipv6 interface type");

--- a/staticd/static_nht.c
+++ b/staticd/static_nht.c
@@ -27,10 +27,9 @@ static void static_nht_update_path(struct static_path *pn, struct prefix *nhp,
 		if (nh->nh_vrf_id != nh_vrf_id)
 			continue;
 
-		if (nh->type != STATIC_IPV4_GATEWAY
-		    && nh->type != STATIC_IPV4_GATEWAY_IFNAME
-		    && nh->type != STATIC_IPV6_GATEWAY
-		    && nh->type != STATIC_IPV6_GATEWAY_IFNAME)
+		if (nh->type != STATIC_IPV4_GATEWAY && nh->type != STATIC_IPV4_GATEWAY_IFNAME &&
+		    nh->type != STATIC_IPV6_GATEWAY && nh->type != STATIC_IPV6_GATEWAY_IFNAME &&
+		    nh->type != STATIC_IPV4_IFNAME_DHCP_GATEWAY)
 			continue;
 
 		if (nhp->family == AF_INET

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -52,6 +52,7 @@ enum static_nh_type {
 	STATIC_IPV6_GATEWAY,
 	STATIC_IPV6_GATEWAY_IFNAME,
 	STATIC_BLACKHOLE,
+	STATIC_IPV4_IFNAME_DHCP_GATEWAY,
 };
 
 /*
@@ -191,6 +192,9 @@ static inline void static_get_nh_type(enum static_nh_type stype, char *type,
 		break;
 	case STATIC_IPV6_GATEWAY_IFNAME:
 		strlcpy(type, "ip6-ifindex", size);
+		break;
+	case STATIC_IPV4_IFNAME_DHCP_GATEWAY:
+		strlcpy(type, "ip4-dhcp-gateway", size);
 		break;
 	};
 }

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -301,6 +301,7 @@ static bool static_zebra_nht_get_prefix(const struct static_nexthop *nh,
 
 	case STATIC_IPV4_GATEWAY:
 	case STATIC_IPV4_GATEWAY_IFNAME:
+	case STATIC_IPV4_IFNAME_DHCP_GATEWAY:
 		p->family = AF_INET;
 		p->prefixlen = IPV4_MAX_BITLEN;
 		p->u.prefix4 = nh->addr.ipv4;
@@ -475,6 +476,7 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
 			api_nh->ifindex = nh->ifindex;
 			api_nh->type = NEXTHOP_TYPE_IFINDEX;
 			break;
+		case STATIC_IPV4_IFNAME_DHCP_GATEWAY:
 		case STATIC_IPV4_GATEWAY:
 			if (!nh->nh_valid)
 				continue;

--- a/staticd/subdir.am
+++ b/staticd/subdir.am
@@ -12,6 +12,7 @@ endif
 staticd_libstatic_a_SOURCES = \
 	staticd/static_bfd.c \
 	staticd/static_debug.c \
+	staticd/static_dhcpgw.c \
 	staticd/static_nht.c \
 	staticd/static_routes.c \
 	staticd/static_zebra.c \
@@ -24,6 +25,7 @@ staticd_libstatic_a_SOURCES = \
 
 noinst_HEADERS += \
 	staticd/static_debug.h \
+	staticd/static_dhcpgw.h \
 	staticd/static_nht.h \
 	staticd/static_zebra.h \
 	staticd/static_routes.h \

--- a/yang/frr-nexthop.yang
+++ b/yang/frr-nexthop.yang
@@ -106,6 +106,11 @@ module frr-nexthop {
         description
           "Unreachable or prohibited.";
       }
+      enum "ip4-dhcp-gateway" {
+        value 7;
+        description
+          "IPv4 interfaces with dhcp gateway";
+      }
     }
     description
       "Nexthop types.";
@@ -195,7 +200,8 @@ module frr-nexthop {
       when "../nh-type = 'ip4' or
             ../nh-type = 'ip6' or
             ../nh-type = 'ip4-ifindex' or
-            ../nh-type = 'ip6-ifindex'";
+            ../nh-type = 'ip6-ifindex' or
+            ../nh-type = 'ip4-dhcp-gateway'";
       type uint32;
       description
         "The nexthop SR-TE color";

--- a/yang/frr-staticd.yang
+++ b/yang/frr-staticd.yang
@@ -209,7 +209,8 @@ module frr-staticd {
               "Augments the nexthop container with BFD monitoring options.";
             container bfd-monitoring {
               when "../nh-type = 'ip4' or ../nh-type = 'ip4-ifindex' or
-                    ../nh-type = 'ip6' or ../nh-type = 'ip6-ifindex'";
+                    ../nh-type = 'ip6' or ../nh-type = 'ip6-ifindex' or
+                    ../nh-type = 'ip4-dhcp-gateway'";
               presence
                 "Present if BFD configuration is available.";
               description "BFD monitoring options.";


### PR DESCRIPTION
Add possibility to add static routes via dhcp-gateway of interface:

ip route 10.1.2.0/24 dhcp-gateway eth0

Adds route to 10.1.2.0/24 via dhcp gateway of eth0.

Added options:

* static-route-dhcp-gateway poll-period PERIOD-SECONDS
* static-route-dhcp-gateway dhclient-lease-path-prefix LEASEPREFIX
* static-route-dhcp-gateway dhclient-lease-path-suffix LEASESUFFIX

Added command:

static-route-dhcp-gateway update

Watching dhcp gateway changes is possible by two methods:

1. Polling: just poll periodically all lease files.
2. External command, sample dhclient hook is provided in staticd/sample-dhclient-hook

To support this change new nexthop type STATIC_IPV4_IFNAME_DHCP_GATEWAY was added.


