### PR TITLE
docs: bgpd: clarify `bgp bestpath as-path multipath-relax` option

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -198,8 +198,9 @@ bottom until one of the factors can be used.
    If multi-pathing is enabled, then check whether the routes not yet
    distinguished in preference may be considered equal. If
    :clicmd:`bgp bestpath as-path multipath-relax` is set, all such routes are
-   considered equal, otherwise routes received via iBGP with identical AS_PATHs
-   or routes received from eBGP neighbours in the same AS are considered equal.
+   considered equal; otherwise, only routes received via iBGP with identical
+   AS_PATHs or routes received from eBGP neighbours in the same AS are
+   considered equal.
 
 10. **Already-selected external check**
 


### PR DESCRIPTION
Adding 'only' makes it clearer that when `as-path multipath-relax` is off, only a identical AS_PATH (iBGP) or identical AS (eBGP) is considered equal.