### PR TITLE
lib, bgpd: enable evpn graceful restart

### DIFF
--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -3073,7 +3073,9 @@ static inline bool bgp_gr_supported_for_afi_safi(afi_t afi, safi_t safi)
 	 * GR restarter behavior is supported only for IPv4-unicast
 	 * and IPv6-unicast.
 	 */
-	if ((afi == AFI_IP && safi == SAFI_UNICAST) || (afi == AFI_IP6 && safi == SAFI_UNICAST))
+       if ((afi == AFI_IP && safi == SAFI_UNICAST)
+       || (afi == AFI_IP6 && safi == SAFI_UNICAST)
+       || (afi == AFI_L2VPN && safi == SAFI_EVPN))
 		return true;
 	return false;
 }

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -191,7 +191,8 @@ typedef enum {
 
 #define FOREACH_AFI_SAFI_NSF(afi, safi)                                        \
 	for (afi = AFI_IP; afi < AFI_MAX; afi++)                               \
-		for (safi = SAFI_UNICAST; safi <= SAFI_MPLS_VPN; safi++)
+               for (safi = SAFI_UNICAST; safi <= SAFI_EVPN; safi++)                       \
+                               if (safi != SAFI_ENCAP)
 
 /* Flag manipulation macros. */
 #define CHECK_FLAG(V,F)      ((V) & (F))


### PR DESCRIPTION
# Support EVPN Graceful Restart

We would like to support EVPN GR in FRR, this PR is a draft that just enables this feature in two crucial places.

I'd like to open discussion to what are other necesary things required for this feature to be accepted. E.g. from [this mail thread](https://lists.frrouting.org/pipermail/dev/2024-December/002484.html) I know that around a year ago lack of necessary topotests was a blocker. 

I'm trying to find out if this is still valid, is someone working on this concurrently, what is expected of me if I want to introduce this feature into master?


Linking issue: https://github.com/FRRouting/frr/issues/9749