### PR TITLE
*: don't access invalid zapi route msg nexthops

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -512,18 +512,21 @@ static int zebra_read_route(ZAPI_CALLBACK_ARGS)
 	    && IN6_IS_ADDR_LINKLOCAL(&api.prefix.u.prefix6))
 		return 0;
 
-	ifindex = api.nexthops[0].ifindex;
-	nhtype = api.nexthops[0].type;
-
-	/* api_nh structure has union of gate and bh_type */
-	if (nhtype == NEXTHOP_TYPE_BLACKHOLE) {
-		/* bh_type is only applicable if NEXTHOP_TYPE_BLACKHOLE*/
-		bhtype = api.nexthops[0].bh_type;
-	} else
-		nexthop = api.nexthops[0].gate;
-
 	add = (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD);
 	if (add) {
+		if (api.nexthop_num == 0)
+			return 0;
+
+		ifindex = api.nexthops[0].ifindex;
+		nhtype = api.nexthops[0].type;
+
+		/* api_nh structure has union of gate and bh_type */
+		if (nhtype == NEXTHOP_TYPE_BLACKHOLE) {
+			/* bh_type is only applicable if NEXTHOP_TYPE_BLACKHOLE*/
+			bhtype = api.nexthops[0].bh_type;
+		} else
+			nexthop = api.nexthops[0].gate;
+
 		/*
 		 * The ADD message is actually an UPDATE and there is no
 		 * explicit DEL

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -250,7 +250,7 @@ int ospf6_zebra_gr_disable(struct ospf6 *ospf6)
 static int ospf6_zebra_read_route(ZAPI_CALLBACK_ARGS)
 {
 	struct zapi_route api;
-	unsigned long ifindex;
+	unsigned long ifindex = 0;
 	const struct in6_addr *nexthop = &in6addr_any;
 	struct ospf6 *ospf6;
 	struct prefix_ipv6 p;
@@ -270,10 +270,12 @@ static int ospf6_zebra_read_route(ZAPI_CALLBACK_ARGS)
 	if (IN6_IS_ADDR_LINKLOCAL(&api.prefix.u.prefix6))
 		return 0;
 
-	ifindex = api.nexthops[0].ifindex;
-	if (api.nexthops[0].type == NEXTHOP_TYPE_IPV6
-	    || api.nexthops[0].type == NEXTHOP_TYPE_IPV6_IFINDEX)
-		nexthop = &api.nexthops[0].gate.ipv6;
+	if (api.nexthop_num > 0) {
+		ifindex = api.nexthops[0].ifindex;
+		if (api.nexthops[0].type == NEXTHOP_TYPE_IPV6 ||
+		    api.nexthops[0].type == NEXTHOP_TYPE_IPV6_IFINDEX)
+			nexthop = &api.nexthops[0].gate.ipv6;
+	}
 
 	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
 		zlog_debug(

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1284,8 +1284,8 @@ static int ospf_zebra_read_route(ZAPI_CALLBACK_ARGS)
 	struct zapi_route api;
 	struct prefix_ipv4 p;
 	struct prefix pgen = {};
-	unsigned long ifindex;
-	struct in_addr nexthop;
+	unsigned long ifindex = 0;
+	struct in_addr nexthop = {};
 	struct external_info *ei;
 	struct ospf *ospf;
 	int i;
@@ -1298,8 +1298,10 @@ static int ospf_zebra_read_route(ZAPI_CALLBACK_ARGS)
 	if (zapi_route_decode(zclient->ibuf, &api) < 0)
 		return -1;
 
-	ifindex = api.nexthops[0].ifindex;
-	nexthop = api.nexthops[0].gate.ipv4;
+	if (api.nexthop_num > 0) {
+		ifindex = api.nexthops[0].ifindex;
+		nexthop = api.nexthops[0].gate.ipv4;
+	}
 	rt_type = api.type;
 
 	memcpy(&p, &api.prefix, sizeof(p));

--- a/ripd/rip_zebra.c
+++ b/ripd/rip_zebra.c
@@ -120,9 +120,12 @@ static int rip_zebra_read_route(ZAPI_CALLBACK_ARGS)
 		return -1;
 
 	memset(&nh, 0, sizeof(nh));
-	nh.type = api.nexthops[0].type;
-	nh.gate.ipv4 = api.nexthops[0].gate.ipv4;
-	nh.ifindex = api.nexthops[0].ifindex;
+
+	if (api.nexthop_num > 0) {
+		nh.type = api.nexthops[0].type;
+		nh.gate.ipv4 = api.nexthops[0].gate.ipv4;
+		nh.ifindex = api.nexthops[0].ifindex;
+	}
 
 	/* Then fetch IPv4 prefixes. */
 	if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD)

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -104,8 +104,8 @@ static int ripng_zebra_read_route(ZAPI_CALLBACK_ARGS)
 {
 	struct ripng *ripng;
 	struct zapi_route api;
-	struct in6_addr nexthop;
-	unsigned long ifindex;
+	struct in6_addr nexthop = {};
+	unsigned long ifindex = 0;
 
 	ripng = ripng_lookup_by_vrf_id(vrf_id);
 	if (!ripng)
@@ -121,8 +121,10 @@ static int ripng_zebra_read_route(ZAPI_CALLBACK_ARGS)
 	if (IN6_IS_ADDR_LINKLOCAL(&api.prefix.u.prefix6))
 		return 0;
 
-	nexthop = api.nexthops[0].gate.ipv6;
-	ifindex = api.nexthops[0].ifindex;
+	if (api.nexthop_num > 0) {
+		nexthop = api.nexthops[0].gate.ipv6;
+		ifindex = api.nexthops[0].ifindex;
+	}
 
 	if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD)
 		ripng_redistribute_add(ripng, api.type,


### PR DESCRIPTION
Some zapi route-update handlers were accessing the zapi message nexthop array without checking that the array contained valid data. Init locals in those functions, and only access valid data in the zapi messages.