### PR TITLE
pbrd: fix crash

### DIFF
--- a/pbrd/pbr_nht.h
+++ b/pbrd/pbr_nht.h
@@ -102,7 +102,7 @@ extern void pbr_nht_set_seq_nhg_data(struct pbr_map_sequence *pbrms,
 extern void pbr_nht_set_seq_nhg(struct pbr_map_sequence *pbrms,
 				const char *name);
 
-extern void pbr_nht_add_individual_nexthop(struct pbr_map_sequence *pbrms,
+extern bool pbr_nht_add_individual_nexthop(struct pbr_map_sequence *pbrms,
 					   const struct nexthop *nhop);
 extern void pbr_nht_delete_individual_nexthop(struct pbr_map_sequence *pbrms);
 /*

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -1296,7 +1296,10 @@ DEFPY  (pbr_map_nexthop,
 	/* This is new/replacement config */
 	pbrms_clear_set_config(pbrms);
 
-	pbr_nht_add_individual_nexthop(pbrms, &nhop);
+	if (!pbr_nht_add_individual_nexthop(pbrms, &nhop)) {
+		vty_out(vty, "%% Failed to create table identifier\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 
 	pbr_map_check(pbrms, true);
 


### PR DESCRIPTION

Two commits: one is cosmetic change, the other is for crash.

The stack:

```
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6,
    no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
#1  0x00007fef42f5af4f in __pthread_kill_internal (signo=6, threadid=<optimized out>)
    at ./nptl/pthread_kill.c:78
#2  0x00007fef42f0bfb2 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007fef42ef6472 in __GI_abort () at ./stdlib/abort.c:79
#4  0x00007fef432485e4 in _zlog_assert_failed (xref=0x5644fc22f2a0 <_xref.52>, extra=0x0)
    at ../lib/zlog.c:789
#5  0x00005644fc21b509 in pbrms_nexthop_group_write_individual_nexthop (vty=0x5644fe72cda0,
    pbrms=0x5644fe1ffcd0) at ../pbrd/pbr_vty.c:1498
#6  0x00005644fc21d5bf in pbr_vty_map_config_write_sequence (vty=0x5644fe72cda0,
    pbrm=0x5644fe1fa510, pbrms=0x5644fe1ffcd0) at ../pbrd/pbr_vty.c:2132
#7  0x00005644fc21d6b6 in pbr_vty_map_config_write (vty=0x5644fe72cda0)
    at ../pbrd/pbr_vty.c:2153
#8  0x00007fef43159eb3 in vty_write_config (vty=0x5644fe72cda0) at ../lib/command.c:1653
#9  0x00007fef4315a3eb in config_write (self=0x7fef432fd5e0 <config_write_cmd>,
    vty=0x5644fe72cda0, argc=2, argv=0x5644fe282b30) at ../lib/command.c:1791
#10 0x00007fef4315890c in cmd_execute_command_real (vline=0x5644fe183280, vty=0x5644fe72cda0,
    cmd=0x0, up_level=0) at ../lib/command.c:1010
#11 0x00007fef43158a26 in cmd_execute_command (vline=0x5644fe1fea50, vty=0x5644fe72cda0,
    cmd=0x0, vtysh=0) at ../lib/command.c:1060
#12 0x00007fef43158fd0 in cmd_execute (vty=0x5644fe72cda0,
    cmd=0x5644fe1dc900 "do write terminal", matched=0x0, vtysh=0) at ../lib/command.c:1235
#13 0x00007fef43225aac in vty_command (vty=0x5644fe72cda0,
    buf=0x5644fe1dc900 "do write terminal") at ../lib/vty.c:643
#14 0x00007fef43227702 in vty_execute (vty=0x5644fe72cda0) at ../lib/vty.c:1406
#15 0x00007fef4322992b in vtysh_read (thread=0x7fffdcead230) at ../lib/vty.c:2431
#16 0x00007fef4321e872 in event_call (thread=0x7fffdcead230) at ../lib/event.c:2009
#17 0x00007fef43196d83 in frr_run (loop=0x5644fdf056f0) at ../lib/libfrr.c:1252
#18 0x00005644fc211cbb in main (argc=6, argv=0x7fffdcead478, envp=0x7fffdcead4b0)

```