### PR TITLE
bfdd: fix updating wrong bfd parameters

### DIFF
--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -509,8 +509,7 @@ static void bfdd_dest_register(struct stream *msg, vrf_id_t vrf_id)
 		 * changing peer configuration manually (through `peer` node)
 		 * or via profiles.
 		 */
-		if (bpc.bpc_has_profile)
-			bfd_profile_apply(bpc.bpc_profile, bs);
+		bfd_profile_apply(bpc.bpc_has_profile ? bpc.bpc_profile : NULL, bs);
 	}
 
 	/* Create client peer notification register. */


### PR DESCRIPTION
When using `bfd_profile_apply` to update the bfd parameters, the situation without profile also needs to be considered.

Take BGP as an example: delete `neighbor A bfd profile <NAME>`, then keep only `neighbor A bfd`. At this point, the default parameters of the bfd peer should be used, but the current code has not updated the parameters and still uses the parameters in the profile <NAME>.

So, let `bfd_profile_apply` update empty profile.