### PR TITLE
bgpd: Convert the bgp->peerhash to a connectionhash

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -2369,14 +2369,13 @@ bgp_establish(struct peer_connection *connection)
 	struct peer *other;
 	struct peer *peer = connection->peer;
 	struct bgp *bgp = peer->bgp;
-	struct peer *orig = peer;
 	bool rpki_cache_connected;
 	struct vrf *vrf = NULL;
 
 	other = peer->doppelganger;
-	hash_release(bgp->peerhash, peer);
-	if (other)
-		hash_release(bgp->peerhash, other);
+	hash_release(bgp->connectionhash, connection);
+	if (other && other->connection)
+		hash_release(bgp->connectionhash, other->connection);
 
 	peer = peer_xfer_conn(peer);
 	if (!peer) {
@@ -2388,9 +2387,9 @@ bgp_establish(struct peer_connection *connection)
 		 * connections are rejected, as that the peer is not found
 		 * when a lookup is done
 		 */
-		(void)hash_get(bgp->peerhash, orig, hash_alloc_intern);
-		if (other)
-			(void)hash_get(bgp->peerhash, other, hash_alloc_intern);
+		(void)hash_get(bgp->connectionhash, connection, hash_alloc_intern);
+		if (other && other->connection)
+			(void)hash_get(bgp->connectionhash, other->connection, hash_alloc_intern);
 		return BGP_FSM_FAILURE;
 	}
 
@@ -2520,7 +2519,7 @@ bgp_establish(struct peer_connection *connection)
 	 * the doppelgangers su and this peer's su are the same
 	 * so the hash_release is the same for either.
 	 */
-	(void)hash_get(bgp->peerhash, peer, hash_alloc_intern);
+	(void)hash_get(bgp->connectionhash, connection, hash_alloc_intern);
 
 	/* Start BFD peer if not already running. */
 	if (peer->bfd_config)

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -17156,12 +17156,13 @@ DEFUN (clear_ip_bgp_dampening_address_mask,
 				    NULL, 0);
 }
 
-static void show_bgp_peerhash_entry(struct hash_bucket *bucket, void *arg)
+static void show_bgp_connectionhash_entry(struct hash_bucket *bucket, void *arg)
 {
-       struct vty *vty = arg;
-       struct peer *peer = bucket->data;
+	struct vty *vty = arg;
+	struct peer_connection *connection = bucket->data;
+	struct peer *peer = connection->peer;
 
-       vty_out(vty, "\tPeer: %s %pSU\n", peer->host, &peer->connection->su);
+	vty_out(vty, "\tPeer: %s %pSU\n", peer->host, &peer->connection->su);
 }
 
 DEFUN (show_bgp_listeners,
@@ -17189,8 +17190,7 @@ DEFUN (show_bgp_peerhash,
 
        for (ALL_LIST_ELEMENTS_RO(instances, node, bgp)) {
 	       vty_out(vty, "BGP: %s\n", bgp->name_pretty);
-	       hash_iterate(bgp->peerhash, show_bgp_peerhash_entry,
-                            vty);
+	       hash_iterate(bgp->connectionhash, show_bgp_connectionhash_entry, vty);
        }
 
        return CMD_SUCCESS;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -499,7 +499,7 @@ struct bgp {
 
 	/* BGP peer. */
 	struct list *peer;
-	struct hash *peerhash;
+	struct hash *connectionhash;
 
 	/* BGP peer group.  */
 	struct list *group;


### PR DESCRIPTION
This hash is really connection oriented instead of peer oriented.  Let's change it over to be connection based.

Long term the end goal is to get rid of the doppelganger.  This is addtional work towards this