### PR TITLE
lib: Properly set event_execute type

### DIFF
--- a/lib/event.c
+++ b/lib/event.c
@@ -2094,11 +2094,10 @@ void _event_execute(const struct xref_eventsched *xref, struct event_loop *m,
 
 	/* Get or allocate new thread to execute. */
 	frr_with_mutex (&m->mtx) {
-		event = event_get(m, EVENT_EVENT, func, arg, xref);
+		event = event_get(m, EVENT_EXECUTE, func, arg, xref);
 
 		/* Set its event value. */
 		frr_with_mutex (&event->mtx) {
-			event->add_type = EVENT_EXECUTE;
 			event->u.val = val;
 			event->ref = &event;
 		}

--- a/lib/frrevent.h
+++ b/lib/frrevent.h
@@ -107,8 +107,8 @@ enum event_types {
 
 /* Event itself. */
 struct event {
-	enum event_types type;	   /* event type */
-	enum event_types add_type; /* event type */
+	enum event_types type;	   /* event type as it moves through the event system*/
+	enum event_types add_type; /* event type as it was created */
 	struct event_list_item eventitem;
 	struct event_timer_list_item timeritem;
 	struct event **ref;	      /* external reference (if given) */


### PR DESCRIPTION
The event_execute command runs the event immediately.  Let's just set the type as it should be immediately instead of having to play around with it as we currently do.