### PR TITLE
bgpd: EVPN init local variable

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2385,7 +2385,7 @@ static struct bgpevpn *evpn_create_update_vni(struct bgp *bgp, vni_t vni)
 {
 	struct bgpevpn *vpn;
 	struct in_addr mcast_grp = {INADDR_ANY};
-	struct ipaddr orignator_ip;
+	struct ipaddr orignator_ip = {};
 
 	vpn = bgp_evpn_lookup_vni(bgp, vni);
 	if (!vpn) {


### PR DESCRIPTION
==3758825== Use of uninitialised value of size 8
==3758825==    at 0x49ACE10: rn_hash_node_add (table.c:28)
==3758825==    by 0x49AD232: route_node_set (table.c:66)
==3758825==    by 0x49AD940: route_node_get (table.c:279)
==3758825==    by 0x2176C1: bgp_node_get (bgp_table.h:249)
==3758825==    by 0x219F66: bgp_evpn_vni_ip_node_get (bgp_evpn.c:808)
==3758825==    by 0x21A1B1: bgp_evpn_vni_node_get (bgp_evpn.c:897)
==3758825==    by 0x21D615: update_evpn_route (bgp_evpn.c:2349)
==3758825==    by 0x227E67: bgp_evpn_local_vni_add (bgp_evpn.c:7471)
==3758825==    by 0x348A09: bgp_zebra_process_local_vni (bgp_zebra.c:3355)
==3758825==    by 0x49DDC39: zclient_read (zclient.c:4868)
==3758825==    by 0x49B6D91: event_call (event.c:2013)
==3758825==    by 0x492EAF2: frr_run (libfrr.c:1257)
==3758825==    by 0x1F24A0: main (bgp_main.c:548)
==3758825==  Uninitialised value was created by a stack allocation
==3758825==    at 0x23DCB0: evpn_create_update_vni (bgp_evpn_vty.c:2381)