### PR TITLE
babeld: fix RFC violations in babel message parser

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -706,8 +706,8 @@ void parse_packet(const unsigned char *from, struct interface *ifp, const unsign
 			}
 		} else if (type == MESSAGE_NH) {
 			unsigned char nh[16];
-
 			int rc;
+
 			if (message[2] != 1 && message[2] != 3) {
 				debugf(BABEL_DEBUG_COMMON, "Received NH with incorrect AE %d.",
 				       message[2]);


### PR DESCRIPTION
This commit fix various RFC violations found in `message.c`.

1. In Update message, this commit add a check to ignore the whole enclosing TLV if the mandatory bit of a sub-TLV is set. This commit also add a check to ensure that if AE is 3, Omitted must be zero.
2. In IHU message, this commit add similar mandatory bit check for sub-TLVs.
3. Add checks for `interval != 0` in various locations as RFC states that interval must not be zero.
4. Remove `Reserved == 0` checks from various locations, as RFC states that they must be ignored on recepton.
5. Add checks for `router_id` that ensure they must not be all zeros or all ones.
6. Add sub-TLV handling logic to various message types.