### PR TITLE
zebra: freebsd is sending a broadcast of 0.0.0.0

### DIFF
--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -830,7 +830,7 @@ static void ifam_read_mesg(struct ifa_msghdr *ifm, union sockunion *addr,
 int ifam_read(struct ifa_msghdr *ifam)
 {
 	struct interface *ifp = NULL;
-	union sockunion addr, mask, brd;
+	union sockunion addr, mask, brd, zero = { 0 };
 	bool dest_same = false;
 	char ifname[IFNAMSIZ];
 	short ifnlen = 0;
@@ -865,7 +865,8 @@ int ifam_read(struct ifa_msghdr *ifam)
 	if (if_is_pointopoint(ifp))
 		SET_FLAG(flags, ZEBRA_IFA_PEER);
 	else {
-		if (memcmp(&addr, &brd, sizeof(addr)) == 0)
+		if ((memcmp(&addr, &brd, sizeof(addr)) == 0)
+		    || (memcmp(&brd, &zero, sizeof(addr)) == 0))
 			dest_same = true;
 	}
 


### PR DESCRIPTION
This broadcast of 0.0.0.0 is being treated as
the dest_same as false.  When creating the
ifc on freebsd the ifc is created with no
broadcast values and as such when a deletion
event happens the ifc is not found and the
event is ignored.  Modify the code to
treat a broadcast address of 0 as a dest_same = true.

This allows for the deletion of the local and connected routes.

sharpd@robot:~/frr $ sudo ifconfig lo0 inet 216.92.216.57 netmask 255.255.255.0 add sharpd@robot:~/frr $ sudo vtysh -c "show ip route" % Can't open configuration file /usr/local/etc/frr/vtysh.conf due to 'No such file or directory'. Configuration file[/usr/local/etc/frr/frr.conf] processing failure: 11 2025/10/01 18:29:59 [H0DHT-S9KF2][EC 100663299] setsockopt_so_recvbuf: fd 3: SO_RCVBUF set to 1048576 (requested 16777216) 2025/10/01 18:29:59 [H0DHT-S9KF2][EC 100663299] setsockopt_so_recvbuf: fd 4: SO_RCVBUF set to 1048576 (requested 16777216) Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

IPv4 unicast VRF default:
K>* 0.0.0.0/0 [0/0] via 192.168.64.1, vtnet0, 00:01:23 C>* 192.168.64.0/24 [0/1] is directly connected, vtnet0, weight 1, 00:01:23 L>* 192.168.64.5/32 is directly connected, vtnet0, weight 1, 00:01:23 C>* 216.92.216.0/24 [0/1] is directly connected, lo0, weight 1, 00:00:06 L>* 216.92.216.57/32 is directly connected, lo0, weight 1, 00:00:06 sharpd@robot:~/frr $ sudo ifconfig lo0 inet 216.92.216.57 netmask 255.255.255.0 delete sharpd@robot:~/frr $ sudo vtysh -c "show ip route" % Can't open configuration file /usr/local/etc/frr/vtysh.conf due to 'No such file or directory'. Configuration file[/usr/local/etc/frr/frr.conf] processing failure: 11 2025/10/01 18:30:06 [H0DHT-S9KF2][EC 100663299] setsockopt_so_recvbuf: fd 3: SO_RCVBUF set to 1048576 (requested 16777216) 2025/10/01 18:30:06 [H0DHT-S9KF2][EC 100663299] setsockopt_so_recvbuf: fd 4: SO_RCVBUF set to 1048576 (requested 16777216) Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

IPv4 unicast VRF default:
K>* 0.0.0.0/0 [0/0] via 192.168.64.1, vtnet0, 00:01:30 C>* 192.168.64.0/24 [0/1] is directly connected, vtnet0, weight 1, 00:01:30 L>* 192.168.64.5/32 is directly connected, vtnet0, weight 1, 00:01:30 sharpd@robot:~/frr $