### PR TITLE
Add info_count to route_table for accurate RIB entry reporting

### DIFF
--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -90,7 +90,7 @@ inline struct bgp_dest *bgp_dest_unlock_node(struct bgp_dest *dest)
 		}
 		XFREE(MTYPE_BGP_NODE, dest);
 		dest = NULL;
-		rn->info = NULL;
+		route_node_set_info(rn, NULL);
 	}
 	route_unlock_node(rn);
 
@@ -114,7 +114,7 @@ static void bgp_node_destroy(route_table_delegate_t *delegate,
 						   rt->afi, rt->safi);
 		}
 		XFREE(MTYPE_BGP_NODE, dest);
-		node->info = NULL;
+		route_node_set_info(node, NULL);
 	}
 
 	if (node->p.family == AF_FLOWSPEC)

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -253,7 +253,7 @@ static inline struct bgp_dest *bgp_node_get(struct bgp_table *const table,
 						sizeof(struct bgp_dest));
 
 		RB_INIT(bgp_adj_out_rb, &dest->adj_out);
-		rn->info = dest;
+		route_node_set_info(rn, dest);
 		dest->rn = rn;
 	}
 	return rn->info;
@@ -283,7 +283,7 @@ static inline struct bgp_dest *bgp_node_match(const struct bgp_table *table,
 
 static inline unsigned long bgp_table_count(const struct bgp_table *const table)
 {
-	return route_table_count(table->route_table);
+	return route_table_info_count(table->route_table);
 }
 
 /*

--- a/lib/table.c
+++ b/lib/table.c
@@ -121,6 +121,7 @@ static void route_table_free(struct route_table *rt)
 	}
 
 	assert(rt->count == 0);
+	assert(rt->info_count == 0);
 
 	rn_hash_node_fini(&rt->hash);
 	XFREE(MTYPE_ROUTE_TABLE, rt);
@@ -449,6 +450,11 @@ struct route_node *route_next_until(struct route_node *node,
 unsigned long route_table_count(struct route_table *table)
 {
 	return table->count;
+}
+
+unsigned long route_table_info_count(struct route_table *table)
+{
+	return table->info_count;
 }
 
 /**

--- a/tests/lib/test_table.c
+++ b/tests/lib/test_table.c
@@ -54,7 +54,7 @@ static void add_node(struct route_table *table, const char *prefix_str)
 	assert(node);
 	node->prefix_str = strdup(prefix_str);
 	assert(node->prefix_str);
-	rn->info = node;
+	route_node_set_info(rn, node);
 }
 
 /*
@@ -150,7 +150,7 @@ static void clear_table(struct route_table *table)
 		if (!node) {
 			continue;
 		}
-		rn->info = NULL;
+		route_node_set_info(rn, NULL);
 		route_unlock_node(rn);
 		free(node->prefix_str);
 		free(node);
@@ -478,6 +478,30 @@ static void test_iter_pause(void)
 }
 
 /*
+ * test_info_count
+ *
+ * Tests that route_table_info_count() correctly tracks nodes with data.
+ */
+static void test_info_count(void)
+{
+	struct route_table *table;
+
+	printf("\n\nTesting route_table_info_count()\n");
+	table = route_table_init();
+
+	/* Two disjoint prefixes create one glue node and two real entries. */
+	add_nodes(table, "10.0.0.0/24", "10.0.128.0/24", NULL);
+
+	assert(route_table_info_count(table) == 2);
+	assert(route_table_count(table) == 3);
+
+	clear_table(table);
+	assert(route_table_info_count(table) == 0);
+
+	route_table_finish(table);
+}
+
+/*
  * run_tests
  */
 static void run_tests(void)
@@ -485,6 +509,7 @@ static void run_tests(void)
 	test_prefix_iter_cmp();
 	test_get_next();
 	test_iter_pause();
+	test_info_count();
 }
 
 /*


### PR DESCRIPTION
**Description**

This PR adds a new info_count field to struct route_table that tracks only nodes with actual data (info != NULL), excluding auxiliary/glue nodes that exist solely for the Patricia trie structure.

**Problem**

BGP stores prefix destinations using the Patricia trie in lib/table.[ch].
This data structure requires auxiliary glue nodes to preserve tree structure invariants.

The show ip bgp summary command displays "RIB entries" using route_table_count(),
which counts all nodes in the Patricia trie, including internal glue nodes. 
This is misleading because glue nodes don't represent actual routes.

Example - Before (incorrect):

```
sonic# show ip bgp summary

IPv4 Unicast Summary:
BGP router identifier 192.168.123.118, local AS number 1 VRF default vrf-id 0
BGP table version 12
RIB entries 7, using 896 bytes of memory   <-- includes glue nodes
Peers 1, using 24 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
10.0.0.1        4          1       724       759       12    0    0 11:34:42            0        4 FRRouting/10.3

Total number of neighbors 1
```

In this example, there are only 4 actual prefixes (PfxSnt 4), but "RIB entries" shows 7 because it includes 3 auxiliary glue nodes created by the Patricia trie structure.

Example - After (correct):

```
RIB entries 4, using 896 bytes of memory   <-- only real prefixes
```

**Solution**

Add info_count field to struct route_table to track nodes with info != NULL
Add route_node_set_info() helper function that automatically maintains info_count when setting/clearing a node's info pointer
Update BGP to use  route_node_set_info()
