### PR TITLE
ci: add retry logic for apt and curl to handle transient failures - default 3 times

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -86,7 +86,9 @@ jobs:
         run: |
           uname -a
           MODPKGVER=$(uname -r)
-          sudo apt-get update -y
+          # Retry loop for apt-get update in case of transient mirror failures
+          APT_RETRIES=3
+          for i in $(seq 1 ${APT_RETRIES}); do sudo apt-get update -y && break || sleep 10; done
           # Github is running old kernels but installing newer packages :(
           sudo apt-get install -y linux-modules-extra-azure linux-modules-${MODPKGVER} linux-modules-extra-${MODPKGVER} python3-xmltodict
           sudo modprobe vrf || true

--- a/docker/ubuntu-ci/Dockerfile
+++ b/docker/ubuntu-ci/Dockerfile
@@ -5,8 +5,18 @@ FROM ubuntu:$UBUNTU_VERSION
 ARG UBUNTU_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Number of retries for transient network failures
+ARG APT_RETRIES=3
+
+# Configure apt to retry on transient network failures
+RUN echo "Acquire::Retries \"${APT_RETRIES}\";" > /etc/apt/apt.conf.d/80-retries && \
+    echo 'Acquire::http::Timeout "30";' >> /etc/apt/apt.conf.d/80-retries && \
+    echo 'Acquire::https::Timeout "30";' >> /etc/apt/apt.conf.d/80-retries
+
 # Update and install build requirements.
-RUN apt update && apt upgrade -y && \
+# Retry loop for apt-get update in case of transient mirror failures
+RUN for i in $(seq 1 ${APT_RETRIES}); do apt-get update && break || sleep 10; done && \
+    apt-get upgrade -y && \
     # Basic build requirements from documentation
     apt-get install -y \
             autoconf \
@@ -112,11 +122,15 @@ RUN groupadd -r -g 92 frr && \
       mkdir -p /home/frr && chown frr.frr /home/frr
 
 # Install FRR built packages
+# Retry loop for curl in case of transient network failures
 RUN mkdir -p /etc/apt/keyrings && \
-    curl -s -o /etc/apt/keyrings/frrouting.gpg https://deb.frrouting.org/frr/keys.gpg && \
+    for i in $(seq 1 ${APT_RETRIES}); do \
+        curl -sf -o /etc/apt/keyrings/frrouting.gpg https://deb.frrouting.org/frr/keys.gpg && break || sleep 10; \
+    done && \
     echo deb '[signed-by=/etc/apt/keyrings/frrouting.gpg]' https://deb.frrouting.org/frr \
         $(lsb_release -s -c) "frr-stable" > /etc/apt/sources.list.d/frr.list && \
-    apt-get update && apt-get install -y librtr-dev
+    for i in $(seq 1 ${APT_RETRIES}); do apt-get update && break || sleep 10; done && \
+    apt-get install -y librtr-dev
 
 # build and install libyang3
 RUN cd && pwd && ls -al && \


### PR DESCRIPTION
Ubuntu package mirrors can experience transient failures during CI runs, causing builds to fail with 404 errors even though the packages exist. Similarly, fetching GPG keys from external servers may fail due to temporary network issues.

This patch introduces an APT_RETRIES build argument (defaulting to 3) that controls the number of retry attempts for network operations. The apt configuration is updated to use Acquire::Retries along with reasonable timeouts for http and https connections.

The apt-get update commands are wrapped in retry loops that sleep for 10 seconds between attempts, giving mirrors time to recover. The same pattern is applied to the curl command that fetches the FRR GPG key for the package repository.

The github-ci.yml workflow receives the same retry treatment for its apt-get update call during test environment setup.