### PR TITLE
lib,zebra: replace VRF_GET_ID macro with a function

### DIFF
--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -108,27 +108,32 @@ extern const char *vrf_id_to_name(vrf_id_t vrf_id);
 
 #define VRF_LOGNAME(V) V ? V->name : "Unknown"
 
-#define VRF_GET_ID(V, NAME, USE_JSON)                                          \
-	do {                                                                   \
-		struct vrf *_vrf;                                              \
-		if (!(_vrf = vrf_lookup_by_name(NAME))) {                      \
-			if (USE_JSON) {                                        \
-				vty_out(vty, "{}\n");                          \
-			} else {                                               \
-				vty_out(vty, "%% VRF %s not found\n", NAME);   \
-			}                                                      \
-			return CMD_WARNING;                                    \
-		}                                                              \
-		if (_vrf->vrf_id == VRF_UNKNOWN) {                             \
-			if (USE_JSON) {                                        \
-				vty_out(vty, "{}\n");                          \
-			} else {                                               \
-				vty_out(vty, "%% VRF %s not active\n", NAME);  \
-			}                                                      \
-			return CMD_WARNING;                                    \
-		}                                                              \
-		(V) = _vrf->vrf_id;                                            \
-	} while (0)
+/* Utility for lookups in a cli/vty context */
+static inline bool vrf_get_id(struct vty *vty, vrf_id_t *pvrfid, const char *name,
+			      bool use_json)
+{
+	struct vrf *_vrf;
+
+	if (!(_vrf = vrf_lookup_by_name(name))) {
+		if (use_json)
+			vty_out(vty, "{}\n");
+		else
+			vty_out(vty, "%% VRF %s not found\n", name);
+
+		return false;
+	}
+	if (_vrf->vrf_id == VRF_UNKNOWN) {
+		if (use_json)
+			vty_out(vty, "{}\n");
+		else
+			vty_out(vty, "%% VRF %s not active\n", name);
+
+		return false;
+	}
+	*pvrfid = _vrf->vrf_id;
+
+	return true;
+}
 
 /*
  * Check whether the VRF is enabled.

--- a/zebra/router-id.c
+++ b/zebra/router-id.c
@@ -258,7 +258,8 @@ DEFUN (show_ip_router_id,
 	is_ipv6 = argv_find(argv, argc, "ipv6", &idx);
 
 	if (argv_find(argv, argc, "NAME", &idx)) {
-		VRF_GET_ID(vrf_id, argv[idx]->arg, false);
+		if (!vrf_get_id(vty, &vrf_id, argv[idx]->arg, false))
+			return CMD_WARNING;
 		vrf_name = argv[idx]->arg;
 	}
 

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -179,8 +179,10 @@ static int show_proto_rm(struct vty *vty, int af_type, const char *vrf_all,
 	} else {
 		vrf_id_t vrf_id = VRF_DEFAULT;
 
-		if (vrf_name)
-			VRF_GET_ID(vrf_id, vrf_name, false);
+		if (vrf_name) {
+			if (!vrf_get_id(vty, &vrf_id, vrf_name, false))
+				return CMD_WARNING;
+		}
 
 		zvrf = zebra_vrf_lookup_by_id(vrf_id);
 		if (!zvrf)
@@ -202,8 +204,10 @@ static int show_nht_rm(struct vty *vty, int af_type, const char *vrf_all,
 	json_object *json_vrfs = NULL;
 
 	/* Check for single vrf name. Note that this macro returns on error. */
-	if (vrf_all == NULL && vrf_name != NULL)
-		VRF_GET_ID(vrf_id, vrf_name, false);
+	if (vrf_all == NULL && vrf_name != NULL) {
+		if (!vrf_get_id(vty, &vrf_id, vrf_name, false))
+			return CMD_WARNING;
+	}
 
 	if (use_json) {
 		json = json_object_new_object();

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1013,8 +1013,10 @@ DEFPY (show_ip_nht,
 
 		return CMD_SUCCESS;
 	}
-	if (vrf_name)
-		VRF_GET_ID(vrf_id, vrf_name, false);
+	if (vrf_name) {
+		if (!vrf_get_id(vty, &vrf_id, vrf_name, false))
+			return CMD_WARNING;
+	}
 
 	memset(&prefix, 0, sizeof(prefix));
 	if (addr) {
@@ -1700,8 +1702,10 @@ DEFPY (show_route,
 	} else {
 		vrf_id_t vrf_id = VRF_DEFAULT;
 
-		if (vrf_name)
-			VRF_GET_ID(vrf_id, vrf_name, !!json);
+		if (vrf_name) {
+			if (!vrf_get_id(vty, &vrf_id, vrf_name, !!json))
+				return CMD_WARNING;
+		}
 		vrf = vrf_lookup_by_id(vrf_id);
 		if (!vrf)
 			return CMD_SUCCESS;
@@ -1869,8 +1873,10 @@ DEFPY (show_route_detail,
 	} else {
 		vrf_id_t vrf_id = VRF_DEFAULT;
 
-		if (vrf_name)
-			VRF_GET_ID(vrf_id, vrf_name, false);
+		if (vrf_name) {
+			if (!vrf_get_id(vty, &vrf_id, vrf_name, false))
+				return CMD_WARNING;
+		}
 
 		if (table_id)
 			table = zebra_vrf_lookup_table_with_table_id(afi, safi, vrf_id, table_id);
@@ -1969,8 +1975,10 @@ DEFPY (show_route_summary,
 	} else {
 		vrf_id_t vrf_id = VRF_DEFAULT;
 
-		if (vrf_name)
-			VRF_GET_ID(vrf_id, vrf_name, false);
+		if (vrf_name) {
+			if (!vrf_get_id(vty, &vrf_id, vrf_name, false))
+				return CMD_WARNING;
+		}
 
 		if (table_id == 0)
 			table = zebra_vrf_table(afi, safi, vrf_id);
@@ -2022,8 +2030,10 @@ DEFPY_HIDDEN (show_route_zebra_dump,
 	} else {
 		vrf_id_t vrf_id = VRF_DEFAULT;
 
-		if (vrf_name)
-			VRF_GET_ID(vrf_id, vrf_name, false);
+		if (vrf_name) {
+			if (!vrf_get_id(vty, &vrf_id, vrf_name, false))
+				return CMD_WARNING;
+		}
 
 		table = zebra_vrf_table(afi, safi, vrf_id);
 


### PR DESCRIPTION
Remove a macro and replace it with a simple function. The macro returned from the calling function in error paths; since the application code wasn't involved, it wasn't able to clean up memory allocations. Replace the macro with a simple function that returns to the application code; the application can then handle errors itself.
