### PR TITLE
ldpd: fix wrong label mapping procedure

### DIFF
--- a/ldpd/lde_lib.c
+++ b/ldpd/lde_lib.c
@@ -431,6 +431,9 @@ lde_kernel_update(struct fec *fec)
 		return;
 
 	LIST_FOREACH(fnh, &fn->nexthops, entry) {
+		if (CHECK_FLAG(fnh->flags, F_FEC_NH_NO_LDP))
+			continue;
+
 		lde_send_change_klabel(fn, fnh);
 
 		switch (fn->fec.type) {


### PR DESCRIPTION
Consider the ldp neighbor with both link and targeted adjs at the same time. After the directed interface of the two boxes are removed from ldp by command line, the route via the directed interface is wrongly with label.

The reason is its targeted adj may have other path to the neighbor, so the neighbor relation between them was maintained and it did label mapping procedure for all nexthops without checking ldp interface.