### PR TITLE
bgpd: update source address for bgp neighbor

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1995,6 +1995,9 @@ bgp_connect_success(struct peer_connection *connection)
 	/* Send an open message */
 	bgp_open_send(connection);
 
+	if (peer->bfd_config)
+		bgp_peer_bfd_update_source(peer);
+
 	return BGP_FSM_SUCCESS;
 }
 
@@ -2053,6 +2056,9 @@ bgp_connect_success_w_delayopen(struct peer_connection *connection)
 		zlog_debug("%s [FSM] BGP OPEN message delayed for %d seconds for connection %s",
 			   peer->host, peer->delayopen,
 			   bgp_peer_get_connection_direction(connection));
+
+	if (peer->bfd_config)
+		bgp_peer_bfd_update_source(peer);
 
 	return BGP_FSM_SUCCESS;
 }


### PR DESCRIPTION
The two bgp ipv6 neighbors: A and B, A is with "neighbor B bfd" and B is with "neighbor A bfd strict mode".

Ater bgp neighbor is established, then delete and add the global address (2001::75/64) on A, BFD of A will always use "fe80::x" as source address forever:

```
2025/12/24 01:50:52 BFD: [SSYGJ-9ZAE0] zclient: add local address 2001::75/64 (VRF 6)
2025/12/24 01:50:52 BGP: [HFMHR-E3VMR] Rx Intf address add VRF vrf1 IF enp1s0 addr 2001::75/64
2025/12/24 01:50:52 BGP: [WJWH8-SHS78] bgp_peer_bfd_update_source: address [2001::75->3001::77] to [fe80::2e53:4aff:fe00:677->3001::77]
2025/12/24 01:50:52 BGP: [TT430-NZ800] zclient_bfd_command: multi hop is configured, not sending interface
```

The reason is currently A doesn't update BFD source until bgp neighbor is established.                                                                        
But B uses BFD's strict mode, doesn't response A's OPEN message until BFD is UP,                                                                              It is dead lock for A and B.  So the bgp neighbor between A and B will not be                                                                                 
established and BFD is keeping in DOWN status because A is with "fe80::x" as source address.                                                                                                                                                                                                                                
So updating the source address not only when the bgp neighbor is established,                                                                                 but also when the tcp connection is established.