### PR TITLE
bfdd: Turn zlog_fatal into zlog_err

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -533,17 +533,6 @@ void socket_close(int *s);
 
 
 /*
- * logging - alias to zebra log
- */
-#define zlog_fatal(msg, ...)                                                   \
-	do {                                                                   \
-		zlog_err(msg, ##__VA_ARGS__);                                  \
-		assert(!msg);                                                  \
-		abort();                                                       \
-	} while (0)
-
-
-/*
  * bfd_packet.c
  *
  * Contains the code related with receiving/seding, packing/unpacking BFD data.

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -1371,18 +1371,17 @@ static void bp_set_ipopts(int sd)
 	int rcvttl = BFD_RCV_TTL_VAL;
 
 	if (!bp_set_reuse_addr(sd))
-		zlog_fatal("set-reuse-addr: failed");
+		zlog_err("set-reuse-addr: failed");
 
 	if (!bp_set_reuse_port(sd))
-		zlog_fatal("set-reuse-port: failed");
+		zlog_err("set-reuse-port: failed");
 
 	if (bp_set_ttl(sd, BFD_TTL_VAL) != 0)
-		zlog_fatal("set-ipopts: TTL configuration failed");
+		zlog_err("set-ipopts: TTL configuration failed");
 
 	if (setsockopt(sd, IPPROTO_IP, IP_RECVTTL, &rcvttl, sizeof(rcvttl))
 	    == -1)
-		zlog_fatal("set-ipopts: setsockopt(IP_RECVTTL, %d): %s", rcvttl,
-			   strerror(errno));
+		zlog_err("set-ipopts: setsockopt(IP_RECVTTL, %d): %s", rcvttl, strerror(errno));
 
 #ifdef BFD_LINUX
 	int pktinfo = BFD_PKT_INFO_VAL;
@@ -1390,21 +1389,18 @@ static void bp_set_ipopts(int sd)
 	/* Figure out address and interface to do the peer matching. */
 	if (setsockopt(sd, IPPROTO_IP, IP_PKTINFO, &pktinfo, sizeof(pktinfo))
 	    == -1)
-		zlog_fatal("set-ipopts: setsockopt(IP_PKTINFO, %d): %s",
-			   pktinfo, strerror(errno));
+		zlog_err("set-ipopts: setsockopt(IP_PKTINFO, %d): %s", pktinfo, strerror(errno));
 #endif /* BFD_LINUX */
 #ifdef BFD_BSD
 	int yes = 1;
 
 	/* Find out our address for peer matching. */
 	if (setsockopt(sd, IPPROTO_IP, IP_RECVDSTADDR, &yes, sizeof(yes)) == -1)
-		zlog_fatal("set-ipopts: setsockopt(IP_RECVDSTADDR, %d): %s",
-			   yes, strerror(errno));
+		zlog_err("set-ipopts: setsockopt(IP_RECVDSTADDR, %d): %s", yes, strerror(errno));
 
 	/* Find out interface where the packet came in. */
 	if (setsockopt_ifindex(AF_INET, sd, yes) == -1)
-		zlog_fatal("set-ipopts: setsockopt_ipv4_ifindex(%d): %s", yes,
-			   strerror(errno));
+		zlog_err("set-ipopts: setsockopt_ipv4_ifindex(%d): %s", yes, strerror(errno));
 #endif /* BFD_BSD */
 }
 
@@ -1417,7 +1413,7 @@ static void bp_bind_ip(int sd, uint16_t port)
 	sin.sin_addr.s_addr = htonl(INADDR_ANY);
 	sin.sin_port = htons(port);
 	if (bind(sd, (struct sockaddr *)&sin, sizeof(sin)) == -1)
-		zlog_fatal("bind-ip: bind: %s", strerror(errno));
+		zlog_err("bind-ip: bind: %s", strerror(errno));
 }
 
 void bp_set_prio(int sd, int value)
@@ -1439,7 +1435,7 @@ int bp_udp_shop(const struct vrf *vrf)
 				vrf->name);
 	}
 	if (sd == -1)
-		zlog_fatal("udp-shop: socket: %s", strerror(errno));
+		zlog_err("udp-shop: socket: %s", strerror(errno));
 
 	bp_set_ipopts(sd);
 	bp_bind_ip(sd, BFD_DEFDESTPORT);
@@ -1455,7 +1451,7 @@ int bp_udp_mhop(const struct vrf *vrf)
 				vrf->name);
 	}
 	if (sd == -1)
-		zlog_fatal("udp-mhop: socket: %s", strerror(errno));
+		zlog_err("udp-mhop: socket: %s", strerror(errno));
 
 	bp_set_ipopts(sd);
 	bp_bind_ip(sd, BFD_DEF_MHOP_DEST_PORT);
@@ -1630,29 +1626,28 @@ static void bp_set_ipv6opts(int sd)
 	int ipv6_only = BFD_IPV6_ONLY_VAL;
 
 	if (!bp_set_reuse_addr(sd))
-		zlog_fatal("set-reuse-addr: failed");
+		zlog_err("set-reuse-addr: failed");
 
 	if (!bp_set_reuse_port(sd))
-		zlog_fatal("set-reuse-port: failed");
+		zlog_err("set-reuse-port: failed");
 
 	if (bp_set_ttlv6(sd, BFD_TTL_VAL) == -1)
-		zlog_fatal(
-			"set-ipv6opts: setsockopt(IPV6_UNICAST_HOPS, %d): %s",
-			BFD_TTL_VAL, strerror(errno));
+		zlog_err("set-ipv6opts: setsockopt(IPV6_UNICAST_HOPS, %d): %s", BFD_TTL_VAL,
+			 strerror(errno));
 
 	if (setsockopt_ipv6_hoplimit(sd, BFD_RCV_TTL_VAL) == -1)
-		zlog_fatal("set-ipv6opts: setsockopt(IPV6_HOPLIMIT, %d): %s",
-			   BFD_RCV_TTL_VAL, strerror(errno));
+		zlog_err("set-ipv6opts: setsockopt(IPV6_HOPLIMIT, %d): %s", BFD_RCV_TTL_VAL,
+			 strerror(errno));
 
 	if (setsockopt_ipv6_pktinfo(sd, ipv6_pktinfo) == -1)
-		zlog_fatal("set-ipv6opts: setsockopt(IPV6_PKTINFO, %d): %s",
-			   ipv6_pktinfo, strerror(errno));
+		zlog_err("set-ipv6opts: setsockopt(IPV6_PKTINFO, %d): %s", ipv6_pktinfo,
+			 strerror(errno));
 
 	if (setsockopt(sd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6_only,
 		       sizeof(ipv6_only))
 	    == -1)
-		zlog_fatal("set-ipv6opts: setsockopt(IPV6_V6ONLY, %d): %s",
-			   ipv6_only, strerror(errno));
+		zlog_err("set-ipv6opts: setsockopt(IPV6_V6ONLY, %d): %s", ipv6_only,
+			 strerror(errno));
 }
 
 static void bp_bind_ipv6(int sd, uint16_t port)
@@ -1667,7 +1662,7 @@ static void bp_bind_ipv6(int sd, uint16_t port)
 	sin6.sin6_len = sizeof(sin6);
 #endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 	if (bind(sd, (struct sockaddr *)&sin6, sizeof(sin6)) == -1)
-		zlog_fatal("bind-ipv6: bind: %s", strerror(errno));
+		zlog_err("bind-ipv6: bind: %s", strerror(errno));
 }
 
 int bp_udp6_shop(const struct vrf *vrf)
@@ -1680,7 +1675,7 @@ int bp_udp6_shop(const struct vrf *vrf)
 	}
 	if (sd == -1) {
 		if (errno != EAFNOSUPPORT)
-			zlog_fatal("udp6-shop: socket: %s", strerror(errno));
+			zlog_err("udp6-shop: socket: %s", strerror(errno));
 		else
 			zlog_warn("udp6-shop: V6 is not supported, continuing");
 
@@ -1703,7 +1698,7 @@ int bp_udp6_mhop(const struct vrf *vrf)
 	}
 	if (sd == -1) {
 		if (errno != EAFNOSUPPORT)
-			zlog_fatal("udp6-mhop: socket: %s", strerror(errno));
+			zlog_err("udp6-mhop: socket: %s", strerror(errno));
 		else
 			zlog_warn("udp6-mhop: V6 is not supported, continuing");
 
@@ -1739,7 +1734,7 @@ int bp_echo_socket(const struct vrf *vrf)
 	}
 
 	if (s == -1)
-		zlog_fatal("echo-socket: socket: %s", strerror(errno));
+		zlog_err("echo-socket: socket: %s", strerror(errno));
 
 	struct sock_fprog pf;
 	struct sockaddr_ll sll = {0};
@@ -1777,7 +1772,7 @@ int bp_echo_socket(const struct vrf *vrf)
 		s = vrf_socket(AF_INET, SOCK_DGRAM, 0, vrf->vrf_id, vrf->name);
 	}
 	if (s == -1)
-		zlog_fatal("echo-socket: socket: %s", strerror(errno));
+		zlog_err("echo-socket: socket: %s", strerror(errno));
 
 	bp_set_ipopts(s);
 	bp_bind_ip(s, BFD_DEF_ECHO_PORT);
@@ -1795,8 +1790,7 @@ int bp_echov6_socket(const struct vrf *vrf)
 	}
 	if (s == -1) {
 		if (errno != EAFNOSUPPORT)
-			zlog_fatal("echov6-socket: socket: %s",
-				   strerror(errno));
+			zlog_err("echov6-socket: socket: %s", strerror(errno));
 		else
 			zlog_warn("echov6-socket: V6 is not supported, continuing");
 
@@ -2137,7 +2131,7 @@ int bp_initv6_socket(const struct vrf *vrf)
 	}
 	if (sd == -1) {
 		if (errno != EAFNOSUPPORT)
-			zlog_fatal("echov6-socket: socket: %s", strerror(errno));
+			zlog_err("echov6-socket: socket: %s", strerror(errno));
 		else
 			zlog_warn("echov6-socket: V6 is not supported, continuing");
 
@@ -2341,7 +2335,7 @@ int bp_sbfd_socket(const struct vrf *vrf)
 	}
 	if (s == -1) {
 		if (errno != EAFNOSUPPORT)
-			zlog_fatal("sbfdv6-socket: socket: %s", strerror(errno));
+			zlog_err("sbfdv6-socket: socket: %s", strerror(errno));
 		else
 			zlog_warn("sbfdv6-socket: V6 is not supported, continuing");
 


### PR DESCRIPTION
The usage of zlog_fatal, causes bfd to just go down creating core files all over the place.  Let's follow other daemons leads and just make them zlog_err and continue on.  Yes things will not work but we will be in a degraded state -vs- a bfdd is not even working.