### PR TITLE
yang: Reorderd must constraints in frr-eigrpd module

### DIFF
--- a/yang/frr-eigrpd.yang
+++ b/yang/frr-eigrpd.yang
@@ -110,9 +110,9 @@ module frr-eigrpd {
     description "EIGRP daemon configuration";
 
     list instance {
+      must "count(../instance[vrf =current()/vrf]) = 1";
       key "asn vrf";
       description "EIGRP autonomous system instance";
-      must "count(../instance[vrf =current()/vrf]) = 1";
       leaf asn {
         type autonomous-system;
         description "Autonomous System Number";


### PR DESCRIPTION
error: keyword "must" not in canonical order (see RFC 7950, Section 14)
Reordered must constraints in frr-eigrpd.yang