### PR TITLE
bgpd: fix BGP_ATTR_ORIGINATOR_ID flag in outbound attribute cache

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2456,7 +2456,7 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
 	   set the originator id */
 	if (ibgp_to_ibgp && (!CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_ORIGINATOR_ID)))) {
 		IPV4_ADDR_COPY(&(attr->originator_id), &(from->remote_id));
-		SET_FLAG(attr->flag, BGP_ATTR_ORIGINATOR_ID);
+		SET_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_ORIGINATOR_ID));
 	}
 
 	/* Remove MED if its an EBGP peer - will get overwritten by route-maps


### PR DESCRIPTION
Fix the setting of the BGP_ATTR_ORIGINATOR_ID flag in the outbound attribute cache.