### PR TITLE
zebra: Expand the EVPN help string in `debug zebra evpn..`

### DIFF
--- a/zebra/debug.c
+++ b/zebra/debug.c
@@ -468,7 +468,7 @@ DEFPY (debug_zebra_evpn_mh,
        NO_STR
        DEBUG_STR
        "Zebra configuration\n"
-       "EVPN\n"
+       "Debug zebra EVPN events\n"
        "Multihoming\n"
        "Ethernet Segment Debugging\n"
        "MAC Debugging\n"


### PR DESCRIPTION
The help string of `EVPN` was not really that helpful. Let's make it more helpful.