### PR TITLE
lib: suppress known memleaks in LeakSanitizer

### DIFF
--- a/lib/sanitizer.c
+++ b/lib/sanitizer.c
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Sanitizer related code
+ * Copyright (c) 2025 Network Device Education Foundation (NetDEF), Inc.
+ *               David Schweizer
+ */
+
+
+#include "sanitizer.h"
+
+
+/* Suppress known FRRouting memory leaks in leak sanitizer output */
+#if defined(FRR_HAVE_LEAK_SANITIZER) && !defined(FRR_NO_KNOWN_MEMLEAK)
+const char *__lsan_default_suppressions(void)
+{
+	/* clang-format off */
+
+	/*
+	 * List of known memory leaks to suppress. Please keep in alphabetical
+	 * order.
+	 */
+	return
+		"leak:list_new\n"
+		"leak:listnode_new\n"
+		"leak:ospf_path_new\n"
+		"leak:ospf_route_new\n"
+		"leak:ospf_spf_vertex_copy\n"
+		"leak:ospf_spf_vertex_parent_copy\n"
+		"leak:prefix_copy\n"
+		"leak:route_node_create\n"
+		"leak:route_table_init_with_delegate\n"
+		"leak:vertex_nexthop_new\n"
+		"leak:vertex_parent_new\n"
+		"";
+
+	/* clang-format on */
+}
+#endif
+
+
+/* EOF */

--- a/lib/sanitizer.h
+++ b/lib/sanitizer.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Sanitizer related definitions
+ * Copyright (c) 2025 Network Device Education Foundation (NetDEF), Inc.
+ *               David Schweizer
+ */
+
+
+#ifndef _FRR_SANITIZER_H
+#define _FRR_SANITIZER_H
+
+
+/* Leak sanitizer availability check for LLVM */
+#if defined(__clang__) && defined(__has_feature)
+#if __has_feature(leak_sanitizer) || __has_feature(address_sanitizer)
+#define FRR_HAVE_LEAK_SANITIZER
+#endif
+#endif
+
+/* Leak sanitizer availability check for GCC */
+#if (defined(__GNUC__) || defined(__GNUG__)) && defined(__SANITIZE_ADDRESS__)
+#define FRR_HAVE_LEAK_SANITIZER
+#endif
+
+/* Suppress known FRRouting memory leaks in leak sanitizer output */
+#if defined(FRR_HAVE_LEAK_SANITIZER) && !defined(FRR_NO_KNOWN_MEMLEAK)
+extern const char *__lsan_default_suppressions(void);
+#endif
+
+
+#endif /* _FRR_SANITIZER_H */
+
+
+/* EOF */

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -103,6 +103,7 @@ lib_libfrr_la_SOURCES = \
 	lib/routemap.c \
 	lib/routemap_cli.c \
 	lib/routemap_northbound.c \
+	lib/sanitizer.c \
 	lib/sbuf.c \
 	lib/seqlock.c \
 	lib/sha256.c \
@@ -290,6 +291,7 @@ pkginclude_HEADERS += \
 	lib/ringbuf.h \
 	lib/routemap.h \
 	lib/route_opaque.h \
+	lib/sanitizer.h \
 	lib/sbuf.h \
 	lib/seqlock.h \
 	lib/sha256.h \


### PR DESCRIPTION
Suppress known memory leaks reported by LeakSanitizer with a filter list.

