### PR TITLE
docker: modify libyang version in Dockerfile for centos-8

### DIFF
--- a/docker/centos-8/Dockerfile
+++ b/docker/centos-8/Dockerfile
@@ -10,8 +10,8 @@ RUN dnf install --enablerepo=powertools -y rpm-build git autoconf pcre-devel \
         groff pkgconfig json-c-devel pam-devel bison flex python3-pytest \
         c-ares-devel python3-devel python3-sphinx libcap-devel platform-python-devel \
         protobuf-c-devel \
-        https://ci1.netdef.org/artifact/LIBYANG-LIBYANG2/shared/build-00181/RedHat-8-x86_64-Packages/libyang-2.1.80-1.el8.x86_64.rpm \
-        https://ci1.netdef.org/artifact/LIBYANG-LIBYANG2/shared/build-00181/RedHat-8-x86_64-Packages/libyang-devel-2.1.80-1.el8.x86_64.rpm \
+        https://ci1.netdef.org/artifact/LIBYANG-LIBYANG2/shared/build-00184/RedHat-8-x86_64-Packages/libyang-2.1.128.83.gfc4dbd92-1.el8.x86_64.rpm \
+        https://ci1.netdef.org/artifact/LIBYANG-LIBYANG2/shared/build-00184/RedHat-8-x86_64-Packages/libyang-devel-2.1.128.83.gfc4dbd92-1.el8.x86_64.rpm \
         https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-00146/CentOS-7-x86_64-Packages/librtr-0.8.0-1.el7.x86_64.rpm \
         https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-00146/CentOS-7-x86_64-Packages/librtr-devel-0.8.0-1.el7.x86_64.rpm
 
@@ -43,7 +43,7 @@ RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-*  \
     && sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
 
 RUN mkdir -p /pkgs/rpm \
-    && yum install -y https://ci1.netdef.org/artifact/LIBYANG-LIBYANG2/shared/build-00181/RedHat-8-x86_64-Packages/libyang-2.1.80-1.el8.x86_64.rpm \
+    && yum install -y https://ci1.netdef.org/artifact/LIBYANG-LIBYANG2/shared/build-00184/RedHat-8-x86_64-Packages/libyang-2.1.128.83.gfc4dbd92-1.el8.x86_64.rpm \
         https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-00146/CentOS-7-x86_64-Packages/librtr-0.8.0-1.el7.x86_64.rpm
 
 COPY --from=centos-8-builder /rpmbuild/RPMS/ /pkgs/rpm/


### PR DESCRIPTION
Currently, in master branch, executing `build.sh` in `docker/centos-8` fails, because the version of libyang installed by `Dockerfile` is too old.

I've fixed this probrem by modifying `Dockerfile`.

