### PR TITLE
bgpd: High coverity changes - Uninitialzed scalar variable

### DIFF
--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -1229,7 +1229,7 @@ void subgroup_default_withdraw_packet(struct update_subgroup *subgrp)
 		 * +/- (just in case)         +  1
 		 * null terminator            +  1
 		 * ============================ 29 */
-		char tx_id_buf[30];
+		char tx_id_buf[30] = {};
 
 		if (addpath_capable)
 			snprintf(tx_id_buf, sizeof(tx_id_buf),


### PR DESCRIPTION
This commit addresses uninitialised variable issue in bgp_updgrp_packet.c

CID 12282: Uninitialized scalar variable (UNINIT)
uninit_use_in_call: Using uninitialized value *tx_id_buf as argument to %s when calling zlog_ref

Description:
Initialised the same.