### PR TITLE
pimd: Prevent crash on interface removal

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -2238,6 +2238,10 @@ static bool pim_upstream_kat_start_ok(struct pim_upstream *up)
 		return false;
 
 	pim_ifp = ifp->info;
+
+	if (!pim_ifp || !c_oil)
+		return false;
+
 	if (pim_ifp->mroute_vif_index != *oil_incoming_vif(c_oil))
 		return false;
 


### PR DESCRIPTION
Prevent a crash when we remove interfaces from pim configuration at scale.

Ticket: CM-32197