### PR TITLE
bfdd: early return on socket allocation failure

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -1790,8 +1790,10 @@ int bp_echo_socket(const struct vrf *vrf)
 			       vrf->name);
 	}
 
-	if (s == -1)
+	if (s == -1) {
 		zlog_err("echo-socket: socket: %s", strerror(errno));
+		return -1;
+	}
 
 	struct sock_fprog pf;
 	struct sockaddr_ll sll = {0};
@@ -1828,8 +1830,10 @@ int bp_echo_socket(const struct vrf *vrf)
 	frr_with_privs(&bglobal.bfdd_privs) {
 		s = vrf_socket(AF_INET, SOCK_DGRAM, 0, vrf->vrf_id, vrf->name);
 	}
-	if (s == -1)
+	if (s == -1) {
 		zlog_err("echo-socket: socket: %s", strerror(errno));
+		return -1;
+	}
 
 	bp_set_ipopts(s);
 	bp_bind_ip(s, BFD_DEF_ECHO_PORT);


### PR DESCRIPTION
Return early if vrf_socket() fails. This prevents redundant error logs caused by subsequent attempts to set options or bind to an invalid (-1) socket descriptor.