### PR TITLE
bgpd: fix compilation warnings in bgp_pi_hash

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -174,6 +174,20 @@ uint32_t bgp_pi_hash_hashfn(const struct bgp_path_info *pi)
 	return h;
 }
 
+// coverity[INFINITE_LOOP]  // Suppress false positive
+// coverity[PW.NON_CONST_PRINTF_FORMAT_STRING]  // Suppress false positive
+DECLARE_HASH(bgp_pi_hash, struct bgp_path_info, pi_hash_link, bgp_pi_hash_cmp, bgp_pi_hash_hashfn);
+
+void bgp_pi_hash_table_init(struct bgp_pi_hash_head *h)
+{
+	bgp_pi_hash_init(h);
+}
+
+void bgp_pi_hash_table_fini(struct bgp_pi_hash_head *h)
+{
+	bgp_pi_hash_fini(h);
+}
+
 static inline char *bgp_route_dump_path_info_flags(struct bgp_path_info *pi,
 						   char *buf, size_t len)
 {

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -746,7 +746,8 @@ DECLARE_HOOK(bgp_route_update,
 extern int bgp_pi_hash_cmp(const struct bgp_path_info *p1, const struct bgp_path_info *p2);
 extern uint32_t bgp_pi_hash_hashfn(const struct bgp_path_info *pi);
 
-DECLARE_HASH(bgp_pi_hash, struct bgp_path_info, pi_hash_link, bgp_pi_hash_cmp, bgp_pi_hash_hashfn);
+extern void bgp_pi_hash_table_init(struct bgp_pi_hash_head *h);
+extern void bgp_pi_hash_table_fini(struct bgp_pi_hash_head *h);
 
 /* BGP show options */
 #define BGP_SHOW_OPT_JSON (1 << 0)

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -34,7 +34,7 @@ void bgp_table_unlock(struct bgp_table *rt)
 	}
 
 	/* Cleanup pi_hash in bgp_table */
-	bgp_pi_hash_fini(&rt->pi_hash);
+	bgp_pi_hash_table_fini(&rt->pi_hash);
 
 	route_table_finish(rt->route_table);
 	rt->route_table = NULL;
@@ -170,7 +170,7 @@ struct bgp_table *bgp_table_init(struct bgp *bgp, afi_t afi, safi_t safi)
 	bgp_table_lock(rt);
 	rt->afi = afi;
 	rt->safi = safi;
-	bgp_pi_hash_init(&rt->pi_hash);
+	bgp_pi_hash_table_init(&rt->pi_hash);
 
 	return rt;
 }


### PR DESCRIPTION
Move DECLARE_HASH from header to bgp_route.c and add wrapper functions for cross-file usage, eliminating warnings from assert() macros in inline functions.