### PR TITLE
ospfd: On cleanup, actually free vertexes

### DIFF
--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -57,8 +57,6 @@ static void ospf_spf_set_reason(ospf_spf_reason_t reason)
 	spf_reason_flags |= 1 << reason;
 }
 
-static void ospf_vertex_free(void *);
-
 /*
  * Heap related functions, for the managment of the candidates, to
  * be used with pqueue.
@@ -207,7 +205,7 @@ static struct vertex *ospf_vertex_new(struct ospf_area *area,
 	return new;
 }
 
-static void ospf_vertex_free(void *data)
+void ospf_vertex_free(void *data)
 {
 	struct vertex *v = data;
 

--- a/ospfd/ospf_spf.h
+++ b/ospfd/ospf_spf.h
@@ -74,6 +74,7 @@ extern void ospf_spf_calculate_areas(struct ospf *ospf,
 				     struct route_table *new_rtrs);
 extern void ospf_rtrs_free(struct route_table *);
 extern void ospf_spf_cleanup(struct vertex *spf, struct list *vertex_list);
+extern void ospf_vertex_free(void *data);
 extern void ospf_spf_copy(struct vertex *vertex, struct list *vertex_list);
 extern void ospf_spf_remove_resource(struct vertex *vertex,
 				     struct list *vertex_list,

--- a/ospfd/ospf_ti_lfa.c
+++ b/ospfd/ospf_ti_lfa.c
@@ -782,6 +782,7 @@ ospf_ti_lfa_generate_p_space(struct ospf_area *area, struct vertex *child,
 
 	p_space = XCALLOC(MTYPE_OSPF_P_SPACE, sizeof(struct p_space));
 	vertex_list = list_new();
+	vertex_list->del = ospf_vertex_free;
 
 	/* The P-space will get its own SPF tree, so copy the old one */
 	ospf_spf_copy(area->spf, vertex_list);


### PR DESCRIPTION
Upon examining this Indirect leak:

Indirect leak of 160 byte(s) in 4 object(s) allocated from:
    #0 0x7fe4f40b83b7 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x7fe4f3c24c1d in qcalloc lib/memory.c:111
    #2 0x7fe4f3c03441 in list_new lib/linklist.c:49
    #3 0x564c81d076f9 in ospf_spf_vertex_copy ospfd/ospf_spf.c:335
    #4 0x564c81d0bff2 in ospf_spf_copy ospfd/ospf_spf.c:378
    #5 0x564c81d158e8 in ospf_ti_lfa_generate_p_space ospfd/ospf_ti_lfa.c:787
    #6 0x564c81d162f5 in ospf_ti_lfa_generate_p_spaces ospfd/ospf_ti_lfa.c:923
    #7 0x564c81d16532 in ospf_ti_lfa_compute ospfd/ospf_ti_lfa.c:1101
    #8 0x564c81d0e942 in ospf_spf_calculate_area ospfd/ospf_spf.c:1811
    #9 0x564c81d0eaa6 in ospf_spf_calculate_areas ospfd/ospf_spf.c:1840
    #10 0x564c81d0eda2 in ospf_spf_calculate_schedule_worker ospfd/ospf_spf.c:1871
    #11 0x7fe4f3cdd7c3 in event_call lib/event.c:2009
    #12 0x7fe4f3c027e9 in frr_run lib/libfrr.c:1252
    #13 0x564c81c95191 in main ospfd/ospf_main.c:307
    #14 0x7fe4f370c249 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

It was noticed that the vertex has another list that is not being cleanedup.  Let's allow this to happen.