### PR TITLE
staticd: Fix CID 1668073 (NULL pointer dereference in SRv6 code)

### DIFF
--- a/staticd/static_srv6.c
+++ b/staticd/static_srv6.c
@@ -809,6 +809,16 @@ void static_srv6_neigh_register_if_needed(void)
 		static_srv6_neigh_cache_init();
 	}
 
+	/*
+	 * Coverity complains about a potential NULL pointer dereference here.
+	 * However, neigh_cache is guaranteed to be non-NULL at this point.
+	 * This is because if it was initially NULL, static_srv6_neigh_cache_init would have been called.
+	 * static_srv6_neigh_cache_init uses XCALLOC to allocate memory for neigh_cache,
+	 * which either succeeds (making neigh_cache non-NULL) or aborts the program on failure.
+	 * The assert below is added to make Coverity happy.
+	 */
+	assert(neigh_cache);
+
 	neigh_cache->resolve_sids_cnt++;
 	DEBUGD(&static_dbg_srv6, "%s: SRv6 SID resolve count increased to %u", __func__,
 	       neigh_cache->resolve_sids_cnt);


### PR DESCRIPTION
```
*** CID 1668073:         Null pointer dereferences  (FORWARD_NULL)
/staticd/static_srv6.c: 812             in static_srv6_neigh_register_if_needed()
806     {
807     	if (!neigh_cache) {
808     		DEBUGD(&static_dbg_srv6, "%s: Initializing neighbor cache", __func__);
809     		static_srv6_neigh_cache_init();
810     	}
811
>>>     CID 1668073:         Null pointer dereferences  (FORWARD_NULL)
>>>     Dereferencing null pointer "neigh_cache".
812     	neigh_cache->resolve_sids_cnt++;
813     	DEBUGD(&static_dbg_srv6, "%s: SRv6 SID resolve count increased to %u", __func__,
814     	       neigh_cache->resolve_sids_cnt);
815
816     	if (!neigh_cache->registered && neigh_cache->resolve_sids_cnt > 0) {
817     		DEBUGD(&static_dbg_srv6, "%s: Registering for IPv6 neighbor notifications",
```

Coverity complains about a potential NULL pointer dereference. However, neigh_cache is guaranteed to be non-NULL. This is because if it was initially NULL, static_srv6_neigh_cache_init would have been called.
static_srv6_neigh_cache_init uses XCALLOC to allocate memory for neigh_cache, which either succeeds (making neigh_cache non-NULL) or aborts the program on failure.

Let's add an assert to make Coverity happy.