### PR TITLE
ospfd: Display message when clearing interface without OSPF

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -13366,7 +13366,9 @@ DEFUN (clear_ip_ospf_interface,
 		/* Interface name is specified. */
 		ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf_id);
 		if (ifp == NULL)
-			vty_out(vty, "No such interface name\n");
+			vty_out(vty, "%% No such interface name\n");
+		else if (ospf_oi_count(ifp) == 0)
+			vty_out(vty, "%% OSPF not enabled on this interface\n");
 		else
 			ospf_interface_clear(ifp);
 	}


### PR DESCRIPTION
ospfd: Display message when clearing interface without OSPF
When attempting to clear OSPF on an interface that does not have OSPF
configured, provide user feedback instead of silently succeeding.

This commit adds a check to verify whether OSPF is enabled on the
specified interface. If no OSPF instances are found (count == 0),
the command now prints an informational message: "OSPF not enabled
on this interface".

Signed-off-by: Manpreet Kaur <manpreetk@nvidia.com>