### PR TITLE
tests: comment out debugs in bgp_batch_clearing topotest

### DIFF
--- a/tests/topotests/bgp_batch_clearing/r1/frr.conf
+++ b/tests/topotests/bgp_batch_clearing/r1/frr.conf
@@ -1,6 +1,6 @@
 hostname r1
-debug bgp neighbor-events 10.255.0.2
-debug bgp neighbor-events
+!debug bgp neighbor-events 10.255.0.2
+!debug bgp neighbor-events
 !
 interface lo
  ip address 10.255.0.1/32


### PR DESCRIPTION
Comment out debugs in the topotest configs, missed these during review.