### PR TITLE
lib, zebra: choose macvlan connected routes over others

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -827,6 +827,12 @@ int if_is_vrf(const struct interface *ifp)
 	return CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK);
 }
 
+/* Check interface is MACVLAN */
+int if_is_macvlan(const struct interface *ifp)
+{
+	return CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_MACVLAN);
+}
+
 /* Should this interface be treated as a loopback? */
 bool if_is_loopback(const struct interface *ifp)
 {

--- a/lib/if.h
+++ b/lib/if.h
@@ -243,6 +243,7 @@ struct interface {
 #define ZEBRA_INTERFACE_LINKDETECTION (1 << 2)
 #define ZEBRA_INTERFACE_VRF_LOOPBACK (1 << 3)
 #define ZEBRA_INTERFACE_DUMMY (1 << 4)
+#define ZEBRA_INTERFACE_MACVLAN	      (1 << 5)
 
 	/* Interface flags. */
 	uint64_t flags;
@@ -577,6 +578,7 @@ extern int if_is_running(const struct interface *ifp);
 extern int if_is_operative(const struct interface *ifp);
 extern int if_is_no_ptm_operative(const struct interface *ifp);
 extern int if_is_loopback_exact(const struct interface *ifp);
+extern int if_is_macvlan(const struct interface *ifp);
 extern int if_is_vrf(const struct interface *ifp);
 extern bool if_is_loopback(const struct interface *ifp);
 extern int if_is_broadcast(const struct interface *ifp);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -547,6 +547,9 @@ void if_add_update(struct interface *ifp)
 	if (IS_ZEBRA_IF_DUMMY(ifp))
 		SET_FLAG(ifp->status, ZEBRA_INTERFACE_DUMMY);
 
+	if (IS_ZEBRA_IF_MACVLAN(ifp))
+		SET_FLAG(ifp->status, ZEBRA_INTERFACE_MACVLAN);
+
 	if (!CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE)) {
 		SET_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE);
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1182,7 +1182,7 @@ static struct route_entry *rib_choose_best_type(uint8_t route_type,
 			struct interface *ifp = if_lookup_by_index(
 				nexthop->ifindex, alternate->vrf_id);
 
-			if (ifp && if_is_loopback(ifp))
+			if (ifp && (if_is_loopback(ifp) || if_is_macvlan(ifp)))
 				return alternate;
 		}
 
@@ -1190,7 +1190,7 @@ static struct route_entry *rib_choose_best_type(uint8_t route_type,
 			struct interface *ifp = if_lookup_by_index(
 				nexthop->ifindex, current->vrf_id);
 
-			if (ifp && if_is_loopback(ifp))
+			if (ifp && (if_is_loopback(ifp) || if_is_macvlan(ifp)))
 				return current;
 		}
 


### PR DESCRIPTION
When two same connected prefixes are available on both a physical and a vrrp interface, if vrrp flaps, then the static routes linked to the vrrp interface and using the connected prefix do not appear again. To illustrate:

> interface vrrp1
>  ip address 192.0.2.10/24
> exit
> interface eth0
>  ip address 192.0.2.20/24
> exit
> ip route 192.168.0.0/24 192.0.2.80 vrrp1

The above example requests that when vrrp1 goes up again, then the static route is selected and valid.

The best path of two identical prefixes will keep the one that is current or attached to a loopback or a vrf. Add the macvlan kind to help static route to go back.