### PR TITLE
Fix Batch Clearing to not skip path_info's

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -808,7 +808,9 @@ static void bgp_nht_ifp_table_handle(struct bgp *bgp,
 	}
 
 	frr_each (bgp_nexthop_cache, table, bnc) {
-		if (bnc->ifindex_ipv6_ll != ifp->ifindex)
+		if ((bnc->nexthop_num == 1 && bnc->nexthop &&
+		     bnc->nexthop->ifindex != ifp->ifindex) &&
+		    (bnc->ifindex_ipv6_ll != ifp->ifindex))
 			continue;
 
 		bnc->last_update = monotime(NULL);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7295,21 +7295,14 @@ static struct bgp_dest *clearing_dest_helper(struct bgp_table *table,
 						   inner_p ? " inner" : "", buf);
 				}
 
-				dest = bgp_node_match(table, pfx);
+				dest = bgp_node_get(table, pfx);
 			} else {
 				/* Normal prefix: look for next prefix */
 				if (BGP_DEBUG(neighbor_events, NEIGHBOR_EVENTS_DETAIL))
 					zlog_debug("%s: using RESUME%s prefix %pFX", __func__,
 						   inner_p ? " inner" : "", pfx);
 
-				dest = bgp_node_match(table, pfx);
-				if (dest) {
-					/* if 'dest' matches or precedes the 'last' prefix
-					 * visited, then advance.
-					 */
-					while (dest && (prefix_cmp(&(dest->rn->p), pfx) <= 0))
-						dest = bgp_route_next(dest);
-				}
+				dest = bgp_node_get(table, pfx);
 			}
 		}
 	}

--- a/tests/topotests/bgp_batch_clearing/r1/frr.conf
+++ b/tests/topotests/bgp_batch_clearing/r1/frr.conf
@@ -1,0 +1,27 @@
+hostname r1
+debug bgp neighbor-events 10.255.0.2
+debug bgp neighbor-events
+!
+interface lo
+ ip address 10.255.0.1/32
+!
+interface r1-eth0
+ ip address 10.0.0.1/30
+ no shutdown
+!
+ip route 10.255.0.2/32 10.0.0.2
+!
+router bgp 65001
+ bgp fast-convergence
+ bgp router-id 10.255.0.1
+ timers bgp 3 10
+ no bgp ebgp-requires-policy
+ neighbor 10.255.0.2 remote-as 65002
+ neighbor 10.255.0.2 ebgp-multihop 2
+ neighbor 10.255.0.2 update-source lo
+ !
+ address-family ipv4 unicast
+  neighbor 10.255.0.2 activate
+ exit-address-family
+!
+line vty

--- a/tests/topotests/bgp_batch_clearing/r2/frr.conf
+++ b/tests/topotests/bgp_batch_clearing/r2/frr.conf
@@ -1,0 +1,31 @@
+hostname r2
+!
+interface lo
+ ip address 10.255.0.2/32
+!
+interface r2-eth0
+ ip address 10.0.0.2/30
+ no shutdown
+!
+ip route 10.255.0.1/32 10.0.0.1
+!
+router bgp 65002
+ bgp fast-convergence
+ bgp router-id 10.255.0.2
+ timers bgp 3 10
+ no bgp ebgp-requires-policy
+ neighbor 10.255.0.1 remote-as 65001
+ neighbor 10.255.0.1 ebgp-multihop 2
+ neighbor 10.255.0.1 update-source lo
+ !
+ address-family ipv4 unicast
+  redistribute static
+  redistribute connected
+  neighbor 10.255.0.1 activate
+  neighbor 10.255.0.1 route-map SET-NH-ETH0 out
+ exit-address-family
+!
+route-map SET-NH-ETH0 permit 10
+ set ip next-hop 10.0.0.2
+!
+line vty

--- a/tests/topotests/bgp_batch_clearing/test_bgp_batch_clearing.py
+++ b/tests/topotests/bgp_batch_clearing/test_bgp_batch_clearing.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# test_bgp_batch_clearing.py
+# Copyright (c) 2026 by Nvidia Inc.
+#                       Donald Sharp
+#
+"""
+Test eBGP route batch clearing in bgp.  r1 is connected
+to r2 over ebgp.  r2 is generating a large number of
+overlapping routes that are learned on r1.  Then
+we turn off a interface.  This causes r1 to attempt
+to batch clear the problem.  The previous commit in
+this series fixes this issue as that without this
+change the test will fail.
+
+"""
+
+import functools
+import ipaddress
+import json
+import os
+import sys
+import pytest
+
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+
+pytestmark = [pytest.mark.bgpd, pytest.mark.staticd]
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+
+def build_topo(tgen):
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+
+def setup_module(module):
+    "Setup topology"
+    tgen = Topogen(build_topo, module.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr.conf".format(rname)),
+            [
+                (TopoRouter.RD_ZEBRA, None),
+                (TopoRouter.RD_BGP, None),
+            ],
+        )
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _bgp_neighbor_established(router, neighbor):
+    output = json.loads(router.vtysh_cmd(f"show bgp ipv4 neighbors {neighbor} json"))
+    state = output.get(neighbor, {}).get("bgpState")
+    if state != "Established":
+        return {"bgpState": state}
+    return None
+
+
+def _r1_has_received_prefixes():
+    r1 = get_topogen().gears["r1"]
+    output = json.loads(r1.vtysh_cmd("show bgp ipv4 neighbors 10.255.0.2 json"))
+    afi = (
+        output.get("10.255.0.2", {})
+        .get("addressFamilyInfo", {})
+        .get("ipv4Unicast", {})
+    )
+    if afi.get("acceptedPrefixCounter", 0) < 100000:
+        return {"acceptedPrefixCounter": afi.get("acceptedPrefixCounter")}
+    return None
+
+
+def _build_static_routes_config(path, total_routes=100000):
+    # Build a deep, overlapping prefix tree with routes at multiple levels.
+    prefixes = []
+
+    def add_prefix(prefix):
+        prefixes.append(str(prefix))
+
+    # Broad overlapping parents
+    for parent in [
+        "100.0.0.0/8",
+        "100.64.0.0/10",
+        "172.16.0.0/12",
+        "172.16.0.0/13",
+        "172.16.0.0/14",
+        "172.16.0.0/15",
+        "172.16.0.0/16",
+        "198.18.0.0/15",
+        "198.18.0.0/16",
+        "198.19.0.0/16",
+        "198.18.0.0/17",
+        "198.18.128.0/17",
+    ]:
+        add_prefix(parent)
+
+    tree_specs = [
+        (
+            ipaddress.ip_network("100.64.0.0/10"),
+            [(11, 2), (12, 4), (14, 32), (16, 128), (20, 1024)],
+        ),
+        (
+            ipaddress.ip_network("172.16.0.0/12"),
+            [(13, 2), (14, 8), (16, 64), (18, 256), (20, 1024)],
+        ),
+        (
+            ipaddress.ip_network("198.18.0.0/15"),
+            [(16, 2), (17, 8), (18, 32), (20, 256), (22, 1024)],
+        ),
+    ]
+
+    def add_balanced_subnets(base, new_prefix, limit):
+        # Mix from the start and end to fill both left and right branches.
+        nets = list(base.subnets(new_prefix=new_prefix))
+        left = 0
+        right = len(nets) - 1
+        added = 0
+        while left <= right and added < limit:
+            add_prefix(nets[left])
+            added += 1
+            if added >= limit or left == right:
+                break
+            add_prefix(nets[right])
+            added += 1
+            left += 1
+            right -= 1
+
+    for base, levels in tree_specs:
+        for plen, limit in levels:
+            add_balanced_subnets(base, plen, limit)
+
+    # Add 50 /24s that match multiple upper layers (deepest layer).
+    deepest_base = ipaddress.ip_network("172.16.0.0/12")
+    add_balanced_subnets(deepest_base, 24, 50)
+
+    # De-dup while keeping order.
+    ordered = []
+    seen = set()
+    for prefix in prefixes:
+        if prefix not in seen:
+            ordered.append(prefix)
+            seen.add(prefix)
+
+    # Fill remaining routes with /32s inside 198.18.0.0/15.
+    remaining = total_routes - len(ordered)
+    if remaining < 0:
+        ordered = ordered[:total_routes]
+        remaining = 0
+
+    base = ipaddress.ip_network("198.18.0.0/15")
+    base_int = int(base.network_address)
+    for i in range(remaining):
+        addr = ipaddress.ip_address(base_int + i)
+        ordered.append(f"{addr}/32")
+
+    with open(path, "w", encoding="utf-8") as cfg:
+        cfg.write("configure terminal\n")
+        for prefix in ordered:
+            cfg.write(f"ip route {prefix} blackhole\n")
+        cfg.write("end\n")
+
+
+def _bgp_neighbor_cleared(router, neighbor):
+    output = json.loads(router.vtysh_cmd(f"show bgp ipv4 neighbors {neighbor} json"))
+    state = output.get(neighbor, {}).get("bgpState")
+    if state == "Established":
+        return {"bgpState": state}
+    return None
+
+
+def _r1_bgp_table_empty():
+    r1 = get_topogen().gears["r1"]
+    output = json.loads(r1.vtysh_cmd("show bgp ipv4 unicast json"))
+    routes = output.get("routes", {})
+    if routes:
+        return {"routes": len(routes)}
+    return None
+
+
+def test_ebgp_loopback_convergence():
+    "Validate eBGP session and received prefixes from r2"
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    test_func = functools.partial(_bgp_neighbor_established, r1, "10.255.0.2")
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, f"r1 neighbor not Established: {result}"
+
+    test_func = functools.partial(_bgp_neighbor_established, r2, "10.255.0.1")
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, f"r2 neighbor not Established: {result}"
+
+    routes_cfg = os.path.join("/tmp", "r2_blackhole_routes.conf")
+    _build_static_routes_config(routes_cfg)
+    r2.cmd(f"vtysh -f {routes_cfg}")
+
+    test_func = functools.partial(_r1_has_received_prefixes)
+    _, result = topotest.run_and_expect(test_func, None, count=240, wait=1)
+    assert result is None, f"r1 did not receive 100k routes from r2: {result}"
+
+
+def test_link_down_clears_routes():
+    "Shutdown link between r1 and r2 and ensure routes are removed"
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+
+    r1.cmd("ip link set r1-eth0 down")
+
+    test_func = functools.partial(_bgp_neighbor_cleared, r1, "10.255.0.2")
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, f"r1 neighbor did not clear: {result}"
+
+    test_func = functools.partial(_bgp_neighbor_cleared, r2, "10.255.0.1")
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, f"r2 neighbor did not clear: {result}"
+
+    test_func = functools.partial(_r1_bgp_table_empty)
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assert result is None, f"r1 still has BGP routes: {result}"
+
+    r1.cmd("ip link set r1-eth0 up")
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
    The batch clearing code is using a bgp_node_match in clearing_dest_helper
    to grab the next node we want to work on.  Unfortunately this is not necessarily
    the node that was last used and it allows for skipping nodes and leaving
    some of the path_info's to stick around.  Modify the code to use bgp_node_get
    and to not increment to the next one, since walk_batch_table_helper is
    walking to the next node automatically.

    Here is an example of the problem:

    r1# show bgp ipv4 uni
    BGP table version is 200004, local router ID is 10.255.0.1, vrf id 0
    Default local pref 100, local AS 65001
    Status codes:  s suppressed, d damped, h history, u unsorted, * valid, > best, = multipath,
                   i internal, r RIB-failure, S Stale, R Removed
    Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
    Origin codes:  i - IGP, e - EGP, ? - incomplete
    RPKI validation codes: V valid, I invalid, N Not found

    Network          Next Hop            Metric LocPrf Weight Path
     =  198.18.156.0/22  10.0.0.2                 0             0 65002 ?
     =  198.18.172.0/22  10.0.0.2                 0             0 65002 ?
     =  198.18.188.0/22  10.0.0.2                 0             0 65002 ?

    Displayed 3 routes and 3 total paths
    r1# show bgp ipv4 uni summ
    BGP router identifier 10.255.0.1, local AS number 65001 VRF default vrf-id 0
    BGP table version 200004
    RIB entries 1997, using 296 KiB of memory
    Peers 1, using 24 KiB of memory

    Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
    10.255.0.2      4      65002        39        38        0    0    0 00:00:29       Active        0 N/A

    Total number of neighbors 1
    r1#

    This problem especially happens if you have a large set of routes in
    a table that have multiple levels of overlapping prefixes.
    
    See the individual commits for how this problem was approached.
    