### PR TITLE
bgpd: fix memory leak in BGP NHC TLV processing

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3805,6 +3805,7 @@ static int bgp_attr_nhc(struct bgp_attr_parser_args *args)
 			if (tlv->length % IPV4_MAX_BYTELEN != 0) {
 				zlog_err("%pBP rcvd BGP NHC (NNHN TLV) length %d not a multiple of %d",
 					 peer, tlv->length, IPV4_MAX_BYTELEN);
+				bgp_nhc_tlv_free(tlv);
 				bgp_nhc_free(nhc);
 				return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_OPT_ATTR_ERR,
 							  args->total);
@@ -3814,6 +3815,8 @@ static int bgp_attr_nhc(struct bgp_attr_parser_args *args)
 		found = bgp_nhc_tlv_find(nhc, tlv_code);
 		if (!found)
 			bgp_nhc_tlv_add(nhc, tlv);
+		else
+			bgp_nhc_tlv_free(tlv);
 
 		length -= tlv_length + BGP_NHC_TLV_MIN_LEN;
 	}


### PR DESCRIPTION
Fix memory leak that occurs when processing duplicate NHC TLVs in BGP UPDATE messages. The code was allocating a TLV structure and value buffer before checking if a TLV with the same code already existed. If a duplicate was found, the newly allocated TLV was leaked.

Also fix error path where TLV was not freed before returning on NNHN TLV validation error.