### PR TITLE
pbrd: DSCP-only PBR rules not installing due to incorrect family field

### DIFF
--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -521,7 +521,7 @@ static bool pbr_encode_pbr_map_sequence(struct stream *s,
 	r.priority = pbrms->ruleno;
 	r.unique = pbrms->unique;
 
-	r.family = pbrms->family;
+	r.family = family;
 
 	/* filter */
 	r.filter.filter_bm = pbrms->filter_bm;


### PR DESCRIPTION
When configuring PBR rules with only DSCP matches (no source/destination IP), the family field was not being set, causing zebra to reject the rules with "Unsupported PBR source IP family" error.

The issue was in pbr_zebra.c where r.family was being set directly from pbrms->family instead of using the processed family value that includes the default AF_INET fallback.