### PR TITLE
pbrd: Fix the way IPv6 address is formatted

### DIFF
--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -1515,6 +1515,8 @@ static void vty_show_pbrms(struct vty *vty,
 			   const struct pbr_map_sequence *pbrms, bool detail)
 {
 	char rbuf[64];
+	char src_str[INET6_ADDRSTRLEN];
+	char dst_str[INET6_ADDRSTRLEN];
 
 	if (pbrms->reason)
 		pbr_map_reason_string(pbrms->reason, rbuf, sizeof(rbuf));
@@ -1538,11 +1540,37 @@ static void vty_show_pbrms(struct vty *vty,
 		p = getprotobynumber(pbrms->ip_proto);
 		vty_out(vty, "        IP Protocol Match: %s\n", p->p_name);
 	}
-
-	if (CHECK_FLAG(pbrms->filter_bm, PBR_FILTER_SRC_IP))
-		vty_out(vty, "        SRC IP Match: %pFX\n", pbrms->src);
-	if (CHECK_FLAG(pbrms->filter_bm, PBR_FILTER_DST_IP))
-		vty_out(vty, "        DST IP Match: %pFX\n", pbrms->dst);
+	if (CHECK_FLAG(pbrms->filter_bm, PBR_FILTER_SRC_IP)) {
+		if (pbrms->src->family == AF_INET) {
+			if (inet_ntop(AF_INET, &pbrms->src->u.prefix4, src_str, INET_ADDRSTRLEN) !=
+			    NULL) {
+				vty_out(vty, "        SRC IP Match: %s/%d\n", src_str,
+					pbrms->src->prefixlen);
+			}
+		} else if (pbrms->src->family == AF_INET6) {
+			// ipv6 addr
+			if (inet_ntop(AF_INET6, &pbrms->src->u.prefix6, src_str,
+				      INET6_ADDRSTRLEN) != NULL) {
+				vty_out(vty, "        SRC IP Match: %s/%d\n", src_str,
+					pbrms->src->prefixlen);
+			}
+		}
+	}
+	if (CHECK_FLAG(pbrms->filter_bm, PBR_FILTER_DST_IP)) {
+		if (pbrms->dst->family == AF_INET) {
+			if (inet_ntop(AF_INET, &pbrms->dst->u.prefix4, dst_str, INET_ADDRSTRLEN) !=
+			    NULL) {
+				vty_out(vty, "        DST IP Match: %s/%d\n", dst_str,
+					pbrms->dst->prefixlen);
+			}
+		} else if (pbrms->dst->family == AF_INET6) {
+			if (inet_ntop(AF_INET6, &pbrms->dst->u.prefix6, dst_str,
+				      INET6_ADDRSTRLEN) != NULL) {
+				vty_out(vty, "        DST IP Match: %s/%d\n", dst_str,
+					pbrms->dst->prefixlen);
+			}
+		}
+	}
 
 	if (CHECK_FLAG(pbrms->filter_bm, PBR_FILTER_SRC_PORT))
 		vty_out(vty, "        SRC Port Match: %u\n", pbrms->src_prt);

--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -214,8 +214,10 @@ def get_normalized_es_id(line):
 def get_normalized_mac_ip_line(line):
     if line.startswith("evpn mh es"):
         return get_normalized_es_id(line)
-
-    if not "ipv6 add" in line:
+    """
+    pbr map match should preserve Full Address
+    """
+    if not "ipv6 add" or not "match" in line:
         return get_normalized_ipv6_line(line)
 
     return line


### PR DESCRIPTION
Issue:
issue is how the IPv6 address is formatted when being printed in PBR. Format specifier %pFX  not be the correct one to use for printing IPv6 addresses.

Fix:
1.In C, to print IPv6 addresses, typically use the inet_ntop function to convert the
 binary address into a human-readable string based on the address
 family.

 2. During frr reload - preserving the full IPv6 address along with its prefix length

 Testing Done:
 precommit, pbr map with ipv6 and ipv4 rule

 Ticket: #3498263
 Signed-off-by: Rajesh Varatharaj <rvaratharaj@nvidia.com>