### PR TITLE
zebra: rename BondState to State in 'show evpn es' output

### DIFF
--- a/zebra/zebra_evpn_mh.c
+++ b/zebra/zebra_evpn_mh.c
@@ -3156,7 +3156,7 @@ static void zebra_evpn_es_show_entry(struct vty *vty, struct zebra_evpn_es *es,
 
 		/* Add bond state field for local ES */
 		if (es->flags & ZEBRA_EVPNES_LOCAL)
-			json_object_string_add(json, "bondState",
+			json_object_string_add(json, "state",
 					       (es->flags & ZEBRA_EVPNES_OPER_UP) ? "up" : "down");
 
 		if (listcount(es->es_vtep_list)) {
@@ -3184,7 +3184,7 @@ static void zebra_evpn_es_show_entry(struct vty *vty, struct zebra_evpn_es *es,
 
 		zebra_evpn_es_vtep_str(vtep_str, es, sizeof(vtep_str));
 
-		vty_out(vty, "%-30s %-4s %-21s %-9s %s\n", es->esi_str, type_str,
+		vty_out(vty, "%-30s %-4s %-21s %-5s %s\n", es->esi_str, type_str,
 			es->zif ? es->zif->ifp->name : "-", state_str, vtep_str);
 	}
 }
@@ -3317,7 +3317,7 @@ void zebra_evpn_es_show(struct vty *vty, bool uj)
 		json_array = json_object_new_array();
 	} else {
 		vty_out(vty, "Type: B bypass, L local, R remote, N non-DF\n");
-		vty_out(vty, "%-30s %-4s %-21s %-9s %s\n", "ESI", "Type", "ES-IF", "BondState",
+		vty_out(vty, "%-30s %-4s %-21s %-5s %s\n", "ESI", "Type", "ES-IF", "State",
 			"VTEPs");
 	}
 


### PR DESCRIPTION
This is a follow-up to PR #20711 which added the State column to 'show evpn es' output.

Rename the column/field name from 'BondState' to 'State' for consistency with other FRR CLI commands that use 'State' to define an entity's current operational state.

The following CLIs already use 'State' as the column name:
- show vrf [NAME|all] vni [json]: VRF, VNI, VxLAN IF, L3-SVI, State, Rmac
- show ip neigh: Neighbor, Type, Flags, State, MAC, Remote ES/VTEP, Seq #'s
- show evpn arp-cache vni <vni> [json]: same header as above
- show evpn arp-cache vni all [json]: same header
- show evpn arp-cache vni <vni> duplicate [json]: IP, Type, State, MAC, ...

Using consistent naming simplifies user parsing via object model - 'state' is easier than having 'bondState', 'vniState', etc.

Changes:
- Rename column header from 'BondState' to 'State'
- Rename JSON field from 'bondState' to 'state'
- Adjust format width from %-9s to %-5s to match column name length

Before (PR #20711):
ESI                            Type ES-IF                 BondState VTEPs
03:44:38:39:ff:ff:01:00:00:01  LRN  hostbond_1            down      ...

After:
ESI                            Type ES-IF                 State VTEPs
03:44:38:39:ff:ff:01:00:00:01  LRN  hostbond_1            down  ...