### PR TITLE
yang: Fix pyang errors in frr-ospf-route-map.yang

### DIFF
--- a/yang/frr-ospf-route-map.yang
+++ b/yang/frr-ospf-route-map.yang
@@ -3,10 +3,6 @@ module frr-ospf-route-map {
   namespace "http://frrouting.org/yang/ospf-route-map";
   prefix frr-ospf-route-map;
 
-  import ietf-inet-types {
-    prefix inet;
-  }
-
   import frr-route-map {
     prefix frr-route-map;
   }
@@ -22,6 +18,9 @@ module frr-ospf-route-map {
   revision 2020-01-02 {
     description
       "Initial revision";
+
+    reference
+      "FRRouting";
   }
 
   identity metric-type {
@@ -31,6 +30,8 @@ module frr-ospf-route-map {
   }
 
   augment "/frr-route-map:lib/frr-route-map:route-map/frr-route-map:entry/frr-route-map:set-action/frr-route-map:rmap-set-action/frr-route-map:set-action" {
+    description
+      "Augments the route map configuration to support setting metric types for OSPF6 routes";
     case metric-type {
       when "derived-from-or-self(../frr-route-map:action, 'metric-type')";
       leaf metric-type {
@@ -46,6 +47,8 @@ module frr-ospf-route-map {
               "OSPF6 external type 2 metric";
           }
         }
+        description
+          "Specifies the metric type for the route map entry";
       }
     }
   }


### PR DESCRIPTION
Fix pyang errors in frr-ospf-route-map.yang

frr-ospf-route-map.yang:6: warning: imported module "ietf-inet-types" not used
frr-ospf-route-map.yang:22: error: RFC 8407: 4.8: statement "revision" must have a "reference" substatement
frr-ospf-route-map.yang:33: error: RFC 8407: 4.14: statement "augment" must have a "description" substatement
frr-ospf-route-map.yang:36: error: RFC 8407: 4.14: statement "leaf" must have a "description" substatement