### PR TITLE
bgpd: Notify all incoming/outgoing on peer group notify unconfig

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3231,8 +3231,8 @@ void peer_group_notify_unconfig(struct peer_group *group)
 		if (other && other->connection->status != Deleted) {
 			other->group = NULL;
 			peer_notify_unconfig(other->connection);
-		} else
-			peer_notify_unconfig(peer->connection);
+		}
+		peer_notify_unconfig(peer->connection);
 	}
 }
 


### PR DESCRIPTION
The peer_group_notify_unconfig function was only sending Notification to either the incoming or outgoing connection, but not both. If you are in early stages of bringing up a neighbor on both incoming and outgoing connections. If the cli is changed that something about a peer group changes the code is only notifying either incoming or outgoing, but not both.  If we need to reset the connections, which is what peer_notify_unconfig does, then we need to reset both.