### PR TITLE
tests: ospf_topo2 allow dead interval to be a bit longer

### DIFF
--- a/tests/topotests/ospf_topo2/r1/frr.conf
+++ b/tests/topotests/ospf_topo2/r1/frr.conf
@@ -8,7 +8,8 @@ ip router-id 192.0.2.1
 interface eth1
  ip address 192.0.2.1/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf hello-interval 1
+ ip ospf dead-interval 5
  ip ospf network point-to-point
  ipv6 address 2001:db8::1/128
  ipv6 ospf6 area 0.0.0.0
@@ -20,7 +21,8 @@ exit
 interface eth2
  ip address 192.0.2.1/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf hello-interval 1
+ ip ospf dead-interval 5
  ip ospf network point-to-point
  ipv6 address 2001:db8::1/128
  ipv6 ospf6 area 0.0.0.0
@@ -32,7 +34,8 @@ exit
 interface eth3
  ip address 192.0.2.1/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf hello-interval 1
+ ip ospf dead-interval 5
  ip ospf network point-to-point
  ipv6 address 2001:db8::1/128
  ipv6 ospf6 area 0.0.0.0
@@ -59,3 +62,4 @@ router ospf6
 exit
 !
 end
+

--- a/tests/topotests/ospf_topo2/r2/frr.conf
+++ b/tests/topotests/ospf_topo2/r2/frr.conf
@@ -8,7 +8,8 @@ ip router-id 192.0.2.2
 interface eth1
  ip address 192.0.2.2/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf hello-interval 1
+ ip ospf dead-interval 5
  ip ospf network point-to-point
  ipv6 address 2001:db8::2/128
  ipv6 ospf6 area 0.0.0.0
@@ -20,7 +21,8 @@ exit
 interface eth2
  ip address 192.0.2.2/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf hello-interval 1
+ ip ospf dead-interval 5
  ip ospf network point-to-point
  ipv6 address 2001:db8::2/128
  ipv6 ospf6 area 0.0.0.0
@@ -32,7 +34,8 @@ exit
 interface eth3
  ip address 192.0.2.2/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf hello-interval 1
+ ip ospf dead-interval 5
  ip ospf network point-to-point
  ipv6 address 2001:db8::2/128
  ipv6 ospf6 area 0.0.0.0
@@ -59,3 +62,4 @@ router ospf6
 exit
 !
 end
+

--- a/tests/topotests/ospf_topo2/r3/frr.conf
+++ b/tests/topotests/ospf_topo2/r3/frr.conf
@@ -8,7 +8,8 @@ ip router-id 192.0.2.3
 interface eth1
  ip address 192.0.2.3/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf hello-interval 1
+ ip ospf dead-interval 5
  ip ospf network point-to-point
  ipv6 address 2001:db8::3/128
  ipv6 ospf6 area 0.0.0.0
@@ -20,7 +21,8 @@ exit
 interface eth2
  ip address 192.0.2.3/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf hello-interval 1
+ ip ospf dead-interval 5
  ip ospf network point-to-point
  ipv6 address 2001:db8::3/128
  ipv6 ospf6 area 0.0.0.0
@@ -32,7 +34,8 @@ exit
 interface eth3
  ip address 192.0.2.3/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf hello-interval 1
+ ip ospf dead-interval 5
  ip ospf network point-to-point
  ipv6 address 2001:db8::3/128
  ipv6 ospf6 area 0.0.0.0
@@ -59,3 +62,4 @@ router ospf6
 exit
 !
 end
+

--- a/tests/topotests/ospf_topo2/r4/frr.conf
+++ b/tests/topotests/ospf_topo2/r4/frr.conf
@@ -8,7 +8,8 @@ ip router-id 192.0.2.4
 interface eth1
  ip address 192.0.2.4/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf hello-interval 1
+ ip ospf dead-interval 5
  ip ospf network point-to-point
  ipv6 address 2001:db8::4/128
  ipv6 ospf6 area 0.0.0.0
@@ -20,7 +21,8 @@ exit
 interface eth2
  ip address 192.0.2.4/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf hello-interval 1
+ ip ospf dead-interval 5
  ip ospf network point-to-point
  ipv6 address 2001:db8::4/128
  ipv6 ospf6 area 0.0.0.0
@@ -32,7 +34,8 @@ exit
 interface eth3
  ip address 192.0.2.4/32
  ip ospf area 0.0.0.0
- ip ospf dead-interval minimal hello-multiplier 4
+ ip ospf hello-interval 1
+ ip ospf dead-interval 5
  ip ospf network point-to-point
  ipv6 address 2001:db8::4/128
  ipv6 ospf6 area 0.0.0.0
@@ -59,3 +62,4 @@ router ospf6
 exit
 !
 end
+


### PR DESCRIPTION
The current code for this test uses the `dead-interval minimal..` command.  This causes the hello timer to be `1/<minimal value>` in seconds.  So with 4 each hello is sent out every 1/4 second. In our ci system a heavily loaded system may not even get to a 1 second dead timer and cause the daemon to time out the peering.  This is not really conducive to a testing setup that is under load.  Change the test to not do this and to give much more lenient timers.