### PR TITLE
zebra: Crash within bgp_evpn_vxlan_svd_topo1 test

### DIFF
--- a/zebra/zebra_vxlan_if.c
+++ b/zebra/zebra_vxlan_if.c
@@ -669,7 +669,6 @@ struct zebra_vxlan_vni *zebra_vxlan_if_vni_find(const struct zebra_if *zif,
 	if (vnip)
 		assert(vnip->vni == vni);
 
-	assert(vnip);
 	return vnip;
 }
 


### PR DESCRIPTION
Description:
Assert in zebra_vxlan_if_vni_find causes this crash. Reverting assert.

Issues: 20188