### PR TITLE
bgpd: add prefix info to bgp update debug

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -594,8 +594,8 @@ bool bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 
 			bgp_dump_attr(attr, attr_str, sizeof(attr_str));
 
-			zlog_debug("%s suppress UPDATE %pBD w/ attr: %s", peer->host, dest,
-				   attr_str);
+			zlog_debug("%s suppress UPDATE %pBD w/ attr: %s, afi=%s, safi=%s",
+				   peer->host, dest, attr_str, afi2str(afi), safi2str(safi));
 		}
 
 		/*


### PR DESCRIPTION
If the path attribute hash are same, then the bgp update is supressed. Print out the prefix info in the debug.

Ticket: #4290784
Testing:
Before:
2025/04/14 18:33:53.402848 BGP: [K423X-ETGCQ] group_announce_route_walkcb: afi=IPv4, safi=unicast, p=10.1.1.29/32 2025/04/14 18:33:53.402851 BGP: [MAXTH-W5WMN] 210.4.1.4 suppress UPDATE w/ attr: nexthop 0.0.0.0, origin ?, path 201 200

After:
95621:2025/04/14 21:08:16.295425 BGP: [K423X-ETGCQ] group_announce_route_walkcb: afi=IPv4, safi=unicast, p=10.1.1.3/32 95622:2025/04/14 21:08:16.295429 BGP: [YRY0X-FSYXE] 210.2.6.2 suppress UPDATE w/ attr: nexthop 0.0.0.0, origin ?, path 207 200, afi=IPv4, safi=unicast, p=10.1.1.3/32