### PR TITLE
yang: Correct pyang errors in frr-pim.yang

### DIFF
--- a/yang/frr-pim.yang
+++ b/yang/frr-pim.yang
@@ -80,10 +80,14 @@ module frr-pim {
 
   typedef plist-ref {
     type string;
+    description
+      "Reference to a policy list.";
   }
 
   typedef access-list-ref {
     type string;
+    description
+      "Reference to an access list.";
   }
 
   /*
@@ -132,6 +136,9 @@ module frr-pim {
    */
 
   grouping msdp-timers {
+    description
+      "Grouping for MSDP timer configurations.";
+
     leaf hold-time {
       type uint16 {
         range "1..max";
@@ -195,8 +202,8 @@ module frr-pim {
 
     leaf authentication-key {
       when "../authentication-type = 'MD5'";
-      mandatory true;
       type string;
+      mandatory true;
       description
         "Authentication key.";
     }
@@ -387,6 +394,9 @@ module frr-pim {
       list members {
         key "address";
 
+        description
+          "List of peer members associated with the configuration.";
+
         leaf address {
           type inet:ip-address;
           description
@@ -407,8 +417,8 @@ module frr-pim {
       }
 
       leaf source-ip {
-        mandatory true;
         type inet:ip-address;
+        mandatory true;
         description
           "MSDP source IP address.";
       }
@@ -441,8 +451,11 @@ module frr-pim {
     }
 
     container mlag {
-      presence
-        "Multi-chassis link aggregation.";
+     presence
+       "Multi-chassis link aggregation.";
+
+     description
+       "Configuration for mlag on the interface.";
 
      leaf peerlink-rif {
         type frr-interface:interface-ref;
@@ -603,6 +616,9 @@ module frr-pim {
       presence
         "Enable BFD support on the interface.";
 
+      description
+        "Configuration for BFD on the interface.";
+
       leaf min-rx-interval {
         type uint16 {
           range "1..max";
@@ -742,6 +758,8 @@ module frr-pim {
    */
   augment "/frr-rt:routing/frr-rt:control-plane-protocols/"
         + "frr-rt:control-plane-protocol" {
+    description
+      "Augments the control plane protocol configuration to support pim configuration.";
     container pim {
       when "../frr-rt:type = 'frr-pim:pimd'" {
         description
@@ -765,7 +783,11 @@ module frr-pim {
    * Per-interface configuration data
    */
   augment "/frr-interface:lib/frr-interface:interface" {
+    description
+      "Augments the interface configuration to support pim configuration.";
     container pim {
+      description
+        "Configuration for pim on the interface.";
       list address-family {
         key "address-family";
         description


### PR DESCRIPTION
Correct pyang errors in frr-pim.yang

frr-pim.yang:81: error: RFC 8407: 4.13,4.14: statement "typedef" must have a "description" substatement
frr-pim.yang:85: error: RFC 8407: 4.13,4.14: statement "typedef" must have a "description" substatement
frr-pim.yang:134: error: RFC 8407: 4.14: statement "grouping" must have a "description" substatement
frr-pim.yang:198: error: keyword "mandatory" not in canonical order, expected "type" (see RFC 7950, Section 14)
frr-pim.yang:199: error: keyword "type" not in canonical order (see RFC 7950, Section 14)
frr-pim.yang:387: error: RFC 8407: 4.14: statement "list" must have a "description" substatement
frr-pim.yang:410: error: keyword "mandatory" not in canonical order, expected "type" (see RFC 7950, Section 14)
frr-pim.yang:411: error: keyword "type" not in canonical order (see RFC 7950, Section 14)
frr-pim.yang:443: error: RFC 8407: 4.14: statement "container" must have a "description" substatement
frr-pim.yang:602: error: RFC 8407: 4.14: statement "container" must have a "description" substatement
frr-pim.yang:744: error: RFC 8407: 4.14: statement "augment" must have a "description" substatement
frr-pim.yang:767: error: RFC 8407: 4.14: statement "augment" must have a "description" substatement
frr-pim.yang:768: error: RFC 8407: 4.14: statement "container" must have a "description" substatement