### PR TITLE
Sharp send tableid for route

### DIFF
--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -28,7 +28,7 @@ Using SHARP
 All sharp commands are under the enable node and preceded by the ``sharp``
 keyword. At present, no sharp commands will be preserved in the config.
 
-.. clicmd:: sharp install routes A.B.C.D <nexthop <E.F.G.H|X:X::X:X>|nexthop-group NAME> (1-1000000) [instance (0-255)] [repeat (2-1000)] [opaque WORD]
+.. clicmd:: sharp install routes A.B.C.D <nexthop <E.F.G.H|X:X::X:X>|nexthop-group NAME> (1-1000000) [table (0-4294967295)] [instance (0-255)] [repeat (2-1000)] [opaque WORD]
 
    Install up to 1,000,000 (one million) /32 routes starting at ``A.B.C.D``
    with specified nexthop ``E.F.G.H`` or ``X:X::X:X``. The nexthop is
@@ -50,6 +50,11 @@ keyword. At present, no sharp commands will be preserved in the config.
    routes are removed from zebra. Route deletion start is noted in the debug
    log and when all routes have been successfully deleted the debug log will be
    updated with this information as well.
+
+.. clicmd:: sharp install stop
+
+   If sharpd is operating in a repeat loop, stop the repeat and remove
+   any installed routes.
 
 .. clicmd:: sharp data route
 

--- a/sharpd/sharp_globals.h
+++ b/sharpd/sharp_globals.h
@@ -32,6 +32,7 @@ struct sharp_routes {
 
 	bool tableid_set;
 	uint32_t tableid;
+	bool stop_loop;
 
 	uint8_t inst;
 	vrf_id_t vrf_id;

--- a/sharpd/sharp_globals.h
+++ b/sharpd/sharp_globals.h
@@ -30,6 +30,9 @@ struct sharp_routes {
 	/* ZAPI_ROUTE's flag */
 	uint32_t flags;
 
+	bool tableid_set;
+	uint32_t tableid;
+
 	uint8_t inst;
 	vrf_id_t vrf_id;
 

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -200,6 +200,16 @@ DEFPY (install_routes_data_dump,
 	return CMD_SUCCESS;
 }
 
+DEFPY(sharp_install_stop_vty, sharp_install_stop_cmd, "sharp install stop",
+      "Sharp routing Protocol\n"
+      "install some routes\n"
+      "Stop any repeating install/remove loops\n")
+{
+	sharp_install_stop();
+
+	return CMD_SUCCESS;
+}
+
 DEFPY (install_routes,
        install_routes_cmd,
        "sharp install routes [vrf NAME$vrf_name]\
@@ -244,6 +254,7 @@ DEFPY (install_routes,
 	sg.r.flags = 0;
 	sg.r.tableid = 0;
 	sg.r.tableid_set = false;
+	sg.r.stop_loop = false;
 
 	if (rpt >= 2)
 		sg.r.repeat = rpt * 2;
@@ -397,6 +408,7 @@ DEFPY (install_seg6_routes,
 
 	sg.r.total_routes = routes;
 	sg.r.installed_routes = 0;
+	sg.r.stop_loop = false;
 
 	if (rpt >= 2)
 		sg.r.repeat = rpt * 2;
@@ -490,6 +502,7 @@ DEFPY(install_seg6local_segs_routes, install_seg6local_segs_routes_cmd,
 
 	sg.r.total_routes = routes;
 	sg.r.installed_routes = 0;
+	sg.r.stop_loop = false;
 
 	if (rpt >= 2)
 		sg.r.repeat = rpt * 2;
@@ -625,6 +638,7 @@ DEFPY (install_seg6local_routes,
 
 	sg.r.total_routes = routes;
 	sg.r.installed_routes = 0;
+	sg.r.stop_loop = false;
 
 	if (rpt >= 2)
 		sg.r.repeat = rpt * 2;
@@ -785,6 +799,7 @@ DEFPY (remove_routes,
 
 	sg.r.total_routes = routes;
 	sg.r.removed_routes = 0;
+	sg.r.stop_loop = false;
 	uint32_t rts;
 
 	memset(&prefix, 0, sizeof(prefix));
@@ -1688,6 +1703,7 @@ DEFPY(sharp_use_resolved_nexthop_weight,
 void sharp_vty_init(void)
 {
 	install_element(ENABLE_NODE, &install_routes_data_dump_cmd);
+	install_element(ENABLE_NODE, &sharp_install_stop_cmd);
 	install_element(ENABLE_NODE, &install_routes_cmd);
 	install_element(ENABLE_NODE, &install_seg6_routes_cmd);
 	install_element(ENABLE_NODE, &install_seg6local_routes_cmd);

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -207,7 +207,7 @@ DEFPY (install_routes,
 	  <nexthop <A.B.C.D$nexthop4|X:X::X:X$nexthop6>|\
 	   nexthop-group NHGNAME$nexthop_group>\
 	  [backup$backup <A.B.C.D$backup_nexthop4|X:X::X:X$backup_nexthop6>] \
-	  (1-1000000)$routes [instance (0-255)$instance] [repeat (2-1000)$rpt] [opaque WORD] [no-recurse$norecurse]",
+	  (1-1000000)$routes [instance (0-255)$instance] [table (0-4294967295)$table_id] [repeat (2-1000)$rpt] [opaque WORD] [no-recurse$norecurse]",
        "Sharp routing Protocol\n"
        "install some routes\n"
        "Routes to install\n"
@@ -226,6 +226,8 @@ DEFPY (install_routes,
        "How many to create\n"
        "Instance to use\n"
        "Instance\n"
+       "Table to install into\n"
+       "Table id\n"
        "Should we repeat this command\n"
        "How many times to repeat this command\n"
        "What opaque data to send down\n"
@@ -240,6 +242,8 @@ DEFPY (install_routes,
 	sg.r.total_routes = routes;
 	sg.r.installed_routes = 0;
 	sg.r.flags = 0;
+	sg.r.tableid = 0;
+	sg.r.tableid_set = false;
 
 	if (rpt >= 2)
 		sg.r.repeat = rpt * 2;
@@ -347,6 +351,11 @@ DEFPY (install_routes,
 	else
 		sg.r.opaque[0] = '\0';
 
+	if (table_id_str) {
+		sg.r.tableid = (uint32_t)table_id;
+		sg.r.tableid_set = true;
+	}
+
 	/* Default is to ask for recursive nexthop resolution */
 	if (norecurse == NULL)
 		SET_FLAG(sg.r.flags, ZEBRA_FLAG_ALLOW_RECURSION);
@@ -354,9 +363,9 @@ DEFPY (install_routes,
 	sg.r.inst = instance;
 	sg.r.vrf_id = vrf->vrf_id;
 	rts = routes;
-	sharp_install_routes_helper(&prefix, sg.r.vrf_id, sg.r.inst, nhgid,
-				    &sg.r.nhop_group, &sg.r.backup_nhop_group,
-				    rts, sg.r.flags, sg.r.opaque);
+	sharp_install_routes_helper(&prefix, sg.r.vrf_id, sg.r.inst, nhgid, &sg.r.nhop_group,
+				    &sg.r.backup_nhop_group, rts, sg.r.flags, sg.r.opaque,
+				    sg.r.tableid, sg.r.tableid_set);
 
 	return CMD_SUCCESS;
 }
@@ -433,9 +442,9 @@ DEFPY (install_seg6_routes,
 	nexthop_add_srv6_seg6(&sg.r.nhop, &seg6_seg, 1, SRV6_HEADEND_BEHAVIOR_H_ENCAPS);
 
 	sg.r.vrf_id = vrf->vrf_id;
-	sharp_install_routes_helper(&prefix, sg.r.vrf_id, sg.r.inst, 0,
-				    &sg.r.nhop_group, &sg.r.backup_nhop_group,
-				    routes, route_flags, sg.r.opaque);
+	sharp_install_routes_helper(&prefix, sg.r.vrf_id, sg.r.inst, 0, &sg.r.nhop_group,
+				    &sg.r.backup_nhop_group, routes, route_flags, sg.r.opaque, 0,
+				    false);
 
 	return CMD_SUCCESS;
 }
@@ -532,7 +541,8 @@ DEFPY(install_seg6local_segs_routes, install_seg6local_segs_routes_cmd,
 
 	sg.r.vrf_id = vrf->vrf_id;
 	sharp_install_routes_helper(&sg.r.orig_prefix, sg.r.vrf_id, sg.r.inst, 0, &sg.r.nhop_group,
-				    &sg.r.backup_nhop_group, routes, route_flags, sg.r.opaque);
+				    &sg.r.backup_nhop_group, routes, route_flags, sg.r.opaque, 0,
+				    false);
 
 	return CMD_SUCCESS;
 }
@@ -717,10 +727,9 @@ DEFPY (install_seg6local_routes,
 	nexthop_add_srv6_seg6local(&sg.r.nhop, action, &ctx);
 
 	sg.r.vrf_id = vrf->vrf_id;
-	sharp_install_routes_helper(&sg.r.orig_prefix, sg.r.vrf_id, sg.r.inst,
-				    0, &sg.r.nhop_group,
-				    &sg.r.backup_nhop_group, routes,
-				    route_flags, sg.r.opaque);
+	sharp_install_routes_helper(&sg.r.orig_prefix, sg.r.vrf_id, sg.r.inst, 0, &sg.r.nhop_group,
+				    &sg.r.backup_nhop_group, routes, route_flags, sg.r.opaque, 0,
+				    false);
 
 	return CMD_SUCCESS;
 }
@@ -757,7 +766,7 @@ DEFPY(vrf_label, vrf_label_cmd,
 
 DEFPY (remove_routes,
        remove_routes_cmd,
-       "sharp remove routes [vrf NAME$vrf_name] <A.B.C.D$start4|X:X::X:X$start6> (1-1000000)$routes [instance (0-255)$instance]",
+       "sharp remove routes [vrf NAME$vrf_name] <A.B.C.D$start4|X:X::X:X$start6> (1-1000000)$routes [instance (0-255)$instance] [table (0-4294967295)$table_id]",
        "Sharp Routing Protocol\n"
        "Remove some routes\n"
        "Routes to remove\n"
@@ -767,7 +776,9 @@ DEFPY (remove_routes,
        "v6 Starting spot\n"
        "Routes to uninstall\n"
        "instance to use\n"
-       "Value of instance\n")
+       "Value of instance\n"
+       "Table to remove from\n"
+       "Table id\n")
 {
 	struct vrf *vrf;
 	struct prefix prefix;
@@ -797,9 +808,15 @@ DEFPY (remove_routes,
 
 	sg.r.inst = instance;
 	sg.r.vrf_id = vrf->vrf_id;
+	sg.r.tableid = 0;
+	sg.r.tableid_set = false;
+	if (table_id_str) {
+		sg.r.tableid = (uint32_t)table_id;
+		sg.r.tableid_set = true;
+	}
 	rts = routes;
-	sharp_remove_routes_helper(&prefix, sg.r.vrf_id,
-				   sg.r.inst, rts);
+	sharp_remove_routes_helper(&prefix, sg.r.vrf_id, sg.r.inst, rts, sg.r.tableid,
+				   sg.r.tableid_set);
 
 	return CMD_SUCCESS;
 }

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -217,6 +217,8 @@ struct buffer_delay {
 	uint8_t instance;
 	uint32_t nhgid;
 	uint32_t flags;
+	uint32_t tableid;
+	bool tableid_set;
 	const struct nexthop_group *nhg;
 	const struct nexthop_group *backup_nhg;
 	enum where_to_restart restart;
@@ -229,10 +231,9 @@ struct buffer_delay {
  * This function returns true when the route was buffered
  * by the underlying stream system
  */
-static bool route_add(const struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
-		      uint32_t nhgid, const struct nexthop_group *nhg,
-		      const struct nexthop_group *backup_nhg, uint32_t flags,
-		      char *opaque)
+static bool route_add(const struct prefix *p, vrf_id_t vrf_id, uint8_t instance, uint32_t nhgid,
+		      const struct nexthop_group *nhg, const struct nexthop_group *backup_nhg,
+		      uint32_t flags, char *opaque, uint32_t tableid, bool tableid_set)
 {
 	struct zapi_route api;
 	struct zapi_nexthop *api_nh;
@@ -250,6 +251,11 @@ static bool route_add(const struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
 
 	if (sg.use_underlying_nexthop_group_weight)
 		SET_FLAG(api.flags, ZEBRA_FLAG_USE_RECURSIVE_WEIGHT);
+
+	if (tableid_set) {
+		api.tableid = tableid;
+		SET_FLAG(api.message, ZAPI_MESSAGE_TABLEID);
+	}
 
 	/* Only send via ID if nhgroup has been successfully installed */
 	if (nhgid && sharp_nhgroup_id_is_installed(nhgid)) {
@@ -307,7 +313,8 @@ static bool route_add(const struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
  * This function returns true when the route sent was
  * buffered by the underlying stream system.
  */
-static bool route_delete(struct prefix *p, vrf_id_t vrf_id, uint8_t instance)
+static bool route_delete(struct prefix *p, vrf_id_t vrf_id, uint8_t instance, uint32_t tableid,
+			 bool tableid_set)
 {
 	struct zapi_route api;
 
@@ -318,6 +325,11 @@ static bool route_delete(struct prefix *p, vrf_id_t vrf_id, uint8_t instance)
 	api.instance = instance;
 	memcpy(&api.prefix, p, sizeof(*p));
 
+	if (tableid_set) {
+		api.tableid = tableid;
+		SET_FLAG(api.message, ZAPI_MESSAGE_TABLEID);
+	}
+
 	if (zclient_route_send(ZEBRA_ROUTE_DELETE, g_zclient, &api) ==
 	    ZCLIENT_SEND_BUFFERED)
 		return true;
@@ -325,13 +337,12 @@ static bool route_delete(struct prefix *p, vrf_id_t vrf_id, uint8_t instance)
 		return false;
 }
 
-static void sharp_install_routes_restart(struct prefix *p, uint32_t count,
-					 vrf_id_t vrf_id, uint8_t instance,
-					 uint32_t nhgid,
+static void sharp_install_routes_restart(struct prefix *p, uint32_t count, vrf_id_t vrf_id,
+					 uint8_t instance, uint32_t nhgid,
 					 const struct nexthop_group *nhg,
-					 const struct nexthop_group *backup_nhg,
-					 uint32_t routes, uint32_t flags,
-					 char *opaque)
+					 const struct nexthop_group *backup_nhg, uint32_t routes,
+					 uint32_t flags, char *opaque, uint32_t tableid,
+					 bool tableid_set)
 {
 	uint32_t temp, i;
 	bool v4 = false;
@@ -343,8 +354,8 @@ static void sharp_install_routes_restart(struct prefix *p, uint32_t count,
 		temp = ntohl(p->u.val32[3]);
 
 	for (i = count; i < routes; i++) {
-		bool buffered = route_add(p, vrf_id, (uint8_t)instance, nhgid,
-					  nhg, backup_nhg, flags, opaque);
+		bool buffered = route_add(p, vrf_id, (uint8_t)instance, nhgid, nhg, backup_nhg,
+					  flags, opaque, tableid, tableid_set);
 		if (v4)
 			p->u.prefix4.s_addr = htonl(++temp);
 		else
@@ -359,6 +370,8 @@ static void sharp_install_routes_restart(struct prefix *p, uint32_t count,
 			wb.nhgid = nhgid;
 			wb.nhg = nhg;
 			wb.flags = flags;
+			wb.tableid = tableid;
+			wb.tableid_set = tableid_set;
 			wb.backup_nhg = backup_nhg;
 			wb.opaque = opaque;
 			wb.restart = SHARP_INSTALL_ROUTES_RESTART;
@@ -368,11 +381,10 @@ static void sharp_install_routes_restart(struct prefix *p, uint32_t count,
 	}
 }
 
-void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id,
-				 uint8_t instance, uint32_t nhgid,
-				 const struct nexthop_group *nhg,
-				 const struct nexthop_group *backup_nhg,
-				 uint32_t routes, uint32_t flags, char *opaque)
+void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
+				 uint32_t nhgid, const struct nexthop_group *nhg,
+				 const struct nexthop_group *backup_nhg, uint32_t routes,
+				 uint32_t flags, char *opaque, uint32_t tableid, bool tableid_set)
 {
 	zlog_debug("Inserting %u routes", routes);
 
@@ -381,13 +393,13 @@ void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id,
 		backup_nhg = NULL;
 
 	monotime(&sg.r.t_start);
-	sharp_install_routes_restart(p, 0, vrf_id, instance, nhgid, nhg,
-				     backup_nhg, routes, flags, opaque);
+	sharp_install_routes_restart(p, 0, vrf_id, instance, nhgid, nhg, backup_nhg, routes, flags,
+				     opaque, tableid, tableid_set);
 }
 
-static void sharp_remove_routes_restart(struct prefix *p, uint32_t count,
-					vrf_id_t vrf_id, uint8_t instance,
-					uint32_t routes)
+static void sharp_remove_routes_restart(struct prefix *p, uint32_t count, vrf_id_t vrf_id,
+					uint8_t instance, uint32_t routes, uint32_t tableid,
+					bool tableid_set)
 {
 	uint32_t temp, i;
 	bool v4 = false;
@@ -399,7 +411,7 @@ static void sharp_remove_routes_restart(struct prefix *p, uint32_t count,
 		temp = ntohl(p->u.val32[3]);
 
 	for (i = count; i < routes; i++) {
-		bool buffered = route_delete(p, vrf_id, (uint8_t)instance);
+		bool buffered = route_delete(p, vrf_id, (uint8_t)instance, tableid, tableid_set);
 
 		if (v4)
 			p->u.prefix4.s_addr = htonl(++temp);
@@ -412,6 +424,8 @@ static void sharp_remove_routes_restart(struct prefix *p, uint32_t count,
 			wb.vrf_id = vrf_id;
 			wb.instance = instance;
 			wb.routes = routes;
+			wb.tableid = tableid;
+			wb.tableid_set = tableid_set;
 			wb.restart = SHARP_DELETE_ROUTES_RESTART;
 
 			return;
@@ -419,14 +433,14 @@ static void sharp_remove_routes_restart(struct prefix *p, uint32_t count,
 	}
 }
 
-void sharp_remove_routes_helper(struct prefix *p, vrf_id_t vrf_id,
-				uint8_t instance, uint32_t routes)
+void sharp_remove_routes_helper(struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
+				uint32_t routes, uint32_t tableid, bool tableid_set)
 {
 	zlog_debug("Removing %u routes", routes);
 
 	monotime(&sg.r.t_start);
 
-	sharp_remove_routes_restart(p, 0, vrf_id, instance, routes);
+	sharp_remove_routes_restart(p, 0, vrf_id, instance, routes, tableid, tableid_set);
 }
 
 static void handle_repeated(bool installed)
@@ -439,16 +453,16 @@ static void handle_repeated(bool installed)
 
 	if (installed) {
 		sg.r.removed_routes = 0;
-		sharp_remove_routes_helper(&p, sg.r.vrf_id, sg.r.inst,
-					   sg.r.total_routes);
+		sharp_remove_routes_helper(&p, sg.r.vrf_id, sg.r.inst, sg.r.total_routes,
+					   sg.r.tableid, sg.r.tableid_set);
 	}
 
 	if (!installed) {
 		sg.r.installed_routes = 0;
-		sharp_install_routes_helper(
-			&p, sg.r.vrf_id, sg.r.inst, sg.r.nhgid,
-			&sg.r.nhop_group, &sg.r.backup_nhop_group,
-			sg.r.total_routes, sg.r.flags, sg.r.opaque);
+		sharp_install_routes_helper(&p, sg.r.vrf_id, sg.r.inst, sg.r.nhgid,
+					    &sg.r.nhop_group, &sg.r.backup_nhop_group,
+					    sg.r.total_routes, sg.r.flags, sg.r.opaque,
+					    sg.r.tableid, sg.r.tableid_set);
 	}
 }
 
@@ -456,13 +470,13 @@ static void sharp_zclient_buffer_ready(void)
 {
 	switch (wb.restart) {
 	case SHARP_INSTALL_ROUTES_RESTART:
-		sharp_install_routes_restart(
-			&wb.p, wb.count, wb.vrf_id, wb.instance, wb.nhgid,
-			wb.nhg, wb.backup_nhg, wb.routes, wb.flags, wb.opaque);
+		sharp_install_routes_restart(&wb.p, wb.count, wb.vrf_id, wb.instance, wb.nhgid,
+					     wb.nhg, wb.backup_nhg, wb.routes, wb.flags, wb.opaque,
+					     wb.tableid, wb.tableid_set);
 		return;
 	case SHARP_DELETE_ROUTES_RESTART:
-		sharp_remove_routes_restart(&wb.p, wb.count, wb.vrf_id,
-					    wb.instance, wb.routes);
+		sharp_remove_routes_restart(&wb.p, wb.count, wb.vrf_id, wb.instance, wb.routes,
+					    wb.tableid, wb.tableid_set);
 		return;
 	}
 }

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -21,14 +21,13 @@ extern void nhg_del(uint32_t id);
 extern void sharp_zebra_nexthop_watch(struct prefix *p, vrf_id_t vrf_id, bool import, bool watch,
 				      bool connected, bool mrib);
 
-extern void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id,
-					uint8_t instance, uint32_t nhgid,
-					const struct nexthop_group *nhg,
-					const struct nexthop_group *backup_nhg,
-					uint32_t routes, uint32_t flags,
-					char *opaque);
-extern void sharp_remove_routes_helper(struct prefix *p, vrf_id_t vrf_id,
-				       uint8_t instance, uint32_t routes);
+extern void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
+					uint32_t nhgid, const struct nexthop_group *nhg,
+					const struct nexthop_group *backup_nhg, uint32_t routes,
+					uint32_t flags, char *opaque, uint32_t tableid,
+					bool tableid_set);
+extern void sharp_remove_routes_helper(struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
+				       uint32_t routes, uint32_t tableid, bool tableid_set);
 
 int sharp_install_lsps_helper(bool install_p, bool update_p,
 			      const struct prefix *p, uint8_t type,

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -28,6 +28,7 @@ extern void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id, uint8
 					bool tableid_set);
 extern void sharp_remove_routes_helper(struct prefix *p, vrf_id_t vrf_id, uint8_t instance,
 				       uint32_t routes, uint32_t tableid, bool tableid_set);
+extern void sharp_install_stop(void);
 
 int sharp_install_lsps_helper(bool install_p, bool update_p,
 			      const struct prefix *p, uint8_t type,


### PR DESCRIPTION
Allow the optional send of a table id for the installation/removal of routes.