### PR TITLE
zebra : EVPN VXLAN Multihome extern mode: Enable --kernel-ext-learn

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -103,6 +103,14 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
    the upper level daemons that can install v6 routes with v4
    nexthops.
 
+.. option:: --kernel-ext-learn
+
+   Signal to zebra that its operating in kernel external learn mode.
+   MAC learning and Aging in this mode, is done by the Hardware.
+   Kernel MAC aging is disabled. Both Control plane and Data Plane
+   learnt MAC are programmed as 'extern_learn'.
+   ARP/ND Suppression is not supported in this mode.
+
 .. _interface-commands:
 
 Configuration Addresses behaviour

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -79,6 +79,7 @@ uint32_t rt_table_main_id = RT_TABLE_MAIN;
 #define OPTION_V6_RR_SEMANTICS 2000
 #define OPTION_ASIC_OFFLOAD    2001
 #define OPTION_V6_WITH_V4_NEXTHOP 2002
+#define OPTION_KERNEL_EXT_LEARN	  2003
 
 /* Command line options. */
 const struct option longopts[] = {
@@ -89,6 +90,7 @@ const struct option longopts[] = {
 	{ "retain", no_argument, NULL, 'r' },
 	{ "asic-offload", optional_argument, NULL, OPTION_ASIC_OFFLOAD },
 	{ "v6-with-v4-nexthops", no_argument, NULL, OPTION_V6_WITH_V4_NEXTHOP },
+	{ "kernel-ext-learn", optional_argument, NULL, OPTION_KERNEL_EXT_LEARN },
 #ifdef HAVE_NETLINK
 	{ "vrfwnetns", no_argument, NULL, 'n' },
 	{ "nl-bufsize", required_argument, NULL, 's' },
@@ -356,6 +358,7 @@ int main(int argc, char **argv)
 	bool asic_offload = false;
 	bool v6_with_v4_nexthop = false;
 	bool notify_on_ack = true;
+	bool kernel_ext_learn = false;
 
 	zserv_path = NULL;
 
@@ -377,6 +380,7 @@ int main(int argc, char **argv)
 		    "  -r, --retain              When program terminates, retain added route by zebra.\n"
 		    "  -A, --asic-offload        FRR is interacting with an asic underneath the linux kernel\n"
 		    "      --v6-with-v4-nexthops Underlying dataplane supports v6 routes with v4 nexthops\n"
+		    "      --kernel-ext-learn    Enable kernel extended learning\n"
 #ifdef HAVE_NETLINK
 		    "  -s, --nl-bufsize          Set netlink receive buffer size\n"
 		    "  -n, --vrfwnetns           Use NetNS as VRF backend (deprecated, use -w)\n"
@@ -438,6 +442,9 @@ int main(int argc, char **argv)
 		case 'R':
 			rt_table_main_id = atoi(optarg);
 			break;
+		case OPTION_KERNEL_EXT_LEARN:
+			kernel_ext_learn = true;
+			break;
 #ifdef HAVE_NETLINK
 		case 'n':
 			fprintf(stderr,
@@ -467,7 +474,7 @@ int main(int argc, char **argv)
 
 	/* Zebra related initialize. */
 	libagentx_init();
-	zebra_router_init(asic_offload, notify_on_ack, v6_with_v4_nexthop);
+	zebra_router_init(asic_offload, notify_on_ack, v6_with_v4_nexthop, kernel_ext_learn);
 	zserv_init();
 	zebra_rib_init();
 	zebra_if_init();

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -14,6 +14,7 @@
 #include "zebra_mlag.h"
 #include "zebra_nhg.h"
 #include "zebra_neigh.h"
+#include "zebra_evpn.h"
 #include "zebra/zebra_tc.h"
 #include "debug.h"
 #include "zebra_script.h"
@@ -278,8 +279,8 @@ bool zebra_router_notify_on_ack(void)
 	return !zrouter.asic_offloaded || zrouter.notify_on_ack;
 }
 
-void zebra_router_init(bool asic_offload, bool notify_on_ack,
-		       bool v6_with_v4_nexthop)
+void zebra_router_init(bool asic_offload, bool notify_on_ack, bool v6_with_v4_nexthop,
+		       bool kernel_ext_learn)
 {
 	zrouter.sequence_num = 0;
 
@@ -339,6 +340,8 @@ void zebra_router_init(bool asic_offload, bool notify_on_ack,
 	zrouter.asic_offloaded = asic_offload;
 	zrouter.notify_on_ack = notify_on_ack;
 	zrouter.v6_with_v4_nexthop = v6_with_v4_nexthop;
+	zrouter.kernel_ext_learn = kernel_ext_learn;
+
 	/*
 	 * If you start using asic_notification_nexthop_control
 	 * come talk to the FRR community about what you are doing

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -209,6 +209,11 @@ struct zebra_router {
 	bool notify_on_ack;
 	bool v6_with_v4_nexthop;
 
+	/*
+	 * Is zebra operating in Kernel EXT-LEARN mode
+	 */
+	bool kernel_ext_learn;
+
 	bool v6_rr_semantics;
 
 	/*
@@ -242,8 +247,8 @@ struct zebra_router {
 extern struct zebra_router zrouter;
 extern uint32_t rcvbufsize;
 
-extern void zebra_router_init(bool asic_offload, bool notify_on_ack,
-			      bool v6_with_v4_nexthop);
+extern void zebra_router_init(bool asic_offload, bool notify_on_ack, bool v6_with_v4_nexthop,
+			      bool kernel_ext_learn);
 extern void zebra_router_cleanup(void);
 extern void zebra_router_terminate(void);
 

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -40,6 +40,12 @@ is_vxlan_flooding_head_end(void)
 	return (zvrf->vxlan_flood_ctrl == VXLAN_FLOOD_HEAD_END_REPL);
 }
 
+/* static function returning if the EXT-LEARN mode is set */
+static inline bool zebra_mac_ext_learn_mode(void)
+{
+	return zrouter.kernel_ext_learn;
+}
+
 /* VxLAN interface change flags of interest. */
 #define ZEBRA_VXLIF_LOCAL_IP_CHANGE     (1 << 0)
 #define ZEBRA_VXLIF_MASTER_CHANGE       (1 << 1)


### PR DESCRIPTION
Introduction of "--kernel-ext-learn" mode of operation in zebra. This delivers a comprehensive set of enhancements and fixes
 to support and validate EVPN VXLAN multihoming in external learning mode.

This is part of the change is to enable the
 option '--kernel-ext-learn' in zebra.

Rationale:
EVPN Multihoming External Mode Support is to enable platforms doing Hardware Based MAC Learning and Aging, to support EVPN VXLAN Multihome.

MAC's in this mode, for both data and control plane, will be marked and programmed as 'extern_only' in kernel. With this kernel aging is disabled for these MACs. Zebra along with HW will control these MACs for control plane and data plane respectively.

Per File change summary:
zebra/main.c:
  Add option '--kernel-ext-learn' in zebra startup.
zebra/zebra_router.c:
   - new bool field 'kernel_ext_learn' in zebra_router, to store extern only mode zebra/zebra_vxlan.c:
   - Accessor for Extern Only mode i.e zebra_mac_ext_learn_mode