### PR TITLE
bgpd: use BGP_PATH_INFO_NUM_LABELS macro in bgp_evpn_path_info_get_l3vni

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -8289,20 +8289,13 @@ mpls_label_t *bgp_evpn_path_info_labels_get_l3vni(mpls_label_t *labels,
  */
 vni_t bgp_evpn_path_info_get_l3vni(const struct bgp_path_info *pi)
 {
-	if (!pi->extra)
+	if (!BGP_PATH_INFO_NUM_LABELS(pi))
 		return 0;
 
-	mpls_label_t *label = bgp_evpn_path_info_labels_get_l3vni(pi->extra->labels->label,
-								  pi->extra->labels->num_labels);
-	if (!label) {
-		/* Shouldn't happen: label not found in pi->extra */
-		flog_err(EC_BGP_PATH_WITHOUT_LABEL,
-			 "%s: path_info without label stack, label=%p, num_labels=%d", __func__,
-			 pi->extra->labels->label, pi->extra->labels->num_labels);
-		return 0;
-	}
-
-	return label2vni(label);
+	return label2vni(
+		bgp_evpn_path_info_labels_get_l3vni(pi->extra->labels->label,
+						    pi->extra->labels
+							    ->num_labels));
 }
 
 /*


### PR DESCRIPTION
Commit a932abc105b5 ("bgpd: do not crash when labels are empty") attempted to fix a crash by adding a NULL check on the return value of bgp_evpn_path_info_labels_get_l3vni(). However, this still accesses pi->extra->labels->label without first verifying that pi->extra->labels is non-NULL, which can lead to a crash.

Use the BGP_PATH_INFO_NUM_LABELS() macro as a guard instead, which properly validates the entire chain (pi, pi->extra, pi->extra->labels) before accessing the label data. This follows the established pattern used throughout the codebase for safe label access, and simplifies the code back to its original form while correctly addressing the issue.

Signed-off-by: Nick Bouliane <nbouliane@coreweave.com>