### PR TITLE
zebra: avoid using freed vtep pointer in debug log

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1418,7 +1418,7 @@ static int zl3vni_remote_rmac_add(struct zebra_l3vni *zl3vni,
 			XFREE(MTYPE_EVPN_VTEP, vtep);
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug("%s L3VNI %u VTEP %pIA nh_list count %u", __func__, zl3vni->vni,
-				   vtep, listcount(zrmac->nh_list));
+				   vtep_ip, listcount(zrmac->nh_list));
 	}
 
 	return 0;


### PR DESCRIPTION
Use input vtep_ip field for printing in debug log rather than vtep pointer which is potentially freed if the VTEP is a duplicate in the nh_list.

Found during code walkthrough