### PR TITLE
lib, zebra: Add fib installed NH count in json show cmd

### DIFF
--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -105,6 +105,19 @@ uint16_t nexthop_group_active_nexthop_num(const struct nexthop_group *nhg)
 	return num;
 }
 
+uint16_t nexthop_group_fib_nexthop_num(const struct nexthop_group *nhg)
+{
+	struct nexthop *nhop;
+	uint16_t num = 0;
+
+	for (ALL_NEXTHOPS_PTR(nhg, nhop)) {
+		if (CHECK_FLAG(nhop->flags, NEXTHOP_FLAG_FIB))
+			num++;
+	}
+
+	return num;
+}
+
 bool nexthop_group_has_label(const struct nexthop_group *nhg)
 {
 	struct nexthop *nhop;

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -151,6 +151,7 @@ extern void nexthop_group_json_nexthop(json_object *j,
 /* Return the number of nexthops in this nhg */
 extern uint16_t nexthop_group_nexthop_num(const struct nexthop_group *nhg);
 extern uint16_t nexthop_group_active_nexthop_num(const struct nexthop_group *nhg);
+extern uint16_t nexthop_group_fib_nexthop_num(const struct nexthop_group *nhg);
 
 /* Return TRUE if the NHG is Singleton (has only one nexthop) */
 #define NHG_IS_SINGLETON(nhg) ((nhg)->nexthop && !(nhg)->nexthop->next)

--- a/tests/topotests/bgp_duplicate_nexthop/test_bgp_duplicate_nexthop.py
+++ b/tests/topotests/bgp_duplicate_nexthop/test_bgp_duplicate_nexthop.py
@@ -417,6 +417,18 @@ def test_bgp_ipv4_recursive_routes():
 
     check_ipv4_prefix_with_multiple_nexthops_linux("192.0.2.8")
 
+    # Calculate expected installed count: Count nexthops that are actually installed
+    output = json.loads(tgen.gears["r1"].vtysh_cmd("show ip route 192.0.2.8/32 json"))
+    expected_installed = 0
+    for nh in output["192.0.2.8/32"][0]["nexthops"]:
+        if nh.get("fib") == True:
+            expected_installed += 1
+
+    installed_num = output["192.0.2.8/32"][0]["internalNextHopFibInstalledNum"]
+    assert (
+        installed_num == expected_installed
+    ), f"Expected internalNextHopFibInstalledNum={expected_installed}, got {installed_num}"
+
 
 def test_bgp_ipv4_recursive_routes_when_no_mpath():
     """

--- a/tests/topotests/bgp_redistribute_table/test_bgp_redistribute_table.py
+++ b/tests/topotests/bgp_redistribute_table/test_bgp_redistribute_table.py
@@ -98,6 +98,8 @@ def _router_json_cmp_exact_filter(router, cmd, expected):
                 attr.pop("internalNextHopNum")
             if "internalNextHopActiveNum" in attr:
                 attr.pop("internalNextHopActiveNum")
+            if "internalNextHopFibInstalledNum" in attr:
+                attr.pop("internalNextHopFibInstalledNum")
             if "nexthopGroupId" in attr:
                 attr.pop("nexthopGroupId")
             if "installedNexthopGroupId" in attr:

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -594,6 +594,8 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 		json_object_int_add(json_route, "internalNextHopActiveNum",
 				    nexthop_group_active_nexthop_num(
 					    &(re->nhe->nhg)));
+		json_object_int_add(json_route, "internalNextHopFibInstalledNum",
+				    nexthop_group_fib_nexthop_num(&(re->nhe->nhg)));
 		json_object_int_add(json_route, "nexthopGroupId", re->nhe_id);
 
 		if (re->nhe_installed_id != 0)


### PR DESCRIPTION
Add a JSON field showing count of nexthops installed in kernel FIB. Useful for debugging duplicate nexthop scenarios.