### PR TITLE
bgpd: Check L3VNI status before adv evpn vrf routes

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -4594,6 +4594,9 @@ void update_advertise_vrf_routes(struct bgp *bgp_vrf)
 	if (!bgp_evpn)
 		return;
 
+	if (!is_l3vni_live(bgp_vrf))
+		return; /* Nothing to do if no l3vni */
+
 	/* update all ipv4 routes */
 	if (advertise_type5_routes_bestpath(bgp_vrf, AFI_IP) ||
 	    advertise_type5_routes_multipath(bgp_vrf, AFI_IP))


### PR DESCRIPTION
Check L3VNI is UP before advertising any evpn vrf/Tye-5 routes. There can be a timing EVPN type-5 default route is advertised with VNI 0 and invalid RTs where l3vni is not known to bgpd. The check ensures all type-5 route advertisement check for L3VNI UP state.


Testing:

Validating via flapping vrf interface,
disable/enable advetise-pip in presence of advetise default route as Type-5.
Without the fix, default routes were advertised as VNI 0.

Signed-off--by: Chirag Shah <chirag@nvidia.com>