### PR TITLE
bgpd: reduce ibuf_work ring buffer size

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1271,7 +1271,7 @@ struct peer_connection *bgp_peer_connection_new(struct peer *peer, const union s
 	 * UPDATE.
 	 */
 	connection->ibuf_work =
-		ringbuf_new(BGP_MAX_PACKET_SIZE * BGP_READ_PACKET_MAX);
+		ringbuf_new(BGP_MAX_PACKET_SIZE + BGP_MAX_PACKET_SIZE / 2);
 
 	connection->status = Idle;
 	connection->ostatus = Idle;


### PR DESCRIPTION
Restore the size reduction for ibuf_work after the allocation moved to bgp_peer_connection_new. This aligns with the original size-reduction commit (fe1c72a573, cherry-pick 91e95112e8) and avoids the 10x sizing from e27bf2b9bd6 in the new allocation site.

It can hold one full max‑size BGP message (65,535 bytes) plus 50% headroom (~32 KB) for partial next reads. 98KB per peer.

History:
- fe1c72a573 / 91e95112e8: reduce ibuf_work ringbuf size
- e27bf2b9bd6: introduce bgp_peer_connection_new allocation