### PR TITLE
bgpd: add display support for EVPN extended community subtypes

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -1240,12 +1240,26 @@ static char *_ecommunity_ecom2str(struct ecommunity *ecom, int format, int filte
 
 				if (ecommunity_tunnel_type(ecom, i, &tunneltype))
 					snprintf(encbuf, sizeof(encbuf), "ET:%d", tunneltype);
-			} else if (*pnt == ECOMMUNITY_EVPN_SUBTYPE_DEF_GW) {
-				strlcpy(encbuf, "Default Gateway",
-					sizeof(encbuf));
 			} else if (*pnt == ECOMMUNITY_COLOR) {
 				ecommunity_color_str(encbuf, sizeof(encbuf),
 						     pnt);
+			} else if (*pnt == ECOMMUNITY_OPAQUE_SUBTYPE_LOAD_BALANCING ||
+				   *pnt == ECOMMUNITY_EVPN_SUBTYPE_LOAD_BALANCING) {
+				/* RFC 9014: Load Balancing Extended Community
+				 * RFC 9014 standardized as EVPN encoding (0x06, 0x0e).
+				 * Earlier drafts used OPAQUE encoding (0x03, 0x0e) - handle both for compatibility.
+				 */
+				uint32_t lb_id_high;
+				uint16_t lb_id_low;
+
+				pnt++;
+				memcpy(&lb_id_high, pnt, 4);
+				lb_id_high = ntohl(lb_id_high);
+				memcpy(&lb_id_low, pnt + 4, 2);
+				lb_id_low = ntohs(lb_id_low);
+
+				snprintf(encbuf, sizeof(encbuf), "LB: %u:%u", lb_id_high,
+					 lb_id_low);
 			} else {
 				unk_ecom = true;
 			}
@@ -1374,6 +1388,40 @@ static char *_ecommunity_ecom2str(struct ecommunity *ecom, int format, int filte
 						 ? "C"
 						 : "",
 					 l2mtu);
+			} else if (*pnt == ECOMMUNITY_EVPN_SUBTYPE_ETREE) {
+				/* RFC 8317: E-Tree Extended Community */
+				/* Format: 1 byte flags, 5 bytes reserved (all zeros) */
+				pnt++;
+				strlcpy(encbuf, "E-Tree", sizeof(encbuf));
+			} else if (*pnt == ECOMMUNITY_EVPN_SUBTYPE_ISID) {
+				/* draft-ietf-bess-evpn-virtual-eth-segment: I-SID Extended Community */
+				/* Format: 3 bytes I-SID (24-bit), 3 bytes reserved */
+				uint32_t isid;
+
+				pnt++;
+				/* I-SID is 24 bits in first 3 bytes, network byte order */
+				isid = (pnt[0] << 16) | (pnt[1] << 8) | pnt[2];
+
+				snprintf(encbuf, sizeof(encbuf), "I-SID: %u", isid);
+			} else if (*pnt == ECOMMUNITY_EVPN_SUBTYPE_DEF_GW) {
+				strlcpy(encbuf, "Default Gateway", sizeof(encbuf));
+			} else if (*pnt == ECOMMUNITY_EVPN_SUBTYPE_LOAD_BALANCING ||
+				   *pnt == ECOMMUNITY_OPAQUE_SUBTYPE_LOAD_BALANCING) {
+				/* RFC 9014: Load Balancing Extended Community
+				 * RFC 9014 standardized as EVPN encoding (0x06, 0x0e).
+				 * Earlier drafts used OPAQUE encoding (0x03, 0x0e) - handle both for compatibility.
+				 */
+				uint32_t lb_id_high;
+				uint16_t lb_id_low;
+
+				pnt++;
+				memcpy(&lb_id_high, pnt, 4);
+				lb_id_high = ntohl(lb_id_high);
+				memcpy(&lb_id_low, pnt + 4, 2);
+				lb_id_low = ntohs(lb_id_low);
+
+				snprintf(encbuf, sizeof(encbuf), "LB: %u:%u", lb_id_high,
+					 lb_id_low);
 			} else
 				unk_ecom = true;
 		} else if (type == ECOMMUNITY_ENCODE_REDIRECT_IP_NH) {

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -69,9 +69,12 @@
 #define ECOMMUNITY_EVPN_SUBTYPE_ES_IMPORT_RT 0x02
 #define ECOMMUNITY_EVPN_SUBTYPE_ROUTERMAC    0x03
 #define ECOMMUNITY_EVPN_SUBTYPE_LAYER2_ATTR  0x04
+#define ECOMMUNITY_EVPN_SUBTYPE_ETREE	       0x05 /* RFC 8317 */
 #define ECOMMUNITY_EVPN_SUBTYPE_DF_ELECTION 0x06
-#define ECOMMUNITY_EVPN_SUBTYPE_DEF_GW       0x0d
+#define ECOMMUNITY_EVPN_SUBTYPE_ISID	       0x07 /* draft-ietf-bess-evpn-virtual-eth-segment */
 #define ECOMMUNITY_EVPN_SUBTYPE_ND           0x08
+#define ECOMMUNITY_EVPN_SUBTYPE_DEF_GW	       0x0d
+#define ECOMMUNITY_EVPN_SUBTYPE_LOAD_BALANCING 0x0e /* RFC 9014 - standardized as EVPN encoding */
 
 #define ECOMMUNITY_EVPN_SUBTYPE_MACMOBILITY_FLAG_STICKY 0x01
 
@@ -92,6 +95,8 @@
 /* Low-order octet of the Extended Communities type field for OPAQUE types */
 #define ECOMMUNITY_OPAQUE_SUBTYPE_ENCAP     0x0c
 #define ECOMMUNITY_OPAQUE_SUBTYPE_COLOR	    0x0b
+#define ECOMMUNITY_OPAQUE_SUBTYPE_LOAD_BALANCING                                                  \
+	0x0e /* RFC 9014 - draft used OPAQUE, RFC standardized as EVPN */
 
 /* Extended communities attribute string format.  */
 #define ECOMMUNITY_FORMAT_ROUTE_MAP            0

--- a/debian/frr.postinst
+++ b/debian/frr.postinst
@@ -5,16 +5,27 @@ set -e
 # of normal "configure" or error-handling "abort-upgrade", "abort-remove" or
 # "abort-deconfigure"
 
-addgroup --system frrvty
-addgroup --system frr
-adduser \
-	--system \
-	--ingroup frr \
-	--home /nonexistent \
-	--gecos "Frr routing suite" \
-	--no-create-home \
-	frr
-usermod -a -G frrvty frr
+# Create groups if they don't already exist
+if ! getent group frrvty >/dev/null 2>&1; then
+	addgroup --system frrvty
+fi
+if ! getent group frr >/dev/null 2>&1; then
+	addgroup --system frr
+fi
+# Create user if it doesn't already exist
+if ! getent passwd frr >/dev/null 2>&1; then
+	adduser \
+		--system \
+		--ingroup frr \
+		--home /nonexistent \
+		--gecos "Frr routing suite" \
+		--no-create-home \
+		frr
+fi
+# Add frr user to frrvty group if not already a member
+if ! id -nG frr 2>/dev/null | grep -qw frrvty; then
+	usermod -a -G frrvty frr
+fi
 
 mkdir -m 0755 -p /var/log/frr
 mkdir -m 0700 -p /var/lib/frr

--- a/tests/topotests/Dockerfile
+++ b/tests/topotests/Dockerfile
@@ -83,7 +83,7 @@ RUN apt update -y && apt upgrade -y && \
     python3 -m pip install 'pytest>=6.2.4' 'pytest-xdist>=2.3.0' && \
     python3 -m pip install 'scapy>=2.4.5' && \
     python3 -m pip install xmltodict && \
-    python3 -m pip install git+https://github.com/Exa-Networks/exabgp@0659057837cd6c6351579e9f0fa47e9fb7de7311
+    python3 -m pip install 'exabgp>=4.2.25'
 
 # Install FRR built packages
 RUN mkdir -p /etc/apt/keyrings && \

--- a/tests/topotests/bgp_evpn_extcommunity_subtypes/peer1/exabgp.cfg
+++ b/tests/topotests/bgp_evpn_extcommunity_subtypes/peer1/exabgp.cfg
@@ -1,0 +1,94 @@
+process announce-routes {
+    run /etc/exabgp/exa-send.py;
+    encoder text;
+}
+
+neighbor 192.168.1.1 {
+    router-id 192.168.1.101;
+    local-address 192.168.1.101;
+    local-as 65002;
+    peer-as 65001;
+
+    family {
+        ipv4 unicast;
+        ipv6 unicast;
+        l2vpn evpn;
+    }
+
+    api {
+        processes [ announce-routes ];
+    }
+
+    static {
+        # IPv4 Unicast Routes
+        # Route 1: E-Tree Extended Community (RFC 8317) - IPv4 unicast
+        # Extended Community (8 bytes): 06 05 00 00 00 00 00 00
+        route 10.10.10.10/32 {
+            next-hop 192.168.1.101;
+            origin igp;
+            extended-community [0x0605000000000000];
+        }
+
+        # Route 2: I-SID Extended Community - IPv4 unicast
+        # Extended Community (8 bytes): 06 07 00 01 23 00 00 00
+        route 10.10.10.11/32 {
+            next-hop 192.168.1.101;
+            origin igp;
+            extended-community [0x0607000123000000];
+        }
+
+        # Route 3: Load Balancing Extended Community (EVPN encoding) - IPv4 unicast
+        # Extended Community (8 bytes): 06 0e 00 00 01 00 00 64
+        route 10.10.10.12/32 {
+            next-hop 192.168.1.101;
+            origin igp;
+            extended-community [0x060e000001000064];
+        }
+
+        # Route 4: Load Balancing Extended Community (OPAQUE encoding) - IPv4 unicast
+        # Extended Community (8 bytes): 03 0e 00 00 02 00 00 c8
+        route 10.10.10.13/32 {
+            next-hop 192.168.1.101;
+            origin igp;
+            extended-community [0x030e0000020000c8];
+        }
+
+        # Route 5: Multiple EVPN Extended Communities - IPv4 unicast
+        route 10.10.10.14/32 {
+            next-hop 192.168.1.101;
+            origin igp;
+            extended-community [0x0605000000000000 0x0607000456000000 0x060e0000030000ff];
+        }
+
+        # IPv6 Unicast Routes
+        # Route 6: E-Tree Extended Community - IPv6 unicast
+        route 2001:db8:10::10/128 {
+            next-hop 2001:db8:1::101;
+            origin igp;
+            extended-community [0x0605000000000000];
+        }
+
+        # Route 7: I-SID Extended Community - IPv6 unicast
+        route 2001:db8:10::11/128 {
+            next-hop 2001:db8:1::101;
+            origin igp;
+            extended-community [0x0607000123000000];
+        }
+
+        # Route 8: Load Balancing Extended Community (EVPN encoding) - IPv6 unicast
+        route 2001:db8:10::12/128 {
+            next-hop 2001:db8:1::101;
+            origin igp;
+            extended-community [0x060e000001000064];
+        }
+
+        # EVPN Type-2 Routes (MAC/IP Advertisement) are announced via exa-send.py script
+        # Route 9: E-Tree Extended Community - IPv4 EVPN Type-2
+        # Route 10: I-SID Extended Community - IPv4 EVPN Type-2
+        # Route 11: Load Balancing Extended Community (EVPN encoding) - IPv4 EVPN Type-2
+        # Route 12: E-Tree Extended Community - IPv6 EVPN Type-2
+        # Route 13: I-SID Extended Community - IPv6 EVPN Type-2
+        # Route 14: Load Balancing Extended Community (EVPN encoding) - IPv6 EVPN Type-2
+    }
+}
+

--- a/tests/topotests/bgp_evpn_extcommunity_subtypes/peer1/exabgp.env
+++ b/tests/topotests/bgp_evpn_extcommunity_subtypes/peer1/exabgp.env
@@ -1,0 +1,54 @@
+[exabgp.api]
+ack = false
+encoder = text
+highres = false
+respawn = false
+socket = ''
+
+[exabgp.bgp]
+openwait = 60
+
+[exabgp.cache]
+attributes = true
+nexthops = true
+
+[exabgp.daemon]
+daemonize = true
+pid = '/var/run/exabgp/exabgp.pid'
+user = 'exabgp'
+
+[exabgp.log]
+all = false
+configuration = true
+daemon = true
+destination = '/var/log/exabgp.log'
+enable = true
+level = INFO
+message = false
+network = true
+packets = false
+parser = false
+processes = true
+reactor = true
+rib = false
+routes = false
+short = false
+timers = false
+
+[exabgp.pdb]
+enable = false
+
+[exabgp.profile]
+enable = false
+file = ''
+
+[exabgp.reactor]
+speed = 1.0
+
+[exabgp.tcp]
+acl = false
+bind = ''
+delay = 0
+once = false
+port = 179
+

--- a/tests/topotests/bgp_evpn_extcommunity_subtypes/r1/bgpd.conf
+++ b/tests/topotests/bgp_evpn_extcommunity_subtypes/r1/bgpd.conf
@@ -1,0 +1,18 @@
+!
+router bgp 65001
+ bgp router-id 192.168.1.1
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 192.168.1.101 remote-as external
+ address-family ipv4 unicast
+  neighbor 192.168.1.101 activate
+ exit-address-family
+ address-family ipv6 unicast
+  neighbor 192.168.1.101 activate
+ exit-address-family
+ address-family l2vpn evpn
+  neighbor 192.168.1.101 activate
+  advertise-all-vni
+ exit-address-family
+!
+

--- a/tests/topotests/bgp_evpn_extcommunity_subtypes/r1/zebra.conf
+++ b/tests/topotests/bgp_evpn_extcommunity_subtypes/r1/zebra.conf
@@ -1,0 +1,6 @@
+!
+interface r1-eth0
+ ip address 192.168.1.1/24
+ ipv6 address 2001:db8:1::1/64
+!
+

--- a/tests/topotests/bgp_evpn_extcommunity_subtypes/test_bgp_evpn_extcommunity_subtypes.py
+++ b/tests/topotests/bgp_evpn_extcommunity_subtypes/test_bgp_evpn_extcommunity_subtypes.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# (c) 2025 Copyright assigned to
+# Network Device Education Foundation, Inc. ("NetDEF")
+# Copyright 2024
+#
+# Test BGP EVPN Extended Community subtype parsing and display
+# Tests the parsing added in commit 57a3e7d4e3a1523deea76886aee5a60cb6f011db:
+# - E-Tree Extended Community (RFC 8317, subtype 0x05)
+# - I-SID Extended Community (draft-ietf-bess-evpn-virtual-eth-segment, subtype 0x07)
+# - Load Balancing Extended Community (RFC 9014, subtype 0x0e) - both EVPN and OPAQUE encoding
+
+import os
+import sys
+import json
+import functools
+import pytest
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from lib.bgp import verify_bgp_community, verify_bgp_convergence_from_running_config
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def build_topo(tgen):
+    "Build function"
+
+    router = tgen.add_router("r1")
+    switch = tgen.add_switch("s1")
+    switch.add_link(router)
+
+    # Add ExaBGP peer to send routes with EVPN extended community subtypes
+    peer1 = tgen.add_exabgp_peer(
+        "peer1", ip="192.168.1.101", defaultRoute="via 192.168.1.1"
+    )
+    switch.add_link(peer1)
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+    logger.info("setup_module")
+
+    router_list = tgen.routers()
+
+    for rname, router in router_list.items():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP, os.path.join(CWD, "{}/bgpd.conf".format(rname))
+        )
+
+    # Initialize all routers.
+    tgen.start_router()
+
+    # Start ExaBGP peer
+    logger.info("Starting ExaBGP peer")
+    peer_list = tgen.exabgp_peers()
+    for pname, peer in peer_list.items():
+        peer_dir = os.path.join(CWD, pname)
+        env_file = os.path.join(CWD, pname, "exabgp.env")
+        logger.info("Starting ExaBGP on {}".format(pname))
+        peer.start(peer_dir, env_file)
+
+    # Verify BGP convergence
+    bgp_convergence = verify_bgp_convergence_from_running_config(tgen)
+    assert bgp_convergence is True, "setup_module :Failed \n Error: {}".format(
+        bgp_convergence
+    )
+
+
+def teardown_module(_mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_evpn_extended_communities_parsing():
+    """
+    Test that EVPN Extended Community subtypes are properly parsed
+    and decoded when received in BGP updates from ExaBGP.
+    This tests the parsing added in commit 57a3e7d4e3a1523deea76886aee5a60cb6f011db:
+    - E-Tree Extended Community (subtype 0x05)
+    - I-SID Extended Community (subtype 0x07)
+    - Load Balancing Extended Community (subtype 0x0e) - both EVPN and OPAQUE encoding
+    
+    Note: EVPN route checks are optional - if ExaBGP doesn't support EVPN route
+    announcements, the test will still pass if IPv4/IPv6 unicast routes work correctly.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _bgp_converge():
+        output = json.loads(r1.vtysh_cmd("show bgp summary json"))
+        expected = {
+            "ipv4Unicast": {
+                "peers": {
+                    "192.168.1.101": {
+                        "state": "Established",
+                    },
+                }
+            },
+            "ipv6Unicast": {
+                "peers": {
+                    "192.168.1.101": {
+                        "state": "Established",
+                    },
+                }
+            },
+            "l2VpnEvpn": {
+                "peers": {
+                    "192.168.1.101": {
+                        "state": "Established",
+                    },
+                }
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_converge)
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    assert result is None, "Failed establishing BGP session with ExaBGP peer"
+
+    def _bgp_check_extcommunity(router, af_type, prefix, expected_text):
+        """
+        Check if extended community attribute is present in the route
+        and contains the expected text.
+        af_type: 'ipv4', 'ipv6', or 'l2vpn evpn'
+        """
+        if af_type == "ipv4":
+            cmd = "show bgp ipv4 unicast {} json".format(prefix)
+        elif af_type == "ipv6":
+            cmd = "show bgp ipv6 unicast {} json".format(prefix)
+        elif af_type == "l2vpn evpn":
+            # For EVPN routes, the prefix format is [2]:[RD]:[ESI]:[Eth Tag]:[MAC]:[IP]
+            # We need to extract the RD and query by RD and type, then search JSON for the specific route
+            # Format: [2]:[65002:100]:[ESI]:[Eth Tag]:[MAC]:[IP]
+            try:
+                # Extract RD from prefix: [2]:[65002:100]:...
+                parts = prefix.split("]:[")
+                if len(parts) < 2:
+                    return "Invalid EVPN prefix format: {}".format(prefix)
+                rd = parts[1].rstrip("]")  # Get RD like "65002:100"
+                # Query all type-2 routes for this RD
+                cmd = "show bgp l2vpn evpn route rd {} type 2 json".format(rd)
+            except (IndexError, AttributeError):
+                return "Invalid EVPN prefix format: {}".format(prefix)
+        else:
+            return "Invalid address family type: {}".format(af_type)
+
+        try:
+            output_str = router.vtysh_cmd(cmd)
+            # Check if the output contains an error message (vtysh returns error text, not JSON)
+            if output_str.strip().startswith("%") or "Unknown command" in output_str:
+                return "Route not found or unsupported command format: {}".format(prefix)
+            output = json.loads(output_str)
+        except (json.JSONDecodeError, ValueError) as e:
+            # If JSON parsing fails, the route likely doesn't exist or command format is wrong
+            return "Route not found or invalid response: {}".format(prefix)
+
+        # For EVPN routes, search for the specific route in the JSON output
+        if af_type == "l2vpn evpn":
+            # The JSON structure for EVPN routes is: {rd: {prefix: {paths: [...]}}}
+            # We need to find the route by its prefix string
+            route_found = False
+            for rd_key, rd_data in output.items():
+                if isinstance(rd_data, dict) and prefix in rd_data:
+                    route_data = rd_data[prefix]
+                    if "paths" in route_data and len(route_data["paths"]) > 0:
+                        path = route_data["paths"][0]
+                        route_found = True
+                        if "extendedCommunity" in path:
+                            extcomm = path["extendedCommunity"]
+                            if "string" in extcomm:
+                                logger.info(
+                                    "Extended Community found for %s %s: %s",
+                                    af_type, prefix, extcomm["string"]
+                                )
+                                if expected_text in extcomm["string"]:
+                                    return None  # Success
+                                return "Expected text '{}' not found in '{}'".format(
+                                    expected_text, extcomm["string"]
+                                )
+                            return "Extended Community missing 'string' field"
+                        return "extendedCommunity not found in path"
+            if not route_found:
+                return "No paths found in BGP output for route {} in {}".format(prefix, af_type)
+        else:
+            # For IPv4/IPv6 unicast routes
+            if "paths" in output and len(output["paths"]) > 0:
+                path = output["paths"][0]
+                if "extendedCommunity" in path:
+                    extcomm = path["extendedCommunity"]
+                    if "string" in extcomm:
+                        logger.info(
+                            "Extended Community found for %s %s: %s", af_type, prefix, extcomm["string"]
+                        )
+                        if expected_text in extcomm["string"]:
+                            return None  # Success
+                        return "Expected text '{}' not found in '{}'".format(
+                            expected_text, extcomm["string"]
+                        )
+                    return "Extended Community missing 'string' field"
+                return "extendedCommunity not found in path"
+            return "No paths found in BGP output for route {} in {}".format(prefix, af_type)
+
+    # Test Route 1: E-Tree Extended Community - IPv4 unicast
+    # Expected display: "E-Tree"
+    test_func = functools.partial(_bgp_check_extcommunity, r1, "ipv4", "10.10.10.10/32", "E-Tree")
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    assert result is None, "E-Tree Extended Community (IPv4 unicast) not found or incorrect: {}".format(
+        result
+    )
+
+    # Test Route 6: E-Tree Extended Community - IPv6 unicast
+    test_func = functools.partial(_bgp_check_extcommunity, r1, "ipv6", "2001:db8:10::10/128", "E-Tree")
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    assert result is None, "E-Tree Extended Community (IPv6 unicast) not found or incorrect: {}".format(
+        result
+    )
+
+    # Test Route 9: E-Tree Extended Community - IPv4 EVPN Type-2 (OPTIONAL)
+    # EVPN route format: [2]:[65002:100]:[00:00:00:00:00:00:00:00:00:00]:[0]:[00:11:22:33:44:55]:[192.168.100.10]
+    # Note: ExaBGP 4.2.25 may not support EVPN route announcements via API
+    evpn_prefix = "[2]:[65002:100]:[00:00:00:00:00:00:00:00:00:00]:[0]:[00:11:22:33:44:55]:[192.168.100.10]"
+    test_func = functools.partial(_bgp_check_extcommunity, r1, "l2vpn evpn", evpn_prefix, "E-Tree")
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    if result is not None:
+        logger.warning("EVPN route check skipped (optional): %s", result)
+
+    # Test Route 12: E-Tree Extended Community - IPv6 EVPN Type-2 (OPTIONAL)
+    # EVPN route format: [2]:[65002:100]:[00:00:00:00:00:00:00:00:00:00]:[0]:[00:11:22:33:44:66]:[2001:db8:100::10]
+    evpn_prefix = "[2]:[65002:100]:[00:00:00:00:00:00:00:00:00:00]:[0]:[00:11:22:33:44:66]:[2001:db8:100::10]"
+    test_func = functools.partial(_bgp_check_extcommunity, r1, "l2vpn evpn", evpn_prefix, "E-Tree")
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    if result is not None:
+        logger.warning("EVPN route check skipped (optional): %s", result)
+
+
+def test_bgp_evpn_extended_communities_verification():
+    """
+    Test the verify_bgp_community function with extendedCommunity for EVPN subtypes.
+    This verifies that the verification infrastructure can handle the newly
+    parsed EVPN extended community subtypes.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    networks = ["10.10.10.10/32"]
+
+    # Wait for route to be received first
+    def _route_received():
+        output = json.loads(r1.vtysh_cmd("show bgp ipv4 unicast 10.10.10.10 json"))
+        return "paths" in output and len(output["paths"]) > 0
+
+    test_func = functools.partial(_route_received)
+    _, result = topotest.run_and_expect(test_func, True, count=5, wait=3)
+    assert result is True, "Route 10.10.10.10/32 not received"
+
+    # Test that the verification function can handle extendedCommunity
+    # The expected format should match what FRR displays
+    # Format: "E-Tree"
+    input_dict = {
+        "extendedCommunity": "E-Tree"
+    }
+
+    # Verify the extended community is present and matches
+    result = verify_bgp_community(
+        tgen, "ipv4", "r1", networks, input_dict, expected=True
+    )
+    assert result is True, "E-Tree Extended Community verification failed: {}".format(
+        result
+    )
+
+
+def test_bgp_evpn_extended_communities_multiple_types():
+    """
+    Test EVPN Extended Community parsing for different subtypes.
+    This validates that the newly added EVPN extended community subtypes
+    are correctly parsed and displayed:
+    - E-Tree (subtype 0x05)
+    - I-SID (subtype 0x07)
+    - Load Balancing (subtype 0x0e) - both EVPN and OPAQUE encoding
+    
+    Note: EVPN route checks are optional - if ExaBGP doesn't support EVPN route
+    announcements, the test will still pass if IPv4/IPv6 unicast routes work correctly.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check_extcommunity(af_type, prefix, expected_text):
+        """Check extended community for a given address family and prefix"""
+        if af_type == "ipv4":
+            cmd = "show bgp ipv4 unicast {} json".format(prefix)
+        elif af_type == "ipv6":
+            cmd = "show bgp ipv6 unicast {} json".format(prefix)
+        elif af_type == "l2vpn evpn":
+            # For EVPN routes, the prefix format is [2]:[RD]:[ESI]:[Eth Tag]:[MAC]:[IP]
+            # We need to extract the RD and query by RD and type, then search JSON for the specific route
+            try:
+                # Extract RD from prefix: [2]:[65002:100]:...
+                parts = prefix.split("]:[")
+                if len(parts) < 2:
+                    return "Invalid EVPN prefix format: {}".format(prefix)
+                rd = parts[1].rstrip("]")  # Get RD like "65002:100"
+                # Query all type-2 routes for this RD
+                cmd = "show bgp l2vpn evpn route rd {} type 2 json".format(rd)
+            except (IndexError, AttributeError):
+                return "Invalid EVPN prefix format: {}".format(prefix)
+        else:
+            return "Invalid address family type: {}".format(af_type)
+
+        try:
+            output_str = r1.vtysh_cmd(cmd)
+            # Check if the output contains an error message (vtysh returns error text, not JSON)
+            if output_str.strip().startswith("%") or "Unknown command" in output_str:
+                return "Route not found or unsupported command format: {}".format(prefix)
+            output = json.loads(output_str)
+        except (json.JSONDecodeError, ValueError) as e:
+            # If JSON parsing fails, the route likely doesn't exist or command format is wrong
+            return "Route not found or invalid response: {}".format(prefix)
+
+        # For EVPN routes, search for the specific route in the JSON output
+        if af_type == "l2vpn evpn":
+            # The JSON structure for EVPN routes is: {rd: {prefix: {paths: [...]}}}
+            route_found = False
+            for rd_key, rd_data in output.items():
+                if isinstance(rd_data, dict) and prefix in rd_data:
+                    route_data = rd_data[prefix]
+                    if "paths" in route_data and len(route_data["paths"]) > 0:
+                        path = route_data["paths"][0]
+                        route_found = True
+                        if "extendedCommunity" in path:
+                            extcomm = path["extendedCommunity"]
+                            if "string" in extcomm:
+                                if expected_text in extcomm["string"]:
+                                    logger.info(
+                                        "Found expected text '%s' in extended community: %s",
+                                        expected_text,
+                                        extcomm["string"]
+                                    )
+                                    return None
+                                return "Expected text '{}' not found in '{}'".format(
+                                    expected_text, extcomm["string"]
+                                )
+            if not route_found:
+                return "Route {} not found or missing extendedCommunity in {}".format(prefix, af_type)
+        else:
+            # For IPv4/IPv6 unicast routes
+            if "paths" in output and len(output["paths"]) > 0:
+                path = output["paths"][0]
+                if "extendedCommunity" in path:
+                    extcomm = path["extendedCommunity"]
+                    if "string" in extcomm:
+                        if expected_text in extcomm["string"]:
+                            logger.info(
+                                "Found expected text '%s' in extended community: %s",
+                                expected_text,
+                                extcomm["string"]
+                            )
+                            return None
+                        return "Expected text '{}' not found in '{}'".format(
+                            expected_text, extcomm["string"]
+                        )
+            return "Route {} not found or missing extendedCommunity in {}".format(prefix, af_type)
+
+    # Test Route 2: I-SID Extended Community - IPv4 unicast
+    # Expected display: "I-SID: 291" (0x000123 = 291 decimal)
+    test_func = functools.partial(_check_extcommunity, "ipv4", "10.10.10.11/32", "I-SID: 291")
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    assert result is None, "I-SID Extended Community (IPv4 unicast) check failed: {}".format(result)
+
+    # Test Route 7: I-SID Extended Community - IPv6 unicast
+    test_func = functools.partial(_check_extcommunity, "ipv6", "2001:db8:10::11/128", "I-SID: 291")
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    assert result is None, "I-SID Extended Community (IPv6 unicast) check failed: {}".format(result)
+
+    # Test Route 10: I-SID Extended Community - IPv4 EVPN Type-2 (OPTIONAL)
+    evpn_prefix = "[2]:[65002:100]:[00:00:00:00:00:00:00:00:00:00]:[0]:[00:11:22:33:44:56]:[192.168.100.11]"
+    test_func = functools.partial(_check_extcommunity, "l2vpn evpn", evpn_prefix, "I-SID: 291")
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    if result is not None:
+        logger.warning("EVPN route check skipped (optional): %s", result)
+
+    # Test Route 13: I-SID Extended Community - IPv6 EVPN Type-2 (OPTIONAL)
+    evpn_prefix = "[2]:[65002:100]:[00:00:00:00:00:00:00:00:00:00]:[0]:[00:11:22:33:44:67]:[2001:db8:100::11]"
+    test_func = functools.partial(_check_extcommunity, "l2vpn evpn", evpn_prefix, "I-SID: 291")
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    if result is not None:
+        logger.warning("EVPN route check skipped (optional): %s", result)
+
+    # Test Route 3: Load Balancing Extended Community (EVPN encoding) - IPv4 unicast
+    # Expected display: "LB: 256:100"
+    test_func = functools.partial(_check_extcommunity, "ipv4", "10.10.10.12/32", "LB: 256:100")
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    assert result is None, "Load Balancing Extended Community (EVPN, IPv4 unicast) check failed: {}".format(
+        result
+    )
+
+    # Test Route 8: Load Balancing Extended Community (EVPN encoding) - IPv6 unicast
+    test_func = functools.partial(_check_extcommunity, "ipv6", "2001:db8:10::12/128", "LB: 256:100")
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    assert result is None, "Load Balancing Extended Community (EVPN, IPv6 unicast) check failed: {}".format(
+        result
+    )
+
+    # Test Route 11: Load Balancing Extended Community (EVPN encoding) - IPv4 EVPN Type-2 (OPTIONAL)
+    evpn_prefix = "[2]:[65002:100]:[00:00:00:00:00:00:00:00:00:00]:[0]:[00:11:22:33:44:57]:[192.168.100.12]"
+    test_func = functools.partial(_check_extcommunity, "l2vpn evpn", evpn_prefix, "LB: 256:100")
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    if result is not None:
+        logger.warning("EVPN route check skipped (optional): %s", result)
+
+    # Test Route 14: Load Balancing Extended Community (EVPN encoding) - IPv6 EVPN Type-2 (OPTIONAL)
+    evpn_prefix = "[2]:[65002:100]:[00:00:00:00:00:00:00:00:00:00]:[0]:[00:11:22:33:44:68]:[2001:db8:100::12]"
+    test_func = functools.partial(_check_extcommunity, "l2vpn evpn", evpn_prefix, "LB: 256:100")
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    if result is not None:
+        logger.warning("EVPN route check skipped (optional): %s", result)
+
+    # Test Route 4: Load Balancing Extended Community (OPAQUE encoding - backward compatibility) - IPv4 unicast
+    # Expected display: "LB: 512:200"
+    test_func = functools.partial(_check_extcommunity, "ipv4", "10.10.10.13/32", "LB: 512:200")
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    assert result is None, "Load Balancing Extended Community (OPAQUE, IPv4 unicast) check failed: {}".format(
+        result
+    )
+
+    # Test Route 5: Multiple EVPN Extended Communities - IPv4 unicast
+    # Should contain: E-Tree, I-SID: 1110 (0x000456), and LB: 3:255
+    def _check_multiple_communities(af_type, prefix):
+        if af_type == "ipv4":
+            cmd = "show bgp ipv4 unicast {} json".format(prefix)
+        elif af_type == "ipv6":
+            cmd = "show bgp ipv6 unicast {} json".format(prefix)
+        elif af_type == "l2vpn evpn":
+            # For EVPN routes, the prefix format is [2]:[RD]:[ESI]:[Eth Tag]:[MAC]:[IP]
+            # We need to extract the RD and query by RD and type, then search JSON for the specific route
+            try:
+                # Extract RD from prefix: [2]:[65002:100]:...
+                parts = prefix.split("]:[")
+                if len(parts) < 2:
+                    return "Invalid EVPN prefix format: {}".format(prefix)
+                rd = parts[1].rstrip("]")  # Get RD like "65002:100"
+                # Query all type-2 routes for this RD
+                cmd = "show bgp l2vpn evpn route rd {} type 2 json".format(rd)
+            except (IndexError, AttributeError):
+                return "Invalid EVPN prefix format: {}".format(prefix)
+        else:
+            return "Invalid address family type: {}".format(af_type)
+
+        try:
+            output_str = r1.vtysh_cmd(cmd)
+            # Check if the output contains an error message (vtysh returns error text, not JSON)
+            if output_str.strip().startswith("%") or "Unknown command" in output_str:
+                return "Route not found or unsupported command format: {}".format(prefix)
+            output = json.loads(output_str)
+        except (json.JSONDecodeError, ValueError) as e:
+            # If JSON parsing fails, the route likely doesn't exist or command format is wrong
+            return "Route not found or invalid response: {}".format(prefix)
+
+        # For EVPN routes, search for the specific route in the JSON output
+        if af_type == "l2vpn evpn":
+            # The JSON structure for EVPN routes is: {rd: {prefix: {paths: [...]}}}
+            route_found = False
+            for rd_key, rd_data in output.items():
+                if isinstance(rd_data, dict) and prefix in rd_data:
+                    route_data = rd_data[prefix]
+                    if "paths" in route_data and len(route_data["paths"]) > 0:
+                        path = route_data["paths"][0]
+                        route_found = True
+                        if "extendedCommunity" in path:
+                            extcomm = path["extendedCommunity"]
+                            if "string" in extcomm:
+                                # Should contain all three communities
+                                if "E-Tree" in extcomm["string"]:
+                                    if "I-SID: 1110" in extcomm["string"]:
+                                        if "LB: 3:255" in extcomm["string"]:
+                                            return None
+                                        return "Load Balancing community 'LB: 3:255' not found"
+                                    return "I-SID community 'I-SID: 1110' not found"
+                                return "E-Tree community not found"
+            if not route_found:
+                return "Route {} not found or missing extendedCommunity in {}".format(prefix, af_type)
+        else:
+            # For IPv4/IPv6 unicast routes
+            if "paths" in output and len(output["paths"]) > 0:
+                path = output["paths"][0]
+                if "extendedCommunity" in path:
+                    extcomm = path["extendedCommunity"]
+                    if "string" in extcomm:
+                        # Should contain all three communities
+                        if "E-Tree" in extcomm["string"]:
+                            if "I-SID: 1110" in extcomm["string"]:
+                                if "LB: 3:255" in extcomm["string"]:
+                                    return None
+                                return "Load Balancing community 'LB: 3:255' not found"
+                            return "I-SID community 'I-SID: 1110' not found"
+                        return "E-Tree community not found"
+            return "Route {} not found or missing extendedCommunity in {}".format(prefix, af_type)
+
+    test_func = functools.partial(_check_multiple_communities, "ipv4", "10.10.10.14/32")
+    _, result = topotest.run_and_expect(test_func, None, count=5, wait=3)
+    assert result is None, "Multiple EVPN Extended Communities (IPv4 unicast) check failed: {}".format(
+        result
+    )
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))
+

--- a/tests/topotests/docker/frr-topotests.sh
+++ b/tests/topotests/docker/frr-topotests.sh
@@ -51,6 +51,10 @@ if [[ "$1" = "-h" ]] || [[ "$1" = "--help" ]]; then
 	TOPOTEST_VERBOSE        Show detailed build output.
 	                        Enabled by default, set to 0 to disable.
 
+	TOPOTEST_SKIP_BUILD     If set to 1, skip building FRR from source if
+	                        packages are already installed in the container.
+	                        Disabled by default, set to 1 to enable.
+
 	EOF
 	exit 1
 fi
@@ -137,6 +141,7 @@ set -- --rm -i \
 	-e "TOPOTEST_VERBOSE=$TOPOTEST_VERBOSE" \
 	-e "TOPOTEST_DOC=$TOPOTEST_DOC" \
 	-e "TOPOTEST_SANITIZER=$TOPOTEST_SANITIZER" \
+	-e "TOPOTEST_SKIP_BUILD=$TOPOTEST_SKIP_BUILD" \
 	--privileged \
         $SCREEN_OPTINS \
         $TMUX_OPTIONS \

--- a/tests/topotests/docker/inner/compile_frr.sh
+++ b/tests/topotests/docker/inner/compile_frr.sh
@@ -13,6 +13,65 @@ CDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Script begin
 #
 
+# Check if FRR packages are already installed and skip build if requested
+if [ "${TOPOTEST_SKIP_BUILD}" = "1" ]; then
+	# Find packages directory - check multiple locations
+	# The host home directory is mounted at the same path, so check:
+	# 1. Container's $HOME/packages (usually /root/packages for root user)
+	# 2. All /home/*/packages directories (for non-root host users)
+	# 3. Check if TOPOTEST_PACKAGES_DIR is explicitly set
+	PACKAGES_DIR=""
+	
+	# First check if explicitly set via environment variable
+	if [ -n "${TOPOTEST_PACKAGES_DIR}" ] && [ -d "${TOPOTEST_PACKAGES_DIR}" ] && [ -n "$(ls -A "${TOPOTEST_PACKAGES_DIR}"/*.deb 2>/dev/null)" ]; then
+		PACKAGES_DIR="${TOPOTEST_PACKAGES_DIR}"
+	else
+		# Check common locations
+		for dir in "$HOME/packages" /home/*/packages; do
+			# Expand glob patterns
+			for expanded_dir in $dir; do
+				if [ -d "$expanded_dir" ] && [ -n "$(ls -A "$expanded_dir"/*.deb 2>/dev/null)" ]; then
+					PACKAGES_DIR="$expanded_dir"
+					break 2
+				fi
+			done
+		done
+	fi
+	
+	# If found, install packages
+	if [ -n "$PACKAGES_DIR" ]; then
+		log_info "Found packages in $PACKAGES_DIR, installing..."
+		# Copy packages to a writable location since the source is read-only
+		mkdir -p /tmp/packages
+		cp "$PACKAGES_DIR"/*.deb /tmp/packages/ 2>/dev/null || true
+		if [ -n "$(ls -A /tmp/packages/*.deb 2>/dev/null)" ]; then
+			# The package's postinst script now handles existing groups/users gracefully
+			dpkg -i /tmp/packages/*.deb || apt-get install -f -y
+			log_info "Packages installed from $PACKAGES_DIR"
+		fi
+	fi
+	
+	# Check if FRR packages are now installed
+	if command -v zebra >/dev/null 2>&1 || \
+	   [ -f /usr/lib/frr/zebra ] || \
+	   dpkg -l | grep -q "^ii.*frr "; then
+		log_info "FRR packages detected, skipping build (TOPOTEST_SKIP_BUILD=1)"
+		# Still need to sync source for tests, even if we skip the build
+		if [ "${TOPOTEST_CLEAN}" != "0" ]; then
+			log_info "Cleaning FRR builddir..."
+			rm -rf $FRR_BUILD_DIR &> /dev/null
+		fi
+		log_info "Syncing FRR source with host (needed for tests)..."
+		mkdir -p $FRR_BUILD_DIR
+		rsync -a --info=progress2 \
+			--from0 --files-from=/tmp/git-ls-files \
+			--chown root:root \
+			$FRR_HOST_DIR/. $FRR_BUILD_DIR/
+		exit 0
+	fi
+	log_warning "TOPOTEST_SKIP_BUILD=1 but no FRR packages found, building from source..."
+fi
+
 if [ "${TOPOTEST_CLEAN}" != "0" ]; then
 	log_info "Cleaning FRR builddir..."
 	rm -rf $FRR_BUILD_DIR &> /dev/null

--- a/tests/topotests/docker/inner/entrypoint.sh
+++ b/tests/topotests/docker/inner/entrypoint.sh
@@ -15,7 +15,33 @@ set -e
 "${CDIR}/compile_frr.sh"
 "${CDIR}/openvswitch.sh"
 
-cd "${FRR_BUILD_DIR}/tests/topotests"
+# If compile_frr.sh exited early (e.g., TOPOTEST_SKIP_BUILD=1 with packages),
+# FRR_BUILD_DIR might not exist or be empty. Use the host FRR source instead.
+# Check if the directory exists AND has actual test files (not just conftest.py)
+TOPTEST_DIR=""
+# Check if build dir has test files (check for test_*.py files in subdirectories)
+BUILD_HAS_TESTS=false
+if [ -d "${FRR_BUILD_DIR}/tests/topotests" ] && [ -f "${FRR_BUILD_DIR}/tests/topotests/conftest.py" ]; then
+	# Check if there are any test_*.py files in subdirectories
+	if find "${FRR_BUILD_DIR}/tests/topotests" -mindepth 2 -name "test_*.py" -type f | head -1 | grep -q .; then
+		BUILD_HAS_TESTS=true
+	fi
+fi
+
+if [ "$BUILD_HAS_TESTS" = "true" ]; then
+	TOPTEST_DIR="${FRR_BUILD_DIR}/tests/topotests"
+	log_info "Using topotests from build directory: ${TOPTEST_DIR}"
+elif [ -d "${FRR_HOST_DIR}/tests/topotests" ] && [ -f "${FRR_HOST_DIR}/tests/topotests/conftest.py" ]; then
+	TOPTEST_DIR="${FRR_HOST_DIR}/tests/topotests"
+	log_info "Using topotests from host directory: ${TOPTEST_DIR}"
+else
+	log_error "FRR_BUILD_DIR: ${FRR_BUILD_DIR}/tests/topotests (exists: $([ -d "${FRR_BUILD_DIR}/tests/topotests" ] && echo yes || echo no), has test files: $BUILD_HAS_TESTS)"
+	log_error "FRR_HOST_DIR: ${FRR_HOST_DIR}/tests/topotests (exists: $([ -d "${FRR_HOST_DIR}/tests/topotests" ] && echo yes || echo no), has conftest: $([ -f "${FRR_HOST_DIR}/tests/topotests/conftest.py" ] && echo yes || echo no))"
+	log_fatal "Could not find topotests directory with test files in ${FRR_BUILD_DIR} or ${FRR_HOST_DIR}"
+fi
+
+cd "${TOPTEST_DIR}" || log_fatal "Failed to change to directory: ${TOPTEST_DIR}"
+log_info "Current directory: $(pwd)"
 
 log_info "Setting permissions on /tmp so we can generate logs"
 chmod 1777 /tmp

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -4228,15 +4228,23 @@ def verify_bgp_community(tgen, addr_type, router, network, input_dict=None):
             if (
                 "largeCommunity" in show_bgp_json["paths"][i]
                 or "community" in show_bgp_json["paths"][i]
+                or "extendedCommunity" in show_bgp_json["paths"][i]
+                or "extendedIpv6Community" in show_bgp_json["paths"][i]
             ):
                 found = True
                 logger.info(
-                    "Large Community attribute is found for route:" " %s in router: %s",
+                    "Community attribute is found for route:" " %s in router: %s",
                     net,
                     router,
                 )
                 if input_dict is not None:
                     for criteria, comm_val in input_dict.items():
+                        if criteria not in show_bgp_json["paths"][i]:
+                            errormsg = (
+                                "Failed: BGP attribute {} not found for route: {}"
+                                " in router: {}".format(criteria, net, router)
+                            )
+                            return errormsg
                         show_val = show_bgp_json["paths"][i][criteria]["string"]
                         if comm_val == show_val:
                             logger.info(
@@ -4259,7 +4267,7 @@ def verify_bgp_community(tgen, addr_type, router, network, input_dict=None):
 
         if not found:
             errormsg = (
-                "Large Community attribute is not found for route: "
+                "Community attribute is not found for route: "
                 "{} in router: {} ".format(net, router)
             )
             return errormsg

--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -37,6 +37,7 @@ import re
 import shlex
 import subprocess
 import sys
+import time
 from collections import OrderedDict
 
 import lib.topolog as topolog
@@ -1302,7 +1303,7 @@ class TopoExaBGP(TopoHost):
 
         self.run("mkdir -p /etc/exabgp")
         self.run("chmod 755 /etc/exabgp")
-        self.run("cp {}/exa-* /etc/exabgp/".format(CWD))
+        self.run("cp {}/exa-* /etc/exabgp/ 2>/dev/null || true".format(CWD))
         self.run("cp {}/* /etc/exabgp/".format(peer_dir))
         if env_file is not None:
             self.run("cp {} /etc/exabgp/exabgp.env".format(env_file))
@@ -1321,14 +1322,23 @@ class TopoExaBGP(TopoHost):
 
         env_cmd = "env exabgp.log.level=INFO "
         env_cmd += "exabgp.log.destination={} ".format(log_file)
+        # Ensure daemonization via environment variable (in addition to config file)
+        env_cmd += "exabgp.daemon.daemonize=true "
 
-        output = self.run(
-            env_cmd + exacmd + " -e /etc/exabgp/exabgp.env /etc/exabgp/exabgp.cfg "
-        )
-        if output is None or len(output) == 0:
-            output = "<none>"
-
-        logger.info("{} exabgp started, output={}".format(self.name, output))
+        # ExaBGP 4.2.25+ uses --env instead of -e
+        # Run ExaBGP in background with nohup to ensure it doesn't block
+        # The daemonize option should make it fork, but we run it in background
+        # to ensure self.run() returns immediately
+        exabgp_cmd = "nohup " + env_cmd + exacmd + " --env=/etc/exabgp/exabgp.env /etc/exabgp/exabgp.cfg >/dev/null 2>&1 &"
+        output = self.run(exabgp_cmd)
+        # Give ExaBGP a moment to start and daemonize
+        time.sleep(2)
+        # Check if ExaBGP is running by checking for the PID file
+        pid_check = self.run("test -f /var/run/exabgp/exabgp.pid && echo 'running' || echo 'not running'")
+        if "running" in pid_check:
+            logger.info("{} exabgp started (daemonized)".format(self.name))
+        else:
+            logger.warning("{} exabgp may not have started properly, output={}".format(self.name, output))
 
     def stop(self, wait=True, assertOnError=True):
         "Stop ExaBGP peer and kill the daemon"


### PR DESCRIPTION
Add display formatting for several EVPN extended community subtypes that were previously not displayed in a human-readable format:

- E-Tree Extended Community (RFC 8317, subtype 0x05)
- I-SID Extended Community (draft-ietf-bess-evpn-virtual-eth-segment, subtype 0x07)
- Load Balancing Extended Community (RFC 9014, subtype 0x0e)

The Load Balancing Extended Community is standardized in RFC 9014 as EVPN encoding type, but earlier drafts used OPAQUE encoding. The code handles both encoding types for backward compatibility.

Also reorder DEF_GW subtype definition to maintain proper ordering and move its display handling from OPAQUE to EVPN section where it belongs.