### PR TITLE
lib: Have a minimum event sleep of 1 ms.

### DIFF
--- a/lib/event.c
+++ b/lib/event.c
@@ -1730,7 +1730,7 @@ struct event *event_fetch(struct event_loop *m, struct event *fetch)
 {
 	struct event *thread = NULL;
 	struct timeval now;
-	struct timeval zerotime = {0, 0};
+	struct timeval mintime = {0, 1000}; /* 1ms minimum timeout */
 	struct timeval tv;
 	struct timeval *tw = NULL;
 	bool eintr_p = false;
@@ -1775,7 +1775,7 @@ struct event *event_fetch(struct event_loop *m, struct event *fetch)
 		 * until a timer expires or we receive I/O, whichever comes
 		 * first. The strategy for doing this is:
 		 *
-		 * - If there are events pending, set the poll() timeout to zero
+		 * - If there are events pending, set the poll() timeout to 1ms minimum
 		 * - If there are no events pending, but there are timers
 		 * pending, set the timeout to the smallest remaining time on
 		 * any timer.
@@ -1790,8 +1790,8 @@ struct event *event_fetch(struct event_loop *m, struct event *fetch)
 			tw = thread_timer_wait(&m->timer, &tv);
 
 		if (event_list_count(&m->ready) ||
-		    (tw && !timercmp(tw, &zerotime, >)))
-			tw = &zerotime;
+		    (tw && !timercmp(tw, &mintime, >)))
+			tw = &mintime;
 
 		if (!tw && m->handler.pfdcount == 0) { /* die */
 			pthread_mutex_unlock(&m->mtx);


### PR DESCRIPTION
Currently the event system will attempt to sleep the shortest amount of time left if there are timer events in the system.  When the system has a very very large number of timer events this increases load significantly since we are not limiting the shortest sleep time, leaving the code to sleep whatever time is left till the next timer is actually going to pop.  So if you have a set of timers that are going to expire in 100, 200 and 300 microseconds. With this change the min time slept is 1 ms.  All three timers would be expired and moved to the ready queue on wake up.

When I experimented with 10k timers evenly expiring between 1 and 1000 ms, zebra load goes from 1.0 to between 0.02 and 0.023. A significant amount of time savings and cpu load savings.