### PR TITLE
zebra: skip kernel provider work when skip_kernel is set

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1412,9 +1412,6 @@ enum netlink_msg_status netlink_batch_add_msg(
 static enum netlink_msg_status nl_put_msg(struct nl_batch *bth,
 					  struct zebra_dplane_ctx *ctx)
 {
-	if (dplane_ctx_is_skip_kernel(ctx))
-		return FRR_NETLINK_SUCCESS;
-
 	switch (dplane_ctx_get_op(ctx)) {
 
 	case DPLANE_OP_ROUTE_INSTALL:

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1599,16 +1599,6 @@ void kernel_update_multi(struct dplane_ctx_list_head *ctx_list)
 		ctx = dplane_ctx_dequeue(ctx_list);
 		if (ctx == NULL)
 			break;
-
-		/*
-		 * A previous provider plugin may have asked to skip the
-		 * kernel update.
-		 */
-		if (dplane_ctx_is_skip_kernel(ctx)) {
-			res = ZEBRA_DPLANE_REQUEST_SUCCESS;
-			goto skip_one;
-		}
-
 		switch (dplane_ctx_get_op(ctx)) {
 
 		case DPLANE_OP_ROUTE_INSTALL:
@@ -1710,7 +1700,6 @@ void kernel_update_multi(struct dplane_ctx_list_head *ctx_list)
 			res = ZEBRA_DPLANE_REQUEST_FAILURE;
 		}
 
-	skip_one:
 		dplane_ctx_set_status(ctx, res);
 
 		dplane_ctx_enqueue_tail(&handled_list, ctx);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -7263,6 +7263,16 @@ static int kernel_dplane_process_func(struct zebra_dplane_provider *prov)
 		if (IS_ZEBRA_DEBUG_DPLANE_DETAIL)
 			kernel_dplane_log_detail(ctx);
 
+		/*
+		 * A previous provider plugin may have asked to skip the
+		 * kernel update.
+		 */
+		if (dplane_ctx_is_skip_kernel(ctx)) {
+			dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_SUCCESS);
+			dplane_provider_enqueue_out_ctx(prov, ctx);
+			continue;
+		}
+
 		if ((dplane_ctx_get_op(ctx) == DPLANE_OP_IPTABLE_ADD
 		     || dplane_ctx_get_op(ctx) == DPLANE_OP_IPTABLE_DELETE))
 			kernel_dplane_process_iptable(prov, ctx);


### PR DESCRIPTION
 Centralize `skip_kernel` handling in the kernel dplane provider.                                                                                                        
                                                                                                                                                                           
   - `skip_kernel` was only applied in the netlink batch send path                                                                                                         
   - Operations processed by dedicated handlers (e.g. IPTABLE, IPSET) were still executed even when a previous provider plugin requested to skip kernel updates            
   - Handle `skip_kernel` early in `kernel_dplane_process_func()` so it applies to all kernel provider operations                                                          
   - Remove the scattered checks from the netlink/socket helpers                           