### PR TITLE
zebra: Fix `release_srv6_sid_func_explicit` to return int instead of bool

### DIFF
--- a/zebra/zebra_srv6.c
+++ b/zebra/zebra_srv6.c
@@ -2131,7 +2131,7 @@ int get_srv6_sid(struct zebra_srv6_sid **sid, struct srv6_sid_ctx *ctx, struct i
  * @param sid_func SID function to be released
  * @return 0 on success, -1 otherwise
  */
-static bool release_srv6_sid_func_explicit(struct zebra_srv6_sid_block *block,
+static int release_srv6_sid_func_explicit(struct zebra_srv6_sid_block *block,
 					   uint32_t sid_func,
 					   uint32_t sid_wide_func)
 {


### PR DESCRIPTION
The function `release_srv6_sid_func_explicit` is declared to return a bool, but its implementation returns an int.

This PR updates the function signature to return int instead of bool.