### PR TITLE
zebra: Coverity issue (Null pointer dereference)

### DIFF
--- a/zebra/zebra_srv6_vty.c
+++ b/zebra/zebra_srv6_vty.c
@@ -464,7 +464,7 @@ static void do_show_srv6_sid_json(struct vty *vty, json_object **json, struct sr
 				json_object_string_add(json_sid_ctx, "vrfName", vrf->name);
 
 			zvrf = vrf_info_lookup(sid_ctx->ctx.vrf_id);
-			if (vrf)
+			if (zvrf)
 				json_object_int_add(json_sid_ctx, "table", zvrf->table_id);
 		}
 		if (sid_ctx->ctx.ifindex) {


### PR DESCRIPTION
This commit addresses null pointer dereference in zebra/zebra_srv6_vty.c

CID 110225: Dereference null return value (NULL_RETURNS) dereference: Dereferencing zvrf, which is known to be NULL.

Description:
Handled null check accordingly.