### PR TITLE
bgpd: fix BGP_ATTR_LOCAL_PREF being set appropriately

### DIFF
--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -98,7 +98,7 @@ static void encap_attr_export_ce(struct attr *new, struct attr *orig,
 	if (!CHECK_FLAG(new->flag, BGP_ATTR_MULTI_EXIT_DISC)) {
 		uint32_t med = 255;
 
-		if (CHECK_FLAG(new->flag, BGP_ATTR_LOCAL_PREF)) {
+		if (CHECK_FLAG(new->flag, ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF))) {
 			if (new->local_pref > 255)
 				med = 0;
 			else
@@ -645,7 +645,7 @@ encap_attr_export(struct attr *new, struct attr *orig,
 	if (!CHECK_FLAG(new->flag, BGP_ATTR_MULTI_EXIT_DISC)) {
 		uint32_t med = 255;
 
-		if (CHECK_FLAG(new->flag, BGP_ATTR_LOCAL_PREF)) {
+		if (CHECK_FLAG(new->flag, ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF))) {
 			if (new->local_pref > 255)
 				med = 0;
 			else


### PR DESCRIPTION
The BGP_ATTR_XXX flags are all using ATTR_FLAG_BIT to find the right spot in the bitfield of the flags
variable.  From looking at 004f9909c866ddf8d04e680db00120071dd22344 I decided to go looking at the rest of them.  This is where I found it wrong too.