### PR TITLE
Clang 19 on bsd sa issues

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2724,7 +2724,7 @@ route_set_aspath_replace(void *rule, const struct prefix *dummy, void *object)
 		path->attr->aspath = aspath_replace_regex_asn(aspath_new,
 							      aspath_acl,
 							      configured_asn);
-	} else if (strmatch(replace, "any")) {
+	} else if (replace && strmatch(replace, "any")) {
 		path->attr->aspath =
 			aspath_replace_all_asn(aspath_new, configured_asn);
 	} else {

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -845,8 +845,9 @@ int vrf_bind(vrf_id_t vrf_id, int fd, const char *ifname)
 		/* nothing to do for default vrf */
 		if (vrf_id == VRF_DEFAULT)
 			return 0;
-
+#ifdef SO_BINDTODEVICE
 		ifname = vrf->name;
+#endif
 	}
 
 #ifdef SO_BINDTODEVICE

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -599,8 +599,12 @@ struct ripng_info *ripng_ecmp_replace(struct ripng *ripng,
 struct ripng_info *ripng_ecmp_delete(struct ripng *ripng,
 				     struct ripng_info *rinfo)
 {
-	struct agg_node *rp = rinfo->rp;
-	struct list *list = (struct list *)rp->info;
+	struct agg_node *rp;
+	struct list *list;
+
+	assert(rinfo);
+	rp = rinfo->rp;
+	list = rp->info;
 
 	event_cancel(&rinfo->t_timeout);
 


### PR DESCRIPTION
Ran clang 19 SA on *BSD and it found some stuff that needed to be cleaned up.  