### PR TITLE
Evpn test abstraction

### DIFF
--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
@@ -32,6 +32,7 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
+from lib.evpn import evpn_ip_learn_test
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.common_config import step
@@ -359,78 +360,6 @@ def test_local_remote_mac_pe2():
     mac_test_local_remote(pe2, pe1)
 
 
-def ip_learn_test(tgen, host, local, remote, ip_addr):
-    "check the host IP gets learned by the VNI"
-    host_output = host.vtysh_cmd("show interface {}-eth0".format(host.name))
-    int_lines = host_output.splitlines()
-    for line in int_lines:
-        line_items = line.split(": ")
-        if "HWaddr" in line_items[0]:
-            mac = line_items[1]
-            break
-    print(host_output)
-
-    # check we have a local association between the MAC and IP
-    local_output = local.vtysh_cmd("show evpn mac vni 101 mac {} json".format(mac))
-    print(local_output)
-    local_output_json = json.loads(local_output)
-    mac_type = local_output_json[mac]["type"]
-    assertmsg = "Failed to learn local IP address on host {}".format(host.name)
-    assert local_output_json[mac]["neighbors"] != "none", assertmsg
-    learned_ip = local_output_json[mac]["neighbors"]["active"][0]
-
-    assertmsg = "local learned mac wrong type: {} ".format(mac_type)
-    assert mac_type == "local", assertmsg
-
-    assertmsg = (
-        "learned address mismatch with configured address host: {} learned: {}".format(
-            ip_addr, learned_ip
-        )
-    )
-    assert ip_addr == learned_ip, assertmsg
-
-    # now lets check the remote
-    count = 0
-    converged = False
-    while count < 30:
-        remote_output = remote.vtysh_cmd(
-            "show evpn mac vni 101 mac {} json".format(mac)
-        )
-        print(remote_output)
-        remote_output_json = json.loads(remote_output)
-        type = remote_output_json[mac]["type"]
-        if not remote_output_json[mac]["neighbors"] == "none":
-            # due to a kernel quirk, learned IPs can be inactive
-            if (
-                remote_output_json[mac]["neighbors"]["active"]
-                or remote_output_json[mac]["neighbors"]["inactive"]
-            ):
-                converged = True
-                break
-        count += 1
-        sleep(1)
-
-    print("tries: {}".format(count))
-    assertmsg = "{} remote learned mac no address: {} ".format(host.name, mac)
-    # some debug for this failure
-    if not converged == True:
-        log_output = remote.run("cat zebra.log")
-        print(log_output)
-
-    assert converged == True, assertmsg
-    if remote_output_json[mac]["neighbors"]["active"]:
-        learned_ip = remote_output_json[mac]["neighbors"]["active"][0]
-    else:
-        learned_ip = remote_output_json[mac]["neighbors"]["inactive"][0]
-    assertmsg = "remote learned mac wrong type: {} ".format(type)
-    assert type == "remote", assertmsg
-
-    assertmsg = "remote learned address mismatch with configured address host: {} learned: {}".format(
-        ip_addr, learned_ip
-    )
-    assert ip_addr == learned_ip, assertmsg
-
-
 def test_ip_pe1_learn():
     "run the IP learn test for PE1"
 
@@ -446,7 +375,7 @@ def test_ip_pe1_learn():
     # pe2.vtysh_cmd("debug zebra kernel")
     # lets populate that arp cache
     host1.run("ping -c1 10.10.1.1")
-    ip_learn_test(tgen, host1, pe1, pe2, "10.10.1.55")
+    evpn_ip_learn_test(tgen, host1, pe1, pe2, "10.10.1.55")
     # tgen.mininet_cli()
 
 
@@ -465,7 +394,7 @@ def test_ip_pe2_learn():
     # pe1.vtysh_cmd("debug zebra kernel")
     # lets populate that arp cache
     host2.run("ping -c1 10.10.1.3")
-    ip_learn_test(tgen, host2, pe2, pe1, "10.10.1.56")
+    evpn_ip_learn_test(tgen, host2, pe2, pe1, "10.10.1.56")
     # tgen.mininet_cli()
 
 

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
@@ -36,6 +36,7 @@ from lib.evpn import (
     evpn_check_vni_macs_present,
     evpn_ip_learn_test,
     evpn_mac_learn_test,
+    evpn_mac_test_local_remote,
     evpn_show_vni_json_elide_ifindex,
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
@@ -253,30 +254,6 @@ def test_pe2_converge_evpn():
         assert None, '"{}" missing expected MACs'.format(pe2.name)
 
 
-def mac_test_local_remote(local, remote):
-    "test MAC transfer between local and remote"
-
-    local_output = local.vtysh_cmd("show evpn mac vni all json")
-    remote_output = remote.vtysh_cmd("show evpn mac vni all json")
-    local_output_vni = local.vtysh_cmd("show evpn vni detail json")
-    local_output_json = json.loads(local_output)
-    remote_output_json = json.loads(remote_output)
-    local_output_vni_json = json.loads(local_output_vni)
-
-    for vni in local_output_json:
-        mac_list = local_output_json[vni]["macs"]
-        for mac in mac_list:
-            if mac_list[mac]["type"] == "local" and mac_list[mac]["intf"] != "br101":
-                assertmsg = "JSON output mismatches local: {} remote: {}".format(
-                    local_output_vni_json[0]["vtepIp"],
-                    remote_output_json[vni]["macs"][mac]["remoteVtep"],
-                )
-                assert (
-                    remote_output_json[vni]["macs"][mac]["remoteVtep"]
-                    == local_output_vni_json[0]["vtepIp"]
-                ), assertmsg
-
-
 def test_learning_pe1():
     "test MAC learning on PE1"
 
@@ -313,7 +290,7 @@ def test_local_remote_mac_pe1():
 
     pe1 = tgen.gears["PE1"]
     pe2 = tgen.gears["PE2"]
-    mac_test_local_remote(pe1, pe2)
+    evpn_mac_test_local_remote(pe1, pe2)
 
 
 def test_local_remote_mac_pe2():
@@ -326,7 +303,7 @@ def test_local_remote_mac_pe2():
 
     pe1 = tgen.gears["PE1"]
     pe2 = tgen.gears["PE2"]
-    mac_test_local_remote(pe2, pe1)
+    evpn_mac_test_local_remote(pe2, pe1)
 
 
 def test_ip_pe1_learn():

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
@@ -32,7 +32,7 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.evpn import evpn_ip_learn_test
+from lib.evpn import evpn_ip_learn_test, evpn_show_vni_json_elide_ifindex
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.common_config import step
@@ -179,14 +179,6 @@ def teardown_module(mod):
     tgen.stop_topology()
 
 
-def show_vni_json_elide_ifindex(pe, vni, expected):
-    output_json = pe.vtysh_cmd("show evpn vni {} json".format(vni), isjson=True)
-    if "ifindex" in output_json:
-        output_json.pop("ifindex")
-
-    return topotest.json_cmp(output_json, expected)
-
-
 def check_vni_macs_present(tgen, router, vni, maclist):
     result = router.vtysh_cmd("show evpn mac vni {} json".format(vni), isjson=True)
     for rname, ifname in maclist:
@@ -210,7 +202,7 @@ def test_pe1_converge_evpn():
     json_file = "{}/{}/evpn.vni.json".format(CWD, pe1.name)
     expected = json.loads(open(json_file).read())
 
-    test_func = partial(show_vni_json_elide_ifindex, pe1, 101, expected)
+    test_func = partial(evpn_show_vni_json_elide_ifindex, pe1, 101, expected)
     _, result = topotest.run_and_expect(test_func, None, count=45, wait=1)
     assertmsg = '"{}" JSON output mismatches'.format(pe1.name)
 
@@ -249,7 +241,7 @@ def test_pe2_converge_evpn():
     json_file = "{}/{}/evpn.vni.json".format(CWD, pe2.name)
     expected = json.loads(open(json_file).read())
 
-    test_func = partial(show_vni_json_elide_ifindex, pe2, 101, expected)
+    test_func = partial(evpn_show_vni_json_elide_ifindex, pe2, 101, expected)
     _, result = topotest.run_and_expect(test_func, None, count=45, wait=1)
     assertmsg = '"{}" JSON output mismatches'.format(pe2.name)
     assert result is None, assertmsg

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo.py
@@ -35,6 +35,7 @@ from lib import topotest
 from lib.evpn import (
     evpn_check_vni_macs_present,
     evpn_ip_learn_test,
+    evpn_mac_learn_test,
     evpn_show_vni_json_elide_ifindex,
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
@@ -252,23 +253,6 @@ def test_pe2_converge_evpn():
         assert None, '"{}" missing expected MACs'.format(pe2.name)
 
 
-def mac_learn_test(host, local):
-    "check the host MAC gets learned by the VNI"
-
-    host_output = host.vtysh_cmd("show interface {}-eth0".format(host.name))
-    int_lines = host_output.splitlines()
-    for line in int_lines:
-        line_items = line.split(": ")
-        if "HWaddr" in line_items[0]:
-            mac = line_items[1]
-            break
-
-    mac_output = local.vtysh_cmd("show evpn mac vni 101 mac {} json".format(mac))
-    mac_output_json = json.loads(mac_output)
-    assertmsg = "Local MAC output does not match interface mac {}".format(mac)
-    assert mac_output_json[mac]["type"] == "local", assertmsg
-
-
 def mac_test_local_remote(local, remote):
     "test MAC transfer between local and remote"
 
@@ -303,7 +287,7 @@ def test_learning_pe1():
 
     host1 = tgen.gears["host1"]
     pe1 = tgen.gears["PE1"]
-    mac_learn_test(host1, pe1)
+    evpn_mac_learn_test(host1, pe1)
 
 
 def test_learning_pe2():
@@ -316,7 +300,7 @@ def test_learning_pe2():
 
     host2 = tgen.gears["host2"]
     pe2 = tgen.gears["PE2"]
-    mac_learn_test(host2, pe2)
+    evpn_mac_learn_test(host2, pe2)
 
 
 def test_local_remote_mac_pe1():

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo_v6_vtep.py
@@ -32,6 +32,7 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
+from lib.evpn import evpn_ip_learn_test
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.common_config import step
@@ -359,78 +360,6 @@ def test_local_remote_mac_pe2():
     mac_test_local_remote(pe2, pe1)
 
 
-def ip_learn_test(tgen, host, local, remote, ip_addr):
-    "check the host IP gets learned by the VNI"
-    host_output = host.vtysh_cmd("show interface {}-eth0".format(host.name))
-    int_lines = host_output.splitlines()
-    for line in int_lines:
-        line_items = line.split(": ")
-        if "HWaddr" in line_items[0]:
-            mac = line_items[1]
-            break
-    print(host_output)
-
-    # check we have a local association between the MAC and IP
-    local_output = local.vtysh_cmd("show evpn mac vni 101 mac {} json".format(mac))
-    print(local_output)
-    local_output_json = json.loads(local_output)
-    mac_type = local_output_json[mac]["type"]
-    assertmsg = "Failed to learn local IP address on host {}".format(host.name)
-    assert local_output_json[mac]["neighbors"] != "none", assertmsg
-    learned_ip = local_output_json[mac]["neighbors"]["active"][0]
-
-    assertmsg = "local learned mac wrong type: {} ".format(mac_type)
-    assert mac_type == "local", assertmsg
-
-    assertmsg = (
-        "learned address mismatch with configured address host: {} learned: {}".format(
-            ip_addr, learned_ip
-        )
-    )
-    assert ip_addr == learned_ip, assertmsg
-
-    # now lets check the remote
-    count = 0
-    converged = False
-    while count < 30:
-        remote_output = remote.vtysh_cmd(
-            "show evpn mac vni 101 mac {} json".format(mac)
-        )
-        print(remote_output)
-        remote_output_json = json.loads(remote_output)
-        type = remote_output_json[mac]["type"]
-        if not remote_output_json[mac]["neighbors"] == "none":
-            # due to a kernel quirk, learned IPs can be inactive
-            if (
-                remote_output_json[mac]["neighbors"]["active"]
-                or remote_output_json[mac]["neighbors"]["inactive"]
-            ):
-                converged = True
-                break
-        count += 1
-        sleep(1)
-
-    print("tries: {}".format(count))
-    assertmsg = "{} remote learned mac no address: {} ".format(host.name, mac)
-    # some debug for this failure
-    if not converged == True:
-        log_output = remote.run("cat zebra.log")
-        print(log_output)
-
-    assert converged == True, assertmsg
-    if remote_output_json[mac]["neighbors"]["active"]:
-        learned_ip = remote_output_json[mac]["neighbors"]["active"][0]
-    else:
-        learned_ip = remote_output_json[mac]["neighbors"]["inactive"][0]
-    assertmsg = "remote learned mac wrong type: {} ".format(type)
-    assert type == "remote", assertmsg
-
-    assertmsg = "remote learned address mismatch with configured address host: {} learned: {}".format(
-        ip_addr, learned_ip
-    )
-    assert ip_addr == learned_ip, assertmsg
-
-
 def test_ip_pe1_learn():
     "run the IP learn test for PE1"
 
@@ -446,7 +375,7 @@ def test_ip_pe1_learn():
     # pe2.vtysh_cmd("debug zebra kernel")
     # lets populate that arp cache
     host1.run("ping -c1 10.10.1.1")
-    ip_learn_test(tgen, host1, pe1, pe2, "10.10.1.55")
+    evpn_ip_learn_test(tgen, host1, pe1, pe2, "10.10.1.55")
     # tgen.mininet_cli()
 
 
@@ -465,7 +394,7 @@ def test_ip_pe2_learn():
     # pe1.vtysh_cmd("debug zebra kernel")
     # lets populate that arp cache
     host2.run("ping -c1 10.10.1.3")
-    ip_learn_test(tgen, host2, pe2, pe1, "10.10.1.56")
+    evpn_ip_learn_test(tgen, host2, pe2, pe1, "10.10.1.56")
     # tgen.mininet_cli()
 
 

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo_v6_vtep.py
@@ -36,6 +36,7 @@ from lib.evpn import (
     evpn_check_vni_macs_present,
     evpn_ip_learn_test,
     evpn_mac_learn_test,
+    evpn_mac_test_local_remote,
     evpn_show_vni_json_elide_ifindex,
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
@@ -253,30 +254,6 @@ def test_pe2_converge_evpn():
         assert None, '"{}" missing expected MACs'.format(pe2.name)
 
 
-def mac_test_local_remote(local, remote):
-    "test MAC transfer between local and remote"
-
-    local_output = local.vtysh_cmd("show evpn mac vni all json")
-    remote_output = remote.vtysh_cmd("show evpn mac vni all json")
-    local_output_vni = local.vtysh_cmd("show evpn vni detail json")
-    local_output_json = json.loads(local_output)
-    remote_output_json = json.loads(remote_output)
-    local_output_vni_json = json.loads(local_output_vni)
-
-    for vni in local_output_json:
-        mac_list = local_output_json[vni]["macs"]
-        for mac in mac_list:
-            if mac_list[mac]["type"] == "local" and mac_list[mac]["intf"] != "br101":
-                assertmsg = "JSON output mismatches local: {} remote: {}".format(
-                    local_output_vni_json[0]["vtepIp"],
-                    remote_output_json[vni]["macs"][mac]["remoteVtep"],
-                )
-                assert (
-                    remote_output_json[vni]["macs"][mac]["remoteVtep"]
-                    == local_output_vni_json[0]["vtepIp"]
-                ), assertmsg
-
-
 def test_learning_pe1():
     "test MAC learning on PE1"
 
@@ -313,7 +290,7 @@ def test_local_remote_mac_pe1():
 
     pe1 = tgen.gears["PE1"]
     pe2 = tgen.gears["PE2"]
-    mac_test_local_remote(pe1, pe2)
+    evpn_mac_test_local_remote(pe1, pe2)
 
 
 def test_local_remote_mac_pe2():
@@ -326,7 +303,7 @@ def test_local_remote_mac_pe2():
 
     pe1 = tgen.gears["PE1"]
     pe2 = tgen.gears["PE2"]
-    mac_test_local_remote(pe2, pe1)
+    evpn_mac_test_local_remote(pe2, pe1)
 
 
 def test_ip_pe1_learn():

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo_v6_vtep.py
@@ -32,7 +32,7 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.evpn import evpn_ip_learn_test
+from lib.evpn import evpn_ip_learn_test, evpn_show_vni_json_elide_ifindex
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.common_config import step
@@ -179,14 +179,6 @@ def teardown_module(mod):
     tgen.stop_topology()
 
 
-def show_vni_json_elide_ifindex(pe, vni, expected):
-    output_json = pe.vtysh_cmd("show evpn vni {} json".format(vni), isjson=True)
-    if "ifindex" in output_json:
-        output_json.pop("ifindex")
-
-    return topotest.json_cmp(output_json, expected)
-
-
 def check_vni_macs_present(tgen, router, vni, maclist):
     result = router.vtysh_cmd("show evpn mac vni {} json".format(vni), isjson=True)
     for rname, ifname in maclist:
@@ -210,7 +202,7 @@ def test_pe1_converge_evpn():
     json_file = "{}/{}/evpn.vni.v6_vtep.json".format(CWD, pe1.name)
     expected = json.loads(open(json_file).read())
 
-    test_func = partial(show_vni_json_elide_ifindex, pe1, 101, expected)
+    test_func = partial(evpn_show_vni_json_elide_ifindex, pe1, 101, expected)
     _, result = topotest.run_and_expect(test_func, None, count=45, wait=1)
     assertmsg = '"{}" JSON output mismatches'.format(pe1.name)
 
@@ -249,7 +241,7 @@ def test_pe2_converge_evpn():
     json_file = "{}/{}/evpn.vni.v6_vtep.json".format(CWD, pe2.name)
     expected = json.loads(open(json_file).read())
 
-    test_func = partial(show_vni_json_elide_ifindex, pe2, 101, expected)
+    test_func = partial(evpn_show_vni_json_elide_ifindex, pe2, 101, expected)
     _, result = topotest.run_and_expect(test_func, None, count=45, wait=1)
     assertmsg = '"{}" JSON output mismatches'.format(pe2.name)
     assert result is None, assertmsg

--- a/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_vxlan_macvrf_soo_topo1/test_bgp_evpn_vxlan_macvrf_soo_v6_vtep.py
@@ -35,6 +35,7 @@ from lib import topotest
 from lib.evpn import (
     evpn_check_vni_macs_present,
     evpn_ip_learn_test,
+    evpn_mac_learn_test,
     evpn_show_vni_json_elide_ifindex,
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
@@ -252,23 +253,6 @@ def test_pe2_converge_evpn():
         assert None, '"{}" missing expected MACs'.format(pe2.name)
 
 
-def mac_learn_test(host, local):
-    "check the host MAC gets learned by the VNI"
-
-    host_output = host.vtysh_cmd("show interface {}-eth0".format(host.name))
-    int_lines = host_output.splitlines()
-    for line in int_lines:
-        line_items = line.split(": ")
-        if "HWaddr" in line_items[0]:
-            mac = line_items[1]
-            break
-
-    mac_output = local.vtysh_cmd("show evpn mac vni 101 mac {} json".format(mac))
-    mac_output_json = json.loads(mac_output)
-    assertmsg = "Local MAC output does not match interface mac {}".format(mac)
-    assert mac_output_json[mac]["type"] == "local", assertmsg
-
-
 def mac_test_local_remote(local, remote):
     "test MAC transfer between local and remote"
 
@@ -303,7 +287,7 @@ def test_learning_pe1():
 
     host1 = tgen.gears["host1"]
     pe1 = tgen.gears["PE1"]
-    mac_learn_test(host1, pe1)
+    evpn_mac_learn_test(host1, pe1)
 
 
 def test_learning_pe2():
@@ -316,7 +300,7 @@ def test_learning_pe2():
 
     host2 = tgen.gears["host2"]
     pe2 = tgen.gears["PE2"]
-    mac_learn_test(host2, pe2)
+    evpn_mac_learn_test(host2, pe2)
 
 
 def test_local_remote_mac_pe1():

--- a/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
+++ b/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
@@ -40,7 +40,7 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.evpn import evpn_ip_learn_test
+from lib.evpn import evpn_ip_learn_test, evpn_show_vni_json_elide_ifindex
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.common_config import required_linux_kernel_version
@@ -214,15 +214,6 @@ def teardown_module(mod):
     tgen.stop_topology()
 
 
-def show_vni_json_elide_ifindex(pe, vni, expected):
-    output_json = pe.vtysh_cmd("show evpn vni {} json".format(vni), isjson=True)
-
-    if "ifindex" in output_json:
-        output_json.pop("ifindex")
-
-    return topotest.json_cmp(output_json, expected)
-
-
 def show_bgp_l2vpn_evpn_route_type_prefix_json(pe, expected):
     output_json = pe.vtysh_cmd(
         "show bgp l2vpn evpn route type prefix json", isjson=True
@@ -268,7 +259,7 @@ def test_pe1_converge_evpn():
     json_file = "{}/{}/evpn.vni.json".format(CWD, pe1.name)
     expected = json.loads(open(json_file).read())
 
-    test_func = partial(show_vni_json_elide_ifindex, pe1, 101, expected)
+    test_func = partial(evpn_show_vni_json_elide_ifindex, pe1, 101, expected)
     _, result = topotest.run_and_expect(test_func, None, count=45, wait=1)
     assertmsg = '"{}" JSON output mismatches'.format(pe1.name)
 
@@ -312,7 +303,7 @@ def test_pe2_converge_evpn():
     json_file = "{}/{}/evpn.vni.json".format(CWD, pe2.name)
     expected = json.loads(open(json_file).read())
 
-    test_func = partial(show_vni_json_elide_ifindex, pe2, 101, expected)
+    test_func = partial(evpn_show_vni_json_elide_ifindex, pe2, 101, expected)
     _, result = topotest.run_and_expect(test_func, None, count=45, wait=1)
     assertmsg = '"{}" JSON output mismatches'.format(pe2.name)
     assert result is None, assertmsg

--- a/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
+++ b/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
@@ -44,6 +44,7 @@ from lib.evpn import (
     evpn_check_vni_macs_present,
     evpn_ip_learn_test,
     evpn_mac_learn_test,
+    evpn_mac_test_local_remote,
     evpn_show_vni_json_elide_ifindex,
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
@@ -321,34 +322,6 @@ def test_pe2_converge_evpn():
     assert result is None, assertmsg
 
 
-def mac_test_local_remote(local, remote):
-    "test MAC transfer between local and remote"
-
-    local_output = local.vtysh_cmd("show evpn mac vni all json")
-    remote_output = remote.vtysh_cmd("show evpn mac vni all json")
-    local_output_vni = local.vtysh_cmd("show evpn vni detail json")
-    local_output_json = json.loads(local_output)
-    remote_output_json = json.loads(remote_output)
-    local_output_vni_json = json.loads(local_output_vni)
-
-    # breakpoint()
-    for vni in local_output_json:
-        if vni not in remote_output_json:
-            continue
-
-        mac_list = local_output_json[vni]["macs"]
-        for mac in mac_list:
-            if mac_list[mac]["type"] == "local" and mac_list[mac]["intf"] != "br101":
-                assertmsg = "JSON output mismatches local: {} remote: {}".format(
-                    local_output_vni_json[0]["vtepIp"],
-                    remote_output_json[vni]["macs"][mac]["remoteVtep"],
-                )
-                assert (
-                    remote_output_json[vni]["macs"][mac]["remoteVtep"]
-                    == local_output_vni_json[0]["vtepIp"]
-                ), assertmsg
-
-
 def test_learning_pe1():
     "test MAC learning on PE1"
 
@@ -385,7 +358,7 @@ def test_local_remote_mac_pe1():
 
     pe1 = tgen.gears["PE1"]
     pe2 = tgen.gears["PE2"]
-    mac_test_local_remote(pe1, pe2)
+    evpn_mac_test_local_remote(pe1, pe2, skip_missing_remote_vni=True)
 
 
 def test_local_remote_mac_pe2():
@@ -398,7 +371,7 @@ def test_local_remote_mac_pe2():
 
     pe1 = tgen.gears["PE1"]
     pe2 = tgen.gears["PE2"]
-    mac_test_local_remote(pe2, pe1)
+    evpn_mac_test_local_remote(pe2, pe1, skip_missing_remote_vni=True)
 
 
 def test_ip_pe1_learn():

--- a/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
+++ b/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
@@ -43,6 +43,7 @@ from lib import topotest
 from lib.evpn import (
     evpn_check_vni_macs_present,
     evpn_ip_learn_test,
+    evpn_mac_learn_test,
     evpn_show_vni_json_elide_ifindex,
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
@@ -320,23 +321,6 @@ def test_pe2_converge_evpn():
     assert result is None, assertmsg
 
 
-def mac_learn_test(host, local):
-    "check the host MAC gets learned by the VNI"
-
-    host_output = host.vtysh_cmd("show interface {}-eth0".format(host.name))
-    int_lines = host_output.splitlines()
-    for line in int_lines:
-        line_items = line.split(": ")
-        if "HWaddr" in line_items[0]:
-            mac = line_items[1]
-            break
-
-    mac_output = local.vtysh_cmd("show evpn mac vni 101 mac {} json".format(mac))
-    mac_output_json = json.loads(mac_output)
-    assertmsg = "Local MAC output does not match interface mac {}".format(mac)
-    assert mac_output_json[mac]["type"] == "local", assertmsg
-
-
 def mac_test_local_remote(local, remote):
     "test MAC transfer between local and remote"
 
@@ -375,7 +359,7 @@ def test_learning_pe1():
 
     host1 = tgen.gears["host1"]
     pe1 = tgen.gears["PE1"]
-    mac_learn_test(host1, pe1)
+    evpn_mac_learn_test(host1, pe1)
 
 
 def test_learning_pe2():
@@ -388,7 +372,7 @@ def test_learning_pe2():
 
     host2 = tgen.gears["host2"]
     pe2 = tgen.gears["PE2"]
-    mac_learn_test(host2, pe2)
+    evpn_mac_learn_test(host2, pe2)
 
 
 def test_local_remote_mac_pe1():

--- a/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
+++ b/tests/topotests/bgp_evpn_vxlan_svd_topo1/test_bgp_evpn_vxlan_svd.py
@@ -40,7 +40,11 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.evpn import evpn_ip_learn_test, evpn_show_vni_json_elide_ifindex
+from lib.evpn import (
+    evpn_check_vni_macs_present,
+    evpn_ip_learn_test,
+    evpn_show_vni_json_elide_ifindex,
+)
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 from lib.common_config import required_linux_kernel_version
@@ -222,17 +226,6 @@ def show_bgp_l2vpn_evpn_route_type_prefix_json(pe, expected):
     return topotest.json_cmp(output_json, expected)
 
 
-def check_vni_macs_present(tgen, router, vni, maclist):
-    result = router.vtysh_cmd("show evpn mac vni {} json".format(vni), isjson=True)
-    for rname, ifname in maclist:
-        m = tgen.net.macs[(rname, ifname)]
-        if m not in result["macs"]:
-            return "MAC ({}) for interface {} on {} missing on {} from {}".format(
-                m, ifname, rname, router.name, json.dumps(result, indent=4)
-            )
-    return None
-
-
 def check_flood_entry_present(pe, vni, vtep):
     if not topotest.iproute2_is_fdb_get_capable():
         return None
@@ -273,7 +266,7 @@ def test_pe1_converge_evpn():
     host2.run("ping -c 1 10.10.1.55")
 
     test_func = partial(
-        check_vni_macs_present,
+        evpn_check_vni_macs_present,
         tgen,
         pe1,
         101,
@@ -309,7 +302,7 @@ def test_pe2_converge_evpn():
     assert result is None, assertmsg
 
     test_func = partial(
-        check_vni_macs_present,
+        evpn_check_vni_macs_present,
         tgen,
         pe2,
         101,

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
@@ -28,6 +28,7 @@ from lib import topotest
 from lib.evpn import (
     evpn_check_vni_macs_present,
     evpn_mac_learn_test,
+    evpn_mac_test_local_remote,
     evpn_show_vni_json_elide_ifindex,
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
@@ -241,30 +242,6 @@ def test_pe2_converge_evpn():
         assert None, '"{}" missing expected MACs'.format(pe2.name)
 
 
-def mac_test_local_remote(local, remote):
-    "test MAC transfer between local and remote"
-
-    local_output = local.vtysh_cmd("show evpn mac vni all json")
-    remote_output = remote.vtysh_cmd("show evpn mac vni all json")
-    local_output_vni = local.vtysh_cmd("show evpn vni detail json")
-    local_output_json = json.loads(local_output)
-    remote_output_json = json.loads(remote_output)
-    local_output_vni_json = json.loads(local_output_vni)
-
-    for vni in local_output_json:
-        mac_list = local_output_json[vni]["macs"]
-        for mac in mac_list:
-            if mac_list[mac]["type"] == "local" and mac_list[mac]["intf"] != "br101":
-                assertmsg = "JSON output mismatches local: {} remote: {}".format(
-                    local_output_vni_json[0]["vtepIp"],
-                    remote_output_json[vni]["macs"][mac]["remoteVtep"],
-                )
-                assert (
-                    remote_output_json[vni]["macs"][mac]["remoteVtep"]
-                    == local_output_vni_json[0]["vtepIp"]
-                ), assertmsg
-
-
 def test_learning_pe1():
     "test MAC learning on PE1"
 
@@ -301,7 +278,7 @@ def test_local_remote_mac_pe1():
 
     pe1 = tgen.gears["PE1"]
     pe2 = tgen.gears["PE2"]
-    mac_test_local_remote(pe1, pe2)
+    evpn_mac_test_local_remote(pe1, pe2)
 
 
 def test_local_remote_mac_pe2():
@@ -314,7 +291,7 @@ def test_local_remote_mac_pe2():
 
     pe1 = tgen.gears["PE1"]
     pe2 = tgen.gears["PE2"]
-    mac_test_local_remote(pe2, pe1)
+    evpn_mac_test_local_remote(pe2, pe1)
 
     # Memory leak test template
 

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
@@ -25,7 +25,7 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.evpn import evpn_show_vni_json_elide_ifindex
+from lib.evpn import evpn_show_vni_json_elide_ifindex, evpn_check_vni_macs_present
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
@@ -168,17 +168,6 @@ def teardown_module(mod):
     tgen.stop_topology()
 
 
-def check_vni_macs_present(tgen, router, vni, maclist):
-    result = router.vtysh_cmd("show evpn mac vni {} json".format(vni), isjson=True)
-    for rname, ifname in maclist:
-        m = tgen.net.macs[(rname, ifname)]
-        if m not in result["macs"]:
-            return "MAC ({}) for interface {} on {} missing on {} from {}".format(
-                m, ifname, rname, router.name, json.dumps(result, indent=4)
-            )
-    return None
-
-
 def test_pe1_converge_evpn():
     "Wait for protocol convergence"
 
@@ -205,7 +194,7 @@ def test_pe1_converge_evpn():
     host2.run("ping -c 1 10.10.1.55")
 
     test_func = partial(
-        check_vni_macs_present,
+        evpn_check_vni_macs_present,
         tgen,
         pe1,
         101,
@@ -236,7 +225,7 @@ def test_pe2_converge_evpn():
     assert result is None, assertmsg
 
     test_func = partial(
-        check_vni_macs_present,
+        evpn_check_vni_macs_present,
         tgen,
         pe2,
         101,

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan.py
@@ -25,6 +25,7 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
+from lib.evpn import evpn_show_vni_json_elide_ifindex
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
@@ -167,14 +168,6 @@ def teardown_module(mod):
     tgen.stop_topology()
 
 
-def show_vni_json_elide_ifindex(pe, vni, expected):
-    output_json = pe.vtysh_cmd("show evpn vni {} json".format(vni), isjson=True)
-    if "ifindex" in output_json:
-        output_json.pop("ifindex")
-
-    return topotest.json_cmp(output_json, expected)
-
-
 def check_vni_macs_present(tgen, router, vni, maclist):
     result = router.vtysh_cmd("show evpn mac vni {} json".format(vni), isjson=True)
     for rname, ifname in maclist:
@@ -198,7 +191,7 @@ def test_pe1_converge_evpn():
     json_file = "{}/{}/evpn.vni.json".format(CWD, pe1.name)
     expected = json.loads(open(json_file).read())
 
-    test_func = partial(show_vni_json_elide_ifindex, pe1, 101, expected)
+    test_func = partial(evpn_show_vni_json_elide_ifindex, pe1, 101, expected)
     _, result = topotest.run_and_expect(test_func, None, count=45, wait=1)
     assertmsg = '"{}" JSON output mismatches'.format(pe1.name)
 
@@ -237,7 +230,7 @@ def test_pe2_converge_evpn():
     json_file = "{}/{}/evpn.vni.json".format(CWD, pe2.name)
     expected = json.loads(open(json_file).read())
 
-    test_func = partial(show_vni_json_elide_ifindex, pe2, 101, expected)
+    test_func = partial(evpn_show_vni_json_elide_ifindex, pe2, 101, expected)
     _, result = topotest.run_and_expect(test_func, None, count=45, wait=1)
     assertmsg = '"{}" JSON output mismatches'.format(pe2.name)
     assert result is None, assertmsg

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan_v6_vtep.py
@@ -31,6 +31,7 @@ from lib import topotest
 from lib.evpn import (
     evpn_check_vni_macs_present,
     evpn_ip_learn_test,
+    evpn_mac_learn_test,
     evpn_show_vni_json_elide_ifindex,
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
@@ -205,23 +206,6 @@ def test_pe2_converge_evpn():
         assert None, '"{}" missing expected MACs'.format(pe2.name)
 
 
-def mac_learn_test(host, local):
-    "check the host MAC gets learned by the VNI"
-
-    host_output = host.vtysh_cmd("show interface {}-eth0".format(host.name))
-    int_lines = host_output.splitlines()
-    for line in int_lines:
-        line_items = line.split(": ")
-        if "HWaddr" in line_items[0]:
-            mac = line_items[1]
-            break
-
-    mac_output = local.vtysh_cmd("show evpn mac vni 101 mac {} json".format(mac))
-    mac_output_json = json.loads(mac_output)
-    assertmsg = "Local MAC output does not match interface mac {}".format(mac)
-    assert mac_output_json[mac]["type"] == "local", assertmsg
-
-
 def mac_test_local_remote(local, remote):
     "test MAC transfer between local and remote"
 
@@ -256,7 +240,7 @@ def test_learning_pe1():
 
     host1 = tgen.gears["host1"]
     pe1 = tgen.gears["PE1"]
-    mac_learn_test(host1, pe1)
+    evpn_mac_learn_test(host1, pe1)
 
 
 def test_learning_pe2():
@@ -269,7 +253,7 @@ def test_learning_pe2():
 
     host2 = tgen.gears["host2"]
     pe2 = tgen.gears["PE2"]
-    mac_learn_test(host2, pe2)
+    evpn_mac_learn_test(host2, pe2)
 
 
 def test_local_remote_mac_pe1():

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan_v6_vtep.py
@@ -28,7 +28,11 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.evpn import evpn_ip_learn_test, evpn_show_vni_json_elide_ifindex
+from lib.evpn import (
+    evpn_check_vni_macs_present,
+    evpn_ip_learn_test,
+    evpn_show_vni_json_elide_ifindex,
+)
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
@@ -132,17 +136,6 @@ def teardown_module(mod):
     tgen.stop_topology()
 
 
-def check_vni_macs_present(tgen, router, vni, maclist):
-    result = router.vtysh_cmd("show evpn mac vni {} json".format(vni), isjson=True)
-    for rname, ifname in maclist:
-        m = tgen.net.macs[(rname, ifname)]
-        if m not in result["macs"]:
-            return "MAC ({}) for interface {} on {} missing on {} from {}".format(
-                m, ifname, rname, router.name, json.dumps(result, indent=4)
-            )
-    return None
-
-
 def test_pe1_converge_evpn():
     "Wait for protocol convergence"
 
@@ -169,7 +162,7 @@ def test_pe1_converge_evpn():
     host2.run("ping -c 1 10.10.1.55")
 
     test_func = partial(
-        check_vni_macs_present,
+        evpn_check_vni_macs_present,
         tgen,
         pe1,
         101,
@@ -200,7 +193,7 @@ def test_pe2_converge_evpn():
     assert result is None, assertmsg
 
     test_func = partial(
-        check_vni_macs_present,
+        evpn_check_vni_macs_present,
         tgen,
         pe2,
         101,

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan_v6_vtep.py
@@ -28,7 +28,7 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
-from lib.evpn import evpn_ip_learn_test
+from lib.evpn import evpn_ip_learn_test, evpn_show_vni_json_elide_ifindex
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
@@ -132,14 +132,6 @@ def teardown_module(mod):
     tgen.stop_topology()
 
 
-def show_vni_json_elide_ifindex(pe, vni, expected):
-    output_json = pe.vtysh_cmd("show evpn vni {} json".format(vni), isjson=True)
-    if "ifindex" in output_json:
-        output_json.pop("ifindex")
-
-    return topotest.json_cmp(output_json, expected)
-
-
 def check_vni_macs_present(tgen, router, vni, maclist):
     result = router.vtysh_cmd("show evpn mac vni {} json".format(vni), isjson=True)
     for rname, ifname in maclist:
@@ -163,7 +155,7 @@ def test_pe1_converge_evpn():
     json_file = "{}/{}/evpn.vni.v6_vtep.json".format(CWD, pe1.name)
     expected = json.loads(open(json_file).read())
 
-    test_func = partial(show_vni_json_elide_ifindex, pe1, 101, expected)
+    test_func = partial(evpn_show_vni_json_elide_ifindex, pe1, 101, expected)
     _, result = topotest.run_and_expect(test_func, None, count=45, wait=1)
     assertmsg = '"{}" JSON output mismatches'.format(pe1.name)
 
@@ -202,7 +194,7 @@ def test_pe2_converge_evpn():
     json_file = "{}/{}/evpn.vni.v6_vtep.json".format(CWD, pe2.name)
     expected = json.loads(open(json_file).read())
 
-    test_func = partial(show_vni_json_elide_ifindex, pe2, 101, expected)
+    test_func = partial(evpn_show_vni_json_elide_ifindex, pe2, 101, expected)
     _, result = topotest.run_and_expect(test_func, None, count=45, wait=1)
     assertmsg = '"{}" JSON output mismatches'.format(pe2.name)
     assert result is None, assertmsg

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan_v6_vtep.py
@@ -32,6 +32,7 @@ from lib.evpn import (
     evpn_check_vni_macs_present,
     evpn_ip_learn_test,
     evpn_mac_learn_test,
+    evpn_mac_test_local_remote,
     evpn_show_vni_json_elide_ifindex,
 )
 from lib.topogen import Topogen, TopoRouter, get_topogen
@@ -206,30 +207,6 @@ def test_pe2_converge_evpn():
         assert None, '"{}" missing expected MACs'.format(pe2.name)
 
 
-def mac_test_local_remote(local, remote):
-    "test MAC transfer between local and remote"
-
-    local_output = local.vtysh_cmd("show evpn mac vni all json")
-    remote_output = remote.vtysh_cmd("show evpn mac vni all json")
-    local_output_vni = local.vtysh_cmd("show evpn vni detail json")
-    local_output_json = json.loads(local_output)
-    remote_output_json = json.loads(remote_output)
-    local_output_vni_json = json.loads(local_output_vni)
-
-    for vni in local_output_json:
-        mac_list = local_output_json[vni]["macs"]
-        for mac in mac_list:
-            if mac_list[mac]["type"] == "local" and mac_list[mac]["intf"] != "br101":
-                assertmsg = "JSON output mismatches local: {} remote: {}".format(
-                    local_output_vni_json[0]["vtepIp"],
-                    remote_output_json[vni]["macs"][mac]["remoteVtep"],
-                )
-                assert (
-                    remote_output_json[vni]["macs"][mac]["remoteVtep"]
-                    == local_output_vni_json[0]["vtepIp"]
-                ), assertmsg
-
-
 def test_learning_pe1():
     "test MAC learning on PE1"
 
@@ -266,7 +243,7 @@ def test_local_remote_mac_pe1():
 
     pe1 = tgen.gears["PE1"]
     pe2 = tgen.gears["PE2"]
-    mac_test_local_remote(pe1, pe2)
+    evpn_mac_test_local_remote(pe1, pe2)
 
 
 def test_local_remote_mac_pe2():
@@ -279,7 +256,7 @@ def test_local_remote_mac_pe2():
 
     pe1 = tgen.gears["PE1"]
     pe2 = tgen.gears["PE2"]
-    mac_test_local_remote(pe2, pe1)
+    evpn_mac_test_local_remote(pe2, pe1)
 
     # Memory leak test template
 

--- a/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan_v6_vtep.py
+++ b/tests/topotests/bgp_evpn_vxlan_topo1/test_bgp_evpn_vxlan_v6_vtep.py
@@ -28,6 +28,7 @@ sys.path.append(os.path.join(CWD, "../"))
 # pylint: disable=C0413
 # Import topogen and topotest helpers
 from lib import topotest
+from lib.evpn import evpn_ip_learn_test
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
 
@@ -314,78 +315,6 @@ def test_local_remote_mac_pe2():
     # Memory leak test template
 
 
-def ip_learn_test(tgen, host, local, remote, ip_addr):
-    "check the host IP gets learned by the VNI"
-    host_output = host.vtysh_cmd("show interface {}-eth0".format(host.name))
-    int_lines = host_output.splitlines()
-    for line in int_lines:
-        line_items = line.split(": ")
-        if "HWaddr" in line_items[0]:
-            mac = line_items[1]
-            break
-    print(host_output)
-
-    # check we have a local association between the MAC and IP
-    local_output = local.vtysh_cmd("show evpn mac vni 101 mac {} json".format(mac))
-    print(local_output)
-    local_output_json = json.loads(local_output)
-    mac_type = local_output_json[mac]["type"]
-    assertmsg = "Failed to learn local IP address on host {}".format(host.name)
-    assert local_output_json[mac]["neighbors"] != "none", assertmsg
-    learned_ip = local_output_json[mac]["neighbors"]["active"][0]
-
-    assertmsg = "local learned mac wrong type: {} ".format(mac_type)
-    assert mac_type == "local", assertmsg
-
-    assertmsg = (
-        "learned address mismatch with configured address host: {} learned: {}".format(
-            ip_addr, learned_ip
-        )
-    )
-    assert ip_addr == learned_ip, assertmsg
-
-    # now lets check the remote
-    count = 0
-    converged = False
-    while count < 30:
-        remote_output = remote.vtysh_cmd(
-            "show evpn mac vni 101 mac {} json".format(mac)
-        )
-        print(remote_output)
-        remote_output_json = json.loads(remote_output)
-        type = remote_output_json[mac]["type"]
-        if not remote_output_json[mac]["neighbors"] == "none":
-            # due to a kernel quirk, learned IPs can be inactive
-            if (
-                remote_output_json[mac]["neighbors"]["active"]
-                or remote_output_json[mac]["neighbors"]["inactive"]
-            ):
-                converged = True
-                break
-        count += 1
-        sleep(1)
-
-    print("tries: {}".format(count))
-    assertmsg = "{} remote learned mac no address: {} ".format(host.name, mac)
-    # some debug for this failure
-    if not converged == True:
-        log_output = remote.run("cat zebra.log")
-        print(log_output)
-
-    assert converged == True, assertmsg
-    if remote_output_json[mac]["neighbors"]["active"]:
-        learned_ip = remote_output_json[mac]["neighbors"]["active"][0]
-    else:
-        learned_ip = remote_output_json[mac]["neighbors"]["inactive"][0]
-    assertmsg = "remote learned mac wrong type: {} ".format(type)
-    assert type == "remote", assertmsg
-
-    assertmsg = "remote learned address mismatch with configured address host: {} learned: {}".format(
-        ip_addr, learned_ip
-    )
-    assert ip_addr == learned_ip, assertmsg
-
-
 def test_ip_pe1_learn():
     "run the IP learn test for PE1"
 
@@ -401,7 +330,7 @@ def test_ip_pe1_learn():
     # pe2.vtysh_cmd("debug zebra kernel")
     # lets populate that arp cache
     host1.run("ping -c1 10.10.1.1")
-    ip_learn_test(tgen, host1, pe1, pe2, "10.10.1.55")
+    evpn_ip_learn_test(tgen, host1, pe1, pe2, "10.10.1.55")
     # tgen.mininet_cli()
 
 
@@ -420,7 +349,7 @@ def test_ip_pe2_learn():
     # pe1.vtysh_cmd("debug zebra kernel")
     # lets populate that arp cache
     host2.run("ping -c1 10.10.1.3")
-    ip_learn_test(tgen, host2, pe2, pe1, "10.10.1.56")
+    evpn_ip_learn_test(tgen, host2, pe2, pe1, "10.10.1.56")
     # tgen.mininet_cli()
 
 

--- a/tests/topotests/lib/evpn.py
+++ b/tests/topotests/lib/evpn.py
@@ -48,6 +48,17 @@ def evpn_show_vni_json_elide_ifindex(pe, vni, expected):
     return topotest.json_cmp(output_json, expected)
 
 
+def evpn_check_vni_macs_present(tgen, router, vni, maclist):
+    result = router.vtysh_cmd("show evpn mac vni {} json".format(vni), isjson=True)
+    for rname, ifname in maclist:
+        m = tgen.net.macs[(rname, ifname)]
+        if m not in result["macs"]:
+            return "MAC ({}) for interface {} on {} missing on {} from {}".format(
+                m, ifname, rname, router.name, json.dumps(result, indent=4)
+            )
+    return None
+
+
 def evpn_ip_learn_test(tgen, host, local, remote, ip_addr, vni=101, count=30, wait=1):
     "check the host IP gets learned by the VNI"
     host_output = host.vtysh_cmd("show interface {}-eth0".format(host.name))

--- a/tests/topotests/lib/evpn.py
+++ b/tests/topotests/lib/evpn.py
@@ -59,6 +59,24 @@ def evpn_check_vni_macs_present(tgen, router, vni, maclist):
     return None
 
 
+def evpn_mac_learn_test(host, local, vni=101):
+    "check the host MAC gets learned by the VNI"
+    host_output = host.vtysh_cmd("show interface {}-eth0".format(host.name))
+    int_lines = host_output.splitlines()
+    mac = None
+    for line in int_lines:
+        line_items = line.split(": ")
+        if "HWaddr" in line_items[0]:
+            mac = line_items[1]
+            break
+    assert mac is not None, "Failed to find host MAC for {}".format(host.name)
+
+    mac_output = local.vtysh_cmd("show evpn mac vni {} mac {} json".format(vni, mac))
+    mac_output_json = json.loads(mac_output)
+    assertmsg = "Local MAC output does not match interface mac {}".format(mac)
+    assert mac_output_json[mac]["type"] == "local", assertmsg
+
+
 def evpn_ip_learn_test(tgen, host, local, remote, ip_addr, vni=101, count=30, wait=1):
     "check the host IP gets learned by the VNI"
     host_output = host.vtysh_cmd("show interface {}-eth0".format(host.name))


### PR DESCRIPTION
There are a bunch of cut-n-pasted code in evpn tests.  One of which is causing test failures because the test has not given time to linux + FRR to process the test input yet.  Fix these problems.