### PR TITLE
bgpd,zebra: EVPNv6 addressing coverity warnings

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3374,7 +3374,10 @@ static int bgp_zebra_process_local_l3vni(ZAPI_CALLBACK_ARGS)
 	l3vni = stream_getl(s);
 	if (cmd == ZEBRA_L3VNI_ADD) {
 		stream_get(&svi_rmac, s, sizeof(struct ethaddr));
-		stream_get_ipaddr(s, &originator_ip);
+		if (!stream_get_ipaddr(s, &originator_ip)) {
+			zlog_err("Unable to read originator ip address from stream");
+			return 0;
+		}
 		stream_get(&filter, s, sizeof(int));
 		svi_ifindex = stream_getl(s);
 		stream_get(&vrr_rmac, s, sizeof(struct ethaddr));
@@ -3411,7 +3414,7 @@ static int bgp_zebra_process_local_vni(ZAPI_CALLBACK_ARGS)
 	struct stream *s;
 	vni_t vni;
 	struct bgp *bgp;
-	struct ipaddr vtep_ip = {0};
+	struct ipaddr vtep_ip = { .ipa_type = IPADDR_NONE };
 	vrf_id_t tenant_vrf_id = VRF_DEFAULT;
 	struct in_addr mcast_grp = {INADDR_ANY};
 	ifindex_t svi_ifindex = 0;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -5598,7 +5598,7 @@ enum zebra_dplane_result dplane_local_mac_add(const struct interface *ifp,
 {
 	enum zebra_dplane_result result;
 	uint32_t update_flags = 0;
-	struct ipaddr vtep_ip = {};
+	struct ipaddr vtep_ip = { .ipa_type = IPADDR_NONE };
 
 	if (set_static)
 		update_flags |= DPLANE_MAC_SET_STATIC;
@@ -5621,7 +5621,7 @@ dplane_local_mac_del(const struct interface *ifp,
 		     const struct ethaddr *mac)
 {
 	enum zebra_dplane_result result;
-	struct ipaddr vtep_ip = {};
+	struct ipaddr vtep_ip = { .ipa_type = IPADDR_NONE };
 
 	/* Use common helper api */
 	result = mac_update_common(DPLANE_OP_MAC_DELETE, ifp, bridge_ifp, vid, mac, 0, &vtep_ip,

--- a/zebra/zebra_evpn_mac.c
+++ b/zebra/zebra_evpn_mac.c
@@ -2156,7 +2156,7 @@ int zebra_evpn_add_update_local_mac(struct zebra_vrf *zvrf,
 	bool inform_client = false;
 	bool upd_neigh = false;
 	bool is_dup_detect = false;
-	struct ipaddr vtep_ip = { 0 };
+	struct ipaddr vtep_ip = { .ipa_type = IPADDR_NONE };
 	bool es_change = false;
 	bool new_bgp_ready;
 	/* assume inactive if not present or if not local */

--- a/zebra/zebra_evpn_neigh.c
+++ b/zebra/zebra_evpn_neigh.c
@@ -1309,7 +1309,7 @@ int zebra_evpn_local_neigh_update(struct zebra_evpn *zevpn,
 	bool neigh_on_hold = false;
 	bool neigh_was_remote = false;
 	bool do_dad = false;
-	struct ipaddr vtep_ip = { 0 };
+	struct ipaddr vtep_ip = { .ipa_type = IPADDR_NONE };
 	bool inform_dataplane = false;
 	bool created = false;
 	bool new_static = false;

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3360,6 +3360,8 @@ DEFPY (show_evpn_mac_vni_all_vtep,
 		return CMD_WARNING;
 	}
 	zvrf = zebra_vrf_get_evpn();
+	assert(zvrf);
+
 	zebra_vxlan_print_macs_all_vni_vtep(vty, zvrf, &vtep_ip, uj);
 
 	return CMD_SUCCESS;


### PR DESCRIPTION
Fixed coverity warnings in evpnv6 code
UNINIT
UNINIT_VAR
MISSING_INITIALIZATION
NULL_RETURNS
