### PR TITLE
bgpd: fix show running-config encapsulation-[mpls/srv6]

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -19889,7 +19889,7 @@ static void bgp_config_write_peer_af(struct vty *vty, struct bgp *bgp,
 	else if (peergroup_af_flag_check(peer, afi, safi,
 					 PEER_FLAG_CONFIG_ENCAPSULATION_SRV6_RELAX))
 		vty_out(vty, "  neighbor %s encapsulation-srv6-relax\n", addr);
-	else if (peergroup_af_flag_check(peer, afi, safi, PEER_FLAG_CONFIG_ENCAPSULATION_MPLS))
+	if (peergroup_af_flag_check(peer, afi, safi, PEER_FLAG_CONFIG_ENCAPSULATION_MPLS))
 		vty_out(vty, "  neighbor %s encapsulation-mpls\n", addr);
 
 	/* Filter. */


### PR DESCRIPTION
When a VPN neighbor is configured as both MPLS and SRv6, the show running-config is wrong:

> router bgp 1
> address-family ipv4 vpn
> neighbor 1::1 encapsulation-srv6

Fixes: 8e6bb4a07078 ("bgpd: add neighbor <encapsulation-srv6|encapsulation-mpls> command")