### PR TITLE
build: Add warning for address of packed member

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -482,6 +482,7 @@ AC_C_FLAG([-Wno-unused-parameter])
 AC_C_FLAG([-Wno-missing-field-initializers])
 AC_C_FLAG([-Wno-microsoft-anon-tag])
 AC_C_FLAG([-Wno-error=deprecated-declarations])
+AC_C_FLAG([-Waddress-of-packed-member])
 
 AC_C_FLAG([-Wc++-compat], [], [CXX_COMPAT_CFLAGS="-Wc++-compat"])
 AC_SUBST([CXX_COMPAT_CFLAGS])


### PR DESCRIPTION
Compilers have the ability to tell you when you take a unaligned address within a packed structure.  Let's turn that on.