### PR TITLE
lib: Remove unused functionality

### DIFF
--- a/lib/frrevent.h
+++ b/lib/frrevent.h
@@ -73,7 +73,7 @@ struct event_loop {
 	struct event **read;
 	struct event **write;
 	struct event_timer_list_head timer;
-	struct event_list_head event, ready, unuse;
+	struct event_list_head event, ready;
 	struct list *cancel_req;
 	bool canceled;
 	pthread_cond_t cancel_cond;
@@ -101,7 +101,6 @@ enum event_types {
 	EVENT_TIMER,
 	EVENT_EVENT,
 	EVENT_READY,
-	EVENT_UNUSED,
 	EVENT_EXECUTE,
 };
 


### PR DESCRIPTION
The unused functionality for events was meant as a methodology of keeping around some of the last allocated events on a list such that we could quickly reuse them.  This has at least one serious problem that caused me to rethink this whole approach. Namely that if there is any type of address sanitizer issue associated with a event, we get the callstack that created the `struct event`, not it's current usage if a event was reused. Which is double plus not good, since we have exactly that right now.

Events are ephermeal, our reporting around them is not able to handle any of that and any attempt at tracking this is expensive and doesn't buy us much.  I do not think that the possibly? reduced allocation time is even worth it by any stretch of the imagination, since modern allocation functions are pretty fast.

Also note that the attempt at reusing the cpu history would more than likely never ever work as that we push to the tail of the unused and then pop from the front, pretty much guaranteeing that the cpu history will be different.