### PR TITLE
zebra: Fix static route invalid, when interface up/down flap

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2805,6 +2805,7 @@ static void process_subq_early_route_delete(struct zebra_early_route *ere)
 		if (re->instance != ere->re->instance)
 			continue;
 		if (CHECK_FLAG(re->flags, ZEBRA_FLAG_RR_USE_DISTANCE) &&
+		    !ere->fromkernel &&
 		    ere->re->distance != re->distance)
 			continue;
 


### PR DESCRIPTION
By default, the administrative distance of a static route is 1. However, when a route is removed from the kernel, the distance is 0.

When zebra receives a RTM_DELROUTE message from the kernel for such a route, it attempts to locate the associated route entry (re) for cleanup or invalidation. If the route lookup fails — zebra cannot find the corresponding route entry (re) in the relevant function. This can lead to the static route being left in an invalid state.

show ipv6 route vrf all static
Codes: K - kernel route, C - connected, S - static, R - RIPng,
O - OSPFv3, I - IS-IS, B - BGP, N - NHRP, T - Table,
A - Babel, F - PBR, f - OpenFabric,
> - selected route, * - FIB route, q - queued, r - rejected, b - backup
t - trapped, o - offload failure

VRF Default:
S>* abcd:100::1/128 [1/0] is directly connected, lo, weight 1, 1d05h56m
S>* abcd:200::1/128 [1/0] is directly connected, lo, weight 1, 1d05h56m
S>* cc1e:1:2::3/128 [1/0] is directly connected, lo, weight 1, 1d05h56m

VRF VRF102v118:
S> abcd:100::/32 [1/0] via cc1e:102:119::119, Ethernet102, weight 1, 1d05h55m
S>* abcd:200::/32 [1/0] via cc1e:101:118::101, Ethernet118, weight 1, 1d05h55m
S>* cc1e:101:118::118/128 [1/0] is directly connected, lo (vrf Default), weight 1, 1d05h55m
S>* cc1e:102:119::102/128 [1/0] is directly connected, lo (vrf Default), weight 1, 1d05h55m

After:
show ipv6 route vrf all static
Codes: K - kernel route, C - connected, S - static, R - RIPng,
O - OSPFv3, I - IS-IS, B - BGP, N - NHRP, T - Table,
A - Babel, F - PBR, f - OpenFabric,
> - selected route, * - FIB route, q - queued, r - rejected, b - backup
t - trapped, o - offload failure

VRF Default:
S>* abcd:100::1/128 [1/0] is directly connected, lo, weight 1, 00:12:40
S>* abcd:200::1/128 [1/0] is directly connected, lo, weight 1, 00:12:40
S>* cc1e:1:2::3/128 [1/0] is directly connected, lo, weight 1, 00:12:40

VRF VRF102v118:
S>* abcd:100::/32 [1/0] via cc1e:102:119::119, Ethernet102, weight 1, 00:11:10
S>* abcd:200::/32 [1/0] via cc1e:101:118::101, Ethernet118, weight 1, 00:11:10
S>* cc1e:101:118::118/128 [1/0] is directly connected, lo (vrf Default), weight 1, 00:11:19
S>* cc1e:102:119::102/128 [1/0] is directly connected, lo (vrf Default), weight 1, 00:11:19