### PR TITLE
zebra: Transform FreeBSD to use the dplane for route changes.

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3694,6 +3694,13 @@ int dplane_ctx_route_init_basic(struct zebra_dplane_ctx *ctx,
 	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
 
+	/* Set AFI/SAFI before checking re, as these are needed even
+	 * when creating a dplane context without a route entry (e.g. for
+	 * kernel routes).
+	 */
+	ctx->u.rinfo.zd_afi = afi;
+	ctx->u.rinfo.zd_safi = safi;
+
 	/* This function may be called to create/init a dplane context, not
 	 * necessarily to copy a route object. Let's return if there is no route
 	 * object to copy.
@@ -3723,9 +3730,6 @@ int dplane_ctx_route_init_basic(struct zebra_dplane_ctx *ctx,
 	ctx->u.rinfo.zd_tag = re->tag;
 	ctx->u.rinfo.zd_old_tag = re->tag;
 	ctx->u.rinfo.zd_distance = re->distance;
-
-	ctx->u.rinfo.zd_afi = afi;
-	ctx->u.rinfo.zd_safi = safi;
 
 	return AOK;
 }

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -5128,6 +5128,59 @@ static inline void zebra_rib_translate_ctx_from_dplane(struct zebra_dplane_ctx *
 }
 
 /*
+ * Process system route updates from the dataplane context.
+ * These are routes learned from the kernel that need to be
+ * added to or deleted from the zebra RIB.
+ */
+static void rib_process_sys_route(struct zebra_dplane_ctx *ctx)
+{
+	enum dplane_op_e op = dplane_ctx_get_op(ctx);
+	afi_t afi = dplane_ctx_get_afi(ctx);
+	vrf_id_t vrf_id = dplane_ctx_get_vrf(ctx);
+	uint32_t table = dplane_ctx_get_table(ctx);
+	int proto = dplane_ctx_get_type(ctx);
+	uint32_t flags = dplane_ctx_get_flags(ctx);
+	uint8_t distance = dplane_ctx_get_distance(ctx);
+	const struct prefix *prefix = dplane_ctx_get_dest(ctx);
+	const char *ifname = dplane_ctx_get_ifname(ctx);
+	ifindex_t ifindex = IFINDEX_INTERNAL;
+	struct nexthop_group *ng = NULL;
+	struct nexthop *nexthop;
+	struct route_entry *re = NULL;
+
+	/* Look up interface by name if specified */
+	if (ifname && ifname[0] != '\0') {
+		struct interface *ifp = if_lookup_by_name(ifname, vrf_id);
+
+		if (ifp)
+			ifindex = ifp->ifindex;
+	}
+
+	if (op == DPLANE_OP_SYS_ROUTE_ADD) {
+		/* Create route entry */
+		re = zebra_rib_route_entry_new(vrf_id, proto, 0, flags, 0, table, 0, 0, distance,
+					       0);
+
+		/* Create nexthop group and copy nexthops from context */
+		ng = nexthop_group_new();
+		copy_nexthops(&ng->nexthop, dplane_ctx_get_ng(ctx)->nexthop, NULL);
+
+		/* Resolve IFINDEX_INTERNAL placeholders if we found the interface */
+		if (ifindex > 0) {
+			for (ALL_NEXTHOPS_PTR(ng, nexthop)) {
+				if (nexthop->ifindex == IFINDEX_INTERNAL)
+					nexthop->ifindex = ifindex;
+			}
+		}
+
+		rib_add_multipath(afi, SAFI_UNICAST, (struct prefix *)prefix, NULL, re, ng, false);
+	} else if (op == DPLANE_OP_SYS_ROUTE_DELETE) {
+		rib_delete(afi, SAFI_UNICAST, vrf_id, proto, 0, flags, prefix, NULL, NULL, 0,
+			   table, 0, distance, false);
+	}
+}
+
+/*
  * Handle results from the dataplane system. Dequeue update context
  * structs, dispatch to appropriate internal handlers.
  */
@@ -5240,6 +5293,7 @@ static void rib_process_dplane_results(struct event *event)
 
 			case DPLANE_OP_SYS_ROUTE_ADD:
 			case DPLANE_OP_SYS_ROUTE_DELETE:
+				rib_process_sys_route(ctx);
 				break;
 
 			case DPLANE_OP_MAC_INSTALL:


### PR DESCRIPTION
Currently the FreeBSD dataplane code in kernel_socket.c needs to reach directly into some zebra private data structures in order to make interface based routes work.  The architecture that is being pushed for is having a separate pthread for the dplane activites and as such lookup up data structures that are owned by the master pthread in zebra is a no-go since we have absolutely no protections for X pthreads work.  Nor do we really want to add any.  Modify the kernel_socket code to parse the incoming add/delete route message and push it up into zebra
via a dplane context.   Additionally allow the creation of
interface based routes to just work.

Let's show that it works:
janelle# show ip route
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

IPv4 unicast VRF default:
K>* 0.0.0.0/0 [0/0] via 192.168.122.1, vtnet0, 00:37:42 K>* 1.1.1.1/32 [0/0] is directly connected, vtnet0, 00:37:42 K>* 1.1.1.2/32 [0/0] is directly connected, vtnet0, 00:37:42 K>* 1.1.1.3/32 [0/0] is directly connected, vtnet0, 00:37:42 K>* 1.1.1.4/32 [0/0] is directly connected, vtnet0, 00:37:42 K>* 1.1.1.5/32 [0/0] is directly connected, vtnet0, 00:37:42 K>* 1.1.1.8/32 [0/0] is directly connected, vtnet0, 00:37:42 C>* 192.168.122.0/24 is directly connected, vtnet0, weight 1, 00:37:42 L>* 192.168.122.102/32 is directly connected, vtnet0, weight 1, 00:37:42 janelle# exit
sharpd@janelle:~/frr $ netstat -rn
Routing tables

Internet:
Destination        Gateway            Flags         Netif Expire
default            192.168.122.1      UGS          vtnet0
1.1.1.1            link#1             UHS          vtnet0
1.1.1.2            link#1             UHS          vtnet0
1.1.1.3            link#1             UHS          vtnet0
1.1.1.4            link#1             UHS          vtnet0
1.1.1.5            link#1             UHS          vtnet0
1.1.1.8            link#1             UHS          vtnet0
127.0.0.1          link#2             UH              lo0
192.168.122.0/24   link#1             U            vtnet0
192.168.122.102    link#2             UHS             lo0

Now do the deletion:

sharpd@janelle:~/frr $ sudo route del 1.1.1.8/32 -iface vtnet0 del net 1.1.1.8: gateway vtnet0
sharpd@janelle:~/frr $ sudo vtysh -c "show ip route" % Can't open configuration file /usr/local/etc/frr/vtysh.conf due to 'No such file or directory'. Configuration file[/usr/local/etc/frr/frr.conf] processing failure: 11 2025/12/18 11:39:02 [H0DHT-S9KF2][EC 100663299] setsockopt_so_recvbuf: fd 3: SO_RCVBUF set to 4194304 (requested 16777216) 2025/12/18 11:39:02 [H0DHT-S9KF2][EC 100663299] setsockopt_so_recvbuf: fd 4: SO_RCVBUF set to 4194304 (requested 16777216) Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

IPv4 unicast VRF default:
K>* 0.0.0.0/0 [0/0] via 192.168.122.1, vtnet0, 00:38:48 K>* 1.1.1.1/32 [0/0] is directly connected, vtnet0, 00:38:48 K>* 1.1.1.2/32 [0/0] is directly connected, vtnet0, 00:38:48 K>* 1.1.1.3/32 [0/0] is directly connected, vtnet0, 00:38:48 K>* 1.1.1.4/32 [0/0] is directly connected, vtnet0, 00:38:48 K>* 1.1.1.5/32 [0/0] is directly connected, vtnet0, 00:38:48 C>* 192.168.122.0/24 is directly connected, vtnet0, weight 1, 00:38:48 L>* 192.168.122.102/32 is directly connected, vtnet0, weight 1, 00:38:48

This also sets the stage for the conversion of the linux route add/deletion events to be dplane contexts too.