### PR TITLE
zebra: fix the bug zebra installs more ECMP next hops than specified

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -5037,6 +5037,10 @@ ssize_t netlink_mpls_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx,
 		nexthop = nhlfe->nexthop;
 		if (!nexthop)
 			continue;
+
+		if (nexthop_num >= zrouter.zav.multipath_num)
+			break;
+		
 		if (cmd == RTM_NEWROUTE) {
 			/* Count all selected NHLFEs */
 			if (CHECK_FLAG(nhlfe->flags, NHLFE_FLAG_SELECTED)


### PR DESCRIPTION
  Ensure the number of installed ECMP next hops does not exceed zrouter.zav.multipath_num by stopping iteration once the limit is reached, matching OpenBSD behavior (see zebra_mpls_openbsd.c:250–251).