### PR TITLE
pimd: move dense (S,G) to sparse mode when an RP is added

### DIFF
--- a/pimd/pim_dm.c
+++ b/pimd/pim_dm.c
@@ -43,6 +43,7 @@ static void pim_dm_range_reevaluate(struct pim_instance *pim)
 	 * will
 	 * disappear in time for SSM groups.
 	 */
+	pim_upstream_dense_reevaluate(pim);
 	pim_upstream_register_reevaluate(pim);
 	igmp_source_forward_reevaluate_all(pim);
 #endif

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -334,7 +334,12 @@ void pim_rp_refresh_group_to_rp_mapping(struct pim_instance *pim)
 #if PIM_IPV == 4
 	pim_msdp_i_am_rp_changed(pim);
 #endif /* PIM_IPV == 4 */
+	/* Transition DM->SM upstreams first, then re-evaluate RPT/SPT usage
+	 * and finally re-evaluate source registration state.
+	 */
+	pim_upstream_dense_reevaluate(pim);
 	pim_upstream_reeval_use_rpt(pim);
+	pim_upstream_register_reevaluate(pim);
 }
 
 void pim_rp_prefix_list_update(struct pim_instance *pim,

--- a/pimd/pim_ssm.c
+++ b/pimd/pim_ssm.c
@@ -37,6 +37,7 @@ static void pim_ssm_range_reevaluate(struct pim_instance *pim)
 	 * will
 	 * disappear in time for SSM groups.
 	 */
+	pim_upstream_dense_reevaluate(pim);
 	pim_upstream_register_reevaluate(pim);
 	igmp_source_forward_reevaluate_all(pim);
 #endif

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -780,17 +780,140 @@ int pim_upstream_could_register(struct pim_upstream *up)
 	return 0;
 }
 
-/* Source registration is suppressed for SSM groups. When the SSM range changes
- * we re-revaluate register setup for existing upstream entries */
+static void pim_upstream_transition_dm_to_sm(struct pim_instance *pim, struct pim_upstream *up)
+{
+	struct interface *ifp = NULL;
+	struct pim_interface *pim_ifp = NULL;
+
+	if (!PIM_UPSTREAM_DM_TEST_INTERFACE(up->flags) || !RP(pim, up->sg.grp))
+		return;
+
+	if (PIM_DEBUG_PIM_EVENTS)
+		zlog_debug("Setting DM mroute %s to sparse", up->sg_str);
+	/* Cancel stale DM timers before transitioning. */
+	if (up->t_prune_timer)
+		event_cancel(&up->t_prune_timer);
+	if (up->t_graft_timer)
+		event_cancel(&up->t_graft_timer);
+	PIM_UPSTREAM_DM_UNSET_PRUNE(up->flags);
+	/* Upstream is both sparse and dense, unset dense flag */
+	PIM_UPSTREAM_DM_UNSET_INTERFACE(up->flags);
+	/* For non-FHR upstreams, default to using the RP tree after
+	 * transitioning from dense to sparse. FHR (S,G) entries manage
+	 * RPT/SPT state via the SPT switch logic and should not have
+	 * USE_RPT forced here.
+	 */
+	if (!PIM_UPSTREAM_FLAG_TEST_FHR(up->flags))
+		PIM_UPSTREAM_FLAG_SET_USE_RPT(up->flags);
+	/* Clear all OIFs without per-OIF kernel flushes; one final MFC
+	 * update is done after the loop. */
+	FOR_ALL_INTERFACES (pim->vrf, ifp) {
+		pim_ifp = ifp->info;
+		if (!pim_ifp || pim_ifp->mroute_vif_index < 0)
+			continue;
+
+		if (up->channel_oil->oif_flags[pim_ifp->mroute_vif_index] & PIM_OIF_FLAG_PROTO_ANY) {
+			bool had_oif = oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index);
+			bool had_mute = !!(up->channel_oil->oif_flags[pim_ifp->mroute_vif_index] &
+					   PIM_OIF_FLAG_MUTE);
+
+			/* Clear proto and mute flags together so oif_flags is
+			 * fully zeroed before any oil_if_set/oil_size update.
+			 */
+			up->channel_oil->oif_flags[pim_ifp->mroute_vif_index] &=
+				~(PIM_OIF_FLAG_PROTO_ANY | PIM_OIF_FLAG_MUTE);
+			if (had_oif) {
+				oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 0);
+				if (up->channel_oil->oil_size > 0)
+					--up->channel_oil->oil_size;
+				else if (PIM_DEBUG_PIM_EVENTS)
+					zlog_debug("%s: oil_size underflow for %s vif %d",
+						   __func__, up->sg_str, pim_ifp->mroute_vif_index);
+			} else if (had_mute) {
+				/* MUTE set but TTL already zeroed externally. */
+				if (PIM_DEBUG_PIM_EVENTS)
+					zlog_debug("%s: MUTE set but OIF inactive for %s vif %d",
+						   __func__, up->sg_str, pim_ifp->mroute_vif_index);
+			}
+		}
+
+		/* DM-native OIFs are installed via oil_if_set() directly. */
+		if (oil_if_has(up->channel_oil, pim_ifp->mroute_vif_index)) {
+			oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 0);
+			up->channel_oil->oif_flags[pim_ifp->mroute_vif_index] = 0;
+		}
+	}
+	/* Rebuild sparse-mode forwarding; already-JOINED upstreams do not
+	 * re-enter pim_upstream_switch() via update_join_desired() alone.
+	 */
+	{
+		enum pim_upstream_state join_state_before = up->join_state;
+
+		if (up->join_state == PIM_UPSTREAM_JOINED) {
+			struct pim_rpf old_rpf;
+			enum pim_rpf_result rpf_result;
+
+			pim_upstream_inherited_olist_decide(pim, up);
+			pim_upstream_update_join_desired(pim, up);
+			/* update_join_desired() only switches to NOTJOINED when
+			 * DR_JOIN_DESIRED was already set; DM graft JOINED
+			 * upstreams may never have had that flag.
+			 */
+			if (up->join_state == PIM_UPSTREAM_JOINED &&
+			    !pim_upstream_evaluate_join_desired(pim, up))
+				pim_upstream_switch(pim, up, PIM_UPSTREAM_NOTJOINED);
+			else if (up->join_state == PIM_UPSTREAM_JOINED &&
+				 !pim_addr_is_any(up->upstream_addr) &&
+				 !PIM_UPSTREAM_FLAG_TEST_FHR(up->flags)) {
+				/* JOINED upstreams skip pim_upstream_switch(), so refresh RPF
+				 * and re-send the SM join toward the current upstream
+				 * neighbor. Without this, a DM graft cycle leaves the join
+				 * timer aimed at the old RPF until the next NHT update.
+				 * FHR upstreams register instead; that is handled later by
+				 * pim_upstream_register_reevaluate().
+				 */
+				old_rpf.source_nexthop.interface = up->rpf.source_nexthop.interface;
+				old_rpf.rpf_addr = up->rpf.rpf_addr;
+				rpf_result = pim_rpf_update(pim, up, &old_rpf, __func__);
+				if (rpf_result == PIM_RPF_CHANGED ||
+				    (rpf_result == PIM_RPF_FAILURE &&
+				     old_rpf.source_nexthop.interface))
+					pim_zebra_upstream_rpf_changed(pim, up, &old_rpf);
+				if (!pim_upstream_could_register(up)) {
+					pim_upstream_send_join(up);
+					join_timer_start(up);
+				}
+			}
+		} else
+			pim_upstream_update_join_desired(pim, up);
+
+		/* NOTJOINED→JOINED via update_join_desired already installs MFC. */
+		if (!(join_state_before == PIM_UPSTREAM_NOTJOINED &&
+		      up->join_state == PIM_UPSTREAM_JOINED))
+			pim_upstream_mroute_update(up->channel_oil, __func__);
+	}
+}
+
+void pim_upstream_dense_reevaluate(struct pim_instance *pim)
+{
+	struct pim_upstream *up;
+
+	frr_each_safe (rb_pim_upstream, &pim->upstream_head, up)
+		pim_upstream_transition_dm_to_sm(pim, up);
+}
+
+/* Re-evaluate source-registration setup for SSM/ASM changes. */
 void pim_upstream_register_reevaluate(struct pim_instance *pim)
 {
 	struct pim_upstream *up;
 
-	frr_each (rb_pim_upstream, &pim->upstream_head, up) {
+	frr_each_safe (rb_pim_upstream, &pim->upstream_head, up) {
 		/* If FHR is set CouldRegister is True. Also check if the flow
 		 * is actually active; if it is not kat setup will trigger
 		 * source
-		 * registration whenever the flow becomes active. */
+		 * registration whenever the flow becomes active.
+		 */
+
 		if (!PIM_UPSTREAM_FLAG_TEST_FHR(up->flags) ||
 			!pim_upstream_is_kat_running(up))
 			continue;

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -149,6 +149,7 @@ struct prefix_list;
 #define PIM_UPSTREAM_FLAG_SET_MLAG_INTERFACE(flags) ((flags) |= PIM_UPSTREAM_FLAG_MASK_MLAG_INTERFACE)
 
 #define PIM_UPSTREAM_DM_UNSET_PRUNE(flags) ((flags) &= ~PIM_UPSTREAM_DM_FLAG_MASK_PRUNE)
+#define PIM_UPSTREAM_DM_UNSET_INTERFACE(flags) ((flags) &= ~PIM_UPSTREAM_DM_FLAG_MASK_INTERFACE)
 
 #define PIM_UPSTREAM_FLAG_UNSET_DR_JOIN_DESIRED(flags) ((flags) &= ~PIM_UPSTREAM_FLAG_MASK_DR_JOIN_DESIRED)
 #define PIM_UPSTREAM_FLAG_UNSET_DR_JOIN_DESIRED_UPDATED(flags) ((flags) &= ~PIM_UPSTREAM_FLAG_MASK_DR_JOIN_DESIRED_UPDATED)
@@ -389,6 +390,7 @@ DECLARE_RBTREE_UNIQ(rb_pim_upstream, struct pim_upstream, upstream_rb,
 		    pim_upstream_compare);
 
 void pim_upstream_register_reevaluate(struct pim_instance *pim);
+void pim_upstream_dense_reevaluate(struct pim_instance *pim);
 
 void pim_upstream_add_lhr_star_pimreg(struct pim_instance *pim);
 void pim_upstream_remove_lhr_star_pimreg(struct pim_instance *pim,

--- a/tests/topotests/multicast_pim_sm_topo2/test_multicast_pim_sm_topo2.py
+++ b/tests/topotests/multicast_pim_sm_topo2/test_multicast_pim_sm_topo2.py
@@ -959,10 +959,10 @@ def test_verify_mroute_after_shut_noshut_of_upstream_interface_p1(request):
 
     step("Shut and No shut FRR1 and FRR3 interface")
     shutdown_bringup_interface(tgen, "l1", "l1-r2-eth4", False)
-    shutdown_bringup_interface(tgen, dut, intf, True)
+    shutdown_bringup_interface(tgen, "l1", "l1-r2-eth4", True)
 
     shutdown_bringup_interface(tgen, "f1", "f1-r2-eth3", False)
-    shutdown_bringup_interface(tgen, dut, intf, True)
+    shutdown_bringup_interface(tgen, "f1", "f1-r2-eth3", True)
 
     step(
         "After shut/no shut of interface , verify traffic resume to all"
@@ -1074,6 +1074,13 @@ def test_verify_mroute_after_shut_noshut_of_upstream_interface_p1(request):
             "Found: {}".format(tc_name, data["dut"], result)
         )
 
+    clear_mroute(tgen)
+    reset_config_on_routers(tgen)
+    clear_pim_interface_traffic(tgen, topo)
+    for rname in ["l1", "f1", "c1", "c2", "r2"]:
+        kill_router_daemons(tgen, rname, ["pimd"], save_config=False)
+        start_router_daemons(tgen, rname, ["pimd"])
+
     write_test_footer(tc_name)
 
 
@@ -1154,6 +1161,11 @@ def test_verify_mroute_when_receiver_is_outside_frr_p0(request):
 
     result = app_helper.run_join("i5", _IGMP_JOIN_RANGE, "c2")
     assert result is True, "Testcase {}: Failed Error: {}".format(tc_name, result)
+
+    step("Restart traffic after all receivers have joined")
+    app_helper.stop_host("i2")
+    result = app_helper.run_traffic("i2", _IGMP_JOIN_RANGE, "f1")
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
 
     step("FRR1 has 10 (*.G) and 10 (S,G) verify using 'show ip mroute count'")
     step(

--- a/tests/topotests/pim_dense/test_pim_dense.py
+++ b/tests/topotests/pim_dense/test_pim_dense.py
@@ -700,6 +700,19 @@ def verify_mroute_pimreg_absent(tgen, router, group, group_type):
     return None
 
 
+def mroute_entry(tgen, router, src, group):
+    """Return the JSON mroute object for a specific (S,G) entry."""
+    output = tgen.gears[router].vtysh_cmd(
+        "show ip mroute {} json".format(group), isjson=True
+    )
+    return output.get(group, {}).get(src, {})
+
+
+def mroute_oil_names(mroute):
+    """Return sorted OIF names for an mroute JSON object, excluding pimreg."""
+    return sorted([oif for oif in mroute.get("oil", {}).keys() if oif != "pimreg"])
+
+
 def test_pim_verify_pimreg_not_in_ssm_dense(request):
     """
     Verify that pimreg interface is NOT added to Dense mode groups.
@@ -801,6 +814,138 @@ def test_pim_verify_pimreg_not_in_ssm_dense(request):
     )
     _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
     assert result is None, "Dense mode test failed: {}".format(result)
+
+
+def test_pim_dense_to_sparse_on_rp_add(request):
+    "Verify existing dense (S,G) transitions when RP is added"
+    tgen = get_topogen()
+    tc_name = request.node.name
+    write_test_header(tc_name)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    routers = ["r1", "r2", "r3", "r4", "r5", "r6"]
+
+    step("Reset dynamic RP mapping for dense test group")
+    for rname in routers:
+        tgen.gears[rname].vtysh_cmd(
+            """
+            conf t
+              router pim
+                no rp 10.0.2.1 239.0.0.0/8
+            """
+        )
+
+    step("Ensure only source traffic is active for transition check")
+    app_helper.stop_host("h4")
+    app_helper.stop_host("h5")
+    app_helper.stop_host("h6")
+    app_helper.stop_host("h1")
+    result = app_helper.run_traffic("h1", DENSE_GROUP, bind_intf="h1-eth0")
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    step("Add downstream receiver before RP add")
+    result = app_helper.run_join("h4", DENSE_GROUP, join_intf="h4-eth0")
+    assert result is True, "Testcase {} : Failed Error: {}".format(tc_name, result)
+
+    step("Verify dense (S,G) exists before RP add")
+
+    def _r1_dense_before_rp():
+        output = tgen.gears["r1"].vtysh_cmd("show ip pim upstream json", isjson=True)
+        group = output.get(DENSE_GROUP, {})
+        if "10.100.0.2" not in group:
+            return "No upstream for 10.100.0.2,{}".format(DENSE_GROUP)
+
+        result = verify_mroutes(
+            tgen, "r1", "10.100.0.2", DENSE_GROUP, "r1-eth1", "r1-eth0"
+        )
+        if result is not True:
+            return result
+        return None
+
+    _, result = topotest.run_and_expect(_r1_dense_before_rp, None, count=30, wait=1)
+    assert result is None, "Dense upstream not present before RP add: {}".format(result)
+
+    step("Add RP mapping for dense group range")
+    for rname in routers:
+        tgen.gears[rname].vtysh_cmd(
+            """
+            conf t
+              router pim
+                rp 10.0.2.1 239.0.0.0/8
+            """
+        )
+
+    step("Verify existing upstream transitions to sparse mode state")
+
+    def _r1_upstream_sparse():
+        output = tgen.gears["r1"].vtysh_cmd(
+            "show ip pim upstream 10.100.0.2 {} json".format(DENSE_GROUP), isjson=True
+        )
+        upstream = output.get(DENSE_GROUP, {}).get("10.100.0.2", {})
+        if not upstream:
+            return "No upstream for 10.100.0.2,{}".format(DENSE_GROUP)
+        if not upstream.get("firstHopRouter"):
+            return "Expected FHR upstream on r1 after RP add"
+        if upstream.get("rpfAddress") != "10.0.2.1":
+            return "Expected sparse RP RPF on r1 after RP add, got {}".format(
+                upstream.get("rpfAddress")
+            )
+
+        mroute = mroute_entry(tgen, "r1", "10.100.0.2", DENSE_GROUP)
+        if not mroute:
+            return "No mroute for (10.100.0.2,{}) on r1 after RP add".format(
+                DENSE_GROUP
+            )
+        if mroute.get("iif") != "r1-eth1":
+            return "Unexpected IIF on r1 after RP add: {}".format(mroute.get("iif"))
+
+        if "flags" in mroute:
+            flags = mroute["flags"]
+            if "D" in flags:
+                return "Dense (D) mroute flag still set on r1, got {!r}".format(flags)
+            if "S" not in flags:
+                return "Expected sparse (S) mroute flag on r1, got {!r}".format(flags)
+        else:
+            oil = mroute_oil_names(mroute)
+            if oil == ["r1-eth0"]:
+                return "Still using dense-style OIL on r1 after RP add: {}".format(oil)
+            if "r1-eth0" in oil:
+                return (
+                    "Unexpected dense flood OIF r1-eth0 on r1 after RP add: {}".format(
+                        oil
+                    )
+                )
+
+        return None
+
+    _, result = topotest.run_and_expect(_r1_upstream_sparse, None, count=60, wait=1)
+    assert result is None, "DM to SM transition check failed: {}".format(result)
+
+    step("Verify r1 no longer uses dense-mode OIL toward r2")
+
+    def _r1_not_dense_oil():
+        mroute = mroute_entry(tgen, "r1", "10.100.0.2", DENSE_GROUP)
+        if not mroute:
+            return "No mroute on r1 after RP add"
+        oil = mroute_oil_names(mroute)
+        if oil == ["r1-eth0"]:
+            return "Dense-style OIL still present on r1: {}".format(oil)
+        return None
+
+    _, result = topotest.run_and_expect(_r1_not_dense_oil, None, count=30, wait=1)
+    assert result is None, "Dense OIL check failed on r1: {}".format(result)
+
+    step("Remove transient RP mapping added for this test")
+    for rname in routers:
+        tgen.gears[rname].vtysh_cmd(
+            """
+            conf t
+              router pim
+                no rp 10.0.2.1 239.0.0.0/8
+            """
+        )
 
 
 def test_memory_leak():


### PR DESCRIPTION
## Summary

- Reworked DM->SM transition so existing `(S,G)` upstreams are re-evaluated when RP mappings change.
- Updated dense/sparse classification to treat groups as sparse when an RP exists (not only when RP is reachable), and hooked reevaluation into RP refresh paths.
- Hardened transition flow in `pim_upstream_register_reevaluate()`:
  - cancel stale DM prune/graft timers
  - clear DM prune/interface flags and set sparse-mode state
  - clear OIL forwarding entries for all valid PIM VIFs
  - sync updated OIL to kernel MFC
  - trigger sparse join state machine via `pim_upstream_update_join_desired()`
- Fixed OIL bookkeeping during transition:
  - clear per-OIF protocol flags (`oif_flags`)
  - decrement `oil_size` when protocol-owned OIFs are removed, so mixed GM+DM entries do not leave stale MFC state
- Reduced transition log noise by using debug-gated logging for per-upstream DM->SM messages.
