### PR TITLE
zebra: ensure zif mac_list exists before unlinking mac

### DIFF
--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -107,7 +107,10 @@ static void zebra_evpn_mac_ifp_unlink(struct zebra_mac *zmac)
 			   ifp->ifindex);
 
 	zif = ifp->info;
-	list_delete_node(zif->mac_list, &zmac->ifp_listnode);
+
+	if (zif && zif->mac_list)
+		list_delete_node(zif->mac_list, &zmac->ifp_listnode);
+
 	zmac->ifp = NULL;
 }
 


### PR DESCRIPTION
Ensure that an ifp's evpn mac_list still exists before trying to reference it, when unlinking a mac object.