### PR TITLE
tests: Ensure key exists for bgp_evpn_mh

### DIFF
--- a/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
+++ b/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
@@ -485,6 +485,8 @@ def check_es(dut):
     for es in bgp_es_json:
         esi = es["esi"]
         curr_es_set.append(esi)
+        if not es.get("type", False):
+            return None
         types = es["type"]
         vtep_ips = []
         for vtep in es.get("vteps", []):
@@ -516,6 +518,8 @@ def check_one_es(dut, esi, down_vteps):
         return "esi %s not found" % esi
 
     esi = es["esi"]
+    if not es.get("type", False):
+        return None
     types = es["type"]
     vtep_ips = []
     for vtep in es.get("vteps", []):


### PR DESCRIPTION
I am seeing occassional test failures with the
bgp_evpn_mh test where the key doesn't exist.  When I look at the support bundle the key is there.  Clearly a tight timing window is being hit.