### PR TITLE
bgpd: do not change last_reset when a peer is un-shut

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -5239,10 +5239,8 @@ void bgp_shutdown_disable(struct bgp *bgp)
 	/* clear the BGP instances shutdown flag */
 	UNSET_FLAG(bgp->flags, BGP_FLAG_SHUTDOWN);
 
-	for (ALL_LIST_ELEMENTS_RO(bgp->peer, node, peer)) {
+	for (ALL_LIST_ELEMENTS_RO(bgp->peer, node, peer))
 		bgp_timer_set(peer->connection);
-		peer->last_reset = PEER_DOWN_WAITING_OPEN;
-	}
 }
 
 /* Change specified peer flag. */
@@ -5314,9 +5312,8 @@ static int peer_flag_modify(struct peer *peer, uint64_t flag, int set)
 				bgp_zebra_terminate_radv(peer->bgp, peer);
 		}
 
-		if (flag == PEER_FLAG_SHUTDOWN)
-			peer->last_reset = set ? PEER_DOWN_USER_SHUTDOWN
-					       : PEER_DOWN_WAITING_OPEN;
+		if ((flag == PEER_FLAG_SHUTDOWN) && set)
+			peer->last_reset = PEER_DOWN_USER_SHUTDOWN;
 
 		/* Execute flag action on peer. */
 		if (action.type == peer_change_reset)
@@ -5353,9 +5350,8 @@ static int peer_flag_modify(struct peer *peer, uint64_t flag, int set)
 			set ? bgp_zebra_initiate_radv(member->bgp, member)
 			    : bgp_zebra_terminate_radv(member->bgp, member);
 
-		if (flag == PEER_FLAG_SHUTDOWN)
-			member->last_reset = set ? PEER_DOWN_USER_SHUTDOWN
-						 : PEER_DOWN_WAITING_OPEN;
+		if ((flag == PEER_FLAG_SHUTDOWN) && set)
+			member->last_reset = PEER_DOWN_USER_SHUTDOWN;
 
 		/* Execute flag action on peer-group member. */
 		if (action.type == peer_change_reset)


### PR DESCRIPTION
When a peer is un-shut, the last_reset reason should remain as PEER_DOWN_USER_SHUTDOWN, and not changed.