### PR TITLE
tests: add some wait time to bgp LU test

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3640,8 +3640,18 @@ static void bgp_lu_handle_label_allocation(struct bgp *bgp,
 {
 	mpls_label_t mpls_label_null;
 
+	zlog_debug("%pBD new: %p old: %p allocate mpls labels: %d",
+		   dest, new_select, old_select, bgp->allocate_mpls_labels[afi][SAFI_UNICAST]);
+
 	if (bgp->allocate_mpls_labels[afi][SAFI_UNICAST]) {
 		if (new_select) {
+			zlog_debug("   label differs: %u subtypes %d %d, valid label: %d registered for label %d label requested %d",
+				   bgp_label_index_differs(new_select, old_select ? old_select : new_select),
+				   new_select->sub_type, old_select ? old_select->sub_type : -1,
+				   bgp_is_valid_label(&dest->local_label),
+				   CHECK_FLAG(dest->flags, BGP_NODE_REGISTERED_FOR_LABEL),
+				   CHECK_FLAG(dest->flags, BGP_NODE_LABEL_REQUESTED));
+
 			if (!old_select ||
 			    bgp_label_index_differs(new_select, old_select) ||
 			    new_select->sub_type != old_select->sub_type ||
@@ -3653,6 +3663,8 @@ static void bgp_lu_handle_label_allocation(struct bgp *bgp,
 				mpls_label_null = MPLS_LABEL_IMPLICIT_NULL;
 				if (bgp_lu_need_null_label(bgp, new_select, afi,
 							   &mpls_label_null)) {
+					zlog_debug("   need null label?");
+
 					if (CHECK_FLAG(
 						    dest->flags,
 						    BGP_NODE_REGISTERED_FOR_LABEL) ||

--- a/tests/topotests/bgp_lu_topo1/R1/bgpd.conf
+++ b/tests/topotests/bgp_lu_topo1/R1/bgpd.conf
@@ -1,6 +1,7 @@
 !
-! debug bgp labelpool
-! debug bgp zebra
+debug bgp labelpool
+debug bgp zebra
+debug bgp neigh
 !
 router bgp 1
  bgp router-id 10.0.0.1

--- a/tests/topotests/bgp_lu_topo1/test_bgp_lu.py
+++ b/tests/topotests/bgp_lu_topo1/test_bgp_lu.py
@@ -107,7 +107,7 @@ def check_labelpool(router):
     test_func = partial(
         topotest.router_json_cmp, router, "show bgp labelpool summary json", expected
     )
-    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=2)
     assertmsg = '"{}" JSON output mismatches - Did not converge'.format(router.name)
     assert result is None, assertmsg
 

--- a/tests/topotests/bgp_lu_topo1/test_bgp_lu.py
+++ b/tests/topotests/bgp_lu_topo1/test_bgp_lu.py
@@ -140,6 +140,9 @@ def test_clear_bgplu():
     r1 = tgen.gears["R1"]
     r2 = tgen.gears["R2"]
 
+    # TODO debug
+    r1.vtysh_cmd("debug bgp bestpath 11.0.1.250/32")
+
     r1.vtysh_cmd("clear bgp 10.0.0.2")
     check_labelpool(r1)
     check_labelpool(r2)


### PR DESCRIPTION
Let the bgp LU topo1 test wait a little longer before failing- it was only waiting 20 seconds.