### PR TITLE
zebra: Explicitly print "exit" at the end of srv6 encap node config

### DIFF
--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -1602,6 +1602,7 @@ static int zebra_sr_config(struct vty *vty)
 			vty_out(vty, "  encapsulation\n");
 			vty_out(vty, "   source-address %pI6\n",
 				&srv6->encap_src_addr);
+			vty_out(vty, "  exit\n");
 		}
 	}
 	if (srv6 && zebra_srv6_is_enable()) {


### PR DESCRIPTION
Explicitly print 'exit' at the end of srv6 encapsulation node configuration. This ensures consistency with other VTY nodes and prevents issues similar to those fixed in https://github.com/FRRouting/frr/pull/9331.

```
segment-routing
 srv6
  encapsulation
   source-address fcbb:bbbb:1::1
  exit                <<<<<<<<<< Add this "exit" statement
  locators
   locator MAIN
    prefix fcbb:bbbb::/48
    format usid-f3216
   exit
...
```