### PR TITLE
bgpd: fix clumsy boolean logic

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -11261,7 +11261,7 @@ DEFPY (bgp_srv6_only,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
-	if (!no == bgp->srv6_only)
+	if ((!no && bgp->srv6_only) || (no && !bgp->srv6_only))
 		return CMD_SUCCESS;
 
 	/* pre-change */


### PR DESCRIPTION
Only make boolean tests on boolean variables, resolve SA warning.
Should fix coverity CID 1658773