### PR TITLE
bgpd: Fix RA not re-initiated when remote-as is re-added to peer group

### DIFF
--- a/tests/topotests/bgp_remote_as_ra_validation/r1/frr.conf
+++ b/tests/topotests/bgp_remote_as_ra_validation/r1/frr.conf
@@ -1,0 +1,23 @@
+!
+int r1-eth0
+ ip address 192.168.1.1/24
+!
+int r1-eth1
+ ip address 192.168.14.1/24
+!
+router bgp 65001
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.1.2 remote-as auto
+ neighbor 192.168.1.2 timers 1 3
+ neighbor 192.168.1.2 timers connect 1
+ neighbor 192.168.1.3 remote-as auto
+ neighbor 192.168.1.3 timers 1 3
+ neighbor 192.168.1.3 timers connect 1
+ neighbor r1-eth1 interface remote-as auto
+ neighbor r1-eth1 timers 1 3
+ neighbor r1-eth1 timers connect 1
+ address-family ipv4 unicast
+  network 10.0.0.1/32
+ exit-address-family
+!

--- a/tests/topotests/bgp_remote_as_ra_validation/test_bgp_remote_as_ra_validation.py
+++ b/tests/topotests/bgp_remote_as_ra_validation/test_bgp_remote_as_ra_validation.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2025 by
+# Rajasekar Raja <rajasekarr@nvidia.com>
+#
+
+import os
+import re
+import sys
+import json
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def setup_module(mod):
+    topodef = {"s1": ("r1",)}
+    tgen = Topogen(topodef, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for _, (rname, router) in enumerate(router_list.items(), 1):
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_peer_group_remote_as_ra_validation():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    # Verify interface configuration shows BGP RA
+    def _check_interface_bgp_ra(expected_value):
+        output = r1.vtysh_cmd("show interface r1-eth0 json", isjson=True)
+        bgpRAConfigured = output["r1-eth0"]["bgpRAConfigured"]
+        return bgpRAConfigured is expected_value
+
+    # Add BGP peer group with remote-as external
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        router bgp 65001
+          neighbor TEST_PG peer-group
+          neighbor TEST_PG remote-as external
+          neighbor r1-eth0 interface peer-group TEST_PG
+        """
+    )
+    test_func = functools.partial(_check_interface_bgp_ra, True)
+    _, result = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert result is True, "Interface r1-eth0 should have BGP RA configured"
+
+    # Remove remote-as external from peer group
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        router bgp 65001
+          no neighbor TEST_PG remote-as external
+        """
+    )
+    test_func = functools.partial(_check_interface_bgp_ra, False)
+    _, result = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert result is True, "Interface r1-eth0 should not have BGP RA configured"
+
+    # Re-add remote-as external to peer group
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        router bgp 65001
+          neighbor TEST_PG remote-as external
+        """
+    )
+    test_func = functools.partial(_check_interface_bgp_ra, True)
+    _, result = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert result is True, "Interface r1-eth0 should have BGP RA configured back"
+
+    # Clean up - remove the peer group configuration
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        router bgp 65001
+          no neighbor r1-eth0 interface peer-group TEST_PG
+          no neighbor TEST_PG peer-group
+        """
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
When a peer group's remote-as configuration is removed and then re-added, BGP unnumbered peers in that group were not getting their Router Advertisement (RA) re-initiated.

The issue was in peer_group_remote_as() function which handles adding remote-as to peer groups. While peer_group_remote_as_delete() properly terminates RA for BGP unnumbered peers, the add function was missing the corresponding RA re-initiation logic.

Fix adds RA re-initiation for all BGP unnumbered peers with extended next-hop capability when remote-as is configured on the peer group.

Ticket :#4597330