### PR TITLE
zebra: Coverity issue Medium null pointer dereference

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -683,8 +683,12 @@ bool nl_attr_put(struct nlmsghdr *n, unsigned int maxlen, int type,
 
 	len = RTA_LENGTH(alen);
 
-	if (NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len) > maxlen)
+	if (NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len) > maxlen) {
+		flog_err(EC_ZEBRA_NETLINK_LENGTH_ERROR,
+			 "%s: message exceeded bound: maxlen=%u type=%d alen=%u", __func__, maxlen,
+			 type, alen);
 		return false;
+	}
 
 	rta = (struct rtattr *)(((char *)n) + NLMSG_ALIGN(n->nlmsg_len));
 	rta->rta_type = type;

--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -1511,6 +1511,12 @@ void zebra_evpn_rem_macip_del(vni_t vni, const struct ethaddr *macaddr, uint16_t
 	struct zebra_vrf *zvrf;
 	char buf1[INET6_ADDRSTRLEN];
 
+	if (!macaddr) {
+		if (IS_ZEBRA_DEBUG_VXLAN)
+			zlog_debug("NULL MAC address provided for remote MACIP DEL VNI %u", vni);
+		return;
+	}
+
 	/* Locate EVPN hash entry - expected to exist. */
 	zevpn = zebra_evpn_lookup(vni);
 	if (!zevpn) {

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -3841,6 +3841,12 @@ struct nhg_hash_entry *zebra_nhg_proto_add(uint32_t id, int type,
 
 	new = zebra_nhg_rib_find_nhe(&lookup, afi);
 
+	if (!new) {
+		if (IS_ZEBRA_DEBUG_NHG)
+			zlog_debug("%s: zebra_nhg_rib_find_nhe failed for id %u", __func__, id);
+		return NULL;
+	}
+
 	zebra_nhg_increment_ref(new);
 
 	/* Capture zapi client info */

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -86,6 +86,9 @@ struct zebra_router_table *zebra_router_find_next_zrt(struct zebra_vrf *zvrf,
 	finder.tableid = tableid;
 	finder.ns_id = zvrf->zns->ns_id;
 	zrt = RB_NFIND(zebra_router_table_head, &zrouter.tables, &finder);
+	if (!zrt)
+		return NULL;
+
 	if (zrt->afi == afi && zrt->safi == safi && zrt->tableid == tableid &&
 	    zrt->ns_id == finder.ns_id)
 		zrt = RB_NEXT(zebra_router_table_head, zrt);


### PR DESCRIPTION
This commit addresses null pointer dereference in zebra folder.

CID covering:
109898, 72706, 90819, 109575

Description:
Handled null check accordingly.