### PR TITLE
lib: fix memleak in nexthop label copy

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -592,6 +592,12 @@ void nexthop_add_labels(struct nexthop *nexthop, enum lsp_types_t ltype,
 	if (num_labels == 0)
 		return;
 
+	/* Free existing labels if present to prevent memory leak */
+	if (nexthop->nh_label != NULL) {
+		XFREE(MTYPE_NH_LABEL, nexthop->nh_label);
+		nexthop->nh_label = NULL;
+	}
+
 	/* Enforce limit on label stack size */
 	if (num_labels > MPLS_MAX_LABELS)
 		num_labels = MPLS_MAX_LABELS;


### PR DESCRIPTION
Free the existing one before allocating new label info.

==2996408== 8 bytes in 1 blocks are possibly lost in loss record 5,746 of 23,021
==2996408==    at 0x48465EF: calloc (vg_replace_malloc.c:1328)
==2996408==    by 0x4943710: qcalloc (memory.c:111)
==2996408==    by 0x4955996: nexthop_add_labels (nexthop.c:601)
==2996408==    by 0x49564CE: nexthop_copy_no_recurse (nexthop.c:891)
==2996408==    by 0x49565DA: nexthop_copy (nexthop.c:913)
==2996408==    by 0x4956674: nexthop_dup (nexthop.c:937)
==2996408==    by 0x495B633: copy_nexthops (nexthop_group.c:441)
==2996408==    by 0x1D5FE6: dplane_ctx_route_init (zebra_dplane.c:3777)
==2996408==    by 0x1D79FB: dplane_route_update_internal (zebra_dplane.c:4565)
==2996408==    by 0x1D80B2: dplane_route_delete (zebra_dplane.c:4895)
==2996408==    by 0x22D3B1: rib_uninstall_kernel (zebra_rib.c:732)
==2996408==    by 0x22DBF3: rib_process_del_fib (zebra_rib.c:1035)
==2996408==    by 0x22EAC5: rib_process (zebra_rib.c:1502)
==2996408==    by 0x2314F0: process_subq_route (zebra_rib.c:2692)
==2996408==    by 0x232C76: process_subq (zebra_rib.c:3307)
==2996408==    by 0x232D5A: meta_queue_process (zebra_rib.c:3346)
==2996408==    by 0x49C7265: work_queue_run (workqueue.c:282)
==2996408==    by 0x49B6D52: event_call (event.c:2013)
==2996408==    by 0x492EAF2: frr_run (libfrr.c:1257)
==2996408==    by 0x1AA646: main (main.c:552)
