### PR TITLE
Send register in fhr lhr case

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -604,9 +604,9 @@ struct connected *if_lookup_address(const void *matchaddr, int family,
 
 	FOR_ALL_INTERFACES (vrf, ifp) {
 		frr_each (if_connected, ifp->connected, c) {
-			if (c->address && (c->address->family == AF_INET)
-			    && prefix_match(CONNECTED_PREFIX(c), &addr)
-			    && (c->address->prefixlen > bestlen)) {
+			if (c->address && (c->address->family == family) &&
+			    prefix_match(CONNECTED_PREFIX(c), &addr) &&
+			    (c->address->prefixlen > bestlen)) {
 				bestlen = c->address->prefixlen;
 				match = c;
 			}

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -436,30 +436,53 @@ int pim_mroute_msg_wholepkt(int fd, struct interface *ifp, const char *buf,
 	up = pim_upstream_find(pim_ifp->pim, &sg);
 	if (!up) {
 		pim_sgaddr star = sg;
+
 		star.src = PIMADDR_ANY;
 
 		up = pim_upstream_find(pim_ifp->pim, &star);
 
 		if (up && PIM_UPSTREAM_FLAG_TEST_CAN_BE_LHR(up->flags)) {
-			up = pim_upstream_add(pim_ifp->pim, &sg, ifp,
-					      PIM_UPSTREAM_FLAG_MASK_SRC_LHR,
-					      __func__, NULL);
-			if (!up) {
+			struct connected *src_conn = NULL;
+			struct pim_interface *src_pim_ifp = NULL;
+
+			/*
+			 * Now let's test to see if this also can be
+			 * a FHR as well, As that this is a possibility
+			 * and if it is we must treat it as such.
+			 */
+			src_conn = if_lookup_address(&sg.src, PIM_AF, pim_ifp->pim->vrf->vrf_id);
+
+			if (src_conn && src_conn->ifp->info)
+				src_pim_ifp = src_conn->ifp->info;
+
+			if (src_conn != NULL && src_pim_ifp && src_pim_ifp->pim_enable) {
+				up = pim_upstream_add(pim_ifp->pim, &sg, src_conn->ifp,
+						      PIM_UPSTREAM_FLAG_MASK_FHR, __func__, NULL);
+				PIM_UPSTREAM_FLAG_SET_SRC_STREAM(up->flags);
+				pim_upstream_keep_alive_timer_start(up,
+								    pim_ifp->pim->keep_alive_time);
+				pim_upstream_inherited_olist(pim_ifp->pim, up);
+				pim_upstream_update_join_desired(pim_ifp->pim, up);
+				if (!pim_is_group_filtered(pim_ifp, &sg.grp, &sg.src))
+					pim_register_join(up);
 				if (PIM_DEBUG_MROUTE)
-					zlog_debug(
-						"%s: Unable to create upstream information for %pSG",
-						__func__, &sg);
+					zlog_debug("%s: Treat WHOLEPKT on pimreg as FHR for %pSG",
+						   __func__, &sg);
+				goto have_up;
+			} else {
+				up = pim_upstream_add(pim_ifp->pim, &sg, ifp,
+						      PIM_UPSTREAM_FLAG_MASK_SRC_LHR, __func__,
+						      NULL);
+				pim_upstream_keep_alive_timer_start(up,
+								    pim_ifp->pim->keep_alive_time);
+				pim_upstream_inherited_olist(pim_ifp->pim, up);
+				pim_upstream_update_join_desired(pim_ifp->pim, up);
+
+				if (PIM_DEBUG_MROUTE)
+					zlog_debug("%s: Creating %s upstream on LHR", __func__,
+						   up->sg_str);
 				return 0;
 			}
-			pim_upstream_keep_alive_timer_start(
-				up, pim_ifp->pim->keep_alive_time);
-			pim_upstream_inherited_olist(pim_ifp->pim, up);
-			pim_upstream_update_join_desired(pim_ifp->pim, up);
-
-			if (PIM_DEBUG_MROUTE)
-				zlog_debug("%s: Creating %s upstream on LHR",
-					   __func__, up->sg_str);
-			return 0;
 		}
 		if (PIM_DEBUG_MROUTE_DETAIL) {
 			zlog_debug(
@@ -468,6 +491,8 @@ int pim_mroute_msg_wholepkt(int fd, struct interface *ifp, const char *buf,
 		}
 		return 0;
 	}
+
+have_up:
 
 	if (!up->rpf.source_nexthop.interface) {
 		if (PIM_DEBUG_PIM_TRACE)

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -2340,6 +2340,23 @@ static bool pim_upstream_sg_running_proc(struct pim_upstream *up)
 			PIM_UPSTREAM_FLAG_SET_SRC_STREAM(up->flags);
 			pim_upstream_fhr_kat_start(up);
 		}
+
+		/*
+		 * Let's ensure that when we have an active source that we do not have any
+		 * register state for that is a FHR, that we allow the registration to
+		 * happen if it should be
+		 */
+		if (pim_upstream_could_register(up) && !pim_is_grp_ssm(pim, up->sg.grp) &&
+		    up->reg_state == PIM_REG_NOINFO && !event_is_scheduled(up->t_rs_timer) &&
+		    !PIM_UPSTREAM_DM_TEST_INTERFACE(up->flags) && pim->regiface &&
+		    pim->regiface->configured) {
+			if (PIM_DEBUG_PIM_TRACE)
+				zlog_debug("%s: add pimreg to %s[%s]", __func__, up->sg_str,
+					   pim->vrf->name);
+			PIM_UPSTREAM_FLAG_SET_FHR(up->flags);
+			pim_register_join(up);
+			pim_upstream_update_use_rpt(up, true /*update_mroute*/);
+		}
 		pim_upstream_keep_alive_timer_start(up, pim->keep_alive_time);
 		rv = true;
 	} else if (PIM_UPSTREAM_FLAG_TEST_SRC_LHR(up->flags)) {


### PR DESCRIPTION
Currently if pim is both a FHR and a LHR for a S,G, it is possible that the actions of the LHR or other actions on the network can cause a S,G join to happen on the LHR prior to any S, G stream flowing.  When this happens pimd was not correctly transitioning the S,G mroute to have a pimreg device to allow for proper registration of the S,G with the RP.  This fixes this problem.

Fixes #18445