### PR TITLE
bgpd: remove assert in batch-clearing

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -9449,8 +9449,9 @@ static void bgp_clearing_batch_end(struct bgp *bgp)
 		return;
 
 	cinfo = bgp_clearing_info_first(&bgp->clearing_list);
+	if (!cinfo)
+		return; /* Nothing to do */
 
-	assert(cinfo != NULL);
 	assert(CHECK_FLAG(cinfo->flags, BGP_CLEARING_INFO_FLAG_OPEN));
 
 	/* Batch is closed */


### PR DESCRIPTION
No need to assert in the batch-clearing handler if there are no batches - just return.
I'm adding this to the 10.6 milestone too.