### PR TITLE
zebra: fix dvni nexthop install for IPv6 routes with ipv4 VTEP

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -3216,7 +3216,10 @@ ssize_t netlink_nexthop_msg_encode(uint16_t cmd,
 				nh_afi = LWTUNNEL_ENCAP_IP;
 			} else if (afi == AFI_IP6) {
 				req->nhm.nh_family = AF_INET6;
-				nh_afi = LWTUNNEL_ENCAP_IP6;
+				if (IS_MAPPED_IPV6(&nh->gate.ipv6))
+					nh_afi = LWTUNNEL_ENCAP_IP;
+				else
+					nh_afi = LWTUNNEL_ENCAP_IP6;
 			}
 
 			switch (nh->type) {


### PR DESCRIPTION
When using IPv4 Vxlan Tunnel IPs and using DVNI, its observed that IPv6 Overlay prefixes learnt via DVNI are marked "rejected" in RIB.

RCA:
netlink_nexthop_msg_encode was setting NHA_ENCAP_TYPE based solely on the NHE AFI, so IPv6 routes was sending ENCAP_TYPE=LWTUNNEL_ENCAP_IP6 for IPv4-mapped-IPv6 nexthop causing kernel to reject the entry.

FIX:
Update the dvni nexthop path to select the encap type based on the actual nexthop underlay.

Testing:
Before fix:
vtysh -c "show ipv6 route vrf vrf1" | grep label
B>r 123:123::/64 [20/0] via ::ffff:6.0.0.1, vxlan99 (vrf default) onlink, label 104003, weight 1, 04:15:12                                                             r                     via ::ffff:6.0.0.1, vxlan99 (vrf default) onlink, label 104003, weight 1, 04:15:12

After fix:
vtysh -c "show ipv6 route vrf vrf1" | grep label
B>* 123:123::/64 [20/0] via ::ffff:6.0.0.1, vxlan99 (vrf default) onlink, label 104003, weight 1, 03:30:23
                        via ::ffff:6.0.0.1, vxlan99 (vrf default) onlink, label 104003, weight 1, 03:30:23

ip -6 route show vrf vrf1
123:123::/64 nhid 193 proto bgp metric 20 pref medium