### PR TITLE
zebra: Null pointer dereferences (medium)

### DIFF
--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -150,6 +150,7 @@ static struct zebra_vrf *rtadv_interface_get_zvrf(const struct interface *ifp)
 	if (!vrf_is_backend_netns())
 		return vrf_info_lookup(VRF_DEFAULT);
 
+	assert(ifp->vrf->info);
 	return ifp->vrf->info;
 }
 

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -7794,13 +7794,13 @@ static void dplane_thread_loop(struct event *event)
 			if (IS_ZEBRA_DEBUG_DPLANE_DETAIL)
 				zlog_debug("%s: Next Provider(%s) Input queue is %" PRIu64
 					   ", holding off work",
-					   __func__, next_prov->dp_name, curr);
+					   __func__, next_prov ? next_prov->dp_name : "NULL", curr);
 			counter = 0;
 		} else if (out_curr >= (uint64_t)limit) {
 			if (IS_ZEBRA_DEBUG_DPLANE_DETAIL)
 				zlog_debug("%s: Next Provider(%s) Output queue is %" PRIu64
 					   ", holding off work",
-					   __func__, next_prov->dp_name,
+					   __func__, next_prov ? next_prov->dp_name : "NULL",
 					   out_curr);
 			counter = 0;
 		} else {

--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -2638,7 +2638,7 @@ bool zebra_evpn_es_mac_ref(struct zebra_mac *mac, const esi_t *esi)
 			es = zebra_evpn_es_new(esi);
 			if (IS_ZEBRA_DEBUG_EVPN_MH_ES)
 				zlog_debug("auto es %s add on mac ref",
-					   es->esi_str);
+					   es ? es->esi_str : "unknown");
 		}
 	}
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3055,9 +3055,8 @@ static void process_subq_early_route_delete(struct zebra_early_route *ere)
 				src_buf[0] = '\0';
 
 			zlog_debug("%s[%d]:%pRN%s%s doesn't exist in rib",
-				   vrf->name, ere->re->table, rn,
-				   (src_buf[0] != '\0') ? " from " : "",
-				   src_buf);
+				   vrf ? vrf->name : "Unknown", ere->re->table, rn,
+				   (src_buf[0] != '\0') ? " from " : "", src_buf);
 		}
 		early_route_memory_free(ere);
 		return;

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -287,7 +287,7 @@ void zebra_remove_rnh_client(struct rnh *rnh, struct zserv *client)
 
 		zlog_debug("Client %s unregisters for RNH %s(%u)%pRN",
 			   zebra_route_string(client->proto), VRF_LOGNAME(vrf),
-			   vrf->vrf_id, rnh->node);
+			   vrf ? vrf->vrf_id : rnh->vrf_id, rnh->node);
 	}
 	listnode_delete(rnh->client_list, client);
 	zebra_delete_rnh(rnh);
@@ -708,9 +708,8 @@ static void zebra_rnh_evaluate_entry(struct zebra_vrf *zvrf, afi_t afi,
 	struct route_node *prn;
 
 	if (IS_ZEBRA_DEBUG_NHT) {
-		zlog_debug("%s(%u):%pRN: Evaluate RNH, %s",
-			   VRF_LOGNAME(zvrf->vrf), zvrf->vrf->vrf_id, nrn,
-			   force ? "(force)" : "");
+		zlog_debug("%s(%u):%pRN: Evaluate RNH, %s", VRF_LOGNAME(zvrf->vrf),
+			   zvrf->vrf ? zvrf->vrf->vrf_id : 0, nrn, force ? "(force)" : "");
 	}
 
 	rnh = nrn->info;

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5912,6 +5912,8 @@ static struct zebra_vxlan_sg *zebra_vxlan_sg_new(struct zebra_vrf *zvrf,
 	struct zebra_vxlan_sg *vxlan_sg;
 
 	vxlan_sg = XCALLOC(MTYPE_ZVXLAN_SG, sizeof(*vxlan_sg));
+	assert(sg);
+	assert(zvrf);
 
 	vxlan_sg->zvrf = zvrf;
 	vxlan_sg->sg = *sg;
@@ -5970,6 +5972,7 @@ static void zebra_vxlan_sg_del(struct zebra_vxlan_sg *vxlan_sg)
 	struct ipaddr sip;
 	struct zebra_vrf *zvrf;
 
+	assert(vxlan_sg);
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
 
 	/* On SG entry deletion remove the reference to its parent XG

--- a/zebra/zebra_vxlan_if.c
+++ b/zebra/zebra_vxlan_if.c
@@ -669,6 +669,7 @@ struct zebra_vxlan_vni *zebra_vxlan_if_vni_find(const struct zebra_if *zif,
 	if (vnip)
 		assert(vnip->vni == vni);
 
+	assert(vnip);
 	return vnip;
 }
 


### PR DESCRIPTION
This commit addresses null pointer dereferences in zebra folder alone. Added asserts at some places , other places used ternary operator.