### PR TITLE
bgpd: Fix Coverity analysis

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6866,7 +6866,6 @@ static struct bgp_dest *clearing_dest_helper(struct bgp_table *table,
 		 *    the RD in the "outer" table, and then a second time to locate
 		 *    the closest prefix _after_ the "inner" prefix within the RD table.
 		 */
-		pfx = NULL;
 		if (inner_p && CHECK_FLAG(cinfo->flags, BGP_CLEARING_INFO_FLAG_INNER))
 			pfx = &(cinfo->inner_pfx);
 		else


### PR DESCRIPTION
This fixes coverity warning: Assigning value "NULL" to "pfx" here, but that stored value is overwritten before it can be used

Removed unnessary NULL assignement to const struct prefix *pfx

 - The line pfx = NULL; assigns NULL to the variable
 - Immediately after, the very next statement checks a condition and overwrites pfx with a different value
 - The NULL value is never actually used - it's a "dead store"