### PR TITLE
eigrpd, ospfd, pimd: Fix usage of packed member unaligned

### DIFF
--- a/eigrpd/eigrp_dump.c
+++ b/eigrpd/eigrp_dump.c
@@ -97,6 +97,9 @@ static int eigrp_neighbor_packet_queue_sum(struct eigrp_interface *ei)
  */
 void eigrp_ip_header_dump(struct ip *iph)
 {
+	struct in_addr srcaddr = iph->ip_src;
+	struct in_addr dstaddr = iph->ip_dst;
+
 	/* IP Header dump. */
 	zlog_debug("ip_v %u", iph->ip_v);
 	zlog_debug("ip_hl %u", iph->ip_hl);
@@ -107,8 +110,8 @@ void eigrp_ip_header_dump(struct ip *iph)
 	zlog_debug("ip_ttl %u", iph->ip_ttl);
 	zlog_debug("ip_p %u", iph->ip_p);
 	zlog_debug("ip_sum 0x%x", (uint32_t)iph->ip_sum);
-	zlog_debug("ip_src %pI4", &iph->ip_src);
-	zlog_debug("ip_dst %pI4", &iph->ip_dst);
+	zlog_debug("ip_src %pI4", &srcaddr);
+	zlog_debug("ip_dst %pI4", &dstaddr);
 }
 
 /*

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -771,9 +771,12 @@ int pim_igmp_packet(struct gm_sock *igmp, char *buf, size_t len)
 		router_alert = false;
 
 	if (pim_interface->gmp_require_ra && !router_alert) {
-		if (PIM_DEBUG_GM_PACKETS)
+		if (PIM_DEBUG_GM_PACKETS) {
+			struct in_addr srcaddr = ip_hdr->ip_src;
+
 			zlog_debug("discarding IGMP packet from %pI4 on %s due to Router Alert option missing",
-				   &ip_hdr->ip_src, igmp->interface->name);
+				   &srcaddr, igmp->interface->name);
+		}
 		return -1;
 	}
 

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -236,9 +236,13 @@ int pim_pim_packet(struct interface *ifp, uint8_t *buf, size_t len,
 			break;
 
 #if PIM_IPV == 4
-		if (PIM_DEBUG_PIM_PACKETS)
-			zlog_debug("neighbor filter rejects packet %pI4 -> %pI4 on %s",
-				   &ip_hdr->ip_src, &ip_hdr->ip_dst, ifp->name);
+		if (PIM_DEBUG_PIM_PACKETS) {
+			struct in_addr srcaddr = ip_hdr->ip_src;
+			struct in_addr dstaddr = ip_hdr->ip_dst;
+
+			zlog_debug("neighbor filter rejects packet %pI4 -> %pI4 on %s", &srcaddr,
+				   &dstaddr, ifp->name);
+		}
 #else
 		if (PIM_DEBUG_PIM_PACKETS)
 			zlog_debug("neighbor filter rejects packet %pI6 -> %pI6 on %s", &sg.src,


### PR DESCRIPTION
FreeBSD is complaining:

warning: taking address of packed member 'ip_src' of class or structure 'ip' may result in an unaligned pointer value [-Waddress-of-packed-member]

Let's fix this so the problem goes away and the compilation is clean.