### PR TITLE
lib: fix SNMP crash when canceling events from callbacks

### DIFF
--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -101,7 +101,7 @@ static void agentx_events_update(void)
 	struct event **thr;
 	int fd, thr_fd;
 
-	event_cancel(&timeout_thr);
+	event_cancel_async(agentx_tm, &timeout_thr, NULL);
 
 	netsnmp_large_fd_set_init(&lfds, FD_SETSIZE);
 	snmp_select_info2(&maxfd, &lfds, &timeout, &block);
@@ -123,7 +123,7 @@ static void agentx_events_update(void)
 		if (thr_fd == fd) {
 			struct listnode *nextln = listnextnode(ln);
 			if (!netsnmp_large_fd_is_set(fd, &lfds)) {
-				event_cancel(thr);
+				event_cancel_async(agentx_tm, thr, NULL);
 				XFREE(MTYPE_TMP, thr);
 				list_delete_node(events, ln);
 			}
@@ -146,7 +146,7 @@ static void agentx_events_update(void)
 	while (ln) {
 		struct listnode *nextln = listnextnode(ln);
 		thr = listgetdata(ln);
-		event_cancel(thr);
+		event_cancel_async(agentx_tm, thr, NULL);
 		XFREE(MTYPE_TMP, thr);
 		list_delete_node(events, ln);
 		ln = nextln;


### PR DESCRIPTION
The SNMP AgentX subsystem was crashing with a segmentation fault when trying to cancel events from within event callbacks. This occurred because agentx_events_update() was calling the non-reentrant event_cancel() function while already executing inside an event callback context.

Root Cause:
The SNMP AgentX subsystem in lib/agentx.c was using the MT-Unsafe function event_cancel() from a callback context that doesn't own the event loop thread, causing the assertion failure.

The agentx_read() callback invokes agentx_events_update(), which attempts to cancel pending events using event_cancel() which is MT-Unsafe and is not reentrant - it cannot be safely called from
within an event callback while the event loop is still executing.

Fix:
Replace all three calls to event_cancel() in agentx_events_update() with event_cancel_async(), which is MT-Safe and designed to be called from threads that do NOT own the event loop:

BT:

```
0.  0x00007f8cfb8e1eec in ?? () from /lib/x86_64-linux-gnu/libc.so.6
1.  0x00007f8cfb892fb2 in raise () from /lib/x86_64-linux-gnu/libc.so.6
2.  0x00007f8cfbd00d6c in core_handler (signo=11, siginfo=0x7ffe6bcfa2b0) at ../lib/sigevent.c:261
3.  <signal handler called>
4.  event_cancel (thread=0x55872cd41470) at ../lib/event.c:1509
     >>>>>>>>> CRASH: assert(master->owner == pthread_self())
               SIGSEGV at address 0x158 (NULL pointer dereference)
5.  0x00007f8cfa7ed5b8 in ?? () from /usr/lib/x86_64-linux-gnu/frr/libfrrsnmp.so.0 (agentx_events_update at ../lib/agentx.c:104, 126, or 149)
6.  0x00007f8cfa7ed86b in ?? () from /usr/lib/x86_64-linux-gnu/frr/libfrrsnmp.so.0 (agentx_read at ../lib/agentx.c:90)
7.  0x00007f8cfbd13211 in event_call (thread=0x7ffe6bcfa9c0) at ../lib/event.c:2034 Executing callback: (*thread->func)(thread)
8.  0x00007f8cfbcbcc10 in frr_run (master=0x55872ca59ff0) at ../lib/libfrr.c:1242
9.  0x00005586efc7744d in main (argc=14, argv=0x7ffe6bcface8) at ../zebra/main.c:584
```

Signed-off-by: Rajasekar Raja <rajasekarr@nvidia.com>