### PR TITLE
lib: Fix SQLite DB location when using pathspace option

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -757,8 +757,8 @@ struct event_loop *frr_init(void)
 	snprintf(pidfile_default, sizeof(pidfile_default), "%s/%s%s.pid",
 		 frr_runstatedir, di->name, p_instance);
 #ifdef HAVE_SQLITE3
-	snprintf(dbfile_default, sizeof(dbfile_default), "%s/%s%s%s.db",
-		 frr_libstatedir, p_pathspace, di->name, p_instance);
+	snprintf(dbfile_default, sizeof(dbfile_default), "%s/%s%s.db", frr_libstatedir, di->name,
+		 p_instance);
 #endif
 
 	zprivs_preinit(di->privs);


### PR DESCRIPTION
If FRR is compiled with HAVE_SQLITE3, the DB location in dbfile_default gets initialized improperly when the --pathspace/-N option is used. The code handling the option already adds the pathspace to frr_libstatedir but frr_init() determines dbfile_default by using both frr_libstatedir and p_pathspace, resulting in having the pathspace twice in the DB filename, e.g: /var/lib/frr/netns-test/netns-test/watchfrr.db instead of /var/lib/frr/netns-test/watchfrr.db.

Fix this by simply using frr_libstatedir when determining dbfile_default.