### PR TITLE
ospfd/isisd: fix sr local block request bug, bitmap should be uint64_t

### DIFF
--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -552,7 +552,7 @@ static mpls_label_t sr_local_block_request_label(struct sr_local_block *srlb)
 {
 	mpls_label_t label;
 	uint32_t index;
-	uint32_t pos;
+	uint64_t pos;
 	uint32_t size = srlb->end - srlb->start + 1;
 
 	/* Check if we ran out of available labels */
@@ -598,7 +598,7 @@ static int sr_local_block_release_label(struct sr_local_block *srlb,
 					mpls_label_t label)
 {
 	uint32_t index;
-	uint32_t pos;
+	uint64_t pos;
 
 	/* Check that label falls inside the SRLB */
 	if ((label < srlb->start) || (label > srlb->end)) {

--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -371,7 +371,7 @@ mpls_label_t ospf_sr_local_block_request_label(void)
 	struct sr_local_block *srlb = &OspfSR.srlb;
 	mpls_label_t label;
 	uint32_t index;
-	uint32_t pos;
+	uint64_t pos;
 	uint32_t size = srlb->end - srlb->start + 1;
 
 	/* Check if we ran out of available labels */
@@ -416,7 +416,7 @@ int ospf_sr_local_block_release_label(mpls_label_t label)
 {
 	struct sr_local_block *srlb = &OspfSR.srlb;
 	uint32_t index;
-	uint32_t pos;
+	uint64_t pos;
 
 	/* Check that label falls inside the SRLB */
 	if ((label < srlb->start) || (label > srlb->end)) {


### PR DESCRIPTION
ospfd/isisd: fix sr local block request bug, bitmap should be uint64_t as SRLB_BLOCK_SIZE=64
CLOSES: https://github.com/FRRouting/frr/issues/19433