### PR TITLE
bgpd: Free up leaked bpme on release

### DIFF
--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1683,6 +1683,9 @@ static void bgp_pbr_flush_iprule(struct bgp *bgp, struct bgp_pbr_action *bpa,
 	bgp_pbr_bpa_remove(bpa);
 }
 
+/*
+ * This function frees the bpme that is passed in
+ */
 static void bgp_pbr_flush_entry(struct bgp *bgp, struct bgp_pbr_action *bpa,
 				struct bgp_pbr_match *bpm,
 				struct bgp_pbr_match_entry *bpme)
@@ -1730,6 +1733,8 @@ static void bgp_pbr_flush_entry(struct bgp *bgp, struct bgp_pbr_action *bpa,
 		 * note that drop does not need to call send_pbr_action
 		 */
 	}
+
+	bgp_pbr_match_entry_free(bpme);
 	bgp_pbr_bpa_remove(bpa);
 }
 


### PR DESCRIPTION
Direct leak of 160 byte(s) in 1 object(s) allocated from:
    0 0x7f5b26cb83b7 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:77
    1 0x7f5b2683a34d in qcalloc lib/memory.c:106
    2 0x5592a7ec084a in bgp_pbr_match_entry_alloc_intern bgpd/bgp_pbr.c:1097
    3 0x7f5b267f9b2f in hash_get lib/hash.c:147
    4 0x5592a7ec3654 in bgp_pbr_policyroute_add_to_zebra_unit bgpd/bgp_pbr.c:2467
    5 0x5592a7ec643b in bgp_pbr_policyroute_add_to_zebra bgpd/bgp_pbr.c:2608
    6 0x5592a7ecd423 in bgp_pbr_handle_entry bgpd/bgp_pbr.c:2813
    7 0x5592a7ecd423 in bgp_pbr_update_entry bgpd/bgp_pbr.c:2876
    8 0x5592a7fd740a in bgp_zebra_announce_actual bgpd/bgp_zebra.c:1539
    9 0x5592a7fdd85d in bgp_handle_route_announcements_to_zebra bgpd/bgp_zebra.c:1810
    10 0x7f5b268eecf0 in event_call lib/event.c:2019
    11 0x7f5b2681b293 in frr_run lib/libfrr.c:1247
    12 0x5592a7dae8b7 in main bgpd/bgp_main.c:557
    13 0x7f5b2630c249 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Turns out that the hash_release of a bpme and not actually freeing it.... is a recipe to leak memory.