### PR TITLE
zebra: EVPN install vtep ip as src in dvni tunnel encap route

### DIFF
--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -146,9 +146,9 @@ struct nexthop {
 
 	/* Encapsulation information. */
 	enum nh_encap_type nh_encap_type;
-	union {
-		vni_t vni;
-	} nh_encap;
+	vni_t nh_encap_vni;
+	/* use for LWT tunnel src field */
+	struct ipaddr nh_encap_src_ip;
 
 	/* EVPN router's MAC.
 	 * Don't support multiple RMAC from the same VTEP yet, so it's not

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1730,6 +1730,13 @@ static bool _netlink_nexthop_encode_dvni_label(const struct nexthop *nexthop,
 		return false;
 	}
 
+	/* Set tunnel source IP */
+	if (IS_IPADDR_V4(&nexthop->nh_encap_src_ip)) {
+		if (!nl_attr_put(nlmsg, buflen, LWTUNNEL_IP_SRC,
+				 &nexthop->nh_encap_src_ip.ipaddr_v4, 4))
+			return false;
+	}
+
 	return true;
 }
 
@@ -2241,7 +2248,7 @@ static int netlink_route_nexthop_encap(bool fpm, struct nlmsghdr *n,
 		if (!nest)
 			return false;
 
-		if (!nl_attr_put32(n, nlen, 0 /* VXLAN_VNI */, nh->nh_encap.vni))
+		if (!nl_attr_put32(n, nlen, 0 /* VXLAN_VNI */, nh->nh_encap_vni))
 			return false;
 		nl_attr_nest_end(n, nest);
 		break;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3841,7 +3841,11 @@ int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
 		zl3vni = zl3vni_from_vrf(nexthop->vrf_id);
 		if (zl3vni && is_l3vni_oper_up(zl3vni)) {
 			nexthop->nh_encap_type = NET_VXLAN;
-			nexthop->nh_encap.vni = zl3vni->vni;
+			nexthop->nh_encap_vni = zl3vni->vni;
+			nexthop->nh_encap_src_ip = zl3vni->local_vtep_ip;
+			if (IS_ZEBRA_DEBUG_DPLANE_DETAIL)
+				zlog_debug("%s vni %u tunnel_ip %pIA", __func__, zl3vni->vni,
+					   &nexthop->nh_encap_src_ip);
 		}
 	}
 


### PR DESCRIPTION
For CPU bound dvni based route outer IP is chosen as outgoing interface IP, which may not be recognized by the destination VTEP and gets dropped. Rather choose the source VTEP IP as outer source IP which is recognized by the remote VTEPs.

Ticket: #4605303

9.4.8.0/24  encap ip id 8892 src 0.0.0.0 dst 27.0.0.5 ttl 0 tos 0 via
  27.0.0.5 dev vxlan99 proto bgp metric 20 onlink

After:
src field is filled
9.4.8.0/24  encap ip id 8892 src 27.0.0.9 dst 27.0.0.5 ttl 0 tos 0 via
  27.0.0.5 dev vxlan99 proto bgp metric 20 onlink