### PR TITLE
lib: Change sizeof(..) to actual byte sizes for addresses

### DIFF
--- a/lib/smux.h
+++ b/lib/smux.h
@@ -28,8 +28,8 @@ extern "C" {
 #define SNMP_VALID  1
 #define SNMP_INVALID 2
 
-#define IN_ADDR_SIZE sizeof(struct in_addr)
-#define IN6_ADDR_SIZE sizeof(struct in6_addr)
+#define IN_ADDR_SIZE 4
+#define IN6_ADDR_SIZE 16
 
 /* IANAipRouteProtocol */
 #define IANAIPROUTEPROTOCOLOTHER 1


### PR DESCRIPTION
Coverity is complaining about mixing sizeof operators with ptr arithmetic.  Let's just convert to the actual byte sizes instead of doing sizeof()..  We already have this in other places in the code.  Should be ok.