### PR TITLE
bgpd: [TP] Add BGP FSM and session tracing with conditional fsm_event

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -42,6 +42,7 @@
 #include "bgpd/bgp_io.h"
 #include "bgpd/bgp_zebra.h"
 #include "bgpd/bgp_vty.h"
+#include "bgpd/bgp_trace.h"
 
 DEFINE_HOOK(peer_backward_transition, (struct peer * peer), (peer));
 DEFINE_HOOK(peer_status_changed, (struct peer * peer), (peer));
@@ -482,6 +483,7 @@ static void bgp_start_timer(struct event *event)
 	struct peer_connection *connection = EVENT_ARG(event);
 	struct peer *peer = connection->peer;
 
+	frrtrace(2, frr_bgp, session_state_change, peer, 1);
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [FSM] Timer (start timer expire for %s).", peer->host,
 			   bgp_peer_get_connection_direction(connection));
@@ -502,6 +504,7 @@ static void bgp_connect_timer(struct event *event)
 	assert(!connection->t_write);
 	assert(!connection->t_read);
 
+	frrtrace(2, frr_bgp, session_state_change, peer, 2);
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [FSM] Timer (connect timer (%us) expire for %s)", peer->host,
 			   peer->v_connect, bgp_peer_get_connection_direction(connection));
@@ -523,6 +526,7 @@ static void bgp_holdtime_timer(struct event *event)
 	struct peer_connection *connection = EVENT_ARG(event);
 	struct peer *peer = connection->peer;
 
+	frrtrace(2, frr_bgp, session_state_change, peer, 3);
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [FSM] Timer (holdtime timer expire for %s)", peer->host,
 			   bgp_peer_get_connection_direction(connection));
@@ -555,6 +559,7 @@ void bgp_routeadv_timer(struct event *event)
 	struct peer_connection *connection = EVENT_ARG(event);
 	struct peer *peer = connection->peer;
 
+	frrtrace(2, frr_bgp, session_state_change, peer, 4);
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [FSM] Timer (routeadv timer expire for %s)", peer->host,
 			   bgp_peer_get_connection_direction(connection));
@@ -575,6 +580,7 @@ void bgp_delayopen_timer(struct event *event)
 	struct peer_connection *connection = EVENT_ARG(event);
 	struct peer *peer = connection->peer;
 
+	frrtrace(2, frr_bgp, session_state_change, peer, 5);
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [FSM] Timer (DelayOpentimer expire for %s)", peer->host,
 			   bgp_peer_get_connection_direction(connection));
@@ -2041,6 +2047,7 @@ bgp_connect_success_w_delayopen(struct peer_connection *connection)
 		BGP_TIMER_ON(peer->connection->t_delayopen, bgp_delayopen_timer,
 			     peer->v_delayopen);
 
+	frrtrace(2, frr_bgp, session_state_change, peer, 6);
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [FSM] BGP OPEN message delayed for %d seconds for connection %s",
 			   peer->host, peer->delayopen,
@@ -2102,6 +2109,7 @@ static enum bgp_fsm_state_progress bgp_start(struct peer_connection *connection)
 	bgp_peer_conf_if_to_su_update(connection);
 
 	if (connection->su.sa.sa_family == AF_UNSPEC) {
+		frrtrace(2, frr_bgp, session_state_change, peer, 7);
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%s [FSM] Unable to get neighbor's IP address, waiting... for %s",
 				   peer->host, bgp_peer_get_connection_direction(connection));
@@ -2159,6 +2167,7 @@ static enum bgp_fsm_state_progress bgp_start(struct peer_connection *connection)
 	 */
 	if (!bgp_peer_reg_with_nht(peer)) {
 		if (bgp_zebra_num_connects()) {
+			frrtrace(2, frr_bgp, session_state_change, peer, 8);
 			if (bgp_debug_neighbor_events(peer))
 				zlog_debug("%s [FSM] Waiting for NHT, no path to neighbor present for %s",
 					   peer->host,
@@ -2175,6 +2184,7 @@ static enum bgp_fsm_state_progress bgp_start(struct peer_connection *connection)
 	assert(!CHECK_FLAG(connection->thread_flags, PEER_THREAD_READS_ON));
 	status = bgp_connect(connection);
 
+	frrtrace(2, frr_bgp, connection_attempt, peer, status);
 	switch (status) {
 	case connect_error:
 		if (bgp_debug_neighbor_events(peer))
@@ -2274,6 +2284,7 @@ bgp_fsm_holdtime_expire(struct peer_connection *connection)
 {
 	struct peer *peer = connection->peer;
 
+	frrtrace(2, frr_bgp, session_state_change, peer, 9);
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [FSM] Hold timer expire for %s", peer->host,
 			   bgp_peer_get_connection_direction(connection));
@@ -2824,6 +2835,10 @@ int bgp_event_update(struct peer_connection *connection,
 
 	/* Logging this event. */
 	next = FSM[connection->status - 1][event - 1].next_state;
+
+	if (connection->status != next)
+		frrtrace(2, frr_bgp, fsm_event, peer, event, connection->status, next,
+			 connection->fd);
 
 	if (bgp_debug_neighbor_events(peer) && connection->status != next)
 		zlog_debug("%s [FSM] %s (%s->%s), fd %d for %s", peer->host, bgp_event_str[event],

--- a/bgpd/bgp_trace.h
+++ b/bgpd/bgp_trace.h
@@ -676,6 +676,55 @@ TRACEPOINT_EVENT(
 )
 TRACEPOINT_LOGLEVEL(frr_bgp, gr_bgp_state, TRACE_INFO)
 
+TRACEPOINT_EVENT(
+	frr_bgp,
+	session_state_change,
+	TP_ARGS(struct peer *, peer, uint8_t, location),
+	TP_FIELDS(
+		ctf_string(peer, PEER_HOSTNAME(peer))
+		ctf_integer(uint8_t, location, location)
+		ctf_integer(enum bgp_fsm_status, old_status, peer->connection->ostatus)
+		ctf_integer(enum bgp_fsm_status, new_status, peer->connection->status)
+		ctf_integer(enum bgp_fsm_events, event, peer->cur_event)
+		ctf_integer(uint32_t, vrf_id, peer->bgp->vrf_id)
+		ctf_integer(int, fd, peer->connection->fd)
+		ctf_integer(uint32_t, established_peers, peer->bgp->established_peers)
+	)
+)
+
+TRACEPOINT_LOGLEVEL(frr_bgp, session_state_change, TRACE_INFO)
+
+TRACEPOINT_EVENT(
+	frr_bgp,
+	connection_attempt,
+	TP_ARGS(struct peer *, peer, int, status),
+	TP_FIELDS(
+		ctf_string(peer, PEER_HOSTNAME(peer))
+		ctf_integer(int, status, status)
+		ctf_integer(enum bgp_fsm_status, current_status, peer->connection->status)
+		ctf_integer(uint32_t, vrf_id, peer->bgp->vrf_id)
+		ctf_integer(int, fd, peer->connection->fd)
+	)
+)
+
+TRACEPOINT_LOGLEVEL(frr_bgp, connection_attempt, TRACE_INFO)
+
+TRACEPOINT_EVENT(
+	frr_bgp,
+	fsm_event,
+	TP_ARGS(struct peer *, peer, enum bgp_fsm_events, event, enum bgp_fsm_status, current_status, enum bgp_fsm_status, next_status, int, fd),
+	TP_FIELDS(
+		ctf_string(peer, PEER_HOSTNAME(peer))
+		ctf_integer(enum bgp_fsm_events, event, event)
+		ctf_integer(enum bgp_fsm_status, current_status, current_status)
+		ctf_integer(enum bgp_fsm_status, next_status, next_status)
+		ctf_integer(int, fd, fd)
+		ctf_integer(uint32_t, vrf_id, peer->bgp->vrf_id)
+	)
+)
+
+TRACEPOINT_LOGLEVEL(frr_bgp, fsm_event, TRACE_INFO)
+
 /* clang-format on */
 
 #include <lttng/tracepoint-event.h>

--- a/tools/frr_babeltrace.py
+++ b/tools/frr_babeltrace.py
@@ -216,8 +216,7 @@ def parse_frr_bgp_evpn_mh_es_evi_vtep_add(event):
     bgp evpn remote ead evi remote vtep add; raw format -
     ctf_array(unsigned char, esi, esi, sizeof(esi_t))
     """
-    field_parsers = {"esi": print_esi,
-                     "vtep": print_net_ipv4_addr}
+    field_parsers = {"esi": print_esi, "vtep": print_net_ipv4_addr}
 
     parse_event(event, field_parsers)
 
@@ -227,8 +226,7 @@ def parse_frr_bgp_evpn_mh_es_evi_vtep_del(event):
     bgp evpn remote ead evi remote vtep del; raw format -
     ctf_array(unsigned char, esi, esi, sizeof(esi_t))
     """
-    field_parsers = {"esi": print_esi,
-                     "vtep": print_net_ipv4_addr}
+    field_parsers = {"esi": print_esi, "vtep": print_net_ipv4_addr}
 
     parse_event(event, field_parsers)
 
@@ -238,8 +236,7 @@ def parse_frr_bgp_evpn_mh_local_ead_es_evi_route_upd(event):
     bgp evpn local ead evi vtep; raw format -
     ctf_array(unsigned char, esi, esi, sizeof(esi_t))
     """
-    field_parsers = {"esi": print_esi,
-                     "vtep": print_net_ipv4_addr}
+    field_parsers = {"esi": print_esi, "vtep": print_net_ipv4_addr}
 
     parse_event(event, field_parsers)
 
@@ -249,8 +246,7 @@ def parse_frr_bgp_evpn_mh_local_ead_es_evi_route_del(event):
     bgp evpn local ead evi vtep del; raw format -
     ctf_array(unsigned char, esi, esi, sizeof(esi_t))
     """
-    field_parsers = {"esi": print_esi,
-                     "vtep": print_net_ipv4_addr}
+    field_parsers = {"esi": print_esi, "vtep": print_net_ipv4_addr}
 
     parse_event(event, field_parsers)
 
@@ -261,8 +257,7 @@ def parse_frr_bgp_evpn_local_vni_add_zrecv(event):
     ctf_integer_network_hex(unsigned int, vtep, vtep.s_addr)
     ctf_integer_network_hex(unsigned int, mc_grp, mc_grp.s_addr)
     """
-    field_parsers = {"vtep": print_ip_addr,
-                     "mc_grp": print_net_ipv4_addr}
+    field_parsers = {"vtep": print_ip_addr, "mc_grp": print_net_ipv4_addr}
 
     parse_event(event, field_parsers)
 
@@ -290,9 +285,7 @@ def parse_frr_bgp_evpn_local_macip_add_zrecv(event):
     ctf_array(unsigned char, mac, mac, sizeof(struct ethaddr))
     ctf_array(unsigned char, esi, esi, sizeof(esi_t))
     """
-    field_parsers = {"ip": print_ip_addr,
-                     "mac": print_mac,
-                     "esi": print_esi}
+    field_parsers = {"ip": print_ip_addr, "mac": print_mac, "esi": print_esi}
 
     parse_event(event, field_parsers)
 
@@ -303,8 +296,7 @@ def parse_frr_bgp_evpn_local_macip_del_zrecv(event):
     ctf_array(unsigned char, ip, ip, sizeof(struct ipaddr))
     ctf_array(unsigned char, mac, mac, sizeof(struct ethaddr))
     """
-    field_parsers = {"ip": print_ip_addr,
-                     "mac": print_mac}
+    field_parsers = {"ip": print_ip_addr, "mac": print_mac}
 
     parse_event(event, field_parsers)
 
@@ -334,45 +326,115 @@ def parse_frr_bgp_evpn_withdraw_type5(event):
 ############################ evpn parsers - end *#############################
 
 
+def location_bgp_session_state_change(field_val):
+    locations = {
+        1: "START_TIMER_EXPIRE",
+        2: "CONNECT_TIMER_EXPIRE",
+        3: "HOLDTIME_EXPIRE",
+        4: "ROUTEADV_TIMER_EXPIRE",
+        5: "DELAY_OPEN_TIMER_EXPIRE",
+        6: "BGP_OPEN_MSG_DELAYED",
+        7: "Unable to get Nbr's IP Addr, waiting..",
+        8: "Waiting for NHT, no path to Nbr present",
+        9: "FSM_HOLDTIME_EXPIRE",
+    }
+    return locations.get(field_val, f"UNKNOWN({field_val})")
+
+
+def bgp_status_to_string(field_val):
+    statuses = {
+        1: "Idle",
+        2: "Connect",
+        3: "Active",
+        4: "OpenSent",
+        5: "OpenConfirm",
+        6: "Established",
+        7: "Clearing",
+        8: "Deleted",
+    }
+    return statuses.get(field_val, f"UNKNOWN({field_val})")
+
+
+def bgp_event_to_string(field_val):
+    events = {
+        1: "BGP_Start",
+        2: "BGP_Stop",
+        3: "TCP_connection_open",
+        4: "TCP_connection_open_w_delay",
+        5: "TCP_connection_closed",
+        6: "TCP_connection_open_failed",
+        7: "TCP_fatal_error",
+        8: "ConnectRetry_timer_expired",
+        9: "Hold_Timer_expired",
+        10: "KeepAlive_timer_expired",
+        11: "DelayOpen_timer_expired",
+        12: "Receive_OPEN_message",
+        13: "Receive_KEEPALIVE_message",
+        14: "Receive_UPDATE_message",
+        15: "Receive_NOTIFICATION_message",
+        16: "Clearing_Completed",
+    }
+    return events.get(field_val, f"UNKNOWN({field_val})")
+
+
+def parse_frr_bgp_session_state_change(event):
+    field_parsers = {
+        "location": location_bgp_session_state_change,
+        "old_status": bgp_status_to_string,
+        "new_status": bgp_status_to_string,
+        "event": bgp_event_to_string,
+    }
+    parse_event(event, field_parsers)
+
+
+def connection_status_to_string(field_val):
+    statuses = {0: "connect_error", 1: "connect_success", 2: "connect_in_progress"}
+    return statuses.get(field_val, f"UNKNOWN({field_val})")
+
+
+def parse_frr_bgp_connection_attempt(event):
+    field_parsers = {
+        "status": connection_status_to_string,
+        "current_status": bgp_status_to_string,
+    }
+    parse_event(event, field_parsers)
+
+
+def parse_frr_bgp_fsm_event(event):
+    field_parsers = {
+        "event": bgp_event_to_string,
+        "current_status": bgp_status_to_string,
+        "next_status": bgp_status_to_string,
+    }
+    parse_event(event, field_parsers)
+
+
 def main():
     """
     FRR lttng trace output parser; babel trace plugin
     """
-    event_parsers = {"frr_bgp:evpn_mac_ip_zsend":
-                     parse_frr_bgp_evpn_mac_ip_zsend,
-                     "frr_bgp:evpn_bum_vtep_zsend":
-                     parse_frr_bgp_evpn_bum_vtep_zsend,
-                     "frr_bgp:evpn_mh_nh_rmac_zsend":
-                     parse_frr_bgp_evpn_mh_nh_rmac_send,
-                     "frr_bgp:evpn_mh_local_es_add_zrecv":
-                     parse_frr_bgp_evpn_mh_local_es_add_zrecv,
-                     "frr_bgp:evpn_mh_local_es_del_zrecv":
-                     parse_frr_bgp_evpn_mh_local_es_del_zrecv,
-                     "frr_bgp:evpn_mh_local_es_evi_add_zrecv":
-                     parse_frr_bgp_evpn_mh_local_es_evi_add_zrecv,
-                     "frr_bgp:evpn_mh_local_es_evi_del_zrecv":
-                     parse_frr_bgp_evpn_mh_local_es_evi_del_zrecv,
-                     "frr_bgp:evpn_mh_es_evi_vtep_add":
-                     parse_frr_bgp_evpn_mh_es_evi_vtep_add,
-                     "frr_bgp:evpn_mh_es_evi_vtep_del":
-                     parse_frr_bgp_evpn_mh_es_evi_vtep_del,
-                     "frr_bgp:evpn_mh_local_ead_es_evi_route_upd":
-                     parse_frr_bgp_evpn_mh_local_ead_es_evi_route_upd,
-                     "frr_bgp:evpn_mh_local_ead_es_evi_route_del":
-                     parse_frr_bgp_evpn_mh_local_ead_es_evi_route_del,
-                     "frr_bgp:evpn_local_vni_add_zrecv":
-                     parse_frr_bgp_evpn_local_vni_add_zrecv,
-                     "frr_bgp:evpn_local_l3vni_add_zrecv":
-                     parse_frr_bgp_evpn_local_l3vni_add_zrecv,
-                     "frr_bgp:evpn_local_macip_add_zrecv":
-                     parse_frr_bgp_evpn_local_macip_add_zrecv,
-                     "frr_bgp:evpn_local_macip_del_zrecv":
-                     parse_frr_bgp_evpn_local_macip_del_zrecv,
-                     "frr_bgp:evpn_advertise_type5":
-                     parse_frr_bgp_evpn_advertise_type5,
-                     "frr_bgp:evpn_withdraw_type5":
-                     parse_frr_bgp_evpn_withdraw_type5,
-}
+    event_parsers = {
+        "frr_bgp:evpn_mac_ip_zsend": parse_frr_bgp_evpn_mac_ip_zsend,
+        "frr_bgp:evpn_bum_vtep_zsend": parse_frr_bgp_evpn_bum_vtep_zsend,
+        "frr_bgp:evpn_mh_nh_rmac_zsend": parse_frr_bgp_evpn_mh_nh_rmac_send,
+        "frr_bgp:evpn_mh_local_es_add_zrecv": parse_frr_bgp_evpn_mh_local_es_add_zrecv,
+        "frr_bgp:evpn_mh_local_es_del_zrecv": parse_frr_bgp_evpn_mh_local_es_del_zrecv,
+        "frr_bgp:evpn_mh_local_es_evi_add_zrecv": parse_frr_bgp_evpn_mh_local_es_evi_add_zrecv,
+        "frr_bgp:evpn_mh_local_es_evi_del_zrecv": parse_frr_bgp_evpn_mh_local_es_evi_del_zrecv,
+        "frr_bgp:evpn_mh_es_evi_vtep_add": parse_frr_bgp_evpn_mh_es_evi_vtep_add,
+        "frr_bgp:evpn_mh_es_evi_vtep_del": parse_frr_bgp_evpn_mh_es_evi_vtep_del,
+        "frr_bgp:evpn_mh_local_ead_es_evi_route_upd": parse_frr_bgp_evpn_mh_local_ead_es_evi_route_upd,
+        "frr_bgp:evpn_mh_local_ead_es_evi_route_del": parse_frr_bgp_evpn_mh_local_ead_es_evi_route_del,
+        "frr_bgp:evpn_local_vni_add_zrecv": parse_frr_bgp_evpn_local_vni_add_zrecv,
+        "frr_bgp:evpn_local_l3vni_add_zrecv": parse_frr_bgp_evpn_local_l3vni_add_zrecv,
+        "frr_bgp:evpn_local_macip_add_zrecv": parse_frr_bgp_evpn_local_macip_add_zrecv,
+        "frr_bgp:evpn_local_macip_del_zrecv": parse_frr_bgp_evpn_local_macip_del_zrecv,
+        "frr_bgp:evpn_advertise_type5": parse_frr_bgp_evpn_advertise_type5,
+        "frr_bgp:evpn_withdraw_type5": parse_frr_bgp_evpn_withdraw_type5,
+        "frr_bgp:session_state_change": parse_frr_bgp_session_state_change,
+        "frr_bgp:connection_attempt": parse_frr_bgp_connection_attempt,
+        "frr_bgp:fsm_event": parse_frr_bgp_fsm_event,
+    }
 
     # get the trace path from the first command line argument
     trace_path = sys.argv[1]


### PR DESCRIPTION
Add comprehensive tracing for BGP peer events including
 - session state changes,
 - connection attempts, and
 - FSM transitions.

Only trace FSM events when state actually changes to avoid redundancy.