### PR TITLE
ospf6d: protect LSA in vertex

### DIFF
--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -127,7 +127,7 @@ static struct ospf6_vertex *ospf6_vertex_create(struct ospf6_lsa *lsa)
 
 
 	/* Associated LSA */
-	v->lsa = lsa;
+	v->lsa = ospf6_lsa_lock(lsa);
 
 	/* capability bits + options */
 	v->capability = *(uint8_t *)(ospf6_lsa_header_end(lsa->header));
@@ -150,6 +150,7 @@ static void ospf6_vertex_delete(struct ospf6_vertex *v)
 {
 	list_delete(&v->nh_list);
 	list_delete(&v->child_list);
+	ospf6_lsa_unlock(&v->lsa);
 	XFREE(MTYPE_OSPF6_VERTEX, v);
 }
 


### PR DESCRIPTION
crash occurs in fields

core 1:
    result_table=0x5e7c57a1ba80, oa=0x5e7c57a1b810)
    at /build/make-pkg/output/_packages/cp-routing/src/ospf6d/ospf6_spf.c:502
    at /build/make-pkg/output/_packages/cp-routing/src/ospf6d/ospf6_spf.c:638

core 2:
    at /build/make-pkg/output/_packages/cp-routing/src/ospf6d/ospf6_spf.c:386
    result_table=0x5727e5e99200, oa=0x5727e5eae1d0)
    at /build/make-pkg/output/_packages/cp-routing/src/ospf6d/ospf6_spf.c:502
    at /build/make-pkg/output/_packages/cp-routing/src/ospf6d/ospf6_spf.c:638

core analysis exhibits v->lsa is use while the memory had been freed or more reallocated to another type structure.

proposed fix, protect v->lsa by ospf6_lsa_lock/unlock use.