### PR TITLE
ospf6d: Fix FULL adjacency persisting despite MTU mismatch

### DIFF
--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -244,6 +244,7 @@ extern struct ospf6_interface *
 ospf6_interface_lookup_by_ifindex(ifindex_t, vrf_id_t vrf_id);
 extern struct ospf6_interface *ospf6_interface_create(struct interface *ifp);
 extern void ospf6_interface_delete(struct ospf6_interface *oi);
+extern void ospf6_interface_reset(struct interface *ifp);
 
 extern void ospf6_interface_enable(struct ospf6_interface *oi);
 extern void ospf6_interface_disable(struct ospf6_interface *oi);


### PR DESCRIPTION
In ospfd(OSPFv2), any MTU change immediately triggers a new DBD exchange, causing the adjacency to revert to ExStart.
But OSPFv3 does not react to MTU changes,  allowing adjacencies to remain in FULL state even when MTUs no longer matched.
This could lead to operational inconsistencies and protocol issues.

Implemented automatic neighbor reset when an interface MTU is modified after the adjacency has already reached FULL state - bringing OSPFv3 behavior in line with OSPFv2.

Testing:
1. Added test_ospfv3_tc5_mtu_auto_change_p0 test
2. Verified the fix on real switch setup.