### PR TITLE
pimd: fix memory leaks in parent process after fork()

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -2390,6 +2390,9 @@ bgp_connect_success_w_delayopen(struct peer_connection *connection)
 	if (peer->bfd_config)
 		bgp_peer_bfd_update_source(peer);
 
+	if (peer->bfd_config)
+		bgp_peer_bfd_update_source(peer);
+
 	return BGP_FSM_SUCCESS;
 }
 


### PR DESCRIPTION
Fix memory leaks that occur when the parent process exits after fork() in frr_daemonize(). The parent process was not cleaning up memory allocated before fork(), specifically:

- router structure allocated in pim_router_init()
- MLAG resources (mlag_fifo and mlag_stream) allocated in pim_mlag_init()
- zclient structures (pim_zclient and pim_zlookup) allocated in pim_zebra_init()

Add a new frr_parent_cleanup hook that is called in the parent process before it exits. Register pim_parent_cleanup() to free all PIM-specific resources in the parent process.

Also add NULL pointer checks in pim_mlag_terminate() to safely handle cases where MLAG was not initialized (e.g., pim6d).

Related PR: #18718