### PR TITLE
Revert "bgpd: Free dup'ed attributes for aggregate routes with route-maps"

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8408,10 +8408,6 @@ static void bgp_aggregate_install(
 		attr = bgp_attr_aggregate_intern(bgp, origin, aspath, community, ecommunity,
 						 lcommunity, aggregate, atomic_aggregate, p);
 		if (!attr) {
-			aspath_free(aspath);
-			community_free(&community);
-			ecommunity_free(&ecommunity);
-			lcommunity_free(&lcommunity);
 			bgp_dest_unlock_node(dest);
 			bgp_aggregate_delete(bgp, p, afi, safi, aggregate);
 			if (debug)


### PR DESCRIPTION


This reverts commit e11791f475be03f1e5bbacac8368fece717e51ca.

This commit is causing double free. Hence reverting it.

Details:

This commit is causing double free of lecomm, ecomm, comm and aspath attributes for aggregate route with as-set, leading to BGP crash. Hence reverting it.

Problem:

When BGP route aggregation is configured with as-set and a non-existent route-map (example config below) following events occur:

1. BGP runs the route-map for aggregate route and returns RMAP_DENYMATCH in bgp_attr_aggregate_intern() since rmap `test` doesn't exist
2. bgp_attr_aggregate_intern() cleans up memory allocated for all the attributes and returns NULL to bgp_aggregate_install()
3. In bgp_aggregate_install() ,this commit introduced code to free aspath, lcomm, ecomm and comm attributes if attr is null, causing BGP to double free!

```
Example config:
leaf11(config)# router bgp 65101
leaf11(config-router)# address-family ipv6 unicast
leaf11(config-router-af)# no aggregate-address 2001:c15c:d06:f00d::11:0/112 as-set summary-only
leaf11(config-router-af)# aggregate-address 2001:c15c:d06:f00d::11:0/112 as-set route-map test --> route map `test` is not configured. It's a non existent route map
```

Valgrind output:
```

==14488== 
==14488== Invalid free() / delete / delete[] / realloc()
==14488==    at 0x484417B: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==14488==    by 0x27CD5E: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x27D20C: bgp_aggregate_route (in /usr/lib/frr/bgpd)
==14488==    by 0x283CFF: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x2843DC: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x48F486F: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x48F496D: cmd_execute_command (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x48F4BFF: cmd_execute (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x4977D56: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x4978C03: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x497A0DA: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x4971780: event_call (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==  Address 0x526ebc0 is 0 bytes inside a block of size 40 free'd
==14488==    at 0x484417B: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==14488==    by 0x318C4C: aspath_intern (in /usr/lib/frr/bgpd)
==14488==    by 0x1F429F: bgp_attr_aggregate_intern (in /usr/lib/frr/bgpd)
==14488==    by 0x27CC29: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x27D20C: bgp_aggregate_route (in /usr/lib/frr/bgpd)
==14488==    by 0x283CFF: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x2843DC: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x48F486F: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x48F496D: cmd_execute_command (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x48F4BFF: cmd_execute (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x4977D56: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x4978C03: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==  Block was alloc'd at
==14488==    at 0x48465EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==14488==    by 0x4927F7F: qcalloc (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x318CA5: aspath_dup (in /usr/lib/frr/bgpd)
==14488==    by 0x27D2A1: bgp_aggregate_route (in /usr/lib/frr/bgpd)
==14488==    by 0x283CFF: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x2843DC: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x48F486F: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x48F496D: cmd_execute_command (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x48F4BFF: cmd_execute (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x4977D56: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x4978C03: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x497A0DA: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)

==14488== 
==14488== Invalid free() / delete / delete[] / realloc()
==14488==    at 0x484417B: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==14488==    by 0x2441D6: lcommunity_free (in /usr/lib/frr/bgpd)
==14488==    by 0x27CD79: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x27D20C: bgp_aggregate_route (in /usr/lib/frr/bgpd)
==14488==    by 0x283CFF: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x2843DC: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x48F486F: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x48F496D: cmd_execute_command (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x48F4BFF: cmd_execute (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x4977D56: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x4978C03: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x497A0DA: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==  Address 0x526ec80 is 0 bytes inside a block of size 40 free'd
==14488==    at 0x484417B: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==14488==    by 0x2441D6: lcommunity_free (in /usr/lib/frr/bgpd)
==14488==    by 0x1F41B0: bgp_attr_flush (in /usr/lib/frr/bgpd)
==14488==    by 0x1F4602: bgp_attr_aggregate_intern (in /usr/lib/frr/bgpd)
==14488==    by 0x27CC29: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x27D20C: bgp_aggregate_route (in /usr/lib/frr/bgpd)
==14488==    by 0x283CFF: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x2843DC: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x48F486F: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x48F496D: cmd_execute_command (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x48F4BFF: cmd_execute (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x4977D56: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==  Block was alloc'd at
==14488==    at 0x48465EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==14488==    by 0x4927F7F: qcalloc (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x24429A: lcommunity_dup (in /usr/lib/frr/bgpd)
==14488==    by 0x27D2E6: bgp_aggregate_route (in /usr/lib/frr/bgpd)
==14488==    by 0x283CFF: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x2843DC: ??? (in /usr/lib/frr/bgpd)
==14488==    by 0x48F486F: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x48F496D: cmd_execute_command (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x48F4BFF: cmd_execute (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x4977D56: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x4978C03: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==14488==    by 0x497A0DA: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)

==20312== Invalid free() / delete / delete[] / realloc()
==20312==    at 0x484417B: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==20312==    by 0x1FFA9E: community_free (bgp_community.c:41)
==20312==    by 0x27DD8E: bgp_aggregate_install (bgp_route.c:8571)
==20312==    by 0x27E22C: bgp_aggregate_route (bgp_route.c:8968)
==20312==    by 0x27E22C: bgp_aggregate_route (bgp_route.c:8761)
==20312==    by 0x284C4F: bgp_aggregate_set (bgp_route.c:9556)
==20312==    by 0x28532C: aggregate_addressv6_magic (bgp_route.c:9700)
==20312==    by 0x28532C: aggregate_addressv6 (bgp_route_clippy.c:341)
==20312==    by 0x48F4A0F: cmd_execute_command_real (command.c:1018)
==20312==    by 0x48F4B0D: cmd_execute_command (command.c:1077)
==20312==    by 0x48F4D9F: cmd_execute (command.c:1243)
==20312==    by 0x49787C6: vty_command (vty.c:609)
==20312==    by 0x4979673: vty_execute (vty.c:1372)
==20312==    by 0x497AB4A: vtysh_read (vty.c:2385)
==20312==  Address 0x536c910 is 0 bytes inside a block of size 40 free'd
==20312==    at 0x484417B: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==20312==    by 0x1FFA9E: community_free (bgp_community.c:41)
==20312==    by 0x1F51E0: bgp_attr_flush (bgp_attr.c:1283)
==20312==    by 0x1F5662: bgp_attr_aggregate_intern (bgp_attr.c:1169)
==20312==    by 0x27DC59: bgp_aggregate_install (bgp_route.c:8565)
==20312==    by 0x27E22C: bgp_aggregate_route (bgp_route.c:8968)
==20312==    by 0x27E22C: bgp_aggregate_route (bgp_route.c:8761)
==20312==    by 0x284C4F: bgp_aggregate_set (bgp_route.c:9556)
==20312==    by 0x28532C: aggregate_addressv6_magic (bgp_route.c:9700)
==20312==    by 0x28532C: aggregate_addressv6 (bgp_route_clippy.c:341)
==20312==    by 0x48F4A0F: cmd_execute_command_real (command.c:1018)
==20312==    by 0x48F4B0D: cmd_execute_command (command.c:1077)
==20312==    by 0x48F4D9F: cmd_execute (command.c:1243)
==20312==    by 0x49787C6: vty_command (vty.c:609)
==20312==  Block was alloc'd at
==20312==    at 0x48465EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==20312==    by 0x492842F: qcalloc (memory.c:105)
==20312==    by 0x1FFEEA: community_dup (bgp_community.c:514)
==20312==    by 0x27E2D6: bgp_aggregate_route (bgp_route.c:8952)
==20312==    by 0x27E2D6: bgp_aggregate_route (bgp_route.c:8761)
==20312==    by 0x284C4F: bgp_aggregate_set (bgp_route.c:9556)
==20312==    by 0x28532C: aggregate_addressv6_magic (bgp_route.c:9700)
==20312==    by 0x28532C: aggregate_addressv6 (bgp_route_clippy.c:341)
==20312==    by 0x48F4A0F: cmd_execute_command_real (command.c:1018)
==20312==    by 0x48F4B0D: cmd_execute_command (command.c:1077)
==20312==    by 0x48F4D9F: cmd_execute (command.c:1243)
==20312==    by 0x49787C6: vty_command (vty.c:609)
==20312==    by 0x4979673: vty_execute (vty.c:1372)
==20312==    by 0x497AB4A: vtysh_read (vty.c:2385)
==20312== 
==20312== Invalid read of size 8
==20312==    at 0x20901B: ecommunity_free (bgp_ecommunity.c:57)
==20312==    by 0x27DD97: bgp_aggregate_install (bgp_route.c:8572)
==20312==    by 0x27E22C: bgp_aggregate_route (bgp_route.c:8968)
==20312==    by 0x27E22C: bgp_aggregate_route (bgp_route.c:8761)
==20312==    by 0x284C4F: bgp_aggregate_set (bgp_route.c:9556)
==20312==    by 0x28532C: aggregate_addressv6_magic (bgp_route.c:9700)
==20312==    by 0x28532C: aggregate_addressv6 (bgp_route_clippy.c:341)
==20312==    by 0x48F4A0F: cmd_execute_command_real (command.c:1018)
==20312==    by 0x48F4B0D: cmd_execute_command (command.c:1077)
==20312==    by 0x48F4D9F: cmd_execute (command.c:1243)
==20312==    by 0x49787C6: vty_command (vty.c:609)
==20312==    by 0x4979673: vty_execute (vty.c:1372)
==20312==    by 0x497AB4A: vtysh_read (vty.c:2385)
==20312==    by 0x49721F0: event_call (event.c:2034)
==20312==  Address 0x536c990 is 16 bytes inside a block of size 32 free'd
==20312==    at 0x484417B: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==20312==    by 0x209055: ecommunity_free (bgp_ecommunity.c:59)
==20312==    by 0x1F51C8: bgp_attr_flush (bgp_attr.c:1288)
==20312==    by 0x1F5662: bgp_attr_aggregate_intern (bgp_attr.c:1169)
==20312==    by 0x27DC59: bgp_aggregate_install (bgp_route.c:8565)
==20312==    by 0x27E22C: bgp_aggregate_route (bgp_route.c:8968)
==20312==    by 0x27E22C: bgp_aggregate_route (bgp_route.c:8761)
==20312==    by 0x284C4F: bgp_aggregate_set (bgp_route.c:9556)
==20312==    by 0x28532C: aggregate_addressv6_magic (bgp_route.c:9700)
==20312==    by 0x28532C: aggregate_addressv6 (bgp_route_clippy.c:341)
==20312==    by 0x48F4A0F: cmd_execute_command_real (command.c:1018)
==20312==    by 0x48F4B0D: cmd_execute_command (command.c:1077)
==20312==    by 0x48F4D9F: cmd_execute (command.c:1243)
==20312==    by 0x49787C6: vty_command (vty.c:609)
==20312==  Block was alloc'd at
==20312==    at 0x48465EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==20312==    by 0x492842F: qcalloc (memory.c:105)
==20312==    by 0x20996A: ecommunity_dup (bgp_ecommunity.c:252)
==20312==    by 0x27E2EA: bgp_aggregate_route (bgp_route.c:8957)
==20312==    by 0x27E2EA: bgp_aggregate_route (bgp_route.c:8761)
==20312==    by 0x284C4F: bgp_aggregate_set (bgp_route.c:9556)
==20312==    by 0x28532C: aggregate_addressv6_magic (bgp_route.c:9700)
==20312==    by 0x28532C: aggregate_addressv6 (bgp_route_clippy.c:341)
==20312==    by 0x48F4A0F: cmd_execute_command_real (command.c:1018)
==20312==    by 0x48F4B0D: cmd_execute_command (command.c:1077)
==20312==    by 0x48F4D9F: cmd_execute (command.c:1243)
==20312==    by 0x49787C6: vty_command (vty.c:609)
==20312==    by 0x4979673: vty_execute (vty.c:1372)
==20312==    by 0x497AB4A: vtysh_read (vty.c:2385)
```