### PR TITLE
*: configure.ac - accept localstatedir from user input

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,15 +57,13 @@ frr_sysconfdir="\${sysconfdir}/frr"
 AC_MSG_CHECKING([whether --localstatedir option is FRR-specific])
 case "$localstatedir" in
   */run/frr)
-    AC_MSG_RESULT([yes, ends in /run/frr - removing suffix])
+    AC_MSG_RESULT([yes, ends in /run/frr])
     AC_MSG_WARN([Please remove /run/frr suffix from --localstatedir=${localstatedir} (it should be /var in 99% of cases)])
-    localstatedir="${localstatedir%/run/frr}"
     path_warn_banner=true
     ;;
   */frr)
-    AC_MSG_RESULT([yes, ends in /frr - removing suffix])
+    AC_MSG_RESULT([yes, ends in /frr])
     AC_MSG_WARN([The --localstatedir=${localstatedir} option seems to include /frr but not /run, this is unexpected.  Please check for consistency.)])
-    localstatedir="${localstatedir%/frr}"
     path_warn_banner=true
     ;;
   *)


### PR DESCRIPTION
Systems using path seperation for applications cannot properly compile from user specified localstatedir when the path ends with /frr. This path is typically used because the application itself is called frr. Instead of configure removing the /frr from localstatedir, just give a warning and let the user decide.

Example: our systems always use /var/app/application_name as the localestatedir prefix