### PR TITLE
tests: don't access event struct in grpc unit test

### DIFF
--- a/tests/lib/test_grpc.cpp
+++ b/tests/lib/test_grpc.cpp
@@ -480,7 +480,7 @@ void grpc_client_run_test(void)
 void *grpc_client_test_start(void *arg)
 {
 	struct frr_pthread *fpt = (struct frr_pthread *)arg;
-	fpt->master->owner = pthread_self();
+	frr_event_loop_set_pthread_owner(master, pthread_self());
 	frr_pthread_set_name(fpt);
 	frr_pthread_notify_running(fpt);
 


### PR DESCRIPTION
Use an api instead of direct struct access in the GRPC unit-test: the struct is opaque now.
