### PR TITLE
tests: There is no pytest.mark.zebra

### DIFF
--- a/tests/topotests/zebra_ipv6_import_table/test_zebra_ipv6_import_table.py
+++ b/tests/topotests/zebra_ipv6_import_table/test_zebra_ipv6_import_table.py
@@ -33,7 +33,7 @@ TOPOLOGY = """
 CWD = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(CWD, "../"))
 
-pytestmark = [pytest.mark.staticd, pytest.mark.zebra]
+pytestmark = [pytest.mark.staticd]
 krel = platform.release()
 
 def build_topo(tgen):


### PR DESCRIPTION
There is no pytest.mark.zebra.  As that all tests implicitly test zebra at some level.  So no need for one.