### PR TITLE
tests: Fix duplicate_nexthop test to connect more often

### DIFF
--- a/tests/topotests/bgp_duplicate_nexthop/r3/bgpd.conf
+++ b/tests/topotests/bgp_duplicate_nexthop/r3/bgpd.conf
@@ -4,6 +4,7 @@ router bgp 64500 view one
  neighbor rr peer-group
  neighbor rr remote-as 64500
  neighbor rr update-source lo
+ neighbor rr timers connect 1
  neighbor 192.0.2.1 peer-group rr
  neighbor 192.0.2.5 peer-group rr
  neighbor 192.0.2.6 peer-group rr


### PR DESCRIPTION
Examination of a test failure support bundle  showed that the next reconnect attempt was 30 seconds away.  Let's modify the code to attempt to connect to our peers a bit more often when bringing up.  This is especially important because the bgp RR is dependent on ISIS routes coming up first.