### PR TITLE
doc, tests: Add `--ignore-backtraces` command to pytest

### DIFF
--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -593,6 +593,25 @@ Here's an example of launching ``vtysh`` on routers ``rt1`` and ``rt2``.
 
    sudo -E pytest --vtysh=rt1,rt2 all-protocol-startup
 
+Ignoring Backtrace Detection
+""""""""""""""""""""""""""""
+
+By default, topotests automatically check for backtraces in daemon log files after
+each test execution. If backtraces are detected, the test will fail. However, in
+some scenarios you may want to disable this automatic backtrace detection.
+
+To disable backtrace detection during test execution, use the ``--ignore-backtraces``
+CLI option:
+
+.. code:: shell
+
+   sudo -E pytest --ignore-backtraces all-protocol-startup
+
+This option is useful when:
+- Running tests in environments where backtraces are expected or acceptable
+- Debugging specific issues where backtrace detection interferes with test execution
+- Running tests with known issues that produce backtraces but are not critical
+
 .. _debug_with_gdb:
 
 Debugging with GDB

--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -265,6 +265,12 @@ def pytest_addoption(parser):
         help="Spawn vtysh on all routers on test failure",
     )
 
+    parser.addoption(
+        "--ignore-backtraces",
+        action="store_true",
+        help="Ignore backtrace detection during test execution",
+    )
+
 
 def check_for_valgrind_memleaks():
     assert topotest.g_pytest_config.option.valgrind_memleaks
@@ -469,7 +475,8 @@ def pytest_runtest_call(item: pytest.Item) -> None:
     # Let the default pytest_runtest_call execute the test function
     yield
 
-    check_for_backtraces()
+    if not item.config.option.ignore_backtraces:
+        check_for_backtraces()
     check_for_core_dumps()
 
     # Check for leaks if requested


### PR DESCRIPTION
It is sometimes desirable to allow for backtraces to be ignored when running the pytests.  Add a feature to allow this to happen.