### PR TITLE
lib,doc: remove zlog tmp dirs by default at exit

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -1300,6 +1300,7 @@ void frr_fini(void)
 	frrmod_terminate();
 
 	log_memstats(di->name, debug_memstats_at_exit);
+	zlog_tmpdir_fini();
 }
 
 struct json_object *frr_daemon_state_load(void)

--- a/lib/zlog.c
+++ b/lib/zlog.c
@@ -1151,7 +1151,13 @@ out_warn:
 void zlog_fini(void)
 {
 	hook_call(zlog_fini);
+}
 
+/*
+ * Remove the process's temp log dir, at shutdown
+ */
+void zlog_tmpdir_fini(void)
+{
 	if (zlog_tmpdirfd >= 0) {
 		close(zlog_tmpdirfd);
 		zlog_tmpdirfd = -1;

--- a/lib/zlog.h
+++ b/lib/zlog.h
@@ -283,6 +283,9 @@ bool zlog_get_immediate_mode(void);
 
 extern const char *zlog_priority_str(int priority);
 
+/* Remove temp dirs at shutdown */
+void zlog_tmpdir_fini(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Remove zlog tmp dirs for each process by default, very late during shutdown

Fixes #18128 
