### PR TITLE
vrrpd: [Mem leak] Vrrp interface delete fails to free connected route

### DIFF
--- a/vrrpd/vrrp_zebra.c
+++ b/vrrpd/vrrp_zebra.c
@@ -150,6 +150,7 @@ static int vrrp_zebra_if_address_del(int command, struct zclient *client,
 	vrrp_zebra_debug_if_dump_address(c->ifp, __func__);
 
 	vrrp_if_address_del(c->ifp);
+	connected_free(&c);
 
 	return 0;
 }


### PR DESCRIPTION
Changes:

   - free the connected route on intf_del

```
==45568== HEAP SUMMARY:
==45568==     in use at exit: 188,376 bytes in 277 blocks
==45568==   total heap usage: 59,088 allocs, 58,811 frees, 8,174,957 bytes allocated
==45568== 
==45568== 7,920 (4,224 direct, 3,696 indirect) bytes in 66 blocks are definitely lost in loss record 24 of 27
==45568==    at 0x48465EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==45568==    by 0x491B42F: qcalloc (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==45568==    by 0x4906998: connected_add_by_prefix (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==45568==    by 0x49802C8: zebra_interface_address_read (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==45568==    by 0x11F841: ??? (in /usr/lib/frr/vrrpd)
==45568==    by 0x497AEF9: ??? (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==45568==    by 0x4965210: event_call (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==45568==    by 0x490EC0F: frr_run (in /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0.0.0)
==45568==    by 0x114A7B: main (in /usr/lib/frr/vrrpd)
```