### PR TITLE
tests: Stop double run of a large number of commands

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -227,12 +227,7 @@ def run_frr_cmd(rnode, cmd, isjson=False):
     """
 
     if cmd:
-        ret_data = rnode.vtysh_cmd(cmd, isjson=isjson)
-
-        if isjson:
-            rnode.vtysh_cmd(cmd.rstrip("json"), isjson=False)
-
-        return ret_data
+        return rnode.vtysh_cmd(cmd, isjson=isjson)
 
     else:
         raise InvalidCLIError("No actual cmd passed")


### PR DESCRIPTION
The run_frr_cmd function in common_config.py is running the command given and then if it is json, stripping the json part of the command and rerunning the command.  This is just too much data being generated and in addition it is slowing runs down.