### PR TITLE
zebra: Return checks are missing in some spots

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -800,8 +800,8 @@ static int netlink_request_intf_addr(struct nlsock *netlink_cmd, int family,
 	req.ifm.ifi_family = family;
 
 	/* Include filter, if specified. */
-	if (filter_mask)
-		nl_attr_put32(&req.n, sizeof(req), IFLA_EXT_MASK, filter_mask);
+	if (filter_mask && !nl_attr_put32(&req.n, sizeof(req), IFLA_EXT_MASK, filter_mask))
+		return -1;
 
 	return netlink_request(netlink_cmd, &req);
 }

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2461,11 +2461,13 @@ static int netlink_neigh_update(int cmd, int ifindex, void *addr, char *lla,
 	} else
 		req.ndm.ndm_state = NUD_FAILED;
 
-	nl_attr_put(&req.n, sizeof(req), NDA_PROTOCOL, &protocol,
-		    sizeof(protocol));
+	if (!nl_attr_put(&req.n, sizeof(req), NDA_PROTOCOL, &protocol, sizeof(protocol)))
+		return -1;
+
 	req.ndm.ndm_type = RTN_UNICAST;
-	nl_attr_put(&req.n, sizeof(req), NDA_DST, addr,
-		    family2addrsize(family));
+	if (!nl_attr_put(&req.n, sizeof(req), NDA_DST, addr, family2addrsize(family)))
+		return -1;
+
 	if (lla)
 		nl_attr_put(&req.n, sizeof(req), NDA_LLADDR, lla, llalen);
 

--- a/zebra/tc_netlink.c
+++ b/zebra/tc_netlink.c
@@ -553,6 +553,9 @@ static ssize_t netlink_tfilter_msg_encode(int cmd, struct zebra_dplane_ctx *ctx,
 			dplane_ctx_tc_filter_get_ip_proto(ctx));
 
 		nest = nl_attr_nest(&req->n, datalen, TCA_OPTIONS);
+		if (!nest)
+			return 0;
+
 		switch (dplane_ctx_tc_filter_get_kind(ctx)) {
 		case TC_FILTER_FLOWER: {
 			ret = netlink_tfilter_flower_put_options(&req->n, datalen, ctx);

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -458,6 +458,9 @@ static int netlink_route_info_encode(struct netlink_route_info *ri,
 			}
 			vxlan = &nhi->encap_info.vxlan_encap;
 			nest = nl_attr_nest(&req->n, in_buf_len, RTA_ENCAP);
+			if (!nest)
+				return 0;
+
 			if (!nl_attr_put32(&req->n, in_buf_len, VXLAN_VNI, vxlan->vni)) {
 				zlog_err("%s: Failed to add VXLAN_VNI nl attribute", __func__);
 				return 0;


### PR DESCRIPTION
coverity is pointing out that in most instances FRR is doing return checks.  Looks like just some new stuff that has come up due to other checks going in place.