### PR TITLE
vrrpd: IPv6 VRRP macvlan doesn't have IPv6 link-local address

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -2084,9 +2084,10 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 						       rc_bitfield);
 
 			if (if_is_no_ptm_operative(ifp)) {
-				bool is_up = if_is_operative(ifp);
 
 				ifp->flags = flags;
+				bool is_up = if_is_operative(ifp);
+
 				if (!if_is_no_ptm_operative(ifp) ||
 				    CHECK_FLAG(zif->flags,
 					       ZIF_FLAG_PROTODOWN)) {
@@ -2107,7 +2108,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 						zlog_debug(
 							"Intf %s(%u) PTM up, notifying clients",
 							name, ifp->ifindex);
-					if_up(ifp, !is_up);
+					if_up(ifp, is_up);
 
 					/*
 					 * Update EVPN VNI when SVI MAC change


### PR DESCRIPTION
Problem description:
In some race conditions, vrrp doesnot get newlink update notifications from zebra.

Fix:
Kernel flags are updated in ifp->flags in all scenarios as per our code though protodown is set. So when proto is coming up, is_up has already set when kernel sends UP status even when protodown happened so it is called with false instead of true. Made code changes accordingly to send true based on current operative status.
Note: This happens only in below order
1) Kernel sends flags=0x11043 protodown=1
ifp->flags = 0x11043  => we update in our code based on kernel flags.

2) Kernel sends flags=0x11043 protodown=0
Now , flags are already set as up in previous call, so it tries to call if_up with false.