### PR TITLE
isisd: use IPv6 MTID for SRv6 locator TLVs when IPv6 MT is enabled

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1236,7 +1236,7 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 			listnode_add(locator.srv6_sid, sid);
 		}
 
-		isis_tlvs_add_srv6_locator(lsp->tlvs, 0, &locator);
+		isis_tlvs_add_srv6_locator(lsp->tlvs, isis_area_ipv6_topology(area), &locator);
 		lsp_debug("ISIS (%s): Adding SRv6 Locator information",
 			  area->area_tag);
 


### PR DESCRIPTION
When IS-IS is configured with IPv6 Multi-Topology (topology ipv6-unicast),
SRv6 locator TLVs are still advertised with MTID 0 (ISIS_MT_STANDARD).
This patch makes SRv6 locator TLVs use the IPv6 MTID returned by
isis_area_ipv6_topology(area), so that they are consistent with IPv6
reachability TLVs and interoperable with implementations that expect
locators in the IPv6-unicast MT.

This patch keeps single-topology setups unchanged.
When IPv6 multi-topology is enabled (topology ipv6-unicast),
SRv6 locators are advertised in MTID=2.

This issue was observed while testing interoperability with a
Junos Evolved (cJunosEvolved).
With FRR advertising SRv6 locator in MTID 0, the peer does not
install the SRv6 tunnel route into inet6.3.
When the same locators are advertised in MTID 2 (IPv6-unicast MT),
the peer immediately installs the SRv6 underlay into inet6.3.

The change in this PR makes FRR behave like the latter, interoperable
case whenever topology ipv6-unicast is configured.