### PR TITLE
bgp_bmp: fix pullwr bump call

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1642,6 +1642,9 @@ out:
 	if (bn)
 		bgp_dest_unlock_node(bn);
 
+	if (!written && bmp->locrib_queuepos)
+		pullwr_bump(bmp->pullwr);
+
 	return written;
 }
 
@@ -1734,6 +1737,9 @@ out:
 
 	if (bn)
 		bgp_dest_unlock_node(bn);
+
+	if (!written && bmp->queuepos)
+		pullwr_bump(bmp->pullwr);
 
 	return written;
 }


### PR DESCRIPTION
During the bmp item writing process, the related peer’s state may change, causing the bmp item to be skipped, as a result, no data is written during this pullwr fill call. The pullwr then stops because the buffer remains empty.

In this scenario, if no further updates come from bgp, the remaining bmp items in the list are never processed.
This mostly happens when bgp has converged and is stable — i.e., there are no more hooks for bmp, and many bmp items are wating to be processed. Once a pullwr fill call does not write to the buffer, the entire items in the list are not processed.

Bump the pullwr by checking if there is a next bmp item to process.