### PR TITLE
Bgp explicit connection direction

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -43,7 +43,7 @@ static void bgp_bfd_strict_holdtime_expire(struct event *event)
 
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%pBP BFD Strict mode Hold timer expire for %s", peer,
-			   bgp_peer_get_connection_direction(connection));
+			   bgp_peer_get_connection_direction_string(connection));
 
 	peer_set_last_reset(peer, PEER_DOWN_BFD_DOWN);
 	SET_FLAG(peer->sflags, PEER_STATUS_BFD_STRICT_HOLD_TIME_EXPIRED);

--- a/bgpd/bgp_conditional_adv.c
+++ b/bgpd/bgp_conditional_adv.c
@@ -194,7 +194,7 @@ static void bgp_conditional_adv_timer(struct event *t)
 	 * based on condition(exist-map or non-exist map)
 	 */
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-		if (!CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE))
+		if (!peer_is_config_node(peer))
 			continue;
 
 		if (!peer_established(peer->connection))

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -135,7 +135,7 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 	keeper = from_peer->connection;
 	peer = from_peer->doppelganger;
 
-	if (!peer || !CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE))
+	if (!peer || !peer_is_config_node(peer))
 		return from_peer;
 
 	/*
@@ -1273,8 +1273,7 @@ static bool bgp_gr_check_all_eors(struct bgp *bgp, afi_t afi, safi_t safi)
 				   peer->host,
 				   lookup_msg(bgp_status_msg, peer->connection->status, NULL),
 				   peer->flags, peer->af_sflags[afi][safi]);
-		if (!CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE) ||
-		    CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN) ||
+		if (!peer_is_config_node(peer) || CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN) ||
 		    !CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART))
 			continue;
 
@@ -1830,8 +1829,7 @@ enum bgp_fsm_state_progress bgp_stop(struct peer_connection *connection)
 
 	peer->update_time = 0;
 
-	if (!CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE)
-	    && !(CHECK_FLAG(peer->flags, PEER_FLAG_DELETE))) {
+	if (!peer_is_config_node(peer) && !(CHECK_FLAG(peer->flags, PEER_FLAG_DELETE))) {
 		peer_delete(peer);
 		ret = BGP_FSM_FAILURE_AND_DELETE;
 	} else {

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -487,7 +487,7 @@ static void bgp_start_timer(struct event *event)
 	frrtrace(2, frr_bgp, session_state_change, peer, 1);
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [FSM] Timer (start timer expire for %s).", peer->host,
-			   bgp_peer_get_connection_direction(connection));
+			   bgp_peer_get_connection_direction_string(connection));
 
 	EVENT_VAL(event) = BGP_Start;
 	bgp_event(event); /* bgp_event unlocks peer */
@@ -508,7 +508,7 @@ static void bgp_connect_timer(struct event *event)
 	frrtrace(2, frr_bgp, session_state_change, peer, 2);
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [FSM] Timer (connect timer (%us) expire for %s)", peer->host,
-			   peer->v_connect, bgp_peer_get_connection_direction(connection));
+			   peer->v_connect, bgp_peer_get_connection_direction_string(connection));
 
 	if (CHECK_FLAG(peer->sflags, PEER_STATUS_ACCEPT_PEER))
 		bgp_stop(connection);
@@ -530,7 +530,7 @@ static void bgp_holdtime_timer(struct event *event)
 	frrtrace(2, frr_bgp, session_state_change, peer, 3);
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [FSM] Timer (holdtime timer expire for %s)", peer->host,
-			   bgp_peer_get_connection_direction(connection));
+			   bgp_peer_get_connection_direction_string(connection));
 
 	/*
 	 * Given that we do not have any expectation of ordering
@@ -563,7 +563,7 @@ void bgp_routeadv_timer(struct event *event)
 	frrtrace(2, frr_bgp, session_state_change, peer, 4);
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [FSM] Timer (routeadv timer expire for %s)", peer->host,
-			   bgp_peer_get_connection_direction(connection));
+			   bgp_peer_get_connection_direction_string(connection));
 
 	peer->synctime = monotime(NULL);
 
@@ -584,7 +584,7 @@ void bgp_delayopen_timer(struct event *event)
 	frrtrace(2, frr_bgp, session_state_change, peer, 5);
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [FSM] Timer (DelayOpentimer expire for %s)", peer->host,
-			   bgp_peer_get_connection_direction(connection));
+			   bgp_peer_get_connection_direction_string(connection));
 
 	EVENT_VAL(event) = DelayOpen_timer_expired;
 	bgp_event(event); /* bgp_event unlocks peer */
@@ -659,7 +659,8 @@ static void bgp_graceful_restart_timer_off(struct peer_connection *connection,
 	    !(CHECK_FLAG(peer->flags, PEER_FLAG_DELETE))) {
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%s (dynamic neighbor) deleted (%s) for %s", __func__,
-				   peer->host, bgp_peer_get_connection_direction(connection));
+				   peer->host,
+				   bgp_peer_get_connection_direction_string(connection));
 		peer_delete(peer);
 	}
 
@@ -686,7 +687,7 @@ static void bgp_llgr_stale_timer_expire(struct event *event)
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%pBP Long-lived stale timer (%s) expired for %s", peer,
 			   get_afi_safi_str(afi, safi, false),
-			   bgp_peer_get_connection_direction(peer->connection));
+			   bgp_peer_get_connection_direction_string(peer->connection));
 
 	UNSET_FLAG(peer->af_sflags[afi][safi], PEER_STATUS_LLGR_WAIT);
 
@@ -784,7 +785,7 @@ static void bgp_graceful_restart_timer_expire(struct event *event)
 
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%pBP graceful restart timer expired and graceful restart stalepath timer stopped for %s",
-			   peer, bgp_peer_get_connection_direction(connection));
+			   peer, bgp_peer_get_connection_direction_string(connection));
 
 	FOREACH_AFI_SAFI (afi, safi) {
 		if (!peer->nsf[afi][safi])
@@ -811,7 +812,7 @@ static void bgp_graceful_restart_timer_expire(struct event *event)
 				zlog_debug("%pBP Long-lived stale timer (%s) started for %d sec for %s",
 					   peer, get_afi_safi_str(afi, safi, false),
 					   peer->llgr[afi][safi].stale_time,
-					   bgp_peer_get_connection_direction(connection));
+					   bgp_peer_get_connection_direction_string(connection));
 
 			SET_FLAG(peer->af_sflags[afi][safi],
 				 PEER_STATUS_LLGR_WAIT);
@@ -843,7 +844,7 @@ static void bgp_graceful_stale_timer_expire(struct event *event)
 
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%pBP graceful restart stalepath timer expired for %s", peer,
-			   bgp_peer_get_connection_direction(connection));
+			   bgp_peer_get_connection_direction_string(connection));
 
 	/* NSF delete stale route */
 	FOREACH_AFI_SAFI_NSF (afi, safi)
@@ -1534,7 +1535,7 @@ void bgp_fsm_change_status(struct peer_connection *connection,
 		zlog_debug("%s : vrf %s(%u), Status: %s established_peers %u for %s", __func__,
 			   vrf ? vrf->name : "Unknown", bgp->vrf_id,
 			   lookup_msg(bgp_status_msg, status, NULL), bgp->established_peers,
-			   bgp_peer_get_connection_direction(connection));
+			   bgp_peer_get_connection_direction_string(connection));
 	}
 
 	/* Set to router ID to the value provided by RIB if there are no peers
@@ -1618,7 +1619,7 @@ void bgp_fsm_change_status(struct peer_connection *connection,
 		zlog_debug("%s fd %d went from %s to %s for %s", peer->host, connection->fd,
 			   lookup_msg(bgp_status_msg, connection->ostatus, NULL),
 			   lookup_msg(bgp_status_msg, connection->status, NULL),
-			   bgp_peer_get_connection_direction(connection));
+			   bgp_peer_get_connection_direction_string(connection));
 }
 
 /* Flush the event queue and ensure the peer is shut down */
@@ -1650,7 +1651,8 @@ enum bgp_fsm_state_progress bgp_stop(struct peer_connection *connection)
 	    !(CHECK_FLAG(peer->flags, PEER_FLAG_DELETE))) {
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%s (dynamic neighbor) deleted (%s) for %s", __func__,
-				   peer->host, bgp_peer_get_connection_direction(connection));
+				   peer->host,
+				   bgp_peer_get_connection_direction_string(connection));
 		peer_delete(peer);
 		return BGP_FSM_FAILURE_AND_DELETE;
 	}
@@ -1694,16 +1696,17 @@ enum bgp_fsm_state_progress bgp_stop(struct peer_connection *connection)
 			event_cancel(&connection->t_gr_stale);
 			if (bgp_debug_neighbor_events(peer))
 				zlog_debug("%pBP graceful restart stalepath timer stopped for %s",
-					   peer, bgp_peer_get_connection_direction(connection));
+					   peer,
+					   bgp_peer_get_connection_direction_string(connection));
 		}
 		if (CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_WAIT)) {
 			if (bgp_debug_neighbor_events(peer)) {
 				zlog_debug("%pBP graceful restart timer started for %d sec for %s",
 					   peer, peer->v_gr_restart,
-					   bgp_peer_get_connection_direction(connection));
+					   bgp_peer_get_connection_direction_string(connection));
 				zlog_debug("%pBP graceful restart stalepath timer started for %d sec for %s",
 					   peer, bgp->stalepath_time,
-					   bgp_peer_get_connection_direction(connection));
+					   bgp_peer_get_connection_direction_string(connection));
 			}
 			BGP_TIMER_ON(connection->t_gr_restart,
 				     bgp_graceful_restart_timer_expire,
@@ -1723,7 +1726,8 @@ enum bgp_fsm_state_progress bgp_stop(struct peer_connection *connection)
 
 			if (bgp_debug_neighbor_events(peer))
 				zlog_debug("%pBP route-refresh restart stalepath timer stopped for %s",
-					   peer, bgp_peer_get_connection_direction(connection));
+					   peer,
+					   bgp_peer_get_connection_direction_string(connection));
 		}
 
 		/* set last reset time */
@@ -1731,7 +1735,7 @@ enum bgp_fsm_state_progress bgp_stop(struct peer_connection *connection)
 
 		if (BGP_DEBUG(update_groups, UPDATE_GROUPS))
 			zlog_debug("%s remove from all update group for %s", peer->host,
-				   bgp_peer_get_connection_direction(connection));
+				   bgp_peer_get_connection_direction_string(connection));
 		update_group_remove_peer_afs(peer);
 
 		/* Reset peer synctime */
@@ -1857,7 +1861,8 @@ bgp_stop_with_error(struct peer_connection *connection)
 	if (peer_dynamic_neighbor_no_nsf(peer)) {
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%s (dynamic neighbor) deleted (%s) for %s", __func__,
-				   peer->host, bgp_peer_get_connection_direction(connection));
+				   peer->host,
+				   bgp_peer_get_connection_direction_string(connection));
 		peer_delete(peer);
 		return BGP_FSM_FAILURE;
 	}
@@ -1879,7 +1884,8 @@ bgp_stop_with_notify(struct peer_connection *connection, uint8_t code,
 	if (peer_dynamic_neighbor_no_nsf(peer)) {
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%s (dynamic neighbor) deleted (%s) for %s", __func__,
-				   peer->host, bgp_peer_get_connection_direction(connection));
+				   peer->host,
+				   bgp_peer_get_connection_direction_string(connection));
 		peer_delete(peer);
 		return BGP_FSM_FAILURE;
 	}
@@ -1944,9 +1950,9 @@ static void bgp_connect_check(struct event *event)
 		return;
 	} else {
 		if (bgp_debug_neighbor_events(peer))
-			zlog_debug("%s [Event] Connect failed %d(%s) for connection %s", peer->host,
-				   status, safe_strerror(status),
-				   bgp_peer_get_connection_direction(connection));
+			zlog_debug("%s [Event] Connect failed %d(%s) for connection %s",
+				   peer->host, status, safe_strerror(status),
+				   bgp_peer_get_connection_direction_string(connection));
 		BGP_EVENT_ADD(connection, TCP_connection_open_failed);
 		return;
 	}
@@ -1987,10 +1993,10 @@ bgp_connect_success(struct peer_connection *connection)
 		if (!CHECK_FLAG(peer->sflags, PEER_STATUS_ACCEPT_PEER))
 			zlog_debug("%s open active, local address %pSU for %s", peer->host,
 				   connection->su_local,
-				   bgp_peer_get_connection_direction(connection));
+				   bgp_peer_get_connection_direction_string(connection));
 		else
 			zlog_debug("%s passive open for %s", peer->host,
-				   bgp_peer_get_connection_direction(connection));
+				   bgp_peer_get_connection_direction_string(connection));
 	}
 
 	/* Send an open message */
@@ -2035,10 +2041,10 @@ bgp_connect_success_w_delayopen(struct peer_connection *connection)
 		if (!CHECK_FLAG(peer->sflags, PEER_STATUS_ACCEPT_PEER))
 			zlog_debug("%s open active, local address %pSU for %s", peer->host,
 				   connection->su_local,
-				   bgp_peer_get_connection_direction(connection));
+				   bgp_peer_get_connection_direction_string(connection));
 		else
 			zlog_debug("%s passive open for %s", peer->host,
-				   bgp_peer_get_connection_direction(connection));
+				   bgp_peer_get_connection_direction_string(connection));
 	}
 
 	/* set the DelayOpenTime to the inital value */
@@ -2053,7 +2059,7 @@ bgp_connect_success_w_delayopen(struct peer_connection *connection)
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [FSM] BGP OPEN message delayed for %d seconds for connection %s",
 			   peer->host, peer->delayopen,
-			   bgp_peer_get_connection_direction(connection));
+			   bgp_peer_get_connection_direction_string(connection));
 
 	return BGP_FSM_SUCCESS;
 }
@@ -2067,7 +2073,8 @@ bgp_connect_fail(struct peer_connection *connection)
 	if (peer_dynamic_neighbor_no_nsf(peer)) {
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%s (dynamic neighbor) deleted (%s) for %s", __func__,
-				   peer->host, bgp_peer_get_connection_direction(connection));
+				   peer->host,
+				   bgp_peer_get_connection_direction_string(connection));
 		peer_delete(peer);
 		return BGP_FSM_FAILURE_AND_DELETE;
 	}
@@ -2114,7 +2121,8 @@ static enum bgp_fsm_state_progress bgp_start(struct peer_connection *connection)
 		frrtrace(2, frr_bgp, session_state_change, peer, 7);
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%s [FSM] Unable to get neighbor's IP address, waiting... for %s",
-				   peer->host, bgp_peer_get_connection_direction(connection));
+				   peer->host,
+				   bgp_peer_get_connection_direction_string(connection));
 		peer_set_last_reset(peer, PEER_DOWN_NBR_ADDR);
 		return BGP_FSM_FAILURE;
 	}
@@ -2173,7 +2181,7 @@ static enum bgp_fsm_state_progress bgp_start(struct peer_connection *connection)
 			if (bgp_debug_neighbor_events(peer))
 				zlog_debug("%s [FSM] Waiting for NHT, no path to neighbor present for %s",
 					   peer->host,
-					   bgp_peer_get_connection_direction(connection));
+					   bgp_peer_get_connection_direction_string(connection));
 			peer_set_last_reset(peer, PEER_DOWN_WAITING_NHT);
 			BGP_EVENT_ADD(connection, TCP_connection_open_failed);
 			return BGP_FSM_SUCCESS;
@@ -2191,13 +2199,14 @@ static enum bgp_fsm_state_progress bgp_start(struct peer_connection *connection)
 	case connect_error:
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%s [FSM] Connect error for %s", peer->host,
-				   bgp_peer_get_connection_direction(connection));
+				   bgp_peer_get_connection_direction_string(connection));
 		BGP_EVENT_ADD(connection, TCP_connection_open_failed);
 		break;
 	case connect_success:
 		if (bgp_debug_neighbor_events(peer))
-			zlog_debug("%s [FSM] Connect immediately success, fd %d for %s", peer->host,
-				   connection->fd, bgp_peer_get_connection_direction(connection));
+			zlog_debug("%s [FSM] Connect immediately success, fd %d for %s",
+				   peer->host, connection->fd,
+				   bgp_peer_get_connection_direction_string(connection));
 
 		BGP_EVENT_ADD(connection, TCP_connection_open);
 		break;
@@ -2207,7 +2216,7 @@ static enum bgp_fsm_state_progress bgp_start(struct peer_connection *connection)
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%s [FSM] Non blocking connect waiting result, fd %d for %s",
 				   peer->host, connection->fd,
-				   bgp_peer_get_connection_direction(connection));
+				   bgp_peer_get_connection_direction_string(connection));
 		if (connection->fd < 0) {
 			flog_err(EC_BGP_FSM, "%s peer's fd is negative value %d",
 				 __func__, peer->connection->fd);
@@ -2289,7 +2298,7 @@ bgp_fsm_holdtime_expire(struct peer_connection *connection)
 	frrtrace(2, frr_bgp, session_state_change, peer, 9);
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s [FSM] Hold timer expire for %s", peer->host,
-			   bgp_peer_get_connection_direction(connection));
+			   bgp_peer_get_connection_direction_string(connection));
 
 	/* RFC8538 updates RFC 4724 by defining an extension that permits
 	 * the Graceful Restart procedures to be performed when the BGP
@@ -2489,7 +2498,7 @@ bgp_establish(struct peer_connection *connection)
 			if (bgp_debug_neighbor_events(peer))
 				zlog_debug("%pBP Long-lived stale timer stopped for afi/safi: %d/%d for %s",
 					   peer, afi, safi,
-					   bgp_peer_get_connection_direction(connection));
+					   bgp_peer_get_connection_direction_string(connection));
 		}
 
 		if (CHECK_FLAG(peer->af_cap[afi][safi],
@@ -2530,8 +2539,10 @@ bgp_establish(struct peer_connection *connection)
 	if (peer->doppelganger &&
 	    (peer->doppelganger->connection->status != Deleted)) {
 		if (bgp_debug_neighbor_events(peer))
-			zlog_debug("[Event] Deleting stub connection for peer %s for %s", peer->host,
-				   bgp_peer_get_connection_direction(peer->doppelganger->connection));
+			zlog_debug("[Event] Deleting stub connection for peer %s for %s",
+				   peer->host,
+				   bgp_peer_get_connection_direction_string(
+					   peer->doppelganger->connection));
 
 		if (peer->doppelganger->connection->status > Active)
 			bgp_notify_send(peer->doppelganger->connection,
@@ -2579,7 +2590,7 @@ static enum bgp_fsm_state_progress bgp_ignore(struct peer_connection *connection
 
 	flog_err(EC_BGP_FSM,
 		 "%s(%s) [FSM] Ignoring event %s in state %s, prior events %s, %s, fd %d",
-		 peer->host, bgp_peer_get_connection_direction(connection),
+		 peer->host, bgp_peer_get_connection_direction_string(connection),
 		 bgp_event_str[peer->cur_event],
 		 lookup_msg(bgp_status_msg, connection->status, NULL),
 		 bgp_event_str[peer->last_event], bgp_event_str[peer->last_major_event],
@@ -2595,7 +2606,7 @@ bgp_fsm_exception(struct peer_connection *connection)
 
 	flog_err(EC_BGP_FSM,
 		 "%s(%s) [FSM] Unexpected event %s in state %s, prior events %s, %s, fd %d",
-		 peer->host, bgp_peer_get_connection_direction(connection),
+		 peer->host, bgp_peer_get_connection_direction_string(connection),
 		 bgp_event_str[peer->cur_event],
 		 lookup_msg(bgp_status_msg, connection->status, NULL),
 		 bgp_event_str[peer->last_event], bgp_event_str[peer->last_major_event],
@@ -2848,7 +2859,7 @@ int bgp_event_update(struct peer_connection *connection,
 		zlog_debug("%s [FSM] %s (%s->%s), fd %d for %s", peer->host, bgp_event_str[event],
 			   lookup_msg(bgp_status_msg, connection->status, NULL),
 			   lookup_msg(bgp_status_msg, next, NULL), connection->fd,
-			   bgp_peer_get_connection_direction(connection));
+			   bgp_peer_get_connection_direction_string(connection));
 
 	peer->last_event = peer->cur_event;
 	peer->cur_event = event;

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1591,6 +1591,9 @@ void bgp_fsm_change_status(struct peer_connection *connection,
 	/* Save event that caused status change. */
 	peer->last_major_event = peer->cur_event;
 
+	if (status == Established)
+		connection->dir = ESTABLISHED;
+
 	/* Operations after status change */
 	hook_call(peer_status_changed, peer);
 

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1598,9 +1598,6 @@ void bgp_fsm_change_status(struct peer_connection *connection,
 	/* Operations after status change */
 	hook_call(peer_status_changed, peer);
 
-	if (status == Established)
-		UNSET_FLAG(peer->sflags, PEER_STATUS_ACCEPT_PEER);
-
 	/* If max-med processing is applicable, do the necessary. */
 	if (status == Established) {
 		if (bgp_maxmed_onstartup_configured(bgp) && bgp_maxmed_onstartup_applicable(bgp))

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -685,7 +685,6 @@ static void bgp_accept(struct event *event)
 	bgp_fsm_change_status(incoming, Active);
 	event_cancel(&incoming->t_start); /* created in peer_create() */
 
-	SET_FLAG(doppelganger->sflags, PEER_STATUS_ACCEPT_PEER);
 	/* Make dummy peer until read Open packet. */
 	if (peer_established(connection) && CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_MODE)) {
 		/* If we have an existing established connection with graceful

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -501,7 +501,7 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop, afi_
 		 * When we come back around we'll fix up this
 		 * data properly in replace_nexthop_by_peer
 		 */
-		if (CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE))
+		if (peer_is_config_node(peer))
 			bnc->nht_info = (void *)peer; /* NHT peer reference */
 	}
 

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -4087,7 +4087,8 @@ void bgp_process_packet(struct event *event)
 			if (mprc == BGP_Stop)
 				flog_err(EC_BGP_PKT_OPEN,
 					 "%s: BGP OPEN receipt failed for peer: %s(%s)", __func__,
-					 peer->host, bgp_peer_get_connection_direction(connection));
+					 peer->host,
+					 bgp_peer_get_connection_direction_string(connection));
 			break;
 		case BGP_MSG_UPDATE:
 			frrtrace(2, frr_bgp, update_process, peer, size);
@@ -4099,7 +4100,7 @@ void bgp_process_packet(struct event *event)
 				flog_err(EC_BGP_UPDATE_RCV,
 					 "%s: BGP UPDATE receipt failed for peer: %s(%s)",
 					 __func__, peer->host,
-					 bgp_peer_get_connection_direction(connection));
+					 bgp_peer_get_connection_direction_string(connection));
 			break;
 		case BGP_MSG_NOTIFY:
 			frrtrace(2, frr_bgp, notification_process, peer, size);
@@ -4110,7 +4111,7 @@ void bgp_process_packet(struct event *event)
 				flog_err(EC_BGP_NOTIFY_RCV,
 					 "%s: BGP NOTIFY receipt failed for peer: %s(%s)",
 					 __func__, peer->host,
-					 bgp_peer_get_connection_direction(connection));
+					 bgp_peer_get_connection_direction_string(connection));
 			break;
 		case BGP_MSG_KEEPALIVE:
 			frrtrace(2, frr_bgp, keepalive_process, peer, size);
@@ -4122,7 +4123,7 @@ void bgp_process_packet(struct event *event)
 				flog_err(EC_BGP_KEEP_RCV,
 					 "%s: BGP KEEPALIVE receipt failed for peer: %s(%s)",
 					 __func__, peer->host,
-					 bgp_peer_get_connection_direction(connection));
+					 bgp_peer_get_connection_direction_string(connection));
 			break;
 		case BGP_MSG_ROUTE_REFRESH_NEW:
 		case BGP_MSG_ROUTE_REFRESH_OLD:
@@ -4134,7 +4135,7 @@ void bgp_process_packet(struct event *event)
 				flog_err(EC_BGP_RFSH_RCV,
 					 "%s: BGP ROUTEREFRESH receipt failed for peer: %s(%s)",
 					 __func__, peer->host,
-					 bgp_peer_get_connection_direction(connection));
+					 bgp_peer_get_connection_direction_string(connection));
 			break;
 		case BGP_MSG_CAPABILITY:
 			frrtrace(2, frr_bgp, capability_process, peer, size);
@@ -4145,7 +4146,7 @@ void bgp_process_packet(struct event *event)
 				flog_err(EC_BGP_CAP_RCV,
 					 "%s: BGP CAPABILITY receipt failed for peer: %s(%s)",
 					 __func__, peer->host,
-					 bgp_peer_get_connection_direction(connection));
+					 bgp_peer_get_connection_direction_string(connection));
 			break;
 		default:
 			/* Suppress uninitialized variable warning */

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1672,7 +1672,7 @@ static int bgp_collision_detect(struct peer_connection *connection,
 	if (ntohl(peer->local_id.s_addr) < ntohl(remote_id.s_addr)
 	    || (ntohl(peer->local_id.s_addr) == ntohl(remote_id.s_addr)
 		&& peer->local_as < peer->as))
-		if (!CHECK_FLAG(peer->sflags, PEER_STATUS_ACCEPT_PEER)) {
+		if (bgp_peer_get_connection_direction(peer->connection) != CONNECTION_INCOMING) {
 			/*
 			 * 2. If the value of the local BGP
 			 * Identifier is less than the remote one,
@@ -1707,7 +1707,7 @@ static int bgp_collision_detect(struct peer_connection *connection,
 		 * the existing one (the one that is already in the
 		 * OpenConfirm state).
 		 */
-		if (CHECK_FLAG(peer->sflags, PEER_STATUS_ACCEPT_PEER)) {
+		if (bgp_peer_get_connection_direction(peer->connection) == CONNECTION_INCOMING) {
 			bgp_notify_send(other, BGP_NOTIFY_CEASE,
 					BGP_NOTIFY_CEASE_COLLISION_RESOLUTION);
 			return 1;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2197,7 +2197,7 @@ void bgp_notify_conditional_adv_scanner(struct update_subgroup *subgrp)
 	if (!ADVERTISE_MAP_NAME(filter))
 		return;
 
-	if (!CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE))
+	if (!peer_is_config_node(peer))
 		return;
 
 	peer->advmap_table_change = true;

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -2032,7 +2032,7 @@ void update_group_adjust_peer(struct peer_af *paf)
 		return;
 	}
 
-	if (!CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE)) {
+	if (!peer_is_config_node(peer)) {
 		return;
 	}
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -11983,7 +11983,7 @@ static inline void calc_peers_cfgd_estbd(struct bgp *bgp, int *peers_cfgd,
 
 	*peers_cfgd = *peers_estbd = 0;
 	for (ALL_LIST_ELEMENTS_RO(bgp->peer, node, peer)) {
-		if (!CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE))
+		if (!peer_is_config_node(peer))
 			continue;
 		(*peers_cfgd)++;
 		if (peer_established(peer->connection))
@@ -12798,7 +12798,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 				continue;
 			}
 
-			if (!CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE))
+			if (!peer_is_config_node(peer))
 				continue;
 
 			if (peer->afc[afi][safi]) {
@@ -12824,7 +12824,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 				continue;
 			}
 
-			if (!CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE))
+			if (!peer_is_config_node(peer))
 				continue;
 
 			if (peer->afc[afi][safi]) {
@@ -12882,7 +12882,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 	filtered_count = 0;
 	dn_count = 0;
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-		if (!CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE))
+		if (!peer_is_config_node(peer))
 			continue;
 
 		if (!peer->afc[afi][safi])
@@ -16858,7 +16858,7 @@ static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp, enum show_type ty
 	}
 
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-		if (!CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE))
+		if (!peer_is_config_node(peer))
 			continue;
 
 		switch (type) {
@@ -20057,9 +20057,8 @@ static void bgp_config_write_family(struct vty *vty, struct bgp *bgp, afi_t afi,
 				       PEER_FLAG_CONFIG_DAMPENING))
 			bgp_config_write_peer_damp(vty, group->conf, afi, safi);
 	for (ALL_LIST_ELEMENTS_RO(bgp->peer, node, peer))
-		if (CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE) &&
-		    peer_af_flag_check(peer, afi, safi,
-				       PEER_FLAG_CONFIG_DAMPENING))
+		if (peer_is_config_node(peer) &&
+		    peer_af_flag_check(peer, afi, safi, PEER_FLAG_CONFIG_DAMPENING))
 			bgp_config_write_peer_damp(vty, peer, afi, safi);
 
 	for (ALL_LIST_ELEMENTS(bgp->group, node, nnode, group))
@@ -20067,7 +20066,7 @@ static void bgp_config_write_family(struct vty *vty, struct bgp *bgp, afi_t afi,
 
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
 		/* Do not display doppelganger peers */
-		if (CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE))
+		if (peer_is_config_node(peer))
 			bgp_config_write_peer_af(vty, bgp, peer, afi, safi);
 	}
 
@@ -20602,7 +20601,7 @@ int bgp_config_write(struct vty *vty)
 
 		/* Normal neighbor configuration. */
 		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-			if (CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE))
+			if (peer_is_config_node(peer))
 				bgp_config_write_peer_global(vty, bgp, peer);
 		}
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2870,7 +2870,6 @@ int peer_delete(struct peer *peer)
 		peer->doppelganger = NULL;
 	}
 
-	UNSET_FLAG(peer->sflags, PEER_STATUS_ACCEPT_PEER);
 	bgp_fsm_change_status(peer->connection, Deleted);
 
 	/* Remove from NHT */

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2795,7 +2795,7 @@ int peer_delete(struct peer *peer)
 		zlog_debug("%s: peer %pBP", __func__, peer);
 
 	bgp = peer->bgp;
-	accept_peer = CHECK_FLAG(peer->sflags, PEER_STATUS_ACCEPT_PEER);
+	accept_peer = !peer_is_config_node(peer);
 
 	bgp_soft_reconfig_table_task_cancel(bgp, NULL, peer);
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1221,7 +1221,7 @@ void bgp_peer_connection_free(struct peer_connection **connection)
 	connection = NULL;
 }
 
-const char *bgp_peer_get_connection_direction(struct peer_connection *connection)
+const char *bgp_peer_get_connection_direction_string(const struct peer_connection *connection)
 {
 	switch (connection->dir) {
 	case UNKNOWN:

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1816,7 +1816,6 @@ struct peer {
 
 	/* Peer status flags. */
 	uint16_t sflags;
-#define PEER_STATUS_ACCEPT_PEER	      (1U << 0) /* accept peer */
 #define PEER_STATUS_PREFIX_OVERFLOW   (1U << 1) /* prefix-overflow */
 #define PEER_STATUS_CAPABILITY_OPEN   (1U << 2) /* capability open send */
 #define PEER_STATUS_HAVE_ACCEPT       (1U << 3) /* accept peer's parent */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -3001,6 +3001,11 @@ static inline bool peer_dynamic_neighbor_no_nsf(struct peer *peer)
 		!CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_WAIT));
 }
 
+static inline bool peer_is_config_node(const struct peer *peer)
+{
+	return !!CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE);
+}
+
 static inline int peer_cap_enhe(struct peer *peer, afi_t afi, safi_t safi)
 {
 	assert(peer);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1427,7 +1427,7 @@ struct peer_connection {
 /* Declare the FIFO list implementation */
 DECLARE_LIST(peer_connection_fifo, struct peer_connection, fifo_item);
 
-const char *bgp_peer_get_connection_direction(struct peer_connection *connection);
+const char *bgp_peer_get_connection_direction_string(const struct peer_connection *connection);
 extern struct peer_connection *bgp_peer_connection_new(struct peer *peer, const union sockunion *su,
 						       enum connection_direction dir);
 extern void bgp_peer_connection_free(struct peer_connection **connection);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1818,7 +1818,6 @@ struct peer {
 	uint16_t sflags;
 #define PEER_STATUS_PREFIX_OVERFLOW   (1U << 1) /* prefix-overflow */
 #define PEER_STATUS_CAPABILITY_OPEN   (1U << 2) /* capability open send */
-#define PEER_STATUS_HAVE_ACCEPT       (1U << 3) /* accept peer's parent */
 #define PEER_STATUS_GROUP             (1U << 4) /* peer-group conf */
 #define PEER_STATUS_NSF_MODE          (1U << 5) /* NSF aware peer */
 #define PEER_STATUS_NSF_WAIT          (1U << 6) /* wait comeback peer */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1427,6 +1427,12 @@ struct peer_connection {
 /* Declare the FIFO list implementation */
 DECLARE_LIST(peer_connection_fifo, struct peer_connection, fifo_item);
 
+static inline enum connection_direction
+bgp_peer_get_connection_direction(const struct peer_connection *connection)
+{
+	return connection->dir;
+}
+
 const char *bgp_peer_get_connection_direction_string(const struct peer_connection *connection);
 extern struct peer_connection *bgp_peer_connection_new(struct peer *peer, const union sockunion *su,
 						       enum connection_direction dir);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1816,14 +1816,14 @@ struct peer {
 
 	/* Peer status flags. */
 	uint16_t sflags;
-#define PEER_STATUS_PREFIX_OVERFLOW   (1U << 1) /* prefix-overflow */
-#define PEER_STATUS_CAPABILITY_OPEN   (1U << 2) /* capability open send */
-#define PEER_STATUS_GROUP             (1U << 4) /* peer-group conf */
-#define PEER_STATUS_NSF_MODE          (1U << 5) /* NSF aware peer */
-#define PEER_STATUS_NSF_WAIT          (1U << 6) /* wait comeback peer */
+#define PEER_STATUS_PREFIX_OVERFLOW   (1U << 0) /* prefix-overflow */
+#define PEER_STATUS_CAPABILITY_OPEN   (1U << 1) /* capability open send */
+#define PEER_STATUS_GROUP             (1U << 2) /* peer-group conf */
+#define PEER_STATUS_NSF_MODE          (1U << 3) /* NSF aware peer */
+#define PEER_STATUS_NSF_WAIT          (1U << 4) /* wait comeback peer */
 /* received extended format encoding for OPEN message */
-#define PEER_STATUS_EXT_OPT_PARAMS_LENGTH (1U << 7)
-#define PEER_STATUS_BFD_STRICT_HOLD_TIME_EXPIRED (1U << 8) /* BFD strict hold time expired */
+#define PEER_STATUS_EXT_OPT_PARAMS_LENGTH	 (1U << 5)
+#define PEER_STATUS_BFD_STRICT_HOLD_TIME_EXPIRED (1U << 6) /* BFD strict hold time expired */
 
 	/* Peer status af flags (reset in bgp_stop) */
 	uint16_t af_sflags[AFI_MAX][SAFI_MAX];


### PR DESCRIPTION
The bgp code is using a flag `PEER_STATUS_ACCEPT_PEER` that is placed on the peer->sflags bit field.  From my perspective this code is being used to figure out if a connection is incoming or not.  But it's poorly named and not really used in a way that I caught on to it being used until yesterday in this way.  This check to see the direction of a connection is a `struct peer_connection` decision not a peer level decision.  Let's use the connection->dir that is already there and create a accessor function that returns the direction then use that explicitly in the code base to clarify the questions being asked.   Then let's remove the above flag and another one that was found to not even be used and renumber the bit field positions in the defines.