### PR TITLE
doc: Update bgp's treat-as-withdraw command doc

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2027,7 +2027,11 @@ Configuring Peers
 .. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> path-attribute treat-as-withdraw (1-255)...
 
    Received BGP UPDATES that contain specified path attributes are treat-as-withdraw. If
-   there is an existing prefix in the BGP routing table, it will be removed.
+   there is an existing prefix in the BGP routing table, it will be removed.  These
+   attributes: ORIGIN AS_PATH NEXT_HOP MULTI_EXIT_DISC MP_REACH_NLRI MP_UNREACH_NLRI
+   and EXT_COMMUNITIES cannot be ignored.  Additionally if the peer is ebgp then
+   LOCAL_PREF ORIGINATOR_ID and CLUSTER_LIST cannot be ignored.  If you choose
+   any of these then the whole command will be ignored.
 
 .. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> graceful-shutdown
 


### PR DESCRIPTION
This command has some specific pecularities about
what is not allowed to be accepted.  Let's just
go ahead and document this as well.