### PR TITLE
bgpd: clear write fifo when disabling io writes

### DIFF
--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -58,6 +58,7 @@ void bgp_writes_on(struct peer_connection *connection)
 
 	event_add_write(fpt->master, bgp_process_writes, connection,
 			connection->fd, &connection->t_write);
+
 	SET_FLAG(connection->thread_flags, PEER_THREAD_WRITES_ON);
 }
 
@@ -65,12 +66,22 @@ void bgp_writes_off(struct peer_connection *connection)
 {
 	struct peer *peer = connection->peer;
 	struct frr_pthread *fpt = bgp_pth_io;
+	struct stream *s;
+
 	assert(fpt->running);
+
+	UNSET_FLAG(peer->connection->thread_flags, PEER_THREAD_WRITES_ON);
+
+	/* Clear out the write fifo */
+	frr_with_mutex (&connection->io_mtx) {
+		if (connection->obuf != NULL) {
+			while ((s = stream_fifo_pop(connection->obuf)) != NULL)
+				stream_free(s);
+		}
+	}
 
 	event_cancel_async(fpt->master, &connection->t_write, NULL);
 	event_cancel(&connection->t_generate_updgrp_packets);
-
-	UNSET_FLAG(peer->connection->thread_flags, PEER_THREAD_WRITES_ON);
 }
 
 void bgp_reads_on(struct peer_connection *connection)
@@ -118,15 +129,18 @@ static void bgp_process_writes(struct event *event)
 	static struct peer *peer;
 	struct peer_connection *connection = EVENT_ARG(event);
 	uint16_t status;
-	bool reschedule;
+	bool reschedule = false;
 	bool fatal = false;
+	struct frr_pthread *fpt = bgp_pth_io;
 
 	peer = connection->peer;
 
 	if (connection->fd < 0)
 		return;
 
-	struct frr_pthread *fpt = bgp_pth_io;
+	/* Anticipate rescheduling */
+	event_add_write(fpt->master, bgp_process_writes, connection, connection->fd,
+			&connection->t_write);
 
 	frr_with_mutex (&connection->io_mtx) {
 		status = bgp_write(connection);
@@ -148,12 +162,12 @@ static void bgp_process_writes(struct event *event)
 	 * to update group packet generate which will allow more routes to be
 	 * sent in the update message
 	 */
-	if (reschedule) {
-		event_add_write(fpt->master, bgp_process_writes, connection,
-				connection->fd, &connection->t_write);
-	} else if (!fatal) {
-		BGP_UPDATE_GROUP_TIMER_ON(&connection->t_generate_updgrp_packets,
-					  bgp_generate_updgrp_packets);
+	if (!reschedule) {
+		event_cancel(&connection->t_write);
+
+		if (!fatal)
+			BGP_UPDATE_GROUP_TIMER_ON(&connection->t_generate_updgrp_packets,
+						  bgp_generate_updgrp_packets);
 	}
 }
 


### PR DESCRIPTION
Clear the connection's write fifo as well as cancelling the write task. It's possible that the cancel action will race with a running callback in the io pthread. If the write event is still present, the cancel should find it. If the write callback is running before taking the io mutex, emptying the fifo should prevent it from rescheduling itself. If the write callback is running and holds the io mutex, the cancel should find and cancel the event if the io pthread reschedules it.

See the issue #20238 for some background and discussion about the details of the possible race condition.