### PR TITLE
lib: increase the buffer size to prevent from incomplete information

### DIFF
--- a/lib/sbuf.h
+++ b/lib/sbuf.h
@@ -48,7 +48,7 @@ extern "C" {
  * the string returned in parser_log.
  */
 
-#define SBUF_DEFAULT_SIZE 8192
+#define SBUF_DEFAULT_SIZE 131072
 
 struct sbuf {
 	bool fixed;


### PR DESCRIPTION
When IS-IS handles a lot of data, the initial 8K buffer may not be enough. Propose to initialise this buffer to 128K.