### PR TITLE
isisd: update snp end after pdu validate

### DIFF
--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -1363,6 +1363,10 @@ static int process_snp(uint8_t pdu_type, struct isis_circuit *circuit,
 		zlog_warn("Received a CSNP with bogus length %d", pdu_len);
 		return ISIS_WARNING;
 	}
+#ifndef FABRICD
+	/* endp may have been decreased by pdu_len_validate() */
+	pdu_end = stream_get_endp(circuit->rcv_stream);
+#endif
 
 	if (IS_DEBUG_SNP_PACKETS) {
 		zlog_debug(


### PR DESCRIPTION
In process_snp(), the value of endp is stored and subsequently it is used in a call to stream_get_from(). In between those two events, pdu_len_validate() is called. If the length of the pdu in the packet is less than the value of endp stored on the stream, pdu_len_validate() resets endp to the length from the packet. The situation where this was observed was on a system where snp authentication is enabled but a peer was sending unauthenticated packets. The result is that every time an unauthenticated packet is received, isisd dies on a failed assert with an error message like 'Attempt to get from out of bounds'.

Store the value of endp again after calling pdu_len_validate().