### PR TITLE
pimd,pim6d: fix last-member-query-count and add robustness value

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -552,10 +552,16 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
        ip multicast boundary pim-acl
       exit
 
+.. clicmd:: ip igmp robustness (1-255)
+
+   Set the IGMP robustness value. The default value is 2. 'no' form of
+   this command is used to to configure back to the default value.
+
 .. clicmd:: ip igmp last-member-query-count (1-255)
 
-   Set the IGMP last member query count. The default value is 2. 'no' form of
-   this command is used to to configure back to the default value.
+   Set the IGMP last member query count. The default value is the currently
+   configured robustness value. 'no' form of this command is used to to
+   configure back to the default value.
 
 .. clicmd:: ip igmp last-member-query-interval (1-65535)
 

--- a/doc/user/pimv6.rst
+++ b/doc/user/pimv6.rst
@@ -324,10 +324,16 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
    join or MLD report is received on this interface and the Group is denied by
    the prefix-list, PIMv6 will ignore the join or report.
 
+.. clicmd:: ipv6 mld robustness (1-255)
+
+   Set the MLD robustness value. The default value is 2. 'no' form of
+   this command is used to configure back to the default value.
+
 .. clicmd:: ipv6 mld last-member-query-count (1-255)
 
-   Set the MLD last member query count. The default value is 2. 'no' form of
-   this command is used to configure back to the default value.
+   Set the MLD last member query count. The default value is the currently
+   configured robustness value. 'no' form of this command is used to
+   configure back to the default value.
 
 .. clicmd:: ipv6 mld last-member-query-interval (1-65535)
 

--- a/pimd/pim6_cmd.c
+++ b/pimd/pim6_cmd.c
@@ -1818,6 +1818,29 @@ DEFPY (interface_no_ipv6_mld_query_max_response_time,
 	return gm_process_no_query_max_response_time_cmd(vty);
 }
 
+DEFPY_YANG(interface_ipv6_mld_robustness,
+           interface_ipv6_mld_robustness_cmd,
+           "ipv6 mld robustness (1-255)$robustness",
+           IPV6_STR
+           IFACE_MLD_STR
+           "Querier's Robustness Variable\n"
+           "Querier's Robustness Variable\n")
+{
+	return gm_process_robustness_cmd(vty, robustness_str);
+}
+
+DEFPY_YANG(interface_no_ipv6_mld_robustness,
+           interface_no_ipv6_mld_robustness_cmd,
+           "no ipv6 mld robustness [(1-255)]",
+           NO_STR
+           IPV6_STR
+           IFACE_MLD_STR
+           "Querier's Robustness Variable\n"
+           "Querier's Robustness Variable\n")
+{
+	return gm_process_no_robustness_cmd(vty);
+}
+
 DEFPY (interface_ipv6_mld_last_member_query_count,
        interface_ipv6_mld_last_member_query_count_cmd,
        "ipv6 mld last-member-query-count (1-255)$lmqc",
@@ -3159,6 +3182,8 @@ void pim_cmd_init(void)
 			&interface_ipv6_mld_query_max_response_time_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_no_ipv6_mld_query_max_response_time_cmd);
+	install_element(INTERFACE_NODE, &interface_ipv6_mld_robustness_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ipv6_mld_robustness_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_ipv6_mld_last_member_query_count_cmd);
 	install_element(INTERFACE_NODE,

--- a/pimd/pim6_mld.c
+++ b/pimd/pim6_mld.c
@@ -2282,7 +2282,7 @@ static void gm_start(struct interface *ifp)
 	gm_ifp->cur_query_intv_trig =
 		pim_ifp->gm_specific_query_max_response_time_dsec * 100;
 	gm_ifp->cur_max_resp = pim_ifp->gm_query_max_response_time_dsec * 100;
-	gm_ifp->cur_lmqc = pim_ifp->gm_last_member_query_count;
+	gm_ifp->cur_lmqc = if_gm_last_member_query_count(pim_ifp);
 
 	gm_ifp->cfg_timing_fuzz.tv_sec = 0;
 	gm_ifp->cfg_timing_fuzz.tv_usec = 10 * 1000;
@@ -2478,8 +2478,7 @@ void gm_ifp_update(struct interface *ifp)
 	if (gm_ifp->cur_max_resp != cfg_max_response)
 		gm_ifp->cur_max_resp = cfg_max_response;
 
-	if (gm_ifp->cur_lmqc != pim_ifp->gm_last_member_query_count)
-		gm_ifp->cur_lmqc = pim_ifp->gm_last_member_query_count;
+	gm_ifp->cur_lmqc = if_gm_last_member_query_count(pim_ifp);
 
 	enum gm_version cfg_version;
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -410,9 +410,9 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 				igmp->querier_query_interval,
 				pim_ifp->gm_query_max_response_time_dsec);
 
-			lmqt_msec = PIM_IGMP_LMQT_MSEC(
-				pim_ifp->gm_specific_query_max_response_time_dsec,
-				pim_ifp->gm_last_member_query_count);
+			lmqt_msec =
+				PIM_IGMP_LMQT_MSEC(pim_ifp->gm_specific_query_max_response_time_dsec,
+						   if_gm_last_member_query_count(pim_ifp));
 
 			ohpi_msec =
 				PIM_IGMP_OHPI_DSEC(
@@ -422,7 +422,7 @@ static void igmp_show_interfaces_single(struct pim_instance *pim,
 				100;
 
 			qri_msec = pim_ifp->gm_query_max_response_time_dsec * 100L;
-			lmqc = pim_ifp->gm_last_member_query_count;
+			lmqc = if_gm_last_member_query_count(pim_ifp);
 
 			if (uj) {
 				json_row = json_object_new_object();

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5621,6 +5621,29 @@ DEFUN_YANG_HIDDEN (interface_no_ip_igmp_query_max_response_time_dsec,
 				    "frr-routing:ipv4");
 }
 
+DEFPY_YANG(interface_ip_igmp_robustness,
+           interface_ip_igmp_robustness_cmd,
+           "ip igmp robustness (1-255)$robustness",
+           IP_STR
+           IFACE_IGMP_STR
+           "Querier's Robustness Variable\n"
+           "Querier's Robustness Variable\n")
+{
+	return gm_process_robustness_cmd(vty, robustness_str);
+}
+
+DEFPY_YANG(interface_no_ip_igmp_robustness,
+           interface_no_ip_igmp_robustness_cmd,
+           "no ip igmp robustness [(1-255)]",
+           NO_STR
+           IP_STR
+           IFACE_IGMP_STR
+           "Querier's Robustness Variable\n"
+           "Querier's Robustness Variable\n")
+{
+	return gm_process_no_robustness_cmd(vty);
+}
+
 DEFPY (interface_ip_igmp_last_member_query_count,
        interface_ip_igmp_last_member_query_count_cmd,
        "ip igmp last-member-query-count (1-255)$lmqc",
@@ -9424,6 +9447,8 @@ void pim_cmd_init(void)
 			&interface_ip_igmp_query_max_response_time_dsec_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_no_ip_igmp_query_max_response_time_dsec_cmd);
+	install_element(INTERFACE_NODE, &interface_ip_igmp_robustness_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ip_igmp_robustness_cmd);
 	install_element(INTERFACE_NODE,
 			&interface_ip_igmp_last_member_query_count_cmd);
 	install_element(INTERFACE_NODE,

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -3429,16 +3429,14 @@ int gm_process_last_member_query_count_cmd(struct vty *vty,
 					      "true");
 	}
 
-	nb_cli_enqueue_change(vty, "./robustness-variable", NB_OP_MODIFY,
-			      lmqc_str);
+	nb_cli_enqueue_change(vty, "./last-member-query-count", NB_OP_MODIFY, lmqc_str);
 	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
 				    FRR_PIM_AF_XPATH_VAL);
 }
 
 int gm_process_no_last_member_query_count_cmd(struct vty *vty)
 {
-	nb_cli_enqueue_change(vty, "./robustness-variable", NB_OP_DESTROY,
-			      NULL);
+	nb_cli_enqueue_change(vty, "./last-member-query-count", NB_OP_DESTROY, NULL);
 	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH,
 				    FRR_PIM_AF_XPATH_VAL);
 }

--- a/pimd/pim_cmd_common.c
+++ b/pimd/pim_cmd_common.c
@@ -3413,6 +3413,29 @@ int gm_process_no_query_max_response_time_cmd(struct vty *vty)
 				    FRR_PIM_AF_XPATH_VAL);
 }
 
+int gm_process_robustness_cmd(struct vty *vty, const char *robustness)
+{
+	const struct lyd_node *pim_enable_dnode;
+
+	pim_enable_dnode = yang_dnode_getf(vty->candidate_config->dnode, FRR_PIM_ENABLE_XPATH,
+					   VTY_CURR_XPATH, FRR_PIM_AF_XPATH_VAL);
+	if (!pim_enable_dnode) {
+		nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY, "true");
+	} else {
+		if (!yang_dnode_get_bool(pim_enable_dnode, "."))
+			nb_cli_enqueue_change(vty, "./enable", NB_OP_MODIFY, "true");
+	}
+
+	nb_cli_enqueue_change(vty, "./robustness-variable", NB_OP_MODIFY, robustness);
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH, FRR_PIM_AF_XPATH_VAL);
+}
+
+int gm_process_no_robustness_cmd(struct vty *vty)
+{
+	nb_cli_enqueue_change(vty, "./robustness-variable", NB_OP_DESTROY, NULL);
+	return nb_cli_apply_changes(vty, FRR_GMP_INTERFACE_XPATH, FRR_PIM_AF_XPATH_VAL);
+}
+
 int gm_process_last_member_query_count_cmd(struct vty *vty,
 					   const char *lmqc_str)
 {

--- a/pimd/pim_cmd_common.h
+++ b/pimd/pim_cmd_common.h
@@ -130,6 +130,8 @@ int pim_show_bsm_db_helper(const char *vrf, struct vty *vty, bool uj);
 int gm_process_query_max_response_time_cmd(struct vty *vty,
 					   const char *qmrt_str);
 int gm_process_no_query_max_response_time_cmd(struct vty *vty);
+int gm_process_robustness_cmd(struct vty *vty, const char *robustness);
+int gm_process_no_robustness_cmd(struct vty *vty);
 int gm_process_last_member_query_count_cmd(struct vty *vty,
 					   const char *lmqc_str);
 int gm_process_no_last_member_query_count_cmd(struct vty *vty);

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -127,7 +127,7 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool gm, bool pim,
 		GM_QUERY_MAX_RESPONSE_TIME_DSEC;
 	pim_ifp->gm_specific_query_max_response_time_dsec =
 		GM_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC;
-	pim_ifp->gm_last_member_query_count = GM_DEFAULT_ROBUSTNESS_VARIABLE;
+	pim_ifp->gm_last_member_query_count = 0;
 	pim_ifp->gm_group_limit = UINT32_MAX;
 	pim_ifp->gm_source_limit = UINT32_MAX;
 	pim_ifp->periodic_jp_sec = -1;

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -208,6 +208,14 @@ struct pim_interface {
 	} bfd_config;
 };
 
+/* Last member query count is robustness variable unless overridden */
+static inline int if_gm_last_member_query_count(const struct pim_interface *pim_interface)
+{
+	return (pim_interface->gm_last_member_query_count != 0)
+		       ? pim_interface->gm_last_member_query_count
+		       : pim_interface->gm_default_robustness_variable;
+}
+
 /*
  * if default_holdtime is set (>= 0), use it;
  * otherwise default_holdtime is 3.5 * hello_period

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -343,6 +343,17 @@ static void pim_igmp_other_querier_expire(struct event *t)
 			       sizeof(ifaddr_str));
 		zlog_debug("%s: Querier %s resuming", __func__, ifaddr_str);
 	}
+
+	/*
+	 * Adjust the querier robustness value to our own configuration if the
+	 * other querier is no longer present.
+	 */
+	if (igmp->t_other_querier_timer == NULL) {
+		struct pim_interface *pim_ifp = igmp->interface->info;
+
+		igmp->querier_robustness_variable = pim_ifp->gm_default_robustness_variable;
+	}
+
 	/* Mark the interface address as querier address */
 	igmp->querier_addr = igmp->ifaddr;
 

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -1080,8 +1080,8 @@ static void group_retransmit_group(struct gm_group *group)
 
 	char query_buf[query_buf_size];
 
-	lmqc = pim_ifp->gm_last_member_query_count;
-	lmqi_msec = 100L * pim_ifp->gm_specific_query_max_response_time_dsec;
+	lmqc = if_gm_last_member_query_count(pim_ifp);
+	lmqi_msec = 100 * pim_ifp->gm_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/*
@@ -1150,8 +1150,8 @@ static int group_retransmit_sources(struct gm_group *group,
 
 	pim_ifp = group->interface->info;
 
-	lmqc = pim_ifp->gm_last_member_query_count;
-	lmqi_msec = 100L * pim_ifp->gm_specific_query_max_response_time_dsec;
+	lmqc = if_gm_last_member_query_count(pim_ifp);
+	lmqi_msec = 100 * pim_ifp->gm_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/* Scan all group sources */
@@ -1375,7 +1375,7 @@ static void group_query_send(struct gm_group *group)
 	long lmqc; /* Last Member Query Count */
 
 	pim_ifp = group->interface->info;
-	lmqc = pim_ifp->gm_last_member_query_count;
+	lmqc = if_gm_last_member_query_count(pim_ifp);
 
 	/* lower group timer to lmqt */
 	igmp_group_timer_lower_to_lmqt(group);
@@ -1408,8 +1408,8 @@ static void source_query_send_by_flag(struct gm_group *group,
 
 	pim_ifp = group->interface->info;
 
-	lmqc = pim_ifp->gm_last_member_query_count;
-	lmqi_msec = 100L * pim_ifp->gm_specific_query_max_response_time_dsec;
+	lmqc = if_gm_last_member_query_count(pim_ifp);
+	lmqi_msec = 100 * pim_ifp->gm_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
 	/*
@@ -1568,7 +1568,7 @@ void igmp_group_timer_lower_to_lmqt(struct gm_group *group)
 	lmqi_dsec = pim_ifp->gmp_immediate_leave
 			    ? 0
 			    : pim_ifp->gm_specific_query_max_response_time_dsec;
-	lmqc = pim_ifp->gm_last_member_query_count;
+	lmqc = if_gm_last_member_query_count(pim_ifp);
 	lmqt_msec = PIM_IGMP_LMQT_MSEC(
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 
@@ -1605,7 +1605,7 @@ void igmp_source_timer_lower_to_lmqt(struct gm_source *source)
 	lmqi_dsec = pim_ifp->gmp_immediate_leave
 			    ? 0
 			    : pim_ifp->gm_specific_query_max_response_time_dsec;
-	lmqc = pim_ifp->gm_last_member_query_count;
+	lmqc = if_gm_last_member_query_count(pim_ifp);
 	lmqt_msec = PIM_IGMP_LMQT_MSEC(
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 

--- a/pimd/pim_nb.c
+++ b/pimd/pim_nb.c
@@ -821,6 +821,13 @@ const struct frr_yang_module_info frr_gmp_info = {
 			}
 		},
 		{
+			.xpath = "/frr-interface:lib/interface/frr-gmp:gmp/address-family/last-member-query-count",
+			.cbs = {
+				.modify = lib_interface_gmp_address_family_last_member_query_count_modify,
+				.destroy = lib_interface_gmp_address_family_last_member_query_count_destroy,
+			}
+		},
+		{
 			.xpath = "/frr-interface:lib/interface/frr-gmp:gmp/address-family/robustness-variable",
 			.cbs = {
 				.modify = lib_interface_gmp_address_family_robustness_variable_modify,

--- a/pimd/pim_nb.h
+++ b/pimd/pim_nb.h
@@ -298,6 +298,9 @@ int lib_interface_gmp_address_family_query_max_response_time_modify(
 		struct nb_cb_modify_args *args);
 int lib_interface_gmp_address_family_last_member_query_interval_modify(
 		struct nb_cb_modify_args *args);
+int lib_interface_gmp_address_family_last_member_query_count_modify(struct nb_cb_modify_args *args);
+int lib_interface_gmp_address_family_last_member_query_count_destroy(
+	struct nb_cb_destroy_args *args);
 int lib_interface_gmp_address_family_robustness_variable_modify(
 		struct nb_cb_modify_args *args);
 int lib_interface_gmp_address_family_join_group_create(

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -4791,14 +4791,12 @@ int lib_interface_gm_max_sources_modify(struct nb_cb_modify_args *args)
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-gmp:gmp/address-family/robustness-variable
+ * XPath: /frr-interface:lib/interface/frr-gmp:gmp/address-family/last-member-query-count
  */
-int lib_interface_gmp_address_family_robustness_variable_modify(
-	struct nb_cb_modify_args *args)
+int lib_interface_gmp_address_family_last_member_query_count_modify(struct nb_cb_modify_args *args)
 {
 	struct interface *ifp;
 	struct pim_interface *pim_ifp;
-	int last_member_query_count;
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -4808,9 +4806,56 @@ int lib_interface_gmp_address_family_robustness_variable_modify(
 	case NB_EV_APPLY:
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
-		last_member_query_count =
-			yang_dnode_get_uint8(args->dnode, NULL);
-		pim_ifp->gm_last_member_query_count = last_member_query_count;
+		pim_ifp->gm_last_member_query_count = yang_dnode_get_uint8(args->dnode, NULL);
+#if PIM_IPV == 6
+		gm_ifp_update(ifp);
+#endif
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_gmp_address_family_last_member_query_count_destroy(struct nb_cb_destroy_args *args)
+{
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
+		pim_ifp = ifp->info;
+		pim_ifp->gm_last_member_query_count = 0;
+#if PIM_IPV == 6
+		gm_ifp_update(ifp);
+#endif
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-gmp:gmp/address-family/robustness-variable
+ */
+int lib_interface_gmp_address_family_robustness_variable_modify(struct nb_cb_modify_args *args)
+{
+	struct interface *ifp;
+	struct pim_interface *pim_ifp;
+
+	switch (args->event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		ifp = nb_running_get_entry(args->dnode, NULL, true);
+		pim_ifp = ifp->info;
+		pim_ifp->gm_default_robustness_variable = yang_dnode_get_uint8(args->dnode, NULL);
 #if PIM_IPV == 6
 		gm_ifp_update(ifp);
 #endif

--- a/pimd/pim_nb_config.c
+++ b/pimd/pim_nb_config.c
@@ -4856,7 +4856,19 @@ int lib_interface_gmp_address_family_robustness_variable_modify(struct nb_cb_mod
 		ifp = nb_running_get_entry(args->dnode, NULL, true);
 		pim_ifp = ifp->info;
 		pim_ifp->gm_default_robustness_variable = yang_dnode_get_uint8(args->dnode, NULL);
-#if PIM_IPV == 6
+
+#if PIM_IPV == 4
+		struct listnode *node;
+		struct gm_sock *igmp;
+
+		/* Update all addresses that are acting as querier */
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->gm_socket_list, node, igmp)) {
+			if (igmp->t_other_querier_timer)
+				continue;
+
+			igmp->querier_robustness_variable = pim_ifp->gm_default_robustness_variable;
+		}
+#else
 		gm_ifp_update(ifp);
 #endif
 		break;

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -334,8 +334,7 @@ static int gm_config_write(struct vty *vty, int writes,
 	}
 
 	/* IF ip igmp last-member_query-count */
-	if (pim_ifp->gm_last_member_query_count !=
-	    GM_DEFAULT_ROBUSTNESS_VARIABLE) {
+	if (pim_ifp->gm_last_member_query_count != 0) {
 		vty_out(vty, " ip igmp last-member-query-count %d\n",
 			pim_ifp->gm_last_member_query_count);
 		++writes;
@@ -416,8 +415,7 @@ static int gm_config_write(struct vty *vty, int writes,
 			pim_ifp->gm_default_query_interval);
 
 	/* IF ipv6 mld last-member_query-count */
-	if (pim_ifp->gm_last_member_query_count !=
-	    GM_DEFAULT_ROBUSTNESS_VARIABLE)
+	if (pim_ifp->gm_last_member_query_count != 0)
 		vty_out(vty, " ipv6 mld last-member-query-count %d\n",
 			pim_ifp->gm_last_member_query_count);
 

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -333,6 +333,12 @@ static int gm_config_write(struct vty *vty, int writes,
 		++writes;
 	}
 
+	/* IF ip igmp robustness */
+	if (pim_ifp->gm_default_robustness_variable != GM_DEFAULT_ROBUSTNESS_VARIABLE) {
+		vty_out(vty, " ip igmp robustness %d\n", pim_ifp->gm_default_robustness_variable);
+		++writes;
+	}
+
 	/* IF ip igmp last-member_query-count */
 	if (pim_ifp->gm_last_member_query_count != 0) {
 		vty_out(vty, " ip igmp last-member-query-count %d\n",
@@ -413,6 +419,12 @@ static int gm_config_write(struct vty *vty, int writes,
 	if (pim_ifp->gm_default_query_interval != GM_GENERAL_QUERY_INTERVAL)
 		vty_out(vty, " ipv6 mld query-interval %d\n",
 			pim_ifp->gm_default_query_interval);
+
+	/* IF ipv6 mld robustness */
+	if (pim_ifp->gm_default_robustness_variable != GM_DEFAULT_ROBUSTNESS_VARIABLE) {
+		vty_out(vty, " ipv6 mld robustness %d\n", pim_ifp->gm_default_robustness_variable);
+		++writes;
+	}
 
 	/* IF ipv6 mld last-member_query-count */
 	if (pim_ifp->gm_last_member_query_count != 0)

--- a/tests/topotests/pim_timers/r1/frr.conf
+++ b/tests/topotests/pim_timers/r1/frr.conf
@@ -1,5 +1,8 @@
 interface r1-eth0
+ ip address 192.168.0.1/24
+ ip igmp
  ip pim
+ ipv6 mld
  ipv6 pim
 exit
 !

--- a/tests/topotests/pim_timers/test_pim_timers.py
+++ b/tests/topotests/pim_timers/test_pim_timers.py
@@ -245,6 +245,164 @@ def test_pim6_assert_interval():
     ), "invalid interface assert override interval"
 
 
+def test_igmp_robustness():
+    """
+    Test robustness and last-member-query-count value changes.
+
+    If unspecified last-member-query-count defaults to robustness.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Check the default value
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ip igmp interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(
+            output,
+            {
+                "r1-eth0": {
+                    "timerRobustnessVariable": 2,
+                    "lastMemberQueryCount": 2,
+                }
+            },
+        )
+        is None
+    ), "invalid default robustness or last-member-query-count value"
+
+    # Check interface robustness value change and default last-member-query-count value change
+    tgen.gears["r1"].vtysh_cmd(
+        """
+    configure terminal
+    interface r1-eth0
+     ip igmp robustness 3
+    """
+    )
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ip igmp interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(
+            output,
+            {
+                "r1-eth0": {
+                    "timerRobustnessVariable": 3,
+                    "lastMemberQueryCount": 3,
+                }
+            },
+        )
+        is None
+    ), "invalid interface robustness or last-member-query-count value"
+
+    # Check interface last-member-query-count value override
+    tgen.gears["r1"].vtysh_cmd(
+        """
+    configure terminal
+    interface r1-eth0
+     ip igmp last-member-query-count 4
+    """
+    )
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ip igmp interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(
+            output,
+            {
+                "r1-eth0": {
+                    "timerRobustnessVariable": 3,
+                    "lastMemberQueryCount": 4,
+                }
+            },
+        )
+        is None
+    ), "invalid interface last-member-query-count override value"
+
+
+def test_mld_robustness():
+    """
+    Test robustness and last-member-query-count value changes.
+
+    If unspecified last-member-query-count defaults to robustness.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Check the default value
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ipv6 mld interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(
+            output,
+            {
+                "default": {
+                    "r1-eth0": {
+                        "timerRobustnessValue": 2,
+                        "lastMemberQueryCount": 2,
+                    }
+                }
+            },
+        )
+        is None
+    ), "invalid default robustness or last-member-query-count value"
+
+    # Check interface robustness value change and default last-member-query-count value change
+    tgen.gears["r1"].vtysh_cmd(
+        """
+    configure terminal
+    interface r1-eth0
+     ipv6 mld robustness 3
+    """
+    )
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ipv6 mld interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(
+            output,
+            {
+                "default": {
+                    "r1-eth0": {
+                        "timerRobustnessValue": 3,
+                        "lastMemberQueryCount": 3,
+                    }
+                }
+            },
+        )
+        is None
+    ), "invalid interface robustness or last-member-query-count value"
+
+    # Check interface last-member-query-count value override
+    tgen.gears["r1"].vtysh_cmd(
+        """
+    configure terminal
+    interface r1-eth0
+     ipv6 mld last-member-query-count 4
+    """
+    )
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ipv6 mld interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(
+            output,
+            {
+                "default": {
+                    "r1-eth0": {
+                        "timerRobustnessValue": 3,
+                        "lastMemberQueryCount": 4,
+                    }
+                }
+            },
+        )
+        is None
+    ), "invalid interface last-member-query-count override value"
+
+
 def test_memory_leak():
     "Run the memory leak test and report results."
     tgen = get_topogen()

--- a/tests/topotests/pim_timers/test_pim_timers.py
+++ b/tests/topotests/pim_timers/test_pim_timers.py
@@ -35,9 +35,7 @@ pytestmark = [pytest.mark.pimd]
 def setup_module(mod):
     "Sets up the pytest environment"
 
-    topodef = {
-        "s1": ("r1")
-    }
+    topodef = {"s1": ("r1")}
 
     tgen = Topogen(topodef, mod.__name__)
     tgen.start_topology()
@@ -59,164 +57,192 @@ def test_pim_join_prune():
     tgen = get_topogen()
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
-    
+
     # Check the default value
-    output = tgen.gears['r1'].vtysh_cmd('show ip pim interface r1-eth0 json', isjson=True)
-    assert topotest.json_cmp(output, {
-        "r1-eth0": {
-            "joinPruneInterval": 60
-        }
-    }) is None, "invalid default join-prune interval"
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ip pim interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(output, {"r1-eth0": {"joinPruneInterval": 60}}) is None
+    ), "invalid default join-prune interval"
 
     # Check global variable change
-    tgen.gears['r1'].vtysh_cmd("""
+    tgen.gears["r1"].vtysh_cmd(
+        """
     configure terminal
     router pim
      join-prune-interval 123
-    """)
-    output = tgen.gears['r1'].vtysh_cmd('show ip pim interface r1-eth0 json', isjson=True)
-    assert topotest.json_cmp(output, {
-        "r1-eth0": {
-            "joinPruneInterval": 123
-        }
-    }) is None, "invalid global join-prune interval"
+    """
+    )
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ip pim interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(output, {"r1-eth0": {"joinPruneInterval": 123}}) is None
+    ), "invalid global join-prune interval"
 
     # Check interface variable change
-    tgen.gears['r1'].vtysh_cmd("""
+    tgen.gears["r1"].vtysh_cmd(
+        """
     configure terminal
     interface r1-eth0
      ip pim join-prune-interval 134
-    """)
-    output = tgen.gears['r1'].vtysh_cmd('show ip pim interface r1-eth0 json', isjson=True)
-    assert topotest.json_cmp(output, {
-        "r1-eth0": {
-            "joinPruneInterval": 134
-        }
-    }) is None, "invalid interface join-prune interval"
+    """
+    )
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ip pim interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(output, {"r1-eth0": {"joinPruneInterval": 134}}) is None
+    ), "invalid interface join-prune interval"
 
 
 def test_pim_assert_interval():
     tgen = get_topogen()
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
-    
+
     # Check the default value
-    output = tgen.gears['r1'].vtysh_cmd('show ip pim interface r1-eth0 json', isjson=True)
-    assert topotest.json_cmp(output, {
-        "r1-eth0": {
-            "assertInterval": 180000
-        }
-    }) is None, "invalid default assert interval"
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ip pim interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(output, {"r1-eth0": {"assertInterval": 180000}}) is None
+    ), "invalid default assert interval"
 
     # Check interface variable change
-    tgen.gears['r1'].vtysh_cmd("""
+    tgen.gears["r1"].vtysh_cmd(
+        """
     configure terminal
     interface r1-eth0
      ip pim assert-interval 190000
-    """)
-    output = tgen.gears['r1'].vtysh_cmd('show ip pim interface r1-eth0 json', isjson=True)
-    assert topotest.json_cmp(output, {
-        "r1-eth0": {
-            "assertInterval": 190000
-        }
-    }) is None, "invalid interface assert interval"
+    """
+    )
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ip pim interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(output, {"r1-eth0": {"assertInterval": 190000}}) is None
+    ), "invalid interface assert interval"
 
     # Check interface variable change
-    tgen.gears['r1'].vtysh_cmd("""
+    tgen.gears["r1"].vtysh_cmd(
+        """
     configure terminal
     interface r1-eth0
      ip pim assert-override-interval 3500
-    """)
-    output = tgen.gears['r1'].vtysh_cmd('show ip pim interface r1-eth0 json', isjson=True)
-    assert topotest.json_cmp(output, {
-        "r1-eth0": {
-            "assertInterval": 190000,
-            "assertOverrideInterval": 3500
-        }
-    }) is None, "invalid interface assert override interval"
+    """
+    )
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ip pim interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(
+            output,
+            {"r1-eth0": {"assertInterval": 190000, "assertOverrideInterval": 3500}},
+        )
+        is None
+    ), "invalid interface assert override interval"
 
 
 def test_pim6_join_prune():
     tgen = get_topogen()
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
-    
+
     # Check the default value
-    output = tgen.gears['r1'].vtysh_cmd('show ipv6 pim interface r1-eth0 json', isjson=True)
-    assert topotest.json_cmp(output, {
-        "r1-eth0": {
-            "joinPruneInterval": 60
-        }
-    }) is None, "invalid default join-prune interval"
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ipv6 pim interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(output, {"r1-eth0": {"joinPruneInterval": 60}}) is None
+    ), "invalid default join-prune interval"
 
     # Check global variable change
-    tgen.gears['r1'].vtysh_cmd("""
+    tgen.gears["r1"].vtysh_cmd(
+        """
     configure terminal
     router pim6
      join-prune-interval 123
-    """)
-    output = tgen.gears['r1'].vtysh_cmd('show ipv6 pim interface r1-eth0 json', isjson=True)
-    assert topotest.json_cmp(output, {
-        "r1-eth0": {
-            "joinPruneInterval": 123
-        }
-    }) is None, "invalid global join-prune interval"
+    """
+    )
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ipv6 pim interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(output, {"r1-eth0": {"joinPruneInterval": 123}}) is None
+    ), "invalid global join-prune interval"
 
     # Check interface variable change
-    tgen.gears['r1'].vtysh_cmd("""
+    tgen.gears["r1"].vtysh_cmd(
+        """
     configure terminal
     interface r1-eth0
      ipv6 pim join-prune-interval 134
-    """)
-    output = tgen.gears['r1'].vtysh_cmd('show ipv6 pim interface r1-eth0 json', isjson=True)
-    assert topotest.json_cmp(output, {
-        "r1-eth0": {
-            "joinPruneInterval": 134
-        }
-    }) is None, "invalid interface join-prune interval"
+    """
+    )
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ipv6 pim interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(output, {"r1-eth0": {"joinPruneInterval": 134}}) is None
+    ), "invalid interface join-prune interval"
 
 
 def test_pim6_assert_interval():
     tgen = get_topogen()
     if tgen.routers_have_failure():
         pytest.skip(tgen.errors)
-    
+
     # Check the default value
-    output = tgen.gears['r1'].vtysh_cmd('show ipv6 pim interface r1-eth0 json', isjson=True)
-    assert topotest.json_cmp(output, {
-        "r1-eth0": {
-            "assertInterval": 180000,
-            "assertOverrideInterval": 3000
-        }
-    }) is None, "invalid default assert interval"
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ipv6 pim interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(
+            output,
+            {"r1-eth0": {"assertInterval": 180000, "assertOverrideInterval": 3000}},
+        )
+        is None
+    ), "invalid default assert interval"
 
     # Check interface variable change
-    tgen.gears['r1'].vtysh_cmd("""
+    tgen.gears["r1"].vtysh_cmd(
+        """
     configure terminal
     interface r1-eth0
      ipv6 pim assert-interval 190000
-    """)
-    output = tgen.gears['r1'].vtysh_cmd('show ipv6 pim interface r1-eth0 json', isjson=True)
-    assert topotest.json_cmp(output, {
-        "r1-eth0": {
-            "assertInterval": 190000,
-            "assertOverrideInterval": 3133
-        }
-    }) is None, "invalid interface assert interval"
+    """
+    )
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ipv6 pim interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(
+            output,
+            {"r1-eth0": {"assertInterval": 190000, "assertOverrideInterval": 3133}},
+        )
+        is None
+    ), "invalid interface assert interval"
 
     # Check interface variable change
-    tgen.gears['r1'].vtysh_cmd("""
+    tgen.gears["r1"].vtysh_cmd(
+        """
     configure terminal
     interface r1-eth0
      ipv6 pim assert-override-interval 3500
-    """)
-    output = tgen.gears['r1'].vtysh_cmd('show ipv6 pim interface r1-eth0 json', isjson=True)
-    assert topotest.json_cmp(output, {
-        "r1-eth0": {
-            "assertInterval": 190000,
-            "assertOverrideInterval": 3500
-        }
-    }) is None, "invalid interface assert override interval"
+    """
+    )
+    output = tgen.gears["r1"].vtysh_cmd(
+        "show ipv6 pim interface r1-eth0 json", isjson=True
+    )
+    assert (
+        topotest.json_cmp(
+            output,
+            {"r1-eth0": {"assertInterval": 190000, "assertOverrideInterval": 3500}},
+        )
+        is None
+    ), "invalid interface assert override interval"
 
 
 def test_memory_leak():

--- a/yang/frr-gmp.yang
+++ b/yang/frr-gmp.yang
@@ -145,6 +145,15 @@ module frr-gmp {
          the leave latency of the network.";
     }
 
+    leaf last-member-query-count {
+      type uint8 {
+        range "1..max";
+      }
+      description
+        "Last Member Query Count allows tuning for the expected
+	 packet loss on a network when leaving a group/group-source.";
+    }
+
     leaf robustness-variable {
       type uint8 {
         range "1..max";


### PR DESCRIPTION
The interface multicast configuration `<ip|ipv6> <igmp|mld> last-member-query-count` configuration was actually calling the robustness value northbound callbacks and no last-member-query-count northbound callbacks existed.

This PR adds the last-member-query-count northbound callback, adds the command to configure the robustness value and fixes the usage of robustness value in case of non-querier router.