### PR TITLE
staticd: support static route description

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -317,7 +317,7 @@ addresses but unicast addresses.
 This table is fully separate from the default unicast table. However,
 RPF lookup can include the unicast table.
 
-.. clicmd:: ip mroute PREFIX NEXTHOP [DISTANCE]
+.. clicmd:: ip mroute PREFIX NEXTHOP [DISTANCE] [description DESCRIPTION]
 
    Adds a static route entry to the Multicast RIB. This performs exactly as the
    ``ip route`` command, except that it inserts the route in the Multicast RIB

--- a/doc/user/static.rst
+++ b/doc/user/static.rst
@@ -32,16 +32,26 @@ a static prefix and gateway, with several possible forms.
 .. clicmd:: ip route NETWORK IFNAME [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
 .. clicmd:: ip route NETWORK GATEWAY IFNAME [DISTANCE] [weight WEIGHT] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK GATEWAY [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME] [description DESCRIPTION]
 
-.. clicmd:: ip route NETWORK (Null0|blackhole|reject) [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ip route NETWORK IFNAME [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME] [description DESCRIPTION]
+
+.. clicmd:: ip route NETWORK GATEWAY IFNAME [DISTANCE] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME] [description DESCRIPTION]
+
+.. clicmd:: ip route NETWORK (Null0|blackhole|reject) [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME] [description DESCRIPTION]
 
 .. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
 .. clicmd:: ipv6 route NETWORK [from SRCPREFIX] IFNAME [DISTANCE] [weight WEIGHT] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
 
 .. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY IFNAME [DISTANCE] [weight WEIGHT] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME] [description DESCRIPTION]
 
-.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] (Null0|blackhole|reject) [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME]
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] IFNAME [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME] [description DESCRIPTION]
+
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] GATEWAY IFNAME [DISTANCE] [onlink] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME] [description DESCRIPTION]
+
+.. clicmd:: ipv6 route NETWORK [from SRCPREFIX] (Null0|blackhole|reject) [DISTANCE] [table TABLENO] [nexthop-vrf VRFNAME] [vrf VRFNAME] [description DESCRIPTION]
 
    NETWORK is destination prefix with a valid v4 or v6 network based upon
    initial form of the command.
@@ -77,6 +87,9 @@ a static prefix and gateway, with several possible forms.
 
    ``nexthop-vrf`` VRFNAME allows you to create a leaked route with a nexthop in the
    specified VRFNAME. ``nexthop-vrf`` cannot be currently used with namespace based vrfs.
+
+   ``description`` DESCRIPTION allows you to set a text description (up to 80 characters) for the
+   route.
    
    The IPv6 variant allows the installation of a static source-specific route
    with the SRCPREFIX sub command.  These routes are currently supported

--- a/staticd/static_nb.c
+++ b/staticd/static_nb.c
@@ -36,6 +36,13 @@ const struct frr_yang_module_info frr_staticd_info = {
 			}
 		},
 		{
+			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/description",
+			.cbs = {
+				.modify = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_description_modify,
+				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_description_destroy,
+			}
+		},
+		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop",
 			.cbs = {
 				.apply_finish = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_apply_finish,

--- a/staticd/static_nb.h
+++ b/staticd/static_nb.h
@@ -29,6 +29,12 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	struct nb_cb_destroy_args *args);
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_tag_modify(
 	struct nb_cb_modify_args *args);
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_description_modify(
+	struct nb_cb_modify_args *args);
+void routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_description_cli_write(
+	struct vty *vty, const struct lyd_node *dnode, bool show_defaults);
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_description_destroy(
+	struct nb_cb_destroy_args *args);
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_create(
 	struct nb_cb_create_args *args);
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_destroy(
@@ -155,6 +161,8 @@ int routing_control_plane_protocols_name_validate(
 
 
 #define FRR_STATIC_ROUTE_PATH_TAG_XPATH "/tag"
+
+#define FRR_STATIC_ROUTE_PATH_DESCRIPTION_XPATH "/description"
 
 /* route-list/frr-nexthops */
 #define FRR_STATIC_ROUTE_NH_KEY_XPATH                                          \

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -788,6 +788,48 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 }
 
 /*
+ * XPath: /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/description
+ */
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_description_modify(
+	struct nb_cb_modify_args *args)
+{
+	struct static_path *pn;
+	const char *desc;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+		break;
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		pn = nb_running_get_entry(args->dnode, NULL, true);
+		desc = yang_dnode_get_string(args->dnode, NULL);
+		static_description_set(pn, desc);
+		break;
+	}
+
+	return NB_OK;
+}
+
+int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_description_destroy(
+	struct nb_cb_destroy_args *args)
+{
+	struct static_path *pn;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		pn = nb_running_get_entry(args->dnode, NULL, true);
+		static_description_unset(pn);
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
  * XPath:
  * /frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop
  */

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -163,6 +163,20 @@ struct static_path *static_add_path(struct route_node *rn, uint32_t table_id,
 	return pn;
 }
 
+void static_description_set(struct static_path *pn, const char *desc)
+{
+	if (pn->desc)
+		XFREE(MTYPE_STATIC_ROUTE, pn->desc);
+
+	if (desc)
+		pn->desc = XSTRDUP(MTYPE_STATIC_ROUTE, desc);
+}
+
+void static_description_unset(struct static_path *pn)
+{
+	XFREE(MTYPE_STATIC_ROUTE, pn->desc);
+}
+
 void static_del_path(struct static_path *pn)
 {
 	struct route_node *rn = pn->rn;
@@ -176,6 +190,9 @@ void static_del_path(struct static_path *pn)
 	frr_each_safe(static_nexthop_list, &pn->nexthop_list, nh) {
 		static_delete_nexthop(nh);
 	}
+
+	if (pn->desc)
+		static_description_unset(pn);
 
 	route_unlock_node(rn);
 

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -97,6 +97,8 @@ struct static_path {
 	route_tag_t tag;
 	/* Table-id */
 	uint32_t table_id;
+	/* Description */
+	char *desc;
 	/* Nexthop list */
 	struct static_nexthop_list_head nexthop_list;
 };
@@ -227,6 +229,8 @@ extern void static_del_route(struct route_node *rn);
 
 extern struct static_path *static_add_path(struct route_node *rn,
 					   uint32_t table_id, uint8_t distance);
+extern void static_description_set(struct static_path *pn, const char *desc);
+extern void static_description_unset(struct static_path *pn);
 extern void static_del_path(struct static_path *pn);
 
 extern bool static_add_nexthop_validate(const char *nh_vrf_name,

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -59,6 +59,7 @@ struct static_route_args {
 	const char *table;
 	const char *color;
 	const char *weight;
+	const char *desc;
 
 	bool bfd;
 	bool bfd_multi_hop;
@@ -120,6 +121,7 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 	const struct lyd_node *dnode;
 	const struct lyd_node *vrf_dnode;
 	const char *srv6_encap_behavior = "ietf-srv6-types:H.Encaps";
+	const size_t DESC_MAXLEN = 80;
 
 	if (args->xpath_vrf) {
 		vrf_dnode = yang_dnode_get(vty->candidate_config->dnode,
@@ -257,6 +259,19 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 		strlcat(ab_xpath, FRR_STATIC_ROUTE_PATH_TAG_XPATH,
 			sizeof(ab_xpath));
 		nb_cli_enqueue_change(vty, ab_xpath, NB_OP_MODIFY, buf_tag);
+
+		/* Description processing */
+		if (args->desc) {
+			if (strlen(args->desc) > DESC_MAXLEN) {
+				vty_out(vty, "%% Description too long (Max %lu characters)\n",
+					DESC_MAXLEN);
+				return CMD_WARNING;
+			}
+			strlcpy(ab_xpath, xpath_prefix, sizeof(ab_xpath));
+			strlcat(ab_xpath, FRR_STATIC_ROUTE_PATH_DESCRIPTION_XPATH,
+				sizeof(ab_xpath));
+			nb_cli_enqueue_change(vty, ab_xpath, NB_OP_MODIFY, args->desc);
+		}
 
 		/* nexthop processing */
 
@@ -516,10 +531,12 @@ static int static_route_nb_run(struct vty *vty, struct static_route_args *args)
 /* Static unicast routes for multicast RPF lookup. */
 DEFPY_YANG (ip_mroute_dist,
        ip_mroute_dist_cmd,
-       "[no] ip mroute A.B.C.D/M$prefix <A.B.C.D$gate|INTERFACE$ifname> [{"
-       "(1-255)$distance"
-       "|bfd$bfd [{multi-hop$bfd_multi_hop|source A.B.C.D$bfd_source|profile BFDPROF$bfd_profile}]"
-       "}]",
+       "[no] ip mroute A.B.C.D/M$prefix <A.B.C.D$gate|INTERFACE$ifname>  \
+	   [{ \
+       (1-255)$distance \
+       |bfd$bfd [{multi-hop$bfd_multi_hop|source A.B.C.D$bfd_source|profile BFDPROF$bfd_profile}] \
+	   |description LINE$desc_str \
+       }]",
        NO_STR
        IP_STR
        "Configure static unicast route into MRIB for multicast RPF lookup\n"
@@ -532,7 +549,9 @@ DEFPY_YANG (ip_mroute_dist,
        BFD_INTEGRATION_SOURCE_STR
        BFD_INTEGRATION_SOURCEV4_STR
        BFD_PROFILE_STR
-       BFD_PROFILE_NAME_STR)
+       BFD_PROFILE_NAME_STR
+	   "Set description for this route\n"
+	   "Description\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -546,6 +565,7 @@ DEFPY_YANG (ip_mroute_dist,
 		.bfd_multi_hop = !!bfd_multi_hop,
 		.bfd_source = bfd_source_str,
 		.bfd_profile = bfd_profile,
+		.desc = desc_str,
 	};
 
 	return static_route_nb_run(vty, &args);
@@ -562,7 +582,8 @@ DEFPY_YANG(ip_route_blackhole,
 	  |(1-255)$distance                                                   \
 	  |vrf NAME                                                           \
 	  |label WORD                                                         \
-          |table (1-4294967295)                                               \
+      |table (1-4294967295)                                               \
+	  |description LINE$desc_str                                          \
           }]",
       NO_STR IP_STR
       "Establish static routes\n"
@@ -577,7 +598,9 @@ DEFPY_YANG(ip_route_blackhole,
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
-      "The table number to configure\n")
+      "The table number to configure\n"
+	  "Set description for this route\n"
+	  "Description\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -591,6 +614,7 @@ DEFPY_YANG(ip_route_blackhole,
 		.label = label,
 		.table = table_str,
 		.vrf = vrf,
+		.desc = desc_str,
 	};
 
 	return static_route_nb_run(vty, &args);
@@ -606,6 +630,7 @@ DEFPY_YANG(ip_route_blackhole_vrf,
 	  |(1-255)$distance                                                   \
 	  |label WORD                                                         \
 	  |table (1-4294967295)                                               \
+	  |description LINE$desc_str                                          \
           }]",
       NO_STR IP_STR
       "Establish static routes\n"
@@ -619,7 +644,9 @@ DEFPY_YANG(ip_route_blackhole_vrf,
       "Distance value for this route\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
-      "The table number to configure\n")
+      "The table number to configure\n"
+	  "Set description for this route\n"
+	  "Description\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -633,6 +660,7 @@ DEFPY_YANG(ip_route_blackhole_vrf,
 		.label = label,
 		.table = table_str,
 		.xpath_vrf = true,
+		.desc = desc_str,
 	};
 
 	/*
@@ -663,6 +691,7 @@ DEFPY_YANG(ip_route_address_interface,
 	  |color (1-4294967295)                        \
 	  |bfd$bfd [{multi-hop$bfd_multi_hop|source A.B.C.D$bfd_source|profile BFDPROF$bfd_profile}] \
 	  |segments WORD [encap-behavior <H_Encaps|H_Encaps_Red>$encap_behavior] \
+	  |description LINE$desc_str                   \
           }]",
       NO_STR IP_STR
       "Establish static routes\n"
@@ -696,7 +725,9 @@ DEFPY_YANG(ip_route_address_interface,
       "SRv6 SID list\n"
 	  "Configure SRv6 encap mode\n"
 	  "H.Encaps\n"
-	  "H.Encaps.Red\n")
+	  "H.Encaps.Red\n"
+	  "Set description for this route\n"
+	  "Description\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -721,6 +752,7 @@ DEFPY_YANG(ip_route_address_interface,
 		.segs = segments,
 		.srv6_encap_behavior = encap_behavior,
 		.weight = weight_str,
+		.desc = desc_str,
 	};
 
 	return static_route_nb_run(vty, &args);
@@ -743,6 +775,7 @@ DEFPY_YANG(ip_route_address_interface_vrf,
 	  |color (1-4294967295)                        \
 	  |bfd$bfd [{multi-hop$bfd_multi_hop|source A.B.C.D$bfd_source|profile BFDPROF$bfd_profile}] \
 	  |segments WORD [encap-behavior <H_Encaps|H_Encaps_Red>$encap_behavior] \
+	  |description LINE$desc_str                   \
 	  }]",
       NO_STR IP_STR
       "Establish static routes\n"
@@ -775,7 +808,9 @@ DEFPY_YANG(ip_route_address_interface_vrf,
       "SRv6 SID list\n"
 	  "Configure SRv6 encap mode\n"
 	  "H.Encaps\n"
-	  "H.Encaps.Red\n")
+	  "H.Encaps.Red\n"
+	  "Set description for this route\n"
+	  "Description\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -800,6 +835,7 @@ DEFPY_YANG(ip_route_address_interface_vrf,
 		.segs = segments,
 		.srv6_encap_behavior = encap_behavior,
 		.weight = weight_str,
+		.desc = desc_str,
 	};
 
 	return static_route_nb_run(vty, &args);
@@ -821,6 +857,7 @@ DEFPY_YANG(ip_route,
 	  |color (1-4294967295)                            \
 	  |bfd$bfd [{multi-hop$bfd_multi_hop|source A.B.C.D$bfd_source|profile BFDPROF$bfd_profile}] \
 	  |segments WORD [encap-behavior <H_Encaps|H_Encaps_Red>$encap_behavior] \
+	  |description LINE$desc_str                       \
           }]",
       NO_STR IP_STR
       "Establish static routes\n"
@@ -853,7 +890,9 @@ DEFPY_YANG(ip_route,
       "SRv6 SID list\n"
 	  "Configure SRv6 encap mode\n"
 	  "H.Encaps\n"
-	  "H.Encaps.Red\n")
+	  "H.Encaps.Red\n"
+	  "Set description for this route\n"
+	  "Description\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -877,6 +916,7 @@ DEFPY_YANG(ip_route,
 		.segs = segments,
 		.srv6_encap_behavior = encap_behavior,
 		.weight = weight_str,
+		.desc = desc_str,
 	};
 
 	return static_route_nb_run(vty, &args);
@@ -897,6 +937,7 @@ DEFPY_YANG(ip_route_vrf,
 	  |color (1-4294967295)                            \
 	  |bfd$bfd [{multi-hop$bfd_multi_hop|source A.B.C.D$bfd_source|profile BFDPROF$bfd_profile}] \
 	  |segments WORD [encap-behavior <H_Encaps|H_Encaps_Red>$encap_behavior] \
+	  |description LINE$desc_str                       \
           }]",
       NO_STR IP_STR
       "Establish static routes\n"
@@ -928,7 +969,9 @@ DEFPY_YANG(ip_route_vrf,
       "SRv6 SID list\n"
 	  "Configure SRv6 encap mode\n"
 	  "H.Encaps\n"
-	  "H.Encaps.Red\n")
+	  "H.Encaps.Red\n"
+	  "Set description for this route\n"
+	  "Description\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -952,6 +995,7 @@ DEFPY_YANG(ip_route_vrf,
 		.segs = segments,
 		.srv6_encap_behavior = encap_behavior,
 		.weight = weight_str,
+		.desc = desc_str,
 	};
 
 	return static_route_nb_run(vty, &args);
@@ -967,6 +1011,7 @@ DEFPY_YANG(ipv6_route_blackhole,
             |vrf NAME                                      \
             |label WORD                                    \
             |table (1-4294967295)                          \
+			|description LINE$desc_str                     \
           }]",
       NO_STR
       IPV6_STR
@@ -982,7 +1027,9 @@ DEFPY_YANG(ipv6_route_blackhole,
       VRF_CMD_HELP_STR
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
-      "The table number to configure\n")
+      "The table number to configure\n"
+	  "Set description for this route\n"
+	  "Description\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -996,6 +1043,7 @@ DEFPY_YANG(ipv6_route_blackhole,
 		.label = label,
 		.table = table_str,
 		.vrf = vrf,
+		.desc = desc_str,
 	};
 
 	return static_route_nb_run(vty, &args);
@@ -1010,6 +1058,7 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
             |(1-255)$distance                              \
             |label WORD                                    \
             |table (1-4294967295)                          \
+			|description LINE$desc_str                     \
           }]",
       NO_STR
       IPV6_STR
@@ -1024,7 +1073,9 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
       "Distance value for this prefix\n"
       MPLS_LABEL_HELPSTR
       "Table to configure\n"
-      "The table number to configure\n")
+      "The table number to configure\n"
+	  "Set description for this route\n"
+	  "Description\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -1038,6 +1089,7 @@ DEFPY_YANG(ipv6_route_blackhole_vrf,
 		.label = label,
 		.table = table_str,
 		.xpath_vrf = true,
+		.desc = desc_str,
 	};
 
 	/*
@@ -1066,6 +1118,7 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
 	    |color (1-4294967295)                          \
 	    |bfd$bfd [{multi-hop$bfd_multi_hop|source X:X::X:X$bfd_source|profile BFDPROF$bfd_profile}] \
 		|segments WORD [encap-behavior <H_Encaps|H_Encaps_Red>$encap_behavior] \
+		|description LINE$desc_str                       \
           }]",
 	   NO_STR IPV6_STR
 	   "Establish static routes\n"
@@ -1091,7 +1144,9 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
 	   "Segs (SIDs)\n"
 	  "Configure SRv6 encap mode\n"
 	  "H.Encaps\n"
-	  "H.Encaps.Red\n")
+	  "H.Encaps.Red\n"
+	  "Set description for this route\n"
+	  "Description\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -1116,6 +1171,7 @@ DEFPY_YANG(ipv6_route_address_interface, ipv6_route_address_interface_cmd,
 		.segs = segments,
 		.srv6_encap_behavior = encap_behavior,
 		.weight = weight_str,
+		.desc = desc_str,
 	};
 
 	return static_route_nb_run(vty, &args);
@@ -1137,6 +1193,7 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
 	    |color (1-4294967295)                          \
 	    |bfd$bfd [{multi-hop$bfd_multi_hop|source X:X::X:X$bfd_source|profile BFDPROF$bfd_profile}] \
 		|segments WORD [encap-behavior <H_Encaps|H_Encaps_Red>$encap_behavior] \
+		|description LINE$desc_str                       \
           }]",
 	   NO_STR IPV6_STR
 	   "Establish static routes\n"
@@ -1162,7 +1219,9 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
 	   "Segs (SIDs)\n"
 	  "Configure SRv6 encap mode\n"
 	  "H.Encaps\n"
-	  "H.Encaps.Red\n")
+	  "H.Encaps.Red\n"
+	  "Set description for this route\n"
+	  "Description\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -1187,6 +1246,7 @@ DEFPY_YANG(ipv6_route_address_interface_vrf,
 		.segs = segments,
 		.srv6_encap_behavior = encap_behavior,
 		.weight = weight_str,
+		.desc = desc_str,
 	};
 
 	return static_route_nb_run(vty, &args);
@@ -1206,6 +1266,7 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
             |color (1-4294967295)                          \
 	    |bfd$bfd [{multi-hop$bfd_multi_hop|source X:X::X:X$bfd_source|profile BFDPROF$bfd_profile}] \
 			|segments WORD [encap-behavior <H_Encaps|H_Encaps_Red>$encap_behavior] \
+			|description LINE$desc_str                     \
           }]",
 	   NO_STR IPV6_STR
 	   "Establish static routes\n"
@@ -1230,7 +1291,9 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
 	   "Segs (SIDs)\n"
 	  "Configure SRv6 encap mode\n"
 	  "H.Encaps\n"
-	  "H.Encaps.Red\n")
+	  "H.Encaps.Red\n"
+	  "Set description for this route\n"
+	  "Description\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -1254,6 +1317,7 @@ DEFPY_YANG(ipv6_route, ipv6_route_cmd,
 		.segs = segments,
 		.srv6_encap_behavior = encap_behavior,
 		.weight = weight_str,
+		.desc = desc_str,
 
 	};
 
@@ -1273,6 +1337,7 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
 	    |color (1-4294967295)                          \
 	    |bfd$bfd [{multi-hop$bfd_multi_hop|source X:X::X:X$bfd_source|profile BFDPROF$bfd_profile}] \
 		|segments WORD [encap-behavior <H_Encaps|H_Encaps_Red>$encap_behavior] \
+		|description LINE$desc_str                       \
           }]",
 	   NO_STR IPV6_STR
 	   "Establish static routes\n"
@@ -1297,7 +1362,9 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
 	   "Segs (SIDs)\n"
 	  "Configure SRv6 encap mode\n"
 	  "H.Encaps\n"
-	  "H.Encaps.Red\n")
+	  "H.Encaps.Red\n"
+	  "Set description for this route\n"
+	  "Description\n")
 {
 	struct static_route_args args = {
 		.delete = !!no,
@@ -1321,6 +1388,7 @@ DEFPY_YANG(ipv6_route_vrf, ipv6_route_vrf_cmd,
 		.segs = segments,
 		.srv6_encap_behavior = encap_behavior,
 		.weight = weight_str,
+		.desc = desc_str,
 	};
 
 	return static_route_nb_run(vty, &args);
@@ -1624,6 +1692,7 @@ static void nexthop_cli_show(struct vty *vty, const struct lyd_node *route,
 	uint32_t table_id;
 	struct prefix src_prefix;
 	bool onlink;
+	const char *desc;
 
 	vrf = yang_dnode_get_string(route, "../../vrf");
 
@@ -1753,6 +1822,10 @@ static void nexthop_cli_show(struct vty *vty, const struct lyd_node *route,
 		if (yang_dnode_exists(bfd_dnode, "profile"))
 			vty_out(vty, " profile %s",
 				yang_dnode_get_string(bfd_dnode, "profile"));
+	}
+	if (yang_dnode_exists(path, "description")) {
+		desc = yang_dnode_get_string(path, "description");
+		vty_out(vty, " description %s", desc);
 	}
 
 	vty_out(vty, "\n");

--- a/tests/topotests/static_route_description/r1/frr.conf
+++ b/tests/topotests/static_route_description/r1/frr.conf
@@ -1,0 +1,5 @@
+hostname r1
+!
+ip route 1.1.1.1/32 Null0 description TEST_DESCRIPTION
+!
+exit

--- a/tests/topotests/static_route_description/test_static_route_description.py
+++ b/tests/topotests/static_route_description/test_static_route_description.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 eval: (blacken-mode 1) -*-
+# SPDX-License-Identifier: ISC
+#
+# test_static_route_description.py:
+# Static Route Description Test
+#
+# Copyright (c) 2025 by Dustin Rosarius
+#
+
+r"""
+test_static_route_description.py: Test to verify that static route description command works correctly.
+"""
+
+import os
+import sys
+import pytest
+import functools
+
+# Import topogen and required test moduless
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter
+from lib.common_config import step
+
+pytestmark = [pytest.mark.staticd]
+
+
+def build_topo(tgen):
+    """Build the topology for Static Route decription test."""
+
+    # Create router
+    r1 = tgen.add_router("r1")
+
+
+@pytest.fixture(scope="module")
+def tgen(request):
+    "Setup/Teardown the environment and provide tgen argument to tests"
+
+    tgen = Topogen(build_topo, request.module.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    # For all routers arrange for:
+    # - starting zebra using config file from <rtrname>/zebra.conf
+    # - starting ripd using an empty config file.
+    # - loading frr config file from <rtrname>/frr.conf
+    for rname, router in router_list.items():
+        router.load_config(TopoRouter.RD_ZEBRA)
+        router.load_config(TopoRouter.RD_STATIC)
+        router.load_config(TopoRouter.RD_MGMTD)
+        router.load_frr_config(os.path.join(CWD, f"{rname}/frr.conf"))
+
+    # Start and configure the router daemons
+    tgen.start_router()
+
+    # Provide tgen as argument to each test function
+    yield tgen
+
+    # Teardown after last test runs
+    tgen.stop_topology()
+
+
+# ===================
+# The tests functions
+# ===================
+
+
+def test_static_route_description(tgen):
+
+    r1 = tgen.gears["r1"]
+
+    def _check_config(pattern, command, should_exist=True):
+
+        output = r1.vtysh_cmd(command)
+        found = pattern in output
+
+        if should_exist and found:
+            return None
+        if not should_exist and not found:
+            return None
+
+        return "'{}' {} (Expected: {})".format(
+            pattern,
+            "found" if found else "NOT found",
+            "Found" if should_exist else "Not Found",
+        )
+
+    step(
+        "Test static route description command: Verify r1 has 'ip route 1.1.1.1/32 Null0' with description"
+        "'TEST_DESCRIPTION' in running-config"
+    )
+
+    expected = "ip route 1.1.1.1/32 Null0 description TEST_DESCRIPTION"
+    command = "show running-config"
+    test_func = functools.partial(_check_config, expected, command)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    assert result is None, result
+
+    step(
+        "Test update static route description: Verify r1 static route 'ip route 1.1.1.1/32 Null0' has an updated description of "
+        "'NEW_DESCRIPTION' in running-config"
+    )
+    r1.vtysh_cmd(
+        """
+                     configure terminal
+                     ip route 1.1.1.1/32 Null0 description NEW_DESCRIPTION
+                     exit
+                """
+    )
+
+    expected = "ip route 1.1.1.1/32 Null0 description NEW_DESCRIPTION"
+    command = "show running-config"
+    test_func = functools.partial(_check_config, expected, command)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    assert result is None, result
+
+    step(
+        "Test delete static route: Verify r1 static route 'ip route 1.1.1.1/32 Null0 description NEW_DESCRIPTION' has been removed from running-config"
+    )
+    r1.vtysh_cmd(
+        """
+                     configure terminal
+                     no ip route 1.1.1.1/32 Null0 description NEW_DESCRIPTION
+                     exit
+                """
+    )
+
+    expected = "ip route 1.1.1.1/32 Null0 description NEW_DESCRIPTION"
+    command = "show running-config"
+    test_func = functools.partial(_check_config, expected, command, False)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+
+    assert result is None, result
+
+    step(
+        "Test static route with a too long description: Verify r1 will display an error message and the static route will not be in running-config"
+    )
+    command = """
+                     configure terminal
+                     ip route 1.1.1.1/32 Null0 description aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+                     exit
+                """
+
+    expected = "% Description too long (Max 80 characters)"
+    test_func = functools.partial(_check_config, expected, command)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, result
+
+    expected = "ip route 1.1.1.1/32 Null0"
+    command = "show running-config"
+    test_func = functools.partial(_check_config, expected, command, False)
+    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+    assert result is None, result
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-staticd.yang
+++ b/yang/frr-staticd.yang
@@ -107,6 +107,16 @@ module frr-staticd {
           "Route tag";
       }
 
+      leaf description {
+        type string {
+          length "1..80" {
+            error-message "The description must be between 1 and 80 characters long";
+          }
+        }
+        description
+          "Static route description.";
+      }
+
       uses frr-nexthop:frr-nexthop;
     }
   }


### PR DESCRIPTION
This PR adds the ability to put descriptions (up to 80 chars long) on static routes (ip route, ipv6 route, and ip mroute). 
Summary of changes:

YANG: Added a description leaf to the frr-staticd.yang model. 

CLI:  Updated ip route, ipv6 route, and ip mroute commands to accept the description keyword

Northbound: added modify and destroy callbacks

docs: updated staticd.rst and pim.rst to include description parameter

tests: added test cases to test creation, modifying, deleting, and error handling for strings >80 characters.

Ex:
```
ip mroute 1.1.1.1/32 eth0 description MROUTE_DESCRIPTION
ip route 1.1.1.1/32 Null0 description IP_DESCRIPTION
ipv6 route 2001:db8::/64 2001:db8::1 description IPV6_DESCRIPTION
```

related: #20203 

