### PR TITLE
zebra: don't access ifp from dplane pthread (backport to 10.5)

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -4496,7 +4496,6 @@ ssize_t netlink_macfdb_update_ctx(struct zebra_dplane_ctx *ctx, void *data,
 static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 {
 	struct ndmsg *ndm;
-	struct interface *ifp;
 	struct rtattr *tb[NDA_MAX + 1];
 	struct ethaddr mac;
 	struct ipaddr ip;
@@ -4517,19 +4516,13 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 
 	ndm = NLMSG_DATA(h);
 
-	/* The interface should exist. */
-	ifp = if_lookup_by_index_per_ns(zebra_ns_lookup(ns_id), ndm->ndm_ifindex);
-	if (!ifp || !ifp->info)
-		return 0;
-
 	/* Parse attributes and extract fields of interest. */
 	netlink_parse_rtattr(tb, NDA_MAX, NDA_RTA(ndm), len);
 
 	if (!tb[NDA_DST]) {
-		zlog_debug("%s family %s IF %s(%u) vrf %s(%u) - no DST",
+		zlog_debug("%s family %s IF %u NSID %u - no DST",
 			   nl_msg_type_to_str(h->nlmsg_type),
-			   nl_family_to_str(ndm->ndm_family), ifp->name,
-			   ndm->ndm_ifindex, ifp->vrf->name, ifp->vrf->vrf_id);
+			   nl_family_to_str(ndm->ndm_family), ndm->ndm_ifindex, ns_id);
 		return 0;
 	}
 
@@ -4587,14 +4580,12 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 			if (RTA_PAYLOAD(tb[NDA_LLADDR]) != ETH_ALEN) {
 				if (IS_ZEBRA_DEBUG_KERNEL)
 					zlog_debug(
-						"%s family %s IF %s(%u) vrf %s(%u) - LLADDR is not MAC, len %lu",
+						"%s family %s IF %u NSID %u - LLADDR is not MAC, len %lu",
 						nl_msg_type_to_str(
 							h->nlmsg_type),
 						nl_family_to_str(
 							ndm->ndm_family),
-						ifp->name, ndm->ndm_ifindex,
-						ifp->vrf->name,
-						ifp->vrf->vrf_id,
+						ndm->ndm_ifindex, ns_id,
 						(unsigned long)RTA_PAYLOAD(
 							tb[NDA_LLADDR]));
 
@@ -4622,16 +4613,12 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 		dplane_ctx_neigh_set_dp_static(ctx, dp_static);
 
 		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug(
-				"Rx %s family %s IF %s(%u) vrf %s(%u) IP %pIA MAC %s state 0x%x flags 0x%x ext_flags 0x%x",
-				nl_msg_type_to_str(h->nlmsg_type),
-				nl_family_to_str(ndm->ndm_family), ifp->name,
-				ndm->ndm_ifindex, ifp->vrf->name,
-				ifp->vrf->vrf_id, &ip,
-				mac_present
-					? prefix_mac2str(&mac, buf, sizeof(buf))
-					: "",
-				ndm->ndm_state, ndm->ndm_flags, ext_flags);
+			zlog_debug("Rx %s family %s IF %u NSID %u IP %pIA MAC %s state 0x%x flags 0x%x ext_flags 0x%x",
+				   nl_msg_type_to_str(h->nlmsg_type),
+				   nl_family_to_str(ndm->ndm_family), ndm->ndm_ifindex,
+				   ns_id, &ip,
+				   mac_present ? prefix_mac2str(&mac, buf, sizeof(buf)) : "",
+				   ndm->ndm_state, ndm->ndm_flags, ext_flags);
 
 		if (ndm->ndm_state & NUD_VALID) {
 			if (zebra_evpn_mh_do_adv_reachable_neigh_only())


### PR DESCRIPTION
The function that handles incoming IPNEIGH netlink messages runs in the dplane pthread - it can't look up vrfs or ifps.

This is a backport of pull request https://github.com/FRRouting/frr/pull/20289
