### PR TITLE
pimd: capture pim_msg_send_frame return

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -956,7 +956,7 @@ static int pim_iface_next_vif_index(struct interface *ifp)
 }
 
 /*
-  pim_if_add_vif() uses ifindex as vif_index
+  pim_if_add_vif() uses ifindex as mroute_vif_index
 
   see also pim_if_find_vifindex_by_ifindex()
  */

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -818,9 +818,9 @@ int pim_msg_send(int fd, pim_addr src, pim_addr dst, uint8_t *pim_msg,
 		pim_pkt_dump(__func__, pim_msg, pim_msg_size);
 	}
 
-	pim_msg_send_frame(fd, (char *)buffer, sendlen, (struct sockaddr *)&to,
-			   tolen, ifp ? ifp->name : "*");
-	return 0;
+	return pim_msg_send_frame(fd, (char *)buffer, sendlen,
+				  (struct sockaddr *)&to, tolen,
+				  ifp ? ifp->name : "*");
 
 #else
 	struct iovec iovector[2];
@@ -828,9 +828,8 @@ int pim_msg_send(int fd, pim_addr src, pim_addr dst, uint8_t *pim_msg,
 	iovector[0].iov_base = pim_msg;
 	iovector[0].iov_len = pim_msg_size;
 
-	pim_msg_send_frame(src, dst, ifp ? ifp->ifindex : 0, &iovector[0], fd);
-
-	return 0;
+	return pim_msg_send_frame(src, dst, ifp ? ifp->ifindex : 0,
+				  &iovector[0], fd);
 #endif
 }
 


### PR DESCRIPTION
    pimd: capture pim_msg_send_frame return
    
    It's valuable to capture the return from
     and log the error. Otherwise, send failures will be silently ignored.
    
    Testing Done:
    pim-min, pim-smoke,
    
    Signed-off-by: Rajesh Varatharaj <rvaratharaj@nvidia.com>