### PR TITLE
zebra: remove kernel route on last address deletion

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -972,6 +972,18 @@ struct nbr_connected *nbr_connected_check(struct interface *ifp,
 	return NULL;
 }
 
+/* Return true if there is at least one connected address in the given family  */
+bool if_has_connected_with_family(struct interface *ifp, int family)
+{
+	struct connected *connected;
+
+	frr_each (if_connected, ifp->connected, connected)
+		if (connected->address->family == family)
+			return true;
+
+	return false;
+}
+
 /* count the number of connected addresses that are in the given family */
 unsigned int connected_count_by_family(struct interface *ifp, int family)
 {

--- a/lib/if.h
+++ b/lib/if.h
@@ -630,6 +630,7 @@ extern struct connected *connected_lookup_prefix(struct interface *ifp,
 						 const struct prefix *p);
 extern struct connected *connected_lookup_prefix_exact(struct interface *ifp,
 						       const struct prefix *p);
+extern bool if_has_connected_with_family(struct interface *ifp, int family);
 extern unsigned int connected_count_by_family(struct interface *ifp, int family);
 extern struct nbr_connected *nbr_connected_new(void);
 extern void nbr_connected_free(struct nbr_connected *connected);

--- a/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
+++ b/tests/topotests/zebra_multiple_connected/test_zebra_multiple_connected.py
@@ -336,6 +336,182 @@ def test_zebra_mtu_single_local_route_per_address():
     assert result is None, "Local route check failed: {}".format(result)
 
 
+def test_zebra_kernel_last_ipv4_address_deleted():
+    "Test that when last IPv4 address is deleted on interface, kernel routes are deleted as well"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+
+    ifname = "dummy0"
+
+    def _get_routes_dict(val):
+        return {
+            "203.0.113.0/24": val,
+            "10.0.170.0/24": val,
+        }
+
+    def _assert_kernel_routes(router, msg, val):
+        routes = topotest.ip4_route(router)
+        expected = _get_routes_dict(val)
+        cmp = topotest.json_cmp(routes, expected)
+        assert cmp is None, msg.format(cmp)
+
+    def _assert_kernel_routes_up(router, msg):
+        _assert_kernel_routes(router, msg, {})
+
+    def _assert_kernel_routes_down(router, msg):
+        _assert_kernel_routes(router, msg, None)
+
+    def _assert_zebra_kernel_routes(router, msg, val):
+        expected = _get_routes_dict(val)
+        test_func = partial(
+            topotest.router_json_cmp, router, "show ip route json", expected
+        )
+        result, _ = topotest.run_and_expect(test_func, None, count=20, wait=1)
+        assert result, msg.format(_)
+
+    def _assert_zebra_kernel_routes_up(router, msg):
+        _assert_zebra_kernel_routes(router, msg, [])
+
+    def _assert_zebra_kernel_routes_down(router, msg):
+        _assert_zebra_kernel_routes(router, msg, None)
+
+    # Prepare scene: create dummy interface
+    # add two addresses, two routes
+    router.run(f"ip link add {ifname} type dummy")
+    router.run(f"ip link set {ifname} up")
+    router.run(f"ip -4 addr add 192.168.0.2/24 dev {ifname}")
+    router.run(f"ip -4 addr add 192.168.100.7/24 dev {ifname}")
+    router.run(f"ip -4 route add 203.0.113.0/24 via 192.168.0.1")
+    router.run(f"ip -4 route add 10.0.170.0/24 dev {ifname}")
+
+    _assert_kernel_routes_up(
+        router, "Unexpected kernel behaviour: routes should have been added:\n{}"
+    )
+    _assert_zebra_kernel_routes_up(router, "Expected zebra to add kernel routes:\n{}")
+
+    # Delete one of two addresses, nothing should change
+    router.run(f"ip -4 addr del 192.168.0.2/24 dev {ifname}")
+
+    _assert_kernel_routes_up(
+        router,
+        "Unexpected kernel behaviour: routes should have been unchanged after not last address deletion:\n{}",
+    )
+    _assert_zebra_kernel_routes_up(
+        router,
+        "Expected zebra not to change kernel routes after not last address deletion:\n{}",
+    )
+
+    # Delete last address, all routes should be gone
+    router.run(f"ip -4 addr del 192.168.100.7/24 dev {ifname}")
+    _assert_kernel_routes_down(
+        router,
+        "Unexpected kernel behaviour: routes should have been deleted after last address deletion:\n{}",
+    )
+    _assert_zebra_kernel_routes_down(
+        router,
+        "Expected zebra to delete kernel routes after last address deletion:\n{}",
+    )
+
+
+def test_zebra_kernel_last_ipv6_address_deleted():
+    "Test that both kernel and FRR don't delete route when last address is deleted for IPv6"
+
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+
+    ifname = "dummy0"
+
+    def _get_routes_dict(val):
+        return {
+            "2001:db8:c::/64": val,
+            "2001:db8:d::/64": val,
+        }
+
+    def _assert_kernel_routes(router, msg, val):
+        routes = topotest.ip6_route(router)
+        expected = _get_routes_dict(val)
+        cmp = topotest.json_cmp(routes, expected)
+        assert cmp is None, msg.format(cmp)
+
+    def _assert_kernel_routes_up(router, msg):
+        _assert_kernel_routes(router, msg, {})
+
+    def _assert_kernel_routes_down(router, msg):
+        _assert_kernel_routes(router, msg, None)
+
+    def _assert_zebra_kernel_routes(router, msg, val):
+        expected = _get_routes_dict(val)
+        test_func = partial(
+            topotest.router_json_cmp, router, "show ipv6 route json", expected
+        )
+        result, _ = topotest.run_and_expect(test_func, None, count=20, wait=1)
+        assert result, msg.format(_)
+
+    def _assert_zebra_kernel_routes_up(router, msg):
+        _assert_zebra_kernel_routes(router, msg, [])
+
+    def _assert_zebra_kernel_routes_down(router, msg):
+        _assert_zebra_kernel_routes(router, msg, None)
+
+    # Prepare scene: create dummy interface
+    # add two addresses, two routes
+    router.run(f"ip link add {ifname} type dummy")
+    router.run(f"ip link set {ifname} up")
+    # clear scope link address
+    router.run(f"ip -6 addr flush dev {ifname}")
+    router.run(f"ip -6 addr add 2001:db8:a::2/64 dev {ifname}")
+    router.run(f"ip -6 addr add 2001:db8:b::7/64 dev {ifname}")
+    router.run(f"ip -6 route add 2001:db8:c::/64 via 2001:db8:a::1")
+    router.run(f"ip -6 route add 2001:db8:d::/64 dev {ifname}")
+
+    _assert_kernel_routes_up(
+        router, "Unexpected kernel behaviour: routes should have been added:\n{}"
+    )
+    _assert_zebra_kernel_routes_up(router, "Expected zebra to add kernel routes:\n{}")
+
+    # Delete one of two addresses, nothing should change
+    router.run(f"ip -6 addr del 2001:db8:a::2/64 dev {ifname}")
+
+    _assert_kernel_routes_up(
+        router,
+        "Unexpected kernel behaviour: routes should have been unchanged after first IPv6 address deletion:\n{}",
+    )
+    _assert_zebra_kernel_routes_up(
+        router,
+        "Expected zebra not to change kernel routes after first IPv6 address deletion:\n{}",
+    )
+
+    # Delete last address, but no route changes for IPv6
+    router.run(f"ip -6 addr del 2001:db8:b::7/64 dev {ifname}")
+    _assert_kernel_routes_up(
+        router,
+        "Unexpected kernel behaviour: routes should NOT have been deleted after last IPv6 address deletion:\n{}",
+    )
+    _assert_zebra_kernel_routes_up(
+        router,
+        "Expected zebra NOT to delete kernel routes after last IPv6 address deletion:\n{}",
+    )
+
+    # Delete IPv6 routes manually:
+    router.run(f"ip -6 route del 2001:db8:c::/64 via 2001:db8:a::1")
+    router.run(f"ip -6 route del 2001:db8:d::/64 dev {ifname}")
+    _assert_kernel_routes_down(
+        router,
+        "Unexpected kernel behaviour: routes should have been deleted:\n{}",
+    )
+    _assert_zebra_kernel_routes_down(
+        router,
+        "Expected zebra to delete kernel routes after manual IPv6 routes deletion:\n{}",
+    )
+
+
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]
     sys.exit(pytest.main(args))

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1345,11 +1345,13 @@ static void zebra_if_addr_update_ctx(struct zebra_dplane_ctx *ctx,
 	}
 
 	/*
-	 * Linux kernel does not send route delete on interface down/addr del
+	 * Linux kernel does not send route delete on interface down/IPv4 last addr del
 	 * so we have to re-process routes it owns (i.e. kernel routes)
+	 * See rib_update_handle_kernel_route_down_possibility for more details
 	 */
-	if (op != DPLANE_OP_INTF_ADDR_ADD)
-		rib_update(RIB_UPDATE_KERNEL);
+	if (op != DPLANE_OP_INTF_ADDR_ADD && addr->family == AF_INET &&
+	    !if_has_connected_with_family(ifp, AF_INET))
+		rib_update(RIB_UPDATE_KERNEL_LAST_IPV4_ADDRESS_DELETED);
 }
 
 static void zebra_if_update_ctx(struct zebra_dplane_ctx *ctx,

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -344,6 +344,7 @@ enum rib_update_event {
 	RIB_UPDATE_KERNEL,
 	RIB_UPDATE_RMAP_CHANGE,
 	RIB_UPDATE_OTHER,
+	RIB_UPDATE_KERNEL_LAST_IPV4_ADDRESS_DELETED,
 	RIB_UPDATE_MAX
 };
 void rib_update_finish(void);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -4514,6 +4514,9 @@ static const char *rib_update_event2str(enum rib_update_event event)
 	case RIB_UPDATE_OTHER:
 		ret = "RIB_UPDATE_OTHER";
 		break;
+	case RIB_UPDATE_KERNEL_LAST_IPV4_ADDRESS_DELETED:
+		ret = "RIB_UPDATE_KERNEL_LAST_IPV4_ADDRESS_DELETED";
+		break;
 	case RIB_UPDATE_MAX:
 		break;
 	}
@@ -4524,7 +4527,7 @@ static const char *rib_update_event2str(enum rib_update_event event)
 /*
  * We now keep kernel routes, but we don't have any
  * trigger events for them when they are implicitly
- * deleted.  Since we are already walking the
+ * deleted. Since we are already walking the
  * entire table on a down event let's look at
  * the few kernel routes we may have
  */
@@ -4536,7 +4539,7 @@ rib_update_handle_kernel_route_down_possibility(struct route_node *rn,
 	bool alive = false;
 
 	for (ALL_NEXTHOPS(re->nhe->nhg, nexthop)) {
-		if (!nexthop->ifindex) {
+		if (!nexthop->ifindex || nexthop->type == NEXTHOP_TYPE_BLACKHOLE) {
 			/* blackhole nexthops have no interfaces */
 			alive = true;
 			break;
@@ -4545,10 +4548,38 @@ rib_update_handle_kernel_route_down_possibility(struct route_node *rn,
 		struct interface *ifp = if_lookup_by_index(nexthop->ifindex,
 							   nexthop->vrf_id);
 
-		if ((ifp && if_is_up(ifp)) || nexthop->type == NEXTHOP_TYPE_BLACKHOLE) {
+		if (!ifp || !if_is_up(ifp)) {
+			/* interface is not up, not alive */
+			continue;
+		}
+
+		/*
+		 * Kernel deletes IPv4 routes from interface when last IPv4 address is deleted
+		 * It is not important whether nexthop is reachable after address
+		 * is deleted - route is deleted only after last address deletion.
+		 *
+		 * See net/ipv4/fib_frontend.c fib_inetaddr_event,
+		 * net/ipv4/fib_semantics.c fib_sync_down_dev
+		 *
+		 * IPv6 has no such behaviour: routes are intact on last address deletion.
+		 */
+
+		/* If not IPv4, set alive
+		 * Check rn->p.family: for nexthop->type=NEXTHOP_TYPE_IFINDEX it
+		 * depends on destination only
+		 */
+		if (rn->p.family != AF_INET) {
 			alive = true;
 			break;
 		}
+
+		/* Check if there are any IPv4 addresses connected, if yes - set alive */
+		if (if_has_connected_with_family(ifp, AF_INET)) {
+			alive = true;
+			break;
+		}
+
+		/* Otherwise kernel deletes the route */
 	}
 
 	if (!alive) {
@@ -4573,8 +4604,9 @@ static void rib_update_route_node(struct route_node *rn, int type,
 	bool re_changed = false;
 
 	RNODE_FOREACH_RE_SAFE (rn, re, next) {
-		if (event == RIB_UPDATE_INTERFACE_DOWN && type == re->type &&
-		    type == ZEBRA_ROUTE_KERNEL)
+		if ((event == RIB_UPDATE_INTERFACE_DOWN ||
+		     event == RIB_UPDATE_KERNEL_LAST_IPV4_ADDRESS_DELETED) &&
+		    type == re->type && type == ZEBRA_ROUTE_KERNEL)
 			rib_update_handle_kernel_route_down_possibility(rn, re);
 		else if (type == ZEBRA_ROUTE_ALL || type == re->type) {
 			SET_FLAG(re->status, ROUTE_ENTRY_CHANGED);
@@ -4617,17 +4649,18 @@ void rib_update_table(struct route_table *table, enum rib_update_event event,
 		 * If we are looking at a route node and the node
 		 * has already been queued  we don't
 		 * need to queue it up again, unless it is
-		 * an interface down event as that we need
-		 * to process this no matter what.
+		 * an interface down event or last address down event
+		 * as that we need
+		 * to process these no matter what.
 		 */
-		if (rn->info &&
-		    CHECK_FLAG(rib_dest_from_rnode(rn)->flags,
-			       RIB_ROUTE_ANY_QUEUED) &&
-		    event != RIB_UPDATE_INTERFACE_DOWN)
+		if (rn->info && CHECK_FLAG(rib_dest_from_rnode(rn)->flags, RIB_ROUTE_ANY_QUEUED) &&
+		    event != RIB_UPDATE_INTERFACE_DOWN &&
+		    event != RIB_UPDATE_KERNEL_LAST_IPV4_ADDRESS_DELETED)
 			continue;
 
 		switch (event) {
 		case RIB_UPDATE_INTERFACE_DOWN:
+		case RIB_UPDATE_KERNEL_LAST_IPV4_ADDRESS_DELETED:
 		case RIB_UPDATE_KERNEL:
 			rib_update_route_node(rn, ZEBRA_ROUTE_KERNEL, event);
 			break;


### PR DESCRIPTION
Fixes #13561

Linux kernel deletes IPv4 routes when last interface IPv4 address is deleted, but intentionally doesn't send RTM_DELROUTE in this case.

FRR has function rib_update_handle_kernel_route_down_possibility that handles setting interface down, but not removal of last address.

To fix the situation:

* Add `RIB_UPDATE_KERNEL_LAST_ADDRESS_DELETED` to enum rib_update_event
* In `zebra_if_addr_update_ctx` make more specific check that last address is deleted and trigger `RIB_UPDATE_KERNEL_LAST_ADDRESS_DELETED` instead of `RIB_UPDATE_KERNEL` in this case. If it was not last address, don't emit any RIB_UPDATE.
* Call `rib_update_handle_kernel_route_down_possibility` not only for event `RIB_UPDATE_INTERFACE_DOWN`, but also for `RIB_UPDATE_KERNEL_LAST_ADDRESS_DELETED`.
* Change `rib_update_handle_kernel_route_down_possibility` not to consider IPv4 route alive when interface is up, but there are no IPv4 addresses left.
  
Relevant kernel code:

* net/ipv4/fib_frontend.c fib_inetaddr_event
* net/ipv4/fib_semantics.c fib_sync_down_dev

Comment from kernel networking author that RTM_DELROUTE isn't sent intentionally:

> Routing applications are expected to know that when an interface or address goes away the related routes disappear as well.

> This is done as an optimization to avoid sending millions of netlink messages for large scale routers. It has always been this way since the first versions of netlink on Linux and will not change since it would break applications.

> (Stephen Hemminger)

https://bugzilla.kernel.org/show_bug.cgi?id=207089

### test

Also added  test_zebra_kernel_last_ipv4_address_deleted to zebra_multiple_connected/test_zebra_multiple_connected.py with basic flow:

```bash
ip -4 addr flush dev {ifname}
ip -4 addr add 192.168.0.2/24 dev {ifname}
ip -4 route add default via 192.168.0.1
ip -4 addr add 192.168.100.7/24 dev {ifname}
ip -4 route add 10.0.170.3 dev {ifname}
```

Check there are `default` and `10.0.170.3` routes.

```bash
ip -4 addr del 192.168.0.2/24 dev {ifname}
```

Check there are still `default` and `10.0.170.3` routes.

```bash
ip -4 addr del 192.168.100.7/24 dev {ifname}
```

Check there are no `default` and `10.0.170.3` routes.

In each check make sure kernel routes are as expected (using topotest.ip4_route) and zebra routes are as expected (using `show ip route json`).