### PR TITLE
Use underlay weights

### DIFF
--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -365,9 +365,14 @@ struct attr *bgp_path_info_mpath_attr(struct bgp_path_info *path)
  */
 enum bgp_wecmp_behavior bgp_path_info_mpath_chkwtd(struct bgp *bgp, struct bgp_path_info *path)
 {
+	enum bgp_wecmp_behavior default_val = BGP_WECMP_BEHAVIOR_NONE;
+
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_USE_RECURSIVE_WEIGHT))
+		default_val = BGP_WECMP_BEHAVIOR_USE_RECURSIVE_VALUE;
+
 	/* Check if not multipath */
 	if (!path->mpath)
-		return BGP_WECMP_BEHAVIOR_NONE;
+		return default_val;
 
 	/* If link bandwidth is to be ignored, check if we have Next-Next Hop Nodes
 	 * characteristic and do weighted ECMP based on that.
@@ -385,13 +390,13 @@ enum bgp_wecmp_behavior bgp_path_info_mpath_chkwtd(struct bgp *bgp, struct bgp_p
 		if (CHECK_FLAG(path->mpath->mp_flags, BGP_MP_LB_ALL))
 			return BGP_WECMP_BEHAVIOR_LINK_BW;
 		else
-			return BGP_WECMP_BEHAVIOR_NONE;
+			return default_val;
 	}
 
 	if (CHECK_FLAG(path->mpath->mp_flags, BGP_MP_LB_PRESENT))
 		return BGP_WECMP_BEHAVIOR_LINK_BW;
 
-	return BGP_WECMP_BEHAVIOR_NONE;
+	return default_val;
 }
 
 /*

--- a/bgpd/bgp_mpath.h
+++ b/bgpd/bgp_mpath.h
@@ -13,7 +13,8 @@
 enum bgp_wecmp_behavior {
 	BGP_WECMP_BEHAVIOR_NONE = 0,
 	BGP_WECMP_BEHAVIOR_LINK_BW = 1,
-	BGP_WECMP_BEHAVIOR_NNHN_COUNT = 2
+	BGP_WECMP_BEHAVIOR_NNHN_COUNT = 2,
+	BGP_WECMP_BEHAVIOR_USE_RECURSIVE_VALUE = 3,
 };
 
 /* Supplemental information linked to bgp_path_info for keeping track of

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2647,6 +2647,22 @@ DEFUN (no_bgp_coalesce_time,
 	return CMD_SUCCESS;
 }
 
+DEFPY (bgp_use_underlying_nexthop_weight,
+       bgp_use_underlying_nexthop_weight_cmd,
+       "[no] use-underlays-nexthop-weight",
+       NO_STR
+       "Tell Zebra when resolving a route to use the underlays nexthop weight for when nexthops are resolved\n")
+{
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+
+	if (no)
+		UNSET_FLAG(bgp->flags, BGP_WECMP_BEHAVIOR_USE_RECURSIVE_VALUE);
+	else
+		SET_FLAG(bgp->flags, BGP_FLAG_USE_RECURSIVE_WEIGHT);
+
+	return CMD_SUCCESS;
+}
+
 /* Maximum-paths configuration */
 DEFUN (bgp_maxpaths,
        bgp_maxpaths_cmd,
@@ -20601,6 +20617,9 @@ int bgp_config_write(struct vty *vty)
 		if (bgp->allow_martian)
 			vty_out(vty, " bgp allow-martian-nexthop\n");
 
+		if (CHECK_FLAG(bgp->flags, BGP_WECMP_BEHAVIOR_USE_RECURSIVE_VALUE))
+			vty_out(vty, " use-underlays-nexthop-weight\n");
+
 		if (bgp->fast_convergence)
 			vty_out(vty, " bgp fast-convergence\n");
 
@@ -21256,6 +21275,8 @@ void bgp_vty_init(void)
 
 	install_element(BGP_NODE, &bgp_coalesce_time_cmd);
 	install_element(BGP_NODE, &no_bgp_coalesce_time_cmd);
+
+	install_element(BGP_NODE, &bgp_use_underlying_nexthop_weight_cmd);
 
 	/* "maximum-paths" commands. */
 	install_element(BGP_NODE, &bgp_maxpaths_hidden_cmd);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -189,7 +189,6 @@ struct bgp_master {
 #define BM_FLAG_IPV6_NO_AUTO_RA		 (1 << 8)
 #define BM_FLAG_CONFIG_LOADED		 (1 << 9)
 
-
 #define BM_FLAG_GR_CONFIGURED (BM_FLAG_GR_RESTARTER | BM_FLAG_GR_DISABLED)
 
 	/* BGP-wide graceful restart config params */
@@ -670,6 +669,7 @@ struct bgp {
 #define BGP_FLAG_LINK_LOCAL_CAPABILITY	    (1ULL << 43)
 #define BGP_FLAG_VRF_MAY_LISTEN		    (1ULL << 44)
 #define BGP_FLAG_SOFT_VERSION_CAPABILITY_NEW (1ULL << 45)
+#define BGP_FLAG_USE_RECURSIVE_WEIGHT (1ULL << 46)
 
 	/* BGP default address-families.
 	 * New peers inherit enabled afi/safis from bgp instance.

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -4404,6 +4404,19 @@ The following are available in the ``router bgp`` mode:
    at a time in a loop. This setting controls how many iterations the loop runs
    for. As with write-quanta, it is best to leave this setting on the default.
 
+.. clicmd:: use-underlays-nexthop-weight
+
+   BGP when it installs routes has a feature that allows it to use weights
+   that are based upon community values.  This allows the nexthops using
+   those weights to be used in accordance to the operators configuration.
+   If BGP is using itself as a underlay and the underlay has weights associated
+   with them, turn on this command to tell BGP to signal to zebra when
+   installing the route that the underlays weights should be used for the
+   recursively resolved nexthops.  If this command is turned on and the
+   route already has weights associated with it, then BGP will not signal
+   to zebra that it should use the recursively resolved underlay routes
+   nexthop weights.
+
 The following command is available in ``config`` mode as well as in the
 ``router bgp`` mode:
 

--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -326,3 +326,10 @@ keyword. At present, no sharp commands will be preserved in the config.
 .. clicmd:: sharp interface IFNAME protodown
 
    Set an interface protodown.
+
+.. clicmd:: sharp use-underlays-nexthop-weight
+
+   If you are using sharpd to install routes and the underlying route
+   that the sharp route is being resolved through has nexthop weights
+   associated with it, tell the RIB to use those nexthop weights
+   when creating the nexthop group for the sharp route being installed.

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -586,6 +586,8 @@ struct zapi_route {
  */
 #define ZEBRA_FLAG_TABLEID 0x800
 
+#define ZEBRA_FLAG_USE_RECURSIVE_WEIGHT 0x1000
+
 	/* The older XXX_MESSAGE flags live here */
 	uint32_t message;
 

--- a/sharpd/sharp_globals.h
+++ b/sharpd/sharp_globals.h
@@ -59,6 +59,8 @@ struct sharp_global {
 
 	/* list of sharp_srv6_locator */
 	struct list *srv6_locators;
+
+	bool use_underlying_nexthop_group_weight;
 };
 
 extern struct sharp_global sg;

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -1653,6 +1653,20 @@ DEFPY(crashme_uaf,
 	return CMD_SUCCESS;
 }
 
+DEFPY(sharp_use_resolved_nexthop_weight,
+      sharp_use_resolved_nexthop_weight_cmd,
+      "[no] sharp use-underlays-nexthop-weight",
+      NO_STR
+      SHARP_STR
+      "Tell zebra when resolving a route to use the underlays nexthop weight for when nexthops are resolved\n")
+{
+	if (no)
+		sg.use_underlying_nexthop_group_weight = false;
+	else
+		sg.use_underlying_nexthop_group_weight = true;
+
+	return CMD_SUCCESS;
+}
 
 void sharp_vty_init(void)
 {
@@ -1696,5 +1710,7 @@ void sharp_vty_init(void)
 
 	install_element(ENABLE_NODE, &crashme_segv_cmd);
 	install_element(ENABLE_NODE, &crashme_uaf_cmd);
+
+	install_element(ENABLE_NODE, &sharp_use_resolved_nexthop_weight_cmd);
 	return;
 }

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -248,6 +248,9 @@ static bool route_add(const struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
 
 	api.flags = flags;
 
+	if (sg.use_underlying_nexthop_group_weight)
+		SET_FLAG(api.flags, ZEBRA_FLAG_USE_RECURSIVE_WEIGHT);
+
 	/* Only send via ID if nhgroup has been successfully installed */
 	if (nhgid && sharp_nhgroup_id_is_installed(nhgid)) {
 		zapi_route_set_nhg_id(&api, &nhgid);

--- a/tests/topotests/wucmp_bgp_diamond/r1/frr.conf
+++ b/tests/topotests/wucmp_bgp_diamond/r1/frr.conf
@@ -1,0 +1,53 @@
+!
+! r1 configuration - Top of the diamond
+!
+int lo
+ ip address 11.11.11.11/32
+!
+int r1-eth0
+ ip address 192.168.12.1/24
+!
+int r1-eth1
+ ip address 192.168.13.1/24
+!
+router bgp 65001
+ use-underlays-nexthop-weight
+ no bgp ebgp-requires-policy
+ bgp router-id 1.1.1.1
+ bgp bestpath as-path multipath-relax
+ neighbor 192.168.12.2 remote-as 65002
+ neighbor 192.168.12.2 timers 1 3
+ neighbor 192.168.12.2 timers connect 1
+ neighbor 192.168.13.3 remote-as 65003
+ neighbor 192.168.13.3 timers 1 3
+ neighbor 192.168.13.3 timers connect 1
+ neighbor 10.10.10.10 remote-as 65004
+ neighbor 10.10.10.10 update-source lo
+ neighbor 10.10.10.10 ebgp-multihop
+ neighbor 10.10.10.10 timers 1 3
+ neighbor 10.10.10.10 timers connect 1
+ !
+ address-family ipv4 unicast
+  redistribute connected
+  neighbor 192.168.12.2 activate
+  neighbor 192.168.12.2 route-map FILTER-OUT out
+  neighbor 192.168.13.3 activate
+  neighbor 192.168.13.3 route-map FILTER-OUT out
+  neighbor 10.10.10.10 activate
+  neighbor 10.10.10.10 route-map ONLY-10-1-1-1 in
+ exit-address-family
+!
+ip prefix-list BLOCK-10-1-1-1 deny 10.1.1.1/32
+ip prefix-list BLOCK-10-1-1-1 permit any
+!
+ip prefix-list ONLY-10-1-1-1-PREFIX permit 10.1.1.1/32
+!
+route-map FILTER-OUT permit 10
+ match ip address prefix-list BLOCK-10-1-1-1
+exit
+!
+route-map ONLY-10-1-1-1 permit 10
+ match ip address prefix-list ONLY-10-1-1-1-PREFIX
+exit
+!
+

--- a/tests/topotests/wucmp_bgp_diamond/r2/frr.conf
+++ b/tests/topotests/wucmp_bgp_diamond/r2/frr.conf
@@ -1,0 +1,27 @@
+!
+! r2 configuration - Left side of the diamond
+!
+int r2-eth0
+ ip address 192.168.12.2/24
+!
+int r2-eth1
+ ip address 192.168.24.2/24
+!
+router bgp 65002
+ no bgp ebgp-requires-policy
+ bgp router-id 2.2.2.2
+ bgp bestpath as-path multipath-relax
+ neighbor 192.168.12.1 remote-as 65001
+ neighbor 192.168.12.1 timers 1 3
+ neighbor 192.168.12.1 timers connect 1
+ neighbor 192.168.24.4 remote-as 65004
+ neighbor 192.168.24.4 timers 1 3
+ neighbor 192.168.24.4 timers connect 1
+ !
+ address-family ipv4 unicast
+  neighbor 192.168.12.1 activate
+  neighbor 192.168.12.1 send-community extended
+  neighbor 192.168.24.4 activate
+ exit-address-family
+!
+

--- a/tests/topotests/wucmp_bgp_diamond/r3/frr.conf
+++ b/tests/topotests/wucmp_bgp_diamond/r3/frr.conf
@@ -1,0 +1,27 @@
+!
+! r3 configuration - Right side of the diamond
+!
+int r3-eth0
+ ip address 192.168.13.3/24
+!
+int r3-eth1
+ ip address 192.168.34.3/24
+!
+router bgp 65003
+ no bgp ebgp-requires-policy
+ bgp router-id 3.3.3.3
+ bgp bestpath as-path multipath-relax
+ neighbor 192.168.13.1 remote-as 65001
+ neighbor 192.168.13.1 timers 1 3
+ neighbor 192.168.13.1 timers connect 1
+ neighbor 192.168.34.4 remote-as 65004
+ neighbor 192.168.34.4 timers 1 3
+ neighbor 192.168.34.4 timers connect 1
+ !
+ address-family ipv4 unicast
+  neighbor 192.168.13.1 activate
+  neighbor 192.168.13.1 send-community extended
+  neighbor 192.168.34.4 activate
+ exit-address-family
+!
+

--- a/tests/topotests/wucmp_bgp_diamond/r4/frr.conf
+++ b/tests/topotests/wucmp_bgp_diamond/r4/frr.conf
@@ -1,0 +1,74 @@
+!
+! r4 configuration - Bottom of the diamond
+!
+int lo
+ ip address 10.10.10.10/32
+ ip address 10.1.1.1/32
+!
+int r4-eth0
+ ip address 192.168.24.4/24
+!
+int r4-eth1
+ ip address 192.168.34.4/24
+!
+router bgp 65004
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ bgp router-id 4.4.4.4
+ bgp bestpath as-path multipath-relax
+ neighbor 192.168.24.2 remote-as 65002
+ neighbor 192.168.24.2 timers 1 3
+ neighbor 192.168.24.2 timers connect 1
+ neighbor 192.168.34.3 remote-as 65003
+ neighbor 192.168.34.3 timers 1 3
+ neighbor 192.168.34.3 timers connect 1
+ neighbor 11.11.11.11 remote-as 65001
+ neighbor 11.11.11.11 update-source lo
+ neighbor 11.11.11.11 ebgp-multihop
+ neighbor 11.11.11.11 timers 1 3
+ neighbor 11.11.11.11 timers connect 1
+ !
+ address-family ipv4 unicast
+  redistribute connected
+  neighbor 192.168.24.2 activate
+  neighbor 192.168.24.2 send-community extended
+  neighbor 192.168.24.2 route-map TO-R2 out
+  neighbor 192.168.34.3 activate
+  neighbor 192.168.34.3 send-community extended
+  neighbor 192.168.34.3 route-map TO-R3 out
+  neighbor 11.11.11.11 activate
+  neighbor 11.11.11.11 route-map ONLY-10-1-1-1 out
+ exit-address-family
+!
+ip prefix-list BLOCK-10-1-1-1 deny 10.1.1.1/32
+ip prefix-list BLOCK-10-1-1-1 permit 10.10.10.10/32
+ip prefix-list BLOCK-10-1-1-1 permit 192.168.24.0/24
+ip prefix-list BLOCK-10-1-1-1 permit 192.168.34.0/24
+!
+ip prefix-list ONLY-10-1-1-1-PREFIX permit 10.1.1.1/32
+!
+ip prefix-list 10-10-10-10 permit 10.10.10.10/32
+!
+route-map TO-R2 permit 10
+ match ip address prefix-list 10-10-10-10
+ set extcommunity bandwidth 1000
+exit
+!
+route-map TO-R2 permit 20
+ match ip address prefix-list BLOCK-10-1-1-1
+exit
+!
+route-map TO-R3 permit 10
+ match ip address prefix-list 10-10-10-10
+ set extcommunity bandwidth 2000
+exit
+!
+route-map TO-R3 permit 20
+ match ip address prefix-list BLOCK-10-1-1-1
+exit
+!
+route-map ONLY-10-1-1-1 permit 10
+ match ip address prefix-list ONLY-10-1-1-1-PREFIX
+exit
+!
+

--- a/tests/topotests/wucmp_bgp_diamond/test_wucmp_use_underlay.py
+++ b/tests/topotests/wucmp_bgp_diamond/test_wucmp_use_underlay.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# Copyright (c) 2025 by
+# Donald Sharp <sharpd@nvidia.com>
+#
+
+"""
+Test weighted ECMP with underlay nexthop weight in diamond topology.
+This test creates a diamond topology with eBGP between all 4 nodes (r1, r2, r3, r4).
+Each router is in a different AS:
+- r1: AS 65001
+- r2: AS 65002
+- r3: AS 65003
+- r4: AS 65004
+"""
+
+import os
+import re
+import sys
+import json
+import pytest
+import functools
+
+pytestmark = [pytest.mark.bgpd]
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.common_config import step
+
+
+def build_topo(tgen):
+    """
+    Build a diamond topology:
+          r1 (AS 65001)
+         /  \
+        r2  r3 (AS 65002/65003)
+         \  /
+          r4 (AS 65004)
+
+    All nodes have eBGP sessions with their directly connected peers.
+    """
+    # Create 4 routers
+    for routern in range(1, 5):
+        tgen.add_router(f"r{routern}")
+
+    # Create switches for the diamond connections
+    # r1-r2 link
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # r1-r3 link
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r3"])
+
+    # r2-r4 link
+    switch = tgen.add_switch("s3")
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r4"])
+
+    # r3-r4 link
+    switch = tgen.add_switch("s4")
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["r4"])
+
+
+def setup_module(mod):
+    """Setup the pytest environment."""
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for _, (rname, router) in enumerate(router_list.items(), 1):
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    """Teardown the pytest environment."""
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_convergence():
+    """Test that eBGP sessions converge in the diamond topology."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Verify eBGP convergence on all routers")
+
+    # Check r1 - should have eBGP sessions with r2, r3, and r4 (via loopback)
+    r1 = tgen.gears["r1"]
+
+    def _bgp_converge_r1():
+        output = json.loads(r1.vtysh_cmd("show bgp summary json"))
+        expected = {
+            "ipv4Unicast": {
+                "peers": {
+                    "192.168.12.2": {"state": "Established"},
+                    "192.168.13.3": {"state": "Established"},
+                    "10.10.10.10": {"state": "Established"},
+                }
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_converge_r1)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "BGP sessions on r1 did not converge"
+
+    # Check r2 - should have eBGP sessions with r1 and r4
+    r2 = tgen.gears["r2"]
+
+    def _bgp_converge_r2():
+        output = json.loads(r2.vtysh_cmd("show bgp summary json"))
+        expected = {
+            "ipv4Unicast": {
+                "peers": {
+                    "192.168.12.1": {"state": "Established"},
+                    "192.168.24.4": {"state": "Established"},
+                }
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_converge_r2)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "BGP sessions on r2 did not converge"
+
+    # Check r3 - should have eBGP sessions with r1 and r4
+    r3 = tgen.gears["r3"]
+
+    def _bgp_converge_r3():
+        output = json.loads(r3.vtysh_cmd("show bgp summary json"))
+        expected = {
+            "ipv4Unicast": {
+                "peers": {
+                    "192.168.13.1": {"state": "Established"},
+                    "192.168.34.4": {"state": "Established"},
+                }
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_converge_r3)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "BGP sessions on r3 did not converge"
+
+    # Check r4 - should have eBGP sessions with r2, r3, and r1 (via loopback)
+    r4 = tgen.gears["r4"]
+
+    def _bgp_converge_r4():
+        output = json.loads(r4.vtysh_cmd("show bgp summary json"))
+        expected = {
+            "ipv4Unicast": {
+                "peers": {
+                    "192.168.24.2": {"state": "Established"},
+                    "192.168.34.3": {"state": "Established"},
+                    "11.11.11.11": {"state": "Established"},
+                }
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_converge_r4)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "BGP sessions on r4 did not converge"
+
+
+def test_wucmp_use_underlay():
+    """
+    Test that weighted ECMP uses underlay nexthop weights properly in the diamond topology.
+
+    r4 advertises 10.10.10.10/32 with bandwidth extended communities to r2 and r3.
+    r2 and r3 propagate the route to r1 via eBGP.
+    r1 should receive the route via both r2 (192.168.12.2) and r3 (192.168.13.3).
+    The test verifies that the route has both nexthops with proper weights.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    step("Verify that r1 receives the test route from r4 via both r2 and r3")
+
+    def _check_route_weights():
+        output = json.loads(r1.vtysh_cmd("show ip route 10.10.10.10/32 json"))
+        expected = {
+            "10.10.10.10/32": [
+                {
+                    "protocol": "bgp",
+                    "selected": True,
+                    "installed": True,
+                    "nexthops": [
+                        {"ip": "192.168.12.2", "active": True, "weight": 127},
+                        {"ip": "192.168.13.3", "active": True, "weight": 255},
+                    ],
+                }
+            ]
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_check_route_weights)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, "Route 10.10.10.10/32 on r1 does not have expected nexthops"
+
+
+def test_use_of_underlay_route():
+    """
+    Test that the 10.1.1.1/32 route uses underlay nexthop weights.
+
+    r4 advertises 10.1.1.1/32 directly to r1 via loopback peering with BGP next-hop 10.10.10.10.
+    The BGP next-hop 10.10.10.10 is recursively resolved through both r2 and r3 paths,
+    which have different bandwidth extended communities (1000 vs 2000).
+    This should result in different weights (127 vs 255) for the underlay nexthops.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    step(
+        "Verify that r1's route to 10.1.1.1/32 uses underlay nexthops with proper weights"
+    )
+
+    def _check_underlay_weights():
+        output = json.loads(r1.vtysh_cmd("show ip route 10.1.1.1/32 json"))
+        expected = {
+            "10.1.1.1/32": [
+                {
+                    "protocol": "bgp",
+                    "selected": True,
+                    "installed": True,
+                    "nexthops": [
+                        {
+                            "ip": "10.10.10.10",
+                            "active": True,
+                            "recursive": True,
+                            "weight": 1,
+                        },
+                        {
+                            "ip": "192.168.12.2",
+                            "active": True,
+                            "resolver": True,
+                            "weight": 127,
+                        },
+                        {
+                            "ip": "192.168.13.3",
+                            "active": True,
+                            "resolver": True,
+                            "weight": 255,
+                        },
+                    ],
+                }
+            ]
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_check_underlay_weights)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert (
+        result is None
+    ), "Route 10.1.1.1/32 on r1 does not have expected underlay weights"
+
+
+def test_modify_bandwidth_extended_community():
+    """
+    Test that modifying the bandwidth extended community changes the underlay weights.
+
+    This test changes r4's TO-R3 route-map to set bandwidth to 10000 (instead of 2000).
+    This should cause the weight for the r3 path to remain at 255 (max), while the
+    r2 path weight should decrease to 25 due to the relative difference.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r4 = tgen.gears["r4"]
+    r1 = tgen.gears["r1"]
+
+    step("Modify r4's TO-R3 route-map to set bandwidth to 10000")
+
+    # Modify the route-map on r4
+    r4.vtysh_cmd(
+        """
+        configure terminal
+         route-map TO-R3 permit 10
+          set extcommunity bandwidth 10000
+         exit
+        exit
+        """
+    )
+
+    step("Verify that r1's route to 10.1.1.1/32 now has updated weights (25 and 255)")
+
+    def _check_updated_weights():
+        output = json.loads(r1.vtysh_cmd("show ip route 10.1.1.1/32 json"))
+        expected = {
+            "10.1.1.1/32": [
+                {
+                    "protocol": "bgp",
+                    "selected": True,
+                    "installed": True,
+                    "nexthops": [
+                        {
+                            "ip": "10.10.10.10",
+                            "active": True,
+                            "recursive": True,
+                            "weight": 1,
+                        },
+                        {
+                            "ip": "192.168.12.2",
+                            "active": True,
+                            "resolver": True,
+                            "weight": 25,
+                        },
+                        {
+                            "ip": "192.168.13.3",
+                            "active": True,
+                            "resolver": True,
+                            "weight": 255,
+                        },
+                    ],
+                }
+            ]
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_check_updated_weights)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert (
+        result is None
+    ), "Route 10.1.1.1/32 on r1 does not have expected updated weights after bandwidth change"
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Add the ability for bgp to specify via a `use-underlays-nexthop-weight` command that tells bgp to instruct zebra to use the underlays nexthop weights for this route.