### PR TITLE
zebra: Check if the netlink socket is _active_ before doing batch ops

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1359,7 +1359,10 @@ enum netlink_msg_status netlink_batch_add_msg(
 	int seq;
 	ssize_t size;
 	struct nlmsghdr *msgh;
-	struct nlsock *nl;
+	struct nlsock *nl = kernel_netlink_nlsock_lookup(dplane_ctx_get_ns_sock(ctx));
+
+	if (!nl || nl->sock < 0 || !nl->buf)
+		return FRR_NETLINK_ERROR;
 
 	size = (*msg_encoder)(ctx, bth->buf_head, bth->bufsiz - bth->curlen);
 
@@ -1387,7 +1390,6 @@ enum netlink_msg_status netlink_batch_add_msg(
 	}
 
 	seq = dplane_ctx_get_ns(ctx)->seq;
-	nl = kernel_netlink_nlsock_lookup(dplane_ctx_get_ns_sock(ctx));
 
 	if (ignore_res)
 		seq++;


### PR DESCRIPTION
kernel_terminate() might be called earlier before kernel_update_multi(), where kernel_terminate() frees netlink socket buffers, closes the socket, etc.

Closes https://github.com/FRRouting/frr/issues/19232