### PR TITLE
tests: Fix convergence issue in evpn_pim_1

### DIFF
--- a/tests/topotests/evpn_pim_1/spine/bgp.summ.json
+++ b/tests/topotests/evpn_pim_1/spine/bgp.summ.json
@@ -12,8 +12,6 @@
       "pfxRcd":3,
       "pfxSnt":7,
       "state":"Established",
-      "connectionsEstablished":1,
-      "connectionsDropped":0,
       "idType":"ipv4"
     },
     "192.168.2.3":{
@@ -24,8 +22,6 @@
       "pfxRcd":3,
       "pfxSnt":7,
       "state":"Established",
-      "connectionsEstablished":1,
-      "connectionsDropped":0,
       "idType":"ipv4"
     }
   },


### PR DESCRIPTION
The test is failing:

        test_func = partial(
            topotest.router_json_cmp, spine, "show bgp ipv4 uni summ json", expected
        )
        _, result = topotest.run_and_expect(test_func, None, count=125, wait=1)
        assertmsg = '"{}" JSON output mismatches'.format(spine.name)
>       assert result is None, assertmsg
E       AssertionError: "spine" JSON output mismatches
E       assert Generated JSON diff error report:
E
E         > $->peers->192.168.1.2->connectionsEstablished: output has element with value '2' but in expected it has value '1'
E         > $->peers->192.168.1.2->connectionsDropped: output has element with value '1' but in expected it has value '0'

/home/sharpd/frr2/tests/topotests/evpn_pim_1/test_evpn_pim_topo1.py:144: AssertionError

This is silly.  We don't care that we have more than 1 connectionsEstablished or 1 connectionsDropped.  This can happen from a collision that needs to be handled of some sort.