### PR TITLE
bgpd: Do not clear writes on keeper when transferring connection

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -172,8 +172,6 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 
 	bgp_writes_off(going_away);
 	bgp_reads_off(going_away);
-	bgp_writes_off(keeper);
-	bgp_reads_off(keeper);
 
 	/*
 	 * Before exchanging FD remove doppelganger from


### PR DESCRIPTION
We are seeing this type of log message in BGP in a variety of tests:

2026/01/26 16:45:35.249566 BGP: [VRBDE-PTM0N][EC 33554454] 2.2.2.2 [FSM] Update packet received under status OpenConfirm for Outgoing
2026/01/26 16:45:35.249616 BGP: [PHZEJ-9MX8C][EC 33554455] bgp_process_packet: BGP UPDATE receipt failed for peer: 2.2.2.2(Outgoing)

Upon tracking this down, the peer( in this case 2.2.2.2 ) is initiating a peer_xfer_conn and the incoming connection is the winner.  What is happening is that this peer has received a open message on it's incoming connection.  It has transitioned to openConfirm and scheduled the keepalive to go out.  Immediately after this, it recieves the peers keepalive, which causes it to go to Established.  As part of the peer_xfer_conn processing it calls bgp_writes_off(keeper);  This writes off clears the outgoing queue of data( which has this peers keepalive ).  Then it turns the writes back on later on in the function for the keeper.  As this side is now established it sends an update message which the peer receives and since the peer has never received a keepalive it rightly shuts the connection down.

Modify the peer_xfer_conn script to just no longer turn the reads and writes off then on for the keeper.  There is no need to do so.