### PR TITLE
yang: Imported module ietf-yang-types not used at frr-isisd.yang

### DIFF
--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -4,10 +4,6 @@ module frr-isisd {
   namespace "http://frrouting.org/yang/isisd";
   prefix frr-isisd;
 
-  import ietf-yang-types {
-    prefix yang;
-  }
-
   import ietf-inet-types {
     prefix inet;
   }


### PR DESCRIPTION
warning: imported module "ietf-yang-types" not used