### PR TITLE
bgpd: set last_reset for the nht change only in specific cases

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -2571,10 +2571,11 @@ void bgp_fsm_nht_update(struct peer_connection *connection, struct peer *peer,
 	case OpenSent:
 	case OpenConfirm:
 	case Established:
-		if (!has_valid_nexthops
-		    && (peer->gtsm_hops == BGP_GTSM_HOPS_CONNECTED
-			|| peer->bgp->fast_convergence))
+		if (!has_valid_nexthops &&
+		    (peer->gtsm_hops == BGP_GTSM_HOPS_CONNECTED || peer->bgp->fast_convergence)) {
 			BGP_EVENT_ADD(connection, TCP_fatal_error);
+			peer->last_reset = PEER_DOWN_WAITING_NHT;
+		}
 		break;
 	case Clearing:
 	case Deleted:

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -1510,14 +1510,10 @@ void evaluate_paths(struct bgp_nexthop_cache *bnc)
 			/*
 			 * Peering cannot occur across a blackhole nexthop
 			 */
-			if (bnc->nexthop_num == 1 && bnc->nexthop
-			    && bnc->nexthop->type == NEXTHOP_TYPE_BLACKHOLE) {
-				peer->last_reset = PEER_DOWN_WAITING_NHT;
+			if (bnc->nexthop_num == 1 && bnc->nexthop &&
+			    bnc->nexthop->type == NEXTHOP_TYPE_BLACKHOLE)
 				valid_nexthops = 0;
-			} else
-				peer->last_reset = PEER_DOWN_WAITING_OPEN;
-		} else
-			peer->last_reset = PEER_DOWN_WAITING_NHT;
+		}
 
 		if (!CHECK_FLAG(bnc->flags, BGP_NEXTHOP_PEER_NOTIFIED)) {
 			if (BGP_DEBUG(nht, NHT))


### PR DESCRIPTION
When a nht becomes unresolved, a peer being tracked by the nht is brought down only under certain specific conditions. Record the last_reset accordingly.