### PR TITLE
pimd : Added support for multi-oif static mroute

### DIFF
--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -468,7 +468,12 @@ int pim_process_ip_gmp_proxy_cmd(struct vty *vty, bool enable)
 int pim_process_ip_mroute_cmd(struct vty *vty, const char *interface,
 			      const char *group_str, const char *source_str)
 {
-	nb_cli_enqueue_change(vty, "./oif", NB_OP_MODIFY, interface);
+	/* managing list of oif regarding (iif,mcast group, mcast source)*/
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), "./oif[.='%s']", interface);
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
 
 	if (!source_str) {
 		char buf[SRCDEST2STR_BUFFER];
@@ -487,7 +492,12 @@ int pim_process_ip_mroute_cmd(struct vty *vty, const char *interface,
 int pim_process_no_ip_mroute_cmd(struct vty *vty, const char *interface,
 				 const char *group_str, const char *source_str)
 {
-	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
+	/* managing list of oif regarding (iif,mcast group, mcast source)*/
+	char xpath[XPATH_MAXLEN];
+
+	snprintf(xpath, sizeof(xpath), "./oif[.='%s']", interface);
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
 
 	if (!source_str) {
 		char buf[SRCDEST2STR_BUFFER];

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -418,13 +418,13 @@ const struct frr_yang_module_info frr_pim_info = {
 			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/mroute",
 			.cbs = {
 				.create = lib_interface_pim_address_family_mroute_create,
-				.destroy = lib_interface_pim_address_family_mroute_destroy,
+				.destroy = lib_interface_pim_address_family_mroute_oif_destroy,
 			}
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/mroute/oif",
 			.cbs = {
-				.modify = lib_interface_pim_address_family_mroute_oif_modify,
+				.create = lib_interface_pim_address_family_mroute_oif_create,
 				.destroy = lib_interface_pim_address_family_mroute_oif_destroy,
 			}
 		},

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -164,10 +164,7 @@ int lib_interface_pim_address_family_multicast_boundary_acl_modify(struct nb_cb_
 int lib_interface_pim_address_family_multicast_boundary_acl_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_pim_address_family_mroute_create(
 	struct nb_cb_create_args *args);
-int lib_interface_pim_address_family_mroute_destroy(
-	struct nb_cb_destroy_args *args);
-int lib_interface_pim_address_family_mroute_oif_modify(
-	struct nb_cb_modify_args *args);
+int lib_interface_pim_address_family_mroute_oif_create(struct nb_cb_create_args *args);
 int lib_interface_pim_address_family_mroute_oif_destroy(
 	struct nb_cb_destroy_args *args);
 

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2903,65 +2903,10 @@ int lib_interface_pim_address_family_mroute_create(
 	return NB_OK;
 }
 
-int lib_interface_pim_address_family_mroute_destroy(
-	struct nb_cb_destroy_args *args)
-{
-	struct pim_instance *pim;
-	struct pim_interface *pim_iifp;
-	struct interface *iif;
-	struct interface *oif;
-	const char *oifname;
-	pim_addr source_addr;
-	pim_addr group_addr;
-	const struct lyd_node *if_dnode;
-
-	switch (args->event) {
-	case NB_EV_VALIDATE:
-		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
-		if (!is_pim_interface(if_dnode)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "%% Enable PIM and/or IGMP on this interface first");
-			return NB_ERR_VALIDATION;
-		}
-		break;
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-		break;
-	case NB_EV_APPLY:
-		iif = nb_running_get_entry(args->dnode, NULL, true);
-		pim_iifp = iif->info;
-		pim = pim_iifp->pim;
-
-		oifname = yang_dnode_get_string(args->dnode, "oif");
-		oif = if_lookup_by_name(oifname, pim->vrf->vrf_id);
-
-		if (!oif) {
-			snprintf(args->errmsg, args->errmsg_len,
-					"No such interface name %s",
-					oifname);
-			return NB_ERR_INCONSISTENCY;
-		}
-
-		yang_dnode_get_pimaddr(&source_addr, args->dnode, "source-addr");
-		yang_dnode_get_pimaddr(&group_addr, args->dnode, "group-addr");
-
-		if (pim_static_del(pim, iif, oif, group_addr, source_addr)) {
-			snprintf(args->errmsg, args->errmsg_len,
-					"Failed to remove static mroute");
-			return NB_ERR_INCONSISTENCY;
-		}
-
-		break;
-	}
-
-	return NB_OK;
-}
-
 /*
  * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/mroute/oif
  */
-int lib_interface_pim_address_family_mroute_oif_modify(
-	struct nb_cb_modify_args *args)
+int lib_interface_pim_address_family_mroute_oif_create(struct nb_cb_create_args *args)
 {
 	struct pim_instance *pim;
 	struct pim_interface *pim_iifp;
@@ -3004,15 +2949,19 @@ int lib_interface_pim_address_family_mroute_oif_modify(
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		iif = nb_running_get_entry(args->dnode, NULL, true);
+		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
+
+		iif = nb_running_get_entry(if_dnode, NULL, true);
+		if (!iif)
+			return NB_ERR_INCONSISTENCY;
+
 		pim_iifp = iif->info;
 		pim = pim_iifp->pim;
 
 		oifname = yang_dnode_get_string(args->dnode, NULL);
 		oif = if_lookup_by_name(oifname, pim->vrf->vrf_id);
 		if (!oif) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "No such interface name %s",
+			snprintf(args->errmsg, args->errmsg_len, "No such interface name %s",
 				 oifname);
 			return NB_ERR_INCONSISTENCY;
 		}
@@ -3021,8 +2970,7 @@ int lib_interface_pim_address_family_mroute_oif_modify(
 		yang_dnode_get_pimaddr(&group_addr, args->dnode, "../group-addr");
 
 		if (pim_static_add(pim, iif, oif, group_addr, source_addr)) {
-			snprintf(args->errmsg, args->errmsg_len,
-				 "Failed to add static mroute");
+			snprintf(args->errmsg, args->errmsg_len, "Failed to add static mroute");
 			return NB_ERR_INCONSISTENCY;
 		}
 
@@ -3032,14 +2980,55 @@ int lib_interface_pim_address_family_mroute_oif_modify(
 	return NB_OK;
 }
 
-int lib_interface_pim_address_family_mroute_oif_destroy(
-	struct nb_cb_destroy_args *args)
+int lib_interface_pim_address_family_mroute_oif_destroy(struct nb_cb_destroy_args *args)
 {
+	struct pim_instance *pim;
+	struct pim_interface *pim_iifp;
+	struct interface *iif;
+	struct interface *oif;
+	const char *oifname;
+	pim_addr source_addr;
+	pim_addr group_addr;
+	const struct lyd_node *if_dnode;
+
 	switch (args->event) {
 	case NB_EV_VALIDATE:
+		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
+		if (!is_pim_interface(if_dnode)) {
+			snprintf(args->errmsg, args->errmsg_len,
+				 "%% Enable PIM and/or IGMP on this interface first");
+			return NB_ERR_VALIDATION;
+		}
+		break;
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+		break;
 	case NB_EV_APPLY:
+		if_dnode = yang_dnode_get_parent(args->dnode, "interface");
+
+		iif = nb_running_get_entry(if_dnode, NULL, true);
+		if (!iif)
+			return NB_ERR_INCONSISTENCY;
+
+
+		pim_iifp = iif->info;
+		pim = pim_iifp->pim;
+
+		oifname = yang_dnode_get_string(args->dnode, NULL);
+		oif = if_lookup_by_name(oifname, pim->vrf->vrf_id);
+		if (!oif) {
+			snprintf(args->errmsg, args->errmsg_len, "No such interface name %s",
+				 oifname);
+			return NB_ERR_INCONSISTENCY;
+		}
+
+		yang_dnode_get_pimaddr(&source_addr, args->dnode, "../source-addr");
+		yang_dnode_get_pimaddr(&group_addr, args->dnode, "../group-addr");
+
+		if (pim_static_del(pim, iif, oif, group_addr, source_addr)) {
+			snprintf(args->errmsg, args->errmsg_len, "Failed to del static mroute");
+			return NB_ERR_INCONSISTENCY;
+		}
 		break;
 	}
 

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -650,10 +650,10 @@ module frr-pim {
       description
         "Add multicast route.";
 
-      leaf oif {
+      leaf-list oif {
         type frr-interface:interface-ref;
         description
-          "Outgoing interface name.";
+          "List of Outgoing interface names.";
       }
 
       leaf source-addr {


### PR DESCRIPTION
Fixed a bug with ip mroute handling : the internal data model did not handle multiple oifs for a same {iif, src, grp}. 
This caused unpredictable behavior when adding and deleting such routes (zombie resident mroutes for example).