### PR TITLE
bgpd: fix wrong automatic router-id use

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -2977,6 +2977,9 @@ void vpn_handle_router_id_update(struct bgp *bgp, bool withdraw,
 	edir = BGP_VPN_POLICY_DIR_TOVPN;
 
 	for (afi = 0; afi < AFI_MAX; ++afi) {
+		if (CHECK_FLAG(bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_RD_SET))
+			continue;
+
 		if (!vpn_leak_to_vpn_active(bgp, afi, NULL, false))
 			continue;
 


### PR DESCRIPTION
Only considers the automatic rd scenario without a bgp connection and without configuring any rd in the command line.

This automatic rd is created and used for bgp at this case, but it should not be used for vpn if `rd vpn export` is set in command line.  And both IPv4 and IPv6 family also have this issue.

With the configuration:
```
router bgp 88 vrf vrf1
 neighbor 3.3.3.3 remote-as 99
 !
 address-family ipv4 unicast
  rd vpn export 4:4
  rt vpn export 4:4
  export vpn
  import vpn
 exit-address-family
exit
```

At the beginning, there was no address in vrf1, then set address 1.1.1.1/24. The running is changed:
```
router bgp 88 vrf xx
 neighbor 3.3.3.3 remote-as 99
 !
 address-family ipv4 unicast
  rd vpn export 4:4
  rt vpn export 1.1.1.1:4 <--
  export vpn
  import vpn
 exit-address-family
 ```