### PR TITLE
bgpd: bounds-check when parsing incoming label in nlri

### DIFF
--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -424,7 +424,7 @@ static int bgp_nlri_get_labels(struct peer *peer, uint8_t *pnt, uint8_t plen,
 	if (plen < BGP_LABEL_BYTES)
 		return 0;
 
-	for (; data < lim; data += BGP_LABEL_BYTES) {
+	for (; (data + BGP_LABEL_BYTES) <= lim; data += BGP_LABEL_BYTES) {
 		memcpy(label, data, BGP_LABEL_BYTES);
 		llen += BGP_LABEL_BYTES;
 


### PR DESCRIPTION
Only look at octets we think are valid when parsing a label stack in an NLRI

This might lead to a conflict with #19961 so maybe we should wait a bit
