### PR TITLE
zebra: Refactor SRv6 netlink code to remove duplication

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2068,8 +2068,7 @@ static bool _netlink_route_build_singlepath(const struct prefix *p,
 			nl_attr_nest_end(nlmsg, nest);
 		}
 
-		if (nexthop->nh_srv6->seg6_segs &&
-		    nexthop->nh_srv6->seg6_segs->num_segs &&
+		if (nexthop->nh_srv6->seg6_segs && nexthop->nh_srv6->seg6_segs->num_segs &&
 		    !sid_zero(nexthop->nh_srv6->seg6_segs)) {
 			struct rtattr *nest;
 
@@ -3322,8 +3321,8 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 
 				if (nh->nh_srv6->seg6_segs && nh->nh_srv6->seg6_segs->num_segs &&
 				    !sid_zero(nh->nh_srv6->seg6_segs) &&
-				    nh->nh_srv6->seg6local_action == ZEBRA_SEG6_LOCAL_ACTION_UNSPEC) {
-
+				    nh->nh_srv6->seg6local_action ==
+					    ZEBRA_SEG6_LOCAL_ACTION_UNSPEC) {
 					if (!nl_attr_put16(&req->n, buflen,
 					    NHA_ENCAP_TYPE,
 					    LWTUNNEL_ENCAP_SEG6))


### PR DESCRIPTION
The SRv6 netlink encoding logic in `rt_netlink.c` contains significant code duplication between the single-path route and nexthop encoders.

This pull request refactors the duplicated logic into common helper functions. 

---

It also fixes a couple of warnings reported by checkpatch:

```
Report for rt_netlink.c | 2 issues
===============================================
< WARNING: Too many leading tabs - consider code refactoring
< #3341: FILE: /tmp/f1-896649/rt_netlink.c:3341:
Checkpatch found Errors:
Report for rt_netlink.c | 2 issues
===============================================
< WARNING: Too many leading tabs - consider code refactoring
< #3341: FILE: /tmp/f1-896649/rt_netlink.c:3341:
```
https://ci1.netdef.org/browse/FRR-PULLREQ3-CHECKOUT-11869

---

This is a pure refactoring with no functional changes.