### PR TITLE
zebra: event fd_poll timeout fix

### DIFF
--- a/lib/event.c
+++ b/lib/event.c
@@ -818,32 +818,8 @@ static int fd_poll(struct event_loop *m, const struct timeval *timer_wait,
 	unsigned char trash[64];
 	nfds_t count = m->handler.copycount;
 
-	/*
-	 * If timer_wait is null here, that means poll() should block
-	 * indefinitely, unless the event_master has overridden it by setting
-	 * ->selectpoll_timeout.
-	 *
-	 * If the value is positive, it specifies the maximum number of
-	 * milliseconds to wait. If the timeout is -1, it specifies that
-	 * we should never wait and always return immediately even if no
-	 * event is detected. If the value is zero, the behavior is default.
-	 */
-	int timeout = -1;
-
 	/* number of file descriptors with events */
 	int num;
-
-	if (timer_wait != NULL && m->selectpoll_timeout == 0) {
-		/* use the default value */
-		timeout = (timer_wait->tv_sec * 1000)
-			  + (timer_wait->tv_usec / 1000);
-	} else if (m->selectpoll_timeout > 0) {
-		/* use the user's timeout */
-		timeout = m->selectpoll_timeout;
-	} else if (m->selectpoll_timeout < 0) {
-		/* effect a poll (return immediately) */
-		timeout = 0;
-	}
 
 	zlog_tls_buffer_flush();
 	rcu_read_unlock();
@@ -881,16 +857,53 @@ static int fd_poll(struct event_loop *m, const struct timeval *timer_wait,
 #if defined(HAVE_PPOLL)
 	struct timespec ts, *tsp;
 
-	if (timeout >= 0) {
-		ts.tv_sec = timeout / 1000;
-		ts.tv_nsec = (timeout % 1000) * 1000000;
+	if (timer_wait != NULL && m->selectpoll_timeout == 0) {
+		/* use the default value */
+		ts.tv_sec = timer_wait->tv_sec;
+		ts.tv_nsec = timer_wait->tv_usec * 1000;
 		tsp = &ts;
-	} else
+	} else if (m->selectpoll_timeout > 0) {
+		/* use the user's timeout */
+		ts.tv_sec = m->selectpoll_timeout / 1000;
+		ts.tv_nsec = (m->selectpoll_timeout % 1000) * 1000000;
+		tsp = &ts;
+	} else if (m->selectpoll_timeout == 0) {
+		/* ifinite timeout */
 		tsp = NULL;
+	} else {
+		/* effect a poll (return immediately) */
+		bzero(&ts, sizeof(ts));
+		tsp = &ts;
+	}
 
 	num = ppoll(m->handler.copy, count + 1, tsp, &origsigs);
 	pthread_sigmask(SIG_SETMASK, &origsigs, NULL);
 #else
+
+	/*
+	 * If timer_wait is null here, that means poll() should block
+	 * indefinitely, unless the event_master has overridden it by setting
+	 * ->selectpoll_timeout.
+	 *
+	 * If the value is positive, it specifies the maximum number of
+	 * milliseconds to wait. If the timeout is -1, it specifies that
+	 * we should never wait and always return immediately even if no
+	 * event is detected. If the value is zero, the behavior is default.
+	 */
+	int timeout = -1;
+
+	if (timer_wait != NULL && m->selectpoll_timeout == 0) {
+		/* use the default value */
+		timeout = (timer_wait->tv_sec * 1000)
+			  + (timer_wait->tv_usec / 1000);
+	} else if (m->selectpoll_timeout > 0) {
+		/* use the user's timeout */
+		timeout = m->selectpoll_timeout;
+	} else if (m->selectpoll_timeout < 0) {
+		/* effect a poll (return immediately) */
+		timeout = 0;
+	}
+	
 	/* Not ideal - there is a race after we restore the signal mask */
 	pthread_sigmask(SIG_SETMASK, &origsigs, NULL);
 	num = poll(m->handler.copy, count + 1, timeout);


### PR DESCRIPTION
There is a usec to nsec calculation error when using ppoll causing ppoll to run without a timeout which in turn causes high cpu usage. I think the timeout specified by the caller of fd_poll() in lib/event.c is pretty low which causes too frequent calls to ppoll, but at least it is now blocking instead of returning immedeately


reduces problem with zebra and issue #20649