### PR TITLE
bgpd: remove the implicit EOR (keepalive message) for GR

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -898,8 +898,7 @@ void bgp_update_delay_end(struct bgp *bgp)
 	bgp->update_delay_over = 1;
 	bgp->established = 0;
 	bgp->restarted_peers = 0;
-	bgp->implicit_eors = 0;
-	bgp->explicit_eors = 0;
+	bgp->received_eors = 0;
 
 	frr_timestamp(3, bgp->update_delay_end_time,
 		      sizeof(bgp->update_delay_end_time));

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -71,7 +71,6 @@ extern int bgp_nlri_parse(struct peer *peer, struct attr *attr,
 			  struct bgp_nlri *nlri, bool mp_withdraw);
 
 extern void bgp_update_restarted_peers(struct peer *peer);
-extern void bgp_update_implicit_eors(struct peer *peer);
 extern void bgp_check_update_delay(struct bgp *peer);
 
 extern int bgp_packet_set_marker(struct stream *s, uint8_t type);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -596,8 +596,7 @@ struct bgp {
 	char update_delay_peers_resume_time[64];
 	uint32_t established;
 	uint32_t restarted_peers;
-	uint32_t implicit_eors;
-	uint32_t explicit_eors;
+	uint32_t received_eors;
 #define BGP_UPDATE_DELAY_DEFAULT 0
 
 	/* Reference bandwidth for BGP link-bandwidth. Used when


### PR DESCRIPTION
Treating the first keepalive message as an "implicit" EOR was a temporary hack before the EOR for GR was defined more than 20 years ago. The logic can cause GR to be prematurely terminated, and should have been removed a long time ago.