### PR TITLE
bgpd: Fix resource leak coverity

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -1060,6 +1060,7 @@ int bgp_socket(struct bgp *bgp, unsigned short port, const char *address)
 		if (ret < 0) {
 			flog_err_sys(EC_LIB_SOCKET, "%s: Can't set TTL on socket %d err = %s",
 				     __func__, sock, safe_strerror(errno));
+			close(sock);
 			continue;
 		}
 


### PR DESCRIPTION
fix - close socket, on error, while setting ttl sockopt.