### PR TITLE
pimd/pim6d: fix router-alert crash

### DIFF
--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -4699,6 +4699,11 @@ int lib_interface_gmp_immediate_leave_modify(struct nb_cb_modify_args *args)
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
+		if (!pim_ifp) {
+			pim_ifp = pim_if_new(ifp, true, false, false, false);
+			ifp->info = pim_ifp;
+		}
+
 		pim_ifp->gmp_immediate_leave = yang_dnode_get_bool(args->dnode, NULL);
 		break;
 	}
@@ -4720,6 +4725,10 @@ int lib_interface_gm_rmap_modify(struct nb_cb_modify_args *args)
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
+		if (!pim_ifp) {
+			pim_ifp = pim_if_new(ifp, true, false, false, false);
+			ifp->info = pim_ifp;
+		}
 
 		rmap = yang_dnode_get_string(args->dnode, NULL);
 		pim_filter_ref_set_rmap(&pim_ifp->gmp_filter, rmap);
@@ -4742,6 +4751,9 @@ int lib_interface_gm_rmap_destroy(struct nb_cb_destroy_args *args)
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
+		if (!pim_ifp)
+			return NB_ERR_INCONSISTENCY;
+
 		pim_filter_ref_set_rmap(&pim_ifp->gmp_filter, NULL);
 		break;
 	}


### PR DESCRIPTION
On one interface without any mld/pim/igmp configuration, set the command: `ip igmp require-router-alert` or `ipv6 mld require-router-alert`. It will crash for empty `pim_ifp`.

```
 #0  0x000055cd72861d40 in lib_interface_gmp_require_router_alert_modify (args=0x7ffec1894e70) at ../pimd/pim_nb_config.c:4768
 #1  0x00007f5cdcda137b in nb_callback_modify (context=0x55cd74647a10, nb_node=0x55cd7441c970, event=NB_EV_APPLY, dnode=0x55cd74646350, resource=0x55cd746470c8,
     errmsg=0x7ffec1895460 "", errmsg_len=8192) at ../lib/northbound.c:1598
 #2  0x00007f5cdcda20b7 in nb_callback_configuration (context=0x55cd74647a10, event=NB_EV_APPLY, change=0x55cd74647090, errmsg=0x7ffec1895460 "", errmsg_len=8192)
     at ../lib/northbound.c:1962
 #3  0x00007f5cdcda261f in nb_transaction_process (event=NB_EV_APPLY, transaction=0x55cd74647a10, errmsg=0x7ffec1895460 "", errmsg_len=8192) at ../lib/northbound.c:2091
 #4  0x00007f5cdcda0cee in nb_candidate_commit_apply (transaction=0x55cd74647a10, save_transaction=true, transaction_id=0x0, errmsg=0x7ffec1895460 "", errmsg_len=8192)
     at ../lib/northbound.c:1409
 #5  0x00007f5cdcda0e76 in nb_candidate_commit (context=..., candidate=0x55cd7439d960, save_transaction=true, comment=0x0, transaction_id=0x0, errmsg=0x7ffec1895460 "",
     errmsg_len=8192) at ../lib/northbound.c:1449
 #6  0x00007f5cdcda78aa in nb_cli_classic_commit (vty=0x55cd74639b60) at ../lib/northbound_cli.c:57
 #7  0x00007f5cdcda7ea5 in nb_cli_apply_changes_internal (vty=0x55cd74639b60,
     xpath_base=0x7ffec18994f0 "/frr-interface:lib/interface[name='xx']/frr-gmp:gmp/address-family[address-family='frr-routing:ipv4']", clear_pending=false)
     at ../lib/northbound_cli.c:195
 #8  0x00007f5cdcda8196 in _nb_cli_apply_changes (vty=0x55cd74639b60, xpath_base=0x7ffec1899940 "./frr-gmp:gmp/address-family[address-family='frr-routing:ipv4']",
     clear_pending=false) at ../lib/northbound_cli.c:251
 ```