### PR TITLE
lib,pceplib: fix DNS resolver and PCEP memory leaks

### DIFF
--- a/lib/resolver.c
+++ b/lib/resolver.c
@@ -324,8 +324,19 @@ void resolver_resolve(struct resolver_query *query, int af, vrf_id_t vrf_id,
 
 	ret = vrf_switch_to_netns(vrf_id);
 	if (ret < 0) {
+		void (*cb)(struct resolver_query *query, const char *errstr,
+			   int numaddrs, union sockunion *addr);
+		const char *errstr;
+
+		errstr = safe_strerror(errno);
 		flog_err_sys(EC_LIB_SOCKET, "%s: Can't switch to VRF %u (%s)",
-			     __func__, vrf_id, safe_strerror(errno));
+			     __func__, vrf_id, errstr);
+
+		/* Call callback with error to prevent blocking retries */
+		cb = query->callback;
+		query->callback = NULL;
+		if (cb)
+			cb(query, errstr, -1, NULL);
 		return;
 	}
 


### PR DESCRIPTION
Fix memory leaks in DNS resolver and PCEP library:

- lib/resolver.c: Fix callback leak when VRF switch fails during DNS resolution. Call callback with error before returning to prevent blocking retries in callers like BMP.

- pceplib/pcep_pcc.c: Replace deprecated gethostbyname2() with getaddrinfo() for proper IPv4/IPv6 support and thread safety.

- pceplib/test/pcep_pcc_api_test.c: Fix memory leak where pcep_configuration was not freed on DNS resolution error paths.

- pceplib/pcep_msg_tools.c: Add NULL check to pcep_msg_free_message() to prevent crashes when called with NULL pointer.