### PR TITLE
*: add a more efficient zapi_route_init api

### DIFF
--- a/babeld/kernel.c
+++ b/babeld/kernel.c
@@ -102,8 +102,6 @@ static int zebra_route(int add, int family, const unsigned char *pref, unsigned 
 	union g_addr babel_prefix_addr; /* babeld's prefix addr */
 	struct zapi_nexthop *api_nh;	/* next router to go - no ECMP */
 
-	api_nh = &api.nexthops[0];
-
 	/* convert to be understandable by quagga */
 	/* convert given addresses */
 	switch (family) {
@@ -131,11 +129,14 @@ static int zebra_route(int add, int family, const unsigned char *pref, unsigned 
 	}
 	apply_mask(&quagga_prefix);
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.type = ZEBRA_ROUTE_BABEL;
 	api.safi = SAFI_UNICAST;
 	api.vrf_id = VRF_DEFAULT;
 	api.prefix = quagga_prefix;
+
+	api_nh = &api.nexthops[0];
+	zapi_nexthop_init(api_nh);
 
 	if (metric >= KERNEL_INFINITY) {
 		zapi_route_set_blackhole(&api, BLACKHOLE_REJECT);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1308,6 +1308,8 @@ static void bgp_zebra_announce_parse_nexthop(
 		}
 		api_nh = &api->nexthops[*valid_nh_count];
 
+		zapi_nexthop_init(api_nh);
+
 		api_nh->srte_color = bgp_attr_get_color(info->attr);
 
 		if (bgp_debug_zebra(&api->prefix)) {
@@ -1524,7 +1526,7 @@ bgp_zebra_announce_actual(struct bgp_dest *dest, struct bgp_path_info *info,
 			  struct bgp *bgp)
 {
 	struct bgp_path_info *bpi_ultimate;
-	struct zapi_route api = { 0 };
+	struct zapi_route api;
 	unsigned int valid_nh_count = 0;
 	bool allow_recursion = false;
 	uint8_t distance;
@@ -1540,6 +1542,8 @@ bgp_zebra_announce_actual(struct bgp_dest *dest, struct bgp_path_info *info,
 				     true);
 		return ZCLIENT_SEND_SUCCESS;
 	}
+
+	zapi_route_init(&api);
 
 	/* Make Zebra API structure. */
 	api.vrf_id = bgp->vrf_id;
@@ -1731,7 +1735,7 @@ enum zclient_send_status bgp_zebra_withdraw_actual(struct bgp_dest *dest,
 		return ZCLIENT_SEND_SUCCESS;
 	}
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = bgp->vrf_id;
 	api.type = ZEBRA_ROUTE_BGP;
 	api.safi = table->safi;
@@ -4363,7 +4367,7 @@ void bgp_zebra_announce_default(struct bgp *bgp, struct nexthop *nh,
 	if (afi != AFI_IP && afi != AFI_IP6)
 		return;
 	p.family = afi2family(afi);
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = bgp->vrf_id;
 	api.type = ZEBRA_ROUTE_BGP;
 	api.safi = SAFI_UNICAST;
@@ -4373,6 +4377,8 @@ void bgp_zebra_announce_default(struct bgp *bgp, struct nexthop *nh,
 	SET_FLAG(api.message, ZAPI_MESSAGE_TABLEID);
 	SET_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP);
 	api_nh = &api.nexthops[0];
+
+	zapi_nexthop_init(api_nh);
 
 	api.distance = ZEBRA_EBGP_DISTANCE_DEFAULT;
 	SET_FLAG(api.message, ZAPI_MESSAGE_DISTANCE);

--- a/bgpd/rfapi/vnc_zebra.c
+++ b/bgpd/rfapi/vnc_zebra.c
@@ -362,7 +362,7 @@ static void vnc_zebra_route_msg(const struct prefix *p, unsigned int nhp_count,
 		return;
 	}
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = VRF_DEFAULT;
 	api.type = ZEBRA_ROUTE_VNC;
 	api.safi = SAFI_UNICAST;
@@ -374,6 +374,8 @@ static void vnc_zebra_route_msg(const struct prefix *p, unsigned int nhp_count,
 	for (i = 0; i < api.nexthop_num; i++) {
 
 		api_nh = &api.nexthops[i];
+		zapi_nexthop_init(api_nh);
+
 		api_nh->vrf_id = VRF_DEFAULT;
 		switch (p->family) {
 		case AF_INET:

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -195,7 +195,7 @@ void eigrp_zebra_route_add(struct eigrp *eigrp, struct prefix *p,
 	if (!eigrp_zclient->redist[AFI_IP][ZEBRA_ROUTE_EIGRP])
 		return;
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = eigrp->vrf_id;
 	api.type = ZEBRA_ROUTE_EIGRP;
 	api.safi = SAFI_UNICAST;
@@ -210,6 +210,8 @@ void eigrp_zebra_route_add(struct eigrp *eigrp, struct prefix *p,
 		if (count >= MULTIPATH_NUM)
 			break;
 		api_nh = &api.nexthops[count];
+		zapi_nexthop_init(api_nh);
+
 		api_nh->vrf_id = eigrp->vrf_id;
 		if (te->adv_router->src.s_addr) {
 			api_nh->gate.ipv4 = te->adv_router->src;
@@ -236,7 +238,7 @@ void eigrp_zebra_route_delete(struct eigrp *eigrp, struct prefix *p)
 	if (!eigrp_zclient->redist[AFI_IP][ZEBRA_ROUTE_EIGRP])
 		return;
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = eigrp->vrf_id;
 	api.type = ZEBRA_ROUTE_EIGRP;
 	api.safi = SAFI_UNICAST;

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -171,6 +171,9 @@ static int isis_zebra_add_nexthops(struct isis *isis, struct list *nexthops,
 		if (count >= MULTIPATH_NUM)
 			break;
 		api_nh = &zapi_nexthops[count];
+
+		zapi_nexthop_init(api_nh);
+
 		if (fabricd)
 			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);
 		api_nh->vrf_id = isis->vrf_id;
@@ -263,7 +266,7 @@ void isis_zebra_route_add_route(struct isis *isis, struct prefix *prefix,
 		return;
 	}
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = isis->vrf_id;
 	api.type = PROTO_TYPE;
 	api.safi = SAFI_UNICAST;

--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -98,7 +98,7 @@ void nhrp_route_announce(int add, enum nhrp_cache_type type,
 	if (nhrp_zclient->sock < 0)
 		return;
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.type = ZEBRA_ROUTE_NHRP;
 	api.safi = SAFI_UNICAST;
 	api.vrf_id = VRF_DEFAULT;
@@ -136,6 +136,8 @@ void nhrp_route_announce(int add, enum nhrp_cache_type type,
 	SET_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP);
 	api.nexthop_num = 1;
 	api_nh = &api.nexthops[0];
+	zapi_nexthop_init(api_nh);
+
 	api_nh->vrf_id = VRF_DEFAULT;
 
 	switch (api.prefix.family) {

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -339,6 +339,8 @@ void ospf6_route_zebra_copy_nexthops(struct ospf6_route *route,
 			if (i >= entries)
 				return;
 
+			zapi_nexthop_init(&nexthops[i]);
+
 			nexthops[i].vrf_id = vrf_id;
 			nexthops[i].type = nh->type;
 

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -451,7 +451,7 @@ static void ospf6_zebra_route_update(int type, struct ospf6_route *request,
 
 	dest = &request->prefix;
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = ospf6->vrf_id;
 	api.type = ZEBRA_ROUTE_OSPF6;
 	api.safi = SAFI_UNICAST;
@@ -545,7 +545,7 @@ void ospf6_zebra_add_discard(struct ospf6_route *request, struct ospf6 *ospf6)
 	}
 
 	if (!CHECK_FLAG(request->flag, OSPF6_ROUTE_BLACKHOLE_ADDED)) {
-		memset(&api, 0, sizeof(api));
+		zapi_route_init(&api);
 		api.vrf_id = ospf6->vrf_id;
 		api.type = ZEBRA_ROUTE_OSPF6;
 		api.safi = SAFI_UNICAST;
@@ -582,7 +582,7 @@ void ospf6_zebra_delete_discard(struct ospf6_route *request,
 	}
 
 	if (CHECK_FLAG(request->flag, OSPF6_ROUTE_BLACKHOLE_ADDED)) {
-		memset(&api, 0, sizeof(api));
+		zapi_route_init(&api);
 		api.vrf_id = ospf6->vrf_id;
 		api.type = ZEBRA_ROUTE_OSPF6;
 		api.safi = SAFI_UNICAST;

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -173,6 +173,8 @@ static void ospf_zebra_add_nexthop(struct ospf *ospf, struct ospf_path *path,
 	/* TI-LFA backup path label stack comes first, if present */
 	if (path->srni.backup_label_stack) {
 		api_nh_backup = &api->backup_nexthops[api->backup_nexthop_num];
+		zapi_nexthop_init(api_nh_backup);
+
 		api_nh_backup->vrf_id = ospf->vrf_id;
 
 		api_nh_backup->type = NEXTHOP_TYPE_IPV4;
@@ -189,6 +191,7 @@ static void ospf_zebra_add_nexthop(struct ospf *ospf, struct ospf_path *path,
 
 	/* And here comes the primary nexthop */
 	api_nh = &api->nexthops[api->nexthop_num];
+	zapi_nexthop_init(api_nh);
 #ifdef HAVE_NETLINK
 	if (path->unnumbered
 	    || (path->nexthop.s_addr != INADDR_ANY && path->ifindex != 0)) {
@@ -267,7 +270,7 @@ void ospf_zebra_add(struct ospf *ospf, struct prefix_ipv4 *p,
 		return;
 	}
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = ospf->vrf_id;
 	api.type = ZEBRA_ROUTE_OSPF;
 	api.instance = ospf->instance;
@@ -357,7 +360,7 @@ void ospf_zebra_delete(struct ospf *ospf, struct prefix_ipv4 *p,
 		return;
 	}
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = ospf->vrf_id;
 	api.type = ZEBRA_ROUTE_OSPF;
 	api.instance = ospf->instance;
@@ -382,7 +385,7 @@ void ospf_zebra_add_discard(struct ospf *ospf, struct prefix_ipv4 *p)
 		return;
 	}
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = ospf->vrf_id;
 	api.type = ZEBRA_ROUTE_OSPF;
 	api.instance = ospf->instance;
@@ -408,7 +411,7 @@ void ospf_zebra_delete_discard(struct ospf *ospf, struct prefix_ipv4 *p)
 		return;
 	}
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = ospf->vrf_id;
 	api.type = ZEBRA_ROUTE_OSPF;
 	api.instance = ospf->instance;

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -241,6 +241,8 @@ static void route_add_helper(struct zapi_route *api, struct nexthop_group nhg,
 	i = 0;
 	for (ALL_NEXTHOPS(nhg, nhop)) {
 		api_nh = &api->nexthops[i];
+		zapi_nexthop_init(api_nh);
+
 		api_nh->vrf_id = nhop->vrf_id;
 		api_nh->type = nhop->type;
 		api_nh->weight = nhop->weight;
@@ -284,7 +286,7 @@ void route_add(struct pbr_nexthop_group_cache *pnhgc, struct nexthop_group nhg,
 {
 	struct zapi_route api;
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 
 	DEBUGD(&pbr_dbg_zebra, "%s %pFX for Table: %d", __func__, &api.prefix, pnhgc->table_id);
 
@@ -331,7 +333,7 @@ void route_delete(struct pbr_nexthop_group_cache *pnhgc, afi_t afi)
 
 	DEBUGD(&pbr_dbg_zebra, "%s for Table: %d", __func__, pnhgc->table_id);
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = VRF_DEFAULT;
 	api.type = ZEBRA_ROUTE_PBR;
 	api.safi = SAFI_UNICAST;

--- a/ripd/rip_zebra.c
+++ b/ripd/rip_zebra.c
@@ -34,7 +34,7 @@ static void rip_zebra_ipv4_send(struct rip *rip, struct route_node *rp,
 	struct rip_info *rinfo = NULL;
 	uint32_t count = 0;
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = rip->vrf->vrf_id;
 	api.type = ZEBRA_ROUTE_RIP;
 	api.safi = SAFI_UNICAST;
@@ -44,6 +44,8 @@ static void rip_zebra_ipv4_send(struct rip *rip, struct route_node *rp,
 		if (count >= zebra_ecmp_count)
 			break;
 		api_nh = &api.nexthops[count];
+		zapi_nexthop_init(api_nh);
+
 		api_nh->vrf_id = rip->vrf->vrf_id;
 		api_nh->gate = rinfo->nh.gate;
 		api_nh->type = NEXTHOP_TYPE_IPV4;

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -33,7 +33,7 @@ static void ripng_zebra_ipv6_send(struct ripng *ripng, struct agg_node *rp,
 	uint32_t count = 0;
 	const struct prefix *p = agg_node_get_prefix(rp);
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = ripng->vrf->vrf_id;
 	api.type = ZEBRA_ROUTE_RIPNG;
 	api.safi = SAFI_UNICAST;
@@ -44,6 +44,8 @@ static void ripng_zebra_ipv6_send(struct ripng *ripng, struct agg_node *rp,
 		if (count >= zebra_ecmp_count)
 			break;
 		api_nh = &api.nexthops[count];
+		zapi_nexthop_init(api_nh);
+
 		api_nh->vrf_id = ripng->vrf->vrf_id;
 		api_nh->gate.ipv6 = rinfo->nexthop;
 		api_nh->ifindex = rinfo->ifindex;

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -239,7 +239,7 @@ static bool route_add(const struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
 	struct nexthop *nh;
 	int i = 0;
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = vrf_id;
 	api.type = ZEBRA_ROUTE_SHARP;
 	api.instance = instance;
@@ -308,7 +308,7 @@ static bool route_delete(struct prefix *p, vrf_id_t vrf_id, uint8_t instance)
 {
 	struct zapi_route api;
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = vrf_id;
 	api.type = ZEBRA_ROUTE_SHARP;
 	api.safi = SAFI_UNICAST;

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -421,7 +421,7 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
 	p = src_pp = NULL;
 	srcdest_rnode_prefixes(rn, &p, &src_pp);
 
-	memset(&api, 0, sizeof(api));
+	zapi_route_init(&api);
 	api.vrf_id = si->svrf->vrf->vrf_id;
 	api.type = ZEBRA_ROUTE_STATIC;
 	api.safi = si->safi;
@@ -458,6 +458,7 @@ extern void static_zebra_route_add(struct static_path *pn, bool install)
 		if (nh->path_down)
 			continue;
 
+		zapi_nexthop_init(api_nh);
 		api_nh->vrf_id = nh->nh_vrf_id;
 		if (nh->onlink)
 			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -517,8 +517,9 @@ int zsend_redistribute_route(int cmd, struct zserv *client, const struct route_n
 	uint16_t count = 0;
 	afi_t afi;
 
+	zapi_route_init(&api);
 	srcdest_rnode_prefixes(rn, &p, &src_p);
-	memset(&api, 0, sizeof(api));
+
 	api.vrf_id = re->vrf_id;
 	api.type = re->type;
 	api.safi = SAFI_UNICAST;
@@ -563,6 +564,8 @@ int zsend_redistribute_route(int cmd, struct zserv *client, const struct route_n
 			continue;
 
 		api_nh = &api.nexthops[count];
+		zapi_nexthop_init(api_nh);
+
 		api_nh->vrf_id = nexthop->vrf_id;
 		api_nh->type = nexthop->type;
 		api_nh->weight = nexthop->weight;


### PR DESCRIPTION
memset'ing the fairly large zapi_route struct can be expensive. reorganize the zapi_route struct so that the large fields/arrays are at the end of the struct, and then add an init function that initializes only a subset of the struct.
This PR replaces the raw "memset" in all daemons (I think).
