### PR TITLE
bgpd: use a function to set the peer reset cause

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -45,7 +45,7 @@ static void bgp_bfd_strict_holdtime_expire(struct event *event)
 		zlog_debug("%pBP BFD Strict mode Hold timer expire for %s", peer,
 			   bgp_peer_get_connection_direction(connection));
 
-	peer->last_reset = PEER_DOWN_BFD_DOWN;
+	peer_set_last_reset(peer, PEER_DOWN_BFD_DOWN);
 	SET_FLAG(peer->sflags, PEER_STATUS_BFD_STRICT_HOLD_TIME_EXPIRED);
 
 	if (BGP_IS_VALID_STATE_FOR_NOTIF(peer->connection->status))
@@ -90,7 +90,7 @@ static void bfd_session_status_update(struct bfd_session_params *bsp,
 						peer->bfd_config->hold_time,
 						&peer->bfd_config->t_hold_timer);
 			} else {
-				peer->last_reset = PEER_DOWN_BFD_DOWN;
+				peer_set_last_reset(peer, PEER_DOWN_BFD_DOWN);
 				/* rfc9384 */
 				if (BGP_IS_VALID_STATE_FOR_NOTIF(peer->connection->status))
 					bgp_notify_send(peer->connection, BGP_NOTIFY_CEASE,

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2986,7 +2986,7 @@ DEFUN(bgp_reject_as_sets, bgp_reject_as_sets_cmd,
 	 * with aspath containing AS_SET or AS_CONFED_SET.
 	 */
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-		peer->last_reset = PEER_DOWN_AS_SETS_REJECT;
+		peer_set_last_reset(peer, PEER_DOWN_AS_SETS_REJECT);
 		peer_notify_config_change(peer->connection);
 	}
 
@@ -3009,7 +3009,7 @@ DEFUN(no_bgp_reject_as_sets, no_bgp_reject_as_sets_cmd,
 	 * with aspath containing AS_SET or AS_CONFED_SET.
 	 */
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-		peer->last_reset = PEER_DOWN_AS_SETS_REJECT;
+		peer_set_last_reset(peer, PEER_DOWN_AS_SETS_REJECT);
 		peer_notify_config_change(peer->connection);
 	}
 
@@ -3272,7 +3272,7 @@ static void bgp_update_graceful_restart_capability(struct peer *peer)
 	 * exchanged again
 	 */
 	if (BGP_IS_VALID_STATE_FOR_NOTIF(peer->connection->status)) {
-		peer->last_reset = PEER_DOWN_CAPABILITY_CHANGE;
+		peer_set_last_reset(peer, PEER_DOWN_CAPABILITY_CHANGE);
 		bgp_notify_send(peer->connection, BGP_NOTIFY_CEASE, BGP_NOTIFY_CEASE_CONFIG_CHANGE);
 	}
 }
@@ -5304,7 +5304,7 @@ static int peer_conf_interface_get(struct vty *vty, const char *conf_if,
 		else
 			peer_flag_unset(peer, PEER_FLAG_IFPEER_V6ONLY);
 
-		peer->last_reset = PEER_DOWN_V6ONLY_CHANGE;
+		peer_set_last_reset(peer, PEER_DOWN_V6ONLY_CHANGE);
 
 		/* v6only flag changed. Reset bgp seesion */
 		if (!peer_notify_config_change(peer->connection))

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -176,7 +176,7 @@ static void bgp_nbr_connected_delete(struct bgp *bgp, struct nbr_connected *ifc,
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
 		if (peer->conf_if
 		    && (strcmp(peer->conf_if, ifc->ifp->name) == 0)) {
-			peer->last_reset = PEER_DOWN_NBR_ADDR_DEL;
+			peer_set_last_reset(peer, PEER_DOWN_NBR_ADDR_DEL);
 			BGP_EVENT_ADD(peer->connection, BGP_Stop);
 		}
 	}
@@ -281,7 +281,7 @@ static int bgp_ifp_down(struct interface *ifp)
 
 			if (ifp == peer->nexthop.ifp) {
 				BGP_EVENT_ADD(peer->connection, BGP_Stop);
-				peer->last_reset = PEER_DOWN_IF_DOWN;
+				peer_set_last_reset(peer, PEER_DOWN_IF_DOWN);
 			}
 		}
 	}

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2930,6 +2930,11 @@ static inline bool peer_established(struct peer_connection *connection)
 	return connection->status == Established;
 }
 
+static inline void peer_set_last_reset(struct peer *peer, uint8_t reset_cause)
+{
+	peer->last_reset = reset_cause;
+}
+
 static inline bool peer_dynamic_neighbor(struct peer *peer)
 {
 	return CHECK_FLAG(peer->flags, PEER_FLAG_DYNAMIC_NEIGHBOR);


### PR DESCRIPTION
The function peer_set_last_reset() is introduced to facilitate additional features, such as checking for peer status and duplicate setting and even possible recording of a series of reset causes.