### PR TITLE
bgp: memleak in ecommunity,community,lcommunity

### DIFF
--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -685,12 +685,24 @@ void bgp_path_info_mpath_aggregate_update(struct bgp_path_info *new_best,
 
 		attr.aspath = aspath;
 		attr.origin = origin;
-		if (community)
+		if (community) {
+			struct community *old_comm = bgp_attr_get_community(&attr);
+			if (old_comm && !old_comm->refcnt)
+				community_free(&old_comm);
 			bgp_attr_set_community(&attr, community);
-		if (ecomm)
+		}
+		if (ecomm) {
+			struct ecommunity *old_ecom = bgp_attr_get_ecommunity(&attr);
+			if (old_ecom && !old_ecom->refcnt)
+				ecommunity_free(&old_ecom);
 			bgp_attr_set_ecommunity(&attr, ecomm);
-		if (lcomm)
+		}
+		if (lcomm) {
+			struct lcommunity *old_lcomm = bgp_attr_get_lcommunity(&attr);
+			if (old_lcomm && !old_lcomm->refcnt)
+				lcommunity_free(&old_lcomm);
 			bgp_attr_set_lcommunity(&attr, lcomm);
+		}
 
 		/* Zap multipath attr nexthop so we set nexthop to self */
 		attr.nexthop.s_addr = INADDR_ANY;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2858,14 +2858,20 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 	if (nh_reset && bgp_path_info_mpath_chkwtd(bgp, pi) &&
 	    (cum_bw = bgp_path_info_mpath_cumbw(pi)) != 0 &&
 	    !CHECK_FLAG(attr->rmap_change_flags, BATTR_RMAP_LINK_BW_SET)) {
-		if (CHECK_FLAG(peer->flags, PEER_FLAG_EXTENDED_LINK_BANDWIDTH))
+		if (CHECK_FLAG(peer->flags, PEER_FLAG_EXTENDED_LINK_BANDWIDTH)) {
+			struct ecommunity *old_ecom = bgp_attr_get_ipv6_ecommunity(attr);
+			if (old_ecom && !old_ecom->refcnt)
+				ecommunity_free(&old_ecom);
 			bgp_attr_set_ipv6_ecommunity(
 				attr,
 				ecommunity_replace_linkbw(bgp->as,
 							  bgp_attr_get_ipv6_ecommunity(
 								  attr),
 							  cum_bw, false, true));
-		else
+		} else {
+			struct ecommunity *old_ecom = bgp_attr_get_ecommunity(attr);
+			if (old_ecom && !old_ecom->refcnt)
+				ecommunity_free(&old_ecom);
 			bgp_attr_set_ecommunity(
 				attr,
 				ecommunity_replace_linkbw(
@@ -2874,6 +2880,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 					CHECK_FLAG(peer->flags,
 						   PEER_FLAG_DISABLE_LINK_BW_ENCODING_IEEE),
 					false));
+		}
 	}
 
 	/*


### PR DESCRIPTION
During  ecommunity_replace_linkbw, we are not freeing old ecom memory.  Similar thing handled in
bgp_path_info_mpath_aggregate_update