### PR TITLE
tests: fix several topotests for bgp GR

### DIFF
--- a/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-4.py
+++ b/tests/topotests/bgp_gr_functionality_topo1/test_bgp_gr_functionality_topo1-4.py
@@ -1338,7 +1338,14 @@ def test_BGP_GR_TC_49_p1(request):
     step("Configure R1 as GR restarting node in global level")
 
     input_dict = {
-        "r1": {"bgp": {"graceful-restart": {"graceful-restart": True}}},
+        "r1": {
+            "bgp": {
+                "graceful-restart": {
+                    "graceful-restart": True,
+                    "preserve-fw-state": True,
+                }
+            }
+        },
         "r2": {"bgp": {"graceful-restart": {"graceful-restart-helper": True}}},
     }
 
@@ -1706,7 +1713,9 @@ def test_BGP_GR_TC_53_p1(request):
     step("Configure R1 as GR restarting node in global level")
 
     input_dict = {
-        "r1": {"graceful-restart": {"graceful-restart": True}},
+        "r1": {
+            "graceful-restart": {"graceful-restart": True, "preserve-fw-state": True}
+        },
         "r2": {"graceful-restart": {"graceful-restart-helper": True}},
     }
 
@@ -1714,6 +1723,7 @@ def test_BGP_GR_TC_53_p1(request):
         """
         configure terminal
         bgp graceful-restart
+        bgp graceful-restart preserve-fw-state
         !
         """
     )

--- a/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-3.py
+++ b/tests/topotests/bgp_gr_functionality_topo2/test_bgp_gr_functionality_topo2-3.py
@@ -957,6 +957,9 @@ def test_BGP_GR_15_p2(request):
     input_dict = {
         "r1": {
             "bgp": {
+                "graceful-restart": {
+                    "preserve-fw-state": True,
+                },
                 "address_family": {
                     "ipv4": {
                         "unicast": {
@@ -1023,6 +1026,9 @@ def test_BGP_GR_15_p2(request):
     input_dict = {
         "r1": {
             "bgp": {
+                "graceful-restart": {
+                    "preserve-fw-state": True,
+                },
                 "address_family": {
                     "ipv4": {
                         "unicast": {


### PR DESCRIPTION
Fix several topotests for bgp gr: test_BGP_GR_TC_49_p1 and
test_BGP_GR_TC_53_p1 in topo1-4.py, and test_BGP_GR_15_p2 in
topo2-3.py.
    
The "preserve-fw-state" needs to be set on R1 in order for R2 to
retain the routes from R1 when R1 restarts.