### PR TITLE
bgpd: Move mpath pointer from bgp_path_info to bgp_dest

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -4701,12 +4701,12 @@ static void bgp_packet_nhc(struct stream *s, struct peer *peer, afi_t afi, safi_
 	if (!bpi)
 		return;
 
-	if (bgp_path_info_mpath_count(bpi) < 2 && !nhc)
+	if (bgp_path_info_mpath_count(bpi->net) < 2 && !nhc)
 		return;
 
 	prefix = bgp_dest_get_prefix(bpi->net);
 
-	total = bgp_path_info_mpath_count(bpi) * IPV4_MAX_BYTELEN;
+	total = bgp_path_info_mpath_count(bpi->net) * IPV4_MAX_BYTELEN;
 	total += IPV4_MAX_BYTELEN; /* Next-hop BGP ID */
 
 	stream_putc(s, BGP_ATTR_FLAG_OPTIONAL | BGP_ATTR_FLAG_TRANS);
@@ -4748,7 +4748,7 @@ static void bgp_packet_nhc(struct stream *s, struct peer *peer, afi_t afi, safi_
 	 * |               Next-next-hop BGP IDs (variable)                |
 	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 	 */
-	if (bgp_path_info_mpath_count(bpi) > 1) {
+	if (bgp_path_info_mpath_count(bpi->net) > 1) {
 		if (bgp_debug_update(peer, NULL, NULL, 1))
 			zlog_debug("%pBP: Sending NHC TLV (%d) for %pFX", peer,
 				   BGP_ATTR_NHC_TLV_NNHN, prefix);

--- a/bgpd/bgp_mpath.h
+++ b/bgpd/bgp_mpath.h
@@ -17,12 +17,12 @@ enum bgp_wecmp_behavior {
 	BGP_WECMP_BEHAVIOR_USE_RECURSIVE_VALUE = 3,
 };
 
-/* Supplemental information linked to bgp_path_info for keeping track of
+/* Supplemental information linked to bgp_dest for keeping track of
  * multipath selections, lazily allocated to save memory
  */
 struct bgp_path_info_mpath {
-	/* Points to bgp_path_info associated with this multipath info */
-	struct bgp_path_info *mp_info;
+	/* Points to bgp_dest associated with this multipath info */
+	struct bgp_dest *mp_dest;
 
 	/* When attached to best path, the number of selected multipaths */
 	uint16_t mp_count;
@@ -71,10 +71,9 @@ extern struct bgp_path_info *
 bgp_path_info_mpath_next(struct bgp_path_info *path);
 
 /* Accessors for multipath information */
-extern uint32_t bgp_path_info_mpath_count(struct bgp_path_info *path);
-extern struct attr *bgp_path_info_mpath_attr(struct bgp_path_info *path);
-extern enum bgp_wecmp_behavior bgp_path_info_mpath_chkwtd(struct bgp *bgp,
-							  struct bgp_path_info *path);
-extern uint64_t bgp_path_info_mpath_cumbw(struct bgp_path_info *path);
+extern uint32_t bgp_path_info_mpath_count(struct bgp_dest *dest);
+extern struct attr *bgp_path_info_mpath_attr(struct bgp_dest *dest);
+extern enum bgp_wecmp_behavior bgp_path_info_mpath_chkwtd(struct bgp *bgp, struct bgp_dest *dest);
+extern uint64_t bgp_path_info_mpath_cumbw(struct bgp_dest *dest);
 
 #endif /* _FRR_BGP_MPATH_H */

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -296,10 +296,6 @@ struct bgp_path_info {
 	/* Extra information */
 	struct bgp_path_info_extra *extra;
 
-
-	/* Multipath information */
-	struct bgp_path_info_mpath *mpath;
-
 	/* Uptime.  */
 	time_t uptime;
 
@@ -669,7 +665,6 @@ static inline void prep_for_rmap_apply(struct bgp_path_info *dst_pi,
 	dst_pi->flags = src_pi->flags;
 	dst_pi->type = src_pi->type;
 	dst_pi->sub_type = src_pi->sub_type;
-	dst_pi->mpath = src_pi->mpath;
 	if (src_pi->extra) {
 		memcpy(dst_pie, src_pi->extra,
 		       sizeof(struct bgp_path_info_extra));

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3475,7 +3475,7 @@ route_set_ecommunity_lb(void *rule, const struct prefix *prefix, void *object)
 		if (!CHECK_FLAG(path->flags, BGP_PATH_SELECTED))
 			return RMAP_OKAY;
 
-		bw_bytes = bgp_path_info_mpath_cumbw(path);
+		bw_bytes = bgp_path_info_mpath_cumbw(path->net);
 		if (!bw_bytes)
 			return RMAP_OKAY;
 
@@ -3486,7 +3486,7 @@ route_set_ecommunity_lb(void *rule, const struct prefix *prefix, void *object)
 			return RMAP_OKAY;
 
 		bw_bytes = (peer->bgp->lb_ref_bw * 1000 * 1000) / 8;
-		mpath_count = bgp_path_info_mpath_count(path);
+		mpath_count = bgp_path_info_mpath_count(path->net);
 		bw_bytes *= mpath_count;
 	}
 

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -17,6 +17,7 @@
 #include "bgpd/bgp_table.h"
 #include "bgp_addpath.h"
 #include "bgp_trace.h"
+#include "bgp_mpath.h"
 
 void bgp_table_lock(struct bgp_table *rt)
 {
@@ -88,6 +89,11 @@ inline struct bgp_dest *bgp_dest_unlock_node(struct bgp_dest *dest)
 						   &dest->tx_addpath, rt->afi,
 						   rt->safi);
 		}
+
+		/* Free mpath if exists */
+		if (dest->mpath)
+			bgp_path_info_mpath_free(&dest->mpath);
+
 		XFREE(MTYPE_BGP_NODE, dest);
 		dest = NULL;
 		rn->info = NULL;
@@ -113,6 +119,11 @@ static void bgp_node_destroy(route_table_delegate_t *delegate,
 						   &dest->tx_addpath,
 						   rt->afi, rt->safi);
 		}
+
+		/* Free mpath if exists */
+		if (dest->mpath)
+			bgp_path_info_mpath_free(&dest->mpath);
+
 		XFREE(MTYPE_BGP_NODE, dest);
 		node->info = NULL;
 	}

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -107,6 +107,9 @@ struct bgp_dest {
 	struct bgp_addpath_node_data tx_addpath;
 
 	enum bgp_path_selection_reason reason;
+
+	/* Multipath information */
+	struct bgp_path_info_mpath *mpath;
 };
 
 DECLARE_LIST(zebra_announce, struct bgp_dest, zai);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1642,7 +1642,7 @@ enum zclient_send_status bgp_zebra_announce_actual(struct bgp_dest *dest,
 	metric = info->attr->med;
 
 	/* Determine if we're doing weighted ECMP or not */
-	do_wt_ecmp = bgp_path_info_mpath_chkwtd(bgp, info);
+	do_wt_ecmp = bgp_path_info_mpath_chkwtd(bgp, dest);
 	bgp_zebra_announce_parse_nexthop(info, p, bgp, &api, &valid_nh_count, table->afi,
 					 table->safi, &nhg_id, &metric, &tag, &allow_recursion,
 					 do_wt_ecmp);


### PR DESCRIPTION
This change optimizes BGP memory usage 
by relocating the multipath (mpath) pointer from bgp_path_info to bgp_dest.

In ECMP scenarios, the number of bgp_path_info entries can be up to MULTIPATH_NUM times that of bgp_dest. 
By moving the mpath pointer to bgp_dest, we reduce the total number of mpath pointers allocated, 
leading to lower memory consumption in large BGP deployments.