### PR TITLE
zebra: Fix early route processing cleanup when kernel routes are clea…

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -195,7 +195,7 @@ static void connected_remove_kernel_for_connected(afi_t afi, safi_t safi, struct
 	/*
 	 * Needs to be early as that the actual route_node may not exist yet
 	 */
-	rib_meta_queue_early_route_cleanup(p, ZEBRA_ROUTE_KERNEL);
+	rib_meta_queue_early_route_cleanup(p, afi, safi, zvrf->vrf->vrf_id, ZEBRA_ROUTE_KERNEL);
 
 	if (!table)
 		return;

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -466,7 +466,8 @@ int zebra_rib_queue_evpn_rem_vtep_del(vrf_id_t vrf_id, vni_t vni, struct ipaddr 
 
 extern void meta_queue_free(struct meta_queue *mq, struct zebra_vrf *zvrf);
 extern int zebra_rib_labeled_unicast(struct route_entry *re);
-extern void rib_meta_queue_early_route_cleanup(const struct prefix *p, int route_type);
+extern void rib_meta_queue_early_route_cleanup(const struct prefix *p, afi_t afi, safi_t safi,
+					       vrf_id_t vrf_id, int route_type);
 extern struct route_table *rib_table_ipv6;
 
 extern uint32_t zebra_rib_meta_queue_size(void);


### PR DESCRIPTION
…ned up

Currently when FRR receives a kernel route notification it cleans the route up from the early route meta Queue.  This is presenting some problems when the same route happens to be in the early route metaQueue multiple times for different vrf's and safi's.  Tighten up the search to only look for the afi/safi and vrf id for the route in question to not cause it to remove the wrong route.

This problem was exposed by the zebra_rib/test_zebra_rib.py topotest under very very heavy system load locally for me.

I have also added some additional modifications to the debugs under `debug zebra rib detail` that allow to see more data about the safi and the actual route type being looked at.