### PR TITLE
bgpd: don't use stale 'evpn' pointer in bgp_update()

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5324,6 +5324,9 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 
 	attr_new = bgp_attr_intern(&new_attr);
 
+	/* Use new evpn overlay pointer */
+	evpn = bgp_attr_get_evpn_overlay(attr_new);
+
 	/* If the update is implicit withdraw. */
 	if (pi) {
 		pi->uptime = monotime(NULL);


### PR DESCRIPTION
The pointer 'evpn' in bgp_update() can be stale after creating/ interning attrs into attr_new; use the value from the new attr object.
Turning on debug bgp updates with asan on exposed this as a use-after-free.
