### PR TITLE
zebra: Fix memory leak when SRv6 explicit SID allocation fails

### DIFF
--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -1914,6 +1914,7 @@ static int get_srv6_sid_explicit(struct zebra_srv6_sid **sid, struct srv6_sid_ct
 			flog_err(EC_ZEBRA_SM_CANNOT_ASSIGN_SID,
 				 "%s: failed to create SRv6 SID %s (%pI6)", __func__,
 				 srv6_sid_ctx2str(buf, sizeof(buf), ctx), sid_value);
+			zebra_srv6_sid_ctx_free(zctx);
 			return -1;
 		}
 		(*sid)->wide_func = sid_func_wide;


### PR DESCRIPTION
Ensure that the `zebra_srv6_sid_ctx` object is properly freed if `zebra_srv6_sid_alloc` fails, to prevent memory leaks in the SRv6 explicit SID allocation code path.