### PR TITLE
zebra: Fix memory leak when SRv6 dynamic SID allocation fails

### DIFF
--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -2021,6 +2021,7 @@ static int get_srv6_sid_dynamic(struct zebra_srv6_sid **sid, struct srv6_sid_ctx
 		flog_err(EC_ZEBRA_SM_CANNOT_ASSIGN_SID,
 			 "%s: failed to create SRv6 SID ctx %s (%pI6)", __func__,
 			 srv6_sid_ctx2str(buf, sizeof(buf), ctx), &sid_value);
+		zebra_srv6_sid_ctx_free(zctx);
 		return -1;
 	}
 	(*sid)->ctx = zctx;


### PR DESCRIPTION
Ensure that the `zebra_srv6_sid_ctx` object is properly freed if `zebra_srv6_sid_alloc` fails, to prevent memory leaks in the SRv6 dynamic SID allocation code path.