### PR TITLE
Non route replace semantics

### DIFF
--- a/tests/topotests/ipv6_ra_simple/r1/frr.conf
+++ b/tests/topotests/ipv6_ra_simple/r1/frr.conf
@@ -1,0 +1,7 @@
+!
+interface r1-eth0
+  ipv6 address 2001:db8:1::1/64
+  no ipv6 nd suppress-ra
+  ipv6 nd ra-interval 3
+  ipv6 nd ra-lifetime 30
+exit

--- a/tests/topotests/ipv6_ra_simple/r2/frr.conf
+++ b/tests/topotests/ipv6_ra_simple/r2/frr.conf
@@ -1,0 +1,15 @@
+log file frr.log
+
+!debug zebra kernel 
+!debug zebra kernel msgdump
+!debug zebra rib detail
+!
+interface r2-eth0
+  ipv6 address 2001:db8:1::2/64
+  ipv6 nd suppress-ra
+exit
+
+interface r2-eth1
+  ipv6 address 2001:db8:2::2/64
+  ipv6 nd suppress-ra
+exit

--- a/tests/topotests/ipv6_ra_simple/r3/frr.conf
+++ b/tests/topotests/ipv6_ra_simple/r3/frr.conf
@@ -1,0 +1,8 @@
+log file frr.log
+
+interface r3-eth0
+  ipv6 address 2001:db8:2::3/64
+  no ipv6 nd suppress-ra
+  ipv6 nd ra-interval 3
+  ipv6 nd ra-lifetime 30
+exit

--- a/tests/topotests/ipv6_ra_simple/test_ipv6_ra_simple.py
+++ b/tests/topotests/ipv6_ra_simple/test_ipv6_ra_simple.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+
+# test_ipv6_ra_simple.py
+#
+# Copyright (c) 2026 by Nvidia Corporation
+#                       Donald Sharp
+
+"""
+Test IPv6 RA default routes being properly handled by zebra.
+Have an additional test that shows the old behavior still works
+as well.
+
+The topology is r1 ----- r2 ----- r3
+Both r1 and r3 are sending the default route to
+r2.
+"""
+
+import os
+import sys
+from functools import partial
+import pytest
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, get_topogen
+
+
+def build_topo(tgen):
+    "Build function"
+    tgen.add_router("r1")
+    tgen.add_router("r2")
+    tgen.add_router("r3")
+
+    sw1 = tgen.add_switch("s1")
+    sw1.add_link(tgen.gears["r1"])
+    sw1.add_link(tgen.gears["r2"])
+
+    sw2 = tgen.add_switch("s2")
+    sw2.add_link(tgen.gears["r2"])
+    sw2.add_link(tgen.gears["r3"])
+
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+    for rname, router in router_list.items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    # R2 is a router, so accept RA explicitly on both links.
+    topotest.sysctl_assure(tgen.net["r2"], "net.ipv6.conf.all.accept_ra", 2)
+    topotest.sysctl_assure(tgen.net["r2"], "net.ipv6.conf.default.accept_ra", 2)
+    topotest.sysctl_assure(tgen.net["r2"], "net.ipv6.conf.r2-eth0.accept_ra", 2)
+    topotest.sysctl_assure(tgen.net["r2"], "net.ipv6.conf.r2-eth1.accept_ra", 2)
+
+    tgen.start_router()
+
+
+def teardown_module(_mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def _kernel_default_routes_present(router):
+    out = router.cmd("ip -6 route show default")
+    found = {"r2-eth0": False, "r2-eth1": False}
+    for line in out.splitlines():
+        if "default" not in line or "proto ra" not in line:
+            continue
+        for dev in found:
+            if "dev {}".format(dev) in line:
+                found[dev] = True
+    return all(found.values())
+
+
+def _vtysh_default_routes_present(router):
+    out = router.vtysh_cmd("show ipv6 route")
+    found = {"r2-eth0": False, "r2-eth1": False}
+    for line in out.splitlines():
+        if "::/0" not in line:
+            continue
+        for dev in found:
+            if ", {}".format(dev) in line:
+                found[dev] = True
+    return all(found.values())
+
+
+def _vtysh_default_table_route_ok(router):
+    out = router.vtysh_cmd("show ipv6 route")
+    want = "K>* 3::2/128 [0/1034] via fe80::202:ff:fe00:12, r2-eth1"
+    return want in out
+
+
+def _kernel_default_route_missing(router, dev):
+    out = router.cmd("ip -6 route show default dev {}".format(dev))
+    return out.strip() == ""
+
+
+def _vtysh_default_route_missing(router, dev):
+    out = router.vtysh_cmd("show ipv6 route")
+    for line in out.splitlines():
+        if "::/0" in line and ", {}".format(dev) in line:
+            return False
+    return True
+
+
+def test_ipv6_ra_default_routes():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    test_func = partial(_kernel_default_routes_present, r2)
+    _, result = topotest.run_and_expect(test_func, True, count=40, wait=1)
+    assert result is True, "Missing kernel RA default routes on r2"
+
+    test_func = partial(_vtysh_default_routes_present, r2)
+    _, result = topotest.run_and_expect(test_func, True, count=40, wait=1)
+    assert result is True, "Missing vtysh default routes on r2"
+
+
+def test_kernel_route_replace():
+    tgen = get_topogen()
+    # if tgen.routers_have_failure():
+    #    pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+
+    r2.cmd_raises(
+        "ip -6 route add 3::2/128 via fe80::202:ff:fe00:11 dev r2-eth0 "
+        "proto ra metric 1034 hoplimit 64 pref high"
+    )
+    r2.cmd_raises(
+        "ip -6 route replace 3::2/128 via fe80::202:ff:fe00:12 dev r2-eth1 "
+        "proto ra metric 1034 hoplimit 64 pref high"
+    )
+
+    test_func = partial(_vtysh_default_table_route_ok, r2)
+    _, result = topotest.run_and_expect(test_func, True, count=20, wait=1)
+    assert result is True, "FRR did not track route replacement in default table"
+
+
+def test_stop_r3_ra_default_removed():
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    r2 = tgen.gears["r2"]
+    r3 = tgen.gears["r3"]
+
+    r3.cmd_raises(
+        'vtysh -c "conf t" -c "interface r3-eth0" -c "ipv6 nd suppress-ra" -c "exit" -c "exit"'
+    )
+
+    test_func = partial(_kernel_default_route_missing, r2, "r2-eth1")
+    _, result = topotest.run_and_expect(test_func, True, count=40, wait=1)
+    assert result is True, "Kernel default route via r2-eth1 not removed"
+
+    test_func = partial(_vtysh_default_route_missing, r2, "r2-eth1")
+    _, result = topotest.run_and_expect(test_func, True, count=40, wait=1)
+    assert result is True, "Zebra default route via r2-eth1 not removed"
+
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip("Memory leak test/report is disabled")
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -329,23 +329,19 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 	if (!CHECK_FLAG(ifc->flags, ZEBRA_IFA_NOPREFIXROUTE)) {
 		connected_remove_kernel_for_connected(afi, SAFI_UNICAST, zvrf, &p, &nh);
 
-		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id,
-			ZEBRA_ROUTE_CONNECT, 0, flags, &p, NULL, &nh, 0,
-			zvrf->table_id, metric, 0, 0, 0, false);
+		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_CONNECT, 0, flags, &p,
+			NULL, &nh, 0, zvrf->table_id, metric, 0, 0, 0, false, true);
 
 		connected_remove_kernel_for_connected(afi, SAFI_MULTICAST, zvrf, &p, &nh);
-		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id,
-			ZEBRA_ROUTE_CONNECT, 0, flags, &p, NULL, &nh, 0,
-			zvrf->table_id, metric, 0, 0, 0, false);
+		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_CONNECT, 0, flags, &p,
+			NULL, &nh, 0, zvrf->table_id, metric, 0, 0, 0, false, true);
 	}
 
 	if (install_local) {
-		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL,
-			0, flags, &plocal, NULL, &nh, 0, zvrf->table_id, 0, 0,
-			0, 0, false);
-		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id,
-			ZEBRA_ROUTE_LOCAL, 0, flags, &plocal, NULL, &nh, 0,
-			zvrf->table_id, 0, 0, 0, 0, false);
+		rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, flags, &plocal,
+			NULL, &nh, 0, zvrf->table_id, 0, 0, 0, 0, false, true);
+		rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_LOCAL, 0, flags,
+			&plocal, NULL, &nh, 0, zvrf->table_id, 0, 0, 0, 0, false, true);
 	}
 
 	/* Schedule LSP forwarding entries for processing, if appropriate. */

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -764,7 +764,7 @@ int zebra_add_import_table_entry(struct zebra_vrf *zvrf, safi_t safi, struct rou
 	ng = nexthop_group_new();
 	copy_nexthops(&ng->nexthop, re->nhe->nhg.nexthop, NULL);
 
-	rib_add_multipath(afi, safi, &p, NULL, newre, ng, false);
+	rib_add_multipath(afi, safi, &p, NULL, newre, ng, false, true);
 	nexthop_group_delete(&ng);
 
 	return 0;

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -386,27 +386,24 @@ extern void rib_uninstall_kernel(struct route_node *rn, struct route_entry *re);
 /* NOTE:
  * All rib_add function will not just add prefix into RIB, but
  * also implicitly withdraw equal prefix of same type. */
-extern int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
-		   unsigned short instance, uint32_t flags, struct prefix *p,
-		   struct prefix_ipv6 *src_p, const struct nexthop *nh,
-		   uint32_t nhe_id, uint32_t table_id, uint32_t metric,
-		   uint32_t mtu, uint8_t distance, route_tag_t tag,
-		   bool startup);
+extern int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type, unsigned short instance,
+		   uint32_t flags, struct prefix *p, struct prefix_ipv6 *src_p,
+		   const struct nexthop *nh, uint32_t nhe_id, uint32_t table_id, uint32_t metric,
+		   uint32_t mtu, uint8_t distance, route_tag_t tag, bool startup, bool replace);
 /*
  * Multipath route apis.
  */
-extern int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
-			     struct prefix_ipv6 *src_p, struct route_entry *re,
-			     struct nexthop_group *ng, bool startup);
+extern int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p, struct prefix_ipv6 *src_p,
+			     struct route_entry *re, struct nexthop_group *ng, bool startup,
+			     bool replace);
 /*
  * -1 -> some sort of error
  *  0 -> an add
  *  1 -> an update
  */
 extern int rib_add_multipath_nhe(afi_t afi, safi_t safi, struct prefix *p,
-				 struct prefix_ipv6 *src_p,
-				 struct route_entry *re,
-				 struct nhg_hash_entry *nhe, bool startup);
+				 struct prefix_ipv6 *src_p, struct route_entry *re,
+				 struct nhg_hash_entry *nhe, bool startup, bool replace);
 
 extern void rib_delete(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 		       unsigned short instance, uint32_t flags,

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -784,6 +784,7 @@ static int netlink_route_read_unicast_ctx(struct nlmsghdr *h, ns_id_t ns_id,
 	struct rtmsg *rtm;
 	struct rtattr **tb, *tb_array[RTA_MAX + 1];
 	uint32_t flags = 0;
+	bool replace = false;
 	struct prefix p;
 	struct prefix src_p = {};
 	bool selfroute;
@@ -879,6 +880,8 @@ static int netlink_route_read_unicast_ctx(struct nlmsghdr *h, ns_id_t ns_id,
 
 	if (h->nlmsg_flags & NLM_F_APPEND)
 		flags |= ZEBRA_FLAG_OUTOFSYNC;
+	if (h->nlmsg_flags & NLM_F_REPLACE)
+		replace = true;
 
 	/* Route which was inserted by Zebra. */
 	if (selfroute) {
@@ -1030,6 +1033,7 @@ static int netlink_route_read_unicast_ctx(struct nlmsghdr *h, ns_id_t ns_id,
 	else
 		dplane_ctx_set_src(ctx, NULL);
 	dplane_ctx_set_type(ctx, proto);
+	dplane_ctx_route_set_replace(ctx, replace);
 	dplane_ctx_set_flags(ctx, flags);
 	dplane_ctx_set_route_metric(ctx, metric);
 	dplane_ctx_set_route_mtu(ctx, mtu);
@@ -1328,9 +1332,8 @@ static int netlink_route_change_read_unicast_internal(struct nlmsghdr *h,
 			}
 		}
 		if (nhe_id || ng) {
-			rib_add_multipath(afi, SAFI_UNICAST, &p,
-					  (struct prefix_ipv6 *)&src_p,
-					  re, ng, startup);
+			rib_add_multipath(afi, SAFI_UNICAST, &p, (struct prefix_ipv6 *)&src_p, re,
+					  ng, startup, dplane_ctx_route_get_replace(ctx));
 			if (ng)
 				nexthop_group_delete(&ng);
 		} else {

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2256,8 +2256,7 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 		nhe.backup_info = bnhg;
 		n = zebra_nhe_copy(&nhe, 0);
 	}
-	ret = rib_add_multipath_nhe(afi, api.safi, &api.prefix, src_p, re, n,
-				    false);
+	ret = rib_add_multipath_nhe(afi, api.safi, &api.prefix, src_p, re, n, false, true);
 
 	/*
 	 * rib_add_multipath_nhe only fails in a couple spots

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -135,6 +135,7 @@ struct dplane_route_info {
 	uint32_t zd_nexthop_mtu;
 
 	uint32_t zd_flags;
+	bool zd_replace;
 
 	/* Nexthop hash entry info */
 	struct dplane_nexthop_info nhe;
@@ -1939,6 +1940,20 @@ void dplane_ctx_set_flags(struct zebra_dplane_ctx *ctx, uint32_t flags)
 	DPLANE_CTX_VALID(ctx);
 
 	ctx->u.rinfo.zd_flags = flags;
+}
+
+bool dplane_ctx_route_get_replace(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.rinfo.zd_replace;
+}
+
+void dplane_ctx_route_set_replace(struct zebra_dplane_ctx *ctx, bool replace)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	ctx->u.rinfo.zd_replace = replace;
 }
 
 void dplane_ctx_set_route_metric(struct zebra_dplane_ctx *ctx, uint32_t metric)
@@ -3751,6 +3766,7 @@ int dplane_ctx_route_init_basic(struct zebra_dplane_ctx *ctx,
 	ctx->zd_table_id = re->table;
 
 	ctx->u.rinfo.zd_flags = re->flags;
+	ctx->u.rinfo.zd_replace = true;
 	ctx->u.rinfo.zd_metric = re->metric;
 	ctx->u.rinfo.zd_old_metric = re->metric;
 	ctx->zd_vrf_id = re->vrf_id;

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -524,6 +524,8 @@ void dplane_ctx_set_instance(struct zebra_dplane_ctx *ctx, uint16_t instance);
 uint16_t dplane_ctx_get_old_instance(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_get_flags(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_flags(struct zebra_dplane_ctx *ctx, uint32_t flags);
+bool dplane_ctx_route_get_replace(const struct zebra_dplane_ctx *ctx);
+void dplane_ctx_route_set_replace(struct zebra_dplane_ctx *ctx, bool replace);
 uint32_t dplane_ctx_get_metric(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_get_old_metric(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_route_metric(struct zebra_dplane_ctx *ctx, uint32_t metric);


### PR DESCRIPTION
The linux kernel for v6 ra default routes is installing the same route multiple times.  Currently in FRR we are ignoring the RTM_F_REPLACE semantics.  Grab this value and pass it through for correct handling.  See the 2nd commit for more detailed explanation.