### PR TITLE
bgpd: Convince coverity that dest is still valid

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6937,7 +6937,8 @@ static int walk_batch_table_helper(struct bgp_clearing_info *cinfo,
 			processed++;
 
 			if (force) {
-				bgp_path_info_reap(dest, pi);
+				dest = bgp_path_info_reap(dest, pi);
+				assert(dest);
 			} else {
 				/* Do clearing for this pi */
 				clearing_clear_one_pi(table, dest, pi);


### PR DESCRIPTION
We have this:

for (;; dest = bgp_route_next(dest)) {
    bgp_path_info_reap(dest, pi);
}

bgp_path_info_reap() can free dest, but we know
that it will not happen because of the bgp_route_next(dest) calls lock the dest and unlock the old one upon traversing to the next.  Thus we know that dest is not going to be null, coverity is not counting that and sees that it might become freed memory and as such things could go sideways.  Let's just make coverity happy with a assert(dest).  This is done in other places to convince coverity.