### PR TITLE
bgpd, lib: fix memset overhead in zapi_route

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1640,8 +1640,22 @@ int zapi_route_decode(struct stream *s, struct zapi_route *api)
 	struct zapi_nexthop *api_nh;
 	int i;
 
-	memset(api, 0, sizeof(*api));
-
+	/* Initialize only required fields to avoid zeroing large arrays. */
+	api->message = 0;
+	api->flags = 0;
+	api->instance = 0;
+	api->nexthop_num = 0;
+	api->backup_nexthop_num = 0;
+	api->nhgid = 0;
+	api->distance = 0;
+	api->metric = 0;
+	api->tag = 0;
+	api->mtu = 0;
+	api->tableid = 0;
+	api->srte_color = 0;
+	api->opaque.length = 0;
+	api->src_prefix.prefixlen = 0;
+	api->prefix.prefixlen = 0;
 	/* Type, flags, message. */
 	STREAM_GETC(s, api->type);
 	if (api->type >= ZEBRA_ROUTE_MAX) {
@@ -1730,9 +1744,11 @@ int zapi_route_decode(struct stream *s, struct zapi_route *api)
 
 		for (i = 0; i < api->nexthop_num; i++) {
 			api_nh = &api->nexthops[i];
+			/* Ensure clean defaults for flags, label, counters etc. */
+			memset(api_nh, 0, sizeof(*api_nh));
 
 			if (zapi_nexthop_decode(s, api_nh, api->flags,
-						api->message)
+					api->message)
 			    != 0)
 				return -1;
 		}
@@ -1750,9 +1766,11 @@ int zapi_route_decode(struct stream *s, struct zapi_route *api)
 
 		for (i = 0; i < api->backup_nexthop_num; i++) {
 			api_nh = &api->backup_nexthops[i];
+			/* Ensure clean defaults for flags, label, counters etc. */
+			memset(api_nh, 0, sizeof(*api_nh));
 
 			if (zapi_nexthop_decode(s, api_nh, api->flags,
-						api->message)
+					api->message)
 			    != 0)
 				return -1;
 		}


### PR DESCRIPTION
**Issue:**
In a scaled setup, observed CPU hotspots in BGPd and zebra due to implicit memset(zeroing of full structure) of `struct zapi_route`:
    - In BGPd: `struct zapi_route api = { 0 };` inside `bgp_zebra_announce_actual`.
    - In zebra: `memset(api, 0, sizeof(*api));` in `zapi_route_decode`. In the above code, memset is called implicitely and that causes cpu overhead.

**Root-cause:** 
`struct zapi_route` is large (nexthop arrays sized for MULTIPATH_NUM=512). Full zeroing calls `__memset_avx2_erms` creating CPU overhead as this is hot path. This looks to be an avoidable overhead. Only used entries can have clean state; zeroing the whole struct is unnecessary.

**Fix:**
Avoid full-struct zeroing; initialize only what’s required and zero per-entry where used: BGPd (encode path, `bgp_zebra_announce_actual`):
    - Replace `{ 0 }` with explicit counter initialization: `message`, `flags`, `instance`, `nexthop_num`, etc.
    - Before filling each nexthop: zero only that slot (`memset(&api->nexthops[i], 0, sizeof(...))`).
    - Aggregate (blackhole) case: zero `nexthops[0]` before `zapi_route_set_blackhole` to avoid stale fields leaking to zapi stream.
    - Leave `opaque.data` untouched; we only serialize `opaque.length` bytes when the flag is set. Zebra (decode path, `zapi_route_decode`):
    - Remove `memset(api, 0, sizeof(*api))`; explicitly init the same counters as above.
    - Zero only each used `nexthop`/`backup_nexthop` entry before decoding into it.

**Notes:**
    - Backups aren’t used in this BGP announce path; so it is untouched.

**Result:** 
This is reducing CPU overhead under scale considerably(~20%)

**Without-Fix**
**Event statistics for zebra:**
```
Active   Runtime(ms)   Invoked Avg uSec Max uSecs Avg uSec Max uSecs  CPU_Warn Wall_Warn Starv_Warn   Type  Event
    0      13570.586    622713       21     19968       22     19968         0         0          0     E   zserv_process_messages
   12      47508.758   1282139       37    101689       42    332439         0         0          0  RWTEX  TOTAL
```
Total time: 47508.758

 **Event statistics for bgpd:**
```
Active   Runtime(ms)   Invoked Avg uSec Max uSecs Avg uSec Max uSecs  CPU_Warn Wall_Warn Starv_Warn   Type  Event
    0      11145.584       615    18122     32004    18142     32127         0         0          0   W     zclient_flush_data
   20      29990.544     17011     1763     55505     1764     55505         0         0          0  RWTEX  TOTAL
```
Total time: 29990.544

**Flamegraph for BGPd without fix:**
<img width="2394" height="1268" alt="image" src="https://github.com/user-attachments/assets/09ff35f5-17fb-48c0-8e4b-9fe0dd873d82" />



**With-Fix:**
**Event statistics for zebra:**
```
Active   Runtime(ms)   Invoked Avg uSec Max uSecs Avg uSec Max uSecs  CPU_Warn Wall_Warn Starv_Warn   Type  Event
    0       5081.615    759984        6     12897        7     12898         0         0          0     E   zserv_process_messages
   20      38969.969   1389176       28    102713       33    306580         0         0          0  RWTEX  TOTAL
```

 **Event statistics for bgpd:**
```
Active   Runtime(ms)   Invoked Avg uSec Max uSecs Avg uSec Max uSecs  CPU_Warn Wall_Warn Starv_Warn   Type  Event
    0       3356.401       586     5727     11413     5742     11413         0         0          0   W     zclient_flush_data
   28      20106.778     16356     1229     55379     1230     55379         0         0          0  RWTEX  TOTAL
```

**Flamegraph for BGPd with fix:**
<img width="2386" height="1348" alt="image" src="https://github.com/user-attachments/assets/61a885b3-9597-4d1a-a6f2-7950a5ed0751" />

