### PR TITLE
bgpd: Fix multipath decision when multipath is 1

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3584,6 +3584,14 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,
 			old_select ? old_select->peer->host : "NONE");
 	}
 
+	if (new_select) {
+		if (debug)
+			zlog_debug("%pBD(%s): %s is the bestpath, add to the multipath list", dest,
+				   bgp->name_pretty, path_buf);
+		SET_FLAG(new_select->flags, BGP_PATH_MULTIPATH_NEW);
+		num_candidates++;
+	}
+
 	if (do_mpath && new_select) {
 		bool first_reason = true;
 		enum bgp_path_selection_reason ignore;
@@ -3593,16 +3601,8 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_dest *dest,
 				bgp_path_info_path_with_addpath_rx_str(
 					pi, path_buf, sizeof(path_buf));
 
-			if (pi == new_select) {
-				if (debug)
-					zlog_debug(
-						"%pBD(%s): %s is the bestpath, add to the multipath list",
-						dest, bgp->name_pretty,
-						path_buf);
-				SET_FLAG(pi->flags, BGP_PATH_MULTIPATH_NEW);
-				num_candidates++;
+			if (pi == new_select)
 				continue;
-			}
 
 			if (BGP_PATH_HOLDDOWN(pi))
 				continue;


### PR DESCRIPTION
The current code when you set `maximum-paths 1` is doing this when you take away a neighbor:

2026-01-15 16:06:14.194 [NTFY] bgpd: [M7Q4P-46WDR] vty[47]@(config-router)# neighbor 10.0.1.101 shutdown 2026-01-15 16:06:14.206 [DEBG] bgpd: [V64FH-G6883] 10.204.9.0/24 queued into sub-queue Other Route 2026-01-15 16:06:14.256 [DEBG] bgpd: [ZAPXS-9754G] 10.204.9.0/24 dequeued from sub-queue Other Route 2026-01-15 16:06:14.256 [DEBG] bgpd: [V7N4G-NR80B] bgp_process_main_one: p=10.204.9.0/24(0x5d6c6ade9d10)(VRF default) afi=IPv4, safi=unicast start 2026-01-15 16:06:14.256 [DEBG] bgpd: [PAFVN-67W5Y] bgp_best_selection: 10.204.9.0/24(0x5d6c6ade9d10)(VRF default) pi 0x5d6c6ade9db0 from 10.0.1.101 in holddown 2026-01-15 16:06:14.256 [DEBG] bgpd: [N6CTF-2RSKS] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): After path selection, newbest is path 10.0.1.102 oldbest was 10.0.1.101 2026-01-15 16:06:14.256 [DEBG] bgpd: [Z6Q7S-1JJ2S] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): starting mpath update, newbest 10.0.1.102 num candidates 0 old-mpath-count 1 old-cum-bw 0 maxpaths set 1 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.1.102 old_mpath: 0 new_mpath: 0, Nexthop 10.0.1.102 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.1.103 old_mpath: 0 new_mpath: 0, Nexthop 10.0.1.103 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.1.104 old_mpath: 0 new_mpath: 0, Nexthop 10.0.1.104 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.1.105 old_mpath: 0 new_mpath: 0, Nexthop 10.0.1.105 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.2.106 old_mpath: 0 new_mpath: 0, Nexthop 10.0.2.106 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.2.107 old_mpath: 0 new_mpath: 0, Nexthop 10.0.2.107 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.2.108 old_mpath: 0 new_mpath: 0, Nexthop 10.0.2.108 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.2.109 old_mpath: 0 new_mpath: 0, Nexthop 10.0.2.109 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.2.110 old_mpath: 0 new_mpath: 0, Nexthop 10.0.2.110 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.3.111 old_mpath: 0 new_mpath: 0, Nexthop 10.0.3.111 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.3.112 old_mpath: 0 new_mpath: 0, Nexthop 10.0.3.112 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.3.113 old_mpath: 0 new_mpath: 0, Nexthop 10.0.3.113 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.3.114 old_mpath: 0 new_mpath: 0, Nexthop 10.0.3.114 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.3.115 old_mpath: 0 new_mpath: 0, Nexthop 10.0.3.115 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.4.116 old_mpath: 0 new_mpath: 0, Nexthop 10.0.4.116 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.4.117 old_mpath: 0 new_mpath: 0, Nexthop 10.0.4.117 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.4.118 old_mpath: 0 new_mpath: 0, Nexthop 10.0.4.118 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.4.119 old_mpath: 0 new_mpath: 0, Nexthop 10.0.4.119 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.4.120 old_mpath: 0 new_mpath: 0, Nexthop 10.0.4.120 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): Candidate 10.0.1.101 old_mpath: 1 new_mpath: 0, Nexthop 10.0.1.101 current mpath count: 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [S7KWG-REZFR] 10.204.9.0/24(0x5d6c6ade9d10)(VRF default): New mpath count (incl newbest) 0 mpath-change YES all_paths_lb 1 cum_bw 0 2026-01-15 16:06:14.256 [DEBG] bgpd: [GVV1N-MH1P0] bgp_process_main_one: p=10.204.9.0/24(0x5d6c6ade9d10)(VRF default) afi=IPv4, safi=unicast, old_select=0x5d6c6ade9db0, new_select=0x5d6c6ad9fef0 2026-01-15 16:06:14.256 [DEBG] bgpd: [ZJBDG-KD5FM] bgp_process_main_one: 10.204.9.0/24(0x5d6c6ade9d10) setting SELECTED flag r1(config-router)#

Effectively when bgp_path_info_mpath_update is called it is attempting to use the BGP_PATH_MULTIPATH_NEW as a determinator of doing less work on a pi.  But since multipath is hard code to 1, the BGP_PATH_MULTIPATH_NEW is not being set on the new_select at all.  We end up calling bgp_path_info_mpath_update and having to iterate over everything, instead of being allowed to bail out.  Modify the code to always set BGP_PATH_MULTIPATH_NEW and the num_candidates to allow proper function.

New behavior:

r1(config-router)# neighbor 10.0.1.101 shutdown
2026-01-15 16:11:46.800 [NTFY] bgpd: [M7Q4P-46WDR] vty[47]@(config-router)# neighbor 10.0.1.101 shutdown 2026-01-15 16:11:46.810 [DEBG] bgpd: [V64FH-G6883] 10.204.9.0/24 queued into sub-queue Other Route 2026-01-15 16:11:46.861 [DEBG] bgpd: [ZAPXS-9754G] 10.204.9.0/24 dequeued from sub-queue Other Route 2026-01-15 16:11:46.861 [DEBG] bgpd: [V7N4G-NR80B] bgp_process_main_one: p=10.204.9.0/24(0x5ec44fb0ad10)(VRF default) afi=IPv4, safi=unicast start 2026-01-15 16:11:46.861 [DEBG] bgpd: [PAFVN-67W5Y] bgp_best_selection: 10.204.9.0/24(0x5ec44fb0ad10)(VRF default) pi 0x5ec44fb0adb0 from 10.0.1.101 in holddown 2026-01-15 16:11:46.861 [DEBG] bgpd: [N6CTF-2RSKS] 10.204.9.0/24(0x5ec44fb0ad10)(VRF default): After path selection, newbest is path 10.0.1.102 oldbest was 10.0.1.101 2026-01-15 16:11:46.861 [DEBG] bgpd: [ZF63D-VT50R] 10.204.9.0/24(0x5ec44fb0ad10)(VRF default): path 10.0.1.102 is the bestpath, add to the multipath list 2026-01-15 16:11:46.861 [DEBG] bgpd: [Z6Q7S-1JJ2S] 10.204.9.0/24(0x5ec44fb0ad10)(VRF default): starting mpath update, newbest 10.0.1.102 num candidates 1 old-mpath-count 1 old-cum-bw 0 maxpaths set 1 2026-01-15 16:11:46.861 [DEBG] bgpd: [GD7KP-7ZCB3] 10.204.9.0/24(0x5ec44fb0ad10)(VRF default): Candidate 10.0.1.102 old_mpath: 0 new_mpath: 1, Nexthop 10.0.1.102 current mpath count: 0 2026-01-15 16:11:46.861 [DEBG] bgpd: [RSD08-KBQD4] 10.204.9.0/24(0x5ec44fb0ad10): add mpath path 10.0.1.102 nexthop 10.0.1.102, cur count 1 cum_bw: 0 all_paths_lb: 0 2026-01-15 16:11:46.861 [DEBG] bgpd: [XBB06-669QN] 10.204.9.0/24(0x5ec44fb0ad10)(VRF default): Mpath count 1 is equal to maximum paths allowed, finished comparison for MPATHS 2026-01-15 16:11:46.861 [DEBG] bgpd: [S7KWG-REZFR] 10.204.9.0/24(0x5ec44fb0ad10)(VRF default): New mpath count (incl newbest) 1 mpath-change YES all_paths_lb 0 cum_bw 0 2026-01-15 16:11:46.861 [DEBG] bgpd: [GVV1N-MH1P0] bgp_process_main_one: p=10.204.9.0/24(0x5ec44fb0ad10)(VRF default) afi=IPv4, safi=unicast, old_select=0x5ec44fb0adb0, new_select=0x5ec44fac1720 2026-01-15 16:11:46.861 [DEBG] bgpd: [ZJBDG-KD5FM] bgp_process_main_one: 10.204.9.0/24(0x5ec44fb0ad10) setting SELECTED flag

Granted this is a unlikely case but it's always good to get bestpath rolling faster.