### PR TITLE
lib: mgmt_msg: fix bug with disconnect and event scheduling

### DIFF
--- a/lib/mgmt_msg.c
+++ b/lib/mgmt_msg.c
@@ -558,6 +558,10 @@ void msg_conn_disconnect(struct msg_conn *conn, bool reconnect)
 		close(conn->fd);
 		conn->fd = -1;
 
+		/* We need to unschedule any pending events on this fd */
+		event_cancel(&conn->read_ev);
+		event_cancel(&conn->write_ev);
+
 		/* Notify client through registered callback (if any) */
 		if (conn->notify_disconnect)
 			(void)(*conn->notify_disconnect)(conn);


### PR DESCRIPTION
- Was not canceling read/write events for the socket being closed. This lead to a bug when the connection reopened of events using the same FD not getting scheduled.