### PR TITLE
CISCO BGP4 MIB support

### DIFF
--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -164,10 +164,10 @@ bool bgp_adj_out_lookup(struct peer *peer, struct bgp_dest *dest,
 }
 
 
-void bgp_adj_in_set(struct bgp_dest *dest, struct peer *peer, struct attr *attr,
-		    uint32_t addpath_id, struct bgp_labels *labels)
+struct bgp_adj_in *bgp_adj_in_set(struct bgp_dest *dest, struct peer *peer, struct attr *attr,
+				  uint32_t addpath_id, struct bgp_labels *labels)
 {
-	struct bgp_adj_in *adj;
+	struct bgp_adj_in *adj = NULL;
 
 	for (adj = dest->adj_in; adj; adj = adj->next) {
 		if (adj->peer == peer && adj->addpath_rx_id == addpath_id) {
@@ -179,7 +179,7 @@ void bgp_adj_in_set(struct bgp_dest *dest, struct peer *peer, struct attr *attr,
 				bgp_labels_unintern(&adj->labels);
 				adj->labels = bgp_labels_intern(labels);
 			}
-			return;
+			return adj;
 		}
 	}
 	adj = XCALLOC(MTYPE_BGP_ADJ_IN, sizeof(struct bgp_adj_in));
@@ -191,6 +191,7 @@ void bgp_adj_in_set(struct bgp_dest *dest, struct peer *peer, struct attr *attr,
 	BGP_ADJ_IN_ADD(dest, adj);
 	peer->stat_pfx_adj_rib_in++;
 	bgp_dest_lock_node(dest);
+	return adj;
 }
 
 void bgp_adj_in_remove(struct bgp_dest **dest, struct bgp_adj_in *bai)
@@ -210,6 +211,13 @@ bool bgp_adj_in_unset(struct bgp_dest **dest, struct peer *peer,
 {
 	struct bgp_adj_in *adj;
 	struct bgp_adj_in *adj_next;
+	struct bgp_table *table;
+	afi_t afi;
+	safi_t safi;
+
+	table = bgp_dest_table(*dest);
+	afi = table->afi;
+	safi = table->safi;
 
 	adj = (*dest)->adj_in;
 
@@ -219,8 +227,11 @@ bool bgp_adj_in_unset(struct bgp_dest **dest, struct peer *peer,
 	while (adj) {
 		adj_next = adj->next;
 
-		if (adj->peer == peer && adj->addpath_rx_id == addpath_id)
+		if (adj->peer == peer && adj->addpath_rx_id == addpath_id) {
+			if (adj->filtered)
+				peer->pfiltered[afi][safi]--;
 			bgp_adj_in_remove(dest, adj);
+		}
 
 		adj = adj_next;
 

--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -103,6 +103,9 @@ struct bgp_adj_in {
 
 	/* Addpath identifier */
 	uint32_t addpath_rx_id;
+
+	/* if this update was filtered */
+	bool filtered;
 };
 
 /* BGP advertisement list.  */
@@ -137,9 +140,8 @@ struct bgp_synchronize {
 /* Prototypes.  */
 extern bool bgp_adj_out_lookup(struct peer *peer, struct bgp_dest *dest,
 			       uint32_t addpath_tx_id);
-extern void bgp_adj_in_set(struct bgp_dest *dest, struct peer *peer,
-			   struct attr *attr, uint32_t addpath_id,
-			   struct bgp_labels *labels);
+struct bgp_adj_in *bgp_adj_in_set(struct bgp_dest *dest, struct peer *peer, struct attr *attr,
+				  uint32_t addpath_id, struct bgp_labels *labels);
 extern bool bgp_adj_in_unset(struct bgp_dest **dest, struct peer *peer,
 			     uint32_t addpath_id);
 extern void bgp_adj_in_remove(struct bgp_dest **dest, struct bgp_adj_in *bai);

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -200,6 +200,8 @@ static void bgp_reuse_timer(struct event *t)
 			bgp_path_info_unset_flag(bdi->dest, bdi->path,
 						 BGP_PATH_DAMPED);
 			bdi->suppress_time = 0;
+			if (bdi->path->peer->psuppressed_cnt[bdi->afi][bdi->safi])
+				bdi->path->peer->psuppressed_cnt[bdi->afi][bdi->safi]--;
 
 			if (bdi->lastrecord == BGP_RECORD_UPDATE) {
 				bgp_path_info_unset_flag(bdi->dest, bdi->path,
@@ -318,6 +320,7 @@ int bgp_damp_withdraw(struct bgp_path_info *path, struct bgp_dest *dest,
 		bdi->suppress_time = t_now;
 		bgp_no_reuse_list_delete(bdi);
 		bgp_reuse_list_add(bdi, bdc);
+		path->peer->psuppressed_cnt[afi][safi]++;
 	}
 	return BGP_DAMP_USED;
 }
@@ -352,6 +355,8 @@ int bgp_damp_update(struct bgp_path_info *path, struct bgp_dest *dest,
 		bgp_reuse_list_delete(bdi);
 		bgp_no_reuse_list_add(bdi, bdc);
 		bdi->suppress_time = 0;
+		if (path->peer->psuppressed_cnt[afi][safi])
+			path->peer->psuppressed_cnt[afi][safi]--;
 		status = BGP_DAMP_USED;
 	} else
 		status = BGP_DAMP_SUPPRESSED;
@@ -376,6 +381,11 @@ void bgp_damp_info_free(struct bgp_damp_info *bdi, struct reuselist *list,
 	struct bgp *bgp = bpi->peer->bgp;
 
 	bgp_damp_info_unclaim(bdi, list);
+
+	if (CHECK_FLAG(bpi->flags, BGP_PATH_DAMPED)) {
+		if (bpi->peer->psuppressed_cnt[afi][safi])
+			bpi->peer->psuppressed_cnt[afi][safi]--;
+	}
 
 	bpi->extra->damp_info = NULL;
 	bgp_path_info_unset_flag(dest, bpi, BGP_PATH_HISTORY | BGP_PATH_DAMPED);

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -2316,6 +2316,10 @@ enum bgp_fsm_state_progress bgp_stop(struct peer_connection *connection)
 		} else
 			peer->af_sflags[afi][safi] = 0;
 
+		/* Reset SNMP prefix counters */
+		peer->pwithdraw_cnt[afi][safi] = 0;
+		peer->psuppressed_cnt[afi][safi] = 0;
+
 		/* Received ORF prefix-filter */
 		peer->orf_plist[afi][safi] = NULL;
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -236,6 +236,12 @@ DEFINE_HOOK(bgp_process,
 	     struct peer *peer, bool withdraw),
 	    (bgp, afi, safi, bn, peer, withdraw));
 
+DEFINE_HOOK(bgp_pfx_threshold_exceeded, (struct peer * peer, afi_t afi, safi_t safi),
+	    (peer, afi, safi));
+
+DEFINE_HOOK(bgp_pfx_threshold_clear, (struct peer * peer, afi_t afi, safi_t safi),
+	    (peer, afi, safi));
+
 /** Test if path is suppressed. */
 bool bgp_path_suppressed(struct bgp_path_info *pi)
 {
@@ -5249,52 +5255,13 @@ static void bgp_maximum_prefix_restart_timer(struct event *event)
 		zlog_debug("%s: %s peer_clear failed", __func__, peer->host);
 }
 
-static uint32_t bgp_filtered_routes_count(struct peer *peer, afi_t afi,
-					  safi_t safi)
-{
-	uint32_t count = 0;
-	bool filtered = false;
-	struct bgp_dest *dest;
-	struct bgp_adj_in *ain;
-	struct attr attr = {};
-	struct bgp_table *table = peer->bgp->rib[afi][safi];
-
-	for (dest = bgp_table_top(table); dest; dest = bgp_route_next(dest)) {
-		for (ain = dest->adj_in; ain; ain = ain->next) {
-			const struct prefix *rn_p = bgp_dest_get_prefix(dest);
-
-			bgp_attr_dup_into(&attr, ain->attr);
-
-			filtered = false;
-
-			if (bgp_input_filter(peer, rn_p, &attr, afi, safi)
-			    == FILTER_DENY)
-				filtered = true;
-
-			if (bgp_input_modifier(peer, rn_p, &attr, afi, safi,
-					       ROUTE_MAP_IN_NAME(&peer->filter[afi][safi]), NULL,
-					       0, NULL, NULL) == RMAP_DENY)
-				filtered = true;
-
-			if (filtered)
-				count++;
-
-			bgp_attr_flush(&attr);
-		}
-	}
-
-	return count;
-}
-
 bool bgp_maximum_prefix_overflow(struct peer *peer, afi_t afi, safi_t safi,
 				 int always)
 {
 	iana_afi_t pkt_afi;
 	iana_safi_t pkt_safi;
-	uint32_t pcount = (CHECK_FLAG(peer->af_flags[afi][safi],
-				      PEER_FLAG_MAX_PREFIX_FORCE))
-				  ? bgp_filtered_routes_count(peer, afi, safi)
-					    + peer->pcount[afi][safi]
+	uint32_t pcount = (CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_MAX_PREFIX_FORCE))
+				  ? peer->pcount[afi][safi] + peer->pfiltered[afi][safi]
 				  : peer->pcount[afi][safi];
 	struct peer_connection *connection = peer->connection;
 
@@ -5374,9 +5341,13 @@ bool bgp_maximum_prefix_overflow(struct peer *peer, afi_t afi, safi_t safi,
 			peer->pmax[afi][safi]);
 		SET_FLAG(peer->af_sflags[afi][safi],
 			 PEER_STATUS_PREFIX_THRESHOLD);
-	} else
+		hook_call(bgp_pfx_threshold_exceeded, peer, afi, safi);
+	} else {
+		if (CHECK_FLAG(peer->af_sflags[afi][safi], PEER_STATUS_PREFIX_THRESHOLD))
+			hook_call(bgp_pfx_threshold_clear, peer, afi, safi);
 		UNSET_FLAG(peer->af_sflags[afi][safi],
 			   PEER_STATUS_PREFIX_THRESHOLD);
+	}
 	return false;
 }
 
@@ -5421,6 +5392,8 @@ void bgp_rib_remove(struct bgp_dest *dest, struct bgp_path_info *pi,
 static void bgp_rib_withdraw(const struct prefix *p, struct bgp_dest *dest, struct bgp_path_info *pi,
 			     struct peer *peer, afi_t afi, safi_t safi, struct prefix_rd *prd)
 {
+	peer->pwithdraw_cnt[afi][safi]++;
+
 	/* apply dampening, if result is suppressed, we'll be retaining
 	 * the bgp_path_info in the RIB for historical reference.
 	 */
@@ -5777,6 +5750,7 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	struct bgp_path_info rmap_bpi = { .extra = &rmap_extra };
 	struct bgp_route_evpn *p_evpn = evpn;
 	uint8_t i;
+	struct bgp_adj_in *ain = NULL;
 
 	if (frrtrace_enabled(frr_bgp, process_update)) {
 		char pfxprint[PREFIX2STR_BUFFER] = { 0 };
@@ -5822,7 +5796,7 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 			bgp_attr_set_evpn_overlay(attr, evpn);
 			p_evpn = NULL;
 		}
-		bgp_adj_in_set(dest, peer, attr, addpath_id, &bgp_labels);
+		ain = bgp_adj_in_set(dest, peer, attr, addpath_id, &bgp_labels);
 	}
 
 	/* Check previously received route using pi_hash */
@@ -6165,6 +6139,16 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 		reason = "failing otc validation";
 		bgp_attr_flush(&new_attr);
 		goto filtered;
+	}
+
+	/* If the route passed all filters and was previously filtered,
+	 * decrement the filtered counter and clear the flag.
+	 * This handles the case where policy changes and routes that were
+	 * previously filtered now pass (e.g., after soft reconfiguration).
+	 */
+	if (ain && ain->filtered) {
+		peer->pfiltered[afi][orig_safi]--;
+		ain->filtered = false;
 	}
 
 	/* If neighbor soo is configured, tag all incoming routes with
@@ -6674,6 +6658,11 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 /* This BGP update is filtered.  Log the reason then update BGP
    entry.  */
 filtered:
+	if (ain && !ain->filtered) {
+		peer->pfiltered[afi][orig_safi]++;
+		ain->filtered = true;
+	}
+
 	if (new) {
 		bgp_unlink_nexthop(new);
 		bgp_path_info_mark_for_delete(dest, new);
@@ -7402,8 +7391,11 @@ static void bgp_clear_route_table(struct peer *peer, afi_t afi, safi_t safi,
 		while (ain) {
 			ain_next = ain->next;
 
-			if (ain->peer == peer)
+			if (ain->peer == peer) {
+				if (ain->filtered)
+					peer->pfiltered[afi][safi]--;
 				bgp_adj_in_remove(&dest, ain);
+			}
 
 			ain = ain_next;
 
@@ -7969,8 +7961,11 @@ void bgp_clear_adj_in(struct peer *peer, afi_t afi, safi_t safi)
 		while (ain) {
 			ain_next = ain->next;
 
-			if (ain->peer == peer)
+			if (ain->peer == peer) {
+				if (ain->filtered)
+					peer->pfiltered[afi][safi]--;
 				bgp_adj_in_remove(&dest, ain);
+			}
 
 			ain = ain_next;
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -774,6 +774,11 @@ static inline bool bgp_check_withdrawal(struct bgp *bgp, struct bgp_dest *dest,
 }
 
 /* called before bgp_process() */
+DECLARE_HOOK(bgp_pfx_threshold_exceeded, (struct peer * peer, afi_t afi, safi_t safi),
+	     (peer, afi, safi));
+DECLARE_HOOK(bgp_pfx_threshold_clear, (struct peer * peer, afi_t afi, safi_t safi),
+	     (peer, afi, safi));
+
 DECLARE_HOOK(bgp_process,
 	     (struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
 	      struct peer *peer, bool withdraw),

--- a/bgpd/bgp_snmp.c
+++ b/bgpd/bgp_snmp.c
@@ -28,6 +28,7 @@
 #include "bgpd/bgp_snmp.h"
 #include "bgpd/bgp_snmp_bgp4.h"
 #include "bgpd/bgp_snmp_bgp4v2.h"
+#include "bgpd/bgp_snmp_cbgp4.h"
 #include "bgpd/bgp_mplsvpn_snmp.h"
 #include "bgpd/bgp_snmp_clippy.c"
 
@@ -80,14 +81,30 @@ DEFPY(bgp_snmp_traps_bgp4_mibv2, bgp_snmp_traps_bgp4_mibv2_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY(bgp_snmp_traps_cisco_bgp4, bgp_snmp_traps_cisco_bgp4_cmd,
+      "[no$no] bgp snmp traps cisco-bgp4",
+      NO_STR BGP_STR
+      "Configure BGP SNMP\n"
+      "Configure SNMP traps for BGP\n"
+      "Configure use of CISCO-BGP4-MIB SNMP traps for BGP\n")
+{
+	if (no) {
+		UNSET_FLAG(bm->options, BGP_OPT_TRAPS_CISCO_BGP4);
+		return CMD_SUCCESS;
+	}
+	SET_FLAG(bm->options, BGP_OPT_TRAPS_CISCO_BGP4);
+	return CMD_SUCCESS;
+}
+
 static void bgp_snmp_traps_init(void)
 {
 	install_element(CONFIG_NODE, &bgp_snmp_traps_rfc4273_cmd);
 	install_element(CONFIG_NODE, &bgp_snmp_traps_bgp4_mibv2_cmd);
 	install_element(CONFIG_NODE, &bgp_snmp_traps_rfc4382_cmd);
+	install_element(CONFIG_NODE, &bgp_snmp_traps_cisco_bgp4_cmd);
 
 	SET_FLAG(bm->options, BGP_OPT_TRAPS_RFC4273);
-	/* BGP4MIBv2 traps are disabled by default */
+	/* BGP4MIBv2 and CISCO-BGP4-MIB traps are disabled by default */
 
 	SET_FLAG(bm->options, BGP_OPT_TRAPS_RFC4382);
 }
@@ -108,11 +125,15 @@ int bgp_cli_snmp_traps_config_write(struct vty *vty)
 		vty_out(vty, "no bgp snmp traps rfc4382\n");
 		write++;
 	}
+	if (CHECK_FLAG(bm->options, BGP_OPT_TRAPS_CISCO_BGP4)) {
+		vty_out(vty, "bgp snmp traps cisco-bgp4\n");
+		write++;
+	}
 
 	return write;
 }
 
-int bgpTrapEstablished(struct peer *peer)
+static int bgpTrapEstablished(struct peer *peer)
 {
 	if (CHECK_FLAG(bm->options, BGP_OPT_TRAPS_RFC4273))
 		bgp4TrapEstablished(peer);
@@ -120,16 +141,22 @@ int bgpTrapEstablished(struct peer *peer)
 	if (CHECK_FLAG(bm->options, BGP_OPT_TRAPS_BGP4MIBV2))
 		bgpv2TrapEstablished(peer);
 
+	if (CHECK_FLAG(bm->options, BGP_OPT_TRAPS_CISCO_BGP4))
+		cbgpPeerStatusChanged(peer);
+
 	return 0;
 }
 
-int bgpTrapBackwardTransition(struct peer *peer)
+static int bgpTrapBackwardTransition(struct peer *peer)
 {
 	if (CHECK_FLAG(bm->options, BGP_OPT_TRAPS_RFC4273))
 		bgp4TrapBackwardTransition(peer);
 
 	if (CHECK_FLAG(bm->options, BGP_OPT_TRAPS_BGP4MIBV2))
 		bgpv2TrapBackwardTransition(peer);
+
+	if (CHECK_FLAG(bm->options, BGP_OPT_TRAPS_CISCO_BGP4))
+		cbgpPeerBackwardTransition(peer);
 
 	return 0;
 }
@@ -140,6 +167,7 @@ static int bgp_snmp_init(struct event_loop *tm)
 	bgp_snmp_traps_init();
 	bgp_snmp_bgp4_init(tm);
 	bgp_snmp_bgp4v2_init(tm);
+	bgp_snmp_cbgp4_init(tm);
 	bgp_mpls_l3vpn_module_init();
 	return 0;
 }
@@ -154,11 +182,278 @@ static int bgp_snmp_module_init(void)
 {
 	hook_register(peer_status_changed, bgpTrapEstablished);
 	hook_register(peer_backward_transition, bgpTrapBackwardTransition);
+	hook_register(bgp_pfx_threshold_exceeded, cbgpPrefixThresholdExceeded);
+	hook_register(bgp_pfx_threshold_clear, cbgpPrefixThresholdClear);
 	hook_register(frr_late_init, bgp_snmp_init);
 	hook_register(frr_fini, bgp_snmp_terminate);
 	hook_register(bgp_snmp_traps_config_write,
 		      bgp_cli_snmp_traps_config_write);
 	return 0;
+}
+
+static struct peer *bgp_snmp_lookup_peer_in_vrf(struct bgp *bgp, const struct ipaddr *addr)
+{
+	struct peer *peer;
+	sa_family_t peer_family;
+
+	/*
+	 * peer_by_addr is kept sorted by address, so walk it looking for the
+	 * first entry strictly greater than the supplied key. This works even if
+	 * the exact peer has disappeared between requests.
+	 */
+	frr_each (peer_by_addr_list, &bgp->peer_by_addr, peer) {
+		peer_family = sockunion_family(&peer->connection->su);
+
+		/* Check if the address matches */
+		if (peer_family != addr->ipa_type)
+			continue;
+
+		switch (peer_family) {
+		case AF_INET:
+			if (IPV4_ADDR_SAME(&peer->connection->su.sin.sin_addr, &addr->ipaddr_v4))
+				return peer;
+			break;
+		case AF_INET6:
+			if (IPV6_ADDR_SAME(&peer->connection->su.sin6.sin6_addr, &addr->ipaddr_v6))
+				return peer;
+			break;
+		default:
+			break;
+		}
+	}
+
+	return NULL;
+}
+
+static struct peer *bgp_snmp_get_first_peer_in_vrf(struct bgp *bgp, sa_family_t family)
+{
+	struct peer *peer;
+	struct peer *first_peer = NULL;
+
+	if (family == AF_UNSPEC)
+		return peer_by_addr_list_first(&bgp->peer_by_addr);
+
+	/*
+	 * Iterate through the peers in the VRF and get the first peer
+	 * that matches the address type.
+	 */
+	frr_each (peer_by_addr_list, &bgp->peer_by_addr, peer) {
+		if (sockunion_family(&peer->connection->su) == family) {
+			first_peer = peer;
+			break;
+		}
+	}
+	return first_peer;
+}
+
+
+/*
+ * Static map of (AFI, SAFI) pairs in IANA lexicographic order.
+ * This map must be kept in sync with IANA AFI/SAFI definitions.
+ * See lib/iana_afi.h for IANA values.
+ *
+ * NOTE: When adding new AFI/SAFI to BGP, this map MUST be updated
+ * to maintain correct SNMP OID ordering.
+ */
+static const struct {
+	afi_t afi;
+	safi_t safi;
+} iana_ordered_afi_safi[] = {
+	{ AFI_IP, SAFI_UNICAST },	   /* IANA 1.1 */
+	{ AFI_IP, SAFI_MULTICAST },	   /* IANA 1.2 */
+	{ AFI_IP, SAFI_LABELED_UNICAST },  /* IANA 1.4 */
+	{ AFI_IP, SAFI_MPLS_VPN },	   /* IANA 1.128 */
+	{ AFI_IP, SAFI_FLOWSPEC },	   /* IANA 1.133 */
+	{ AFI_IP6, SAFI_UNICAST },	   /* IANA 2.1 */
+	{ AFI_IP6, SAFI_MULTICAST },	   /* IANA 2.2 */
+	{ AFI_IP6, SAFI_LABELED_UNICAST }, /* IANA 2.4 */
+	{ AFI_IP6, SAFI_MPLS_VPN },	   /* IANA 2.128 */
+	{ AFI_IP6, SAFI_FLOWSPEC },	   /* IANA 2.133 */
+	{ AFI_L2VPN, SAFI_EVPN },	   /* IANA 25.70 */
+};
+
+/*
+ * Get the next peer address family in lexicographic IANA (AFI, SAFI) order.
+ * This ensures SNMP OIDs are returned in strictly increasing order.
+ *
+ * @param peer - The peer to search
+ * @param afi - Current AFI (AFI_UNSPEC to start from beginning)
+ * @param safi - Current SAFI (SAFI_UNSPEC to start from beginning)
+ * @return Next peer_af structure, or NULL if no more address families
+ */
+struct peer_af *bgp_snmp_peer_af_next(struct peer *peer, afi_t afi, safi_t safi)
+{
+	size_t start_idx = 0;
+	int afid;
+
+	if (!peer)
+		return NULL;
+
+	/* Find starting position in IANA-ordered map */
+	if (afi != AFI_UNSPEC && safi != SAFI_UNSPEC) {
+		for (size_t i = 0; i < array_size(iana_ordered_afi_safi); i++) {
+			if (iana_ordered_afi_safi[i].afi == afi &&
+			    iana_ordered_afi_safi[i].safi == safi) {
+				start_idx = i + 1;
+				break;
+			}
+		}
+	}
+
+	/* Iterate through map in IANA order, return first active AF */
+	for (size_t i = start_idx; i < array_size(iana_ordered_afi_safi); i++) {
+		afid = afindex(iana_ordered_afi_safi[i].afi, iana_ordered_afi_safi[i].safi);
+		if (afid < BGP_AF_MAX && peer->peer_af_array[afid])
+			return peer->peer_af_array[afid];
+	}
+
+	return NULL;
+}
+
+static struct peer *bgp_snmp_get_next_peer_in_vrf(struct bgp *bgp, const struct ipaddr *addr,
+						  sa_family_t peer_family)
+{
+	struct peer *peer;
+
+	if (!addr)
+		return NULL;
+
+	frr_each (peer_by_addr_list, &bgp->peer_by_addr, peer) {
+		sa_family_t fam;
+		struct ipaddr peer_addr;
+
+		fam = sockunion_family(&peer->connection->su);
+
+		if (peer_family != AF_UNSPEC && fam != peer_family)
+			continue;
+
+		switch (fam) {
+		case AF_INET:
+			peer_addr.ipa_type = IPADDR_V4;
+			peer_addr.ipaddr_v4 = peer->connection->su.sin.sin_addr;
+			break;
+		case AF_INET6:
+			peer_addr.ipa_type = IPADDR_V6;
+			peer_addr.ipaddr_v6 = peer->connection->su.sin6.sin6_addr;
+			break;
+		default:
+			continue;
+		}
+
+		if (ipaddr_cmp(&peer_addr, addr) > 0)
+			return peer;
+	}
+
+	return NULL;
+}
+
+struct peer *bgp_snmp_lookup_peer(vrf_id_t peer_vrf_id, const struct ipaddr *addr)
+{
+	struct bgp *bgp;
+	struct peer *peer = NULL;
+
+	if (!addr)
+		return NULL;
+	bgp = bgp_lookup_by_vrf_id(peer_vrf_id);
+
+	if (bgp) {
+		/* Lookup in VRF */
+		peer = bgp_snmp_lookup_peer_in_vrf(bgp, addr);
+	}
+	return peer;
+}
+
+/*
+ * Find the next VRF with lowest VRF ID > min_vrf_id.
+ * Pass min_vrf_id = VRF_UNKNOWN to find the first VRF with lowest ID.
+ * Returns the BGP instance, or NULL if no next VRF is found.
+ * Note: Caller should check if the returned VRF has peers of the desired family.
+ */
+static struct bgp *bgp_snmp_get_next_vrf(vrf_id_t min_vrf_id)
+{
+	struct bgp *bgp;
+	struct bgp *bgp_next = NULL;
+	struct listnode *bgpnode;
+	vrf_id_t next_vrf_id = VRF_UNKNOWN;
+	bool find_first = (min_vrf_id == VRF_UNKNOWN);
+
+	/* Find VRF with lowest VRF ID (> min_vrf_id if not finding first) */
+	for (ALL_LIST_ELEMENTS_RO(bm->bgp, bgpnode, bgp)) {
+		/* Skip VRF_UNKNOWN to prevent wrap-around in SNMP walks */
+		if (bgp->vrf_id == VRF_UNKNOWN)
+			continue;
+
+		if (find_first || bgp->vrf_id > min_vrf_id) {
+			if (bgp_next == NULL || bgp->vrf_id < next_vrf_id) {
+				bgp_next = bgp;
+				next_vrf_id = bgp->vrf_id;
+			}
+		}
+	}
+
+	return bgp_next;
+}
+
+struct peer *bgp_snmp_get_first_peer(bool all_vrfs, sa_family_t family)
+{
+	struct bgp *bgp;
+	struct peer *peer = NULL;
+	vrf_id_t vrf_id;
+
+	if (all_vrfs) {
+		/* Find VRF with lowest VRF ID that has peers */
+		vrf_id = VRF_UNKNOWN;
+		while ((bgp = bgp_snmp_get_next_vrf(vrf_id)) != NULL) {
+			peer = bgp_snmp_get_first_peer_in_vrf(bgp, family);
+			if (peer)
+				break;
+			vrf_id = bgp->vrf_id;
+		}
+
+	} else {
+		/* Lookup in default VRF */
+		bgp = bgp_get_default();
+		if (bgp)
+			peer = bgp_snmp_get_first_peer_in_vrf(bgp, family);
+	}
+	return peer;
+}
+
+struct peer *bgp_snmp_get_next_peer(bool all_vrfs, vrf_id_t peer_vrf_id, sa_family_t family,
+				    const struct ipaddr *addr)
+{
+	struct bgp *bgp;
+	struct peer *peer = NULL;
+	struct listnode *bgpnode;
+	vrf_id_t vrf_id;
+
+	if (all_vrfs) {
+		/* First try to find next peer in current VRF */
+		for (ALL_LIST_ELEMENTS_RO(bm->bgp, bgpnode, bgp)) {
+			if (bgp->vrf_id == peer_vrf_id) {
+				peer = bgp_snmp_get_next_peer_in_vrf(bgp, addr, family);
+				if (peer)
+					return peer;
+				break;
+			}
+		}
+
+		/* No more peers in current VRF, find next VRF with lowest ID > peer_vrf_id */
+		vrf_id = peer_vrf_id;
+		while ((bgp = bgp_snmp_get_next_vrf(vrf_id)) != NULL) {
+			peer = bgp_snmp_get_first_peer_in_vrf(bgp, family);
+			if (peer)
+				break;
+			vrf_id = bgp->vrf_id;
+		}
+
+	} else {
+		/* Lookup in default VRF */
+		bgp = bgp_get_default();
+		if (bgp)
+			peer = bgp_snmp_get_next_peer_in_vrf(bgp, addr, family);
+	}
+	return peer;
 }
 
 FRR_MODULE_SETUP(.name = "bgpd_snmp", .version = FRR_VERSION,

--- a/bgpd/bgp_snmp.h
+++ b/bgpd/bgp_snmp.h
@@ -15,7 +15,20 @@
 #define IPADDRESS ASN_IPADDRESS
 #define GAUGE32 ASN_UNSIGNED
 
-extern int bgpTrapEstablished(struct peer *peer);
-extern int bgpTrapBackwardTransition(struct peer *peer);
+extern struct peer *bgp_snmp_lookup_peer(vrf_id_t vrf_id, const struct ipaddr *addr);
+extern struct peer *bgp_snmp_get_first_peer(bool all_vrfs, sa_family_t family);
+extern struct peer *bgp_snmp_get_next_peer(bool all_vrfs, vrf_id_t peer_vrf_id, sa_family_t family,
+					   const struct ipaddr *addr);
+extern struct peer_af *bgp_snmp_peer_af_next(struct peer *peer, afi_t afi, safi_t safi);
+
+/*
+ * Workaround for net-snmp 5.7.3: OID array items are uninitialized
+ * and contain random values. Zero them out to ensure correct behavior.
+ * This issue is fixed in net-snmp 5.8+.
+ */
+static inline void bgp_snmp_index_init(oid *index, size_t max_len)
+{
+	memset(index, 0, max_len * sizeof(oid));
+}
 
 #endif /* _FRR_BGP_SNMP_H_ */

--- a/bgpd/bgp_snmp_cbgp4.c
+++ b/bgpd/bgp_snmp_cbgp4.c
@@ -1,0 +1,3984 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* CISCO-BGP4-MIB SNMP support
+ * Copyright (C) 2025 Sudharsan Rajagopalan
+ */
+
+#include <zebra.h>
+
+#include <string.h>
+
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+
+#include "if.h"
+#include "log.h"
+#include "prefix.h"
+#include "command.h"
+#include "frrevent.h"
+#include "smux.h"
+#include "filter.h"
+#include "hook.h"
+#include "libfrr.h"
+#include "lib/version.h"
+
+#include "bgpd/bgpd.h"
+#include "bgpd/bgp_table.h"
+#include "bgpd/bgp_aspath.h"
+#include "bgpd/bgp_attr.h"
+#include "bgpd/bgp_debug.h"
+#include "bgpd/bgp_route.h"
+#include "bgpd/bgp_fsm.h"
+#include "bgpd/bgp_vty.h"
+#include "bgpd/bgp_snmp.h"
+#include "bgpd/bgp_snmp_cbgp4.h"
+#include "bgpd/bgp_open.h"
+
+SNMP_LOCAL_VARIABLES
+
+static oid cbgp4_oid[] = { CBGP4MIB };
+static oid cbgp4_trap_oid[] = {CBGP4MIB, CBGP_NOTIFY_PREFIX};
+static struct in_addr bgp_empty_addr = {};
+
+static struct trap_object cbgpPeer2TrapList[] = {
+	{5, {CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE,
+	     CBGP_PEER2_ENTRY, CBGP_PEER2_LAST_ERROR}},
+	{5, {CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE,
+	     CBGP_PEER2_ENTRY, CBGP_PEER2_STATE}},
+};
+
+static struct trap_object cbgpPeer2FsmTrapList[] = {
+	{5, {CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE,
+	     CBGP_PEER2_ENTRY, CBGP_PEER2_LAST_ERROR}},
+	{5, {CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE,
+	     CBGP_PEER2_ENTRY, CBGP_PEER2_STATE}},
+	{5, {CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE,
+	     CBGP_PEER2_ENTRY, CBGP_PEER2_LAST_ERROR_TXT}},
+	{5, {CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE,
+	     CBGP_PEER2_ENTRY, CBGP_PEER2_PREV_STATE}},
+};
+
+static int cbgp4_build_peer2_index(struct peer *peer, oid *index)
+{
+	switch (sockunion_family(&peer->connection->su)) {
+	case AF_INET:
+		index[0] = INETADDRESSTYPEIPV4;
+		oid_copy_in_addr(&index[1], &peer->connection->su.sin.sin_addr);
+		return IN_ADDR_SIZE + 1;
+	case AF_INET6:
+		index[0] = INETADDRESSTYPEIPV6;
+		oid_copy_in6_addr(&index[1], &peer->connection->su.sin6.sin6_addr);
+		return IN6_ADDR_SIZE + 1;
+	default:
+		return 0;
+	}
+}
+
+static struct peer *cbgp4_peer_next_global(struct peer *peer)
+{
+	if (!peer)
+		return NULL;
+
+	struct ipaddr addr = {};
+	sa_family_t family = sockunion_family(&peer->connection->su);
+
+	switch (family) {
+	case AF_INET:
+		addr.ipa_type = AF_INET;
+		addr.ip._v4_addr = peer->connection->su.sin.sin_addr;
+		break;
+	case AF_INET6:
+		addr.ipa_type = AF_INET6;
+		addr.ip._v6_addr = peer->connection->su.sin6.sin6_addr;
+		break;
+	default:
+		return NULL;
+	}
+
+	return bgp_snmp_get_next_peer(true, peer->bgp->vrf_id, AF_UNSPEC, &addr);
+}
+
+static size_t cbgp4_fill_peer3_index(const struct peer *peer, oid *out)
+{
+	if (!peer || !out)
+		return 0;
+
+	out[0] = peer->bgp->vrf_id;
+	switch (sockunion_family(&peer->connection->su)) {
+	case AF_INET:
+		out[1] = INETADDRESSTYPEIPV4;
+		oid_copy_in_addr(&out[2], &peer->connection->su.sin.sin_addr);
+		return IN_ADDR_SIZE + 2;
+	case AF_INET6:
+		out[1] = INETADDRESSTYPEIPV6;
+		oid_copy_in6_addr(&out[2], &peer->connection->su.sin6.sin6_addr);
+		return IN6_ADDR_SIZE + 2;
+	default:
+		return 0;
+	}
+}
+
+static int cbgp4_compare_index(const oid *lhs, size_t lhs_len, const oid *rhs, size_t rhs_len)
+{
+	size_t min = lhs_len < rhs_len ? lhs_len : rhs_len;
+
+	for (size_t i = 0; i < min; i++) {
+		if (lhs[i] < rhs[i])
+			return -1;
+		if (lhs[i] > rhs[i])
+			return 1;
+	}
+
+	if (lhs_len == rhs_len)
+		return 0;
+
+	return (lhs_len < rhs_len) ? -1 : 1;
+}
+
+static struct peer *cbgp4PeerTable_lookup(struct variable *v, oid name[], size_t *length, int exact)
+{
+	struct peer *peer = NULL;
+	size_t namelen = v ? v->namelen : CBGP_PEER_TABLE_INDEX_OFFSET;
+	oid *index = name + namelen;
+	size_t offsetlen = *length - namelen;
+	struct ipaddr addr = {};
+
+	if (!offsetlen) {
+		bgp_snmp_index_init(index, CBGP_PEER_TABLE_MAX_INDEX_LEN);
+	} else if (offsetlen == IN_ADDR_SIZE) {
+		addr.ipa_type = AF_INET;
+		oid2in_addr(index, IN_ADDR_SIZE, &addr.ip._v4_addr);
+	} else {
+		/* We cannot support partial indexes */
+		return NULL;
+	}
+
+	if (exact)
+		peer = bgp_snmp_lookup_peer(VRF_DEFAULT, &addr);
+	else if (!offsetlen)
+		peer = bgp_snmp_get_first_peer(false, AF_UNSPEC);
+	else
+		peer = bgp_snmp_get_next_peer(false, VRF_DEFAULT, AF_INET, &addr);
+
+	if (!peer || !peer->connection)
+		return NULL;
+
+	if (!exact) {
+		oid_copy_in_addr(index, &peer->connection->su.sin.sin_addr);
+		*length = namelen + IN_ADDR_SIZE;
+	}
+
+	return peer;
+}
+
+static struct peer *cbgp4Peer2Table_lookup(struct variable *v, oid name[], size_t *length,
+					   int exact)
+{
+	struct peer *peer = NULL;
+	size_t namelen = v ? v->namelen : CBGP_PEER_TABLE_INDEX_OFFSET;
+	oid *index = name + namelen;
+	size_t offsetlen = *length - namelen;
+	struct ipaddr addr = {};
+	bool addr_present = false;
+	sa_family_t family = AF_UNSPEC;
+
+	if (!offsetlen) {
+		bgp_snmp_index_init(index, CBGP_PEER2_TABLE_MAX_INDEX_LEN);
+	} else if (offsetlen == 1) {
+		if (index[0] == INETADDRESSTYPEIPV4)
+			family = AF_INET;
+		else if (index[0] == INETADDRESSTYPEIPV6)
+			family = AF_INET6;
+		else
+			return NULL;
+	} else {
+		if (offsetlen == IN_ADDR_SIZE + 1 && index[0] == INETADDRESSTYPEIPV4) {
+			family = AF_INET;
+			addr.ipa_type = AF_INET;
+			oid2in_addr(&index[1], IN_ADDR_SIZE, &addr.ip._v4_addr);
+			addr_present = true;
+		} else if (offsetlen == IN6_ADDR_SIZE + 1 && index[0] == INETADDRESSTYPEIPV6) {
+			family = AF_INET6;
+			addr.ipa_type = AF_INET6;
+			oid2in6_addr(&index[1], &addr.ip._v6_addr);
+			addr_present = true;
+		} else {
+			/* Unsupported partial index */
+			return NULL;
+		}
+	}
+
+	if (exact) {
+		if (!addr_present)
+			return NULL;
+		peer = bgp_snmp_lookup_peer(VRF_DEFAULT, &addr);
+		if (peer &&
+		    (!peer->connection || sockunion_family(&peer->connection->su) != family))
+			peer = NULL;
+	} else {
+		if (!offsetlen)
+			peer = bgp_snmp_get_first_peer(false, AF_UNSPEC);
+		else if (!addr_present)
+			peer = bgp_snmp_get_first_peer(false, family);
+		else {
+			sa_family_t primary_family = family;
+
+			peer = bgp_snmp_get_next_peer(false, VRF_DEFAULT, primary_family, &addr);
+			if (!peer && primary_family != AF_UNSPEC)
+				peer = bgp_snmp_get_next_peer(false, VRF_DEFAULT, AF_UNSPEC, &addr);
+		}
+
+		if (peer == NULL || !peer->connection)
+			return NULL;
+
+		switch (sockunion_family(&peer->connection->su)) {
+		case AF_INET:
+			index[0] = INETADDRESSTYPEIPV4;
+			oid_copy_in_addr(&index[1], &peer->connection->su.sin.sin_addr);
+			*length = namelen + IN_ADDR_SIZE + 1;
+			break;
+		case AF_INET6:
+			index[0] = INETADDRESSTYPEIPV6;
+			oid_copy_in6_addr(&index[1], &peer->connection->su.sin6.sin6_addr);
+			*length = namelen + IN6_ADDR_SIZE + 1;
+			break;
+		default:
+			break;
+		}
+	}
+
+	return peer;
+}
+
+static struct peer *cbgp4Peer3Table_lookup(struct variable *v, oid name[], size_t *length,
+					   int exact)
+{
+	struct peer *peer = NULL;
+	size_t namelen = v ? v->namelen : CBGP_PEER_TABLE_INDEX_OFFSET;
+	oid *index = name + namelen;
+	size_t offsetlen = *length - namelen;
+	vrf_id_t vrf_id = VRF_UNKNOWN;
+	struct ipaddr addr = {};
+	bool addr_present = false;
+	sa_family_t family = AF_UNSPEC;
+
+	if (!offsetlen) {
+		bgp_snmp_index_init(index, CBGP_PEER3_TABLE_MAX_INDEX_LEN);
+	} else {
+		vrf_id = index[0];
+
+		if (offsetlen == 1) {
+			/* Only VRF provided */
+			; /* nothing else to parse */
+		} else if (offsetlen == 2) {
+			if (index[1] == INETADDRESSTYPEIPV4)
+				family = AF_INET;
+			else if (index[1] == INETADDRESSTYPEIPV6)
+				family = AF_INET6;
+			else
+				return NULL;
+		} else if ((offsetlen == IN_ADDR_SIZE + 2 && index[1] == INETADDRESSTYPEIPV4) ||
+			   (offsetlen == IN6_ADDR_SIZE + 2 && index[1] == INETADDRESSTYPEIPV6)) {
+			if (index[1] == INETADDRESSTYPEIPV4) {
+				family = AF_INET;
+				addr.ipa_type = AF_INET;
+				oid2in_addr(&index[2], IN_ADDR_SIZE, &addr.ip._v4_addr);
+				addr_present = true;
+			} else {
+				family = AF_INET6;
+				addr.ipa_type = AF_INET6;
+				oid2in6_addr(&index[2], &addr.ip._v6_addr);
+				addr_present = true;
+			}
+		} else {
+			/* Unsupported partial index */
+			return NULL;
+		}
+	}
+
+	if (exact) {
+		if (!addr_present)
+			return NULL;
+		peer = bgp_snmp_lookup_peer(vrf_id, &addr);
+		if (peer &&
+		    (!peer->connection ||
+		     (family != AF_UNSPEC && sockunion_family(&peer->connection->su) != family)))
+			peer = NULL;
+	} else {
+		peer = bgp_snmp_get_first_peer(true, AF_UNSPEC);
+		oid candidate_index[CBGP_PEER3_TABLE_MAX_INDEX_LEN];
+		size_t candidate_len = 0;
+
+		while (peer) {
+			candidate_len = cbgp4_fill_peer3_index(peer, candidate_index);
+			if (!candidate_len) {
+				peer = cbgp4_peer_next_global(peer);
+				continue;
+			}
+
+			if (!offsetlen)
+				break;
+
+			int cmp = cbgp4_compare_index(index, offsetlen, candidate_index,
+						      candidate_len);
+			if (cmp < 0)
+				break;
+			if (cmp == 0) {
+				peer = cbgp4_peer_next_global(peer);
+				continue;
+			}
+
+			peer = cbgp4_peer_next_global(peer);
+		}
+
+		if (!peer)
+			return NULL;
+
+		memcpy(index, candidate_index, candidate_len * sizeof(oid));
+		*length = namelen + candidate_len;
+	}
+
+	return peer;
+}
+
+static uint8_t *cbgp4PeerTable(struct variable *v, oid name[], size_t *length, int exact,
+			       size_t *var_len, WriteMethod **write_method)
+{
+	struct peer *peer;
+
+	if (smux_header_table(v, name, length, exact, var_len, write_method) == MATCH_FAILED)
+		return NULL;
+
+	peer = cbgp4PeerTable_lookup(v, name, length, exact);
+	if (!peer)
+		return NULL;
+
+	switch (v->magic) {
+	case CBGP_PEER_LAST_ERROR_TXT:
+		if (peer->last_reset == PEER_DOWN_NOTIFY_RECEIVED) {
+			struct bgp_notify notify = peer->notify;
+			char msg_buf[255];
+			const char *msg_str = NULL;
+
+			if (notify.code == BGP_NOTIFY_CEASE &&
+			    (notify.subcode == BGP_NOTIFY_CEASE_ADMIN_SHUTDOWN ||
+			     notify.subcode == BGP_NOTIFY_CEASE_ADMIN_RESET)) {
+				msg_str = bgp_notify_admin_message(msg_buf, sizeof(msg_buf),
+								   (uint8_t *)notify.data,
+								   notify.length);
+				return SNMP_STRING(msg_str);
+			}
+		}
+		return SNMP_STRING("");
+
+	case CBGP_PEER_PREV_STATE:
+		return SNMP_INTEGER(peer->connection ? peer->connection->ostatus : Idle);
+
+	// Deprecated
+	case CBGP_PEER_PREFIX_ACCEPTED:
+	case CBGP_PEER_PREFIX_DENIED:
+	case CBGP_PEER_PREFIX_LIMIT:
+	case CBGP_PEER_PREFIX_ADVERTISED:
+	case CBGP_PEER_PREFIX_SUPPRESSED:
+	case CBGP_PEER_PREFIX_WITHDRAWN:
+	default:
+		break;
+	}
+
+	return NULL;
+}
+
+static uint8_t *cbgp4Peer2Table(struct variable *v, oid name[], size_t *length, int exact,
+				size_t *var_len, WriteMethod **write_method)
+{
+	struct peer *peer;
+	uint32_t ui, uo;
+
+	if (smux_header_table(v, name, length, exact, var_len, write_method) == MATCH_FAILED)
+		return NULL;
+
+	peer = cbgp4Peer2Table_lookup(v, name, length, exact);
+	if (!peer)
+		return NULL;
+
+	switch (v->magic) {
+	case CBGP_PEER2_LOCAL_ADDR:
+		if (peer->connection && peer->connection->su_local)
+			if (peer->connection->su_local->sa.sa_family == AF_INET)
+				return SNMP_IPADDRESS(peer->connection->su_local->sin.sin_addr);
+			else
+				return SNMP_IP6ADDRESS(peer->connection->su_local->sin6.sin6_addr);
+		else
+			return SNMP_IPADDRESS(bgp_empty_addr);
+
+	case CBGP_PEER2_TYPE:
+		if (peer->connection && peer->connection->su_remote)
+			return SNMP_INTEGER(peer->connection->su_remote->sa.sa_family == AF_INET
+						    ? AFI_IP
+						    : AFI_IP6);
+		else
+			return SNMP_INTEGER(0);
+
+	case CBGP_PEER2_REMOTE_ADDR:
+		if (peer->connection && peer->connection->su_remote)
+			if (peer->connection->su_remote->sa.sa_family == AF_INET)
+				return SNMP_IPADDRESS(peer->connection->su_remote->sin.sin_addr);
+			else
+				return SNMP_IP6ADDRESS(peer->connection->su_remote->sin6.sin6_addr);
+		else
+			return SNMP_IPADDRESS(bgp_empty_addr);
+
+	case CBGP_PEER2_LOCAL_PORT:
+		if (peer->connection && peer->connection->su_local)
+			if (peer->connection->su_local->sa.sa_family == AF_INET)
+				return SNMP_INTEGER(
+					ntohs(peer->connection->su_local->sin.sin_port));
+			else
+				return SNMP_INTEGER(
+					ntohs(peer->connection->su_local->sin6.sin6_port));
+		else
+			return SNMP_INTEGER(0);
+
+	case CBGP_PEER2_LOCAL_AS:
+		return SNMP_INTEGER(peer->local_as);
+
+	case CBGP_PEER2_LOCAL_IDENTIFIER:
+		return SNMP_IPADDRESS(peer->local_id);
+
+	case CBGP_PEER2_REMOTE_PORT:
+		if (peer->connection && peer->connection->su_remote)
+			if (peer->connection->su_remote->sa.sa_family == AF_INET)
+				return SNMP_INTEGER(
+					ntohs(peer->connection->su_remote->sin.sin_port));
+			else
+				return SNMP_INTEGER(
+					ntohs(peer->connection->su_remote->sin6.sin6_port));
+		else
+			return SNMP_INTEGER(0);
+
+	case CBGP_PEER2_REMOTE_AS:
+		return SNMP_INTEGER(peer->as);
+
+	case CBGP_PEER2_REMOTE_IDENTIFIER:
+		return SNMP_IPADDRESS(peer->remote_id);
+
+	case CBGP_PEER2_ADMIN_STATUS:
+#define CBGP_PEER2_ADMIN_STATUS_HALTED	1
+#define CBGP_PEER2_ADMIN_STATUS_RUNNING 2
+		if (BGP_PEER_START_SUPPRESSED(peer))
+			return SNMP_INTEGER(CBGP_PEER2_ADMIN_STATUS_HALTED);
+		else
+			return SNMP_INTEGER(CBGP_PEER2_ADMIN_STATUS_RUNNING);
+
+	case CBGP_PEER2_STATE:
+		return SNMP_INTEGER(peer->connection ? peer->connection->status : Idle);
+
+	case CBGP_PEER2_LAST_ERROR:
+	{
+		static uint8_t last_error[2];
+		if (peer->last_reset == PEER_DOWN_NOTIFY_RECEIVED) {
+			last_error[0] = peer->notify.code;
+			last_error[1] = peer->notify.subcode;
+		} else {
+			last_error[0] = 0;
+			last_error[1] = 0;
+		}
+		*var_len = 2;
+		return last_error;
+	}
+
+	case CBGP_PEER2_LAST_ERROR_TXT:
+		if (peer->last_reset == PEER_DOWN_NOTIFY_RECEIVED) {
+			struct bgp_notify notify = peer->notify;
+			char msg_buf[255];
+			const char *msg_str = NULL;
+
+			if (notify.code == BGP_NOTIFY_CEASE &&
+			    (notify.subcode == BGP_NOTIFY_CEASE_ADMIN_SHUTDOWN ||
+			     notify.subcode == BGP_NOTIFY_CEASE_ADMIN_RESET)) {
+				msg_str = bgp_notify_admin_message(msg_buf, sizeof(msg_buf),
+								   (uint8_t *)notify.data,
+								   notify.length);
+				return SNMP_STRING(msg_str);
+			}
+		}
+		return SNMP_STRING("");
+
+	case CBGP_PEER2_CONNECT_RETRY_INTERVAL:
+		return SNMP_INTEGER(peer->v_connect);
+
+	case CBGP_PEER2_HOLD_TIME:
+		return SNMP_INTEGER(peer->v_holdtime);
+
+	case CBGP_PEER2_KEEP_ALIVE:
+		return SNMP_INTEGER(peer->v_keepalive);
+
+	case CBGP_PEER2_HOLD_TIME_CONFIGURED:
+		return SNMP_INTEGER(CHECK_FLAG(peer->flags, PEER_FLAG_TIMER)
+					    ? peer->holdtime
+					    : peer->bgp->default_holdtime);
+
+	case CBGP_PEER2_KEEP_ALIVE_CONFIGURED:
+		return SNMP_INTEGER(CHECK_FLAG(peer->flags, PEER_FLAG_TIMER)
+					    ? peer->keepalive
+					    : peer->bgp->default_keepalive);
+
+	case CBGP_PEER2_MIN_ROUTE_ADVERTISEMENT_INTERVAL:
+		return SNMP_INTEGER(peer->v_routeadv);
+
+	case CBGP_PEER2_IN_UPDATE_ELAPSED_TIME:
+		if (!peer->update_time)
+			return SNMP_INTEGER(0);
+		else
+			return SNMP_INTEGER(monotime(NULL) - peer->update_time);
+
+	case CBGP_PEER2_IN_UPDATES:
+		ui = atomic_load_explicit(&peer->update_in, memory_order_relaxed);
+		return SNMP_INTEGER(ui);
+
+	case CBGP_PEER2_OUT_UPDATES:
+		uo = atomic_load_explicit(&peer->update_out, memory_order_relaxed);
+		return SNMP_INTEGER(uo);
+
+	case CBGP_PEER2_IN_TOTAL_MESSAGES:
+		return SNMP_INTEGER(PEER_TOTAL_RX(peer));
+
+	case CBGP_PEER2_OUT_TOTAL_MESSAGES:
+		return SNMP_INTEGER(PEER_TOTAL_TX(peer));
+
+	case CBGP_PEER2_FSM_ESTABLISHED_TRANSITIONS:
+		return SNMP_INTEGER(peer->established);
+
+	case CBGP_PEER2_FSM_ESTABLISHED_TIME:
+		if (!peer->uptime)
+			return SNMP_INTEGER(0);
+		else
+			return SNMP_INTEGER(monotime(NULL) - peer->uptime);
+
+	case CBGP_PEER2_PREV_STATE:
+		return SNMP_INTEGER(peer->connection ? peer->connection->ostatus : Idle);
+
+	case CBGP_PEER2_NEGOTIATED_VERSION:
+		return SNMP_INTEGER(BGP_VERSION_4);
+
+	case CBGP_PEER2_MIN_AS_ORIGINATION_INTERVAL:
+		return SNMP_INTEGER(peer->v_routeadv);
+	default:
+		break;
+	}
+
+	return NULL;
+}
+
+static uint8_t *cbgp4Peer3Table(struct variable *v, oid name[], size_t *length, int exact,
+				size_t *var_len, WriteMethod **write_method)
+{
+	struct peer *peer;
+	uint32_t ui, uo;
+
+	if (smux_header_table(v, name, length, exact, var_len, write_method) == MATCH_FAILED)
+		return NULL;
+
+	peer = cbgp4Peer3Table_lookup(v, name, length, exact);
+	if (!peer)
+		return NULL;
+
+	switch (v->magic) {
+	case CBGP_PEER3_VRF_ID:
+		return SNMP_INTEGER(peer->bgp->vrf_id);
+	case CBGP_PEER3_VRF_NAME:
+		return SNMP_STRING(peer->bgp->name_pretty);
+	case CBGP_PEER3_LOCAL_ADDR:
+		if (peer->connection && peer->connection->su_local)
+			if (peer->connection->su_local->sa.sa_family == AF_INET)
+				return SNMP_IPADDRESS(peer->connection->su_local->sin.sin_addr);
+			else
+				return SNMP_IP6ADDRESS(peer->connection->su_local->sin6.sin6_addr);
+		else
+			return SNMP_IPADDRESS(bgp_empty_addr);
+
+	case CBGP_PEER3_TYPE:
+		if (peer->connection && peer->connection->su_remote)
+			return SNMP_INTEGER(peer->connection->su_remote->sa.sa_family == AF_INET
+						    ? AFI_IP
+						    : AFI_IP6);
+		else
+			return SNMP_INTEGER(0);
+
+	case CBGP_PEER3_REMOTE_ADDR:
+		if (peer->connection && peer->connection->su_remote)
+			if (peer->connection->su_remote->sa.sa_family == AF_INET)
+				return SNMP_IPADDRESS(peer->connection->su_remote->sin.sin_addr);
+			else
+				return SNMP_IP6ADDRESS(peer->connection->su_remote->sin6.sin6_addr);
+		else
+			return SNMP_IPADDRESS(bgp_empty_addr);
+
+	case CBGP_PEER3_LOCAL_PORT:
+		if (peer->connection && peer->connection->su_local)
+			if (peer->connection->su_local->sa.sa_family == AF_INET)
+				return SNMP_INTEGER(
+					ntohs(peer->connection->su_local->sin.sin_port));
+			else
+				return SNMP_INTEGER(
+					ntohs(peer->connection->su_local->sin6.sin6_port));
+		else
+			return SNMP_INTEGER(0);
+
+	case CBGP_PEER3_LOCAL_AS:
+		return SNMP_INTEGER(peer->local_as);
+
+	case CBGP_PEER3_LOCAL_IDENTIFIER:
+		return SNMP_IPADDRESS(peer->local_id);
+
+	case CBGP_PEER3_REMOTE_PORT:
+		if (peer->connection && peer->connection->su_remote)
+			if (peer->connection->su_remote->sa.sa_family == AF_INET)
+				return SNMP_INTEGER(
+					ntohs(peer->connection->su_remote->sin.sin_port));
+			else
+				return SNMP_INTEGER(
+					ntohs(peer->connection->su_remote->sin6.sin6_port));
+		else
+			return SNMP_INTEGER(0);
+
+	case CBGP_PEER3_REMOTE_AS:
+		return SNMP_INTEGER(peer->as);
+
+	case CBGP_PEER3_REMOTE_IDENTIFIER:
+		return SNMP_IPADDRESS(peer->remote_id);
+
+	case CBGP_PEER3_ADMIN_STATUS:
+#define CBGP_PEER3_ADMIN_STATUS_HALTED	1
+#define CBGP_PEER3_ADMIN_STATUS_RUNNING 2
+		if (BGP_PEER_START_SUPPRESSED(peer))
+			return SNMP_INTEGER(CBGP_PEER3_ADMIN_STATUS_HALTED);
+		else
+			return SNMP_INTEGER(CBGP_PEER3_ADMIN_STATUS_RUNNING);
+
+	case CBGP_PEER3_STATE:
+		return SNMP_INTEGER(peer->connection ? peer->connection->status : Idle);
+
+	case CBGP_PEER3_LAST_ERROR:
+	{
+		static uint8_t last_error[2];
+		if (peer->last_reset == PEER_DOWN_NOTIFY_RECEIVED) {
+			last_error[0] = peer->notify.code;
+			last_error[1] = peer->notify.subcode;
+		} else {
+			last_error[0] = 0;
+			last_error[1] = 0;
+		}
+		*var_len = 2;
+		return last_error;
+	}
+
+	case CBGP_PEER3_LAST_ERROR_TXT:
+		if (peer->last_reset == PEER_DOWN_NOTIFY_RECEIVED) {
+			struct bgp_notify notify = peer->notify;
+			char msg_buf[255];
+			const char *msg_str = NULL;
+
+			if (notify.code == BGP_NOTIFY_CEASE &&
+			    (notify.subcode == BGP_NOTIFY_CEASE_ADMIN_SHUTDOWN ||
+			     notify.subcode == BGP_NOTIFY_CEASE_ADMIN_RESET)) {
+				msg_str = bgp_notify_admin_message(msg_buf, sizeof(msg_buf),
+								   (uint8_t *)notify.data,
+								   notify.length);
+				return SNMP_STRING(msg_str);
+			}
+		}
+		return SNMP_STRING("");
+
+	case CBGP_PEER3_CONNECT_RETRY_INTERVAL:
+		return SNMP_INTEGER(peer->v_connect);
+
+	case CBGP_PEER3_HOLD_TIME:
+		return SNMP_INTEGER(peer->v_holdtime);
+
+	case CBGP_PEER3_KEEP_ALIVE:
+		return SNMP_INTEGER(peer->v_keepalive);
+
+	case CBGP_PEER3_HOLD_TIME_CONFIGURED:
+		return SNMP_INTEGER(CHECK_FLAG(peer->flags, PEER_FLAG_TIMER)
+					    ? peer->holdtime
+					    : peer->bgp->default_holdtime);
+
+	case CBGP_PEER3_KEEP_ALIVE_CONFIGURED:
+		return SNMP_INTEGER(CHECK_FLAG(peer->flags, PEER_FLAG_TIMER)
+					    ? peer->keepalive
+					    : peer->bgp->default_keepalive);
+
+	case CBGP_PEER3_MIN_ROUTE_ADVERTISEMENT_INTERVAL:
+		return SNMP_INTEGER(peer->v_routeadv);
+
+	case CBGP_PEER3_IN_UPDATE_ELAPSED_TIME:
+		if (!peer->update_time)
+			return SNMP_INTEGER(0);
+		else
+			return SNMP_INTEGER(monotime(NULL) - peer->update_time);
+
+	case CBGP_PEER3_IN_UPDATES:
+		ui = atomic_load_explicit(&peer->update_in, memory_order_relaxed);
+		return SNMP_INTEGER(ui);
+	case CBGP_PEER3_OUT_UPDATES:
+		uo = atomic_load_explicit(&peer->update_out, memory_order_relaxed);
+		return SNMP_INTEGER(uo);
+
+	case CBGP_PEER3_IN_TOTAL_MESSAGES:
+		return SNMP_INTEGER(PEER_TOTAL_RX(peer));
+
+	case CBGP_PEER3_OUT_TOTAL_MESSAGES:
+		return SNMP_INTEGER(PEER_TOTAL_TX(peer));
+
+	case CBGP_PEER3_FSM_ESTABLISHED_TRANSITIONS:
+		return SNMP_INTEGER(peer->established);
+
+	case CBGP_PEER3_FSM_ESTABLISHED_TIME:
+		if (!peer->uptime)
+			return SNMP_INTEGER(0);
+		else
+			return SNMP_INTEGER(monotime(NULL) - peer->uptime);
+
+	case CBGP_PEER3_PREV_STATE:
+		return SNMP_INTEGER(peer->connection ? peer->connection->ostatus : Idle);
+
+	case CBGP_PEER3_NEGOTIATED_VERSION:
+		return SNMP_INTEGER(BGP_VERSION_4);
+
+	case CBGP_PEER3_MIN_AS_ORIGINATION_INTERVAL:
+		return SNMP_INTEGER(peer->v_routeadv);
+	default:
+		break;
+	}
+
+	return NULL;
+}
+
+static struct peer_af *cbgp4PeerAfTable_lookup(struct variable *v, oid name[], size_t *length,
+					       int exact)
+{
+	struct peer *peer = NULL;
+	size_t namelen = v ? v->namelen : CBGP_PEER_TABLE_INDEX_OFFSET;
+	oid *index = name + namelen;
+	size_t offsetlen = *length - namelen;
+	struct peer_af *paf = NULL;
+	afi_t afi = 0;
+	safi_t safi = 0;
+	iana_afi_t iana_afi;
+	iana_safi_t iana_safi;
+	struct ipaddr addr = {};
+
+	if (!offsetlen) {
+		bgp_snmp_index_init(index, CBGP_PEER_TABLE_MAX_INDEX_LEN + 2);
+	} else if (offsetlen == IN_ADDR_SIZE + 2) {
+		addr.ipa_type = AF_INET;
+		oid2in_addr(index, IN_ADDR_SIZE, &addr.ip._v4_addr);
+		iana_afi = index[IN_ADDR_SIZE];
+		iana_safi = index[IN_ADDR_SIZE + 1];
+		/* Convert IANA AFI/SAFI to internal values */
+		if (bgp_map_afi_safi_iana2int(iana_afi, iana_safi, &afi, &safi)) {
+			/* Unsupported AFI/SAFI */
+			return NULL;
+		}
+	} else {
+		/* We cannot support partial indexes */
+		return NULL;
+	}
+
+	if (exact) {
+		peer = bgp_snmp_lookup_peer(VRF_DEFAULT, &addr);
+
+		if (!peer)
+			return NULL;
+		paf = peer_af_find(peer, afi, safi);
+	} else {
+		if (!offsetlen) {
+			/*
+			 * First Peer lookup
+			 */
+			peer = bgp_snmp_get_first_peer(false, AF_INET);
+			paf = bgp_snmp_peer_af_next(peer, afi, safi);
+
+		} else {
+			/*
+			 * First try to lookup the current Peer to traverse all
+			 * the peer_af array.
+			 */
+			peer = bgp_snmp_lookup_peer(VRF_DEFAULT, &addr);
+
+			if (!peer) {
+				// This should not happen.
+				assert(0);
+			}
+
+			paf = bgp_snmp_peer_af_next(peer, afi, safi);
+
+			if (paf == NULL) {
+				/*
+				 * We have traversed the entire peer_af array
+				 * for this peer. Go to the next peer
+				 */
+				peer = bgp_snmp_get_next_peer(false, VRF_DEFAULT, AF_INET, &addr);
+				if (!peer) {
+					/*
+					 * We have traversed all the peers
+					 */
+					return NULL;
+				}
+
+				afi = 0;
+				safi = 0;
+				paf = bgp_snmp_peer_af_next(peer, afi, safi);
+			}
+		}
+		if (paf && peer->connection) {
+			iana_afi_t pkt_afi;
+			iana_safi_t pkt_safi;
+
+			/* Convert internal AFI/SAFI to IANA values for OID */
+			bgp_map_afi_safi_int2iana(paf->afi, paf->safi, &pkt_afi, &pkt_safi);
+
+			oid_copy_in_addr(index, &peer->connection->su.sin.sin_addr);
+			index[IN_ADDR_SIZE] = pkt_afi;
+			index[IN_ADDR_SIZE + 1] = pkt_safi;
+			*length = namelen + IN_ADDR_SIZE + 2;
+		}
+	}
+	return paf;
+}
+
+static struct peer_af *cbgp4Peer2AfTable_lookup(struct variable *v, oid name[], size_t *length,
+						int exact)
+{
+	struct peer *peer = NULL;
+	size_t namelen = v ? v->namelen : CBGP_PEER_TABLE_INDEX_OFFSET;
+	oid *index = name + namelen;
+	size_t offsetlen = *length - namelen;
+	struct peer_af *paf = NULL;
+	afi_t afi = 0;
+	safi_t safi = 0;
+	iana_afi_t iana_afi;
+	iana_safi_t iana_safi;
+	struct ipaddr addr = {};
+
+	if (!offsetlen) {
+		bgp_snmp_index_init(index, CBGP_PEER2_TABLE_MAX_INDEX_LEN + 2);
+	} else if ((offsetlen == IN_ADDR_SIZE + 3) || (offsetlen == IN6_ADDR_SIZE + 3)) {
+		addr.ipa_type = index[0] == 1 ? AF_INET : AF_INET6;
+		if (addr.ipa_type == AF_INET) {
+			oid2in_addr(&index[1], IN_ADDR_SIZE, &addr.ip._v4_addr);
+			iana_afi = index[IN_ADDR_SIZE + 1];
+			iana_safi = index[IN_ADDR_SIZE + 2];
+		} else if (addr.ipa_type == AF_INET6) {
+			oid2in6_addr(&index[1], &addr.ip._v6_addr);
+			iana_afi = index[IN6_ADDR_SIZE + 1];
+			iana_safi = index[IN6_ADDR_SIZE + 2];
+		}
+		/* Convert IANA AFI/SAFI to internal values */
+		if (bgp_map_afi_safi_iana2int(iana_afi, iana_safi, &afi, &safi)) {
+			/* Unsupported AFI/SAFI */
+			return NULL;
+		}
+	} else {
+		/* We cannot support partial indexes */
+		return NULL;
+	}
+
+	if (exact) {
+		peer = bgp_snmp_lookup_peer(VRF_DEFAULT, &addr);
+
+		if (!peer)
+			return NULL;
+		paf = peer_af_find(peer, afi, safi);
+	} else {
+		if (!offsetlen) {
+			/*
+			 * First Peer lookup
+			 */
+			peer = bgp_snmp_get_first_peer(false, AF_UNSPEC);
+			paf = bgp_snmp_peer_af_next(peer, afi, safi);
+
+		} else {
+			/*
+			 * First try to lookup the current Peer to traverse all
+			 * the peer_af array.
+			 */
+			peer = bgp_snmp_lookup_peer(VRF_DEFAULT, &addr);
+
+			if (!peer) {
+				// This should not happen.
+				assert(0);
+			}
+
+			paf = bgp_snmp_peer_af_next(peer, afi, safi);
+
+			if (paf == NULL) {
+				/*
+				 * We have traversed the entire peer_af array
+				 * for this peer. Go to the next peer
+				 */
+				sa_family_t next_family = AF_UNSPEC;
+
+				if (addr.ipa_type == IPADDR_V4)
+					next_family = AF_INET;
+				else if (addr.ipa_type == IPADDR_V6)
+					next_family = AF_INET6;
+
+				peer = bgp_snmp_get_next_peer(false, VRF_DEFAULT, next_family,
+							      &addr);
+				if (!peer && next_family != AF_UNSPEC)
+					peer = bgp_snmp_get_next_peer(false, VRF_DEFAULT,
+								      AF_UNSPEC, &addr);
+				if (!peer) {
+					/*
+					 * We have traversed all the peers
+					 */
+					return NULL;
+				}
+
+				afi = 0;
+				safi = 0;
+				paf = bgp_snmp_peer_af_next(peer, afi, safi);
+			}
+		}
+		if (paf && peer->connection) {
+			iana_afi_t pkt_afi;
+			iana_safi_t pkt_safi;
+
+			/* Convert internal AFI/SAFI to IANA values for OID */
+			bgp_map_afi_safi_int2iana(paf->afi, paf->safi, &pkt_afi, &pkt_safi);
+
+			switch (sockunion_family(&peer->connection->su)) {
+			case AF_INET:
+				index[0] = INETADDRESSTYPEIPV4;
+				oid_copy_in_addr(&index[1],
+						 &peer->connection->su.sin.sin_addr);
+				index[1 + IN_ADDR_SIZE] = pkt_afi;
+				index[2 + IN_ADDR_SIZE] = pkt_safi;
+				*length = namelen + IN_ADDR_SIZE + 3;
+				break;
+			case AF_INET6:
+				index[0] = INETADDRESSTYPEIPV6;
+				oid_copy_in6_addr(&index[1],
+						  &peer->connection->su.sin6.sin6_addr);
+				index[1 + IN6_ADDR_SIZE] = pkt_afi;
+				index[2 + IN6_ADDR_SIZE] = pkt_safi;
+				*length = IN6_ADDR_SIZE + namelen + 3;
+				break;
+			default:
+				break;
+			}
+		}
+	}
+	return paf;
+}
+
+static uint8_t *cbgp4PeerAddrFamilyTable(struct variable *v, oid name[], size_t *length, int exact,
+					 size_t *var_len, WriteMethod **write_method)
+{
+	struct peer_af *paf = NULL;
+	iana_afi_t iana_afi;
+	iana_safi_t iana_safi;
+
+	if (smux_header_table(v, name, length, exact, var_len, write_method) == MATCH_FAILED)
+		return NULL;
+
+	paf = cbgp4PeerAfTable_lookup(v, name, length, exact);
+	if (!paf)
+		return NULL;
+
+	/* Convert internal AFI/SAFI to IANA values for SNMP */
+	bgp_map_afi_safi_int2iana(paf->afi, paf->safi, &iana_afi, &iana_safi);
+
+	switch (v->magic) {
+	case CBGP_PEER_ADDR_FAMILY_AFI:
+		return SNMP_INTEGER(iana_afi);
+
+	case CBGP_PEER_ADDR_FAMILY_SAFI:
+		return SNMP_INTEGER(iana_safi);
+
+	case CBGP_PEER_ADDR_FAMILY_NAME:
+		return SNMP_STRING(get_afi_safi_vty_str(paf->afi, paf->safi));
+
+	default:
+		break;
+	}
+
+	return NULL;
+}
+
+static uint8_t *cbgp4PeerAddrFamilyPrefixTable(struct variable *v, oid name[], size_t *length,
+					       int exact, size_t *var_len,
+					       WriteMethod **write_method)
+{
+	struct peer *peer;
+	struct peer_af *paf = NULL;
+
+	/*
+	 * Validate the SMUX header
+	 */
+	if (smux_header_table(v, name, length, exact, var_len, write_method) == MATCH_FAILED)
+		return NULL;
+
+	/*
+	 * Extract AFI and SAFI from the OID
+	 */
+	paf = cbgp4PeerAfTable_lookup(v, name, length, exact);
+	if (!paf)
+		return NULL;
+
+	peer = paf->peer;
+
+	/*
+	 * Handle the requested variable
+	 */
+	switch (v->magic) {
+	case CBGP_PEER_ACCEPTED_PREFIXES:
+		return SNMP_INTEGER(peer->pcount[paf->afi][paf->safi]);
+
+	case CBGP_PEER_DENIED_PREFIXES:
+		return SNMP_INTEGER(peer->pfiltered[paf->afi][paf->safi]);
+
+	case CBGP_PEER_PREFIX_ADMIN_LIMIT:
+		return SNMP_INTEGER(peer->pmax[paf->afi][paf->safi]);
+
+	case CBGP_PEER_PREFIX_THRESHOLD:
+		return SNMP_INTEGER(peer->pmax_threshold[paf->afi][paf->safi]);
+
+	case CBGP_PEER_ADVERTISED_PREFIXES:
+		if (PAF_SUBGRP(paf))
+			return (SNMP_INTEGER(PAF_SUBGRP(paf)->scount));
+		else
+			return SNMP_INTEGER(0);
+
+	case CBGP_PEER_PREFIX_CLEAR_THRESHOLD:
+		return SNMP_INTEGER(peer->pmax_threshold[paf->afi][paf->safi]);
+
+	case CBGP_PEER_SUPPRESSED_PREFIXES:
+		return SNMP_INTEGER(peer->psuppressed_cnt[paf->afi][paf->safi]);
+
+	case CBGP_PEER_WITHDRAWN_PREFIXES:
+		return SNMP_INTEGER(peer->pwithdraw_cnt[paf->afi][paf->safi]);
+
+	default:
+		break;
+	}
+
+	return NULL;
+}
+
+
+static uint8_t *cbgp4Peer2AddrFamilyTable(struct variable *v, oid name[], size_t *length,
+					  int exact, size_t *var_len, WriteMethod **write_method)
+{
+	struct peer_af *paf = NULL;
+	iana_afi_t iana_afi;
+	iana_safi_t iana_safi;
+
+	if (smux_header_table(v, name, length, exact, var_len, write_method) == MATCH_FAILED)
+		return NULL;
+
+	paf = cbgp4Peer2AfTable_lookup(v, name, length, exact);
+	if (!paf)
+		return NULL;
+
+	/* Convert internal AFI/SAFI to IANA values for SNMP */
+	bgp_map_afi_safi_int2iana(paf->afi, paf->safi, &iana_afi, &iana_safi);
+
+	switch (v->magic) {
+	case CBGP_PEER2_ADDR_FAMILY_AFI:
+		return SNMP_INTEGER(iana_afi);
+
+	case CBGP_PEER2_ADDR_FAMILY_SAFI:
+		return SNMP_INTEGER(iana_safi);
+
+	case CBGP_PEER2_ADDR_FAMILY_NAME:
+		return SNMP_STRING(get_afi_safi_vty_str(paf->afi, paf->safi));
+
+	default:
+		break;
+	}
+
+	return NULL;
+}
+
+static uint8_t *cbgp4Peer2AddrFamilyPrefixTable(struct variable *v, oid name[], size_t *length,
+						int exact, size_t *var_len,
+						WriteMethod **write_method)
+{
+	struct peer *peer;
+	struct peer_af *paf = NULL;
+
+	/*
+	 * Validate the SMUX header
+	 */
+	if (smux_header_table(v, name, length, exact, var_len, write_method) == MATCH_FAILED)
+		return NULL;
+
+	/*
+	 * Extract AFI and SAFI from the OID
+	 */
+	paf = cbgp4Peer2AfTable_lookup(v, name, length, exact);
+	if (!paf)
+		return NULL;
+
+	peer = paf->peer;
+
+	/*
+	 * Handle the requested variable
+	 */
+	switch (v->magic) {
+	case CBGP_PEER2_ACCEPTED_PREFIXES:
+		return SNMP_INTEGER(peer->pcount[paf->afi][paf->safi]);
+
+	case CBGP_PEER2_DENIED_PREFIXES:
+		return SNMP_INTEGER(peer->pfiltered[paf->afi][paf->safi]);
+
+	case CBGP_PEER2_PREFIX_ADMIN_LIMIT:
+		return SNMP_INTEGER(peer->pmax[paf->afi][paf->safi]);
+
+	case CBGP_PEER2_PREFIX_THRESHOLD:
+		return SNMP_INTEGER(peer->pmax_threshold[paf->afi][paf->safi]);
+
+	case CBGP_PEER2_ADVERTISED_PREFIXES:
+		if (PAF_SUBGRP(paf))
+			return (SNMP_INTEGER(PAF_SUBGRP(paf)->scount));
+		else
+			return SNMP_INTEGER(0);
+
+	/*
+	 * Not supported Yet.
+	 */
+	case CBGP_PEER2_PREFIX_CLEAR_THRESHOLD:
+		return SNMP_INTEGER(peer->pmax_threshold[paf->afi][paf->safi]);
+
+	case CBGP_PEER2_SUPPRESSED_PREFIXES:
+		return SNMP_INTEGER(peer->psuppressed_cnt[paf->afi][paf->safi]);
+
+	case CBGP_PEER2_WITHDRAWN_PREFIXES:
+		return SNMP_INTEGER(peer->pwithdraw_cnt[paf->afi][paf->safi]);
+
+	default:
+		break;
+	}
+
+	return NULL;
+}
+/*
+ * AFI/SAFI pairs for cbgpRouteTable iteration
+ * IPv4 Unicast, IPv6 Unicast, and L2VPN EVPN are supported
+ */
+static const struct {
+	afi_t afi;
+	safi_t safi;
+} afi_safi_list[] = {
+	{ AFI_IP, SAFI_UNICAST },    /* IPv4 Unicast */
+	{ AFI_IP6, SAFI_UNICAST },   /* IPv6 Unicast */
+	{ AFI_L2VPN, SAFI_EVPN },    /* L2VPN EVPN */
+};
+#define AFI_SAFI_LIST_SIZE (sizeof(afi_safi_list) / sizeof(afi_safi_list[0]))
+
+/* Maximum EVPN prefix size in bytes (route_type + eth_tag + mac + ip + esi + etc) */
+#define CBGP_MAX_EVPN_PREFIX_LEN 64
+
+/* Static buffer for cbgpRouteTable OCTET STRING columns */
+static uint8_t cbgp_route_octet_buf[CBGP_MAX_EVPN_PREFIX_LEN];
+
+/*
+ * Helper function to encode EVPN prefix into bytes for SNMP
+ * Returns the number of bytes encoded, or 0 on error
+ */
+static size_t encode_evpn_prefix(const struct prefix *p, uint8_t *buf, size_t buflen)
+{
+	const struct prefix_evpn *evp;
+	size_t offset = 0;
+
+	if (!p || p->family != AF_EVPN || !buf || buflen < 1)
+		return 0;
+
+	evp = (const struct prefix_evpn *)p;
+
+	/* Encode route type first */
+	buf[offset++] = evp->prefix.route_type;
+
+	switch (evp->prefix.route_type) {
+	case BGP_EVPN_AD_ROUTE: /* Type 1 - Ethernet Auto-Discovery */
+		/* esi (10) + eth_tag (4) + ip_len (1) + ip (0/4/16) + frag_id (2) */
+		if (offset + 17 > buflen)
+			return 0;
+		/* ESI (10 bytes) */
+		memcpy(&buf[offset], evp->prefix.ead_addr.esi.val, ESI_BYTES);
+		offset += ESI_BYTES;
+		/* Ethernet tag */
+		buf[offset++] = (evp->prefix.ead_addr.eth_tag >> 24) & 0xff;
+		buf[offset++] = (evp->prefix.ead_addr.eth_tag >> 16) & 0xff;
+		buf[offset++] = (evp->prefix.ead_addr.eth_tag >> 8) & 0xff;
+		buf[offset++] = evp->prefix.ead_addr.eth_tag & 0xff;
+		/* IP address (optional) */
+		if (IS_IPADDR_V4(&evp->prefix.ead_addr.ip)) {
+			buf[offset++] = 4;
+			if (offset + 4 > buflen)
+				return 0;
+			memcpy(&buf[offset], &evp->prefix.ead_addr.ip.ipaddr_v4, 4);
+			offset += 4;
+		} else if (IS_IPADDR_V6(&evp->prefix.ead_addr.ip)) {
+			buf[offset++] = 16;
+			if (offset + 16 > buflen)
+				return 0;
+			memcpy(&buf[offset], &evp->prefix.ead_addr.ip.ipaddr_v6, 16);
+			offset += 16;
+		} else {
+			buf[offset++] = 0; /* No IP */
+		}
+		/* Fragment ID (2 bytes) */
+		buf[offset++] = (evp->prefix.ead_addr.frag_id >> 8) & 0xff;
+		buf[offset++] = evp->prefix.ead_addr.frag_id & 0xff;
+		break;
+
+	case BGP_EVPN_MAC_IP_ROUTE: /* Type 2 */
+		/* eth_tag (4) + mac (6) + ip_len (1) + ip (0/4/16) */
+		if (offset + 11 > buflen)
+			return 0;
+		/* Ethernet tag */
+		buf[offset++] = (evp->prefix.macip_addr.eth_tag >> 24) & 0xff;
+		buf[offset++] = (evp->prefix.macip_addr.eth_tag >> 16) & 0xff;
+		buf[offset++] = (evp->prefix.macip_addr.eth_tag >> 8) & 0xff;
+		buf[offset++] = evp->prefix.macip_addr.eth_tag & 0xff;
+		/* MAC address */
+		memcpy(&buf[offset], evp->prefix.macip_addr.mac.octet, 6);
+		offset += 6;
+		/* IP address */
+		if (IS_IPADDR_V4(&evp->prefix.macip_addr.ip)) {
+			buf[offset++] = 4;
+			if (offset + 4 > buflen)
+				return 0;
+			memcpy(&buf[offset], &evp->prefix.macip_addr.ip.ipaddr_v4, 4);
+			offset += 4;
+		} else if (IS_IPADDR_V6(&evp->prefix.macip_addr.ip)) {
+			buf[offset++] = 16;
+			if (offset + 16 > buflen)
+				return 0;
+			memcpy(&buf[offset], &evp->prefix.macip_addr.ip.ipaddr_v6, 16);
+			offset += 16;
+		} else {
+			buf[offset++] = 0; /* No IP */
+		}
+		break;
+
+	case BGP_EVPN_IMET_ROUTE: /* Type 3 */
+		/* eth_tag (4) + ip_len (1) + ip (4/16) */
+		if (offset + 5 > buflen)
+			return 0;
+		/* Ethernet tag */
+		buf[offset++] = (evp->prefix.imet_addr.eth_tag >> 24) & 0xff;
+		buf[offset++] = (evp->prefix.imet_addr.eth_tag >> 16) & 0xff;
+		buf[offset++] = (evp->prefix.imet_addr.eth_tag >> 8) & 0xff;
+		buf[offset++] = evp->prefix.imet_addr.eth_tag & 0xff;
+		/* IP address */
+		if (IS_IPADDR_V4(&evp->prefix.imet_addr.ip)) {
+			buf[offset++] = 4;
+			if (offset + 4 > buflen)
+				return 0;
+			memcpy(&buf[offset], &evp->prefix.imet_addr.ip.ipaddr_v4, 4);
+			offset += 4;
+		} else if (IS_IPADDR_V6(&evp->prefix.imet_addr.ip)) {
+			buf[offset++] = 16;
+			if (offset + 16 > buflen)
+				return 0;
+			memcpy(&buf[offset], &evp->prefix.imet_addr.ip.ipaddr_v6, 16);
+			offset += 16;
+		} else {
+			buf[offset++] = 0;
+		}
+		break;
+
+	case BGP_EVPN_IP_PREFIX_ROUTE: /* Type 5 */
+		/* eth_tag (4) + prefix_len (1) + ip (4/16) */
+		if (offset + 5 > buflen)
+			return 0;
+		/* Ethernet tag */
+		buf[offset++] = (evp->prefix.prefix_addr.eth_tag >> 24) & 0xff;
+		buf[offset++] = (evp->prefix.prefix_addr.eth_tag >> 16) & 0xff;
+		buf[offset++] = (evp->prefix.prefix_addr.eth_tag >> 8) & 0xff;
+		buf[offset++] = evp->prefix.prefix_addr.eth_tag & 0xff;
+		/* Prefix length */
+		buf[offset++] = evp->prefix.prefix_addr.ip_prefix_length;
+		/* IP prefix */
+		if (IS_IPADDR_V4(&evp->prefix.prefix_addr.ip)) {
+			if (offset + 4 > buflen)
+				return 0;
+			memcpy(&buf[offset], &evp->prefix.prefix_addr.ip.ipaddr_v4, 4);
+			offset += 4;
+		} else if (IS_IPADDR_V6(&evp->prefix.prefix_addr.ip)) {
+			if (offset + 16 > buflen)
+				return 0;
+			memcpy(&buf[offset], &evp->prefix.prefix_addr.ip.ipaddr_v6, 16);
+			offset += 16;
+		}
+		break;
+
+	case BGP_EVPN_ES_ROUTE: /* Type 4 - Ethernet Segment */
+		/* esi (10) + ip_len (1) + ip (4/16) */
+		if (offset + 11 > buflen)
+			return 0;
+		/* ESI (10 bytes) */
+		memcpy(&buf[offset], evp->prefix.es_addr.esi.val, ESI_BYTES);
+		offset += ESI_BYTES;
+		/* IP address */
+		if (IS_IPADDR_V4(&evp->prefix.es_addr.ip)) {
+			buf[offset++] = 4;
+			if (offset + 4 > buflen)
+				return 0;
+			memcpy(&buf[offset], &evp->prefix.es_addr.ip.ipaddr_v4, 4);
+			offset += 4;
+		} else if (IS_IPADDR_V6(&evp->prefix.es_addr.ip)) {
+			buf[offset++] = 16;
+			if (offset + 16 > buflen)
+				return 0;
+			memcpy(&buf[offset], &evp->prefix.es_addr.ip.ipaddr_v6, 16);
+			offset += 16;
+		} else {
+			buf[offset++] = 0;
+		}
+		break;
+
+	default:
+		/* Unknown route type - just encode route type byte */
+		break;
+	}
+
+	return offset;
+}
+
+
+/*
+ * cbgpRouteTable lookup function
+ * 
+ * CISCO-BGP4-MIB Index Order (strict compliance):
+ * INDEX { cbgpRouteAfi, cbgpRouteSafi, cbgpRoutePeerType, cbgpRoutePeer,
+ *         cbgpRouteAddrPrefix, cbgpRouteAddrPrefixLen }
+ *
+ * OID encoding (per SNMP rules for OCTET STRING indexes):
+ * - InetAddress (cbgpRoutePeer): length + bytes  (e.g., IPv4: 4.a.b.c.d)
+ * - CbGpNetworkAddress (cbgpRouteAddrPrefix): length + bytes (e.g., 4.172.16.1.0)
+ *
+ * Full OID structure:
+ * <base>.<column>.<afi>.<safi>.<peerType>.<peerLen>.<peer[0]>...<peer[n]>.<prefixLen>.<prefix[0]>...<prefix[n]>.<prefixBitLen>
+ *
+ * Example for IPv4 peer 10.10.0.2, prefix 172.16.1.0/24:
+ * ...7.1.1.1.4.10.10.0.2.4.172.16.1.0.24
+ *      ^afi ^safi ^peerType ^peerLen(4) ^peerAddr ^prefixLen(4 bytes) ^prefix ^prefixBitLen(24 bits)
+ *
+ * Supports: IPv4 Unicast (AFI=1, SAFI=1) and IPv6 Unicast (AFI=2, SAFI=1)
+ *
+ * Algorithm for GETNEXT:
+ * 1. Parse OID to extract the full index tuple
+ * 2. Iterate through all AFI/SAFI pairs in order
+ * 3. Find the first (afi, safi, peer, route) tuple > search key
+ */
+static struct bgp_path_info *
+cbgp4RouteTable_lookup(struct variable *v, oid name[], size_t *length,
+		       struct bgp *bgp, struct prefix *addr, int exact)
+{
+	oid *offset;
+	int offsetlen;
+	size_t offsetlen_initial;
+	struct bgp_path_info *path;
+	struct bgp_dest *dest;
+	union sockunion su;
+	size_t namelen = v ? v->namelen : CBGP_ROUTE_ENTRY_OFFSET;
+	afi_t afi = AFI_IP;
+	safi_t safi = SAFI_UNICAST;
+	
+	/* Search key components */
+	int search_peer_type = 0;
+	size_t search_peer_len = 0;
+	uint8_t search_peer_bytes[16] = {};
+	size_t search_prefix_len_bytes = 0;
+	uint8_t search_prefix_bytes[CBGP_MAX_EVPN_PREFIX_LEN] = {};
+	uint8_t search_prefix_bitlen = 0;
+
+	sockunion_init(&su);
+
+	offset = name + namelen;
+	offsetlen = *length - namelen;
+	offsetlen_initial = (size_t)(*length - namelen);
+
+	/* Parse IANA AFI from OID index and convert to internal */
+	iana_afi_t iana_afi = IANA_AFI_IPV4;
+	iana_safi_t iana_safi = IANA_SAFI_UNICAST;
+
+	if (offsetlen > 0) {
+		iana_afi = *offset;
+		offset++;
+		offsetlen--;
+	}
+
+	/* Parse IANA SAFI from OID index */
+	if (offsetlen > 0) {
+		iana_safi = *offset;
+		offset++;
+		offsetlen--;
+	}
+
+	/* Convert IANA to internal AFI/SAFI */
+	if (bgp_map_afi_safi_iana2int(iana_afi, iana_safi, &afi, &safi)) {
+		/* Invalid AFI/SAFI - use defaults */
+		afi = AFI_IP;
+		safi = SAFI_UNICAST;
+	}
+
+	/* Parse PeerType (InetAddressType: 1=IPv4, 2=IPv6) */
+	if (offsetlen > 0) {
+		search_peer_type = *offset;
+		offset++;
+		offsetlen--;
+	}
+
+	/* Parse PeerAddr (InetAddress: length + bytes) */
+	if (offsetlen > 0) {
+		search_peer_len = *offset;
+		if (search_peer_len > 16)
+			search_peer_len = 16;
+		offset++;
+		offsetlen--;
+
+		for (size_t i = 0; i < search_peer_len && offsetlen > 0; i++) {
+			search_peer_bytes[i] = *offset;
+			offset++;
+			offsetlen--;
+		}
+	}
+
+	/* Parse Prefix (CbGpNetworkAddress: length + bytes) */
+	if (offsetlen > 0) {
+		search_prefix_len_bytes = *offset;
+		if (search_prefix_len_bytes > CBGP_MAX_EVPN_PREFIX_LEN)
+			search_prefix_len_bytes = CBGP_MAX_EVPN_PREFIX_LEN;
+		offset++;
+		offsetlen--;
+
+		for (size_t i = 0; i < search_prefix_len_bytes && offsetlen > 0; i++) {
+			search_prefix_bytes[i] = *offset;
+			offset++;
+			offsetlen--;
+		}
+	}
+
+	/* Parse PrefixBitLen (Unsigned32 - the CIDR prefix length in bits) */
+	if (offsetlen > 0) {
+		search_prefix_bitlen = *offset;
+	}
+
+	if (exact) {
+		/*
+		 * Minimum index for exact match: afi(1) + safi(1) + peerType(1) + peerLen(1) + peerBytes
+		 * + prefixLenBytes(1) + prefixBytes + prefixBitLen(1)
+		 */
+		if (offsetlen_initial < 6 + search_peer_len + search_prefix_len_bytes)
+			return NULL;
+
+		/* Build prefix from parsed bytes based on AFI */
+		if (afi == AFI_IP) {
+			addr->family = AF_INET;
+			memcpy(&addr->u.prefix4, search_prefix_bytes, 
+			       search_prefix_len_bytes > 4 ? 4 : search_prefix_len_bytes);
+		} else if (afi == AFI_IP6) {
+			addr->family = AF_INET6;
+			memcpy(&addr->u.prefix6, search_prefix_bytes,
+			       search_prefix_len_bytes > 16 ? 16 : search_prefix_len_bytes);
+		} else if (afi == AFI_L2VPN) {
+			/*
+			 * For EVPN exact match, we need to iterate through the table
+			 * and find a matching prefix since decoding EVPN from OID bytes
+			 * back to struct prefix_evpn is complex. For now, return NULL
+			 * for exact match on EVPN - GETNEXT still works.
+			 */
+			return NULL;
+		} else {
+			return NULL;
+		}
+		addr->prefixlen = search_prefix_bitlen;
+
+		/* Build peer sockunion from parsed bytes */
+		if (search_peer_type == 1) {
+			su.sa.sa_family = AF_INET;
+			memcpy(&su.sin.sin_addr, search_peer_bytes,
+			       search_peer_len > 4 ? 4 : search_peer_len);
+		} else {
+			su.sa.sa_family = AF_INET6;
+			memcpy(&su.sin6.sin6_addr, search_peer_bytes,
+			       search_peer_len > 16 ? 16 : search_peer_len);
+		}
+
+		/* Lookup node in RIB */
+		dest = bgp_node_lookup(bgp->rib[afi][safi], addr);
+		if (dest) {
+			for (path = bgp_dest_get_bgp_path_info(dest); path;
+			     path = path->next) {
+				if (sockunion_same(&path->peer->connection->su, &su)) {
+					bgp_dest_unlock_node(dest);
+					return path;
+				}
+				/* Check for self-originated routes using router-id */
+				if (path->peer == path->peer->bgp->peer_self &&
+				    search_peer_type == 1 && search_peer_len == 4) {
+					if (memcmp(&path->peer->bgp->router_id,
+						   search_peer_bytes, 4) == 0) {
+						bgp_dest_unlock_node(dest);
+						return path;
+					}
+				}
+			}
+			bgp_dest_unlock_node(dest);
+		}
+		return NULL;
+	}
+
+	/*
+	 * GETNEXT handling - CISCO index order with correct InetAddress encoding
+	 * 
+	 * Full tuple order for comparison:
+	 * 1. AFI (1=IPv4 < 2=IPv6)
+	 * 2. SAFI (1=Unicast)
+	 * 3. PeerType (1=IPv4 < 2=IPv6)
+	 * 4. PeerLen (length of peer address)
+	 * 5. PeerBytes (byte-by-byte)
+	 * 6. PrefixLenBytes (length of prefix in bytes)
+	 * 7. PrefixBytes (byte-by-byte)
+	 * 8. PrefixBitLen (CIDR prefix length)
+	 *
+	 * We iterate through ALL AFI/SAFI pairs to find the minimum tuple > search key
+	 */
+
+	struct bgp_path_info *min_path = NULL;
+	struct prefix min_prefix = {};
+	
+	/* Minimum tuple components for comparison */
+	afi_t min_afi = 0;
+	safi_t min_safi = 0;
+	int min_peer_type = 0;
+	size_t min_peer_len = 0;
+	uint8_t min_peer_bytes[16] = {};
+	size_t min_prefix_len_bytes = 0;
+	uint8_t min_prefix_bytes[CBGP_MAX_EVPN_PREFIX_LEN] = {};
+	uint8_t min_prefix_bitlen = 0;
+
+	/* Iterate through ALL AFI/SAFI combinations */
+	for (size_t af_idx = 0; af_idx < AFI_SAFI_LIST_SIZE; af_idx++) {
+		afi_t cur_afi = afi_safi_list[af_idx].afi;
+		safi_t cur_safi = afi_safi_list[af_idx].safi;
+
+		/* Skip if RIB table doesn't exist */
+		if (!bgp->rib[cur_afi][cur_safi])
+			continue;
+
+		/*
+		 * EVPN uses a two-level RIB structure:
+		 * Level 1: RD (Route Distinguisher) entries
+		 * Level 2: Actual EVPN prefixes under each RD
+		 *
+		 * For IPv4/IPv6 unicast, it's a single-level structure.
+		 */
+		if (cur_afi == AFI_L2VPN && cur_safi == SAFI_EVPN) {
+			/* Two-level iteration for EVPN */
+			struct bgp_dest *rd_dest;
+			struct bgp_table *evpn_table;
+
+			for (rd_dest = bgp_table_top(bgp->rib[cur_afi][cur_safi]); rd_dest;
+			     rd_dest = bgp_route_next(rd_dest)) {
+				/* Get the sub-table for this RD */
+				evpn_table = bgp_dest_get_bgp_table_info(rd_dest);
+				if (!evpn_table)
+					continue;
+
+				/* Iterate actual EVPN routes in sub-table */
+				for (dest = bgp_table_top(evpn_table); dest;
+				     dest = bgp_route_next(dest)) {
+					const struct prefix *rn_p = bgp_dest_get_prefix(dest);
+
+					/* Skip if prefix is NULL or not EVPN */
+					if (!rn_p || rn_p->family != AF_EVPN)
+						continue;
+
+					for (path = bgp_dest_get_bgp_path_info(dest); path;
+					     path = path->next) {
+						/* Process EVPN path - call helper macro/goto */
+						/* Skip paths without peer or attr */
+						if (!path->peer || !path->attr)
+							continue;
+
+						sa_family_t peer_family = sockunion_family(&path->peer->connection->su);
+						int is_self_peer = 0;
+
+						/* Handle locally originated routes (peer_self) */
+						if (peer_family != AF_INET && peer_family != AF_INET6) {
+							if (path->peer == path->peer->bgp->peer_self) {
+								is_self_peer = 1;
+								peer_family = AF_INET;
+							} else {
+								continue;
+							}
+						}
+
+						/* Build current tuple */
+						int cur_peer_type = (peer_family == AF_INET) ? 1 : 2;
+						size_t cur_peer_len = (peer_family == AF_INET) ? 4 : 16;
+						uint8_t cur_peer_bytes[16] = {};
+						uint8_t cur_prefix_bytes[CBGP_MAX_EVPN_PREFIX_LEN] = {};
+						size_t cur_prefix_len_bytes = 0;
+						uint8_t cur_prefix_bitlen = rn_p->prefixlen;
+
+						if (is_self_peer) {
+							memcpy(cur_peer_bytes, &path->peer->bgp->router_id, 4);
+						} else if (peer_family == AF_INET) {
+							memcpy(cur_peer_bytes, &path->peer->connection->su.sin.sin_addr, 4);
+						} else {
+							memcpy(cur_peer_bytes, &path->peer->connection->su.sin6.sin6_addr, 16);
+						}
+
+						/* Encode EVPN prefix */
+						cur_prefix_len_bytes = encode_evpn_prefix(rn_p, cur_prefix_bytes,
+											  sizeof(cur_prefix_bytes));
+						if (cur_prefix_len_bytes == 0)
+							continue;
+
+						/* Convert to IANA for comparison */
+						iana_afi_t cur_iana_afi;
+						iana_safi_t cur_iana_safi;
+						bgp_map_afi_safi_int2iana(cur_afi, cur_safi, &cur_iana_afi, &cur_iana_safi);
+
+						/* Compare current tuple with search key */
+						int cmp = 0;
+						if (cmp == 0)
+							cmp = (int)cur_iana_afi - (int)iana_afi;
+						if (cmp == 0)
+							cmp = (int)cur_iana_safi - (int)iana_safi;
+						if (cmp == 0)
+							cmp = cur_peer_type - search_peer_type;
+						if (cmp == 0)
+							cmp = (int)cur_peer_len - (int)search_peer_len;
+						if (cmp == 0)
+							cmp = memcmp(cur_peer_bytes, search_peer_bytes, cur_peer_len);
+						if (cmp == 0)
+							cmp = (int)cur_prefix_len_bytes - (int)search_prefix_len_bytes;
+						if (cmp == 0)
+							cmp = memcmp(cur_prefix_bytes, search_prefix_bytes, cur_prefix_len_bytes);
+						if (cmp == 0)
+							cmp = cur_prefix_bitlen - search_prefix_bitlen;
+
+						if (cmp <= 0)
+							continue;
+
+						/* Current > search. Check if smaller than min */
+						if (!min_path) {
+							min_path = path;
+							min_prefix = *rn_p;
+							min_afi = cur_afi;
+							min_safi = cur_safi;
+							min_peer_type = cur_peer_type;
+							min_peer_len = cur_peer_len;
+							memcpy(min_peer_bytes, cur_peer_bytes, 16);
+							min_prefix_len_bytes = cur_prefix_len_bytes;
+							memcpy(min_prefix_bytes, cur_prefix_bytes, cur_prefix_len_bytes);
+							min_prefix_bitlen = cur_prefix_bitlen;
+						} else {
+							/* Compare with min */
+							int min_cmp = 0;
+							iana_afi_t min_iana_afi;
+							iana_safi_t min_iana_safi;
+							bgp_map_afi_safi_int2iana(min_afi, min_safi, &min_iana_afi, &min_iana_safi);
+
+							if (min_cmp == 0)
+								min_cmp = (int)cur_iana_afi - (int)min_iana_afi;
+							if (min_cmp == 0)
+								min_cmp = (int)cur_iana_safi - (int)min_iana_safi;
+							if (min_cmp == 0)
+								min_cmp = cur_peer_type - min_peer_type;
+							if (min_cmp == 0)
+								min_cmp = (int)cur_peer_len - (int)min_peer_len;
+							if (min_cmp == 0)
+								min_cmp = memcmp(cur_peer_bytes, min_peer_bytes, cur_peer_len);
+							if (min_cmp == 0)
+								min_cmp = (int)cur_prefix_len_bytes - (int)min_prefix_len_bytes;
+							if (min_cmp == 0)
+								min_cmp = memcmp(cur_prefix_bytes, min_prefix_bytes, cur_prefix_len_bytes);
+							if (min_cmp == 0)
+								min_cmp = cur_prefix_bitlen - min_prefix_bitlen;
+
+							if (min_cmp < 0) {
+								min_path = path;
+								min_prefix = *rn_p;
+								min_afi = cur_afi;
+								min_safi = cur_safi;
+								min_peer_type = cur_peer_type;
+								min_peer_len = cur_peer_len;
+								memcpy(min_peer_bytes, cur_peer_bytes, 16);
+								min_prefix_len_bytes = cur_prefix_len_bytes;
+								memcpy(min_prefix_bytes, cur_prefix_bytes, cur_prefix_len_bytes);
+								min_prefix_bitlen = cur_prefix_bitlen;
+							}
+						}
+					}
+				}
+			}
+			continue; /* Done with EVPN, move to next AFI/SAFI */
+		}
+
+		/* Single-level iteration for IPv4/IPv6 unicast */
+		for (dest = bgp_table_top(bgp->rib[cur_afi][cur_safi]); dest;
+		     dest = bgp_route_next(dest)) {
+			const struct prefix *rn_p = bgp_dest_get_prefix(dest);
+
+			/* Skip if prefix is NULL */
+			if (!rn_p)
+				continue;
+
+			for (path = bgp_dest_get_bgp_path_info(dest); path;
+			     path = path->next) {
+				/* Skip paths without peer or attr */
+				if (!path->peer || !path->attr)
+					continue;
+
+				sa_family_t peer_family = sockunion_family(&path->peer->connection->su);
+				int is_self_peer = 0;
+
+				/* Handle locally originated routes (peer_self) */
+				if (peer_family != AF_INET && peer_family != AF_INET6) {
+					/* Check if this is a self-originated route */
+					if (path->peer == path->peer->bgp->peer_self) {
+						is_self_peer = 1;
+						peer_family = AF_INET; /* Router-ID is IPv4 */
+					} else {
+						continue;
+					}
+				}
+
+				/* Build current tuple */
+				int cur_peer_type = (peer_family == AF_INET) ? 1 : 2;
+				size_t cur_peer_len = (peer_family == AF_INET) ? 4 : 16;
+				uint8_t cur_peer_bytes[16] = {};
+				uint8_t cur_prefix_bytes[CBGP_MAX_EVPN_PREFIX_LEN] = {};
+				size_t cur_prefix_len_bytes = 0;
+				uint8_t cur_prefix_bitlen = rn_p->prefixlen;
+
+				if (is_self_peer) {
+					/* Use router-id as peer address for self-originated routes */
+					memcpy(cur_peer_bytes, &path->peer->bgp->router_id, 4);
+				} else if (peer_family == AF_INET) {
+					memcpy(cur_peer_bytes, &path->peer->connection->su.sin.sin_addr, 4);
+				} else {
+					memcpy(cur_peer_bytes, &path->peer->connection->su.sin6.sin6_addr, 16);
+				}
+
+				/* Handle prefix encoding based on AFI */
+				if (cur_afi == AFI_IP) {
+					cur_prefix_len_bytes = 4;
+					memcpy(cur_prefix_bytes, &rn_p->u.prefix4, 4);
+				} else if (cur_afi == AFI_IP6) {
+					cur_prefix_len_bytes = 16;
+					memcpy(cur_prefix_bytes, &rn_p->u.prefix6, 16);
+				} else if (cur_afi == AFI_L2VPN && rn_p->family == AF_EVPN) {
+					/* EVPN prefix - encode safely */
+					cur_prefix_len_bytes = encode_evpn_prefix(rn_p, cur_prefix_bytes,
+										     sizeof(cur_prefix_bytes));
+					if (cur_prefix_len_bytes == 0)
+						continue; /* Skip invalid EVPN prefix */
+				} else {
+					/* Unknown AFI/family combination - skip */
+					continue;
+				}
+
+				/*
+				 * Compare current tuple with search key
+				 * Full tuple order: (AFI, SAFI, peerType, peerLen, peerBytes, prefixLenBytes, prefixBytes, prefixBitLen)
+				 * Use IANA AFI/SAFI values for proper ordering (L2VPN=25 > IPv6=2 > IPv4=1)
+				 */
+				int cmp = 0;
+
+				/* Convert current AFI/SAFI to IANA for comparison */
+				iana_afi_t cur_iana_afi;
+				iana_safi_t cur_iana_safi;
+				bgp_map_afi_safi_int2iana(cur_afi, cur_safi, &cur_iana_afi, &cur_iana_safi);
+
+				/* 1. Compare AFI (using IANA values) */
+				if (cmp == 0)
+					cmp = (int)cur_iana_afi - (int)iana_afi;
+
+				/* 2. Compare SAFI (using IANA values) */
+				if (cmp == 0)
+					cmp = (int)cur_iana_safi - (int)iana_safi;
+
+				/* 3. Compare PeerType */
+				if (cmp == 0)
+					cmp = cur_peer_type - search_peer_type;
+
+				/* 4. Compare PeerLen */
+				if (cmp == 0)
+					cmp = (int)cur_peer_len - (int)search_peer_len;
+
+				/* 5. Compare PeerBytes */
+				if (cmp == 0)
+					cmp = memcmp(cur_peer_bytes, search_peer_bytes, cur_peer_len);
+
+				/* 6. Compare PrefixLenBytes */
+				if (cmp == 0)
+					cmp = (int)cur_prefix_len_bytes - (int)search_prefix_len_bytes;
+
+				/* 7. Compare PrefixBytes */
+				if (cmp == 0)
+					cmp = memcmp(cur_prefix_bytes, search_prefix_bytes, cur_prefix_len_bytes);
+
+				/* 8. Compare PrefixBitLen */
+				if (cmp == 0)
+					cmp = cur_prefix_bitlen - search_prefix_bitlen;
+
+				/* Skip if current <= search */
+				if (cmp <= 0)
+					continue;
+
+				/* Current > search. Check if smaller than current min */
+				if (!min_path) {
+					/* First candidate */
+					min_path = path;
+					min_prefix = *rn_p;
+					min_afi = cur_afi;
+					min_safi = cur_safi;
+					min_peer_type = cur_peer_type;
+					min_peer_len = cur_peer_len;
+					memcpy(min_peer_bytes, cur_peer_bytes, 16);
+					min_prefix_len_bytes = cur_prefix_len_bytes;
+					memcpy(min_prefix_bytes, cur_prefix_bytes, cur_prefix_len_bytes);
+					min_prefix_bitlen = cur_prefix_bitlen;
+				} else {
+					/* Compare current with min (full tuple) using IANA AFI/SAFI */
+					int min_cmp = 0;
+					iana_afi_t min_iana_afi;
+					iana_safi_t min_iana_safi;
+					bgp_map_afi_safi_int2iana(min_afi, min_safi, &min_iana_afi, &min_iana_safi);
+
+					if (min_cmp == 0)
+						min_cmp = (int)cur_iana_afi - (int)min_iana_afi;
+					if (min_cmp == 0)
+						min_cmp = (int)cur_iana_safi - (int)min_iana_safi;
+					if (min_cmp == 0)
+						min_cmp = cur_peer_type - min_peer_type;
+					if (min_cmp == 0)
+						min_cmp = (int)cur_peer_len - (int)min_peer_len;
+					if (min_cmp == 0)
+						min_cmp = memcmp(cur_peer_bytes, min_peer_bytes, cur_peer_len);
+					if (min_cmp == 0)
+						min_cmp = (int)cur_prefix_len_bytes - (int)min_prefix_len_bytes;
+					if (min_cmp == 0)
+						min_cmp = memcmp(cur_prefix_bytes, min_prefix_bytes, cur_prefix_len_bytes);
+					if (min_cmp == 0)
+						min_cmp = cur_prefix_bitlen - min_prefix_bitlen;
+
+					if (min_cmp < 0) {
+						/* Current < min, update min */
+						min_path = path;
+						min_prefix = *rn_p;
+						min_afi = cur_afi;
+						min_safi = cur_safi;
+						min_peer_type = cur_peer_type;
+						min_peer_len = cur_peer_len;
+						memcpy(min_peer_bytes, cur_peer_bytes, 16);
+						min_prefix_len_bytes = cur_prefix_len_bytes;
+						memcpy(min_prefix_bytes, cur_prefix_bytes, cur_prefix_len_bytes);
+						min_prefix_bitlen = cur_prefix_bitlen;
+					}
+				}
+			}
+		}
+	}
+
+	if (min_path) {
+		/* Encode the result OID */
+		offset = name + namelen;
+
+		/* Convert internal AFI/SAFI to IANA values for OID */
+		iana_afi_t out_iana_afi;
+		iana_safi_t out_iana_safi;
+		bgp_map_afi_safi_int2iana(min_afi, min_safi, &out_iana_afi, &out_iana_safi);
+
+		/* AFI (IANA value) */
+		*offset++ = out_iana_afi;
+		/* SAFI (IANA value) */
+		*offset++ = out_iana_safi;
+
+		/* PeerType */
+		*offset++ = min_peer_type;
+
+		/* PeerAddr: length + bytes */
+		*offset++ = min_peer_len;
+		for (size_t i = 0; i < min_peer_len; i++)
+			*offset++ = min_peer_bytes[i];
+
+		/* Prefix: length + bytes */
+		*offset++ = min_prefix_len_bytes;
+		for (size_t i = 0; i < min_prefix_len_bytes; i++)
+			*offset++ = min_prefix_bytes[i];
+
+		/* PrefixBitLen (CIDR bits) */
+		*offset++ = min_prefix_bitlen;
+
+		/* Total length: namelen + afi(1) + safi(1) + peerType(1) + peerLen(1) + peer + prefixLenBytes(1) + prefix + prefixBitLen(1) */
+		*length = namelen + 1 + 1 + 1 + 1 + min_peer_len + 1 + min_prefix_len_bytes + 1;
+
+		/* Return prefix info */
+		*addr = min_prefix;
+
+		return min_path;
+	}
+
+	return NULL;
+}
+
+/*
+ * cbgpRouteTable handler
+ * 
+ * Handles all cbgpRouteTable columns including:
+ * - INDEX columns (1-6): cbgpRouteAfi, cbgpRouteSafi, cbgpRoutePeerType,
+ *                        cbgpRoutePeer, cbgpRouteAddrPrefix, cbgpRouteAddrPrefixLen
+ * - Data columns (7-19): cbgpRouteOrigin, cbgpRouteAsPathSegment, etc.
+ */
+static uint8_t *cbgp4RouteTable(struct variable *v, oid name[], size_t *length,
+                int exact, size_t *var_len,
+                WriteMethod **write_method)
+{
+    struct bgp *bgp;
+    struct bgp_path_info *path;
+    struct prefix addr = {};
+
+    bgp = bgp_get_default();
+    if (!bgp)
+        return NULL;
+
+    if (smux_header_table(v, name, length, exact, var_len, write_method) ==
+        MATCH_FAILED)
+        return NULL;
+
+    path = cbgp4RouteTable_lookup(v, name, length, bgp, &addr, exact);
+    if (!path)
+        return NULL;
+
+    /* Safety check - ensure path has valid peer and attr */
+    if (!path->peer || !path->attr)
+        return NULL;
+
+    switch (v->magic) {
+    /* INDEX columns (1-6) - read-only implementation */
+    case CBGP_ROUTE_AFI:
+        /* Return IANA AFI from the OID index */
+        /* Parse AFI directly from OID: name[namelen] = AFI */
+        if (*length > v->namelen) {
+            return SNMP_INTEGER(name[v->namelen]);
+        }
+        /* Fallback based on prefix family */
+        if (addr.family == AF_INET)
+            return SNMP_INTEGER(1);   /* IANA AFI IPv4 */
+        else if (addr.family == AF_INET6)
+            return SNMP_INTEGER(2);   /* IANA AFI IPv6 */
+        else if (addr.family == AF_EVPN)
+            return SNMP_INTEGER(25);  /* IANA AFI L2VPN */
+        else
+            return SNMP_INTEGER(1);   /* Default to IPv4 */
+
+    case CBGP_ROUTE_SAFI:
+        /* Return IANA SAFI from the OID index */
+        /* Parse SAFI directly from OID: name[namelen+1] = SAFI */
+        if (*length > (size_t)(v->namelen + 1)) {
+            return SNMP_INTEGER(name[v->namelen + 1]);
+        }
+        /* Fallback based on prefix family */
+        if (addr.family == AF_EVPN)
+            return SNMP_INTEGER(70);  /* IANA SAFI EVPN */
+        else
+            return SNMP_INTEGER(1);   /* IANA SAFI unicast */
+
+    case CBGP_ROUTE_PEER_TYPE:
+        /* Return peer address type: 1=IPv4, 2=IPv6 */
+        /* Self-originated routes use router-id (IPv4) */
+        if (path->peer == path->peer->bgp->peer_self)
+            return SNMP_INTEGER(1);  /* Router-ID is IPv4 */
+        else if (sockunion_family(&path->peer->connection->su) == AF_INET)
+            return SNMP_INTEGER(1);  /* IPv4 */
+        else
+            return SNMP_INTEGER(2);  /* IPv6 */
+
+    case CBGP_ROUTE_PEER:
+        /* Return peer IP address as OCTET STRING */
+        /* Self-originated routes use router-id as peer address */
+        if (path->peer == path->peer->bgp->peer_self) {
+            memcpy(cbgp_route_octet_buf, &path->peer->bgp->router_id, 4);
+            *var_len = 4;
+        } else if (sockunion_family(&path->peer->connection->su) == AF_INET) {
+            memcpy(cbgp_route_octet_buf, &path->peer->connection->su.sin.sin_addr, 4);
+            *var_len = 4;
+        } else {
+            memcpy(cbgp_route_octet_buf, &path->peer->connection->su.sin6.sin6_addr, 16);
+            *var_len = 16;
+        }
+        return cbgp_route_octet_buf;
+
+    case CBGP_ROUTE_ADDR_PREFIX:
+        /* Return prefix address as OCTET STRING */
+        if (addr.family == AF_INET) {
+            memcpy(cbgp_route_octet_buf, &addr.u.prefix4, 4);
+            *var_len = 4;
+        } else if (addr.family == AF_INET6) {
+            memcpy(cbgp_route_octet_buf, &addr.u.prefix6, 16);
+            *var_len = 16;
+        } else if (addr.family == AF_EVPN) {
+            /* Encode EVPN prefix into bytes */
+            size_t evpn_len = encode_evpn_prefix(&addr, cbgp_route_octet_buf,
+                                                  sizeof(cbgp_route_octet_buf));
+            if (evpn_len == 0) {
+                /* Fallback on encoding error */
+                *var_len = 0;
+                return cbgp_route_octet_buf;
+            }
+            *var_len = evpn_len;
+        } else {
+            /* Default to IPv4 */
+            memcpy(cbgp_route_octet_buf, &addr.u.prefix4, 4);
+            *var_len = 4;
+        }
+        return cbgp_route_octet_buf;
+
+    case CBGP_ROUTE_ADDR_PREFIX_LEN:
+        /* Return prefix length in bits */
+        return SNMP_INTEGER(addr.prefixlen);
+
+    /* Data columns (7-19) */
+    case CBGP_ROUTE_ORIGIN:
+        /* 1=igp, 2=egp, 3=incomplete */
+        switch (path->attr->origin) {
+        case BGP_ORIGIN_IGP:
+            return SNMP_INTEGER(1);
+        case BGP_ORIGIN_EGP:
+            return SNMP_INTEGER(2);
+        case BGP_ORIGIN_INCOMPLETE:
+            return SNMP_INTEGER(3);
+        default:
+            return SNMP_INTEGER(0);
+        }
+
+    case CBGP_ROUTE_AS_PATH_SEGMENT:
+        if (path->attr->aspath)
+            return aspath_snmp_pathseg(path->attr->aspath, var_len);
+        else {
+            *var_len = 0;
+            return NULL;
+        }
+
+    case CBGP_ROUTE_NEXT_HOP:
+        switch (path->attr->mp_nexthop_len) {
+        case BGP_ATTR_NHLEN_IPV4:
+            return SNMP_IPADDRESS(path->attr->mp_nexthop_global_in);
+        case BGP_ATTR_NHLEN_IPV6_GLOBAL:
+            return SNMP_IP6ADDRESS(path->attr->mp_nexthop_global);
+        case BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL:
+            if (CHECK_FLAG(path->attr->nh_flags,
+                           BGP_ATTR_NH_MP_PREFER_GLOBAL))
+                return SNMP_IP6ADDRESS(path->attr->mp_nexthop_global);
+            else
+                return SNMP_IP6ADDRESS(path->attr->mp_nexthop_local);
+        default:
+            return SNMP_IPADDRESS(path->attr->nexthop);
+        }
+
+    case CBGP_ROUTE_MED_PRESENT:
+        if (CHECK_FLAG(path->attr->flag,
+                   ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC)))
+            return SNMP_INTEGER(1); /* true */
+        else
+            return SNMP_INTEGER(2); /* false */
+
+    case CBGP_ROUTE_MULTI_EXIT_DISC:
+        if (CHECK_FLAG(path->attr->flag,
+                   ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC)))
+            return SNMP_INTEGER(path->attr->med);
+        else
+            return SNMP_INTEGER(0);
+
+    case CBGP_ROUTE_LOCAL_PREF_PRESENT:
+        if (CHECK_FLAG(path->attr->flag,
+                   ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)))
+            return SNMP_INTEGER(1); /* true */
+        else
+            return SNMP_INTEGER(2); /* false */
+
+    case CBGP_ROUTE_LOCAL_PREF:
+        if (CHECK_FLAG(path->attr->flag,
+                   ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)))
+            return SNMP_INTEGER(path->attr->local_pref);
+        else
+            return SNMP_INTEGER(0);
+
+    case CBGP_ROUTE_ATOMIC_AGGREGATE:
+        /* 1=lessSpecificRouteNotSelected, 2=lessSpecificRouteSelected */
+        if (CHECK_FLAG(path->attr->flag,
+                   ATTR_FLAG_BIT(BGP_ATTR_ATOMIC_AGGREGATE)))
+            return SNMP_INTEGER(1);
+        else
+            return SNMP_INTEGER(2);
+
+    case CBGP_ROUTE_AGGREGATOR_AS:
+        if (CHECK_FLAG(path->attr->flag,
+                   ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR)))
+            return SNMP_INTEGER(path->attr->aggregator_as);
+        else
+            return SNMP_INTEGER(0);
+
+    case CBGP_ROUTE_AGGREGATOR_ADDR_TYPE:
+        /* Aggregator address is always IPv4 per BGP spec */
+        if (CHECK_FLAG(path->attr->flag,
+                   ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR)))
+            return SNMP_INTEGER(1); /* ipv4 */
+        else
+            return SNMP_INTEGER(0); /* unknown */
+
+    case CBGP_ROUTE_AGGREGATOR_ADDR:
+        if (CHECK_FLAG(path->attr->flag,
+                   ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR)))
+            return SNMP_IPADDRESS(path->attr->aggregator_addr);
+        else
+            return SNMP_IPADDRESS(bgp_empty_addr);
+
+    case CBGP_ROUTE_BEST:
+        /* 1=true, 2=false */
+        if (CHECK_FLAG(path->flags, BGP_PATH_SELECTED))
+            return SNMP_INTEGER(1);
+        else
+            return SNMP_INTEGER(2);
+
+	case CBGP_ROUTE_UNKNOWN_ATTR: {
+		static uint8_t transit_buf[512];
+		struct transit *transit = bgp_attr_get_transit(path->attr);
+
+		if (transit && transit->val && transit->length > 0) {
+			*var_len = MIN(transit->length, sizeof(transit_buf));
+			memcpy(transit_buf, transit->val, *var_len);
+			return transit_buf;
+		}
+		*var_len = 0;
+		return (uint8_t *)&bgp_empty_addr;
+	}
+
+    default:
+        break;
+    }
+
+    return NULL;
+}
+
+/* cbgpNotifsEnable BITS { cbgpBackwardTransition(0),
+ *   cbgpPrefixThresholdExceeded(1), cbgpPrefixThresholdClear(2) }
+ * All notifications enabled by default.  BITS are encoded MSB-first:
+ *   bit 0 → byte-0 bit-7, bit 1 → byte-0 bit-6, bit 2 → byte-0 bit-5
+ *   → 0xE0.  Read-only in this implementation.
+ */
+static uint8_t cbgp_notifs_enable_bits[] = {0xE0};
+
+static uint8_t *cbgpGlobalTable(struct variable *v, oid name[], size_t *length,
+				int exact, size_t *var_len,
+				WriteMethod **write_method)
+{
+	struct bgp *bgp;
+
+	if (smux_header_generic(v, name, length, exact, var_len, write_method)
+	    == MATCH_FAILED)
+		return NULL;
+
+	bgp = bgp_get_default();
+	if (!bgp)
+		return NULL;
+
+	switch (v->magic) {
+	case CBGP_LOCAL_AS:
+		return SNMP_INTEGER(bgp->as);
+
+	case CBGP_NOTIFS_ENABLE:
+		*var_len = sizeof(cbgp_notifs_enable_bits);
+		return cbgp_notifs_enable_bits;
+
+	default:
+		break;
+	}
+	return NULL;
+}
+
+/*
+ * Capability table: reconstruct received capabilities from parsed peer state.
+ * Each entry has (code, index, value, value_len). Index is 1-based per code.
+ */
+#define CBGP_CAP_MAX_ENTRIES 64
+#define CBGP_CAP_MAX_VALUE   255
+
+struct cbgp_cap_entry {
+	uint8_t code;
+	uint8_t index;
+	uint8_t value[CBGP_CAP_MAX_VALUE];
+	uint8_t value_len;
+};
+
+struct cbgp_cap_list {
+	uint16_t count;
+	struct cbgp_cap_entry entries[CBGP_CAP_MAX_ENTRIES];
+};
+
+static void cbgp4_build_cap_list(struct peer *peer, struct cbgp_cap_list *caps)
+{
+	uint16_t n = 0;
+	afi_t afi;
+	safi_t safi;
+	iana_afi_t pkt_afi;
+	iana_safi_t pkt_safi;
+
+	memset(caps, 0, sizeof(*caps));
+
+	/* MP (code 1): one entry per received AFI/SAFI */
+	FOREACH_AFI_SAFI (afi, safi) {
+		if (peer->afc_recv[afi][safi] && n < CBGP_CAP_MAX_ENTRIES) {
+			bgp_map_afi_safi_int2iana(afi, safi, &pkt_afi,
+						  &pkt_safi);
+			caps->entries[n].code = CAPABILITY_CODE_MP;
+			caps->entries[n].value[0] = (pkt_afi >> 8) & 0xff;
+			caps->entries[n].value[1] = pkt_afi & 0xff;
+			caps->entries[n].value[2] = 0;
+			caps->entries[n].value[3] = pkt_safi & 0xff;
+			caps->entries[n].value_len = 4;
+			n++;
+		}
+	}
+
+	/* Route Refresh (code 2) */
+	if (CHECK_FLAG(peer->cap, PEER_CAP_REFRESH_RCV) &&
+	    n < CBGP_CAP_MAX_ENTRIES) {
+		caps->entries[n].code = CAPABILITY_CODE_REFRESH;
+		caps->entries[n].value_len = 0;
+		n++;
+	}
+
+	/* Extended Nexthop (code 5) */
+	if (CHECK_FLAG(peer->cap, PEER_CAP_ENHE_RCV) &&
+	    n < CBGP_CAP_MAX_ENTRIES) {
+		uint8_t *val = caps->entries[n].value;
+		uint8_t vlen = 0;
+
+		FOREACH_AFI_SAFI (afi, safi) {
+			if (CHECK_FLAG(peer->af_cap[afi][safi],
+				       PEER_CAP_ENHE_AF_RCV) &&
+			    vlen + 6 <= CBGP_CAP_MAX_VALUE) {
+				bgp_map_afi_safi_int2iana(afi, safi, &pkt_afi,
+							  &pkt_safi);
+				val[vlen++] = (pkt_afi >> 8) & 0xff;
+				val[vlen++] = pkt_afi & 0xff;
+				val[vlen++] = (pkt_safi >> 8) & 0xff;
+				val[vlen++] = pkt_safi & 0xff;
+				val[vlen++] = 0;
+				val[vlen++] = AFI_IP6;
+			}
+		}
+		caps->entries[n].code = CAPABILITY_CODE_ENHE;
+		caps->entries[n].value_len = vlen;
+		n++;
+	}
+
+	/* Extended Message (code 6) */
+	if (CHECK_FLAG(peer->cap, PEER_CAP_EXTENDED_MESSAGE_RCV) &&
+	    n < CBGP_CAP_MAX_ENTRIES) {
+		caps->entries[n].code = CAPABILITY_CODE_EXT_MESSAGE;
+		caps->entries[n].value_len = 0;
+		n++;
+	}
+
+	/* Role (code 9) */
+	if (CHECK_FLAG(peer->cap, PEER_CAP_ROLE_RCV) &&
+	    n < CBGP_CAP_MAX_ENTRIES) {
+		caps->entries[n].code = CAPABILITY_CODE_ROLE;
+		caps->entries[n].value[0] = peer->remote_role;
+		caps->entries[n].value_len = 1;
+		n++;
+	}
+
+	/* Graceful Restart (code 64) */
+	if (CHECK_FLAG(peer->cap, PEER_CAP_RESTART_RCV) &&
+	    n < CBGP_CAP_MAX_ENTRIES) {
+		uint8_t *val = caps->entries[n].value;
+		uint8_t vlen = 0;
+		uint16_t flags_time = peer->v_gr_restart & 0x0FFF;
+
+		if (CHECK_FLAG(peer->cap,
+			       PEER_CAP_GRACEFUL_RESTART_R_BIT_RCV))
+			flags_time |= 0x8000;
+		if (CHECK_FLAG(peer->cap,
+			       PEER_CAP_GRACEFUL_RESTART_N_BIT_RCV))
+			flags_time |= 0x4000;
+
+		val[vlen++] = (flags_time >> 8) & 0xff;
+		val[vlen++] = flags_time & 0xff;
+
+		FOREACH_AFI_SAFI (afi, safi) {
+			if (CHECK_FLAG(peer->af_cap[afi][safi],
+				       PEER_CAP_RESTART_AF_RCV) &&
+			    vlen + 4 <= CBGP_CAP_MAX_VALUE) {
+				bgp_map_afi_safi_int2iana(afi, safi, &pkt_afi,
+							  &pkt_safi);
+				val[vlen++] = (pkt_afi >> 8) & 0xff;
+				val[vlen++] = pkt_afi & 0xff;
+				val[vlen++] = pkt_safi & 0xff;
+				val[vlen++] = CHECK_FLAG(
+					peer->af_cap[afi][safi],
+					PEER_CAP_RESTART_AF_PRESERVE_RCV)
+						     ? 0x80
+						     : 0;
+			}
+		}
+		caps->entries[n].code = CAPABILITY_CODE_RESTART;
+		caps->entries[n].value_len = vlen;
+		n++;
+	}
+
+	/* 4-byte AS (code 65) */
+	if (CHECK_FLAG(peer->cap, PEER_CAP_AS4_RCV) &&
+	    n < CBGP_CAP_MAX_ENTRIES) {
+		uint32_t as4 = peer->as;
+
+		caps->entries[n].code = CAPABILITY_CODE_AS4;
+		caps->entries[n].value[0] = (as4 >> 24) & 0xff;
+		caps->entries[n].value[1] = (as4 >> 16) & 0xff;
+		caps->entries[n].value[2] = (as4 >> 8) & 0xff;
+		caps->entries[n].value[3] = as4 & 0xff;
+		caps->entries[n].value_len = 4;
+		n++;
+	}
+
+	/* Dynamic (code 67) */
+	if (CHECK_FLAG(peer->cap, PEER_CAP_DYNAMIC_RCV) &&
+	    n < CBGP_CAP_MAX_ENTRIES) {
+		caps->entries[n].code = CAPABILITY_CODE_DYNAMIC;
+		caps->entries[n].value_len = 0;
+		n++;
+	}
+
+	/* Addpath (code 69) */
+	if (CHECK_FLAG(peer->cap, PEER_CAP_ADDPATH_RCV) &&
+	    n < CBGP_CAP_MAX_ENTRIES) {
+		uint8_t *val = caps->entries[n].value;
+		uint8_t vlen = 0;
+
+		FOREACH_AFI_SAFI (afi, safi) {
+			uint8_t sr = 0;
+
+			if (CHECK_FLAG(peer->af_cap[afi][safi],
+				       PEER_CAP_ADDPATH_AF_TX_RCV))
+				sr |= 0x01;
+			if (CHECK_FLAG(peer->af_cap[afi][safi],
+				       PEER_CAP_ADDPATH_AF_RX_RCV))
+				sr |= 0x02;
+			if (sr && vlen + 4 <= CBGP_CAP_MAX_VALUE) {
+				bgp_map_afi_safi_int2iana(afi, safi, &pkt_afi,
+							  &pkt_safi);
+				val[vlen++] = (pkt_afi >> 8) & 0xff;
+				val[vlen++] = pkt_afi & 0xff;
+				val[vlen++] = pkt_safi & 0xff;
+				val[vlen++] = sr;
+			}
+		}
+		caps->entries[n].code = CAPABILITY_CODE_ADDPATH;
+		caps->entries[n].value_len = vlen;
+		n++;
+	}
+
+	/* Enhanced Route Refresh (code 70) */
+	if (CHECK_FLAG(peer->cap, PEER_CAP_ENHANCED_RR_RCV) &&
+	    n < CBGP_CAP_MAX_ENTRIES) {
+		caps->entries[n].code = CAPABILITY_CODE_ENHANCED_RR;
+		caps->entries[n].value_len = 0;
+		n++;
+	}
+
+	/* LLGR (code 71) */
+	if (CHECK_FLAG(peer->cap, PEER_CAP_LLGR_RCV) &&
+	    n < CBGP_CAP_MAX_ENTRIES) {
+		uint8_t *val = caps->entries[n].value;
+		uint8_t vlen = 0;
+
+		FOREACH_AFI_SAFI (afi, safi) {
+			if (CHECK_FLAG(peer->af_cap[afi][safi],
+				       PEER_CAP_LLGR_AF_RCV) &&
+			    vlen + 7 <= CBGP_CAP_MAX_VALUE) {
+				uint32_t st = peer->llgr[afi][safi].stale_time;
+
+				bgp_map_afi_safi_int2iana(afi, safi, &pkt_afi,
+							  &pkt_safi);
+				val[vlen++] = (pkt_afi >> 8) & 0xff;
+				val[vlen++] = pkt_afi & 0xff;
+				val[vlen++] = pkt_safi & 0xff;
+				val[vlen++] = peer->llgr[afi][safi].flags;
+				val[vlen++] = (st >> 16) & 0xff;
+				val[vlen++] = (st >> 8) & 0xff;
+				val[vlen++] = st & 0xff;
+			}
+		}
+		caps->entries[n].code = CAPABILITY_CODE_LLGR;
+		caps->entries[n].value_len = vlen;
+		n++;
+	}
+
+	/* FQDN (code 73) */
+	if (CHECK_FLAG(peer->cap, PEER_CAP_HOSTNAME_RCV) &&
+	    n < CBGP_CAP_MAX_ENTRIES) {
+		uint8_t *val = caps->entries[n].value;
+		uint8_t vlen = 0;
+		uint8_t hlen = peer->hostname
+				      ? strnlen(peer->hostname, 64)
+				      : 0;
+		uint8_t dlen = peer->domainname
+				      ? strnlen(peer->domainname, 64)
+				      : 0;
+
+		if (1 + hlen + 1 + dlen <= CBGP_CAP_MAX_VALUE) {
+			val[vlen++] = hlen;
+			if (hlen) {
+				memcpy(&val[vlen], peer->hostname, hlen);
+				vlen += hlen;
+			}
+			val[vlen++] = dlen;
+			if (dlen) {
+				memcpy(&val[vlen], peer->domainname, dlen);
+				vlen += dlen;
+			}
+		}
+		caps->entries[n].code = CAPABILITY_CODE_FQDN;
+		caps->entries[n].value_len = vlen;
+		n++;
+	}
+
+	/* Route Refresh Old/Cisco (code 128) - upstream unifies old/new */
+	if (CHECK_FLAG(peer->cap, PEER_CAP_REFRESH_RCV) &&
+	    n < CBGP_CAP_MAX_ENTRIES) {
+		caps->entries[n].code = BGP_MSG_ROUTE_REFRESH_OLD;
+		caps->entries[n].value_len = 0;
+		n++;
+	}
+
+	/* Assign per-code indices (1-based) */
+	caps->count = n;
+	for (uint16_t i = 0; i < n; i++) {
+		uint8_t idx = 1;
+
+		for (uint16_t j = 0; j < i; j++) {
+			if (caps->entries[j].code == caps->entries[i].code)
+				idx++;
+		}
+		caps->entries[i].index = idx;
+	}
+}
+
+static struct cbgp_cap_entry *cbgp4_cap_find(struct cbgp_cap_list *caps,
+					     uint8_t code, uint8_t idx)
+{
+	for (uint16_t i = 0; i < caps->count; i++) {
+		if (caps->entries[i].code == code &&
+		    caps->entries[i].index == idx)
+			return &caps->entries[i];
+	}
+	return NULL;
+}
+
+static struct cbgp_cap_entry *cbgp4_cap_next(struct cbgp_cap_list *caps,
+					     uint8_t code, uint8_t idx)
+{
+	bool found = (code == 0 && idx == 0);
+
+	for (uint16_t i = 0; i < caps->count; i++) {
+		if (found)
+			return &caps->entries[i];
+		if (caps->entries[i].code == code &&
+		    caps->entries[i].index == idx)
+			found = true;
+	}
+	return NULL;
+}
+
+/*
+ * cbgpPeerCapsTable handler (legacy IPv4 peers).
+ * INDEX: bgpPeerRemoteAddr(4) + capCode(1) + capIndex(1)
+ */
+static uint8_t *cbgp4PeerCapsTable(struct variable *v, oid name[],
+				   size_t *length, int exact, size_t *var_len,
+				   WriteMethod **write_method)
+{
+	static uint8_t cap_val_peer[CBGP_CAP_MAX_VALUE];
+	struct peer *peer;
+	struct cbgp_cap_list caps;
+	struct cbgp_cap_entry *ent;
+	size_t namelen = v ? v->namelen : CBGP_PEER_TABLE_INDEX_OFFSET;
+	oid *index = name + namelen;
+	size_t offsetlen = *length - namelen;
+	struct ipaddr addr = {};
+	uint8_t cap_code = 0, cap_idx = 0;
+
+	if (smux_header_table(v, name, length, exact, var_len, write_method) ==
+	    MATCH_FAILED)
+		return NULL;
+
+	if (offsetlen >= IN_ADDR_SIZE + 2) {
+		addr.ipa_type = AF_INET;
+		oid2in_addr(index, IN_ADDR_SIZE, &addr.ip._v4_addr);
+		cap_code = index[IN_ADDR_SIZE];
+		cap_idx = index[IN_ADDR_SIZE + 1];
+	} else if (offsetlen >= IN_ADDR_SIZE) {
+		addr.ipa_type = AF_INET;
+		oid2in_addr(index, IN_ADDR_SIZE, &addr.ip._v4_addr);
+	} else if (!offsetlen) {
+		for (size_t i = 0; i < IN_ADDR_SIZE + 2; i++)
+			*(index + i) = 0;
+	} else {
+		return NULL;
+	}
+
+	if (exact) {
+		peer = bgp_snmp_lookup_peer(VRF_DEFAULT, &addr);
+		if (!peer)
+			return NULL;
+		cbgp4_build_cap_list(peer, &caps);
+		ent = cbgp4_cap_find(&caps, cap_code, cap_idx);
+		if (!ent)
+			return NULL;
+	} else {
+		if (!offsetlen)
+			peer = bgp_snmp_get_first_peer(false, AF_UNSPEC);
+		else
+			peer = bgp_snmp_lookup_peer(VRF_DEFAULT, &addr);
+
+		ent = NULL;
+		while (peer) {
+			if (sockunion_family(&peer->connection->su) != AF_INET) {
+				peer = bgp_snmp_get_next_peer(
+					false, VRF_DEFAULT, AF_INET, &addr);
+				continue;
+			}
+			cbgp4_build_cap_list(peer, &caps);
+			ent = cbgp4_cap_next(&caps, cap_code, cap_idx);
+			if (ent)
+				break;
+			addr.ipa_type = AF_INET;
+			addr.ip._v4_addr = peer->connection->su.sin.sin_addr;
+			peer = bgp_snmp_get_next_peer(false, VRF_DEFAULT,
+						      AF_INET, &addr);
+			cap_code = 0;
+			cap_idx = 0;
+		}
+
+		if (!peer || !ent)
+			return NULL;
+
+		oid_copy_in_addr(index, &peer->connection->su.sin.sin_addr);
+		index[IN_ADDR_SIZE] = ent->code;
+		index[IN_ADDR_SIZE + 1] = ent->index;
+		*length = namelen + IN_ADDR_SIZE + 2;
+	}
+
+	switch (v->magic) {
+	case CBGP_PEER_CAP_VALUE:
+		*var_len = ent->value_len;
+		if (ent->value_len)
+			memcpy(cap_val_peer, ent->value, ent->value_len);
+		return cap_val_peer;
+	default:
+		break;
+	}
+	return NULL;
+}
+
+/*
+ * cbgpPeer2CapsTable handler (IPv4/IPv6 peers).
+ * INDEX: addrType(1) + addr(4|16) + capCode(1) + capIndex(1)
+ */
+static uint8_t *cbgp4Peer2CapsTable(struct variable *v, oid name[],
+				    size_t *length, int exact, size_t *var_len,
+				    WriteMethod **write_method)
+{
+	static uint8_t cap_val_peer2[CBGP_CAP_MAX_VALUE];
+	struct peer *peer;
+	struct cbgp_cap_list caps;
+	struct cbgp_cap_entry *ent;
+	size_t namelen = v ? v->namelen : CBGP_PEER_TABLE_INDEX_OFFSET;
+	oid *index = name + namelen;
+	size_t offsetlen = *length - namelen;
+	struct ipaddr addr = {};
+	uint8_t cap_code = 0, cap_idx = 0;
+	int addr_len;
+
+	if (smux_header_table(v, name, length, exact, var_len, write_method) ==
+	    MATCH_FAILED)
+		return NULL;
+
+	if (offsetlen >= IN_ADDR_SIZE + 3 || offsetlen >= IN6_ADDR_SIZE + 3) {
+		addr.ipa_type = index[0] == 1 ? AF_INET : AF_INET6;
+		if (addr.ipa_type == AF_INET && offsetlen >= IN_ADDR_SIZE + 3) {
+			oid2in_addr(&index[1], IN_ADDR_SIZE, &addr.ip._v4_addr);
+			cap_code = index[IN_ADDR_SIZE + 1];
+			cap_idx = index[IN_ADDR_SIZE + 2];
+		} else if (addr.ipa_type == AF_INET6 &&
+			   offsetlen >= IN6_ADDR_SIZE + 3) {
+			oid2in6_addr(&index[1], &addr.ip._v6_addr);
+			cap_code = index[IN6_ADDR_SIZE + 1];
+			cap_idx = index[IN6_ADDR_SIZE + 2];
+		}
+	} else if (offsetlen >= IN_ADDR_SIZE + 1 ||
+		   offsetlen >= IN6_ADDR_SIZE + 1) {
+		addr.ipa_type = index[0] == 1 ? AF_INET : AF_INET6;
+		if (addr.ipa_type == AF_INET)
+			oid2in_addr(&index[1], IN_ADDR_SIZE, &addr.ip._v4_addr);
+		else
+			oid2in6_addr(&index[1], &addr.ip._v6_addr);
+	} else if (!offsetlen) {
+		for (size_t i = 0; i < IN6_ADDR_SIZE + 3; i++)
+			*(index + i) = 0;
+	} else {
+		return NULL;
+	}
+
+	if (exact) {
+		peer = bgp_snmp_lookup_peer(VRF_DEFAULT, &addr);
+		if (!peer)
+			return NULL;
+		cbgp4_build_cap_list(peer, &caps);
+		ent = cbgp4_cap_find(&caps, cap_code, cap_idx);
+		if (!ent)
+			return NULL;
+	} else {
+		if (!offsetlen)
+			peer = bgp_snmp_get_first_peer(false, AF_UNSPEC);
+		else
+			peer = bgp_snmp_lookup_peer(VRF_DEFAULT, &addr);
+
+		ent = NULL;
+		while (peer) {
+			cbgp4_build_cap_list(peer, &caps);
+			ent = cbgp4_cap_next(&caps, cap_code, cap_idx);
+			if (ent)
+				break;
+			peer = bgp_snmp_get_next_peer(false, VRF_DEFAULT,
+						      AF_UNSPEC, &addr);
+			if (peer) {
+				switch (sockunion_family(&peer->connection->su)) {
+				case AF_INET:
+					addr.ipa_type = AF_INET;
+					addr.ip._v4_addr =
+						peer->connection->su.sin.sin_addr;
+					break;
+				case AF_INET6:
+					addr.ipa_type = AF_INET6;
+					addr.ip._v6_addr =
+						peer->connection->su.sin6.sin6_addr;
+					break;
+				default:
+					continue;
+				}
+			}
+			cap_code = 0;
+			cap_idx = 0;
+		}
+
+		if (!peer || !ent)
+			return NULL;
+
+		addr_len = cbgp4_build_peer2_index(peer, index);
+		if (!addr_len)
+			return NULL;
+		index[addr_len] = ent->code;
+		index[addr_len + 1] = ent->index;
+		*length = namelen + addr_len + 2;
+	}
+
+	switch (v->magic) {
+	case CBGP_PEER2_CAP_VALUE:
+		*var_len = ent->value_len;
+		if (ent->value_len)
+			memcpy(cap_val_peer2, ent->value, ent->value_len);
+		return cap_val_peer2;
+	default:
+		break;
+	}
+	return NULL;
+}
+
+
+static struct variable cbgp4_variables[] = {
+	/* cbgpGlobal scalars */
+	{ CBGP_NOTIFS_ENABLE,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgpGlobalTable,
+	  3,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_GLOBAL, CBGP_NOTIFS_ENABLE } },
+
+	{ CBGP_LOCAL_AS,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgpGlobalTable,
+	  3,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_GLOBAL, CBGP_LOCAL_AS } },
+
+	/* cbgp4PeerTable */
+	{ CBGP_PEER_PREFIX_ACCEPTED,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4PeerTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_TABLE, CBGP_PEER_ENTRY,
+	    CBGP_PEER_PREFIX_ACCEPTED } },
+
+	{ CBGP_PEER_PREFIX_DENIED,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4PeerTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_TABLE, CBGP_PEER_ENTRY,
+	    CBGP_PEER_PREFIX_DENIED } },
+
+	{ CBGP_PEER_PREFIX_LIMIT,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4PeerTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_TABLE, CBGP_PEER_ENTRY,
+	    CBGP_PEER_PREFIX_LIMIT } },
+
+	{ CBGP_PEER_PREFIX_ADVERTISED,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4PeerTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_TABLE, CBGP_PEER_ENTRY,
+	    CBGP_PEER_PREFIX_ADVERTISED } },
+
+	{ CBGP_PEER_PREFIX_SUPPRESSED,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4PeerTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_TABLE, CBGP_PEER_ENTRY,
+	    CBGP_PEER_PREFIX_SUPPRESSED } },
+
+	{ CBGP_PEER_PREFIX_WITHDRAWN,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4PeerTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_TABLE, CBGP_PEER_ENTRY,
+	    CBGP_PEER_PREFIX_WITHDRAWN } },
+
+	{ CBGP_PEER_LAST_ERROR_TXT,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgp4PeerTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_TABLE, CBGP_PEER_ENTRY,
+	    CBGP_PEER_LAST_ERROR_TXT } },
+
+	{ CBGP_PEER_PREV_STATE,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4PeerTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_TABLE, CBGP_PEER_ENTRY,
+	    CBGP_PEER_PREV_STATE } },
+
+	/* cbgpPeerCapsTable */
+	{ CBGP_PEER_CAP_VALUE,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgp4PeerCapsTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_CAPS_TABLE,
+	    CBGP_PEER_CAPS_ENTRY, CBGP_PEER_CAP_VALUE } },
+
+	/* cbgp4PeerAddrFamilyTable */
+	{ CBGP_PEER_ADDR_FAMILY_AFI,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4PeerAddrFamilyTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_ADDR_FAMILY_TABLE,
+	    CBGP_PEER_ADDR_FAMILY_ENTRY, CBGP_PEER_ADDR_FAMILY_AFI } },
+
+	{ CBGP_PEER_ADDR_FAMILY_SAFI,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4PeerAddrFamilyTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_ADDR_FAMILY_TABLE,
+	    CBGP_PEER_ADDR_FAMILY_ENTRY, CBGP_PEER_ADDR_FAMILY_SAFI } },
+
+	{ CBGP_PEER_ADDR_FAMILY_NAME,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgp4PeerAddrFamilyTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_ADDR_FAMILY_TABLE,
+	    CBGP_PEER_ADDR_FAMILY_ENTRY, CBGP_PEER_ADDR_FAMILY_NAME } },
+
+	/* cbgp4PeerAddrFamilyPrefixTable */
+	{ CBGP_PEER_ACCEPTED_PREFIXES,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4PeerAddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER_ACCEPTED_PREFIXES } },
+
+	{ CBGP_PEER_DENIED_PREFIXES,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4PeerAddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER_DENIED_PREFIXES } },
+
+	{ CBGP_PEER_PREFIX_ADMIN_LIMIT,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4PeerAddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER_PREFIX_ADMIN_LIMIT } },
+
+	{ CBGP_PEER_PREFIX_THRESHOLD,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4PeerAddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER_PREFIX_THRESHOLD } },
+
+	{ CBGP_PEER_PREFIX_CLEAR_THRESHOLD,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4PeerAddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER_PREFIX_CLEAR_THRESHOLD } },
+
+	{ CBGP_PEER_ADVERTISED_PREFIXES,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4PeerAddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER_ADVERTISED_PREFIXES } },
+
+	{ CBGP_PEER_SUPPRESSED_PREFIXES,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4PeerAddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER_SUPPRESSED_PREFIXES } },
+
+	{ CBGP_PEER_WITHDRAWN_PREFIXES,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4PeerAddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER_WITHDRAWN_PREFIXES } },
+
+	/* cbgp4Peer2Table */
+	{ CBGP_PEER2_TYPE,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_TYPE } },
+
+	{ CBGP_PEER2_REMOTE_PORT,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_REMOTE_PORT } },
+
+	{ CBGP_PEER2_REMOTE_AS,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_REMOTE_AS } },
+
+	{ CBGP_PEER2_REMOTE_IDENTIFIER,
+	  ASN_IPADDRESS,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_REMOTE_IDENTIFIER } },
+
+	{ CBGP_PEER2_IN_UPDATES,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_IN_UPDATES } },
+
+	{ CBGP_PEER2_OUT_UPDATES,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_OUT_UPDATES } },
+
+	{ CBGP_PEER2_IN_TOTAL_MESSAGES,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_IN_TOTAL_MESSAGES } },
+
+	{ CBGP_PEER2_OUT_TOTAL_MESSAGES,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_OUT_TOTAL_MESSAGES } },
+
+	{ CBGP_PEER2_LAST_ERROR,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_LAST_ERROR } },
+
+	{ CBGP_PEER2_FSM_ESTABLISHED_TRANSITIONS,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_FSM_ESTABLISHED_TRANSITIONS } },
+
+	{ CBGP_PEER2_FSM_ESTABLISHED_TIME,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_FSM_ESTABLISHED_TIME } },
+
+	{ CBGP_PEER2_REMOTE_ADDR,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_REMOTE_ADDR } },
+
+	{ CBGP_PEER2_CONNECT_RETRY_INTERVAL,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_CONNECT_RETRY_INTERVAL } },
+
+	{ CBGP_PEER2_HOLD_TIME,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_HOLD_TIME } },
+
+	{ CBGP_PEER2_KEEP_ALIVE,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_KEEP_ALIVE } },
+
+	{ CBGP_PEER2_HOLD_TIME_CONFIGURED,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_HOLD_TIME_CONFIGURED } },
+
+	{ CBGP_PEER2_KEEP_ALIVE_CONFIGURED,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_KEEP_ALIVE_CONFIGURED } },
+
+	{ CBGP_PEER2_MIN_AS_ORIGINATION_INTERVAL,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_MIN_AS_ORIGINATION_INTERVAL } },
+
+	{ CBGP_PEER2_MIN_ROUTE_ADVERTISEMENT_INTERVAL,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_MIN_ROUTE_ADVERTISEMENT_INTERVAL } },
+
+	{ CBGP_PEER2_IN_UPDATE_ELAPSED_TIME,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_IN_UPDATE_ELAPSED_TIME } },
+
+	{ CBGP_PEER2_LAST_ERROR_TXT,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_LAST_ERROR_TXT } },
+
+	{ CBGP_PEER2_PREV_STATE,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_PREV_STATE } },
+
+	{ CBGP_PEER2_STATE,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_STATE } },
+
+	{ CBGP_PEER2_ADMIN_STATUS,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_ADMIN_STATUS } },
+
+	{ CBGP_PEER2_NEGOTIATED_VERSION,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_NEGOTIATED_VERSION } },
+
+	{ CBGP_PEER2_LOCAL_ADDR,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_LOCAL_ADDR } },
+
+	{ CBGP_PEER2_LOCAL_PORT,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_LOCAL_PORT } },
+
+	{ CBGP_PEER2_LOCAL_AS,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_LOCAL_AS } },
+
+	{ CBGP_PEER2_LOCAL_IDENTIFIER,
+	  ASN_IPADDRESS,
+	  RONLY,
+	  cbgp4Peer2Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_TABLE, CBGP_PEER2_ENTRY,
+	    CBGP_PEER2_LOCAL_IDENTIFIER } },
+
+	/* cbgpPeer2CapsTable */
+	{ CBGP_PEER2_CAP_VALUE,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgp4Peer2CapsTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_CAPS_TABLE,
+	    CBGP_PEER2_CAPS_ENTRY, CBGP_PEER2_CAP_VALUE } },
+
+	/* cbgp4Peer2AddrFamilyTable */
+	{ CBGP_PEER2_ADDR_FAMILY_AFI,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer2AddrFamilyTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_ADDR_FAMILY_TABLE,
+	    CBGP_PEER2_ADDR_FAMILY_ENTRY, CBGP_PEER2_ADDR_FAMILY_AFI } },
+
+	{ CBGP_PEER2_ADDR_FAMILY_SAFI,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer2AddrFamilyTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_ADDR_FAMILY_TABLE,
+	    CBGP_PEER2_ADDR_FAMILY_ENTRY, CBGP_PEER2_ADDR_FAMILY_SAFI } },
+
+	{ CBGP_PEER2_ADDR_FAMILY_NAME,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgp4Peer2AddrFamilyTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_ADDR_FAMILY_TABLE,
+	    CBGP_PEER2_ADDR_FAMILY_ENTRY, CBGP_PEER2_ADDR_FAMILY_NAME } },
+
+	/* cbgp4Peer2AddrFamilyPrefixTable */
+	{ CBGP_PEER2_ACCEPTED_PREFIXES,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4Peer2AddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER2_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER2_ACCEPTED_PREFIXES } },
+
+	{ CBGP_PEER2_DENIED_PREFIXES,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer2AddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER2_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER2_DENIED_PREFIXES } },
+
+	{ CBGP_PEER2_PREFIX_ADMIN_LIMIT,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer2AddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER2_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER2_PREFIX_ADMIN_LIMIT } },
+
+	{ CBGP_PEER2_PREFIX_THRESHOLD,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer2AddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER2_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER2_PREFIX_THRESHOLD } },
+
+	{ CBGP_PEER2_PREFIX_CLEAR_THRESHOLD,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer2AddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER2_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER2_PREFIX_CLEAR_THRESHOLD } },
+
+	{ CBGP_PEER2_ADVERTISED_PREFIXES,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer2AddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER2_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER2_ADVERTISED_PREFIXES } },
+
+	{ CBGP_PEER2_SUPPRESSED_PREFIXES,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer2AddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER2_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER2_SUPPRESSED_PREFIXES } },
+
+	{ CBGP_PEER2_WITHDRAWN_PREFIXES,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer2AddrFamilyPrefixTable,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER2_ADDR_FAMILY_PREFIX_TABLE,
+	    CBGP_PEER2_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER2_WITHDRAWN_PREFIXES } },
+
+
+	/* cbgp4Peer3Table */
+	{ CBGP_PEER3_VRF_ID,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_VRF_ID } },
+
+	{ CBGP_PEER3_LOCAL_AS,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_LOCAL_AS } },
+
+	{ CBGP_PEER3_LOCAL_IDENTIFIER,
+	  ASN_IPADDRESS,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_LOCAL_IDENTIFIER } },
+
+	{ CBGP_PEER3_REMOTE_PORT,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_REMOTE_PORT } },
+
+	{ CBGP_PEER3_REMOTE_AS,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_REMOTE_AS } },
+
+	{ CBGP_PEER3_REMOTE_IDENTIFIER,
+	  ASN_IPADDRESS,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_REMOTE_IDENTIFIER } },
+
+	{ CBGP_PEER3_IN_UPDATES,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_IN_UPDATES } },
+
+	{ CBGP_PEER3_OUT_UPDATES,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_OUT_UPDATES } },
+
+	{ CBGP_PEER3_IN_TOTAL_MESSAGES,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_IN_TOTAL_MESSAGES } },
+
+	{ CBGP_PEER3_OUT_TOTAL_MESSAGES,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_OUT_TOTAL_MESSAGES } },
+
+	{ CBGP_PEER3_LAST_ERROR,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_LAST_ERROR } },
+
+	{ CBGP_PEER3_TYPE,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_TYPE } },
+
+	{ CBGP_PEER3_FSM_ESTABLISHED_TRANSITIONS,
+	  ASN_COUNTER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_FSM_ESTABLISHED_TRANSITIONS } },
+
+	{ CBGP_PEER3_FSM_ESTABLISHED_TIME,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_FSM_ESTABLISHED_TIME } },
+
+	{ CBGP_PEER3_CONNECT_RETRY_INTERVAL,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_CONNECT_RETRY_INTERVAL } },
+
+	{ CBGP_PEER3_HOLD_TIME,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_HOLD_TIME } },
+
+	{ CBGP_PEER3_KEEP_ALIVE,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_KEEP_ALIVE } },
+
+	{ CBGP_PEER3_HOLD_TIME_CONFIGURED,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_HOLD_TIME_CONFIGURED } },
+
+	{ CBGP_PEER3_KEEP_ALIVE_CONFIGURED,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_KEEP_ALIVE_CONFIGURED } },
+
+	{ CBGP_PEER3_MIN_AS_ORIGINATION_INTERVAL,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_MIN_AS_ORIGINATION_INTERVAL } },
+
+	{ CBGP_PEER3_MIN_ROUTE_ADVERTISEMENT_INTERVAL,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_MIN_ROUTE_ADVERTISEMENT_INTERVAL } },
+
+	{ CBGP_PEER3_IN_UPDATE_ELAPSED_TIME,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_IN_UPDATE_ELAPSED_TIME } },
+
+	{ CBGP_PEER3_REMOTE_ADDR,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_REMOTE_ADDR } },
+
+	{ CBGP_PEER3_LAST_ERROR_TXT,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_LAST_ERROR_TXT } },
+
+	{ CBGP_PEER3_PREV_STATE,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_PREV_STATE } },
+
+	{ CBGP_PEER3_VRF_NAME,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_VRF_NAME } },
+
+	{ CBGP_PEER3_STATE,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_STATE } },
+
+
+	{ CBGP_PEER3_ADMIN_STATUS,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_ADMIN_STATUS } },
+
+	{ CBGP_PEER3_NEGOTIATED_VERSION,
+	  ASN_INTEGER,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_NEGOTIATED_VERSION } },
+
+	{ CBGP_PEER3_LOCAL_ADDR,
+	  ASN_OCTET_STR,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_LOCAL_ADDR } },
+
+	{ CBGP_PEER3_LOCAL_PORT,
+	  ASN_UNSIGNED,
+	  RONLY,
+	  cbgp4Peer3Table,
+	  5,
+	  { CISCO_BGP4_MIB_OBJECTS, CBGP_PEER, CBGP_PEER3_TABLE, CBGP_PEER3_ENTRY,
+	    CBGP_PEER3_LOCAL_PORT } },
+	/* cbgpRouteTable - OID .1.3.6.1.4.1.9.9.187.1.1.1.1
+	 * 
+	 * INDEX columns (1-6) - normally not-accessible in MIB, but implemented
+	 * as read-only for compatibility with some SNMP managers
+	 */
+    {CBGP_ROUTE_AFI,
+     ASN_INTEGER,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_AFI}},
+
+    {CBGP_ROUTE_SAFI,
+     ASN_INTEGER,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_SAFI}},
+
+    {CBGP_ROUTE_PEER_TYPE,
+     ASN_INTEGER,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_PEER_TYPE}},
+
+    {CBGP_ROUTE_PEER,
+     ASN_OCTET_STR,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_PEER}},
+
+    {CBGP_ROUTE_ADDR_PREFIX,
+     ASN_OCTET_STR,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_ADDR_PREFIX}},
+
+    {CBGP_ROUTE_ADDR_PREFIX_LEN,
+     ASN_UNSIGNED,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_ADDR_PREFIX_LEN}},
+
+	/* Data columns (7-19) */
+    {CBGP_ROUTE_ORIGIN,
+     ASN_INTEGER,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_ORIGIN}},
+
+    {CBGP_ROUTE_AS_PATH_SEGMENT,
+     ASN_OCTET_STR,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_AS_PATH_SEGMENT}},
+
+    {CBGP_ROUTE_NEXT_HOP,
+     ASN_OCTET_STR,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_NEXT_HOP}},
+
+    {CBGP_ROUTE_MED_PRESENT,
+     ASN_INTEGER,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_MED_PRESENT}},
+
+    {CBGP_ROUTE_MULTI_EXIT_DISC,
+     ASN_UNSIGNED,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_MULTI_EXIT_DISC}},
+
+    {CBGP_ROUTE_LOCAL_PREF_PRESENT,
+     ASN_INTEGER,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_LOCAL_PREF_PRESENT}},
+
+    {CBGP_ROUTE_LOCAL_PREF,
+     ASN_UNSIGNED,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_LOCAL_PREF}},
+
+    {CBGP_ROUTE_ATOMIC_AGGREGATE,
+     ASN_INTEGER,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_ATOMIC_AGGREGATE}},
+
+    {CBGP_ROUTE_AGGREGATOR_AS,
+     ASN_UNSIGNED,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_AGGREGATOR_AS}},
+
+    {CBGP_ROUTE_AGGREGATOR_ADDR_TYPE,
+     ASN_INTEGER,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_AGGREGATOR_ADDR_TYPE}},
+
+    {CBGP_ROUTE_AGGREGATOR_ADDR,
+     ASN_OCTET_STR,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_AGGREGATOR_ADDR}},
+
+    {CBGP_ROUTE_BEST,
+     ASN_INTEGER,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_BEST}},
+
+    {CBGP_ROUTE_UNKNOWN_ATTR,
+     ASN_OCTET_STR,
+     RONLY,
+     cbgp4RouteTable,
+     5,
+     {CISCO_BGP4_MIB_OBJECTS, CBGP_ROUTE, CBGP_ROUTE_TABLE, CBGP_ROUTE_ENTRY,
+      CBGP_ROUTE_UNKNOWN_ATTR}},
+};
+
+/*
+ * Send legacy cbgpFsmStateChange (1) or cbgpBackwardTransition (2) traps.
+ * These notifications include varbinds from both BGP4-MIB and CISCO-BGP4-MIB,
+ * so we construct the varbinds manually via send_v2trap.
+ *
+ * OBJECTS for both notifications:
+ *   bgpPeerLastError     (BGP4-MIB 1.3.6.1.2.1.15.3.1.14)
+ *   bgpPeerState         (BGP4-MIB 1.3.6.1.2.1.15.3.1.2)
+ *   cbgpPeerLastErrorTxt (CISCO-BGP4-MIB .1.2.1.1.7)
+ *   cbgpPeerPrevState    (CISCO-BGP4-MIB .1.2.1.1.8)
+ */
+static void cbgp4_send_legacy_trap(struct peer *peer, uint8_t trap_type)
+{
+	int ret;
+	struct in_addr addr;
+	netsnmp_variable_list *vars = NULL;
+
+	oid snmptrap_oid[] = {1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0};
+	size_t snmptrap_oid_len = sizeof(snmptrap_oid) / sizeof(oid);
+
+	oid notif_oid[] = {CBGP4MIB, CBGP_NOTIFY_PREFIX, 0};
+	size_t notif_oid_len = sizeof(notif_oid) / sizeof(oid);
+
+	if (sockunion_family(&peer->connection->su) != AF_INET)
+		return;
+
+	ret = inet_aton(peer->host, &addr);
+	if (ret == 0)
+		return;
+
+	notif_oid[notif_oid_len - 1] = trap_type;
+
+	snmp_varlist_add_variable(&vars, snmptrap_oid, snmptrap_oid_len,
+				  ASN_OBJECT_ID, (uint8_t *)notif_oid,
+				  notif_oid_len * sizeof(oid));
+
+	/* bgpPeerLastError.<peerAddr> from BGP4-MIB */
+	{
+		oid vb_oid[] = {1, 3, 6, 1, 2, 1, 15, 3, 1, 14,
+				0, 0, 0, 0};
+		size_t vb_oid_len = sizeof(vb_oid) / sizeof(oid);
+		uint8_t last_error[2] = {0, 0};
+
+		oid_copy_in_addr(&vb_oid[10], &addr);
+		if (peer->last_reset == PEER_DOWN_NOTIFY_RECEIVED) {
+			last_error[0] = peer->notify.code;
+			last_error[1] = peer->notify.subcode;
+		}
+		snmp_varlist_add_variable(&vars, vb_oid, vb_oid_len,
+					  ASN_OCTET_STR, last_error,
+					  sizeof(last_error));
+	}
+
+	/* bgpPeerState.<peerAddr> from BGP4-MIB */
+	{
+		oid vb_oid[] = {1, 3, 6, 1, 2, 1, 15, 3, 1, 2,
+				0, 0, 0, 0};
+		size_t vb_oid_len = sizeof(vb_oid) / sizeof(oid);
+		long state = peer->connection->status;
+
+		oid_copy_in_addr(&vb_oid[10], &addr);
+		snmp_varlist_add_variable(&vars, vb_oid, vb_oid_len,
+					  ASN_INTEGER, (uint8_t *)&state,
+					  sizeof(state));
+	}
+
+	/* cbgpPeerLastErrorTxt.<peerAddr> from CISCO-BGP4-MIB */
+	{
+		oid vb_oid[] = {CBGP4MIB, CISCO_BGP4_MIB_OBJECTS, CBGP_PEER,
+				CBGP_PEER_TABLE, CBGP_PEER_ENTRY,
+				CBGP_PEER_LAST_ERROR_TXT, 0, 0, 0, 0};
+		size_t vb_oid_len = sizeof(vb_oid) / sizeof(oid);
+		const char *error_txt = "";
+		char msg_buf[255];
+
+		oid_copy_in_addr(&vb_oid[vb_oid_len - IN_ADDR_SIZE], &addr);
+		if (peer->last_reset == PEER_DOWN_NOTIFY_RECEIVED &&
+		    peer->notify.code == BGP_NOTIFY_CEASE &&
+		    (peer->notify.subcode ==
+			     BGP_NOTIFY_CEASE_ADMIN_SHUTDOWN ||
+		     peer->notify.subcode ==
+			     BGP_NOTIFY_CEASE_ADMIN_RESET)) {
+			error_txt = bgp_notify_admin_message(
+				msg_buf, sizeof(msg_buf),
+				(uint8_t *)peer->notify.data,
+				peer->notify.length);
+		}
+		snmp_varlist_add_variable(&vars, vb_oid, vb_oid_len,
+					  ASN_OCTET_STR,
+					  (const uint8_t *)error_txt,
+					  strlen(error_txt));
+	}
+
+	/* cbgpPeerPrevState.<peerAddr> from CISCO-BGP4-MIB */
+	{
+		oid vb_oid[] = {CBGP4MIB, CISCO_BGP4_MIB_OBJECTS, CBGP_PEER,
+				CBGP_PEER_TABLE, CBGP_PEER_ENTRY,
+				CBGP_PEER_PREV_STATE, 0, 0, 0, 0};
+		size_t vb_oid_len = sizeof(vb_oid) / sizeof(oid);
+		long prev_state = peer->connection->ostatus;
+
+		oid_copy_in_addr(&vb_oid[vb_oid_len - IN_ADDR_SIZE], &addr);
+		snmp_varlist_add_variable(&vars, vb_oid, vb_oid_len,
+					  ASN_INTEGER,
+					  (uint8_t *)&prev_state,
+					  sizeof(prev_state));
+	}
+
+	send_v2trap(vars);
+	snmp_free_varbind(vars);
+	smux_events_update();
+}
+
+/*
+ * Hook callback for peer_status_changed.
+ * Fires on every BGP FSM state change.
+ *
+ * Sends:
+ *   cbgpFsmStateChange (1)                 - legacy IPv4, every change
+ *   cbgpPeer2FsmStateChange (7)            - IPv4/IPv6, every change
+ *   cbgpPeer2EstablishedNotification (5)   - IPv4/IPv6, OpenConfirm→Established
+ */
+int cbgpPeerStatusChanged(struct peer *peer)
+{
+	oid index[sizeof(oid) * (IN6_ADDR_SIZE + 1)];
+	int index_len;
+
+	if (!smux_enabled())
+		return 0;
+
+	cbgp4_send_legacy_trap(peer, CBGP_FSM_STATE_CHANGE);
+
+	index_len = cbgp4_build_peer2_index(peer, index);
+	if (!index_len)
+		return 0;
+
+	smux_trap(cbgp4_variables, array_size(cbgp4_variables),
+		  cbgp4_trap_oid, array_size(cbgp4_trap_oid),
+		  cbgp4_oid, sizeof(cbgp4_oid) / sizeof(oid),
+		  index, index_len,
+		  cbgpPeer2FsmTrapList, array_size(cbgpPeer2FsmTrapList),
+		  CBGP_PEER2_FSM_STATE_CHANGE);
+
+	if ((peer->connection->ostatus == OpenConfirm) && peer_established(peer->connection))
+		smux_trap(cbgp4_variables, array_size(cbgp4_variables),
+			  cbgp4_trap_oid, array_size(cbgp4_trap_oid),
+			  cbgp4_oid, sizeof(cbgp4_oid) / sizeof(oid),
+			  index, index_len,
+			  cbgpPeer2TrapList, array_size(cbgpPeer2TrapList),
+			  CBGP_PEER2_ESTABLISHED_NOTIFICATION);
+
+	return 0;
+}
+
+/*
+ * Hook callback for peer_backward_transition.
+ * Fires when BGP FSM transitions from Established to a lower state.
+ *
+ * Sends:
+ *   cbgpBackwardTransition (2)               - legacy IPv4
+ *   cbgpPeer2BackwardTransNotification (6)   - IPv4/IPv6
+ *   cbgpPeer2BackwardTransition (8)          - IPv4/IPv6
+ */
+int cbgpPeerBackwardTransition(struct peer *peer)
+{
+	oid index[sizeof(oid) * (IN6_ADDR_SIZE + 1)];
+	int index_len;
+
+	if (!smux_enabled())
+		return 0;
+
+	cbgp4_send_legacy_trap(peer, CBGP_BACKWARD_TRANSITION);
+
+	index_len = cbgp4_build_peer2_index(peer, index);
+	if (!index_len)
+		return 0;
+
+	smux_trap(cbgp4_variables, array_size(cbgp4_variables),
+		  cbgp4_trap_oid, array_size(cbgp4_trap_oid),
+		  cbgp4_oid, sizeof(cbgp4_oid) / sizeof(oid),
+		  index, index_len,
+		  cbgpPeer2TrapList, array_size(cbgpPeer2TrapList),
+		  CBGP_PEER2_BACKWARD_TRANS_NOTIFICATION);
+
+	smux_trap(cbgp4_variables, array_size(cbgp4_variables),
+		  cbgp4_trap_oid, array_size(cbgp4_trap_oid),
+		  cbgp4_oid, sizeof(cbgp4_oid) / sizeof(oid),
+		  index, index_len,
+		  cbgpPeer2FsmTrapList, array_size(cbgpPeer2FsmTrapList),
+		  CBGP_PEER2_BACKWARD_TRANSITION);
+
+	return 0;
+}
+
+/*
+ * Trap objects for cbgpPrefixThresholdExceeded (3)
+ * OBJECTS: cbgpPeerPrefixAdminLimit, cbgpPeerPrefixThreshold
+ */
+static struct trap_object cbgpPfxThreshExceededTrapList[] = {
+	{5, {CISCO_BGP4_MIB_OBJECTS, CBGP_PEER,
+	     CBGP_PEER_ADDR_FAMILY_PREFIX_TABLE,
+	     CBGP_PEER_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER_PREFIX_ADMIN_LIMIT}},
+	{5, {CISCO_BGP4_MIB_OBJECTS, CBGP_PEER,
+	     CBGP_PEER_ADDR_FAMILY_PREFIX_TABLE,
+	     CBGP_PEER_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER_PREFIX_THRESHOLD}},
+};
+
+/*
+ * Trap objects for cbgpPrefixThresholdClear (4)
+ * OBJECTS: cbgpPeerPrefixAdminLimit, cbgpPeerPrefixClearThreshold
+ */
+static struct trap_object cbgpPfxThreshClearTrapList[] = {
+	{5, {CISCO_BGP4_MIB_OBJECTS, CBGP_PEER,
+	     CBGP_PEER_ADDR_FAMILY_PREFIX_TABLE,
+	     CBGP_PEER_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER_PREFIX_ADMIN_LIMIT}},
+	{5, {CISCO_BGP4_MIB_OBJECTS, CBGP_PEER,
+	     CBGP_PEER_ADDR_FAMILY_PREFIX_TABLE,
+	     CBGP_PEER_ADDR_FAMILY_PREFIX_ENTRY,
+	     CBGP_PEER_PREFIX_CLEAR_THRESHOLD}},
+};
+
+/*
+ * Trap objects for cbgpPeer2PrefixThresholdExceeded (9)
+ * OBJECTS: cbgpPeer2PrefixAdminLimit, cbgpPeer2PrefixThreshold
+ */
+static struct trap_object cbgpPeer2PfxThreshExceededTrapList[] = {
+	{5, {CISCO_BGP4_MIB_OBJECTS, CBGP_PEER,
+	     CBGP_PEER2_ADDR_FAMILY_PREFIX_TABLE,
+	     CBGP_PEER2_ADDR_FAMILY_PREFIX_ENTRY,
+	     CBGP_PEER2_PREFIX_ADMIN_LIMIT}},
+	{5, {CISCO_BGP4_MIB_OBJECTS, CBGP_PEER,
+	     CBGP_PEER2_ADDR_FAMILY_PREFIX_TABLE,
+	     CBGP_PEER2_ADDR_FAMILY_PREFIX_ENTRY, CBGP_PEER2_PREFIX_THRESHOLD}},
+};
+
+/*
+ * Trap objects for cbgpPeer2PrefixThresholdClear (10)
+ * OBJECTS: cbgpPeer2PrefixAdminLimit, cbgpPeer2PrefixClearThreshold
+ */
+static struct trap_object cbgpPeer2PfxThreshClearTrapList[] = {
+	{5, {CISCO_BGP4_MIB_OBJECTS, CBGP_PEER,
+	     CBGP_PEER2_ADDR_FAMILY_PREFIX_TABLE,
+	     CBGP_PEER2_ADDR_FAMILY_PREFIX_ENTRY,
+	     CBGP_PEER2_PREFIX_ADMIN_LIMIT}},
+	{5, {CISCO_BGP4_MIB_OBJECTS, CBGP_PEER,
+	     CBGP_PEER2_ADDR_FAMILY_PREFIX_TABLE,
+	     CBGP_PEER2_ADDR_FAMILY_PREFIX_ENTRY,
+	     CBGP_PEER2_PREFIX_CLEAR_THRESHOLD}},
+};
+
+int cbgpPrefixThresholdExceeded(struct peer *peer, afi_t afi, safi_t safi)
+{
+	oid index[sizeof(oid) * (IN6_ADDR_SIZE + 3)];
+	int index_len;
+	iana_afi_t pkt_afi;
+	iana_safi_t pkt_safi;
+
+	if (!smux_enabled())
+		return 0;
+
+	bgp_map_afi_safi_int2iana(afi, safi, &pkt_afi, &pkt_safi);
+
+	/* Legacy trap (3) - IPv4 peers only */
+	if (sockunion_family(&peer->connection->su) == AF_INET) {
+		oid legacy_index[IN_ADDR_SIZE + 2];
+
+		oid_copy_in_addr(legacy_index, &peer->connection->su.sin.sin_addr);
+		legacy_index[IN_ADDR_SIZE] = pkt_afi;
+		legacy_index[IN_ADDR_SIZE + 1] = pkt_safi;
+
+		smux_trap(cbgp4_variables, array_size(cbgp4_variables),
+			  cbgp4_trap_oid, array_size(cbgp4_trap_oid),
+			  cbgp4_oid, sizeof(cbgp4_oid) / sizeof(oid),
+			  legacy_index, IN_ADDR_SIZE + 2,
+			  cbgpPfxThreshExceededTrapList,
+			  array_size(cbgpPfxThreshExceededTrapList),
+			  CBGP_PREFIX_THRESHOLD_EXCEEDED);
+	}
+
+	/* Peer2 trap (9) - all peers */
+	index_len = cbgp4_build_peer2_index(peer, index);
+	if (!index_len)
+		return 0;
+	index[index_len] = pkt_afi;
+	index[index_len + 1] = pkt_safi;
+	index_len += 2;
+
+	smux_trap(cbgp4_variables, array_size(cbgp4_variables),
+		  cbgp4_trap_oid, array_size(cbgp4_trap_oid),
+		  cbgp4_oid, sizeof(cbgp4_oid) / sizeof(oid),
+		  index, index_len,
+		  cbgpPeer2PfxThreshExceededTrapList,
+		  array_size(cbgpPeer2PfxThreshExceededTrapList),
+		  CBGP_PEER2_PREFIX_THRESHOLD_EXCEEDED);
+
+	return 0;
+}
+
+int cbgpPrefixThresholdClear(struct peer *peer, afi_t afi, safi_t safi)
+{
+	oid index[sizeof(oid) * (IN6_ADDR_SIZE + 3)];
+	int index_len;
+	iana_afi_t pkt_afi;
+	iana_safi_t pkt_safi;
+
+	if (!smux_enabled())
+		return 0;
+
+	bgp_map_afi_safi_int2iana(afi, safi, &pkt_afi, &pkt_safi);
+
+	/* Legacy trap (4) - IPv4 peers only */
+	if (sockunion_family(&peer->connection->su) == AF_INET) {
+		oid legacy_index[IN_ADDR_SIZE + 2];
+
+		oid_copy_in_addr(legacy_index, &peer->connection->su.sin.sin_addr);
+		legacy_index[IN_ADDR_SIZE] = pkt_afi;
+		legacy_index[IN_ADDR_SIZE + 1] = pkt_safi;
+
+		smux_trap(cbgp4_variables, array_size(cbgp4_variables),
+			  cbgp4_trap_oid, array_size(cbgp4_trap_oid),
+			  cbgp4_oid, sizeof(cbgp4_oid) / sizeof(oid),
+			  legacy_index, IN_ADDR_SIZE + 2,
+			  cbgpPfxThreshClearTrapList,
+			  array_size(cbgpPfxThreshClearTrapList),
+			  CBGP_PREFIX_THRESHOLD_CLEAR);
+	}
+
+	/* Peer2 trap (10) - all peers */
+	index_len = cbgp4_build_peer2_index(peer, index);
+	if (!index_len)
+		return 0;
+	index[index_len] = pkt_afi;
+	index[index_len + 1] = pkt_safi;
+	index_len += 2;
+
+	smux_trap(cbgp4_variables, array_size(cbgp4_variables),
+		  cbgp4_trap_oid, array_size(cbgp4_trap_oid),
+		  cbgp4_oid, sizeof(cbgp4_oid) / sizeof(oid),
+		  index, index_len,
+		  cbgpPeer2PfxThreshClearTrapList,
+		  array_size(cbgpPeer2PfxThreshClearTrapList),
+		  CBGP_PEER2_PREFIX_THRESHOLD_CLEAR);
+
+	return 0;
+}
+
+int bgp_snmp_cbgp4_init(struct event_loop *tm)
+{
+	REGISTER_MIB("mibI/cbgp4", cbgp4_variables, variable, cbgp4_oid);
+	return 0;
+}

--- a/bgpd/bgp_snmp_cbgp4.h
+++ b/bgpd/bgp_snmp_cbgp4.h
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* CISCO-BGP4-MIB SNMP support
+ * Copyright (C) 2025 Sudharsan Rajagopalan
+ */
+
+
+#ifndef _FRR_BGP_SNMP_CBGP4_H_
+#define _FRR_BGP_SNMP_CBGP4_H_
+
+
+/* cbgp4 */
+#define CBGP4MIB 1, 3, 6, 1, 4, 1, 9, 9, 187
+
+/* ciscoBgp4MIB Notifications */
+#define CBGP_NOTIFY_PREFIX			    0
+#define CBGP_FSM_STATE_CHANGE			    1
+#define CBGP_BACKWARD_TRANSITION		    2
+#define CBGP_PREFIX_THRESHOLD_EXCEEDED		    3
+#define CBGP_PREFIX_THRESHOLD_CLEAR		    4
+#define CBGP_PEER2_ESTABLISHED_NOTIFICATION	    5
+#define CBGP_PEER2_BACKWARD_TRANS_NOTIFICATION	    6
+#define CBGP_PEER2_FSM_STATE_CHANGE		    7
+#define CBGP_PEER2_BACKWARD_TRANSITION		    8
+#define CBGP_PEER2_PREFIX_THRESHOLD_EXCEEDED	    9
+#define CBGP_PEER2_PREFIX_THRESHOLD_CLEAR	    10
+
+/* ciscoBgp4MIBObjects OIDs */
+#define CISCO_BGP4_MIB_OBJECTS 1
+
+/* cbgpGlobal OIDs (.1.3.6.1.4.1.9.9.187.1.3) */
+#define CBGP_GLOBAL 3
+#define CBGP_NOTIFS_ENABLE 1
+#define CBGP_LOCAL_AS 2
+
+/* cbgp4RouteEntry Offset
+ * offset 1.3.6.1.4.1.9.9.187.1.1.1.x.(1|2).(4|16) = 15
+ */
+#define CBGP_ROUTE_ENTRY_OFFSET 15
+
+/* cbgpRouteTable OIDs */
+#define CBGP_ROUTE			1
+#define CBGP_ROUTE_TABLE		1
+#define CBGP_ROUTE_ENTRY		1
+#define CBGP_ROUTE_AFI			1
+#define CBGP_ROUTE_MED_PRESENT		10
+#define CBGP_ROUTE_MULTI_EXIT_DISC	11
+#define CBGP_ROUTE_LOCAL_PREF_PRESENT	12
+#define CBGP_ROUTE_LOCAL_PREF		13
+#define CBGP_ROUTE_ATOMIC_AGGREGATE	14
+#define CBGP_ROUTE_AGGREGATOR_AS	15
+#define CBGP_ROUTE_AGGREGATOR_ADDR_TYPE 16
+#define CBGP_ROUTE_AGGREGATOR_ADDR	17
+#define CBGP_ROUTE_BEST			18
+#define CBGP_ROUTE_UNKNOWN_ATTR		19
+#define CBGP_ROUTE_SAFI			2
+#define CBGP_ROUTE_PEER_TYPE		3
+#define CBGP_ROUTE_PEER			4
+#define CBGP_ROUTE_ADDR_PREFIX		5
+#define CBGP_ROUTE_ADDR_PREFIX_LEN	6
+#define CBGP_ROUTE_ORIGIN		7
+#define CBGP_ROUTE_AS_PATH_SEGMENT	8
+#define CBGP_ROUTE_NEXT_HOP		9
+
+
+/* cbgp4PeerEntry Offset
+ * offset 1.3.6.1.4.1.9.9.187.1.2.1.x.PEER_IPV4_ADDR
+ */
+/* cbgp4Peer2Entry Offset
+ * offset 1.3.6.1.4.1.9.9.187.1.2.5.x.INETADDRTYPE.PEER_ADDR
+ */
+/* cbgp4Peer3Entry Offset
+ * offset 1.3.6.1.4.1.9.9.187.1.2.9.x.VRFID.INETADDRTYPE.PEER_ADDR
+ */
+#define CBGP_PEER_TABLE_INDEX_OFFSET 13
+
+#define CBGP_PEER_TABLE_MAX_INDEX_LEN  4
+#define CBGP_PEER2_TABLE_MAX_INDEX_LEN 17
+#define CBGP_PEER3_TABLE_MAX_INDEX_LEN 18
+
+/* cbgpPeerTable OIDs */
+#define CBGP_PEER		    2
+#define CBGP_PEER_TABLE		    1
+#define CBGP_PEER_ENTRY		    1
+#define CBGP_PEER_PREFIX_ACCEPTED   1
+#define CBGP_PEER_PREFIX_DENIED	    2
+#define CBGP_PEER_PREFIX_LIMIT	    3
+#define CBGP_PEER_PREFIX_ADVERTISED 4
+#define CBGP_PEER_PREFIX_SUPPRESSED 5
+#define CBGP_PEER_PREFIX_WITHDRAWN  6
+#define CBGP_PEER_LAST_ERROR_TXT    7
+#define CBGP_PEER_PREV_STATE	    8
+
+/* cbgpPeerCapsTable OIDs */
+#define CBGP_PEER_CAPS_TABLE 2
+#define CBGP_PEER_CAPS_ENTRY 1
+#define CBGP_PEER_CAP_CODE   1
+#define CBGP_PEER_CAP_INDEX  2
+#define CBGP_PEER_CAP_VALUE  3
+
+/* cbgpPeerAddrFamilyEntry Offset
+ * offset 1.3.6.1.4.1.9.9.187.1.2.1.x.(1|2).(4|16).x.y.z = 17
+ */
+#define CBGP_PEER_ADDR_FAMILY_ENTRY_OFFSET 17
+
+/* cbgpPeerAddrFamilyTable OIDs */
+#define CBGP_PEER_ADDR_FAMILY_TABLE 3
+#define CBGP_PEER_ADDR_FAMILY_ENTRY 1
+#define CBGP_PEER_ADDR_FAMILY_AFI   1
+#define CBGP_PEER_ADDR_FAMILY_SAFI  2
+#define CBGP_PEER_ADDR_FAMILY_NAME  3
+
+/* cbgpPeerAddrFamilyPrefixTable OIDs */
+#define CBGP_PEER_ADDR_FAMILY_PREFIX_TABLE 4
+#define CBGP_PEER_ADDR_FAMILY_PREFIX_ENTRY 1
+#define CBGP_PEER_ACCEPTED_PREFIXES	   1
+#define CBGP_PEER_DENIED_PREFIXES	   2
+#define CBGP_PEER_PREFIX_ADMIN_LIMIT	   3
+#define CBGP_PEER_PREFIX_THRESHOLD	   4
+#define CBGP_PEER_PREFIX_CLEAR_THRESHOLD   5
+#define CBGP_PEER_ADVERTISED_PREFIXES	   6
+#define CBGP_PEER_SUPPRESSED_PREFIXES	   7
+#define CBGP_PEER_WITHDRAWN_PREFIXES	   8
+
+/* cbgpPeer2Table OIDs */
+#define CBGP_PEER2_TABLE			    5
+#define CBGP_PEER2_ENTRY			    1
+#define CBGP_PEER2_TYPE				    1
+#define CBGP_PEER2_REMOTE_PORT			    10
+#define CBGP_PEER2_REMOTE_AS			    11
+#define CBGP_PEER2_REMOTE_IDENTIFIER		    12
+#define CBGP_PEER2_IN_UPDATES			    13
+#define CBGP_PEER2_OUT_UPDATES			    14
+#define CBGP_PEER2_IN_TOTAL_MESSAGES		    15
+#define CBGP_PEER2_OUT_TOTAL_MESSAGES		    16
+#define CBGP_PEER2_LAST_ERROR			    17
+#define CBGP_PEER2_FSM_ESTABLISHED_TRANSITIONS	    18
+#define CBGP_PEER2_FSM_ESTABLISHED_TIME		    19
+#define CBGP_PEER2_REMOTE_ADDR			    2
+#define CBGP_PEER2_CONNECT_RETRY_INTERVAL	    20
+#define CBGP_PEER2_HOLD_TIME			    21
+#define CBGP_PEER2_KEEP_ALIVE			    22
+#define CBGP_PEER2_HOLD_TIME_CONFIGURED		    23
+#define CBGP_PEER2_KEEP_ALIVE_CONFIGURED	    24
+#define CBGP_PEER2_MIN_AS_ORIGINATION_INTERVAL	    25
+#define CBGP_PEER2_MIN_ROUTE_ADVERTISEMENT_INTERVAL 26
+#define CBGP_PEER2_IN_UPDATE_ELAPSED_TIME	    27
+#define CBGP_PEER2_LAST_ERROR_TXT		    28
+#define CBGP_PEER2_PREV_STATE			    29
+#define CBGP_PEER2_STATE			    3
+#define CBGP_PEER2_ADMIN_STATUS			    4
+#define CBGP_PEER2_NEGOTIATED_VERSION		    5
+#define CBGP_PEER2_LOCAL_ADDR			    6
+#define CBGP_PEER2_LOCAL_PORT			    7
+#define CBGP_PEER2_LOCAL_AS			    8
+#define CBGP_PEER2_LOCAL_IDENTIFIER		    9
+
+/* cbgpPeer2CapsTable OIDs */
+#define CBGP_PEER2_CAPS_TABLE 6
+#define CBGP_PEER2_CAPS_ENTRY 1
+#define CBGP_PEER2_CAP_CODE   1
+#define CBGP_PEER2_CAP_INDEX  2
+#define CBGP_PEER2_CAP_VALUE  3
+
+/* cbgpPeer2AddrFamilyTable OIDs */
+#define CBGP_PEER2_ADDR_FAMILY_TABLE 7
+#define CBGP_PEER2_ADDR_FAMILY_ENTRY 1
+#define CBGP_PEER2_ADDR_FAMILY_AFI   1
+#define CBGP_PEER2_ADDR_FAMILY_SAFI  2
+#define CBGP_PEER2_ADDR_FAMILY_NAME  3
+
+/* cbgpPeer2AddrFamilyPrefixTable OIDs */
+#define CBGP_PEER2_ADDR_FAMILY_PREFIX_TABLE 8
+#define CBGP_PEER2_ADDR_FAMILY_PREFIX_ENTRY 1
+#define CBGP_PEER2_ACCEPTED_PREFIXES	    1
+#define CBGP_PEER2_DENIED_PREFIXES	    2
+#define CBGP_PEER2_PREFIX_ADMIN_LIMIT	    3
+#define CBGP_PEER2_PREFIX_THRESHOLD	    4
+#define CBGP_PEER2_PREFIX_CLEAR_THRESHOLD   5
+#define CBGP_PEER2_ADVERTISED_PREFIXES	    6
+#define CBGP_PEER2_SUPPRESSED_PREFIXES	    7
+#define CBGP_PEER2_WITHDRAWN_PREFIXES	    8
+
+/* cbgpPeer3Table OIDs */
+#define CBGP_PEER3_TABLE			    9
+#define CBGP_PEER3_ENTRY			    1
+#define CBGP_PEER3_VRF_ID			    1
+#define CBGP_PEER3_LOCAL_AS			    10
+#define CBGP_PEER3_LOCAL_IDENTIFIER		    11
+#define CBGP_PEER3_REMOTE_PORT			    12
+#define CBGP_PEER3_REMOTE_AS			    13
+#define CBGP_PEER3_REMOTE_IDENTIFIER		    14
+#define CBGP_PEER3_IN_UPDATES			    15
+#define CBGP_PEER3_OUT_UPDATES			    16
+#define CBGP_PEER3_IN_TOTAL_MESSAGES		    17
+#define CBGP_PEER3_OUT_TOTAL_MESSAGES		    18
+#define CBGP_PEER3_LAST_ERROR			    19
+#define CBGP_PEER3_TYPE				    2
+#define CBGP_PEER3_FSM_ESTABLISHED_TRANSITIONS	    20
+#define CBGP_PEER3_FSM_ESTABLISHED_TIME		    21
+#define CBGP_PEER3_CONNECT_RETRY_INTERVAL	    22
+#define CBGP_PEER3_HOLD_TIME			    23
+#define CBGP_PEER3_KEEP_ALIVE			    24
+#define CBGP_PEER3_HOLD_TIME_CONFIGURED		    25
+#define CBGP_PEER3_KEEP_ALIVE_CONFIGURED	    26
+#define CBGP_PEER3_MIN_AS_ORIGINATION_INTERVAL	    27
+#define CBGP_PEER3_MIN_ROUTE_ADVERTISEMENT_INTERVAL 28
+#define CBGP_PEER3_IN_UPDATE_ELAPSED_TIME	    29
+#define CBGP_PEER3_REMOTE_ADDR			    3
+#define CBGP_PEER3_LAST_ERROR_TXT		    30
+#define CBGP_PEER3_PREV_STATE			    31
+#define CBGP_PEER3_VRF_NAME			    4
+#define CBGP_PEER3_STATE			    5
+#define CBGP_PEER3_ADMIN_STATUS			    6
+#define CBGP_PEER3_NEGOTIATED_VERSION		    7
+#define CBGP_PEER3_LOCAL_ADDR			    8
+#define CBGP_PEER3_LOCAL_PORT			    9
+
+extern int bgp_snmp_cbgp4_init(struct event_loop *tm);
+extern int cbgpPeerStatusChanged(struct peer *peer);
+extern int cbgpPeerBackwardTransition(struct peer *peer);
+extern int cbgpPrefixThresholdExceeded(struct peer *peer, afi_t afi,
+				       safi_t safi);
+extern int cbgpPrefixThresholdClear(struct peer *peer, afi_t afi,
+				    safi_t safi);
+
+#endif /* _FRR_BGP_SNMP_CBGP4_H_ */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -223,7 +223,7 @@ static enum node_type bgp_node_type(afi_t afi, safi_t safi)
 	return BGP_IPV4_NODE;
 }
 
-static const char *get_afi_safi_vty_str(afi_t afi, safi_t safi)
+const char *get_afi_safi_vty_str(afi_t afi, safi_t safi)
 {
 	if (afi == AFI_IP) {
 		if (safi == SAFI_UNICAST)
@@ -16002,6 +16002,10 @@ static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
 		if (paf && PAF_SUBGRP(paf))
 			json_object_int_add(json_addr, "sentPrefixCounter",
 						(PAF_SUBGRP(paf))->scount);
+		json_object_int_add(json_addr, "withdrawnPrefixCounter",
+				    p->pwithdraw_cnt[afi][safi]);
+		json_object_int_add(json_addr, "suppressedPrefixCounter",
+				    p->psuppressed_cnt[afi][safi]);
 
 		json_object_int_add(json_addr, "receivedPrefixDup",
 				    p->pcount_dup[afi][pfx_rcd_safi]);
@@ -16312,6 +16316,12 @@ static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
 		else
 			vty_out(vty, "  %u accepted prefixes, %u received duplicates\n",
 				p->pcount[afi][pfx_rcd_safi], p->pcount_dup[afi][pfx_rcd_safi]);
+		if (p->pwithdraw_cnt[afi][pfx_rcd_safi])
+			vty_out(vty, "  %u withdrawn prefixes\n",
+				p->pwithdraw_cnt[afi][pfx_rcd_safi]);
+		if (p->psuppressed_cnt[afi][pfx_rcd_safi])
+			vty_out(vty, "  %u suppressed prefixes\n",
+				p->psuppressed_cnt[afi][pfx_rcd_safi]);
 
 		/* maximum-prefix-out */
 		if (CHECK_FLAG(p->af_flags[afi][safi],

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -158,6 +158,7 @@ extern void bgp_clear_soft_in(struct bgp *bgp, afi_t afi, safi_t safi);
 extern void bgp_vty_init(void);
 extern void community_alias_vty(void);
 extern const char *get_afi_safi_str(afi_t afi, safi_t safi, bool for_json);
+extern const char *get_afi_safi_vty_str(afi_t afi, safi_t safi);
 extern int bgp_get_vty(struct bgp **bgp, as_t *as, const char *name,
 		       enum bgp_instance_type inst_type, const char *as_pretty,
 		       enum asnotation_mode asnotation);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -5,6 +5,8 @@
 
 #include <zebra.h>
 
+#include <limits.h>
+
 #include "prefix.h"
 #include "frrevent.h"
 #include "buffer.h"
@@ -1091,7 +1093,7 @@ int peer_af_delete(struct peer *peer, afi_t afi, safi_t safi)
 }
 
 /* Peer comparison function for sorting.  */
-int peer_cmp(struct peer *p1, struct peer *p2)
+int peer_cmp(const struct peer *p1, const struct peer *p2)
 {
 	if (p1->group && !p2->group)
 		return -1;
@@ -1112,6 +1114,63 @@ int peer_cmp(struct peer *p1, struct peer *p2)
 		return strcmp(p1->group->name, p2->group->name);
 
 	return sockunion_cmp(&p1->connection->su, &p2->connection->su);
+}
+
+/* Peer comparison function for sorting by address.
+ * Used for SNMP peer enumeration to ensure deterministic ordering.
+ * Must handle:
+ * - IPv6 link-local addresses (same addr, different ifindex)
+ * - Unnumbered interfaces
+ * - Deterministic ordering across runs (no pointer comparison)
+ *
+ * Note: This is only used within a single BGP instance's peer_by_addr list,
+ * so VRF comparison is not needed.
+ */
+int peer_cmp_addr(const struct peer *p1, const struct peer *p2)
+{
+	int cmp;
+
+	/* Compare addresses using sockunion_cmp */
+	if (p1->connection && p2->connection) {
+		cmp = sockunion_cmp(&p1->connection->su, &p2->connection->su);
+		if (cmp)
+			return cmp;
+
+		/* For IPv6 link-local, also compare scope_id/ifindex */
+		if (p1->connection->su.sa.sa_family == AF_INET6 &&
+		    IN6_IS_ADDR_LINKLOCAL(&p1->connection->su.sin6.sin6_addr)) {
+			if (p1->connection->su.sin6.sin6_scope_id !=
+			    p2->connection->su.sin6.sin6_scope_id) {
+				return (p1->connection->su.sin6.sin6_scope_id <
+					p2->connection->su.sin6.sin6_scope_id)
+					       ? -1
+					       : 1;
+			}
+		}
+	} else if (p1->connection && !p2->connection) {
+		return -1;
+	} else if (!p1->connection && p2->connection) {
+		return 1;
+	}
+
+	/* If addresses are identical (or both AF_UNSPEC), use host string for
+	 * deterministic ordering. This handles unnumbered and other edge cases.
+	 */
+	if (p1->host && p2->host) {
+		cmp = strcmp(p1->host, p2->host);
+		if (cmp != 0)
+			return cmp;
+	}
+
+	/* As last resort, compare remote AS and local AS */
+	if (p1->as != p2->as)
+		return (p1->as < p2->as) ? -1 : 1;
+
+	if (p1->local_as != p2->local_as)
+		return (p1->local_as < p2->local_as) ? -1 : 1;
+
+	/* Truly identical peers - should not happen in practice */
+	return 0;
 }
 
 static unsigned int connection_hash_key_make(const void *p)
@@ -2177,6 +2236,23 @@ void bgp_recalculate_all_bestpaths(struct bgp *bgp)
 	}
 }
 
+/* Insert peer into peer_by_addr list in sorted order */
+static void peer_by_addr_insert_sorted(struct bgp *bgp, struct peer *peer)
+{
+	struct peer *iter, *prev = NULL;
+
+	frr_each (peer_by_addr_list, &bgp->peer_by_addr, iter) {
+		if (peer_cmp_addr(peer, iter) < 0)
+			break;
+		prev = iter;
+	}
+
+	if (prev)
+		peer_by_addr_list_add_after(&bgp->peer_by_addr, prev, peer);
+	else
+		peer_by_addr_list_add_head(&bgp->peer_by_addr, peer);
+}
+
 /*
  * Create new BGP peer.
  *
@@ -2226,6 +2302,8 @@ struct peer *peer_create(union sockunion *su, const char *conf_if, struct bgp *b
 	peer = peer_lock(peer); /* bgp peer list reference */
 	peer->group = group;
 	listnode_add_sort(bgp->peer, peer);
+	peer = peer_lock(peer);
+	peer_by_addr_insert_sorted(bgp, peer);
 
 	if (config_node)
 		SET_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE);
@@ -2816,6 +2894,7 @@ static bool non_peergroup_deactivate_af(struct peer *peer, afi_t afi,
 						    CAPABILITY_CODE_MP, CAPABILITY_ACTION_UNSET);
 				bgp_clear_route(peer, afi, safi);
 				peer->pcount[afi][safi] = 0;
+				peer->pfiltered[afi][safi] = 0;
 			} else {
 				peer_notify_config_change(peer->connection);
 			}
@@ -3065,19 +3144,30 @@ int peer_delete(struct peer *peer)
 
 	bgp_timer_set(peer->connection); /* stops all timers for Deleted */
 
-	/* Delete from all peer list. */
-	if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)
-	    && (pn = listnode_lookup(bgp->peer, peer))) {
+	/* Delete from peer address list. */
+	if (peer_by_addr_list_count(&bgp->peer_by_addr) > 0 &&
+	    peer_by_addr_list_member(&bgp->peer_by_addr, peer)) {
 		/*
-		 * Removing from the list node first because
-		 * peer_unlock *can* call peer_delete( I know,
-		 * I know ).  So let's remove it and in
-		 * the su recalculate function we'll ensure
-		 * it's in there or not.
+		 * Remove the node before peer_unlock(); that call can indirectly invoke
+		 * peer_delete() again, so we must ensure the list entry is already gone.
 		 */
-		list_delete_node(bgp->peer, pn);
-		hash_release(bgp->connectionhash, peer->connection);
+		peer_by_addr_list_del(&bgp->peer_by_addr, peer);
 		peer_unlock(peer); /* bgp peer list reference */
+	}
+
+
+	/* Delete from all peer list. */
+	if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
+		pn = listnode_lookup(bgp->peer, peer);
+		if (pn) {
+			/*
+			 * Remove the node before peer_unlock(); that call can indirectly invoke
+			 * peer_delete() again, so we must ensure the list entry is already gone.
+			 */
+			list_delete_node(bgp->peer, pn);
+			hash_release(bgp->connectionhash, peer->connection);
+			peer_unlock(peer); /* bgp peer list reference */
+		}
 	}
 
 	/* Local and remote addresses. */
@@ -3811,6 +3901,7 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 	SET_FLAG(bgp->peer_self->cap, PEER_CAP_AS4_ADV);
 
 	bgp->peer = list_new();
+	peer_by_addr_list_init(&bgp->peer_by_addr);
 
 peer_init:
 	bgp->peer->cmp = (int (*)(void *, void *))peer_cmp;
@@ -3822,6 +3913,7 @@ peer_init:
 
 	if (!bgp->group)
 		bgp->group = list_new();
+
 	bgp->group->cmp = (int (*)(void *, void *))peer_group_cmp;
 
 	FOREACH_AFI_SAFI (afi, safi) {
@@ -4766,6 +4858,7 @@ void bgp_free(struct bgp *bgp)
 	QOBJ_UNREG(bgp);
 
 	list_delete(&bgp->group);
+	peer_by_addr_list_fini(&bgp->peer_by_addr);
 	list_delete(&bgp->peer);
 
 	hash_clean_and_free(&bgp->connectionhash, NULL);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -158,6 +158,7 @@ struct bgp_master {
 #define BGP_OPT_TRAPS_RFC4273            (1 << 3)
 #define BGP_OPT_TRAPS_BGP4MIBV2          (1 << 4)
 #define BGP_OPT_TRAPS_RFC4382		 (1 << 5)
+#define BGP_OPT_TRAPS_CISCO_BGP4	 (1 << 6)
 
 	uint64_t updgrp_idspace;
 	uint64_t subgrp_idspace;
@@ -502,6 +503,9 @@ PREDECL_RBTREE_UNIQ(bgp_mplsvpn_nh_label_bind_cache);
 /* List of peers that have connection errors in the io pthread */
 PREDECL_DLIST(bgp_peer_conn_errlist);
 
+/* List of peers sorted by address for SNMP */
+PREDECL_DLIST(peer_by_addr_list);
+
 /* List of info about peers that are being cleared from BGP RIBs in a batch */
 PREDECL_DLIST(bgp_clearing_info);
 
@@ -588,6 +592,7 @@ struct bgp {
 
 	/* BGP peer. */
 	struct list *peer;
+	struct peer_by_addr_list_head peer_by_addr;
 	struct hash *connectionhash;
 
 	/* BGP peer group.  */
@@ -1573,6 +1578,9 @@ struct peer {
 	 */
 	int lock;
 
+	/* List item for peer_by_addr list (sorted by address for SNMP) */
+	struct peer_by_addr_list_item peer_by_addr_item;
+
 	/* BGP peer group.  */
 	struct peer_group *group;
 
@@ -2118,6 +2126,15 @@ struct peer {
 	/* Duplicate update count */
 	uint32_t pcount_dup[AFI_MAX][SAFI_MAX];
 
+	/* Filtered prefix count */
+	uint32_t pfiltered[AFI_MAX][SAFI_MAX];
+
+	/* Withdrawn prefix count (received from peer) per AFI/SAFI */
+	uint32_t pwithdraw_cnt[AFI_MAX][SAFI_MAX];
+
+	/* Currently suppressed (damped) routes per AFI/SAFI */
+	uint32_t psuppressed_cnt[AFI_MAX][SAFI_MAX];
+
 	/* Max prefix count. */
 	uint32_t pmax[AFI_MAX][SAFI_MAX];
 	uint8_t pmax_threshold[AFI_MAX][SAFI_MAX];
@@ -2296,6 +2313,7 @@ struct peer {
 	QOBJ_FIELDS;
 };
 DECLARE_QOBJ_TYPE(peer);
+DECLARE_DLIST(peer_by_addr_list, struct peer, peer_by_addr_item);
 
 /* Inherit peer attribute from peer-group. */
 #define PEER_ATTR_INHERIT(peer, group, attr)                                   \
@@ -2931,7 +2949,8 @@ extern void bgp_route_map_terminate(void);
 
 extern bool bgp_route_map_has_extcommunity_rt(const struct route_map *map);
 
-extern int peer_cmp(struct peer *p1, struct peer *p2);
+extern int peer_cmp(const struct peer *p1, const struct peer *p2);
+extern int peer_cmp_addr(const struct peer *p1, const struct peer *p2);
 
 extern int bgp_map_afi_safi_iana2int(iana_afi_t pkt_afi, iana_safi_t pkt_safi,
 				     afi_t *afi, safi_t *safi);
@@ -3350,10 +3369,8 @@ extern void bgp_recalculate_afi_safi_bestpaths(struct bgp *bgp, afi_t afi,
 					       safi_t safi);
 extern void peer_on_policy_change(struct peer *peer, afi_t afi, safi_t safi,
 				  int outbound);
-extern bool bgp_path_attribute_discard(struct peer *peer, char *buf,
-				       size_t size);
-extern bool bgp_path_attribute_treat_as_withdraw(struct peer *peer, char *buf,
-						 size_t size);
+extern bool bgp_path_attribute_discard(struct peer *peer, char *buf, size_t size);
+extern bool bgp_path_attribute_treat_as_withdraw(struct peer *peer, char *buf, size_t size);
 
 extern void srv6_function_free(struct bgp_srv6_function *func);
 

--- a/bgpd/subdir.am
+++ b/bgpd/subdir.am
@@ -162,6 +162,7 @@ noinst_HEADERS += \
 	bgpd/bgp_snmp.h \
 	bgpd/bgp_snmp_bgp4.h \
 	bgpd/bgp_snmp_bgp4v2.h \
+	bgpd/bgp_snmp_cbgp4.h \
 	bgpd/bgp_table.h \
 	bgpd/bgp_updgrp.h \
 	bgpd/bgp_vpn.h \
@@ -203,7 +204,7 @@ bgpd_bgp_btoa_SOURCES = bgpd/bgp_btoa.c
 bgpd_bgpd_LDADD = bgpd/libbgp.a $(RFPLDADD) lib/libfrr.la $(LIBYANG_LIBS) $(LIBCAP) $(LIBM) $(UST_LIBS)
 bgpd_bgp_btoa_LDADD = bgpd/libbgp.a $(RFPLDADD) lib/libfrr.la $(LIBYANG_LIBS) $(LIBCAP) $(LIBM) $(UST_LIBS)
 
-bgpd_bgpd_snmp_la_SOURCES = bgpd/bgp_snmp_bgp4.c bgpd/bgp_snmp_bgp4v2.c bgpd/bgp_snmp.c bgpd/bgp_mplsvpn_snmp.c
+bgpd_bgpd_snmp_la_SOURCES = bgpd/bgp_snmp_bgp4.c bgpd/bgp_snmp_bgp4v2.c bgpd/bgp_snmp.c bgpd/bgp_mplsvpn_snmp.c bgpd/bgp_snmp_cbgp4.c
 bgpd_bgpd_snmp_la_CFLAGS = $(AM_CFLAGS) $(SNMP_CFLAGS) -std=gnu11
 bgpd_bgpd_snmp_la_LDFLAGS = $(MODULE_LDFLAGS)
 bgpd_bgpd_snmp_la_LIBADD = lib/libfrrsnmp.la

--- a/doc/user/snmp.rst
+++ b/doc/user/snmp.rst
@@ -15,6 +15,79 @@ on daemon startup. Refer to :ref:`loadable-module-support` on the latter.  If
 you do not start the daemons with snmp module support snmp will not work
 properly.
 
+BGP SNMP Support
+================
+
+In addition to the standard BGP4-MIB (:rfc:`4273`) and BGP4V2-MIB, FRR also
+supports the CISCO-BGP4-MIB (OID 1.3.6.1.4.1.9.9.187). This MIB provides
+extended information about BGP peers, capabilities, routes, and prefix
+statistics organized by address family, along with SNMP trap notifications
+for peer state changes and prefix threshold events.
+
+**Global Scalars** (cbgpGlobal, .1.3):
+
+- cbgpLocalAs: the local BGP AS number
+- cbgpNotifsEnable: bitmask of enabled notification types
+
+**Peer Tables** (cbgpPeerTable, cbgpPeer2Table, cbgpPeer3Table):
+
+- Peer state, timers, connection details, and FSM transition counters
+- Accepted, denied, filtered, withdrawn, and suppressed prefix counts per AFI/SAFI
+- Advertised prefix counts per address family
+- Prefix limits, thresholds, and clear thresholds per address family
+- MinASOriginationInterval and MinRouteAdvertisementInterval
+- Previous state and last error text for diagnostics
+- cbgpPeer3Table adds VRF-aware indexing
+
+**Capability Tables** (cbgpPeerCapsTable, cbgpPeer2CapsTable):
+
+- Received BGP capabilities reconstructed from parsed peer state
+- Zero per-peer memory overhead (capabilities built on demand)
+- Supported capability codes: MP (1), Route Refresh (2), Extended Nexthop (5),
+  Extended Message (6), Role (9), Graceful Restart (64), 4-byte AS (65),
+  Dynamic (67), Addpath (69), Enhanced Route Refresh (70), LLGR (71),
+  FQDN (73), Route Refresh Old/Cisco (128)
+
+**Address Family Prefix Tables** (cbgpPeerAddrFamilyPrefixTable, cbgpPeer2AddrFamilyPrefixTable):
+
+- Accepted, denied, advertised, withdrawn, and suppressed prefix counters
+- Prefix admin limit and threshold/clear-threshold configuration
+- Per-AFI/SAFI granularity (IPv4/IPv6 unicast, L2VPN EVPN, etc.)
+
+**Route Table** (cbgpRouteTable):
+
+- Loc-RIB entries for IPv4 unicast, IPv6 unicast, and L2VPN EVPN
+- Per-route attributes: origin, AS-path, next-hop, MED, local-pref
+- Aggregator information, best-path indication, and unknown attributes (transit data)
+- EVPN route type encoding (Type-1 through Type-5)
+
+**Trap Notifications** (cbgpNotifications, .0):
+
+Ten notification types are supported:
+
+- cbgpFsmStateChange (1): legacy IPv4 peer FSM state change
+- cbgpBackwardTransition (2): legacy IPv4 backward transition (Established to lower)
+- cbgpPrefixThresholdExceeded (3): legacy IPv4 prefix threshold exceeded
+- cbgpPrefixThresholdClear (4): legacy IPv4 prefix threshold cleared
+- cbgpPeer2EstablishedNotification (5): IPv4/IPv6 peer established
+- cbgpPeer2BackwardTransNotification (6): IPv4/IPv6 backward transition
+- cbgpPeer2FsmStateChange (7): IPv4/IPv6 FSM state change
+- cbgpPeer2BackwardTransition (8): IPv4/IPv6 backward transition (extended)
+- cbgpPeer2PrefixThresholdExceeded (9): IPv4/IPv6 prefix threshold exceeded
+- cbgpPeer2PrefixThresholdClear (10): IPv4/IPv6 prefix threshold cleared
+
+To receive traps, configure ``trap2sink`` in your ``snmpd.conf``::
+
+   trap2sink localhost public
+
+Then enable CISCO-BGP4-MIB traps in FRR (disabled by default)::
+
+   bgp snmp traps cisco-bgp4
+
+The CISCO-BGP4-MIB is particularly useful for monitoring BGP peers and
+routes in multi-protocol environments and provides more detailed statistics
+than the standard BGP4-MIB.
+
 .. _getting-and-installing-an-snmp-agent:
 
 Getting and installing an SNMP agent
@@ -121,6 +194,41 @@ An example below is how to query SNMP for BGP:
 
       $ # BGP4-MIB (https://www.circitor.fr/Mibs/Mib/B/BGP4-MIB.mib)
       $ snmpwalk -c public -v2c -On -Ln localhost .1.3.6.1.2.1.15
+
+      $ # CISCO-BGP4-MIB (https://raw.githubusercontent.com/cisco/cisco-mibs/main/v2/CISCO-BGP4-MIB.my)
+
+      $ # cbgpRouteTable - BGP route entries (IPv4/IPv6 unicast, L2VPN EVPN)
+      $ snmpwalk -c public -v2c -On -Ln localhost .1.3.6.1.4.1.9.9.187.1.1.1
+
+      $ # cbgpPeerTable - Basic peer information (legacy IPv4, deprecated)
+      $ snmpwalk -c public -v2c -On -Ln localhost .1.3.6.1.4.1.9.9.187.1.2.1
+
+      $ # cbgpPeerCapsTable - Legacy peer capabilities (IPv4 only)
+      $ snmpwalk -c public -v2c -On -Ln localhost .1.3.6.1.4.1.9.9.187.1.2.2
+
+      $ # cbgpPeerAddrFamilyTable - Address families supported by peer
+      $ snmpwalk -c public -v2c -On -Ln localhost .1.3.6.1.4.1.9.9.187.1.2.3
+
+      $ # cbgpPeerAddrFamilyPrefixTable - Prefix counts per address family
+      $ snmpwalk -c public -v2c -On -Ln localhost .1.3.6.1.4.1.9.9.187.1.2.4
+
+      $ # cbgpPeer2Table - Extended peer information (IPv4 and IPv6)
+      $ snmpwalk -c public -v2c -On -Ln localhost .1.3.6.1.4.1.9.9.187.1.2.5
+
+      $ # cbgpPeer2CapsTable - Peer2 capabilities (IPv4 and IPv6)
+      $ snmpwalk -c public -v2c -On -Ln localhost .1.3.6.1.4.1.9.9.187.1.2.6
+
+      $ # cbgpPeer2AddrFamilyTable - Address families for Peer2 entries
+      $ snmpwalk -c public -v2c -On -Ln localhost .1.3.6.1.4.1.9.9.187.1.2.7
+
+      $ # cbgpPeer2AddrFamilyPrefixTable - Prefix counts for Peer2 entries
+      $ snmpwalk -c public -v2c -On -Ln localhost .1.3.6.1.4.1.9.9.187.1.2.8
+
+      $ # cbgpPeer3Table - VRF-aware peer information
+      $ snmpwalk -c public -v2c -On -Ln localhost .1.3.6.1.4.1.9.9.187.1.2.9
+
+      $ # cbgpGlobal - Global scalars (local AS, notification enables)
+      $ snmpwalk -c public -v2c -On -Ln localhost .1.3.6.1.4.1.9.9.187.1.3
 
       $ # BGP4V2-MIB (http://www.circitor.fr/Mibs/Mib/B/BGP4V2-MIB.mib)
       $ # Information about the peers (bgp4V2PeerTable):

--- a/lib/iana_afi.h
+++ b/lib/iana_afi.h
@@ -20,6 +20,9 @@ extern "C" {
  * The rationale is that the protocol (IANA) values may be sparse and are
  * not optimal for use in data-structure sizing.
  * Note: Only useful (i.e., supported) values are defined below.
+ *
+ * IMPORTANT: When adding new IANA AFI/SAFI values, you MUST also update:
+ *   - bgpd/bgp_snmp.c: iana_ordered_afi_safi[] map for SNMP OID ordering
  */
 typedef enum {
 	IANA_AFI_RESERVED = 0,

--- a/tests/topotests/bgp_snmp_cbgp4mib/r1/bgp_summary.json
+++ b/tests/topotests/bgp_snmp_cbgp4mib/r1/bgp_summary.json
@@ -1,0 +1,108 @@
+{
+  "default": {
+    "ipv4Unicast": {
+      "peers": {
+        "10.10.0.2": {
+          "pfxRcd": 3,
+          "pfxSnt": 7,
+          "state": "Established"
+        },
+        "fd00::2": {
+          "pfxRcd": 5,
+          "pfxSnt": 7,
+          "state": "Established"
+        },
+        "10.10.1.2": {
+          "pfxRcd": 5,
+          "pfxSnt": 7,
+          "state": "Established"
+        },
+        "fd00:1::2": {
+          "pfxRcd": 5,
+          "pfxSnt": 7,
+          "state": "Established"
+        },
+        "10.10.2.2": {
+          "pfxRcd": 5,
+          "pfxSnt": 7,
+          "state": "Established"
+        },
+        "fd00:2::2": {
+          "pfxRcd": 5,
+          "pfxSnt": 7,
+          "state": "Established"
+        },
+        "10.10.6.2": {
+          "pfxRcd": 1,
+          "state": "Established"
+        }
+      }
+    },
+    "ipv6Unicast": {
+      "peers": {
+        "fd00::2": {
+          "pfxRcd": 1,
+          "pfxSnt": 1,
+          "state": "Established"
+        },
+        "fd00:1::2": {
+          "pfxRcd": 1,
+          "pfxSnt": 1,
+          "state": "Established"
+        },
+        "fd00:2::2": {
+          "pfxRcd": 1,
+          "pfxSnt": 1,
+          "state": "Established"
+        }
+      }
+    },
+    "ipv4Vpn": {
+      "peers": {
+        "10.10.0.2": {
+          "state": "Established"
+        },
+        "10.10.1.2": {
+          "state": "Established"
+        },
+        "10.10.2.2": {
+          "state": "Established"
+        }
+      }
+    },
+    "l2VpnEvpn": {
+      "peers": {
+        "10.10.0.2": {
+          "state": "Established"
+        },
+        "10.10.1.2": {
+          "state": "Established"
+        },
+        "10.10.2.2": {
+          "state": "Established"
+        }
+      }
+    }
+  },
+  "RED": {
+    "ipv4Unicast": {
+      "peers": {
+        "10.10.3.2":{
+          "pfxRcd": 3,
+          "pfxSnt": 3,
+          "state": "Established"
+        },
+        "10.10.4.2":{
+          "pfxRcd": 3,
+          "pfxSnt": 3,
+          "state": "Established"
+        },
+        "10.10.5.2":{
+          "pfxRcd": 3,
+          "pfxSnt": 3,
+          "state": "Established"
+        }
+      }
+    }
+  }
+}

--- a/tests/topotests/bgp_snmp_cbgp4mib/r1/frr.conf
+++ b/tests/topotests/bgp_snmp_cbgp4mib/r1/frr.conf
@@ -1,0 +1,148 @@
+!
+hostname r1
+!
+interface lo
+ ip address 192.0.2.1/32
+ ipv6 address fd01:1::1/128
+!
+interface r1-eth0
+ ip address 10.10.0.1/24
+ ipv6 address fd00:0::1/64
+ no shutdown
+!
+interface r1-eth1
+ ip address 10.10.1.1/24
+ ipv6 address fd00:1::1/64
+ no shutdown
+!
+interface r1-eth2
+ ip address 10.10.2.1/24
+ ipv6 address fd00:2::1/64
+ no shutdown
+!
+vrf RED
+ exit-vrf
+!
+interface r1-eth3 vrf RED
+ ip address 10.10.3.1/24
+ no shutdown
+!
+interface r1-eth4 vrf RED
+ ip address 10.10.4.1/24
+ no shutdown
+!
+interface r1-eth5 vrf RED
+ ip address 10.10.5.1/24
+ no shutdown
+!
+interface r1-eth6
+ ip address 10.10.6.1/24
+ no shutdown
+!
+ip route 172.16.11.0/24 Null0
+ip route 172.16.12.0/24 Null0
+ip route 172.16.13.0/24 Null0
+ip route 172.16.14.0/24 Null0
+ip route 172.16.15.0/24 Null0
+!
+ip prefix-list FILTER_ROUTES seq 5 permit 172.16.2.0/24
+ip prefix-list FILTER_ROUTES seq 10 permit 172.16.4.0/24
+!
+route-map FILTER_IN deny 10
+ match ip address prefix-list FILTER_ROUTES
+exit
+route-map FILTER_IN permit 20
+exit
+!
+ip prefix-list FILTER_EBGP seq 5 permit 192.168.2.0/24
+!
+route-map FILTER_EBGP_IN deny 10
+ match ip address prefix-list FILTER_EBGP
+exit
+route-map FILTER_EBGP_IN permit 20
+exit
+!
+router bgp 65001
+ bgp router-id 192.0.2.1
+ bgp bestpath compare-routerid
+ neighbor 10.10.0.2 remote-as 65001
+ neighbor fd00:0:0:0::2 remote-as 65001
+ neighbor PEER_GROUP_1 peer-group
+ neighbor PEER_GROUP_1 remote-as 65001
+ neighbor PEER_GROUP_2 peer-group
+ neighbor PEER_GROUP_2 remote-as 65001
+ neighbor PEER_GROUP_3 peer-group
+ neighbor PEER_GROUP_3 remote-as 65001
+ neighbor PEER_GROUP_4 peer-group
+ neighbor PEER_GROUP_4 remote-as 65001
+ neighbor 10.10.1.2 peer-group PEER_GROUP_4
+ neighbor 10.10.2.2 peer-group PEER_GROUP_3
+ neighbor fd00:1::2 peer-group PEER_GROUP_2
+ neighbor fd00:2::2 peer-group PEER_GROUP_1
+ neighbor 10.10.6.2 remote-as 65002
+ !
+ address-family ipv4 unicast
+  network 192.0.2.1/32
+  network 172.16.11.0/24
+  network 172.16.12.0/24
+  network 172.16.13.0/24
+  network 172.16.14.0/24
+  network 172.16.15.0/24
+  neighbor 10.10.0.2 soft-reconfiguration inbound
+  neighbor 10.10.0.2 route-map FILTER_IN in
+  neighbor 10.10.0.2 maximum-prefix 10
+  neighbor 10.10.6.2 soft-reconfiguration inbound
+  neighbor 10.10.6.2 route-map FILTER_EBGP_IN in
+  neighbor 10.10.6.2 maximum-prefix 10
+  neighbor 10.10.6.2 next-hop-self
+  neighbor fd00::2 maximum-prefix 10
+  neighbor PEER_GROUP_4 maximum-prefix 10
+  neighbor PEER_GROUP_3 maximum-prefix 10
+  neighbor PEER_GROUP_2 maximum-prefix 10
+  neighbor PEER_GROUP_1 maximum-prefix 10
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  neighbor fd00::2 activate
+  neighbor fd00::2 maximum-prefix 10
+  neighbor PEER_GROUP_1 activate
+  neighbor PEER_GROUP_1 maximum-prefix 10
+  neighbor PEER_GROUP_2 activate
+  neighbor PEER_GROUP_2 maximum-prefix 10
+  network fd01:1::1/128
+ exit-address-family
+ !
+ address-family ipv4 vpn
+  neighbor 10.10.0.2 activate
+  neighbor 10.10.1.2 activate
+  neighbor 10.10.2.2 activate
+ exit-address-family
+ !
+ address-family l2vpn evpn
+  neighbor 10.10.0.2 activate
+  neighbor 10.10.1.2 activate
+  neighbor 10.10.2.2 activate
+  advertise-all-vni
+ exit-address-family
+!
+router bgp 65001 vrf RED
+ bgp router-id 10.10.3.1
+ neighbor 10.10.3.2 remote-as 65001
+ neighbor VRF_PEER_GROUP_1 peer-group
+ neighbor VRF_PEER_GROUP_1 remote-as 65001
+ neighbor VRF_PEER_GROUP_2 peer-group
+ neighbor VRF_PEER_GROUP_2 remote-as 65001
+ !
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  redistribute connected
+ exit-address-family
+ !
+ neighbor 10.10.5.2 peer-group VRF_PEER_GROUP_1
+ neighbor 10.10.4.2 peer-group VRF_PEER_GROUP_2
+!
+agentx
+!

--- a/tests/topotests/bgp_snmp_cbgp4mib/r1/snmpd.conf
+++ b/tests/topotests/bgp_snmp_cbgp4mib/r1/snmpd.conf
@@ -1,0 +1,19 @@
+agentAddress 127.0.0.1,[::1]
+
+group public_group v1 public
+group public_group v2c public
+access public_group "" any noauth prefix all all none
+
+rocommunity public default
+
+view all included .1
+
+iquerySecName frr
+rouser frr
+
+trap2sink localhost public
+
+master agentx
+
+agentXSocket /etc/frr/agentx
+agentXPerms 777 755 root frr

--- a/tests/topotests/bgp_snmp_cbgp4mib/r2/frr.conf
+++ b/tests/topotests/bgp_snmp_cbgp4mib/r2/frr.conf
@@ -1,0 +1,122 @@
+!
+hostname r2
+!
+interface lo
+ ip address 192.0.2.2/32
+ ipv6 address fd01:2::1/128
+!
+interface r2-eth0
+ ip address 10.10.0.2/24
+ ipv6 address fd00:0::2/64
+ no shutdown
+!
+interface r2-eth1
+ ip address 10.10.1.2/24
+ ipv6 address fd00:1::2/64
+!
+interface r2-eth2
+ ip address 10.10.2.2/24
+ ipv6 address fd00:2::2/64
+!
+vrf RED
+ exit-vrf
+!
+interface r2-eth3 vrf RED
+ ip address 10.10.3.2/24
+ no shutdown
+!
+interface r2-eth4 vrf RED
+ ip address 10.10.4.2/24
+ no shutdown
+!
+interface r2-eth5 vrf RED
+ ip address 10.10.5.2/24
+ no shutdown
+!
+ip route 172.16.1.0/24 Null0
+ip route 172.16.2.0/24 Null0
+ip route 172.16.3.0/24 Null0
+ip route 172.16.4.0/24 Null0
+ip route 172.16.5.0/24 Null0
+!
+router bgp 65001
+ bgp router-id 192.0.2.2
+ neighbor 10.10.0.1 remote-as 65001
+ neighbor fd00::1 remote-as 65001
+ neighbor PEER_GROUP_1 peer-group
+ neighbor PEER_GROUP_1 remote-as 65001
+ neighbor PEER_GROUP_2 peer-group
+ neighbor PEER_GROUP_2 remote-as 65001
+ neighbor PEER_GROUP_3 peer-group
+ neighbor PEER_GROUP_3 remote-as 65001
+ neighbor PEER_GROUP_4 peer-group
+ neighbor PEER_GROUP_4 remote-as 65001
+ neighbor 10.10.1.1 peer-group PEER_GROUP_4
+ neighbor 10.10.2.1 peer-group PEER_GROUP_3
+ neighbor fd00:1::1 peer-group PEER_GROUP_2
+ neighbor fd00:2::1 peer-group PEER_GROUP_1
+ !
+ address-family ipv4 unicast
+  network 172.16.1.0/24
+  network 172.16.2.0/24
+  network 172.16.3.0/24
+  network 172.16.4.0/24
+  network 172.16.5.0/24
+  neighbor 10.10.0.1 maximum-prefix 10
+  neighbor fd00::1 maximum-prefix 10
+  neighbor PEER_GROUP_4 maximum-prefix 10
+  neighbor PEER_GROUP_3 maximum-prefix 10
+  neighbor PEER_GROUP_2 maximum-prefix 10
+  neighbor PEER_GROUP_1 maximum-prefix 10
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  neighbor fd00::1 activate
+  neighbor fd00::1 maximum-prefix 10
+  neighbor PEER_GROUP_1 activate
+  neighbor PEER_GROUP_1 maximum-prefix 10
+  neighbor PEER_GROUP_2 activate
+  neighbor PEER_GROUP_2 maximum-prefix 10
+  network fd01:2::1/128
+ exit-address-family
+ !
+ address-family ipv4 vpn
+  neighbor 10.10.0.1 activate
+  neighbor 10.10.1.1 activate
+  neighbor 10.10.2.1 activate
+ exit-address-family
+ !
+ address-family l2vpn evpn
+  neighbor 10.10.0.1 activate
+  neighbor 10.10.1.1 activate
+  neighbor 10.10.2.1 activate
+  advertise-all-vni
+ exit-address-family
+ !
+ address-family ipv4 rtfilter
+  neighbor 10.10.0.1 activate
+  neighbor 10.10.1.1 activate
+  neighbor 10.10.2.1 activate
+ exit-address-family
+!
+router bgp 65001 vrf RED
+ bgp router-id 10.10.3.2
+ neighbor 10.10.3.1 remote-as 65001
+ neighbor VRF_PEER_GROUP_1 peer-group
+ neighbor VRF_PEER_GROUP_1 remote-as 65001
+ neighbor VRF_PEER_GROUP_2 peer-group
+ neighbor VRF_PEER_GROUP_2 remote-as 65001
+ !
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  redistribute connected
+ exit-address-family
+ !
+ neighbor 10.10.5.1 peer-group VRF_PEER_GROUP_1
+ neighbor 10.10.4.1 peer-group VRF_PEER_GROUP_2
+!
+agentx
+!

--- a/tests/topotests/bgp_snmp_cbgp4mib/r3/frr.conf
+++ b/tests/topotests/bgp_snmp_cbgp4mib/r3/frr.conf
@@ -1,0 +1,37 @@
+!
+hostname r3
+!
+interface lo
+ ip address 192.0.2.3/32
+!
+interface r3-eth0
+ ip address 10.10.6.2/24
+ no shutdown
+!
+ip route 192.168.1.0/24 Null0
+ip route 192.168.2.0/24 Null0
+ip route 192.168.3.0/24 Null0
+ip route 192.168.4.0/24 Null0
+!
+ip prefix-list LOOP_ROUTES seq 5 permit 192.168.3.0/24
+ip prefix-list LOOP_ROUTES seq 10 permit 192.168.4.0/24
+!
+route-map PREPEND_LOOP permit 10
+ match ip address prefix-list LOOP_ROUTES
+ set as-path prepend 65001
+exit
+route-map PREPEND_LOOP permit 20
+exit
+!
+router bgp 65002
+ bgp router-id 192.0.2.3
+ neighbor 10.10.6.1 remote-as 65001
+ !
+ address-family ipv4 unicast
+  network 192.168.1.0/24
+  network 192.168.2.0/24
+  network 192.168.3.0/24
+  network 192.168.4.0/24
+  neighbor 10.10.6.1 route-map PREPEND_LOOP out
+ exit-address-family
+!

--- a/tests/topotests/bgp_snmp_cbgp4mib/test_bgp_snmp_cbgp4mib.py
+++ b/tests/topotests/bgp_snmp_cbgp4mib/test_bgp_snmp_cbgp4mib.py
@@ -1,0 +1,1900 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# Copyright (c) 2025 Cisco and/or its affiliates.
+#
+
+"""
+Exhaustive test for the CISCO-BGP4-MIB implementation, written in the style
+of FRR 8.5.4, with a dedicated VRF peering session to test cbgpPeer3Table.
+"""
+
+import os
+import sys
+import json
+
+import pytest
+import functools
+import logging
+import re 
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.snmptest import SnmpTester
+from lib import topotest
+from lib.topolog import logger  # The logger is imported from here
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.snmp]
+
+# OID Definitions
+MIB_BASE = "1.3.6.1.4.1.9.9.187.1.2"
+MIB_OBJECTS = "1.3.6.1.4.1.9.9.187.1"
+OIDS = {
+    "cbgpRouteTable": "1.3.6.1.4.1.9.9.187.1.1.1",
+    "cbgpPeerTable": f"{MIB_BASE}.1",
+    "cbgpPeerCapsTable": f"{MIB_BASE}.2",
+    "cbgpPeerAddrFamilyTable": f"{MIB_BASE}.3",
+    "cbgpPeerAddrFamilyPrefixTable": f"{MIB_BASE}.4",
+    "cbgpPeer2Table": f"{MIB_BASE}.5",
+    "cbgpPeer2CapsTable": f"{MIB_BASE}.6",
+    "cbgpPeer2AddrFamilyTable": f"{MIB_BASE}.7",
+    "cbgpPeer2AddrFamilyPrefixTable": f"{MIB_BASE}.8",
+    "cbgpPeer3Table": f"{MIB_BASE}.9",
+    "cbgpGlobal": f"{MIB_OBJECTS}.3",
+}
+
+peers_ipv4 = ["10.10.0.2", "10.10.1.2", "10.10.2.2"]
+peers_ipv6 = ["253.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2", "253.0.0.1.0.0.0.0.0.0.0.0.0.0.0.2", "253.0.0.2.0.0.0.0.0.0.0.0.0.0.0.2"]
+peers_ipv4_lcl = ["0A 0A 00 01", "0A 0A 01 01", "0A 0A 02 01"]
+peers_ipv6_lcl = ["FD 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01", "FD 00 00 01 00 00 00 00 00 00 00 00 00 00 00 01", "FD 00 00 02 00 00 00 00 00 00 00 00 00 00 00 01"]
+peers_ipv4_rmt = ["0A 0A 00 02", "0A 0A 01 02", "0A 0A 02 02"]
+peers_ipv6_rmt = ["FD 00 00 00 00 00 00 00 00 00 00 00 00 00 00 02", "FD 00 00 01 00 00 00 00 00 00 00 00 00 00 00 02", "FD 00 00 02 00 00 00 00 00 00 00 00 00 00 00 02"]
+
+ipv4_af_type = "1"
+ipv6_af_type = "2"
+ipv4_unicast_af_idx = "1.1"
+ipv6_unicast_af_idx = "2.1"
+
+
+cbgpGlobalOIDs = [
+    (rf'{OIDS["cbgpGlobal"]}.1.0', 'E0', "cbgpNotifsEnable (all enabled)"),
+    (rf'{OIDS["cbgpGlobal"]}.2.0', '65001', "cbgpLocalAs"),
+]
+
+cbgpPeerTableOIDs = []
+cbgpPeerCapsTableOIDs = []
+cbgpPeer2TableOIDs = []
+cbgpPeer2TableOIDs_v4 = []
+cbgpPeer2CapsTableOIDs = []
+cbgpPeerAddrFamilyTableOIDs = []
+cbgpPeerAddrFamilyPrefixTableOIDs = []
+cbgpPeer2AddrFamilyTableOIDs = []
+cbgpPeer2AddrFamilyTableOIDs_v4 = []
+cbgpPeer2AddrFamilyPrefixTableOIDs = []
+cbgpPeer3TableOIDs = []
+cbgpPeer3TableOIDs_v4 = []
+
+for peer_ipv4, peer_ipv6, peer_ipv4_lcl, peer_ipv6_lcl, peer_ipv4_rmt, peer_ipv6_rmt in zip(peers_ipv4, peers_ipv6, peers_ipv4_lcl, peers_ipv6_lcl, peers_ipv4_rmt, peers_ipv6_rmt):
+    # Peer 10.10.0.2 has filtering applied, others don't
+    accepted_prefixes = '3' if peer_ipv4 == '10.10.0.2' else '5'
+    denied_prefixes = '2' if peer_ipv4 == '10.10.0.2' else '0'
+    advertised_prefixes = '7'
+    
+    cbgpPeerTableOIDs.extend([
+        (rf'{OIDS["cbgpPeerTable"]}.1.7.{peer_ipv4}', '00', "cbgpPeerLastErrorTxt"),
+        (rf'{OIDS["cbgpPeerTable"]}.1.8.{peer_ipv4}', '5', "cbgpPeerPrevState (idle)"),
+    ])
+    for i in range(1, 7):
+        cbgpPeerTableOIDs.append((rf'{OIDS["cbgpPeerTable"]}.1.{i}.{peer_ipv4}', None, f"Deprecated OID .1.{i}"))
+
+    cbgpPeerAddrFamilyTableOIDs.extend([
+        (rf'{OIDS["cbgpPeerAddrFamilyTable"]}.1.1.{peer_ipv4}.{ipv4_unicast_af_idx}', '1', "cbgpPeerAddrFamilyAfi"),
+        (rf'{OIDS["cbgpPeerAddrFamilyTable"]}.1.2.{peer_ipv4}.{ipv4_unicast_af_idx}', '1', "cbgpPeerAddrFamilySafi"),
+        (rf'{OIDS["cbgpPeerAddrFamilyTable"]}.1.3.{peer_ipv4}.{ipv4_unicast_af_idx}', 'IPv4 Unicast'.encode('utf-8').hex(' ').upper() + ' 00', "cbgpPeerAddrFamilyName"),
+    ])
+
+    cbgpPeerAddrFamilyPrefixTableOIDs.extend([
+        (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.1.{peer_ipv4}.{ipv4_unicast_af_idx}', accepted_prefixes, "cbgpPeerAcceptedPrefixes"),
+        (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.2.{peer_ipv4}.{ipv4_unicast_af_idx}', denied_prefixes, "cbgpPeerDeniedPrefixes"),
+        (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.3.{peer_ipv4}.{ipv4_unicast_af_idx}', '10', "cbgpPeerPrefixAdminLimit"),
+        (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.4.{peer_ipv4}.{ipv4_unicast_af_idx}', '75', "cbgpPeerPrefixThreshold"),
+        (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.5.{peer_ipv4}.{ipv4_unicast_af_idx}', '75', "cbgpPeerPrefixClearThreshold"),
+        (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.6.{peer_ipv4}.{ipv4_unicast_af_idx}', advertised_prefixes, "cbgpPeerAdvertisedPrefixes"),
+        (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.7.{peer_ipv4}.{ipv4_unicast_af_idx}', '0', "cbgpPeerSuppressedPrefixes"),
+        (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.8.{peer_ipv4}.{ipv4_unicast_af_idx}', '0', "cbgpPeerWithdrawnPrefixes"),
+    ])
+
+    cbgpPeer2TableOIDs.extend([
+        #IPv4 Peer
+        (rf'{OIDS["cbgpPeer2Table"]}.1.1.{ipv4_af_type}.{peer_ipv4}', '1', "cbgpPeer2Type"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.2.{ipv4_af_type}.{peer_ipv4}', peer_ipv4_rmt, "cbgpPeer2RemoteAddr"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.3.{ipv4_af_type}.{peer_ipv4}', '6', "cbgpPeer2State"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.4.{ipv4_af_type}.{peer_ipv4}', '2', "cbgpPeer2AdminStatus"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.5.{ipv4_af_type}.{peer_ipv4}', '4', "cbgpPeer2NegotiatedVersion"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.6.{ipv4_af_type}.{peer_ipv4}', peer_ipv4_lcl, "cbgpPeer2LocalAddr"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.8.{ipv4_af_type}.{peer_ipv4}', '65001', "cbgpPeer2LocalAs"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.9.{ipv4_af_type}.{peer_ipv4}', '192.0.2.1', "cbgpPeer2LocalIdentifier"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.11.{ipv4_af_type}.{peer_ipv4}', '65001', "cbgpPeer2RemoteAs"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.12.{ipv4_af_type}.{peer_ipv4}', '192.0.2.2', "cbgpPeer2RemoteIdentifier"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.17.{ipv4_af_type}.{peer_ipv4}', '00 00', "cbgpPeer2LastError"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.18.{ipv4_af_type}.{peer_ipv4}', '1', "cbgpPeer2FsmEstablishedTransitions"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.20.{ipv4_af_type}.{peer_ipv4}', '30', "cbgpPeer2ConnectRetryInterval"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.21.{ipv4_af_type}.{peer_ipv4}', '180', "cbgpPeer2HoldTime"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.22.{ipv4_af_type}.{peer_ipv4}', '60', "cbgpPeer2KeepAlive"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.23.{ipv4_af_type}.{peer_ipv4}', '180', "cbgpPeer2HoldTimeConfigured"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.24.{ipv4_af_type}.{peer_ipv4}', '60', "cbgpPeer2KeepAliveConfigured"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.26.{ipv4_af_type}.{peer_ipv4}', '0', "cbgpPeer2MinRouteAdvertisementInterval"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.28.{ipv4_af_type}.{peer_ipv4}', '00', "cbgpPeer2LastErrorTxt"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.29.{ipv4_af_type}.{peer_ipv4}', '5', "cbgpPeer2PrevState (idle)"),
+        #IPv6 Peer
+        (rf'{OIDS["cbgpPeer2Table"]}.1.1.{ipv6_af_type}.{peer_ipv6}', '2', "cbgpPeer2Type"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.2.{ipv6_af_type}.{peer_ipv6}', peer_ipv6_rmt, "cbgpPeer2RemoteAddr"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.3.{ipv6_af_type}.{peer_ipv6}', '6', "cbgpPeer2State"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.4.{ipv6_af_type}.{peer_ipv6}', '2', "cbgpPeer2AdminStatus"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.5.{ipv6_af_type}.{peer_ipv6}', '4', "cbgpPeer2NegotiatedVersion"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.6.{ipv6_af_type}.{peer_ipv6}', peer_ipv6_lcl, "cbgpPeer2LocalAddr"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.8.{ipv6_af_type}.{peer_ipv6}', '65001', "cbgpPeer2LocalAs"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.9.{ipv6_af_type}.{peer_ipv6}', '192.0.2.1', "cbgpPeer2LocalIdentifier"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.11.{ipv6_af_type}.{peer_ipv6}', '65001', "cbgpPeer2RemoteAs"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.12.{ipv6_af_type}.{peer_ipv6}', '192.0.2.2', "cbgpPeer2RemoteIdentifier"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.17.{ipv6_af_type}.{peer_ipv6}', '00 00', "cbgpPeer2LastError"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.18.{ipv6_af_type}.{peer_ipv6}', '1', "cbgpPeer2FsmEstablishedTransitions"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.20.{ipv6_af_type}.{peer_ipv6}', '30', "cbgpPeer2ConnectRetryInterval"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.21.{ipv6_af_type}.{peer_ipv6}', '180', "cbgpPeer2HoldTime"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.22.{ipv6_af_type}.{peer_ipv6}', '60', "cbgpPeer2KeepAlive"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.23.{ipv6_af_type}.{peer_ipv6}', '180', "cbgpPeer2HoldTimeConfigured"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.24.{ipv6_af_type}.{peer_ipv6}', '60', "cbgpPeer2KeepAliveConfigured"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.26.{ipv6_af_type}.{peer_ipv6}', '0', "cbgpPeer2MinRouteAdvertisementInterval"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.28.{ipv6_af_type}.{peer_ipv6}', '00', "cbgpPeer2LastErrorTxt"),
+        (rf'{OIDS["cbgpPeer2Table"]}.1.29.{ipv6_af_type}.{peer_ipv6}', '5', "cbgpPeer2PrevState (idle)"),
+    ])
+        
+    cbgpPeer2AddrFamilyTableOIDs.extend([
+        (rf'{OIDS["cbgpPeer2AddrFamilyTable"]}.1.1.{ipv4_af_type}.{peer_ipv4}.{ipv4_unicast_af_idx}', '1', "cbgpPeer2AddrFamilyAfi"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyTable"]}.1.1.{ipv6_af_type}.{peer_ipv6}.{ipv4_unicast_af_idx}', '1', "cbgpPeer2AddrFamilyAfi"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyTable"]}.1.1.{ipv6_af_type}.{peer_ipv6}.{ipv6_unicast_af_idx}', '2', "cbgpPeer2AddrFamilyAfi"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyTable"]}.1.2.{ipv4_af_type}.{peer_ipv4}.{ipv4_unicast_af_idx}', '1', "cbgpPeer2AddrFamilySafi"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyTable"]}.1.2.{ipv6_af_type}.{peer_ipv6}.{ipv4_unicast_af_idx}', '1', "cbgpPeer2AddrFamilySafi"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyTable"]}.1.2.{ipv6_af_type}.{peer_ipv6}.{ipv6_unicast_af_idx}', '1', "cbgpPeer2AddrFamilySafi"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyTable"]}.1.3.{ipv4_af_type}.{peer_ipv4}.{ipv4_unicast_af_idx}', 'IPv4 Unicast'.encode('utf-8').hex(' ').upper() + ' 00', "cbgpPeer2AddrFamilyName"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyTable"]}.1.3.{ipv6_af_type}.{peer_ipv6}.{ipv4_unicast_af_idx}', 'IPv4 Unicast'.encode('utf-8').hex(' ').upper() + ' 00', "cbgpPeer2AddrFamilyName"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyTable"]}.1.3.{ipv6_af_type}.{peer_ipv6}.{ipv6_unicast_af_idx}', 'IPv6 Unicast'.encode('utf-8').hex(' ').upper() + ' 00', "cbgpPeer2AddrFamilyName"),
+    ])
+
+    cbgpPeer2AddrFamilyPrefixTableOIDs.extend([
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.1.{ipv4_af_type}.{peer_ipv4}.{ipv4_unicast_af_idx}', accepted_prefixes, "cbgpPeer2AcceptedPrefixes"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.1.{ipv6_af_type}.{peer_ipv6}.{ipv4_unicast_af_idx}', '5', "cbgpPeer2AcceptedPrefixes"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.1.{ipv6_af_type}.{peer_ipv6}.{ipv6_unicast_af_idx}', '1', "cbgpPeer2AcceptedPrefixes"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.2.{ipv4_af_type}.{peer_ipv4}.{ipv4_unicast_af_idx}', denied_prefixes, "cbgpPeer2DeniedPrefixes"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.2.{ipv6_af_type}.{peer_ipv6}.{ipv4_unicast_af_idx}', '0', "cbgpPeer2DeniedPrefixes"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.2.{ipv6_af_type}.{peer_ipv6}.{ipv6_unicast_af_idx}', '0', "cbgpPeer2DeniedPrefixes"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.3.{ipv4_af_type}.{peer_ipv4}.{ipv4_unicast_af_idx}', '10', "cbgpPeer2PrefixAdminLimit"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.3.{ipv6_af_type}.{peer_ipv6}.{ipv4_unicast_af_idx}', '10', "cbgpPeer2PrefixAdminLimit"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.3.{ipv6_af_type}.{peer_ipv6}.{ipv6_unicast_af_idx}', '10', "cbgpPeer2PrefixAdminLimit"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.4.{ipv4_af_type}.{peer_ipv4}.{ipv4_unicast_af_idx}', '75', "cbgpPeer2PrefixThreshold"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.4.{ipv6_af_type}.{peer_ipv6}.{ipv4_unicast_af_idx}', '75', "cbgpPeer2PrefixThreshold"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.4.{ipv6_af_type}.{peer_ipv6}.{ipv6_unicast_af_idx}', '75', "cbgpPeer2PrefixThreshold"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.5.{ipv4_af_type}.{peer_ipv4}.{ipv4_unicast_af_idx}', '75', "cbgpPeer2PrefixClearThreshold"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.5.{ipv6_af_type}.{peer_ipv6}.{ipv4_unicast_af_idx}', '75', "cbgpPeer2PrefixClearThreshold"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.5.{ipv6_af_type}.{peer_ipv6}.{ipv6_unicast_af_idx}', '75', "cbgpPeer2PrefixClearThreshold"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.6.{ipv4_af_type}.{peer_ipv4}.{ipv4_unicast_af_idx}', advertised_prefixes, "cbgpPeer2AdvertisedPrefixes"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.6.{ipv6_af_type}.{peer_ipv6}.{ipv4_unicast_af_idx}', advertised_prefixes, "cbgpPeer2AdvertisedPrefixes"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.6.{ipv6_af_type}.{peer_ipv6}.{ipv6_unicast_af_idx}', '1', "cbgpPeer2AdvertisedPrefixes"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.7.{ipv4_af_type}.{peer_ipv4}.{ipv4_unicast_af_idx}', '0', "cbgpPeer2SuppressedPrefixes"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.7.{ipv6_af_type}.{peer_ipv6}.{ipv4_unicast_af_idx}', '0', "cbgpPeer2SuppressedPrefixes"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.7.{ipv6_af_type}.{peer_ipv6}.{ipv6_unicast_af_idx}', '0', "cbgpPeer2SuppressedPrefixes"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.8.{ipv4_af_type}.{peer_ipv4}.{ipv4_unicast_af_idx}', '0', "cbgpPeer2WithdrawnPrefixes"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.8.{ipv6_af_type}.{peer_ipv6}.{ipv4_unicast_af_idx}', '0', "cbgpPeer2WithdrawnPrefixes"),
+        (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.8.{ipv6_af_type}.{peer_ipv6}.{ipv6_unicast_af_idx}', '0', "cbgpPeer2WithdrawnPrefixes"),
+    ])
+
+    cbgpPeer3TableOIDs.extend([
+            # --- IPv4 Peer Checks ---
+            (rf'{OIDS["cbgpPeer3Table"]}.1.2.0.{ipv4_af_type}.{peer_ipv4}', '1', "cbgpPeer3Type"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.3.0.{ipv4_af_type}.{peer_ipv4}', peer_ipv4_rmt, "cbgpPeer3RemoteAddr"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.4.0.{ipv4_af_type}.{peer_ipv4}', 'VRF default'.encode('utf-8').hex(' ').upper() + ' 00', "cbgpPeer3VrfName"), # "VRF default"
+            (rf'{OIDS["cbgpPeer3Table"]}.1.5.0.{ipv4_af_type}.{peer_ipv4}', '6', "cbgpPeer3State"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.6.0.{ipv4_af_type}.{peer_ipv4}', '2', "cbgpPeer3AdminStatus"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.7.0.{ipv4_af_type}.{peer_ipv4}', '4', "cbgpPeer3NegotiatedVersion"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.8.0.{ipv4_af_type}.{peer_ipv4}', peer_ipv4_lcl, "cbgpPeer3LocalAddr"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.10.0.{ipv4_af_type}.{peer_ipv4}', '65001', "cbgpPeer3LocalAs"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.11.0.{ipv4_af_type}.{peer_ipv4}', '192.0.2.1', "cbgpPeer3LocalIdentifier"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.13.0.{ipv4_af_type}.{peer_ipv4}', '65001', "cbgpPeer3RemoteAs"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.14.0.{ipv4_af_type}.{peer_ipv4}', '192.0.2.2', "cbgpPeer3RemoteIdentifier"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.19.0.{ipv4_af_type}.{peer_ipv4}', '00 00', "cbgpPeer3LastError"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.20.0.{ipv4_af_type}.{peer_ipv4}', '1', "cbgpPeer3FsmEstablishedTransitions"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.22.0.{ipv4_af_type}.{peer_ipv4}', '30', "cbgpPeer3ConnectRetryInterval"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.23.0.{ipv4_af_type}.{peer_ipv4}', '180', "cbgpPeer3HoldTime"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.24.0.{ipv4_af_type}.{peer_ipv4}', '60', "cbgpPeer3KeepAlive"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.25.0.{ipv4_af_type}.{peer_ipv4}', '180', "cbgpPeer3HoldTimeConfigured"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.26.0.{ipv4_af_type}.{peer_ipv4}', '60', "cbgpPeer3KeepAliveConfigured"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.28.0.{ipv4_af_type}.{peer_ipv4}', '0', "cbgpPeer3MinRouteAdvertisementInterval"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.30.0.{ipv4_af_type}.{peer_ipv4}', '00', "cbgpPeer3LastErrorTxt"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.31.0.{ipv4_af_type}.{peer_ipv4}', '5', "cbgpPeer3PrevState"),
+
+            # --- IPv6 Peer (fd00::1:0:0:2) Checks ---
+            (rf'{OIDS["cbgpPeer3Table"]}.1.2.0.{ipv6_af_type}.{peer_ipv6}', '2', "cbgpPeer3Type"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.3.0.{ipv6_af_type}.{peer_ipv6}', peer_ipv6_rmt, "cbgpPeer3RemoteAddr"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.4.0.{ipv6_af_type}.{peer_ipv6}', 'VRF default'.encode('utf-8').hex(' ').upper() + ' 00', "cbgpPeer3VrfName"), # "VRF default"
+            (rf'{OIDS["cbgpPeer3Table"]}.1.5.0.{ipv6_af_type}.{peer_ipv6}', '6', "cbgpPeer3State"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.6.0.{ipv6_af_type}.{peer_ipv6}', '2', "cbgpPeer3AdminStatus"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.7.0.{ipv6_af_type}.{peer_ipv6}', '4', "cbgpPeer3NegotiatedVersion"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.8.0.{ipv6_af_type}.{peer_ipv6}', peer_ipv6_lcl, "cbgpPeer3LocalAddr"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.10.0.{ipv6_af_type}.{peer_ipv6}', '65001', "cbgpPeer3LocalAs"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.11.0.{ipv6_af_type}.{peer_ipv6}', '192.0.2.1', "cbgpPeer3LocalIdentifier"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.13.0.{ipv6_af_type}.{peer_ipv6}', '65001', "cbgpPeer3RemoteAs"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.14.0.{ipv6_af_type}.{peer_ipv6}', '192.0.2.2', "cbgpPeer3RemoteIdentifier"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.19.0.{ipv6_af_type}.{peer_ipv6}', '00 00', "cbgpPeer3LastError"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.20.0.{ipv6_af_type}.{peer_ipv6}', '1', "cbgpPeer3FsmEstablishedTransitions"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.22.0.{ipv6_af_type}.{peer_ipv6}', '30', "cbgpPeer3ConnectRetryInterval"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.23.0.{ipv6_af_type}.{peer_ipv6}', '180', "cbgpPeer3HoldTime"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.24.0.{ipv6_af_type}.{peer_ipv6}', '60', "cbgpPeer3KeepAlive"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.25.0.{ipv6_af_type}.{peer_ipv6}', '180', "cbgpPeer3HoldTimeConfigured"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.26.0.{ipv6_af_type}.{peer_ipv6}', '60', "cbgpPeer3KeepAliveConfigured"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.28.0.{ipv6_af_type}.{peer_ipv6}', '0', "cbgpPeer3MinRouteAdvertisementInterval"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.30.0.{ipv6_af_type}.{peer_ipv6}', '00', "cbgpPeer3LastErrorTxt"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.31.0.{ipv6_af_type}.{peer_ipv6}', '5', "cbgpPeer3PrevState"),
+        ])
+
+# =============================================================================
+# cbgpRouteTable Test Data
+# =============================================================================
+# cbgpRouteTable OID: .1.3.6.1.4.1.9.9.187.1.1.1
+#
+# INDEX: { cbgpRouteAfi, cbgpRouteSafi, cbgpRoutePeerType, cbgpRoutePeer,
+#          cbgpRouteAddrPrefix, cbgpRouteAddrPrefixLen }
+#
+# OID structure:
+# <base>.1.<column>.<afi>.<safi>.<peerType>.<peerLen>.<peer[0-n]>.<prefixLen>.<prefix[0-n]>.<prefixBitLen>
+#
+# Columns:
+#  1 - cbgpRouteAfi (INTEGER)
+#  2 - cbgpRouteSafi (INTEGER)
+#  3 - cbgpRoutePeerType (INTEGER: 1=ipv4, 2=ipv6)
+#  4 - cbgpRoutePeer (OCTET STRING)
+#  5 - cbgpRouteAddrPrefix (OCTET STRING)
+#  6 - cbgpRouteAddrPrefixLen (Unsigned32)
+#  7 - cbgpRouteOrigin (INTEGER: 1=igp, 2=egp, 3=incomplete)
+#  8 - cbgpRouteASPathSegment (OCTET STRING)
+#  9 - cbgpRouteNextHop (InetAddress)
+# 10 - cbgpRouteMedPresent (TruthValue: 1=true, 2=false)
+# 11 - cbgpRouteMultiExitDisc (Unsigned32)
+# 12 - cbgpRouteLocalPrefPresent (TruthValue: 1=true, 2=false)
+# 13 - cbgpRouteLocalPref (Unsigned32)
+# 14 - cbgpRouteAtomicAggregate (INTEGER: 1=less-specific-not-selected, 2=less-specific-selected)
+# 15 - cbgpRouteAggregatorAS (Unsigned32)
+# 16 - cbgpRouteAggregatorAddrType (INTEGER)
+# 17 - cbgpRouteAggregatorAddr (InetAddress)
+# 18 - cbgpRouteBest (TruthValue)
+# 19 - cbgpRouteUnknownAttr (OCTET STRING)
+
+cbgpRouteTableOIDs = []
+
+# IPv4 Unicast routes from peer 10.10.0.2 (first peer in peers_ipv4 list)
+# r2 advertises: 172.16.1.0/24, 172.16.2.0/24, 172.16.3.0/24, 172.16.4.0/24, 172.16.5.0/24
+# r1 filters out 172.16.2.0/24 and 172.16.4.0/24 via FILTER_IN route-map
+# So r1 should have: 172.16.1.0/24, 172.16.3.0/24, 172.16.5.0/24 from 10.10.0.2
+
+# Peer 10.10.0.2 = OID encoding: peerType=1, peerLen=4, peer=10.10.0.2
+# IPv4 prefix 172.16.1.0/24 = prefixLen=4, prefix=172.16.1.0, prefixBitLen=24
+
+ipv4_peer_oid = "1.4.10.10.0.2"  # peerType.peerLen.peer[0].peer[1].peer[2].peer[3]
+
+# Route 172.16.1.0/24 from peer 10.10.0.2
+route_172_16_1_0 = f"{ipv4_peer_oid}.4.172.16.1.0.24"  # prefixLen.prefix[0-3].prefixBitLen
+cbgpRouteTableOIDs.extend([
+    # AFI=1 (IPv4), SAFI=1 (Unicast) - Test all 19 columns for this route
+    # Column 1: cbgpRouteAfi
+    (rf'{OIDS["cbgpRouteTable"]}.1.1.1.1.{route_172_16_1_0}', '1', "cbgpRouteAfi 172.16.1.0/24"),
+    # Column 2: cbgpRouteSafi
+    (rf'{OIDS["cbgpRouteTable"]}.1.2.1.1.{route_172_16_1_0}', '1', "cbgpRouteSafi 172.16.1.0/24"),
+    # Column 3: cbgpRoutePeerType
+    (rf'{OIDS["cbgpRouteTable"]}.1.3.1.1.{route_172_16_1_0}', '1', "cbgpRoutePeerType 172.16.1.0/24"),
+    # Column 4: cbgpRoutePeer
+    (rf'{OIDS["cbgpRouteTable"]}.1.4.1.1.{route_172_16_1_0}', '0A 0A 00 02', "cbgpRoutePeer 172.16.1.0/24"),
+    # Column 5: cbgpRouteAddrPrefix
+    (rf'{OIDS["cbgpRouteTable"]}.1.5.1.1.{route_172_16_1_0}', 'AC 10 01 00', "cbgpRouteAddrPrefix 172.16.1.0/24"),
+    # Column 6: cbgpRouteAddrPrefixLen
+    (rf'{OIDS["cbgpRouteTable"]}.1.6.1.1.{route_172_16_1_0}', '24', "cbgpRouteAddrPrefixLen 172.16.1.0/24"),
+    # Column 7: cbgpRouteOrigin (1=IGP, 2=EGP, 3=incomplete)
+    (rf'{OIDS["cbgpRouteTable"]}.1.7.1.1.{route_172_16_1_0}', '1', "cbgpRouteOrigin 172.16.1.0/24 (IGP)"),
+    # Column 8: cbgpRouteASPathSegment (empty for iBGP, no AS path segments)
+    (rf'{OIDS["cbgpRouteTable"]}.1.8.1.1.{route_172_16_1_0}', r'""', "cbgpRouteASPathSegment 172.16.1.0/24 (empty)"),
+    # Column 9: cbgpRouteNextHop (10.10.0.2 = 0A 0A 00 02)
+    (rf'{OIDS["cbgpRouteTable"]}.1.9.1.1.{route_172_16_1_0}', '0A 0A 00 02', "cbgpRouteNextHop 172.16.1.0/24"),
+    # Column 10: cbgpRouteMedPresent (1=true for iBGP routes with default MED)
+    (rf'{OIDS["cbgpRouteTable"]}.1.10.1.1.{route_172_16_1_0}', '1', "cbgpRouteMedPresent 172.16.1.0/24 (true)"),
+    # Column 11: cbgpRouteMultiExitDisc (0 = default MED)
+    (rf'{OIDS["cbgpRouteTable"]}.1.11.1.1.{route_172_16_1_0}', '0', "cbgpRouteMultiExitDisc 172.16.1.0/24"),
+    # Column 12: cbgpRouteLocalPrefPresent (1=true)
+    (rf'{OIDS["cbgpRouteTable"]}.1.12.1.1.{route_172_16_1_0}', '1', "cbgpRouteLocalPrefPresent 172.16.1.0/24 (true)"),
+    # Column 13: cbgpRouteLocalPref (100 = default)
+    (rf'{OIDS["cbgpRouteTable"]}.1.13.1.1.{route_172_16_1_0}', '100', "cbgpRouteLocalPref 172.16.1.0/24"),
+    # Column 14: cbgpRouteAtomicAggregate (1=less-specific-not-selected, 2=less-specific-selected)
+    (rf'{OIDS["cbgpRouteTable"]}.1.14.1.1.{route_172_16_1_0}', '2', "cbgpRouteAtomicAggregate 172.16.1.0/24 (less-specific-selected)"),
+    # Column 15: cbgpRouteAggregatorAS (0 = no aggregator)
+    (rf'{OIDS["cbgpRouteTable"]}.1.15.1.1.{route_172_16_1_0}', '0', "cbgpRouteAggregatorAS 172.16.1.0/24"),
+    # Column 16: cbgpRouteAggregatorAddrType (0=unknown when no aggregator)
+    (rf'{OIDS["cbgpRouteTable"]}.1.16.1.1.{route_172_16_1_0}', '0', "cbgpRouteAggregatorAddrType 172.16.1.0/24"),
+    # Column 17: cbgpRouteAggregatorAddr (0.0.0.0 when no aggregator)
+    (rf'{OIDS["cbgpRouteTable"]}.1.17.1.1.{route_172_16_1_0}', '00 00 00 00', "cbgpRouteAggregatorAddr 172.16.1.0/24 (0.0.0.0)"),
+    # Column 18: cbgpRouteBest (1=true, 2=false)
+    (rf'{OIDS["cbgpRouteTable"]}.1.18.1.1.{route_172_16_1_0}', '1', "cbgpRouteBest 172.16.1.0/24 (true)"),
+])
+
+# Route 172.16.3.0/24 from peer 10.10.0.2
+route_172_16_3_0 = f"{ipv4_peer_oid}.4.172.16.3.0.24"
+cbgpRouteTableOIDs.extend([
+    (rf'{OIDS["cbgpRouteTable"]}.1.1.1.1.{route_172_16_3_0}', '1', "cbgpRouteAfi 172.16.3.0/24"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.2.1.1.{route_172_16_3_0}', '1', "cbgpRouteSafi 172.16.3.0/24"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.3.1.1.{route_172_16_3_0}', '1', "cbgpRoutePeerType 172.16.3.0/24"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.4.1.1.{route_172_16_3_0}', '0A 0A 00 02', "cbgpRoutePeer 172.16.3.0/24"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.5.1.1.{route_172_16_3_0}', 'AC 10 03 00', "cbgpRouteAddrPrefix 172.16.3.0/24"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.6.1.1.{route_172_16_3_0}', '24', "cbgpRouteAddrPrefixLen 172.16.3.0/24"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.7.1.1.{route_172_16_3_0}', '1', "cbgpRouteOrigin 172.16.3.0/24 (IGP)"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.12.1.1.{route_172_16_3_0}', '1', "cbgpRouteLocalPrefPresent 172.16.3.0/24 (true)"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.13.1.1.{route_172_16_3_0}', '100', "cbgpRouteLocalPref 172.16.3.0/24"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.18.1.1.{route_172_16_3_0}', '1', "cbgpRouteBest 172.16.3.0/24 (true)"),
+])
+
+# Route 172.16.5.0/24 from peer 10.10.0.2
+route_172_16_5_0 = f"{ipv4_peer_oid}.4.172.16.5.0.24"
+cbgpRouteTableOIDs.extend([
+    (rf'{OIDS["cbgpRouteTable"]}.1.1.1.1.{route_172_16_5_0}', '1', "cbgpRouteAfi 172.16.5.0/24"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.2.1.1.{route_172_16_5_0}', '1', "cbgpRouteSafi 172.16.5.0/24"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.3.1.1.{route_172_16_5_0}', '1', "cbgpRoutePeerType 172.16.5.0/24"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.4.1.1.{route_172_16_5_0}', '0A 0A 00 02', "cbgpRoutePeer 172.16.5.0/24"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.5.1.1.{route_172_16_5_0}', 'AC 10 05 00', "cbgpRouteAddrPrefix 172.16.5.0/24"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.6.1.1.{route_172_16_5_0}', '24', "cbgpRouteAddrPrefixLen 172.16.5.0/24"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.7.1.1.{route_172_16_5_0}', '1', "cbgpRouteOrigin 172.16.5.0/24 (IGP)"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.12.1.1.{route_172_16_5_0}', '1', "cbgpRouteLocalPrefPresent 172.16.5.0/24 (true)"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.13.1.1.{route_172_16_5_0}', '100', "cbgpRouteLocalPref 172.16.5.0/24"),
+    (rf'{OIDS["cbgpRouteTable"]}.1.18.1.1.{route_172_16_5_0}', '1', "cbgpRouteBest 172.16.5.0/24 (true)"),
+])
+
+# IPv6 Unicast route from peer fd00::2
+# r2 advertises: fd01:2::1/128
+# Peer fd00::2 in OID encoding: peerType=2, peerLen=16, peer=fd00:0000:0000:0000:0000:0000:0000:0002
+ipv6_peer_oid = "2.16.253.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2"  # peerType.peerLen.peer[0-15]
+
+# Route fd01:2::1/128 from peer fd00::2
+# fd01:0002:0000:0000:0000:0000:0000:0001 = 253.1.0.2.0.0.0.0.0.0.0.0.0.0.0.1
+route_fd01_2_1 = f"{ipv6_peer_oid}.16.253.1.0.2.0.0.0.0.0.0.0.0.0.0.0.1.128"
+cbgpRouteTableOIDs.extend([
+    # AFI=2 (IPv6), SAFI=1 (Unicast)
+    # Column 1: cbgpRouteAfi
+    (rf'{OIDS["cbgpRouteTable"]}.1.1.2.1.{route_fd01_2_1}', '2', "cbgpRouteAfi fd01:2::1/128"),
+    # Column 2: cbgpRouteSafi
+    (rf'{OIDS["cbgpRouteTable"]}.1.2.2.1.{route_fd01_2_1}', '1', "cbgpRouteSafi fd01:2::1/128"),
+    # Column 3: cbgpRoutePeerType
+    (rf'{OIDS["cbgpRouteTable"]}.1.3.2.1.{route_fd01_2_1}', '2', "cbgpRoutePeerType fd01:2::1/128"),
+    # Column 4: cbgpRoutePeer (fd00::2 = FD 00 00 00 00 00 00 00 00 00 00 00 00 00 00 02)
+    (rf'{OIDS["cbgpRouteTable"]}.1.4.2.1.{route_fd01_2_1}', 'FD 00 00 00 00 00 00 00 00 00 00 00 00 00 00 02', "cbgpRoutePeer fd01:2::1/128"),
+    # Column 5: cbgpRouteAddrPrefix (fd01:2::1 = FD 01 00 02 00 00 00 00 00 00 00 00 00 00 00 01)
+    (rf'{OIDS["cbgpRouteTable"]}.1.5.2.1.{route_fd01_2_1}', 'FD 01 00 02 00 00 00 00 00 00 00 00 00 00 00 01', "cbgpRouteAddrPrefix fd01:2::1/128"),
+    # Column 6: cbgpRouteAddrPrefixLen
+    (rf'{OIDS["cbgpRouteTable"]}.1.6.2.1.{route_fd01_2_1}', '128', "cbgpRouteAddrPrefixLen fd01:2::1/128"),
+    # Column 7: cbgpRouteOrigin (1=IGP)
+    (rf'{OIDS["cbgpRouteTable"]}.1.7.2.1.{route_fd01_2_1}', '1', "cbgpRouteOrigin fd01:2::1/128 (IGP)"),
+    # Column 8: cbgpRouteASPathSegment (empty for iBGP)
+    (rf'{OIDS["cbgpRouteTable"]}.1.8.2.1.{route_fd01_2_1}', r'""', "cbgpRouteASPathSegment fd01:2::1/128 (empty)"),
+    # Column 9: cbgpRouteNextHop - skipped as IPv6 may use link-local address
+    # Column 10: cbgpRouteMedPresent (1=true)
+    (rf'{OIDS["cbgpRouteTable"]}.1.10.2.1.{route_fd01_2_1}', '1', "cbgpRouteMedPresent fd01:2::1/128 (true)"),
+    # Column 11: cbgpRouteMultiExitDisc (0 = default MED)
+    (rf'{OIDS["cbgpRouteTable"]}.1.11.2.1.{route_fd01_2_1}', '0', "cbgpRouteMultiExitDisc fd01:2::1/128"),
+    # Column 12: cbgpRouteLocalPrefPresent (1=true)
+    (rf'{OIDS["cbgpRouteTable"]}.1.12.2.1.{route_fd01_2_1}', '1', "cbgpRouteLocalPrefPresent fd01:2::1/128 (true)"),
+    # Column 13: cbgpRouteLocalPref (100 = default)
+    (rf'{OIDS["cbgpRouteTable"]}.1.13.2.1.{route_fd01_2_1}', '100', "cbgpRouteLocalPref fd01:2::1/128"),
+    # Column 14: cbgpRouteAtomicAggregate (2=less-specific-selected)
+    (rf'{OIDS["cbgpRouteTable"]}.1.14.2.1.{route_fd01_2_1}', '2', "cbgpRouteAtomicAggregate fd01:2::1/128 (less-specific-selected)"),
+    # Column 15: cbgpRouteAggregatorAS (0 = no aggregator)
+    (rf'{OIDS["cbgpRouteTable"]}.1.15.2.1.{route_fd01_2_1}', '0', "cbgpRouteAggregatorAS fd01:2::1/128"),
+    # Column 16: cbgpRouteAggregatorAddrType (0=unknown when no aggregator)
+    (rf'{OIDS["cbgpRouteTable"]}.1.16.2.1.{route_fd01_2_1}', '0', "cbgpRouteAggregatorAddrType fd01:2::1/128"),
+    # Column 17: cbgpRouteAggregatorAddr (0.0.0.0 when no aggregator)
+    (rf'{OIDS["cbgpRouteTable"]}.1.17.2.1.{route_fd01_2_1}', '00 00 00 00', "cbgpRouteAggregatorAddr fd01:2::1/128 (0.0.0.0)"),
+    # Column 18: cbgpRouteBest (1=true)
+    (rf'{OIDS["cbgpRouteTable"]}.1.18.2.1.{route_fd01_2_1}', '1', "cbgpRouteBest fd01:2::1/128 (true)"),
+])
+
+# --- EBGP peer (r3, AS 65002) for AS-path loop filtering test ---
+# r3 sends 4 routes: 2 normal, 2 with AS 65001 prepended (causing AS-loop).
+# r1 has route-map FILTER_EBGP_IN that denies 192.168.2.0/24.
+# Expected on r1: accepted=1, denied=3 (1 route-map + 2 AS-loop)
+ebgp_peer_ipv4 = "10.10.6.2"
+ebgp_peer_ipv4_lcl = "0A 0A 06 01"
+ebgp_peer_ipv4_rmt = "0A 0A 06 02"
+ebgp_accepted = '1'
+ebgp_denied = '3'
+
+cbgpPeerTableOIDs.extend([
+    (rf'{OIDS["cbgpPeerTable"]}.1.7.{ebgp_peer_ipv4}', '00', "cbgpPeerLastErrorTxt (EBGP)"),
+    (rf'{OIDS["cbgpPeerTable"]}.1.8.{ebgp_peer_ipv4}', '5', "cbgpPeerPrevState (EBGP)"),
+])
+
+cbgpPeerAddrFamilyTableOIDs.extend([
+    (rf'{OIDS["cbgpPeerAddrFamilyTable"]}.1.1.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', '1', "cbgpPeerAddrFamilyAfi (EBGP)"),
+    (rf'{OIDS["cbgpPeerAddrFamilyTable"]}.1.2.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', '1', "cbgpPeerAddrFamilySafi (EBGP)"),
+    (rf'{OIDS["cbgpPeerAddrFamilyTable"]}.1.3.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', 'IPv4 Unicast'.encode('utf-8').hex(' ').upper() + ' 00', "cbgpPeerAddrFamilyName (EBGP)"),
+])
+
+cbgpPeerAddrFamilyPrefixTableOIDs.extend([
+    (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.1.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', ebgp_accepted, "cbgpPeerAcceptedPrefixes (EBGP)"),
+    (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.2.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', ebgp_denied, "cbgpPeerDeniedPrefixes (EBGP) - includes AS-loop"),
+    (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.3.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', '10', "cbgpPeerPrefixAdminLimit (EBGP)"),
+    (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.4.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', '75', "cbgpPeerPrefixThreshold (EBGP)"),
+    (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.5.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', '75', "cbgpPeerPrefixClearThreshold (EBGP)"),
+    (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.7.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', '0', "cbgpPeerSuppressedPrefixes (EBGP)"),
+    (rf'{OIDS["cbgpPeerAddrFamilyPrefixTable"]}.1.8.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', '0', "cbgpPeerWithdrawnPrefixes (EBGP)"),
+])
+
+ebgp_peer2_entries = [
+    (rf'{OIDS["cbgpPeer2Table"]}.1.1.{ipv4_af_type}.{ebgp_peer_ipv4}', '1', "cbgpPeer2Type (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.2.{ipv4_af_type}.{ebgp_peer_ipv4}', ebgp_peer_ipv4_rmt, "cbgpPeer2RemoteAddr (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.3.{ipv4_af_type}.{ebgp_peer_ipv4}', '6', "cbgpPeer2State (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.4.{ipv4_af_type}.{ebgp_peer_ipv4}', '2', "cbgpPeer2AdminStatus (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.5.{ipv4_af_type}.{ebgp_peer_ipv4}', '4', "cbgpPeer2NegotiatedVersion (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.6.{ipv4_af_type}.{ebgp_peer_ipv4}', ebgp_peer_ipv4_lcl, "cbgpPeer2LocalAddr (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.8.{ipv4_af_type}.{ebgp_peer_ipv4}', '65001', "cbgpPeer2LocalAs (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.9.{ipv4_af_type}.{ebgp_peer_ipv4}', '192.0.2.1', "cbgpPeer2LocalIdentifier (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.11.{ipv4_af_type}.{ebgp_peer_ipv4}', '65002', "cbgpPeer2RemoteAs (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.12.{ipv4_af_type}.{ebgp_peer_ipv4}', '192.0.2.3', "cbgpPeer2RemoteIdentifier (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.17.{ipv4_af_type}.{ebgp_peer_ipv4}', '00 00', "cbgpPeer2LastError (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.18.{ipv4_af_type}.{ebgp_peer_ipv4}', '1', "cbgpPeer2FsmEstablishedTransitions (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.20.{ipv4_af_type}.{ebgp_peer_ipv4}', '30', "cbgpPeer2ConnectRetryInterval (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.21.{ipv4_af_type}.{ebgp_peer_ipv4}', '180', "cbgpPeer2HoldTime (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.22.{ipv4_af_type}.{ebgp_peer_ipv4}', '60', "cbgpPeer2KeepAlive (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.23.{ipv4_af_type}.{ebgp_peer_ipv4}', '180', "cbgpPeer2HoldTimeConfigured (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.24.{ipv4_af_type}.{ebgp_peer_ipv4}', '60', "cbgpPeer2KeepAliveConfigured (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.26.{ipv4_af_type}.{ebgp_peer_ipv4}', '0', "cbgpPeer2MinRouteAdvertisementInterval (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.28.{ipv4_af_type}.{ebgp_peer_ipv4}', '00', "cbgpPeer2LastErrorTxt (EBGP)"),
+    (rf'{OIDS["cbgpPeer2Table"]}.1.29.{ipv4_af_type}.{ebgp_peer_ipv4}', '5', "cbgpPeer2PrevState (EBGP)"),
+]
+cbgpPeer2TableOIDs.extend(ebgp_peer2_entries)
+cbgpPeer2TableOIDs_v4.extend(ebgp_peer2_entries)
+
+ebgp_peer2_af_entries = [
+    (rf'{OIDS["cbgpPeer2AddrFamilyTable"]}.1.1.{ipv4_af_type}.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', '1', "cbgpPeer2AddrFamilyAfi (EBGP)"),
+    (rf'{OIDS["cbgpPeer2AddrFamilyTable"]}.1.2.{ipv4_af_type}.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', '1', "cbgpPeer2AddrFamilySafi (EBGP)"),
+    (rf'{OIDS["cbgpPeer2AddrFamilyTable"]}.1.3.{ipv4_af_type}.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', 'IPv4 Unicast'.encode('utf-8').hex(' ').upper() + ' 00', "cbgpPeer2AddrFamilyName (EBGP)"),
+]
+cbgpPeer2AddrFamilyTableOIDs.extend(ebgp_peer2_af_entries)
+cbgpPeer2AddrFamilyTableOIDs_v4.extend(ebgp_peer2_af_entries)
+
+cbgpPeer2AddrFamilyPrefixTableOIDs.extend([
+    (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.1.{ipv4_af_type}.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', ebgp_accepted, "cbgpPeer2AcceptedPrefixes (EBGP)"),
+    (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.2.{ipv4_af_type}.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', ebgp_denied, "cbgpPeer2DeniedPrefixes (EBGP) - includes AS-loop"),
+    (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.3.{ipv4_af_type}.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', '10', "cbgpPeer2PrefixAdminLimit (EBGP)"),
+    (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.4.{ipv4_af_type}.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', '75', "cbgpPeer2PrefixThreshold (EBGP)"),
+    (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.5.{ipv4_af_type}.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', '75', "cbgpPeer2PrefixClearThreshold (EBGP)"),
+    (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.7.{ipv4_af_type}.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', '0', "cbgpPeer2SuppressedPrefixes (EBGP)"),
+    (rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.8.{ipv4_af_type}.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}', '0', "cbgpPeer2WithdrawnPrefixes (EBGP)"),
+])
+
+ebgp_peer3_entries = [
+    (rf'{OIDS["cbgpPeer3Table"]}.1.2.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '1', "cbgpPeer3Type (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.3.0.{ipv4_af_type}.{ebgp_peer_ipv4}', ebgp_peer_ipv4_rmt, "cbgpPeer3RemoteAddr (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.4.0.{ipv4_af_type}.{ebgp_peer_ipv4}', 'VRF default'.encode('utf-8').hex(' ').upper() + ' 00', "cbgpPeer3VrfName (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.5.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '6', "cbgpPeer3State (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.6.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '2', "cbgpPeer3AdminStatus (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.7.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '4', "cbgpPeer3NegotiatedVersion (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.8.0.{ipv4_af_type}.{ebgp_peer_ipv4}', ebgp_peer_ipv4_lcl, "cbgpPeer3LocalAddr (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.10.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '65001', "cbgpPeer3LocalAs (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.11.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '192.0.2.1', "cbgpPeer3LocalIdentifier (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.13.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '65002', "cbgpPeer3RemoteAs (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.14.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '192.0.2.3', "cbgpPeer3RemoteIdentifier (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.19.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '00 00', "cbgpPeer3LastError (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.20.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '1', "cbgpPeer3FsmEstablishedTransitions (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.22.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '30', "cbgpPeer3ConnectRetryInterval (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.23.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '180', "cbgpPeer3HoldTime (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.24.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '60', "cbgpPeer3KeepAlive (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.25.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '180', "cbgpPeer3HoldTimeConfigured (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.26.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '60', "cbgpPeer3KeepAliveConfigured (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.28.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '0', "cbgpPeer3MinRouteAdvertisementInterval (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.30.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '00', "cbgpPeer3LastErrorTxt (EBGP)"),
+    (rf'{OIDS["cbgpPeer3Table"]}.1.31.0.{ipv4_af_type}.{ebgp_peer_ipv4}', '5', "cbgpPeer3PrevState (EBGP)"),
+]
+cbgpPeer3TableOIDs.extend(ebgp_peer3_entries)
+cbgpPeer3TableOIDs_v4.extend(ebgp_peer3_entries)
+
+# --- Logger Configuration ---
+# 1. Get a logger instance
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO) # Set the lowest level to capture
+
+# 2. Create a formatter to define the log message format
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+
+# 3. Create a handler to write logs to a file
+file_handler = logging.FileHandler('test_run.log')
+file_handler.setFormatter(formatter)
+
+# 4. Create a handler to stream logs to the console (screen)
+stream_handler = logging.StreamHandler(sys.stdout)
+stream_handler.setFormatter(formatter)
+
+# 5. Add both handlers to the logger
+# This is the key step: the logger now has two destinations
+if not logger.handlers:
+    logger.addHandler(file_handler)
+    logger.addHandler(stream_handler)
+
+def log_headline(section, message):
+    logger.info(f"=== [{section}] {message} ===")
+
+def build_topo(tgen):
+    "Builds the topology."
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+    tgen.add_router("r3")
+
+    # r1-r2 links: eth0-eth2 for default VRF, eth3-eth5 for RED VRF
+    tgen.add_link(tgen.gears["r1"], tgen.gears["r2"])  # eth0
+    tgen.add_link(tgen.gears["r1"], tgen.gears["r2"])  # eth1
+    tgen.add_link(tgen.gears["r1"], tgen.gears["r2"])  # eth2
+    tgen.add_link(tgen.gears["r1"], tgen.gears["r2"])  # eth3 (RED VRF)
+    tgen.add_link(tgen.gears["r1"], tgen.gears["r2"])  # eth4 (RED VRF)
+    tgen.add_link(tgen.gears["r1"], tgen.gears["r2"])  # eth5 (RED VRF)
+    # r1-r3 link: EBGP peer for AS-path loop filtering test
+    tgen.add_link(tgen.gears["r1"], tgen.gears["r3"])  # r1-eth6, r3-eth0
+
+def setup_module(mod):
+    snmpd = os.system("which snmpd")
+    if snmpd:
+        error_msg = "SNMP not installed - skipping"
+        pytest.skip(error_msg)
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    r1.run("ip link add RED type vrf table 1001")
+    r1.run("ip link set up dev RED")
+    r2.run("ip link add RED type vrf table 1001")
+    r2.run("ip link set up dev RED")
+    r1.run("ip link set r1-eth3 master RED")
+    r2.run("ip link set r2-eth3 master RED")
+    r1.run("ip link set r1-eth4 master RED")
+    r2.run("ip link set r2-eth4 master RED")
+    r1.run("ip link set r1-eth5 master RED")
+    r2.run("ip link set r2-eth5 master RED")
+
+    for rname, router in tgen.routers().items():
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr.conf".format(rname)),
+            [
+                (TopoRouter.RD_ZEBRA, ""),
+                (TopoRouter.RD_BGP, "-M snmp"),
+            ],
+        )
+        snmpd_conf = os.path.join(CWD, "{}/snmpd.conf".format(rname))
+        if os.path.exists(snmpd_conf):
+            router.load_config(
+                TopoRouter.RD_SNMP,
+                snmpd_conf,
+                "-Le -Ivacm_conf,usmConf,iquery -V -DAgentX",
+            )
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    "Teardown the pytest environment"
+    get_topogen().stop_topology()
+
+
+def bgp_converge_summary(device):
+    json_file = os.path.join(CWD, "r1/bgp_summary.json")
+    expected = json.loads(open(json_file).read())
+    output = json.loads(device.vtysh_cmd("show bgp vrf all summary json"))
+
+    # Capture the comparison result
+    diff = topotest.json_cmp(output, expected)
+
+    # If there is a difference, log it before returning
+    if diff:
+        logger.error("BGP summary mismatch:\n{}".format(diff))
+
+    # Return the result (None on success, diff string on failure)
+    return diff
+
+def get_vrf_id(device, vrf_name):
+    # Execute the command to show all VRFs
+    output = device.vtysh_cmd("show vrf")
+
+    # Define the regex pattern to find the VRF name and capture its ID.
+    # Pattern breakdown:
+    # ^vrf\s+      - Line starts with "vrf" followed by one or more spaces.
+    # {vrf_name}   - The specific VRF name we are searching for.
+    # \s+id\s+     - A space, the word "id", and another space.
+    # (\d+)        - A capturing group for one or more digits (this is the ID).
+    pattern = rf"^vrf\s+{vrf_name}\s+id\s+(\d+).*"
+
+    # Iterate through each line of the output
+    for line in output.strip().splitlines():
+        match = re.search(pattern, line)
+        if match:
+            # If a match is found, group(1) contains the captured ID string.
+            vrf_id_str = match.group(1)
+            # Convert the captured string to an integer and return it.
+            return int(vrf_id_str)
+
+    # If the loop completes without finding a match, return None.
+    return None
+
+
+def test_cisco_bgp4_mib_walk():
+    "Main test function for CISCO-BGP4-MIB."
+    tgen = get_topogen()
+    r1 = tgen.gears["r1"]
+
+    test_func = functools.partial(bgp_converge_summary, r1)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "Failed to see all BGP sessions established on r1"
+
+    vrf_peers_ipv4 = ["10.10.3.2", "10.10.4.2", "10.10.5.2"]
+    vrf_peers_ipv4_lcl = ["0A 0A 03 01", "0A 0A 04 01", "0A 0A 05 01"]
+    vrf_peers_ipv4_rmt = ["0A 0A 03 02", "0A 0A 04 02", "0A 0A 05 02"]
+
+    vrf_id = get_vrf_id(r1, "RED")
+
+    for peer_ipv4, peer_ipv4_lcl, peer_ipv4_rmt in zip(vrf_peers_ipv4, vrf_peers_ipv4_lcl, vrf_peers_ipv4_rmt):
+    
+        cbgpPeer3TableOIDs.extend([
+            # --- IPv4 Peer (10.10.10.2) Checks ---
+            (rf'{OIDS["cbgpPeer3Table"]}.1.2.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '1', "cbgpPeer3Type"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.3.{vrf_id}.{ipv4_af_type}.{peer_ipv4}',  peer_ipv4_rmt, "cbgpPeer3RemoteAddr"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.4.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', 'VRF RED'.encode('utf-8').hex(' ').upper() + ' 00', "cbgpPeer3VrfName"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.5.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '6', "cbgpPeer3State"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.6.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '2', "cbgpPeer3AdminStatus"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.7.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '4', "cbgpPeer3NegotiatedVersion"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.8.{vrf_id}.{ipv4_af_type}.{peer_ipv4}',  peer_ipv4_lcl, "cbgpPeer3LocalAddr"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.10.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '65001', "cbgpPeer3LocalAs"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.11.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '10.10.3.1', "cbgpPeer3LocalIdentifier"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.13.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '65001', "cbgpPeer3RemoteAs"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.14.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '10.10.3.2', "cbgpPeer3RemoteIdentifier"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.15.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '4', "cbgpPeer3InUpdates"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.16.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '4', "cbgpPeer3OutUpdates"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.19.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '00 00', "cbgpPeer3LastError"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.22.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '30', "cbgpPeer3ConnectRetryInterval"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.23.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '180', "cbgpPeer3HoldTime"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.24.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '60', "cbgpPeer3KeepAlive"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.25.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '180', "cbgpPeer3HoldTimeConfigured"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.26.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '60', "cbgpPeer3KeepAliveConfigured"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.28.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '0', "cbgpPeer3MinRouteAdvertisementInterval"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.30.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '00', "cbgpPeer3LastErrorTxt"),
+            (rf'{OIDS["cbgpPeer3Table"]}.1.31.{vrf_id}.{ipv4_af_type}.{peer_ipv4}', '5', "cbgpPeer3PrevState"),
+        ])
+
+    # --hexOutputLength=0 disables net-snmp's default 16-byte line wrapping
+    # for Hex-STRING values (snmp.conf(5)).  Without this, OCTET STRING
+    # values longer than 16 bytes (e.g. FQDN capability) produce multi-line
+    # output that SnmpTester._parse_multiline cannot handle.
+    snmp = SnmpTester(r1, "localhost", "public", "2c",
+                      "-Ln -On --hexOutputLength=0")
+
+    def _check_snmp_walk_no_errors(table_oid, table_name):
+        """Check that snmpwalk completes without OID ordering errors."""
+        cmd = f"snmpwalk -v2c -c public -Ln -On localhost {table_oid}"
+        result = r1.cmd(cmd)
+        
+        if "OID not increasing" in result or "Error:" in result:
+            logger.error(f"SNMP walk error for {table_name}:")
+            logger.error(result)
+            return False
+        
+        return True
+
+    def _check_snmp_get_oids(snmp_inst, checks):
+        """Check OIDs via snmpget for scalar and non-walkable OIDs."""
+        for oid, expected_value, description in checks:
+            value = snmp_inst.get(oid)
+            if expected_value is None:
+                if value is not None:
+                    logger.error(f"SNMP GET FAIL: {description} - OID {oid} should be absent but was found: {value}")
+                    return False
+                logger.info(f"SNMP GET PASS: {description}, {oid} (absent)")
+            else:
+                if value is None:
+                    logger.error(f"SNMP GET FAIL: {description} - OID {oid} not found")
+                    return False
+                if str(value) != str(expected_value):
+                    logger.error(f"SNMP GET FAIL: {description} - OID {oid}: expected '{expected_value}', got '{value}'")
+                    return False
+                logger.info(f"SNMP GET PASS: {description}, {oid}, {expected_value}")
+        return True
+
+    def _check_oids(snmp_output, checks):
+        if not isinstance(snmp_output, dict):
+            logger.error("SNMP output is not a dictionary")
+            return False
+        for oid_pattern, value_pattern, message in checks:
+            if value_pattern is None:
+                found = oid_pattern in snmp_output
+                if found:
+                    logger.error(f"SNMP WALK FAIL: {message} - OID {oid_pattern} should be absent but was found.")
+                    return False
+                logger.info(f"SNMP WALK PASS: {message}, {oid_pattern} ")
+                continue
+            else:
+                found = oid_pattern in snmp_output and snmp_output[oid_pattern] == value_pattern
+                if not found:
+                    logger.error(f"SNMP WALK FAIL: {message} - Pattern not found: {snmp_output} {oid_pattern}: {value_pattern}")
+                    return False
+                logger.info(f"SNMP WALK PASS: {message}, {oid_pattern}, {value_pattern}")
+        return True
+
+    # 1. Test cbgpGlobal scalars
+    def _snmp_check_cbgpGlobal():
+        if not _check_snmp_get_oids(snmp, cbgpGlobalOIDs):
+            return False
+        return True
+
+    _, result = topotest.run_and_expect(_snmp_check_cbgpGlobal, True, count=6, wait=5)
+    assert result, "SNMP checks for cbgpGlobal scalars failed"
+
+    # 2. Test cbgpPeerCapsTable
+    def _snmp_check_cbgpPeerCapsTable():
+        if not _check_snmp_walk_no_errors(OIDS["cbgpPeerCapsTable"], "cbgpPeerCapsTable"):
+            return False
+        output, _ = snmp.walk(OIDS["cbgpPeerCapsTable"])
+        if not output:
+            logger.error("cbgpPeerCapsTable: No entries found in SNMP walk")
+            return False
+        logger.info(f"cbgpPeerCapsTable: Found {len(output)} OIDs in walk")
+        return True
+
+    _, result = topotest.run_and_expect(_snmp_check_cbgpPeerCapsTable, True, count=6, wait=5)
+    assert result, "SNMP checks for cbgpPeerCapsTable failed"
+
+    # 3. Test cbgpPeer2CapsTable
+    def _snmp_check_cbgpPeer2CapsTable():
+        if not _check_snmp_walk_no_errors(OIDS["cbgpPeer2CapsTable"], "cbgpPeer2CapsTable"):
+            return False
+        output, _ = snmp.walk(OIDS["cbgpPeer2CapsTable"])
+        if not output:
+            logger.error("cbgpPeer2CapsTable: No entries found in SNMP walk")
+            return False
+        logger.info(f"cbgpPeer2CapsTable: Found {len(output)} OIDs in walk")
+        return True
+
+    _, result = topotest.run_and_expect(_snmp_check_cbgpPeer2CapsTable, True, count=6, wait=5)
+    assert result, "SNMP checks for cbgpPeer2CapsTable failed"
+
+    # 4. Test IPv4 Peer Tables
+    def _snmp_check_cbgpPeerTable():
+        
+        # Check cbgpPeerTable
+        output, _ = snmp.walk(OIDS["cbgpPeerTable"])
+        for i in range(1, 7):
+            cbgpPeerTableOIDs.append((rf'{OIDS["cbgpPeerTable"]}.1.{i}.{peer_ipv4}', None, f"Deprecated OID .1.{i}"))
+        if not _check_oids(output, cbgpPeerTableOIDs): return False
+
+        # Check cbgpPeerAddrFamilyTable - explicitly check for OID ordering errors
+        if not _check_snmp_walk_no_errors(OIDS["cbgpPeerAddrFamilyTable"], "cbgpPeerAddrFamilyTable"):
+            return False
+        output, _ = snmp.walk(OIDS["cbgpPeerAddrFamilyTable"])
+        if not _check_oids(output, cbgpPeerAddrFamilyTableOIDs): return False
+
+        # Check cbgpPeerAddrFamilyPrefixTable - explicitly check for OID ordering errors
+        if not _check_snmp_walk_no_errors(OIDS["cbgpPeerAddrFamilyPrefixTable"], "cbgpPeerAddrFamilyPrefixTable"):
+            return False
+        output, _ = snmp.walk(OIDS["cbgpPeerAddrFamilyPrefixTable"])
+        if not _check_oids(output, cbgpPeerAddrFamilyPrefixTableOIDs): return False
+
+        return True
+
+    _, result = topotest.run_and_expect(_snmp_check_cbgpPeerTable, True, count=6, wait=5)
+    assert result, "SNMP checks for cbgpPeerTable failed"
+
+    # 5. Test IPv6 Peer Tables
+    def _snmp_check_cbgpPeer2Table():
+        
+        # Check cbgpPeer2Table
+        output, _ = snmp.walk(OIDS["cbgpPeer2Table"])
+        if not _check_oids(output, cbgpPeer2TableOIDs): return False
+
+        # Check cbgpPeer2AddrFamilyTable - explicitly check for OID ordering errors
+        if not _check_snmp_walk_no_errors(OIDS["cbgpPeer2AddrFamilyTable"], "cbgpPeer2AddrFamilyTable"):
+            return False
+        output, _ = snmp.walk(OIDS["cbgpPeer2AddrFamilyTable"])
+        if not _check_oids(output, cbgpPeer2AddrFamilyTableOIDs): return False
+
+        # Check cbgpPeer2AddrFamilyPrefixTable - explicitly check for OID ordering errors
+        if not _check_snmp_walk_no_errors(OIDS["cbgpPeer2AddrFamilyPrefixTable"], "cbgpPeer2AddrFamilyPrefixTable"):
+            return False
+        output, _ = snmp.walk(OIDS["cbgpPeer2AddrFamilyPrefixTable"])
+        if not _check_oids(output, cbgpPeer2AddrFamilyPrefixTableOIDs): return False
+
+        return True
+
+    _, result = topotest.run_and_expect(_snmp_check_cbgpPeer2Table, True, count=6, wait=5)
+    assert result, "SNMP checks for cbgpPeer2Table failed"
+
+    # 6. Test VRF Peer Table
+    def _snmp_check_vrf_peer():
+
+        output, _ = snmp.walk(OIDS["cbgpPeer3Table"])
+
+        if not _check_oids(output, cbgpPeer3TableOIDs): return False
+        return True
+
+    _, result = topotest.run_and_expect(_snmp_check_vrf_peer, True, count=6, wait=5)
+    assert result, "SNMP checks for VRF peer failed"
+
+    # 7. Test cbgpRouteTable - BGP Route Table
+    def _snmp_check_cbgpRouteTable():
+        """Test cbgpRouteTable for IPv4 and IPv6 unicast routes."""
+        
+        # Check for OID ordering errors first
+        if not _check_snmp_walk_no_errors(OIDS["cbgpRouteTable"], "cbgpRouteTable"):
+            return False
+        
+        # Walk the cbgpRouteTable
+        output, _ = snmp.walk(OIDS["cbgpRouteTable"])
+        
+        if not output:
+            logger.error("cbgpRouteTable: No routes found in SNMP walk")
+            return False
+        
+        logger.info(f"cbgpRouteTable: Found {len(output)} OIDs in walk")
+        
+        # Check expected routes
+        if not _check_oids(output, cbgpRouteTableOIDs):
+            return False
+        
+        return True
+
+    _, result = topotest.run_and_expect(_snmp_check_cbgpRouteTable, True, count=10, wait=3)
+    assert result, "SNMP checks for cbgpRouteTable failed"
+
+def test_cisco_mib_wrong_type():
+    """Walk the entire CISCO-BGP4-MIB and fail if any OID has 'Wrong Type'.
+
+    When the Cisco MIB is loaded, snmpwalk validates the ASN type returned by
+    the agent against the SYNTAX declared in the MIB.  Any mismatch is flagged
+    as 'Wrong Type (should be ...)'.  This test walks every table in the MIB
+    and asserts that zero Wrong Type errors are present.
+
+    The test fails if the Cisco MIB files are not installed.
+    """
+    tgen = get_topogen()
+    r1 = tgen.gears["r1"]
+
+    mib_dir = "/usr/share/snmp/mibs/cisco"
+    mib_name = "CISCO-BGP4-MIB"
+
+    probe = r1.cmd(
+        f"snmptranslate -M +{mib_dir} -m +{mib_name} "
+        f"{mib_name}::cbgpPeer2LocalIdentifier 2>&1"
+    ).strip()
+    assert "cbgpPeer2LocalIdentifier" in probe, (
+        f"{mib_name} is not installed at {mib_dir}. "
+        f"Place CISCO-BGP4-MIB.my and CISCO-SMI.my in {mib_dir}."
+    )
+    logger.info(f"Cisco MIB precheck passed: {probe}")
+
+    test_func = functools.partial(bgp_converge_summary, r1)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "Failed to see all BGP sessions established on r1"
+
+    # Walk the entire CISCO-BGP4-MIB enterprise subtree
+    cisco_bgp4_oid = "1.3.6.1.4.1.9.9.187"
+    cmd = (
+        f"snmpwalk -v2c -c public -M +{mib_dir} -m +{mib_name} "
+        f"localhost {cisco_bgp4_oid}"
+    )
+    out = r1.cmd(cmd)
+
+    wrong_type_lines = [l for l in out.strip().splitlines() if "Wrong Type" in l]
+
+    # Group by OID column name for readable output
+    wrong_type_by_oid = {}
+    for line in wrong_type_lines:
+        oid_name = line.split("::")[1].split(".")[0] if "::" in line else line.split("=")[0].strip()
+        wrong_type_by_oid.setdefault(oid_name, []).append(line)
+
+    for oid_name, lines in wrong_type_by_oid.items():
+        logger.error(f"FAIL: {oid_name} — {len(lines)} instance(s) with Wrong Type")
+        for line in lines:
+            logger.error(f"  {line.strip()}")
+
+    total_oids = len(out.strip().splitlines())
+    logger.info(
+        f"Walked {total_oids} OIDs under {mib_name}, "
+        f"found {len(wrong_type_lines)} Wrong Type error(s) "
+        f"across {len(wrong_type_by_oid)} OID column(s)"
+    )
+
+    assert not wrong_type_lines, (
+        f"SNMP agent returned Wrong Type for {len(wrong_type_lines)} OID(s) "
+        f"across {len(wrong_type_by_oid)} column(s): "
+        + ", ".join(f"{name} ({len(lines)})" for name, lines in wrong_type_by_oid.items())
+    )
+
+def test_cisco_bgp4_mib_get():
+    tgen = get_topogen()
+    r1 = tgen.gears["r1"]
+
+    test_func = functools.partial(bgp_converge_summary, r1)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "Failed to see all BGP sessions established on r1"
+    snmp = SnmpTester(r1, "localhost", "public", "2c",
+                      "-Ln -On --hexOutputLength=0")
+
+    # Helper function to check individual OIDs using snmp.get
+    def _check_oids_get(checks):
+        """
+        Iterates through a list of checks, performs an snmp.get for each OID,
+        and compares the result with the expected value.
+
+        Args:
+            checks (list): A list of tuples, where each tuple is
+                        (OID, expected_value, description).
+
+        Returns:
+            bool: True if all checks pass, False otherwise.
+        """
+        for oid, expected_value, description in checks:
+            # Assume snmp.get returns a tuple: (value, error_message)
+            # value is None if the OID is not found or an error occurs.
+            value = snmp.get(oid)
+
+            # --- Case 1: The OID should NOT exist ---
+            if expected_value is None:
+                if value is not None:
+                    # Failure: The OID was found when it should have been absent.
+                    log_message = f"SNMP GET FAIL: {description} - OID {oid} {value}should be absent but was found."
+                    logger.error(log_message)
+                    return False
+                else:
+                    # Success: The OID is correctly absent.
+                    log_message = f"SNMP GET PASS: {description}, {oid}"
+                    logger.info(log_message)
+            
+            # --- Case 2: The OID SHOULD exist with a specific value ---
+            else:
+                if value is None:
+                    # Failure: The OID was not found at all.
+                    log_message = f"SNMP GET FAIL: {description} - OID {oid} was not found"
+                    logger.error(log_message)
+                    return False
+
+                # Failure: The OID was found, but its value is incorrect.
+                if str(value) != str(expected_value):
+                    log_message = (
+                        f"SNMP GET FAIL: {description} - Pattern not found for OID {oid}: "
+                        f"Expected '{expected_value}', but got '{value}'"
+                    )
+                    logger.error(log_message)
+                    return False
+                
+                # Success: The OID was found with the correct value.
+                log_message = f"SNMP GET PASS: {description}, {oid}, {expected_value}"
+                logger.info(log_message)
+
+        return True
+
+
+    # 0. Test cbgpGlobal scalars using snmp.get
+    def _snmp_check_cbgpGlobal_get():
+        if not _check_oids_get(cbgpGlobalOIDs): return False
+        return True
+
+    _, result = topotest.run_and_expect(_snmp_check_cbgpGlobal_get, True, count=6, wait=5)
+    assert result, "SNMP GET checks for cbgpGlobal scalars failed"
+
+    # 1. Test cbgpPeerTable using snmp.get
+    def _snmp_check_cbgpPeerTable_get():
+        if not _check_oids_get(cbgpPeerTableOIDs): return False
+
+        if not _check_oids_get(cbgpPeerAddrFamilyTableOIDs): return False
+
+        if not _check_oids_get(cbgpPeerAddrFamilyPrefixTableOIDs): return False
+
+        return True
+
+    _, result = topotest.run_and_expect(_snmp_check_cbgpPeerTable_get, True, count=6, wait=5)
+    assert result, "SNMP GET checks for cbgpPeerTable failed"
+
+
+    # 2. Test IPv6 Peer Tables using snmp.get
+    def _snmp_check_cbgpPeer2Table_get():
+
+        # Check SNMP gets for cbgpPeer2Table
+        if not _check_oids_get(cbgpPeer2TableOIDs): return False
+
+        # Checks SNMP gets for cbgpPeer2AddrFamilyTable
+        if not _check_oids_get(cbgpPeer2AddrFamilyTableOIDs): return False
+
+        # Checks NMP gets for cbgpPeer2AddrFamilyPrefixTable
+        if not _check_oids_get(cbgpPeer2AddrFamilyPrefixTableOIDs): return False
+
+        return True
+
+    _, result = topotest.run_and_expect(_snmp_check_cbgpPeer2Table_get, True, count=6, wait=5)
+    assert result, "SNMP GET checks for cbgpPeer2Table failed"
+
+
+    # 3. Test VRF Peer Table using snmp.get
+    def _snmp_check_vrf_peer_get():
+        if not _check_oids_get(cbgpPeer3TableOIDs): return False
+        return True
+
+    _, result = topotest.run_and_expect(_snmp_check_vrf_peer_get, True, count=6, wait=5)
+    assert result, "SNMP GET checks for VRF peer failed"
+
+
+def test_snmp_cli_cross_validation():
+    """
+    Cross-validate SNMP counter values against CLI show command outputs.
+
+    For each BGP peer, queries both SNMP (cbgpPeer2 tables) and CLI
+    (show bgp neighbors json) and verifies the values match:
+      - cbgpPeer2State vs bgpState
+      - cbgpPeer2RemoteAs vs remoteAs
+      - cbgpPeer2AcceptedPrefixes vs acceptedPrefixCounter
+      - cbgpPeer2AdvertisedPrefixes vs sentPrefixCounter
+      - cbgpPeer2AcceptedPrefixes + cbgpPeer2DeniedPrefixes vs totalPrefixCounter
+        (for peers with soft-reconfiguration inbound, validating the pfiltered fix)
+    """
+    tgen = get_topogen()
+    r1 = tgen.gears["r1"]
+
+    log_headline("4.", "SNMP vs CLI cross-validation suite")
+    test_func = functools.partial(bgp_converge_summary, r1)
+    log_headline("4.1", "Waiting for all BGP sessions to establish")
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "Failed to see all BGP sessions established on r1"
+
+    snmp = SnmpTester(r1, "localhost", "public", "2c",
+                      "-Ln -On --hexOutputLength=0")
+
+    # BGP state name to SNMP numeric mapping (RFC 4273 / CISCO-BGP4-MIB)
+    bgp_state_map = {
+        "Idle": "1",
+        "Connect": "2",
+        "Active": "3",
+        "OpenSent": "4",
+        "OpenConfirm": "5",
+        "Established": "6",
+    }
+
+    # Define all default-VRF peers with their CLI address, SNMP indexing,
+    # address families, and whether soft-reconfiguration is enabled.
+    cross_check_peers = [
+        {
+            "cli_addr": "10.10.0.2",
+            "snmp_af_type": ipv4_af_type,
+            "snmp_peer_addr": "10.10.0.2",
+            "afis": [("ipv4Unicast", ipv4_unicast_af_idx)],
+            "soft_reconfig": True,
+        },
+        {
+            "cli_addr": "10.10.1.2",
+            "snmp_af_type": ipv4_af_type,
+            "snmp_peer_addr": "10.10.1.2",
+            "afis": [("ipv4Unicast", ipv4_unicast_af_idx)],
+            "soft_reconfig": False,
+        },
+        {
+            "cli_addr": "10.10.2.2",
+            "snmp_af_type": ipv4_af_type,
+            "snmp_peer_addr": "10.10.2.2",
+            "afis": [("ipv4Unicast", ipv4_unicast_af_idx)],
+            "soft_reconfig": False,
+        },
+        {
+            "cli_addr": "fd00::2",
+            "snmp_af_type": ipv6_af_type,
+            "snmp_peer_addr": peers_ipv6[0],
+            "afis": [
+                ("ipv4Unicast", ipv4_unicast_af_idx),
+                ("ipv6Unicast", ipv6_unicast_af_idx),
+            ],
+            "soft_reconfig": False,
+        },
+        {
+            "cli_addr": "fd00:1::2",
+            "snmp_af_type": ipv6_af_type,
+            "snmp_peer_addr": peers_ipv6[1],
+            "afis": [
+                ("ipv4Unicast", ipv4_unicast_af_idx),
+                ("ipv6Unicast", ipv6_unicast_af_idx),
+            ],
+            "soft_reconfig": False,
+        },
+        {
+            "cli_addr": "fd00:2::2",
+            "snmp_af_type": ipv6_af_type,
+            "snmp_peer_addr": peers_ipv6[2],
+            "afis": [
+                ("ipv4Unicast", ipv4_unicast_af_idx),
+                ("ipv6Unicast", ipv6_unicast_af_idx),
+            ],
+            "soft_reconfig": False,
+        },
+        {
+            "cli_addr": "10.10.6.2",
+            "snmp_af_type": ipv4_af_type,
+            "snmp_peer_addr": ebgp_peer_ipv4,
+            "afis": [("ipv4Unicast", ipv4_unicast_af_idx)],
+            "soft_reconfig": True,
+        },
+    ]
+
+    def _cross_validate_peer_state_and_as():
+        """Cross-check BGP state and remote AS for all peers."""
+        for peer in cross_check_peers:
+            cli_addr = peer["cli_addr"]
+            af_type = peer["snmp_af_type"]
+            snmp_addr = peer["snmp_peer_addr"]
+
+            try:
+                cli_output = json.loads(
+                    r1.vtysh_cmd(f"show bgp neighbors {cli_addr} json")
+                )
+                peer_data = cli_output.get(cli_addr, {})
+            except Exception as e:
+                logger.error(f"[{cli_addr}] Failed to get CLI data: {e}")
+                return False
+
+            # Cross-check 1: BGP State
+            cli_state = peer_data.get("bgpState", "Unknown")
+            expected_snmp_state = bgp_state_map.get(cli_state)
+            snmp_state = snmp.get(
+                f'{OIDS["cbgpPeer2Table"]}.1.3.{af_type}.{snmp_addr}'
+            )
+            if expected_snmp_state and str(snmp_state) != expected_snmp_state:
+                logger.error(
+                    f"[{cli_addr}] State mismatch: "
+                    f"CLI={cli_state} (SNMP expected={expected_snmp_state}), "
+                    f"SNMP actual={snmp_state}"
+                )
+                return False
+            logger.info(
+                f"[{cli_addr}] State cross-check PASS: "
+                f"CLI={cli_state}, SNMP={snmp_state}"
+            )
+
+            # Cross-check 2: Remote AS
+            cli_remote_as = str(peer_data.get("remoteAs", ""))
+            snmp_remote_as = str(
+                snmp.get(
+                    f'{OIDS["cbgpPeer2Table"]}.1.11.{af_type}.{snmp_addr}'
+                )
+            )
+            if cli_remote_as != snmp_remote_as:
+                logger.error(
+                    f"[{cli_addr}] Remote AS mismatch: "
+                    f"CLI={cli_remote_as}, SNMP={snmp_remote_as}"
+                )
+                return False
+            logger.info(
+                f"[{cli_addr}] Remote AS cross-check PASS: "
+                f"CLI={cli_remote_as}, SNMP={snmp_remote_as}"
+            )
+
+        return True
+
+    log_headline("4.2", "Cross-checking BGP state and remote AS")
+    _, result = topotest.run_and_expect(
+        _cross_validate_peer_state_and_as, True, count=10, wait=2
+    )
+    assert result, "SNMP vs CLI cross-check failed for BGP state or remote AS"
+
+    def _cross_validate_prefix_counters():
+        """Cross-check accepted and advertised prefix counters for all peers."""
+        for peer in cross_check_peers:
+            cli_addr = peer["cli_addr"]
+            af_type = peer["snmp_af_type"]
+            snmp_addr = peer["snmp_peer_addr"]
+
+            try:
+                cli_output = json.loads(
+                    r1.vtysh_cmd(f"show bgp neighbors {cli_addr} json")
+                )
+                peer_data = cli_output.get(cli_addr, {})
+            except Exception as e:
+                logger.error(f"[{cli_addr}] Failed to get CLI data: {e}")
+                return False
+
+            for afi_name, afi_safi_idx in peer["afis"]:
+                af_info = (
+                    peer_data
+                    .get("addressFamilyInfo", {})
+                    .get(afi_name, {})
+                )
+                label = f"{cli_addr}/{afi_name}"
+
+                # Cross-check 3: AcceptedPrefixes
+                # CLI: acceptedPrefixCounter = peer->pcount[afi][safi]
+                # SNMP: cbgpPeer2AcceptedPrefixes = peer->pcount[afi][safi]
+                cli_accepted = af_info.get("acceptedPrefixCounter")
+                snmp_accepted = snmp.get(
+                    f'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.1'
+                    f'.{af_type}.{snmp_addr}.{afi_safi_idx}'
+                )
+                if cli_accepted is not None and str(cli_accepted) != str(snmp_accepted):
+                    logger.error(
+                        f"[{label}] AcceptedPrefixes mismatch: "
+                        f"CLI={cli_accepted}, SNMP={snmp_accepted}"
+                    )
+                    return False
+                logger.info(
+                    f"[{label}] AcceptedPrefixes cross-check PASS: "
+                    f"CLI={cli_accepted}, SNMP={snmp_accepted}"
+                )
+
+                # Cross-check 4: AdvertisedPrefixes
+                # CLI: sentPrefixCounter = PAF_SUBGRP(paf)->scount
+                # SNMP: cbgpPeer2AdvertisedPrefixes = PAF_SUBGRP(paf)->scount
+                cli_sent = af_info.get("sentPrefixCounter")
+                snmp_advertised = snmp.get(
+                    f'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.6'
+                    f'.{af_type}.{snmp_addr}.{afi_safi_idx}'
+                )
+                if cli_sent is not None and str(cli_sent) != str(snmp_advertised):
+                    logger.error(
+                        f"[{label}] AdvertisedPrefixes mismatch: "
+                        f"CLI={cli_sent}, SNMP={snmp_advertised}"
+                    )
+                    return False
+                logger.info(
+                    f"[{label}] AdvertisedPrefixes cross-check PASS: "
+                    f"CLI={cli_sent}, SNMP={snmp_advertised}"
+                )
+
+        return True
+
+    log_headline("4.3", "Cross-checking accepted and advertised prefix counters")
+    _, result = topotest.run_and_expect(
+        _cross_validate_prefix_counters, True, count=10, wait=2
+    )
+    assert result, "SNMP vs CLI cross-check failed for prefix counters"
+
+    def _cross_validate_adj_rib_in_totals():
+        """
+        For peers with soft-reconfiguration inbound, verify that:
+            SNMP(accepted + denied) == CLI(totalPrefixCounter)
+
+        This validates the pfiltered fix: after centralizing pfiltered
+        at the filtered: label, pcount + pfiltered should equal the
+        total number of entries in adj-rib-in.
+
+        CLI source: show bgp <afi> neighbors <peer> received-routes json
+                    -> totalPrefixCounter (walks adj_in at display time)
+        SNMP source: cbgpPeer2AcceptedPrefixes + cbgpPeer2DeniedPrefixes
+                    = peer->pcount + peer->pfiltered (maintained incrementally)
+        """
+        soft_reconfig_peers = [
+            p for p in cross_check_peers if p["soft_reconfig"]
+        ]
+
+        for peer in soft_reconfig_peers:
+            cli_addr = peer["cli_addr"]
+            af_type = peer["snmp_af_type"]
+            snmp_addr = peer["snmp_peer_addr"]
+
+            for afi_name, afi_safi_idx in peer["afis"]:
+                label = f"{cli_addr}/{afi_name}"
+                # Map CLI AFI name to the show command AFI keyword
+                if afi_name == "ipv4Unicast":
+                    afi_keyword = "ipv4 unicast"
+                elif afi_name == "ipv6Unicast":
+                    afi_keyword = "ipv6 unicast"
+                else:
+                    continue
+
+                try:
+                    cli_output = json.loads(
+                        r1.vtysh_cmd(
+                            f"show bgp {afi_keyword} neighbors "
+                            f"{cli_addr} received-routes json"
+                        )
+                    )
+                    cli_total = cli_output.get("totalPrefixCounter", -1)
+                except Exception as e:
+                    logger.error(
+                        f"[{label}] Failed to get received-routes: {e}"
+                    )
+                    return False
+
+                snmp_accepted_val = snmp.get(
+                    f'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.1'
+                    f'.{af_type}.{snmp_addr}.{afi_safi_idx}'
+                )
+                snmp_denied_val = snmp.get(
+                    f'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.2'
+                    f'.{af_type}.{snmp_addr}.{afi_safi_idx}'
+                )
+
+                try:
+                    snmp_total = int(snmp_accepted_val) + int(snmp_denied_val)
+                except (ValueError, TypeError):
+                    logger.error(
+                        f"[{label}] Could not parse SNMP values: "
+                        f"accepted={snmp_accepted_val}, denied={snmp_denied_val}"
+                    )
+                    return False
+
+                if cli_total != snmp_total:
+                    logger.error(
+                        f"[{label}] Adj-RIB-In total mismatch: "
+                        f"CLI totalPrefixCounter={cli_total}, "
+                        f"SNMP (accepted+denied)={snmp_total} "
+                        f"(accepted={snmp_accepted_val}, denied={snmp_denied_val}). "
+                        f"If SNMP < CLI, pfiltered is under-counting."
+                    )
+                    return False
+                logger.info(
+                    f"[{label}] Adj-RIB-In total cross-check PASS: "
+                    f"CLI={cli_total}, SNMP={snmp_total} "
+                    f"(accepted={snmp_accepted_val}+denied={snmp_denied_val})"
+                )
+
+        return True
+
+    log_headline(
+        "4.4",
+        "Cross-checking SNMP(accepted+denied) vs CLI totalPrefixCounter "
+        "(soft-reconfig peers)"
+    )
+    _, result = topotest.run_and_expect(
+        _cross_validate_adj_rib_in_totals, True, count=10, wait=2
+    )
+    assert result, (
+        "SNMP(accepted+denied) != CLI(totalPrefixCounter) for a "
+        "soft-reconfiguration peer. This indicates pfiltered is "
+        "under-counting denied prefixes."
+    )
+
+    log_headline("4.5", "SNMP vs CLI cross-validation PASSED")
+
+
+def test_pfiltered_counts_all_deny_reasons():
+    """
+    Verify that cbgpPeer2DeniedPrefixes (pfiltered) counts ALL deny paths,
+    not just route-map and input-filter denials.
+
+    Topology:
+      r3 (AS 65002) → r1 (AS 65001), EBGP
+
+    r3 sends 4 IPv4 routes to r1:
+      - 192.168.1.0/24: normal (AS path "65002") → accepted
+      - 192.168.2.0/24: normal (AS path "65002") → denied by route-map FILTER_EBGP_IN
+      - 192.168.3.0/24: AS-loop (AS path "65002 65001") → denied by AS-path loop check
+      - 192.168.4.0/24: AS-loop (AS path "65002 65001") → denied by AS-path loop check
+
+    Expected SNMP counters for peer 10.10.6.2:
+      cbgpPeer2AcceptedPrefixes = 1
+      cbgpPeer2DeniedPrefixes = 3  (1 route-map + 2 AS-loop)
+
+    Before the pfiltered fix, denied would be 1 (only route-map counted).
+    After the fix, denied is 3 (all deny paths counted).
+    """
+    tgen = get_topogen()
+    r1 = tgen.gears["r1"]
+
+    log_headline("5.", "pfiltered counts all deny reasons (AS-loop + route-map)")
+
+    # Wait for BGP convergence
+    test_func = functools.partial(bgp_converge_summary, r1)
+    log_headline("5.1", "Waiting for all BGP sessions to establish (including EBGP r3)")
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "Failed to see all BGP sessions established on r1"
+
+    snmp = SnmpTester(r1, "localhost", "public", "2c",
+                      "-Ln -On --hexOutputLength=0")
+
+    # Verify via CLI that r3 peer shows expected route counts.
+    # Note: CLI filteredPrefixCounter only counts policy denials (route-map/filter),
+    # NOT AS-path loop denials. The SNMP pfiltered counter (with our fix) counts all.
+    def _verify_ebgp_cli_counters():
+        """Cross-check adj-rib-in population via CLI received-routes."""
+        try:
+            output = json.loads(
+                r1.vtysh_cmd("show bgp ipv4 unicast neighbors 10.10.6.2 received-routes json")
+            )
+            total = output.get("totalPrefixCounter", -1)
+            filtered = output.get("filteredPrefixCounter", -1)
+            logger.info(
+                f"CLI received-routes for 10.10.6.2: total={total}, filtered={filtered}"
+            )
+            # totalPrefixCounter = 4 (all routes in adj-rib-in via soft-reconfig)
+            if total != 4:
+                logger.error(f"Expected totalPrefixCounter=4, got {total}")
+                return False
+            # filteredPrefixCounter = 1 (only route-map denial; CLI re-applies
+            # bgp_input_filter + bgp_input_modifier but NOT AS-loop check)
+            if filtered != 1:
+                logger.error(f"Expected filteredPrefixCounter=1, got {filtered}")
+                return False
+            return True
+        except Exception as e:
+            logger.error(f"CLI check failed: {e}")
+            return False
+
+    log_headline("5.2", "Verifying CLI route counters for EBGP peer")
+    _, result = topotest.run_and_expect(_verify_ebgp_cli_counters, True, count=15, wait=2)
+    assert result, "CLI counters for EBGP peer did not match expected values"
+
+    # Also verify accepted count via show bgp neighbors json
+    def _verify_ebgp_accepted():
+        """Check acceptedPrefixCounter matches expected value."""
+        try:
+            output = json.loads(r1.vtysh_cmd("show bgp neighbors 10.10.6.2 json"))
+            peer_info = output.get("10.10.6.2", {})
+            af_info = peer_info.get("addressFamilyInfo", {}).get("ipv4Unicast", {})
+            accepted = af_info.get("acceptedPrefixCounter", -1)
+            logger.info(f"CLI acceptedPrefixCounter for 10.10.6.2: {accepted}")
+            if accepted != 1:
+                logger.error(f"Expected acceptedPrefixCounter=1, got {accepted}")
+                return False
+            return True
+        except Exception as e:
+            logger.error(f"CLI accepted check failed: {e}")
+            return False
+
+    log_headline("5.2b", "Verifying CLI acceptedPrefixCounter for EBGP peer")
+    _, result = topotest.run_and_expect(_verify_ebgp_accepted, True, count=15, wait=2)
+    assert result, "CLI acceptedPrefixCounter for EBGP peer did not match"
+
+    # Now check SNMP counters
+    accepted_oid = rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.1.{ipv4_af_type}.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}'
+    denied_oid = rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.2.{ipv4_af_type}.{ebgp_peer_ipv4}.{ipv4_unicast_af_idx}'
+
+    def _verify_ebgp_snmp_pfiltered():
+        """Check SNMP cbgpPeer2DeniedPrefixes includes AS-loop denials."""
+        accepted = snmp.get(accepted_oid)
+        denied = snmp.get(denied_oid)
+        logger.info(
+            f"SNMP counters for 10.10.6.2: accepted={accepted}, denied={denied}"
+        )
+        if str(accepted) != '1':
+            logger.error(f"cbgpPeer2AcceptedPrefixes: expected 1, got {accepted}")
+            return False
+        if str(denied) != '3':
+            logger.error(
+                f"cbgpPeer2DeniedPrefixes: expected 3 (1 route-map + 2 AS-loop), got {denied}. "
+                "If denied=1, the pfiltered fix is missing."
+            )
+            return False
+        return True
+
+    log_headline("5.3", "Verifying SNMP pfiltered counter includes AS-loop denials")
+    _, result = topotest.run_and_expect(_verify_ebgp_snmp_pfiltered, True, count=10, wait=2)
+    assert result, (
+        "cbgpPeer2DeniedPrefixes did not count AS-path loop denials. "
+        "Expected denied=3 (1 route-map + 2 AS-loop), check pfiltered fix in bgp_route.c"
+    )
+
+    # Also verify the existing IBGP peer with route-map-only filtering still works
+    ibgp_denied_oid = rf'{OIDS["cbgpPeer2AddrFamilyPrefixTable"]}.1.2.{ipv4_af_type}.10.10.0.2.{ipv4_unicast_af_idx}'
+
+    def _verify_ibgp_snmp_pfiltered():
+        """Confirm IBGP peer (10.10.0.2) still shows correct route-map-only denial count."""
+        denied = snmp.get(ibgp_denied_oid)
+        logger.info(f"SNMP denied for IBGP peer 10.10.0.2: {denied}")
+        if str(denied) != '2':
+            logger.error(f"cbgpPeer2DeniedPrefixes for 10.10.0.2: expected 2, got {denied}")
+            return False
+        return True
+
+    log_headline("5.4", "Verifying IBGP peer route-map-only denied count unchanged")
+    _, result = topotest.run_and_expect(_verify_ibgp_snmp_pfiltered, True, count=10, wait=2)
+    assert result, "IBGP peer denied count changed unexpectedly"
+
+    log_headline("5.5", "pfiltered test PASSED - all deny paths correctly counted")
+
+
+def test_cbgp4_traps():
+    """
+    Verify CISCO-BGP4-MIB trap notifications by cycling BGP peer sessions
+    and capturing traps via snmptrapd.
+
+    IPv4 peer (10.10.0.2) tests both legacy and Peer2 notifications:
+      Backward: cbgpFsmStateChange(1), cbgpBackwardTransition(2),
+                cbgpPeer2BackwardTransNotification(6),
+                cbgpPeer2FsmStateChange(7), cbgpPeer2BackwardTransition(8)
+      Established: cbgpPeer2EstablishedNotification(5)
+
+    IPv6 peer (fd00::2) tests Peer2 notifications only (legacy is IPv4-only):
+      Backward: cbgpPeer2BackwardTransNotification(6),
+                cbgpPeer2FsmStateChange(7), cbgpPeer2BackwardTransition(8)
+      Established: cbgpPeer2EstablishedNotification(5)
+    """
+    tgen = get_topogen()
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    log_headline("TRAP", "CBGP4 MIB SNMP Trap Tests")
+
+    if os.system("which snmptrapd") != 0:
+        pytest.skip("snmptrapd not installed - skipping trap tests")
+
+    test_func = functools.partial(bgp_converge_summary, r1)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "BGP not converged before trap test"
+
+    r1.vtysh_cmd("configure terminal\nbgp snmp traps cisco-bgp4")
+
+    trap_log = "/tmp/cbgp4_traps.log"
+
+    def _has_trap(log_text, trap_num):
+        """Check if a specific CBGP4 notification OID is in the trap log.
+
+        Notification OIDs are .1.3.6.1.4.1.9.9.187.0.<trap_num>.
+        Uses negative lookahead to prevent e.g. trap 1 matching trap 10.
+        """
+        pattern = r'\.1\.3\.6\.1\.4\.1\.9\.9\.187\.0\.{}(?!\d)'.format(trap_num)
+        return bool(re.search(pattern, log_text))
+
+    def _start_trapd():
+        r1.run("rm -f {}".format(trap_log))
+        r1.run(
+            "snmptrapd -Lf {} -On "
+            "--disableAuthorization=yes "
+            "udp:162 &".format(trap_log)
+        )
+
+        def _trapd_running():
+            return "snmptrapd" in r1.run("pgrep -a snmptrapd 2>/dev/null")
+
+        _, ok = topotest.run_and_expect(_trapd_running, True, count=6, wait=5)
+        assert ok, "snmptrapd did not start"
+
+    def _stop_trapd():
+        r1.run("pkill -f snmptrapd 2>/dev/null; true")
+
+        def _trapd_stopped():
+            return "snmptrapd" not in r1.run("pgrep -a snmptrapd 2>/dev/null")
+
+        topotest.run_and_expect(_trapd_stopped, True, count=6, wait=5)
+
+    def _read_trap_log():
+        return r1.run("cat {} 2>/dev/null".format(trap_log))
+
+    _start_trapd()
+
+    try:
+        # ================================================================
+        # Phase 1: IPv4 backward transition
+        # Shut down peer on r2 side to trigger traps on r1.
+        # r2 sends CEASE/AdminShutdown NOTIFICATION; r1 transitions
+        # from Established to Idle, firing backward transition hooks.
+        # ================================================================
+        log_headline("TRAP.1", "IPv4 backward transition - shutting 10.10.0.1 on r2")
+        r2.vtysh_cmd(
+            """
+            configure terminal
+            router bgp 65001
+            neighbor 10.10.0.1 shutdown
+            """
+        )
+
+        def _check_ipv4_backward():
+            output = _read_trap_log()
+            if not output.strip():
+                return False
+            traps = {
+                "cbgpFsmStateChange(1)": _has_trap(output, 1),
+                "cbgpBackwardTransition(2)": _has_trap(output, 2),
+                "cbgpPeer2BackwardTransNotif(6)": _has_trap(output, 6),
+                "cbgpPeer2FsmStateChange(7)": _has_trap(output, 7),
+                "cbgpPeer2BackwardTransition(8)": _has_trap(output, 8),
+            }
+            for name, present in traps.items():
+                logger.info(
+                    "IPv4 backward: {} = {}".format(
+                        name, "FOUND" if present else "missing"
+                    )
+                )
+            return all(traps.values())
+
+        _, result = topotest.run_and_expect(
+            _check_ipv4_backward, True, count=20, wait=2
+        )
+        assert result, "Missing CBGP4 backward transition traps for IPv4 peer"
+
+        trap_output = _read_trap_log()
+
+        # Verify varbinds contain the IPv4 peer address OID component
+        assert "10.10.0" in trap_output, \
+            "Backward transition trap varbinds missing peer address 10.10.0.x"
+
+        # Verify cbgpPeer2PrevState varbind contains 6 (Established)
+        # OID: .1.3.6.1.4.1.9.9.187.1.2.5.1.29.1.10.10.0.2
+        prev_state_oid = ".1.3.6.1.4.1.9.9.187.1.2.5.1.29.1.10.10.0.2"
+        if prev_state_oid in trap_output:
+            assert "INTEGER: 6" in trap_output, \
+                "cbgpPeer2PrevState should be 6 (Established) for backward transition"
+            logger.info("cbgpPeer2PrevState varbind verified: 6 (Established)")
+
+        # ================================================================
+        # Phase 2: IPv4 established notification
+        # Bring peer back up; r1 transitions through Connect/OpenSent/
+        # OpenConfirm to Established, firing the established hook.
+        # ================================================================
+        log_headline("TRAP.2", "IPv4 established - unsetting shutdown on r2")
+        r2.vtysh_cmd(
+            """
+            configure terminal
+            router bgp 65001
+            no neighbor 10.10.0.1 shutdown
+            """
+        )
+
+        def _check_ipv4_established():
+            output = _read_trap_log()
+            return _has_trap(output, 5)
+
+        _, result = topotest.run_and_expect(
+            _check_ipv4_established, True, count=30, wait=2
+        )
+        assert result, "Missing cbgpPeer2EstablishedNotification(5) for IPv4 peer"
+
+        # Wait for full re-convergence before IPv6 test
+        _, result = topotest.run_and_expect(
+            functools.partial(bgp_converge_summary, r1), None, count=30, wait=2
+        )
+        assert result is None, "BGP did not re-converge after IPv4 trap test"
+
+        # ================================================================
+        # Phase 3: IPv6 backward transition
+        # Restart snmptrapd with a fresh log to isolate IPv6 traps.
+        # Legacy traps (1, 2) must NOT fire for IPv6 peers.
+        # ================================================================
+        log_headline("TRAP.3", "IPv6 backward transition - shutting fd00::1 on r2")
+        _stop_trapd()
+        _start_trapd()
+
+        r2.vtysh_cmd(
+            """
+            configure terminal
+            router bgp 65001
+            neighbor fd00::1 shutdown
+            """
+        )
+
+        def _check_ipv6_backward():
+            output = _read_trap_log()
+            if not output.strip():
+                return False
+            traps = {
+                "cbgpPeer2BackwardTransNotif(6)": _has_trap(output, 6),
+                "cbgpPeer2FsmStateChange(7)": _has_trap(output, 7),
+                "cbgpPeer2BackwardTransition(8)": _has_trap(output, 8),
+            }
+            for name, present in traps.items():
+                logger.info(
+                    "IPv6 backward: {} = {}".format(
+                        name, "FOUND" if present else "missing"
+                    )
+                )
+            return all(traps.values())
+
+        _, result = topotest.run_and_expect(
+            _check_ipv6_backward, True, count=20, wait=2
+        )
+        assert result, "Missing CBGP4 backward transition traps for IPv6 peer"
+
+        ipv6_output = _read_trap_log()
+        assert not _has_trap(ipv6_output, 2), \
+            "Legacy cbgpBackwardTransition(2) must not fire for IPv6 peers"
+        logger.info("Confirmed: no legacy backward trap for IPv6 peer")
+
+        # ================================================================
+        # Phase 4: IPv6 established notification
+        # ================================================================
+        log_headline("TRAP.4", "IPv6 established - unsetting shutdown on r2")
+        r2.vtysh_cmd(
+            """
+            configure terminal
+            router bgp 65001
+            no neighbor fd00::1 shutdown
+            """
+        )
+
+        def _check_ipv6_established():
+            output = _read_trap_log()
+            return _has_trap(output, 5)
+
+        _, result = topotest.run_and_expect(
+            _check_ipv6_established, True, count=30, wait=2
+        )
+        assert result, "Missing cbgpPeer2EstablishedNotification(5) for IPv6 peer"
+
+        assert not _has_trap(_read_trap_log(), 1), \
+            "Legacy cbgpFsmStateChange(1) must not fire for IPv6 peers"
+        logger.info("Confirmed: no legacy FSM state change trap for IPv6 peer")
+
+        # Wait for full re-convergence
+        _, result = topotest.run_and_expect(
+            functools.partial(bgp_converge_summary, r1), None, count=30, wait=2
+        )
+        assert result is None, "BGP did not re-converge after IPv6 trap test"
+
+    finally:
+        _stop_trapd()
+
+    log_headline("TRAP.5", "All CBGP4 trap tests PASSED")
+
+
+def test_bgp_snmp_no_peers():
+    """Test BGP SNMP behavior when no peers are configured - run after main tests."""
+    tgen = get_topogen()
+    
+    # Use r1 for this test
+    r1 = tgen.gears["r1"]
+    
+    # Remove all BGP neighbors from default VRF
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        router bgp 65001
+        no neighbor 10.10.0.2
+        no neighbor 10.10.1.2
+        no neighbor 10.10.2.2
+        no neighbor 10.10.6.2
+        no neighbor fd00::2
+        no neighbor fd00:1::2
+        no neighbor fd00:2::2
+        """
+    )
+    
+    # Also remove VRF peers if any
+    r1.vtysh_cmd(
+        """
+        configure terminal
+        router bgp 65001 vrf vrf1
+        no neighbor 10.10.5.2
+        no neighbor fd00:5::2
+        """
+    )
+    
+    logger.info("Testing SNMP walk with no peers configured")
+    
+    # Verify no peers exist
+    def _verify_no_peers():
+        output = json.loads(r1.vtysh_cmd("show bgp summary json"))
+        for afi in ["ipv4Unicast", "ipv6Unicast"]:
+            if afi in output and "peers" in output[afi]:
+                if len(output[afi]["peers"]) > 0:
+                    return False
+        return True
+    
+    test_func = functools.partial(_verify_no_peers)
+    _, result = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert result, "Failed to remove all BGP peers"
+    
+    # Test SNMP queries when no peers are configured
+    snmp = SnmpTester(r1, "localhost", "public", "2c",
+                      "-Ln -On --hexOutputLength=0")
+    
+    def _snmpwalk_no_peers_remote_addr():
+        # First verify BGP is alive before the test
+        try:
+            pre_test_check = json.loads(r1.vtysh_cmd("show bgp summary json"))
+        except:
+            return False  # BGP already dead
+        
+        try:
+
+            output, _ = snmp.walk(OIDS["cbgpPeer2Table"])
+            
+            # If we get here without exception, check if BGP is still alive
+            try:
+                post_test_check = json.loads(r1.vtysh_cmd("show bgp summary json"))
+                # BGP survived - either fix is applied or crash didn't occur
+                return True  # This is unexpected if fix not applied
+            except:
+                # BGP died after SNMP operation - crash occurred!
+                return False  # This indicates the crash happened
+                
+        except Exception as e:
+            error_str = str(e).lower()
+            # Check if BGP crashed (timeout/no response) or just returned error
+            if "timeout" in error_str or "no response" in error_str:
+                # Likely BGP crashed - verify by checking if it's still responsive
+                try:
+                    json.loads(r1.vtysh_cmd("show bgp summary json"))
+                    return True  # BGP still alive, just SNMP timeout
+                except:
+                    return False  # BGP crashed!
+            else:
+                # Got SNMP error but need to verify BGP is still alive
+                try:
+                    json.loads(r1.vtysh_cmd("show bgp summary json"))
+                    return True  # BGP alive, got expected SNMP error
+                except:
+                    return False  # BGP crashed during SNMP operation
+    
+
+    _, result = topotest.run_and_expect(_snmpwalk_no_peers_remote_addr, True, count=10, wait=2)
+    
+
+    if result:
+        logger.info("BGP survived SNMP walk with no peers")
+    else:
+        logger.error("BGP crashed during SNMP walk with no peers")
+        assert False, "BGP daemon crashed"
+    
+    def _snmpwalk_no_peers_state():
+        """bgp4V2PeerState should also trigger crash if fix not applied."""
+        # Verify BGP is still alive before this test
+        try:
+            pre_test_check = json.loads(r1.vtysh_cmd("show bgp summary json"))
+        except:
+            return False  # BGP already dead from previous test
+        
+        try:
+            # This Cisco BGP MIB OID may also trigger the same crash condition
+            output, _ = snmp.walk(OIDS["cbgpPeerTable"])
+            
+            # Check if BGP survived
+            try:
+                post_test_check = json.loads(r1.vtysh_cmd("show bgp summary json"))
+                return True  # BGP survived
+            except:
+                return False  # BGP crashed
+                
+        except Exception as e:
+            # Check for crash indicators
+            error_str = str(e).lower()
+            if "timeout" in error_str or "no response" in error_str:
+                try:
+                    json.loads(r1.vtysh_cmd("show bgp summary json"))
+                    return True  # BGP alive despite timeout
+                except:
+                    return False  # BGP crashed
+            else:
+                try:
+                    json.loads(r1.vtysh_cmd("show bgp summary json"))
+                    return True  # BGP alive, got SNMP error
+                except:
+                    return False  # BGP crashed
+    
+    _, result = topotest.run_and_expect(_snmpwalk_no_peers_state, True, count=10, wait=2)
+    
+    if result:
+        logger.info("BGP survived second SNMP walk with no peers")
+    else:
+        logger.error("BGP crashed during second SNMP walk with no peers")
+        assert False, "BGP daemon crashed"
+    
+    # Verify BGP daemon is still running after SNMP operations
+    def _verify_bgp_still_alive():
+        """Final check that BGP daemon survived the SNMP operations."""
+        try:
+            # If BGP crashed, this command will fail
+            output = json.loads(r1.vtysh_cmd("show bgp summary json"))
+            return True
+        except:
+            return False
+    
+    _, result = topotest.run_and_expect(_verify_bgp_still_alive, True, count=10, wait=2)
+    assert result, "BGP daemon crashed"
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    log_headline("6.", "Reporting memory leaks")
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/tests/topotests/lib/snmptest.py
+++ b/tests/topotests/lib/snmptest.py
@@ -20,6 +20,9 @@ Basic usage instructions:
 from lib.topolog import logger
 import re
 
+EoMIB = "No more variables left in this MIB View"
+OID_NOT_FOUND = "No Such Instance currently exists at this OID"
+
 
 class SnmpTester(object):
     "A helper class for testing SNMP"
@@ -79,6 +82,8 @@ class SnmpTester(object):
         out_dict = {}
         out_list = []
         for response in results:
+            if EoMIB in response:
+                break
             out_dict[self._get_snmp_oid(response)] = self._get_snmp_value(response)
             out_list.append(self._get_snmp_value(response))
 
@@ -89,7 +94,7 @@ class SnmpTester(object):
             self._snmp_config(), oid
         )
         result = self.router.cmd(cmd)
-        if "not found" in result:
+        if "not found" in result or OID_NOT_FOUND in result:
             return None
         return self._get_snmp_value(result)
 


### PR DESCRIPTION
### CISCO-BGP4-MIB support for FRRouting

This adds full support for the CISCO-BGP4-MIB (OID 1.3.6.1.4.1.9.9.187) in bgpd.
The Cisco MIB is widely used in production networks and provides much richer BGP
peer and route telemetry than the standard BGP4-MIB.

Reference: https://github.com/cisco/cisco-mibs/blob/main/v2/CISCO-BGP4-MIB.my

### What's implemented

**Global scalars** — cbgpLocalAs and cbgpNotifsEnable

**Peer tables** — cbgpPeerTable (legacy IPv4), cbgpPeer2Table (IPv4+IPv6),
cbgpPeer3Table (VRF-aware). Covers peer state, timers, connection details,
FSM transitions, error codes, previous state, and last error text.

**Capability tables** — cbgpPeerCapsTable and cbgpPeer2CapsTable.
Capabilities are reconstructed on-demand from parsed peer state,
so there's zero per-peer memory overhead. Supports MP, Route Refresh,
Extended Nexthop, Extended Message, Role, Graceful Restart, 4-byte AS,
Dynamic, Addpath, Enhanced Route Refresh, LLGR, FQDN, and legacy
Route Refresh (code 128).

**Address-family prefix tables** — Per-AFI/SAFI prefix counters including
accepted, denied, advertised, withdrawn, and suppressed counts.
Also exposes prefix admin limit, threshold, clear-threshold, and
MinASOriginationInterval.

**Route table** — cbgpRouteTable with Loc-RIB entries for IPv4 unicast,
IPv6 unicast, and L2VPN EVPN. Per-route attributes include origin,
AS-path, next-hop, MED, local-pref, aggregator info, best-path flag,
and unknown/transit attributes.

**Trap notifications** — All 10 notification types:
- Legacy IPv4: FSM state change, backward transition, prefix threshold exceeded/clear
- Peer2 (IPv4/IPv6): established, backward transition, FSM state change,
  backward transition (extended), prefix threshold exceeded/clear

### Infrastructure additions

- Per-peer filtered/withdrawn/suppressed prefix counters with hooks for
  prefix threshold events
- Peer list sorted by IP address for correct SNMP GetNext lexicographic ordering

### Commits

1. **bgpd: add filtered prefix tracking infrastructure** — per-peer/per-AFI counters
   for filtered, withdrawn, and suppressed prefixes; hook points for threshold events
2. **bgpd: add peer list sorted by address for SNMP** — maintains address-sorted peer
   list so MIB walks return OIDs in the right order
3. **bgpd: implement CISCO-BGP4-MIB support** — the main implementation (~4500 lines),
   all tables, traps, and capability reconstruction
4. **tests: add topotest for CISCO-BGP4-MIB** — comprehensive test covering SNMP walks,
   per-OID validation, SNMP-vs-CLI cross-checks, trap verification, filtered prefix
   counting, and no-peers edge case
5. **doc: add CISCO-BGP4-MIB documentation** — user-facing docs with configuration
   guidance and snmpwalk examples

### Testing

Topotest results: **7 passed, 1 skipped** (memory leak test disabled — standard infra skip).
Trap tests pass with snmptrapd installed.