### PR TITLE
tests: Add a `show ip rip` to test_rip_del_instance

### DIFF
--- a/tests/topotests/rip_del_instance/test_rip_del_instance.py
+++ b/tests/topotests/rip_del_instance/test_rip_del_instance.py
@@ -97,6 +97,18 @@ def test_rip_del_instance(tgen):
     _, result = topotest.run_and_expect(check_if_rip_removed, True, count=30, wait=1)
     assert result, "RIP is still running"
 
+    step("Verifying 'show ip rip' returns expected error message")
+
+    def check_rip_error_message():
+        output = router.vtysh_cmd("show ip rip")
+        expected = "% RIP instance not found"
+        if expected in output:
+            return True
+        return False
+
+    _, result = topotest.run_and_expect(check_rip_error_message, True, count=15, wait=1)
+    assert result, "Expected error message not found in 'show ip rip' output"
+
 
 if __name__ == "__main__":
     args = ["-s"] + sys.argv[1:]


### PR DESCRIPTION
Add a double check that the rip instance is actually deleted in the test.

This was asked for by @ton31337 and I promised to do so.