### PR TITLE
doc: correct bfd detect-multiplier behavior

### DIFF
--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -150,14 +150,15 @@ BFD peers and profiles share the same BFD session configuration commands.
 .. clicmd:: detect-multiplier (1-255)
 
    Configures the detection multiplier to determine packet loss. The
-   remote transmission interval will be multiplied by this value to
-   determine the connection loss detection timer. The default value is
-   3.
+   larger value of a comparison between the local system's `transmit-interval`
+   and the remote system's `receive-interval` will be multiplied by this value
+   to determine the connection loss detection timer on the remote system. The
+   default value is 3.
 
-   Example: when the local system has `detect-multiplier 3` and  the
-   remote system has `transmission interval 300`, the local system will
-   detect failures only after 900 milliseconds without receiving
-   packets.
+   Example: when the local system has `detect-multiplier 3` with
+   `transmit-interval 300`, and the remote system has `receive-interval 200`
+   the remote system will detect failures only after 900 milliseconds without
+   receiving packets.
 
 .. clicmd:: receive-interval (10-4294967)
 


### PR DESCRIPTION
To correct issue raised in https://github.com/FRRouting/frr/issues/19850

[RFC 5880](https://www.rfc-editor.org/rfc/rfc5880#section-6.8.4):

>    In Asynchronous mode, the Detection Time calculated in the local
   system is equal to the value of Detect Mult received from the remote
   system, multiplied by the agreed transmit interval of the remote
   system (the greater of bfd.RequiredMinRxInterval and the last
   received Desired Min TX Interval).  The Detect Mult value is (roughly
   speaking, due to jitter) the number of packets that have to be missed
   in a row to declare the session to be down.

In other words, the detection time calculated in the remote system is equal to the value of **detect multiplier set on the local system,** multiplied by **max**(remote's min receive interval, local min TX interval). 

the local system's detect multiplier is used by the remote system to determine loss from the local system. 

https://github.com/FRRouting/frr/blob/59654f81beced0eabdbe219e0adce884518a28b3/bfdd/bfd_packet.c#L1079-L1092

This PR corrects the documentation's language to adhere to implementation and RFC.
