### PR TITLE
zebra: PBR count tracking

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -374,6 +374,9 @@ zebra_rib_route_entry_new(vrf_id_t vrf_id, int type, uint8_t instance,
 			  uint32_t metric, uint32_t mtu, uint8_t distance,
 			  route_tag_t tag);
 
+void rib_update_route_count(vrf_id_t vrf_id, int type, afi_t afi, safi_t safi,
+			    uint32_t tableid, bool add);
+
 #define ZEBRA_RIB_LOOKUP_ERROR -1
 #define ZEBRA_RIB_FOUND_EXACT 0
 #define ZEBRA_RIB_FOUND_NOGATE 1


### PR DESCRIPTION
Add count to the zebra route info for PBRc

Test:

r3# show yang operational-data /frr-zebra:lib zebra {
  "frr-zebra:lib": {
    "vrf": [
      {
        "id": "default",
        "ipv4-route-count": {
          "total": 23,
          "connected": 4,
          "bgp": 9,
          "kernel": 0,
          "static": 0,
          "pbr": 1,
          "table": 0,
          "ospf": 8
        },

r3# show pbr map
  pbr-map otel-pbr valid: yes
    Seq: 1 rule: 300
        Installed: yes Reason: Valid
        DST IP Match: 20.10.0.4/32
        Nexthop-Group: otel-nhg
          Installed: yes Tableid: 10000
r3# show running-config no-header
r3# show ip route table 10000
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, A - Babel, D - SHARP, F - PBR, f - OpenFabric,
       Z - FRR,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

VRF default table 10000:
F>  0.0.0.0/0 [200/0] via 20.0.0.1 inactive, weight 1, 00:01:30
  *                   via 20.1.1.9, swp1, weight 1, 00:01:30

r3# show ip route summary table 10000
Route Source         Routes               FIB  (vrf default)
pbr                  1                    1
------
Totals               1                    1

Ticket: #4370621