### PR TITLE
ripd: Fix default-route accept and announce

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -806,7 +806,11 @@ static void rip_packet_dump(struct rip_packet *packet, int size,
    check net 0 because we accept default route. */
 static int rip_destination_check(struct in_addr addr)
 {
-	return ipv4_unicast_valid(&addr);
+	if (addr.s_addr == INADDR_ANY)
+		/* default route allowed */
+		return 1;
+	else
+		return ipv4_unicast_valid(&addr);
 }
 
 /* RIP version 2 authentication. */


### PR DESCRIPTION
Fix commit 2616e95 ("ripd: Allow using reserved ranges") which accidently blocked the acceptance and announcement of a default route via RIP

Fixes: #20415 