### PR TITLE
bgpd: type-5 routes were sometimes being injected when they should not

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5550,6 +5550,11 @@ void bgp_evpn_advertise_type5_routes(struct bgp *bgp_vrf, afi_t afi,
 		for (pi = bgp_dest_get_bgp_path_info(dest); pi; pi = pi->next) {
 			if (!is_route_injectable_into_evpn(pi))
 				continue;
+
+			if (!CHECK_FLAG(pi->flags, BGP_PATH_SELECTED) &&
+			    !CHECK_FLAG(pi->flags, BGP_PATH_MULTIPATH))
+				continue;
+
 			bgp_evpn_export_type5_route(bgp_vrf, dest, pi, afi, safi);
 
 			if (advertise_type5_routes_bestpath(bgp_vrf, afi))


### PR DESCRIPTION
Effectively, bgp decides that it is time to import a vrf table in the update_advertise_vrf_routes.  Then the call into is_route_injectable_into_evpn runs but it does not check whether or not the path is selected or multipath.  Since we are not checking that this is allowing non-selected and non-multipath path_info's be moved into the evpn table.  This is causing some intermittant( ie timing ) failures in the evpn_type5_topo1 test.