### PR TITLE
updating RIPng interfaces after deleting a network

### DIFF
--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -495,6 +495,8 @@ int ripng_enable_network_delete(struct ripng *ripng, struct prefix *p)
 		/* Unlock lookup lock. */
 		agg_unlock_node(node);
 
+		ripng_enable_apply_all(ripng);
+
 		return NB_OK;
 	}
 


### PR DESCRIPTION
Currently, the command
```
router ripng
  no network X:X::X:X/M
exit
```
has no effect.
Adding a line _'ripng_enable_apply_all(ripng);_' to the function _ripng_enable_network_delete (...)_ seems to fix it.