### PR TITLE
zebra: Coverity issue (Null pointer dereference(CID 46907))

### DIFF
--- a/zebra/zebra_evpn.c
+++ b/zebra/zebra_evpn.c
@@ -932,11 +932,21 @@ void zebra_evpn_read_mac_neigh(struct zebra_evpn *zevpn, struct interface *ifp)
 	struct interface *vrr_if;
 
 	zif = ifp->info;
+	if (!zif)
+		return;
+
 	vni = zebra_vxlan_if_vni_find(zif, zevpn->vni);
 	zvrf = zebra_vrf_lookup_by_id(zevpn->vrf_id);
 	if (!zvrf || !zvrf->zns)
 		return;
 	zns = zvrf->zns;
+
+	if (!br_if) {
+		if (IS_ZEBRA_DEBUG_VXLAN)
+			zlog_debug("VNI %u - interface %s(%u) not mapped to bridge, skipping MAC/neigh read",
+				   zevpn->vni, ifp->name, ifp->ifindex);
+		return;
+	}
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
 		zlog_debug(


### PR DESCRIPTION
This commit addresses null pointer dereference in zebra/zebra_evpn.c

CID 46907: Dereference before null check (REVERSE_INULL)
check_after_deref: Null-checking br_if suggests that it may be null, but it has already been dereferenced on all paths leading to the check

Description:
Handled null check accordingly.