### PR TITLE
zebra: fix duplicate route from local protocol

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -339,7 +339,29 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 			zvrf->table_id, metric, 0, 0, 0, false);
 	}
 
+	struct route_table *u_table = zebra_vrf_table(afi, SAFI_UNICAST, zvrf->vrf->vrf_id);
+	struct route_table *m_table = zebra_vrf_table(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id);
+
+	if (!u_table || !m_table)
+		return;
+
+
 	if (install_local) {
+		struct route_node *u_rn = route_node_lookup(u_table, (struct prefix *)&plocal);
+		struct route_node *m_rn = route_node_lookup(m_table, (struct prefix *)&plocal);
+
+		if (u_rn) {
+			rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, 0,
+				   &plocal, NULL, &nh, 0, zvrf->table_id, 0, 0, false);
+			route_unlock_node(u_rn);
+		}
+
+		if (m_rn) {
+			rib_delete(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, 0,
+				   &plocal, NULL, &nh, 0, zvrf->table_id, 0, 0, false);
+			route_unlock_node(m_rn);
+		}
+
 		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL,
 			0, flags, &plocal, NULL, &nh, 0, zvrf->table_id, 0, 0,
 			0, 0, false);


### PR DESCRIPTION
Fix duplicate local route from zebra:

Before patch:
```
root@debian:/home/user/frr# /tmp/test.sh
root@debian:/home/user/frr# vtysh

Hello, this is FRRouting (version 10.6-dev-MyOwnFRRVersion-gUNKNOWN).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

This is a git build of 923ffea80
Associated branch(es):
        local:master
        github/ne-vlezay80/frr/master

debian# show ip ro
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

IPv4 unicast VRF default:
K>* 0.0.0.0/0 [0/0] via 172.18.4.1, enp2s0, weight 1, 00:03:27
L * 169.254.0.1/32 is directly connected, null0, weight 1, 00:00:05
C * 169.254.0.1/32 is directly connected, null0, weight 1, 00:00:05
L * 169.254.0.1/32 is directly connected, null0, weight 1, 00:00:05
L * 169.254.0.1/32 is directly connected, null0, weight 1, 00:00:05
L * 169.254.0.1/32 is directly connected, null0, weight 1, 00:00:05
L * 169.254.0.1/32 is directly connected, null0, weight 1, 00:00:05
L * 169.254.0.1/32 is directly connected, null0, weight 1, 00:00:05
L * 169.254.0.1/32 is directly connected, null0, weight 1, 00:00:05
L * 169.254.0.1/32 is directly connected, null0, weight 1, 00:00:05
L * 169.254.0.1/32 is directly connected, null0, weight 1, 00:00:05
L * 169.254.0.1/32 is directly connected, null0, weight 1, 00:00:05
L>* 169.254.0.1/32 is directly connected, null0, weight 1, 00:02:37
C>* 172.18.4.0/27 is directly connected, enp2s0, weight 1, 00:03:27
L>* 172.18.4.25/32 is directly connected, enp2s0, weight 1, 00:03:27
root@debian:/home/user/frr# ip addr show dev null0
5: null0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 9009 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 52:cc:4f:40:66:77 brd ff:ff:ff:ff:ff:ff
    inet 169.254.0.1/32 scope global null0
       valid_lft forever preferred_lft forever
    inet6 fe80::a0c3:e6ff:fe9a:7b0d/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever

```
After patch:
```
root@debian:/home/user/frr# /tmp/test.sh 
root@debian:/home/user/frr# vtysh

Hello, this is FRRouting (version 10.6-dev-MyOwnFRRVersion-gUNKNOWN).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

This is a git build of d4d96b306
Associated branch(es):
        local:fix-dup-routes
        github/ne-vlezay80/frr/fix-dup-routes

debian# show ip ro
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIP, O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

IPv4 unicast VRF default:
K>* 0.0.0.0/0 [0/0] via 172.18.4.1, enp2s0, weight 1, 00:00:16
L * 169.254.0.1/32 is directly connected, null0, weight 1, 00:00:02
C>* 169.254.0.1/32 is directly connected, null0, weight 1, 00:00:02
C>* 172.18.4.0/27 is directly connected, enp2s0, weight 1, 00:00:16
L>* 172.18.4.25/32 is directly connected, enp2s0, weight 1, 00:00:16
```
/tmp/test.sh:
```
#!/bin/bash

iface="null0"

MTU=9000
count=10

while true; do
        if [[ $count -le 0 ]]; then
                break
        fi

        ip link set dev $iface mtu $MTU

        MTU=$((MTU+1))
        count=$((count-1))
done
```

FIX ISSUE: https://github.com/FRRouting/frr/issues/20337