### PR TITLE
ospf6d: Fix LSA scope check in flooding for unknown LSAs

### DIFF
--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -558,10 +558,10 @@ static void ospf6_flood_process(struct ospf6_neighbor *from,
 		/* If unknown LSA and U-bit clear, treat as link local
 		 * flooding scope
 		 */
-		if (!OSPF6_LSA_IS_KNOWN(lsa->header->type)
-		    && !(ntohs(lsa->header->type) & OSPF6_LSTYPE_UBIT_MASK)
-		    && (oa != OSPF6_INTERFACE(lsa->lsdb->data)->area)) {
-
+		if (!OSPF6_LSA_IS_KNOWN(lsa->header->type) &&
+		    !(ntohs(lsa->header->type) & OSPF6_LSTYPE_UBIT_MASK) &&
+		    OSPF6_LSA_SCOPE(lsa->header->type) == OSPF6_SCOPE_LINKLOCAL &&
+		    (oa != OSPF6_INTERFACE(lsa->lsdb->data)->area)) {
 			if (IS_OSPF6_DEBUG_FLOODING)
 				zlog_debug("Unknown LSA, do not flood");
 			continue;


### PR DESCRIPTION
Add missing scope check before accessing interface pointer when handling unknown LSAs with U-bit clear. AS-scope LSAs use process pointer, not interface, causing incorrect flooding behavior.

Discovered during CI/CD testing of PR #20030 in ospf6_point_to_multipoint test.