### PR TITLE
lib: make getloadavg() optional in late timer warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1367,6 +1367,7 @@ dnl ---------------
 AC_CHECK_FUNCS([ \
 	strlcat strlcpy \
 	getgrouplist \
+	getloadavg \
 	openat \
 	unlinkat \
 	posix_fallocate \

--- a/lib/event.c
+++ b/lib/event.c
@@ -1924,7 +1924,11 @@ static void event_tardy_warn(struct event *thread, unsigned long since_us)
 	double loadavg[3];
 	int rv;
 
+#ifdef HAVE_GETLOADAVG
 	rv = getloadavg(loadavg, array_size(loadavg));
+#else
+	rv = -1;
+#endif
 	if (rv < 0)
 		bprintfrr(&fb, "not available");
 	else {


### PR DESCRIPTION
Commit ff76fb21d7b3 ("lib: improve late timer warnings") added an unconditional getloadavg() call. Older libcs (e.g. uClibc, dietlibc) lack this function, breaking the build. Before, no system load was shown, so skipping it restores prior behavior.

Fixes: ff76fb21d7b3 ("lib: improve late timer warnings")