### PR TITLE
ospfd: Fix crash when entering `ospf authentication key XX`

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -7697,8 +7697,10 @@ DEFUN (ip_ospf_authentication_key,
 		ospf_if_update_params(ifp, addr);
 	}
 
-	strlcpy((char *)params->auth_simple, argv[3]->arg,
-		sizeof(params->auth_simple));
+	if (!argv_find(argv, argc, "AUTH_KEY", &idx))
+		return CMD_WARNING;
+
+	strlcpy((char *)params->auth_simple, argv[idx]->arg, sizeof(params->auth_simple));
 	SET_IF_PARAM(params, auth_simple);
 
 	return CMD_SUCCESS;


### PR DESCRIPTION
The code is hard coding the index for the argv_find call.  This is ok for the `ip ospf authentication-key AUTH_KEY [A.B.C.D]` but the DEFUN_HIDDEN that uses the ip_ospf_authentication_key too has a different number of parameters so it causes a crash. Let's make the code be a bit smarter about this problem.

Fixes: #19908