### PR TITLE
bgpd: correction in json output structure for no data case

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3417,13 +3417,9 @@ static void evpn_show_vni(struct vty *vty, struct bgp *bgp, vni_t vni,
 		}
 	}
 
-	if (!found) {
-		if (json) {
-			vty_out(vty, "{}\n");
-		} else {
-			vty_out(vty, "VNI not found\n");
-			return;
-		}
+	if (!found && !json) {
+		vty_out(vty, "VNI not found\n");
+		return;
 	}
 }
 


### PR DESCRIPTION
Problem:

The VTYSH JSON output is not in the proper format when bgp l2vpn-evpn information is missing or not populated for a given vni-id. This results in a malformed JSON structure, which causes a parsing error.

Fix:
Corrected the JSON output structure generated during command execution to properly handle cases where no bgp l2vpn-evpn data is available for a given vni-id.

Before Fix:

```
{}
{
}
```

After Fix:

```
{
}

```