### PR TITLE
lib: add an option to disable tls log mode

### DIFF
--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -129,6 +129,7 @@ struct frr_daemon_info {
 	bool daemon_mode;
 	bool terminal;
 	bool graceful_restart;
+	bool tls_mode;
 	int gr_cleanup_time;
 	enum frr_cli_mode cli_mode;
 


### PR DESCRIPTION
It should be possible to disable Thread Local Storage of log. 
This should remain optional as per [0].
Multiple consecutive reboots can lead to an increase in the number of log files stored in /var/tmp/

[0] https://github.com/FRRouting/frr/blob/master/lib/zlog.c#L145