### PR TITLE
pimd/pim6d: fix wrong running config

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -584,8 +584,7 @@ void pim_update_suppress_timers(uint32_t suppress_time)
 	unsigned int old_rp_ka_time;
 
 	/* stash the old one so we know which values were manually configured */
-	old_rp_ka_time =  (3 * router->register_suppress_time
-			   + router->register_probe_time);
+	old_rp_ka_time = MIN(PIM_RP_KEEPALIVE_PERIOD, UINT16_MAX);
 	router->register_suppress_time = suppress_time;
 
 	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
@@ -595,7 +594,7 @@ void pim_update_suppress_timers(uint32_t suppress_time)
 
 		/* Only adjust if not manually configured */
 		if (pim->rp_keep_alive_time == old_rp_ka_time)
-			pim->rp_keep_alive_time = PIM_RP_KEEPALIVE_PERIOD;
+			pim->rp_keep_alive_time = MIN(PIM_RP_KEEPALIVE_PERIOD, UINT16_MAX);
 	}
 }
 

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -238,9 +238,8 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 		vty_out(vty, " keep-alive-timer %d\n", pim->keep_alive_time);
 		++writes;
 	}
-	if (pim->rp_keep_alive_time != (unsigned int)PIM_RP_KEEPALIVE_PERIOD) {
-		vty_out(vty, " rp keep-alive-timer %d\n",
-			pim->rp_keep_alive_time);
+	if (pim->rp_keep_alive_time != MIN(PIM_RP_KEEPALIVE_PERIOD, UINT16_MAX)) {
+		vty_out(vty, " rp keep-alive-timer %d\n", pim->rp_keep_alive_time);
 		++writes;
 	}
 	if (ssm->plist_name) {


### PR DESCRIPTION
With the configuration:
```
router pim6
 register-suppress-time 50000
```

Then:
```
anlan(config-pim6)# rp keep-alive-timer 12
anlan(config-pim6)# no rp keep-alive-timer 12
anlan(config-pim6)# do show run
!
router pim6
 register-suppress-time 50000
 rp keep-alive-timer 65535 <-
exit
!
```

Since `pim->rp_keep_alive_time` can't exceed 65535, these places should consider the special conversion:
1) show running config
2) set/unset "register-suppress-time" commands