### PR TITLE
bgpd: Fix route node lock leak in NHT resolved prefix marking

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -599,14 +599,17 @@ static void bgp_bnc_mark_nht_important(struct bgp_nexthop_cache *bnc, struct zap
 		return;
 
 	dest = bgp_afi_node_get(table, afi, nhr->safi, &bnc->resolved_prefix, NULL);
-	if (dest)
+	if (dest) {
 		UNSET_FLAG(dest->flags, BGP_NODE_NHT_RESOLVED_NODE);
+		bgp_dest_unlock_node(dest);
+	}
 
 	dest = bgp_afi_node_get(table, afi, nhr->safi, &nhr->prefix, NULL);
 	if (!dest)
 		return;
 
 	SET_FLAG(dest->flags, BGP_NODE_NHT_RESOLVED_NODE);
+	bgp_dest_unlock_node(dest);
 }
 
 static void bgp_process_nexthop_update(struct bgp_nexthop_cache *bnc,
@@ -968,6 +971,7 @@ void bgp_nexthop_update(struct vrf *vrf, struct prefix *match,
 				    pi->sub_type == BGP_ROUTE_STATIC)
 					vpn_leak_from_vrf_update(bgp_default,
 								 bgp, pi);
+			bgp_dest_unlock_node(dest);
 		}
 	} else if (BGP_DEBUG(nht, NHT))
 		zlog_debug("parse nexthop update %pFX(%u)(%s): bnc info not found for import check",


### PR DESCRIPTION
When bgp_afi_node_get() is called, it locks the node via route_lock_node() before returning it to the caller. The caller is responsible for unlocking the node when done.

Call chain:

  bgp_afi_node_get()
    bgp_node_get()
      route_node_get()
        route_lock_node()

In bgp_bnc_mark_nht_important() and bgp_nexthop_update(), the route nodes obtained from bgp_afi_node_get() were not being unlocked after use, causing a reference count leak.

These issues were introduced by:
- Recent commit 
https://github.com/FRRouting/frr/pull/19008 (bgp_bnc_mark_nht_important function)
- VRF leaking commit 
https://github.com/FRRouting/frr/pull/15238 (bgp_nexthop_update function)