### PR TITLE
pbrd: extend PBR policy interface limit from 64 to 512

### DIFF
--- a/lib/bitfield.h
+++ b/lib/bitfield.h
@@ -92,6 +92,9 @@ DECLARE_MTYPE(BITFIELD);
 /* check if the bit field has been setup */
 #define bf_is_inited(v) ((v).data)
 
+/* check if a bit index is valid (within allocated range) */
+#define bf_index_is_valid(v, b) ((b) < ((v).m * WORD_SIZE))
+
 /* compare two bitmaps of the same length */
 #define bf_cmp(v1, v2) (memcmp((v1).data, (v2).data, ((v1).m * sizeof(word_t))))
 

--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -64,6 +64,9 @@ static int pbr_map_sequence_compare(const struct pbr_map_sequence *pbrms1,
 
 void pbr_map_sequence_delete(struct pbr_map_sequence *pbrms)
 {
+	if (bf_is_inited(pbrms->installed))
+		bf_free(pbrms->installed);
+
 	XFREE(MTYPE_TMP, pbrms->internal_nhg_name);
 
 	QOBJ_UNREG(pbrms);
@@ -92,14 +95,11 @@ static void pbr_map_interface_list_delete(struct pbr_map_interface *pmi)
 static bool pbrms_is_installed(const struct pbr_map_sequence *pbrms,
 			       const struct pbr_map_interface *pmi)
 {
-	uint64_t is_installed = (uint64_t)1 << pmi->install_bit;
+	if (!bf_is_inited(pbrms->installed) ||
+	    !bf_index_is_valid(pbrms->installed, pmi->install_bit))
+		return false;
 
-	is_installed &= pbrms->installed;
-
-	if (is_installed)
-		return true;
-
-	return false;
+	return bf_test_index(pbrms->installed, pmi->install_bit) != 0;
 }
 
 /* If any sequence is installed on the interface, assume installed */
@@ -215,14 +215,24 @@ void pbr_map_interface_delete(struct pbr_map *pbrm, struct interface *ifp_del)
 		pbr_map_policy_delete(pbrm, pmi);
 }
 
-void pbr_map_add_interface(struct pbr_map *pbrm, struct interface *ifp_add)
+bool pbr_map_add_interface(struct pbr_map *pbrm, struct interface *ifp_add)
 {
 	struct listnode *node;
 	struct pbr_map_interface *pmi;
 
 	for (ALL_LIST_ELEMENTS_RO(pbrm->incoming, node, pmi)) {
 		if (ifp_add == pmi->ifp)
-			return;
+			return true; /* Already added */
+	}
+
+	/*
+	 * Check if we have room in the bitfield before adding.
+	 */
+	if (listcount(pbrm->incoming) >= PBR_MAP_INTERFACE_MAX) {
+		zlog_warn("%s: PBR map %s has reached maximum interface limit (%d), cannot add interface %s",
+			  __func__, pbrm->name, PBR_MAP_INTERFACE_MAX,
+			  ifp_add->name);
+		return false; /* Limit reached */
 	}
 
 	pmi = XCALLOC(MTYPE_PBR_MAP_INTERFACE, sizeof(*pmi));
@@ -234,6 +244,8 @@ void pbr_map_add_interface(struct pbr_map *pbrm, struct interface *ifp_add)
 	pbr_map_check_valid(pbrm->name);
 	if (pbrm->valid)
 		pbr_map_install(pbrm);
+
+	return true; /* Success */
 }
 
 static int
@@ -522,7 +534,7 @@ struct pbr_map_sequence *pbrms_get(const char *name, uint32_t seqno)
 
 		RB_INSERT(pbr_map_entry_head, &pbr_maps, pbrm);
 
-		bf_init(pbrm->ifi_bitfield, 64);
+		bf_init(pbrm->ifi_bitfield, PBR_MAP_INTERFACE_MAX);
 		pbr_map_add_interfaces(pbrm);
 	}
 
@@ -545,6 +557,8 @@ struct pbr_map_sequence *pbrms_get(const char *name, uint32_t seqno)
 			PBR_MAP_INVALID_EMPTY |
 			PBR_MAP_INVALID_NO_NEXTHOPS;
 		pbrms->vrf_name[0] = '\0';
+
+		bf_init(pbrms->installed, PBR_MAP_INTERFACE_MAX);
 
 		QOBJ_REG(pbrms, pbr_map_sequence);
 		listnode_add_sort(pbrm->seqnumbers, pbrms);

--- a/pbrd/pbr_map.h
+++ b/pbrd/pbr_map.h
@@ -14,6 +14,11 @@
 
 #include "pbr_vrf.h"
 
+/*
+ * Maximum number of interfaces that can be associated with a single PBR map.
+ */
+#define PBR_MAP_INTERFACE_MAX 512
+
 struct pbr_map {
 	/*
 	 * RB Tree of the pbr_maps
@@ -175,10 +180,7 @@ struct pbr_map_sequence {
 	 */
 	bool nhs_installed;
 
-	/*
-	 * Are we installed
-	 */
-	uint64_t installed;
+	bitfield_t installed;
 
 	/*
 	 * A reason of 0 means we think the pbr_map_sequence is good to go
@@ -210,7 +212,7 @@ extern struct pbr_map *pbrm_find(const char *name);
 extern void pbr_map_delete(struct pbr_map_sequence *pbrms);
 extern void pbr_map_delete_nexthops(struct pbr_map_sequence *pbrms);
 extern void pbr_map_delete_vrf(struct pbr_map_sequence *pbrms);
-extern void pbr_map_add_interface(struct pbr_map *pbrm, struct interface *ifp);
+extern bool pbr_map_add_interface(struct pbr_map *pbrm, struct interface *ifp);
 extern void pbr_map_interface_delete(struct pbr_map *pbrm,
 				     struct interface *ifp);
 

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -20,6 +20,7 @@
 #include "json.h"
 #include "debug.h"
 #include "pbr.h"
+#include "bitfield.h"
 
 #include "pbrd/pbr_nht.h"
 #include "pbrd/pbr_map.h"
@@ -1458,15 +1459,24 @@ DEFPY  (pbr_policy,
 			if (old_pbrm && old_pbrm != pbrm)
 				pbr_map_interface_delete(old_pbrm, ifp);
 		}
-		snprintf(pbr_ifp->mapname, sizeof(pbr_ifp->mapname),
-			 "%s", mapname);
 
 		/*
 		 * So only reinstall if the old_pbrm and this pbrm are
-		 * different.
+		 * different. Only set mapname if we successfully add
+		 * the interface (or if the map doesn't exist yet for
+		 * deferred application).
 		 */
-		if (pbrm && pbrm != old_pbrm)
-			pbr_map_add_interface(pbrm, ifp);
+		if (pbrm && pbrm != old_pbrm) {
+			if (!pbr_map_add_interface(pbrm, ifp)) {
+				vty_out(vty,
+					"%% PBR map %s has reached maximum interface limit (%d)\n",
+					mapname, PBR_MAP_INTERFACE_MAX);
+				return CMD_WARNING;
+			}
+		}
+
+		snprintf(pbr_ifp->mapname, sizeof(pbr_ifp->mapname),
+			 "%s", mapname);
 	}
 
 	return CMD_SUCCESS;
@@ -1511,6 +1521,30 @@ pbrms_nexthop_group_write_individual_nexthop(
 	vty_out(vty, "\n");
 }
 
+static uint32_t count_installed_interfaces(const struct pbr_map_sequence *pbrms)
+{
+	uint32_t count = 0;
+	unsigned int bit;
+
+	if (!bf_is_inited(pbrms->installed))
+		return 0;
+
+	for (bit = bf_find_next_set_bit(pbrms->installed, 0);
+	     bit != WORD_MAX;
+	     bit = bf_find_next_set_bit(pbrms->installed, bit + 1))
+		count++;
+
+	return count;
+}
+
+static bool is_any_interface_installed(const struct pbr_map_sequence *pbrms)
+{
+	if (!bf_is_inited(pbrms->installed))
+		return false;
+
+	return bf_find_next_set_bit(pbrms->installed, 0) != WORD_MAX;
+}
+
 static void vty_show_pbrms(struct vty *vty,
 			   const struct pbr_map_sequence *pbrms, bool detail)
 {
@@ -1522,12 +1556,12 @@ static void vty_show_pbrms(struct vty *vty,
 	vty_out(vty, "    Seq: %u rule: %u\n", pbrms->seqno, pbrms->ruleno);
 
 	if (detail)
-		vty_out(vty, "        Installed: %" PRIu64 "(%u) Reason: %s\n",
-			pbrms->installed, pbrms->unique,
+		vty_out(vty, "        Installed: %u(%u) Reason: %s\n",
+			count_installed_interfaces(pbrms), pbrms->unique,
 			pbrms->reason ? rbuf : "Valid");
 	else
 		vty_out(vty, "        Installed: %s Reason: %s\n",
-			pbrms->installed ? "yes" : "no",
+			is_any_interface_installed(pbrms) ? "yes" : "no",
 			pbrms->reason ? rbuf : "Valid");
 
 	/* match clauses first */
@@ -1669,7 +1703,7 @@ static void vty_json_pbrms(json_object *j, struct vty *vty,
 	json_object_int_add(jpbrm, "sequenceNumber", pbrms->seqno);
 	json_object_int_add(jpbrm, "ruleNumber", pbrms->ruleno);
 	json_object_boolean_add(jpbrm, "vrfUnchanged", pbrms->vrf_unchanged);
-	json_object_boolean_add(jpbrm, "installed", pbrms->installed);
+	json_object_boolean_add(jpbrm, "installed", is_any_interface_installed(pbrms));
 	json_object_string_add(jpbrm, "installedReason",
 			       pbrms->reason ? rbuf : "Valid");
 

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -181,7 +181,6 @@ static int rule_notify_owner(ZAPI_CALLBACK_ARGS)
 	struct pbr_map_sequence *pbrms;
 	struct pbr_map_interface *pmi;
 	char ifname[IFNAMSIZ + 1];
-	uint64_t installed;
 
 	if (!zapi_rule_notify_decode(zclient->ibuf, &seqno, &priority, &unique,
 				     ifname, &note))
@@ -196,25 +195,38 @@ static int rule_notify_owner(ZAPI_CALLBACK_ARGS)
 		return 0;
 	}
 
-	installed = 1ULL << pmi->install_bit;
+	if (!pmi) {
+		DEBUGD(&pbr_dbg_zebra,
+		       "%s: No interface found for pbrms %u ifname %s",
+		       __func__, unique, ifname);
+		return 0;
+	}
+
+	if (!bf_is_inited(pbrms->installed) ||
+	    pmi->install_bit >= (pbrms->installed.m * WORD_SIZE)) {
+		DEBUGD(&pbr_dbg_zebra,
+		       "%s: Bitfield not ready or install_bit %u out of range for pbrms %u",
+		       __func__, pmi->install_bit, unique);
+		pbr_map_final_interface_deletion(pbrms->parent, pmi);
+		return 0;
+	}
 
 	switch (note) {
 	case ZAPI_RULE_FAIL_INSTALL:
-		pbrms->installed &= ~installed;
+		bf_release_index(pbrms->installed, pmi->install_bit);
 		break;
 	case ZAPI_RULE_INSTALLED:
-		pbrms->installed |= installed;
+		bf_set_bit(pbrms->installed, pmi->install_bit);
 		break;
 	case ZAPI_RULE_FAIL_REMOVE:
-		/* Don't change state on rule removal failure */
 		break;
 	case ZAPI_RULE_REMOVED:
-		pbrms->installed &= ~installed;
+		bf_release_index(pbrms->installed, pmi->install_bit);
 		break;
 	}
 
-	DEBUGD(&pbr_dbg_zebra, "%s: Received %s: %" PRIu64, __func__,
-	       zapi_rule_notify_owner2str(note), pbrms->installed);
+	DEBUGD(&pbr_dbg_zebra, "%s: Received %s for install_bit %u", __func__,
+	       zapi_rule_notify_owner2str(note), pmi->install_bit);
 
 	pbr_map_final_interface_deletion(pbrms->parent, pmi);
 
@@ -601,9 +613,11 @@ bool pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 {
 	struct pbr_map *pbrm = pbrms->parent;
 	struct stream *s;
-	uint64_t is_installed = (uint64_t)1 << pmi->install_bit;
+	bool is_installed = false;
 
-	is_installed &= pbrms->installed;
+	if (bf_is_inited(pbrms->installed) &&
+	    pmi->install_bit < (pbrms->installed.m * WORD_SIZE))
+		is_installed = bf_test_index(pbrms->installed, pmi->install_bit) != 0;
 
 	/*
 	 * If we are installed and asked to do so again and the config

--- a/tests/topotests/pbr_interface_limit/__init__.py
+++ b/tests/topotests/pbr_interface_limit/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: ISC

--- a/tests/topotests/pbr_interface_limit/r1/pbrd.conf
+++ b/tests/topotests/pbr_interface_limit/r1/pbrd.conf
@@ -1,0 +1,10 @@
+!
+! PBR configuration for interface limit test
+!
+nexthop-group TESTGRP
+  nexthop 192.168.1.1
+!
+pbr-map TESTMAP seq 10
+  match dst-ip 10.0.0.0/8
+  set nexthop-group TESTGRP
+!

--- a/tests/topotests/pbr_interface_limit/r1/zebra.conf
+++ b/tests/topotests/pbr_interface_limit/r1/zebra.conf
@@ -1,0 +1,4 @@
+!
+! Zebra configuration for PBR interface limit test
+! Interfaces r1-eth0 through r1-eth519 are created by topology
+!

--- a/tests/topotests/pbr_interface_limit/test_pbr_interface_limit.py
+++ b/tests/topotests/pbr_interface_limit/test_pbr_interface_limit.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_pbr_interface_limit.py
+#
+# Copyright (c) 2026 FRRouting
+#
+# Test to verify PBR map interface limit (PBR_MAP_INTERFACE_MAX = 512)
+#
+
+"""
+test_pbr_interface_limit.py: Test PBR interface limit handling
+
+This test verifies that:
+1. PBR maps can handle up to 512 interfaces
+2. When the 512 interface limit is reached, a warning is logged
+3. Additional interfaces beyond 512 are rejected gracefully
+"""
+
+import os
+import sys
+import pytest
+import json
+import platform
+import re
+from functools import partial
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.pbrd]
+
+# PBR_MAP_INTERFACE_MAX as defined in pbr_map.h
+PBR_MAP_INTERFACE_MAX = 512
+
+# Number of interfaces to test with (slightly over the limit)
+TEST_INTERFACE_COUNT = 520
+
+
+def build_topo(tgen):
+    """Build function - create topology with multiple switches/interfaces"""
+    # Create router
+    tgen.add_router("r1")
+
+    # Create switches that will create interfaces r1-eth0, r1-eth1, etc.
+    # We need more than 512 to test the limit
+    for switchn in range(1, TEST_INTERFACE_COUNT + 1):
+        switch = tgen.add_switch("sw{}".format(switchn))
+        switch.add_link(tgen.gears["r1"])
+
+
+def setup_module(module):
+    """Setup topology"""
+    # Skip test on 32bit platforms (limited memory)
+    if sys.maxsize <= 2**32:
+        pytest.skip("skipped because of limited memory on 32bit platforms")
+
+    tgen = Topogen(build_topo, module.__name__)
+    tgen.start_topology()
+
+    krel = platform.release()
+    if topotest.version_cmp(krel, "4.10") < 0:
+        tgen.errors = "Newer kernel than 4.9 needed for pbr tests"
+        pytest.skip(tgen.errors)
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_config(
+            TopoRouter.RD_ZEBRA, os.path.join(CWD, "{}/zebra.conf".format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_PBRD, os.path.join(CWD, "{}/pbrd.conf".format(rname))
+        )
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    """Teardown the pytest environment"""
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_converge_protocols():
+    """Wait for protocol convergence"""
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    topotest.sleep(5, "Waiting for PBR convergence")
+
+
+def test_pbr_interface_limit():
+    """
+    Test PBR interface limit handling.
+    
+    This test verifies:
+    1. We can add interfaces up to the PBR_MAP_INTERFACE_MAX limit
+    2. When the limit is reached, a warning is logged
+    3. Interfaces beyond the limit are rejected
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears["r1"]
+    
+    logger.info("=" * 60)
+    logger.info("Testing PBR interface limit (max = {})".format(PBR_MAP_INTERFACE_MAX))
+    logger.info("=" * 60)
+
+    # Apply PBR policy to all interfaces via vtysh
+    logger.info("Applying PBR policy TESTMAP to {} interfaces".format(TEST_INTERFACE_COUNT))
+    
+    # Build vtysh commands in batches for efficiency
+    batch_size = 100
+    for batch_start in range(0, TEST_INTERFACE_COUNT, batch_size):
+        batch_end = min(batch_start + batch_size, TEST_INTERFACE_COUNT)
+        
+        cmds = ["configure terminal"]
+        for i in range(batch_start, batch_end):
+            ifname = "r1-eth{}".format(i)
+            cmds.append("interface {}".format(ifname))
+            cmds.append("pbr-policy TESTMAP")
+        cmds.append("end")
+        
+        router.vtysh_multicmd("\n".join(cmds))
+
+    # Wait for pbrd to process all interfaces
+    topotest.sleep(5, "Waiting for PBR to process interfaces")
+
+    # Check the number of interfaces in the PBR map
+    def get_interface_count():
+        output = router.vtysh_cmd("show pbr interface json")
+        try:
+            data = json.loads(output)
+            if data and isinstance(data, list):
+                count = sum(1 for entry in data if entry.get("policy") == "TESTMAP")
+                return count
+        except Exception as e:
+            logger.error("Failed to parse JSON: {}".format(e))
+        return 0
+
+    def check_interface_count(expected_min):
+        count = get_interface_count()
+        if count >= expected_min:
+            return None
+        return "Expected at least {} interfaces, got {}".format(expected_min, count)
+
+    # Wait for interfaces to be registered (up to 60 seconds)
+    test_func = partial(check_interface_count, PBR_MAP_INTERFACE_MAX)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    
+    iface_count = get_interface_count()
+    logger.info("Interfaces in PBR map TESTMAP: {}".format(iface_count))
+
+    # Debug output
+    output = router.vtysh_cmd("show pbr interface")
+    logger.info("show pbr interface (first 3000 chars):\n{}".format(output[:3000]))
+
+    # The count should be capped at PBR_MAP_INTERFACE_MAX
+    assert iface_count <= PBR_MAP_INTERFACE_MAX, \
+        "Interface count {} exceeds maximum {}".format(iface_count, PBR_MAP_INTERFACE_MAX)
+    
+    assert iface_count == PBR_MAP_INTERFACE_MAX, \
+        "Expected {} interfaces, got {}".format(PBR_MAP_INTERFACE_MAX, iface_count)
+
+    # Verify warning was logged
+    logger.info("Checking for limit warning in pbrd log")
+    log_output = router.run("cat pbrd.log 2>/dev/null | grep -i 'maximum interface limit' || echo ''")
+    logger.info("Log search result: {}".format(log_output[:500]))
+    
+    assert "maximum interface limit" in log_output.lower(), \
+        "Expected warning about interface limit not found in log"
+    
+    logger.info("SUCCESS: Interface limit is enforced correctly")
+    logger.info("=" * 60)
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Replace uint64_t bitmask with dynamic bitfield_t in pbr_map_sequence to track rule installation state

Fix:
- Change installed field from uint64_t to bitfield_t
- Update all bit operations to use bitfield library functions
- Initialize bitfield with 512-bit capacity
- updated vtysh to parse bitf for installed count

Ticket:#
Signed-off-by: Rajesh Varatharaj <rvaratharaj@nvidia.com>