### PR TITLE
bfd: fix RFC 5880 compliance violations in packet reception

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -192,12 +192,18 @@ struct bfd_echo_pkt {
 			SET_FLAG(flags, (CHECK_FLAG(val, 0x3) << 6));          \
 	}
 #define BFD_GETSTATE(flags) (CHECK_FLAG((flags >> 6), 0x3))
-#define BFD_SETCBIT(flags, val)                                                \
-	{                                                                      \
-		if ((val))                                                     \
-			SET_FLAG(flags, val);                                  \
+#define BFD_SETCBIT(flags, val)                                                                   \
+	{                                                                                         \
+		if ((val))                                                                        \
+			SET_FLAG(flags, BFD_CBIT);                                                \
 	}
 #define BFD_GETCBIT(flags) (CHECK_FLAG(flags, BFD_CBIT))
+#define BFD_SETABIT(flags, val)                                                                   \
+	{                                                                                         \
+		if ((val))                                                                        \
+			SET_FLAG(flags, BFD_ABIT);                                                \
+	}
+#define BFD_GETABIT(flags) (CHECK_FLAG(flags, BFD_ABIT))
 #define BFD_ECHO_VERSION 1
 #define BFD_ECHO_PKT_LEN sizeof(struct bfd_echo_pkt)
 


### PR DESCRIPTION
Fixes in this commit:
1. RFC violation on session reset.
2. RFC violation on checking of cp->len.
3. RFC violation on the timing of updating remote discriminator.

For 1, the previous logic in `bfd_recv_cb` incorrectly discarded all packets  with `Your Discriminator` set to 0 if the local session state was `UP` or `INIT`. This violated RFC 5880 Section 6.8.6, which requires accepting such packets (specifically when State is DOWN) to handle remote peer restarts. This discrepancy may cause "zombie sessions" where the local side remained UP ignoring the peer's reset signal.

The original check was introduced with the intention to prevent session aliasing, which caused session state flapping. However, the check was too broad.

This patch replaces the state-based check with a more strict address-based check:
- Removed the conditions of `bfd->ses_state !=` which would block legitimate resets.
- Added `match_ip_address` to verify that if a zero-discriminator packet arrives for an UP session. its destination address matches the session's bound local address.
- Added the check required by the RFC 5880 that if a zero remote discriminator packet arrives with a state that is not DOWN or ADMIN_DOWN, the packet should be dropped.

This allows legitimate peer resets (correct destination) to proceed while dropping aliased packets that causes vibration.

For 2, this is a relatively minor one and potentially nitpicking. But RFC 5880 requires that the parser should check `cp->len < 26` if A bit is set, so I include it.

For 3, the patch delays the update of remote discriminator to after `bfd_check_auth` returns success. This is required by the RFC. Updating remote discriminator before auth check would incorrectly update local state even when authentication fails, which can be harmful.

This patch also modifies `bfd.h` to add a new pair of marco that get and set A bit. It also changes the implementation of `BFD_SETCBIT` to align with other marco's way of implementation.