### PR TITLE
lib, bgpd: Move BGP-specific funcs out of lib and refactor

### DIFF
--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -687,4 +687,14 @@ extern bool route_matches_soo(struct bgp_path_info *pi, struct ecommunity *soo);
 extern void evpn_overlay_free(struct bgp_route_evpn *bre);
 extern struct bgp_route_evpn *evpn_overlay_intern(struct bgp_route_evpn *bre);
 
+extern int bgp_attr_stream_put_labeled_prefix(struct stream *s, const struct prefix *p,
+					      mpls_label_t *label, bool addpath_capable,
+					      uint32_t addpath_tx_id);
+
+static inline int bgp_attr_stream_put_prefix_addpath(struct stream *s, const struct prefix *p,
+						     bool addpath_capable, uint32_t addpath_tx_id)
+{
+	return bgp_attr_stream_put_labeled_prefix(s, p, NULL, addpath_capable, addpath_tx_id);
+}
+
 #endif /* _QUAGGA_BGP_ATTR_H */

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -797,8 +797,8 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 
 		if ((afi == AFI_IP && safi == SAFI_UNICAST)
 		    && !peer_cap_enhe(peer, afi, safi))
-			stream_put_prefix_addpath(s, dest_p, addpath_capable,
-						  addpath_tx_id);
+			bgp_attr_stream_put_prefix_addpath(s, dest_p, addpath_capable,
+							   addpath_tx_id);
 		else {
 			/* Encode the prefix in MP_REACH_NLRI attribute */
 			if (dest->pdest)
@@ -1003,8 +1003,8 @@ struct bpacket *subgroup_withdraw_packet(struct update_subgroup *subgrp)
 
 		if (afi == AFI_IP && safi == SAFI_UNICAST
 		    && !peer_cap_enhe(peer, afi, safi))
-			stream_put_prefix_addpath(s, dest_p, addpath_capable,
-						  addpath_tx_id);
+			bgp_attr_stream_put_prefix_addpath(s, dest_p, addpath_capable,
+							   addpath_tx_id);
 		else {
 			if (dest->pdest)
 				prd = (struct prefix_rd *)bgp_dest_get_prefix(
@@ -1177,9 +1177,8 @@ void subgroup_default_update_packet(struct update_subgroup *subgrp,
 	/* NLRI set. */
 	if (p.family == AF_INET && safi == SAFI_UNICAST
 	    && !peer_cap_enhe(peer, afi, safi))
-		stream_put_prefix_addpath(
-			s, &p, addpath_capable,
-			BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE);
+		bgp_attr_stream_put_prefix_addpath(s, &p, addpath_capable,
+						   BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE);
 
 	/* Set size. */
 	bgp_packet_set_size(s);
@@ -1252,9 +1251,8 @@ void subgroup_default_withdraw_packet(struct update_subgroup *subgrp)
 	/* Withdrawn Routes. */
 	if (p.family == AF_INET && safi == SAFI_UNICAST
 	    && !peer_cap_enhe(peer, afi, safi)) {
-		stream_put_prefix_addpath(
-			s, &p, addpath_capable,
-			BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE);
+		bgp_attr_stream_put_prefix_addpath(s, &p, addpath_capable,
+						   BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE);
 
 		unfeasible_len = stream_get_endp(s) - cp - 2;
 

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -180,15 +180,8 @@ extern int stream_put_in_addr(struct stream *s, const struct in_addr *addr);
 extern bool stream_put_ipaddr(struct stream *s, const struct ipaddr *ip);
 extern int stream_put_in_addr_at(struct stream *s, size_t putp,
 				 const struct in_addr *addr);
-extern int stream_put_in6_addr_at(struct stream *s, size_t putp,
-				  const struct in6_addr *addr);
-extern int stream_put_prefix_addpath(struct stream *s, const struct prefix *p,
-				     bool addpath_capable,
-				     uint32_t addpath_tx_id);
+extern int stream_put_in6_addr_at(struct stream *s, size_t putp, const struct in6_addr *addr);
 extern int stream_put_prefix(struct stream *s, const struct prefix *p);
-extern int stream_put_labeled_prefix(struct stream *s, const struct prefix *p,
-				     mpls_label_t *label, bool addpath_capable,
-				     uint32_t addpath_tx_id);
 extern void stream_get(void *dst, struct stream *s, size_t size);
 extern bool stream_get2(void *data, struct stream *s, size_t size);
 extern void stream_get_from(void *dst, struct stream *s, size_t from, size_t size);


### PR DESCRIPTION
* Move stream_put_labeled_prefix and stream_put_prefix_addpath (lib/stream.c) to bgp_attr_stream_put_labeled_prefix and bgp_attr_stream_put_prefix_addpath in bgpd/bgp_attr.c
* Merge these two function implementations as stream_put_labeled_prefix is more general
      
This is continuation of https://github.com/FRRouting/frr/pull/19961, where @mjstapp suggested to make changes to lib/stream* a separate PR.

In next PR I'll add sending of multiple labels in BGP-LU at last :)
