### PR TITLE
zebra: fix connected route NHT resolution

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -279,6 +279,8 @@ DECLARE_LIST(re_list, struct route_entry, next);
 
 #define RIB_DEST_UPDATE_LSPS   (1 << (ZEBRA_MAX_QINDEX + 3))
 
+#define RIB_DEST_FORCE_RNH (1 << (ZEBRA_MAX_QINDEX + 4))
+
 /*
  * Macro to iterate over each route for a destination (prefix).
  */

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2261,6 +2261,7 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 
 	zebra_rib_evaluate_rn_nexthops(rn, seq, rt_delete);
 	zebra_rib_evaluate_mpls(rn);
+
 done:
 
 	if (rn)
@@ -3069,6 +3070,14 @@ static void process_subq_early_route_delete(struct zebra_early_route *ere)
 
 	if (ere->re_nhe)
 		nh = ere->re_nhe->nhg.nexthop;
+
+	if (ere->re->type == ZEBRA_ROUTE_CONNECT || ere->re->type == ZEBRA_ROUTE_LOCAL ||
+	    ere->re->type == ZEBRA_ROUTE_STATIC) {
+		if (IS_ZEBRA_DEBUG_RIB_DETAILED)
+			zlog_debug("%s %pRN re %p type %s, set force rnh flag", __func__, rn,
+				   ere->re, zebra_route_string(ere->re->type));
+		SET_FLAG(dest->flags, RIB_DEST_FORCE_RNH);
+	}
 
 	/* Lookup same type route. */
 	RNODE_FOREACH_RE (rn, re) {


### PR DESCRIPTION
The route in question depends on a connected route, which itself is
    resolved through multiple interfaces. When these interfaces flap rapidly
    in succession, the resulting interface events trigger changes to the
    connected route. These changes are queued in the meta queue, impacting
    the overall route resolution.
    If the flap happens quick where the connected
    route's only route add request is honored. Upon dplane result
    success of the connected route processing nht is not triggered
    as the NHT's nexthop cache shows no change for the connected prefix.
    Meanwhile dplane (kernel) would have deleted the upper layer route
    which dependented on the connected prefix.

    To solve, introduce a flag during interface flap event to have force
    rnh trigger. When the dplane success is invoked based on this flag,
    the RNH is retriggered, prompting notification to the upper-layer
    protocol. This, in turn, reinstalls the route.

    The current commit handles Static, Local and Connected routes

This would address the https://github.com/FRRouting/frr/issues/18784