### PR TITLE
bgpd: Do not crash with only vni configed.

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3581,7 +3581,8 @@ static void write_vni_config(struct vty *vty, struct bgpevpn *vpn)
 		if (is_rd_configured(vpn))
 			vty_out(vty, "   rd %s\n", vpn->prd_pretty);
 
-		if (vpn->vxlan_flood_ctrl != vpn->bgp_vrf->vxlan_flood_ctrl) {
+		if (!vpn->bgp_vrf ||
+		    (vpn->bgp_vrf && (vpn->vxlan_flood_ctrl != vpn->bgp_vrf->vxlan_flood_ctrl))) {
 			if (vpn->vxlan_flood_ctrl == VXLAN_FLOOD_DISABLED)
 				vty_out(vty, "   flooding disable\n");
 			else if (vpn->vxlan_flood_ctrl == VXLAN_FLOOD_HEAD_END_REPL)


### PR DESCRIPTION
If BGP has been created with a vni, but there has
been no reason to create the bgp vrf associated with the vni, prevent a crash with the show run.

If you have this config:
router bgp 65000
 timers bgp 3 9
 bgp router-id 10.10.10.10
 no bgp default ipv4-unicast
 neighbor 10.30.30.30 remote-as 65000
 neighbor 10.30.30.30 update-source lo
 neighbor 10.30.30.30 timers 3 10
 !
 address-family l2vpn evpn
  neighbor 10.30.30.30 activate
  advertise-all-vni
  advertise-svi-ip
  vni 101
   rd 10.10.10.10:101
   route-target import 65000:101
   route-target export 65000:101
  exit-vni
  advertise-svi-ip

And if there is no reason to yet create the bgp vrf associated with the vni and you issue a show run,
bgp will crash.  This is because the vpn->bgp_vrf
pointer is NULL and it is dereferenced.  If you examine the bgp_evpn code, there are numerous places where the vpn->bgp_vrf is tested to ensure that it is
non NULL.  Let's just extend this curtesy to
the show run too.