### PR TITLE
zebra: FRR restart leads to zebra mlag core

### DIFF
--- a/zebra/zebra_mlag.c
+++ b/zebra/zebra_mlag.c
@@ -1083,7 +1083,7 @@ int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 
 			/* Actual Data */
 			for (i = 0; i < Bulk_msg->n_mroute_add; i++) {
-				if (STREAM_SIZE(s) < VRF_NAMSIZ + 22 + IFNAMSIZ) {
+				if (STREAM_WRITEABLE(s) < VRF_NAMSIZ + 22 + IFNAMSIZ) {
 					zlog_warn(
 						"We have received more messages than we can parse at this point in time: %zu",
 						Bulk_msg->n_mroute_add);
@@ -1133,7 +1133,7 @@ int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 
 			/* Actual Data */
 			for (i = 0; i < Bulk_msg->n_mroute_del; i++) {
-				if (STREAM_SIZE(s) < VRF_NAMSIZ + 16 + IFNAMSIZ) {
+				if (STREAM_WRITEABLE(s) < VRF_NAMSIZ + 16 + IFNAMSIZ) {
 					zlog_warn(
 						"We have received more messages than we can parse at this time");
 					break;


### PR DESCRIPTION
Issue: With higher mroute scale (around 900), in
       PIM MLAG active-active setup crash was observed on
       a) restarting frr service on standby
       b) Enabling/Disabling pim active-active

Root Cause: During bulk delete event the message read from the
            socket was around for 500 mroutes.
            While decoding the protobuf message the stream size allocated
            was 32768 bytes. But after decoding the message for 500 mroute 34000 bytes
            are needed. So while adding the 482nd mroute to stream, we run out of the space.
            We already have a check in the loop which checks for the size, before writing every mroute.
            But the check was for the whole stream size allocated instead of
            correctly checking the remaining space in the stream via STREAM_WRITEABLE API.
            The change is made to check against the remaining space instead of
            checking against the actual size of the stream that has been allocated.

Testing : Tested with 900 mroute scale on the PIM MLAG AA setup with FRR restart.
	  No crash is observed.

Ticket: #4633514