### PR TITLE
zebra: EVPN fix show interface vxlan json

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -2907,15 +2907,27 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 #endif /* HAVE_NET_RT_IFLIST */
 }
 
+/*
+ * Create hierarchical JSON structure for VNI information
+ * This creates a nested object keyed by VNI ID to support both:
+ * - TVD (Traditional VxLAN Device): single VLAN-to-VNI mapping
+ * - SVD (Single VxLAN Device): multiple VLAN-to-VNI mappings
+ * The VNI ID is used as the key, allowing multiple VNI entries
+ * to coexist under the "vxlanId" parent object.
+ */
 static void zebra_vxlan_if_vni_dump_vty_json(json_object *json_if,
 					     struct zebra_vxlan_vni *vni)
 {
-	json_object_int_add(json_if, "vxlanId", vni->vni);
+	json_object *json_vni;
+	char vni_str[VNI_STR_LEN];
+
+	json_vni = json_object_new_object();
+	snprintf(vni_str, sizeof(vni_str), "%u", vni->vni);
 	if (vni->access_vlan)
-		json_object_int_add(json_if, "accessVlanId", vni->access_vlan);
+		json_object_int_add(json_vni, "accessVlanId", vni->access_vlan);
 	if (vni->mcast_grp.s_addr != INADDR_ANY)
-		json_object_string_addf(json_if, "mcastGroup", "%pI4",
-					&vni->mcast_grp);
+		json_object_string_addf(json_vni, "mcastGroup", "%pI4", &vni->mcast_grp);
+	json_object_object_add(json_if, vni_str, json_vni);
 }
 
 static void zebra_vxlan_if_vni_hash_dump_vty_json(struct hash_bucket *bucket,
@@ -2935,6 +2947,7 @@ static void zebra_vxlan_if_dump_vty_json(json_object *json_if,
 {
 	struct zebra_l2info_vxlan *vxlan_info;
 	struct zebra_vxlan_vni_info *vni_info;
+	json_object *json_vnis = NULL;
 
 	vxlan_info = &zebra_if->l2info.vxl;
 	vni_info = &vxlan_info->vni_info;
@@ -2951,12 +2964,14 @@ static void zebra_vxlan_if_dump_vty_json(json_object *json_if,
 		json_object_string_add(json_if, "linkInterface",
 				       ifp == NULL ? "Unknown" : ifp->name);
 	}
-	if (IS_ZEBRA_VXLAN_IF_VNI(zebra_if)) {
-		zebra_vxlan_if_vni_dump_vty_json(json_if, &vni_info->vni);
-	} else {
-		hash_iterate(vni_info->vni_table,
-			     zebra_vxlan_if_vni_hash_dump_vty_json, json_if);
-	}
+
+	json_vnis = json_object_new_object();
+	if (IS_ZEBRA_VXLAN_IF_VNI(zebra_if))
+		zebra_vxlan_if_vni_dump_vty_json(json_vnis, &vni_info->vni);
+	else
+		hash_iterate(vni_info->vni_table, zebra_vxlan_if_vni_hash_dump_vty_json, json_vnis);
+
+	json_object_object_add(json_if, "vxlanId", json_vnis);
 }
 
 static void if_dump_vty_json(struct vty *vty, struct interface *ifp,


### PR DESCRIPTION
The VxLAN device can be SVD or non-SVD mode.
TVD: Traditional VxLAN Device where
    one VLAN and VNI mapped under the VxLAN device).
SVD: Single VxLAN Device where multiple VLAN and
    VNI mappins exists.
 
The current show interface vxlan-device command displays only one of the mapping for SVD rather than all mapped VNI information like it does in non-json output.
The change in json hierarchy is required to handle both the modes.



**Non-SVD:**

 ```   
    r1# show interface vxlan-101
    Interface vxlan-101 is up, line protocol is up
      Link ups:       0    last: (never)
      Link downs:     0    last: (never)
      vrf: vrf-101
      inet6 fe80::90a6:7eff:fe67:57d8/64
      Interface Type Vxlan
      Interface Slave Type Bridge
       ...
      VTEP IP: 192.168.1.1 Link Interface eth-rr
      VxLAN Id 101 Access VLAN Id 1   <<<<<
 ```     
JSON:
```
    r1# show interface vxlan-101 json
    {
      "vxlan-101":{
        "administrativeStatus":"up",
         ...

        "interfaceType":"Vxlan",
        "interfaceSlaveType":"Bridge",
        "vtepIp":"192.168.1.1",
        "linkInterface":"eth-rr",
        "vxlanId":{               <<<<<<
          "101":{
            "accessVlanId":1
          }
        },
        "masterInterface":"bridge-101",
        "lacpBypass":false,
        "evpnMh":{
        },
        "protodown":"off",
        "parentInterface":"eth-rr"
      }
    }
```

**SVD:**

```
    tor-21# show interface vxlan48
    Interface vxlan48 is up, line protocol is up
      Link ups:       0    last: (never)
      Link downs:     0    last: (never)
       ....
      VTEP IP: 6.0.0.30
      VxLAN Id 1000112 Access VLAN Id 112
      VxLAN Id 104001 Access VLAN Id 4001
      VxLAN Id 104002 Access VLAN Id 4002
      VxLAN Id 1000111 Access VLAN Id 111
 ```
 JSON:
 ```     
    tor-21# show interface vxlan48 json
     {
      "vxlan48":{
        ...
        "interfaceType":"Vxlan",
        "interfaceSlaveType":"Bridge",
        "vtepIp":"6.0.0.30",
        "vxlanId":{
          "1000112":{
            "accessVlanId":112
          },
          "104001":{
            "accessVlanId":4001
          },
          "104002":{
            "accessVlanId":4002
          },
          "1000111":{
            "accessVlanId":111
          }
        },
        "masterInterface":"br_default",
        "lacpBypass":false,
        "evpnMh":{
        },
        "protodown":"off"
      }
    }
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>


        