### PR TITLE
bgpd: Fix Coverity issues after 19506

### DIFF
--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -435,7 +435,7 @@ static int bgp_nlri_get_labels(struct peer *peer, uint8_t *pnt, uint8_t plen, mp
 	if (plen < BGP_LABEL_BYTES)
 		return 0;
 
-	label_pnt = &labels[0];
+	label_pnt = labels;
 	for (; (data + BGP_LABEL_BYTES) <= lim; data += BGP_LABEL_BYTES, label_pnt++) {
 		/*
 		 * Support only BGP_MAX_LABELS, read rest to local variable and

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1421,8 +1421,8 @@ static void bgp_zebra_announce_parse_nexthop(
 				api_nh->labels[0] = nh_label;
 			} else {
 				uint8_t i;
-				int max_elements = sizeof(api_nh->labels) /
-						   sizeof(api_nh->labels[0]);
+				int max_elements = MIN(array_size(api_nh->labels),
+						       array_size(mpinfo->extra->labels->label));
 
 				api_nh->label_num = num_labels;
 				if (api_nh->label_num > max_elements) {


### PR DESCRIPTION
Fixing two coverity issues:

* In bgp_label: took address of first element of array and Coverity gave ARRAY_VS_SINGLETON error, changed to just copying array pointer
* In bgp_zebra: though there was check for size of maximum destination address length, there was no explicit check for size of source array, added this check

This is draft as I have no access to Coverity and only guessing fixes here.

Also this
```c
				int max_elements =
					MIN(sizeof(api_nh->labels) / sizeof(api_nh->labels[0]),
					    sizeof(mpinfo->extra->labels->label) /
						    sizeof(mpinfo->extra->labels->label[0]));
```

is currently equivalent to

```c
				int max_elements = MIN(MPLS_MAX_LABELS, BGP_MAX_LABELS);
```

I've selected current more verbose option as it will be valid even if definitions of structs will be changed to use other macro/expression/etc for number of elements.