### PR TITLE
pimd: demote a warning to a debug to avoid spamming the logs

### DIFF
--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -1825,9 +1825,9 @@ void igmp_v3_recv_query(struct gm_sock *igmp, const char *from_str,
 		if (group_addr.s_addr == INADDR_ANY) {
 			/* this is a general query */
 			/* log that general query should have the s_flag set */
-			zlog_warn(
-				"General IGMP query v3 from %s on %s: Suppress Router-Side Processing flag is clear",
-				from_str, ifp->name);
+			if (PIM_DEBUG_GM_TRACE)
+				zlog_debug("General IGMP query v3 from %s on %s: Suppress Router-Side Processing flag is clear",
+					   from_str, ifp->name);
 		} else {
 			struct gm_group *group;
 


### PR DESCRIPTION
If a router/switch keeps sending us a general igmp query with a flag we don't expect, we shouldn't spam the logs, especially if the condition is totally harmless and can be just ignored.

Just move it under a debug config.

Sample log firing every 15 seconds:
```
02:10:32 pimd: General IGMP query v3 from 192.168.1.1 on eth0: Suppress Router-Side Processing flag is clear
02:10:47 pimd: General IGMP query v3 from 192.168.1.1 on eth0: Suppress Router-Side Processing flag is clear
02:11:02 pimd: General IGMP query v3 from 192.168.1.1 on eth0: Suppress Router-Side Processing flag is clear
02:11:17 pimd: General IGMP query v3 from 192.168.1.1 on eth0: Suppress Router-Side Processing flag is clear
```