### PR TITLE
bgpd: Optimize BGP path lookup using typesafe hash for efficient lookup

### DIFF
--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -11,6 +11,7 @@
 #include "hook.h"
 #include "queue.h"
 #include "nexthop.h"
+#include "typesafe.h"
 #include "bgp_table.h"
 #include "bgp_addpath_types.h"
 #include "bgp_rpki.h"
@@ -274,6 +275,9 @@ struct bgp_path_info {
 	/* For linked list. */
 	struct bgp_path_info *next;
 	struct bgp_path_info *prev;
+
+	/* Hash linkage for pi_hash in bgp_table */
+	struct bgp_pi_hash_item pi_hash_link;
 
 	/* For nexthop linked list */
 	LIST_ENTRY(bgp_path_info) nh_thread;
@@ -738,6 +742,11 @@ DECLARE_HOOK(bgp_route_update,
 	     (struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
 	      struct bgp_path_info *old_route, struct bgp_path_info *new_route),
 	     (bgp, afi, safi, bn, old_route, new_route));
+
+extern int bgp_pi_hash_cmp(const struct bgp_path_info *p1, const struct bgp_path_info *p2);
+extern uint32_t bgp_pi_hash_hashfn(const struct bgp_path_info *pi);
+
+DECLARE_HASH(bgp_pi_hash, struct bgp_path_info, pi_hash_link, bgp_pi_hash_cmp, bgp_pi_hash_hashfn);
 
 /* BGP show options */
 #define BGP_SHOW_OPT_JSON (1 << 0)

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -33,6 +33,9 @@ void bgp_table_unlock(struct bgp_table *rt)
 		return;
 	}
 
+	/* Cleanup pi_hash in bgp_table */
+	bgp_pi_hash_fini(&rt->pi_hash);
+
 	route_table_finish(rt->route_table);
 	rt->route_table = NULL;
 
@@ -84,6 +87,8 @@ inline struct bgp_dest *bgp_dest_unlock_node(struct bgp_dest *dest)
 
 	if (rn->lock == 1) {
 		struct bgp_table *rt = bgp_dest_table(dest);
+
+
 		if (rt->bgp) {
 			bgp_addpath_free_node_data(&rt->bgp->tx_addpath,
 						   &dest->tx_addpath, rt->afi,
@@ -165,6 +170,7 @@ struct bgp_table *bgp_table_init(struct bgp *bgp, afi_t afi, safi_t safi)
 	bgp_table_lock(rt);
 	rt->afi = afi;
 	rt->safi = safi;
+	bgp_pi_hash_init(&rt->pi_hash);
 
 	return rt;
 }

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -10,9 +10,13 @@
 #include "table.h"
 #include "queue.h"
 #include "linklist.h"
+#include "typesafe.h"
 #include "bgpd.h"
 #include "bgp_advertise.h"
 #include "bgp_attr_srv6.h"
+
+/* Typesafe hash for bgp_path_info lookup */
+PREDECL_HASH(bgp_pi_hash);
 
 struct bgp_table {
 	/* table belongs to this instance */
@@ -23,6 +27,9 @@ struct bgp_table {
 	safi_t safi;
 
 	int lock;
+
+	/* Hash for bgp_path_info lookups across all prefixes in this table */
+	struct bgp_pi_hash_head pi_hash;
 
 	/* soft_reconfig_table in progress */
 	bool soft_reconfig_init;

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -1008,7 +1008,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 		}
 	}
 
-	new = info_make(type, sub_type, 0, rfd->peer, new_attr, NULL);
+	new = info_make(type, sub_type, 0, rfd->peer, new_attr, bn);
 	SET_FLAG(new->flags, BGP_PATH_VALID);
 
 	/* save backref to rfapi handle */


### PR DESCRIPTION
Problem:
--------
BGP path lookup currently uses O(N) linear search through the list (dest->info) for every incoming route update. In high-ECMP scenarios, each update requires iterating through the entire path list to check if a path from that peer already exists.

This becomes a severe performance bottleneck in data center environments with high ECMP during large-scale route updates churn.

Solution:
---------
Implement a path_info hash per table using typesafe hash. Use the same in bgp_update() for efficient lookup.

This hash lookup improves CPU overhead upto ~60%