### PR TITLE
    zebra: changes to include ecn bits in tos value

### DIFF
--- a/tests/topotests/pbr_topo1/r1/pbr-map.json
+++ b/tests/topotests/pbr_topo1/r1/pbr-map.json
@@ -1,152 +1,166 @@
 [
-  {
-    "name":"AKIHABARA",
-    "valid":false,
-    "policies":[
-      {
-        "sequenceNumber":5,
-        "vrfUnchanged":false,
-        "installed":true,
-        "installedReason":"Valid",
-        "nexthopGroup": {
-          "name":"C",
-          "installed":true,
-          "installedInternally":1
-        },
-        "matchDst":"192.168.4.0\/24"
-      },
-      {
-        "sequenceNumber":10,
-        "vrfUnchanged":false,
-        "installed":false,
-        "installedReason":"Invalid Src or Dst",
-        "nexthopGroup":{
-          "name":"C",
-          "installed":true,
-          "installedInternally":1
-        }
-      },
-      {
-        "sequenceNumber":15,
-        "vrfUnchanged":false,
-        "installed":false,
-        "installedReason":"No Nexthops"
-      }
-    ]
-  },
-  {
-    "name":"ASAKUSA",
-    "valid":true,
-    "policies":[
-      {
-        "sequenceNumber":5,
-        "vrfUnchanged":false,
-        "installed":true,
-        "installedReason":"Valid",
-        "matchDst":"c0ff:ee::\/64",
-        "nexthopGroup":{
-          "name":"D",
-          "installed":true,
-          "installedInternally":1
-        }
-      },
-      {
-        "sequenceNumber":10,
-        "vrfUnchanged":false,
-        "installed":true,
-        "installedReason":"Valid",
-        "nexthopGroup":{
-          "name":"ASAKUSA10",
-          "installed":true,
-          "installedInternally":1
-        },
-        "matchDst":"dead:beef::\/64",
-        "matchMark":314159
-      },
-      {
-        "sequenceNumber":15,
-        "vrfUnchanged":false,
-        "installed":true,
-        "installedReason":"Valid",
-        "nexthopGroup":{
-          "name":"ASAKUSA15",
-          "installed":true,
-          "installedInternally":1
-        },
-        "matchDst":"dead:beef::/64",
-        "matchDscp":10
-      },
-      {
-        "sequenceNumber":20,
-        "vrfUnchanged":false,
-        "installed":true,
-        "installedReason":"Valid",
-        "nexthopGroup":{
-          "name":"ASAKUSA20",
-          "installed":true,
-          "installedInternally":1
-        },
-        "matchDst":"dead:beef::/64",
-        "matchEcn":1
-      }
-    ]
-  },
-  {
-    "name":"DONNA",
-    "valid":false,
-    "policies":[
-      {
-        "sequenceNumber":5,
-        "vrfUnchanged":false,
-        "installed":true,
-        "installedReason":"Invalid NH-group",
-        "nexthopGroup":{
-          "name":"B",
-          "installed":false,
-          "installedInternally":0
-        },
-        "matchSrc":"1.2.0.0\/16",
-        "matchDst":"3.4.5.0\/24"
-      },
-      {
-        "sequenceNumber":10,
-        "vrfUnchanged":true,
-        "installed":true,
-        "installedReason":"Valid",
-        "matchSrc":"1.2.0.0\/16",
-        "matchDst":"3.4.5.0\/24"
-      }
-    ]
-  },
-  {
-    "name":"EVA",
-    "valid":true,
-    "policies":[
-      {
-        "sequenceNumber":5,
-        "vrfUnchanged":false,
-        "installed":true,
-        "installedReason":"Valid",
-        "nexthopGroup":{
-          "name":"EVA5",
-          "installed":true,
-          "installedInternally":1
-        },
-        "matchSrc":"4.5.6.7\/32"
-      },
-      {
-        "sequenceNumber":10,
-        "ruleNumber":309,
-        "vrfUnchanged":false,
-        "installed":true,
-        "installedReason":"Valid",
-        "nexthopGroup":{
-          "name":"A",
-          "installed":true,
-          "installedInternally":1
-        },
-        "matchDst":"9.9.9.9\/32"
-      }
-    ]
-  }
+	{
+		"name": "AKIHABARA",
+		"valid": false,
+		"policies": [
+			{
+				"sequenceNumber": 5,
+				"vrfUnchanged": false,
+				"installed": true,
+				"installedReason": "Valid",
+				"nexthopGroup": {
+					"name": "C",
+					"installed": true,
+					"installedInternally": 1
+				},
+				"matchDst": "192.168.4.0\/24"
+			},
+			{
+				"sequenceNumber": 10,
+				"vrfUnchanged": false,
+				"installed": false,
+				"installedReason": "Invalid Src or Dst",
+				"nexthopGroup": {
+					"name": "C",
+					"installed": true,
+					"installedInternally": 1
+				}
+			},
+			{
+				"sequenceNumber": 15,
+				"vrfUnchanged": false,
+				"installed": false,
+				"installedReason": "No Nexthops"
+			}
+		]
+	},
+	{
+		"name": "ASAKUSA",
+		"valid": true,
+		"policies": [
+			{
+				"sequenceNumber": 5,
+				"vrfUnchanged": false,
+				"installed": true,
+				"installedReason": "Valid",
+				"matchDst": "c0ff:ee::\/64",
+				"nexthopGroup": {
+					"name": "D",
+					"installed": true,
+					"installedInternally": 1
+				}
+			},
+			{
+				"sequenceNumber": 10,
+				"vrfUnchanged": false,
+				"installed": true,
+				"installedReason": "Valid",
+				"nexthopGroup": {
+					"name": "ASAKUSA10",
+					"installed": true,
+					"installedInternally": 1
+				},
+				"matchDst": "dead:beef::\/64",
+				"matchMark": 314159
+			},
+			{
+				"sequenceNumber": 15,
+				"vrfUnchanged": false,
+				"installed": true,
+				"installedReason": "Valid",
+				"nexthopGroup": {
+					"name": "ASAKUSA15",
+					"installed": true,
+					"installedInternally": 1
+				},
+				"matchDst": "dead:beef::/64",
+				"matchDscp": 10
+			},
+			{
+				"sequenceNumber": 20,
+				"vrfUnchanged": false,
+				"installed": true,
+				"installedReason": "Valid",
+				"nexthopGroup": {
+					"name": "ASAKUSA20",
+					"installed": true,
+					"installedInternally": 1
+				},
+				"matchDst": "dead:beef::/64",
+				"matchEcn": 1
+			},
+			{
+				"sequenceNumber": 25,
+				"vrfUnchanged": false,
+				"installed": true,
+				"installedReason": "Valid",
+				"nexthopGroup": {
+					"name": "ASAKUSA25",
+					"installed": true,
+					"installedInternally": 1
+				},
+				"matchDst": "dead:beef::/64",
+				"matchDscp": 10,
+				"matchEcn": 1
+			}
+		]
+	},
+	{
+		"name": "DONNA",
+		"valid": false,
+		"policies": [
+			{
+				"sequenceNumber": 5,
+				"vrfUnchanged": false,
+				"installed": true,
+				"installedReason": "Invalid NH-group",
+				"nexthopGroup": {
+					"name": "B",
+					"installed": false,
+					"installedInternally": 0
+				},
+				"matchSrc": "1.2.0.0\/16",
+				"matchDst": "3.4.5.0\/24"
+			},
+			{
+				"sequenceNumber": 10,
+				"vrfUnchanged": true,
+				"installed": true,
+				"installedReason": "Valid",
+				"matchSrc": "1.2.0.0\/16",
+				"matchDst": "3.4.5.0\/24"
+			}
+		]
+	},
+	{
+		"name": "EVA",
+		"valid": true,
+		"policies": [
+			{
+				"sequenceNumber": 5,
+				"vrfUnchanged": false,
+				"installed": true,
+				"installedReason": "Valid",
+				"nexthopGroup": {
+					"name": "EVA5",
+					"installed": true,
+					"installedInternally": 1
+				},
+				"matchSrc": "4.5.6.7\/32"
+			},
+			{
+				"sequenceNumber": 10,
+				"ruleNumber": 309,
+				"vrfUnchanged": false,
+				"installed": true,
+				"installedReason": "Valid",
+				"nexthopGroup": {
+					"name": "A",
+					"installed": true,
+					"installedInternally": 1
+				},
+				"matchDst": "9.9.9.9\/32"
+			}
+		]
+	}
 ]

--- a/tests/topotests/pbr_topo1/r1/pbrd.conf
+++ b/tests/topotests/pbr_topo1/r1/pbrd.conf
@@ -83,6 +83,12 @@ pbr-map ASAKUSA seq 20
   match ecn 1
   set nexthop c0ff:ee::1
 !
+pbr-map ASAKUSA seq 25
+  match dst-ip dead:beef::/64
+  match dscp af11
+  match ecn 1
+  set nexthop c0ff:ee::1
+!
 # Interface policies
 int r1-eth1
   pbr-policy EVA


### PR DESCRIPTION

    while creating ip rule in kernel

    Issue - pbr rules created with ecn match conditions
    are not synced to kernel, since tos value at the time of
    ip rule creation has only dscp bits.

**WITHOUT FIX (Bug)**
``` 
FRR Configuration Shows:
r1# show pbr map ASAKUSA
  pbr-map ASAKUSA valid: yes
    Seq: 25 rule: 324
        Installed: yes Reason: Valid
        DST IP Match: dead:beef::/64
        DSCP Match: 10      ← DSCP configured
        ECN Match: 1        ← ECN configured
        nexthop c0ff:ee::1
          Installed: yes Tableid: 10008

Kernel Rule Shows:
r1# ip -6 rule show | grep 324
324: from all to dead:beef::/64 tos 0x28 iif r1-eth4 lookup 10008
     ^^^ DSCP only (10 << 2 = 0x28), ECN bit MISSING! 
```

**WITH FIX**
```
r1# show pbr map ASAKUSA
  pbr-map ASAKUSA valid: yes
    Seq: 25 rule: 324
        Installed: yes Reason: Valid
        DST IP Match: dead:beef::/64
        DSCP Match: 10      ← DSCP configured
        ECN Match: 1        ← ECN configured
        nexthop c0ff:ee::1
          Installed: yes Tableid: 10008

r1# ip -6 rule show | grep 324
324: from all to dead:beef::/64 tos 0x29 iif r1-eth4 lookup 10008
     ^^^ DSCP + ECN combined (0x28 | 0x01 = 0x29) ✓
```
