### PR TITLE
bgpd: fix remove useless srv6 FUNC_WIDE flag

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -371,11 +371,7 @@ void vpn_leak_zebra_vrf_sid_update_per_af(struct bgp *bgp, afi_t afi)
 			bgp->vpn_policy[afi].tovpn_sid_locator->block_bits_length;
 		ctx.node_len =
 			bgp->vpn_policy[afi].tovpn_sid_locator->node_bits_length;
-		if (CHECK_FLAG(bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_SID_FUNC_WIDE))
-			ctx.function_len = BGP_PREFIX_SID_SRV6_MAX_FUNCTION_LENGTH_FOR_BGP;
-		else
-			ctx.function_len =
-				bgp->vpn_policy[afi].tovpn_sid_locator->function_bits_length;
+		ctx.function_len = bgp->vpn_policy[afi].tovpn_sid_locator->function_bits_length;
 		ctx.argument_len =
 			bgp->vpn_policy[afi]
 				.tovpn_sid_locator->argument_bits_length;
@@ -442,10 +438,7 @@ void vpn_leak_zebra_vrf_sid_update_per_vrf(struct bgp *bgp)
 	if (bgp->tovpn_sid_locator) {
 		ctx.block_len = bgp->tovpn_sid_locator->block_bits_length;
 		ctx.node_len = bgp->tovpn_sid_locator->node_bits_length;
-		if (CHECK_FLAG(bgp->vrf_flags, BGP_VRF_TOVPN_SID_FUNC_WIDE))
-			ctx.function_len = BGP_PREFIX_SID_SRV6_MAX_FUNCTION_LENGTH_FOR_BGP;
-		else
-			ctx.function_len = bgp->tovpn_sid_locator->function_bits_length;
+		ctx.function_len = bgp->tovpn_sid_locator->function_bits_length;
 		ctx.argument_len = bgp->tovpn_sid_locator->argument_bits_length;
 		if (CHECK_FLAG(bgp->tovpn_sid_locator->flags, SRV6_LOCATOR_USID))
 			SET_SRV6_FLV_OP(ctx.flv.flv_ops, ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
@@ -513,11 +506,8 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_af(struct bgp *bgp, afi_t afi)
 			bgp->vpn_policy[afi].tovpn_sid_locator->block_bits_length;
 		seg6localctx.node_len =
 			bgp->vpn_policy[afi].tovpn_sid_locator->node_bits_length;
-		if (CHECK_FLAG(bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_SID_FUNC_WIDE))
-			seg6localctx.function_len = BGP_PREFIX_SID_SRV6_MAX_FUNCTION_LENGTH_FOR_BGP;
-		else
-			seg6localctx.function_len =
-				bgp->vpn_policy[afi].tovpn_sid_locator->function_bits_length;
+		seg6localctx.function_len =
+			bgp->vpn_policy[afi].tovpn_sid_locator->function_bits_length;
 		seg6localctx.argument_len =
 			bgp->vpn_policy[afi]
 				.tovpn_sid_locator->argument_bits_length;
@@ -533,7 +523,6 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_af(struct bgp *bgp, afi_t afi)
 	ctx.behavior = afi == AFI_IP ? ZEBRA_SEG6_LOCAL_ACTION_END_DT4
 				     : ZEBRA_SEG6_LOCAL_ACTION_END_DT6;
 	bgp_zebra_release_srv6_sid(&ctx, bgp->vpn_policy[afi].tovpn_sid_locator->name);
-	UNSET_FLAG(bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_SID_FUNC_WIDE);
 }
 
 /*
@@ -567,10 +556,7 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_vrf(struct bgp *bgp)
 		seg6localctx.block_len =
 			bgp->tovpn_sid_locator->block_bits_length;
 		seg6localctx.node_len = bgp->tovpn_sid_locator->node_bits_length;
-		if (CHECK_FLAG(bgp->vrf_flags, BGP_VRF_TOVPN_SID_FUNC_WIDE))
-			seg6localctx.function_len = BGP_PREFIX_SID_SRV6_MAX_FUNCTION_LENGTH_FOR_BGP;
-		else
-			seg6localctx.function_len = bgp->tovpn_sid_locator->function_bits_length;
+		seg6localctx.function_len = bgp->tovpn_sid_locator->function_bits_length;
 		seg6localctx.argument_len =
 			bgp->tovpn_sid_locator->argument_bits_length;
 	}
@@ -583,7 +569,6 @@ void vpn_leak_zebra_vrf_sid_withdraw_per_vrf(struct bgp *bgp)
 	ctx.vrf_id = bgp->vrf_id;
 	ctx.behavior = ZEBRA_SEG6_LOCAL_ACTION_END_DT46;
 	bgp_zebra_release_srv6_sid(&ctx, bgp->tovpn_sid_locator->name);
-	UNSET_FLAG(bgp->vrf_flags, BGP_VRF_TOVPN_SID_FUNC_WIDE);
 }
 
 /*
@@ -1025,7 +1010,6 @@ void delete_vrf_tovpn_sid_per_af(struct bgp *bgp_vpn, struct bgp *bgp_vrf,
 		ctx.behavior = afi == AFI_IP ? ZEBRA_SEG6_LOCAL_ACTION_END_DT4
 					     : ZEBRA_SEG6_LOCAL_ACTION_END_DT6;
 		bgp_zebra_release_srv6_sid(&ctx, bgp_vrf->vpn_policy[afi].tovpn_sid_locator->name);
-		UNSET_FLAG(bgp_vrf->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_SID_FUNC_WIDE);
 
 		sid_unregister(bgp_vpn, bgp_vrf->vpn_policy[afi].tovpn_sid);
 		XFREE(MTYPE_BGP_SRV6_SID, bgp_vrf->vpn_policy[afi].tovpn_sid);
@@ -1072,7 +1056,6 @@ void delete_vrf_tovpn_sid_per_vrf(struct bgp *bgp_vpn, struct bgp *bgp_vrf)
 		ctx.vrf_id = bgp_vrf->vrf_id;
 		ctx.behavior = ZEBRA_SEG6_LOCAL_ACTION_END_DT46;
 		bgp_zebra_release_srv6_sid(&ctx, bgp_vrf->tovpn_sid_locator->name);
-		UNSET_FLAG(bgp_vrf->vrf_flags, BGP_VRF_TOVPN_SID_FUNC_WIDE);
 
 		sid_unregister(bgp_vpn, bgp_vrf->tovpn_sid);
 		XFREE(MTYPE_BGP_SRV6_SID, bgp_vrf->tovpn_sid);
@@ -1766,12 +1749,8 @@ static bool vpn_leak_from_vrf_fill_srv6(struct attr *attr, struct bgp *from_bgp,
 			from_bgp->vpn_policy[afi].tovpn_sid_locator->block_bits_length;
 		attr->srv6_l3service->loc_node_len =
 			from_bgp->vpn_policy[afi].tovpn_sid_locator->node_bits_length;
-		if (CHECK_FLAG(from_bgp->vpn_policy[afi].flags, BGP_VPN_POLICY_TOVPN_SID_FUNC_WIDE))
-			attr->srv6_l3service->func_len =
-				BGP_PREFIX_SID_SRV6_MAX_FUNCTION_LENGTH_FOR_BGP;
-		else
-			attr->srv6_l3service->func_len =
-				from_bgp->vpn_policy[afi].tovpn_sid_locator->function_bits_length;
+		attr->srv6_l3service->func_len =
+			from_bgp->vpn_policy[afi].tovpn_sid_locator->function_bits_length;
 		attr->srv6_l3service->arg_len =
 			from_bgp->vpn_policy[afi].tovpn_sid_locator->argument_bits_length;
 		if (attr->srv6_l3service->func_len >
@@ -1805,12 +1784,7 @@ static bool vpn_leak_from_vrf_fill_srv6(struct attr *attr, struct bgp *from_bgp,
 		attr->srv6_l3service->loc_block_len =
 			from_bgp->tovpn_sid_locator->block_bits_length;
 		attr->srv6_l3service->loc_node_len = from_bgp->tovpn_sid_locator->node_bits_length;
-		if (CHECK_FLAG(from_bgp->vrf_flags, BGP_VRF_TOVPN_SID_FUNC_WIDE))
-			attr->srv6_l3service->func_len =
-				BGP_PREFIX_SID_SRV6_MAX_FUNCTION_LENGTH_FOR_BGP;
-		else
-			attr->srv6_l3service->func_len =
-				from_bgp->tovpn_sid_locator->function_bits_length;
+		attr->srv6_l3service->func_len = from_bgp->tovpn_sid_locator->function_bits_length;
 		attr->srv6_l3service->arg_len = from_bgp->tovpn_sid_locator->argument_bits_length;
 		if (attr->srv6_l3service->func_len >
 		    BGP_PREFIX_SID_SRV6_MAX_FUNCTION_LENGTH_FOR_LABEL) {

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3859,16 +3859,10 @@ static int bgp_zebra_srv6_sid_notify(ZAPI_CALLBACK_ARGS)
 		mpls_label_t label = MPLS_LABEL_IMPLICIT_NULL;
 
 		if (sid_wide_func && (CHECK_FLAG(locator_bgp->flags, SRV6_LOCATOR_F3216) ||
-				      CHECK_FLAG(locator_bgp->flags, SRV6_LOCATOR_F4816))) {
-			if (ctx.behavior == ZEBRA_SEG6_LOCAL_ACTION_END_DT6)
-				SET_FLAG(bgp_vrf->vpn_policy[AFI_IP6].flags,
-					 BGP_VPN_POLICY_TOVPN_SID_FUNC_WIDE);
-			else if (ctx.behavior == ZEBRA_SEG6_LOCAL_ACTION_END_DT4)
-				SET_FLAG(bgp_vrf->vpn_policy[AFI_IP].flags,
-					 BGP_VPN_POLICY_TOVPN_SID_FUNC_WIDE);
-			else if (ctx.behavior == ZEBRA_SEG6_LOCAL_ACTION_END_DT46)
-				SET_FLAG(bgp_vrf->vrf_flags, BGP_VRF_TOVPN_SID_FUNC_WIDE);
-		} else if (func_len <= BGP_PREFIX_SID_SRV6_MAX_FUNCTION_LENGTH_FOR_LABEL)
+				      CHECK_FLAG(locator_bgp->flags, SRV6_LOCATOR_F4816)))
+			locator_bgp->function_bits_length =
+				BGP_PREFIX_SID_SRV6_MAX_FUNCTION_LENGTH_FOR_BGP;
+		else if (func_len <= BGP_PREFIX_SID_SRV6_MAX_FUNCTION_LENGTH_FOR_LABEL)
 			label = sid_func
 				<< (BGP_PREFIX_SID_SRV6_MAX_FUNCTION_LENGTH_FOR_LABEL - func_len);
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -311,8 +311,7 @@ struct vpn_policy {
 #define BGP_VPN_POLICY_TOVPN_LABEL_MANUAL_REG (1 << 5)
 #define BGP_VPN_POLICY_TOVPN_SID_EXPLICIT     (1 << 6)
 /* Is this value set by the cli? */
-#define BGP_VPN_POLICY_TOVPN_RD_CLI_SET       (1 << 7)
-#define BGP_VPN_POLICY_TOVPN_SID_FUNC_WIDE    (1 << 8)
+#define BGP_VPN_POLICY_TOVPN_RD_CLI_SET (1 << 7)
 
 	/*
 	 * If we are importing another vrf into us keep a list of
@@ -1006,7 +1005,6 @@ struct bgp {
 /* per-VRF toVPN SID */
 #define BGP_VRF_TOVPN_SID_AUTO              (1 << 7)
 #define BGP_VRF_TOVPN_SID_EXPLICIT	    (1 << 8)
-#define BGP_VRF_TOVPN_SID_FUNC_WIDE	    (1 << 9)
 
 	/* unique ID for auto derivation of RD for this vrf */
 	uint16_t vrf_rd_id;


### PR DESCRIPTION
When allocating a SID with wide function range, a flag is specifically used to tell the sid should be encoded with a function length of 32 bits. This can be simplified by directly modifying the locator bound to the SID, because a locator context is allocated for each SID.

Fixes: 5a10caf7c12f ("bgpd: change function length to 32 bits when wide_func is used")