### PR TITLE
bgpd: Disable enabling link local capability by default

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -116,7 +116,6 @@ FRR_CFG_DEFAULT_BOOL(BGP_SOFT_VERSION_CAPABILITY,
 	{ .val_bool = false },
 );
 FRR_CFG_DEFAULT_BOOL(BGP_LINK_LOCAL_CAPABILITY,
-	{ .val_bool = true, .match_profile = "datacenter", },
 	{ .val_bool = false },
 );
 FRR_CFG_DEFAULT_BOOL(BGP_DYNAMIC_CAPABILITY,
@@ -5324,11 +5323,6 @@ static int peer_conf_interface_get(struct vty *vty, const char *conf_if,
 		SET_FLAG(peer->flags_invert, PEER_FLAG_CAPABILITY_ENHE);
 		SET_FLAG(peer->flags_override, PEER_FLAG_CAPABILITY_ENHE);
 	}
-
-	/* For unnumbered peers enable Link-Local Next Hop
-	 * capability implicitly.
-	 */
-	peer_flag_set(peer, PEER_FLAG_CAPABILITY_LINK_LOCAL);
 
 	if (peer_group_name) {
 		group = peer_group_lookup(bgp, peer_group_name);


### PR DESCRIPTION
Part of recent Link-Local Next Hop Capability fature, we have enabled exchange of Link-Local Next Hop Capability by default for 1) bgp unnumbered peering and
2) frr defaults datacenter profile. Once
“Link-Local Next Hop Capability: advertised link-local received link-local” is achieved, i.e. Link-Local Next Hop Capability is exchanged, only LL address would be sent by the sender. This is causing multiple regressions.

Fix:
Have the Link-Local Next Hop Capability feature, but lets not enable it by default, user can enable it via explicit configuration, say under neighbor, neighbor X:X::X:X capability link-local, or so.

Signed-off-by: Soumya Roy <souroy@nvidia.com>

Testing
Before fix>>>>>>>
Unnumbered:
BGP routing table entry for 2100:cafe::/128, version 1 Paths: (201 available, best #1, table default)
  Advertised to peers:
  r2(r1-eth0) <snip>
  1002
    fe80::d4ce:73ff:fe8d:a04d(r2) from r2(r1-eth0) (192.168.1.2)<<<<<<Only LL received
      Origin incomplete, metric 0, valid, external, multipath, bestpath-from-AS 1002, best (Neighbor IP)
      Last update: Wed Oct  1 22:01:40 2025
  1002

numbered with “frr defaults datacenter”:
BGP routing table entry for 2100:cafe::/128, version 1 Paths: (514 available, best #1, table default)
  Advertised to peers:
 r2(2001:db8:1:107::2) r2(2001:db8:1:108::2) r2(2001:db8:1:109::2) r2(2001:db8:1:110::2)  r2(2001:db8:3:3::2) r2(2001:db8:3:4::2)
  1002
    fe80::c45c:9cff:feb5:d164(r2) from r2(2001:db8:1:1::2) (192.168.1.2)<<<<<<Only LL received
      Origin incomplete, metric 0, valid, external, multipath, bestpath-from-AS 1002, best (Neighbor IP)
      Last update: Wed Oct  1 21:54:47 2025

Testing after fix>>>>>>>>
For unnumbered:
r1# sh bgp ipv6 unicast  2100:cafe::/128
BGP routing table entry for 2100:cafe::/128, version 1 Paths: (201 available, best #1, table default)
  Advertised to peers:
  r1-eth0 <snip>
  1002
    2001:db8:1:1::2 from r1-eth0 (192.168.1.2)<<<Both LL and global received
    (fe80::d49b:70ff:fe9f:86be) (used)
      Origin incomplete, metric 0, valid, external, multipath, best (Neighbor IP)
      Last update: Wed Oct  1 20:50:27 2025

 Link-Local Next Hop Capability: not advertised not received

numbered with “frr defaults datacenter”>>
BGP routing table entry for 2100:cafe::/128, version 1 Paths: (514 available, best #1, table default)
  Advertised to peers:
  2001:db8:1:1::2 <snip> 2001:db8:3:4::2
  1002
    2001:db8:1:1::2 from 2001:db8:1:1::2 (192.168.1.2)<<<Both LL and global received
    (fe80::7406:f2ff:fe28:e207) (used)
      Origin incomplete, metric 0, valid, external, multipath, best (Neighbor IP)
      Last update: Wed Oct  1 21:00:39 2025