### PR TITLE
zebra: Add counter for ND router solicitations received

### DIFF
--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -134,6 +134,7 @@ struct zebra_if {
 
 	struct rtadvconf rtadv;
 	unsigned int ra_sent, ra_rcvd;
+	unsigned int rs_rcvd;
 
 #ifdef HAVE_STRUCT_SOCKADDR_DL
 	union {

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -670,6 +670,12 @@ static void rtadv_timer(struct event *event)
 		}
 }
 
+static void rtsolicit_increment_received(struct zebra_if *zif)
+{
+	if (zif)
+		zif->rs_rcvd++;
+}
+
 static void rtadv_process_solicit(struct interface *ifp)
 {
 	struct zebra_vrf *zvrf;
@@ -679,6 +685,7 @@ static void rtadv_process_solicit(struct interface *ifp)
 	assert(zvrf);
 	zif = ifp->info;
 
+	rtsolicit_increment_received(zif);
 	/*
 	 * If FastRetransmit is enabled, send the RA immediately.
 	 * If not enabled but it has been more than MIN_DELAY_BETWEEN_RAS
@@ -1870,6 +1877,7 @@ static int nd_dump_vty(struct vty *vty, json_object *json_if, struct interface *
 			rtadv->AdvRetransTimer);
 		vty_out(vty, "  ND advertised hop-count limit is %d hops\n",
 			rtadv->AdvCurHopLimit);
+		vty_out(vty, "  ND router solicit rcvd: %d\n", zif->rs_rcvd);
 		vty_out(vty, "  ND router advertisements sent: %d rcvd: %d\n",
 			zif->ra_sent, zif->ra_rcvd);
 		interval = rtadv->MaxRtrAdvInterval;
@@ -1925,6 +1933,7 @@ static int nd_dump_vty(struct vty *vty, json_object *json_if, struct interface *
 		json_object_int_add(json_if, "ndAdvertisedRetransmitIntervalMsecs",
 				    rtadv->AdvRetransTimer);
 		json_object_int_add(json_if, "ndAdvertisedHopCountLimitHops", rtadv->AdvCurHopLimit);
+		json_object_int_add(json_if, "ndRouterSolicitsRcvd", zif->rs_rcvd);
 		json_object_int_add(json_if, "ndRouterAdvertisementsSent", zif->ra_sent);
 		json_object_int_add(json_if, "ndRouterAdvertisementsRcvd", zif->ra_rcvd);
 


### PR DESCRIPTION
Add a counter to track the number of IPv6 ND Router Solicitation
messages received on each interface. Display this counter output for
"show interface <inf name> [json]" command.

Testing:
on r2 do 
root@r2:/tmp/topotests/high_ecmp.test_high_ecmp_unnumbered/r2# sysctl -w net.ipv6.conf.r2-eth199.accept_ra=2
root@r2:/tmp/topotests/high_ecmp.test_high_ecmp_unnumbered/r2# ip link set r2-eth199 down
root@r2:/tmp/topotests/high_ecmp.test_high_ecmp_unnumbered/r2# ip link set r2-eth199 up

r1# show interface r1-eth199
Interface r1-eth199 is up, line protocol is up
  Link ups:       2    last: 2025/12/23 16:35:14.83
  Link downs:     4    last: 2025/12/23 16:35:14.83
  vrf: default
  index 201 metric 0 mtu 1500 speed 10000 txqlen 1000
  flags: <UP,LOWER_UP,BROADCAST,RUNNING,MULTICAST>
  MPLS  Not specified by CLI
  Ignore all v4 routes with linkdown
  Ignore all v6 routes with linkdown
  Multicast config is Not specified by CLI
  Shutdown config is Disabled by CLI
  BGP has configured RA
  Type: Ethernet
  HWaddr: ca:db:0f:90:46:14
  inet 10.1.200.1/30
  inet6 2001:db8:1:200::1/64
  inet6 fe80::c8db:fff:fe90:4614/64
  Interface Type VETH
  Interface Slave Type None
  protodown: off 
  Parent ifindex: 600
  ND advertised reachable time is 0 milliseconds
  ND advertised retransmit interval is 0 milliseconds
  ND advertised hop-count limit is 64 hops
  ND router solicit rcvd: 2
  ND router advertisements sent: 234 rcvd: 234
  ND router advertisements are sent every 10 seconds
  ND router advertisements lifetime tracks ra-interval
  ND router advertisement default router preference is medium
  Hosts use stateless autoconfig for addresses.
  Neighbor address(s):
  inet6 fe80::101c:beff:fe10:d167/128

r1# show interface r1-eth199 json 
{
  "r1-eth199":{
    "administrativeStatus":"up",
    "operationalStatus":"up",
    "linkDetection":true,
    "linkUps":2,
    "linkDowns":4,
    "lastLinkUp":"2025/12/23 16:35:14.83",
    "lastLinkDown":"2025/12/23 16:35:14.83",
    "vrfName":"default",
    "mplsEnabled":false,
    "linkDown":true,
    "linkDownV6":true,
    "mcForwardingV4":false,
    "mcForwardingV6":false,
    "bgpRAConfigured":true,
    "multicastConfig":"Not specified by CLI",
    "shutdownConfig":"Disabled by CLI",
    "mplsConfig":"Not specified by CLI",
    "speedChecked":3,
    "pseudoInterface":false,
    "index":201,
    "metric":0,
    "mtu":1500,
    "speed":10000,
    "txqlen":1000,
    "flags":"<UP,LOWER_UP,BROADCAST,RUNNING,MULTICAST>",
    "type":"Ethernet",
    "hardwareAddress":"ca:db:0f:90:46:14",
 "ipAddresses":[
      {
        "address":"10.1.200.1/30",
        "secondary":false,
        "noPrefixRoute":false,
        "unnumbered":false
      },
      {
        "address":"2001:db8:1:200::1/64",
        "secondary":false,
        "noPrefixRoute":false,
        "unnumbered":false
      },
      {
        "address":"fe80::c8db:fff:fe90:4614/64",
        "secondary":false,
        "noPrefixRoute":false,
        "unnumbered":false
      }
    ],
    "interfaceType":"VETH",
    "interfaceSlaveType":"None",
    "lacpBypass":false,
    "evpnMh":{
    },
    "protodown":"off",
    "parentIfindex":600,
    "ndAdvertisedReachableTimeMsecs":0,
    "ndAdvertisedRetransmitIntervalMsecs":0,
    "ndAdvertisedHopCountLimitHops":64,
    "ndRouterSolicitsRcvd":2,
    "ndRouterAdvertisementsSent":192,
    "ndRouterAdvertisementsRcvd":192,
    "ndRouterAdvertisementsIntervalSecs":10,
    "ndRouterAdvertisementsDoNotUseFastRetransmit":false,
    "ndRouterAdvertisementsLifetimeTracksRaInterval":true,
    "ndRouterAdvertisementDefaultRouterPreference":"medium",
    "hostsUseStatelessAutoconfigForAddresses":true,
    "neighborIpAddresses":[
      "fe80::101c:beff:fe10:d167/128"
    ]
  }
}
 Signed-off-by: Vijayalaxmi Basavaraj <vbasavaraj@nvidia.com>