### PR TITLE
*: modify RANGE vty token to use int64_t type

### DIFF
--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -834,7 +834,7 @@ DEFPY_YANG(
 {
 	char value[32];
 
-	snprintf(value, sizeof(value), "%ld", interval * 1000);
+	snprintfrr(value, sizeof(value), "%" PRId64, interval * 1000);
 	nb_cli_enqueue_change(vty, "./required-receive-interval", no ? NB_OP_DESTROY : NB_OP_MODIFY,
 			      value);
 
@@ -858,7 +858,7 @@ DEFPY_YANG(
 {
 	char value[32];
 
-	snprintf(value, sizeof(value), "%ld", interval * 1000);
+	snprintfrr(value, sizeof(value), "%" PRId64, interval * 1000);
 	nb_cli_enqueue_change(vty, "./desired-transmission-interval",
 			      no ? NB_OP_DESTROY : NB_OP_MODIFY, value);
 
@@ -922,7 +922,7 @@ DEFPY_YANG(
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	snprintf(value, sizeof(value), "%ld", interval * 1000);
+	snprintfrr(value, sizeof(value), "%" PRId64, interval * 1000);
 	nb_cli_enqueue_change(vty, "./desired-echo-transmission-interval",
 			      no ? NB_OP_DESTROY : NB_OP_MODIFY, value);
 	nb_cli_enqueue_change(vty, "./required-echo-receive-interval",
@@ -947,7 +947,7 @@ DEFPY_YANG(
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	snprintf(value, sizeof(value), "%ld", interval * 1000);
+	snprintfrr(value, sizeof(value), "%" PRId64, interval * 1000);
 	nb_cli_enqueue_change(vty, "./desired-echo-transmission-interval",
 			      no ? NB_OP_DESTROY : NB_OP_MODIFY, value);
 
@@ -983,7 +983,7 @@ DEFPY_YANG(
 	if (disabled)
 		snprintf(value, sizeof(value), "0");
 	else
-		snprintf(value, sizeof(value), "%ld", interval * 1000);
+		snprintfrr(value, sizeof(value), "%" PRId64, interval * 1000);
 
 	nb_cli_enqueue_change(vty, "./required-echo-receive-interval",
 			      no ? NB_OP_DESTROY : NB_OP_MODIFY, value);

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -1927,8 +1927,7 @@ DEFPY(rpki_cache_tcp, rpki_cache_tcp_cmd,
 	for (ALL_LIST_ELEMENTS_RO(rpki_vrf->cache_list, cache_node,
 				  current_cache)) {
 		if (current_cache->preference == preference) {
-			vty_out(vty,
-				"Cache with preference %ld is already configured\n",
+			vty_out(vty, "Cache with preference %" PRId64 " is already configured\n",
 				preference);
 			return CMD_WARNING;
 		}
@@ -1986,8 +1985,7 @@ DEFPY(rpki_cache_ssh, rpki_cache_ssh_cmd,
 	for (ALL_LIST_ELEMENTS_RO(rpki_vrf->cache_list, cache_node,
 				  current_cache)) {
 		if (current_cache->preference == preference) {
-			vty_out(vty,
-				"Cache with preference %ld is already configured\n",
+			vty_out(vty, "Cache with preference %" PRId64 " is already configured\n",
 				preference);
 			return CMD_WARNING;
 		}
@@ -2049,8 +2047,7 @@ DEFPY (no_rpki_cache,
 	cache_list = rpki_vrf->cache_list;
 	cache_p = find_cache(preference, cache_list);
 	if (!rpki_vrf || !cache_p) {
-		vty_out(vty, "Could not find cache with preference %ld\n",
-			preference);
+		vty_out(vty, "Could not find cache with preference %" PRId64 "\n", preference);
 		return CMD_WARNING;
 	}
 
@@ -2059,8 +2056,7 @@ DEFPY (no_rpki_cache,
 	} else if (is_running(rpki_vrf)) {
 		if (rtr_mgr_remove_group(rpki_vrf->rtr_config, preference) ==
 		    RTR_ERROR) {
-			vty_out(vty,
-				"Could not remove cache with preference %ld\n",
+			vty_out(vty, "Could not remove cache with preference %" PRId64 "\n",
 				preference);
 			return CMD_WARNING;
 		}

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10602,7 +10602,7 @@ DEFPY (af_sid_vpn_export,
 	} else if (sid_idx != 0) {
 		/* SID allocation index-mode */
 		if (debug)
-			zlog_debug("%s: idx %ld sid alloc.", __func__, sid_idx);
+			zlog_debug("%s: idx %" PRId64 " sid alloc.", __func__, sid_idx);
 		bgp->vpn_policy[afi].tovpn_sid_index = sid_idx;
 	} else if (sid_explicit) {
 		/* SID allocation explicit-mode */
@@ -10706,8 +10706,7 @@ DEFPY (bgp_sid_vpn_export,
 	} else if (sid_idx != 0) {
 		/* SID allocation index-mode */
 		if (debug)
-			zlog_debug("%s: idx %ld per-vrf sid alloc.", __func__,
-				   sid_idx);
+			zlog_debug("%s: idx %" PRId64 " per-vrf sid alloc.", __func__, sid_idx);
 		bgp->tovpn_sid_index = sid_idx;
 	} else if (sid_explicit) {
 		/* SID allocation explicit-mode */
@@ -18673,8 +18672,7 @@ DEFPY(bgp_redistribute_ipv6_table, bgp_redistribute_ipv6_table_cmd,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 	if (table_id == RT_TABLE_MAIN || table_id == RT_TABLE_LOCAL) {
-		vty_out(vty,
-			"%% 'table-direct', can not use %lu routing table\n",
+		vty_out(vty, "%% 'table-direct', can not use %" PRIu64 " routing table\n",
 			table_id);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
@@ -18709,8 +18707,7 @@ DEFPY(no_bgp_redistribute_ipv6_table, no_bgp_redistribute_ipv6_table_cmd,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 	if (table_id == RT_TABLE_MAIN || table_id == RT_TABLE_LOCAL) {
-		vty_out(vty,
-			"%% 'table-direct', can not use %lu routing table\n",
+		vty_out(vty, "%% 'table-direct', can not use %" PRIu64 " routing table\n",
 			table_id);
 		return CMD_WARNING_CONFIG_FAILED;
 	}

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -3719,14 +3719,13 @@ DEFPY_YANG_NOSH(flex_algo, flex_algo_cmd, "flex-algo (128-255)$algorithm",
 	int ret;
 	char xpath[XPATH_MAXLEN + 37];
 
-	snprintf(xpath, sizeof(xpath),
-		 "%s/flex-algos/flex-algo[flex-algo='%ld']", VTY_CURR_XPATH,
-		 algorithm);
+	snprintfrr(xpath, sizeof(xpath), "%s/flex-algos/flex-algo[flex-algo='%" PRId64 "']",
+		   VTY_CURR_XPATH, algorithm);
 
 	nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
 
-	ret = nb_cli_apply_changes(
-		vty, "./flex-algos/flex-algo[flex-algo='%ld']", algorithm);
+	ret = nb_cli_apply_changes(vty, "./flex-algos/flex-algo[flex-algo='%" PRId64 "']",
+				   algorithm);
 	if (ret == CMD_SUCCESS)
 		VTY_PUSH_XPATH(ISIS_FLEX_ALGO_NODE, xpath);
 
@@ -3740,18 +3739,18 @@ DEFPY_YANG(no_flex_algo, no_flex_algo_cmd, "no flex-algo (128-255)$algorithm",
 {
 	char xpath[XPATH_MAXLEN + 37];
 
-	snprintf(xpath, sizeof(xpath),
-		 "%s/flex-algos/flex-algo[flex-algo='%ld']", VTY_CURR_XPATH,
-		 algorithm);
+	snprintfrr(xpath, sizeof(xpath), "%s/flex-algos/flex-algo[flex-algo='%'" PRId64 "']",
+		   VTY_CURR_XPATH, algorithm);
 
 	if (!yang_dnode_exists(vty->candidate_config->dnode, xpath)) {
-		vty_out(vty, "ISIS flex-algo %ld isn't exist.\n", algorithm);
+		vty_out(vty, "ISIS flex-algo %" PRId64 " isn't exist.\n", algorithm);
 		return CMD_ERR_NO_MATCH;
 	}
 
 	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
-	return nb_cli_apply_changes_clear_pending(
-		vty, "./flex-algos/flex-algo[flex-algo='%ld']", algorithm);
+	return nb_cli_apply_changes_clear_pending(vty,
+						  "./flex-algos/flex-algo[flex-algo='%" PRId64 "']",
+						  algorithm);
 }
 
 DEFPY_YANG(advertise_definition, advertise_definition_cmd,

--- a/lib/routemap_cli.c
+++ b/lib/routemap_cli.c
@@ -39,8 +39,8 @@ DEFPY_YANG_NOSH(
 		 "/frr-route-map:lib/route-map[name='%s']", name);
 	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
 
-	snprintf(xpath_index, sizeof(xpath_index), "%s/entry[sequence='%lu']",
-		 xpath, sequence);
+	snprintfrr(xpath_index, sizeof(xpath_index), "%s/entry[sequence='%" PRIu64 "']", xpath,
+		   sequence);
 	nb_cli_enqueue_change(vty, xpath_index, NB_OP_CREATE, NULL);
 
 	snprintf(xpath_action, sizeof(xpath_action), "%s/action", xpath_index);
@@ -78,9 +78,9 @@ DEFPY_YANG(
 {
 	char xpath[XPATH_MAXLEN];
 
-	snprintf(xpath, sizeof(xpath),
-		 "/frr-route-map:lib/route-map[name='%s']/entry[sequence='%lu']",
-		 name, sequence);
+	snprintfrr(xpath, sizeof(xpath),
+		   "/frr-route-map:lib/route-map[name='%s']/entry[sequence='%" PRIu64 "']", name,
+		   sequence);
 
 	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 
@@ -572,7 +572,7 @@ DEFPY_YANG(
 	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
 	snprintf(xpath_value, sizeof(xpath_value),
 		 "%s/rmap-match-condition/tag", xpath);
-	snprintf(value, sizeof(value), "%lu", tagged ? tagged : 0);
+	snprintfrr(value, sizeof(value), "%" PRIu64, tagged ? tagged : 0);
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, value);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -1140,7 +1140,7 @@ DEFPY_YANG(
 	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
 	snprintf(xpath_value, sizeof(xpath_value), "%s/rmap-set-action/tag",
 		 xpath);
-	snprintf(value, sizeof(value), "%lu", tagged ? tagged : 0);
+	snprintfrr(value, sizeof(value), "%" PRIu64, tagged ? tagged : 0);
 	nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, value);
 
 	return nb_cli_apply_changes(vty, NULL);

--- a/python/clidef.py
+++ b/python/clidef.py
@@ -40,13 +40,13 @@ class StringHandler(RenderHandler):
     canassert = True
 
 
-class LongHandler(RenderHandler):
-    argtype = "long"
-    decl = Template("long $varname = 0;")
+class Int64Handler(RenderHandler):
+    argtype = "int64_t"
+    decl = Template("int64_t $varname = 0;")
     code = Template(
         """\
 char *_end;
-$varname = strtol(argv[_i]->arg, &_end, 10);
+$varname = strtoll(argv[_i]->arg, &_end, 10);
 _fail = (_end == argv[_i]->arg) || (*_end != '\\0');"""
     )
 
@@ -151,7 +151,7 @@ def mix_handlers(handlers):
 handlers = {
     "WORD_TKN": StringHandler,
     "VARIABLE_TKN": StringHandler,
-    "RANGE_TKN": LongHandler,
+    "RANGE_TKN": Int64Handler,
     "IPV4_TKN": IP4Handler,
     "IPV4_PREFIX_TKN": Prefix4Handler,
     "IPV6_TKN": IP6Handler,

--- a/vrrpd/vrrp_vty.c
+++ b/vrrpd/vrrp_vty.c
@@ -30,7 +30,7 @@
 #define VRRP_IP_STR "Virtual Router IP address\n"
 #define VRRP_VERSION_STR "VRRP protocol version\n"
 
-#define VRRP_XPATH_ENTRY VRRP_XPATH "[virtual-router-id='%ld']"
+#define VRRP_XPATH_ENTRY VRRP_XPATH "[virtual-router-id='%" PRId64 "']"
 
 /* clang-format off */
 
@@ -48,7 +48,7 @@ DEFPY_YANG(vrrp_vrid,
 {
 	char valbuf[20];
 
-	snprintf(valbuf, sizeof(valbuf), "%ld", version ? version : vd.version);
+	snprintfrr(valbuf, sizeof(valbuf), "%" PRId64, version ? version : vd.version);
 
 	if (no)
 		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
@@ -152,7 +152,7 @@ DEFPY_YANG(vrrp_advertisement_interval,
 
 	/* all internal computations are in centiseconds */
 	advertisement_interval /= CS2MS;
-	snprintf(val, sizeof(val), "%ld", advertisement_interval);
+	snprintfrr(val, sizeof(val),  "%" PRId64, advertisement_interval);
 	nb_cli_enqueue_change(vty, "./advertisement-interval", NB_OP_MODIFY,
 			      val);
 

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -240,7 +240,8 @@ DEFPY(mpls_label_dynamic_block, mpls_label_dynamic_block_cmd,
 	}
 	if (start > end) {
 		vty_out(vty,
-			"%% label dynamic-block, wrong range (%ld > %ld), aborting\n",
+			"%% label dynamic-block, wrong range ( %" PRId64 " >  %" PRId64
+			"), aborting\n",
 			start, end);
 		return CMD_WARNING_CONFIG_FAILED;
 	}

--- a/zebra/zebra_cli.c
+++ b/zebra/zebra_cli.c
@@ -1318,9 +1318,9 @@ DEFPY_YANG (ipv6_nd_ra_interval,
 
 	if (!no) {
 		if (sec)
-			snprintf(value, sizeof(value), "%lu", sec * 1000);
+			snprintfrr(value, sizeof(value), "%" PRIu64, sec * 1000);
 		else
-			snprintf(value, sizeof(value), "%lu", msec);
+			snprintfrr(value, sizeof(value), "%" PRIu64, msec);
 
 		nb_cli_enqueue_change(vty,
 				      "./frr-zebra:zebra/ipv6-router-advertisements/max-rtr-adv-interval",
@@ -2463,7 +2463,8 @@ DEFPY_YANG (vni_mapping,
 	} else {
 		if (vty->node == CONFIG_NODE) {
 			if (yang_dnode_existsf(vty->candidate_config->dnode,
-					       "/frr-vrf:lib/vrf[name='%s']/frr-zebra:zebra[l3vni-id='%lu']",
+					       "/frr-vrf:lib/vrf[name='%s']/frr-zebra:zebra[l3vni-id='%" PRIu64
+					       "']",
 					       VRF_DEFAULT_NAME, vni))
 				nb_cli_enqueue_change(vty, "./frr-zebra:zebra/l3vni-id",
 						      NB_OP_DESTROY, NULL);
@@ -2473,7 +2474,8 @@ DEFPY_YANG (vni_mapping,
 				vrf = yang_dnode_get_string(dnode, "name");
 
 				if (yang_dnode_existsf(vty->candidate_config->dnode,
-						       "/frr-vrf:lib/vrf[name='%s']/frr-zebra:zebra[l3vni-id='%lu']",
+						       "/frr-vrf:lib/vrf[name='%s']/frr-zebra:zebra[l3vni-id='%" PRIu64
+						       "']",
 						       vrf, vni))
 					nb_cli_enqueue_change(vty, "./frr-zebra:zebra/l3vni-id",
 							      NB_OP_DESTROY, NULL);

--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -943,7 +943,8 @@ DEFPY (locator_prefix,
 
 	if (prefix->prefixlen + func_bit_len + 0 > 128) {
 		vty_out(vty,
-			"%% prefix-len + function-len + arg-len (%ld) cannot be greater than 128\n",
+			"%% prefix-len + function-len + arg-len (%" PRId64
+			") cannot be greater than 128\n",
 			prefix->prefixlen + func_bit_len + 0);
 		return CMD_WARNING_CONFIG_FAILED;
 	}

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3657,12 +3657,14 @@ DEFPY (ip_zebra_import_table_distance,
 		distance = ZEBRA_TABLE_DISTANCE_DEFAULT;
 
 	if (!is_zebra_valid_kernel_table(table_id)) {
-		vty_out(vty, "Invalid routing table ID, %ld. Must be in range 1-252\n", table_id);
+		vty_out(vty, "Invalid routing table ID, %" PRId64 ". Must be in range 1-252\n",
+			table_id);
 		return CMD_WARNING;
 	}
 
 	if (is_zebra_main_routing_table(table_id)) {
-		vty_out(vty, "Invalid routing table ID, %ld. Must be non-default table\n", table_id);
+		vty_out(vty, "Invalid routing table ID, %" PRId64 ". Must be non-default table\n",
+			table_id);
 		return CMD_WARNING;
 	}
 
@@ -3747,7 +3749,8 @@ DEFPY (no_ip_zebra_import_table,
 	}
 
 	if (is_zebra_main_routing_table(table_id)) {
-		vty_out(vty, "Invalid routing table ID, %ld. Must be non-default table\n", table_id);
+		vty_out(vty, "Invalid routing table ID, %" PRId64 ". Must be non-default table\n",
+			table_id);
 		return CMD_WARNING;
 	}
 


### PR DESCRIPTION
The original problem came with a DEFPY command that uses RANGE token with a big value. To illustrate, tha passed argument is not the expected one on i386 platforms.

> # config:
> router bgp 65003 vrf Vrf20
>  bgp router-id 192.0.2.3
>  sid vpn per-vrf export 4294442578
> # show running-config
> router bgp 65003 vrf Vrf20
>  bgp router-id 192.0.2.3
>  sid vpn per-vrf export 2147483647

The 'long' size on an i386 platform is 32 bits, which differs from most of other platforms (64 bits). Propose to change RANGE to `int64_t` type. Add the necessary casting on places where RANGE is used and where internal attribute type differs from passed argument.