### PR TITLE
Docs: Document `import vrf route-map NAME`, several EVPN improvements

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -3637,6 +3637,36 @@ EVPN BUM Handling
    When ``disable`` is configured, BUM traffic will not be flooded for an arbitrary
    VNI or globally.
 
+
+.. _bgp-evpn-downstream-vni:
+
+EVPN Downstream VNI
+^^^^^^^^^^^^^^^^^^^
+
+EVPN Downstream VNI is a feature that allows the destination (egress) VTEP to
+dictate which VNI the source (ingress) VTEP should use when sending traffic to it
+destined to a certain IP-VRF. This allows easy building of flexible VPN topologies.
+
+Without EVPN Downstream VNI, you must painstakingly configure the same VNI for all
+relevant VRFs across all devices.
+
+With Downstream VNI, the "destination" VNI is simply extracted from the advertised routes
+(MPLS Label 2 Route Type 2, MPLS Label for Route Type 5).
+
+Imagine a scenario where you have hundreds of VRFs and want to leak routes between them.
+
+Without Downstream VNI, you would have to configure all VRFs that you might want to leak from
+on all devices, and you would have to make sure to use the same VNI per VRF across all devices.
+This is a recipe for misconfiguration and operational complexity.
+
+With Downstream VNI, you can simply configure import Route Targets on the VRFs you want to leak to
+(and of course the export Route Targets on the VRFs you want to leak from),
+and the destination VNI will be automatically extracted from the imported routes
+and used as the source VNI for sending traffic to the destination IP-VRF.
+
+Note that in FRR, Downstream VNI requires the use of single VXLAN devices (SVD)
+for the dataplane and will not work with traditional VXLAN devices.
+
 .. _bgp-evpn-ip-vrf-route-targets:
 
 EVPN IP-VRF Route Targets


### PR DESCRIPTION
This PR improves the docs in the following way:
- Document `import vrf route-map NAME` (closes #20646)
- Document EVPN MAC-VRF / L2VNI Route Targets (`router bgp <AS> address-family l2vpn evpn vni <vni> route-target ...`, closes #20503)
- Improved docs for EVPN IP-VRF Route Targets
- Improved docs for EVPN `advertise-all-vni`
- Smaller format fixes for EVPN docs