### PR TITLE
ospfd: fix NULL new_table dereference in get_nexthop_by_addr

### DIFF
--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -763,6 +763,10 @@ static struct ospf_route *get_nexthop_by_addr(struct ospf *top,
 	if (top == NULL)
 		return NULL;
 
+	/* Check if routing table is initialized (SPF may not have run yet) */
+	if (top->new_table == NULL)
+		return NULL;
+
 	osr_debug("      |-  Search Nexthop for prefix %pFX",
 		  (struct prefix *)&p);
 


### PR DESCRIPTION
When OSPF Segment Routing (SR) is used and the daemon processes an Extended Prefix LSA update before the SPF-calculated routing table is ready, ospfd can crash with SIGSEGV. 
The crash occurs because `get_nexthop_by_addr()` in `ospfd/ospf_sr.c` calls `route_node_lookup(top->new_table, ...)` without checking whether `top->new_table` is NULL. When SPF has not yet run or the new routing table has not been installed, `top->new_table` can be NULL. 
Passing NULL as the table to `route_node_lookup()` leads to a NULL pointer dereference when the table's hash is accessed (e.g. in `lib/table.c`). The code comment in ospf_sr.c already notes that the nexthop may not be found when the OSPF adjacency has just come up because SPF has not yet populated the routing table; in that situation `new_table` may still be NULL and must be checked before use.
```
#0  __pthread_kill_implementation (no_tid=0, signo=11, threadid=140104612043200) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=11, threadid=140104612043200) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140104612043200, signo=signo@entry=11) at ./nptl/pthread_kill.c:89
#3  0x00007f6ca5eeb476 in __GI_raise (sig=sig@entry=11) at ../sysdeps/posix/raise.c:26
#4  0x00007f6ca6281836 in core_handler (signo=11, siginfo=0x7ffde1ab8030, context=<optimized out>) at lib/sigevent.c:268
#5  <signal handler called>
#6  rn_hash_node_const_find (item=0x7ffde1ab8bf0, h=0x8) at lib/table.c:28
#7  rn_hash_node_find (item=0x7ffde1ab8bf0, h=0x8) at lib/table.c:28
#8  route_node_lookup (table=0x0, pu=..., pu@entry=...) at lib/table.c:219
#9  0x0000564ff0e10b9b in get_nexthop_by_addr (p=..., top=0x56502a921530) at ospfd/ospf_sr.c:769
#10 compute_prefix_nhlfe (srp=srp@entry=0x56502a919dc0) at ospfd/ospf_sr.c:892
#11 0x0000564ff0e13e74 in update_ext_prefix_sid (srp=0x56502a919dc0, srn=0x56502a917fc0) at ospfd/ospf_sr.c:1252
#12 ospf_sr_ext_prefix_lsa_update (lsa=lsa@entry=0x56502a915980) at ospfd/ospf_sr.c:1804
#13 0x0000564ff0e70483 in ospf_ext_pref_lsa_update (lsa=0x56502a915980) at ospfd/ospf_ext.c:967
#14 0x0000564ff0def3a5 in new_lsa_callback (funclist=<optimized out>, lsa=lsa@entry=0x56502a915980) at ospfd/ospf_opaque.c:1047
#15 0x0000564ff0def4b3 in ospf_opaque_lsa_update_hook (lsa=0x56502a915980) at ospfd/ospf_opaque.c:1344
#16 0x0000564ff0de5d45 in hook_call_ospf_lsa_update (lsa=0x56502a915980) at ospfd/ospf_lsa.c:67
#17 ospf_lsa_install (ospf=ospf@entry=0x56502a921530, oi=oi@entry=0x56502a937680, lsa=0x56502a915980) at ospfd/ospf_lsa.c:3149
#18 0x0000564ff0dd15d3 in ospf_flood (ospf=0x56502a921530, nbr=nbr@entry=0x56502a912910, current=current@entry=0x0, new=<optimized out>, new@entry=0x56502a915980) at ospfd/ospf_flood.c:498
#19 0x0000564ff0dfd393 in ospf_ls_upd (size=<optimized out>, oi=<optimized out>, s=<optimized out>, ospfh=0x56502a922514, iph=<optimized out>, ospf=<optimized out>) at ospfd/ospf_packet.c:1959
#20 ospf_read_helper (ospf=<optimized out>) at ospfd/ospf_packet.c:2926
#21 ospf_read (thread=<optimized out>) at ospfd/ospf_packet.c:2957
#22 0x00007f6ca629def6 in event_call (thread=thread@entry=0x7ffde1ab9170) at lib/event.c:2005
#23 0x00007f6ca62165c0 in frr_run (loop=0x56502a63e7f0) at lib/libfrr.c:1250
#24 0x0000564ff0dbe517 in main (argc=12, argv=0x7ffde1ab93c8) at ospfd/ospf_main.c:307
```

