### PR TITLE
isisd: allow unnumbered interfaces

### DIFF
--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -16,11 +16,18 @@ like :abbr:`OSPF`. ISIS is widely used in large networks such as :abbr:`ISP
 Configuring isisd
 =================
 
-There are no *isisd* specific options. Common options can be specified
-(:ref:`common-invocation-options`) to *isisd*. *isisd* needs to acquire
-interface information from *zebra* in order to function. Therefore *zebra* must
-be running before invoking *isisd*. Also, if *zebra* is restarted then *isisd*
-must be too.
+*isisd* accepts all common invocations (:ref:`common-invocation-options`) and
+the following specific options.
+
+.. program:: isisd
+
+.. option:: --dummy_as_loopback
+
+   Treat dummy interfaces as loopback interfaces.
+
+*isisd* needs to acquire interface information from *zebra* in order to
+function. Therefore *zebra* must be running before invoking *isisd*. Also, if
+*zebra* is restarted then *isisd* must be too.
 
 .. include:: config-include.rst
 
@@ -203,6 +210,10 @@ ISIS region
 
 ISIS interface
 ==============
+
+ISIS supports unnumbered interfaces, so interfaces with no IP-Address
+configured. If there is no address on the given interfaces, ISIS searches
+through all the loopback interfaces configured on the node.
 
 .. _ip-router-isis-word:
 

--- a/isisd/fabricd.c
+++ b/isisd/fabricd.c
@@ -717,29 +717,6 @@ void fabricd_trigger_csnp(struct isis_area *area, bool circuit_scoped)
 	}
 }
 
-struct list *fabricd_ip_addrs(struct isis_circuit *circuit)
-{
-	if (listcount(circuit->ip_addrs))
-		return circuit->ip_addrs;
-
-	if (!fabricd || !circuit->area)
-		return NULL;
-
-	struct isis_circuit *c;
-
-	frr_each (isis_circuit_list, &circuit->area->circuit_list, c) {
-		if (c->circ_type != CIRCUIT_T_LOOPBACK)
-			continue;
-
-		if (!listcount(c->ip_addrs))
-			return NULL;
-
-		return c->ip_addrs;
-	}
-
-	return NULL;
-}
-
 void fabricd_lsp_free(struct isis_lsp *lsp)
 {
 	XFREE(MTYPE_FABRICD_FLOODING_INFO, lsp->flooding_interface);

--- a/isisd/fabricd.h
+++ b/isisd/fabricd.h
@@ -33,7 +33,6 @@ uint8_t fabricd_tier(struct isis_area *area);
 int fabricd_write_settings(struct isis_area *area, struct vty *vty);
 void fabricd_lsp_flood(struct isis_lsp *lsp, struct isis_circuit *circuit);
 void fabricd_trigger_csnp(struct isis_area *area, bool circuit_scoped);
-struct list *fabricd_ip_addrs(struct isis_circuit *circuit);
 void fabricd_lsp_free(struct isis_lsp *lsp);
 void fabricd_update_lsp_no_flood(struct isis_lsp *lsp,
 				 struct isis_circuit *circuit);

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -970,5 +970,14 @@ bool isis_adj_ipv6_usable(const struct isis_adjacency *adj)
 	if (!circuit)
 		return false;
 
-	return (listcount(circuit->ipv6_link) && adj->ll_ipv6_count);
+	if (listcount(circuit->ipv6_link) && adj->ll_ipv6_count)
+		return true;
+
+	/*
+	 * Unnumbered: neither end has a link-local address, so the only
+	 * usable nexthop is the global address exchanged in TLV 233
+	 * (RFC 6119). This mirrors the v6_usable test done on reception
+	 * of an IIH.
+	 */
+	return (isis_circuit_ipv6_non_link_addrs(circuit) && adj->global_ipv6_count);
 }

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -960,7 +960,7 @@ bool isis_adj_ipv4_usable(const struct isis_adjacency *adj)
 	if (!circuit)
 		return false;
 
-	return (fabricd_ip_addrs(circuit) && adj->ipv4_address_count);
+	return (isis_circuit_ip_addrs(circuit) && adj->ipv4_address_count);
 }
 
 bool isis_adj_ipv6_usable(const struct isis_adjacency *adj)

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -95,7 +95,7 @@ static void bfd_handle_adj_up(struct isis_adjacency *adj)
 	} else if (circuit->ip_router && adj->ipv4_address_count) {
 		family = AF_INET;
 		dst_ip.ipv4 = adj->ipv4_addresses[0];
-		local_ips = fabricd_ip_addrs(adj->circuit);
+		local_ips = isis_circuit_ip_addrs(adj->circuit);
 		if (!local_ips || list_isempty(local_ips)) {
 			if (IS_DEBUG_BFD)
 				zlog_debug(

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -83,8 +83,11 @@ static void bfd_handle_adj_up(struct isis_adjacency *adj)
 	if (circuit->ipv6_router && adj->ll_ipv6_count) {
 		family = AF_INET6;
 		dst_ip.ipv6 = adj->ll_ipv6_addrs[0];
-		local_ips = circuit->ipv6_link;
-		if (list_isempty(local_ips)) {
+		if (list_isempty(circuit->ipv6_link))
+			local_ips = isis_circuit_ipv6_non_link_addrs(circuit);
+		else
+			local_ips = circuit->ipv6_link;
+		if (!local_ips) {
 			if (IS_DEBUG_BFD)
 				zlog_debug(
 					"ISIS-BFD: skipping BFD initialization: IPv6 enabled and no local IPv6 addresses");

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1703,6 +1703,35 @@ void isis_reset_hello_timer(struct isis_circuit *circuit)
 	}
 }
 
+/*
+ * Return all IP-Addresses defined on this circuit. If there are no
+ * addresses defined (unnumbered interface) search for other addresses
+ * on the loopback interface.
+ */
+struct list *isis_circuit_ip_addrs(struct isis_circuit *circuit)
+{
+	if (listcount(circuit->ip_addrs))
+		return circuit->ip_addrs;
+
+	if (!fabricd || !circuit->area)
+		return NULL;
+
+	struct isis_circuit *c;
+
+	frr_each (isis_circuit_list, &circuit->area->circuit_list, c) {
+		if (c->circ_type != CIRCUIT_T_LOOPBACK)
+			continue;
+
+		if (!listcount(c->ip_addrs))
+			return NULL;
+
+		return c->ip_addrs;
+	}
+
+	return NULL;
+}
+
+
 void isis_circuit_init(void)
 {
 	/* Initialize Zebra interface data structure */

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1729,6 +1729,32 @@ struct list *isis_circuit_ip_addrs(struct isis_circuit *circuit)
 	return NULL;
 }
 
+/*
+ * Return all IPv6 global addresses defined on this circuit. If there are no
+ * addresses defined (unnumbered interface) search for other addresses
+ * on the loopback interface.
+ */
+struct list *isis_circuit_ipv6_non_link_addrs(struct isis_circuit *circuit)
+{
+	if (listcount(circuit->ipv6_non_link))
+		return circuit->ipv6_non_link;
+
+	if (!circuit->area)
+		return NULL;
+
+	struct isis_circuit *c;
+
+	frr_each (isis_circuit_list, &circuit->area->circuit_list, c) {
+		if (c->circ_type != CIRCUIT_T_LOOPBACK)
+			continue;
+
+		if (listcount(c->ipv6_non_link))
+			return c->ipv6_non_link;
+
+	}
+
+	return NULL;
+}
 
 void isis_circuit_init(void)
 {

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1713,7 +1713,7 @@ struct list *isis_circuit_ip_addrs(struct isis_circuit *circuit)
 	if (listcount(circuit->ip_addrs))
 		return circuit->ip_addrs;
 
-	if (!fabricd || !circuit->area)
+	if (!circuit->area)
 		return NULL;
 
 	struct isis_circuit *c;

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1722,10 +1722,8 @@ struct list *isis_circuit_ip_addrs(struct isis_circuit *circuit)
 		if (c->circ_type != CIRCUIT_T_LOOPBACK)
 			continue;
 
-		if (!listcount(c->ip_addrs))
-			return NULL;
-
-		return c->ip_addrs;
+		if (listcount(c->ip_addrs))
+			return c->ip_addrs;
 	}
 
 	return NULL;

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1737,10 +1737,8 @@ struct list *isis_circuit_ip_addrs(struct isis_circuit *circuit)
 		if (c->circ_type != CIRCUIT_T_LOOPBACK)
 			continue;
 
-		if (!listcount(c->ip_addrs))
-			return NULL;
-
-		return c->ip_addrs;
+		if (listcount(c->ip_addrs))
+			return c->ip_addrs;
 	}
 
 	return NULL;

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1718,6 +1718,35 @@ void isis_reset_hello_timer(struct isis_circuit *circuit)
 	}
 }
 
+/*
+ * Return all IP-Addresses defined on this circuit. If there are no
+ * addresses defined (unnumbered interface) search for other addresses
+ * on the loopback interface.
+ */
+struct list *isis_circuit_ip_addrs(struct isis_circuit *circuit)
+{
+	if (listcount(circuit->ip_addrs))
+		return circuit->ip_addrs;
+
+	if (!fabricd || !circuit->area)
+		return NULL;
+
+	struct isis_circuit *c;
+
+	frr_each (isis_circuit_list, &circuit->area->circuit_list, c) {
+		if (c->circ_type != CIRCUIT_T_LOOPBACK)
+			continue;
+
+		if (!listcount(c->ip_addrs))
+			return NULL;
+
+		return c->ip_addrs;
+	}
+
+	return NULL;
+}
+
+
 void isis_circuit_init(void)
 {
 	/* Initialize Zebra interface data structure */

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1728,7 +1728,7 @@ struct list *isis_circuit_ip_addrs(struct isis_circuit *circuit)
 	if (listcount(circuit->ip_addrs))
 		return circuit->ip_addrs;
 
-	if (!fabricd || !circuit->area)
+	if (!circuit->area)
 		return NULL;
 
 	struct isis_circuit *c;

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1744,6 +1744,32 @@ struct list *isis_circuit_ip_addrs(struct isis_circuit *circuit)
 	return NULL;
 }
 
+/*
+ * Return all IPv6 global addresses defined on this circuit. If there are no
+ * addresses defined (unnumbered interface) search for other addresses
+ * on the loopback interface.
+ */
+struct list *isis_circuit_ipv6_non_link_addrs(struct isis_circuit *circuit)
+{
+	if (listcount(circuit->ipv6_non_link))
+		return circuit->ipv6_non_link;
+
+	if (!circuit->area)
+		return NULL;
+
+	struct isis_circuit *c;
+
+	frr_each (isis_circuit_list, &circuit->area->circuit_list, c) {
+		if (c->circ_type != CIRCUIT_T_LOOPBACK)
+			continue;
+
+		if (listcount(c->ipv6_non_link))
+			return c->ipv6_non_link;
+
+	}
+
+	return NULL;
+}
 
 void isis_circuit_init(void)
 {

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -234,6 +234,8 @@ int isis_circuit_mt_enabled_set(struct isis_circuit *circuit, uint16_t mtid, boo
 /* Reset ISIS hello timer and send immediate hello */
 void isis_reset_hello_timer(struct isis_circuit *circuit);
 
+struct list *isis_circuit_ip_addrs(struct isis_circuit *circuit);
+
 #ifdef FABRICD
 DECLARE_HOOK(isis_circuit_config_write,
 	     (struct isis_circuit *circuit, struct vty *vty), (circuit, vty));

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -235,6 +235,7 @@ int isis_circuit_mt_enabled_set(struct isis_circuit *circuit, uint16_t mtid, boo
 void isis_reset_hello_timer(struct isis_circuit *circuit);
 
 struct list *isis_circuit_ip_addrs(struct isis_circuit *circuit);
+struct list *isis_circuit_ipv6_non_link_addrs(struct isis_circuit *circuit);
 
 #ifdef FABRICD
 DECLARE_HOOK(isis_circuit_config_write,

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -236,6 +236,7 @@ int isis_circuit_mt_enabled_set(struct isis_circuit *circuit, uint16_t mtid, boo
 void isis_reset_hello_timer(struct isis_circuit *circuit);
 
 struct list *isis_circuit_ip_addrs(struct isis_circuit *circuit);
+struct list *isis_circuit_ipv6_non_link_addrs(struct isis_circuit *circuit);
 
 #ifdef FABRICD
 DECLARE_HOOK(isis_circuit_config_write,

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -235,6 +235,8 @@ int isis_circuit_mt_enabled_set(struct isis_circuit *circuit, uint16_t mtid, boo
 /* Reset ISIS hello timer and send immediate hello */
 void isis_reset_hello_timer(struct isis_circuit *circuit);
 
+struct list *isis_circuit_ip_addrs(struct isis_circuit *circuit);
+
 #ifdef FABRICD
 DECLARE_HOOK(isis_circuit_config_write,
 	     (struct isis_circuit *circuit, struct vty *vty), (circuit, vty));

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1319,6 +1319,8 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 			lsp_debug("ISIS (%s): Circuit is not passive, don't add prefixes.",
 				  area->area_tag);
 		} else {
+			struct list *ipv6_non_link = isis_circuit_ipv6_non_link_addrs(circuit);
+
 			if (circuit->ip_router && circuit->ip_addrs->count > 0) {
 				lsp_debug("ISIS (%s): Circuit has IPv4 active, adding respective TLVs.",
 					  area->area_tag);
@@ -1328,11 +1330,11 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 					lsp_build_internal_reach_ipv4(lsp, area, ipv4, metric);
 			}
 
-			if (circuit->ipv6_router && circuit->ipv6_non_link->count > 0) {
+			if (circuit->ipv6_router && ipv6_non_link && listcount(ipv6_non_link) > 0) {
 				struct listnode *ipnode;
 				struct prefix_ipv6 *ipv6;
 
-				for (ALL_LIST_ELEMENTS_RO(circuit->ipv6_non_link, ipnode, ipv6))
+				for (ALL_LIST_ELEMENTS_RO(ipv6_non_link, ipnode, ipv6))
 					lsp_build_internal_reach_ipv6(lsp, area, ipv6, metric);
 			}
 		}

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -806,8 +806,7 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 		goto out;
 	}
 
-	iih.v4_usable = (fabricd_ip_addrs(circuit)
-			 && iih.tlvs->ipv4_address.count);
+	iih.v4_usable = (isis_circuit_ip_addrs(circuit) && iih.tlvs->ipv4_address.count);
 
 	iih.v6_usable =
 		(listcount(circuit->ipv6_link) && iih.tlvs->ipv6_address.count);
@@ -2014,7 +2013,7 @@ int send_hello(struct isis_circuit *circuit, int level)
 	}
 
 	if (circuit->ip_router) {
-		struct list *circuit_ip_addrs = fabricd_ip_addrs(circuit);
+		struct list *circuit_ip_addrs = isis_circuit_ip_addrs(circuit);
 
 		if (circuit_ip_addrs)
 			isis_tlvs_add_ipv4_addresses(tlvs, circuit_ip_addrs);

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -809,7 +809,8 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 	iih.v4_usable = (isis_circuit_ip_addrs(circuit) && iih.tlvs->ipv4_address.count);
 
 	iih.v6_usable =
-		(listcount(circuit->ipv6_link) && iih.tlvs->ipv6_address.count);
+		(listcount(circuit->ipv6_link) && iih.tlvs->ipv6_address.count) ||
+		(isis_circuit_ipv6_non_link_addrs(circuit) && iih.tlvs->global_ipv6_address.count);
 
 	if (!iih.v4_usable && !iih.v6_usable) {
 		if (IS_DEBUG_ADJ_PACKETS) {
@@ -2019,13 +2020,16 @@ int send_hello(struct isis_circuit *circuit, int level)
 			isis_tlvs_add_ipv4_addresses(tlvs, circuit_ip_addrs);
 	}
 
-	if (circuit->ipv6_router)
+	if (circuit->ipv6_router && listcount(circuit->ipv6_link) > 0)
 		isis_tlvs_add_ipv6_addresses(tlvs, circuit->ipv6_link);
 
 	/* RFC6119 section 4 define TLV 233 to provide Global IPv6 address */
-	if (circuit->ipv6_router)
-		isis_tlvs_add_global_ipv6_addresses(tlvs,
-						    circuit->ipv6_non_link);
+	if (circuit->ipv6_router) {
+		struct list *circuit_ipv6_addrs = isis_circuit_ipv6_non_link_addrs(circuit);
+
+		if (circuit_ipv6_addrs)
+			isis_tlvs_add_global_ipv6_addresses(tlvs, circuit_ipv6_addrs);
+	}
 
 	bool should_pad_hello =
 		circuit->pad_hellos == ISIS_HELLO_PADDING_ALWAYS ||

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -802,8 +802,7 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 		goto out;
 	}
 
-	iih.v4_usable = (fabricd_ip_addrs(circuit)
-			 && iih.tlvs->ipv4_address.count);
+	iih.v4_usable = (isis_circuit_ip_addrs(circuit) && iih.tlvs->ipv4_address.count);
 
 	iih.v6_usable =
 		(listcount(circuit->ipv6_link) && iih.tlvs->ipv6_address.count);
@@ -2008,7 +2007,7 @@ int send_hello(struct isis_circuit *circuit, int level)
 	}
 
 	if (circuit->ip_router) {
-		struct list *circuit_ip_addrs = fabricd_ip_addrs(circuit);
+		struct list *circuit_ip_addrs = isis_circuit_ip_addrs(circuit);
 
 		if (circuit_ip_addrs)
 			isis_tlvs_add_ipv4_addresses(tlvs, circuit_ip_addrs);

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -429,6 +429,16 @@ static int process_p2p_hello(struct iih_info *iih)
 
 	if (adj) {
 		if (adj->adj_state == ISIS_ADJ_UP && changed) {
+			/*
+			 * The neighbor may have replaced an address it only
+			 * borrowed from its loopback with the one it finally
+			 * learned for this link. The TE neighbor address
+			 * subTLVs are recomputed from the adjacency IP
+			 * enabled/disabled hooks only, which do not fire when
+			 * an address is merely replaced, so refresh them
+			 * before re-originating our LSP.
+			 */
+			isis_mpls_te_circuit_ip_update(adj->circuit);
 			lsp_regenerate_schedule(
 				adj->circuit->area,
 				isis_adj_usage2levels(adj->adj_usage), 0);

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -815,7 +815,8 @@ static int process_hello(uint8_t pdu_type, struct isis_circuit *circuit,
 	iih.v4_usable = (isis_circuit_ip_addrs(circuit) && iih.tlvs->ipv4_address.count);
 
 	iih.v6_usable =
-		(listcount(circuit->ipv6_link) && iih.tlvs->ipv6_address.count);
+		(listcount(circuit->ipv6_link) && iih.tlvs->ipv6_address.count) ||
+		(isis_circuit_ipv6_non_link_addrs(circuit) && iih.tlvs->global_ipv6_address.count);
 
 	if (!iih.v4_usable && !iih.v6_usable) {
 		if (IS_DEBUG_ADJ_PACKETS) {
@@ -2023,13 +2024,16 @@ int send_hello(struct isis_circuit *circuit, int level)
 			isis_tlvs_add_ipv4_addresses(tlvs, circuit_ip_addrs);
 	}
 
-	if (circuit->ipv6_router)
+	if (circuit->ipv6_router && listcount(circuit->ipv6_link) > 0)
 		isis_tlvs_add_ipv6_addresses(tlvs, circuit->ipv6_link);
 
 	/* RFC6119 section 4 define TLV 233 to provide Global IPv6 address */
-	if (circuit->ipv6_router)
-		isis_tlvs_add_global_ipv6_addresses(tlvs,
-						    circuit->ipv6_non_link);
+	if (circuit->ipv6_router) {
+		struct list *circuit_ipv6_addrs = isis_circuit_ipv6_non_link_addrs(circuit);
+
+		if (circuit_ipv6_addrs)
+			isis_tlvs_add_global_ipv6_addresses(tlvs, circuit_ipv6_addrs);
+	}
 
 	bool should_pad_hello =
 		circuit->pad_hellos == ISIS_HELLO_PADDING_ALWAYS ||

--- a/isisd/isis_route.c
+++ b/isisd/isis_route.c
@@ -195,6 +195,23 @@ void adjinfo2nexthop(int family, struct list *nexthops, struct isis_adjacency *a
 				break;
 			}
 		}
+		if (adj->ll_ipv6_count)
+			break;
+		for (unsigned int i = 0; i < adj->global_ipv6_count; i++) {
+			ip.ipv6 = adj->global_ipv6_addrs[i];
+
+			if (!nexthoplookup(nexthops, AF_INET6, &ip,
+					   adj->circuit->interface->ifindex)) {
+				nh = isis_nexthop_create(AF_INET6, &ip,
+							 adj->circuit->interface->ifindex);
+				memcpy(nh->sysid, adj->sysid, sizeof(nh->sysid));
+				if (sr)
+					nh->sr = *sr;
+				nh->label_stack = label_stack;
+				listnode_add(nexthops, nh);
+				break;
+			}
+		}
 		break;
 	default:
 		flog_err(EC_LIB_DEVELOPMENT, "%s: unknown address family [%d]", __func__, family);

--- a/isisd/isis_route.c
+++ b/isisd/isis_route.c
@@ -196,6 +196,23 @@ void adjinfo2nexthop(int family, struct list *nexthops, struct isis_adjacency *a
 				break;
 			}
 		}
+		if (adj->ll_ipv6_count)
+			break;
+		for (unsigned int i = 0; i < adj->global_ipv6_count; i++) {
+			ip.ipv6 = adj->global_ipv6_addrs[i];
+
+			if (!nexthoplookup(nexthops, AF_INET6, &ip,
+					   adj->circuit->interface->ifindex)) {
+				nh = isis_nexthop_create(AF_INET6, &ip,
+							 adj->circuit->interface->ifindex);
+				memcpy(nh->sysid, adj->sysid, sizeof(nh->sysid));
+				if (sr)
+					nh->sr = *sr;
+				nh->label_stack = label_stack;
+				listnode_add(nexthops, nh);
+				break;
+			}
+		}
 		break;
 	default:
 		flog_err(EC_LIB_DEVELOPMENT, "%s: unknown address family [%d]", __func__, family);

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -51,8 +51,6 @@
 
 DEFINE_MTYPE_STATIC(ISISD, ISIS_MPLS_TE, "ISIS MPLS_TE parameters");
 
-static void isis_mpls_te_circuit_ip_update(struct isis_circuit *circuit);
-
 /*------------------------------------------------------------------------*
  * Following are control functions for MPLS-TE parameters management.
  *------------------------------------------------------------------------*/
@@ -600,7 +598,7 @@ static int isis_mpls_te_adj_ip_disabled(struct isis_adjacency *adj, int family, 
 	return ret;
 }
 
-static void isis_mpls_te_circuit_ip_update(struct isis_circuit *circuit)
+void isis_mpls_te_circuit_ip_update(struct isis_circuit *circuit)
 {
 	struct isis_adjacency *adj;
 

--- a/isisd/isis_te.h
+++ b/isisd/isis_te.h
@@ -119,6 +119,7 @@ void isis_link_params_update_asla(struct isis_circuit *circuit,
 				  struct interface *ifp);
 void isis_link_params_update(struct isis_circuit *circuit, struct interface *ifp);
 int isis_mpls_te_update(struct interface *ifp);
+void isis_mpls_te_circuit_ip_update(struct isis_circuit *circuit);
 void isis_te_lsp_event(struct isis_lsp *lsp, enum lsp_event event);
 int isis_te_sync_ted(struct zapi_opaque_reg_info dst);
 void isis_te_init_ted(struct isis_area *area);

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -186,11 +186,12 @@ static int isis_zebra_add_nexthops(struct isis *isis, struct list *nexthops,
 			}
 			break;
 		case AF_INET6:
-			if (!IN6_IS_ADDR_LINKLOCAL(&nexthop->ip.ipv6) &&
-				IPV6_ADDR_SAME(&nexthop->ip.ipv6, &in6addr_any))
-				continue;
-			api_nh->gate.ipv6 = nexthop->ip.ipv6;
-			api_nh->type = NEXTHOP_TYPE_IPV6_IFINDEX;
+			if (!IN6_IS_ADDR_LINKLOCAL(&nexthop->ip.ipv6)) {
+				api_nh->type = NEXTHOP_TYPE_IFINDEX;
+			} else {
+				api_nh->gate.ipv6 = nexthop->ip.ipv6;
+				api_nh->type = NEXTHOP_TYPE_IPV6_IFINDEX;
+			}
 			break;
 		default:
 			flog_err(EC_LIB_DEVELOPMENT,

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -203,23 +203,27 @@ static int isis_zebra_add_nexthops(struct isis *isis, struct list *nexthops,
 		api_nh->ifindex = nexthop->ifindex;
 
 		/*
-		 * Force ONLINK when the egress interface is unnumbered
-		 * (has no IP addresses), so the kernel skips the nexthop
-		 * reachability check. Also keep the existing fabricd
-		 * behavior.
+		 * Force ONLINK for IPv4 when the egress interface is
+		 * unnumbered (has no IP addresses), so the kernel skips
+		 * the nexthop reachability check.  IPv6 never needs this:
+		 * link-local gateways are on-link by definition and
+		 * interface-only nexthops have no gateway to validate.
+		 * Also keep the existing fabricd behavior.
 		 */
-		if (fabricd) {
-			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
-		} else {
-			struct interface *ifp;
+		if (nexthop->family == AF_INET) {
+			if (fabricd) {
+				SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
+			} else {
+				struct interface *ifp;
 
-			ifp = if_lookup_by_index(nexthop->ifindex, isis->vrf_id);
-			if (ifp) {
-				struct isis_circuit *circuit;
+				ifp = if_lookup_by_index(nexthop->ifindex, isis->vrf_id);
+				if (ifp) {
+					struct isis_circuit *circuit;
 
-				circuit = circuit_scan_by_ifp(ifp);
-				if (circuit && listcount(circuit->ip_addrs) == 0)
-					SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
+					circuit = circuit_scan_by_ifp(ifp);
+					if (circuit && listcount(circuit->ip_addrs) == 0)
+						SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
+				}
 			}
 		}
 

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -186,10 +186,9 @@ static int isis_zebra_add_nexthops(struct isis *isis, struct list *nexthops,
 			}
 			break;
 		case AF_INET6:
-			if (!IN6_IS_ADDR_LINKLOCAL(&nexthop->ip.ipv6)
-			    && !IN6_IS_ADDR_UNSPECIFIED(&nexthop->ip.ipv6)) {
+			if (!IN6_IS_ADDR_LINKLOCAL(&nexthop->ip.ipv6) &&
+				IPV6_ADDR_SAME(&nexthop->ip.ipv6, &in6addr_any))
 				continue;
-			}
 			api_nh->gate.ipv6 = nexthop->ip.ipv6;
 			api_nh->type = NEXTHOP_TYPE_IPV6_IFINDEX;
 			break;

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -173,8 +173,6 @@ static int isis_zebra_add_nexthops(struct isis *isis, struct list *nexthops,
 
 		zapi_nexthop_init(api_nh);
 
-		if (fabricd)
-			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
 		api_nh->vrf_id = isis->vrf_id;
 
 		switch (nexthop->family) {
@@ -203,6 +201,27 @@ static int isis_zebra_add_nexthops(struct isis *isis, struct list *nexthops,
 		}
 
 		api_nh->ifindex = nexthop->ifindex;
+
+		/*
+		 * Force ONLINK when the egress interface is unnumbered
+		 * (has no IP addresses), so the kernel skips the nexthop
+		 * reachability check. Also keep the existing fabricd
+		 * behavior.
+		 */
+		if (fabricd) {
+			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
+		} else {
+			struct interface *ifp;
+
+			ifp = if_lookup_by_index(nexthop->ifindex, isis->vrf_id);
+			if (ifp) {
+				struct isis_circuit *circuit;
+
+				circuit = circuit_scan_by_ifp(ifp);
+				if (circuit && listcount(circuit->ip_addrs) == 0)
+					SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
+			}
+		}
 
 		/* Add MPLS label(s). */
 		if (nexthop->label_stack) {

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -174,8 +174,6 @@ static int isis_zebra_add_nexthops(struct isis *isis, struct list *nexthops,
 
 		zapi_nexthop_init(api_nh);
 
-		if (fabricd)
-			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
 		api_nh->vrf_id = isis->vrf_id;
 
 		switch (nexthop->family) {
@@ -204,6 +202,27 @@ static int isis_zebra_add_nexthops(struct isis *isis, struct list *nexthops,
 		}
 
 		api_nh->ifindex = nexthop->ifindex;
+
+		/*
+		 * Force ONLINK when the egress interface is unnumbered
+		 * (has no IP addresses), so the kernel skips the nexthop
+		 * reachability check. Also keep the existing fabricd
+		 * behavior.
+		 */
+		if (fabricd) {
+			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
+		} else {
+			struct interface *ifp;
+
+			ifp = if_lookup_by_index(nexthop->ifindex, isis->vrf_id);
+			if (ifp) {
+				struct isis_circuit *circuit;
+
+				circuit = circuit_scan_by_ifp(ifp);
+				if (circuit && listcount(circuit->ip_addrs) == 0)
+					SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
+			}
+		}
 
 		/* Add MPLS label(s). */
 		if (nexthop->label_stack) {

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -187,10 +187,9 @@ static int isis_zebra_add_nexthops(struct isis *isis, struct list *nexthops,
 			}
 			break;
 		case AF_INET6:
-			if (!IN6_IS_ADDR_LINKLOCAL(&nexthop->ip.ipv6)
-			    && !IN6_IS_ADDR_UNSPECIFIED(&nexthop->ip.ipv6)) {
+			if (!IN6_IS_ADDR_LINKLOCAL(&nexthop->ip.ipv6) &&
+				IPV6_ADDR_SAME(&nexthop->ip.ipv6, &in6addr_any))
 				continue;
-			}
 			api_nh->gate.ipv6 = nexthop->ip.ipv6;
 			api_nh->type = NEXTHOP_TYPE_IPV6_IFINDEX;
 			break;

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -204,13 +204,21 @@ static int isis_zebra_add_nexthops(struct isis *isis, struct list *nexthops,
 		api_nh->ifindex = nexthop->ifindex;
 
 		/*
-		 * Force ONLINK when the egress interface is unnumbered
-		 * (has no IP addresses), so the kernel skips the nexthop
-		 * reachability check. Also keep the existing fabricd
-		 * behavior.
+		 * Force ONLINK when the gateway is not covered by any prefix
+		 * configured on the egress interface, so that the kernel skips
+		 * the nexthop reachability check.  For IPv4 this is the case on
+		 * unnumbered interfaces, which have no addresses at all; for
+		 * IPv6 it is the case whenever the neighbor could only offer a
+		 * global address, borrowed from its loopback.  Link-local IPv6
+		 * gateways are on-link by definition and need no flag.  Also
+		 * keep the existing fabricd behavior.
 		 */
 		if (fabricd) {
 			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
+		} else if (nexthop->family == AF_INET6) {
+			if (api_nh->type == NEXTHOP_TYPE_IPV6_IFINDEX &&
+			    !IN6_IS_ADDR_LINKLOCAL(&nexthop->ip.ipv6))
+				SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
 		} else {
 			struct interface *ifp;
 

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -187,11 +187,12 @@ static int isis_zebra_add_nexthops(struct isis *isis, struct list *nexthops,
 			}
 			break;
 		case AF_INET6:
-			if (!IN6_IS_ADDR_LINKLOCAL(&nexthop->ip.ipv6) &&
-				IPV6_ADDR_SAME(&nexthop->ip.ipv6, &in6addr_any))
-				continue;
-			api_nh->gate.ipv6 = nexthop->ip.ipv6;
-			api_nh->type = NEXTHOP_TYPE_IPV6_IFINDEX;
+			if (IN6_IS_ADDR_UNSPECIFIED(&nexthop->ip.ipv6)) {
+				api_nh->type = NEXTHOP_TYPE_IFINDEX;
+			} else {
+				api_nh->gate.ipv6 = nexthop->ip.ipv6;
+				api_nh->type = NEXTHOP_TYPE_IPV6_IFINDEX;
+			}
 			break;
 		default:
 			flog_err(EC_LIB_DEVELOPMENT,

--- a/tests/topotests/isis_unnumbered/r1/isisd.conf
+++ b/tests/topotests/isis_unnumbered/r1/isisd.conf
@@ -1,0 +1,22 @@
+hostname r1
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
+interface r1-eth0
+ ip router isis 1
+ isis hello-interval 2
+ isis network point-to-point
+!
+interface r1-eth1
+ ip router isis 1
+ isis hello-interval 2
+ isis network point-to-point
+!
+interface lo
+ ip router isis 1
+ isis passive
+!
+router isis 1
+ net 10.0000.0000.0000.0000.0000.0000.0000.0000.0000.00
+ metric-style wide
+!

--- a/tests/topotests/isis_unnumbered/r1/isisd.conf
+++ b/tests/topotests/isis_unnumbered/r1/isisd.conf
@@ -4,19 +4,23 @@ hostname r1
 ! debug isis update-packets
 interface r1-eth0
  ip router isis 1
+ ipv6 router isis 1
  isis hello-interval 2
  isis network point-to-point
 !
 interface r1-eth1
  ip router isis 1
+ ipv6 router isis 1
  isis hello-interval 2
  isis network point-to-point
 !
 interface lo
  ip router isis 1
+ ipv6 router isis 1
  isis passive
 !
 router isis 1
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0000.00
  metric-style wide
+ topology ipv6-unicast
 !

--- a/tests/topotests/isis_unnumbered/r1/r1_route.json
+++ b/tests/topotests/isis_unnumbered/r1/r1_route.json
@@ -1,0 +1,53 @@
+{
+  "10.254.0.1/32": [
+    {
+      "nexthops": [
+        {
+          "active": true,
+          "directlyConnected": true,
+          "fib": true,
+          "interfaceName": "lo"
+        }
+      ],
+      "prefix": "10.254.0.1/32",
+      "protocol": "connected",
+      "selected": true
+    }
+  ],
+  "10.254.0.2/32": [
+    {
+      "distance": 115,
+      "metric": 20,
+      "nexthops": [
+        {
+          "active": true,
+          "afi": "ipv4",
+          "fib": true,
+          "interfaceName": "r1-eth0",
+          "ip": "10.254.0.2"
+        }
+      ],
+      "prefix": "10.254.0.2/32",
+      "protocol": "isis",
+      "selected": true
+    }
+  ],
+  "10.254.0.3/32": [
+    {
+      "distance": 115,
+      "metric": 20,
+      "nexthops": [
+        {
+          "active": true,
+          "afi": "ipv4",
+          "fib": true,
+          "interfaceName": "r1-eth1",
+          "ip": "10.254.0.3"
+        }
+      ],
+      "prefix": "10.254.0.3/32",
+      "protocol": "isis",
+      "selected": true
+    }
+  ]
+}

--- a/tests/topotests/isis_unnumbered/r1/r1_route6.json
+++ b/tests/topotests/isis_unnumbered/r1/r1_route6.json
@@ -1,0 +1,47 @@
+{
+  "10:254::1/128": [
+    {
+      "nexthops": [
+        {
+          "active": true,
+          "directlyConnected": true,
+          "fib": true,
+          "interfaceName": "lo"
+        }
+      ],
+      "prefix": "10:254::1/128",
+      "protocol": "connected",
+      "selected": true
+    }
+  ],
+  "10:254::2/128": [
+    {
+      "nexthops": [
+        {
+          "active": true,
+          "directlyConnected": true,
+          "fib": true,
+          "interfaceName": "lo"
+        }
+      ],
+      "prefix": "10:254::2/128",
+      "protocol": "connected",
+      "selected": true
+    }
+  ],
+  "10:254::3/128": [
+    {
+      "nexthops": [
+        {
+          "active": true,
+          "directlyConnected": true,
+          "fib": true,
+          "interfaceName": "lo"
+        }
+      ],
+      "prefix": "10:254::3/128",
+      "protocol": "connected",
+      "selected": true
+    }
+  ]
+}

--- a/tests/topotests/isis_unnumbered/r1/r1_route_linux.json
+++ b/tests/topotests/isis_unnumbered/r1/r1_route_linux.json
@@ -1,0 +1,23 @@
+[
+  {
+    "dst": "10.254.0.2",
+    "gateway": "10.254.0.2",
+    "dev": "r1-eth0",
+    "protocol": "isis",
+    "metric": 20,
+    "flags": [
+      "onlink"
+    ]
+  },
+  {
+    "dst": "10.254.0.3",
+    "gateway": "10.254.0.3",
+    "dev": "r1-eth1",
+    "protocol": "isis",
+    "metric": 20,
+    "flags": [
+      "onlink"
+    ]
+  }
+]
+

--- a/tests/topotests/isis_unnumbered/r1/r1_route_linux6.json
+++ b/tests/topotests/isis_unnumbered/r1/r1_route_linux6.json
@@ -1,0 +1,23 @@
+[
+  {
+    "dst": "10.254.0.2",
+    "gateway": "10.254.0.2",
+    "dev": "r1-eth0",
+    "protocol": "isis",
+    "metric": 20,
+    "flags": [
+      "onlink"
+    ]
+  },
+  {
+    "dst": "10.254.0.3",
+    "gateway": "10.254.0.3",
+    "dev": "r1-eth1",
+    "protocol": "isis",
+    "metric": 20,
+    "flags": [
+      "onlink"
+    ]
+  }
+]
+

--- a/tests/topotests/isis_unnumbered/r1/r1_route_linux6.json
+++ b/tests/topotests/isis_unnumbered/r1/r1_route_linux6.json
@@ -5,9 +5,7 @@
     "dev": "r1-eth0",
     "protocol": "isis",
     "metric": 20,
-    "flags": [
-      "onlink"
-    ]
+    "flags": []
   },
   {
     "dst": "10:254::3",
@@ -15,9 +13,6 @@
     "dev": "r1-eth1",
     "protocol": "isis",
     "metric": 20,
-    "flags": [
-      "onlink"
-    ]
+    "flags": []
   }
 ]
-

--- a/tests/topotests/isis_unnumbered/r1/r1_topology.json
+++ b/tests/topotests/isis_unnumbered/r1/r1_topology.json
@@ -1,0 +1,96 @@
+[
+    {
+        "area": "1",
+        "algorithm": 0,
+        "level-1":  {
+            "ipv4-paths": [
+                {
+                    "vertex": "r1"
+                },
+                {
+                    "metric": 0,
+                    "parent": "r1(4)",
+                    "type": "IP internal",
+                    "vertex": "10.254.0.1/32"
+                },
+                {
+                    "interface": "r1-eth0",
+                    "metric": 10,
+                    "nextHop": "r2",
+                    "parent": "r1(4)",
+                    "type": "TE-IS",
+                    "vertex": "r2"
+                },
+                {
+                    "interface": "r1-eth0",
+                    "metric": 20,
+                    "nextHop": "r2",
+                    "parent": "r2(4)",
+                    "type": "IP TE",
+                    "vertex": "10.254.0.2/32"
+                },
+                {
+                    "interface": "r1-eth1",
+                    "metric": 10,
+                    "nextHop": "r3",
+                    "parent": "r1(4)",
+                    "type": "TE-IS",
+                    "vertex": "r3"
+                },
+                {
+                    "interface": "r1-eth1",
+                    "metric": 20,
+                    "nextHop": "r3",
+                    "parent": "r3(4)",
+                    "type": "IP TE",
+                    "vertex": "10.254.0.3/32"
+                }
+            ]
+        },
+        "level-2": {
+            "ipv4-paths": [
+                {
+                    "vertex": "r1"
+                },
+                {
+                    "metric": 0,
+                    "parent": "r1(4)",
+                    "type": "IP internal",
+                    "vertex": "10.254.0.1/32"
+                },
+                {
+                    "interface": "r1-eth0",
+                    "metric": 10,
+                    "nextHop": "r2",
+                    "parent": "r1(4)",
+                    "type": "TE-IS",
+                    "vertex": "r2"
+                },
+                {
+                    "interface": "r1-eth0",
+                    "metric": 20,
+                    "nextHop": "r2",
+                    "parent": "r2(4)",
+                    "type": "IP TE",
+                    "vertex": "10.254.0.2/32"
+                },
+                {
+                    "interface": "r1-eth1",
+                    "metric": 10,
+                    "nextHop": "r3",
+                    "parent": "r1(4)",
+                    "type": "TE-IS",
+                    "vertex": "r3"
+                },
+                {
+                    "interface": "r1-eth1",
+                    "metric": 20,
+                    "nextHop": "r3",
+                    "parent": "r3(4)",
+                    "type": "IP TE",
+                    "vertex": "10.254.0.3/32"
+                }
+            ]
+        }
+    }
+]

--- a/tests/topotests/isis_unnumbered/r1/zebra.conf
+++ b/tests/topotests/isis_unnumbered/r1/zebra.conf
@@ -1,0 +1,8 @@
+hostname r1
+interface r1-eth0
+!
+interface r1-eth1
+!
+interface lo
+ ip address 10.254.0.1/32
+!

--- a/tests/topotests/isis_unnumbered/r1/zebra.conf
+++ b/tests/topotests/isis_unnumbered/r1/zebra.conf
@@ -5,4 +5,5 @@ interface r1-eth1
 !
 interface lo
  ip address 10.254.0.1/32
+ ipv6 address 10:254::1/128
 !

--- a/tests/topotests/isis_unnumbered/r2/isisd.conf
+++ b/tests/topotests/isis_unnumbered/r2/isisd.conf
@@ -1,0 +1,22 @@
+hostname r2
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
+interface r2-eth0
+ ip router isis 1
+ isis hello-interval 2
+ isis network point-to-point
+!
+interface r2-eth1
+ ip router isis 1
+ isis hello-interval 2
+ isis network point-to-point
+!
+interface lo
+ ip router isis 1
+ isis passive
+!
+router isis 1
+ net 10.0000.0000.0000.0000.0000.0000.0000.0000.0001.00
+ metric-style wide
+!

--- a/tests/topotests/isis_unnumbered/r2/isisd.conf
+++ b/tests/topotests/isis_unnumbered/r2/isisd.conf
@@ -4,19 +4,23 @@ hostname r2
 ! debug isis update-packets
 interface r2-eth0
  ip router isis 1
+ ipv6 router isis 1
  isis hello-interval 2
  isis network point-to-point
 !
 interface r2-eth1
  ip router isis 1
+ ipv6 router isis 1
  isis hello-interval 2
  isis network point-to-point
 !
 interface lo
  ip router isis 1
+ ipv6 router isis 1
  isis passive
 !
 router isis 1
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0001.00
  metric-style wide
+ topology ipv6-unicast
 !

--- a/tests/topotests/isis_unnumbered/r2/r2_route.json
+++ b/tests/topotests/isis_unnumbered/r2/r2_route.json
@@ -1,0 +1,53 @@
+{
+  "10.254.0.2/32": [
+    {
+      "nexthops": [
+        {
+          "active": true,
+          "directlyConnected": true,
+          "fib": true,
+          "interfaceName": "lo"
+        }
+      ],
+      "prefix": "10.254.0.2/32",
+      "protocol": "connected",
+      "selected": true
+    }
+  ],
+  "10.254.0.1/32": [
+    {
+      "distance": 115,
+      "metric": 20,
+      "nexthops": [
+        {
+          "active": true,
+          "afi": "ipv4",
+          "fib": true,
+          "interfaceName": "r2-eth0",
+          "ip": "10.254.0.1"
+        }
+      ],
+      "prefix": "10.254.0.1/32",
+      "protocol": "isis",
+      "selected": true
+    }
+  ],
+  "10.254.0.3/32": [
+    {
+      "distance": 115,
+      "metric": 20,
+      "nexthops": [
+        {
+          "active": true,
+          "afi": "ipv4",
+          "fib": true,
+          "interfaceName": "r2-eth1",
+          "ip": "10.254.0.3"
+        }
+      ],
+      "prefix": "10.254.0.3/32",
+      "protocol": "isis",
+      "selected": true
+    }
+  ]
+}

--- a/tests/topotests/isis_unnumbered/r2/r2_route6.json
+++ b/tests/topotests/isis_unnumbered/r2/r2_route6.json
@@ -1,5 +1,5 @@
 {
-  "10:254::1/128": [
+  "10:254::2/128": [
     {
       "nexthops": [
         {
@@ -9,12 +9,12 @@
           "interfaceName": "lo"
         }
       ],
-      "prefix": "10:254::1/128",
+      "prefix": "10:254::2/128",
       "protocol": "connected",
       "selected": true
     }
   ],
-  "10:254::2/128": [
+  "10:254::1/128": [
     {
       "distance": 115,
       "metric": 20,
@@ -23,11 +23,11 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceName": "r1-eth0",
-          "ip": "10:254::2"
+          "interfaceName": "r2-eth0",
+          "ip": "10:254::1"
         }
       ],
-      "prefix": "10:254::2/128",
+      "prefix": "10:254::1/128",
       "protocol": "isis",
       "selected": true
     }
@@ -41,7 +41,7 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceName": "r1-eth1",
+          "interfaceName": "r2-eth1",
           "ip": "10:254::3"
         }
       ],
@@ -51,3 +51,4 @@
     }
   ]
 }
+

--- a/tests/topotests/isis_unnumbered/r2/r2_route_linux.json
+++ b/tests/topotests/isis_unnumbered/r2/r2_route_linux.json
@@ -1,0 +1,23 @@
+[
+  {
+    "dst": "10.254.0.1",
+    "gateway": "10.254.0.1",
+    "dev": "r2-eth0",
+    "protocol": "isis",
+    "metric": 20,
+    "flags": [
+      "onlink"
+    ]
+  },
+  {
+    "dst": "10.254.0.3",
+    "gateway": "10.254.0.3",
+    "dev": "r2-eth1",
+    "protocol": "isis",
+    "metric": 20,
+    "flags": [
+      "onlink"
+    ]
+  }
+]
+

--- a/tests/topotests/isis_unnumbered/r2/r2_route_linux6.json
+++ b/tests/topotests/isis_unnumbered/r2/r2_route_linux6.json
@@ -1,8 +1,8 @@
 [
   {
-    "dst": "10:254::2",
-    "gateway": "10:254::2",
-    "dev": "r1-eth0",
+    "dst": "10:254::1",
+    "gateway": "10:254::1",
+    "dev": "r2-eth0",
     "protocol": "isis",
     "metric": 20,
     "flags": [
@@ -12,7 +12,7 @@
   {
     "dst": "10:254::3",
     "gateway": "10:254::3",
-    "dev": "r1-eth1",
+    "dev": "r2-eth1",
     "protocol": "isis",
     "metric": 20,
     "flags": [

--- a/tests/topotests/isis_unnumbered/r2/r2_route_linux6.json
+++ b/tests/topotests/isis_unnumbered/r2/r2_route_linux6.json
@@ -5,9 +5,7 @@
     "dev": "r2-eth0",
     "protocol": "isis",
     "metric": 20,
-    "flags": [
-      "onlink"
-    ]
+    "flags": []
   },
   {
     "dst": "10:254::3",
@@ -15,9 +13,6 @@
     "dev": "r2-eth1",
     "protocol": "isis",
     "metric": 20,
-    "flags": [
-      "onlink"
-    ]
+    "flags": []
   }
 ]
-

--- a/tests/topotests/isis_unnumbered/r2/r2_topology.json
+++ b/tests/topotests/isis_unnumbered/r2/r2_topology.json
@@ -1,0 +1,96 @@
+[
+    {
+        "area": "1",
+        "algorithm": 0,
+        "level-1":  {
+            "ipv4-paths": [
+                {
+                    "vertex": "r2"
+                },
+                {
+                    "metric": 0,
+                    "parent": "r2(4)",
+                    "type": "IP internal",
+                    "vertex": "10.254.0.2/32"
+                },
+                {
+                    "interface": "r2-eth0",
+                    "metric": 10,
+                    "nextHop": "r1",
+                    "parent": "r2(4)",
+                    "type": "TE-IS",
+                    "vertex": "r1"
+                },
+                {
+                    "interface": "r2-eth0",
+                    "metric": 20,
+                    "nextHop": "r1",
+                    "parent": "r1(4)",
+                    "type": "IP TE",
+                    "vertex": "10.254.0.1/32"
+                },
+                {
+                    "interface": "r2-eth1",
+                    "metric": 10,
+                    "nextHop": "r3",
+                    "parent": "r2(4)",
+                    "type": "TE-IS",
+                    "vertex": "r3"
+                },
+                {
+                    "interface": "r2-eth1",
+                    "metric": 20,
+                    "nextHop": "r3",
+                    "parent": "r3(4)",
+                    "type": "IP TE",
+                    "vertex": "10.254.0.3/32"
+                }
+            ]
+        },
+        "level-2": {
+            "ipv4-paths": [
+                {
+                    "vertex": "r2"
+                },
+                {
+                    "metric": 0,
+                    "parent": "r2(4)",
+                    "type": "IP internal",
+                    "vertex": "10.254.0.2/32"
+                },
+                {
+                    "interface": "r2-eth0",
+                    "metric": 10,
+                    "nextHop": "r1",
+                    "parent": "r2(4)",
+                    "type": "TE-IS",
+                    "vertex": "r1"
+                },
+                {
+                    "interface": "r2-eth0",
+                    "metric": 20,
+                    "nextHop": "r1",
+                    "parent": "r1(4)",
+                    "type": "IP TE",
+                    "vertex": "10.254.0.1/32"
+                },
+                {
+                    "interface": "r2-eth1",
+                    "metric": 10,
+                    "nextHop": "r3",
+                    "parent": "r2(4)",
+                    "type": "TE-IS",
+                    "vertex": "r3"
+                },
+                {
+                    "interface": "r2-eth1",
+                    "metric": 20,
+                    "nextHop": "r3",
+                    "parent": "r3(4)",
+                    "type": "IP TE",
+                    "vertex": "10.254.0.3/32"
+                }
+            ]
+        }
+    }
+]

--- a/tests/topotests/isis_unnumbered/r2/zebra.conf
+++ b/tests/topotests/isis_unnumbered/r2/zebra.conf
@@ -1,0 +1,8 @@
+hostname r2
+interface r2-eth0
+!
+interface r2-eth1
+!
+interface lo
+ ip address 10.254.0.2/32
+!

--- a/tests/topotests/isis_unnumbered/r2/zebra.conf
+++ b/tests/topotests/isis_unnumbered/r2/zebra.conf
@@ -5,4 +5,5 @@ interface r2-eth1
 !
 interface lo
  ip address 10.254.0.2/32
+ ipv6 address 10:254::2/128
 !

--- a/tests/topotests/isis_unnumbered/r3/isisd.conf
+++ b/tests/topotests/isis_unnumbered/r3/isisd.conf
@@ -1,0 +1,22 @@
+hostname r3
+! debug isis adj-packets
+! debug isis events
+! debug isis update-packets
+interface r3-eth0
+ ip router isis 1
+ isis hello-interval 2
+ isis network point-to-point
+!
+interface r3-eth1
+ ip router isis 1
+ isis hello-interval 2
+ isis network point-to-point
+!
+interface lo
+ ip router isis 1
+ isis passive
+!
+router isis 1
+ net 10.0000.0000.0000.0000.0000.0000.0000.0000.0002.00
+ metric-style wide
+!

--- a/tests/topotests/isis_unnumbered/r3/isisd.conf
+++ b/tests/topotests/isis_unnumbered/r3/isisd.conf
@@ -4,19 +4,23 @@ hostname r3
 ! debug isis update-packets
 interface r3-eth0
  ip router isis 1
+ ipv6 router isis 1
  isis hello-interval 2
  isis network point-to-point
 !
 interface r3-eth1
  ip router isis 1
+ ipv6 router isis 1
  isis hello-interval 2
  isis network point-to-point
 !
 interface lo
  ip router isis 1
+ ipv6 router isis 1
  isis passive
 !
 router isis 1
  net 10.0000.0000.0000.0000.0000.0000.0000.0000.0002.00
  metric-style wide
+ topology ipv6-unicast
 !

--- a/tests/topotests/isis_unnumbered/r3/r3_route.json
+++ b/tests/topotests/isis_unnumbered/r3/r3_route.json
@@ -1,0 +1,53 @@
+{
+  "10.254.0.3/32": [
+    {
+      "nexthops": [
+        {
+          "active": true,
+          "directlyConnected": true,
+          "fib": true,
+          "interfaceName": "lo"
+        }
+      ],
+      "prefix": "10.254.0.3/32",
+      "protocol": "connected",
+      "selected": true
+    }
+  ],
+  "10.254.0.2/32": [
+    {
+      "distance": 115,
+      "metric": 20,
+      "nexthops": [
+        {
+          "active": true,
+          "afi": "ipv4",
+          "fib": true,
+          "interfaceName": "r3-eth1",
+          "ip": "10.254.0.2"
+        }
+      ],
+      "prefix": "10.254.0.2/32",
+      "protocol": "isis",
+      "selected": true
+    }
+  ],
+  "10.254.0.1/32": [
+    {
+      "distance": 115,
+      "metric": 20,
+      "nexthops": [
+        {
+          "active": true,
+          "afi": "ipv4",
+          "fib": true,
+          "interfaceName": "r3-eth0",
+          "ip": "10.254.0.1"
+        }
+      ],
+      "prefix": "10.254.0.1/32",
+      "protocol": "isis",
+      "selected": true
+    }
+  ]
+}

--- a/tests/topotests/isis_unnumbered/r3/r3_route6.json
+++ b/tests/topotests/isis_unnumbered/r3/r3_route6.json
@@ -1,5 +1,5 @@
 {
-  "10:254::1/128": [
+  "10:254::3/128": [
     {
       "nexthops": [
         {
@@ -9,7 +9,7 @@
           "interfaceName": "lo"
         }
       ],
-      "prefix": "10:254::1/128",
+      "prefix": "10:254::3/128",
       "protocol": "connected",
       "selected": true
     }
@@ -23,7 +23,7 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceName": "r1-eth0",
+          "interfaceName": "r3-eth1",
           "ip": "10:254::2"
         }
       ],
@@ -32,7 +32,7 @@
       "selected": true
     }
   ],
-  "10:254::3/128": [
+  "10:254::1/128": [
     {
       "distance": 115,
       "metric": 20,
@@ -41,13 +41,14 @@
           "active": true,
           "afi": "ipv6",
           "fib": true,
-          "interfaceName": "r1-eth1",
-          "ip": "10:254::3"
+          "interfaceName": "r3-eth0",
+          "ip": "10:254::1"
         }
       ],
-      "prefix": "10:254::3/128",
+      "prefix": "10:254::1/128",
       "protocol": "isis",
       "selected": true
     }
   ]
 }
+

--- a/tests/topotests/isis_unnumbered/r3/r3_route_linux.json
+++ b/tests/topotests/isis_unnumbered/r3/r3_route_linux.json
@@ -1,0 +1,23 @@
+[
+  {
+    "dst": "10.254.0.2",
+    "gateway": "10.254.0.2",
+    "dev": "r3-eth1",
+    "protocol": "isis",
+    "metric": 20,
+    "flags": [
+      "onlink"
+    ]
+  },
+  {
+    "dst": "10.254.0.1",
+    "gateway": "10.254.0.1",
+    "dev": "r3-eth0",
+    "protocol": "isis",
+    "metric": 20,
+    "flags": [
+      "onlink"
+    ]
+  }
+]
+

--- a/tests/topotests/isis_unnumbered/r3/r3_route_linux6.json
+++ b/tests/topotests/isis_unnumbered/r3/r3_route_linux6.json
@@ -2,7 +2,7 @@
   {
     "dst": "10:254::2",
     "gateway": "10:254::2",
-    "dev": "r1-eth0",
+    "dev": "r3-eth1",
     "protocol": "isis",
     "metric": 20,
     "flags": [
@@ -10,9 +10,9 @@
     ]
   },
   {
-    "dst": "10:254::3",
-    "gateway": "10:254::3",
-    "dev": "r1-eth1",
+    "dst": "10:254::1",
+    "gateway": "10:254::1",
+    "dev": "r3-eth0",
     "protocol": "isis",
     "metric": 20,
     "flags": [
@@ -20,4 +20,3 @@
     ]
   }
 ]
-

--- a/tests/topotests/isis_unnumbered/r3/r3_route_linux6.json
+++ b/tests/topotests/isis_unnumbered/r3/r3_route_linux6.json
@@ -5,9 +5,7 @@
     "dev": "r3-eth1",
     "protocol": "isis",
     "metric": 20,
-    "flags": [
-      "onlink"
-    ]
+    "flags": []
   },
   {
     "dst": "10:254::1",
@@ -15,8 +13,6 @@
     "dev": "r3-eth0",
     "protocol": "isis",
     "metric": 20,
-    "flags": [
-      "onlink"
-    ]
+    "flags": []
   }
 ]

--- a/tests/topotests/isis_unnumbered/r3/r3_topology.json
+++ b/tests/topotests/isis_unnumbered/r3/r3_topology.json
@@ -1,0 +1,96 @@
+[
+    {
+        "area": "1",
+        "algorithm": 0,
+        "level-1":  {
+            "ipv4-paths": [
+                {
+                    "vertex": "r3"
+                },
+                {
+                    "metric": 0,
+                    "parent": "r3(4)",
+                    "type": "IP internal",
+                    "vertex": "10.254.0.3/32"
+                },
+                {
+                    "interface": "r3-eth1",
+                    "metric": 10,
+                    "nextHop": "r2",
+                    "parent": "r3(4)",
+                    "type": "TE-IS",
+                    "vertex": "r2"
+                },
+                {
+                    "interface": "r3-eth1",
+                    "metric": 20,
+                    "nextHop": "r2",
+                    "parent": "r2(4)",
+                    "type": "IP TE",
+                    "vertex": "10.254.0.2/32"
+                },
+                {
+                    "interface": "r3-eth0",
+                    "metric": 10,
+                    "nextHop": "r1",
+                    "parent": "r3(4)",
+                    "type": "TE-IS",
+                    "vertex": "r1"
+                },
+                {
+                    "interface": "r3-eth0",
+                    "metric": 20,
+                    "nextHop": "r1",
+                    "parent": "r1(4)",
+                    "type": "IP TE",
+                    "vertex": "10.254.0.1/32"
+                }
+            ]
+        },
+        "level-2":  {
+            "ipv4-paths": [
+                {
+                    "vertex": "r3"
+                },
+                {
+                    "metric": 0,
+                    "parent": "r3(4)",
+                    "type": "IP internal",
+                    "vertex": "10.254.0.3/32"
+                },
+                {
+                    "interface": "r3-eth1",
+                    "metric": 10,
+                    "nextHop": "r2",
+                    "parent": "r3(4)",
+                    "type": "TE-IS",
+                    "vertex": "r2"
+                },
+                {
+                    "interface": "r3-eth1",
+                    "metric": 20,
+                    "nextHop": "r2",
+                    "parent": "r2(4)",
+                    "type": "IP TE",
+                    "vertex": "10.254.0.2/32"
+                },
+                {
+                    "interface": "r3-eth0",
+                    "metric": 10,
+                    "nextHop": "r1",
+                    "parent": "r3(4)",
+                    "type": "TE-IS",
+                    "vertex": "r1"
+                },
+                {
+                    "interface": "r3-eth0",
+                    "metric": 20,
+                    "nextHop": "r1",
+                    "parent": "r1(4)",
+                    "type": "IP TE",
+                    "vertex": "10.254.0.1/32"
+                }
+            ]
+        }
+    }
+]

--- a/tests/topotests/isis_unnumbered/r3/zebra.conf
+++ b/tests/topotests/isis_unnumbered/r3/zebra.conf
@@ -1,0 +1,8 @@
+hostname r3
+interface r3-eth0
+!
+interface r3-eth1
+!
+interface lo
+ ip address 10.254.0.3/32
+!

--- a/tests/topotests/isis_unnumbered/r3/zebra.conf
+++ b/tests/topotests/isis_unnumbered/r3/zebra.conf
@@ -5,4 +5,5 @@ interface r3-eth1
 !
 interface lo
  ip address 10.254.0.3/32
+ ipv6 address 10:254::3/128
 !

--- a/tests/topotests/isis_unnumbered/test_isis_unnumbered.dot
+++ b/tests/topotests/isis_unnumbered/test_isis_unnumbered.dot
@@ -1,0 +1,47 @@
+## Color coding:
+#########################
+##  Main FRR: #f08080  red
+##  Switches: #d0e0d0  gray
+##  RIP:      #19e3d9  Cyan
+##  RIPng:    #fcb314  dark yellow
+##  OSPFv2:   #32b835  Green
+##  OSPFv3:   #19e3d9  Cyan
+##  ISIS IPv4 #fcb314  dark yellow
+##  ISIS IPv6 #9a81ec  purple
+##  BGP IPv4  #eee3d3  beige
+##  BGP IPv6  #fdff00  yellow
+##### Colors (see http://www.color-hex.com/)
+
+graph template {
+    label="isis unnumbered";
+
+    # Routers
+    r1 [
+        shape=doubleoctagon,
+        label="r1\nlo: 10.254.0.1",
+        fillcolor="#f08080",
+        style=filled,
+    ];
+    r2 [
+        shape=doubleoctagon
+            label="r2\nlo: 10.254.0.2",
+        fillcolor="#f08080",
+        style=filled,
+    ];
+    r3 [
+        shape=doubleoctagon
+            label="r3\nlo: 10.254.0.3",
+        fillcolor="#f08080",
+        style=filled,
+    ];
+
+    # Connections
+    subgraph cluster1 {
+        label="level 1/2";
+
+        r1 -- r2 [label="eth0\n.0"];
+        r1 -- r3 [label="eth1\n.0"];
+        r2 -- r3 [label="eth1\n.1"];
+    }
+}
+

--- a/tests/topotests/isis_unnumbered/test_isis_unnumbered.py
+++ b/tests/topotests/isis_unnumbered/test_isis_unnumbered.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_isis_unnumbered.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2025 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+
+"""
+test_isis_unnumbered.py: Unnumbered ISIS topology.
+"""
+import time
+import datetime
+import functools
+import json
+import os
+import re
+import sys
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.common_config import start_router
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.isisd]
+
+
+def build_topo(tgen):
+    "Build function"
+
+    # Add ISIS routers:
+    #      r1
+    #    /   \
+    #  r2 --- r3
+    for routern in range(1, 4):
+        tgen.add_router("r{}".format(routern))
+
+    tgen.add_link(tgen.gears["r1"], tgen.gears["r2"], "r1-eth0", "r2-eth0")
+    tgen.add_link(tgen.gears["r1"], tgen.gears["r3"], "r1-eth1", "r3-eth0")
+    tgen.add_link(tgen.gears["r2"], tgen.gears["r3"], "r2-eth1", "r3-eth1")
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    # For all registered routers, load the zebra configuration file
+    for rname, router in tgen.routers().items():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_ISIS, os.path.join(CWD, "{}/isisd.conf".format(rname))
+        )
+
+    # After loading the configurations, this function loads configured daemons.
+    tgen.start_router()
+
+
+def teardown_module():
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+
+    # This function tears down the whole topology.
+    tgen.stop_topology()
+
+
+def test_isis_convergence():
+    "Wait for the protocol to converge before starting to test"
+    tgen = get_topogen()
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("waiting for ISIS protocol to converge")
+    for rname, router in tgen.routers().items():
+        filename = "{0}/{1}/{1}_topology.json".format(CWD, rname)
+        expected = json.loads(open(filename).read())
+
+        def compare_isis_topology(router, expected):
+            "Helper function to test ISIS topology convergence."
+            actual = json.loads(router.vtysh_cmd("show isis topology json"))
+            return topotest.json_cmp(actual, expected)
+
+        test_func = functools.partial(compare_isis_topology, router, expected)
+        (result, diff) = topotest.run_and_expect(test_func, None, wait=0.5, count=120)
+        assert result, "ISIS did not converge on {}:\n{}".format(rname, diff)
+
+
+def test_isis_route_installation():
+    "Check whether all expected routes are present"
+    tgen = get_topogen()
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Checking routers for installed ISIS routes")
+
+    # Check for routes in 'show ip route json'
+    for rname, router in tgen.routers().items():
+        filename = "{0}/{1}/{1}_route.json".format(CWD, rname)
+        expected = json.loads(open(filename, "r").read())
+
+        def compare_isis_installed_routes(router, expected):
+            "Helper function to test ISIS routes installed in rib."
+            actual = router.vtysh_cmd("show ip route json", isjson=True)
+            return topotest.json_cmp(actual, expected)
+
+        test_func = functools.partial(compare_isis_installed_routes, router, expected)
+        (result, diff) = topotest.run_and_expect(test_func, None, wait=1, count=10)
+        assert result, "Router '{}' routes mismatch:\n{}".format(rname, diff)
+
+
+def test_isis_linux_route_installation():
+    "Check whether all expected routes are present and installed in the OS"
+    tgen = get_topogen()
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Checking routers for installed ISIS routes in OS")
+
+    # Check for routes in `ip route`
+    for rname, router in tgen.routers().items():
+        filename = "{0}/{1}/{1}_route_linux.json".format(CWD, rname)
+        expected = json.loads(open(filename, "r").read())
+        # use `ip route` directly and not `topotest.ip4_route(router)` so that
+        # we can check the `onlink` flag.
+        actual = json.loads(router.run("ip -json route"))
+
+        assertmsg = "Router '{}' OS routes mismatch".format(rname)
+        assert topotest.json_cmp(actual, expected) is None, assertmsg
+
+
+def test_isis_summary_json():
+    "Check json struct in show isis summary json"
+
+    tgen = get_topogen()
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Checking 'show isis summary json'")
+    for rname, _ in tgen.routers().items():
+        logger.info("Checking router %s", rname)
+        json_output = tgen.gears[rname].vtysh_cmd("show isis summary json", isjson=True)
+        assertmsg = "Test isis summary json failed in '{}' data '{}'".format(
+            rname, json_output
+        )
+        assert json_output["vrfs"][0]["vrf"] == "default", assertmsg
+        assert json_output["vrfs"][0]["areas"][0]["area"] == "1", assertmsg
+        assert json_output["vrfs"][0]["areas"][0]["levels"][0]["id"] != "3", assertmsg
+
+
+def test_isis_interface_json():
+    "Check json struct in show isis interface json"
+
+    tgen = get_topogen()
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Checking 'show isis interface json'")
+    for rname, _ in tgen.routers().items():
+        logger.info("Checking router %s", rname)
+        json_output = tgen.gears[rname].vtysh_cmd(
+            "show isis interface json", isjson=True
+        )
+        assertmsg = "Test isis interface json failed in '{}' data '{}'".format(
+            rname, json_output
+        )
+        assert (
+            json_output["areas"][0]["circuits"][0]["interface"]["name"] == "lo"
+        ), assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][1]["interface"]["name"]
+            == rname + "-eth0"
+        ), assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][2]["interface"]["name"]
+            == rname + "-eth1"
+        ), assertmsg
+
+    for rname, router in tgen.routers().items():
+        logger.info("Checking router %s", rname)
+        json_output = tgen.gears[rname].vtysh_cmd(
+            "show isis interface detail json", isjson=True
+        )
+        assertmsg = "Test isis interface json failed in '{}' data '{}'".format(
+            rname, json_output
+        )
+        assert (
+            json_output["areas"][0]["circuits"][0]["interface"]["name"] == "lo"
+        ), assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][1]["interface"]["name"]
+            == rname + "-eth0"
+        ), assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][2]["interface"]["name"]
+            == rname + "-eth1"
+        ), assertmsg
+
+
+def test_isis_neighbor_json():
+    "Check json struct in show isis neighbor json"
+
+    tgen = get_topogen()
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # tgen.mininet_cli()
+    logger.info("Checking 'show isis neighbor json'")
+    for rname, _ in tgen.routers().items():
+        logger.info("Checking router %s", rname)
+        json_output = tgen.gears[rname].vtysh_cmd(
+            "show isis neighbor json", isjson=True
+        )
+        assertmsg = "Test isis neighbor json failed in '{}' data '{}'".format(
+            rname, json_output
+        )
+        assert (
+            json_output["areas"][0]["circuits"][1]["interface"] == rname + "-eth0"
+        ), assertmsg
+        assert json_output["areas"][0]["circuits"][1]["state"] == "Up", assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][2]["interface"] == rname + "-eth1"
+        ), assertmsg
+        assert json_output["areas"][0]["circuits"][2]["state"] == "Up", assertmsg
+
+    for rname, router in tgen.routers().items():
+        logger.info("Checking router %s", rname)
+        json_output = tgen.gears[rname].vtysh_cmd(
+            "show isis neighbor detail json", isjson=True
+        )
+        assertmsg = "Test isis neighbor json failed in '{}' data '{}'".format(
+            rname, json_output
+        )
+        assert (
+            json_output["areas"][0]["circuits"][1]["interface"]["name"]
+            == rname + "-eth0"
+        ), assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][1]["interface"]["state"] == "Up"
+        ), assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][2]["interface"]["name"]
+            == rname + "-eth1"
+        ), assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][2]["interface"]["state"] == "Up"
+        ), assertmsg
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/isis_unnumbered/test_isis_unnumbered.py
+++ b/tests/topotests/isis_unnumbered/test_isis_unnumbered.py
@@ -51,6 +51,25 @@ def setup_module(mod):
     tgen = Topogen(build_topo, mod.__name__)
     tgen.start_topology()
 
+    tgen.net['r1'].cmd('ip link set dev r1-eth0 down')
+    tgen.net['r1'].cmd('ip link set dev r1-eth1 down')
+    tgen.net['r2'].cmd('ip link set dev r2-eth0 down')
+    tgen.net['r2'].cmd('ip link set dev r2-eth1 down')
+    tgen.net['r3'].cmd('ip link set dev r3-eth0 down')
+    tgen.net['r3'].cmd('ip link set dev r3-eth1 down')
+    tgen.net['r1'].cmd('sysctl net/ipv6/conf/r1-eth0/addr_gen_mode=1')
+    tgen.net['r1'].cmd('sysctl net/ipv6/conf/r1-eth1/addr_gen_mode=1')
+    tgen.net['r2'].cmd('sysctl net/ipv6/conf/r2-eth0/addr_gen_mode=1')
+    tgen.net['r2'].cmd('sysctl net/ipv6/conf/r2-eth1/addr_gen_mode=1')
+    tgen.net['r3'].cmd('sysctl net/ipv6/conf/r3-eth0/addr_gen_mode=1')
+    tgen.net['r3'].cmd('sysctl net/ipv6/conf/r3-eth1/addr_gen_mode=1')
+    tgen.net['r1'].cmd('ip link set dev r1-eth0 up')
+    tgen.net['r1'].cmd('ip link set dev r1-eth1 up')
+    tgen.net['r2'].cmd('ip link set dev r2-eth0 up')
+    tgen.net['r2'].cmd('ip link set dev r2-eth1 up')
+    tgen.net['r3'].cmd('ip link set dev r3-eth0 up')
+    tgen.net['r3'].cmd('ip link set dev r3-eth1 up')
+
     # For all registered routers, load the zebra configuration file
     for rname, router in tgen.routers().items():
         router.load_config(

--- a/tests/topotests/isis_unnumbered/test_isis_unnumbered.py
+++ b/tests/topotests/isis_unnumbered/test_isis_unnumbered.py
@@ -124,17 +124,28 @@ def test_isis_route_installation():
 
     # Check for routes in 'show ip route json'
     for rname, router in tgen.routers().items():
-        filename = "{0}/{1}/{1}_route.json".format(CWD, rname)
-        expected = json.loads(open(filename, "r").read())
+        filename_ip = "{0}/{1}/{1}_route.json".format(CWD, rname)
+        expected_ip = json.loads(open(filename_ip, "r").read())
+        filename_ipv6 = "{0}/{1}/{1}_route6.json".format(CWD, rname)
+        expected_ipv6 = json.loads(open(filename_ipv6, "r").read())
 
-        def compare_isis_installed_routes(router, expected):
-            "Helper function to test ISIS routes installed in rib."
+        def compare_isis_installed_ip_routes(router, expected):
+            "Helper function to test ISIS ip routes installed in rib."
             actual = router.vtysh_cmd("show ip route json", isjson=True)
             return topotest.json_cmp(actual, expected)
 
-        test_func = functools.partial(compare_isis_installed_routes, router, expected)
+        def compare_isis_installed_ipv6_routes(router, expected):
+            "Helper function to test ISIS ipv6 routes installed in rib."
+            actual = router.vtysh_cmd("show ipv6 route json", isjson=True)
+            return topotest.json_cmp(actual, expected)
+
+        test_func = functools.partial(compare_isis_installed_ip_routes, router, expected_ip)
         (result, diff) = topotest.run_and_expect(test_func, None, wait=1, count=10)
-        assert result, "Router '{}' routes mismatch:\n{}".format(rname, diff)
+        assert result, "Router '{}' ip routes mismatch:\n{}".format(rname, diff)
+
+        test_func = functools.partial(compare_isis_installed_ipv6_routes, router, expected_ipv6)
+        (result, diff) = topotest.run_and_expect(test_func, None, wait=1, count=10)
+        assert result, "Router '{}' ipv6 routes mismatch:\n{}".format(rname, diff)
 
 
 def test_isis_linux_route_installation():
@@ -148,14 +159,20 @@ def test_isis_linux_route_installation():
 
     # Check for routes in `ip route`
     for rname, router in tgen.routers().items():
-        filename = "{0}/{1}/{1}_route_linux.json".format(CWD, rname)
-        expected = json.loads(open(filename, "r").read())
+        filename_ip = "{0}/{1}/{1}_route_linux.json".format(CWD, rname)
+        filename_ipv6 = "{0}/{1}/{1}_route_linux6.json".format(CWD, rname)
+        expected_ip = json.loads(open(filename_ip, "r").read())
+        expected_ipv6 = json.loads(open(filename_ipv6, "r").read())
         # use `ip route` directly and not `topotest.ip4_route(router)` so that
         # we can check the `onlink` flag.
-        actual = json.loads(router.run("ip -json route"))
+        actual_ip = json.loads(router.run("ip -json route"))
+        actual_ipv6 = json.loads(router.run("ip -6 -json route"))
 
-        assertmsg = "Router '{}' OS routes mismatch".format(rname)
-        assert topotest.json_cmp(actual, expected) is None, assertmsg
+        assertmsg = "Router '{}' OS ip routes mismatch".format(rname)
+        assert topotest.json_cmp(actual_ip, expected_ip) is None, assertmsg
+
+        assertmsg = "Router '{}' OS ipv6 routes mismatch".format(rname)
+        assert topotest.json_cmp(actual_ipv6, expected_ipv6) is None, assertmsg
 
 
 def test_isis_summary_json():

--- a/tests/topotests/isis_unnumbered/test_isis_unnumbered.py
+++ b/tests/topotests/isis_unnumbered/test_isis_unnumbered.py
@@ -122,17 +122,28 @@ def test_isis_route_installation():
 
     # Check for routes in 'show ip route json'
     for rname, router in tgen.routers().items():
-        filename = "{0}/{1}/{1}_route.json".format(CWD, rname)
-        expected = json.loads(open(filename, "r").read())
+        filename_ip = "{0}/{1}/{1}_route.json".format(CWD, rname)
+        expected_ip = json.loads(open(filename_ip, "r").read())
+        filename_ipv6 = "{0}/{1}/{1}_route6.json".format(CWD, rname)
+        expected_ipv6 = json.loads(open(filename_ipv6, "r").read())
 
-        def compare_isis_installed_routes(router, expected):
-            "Helper function to test ISIS routes installed in rib."
+        def compare_isis_installed_ip_routes(router, expected):
+            "Helper function to test ISIS ip routes installed in rib."
             actual = router.vtysh_cmd("show ip route json", isjson=True)
             return topotest.json_cmp(actual, expected)
 
-        test_func = functools.partial(compare_isis_installed_routes, router, expected)
+        def compare_isis_installed_ipv6_routes(router, expected):
+            "Helper function to test ISIS ipv6 routes installed in rib."
+            actual = router.vtysh_cmd("show ipv6 route json", isjson=True)
+            return topotest.json_cmp(actual, expected)
+
+        test_func = functools.partial(compare_isis_installed_ip_routes, router, expected_ip)
         (result, diff) = topotest.run_and_expect(test_func, None, wait=1, count=10)
-        assert result, "Router '{}' routes mismatch:\n{}".format(rname, diff)
+        assert result, "Router '{}' ip routes mismatch:\n{}".format(rname, diff)
+
+        test_func = functools.partial(compare_isis_installed_ipv6_routes, router, expected_ipv6)
+        (result, diff) = topotest.run_and_expect(test_func, None, wait=1, count=10)
+        assert result, "Router '{}' ipv6 routes mismatch:\n{}".format(rname, diff)
 
 
 def normalize_os_routes(routes):
@@ -165,14 +176,20 @@ def test_isis_linux_route_installation():
 
     # Check for routes in `ip route`
     for rname, router in tgen.routers().items():
-        filename = "{0}/{1}/{1}_route_linux.json".format(CWD, rname)
-        expected = json.loads(open(filename, "r").read())
+        filename_ip = "{0}/{1}/{1}_route_linux.json".format(CWD, rname)
+        filename_ipv6 = "{0}/{1}/{1}_route_linux6.json".format(CWD, rname)
+        expected_ip = json.loads(open(filename_ip, "r").read())
+        expected_ipv6 = json.loads(open(filename_ipv6, "r").read())
         # use `ip route` directly and not `topotest.ip4_route(router)` so that
         # we can check the `onlink` flag.
-        actual = json.loads(router.run("ip -json route"))
+        actual_ip = normalize_os_routes(json.loads(router.run("ip -json route")))
+        actual_ipv6 = normalize_os_routes(json.loads(router.run("ip -6 -json route")))
 
-        assertmsg = "Router '{}' OS routes mismatch".format(rname)
-        assert topotest.json_cmp(actual, expected) is None, assertmsg
+        assertmsg = "Router '{}' OS ip routes mismatch".format(rname)
+        assert topotest.json_cmp(actual_ip, expected_ip) is None, assertmsg
+
+        assertmsg = "Router '{}' OS ipv6 routes mismatch".format(rname)
+        assert topotest.json_cmp(actual_ipv6, expected_ipv6) is None, assertmsg
 
 
 def test_isis_summary_json():

--- a/tests/topotests/isis_unnumbered/test_isis_unnumbered.py
+++ b/tests/topotests/isis_unnumbered/test_isis_unnumbered.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# Copyright (C) 2026 Proxmox Server Solutions GmbH
+#                    Gabriel Goller
+#
+
+"""
+test_isis_unnumbered.py: Unnumbered ISIS topology.
+"""
+import time
+import datetime
+import functools
+import json
+import os
+import re
+import sys
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.common_config import start_router
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.isisd]
+
+
+def build_topo(tgen):
+    "Build function"
+
+    # Add ISIS routers:
+    #      r1
+    #    /   \
+    #  r2 --- r3
+    for routern in range(1, 4):
+        tgen.add_router("r{}".format(routern))
+
+    tgen.add_link(tgen.gears["r1"], tgen.gears["r2"], "r1-eth0", "r2-eth0")
+    tgen.add_link(tgen.gears["r1"], tgen.gears["r3"], "r1-eth1", "r3-eth0")
+    tgen.add_link(tgen.gears["r2"], tgen.gears["r3"], "r2-eth1", "r3-eth1")
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    # For all registered routers, load the zebra configuration file
+    for rname, router in tgen.routers().items():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_ISIS, os.path.join(CWD, "{}/isisd.conf".format(rname))
+        )
+
+    # After loading the configurations, this function loads configured daemons.
+    tgen.start_router()
+
+
+def teardown_module():
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+
+    # This function tears down the whole topology.
+    tgen.stop_topology()
+
+
+def test_isis_convergence():
+    "Wait for the protocol to converge before starting to test"
+    tgen = get_topogen()
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("waiting for ISIS protocol to converge")
+    for rname, router in tgen.routers().items():
+        filename = "{0}/{1}/{1}_topology.json".format(CWD, rname)
+        expected = json.loads(open(filename).read())
+
+        def compare_isis_topology(router, expected):
+            "Helper function to test ISIS topology convergence."
+            actual = json.loads(router.vtysh_cmd("show isis topology json"))
+            return topotest.json_cmp(actual, expected)
+
+        test_func = functools.partial(compare_isis_topology, router, expected)
+        (result, diff) = topotest.run_and_expect(test_func, None, wait=0.5, count=120)
+        assert result, "ISIS did not converge on {}:\n{}".format(rname, diff)
+
+
+def test_isis_route_installation():
+    "Check whether all expected routes are present"
+    tgen = get_topogen()
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Checking routers for installed ISIS routes")
+
+    # Check for routes in 'show ip route json'
+    for rname, router in tgen.routers().items():
+        filename = "{0}/{1}/{1}_route.json".format(CWD, rname)
+        expected = json.loads(open(filename, "r").read())
+
+        def compare_isis_installed_routes(router, expected):
+            "Helper function to test ISIS routes installed in rib."
+            actual = router.vtysh_cmd("show ip route json", isjson=True)
+            return topotest.json_cmp(actual, expected)
+
+        test_func = functools.partial(compare_isis_installed_routes, router, expected)
+        (result, diff) = topotest.run_and_expect(test_func, None, wait=1, count=10)
+        assert result, "Router '{}' routes mismatch:\n{}".format(rname, diff)
+
+
+def normalize_os_routes(routes):
+    """
+    A route installed through a kernel nexthop object is reported by
+    `ip -json route` either flat or with its single nexthop nested in a
+    `nexthops` array, depending on the address family and on whether the
+    kernel supports nexthop objects at all. Flatten the nested form so that
+    one set of expected routes covers every variant.
+    """
+    normalized = []
+    for route in routes:
+        nexthops = route.get("nexthops")
+        if nexthops and len(nexthops) == 1:
+            route = {**route, **nexthops[0]}
+            del route["nexthops"]
+        normalized.append(route)
+
+    return normalized
+
+
+def test_isis_linux_route_installation():
+    "Check whether all expected routes are present and installed in the OS"
+    tgen = get_topogen()
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Checking routers for installed ISIS routes in OS")
+
+    # Check for routes in `ip route`
+    for rname, router in tgen.routers().items():
+        filename = "{0}/{1}/{1}_route_linux.json".format(CWD, rname)
+        expected = json.loads(open(filename, "r").read())
+        # use `ip route` directly and not `topotest.ip4_route(router)` so that
+        # we can check the `onlink` flag.
+        actual = json.loads(router.run("ip -json route"))
+
+        assertmsg = "Router '{}' OS routes mismatch".format(rname)
+        assert topotest.json_cmp(actual, expected) is None, assertmsg
+
+
+def test_isis_summary_json():
+    "Check json struct in show isis summary json"
+
+    tgen = get_topogen()
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Checking 'show isis summary json'")
+    for rname, _ in tgen.routers().items():
+        logger.info("Checking router %s", rname)
+        json_output = tgen.gears[rname].vtysh_cmd("show isis summary json", isjson=True)
+        assertmsg = "Test isis summary json failed in '{}' data '{}'".format(
+            rname, json_output
+        )
+        assert json_output["vrfs"][0]["vrf"] == "default", assertmsg
+        assert json_output["vrfs"][0]["areas"][0]["area"] == "1", assertmsg
+        assert json_output["vrfs"][0]["areas"][0]["levels"][0]["id"] != "3", assertmsg
+
+
+def test_isis_interface_json():
+    "Check json struct in show isis interface json"
+
+    tgen = get_topogen()
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Checking 'show isis interface json'")
+    for rname, _ in tgen.routers().items():
+        logger.info("Checking router %s", rname)
+        json_output = tgen.gears[rname].vtysh_cmd(
+            "show isis interface json", isjson=True
+        )
+        assertmsg = "Test isis interface json failed in '{}' data '{}'".format(
+            rname, json_output
+        )
+        assert (
+            json_output["areas"][0]["circuits"][0]["interface"]["name"] == "lo"
+        ), assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][1]["interface"]["name"]
+            == rname + "-eth0"
+        ), assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][2]["interface"]["name"]
+            == rname + "-eth1"
+        ), assertmsg
+
+    for rname, router in tgen.routers().items():
+        logger.info("Checking router %s", rname)
+        json_output = tgen.gears[rname].vtysh_cmd(
+            "show isis interface detail json", isjson=True
+        )
+        assertmsg = "Test isis interface json failed in '{}' data '{}'".format(
+            rname, json_output
+        )
+        assert (
+            json_output["areas"][0]["circuits"][0]["interface"]["name"] == "lo"
+        ), assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][1]["interface"]["name"]
+            == rname + "-eth0"
+        ), assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][2]["interface"]["name"]
+            == rname + "-eth1"
+        ), assertmsg
+
+
+def test_isis_neighbor_json():
+    "Check json struct in show isis neighbor json"
+
+    tgen = get_topogen()
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # tgen.mininet_cli()
+    logger.info("Checking 'show isis neighbor json'")
+    for rname, _ in tgen.routers().items():
+        logger.info("Checking router %s", rname)
+        json_output = tgen.gears[rname].vtysh_cmd(
+            "show isis neighbor json", isjson=True
+        )
+        assertmsg = "Test isis neighbor json failed in '{}' data '{}'".format(
+            rname, json_output
+        )
+        assert (
+            json_output["areas"][0]["circuits"][1]["interface"] == rname + "-eth0"
+        ), assertmsg
+        assert json_output["areas"][0]["circuits"][1]["state"] == "Up", assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][2]["interface"] == rname + "-eth1"
+        ), assertmsg
+        assert json_output["areas"][0]["circuits"][2]["state"] == "Up", assertmsg
+
+    for rname, router in tgen.routers().items():
+        logger.info("Checking router %s", rname)
+        json_output = tgen.gears[rname].vtysh_cmd(
+            "show isis neighbor detail json", isjson=True
+        )
+        assertmsg = "Test isis neighbor json failed in '{}' data '{}'".format(
+            rname, json_output
+        )
+        assert (
+            json_output["areas"][0]["circuits"][1]["interface"]["name"]
+            == rname + "-eth0"
+        ), assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][1]["interface"]["state"] == "Up"
+        ), assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][2]["interface"]["name"]
+            == rname + "-eth1"
+        ), assertmsg
+        assert (
+            json_output["areas"][0]["circuits"][2]["interface"]["state"] == "Up"
+        ), assertmsg
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/isis_unnumbered/test_isis_unnumbered.py
+++ b/tests/topotests/isis_unnumbered/test_isis_unnumbered.py
@@ -49,6 +49,25 @@ def setup_module(mod):
     tgen = Topogen(build_topo, mod.__name__)
     tgen.start_topology()
 
+    tgen.net['r1'].cmd('ip link set dev r1-eth0 down')
+    tgen.net['r1'].cmd('ip link set dev r1-eth1 down')
+    tgen.net['r2'].cmd('ip link set dev r2-eth0 down')
+    tgen.net['r2'].cmd('ip link set dev r2-eth1 down')
+    tgen.net['r3'].cmd('ip link set dev r3-eth0 down')
+    tgen.net['r3'].cmd('ip link set dev r3-eth1 down')
+    tgen.net['r1'].cmd('sysctl net/ipv6/conf/r1-eth0/addr_gen_mode=1')
+    tgen.net['r1'].cmd('sysctl net/ipv6/conf/r1-eth1/addr_gen_mode=1')
+    tgen.net['r2'].cmd('sysctl net/ipv6/conf/r2-eth0/addr_gen_mode=1')
+    tgen.net['r2'].cmd('sysctl net/ipv6/conf/r2-eth1/addr_gen_mode=1')
+    tgen.net['r3'].cmd('sysctl net/ipv6/conf/r3-eth0/addr_gen_mode=1')
+    tgen.net['r3'].cmd('sysctl net/ipv6/conf/r3-eth1/addr_gen_mode=1')
+    tgen.net['r1'].cmd('ip link set dev r1-eth0 up')
+    tgen.net['r1'].cmd('ip link set dev r1-eth1 up')
+    tgen.net['r2'].cmd('ip link set dev r2-eth0 up')
+    tgen.net['r2'].cmd('ip link set dev r2-eth1 up')
+    tgen.net['r3'].cmd('ip link set dev r3-eth0 up')
+    tgen.net['r3'].cmd('ip link set dev r3-eth1 up')
+
     # For all registered routers, load the zebra configuration file
     for rname, router in tgen.routers().items():
         router.load_config(


### PR DESCRIPTION
Allow unnumbered interfaces (interfaces without an ip-address) like in openfabric. The first commit is just a preparation, it renames and moves a function. The second commit allows isis to discover ip addresses from the loopback interface if no address is found on the local interface. The third commit sets the `onlink` flag for every route inserted by isis -- this is to bypass the nexthop check, which will fail because the neighbor potentially has no ip address.

The first two commits should be fine, but I'm really not sure about the third one. It could have some serious implications. Maybe we could add a config option, something like cisco's `ip unnumbered` (https://www.cisco.com/E-Learning/bulk/public/tac/cim/cib/using_cisco_ios_software/cmdrefs/ip_unnumbered.htm) but just for isis (`isis unnumbered lo`?).

Also paging the FRR isis expert: @rwestphal :)

Fixes: #16018
Fixes: #8397