### PR TITLE
zebra: Fix tentative address handling to respect dplane data model

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -248,6 +248,7 @@ struct dplane_intf_info {
 #define DPLANE_INTF_HAS_DEST    DPLANE_INTF_CONNECTED
 #define DPLANE_INTF_HAS_LABEL   (1 << 4)
 #define DPLANE_INTF_NOPREFIXROUTE (1 << 5)
+#define DPLANE_INTF_TENTATIVE   (1 << 6) /* IPv6 address is tentative (DAD) */
 
 	/* Interface address/prefix */
 	struct prefix prefix;
@@ -2685,6 +2686,20 @@ void dplane_ctx_intf_set_broadcast(struct zebra_dplane_ctx *ctx)
 	DPLANE_CTX_VALID(ctx);
 
 	ctx->u.intf.flags |= DPLANE_INTF_BROADCAST;
+}
+
+bool dplane_ctx_intf_is_tentative(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return (ctx->u.intf.flags & DPLANE_INTF_TENTATIVE);
+}
+
+void dplane_ctx_intf_set_tentative(struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	ctx->u.intf.flags |= DPLANE_INTF_TENTATIVE;
 }
 
 const struct prefix *dplane_ctx_get_intf_addr(

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -705,6 +705,8 @@ bool dplane_ctx_intf_is_noprefixroute(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_intf_set_noprefixroute(struct zebra_dplane_ctx *ctx);
 bool dplane_ctx_intf_is_broadcast(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_intf_set_broadcast(struct zebra_dplane_ctx *ctx);
+bool dplane_ctx_intf_is_tentative(const struct zebra_dplane_ctx *ctx);
+void dplane_ctx_intf_set_tentative(struct zebra_dplane_ctx *ctx);
 const struct prefix *dplane_ctx_get_intf_addr(
 	const struct zebra_dplane_ctx *ctx);
 const struct in6_addr *


### PR DESCRIPTION
The original commit accessed interface pointers in the dplane pthread via if_lookup_by_index_per_ns(), breaking the data model. Fix by passing IFA_F_TENTATIVE through the dplane context and moving the interface operative check to zebra_if_addr_update_ctx() in the master pthread.

Fixes: 2e06e5b729e4 ("zebra: Allow tentative IPv6 addresses on DOWN interfaces")
Ref: https://github.com/FRRouting/frr/pull/20526

Signed-off-by: Rajesh Varatharaj <rvaratharaj@nvidia.com>