### PR TITLE
*: Fixed coverity warnings in multiple areas

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -1520,7 +1520,7 @@ DEFPY (debug_bgp_update_prefix_afi_safi,
        "IPv4 prefix\n"
        "IPv6 prefix\n")
 {
-	struct prefix argv_p;
+	struct prefix argv_p = { 0 };
 	int ret = CMD_SUCCESS;
 
 	ret = bgp_debug_parse_evpn_prefix(vty, argv, argc, &argv_p);
@@ -1578,7 +1578,7 @@ DEFPY (no_debug_bgp_update_prefix_afi_safi,
        "IPv4 prefix\n"
        "IPv6 prefix\n")
 {
-	struct prefix argv_p;
+	struct prefix argv_p = { 0 };
 	bool found_prefix = false;
 	int ret = CMD_SUCCESS;
 

--- a/bgpd/bgp_labelpool.c
+++ b/bgpd/bgp_labelpool.c
@@ -569,7 +569,7 @@ static void bgp_sync_label_manager(struct event *e)
 	struct lp_fifo *lf;
 
 	while ((lf = lp_fifo_pop(&lp->requests))) {
-		struct lp_lcb *lcb;
+		struct lp_lcb *lcb = NULL;
 		void *labelid = lf->lcb.labelid;
 
 		if (skiplist_search(lp->ledger, labelid, (void **)&lcb)) {

--- a/bgpd/bgp_rd.c
+++ b/bgpd/bgp_rd.c
@@ -91,7 +91,7 @@ int str2prefix_rd(const char *str, struct prefix_rd *prd)
 	struct stream *s = NULL;
 	char *half = NULL;
 	struct in_addr addr;
-	as_t as_val;
+	as_t as_val = 0;
 
 	prd->family = AF_UNSPEC;
 	prd->prefixlen = 64;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4824,7 +4824,7 @@ static wq_item_status meta_queue_process(struct work_queue *dummy, void *data)
 
 static int early_route_meta_queue_add(struct meta_queue *mq, void *data)
 {
-	uint8_t qindex = META_QUEUE_EARLY_ROUTE;
+	enum meta_queue_indexes qindex = META_QUEUE_EARLY_ROUTE;
 	struct bgp_dest *dest = data;
 
 	if (bgp_debug_bestpath(dest))
@@ -4839,7 +4839,7 @@ static int early_route_meta_queue_add(struct meta_queue *mq, void *data)
 
 static int other_route_meta_queue_add(struct meta_queue *mq, void *data)
 {
-	uint8_t qindex = META_QUEUE_OTHER_ROUTE;
+	enum meta_queue_indexes qindex = META_QUEUE_OTHER_ROUTE;
 	struct bgp_dest *dest = data;
 
 	if (bgp_debug_bestpath(dest))
@@ -4854,7 +4854,7 @@ static int other_route_meta_queue_add(struct meta_queue *mq, void *data)
 
 static int eoiu_marker_meta_queue_add(struct meta_queue *mq, void *data)
 {
-	uint8_t qindex = META_QUEUE_EOIU_MARKER;
+	enum meta_queue_indexes qindex = META_QUEUE_EOIU_MARKER;
 	struct bgp_dest *dest = data;
 
 	if (BGP_DEBUG(update, UPDATE_IN))

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2694,7 +2694,7 @@ route_set_aspath_replace(void *rule, const struct prefix *dummy, void *object)
 	const char *replace = rule;
 	struct bgp_path_info *path = object;
 	as_t replace_asn = 0;
-	as_t configured_asn;
+	as_t configured_asn = 0;
 	char *buf;
 	char src_asn[ASN_STRING_MAX_SIZE];
 	char *acl_list_name = NULL;
@@ -3250,8 +3250,8 @@ route_set_ecommunity_delete(void *rule, const struct prefix *prefix,
 static void *route_set_ecommunity_delete_compile(const char *arg)
 {
 	struct rmap_community *rcom;
-	char **splits;
-	int num;
+	char **splits = NULL;
+	int num = 0;
 
 	frrstr_split(arg, " ", &splits, &num);
 

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -1262,7 +1262,7 @@ static int rpki_create_socket(void *_cache)
 	socklen_t optlen;
 	char *host, *port;
 	struct vrf *vrf;
-	int cancel_state;
+	int cancel_state = 0;
 	int socket;
 	int ret;
 #if defined(FOUND_SSH)

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1331,7 +1331,7 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 
 	/* Clear all neighbors belonging to a specific AS. */
 	if (sort == clear_as) {
-		as_t as;
+		as_t as = 0;
 
 		if (!asn_str2asn(arg, &as)) {
 			vty_out(vty, "%% BGP: No such AS %s\n", arg);
@@ -1595,7 +1595,7 @@ DEFUN_NOSH (router_bgp,
 	int idx_asnotation_kind = 4;
 	enum asnotation_mode asnotation = ASNOTATION_UNDEFINED;
 	int ret;
-	as_t as;
+	as_t as = 0;
 	struct bgp *bgp = NULL;
 	const char *name = NULL;
 	enum bgp_instance_type inst_type;
@@ -1739,8 +1739,8 @@ DEFUN (no_router_bgp,
 {
 	int idx_asn = 3;
 	int idx_vrf = 5;
-	as_t as;
-	struct bgp *bgp;
+	as_t as = 0;
+	struct bgp *bgp = NULL;
 	const char *name = NULL;
 
 	// "no router bgp" without an ASN
@@ -2127,7 +2127,7 @@ DEFUN (bgp_confederation_identifier,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	int idx_number = 3;
-	as_t as;
+	as_t as = 0;
 
 	if (!asn_str2asn(argv[idx_number]->arg, &as)) {
 		vty_out(vty, "%% BGP: No such AS %s\n", argv[idx_number]->arg);
@@ -2164,7 +2164,7 @@ DEFUN (bgp_confederation_peers,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	int idx_asn = 3;
-	as_t as;
+	as_t as = 0;
 	int i;
 
 	for (i = idx_asn; i < argc; i++) {
@@ -2190,7 +2190,7 @@ DEFUN (no_bgp_confederation_peers,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	int idx_asn = 4;
-	as_t as;
+	as_t as = 0;
 	int i;
 
 	for (i = idx_asn; i < argc; i++) {
@@ -5125,7 +5125,7 @@ static int peer_remote_as_vty(struct vty *vty, const char *peer_str,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	int ret;
-	as_t as;
+	as_t as = 0;
 	enum peer_asn_type as_type = AS_SPECIFIED;
 	union sockunion su;
 
@@ -5728,7 +5728,7 @@ DEFUN (neighbor_local_as,
 	int idx_number = 3;
 	struct peer *peer;
 	int ret;
-	as_t as;
+	as_t as = 0;
 
 	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
 	if (!peer)
@@ -5757,7 +5757,7 @@ DEFUN (neighbor_local_as_no_prepend,
 	int idx_number = 3;
 	struct peer *peer;
 	int ret;
-	as_t as;
+	as_t as = 0;
 
 	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
 	if (!peer)
@@ -5788,7 +5788,7 @@ DEFPY (neighbor_local_as_no_prepend_replace_as,
 	int idx_number = 3;
 	struct peer *peer;
 	int ret;
-	as_t as;
+	as_t as = 0;
 
 	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
 	if (!peer)
@@ -5972,7 +5972,7 @@ DEFUN (neighbor_set_peer_group,
 	int idx_peer = 1;
 	int idx_word = 3;
 	int ret;
-	as_t as;
+	as_t as = 0;
 	union sockunion su;
 	struct peer *peer;
 	struct peer_group *group;

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -965,7 +965,7 @@ static int process_lsp(uint8_t pdu_type, struct isis_circuit *circuit,
 
 	struct isis_tlvs *tlvs = NULL;
 	int retval = ISIS_WARNING;
-	const char *error_log;
+	const char *error_log = NULL;
 
 	if (isis_unpack_tlvs(STREAM_READABLE(circuit->rcv_stream),
 			     circuit->rcv_stream, &tlvs, &error_log)) {
@@ -1846,8 +1846,8 @@ int isis_handle_pdu(struct isis_circuit *circuit, uint8_t *ssnpa)
 
 void isis_receive(struct event *event)
 {
-	struct isis_circuit *circuit;
-	uint8_t ssnpa[ETH_ALEN];
+	struct isis_circuit *circuit = NULL;
+	uint8_t ssnpa[ETH_ALEN] = { 0 };
 
 	/*
 	 * Get the circuit

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -3379,9 +3379,9 @@ void isis_restart_write_overload_time(struct isis_area *isis_area,
 				      uint32_t overload_time)
 {
 	const char *area_name;
-	json_object *json;
-	json_object *json_areas;
-	json_object *json_area;
+	json_object *json = NULL;
+	json_object *json_areas = NULL;
+	json_object *json_area = NULL;
 
 	json = frr_daemon_state_load();
 	area_name = isis_area->area_tag;
@@ -3411,9 +3411,9 @@ uint32_t isis_restart_read_overload_time(struct isis_area *isis_area)
 {
 	const char *area_name;
 	json_object *json;
-	json_object *json_areas;
-	json_object *json_area;
-	json_object *json_overload_time;
+	json_object *json_areas = NULL;
+	json_object *json_area = NULL;
+	json_object *json_overload_time = NULL;
 	uint32_t overload_time = 0;
 
 	area_name = isis_area->area_tag;

--- a/lib/darr.c
+++ b/lib/darr.c
@@ -59,7 +59,7 @@ char *_darr__in_vsprintf(char **sp, bool concat, const char *fmt, va_list ap)
 	size_t inlen = concat ? darr_strlen(*sp) : 0;
 	size_t capcount = strlen(fmt) + MIN(inlen + 64, 128);
 	ssize_t len;
-	va_list ap_copy;
+	va_list ap_copy = { 0 };
 
 	darr_ensure_cap(*sp, capcount);
 

--- a/lib/mgmt_msg.c
+++ b/lib/mgmt_msg.c
@@ -683,7 +683,7 @@ static int msg_client_connect_short_circuit(struct msg_client *client)
 	const char *dbgtag =
 		client->conn.debug ? client->conn.mstate.idtag : NULL;
 	union sockunion su = {};
-	int sockets[2];
+	int sockets[2] = { 0 };
 
 	frr_each (msg_server_list, &msg_servers, server)
 		if (!strcmp(server->sopath, client->sopath))

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -720,7 +720,7 @@ void nb_config_diff(const struct nb_config *config1,
 static LY_ERR dnode_create(struct nb_config *candidate, const char *xpath, const char *value,
 			   uint32_t options, struct lyd_node **new_dnode)
 {
-	struct lyd_node *dnode;
+	struct lyd_node *dnode = NULL;
 	LY_ERR err;
 
 	err = yang_new_path2(candidate->dnode, ly_native_ctx, xpath, value, 0, 0, options, NULL,
@@ -2414,9 +2414,9 @@ DEFINE_HOOK(nb_notification_send, (const char *xpath, struct list *arguments),
 int nb_notification_send(const char *xpath, struct list *arguments)
 {
 	struct lyd_node *root = NULL;
-	struct lyd_node *dnode;
-	struct yang_data *data;
-	struct listnode *ln;
+	struct lyd_node *dnode = NULL;
+	struct yang_data *data = NULL;
+	struct listnode *ln = NULL;
 	LY_ERR err;
 	int ret;
 

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -355,7 +355,7 @@ void nb_cli_confirmed_commit_clean(struct vty *vty)
 int nb_cli_confirmed_commit_rollback(struct vty *vty)
 {
 	struct nb_context context = {};
-	uint32_t transaction_id;
+	uint32_t transaction_id = 0;
 	char errmsg[BUFSIZ] = {0};
 	int ret;
 

--- a/lib/northbound_oper.c
+++ b/lib/northbound_oper.c
@@ -1260,7 +1260,7 @@ static enum nb_error _walk(struct nb_op_yield_state *ys, bool is_resume)
 	const void *parent_list_entry = NULL;
 	const void *list_entry = NULL;
 	struct nb_op_node_info *ni, *pni;
-	struct lyd_node *node;
+	struct lyd_node *node = NULL;
 	struct nb_node *nn;
 	char *xpath_child = NULL;
 	// bool at_query_base;

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -412,7 +412,7 @@ static inline uint8_t *ptr_get_be16(uint8_t *ptr, uint16_t *out)
  */
 #define STREAM_GETC(S, P)                                                      \
 	do {                                                                   \
-		uint8_t _pval;                                                 \
+		uint8_t _pval = 0;                                             \
 		if (!stream_getc2((S), &_pval))                                \
 			goto stream_failure;                                   \
 		(P) = _pval;                                                   \
@@ -420,7 +420,7 @@ static inline uint8_t *ptr_get_be16(uint8_t *ptr, uint16_t *out)
 
 #define STREAM_GETW(S, P)                                                      \
 	do {                                                                   \
-		uint16_t _pval;                                                \
+		uint16_t _pval = 0;                                            \
 		if (!stream_getw2((S), &_pval))                                \
 			goto stream_failure;                                   \
 		(P) = _pval;                                                   \
@@ -428,7 +428,7 @@ static inline uint8_t *ptr_get_be16(uint8_t *ptr, uint16_t *out)
 
 #define STREAM_GETL(S, P)                                                      \
 	do {                                                                   \
-		uint32_t _pval;                                                \
+		uint32_t _pval = 0;                                            \
 		if (!stream_getl2((S), &_pval))                                \
 			goto stream_failure;                                   \
 		(P) = _pval;                                                   \
@@ -439,7 +439,7 @@ static inline uint8_t *ptr_get_be16(uint8_t *ptr, uint16_t *out)
 		union {                                                        \
 			float r;                                               \
 			uint32_t d;                                            \
-		} _pval;                                                       \
+		} _pval = { 0 };                                              \
 		if (!stream_getl2((S), &_pval.d))                              \
 			goto stream_failure;                                   \
 		(P) = _pval.r;                                                 \
@@ -447,7 +447,7 @@ static inline uint8_t *ptr_get_be16(uint8_t *ptr, uint16_t *out)
 
 #define STREAM_GETQ(S, P)                                                      \
 	do {                                                                   \
-		uint64_t _pval;                                                \
+		uint64_t _pval = 0;                                            \
 		if (!stream_getq2((S), &_pval))                                \
 			goto stream_failure;                                   \
 		(P) = _pval;                                                   \

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -306,8 +306,8 @@ void yang_snode_get_path(const struct lysc_node *snode,
 LY_ERR yang_resolve_snode_xpath(struct ly_ctx *ly_ctx, const char *xpath,
 				const struct lysc_node ***snodes, bool *simple)
 {
-	struct lysc_node *snode;
-	struct ly_set *set;
+	struct lysc_node *snode = NULL;
+	struct ly_set *set = NULL;
 	LY_ERR err;
 
 	/* lys_find_path will not resolve complex xpaths */
@@ -569,7 +569,7 @@ uint32_t yang_dnode_count(const struct lyd_node *dnode, const char *xpath_fmt,
 {
 	va_list ap;
 	char xpath[XPATH_MAXLEN];
-	struct ly_set *set;
+	struct ly_set *set = NULL;
 	uint32_t count;
 
 	va_start(ap, xpath_fmt);
@@ -952,7 +952,7 @@ done:
 LY_ERR yang_parse_notification(const char *xpath, LYD_FORMAT format,
 			       const char *data, struct lyd_node **notif)
 {
-	struct lyd_node *tree;
+	struct lyd_node *tree = NULL;
 	struct ly_set *set = NULL;
 	struct ly_in *in = NULL;
 	LY_ERR err;

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2346,7 +2346,7 @@ bool zapi_srv6_sid_notify_decode(struct stream *s, struct srv6_sid_ctx *ctx,
 				 char **p_locator_name)
 {
 	uint32_t f, wf;
-	uint16_t len;
+	uint16_t len = 0;
 	static char locator_name[SRV6_LOCNAME_SIZE];
 
 	STREAM_GET(note, s, sizeof(*note));

--- a/mgmtd/mgmt_ds.c
+++ b/mgmtd/mgmt_ds.c
@@ -344,7 +344,7 @@ int mgmt_ds_copy_dss(struct mgmt_ds_ctx *dst, struct mgmt_ds_ctx *src, bool updt
 
 int mgmt_ds_dump_ds_to_file(char *file_name, struct mgmt_ds_ctx *ds_ctx)
 {
-	struct ly_out *out;
+	struct ly_out *out = NULL;
 	int ret = 0;
 
 	if (ly_out_new_filepath(file_name, &out) == LY_SUCCESS) {
@@ -389,6 +389,7 @@ static int mgmt_walk_ds_nodes(
 	if (!base_dnode)
 		return -1;
 
+	xpath[0] = '\0';
 	_dbg("           search base schema: '%s'",
 	     lysc_path(base_dnode->schema, LYSC_PATH_LOG, xpath, sizeof(xpath)));
 
@@ -461,6 +462,7 @@ int mgmt_ds_delete_data_nodes(struct mgmt_ds_ctx *ds_ctx, const char *xpath)
 		return NB_ERR_NOT_FOUND;
 	/* destroy dependant */
 	if (nb_node && nb_node->dep_cbs.get_dependant_xpath) {
+		dep_xpath[0] = '\0';
 		nb_node->dep_cbs.get_dependant_xpath(dnode, dep_xpath);
 
 		dep_dnode = yang_dnode_get(
@@ -516,6 +518,7 @@ int mgmt_ds_iter_data(enum mgmt_ds_id ds_id, struct nb_config *root, const char 
 	if (!root)
 		return -1;
 
+	xpath[0] = '\0';
 	strlcpy(xpath, base_xpath, sizeof(xpath));
 	mgmt_remove_trailing_separator(xpath, '/');
 
@@ -552,15 +555,16 @@ int mgmt_ds_iter_data(enum mgmt_ds_id ds_id, struct nb_config *root, const char 
 void mgmt_ds_dump_tree(struct vty *vty, struct mgmt_ds_ctx *ds_ctx,
 		       const char *xpath, FILE *f, LYD_FORMAT format)
 {
-	struct ly_out *out;
-	char *str;
-	char base_xpath[MGMTD_MAX_XPATH_LEN] = {0};
+	struct ly_out *out = NULL;
+	char *str = NULL;
+	char base_xpath[MGMTD_MAX_XPATH_LEN];
 
 	if (!ds_ctx) {
 		vty_out(vty, "    >>>>> Datastore Not Initialized!\n");
 		return;
 	}
 
+	base_xpath[0] = '\0';
 	if (xpath) {
 		strlcpy(base_xpath, xpath, MGMTD_MAX_XPATH_LEN);
 		mgmt_remove_trailing_separator(base_xpath, '/');

--- a/ospf6d/ospf6_auth_trailer.c
+++ b/ospf6d/ospf6_auth_trailer.c
@@ -922,9 +922,9 @@ __attribute__((unused)) static void
 ospf6_auth_seqno_nvm_delete(struct ospf6 *ospf6)
 {
 	const char *inst_name;
-	json_object *json;
-	json_object *json_instances;
-	json_object *json_instance;
+	json_object *json = NULL;
+	json_object *json_instances = NULL;
+	json_object *json_instance = NULL;
 
 	zlog_err("Higher order sequence number delete for %s process",
 		 ospf6->name);

--- a/ospf6d/ospf6_gr.c
+++ b/ospf6d/ospf6_gr.c
@@ -627,10 +627,10 @@ void ospf6_gr_nvm_read(struct ospf6 *ospf6)
 {
 	const char *inst_name;
 	json_object *json;
-	json_object *json_instances;
-	json_object *json_instance;
-	json_object *json_timestamp;
-	json_object *json_grace_period;
+	json_object *json_instances = NULL;
+	json_object *json_instance = NULL;
+	json_object *json_timestamp = NULL;
+	json_object *json_grace_period = NULL;
 	time_t timestamp = 0;
 
 	inst_name = ospf6->name ? ospf6->name : VRF_DEFAULT_NAME;

--- a/ospfd/ospf_api.c
+++ b/ospfd/ospf_api.c
@@ -467,8 +467,14 @@ struct msg *new_msg_register_event(uint32_t seqnum,
 	emsg->filter.typemask = htons(filter->typemask);
 	emsg->filter.origin = filter->origin;
 	emsg->filter.num_areas = filter->num_areas;
-	if (len > sizeof(buf))
-		len = sizeof(buf);
+
+	/* Check for integer overflow when casting to uint16_t */
+	if (len > UINT16_MAX) {
+		zlog_warn("%s: Message length %u exceeds maximum allowed size %u", __func__, len,
+			  UINT16_MAX);
+		len = UINT16_MAX;
+	}
+
 	/* API broken - missing memcpy to fill data */
 	return msg_new(MSG_REGISTER_EVENT, emsg, seqnum, len);
 }
@@ -485,8 +491,14 @@ struct msg *new_msg_sync_lsdb(uint32_t seqnum, struct lsa_filter_type *filter)
 	smsg->filter.typemask = htons(filter->typemask);
 	smsg->filter.origin = filter->origin;
 	smsg->filter.num_areas = filter->num_areas;
-	if (len > sizeof(buf))
-		len = sizeof(buf);
+
+	/* Check for integer overflow when casting to uint16_t */
+	if (len > UINT16_MAX) {
+		zlog_warn("%s: Message length %u exceeds maximum allowed size %u", __func__, len,
+			  UINT16_MAX);
+		len = UINT16_MAX;
+	}
+
 	/* API broken - missing memcpy to fill data */
 	return msg_new(MSG_SYNC_LSDB, smsg, seqnum, len);
 }

--- a/ospfd/ospf_gr.c
+++ b/ospfd/ospf_gr.c
@@ -646,11 +646,11 @@ void ospf_gr_nvm_delete(struct ospf *ospf)
 void ospf_gr_nvm_read(struct ospf *ospf)
 {
 	const char *inst_name;
-	json_object *json;
-	json_object *json_instances;
-	json_object *json_instance;
-	json_object *json_timestamp;
-	json_object *json_grace_period;
+	json_object *json = NULL;
+	json_object *json_instances = NULL;
+	json_object *json_instance = NULL;
+	json_object *json_timestamp = NULL;
+	json_object *json_grace_period = NULL;
 	time_t timestamp = 0;
 
 	inst_name = ospf_get_name(ospf);

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -1691,8 +1691,6 @@ def generate_ips(network, no_of_ips):
                 return ipaddress_list
             start_ip = ipaddress.IPv6Address(frr_unicode(start_ip))
             step = 2 ** (128 - mask)
-        else:
-            return []
 
         next_ip = start_ip
         count = 0

--- a/zebra/ge_netlink.c
+++ b/zebra/ge_netlink.c
@@ -225,7 +225,7 @@ netlink_put_sr_tunsrc_set_msg(struct nl_batch *bth, struct zebra_dplane_ctx *ctx
 {
 	enum dplane_op_e op;
 	struct zebra_ns *zns;
-	struct genl_request req;
+	struct genl_request req = { 0 };
 
 	op = dplane_ctx_get_op(ctx);
 	assert(op == DPLANE_OP_SRV6_ENCAP_SRCADDR_SET);
@@ -296,7 +296,7 @@ int netlink_sr_tunsrc_reply_read(struct nlmsghdr *h, ns_id_t ns_id, int startup)
  */
 static int netlink_request_sr_tunsrc(struct zebra_ns *zns)
 {
-	struct genl_request req;
+	struct genl_request req = { 0 };
 
 	if (zns->ge_netlink_cmd.sock < 0)
 		return -1;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2150,7 +2150,7 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 	struct nhg_backup_info *bnhg = NULL;
 	int ret;
 	vrf_id_t vrf_id;
-	struct nhg_hash_entry nhe, *n = NULL;
+	struct nhg_hash_entry nhe = { 0 }, *n = NULL;
 
 	s = msg;
 	if (zapi_route_decode(s, &api) < 0) {
@@ -3097,7 +3097,7 @@ static void zread_srv6_manager_get_srv6_sid(struct zserv *client,
 	char locator[SRV6_LOCNAME_SIZE] = { 0 };
 	uint16_t len;
 	struct zebra_srv6_sid *sid = NULL;
-	uint8_t flags;
+	uint8_t flags = 0;
 	bool is_localonly = false;
 
 	/* Get input stream */
@@ -3178,7 +3178,7 @@ static void zread_srv6_manager_get_locator(struct zserv *client,
 					   struct stream *msg)
 {
 	struct stream *s = msg;
-	uint16_t len;
+	uint16_t len = 0;
 	char locator_name[SRV6_LOCNAME_SIZE] = { 0 };
 	struct srv6_locator *locator = NULL;
 

--- a/zebra/zebra_cli.c
+++ b/zebra/zebra_cli.c
@@ -1114,7 +1114,7 @@ static void lib_interface_zebra_evpn_mh_type_3_system_mac_cli_write(
 	struct vty *vty, const struct lyd_node *dnode, bool show_defaults)
 {
 	char buf[ETHER_ADDR_STRLEN];
-	struct ethaddr mac;
+	struct ethaddr mac = { 0 };
 
 	yang_dnode_get_mac(&mac, dnode, NULL);
 

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -2272,7 +2272,7 @@ static bool evpn_mh_dnode_to_esi(const struct lyd_node *dnode, esi_t *esi)
 			assert(false);
 	} else if (yang_dnode_exists(dnode, "type-3/system-mac") &&
 		   yang_dnode_exists(dnode, "type-3/local-discriminator")) {
-		struct ethaddr mac;
+		struct ethaddr mac = { 0 };
 		uint32_t lid;
 
 		yang_dnode_get_mac(&mac, dnode, "type-3/system-mac");
@@ -2422,7 +2422,7 @@ int lib_interface_zebra_evpn_mh_type_3_system_mac_modify(
 	struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
-	struct ethaddr mac;
+	struct ethaddr mac = { 0 };
 
 	yang_dnode_get_mac(&mac, args->dnode, NULL);
 

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -637,7 +637,7 @@ void zebra_ptm_bfd_dst_register(ZAPI_HANDLER_ARGS)
 	unsigned int min_rx_timer;
 	unsigned int min_tx_timer;
 	char if_name[IFNAMSIZ];
-	uint8_t len;
+	uint8_t len = 0;
 	void *out_ctxt;
 	char buf[INET6_ADDRSTRLEN];
 	char tmp_buf[64];

--- a/zebra/zebra_snmp.c
+++ b/zebra/zebra_snmp.c
@@ -412,7 +412,7 @@ static void get_fwtable_route_node(struct variable *v, oid objid[],
 	*objid_len = v->namelen + 10;
 	pnt = (uint8_t *)&(*np)->p.u.prefix;
 	for (i = 0; i < 4; i++)
-		objid[v->namelen + i] = *pnt++;
+		objid[v->namelen + i] = pnt[i];
 
 	objid[v->namelen + 4] = proto;
 	objid[v->namelen + 5] = policy;
@@ -424,7 +424,7 @@ static void get_fwtable_route_node(struct variable *v, oid objid[],
 		if (nh) {
 			pnt = (uint8_t *)&nh->gate.ipv4;
 			for (i = 0; i < 4; i++)
-				objid[i + v->namelen + 6] = *pnt++;
+				objid[i + v->namelen + 6] = pnt[i];
 		}
 	}
 


### PR DESCRIPTION
Fixed few of the coverity warnings in multiple areas for below category:
1. Uninitialized scalar variable
2. Uninitialized pointer read
3. Resource leak
4. Overflowed integer argument