### PR TITLE
ospfd:add vrf option to clear process and neighbor

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -11780,18 +11780,19 @@ DEFUN (show_ip_ospf_vrfs,
 
 	return CMD_SUCCESS;
 }
-DEFPY (clear_ip_ospf_neighbor,
-       clear_ip_ospf_neighbor_cmd,
-       "clear ip ospf [(1-65535)]$instance neighbor [A.B.C.D$nbr_id]",
-       CLEAR_STR
-       IP_STR
-       "OSPF information\n"
-       "Instance ID\n"
-       "Reset OSPF Neighbor\n"
-       "Neighbor ID\n")
+
+DEFPY(clear_ip_ospf_neighbor, clear_ip_ospf_neighbor_cmd,
+      "clear ip ospf [{(1-65535)$instance|vrf NAME$vrf_name}] neighbor [A.B.C.D$nbr_id]",
+      CLEAR_STR IP_STR
+      "OSPF information\n"
+      "Instance ID\n"
+      VRF_CMD_HELP_STR
+      "Reset OSPF Neighbor\n"
+      "Neighbor ID\n")
 {
 	struct listnode *node;
 	struct ospf *ospf = NULL;
+	struct vrf *vrf = NULL;
 
 	/* If user does not specify the arguments,
 	 * instance = 0 and nbr_id = 0.0.0.0
@@ -11802,8 +11803,25 @@ DEFPY (clear_ip_ospf_neighbor,
 			return CMD_NOT_MY_INSTANCE;
 	}
 
+	if (vrf_name) {
+		vrf = vrf_lookup_by_name(vrf_name);
+		if (!vrf)
+			return CMD_WARNING;
+	}
+
 	/* Clear all the ospf processes */
 	for (ALL_LIST_ELEMENTS_RO(om->ospf, node, ospf)) {
+		if (vrf && (ospf->vrf_id == vrf->vrf_id)) {
+			if (nbr_id_str && IPV4_ADDR_SAME(&ospf->router_id, &nbr_id)) {
+				vty_out(vty, "Self router-id is not allowed.\r\n ");
+				return CMD_SUCCESS;
+			}
+
+			if (ospf->oi_running)
+				ospf_neighbor_reset(ospf, nbr_id, nbr_id_str);
+			return CMD_SUCCESS;
+		}
+
 		if (!ospf->oi_running)
 			continue;
 
@@ -11818,17 +11836,17 @@ DEFPY (clear_ip_ospf_neighbor,
 	return CMD_SUCCESS;
 }
 
-DEFPY (clear_ip_ospf_process,
-       clear_ip_ospf_process_cmd,
-       "clear ip ospf [(1-65535)]$instance process",
-       CLEAR_STR
-       IP_STR
-       "OSPF information\n"
-       "Instance ID\n"
-       "Reset OSPF Process\n")
+DEFPY(clear_ip_ospf_process, clear_ip_ospf_process_cmd,
+      "clear ip ospf [{(1-65535)$instance|vrf NAME$vrf_name}] process",
+      CLEAR_STR IP_STR
+      "OSPF information\n"
+      "Instance ID\n"
+      VRF_CMD_HELP_STR
+      "Reset OSPF Process\n")
 {
 	struct listnode *node;
 	struct ospf *ospf = NULL;
+	struct vrf *vrf = NULL;
 
 	/* Check if instance is not passed as an argument */
 	if (instance != 0) {
@@ -11837,8 +11855,20 @@ DEFPY (clear_ip_ospf_process,
 			return CMD_NOT_MY_INSTANCE;
 	}
 
+	if (vrf_name) {
+		vrf = vrf_lookup_by_name(vrf_name);
+		if (!vrf)
+			return CMD_WARNING;
+	}
+
 	/* Clear all the ospf processes */
 	for (ALL_LIST_ELEMENTS_RO(om->ospf, node, ospf)) {
+		if (vrf && (ospf->vrf_id == vrf->vrf_id)) {
+			if (ospf->oi_running)
+				ospf_process_reset(ospf);
+			return CMD_SUCCESS;
+		}
+
 		if (!ospf->oi_running)
 			continue;
 


### PR DESCRIPTION
Add vrf option to clear ip ospf process and
clear ip ospf neighbor commands.
l1# clear ip ospf vrf red neighbor
  <cr>
  A.B.C.D
Ticket: #3605446
Testing:

"clear ip ospf process"
before:
tor-11# clear ip ospf vrf vrf1012
  interface  Interface information

after:
tor-11# clear ip ospf vrf
  NAME  The VRF name
     default mgmt
tor-11# clear ip ospf vrf red
  (1-65535)  Instance ID
  interface  Interface information
  process    Reset OSPF Process
tor-11# clear ip ospf vrf red process

"clear ip ospf neighbor"
before:
tor-12# clear ip ospf vrf red
  interface  Interface information

after:
l1# clear ip ospf vrf vrf1012
  (1-65535)  Instance ID
  interface  Interface information
  neighbor   Reset OSPF Neighbor
  process    Reset OSPF Process
l1# clear ip ospf vrf red neighbor
  <cr>
  A.B.C.D

Signed-off-by: Vijayalaxmi Basavaraj <vbasavaraj@nvidia.com>