### PR TITLE
bgpd: Fix EVPN-MH route cleanup race condition during interfaces flap

### DIFF
--- a/bgpd/bgp_evpn_mh.c
+++ b/bgpd/bgp_evpn_mh.c
@@ -3284,8 +3284,22 @@ void bgp_evpn_es_evi_vrf_ref(struct bgpevpn *vpn)
 	if (BGP_DEBUG(evpn_mh, EVPN_MH_ES))
 		zlog_debug("es-vrf ref for vni %u", vpn->vni);
 
-	RB_FOREACH (es_evi, bgp_es_evi_rb_head, &vpn->es_evi_rb_tree)
+	RB_FOREACH (es_evi, bgp_es_evi_rb_head, &vpn->es_evi_rb_tree) {
 		bgp_evpn_es_vrf_ref(es_evi, vpn->bgp_vrf);
+
+		/* Now that the VRF is updated for the ES-EVI, check if any local
+		 * route cleanup is required which was deferred earlier when the
+		 * VRF was not updated during local ESI creation.
+		 */
+		if (CHECK_FLAG(es_evi->flags, BGP_EVPNES_EVI_SWEEP_LOCAL_ROUTES) && es_evi->es_vrf) {
+			if (BGP_DEBUG(evpn_mh, EVPN_MH_RT))
+				zlog_debug("es %s vni %u: executing deferred route cleanup for vrf %s",
+					   es_evi->es->esi_str, vpn->vni,
+					   vpn->bgp_vrf->name_pretty);
+			UNSET_FLAG(es_evi->flags, BGP_EVPNES_EVI_SWEEP_LOCAL_ROUTES);
+			bgp_evpn_local_es_evi_uninstall_local_routes_in_vrfs(es_evi->es, es_evi);
+		}
+	}
 }
 
 /* 1. If ES-VRF is not present install the host route with the exploded/flat
@@ -5278,8 +5292,14 @@ void bgp_evpn_local_es_evi_uninstall_local_routes_in_vrfs(struct bgp_evpn_es *es
 	const struct prefix_evpn *evp;
 	struct bgp_evpn_es_vrf *es_vrf = es_evi->es_vrf;
 
-	if (!es_vrf)
+	if (!es_vrf) {
+		/* VRF not available yet, mark for deferred cleanup once the VRF is updated */
+		if (BGP_DEBUG(evpn_mh, EVPN_MH_RT))
+			zlog_debug("es %s vni %u: VRF not available, marking for deferred route cleanup",
+				   es->esi_str, es_evi->vpn->vni);
+		SET_FLAG(es_evi->flags, BGP_EVPNES_EVI_SWEEP_LOCAL_ROUTES);
 		return;
+	}
 
 	for (ALL_LIST_ELEMENTS_RO(es->macip_global_path_list, node, es_info)) {
 		pi = es_info->pi;

--- a/bgpd/bgp_evpn_mh.h
+++ b/bgpd/bgp_evpn_mh.h
@@ -225,6 +225,8 @@ struct bgp_evpn_es_evi {
 /* created via a remote VTEP imported by BGP */
 #define BGP_EVPNES_EVI_REMOTE           (1 << 1)
 #define BGP_EVPNES_EVI_INCONS_VTEP_LIST (1 << 2)
+/* deferred route cleanup needed when VRF becomes available */
+#define BGP_EVPNES_EVI_SWEEP_LOCAL_ROUTES (1 << 3)
 
 	/* memory used for adding the es_evi to es_evi->vpn->es_evi_rb_tree */
 	RB_ENTRY(bgp_evpn_es_evi) rb_node;


### PR DESCRIPTION
**Issue:**
In EVPN-MH setup, when all the interfaces are flapped(using 'ifdown/ifup'), the VTEP ends up having stale route entries(via vxlan) to the multi-homed hosts even though they are connected MH hosts.

The events sequencing is as below:
ifdown br_default:
 - Brings down all the host facing interfaces/vni/es
 - So, new route entries(via vxlan) created for the hosts, because the multi-homed hosts(before ifdown) are not connected hosts now.

ifup br_default:
 - The ES becomes active now.
 - We should clear/uninstall the above created routes as the hosts are multi-homed now. This does not happen.
 - This is because of the events sequencing where a local ES add event arrives bgpd before before the VNI-VRF association becomes available.
 - When this happens, the current code that handles the es_evi add is skipping the unistall_local_routes (bgp_evpn_local_es_evi_add->bgp_evpn_local_es_evi_unistall_local_routes_in_vrfs).
 - This is because the explicit check 'if(es_evi->es_vrf)' fails in this path as the VRF mapping is not yet received.
 - Also, we never go for an attempt to clear the global routes in the same ES when the 'es_evi->es_vrf' mapping is received later.
 - So, This causes stale routes in the system and traffic drop as well.

**Fix:**
Add 'sweep_local_routes' flag in es-evi to track when cleanup is needed but VRF is not yet available.
Once we receive vni-vrf update, clean up the local routes that were installed earlier for remote ES(now local ES hosts).