### PR TITLE
bgpd: fix consider MAX PACKET SIZE when receiving peer has option

### DIFF
--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1477,8 +1477,7 @@ int bgp_open_option_parse(struct peer *peer, uint16_t length,
 
 	/* Extended Message Support */
 	peer->max_packet_size =
-		(CHECK_FLAG(peer->cap, PEER_CAP_EXTENDED_MESSAGE_RCV)
-		 && CHECK_FLAG(peer->cap, PEER_CAP_EXTENDED_MESSAGE_ADV))
+		CHECK_FLAG(peer->cap, PEER_CAP_EXTENDED_MESSAGE_RCV)
 			? BGP_EXTENDED_MESSAGE_MAX_PACKET_SIZE
 			: BGP_STANDARD_MESSAGE_MAX_PACKET_SIZE;
 

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1475,11 +1475,13 @@ int bgp_open_option_parse(struct peer *peer, uint16_t length,
 		}
 	}
 
-	/* Extended Message Support */
-	peer->max_packet_size =
-		CHECK_FLAG(peer->cap, PEER_CAP_EXTENDED_MESSAGE_RCV)
-			? BGP_EXTENDED_MESSAGE_MAX_PACKET_SIZE
-			: BGP_STANDARD_MESSAGE_MAX_PACKET_SIZE;
+	/* Extended Message Support: set to MAX_PACKET_SIZE
+	 * if peer is capable and dont-capability-negotiate is not set
+	 */
+	peer->max_packet_size = CHECK_FLAG(peer->cap, PEER_CAP_EXTENDED_MESSAGE_RCV) &&
+						!CHECK_FLAG(peer->flags, PEER_FLAG_DONT_CAPABILITY)
+					? BGP_EXTENDED_MESSAGE_MAX_PACKET_SIZE
+					: BGP_STANDARD_MESSAGE_MAX_PACKET_SIZE;
 
 	/* Check that roles are corresponding to each other */
 	if (bgp_role_violation(peer))


### PR DESCRIPTION
When peering between two eBGP peers initiated by A, if BGP from B sends a lot of BGP updates, A sends back the updates in a big update packet, and that packet is rejected.

> 2025/08/19 18:37:23 BGP: [G00A3-MV858] 192.168.0.1 bad message length - 32408 for UPDATE
> 2025/08/19 18:37:23 BGP: [HZN6M-XRM1G] %NOTIFICATION: sent to neighbor 192.168.0.1 1/2 (Message Header Error/Bad Message Length) 2 bytes 7

Actually, B device considers A has a standard packet size of 4096, whereas A already had sent in its open message the info that packet size of 65535 are authorised.

Fix this by only relying on the incoming open message, as by default, BGP instance sends BGP open messages with the instruction.

Fixes: 8d976b0e2b78 ("bgpd: Set extended msg size only if we advertised and received capability")