### PR TITLE
Debian build: introduce profile "pkg.frr.asan"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -39,6 +39,12 @@ else
   CONF_GRPC=--enable-grpc
 endif
 
+ifeq ($(filter pkg.frr.asan,$(DEB_BUILD_PROFILES)),)
+  CONF_ASAN=--disable-address-sanitizer
+else
+  CONF_ASAN=--enable-address-sanitizer
+endif
+
 export PYTHON=python3
 
 %:
@@ -58,6 +64,7 @@ override_dh_auto_configure:
 		$(CONF_LUA) \
 		$(CONF_PIM6) \
 		$(CONF_GRPC) \
+		$(CONF_ASAN) \
 		--with-libpam \
 		--enable-doc \
 		--enable-doc-html \

--- a/doc/developer/packaging-debian.rst
+++ b/doc/developer/packaging-debian.rst
@@ -70,6 +70,9 @@ buster.)
      +----------------+-------------------+-----------------------------------------+
      | pkg.frr.grpc   | pkg.frr.nogrpc    | builds with grpc support (default: no)  |
      +----------------+-------------------+-----------------------------------------+
+     | pkg.frr.asan   | pkg.frr.noasan    | builds with --enable-address-sanitizer  |
+     |                |                   | (default: disabled)                     |
+     +----------------+-------------------+-----------------------------------------+
 
    * the ``-uc -us`` options to disable signing the packages with your GPG key
 


### PR DESCRIPTION
To debug hard to reproduce memory corruptions, it may be useful to have "production" build of FRR compiled with enabled address sanitizer. However this should not be the default. Use `DEB_BUILD_PROFILES` feature to optionally enable sanitizer at package build time. With such profile, debian package will be built with configure option "--enable-address-sanitizer".