### PR TITLE
tests: Allow --with-timestamp-precision=X to actually work w/ make check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1068,11 +1068,6 @@ AC_MSG_FAILURE([Please specify a number from 0-12 for log precision ARG])
 ;;
 esac
 with_log_timestamp_precision=${with_log_timestamp_precision:-0}
-if test "${with_log_timestamp_precision}" != 0; then
-AC_SUBST([LOG_TIMESTAMP_PRECISION_CLI], ["
-log timestamp precision ${with_log_timestamp_precision}"])
-AM_SUBST_NOTMAKE([LOG_TIMESTAMP_PRECISION_CLI])
-fi
 AC_DEFINE_UNQUOTED([LOG_TIMESTAMP_PRECISION], [${with_log_timestamp_precision}], [Startup zlog timestamp precision])
 
 AC_DEFINE_UNQUOTED([VTYSH_PAGER], ["$VTYSH_PAGER"], [What pager to use])

--- a/tests/lib/cli/test_cli.refout.in
+++ b/tests/lib/cli/test_cli.refout.in
@@ -405,7 +405,7 @@ frr version @PACKAGE_VERSION@
 frr defaults @DFLT_NAME@
 !
 hostname test
-domainname test.domain@LOG_TIMESTAMP_PRECISION_CLI@
+domainname test.domain
 !
 !
 !
@@ -420,7 +420,7 @@ frr version @PACKAGE_VERSION@
 frr defaults @DFLT_NAME@
 !
 hostname foohost
-domainname test.domain@LOG_TIMESTAMP_PRECISION_CLI@
+domainname test.domain
 !
 !
 !


### PR DESCRIPTION
When I was building with --with-log-timestamp-precision=X, `make check` was always failing for me.  The cli is never dumping out the default value you compiled with.  Nor am I sure how this ever worked.  In any event, let's just remove this from make check.