### PR TITLE
tests: log test start, end and result to all log files

### DIFF
--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -576,6 +576,36 @@ class Topogen(object):
             return True
         return False
 
+    def log_test_start(self, test_path):
+        "Log the start of a test"
+        for router in self.routers().values():
+            try:
+                router.net.cmd_nostatus(
+                    f"vtysh -c 'send log level info === TEST-START: {shlex.quote(test_path)}'"
+                )
+            except Exception:
+                pass
+
+    def log_test_result(self, test_path, result):
+        "Log the result of a test"
+        for router in self.routers().values():
+            try:
+                router.net.cmd_nostatus(
+                    f"vtysh -c 'send log level info === TEST-RESULT: {result}: {shlex.quote(test_path)}'"
+                )
+            except Exception:
+                pass
+
+    def log_test_end(self, test_path):
+        "Log the end of a test"
+        for router in self.routers().values():
+            try:
+                router.net.cmd_nostatus(
+                    f"vtysh -c 'send log level info === TEST-END: {shlex.quote(test_path)}'"
+                )
+            except Exception:
+                pass
+
 
 #
 # Topology gears (equipment)


### PR DESCRIPTION
Log TEST-START, TEST-END and TEST-RESULT to the all log files. We use the vtysh command `send log ...` to enter the log in all the daemon log files. As a result of running the command the messages also get logged in the router log and in the exec.log as well.

logs:
  - exec.log
  - <router>.log
  - <router>/<daemon>.log

Also log when doing the extra checks (valgrind memleaks, cores, memleaks)