### PR TITLE
ospfd: Fix NULL Pointer Deference when dumping opaque lsa

### DIFF
--- a/ospfd/ospf_ext.c
+++ b/ospfd/ospf_ext.c
@@ -1706,16 +1706,18 @@ static void ospf_ext_lsa_schedule(struct ext_itf *exti, enum lsa_opcode op)
  */
 
 /* Check NULL for vty. If vty is not available, dump info via zlog */
-#define check_tlv_size(size, msg)                                              \
-	do {                                                                   \
-		if (ntohs(tlvh->length) != size) {                             \
-			if (vty != NULL)                         \
-				vty_out(vty, "  Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!\n",  \
-					msg, ntohs(tlvh->length), size);               \
-			else                                              \
-				zlog_debug("    Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!", msg, ntohs(tlvh->length), size);    \
-			return OSPF_MAX_LSA_SIZE + 1;                            \
-		}                                                              \
+#define check_tlv_size(size, msg)                                                                           \
+	do {                                                                                                \
+		if (ntohs(tlvh->length) != size) {                                                          \
+			if (vty != NULL)                                                                    \
+				vty_out(vty,                                                                \
+					"  Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!\n",    \
+					msg, ntohs(tlvh->length), size);                                    \
+			else                                                                                \
+				zlog_debug("    Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!", \
+					   msg, ntohs(tlvh->length), size);                                 \
+			return OSPF_MAX_LSA_SIZE + 1;                                                       \
+		}                                                                                           \
 	} while (0)
 
 /* Cisco experimental SubTLV */

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -1202,17 +1202,18 @@ static int ospf_router_info_lsa_update(struct ospf_lsa *lsa)
  * Following are vty session control functions.
  *------------------------------------------------------------------------*/
 
-#define check_tlv_size(size, msg)                                              \
-	do {                                                                   \
-		if (ntohs(tlvh->length) > size) {                              \
-			if (vty != NULL)                                       \
-				vty_out(vty, "  Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!\n",  \
-					msg, ntohs(tlvh->length), size);       \
-			else                                                   \
-				zlog_debug("    Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!",    \
-					   msg, ntohs(tlvh->length), size);    \
-			return OSPF_MAX_LSA_SIZE + 1;                            \
-		}                                                              \
+#define check_tlv_size(size, msg)                                                                           \
+	do {                                                                                                \
+		if (ntohs(tlvh->length) > size) {                                                           \
+			if (vty != NULL)                                                                    \
+				vty_out(vty,                                                                \
+					"  Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!\n",    \
+					msg, ntohs(tlvh->length), size);                                    \
+			else                                                                                \
+				zlog_debug("    Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!", \
+					   msg, ntohs(tlvh->length), size);                                 \
+			return OSPF_MAX_LSA_SIZE + 1;                                                       \
+		}                                                                                           \
 	} while (0)
 
 static uint16_t show_vty_router_cap(struct vty *vty, struct tlv_header *tlvh,

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -3154,17 +3154,18 @@ static void ospf_te_init_ted(struct ls_ted *ted, struct ospf *ospf)
 /*------------------------------------------------------------------------*
  * Following are vty session control functions.
  *------------------------------------------------------------------------*/
-#define check_tlv_size(size, msg)                                              \
-	do {                                                                   \
-		if (ntohs(tlvh->length) > size) {                              \
-			if (vty != NULL)                                       \
-				vty_out(vty, "  Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!\n",  \
-					msg, ntohs(tlvh->length), size);       \
-			else                                                   \
-				zlog_debug("    Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!",    \
-					   msg, ntohs(tlvh->length), size);    \
-			return OSPF_MAX_LSA_SIZE + 1;                            \
-		}                                                              \
+#define check_tlv_size(size, msg)                                                                           \
+	do {                                                                                                \
+		if (ntohs(tlvh->length) > size) {                                                           \
+			if (vty != NULL)                                                                    \
+				vty_out(vty,                                                                \
+					"  Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!\n",    \
+					msg, ntohs(tlvh->length), size);                                    \
+			else                                                                                \
+				zlog_debug("    Wrong %s TLV size: %d(expected %d). Skip subsequent TLVs!", \
+					   msg, ntohs(tlvh->length), size);                                 \
+			return OSPF_MAX_LSA_SIZE + 1;                                                       \
+		}                                                                                           \
 	} while (0)
 
 static uint16_t show_vty_router_addr(struct vty *vty, struct tlv_header *tlvh,


### PR DESCRIPTION
Re-open https://github.com/FRRouting/frr/pull/19480 because we have no news from the original author.

I have fixed the styling and an issue that could have led to a memory out-of-bound issue:
https://github.com/FRRouting/frr/pull/19480#pullrequestreview-3398697861

Related to CVEs:
https://app.opencve.io/cve/CVE-2025-61099
https://app.opencve.io/cve/CVE-2025-61100
https://app.opencve.io/cve/CVE-2025-61101
https://app.opencve.io/cve/CVE-2025-61102
https://app.opencve.io/cve/CVE-2025-61103
https://app.opencve.io/cve/CVE-2025-61104
https://app.opencve.io/cve/CVE-2025-61105
https://app.opencve.io/cve/CVE-2025-61106
https://app.opencve.io/cve/CVE-2025-61107
