### PR TITLE
doc: Fixup building freebsd14 doc

### DIFF
--- a/doc/developer/building-frr-for-freebsd14.rst
+++ b/doc/developer/building-frr-for-freebsd14.rst
@@ -18,7 +18,7 @@ is first package install and asked)
 .. code-block:: shell
 
    pkg install autoconf automake bison c-ares git gmake json-c libtool \
-        libunwind libyang2 pkgconf protobuf-c py39-pytest py39-sphinx texinfo
+        libunwind libyang2 pkgconf protobuf-c texinfo
 
 .. include:: building-libunwind-note.rst
 


### PR DESCRIPTION
These two packages are not available on freebsd14 when I try to install them:

sharpd@robot:~/frr $ sudo pkg install py32-sphinx
Updating FreeBSD-ports repository catalogue...
FreeBSD-ports repository is up to date.
Updating FreeBSD-ports-kmods repository catalogue... FreeBSD-ports-kmods repository is up to date.
All repositories are up to date.
pkg: No packages available to install matching 'py32-sphinx' have been found in the repositories sharpd@robot:~/frr $ sudo pkg install py39-pytest
Updating FreeBSD-ports repository catalogue...
FreeBSD-ports repository is up to date.
Updating FreeBSD-ports-kmods repository catalogue... FreeBSD-ports-kmods repository is up to date.
All repositories are up to date.
pkg: No packages available to install matching 'py39-pytest' have been found in the repositories

Build proceeds as per normal and I do not have any issues with building or running FRR.  Let's remove these needed packages.