### PR TITLE
Implement detailed metric matching for route-maps [DRAFT]

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2137,6 +2137,43 @@ static const struct route_map_rule_cmd route_match_tag_cmd = {
 	route_map_rule_tag_free,
 };
 
+/* `match metric <proto> [range METRIC] METRIC' */
+/* Match function return 1 if match is success else return zero. */
+static enum route_map_cmd_result_t
+route_match_metric_detail(void *rule, const struct prefix *prefix, void *object)
+{
+	struct route_map_metric_compiled *mc;
+	struct bgp_path_info *bp;
+
+	mc = rule;
+	bp = object;
+
+	/* Route type */
+	if (mc->proto != bp->type)
+		return RMAP_NOMATCH;
+	/* What does external metric mean here? Strictly OSPF external metric types? */
+	if (mc->external && bp->type != ZEBRA_ROUTE_OSPF)
+		return RMAP_NOMATCH;
+	/* Metric (optional range) */
+	if (!CHECK_FLAG(bp->attr->flag, ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC))) {
+		return RMAP_NOMATCH;
+	} else if (mc->range && (mc->min_metric > bp->attr->med || mc->max_metric < bp->attr->med)) {
+		return RMAP_NOMATCH;
+	} else if (mc->metric != bp->attr->med) {
+		return RMAP_NOMATCH;
+	}
+
+	return RMAP_MATCH;
+}
+
+/* Route map commands for metric detail matching. */
+static const struct route_map_rule_cmd route_match_metric_detail_cmd = {
+	"metric detail",
+	route_match_metric_detail,
+	route_map_rule_metric_detail_compile,
+	route_map_rule_metric_detail_free,
+};
+
 static enum route_map_cmd_result_t
 route_set_srte_color(void *rule, const struct prefix *prefix, void *object)
 {
@@ -8052,6 +8089,9 @@ void bgp_route_map_init(void)
 	route_map_match_metric_hook(generic_match_add);
 	route_map_no_match_metric_hook(generic_match_delete);
 
+	route_map_match_metric_detail_hook(generic_match_add);
+	route_map_no_match_metric_detail_hook(generic_match_delete);
+
 	route_map_match_tag_hook(generic_match_add);
 	route_map_no_match_tag_hook(generic_match_delete);
 
@@ -8091,6 +8131,7 @@ void bgp_route_map_init(void)
 	route_map_install_match(&route_match_ecommunity_cmd);
 	route_map_install_match(&route_match_local_pref_cmd);
 	route_map_install_match(&route_match_metric_cmd);
+	route_map_install_match(&route_match_metric_detail_cmd);
 	route_map_install_match(&route_match_origin_cmd);
 	route_map_install_match(&route_match_probability_cmd);
 	route_map_install_match(&route_match_interface_cmd);

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -20,6 +20,7 @@
 #include "table.h"
 #include "json.h"
 #include "jhash.h"
+#include "frrstr.h"
 
 #include "lib/routemap_clippy.c"
 
@@ -302,6 +303,24 @@ void route_map_no_match_metric_hook(int (*func)(
 	char *errmsg, size_t errmsg_len))
 {
 	rmap_match_set_hook.no_match_metric = func;
+}
+
+/* match metric <proto> ... */
+void route_map_match_metric_detail_hook(int (*func)(
+	struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type,
+	char *errmsg, size_t errmsg_len))
+{
+	rmap_match_set_hook.match_metric_detail = func;
+}
+
+/* no match metric <proto> ... */
+void route_map_no_match_metric_detail_hook(int (*func)(
+	struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type,
+	char *errmsg, size_t errmsg_len))
+{
+	rmap_match_set_hook.no_match_metric_detail = func;
 }
 
 /* match tag */
@@ -3287,6 +3306,56 @@ void *route_map_rule_tag_compile(const char *arg)
 }
 
 void route_map_rule_tag_free(void *rule)
+{
+	XFREE(MTYPE_ROUTE_MAP_COMPILED, rule);
+}
+
+void *route_map_rule_metric_detail_compile(const char *argstr)
+{
+	struct route_map_metric_compiled *mc = NULL;
+	uint8_t proto;
+	uint32_t metric = 0, min_metric = 0, max_metric = 0;
+	bool external = false, range = false;
+
+	int num_args;
+	char **args;
+
+	frrstr_split(argstr, " ", &args, &num_args);
+	/* arg format: <proto> [range <metric>] <metric> [external] */
+	if (num_args >= 2 && num_args <= 5)
+	{
+		proto = strtoul(args[0], NULL, 10);
+		if (strstr(argstr, "external") != NULL) {
+			external = true;
+		}
+		if (strstr(argstr, "range") != NULL) {
+			range = true;
+			min_metric = strtoul(args[2], NULL, 10);
+			max_metric = strtoul(args[3], NULL, 10);
+		} else {
+			metric = strtoul(args[1], NULL, 10);
+		}
+		if (min_metric <= max_metric)
+		{
+			// Also validate metric based on proto?
+			mc = XMALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(struct route_map_metric_compiled));
+			mc->proto = proto;
+			mc->metric = metric;
+			mc->min_metric = min_metric;
+			mc->max_metric = max_metric;
+			mc->external = external;
+			mc->range = range;
+		}
+	}
+
+	for (int i = 0; i < num_args; i++)
+		XFREE(MTYPE_TMP, args[i]);
+	XFREE(MTYPE_TMP, args);
+
+	return mc;
+}
+
+void route_map_rule_metric_detail_free(void *rule)
 {
 	XFREE(MTYPE_ROUTE_MAP_COMPILED, rule);
 }

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -262,6 +262,8 @@ DECLARE_QOBJ_TYPE(route_map);
 	(strmatch(C, "frr-route-map:ipv6-next-hop-type"))
 #define IS_MATCH_METRIC(C)                                                     \
 	(strmatch(C, "frr-route-map:match-metric"))
+#define IS_MATCH_METRIC_DETAIL(C)                                              \
+	(strmatch(C, "frr-route-map:match-metric-detail"))
 #define IS_MATCH_TAG(C) (strmatch(C, "frr-route-map:match-tag"))
 /* Zebra route-map match conditions */
 #define IS_MATCH_IPv4_PREFIX_LEN(C)                                            \
@@ -429,6 +431,17 @@ enum ecommunity_lb_type {
 	EXPLICIT_BANDWIDTH,
 	CUMULATIVE_BANDWIDTH,
 	COMPUTED_BANDWIDTH
+};
+
+struct route_map_metric_compiled {
+	/* Route type */
+	uint8_t proto;
+	uint32_t metric;
+	uint32_t min_metric;
+	uint32_t max_metric;
+	/* External metric */
+	bool external;
+	bool range;
 };
 
 /* Prototypes. */
@@ -677,6 +690,20 @@ extern void route_map_no_match_metric_hook(int (*func)(
 	struct route_map_index *index, const char *command,
 	const char *arg, route_map_event_t type,
 	char *errmsg, size_t errmsg_len));
+/* match metric detail */
+extern void route_map_match_metric_detail_hook(int (*func)(
+	struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type,
+	char *errmsg, size_t errmsg_len));
+/* no match metric detail */
+extern void route_map_no_match_metric_detail_hook(int (*func)(
+	struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type,
+	char *errmsg, size_t errmsg_len));
+
+extern void *route_map_rule_metric_detail_compile(const char *arg);
+extern void route_map_rule_metric_detail_free(void *rule);
+
 /* match tag */
 extern void route_map_match_tag_hook(int (*func)(
 	struct route_map_index *index, const char *command,
@@ -925,6 +952,18 @@ struct route_map_match_set_hooks {
 
 	/* no match metric */
 	int (*no_match_metric)(struct route_map_index *index,
+			       const char *command, const char *arg,
+			       route_map_event_t type,
+			       char *errmsg, size_t errmsg_len);
+
+	/* match metric detail */
+	int (*match_metric_detail)(struct route_map_index *index,
+			    const char *command, const char *arg,
+			    route_map_event_t type,
+			    char *errmsg, size_t errmsg_len);
+
+	/* no match metric detail */
+	int (*no_match_metric_detail)(struct route_map_index *index,
 			       const char *command, const char *arg,
 			       route_map_event_t type,
 			       char *errmsg, size_t errmsg_len);

--- a/lib/routemap_cli.c
+++ b/lib/routemap_cli.c
@@ -556,6 +556,59 @@ DEFPY_YANG(
 	return nb_cli_apply_changes(vty, NULL);
 }
 
+DEFPY_YANG(match_metric_detail,
+	match_metric_detail_cmd,
+	"[no] match metric <isis|ospf|rip>$proto [external$external] [range$range (0-4294967295)$metric_min] (0-4294967295)$metric",
+	NO_STR
+	MATCH_STR
+	"Match metric of route\n"
+	"Match IS-IS metric\n"
+	"Match OSPF metric\n"
+	"Match RIP metric\n"
+	"Match external metric\n"
+	"Match a metric range\n"
+	"Minimum metric value\n"
+	"Specific or maximum metric value\n")
+{
+	const char *xpath =
+		"./match-condition[condition='frr-route-map:match-metric-detail']";
+	char xpath_value[XPATH_MAXLEN];
+
+	if (no) {
+		nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+	} else {
+
+		nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+
+		snprintf(xpath_value, sizeof(xpath_value),
+			"%s/rmap-match-condition/metric-detail/range", xpath);
+		nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, (range ? "true" : "false"));
+
+		if (range) {
+			snprintf(xpath_value, sizeof(xpath_value),
+				"%s/rmap-match-condition/metric-detail/metric-min", xpath);
+			nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, metric_min_str);
+
+			snprintf(xpath_value, sizeof(xpath_value),
+				"%s/rmap-match-condition/metric-detail/metric-max", xpath);
+		} else {
+			snprintf(xpath_value, sizeof(xpath_value),
+				"%s/rmap-match-condition/metric-detail/metric", xpath);
+		}
+		nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, metric_str);
+
+		snprintf(xpath_value, sizeof(xpath_value),
+			"%s/rmap-match-condition/metric-detail/external", xpath);
+		nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, (external ? "true" : "false"));
+
+		snprintf(xpath_value, sizeof(xpath_value),
+			"%s/rmap-match-condition/metric-detail/protocol", xpath);
+		nb_cli_enqueue_change(vty, xpath_value, NB_OP_MODIFY, proto);
+	}
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
 DEFPY_YANG(
 	match_tag, match_tag_cmd,
 	"match tag <untagged$untagged|(1-4294967295)$tagged>",
@@ -652,6 +705,32 @@ void route_map_condition_show(struct vty *vty, const struct lyd_node *dnode,
 		vty_out(vty, " match metric %s\n",
 			yang_dnode_get_string(dnode,
 					      "./rmap-match-condition/metric"));
+	} else if (IS_MATCH_METRIC_DETAIL(condition)) {
+		vty_out(vty, " match metric");
+		vty_out(vty, " %s",
+			yang_dnode_get_string(
+				dnode,
+				"./rmap-match-condition/metric-detail/protocol"));
+		if (yang_dnode_get_bool(
+			    dnode,
+			    "./rmap-match-condition/metric-detail/external"))
+			vty_out(vty, " external");
+		if (yang_dnode_get_bool(
+			dnode,
+			    "./rmap-match-condition/metric-detail/range")) {
+			vty_out(vty, " range %s %s\n",
+				yang_dnode_get_string(
+					dnode,
+					"./rmap-match-condition/metric-detail/metric-min"),
+				yang_dnode_get_string(
+					dnode,
+					"./rmap-match-condition/metric-detail/metric-max"));
+		} else {
+			vty_out(vty, " %s\n",
+				yang_dnode_get_string(
+					dnode,
+					"./rmap-match-condition/metric-detail/metric"));
+		}
 	} else if (IS_MATCH_TAG(condition)) {
 		uint32_t tag =
 			strtoul(yang_dnode_get_string(dnode,
@@ -1809,6 +1888,7 @@ void route_map_cli_init(void)
 
 	install_element(RMAP_NODE, &match_metric_cmd);
 	install_element(RMAP_NODE, &no_match_metric_cmd);
+	install_element(RMAP_NODE, &match_metric_detail_cmd);
 
 	install_element(RMAP_NODE, &match_tag_cmd);
 	install_element(RMAP_NODE, &no_match_tag_cmd);

--- a/lib/routemap_northbound.c
+++ b/lib/routemap_northbound.c
@@ -796,6 +796,136 @@ static int lib_route_map_entry_match_condition_metric_destroy(
 	return lib_route_map_entry_match_destroy(args);
 }
 
+
+/*
+ * XPath: /frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/metric-detail
+ */
+static int lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_create(struct nb_cb_create_args *args)
+{
+	return NB_OK;
+}
+
+static int lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_destroy(struct nb_cb_destroy_args *args)
+{
+	return lib_route_map_entry_match_destroy(args);
+}
+
+static void lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_apply_finish(struct nb_cb_apply_finish_args *args)
+{
+	struct routemap_hook_context *rhc;
+	char argstr[VTY_BUFSIZ];
+	uint8_t proto;
+	uint32_t metric, metric_min, metric_max;
+	int rv;
+
+	/* Add configuration. */
+	rhc = nb_running_get_entry(args->dnode, NULL, true);
+	proto = yang_dnode_get_enum(args->dnode, "protocol");
+
+	/* Set destroy information. */
+	rhc->rhc_mhook = generic_match_delete;
+	rhc->rhc_rule = "metric detail";
+	rhc->rhc_event = RMAP_EVENT_MATCH_DELETED;
+
+	if (yang_dnode_get_bool(args->dnode, "range")) {
+		metric_min = yang_dnode_get_uint32(args->dnode, "metric-min");
+		metric_max = yang_dnode_get_uint32(args->dnode, "metric-max");
+		/* Format: <proto> range <metric_min> <metric_max> [external] */
+		snprintf(argstr, sizeof(argstr), "%u range %u %u", proto, metric_min, metric_max);
+	} else {
+		metric = yang_dnode_get_uint32(args->dnode, "metric");
+		/* Format: <proto> <metric> [external] */
+		snprintf(argstr, sizeof(argstr), "%u %u", proto, metric);
+	}
+
+	if (yang_dnode_get_bool(args->dnode, "external"))
+		strlcat(argstr, " external", sizeof(argstr));
+
+	rv = generic_match_add(rhc->rhc_rmi, "metric detail", argstr, RMAP_EVENT_MATCH_ADDED,
+			      args->errmsg, args->errmsg_len);
+
+	assert(rv == RMAP_COMPILE_SUCCESS);
+}
+
+/*
+ * XPath: /frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/metric-detail/metric
+ */
+static int lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_metric_modify(struct nb_cb_modify_args *args)
+{
+	return NB_OK;
+}
+
+static int lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_metric_destroy(struct nb_cb_destroy_args *args)
+{
+	return lib_route_map_entry_match_destroy(args);
+}
+
+/*
+ * XPath: /frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/metric-detail/metric-min
+ */
+static int lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_metric_min_modify(struct nb_cb_modify_args *args)
+{
+	return NB_OK;
+}
+
+static int lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_metric_min_destroy(struct nb_cb_destroy_args *args)
+{
+	return lib_route_map_entry_match_destroy(args);
+}
+
+/*
+ * XPath: /frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/metric-detail/metric-max
+ */
+static int lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_metric_max_modify(struct nb_cb_modify_args *args)
+{
+	return NB_OK;
+}
+
+static int lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_metric_max_destroy(struct nb_cb_destroy_args *args)
+{
+	return lib_route_map_entry_match_destroy(args);
+}
+
+
+/*
+ * XPath: /frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/metric-detail/protocol
+ */
+static int lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_protocol_modify(struct nb_cb_modify_args *args)
+{
+	return NB_OK;
+}
+
+static int lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_protocol_destroy(struct nb_cb_destroy_args *args)
+{
+	return lib_route_map_entry_match_destroy(args);
+}
+
+/*
+ * XPath: /frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/metric-detail/external
+ */
+static int lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_external_modify(struct nb_cb_modify_args *args)
+{
+	return NB_OK;
+}
+
+static int lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_external_destroy(struct nb_cb_destroy_args *args)
+{
+	return lib_route_map_entry_match_destroy(args);
+}
+
+/*
+ * XPath: /frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/metric-detail/range
+ */
+static int lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_range_modify(struct nb_cb_modify_args *args)
+{
+	return NB_OK;
+}
+
+static int lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_range_destroy(struct nb_cb_destroy_args *args)
+{
+	return lib_route_map_entry_match_destroy(args);
+}
+
 /*
  * XPath: /frr-route-map:lib/route-map/entry/match-condition/tag
  */
@@ -1471,6 +1601,56 @@ const struct frr_yang_module_info frr_route_map_info = {
 			.cbs = {
 				.modify = lib_route_map_entry_match_condition_metric_modify,
 				.destroy = lib_route_map_entry_match_condition_metric_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/metric-detail",
+			.cbs = {
+				.create = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_create,
+				.destroy = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_destroy,
+				.apply_finish = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_apply_finish,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/metric-detail/metric",
+			.cbs = {
+				.modify = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_metric_modify,
+				.destroy = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_metric_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/metric-detail/metric-min",
+			.cbs = {
+				.modify = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_metric_min_modify,
+				.destroy = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_metric_min_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/metric-detail/metric-max",
+			.cbs = {
+				.modify = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_metric_max_modify,
+				.destroy = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_metric_max_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/metric-detail/protocol",
+			.cbs = {
+				.modify = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_protocol_modify,
+				.destroy = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_protocol_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/metric-detail/external",
+			.cbs = {
+				.modify = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_external_modify,
+				.destroy = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_external_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-route-map:lib/route-map/entry/match-condition/rmap-match-condition/metric-detail/range",
+			.cbs = {
+				.modify = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_range_modify,
+				.destroy = lib_route_map_entry_match_condition_rmap_match_condition_metric_detail_range_destroy,
 			}
 		},
 		{

--- a/yang/frr-route-map.yang
+++ b/yang/frr-route-map.yang
@@ -16,6 +16,10 @@ module frr-route-map {
     prefix frr-interface;
   }
 
+  import frr-route-types {
+    prefix frr-route-types;
+  }
+
   organization
     "FRRouting";
   contact
@@ -129,6 +133,12 @@ module frr-route-map {
     base rmap-match-type;
     description
       "Match a route metric";
+  }
+
+  identity match-metric-detail {
+    base frr-route-map:rmap-match-type;
+    description
+      "Match a detailed route metric";
   }
 
   identity match-tag {
@@ -263,6 +273,43 @@ module frr-route-map {
             }
           }
         }
+
+        case match-metric-detail {
+          when "derived-from-or-self(../condition, 'match-metric-detail')";
+          container metric-detail {
+            leaf metric {
+              type uint32 {
+                range "0..4294967295";
+              }
+            }
+            leaf metric-min {
+              type uint32 {
+                range "0..4294967295";
+              }
+            }
+            leaf metric-max {
+              type uint32 {
+                range "0..4294967295";
+              }
+            }
+            leaf protocol {
+              type frr-route-types:frr-route-types;
+              description
+                "Specifies the route protocol";
+            }
+            leaf external {
+              type boolean;
+              description
+                "Match external route metric.";
+            }
+            leaf range {
+              type boolean;
+              description
+                "Match a route metric range.";
+            }
+          }
+        }
+        
 
         case match-tag {
           when "derived-from-or-self(../condition, 'match-tag')";

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -62,6 +62,40 @@ static const struct route_map_rule_cmd route_match_tag_cmd = {
 	route_map_rule_tag_free,
 };
 
+/* `match metric <proto> [range METRIC] METRIC' */
+/* Match function return 1 if match is success else return zero. */
+static enum route_map_cmd_result_t
+route_match_metric_detail(void *rule, const struct prefix *prefix, void *object)
+{
+	struct route_map_metric_compiled *mc;
+	struct zebra_rmap_obj *rm_data;
+
+	mc = rule;
+	rm_data = object;
+
+	/* Route type */
+	if (mc->proto != rm_data->re->type)
+		return RMAP_NOMATCH;
+	/* What does external metric mean here? Strictly OSPF external metric types? */
+	if (mc->external && rm_data->re->type != ZEBRA_ROUTE_OSPF)
+		return RMAP_NOMATCH;
+	/* Metric (optional range) */	
+	if (mc->range && (mc->min_metric > rm_data->re->metric || mc->max_metric < rm_data->re->metric)) {
+		return RMAP_NOMATCH;
+	} else if (mc->metric != rm_data->re->metric) {
+		return RMAP_NOMATCH;
+	}
+
+	return RMAP_MATCH;
+}
+
+/* Route map commands for metric detail matching. */
+static const struct route_map_rule_cmd route_match_metric_detail_cmd = {
+	"metric detail",
+	route_match_metric_detail,
+	route_map_rule_metric_detail_compile,
+	route_map_rule_metric_detail_free,
+};
 
 /* `match interface IFNAME' */
 /* Match function return 1 if match is success else return zero. */
@@ -1386,6 +1420,9 @@ void zebra_route_map_init(void)
 	route_map_match_ipv6_next_hop_type_hook(generic_match_add);
 	route_map_no_match_ipv6_next_hop_type_hook(generic_match_delete);
 
+	route_map_match_metric_detail_hook(generic_match_add);
+	route_map_no_match_metric_detail_hook(generic_match_delete);
+
 	route_map_install_match(&route_match_tag_cmd);
 	route_map_install_match(&route_match_interface_cmd);
 	route_map_install_match(&route_match_ip_next_hop_cmd);
@@ -1401,6 +1438,7 @@ void zebra_route_map_init(void)
 	route_map_install_match(&route_match_ipv6_next_hop_type_cmd);
 	route_map_install_match(&route_match_source_protocol_cmd);
 	route_map_install_match(&route_match_source_instance_cmd);
+	route_map_install_match(&route_match_metric_detail_cmd);
 
 	/* */
 	route_map_install_set(&route_set_src_cmd);


### PR DESCRIPTION
This is an attempt to implement detailed metric matching as requested in https://github.com/FRRouting/frr/issues/18687. The command, northbound, and supporting code were added to the route-map library code so each daemon that may use it can simply implement its own match function.

Enables metric matching based on:
* Protocol (OSPF, IS-IS, RIP)
* Metric ranges
* External metrics?
  * The request was for OSPF E1/E2 external metrics but I'm unsure whether "external metric" has meaning for other route-types/in daemons other than `ospfd` -- `ripd` also specifically has an `external_metric` in its route info

The reason this has been opened as a draft is (beyond general review) for feedback on the above question/comments in code on external metrics.

Other to do:
* Documentation
* Test