### PR TITLE
bfdd, ripd, ripngd: implement yang:date-and-time

### DIFF
--- a/bfdd/bfdd_nb_state.c
+++ b/bfdd/bfdd_nb_state.c
@@ -208,12 +208,11 @@ struct yang_data *bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem(
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_last_down_time_get_elem(
 	struct nb_cb_get_elem_args *args)
 {
-	/*
-	 * TODO: implement me.
-	 *
-	 * No yang support for time elements yet.
-	 */
-	return NULL;
+	const struct bfd_session *bs = args->list_entry;
+
+	time_t last_down_time = monotime_to_realtime(&bs->downtime, NULL);
+
+	return yang_data_new_date_and_time(args->xpath, last_down_time, false);
 }
 
 /*
@@ -222,12 +221,11 @@ struct yang_data *bfdd_bfd_sessions_single_hop_stats_last_down_time_get_elem(
 struct yang_data *bfdd_bfd_sessions_single_hop_stats_last_up_time_get_elem(
 	struct nb_cb_get_elem_args *args)
 {
-	/*
-	 * TODO: implement me.
-	 *
-	 * No yang support for time elements yet.
-	 */
-	return NULL;
+	const struct bfd_session *bs = args->list_entry;
+
+	time_t last_up_time = monotime_to_realtime(&bs->uptime, NULL);
+
+	return yang_data_new_date_and_time(args->xpath, last_up_time, false);
 }
 
 /*

--- a/doc/developer/northbound/operational-data-rpcs-and-notifications.rst
+++ b/doc/developer/northbound/operational-data-rpcs-and-notifications.rst
@@ -289,8 +289,9 @@ Finally, each YANG leaf inside the ``neighbor`` list has its associated
    ripd_state_neighbors_neighbor_last_update_get_elem(const char *xpath,
                                                       void *list_entry)
    {
-           /* TODO: yang:date-and-time is tricky */
-           return NULL;
+           struct rip_peer *peer = list_entry;
+
+           return yang_data_new_date_and_time(args->xpath, peer->uptime, false);
    }
 
    /*

--- a/ripd/rip_nb_state.c
+++ b/ripd/rip_nb_state.c
@@ -119,8 +119,10 @@ struct yang_data *ripd_instance_state_neighbors_neighbor_address_get_elem(
 struct yang_data *ripd_instance_state_neighbors_neighbor_last_update_get_elem(
 	struct nb_cb_get_elem_args *args)
 {
-	/* TODO: yang:date-and-time is tricky */
-	return NULL;
+	const struct listnode *node = args->list_entry;
+	const struct rip_peer *peer = listgetdata(node);
+
+	return yang_data_new_date_and_time(args->xpath, peer->uptime, false);
 }
 
 /*

--- a/ripngd/ripng_nb_state.c
+++ b/ripngd/ripng_nb_state.c
@@ -88,8 +88,10 @@ struct yang_data *ripngd_instance_state_neighbors_neighbor_address_get_elem(
 struct yang_data *ripngd_instance_state_neighbors_neighbor_last_update_get_elem(
 	struct nb_cb_get_elem_args *args)
 {
-	/* TODO: yang:date-and-time is tricky */
-	return NULL;
+	const struct listnode *node = args->list_entry;
+	const struct ripng_peer *peer = listgetdata(node);
+
+	return yang_data_new_date_and_time(args->xpath, peer->uptime, false);
 }
 
 /*


### PR DESCRIPTION
The proper implementation of yang:date-and-time was added some time ago in yang_data_new_date_and_time. This commit updates places where the usage was missing.