### PR TITLE
bgpd: Fix maximum-prefix session recovery for peers and peer-groups

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -8133,6 +8133,8 @@ int peer_maximum_prefix_set(struct peer *peer, afi_t afi, safi_t safi,
 		if ((peer_established(peer->connection)) &&
 		    (peer->afc[afi][safi]))
 			bgp_maximum_prefix_overflow(peer, afi, safi, 1);
+		else if (!peer_established(peer->connection))
+			peer_maximum_prefix_clear_overflow(peer);
 
 		/* Skip peer-group mechanics for regular peers. */
 		return 0;
@@ -8171,6 +8173,8 @@ int peer_maximum_prefix_set(struct peer *peer, afi_t afi, safi_t safi,
 		if ((peer_established(member->connection)) &&
 		    (member->afc[afi][safi]))
 			bgp_maximum_prefix_overflow(member, afi, safi, 1);
+		else if (!peer_established(member->connection))
+			peer_maximum_prefix_clear_overflow(member);
 	}
 
 	return 0;
@@ -8188,6 +8192,9 @@ int peer_maximum_prefix_unset(struct peer *peer, afi_t afi, safi_t safi)
 		PEER_ATTR_INHERIT(peer, peer->group, pmax[afi][safi]);
 		PEER_ATTR_INHERIT(peer, peer->group, pmax_threshold[afi][safi]);
 		PEER_ATTR_INHERIT(peer, peer->group, pmax_restart[afi][safi]);
+
+		/* Trigger peer FSM to form neighborship using updated config */
+		peer_maximum_prefix_clear_overflow(peer);
 
 		return 0;
 	}


### PR DESCRIPTION
When a BGP session goes down due to maximum-prefix overflow, modifying the configuration should allow the session to recover. However, the session remains in Idle state because PEER_STATUS_PREFIX_OVERFLOW is not cleared.

Fix three scenarios:
1. Increasing maximum-prefix limit on regular neighbor
2. Increasing maximum-prefix limit on peer-group member
3. Unsetting maximum-prefix on peer-group member (inherits from group)

In peer_maximum_prefix_set() and peer_maximum_prefix_unset(), call peer_maximum_prefix_clear_overflow() for non-established peers. This clears the overflow flag, cancels the restart timer, and triggers BGP_Start to re-establish the session.