### PR TITLE
Allow notify callback on non-presence container

### DIFF
--- a/mgmtd/mgmt_testc.c
+++ b/mgmtd/mgmt_testc.c
@@ -86,7 +86,7 @@ static const struct frr_yang_module_info frr_if_info = {
 	.ignore_cfg_cbs = true,
 	.nodes = {
 		{
-			.xpath = "/frr-interface:lib/interface",
+			.xpath = "/frr-interface:lib",
 			.cbs.notify = async_notification,
 		},
 		{

--- a/tests/topotests/mgmt_notif/test_ds_notify.py
+++ b/tests/topotests/mgmt_notif/test_ds_notify.py
@@ -79,11 +79,6 @@ def test_frontend_datastore_notification(tgen):
 
     check_kernel_32(r1, "11.11.11.11", 1, "")
 
-    rc, _, _ = r1.cmd_status(FE_CLIENT + " --help")
-
-    if rc:
-        pytest.skip("No protoc or present cannot run test")
-
     # Start our FE client in the background
     p = r1.popen(
         [
@@ -225,10 +220,6 @@ def test_datastore_backend_filters(tgen):
     r1 = tgen.gears["r1"].net
 
     check_kernel_32(r1, "11.11.11.11", 1, "")
-
-    rc, _, _ = r1.cmd_status(FE_CLIENT + " --help")
-    if rc:
-        pytest.skip("No protoc or present cannot run test")
 
     # Start our FE client in the background
     p = r1.popen(


### PR DESCRIPTION
Previously attaching a notify handler to a covering container that was non-presence would not be noticed due to an apparent optimization in the nb_node parent chain which skips over NP container nodes in branches. Use the libyang parent pointer chain to avoid this problem.

Update test client so topotest tests this bug and fix.