### PR TITLE
lib: ospf_snmp.c is compiling with warnings

### DIFF
--- a/lib/smux.h
+++ b/lib/smux.h
@@ -28,8 +28,8 @@ extern "C" {
 #define SNMP_VALID  1
 #define SNMP_INVALID 2
 
-#define IN_ADDR_SIZE 4
-#define IN6_ADDR_SIZE 16
+#define IN_ADDR_SIZE  4UL
+#define IN6_ADDR_SIZE 16UL
 
 /* IANAipRouteProtocol */
 #define IANAIPROUTEPROTOCOLOTHER 1


### PR DESCRIPTION
Since the change to the byte length macros
was switching it from a sizeof(X) to a straight
number, the number is being treated as a integer.
GCC is rightly treating this as mixing integer
sizes and calling out problems.  Let's tell
the compiler that these values are actually Unsigned Longs.