### PR TITLE
bgpd: fix routemap evpn type-5 default route check

### DIFF
--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -424,13 +424,20 @@ static inline void ip_prefix_from_type5_prefix(const struct prefix_evpn *evp,
 	}
 }
 
-static inline int is_evpn_prefix_default(const struct prefix *evp)
+static inline bool is_evpn_prefix_default(const struct prefix *evp)
 {
 	if (evp->family != AF_EVPN)
-		return 0;
+		return false;
 
-	return ((evp->u.prefix_evpn.prefix_addr.ip_prefix_length  == 0) ?
-		1 : 0);
+	/*
+	 * EVPN default type-5 route
+	 * RD:[5]:[0]:[0.0.0.0/0]/352 or RD:[5]:[0]:[::/0]/352
+	 */
+	if ((evp->u.prefix_evpn.route_type == BGP_EVPN_IP_PREFIX_ROUTE) &&
+	    (evp->u.prefix_evpn.prefix_addr.ip_prefix_length == 0))
+		return true;
+
+	return false;
 }
 
 static inline void ip_prefix_from_type2_prefix(const struct prefix_evpn *evp,


### PR DESCRIPTION
route-map match condition on evpn default-route does not have proper check that its truly type-5 before checking prefixlen being 0.

In absence of the fix, the set condition applied to all evpn routes as evpn prefix is type union so just checking for prefixlen 0 is not sufficient.



Testing Done:

Apply ingress route-map policy:

```
route-map POLICY_OUT_SS permit 10
 match evpn default-route
 set metric 6666
```

Default route contains metric only to default
```
 route: BGP routing table entry for 144.1.1.6:4:[5]:[0]:[0.0.0.0/0]/352 Paths: (2 available, best #1)
  Advertised to non peer-group peers:
  leaf-21(swp1) leaf-22(swp2)
  Route [5]:[0]:[0]:[0.0.0.0] VNI 104002
  651004 652000 651001 660000
    6.0.0.1 from leaf-21(swp1) (6.0.0.26)
      Origin IGP, metric 6666, valid, external,
         bestpath-from-AS 651004, best (Router ID)
      Extended Community: RT:4640:104002 ET:8
         Rmac:00:02:00:00:00:04
      Last update: Fri Oct  7 20:25:39 2022
  Route [5]:[0]:[0]:[0.0.0.0] VNI 104002
  651004 652000 651001 660000
    6.0.0.1 from leaf-22(swp2) (6.0.0.27)
      Origin IGP, metric 6666, valid, external
      Extended Community: RT:4640:104002 ET:8
         Rmac:00:02:00:00:00:04
      Last update: Fri Oct  7 20:25:39 2022
  ```
  
  Signed-off-by: Chirag Shah <chirag@nvidia.com>
  