### PR TITLE
ripngd: remove dead assignment in ripng_ecmp_delete - Coverity

### DIFF
--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -624,7 +624,6 @@ struct ripng_info *ripng_ecmp_delete(struct ripng *ripng,
 			/* The ADD message implies the update. */
 			ripng_zebra_ipv6_add(ripng, rp);
 		ripng_info_free(rinfo);
-		rinfo = NULL;
 	} else {
 		assert(rinfo == ripng_info_list_first(list));
 


### PR DESCRIPTION
CID 1668677: rinfo is reassigned before use, remove useless NULL assignment.
Fixes: c880b6367ec6 ("ripngd: add ECMP support")