### PR TITLE
ripd: Speed up convergence of rip_default_metric

### DIFF
--- a/tests/topotests/rip_default_metric/r1/frr.conf
+++ b/tests/topotests/rip_default_metric/r1/frr.conf
@@ -7,6 +7,7 @@ interface r1-eth0
 exit
 !
 router rip
+ timers basic 5 25 60
  network 10.1.1.0/24
  redistribute static
  version 2

--- a/tests/topotests/rip_default_metric/r2/frr.conf
+++ b/tests/topotests/rip_default_metric/r2/frr.conf
@@ -5,6 +5,7 @@ interface r2-eth0
 exit
 !
 router rip
+ timers basic 5 25 60
  network 10.1.1.0/24
  version 2
 exit


### PR DESCRIPTION
This test is changing the default metric and then waiting 30 seconds to ensure that the value is passed.  This is a bit problematic in that rip operates on a 30 second window before updates are sent.  Let's change the basic update operation in rip to 5 seconds and see if the test will not occassionally fail now.