### PR TITLE
*: Add commit to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -22,3 +22,5 @@ bf8d3d6aca3f20255a621ed1c148fd05b3a8ae5c
 96941f80927ce31a41f7d1905717f099187be723
 # apply `black` python formatting for all tests/topotests
 1a1c2a9f84d0ad1bdadc0cb47d6175d4ccc32544
+# thread->event renaming
+c05e7b1ca2b050f8fdfc26ce83308685ae489cef


### PR DESCRIPTION
Recent changes to renaming thread->event would make git blame easier if this commit was added to the blame-ignore file.