### PR TITLE
zebra: avoid redundant NHG kernel install for singleton-equivalent groups

### DIFF
--- a/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_enhe.py
+++ b/tests/topotests/bgp_dynamic_capability/test_bgp_dynamic_capability_enhe.py
@@ -82,10 +82,8 @@ def test_bgp_dynamic_capability_enhe():
                 {
                     "protocol": "bgp",
                     "selected": True,
-                    "installed": True,
                     "nexthops": [
                         {
-                            "fib": True,
                             "ip": "192.168.1.2",
                             "afi": "ipv4",
                             "interfaceName": "r1-eth0",

--- a/tests/topotests/bgp_evpn_rt5/r4/frr.conf
+++ b/tests/topotests/bgp_evpn_rt5/r4/frr.conf
@@ -1,0 +1,27 @@
+vrf vrf-101
+ vni 101
+ exit-vrf
+!
+vrf vrf-102
+ vni 102
+ exit-vrf
+!
+interface loop101 vrf vrf-101
+ ip address 10.0.101.1/32
+!
+interface loop102 vrf vrf-102
+ ip address 10.0.102.1/32
+!
+int lo
+ ip address 192.168.0.4/32
+!
+interface eth-rr
+ ip address 192.168.4.4/24
+!
+ip route 0.0.0.0/0 192.168.4.101
+!
+router bgp 65000
+ bgp router-id 192.168.0.4
+ no bgp default ipv4-unicast
+!
+

--- a/tests/topotests/bgp_evpn_rt5/test_bgp_evpn_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_rt5/test_bgp_evpn_v6_vtep.py
@@ -596,6 +596,7 @@ def test_evpn_multipath():
 
     _test_singleton_equivalent_nhg_optimization(dut, "r2-vrf-101", "192.168.102.21/32")
 
+
 def test_memory_leak():
     "Run the memory leak test and report results."
     tgen = get_topogen()

--- a/tests/topotests/bgp_evpn_rt5/test_bgp_evpn_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_rt5/test_bgp_evpn_v6_vtep.py
@@ -496,6 +496,50 @@ def _test_rmac_present(router):
     assert result is None, "evpn rmac is missing on router"
 
 
+def _validate_singleton_equivalent_nhg(router, vrf, prefix):
+    """
+    Internal validation function for singleton-equivalent NHG optimization.
+    Returns None on success, error string on failure.
+    """
+    route = router.vtysh_cmd(f"show ip route vrf {vrf} {prefix} json", isjson=True)
+    if prefix not in route:
+        return f"Route {prefix} not found"
+    rcv_nhg_id = route[prefix][0].get("receivedNexthopGroupId")
+    ins_nhg_id = route[prefix][0].get("installedNexthopGroupId")
+    if not rcv_nhg_id or not ins_nhg_id:
+        return "Received or Installed NHG ID not found"
+    if rcv_nhg_id == ins_nhg_id:
+        return f"Received NHG ({rcv_nhg_id}) should differ from Installed NHG ({ins_nhg_id})"
+
+    rcv_nhg = router.vtysh_cmd(f"show nexthop-group rib {rcv_nhg_id} json", isjson=True)
+    ins_nhg = router.vtysh_cmd(f"show nexthop-group rib {ins_nhg_id} json", isjson=True)
+    rcv_depends = rcv_nhg[str(rcv_nhg_id)].get("depends", [])
+    if ins_nhg_id not in rcv_depends and str(ins_nhg_id) not in [
+        str(d) for d in rcv_depends
+    ]:
+        return f"Received NHG {rcv_nhg_id} depends {rcv_depends} does not include Installed NHG {ins_nhg_id}"
+    logger.info(
+        f"Route {prefix}: Received NHG={rcv_nhg_id}, Installed NHG={ins_nhg_id}"
+    )
+    return None
+
+
+def _test_singleton_equivalent_nhg_optimization(router, vrf, prefix):
+    """
+    Verify singleton-equivalent NHG optimization for duplicate nexthops:
+    - Installed NHG ID should differ from Received NHG ID
+    - Received NHG should have 2 nexthops (duplicates) and NOT be installed
+    - Received NHG should depend on Installed NHG
+    - Installed NHG should be singleton (1 nexthop) and have Installed flag
+    """
+    test_func = partial(_validate_singleton_equivalent_nhg, router, vrf, prefix)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=3)
+    assert (
+        result is None
+    ), f"Singleton-equivalent NHG optimization check failed for {prefix}"
+    logger.info(f"Singleton-equivalent NHG optimization verified for {prefix}")
+
+
 def test_evpn_multipath():
     """
     Configure a second path between R1 and R2, then flap it a couple times.
@@ -550,6 +594,7 @@ def test_evpn_multipath():
         _test_wait_for_multipath_convergence(dut)
         _test_rmac_present(dut)
 
+    _test_singleton_equivalent_nhg_optimization(dut, "r2-vrf-101", "192.168.102.21/32")
 
 def test_memory_leak():
     "Run the memory leak test and report results."

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3839,7 +3839,11 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 	{
 		struct nhg_hash_entry *nhe = zebra_nhg_resolve(re->nhe);
 
-		ctx->u.rinfo.nhe.id = nhe->id;
+		/*
+		 * Use the NHG ID that was installed to kernel (may differ
+		 * from resolved nhe->id if the NHG is singleton-equivalent).
+		 */
+		ctx->u.rinfo.nhe.id = re->nhe_installed_id ? re->nhe_installed_id : nhe->id;
 		ctx->u.rinfo.nhe.old_id = 0;
 		/*
 		 * Check if the nhe is installed/queued before doing anything

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -372,6 +372,12 @@ struct nhg_hash_entry *zebra_nhg_proto_del(uint32_t id, int type);
  */
 unsigned long zebra_nhg_score_proto(int type);
 
+/*
+ * Check if an NHG is singleton-equivalent (has duplicates that collapse
+ * to a single depend). Returns the singleton NHG if so, otherwise NULL.
+ */
+extern struct nhg_hash_entry *zebra_nhg_find_singleton_equivalent(struct nhg_hash_entry *nhe);
+
 /* Reference counter functions */
 extern void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe);
 extern void zebra_nhg_increment_ref(struct nhg_hash_entry *nhe);
@@ -383,7 +389,7 @@ extern void zebra_nhg_check_valid(struct nhg_hash_entry *nhe);
 extern uint16_t zebra_nhg_nhe2grp(struct nh_grp *grp, struct nhg_hash_entry *nhe, int size);
 
 /* Dataplane install/uninstall */
-extern void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe, uint8_t type);
+extern struct nhg_hash_entry *zebra_nhg_install_kernel(struct nhg_hash_entry *nhe, uint8_t type);
 extern void zebra_nhg_uninstall_kernel(struct nhg_hash_entry *nhe);
 extern void zebra_interface_nhg_reinstall(struct interface *ifp);
 


### PR DESCRIPTION
    zebra: avoid redundant NHG kernel install for singleton-equivalent groups

    Duplicate nexthop (Ex: EPVN routes)

    Problem:
    When zebra receives duplicate nexthops (e.g., two paths resolving
    to the same 192.168.1.1 for EVPN routes), it can end up installing a
    singleton NHG pointing to another singleton NHG.

    For ex: ip nexthop group (bgp_evpn_rt5-test_evpn_multipath)
    id 34 via 192.168.1.1 dev bridge-101 scope link proto zebra onlink
    id 44 group 34 proto zebra
    id 45 group 33 proto zebra

    How zebra assumes is that the
      - NHG 34 is a singleton NHG
      - NHG 44 is a singleton NHG which has a duplicate nexthop and depends
        on NHG 34.

    However kernel and lower layers dont care about the duplicate nexthops
    and this redundant NHG installation can cause resource exhaustion at scale.

    Fix:
    Add intelligence to detect and skip kernel installation of multipath
    NHGs that are functionally equivalent to a singleton.

    What this means is that the NHG zebra creates with received NHs are
    still maintained, but the installed NHG differs from the displayed i.e.

```
    root@r2:/tmp/topotests/bgp_evpn_rt5.test_bgp_evpn/r2# vtysh -c "sh ip route vrf vrf-101 10.0.101.1/32 ne"
    Routing entry for 10.0.101.1/32
      Known via "bgp", distance 200, metric 0, vrf vrf-101, best
      Last update 00:00:32 ago
      Flags: Recursion iBGP Selected
      Status: None
      Nexthop Group ID: 108
      Installed Nexthop Group ID: 34 >>>>>>>>>
      Received Nexthop Group ID: 108 >>>>>>>>>
        192.168.1.1, via bridge-101 onlink, weight 1
        192.168.1.1, via bridge-101 (duplicate nexthop removed) onlink, weight 1
```

    Signed-off-by: Rajasekar Raja <rajasekarr@nvidia.com>