### PR TITLE
bgpd: clean up lp_release api

### DIFF
--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -407,8 +407,7 @@ void bgp_reg_dereg_for_label(struct bgp_dest *dest, struct bgp_path_info *pi,
 		}
 	} else {
 		UNSET_FLAG(dest->flags, BGP_NODE_LABEL_REQUESTED);
-		bgp_lp_release(LP_TYPE_BGP_LU, dest, label);
-		bgp_unset_valid_label(&dest->local_label);
+		bgp_lu_lp_release(dest, label);
 	}
 
 	bgp_send_fec_register_label_msg(

--- a/bgpd/bgp_labelpool.h
+++ b/bgpd/bgp_labelpool.h
@@ -37,7 +37,15 @@ extern void bgp_lp_init(struct event_loop *master, struct labelpool *pool);
 extern void bgp_lp_finish(void);
 extern void bgp_lp_get(int type, void *labelid, vrf_id_t vrf_id,
 		       int (*cbfunc)(mpls_label_t label, void *labelid, bool allocated));
-extern void bgp_lp_release(int type, void *labelid, mpls_label_t label);
+
+struct bgp_dest;
+void bgp_lu_lp_release(struct bgp_dest *dest, mpls_label_t label);
+struct vpn_policy;
+void bgp_vpn_lp_release(struct vpn_policy *policy, mpls_label_t label);
+struct bgp_mplsvpn_nh_label_bind_cache;
+void bgp_vpn_nh_lp_release(struct bgp_mplsvpn_nh_label_bind_cache *bmnc,
+			   mpls_label_t label);
+
 extern void bgp_lp_event_chunk(uint32_t first, uint32_t last);
 extern void bgp_lp_event_zebra_down(void);
 extern void bgp_lp_event_zebra_up(void);

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -4233,8 +4233,7 @@ void bgp_vpn_release_label(struct bgp *bgp, afi_t afi, bool reset)
 	if (CHECK_FLAG(bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_LABEL_PER_NEXTHOP))
 		return;
 
-	bgp_lp_release(LP_TYPE_VRF, &bgp->vpn_policy[afi], bgp->vpn_policy[afi].tovpn_label);
-	bgp->vpn_policy[afi].tovpn_label = MPLS_LABEL_NONE;
+	bgp_vpn_lp_release(&bgp->vpn_policy[afi], bgp->vpn_policy[afi].tovpn_label);
 
 	if (reset)
 		UNSET_FLAG(bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_LABEL_AUTO);
@@ -4337,7 +4336,7 @@ void bgp_mplsvpn_nh_label_bind_free(
 	if (bmnc->new_label != MPLS_INVALID_LABEL) {
 		bgp_mplsvpn_nh_label_bind_send_nexthop_label(
 			bmnc, ZEBRA_MPLS_LABELS_DELETE);
-		bgp_lp_release(LP_TYPE_BGP_L3VPN_BIND, bmnc, bmnc->new_label);
+		bgp_vpn_nh_lp_release(bmnc, bmnc->new_label);
 	}
 	bgp_mplsvpn_nh_label_bind_cache_del(
 		&bmnc->bgp_vpn->mplsvpn_nh_label_bind, bmnc);


### PR DESCRIPTION
The bgp labelpool manager used a ... scary "void *" based api that accepted several different structs as arguments. Use typed apis for the various structs that can release labels; move the generic release code to a private common helper.
