### PR TITLE
yang: fix wrong comment to match-condition entry

### DIFF
--- a/yang/frr-bgp-route-map.yang
+++ b/yang/frr-bgp-route-map.yang
@@ -569,7 +569,7 @@ identity set-extcommunity-color {
 
   augment "/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:match-condition/frr-route-map:rmap-match-condition/frr-route-map:match-condition" {
     description
-      "Augments the match condition with vpn dataplane";
+      "Augment match-condition for route-map entries";
 
     case vpn-dataplane {
       when "derived-from-or-self(../frr-route-map:condition, 'frr-bgp-route-map:match-vpn-dataplane')";


### PR DESCRIPTION
The comment was wrongly assigned to one of the cases of the match-condition entries.

Fixes: 72cbdd4d82ee ("yang: Correct pyang errors in frr-bgp-route-map.yang")
Fixes: 88aaed993d23 ("bgpd, lib, yang: add 'match vpn-dataplane' route-map command")