### PR TITLE
bgpd: fix expanded extcomm list delete

### DIFF
--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -1108,13 +1108,15 @@ struct ecommunity *ecommunity_list_match_delete(struct ecommunity *ecom,
 	struct ecommunity local_ecom = {.size = 1};
 	struct ecommunity_val local_eval = {0};
 
+	local_ecom.unit_size = ecom->unit_size;
+	local_ecom.disable_ieee_floating = ecom->disable_ieee_floating;
 	for (i = 0; i < ecom->size; i++) {
 		local_ecom.val = ecom->val + (i * ECOMMUNITY_SIZE);
 		for (entry = list->head; entry; entry = entry->next) {
 			if (((entry->style == EXTCOMMUNITY_LIST_STANDARD) &&
 			     ecommunity_include(entry->u.ecom, &local_ecom)) ||
-			   ((entry->style == EXTCOMMUNITY_LIST_EXPANDED) &&
-			    ecommunity_regexp_match(ecom, entry->reg))) {
+			    ((entry->style == EXTCOMMUNITY_LIST_EXPANDED) &&
+			     ecommunity_regexp_match(&local_ecom, entry->reg))) {
 				if (entry->direct == COMMUNITY_PERMIT) {
 					com_index_to_delete[delete_index] = i;
 					delete_index++;
@@ -1122,6 +1124,7 @@ struct ecommunity *ecommunity_list_match_delete(struct ecommunity *ecom,
 				break;
 			}
 		}
+		ecommunity_strfree(&local_ecom.str);
 	}
 
 	/* Delete all of the extended communities we flagged for deletion */


### PR DESCRIPTION
this fix is related to extended communitylist deletion with expanded regex rule.

current behavior:
if a value match the regex, all the extended community is deletedd.

expected behavior:
only values that match ethe regex are removed