### PR TITLE
bgpd: EVPN fix auto derive rd when user cfg removed

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2327,8 +2327,8 @@ static void evpn_unconfigure_vrf_rd(struct bgp *bgp_vrf)
 	bgp_evpn_handle_vrf_rd_change(bgp_vrf, 1);
 
 	/* fall back to default RD */
-	bgp_evpn_derive_auto_rd_for_vrf(bgp_vrf);
 	UNSET_FLAG(bgp_vrf->vrf_flags, BGP_VRF_RD_CFGD);
+	bgp_evpn_derive_auto_rd_for_vrf(bgp_vrf);
 	if (bgp_vrf->vrf_prd_pretty)
 		XFREE(MTYPE_BGP_NAME, bgp_vrf->vrf_prd_pretty);
 	/* We have a new RD for VRF.


### PR DESCRIPTION
When a user unconfigures user provided RD value, ensure the flag BGP_VRF_RD_CFGD is unset first then call the auto derived RD to happen.

