### PR TITLE
lib: Remove unnecessary #includes

### DIFF
--- a/lib/elf_py.c
+++ b/lib/elf_py.c
@@ -56,8 +56,6 @@
 #define _FILE_OFFSET_BITS 32
 #endif
 
-#include <elf.h>
-#include <libelf.h>
 #include <gelf.h>
 
 #include "typesafe.h"


### PR DESCRIPTION
This change should improve code portability, since POSIX-conformant
systems are not required to provide a header named <elf.h>.