### PR TITLE
tests: Allow a Collision notification to not fail the test

### DIFF
--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/notification_check.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/notification_check.py
@@ -12,6 +12,9 @@ for rtr in rtrs:
     found = luLast()
     if ret != False and found != None:
         val = found.group(1)
+        # Skip Connection Collision Resolution notifications as they are normal
+        if "Cease/Connection Collision Resolution" in val:
+            continue
         ret = luCommand(
             rtr,
             'vtysh -c "show bgp neigh"',


### PR DESCRIPTION
There are a series of tests that use the `notification_check.py` script to test that neighbors have come up.  Unfortunately it is failing if any notification messages come in.  A `Cease/Collision` notification is a normal part of bgp operation and should not be used to fail the test as that it is completely normal for both sides to connect at the same time, especially in a testing environment.

We can see this in our daily runs:
     * test_notification_check (https://ci1.netdef.org/browse/FRR-FRR-9012)
     * test_notification_check (https://ci1.netdef.org/browse/FRR-FRR-9018)
     * test_notification_check (https://ci1.netdef.org/browse/FRR-FRR-9019)

All three of these show the same problem.  Let's just make the message something that doesn't fail the test.