### PR TITLE
zebra: nhg code selection doesnot check invalid status

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1380,6 +1380,16 @@ static void rib_process(struct route_node *rn)
 			}
 		} else {
 			/*
+			 * During interface flap events, we have multiple NHGs
+			 * some with valid and some with invalid flags, skip
+			 * invalid NHGs
+			 */
+			if (!re->nhe)
+				continue;
+
+			if (!CHECK_FLAG(re->nhe->flags, NEXTHOP_GROUP_VALID))
+				continue;
+			/*
 			 * If the re has not changed and the nhg we have is
 			 * not usable, then we cannot use this route entry
 			 * for consideration, as that the route will just


### PR DESCRIPTION
Problem description:
1)In some corner cases in zebra, “Failed to enqueue dataplane  install” happened for routes which was caused because of INVALID nhg. 
2)Our NHG code logic, check all nexthop entries is valid or not,but it does not check whether the nhg itself is valid or not during our checks which in turn cause route install failures in zebra.

Fix:
Handled the nhg logic to check for validity during selection.