### PR TITLE
tests: add a retry timeout to verify_admin_distance

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -3973,6 +3973,7 @@ def verify_fib_routes(tgen, addr_type, dut, input_dict, next_hop=None, protocol=
     return True
 
 
+@retry(retry_timeout=30)
 def verify_admin_distance_for_static_routes(tgen, input_dict):
     """
     API to verify admin distance for static routes as defined in input_dict/


### PR DESCRIPTION
Add a retry timeout to the verify_admin_distance topojson helper; give a little time for a config change to make its way through to zebra.

