### PR TITLE
zebra:fix memory leak in event handling

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -50,6 +50,7 @@
 #include "zebra/zebra_srte.h"
 #include "zebra/zebra_srv6.h"
 #include "zebra/zebra_srv6_vty.h"
+#include "zebra/zebra_dplane.h"
 
 #define ZEBRA_PTM_SUPPORT
 
@@ -233,6 +234,9 @@ void zebra_finalize(struct event *dummy)
 	 * in those functions
 	 */
 	zebra_dplane_shutdown();
+
+	/* Clean up any remaining dplane namespace info structures */
+	zebra_dplane_cleanup();
 
 	ns_walk_func(zebra_ns_early_shutdown, NULL, NULL);
 	zebra_ns_notify_close();

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -1315,6 +1315,11 @@ void zebra_dplane_startup_stage(struct zebra_ns *zns,
 enum zebra_dplane_startup_notifications
 dplane_ctx_get_startup_spot(struct zebra_dplane_ctx *ctx);
 
+/*
+ * Cleanup all dplane namespace info structures during shutdown.
+ */
+void zebra_dplane_cleanup(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
struct dplane_zns_info allocated in zebra_dplane_ns_enable() during startup was not being freed during shutdown.