### PR TITLE
bgpd: fix uninitialized variable in bgp_need_listening

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1472,7 +1472,7 @@ static int peer_flag_unset_vty(struct vty *vty, const char *ip_str,
 static void bgp_need_listening(struct bgp *bgp, struct vty *vty)
 {
 	struct listnode *node;
-	struct bgp_listener *listener;
+	struct bgp_listener *listener = NULL;
 
 	for (ALL_LIST_ELEMENTS_RO(bm->listen_sockets, node, listener)) {
 		if (listener->bgp == bgp)


### PR DESCRIPTION
The listener variable was not initialized to NULL, causing undefined behavior when the listen_sockets list is empty. This prevented the listening socket from being created for the default VRF, leading to poll() errors and crashes in BGP tests.

Root cause: When the list is empty, the loop never executes, leaving listener uninitialized. The subsequent NULL check then reads an uninitialized value, causing undefined behavior.

Fix: Initialize listener to NULL to properly handle the empty list case.

Fixes: df7b1910a ("bgpd: Activate listening socket for a default VRF when created")