### PR TITLE
zebra: fix yang data for mcast-group

### DIFF
--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -194,6 +194,10 @@ lib_interface_zebra_state_mcast_group_get_elem(struct nb_cb_get_elem_args *args)
 		return NULL;
 
 	vni = zebra_vxlan_if_vni_find(zebra_if, 0);
+
+	if (vni->mcast_grp.s_addr == INADDR_ANY)
+		return NULL;
+
 	return yang_data_new_ipv4(args->xpath, &vni->mcast_grp);
 }
 


### PR DESCRIPTION
Zebra currently returns data even if it's not set, resulting in YANG pattern match failure:
```
zebra[3900358]: libyang: Unsatisfied pattern - "0.0.0.0" does not conform to "(2((2[4-9])|(3[0-9]))\.).*". (Schema location "/frr-interface:lib/interface/frr-zebra:zebra/state/mcast-group".)
```

The whole "get-data" transaction fails because of this. Fix by checking for an empty IP.