### PR TITLE
ospfd: fix compilation with snmp

### DIFF
--- a/ospfd/ospf_snmp.c
+++ b/ospfd/ospf_snmp.c
@@ -641,7 +641,7 @@ static struct ospf_area *ospfAreaLookup(struct variable *v, oid name[],
 
 	if (exact) {
 		/* Length is insufficient to lookup OSPF area. */
-		if (*length - v->namelen != sizeof(struct in_addr))
+		if (*length != (size_t)v->namelen + IN_ADDR_SIZE)
 			return NULL;
 
 		oid2in_addr(name + v->namelen, sizeof(struct in_addr), addr);
@@ -760,7 +760,7 @@ static struct ospf_area *ospfStubAreaLookup(struct variable *v, oid name[],
 	/* Exact lookup. */
 	if (exact) {
 		/* ospfStubAreaID + ospfStubTOS. */
-		if (*length != v->namelen + sizeof(struct in_addr) + 1)
+		if (*length != (size_t)v->namelen + IN_ADDR_SIZE + 1)
 			return NULL;
 
 		/* Check ospfStubTOS is zero. */
@@ -895,7 +895,7 @@ static struct ospf_lsa *ospfLsdbLookup(struct variable *v, oid *name,
 
 	if (exact) {
 		/* Area ID + Type + LS ID + Router ID. */
-		if (*length - v->namelen != OSPF_LSDB_ENTRY_OFFSET)
+		if (*length != (size_t)v->namelen + OSPF_LSDB_ENTRY_OFFSET)
 			return NULL;
 
 		/* Set OID offset for Area ID. */
@@ -1093,7 +1093,7 @@ static struct ospf_area_range *ospfAreaRangeLookup(struct variable *v,
 
 	if (exact) {
 		/* Area ID + Range Network. */
-		if (v->namelen + IN_ADDR_SIZE + IN_ADDR_SIZE != *length)
+		if (*length != (size_t)v->namelen + IN_ADDR_SIZE + IN_ADDR_SIZE)
 			return NULL;
 
 		/* Set OID offset for Area ID. */
@@ -1231,7 +1231,7 @@ static struct ospf_nbr_nbma *ospfHostLookup(struct variable *v, oid *name,
 
 	if (exact) {
 		/* INDEX { ospfHostIpAddress, ospfHostTOS } */
-		if (*length != v->namelen + IN_ADDR_SIZE + 1)
+		if (*length != (size_t)v->namelen + IN_ADDR_SIZE + 1)
 			return NULL;
 
 		/* Check ospfHostTOS. */
@@ -1528,7 +1528,7 @@ static struct ospf_interface *ospfIfLookup(struct variable *v, oid *name,
 	oid *offset;
 
 	if (exact) {
-		if (*length != v->namelen + IN_ADDR_SIZE + 1)
+		if (*length != (size_t)v->namelen + IN_ADDR_SIZE + 1)
 			return NULL;
 
 		oid2in_addr(name + v->namelen, IN_ADDR_SIZE, ifaddr);
@@ -1668,7 +1668,7 @@ static struct ospf_interface *ospfIfMetricLookup(struct variable *v, oid *name,
 	int metric;
 
 	if (exact) {
-		if (*length != v->namelen + IN_ADDR_SIZE + 1 + 1)
+		if (*length != (size_t)v->namelen + IN_ADDR_SIZE + 1 + 1)
 			return NULL;
 
 		oid2in_addr(name + v->namelen, IN_ADDR_SIZE, ifaddr);
@@ -1864,7 +1864,7 @@ ospfVirtIfLookup(struct variable *v, oid *name, size_t *length,
 	struct ospf_vl_data *vl_data;
 
 	if (exact) {
-		if (*length != v->namelen + IN_ADDR_SIZE + IN_ADDR_SIZE)
+		if (*length != (size_t)v->namelen + IN_ADDR_SIZE + IN_ADDR_SIZE)
 			return NULL;
 
 		oid2in_addr(name + v->namelen, IN_ADDR_SIZE, area_id);
@@ -2041,7 +2041,7 @@ static struct ospf_neighbor *ospfNbrLookup(struct variable *v, oid *name,
 		return NULL;
 
 	if (exact) {
-		if (*length != v->namelen + IN_ADDR_SIZE + 1)
+		if (*length != (size_t)v->namelen + IN_ADDR_SIZE + 1)
 			return NULL;
 
 		oid2in_addr(name + v->namelen, IN_ADDR_SIZE, nbr_addr);
@@ -2227,7 +2227,7 @@ static struct ospf_lsa *ospfExtLsdbLookup(struct variable *v, oid *name,
 
 	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
 	if (exact) {
-		if (*length != v->namelen + 1 + IN_ADDR_SIZE + IN_ADDR_SIZE)
+		if (*length != (size_t)v->namelen + 1 + IN_ADDR_SIZE + IN_ADDR_SIZE)
 			return NULL;
 
 		offset = name + v->namelen;


### PR DESCRIPTION
> ospfd/ospf_snmp.c: In function ‘ospfAreaRangeLookup’:
> ospfd/ospf_snmp.c:1096:48: error: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
>  1096 |   if (v->namelen + IN_ADDR_SIZE + IN_ADDR_SIZE != *length)
>       |                                                ^~
> ospfd/ospf_snmp.c: In function ‘ospfHostLookup’:
> ospfd/ospf_snmp.c:1234:15: error: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
>  1234 |   if (*length != v->namelen + IN_ADDR_SIZE + 1)
>       |               ^~
> ospfd/ospf_snmp.c: In function ‘ospfIfLookup’:
> ospfd/ospf_snmp.c:1531:15: error: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
>  1531 |   if (*length != v->namelen + IN_ADDR_SIZE + 1)
>       |               ^~
> ospfd/ospf_snmp.c: In function ‘ospfIfMetricLookup’:
> ospfd/ospf_snmp.c:1671:15: error: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
>  1671 |   if (*length != v->namelen + IN_ADDR_SIZE + 1 + 1)
>       |               ^~
> ospfd/ospf_snmp.c: In function ‘ospfVirtIfLookup’:
> ospfd/ospf_snmp.c:1867:15: error: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
>  1867 |   if (*length != v->namelen + IN_ADDR_SIZE + IN_ADDR_SIZE)
>       |               ^~
> ospfd/ospf_snmp.c: In function ‘ospfNbrLookup’:
> ospfd/ospf_snmp.c:2044:15: error: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
>  2044 |   if (*length != v->namelen + IN_ADDR_SIZE + 1)
>       |               ^~
> ospfd/ospf_snmp.c: In function ‘ospfExtLsdbLookup’:
> ospfd/ospf_snmp.c:2230:15: error: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
>  2230 |   if (*length != v->namelen + 1 + IN_ADDR_SIZE + IN_ADDR_SIZE)
>       |               ^~
> cc1: all warnings being treated as errors

Fixes: 7f1b2a509e ("lib: Change sizeof(..) to actual byte sizes for addresses")