### PR TITLE
*: only include frr json.h where needed

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -19,6 +19,7 @@
 #include "if.h"
 #include "stream.h"
 #include "bfd.h"
+#include "lib/json.h"
 
 #include "isisd/isis_constants.h"
 #include "isisd/isis_common.h"

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -26,6 +26,7 @@
 #include "stream.h"
 #include "qobj.h"
 #include "lib/northbound_cli.h"
+#include "lib/json.h"
 
 #include "isisd/isis_constants.h"
 #include "isisd/isis_common.h"

--- a/isisd/isis_srv6.c
+++ b/isisd/isis_srv6.c
@@ -10,6 +10,7 @@
 #include <zebra.h>
 
 #include "srv6.h"
+#include "lib/command.h"
 #include "termtable.h"
 #include "lib/lib_errors.h"
 

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -25,6 +25,7 @@
 #include "stream.h"
 #include "sbuf.h"
 #include "network.h"
+#include "lib/json.h"
 
 #include "isisd/isisd.h"
 #include "isisd/isis_tlvs.h"

--- a/lib/asn.c
+++ b/lib/asn.c
@@ -7,6 +7,7 @@
 #include <zebra.h>
 #include "log.h"
 #include "asn.h"
+#include "lib/json.h"
 
 static bool relax_as_zero;
 

--- a/lib/asn.h
+++ b/lib/asn.h
@@ -9,7 +9,6 @@
 
 #include "zebra.h"
 #include "command_match.h"
-#include "json.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,10 +33,12 @@ extern enum match_type asn_str2asn_match(const char *str);
 extern bool asn_str2asn_notation(const char *asstring, as_t *asn,
 				 enum asnotation_mode *asnotation);
 extern const char *asn_mode2str(enum asnotation_mode asnotation);
-void asn_asn2json_array(json_object *jseg_list, as_t asn,
+
+struct json_object;
+void asn_asn2json_array(struct json_object *jseg_list, as_t asn,
 			enum asnotation_mode asnotation);
-void asn_asn2json(json_object *jseg_list, const char *attr,
-		  as_t asn, enum asnotation_mode asnotation);
+void asn_asn2json(struct json_object *jseg_list, const char *attr, as_t asn,
+		  enum asnotation_mode asnotation);
 extern char *asn_asn2string(const as_t *as, char *buf, size_t len,
 			    enum asnotation_mode asnotation);
 /* display AS in appropriate format */

--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -17,6 +17,7 @@
 #include "libfrr.h"
 #include "table.h"
 #include "vty.h"
+#include "lib/json.h"
 #include "bfd.h"
 #include "bfdd/bfd.h"
 

--- a/lib/bfd.h
+++ b/lib/bfd.h
@@ -8,7 +8,6 @@
 #ifndef _ZEBRA_BFD_H
 #define _ZEBRA_BFD_H
 
-#include "lib/json.h"
 #include "lib/zclient.h"
 
 #ifdef __cplusplus
@@ -338,6 +337,7 @@ bool bfd_sess_auto_source(const struct bfd_session_params *bsp);
  * \param json (optional) JSON object pointer.
  * \param bsp session parameters.
  */
+struct json_object;
 void bfd_sess_show(struct vty *vty, struct json_object *json,
 		   struct bfd_session_params *bsp);
 

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -36,6 +36,7 @@
 #include "defaults.h"
 #include "frrscript.h"
 #include "systemd.h"
+#include "json.h"
 
 #include "lib/config_paths.h"
 

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -18,6 +18,7 @@
 #include "printfrr.h"
 #include "vrf.h"
 #include "nexthop_group.h"
+#include "lib/json.h"
 
 DEFINE_MTYPE_STATIC(LIB, NEXTHOP, "Nexthop");
 DEFINE_MTYPE_STATIC(LIB, NH_LABEL, "Nexthop label");

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -292,7 +292,7 @@ extern bool nexthop_is_blackhole(const struct nexthop *nh);
 int nexthop_str2backups(const char *str, int *num_backups,
 			uint8_t *backups);
 
-void nexthop_json_helper(json_object *json_nexthop,
+void nexthop_json_helper(struct json_object *json_nexthop,
 			 const struct nexthop *nexthop, bool display_vrfid,
 			 uint8_t rn_family);
 void nexthop_vty_helper(struct vty *vty, const struct nexthop *nexthop,

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -14,6 +14,7 @@
 #include <vty.h>
 #include <command.h>
 #include <jhash.h>
+#include "lib/json.h"
 
 #include "lib/nexthop_group_clippy.c"
 

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -9,7 +9,6 @@
 #define __NEXTHOP_GROUP__
 
 #include <vty.h>
-#include "json.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -145,7 +144,8 @@ extern void nexthop_group_write_nexthop_simple(struct vty *vty,
 extern void nexthop_group_write_nexthop(struct vty *vty,
 					const struct nexthop *nh);
 
-extern void nexthop_group_json_nexthop(json_object *j,
+struct json_object;
+extern void nexthop_group_json_nexthop(struct json_object *j,
 				       const struct nexthop *nh);
 
 /* Return the number of nexthops in this nhg */

--- a/lib/srv6.c
+++ b/lib/srv6.c
@@ -8,6 +8,7 @@
 
 #include "srv6.h"
 #include "log.h"
+#include "lib/json.h"
 
 DEFINE_QOBJ_TYPE(srv6_locator);
 DEFINE_QOBJ_TYPE(srv6_sid_format);

--- a/lib/srv6.h
+++ b/lib/srv6.h
@@ -9,7 +9,6 @@
 
 #include <zebra.h>
 #include "prefix.h"
-#include "json.h"
 #include "vrf.h"
 
 #include <arpa/inet.h>
@@ -465,9 +464,12 @@ seg6local_action2str(uint32_t action);
 const char *seg6local_context2str(char *str, size_t size,
 				  const struct seg6local_context *ctx,
 				  uint32_t action);
-void seg6local_context2json(const struct seg6local_context *ctx,
-			    uint32_t action, json_object *json);
-void srv6_sid_structure2json(const struct seg6local_context *ctx, json_object *json);
+
+struct json_object;
+
+void seg6local_context2json(const struct seg6local_context *ctx, uint32_t action,
+			    struct json_object *json);
+void srv6_sid_structure2json(const struct seg6local_context *ctx, struct json_object *json);
 
 static inline const char *srv6_sid_ctx2str(char *str, size_t size,
 					   const struct srv6_sid_ctx *ctx)
@@ -529,10 +531,10 @@ extern void srv6_locator_chunk_list_free(void *data);
 extern void srv6_locator_chunk_free(struct srv6_locator_chunk **chunk);
 extern void srv6_locator_copy(struct srv6_locator *copy,
 			      const struct srv6_locator *locator);
-json_object *srv6_locator_chunk_json(const struct srv6_locator_chunk *chunk);
-json_object *srv6_locator_json(const struct srv6_locator *loc);
-json_object *srv6_locator_detailed_json(const struct srv6_locator *loc);
-json_object *
+struct json_object *srv6_locator_chunk_json(const struct srv6_locator_chunk *chunk);
+struct json_object *srv6_locator_json(const struct srv6_locator *loc);
+struct json_object *srv6_locator_detailed_json(const struct srv6_locator *loc);
+struct json_object *
 srv6_locator_chunk_detailed_json(const struct srv6_locator_chunk *chunk);
 
 extern struct srv6_sid_format *srv6_sid_format_alloc(const char *name);

--- a/lib/termtable.h
+++ b/lib/termtable.h
@@ -8,7 +8,6 @@
 #define _TERMTABLE_H_
 
 #include <zebra.h>
-#include "lib/json.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -287,7 +286,8 @@ char *ttable_dump(struct ttable *tt, const char *newline);
  * @param formats an array of characters indicating what JSON type should be
  * used.
  */
-json_object *ttable_json(struct ttable *tt, const char *const formats);
+struct json_object;
+struct json_object *ttable_json(struct ttable *tt, const char *const formats);
 
 /**
  * Convert a table to a JSON array of objects.
@@ -300,9 +300,9 @@ json_object *ttable_json(struct ttable *tt, const char *const formats);
  * @param formats an optinal string of row headers that overrids the first row of the table.
  * This is useful to get naming convention that align with caml Format.
  */
-json_object *ttable_json_with_json_text(struct ttable *tt,
-					const char *const formats,
-					const char *json_override_text);
+struct json_object *ttable_json_with_json_text(struct ttable *tt,
+					       const char *const formats,
+					       const char *json_override_text);
 
 #ifdef __cplusplus
 }

--- a/pathd/path_pcep_cli.c
+++ b/pathd/path_pcep_cli.c
@@ -17,6 +17,7 @@
 #include "frr_pthread.h"
 #include "jhash.h"
 #include "termtable.h"
+#include "lib/json.h"
 
 #include "pathd/pathd.h"
 #include "pathd/path_errors.h"

--- a/ripd/ripd.h
+++ b/ripd/ripd.h
@@ -11,6 +11,7 @@
 #include "distribute.h"
 #include "memory.h"
 #include "bfd.h"
+#include "lib/vector.h"
 
 /* RIP version number. */
 #define RIPv1                            1

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -18,6 +18,7 @@
 #include "link_state.h"
 #include "cspf.h"
 #include "tc.h"
+#include "lib/json.h"
 
 #include "sharpd/sharp_globals.h"
 #include "sharpd/sharp_zebra.h"

--- a/staticd/static_bfd.c
+++ b/staticd/static_bfd.c
@@ -11,6 +11,7 @@
 #include "lib/bfd.h"
 #include "lib/printfrr.h"
 #include "lib/srcdest_table.h"
+#include "lib/json.h"
 
 #include "staticd/static_routes.h"
 #include "staticd/static_zebra.h"

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -20,6 +20,7 @@
 #include "routing_nb.h"
 #include "northbound_cli.h"
 #include "frrdistance.h"
+#include "lib/json.h"
 
 #include "static_vrf.h"
 #include "static_vty.h"

--- a/tests/zebra/test_lm_plugin.c
+++ b/tests/zebra/test_lm_plugin.c
@@ -7,6 +7,7 @@
 
 
 #include <zebra.h>
+#include "lib/command.h"
 #include "zebra/zapi_msg.h"
 #include "zebra/label_manager.h"
 

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -20,6 +20,7 @@
 #include "lib/stream.h"
 #include "lib/zclient.h"
 #include "lib/libfrr.h"
+#include "lib/json.h"
 
 //#include "zebra/zserv.h"
 #include "zebra/zebra_router.h"

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -32,7 +32,7 @@ extern void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
 			       const struct prefix *p, safi_t safi);
 extern void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, safi_t safi,
 				  struct vty *vty, const struct prefix *p,
-				  json_object *json);
+				  struct json_object *json);
 
 extern int rnh_resolve_via_default(struct zebra_vrf *zvrf, int family);
 
@@ -43,7 +43,7 @@ extern bool rnh_nexthop_valid(const struct route_entry *re,
 void rnh_set_hide_backups(bool hide_p);
 bool rnh_get_hide_backups(void);
 
-void show_nexthop_json_helper(json_object *json_nexthop,
+void show_nexthop_json_helper(struct json_object *json_nexthop,
 			      const struct nexthop *nexthop,
 			      const struct route_node *rn,
 			      const struct route_entry *re);

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -17,6 +17,7 @@
 #include "lib/route_types.h"
 #include "vrf.h"
 #include "frrstr.h"
+#include "lib/json.h"
 
 #include "zebra/zebra_router.h"
 #include "zebra/redistribute.h"

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -41,6 +41,7 @@
 #include "lib/frratomic.h"        /* for atomic_load_explicit, atomic_stor... */
 #include "lib/lib_errors.h"       /* for generic ferr ids */
 #include "lib/printfrr.h"         /* for string functions */
+#include "lib/json.h"
 
 #include "zebra/debug.h"          /* for various debugging macros */
 #include "zebra/rib.h"            /* for rib_score_proto */


### PR DESCRIPTION
Remove our json.h header from some high-use lib headers, and include it where it's needed.
