### PR TITLE
Revert "tools: Ignore errors for frr reload stuff"

### DIFF
--- a/tools/frrinit.sh.in
+++ b/tools/frrinit.sh.in
@@ -123,7 +123,7 @@ reload)
 	NEW_CONFIG_FILE="${2:-$C_PATH/frr.conf}"
 	[ ! -r $NEW_CONFIG_FILE ] && log_failure_msg "Unable to read new configuration file $NEW_CONFIG_FILE" && exit 1
 	"$RELOAD_SCRIPT" --reload --bindir "$B_PATH" --confdir "$C_PATH" --rundir "$V_PATH" "$NEW_CONFIG_FILE" `echo $nsopt`
-	exit 0
+	exit $?
 	;;
 
 *)


### PR DESCRIPTION
This reverts commit 243e27abccf8d02caabc6ae1ea758c4bdc3069e2.

It needs to be very strict, otherwise, all the commands that return `CMD_WARNING_CONFIG_FAILED` (and other errors) will be imperceptibly ommitted, seriously affecting the functionality.