### PR TITLE
Separate sg rpt sg ifchannels and add ability to set a override-interval and a test.

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -424,6 +424,11 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
    Modify the PIM assert override interval in milliseconds on this
    interface (defaults to 3000).
 
+.. clicmd:: ip pim override-interval (0-65535)
+
+   Modify the PIM LAN prune delay override interval in milliseconds on this
+   interface (defaults to 2500).
+
 .. clicmd:: ip pim [sm | dm | sm-dm]
 
    Enable pim on this interface. pim will use this interface to form pim neighbors,

--- a/doc/user/pimv6.rst
+++ b/doc/user/pimv6.rst
@@ -167,6 +167,11 @@ PIMv6 Router
    Modify the PIM assert override interval in milliseconds on this
    interface (defaults to 3000).
 
+.. clicmd:: ipv6 pim override-interval (0-65535)
+
+   Modify the PIM LAN prune delay override interval in milliseconds on this
+   interface (defaults to 2500).
+
 .. clicmd:: keep-alive-timer (1-65535)
    :daemon: pimv6
 

--- a/gdb/pim.txt
+++ b/gdb/pim.txt
@@ -228,6 +228,137 @@ Example usage:
 To also dump the JP aggregation details, use dump_neighbor_jp_agg.
 end
 
+define dump_pim_neighbor
+  set $_neigh = (struct pim_neighbor *)$arg0
+  
+  if $_neigh == 0
+    printf "Neighbor pointer is NULL\n"
+  else
+    printf "========== PIM Neighbor %p ==========\n", $_neigh
+    
+    # Source address
+    printf "Source Address: "
+    if sizeof($_neigh->source_addr) == 4
+      # IPv4
+      set $_na = (unsigned char *)&$_neigh->source_addr
+      printf "%u.%u.%u.%u", $_na[0], $_na[1], $_na[2], $_na[3]
+    else
+      # IPv6
+      dump_s6_addr &$_neigh->source_addr
+    end
+    printf "\n"
+    
+    # Interface
+    if $_neigh->interface != 0
+      printf "Interface:      %s\n", $_neigh->interface->name
+    else
+      printf "Interface:      NULL\n"
+    end
+    
+    # Creation timestamp
+    printf "Creation time:  %ld\n", $_neigh->creation
+    
+    # Hello options (bit flags)
+    printf "Hello options:  0x%08x ", $_neigh->hello_options
+    if $_neigh->hello_options & 0x1
+      printf "HOLDTIME "
+    end
+    if $_neigh->hello_options & 0x2
+      printf "LAN_PRUNE_DELAY "
+    end
+    if $_neigh->hello_options & 0x4
+      printf "DR_PRIORITY "
+    end
+    if $_neigh->hello_options & 0x8
+      printf "GENERATION_ID "
+    end
+    if $_neigh->hello_options & 0x10
+      printf "ADDRESS_LIST "
+    end
+    printf "\n"
+    
+    # Timers and parameters
+    printf "Holdtime:       %u sec\n", $_neigh->holdtime
+    printf "Propagation delay: %u msec\n", $_neigh->propagation_delay_msec
+    printf "Override interval: %u msec\n", $_neigh->override_interval_msec
+    printf "DR priority:    %u\n", $_neigh->dr_priority
+    printf "Generation ID:  0x%08x\n", $_neigh->generation_id
+    
+    # Prefix list (secondary addresses)
+    if $_neigh->prefix_list != 0
+      printf "Secondary addresses: count=%u\n", $_neigh->prefix_list->count
+      if $_neigh->prefix_list->count > 0
+        set $_pnode = $_neigh->prefix_list->head
+        set $_pcount = 0
+        while $_pnode != 0 && $_pcount < 10
+          set $_prefix = (struct prefix *)$_pnode->data
+          printf "  [%u] family=%u prefixlen=%u\n", $_pcount, $_prefix->family, $_prefix->prefixlen
+          set $_pnode = $_pnode->next
+          set $_pcount = $_pcount + 1
+        end
+        if $_neigh->prefix_list->count > 10
+          printf "  ... (%u more)\n", $_neigh->prefix_list->count - 10
+        end
+      end
+    else
+      printf "Secondary addresses: NULL\n"
+    end
+    
+    # Timers
+    printf "\nTimers:\n"
+    if $_neigh->t_expire_timer != 0
+      printf "  Expire timer: RUNNING (expires at %ld.%06ld)\n", $_neigh->t_expire_timer->u.sands.tv_sec, $_neigh->t_expire_timer->u.sands.tv_usec
+    else
+      printf "  Expire timer: stopped\n"
+    end
+    if $_neigh->jp_timer != 0
+      printf "  JP timer:     RUNNING (expires at %ld.%06ld)\n", $_neigh->jp_timer->u.sands.tv_sec, $_neigh->jp_timer->u.sands.tv_usec
+    else
+      printf "  JP timer:     stopped\n"
+    end
+    
+    # JP Aggregation list
+    if $_neigh->upstream_jp_agg != 0
+      printf "\nJP Aggregation: count=%u\n", $_neigh->upstream_jp_agg->count
+    else
+      printf "\nJP Aggregation: NULL\n"
+    end
+    
+    # BFD session
+    if $_neigh->bfd_session != 0
+      printf "BFD session:    %p (configured)\n", $_neigh->bfd_session
+    else
+      printf "BFD session:    NULL\n"
+    end
+    
+    printf "========================================\n"
+  end
+end
+document dump_pim_neighbor
+Dump detailed information about a PIM neighbor structure.
+
+This displays comprehensive information including:
+- Source address and interface
+- Creation timestamp
+- Hello options (decoded bit flags)
+- Holdtime, propagation delay, override interval
+- DR priority and generation ID
+- Secondary address list
+- Timer states
+- JP aggregation list count
+- BFD session status
+
+Arguments:
+  (struct pim_neighbor *) pointer to the neighbor structure
+
+Example usage:
+  (gdb) dump_pim_neighbor neigh
+  (gdb) p pim_ifp->pim_neighbor_list->head->data
+  (gdb) dump_pim_neighbor $
+  
+To also dump the JP aggregation details, use dump_neighbor_jp_agg.
+end
+
 define dump_neighbor_jp_agg
   set $_neigh = (struct pim_neighbor *)$arg0
   

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -226,6 +226,23 @@ DEFPY_YANG(if_ipv6_pim_assert_override_interval,
 	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH, FRR_PIM_AF_XPATH_VAL);
 }
 
+DEFPY_YANG(if_ipv6_pim_override_interval,
+           if_ipv6_pim_override_interval_cmd,
+           "[no] ipv6 pim override-interval ![(0-65535)$oi]",
+           NO_STR
+           IPV6_STR
+           PIM_STR
+           "LAN prune delay override interval\n"
+           "Milliseconds, default 2500\n")
+{
+	if (no)
+		nb_cli_enqueue_change(vty, "./override-interval", NB_OP_DESTROY, NULL);
+	else
+		nb_cli_enqueue_change(vty, "./override-interval", NB_OP_MODIFY, oi_str);
+
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH, FRR_PIM_AF_XPATH_VAL);
+}
+
 DEFPY (pim6_spt_switchover_infinity,
        pim6_spt_switchover_infinity_cmd,
        "spt-switchover infinity-and-beyond",
@@ -3156,6 +3173,7 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &no_interface_ipv6_mld_limits_cmd);
 	install_element(INTERFACE_NODE, &if_ipv6_pim_assert_interval_cmd);
 	install_element(INTERFACE_NODE, &if_ipv6_pim_assert_override_interval_cmd);
+	install_element(INTERFACE_NODE, &if_ipv6_pim_override_interval_cmd);
 
 	install_element(INTERFACE_NODE, &interface_ipv6_pim_use_source_cmd);
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6133,6 +6133,23 @@ DEFPY_YANG(interface_ip_pim_assert_override, interface_ip_pim_assert_override_cm
 	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH, FRR_PIM_AF_XPATH_VAL);
 }
 
+DEFPY_YANG(interface_ip_pim_override_interval,
+           interface_ip_pim_override_interval_cmd,
+           "[no] ip pim override-interval ![(0-65535)$oi]",
+           NO_STR
+           IP_STR
+           "pim multicast routing\n"
+           "LAN prune delay override interval\n"
+           "Milliseconds, default 2500\n")
+{
+	if (no)
+		nb_cli_enqueue_change(vty, "./override-interval", NB_OP_DESTROY, NULL);
+	else
+		nb_cli_enqueue_change(vty, "./override-interval", NB_OP_MODIFY, oi_str);
+
+	return nb_cli_apply_changes(vty, FRR_PIM_INTERFACE_XPATH, FRR_PIM_AF_XPATH_VAL);
+}
+
 DEFUN (debug_igmp,
        debug_igmp_cmd,
        "debug igmp",
@@ -9480,6 +9497,7 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &interface_no_ip_pim_neighbor_prefix_list_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_pim_assert_interval_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_pim_assert_override_cmd);
+	install_element(INTERFACE_NODE, &interface_ip_pim_override_interval_cmd);
 
 	// Static mroutes NEB
 	install_element(INTERFACE_NODE, &interface_ip_mroute_cmd);

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1766,10 +1766,9 @@ static void pim_show_join_helper(struct pim_interface *pim_ifp,
 		json_object_string_add(json_row, "upTime", uptime);
 		json_object_string_add(json_row, "expire", expire);
 		json_object_string_add(json_row, "prune", prune);
-		json_object_string_add(
-			json_row, "channelJoinName",
-			pim_ifchannel_ifjoin_name(ch->ifjoin_state, ch->flags));
-		if (PIM_IF_FLAG_TEST_S_G_RPT(ch->flags))
+		json_object_string_add(json_row, "channelJoinName",
+				       pim_ifchannel_ifjoin_name(ch->ifjoin_state, ch->sg_rpt));
+		if (pim_ifchannel_is_sg_rpt(ch))
 			json_object_int_add(json_row, "sgRpt", 1);
 		if (PIM_IF_FLAG_TEST_PROTO_PIM(ch->flags))
 			json_object_int_add(json_row, "protocolPim", 1);
@@ -1788,11 +1787,10 @@ static void pim_show_join_helper(struct pim_interface *pim_ifp,
 			json_object_object_addf(json_grp, json_row, "%pPAs",
 						&ch->sg.src);
 	} else {
-		ttable_add_row(
-			tt, "%s|%pPAs|%pPAs|%pPAs|%s|%s|%s|%s",
-			ch->interface->name, &ifaddr, &ch->sg.src, &ch->sg.grp,
-			pim_ifchannel_ifjoin_name(ch->ifjoin_state, ch->flags),
-			uptime, expire, prune);
+		ttable_add_row(tt, "%s|%pPAs|%pPAs|%pPAs|%s|%s|%s|%s", ch->interface->name,
+			       &ifaddr, &ch->sg.src, &ch->sg.grp,
+			       pim_ifchannel_ifjoin_name(ch->ifjoin_state, ch->sg_rpt), uptime,
+			       expire, prune);
 	}
 }
 

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -1779,13 +1779,24 @@ static void pim_show_join_helper(struct pim_interface *pim_ifp,
 		json_object_object_get_ex(json_iface, ch_grp_str, &json_grp);
 		if (!json_grp) {
 			json_grp = json_object_new_object();
-			json_object_object_addf(json_grp, json_row, "%pPAs",
-						&ch->sg.src);
 			json_object_object_addf(json_iface, json_grp, "%pPAs",
 						&ch->sg.grp);
-		} else
-			json_object_object_addf(json_grp, json_row, "%pPAs",
-						&ch->sg.src);
+		}
+
+		/* Generate a unique key for this channel entry.
+		 * If this is an (S,G,rpt) channel and a regular (S,G) already exists,
+		 * append ",S,Grpt" suffix to distinguish them.
+		 */
+		char src_key[PIM_ADDRSTRLEN + 16];
+
+		if (pim_ifchannel_is_sg_rpt(ch)) {
+			/* For S,G,rpt entries, append ",S,Grpt" suffix */
+			snprintfrr(src_key, sizeof(src_key), "%pPAs,S,Grpt", &ch->sg.src);
+		} else {
+			snprintfrr(src_key, sizeof(src_key), "%pPAs", &ch->sg.src);
+		}
+
+		json_object_object_add(json_grp, src_key, json_row);
 	} else {
 		ttable_add_row(tt, "%s|%pPAs|%pPAs|%pPAs|%s|%s|%s|%s", ch->interface->name,
 			       &ifaddr, &ch->sg.src, &ch->sg.grp,

--- a/pimd/pim_dm.c
+++ b/pimd/pim_dm.c
@@ -236,7 +236,7 @@ void pim_dm_recv_graft(struct interface *ifp, pim_sgaddr *sg)
 	struct pim_upstream *up;
 	struct pim_interface *pim_ifp = ifp->info;
 	pim_addr group_addr = sg->grp;
-	struct pim_ifchannel *ch;
+	struct pim_ifchannel *ch, *throwaway;
 
 	if (!pim_ifp || !pim_ifp->pim_enable)
 		return;
@@ -256,7 +256,7 @@ void pim_dm_recv_graft(struct interface *ifp, pim_sgaddr *sg)
 		oil_if_set(up->channel_oil, pim_ifp->mroute_vif_index, 1);
 		pim_upstream_mroute_update(up->channel_oil, __func__);
 
-		ch = pim_ifchannel_find(ifp, sg);
+		pim_ifchannel_find(ifp, sg, &ch, &throwaway);
 
 		if (ch) {
 			PIM_UPSTREAM_DM_UNSET_PRUNE(ch->flags);
@@ -283,7 +283,7 @@ void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16
 	struct pim_upstream *up;
 	struct pim_interface *pim_ifp;
 	pim_addr group_addr = sg->grp;
-	struct pim_ifchannel *ch;
+	struct pim_ifchannel *ch, *throwaway;
 
 	struct interface *ifp2 = NULL;
 	struct pim_interface *pim_ifp2;
@@ -332,7 +332,7 @@ void pim_dm_recv_prune(struct interface *ifp, struct pim_neighbor *neigh, uint16
 			prune_timer_start(up);
 		}
 
-		ch = pim_ifchannel_find(ifp, sg);
+		pim_ifchannel_find(ifp, sg, &ch, &throwaway);
 		if (!ch)
 			ch = pim_ifchannel_add(ifp, sg, source_flags,
 					       PIM_UPSTREAM_DM_FLAG_MASK_PRUNE);

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -259,19 +259,15 @@ void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,
 	struct pim_ifchannel *child_ch;
 
 	if (PIM_DEBUG_PIM_EVENTS)
-		zlog_debug(
-			"PIM_IFCHANNEL(%s): %s is switching from %s to %s",
-			ch->interface->name, ch->sg_str,
-			pim_ifchannel_ifjoin_name(ch->ifjoin_state, ch->flags),
-			pim_ifchannel_ifjoin_name(new_state, 0));
+		zlog_debug("PIM_IFCHANNEL(%s): %s is switching from %s to %s", ch->interface->name,
+			   ch->sg_str, pim_ifchannel_ifjoin_name(ch->ifjoin_state, ch->sg_rpt),
+			   pim_ifchannel_ifjoin_name(new_state, false));
 
 
 	if (old_state == new_state) {
 		if (PIM_DEBUG_PIM_EVENTS) {
-			zlog_debug(
-				"%s called by %s: non-transition on state %d (%s)",
-				__func__, caller, new_state,
-				pim_ifchannel_ifjoin_name(new_state, 0));
+			zlog_debug("%s called by %s: non-transition on state %d (%s)", __func__,
+				   caller, new_state, pim_ifchannel_ifjoin_name(new_state, false));
 		}
 		return;
 	}
@@ -372,34 +368,33 @@ void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,
 	}
 }
 
-const char *pim_ifchannel_ifjoin_name(enum pim_ifjoin_state ifjoin_state,
-				      int flags)
+const char *pim_ifchannel_ifjoin_name(enum pim_ifjoin_state ifjoin_state, bool sg_rpt)
 {
 	switch (ifjoin_state) {
 	case PIM_IFJOIN_NOINFO:
-		if (PIM_IF_FLAG_TEST_S_G_RPT(flags))
+		if (sg_rpt)
 			return "SGRpt(NI)";
 		else
 			return "NOINFO";
 	case PIM_IFJOIN_JOIN:
 		return "JOIN";
 	case PIM_IFJOIN_PRUNE:
-		if (PIM_IF_FLAG_TEST_S_G_RPT(flags))
+		if (sg_rpt)
 			return "SGRpt(P)";
 		else
 			return "PRUNE";
 	case PIM_IFJOIN_PRUNE_PENDING:
-		if (PIM_IF_FLAG_TEST_S_G_RPT(flags))
+		if (sg_rpt)
 			return "SGRpt(PP)";
 		else
 			return "PRUNEP";
 	case PIM_IFJOIN_PRUNE_TMP:
-		if (PIM_IF_FLAG_TEST_S_G_RPT(flags))
+		if (sg_rpt)
 			return "SGRpt(P')";
 		else
 			return "PRUNET";
 	case PIM_IFJOIN_PRUNE_PENDING_TMP:
-		if (PIM_IF_FLAG_TEST_S_G_RPT(flags))
+		if (sg_rpt)
 			return "SGRpt(PP')";
 		else
 			return "PRUNEPT";
@@ -557,7 +552,7 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp, pim_sgaddr *sg,
 	ch->flags = 0;
 	if ((source_flags & PIM_ENCODE_RPT_BIT)
 	    && !(source_flags & PIM_ENCODE_WC_BIT))
-		PIM_IF_FLAG_SET_S_G_RPT(ch->flags);
+		pim_ifchannel_set_sg_rpt(ch);
 
 	ch->interface = ifp;
 	ch->sg = *sg;
@@ -679,7 +674,7 @@ static void on_ifjoin_prune_pending_timer(struct event *t)
 	if (ch->ifjoin_state == PIM_IFJOIN_PRUNE_PENDING) {
 		ifp = ch->interface;
 		pim_ifp = ifp->info;
-		if (!PIM_IF_FLAG_TEST_S_G_RPT(ch->flags)) {
+		if (!pim_ifchannel_is_sg_rpt(ch)) {
 			/* Send PruneEcho(S,G) ? */
 			send_prune_echo =
 				(listcount(pim_ifp->pim_neighbor_list) > 1);
@@ -826,7 +821,7 @@ static void pim_ifchannel_ifjoin_handler(struct pim_ifchannel *ch,
 		struct pim_interface *pim_ifp)
 {
 	pim_ifchannel_ifjoin_switch(__func__, ch, PIM_IFJOIN_JOIN);
-	PIM_IF_FLAG_UNSET_S_G_RPT(ch->flags);
+	pim_ifchannel_unset_sg_rpt(ch);
 	/* check if the interface qualifies as an immediate
 	 * OIF
 	 */
@@ -1036,7 +1031,7 @@ void pim_ifchannel_prune(struct interface *ifp, pim_addr upstream,
 	case PIM_IFJOIN_NOINFO:
 		if (source_flags & PIM_ENCODE_RPT_BIT) {
 			if (!(source_flags & PIM_ENCODE_WC_BIT))
-				PIM_IF_FLAG_SET_S_G_RPT(ch->flags);
+				pim_ifchannel_set_sg_rpt(ch);
 
 			ch->ifjoin_state = PIM_IFJOIN_PRUNE_PENDING;
 			pim_upstream_inherited_olist_decide(pim_ifp->pim, ch->upstream);
@@ -1460,15 +1455,14 @@ void pim_ifchannel_set_star_g_join_state(struct pim_ifchannel *ch, int eom,
 	struct pim_upstream *starup = ch->upstream;
 
 	if (PIM_DEBUG_PIM_TRACE)
-		zlog_debug(
-			"%s: %s %s eom: %d join %u", __func__,
-			pim_ifchannel_ifjoin_name(ch->ifjoin_state, ch->flags),
-			ch->sg_str, eom, join);
+		zlog_debug("%s: %s %s eom: %d join %u", __func__,
+			   pim_ifchannel_ifjoin_name(ch->ifjoin_state, ch->sg_rpt), ch->sg_str,
+			   eom, join);
 	if (!ch->sources)
 		return;
 
 	for (ALL_LIST_ELEMENTS(ch->sources, ch_node, nch_node, child)) {
-		if (!PIM_IF_FLAG_TEST_S_G_RPT(child->flags))
+		if (!pim_ifchannel_is_sg_rpt(child))
 			continue;
 
 		switch (child->ifjoin_state) {
@@ -1493,7 +1487,7 @@ void pim_ifchannel_set_star_g_join_state(struct pim_ifchannel *ch, int eom,
 				event_cancel(&child->t_ifjoin_prune_pending_timer);
 			event_cancel(&child->t_ifjoin_expiry_timer);
 
-			PIM_IF_FLAG_UNSET_S_G_RPT(child->flags);
+			pim_ifchannel_unset_sg_rpt(child);
 			child->ifjoin_state = PIM_IFJOIN_NOINFO;
 
 			if ((I_am_RP(pim, child->sg.grp)) &&

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -40,6 +40,7 @@ int pim_ifchannel_compare(const struct pim_ifchannel *ch1,
 {
 	struct pim_interface *pim_ifp1;
 	struct pim_interface *pim_ifp2;
+	int addr_same;
 
 	pim_ifp1 = ch1->interface->info;
 	pim_ifp2 = ch2->interface->info;
@@ -50,7 +51,17 @@ int pim_ifchannel_compare(const struct pim_ifchannel *ch1,
 	if (pim_ifp1->mroute_vif_index > pim_ifp2->mroute_vif_index)
 		return 1;
 
-	return pim_sgaddr_cmp(ch1->sg, ch2->sg);
+	addr_same = pim_sgaddr_cmp(ch1->sg, ch2->sg);
+	if (addr_same != 0)
+		return addr_same;
+
+	if (ch1->sg_rpt == ch2->sg_rpt)
+		return 0;
+
+	if (ch1->sg_rpt)
+		return 1;
+	else
+		return -1;
 }
 
 /*
@@ -98,34 +109,39 @@ static void pim_ifchannel_find_new_children(struct pim_ifchannel *ch)
 	}
 }
 
-void pim_ifchannel_delete(struct pim_ifchannel *ch)
+void pim_ifchannel_delete(struct pim_ifchannel *origch)
 {
 	struct pim_interface *pim_ifp;
 	struct pim_upstream *up;
+	struct pim_ifchannel *ch, *chrpt, *parent;
+	struct interface *ifp = origch->interface;
 
-	pim_ifp = ch->interface->info;
+	pim_ifp = ifp->info;
+
+	up = origch->upstream;
 
 	if (PIM_DEBUG_PIM_TRACE)
-		zlog_debug("%s: ifchannel entry %s(%s) del start", __func__,
-			   ch->sg_str, ch->interface->name);
+		zlog_debug("%s: ifchannel entry %s(%s) del start", __func__, origch->sg_str,
+			   ifp->name);
 
 	if (PIM_I_am_DualActive(pim_ifp)) {
 		if (PIM_DEBUG_MLAG)
-			zlog_debug(
-				"%s: if-chnanel-%s is deleted from a Dual active Interface",
-				__func__, ch->sg_str);
+			zlog_debug("%s: if-chnanel-%s is deleted from a Dual active Interface",
+				   __func__, origch->sg_str);
 		/* Post Delete only if it is the last Dual-active Interface */
-		if (ch->upstream->dualactive_ifchannel_count == 1) {
-			pim_mlag_up_local_del(pim_ifp->pim, ch->upstream);
-			PIM_UPSTREAM_FLAG_UNSET_MLAG_INTERFACE(
-				ch->upstream->flags);
+		if (up->dualactive_ifchannel_count == 1) {
+			pim_mlag_up_local_del(pim_ifp->pim, up);
+			PIM_UPSTREAM_FLAG_UNSET_MLAG_INTERFACE(up->flags);
 		}
-		ch->upstream->dualactive_ifchannel_count--;
+		up->dualactive_ifchannel_count--;
 	}
 
-	if (ch->upstream->channel_oil) {
+	parent = origch->parent;
+
+	if (up->channel_oil) {
 		uint32_t mask = PIM_OIF_FLAG_PROTO_PIM;
-		if (ch->upstream->flags & PIM_UPSTREAM_FLAG_MASK_SRC_IGMP)
+
+		if (up->flags & PIM_UPSTREAM_FLAG_MASK_SRC_IGMP)
 			mask |= PIM_OIF_FLAG_PROTO_GM;
 
 		/*
@@ -135,30 +151,22 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 		 * being inherited.  So let's figure out what
 		 * needs to be done here
 		 */
-		if (!pim_addr_is_any(ch->sg.src) && ch->parent &&
-		    pim_upstream_evaluate_join_desired_interface(
-			    ch->upstream, ch, ch->parent))
-			pim_channel_add_oif(ch->upstream->channel_oil,
-					ch->interface,
-					PIM_OIF_FLAG_PROTO_STAR,
-					__func__);
+		pim_ifchannel_find(ifp, &origch->sg, &ch, &chrpt);
+		if (parent && pim_upstream_evaluate_join_desired_interface(up, ch, chrpt, parent))
+			pim_channel_add_oif(up->channel_oil, ifp, PIM_OIF_FLAG_PROTO_STAR,
+					    __func__);
 
-		pim_channel_del_oif(ch->upstream->channel_oil,
-					ch->interface, mask, __func__);
+		pim_channel_del_oif(up->channel_oil, ifp, mask, __func__);
 		/*
 		 * Do we have any S,G's that are inheriting?
 		 * Nuke from on high too.
 		 */
-		if (ch->upstream->sources) {
+		if (up->sources) {
 			struct pim_upstream *child;
 			struct listnode *up_node;
 
-			for (ALL_LIST_ELEMENTS_RO(ch->upstream->sources,
-						  up_node, child))
-				pim_channel_del_inherited_oif(
-						child->channel_oil,
-						ch->interface,
-						__func__);
+			for (ALL_LIST_ELEMENTS_RO(up->sources, up_node, child))
+				pim_channel_del_inherited_oif(child->channel_oil, ifp, __func__);
 		}
 	}
 
@@ -167,54 +175,50 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 	 * we need to find all our children
 	 * and make sure our pointers are fixed
 	 */
-	pim_ifchannel_remove_children(ch);
+	pim_ifchannel_remove_children(origch);
 
-	if (ch->sources)
-		list_delete(&ch->sources);
+	if (origch->sources)
+		list_delete(&origch->sources);
 
-	listnode_delete(ch->upstream->ifchannels, ch);
-
-	up = ch->upstream;
+	listnode_delete(up->ifchannels, origch);
 
 	/* upstream is common across ifchannels, check if upstream's
 	   ifchannel list is empty before deleting upstream_del
 	   ref count will take care of it.
 	*/
-	if (ch->upstream->ref_count > 0)
-		up = pim_upstream_del(pim_ifp->pim, ch->upstream, __func__);
+	if (up->ref_count > 0)
+		up = pim_upstream_del(pim_ifp->pim, up, __func__);
 
 	else {
 		if (PIM_DEBUG_PIM_TRACE)
-			zlog_debug(
-				"%s: Avoiding deletion of upstream with ref_count %d from ifchannel(%s): %s",
-				__func__, ch->upstream->ref_count,
-				ch->interface->name, ch->sg_str);
+			zlog_debug("%s: Avoiding deletion of upstream with ref_count %d from ifchannel(%s): %s",
+				   __func__, up->ref_count, ifp->name, origch->sg_str);
 	}
 
-	ch->upstream = NULL;
+	origch->upstream = NULL;
 
-	event_cancel(&ch->t_ifjoin_expiry_timer);
-	event_cancel(&ch->t_ifjoin_prune_pending_timer);
-	event_cancel(&ch->t_ifassert_timer);
+	event_cancel(&origch->t_ifjoin_expiry_timer);
+	event_cancel(&origch->t_ifjoin_prune_pending_timer);
+	event_cancel(&origch->t_ifassert_timer);
 
-	if (ch->parent) {
-		listnode_delete(ch->parent->sources, ch);
-		ch->parent = NULL;
+	if (parent) {
+		listnode_delete(parent->sources, origch);
+		origch->parent = NULL;
 	}
 
-	RB_REMOVE(pim_ifchannel_rb, &pim_ifp->ifchannel_rb, ch);
+	RB_REMOVE(pim_ifchannel_rb, &pim_ifp->ifchannel_rb, origch);
 
 	if (PIM_DEBUG_PIM_TRACE)
-		zlog_debug("%s: ifchannel entry %s(%s) is deleted ", __func__,
-			   ch->sg_str, ch->interface->name);
+		zlog_debug("%s: ifchannel entry %s(%s) is deleted ", __func__, origch->sg_str,
+			   ifp->name);
 
 #if PIM_IPV == 6
 	/* Embedded RPs learned via PIM join/connected source are freed here */
-	if (pim_embedded_rp_is_embedded(&ch->sg.grp))
-		pim_embedded_rp_delete(pim_ifp->pim, &ch->sg.grp);
+	if (pim_embedded_rp_is_embedded(&origch->sg.grp))
+		pim_embedded_rp_delete(pim_ifp->pim, &origch->sg.grp);
 #endif /* PIM_IPV == 6 */
 
-	XFREE(MTYPE_PIM_IFCHANNEL, ch);
+	XFREE(MTYPE_PIM_IFCHANNEL, origch);
 
 	if (up)
 		pim_upstream_update_join_desired(pim_ifp->pim, up);
@@ -312,6 +316,8 @@ void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,
 			if (ch->ifjoin_state == PIM_IFJOIN_JOIN) {
 				for (ALL_LIST_ELEMENTS_RO(up->sources, up_node,
 							  child)) {
+					struct pim_ifchannel *child_chrpt;
+
 					if (PIM_DEBUG_PIM_TRACE)
 						zlog_debug(
 							"%s %s: Join(S,G)=%s from %s",
@@ -322,11 +328,11 @@ void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,
 					/* check if the channel can be
 					 * inherited into the SG's OIL
 					 */
-					child_ch = pim_ifchannel_find(
-							ch->interface,
-							&child->sg);
-					if (pim_upstream_eval_inherit_if(
-						    child, child_ch, ch)) {
+					pim_ifchannel_find(ch->interface, &child->sg, &child_ch,
+							   &child_chrpt);
+
+					if (pim_upstream_eval_inherit_if(child, child_ch,
+									 child_chrpt, ch)) {
 						pim_channel_add_oif(
 							child->channel_oil,
 							ch->interface,
@@ -431,25 +437,29 @@ void reset_ifassert_state(struct pim_ifchannel *ch)
 				router->infinite_assert_metric);
 }
 
-struct pim_ifchannel *pim_ifchannel_find(struct interface *ifp, pim_sgaddr *sg)
+void pim_ifchannel_find(struct interface *ifp, pim_sgaddr *sg, struct pim_ifchannel **ch,
+			struct pim_ifchannel **chrpt)
 {
 	struct pim_interface *pim_ifp;
-	struct pim_ifchannel *ch;
 	struct pim_ifchannel lookup;
 
+	assert(ch && chrpt);
 	pim_ifp = ifp->info;
 
 	if (!pim_ifp) {
 		zlog_warn("%s: (S,G)=%pSG: multicast not enabled on interface %s",
 			  __func__, sg, ifp->name);
-		return NULL;
+		*ch = NULL;
+		*chrpt = NULL;
 	}
 
 	lookup.sg = *sg;
 	lookup.interface = ifp;
-	ch = RB_FIND(pim_ifchannel_rb, &pim_ifp->ifchannel_rb, &lookup);
+	lookup.sg_rpt = false;
+	*ch = RB_FIND(pim_ifchannel_rb, &pim_ifp->ifchannel_rb, &lookup);
 
-	return ch;
+	lookup.sg_rpt = true;
+	*chrpt = RB_FIND(pim_ifchannel_rb, &pim_ifp->ifchannel_rb, &lookup);
 }
 
 static void ifmembership_set(struct pim_ifchannel *ch,
@@ -510,12 +520,13 @@ static struct pim_ifchannel *pim_ifchannel_find_parent(struct pim_ifchannel *ch)
 {
 	pim_sgaddr parent_sg = ch->sg;
 	struct pim_ifchannel *parent = NULL;
+	struct pim_ifchannel *parentrpt = NULL;
 
 	// (S,G)
 	if (!pim_addr_is_any(parent_sg.src) &&
 	    !pim_addr_is_any(parent_sg.grp)) {
 		parent_sg.src = PIMADDR_ANY;
-		parent = pim_ifchannel_find(ch->interface, &parent_sg);
+		pim_ifchannel_find(ch->interface, &parent_sg, &parent, &parentrpt);
 
 		if (parent)
 			listnode_add(parent->sources, ch);
@@ -529,10 +540,17 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp, pim_sgaddr *sg,
 					uint8_t source_flags, int up_flags)
 {
 	struct pim_interface *pim_ifp;
-	struct pim_ifchannel *ch;
+	struct pim_ifchannel *ch, *chrpt;
 	struct pim_upstream *up;
+	bool sg_rpt;
 
-	ch = pim_ifchannel_find(ifp, sg);
+	/* Determine if this should be an (S,G,rpt) channel */
+	sg_rpt = (source_flags & PIM_ENCODE_RPT_BIT) && !(source_flags & PIM_ENCODE_WC_BIT);
+
+	/* Look for existing channel with matching sg_rpt flag */
+	pim_ifchannel_find(ifp, sg, &ch, &chrpt);
+	if (sg_rpt)
+		ch = chrpt;
 	if (ch) {
 		if (up_flags == PIM_UPSTREAM_FLAG_MASK_SRC_PIM)
 			PIM_IF_FLAG_SET_PROTO_PIM(ch->flags);
@@ -550,9 +568,7 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp, pim_sgaddr *sg,
 	ch = XCALLOC(MTYPE_PIM_IFCHANNEL, sizeof(*ch));
 
 	ch->flags = 0;
-	if ((source_flags & PIM_ENCODE_RPT_BIT)
-	    && !(source_flags & PIM_ENCODE_WC_BIT))
-		pim_ifchannel_set_sg_rpt(ch);
+	ch->sg_rpt = sg_rpt;
 
 	ch->interface = ifp;
 	ch->sg = *sg;
@@ -817,23 +833,22 @@ static int nonlocal_upstream(int is_join, struct interface *recv_ifp,
 	return 1; /* non-local */
 }
 
-static void pim_ifchannel_ifjoin_handler(struct pim_ifchannel *ch,
-		struct pim_interface *pim_ifp)
+static void pim_ifchannel_ifjoin_handler(struct pim_ifchannel *origch,
+					 struct pim_interface *pim_ifp)
 {
-	pim_ifchannel_ifjoin_switch(__func__, ch, PIM_IFJOIN_JOIN);
-	pim_ifchannel_unset_sg_rpt(ch);
+	struct pim_ifchannel *ch, *chrpt;
+
+	pim_ifchannel_find(origch->interface, &origch->sg, &ch, &chrpt);
+
+	pim_ifchannel_ifjoin_switch(__func__, origch, PIM_IFJOIN_JOIN);
 	/* check if the interface qualifies as an immediate
 	 * OIF
 	 */
-	if (pim_upstream_evaluate_join_desired_interface(
-				ch->upstream, ch,
-				NULL /*starch*/)) {
-		pim_channel_add_oif(ch->upstream->channel_oil,
-				ch->interface,
-				PIM_OIF_FLAG_PROTO_PIM,
-				__func__);
-		pim_upstream_update_join_desired(pim_ifp->pim,
-				ch->upstream);
+	if (pim_upstream_evaluate_join_desired_interface(origch->upstream, ch, chrpt,
+							 NULL /*starch*/)) {
+		pim_channel_add_oif(origch->upstream->channel_oil, origch->interface,
+				    PIM_OIF_FLAG_PROTO_PIM, __func__);
+		pim_upstream_update_join_desired(pim_ifp->pim, origch->upstream);
 	}
 }
 
@@ -1004,16 +1019,20 @@ void pim_ifchannel_prune(struct interface *ifp, pim_addr upstream,
 			 pim_sgaddr *sg, uint8_t source_flags,
 			 uint16_t holdtime)
 {
-	struct pim_ifchannel *ch;
+	struct pim_ifchannel *ch, *chrpt;
 	struct pim_interface *pim_ifp;
 	int jp_override_interval_msec;
+	bool sg_rpt;
 
 	if (nonlocal_upstream(0 /* prune */, ifp, upstream, sg, source_flags,
 			      holdtime)) {
 		return;
 	}
 
-	ch = pim_ifchannel_find(ifp, sg);
+	sg_rpt = (source_flags & PIM_ENCODE_RPT_BIT) && !(source_flags & PIM_ENCODE_WC_BIT);
+	pim_ifchannel_find(ifp, sg, &ch, &chrpt);
+	if (sg_rpt)
+		ch = chrpt;
 	if (!ch && !(source_flags & PIM_ENCODE_RPT_BIT)) {
 		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: Received prune with no relevant ifchannel %s%pSG state: %d",
@@ -1030,12 +1049,8 @@ void pim_ifchannel_prune(struct interface *ifp, pim_addr upstream,
 	switch (ch->ifjoin_state) {
 	case PIM_IFJOIN_NOINFO:
 		if (source_flags & PIM_ENCODE_RPT_BIT) {
-			if (!(source_flags & PIM_ENCODE_WC_BIT))
-				pim_ifchannel_set_sg_rpt(ch);
-
 			ch->ifjoin_state = PIM_IFJOIN_PRUNE_PENDING;
-			pim_upstream_inherited_olist_decide(pim_ifp->pim, ch->upstream);
-
+			pim_upstream_inherited_olist(pim_ifp->pim, ch->upstream);
 			if (listcount(pim_ifp->pim_neighbor_list) > 1)
 				jp_override_interval_msec =
 					pim_if_jp_override_interval_msec(ifp);
@@ -1091,6 +1106,8 @@ void pim_ifchannel_prune(struct interface *ifp, pim_addr upstream,
 				     on_ifjoin_prune_pending_timer, ch,
 				     jp_override_interval_msec,
 				     &ch->t_ifjoin_prune_pending_timer);
+		if (source_flags & PIM_ENCODE_RPT_BIT)
+			pim_upstream_inherited_olist(pim_ifp->pim, ch->upstream);
 		break;
 	case PIM_IFJOIN_PRUNE:
 		if (source_flags & PIM_ENCODE_RPT_BIT) {
@@ -1125,6 +1142,7 @@ void pim_ifchannel_prune(struct interface *ifp, pim_addr upstream,
 			event_add_timer(router->master, on_ifjoin_expiry_timer,
 					ch, holdtime,
 					&ch->t_ifjoin_expiry_timer);
+			pim_upstream_inherited_olist(pim_ifp->pim, ch->upstream);
 		}
 		break;
 	case PIM_IFJOIN_PRUNE_PENDING_TMP:
@@ -1135,6 +1153,7 @@ void pim_ifchannel_prune(struct interface *ifp, pim_addr upstream,
 			event_add_timer(router->master, on_ifjoin_expiry_timer,
 					ch, holdtime,
 					&ch->t_ifjoin_expiry_timer);
+			pim_upstream_inherited_olist(pim_ifp->pim, ch->upstream);
 		}
 		break;
 	}
@@ -1143,7 +1162,7 @@ void pim_ifchannel_prune(struct interface *ifp, pim_addr upstream,
 int pim_ifchannel_local_membership_add(struct interface *ifp, pim_sgaddr *sg,
 				       bool is_vxlan)
 {
-	struct pim_ifchannel *ch, *starch;
+	struct pim_ifchannel *ch, *chrpt, *starch;
 	struct pim_interface *pim_ifp;
 	struct pim_instance *pim;
 	int up_flags;
@@ -1208,9 +1227,8 @@ int pim_ifchannel_local_membership_add(struct interface *ifp, pim_sgaddr *sg,
 				continue;
 			}
 
-			ch = pim_ifchannel_find(ifp, &child->sg);
-			if (pim_upstream_evaluate_join_desired_interface(
-				    child, ch, starch)) {
+			pim_ifchannel_find(ifp, &child->sg, &ch, &chrpt);
+			if (pim_upstream_evaluate_join_desired_interface(child, ch, chrpt, starch)) {
 				pim_channel_add_oif(child->channel_oil, ifp,
 						    PIM_OIF_FLAG_PROTO_STAR,
 							__func__);
@@ -1244,7 +1262,7 @@ int pim_ifchannel_local_membership_add(struct interface *ifp, pim_sgaddr *sg,
 
 void pim_ifchannel_local_membership_del(struct interface *ifp, pim_sgaddr *sg)
 {
-	struct pim_ifchannel *starch, *ch, *orig;
+	struct pim_ifchannel *starch, *ch, *chrpt, *orig;
 	struct pim_interface *pim_ifp;
 
 	/* PIM enabled on interface? */
@@ -1254,9 +1272,11 @@ void pim_ifchannel_local_membership_del(struct interface *ifp, pim_sgaddr *sg)
 	if (!pim_ifp->pim_enable)
 		return;
 
-	orig = ch = pim_ifchannel_find(ifp, sg);
+	pim_ifchannel_find(ifp, sg, &ch, &chrpt);
+	orig = ch;
 	if (!ch)
 		return;
+
 	ifmembership_set(ch, PIM_IFMEMBERSHIP_NOINFO);
 
 	if (pim_addr_is_any(sg->src)) {
@@ -1268,8 +1288,9 @@ void pim_ifchannel_local_membership_del(struct interface *ifp, pim_sgaddr *sg)
 
 		for (ALL_LIST_ELEMENTS(up->sources, up_node, up_nnode, child)) {
 			struct channel_oil *c_oil = child->channel_oil;
-			struct pim_ifchannel *chchannel =
-				pim_ifchannel_find(ifp, &child->sg);
+			struct pim_ifchannel *chchannel, *chchannelrpt;
+
+			pim_ifchannel_find(ifp, &child->sg, &chchannel, &chchannelrpt);
 
 			pim_ifp = ifp->info;
 
@@ -1278,17 +1299,15 @@ void pim_ifchannel_local_membership_del(struct interface *ifp, pim_sgaddr *sg)
 					   __FILE__, __func__, up->sg_str,
 					   ifp->name, child->sg_str);
 
-			ch = pim_ifchannel_find(ifp, &child->sg);
 			/*
 			 * If the S,G has no if channel and the c_oil still
 			 * has output here then the *,G was supplying the
 			 * implied
 			 * if channel.  So remove it.
 			 */
-			if (!pim_upstream_evaluate_join_desired_interface(
-				child, ch, starch) ||
-				(!chchannel &&
-				 oil_if_has(c_oil, pim_ifp->mroute_vif_index))) {
+			if (!pim_upstream_evaluate_join_desired_interface(child, chchannel,
+									  chchannelrpt, starch) ||
+			    (!chchannel && oil_if_has(c_oil, pim_ifp->mroute_vif_index))) {
 				pim_channel_del_inherited_oif(c_oil, ifp,
 						__func__);
 			}
@@ -1487,7 +1506,6 @@ void pim_ifchannel_set_star_g_join_state(struct pim_ifchannel *ch, int eom,
 				event_cancel(&child->t_ifjoin_prune_pending_timer);
 			event_cancel(&child->t_ifjoin_expiry_timer);
 
-			pim_ifchannel_unset_sg_rpt(child);
 			child->ifjoin_state = PIM_IFJOIN_NOINFO;
 
 			if ((I_am_RP(pim, child->sg.grp)) &&

--- a/pimd/pim_ifchannel.h
+++ b/pimd/pim_ifchannel.h
@@ -111,21 +111,12 @@ static inline bool pim_ifchannel_is_sg_rpt(const struct pim_ifchannel *ch)
 	return ch->sg_rpt;
 }
 
-static inline void pim_ifchannel_set_sg_rpt(struct pim_ifchannel *ch)
-{
-	ch->sg_rpt = true;
-}
-
-static inline void pim_ifchannel_unset_sg_rpt(struct pim_ifchannel *ch)
-{
-	ch->sg_rpt = false;
-}
-
-void pim_ifchannel_delete(struct pim_ifchannel *ch);
+void pim_ifchannel_delete(struct pim_ifchannel *origch);
 void pim_ifchannel_delete_all(struct interface *ifp);
 void pim_ifchannel_membership_clear(struct interface *ifp);
 void pim_ifchannel_delete_on_noinfo(struct interface *ifp);
-struct pim_ifchannel *pim_ifchannel_find(struct interface *ifp, pim_sgaddr *sg);
+void pim_ifchannel_find(struct interface *ifp, pim_sgaddr *sg, struct pim_ifchannel **ch,
+			struct pim_ifchannel **chrpt);
 struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp, pim_sgaddr *sg,
 					uint8_t ch_flags, int up_flags);
 void pim_ifchannel_join_add(struct interface *ifp, pim_addr neigh_addr,

--- a/pimd/pim_ifchannel.h
+++ b/pimd/pim_ifchannel.h
@@ -46,13 +46,6 @@ enum pim_ifjoin_state {
 #define PIM_IF_FLAG_SET_ASSERT_TRACKING_DESIRED(flags) ((flags) |= PIM_IF_FLAG_MASK_ASSERT_TRACKING_DESIRED)
 #define PIM_IF_FLAG_UNSET_ASSERT_TRACKING_DESIRED(flags) ((flags) &= ~PIM_IF_FLAG_MASK_ASSERT_TRACKING_DESIRED)
 
-/*
- * Flag to tell us if the ifchannel is (S,G,rpt)
- */
-#define PIM_IF_FLAG_MASK_S_G_RPT         (1 << 2)
-#define PIM_IF_FLAG_TEST_S_G_RPT(flags)  ((flags) & PIM_IF_FLAG_MASK_S_G_RPT)
-#define PIM_IF_FLAG_SET_S_G_RPT(flags)   ((flags) |= PIM_IF_FLAG_MASK_S_G_RPT)
-#define PIM_IF_FLAG_UNSET_S_G_RPT(flags) ((flags) &= ~PIM_IF_FLAG_MASK_S_G_RPT)
 
 /*
  * Flag to tell us if the ifchannel is proto PIM
@@ -104,11 +97,29 @@ struct pim_ifchannel {
 
 	/* Upstream (S,G) state */
 	struct pim_upstream *upstream;
+
+	bool sg_rpt;
 };
 
 RB_HEAD(pim_ifchannel_rb, pim_ifchannel);
 RB_PROTOTYPE(pim_ifchannel_rb, pim_ifchannel, pim_ifp_rb,
 	     pim_ifchannel_compare);
+
+/* Inline accessor functions for sg_rpt field */
+static inline bool pim_ifchannel_is_sg_rpt(const struct pim_ifchannel *ch)
+{
+	return ch->sg_rpt;
+}
+
+static inline void pim_ifchannel_set_sg_rpt(struct pim_ifchannel *ch)
+{
+	ch->sg_rpt = true;
+}
+
+static inline void pim_ifchannel_unset_sg_rpt(struct pim_ifchannel *ch)
+{
+	ch->sg_rpt = false;
+}
 
 void pim_ifchannel_delete(struct pim_ifchannel *ch);
 void pim_ifchannel_delete_all(struct interface *ifp);
@@ -129,8 +140,7 @@ void pim_ifchannel_local_membership_del(struct interface *ifp, pim_sgaddr *sg);
 
 void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,
 				 enum pim_ifjoin_state new_state);
-const char *pim_ifchannel_ifjoin_name(enum pim_ifjoin_state ifjoin_state,
-				      int flags);
+const char *pim_ifchannel_ifjoin_name(enum pim_ifjoin_state ifjoin_state, bool sg_rpt);
 const char *pim_ifchannel_ifassert_name(enum pim_ifassert_state ifassert_state);
 
 int pim_ifchannel_isin_oiflist(struct pim_ifchannel *ch);

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -360,13 +360,13 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 			/* (*,G) prune received */
 			for (ALL_LIST_ELEMENTS(sg_ch->sources, ch_node,
 					       nch_node, child)) {
-				if (PIM_IF_FLAG_TEST_S_G_RPT(child->flags)) {
+				if (pim_ifchannel_is_sg_rpt(child)) {
 					if (child->ifjoin_state
 					    == PIM_IFJOIN_PRUNE_PENDING_TMP)
 						event_cancel(&
 							child->t_ifjoin_prune_pending_timer);
 					event_cancel(&child->t_ifjoin_expiry_timer);
-					PIM_IF_FLAG_UNSET_S_G_RPT(child->flags);
+					pim_ifchannel_unset_sg_rpt(child);
 					child->ifjoin_state = PIM_IFJOIN_NOINFO;
 					delete_on_noinfo(child);
 				}
@@ -376,7 +376,7 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 			if (starg_ch && (msg_source_flags & PIM_RPT_BIT_MASK)
 			    && !(msg_source_flags & PIM_WILDCARD_BIT_MASK)) {
 				struct pim_upstream *up = sg_ch->upstream;
-				PIM_IF_FLAG_SET_S_G_RPT(sg_ch->flags);
+				pim_ifchannel_set_sg_rpt(sg_ch);
 				if (up) {
 					if (PIM_DEBUG_PIM_TRACE)
 						zlog_debug(

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -320,7 +320,9 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 				  &sg, msg_source_flags);
 
 			if (pim_addr_is_any(sg.src)) {
-				starg_ch = pim_ifchannel_find(ifp, &sg);
+				struct pim_ifchannel *throwaway;
+
+				pim_ifchannel_find(ifp, &sg, &starg_ch, &throwaway);
 				if (starg_ch)
 					pim_ifchannel_set_star_g_join_state(
 						starg_ch, 0, 1);
@@ -336,6 +338,8 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 
 		/* Scan pruned sources */
 		for (source = 0; source < msg_num_pruned_sources; ++source) {
+			struct pim_ifchannel *throwaway;
+
 			addr_offset = pim_parse_addr_source(
 				&sg, &msg_source_flags, buf, pastend - buf);
 			if (addr_offset < 1) {
@@ -352,7 +356,7 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 			 * We need to retrieve the sg_ch after
 			 * we parse the prune.
 			 */
-			sg_ch = pim_ifchannel_find(ifp, &sg);
+			pim_ifchannel_find(ifp, &sg, &sg_ch, &throwaway);
 
 			if (!sg_ch)
 				continue;
@@ -366,7 +370,6 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 						event_cancel(&
 							child->t_ifjoin_prune_pending_timer);
 					event_cancel(&child->t_ifjoin_expiry_timer);
-					pim_ifchannel_unset_sg_rpt(child);
 					child->ifjoin_state = PIM_IFJOIN_NOINFO;
 					delete_on_noinfo(child);
 				}
@@ -376,7 +379,6 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 			if (starg_ch && (msg_source_flags & PIM_RPT_BIT_MASK)
 			    && !(msg_source_flags & PIM_WILDCARD_BIT_MASK)) {
 				struct pim_upstream *up = sg_ch->upstream;
-				pim_ifchannel_set_sg_rpt(sg_ch);
 				if (up) {
 					if (PIM_DEBUG_PIM_TRACE)
 						zlog_debug(

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -543,7 +543,7 @@ have_up:
 
 int pim_mroute_msg_wrongvif(int fd, struct interface *ifp, const kernmsg *msg)
 {
-	struct pim_ifchannel *ch;
+	struct pim_ifchannel *ch, *throwaway;
 	struct pim_interface *pim_ifp;
 	pim_sgaddr sg;
 
@@ -579,7 +579,7 @@ int pim_mroute_msg_wrongvif(int fd, struct interface *ifp, const kernmsg *msg)
 		return -2;
 	}
 
-	ch = pim_ifchannel_find(ifp, &sg);
+	pim_ifchannel_find(ifp, &sg, &ch, &throwaway);
 	if (!ch) {
 		pim_sgaddr star_g = sg;
 		if (PIM_DEBUG_MROUTE)
@@ -588,7 +588,7 @@ int pim_mroute_msg_wrongvif(int fd, struct interface *ifp, const kernmsg *msg)
 				__func__, &sg, ifp->name);
 
 		star_g.src = PIMADDR_ANY;
-		ch = pim_ifchannel_find(ifp, &star_g);
+		pim_ifchannel_find(ifp, &star_g, &ch, &throwaway);
 		if (!ch) {
 			if (PIM_DEBUG_MROUTE)
 				zlog_debug(
@@ -656,7 +656,7 @@ int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp, const char *buf,
 	const ipv_hdr *ip_hdr = (const ipv_hdr *)buf;
 	struct pim_interface *pim_ifp;
 	struct pim_instance *pim;
-	struct pim_ifchannel *ch;
+	struct pim_ifchannel *ch, *throwaway;
 	struct pim_upstream *up;
 	pim_sgaddr star_g;
 	pim_sgaddr sg;
@@ -685,7 +685,7 @@ int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp, const char *buf,
 		return 0;
 	}
 
-	ch = pim_ifchannel_find(ifp, &sg);
+	pim_ifchannel_find(ifp, &sg, &ch, &throwaway);
 	if (ch) {
 		if (PIM_DEBUG_MROUTE)
 			zlog_debug(

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -370,6 +370,13 @@ const struct frr_yang_module_info frr_pim_info = {
 			}
 		},
 		{
+			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/override-interval",
+			.cbs = {
+				.modify = lib_interface_pim_override_interval_modify,
+				.destroy = lib_interface_pim_override_interval_destroy,
+			}
+		},
+		{
 			.xpath = "/frr-interface:lib/interface/frr-pim:pim/address-family/bfd",
 			.cbs = {
 				.create = lib_interface_pim_address_family_bfd_create,

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -124,6 +124,8 @@ int lib_interface_pim_address_family_nbr_plist_destroy(struct nb_cb_destroy_args
 int lib_interface_pim_assert_interval_modify(struct nb_cb_modify_args *args);
 int lib_interface_pim_assert_override_interval_modify(struct nb_cb_modify_args *args);
 int lib_interface_pim_assert_override_interval_destroy(struct nb_cb_destroy_args *args);
+int lib_interface_pim_override_interval_modify(struct nb_cb_modify_args *args);
+int lib_interface_pim_override_interval_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_pim_address_family_create(struct nb_cb_create_args *args);
 int lib_interface_pim_address_family_destroy(struct nb_cb_destroy_args *args);
 int lib_interface_pim_address_family_pim_enable_modify(

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -2505,6 +2505,46 @@ int lib_interface_pim_assert_override_interval_destroy(struct nb_cb_destroy_args
 	return NB_OK;
 }
 
+int lib_interface_pim_override_interval_modify(struct nb_cb_modify_args *args)
+{
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_ABORT:
+	case NB_EV_PREPARE:
+		break;
+	case NB_EV_APPLY:
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
+		pim_ifp = ifp->info;
+		pim_ifp->pim_override_interval_msec = yang_dnode_get_uint16(args->dnode, NULL);
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_pim_override_interval_destroy(struct nb_cb_destroy_args *args)
+{
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_ABORT:
+	case NB_EV_PREPARE:
+		break;
+	case NB_EV_APPLY:
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
+		pim_ifp = ifp->info;
+		pim_ifp->pim_override_interval_msec = PIM_DEFAULT_OVERRIDE_INTERVAL_MSEC;
+		break;
+	}
+
+	return NB_OK;
+}
+
 /*
  * XPath: /frr-interface:lib/interface/frr-pim:pim/address-family/bfd
  */

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -224,7 +224,7 @@ void pim_upstream_rpf_clear(struct pim_instance *pim,
 */
 static pim_addr pim_rpf_find_rpf_addr(struct pim_upstream *up)
 {
-	struct pim_ifchannel *rpf_ch;
+	struct pim_ifchannel *rpf_ch, *throwaway;
 	struct pim_neighbor *neigh;
 	pim_addr rpf_addr;
 
@@ -235,7 +235,7 @@ static pim_addr pim_rpf_find_rpf_addr(struct pim_upstream *up)
 		return PIMADDR_ANY;
 	}
 
-	rpf_ch = pim_ifchannel_find(up->rpf.source_nexthop.interface, &up->sg);
+	pim_ifchannel_find(up->rpf.source_nexthop.interface, &up->sg, &rpf_ch, &throwaway);
 	if (rpf_ch) {
 		if (rpf_ch->ifassert_state == PIM_IFASSERT_I_AM_LOSER) {
 			return rpf_ch->ifassert_winner;

--- a/pimd/pim_state_refresh.c
+++ b/pimd/pim_state_refresh.c
@@ -37,7 +37,7 @@ int pim_staterefresh_recv(struct interface *ifp, pim_addr src_addr, uint8_t *buf
 	uint8_t *curr;
 	int curr_size;
 	struct pim_interface *pim_ifp = NULL, *pim_ifp2;
-	struct pim_ifchannel *ch;
+	struct pim_ifchannel *ch, *throwaway;
 	struct listnode *neighnode;
 	struct pim_neighbor *neigh;
 	uint8_t pim_msg[1000];
@@ -160,7 +160,7 @@ int pim_staterefresh_recv(struct interface *ifp, pim_addr src_addr, uint8_t *buf
 		pim_ifp2 = neigh->interface->info;
 		if (pim_is_group_filtered(pim_ifp2, &up->sg.grp, &up->sg.src))
 			continue;
-		ch = pim_ifchannel_find(neigh->interface, &up->sg);
+		pim_ifchannel_find(neigh->interface, &up->sg, &ch, &throwaway);
 		if (!ch)
 			p = 0;
 		else {
@@ -274,7 +274,7 @@ void pim_send_staterefresh(struct pim_upstream *up)
 	int pim_msg_size;
 	struct interface *ifp, *ifp2 = NULL;
 	struct pim_interface *pim_ifp2;
-	struct pim_ifchannel *ch;
+	struct pim_ifchannel *ch, *throwaway;
 	struct listnode *neighnode;
 	struct pim_neighbor *neigh;
 
@@ -301,7 +301,7 @@ void pim_send_staterefresh(struct pim_upstream *up)
 			continue;
 
 		if (HAVE_DENSE_MODE(pim_ifp2->pim_mode) && ifp2->ifindex != ifp->ifindex) {
-			ch = pim_ifchannel_find(ifp2, &up->sg);
+			pim_ifchannel_find(ifp2, &up->sg, &ch, &throwaway);
 			if (!ch)
 				p = 0;
 			else

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1159,7 +1159,7 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 		 * installed with none as OIF */
 		if (up->rpf.source_nexthop.interface &&
 		    !(pim_upstream_empty_inherited_olist(up) && (ch != NULL) &&
-		      PIM_IF_FLAG_TEST_S_G_RPT(ch->flags))) {
+		      pim_ifchannel_is_sg_rpt(ch))) {
 			pim_upstream_mroute_iif_update(up->channel_oil,
 					__func__);
 		}
@@ -1308,7 +1308,7 @@ int pim_upstream_eval_inherit_if(struct pim_upstream *up,
 	 * add it to the OIL
 	 */
 	if (ch) {
-		if (PIM_IF_FLAG_TEST_S_G_RPT(ch->flags))
+		if (pim_ifchannel_is_sg_rpt(ch))
 			return 0;
 	}
 
@@ -1332,7 +1332,7 @@ int pim_upstream_evaluate_join_desired_interface(struct pim_upstream *up,
 						 struct pim_ifchannel *starch)
 {
 	if (ch) {
-		if (PIM_IF_FLAG_TEST_S_G_RPT(ch->flags))
+		if (pim_ifchannel_is_sg_rpt(ch))
 			return 0;
 
 		if (!pim_macro_ch_lost_assert(ch)
@@ -1345,11 +1345,11 @@ int pim_upstream_evaluate_join_desired_interface(struct pim_upstream *up,
 	 */
 	if (starch) {
 		/* XXX: check on this with donald
-		 * we are looking for PIM_IF_FLAG_MASK_S_G_RPT in
+		 * we are looking for sg_rpt in
 		 * upstream flags?
 		 */
 #if 0
-		if (PIM_IF_FLAG_TEST_S_G_RPT(starch->upstream->flags))
+		if (pim_ifchannel_is_sg_rpt(starch))
 			return 0;
 #endif
 
@@ -1773,7 +1773,7 @@ int pim_upstream_is_sg_rpt(struct pim_upstream *up)
 	struct pim_ifchannel *ch;
 
 	for (ALL_LIST_ELEMENTS_RO(up->ifchannels, chnode, ch)) {
-		if (PIM_IF_FLAG_TEST_S_G_RPT(ch->flags))
+		if (pim_ifchannel_is_sg_rpt(ch))
 			return 1;
 	}
 

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -467,10 +467,11 @@ static void join_timer_stop(struct pim_upstream *up)
 		nbr = pim_neighbor_find(up->rpf.source_nexthop.interface,
 					up->rpf.rpf_addr, true);
 
-	if (nbr)
+	if (nbr) {
 		pim_jp_agg_remove_group(nbr->upstream_jp_agg, up, nbr);
 
-	pim_jp_agg_upstream_verification(up, false);
+		pim_jp_agg_upstream_verification(up, false);
+	}
 }
 
 void prune_timer_start(struct pim_upstream *up)
@@ -656,9 +657,11 @@ void pim_upstream_join_suppress(struct pim_upstream *up, pim_addr rpf,
 				t_joinsuppress_msec);
 		}
 
-		if (nbr)
+		if (nbr) {
 			pim_jp_agg_remove_group(nbr->upstream_jp_agg, up, nbr);
 
+			pim_jp_agg_upstream_verification(up, false);
+		}
 		pim_upstream_join_timer_restart_msec(up, t_joinsuppress_msec);
 	}
 }
@@ -1300,17 +1303,14 @@ struct pim_upstream *pim_upstream_add(struct pim_instance *pim, pim_sgaddr *sg,
  * pim_upstream_evaluate_join_desired_interface but limited to
  * parent (*,G)'s includes/joins.
  */
-int pim_upstream_eval_inherit_if(struct pim_upstream *up,
-						 struct pim_ifchannel *ch,
-						 struct pim_ifchannel *starch)
+int pim_upstream_eval_inherit_if(struct pim_upstream *up, struct pim_ifchannel *ch,
+				 struct pim_ifchannel *chrpt, struct pim_ifchannel *starch)
 {
 	/* if there is an explicit prune for this interface we cannot
 	 * add it to the OIL
 	 */
-	if (ch) {
-		if (pim_ifchannel_is_sg_rpt(ch))
-			return 0;
-	}
+	if (chrpt)
+		return 0;
 
 	/* Check if the OIF can be inherited fron the (*,G) entry
 	 */
@@ -1327,32 +1327,22 @@ int pim_upstream_eval_inherit_if(struct pim_upstream *up,
  * Passed in up must be the upstream for ch.  starch is NULL if no
  * information
  */
-int pim_upstream_evaluate_join_desired_interface(struct pim_upstream *up,
-						 struct pim_ifchannel *ch,
+int pim_upstream_evaluate_join_desired_interface(struct pim_upstream *up, struct pim_ifchannel *ch,
+						 struct pim_ifchannel *chrpt,
 						 struct pim_ifchannel *starch)
 {
 	if (ch) {
-		if (pim_ifchannel_is_sg_rpt(ch))
-			return 0;
-
 		if (!pim_macro_ch_lost_assert(ch)
 		    && pim_macro_chisin_joins_or_include(ch))
 			return 1;
 	}
 
+	if (chrpt)
+		return 0;
 	/*
 	 * joins (*,G)
 	 */
 	if (starch) {
-		/* XXX: check on this with donald
-		 * we are looking for sg_rpt in
-		 * upstream flags?
-		 */
-#if 0
-		if (pim_ifchannel_is_sg_rpt(starch))
-			return 0;
-#endif
-
 		if (!pim_macro_ch_lost_assert(starch)
 		    && pim_macro_chisin_joins_or_include(starch))
 			return 1;
@@ -1368,21 +1358,20 @@ static bool pim_upstream_empty_immediate_olist(struct pim_instance *pim,
 				       struct pim_upstream *up)
 {
 	struct interface *ifp;
-	struct pim_ifchannel *ch;
+	struct pim_ifchannel *ch, *chrpt;
 
 	FOR_ALL_INTERFACES (pim->vrf, ifp) {
 		if (!ifp->info)
 			continue;
 
-		ch = pim_ifchannel_find(ifp, &up->sg);
+		pim_ifchannel_find(ifp, &up->sg, &ch, &chrpt);
 		if (!ch)
 			continue;
 
 		/* If we have even one immediate OIF we can return with
 		 * not-empty
 		 */
-		if (pim_upstream_evaluate_join_desired_interface(up, ch,
-					    NULL /* starch */))
+		if (pim_upstream_evaluate_join_desired_interface(up, ch, chrpt, NULL /* starch */))
 			return false;
 	} /* scan iface channel list */
 
@@ -2028,7 +2017,7 @@ int pim_upstream_inherited_olist_decide(struct pim_instance *pim,
 					struct pim_upstream *up)
 {
 	struct interface *ifp;
-	struct pim_ifchannel *ch, *starch;
+	struct pim_ifchannel *ch, *chrpt, *starch, *throwaway;
 	struct pim_upstream *starup = up->parent;
 	int output_intf = 0;
 
@@ -2042,10 +2031,9 @@ int pim_upstream_inherited_olist_decide(struct pim_instance *pim,
 		if (!ifp->info)
 			continue;
 
-		ch = pim_ifchannel_find(ifp, &up->sg);
-
+		pim_ifchannel_find(ifp, &up->sg, &ch, &chrpt);
 		if (starup)
-			starch = pim_ifchannel_find(ifp, &starup->sg);
+			pim_ifchannel_find(ifp, &starup->sg, &starch, &throwaway);
 		else
 			starch = NULL;
 
@@ -2058,8 +2046,7 @@ int pim_upstream_inherited_olist_decide(struct pim_instance *pim,
 		    && (PIM_UPSTREAM_FLAG_TEST_MLAG_NON_DF(up->flags)
 			|| !PIM_UPSTREAM_FLAG_TEST_MLAG_PEER(up->flags)))
 			continue;
-		if (pim_upstream_evaluate_join_desired_interface(up, ch,
-								 starch)) {
+		if (pim_upstream_evaluate_join_desired_interface(up, ch, chrpt, starch)) {
 			int flag = 0;
 
 			if (!ch)

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -318,12 +318,11 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 
 bool pim_upstream_evaluate_join_desired(struct pim_instance *pim,
 					struct pim_upstream *up);
-int pim_upstream_evaluate_join_desired_interface(struct pim_upstream *up,
-						 struct pim_ifchannel *ch,
+int pim_upstream_evaluate_join_desired_interface(struct pim_upstream *up, struct pim_ifchannel *ch,
+						 struct pim_ifchannel *chrpt,
 						 struct pim_ifchannel *starch);
-int pim_upstream_eval_inherit_if(struct pim_upstream *up,
-						 struct pim_ifchannel *ch,
-						 struct pim_ifchannel *starch);
+int pim_upstream_eval_inherit_if(struct pim_upstream *up, struct pim_ifchannel *ch,
+				 struct pim_ifchannel *chrpt, struct pim_ifchannel *starch);
 void pim_upstream_update_join_desired(struct pim_instance *pim,
 				      struct pim_upstream *up);
 

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -571,6 +571,12 @@ int pim_config_write(struct vty *vty, int writes, struct interface *ifp,
 		++writes;
 	}
 
+	if (pim_ifp->pim_override_interval_msec != PIM_DEFAULT_OVERRIDE_INTERVAL_MSEC) {
+		vty_out(vty, " " PIM_AF_NAME " pim override-interval %u\n",
+			pim_ifp->pim_override_interval_msec);
+		++writes;
+	}
+
 	/* update source */
 	if (!pim_addr_is_any(pim_ifp->update_source)) {
 		vty_out(vty, " " PIM_AF_NAME " pim use-source %pPA\n",

--- a/tests/topotests/pim_override_behavior/r1/frr.conf
+++ b/tests/topotests/pim_override_behavior/r1/frr.conf
@@ -1,0 +1,25 @@
+!
+hostname r1
+!
+interface r1-eth0
+ ip address 10.0.1.1/24
+ ip pim
+ ip pim override-interval 30000
+!
+interface r1-eth1
+ ip address 10.0.2.1/24
+ ip pim
+ ip pim override-interval 30000
+!
+interface lo
+ ip address 10.10.10.1/32
+ ip pim
+ ip pim override-interval 30000
+!
+router pim
+ rp 10.10.10.6 224.0.0.0/4
+!
+router rip
+ network 0.0.0.0/0
+ redistribute connected
+!

--- a/tests/topotests/pim_override_behavior/r2/frr.conf
+++ b/tests/topotests/pim_override_behavior/r2/frr.conf
@@ -1,0 +1,40 @@
+!
+hostname r2
+!
+interface r2-eth0
+ ip address 10.0.2.2/24
+ ip pim
+ ip pim override-interval 30000
+!
+interface r2-eth1
+ ip address 10.0.3.2/24
+ ip pim
+ ip igmp
+!
+interface r2-eth2
+ ip address 10.0.4.2/24
+ ip pim
+ ip igmp
+!
+interface r2-eth3
+ ip address 10.0.6.2/24
+ ip pim
+ ip pim override-interval 30000
+!
+interface lo
+ ip address 10.10.10.2/32
+ ip pim
+ ip pim override-interval 30000
+!
+router pim
+ rp 10.10.10.6 224.0.0.0/4
+!
+! Access list to prefer routes via r2-eth1 (to r4)
+! by making routes out r2-eth0 (shared LAN) worse
+access-list PREFER_R4 permit 0.0.0.0 255.255.255.255
+!
+router rip
+ network 0.0.0.0/0
+ redistribute connected
+ offset-list PREFER_R4 out 5 r2-eth0
+ !

--- a/tests/topotests/pim_override_behavior/r3/frr.conf
+++ b/tests/topotests/pim_override_behavior/r3/frr.conf
@@ -1,0 +1,25 @@
+!
+hostname r3
+!
+interface r3-eth0
+ ip address 10.0.2.3/24
+ ip pim
+ ip pim override-interval 30000
+!
+interface r3-eth1
+ ip address 10.0.5.3/24
+ ip pim
+ ip igmp
+!
+interface lo
+ ip address 10.10.10.3/32
+ ip pim
+ ip pim override-interval 30000
+!
+router pim
+ rp 10.10.10.6 224.0.0.0/4
+!
+router rip
+ network 0.0.0.0/0
+ redistribute connected
+!

--- a/tests/topotests/pim_override_behavior/r5/frr.conf
+++ b/tests/topotests/pim_override_behavior/r5/frr.conf
@@ -1,0 +1,9 @@
+!
+hostname r5
+!
+interface r5-eth0
+ ip address 10.0.5.5/24
+!
+interface lo
+ ip address 10.10.10.5/32
+!

--- a/tests/topotests/pim_override_behavior/rp/frr.conf
+++ b/tests/topotests/pim_override_behavior/rp/frr.conf
@@ -1,0 +1,30 @@
+!
+hostname rp
+!
+interface rp-eth0
+ ip address 10.0.1.6/24
+ ip pim
+ ip pim override-interval 30000
+!
+interface rp-eth1
+ ip address 10.0.6.6/24
+ ip pim
+ ip pim override-interval 30000
+!
+interface lo
+ ip address 10.10.10.6/32
+ ip pim
+ ip pim override-interval 30000
+!
+router pim
+ rp 10.10.10.6 224.0.0.0/4
+!
+! Access list to prefer routes via rp-eth1 (direct to r2)
+! by making routes out rp-eth0 worse
+access-list PREFER_R2 permit 0.0.0.0 255.255.255.255
+!
+router rip
+ network 0.0.0.0/0
+ redistribute connected
+ offset-list PREFER_R2 out 5 rp-eth1
+!

--- a/tests/topotests/pim_override_behavior/test_pim_override_behavior.py
+++ b/tests/topotests/pim_override_behavior/test_pim_override_behavior.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+#
+# test_pim_override_behavior.py
+#
+# Copyright (c) 2026 FRR Project
+#
+
+"""
+test_pim_override_behavior.py: Testing PIM Assert/Override behavior
+
+This test validates PIM Assert mechanism where multiple routers 
+on a shared LAN segment compete to be the designated forwarder.
+"""
+
+import os
+import sys
+import pytest
+from functools import partial
+
+pytestmark = [pytest.mark.pimd, pytest.mark.ripd]
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+#####################################################
+##
+##   Network Topology Definition
+##
+#####################################################
+
+
+def build_topo(tgen):
+    """
+    Topology:
+    
+                  +--------+
+                  |   rp   |
+                  | .6     |
+                  +--------+
+                      |
+                  +--------+
+                  |   r1   |
+                  | .1     |
+                  +--------+
+                      |
+         +------------+------------+  (Shared LAN - PIM Assert occurs here)
+         |            |            |
+     +--------+   +--------+   +--------+
+     |   r2   |   |   r3   |   |  r1    |
+     | .2     |   | .3     |   |        |
+     +--------+   +--------+   +--------+
+      |      |         |
+      |      |    +--------+
+      |      |    |   r5   |  (Source/Receiver)
+      |      |    | .5     |
+      |      |    +--------+
+      |      |
+      |   +--------+
+      |   |   r4   |  (Source/Receiver)
+      +-->| .4     |
+          +--------+
+    
+    Key aspects:
+    - rp connected to r1 and r2
+    - r1, r2, r3 share a LAN (PIM Assert will occur here)
+    - r2 has 2 links to r4
+    - r3 has 1 link to r5
+    - PIM only on rp, r1, r2, r3 (NOT on r4/r5)
+    - RIP on rp, r1, r2, r3 with redistribute connected
+    - RIP metrics configured to prefer rp->r2 direct link
+    """
+    
+    # Add routers
+    tgen.add_router("rp")
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+    tgen.add_router("r3")
+    tgen.add_router("r4")
+    tgen.add_router("r5")
+    
+    # Link 1: rp to r1
+    switch = tgen.add_switch("s1")
+    switch.add_link(tgen.gears["rp"])
+    switch.add_link(tgen.gears["r1"])
+    
+    # Link 2: Shared LAN - r1, r2, r3
+    switch = tgen.add_switch("s2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r3"])
+    
+    # Link 3: r2 to r4 (first connection)
+    switch = tgen.add_switch("s3")
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r4"])
+    
+    # Link 4: r2 to r4 (second connection)
+    switch = tgen.add_switch("s4")
+    switch.add_link(tgen.gears["r2"])
+    switch.add_link(tgen.gears["r4"])
+    
+    # Link 5: r3 to r5
+    switch = tgen.add_switch("s5")
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["r5"])
+    
+    # Link 6: rp to r2 (direct connection)
+    switch = tgen.add_switch("s6")
+    switch.add_link(tgen.gears["rp"])
+    switch.add_link(tgen.gears["r2"])
+
+
+#####################################################
+##
+##   Tests starting
+##
+#####################################################
+
+
+def setup_module(module):
+    "Setup topology"
+    tgen = Topogen(build_topo, module.__name__)
+    tgen.start_topology()
+
+    # Configure routers
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(
+            os.path.join(CWD, "{}/frr.conf".format(rname)),
+            [
+                (TopoRouter.RD_ZEBRA, None),
+                (TopoRouter.RD_PIM, None),
+                (TopoRouter.RD_RIP, None),
+            ],
+        )
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+
+    # This function tears down the whole topology.
+    tgen.stop_topology()
+
+
+def test_pim_neighbors():
+    "Verify PIM neighbors are formed"
+    tgen = get_topogen()
+    
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    
+    logger.info("Checking PIM neighbor adjacencies")
+    
+    # Check rp has neighbors with r1 and r2
+    rp = tgen.gears["rp"]
+    expected = {
+        "rp-eth0": {},  # r1
+        "rp-eth1": {},  # r2
+    }
+    test_func = partial(
+        topotest.router_json_cmp, rp, "show ip pim neighbor json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "rp: PIM neighbors did not converge"
+    assert result is None, assertmsg
+    
+    # Check r1 has neighbors with rp, r2, and r3
+    r1 = tgen.gears["r1"]
+    expected = {
+        "r1-eth0": {},  # rp
+        "r1-eth1": {},  # r2 and r3 on shared LAN
+    }
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip pim neighbor json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "r1: PIM neighbors did not converge"
+    assert result is None, assertmsg
+    
+    # Check r2 has neighbors on shared LAN and with rp
+    r2 = tgen.gears["r2"]
+    expected = {
+        "r2-eth0": {},  # r1 and r3 on shared LAN
+        "r2-eth3": {},  # rp
+    }
+    test_func = partial(
+        topotest.router_json_cmp, r2, "show ip pim neighbor json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "r2: PIM neighbors did not converge"
+    assert result is None, assertmsg
+    
+    # Check r3 has neighbors on shared LAN
+    r3 = tgen.gears["r3"]
+    expected = {
+        "r3-eth0": {},  # r1 and r2 on shared LAN
+    }
+    test_func = partial(
+        topotest.router_json_cmp, r3, "show ip pim neighbor json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "r3: PIM neighbors did not converge"
+    assert result is None, assertmsg
+    
+    logger.info("All PIM neighbors converged successfully")
+
+
+def test_ensure_override_is_signaled():
+    "Verify PIM override interval is properly configured and signaled"
+    tgen = get_topogen()
+    
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    
+    logger.info("Checking PIM override interval configuration")
+    
+    # Check that override interval is set to 30000ms on all PIM interfaces
+    routers_to_check = ["rp", "r1", "r2", "r3"]
+    
+    for router_name in routers_to_check:
+        router = tgen.gears[router_name]
+        logger.info(f"Checking override interval on {router_name}")
+        
+        # Get PIM interface details
+        output = router.vtysh_cmd("show ip pim interface detail", isjson=False)
+        
+        # Check that at least one physical interface has override interval configured (30000 ms)
+        # Skip checking loopback and pimreg interfaces
+        # Look for the specific pattern "Override Interval           : 30000 msec"
+        found_30000 = False
+        for line in output.split('\n'):
+            if "Override Interval" in line and ": 30000 msec" in line:
+                found_30000 = True
+                logger.info(f"{router_name}: Found configured override interval: {line.strip()}")
+                break
+        
+        if not found_30000:
+            logger.error(f"{router_name} PIM interface detail output:\n{output}")
+            assert False, f"{router_name}: Override interval not set to 30000ms on any interface"
+        
+        logger.info(f"{router_name}: Override interval is properly configured")
+    
+    logger.info("All routers have override interval properly signaled")
+
+
+def do_not_run_pim_override_behavior():
+    "Test PIM Assert/Override mechanism on shared LAN"
+    logger.info("Testing PIM Override behavior on shared LAN")
+    
+    tgen = get_topogen()
+    
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+    
+    r1 = tgen.gears["r1"]
+    r2 = tgen.gears["r2"]
+    r3 = tgen.gears["r3"]
+    r4 = tgen.gears["r4"]
+    r5 = tgen.gears["r5"]
+    
+    # Start multicast receiver on r4
+    mcast_tester = os.path.join(CWD, "../lib/mcast-tester.py")
+    cmd_r4 = [mcast_tester, "229.1.1.1", "r4-eth1"]
+    p_r4 = r4.popen(cmd_r4)
+    
+    # Start multicast receiver on r5
+    cmd_r5 = [mcast_tester, "229.1.1.1", "r5-eth0"]
+    p_r5 = r5.popen(cmd_r5)
+    
+    # Wait for *,G join to propagate from r2 and r3 to r1
+    logger.info("Waiting for *,G join to propagate to r1")
+    import time
+    
+    # Check that r1 receives *,G join on the shared LAN interface (r1-eth1)
+    expected = {
+        "r1-eth1": {
+            "229.1.1.1": {
+                "*": {
+                    "source": "*",
+                    "group": "229.1.1.1",
+                }
+            }
+        }
+    }
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip pim join json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "r1: *,G join for 229.1.1.1 not received on r1-eth1"
+    assert result is None, assertmsg
+    
+    logger.info("r1 has *,G state for 229.1.1.1 on shared LAN")
+
+    logger.info("start a stream on r4 and make sure that r1 is correct")    
+    # Start multicast source on r4 (first interface)
+    mcast_tx = os.path.join(CWD, "../pim_basic/mcast-tx.py")
+    cmd_tx = [mcast_tx, "--ttl", "10", "--count", "1000", "--interval", "1", 
+              "229.1.1.1", "r4-eth0"]
+    p_tx = r4.popen(cmd_tx)
+ 
+    # Wait for traffic to flow and both S,G JOIN and S,G,rpt state to be established on r1
+    logger.info("Waiting for S,G JOIN and S,G,rpt state on r1")
+    expected = {
+        "r1-eth1": {
+            "229.1.1.1": {
+                "*": {
+                    "source": "*",
+                    "group": "229.1.1.1",
+                    "channelJoinName": "JOIN",
+                },
+                "10.0.3.4": {
+                    "source": "10.0.3.4",
+                    "group": "229.1.1.1",
+                    "channelJoinName": "JOIN",
+                },
+                "10.0.3.4,S,Grpt": {
+                    "source": "10.0.3.4",
+                    "group": "229.1.1.1",
+                    "channelJoinName": "SGRpt(P)",
+                }
+            }
+        }
+    }
+    test_func = partial(
+        topotest.router_json_cmp, r1, "show ip pim join json", expected
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=1)
+    assertmsg = "r1: S,G JOIN and S,G,rpt state for 229.1.1.1 not established on r1-eth1"
+    assert result is None, assertmsg
+    
+    logger.info("r1 has *,G, S,G JOIN, and S,G,rpt state for 229.1.1.1 on shared LAN")
+    
+    # Check that traffic flows through the network
+    # r2 and r3 are on a shared LAN with r1
+    # Both should receive joins from downstream
+    logger.info("Checking for PIM state on shared LAN")
+    
+    # Check r1's upstream state
+    r1_upstream = r1.vtysh_cmd("show ip pim upstream json", isjson=True)
+    logger.info("r1 upstream state: {}".format(r1_upstream))
+    
+    # Check r2's view
+    r2_upstream = r2.vtysh_cmd("show ip pim upstream json", isjson=True)
+    logger.info("r2 upstream state: {}".format(r2_upstream))
+    
+    # Check r3's view
+    r3_upstream = r3.vtysh_cmd("show ip pim upstream json", isjson=True)
+    logger.info("r3 upstream state: {}".format(r3_upstream))
+    
+    # Verify that traffic is being forwarded
+    # r2 should have upstream state (source is behind r2)
+    assert len(r2_upstream) > 0, "No upstream state found on r2"
+    
+    logger.info("PIM Assert behavior test completed successfully")
+    
+    if p_tx:
+        p_tx.terminate()
+        p_tx.wait()
+    if p_r4:
+        p_r4.terminate()
+        p_r4.wait()
+    if p_r5:
+        p_r5.terminate()
+        p_r5.wait()
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -612,6 +612,15 @@ module frr-pim {
         "Assert override interval in milliseconds. (calculated from assert interval by default)";
     }
 
+    leaf override-interval {
+      type uint16 {
+        range "0..65535";
+      }
+      default "2500";
+      description
+        "LAN prune delay override interval in milliseconds.";
+    }
+
     container bfd {
       presence
         "Enable BFD support on the interface.";


### PR DESCRIPTION
Highlights:

a) Fixup a gdb macro that was not quite right and add a new dump_pim_jp_agg_list macro
b) Seperate out the S,G ifchannel state from the S,G rpt ifchannel state they are two different state machines, that the pim code was combining into 1.
c) When a nht event happens and we have to switch the RPF for the up stream.  Let's just immediately remove it from the old periodic jp agg list.  There is absolutely no need to keep it in there to cause problems later.
d) Allow pim to override the default override-interval
e) Add a test that shows that the override-interval is received and understood from the hello's.
f) Additionally have some nascent test that shows that we are doing something fundamentally wrong with lan segments.  At this point in time I am not 100% sure what to do to fix this.  I intend to have discussions with some people about this.