### PR TITLE
bgpd: Free flowspec pointer that is allocated in prefix_copy()

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4757,6 +4757,9 @@ void bgp_rib_remove(struct bgp_dest *dest, struct bgp_path_info *pi,
 
 	struct bgp *bgp = NULL;
 	bool delete_route = false;
+	const struct prefix *p = bgp_dest_get_prefix(dest);
+
+	flowspec_free_prefix(p);
 
 	bgp_aggregate_decrement(peer->bgp, bgp_dest_get_prefix(dest), pi, afi,
 				safi);

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -358,6 +358,20 @@ void prefix_copy(union prefixptr udest, union prefixconstptr usrc)
 	}
 }
 
+/*
+ * Helper function to free memory associated with FlowSpec prefixes
+ */
+void flowspec_free_prefix(const struct prefix *p)
+{
+	void *temp;
+
+	if (!p || p->family != AF_FLOWSPEC || !p->u.prefix_flowspec.ptr)
+		return;
+
+	temp = (void *)p->u.prefix_flowspec.ptr;
+	XFREE(MTYPE_PREFIX_FLOWSPEC, temp);
+}
+
 bool evpn_addr_same(const struct evpn_addr *e1, const struct evpn_addr *e2)
 {
 	if (e1->route_type != e2->route_type)

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -432,6 +432,7 @@ extern int prefix_same(union prefixconstptr ua, union prefixconstptr ub);
 extern int prefix_cmp(union prefixconstptr ua, union prefixconstptr ub);
 extern int prefix_common_bits(union prefixconstptr ua, union prefixconstptr ub);
 extern void prefix_copy(union prefixptr udst, union prefixconstptr usrc);
+extern void flowspec_free_prefix(const struct prefix *p);
 extern void apply_mask(union prefixptr pu);
 extern bool evpn_addr_same(const struct evpn_addr *e1, const struct evpn_addr *e2);
 


### PR DESCRIPTION
This fixes:

```
***********************************************************************************
Address Sanitizer Error detected in /tmp_topotests/bgp_flowspec.test_bgp_flowspec_topo/r1.asan.bgpd.31846

=================================================================
==31846==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 56 byte(s) in 2 object(s) allocated from:
    #0 0x7f35488b83b7 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x7f3548424c0d in qcalloc lib/memory.c:111
    #2 0x7f354848278e in prefix_copy lib/prefix.c:349
    #3 0x7f35484cb9be in route_node_get lib/table.c:248
    #4 0x5562936aaf68 in bgp_node_get bgpd/bgp_table.h:246
    #5 0x5562936aaf68 in bgp_afi_node_get bgpd/bgp_route.c:204
    #6 0x5562936caa7c in bgp_update bgpd/bgp_route.c:5158
    #7 0x5562938a10f5 in bgp_nlri_parse_flowspec bgpd/bgp_flowspec.c:186
    #8 0x55629367995c in bgp_nlri_parse bgpd/bgp_packet.c:324
    #9 0x55629367bd76 in bgp_update_receive bgpd/bgp_packet.c:2493
    #10 0x55629368ad39 in bgp_process_packet bgpd/bgp_packet.c:4066
    #11 0x7f35484dd6b7 in event_call lib/event.c:2009
    #12 0x7f35484027d9 in frr_run lib/libfrr.c:1252
    #13 0x556293577c55 in main bgpd/bgp_main.c:569
    #14 0x7f3547f0c249 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 56 byte(s) leaked in 2 allocation(s).
***********************************************************************************
```