### PR TITLE
zebra: make nd ra prefix cmd idompotent

### DIFF
--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -1293,7 +1293,7 @@ static struct rtadv_prefix *rtadv_prefix_set(struct zebra_if *zif,
 	if (rp->AdvPrefixCreate == PREFIX_SRC_MANUAL) {
 		if (rprefix->AdvPrefixCreate == PREFIX_SRC_AUTO)
 			rprefix->AdvPrefixCreate = PREFIX_SRC_BOTH;
-		else
+		else if (rprefix->AdvPrefixCreate != PREFIX_SRC_BOTH)
 			rprefix->AdvPrefixCreate = PREFIX_SRC_MANUAL;
 
 		rprefix->AdvAutonomousFlag = rp->AdvAutonomousFlag;
@@ -1304,7 +1304,7 @@ static struct rtadv_prefix *rtadv_prefix_set(struct zebra_if *zif,
 	} else if (rp->AdvPrefixCreate == PREFIX_SRC_AUTO) {
 		if (rprefix->AdvPrefixCreate == PREFIX_SRC_MANUAL)
 			rprefix->AdvPrefixCreate = PREFIX_SRC_BOTH;
-		else {
+		else if (rprefix->AdvPrefixCreate != PREFIX_SRC_BOTH) {
 			rprefix->AdvPrefixCreate = PREFIX_SRC_AUTO;
 			rtadv_prefix_set_defaults(rprefix);
 		}
@@ -1333,7 +1333,8 @@ static void rtadv_prefix_reset(struct zebra_if *zif, struct rtadv_prefix *rp,
 				rprefix->AdvPrefixCreate = PREFIX_SRC_AUTO;
 				rtadv_prefix_set_defaults(rprefix);
 				return;
-			}
+			} else if (rprefix->AdvPrefixCreate == PREFIX_SRC_AUTO)
+				return;
 		} else if (rp->AdvPrefixCreate == PREFIX_SRC_AUTO) {
 			if (rprefix->AdvPrefixCreate == PREFIX_SRC_BOTH) {
 				rprefix->AdvPrefixCreate = PREFIX_SRC_MANUAL;


### PR DESCRIPTION
Ticket: #4205223
Testing:
root@r1:mgmt:~# nv unset interface swp3 ip neighbor-discovery prefix 2001:fffe:01::/64 Tcpdump:
05:45:58.892659 IP6 (flowlabel 0x72074, hlim 255, next-header ICMPv6 (58) payload length: 216) fe80::202:ff:fe00:b > ip6-allnodes: [icmp6 sum ok] ICMP6, router advertisement, length 216
	hop limit 64, Flags [none], pref medium, router lifetime 30s, reachable time 0ms, retrans timer 0ms
	  prefix info option (3), length 32 (4): 1234::/64, Flags [onlink, auto], valid time 2592000s, pref. time 604800s
	    0x0000:  40c0 0027 8d00 0009 3a80 0000 0000 1234
	    0x0010:  0000 0000 0000 0000 0000 0000 0000
	  prefix info option (3), length 32 (4): 2001:cccc:1::/64, Flags [onlink, auto], valid time 2592000s, pref. time 604800s
	    0x0000:  40c0 0027 8d00 0009 3a80 0000 0000 2001
	    0x0010:  cccc 0001 0000 0000 0000 0000 0000
	  prefix info option (3), length 32 (4): 2001:dddd:1::/64, Flags [onlink, auto], valid time 2592000s, pref. time 604800s
	    0x0000:  40c0 0027 8d00 0009 3a80 0000 0000 2001
	    0x0010:  dddd 0001 0000 0000 0000 0000 0000
	  prefix info option (3), length 32 (4): 2001:eeee:1::/64, Flags [onlink, auto], valid time 2592000s, pref. time 604800s
	    0x0000:  40c0 0027 8d00 0009 3a80 0000 0000 2001
	    0x0010:  eeee 0001 0000 0000 0000 0000 0000
	  prefix info option (3), length 32 (4): 2001:fffe:1::/64, Flags [onlink, auto], valid time 2592000s, pref. time 604800s
	    0x0000:  40c0 0027 8d00 0009 3a80 0000 0000 2001
	    0x0010:  fffe 0001 0000 0000 0000 0000 0000
	  prefix info option (3), length 32 (4): 2001:ffff:1::/64, Flags [onlink, auto], valid time 2592000s, pref. time 604800s
	    0x0000:  40c0 0027 8d00 0009 3a80 0000 0000 2001
	    0x0010:  ffff 0001 0000 0000 0000 0000 0000
	  source link-address option (1), length 8 (1): 00:02:00:00:00:0b

Signed-off-by: Vijayalaxmi Basavaraj <vbasavaraj@nvidia.com>