### PR TITLE
bgpd: remove unused argument in bgp_adj_out_unset_subgroup()

### DIFF
--- a/bgpd/bgp_conditional_adv.c
+++ b/bgpd/bgp_conditional_adv.c
@@ -137,8 +137,7 @@ static void bgp_conditional_adv_routes(struct peer *peer, afi_t afi,
 				    is_default_prefix(dest_p))
 					break;
 
-				bgp_adj_out_unset_subgroup(
-					dest, subgrp, 1,
+				bgp_adj_out_unset_subgroup(dest, subgrp,
 					bgp_addpath_id_for_peer(
 						peer, afi, safi,
 						&pi->tx_addpath));

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3707,28 +3707,26 @@ void subgroup_process_announce_selected(struct update_subgroup *subgrp,
 							if (!adj->adv &&
 							    adj->addpath_tx_id != addpath_tx_id) {
 								bgp_adj_out_unset_subgroup(dest,
-											   subgrp, 1,
+											   subgrp,
 											   adj->addpath_tx_id);
 							}
 						}
 					}
 				} else {
-					bgp_adj_out_unset_subgroup(
-						dest, subgrp, 1, addpath_tx_id);
+					bgp_adj_out_unset_subgroup(dest, subgrp, addpath_tx_id);
 					bgp_attr_flush(pattr);
 				}
 			} else
 				bgp_attr_flush(pattr);
 		} else {
-			bgp_adj_out_unset_subgroup(dest, subgrp, 1,
-						   addpath_tx_id);
+			bgp_adj_out_unset_subgroup(dest, subgrp, addpath_tx_id);
 			bgp_attr_flush(pattr);
 		}
 	}
 
 	/* If selected is NULL we must withdraw the path using addpath_tx_id */
 	else {
-		bgp_adj_out_unset_subgroup(dest, subgrp, 1, addpath_tx_id);
+		bgp_adj_out_unset_subgroup(dest, subgrp, addpath_tx_id);
 	}
 }
 

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -442,7 +442,7 @@ extern bool bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 				     struct bgp_path_info *path);
 extern void bgp_adj_out_unset_subgroup(struct bgp_dest *dest,
 				       struct update_subgroup *subgrp,
-				       char withdraw, uint32_t addpath_tx_id);
+				       uint32_t addpath_tx_id);
 void subgroup_announce_table(struct update_subgroup *subgrp,
 			     struct bgp_table *table);
 extern void subgroup_trigger_write(struct update_subgroup *subgrp);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -701,12 +701,7 @@ bool bgp_adj_out_set_subgroup(struct bgp_dest *dest,
 	return true;
 }
 
-/* The only time 'withdraw' will be false is if we are sending
- * the "neighbor x.x.x.x default-originate" default and need to clear
- * bgp_adj_out for the 0.0.0.0/0 route in the BGP table.
- */
-void bgp_adj_out_unset_subgroup(struct bgp_dest *dest,
-				struct update_subgroup *subgrp, char withdraw,
+void bgp_adj_out_unset_subgroup(struct bgp_dest *dest, struct update_subgroup *subgrp,
 				uint32_t addpath_tx_id)
 {
 	struct bgp_adj_out *adj;
@@ -734,7 +729,7 @@ void bgp_adj_out_unset_subgroup(struct bgp_dest *dest,
 		    && is_default_prefix(bgp_dest_get_prefix(dest)))
 			return;
 
-		if (adj->attr && withdraw) {
+		if (adj->attr) {
 			/* We need advertisement structure.  */
 			adj->adv = bgp_advertise_new();
 			adv = adj->adv;


### PR DESCRIPTION
Just code clean up, no functional impact.