### PR TITLE
lib,zebra: make nhg nexthop show output consistent

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -1474,6 +1474,9 @@ void nexthop_vty_helper(struct vty *vty, const struct nexthop *nexthop,
 	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
 		vty_out(vty, " (recursive)");
 
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
+		vty_out(vty, " (dup)");
+
 	switch (nexthop->type) {
 	case NEXTHOP_TYPE_IPV4:
 	case NEXTHOP_TYPE_IPV4_IFINDEX:

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1095,7 +1095,7 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 	json_object *json_backup_nexthop_array = NULL;
 	json_object *json_backup_nexthops = NULL;
 	uint16_t nexthop_count = 0;
-
+	bool outdent_p;
 
 	uptime2str(nhe->uptime, up_str, sizeof(up_str));
 
@@ -1242,12 +1242,13 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 			show_nexthop_json_helper(json_nexthops, nexthop, NULL,
 						 NULL);
 		} else {
-			if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE) ||
-			    CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
-				/* Make recursive nexthops a bit more clear */
+			outdent_p = (nexthop->rparent == NULL);
+			if (outdent_p)
 				vty_out(vty, "       ");
 			else
+				/* Make recursive nexthops a bit more clear */
 				vty_out(vty, "          ");
+
 			show_route_nexthop_helper(vty, NULL, NULL, nexthop);
 		}
 
@@ -1310,14 +1311,14 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe,
 				json_object_array_add(json_backup_nexthop_array,
 						      json_backup_nexthops);
 			} else {
-				if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE) ||
-				    CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
-					/* Make recursive nexthops a bit more clear */
+				outdent_p = (nexthop->rparent == NULL);
+				if (outdent_p)
 					vty_out(vty, "       ");
 				else
+					/* Make recursive nexthops a bit more clear */
 					vty_out(vty, "          ");
-				show_route_nexthop_helper(vty, NULL, NULL,
-							  nexthop);
+
+				show_route_nexthop_helper(vty, NULL, NULL, nexthop);
 				vty_out(vty, "\n");
 			}
 		}


### PR DESCRIPTION
Make the output of "show nexthop-group rib" more consistent with the nexthops listed in the "show ip route" output. Indent resolving nexthops below their recursive "parent" nexthops. Also add a dupe string to the nexthop output if the DUPLICATE flag is set. No changes to nexthop json output, which already includes the RECURSIVE and DUPLICATE info.

A recent PR (https://github.com/FRRouting/frr/pull/19015) introduced a change that makes the parent/child relationship between recursive and resolving nexthops unclear. With this change, the output of recursive nexthops that include duplicates is clearer, and matches the "show ip route"  output more closely:

```
mjs-ubu-24-arm# do sho nexthop-group rib 26
ID: 26 (zebra)
     RefCnt: 2
     Uptime: 00:00:15
     VRF: default(No AFI)
     Nexthop Count: 2
     Flags: 0x3
     Valid, Installed
     Depends: (22) (27)
        via 4.4.4.1 (vrf default) (recursive), weight 1
           via 3.3.3.33, BETTY (vrf default), weight 1
        via 5.5.5.1 (vrf default) (recursive), weight 1
           via 3.3.3.33, BETTY (vrf default) (dup), weight 1
```

the route display is largely unchanged, with only the added output for DUPLICATE nexthops:

```
IPv4 unicast VRF default:
K * 0.0.0.0/0 [0/1002] (16) via 10.211.55.1, enp0s5, src 10.211.55.5, weight 1, 00:01:02 K>* 0.0.0.0/0 [0/100] (17) via 10.211.55.1, enp0s5, src 10.211.55.4, weight 1, 00:01:02 C>* 2.2.2.0/24 (11) is directly connected, ANNIE, weight 1, 00:01:02 L>* 2.2.2.1/32 (11) is directly connected, ANNIE, weight 1, 00:01:02 C>* 3.3.3.0/24 (12) is directly connected, BETTY, weight 1, 00:01:02 L>* 3.3.3.1/32 (12) is directly connected, BETTY, weight 1, 00:01:02 D>* 4.4.4.1/32 [150/0] (20) via 3.3.3.33, BETTY, weight 1, 00:00:36 D>  5.5.5.1/32 [150/0] (22) via 4.4.4.1 (recursive), weight 1, 00:00:29
  *                           via 3.3.3.33, BETTY, weight 1, 00:00:29
D>  7.7.7.1/32 [150/0] (26) via 4.4.4.1 (recursive), weight 1, 00:00:07
  *                           via 3.3.3.33, BETTY, weight 1, 00:00:07
                            via 5.5.5.1 (recursive), weight 1, 00:00:07
                              via 3.3.3.33, BETTY (dup), weight 1, 00:00:07
```