### PR TITLE
Add new show command to display only failed routes

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -1594,7 +1594,7 @@ zebra Terminal Mode Commands
    Display detailed information about a route. If [nexthop-group] is
    included, it will display the nexthop group ID the route is using as well.
 
-.. clicmd:: show [ip|ipv6] route [vrf NAME|all|table TABLENO] [A.B.C.D|A.B.C.D/M|X:X::X:X|X:X::X:X/M] [json] [nexthop-group [summary [ecmp-count <gt|lt|eq> (1-256)]]]
+.. clicmd:: show [ip|ipv6] route [vrf NAME|all|table TABLENO] [A.B.C.D|A.B.C.D/M|X:X::X:X|X:X::X:X/M] [nexthop-group [summary [ecmp-count <gt|lt|eq> (1-256)]]] [failed] [json]
 
    Display detailed information about routes in the routing table. This command provides comprehensive information about specific routes, including their attributes, nexthops, and other routing details.
 
@@ -1610,6 +1610,7 @@ zebra Terminal Mode Commands
      - ``gt``: Show routes with ECMP count greater than N
      - ``lt``: Show routes with ECMP count less than N
      - ``eq``: Show routes with ECMP count equal to N
+   - ``failed``: Show only routes that failed to install in the FIB (kernel). This is useful for troubleshooting route installation issues.
    - ``json``: Display output in JSON format
 
    The detailed output includes:
@@ -1704,6 +1705,24 @@ zebra Terminal Mode Commands
    - Troubleshooting nexthop group installation issues
    - Monitoring ECMP load-balancing configurations
    - Verifying routes have the expected number of paths
+
+   **Viewing Failed Routes**
+
+   The ``failed`` option filters the output to show only routes that have failed
+   to install in the FIB. This is useful for troubleshooting route installation
+   issues.
+
+   ::
+
+      Router# show ip route failed
+      Codes: K - kernel route, C - connected, L - local, S - static,
+             R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
+             T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
+             f - OpenFabric, t - Table-Direct,
+             > - selected route, * - FIB route, q - queued, r - rejected, b - backup
+             t - trapped, o - offload failure
+
+      r>* 0.0.0.0/0 [20/0] via 10.0.0.1, Ethernet120, rejected
 
 .. clicmd:: show [ip|ipv6] route summary
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -65,7 +65,7 @@ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi, sa
 			    const struct prefix *longer_prefix_p, bool supernets_only, int type,
 			    unsigned short ospf_instance_id, uint32_t tableid, bool show_ng,
 			    bool show_nhg_summary, bool ecmp_gt, bool ecmp_lt, bool ecmp_eq,
-			    uint16_t ecmp_count, struct route_show_ctx *ctx);
+			    uint16_t ecmp_count, bool failed_only, struct route_show_ctx *ctx);
 static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 				     int mcast, bool use_fib, bool show_ng);
 static void vty_show_ip_route_summary(struct vty *vty, struct route_table *table,
@@ -880,7 +880,7 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 				 bool supernets_only, int type, unsigned short ospf_instance_id,
 				 bool use_json, uint32_t tableid, bool show_ng,
 				 bool show_nhg_summary, bool ecmp_gt, bool ecmp_lt, bool ecmp_eq,
-				 uint16_t ecmp_count, struct route_show_ctx *ctx)
+				 uint16_t ecmp_count, bool failed_only, struct route_show_ctx *ctx)
 {
 	struct route_node *rn;
 	struct route_entry *re;
@@ -911,6 +911,9 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 
 		RNODE_FOREACH_RE (rn, re) {
 			if (use_fib && re != dest->selected_fib)
+				continue;
+
+			if (failed_only && !CHECK_FLAG(re->status, ROUTE_ENTRY_FAILED))
 				continue;
 
 			if (tag && re->tag != tag)
@@ -984,7 +987,7 @@ static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf, afi_t 
 				 const struct prefix *longer_prefix_p, bool supernets_only,
 				 int type, unsigned short ospf_instance_id, bool show_ng,
 				 bool show_nhg_summary, bool ecmp_gt, bool ecmp_lt, bool ecmp_eq,
-				 uint16_t ecmp_count, struct route_show_ctx *ctx)
+				 uint16_t ecmp_count, bool failed_only, struct route_show_ctx *ctx)
 {
 	struct zebra_router_table *zrt;
 	struct rib_table_info *info;
@@ -1001,7 +1004,7 @@ static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf, afi_t 
 		do_show_ip_route(vty, zvrf_name(zvrf), afi, safi, use_fib, use_json, tag,
 				 longer_prefix_p, supernets_only, type, ospf_instance_id,
 				 zrt->tableid, show_ng, show_nhg_summary, ecmp_gt, ecmp_lt,
-				 ecmp_eq, ecmp_count, ctx);
+				 ecmp_eq, ecmp_count, failed_only, ctx);
 	}
 }
 
@@ -1010,7 +1013,7 @@ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi, sa
 			    const struct prefix *longer_prefix_p, bool supernets_only, int type,
 			    unsigned short ospf_instance_id, uint32_t tableid, bool show_ng,
 			    bool show_nhg_summary, bool ecmp_gt, bool ecmp_lt, bool ecmp_eq,
-			    uint16_t ecmp_count, struct route_show_ctx *ctx)
+			    uint16_t ecmp_count, bool failed_only, struct route_show_ctx *ctx)
 {
 	struct route_table *table;
 	struct zebra_vrf *zvrf = NULL;
@@ -1043,7 +1046,8 @@ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi, sa
 
 	do_show_route_helper(vty, zvrf, table, afi, safi, use_fib, tag, longer_prefix_p,
 			     supernets_only, type, ospf_instance_id, use_json, tableid, show_ng,
-			     show_nhg_summary, ecmp_gt, ecmp_lt, ecmp_eq, ecmp_count, ctx);
+			     show_nhg_summary, ecmp_gt, ecmp_lt, ecmp_eq, ecmp_count, failed_only,
+			     ctx);
 
 	return CMD_SUCCESS;
 }
@@ -1730,7 +1734,7 @@ DEFPY (show_route,
           }]\
           [" FRR_IP6_REDIST_STR_ZEBRA "$type_str]\
         >\
-       [nexthop-group$ng [summary$ng_summary [ecmp-count <gt$ecmp_gt|lt$ecmp_lt|eq$ecmp_eq> (1-256)$ecmp_count]]] [json$json]",
+       [nexthop-group$ng [summary$ng_summary [ecmp-count <gt$ecmp_gt|lt$ecmp_lt|eq$ecmp_eq> (1-256)$ecmp_count]]] [failed$failed] [json$json]",
        SHOW_STR
        IP_STR
        "IP forwarding table\n"
@@ -1768,6 +1772,7 @@ DEFPY (show_route,
        "Less than (<)\n"
        "Equal to (=)\n"
        "ECMP count value\n"
+       "Show only failed routes\n"
        JSON_STR)
 {
 	afi_t afi = ipv4 ? AFI_IP : AFI_IP6;
@@ -1816,14 +1821,15 @@ DEFPY (show_route,
 							     !!supernets_only, type,
 							     ospf_instance_id, !!ng, true,
 							     !!ecmp_gt, !!ecmp_lt, !!ecmp_eq,
-							     ecmp_count ? ecmp_count : 0, &ctx);
+							     ecmp_count ? ecmp_count : 0, !!failed,
+							     &ctx);
 				else
 					do_show_ip_route(vty, zvrf_name(zvrf), afi, safi, !!fib,
 							 !!json, tag, prefix_str ? prefix : NULL,
 							 !!supernets_only, type, ospf_instance_id,
 							 table, false, true, !!ecmp_gt, !!ecmp_lt,
 							 !!ecmp_eq, ecmp_count ? ecmp_count : 0,
-							 &ctx);
+							 !!failed, &ctx);
 			}
 			if (json)
 				vty_json_close(vty, first_vrf_json);
@@ -1847,13 +1853,13 @@ DEFPY (show_route,
 						     prefix_str ? prefix : NULL, !!supernets_only,
 						     type, ospf_instance_id, !!ng, true, !!ecmp_gt,
 						     !!ecmp_lt, !!ecmp_eq,
-						     ecmp_count ? ecmp_count : 0, &ctx);
+						     ecmp_count ? ecmp_count : 0, !!failed, &ctx);
 			else
 				do_show_ip_route(vty, vrf->name, afi, safi, !!fib, !!json, tag,
 						 prefix_str ? prefix : NULL, !!supernets_only,
 						 type, ospf_instance_id, table, false, true,
 						 !!ecmp_gt, !!ecmp_lt, !!ecmp_eq,
-						 ecmp_count ? ecmp_count : 0, &ctx);
+						 ecmp_count ? ecmp_count : 0, !!failed, &ctx);
 		}
 
 		return CMD_SUCCESS;
@@ -1872,12 +1878,12 @@ DEFPY (show_route,
 				do_show_ip_route_all(vty, zvrf, afi, safi, !!fib, !!json, tag,
 						     prefix_str ? prefix : NULL, !!supernets_only,
 						     type, ospf_instance_id, !!ng, false, false,
-						     false, false, 0, &ctx);
+						     false, false, 0, !!failed, &ctx);
 			else
 				do_show_ip_route(vty, zvrf_name(zvrf), afi, safi, !!fib, !!json,
 						 tag, prefix_str ? prefix : NULL, !!supernets_only,
 						 type, ospf_instance_id, table, !!ng, false, false,
-						 false, false, 0, &ctx);
+						 false, false, 0, !!failed, &ctx);
 		}
 		if (json)
 			vty_json_close(vty, first_vrf_json);
@@ -1900,12 +1906,12 @@ DEFPY (show_route,
 			do_show_ip_route_all(vty, zvrf, afi, safi, !!fib, !!json, tag,
 					     prefix_str ? prefix : NULL, !!supernets_only, type,
 					     ospf_instance_id, !!ng, false, false, false, false, 0,
-					     &ctx);
+					     !!failed, &ctx);
 		else
 			do_show_ip_route(vty, vrf->name, afi, safi, !!fib, !!json, tag,
 					 prefix_str ? prefix : NULL, !!supernets_only, type,
 					 ospf_instance_id, table, !!ng, false, false, false, false,
-					 0, &ctx);
+					 0, !!failed, &ctx);
 	}
 
 	return CMD_SUCCESS;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To catch/dump failed routes, during periodic route_check, Need a new show command to display only failed routes, instead of displaying the whole routing table and then filtering failed routes). Display of whole routing table on scaled setups causes high memory spikes, and is not suitable for a periodic route_check on failed routes

#### How I did it
Added a new additional option parameter <failed> and in the implementation, filter routes early if the ROUTE_INSTALL_FAILED flag is not set. 

#### How to verify it
Loaded the image on the chassis, and could verify that the device is stable.
the new command is available. the output is as expected.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->


```
admin@svcstr-7800-lc3-1:~$ vtysh -n 0

Hello, this is FRRouting (version 8.5.4).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

svcstr-7800-lc3-1# show ip route 
  <cr>            
  A.B.C.D         Network in the IP routing table to display
  A.B.C.D/M       IP prefix <network>/<length>, e.g., 35.0.0.0/8
  babel           Babel routing protocol (Babel)
  bgp             Border Gateway Protocol (BGP)
  connected       Connected routes (directly attached subnet or host)
  eigrp           Enhanced Interior Gateway Routing Protocol (EIGRP)
  failed          Show only failed routes
  isis            Intermediate System to Intermediate System (IS-IS)
  json            JavaScript Object Notation
  kernel          Kernel routes (not installed via the zebra RIB)
  nexthop-group   Nexthop Group Information
  nhrp            Next Hop Resolution Protocol (NHRP)
  openfabric      OpenFabric Routing Protocol
  ospf            Open Shortest Path First (OSPFv2)
  rip             Routing Information Protocol (RIP)
  static          Statically configured routes
  summary         Summary of all routes
  supernets-only  Show supernet entries only
  table           Table to display
  tag             Show only routes with tag
  vnc             Virtual Network Control (VNC)
  vrf             Specify the VRF
svcstr-7800-lc3-1# show ip route failed 
  <cr>  
svcstr-7800-lc3-1# show ip route failed 
svcstr-7800-lc3-1# show ip route json   
  <cr>    
  failed  Show only failed routes
svcstr-7800-lc3-1# show ip route json failed
{
}
svcstr-7800-lc3-1# 

svcstr-7800-lc3-1# show ipv6 route 
  <cr>           
  X:X::X:X       IPv6 Address
  X:X::X:X/M     IPv6 prefix
  babel          Babel routing protocol (Babel)
  bgp            Border Gateway Protocol (BGP)
  connected      Connected routes (directly attached subnet or host)
  failed         Show only failed routes
  isis           Intermediate System to Intermediate System (IS-IS)
  json           JavaScript Object Notation
  kernel         Kernel routes (not installed via the zebra RIB)
  nexthop-group  Nexthop Group Information
  nhrp           Next Hop Resolution Protocol (NHRP)
  openfabric     OpenFabric Routing Protocol
  ospf6          Open Shortest Path First (IPv6) (OSPFv3)
  ripng          Routing Information Protocol next-generation (IPv6) (RIPng)
  static         Statically configured routes
  summary        Summary of all routes
  table          Table to display
  tag            Show only routes with tag
  vnc            Virtual Network Control (VNC)
  vrf            Specify the VRF
svcstr-7800-lc3-1# show ipv6 route failed 
  <cr>  
svcstr-7800-lc3-1# show ipv6 route failed 
svcstr-7800-lc3-1# show ipv6 route json   
  <cr>    
  failed  Show only failed routes
svcstr-7800-lc3-1# show ipv6 route json failed 
{
}
svcstr-7800-lc3-1# 
```
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

signed-off by: Deepak Singhal [<deepsinghal@microsoft.com>]