### PR TITLE
pimd: Keep track of how long the S,G rpt Prune has been around

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -1078,6 +1078,7 @@ void pim_ifchannel_prune(struct interface *ifp, pim_addr upstream,
 		 * causing it to expire immediately.
 		 */
 
+		ch->ifjoin_creation = pim_time_monotonic_sec();
 		pim_ifchannel_ifjoin_switch(__func__, ch,
 					    PIM_IFJOIN_PRUNE_PENDING);
 
@@ -1133,6 +1134,7 @@ void pim_ifchannel_prune(struct interface *ifp, pim_addr upstream,
 		break;
 	case PIM_IFJOIN_PRUNE_PENDING_TMP:
 		if (source_flags & PIM_ENCODE_RPT_BIT) {
+			ch->ifjoin_creation = pim_time_monotonic_sec();
 			ch->ifjoin_state = PIM_IFJOIN_PRUNE_PENDING;
 			event_cancel(&ch->t_ifjoin_expiry_timer);
 			event_add_timer(router->master, on_ifjoin_expiry_timer,


### PR DESCRIPTION
The S,G rpt prune ifchannel was not tracking uptime.  Let's do so.