### PR TITLE
tests: Fix pim_dense

### DIFF
--- a/tests/topotests/pim_dense/test_pim_dense.py
+++ b/tests/topotests/pim_dense/test_pim_dense.py
@@ -654,12 +654,6 @@ def test_pim_dense_prune_r6(request):
             "oil": "none",
             "joinState": "NotJoined",
         },
-        "r1": {
-            "src_address": "10.100.0.2",
-            "iif": "r1-eth1",
-            "oil": "none",
-            "joinState": "NotJoined",
-        },
     }
 
     step("Verify 'show ip mroute' showing routes with no OIL")


### PR DESCRIPTION
Upstream CI is failing often with this timing failure:

025-12-09 18:48:05,409 ERROR: topo: test failed at "test_pim_dense/test_pim_dense_prune_r6": Testcase test_pim_dense_prune_r6 : Failed Error: [DUT r1]: Verifying (10.100.0.2, 239.1.1.1) mroute [FAILED]!! Expected in: (iif: ['r1-eth1'], oil: none, installed: (10.100.0.2,239.1.1.1)) Found: (iif: r1-eth1, oil: pimreg, installed: (10.100.0.2,239.1.1.1))
assert "[DUT r1]: Verifying (10.100.0.2, 239.1.1.1) mroute [FAILED]!! Expected in: (iif: ['r1-eth1'], oil: none, installed: (10.100.0.2,239.1.1.1)) Found: (iif: r1-eth1, oil: pimreg, installed: (10.100.0.2,239.1.1.1))" is True

Locally I cannot make this test fail with normal timing.  Although if I place a sleep(20) in the test_pim_dense_prune_r6, the test starts failing every time locally.

This is because there still is a stream on h1 that is sending data and it is being received and state is being generated.  The test when it passes just happens to work because the upstream data structure is removed and the multicast packet that is being sent on h1 has not been sent.  So we have a small timing window where the test will pass, but otherwise fail.

The verify_mroutes function does special `things` with the pimreg device and I could not figure out a good way to make it work, nor did I want to spend more time on it, so I am just removing the test for the existence of the mroute on r1.  We know the prune worked on r3 and r2 as it should.  I think that is good enough for the moment.