### PR TITLE
bgpd: Do not override a specified rd

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -3015,7 +3015,9 @@ void vpn_handle_router_id_update(struct bgp *bgp, bool withdraw,
 			 */
 			form_auto_rd(bgp->router_id, bgp->vrf_rd_id,
 				     &bgp->vrf_prd_auto);
-			bgp->vpn_policy[afi].tovpn_rd = bgp->vrf_prd_auto;
+			if (!CHECK_FLAG(bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_RD_CLI_SET))
+				bgp->vpn_policy[afi].tovpn_rd = bgp->vrf_prd_auto;
+
 			prefix_rd2str(&bgp->vpn_policy[afi].tovpn_rd, buf,
 				      sizeof(buf), bgp->asnotation);
 
@@ -3149,9 +3151,13 @@ void vrf_import_from_vrf(struct bgp *to_bgp, struct bgp *from_bgp,
 	if (first_export) {
 		form_auto_rd(from_bgp->router_id, from_bgp->vrf_rd_id,
 			     &from_bgp->vrf_prd_auto);
-		from_bgp->vpn_policy[afi].tovpn_rd = from_bgp->vrf_prd_auto;
+
+		if (!CHECK_FLAG(from_bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_RD_CLI_SET))
+			from_bgp->vpn_policy[afi].tovpn_rd = from_bgp->vrf_prd_auto;
+
 		SET_FLAG(from_bgp->vpn_policy[afi].flags,
 			 BGP_VPN_POLICY_TOVPN_RD_SET);
+
 		prefix_rd2str(&from_bgp->vpn_policy[afi].tovpn_rd, buf,
 			      sizeof(buf), from_bgp->asnotation);
 		from_bgp->vpn_policy[afi].rtlist[edir] =

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10154,11 +10154,13 @@ DEFPY (af_rd_vpn_export,
 		bgp->vpn_policy[afi].tovpn_rd = prd;
 		SET_FLAG(bgp->vpn_policy[afi].flags,
 			 BGP_VPN_POLICY_TOVPN_RD_SET);
+		SET_FLAG(bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_RD_CLI_SET);
 	} else {
 		XFREE(MTYPE_BGP_NAME, bgp->vpn_policy[afi].tovpn_rd_pretty);
 		bgp->vpn_policy[afi].tovpn_rd_pretty = NULL;
 		UNSET_FLAG(bgp->vpn_policy[afi].flags,
 			   BGP_VPN_POLICY_TOVPN_RD_SET);
+		UNSET_FLAG(bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_RD_CLI_SET);
 	}
 	hook_call(bgp_route_distinguisher_update, bgp, afi, false);
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -284,6 +284,8 @@ struct vpn_policy {
 /* Manual label is registered with zebra label manager */
 #define BGP_VPN_POLICY_TOVPN_LABEL_MANUAL_REG (1 << 5)
 #define BGP_VPN_POLICY_TOVPN_SID_EXPLICIT     (1 << 6)
+/* Is this value set by the cli? */
+#define BGP_VPN_POLICY_TOVPN_RD_CLI_SET       (1 << 7)
 
 	/*
 	 * If we are importing another vrf into us keep a list of


### PR DESCRIPTION
If the router-id is learned after a bgp vrf has
already received a specified rd, it will auto-derive a value and override the specified on the command line.

Do not let this happen.