### PR TITLE
ospfd: Fix route map not applied for default routes

### DIFF
--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -363,7 +363,7 @@ static void ospf_asbr_redist_update_timer(struct event *event)
 						       LSA_REFRESH_FORCE);
 	}
 
-	ospf_external_lsa_refresh_default(ospf);
+	ospf_external_lsa_refresh_default(ospf, NULL);
 }
 
 void ospf_schedule_asbr_redist_update(struct ospf *ospf)

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2591,7 +2591,7 @@ void ospf_external_lsa_flush(struct ospf *ospf, uint8_t type,
 		zlog_debug("%s: stop", __func__);
 }
 
-void ospf_external_lsa_refresh_default(struct ospf *ospf)
+void ospf_external_lsa_refresh_default(struct ospf *ospf, struct external_info *default_ei)
 {
 	struct prefix_ipv4 p;
 	struct external_info *ei;
@@ -2601,7 +2601,11 @@ void ospf_external_lsa_refresh_default(struct ospf *ospf)
 	p.prefixlen = 0;
 	p.prefix.s_addr = INADDR_ANY;
 
-	ei = ospf_default_external_info(ospf);
+	if (default_ei)
+		ei = default_ei;
+	else
+		ei = ospf_default_external_info(ospf);
+
 	lsa = ospf_external_info_find_lsa(ospf, &p);
 
 	if (ei && lsa) {
@@ -2699,6 +2703,13 @@ struct ospf_lsa *ospf_external_lsa_refresh(struct ospf *ospf,
 {
 	struct ospf_lsa *new;
 	int changed = 0;
+	struct external_info *default_ei;
+
+	if (is_default_prefix4(&ei->p)) {
+		default_ei = ospf_external_info_lookup(ospf, DEFAULT_ROUTE, ospf->instance, &ei->p);
+		if (default_ei)
+			ospf_external_info_apply_default_routemap(ospf, ei, default_ei);
+	}
 
 	/* Check the AS-external-LSA should be originated. */
 	if (!is_aggr)

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -305,7 +305,7 @@ extern uint32_t get_metric(uint8_t *metric);
 extern void ospf_lsa_maxage_walker(struct event *event);
 extern struct ospf_lsa *ospf_lsa_refresh(struct ospf *ospf, struct ospf_lsa *lsa);
 
-extern void ospf_external_lsa_refresh_default(struct ospf *ospf);
+extern void ospf_external_lsa_refresh_default(struct ospf *ospf, struct external_info *default_ei);
 
 extern void ospf_external_lsa_refresh_type(struct ospf *ospf, uint8_t type, uint8_t instance,
 					   int force);

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -928,7 +928,7 @@ int ospf_redistribute_default_set(struct ospf *ospf, int originate, int mtype,
 				   metric_type(ospf, DEFAULT_ROUTE, 0),
 				   metric_value(ospf, DEFAULT_ROUTE, 0));
 
-		ospf_external_lsa_refresh_default(ospf);
+		ospf_external_lsa_refresh_default(ospf, NULL);
 		return CMD_SUCCESS;
 	}
 
@@ -991,7 +991,7 @@ int ospf_redistribute_default_set(struct ospf *ospf, int originate, int mtype,
 			   metric_type(ospf, DEFAULT_ROUTE, 0),
 			   metric_value(ospf, DEFAULT_ROUTE, 0));
 
-	ospf_external_lsa_refresh_default(ospf);
+	ospf_external_lsa_refresh_default(ospf, NULL);
 	ospf_asbr_status_update(ospf, ospf->redistribute);
 	return CMD_SUCCESS;
 }
@@ -1077,8 +1077,6 @@ static bool ospf_external_lsa_default_routemap_apply(struct ospf *ospf,
 {
 	struct external_info *default_ei;
 	struct prefix_ipv4 p;
-	struct ospf_lsa *lsa;
-	int ret;
 
 	p.family = AF_INET;
 	p.prefixlen = 0;
@@ -1098,65 +1096,7 @@ static bool ospf_external_lsa_default_routemap_apply(struct ospf *ospf,
 			   &ei->p.prefix, ospf_vrf_id_to_name(ospf->vrf_id),
 			   cmd);
 
-	ret = ospf_external_info_apply_default_routemap(ospf, ei, default_ei);
-
-	/* If deny then nothing to be done both in add and del case. */
-	if (!ret) {
-		if (IS_DEBUG_OSPF_DEFAULT_INFO)
-			zlog_debug("Default originte routemap deny for ei: %pI4(%s)",
-				   &ei->p.prefix,
-				   ospf_vrf_id_to_name(ospf->vrf_id));
-		return false;
-	}
-
-	/* Get the default LSA. */
-	lsa = ospf_external_info_find_lsa(ospf, &p);
-
-	/* If this is add route and permit then ooriginate default. */
-	if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD) {
-		/* If permit and default already advertise then return. */
-		if (lsa && !IS_LSA_MAXAGE(lsa)) {
-			if (IS_DEBUG_OSPF_DEFAULT_INFO)
-				zlog_debug("Default lsa already originated(%s)",
-					   ospf_vrf_id_to_name(ospf->vrf_id));
-			return true;
-		}
-
-		if (IS_DEBUG_OSPF_DEFAULT_INFO)
-			zlog_debug("Originating/Refreshing default lsa(%s)",
-				   ospf_vrf_id_to_name(ospf->vrf_id));
-
-		if (lsa && IS_LSA_MAXAGE(lsa))
-			/* Refresh lsa.*/
-			ospf_external_lsa_refresh(ospf, lsa, default_ei, true,
-						  false);
-		else
-			/* If permit and default not advertised then advertise.
-			 */
-			ospf_external_lsa_originate(ospf, default_ei);
-
-	} else if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_DEL) {
-		/* If deny and lsa is not originated then nothing to be done.*/
-		if (!lsa) {
-			if (IS_DEBUG_OSPF_DEFAULT_INFO)
-				zlog_debug("Default lsa not originated, not flushing(%s)",
-					   ospf_vrf_id_to_name(ospf->vrf_id));
-			return true;
-		}
-
-		if (IS_DEBUG_OSPF_DEFAULT_INFO)
-			zlog_debug("Running default route-map again as ei: %pI4(%s) deleted",
-				   &ei->p.prefix,
-				   ospf_vrf_id_to_name(ospf->vrf_id));
-		/*
-		 * if this route delete was permitted then we need to check
-		 * there are any other external info which can still trigger
-		 * default route origination else flush it.
-		 */
-		event_add_event(master,
-				ospf_external_lsa_default_routemap_timer, ospf,
-				0, &ospf->t_default_routemap_timer);
-	}
+	ospf_external_info_apply_default_routemap(ospf, ei, default_ei);
 
 	return true;
 }
@@ -1383,7 +1323,13 @@ static int ospf_zebra_read_route(ZAPI_CALLBACK_ARGS)
 			if (is_default_prefix4(&p)) {
 				if (ei)
 					ei->default_always = false;
-				ospf_external_lsa_refresh_default(ospf);
+				/*
+				 * Check if default-information originate is
+				 * with some routemap prefix/access list match.
+				 */
+				ospf_external_lsa_default_routemap_apply(ospf, ei, cmd);
+
+				ospf_external_lsa_refresh_default(ospf, ei);
 			} else {
 				struct ospf_external_aggr_rt *aggr;
 				struct as_external_lsa *al;
@@ -1475,12 +1421,6 @@ static int ospf_zebra_read_route(ZAPI_CALLBACK_ARGS)
 			}
 		}
 
-		/*
-		 * Check if default-information originate is
-		 * with some routemap prefix/access list match.
-		 */
-		ospf_external_lsa_default_routemap_apply(ospf, ei, cmd);
-
 	} else { /* if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_DEL) */
 		struct ospf_external_aggr_rt *aggr;
 
@@ -1511,7 +1451,7 @@ static int ospf_zebra_read_route(ZAPI_CALLBACK_ARGS)
 						  p);
 
 			if (is_default_prefix4(&p))
-				ospf_external_lsa_refresh_default(ospf);
+				ospf_external_lsa_refresh_default(ospf, NULL);
 			else
 				ospf_external_lsa_flush(ospf, rt_type, &p,
 							ifindex /*, nexthop */);
@@ -1737,7 +1677,7 @@ static void ospf_distribute_list_update_timer(struct event *event)
 		}
 	}
 	if (default_refresh)
-		ospf_external_lsa_refresh_default(ospf);
+		ospf_external_lsa_refresh_default(ospf, NULL);
 }
 
 /* Update distribute-list and set timer to apply access-list. */


### PR DESCRIPTION
For default routes the method ospf_external_lsa_default_routemap_apply() was called after ospf_external_lsa_refresh-default(). As far as I understand the code this has led to the latter method propagating the default route without any route-map applied and the former method did not do anything afterwards, because the route was just freshly propagated already.

Also those two methods have some of their logic in common, so I think it would not work to just call them both after each other. I removed some of the code from ospf_external_lsa_default_routemap_apply() so that it does basically only what the name suggests. But I'm not sure if that code might be missing in other cases now.

Additionally I also added the default_routemap_apply call to the method ospf_external_lsa_refresh_default(), because without this change it still would not work if the default-route was added before the OSPF-daemon started.