### PR TITLE
bgpd: fix the description for PEER_DOWN_NBR_ADDR

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -609,7 +609,7 @@ const char *const peer_down_str[] = {
 	"Interface down",
 	"Neighbor address lost",
 	"No path to specified Neighbor",
-	"Waiting for Peer IPv6 LLA",
+	"Waiting for peer address",
 	"Waiting for VRF to be initialized",
 	"No AFI/SAFI activated for peer",
 	"AS Set config change",

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2010,7 +2010,7 @@ struct peer {
 #define PEER_DOWN_IF_DOWN               25U /* Interface down */
 #define PEER_DOWN_NBR_ADDR_DEL          26U /* Peer address lost */
 #define PEER_DOWN_WAITING_NHT           27U /* Waiting for NHT to resolve */
-#define PEER_DOWN_NBR_ADDR              28U /* Waiting for peer IPv6 IP Addr */
+#define PEER_DOWN_NBR_ADDR              28U /* Waiting for peer address */
 #define PEER_DOWN_VRF_UNINIT            29U /* Associated VRF is not init yet */
 #define PEER_DOWN_NOAFI_ACTIVATED       30U /* No AFI/SAFI activated for peer */
 #define PEER_DOWN_AS_SETS_REJECT        31U /* Reject routes with AS_SET */


### PR DESCRIPTION
It should more generic, and for both ipv4 or ipv6.