### PR TITLE
bgpd: Remove unnecessary code in bgp_bmp.c

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2289,7 +2289,6 @@ bool bmp_bgp_update_vrf_status(enum bmp_vrf_state *vrf_state, struct bgp *bgp,
 			if (bbpeer) {
 				XFREE(MTYPE_BMP_OPEN, bbpeer->open_tx);
 				XFREE(MTYPE_BMP_OPEN, bbpeer->open_rx);
-				XFREE(MTYPE_BMP_OPEN, bbpeer->open_tx);
 				bmp_peerh_del(&bmp_peerh, bbpeer);
 				XFREE(MTYPE_BMP_PEER, bbpeer);
 			}


### PR DESCRIPTION
The code calls XFREE on bbpeer->open_tx twice.
There is no need to do it twice.