### PR TITLE
zebra: evpn encap use re vrf_id to extract l3vni

### DIFF
--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -146,7 +146,9 @@ struct nexthop {
 
 	/* Encapsulation information. */
 	enum nh_encap_type nh_encap_type;
-	vni_t nh_encap_vni;
+	union {
+		vni_t vni;
+	} nh_encap;
 	/* use for LWT tunnel src field */
 	struct ipaddr nh_encap_src_ip;
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2248,7 +2248,7 @@ static int netlink_route_nexthop_encap(bool fpm, struct nlmsghdr *n,
 		if (!nest)
 			return false;
 
-		if (!nl_attr_put32(n, nlen, 0 /* VXLAN_VNI */, nh->nh_encap_vni))
+		if (!nl_attr_put32(n, nlen, 0 /* VXLAN_VNI */, nh->nh_encap.vni))
 			return false;
 		nl_attr_nest_end(n, nest);
 		break;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3856,7 +3856,7 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 		zl3vni = zl3vni_from_vrf(re->vrf_id);
 		if (zl3vni && is_l3vni_oper_up(zl3vni)) {
 			nexthop->nh_encap_type = NET_VXLAN;
-			nexthop->nh_encap_vni = zl3vni->vni;
+			nexthop->nh_encap.vni = zl3vni->vni;
 			nexthop->nh_encap_src_ip = zl3vni->local_vtep_ip;
 			if (IS_ZEBRA_DEBUG_DPLANE_DETAIL)
 				zlog_debug("%s vni %u tunnel_ip %pIA", __func__, zl3vni->vni,


### PR DESCRIPTION
nexthop vrf_id does not help fetch l3vni,
instead use the route's re vrf_id.

Ticket: #4605303