### PR TITLE
bgpd: Crash due to usage of freed up evpn_overlay attr

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -554,7 +554,7 @@ void evpn_overlay_free(struct bgp_route_evpn *bre)
 	XFREE(MTYPE_BGP_EVPN_OVERLAY, bre);
 }
 
-static struct bgp_route_evpn *evpn_overlay_intern(struct bgp_route_evpn *bre)
+struct bgp_route_evpn *evpn_overlay_intern(struct bgp_route_evpn *bre)
 {
 	struct bgp_route_evpn *find;
 

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -683,5 +683,6 @@ bgp_attr_set_vnc_subtlvs(struct attr *attr,
 
 extern bool route_matches_soo(struct bgp_path_info *pi, struct ecommunity *soo);
 extern void evpn_overlay_free(struct bgp_route_evpn *bre);
+extern struct bgp_route_evpn *evpn_overlay_intern(struct bgp_route_evpn *bre);
 
 #endif /* _QUAGGA_BGP_ATTR_H */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5197,6 +5197,7 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 		 * attr->evpn_overlay, so that, this can be stored in adj_in.
 		 */
 		if (evpn && afi == AFI_L2VPN) {
+			evpn = evpn_overlay_intern(evpn);
 			bgp_attr_set_evpn_overlay(attr, evpn);
 			p_evpn = NULL;
 		}


### PR DESCRIPTION
Reason:
Use-after-free in evpn_overlay due to incorrect reference counting when storing routes in Adj-RIB-In.

1) In bgp_update_receive, we parse the attributes first in bgp_attr_parse_ret
   and it will intern those attributes, so refcnt for them would become 0->1. We
   can't do evpn_overlay attribute processing here, as it requires NLRI/EVPN
   knowledge, which happens via bgp_nlri_parse later. So we don't know yet if
   evpn_overlay attribute would be created or not.

2) Later in bgp_update, the evpn_overlay is created with refcnt=0 and assigned to
   attr, stored in adj_in via bgp_adj_in_set(), then interned (refcnt→1). For all
   other used attributes, the refcnt goes to 1->2.

3) At the end of bgp_update_receive(), bgp_attr_unintern_sub(attr) is called, which
   causes evpn_overlay attribute to have refcnt 1->0, so it frees it up, leaving
   adj_in->attr->evpn_overlay with a dangling pointer. Any other attributes that are
   used have refcnt 2->1, so they are not freed up.

4) On next call to bgp_update, in bgp_adj_in_set(), when we try to lookup attr from
   adj_in->attr, it doesn't find a match as the old attr in adj_in->attr has freed
   up evpn_overlay. So in bgp_adj_in_set, we try to unintern the corrupted attr,
   causing hash lookup failure (the key has changed as attr->evpn_overlay is freed
   up, and that is part of hash generation) and assert.

Fix:
Intern evpn_overlay immediately before assigning to attr in the Adj-RIB-In path. This implements the double-refcount pattern used by other attributes like ecommunity: evpn_overlay_intern() sets refcnt=1, bgp_attr_intern() increments to refcnt=2, bgp_attr_unintern_sub() decrements to refcnt=1, leaving adj_in->attr with a valid reference.




BT:

#8  0x0000560dfdb1b01e in bgp_attr_unintern (pattr=pattr@entry=0x560e1e2e14b8) at ../bgpd/bgp_attr.c:1517
#9  0x0000560dfdc60b1e in bgp_adj_in_set (dest=dest@entry=0x560e1e25a130, peer=peer@entry=0x560e1e230f90, attr=attr@entry=0x7ffc6661eb70, addpath_id=addpath_id@entry=0, labels=labels@entry=0x7ffc6661c660) at ../bgpd/bgp_advertise.c:173
#10 0x0000560dfdba10f5 in bgp_update (peer=peer@entry=0x560e1e230f90, p=p@entry=0x7ffc6661c930, addpath_id=addpath_id@entry=0, attr=attr@entry=0x7ffc6661eb70, afi=afi@entry=AFI_L2VPN, safi=<optimized out>, safi@entry=SAFI_EVPN, 
    type=<optimized out>, sub_type=<optimized out>, prd=<optimized out>, label=<optimized out>, num_labels=<optimized out>, soft_reconfig=<optimized out>, evpn=<optimized out>) at ../bgpd/bgp_route.c:5127
#11 0x0000560dfdb339de in process_type5_route (peer=peer@entry=0x560e1e230f90, afi=afi@entry=AFI_L2VPN, safi=safi@entry=SAFI_EVPN, attr=attr@entry=0x7ffc6661eb70, pfx=<optimized out>, psize=psize@entry=34, addpath_id=<optimized out>)
    at ../bgpd/bgp_evpn.c:5150
#12 0x0000560dfdb3d009 in bgp_nlri_parse_evpn (peer=peer@entry=0x560e1e230f90, attr=attr@entry=0x7ffc6661eb70, packet=<optimized out>, withdraw=withdraw@entry=false) at ../bgpd/bgp_evpn.c:6253
#13 0x0000560dfdb81136 in bgp_nlri_parse (peer=peer@entry=0x560e1e230f90, attr=attr@entry=0x7ffc6661eb70, packet=packet@entry=0x7ffc6661eb50, mp_withdraw=mp_withdraw@entry=false) at ../bgpd/bgp_packet.c:349
#14 0x0000560dfdb8146c in bgp_update_receive (connection=connection@entry=0x560e1e22fdf0, peer=peer@entry=0x560e1e230f90, size=size@entry=106) at ../bgpd/bgp_packet.c:2516
#15 0x0000560dfdb87760 in bgp_process_packet (thread=<optimized out>) at ../bgpd/bgp_packet.c:4089

