### PR TITLE
staticd: Fix SRv6 SID installation for default VRF (backport of https://github.com/FRRouting/frr/pull/19410 for 10.4)

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -361,6 +361,7 @@ void vpn_leak_zebra_vrf_sid_update_per_af(struct bgp *bgp, afi_t afi)
 	struct in6_addr *tovpn_sid = NULL;
 	struct in6_addr *tovpn_sid_ls = NULL;
 	struct vrf *vrf;
+	struct interface *ifp;
 
 	if (bgp->vrf_id == VRF_UNKNOWN) {
 		if (debug)
@@ -386,6 +387,10 @@ void vpn_leak_zebra_vrf_sid_update_per_af(struct bgp *bgp, afi_t afi)
 	if (!vrf)
 		return;
 
+	ifp = if_get_vrf_loopback(bgp->vrf_id);
+	if (!ifp)
+		return;
+
 	if (bgp->vpn_policy[afi].tovpn_sid_locator) {
 		ctx.block_len =
 			bgp->vpn_policy[afi].tovpn_sid_locator->block_bits_length;
@@ -403,7 +408,8 @@ void vpn_leak_zebra_vrf_sid_update_per_af(struct bgp *bgp, afi_t afi)
 	ctx.table = vrf->data.l.table_id;
 	act = afi == AFI_IP ? ZEBRA_SEG6_LOCAL_ACTION_END_DT4
 		: ZEBRA_SEG6_LOCAL_ACTION_END_DT6;
-	zclient_send_localsid(bgp_zclient, tovpn_sid, bgp->vrf_id, act, &ctx);
+	zclient_send_localsid(bgp_zclient, ZEBRA_ROUTE_ADD, tovpn_sid, IPV6_MAX_BITLEN,
+			      ifp->ifindex, act, &ctx);
 
 	tovpn_sid_ls = XCALLOC(MTYPE_BGP_SRV6_SID, sizeof(struct in6_addr));
 	*tovpn_sid_ls = *tovpn_sid;
@@ -426,6 +432,7 @@ void vpn_leak_zebra_vrf_sid_update_per_vrf(struct bgp *bgp)
 	struct in6_addr *tovpn_sid = NULL;
 	struct in6_addr *tovpn_sid_ls = NULL;
 	struct vrf *vrf;
+	struct interface *ifp;
 
 	if (bgp->vrf_id == VRF_UNKNOWN) {
 		if (debug)
@@ -451,6 +458,10 @@ void vpn_leak_zebra_vrf_sid_update_per_vrf(struct bgp *bgp)
 	if (!vrf)
 		return;
 
+	ifp = if_get_vrf_loopback(bgp->vrf_id);
+	if (!ifp)
+		return;
+
 	if (bgp->tovpn_sid_locator) {
 		ctx.block_len = bgp->tovpn_sid_locator->block_bits_length;
 		ctx.node_len = bgp->tovpn_sid_locator->node_bits_length;
@@ -461,7 +472,8 @@ void vpn_leak_zebra_vrf_sid_update_per_vrf(struct bgp *bgp)
 	}
 	ctx.table = vrf->data.l.table_id;
 	act = ZEBRA_SEG6_LOCAL_ACTION_END_DT46;
-	zclient_send_localsid(bgp_zclient, tovpn_sid, bgp->vrf_id, act, &ctx);
+	zclient_send_localsid(bgp_zclient, ZEBRA_ROUTE_ADD, tovpn_sid, IPV6_MAX_BITLEN,
+			      ifp->ifindex, act, &ctx);
 
 	tovpn_sid_ls = XCALLOC(MTYPE_BGP_SRV6_SID, sizeof(struct in6_addr));
 	*tovpn_sid_ls = *tovpn_sid;
@@ -499,6 +511,7 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_af(struct bgp *bgp, afi_t afi)
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_LABEL);
 	struct srv6_sid_ctx ctx = {};
 	struct seg6local_context seg6localctx = {};
+	struct interface *ifp;
 
 	if (bgp->vrf_id == VRF_UNKNOWN) {
 		if (debug)
@@ -510,6 +523,10 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_af(struct bgp *bgp, afi_t afi)
 	if (debug)
 		zlog_debug("%s: deleting sid for vrf %s afi (id=%d)", __func__,
 			   bgp->name_pretty, bgp->vrf_id);
+
+	ifp = if_get_vrf_loopback(bgp->vrf_id);
+	if (!ifp)
+		return;
 
 	if (bgp->vpn_policy[afi].tovpn_sid_locator) {
 		seg6localctx.block_len =
@@ -523,10 +540,9 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_af(struct bgp *bgp, afi_t afi)
 			bgp->vpn_policy[afi]
 				.tovpn_sid_locator->argument_bits_length;
 	}
-	zclient_send_localsid(bgp_zclient,
-			      bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent,
-			      bgp->vrf_id, ZEBRA_SEG6_LOCAL_ACTION_UNSPEC,
-			      &seg6localctx);
+	zclient_send_localsid(bgp_zclient, ZEBRA_ROUTE_DELETE,
+			      bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent, IPV6_MAX_BITLEN,
+			      ifp->ifindex, ZEBRA_SEG6_LOCAL_ACTION_UNSPEC, &seg6localctx);
 	XFREE(MTYPE_BGP_SRV6_SID,
 	      bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent);
 	bgp->vpn_policy[afi].tovpn_zebra_vrf_sid_last_sent = NULL;
@@ -546,6 +562,7 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_vrf(struct bgp *bgp)
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_LABEL);
 	struct srv6_sid_ctx ctx = {};
 	struct seg6local_context seg6localctx = {};
+	struct interface *ifp;
 
 	if (bgp->vrf_id == VRF_UNKNOWN) {
 		if (debug)
@@ -559,6 +576,10 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_vrf(struct bgp *bgp)
 		zlog_debug("%s: deleting sid for vrf %s (id=%d)", __func__,
 			   bgp->name_pretty, bgp->vrf_id);
 
+	ifp = if_get_vrf_loopback(bgp->vrf_id);
+	if (!ifp)
+		return;
+
 	if (bgp->tovpn_sid_locator) {
 		seg6localctx.block_len =
 			bgp->tovpn_sid_locator->block_bits_length;
@@ -568,8 +589,8 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_vrf(struct bgp *bgp)
 		seg6localctx.argument_len =
 			bgp->tovpn_sid_locator->argument_bits_length;
 	}
-	zclient_send_localsid(bgp_zclient, bgp->tovpn_zebra_vrf_sid_last_sent,
-			      bgp->vrf_id, ZEBRA_SEG6_LOCAL_ACTION_UNSPEC,
+	zclient_send_localsid(bgp_zclient, ZEBRA_ROUTE_DELETE, bgp->tovpn_zebra_vrf_sid_last_sent,
+			      IPV6_MAX_BITLEN, ifp->ifindex, ZEBRA_SEG6_LOCAL_ACTION_UNSPEC,
 			      &seg6localctx);
 	XFREE(MTYPE_BGP_SRV6_SID, bgp->tovpn_zebra_vrf_sid_last_sent);
 	bgp->tovpn_zebra_vrf_sid_last_sent = NULL;

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -520,6 +520,27 @@ enum zclient_send_status zclient_send_vrf_label(struct zclient *zclient,
 	return zclient_send_message(zclient);
 }
 
+static struct interface *select_oif_for_localsid(ifindex_t candidate_oif)
+{
+	struct interface *ifp;
+
+	ifp = if_lookup_by_index(candidate_oif, VRF_DEFAULT);
+
+	/*
+	 * If the candidate outgoing interface (oif) is the loopback interface,
+	 * select 'sr0' as the oif instead. The Linux kernel does not permit
+	 * attaching SRv6 SIDs to the loopback interface, so 'sr0' must be used
+	 * in this case.
+	 */
+	if (!ifp || if_is_loopback_exact(ifp)) {
+		ifp = if_lookup_by_name(DEFAULT_SRV6_IFNAME, VRF_DEFAULT);
+		if (!ifp)
+			return NULL;
+	}
+
+	return ifp;
+}
+
 enum zclient_send_status zclient_send_localsid(struct zclient *zclient, uint8_t cmd,
 					       const struct in6_addr *sid, uint16_t prefixlen,
 					       ifindex_t oif, enum seg6local_action_t action,
@@ -539,6 +560,19 @@ enum zclient_send_status zclient_send_localsid(struct zclient *zclient, uint8_t 
 		zlog_debug("%s:  |- %s SRv6 SID %pI6 behavior %s", __func__,
 			   cmd != ZEBRA_ROUTE_ADD ? "Add" : "Delete", sid,
 			   seg6local_action2str(action));
+
+	/*
+	 * Select a valid outgoing interface (oif) for attaching the SID.
+	 * If the provided oif is valid and not the loopback interface, it is used.
+	 * Otherwise, fall back to using the 'sr0' interface.
+	 */
+	ifp = select_oif_for_localsid(oif);
+	if (!ifp) {
+		zlog_err("Unable to obtain a valid outgoing interface for installing the SID.");
+		zlog_err(
+			"Please ensure that a dummy interface named 'sr0' exists and is operational.");
+		return ZCLIENT_SEND_FAILURE;
+	}
 
 	p.family = AF_INET6;
 	p.prefixlen = prefixlen;

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -972,10 +972,11 @@ extern enum zclient_send_status
 zclient_send_vrf_label(struct zclient *zclient, vrf_id_t vrf_id, afi_t afi,
 		       mpls_label_t label, enum lsp_types_t ltype);
 
-extern enum zclient_send_status
-zclient_send_localsid(struct zclient *zclient, const struct in6_addr *sid,
-		      vrf_id_t vrf_id, enum seg6local_action_t action,
-		      const struct seg6local_context *context);
+extern enum zclient_send_status zclient_send_localsid(struct zclient *zclient, uint8_t cmd,
+						      const struct in6_addr *sid,
+						      uint16_t prefixlen, ifindex_t oif,
+						      enum seg6local_action_t action,
+						      const struct seg6local_context *context);
 
 extern void zclient_send_reg_requests(struct zclient *, vrf_id_t);
 extern void zclient_send_dereg_requests(struct zclient *, vrf_id_t);

--- a/staticd/static_srv6.c
+++ b/staticd/static_srv6.c
@@ -94,6 +94,17 @@ static bool is_sid_update_required(struct interface *ifp, struct static_srv6_sid
 		if (strmatch(ifp->name, DEFAULT_SRV6_IFNAME) &&
 		    strmatch(sid->attributes.vrf_name, VRF_DEFAULT_NAME))
 			return true;
+
+		/*
+		 * 3c. SID is uDT4 or uDT46 and is associated with the default VRF.
+		 *     These SIDs rely on any VRF bound to the main routing table (table ID 254) for
+		 *     decapsulation and forwarding.
+		 *     Therefore, an update is needed if the provided interface 'ifp' is a VRF interface
+		 *     bound to the main routing table.
+		 */
+		if (is_udt4_or_udt46 && strmatch(sid->attributes.vrf_name, VRF_DEFAULT_NAME) &&
+		    (ifp->vrf->data.l.table_id == 254))
+			return true;
 	}
 
 	/* No dependency found */

--- a/staticd/static_srv6.c
+++ b/staticd/static_srv6.c
@@ -138,7 +138,9 @@ void static_ifp_srv6_sids_update(struct interface *ifp, bool is_up)
 		if (!is_sid_update_required(ifp, sid))
 			continue;
 
-		if (is_up) {
+		if (is_up && !CHECK_FLAG(sid->flags, STATIC_FLAG_SRV6_SID_VALID)) {
+			static_zebra_request_srv6_sid(sid);
+		} else if (is_up && CHECK_FLAG(sid->flags, STATIC_FLAG_SRV6_SID_VALID)) {
 			static_zebra_srv6_sid_install(sid);
 			SET_FLAG(sid->flags, STATIC_FLAG_SRV6_SID_SENT_TO_ZEBRA);
 		} else {

--- a/staticd/static_srv6.c
+++ b/staticd/static_srv6.c
@@ -141,6 +141,11 @@ void static_ifp_srv6_sids_update(struct interface *ifp, bool is_up)
 		if (is_up && !CHECK_FLAG(sid->flags, STATIC_FLAG_SRV6_SID_VALID)) {
 			static_zebra_request_srv6_sid(sid);
 		} else if (is_up && CHECK_FLAG(sid->flags, STATIC_FLAG_SRV6_SID_VALID)) {
+			if (CHECK_FLAG(sid->flags, STATIC_FLAG_SRV6_SID_SENT_TO_ZEBRA)) {
+				static_zebra_srv6_sid_uninstall(sid);
+				UNSET_FLAG(sid->flags, STATIC_FLAG_SRV6_SID_SENT_TO_ZEBRA);
+			}
+
 			static_zebra_srv6_sid_install(sid);
 			SET_FLAG(sid->flags, STATIC_FLAG_SRV6_SID_SENT_TO_ZEBRA);
 		} else {

--- a/staticd/static_srv6.c
+++ b/staticd/static_srv6.c
@@ -85,6 +85,15 @@ static bool is_sid_update_required(struct interface *ifp, struct static_srv6_sid
 		 */
 		if (strmatch(sid->attributes.vrf_name, ifp->name))
 			return true;
+
+		/*
+		 * 3b. SID is uDT* and is associated with the default VRF.
+		 *     When associated with the default VRF, uDT* SIDs are attached to 'sr0'.
+		 *     Therefore, an update is needed if the provided interface 'ifp' is 'sr0'.
+		 */
+		if (strmatch(ifp->name, DEFAULT_SRV6_IFNAME) &&
+		    strmatch(sid->attributes.vrf_name, VRF_DEFAULT_NAME))
+			return true;
 	}
 
 	/* No dependency found */

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -557,68 +557,6 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
 }
 
 /**
- * Send SRv6 SID to ZEBRA for installation or deletion.
- *
- * @param cmd		ZEBRA_ROUTE_ADD or ZEBRA_ROUTE_DELETE
- * @param sid		SRv6 SID to install or delete
- * @param prefixlen	Prefix length
- * @param oif		Outgoing interface
- * @param action	SID action
- * @param context	SID context
- */
-static void static_zebra_send_localsid(int cmd, const struct in6_addr *sid, uint16_t prefixlen,
-				       ifindex_t oif, enum seg6local_action_t action,
-				       const struct seg6local_context *context)
-{
-	struct prefix_ipv6 p = {};
-	struct zapi_route api = {};
-	struct zapi_nexthop *znh;
-
-	if (cmd != ZEBRA_ROUTE_ADD && cmd != ZEBRA_ROUTE_DELETE) {
-		flog_warn(EC_LIB_DEVELOPMENT, "%s: wrong ZEBRA command", __func__);
-		return;
-	}
-
-	if (prefixlen > IPV6_MAX_BITLEN) {
-		flog_warn(EC_LIB_DEVELOPMENT, "%s: wrong prefixlen %u", __func__, prefixlen);
-		return;
-	}
-
-	DEBUGD(&static_dbg_srv6, "%s:  |- %s SRv6 SID %pI6 behavior %s", __func__,
-	       cmd == ZEBRA_ROUTE_ADD ? "Add" : "Delete", sid, seg6local_action2str(action));
-
-	p.family = AF_INET6;
-	p.prefixlen = prefixlen;
-	p.prefix = *sid;
-
-	api.vrf_id = VRF_DEFAULT;
-	api.type = ZEBRA_ROUTE_STATIC;
-	api.instance = 0;
-	api.safi = SAFI_UNICAST;
-	memcpy(&api.prefix, &p, sizeof(p));
-
-	if (cmd == ZEBRA_ROUTE_DELETE)
-		return (void)zclient_route_send(ZEBRA_ROUTE_DELETE, static_zclient, &api);
-
-	SET_FLAG(api.flags, ZEBRA_FLAG_ALLOW_RECURSION);
-	SET_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP);
-
-	znh = &api.nexthops[0];
-
-	memset(znh, 0, sizeof(*znh));
-
-	znh->type = NEXTHOP_TYPE_IFINDEX;
-	znh->ifindex = oif;
-	SET_FLAG(znh->flags, ZAPI_NEXTHOP_FLAG_SEG6LOCAL);
-	znh->seg6local_action = action;
-	memcpy(&znh->seg6local_ctx, context, sizeof(struct seg6local_context));
-
-	api.nexthop_num = 1;
-
-	zclient_route_send(ZEBRA_ROUTE_ADD, static_zclient, &api);
-}
-
-/**
  * Install SRv6 SID in the forwarding plane through Zebra.
  *
  * @param sid		SRv6 SID
@@ -813,8 +751,8 @@ void static_zebra_srv6_sid_install(struct static_srv6_sid *sid)
 	}
 
 	/* Send the SID to zebra */
-	static_zebra_send_localsid(ZEBRA_ROUTE_ADD, &sid->addr.prefix, sid->addr.prefixlen,
-				   ifp->ifindex, action, &ctx);
+	zclient_send_localsid(static_zclient, ZEBRA_ROUTE_ADD, &sid->addr.prefix,
+			      sid->addr.prefixlen, ifp->ifindex, action, &ctx);
 
 	SET_FLAG(sid->flags, STATIC_FLAG_SRV6_SID_SENT_TO_ZEBRA);
 }
@@ -952,8 +890,8 @@ void static_zebra_srv6_sid_uninstall(struct static_srv6_sid *sid)
 
 	ctx.function_len = sid->addr.prefixlen - (ctx.block_len + ctx.node_len);
 
-	static_zebra_send_localsid(ZEBRA_ROUTE_DELETE, &sid->addr.prefix, sid->addr.prefixlen,
-				   ifp->ifindex, action, &ctx);
+	zclient_send_localsid(static_zclient, ZEBRA_ROUTE_DELETE, &sid->addr.prefix,
+			      sid->addr.prefixlen, ifp->ifindex, action, &ctx);
 
 	UNSET_FLAG(sid->flags, STATIC_FLAG_SRV6_SID_SENT_TO_ZEBRA);
 }

--- a/tests/topotests/static_srv6_sids/expected_srv6_sids.json
+++ b/tests/topotests/static_srv6_sids/expected_srv6_sids.json
@@ -197,5 +197,128 @@
 				}
 			]
 		}
+	],
+	"fcbb:bbbb:1:fe60::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe60::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT4",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 254
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe70::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe70::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT6",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 254
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe80::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe80::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT46",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 254
+					}
+				}
+			]
+		}
 	]
 }

--- a/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_delete_1.json
+++ b/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_delete_1.json
@@ -156,5 +156,128 @@
 				}
 			]
 		}
+	],
+	"fcbb:bbbb:1:fe60::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe60::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT4",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 254
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe70::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe70::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT6",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 254
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe80::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe80::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT46",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 254
+					}
+				}
+			]
+		}
 	]
 }

--- a/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_delete_2.json
+++ b/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_delete_2.json
@@ -115,5 +115,128 @@
 				}
 			]
 		}
+	],
+	"fcbb:bbbb:1:fe60::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe60::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT4",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 254
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe70::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe70::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT6",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 254
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe80::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe80::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT46",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 254
+					}
+				}
+			]
+		}
 	]
 }

--- a/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_modify.json
+++ b/tests/topotests/static_srv6_sids/expected_srv6_sids_sid_modify.json
@@ -197,5 +197,128 @@
 				}
 			]
 		}
+	],
+	"fcbb:bbbb:1:fe60::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe60::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT4",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 254
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe70::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe70::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT6",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 254
+					}
+				}
+			]
+		}
+	],
+	"fcbb:bbbb:1:fe80::/64": [
+		{
+			"prefix": "fcbb:bbbb:1:fe80::/64",
+			"prefixLen": 64,
+			"protocol": "static",
+			"vrfId": 0,
+			"vrfName": "default",
+			"selected": true,
+			"destSelected": true,
+			"distance": 1,
+			"metric": 0,
+			"installed": true,
+			"table": 254,
+			"internalStatus": 16,
+			"internalFlags": 9,
+			"internalNextHopNum": 1,
+			"internalNextHopActiveNum": 1,
+			"nexthops": [
+				{
+					"flags": 3,
+					"fib": true,
+					"directlyConnected": true,
+					"interfaceName": "sr0",
+					"active": true,
+					"weight": 1,
+					"seg6local": {
+						"action": "uDT46",
+						"sidStructure": {
+							"blockLen": 32,
+							"nodeLen": 16,
+							"funcLen": 16,
+							"argLen": 0
+						}
+					},
+					"seg6localContext": {
+						"table": 254
+					}
+				}
+			]
+		}
 	]
 }

--- a/tests/topotests/static_srv6_sids/r1/frr.conf
+++ b/tests/topotests/static_srv6_sids/r1/frr.conf
@@ -13,6 +13,9 @@ segment-routing
    sid fcbb:bbbb:1:fe20::/64 locator MAIN behavior uDT6 vrf Vrf20
    sid fcbb:bbbb:1:fe30::/64 locator MAIN behavior uDT46 vrf Vrf30
    sid fcbb:bbbb:1:fe40::/64 locator MAIN behavior uA interface sr0 nexthop 2001::2
+   sid fcbb:bbbb:1:fe60::/64 locator MAIN behavior uDT4 vrf default
+   sid fcbb:bbbb:1:fe70::/64 locator MAIN behavior uDT6 vrf default
+   sid fcbb:bbbb:1:fe80::/64 locator MAIN behavior uDT46 vrf default
   !
  !
 !

--- a/tests/topotests/static_srv6_sids/r1/setup.sh
+++ b/tests/topotests/static_srv6_sids/r1/setup.sh
@@ -13,4 +13,9 @@ ip link set Vrf30 up
 ip link add Vrf40 type vrf table 40
 ip link set Vrf40 up
 
+# VRF associated with main routing table,
+# required for SRv6 uDT4/uDT46 SIDs
+ip link add vrfdefault type vrf table main
+ip link set vrfdefault up
+
 sysctl -w net.vrf.strict_mode=1

--- a/tests/topotests/static_srv6_sids/test_static_srv6_sids.py
+++ b/tests/topotests/static_srv6_sids/test_static_srv6_sids.py
@@ -308,6 +308,9 @@ def test_srv6_static_sids_sid_readd_all():
             sid fcbb:bbbb:1:fe20::/64 locator MAIN behavior uDT6 vrf Vrf20
             sid fcbb:bbbb:1:fe30::/64 locator MAIN behavior uDT46 vrf Vrf30
             sid fcbb:bbbb:1:fe40::/64 locator MAIN behavior uA interface sr0 nexthop 2001::2
+            sid fcbb:bbbb:1:fe60::/64 locator MAIN behavior uDT4 vrf default
+            sid fcbb:bbbb:1:fe70::/64 locator MAIN behavior uDT6 vrf default
+            sid fcbb:bbbb:1:fe80::/64 locator MAIN behavior uDT46 vrf default
         """
     )
 
@@ -391,6 +394,9 @@ def test_srv6_static_sids_srv6_reenable():
             sid fcbb:bbbb:1:fe20::/64 locator MAIN behavior uDT6 vrf Vrf20
             sid fcbb:bbbb:1:fe30::/64 locator MAIN behavior uDT46 vrf Vrf30
             sid fcbb:bbbb:1:fe40::/64 locator MAIN behavior uA interface sr0 nexthop 2001::2
+            sid fcbb:bbbb:1:fe60::/64 locator MAIN behavior uDT4 vrf default
+            sid fcbb:bbbb:1:fe70::/64 locator MAIN behavior uDT6 vrf default
+            sid fcbb:bbbb:1:fe80::/64 locator MAIN behavior uDT46 vrf default
         """
     )
 


### PR DESCRIPTION
Manual backport of https://github.com/FRRouting/frr/pull/19410 for FRR 10.4

Replaces https://github.com/FRRouting/frr/pull/19452