### PR TITLE
Fix duplicate route from local protocol

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -347,13 +347,13 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 		struct route_node *m_rn = route_node_match(m_table, &plocal);
 		if (u_rn) {
 			rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, 0,
-				    &plocal,NULL, &nh, 0, zvrf->table_id, 0, 0, false);
+				   &plocal, NULL, &nh, 0, zvrf->table_id, 0, 0, false);
 			route_unlock_node(u_rn);
 		}
 
 		if (m_rn) {
-			rib_delete(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, 0, 
-				    &plocal, NULL, &nh, 0, zvrf->table_id, 0, 0, false);
+			rib_delete(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, 0,
+				   &plocal, NULL, &nh, 0, zvrf->table_id, 0, 0, false);
 			route_unlock_node(m_rn);
 		}
 


### PR DESCRIPTION
The change is fixing duplicate route from local protocol, if interface change attribute.

Fixed issue #20337 