### PR TITLE
Dplane mutex cleanup

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -6674,14 +6674,6 @@ dplane_provider_dequeue_out_ctx(struct zebra_dplane_provider *prov)
 	return ctx;
 }
 
-/*
- * Accessor for provider object
- */
-bool dplane_provider_is_threaded(const struct zebra_dplane_provider *prov)
-{
-	return CHECK_FLAG(prov->dp_flags, DPLANE_PROV_FLAG_THREADED);
-}
-
 #ifdef HAVE_NETLINK
 /*
  * Callback when an OS (netlink) incoming event read is ready. This runs

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -1231,7 +1231,6 @@ int dplane_provider_register(const char *name,
 const char *dplane_provider_get_name(const struct zebra_dplane_provider *prov);
 uint32_t dplane_provider_get_id(const struct zebra_dplane_provider *prov);
 void *dplane_provider_get_data(const struct zebra_dplane_provider *prov);
-bool dplane_provider_is_threaded(const struct zebra_dplane_provider *prov);
 
 /*
  * Lock/unlock a provider's mutex


### PR DESCRIPTION
Coverity is complaining about the dplane provider mutex being locked and not unlocked or vice versa as well.  Clearly this cannot happen but it does show that we are treating dplane providers differently in ways that are going to cause subtle differences down the line.  Let's normalize the code such that FRR treats all dplane providers all the same