### PR TITLE
eigrpd: Prevent crash in packet handling

### DIFF
--- a/eigrpd/eigrp_update.c
+++ b/eigrpd/eigrp_update.c
@@ -529,7 +529,7 @@ static void eigrp_update_send_to_all_nbrs(struct eigrp_interface *ei,
 			continue;
 
 		if (packet_sent)
-			ep_dup = eigrp_packet_duplicate(ep, NULL);
+			ep_dup = eigrp_packet_duplicate(ep, nbr);
 		else
 			ep_dup = ep;
 


### PR DESCRIPTION
eigrp will crash on a lan segment with more than one neighbor on shutdown in some situations.  Let's just fix it.