### PR TITLE
bgpd: fix use-after-free in bgp_update()

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5232,6 +5232,11 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	    == RMAP_DENY) {
 		peer->stat_pfx_filter++;
 		reason = "route-map;";
+		/* `bgp_attr_flush` will release evpn_overlay, but it may
+		 * still be referenced from `attr`. So better unset it from
+		 * `new_attr` before flushing.
+		 */
+		bgp_attr_set_evpn_overlay(&new_attr, NULL);
 		bgp_attr_flush(&new_attr);
 		goto filtered;
 	}


### PR DESCRIPTION
bgpd_update works with two distinct copies of `attr`, that however share the same pointer to evpn_overlay. Under some conditions, one of the copies of attr was flushed, resulting in release of the evpn struct, that was still used by the other copy of the attr.

This commit un-references evpn pointer from the attr object that is about to be flushed, to keep it intact.

This should hopefully fix issue #19549