### PR TITLE
ospf6d: correct display of one command

### DIFF
--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -271,6 +271,8 @@ static int ospf6_zebra_read_route(ZAPI_CALLBACK_ARGS)
 		return 0;
 
 	ifindex = api.nexthops[0].ifindex;
+	if (!ifindex && cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD)
+		return 0;
 	if (api.nexthops[0].type == NEXTHOP_TYPE_IPV6
 	    || api.nexthops[0].type == NEXTHOP_TYPE_IPV6_IFINDEX)
 		nexthop = &api.nexthops[0].gate.ipv6;


### PR DESCRIPTION
With ospf6 redistribute static configuration:
```
ipv6 route 9001::/64 2002::9  <- The output interface(enp1s0) is not enabled with ospf6
router ospf6
 redistribute static
```

Then run:
"ip link set dev enp1s0 down;ip -6 addr add 2002::1/64 dev enp1s0;ip link set dev enp1s0 up;". or
"ip link set dev enp1s0 down;ip link set dev enp1s0 up;ip -6 addr add 2002::1/64 dev enp1s0;".

When down/up the output interfaces, the 9001::/64 is redistributed from zebra again, but there are the two nexthop notification from zebra: first one is with ifindex 0, the latter one is with correct ifindex. The first one takes affect, so the display command will be with wrong output interface:
```
anlan# show ipv6 ospf6 redistribute
Redistributing External Routes from:
    1: static
Total 1 routes
S 9001::/64                        0.0.0.10        type-2     0 :: (ifindex 0) <- wrong: ifindex 0
```

Just let ospf6 to filter the wrong/redundant nexthop with ifindex 0. After:
```
anlan# show ipv6 ospf6 redistribute
Redistributing External Routes from:
    1: static
Total 1 routes
S 9001::/64                        0.0.0.1         type-2     0 :: (ifindex 7)
```