### PR TITLE
Bgpd: Medium coverity changes - Null pointer dereferences

### DIFF
--- a/bgpd/bgp_btoa.c
+++ b/bgpd/bgp_btoa.c
@@ -89,8 +89,12 @@ static void attr_parse(struct stream *s, uint16_t len)
 
 			aspath = aspath_parse(s, length, 1,
 					      bgp_get_asnotation(NULL));
-			printf("ASPATH: %s\n", aspath->str);
-			aspath_free(aspath);
+			if (aspath) {
+				printf("ASPATH: %s\n", aspath->str);
+				aspath_free(aspath);
+			} else {
+				printf("ASPATH: malformed\n");
+			}
 		} break;
 		case BGP_ATTR_NEXT_HOP: {
 			struct in_addr nexthop;

--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -454,9 +454,10 @@ int bgp_evpn_mh_route_update(struct bgp *bgp, struct bgp_evpn_es *es,
 					: (vpn ? "ead-evi" : "ead-es"),
 				&attr->mp_nexthop_global_in);
 
-		frrtrace(4, frr_bgp, evpn_mh_local_ead_es_evi_route_upd,
-			 &es->esi, (vpn ? vpn->vni : 0), evp->prefix.route_type,
-			 attr->mp_nexthop_global_in);
+		if (es)
+			frrtrace(4, frr_bgp, evpn_mh_local_ead_es_evi_route_upd,
+				 &es->esi, (vpn ? vpn->vni : 0), evp->prefix.route_type,
+				 attr->mp_nexthop_global_in);
 	}
 
 	/* Return back th*e route entry. */

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -592,6 +592,7 @@ void bgp_generate_updgrp_packets(struct event *thread)
 			 * packet with appropriate attributes from peer
 			 * and advance peer */
 			s = bpacket_reformat_for_peer(next_pkt, paf);
+			assert(s);
 			bgp_packet_add(connection, peer, s);
 			bpacket_queue_advance_peer(paf);
 		}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3222,7 +3222,7 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,
 					zlog_debug("%s: %pBD(%s) pi from %s %p in holddown",
 						   __func__, dest,
 						   bgp->name_pretty,
-						   look_thru->peer->host,
+						   look_thru->peer ? look_thru->peer->host : "Unknown",
 						   look_thru);
 
 				if (CHECK_FLAG(look_thru->flags,
@@ -3250,6 +3250,9 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,
 
 					continue;
 				}
+
+			if (!look_thru->peer)
+				continue;
 
 			bgp_path_info_unset_flag(dest, look_thru,
 						 BGP_PATH_DMED_CHECK);

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2724,7 +2724,7 @@ route_set_aspath_replace(void *rule, const struct prefix *dummy, void *object)
 		path->attr->aspath = aspath_replace_regex_asn(aspath_new,
 							      aspath_acl,
 							      configured_asn);
-	} else if (strmatch(replace, "any")) {
+	} else if (replace && strmatch(replace, "any")) {
 		path->attr->aspath =
 			aspath_replace_all_asn(aspath_new, configured_asn);
 	} else {

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -1700,6 +1700,8 @@ DEFPY (no_rpki,
 	}
 
 	rpki_vrf = find_rpki_vrf(vrfname);
+	if (!rpki_vrf)
+		return CMD_WARNING;
 
 	rpki_delete_all_cache_nodes(rpki_vrf);
 	stop(rpki_vrf);

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1435,8 +1435,10 @@ static void update_subgroup_merge(struct update_subgroup *subgrp,
 
 	if (BGP_DEBUG(update_groups, UPDATE_GROUPS))
 		zlog_debug("u%" PRIu64 ":s%" PRIu64" (%d peers) merged into u%" PRIu64 ":s%" PRIu64", trigger: %s",
-			   subgrp->update_group->id, subgrp->id, peer_count,
-			   target->update_group->id, target->id,
+			   subgrp->update_group ? subgrp->update_group->id : 0,
+			   subgrp->id, peer_count,
+			   target->update_group ? target->update_group->id : 0,
+			   target->id,
 			   reason ? reason : "unknown");
 
 	result = update_subgroup_check_delete(subgrp);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -864,14 +864,20 @@ void subgroup_announce_route(struct update_subgroup *subgrp)
 	    && SUBGRP_SAFI(subgrp) != SAFI_ENCAP
 	    && SUBGRP_SAFI(subgrp) != SAFI_EVPN)
 		subgroup_announce_table(subgrp, NULL);
-	else
-		for (dest = bgp_table_top(update_subgroup_rib(subgrp)); dest;
+	else {
+		struct bgp_table *rib = update_subgroup_rib(subgrp);
+
+		if (!rib)
+			return;
+
+		for (dest = bgp_table_top(rib); dest;
 		     dest = bgp_route_next(dest)) {
 			table = bgp_dest_get_bgp_table_info(dest);
 			if (!table)
 				continue;
 			subgroup_announce_table(subgrp, table);
 		}
+	}
 }
 
 void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3487,6 +3487,11 @@ static int bgp_zebra_process_srv6_locator_chunk(ZAPI_CALLBACK_ARGS)
 	s = zclient->ibuf;
 	zapi_srv6_locator_chunk_decode(s, chunk);
 
+	if (!bgp) {
+		srv6_locator_chunk_free(&chunk);
+		return 0;
+	}
+
 	if (strcmp(bgp->srv6_locator_name, chunk->locator_name) != 0) {
 		zlog_err("%s: Locator name unmatch %s:%s", __func__,
 			 bgp->srv6_locator_name, chunk->locator_name);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2802,13 +2802,23 @@ int peer_delete(struct peer *peer)
 	/* If this peer belongs to peer group, clear up the
 	   relationship.  */
 	if (peer->group) {
+		/* CID 109492: Save peer->group pointer BEFORE peer_unlock().
+		 * peer_unlock() can free the peer structure if refcount reaches
+		 * zero, making any subsequent access to peer->group a
+		 * use-after-free bug. We must:
+		 * 1. Save group pointer while peer is valid
+		 * 2. Delete from group->peer list
+		 * 3. Unlock peer LAST (may free peer structure)
+		 * This prevents NULL dereference if peer_unlock() returns NULL.
+		 */
+		struct peer_group *group = peer->group;
+
 		if (peer_dynamic_neighbor(peer))
 			peer_drop_dynamic_neighbor(peer);
 
-		if ((pn = listnode_lookup(peer->group->peer, peer))) {
-			peer = peer_unlock(
-				peer); /* group->peer list reference */
-			list_delete_node(peer->group->peer, pn);
+		if ((pn = listnode_lookup(group->peer, peer))) {
+			list_delete_node(group->peer, pn);
+			peer_unlock(peer); /* group->peer list reference */
 		}
 		peer->group = NULL;
 	}


### PR DESCRIPTION
This commit addresses null pointer dereferences in bgpd folder alone.