### PR TITLE
bgpd: Fix bgp peer clearing logic

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6923,10 +6923,6 @@ static int clear_batch_rib_helper(struct bgp_clearing_info *cinfo)
 				zlog_debug("%s: examining AFI/SAFI %s/%s", __func__, afi2str(afi),
 					   safi2str(safi));
 
-			/* Record the tables we've seen and don't repeat */
-			if (cinfo->table_map[afi][safi] > 0)
-				continue;
-
 			if (safi != SAFI_MPLS_VPN && safi != SAFI_ENCAP && safi != SAFI_EVPN) {
 				table = cinfo->bgp->rib[afi][safi];
 				if (!table) {
@@ -6938,9 +6934,6 @@ static int clear_batch_rib_helper(struct bgp_clearing_info *cinfo)
 				ret = walk_batch_table_helper(cinfo, table, false /*inner*/);
 				if (ret != 0)
 					break;
-
-				cinfo->table_map[afi][safi] = 1;
-
 			} else {
 				/* Process "inner" table for these SAFIs */
 				outer_table = cinfo->bgp->rib[afi][safi];
@@ -6977,8 +6970,6 @@ static int clear_batch_rib_helper(struct bgp_clearing_info *cinfo)
 
 				if (ret != 0)
 					break;
-
-				cinfo->table_map[afi][safi] = 1;
 			}
 
 			/* We've finished with a table: ensure we don't try to use stale

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6749,36 +6749,80 @@ static void set_clearing_resume_info(struct bgp_clearing_info *cinfo,
 
 /*
  * Helper to establish position in a table, possibly using "resume" info stored
- * during an iteration
+ * during an iteration. Special logic helps navigate the outer/inner tables used
+ * for the VPN safis.
  */
 static struct bgp_dest *clearing_dest_helper(struct bgp_table *table,
 					     struct bgp_clearing_info *cinfo,
 					     bool inner_p)
 {
-	struct bgp_dest *dest;
+	struct bgp_dest *dest = NULL;
 	const struct prefix *pfx;
+	bool outer_level_p;
+	char buf[PREFIX_STRLEN];
 
-	/* Iterate at start of table, or resume using inner or outer prefix */
+	/* Is this a call for the outer/RD table of a VPN safi? */
+	outer_level_p = (CHECK_FLAG(cinfo->flags, BGP_CLEARING_INFO_FLAG_INNER) && !inner_p);
+
+	/* Iterate at start of table, or resume using "inner" or "outer" (RD) prefix */
 	dest = bgp_table_top(table);
 
 	if (CHECK_FLAG(cinfo->flags, BGP_CLEARING_INFO_FLAG_RESUME)) {
+		/* We're resuming an in-progress iteration. There are a couple of cases:
+		 * 1. we're resuming in an non-VPN afi/safi; we'll look to locate the
+		 *    closest prefix _after_ the prefix we saved.
+		 * 2. if we're in a VPN safi this will be called twice: first to locate
+		 *    the RD in the "outer" table, and then a second time to locate
+		 *    the closest prefix _after_ the "inner" prefix within the RD table.
+		 */
 		pfx = NULL;
-		if (inner_p) {
-			if (CHECK_FLAG(cinfo->flags, BGP_CLEARING_INFO_FLAG_INNER))
-				pfx = &(cinfo->inner_pfx);
-		} else {
+		if (inner_p && CHECK_FLAG(cinfo->flags, BGP_CLEARING_INFO_FLAG_INNER))
+			pfx = &(cinfo->inner_pfx);
+		else
 			pfx = &(cinfo->last_pfx);
-		}
 
 		if (pfx) {
-			dest = bgp_node_match(table, pfx);
-			if (dest) {
-				/* if 'dest' matches or precedes the 'last' prefix
-				 * visited, then advance.
+			if (outer_level_p) {
+				/* Outer/RD table: use current RD if possible, advance
+				 * otherwise
 				 */
-				while (dest && (prefix_cmp(&(dest->rn->p), pfx) <= 0))
-					dest = bgp_route_next(dest);
+				if (bgp_debug_neighbor_events(NULL)) {
+					prefix_rd2str((struct prefix_rd *)pfx, buf, sizeof(buf),
+						      ASNOTATION_PLAIN);
+					zlog_debug("%s: using RESUME%s prefix %s", __func__,
+						   inner_p ? " inner" : "", buf);
+				}
+
+				dest = bgp_node_match(table, pfx);
+			} else {
+				/* Normal prefix: look for next prefix */
+				if (bgp_debug_neighbor_events(NULL))
+					zlog_debug("%s: using RESUME%s prefix %pFX", __func__,
+						   inner_p ? " inner" : "", pfx);
+
+				dest = bgp_node_match(table, pfx);
+				if (dest) {
+					/* if 'dest' matches or precedes the 'last' prefix
+					 * visited, then advance.
+					 */
+					while (dest && (prefix_cmp(&(dest->rn->p), pfx) <= 0))
+						dest = bgp_route_next(dest);
+				}
 			}
+		}
+	}
+
+	if (bgp_debug_neighbor_events(NULL)) {
+		if (outer_level_p) {
+			if (dest)
+				prefix_rd2str((struct prefix_rd *)(&dest->rn->p), buf, sizeof(buf),
+					      ASNOTATION_PLAIN);
+			else
+				strlcpy(buf, "NULL", sizeof(buf));
+
+			zlog_debug("%s: returns RD dest %s (%p)", __func__, buf, dest);
+		} else {
+			zlog_debug("%s: returns dest %pBD", __func__, dest);
 		}
 	}
 
@@ -6800,7 +6844,6 @@ static void clear_dests_callback(struct event *event)
 		/* All done, clean up context */
 		bgp_clearing_batch_completed(cinfo);
 	} else {
-		/* Need to resume the work, with 'cinfo' */
 		event_add_event(bm->master, clear_dests_callback, cinfo, 0,
 				&cinfo->t_sched);
 	}
@@ -6822,6 +6865,14 @@ static int walk_batch_table_helper(struct bgp_clearing_info *cinfo,
 
 	/* Locate starting dest, possibly using "resume" info */
 	dest = clearing_dest_helper(table, cinfo, inner_p);
+
+	/* Reset flag */
+	UNSET_FLAG(cinfo->flags, BGP_CLEARING_INFO_FLAG_RESUME);
+
+	if (bgp_debug_neighbor_events(NULL))
+		zlog_debug("%s: table %s/%s, dest %pBD", __func__, afi2str(table->afi),
+			   safi2str(table->safi), dest);
+
 	if (dest == NULL) {
 		/* Nothing more to do for this table? */
 		return 0;
@@ -6834,6 +6885,7 @@ static int walk_batch_table_helper(struct bgp_clearing_info *cinfo,
 
 		examined++;
 		cinfo->curr_counter++;
+		cinfo->total_counter++;
 
 		/* Save dest's prefix */
 		memcpy(&pfx, &dest->rn->p, sizeof(struct prefix));
@@ -6903,15 +6955,22 @@ static int clear_batch_rib_helper(struct bgp_clearing_info *cinfo)
 	struct bgp_dest *dest;
 	struct bgp_table *table, *outer_table;
 	struct prefix pfx;
+	const char *resume_str = "starting";
+	char pbuf[PREFIX_STRLEN];
 
 	/* Maybe resume afi/safi iteration */
 	if (CHECK_FLAG(cinfo->flags, BGP_CLEARING_INFO_FLAG_RESUME)) {
 		afi = cinfo->last_afi;
 		safi = cinfo->last_safi;
+		resume_str = "resuming";
 	} else {
 		afi = AFI_IP;
 		safi = SAFI_UNICAST;
 	}
+
+	if (bgp_debug_neighbor_events(NULL))
+		zlog_debug("%s: %s: AFI/SAFI %s/%s", __func__, resume_str, afi2str(afi),
+			   safi2str(safi));
 
 	/* Iterate through afi/safi combos */
 	for (; afi < AFI_MAX; afi++) {
@@ -6941,16 +7000,35 @@ static int clear_batch_rib_helper(struct bgp_clearing_info *cinfo)
 				/* Begin or resume iteration in "outer" table */
 				dest = clearing_dest_helper(outer_table, cinfo, false);
 
+				if (dest)
+					prefix_rd2str((struct prefix_rd *)(&dest->rn->p), pbuf,
+						      sizeof(pbuf), ASNOTATION_PLAIN);
+				else
+					strlcpy(pbuf, "NULL", sizeof(pbuf));
+
+				if (bgp_debug_neighbor_events(NULL))
+					zlog_debug("%s: outer table %s/%s starting dest %s",
+						   __func__, afi2str(outer_table->afi),
+						   safi2str(outer_table->safi), pbuf);
+
 				for (; dest; dest = bgp_route_next(dest)) {
 					table = bgp_dest_get_bgp_table_info(dest);
 					if (!table) {
-						/* If we resumed to an inner afi/safi, but
+						/* If we resumed to an inner table but
 						 * it's no longer valid, reset resume info.
 						 */
 						UNSET_FLAG(cinfo->flags,
 							   BGP_CLEARING_INFO_FLAG_RESUME);
 						continue;
 					}
+
+					prefix_rd2str((struct prefix_rd *)(&dest->rn->p), pbuf,
+						      sizeof(pbuf), ASNOTATION_PLAIN);
+
+					if (bgp_debug_neighbor_events(NULL))
+						zlog_debug("%s: outer table %s/%s, dest %s",
+							   __func__, afi2str(outer_table->afi),
+							   safi2str(outer_table->safi), pbuf);
 
 					/* Capture last prefix */
 					memcpy(&pfx, &dest->rn->p, sizeof(struct prefix));
@@ -6987,8 +7065,10 @@ static int clear_batch_rib_helper(struct bgp_clearing_info *cinfo)
 		if (ret != 0)
 			return ret;
 
+		/* Reset SAFI for next AFI iteration */
 		safi = SAFI_UNICAST;
 	}
+
 	return ret;
 }
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -156,9 +156,6 @@ enum show_type {
 	show_ipv6_peer
 };
 
-static struct peer_group *listen_range_exists(struct bgp *bgp,
-					      struct prefix *range, int exact);
-
 static enum node_type bgp_node_type(afi_t afi, safi_t safi)
 {
 	switch (afi) {

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -8657,6 +8657,9 @@ static void peer_clear_capabilities(struct peer *peer, afi_t afi, safi_t safi)
  */
 int peer_clear(struct peer *peer, struct listnode **nnode)
 {
+	if (bgp_debug_neighbor_events(peer))
+		zlog_debug("%s: peer %pBP", __func__, peer);
+
 	if (!CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN)
 	    || !CHECK_FLAG(peer->bgp->flags, BGP_FLAG_SHUTDOWN)) {
 		if (peer_maximum_prefix_clear_overflow(peer))
@@ -9431,6 +9434,10 @@ void bgp_clearing_batch_completed(struct bgp_clearing_info *cinfo)
 	struct bgp_dest *dest;
 	struct bgp_clearing_dest *destinfo;
 	struct bgp_table *table;
+
+	if (bgp_debug_neighbor_events(NULL))
+		zlog_debug("%s: cinfo id %#x, %p, total %u", __func__, cinfo->id, cinfo,
+			   cinfo->total_counter);
 
 	/* Ensure event is not scheduled */
 	event_cancel_event(bm->master, &cinfo->t_sched);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -454,20 +454,16 @@ struct bgp_clearing_info {
 	struct prefix last_pfx;
 
 	/* For some afi/safi (vpn/evpn e.g.), bgp may do an inner walk
-	 * for a related table; the 'last' info represents the outer walk,
-	 * and this info represents the inner walk.
+	 * for an RD-based table; the 'last' info represents the outer walk,
+	 * and this info represents the inner RD table walk.
 	 */
 	afi_t inner_afi;
 	safi_t inner_safi;
 	struct prefix inner_pfx;
 
-	/* Map of afi/safi so we don't re-walk any tables */
-	uint8_t table_map[AFI_MAX][SAFI_MAX];
-
 	/* Counters: current iteration, overall total, and processed count. */
 	uint32_t curr_counter;
 	uint32_t total_counter;
-	uint32_t total_processed;
 
 	/* TODO -- id, serial number, for debugging/logging? */
 


### PR DESCRIPTION
Ensure the clearing info object iteration correctly accounts for the "outer"/RD table and "inner" table nature of the VPN
SAFIs. Depending on the number of prefixes and number of RDs, the existing iteration logic could move past an RD value before completely removing all associated prefixes.
Also improve some debugs, especially in the paths where the bgp dest object is an RD - the generic bgp dest output format handler doesn't understand RDs.

Fixes: #19605
