### PR TITLE
tests: Fix cleanup of ospf_spf make check test

### DIFF
--- a/tests/ospfd/test_ospf_spf.c
+++ b/tests/ospfd/test_ospf_spf.c
@@ -125,7 +125,6 @@ static void test_run_spf(struct vty *vty, struct ospf *ospf,
 
 	/* Cleanup */
 	ospf_ti_lfa_free_p_spaces(area);
-	ospf_spf_cleanup(area->spf, area->spf_vertex_list);
 
 	/*
 	 * Print the new routing table which is augmented with TI-LFA backup


### PR DESCRIPTION
The introduction of 2d0f4603a4a6f6ab3a7406ba0af575548a1c7b46 caused a issue with `make check` as that it did not properly handle the cleanup since it changed the way cleanup was done.