### PR TITLE
bgpd: Allow LL peering to update v6 GUA

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -364,16 +364,19 @@ static int bgp_interface_address_add(ZAPI_CALLBACK_ARGS)
 				 * address, then copy the Rxed global v6 addr
 				 * into peer's v6_global and send updates out
 				 * with new nexthop addr.
+				 *
+				 * Check both conf_if (unnumbered peers) and ifname
+				 * (peers configured with "neighbor IP interface IFNAME").
+				 * Update the nexthop even if peer is not established,
+				 * so when the session comes up it uses the correct GUA.
 				 */
-				if ((peer->conf_if &&
-				     (strcmp(peer->conf_if, ifc->ifp->name) ==
-				      0)) &&
+				if ((((peer->conf_if &&
+				       (strcmp(peer->conf_if, ifc->ifp->name) == 0)) ||
+				      (peer->ifname &&
+				       (strcmp(peer->ifname, ifc->ifp->name) == 0)))) &&
 				    !IN6_IS_ADDR_LINKLOCAL(&addr->u.prefix6) &&
-				    ((IS_MAPPED_IPV6(
-					     &peer->nexthop.v6_global)) ||
-				     IN6_IS_ADDR_LINKLOCAL(
-					     &peer->nexthop.v6_global))) {
-
+				    ((IS_MAPPED_IPV6(&peer->nexthop.v6_global)) ||
+				     IN6_IS_ADDR_LINKLOCAL(&peer->nexthop.v6_global))) {
 					if (bgp_debug_zebra(ifc->address)) {
 						zlog_debug(
 							"Update peer %pBP's current intf addr %pI6 and send updates",


### PR DESCRIPTION
Currently, when a LL based peer in BGP is created:

  neighbor fe80:1::1 remote-as external
  neighbor fe80:1::1 interface r2-eth0

When the interface is updated with a v6 GUA after
peering is established.  The v6 GUA is never sent to the peer.

Current code behavior allows for bgp unnumbered peering:

  neighbor r2-eth1 remote-as external

To update it's GUA address when it comes the address is added after the peering is established.  Let's modify the code to allow the same thing to have LL based peering to do the same thing.  This should fix the occassional failure in the bgp_ipv6_ll_peering topotest.