### PR TITLE
tools: fix checkpatch.pl for 'FOO < BAR && ...'

### DIFF
--- a/tools/checkpatch.pl
+++ b/tools/checkpatch.pl
@@ -5542,7 +5542,7 @@ sub process {
 			my $to = $4;
 			my $newcomp = $comp;
 			if ($lead !~ /(?:$Operators|\.)\s*$/ &&
-			    $to !~ /^(?:Constant|[A-Z_][A-Z0-9_]*)$/ &&
+			    $to !~ /^(?:Constant|[A-Z_][A-Z0-9_]*)\s*$/ &&
 			    WARN("CONSTANT_COMPARISON",
 				 "Comparisons should place the constant on the right side of the test\n" . $herecurr) &&
 			    $fix) {


### PR DESCRIPTION
In the check $to gets value from $LvalOrFunc in regular expression that ends with '\s*', so in case of check for

if (FOO < BAR && somethingelse)

$to equals 'BAR ' and check that on right side there is also a constant fails.

Simple fix: add '\s*' to re that checks whether $to is constant.