### PR TITLE
tests: Actually look for port 179

### DIFF
--- a/tests/topotests/bgp_listen_l3vrf/test_bgp_listen_l3vrf.py
+++ b/tests/topotests/bgp_listen_l3vrf/test_bgp_listen_l3vrf.py
@@ -53,7 +53,7 @@ from lib.bgp import (
 def check_port_179_open(vrf):
     tgen = get_topogen()
     r1 = tgen.gears["r1"]
-    output = r1.cmd("ss -tuplen | grep :179 ")
+    output = r1.cmd("ss -tuplen | grep ':179 '")
     logger.info(output)
     if vrf == "default":
         match = re.search("0.0.0.0", output)


### PR DESCRIPTION
The grep in the check_port_179_open was matching against incorrect data for the ss output:

2025-08-28 14:33:10,037  INFO: topo: <re.Match object; span=(33, 40), match='0.0.0.0'>
2025-08-28 14:33:11,042 DEBUG: r1: cmd_status("/bin/bash -c 'ss -tuplen | grep :179 '") 2025-08-28 14:33:11,434 DEBUG: r1:
        stdout: tcp   LISTEN 0      3            0.0.0.0:2616      0.0.0.0:*    users...
2025-08-28 14:33:11,434  INFO: topo: tcp   LISTEN 0      3            0.0.0.0:2616      0.0.0.0:*    users:(("staticd",pid=1331068,fd=11)) uid:126 ino:1793738408 sk:102b cgroup:/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-16849abe-4367-40b4-9b10-7c8146fb9591.scope <->
tcp   LISTEN 0      3            0.0.0.0:2623      0.0.0.0:*    users:(("mgmtd",pid=1330722,fd=14)) uid:126 ino:1793730933 sk:102c cgroup:/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-16849abe-4367-40b4-9b10-7c8146fb9591.scope <->
tcp   LISTEN 0      3            0.0.0.0:2601      0.0.0.0:*    users:(("zebra",pid=1330959,fd=26)) uid:126 ino:1793728054 sk:102d cgroup:/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-16849abe-4367-40b4-9b10-7c8146fb9591.scope <->
tcp   LISTEN 0      3            0.0.0.0:2605      0.0.0.0:*    users:(("bgpd",pid=1331275,fd=17)) uid:126 ino:1793742233 sk:102e cgroup:/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-16849abe-4367-40b4-9b10-7c8146fb9591.scope <->
tcp   LISTEN 0      3               [::]:2616         [::]:*    users:(("staticd",pid=1331068,fd=12)) uid:126 ino:1793738409 sk:5084 cgroup:/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-16849abe-4367-40b4-9b10-7c8146fb9591.scope v6only:1 <->
tcp   LISTEN 0      3               [::]:2623         [::]:*    users:(("mgmtd",pid=1330722,fd=15)) uid:126 ino:1793730934 sk:5085 cgroup:/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-16849abe-4367-40b4-9b10-7c8146fb9591.scope v6only:1 <->
tcp   LISTEN 0      3               [::]:2601         [::]:*    users:(("zebra",pid=1330959,fd=27)) uid:126 ino:1793728055 sk:5086 cgroup:/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-16849abe-4367-40b4-9b10-7c8146fb9591.scope v6only:1 <->
tcp   LISTEN 0      3               [::]:2605         [::]:*    users:(("bgpd",pid=1331275,fd=18)) uid:126 ino:1793742234 sk:5087 cgroup:/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-16849abe-4367-40b4-9b10-7c8146fb9591.scope v6only:1 <->

Notice that it's matching against ino:179, that is not actually what we want.  Change the grep to look explicitly for a space after the 179.