### PR TITLE
lib: fix SA warnings re. typesafe _add return val

### DIFF
--- a/lib/atomlist.h
+++ b/lib/atomlist.h
@@ -239,6 +239,8 @@ macro_inline type *prefix ## _add(struct prefix##_head *h, type *item)         \
 {                                                                              \
 	struct atomsort_item *p;                                               \
 	p = atomsort_add(&h->ah, &item->field.ai, cmpfn_uq);                   \
+	if (p)                                                                 \
+		_sa_dummy_store(item);                                         \
 	return container_of_null(p, type, field.ai);                           \
 }                                                                              \
 macro_inline type *prefix ## _first(struct prefix##_head *h)                   \

--- a/lib/typerb.h
+++ b/lib/typerb.h
@@ -86,6 +86,8 @@ macro_inline type *prefix ## _add(struct prefix##_head *h, type *item)         \
 {                                                                              \
 	struct typed_rb_entry *re;                                             \
 	re = typed_rb_insert(&h->rr, &item->field.re, cmpfn_uq);               \
+	if (!re)                                                               \
+		_sa_dummy_store(item);                                         \
 	return container_of_null(re, type, field.re);                          \
 }                                                                              \
 macro_inline const type *prefix ## _const_find_gteq(                           \


### PR DESCRIPTION
cf. inline comment:

```c
/* so.  The _add typesafe calls on unique containers are defined to return
 * either NULL if the item was added to the container (i.e. it was "consumed"),
 * or non-NULL == other item's address if the "same" unique item is already
 * on the list.
 * However, the typesafe containers don't store the address of the item but
 * rather the address of the container's embedded intrinsic "tracker" struct.
 * clang-SA doesn't understand that this is a reference to the item.  So for
 * the normal case (NULL return) it doesn't understand that we do in fact have
 * held a reference to the item.  And it proceeds to complain about a missing
 * free().
 * So, the following macro is here to do a dummy store of the item pointer to
 * the global variable, just to tell clang-SA that we still have a reference
 * to the pointer.  It's never read, just written to as a SA hint.
 */
```

also turned off clang-format around the macros because that was a trainwreck