### PR TITLE
bgpd: Start BFD hold timer ONLY if hold-time is configured (not zero)

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -118,8 +118,13 @@ void bgp_peer_config_apply(struct peer *p, struct peer_group *pg)
 
 	/* When called on a group, apply to all peers. */
 	if (CHECK_FLAG(p->sflags, PEER_STATUS_GROUP)) {
-		for (ALL_LIST_ELEMENTS_RO(p->group->peer, n, pn))
+		for (ALL_LIST_ELEMENTS_RO(p->group->peer, n, pn)) {
+			if (peergroup_flag_check(pn, PEER_FLAG_BFD_STRICT))
+				peer_flag_set(pn, PEER_FLAG_BFD_STRICT);
+			else
+				peer_flag_unset(pn, PEER_FLAG_BFD_STRICT);
 			bgp_peer_config_apply(pn, pg);
+		}
 		return;
 	}
 
@@ -644,10 +649,13 @@ DEFPY (neighbor_bfd_strict_hold_time,
 
 	event_cancel(&peer->bfd_config->t_hold_timer);
 
-	if (no)
+	if (no) {
 		peer->bfd_config->hold_time = BFD_DEF_STRICT_HOLD_TIME;
-	else
+		peer_flag_unset(peer, PEER_FLAG_BFD_STRICT);
+	} else {
 		peer->bfd_config->hold_time = hold_time;
+		peer_flag_set(peer, PEER_FLAG_BFD_STRICT);
+	}
 
 	bgp_peer_config_apply(peer, peer->group);
 

--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -85,7 +85,8 @@ static void bfd_session_status_update(struct bfd_session_params *bsp,
 		 * when the source address is changed, e.g. 0.0.0.0 -> 10.0.0.1.
 		 */
 		if (bss->last_event > peer->uptime) {
-			if (!peer->holdtime) {
+			if ((CHECK_FLAG(peer->flags, PEER_FLAG_TIMER) && !peer->holdtime) ||
+			    !peer->bgp->default_holdtime) {
 				event_add_timer(bm->master, bgp_bfd_strict_holdtime_expire, peer,
 						peer->bfd_config->hold_time,
 						&peer->bfd_config->t_hold_timer);


### PR DESCRIPTION
Closes https://github.com/FRRouting/frr/issues/20215