### PR TITLE
bgpd: Convert bmp path_info tracking from hash to rbtree

### DIFF
--- a/bgpd/bgp_bmp.h
+++ b/bgpd/bgp_bmp.h
@@ -43,7 +43,7 @@
  * instead moved to the end of the queue.  This ensures that the queue size is
  * bounded by the BGP table size.
  *
- * bmp_qlist is the queue itself while bmp_qhash is used to efficiently check
+ * bmp_qlist is the queue itself while bmp_rbtree is used to efficiently check
  * whether a tuple is already on the list.  The queue is maintained per
  * bmp_target.
  *
@@ -54,11 +54,11 @@
  */
 
 PREDECL_DLIST(bmp_qlist);
-PREDECL_HASH(bmp_qhash);
+PREDECL_RBTREE_UNIQ(bmp_rbtree);
 
 struct bmp_queue_entry {
 	struct bmp_qlist_item bli;
-	struct bmp_qhash_item bhi;
+	struct bmp_rbtree_item bhi;
 
 	struct prefix p;
 	uint64_t peerid;
@@ -237,10 +237,10 @@ struct bmp_targets {
 	struct event *t_stats;
 	struct bmp_session_head sessions;
 
-	struct bmp_qhash_head updhash;
+	struct bmp_rbtree_head updhash;
 	struct bmp_qlist_head updlist;
 
-	struct bmp_qhash_head locupdhash;
+	struct bmp_rbtree_head locupdhash;
 	struct bmp_qlist_head locupdlist;
 
 	struct bmp_imported_bgps_head imported_bgps;


### PR DESCRIPTION
The current implementation has this cycle:

a) As path_info comes in, bmp_process is called, this generates an item on a hash.  This typesafe hash was automatically growing as more path info's were received.
b) This generation of items on the hash eventually causes pullwr_run to happen, which pulls items off the hash, encodes them and sends them to a peer.  This causes the hash to automatically shrink.

Now imagine a scenario where you have a large number of paths being brought in upon initial startup.  Run time starts to be dominated by the hash_grow and hash_shrink functions because it involves reallocs and memory manipulation:

+   99.17%     0.00%  bgpd     bgpd               [.] _start
+   99.17%     0.00%  bgpd     libc.so.6          [.] __libc_start_main
+   99.17%     0.00%  bgpd     libc.so.6          [.] 0x00007f0188f2d249
+   99.17%     0.00%  bgpd     bgpd               [.] main
+   99.17%     0.00%  bgpd     libfrr.so.0.0.0    [.] frr_run
+   99.10%     0.01%  bgpd     libfrr.so.0.0.0    [.] event_call
+   64.01%     0.01%  bgpd     bgpd               [.] bgp_process_packet
+   63.95%     0.01%  bgpd     bgpd               [.] bgp_update_receive
+   63.92%     0.01%  bgpd     bgpd               [.] bgp_nlri_parse_ip
+   63.90%     0.04%  bgpd     bgpd               [.] bgp_update
+   63.62%     0.00%  bgpd     bgpd               [.] hook_call_bgp_process (inlined)
+   63.62%     0.00%  bgpd     bgpd_bmp.so        [.] bmp_process
+   63.61%     0.00%  bgpd     bgpd_bmp.so        [.] bmp_process_one (inlined)
+   63.61%     0.00%  bgpd     bgpd_bmp.so        [.] bmp_qhash_add (inlined)
+   63.59%    57.66%  bgpd     libfrr.so.0.0.0    [.] typesafe_hash_grow
+   34.63%     0.00%  bgpd     libfrr.so.0.0.0    [.] pullwr_run
+   34.39%     0.01%  bgpd     bgpd_bmp.so        [.] bmp_wrfill
+   34.39%     0.00%  bgpd     bgpd_bmp.so        [.] bmp_wrqueue (inlined)
+   34.17%     0.00%  bgpd     bgpd_bmp.so        [.] bmp_pull (inlined)
+   34.17%     0.00%  bgpd     bgpd_bmp.so        [.] bmp_pull_from_queue
+   34.17%     0.00%  bgpd     bgpd_bmp.so        [.] bmp_qhash_del (inlined)
+   34.17%    32.71%  bgpd     libfrr.so.0.0.0    [.] typesafe_hash_shrink

As you can see run time is spending 57.66 + 32.71% of the time in grow/shrink cycles as each side of the event system gets to run.

Let's just convert the system to use a RB Tree to avoid this problem.