### PR TITLE
bgpd: ensure batch clearing flags are clear

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6866,8 +6866,9 @@ static int walk_batch_table_helper(struct bgp_clearing_info *cinfo,
 	/* Locate starting dest, possibly using "resume" info */
 	dest = clearing_dest_helper(table, cinfo, inner_p);
 
-	/* Reset flag */
-	UNSET_FLAG(cinfo->flags, BGP_CLEARING_INFO_FLAG_RESUME);
+	/* Reset flags, now that we've used the "resume" info */
+	UNSET_FLAG(cinfo->flags, (BGP_CLEARING_INFO_FLAG_RESUME |
+				  BGP_CLEARING_INFO_FLAG_INNER));
 
 	if (bgp_debug_neighbor_events(NULL))
 		zlog_debug("%s: table %s/%s, dest %pBD", __func__, afi2str(table->afi),


### PR DESCRIPTION
Once the clearing iteration has used any 'resume' info, ensure the appropriate batch flags are cleared. It's possible for the "INNER" flag to remain set after it's been used.