### PR TITLE
isisd: fix crash when changing isis type

### DIFF
--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -2039,6 +2039,8 @@ void isis_spf_invalidate_routes(struct isis_spftree *tree)
 {
 	struct isis_route_table_info *backup_info;
 
+	if (!tree)
+		return;
 	isis_route_invalidate_table(tree->area, tree->route_table);
 
 	/* Delete backup routes. */


### PR DESCRIPTION
The following crash happens, when moving from level-2 to level-1 an isis flex-algorithm configuration

> warning: 44     ./nptl/pthread_kill.c: No such file or directory
> [Current thread is 1 (Thread 0x7108d4cb2980 (LWP 1023))]
> (gdb) bt
> #0  __pthread_kill_implementation (no_tid=0, signo=11,
>     threadid=<optimized out>) at ./nptl/pthread_kill.c:44
> #1  __pthread_kill_internal (signo=11, threadid=<optimized out>)
>     at ./nptl/pthread_kill.c:78
> #2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=11)
>     at ./nptl/pthread_kill.c:89
> #3  0x00007108d3e4527e in __GI_raise (sig=11) at ../sysdeps/posix/raise.c:26
> #4  0x00007108d4b44926 in core_handler (signo=11, siginfo=0x7ffe7c10fb30,
>     context=0x7ffe7c10fa00)
>     at /build/make-pkg/output/_packages/cp-routing/src/lib/sigevent.c:248
> #5  <signal handler called>
> #6  0x00005b5d803bf07b in isis_spf_invalidate_routes (tree=0x0)
>     at /build/make-pkg/output/_packages/cp-routing/src/isisd/isis_spf.c:2118
> #7  0x00005b5d803fb23e in isis_area_invalidate_routes (area=0x5b5db8d5be40,
>     levels=1)
>     at /build/make-pkg/output/_packages/cp-routing/src/isisd/isisd.c:3152
> #8  0x00005b5d803bf280 in isis_run_spf_cb (thread=0x7ffe7c110180)
>     at /build/make-pkg/output/_packages/cp-routing/src/isisd/isis_spf.c:2165
> #9  0x00007108d4b5ff7f in event_call (thread=0x7ffe7c110180)
>     at /build/make-pkg/output/_packages/cp-routing/src/lib/event.c:2011
> #10 0x00007108d4adb761 in frr_run (master=0x5b5db7f7ca40)
>     at /build/make-pkg/output/_packages/cp-routing/src/lib/libfrr.c:1219
> #11 0x00005b5d8038333a in main (argc=5, argv=0x7ffe7c1103d8,
> --Type <RET> for more, q to quit, c to continue without paging--
>     envp=0x7ffe7c110408)
>     at /build/make-pkg/output/_packages/cp-routing/src/isisd/isis_main.c:360
> (gdb)

Fix this by adding protection before invalidating all routes.