### PR TITLE
lib: move `clear log cmdline-targets` to YANG RPC

### DIFF
--- a/lib/log_cli.c
+++ b/lib/log_cli.c
@@ -345,6 +345,21 @@ DEFPY_YANG (log_immediate_mode,
 	return nb_cli_apply_changes(vty, NULL);
 }
 
+
+DEFPY_YANG (clear_log_cmdline,
+	    clear_log_cmdline_cmd,
+	    "clear log cmdline-targets",
+	    CLEAR_STR
+	    "Logging control\n"
+	    "Disable log targets specified at startup by --log option\n")
+{
+	/* run local in mgmtd, as it doesn't handle RPCs yet */
+	if (vty_mgmt_fe_enabled())
+		clear_cmdline_targets();
+
+	return nb_cli_rpc(vty, "/frr-logging:clear-cmdline-targets", NULL);
+}
+
 void log_cli_init(void)
 {
 	install_element(CONFIG_NODE, &config_log_stdout_cmd);
@@ -370,6 +385,8 @@ void log_cli_init(void)
 	install_element(CONFIG_NODE, &log_immediate_mode_cmd);
 
 	install_element(CONFIG_NODE, &debug_uid_backtrace_cmd);
+
+	install_element(ENABLE_NODE, &clear_log_cmdline_cmd);
 }
 
 

--- a/lib/log_nb.c
+++ b/lib/log_nb.c
@@ -658,10 +658,27 @@ static int logging_uid_backtrace_destroy(struct nb_cb_destroy_args *args)
 	return NB_OK;
 }
 
+
+/*
+ * XPath: /frr-logging:logging/clear-cmdline-targets
+ */
+static int clear_cmdline_targets_rpc(struct nb_cb_rpc_args *args)
+{
+	clear_cmdline_targets();
+	return NB_OK;
+}
+
+
 /* clang-format off */
 struct frr_yang_module_info frr_logging_nb_info = {
 	.name = "frr-logging",
 	.nodes = {
+		{
+			.xpath = "/frr-logging:clear-cmdline-targets",
+			.cbs = {
+				.rpc = clear_cmdline_targets_rpc,
+			}
+		},
 		{
 			.xpath = "/frr-logging:logging/stdout",
 			.cbs = {

--- a/lib/log_vty.h
+++ b/lib/log_vty.h
@@ -47,6 +47,7 @@ extern struct zlog_cfg_5424 zt_stdout_journald;
 extern bool stdout_journald_in_use;
 
 void log_stdout_apply_level(void);
+void clear_cmdline_targets(void);
 
 extern struct frr_yang_module_info frr_logging_cli_info;
 

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -84,6 +84,11 @@ static const char *const zebra_oper_xpaths[] = {
 	NULL,
 };
 
+static const char *const zebra_rpc_xpaths[] = {
+	"/frr-logging",
+	NULL,
+};
+
 #ifdef HAVE_MGMTD_TESTC
 static const char *const mgmtd_testc_oper_xpaths[] = {
 	"/frr-backend:clients",
@@ -111,6 +116,7 @@ static const char *const ripd_oper_xpaths[] = {
 };
 static const char *const ripd_rpc_xpaths[] = {
 	"/frr-ripd",
+	"/frr-logging",
 	NULL,
 };
 #endif
@@ -133,6 +139,7 @@ static const char *const ripngd_oper_xpaths[] = {
 };
 static const char *const ripngd_rpc_xpaths[] = {
 	"/frr-ripngd",
+	"/frr-logging",
 	NULL,
 };
 #endif
@@ -146,9 +153,12 @@ static const char *const staticd_config_xpaths[] = {
 	"/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd",
 	NULL,
 };
-
 static const char *const staticd_oper_xpaths[] = {
 	"/frr-backend:clients",
+	NULL,
+};
+static const char *const staticd_rpc_xpaths[] = {
+	"/frr-logging",
 	NULL,
 };
 #endif
@@ -193,6 +203,10 @@ static const char *const *be_client_rpc_xpaths[MGMTD_BE_CLIENT_ID_MAX] = {
 #ifdef HAVE_RIPNGD
 	[MGMTD_BE_CLIENT_ID_RIPNGD] = ripngd_rpc_xpaths,
 #endif
+#ifdef HAVE_STATICD
+	[MGMTD_BE_CLIENT_ID_STATICD] = staticd_rpc_xpaths,
+#endif
+	[MGMTD_BE_CLIENT_ID_ZEBRA] = zebra_rpc_xpaths,
 };
 
 /*

--- a/yang/frr-logging.yang
+++ b/yang/frr-logging.yang
@@ -194,4 +194,8 @@ module frr-logging {
       }
     }
   }
+  rpc clear-cmdline-targets {
+    description
+      "Clear command line logging targets.";
+  }
 }


### PR DESCRIPTION
This was being handled by vty to each daemon, but the correct way this should be handled now is with YANG RPCs, so move to that.