### PR TITLE
zebra: Allow for NOS to initialize some zrouter values

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -295,7 +295,7 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 	 * pretend like the route is offloaded so everything
 	 * else will work
 	 */
-	if (zrouter.asic_offloaded)
+	if (zrouter.zav.asic_offloaded)
 		flags |= ZEBRA_FLAG_OFFLOADED;
 
 	/*

--- a/zebra/debug_nl.c
+++ b/zebra/debug_nl.c
@@ -1377,7 +1377,7 @@ next_rta:
 		for (i = 0; i < count; i++) {
 			uint16_t weight;
 
-			if (zrouter.nexthop_weight_is_16bit)
+			if (zrouter.zav.nexthop_weight_is_16bit)
 				weight = nhgrp[i].weight_high << 8 | nhgrp[i].weight;
 			else
 				weight = nhgrp[i].weight;

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1827,6 +1827,13 @@ skip:
 	return 0;
 }
 
+static int fpm_nl_nos_initialize_data(struct zebra_architectural_values *zav)
+{
+	zlog_info("dplane_fpm_nl: NOS Initialize data");
+
+	return 0;
+}
+
 static int fpm_nl_new(struct event_loop *tm)
 {
 	struct zebra_dplane_provider *prov = NULL;
@@ -1859,6 +1866,8 @@ static int fpm_nl_new(struct event_loop *tm)
 static int fpm_nl_init(void)
 {
 	hook_register(frr_late_init, fpm_nl_new);
+	hook_register(nos_initialize_data, fpm_nl_nos_initialize_data);
+
 	return 0;
 }
 

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -417,7 +417,7 @@ int main(int argc, char **argv)
 					MULTIPATH_NUM);
 				return 1;
 			}
-			zrouter.multipath_num = parsed_multipath;
+			zrouter.zav.multipath_num = parsed_multipath;
 			break;
 		}
 		case 'z':
@@ -449,7 +449,7 @@ int main(int argc, char **argv)
 			vrf_configure_backend(VRF_BACKEND_NETNS);
 			break;
 		case OPTION_V6_RR_SEMANTICS:
-			zrouter.v6_rr_semantics = true;
+			zrouter.zav.v6_rr_semantics = true;
 			break;
 		case OPTION_ASIC_OFFLOAD:
 			if (!strcmp(optarg, "notify_on_offload"))

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1601,17 +1601,15 @@ stream_failure:
 bool zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
 			    const unsigned int nexthop_num)
 {
-	if (nexthop_num > zrouter.multipath_num) {
+	if (nexthop_num > zrouter.zav.multipath_num) {
 		char buff[PREFIX2STR_BUFFER];
 
 		if (p)
 			prefix2str(p, buff, sizeof(buff));
 
-		flog_warn(
-			EC_ZEBRA_MORE_NH_THAN_MULTIPATH,
-			"%s: Prefix %s has %d nexthops, but we can only use the first %d",
-			caller, (p ? buff : "(NULL)"), nexthop_num,
-			zrouter.multipath_num);
+		flog_warn(EC_ZEBRA_MORE_NH_THAN_MULTIPATH,
+			  "%s: Prefix %s has %d nexthops, but we can only use the first %d",
+			  caller, (p ? buff : "(NULL)"), nexthop_num, zrouter.zav.multipath_num);
 		return true;
 	}
 
@@ -2431,9 +2429,9 @@ static void zsend_capabilities(struct zserv *client, struct zebra_vrf *zvrf)
 	zclient_create_header(s, ZEBRA_CAPABILITIES, zvrf->vrf->vrf_id);
 	stream_putl(s, vrf_get_backend());
 	stream_putc(s, mpls_enabled);
-	stream_putl(s, zrouter.multipath_num);
+	stream_putl(s, zrouter.zav.multipath_num);
 	stream_putc(s, zebra_mlag_get_role());
-	stream_putc(s, zrouter.v6_with_v4_nexthop);
+	stream_putc(s, zrouter.zav.v6_with_v4_nexthop);
 	stream_putc(s, zrouter.graceful_restart);
 	stream_putw_at(s, 0, stream_get_endp(s));
 	zserv_send_message(client, s);

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -285,7 +285,7 @@ static int netlink_route_info_fill(struct netlink_route_info *ri, int cmd,
 	ri->metric = &re->metric;
 
 	for (ALL_NEXTHOPS(re->nhe->nhg, nexthop)) {
-		if (ri->num_nhs >= zrouter.multipath_num)
+		if (ri->num_nhs >= zrouter.zav.multipath_num)
 			break;
 
 		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))

--- a/zebra/zebra_fpm_protobuf.c
+++ b/zebra/zebra_fpm_protobuf.c
@@ -159,7 +159,7 @@ static Fpm__AddRoute *create_add_route_message(qpb_allocator_t *allocator,
 	 */
 	num_nhs = 0;
 	for (ALL_NEXTHOPS(re->nhe->nhg, nexthop)) {
-		if (num_nhs >= zrouter.multipath_num)
+		if (num_nhs >= zrouter.zav.multipath_num)
 			break;
 
 		if (num_nhs >= array_size(nexthops))

--- a/zebra/zebra_mpls_openbsd.c
+++ b/zebra/zebra_mpls_openbsd.c
@@ -250,7 +250,7 @@ static int kernel_lsp_cmd(struct zebra_dplane_ctx *ctx)
 		if (!nexthop)
 			continue;
 
-		if (nexthop_num >= zrouter.multipath_num)
+		if (nexthop_num >= zrouter.zav.multipath_num)
 			break;
 
 		if (((action == RTM_ADD || action == RTM_CHANGE)

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -1181,7 +1181,7 @@ lib_vrf_zebra_ribs_rib_route_route_entry_nexthop_group_nexthop_weight_get_elem(
  */
 struct yang_data *zebra_max_multipath_get_elem(struct nb_cb_get_elem_args *args)
 {
-	return yang_data_new_uint16(args->xpath, zrouter.multipath_num);
+	return yang_data_new_uint16(args->xpath, zrouter.zav.multipath_num);
 }
 
 /*

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2922,7 +2922,7 @@ static uint32_t nexthop_list_active_update(struct route_node *rn,
 		 * a multipath perspective should not be a data plane
 		 * decision point.
 		 */
-		if (new_active && counter >= zrouter.multipath_num) {
+		if (new_active && counter >= zrouter.zav.multipath_num) {
 			struct nexthop *nh;
 
 			/* Set it and its resolved nexthop as inactive. */

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1871,7 +1871,7 @@ no_nexthops:
 			ctxnhg->nexthop != NULL ? "" : " (empty)");
 
 	/* Set the flag about the dedicated fib list */
-	if (zrouter.asic_notification_nexthop_control) {
+	if (zrouter.zav.asic_notification_nexthop_control) {
 		SET_FLAG(re->status, ROUTE_ENTRY_USE_FIB_NHG);
 		if (ctxnhg->nexthop)
 			copy_nexthops(&(re->fib_ng.nexthop), ctxnhg->nexthop,
@@ -2091,13 +2091,12 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 			 * a second async response to the request.  In this case we know
 			 * that we should just mark it as no longer queued at all.
 			 */
-			if (zrouter.asic_offloaded && status == ZEBRA_DPLANE_REQUEST_FAILURE)
+			if (zrouter.zav.asic_offloaded && status == ZEBRA_DPLANE_REQUEST_FAILURE)
 				UNSET_FLAG(re->status, ROUTE_ENTRY_QUEUED);
 
-			if (!zrouter.asic_offloaded ||
+			if (!zrouter.zav.asic_offloaded ||
 			    (CHECK_FLAG(re->flags, ZEBRA_FLAG_OFFLOADED) ||
-			     CHECK_FLAG(re->flags,
-					ZEBRA_FLAG_OFFLOAD_FAILED))) {
+			     CHECK_FLAG(re->flags, ZEBRA_FLAG_OFFLOAD_FAILED))) {
 				UNSET_FLAG(re->status,
 					   ROUTE_ENTRY_ROUTE_REPLACING);
 				UNSET_FLAG(re->status, ROUTE_ENTRY_QUEUED);
@@ -2450,7 +2449,7 @@ static void rib_process_dplane_notify(struct zebra_dplane_ctx *ctx)
 	/* Various fib transitions: changed nexthops; from installed to
 	 * not-installed; or not-installed to installed.
 	 */
-	if (zrouter.asic_notification_nexthop_control) {
+	if (zrouter.zav.asic_notification_nexthop_control) {
 		if (start_count > 0 && end_count > 0) {
 			if (debug_p)
 				zlog_debug(
@@ -2878,8 +2877,7 @@ static void process_subq_early_route_add(struct zebra_early_route *ere)
 
 	same = first_same;
 
-	if (!ere->startup && (re->flags & ZEBRA_FLAG_SELFROUTE) &&
-	    zrouter.asic_offloaded) {
+	if (!ere->startup && (re->flags & ZEBRA_FLAG_SELFROUTE) && zrouter.zav.asic_offloaded) {
 		struct route_entry *entry;
 
 		if (!same) {

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -7,6 +7,7 @@
 
 #include <pthread.h>
 #include "lib/frratomic.h"
+#include "lib/hook.h"
 
 #include "zebra_router.h"
 #include "zebra_pbr.h"
@@ -25,6 +26,8 @@ DEFINE_MTYPE_STATIC(ZEBRA, ZEBRA_RT_TABLE, "Zebra VRF table");
 struct zebra_router zrouter = {
 	.zav.multipath_num = MULTIPATH_NUM,
 };
+
+DEFINE_HOOK(nos_initialize_data, (struct zebra_architectural_values *zav), (zav));
 
 static inline int
 zebra_router_table_entry_compare(const struct zebra_router_table *e1,
@@ -353,6 +356,8 @@ void zebra_router_init(bool asic_offload, bool notify_on_ack, bool v6_with_v4_ne
 	zrouter.zav.asic_notification_nexthop_control = false;
 
 	zrouter.backup_nhs_installed = false;
+
+	hook_call(nos_initialize_data, &zrouter.zav);
 
 	if (!zrouter.zav.nexthop_weight_is_16bit)
 		zrouter.nexthop_weight_scale_value = 254;

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -23,7 +23,7 @@ DEFINE_MTYPE_STATIC(ZEBRA, RIB_TABLE_INFO, "RIB table info");
 DEFINE_MTYPE_STATIC(ZEBRA, ZEBRA_RT_TABLE, "Zebra VRF table");
 
 struct zebra_router zrouter = {
-	.multipath_num = MULTIPATH_NUM,
+	.zav.multipath_num = MULTIPATH_NUM,
 };
 
 static inline int
@@ -275,7 +275,7 @@ void zebra_router_terminate(void)
 
 bool zebra_router_notify_on_ack(void)
 {
-	return !zrouter.asic_offloaded || zrouter.notify_on_ack;
+	return !zrouter.zav.asic_offloaded || zrouter.zav.notify_on_ack;
 }
 
 void zebra_router_init(bool asic_offload, bool notify_on_ack, bool v6_with_v4_nexthop,
@@ -336,10 +336,10 @@ void zebra_router_init(bool asic_offload, bool notify_on_ack, bool v6_with_v4_ne
 					       zebra_tc_filter_hash_equal,
 					       "TC (filter) Hash");
 
-	zrouter.asic_offloaded = asic_offload;
-	zrouter.notify_on_ack = notify_on_ack;
-	zrouter.v6_with_v4_nexthop = v6_with_v4_nexthop;
-	zrouter.nexthop_weight_is_16bit = nexthop_weight_16_bit;
+	zrouter.zav.asic_offloaded = asic_offload;
+	zrouter.zav.notify_on_ack = notify_on_ack;
+	zrouter.zav.v6_with_v4_nexthop = v6_with_v4_nexthop;
+	zrouter.zav.nexthop_weight_is_16bit = nexthop_weight_16_bit;
 
 	/*
 	 * If you start using asic_notification_nexthop_control
@@ -350,14 +350,14 @@ void zebra_router_init(bool asic_offload, bool notify_on_ack, bool v6_with_v4_ne
 	CPP_NOTICE(
 		"Remove zrouter.asic_notification_nexthop_control as that it's not being maintained or used");
 #endif
-	zrouter.asic_notification_nexthop_control = false;
+	zrouter.zav.asic_notification_nexthop_control = false;
 
-	if (!zrouter.nexthop_weight_is_16bit)
+	zrouter.backup_nhs_installed = false;
+
+	if (!zrouter.zav.nexthop_weight_is_16bit)
 		zrouter.nexthop_weight_scale_value = 254;
 	else
 		zrouter.nexthop_weight_scale_value = 0xFFFF - 1;
-
-	zrouter.backup_nhs_installed = false;
 
 #ifdef HAVE_SCRIPTING
 	zebra_script_init();

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -117,6 +117,32 @@ struct zebra_mlag_info {
 #define RTADV_TIMER_WHEEL_SLOTS_NO  100
 #define ICMPV6_JOIN_TIMER_EXP_MS    100
 
+/*
+ * These are values that are changeable due to some architectural restrictions
+ * of the underlying NOS's actual data plane.  They are sequestered into
+ * their own area such that we don't necessarily want to expose all of zebra_router
+ */
+struct zebra_architectural_values {
+	uint32_t multipath_num;
+
+	bool asic_offloaded;
+	bool notify_on_ack;
+	bool v6_with_v4_nexthop;
+	bool v6_rr_semantics;
+
+	bool supports_nhgs;
+
+	/*
+	 * If the asic is notifying us about successful nexthop
+	 * allocation/control.  Some developers have made their
+	 * asic take control of how many nexthops/ecmp they can
+	 * have and will report what is successfull or not
+	 */
+	bool asic_notification_nexthop_control;
+	bool nexthop_weight_is_16bit;
+
+};
+
 struct zebra_router {
 	atomic_bool in_shutdown;
 
@@ -182,7 +208,7 @@ struct zebra_router {
 	 */
 	struct zebra_vrf *evpn_vrf;
 
-	uint32_t multipath_num;
+	struct zebra_architectural_values zav;
 
 	/*
 	 * zebra start time and time of sweeping RIB of old routes
@@ -202,25 +228,6 @@ struct zebra_router {
 	struct hash *nhgs;
 	struct hash *nhgs_id;
 
-	/*
-	 * Does the underlying system provide an asic offload
-	 */
-	bool asic_offloaded;
-	bool notify_on_ack;
-	bool v6_with_v4_nexthop;
-
-	bool v6_rr_semantics;
-
-	/*
-	 * If the asic is notifying us about successful nexthop
-	 * allocation/control.  Some developers have made their
-	 * asic take control of how many nexthops/ecmp they can
-	 * have and will report what is successfull or not
-	 */
-	bool asic_notification_nexthop_control;
-
-	bool supports_nhgs;
-
 	bool all_mc_forwardingv4, default_mc_forwardingv4;
 	bool all_mc_forwardingv6, default_mc_forwardingv6;
 	bool all_linkdownv4, default_linkdownv4;
@@ -237,8 +244,6 @@ struct zebra_router {
 	uint64_t nexthop_weight_scale_value;
 
 	bool backup_nhs_installed;
-
-	bool nexthop_weight_is_16bit;
 };
 
 #define GRACEFUL_RESTART_TIME 60
@@ -289,7 +294,7 @@ extern bool zebra_router_notify_on_ack(void);
 
 static inline void zebra_router_set_supports_nhgs(bool support)
 {
-	zrouter.supports_nhgs = support;
+	zrouter.zav.supports_nhgs = support;
 }
 
 static inline bool zebra_router_in_shutdown(void)

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -7,6 +7,7 @@
 #define __ZEBRA_ROUTER_H__
 
 #include "lib/mlag.h"
+#include "lib/hook.h"
 
 #include "zebra/zebra_ns.h"
 #include "zebra/zebra_vrf.h"
@@ -332,6 +333,8 @@ extern void zebra_main_router_started(void);
 
 /* zebra_northbound.c */
 extern const struct frr_yang_module_info frr_zebra_info;
+
+DECLARE_HOOK(nos_initialize_data, (struct zebra_architectural_values *), (zav));
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -108,16 +108,13 @@ static char re_status_output_char(const struct route_entry *re,
 				star_p = true;
 		}
 
-		if (zrouter.asic_offloaded &&
-		    CHECK_FLAG(re->status, ROUTE_ENTRY_QUEUED))
+		if (zrouter.zav.asic_offloaded && CHECK_FLAG(re->status, ROUTE_ENTRY_QUEUED))
 			return 'q';
 
-		if (zrouter.asic_offloaded
-		    && CHECK_FLAG(re->flags, ZEBRA_FLAG_TRAPPED))
+		if (zrouter.zav.asic_offloaded && CHECK_FLAG(re->flags, ZEBRA_FLAG_TRAPPED))
 			return 't';
 
-		if (zrouter.asic_offloaded
-		    && CHECK_FLAG(re->flags, ZEBRA_FLAG_OFFLOAD_FAILED))
+		if (zrouter.zav.asic_offloaded && CHECK_FLAG(re->flags, ZEBRA_FLAG_OFFLOAD_FAILED))
 			return 'o';
 
 		if (CHECK_FLAG(re->flags, ZEBRA_FLAG_OUTOFSYNC))
@@ -3733,7 +3730,7 @@ static inline bool zebra_vty_v6_rr_semantics_used(void)
 	if (zebra_nhg_kernel_nexthops_enabled())
 		return true;
 
-	if (zrouter.v6_rr_semantics)
+	if (zrouter.zav.v6_rr_semantics)
 		return true;
 
 	return false;
@@ -3765,7 +3762,7 @@ DEFUN (show_zebra,
 
 	ttable_rowseps(table, 0, BOTTOM, true, '-');
 	ttable_add_row(table, "OS|%s(%s)", cmd_system_get(), cmd_release_get());
-	ttable_add_row(table, "ECMP Maximum|%d", zrouter.multipath_num);
+	ttable_add_row(table, "ECMP Maximum|%d", zrouter.zav.multipath_num);
 	ttable_add_row(table, "v4 Forwarding|%s", ipforward() ? "On" : "Off");
 	ttable_add_row(table, "v6 Forwarding|%s",
 		       ipforward_ipv6() ? "On" : "Off");
@@ -3776,7 +3773,7 @@ DEFUN (show_zebra,
 		       zebra_vty_v6_rr_semantics_used() ? "Replace"
 							: "Delete then Add");
 	ttable_add_row(table, "Nexthop weight is 16 bits|%s",
-		       zrouter.nexthop_weight_is_16bit ? "Yes" : "No");
+		       zrouter.zav.nexthop_weight_is_16bit ? "Yes" : "No");
 
 #ifdef GNU_LINUX
 	if (!vrf_is_backend_netns())
@@ -3788,10 +3785,10 @@ DEFUN (show_zebra,
 #endif
 
 	ttable_add_row(table, "v6 with v4 nexthop|%s",
-		       zrouter.v6_with_v4_nexthop ? "Used" : "Unavailable");
+		       zrouter.zav.v6_with_v4_nexthop ? "Used" : "Unavailable");
 
 	ttable_add_row(table, "ASIC offload|%s",
-		       zrouter.asic_offloaded ? "Used" : "Unavailable");
+		       zrouter.zav.asic_offloaded ? "Used" : "Unavailable");
 
 	/*
 	 * Do not display this unless someone is actually using it
@@ -3799,7 +3796,7 @@ DEFUN (show_zebra,
 	 * Why this distinction?  I think this is effectively dead code
 	 * and should not be exposed.  Maybe someone proves me wrong.
 	 */
-	if (zrouter.asic_notification_nexthop_control)
+	if (zrouter.zav.asic_notification_nexthop_control)
 		ttable_add_row(table, "ASIC offload and nexthop control|Used");
 
 	ttable_add_row(table, "RA|%s",
@@ -3810,7 +3807,7 @@ DEFUN (show_zebra,
 			       : "BGP is not using");
 
 	ttable_add_row(table, "Kernel NHG|%s",
-		       zrouter.supports_nhgs ? "Available" : "Unavailable");
+		       zrouter.zav.supports_nhgs ? "Available" : "Unavailable");
 
 	ttable_add_row(table, "Allow Non FRR route deletion|%s",
 		       zrouter.allow_delete ? "Yes" : "No");


### PR DESCRIPTION
Currently it is up to the operator to fully specify zrouter values via command line or compile time options.  It is desirable to allow a copy of FRR to dynamically figure some of these out at run time. Let's provide a hook for that too happen.