### PR TITLE
zebra: workaround for a race condition caused by if_zebra_speed_update timer

### DIFF
--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -49,6 +49,12 @@ void zebra_ns_link_ifp(struct zebra_ns *zns, struct interface *ifp)
 	struct zebra_if *zif;
 	struct ifp_tree_link *link, tlink = {};
 
+	if (ifp->ifindex == IFINDEX_INTERNAL) {
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("%s: interface %s not ready, ignoring", __func__, ifp->name);
+		return;
+	}
+
 	zif = ifp->info;
 	assert(zif != NULL);
 


### PR DESCRIPTION
if_zebra_speed_update timer fires 15 seconds after interface creation. If speed is available in kernel, it calls if_add_update -> zebra_ns_link_ifp to link the interface to a namespace. But if this happens before RTM_NEWLINK event, it links the default ifindex IFINDEX_INTERNAL 0 and makes following if_lookup_by_index_per_ns fail. If one interface is affected, the BGP neighbor on that interface will remain permanently down. If two are affected, it causes assertion in zebra_ns_link_ifp because it tries to link both interfaces with ifindex 0.
This workaround just skips linking if the ifindex is IFINDEX_INTERNAL. A complete solution requires careful redesign for the timer.
This fixes https://github.com/FRRouting/frr/issues/19792