### PR TITLE
mgmtd: add be client loopback connection

### DIFF
--- a/lib/log_cli.c
+++ b/lib/log_cli.c
@@ -353,10 +353,6 @@ DEFPY_YANG (clear_log_cmdline,
 	    "Logging control\n"
 	    "Disable log targets specified at startup by --log option\n")
 {
-	/* run local in mgmtd, as it doesn't handle RPCs yet */
-	if (vty_mgmt_fe_enabled())
-		clear_cmdline_targets();
-
 	return nb_cli_rpc(vty, "/frr-logging:clear-cmdline-targets", NULL);
 }
 

--- a/mgmtd/mgmt.c
+++ b/mgmtd/mgmt.c
@@ -30,6 +30,8 @@ static struct mgmt_master mgmt_master;
 /* MGMTD process wide configuration pointer to export.  */
 struct mgmt_master *mm;
 
+struct mgmt_be_client *mgmt_be_client;
+
 void mgmt_master_init(struct event_loop *master, const int buffer_size)
 {
 	memset(&mgmt_master, 0, sizeof(struct mgmt_master));
@@ -82,10 +84,13 @@ void mgmt_init(void)
 	 * on the above 2 events to run prior to any `accept` event from here.
 	 */
 	mgmt_be_adapter_init(mm->master);
+
+	mgmt_be_client = mgmt_be_client_create("mgmtd", NULL, 0, mm->master);
 }
 
 void mgmt_terminate(void)
 {
+	mgmt_be_client_destroy(mgmt_be_client);
 	mgmt_fe_adapter_destroy();
 	mgmt_be_adapter_destroy();
 	mgmt_txn_destroy();

--- a/mgmtd/mgmt_be_adapter.c
+++ b/mgmtd/mgmt_be_adapter.c
@@ -33,6 +33,7 @@
 
 const char *mgmt_be_client_names[MGMTD_BE_CLIENT_ID_MAX + 1] = {
 	[MGMTD_BE_CLIENT_ID_TESTC] = "mgmtd-testc", /* always first */
+	[MGMTD_BE_CLIENT_ID_MGMTD] = "mgmtd",	    /* loopback */
 	[MGMTD_BE_CLIENT_ID_ZEBRA] = "zebra",
 #ifdef HAVE_RIPD
 	[MGMTD_BE_CLIENT_ID_RIPD] = "ripd",
@@ -88,6 +89,22 @@ static const char *const zebra_rpc_xpaths[] = {
 	"/frr-logging",
 	NULL,
 };
+
+/*
+ * MGMTD does not use config paths. Config is handled specially since it's own
+ * tree is modified directly when processing changes from the front end clients
+ */
+
+static const char *const mgmtd_oper_xpaths[] = {
+	"/frr-backend:clients",
+	NULL,
+};
+
+static const char *const mgmtd_rpc_xpaths[] = {
+	"/frr-logging",
+	NULL,
+};
+
 
 #ifdef HAVE_MGMTD_TESTC
 static const char *const mgmtd_testc_oper_xpaths[] = {
@@ -178,6 +195,7 @@ static const char *const *be_client_config_xpaths[MGMTD_BE_CLIENT_ID_MAX] = {
 };
 
 static const char *const *be_client_oper_xpaths[MGMTD_BE_CLIENT_ID_MAX] = {
+	[MGMTD_BE_CLIENT_ID_MGMTD] = mgmtd_oper_xpaths,
 #ifdef HAVE_MGMTD_TESTC
 	[MGMTD_BE_CLIENT_ID_TESTC] = mgmtd_testc_oper_xpaths,
 #endif
@@ -197,6 +215,7 @@ static const char *const *be_client_notif_xpaths[MGMTD_BE_CLIENT_ID_MAX] = {
 };
 
 static const char *const *be_client_rpc_xpaths[MGMTD_BE_CLIENT_ID_MAX] = {
+	[MGMTD_BE_CLIENT_ID_MGMTD] = mgmtd_rpc_xpaths,
 #ifdef HAVE_RIPD
 	[MGMTD_BE_CLIENT_ID_RIPD] = ripd_rpc_xpaths,
 #endif

--- a/mgmtd/mgmt_be_adapter.h
+++ b/mgmtd/mgmt_be_adapter.h
@@ -28,6 +28,7 @@
  */
 enum mgmt_be_client_id {
 	MGMTD_BE_CLIENT_ID_TESTC, /* always first */
+	MGMTD_BE_CLIENT_ID_MGMTD, /* loopback */
 	MGMTD_BE_CLIENT_ID_ZEBRA,
 #ifdef HAVE_RIPD
 	MGMTD_BE_CLIENT_ID_RIPD,

--- a/mgmtd/mgmt_main.c
+++ b/mgmtd/mgmt_main.c
@@ -161,12 +161,6 @@ const struct frr_yang_module_info ietf_netconf_with_defaults_info = {
  * clients into mgmtd. The modules are used by libyang in order to support
  * parsing binary data returns from the backend.
  */
-const struct frr_yang_module_info frr_backend_client_info = {
-	.name = "frr-backend",
-	.ignore_cfg_cbs = true,
-	.nodes = { { .xpath = NULL } },
-};
-
 const struct frr_yang_module_info zebra_route_map_info = {
 	.name = "frr-zebra-route-map",
 	.ignore_cfg_cbs = true,
@@ -178,6 +172,7 @@ const struct frr_yang_module_info zebra_route_map_info = {
  * MGMTd.
  */
 static const struct frr_yang_module_info *const mgmt_yang_modules[] = {
+	&frr_backend_info,
 	&frr_filter_cli_info,
 	&frr_host_cli_info,
 	&frr_interface_cli_info,
@@ -193,7 +188,6 @@ static const struct frr_yang_module_info *const mgmt_yang_modules[] = {
 	/*
 	 * YANG module info used by backend clients get added here.
 	 */
-	&frr_backend_client_info,
 
 	&frr_zebra_cli_info,
 	&zebra_route_map_info,


### PR DESCRIPTION
While we need to special case configuration handling (b/c the user changes from the front end actually occur in mgmtd prior to sending to backends), we do not need to special case handling of oper state and RPCs, so create a mgmtd loopback connection to handle oper-state and RPCs.