### PR TITLE
bgpd: EVPN fix memleak in adv type5 cli cmd

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -4268,8 +4268,10 @@ DEFUN (bgp_evpn_advertise_type5,
 		/* Only allocate/update if the route-map name is different */
 		if (!bgp_vrf->adv_cmd_rmap[afi][safi].name ||
 		    strcmp(bgp_vrf->adv_cmd_rmap[afi][safi].name, argv[idx_rmap + 1]->arg) != 0) {
-			if (bgp_vrf->adv_cmd_rmap[afi][safi].name)
+			if (bgp_vrf->adv_cmd_rmap[afi][safi].name) {
 				XFREE(MTYPE_ROUTE_MAP_NAME, bgp_vrf->adv_cmd_rmap[afi][safi].name);
+				route_map_counter_decrement(bgp_vrf->adv_cmd_rmap[afi][safi].map);
+			}
 			bgp_vrf->adv_cmd_rmap[afi][safi].name = XSTRDUP(MTYPE_ROUTE_MAP_NAME,
 									argv[idx_rmap + 1]->arg);
 			bgp_vrf->adv_cmd_rmap[afi][safi].map =

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4519,6 +4519,12 @@ void bgp_free(struct bgp *bgp)
 			bgp_table_finish(&bgp->rib[afi][safi]);
 		rmap = &bgp->table_map[afi][safi];
 		XFREE(MTYPE_ROUTE_MAP_NAME, rmap->name);
+		/* Free advertise command route-map */
+		rmap = &bgp->adv_cmd_rmap[afi][safi];
+		if (rmap->name) {
+			XFREE(MTYPE_ROUTE_MAP_NAME, rmap->name);
+			route_map_counter_decrement(rmap->map);
+		}
 	}
 
 	bgp_scan_finish(bgp);


### PR DESCRIPTION
The cmd advertise ipv4 unicast [gatewayip] [route-map rmap]

If user configured route-map option first and later with the same route-map option gatewayip is configured the bgp db is overwrites with the new memory allocation of the same route-map.

The fix is to check route-map name is not same and free the old route-map before allocation new memory.
Free the route-map from bgp instance deletion, and decrement reference when free is called from cli

advertise ipv4 unicast route-map FOO
advertise ipv4 unicast gateway-ip route-map FOO

```
==1211321== HEAP SUMMARY:
==1211321==     in use at exit: 154 bytes in 4 blocks
==1211321==   total heap usage: 317,829 allocs, 317,825 frees,
22,423,384 bytes allocated
==1211321==
==1211321== 12 bytes in 2 blocks are definitely lost in loss record 1 of
3
==1211321==    at 0x48417B4: malloc (vg_replace_malloc.c:381)
==1211321==    by 0x4C83999: strdup (strdup.c:42)
==1211321==    by 0x49437DC: qstrdup (memory.c:123)
==1211321==    by 0x246E6F: bgp_evpn_advertise_type5
(bgp_evpn_vty.c:4255)
==1211321==    by 0x48F189E: cmd_execute_command_real (command.c:1011)
==1211321==    by 0x48F19FF: cmd_execute_command (command.c:1070)
==1211321==    by 0x48F1F62: cmd_execute (command.c:1236)
==1211321==    by 0x49BDEF5: vty_command (vty.c:644)
==1211321==    by 0x49BFB4B: vty_execute (vty.c:1407)
==1211321==    by 0x49C1D74: vtysh_read (vty.c:2432)
==1211321==    by 0x49B6CD6: event_call (event.c:2009)
==1211321==    by 0x492EAF2: frr_run (libfrr.c:1257)
==1211321==    by 0x1F1490: main (bgp_main.c:548)
==1211321==
==1211321== LEAK SUMMARY:
==1211321==    definitely lost: 12 bytes in 2 blocks
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>
