### PR TITLE
bgpd: Add command to display EVPN type-5 per-prefix

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -5091,6 +5091,13 @@ Displaying Routes by Route Distinguisher
    can be supplied to the command to only display matching prefixes in the
    specified RD.
 
+.. clicmd:: show bgp l2vpn evpn route rd RD prefix <A.B.C.D/M|X:X::X:X/M> [json]
+
+   For EVPN Type 5 (prefix) routes, an IP prefix (IPv4 or IPv6) can be
+   supplied to the command to only display matching prefixes in the specified
+   RD. This command displays detailed information about the specific prefix
+   including all paths advertised for that prefix.
+
 Displaying Update Group Information
 -----------------------------------
 

--- a/tests/topotests/evpn_type5_test_topo1/e1/bgp_evpn_route_rd_prefix.json
+++ b/tests/topotests/evpn_type5_test_topo1/e1/bgp_evpn_route_rd_prefix.json
@@ -1,0 +1,44 @@
+{
+	"prefix": "[5]:[0]:[32]:[20.1.1.1]",
+	"prefixLen": 352,
+	"rd": "10.0.0.37:2",
+	"routeType": 5,
+	"ethTag": 0,
+	"ipLen": 32,
+	"ip": "20.1.1.1",
+	"pathCount": 1,
+	"paths": [
+		{
+			"vni": "75200",
+			"aspath": {
+				"string": "2",
+				"segments": [
+					{
+						"type": "as-sequence",
+						"list": [
+							2
+						]
+					}
+				],
+				"length": 1
+			},
+			"origin": "incomplete",
+			"metric": 0,
+			"valid": true,
+			"sourced": true,
+			"local": true,
+			"bestpath": {
+				"overall": true
+			},
+			"nexthops": [
+				{
+					"ip": "120.0.0.1",
+					"afi": "ipv4",
+					"metric": 0,
+					"accessible": true,
+					"used": true
+				}
+			]
+		}
+	]
+}

--- a/tests/topotests/evpn_type5_test_topo1/e1/bgp_evpn_route_rd_prefix_ipv6.json
+++ b/tests/topotests/evpn_type5_test_topo1/e1/bgp_evpn_route_rd_prefix_ipv6.json
@@ -1,0 +1,44 @@
+{
+	"prefix": "[5]:[0]:[128]:[20::1]",
+	"prefixLen": 352,
+	"rd": "10.0.0.37:2",
+	"routeType": 5,
+	"ethTag": 0,
+	"ipLen": 128,
+	"ip": "20::1",
+	"pathCount": 1,
+	"paths": [
+		{
+			"vni": "75200",
+			"aspath": {
+				"string": "2",
+				"segments": [
+					{
+						"type": "as-sequence",
+						"list": [
+							2
+						]
+					}
+				],
+				"length": 1
+			},
+			"origin": "incomplete",
+			"metric": 0,
+			"valid": true,
+			"sourced": true,
+			"local": true,
+			"bestpath": {
+				"overall": true
+			},
+			"nexthops": [
+				{
+					"ip": "120.0.0.1",
+					"afi": "ipv4",
+					"metric": 0,
+					"accessible": true,
+					"used": true
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Add support for command **show bgp l2vpn evpn route rd <rd> prefix <prefix> [json]**

For Example:
```
e1# sh bgp l2vpn evpn route rd 10.0.0.33:1 prefix 10.1.1.1/32
BGP routing table entry for 10.0.0.33:1:[5]:[0]:[32]:[10.1.1.1]
Paths: (1 available, best #1)
  Advertised to peers:
  10.0.0.1 10.0.0.17
  Route [5]:[0]:[32]:[10.1.1.1] VNI 75100
  1
    120.0.0.1 from 0.0.0.0 (10.0.0.18)
      Origin incomplete, metric 0, valid, sourced, local, best (First path received)
      Extended Community: ET:8 RT:100:75100 Rmac:d2:b1:2b:cb:fd:fc
      Last update: Mon Nov 17 22:01:34 2025

Displayed 1 paths for requested prefix
e1# sh bgp l2vpn evpn route rd 10.0.0.33:1 prefix 10::1/128
BGP routing table entry for 10.0.0.33:1:[5]:[0]:[128]:[10::1]
Paths: (1 available, best #1)
  Advertised to peers:
  10.0.0.1 10.0.0.17
  Route [5]:[0]:[128]:[10::1] VNI 75100
  1
    120.0.0.1 from 0.0.0.0 (10.0.0.18)
      Origin incomplete, metric 0, valid, sourced, local, best (First path received)
      Extended Community: ET:8 RT:100:75100 Rmac:d2:b1:2b:cb:fd:fc
      Last update: Mon Nov 17 22:01:34 2025

Displayed 1 paths for requested prefix

```