### PR TITLE
bgpd: Add route-map based allowas-in for flexible route filtering

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5781,6 +5781,83 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 					   .sub_type = sub_type,
 					   .addpath_rx_id = addpath_id };
 
+	/*
+	 * Determine effective allowas-in for this prefix.
+	 *
+	 * If allowas-in is configured with a route-map, allowas-in (count or
+	 * origin) only applies to routes that match the route-map; otherwise
+	 * a strict AS-path loop check is enforced.
+	 *
+	 * The route-map pointer is cached and updated via the route-map
+	 * change hook so we never do a name lookup in this hot path.
+	 */
+	int allowas_in = 0;
+	bool allowas_in_origin_effective = false;
+
+	if (CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_ALLOWAS_IN)) {
+		bool allowas_in_apply = false;
+
+		if (peer->allowas_in_rmap[afi][safi].rmap) {
+			/*
+			 * Route-map configured - apply allowas-in only if the
+			 * route-map permits. The route-map is used purely for
+			 * matching here, so apply it on a stack-local copy of
+			 * attr and always flush it afterwards. This ensures any
+			 * `set` actions in the route-map do not leak into the
+			 * downstream inbound processing.
+			 */
+			struct attr local_attr = *attr;
+			struct bgp_path_info rmap_path;
+			struct bgp_path_info_extra rmap_extra;
+			route_map_result_t rmap_ret;
+
+			prep_for_rmap_apply(&rmap_path, &rmap_extra, dest, NULL, peer, NULL,
+					    &local_attr);
+			/*
+			 * prep_for_rmap_apply leaves rmap_path.extra NULL when
+			 * src_pi is NULL, so wire up our local extra explicitly
+			 * to make label info reachable from the route-map.
+			 */
+			rmap_path.extra = &rmap_extra;
+
+			if (num_labels && num_labels <= BGP_MAX_LABELS)
+				rmap_extra.labels = &bgp_labels;
+
+			if (BGP_DEBUG(update, UPDATE_IN))
+				zlog_debug("%s: Applying allowas-in route-map %s for prefix %pFX from peer %s",
+					   __func__, peer->allowas_in_rmap[afi][safi].name, p,
+					   peer->host);
+
+			SET_FLAG(peer->rmap_type, PEER_RMAP_TYPE_ALLOWAS_IN);
+			rmap_ret = route_map_apply(peer->allowas_in_rmap[afi][safi].rmap, p,
+						   &rmap_path);
+			peer->rmap_type = 0;
+
+			if (BGP_DEBUG(update, UPDATE_IN))
+				zlog_debug("%s: Route-map %s result for %pFX: %s", __func__,
+					   peer->allowas_in_rmap[afi][safi].name, p,
+					   rmap_ret == RMAP_PERMITMATCH ? "PERMIT" : "DENY");
+
+			/* Always flush; the route-map is for matching only and
+			 * we never carry forward any of its `set` modifications.
+			 */
+			bgp_attr_flush(&local_attr);
+
+			if (rmap_ret == RMAP_PERMITMATCH)
+				allowas_in_apply = true;
+		} else if (!peer->allowas_in_rmap[afi][safi].name) {
+			/* Standard allowas-in without filtering */
+			allowas_in_apply = true;
+		}
+		/* Else: filter configured but not found - strict check */
+
+		if (allowas_in_apply) {
+			allowas_in = peer->allowas_in[afi][safi];
+			if (CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_ALLOWAS_IN_ORIGIN))
+				allowas_in_origin_effective = true;
+		}
+	}
+
 	pi = bgp_pi_hash_find(&rib_table->pi_hash, &pi_lookup);
 
 	/* AS path local-as loop check. */
@@ -5789,7 +5866,7 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 
 		/* Update permitted loop count */
 		if (CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_ALLOWAS_IN))
-			aspath_loop_count = peer->allowas_in[afi][safi];
+			aspath_loop_count = allowas_in;
 		else if (!CHECK_FLAG(peer->flags,
 				     PEER_FLAG_LOCAL_AS_NO_PREPEND))
 			aspath_loop_count = 1;
@@ -5824,13 +5901,15 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 
 	/*
 	 * If the peer is configured for "allowas-in origin" and the last ASN in
-	 * the as-path is our ASN then we do not need to call aspath_loop_check
+	 * the as-path is our ASN then we do not need to call aspath_loop_check.
+	 *
+	 * When allowas-in is gated by a route-map, the origin bypass only
+	 * applies to routes that the route-map permitted (tracked via
+	 * allowas_in_origin_effective).
 	 */
-	if (!CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_ALLOWAS_IN_ORIGIN) ||
-	    (aspath_get_last_as(attr->aspath) != bgp->as)) {
+	if (!allowas_in_origin_effective || (aspath_get_last_as(attr->aspath) != bgp->as)) {
 		/* AS path loop check. */
-		if (aspath_loop_check(attr->aspath, bgp->as) >
-		    peer->allowas_in[afi][safi]) {
+		if (aspath_loop_check(attr->aspath, bgp->as) > allowas_in) {
 			peer->stat_pfx_aspath_loop++;
 			reason = "as-path contains our own AS;";
 			goto filtered;
@@ -5838,8 +5917,7 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 
 		/* If we're a CONFED we need to loop check the CONFED ID too */
 		if (CHECK_FLAG(bgp->config, BGP_CONFIG_CONFEDERATION)) {
-			if (aspath_loop_check_confed(attr->aspath, bgp->confed_id) >
-			    peer->allowas_in[afi][safi]) {
+			if (aspath_loop_check_confed(attr->aspath, bgp->confed_id) > allowas_in) {
 				peer->stat_pfx_aspath_loop++;
 				reason = "as-path contains our own confed AS;";
 				goto filtered;

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -4749,6 +4749,11 @@ static void bgp_route_map_process_peer(const char *rmap_name,
 	    && (strcmp(rmap_name, peer->default_rmap[afi][safi].name) == 0))
 		peer->default_rmap[afi][safi].map = map;
 
+	/* Update allowas-in route-map cache */
+	if (peer->allowas_in_rmap[afi][safi].name &&
+	    (strcmp(rmap_name, peer->allowas_in_rmap[afi][safi].name) == 0))
+		peer->allowas_in_rmap[afi][safi].rmap = map;
+
 	/* Notify BGP conditional advertisement scanner percess */
 	peer->advmap_config_change[afi][safi] = true;
 }
@@ -4799,6 +4804,29 @@ static void bgp_route_map_update_peer_group(const char *rmap_name,
 			if (filter->advmap.cname &&
 			    (strcmp(rmap_name, filter->advmap.cname) == 0))
 				filter->advmap.cmap = map;
+
+			/* Update allowas-in route-map cache for peer-group */
+			if (group->conf->allowas_in_rmap[afi][safi].name &&
+			    (strcmp(rmap_name, group->conf->allowas_in_rmap[afi][safi].name) == 0)) {
+				struct peer *member;
+				struct listnode *m_node, *m_nnode;
+
+				group->conf->allowas_in_rmap[afi][safi].rmap = map;
+
+				/*
+				 * Refresh the cached map pointer on every
+				 * peer-group member that inherits the same
+				 * allowas-in route-map name, so a route-map
+				 * rename/recreate is reflected immediately
+				 * without waiting for a session reset.
+				 */
+				for (ALL_LIST_ELEMENTS(group->peer, m_node, m_nnode, member)) {
+					if (member->allowas_in_rmap[afi][safi].name &&
+					    strcmp(rmap_name,
+						   member->allowas_in_rmap[afi][safi].name) == 0)
+						member->allowas_in_rmap[afi][safi].rmap = map;
+				}
+			}
 		}
 	}
 }

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -9716,64 +9716,65 @@ DEFPY (no_neighbor_soo,
 }
 
 /* "neighbor allowas-in" */
-DEFUN (neighbor_allowas_in,
+DEFPY (neighbor_allowas_in,
        neighbor_allowas_in_cmd,
-       "neighbor <A.B.C.D|X:X::X:X|WORD> allowas-in [<(1-10)|origin>]",
+       "neighbor <A.B.C.D|X:X::X:X|WORD>$neighbor allowas-in [route-map RMAP_NAME$rmap_name] [<(1-10)$allow_num|origin$origin_kw>]",
        NEIGHBOR_STR
        NEIGHBOR_ADDR_STR2
        "Accept as-path with my AS present in it\n"
+       "Filter routes using route-map\n"
+       "Name of route-map\n"
        "Number of occurrences of AS number\n"
        "Only accept my AS in the as-path if the route was originated in my AS\n")
 {
-	int idx_peer = 1;
-	int idx_number_origin = 3;
 	int ret;
-	bool origin = false;
 	struct peer *peer;
-	int allow_num = 0;
+	int allow_num_val;
+	bool origin = !!origin_kw;
 
-	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
+	peer = peer_and_group_lookup_vty(vty, neighbor);
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	if (argc <= idx_number_origin)
-		allow_num = BGP_ALLOWAS_IN_DEFAULT;
-	else {
-		if (argv[idx_number_origin]->type == WORD_TKN)
-			origin = true;
-		else
-			allow_num = atoi(argv[idx_number_origin]->arg);
-	}
+	if (origin)
+		allow_num_val = 0;
+	else if (allow_num)
+		allow_num_val = (int)allow_num;
+	else
+		allow_num_val = BGP_ALLOWAS_IN_DEFAULT;
 
-	ret = peer_allowas_in_set(peer, bgp_node_afi(vty), bgp_node_safi(vty),
-				  allow_num, origin);
+	ret = peer_allowas_in_set(peer, bgp_node_afi(vty), bgp_node_safi(vty), allow_num_val,
+				  origin, rmap_name);
 
 	return bgp_vty_return(vty, ret);
 }
 
 ALIAS_HIDDEN(
 	neighbor_allowas_in, neighbor_allowas_in_hidden_cmd,
-	"neighbor <A.B.C.D|X:X::X:X|WORD> allowas-in [<(1-10)|origin>]",
+	"neighbor <A.B.C.D|X:X::X:X|WORD>$neighbor allowas-in [route-map RMAP_NAME$rmap_name] [<(1-10)$allow_num|origin$origin_kw>]",
 	NEIGHBOR_STR NEIGHBOR_ADDR_STR2
 	"Accept as-path with my AS present in it\n"
+	"Filter routes using route-map\n"
+	"Name of route-map\n"
 	"Number of occurrences of AS number\n"
 	"Only accept my AS in the as-path if the route was originated in my AS\n")
 
-DEFUN (no_neighbor_allowas_in,
+DEFPY (no_neighbor_allowas_in,
        no_neighbor_allowas_in_cmd,
-       "no neighbor <A.B.C.D|X:X::X:X|WORD> allowas-in [<(1-10)|origin>]",
+       "no neighbor <A.B.C.D|X:X::X:X|WORD>$neighbor allowas-in [route-map [RMAP_NAME]] [<(1-10)|origin>]",
        NO_STR
        NEIGHBOR_STR
        NEIGHBOR_ADDR_STR2
        "allow local ASN appears in aspath attribute\n"
+       "Filter routes using route-map\n"
+       "Name of route-map\n"
        "Number of occurrences of AS number\n"
        "Only accept my AS in the as-path if the route was originated in my AS\n")
 {
-	int idx_peer = 2;
 	int ret;
 	struct peer *peer;
 
-	peer = peer_and_group_lookup_vty(vty, argv[idx_peer]->arg);
+	peer = peer_and_group_lookup_vty(vty, neighbor);
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
 
@@ -9785,9 +9786,11 @@ DEFUN (no_neighbor_allowas_in,
 
 ALIAS_HIDDEN(
 	no_neighbor_allowas_in, no_neighbor_allowas_in_hidden_cmd,
-	"no neighbor <A.B.C.D|X:X::X:X|WORD> allowas-in [<(1-10)|origin>]",
+	"no neighbor <A.B.C.D|X:X::X:X|WORD>$neighbor allowas-in [route-map [RMAP_NAME]] [<(1-10)|origin>]",
 	NO_STR NEIGHBOR_STR NEIGHBOR_ADDR_STR2
 	"allow local ASN appears in aspath attribute\n"
+	"Filter routes using route-map\n"
+	"Name of route-map\n"
 	"Number of occurrences of AS number\n"
 	"Only accept my AS in the as-path if the route was originated in my AS\n")
 
@@ -15619,6 +15622,10 @@ static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
 			else
 				json_object_int_add(json_addr, "allowAsInCount",
 						    p->allowas_in[afi][safi]);
+
+			if (p->allowas_in_rmap[afi][safi].name)
+				json_object_string_add(json_addr, "allowAsInRouteMap",
+						       p->allowas_in_rmap[afi][safi].name);
 		}
 
 		if (p->addpath_type[afi][safi] != BGP_ADDPATH_NONE)
@@ -15937,9 +15944,12 @@ static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
 				vty_out(vty,
 					"  Local AS allowed as path origin\n");
 			else
-				vty_out(vty,
-					"  Local AS allowed in path, %d occurrences\n",
+				vty_out(vty, "  Local AS allowed in path, %d occurrences\n",
 					p->allowas_in[afi][safi]);
+
+			if (p->allowas_in_rmap[afi][safi].name)
+				vty_out(vty, "  Local AS allowed with route-map: %s\n",
+					p->allowas_in_rmap[afi][safi].name);
 		}
 
 		if (p->addpath_type[afi][safi] != BGP_ADDPATH_NONE)
@@ -21665,14 +21675,29 @@ static void bgp_config_write_peer_af(struct vty *vty, struct bgp *bgp,
 
 	/* allowas-in <1-10> */
 	if (peergroup_af_flag_check(peer, afi, safi, PEER_FLAG_ALLOWAS_IN)) {
-		if (peer_af_flag_check(peer, afi, safi,
-				       PEER_FLAG_ALLOWAS_IN_ORIGIN)) {
-			vty_out(vty, "  neighbor %s allowas-in origin\n", addr);
-		} else if (peer->allowas_in[afi][safi] == BGP_ALLOWAS_IN_DEFAULT) {
-			vty_out(vty, "  neighbor %s allowas-in\n", addr);
+		if (peer->allowas_in_rmap[afi][safi].name) {
+			/* allowas-in with route-map */
+			if (peer_af_flag_check(peer, afi, safi, PEER_FLAG_ALLOWAS_IN_ORIGIN)) {
+				vty_out(vty, "  neighbor %s allowas-in route-map %s origin\n",
+					addr, peer->allowas_in_rmap[afi][safi].name);
+			} else if (peer->allowas_in[afi][safi] == BGP_ALLOWAS_IN_DEFAULT) {
+				vty_out(vty, "  neighbor %s allowas-in route-map %s\n", addr,
+					peer->allowas_in_rmap[afi][safi].name);
+			} else {
+				vty_out(vty, "  neighbor %s allowas-in route-map %s %d\n", addr,
+					peer->allowas_in_rmap[afi][safi].name,
+					peer->allowas_in[afi][safi]);
+			}
 		} else {
-			vty_out(vty, "  neighbor %s allowas-in %d\n", addr,
-				peer->allowas_in[afi][safi]);
+			/* regular allowas-in without filtering */
+			if (peer_af_flag_check(peer, afi, safi, PEER_FLAG_ALLOWAS_IN_ORIGIN)) {
+				vty_out(vty, "  neighbor %s allowas-in origin\n", addr);
+			} else if (peer->allowas_in[afi][safi] == BGP_ALLOWAS_IN_DEFAULT) {
+				vty_out(vty, "  neighbor %s allowas-in\n", addr);
+			} else {
+				vty_out(vty, "  neighbor %s allowas-in %d\n", addr,
+					peer->allowas_in[afi][safi]);
+			}
 		}
 	}
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3098,6 +3098,7 @@ int peer_delete(struct peer *peer)
 		XFREE(MTYPE_BGP_FILTER_NAME, filter->usmap.name);
 		XFREE(MTYPE_ROUTE_MAP_NAME, peer->default_rmap[afi][safi].name);
 		ecommunity_free(&peer->soo[afi][safi]);
+		XFREE(MTYPE_ROUTE_MAP_NAME, peer->allowas_in_rmap[afi][safi].name);
 	}
 
 	FOREACH_AFI_SAFI (afi, safi)
@@ -7212,32 +7213,54 @@ void peer_interface_unset(struct peer *peer)
 }
 
 /* Allow-as in.  */
-int peer_allowas_in_set(struct peer *peer, afi_t afi, safi_t safi, int allow_num, bool origin)
+/*
+ * Set/update a peer's allowas-in route-map name and cached pointer.
+ * Pass NULL to clear an existing route-map.
+ */
+static void peer_allowas_in_rmap_update(struct peer *peer, afi_t afi, safi_t safi,
+					const char *rmap_name)
+{
+	XFREE(MTYPE_ROUTE_MAP_NAME, peer->allowas_in_rmap[afi][safi].name);
+	if (rmap_name) {
+		peer->allowas_in_rmap[afi][safi].name = XSTRDUP(MTYPE_ROUTE_MAP_NAME, rmap_name);
+		peer->allowas_in_rmap[afi][safi].rmap = route_map_lookup_by_name(rmap_name);
+	} else {
+		peer->allowas_in_rmap[afi][safi].rmap = NULL;
+	}
+}
+
+int peer_allowas_in_set(struct peer *peer, afi_t afi, safi_t safi, int allow_num, bool origin,
+			const char *rmap_name)
 {
 	struct peer *member;
 	struct listnode *node, *nnode;
+	bool rmap_changed;
 
 	if (!origin && (allow_num < 1 || allow_num > 10))
 		return BGP_ERR_INVALID_VALUE;
 
+	rmap_changed = ((peer->allowas_in_rmap[afi][safi].name == NULL) != (rmap_name == NULL)) ||
+		       (rmap_name && peer->allowas_in_rmap[afi][safi].name &&
+			strcmp(peer->allowas_in_rmap[afi][safi].name, rmap_name) != 0);
+
+	if (rmap_changed)
+		peer_allowas_in_rmap_update(peer, afi, safi, rmap_name);
+
 	/* Set flag and configuration on peer. */
 	peer_af_flag_set(peer, afi, safi, PEER_FLAG_ALLOWAS_IN);
 	if (origin) {
-		if (peer->allowas_in[afi][safi] != 0
-		    || !CHECK_FLAG(peer->af_flags[afi][safi],
-				   PEER_FLAG_ALLOWAS_IN_ORIGIN)) {
-			peer_af_flag_set(peer, afi, safi,
-					 PEER_FLAG_ALLOWAS_IN_ORIGIN);
+		if (peer->allowas_in[afi][safi] != 0 ||
+		    !CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_ALLOWAS_IN_ORIGIN) ||
+		    rmap_changed) {
+			peer_af_flag_set(peer, afi, safi, PEER_FLAG_ALLOWAS_IN_ORIGIN);
 			peer->allowas_in[afi][safi] = 0;
 			peer_on_policy_change(peer, afi, safi, 0);
 		}
 	} else {
-		if (peer->allowas_in[afi][safi] != allow_num
-		    || CHECK_FLAG(peer->af_flags[afi][safi],
-				  PEER_FLAG_ALLOWAS_IN_ORIGIN)) {
-
-			peer_af_flag_unset(peer, afi, safi,
-					   PEER_FLAG_ALLOWAS_IN_ORIGIN);
+		if (peer->allowas_in[afi][safi] != allow_num ||
+		    CHECK_FLAG(peer->af_flags[afi][safi], PEER_FLAG_ALLOWAS_IN_ORIGIN) ||
+		    rmap_changed) {
+			peer_af_flag_unset(peer, afi, safi, PEER_FLAG_ALLOWAS_IN_ORIGIN);
 			peer->allowas_in[afi][safi] = allow_num;
 			peer_on_policy_change(peer, afi, safi, 0);
 		}
@@ -7253,25 +7276,26 @@ int peer_allowas_in_set(struct peer *peer, afi_t afi, safi_t safi, int allow_num
 	 */
 	for (ALL_LIST_ELEMENTS(peer->group->peer, node, nnode, member)) {
 		/* Skip peers with overridden configuration. */
-		if (CHECK_FLAG(member->af_flags_override[afi][safi],
-			       PEER_FLAG_ALLOWAS_IN))
+		if (CHECK_FLAG(member->af_flags_override[afi][safi], PEER_FLAG_ALLOWAS_IN))
 			continue;
+
+		peer_allowas_in_rmap_update(member, afi, safi, rmap_name);
 
 		/* Set flag and configuration on peer-group member. */
 		SET_FLAG(member->af_flags[afi][safi], PEER_FLAG_ALLOWAS_IN);
 		if (origin) {
-			if (member->allowas_in[afi][safi] != 0
-			    || !CHECK_FLAG(member->af_flags[afi][safi],
-					   PEER_FLAG_ALLOWAS_IN_ORIGIN)) {
+			if (member->allowas_in[afi][safi] != 0 ||
+			    !CHECK_FLAG(member->af_flags[afi][safi], PEER_FLAG_ALLOWAS_IN_ORIGIN) ||
+			    rmap_changed) {
 				SET_FLAG(member->af_flags[afi][safi],
 					 PEER_FLAG_ALLOWAS_IN_ORIGIN);
 				member->allowas_in[afi][safi] = 0;
 				peer_on_policy_change(member, afi, safi, 0);
 			}
 		} else {
-			if (member->allowas_in[afi][safi] != allow_num
-			    || CHECK_FLAG(member->af_flags[afi][safi],
-					  PEER_FLAG_ALLOWAS_IN_ORIGIN)) {
+			if (member->allowas_in[afi][safi] != allow_num ||
+			    CHECK_FLAG(member->af_flags[afi][safi], PEER_FLAG_ALLOWAS_IN_ORIGIN) ||
+			    rmap_changed) {
 				UNSET_FLAG(member->af_flags[afi][safi],
 					   PEER_FLAG_ALLOWAS_IN_ORIGIN);
 				member->allowas_in[afi][safi] = allow_num;
@@ -7298,6 +7322,9 @@ int peer_allowas_in_unset(struct peer *peer, afi_t afi, safi_t safi)
 		peer_af_flag_inherit(peer, afi, safi,
 				     PEER_FLAG_ALLOWAS_IN_ORIGIN);
 		PEER_ATTR_INHERIT(peer, peer->group, allowas_in[afi][safi]);
+		PEER_STR_ATTR_INHERIT(peer, peer->group, allowas_in_rmap[afi][safi].name,
+				      MTYPE_ROUTE_MAP_NAME);
+		PEER_ATTR_INHERIT(peer, peer->group, allowas_in_rmap[afi][safi].rmap);
 		peer_on_policy_change(peer, afi, safi, 0);
 
 		return 0;
@@ -7307,6 +7334,7 @@ int peer_allowas_in_unset(struct peer *peer, afi_t afi, safi_t safi)
 	peer_af_flag_unset(peer, afi, safi, PEER_FLAG_ALLOWAS_IN);
 	peer_af_flag_unset(peer, afi, safi, PEER_FLAG_ALLOWAS_IN_ORIGIN);
 	peer->allowas_in[afi][safi] = 0;
+	peer_allowas_in_rmap_update(peer, afi, safi, NULL);
 	peer_on_policy_change(peer, afi, safi, 0);
 
 	/* Skip peer-group mechanics if handling a regular peer. */
@@ -7328,6 +7356,7 @@ int peer_allowas_in_unset(struct peer *peer, afi_t afi, safi_t safi)
 		UNSET_FLAG(member->af_flags[afi][safi],
 			   PEER_FLAG_ALLOWAS_IN_ORIGIN);
 		member->allowas_in[afi][safi] = 0;
+		peer_allowas_in_rmap_update(member, afi, safi, NULL);
 		peer_on_policy_change(member, afi, safi, 0);
 	}
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -2129,6 +2129,12 @@ struct peer {
 	/* allowas-in. */
 	char allowas_in[AFI_MAX][SAFI_MAX];
 
+	/* allowas-in with route-map. */
+	struct {
+		char *name;
+		struct route_map *rmap;
+	} allowas_in_rmap[AFI_MAX][SAFI_MAX];
+
 	/* soo */
 	struct ecommunity *soo[AFI_MAX][SAFI_MAX];
 
@@ -2207,6 +2213,7 @@ struct peer {
 #define PEER_RMAP_TYPE_REDISTRIBUTE   (1U << 3) /* redistribute route-map */
 #define PEER_RMAP_TYPE_DEFAULT        (1U << 4) /* default-originate route-map */
 #define PEER_RMAP_TYPE_AGGREGATE      (1U << 5) /* aggregate-address route-map */
+#define PEER_RMAP_TYPE_ALLOWAS_IN     (1U << 6) /* allowas-in route-map */
 
 	/** Peer overwrite configuration. */
 	struct bfd_session_config {
@@ -2853,7 +2860,7 @@ extern int peer_distribute_set(struct peer *peer, afi_t afi, safi_t safi, int di
 extern int peer_distribute_unset(struct peer *peer, afi_t afi, safi_t safi, int direct);
 
 extern int peer_allowas_in_set(struct peer *peer, afi_t afi, safi_t safi, int allow_num,
-			       bool origin);
+			       bool origin, const char *rmap_name);
 extern int peer_allowas_in_unset(struct peer *peer, afi_t afi, safi_t safi);
 
 extern int peer_local_as_set(struct peer *peer, as_t as, bool no_prepend,

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2080,6 +2080,50 @@ Configuring Peers
 
    This command is only allowed for eBGP peers.
 
+.. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> allowas-in route-map WORD [<(1-10)|origin>]
+
+   Accept incoming routes with AS path containing the system AS number, but only
+   for routes that match the specified route-map. This provides maximum flexibility
+   for selective AS-path loop prevention based on any BGP attributes.
+
+   Route-maps can match on prefixes, AS-path patterns, communities, extended communities, and
+   any other BGP attributes, allowing complex filtering logic.
+
+   The parameter ``WORD`` specifies the name of the route-map to use for matching.
+   Only routes that result in a ``permit`` action from the route-map will have
+   allowas-in applied. The route-map performs matching only; it does not modify
+   route attributes.
+
+   The parameter ``(1-10)`` configures the amount of accepted occurrences of the
+   system AS number in AS path for matching routes (default: 3).
+
+   The parameter ``origin`` configures BGP to only accept routes originated with
+   the same AS number as the system, for matching routes.
+
+   Example configuration to allow AS-path loops for routes with a specific SoO community:
+
+   .. code-block:: frr
+
+      ip extcommunity-list standard MGMT_SOO permit soo 1.1.1.1:0
+      !
+      route-map RM_ALLOW_AS permit 10
+       match extcommunity MGMT_SOO
+      !
+      router bgp 65201
+       neighbor 10.0.0.1 remote-as external
+       !
+       address-family ipv4 unicast
+        neighbor 10.0.0.1 allowas-in route-map RM_ALLOW_AS 1
+       exit-address-family
+
+   Behavior:
+
+   - Routes matching the route-map (permit): allowas-in is applied
+   - Routes NOT matching the route-map (deny): strict AS-path loop detection
+   - If route-map is not found: strict AS-path loop detection
+
+   This command is only allowed for eBGP peers.
+
 .. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> addpath-tx-all-paths
 
    Configure BGP to send all known paths to neighbor in order to preserve multi

--- a/tests/topotests/bgp_as_allow_in/test_bgp_as_allow_in.py
+++ b/tests/topotests/bgp_as_allow_in/test_bgp_as_allow_in.py
@@ -48,6 +48,7 @@ from lib.common_config import (
     verify_rib,
     create_static_routes,
     create_route_maps,
+    create_prefix_lists,
     check_address_types,
     step,
     required_linux_kernel_version,
@@ -948,6 +949,1076 @@ def test_bgp_allowas_in_sameastoebgp_p1(request):
         assert result is True, "Testcase {} : Failed \n Error: {}".format(
             tc_name, result
         )
+    write_test_footer(tc_name)
+
+
+def test_bgp_allowas_in_route_map_p0(request):
+    """
+    Verify that allowas-in route-map permits only matching routes.
+
+    Topology: R1 (AS 200) -> R2 (AS 100) -> R3 (AS 200)
+
+    Routes advertised from R1 (all have AS-path "100 200" at R3):
+    - 192.0.2.0/24      (will NOT match - length /24 < ge 31)
+    - 192.0.2.128/31    (will match - within subnet, length /31 matches)
+    - 192.0.2.1/32      (will match - within subnet, length /32 matches)
+    - 198.51.100.1/32   (will NOT match - different subnet)
+
+    Configuration on R3:
+      ip prefix-list PL_ALLOWAS_V4 permit 192.0.2.0/24 ge 31 le 32
+      ipv6 prefix-list PL_ALLOWAS_V6 permit 2001:db8::/48 ge 127 le 128
+      !
+      route-map RM_ALLOWAS_V4 permit 10
+       match ip address prefix-list PL_ALLOWAS_V4
+      route-map RM_ALLOWAS_V4 deny 20
+      !
+      route-map RM_ALLOWAS_V6 permit 10
+       match ipv6 address prefix-list PL_ALLOWAS_V6
+      route-map RM_ALLOWAS_V6 deny 20
+      !
+      address-family ipv4 unicast
+       neighbor R2 allowas-in route-map RM_ALLOWAS_V4 1
+      address-family ipv6 unicast
+       neighbor R2 allowas-in route-map RM_ALLOWAS_V6 1
+
+    Expected Results (IPv4):
+      ACCEPTED: 192.0.2.128/31, 192.0.2.1/32 (match subnet AND length)
+      REJECTED: 192.0.2.0/24 (wrong length /24 < ge 31)
+      REJECTED: 198.51.100.1/32 (wrong subnet)
+
+    Expected Results (IPv6):
+      ACCEPTED: 2001:db8::1/127, 2001:db8::1/128 (match subnet AND length)
+      REJECTED: 2001:db8::/48 (wrong length /48 < ge 127)
+      REJECTED: 2001:db9::1/128 (wrong subnet)
+
+    Comparison with standard allowas-in (neighbor R2 allowas-in 1):
+      Without route-map: ALL routes would be accepted
+      With route-map: Only routes matching BOTH subnet AND length accepted
+
+    Removal test:
+      Remove allowas-in route-map (removes entire allowas-in config)
+      Result: ALL routes rejected (no allowas-in)
+
+    This demonstrates allowas-in can use ANY route-map match criteria
+    (specific prefixes, prefix-lengths, communities, AS-path, etc.)
+    for flexible, selective AS-loop prevention.
+    """
+
+    tc_name = request.node.name
+    write_test_header(tc_name)
+    tgen = get_topogen()
+    reset_config_on_routers(tgen)
+
+    # Don't run this test if we have any failure.
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    step("Advertise multiple routes with different prefix lengths from R1(AS-200).")
+    dut = "r3"
+    protocol = "bgp"
+
+    # Test routes with different prefix lengths (RFC documentation addresses):
+    # Routes that WILL match (within 192.0.2.0/24 or 2001:db8::/48):
+    network_match1 = {"ipv4": "192.0.2.0/24", "ipv6": "2001:db8::/48"}  # /24, /48
+    network_match2 = {"ipv4": "192.0.2.128/31", "ipv6": "2001:db8::1/127"}  # /31, /127
+    network_match3 = {"ipv4": "192.0.2.1/32", "ipv6": "2001:db8::1/128"}  # /32, /128
+    # Route that will NOT match (different subnet - outside our prefix-list):
+    network_nomatch = {"ipv4": "198.51.100.1/32", "ipv6": "2001:db9::1/128"}
+    next_hop = {"ipv4": "Null0", "ipv6": "Null0"}
+
+    # Use separate route-map names for IPv4 and IPv6 to avoid overwriting
+    plist_names = {"ipv4": "PL_ALLOWAS_V4", "ipv6": "PL_ALLOWAS_V6"}
+    rmap_names = {"ipv4": "RM_ALLOWAS_V4", "ipv6": "RM_ALLOWAS_V6"}
+
+    for addr_type in ADDR_TYPES:
+        # Configure static routes with various prefix lengths
+        input_dict_all = {
+            "r1": {
+                "static_routes": [
+                    {
+                        "network": network_match1[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    },
+                    {
+                        "network": network_match2[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    },
+                    {
+                        "network": network_match3[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    },
+                    {
+                        "network": network_nomatch[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    },
+                ]
+            }
+        }
+
+        logger.info("Configure static routes")
+        result = create_static_routes(tgen, input_dict_all)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("configure redistribute static in Router BGP in R1")
+
+        input_dict_redist = {
+            "r1": {
+                "bgp": {
+                    "address_family": {
+                        addr_type: {
+                            "unicast": {"redistribute": [{"redist_type": "static"}]}
+                        }
+                    }
+                }
+            }
+        }
+        result = create_router_bgp(tgen, topo, input_dict_redist)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("Verify routes are NOT in R3's RIB (own AS in path)")
+        logger.info(
+            "Verifying %s routes on r3, routes should not be present", addr_type
+        )
+        result = verify_rib(
+            tgen,
+            addr_type,
+            dut,
+            input_dict_all,
+            next_hop=next_hop[addr_type],
+            protocol=protocol,
+            expected=False,
+        )
+        assert result is not True, (
+            "Testcase {} : Failed \n".format(tc_name)
+            + "Expected behavior: routes should not be present in rib \n"
+            + "Error: {}".format(result)
+        )
+
+        step("Configure route-map with prefix-list to match subnet AND length")
+        # Match 192.0.2.0/24 ge 31 le 32 (or 2001:db8::/48 ge 127 le 128 for v6)
+        # Accepts /31 and /32 within subnet, rejects /24
+        # Demonstrates filtering on BOTH prefix AND length
+        plist_name = plist_names[addr_type]
+        rmap_name = rmap_names[addr_type]
+
+        # Match specific subnet with specific prefix length range
+        if addr_type == "ipv4":
+            match_subnet = "192.0.2.0/24"
+            min_len = "31"
+            max_len = "32"
+        else:
+            match_subnet = "2001:db8::/48"
+            min_len = "127"
+            max_len = "128"
+
+        input_dict_plist = {
+            "r3": {
+                "prefix_lists": {
+                    addr_type: {
+                        plist_name: [
+                            {
+                                "seqid": 5,
+                                "network": match_subnet,
+                                "ge": min_len,
+                                "le": max_len,
+                                "action": "permit",
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        result = create_prefix_lists(tgen, input_dict_plist)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        # Create route-map that matches prefix-list
+        input_dict_rmap = {
+            "r3": {
+                "route_maps": {
+                    rmap_name: [
+                        {
+                            "action": "permit",
+                            "seq_id": 10,
+                            "match": {addr_type: {"prefix_lists": plist_name}},
+                        },
+                        {
+                            "action": "deny",
+                            "seq_id": 20,
+                        },
+                    ]
+                }
+            }
+        }
+        result = create_route_maps(tgen, input_dict_rmap)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("Configure allowas-in route-map on R3 for R2.")
+        step("Only routes matching prefix-list should be accepted.")
+        # Api call to enable allowas-in with route-map in bgp process.
+        input_dict_allowas = {
+            "r3": {
+                "bgp": {
+                    "address_family": {
+                        addr_type: {
+                            "unicast": {
+                                "neighbor": {
+                                    "r2": {
+                                        "dest_link": {
+                                            "r3": {
+                                                "allowas-in": {
+                                                    "route_map": rmap_name,
+                                                    "number_occurences": 1,
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        result = create_router_bgp(tgen, topo, input_dict_allowas)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("Verify routes matching prefix AND length are accepted")
+        # Only /31 and /32 should be accepted (ge 31 le 32)
+        input_dict_matching = {
+            "r1": {
+                "static_routes": [
+                    {
+                        "network": network_match2[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    },
+                    {
+                        "network": network_match3[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    },
+                ]
+            }
+        }
+        result = verify_rib(
+            tgen, addr_type, dut, input_dict_matching, protocol=protocol
+        )
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("Verify /24 route is rejected (wrong length, even though right subnet)")
+        input_dict_wrong_len = {
+            "r1": {
+                "static_routes": [
+                    {
+                        "network": network_match1[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    },
+                ]
+            }
+        }
+        logger.info(
+            "Verifying /24 route is not present on r3 (length doesn't match ge 31)"
+        )
+        result = verify_rib(
+            tgen,
+            addr_type,
+            dut,
+            input_dict_wrong_len,
+            protocol=protocol,
+            expected=False,
+        )
+        assert result is not True, (
+            "Testcase {} : Failed \n".format(tc_name)
+            + "Expected behavior: /24 route should be rejected (length < ge 31) \n"
+            + "Error: {}".format(result)
+        )
+
+        step("Verify non-matching route is rejected")
+        input_dict_nomatch = {
+            "r1": {
+                "static_routes": [
+                    {
+                        "network": network_nomatch[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    }
+                ]
+            }
+        }
+        logger.info("Verifying non-matching route is not present on r3")
+        result = verify_rib(
+            tgen,
+            addr_type,
+            dut,
+            input_dict_nomatch,
+            protocol=protocol,
+            expected=False,
+        )
+        assert result is not True, (
+            "Testcase {} : Failed \n".format(tc_name)
+            + "Expected behavior: non-matching route should not be present \n"
+            + "Error: {}".format(result)
+        )
+
+        step("Remove allowas-in, verify routes rejected")
+        rmap_name = rmap_names[addr_type]
+        input_dict_remove = {
+            "r3": {
+                "bgp": {
+                    "address_family": {
+                        addr_type: {
+                            "unicast": {
+                                "neighbor": {
+                                    "r2": {
+                                        "dest_link": {
+                                            "r3": {
+                                                "allowas-in": {
+                                                    "route_map": rmap_name,
+                                                    "delete": True,
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        result = create_router_bgp(tgen, topo, input_dict_remove)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("Verify all routes rejected after removal")
+        logger.info("Verifying routes rejected after removing allowas-in")
+        result = verify_rib(
+            tgen,
+            addr_type,
+            dut,
+            input_dict_matching,
+            protocol=protocol,
+            expected=False,
+        )
+        assert result is not True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+    write_test_footer(tc_name)
+
+
+def test_bgp_allowas_in_route_map_count_p0(request):
+    """
+    Verify that allowas-in route-map with AS occurrence count works correctly.
+
+    Test that when AS appears multiple times in path, route-map filtering
+    combined with occurrence count limit works as expected.
+
+    Example AS-path evolution:
+      At R1 (AS 200): "200 200 200 200 200" (prepended 4 times)
+      At R2 (AS 100): prepends 100 → "100 200 200 200 200 200"
+      At R3 (AS 200): sees own AS 200 appear 5 times in path
+
+    Configuration on R3:
+      ip prefix-list PL_COUNT_V4 permit 192.0.2.0/24 le 32
+      route-map RM_COUNT_V4 permit 10
+       match ip address prefix-list PL_COUNT_V4
+      route-map RM_COUNT_V4 deny 20
+      !
+      neighbor R2 allowas-in route-map RM_COUNT_V4 5
+
+    Routes advertised from R1:
+      IPv4: 192.0.2.1/32 (matches), 198.51.100.1/32 (no match)
+      IPv6: 2001:db8::1/128 (matches), 2001:db9::1/128 (no match)
+
+    Expected behavior with count=5:
+      ACCEPTED: 192.0.2.1/32, 2001:db8::1/128 (match route-map + count 5 <= 5)
+      REJECTED: 198.51.100.1/32, 2001:db9::1/128 (no match route-map)
+
+    Expected behavior after changing to count=4:
+      REJECTED: 192.0.2.1/32, 2001:db8::1/128 (match route-map but 5 > 4)
+      REJECTED: 198.51.100.1/32, 2001:db9::1/128 (no match route-map)
+
+    Removal test:
+      Remove allowas-in route-map (removes entire allowas-in config)
+      Result: ALL routes rejected (no allowas-in)
+
+    Demonstrates: Route-map filtering combined with occurrence count limit.
+    """
+
+    tc_name = request.node.name
+    write_test_header(tc_name)
+    tgen = get_topogen()
+    reset_config_on_routers(tgen)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    dut = "r3"
+    protocol = "bgp"
+    network_match = {"ipv4": "192.0.2.1/32", "ipv6": "2001:db8::1/128"}
+    network_nomatch = {"ipv4": "198.51.100.1/32", "ipv6": "2001:db9::1/128"}
+    next_hop = {"ipv4": "Null0", "ipv6": "Null0"}
+
+    plist_names = {"ipv4": "PL_COUNT_V4", "ipv6": "PL_COUNT_V6"}
+    rmap_names = {"ipv4": "RM_COUNT_V4", "ipv6": "RM_COUNT_V6"}
+
+    for addr_type in ADDR_TYPES:
+        # Configure static routes
+        static_routes = {
+            "r1": {
+                "static_routes": [
+                    {
+                        "network": network_match[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    },
+                    {
+                        "network": network_nomatch[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    },
+                ]
+            }
+        }
+
+        logger.info("Configure static routes")
+        result = create_static_routes(tgen, static_routes)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("configure redistribute static in Router BGP in R1")
+
+        input_dict_redist = {
+            "r1": {
+                "bgp": {
+                    "address_family": {
+                        addr_type: {
+                            "unicast": {"redistribute": [{"redist_type": "static"}]}
+                        }
+                    }
+                }
+            }
+        }
+        result = create_router_bgp(tgen, topo, input_dict_redist)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+    step("Configure a route-map on R1 to prepend AS 4 times.")
+    for addr_type in ADDR_TYPES:
+        input_dict_prepend = {
+            "r1": {
+                "route_maps": {
+                    "ASP_{}".format(addr_type): [
+                        {
+                            "action": "permit",
+                            "set": {
+                                "path": {
+                                    "as_num": "200 200 200 200",
+                                    "as_action": "prepend",
+                                }
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+        result = create_route_maps(tgen, input_dict_prepend)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("configure route map in out direction on R1")
+        input_dict_rmap_out = {
+            "r1": {
+                "bgp": {
+                    "address_family": {
+                        addr_type: {
+                            "unicast": {
+                                "neighbor": {
+                                    "r2": {
+                                        "dest_link": {
+                                            "r1": {
+                                                "route_maps": [
+                                                    {
+                                                        "name": "ASP_{}".format(
+                                                            addr_type
+                                                        ),
+                                                        "direction": "out",
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        result = create_router_bgp(tgen, topo, input_dict_rmap_out)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+    for addr_type in ADDR_TYPES:
+        step("Configure prefix-list and route-map on R3")
+        plist_name = plist_names[addr_type]
+        rmap_name = rmap_names[addr_type]
+
+        if addr_type == "ipv4":
+            match_network = "192.0.2.0/24"
+        else:
+            match_network = "2001:db8::/48"
+
+        input_dict_plist = {
+            "r3": {
+                "prefix_lists": {
+                    addr_type: {
+                        plist_name: [
+                            {
+                                "seqid": 5,
+                                "network": match_network,
+                                "le": "32" if addr_type == "ipv4" else "128",
+                                "action": "permit",
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        result = create_prefix_lists(tgen, input_dict_plist)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        input_dict_rmap = {
+            "r3": {
+                "route_maps": {
+                    rmap_name: [
+                        {
+                            "action": "permit",
+                            "seq_id": 10,
+                            "match": {addr_type: {"prefix_lists": plist_name}},
+                        },
+                        {
+                            "action": "deny",
+                            "seq_id": 20,
+                        },
+                    ]
+                }
+            }
+        }
+        result = create_route_maps(tgen, input_dict_rmap)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("Configure allowas-in route-map with count=5 on R3")
+        input_dict_allowas = {
+            "r3": {
+                "bgp": {
+                    "address_family": {
+                        addr_type: {
+                            "unicast": {
+                                "neighbor": {
+                                    "r2": {
+                                        "dest_link": {
+                                            "r3": {
+                                                "allowas-in": {
+                                                    "route_map": rmap_name,
+                                                    "number_occurences": 5,
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        result = create_router_bgp(tgen, topo, input_dict_allowas)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("Verify matching route is accepted (AS occurs 5 times, count=5)")
+        input_dict_match = {
+            "r1": {
+                "static_routes": [
+                    {
+                        "network": network_match[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    }
+                ]
+            }
+        }
+        result = verify_rib(tgen, addr_type, dut, input_dict_match, protocol=protocol)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("Verify non-matching route is rejected (route-map denies)")
+        input_dict_nomatch = {
+            "r1": {
+                "static_routes": [
+                    {
+                        "network": network_nomatch[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    }
+                ]
+            }
+        }
+        logger.info("Verifying non-matching route is not present on r3")
+        result = verify_rib(
+            tgen,
+            addr_type,
+            dut,
+            input_dict_nomatch,
+            protocol=protocol,
+            expected=False,
+        )
+        assert result is not True, (
+            "Testcase {} : Failed \n".format(tc_name)
+            + "Expected behavior: non-matching route should not be present \n"
+            + "Error: {}".format(result)
+        )
+
+        step("Change to count=4, verify route is rejected (AS occurs 5 times > 4)")
+        input_dict_allowas_4 = {
+            "r3": {
+                "bgp": {
+                    "address_family": {
+                        addr_type: {
+                            "unicast": {
+                                "neighbor": {
+                                    "r2": {
+                                        "dest_link": {
+                                            "r3": {
+                                                "allowas-in": {
+                                                    "route_map": rmap_name,
+                                                    "number_occurences": 4,
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        result = create_router_bgp(tgen, topo, input_dict_allowas_4)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        logger.info("Verifying route is rejected with count=4")
+        result = verify_rib(
+            tgen,
+            addr_type,
+            dut,
+            input_dict_match,
+            protocol=protocol,
+            expected=False,
+        )
+        assert result is not True, (
+            "Testcase {} : Failed \n".format(tc_name)
+            + "Expected behavior: route should be rejected (AS count 5 > 4) \n"
+            + "Error: {}".format(result)
+        )
+
+    # Test removal: show route-map is additional filter
+    for addr_type in ADDR_TYPES:
+        step("Remove allowas-in route-map config")
+        rmap_name = rmap_names[addr_type]
+        input_dict_no_rmap = {
+            "r3": {
+                "bgp": {
+                    "address_family": {
+                        addr_type: {
+                            "unicast": {
+                                "neighbor": {
+                                    "r2": {
+                                        "dest_link": {
+                                            "r3": {
+                                                "allowas-in": {
+                                                    "route_map": rmap_name,
+                                                    "delete": True,
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        result = create_router_bgp(tgen, topo, input_dict_no_rmap)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("Verify routes rejected after removal")
+        logger.info("Verifying routes rejected")
+        result = verify_rib(
+            tgen,
+            addr_type,
+            dut,
+            input_dict_match,
+            protocol=protocol,
+            expected=False,
+        )
+        assert result is not True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+    write_test_footer(tc_name)
+
+
+def test_bgp_allowas_in_route_map_origin_p0(request):
+    """
+    Verify that allowas-in route-map with origin flag works correctly.
+
+    The origin flag accepts routes ONLY if last AS (originator) == our AS.
+    Combined with route-map for selective filtering.
+
+    Example AS-path evolution:
+      At R1 (AS 200): "200 200 200" (prepended twice)
+      At R2 (AS 100): prepends 100 → "100 200 200 200"
+      At R3 (AS 200): last AS = 200 (matches our AS)
+
+    Configuration on R3:
+      ip prefix-list PL_ORIGIN_V4 permit 192.0.2.0/24 le 32
+      ipv6 prefix-list PL_ORIGIN_V6 permit 2001:db8::/48 le 128
+      !
+      route-map RM_ORIGIN_V4 permit 10
+       match ip address prefix-list PL_ORIGIN_V4
+      route-map RM_ORIGIN_V4 deny 20
+      !
+      neighbor R2 allowas-in route-map RM_ORIGIN_V4 origin
+
+    Routes advertised from R1:
+      IPv4: 192.0.2.1/32 (matches), 198.51.100.1/32 (no match)
+      IPv6: 2001:db8::1/128 (matches), 2001:db9::1/128 (no match)
+
+    Expected behavior:
+      ACCEPTED: 192.0.2.1/32, 2001:db8::1/128 (origin AS=200 + match route-map)
+      REJECTED: 198.51.100.1/32, 2001:db9::1/128 (origin AS=200 but no match)
+
+    Removal test:
+      After removing allowas-in route-map origin: ALL routes rejected
+
+    Comparison with standard allowas-in count:
+      Without origin: Would need count >= 3 to accept (AS appears 3 times)
+      With origin: Skips occurrence check, only verifies origin AS + route-map
+    """
+
+    tc_name = request.node.name
+    write_test_header(tc_name)
+    tgen = get_topogen()
+    reset_config_on_routers(tgen)
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    dut = "r3"
+    protocol = "bgp"
+    network_match = {"ipv4": "192.0.2.1/32", "ipv6": "2001:db8::1/128"}
+    network_nomatch = {"ipv4": "198.51.100.1/32", "ipv6": "2001:db9::1/128"}
+    next_hop = {"ipv4": "Null0", "ipv6": "Null0"}
+
+    plist_names = {"ipv4": "PL_ORIGIN_V4", "ipv6": "PL_ORIGIN_V6"}
+    rmap_names = {"ipv4": "RM_ORIGIN_V4", "ipv6": "RM_ORIGIN_V6"}
+
+    # Configure route-map and allowas-in FIRST, then advertise routes
+    for addr_type in ADDR_TYPES:
+        step("Configure prefix-list and route-map on R3")
+        plist_name = plist_names[addr_type]
+        rmap_name = rmap_names[addr_type]
+
+        if addr_type == "ipv4":
+            match_network = "192.0.2.0/24"
+        else:
+            match_network = "2001:db8::/48"
+
+        input_dict_plist = {
+            "r3": {
+                "prefix_lists": {
+                    addr_type: {
+                        plist_name: [
+                            {
+                                "seqid": 5,
+                                "network": match_network,
+                                "le": "32" if addr_type == "ipv4" else "128",
+                                "action": "permit",
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        result = create_prefix_lists(tgen, input_dict_plist)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        input_dict_rmap = {
+            "r3": {
+                "route_maps": {
+                    rmap_name: [
+                        {
+                            "action": "permit",
+                            "seq_id": 10,
+                            "match": {addr_type: {"prefix_lists": plist_name}},
+                        },
+                        {
+                            "action": "deny",
+                            "seq_id": 20,
+                        },
+                    ]
+                }
+            }
+        }
+        result = create_route_maps(tgen, input_dict_rmap)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("Configure allowas-in route-map with origin flag on R3")
+        input_dict_allowas = {
+            "r3": {
+                "bgp": {
+                    "address_family": {
+                        addr_type: {
+                            "unicast": {
+                                "neighbor": {
+                                    "r2": {
+                                        "dest_link": {
+                                            "r3": {
+                                                "allowas-in": {
+                                                    "route_map": rmap_name,
+                                                    "origin": True,
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        result = create_router_bgp(tgen, topo, input_dict_allowas)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+    # Now advertise routes with origin AS 200
+    for addr_type in ADDR_TYPES:
+        static_routes = {
+            "r1": {
+                "static_routes": [
+                    {
+                        "network": network_match[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    },
+                    {
+                        "network": network_nomatch[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    },
+                ]
+            }
+        }
+
+        logger.info("Configure static routes")
+        result = create_static_routes(tgen, static_routes)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("configure redistribute static in Router BGP in R1")
+        input_dict_redist = {
+            "r1": {
+                "bgp": {
+                    "address_family": {
+                        addr_type: {
+                            "unicast": {"redistribute": [{"redist_type": "static"}]}
+                        }
+                    }
+                }
+            }
+        }
+        result = create_router_bgp(tgen, topo, input_dict_redist)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+    step("Configure route-map on R1 to prepend AS (last AS remains 200)")
+    for addr_type in ADDR_TYPES:
+        input_dict_prepend = {
+            "r1": {
+                "route_maps": {
+                    "ASP_ORIGIN_{}".format(addr_type): [
+                        {
+                            "action": "permit",
+                            "set": {
+                                "path": {
+                                    "as_num": "200 200",
+                                    "as_action": "prepend",
+                                }
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+        result = create_route_maps(tgen, input_dict_prepend)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("Apply prepend route-map on R1")
+        input_dict_rmap_out = {
+            "r1": {
+                "bgp": {
+                    "address_family": {
+                        addr_type: {
+                            "unicast": {
+                                "neighbor": {
+                                    "r2": {
+                                        "dest_link": {
+                                            "r1": {
+                                                "route_maps": [
+                                                    {
+                                                        "name": "ASP_ORIGIN_{}".format(
+                                                            addr_type
+                                                        ),
+                                                        "direction": "out",
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        result = create_router_bgp(tgen, topo, input_dict_rmap_out)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+    for addr_type in ADDR_TYPES:
+        step("Verify matching route accepted (matches route-map + origin AS)")
+        input_dict_match = {
+            "r1": {
+                "static_routes": [
+                    {
+                        "network": network_match[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    }
+                ]
+            }
+        }
+        result = verify_rib(tgen, addr_type, dut, input_dict_match, protocol=protocol)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("Verify non-matching route rejected (route-map denies)")
+        input_dict_nomatch = {
+            "r1": {
+                "static_routes": [
+                    {
+                        "network": network_nomatch[addr_type],
+                        "next_hop": next_hop[addr_type],
+                    }
+                ]
+            }
+        }
+        logger.info("Verifying non-matching route is not present on r3")
+        result = verify_rib(
+            tgen,
+            addr_type,
+            dut,
+            input_dict_nomatch,
+            protocol=protocol,
+            expected=False,
+        )
+        assert result is not True, (
+            "Testcase {} : Failed \n".format(tc_name)
+            + "Expected behavior: non-matching route should not be present \n"
+            + "Error: {}".format(result)
+        )
+
+    # Test configuration removal
+    for addr_type in ADDR_TYPES:
+        step("Remove allowas-in route-map origin, verify all routes rejected")
+        rmap_name = rmap_names[addr_type]
+        input_dict_no_allowas = {
+            "r3": {
+                "bgp": {
+                    "address_family": {
+                        addr_type: {
+                            "unicast": {
+                                "neighbor": {
+                                    "r2": {
+                                        "dest_link": {
+                                            "r3": {
+                                                "allowas-in": {
+                                                    "route_map": rmap_name,
+                                                    "delete": True,
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        result = create_router_bgp(tgen, topo, input_dict_no_allowas)
+        assert result is True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
+        step("Verify routes rejected after removal")
+        logger.info("Verifying routes rejected")
+        result = verify_rib(
+            tgen,
+            addr_type,
+            dut,
+            input_dict_match,
+            protocol=protocol,
+            expected=False,
+        )
+        assert result is not True, "Testcase {} : Failed \n Error: {}".format(
+            tc_name, result
+        )
+
     write_test_footer(tc_name)
 
 

--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -1162,9 +1162,28 @@ def __create_bgp_unicast_address_family(
 
             if allowas_in:
                 number_occurences = allowas_in.setdefault("number_occurences", {})
+                route_map = allowas_in.setdefault("route_map", None)
+                origin = allowas_in.setdefault("origin", False)
                 del_action = allowas_in.setdefault("delete", False)
 
-                cmd = "{} allowas-in {}".format(neigh_cxt, number_occurences)
+                if route_map:
+                    # allowas-in route-map NAME [<1-10>|origin]
+                    if origin:
+                        cmd = "{} allowas-in route-map {} origin".format(
+                            neigh_cxt, route_map
+                        )
+                    else:
+                        cmd = "{} allowas-in route-map {} {}".format(
+                            neigh_cxt,
+                            route_map,
+                            number_occurences if number_occurences else "",
+                        ).strip()
+                else:
+                    # Standard allowas-in [<1-10>|origin]
+                    if origin:
+                        cmd = "{} allowas-in origin".format(neigh_cxt)
+                    else:
+                        cmd = "{} allowas-in {}".format(neigh_cxt, number_occurences)
 
                 if del_action:
                     cmd = "no {}".format(cmd)


### PR DESCRIPTION
Extends allowas-in to support route-map filtering, providing maximum flexibility for selective AS-path loop prevention based on any BGP attributes (prefixes, communities, AS-path patterns, etc.).

**New Commands:**
```
  neighbor <PEER> allowas-in route-map <NAME> [<1-10>|origin]
  no neighbor <PEER> allowas-in route-map [<NAME> [<1-10>|origin]]
```

**Configuration Example:**
```
  ip prefix-list PL_P2P seq 5 permit 0.0.0.0/0 ge 31 le 31
  !
  route-map RM_ALLOWAS_P2P permit 10
   match ip address prefix-list PL_P2P
  !
  route-map RM_ALLOWAS_P2P deny 20
  !
  router bgp 65201
   address-family ipv4 unicast
    neighbor 10.0.0.1 allowas-in route-map RM_ALLOWAS_P2P 1
```

**Testing:**

```
Before configuration:

   address-family ipv4 unicast
    neighbor fabric soft-reconfiguration inbound
    neighbor fabric maximum-prefix 12000
    neighbor 220.8.0.34 soft-reconfiguration inbound
    neighbor 220.8.0.34 maximum-prefix 12000
    neighbor 220.12.0.1 soft-reconfiguration inbound
    neighbor 220.12.0.1 maximum-prefix 12000
    neighbor 220.12.0.1 allowas-in 1
    neighbor 220.13.0.1 soft-reconfiguration inbound
    neighbor 220.13.0.1 maximum-prefix 12000
    neighbor 220.13.0.1 allowas-in 1
    maximum-paths 64
    maximum-paths ibgp 64
   exit-address-family

  s11# show bgp ipv4 unicast
  BGP table version is 5, local router ID is 6.0.0.8, vrf id 0
  Default local pref 100, local AS 65201
  Status codes:  s suppressed, d damped, h history, u unsorted, * valid, > best, = multipath
                 i internal, r RIB-failure, S Stale, R Removed
  Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
  Origin codes:  i - IGP, e - EGP, ? - incomplete
  RPKI validation codes: V valid, I invalid, N Not found

      Network          Next Hop            Metric LocPrf Weight Path
   *> 1.1.1.1/32       220.8.0.34(l11)
                                               0             0 65011 i
   *                   220.12.0.1(ss1)
                                                             0 65300 65201 65012 i
   *                   220.13.0.1(ss2)
                                                             0 65300 65201 65012 i
   *> 2.2.2.2/32       220.12.0.1(ss1)
                                                             0 65300 65202 65021 i
   *=                  220.13.0.1(ss2)
                                                             0 65300 65202 65021 i
   *> 3.3.3.0/24       220.8.0.34(l11)
                                               0             0 65011 ?
   *                   220.12.0.1(ss1)
                                                             0 65300 65201 65012 ?
   *                   220.13.0.1(ss2)
                                                             0 65300 65201 65012 ?
   *> 3.3.3.4/31       220.12.0.1(ss1)
                                                             0 65300 65201 65012 ?
   *=                  220.13.0.1(ss2)
                                                             0 65300 65201 65012 ?
   *> 4.4.4.0/24       220.12.0.1(ss1)
                                                             0 65300 65202 65021 ?
   *=                  220.13.0.1(ss2)
                                                             0 65300 65202 65021 ?

  Displayed 5 routes and 12 total paths

After configuration:

  ip prefix-list PL_HOST_ROUTES seq 5 permit 0.0.0.0/0 ge 31 le 31

   address-family ipv4 unicast
    bgp nhg-per-origin
    neighbor fabric soft-reconfiguration inbound
    neighbor fabric maximum-prefix 12000
    neighbor 220.8.0.34 soft-reconfiguration inbound
    neighbor 220.8.0.34 maximum-prefix 12000
    neighbor 220.12.0.1 soft-reconfiguration inbound
    neighbor 220.12.0.1 maximum-prefix 12000
    neighbor 220.12.0.1 allowas-in route-map RM_ALLOWAS_HOST_ROUTES 1
    neighbor 220.13.0.1 soft-reconfiguration inbound
    neighbor 220.13.0.1 maximum-prefix 12000
    neighbor 220.13.0.1 allowas-in route-map RM_ALLOWAS_HOST_ROUTES 1
    maximum-paths 64
    maximum-paths ibgp 64
   exit-address-family

   route-map RM_ALLOWAS_HOST_ROUTES permit 10
   description Allow AS for /31 point-to-point links
   match ip address prefix-list PL_HOST_ROUTES
  !
  route-map RM_ALLOWAS_HOST_ROUTES deny 20
   description Deny all others - strict AS-path check
  !

  s11# show bgp ipv4 unicast
  BGP table version is 7, local router ID is 6.0.0.8, vrf id 0
  Default local pref 100, local AS 65201
  Status codes:  s suppressed, d damped, h history, u unsorted, * valid, > best, = multipath, + multipath nhg,
                 i internal, r RIB-failure, S Stale, R Removed
  Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
  Origin codes:  i - IGP, e - EGP, ? - incomplete
  RPKI validation codes: V valid, I invalid, N Not found

      Network          Next Hop            Metric LocPrf Weight Path
   *> 1.1.1.1/32       220.8.0.34(l11)
                                               0             0 65011 i
   *> 2.2.2.2/32       220.12.0.1(ss1)
                                                             0 65300 65202 65021 i
   *+                  220.13.0.1(ss2)
                                                             0 65300 65202 65021 i
   *> 3.3.3.0/24       220.8.0.34(l11)
                                               0             0 65011 ?
   *> 3.3.3.4/31       220.12.0.1(ss1)
                                                             0 65300 65201 65012 ?
   *=                  220.13.0.1(ss2)
                                                             0 65300 65201 65012 ?
   *> 4.4.4.0/24       220.12.0.1(ss1)
                                                             0 65300 65202 65021 ?
   *+                  220.13.0.1(ss2)
                                                             0 65300 65202 65021 ?

  Displayed 5 routes and 8 total paths
```

Signed-off-by: Karthikeya Venkat Muppalla <kmuppalla@nvidia.com>