### PR TITLE
zebra: EVPN check l3vni vxlan intf exist in rmac install

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1299,6 +1299,13 @@ static int zl3vni_rmac_install(struct zebra_l3vni *zl3vni,
 	    || !(CHECK_FLAG(zrmac->flags, ZEBRA_MAC_REMOTE_RMAC)))
 		return 0;
 
+	if (!zl3vni->vxlan_if) {
+		if (IS_ZEBRA_DEBUG_VXLAN)
+			zlog_debug("RMAC %pEA on L3-VNI %u install in dplane failed as vni has no vxlan_if",
+				   &zrmac->macaddr, zl3vni->vni);
+		return -1;
+	}
+
 	zif = zl3vni->vxlan_if->info;
 	if (!zif)
 		return -1;


### PR DESCRIPTION
In event of Vxlan interface down, there is a possibility, L3VNI is cleaned up and its associated routes are triggered for cleanup, at the time of uninstall of RMAC, the L3VNI associated vxlan_if is likely cleaned up.
Check the VxLAN interface existance before proceeding.

```
    (zl3vni=zl3vni@entry=0x561983436860,
    zrmac=zrmac@entry=0x561985002ba0)
        at ../zebra/zebra_vxlan.c:1332
    (vtep_ip=0x56198559d228, zrmac=0x561985002ba0,
        zl3vni=0x561983436860) at ../zebra/zebra_vxlan.c:1563
    vtep_ip=0x56198559d228, host_prefix=<optimized out>)
    at ../zebra/zebra_vxlan.c:2829
    ../zebra/zebra_rib.c:2849

(gdb) p *zl3vni
$2 = {vni = 5000015, vrf_id = 2281, filter = 0, vid = 0, bridge_if = 0x0, local_vtep_ip = {ipa_type = IPADDR_NONE,
    ip = {addr = 0 '\000', addrbytes = '\000' <repeats 15 times>, _v4_addr = {s_addr = 0}, _v6_addr = {__in6_u = {
          __u6_addr8 = '\000' <repeats 15 times>, __u6_addr16 = {0, 0, 0, 0, 0, 0, 0, 0}, __u6_addr32 = {0, 0, 0,
            0}}}}}, vxlan_if = 0x0, svi_if = 0x0, mac_vlan_if = 0x0, l2vnis = 0x5619834368f0,

(gdb) p zl3vni->vxlan_if
$1 = (struct interface *) 0x0
```

FRR log and the time of zebra crash around L3VNI delete:

```
2026/01/13 08:32:57 ZEBRA: [R43YF-2MKZ3] Send L3VNI DEL 5000007 VRF vrf_7 to bgp
2026/01/13 08:32:57 ZEBRA: [WVRMN-YEC5Q] Del L3-VNI 5000012 intf vxlan99(1731)
2026/01/13 08:32:57 ZEBRA: [R43YF-2MKZ3] Send L3VNI DEL 5000012 VRF vrf_12 to bgp
2026/01/13 08:32:57 ZEBRA: [WVRMN-YEC5Q] Del L3-VNI 5000006 intf vxlan99(1731)
2026/01/13 08:32:57 ZEBRA: [R43YF-2MKZ3] Send L3VNI DEL 5000006 VRF vrf_6 to bgp
ZEBRA: Received signal 11 at 1768285977 (si_addr 0xd0, PC 0x561975562257); aborting...
ZEBRA: /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0(zlog_backtrace_sigsafe+0x6f) [0x7f7c7ccc55ff]
ZEBRA: /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0(zlog_signal+0xf5) [0x7f7c7ccc5805]
ZEBRA: /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0(+0x100331) [0x7f7c7cd00331]
ZEBRA: /lib/x86_64-linux-gnu/libc.so.6(+0x3c050) [0x7f7c7c920050]
ZEBRA: /usr/lib/frr/zebra(+0x172257) [0x561975562257]
ZEBRA: /usr/lib/frr/zebra(zebra_vxlan_evpn_vrf_route_del+0x3ee) [0x561975565efe]
ZEBRA: /usr/lib/frr/zebra(+0x142b16) [0x561975532b16]
ZEBRA: /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0(work_queue_run+0x73) [0x7f7c7cd1f983]
ZEBRA: /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0(event_call+0x81) [0x7f7c7cd12ff1]
ZEBRA: /usr/lib/x86_64-linux-gnu/frr/libfrr.so.0(frr_run+0xc0) [0x7f7c7ccbcd80]
ZEBRA: /usr/lib/frr/zebra(main+0x484) [0x5619754a94e4]
ZEBRA: /lib/x86_64-linux-gnu/libc.so.6(+0x2724a) [0x7f7c7c90b24a]
ZEBRA: /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x85) [0x7f7c7c90b305]
ZEBRA: /usr/lib/frr/zebra(_start+0x21) [0x5619754ac3d1]
ZEBRA: in thread work_queue_run scheduled from ../lib/workqueue.c:129 work_queue_schedule()
2026/01/13 08:32:57 ZEBRA: [KZXKD-3PRAJ] l3vni 5000015 del nexthop: rmac 44:38:39:de:ed:01 vtep-ip 28.0.0.1
2026/01/13 08:32:57 ZEBRA: [YNEQ2-A8RGG] L3VNI 5000015 Remote VTEP nh change(28.0.0.1 -> ::ffff:28.0.0.1) for RMAC 44:38:39:de:ed:01
```

Link event trigger the L3VNI delete (around the same timestamp) 
```
2026-01-13T08:32:57.740556+02:00 leaf2 switchd[178821]: sync_base.c:784 [event] vxlan99: ifindex 1731, admin down 2026-01-13T08:32:57.741225+02:00 leaf2 switchd[178821]: sync_base.c:793 [event] vxlan99: ifindex 1731, oper down 2026-01-13T08:32:57.993428+02:00 leaf2 switchd[178821]: sync_base.c:784 [event] bridge_port: vxlan99: ifindex 1731, admin down 2026-01-13T08:32:57.993497+02:00 leaf2 switchd[178821]: sync_base.c:793 [event] bridge_port: vxlan99: ifindex 1731, oper down 2026-01-13T08:32:57.993559+02:00 leaf2 switchd[178821]: sync_base.c:793 [event] br_l3vni: ifindex 1732, oper down
```

Signed-off-by: Chirag Shah <chirag@nvidia.com>