### PR TITLE
ospf6d: Fix summary deletion dropping redistributed routes

### DIFF
--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -3461,6 +3461,7 @@ ospf6_start_asbr_summary_delay_timer(struct ospf6 *ospf6,
 			if (IS_OSPF6_DEBUG_AGGR)
 				zlog_debug("%s: Not required to restart timer,set is already added.",
 					__func__);
+			ospf6->aggr_action = operation;
 			return;
 		}
 


### PR DESCRIPTION
If you have this configuration:

router ospf6
 redistribute static
 summary-address 40::/32
!

This creates a aggregation timer in ospf6 that wakes up and moves routes around to handle the static appropriately. If a ipv6 route that is covered by the static is redistributed into ospf6 during this timer then it is stored on the aggr->match_extnl_hash hash.  Finally if you send a `no summary-address 40::/32` during this timer being run, ospf6 would remove the summary address but not re add the ipv6 route that was added during this timing window to be a lsa that could be sent to a peer.

Basically the function that is determining how the timer should be run is not storing the fact that
the aggregate is being deleted and the information in the match_extnl_hash is just being deleted.