### PR TITLE
*: Wide ncurses support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1497,7 +1497,7 @@ case "${enable_vtysh}" in
   ], [
     dnl readline failed - it might be incorrectly linked and missing its
     dnl termcap/tinfo/curses dependency.  see if we can fix that...
-    AC_SEARCH_LIBS([tputs], [termcap tinfo curses ncurses], [
+    AC_SEARCH_LIBS([tputs], [termcap tinfo curses ncurses ncursesw], [
       LIBREADLINE="$ac_cv_search_tputs"
     ], [
       AC_MSG_ERROR([libreadline (needed for vtysh) not found and/or missing dependencies])


### PR DESCRIPTION
Add support for ncursesw in configure
Wide ncurses is the default when compiling the ncurses library. Frr will fail to configure and compile unless this is supported