### PR TITLE
yang: Fix pyang errors in frr-filter.yang

### DIFF
--- a/yang/frr-filter.yang
+++ b/yang/frr-filter.yang
@@ -278,20 +278,20 @@ module frr-filter {
             when "../type = 'ipv6'";
 
             choice style {
-              description "Access list entry style selection: zebra or cisco.";
               mandatory true;
+              description "Access list entry style selection: zebra or cisco.";
 
               case zebra {
                 leaf ipv6-prefix {
-                  description "Configure IPv6 prefix to match";
                   type inet:ipv6-prefix;
                   mandatory true;
+                  description "Configure IPv6 prefix to match";
                 }
 
                 leaf ipv6-exact-match {
-                  description "Exact match of prefix";
                   type boolean;
                   default false;
+                  description "Exact match of prefix";
                 }
               }
 
@@ -300,19 +300,21 @@ module frr-filter {
                   description "Source value to match";
 
                   leaf ipv6-host {
-                    description "Host to match";
                     type inet:ipv6-address;
+                    description "Host to match";
                   }
                   container ipv6-network {
+                    description "Container for IPv6 network configuration.";
+
                     leaf address {
+                      type inet:ipv6-address;
                       mandatory true;
                       description "Network address part.";
-                      type inet:ipv6-address;
                     }
                     leaf mask {
+                      type inet:ipv6-address;
                       mandatory true;
                       description "Network mask/wildcard part.";
-                      type inet:ipv6-address;
                     }
                   }
                   leaf ipv6-source-any {
@@ -320,8 +322,8 @@ module frr-filter {
                      * Was `any`, however it conflicts with `any` leaf
                      * outside this choice.
                      */
-                    description "Match any";
                     type empty;
+                    description "Match any";
                   }
                 }
 
@@ -329,24 +331,26 @@ module frr-filter {
                   description "Destination value to match";
 
                   leaf ipv6-destination-host {
-                    description "Host to match";
                     type inet:ipv6-address;
+                    description "Host to match";
                   }
                   container ipv6-destination-network {
+                    description "Container for IPv6 destination network configuration.";
+
                     leaf address {
+                      type inet:ipv6-address;
                       mandatory true;
                       description "Network address part.";
-                      type inet:ipv6-address;
                     }
                     leaf mask {
+                      type inet:ipv6-address;
                       mandatory true;
                       description "Network mask/wildcard part.";
-                      type inet:ipv6-address;
                     }
                   }
                   leaf ipv6-destination-any {
-                    description "Match any";
                     type empty;
+                    description "Match any";
                   }
                 }
 


### PR DESCRIPTION
Fix pyang errors in frr-filter.yang

frr-filter.yang:282: error: keyword "mandatory" not in canonical order (see RFC 7950, Section 14)
frr-filter.yang:286: error: keyword "description" not in canonical order, expected "type" (see RFC 7950, Section 14)
frr-filter.yang:287: error: keyword "type" not in canonical order (see RFC 7950, Section 14)
frr-filter.yang:288: error: keyword "mandatory" not in canonical order (see RFC 7950, Section 14)
frr-filter.yang:292: error: keyword "description" not in canonical order, expected "type" (see RFC 7950, Section 14)
frr-filter.yang:293: error: keyword "type" not in canonical order (see RFC 7950, Section 14)
frr-filter.yang:294: error: keyword "default" not in canonical order (see RFC 7950, Section 14)
frr-filter.yang:303: error: keyword "description" not in canonical order, expected "type" (see RFC 7950, Section 14)
frr-filter.yang:304: error: keyword "type" not in canonical order (see RFC 7950, Section 14)
frr-filter.yang:306: error: RFC 8407: 4.14: statement "container" must have a "description" substatement
frr-filter.yang:308: error: keyword "mandatory" not in canonical order, expected "type" (see RFC 7950, Section 14)
frr-filter.yang:310: error: keyword "type" not in canonical order (see RFC 7950, Section 14)
frr-filter.yang:313: error: keyword "mandatory" not in canonical order, expected "type" (see RFC 7950, Section 14)
frr-filter.yang:315: error: keyword "type" not in canonical order (see RFC 7950, Section 14)
frr-filter.yang:323: error: keyword "description" not in canonical order, expected "type" (see RFC 7950, Section 14)
frr-filter.yang:324: error: keyword "type" not in canonical order (see RFC 7950, Section 14)
frr-filter.yang:332: error: keyword "description" not in canonical order, expected "type" (see RFC 7950, Section 14)
frr-filter.yang:333: error: keyword "type" not in canonical order (see RFC 7950, Section 14)
frr-filter.yang:335: error: RFC 8407: 4.14: statement "container" must have a "description" substatement
frr-filter.yang:337: error: keyword "mandatory" not in canonical order, expected "type" (see RFC 7950, Section 14)
frr-filter.yang:339: error: keyword "type" not in canonical order (see RFC 7950, Section 14)
frr-filter.yang:342: error: keyword "mandatory" not in canonical order, expected "type" (see RFC 7950, Section 14)
frr-filter.yang:344: error: keyword "type" not in canonical order (see RFC 7950, Section 14)
frr-filter.yang:348: error: keyword "description" not in canonical order, expected "type" (see RFC 7950, Section 14)
frr-filter.yang:349: error: keyword "type" not in canonical order (see RFC 7950, Section 14)