### PR TITLE
Fix the issue where the OSPF Summary LSA's metric value fails to update properly and promptly when the LinkID changes.

### DIFF
--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -564,7 +564,7 @@ static void ospf_abr_update_aggregate(struct ospf_area_range *range,
 	range->specifics++;
 }
 
-static void set_metric(struct ospf_lsa *lsa, uint32_t metric)
+void ospf_abr_summary_lsa_set_metric(struct ospf_lsa *lsa, uint32_t metric)
 {
 	struct summary_lsa *header;
 	uint8_t *mp;
@@ -736,7 +736,7 @@ void ospf_abr_announce_network_to_area(struct prefix_ipv4 *p, uint32_t cost,
 			/* LSA is changed, refresh it */
 			if (IS_DEBUG_OSPF_EVENT)
 				zlog_debug("%s: refreshing summary", __func__);
-			set_metric(old, full_cost);
+			ospf_abr_summary_lsa_set_metric(old, full_cost);
 			lsa = ospf_lsa_refresh(area->ospf, old);
 
 			if (!lsa) {
@@ -1107,7 +1107,7 @@ static void ospf_abr_announce_rtr_to_area(struct prefix_ipv4 *p, uint32_t cost,
 			zlog_debug("%s: 2.2", __func__);
 
 		if (old) {
-			set_metric(old, cost);
+			ospf_abr_summary_lsa_set_metric(old, cost);
 			lsa = ospf_lsa_refresh(area->ospf, old);
 		} else
 			lsa = ospf_summary_asbr_lsa_originate(p, cost, area);

--- a/ospfd/ospf_abr.h
+++ b/ospfd/ospf_abr.h
@@ -84,6 +84,7 @@ extern void ospf_generate_indication_lsa(struct ospf *ospf,
 					 struct ospf_area *area);
 extern bool ospf_check_fr_enabled_all(struct ospf *ospf);
 extern void ospf_recv_indication_lsa_flush(struct ospf_lsa *lsa);
+extern void ospf_abr_summary_lsa_set_metric(struct ospf_lsa *lsa, uint32_t cost);
 
 /** @brief Static inline functions.
  *  @param Area pointer.

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -1335,8 +1335,6 @@ static struct ospf_lsa *ospf_handle_summarylsa_lsId_chg(struct ospf_area *area,
 	struct prefix_ipv4 old_prefix;
 	uint32_t old_metric;
 	struct in_addr mask;
-	uint32_t metric_val;
-	char *metric_buf;
 
 	lsa = ospf_lsdb_lookup_by_id(area->lsdb, type, p->prefix,
 				     ospf->router_id);
@@ -1360,9 +1358,7 @@ static struct ospf_lsa *ospf_handle_summarylsa_lsId_chg(struct ospf_area *area,
 	sl->mask.s_addr = mask.s_addr;
 
 	/* Copy the metric*/
-	metric_val = htonl(metric);
-	metric_buf = (char *)&metric_val;
-	memcpy(sl->metric, metric_buf, sizeof(metric_val));
+	ospf_abr_summary_lsa_set_metric(lsa, metric);
 
 	if (type == OSPF_SUMMARY_LSA) {
 		/*Refresh the LSA with new LSA*/


### PR DESCRIPTION
1、Adjust Function set_metric and update the functions that call it.
2、Correct the metric setting in Function ospf_handle_summarylsa_lsId_chg, which was truncated due to data size issues.