### PR TITLE
zebra: Allow redistribution events to pass reserved ranges

### DIFF
--- a/tests/topotests/zebra_reserved_ranges/r1/frr.conf
+++ b/tests/topotests/zebra_reserved_ranges/r1/frr.conf
@@ -5,3 +5,11 @@ interface r1-eth0
  ip address 0.1.2.3/24
  ip address 240.1.2.3/24
 !
+router bgp 65001
+ bgp router-id 1.1.1.1
+ no bgp ebgp-requires-policy
+ !
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+!

--- a/tests/topotests/zebra_reserved_ranges/test_zebra_reserved_ranges.py
+++ b/tests/topotests/zebra_reserved_ranges/test_zebra_reserved_ranges.py
@@ -18,8 +18,9 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 from lib import topotest
 from lib.topogen import Topogen, get_topogen, TopoRouter
+from lib.topolog import logger
 
-pytestmark = [pytest.mark.mgmtd]
+pytestmark = [pytest.mark.mgmtd, pytest.mark.bgpd]
 
 
 def build_topo(tgen):
@@ -39,6 +40,7 @@ def setup_module(mod):
             [
                 (TopoRouter.RD_ZEBRA, None),
                 (TopoRouter.RD_MGMTD, None),
+                (TopoRouter.RD_BGP, None),
             ],
         )
 
@@ -79,9 +81,108 @@ def test_zebra_reserved_ranges():
         }
         return topotest.json_cmp(output, expected)
 
+    logger.info("Testing that Zebra sees the reserved ranges")
     test_func = functools.partial(_check_interfaces)
     _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
     assert result is None, "Can't see reserved IP ranges assigned for r1-eth0 interface"
+
+
+def test_redisted_routes_received():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r1 = tgen.gears["r1"]
+
+    def _check_bgp_routes():
+        output = json.loads(r1.vtysh_cmd("show bgp ipv4 uni json"))
+        expected = {
+            "routes": {
+                "0.1.2.0/24": [
+                    {
+                        "valid": True,
+                        "bestpath": True,
+                        "selectionReason": "First path received",
+                        "pathFrom": "external",
+                        "prefix": "0.1.2.0",
+                        "prefixLen": 24,
+                        "network": "0.1.2.0/24",
+                        "metric": 0,
+                        "weight": 32768,
+                        "peerId": "(unspec)",
+                        "path": "",
+                        "origin": "incomplete",
+                        "nexthops": [
+                            {
+                                "ip": "0.0.0.0",
+                                "hostname": "r1",
+                                "afi": "ipv4",
+                                "used": True,
+                            }
+                        ],
+                    }
+                ],
+                "127.1.2.0/24": [
+                    {
+                        "valid": True,
+                        "bestpath": True,
+                        "selectionReason": "First path received",
+                        "pathFrom": "external",
+                        "prefix": "127.1.2.0",
+                        "prefixLen": 24,
+                        "network": "127.1.2.0/24",
+                        "metric": 0,
+                        "weight": 32768,
+                        "peerId": "(unspec)",
+                        "path": "",
+                        "origin": "incomplete",
+                        "nexthops": [
+                            {
+                                "ip": "0.0.0.0",
+                                "hostname": "r1",
+                                "afi": "ipv4",
+                                "used": True,
+                            }
+                        ],
+                    }
+                ],
+                "240.1.2.0/24": [
+                    {
+                        "valid": True,
+                        "bestpath": True,
+                        "selectionReason": "First path received",
+                        "pathFrom": "external",
+                        "prefix": "240.1.2.0",
+                        "prefixLen": 24,
+                        "network": "240.1.2.0/24",
+                        "metric": 0,
+                        "weight": 32768,
+                        "peerId": "(unspec)",
+                        "path": "",
+                        "origin": "incomplete",
+                        "nexthops": [
+                            {
+                                "ip": "0.0.0.0",
+                                "hostname": "r1",
+                                "afi": "ipv4",
+                                "used": True,
+                            }
+                        ],
+                    }
+                ],
+            },
+            "totalRoutes": 3,
+            "totalPaths": 3,
+        }
+        return topotest.json_cmp(output, expected)
+
+    logger.info(
+        "Testing that bgp sees the 0.1.2.0/24, 127.1.2.0/24 and the 240.1.2.0/24 routes"
+    )
+    test_func = functools.partial(_check_bgp_routes)
+    _, result = topotest.run_and_expect(test_func, None, count=20, wait=1)
+    assert result is None, "Missing redistributed routes in BGP"
 
 
 def test_memory_leak():

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -443,8 +443,10 @@ int zebra_check_addr(const struct prefix *p)
 
 		addr = ntohl(p->u.prefix4.s_addr);
 
-		if (IPV4_NET127(addr) || IN_CLASSD(addr) ||
-		    (IPV4_LINKLOCAL(addr) && !IPV4_CLASS_E(addr)))
+		if ((IPV4_NET127(addr) || IN_CLASSD(addr)) && !cmd_allow_reserved_ranges_get())
+			return 0;
+
+		if (IPV4_LINKLOCAL(addr) && !IPV4_CLASS_E(addr))
 			return 0;
 	}
 	if (p->family == AF_INET6) {


### PR DESCRIPTION
If `allow-reserved-ranges` has been configured, allow the redistribution event to be passed up to the interested protocol.

I ran into this while playing with 224/4 flavors of static routes and was trying to get the static route into bgp.  BGP was allowing network XXX statements for the routes.  So I do not see much of a difference here.