### PR TITLE
tests: ospf_topo2 allow dead interval to be a bit longer

### DIFF
--- a/tests/topotests/ospf_topo2/r1/frr.conf
+++ b/tests/topotests/ospf_topo2/r1/frr.conf
@@ -8,7 +8,7 @@ ip router-id 192.0.2.1
 interface eth1
  ip address 192.0.2.1/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf dead-interval minimal hello-multiplier 10
  ip ospf network point-to-point
  ipv6 address 2001:db8::1/128
  ipv6 ospf6 area 0.0.0.0
@@ -20,7 +20,7 @@ exit
 interface eth2
  ip address 192.0.2.1/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf dead-interval minimal hello-multiplier 10
  ip ospf network point-to-point
  ipv6 address 2001:db8::1/128
  ipv6 ospf6 area 0.0.0.0
@@ -32,7 +32,7 @@ exit
 interface eth3
  ip address 192.0.2.1/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf dead-interval minimal hello-multiplier 10
  ip ospf network point-to-point
  ipv6 address 2001:db8::1/128
  ipv6 ospf6 area 0.0.0.0

--- a/tests/topotests/ospf_topo2/r2/frr.conf
+++ b/tests/topotests/ospf_topo2/r2/frr.conf
@@ -8,7 +8,7 @@ ip router-id 192.0.2.2
 interface eth1
  ip address 192.0.2.2/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf dead-interval minimal hello-multiplier 10
  ip ospf network point-to-point
  ipv6 address 2001:db8::2/128
  ipv6 ospf6 area 0.0.0.0
@@ -20,7 +20,7 @@ exit
 interface eth2
  ip address 192.0.2.2/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf dead-interval minimal hello-multiplier 10
  ip ospf network point-to-point
  ipv6 address 2001:db8::2/128
  ipv6 ospf6 area 0.0.0.0
@@ -32,7 +32,7 @@ exit
 interface eth3
  ip address 192.0.2.2/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf dead-interval minimal hello-multiplier 10
  ip ospf network point-to-point
  ipv6 address 2001:db8::2/128
  ipv6 ospf6 area 0.0.0.0

--- a/tests/topotests/ospf_topo2/r3/frr.conf
+++ b/tests/topotests/ospf_topo2/r3/frr.conf
@@ -8,7 +8,7 @@ ip router-id 192.0.2.3
 interface eth1
  ip address 192.0.2.3/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf dead-interval minimal hello-multiplier 10
  ip ospf network point-to-point
  ipv6 address 2001:db8::3/128
  ipv6 ospf6 area 0.0.0.0
@@ -20,7 +20,7 @@ exit
 interface eth2
  ip address 192.0.2.3/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf dead-interval minimal hello-multiplier 10
  ip ospf network point-to-point
  ipv6 address 2001:db8::3/128
  ipv6 ospf6 area 0.0.0.0
@@ -32,7 +32,7 @@ exit
 interface eth3
  ip address 192.0.2.3/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf dead-interval minimal hello-multiplier 10
  ip ospf network point-to-point
  ipv6 address 2001:db8::3/128
  ipv6 ospf6 area 0.0.0.0

--- a/tests/topotests/ospf_topo2/r4/frr.conf
+++ b/tests/topotests/ospf_topo2/r4/frr.conf
@@ -8,7 +8,7 @@ ip router-id 192.0.2.4
 interface eth1
  ip address 192.0.2.4/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf dead-interval minimal hello-multiplier 10
  ip ospf network point-to-point
  ipv6 address 2001:db8::4/128
  ipv6 ospf6 area 0.0.0.0
@@ -20,7 +20,7 @@ exit
 interface eth2
  ip address 192.0.2.4/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf dead-interval minimal hello-multiplier 10
  ip ospf network point-to-point
  ipv6 address 2001:db8::4/128
  ipv6 ospf6 area 0.0.0.0
@@ -32,7 +32,7 @@ exit
 interface eth3
  ip address 192.0.2.4/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf dead-interval minimal hello-multiplier 10
  ip ospf network point-to-point
  ipv6 address 2001:db8::4/128
  ipv6 ospf6 area 0.0.0.0


### PR DESCRIPTION
Current dead interval multiplier is 4, the hello interval is configured for .25s.  This leads to under heavy load a neighbor could be turned off if it cannot get to the offending interface in under 1 second.  Let's give it a bigger leaway of 2.5 seconds.  I am not seeing
this problem with the ospfv6 version of the test
so my assumption is that this is going to make
the problem happen much much less.