### PR TITLE
lib, vtysh: Fix `log timestamp precision` to actually be carried through

### DIFF
--- a/lib/log_nb.c
+++ b/lib/log_nb.c
@@ -544,6 +544,8 @@ static int logging_timestamp_precision_modify(struct nb_cb_modify_args *args)
 	val = yang_dnode_get_uint8(args->dnode, NULL);
 	zt_file.ts_subsec = val;
 	zlog_file_set_other(&zt_file);
+	zt_file_cmdline.ts_subsec = val;
+	zlog_file_set_other(&zt_file_cmdline);
 	if (!stdout_journald_in_use) {
 		zt_stdout_file.ts_subsec = val;
 		zlog_file_set_other(&zt_stdout_file);

--- a/lib/zlog_live.c
+++ b/lib/zlog_live.c
@@ -12,6 +12,8 @@
 #include "memory.h"
 #include "frrcu.h"
 #include "zlog.h"
+#include "log.h"
+#include "log_vty.h"
 #include "printfrr.h"
 #include "network.h"
 
@@ -95,6 +97,7 @@ static void zlog_live(struct zlog_target *zt, struct zlog_msg *msgs[],
 						      memory_order_relaxed);
 		hdr->prio = prio;
 		hdr->flags = 0;
+		hdr->ts_subsec = zt_file.ts_subsec;
 		hdr->textlen = textlen;
 		hdr->texthdrlen = texthdrlen;
 		hdr->n_argpos = n_argpos;
@@ -164,6 +167,7 @@ static void zlog_live_sigsafe(struct zlog_target *zt, const char *text,
 	hdr->ts_sec = ts.tv_sec;
 	hdr->ts_nsec = ts.tv_nsec;
 	hdr->prio = LOG_CRIT;
+	hdr->ts_subsec = zt_file.ts_subsec;
 	hdr->textlen = len;
 
 	iov->iov_base = (char *)hdr;

--- a/lib/zlog_live.h
+++ b/lib/zlog_live.h
@@ -44,6 +44,10 @@ struct zlog_live_hdr {
 	/* EC value */
 	uint32_t ec;
 
+	/* timestamp sub-second precision (digits, 0-9) */
+	uint8_t ts_subsec;
+	uint8_t _pad[3];
+
 	/* recorded printf formatting argument positions (variable length) */
 	uint32_t n_argpos;
 	struct fmt_outpos argpos[0];


### PR DESCRIPTION
This commit fixes both:

a) When using the daemon cli: `--log file:XXX` the log timestamp precision when changed on the cli was not respected.

b) When using `terminal monitor` in vtysh, the set log timestamp precision was not being respected at all.

Modify both places to actually work with timestamp precision.