### PR TITLE
ospfd: fix bug allowing vlink creation on non-ABRs

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -849,6 +849,12 @@ ospf_find_vl_data(struct ospf *ospf, struct ospf_vl_config_data *vl_config)
 	vty = vl_config->vty;
 	area_id = vl_config->area_id;
 
+	if (!CHECK_FLAG(ospf->flags, OSPF_FLAG_ABR)) {
+		vty_out(vty,
+			"Configuring VLs on non-ABRs is not allowed\n");
+		return NULL;
+	}
+
 	if (area_id.s_addr == OSPF_AREA_BACKBONE) {
 		vty_out(vty,
 			"Configuring VLs over the backbone is not allowed\n");


### PR DESCRIPTION
Addresses issue raised in https://github.com/FRRouting/frr/issues/20011

Currently ospfd allows establishing a vlink between ospf routers which are not ABRs, which is illegal behavior. 

[RFC2328](https://www.rfc-editor.org/rfc/rfc2328.html#section-15):

> The single backbone area (Area ID = 0.0.0.0) cannot be disconnected,
    or some areas of the Autonomous System will become unreachable.  To
    establish/maintain connectivity of the backbone, virtual links can
    be configured through non-backbone areas.  Virtual links serve to
    connect physically separate components of the backbone.  The two
    endpoints of a virtual link are area border routers.  The virtual
    link must be configured in both routers.  The configuration
    information in each router consists of the other virtual endpoint
    (the other area border router), and the non-backbone area the two
    routers have in common (called the Transit area).  Virtual links
    cannot be configured through stub areas (see [Section 3.6](https://www.rfc-editor.org/rfc/rfc2328.html#section-3.6)).

This PR adds a guard clause to prevent creating a vlink unless the router is already an ABR.

There is a compatibility issue here. The default `abr-type` is `cisco`, which the implementation does not set the ABR flag unless the router is attached to the backbone area. 

https://github.com/FRRouting/frr/blob/fc31cac07d974215798406ba012b31b72e3f6479/ospfd/ospf_abr.c#L494-L518

I am not sure if it makes sense to make a more crude check, such as if the count of ospf areas is greater than `1` for compatibility reasons or to stick to the true intention of the `cisco` and `ibm` ABR types. I can write the test / docs update once there is more guidance here. 
