### PR TITLE
bgpd: Add support for BGP-LS for BGP fabric

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -43,6 +43,7 @@
 #include "bgpd/bgp_zebra.h"
 #include "bgpd/bgp_vty.h"
 #include "bgpd/bgp_trace.h"
+#include "bgpd/bgp_ls.h"
 
 DEFINE_HOOK(peer_backward_transition, (struct peer * peer), (peer));
 DEFINE_HOOK(peer_status_changed, (struct peer * peer), (peer));
@@ -2092,6 +2093,12 @@ enum bgp_fsm_state_progress bgp_stop(struct peer_connection *connection)
 				   bgp_peer_get_connection_direction_string(connection));
 		update_group_remove_peer_afs(peer);
 
+		/* Withdraw Link NLRI for BGP session (local -> peer) */
+		if (bgp && bgp->ls_info && bgp->ls_info->enable_distribution)
+			if (bgp_ls_withdraw_bgp_link(bgp, peer) != 0)
+				zlog_warn("BGP-LS: Failed to withdraw link NLRI for peer %s",
+					  peer->host);
+
 		/* Reset peer synctime */
 		peer->synctime = 0;
 	}
@@ -2862,6 +2869,11 @@ bgp_establish(struct peer_connection *connection)
 				SET_FLAG(peer->af_sflags[afi][safi],
 					 PEER_STATUS_ORF_WAIT_REFRESH);
 	}
+
+	/* Generate Link NLRI for BGP session (local -> peer) */
+	if (bgp && bgp->ls_info && bgp->ls_info->enable_distribution)
+		if (bgp_ls_originate_bgp_link(bgp, peer) != 0)
+			zlog_warn("BGP-LS: Failed to originate link NLRI for peer %s", peer->host);
 
 	bgp_announce_peer(peer);
 

--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -889,3 +889,620 @@ void bgp_ls_cleanup(struct bgp *bgp)
 
 	zlog_info("BGP-LS: Module terminated for instance %s", bgp->name_pretty);
 }
+
+/*
+ * ===========================================================================
+ * BGP Topology Export (BGP-only fabrics)
+ * ===========================================================================
+ */
+
+/*
+ * Originate Node NLRI for local BGP router
+ *
+ * Reference: draft-ietf-idr-bgp-ls-bgp-only-fabric-04 Section 4.1
+ *
+ * Generates a Node NLRI for the local BGP router with:
+ * - Protocol-ID = BGP_LS_PROTO_BGP (7)
+ * - Autonomous System Number (TLV 512) - local BGP ASN
+ * - BGP Router-ID (TLV 516) - local BGP Identifier
+ */
+int bgp_ls_originate_bgp_node(struct bgp *bgp)
+{
+	struct bgp_ls_nlri *nlri;
+	struct bgp_ls_attr *ls_attr;
+	int ret;
+
+	if (!bgp || !bgp->ls_info || !bgp->ls_info->enable_distribution)
+		return 0;
+
+	nlri = bgp_ls_nlri_alloc();
+
+	/* Set NLRI type and protocol */
+	nlri->nlri_type = BGP_LS_NLRI_TYPE_NODE;
+	nlri->nlri_data.node.protocol_id = BGP_LS_PROTO_BGP;
+	nlri->nlri_data.node.identifier = bgp->ls_info->instance_id;
+
+	/* Local Node Descriptor */
+	/* TLV 512: Autonomous System Number */
+	nlri->nlri_data.node.local_node.asn = bgp->as;
+	BGP_LS_TLV_SET(nlri->nlri_data.node.local_node.present_tlvs, BGP_LS_NODE_DESC_AS_BIT);
+
+	/* TLV 516: BGP Router-ID */
+	nlri->nlri_data.node.local_node.bgp_router_id = bgp->router_id;
+	BGP_LS_TLV_SET(nlri->nlri_data.node.local_node.present_tlvs,
+		       BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT);
+
+	/* Node Attributes */
+	ls_attr = bgp_ls_attr_alloc();
+
+	/* TLV 1026: Node Name */
+	ls_attr->node_name = XSTRDUP(MTYPE_BGP_LS_ATTR, bgp->peer_self->host);
+	BGP_LS_TLV_SET(ls_attr->present_tlvs, BGP_LS_ATTR_NODE_NAME_BIT);
+
+	ret = bgp_ls_update(bgp, nlri, ls_attr);
+	if (ret != 0) {
+		zlog_err("BGP-LS: Failed to originate BGP Node NLRI");
+		bgp_ls_attr_free(ls_attr);
+		bgp_ls_nlri_free(nlri);
+		return -1;
+	}
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS: Originated BGP Node NLRI for AS %u, Router-ID %pI4", bgp->as,
+			   &bgp->router_id);
+
+	bgp_ls_attr_free(ls_attr);
+	bgp_ls_nlri_free(nlri);
+	return 0;
+}
+
+static struct interface *bgp_ls_get_ifp_from_connection(struct peer *peer,
+							struct peer_connection *connection)
+{
+	struct interface *ifp = NULL;
+
+	if (!peer || !peer->bgp)
+		return NULL;
+
+	if (connection && connection->su_local) {
+		if (connection->su_local->sa.sa_family == AF_INET) {
+			ifp = if_lookup_by_ipv4_exact(&connection->su_local->sin.sin_addr,
+						      peer->bgp->vrf_id);
+		} else if (connection->su_local->sa.sa_family == AF_INET6) {
+			ifp = if_lookup_by_ipv6_exact(&connection->su_local->sin6.sin6_addr,
+						      connection->su_local->sin6.sin6_scope_id,
+						      peer->bgp->vrf_id);
+		}
+	}
+
+	if (!ifp && peer->conf_if)
+		ifp = if_lookup_by_name(peer->conf_if, peer->bgp->vrf_id);
+
+	if (!ifp && peer->ifname)
+		ifp = if_lookup_by_name(peer->ifname, peer->bgp->vrf_id);
+
+	if (!ifp && peer->update_if)
+		ifp = if_lookup_by_name(peer->update_if, peer->bgp->vrf_id);
+
+	return ifp;
+}
+
+/*
+ * Originate BGP Link NLRI for a BGP session
+ *
+ * This generates a Link NLRI representing a BGP session from the local
+ * router to a peer. Per draft-ietf-idr-bgp-ls-bgp-only-fabric-04 Section 4.2,
+ * the NLRI includes:
+ * - Local Node Descriptor: Local BGP router (ASN + BGP Router-ID)
+ * - Remote Node Descriptor: Peer BGP router (ASN + BGP Router-ID)
+ * - Link Descriptor: IPv4/IPv6 interface and neighbor addresses
+ * - Protocol-ID: BGP (7)
+ *
+ * @param bgp  - BGP instance
+ * @param peer - BGP peer (remote endpoint of the session)
+ * @return 0 on success, -1 on error
+ */
+int bgp_ls_originate_bgp_link(struct bgp *bgp, struct peer *peer)
+{
+	struct bgp_ls_nlri *nlri;
+	struct peer_connection *connection;
+	struct interface *ifp;
+	uint32_t local_link_id;
+	uint32_t remote_link_id;
+	int ret;
+
+	if (!bgp || !bgp->ls_info || !bgp->ls_info->enable_distribution)
+		return 0;
+
+	if (!peer) {
+		zlog_err("BGP-LS: Cannot originate BGP link without BGP instance or peer");
+		return -1;
+	}
+
+	if (!bgp->peer_self) {
+		zlog_err("BGP-LS: No local peer for BGP link origination");
+		return -1;
+	}
+
+	connection = peer->connection;
+	ifp = bgp_ls_get_ifp_from_connection(peer, connection);
+
+	if (!CHECK_FLAG(peer->flags, PEER_FLAG_LS_LOCAL_LINK_ID) && !ifp) {
+		zlog_err("BGP-LS: Cannot originate BGP link NLRI for peer %s: missing local link-id and interface",
+			 peer->host);
+		return -1;
+	}
+
+	nlri = bgp_ls_nlri_alloc();
+
+	/* Set NLRI type and protocol */
+	nlri->nlri_type = BGP_LS_NLRI_TYPE_LINK;
+	nlri->nlri_data.link.protocol_id = BGP_LS_PROTO_BGP;
+	nlri->nlri_data.link.identifier = bgp->ls_info->instance_id;
+
+	/* Local Node Descriptor */
+	nlri->nlri_data.link.local_node.asn = bgp->as;
+	BGP_LS_TLV_SET(nlri->nlri_data.link.local_node.present_tlvs, BGP_LS_NODE_DESC_AS_BIT);
+
+	nlri->nlri_data.link.local_node.bgp_router_id = bgp->router_id;
+	BGP_LS_TLV_SET(nlri->nlri_data.link.local_node.present_tlvs,
+		       BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT);
+
+	/* Remote Node Descriptor */
+	nlri->nlri_data.link.remote_node.asn = peer->as;
+	BGP_LS_TLV_SET(nlri->nlri_data.link.remote_node.present_tlvs, BGP_LS_NODE_DESC_AS_BIT);
+
+	nlri->nlri_data.link.remote_node.bgp_router_id = peer->remote_id;
+	BGP_LS_TLV_SET(nlri->nlri_data.link.remote_node.present_tlvs,
+		       BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT);
+
+	/* Link Descriptor: Link Local/Remote Identifiers (TLV 258) */
+	local_link_id = CHECK_FLAG(peer->flags, PEER_FLAG_LS_LOCAL_LINK_ID)
+				? peer->ls_local_link_id
+				: (uint32_t)ifp->ifindex;
+	remote_link_id = CHECK_FLAG(peer->flags, PEER_FLAG_LS_REMOTE_LINK_ID)
+				 ? peer->ls_remote_link_id
+				 : 0;
+
+	nlri->nlri_data.link.link_desc.link_local_id = local_link_id;
+	nlri->nlri_data.link.link_desc.link_remote_id = remote_link_id;
+	BGP_LS_TLV_SET(nlri->nlri_data.link.link_desc.present_tlvs, BGP_LS_LINK_DESC_LINK_ID_BIT);
+
+	/* Link Descriptor: IPv4 Neighbor Address (TLV 260) */
+	if (connection && connection->su.sa.sa_family == AF_INET) {
+		nlri->nlri_data.link.link_desc.ipv4_neigh_addr = connection->su.sin.sin_addr;
+		BGP_LS_TLV_SET(nlri->nlri_data.link.link_desc.present_tlvs,
+			       BGP_LS_LINK_DESC_IPV4_NEIGH_BIT);
+	}
+
+	/* Link Descriptor: IPv6 Neighbor Address (TLV 262) */
+	if (connection && connection->su.sa.sa_family == AF_INET6) {
+		nlri->nlri_data.link.link_desc.ipv6_neigh_addr = connection->su.sin6.sin6_addr;
+		BGP_LS_TLV_SET(nlri->nlri_data.link.link_desc.present_tlvs,
+			       BGP_LS_LINK_DESC_IPV6_NEIGH_BIT);
+	}
+
+	/* Link Descriptor: IPv4 Interface Address (TLV 259) */
+	if (connection && connection->su_local && connection->su_local->sa.sa_family == AF_INET) {
+		nlri->nlri_data.link.link_desc.ipv4_intf_addr = connection->su_local->sin.sin_addr;
+		BGP_LS_TLV_SET(nlri->nlri_data.link.link_desc.present_tlvs,
+			       BGP_LS_LINK_DESC_IPV4_INTF_BIT);
+	}
+
+	/* Link Descriptor: IPv6 Interface Address (TLV 261) */
+	if (connection && connection->su_local && connection->su_local->sa.sa_family == AF_INET6) {
+		nlri->nlri_data.link.link_desc.ipv6_intf_addr =
+			connection->su_local->sin6.sin6_addr;
+		BGP_LS_TLV_SET(nlri->nlri_data.link.link_desc.present_tlvs,
+			       BGP_LS_LINK_DESC_IPV6_INTF_BIT);
+	}
+
+	ret = bgp_ls_update(bgp, nlri, NULL);
+	if (ret != 0) {
+		zlog_err("BGP-LS: Failed to originate BGP link NLRI");
+		bgp_ls_nlri_free(nlri);
+		return -1;
+	}
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS: Originated BGP Link NLRI: Local AS %u Router-ID %pI4 -> Peer AS %u Router-ID %pI4",
+			   bgp->as, &bgp->router_id, peer->as, &peer->remote_id);
+
+	bgp_ls_nlri_free(nlri);
+	return 0;
+}
+
+/*
+ * Originate BGP Prefix NLRI
+ *
+ * Reference: draft-ietf-idr-bgp-ls-bgp-only-fabric-04 Section 4.3
+ *
+ * Generates a BGP-LS Prefix NLRI for BGP routes from the local RIB.
+ *
+ * @param bgp - BGP instance
+ * @param afi - Address family (AFI_IP or AFI_IP6)
+ * @param safi - Subsequent address family (SAFI_UNICAST, etc.)
+ * @param dest - BGP destination (route)
+ * @param path - BGP path info
+ * @return 0 on success, -1 on failure
+ */
+int bgp_ls_originate_bgp_prefix(struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *dest,
+				struct bgp_path_info *path)
+{
+	struct bgp_ls_nlri *nlri;
+	const struct prefix *p;
+	int ret;
+
+	if (!bgp || !bgp->ls_info || !bgp->ls_info->enable_distribution)
+		return 0;
+
+	if (!dest || !path) {
+		zlog_err("BGP-LS: Invalid parameters for BGP prefix origination");
+		return -1;
+	}
+
+	if (safi != SAFI_UNICAST)
+		return 0;
+
+	/* Get the prefix */
+	p = bgp_dest_get_prefix(dest);
+	if (!p) {
+		zlog_err("BGP-LS: Cannot get prefix from destination");
+		return -1;
+	}
+
+	nlri = bgp_ls_nlri_alloc();
+
+	/* Set NLRI type and protocol */
+	if (afi == AFI_IP)
+		nlri->nlri_type = BGP_LS_NLRI_TYPE_IPV4_PREFIX;
+	else if (afi == AFI_IP6)
+		nlri->nlri_type = BGP_LS_NLRI_TYPE_IPV6_PREFIX;
+	else {
+		zlog_err("BGP-LS: Unsupported AFI %d for BGP prefix", afi);
+		bgp_ls_nlri_free(nlri);
+		return -1;
+	}
+
+	nlri->nlri_data.prefix.protocol_id = BGP_LS_PROTO_BGP;
+	nlri->nlri_data.prefix.identifier = bgp->ls_info->instance_id;
+
+	/* Local Node Descriptor */
+	/* TLV 512: Autonomous System Number */
+	nlri->nlri_data.prefix.local_node.asn = bgp->as;
+	BGP_LS_TLV_SET(nlri->nlri_data.prefix.local_node.present_tlvs, BGP_LS_NODE_DESC_AS_BIT);
+
+	/* TLV 516: BGP Router-ID */
+	nlri->nlri_data.prefix.local_node.bgp_router_id = bgp->router_id;
+	BGP_LS_TLV_SET(nlri->nlri_data.prefix.local_node.present_tlvs,
+		       BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT);
+
+	/* Prefix Descriptor */
+	/* TLV 267: BGP Route Type */
+	if (path->type == ZEBRA_ROUTE_LOCAL)
+		nlri->nlri_data.prefix.prefix_desc.bgp_route_type = BGP_LS_BGP_RT_LOCAL;
+	else if (path->type == ZEBRA_ROUTE_CONNECT)
+		nlri->nlri_data.prefix.prefix_desc.bgp_route_type = BGP_LS_BGP_RT_ATTACHED;
+	else if (path->type == ZEBRA_ROUTE_BGP && path->peer && path->peer->sort == BGP_PEER_EBGP)
+		nlri->nlri_data.prefix.prefix_desc.bgp_route_type = BGP_LS_BGP_RT_EXTERNAL_BGP;
+	else if (path->type == ZEBRA_ROUTE_BGP && path->peer && path->peer->sort == BGP_PEER_IBGP)
+		nlri->nlri_data.prefix.prefix_desc.bgp_route_type = BGP_LS_BGP_RT_INTERNAL_BGP;
+	else
+		nlri->nlri_data.prefix.prefix_desc.bgp_route_type = BGP_LS_BGP_RT_REDISTRIBUTED;
+	BGP_LS_TLV_SET(nlri->nlri_data.prefix.prefix_desc.present_tlvs,
+		       BGP_LS_PREFIX_DESC_BGP_ROUTE_TYPE_BIT);
+
+	/* TLV 265: IP Reachability Information */
+	nlri->nlri_data.prefix.prefix_desc.prefix = *p;
+	BGP_LS_TLV_SET(nlri->nlri_data.prefix.prefix_desc.present_tlvs,
+		       BGP_LS_PREFIX_DESC_IP_REACH_BIT);
+
+	ret = bgp_ls_update(bgp, nlri, NULL);
+	if (ret != 0) {
+		zlog_err("BGP-LS: Failed to originate BGP prefix NLRI for %pFX", p);
+		bgp_ls_nlri_free(nlri);
+		return -1;
+	}
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS: Originated BGP Prefix NLRI for %pFX", p);
+
+	bgp_ls_nlri_free(nlri);
+	return 0;
+}
+
+/*
+ * Export BGP topology as BGP-LS NLRIs.
+ *
+ * Generates Node, Link, and Prefix NLRIs for the local BGP topology.
+ *
+ * @param bgp - BGP instance
+ * @return 0 on success, -1 on invalid input or when distribution is disabled
+ */
+int bgp_ls_export_bgp_topology(struct bgp *bgp)
+{
+	struct listnode *node;
+	struct peer *peer;
+	int nlri_count = 0;
+
+	if (!bgp || !bgp->ls_info || !bgp->ls_info->enable_distribution) {
+		zlog_err("BGP-LS: BGP topology distribution not enabled");
+		return -1;
+	}
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS: Exporting BGP topology for instance %s", bgp->name_pretty);
+
+	/* Export the local node once. */
+	if (bgp_ls_originate_bgp_node(bgp) != 0)
+		zlog_warn("BGP-LS: Failed to originate local BGP node NLRI");
+	else
+		nlri_count++;
+
+	/* Export one link NLRI for each established non-group peer. */
+	for (ALL_LIST_ELEMENTS_RO(bgp->peer, node, peer)) {
+		if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
+			continue;
+
+		if (!peer->connection || peer->connection->status != Established)
+			continue;
+
+		if (bgp_ls_originate_bgp_link(bgp, peer) != 0)
+			zlog_warn("BGP-LS: Failed to originate link NLRI for peer %s", peer->host);
+		else
+			nlri_count++;
+	}
+
+	/* Export prefix NLRIs from the IPv4/IPv6 unicast RIBs. */
+	afi_t afis[] = { AFI_IP, AFI_IP6 };
+
+	for (int i = 0; i < 2; i++) {
+		afi_t afi = afis[i];
+		struct bgp_dest *dest;
+		struct bgp_path_info *path;
+
+		if (!bgp->rib[afi][SAFI_UNICAST])
+			continue;
+
+		for (dest = bgp_table_top(bgp->rib[afi][SAFI_UNICAST]); dest;
+		     dest = bgp_route_next(dest)) {
+			for (path = bgp_dest_get_bgp_path_info(dest); path; path = path->next) {
+				if (bgp_ls_originate_bgp_prefix(bgp, afi, SAFI_UNICAST, dest,
+								path) != 0) {
+					zlog_warn("BGP-LS: Failed to originate prefix NLRI for %pFX",
+						  bgp_dest_get_prefix(dest));
+				} else
+					nlri_count++;
+			}
+		}
+	}
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		zlog_debug("BGP-LS: Exported %d BGP-LS NLRIs", nlri_count);
+
+	return 0;
+}
+
+/* Withdraw all locally originated BGP-LS routes. */
+void bgp_ls_withdraw_all(struct bgp *bgp)
+{
+	struct bgp_dest *dest;
+	struct bgp_table *table;
+	struct bgp_ls_nlri *nlri;
+
+	if (!bgp)
+		return;
+
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS) || bgp->peer_self == NULL)
+		return;
+
+	if (!bgp->ls_info)
+		return;
+
+	table = bgp->rib[AFI_BGP_LS][SAFI_BGP_LS];
+	if (!table)
+		return;
+
+	for (dest = bgp_table_top(table); dest; dest = bgp_route_next(dest)) {
+		nlri = dest->ls_nlri;
+		if (!nlri)
+			continue;
+
+		bgp_ls_withdraw(bgp, nlri);
+	}
+}
+
+static struct bgp_ls_nlri *bgp_ls_lookup_bgp_link_nlri(struct bgp *bgp, struct peer *peer)
+{
+	struct bgp_dest *dest;
+	struct bgp_table *table;
+	struct bgp_ls_nlri *nlri;
+	struct interface *ifp;
+	struct peer_connection *connection;
+	bool expect_link_id;
+	uint32_t expected_local_link_id = 0;
+	uint32_t expected_remote_link_id = 0;
+
+	connection = peer ? peer->connection : NULL;
+	ifp = bgp_ls_get_ifp_from_connection(peer, connection);
+
+	expect_link_id = CHECK_FLAG(peer->flags, PEER_FLAG_LS_LOCAL_LINK_ID) || (ifp != NULL);
+	if (expect_link_id) {
+		expected_local_link_id = CHECK_FLAG(peer->flags, PEER_FLAG_LS_LOCAL_LINK_ID)
+						 ? peer->ls_local_link_id
+						 : (uint32_t)ifp->ifindex;
+		expected_remote_link_id = CHECK_FLAG(peer->flags, PEER_FLAG_LS_REMOTE_LINK_ID)
+						  ? peer->ls_remote_link_id
+						  : 0;
+	}
+
+	table = bgp->rib[AFI_BGP_LS][SAFI_BGP_LS];
+	if (!table)
+		return NULL;
+
+	for (dest = bgp_table_top(table); dest; dest = bgp_route_next(dest)) {
+		nlri = dest->ls_nlri;
+		if (!nlri)
+			continue;
+
+		if (nlri->nlri_type != BGP_LS_NLRI_TYPE_LINK)
+			continue;
+		if (nlri->nlri_data.link.protocol_id != BGP_LS_PROTO_BGP)
+			continue;
+
+		if (nlri->nlri_data.link.local_node.asn != bgp->as)
+			continue;
+
+		if (nlri->nlri_data.link.remote_node.asn != peer->as)
+			continue;
+
+		if (!IPV4_ADDR_SAME(&nlri->nlri_data.link.local_node.bgp_router_id,
+				    &bgp->router_id))
+			continue;
+
+		if (!IPV4_ADDR_SAME(&nlri->nlri_data.link.remote_node.bgp_router_id,
+				    &peer->remote_id))
+			continue;
+
+		if (expect_link_id) {
+			if (!BGP_LS_TLV_CHECK(nlri->nlri_data.link.link_desc.present_tlvs,
+					      BGP_LS_LINK_DESC_LINK_ID_BIT))
+				continue;
+
+			if (nlri->nlri_data.link.link_desc.link_local_id != expected_local_link_id)
+				continue;
+
+			if (nlri->nlri_data.link.link_desc.link_remote_id !=
+			    expected_remote_link_id)
+				continue;
+		}
+
+		return nlri;
+	}
+
+	return NULL;
+}
+
+static struct bgp_ls_nlri *bgp_ls_lookup_bgp_prefix_nlri(struct bgp *bgp, const struct prefix *p,
+							 enum bgp_ls_bgp_route_type route_type)
+{
+	struct bgp_dest *bn;
+	struct bgp_table *table;
+	struct bgp_ls_nlri *nlri;
+	enum bgp_ls_nlri_type expected_nlri_type;
+	uint64_t expected_identifier;
+
+	expected_nlri_type = (p->family == AF_INET) ? BGP_LS_NLRI_TYPE_IPV4_PREFIX
+						    : BGP_LS_NLRI_TYPE_IPV6_PREFIX;
+	expected_identifier = bgp->ls_info->instance_id;
+
+	table = bgp->rib[AFI_BGP_LS][SAFI_BGP_LS];
+	if (!table)
+		return NULL;
+
+	for (bn = bgp_table_top(table); bn; bn = bgp_route_next(bn)) {
+		nlri = bn->ls_nlri;
+		if (!nlri)
+			continue;
+
+		if (nlri->nlri_type != expected_nlri_type)
+			continue;
+
+		if (nlri->nlri_data.prefix.protocol_id != BGP_LS_PROTO_BGP)
+			continue;
+
+		if (nlri->nlri_data.prefix.identifier != expected_identifier)
+			continue;
+
+		if (nlri->nlri_data.prefix.local_node.asn != bgp->as)
+			continue;
+
+		if (!IPV4_ADDR_SAME(&nlri->nlri_data.prefix.local_node.bgp_router_id,
+				    &bgp->router_id))
+			continue;
+
+		if (nlri->nlri_data.prefix.prefix_desc.bgp_route_type != route_type)
+			continue;
+
+		if (!prefix_same(&nlri->nlri_data.prefix.prefix_desc.prefix, p))
+			continue;
+
+		return nlri;
+	}
+
+	return NULL;
+}
+
+int bgp_ls_withdraw_bgp_link(struct bgp *bgp, struct peer *peer)
+{
+	struct bgp_ls_nlri *nlri;
+
+	if (!bgp || !peer) {
+		flog_err(EC_BGP_LS_PACKET, "BGP-LS: Invalid parameters to %s", __func__);
+		return -1;
+	}
+
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS) || bgp->peer_self == NULL)
+		return 0;
+
+	if (!bgp->ls_info) {
+		if (BGP_DEBUG(linkstate, LINKSTATE))
+			zlog_debug("%s: No BGP-LS info exists for withdraw", __func__);
+
+		return 0;
+	}
+
+	nlri = bgp_ls_lookup_bgp_link_nlri(bgp, peer);
+	if (!nlri)
+		return 0;
+
+	return bgp_ls_withdraw(bgp, nlri);
+}
+
+int bgp_ls_withdraw_bgp_prefix(struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *dest,
+			       struct bgp_path_info *path)
+{
+	const struct prefix *p;
+	enum bgp_ls_bgp_route_type route_type;
+	struct bgp_ls_nlri *nlri;
+
+	if (!bgp || !dest || !path) {
+		zlog_err("BGP-LS: Invalid parameters for BGP prefix withdraw");
+		return -1;
+	}
+
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS) || bgp->peer_self == NULL)
+		return 0;
+
+	if (!bgp->ls_info)
+		return 0;
+
+	if (safi != SAFI_UNICAST)
+		return 0;
+
+	p = bgp_dest_get_prefix(dest);
+	if (!p) {
+		zlog_err("BGP-LS: Cannot get prefix from destination");
+		return -1;
+	}
+
+	if ((afi == AFI_IP && p->family != AF_INET) || (afi == AFI_IP6 && p->family != AF_INET6))
+		return 0;
+
+	if (path->type == ZEBRA_ROUTE_LOCAL)
+		route_type = BGP_LS_BGP_RT_LOCAL;
+	else if (path->type == ZEBRA_ROUTE_CONNECT)
+		route_type = BGP_LS_BGP_RT_ATTACHED;
+	else if (path->type == ZEBRA_ROUTE_BGP && path->peer && path->peer->sort == BGP_PEER_EBGP)
+		route_type = BGP_LS_BGP_RT_EXTERNAL_BGP;
+	else if (path->type == ZEBRA_ROUTE_BGP && path->peer && path->peer->sort == BGP_PEER_IBGP)
+		route_type = BGP_LS_BGP_RT_INTERNAL_BGP;
+	else
+		route_type = BGP_LS_BGP_RT_REDISTRIBUTED;
+
+	nlri = bgp_ls_lookup_bgp_prefix_nlri(bgp, p, route_type);
+	if (!nlri)
+		return 0;
+
+	return bgp_ls_withdraw(bgp, nlri);
+}

--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -59,6 +59,9 @@ static json_object *node_desc_to_json(struct bgp_ls_node_descriptor *node)
 		json_object_string_add(json_node, "igpRouterId", igp_router_id);
 	}
 
+	if (BGP_LS_TLV_CHECK(node->present_tlvs, BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT))
+		json_object_string_addf(json_node, "bgpRouterId", "%pI4", &node->bgp_router_id);
+
 	return json_node;
 }
 
@@ -223,6 +226,13 @@ static void format_node_desc(char **p, size_t *remain, struct bgp_ls_node_descri
 			}
 		}
 		len = snprintfrr(*p, *remain, "]");
+		*p += len;
+		*remain -= len;
+	}
+
+	/* BGP Router ID (TLV 516) */
+	if (BGP_LS_TLV_CHECK(node->present_tlvs, BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT)) {
+		len = snprintfrr(*p, *remain, "[q%pI4]", &node->bgp_router_id);
 		*p += len;
 		*remain -= len;
 	}

--- a/bgpd/bgp_ls.c
+++ b/bgpd/bgp_ls.c
@@ -114,6 +114,11 @@ static json_object *prefix_desc_to_json(struct bgp_ls_prefix_descriptor *prefix_
 					bgp_ls_ospf_route_type_str_json(
 						prefix_desc->ospf_route_type));
 
+	/* BGP Route Type */
+	if (BGP_LS_TLV_CHECK(prefix_desc->present_tlvs, BGP_LS_PREFIX_DESC_BGP_ROUTE_TYPE_BIT))
+		json_object_string_addf(json_prefix, "bgpRouteType", "%s",
+					bgp_ls_bgp_route_type_str_json(prefix_desc->bgp_route_type));
+
 	return json_prefix;
 }
 
@@ -402,6 +407,15 @@ void bgp_ls_nlri_format(struct bgp_ls_nlri *nlri, char *buf, size_t buf_len)
 		len = snprintfrr(p, remain, "]]");
 		p += len;
 		remain -= len;
+
+		/* Format BGP Route Type if present */
+		if (BGP_LS_TLV_CHECK(nlri->nlri_data.prefix.prefix_desc.present_tlvs,
+				     BGP_LS_PREFIX_DESC_BGP_ROUTE_TYPE_BIT)) {
+			len = snprintfrr(p, remain, "[br0x%02x]",
+					 nlri->nlri_data.prefix.prefix_desc.bgp_route_type);
+			p += len;
+			remain -= len;
+		}
 	}
 }
 

--- a/bgpd/bgp_ls.h
+++ b/bgpd/bgp_ls.h
@@ -28,6 +28,11 @@ struct bgp_ls {
 
 	/* Link-state database registration status */
 	bool registered_ls_db;
+
+	bool enable_distribution;
+
+	/* BGP-fabric link-state instance ID */
+	uint64_t instance_id;
 };
 
 /* Function prototypes */
@@ -82,5 +87,38 @@ extern void bgp_ls_nlri_format(struct bgp_ls_nlri *nlri, char *buf, size_t buf_l
 /* Module initialization and cleanup */
 extern void bgp_ls_init(struct bgp *bgp);
 extern void bgp_ls_cleanup(struct bgp *bgp);
+
+/*
+ * ===========================================================================
+ * BGP Topology Export (BGP-only fabrics)
+ * ===========================================================================
+ */
+
+/*
+ * Export BGP topology as BGP-LS NLRIs
+ *
+ * Iterates through all BGP peers and generates Node and Link NLRIs
+ * representing the BGP topology. Used for BGP-only fabrics per
+ * draft-ietf-idr-bgp-ls-bgp-only-fabric.
+ *
+ * @param bgp - BGP instance
+ * @return 0 on success, -1 on error
+ */
+extern int bgp_ls_export_bgp_topology(struct bgp *bgp);
+void bgp_ls_withdraw_all(struct bgp *bgp);
+int bgp_ls_withdraw_bgp_link(struct bgp *bgp, struct peer *peer);
+int bgp_ls_withdraw_bgp_prefix(struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *dest,
+			       struct bgp_path_info *path);
+
+/*
+ * ===========================================================================
+ * Link State Message Processing
+ * ===========================================================================
+ */
+
+extern int bgp_ls_originate_bgp_node(struct bgp *bgp);
+extern int bgp_ls_originate_bgp_link(struct bgp *bgp, struct peer *peer);
+extern int bgp_ls_originate_bgp_prefix(struct bgp *bgp, afi_t afi, safi_t safi,
+				       struct bgp_dest *dest, struct bgp_path_info *path);
 
 #endif /* _FRR_BGP_LS_H */

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -60,6 +60,13 @@ int bgp_ls_node_descriptor_cmp(const struct bgp_ls_node_descriptor *d1,
 			return ret;
 	}
 
+	/* Compare BGP Router ID if present */
+	if (BGP_LS_TLV_CHECK(d1->present_tlvs, BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT)) {
+		ret = IPV4_ADDR_CMP(&d1->bgp_router_id, &d2->bgp_router_id);
+		if (ret != 0)
+			return ret;
+	}
+
 	return 0;
 }
 
@@ -705,10 +712,13 @@ bool bgp_ls_nlri_validate(const struct bgp_ls_nlri *nlri)
 			return false;
 
 		/* IGP Router ID is mandatory (RFC 9552 Section 5.2.1.4) */
-		if (!BGP_LS_TLV_CHECK(n->local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT))
+		if (!BGP_LS_TLV_CHECK(n->local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT) &&
+		    !BGP_LS_TLV_CHECK(n->local_node.present_tlvs,
+				      BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT))
 			return false;
 
-		if (!bgp_ls_igp_router_id_len_valid(n->protocol_id,
+		if (BGP_LS_TLV_CHECK(n->local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT) &&
+		    !bgp_ls_igp_router_id_len_valid(n->protocol_id,
 						    n->local_node.igp_router_id_len))
 			return false;
 
@@ -722,17 +732,24 @@ bool bgp_ls_nlri_validate(const struct bgp_ls_nlri *nlri)
 			return false;
 
 		/* Local node IGP Router ID is mandatory */
-		if (!BGP_LS_TLV_CHECK(l->local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT))
+		if (!BGP_LS_TLV_CHECK(l->local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT) &&
+		    !BGP_LS_TLV_CHECK(l->local_node.present_tlvs,
+				      BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT))
 			return false;
 
 		/* Remote node IGP Router ID is mandatory */
-		if (!BGP_LS_TLV_CHECK(l->remote_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT))
+		if (!BGP_LS_TLV_CHECK(l->remote_node.present_tlvs,
+				      BGP_LS_NODE_DESC_IGP_ROUTER_BIT) &&
+		    !BGP_LS_TLV_CHECK(l->remote_node.present_tlvs,
+				      BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT))
 			return false;
 
-		if (!bgp_ls_igp_router_id_len_valid(l->protocol_id,
-						    l->local_node.igp_router_id_len) ||
-		    !bgp_ls_igp_router_id_len_valid(l->protocol_id,
-						    l->remote_node.igp_router_id_len))
+		if ((BGP_LS_TLV_CHECK(l->local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT) &&
+		     !bgp_ls_igp_router_id_len_valid(l->protocol_id,
+						     l->local_node.igp_router_id_len)) ||
+		    (BGP_LS_TLV_CHECK(l->remote_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT) &&
+		     !bgp_ls_igp_router_id_len_valid(l->protocol_id,
+						     l->remote_node.igp_router_id_len)))
 			return false;
 
 		return true;
@@ -745,10 +762,13 @@ bool bgp_ls_nlri_validate(const struct bgp_ls_nlri *nlri)
 			return false;
 
 		/* Local node IGP Router ID is mandatory */
-		if (!BGP_LS_TLV_CHECK(p->local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT))
+		if (!BGP_LS_TLV_CHECK(p->local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT) &&
+		    !BGP_LS_TLV_CHECK(p->local_node.present_tlvs,
+				      BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT))
 			return false;
 
-		if (!bgp_ls_igp_router_id_len_valid(p->protocol_id,
+		if (BGP_LS_TLV_CHECK(p->local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT) &&
+		    !bgp_ls_igp_router_id_len_valid(p->protocol_id,
 						    p->local_node.igp_router_id_len))
 			return false;
 
@@ -766,10 +786,13 @@ bool bgp_ls_nlri_validate(const struct bgp_ls_nlri *nlri)
 			return false;
 
 		/* Local node IGP Router ID is mandatory */
-		if (!BGP_LS_TLV_CHECK(p->local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT))
+		if (!BGP_LS_TLV_CHECK(p->local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT) &&
+		    !BGP_LS_TLV_CHECK(p->local_node.present_tlvs,
+				      BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT))
 			return false;
 
-		if (!bgp_ls_igp_router_id_len_valid(p->protocol_id,
+		if (BGP_LS_TLV_CHECK(p->local_node.present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT) &&
+		    !bgp_ls_igp_router_id_len_valid(p->protocol_id,
 						    p->local_node.igp_router_id_len))
 			return false;
 
@@ -811,6 +834,9 @@ static size_t bgp_ls_node_descriptor_size(const struct bgp_ls_node_descriptor *d
 	/* IGP Router ID TLV */
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT))
 		size += BGP_LS_TLV_HDR_SIZE + desc->igp_router_id_len;
+	/* BGP Router ID TLV */
+	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT))
+		size += BGP_LS_TLV_HDR_SIZE + BGP_LS_BGP_ROUTER_ID_SIZE;
 
 	return size;
 }
@@ -959,6 +985,8 @@ const char *bgp_ls_node_descriptor_tlv_str(enum bgp_ls_node_descriptor_tlv tlv_t
 		return "OSPF Area-ID";
 	case BGP_LS_TLV_IGP_ROUTER_ID:
 		return "IGP Router-ID";
+	case BGP_LS_TLV_BGP_ROUTER_ID:
+		return "BGP Router-ID";
 	}
 
 	return "Unknown";
@@ -1059,6 +1087,9 @@ static unsigned int bgp_ls_node_descriptor_hash(const struct bgp_ls_node_descrip
 
 	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_NODE_DESC_IGP_ROUTER_BIT))
 		key = jhash(desc->igp_router_id, desc->igp_router_id_len, key);
+
+	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT))
+		key = jhash_1word(desc->bgp_router_id.s_addr, key);
 
 	return key;
 }
@@ -1542,6 +1573,15 @@ int bgp_ls_encode_node_descriptor(struct stream *s, const struct bgp_ls_node_des
 		stream_putw(s, BGP_LS_TLV_IGP_ROUTER_ID);
 		stream_putw(s, desc->igp_router_id_len);
 		stream_put(s, desc->igp_router_id, desc->igp_router_id_len);
+	}
+
+	/* BGP Router ID (TLV 516) */
+	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT)) {
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_BGP_ROUTER_ID_SIZE)
+			return -1;
+		stream_putw(s, BGP_LS_TLV_BGP_ROUTER_ID);
+		stream_putw(s, BGP_LS_BGP_ROUTER_ID_SIZE);
+		stream_put_ipv4(s, desc->bgp_router_id.s_addr);
 	}
 
 	/* Update length field */
@@ -2460,6 +2500,7 @@ int bgp_ls_decode_node_descriptor(struct stream *s, struct bgp_ls_node_descripto
 	size_t end_pos;
 	uint16_t sub_type, sub_len;
 	bool has_igp_router_id = false;
+	bool has_bgp_router_id = false;
 
 	if (!s || !desc)
 		return -1;
@@ -2543,6 +2584,23 @@ int bgp_ls_decode_node_descriptor(struct stream *s, struct bgp_ls_node_descripto
 			has_igp_router_id = true;
 			break;
 
+		case BGP_LS_TLV_BGP_ROUTER_ID:
+			if (BGP_LS_TLV_CHECK(desc->present_tlvs,
+					     BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT)) {
+				flog_warn(EC_BGP_LS_PACKET,
+					  "BGP-LS: duplicate BGP Router-ID TLV in node descriptor");
+				return -1;
+			}
+			if (sub_len != BGP_LS_BGP_ROUTER_ID_SIZE) {
+				flog_warn(EC_BGP_LS_PACKET,
+					  "BGP-LS: Invalid BGP Router-ID TLV length %u", sub_len);
+				return -1;
+			}
+			desc->bgp_router_id.s_addr = stream_get_ipv4(s);
+			BGP_LS_TLV_SET(desc->present_tlvs, BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT);
+			has_bgp_router_id = true;
+			break;
+
 		default:
 			/* Unknown TLV - skip but preserve (RFC 9552 Section 5.1) */
 			flog_warn(EC_BGP_LS_PACKET,
@@ -2554,9 +2612,9 @@ int bgp_ls_decode_node_descriptor(struct stream *s, struct bgp_ls_node_descripto
 	}
 
 	/* Verify mandatory TLV present */
-	if (!has_igp_router_id) {
+	if (!has_igp_router_id && !has_bgp_router_id) {
 		flog_warn(EC_BGP_LS_PACKET,
-			  "BGP-LS: Mandatory IGP Router-ID TLV missing from Node Descriptor");
+			  "BGP-LS: Mandatory IGP Router-ID TLV or BGP Router-ID TLV missing from Node Descriptor");
 		return -1;
 	}
 
@@ -4847,6 +4905,8 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 				vty_out(vty, "\tRouter ID IPv6: %pI6\n",
 					(struct in6_addr *)local_node->igp_router_id);
 		}
+		if (BGP_LS_TLV_CHECK(local_node->present_tlvs, BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT))
+			vty_out(vty, "\tBGP Router Identifier: %pI4\n", &local_node->bgp_router_id);
 	}
 
 	/* Display Remote Node Descriptor for Link NLRI */
@@ -4879,6 +4939,9 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 				vty_out(vty, "\tRouter ID IPv6: %pI6\n",
 					(struct in6_addr *)remote_node->igp_router_id);
 		}
+		if (BGP_LS_TLV_CHECK(remote_node->present_tlvs, BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT))
+			vty_out(vty, "\tBGP Router Identifier: %pI4\n",
+				&remote_node->bgp_router_id);
 
 		/* Display Link Descriptor */
 		struct bgp_ls_link_descriptor *link_desc = &nlri->nlri_data.link.link_desc;

--- a/bgpd/bgp_ls_nlri.c
+++ b/bgpd/bgp_ls_nlri.c
@@ -178,6 +178,12 @@ int bgp_ls_prefix_descriptor_cmp(const struct bgp_ls_prefix_descriptor *d1,
 		}
 	}
 
+	/* Compare BGP Route Type if present */
+	if (BGP_LS_TLV_CHECK(d1->present_tlvs, BGP_LS_PREFIX_DESC_BGP_ROUTE_TYPE_BIT)) {
+		if (d1->bgp_route_type != d2->bgp_route_type)
+			return numcmp(d1->bgp_route_type, d2->bgp_route_type);
+	}
+
 	return 0;
 }
 
@@ -912,6 +918,11 @@ size_t bgp_ls_nlri_size(const struct bgp_ls_nlri *nlri)
 			size += BGP_LS_TLV_HDR_SIZE + BGP_LS_PREFIX_LEN_SIZE +
 				BGP_LS_IPV6_ADDR_SIZE;
 
+		/* BGP Route Type TLV */
+		if (BGP_LS_TLV_CHECK(p->prefix_desc.present_tlvs,
+				     BGP_LS_PREFIX_DESC_BGP_ROUTE_TYPE_BIT))
+			size += BGP_LS_TLV_HDR_SIZE + BGP_LS_BGP_ROUTE_TYPE_SIZE;
+
 		break;
 	}
 
@@ -1021,6 +1032,8 @@ const char *bgp_ls_prefix_descriptor_tlv_str(enum bgp_ls_prefix_descriptor_tlv t
 		return "OSPF Route Type";
 	case BGP_LS_TLV_IP_REACH_INFO:
 		return "IP Reachability Information";
+	case BGP_LS_TLV_BGP_ROUTE_TYPE:
+		return "BGP Route Type";
 	}
 
 	return "Unknown";
@@ -1046,6 +1059,24 @@ const char *bgp_ls_ospf_route_type_str(enum bgp_ls_ospf_route_type route_type)
 	return "Unknown";
 }
 
+const char *bgp_ls_bgp_route_type_str(enum bgp_ls_bgp_route_type route_type)
+{
+	switch (route_type) {
+	case BGP_LS_BGP_RT_LOCAL:
+		return "Local";
+	case BGP_LS_BGP_RT_ATTACHED:
+		return "Attached";
+	case BGP_LS_BGP_RT_EXTERNAL_BGP:
+		return "External BGP";
+	case BGP_LS_BGP_RT_INTERNAL_BGP:
+		return "Internal BGP";
+	case BGP_LS_BGP_RT_REDISTRIBUTED:
+		return "Redistributed";
+	}
+
+	return "Unknown";
+}
+
 const char *bgp_ls_ospf_route_type_str_json(enum bgp_ls_ospf_route_type route_type)
 {
 	switch (route_type) {
@@ -1064,6 +1095,24 @@ const char *bgp_ls_ospf_route_type_str_json(enum bgp_ls_ospf_route_type route_ty
 	}
 
 	return "Unknown";
+}
+
+const char *bgp_ls_bgp_route_type_str_json(enum bgp_ls_bgp_route_type route_type)
+{
+	switch (route_type) {
+	case BGP_LS_BGP_RT_LOCAL:
+		return "local";
+	case BGP_LS_BGP_RT_ATTACHED:
+		return "attached";
+	case BGP_LS_BGP_RT_EXTERNAL_BGP:
+		return "externalBgp";
+	case BGP_LS_BGP_RT_INTERNAL_BGP:
+		return "internalBgp";
+	case BGP_LS_BGP_RT_REDISTRIBUTED:
+		return "redistributed";
+	}
+
+	return "unknown";
 }
 
 /*
@@ -1168,6 +1217,11 @@ static unsigned int bgp_ls_prefix_hash_key_internal(const struct bgp_ls_nlri *nl
 	/* Hash OSPF route type if present */
 	if (BGP_LS_TLV_CHECK(prefix->prefix_desc.present_tlvs, BGP_LS_PREFIX_DESC_OSPF_ROUTE_BIT))
 		key = jhash_1word(prefix->prefix_desc.ospf_route_type, key);
+
+	/* Hash BGP route type if present */
+	if (BGP_LS_TLV_CHECK(prefix->prefix_desc.present_tlvs,
+			     BGP_LS_PREFIX_DESC_BGP_ROUTE_TYPE_BIT))
+		key = jhash_1word(prefix->prefix_desc.bgp_route_type, key);
 
 	return key;
 }
@@ -1758,6 +1812,15 @@ int bgp_ls_encode_prefix_descriptor(struct stream *s, const struct bgp_ls_prefix
 		stream_putw(s, BGP_LS_PREFIX_LEN_SIZE + prefix_len_bytes);
 		stream_putc(s, desc->prefix.prefixlen);
 		stream_put(s, &desc->prefix.u.prefix6, prefix_len_bytes);
+	}
+
+	/* BGP Route Type */
+	if (BGP_LS_TLV_CHECK(desc->present_tlvs, BGP_LS_PREFIX_DESC_BGP_ROUTE_TYPE_BIT)) {
+		if (STREAM_WRITEABLE(s) < BGP_LS_TLV_HDR_SIZE + BGP_LS_BGP_ROUTE_TYPE_SIZE)
+			return -1;
+		stream_putw(s, BGP_LS_TLV_BGP_ROUTE_TYPE);
+		stream_putw(s, BGP_LS_BGP_ROUTE_TYPE_SIZE);
+		stream_putc(s, desc->bgp_route_type);
 	}
 
 	return stream_get_endp(s) - start;
@@ -2941,6 +3004,29 @@ int bgp_ls_decode_prefix_descriptor(struct stream *s, struct bgp_ls_prefix_descr
 
 			BGP_LS_TLV_SET(desc->present_tlvs, BGP_LS_PREFIX_DESC_IP_REACH_BIT);
 			has_ip_reach = true;
+			break;
+
+		case BGP_LS_TLV_BGP_ROUTE_TYPE:
+			if (BGP_LS_TLV_CHECK(desc->present_tlvs,
+					     BGP_LS_PREFIX_DESC_BGP_ROUTE_TYPE_BIT)) {
+				flog_warn(EC_BGP_LS_PACKET,
+					  "BGP-LS: duplicate BGP Route Type TLV in prefix descriptor");
+				goto error;
+			}
+			if (tlv_len != BGP_LS_BGP_ROUTE_TYPE_SIZE) {
+				flog_warn(EC_BGP_LS_PACKET,
+					  "BGP-LS: Invalid BGP Route Type TLV length %u", tlv_len);
+				goto error;
+			}
+			desc->bgp_route_type = stream_getc(s);
+			if (desc->bgp_route_type < BGP_LS_BGP_RT_LOCAL ||
+			    desc->bgp_route_type > BGP_LS_BGP_RT_REDISTRIBUTED) {
+				flog_warn(EC_BGP_LS_PACKET,
+					  "BGP-LS: Invalid BGP Route Type value %u",
+					  desc->bgp_route_type);
+				goto error;
+			}
+			BGP_LS_TLV_SET(desc->present_tlvs, BGP_LS_PREFIX_DESC_BGP_ROUTE_TYPE_BIT);
 			break;
 
 		default:
@@ -5014,6 +5100,13 @@ void bgp_ls_nlri_display(struct vty *vty, struct bgp_ls_nlri *nlri)
 				break;
 			}
 			vty_out(vty, "\tOSPF Route Type: %s\n", ospf_rt_str);
+		}
+
+		/* BGP Route Type */
+		if (BGP_LS_TLV_CHECK(prefix_desc->present_tlvs,
+				     BGP_LS_PREFIX_DESC_BGP_ROUTE_TYPE_BIT)) {
+			vty_out(vty, "\tBGP Route Type: %s\n",
+				bgp_ls_bgp_route_type_str(prefix_desc->bgp_route_type));
 		}
 
 		/* Multi-Topology */

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -63,6 +63,7 @@ enum bgp_ls_node_descriptor_tlv {
 	BGP_LS_TLV_BGP_LS_ID = 513, /* BGP-LS Identifier (deprecated) - RFC 9552, Section 5.2.1.4 */
 	BGP_LS_TLV_OSPF_AREA_ID = 514,	/* OSPF Area-ID - RFC 9552, Section 5.2.1.4 */
 	BGP_LS_TLV_IGP_ROUTER_ID = 515, /* IGP Router-ID - RFC 9552, Section 5.2.1.4 */
+	BGP_LS_TLV_BGP_ROUTER_ID = 516, /* BGP Router-ID - RFC 9086 */
 };
 
 /*
@@ -186,6 +187,7 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_NODE_DESC_BGP_LS_ID_BIT	1
 #define BGP_LS_NODE_DESC_OSPF_AREA_BIT	2
 #define BGP_LS_NODE_DESC_IGP_ROUTER_BIT 3
+#define BGP_LS_NODE_DESC_BGP_ROUTER_ID_BIT 4
 
 /* Bit positions for Link Descriptor TLVs */
 #define BGP_LS_LINK_DESC_LINK_ID_BIT	0
@@ -239,6 +241,7 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_OSPF_ROUTE_TYPE_SIZE 1		     /* OSPF Route Type value */
 #define BGP_LS_MT_ID_SIZE	    2		     /* Multi-Topology ID (per entry) */
 #define BGP_LS_PREFIX_LEN_SIZE	    1		     /* IP prefix length field */
+#define BGP_LS_BGP_ROUTER_ID_SIZE   4		     /* BGP Router-ID value */
 
 /*
  * IGP Metric can be 1, 2, or 3 bytes
@@ -347,6 +350,7 @@ struct bgp_ls_node_descriptor {
 	uint32_t ospf_area_id;	   /* OSPF Area ID */
 	uint8_t igp_router_id_len; /* Length of IGP Router ID (4-16 bytes) */
 	uint8_t igp_router_id[BGP_LS_IGP_ROUTER_ID_MAX_SIZE]; /* IGP Router ID (ISIS, OSPF, Direct, or Static configuration) */
+	struct in_addr bgp_router_id;			      /* BGP Router-ID (TLV 516) */
 };
 
 /*

--- a/bgpd/bgp_ls_nlri.h
+++ b/bgpd/bgp_ls_nlri.h
@@ -87,6 +87,7 @@ enum bgp_ls_link_descriptor_tlv {
 enum bgp_ls_prefix_descriptor_tlv {
 	BGP_LS_TLV_OSPF_ROUTE_TYPE = 264, /* OSPF Route Type - RFC 9552, Section 5.2.3.1 */
 	BGP_LS_TLV_IP_REACH_INFO = 265, /* IP Reachability Information - RFC 9552, Section 5.2.3.2 */
+	BGP_LS_TLV_BGP_ROUTE_TYPE = 535, /* BGP Route Type - draft-ietf-idr-bgp-ls-bgp-only-fabric */
 };
 
 /*
@@ -100,6 +101,18 @@ enum bgp_ls_ospf_route_type {
 	BGP_LS_OSPF_RT_EXTERNAL_2 = 4, /* External Type 2 */
 	BGP_LS_OSPF_RT_NSSA_1 = 5,     /* NSSA Type 1 */
 	BGP_LS_OSPF_RT_NSSA_2 = 6,     /* NSSA Type 2 */
+};
+
+/*
+ * BGP Route Type Values
+ * draft-ietf-idr-bgp-ls-bgp-only-fabric-04, Section 4.3
+ */
+enum bgp_ls_bgp_route_type {
+	BGP_LS_BGP_RT_LOCAL = 1,	 /* Local interface prefix (e.g., Loopback) */
+	BGP_LS_BGP_RT_ATTACHED = 2,	 /* Directly attached node's prefix (e.g., host) */
+	BGP_LS_BGP_RT_EXTERNAL_BGP = 3,	 /* Prefix learned via EBGP */
+	BGP_LS_BGP_RT_INTERNAL_BGP = 4,	 /* Prefix learned via IBGP */
+	BGP_LS_BGP_RT_REDISTRIBUTED = 5, /* Prefix redistributed into BGP */
 };
 
 /*
@@ -202,6 +215,7 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_PREFIX_DESC_MT_ID_BIT	  0
 #define BGP_LS_PREFIX_DESC_OSPF_ROUTE_BIT 1
 #define BGP_LS_PREFIX_DESC_IP_REACH_BIT	  2
+#define BGP_LS_PREFIX_DESC_BGP_ROUTE_TYPE_BIT 3
 
 /* Maximum number of MT-IDs per descriptor */
 #define BGP_LS_MAX_MT_ID 16
@@ -242,6 +256,7 @@ enum bgp_ls_attr_tlv {
 #define BGP_LS_MT_ID_SIZE	    2		     /* Multi-Topology ID (per entry) */
 #define BGP_LS_PREFIX_LEN_SIZE	    1		     /* IP prefix length field */
 #define BGP_LS_BGP_ROUTER_ID_SIZE   4		     /* BGP Router-ID value */
+#define BGP_LS_BGP_ROUTE_TYPE_SIZE  1		     /* BGP Route Type value */
 
 /*
  * IGP Metric can be 1, 2, or 3 bytes
@@ -379,6 +394,7 @@ struct bgp_ls_prefix_descriptor {
 	uint8_t mt_id_count;			     /* Number of Multi-Topology IDs */
 	uint16_t *mt_id;			     /* Multi-Topology IDs */
 	enum bgp_ls_ospf_route_type ospf_route_type; /* OSPF Route Type */
+	enum bgp_ls_bgp_route_type bgp_route_type;   /* BGP Route Type */
 	struct prefix prefix;			     /* IP prefix (IPv4 or IPv6) */
 };
 
@@ -664,9 +680,11 @@ extern const char *bgp_ls_node_descriptor_tlv_str(enum bgp_ls_node_descriptor_tl
 extern const char *bgp_ls_link_descriptor_tlv_str(enum bgp_ls_link_descriptor_tlv tlv_type);
 extern const char *bgp_ls_prefix_descriptor_tlv_str(enum bgp_ls_prefix_descriptor_tlv tlv_type);
 extern const char *bgp_ls_ospf_route_type_str(enum bgp_ls_ospf_route_type route_type);
+extern const char *bgp_ls_bgp_route_type_str(enum bgp_ls_bgp_route_type route_type);
 
 /* Json conversion helpers */
 extern const char *bgp_ls_ospf_route_type_str_json(enum bgp_ls_ospf_route_type route_type);
+extern const char *bgp_ls_bgp_route_type_str_json(enum bgp_ls_bgp_route_type route_type);
 
 /*
  * ===========================================================================

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5406,6 +5406,8 @@ static void bgp_rib_withdraw(const struct prefix *p, struct bgp_dest *dest, stru
 	if (advertise_type5_routes_multipath(peer->bgp, afi) && is_route_injectable_into_evpn(pi))
 		bgp_evpn_unexport_type5_route(peer->bgp, dest, pi, afi, safi);
 
+	bgp_ls_withdraw_bgp_prefix(peer->bgp, afi, safi, dest, pi);
+
 	bgp_rib_remove(dest, pi, peer, afi, safi);
 }
 
@@ -6220,6 +6222,8 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 			force_evpn_export = true;
 		}
 
+		bgp_ls_withdraw_bgp_prefix(bgp, afi, safi, dest, pi);
+
 		/* Special handling for EVPN update of an existing route. If the
 		 * extended community or nexthop attribute has changed, we need
 		 * to un-import
@@ -6308,6 +6312,8 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 			bgp_evpn_export_type5_route(bgp, dest, pi, afi, safi);
 		}
 
+		bgp_ls_originate_bgp_prefix(bgp, afi, safi, dest, pi);
+
 		/* Update bgp route dampening information.  */
 		if (get_active_bdc_from_pi(pi, afi, safi) &&
 		    peer->sort == BGP_PEER_EBGP) {
@@ -6388,6 +6394,10 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 		    && (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT)) {
 			vpn_leak_to_vrf_update(bgp, pi, prd, peer);
 		}
+
+		if (safi == SAFI_UNICAST && bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT &&
+		    bgp->ls_info && bgp->ls_info->enable_distribution)
+			bgp_ls_originate_bgp_prefix(bgp, afi, safi, dest, pi);
 
 #ifdef ENABLE_BGP_VNC
 		if (SAFI_MPLS_VPN == safi) {
@@ -6473,6 +6483,8 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	if (advertise_type5_routes_multipath(bgp, afi) && is_route_injectable_into_evpn(new))
 		bgp_evpn_export_type5_route(bgp, dest, new, afi, safi);
 
+	bgp_ls_originate_bgp_prefix(bgp, afi, safi, dest, new);
+
 	hook_call(bgp_process, bgp, afi, safi, dest, peer, false);
 
 	/* Process change. */
@@ -6499,6 +6511,10 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 				   sub_type, NULL);
 	}
 #endif
+
+	if (safi == SAFI_UNICAST && bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT && bgp->ls_info &&
+	    bgp->ls_info->enable_distribution)
+		bgp_ls_originate_bgp_prefix(bgp, afi, safi, dest, new);
 
 	if (p_evpn)
 		evpn_overlay_free(p_evpn);
@@ -6538,6 +6554,8 @@ filtered:
 		/* If this route is exported to EVPN, process for un-export as it is now filtered */
 		if (advertise_type5_routes_multipath(bgp, afi) && is_route_injectable_into_evpn(pi))
 			bgp_evpn_unexport_type5_route(bgp, dest, pi, afi, safi);
+
+		bgp_ls_withdraw_bgp_prefix(bgp, afi, safi, dest, pi);
 
 		if (SAFI_UNICAST == safi
 		    && (bgp->inst_type == BGP_INSTANCE_TYPE_VRF
@@ -7088,6 +7106,8 @@ static wq_item_status bgp_clear_route_node(struct work_queue *wq, void *data)
 			if (advertise_type5_routes_multipath(bgp, afi) &&
 			    is_route_injectable_into_evpn(pi))
 				bgp_evpn_unexport_type5_route(bgp, dest, pi, afi, safi);
+
+			bgp_ls_withdraw_bgp_prefix(bgp, afi, safi, dest, pi);
 			/* Handle withdraw for VRF route-leaking and L3VPN */
 			if (SAFI_UNICAST == safi
 			    && (bgp->inst_type == BGP_INSTANCE_TYPE_VRF ||
@@ -7316,6 +7336,8 @@ static void clearing_clear_one_pi(struct bgp_table *table, struct bgp_dest *dest
 		/* If this is a route exported to EVPN, process for un-export */
 		if (advertise_type5_routes_multipath(bgp, afi) && is_route_injectable_into_evpn(pi))
 			bgp_evpn_unexport_type5_route(bgp, dest, pi, afi, safi);
+
+		bgp_ls_withdraw_bgp_prefix(bgp, afi, safi, dest, pi);
 		/* Handle withdraw for VRF route-leaking and L3VPN */
 		if (SAFI_UNICAST == safi
 		    && (bgp->inst_type == BGP_INSTANCE_TYPE_VRF ||
@@ -7870,6 +7892,8 @@ void bgp_clear_stale_route(struct peer *peer, afi_t afi, safi_t safi)
 					bgp_evpn_unexport_type5_route(peer->bgp, dest, pi, afi,
 								      safi);
 
+				bgp_ls_withdraw_bgp_prefix(peer->bgp, afi, safi, dest, pi);
+
 				bgp_rib_remove(dest, pi, peer, afi, safi);
 			}
 	}
@@ -8000,6 +8024,8 @@ static void bgp_cleanup_table(struct bgp *bgp, struct bgp_table *table, afi_t af
 			if (advertise_type5_routes_multipath(bgp, afi) &&
 			    is_route_injectable_into_evpn(pi))
 				bgp_evpn_unexport_type5_route(bgp, dest, pi, afi, safi);
+
+			bgp_ls_withdraw_bgp_prefix(bgp, afi, safi, dest, pi);
 
 			if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED) &&
 			    bgp_zebra_announce_eligible(pi)) {
@@ -8497,6 +8523,8 @@ void bgp_static_update(struct bgp *bgp, const struct prefix *p,
 			    is_route_injectable_into_evpn(pi))
 				bgp_evpn_export_type5_route(bgp, dest, pi, afi, safi);
 
+			bgp_ls_originate_bgp_prefix(bgp, afi, safi, dest, pi);
+
 			bgp_dest_unlock_node(dest);
 			aspath_unintern(&attr.aspath);
 			return;
@@ -8549,6 +8577,8 @@ void bgp_static_update(struct bgp *bgp, const struct prefix *p,
 	if (advertise_type5_routes_multipath(bgp, afi) && is_route_injectable_into_evpn(new))
 		bgp_evpn_export_type5_route(bgp, dest, new, afi, safi);
 
+	bgp_ls_originate_bgp_prefix(bgp, afi, safi, dest, new);
+
 #ifdef ENABLE_BGP_VNC
 	if (safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP || safi == SAFI_EVPN)
 		rfapiProcessUpdate(new->peer, NULL, p, &bgp_static->prd,
@@ -8598,6 +8628,8 @@ void bgp_static_withdraw(struct bgp *bgp, const struct prefix *p, afi_t afi,
 		/* If this is a route exported to EVPN, process for un-export. */
 		if (advertise_type5_routes_multipath(bgp, afi) && is_route_injectable_into_evpn(pi))
 			bgp_evpn_unexport_type5_route(bgp, dest, pi, afi, safi);
+
+		bgp_ls_withdraw_bgp_prefix(bgp, afi, safi, dest, pi);
 
 		bgp_aggregate_decrement(bgp, p, pi, afi, safi);
 		bgp_unlink_nexthop(pi);
@@ -9373,6 +9405,7 @@ static void bgp_aggregate_install(
 		if (advertise_type5_routes_multipath(bgp, afi) &&
 		    is_route_injectable_into_evpn(new))
 			bgp_evpn_export_type5_route(bgp, dest, new, afi, safi);
+		bgp_ls_originate_bgp_prefix(bgp, afi, safi, dest, new);
 	} else {
 	uninstall_aggregate_route:
 			/* Withdraw the aggregate route from routing table. */
@@ -9389,6 +9422,8 @@ static void bgp_aggregate_install(
 				if (advertise_type5_routes_multipath(bgp, afi) &&
 				    is_route_injectable_into_evpn(pi))
 					bgp_evpn_unexport_type5_route(bgp, dest, pi, afi, safi);
+
+				bgp_ls_withdraw_bgp_prefix(bgp, afi, safi, dest, pi);
 			}
 	}
 
@@ -9504,6 +9539,8 @@ void bgp_aggregate_toggle_suppressed(struct bgp_aggregate *aggregate,
 					    is_route_injectable_into_evpn(pi))
 						bgp_evpn_unexport_type5_route(bgp, dest, pi, afi,
 									      safi);
+
+					bgp_ls_withdraw_bgp_prefix(bgp, afi, safi, dest, pi);
 				}
 				continue;
 			}
@@ -9518,6 +9555,8 @@ void bgp_aggregate_toggle_suppressed(struct bgp_aggregate *aggregate,
 				if (advertise_type5_routes_multipath(bgp, afi) &&
 				    is_route_injectable_into_evpn(pi))
 					bgp_evpn_unexport_type5_route(bgp, dest, pi, afi, safi);
+
+				bgp_ls_withdraw_bgp_prefix(bgp, afi, safi, dest, pi);
 			}
 		}
 	}
@@ -9660,6 +9699,8 @@ bool bgp_aggregate_route(struct bgp *bgp, const struct prefix *p, afi_t afi,
 					    is_route_injectable_into_evpn(pi))
 						bgp_evpn_unexport_type5_route(bgp, dest, pi, afi,
 									      safi);
+
+					bgp_ls_withdraw_bgp_prefix(bgp, afi, safi, dest, pi);
 				}
 			}
 
@@ -9686,6 +9727,8 @@ bool bgp_aggregate_route(struct bgp *bgp, const struct prefix *p, afi_t afi,
 					    is_route_injectable_into_evpn(pi))
 						bgp_evpn_unexport_type5_route(bgp, dest, pi, afi,
 									      safi);
+
+					bgp_ls_withdraw_bgp_prefix(bgp, afi, safi, dest, pi);
 				}
 			}
 
@@ -9844,6 +9887,8 @@ void bgp_aggregate_delete(struct bgp *bgp, const struct prefix *p, afi_t afi,
 					    is_route_injectable_into_evpn(pi))
 						bgp_evpn_export_type5_route(bgp, dest, pi, afi,
 									    safi);
+
+					bgp_ls_originate_bgp_prefix(bgp, afi, safi, dest, pi);
 				}
 			}
 
@@ -10058,6 +10103,8 @@ static void bgp_remove_route_from_aggregate(struct bgp *bgp, afi_t afi,
 			if (advertise_type5_routes_multipath(bgp, afi) &&
 			    is_route_injectable_into_evpn(pi))
 				bgp_evpn_export_type5_route(bgp, pi->net, pi, afi, safi);
+
+			bgp_ls_originate_bgp_prefix(bgp, afi, safi, pi->net, pi);
 		}
 
 	if (aggregate->suppress_map_name && AGGREGATE_MED_VALID(aggregate)
@@ -10070,6 +10117,8 @@ static void bgp_remove_route_from_aggregate(struct bgp *bgp, afi_t afi,
 			if (advertise_type5_routes_multipath(bgp, afi) &&
 			    is_route_injectable_into_evpn(pi))
 				bgp_evpn_export_type5_route(bgp, pi->net, pi, afi, safi);
+
+			bgp_ls_originate_bgp_prefix(bgp, afi, safi, pi->net, pi);
 		}
 
 	/*
@@ -10756,6 +10805,7 @@ void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 				    is_route_injectable_into_evpn(bpi))
 					bgp_evpn_export_type5_route(bgp, bn, bpi, afi,
 								    SAFI_UNICAST);
+				bgp_ls_originate_bgp_prefix(bgp, afi, SAFI_UNICAST, bn, bpi);
 				return;
 			}
 		}
@@ -10778,6 +10828,9 @@ void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 		if (advertise_type5_routes_multipath(bgp, afi) &&
 		    is_route_injectable_into_evpn(new))
 			bgp_evpn_export_type5_route(bgp, bn, new, afi, SAFI_UNICAST);
+
+		if (bgp && bgp->ls_info && bgp->ls_info->enable_distribution)
+			bgp_ls_originate_bgp_prefix(bgp, afi, SAFI_UNICAST, bn, new);
 	}
 
 	/* Unintern original. */
@@ -10814,6 +10867,8 @@ void bgp_redistribute_delete(struct bgp *bgp, struct prefix *p, uint8_t type,
 			if (advertise_type5_routes_multipath(bgp, afi) &&
 			    is_route_injectable_into_evpn(pi))
 				bgp_evpn_unexport_type5_route(bgp, dest, pi, afi, SAFI_UNICAST);
+
+			bgp_ls_withdraw_bgp_prefix(bgp, afi, SAFI_UNICAST, dest, pi);
 			bgp_aggregate_decrement(bgp, p, pi, afi, SAFI_UNICAST);
 			bgp_path_info_mark_for_delete(dest, pi);
 			bgp_process(bgp, dest, pi, afi, SAFI_UNICAST);
@@ -10851,6 +10906,8 @@ void bgp_redistribute_withdraw(struct bgp *bgp, afi_t afi, int type,
 			if (advertise_type5_routes_multipath(bgp, afi) &&
 			    is_route_injectable_into_evpn(pi))
 				bgp_evpn_unexport_type5_route(bgp, dest, pi, afi, SAFI_UNICAST);
+
+			bgp_ls_withdraw_bgp_prefix(bgp, afi, SAFI_UNICAST, dest, pi);
 			bgp_aggregate_decrement(bgp, bgp_dest_get_prefix(dest),
 						pi, afi, SAFI_UNICAST);
 			bgp_path_info_mark_for_delete(dest, pi);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -70,6 +70,7 @@
 #ifdef ENABLE_BGP_VNC
 #include "bgpd/rfapi/bgp_rfapi_cfg.h"
 #endif
+#include "bgpd/bgp_ls.h"
 
 FRR_CFG_DEFAULT_BOOL(BGP_IMPORT_CHECK,
 	{
@@ -19716,6 +19717,94 @@ DEFPY(bgp_retain_route_target, bgp_retain_route_target_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY(bgp_ls_distribute_bgp_fabric,
+      bgp_ls_distribute_bgp_fabric_cmd,
+      "distribute bgp-fabric-link-state [instance-id WORD$instance_id_str]",
+      "Distribute BGP link-state topology information\n"
+      "Enable BGP fabric link-state topology distribution\n"
+      "BGP-LS instance identifier\n"
+      "Instance ID value\n")
+{
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	uint64_t instance_id = 0;
+	char *endp = NULL;
+
+	if (!bgp->ls_info) {
+		vty_out(vty, "%% BGP-LS not initialized\n");
+		return CMD_WARNING;
+	}
+
+	if (instance_id_str) {
+		errno = 0;
+		instance_id = strtoull(instance_id_str, &endp, 10);
+		if (errno == ERANGE || endp == instance_id_str || *endp != '\0') {
+			vty_out(vty, "%% Invalid instance-id\n");
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	}
+
+	if (bgp->ls_info->enable_distribution && bgp->ls_info->instance_id == instance_id)
+		return CMD_SUCCESS;
+
+	/*
+	 * If already enabled with a different instance-id, withdraw all
+	 * existing NLRIs before re-exporting with the new instance-id.
+	 */
+	if (bgp->ls_info->enable_distribution && bgp->ls_info->instance_id != instance_id)
+		bgp_ls_withdraw_all(bgp);
+
+	bgp->ls_info->instance_id = instance_id;
+	bgp->ls_info->enable_distribution = true;
+
+	if (bgp_ls_export_bgp_topology(bgp) != 0) {
+		vty_out(vty, "%% Failed to export BGP topology\n");
+		return CMD_WARNING;
+	}
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		vty_out(vty,
+			"BGP-LS: BGP fabric topology export enabled (instance-id %" PRIu64 ")\n",
+			instance_id);
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(no_bgp_ls_distribute_bgp_fabric,
+      no_bgp_ls_distribute_bgp_fabric_cmd,
+      "no distribute bgp-fabric-link-state [instance-id WORD$instance_id_str]",
+      NO_STR
+      "Distribute BGP link-state topology information\n"
+      "Disable BGP fabric link-state topology distribution\n"
+      "BGP-LS instance identifier\n"
+      "Instance ID value\n")
+{
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	char *endp = NULL;
+
+	if (instance_id_str) {
+		errno = 0;
+		strtoull(instance_id_str, &endp, 10);
+		if (errno == ERANGE || endp == instance_id_str || *endp != '\0') {
+			vty_out(vty, "%% Invalid instance-id\n");
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	}
+
+	if (bgp->ls_info) {
+		if (!bgp->ls_info->enable_distribution)
+			return CMD_SUCCESS;
+
+		bgp->ls_info->enable_distribution = false;
+		bgp->ls_info->instance_id = 0;
+		bgp_ls_withdraw_all(bgp);
+	}
+
+	if (BGP_DEBUG(linkstate, LINKSTATE))
+		vty_out(vty, "BGP-LS: BGP fabric topology export disabled\n");
+
+	return CMD_SUCCESS;
+}
+
 static void bgp_config_write_redistribute(struct vty *vty, struct bgp *bgp,
 					  afi_t afi, safi_t safi)
 {
@@ -20825,6 +20914,16 @@ static void bgp_config_write_family(struct vty *vty, struct bgp *bgp, afi_t afi,
 			vty_frame(vty, "link-state link-state");
 	}
 	vty_frame(vty, "\n");
+
+	/* BGP-only fabric distribution */
+	if (afi == AFI_BGP_LS && safi == SAFI_BGP_LS && bgp->ls_info &&
+	    bgp->ls_info->enable_distribution) {
+		if (bgp->ls_info->instance_id != 0)
+			vty_out(vty, "  distribute bgp-fabric-link-state instance-id %" PRIu64 "\n",
+				bgp->ls_info->instance_id);
+		else
+			vty_out(vty, "  distribute bgp-fabric-link-state\n");
+	}
 
 	bgp_config_write_distance(vty, bgp, afi, safi);
 
@@ -23625,6 +23724,10 @@ void bgp_vty_init(void)
 	install_element(BGP_IPV6_NODE, &neighbor_encap_srv6_cmd);
 	install_element(BGP_IPV4_NODE, &neighbor_encap_srv6_cmd);
 	install_element(BGP_NODE, &no_bgp_sid_vpn_export_cmd);
+
+	/* BGP-LS commands */
+	install_element(BGP_LS_NODE, &bgp_ls_distribute_bgp_fabric_cmd);
+	install_element(BGP_LS_NODE, &no_bgp_ls_distribute_bgp_fabric_cmd);
 
 	bgp_vty_if_init();
 }

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -23449,6 +23449,8 @@ void bgp_vty_init(void)
 	install_element(BGP_FLOWSPECV6_NODE, &no_neighbor_route_map_cmd);
 	install_element(BGP_EVPN_NODE, &neighbor_route_map_cmd);
 	install_element(BGP_EVPN_NODE, &no_neighbor_route_map_cmd);
+	install_element(BGP_LS_NODE, &neighbor_route_map_cmd);
+	install_element(BGP_LS_NODE, &no_neighbor_route_map_cmd);
 
 	/* "neighbor unsuppress-map" commands. */
 	install_element(BGP_NODE, &neighbor_unsuppress_map_hidden_cmd);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -19805,6 +19805,140 @@ DEFPY(no_bgp_ls_distribute_bgp_fabric,
 	return CMD_SUCCESS;
 }
 
+DEFPY(neighbor_ls_local_link_id,
+      neighbor_ls_local_link_id_cmd,
+      "neighbor <A.B.C.D|X:X::X:X|WORD>$peer_str local-link-id (1-4294967295)$link_id",
+      NEIGHBOR_STR
+      NEIGHBOR_ADDR_STR2
+      "Configure local link ID for BGP-LS topology\n"
+      "Link identifier value\n")
+{
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	struct peer *peer;
+
+	peer = peer_and_group_lookup_vty(vty, peer_str);
+	if (!peer)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	/* If link ID unchanged, nothing to do. */
+	if (CHECK_FLAG(peer->flags, PEER_FLAG_LS_LOCAL_LINK_ID) &&
+	    peer->ls_local_link_id == link_id)
+		return CMD_SUCCESS;
+
+	/* Withdraw the existing link NLRI before changing the key. */
+	if (bgp->ls_info && bgp->ls_info->enable_distribution)
+		bgp_ls_withdraw_bgp_link(bgp, peer);
+
+	peer->ls_local_link_id = link_id;
+	SET_FLAG(peer->flags, PEER_FLAG_LS_LOCAL_LINK_ID);
+
+	/* Re-originate with the new local link ID. */
+	if (bgp->ls_info && bgp->ls_info->enable_distribution)
+		bgp_ls_originate_bgp_link(bgp, peer);
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(no_neighbor_ls_local_link_id,
+      no_neighbor_ls_local_link_id_cmd,
+      "no neighbor <A.B.C.D|X:X::X:X|WORD>$peer_str local-link-id [(1-4294967295)$link_id]",
+      NO_STR
+      NEIGHBOR_STR
+      NEIGHBOR_ADDR_STR2
+      "Configure local link ID for BGP-LS topology\n"
+      "Link identifier value\n")
+{
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	struct peer *peer;
+
+	peer = peer_and_group_lookup_vty(vty, peer_str);
+	if (!peer)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	if (!CHECK_FLAG(peer->flags, PEER_FLAG_LS_LOCAL_LINK_ID))
+		return CMD_SUCCESS;
+
+	/* Withdraw the existing link NLRI before clearing the key. */
+	if (bgp->ls_info && bgp->ls_info->enable_distribution)
+		bgp_ls_withdraw_bgp_link(bgp, peer);
+
+	peer->ls_local_link_id = 0;
+	UNSET_FLAG(peer->flags, PEER_FLAG_LS_LOCAL_LINK_ID);
+
+	/* Re-originate using the fallback local link ID (ifindex). */
+	if (bgp->ls_info && bgp->ls_info->enable_distribution)
+		bgp_ls_originate_bgp_link(bgp, peer);
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(neighbor_ls_remote_link_id,
+      neighbor_ls_remote_link_id_cmd,
+      "neighbor <A.B.C.D|X:X::X:X|WORD>$peer_str remote-link-id (1-4294967295)$link_id",
+      NEIGHBOR_STR
+      NEIGHBOR_ADDR_STR2
+      "Configure remote link ID for BGP-LS topology\n"
+      "Link identifier value\n")
+{
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	struct peer *peer;
+
+	peer = peer_and_group_lookup_vty(vty, peer_str);
+	if (!peer)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	/* If link ID unchanged, nothing to do. */
+	if (CHECK_FLAG(peer->flags, PEER_FLAG_LS_REMOTE_LINK_ID) &&
+	    peer->ls_remote_link_id == link_id)
+		return CMD_SUCCESS;
+
+	/* Withdraw the existing link NLRI before changing the key. */
+	if (bgp->ls_info && bgp->ls_info->enable_distribution)
+		bgp_ls_withdraw_bgp_link(bgp, peer);
+
+	peer->ls_remote_link_id = link_id;
+	SET_FLAG(peer->flags, PEER_FLAG_LS_REMOTE_LINK_ID);
+
+	/* Re-originate with the new remote link ID. */
+	if (bgp->ls_info && bgp->ls_info->enable_distribution)
+		bgp_ls_originate_bgp_link(bgp, peer);
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(no_neighbor_ls_remote_link_id,
+      no_neighbor_ls_remote_link_id_cmd,
+      "no neighbor <A.B.C.D|X:X::X:X|WORD>$peer_str remote-link-id [(1-4294967295)$link_id]",
+      NO_STR
+      NEIGHBOR_STR
+      NEIGHBOR_ADDR_STR2
+      "Configure remote link ID for BGP-LS topology\n"
+      "Link identifier value\n")
+{
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	struct peer *peer;
+
+	peer = peer_and_group_lookup_vty(vty, peer_str);
+	if (!peer)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	if (!CHECK_FLAG(peer->flags, PEER_FLAG_LS_REMOTE_LINK_ID))
+		return CMD_SUCCESS;
+
+	/* Withdraw the existing link NLRI before clearing the key. */
+	if (bgp->ls_info && bgp->ls_info->enable_distribution)
+		bgp_ls_withdraw_bgp_link(bgp, peer);
+
+	peer->ls_remote_link_id = 0;
+	UNSET_FLAG(peer->flags, PEER_FLAG_LS_REMOTE_LINK_ID);
+
+	/* Re-originate using the fallback remote link ID (0). */
+	if (bgp->ls_info && bgp->ls_info->enable_distribution)
+		bgp_ls_originate_bgp_link(bgp, peer);
+
+	return CMD_SUCCESS;
+}
+
 static void bgp_config_write_redistribute(struct vty *vty, struct bgp *bgp,
 					  afi_t afi, safi_t safi)
 {
@@ -20383,6 +20517,12 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 	/* ip-transparent on/off */
 	if (peergroup_flag_check(peer, PEER_FLAG_IP_TRANSPARENT))
 		vty_out(vty, " neighbor %s ip-transparent\n", addr);
+
+	/* BGP-LS link identifiers */
+	if (CHECK_FLAG(peer->flags, PEER_FLAG_LS_LOCAL_LINK_ID))
+		vty_out(vty, " neighbor %s local-link-id %u\n", addr, peer->ls_local_link_id);
+	if (CHECK_FLAG(peer->flags, PEER_FLAG_LS_REMOTE_LINK_ID))
+		vty_out(vty, " neighbor %s remote-link-id %u\n", addr, peer->ls_remote_link_id);
 
 	/* advertisement-interval */
 	if (peergroup_flag_check(peer, PEER_FLAG_ROUTEADV))
@@ -23728,6 +23868,10 @@ void bgp_vty_init(void)
 	/* BGP-LS commands */
 	install_element(BGP_LS_NODE, &bgp_ls_distribute_bgp_fabric_cmd);
 	install_element(BGP_LS_NODE, &no_bgp_ls_distribute_bgp_fabric_cmd);
+	install_element(BGP_NODE, &neighbor_ls_local_link_id_cmd);
+	install_element(BGP_NODE, &no_neighbor_ls_local_link_id_cmd);
+	install_element(BGP_NODE, &neighbor_ls_remote_link_id_cmd);
+	install_element(BGP_NODE, &no_neighbor_ls_remote_link_id_cmd);
 
 	bgp_vty_if_init();
 }

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -339,6 +339,9 @@ static int bgp_router_id_set(struct bgp *bgp, const struct in_addr *id,
 
 	vpn_handle_router_id_update(bgp, true, is_config);
 
+	if (bgp && bgp->ls_info && bgp->ls_info->enable_distribution)
+		bgp_ls_withdraw_all(bgp);
+
 	hook_call(bgp_routerid_update, bgp, true);
 
 	IPV4_ADDR_COPY(&bgp->router_id, id);
@@ -357,6 +360,9 @@ static int bgp_router_id_set(struct bgp *bgp, const struct in_addr *id,
 		bgp_evpn_handle_router_id_update(bgp, false);
 
 	vpn_handle_router_id_update(bgp, false, is_config);
+
+	if (bgp && bgp->ls_info && bgp->ls_info->enable_distribution)
+		bgp_ls_export_bgp_topology(bgp);
 
 	hook_call(bgp_routerid_update, bgp, false);
 	return 0;
@@ -3934,6 +3940,9 @@ peer_init:
 	pthread_mutex_init(&bgp->peer_errs_mtx, NULL);
 	bgp_peer_conn_errlist_init(&bgp->peer_conn_errlist);
 	bgp_clearing_info_init(&bgp->clearing_list);
+
+	if (bgp && bgp->ls_info && bgp->ls_info->enable_distribution)
+		bgp_ls_originate_bgp_node(bgp);
 
 	return bgp;
 }

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1839,6 +1839,9 @@ struct peer {
 #define PEER_FLAG_RPKI_STRICT	     (1ULL << 46) /* RPKI strict mode */
 #define PEER_FLAG_CAPABILITY_SOFT_VERSION_NEW (1ULL << 47)
 #define PEER_FLAG_REMOTE_AS		      (1ULL << 48) /* remote-as override */
+/* BGP-LS per-peer link identifiers configured */
+#define PEER_FLAG_LS_LOCAL_LINK_ID  (1ULL << 49)
+#define PEER_FLAG_LS_REMOTE_LINK_ID (1ULL << 50)
 
 	/*
 	 *GR-Disabled mode means unset PEER_FLAG_GRACEFUL_RESTART
@@ -2248,6 +2251,10 @@ struct peer {
 	struct llgr_info llgr[AFI_MAX][SAFI_MAX];
 
 	bool shut_during_cfg;
+
+	/* BGP-LS per-peer link identifiers (draft-ietf-idr-bgp-ls-bgp-only-fabric) */
+	uint32_t ls_local_link_id;
+	uint32_t ls_remote_link_id;
 
 #define BGP_ATTR_MAX 255
 	/* Path attributes discard */

--- a/doc/user/bgp-linkstate.rst
+++ b/doc/user/bgp-linkstate.rst
@@ -68,6 +68,73 @@ To receive and process BGP-LS information from peers without originating routes:
      neighbor 192.0.2.2 activate
     exit-address-family
 
+BGP-only Fabric Topology Distribution
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In a BGP-only fabric, topology is derived from BGP sessions and BGP routing
+state rather than from IGP protocols.
+
+This behavior aligns with the IETF document
+`draft-ietf-idr-bgp-ls-bgp-only-fabric
+<https://datatracker.ietf.org/doc/draft-ietf-idr-bgp-ls-bgp-only-fabric/>`_.
+
+FRR uses BGP-LS to advertise Node, Link, and Prefix topology for the fabric.
+
+Use the following command under the link-state address family to enable
+export of BGP-only fabric topology:
+
+.. clicmd:: distribute bgp-fabric-link-state [instance-id WORD]
+
+   Enable BGP-LS export for BGP-only fabrics. When enabled, FRR originates
+   BGP-LS Node, Link, and Prefix NLRIs from BGP adjacency and BGP RIB data.
+
+   This command is configured under ``address-family link-state link-state``.
+
+   ``instance-id`` is optional and sets the BGP-LS identifier in originated
+   NLRIs. If omitted, FRR uses ``0``.
+
+Example for a BGP-only fabric speaker with default instance-id:
+
+.. code-block:: frr
+
+   router bgp 65001
+    neighbor 10.255.1.2 remote-as 65000
+    !
+    address-family link-state link-state
+     distribute bgp-fabric-link-state
+     neighbor 10.255.1.2 activate
+    exit-address-family
+
+Example for a BGP-only fabric speaker with explicit instance-id:
+
+.. code-block:: frr
+
+   router bgp 65001
+    neighbor 10.255.1.2 remote-as 65000
+    !
+    address-family link-state link-state
+     distribute bgp-fabric-link-state instance-id 100
+     neighbor 10.255.1.2 activate
+    exit-address-family
+
+Per-neighbor Link Identifier Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following commands let you override local and remote link identifiers
+carried in BGP-LS Link NLRIs for a specific BGP neighbor. These commands are
+configured under ``router bgp`` and accept 32-bit values.
+
+.. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> local-link-id (1-4294967295)
+
+   Set the local link identifier in the neighbor's Link NLRI.
+   If unset, FRR uses the interface kernel ifindex (a unique per-interface
+   identifier) as the fallback value.
+
+.. clicmd:: neighbor <A.B.C.D|X:X::X:X|WORD> remote-link-id (1-4294967295)
+
+   Set the remote link identifier in the neighbor's Link NLRI.
+   If unset, FRR uses ``0`` as fallback.
+
 Displaying BGP-LS Information
 ------------------------------
 

--- a/tests/topotests/bgp_link_state_bgp_fabric/r1/frr.conf
+++ b/tests/topotests/bgp_link_state_bgp_fabric/r1/frr.conf
@@ -1,0 +1,50 @@
+!
+hostname r1
+!
+! Router 1: AS65001, IPv4 iBGP with r2
+!
+! debug bgp updates
+! debug bgp link-state
+! debug bgp zebra
+!
+interface lo
+ ip address 10.1.1.1/32
+!
+interface r1-eth1
+ description Link to r2
+ ip address 172.16.1.1/30
+!
+interface r1-eth0
+ description Point-to-point link to RR
+ ip address 10.255.1.1/30
+!
+! Static route for BGP-LS Prefix NLRI
+ip route 192.0.2.0/24 Null0
+!
+router bgp 65001
+ bgp router-id 1.1.1.1
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ !
+ ! iBGP neighbor (r2)
+ neighbor 172.16.1.2 remote-as 65001
+ neighbor 172.16.1.2 update-source r1-eth1
+ !
+ ! BGP-LS speaker
+ neighbor 10.255.1.2 remote-as 65000
+ !
+ ! IPv4 unicast for iBGP session
+ address-family ipv4 unicast
+  neighbor 172.16.1.2 activate
+  redistribute local
+  redistribute connected
+  redistribute static
+ exit-address-family
+ !
+ ! Link-State address family - export BGP topology to BGP-LS speaker
+ address-family link-state link-state
+  distribute bgp-fabric-link-state
+  neighbor 10.255.1.2 activate
+ exit-address-family
+!
+end

--- a/tests/topotests/bgp_link_state_bgp_fabric/r2/frr.conf
+++ b/tests/topotests/bgp_link_state_bgp_fabric/r2/frr.conf
@@ -1,0 +1,47 @@
+!
+hostname r2
+!
+! Router 2: AS65001, IPv4 iBGP with r1
+!
+! debug bgp updates
+! debug bgp link-state
+! debug bgp zebra
+!
+interface lo
+ ip address 10.2.2.2/32
+!
+interface r2-eth1
+ description Link to r1
+ ip address 172.16.1.2/30
+!
+interface r2-eth0
+ description Point-to-point link to RR
+ ip address 10.255.2.1/30
+!
+router bgp 65001
+ bgp router-id 2.2.2.2
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ !
+ ! iBGP neighbor (r1)
+ neighbor 172.16.1.1 remote-as 65001
+ neighbor 172.16.1.1 update-source r2-eth1
+ !
+ ! BGP-LS speaker
+ neighbor 10.255.2.2 remote-as 65000
+ !
+ ! IPv4 unicast for iBGP session
+ address-family ipv4 unicast
+  neighbor 172.16.1.1 activate
+  redistribute local
+  redistribute connected
+  redistribute static
+ exit-address-family
+ !
+ ! Link-State address family - export BGP topology to BGP-LS speaker
+ address-family link-state link-state
+  distribute bgp-fabric-link-state
+  neighbor 10.255.2.2 activate
+ exit-address-family
+!
+end

--- a/tests/topotests/bgp_link_state_bgp_fabric/r3/frr.conf
+++ b/tests/topotests/bgp_link_state_bgp_fabric/r3/frr.conf
@@ -1,0 +1,55 @@
+!
+hostname r3
+!
+! Router 3: AS65002, IPv6 eBGP with r4
+!
+! debug bgp updates
+! debug bgp link-state
+! debug bgp zebra
+!
+interface lo
+ ip address 10.3.3.3/32
+!
+interface r3-eth1
+ description Link to r4
+ ipv6 address 2001:db8:1::1/64
+!
+interface r3-eth0
+ description Point-to-point link to RR
+ ipv6 address 2001:db9:3::1/126
+!
+! Static route for BGP-LS Prefix NLRI
+ipv6 route 2001:db9:1:124::/64 Null0
+!
+router bgp 65002
+ bgp router-id 3.3.3.3
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ !
+ ! eBGP neighbor (r4)
+ neighbor 2001:db8:1::2 remote-as 65003
+ !
+ ! BGP-LS speaker
+ neighbor 2001:db9:3::2 remote-as 65000
+ !
+ address-family ipv4 unicast
+  redistribute local
+  redistribute connected
+  redistribute static
+ exit-address-family
+ !
+ ! IPv6 unicast for eBGP session
+ address-family ipv6 unicast
+  neighbor 2001:db8:1::2 activate
+  redistribute local
+  redistribute connected
+  redistribute static
+ exit-address-family
+ !
+ ! Link-State address family - export BGP topology to BGP-LS speaker
+ address-family link-state link-state
+  distribute bgp-fabric-link-state
+  neighbor 2001:db9:3::2 activate
+ exit-address-family
+!
+end

--- a/tests/topotests/bgp_link_state_bgp_fabric/r4/frr.conf
+++ b/tests/topotests/bgp_link_state_bgp_fabric/r4/frr.conf
@@ -1,0 +1,54 @@
+!
+hostname r4
+!
+! Router 4: AS65003, IPv6 eBGP with r3
+!
+! debug bgp updates
+! debug bgp link-state
+! debug bgp zebra
+!
+interface lo
+ ip address 10.4.4.4/32
+!
+interface r4-eth1
+ description Link to r3
+ ipv6 address 2001:db8:1::2/64
+!
+interface r4-eth0
+ description Point-to-p\oint link to RR
+ ipv6 address 2001:db9:4::1/126
+!
+!
+router bgp 65003
+ bgp router-id 4.4.4.4
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ !
+ ! eBGP neighbor (r3)
+ neighbor 2001:db8:1::1 remote-as 65002
+ !
+ ! BGP-LS speaker
+ neighbor 2001:db9:4::2 remote-as 65000
+ !
+ ! IPv4 unicast for static route
+ address-family ipv4 unicast
+  redistribute local
+  redistribute connected
+  redistribute static
+ exit-address-family
+ !
+ ! IPv6 unicast for eBGP session
+ address-family ipv6 unicast
+  neighbor 2001:db8:1::1 activate
+  redistribute local
+  redistribute connected
+  redistribute static
+ exit-address-family
+ !
+ ! Link-State address family - export BGP topology to BGP-LS speaker
+ address-family link-state link-state
+  distribute bgp-fabric-link-state
+  neighbor 2001:db9:4::2 activate
+ exit-address-family
+!
+end

--- a/tests/topotests/bgp_link_state_bgp_fabric/rr/expected_bgp_ls.json
+++ b/tests/topotests/bgp_link_state_bgp_fabric/rr/expected_bgp_ls.json
@@ -1,0 +1,1785 @@
+{
+	"vrfId": 0,
+	"vrfName": "default",
+	"routerId": "192.0.2.254",
+	"defaultLocPrf": 100,
+	"localAS": 65000,
+	"routes": {
+		"[V][B][I0x0][N[c65001][q1.1.1.1]]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr": "[V][B][I0x0][N[c65001][q1.1.1.1]]",
+				"nlri": {
+					"nlriType": "node",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.1.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[V][B][I0x0][N[c65001][q2.2.2.2]]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr": "[V][B][I0x0][N[c65001][q2.2.2.2]]",
+				"nlri": {
+					"nlriType": "node",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.2.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[V][B][I0x0][N[c65002][q3.3.3.3]]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr": "[V][B][I0x0][N[c65002][q3.3.3.3]]",
+				"nlri": {
+					"nlriType": "node",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:3::1",
+				"path": "65002",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:3::1",
+						"hostname": "r3",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[V][B][I0x0][N[c65003][q4.4.4.4]]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr": "[V][B][I0x0][N[c65003][q4.4.4.4]]",
+				"nlri": {
+					"nlriType": "node",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:4::1",
+				"path": "65003",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:4::1",
+						"hostname": "r4",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p10.1.1.1/32]][br0x02]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p10.1.1.1/32]][br0x02]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "10.1.1.1/32",
+						"bgpRouteType": "attached"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.1.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p10.255.1.0/30]][br0x02]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p10.255.1.0/30]][br0x02]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "10.255.1.0/30",
+						"bgpRouteType": "attached"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.1.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p10.255.1.1/32]][br0x01]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p10.255.1.1/32]][br0x01]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "10.255.1.1/32",
+						"bgpRouteType": "local"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.1.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p172.16.1.0/30]][br0x02]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p172.16.1.0/30]][br0x02]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "172.16.1.0/30",
+						"bgpRouteType": "attached"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.1.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p172.16.1.1/32]][br0x01]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p172.16.1.1/32]][br0x01]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "172.16.1.1/32",
+						"bgpRouteType": "local"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.1.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p192.0.2.0/24]][br0x05]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p192.0.2.0/24]][br0x05]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "192.0.2.0/24",
+						"bgpRouteType": "redistributed"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.1.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p10.2.2.2/32]][br0x02]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p10.2.2.2/32]][br0x02]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "10.2.2.2/32",
+						"bgpRouteType": "attached"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.2.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p10.255.2.0/30]][br0x02]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p10.255.2.0/30]][br0x02]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "10.255.2.0/30",
+						"bgpRouteType": "attached"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.2.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p10.255.2.1/32]][br0x01]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p10.255.2.1/32]][br0x01]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "10.255.2.1/32",
+						"bgpRouteType": "local"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.2.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p172.16.1.0/30]][br0x02]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p172.16.1.0/30]][br0x02]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "172.16.1.0/30",
+						"bgpRouteType": "attached"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.2.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p172.16.1.2/32]][br0x01]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p172.16.1.2/32]][br0x01]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "172.16.1.2/32",
+						"bgpRouteType": "local"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.2.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p10.2.2.2/32]][br0x04]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p10.2.2.2/32]][br0x04]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "10.2.2.2/32",
+						"bgpRouteType": "internalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.1.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p10.255.2.0/30]][br0x04]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p10.255.2.0/30]][br0x04]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "10.255.2.0/30",
+						"bgpRouteType": "internalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.1.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p10.255.2.1/32]][br0x04]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p10.255.2.1/32]][br0x04]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "10.255.2.1/32",
+						"bgpRouteType": "internalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.1.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p172.16.1.0/30]][br0x04]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p172.16.1.0/30]][br0x04]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "172.16.1.0/30",
+						"bgpRouteType": "internalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.1.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p172.16.1.2/32]][br0x04]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q1.1.1.1]][P[p172.16.1.2/32]][br0x04]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "172.16.1.2/32",
+						"bgpRouteType": "internalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.1.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p10.1.1.1/32]][br0x04]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p10.1.1.1/32]][br0x04]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "10.1.1.1/32",
+						"bgpRouteType": "internalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.2.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p10.255.1.0/30]][br0x04]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p10.255.1.0/30]][br0x04]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "10.255.1.0/30",
+						"bgpRouteType": "internalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.2.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p10.255.1.1/32]][br0x04]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p10.255.1.1/32]][br0x04]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "10.255.1.1/32",
+						"bgpRouteType": "internalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.2.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p172.16.1.0/30]][br0x04]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p172.16.1.0/30]][br0x04]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "172.16.1.0/30",
+						"bgpRouteType": "internalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.2.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p172.16.1.1/32]][br0x04]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p172.16.1.1/32]][br0x04]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "172.16.1.1/32",
+						"bgpRouteType": "internalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.2.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p192.0.2.0/24]][br0x04]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65001][q2.2.2.2]][P[p192.0.2.0/24]][br0x04]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "192.0.2.0/24",
+						"bgpRouteType": "internalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.2.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p10.3.3.3/32]][br0x02]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p10.3.3.3/32]][br0x02]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "10.3.3.3/32",
+						"bgpRouteType": "attached"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:3::1",
+				"path": "65002",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:3::1",
+						"hostname": "r3",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db9:1:124::/64]][br0x05]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db9:1:124::/64]][br0x05]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db9:1:124::/64",
+						"bgpRouteType": "redistributed"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:3::1",
+				"path": "65002",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:3::1",
+						"hostname": "r3",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db8:1::/64]][br0x02]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db8:1::/64]][br0x02]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db8:1::/64",
+						"bgpRouteType": "attached"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:3::1",
+				"path": "65002",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:3::1",
+						"hostname": "r3",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db8:1::1/128]][br0x01]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db8:1::1/128]][br0x01]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db8:1::1/128",
+						"bgpRouteType": "local"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:3::1",
+				"path": "65002",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:3::1",
+						"hostname": "r3",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db9:3::/126]][br0x02]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db9:3::/126]][br0x02]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db9:3::/126",
+						"bgpRouteType": "attached"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:3::1",
+				"path": "65002",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:3::1",
+						"hostname": "r3",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db9:3::1/128]][br0x01]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db9:3::1/128]][br0x01]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db9:3::1/128",
+						"bgpRouteType": "local"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:3::1",
+				"path": "65002",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:3::1",
+						"hostname": "r3",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db9:4::/126]][br0x03]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db9:4::/126]][br0x03]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db9:4::/126",
+						"bgpRouteType": "externalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:3::1",
+				"path": "65002",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:3::1",
+						"hostname": "r3",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db9:4::1/128]][br0x03]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db9:4::1/128]][br0x03]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db9:4::1/128",
+						"bgpRouteType": "externalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:3::1",
+				"path": "65002",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:3::1",
+						"hostname": "r3",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db8:1::/64]][br0x03]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db8:1::/64]][br0x03]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db8:1::/64",
+						"bgpRouteType": "externalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:3::1",
+				"path": "65002",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:3::1",
+						"hostname": "r3",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db8:1::2/128]][br0x03]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65002][q3.3.3.3]][P[p2001:db8:1::2/128]][br0x03]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db8:1::2/128",
+						"bgpRouteType": "externalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:3::1",
+				"path": "65002",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:3::1",
+						"hostname": "r3",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p10.4.4.4/32]][br0x02]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p10.4.4.4/32]][br0x02]",
+				"nlri": {
+					"nlriType": "ipv4Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "10.4.4.4/32",
+						"bgpRouteType": "attached"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:4::1",
+				"path": "65003",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:4::1",
+						"hostname": "r4",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db9:4::/126]][br0x02]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db9:4::/126]][br0x02]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db9:4::/126",
+						"bgpRouteType": "attached"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:4::1",
+				"path": "65003",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:4::1",
+						"hostname": "r4",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db9:4::1/128]][br0x01]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db9:4::1/128]][br0x01]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db9:4::1/128",
+						"bgpRouteType": "local"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:4::1",
+				"path": "65003",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:4::1",
+						"hostname": "r4",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db8:1::/64]][br0x02]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db8:1::/64]][br0x02]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db8:1::/64",
+						"bgpRouteType": "attached"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:4::1",
+				"path": "65003",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:4::1",
+						"hostname": "r4",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db8:1::2/128]][br0x01]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db8:1::2/128]][br0x01]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db8:1::2/128",
+						"bgpRouteType": "local"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:4::1",
+				"path": "65003",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:4::1",
+						"hostname": "r4",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db9:1:124::/64]][br0x03]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db9:1:124::/64]][br0x03]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db9:1:124::/64",
+						"bgpRouteType": "externalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:4::1",
+				"path": "65003",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:4::1",
+						"hostname": "r4",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db9:3::/126]][br0x03]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db9:3::/126]][br0x03]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db9:3::/126",
+						"bgpRouteType": "externalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:4::1",
+				"path": "65003",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:4::1",
+						"hostname": "r4",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db9:3::1/128]][br0x03]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db9:3::1/128]][br0x03]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db9:3::1/128",
+						"bgpRouteType": "externalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:4::1",
+				"path": "65003",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:4::1",
+						"hostname": "r4",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db8:1::/64]][br0x03]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db8:1::/64]][br0x03]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db8:1::/64",
+						"bgpRouteType": "externalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:4::1",
+				"path": "65003",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:4::1",
+						"hostname": "r4",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db8:1::1/128]][br0x03]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[T][B][I0x0][N[c65003][q4.4.4.4]][P[p2001:db8:1::1/128]][br0x03]",
+				"nlri": {
+					"nlriType": "ipv6Prefix",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					},
+					"prefixDescriptors": {
+						"ipReachabilityInformation": "2001:db8:1::1/128",
+						"bgpRouteType": "externalBgp"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:4::1",
+				"path": "65003",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:4::1",
+						"hostname": "r4",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[E][B][I0x0][N[c65001][q1.1.1.1]][R[c65000][q192.0.2.254]][L[l2/0][i10.255.1.1][n10.255.1.2]]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[E][B][I0x0][N[c65001][q1.1.1.1]][R[c65000][q192.0.2.254]][L[l2/0][i10.255.1.1][n10.255.1.2]]",
+				"nlri": {
+					"nlriType": "link",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"remoteNodeDescriptors": {
+						"asn": 65000,
+						"bgpRouterId": "192.0.2.254"
+					},
+					"linkDescriptors": {
+						"linkLocalId": 2,
+						"linkRemoteId": 0,
+						"ipv4InterfaceAddress": "10.255.1.1",
+						"ipv4NeighborAddress": "10.255.1.2"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.1.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[E][B][I0x0][N[c65001][q1.1.1.1]][R[c65001][q2.2.2.2]][L[l3/0][i172.16.1.1][n172.16.1.2]]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[E][B][I0x0][N[c65001][q1.1.1.1]][R[c65001][q2.2.2.2]][L[l3/0][i172.16.1.1][n172.16.1.2]]",
+				"nlri": {
+					"nlriType": "link",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"remoteNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"linkDescriptors": {
+						"linkLocalId": 3,
+						"linkRemoteId": 0,
+						"ipv4InterfaceAddress": "172.16.1.1",
+						"ipv4NeighborAddress": "172.16.1.2"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.1.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[E][B][I0x0][N[c65001][q2.2.2.2]][R[c65000][q192.0.2.254]][L[l2/0][i10.255.2.1][n10.255.2.2]]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[E][B][I0x0][N[c65001][q2.2.2.2]][R[c65000][q192.0.2.254]][L[l2/0][i10.255.2.1][n10.255.2.2]]",
+				"nlri": {
+					"nlriType": "link",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"remoteNodeDescriptors": {
+						"asn": 65000,
+						"bgpRouterId": "192.0.2.254"
+					},
+					"linkDescriptors": {
+						"linkLocalId": 2,
+						"linkRemoteId": 0,
+						"ipv4InterfaceAddress": "10.255.2.1",
+						"ipv4NeighborAddress": "10.255.2.2"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.2.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[E][B][I0x0][N[c65001][q2.2.2.2]][R[c65001][q1.1.1.1]][L[l3/0][i172.16.1.2][n172.16.1.1]]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[E][B][I0x0][N[c65001][q2.2.2.2]][R[c65001][q1.1.1.1]][L[l3/0][i172.16.1.2][n172.16.1.1]]",
+				"nlri": {
+					"nlriType": "link",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "2.2.2.2"
+					},
+					"remoteNodeDescriptors": {
+						"asn": 65001,
+						"bgpRouterId": "1.1.1.1"
+					},
+					"linkDescriptors": {
+						"linkLocalId": 3,
+						"linkRemoteId": 0,
+						"ipv4InterfaceAddress": "172.16.1.2",
+						"ipv4NeighborAddress": "172.16.1.1"
+					}
+				},
+				"weight": 0,
+				"peerId": "10.255.2.1",
+				"path": "65001",
+				"origin": "incomplete"
+			}
+		],
+		"[E][B][I0x0][N[c65002][q3.3.3.3]][R[c65000][q192.0.2.254]][L[l2/0][i2001:db9:3::1][n2001:db9:3::2]]":
+			[
+				{
+					"valid": true,
+					"bestpath": true,
+					"selectionReason": "First path received",
+					"pathFrom": "external",
+					"nlriStr":
+						"[E][B][I0x0][N[c65002][q3.3.3.3]][R[c65000][q192.0.2.254]][L[l2/0][i2001:db9:3::1][n2001:db9:3::2]]",
+					"nlri": {
+						"nlriType": "link",
+						"protocolId": 7,
+						"identifier": 0,
+						"localNodeDescriptors": {
+							"asn": 65002,
+							"bgpRouterId": "3.3.3.3"
+						},
+						"remoteNodeDescriptors": {
+							"asn": 65000,
+							"bgpRouterId": "192.0.2.254"
+						},
+						"linkDescriptors": {
+							"linkLocalId": 2,
+							"linkRemoteId": 0,
+							"ipv6InterfaceAddress": "2001:db9:3::1",
+							"ipv6NeighborAddress": "2001:db9:3::2"
+						}
+					},
+					"weight": 0,
+					"peerId": "2001:db9:3::1",
+					"path": "65002",
+					"origin": "incomplete",
+					"nexthops": [
+						{
+							"ip": "2001:db9:3::1",
+							"hostname": "r3",
+							"afi": "ipv6",
+							"scope": "global",
+							"linkLocalOnly": false,
+							"length": 16,
+							"used": true
+						}
+					]
+				}
+			],
+		"[E][B][I0x0][N[c65002][q3.3.3.3]][R[c65003][q4.4.4.4]][L[l2/0][i2001:db8:1::1][n2001:db8:1::2]]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[E][B][I0x0][N[c65002][q3.3.3.3]][R[c65003][q4.4.4.4]][L[l2/0][i2001:db8:1::1][n2001:db8:1::2]]",
+				"nlri": {
+					"nlriType": "link",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					},
+					"remoteNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					},
+					"linkDescriptors": {
+						"linkLocalId": 2,
+						"linkRemoteId": 0,
+						"ipv6InterfaceAddress": "2001:db8:1::1",
+						"ipv6NeighborAddress": "2001:db8:1::2"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:3::1",
+				"path": "65002",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:3::1",
+						"hostname": "r3",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		],
+		"[E][B][I0x0][N[c65003][q4.4.4.4]][R[c65000][q192.0.2.254]][L[l2/0][i2001:db9:4::1][n2001:db9:4::2]]":
+			[
+				{
+					"valid": true,
+					"bestpath": true,
+					"selectionReason": "First path received",
+					"pathFrom": "external",
+					"nlriStr":
+						"[E][B][I0x0][N[c65003][q4.4.4.4]][R[c65000][q192.0.2.254]][L[l2/0][i2001:db9:4::1][n2001:db9:4::2]]",
+					"nlri": {
+						"nlriType": "link",
+						"protocolId": 7,
+						"identifier": 0,
+						"localNodeDescriptors": {
+							"asn": 65003,
+							"bgpRouterId": "4.4.4.4"
+						},
+						"remoteNodeDescriptors": {
+							"asn": 65000,
+							"bgpRouterId": "192.0.2.254"
+						},
+						"linkDescriptors": {
+							"linkLocalId": 2,
+							"linkRemoteId": 0,
+							"ipv6InterfaceAddress": "2001:db9:4::1",
+							"ipv6NeighborAddress": "2001:db9:4::2"
+						}
+					},
+					"weight": 0,
+					"peerId": "2001:db9:4::1",
+					"path": "65003",
+					"origin": "incomplete",
+					"nexthops": [
+						{
+							"ip": "2001:db9:4::1",
+							"hostname": "r4",
+							"afi": "ipv6",
+							"scope": "global",
+							"linkLocalOnly": false,
+							"length": 16,
+							"used": true
+						}
+					]
+				}
+			],
+		"[E][B][I0x0][N[c65003][q4.4.4.4]][R[c65002][q3.3.3.3]][L[l2/0][i2001:db8:1::2][n2001:db8:1::1]]": [
+			{
+				"valid": true,
+				"bestpath": true,
+				"selectionReason": "First path received",
+				"pathFrom": "external",
+				"nlriStr":
+					"[E][B][I0x0][N[c65003][q4.4.4.4]][R[c65002][q3.3.3.3]][L[l2/0][i2001:db8:1::2][n2001:db8:1::1]]",
+				"nlri": {
+					"nlriType": "link",
+					"protocolId": 7,
+					"identifier": 0,
+					"localNodeDescriptors": {
+						"asn": 65003,
+						"bgpRouterId": "4.4.4.4"
+					},
+					"remoteNodeDescriptors": {
+						"asn": 65002,
+						"bgpRouterId": "3.3.3.3"
+					},
+					"linkDescriptors": {
+						"linkLocalId": 2,
+						"linkRemoteId": 0,
+						"ipv6InterfaceAddress": "2001:db8:1::2",
+						"ipv6NeighborAddress": "2001:db8:1::1"
+					}
+				},
+				"weight": 0,
+				"peerId": "2001:db9:4::1",
+				"path": "65003",
+				"origin": "incomplete",
+				"nexthops": [
+					{
+						"ip": "2001:db9:4::1",
+						"hostname": "r4",
+						"afi": "ipv6",
+						"scope": "global",
+						"linkLocalOnly": false,
+						"length": 16,
+						"used": true
+					}
+				]
+			}
+		]
+	},
+	"totalRoutes": 54,
+	"totalPaths": 54
+}

--- a/tests/topotests/bgp_link_state_bgp_fabric/rr/frr.conf
+++ b/tests/topotests/bgp_link_state_bgp_fabric/rr/frr.conf
@@ -1,0 +1,53 @@
+!
+hostname rr
+!
+! BGP-LS Speaker (Route Reflector)
+! Collects BGP-LS NLRIs from all routers
+!
+! debug bgp updates
+! debug bgp link-state
+! debug bgp zebra
+! debug bgp neighbor-events
+!
+interface rr-eth0
+ description Point-to-point link to r1
+ ip address 10.255.1.2/30
+!
+interface rr-eth1
+ description Point-to-point link to r2
+ ip address 10.255.2.2/30
+!
+interface rr-eth2
+ description Point-to-point link to r3
+ ipv6 address 2001:db9:3::2/126
+!
+interface rr-eth3
+ description Point-to-point link to r4
+ ipv6 address 2001:db9:4::2/126
+!
+route-map BLOCK-ALL deny 10
+!
+router bgp 65000
+ bgp router-id 192.0.2.254
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ !
+ ! Neighbors for BGP-LS collection
+ neighbor 10.255.1.1 remote-as 65001
+ neighbor 10.255.2.1 remote-as 65001
+ neighbor 2001:db9:3::1 remote-as 65002
+ neighbor 2001:db9:4::1 remote-as 65003
+ !
+ ! Enable Link-State address family
+ address-family link-state link-state
+  neighbor 10.255.1.1 activate
+  neighbor 10.255.1.1 route-map BLOCK-ALL out
+  neighbor 10.255.2.1 activate
+  neighbor 10.255.2.1 route-map BLOCK-ALL out
+  neighbor 2001:db9:3::1 activate
+  neighbor 2001:db9:3::1 route-map BLOCK-ALL out
+  neighbor 2001:db9:4::1 activate
+  neighbor 2001:db9:4::1 route-map BLOCK-ALL out
+ exit-address-family
+!
+end

--- a/tests/topotests/bgp_link_state_bgp_fabric/test_bgp_link_state_bgp_fabric.py
+++ b/tests/topotests/bgp_link_state_bgp_fabric/test_bgp_link_state_bgp_fabric.py
@@ -1,0 +1,1180 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: ISC
+#
+# Copyright (c) 2026 by Carmine Scarpitta
+#
+
+"""Topotest for BGP-LS export in a BGP-only fabric scenario.
+
+Reference: draft-ietf-idr-bgp-ls-bgp-only-fabric-04.
+
+Topology diagram:
+
+                          +--------+
+                          |   rr   |
+                          | AS65000|
+                          +---+----+
+                              |
+           +------------------+------------------+------------------+
+           |                  |                  |                  |
+      +----+----+        +----+----+        +----+----+        +----+----+
+      |   r1    |========|   r2    |        |   r3    |========|   r4    |
+      | AS65001 |  IPv4  | AS65001 |        | AS65002 |  IPv6  | AS65003 |
+      +---------+ iBGP   +---------+        +---------+ eBGP   +---------+
+
+Topology summary:
+- rr (AS65000) acts as the BGP-LS collector/speaker.
+- r1/r2 form an IPv4 iBGP session in AS65001.
+- r3/r4 form an IPv6 eBGP session (AS65002 <-> AS65003).
+- All routers peer with rr in address-family link-state link-state.
+"""
+
+import os
+import sys
+import json
+import copy
+import re
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, "../"))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+pytestmark = [pytest.mark.bgpd]
+
+
+def _normalize_bgp_ls_link_ifindex(data):
+    """
+    Normalize dynamic link-local ifindex values in BGP-LS JSON output.
+
+    Link NLRI keys and nlriStr contain local link-id derived from interface ifindex,
+    which can vary between test runs. Replace only that volatile value so JSON
+    comparisons remain deterministic while still validating all other fields.
+    """
+    normalized = copy.deepcopy(data)
+    routes = normalized.get("routes")
+    if not isinstance(routes, dict):
+        return normalized
+
+    new_routes = {}
+    for nlri_key, route_list in routes.items():
+        normalized_key = re.sub(r"\[L\[l\d+/", "[L[l<ifindex>/", nlri_key)
+        new_route_list = []
+
+        for route in route_list:
+            route_copy = copy.deepcopy(route)
+            nlri = route_copy.get("nlri", {})
+
+            if nlri.get("nlriType") == "link":
+                if "nlriStr" in route_copy:
+                    route_copy["nlriStr"] = re.sub(
+                        r"\[L\[l\d+/", "[L[l<ifindex>/", route_copy["nlriStr"]
+                    )
+
+                link_desc = nlri.get("linkDescriptors", {})
+                if "linkLocalId" in link_desc:
+                    link_desc["linkLocalId"] = "<ifindex>"
+
+            new_route_list.append(route_copy)
+
+        new_routes[normalized_key] = new_route_list
+
+    normalized["routes"] = new_routes
+    return normalized
+
+
+def bgp_ls_router_json_cmp(router, expected):
+    """Compare BGP-LS JSON while ignoring dynamic link-local ifindex values."""
+    output = router.vtysh_cmd("show bgp link-state link-state json")
+    actual = json.loads(output)
+
+    actual_norm = _normalize_bgp_ls_link_ifindex(actual)
+    expected_norm = _normalize_bgp_ls_link_ifindex(expected)
+    return topotest.json_cmp(actual_norm, expected_norm)
+
+
+def count_node_nlris(data, bgp_router_id, asn=None):
+    """
+    Count Node NLRIs for a specific BGP router
+
+    Args:
+        data: BGP-LS JSON data (dict with 'routes' key)
+        bgp_router_id: BGP Router-ID to filter by
+        asn: Optional ASN to filter by
+
+    Returns:
+        List of matching Node NLRIs
+    """
+    # Extract all route objects from the routes dictionary
+    all_routes = []
+    if "routes" in data:
+        for nlri_key, route_list in data["routes"].items():
+            all_routes.extend(route_list)
+    nodes = [r for r in all_routes if r.get("nlri", {}).get("nlriType") == "node" and
+             r.get("nlri", {}).get("localNodeDescriptors", {}).get("bgpRouterId") == bgp_router_id]
+    if asn is not None:
+        nodes = [r for r in nodes if r.get("nlri", {}).get("localNodeDescriptors", {}).get("asn") == asn]
+    return nodes
+
+
+def count_link_nlris(data, local_bgp_router_id, remote_bgp_router_id=None):
+    """
+    Count Link NLRIs for a specific local BGP router
+
+    Args:
+        data: BGP-LS JSON data (dict with 'routes' key)
+        local_bgp_router_id: Local BGP Router-ID to filter by
+        remote_bgp_router_id: Optional remote BGP Router-ID to filter by
+
+    Returns:
+        List of matching Link NLRIs
+    """
+    # Extract all route objects from the routes dictionary
+    all_routes = []
+    if "routes" in data:
+        for nlri_key, route_list in data["routes"].items():
+            all_routes.extend(route_list)
+
+    links = [r for r in all_routes if r.get("nlri", {}).get("nlriType") == "link" and
+             r.get("nlri", {}).get("localNodeDescriptors", {}).get("bgpRouterId") == local_bgp_router_id]
+
+    if remote_bgp_router_id is not None:
+        links = [r for r in links if r.get("nlri", {}).get("remoteNodeDescriptors", {}).get("bgpRouterId") == remote_bgp_router_id]
+
+    return links
+
+
+def count_prefix_nlris(data, bgp_router_id, prefix=None):
+    """
+    Count Prefix NLRIs for a specific BGP router
+
+    Args:
+        data: BGP-LS JSON data (dict with 'routes' key)
+        bgp_router_id: BGP Router-ID to filter by
+        prefix: Optional specific prefix to filter by (e.g., "10.1.1.1/32")
+
+    Returns:
+        List of matching Prefix NLRIs
+    """
+    # Extract all route objects from the routes dictionary
+    all_routes = []
+    if "routes" in data:
+        for nlri_key, route_list in data["routes"].items():
+            all_routes.extend(route_list)
+
+    prefixes = [r for r in all_routes if r.get("nlri", {}).get("nlriType") in ["ipv4Prefix", "ipv6Prefix"] and
+                r.get("nlri", {}).get("localNodeDescriptors", {}).get("bgpRouterId") == bgp_router_id]
+
+    if prefix is not None:
+        prefixes = [r for r in prefixes if r.get("nlri", {}).get("prefixDescriptors", {}).get("ipReachabilityInformation") == prefix]
+
+    return prefixes
+
+
+def count_all_nlris_by_type(data):
+    """
+    Count all NLRIs by type across all routers
+
+    Args:
+        data: BGP-LS JSON data (dict with 'routes' key)
+
+    Returns:
+        Dictionary with counts: {
+            'nodes': int,
+            'links': int,
+            'prefixes': int,
+            'total': int
+        }
+    """
+    # Extract all route objects from the routes dictionary
+    all_routes = []
+    if "routes" in data:
+        for nlri_key, route_list in data["routes"].items():
+            all_routes.extend(route_list)
+
+    nodes = [r for r in all_routes if r.get("nlri", {}).get("nlriType") == "node"]
+    links = [r for r in all_routes if r.get("nlri", {}).get("nlriType") == "link"]
+    prefixes = [r for r in all_routes if r.get("nlri", {}).get("nlriType") in ["ipv4Prefix", "ipv6Prefix"]]
+
+    return {
+        'nodes': len(nodes),
+        'links': len(links),
+        'prefixes': len(prefixes),
+        'total': len(nodes) + len(links) + len(prefixes)
+    }
+
+
+def count_router_nlris(data, bgp_router_id, asn=None):
+    """
+    Count all NLRIs for a specific router (nodes, links, prefixes)
+
+    Args:
+        data: BGP-LS JSON data (dict with 'routes' key)
+        bgp_router_id: BGP Router-ID to filter by
+        asn: Optional ASN to filter by for node NLRIs
+
+    Returns:
+        Dictionary with counts: {
+            'nodes': int,
+            'links': int,
+            'prefixes': int,
+            'total': int
+        }
+    """
+    nodes = count_node_nlris(data, bgp_router_id, asn)
+    links = count_link_nlris(data, bgp_router_id)
+    prefixes = count_prefix_nlris(data, bgp_router_id)
+
+    return {
+        'nodes': len(nodes),
+        'links': len(links),
+        'prefixes': len(prefixes),
+        'total': len(nodes) + len(links) + len(prefixes)
+    }
+
+
+def build_topo(tgen):
+    """Build test topology with rr collector and iBGP/eBGP peer pairs."""
+
+    # Create 5 routers
+    tgen.add_router("rr")   # BGP-LS speaker (route reflector)
+    tgen.add_router("r1")   # AS65001
+    tgen.add_router("r2")   # AS65001
+    tgen.add_router("r3")   # AS65002
+    tgen.add_router("r4")   # AS65003
+
+    # Create point-to-point switches for RR connections
+    # rr to r1 (10.255.1.0/30)
+    switch = tgen.add_switch("s-rr-r1")
+    switch.add_link(tgen.gears["rr"])
+    switch.add_link(tgen.gears["r1"])
+
+    # rr to r2 (10.255.2.0/30)
+    switch = tgen.add_switch("s-rr-r2")
+    switch.add_link(tgen.gears["rr"])
+    switch.add_link(tgen.gears["r2"])
+
+    # rr to r3 (10.255.3.0/30)
+    switch = tgen.add_switch("s-rr-r3")
+    switch.add_link(tgen.gears["rr"])
+    switch.add_link(tgen.gears["r3"])
+
+    # rr to r4 (10.255.4.0/30)
+    switch = tgen.add_switch("s-rr-r4")
+    switch.add_link(tgen.gears["rr"])
+    switch.add_link(tgen.gears["r4"])
+
+    # r1 to r2 (IPv4 iBGP session)
+    switch = tgen.add_switch("s-r1-r2")
+    switch.add_link(tgen.gears["r1"])
+    switch.add_link(tgen.gears["r2"])
+
+    # r3 to r4 (IPv6 eBGP session)
+    switch = tgen.add_switch("s-r3-r4")
+    switch.add_link(tgen.gears["r3"])
+    switch.add_link(tgen.gears["r4"])
+
+
+def setup_module(mod):
+    """Set up test environment."""
+    tgen = Topogen(build_topo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for rname, router in router_list.items():
+        router.load_frr_config(os.path.join(CWD, "{}/frr.conf".format(rname)))
+
+    tgen.start_router()
+
+
+def teardown_module(mod):
+    """Tear down test environment."""
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+
+def test_bgp_convergence():
+    """Test BGP convergence"""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Waiting for BGP convergence")
+
+    # Wait for BGP sessions to establish
+    for router in ["rr", "r1", "r2", "r3", "r4"]:
+        logger.info("Checking BGP convergence on {}".format(router))
+        test_func = functools.partial(
+            topotest.router_json_cmp,
+            tgen.gears[router],
+            "show bgp summary json",
+            {},
+        )
+        _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+        assertmsg = '"{}" BGP convergence failure'.format(router)
+        assert result is None, assertmsg
+
+
+def test_bgp_ls_nlris():
+    """Test BGP-LS NLRIs on route reflector"""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Verifying BGP-LS NLRIs on route reflector")
+
+    rr = tgen.gears["rr"]
+
+    # Load expected JSON
+    expected_file = os.path.join(CWD, "rr/expected_bgp_ls.json")
+    expected = json.load(open(expected_file))
+
+    # Use router_json_cmp to compare with expected output
+    test_func = functools.partial(
+        bgp_ls_router_json_cmp,
+        rr,
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assertmsg = 'BGP-LS NLRIs do not match expected output'
+    assert result is None, assertmsg
+
+    logger.info("All NLRIs verified successfully")
+
+
+def test_bgp_router_id_unset_reset():
+    """Verify router-id unset/reset triggers NLRI re-origination on r1."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Testing BGP router-id unset/reset on r1")
+
+    rr = tgen.gears["rr"]
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Verify baseline - r1 NLRIs should be present
+    logger.info("Step 1: Verifying baseline BGP-LS NLRIs from r1")
+
+    def check_r1_nlris_present():
+        output = rr.vtysh_cmd("show bgp link-state link-state json")
+        data = json.loads(output)
+
+        # Count NLRIs from r1 and all routers
+        r1_counts = count_router_nlris(data, "1.1.1.1")
+        total_counts = count_all_nlris_by_type(data)
+
+        # Store counts for error reporting
+        check_r1_nlris_present.last_counts = {
+            "r1_nodes": r1_counts['nodes'],
+            "r1_links": r1_counts['links'],
+            "r1_prefixes": r1_counts['prefixes'],
+            "r1_total": r1_counts['total'],
+            "total_nodes": total_counts['nodes'],
+            "total_links": total_counts['links'],
+            "total_prefixes": total_counts['prefixes'],
+            "total_nlris": total_counts['total']
+        }
+
+        # r1 should have: 1 node, 2 links, 11 prefixes
+        # Total should have: 54 NLRIs
+        if r1_counts['nodes'] == 1 and r1_counts['links'] == 2 and r1_counts['prefixes'] == 11 and total_counts['total'] == 54:
+            return True
+        return False
+
+    test_func = functools.partial(check_r1_nlris_present)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"r1 NLRIs not present in baseline check. "
+        f"Expected: r1 nodes=1, links=2, prefixes=11, total NLRIs=54. "
+        f"Found: r1 nodes={check_r1_nlris_present.last_counts['r1_nodes']}, "
+        f"links={check_r1_nlris_present.last_counts['r1_links']}, "
+        f"prefixes={check_r1_nlris_present.last_counts['r1_prefixes']}, "
+        f"total={check_r1_nlris_present.last_counts['total_nlris']} "
+        f"(nodes={check_r1_nlris_present.last_counts['total_nodes']}, "
+        f"links={check_r1_nlris_present.last_counts['total_links']}, "
+        f"prefixes={check_r1_nlris_present.last_counts['total_prefixes']})"
+    )
+
+    # Step 2: Unset BGP router-id on r1
+    logger.info("Step 2: Unsetting BGP router-id on r1")
+    r1.vtysh_cmd("""
+        configure terminal
+        router bgp 65001
+        no bgp router-id
+    """)
+
+    # Step 3: Verify NLRIs are re-advertised with zebra-provided router-id (10.1.1.1)
+    logger.info("Step 3: Verifying r1 NLRIs are re-advertised with zebra router-id 10.1.1.1")
+
+    def check_r1_nlris_with_zebra_id():
+        output = rr.vtysh_cmd("show bgp link-state link-state json")
+        data = json.loads(output)
+
+        # Count NLRIs with old router-id (1.1.1.1) - should be 0
+        old_counts = count_router_nlris(data, "1.1.1.1")
+
+        # Count NLRIs with zebra router-id (10.1.1.1) - should have all r1's NLRIs
+        zebra_counts = count_router_nlris(data, "10.1.1.1")
+
+        # Count total NLRIs (should remain the same)
+        total_counts = count_all_nlris_by_type(data)
+
+        # Store counts for error reporting
+        check_r1_nlris_with_zebra_id.last_counts = {
+            "old_id_total": old_counts['total'],
+            "zebra_id_nodes": zebra_counts['nodes'],
+            "zebra_id_links": zebra_counts['links'],
+            "zebra_id_prefixes": zebra_counts['prefixes'],
+            "zebra_id_total": zebra_counts['total'],
+            "total_nlris": total_counts['total'],
+            "expected_total": check_r1_nlris_present.last_counts['total_nlris']
+        }
+
+        # Old router-id should have no NLRIs, zebra router-id should have all r1's NLRIs
+        if (old_counts['total'] == 0 and
+            zebra_counts['nodes'] == 1 and
+            zebra_counts['links'] == 2 and
+            zebra_counts['prefixes'] == 11 and
+            total_counts['total'] == check_r1_nlris_present.last_counts['total_nlris']):
+            return True
+        return False
+
+    test_func = functools.partial(check_r1_nlris_with_zebra_id)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"r1 NLRIs not properly re-advertised with zebra router-id after unsetting configured router-id. "
+        f"Expected: old router-id 1.1.1.1 NLRIs=0, zebra router-id 10.1.1.1 nodes=1, links=2, prefixes=11, total NLRIs=54. "
+        f"Found: old router-id NLRIs={check_r1_nlris_with_zebra_id.last_counts['old_id_total']}, "
+        f"zebra router-id nodes={check_r1_nlris_with_zebra_id.last_counts['zebra_id_nodes']}, "
+        f"links={check_r1_nlris_with_zebra_id.last_counts['zebra_id_links']}, "
+        f"prefixes={check_r1_nlris_with_zebra_id.last_counts['zebra_id_prefixes']}, "
+        f"total NLRIs={check_r1_nlris_with_zebra_id.last_counts['total_nlris']} "
+        f"(expected {check_r1_nlris_with_zebra_id.last_counts['expected_total']})"
+    )
+
+    # Step 4: Reconfigure BGP router-id on r1
+    logger.info("Step 4: Reconfiguring BGP router-id to 1.1.1.1 on r1")
+    r1.vtysh_cmd("""
+        configure terminal
+        router bgp 65001
+        bgp router-id 1.1.1.1
+    """)
+
+    # Step 5: Verify NLRIs are re-advertised with configured router-id (1.1.1.1)
+    logger.info("Step 5: Verifying r1 NLRIs are re-advertised with configured router-id 1.1.1.1")
+
+    def check_r1_nlris_with_configured_id():
+        output = rr.vtysh_cmd("show bgp link-state link-state json")
+        data = json.loads(output)
+
+        # Count NLRIs with zebra router-id (10.1.1.1) - should be 0
+        zebra_counts = count_router_nlris(data, "10.1.1.1")
+
+        # Count NLRIs with configured router-id (1.1.1.1) - should have all r1's NLRIs
+        configured_counts = count_router_nlris(data, "1.1.1.1")
+
+        # Count total NLRIs (should remain the same)
+        total_counts = count_all_nlris_by_type(data)
+
+        # Store counts for error reporting
+        check_r1_nlris_with_configured_id.last_counts = {
+            "zebra_id_total": zebra_counts['total'],
+            "configured_id_nodes": configured_counts['nodes'],
+            "configured_id_links": configured_counts['links'],
+            "configured_id_prefixes": configured_counts['prefixes'],
+            "configured_id_total": configured_counts['total'],
+            "total_nlris": total_counts['total']
+        }
+
+        # Zebra router-id should have no NLRIs, configured router-id should have all r1's NLRIs
+        if (zebra_counts['total'] == 0 and
+            configured_counts['nodes'] == 1 and
+            configured_counts['links'] == 2 and
+            configured_counts['prefixes'] == 11 and
+            total_counts['total'] == 54):
+            return True
+        return False
+
+    test_func = functools.partial(check_r1_nlris_with_configured_id)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"r1 NLRIs not re-advertised with configured router-id after reconfiguration. "
+        f"Expected: zebra router-id 10.1.1.1 NLRIs=0, configured router-id 1.1.1.1 nodes=1, links=2, prefixes=11, total NLRIs=54. "
+        f"Found: zebra router-id NLRIs={check_r1_nlris_with_configured_id.last_counts['zebra_id_total']}, "
+        f"configured router-id nodes={check_r1_nlris_with_configured_id.last_counts['configured_id_nodes']}, "
+        f"links={check_r1_nlris_with_configured_id.last_counts['configured_id_links']}, "
+        f"prefixes={check_r1_nlris_with_configured_id.last_counts['configured_id_prefixes']}, "
+        f"total NLRIs={check_r1_nlris_with_configured_id.last_counts['total_nlris']}"
+    )
+
+    # Final check: Verify output matches expected baseline
+    logger.info("Final verification: Comparing output with expected baseline")
+    expected_file = os.path.join(CWD, "rr/expected_bgp_ls.json")
+    expected = json.load(open(expected_file))
+
+    test_func = functools.partial(
+        bgp_ls_router_json_cmp,
+        rr,
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assertmsg = 'BGP-LS NLRIs do not match expected baseline output after router-id reset'
+    assert result is None, assertmsg
+
+    logger.info("BGP router-id unset/reset test completed successfully")
+
+
+def test_bgp_asn_unset_reset():
+    """Verify ASN removal/recreation withdraws and re-originates r1 NLRIs."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Testing BGP ASN unset/reset on r1")
+
+    rr = tgen.gears["rr"]
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Verify baseline - r1 NLRIs should be present
+    logger.info("Step 1: Verifying baseline BGP-LS NLRIs from r1")
+
+    def check_r1_nlris_present():
+        output = rr.vtysh_cmd("show bgp link-state link-state json")
+        data = json.loads(output)
+
+        # Count NLRIs from r1 (BGP Router-ID 1.1.1.1, ASN 65001)
+        r1_nodes = count_node_nlris(data, "1.1.1.1", asn=65001)
+        r1_links = count_link_nlris(data, "1.1.1.1")
+        r1_prefixes = count_prefix_nlris(data, "1.1.1.1")
+        total_nlris = len(r1_nodes) + len(r1_links) + len(r1_prefixes)
+
+        # Store count for error reporting
+        check_r1_nlris_present.last_count = total_nlris
+
+        if total_nlris == 14:  # 1 node + 2 links + 11 prefixes
+            return True
+        return False
+
+    test_func = functools.partial(check_r1_nlris_present)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"r1 NLRIs not present in baseline check (ASN test). "
+        f"Expected: 14 NLRIs (1 node + 2 link + 11 prefixes). "
+        f"Found: {check_r1_nlris_present.last_count} NLRIs"
+    )
+
+    # Step 2: Remove BGP instance on r1
+    logger.info("Step 2: Removing BGP instance (unsetting ASN) on r1")
+    r1.vtysh_cmd("""
+        configure terminal
+        no router bgp 65001
+    """)
+
+    # Step 3: Verify all NLRIs from r1 are withdrawn
+    logger.info("Step 3: Verifying r1 NLRIs are withdrawn from rr")
+
+    def check_r1_nlris_withdrawn():
+        output = rr.vtysh_cmd("show bgp link-state link-state json")
+        data = json.loads(output)
+
+        # Count all NLRIs from r1
+        r1_nodes = count_node_nlris(data, "1.1.1.1")
+        r1_links = count_link_nlris(data, "1.1.1.1")
+        r1_prefixes = count_prefix_nlris(data, "1.1.1.1")
+        total_nlris = len(r1_nodes) + len(r1_links) + len(r1_prefixes)
+
+        # Store count for error reporting
+        check_r1_nlris_withdrawn.last_count = total_nlris
+
+        if total_nlris == 0:
+            return True
+        return False
+
+    test_func = functools.partial(check_r1_nlris_withdrawn)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"r1 NLRIs not withdrawn after ASN removal. "
+        f"Expected: 0 NLRIs. Found: {check_r1_nlris_withdrawn.last_count} NLRIs still present"
+    )
+
+    # Step 4: Reconfigure BGP with full config on r1
+    logger.info("Step 4: Reconfiguring BGP with ASN on r1")
+    r1.vtysh_cmd("""
+        configure terminal
+        router bgp 65001
+        bgp router-id 1.1.1.1
+        no bgp ebgp-requires-policy
+        no bgp default ipv4-unicast
+        neighbor 172.16.1.2 remote-as 65001
+        neighbor 172.16.1.2 update-source r1-eth1
+        neighbor 10.255.1.2 remote-as 65000
+        address-family ipv4 unicast
+         neighbor 172.16.1.2 activate
+         redistribute local
+         redistribute connected
+         redistribute static
+        exit-address-family
+        address-family link-state link-state
+         distribute bgp-fabric-link-state
+         neighbor 10.255.1.2 activate
+        exit-address-family
+    """)
+
+    # Step 5: Verify all NLRIs from r1 are re-advertised
+    logger.info("Step 5: Verifying r1 NLRIs are re-advertised to rr")
+
+    test_func = functools.partial(check_r1_nlris_present)
+    success, _ = topotest.run_and_expect(test_func, True, count=60, wait=1)
+    assert success, (
+        f"r1 NLRIs not re-advertised after ASN reconfiguration. "
+        f"Expected: 14 NLRIs. Found: {check_r1_nlris_present.last_count} NLRIs"
+    )
+
+    # Final check: Verify output matches expected baseline
+    logger.info("Final verification: Comparing output with expected baseline")
+    expected_file = os.path.join(CWD, "rr/expected_bgp_ls.json")
+    expected = json.load(open(expected_file))
+
+    test_func = functools.partial(
+        bgp_ls_router_json_cmp,
+        rr,
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assertmsg = 'BGP-LS NLRIs do not match expected baseline output after router-id reset'
+    assert result is None, assertmsg
+
+    logger.info("BGP ASN unset/reset test completed successfully")
+
+
+def test_bgp_session_teardown_restore():
+    """Verify r1-r2 session teardown/restore updates link NLRI as expected."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Testing BGP session teardown/restore between r1 and r2")
+
+    rr = tgen.gears["rr"]
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Verify baseline - link from r1 to r2 should be present
+    logger.info("Step 1: Verifying baseline link NLRI from r1 to r2")
+
+    def check_r1_r2_link_present():
+        output = rr.vtysh_cmd("show bgp link-state link-state json")
+        data = json.loads(output)
+
+        # Find link from r1 to r2
+        r1_r2_link = count_link_nlris(data, "1.1.1.1", "2.2.2.2")
+
+        # Store count for error reporting
+        check_r1_r2_link_present.last_count = len(r1_r2_link)
+
+        if len(r1_r2_link) == 1:
+            return True
+        return False
+
+    test_func = functools.partial(check_r1_r2_link_present)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"r1-r2 link NLRI not present in baseline check (BGP session test). "
+        f"Expected: 1 link. Found: {check_r1_r2_link_present.last_count} links"
+    )
+
+    # Step 2: Tear down BGP session with r2
+    logger.info("Step 2: Tearing down BGP session on r1 with r2")
+    r1.vtysh_cmd("""
+        configure terminal
+        router bgp 65001
+        no neighbor 172.16.1.2
+    """)
+
+    # Step 3: Verify link NLRI is withdrawn
+    logger.info("Step 3: Verifying r1-r2 link NLRI is withdrawn from rr")
+
+    def check_r1_r2_link_withdrawn():
+        output = rr.vtysh_cmd("show bgp link-state link-state json")
+        data = json.loads(output)
+
+        # Find link from r1 to r2
+        r1_r2_link = count_link_nlris(data, "1.1.1.1", "2.2.2.2")
+
+        # Store count for error reporting
+        check_r1_r2_link_withdrawn.last_count = len(r1_r2_link)
+
+        if len(r1_r2_link) == 0:
+            return True
+        return False
+
+    test_func = functools.partial(check_r1_r2_link_withdrawn)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"r1-r2 link NLRI not withdrawn after session teardown. "
+        f"Expected: 0 links. Found: {check_r1_r2_link_withdrawn.last_count} links still present"
+    )
+
+    # Step 4: Restore BGP session with r2
+    logger.info("Step 4: Restoring BGP session on r1 with r2")
+    r1.vtysh_cmd("""
+        configure terminal
+        router bgp 65001
+        neighbor 172.16.1.2 remote-as 65001
+        neighbor 172.16.1.2 update-source r1-eth1
+        address-family ipv4 unicast
+         neighbor 172.16.1.2 activate
+        exit-address-family
+    """)
+
+    # Step 5: Verify link NLRI is re-advertised
+    logger.info("Step 5: Verifying r1-r2 link NLRI is re-advertised to rr")
+
+    test_func = functools.partial(check_r1_r2_link_present)
+    success, _ = topotest.run_and_expect(test_func, True, count=60, wait=1)
+    assert success, (
+        f"r1-r2 link NLRI not re-advertised after session restoration. "
+        f"Expected: 1 links. Found: {check_r1_r2_link_present.last_count} links"
+    )
+
+    # Final check: Verify output matches expected baseline
+    logger.info("Final verification: Comparing output with expected baseline")
+    expected_file = os.path.join(CWD, "rr/expected_bgp_ls.json")
+    expected = json.load(open(expected_file))
+
+    test_func = functools.partial(
+        bgp_ls_router_json_cmp,
+        rr,
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assertmsg = 'BGP-LS NLRIs do not match expected baseline output after router-id reset'
+    assert result is None, assertmsg
+
+    logger.info("BGP session teardown/restore test completed successfully")
+
+
+def test_prefix_removal_restore():
+    """Verify static prefix removal/restoration updates prefix NLRI on rr."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Testing prefix removal/restore on r1")
+
+    rr = tgen.gears["rr"]
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Verify baseline - static prefix should be present
+    logger.info("Step 1: Verifying baseline static prefix 192.0.2.0/24 from r1")
+
+    def check_static_prefix_present():
+        output = rr.vtysh_cmd("show bgp link-state link-state json")
+        data = json.loads(output)
+
+        # Find prefix 192.0.2.0/24 from r1
+        static_prefix = count_prefix_nlris(data, "1.1.1.1", prefix="192.0.2.0/24")
+
+        # Store count for error reporting
+        check_static_prefix_present.last_count = len(static_prefix)
+
+        if len(static_prefix) == 1:
+            return True
+        return False
+
+    test_func = functools.partial(check_static_prefix_present)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"Static prefix 192.0.2.0/24 not present in baseline check. "
+        f"Expected: 1 prefix. Found: {check_static_prefix_present.last_count} prefixes"
+    )
+
+    # Step 2: Remove static prefix
+    logger.info("Step 2: Removing static prefix 192.0.2.0/24 on r1")
+    r1.vtysh_cmd("""
+        configure terminal
+        no ip route 192.0.2.0/24 Null0
+    """)
+
+    # Step 3: Verify prefix NLRI is withdrawn
+    logger.info("Step 3: Verifying prefix NLRI is withdrawn from rr")
+
+    def check_static_prefix_withdrawn():
+        output = rr.vtysh_cmd("show bgp link-state link-state json")
+        data = json.loads(output)
+
+        # Find prefix 192.0.2.0/24 from r1
+        static_prefix = count_prefix_nlris(data, "1.1.1.1", prefix="192.0.2.0/24")
+
+        # Store count for error reporting
+        check_static_prefix_withdrawn.last_count = len(static_prefix)
+
+        if len(static_prefix) == 0:
+            return True
+        return False
+
+    test_func = functools.partial(check_static_prefix_withdrawn)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"Static prefix not withdrawn after removal. "
+        f"Expected: 0 prefixes. Found: {check_static_prefix_withdrawn.last_count} prefixes still present"
+    )
+
+    # Step 4: Restore static prefix
+    logger.info("Step 4: Restoring static prefix 192.0.2.0/24 on r1")
+    r1.vtysh_cmd("""
+        configure terminal
+        ip route 192.0.2.0/24 Null0
+    """)
+
+    # Step 5: Verify prefix NLRI is re-advertised
+    logger.info("Step 5: Verifying prefix NLRI is re-advertised to rr")
+
+    test_func = functools.partial(check_static_prefix_present)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"Static prefix not re-advertised after restoration. "
+        f"Expected: 1 prefix. Found: {check_static_prefix_present.last_count} prefixes"
+    )
+
+    # Final check: Verify output matches expected baseline
+    logger.info("Final verification: Comparing output with expected baseline")
+    expected_file = os.path.join(CWD, "rr/expected_bgp_ls.json")
+    expected = json.load(open(expected_file))
+
+    test_func = functools.partial(
+        bgp_ls_router_json_cmp,
+        rr,
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assertmsg = 'BGP-LS NLRIs do not match expected baseline output after router-id reset'
+    assert result is None, assertmsg
+
+    logger.info("Prefix removal/restore test completed successfully")
+
+
+def test_loopback_address_unset_restore():
+    """Verify loopback address changes are reflected in prefix NLRI export."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Testing loopback address unset/restore on r1")
+
+    rr = tgen.gears["rr"]
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Verify baseline - loopback prefix should be present
+    logger.info("Step 1: Verifying baseline loopback prefix 10.1.1.1/32 from r1")
+
+    def check_loopback_prefix_present():
+        output = rr.vtysh_cmd("show bgp link-state link-state json")
+        data = json.loads(output)
+
+        # Find loopback prefix 10.1.1.1/32 from r1
+        loopback_prefix = count_prefix_nlris(data, "1.1.1.1", prefix="10.1.1.1/32")
+
+        # Store count for error reporting
+        check_loopback_prefix_present.last_count = len(loopback_prefix)
+
+        if len(loopback_prefix) == 1:
+            return True
+        return False
+
+    test_func = functools.partial(check_loopback_prefix_present)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"Loopback prefix 10.1.1.1/32 not present in baseline check. "
+        f"Expected: 1 prefix. Found: {check_loopback_prefix_present.last_count} prefixes"
+    )
+
+    # Step 2: Remove IP address from loopback
+    logger.info("Step 2: Removing IP address from loopback interface on r1")
+    r1.run("ip addr del 10.1.1.1/32 dev lo")
+
+    # Step 3: Verify loopback prefix NLRI is withdrawn
+    logger.info("Step 3: Verifying loopback prefix NLRI is withdrawn from rr")
+
+    def check_loopback_prefix_withdrawn():
+        output = rr.vtysh_cmd("show bgp link-state link-state json")
+        data = json.loads(output)
+
+        # Find loopback prefix 10.1.1.1/32 from r1
+        loopback_prefix = count_prefix_nlris(data, "1.1.1.1", prefix="10.1.1.1/32")
+
+        # Store count for error reporting
+        check_loopback_prefix_withdrawn.last_count = len(loopback_prefix)
+
+        if len(loopback_prefix) == 0:
+            return True
+        return False
+
+    test_func = functools.partial(check_loopback_prefix_withdrawn)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"Loopback prefix not withdrawn after address removal. "
+        f"Expected: 0 prefixes. Found: {check_loopback_prefix_withdrawn.last_count} prefixes still present"
+    )
+
+    # Step 4: Restore IP address on loopback
+    logger.info("Step 4: Restoring IP address on loopback interface on r1")
+    r1.run("ip addr add 10.1.1.1/32 dev lo")
+
+    # Step 5: Verify loopback prefix NLRI is re-advertised
+    logger.info("Step 5: Verifying loopback prefix NLRI is re-advertised to rr")
+
+    test_func = functools.partial(check_loopback_prefix_present)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"Loopback prefix not re-advertised after address restoration. "
+        f"Expected: 1 prefix. Found: {check_loopback_prefix_present.last_count} prefixes"
+    )
+
+    # Final check: Verify output matches expected baseline
+    logger.info("Final verification: Comparing output with expected baseline")
+    expected_file = os.path.join(CWD, "rr/expected_bgp_ls.json")
+    expected = json.load(open(expected_file))
+
+    test_func = functools.partial(
+        bgp_ls_router_json_cmp,
+        rr,
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assertmsg = 'BGP-LS NLRIs do not match expected baseline output after router-id reset'
+    assert result is None, assertmsg
+
+    logger.info("Loopback address unset/restore test completed successfully")
+
+
+def test_link_down_restore():
+    """Verify interface shutdown/restore updates the r1-r2 link NLRI."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Testing link down/restore between r1 and r2")
+
+    rr = tgen.gears["rr"]
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Verify baseline - link from r1 to r2 should be present
+    logger.info("Step 1: Verifying baseline link NLRI from r1 to r2")
+
+    def check_r1_r2_link_present():
+        output = rr.vtysh_cmd("show bgp link-state link-state json")
+        data = json.loads(output)
+
+        # Find link from r1 to r2
+        r1_r2_link = count_link_nlris(data, "1.1.1.1", "2.2.2.2")
+
+        # Store count for error reporting
+        check_r1_r2_link_present.last_count = len(r1_r2_link)
+
+        if len(r1_r2_link) == 1:
+            return True
+        return False
+
+    test_func = functools.partial(check_r1_r2_link_present)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"r1-r2 link NLRI not present in baseline check (link down test). "
+        f"Expected: 1 link. Found: {check_r1_r2_link_present.last_count} links"
+    )
+
+    # Step 2: Shut down interface r1-eth1
+    logger.info("Step 2: Shutting down interface r1-eth1 on r1")
+    r1.vtysh_cmd("""
+        configure terminal
+        interface r1-eth1
+        shutdown
+    """)
+
+    # Step 3: Verify link NLRI is withdrawn
+    logger.info("Step 3: Verifying r1-r2 link NLRI is withdrawn from rr")
+
+    def check_r1_r2_link_withdrawn():
+        output = rr.vtysh_cmd("show bgp link-state link-state json")
+        data = json.loads(output)
+
+        # Find link from r1 to r2
+        r1_r2_link = count_link_nlris(data, "1.1.1.1", "2.2.2.2")
+
+        # Store count for error reporting
+        check_r1_r2_link_withdrawn.last_count = len(r1_r2_link)
+
+        if len(r1_r2_link) == 1:
+            return True
+        return False
+
+    test_func = functools.partial(check_r1_r2_link_withdrawn)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"r1-r2 link NLRI not withdrawn after interface shutdown. "
+        f"Expected: 1 links. Found: {check_r1_r2_link_withdrawn.last_count} links still present"
+    )
+
+    # Step 4: Bring up interface r1-eth1
+    logger.info("Step 4: Bringing up interface r1-eth1 on r1")
+    r1.vtysh_cmd("""
+        configure terminal
+        interface r1-eth1
+         no shutdown
+    """)
+
+    # Step 5: Verify link NLRI is re-advertised
+    logger.info("Step 5: Verifying r1-r2 link NLRI is re-advertised to rr")
+
+    test_func = functools.partial(check_r1_r2_link_present)
+    success, _ = topotest.run_and_expect(test_func, True, count=60, wait=1)
+    assert success, (
+        f"r1-r2 link NLRI not re-advertised after interface restoration. "
+        f"Expected: 1 link. Found: {check_r1_r2_link_present.last_count} links"
+    )
+
+    # Final check: Verify output matches expected baseline
+    logger.info("Final verification: Comparing output with expected baseline")
+    expected_file = os.path.join(CWD, "rr/expected_bgp_ls.json")
+    expected = json.load(open(expected_file))
+
+    test_func = functools.partial(
+        bgp_ls_router_json_cmp,
+        rr,
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assertmsg = 'BGP-LS NLRIs do not match expected baseline output after router-id reset'
+    assert result is None, assertmsg
+
+    logger.info("Link down/restore test completed successfully")
+
+
+def test_static_route_removal_restore():
+    """Verify IPv4 prefix NLRI count drops/restores on static route changes."""
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info("Testing static route removal/restore on r1")
+
+    rr = tgen.gears["rr"]
+    r1 = tgen.gears["r1"]
+
+    # Step 1: Verify baseline - count total ipv4Prefix NLRIs
+    logger.info("Step 1: Counting baseline ipv4Prefix NLRIs")
+
+    def get_ipv4_prefix_count():
+        """Get total count of ipv4Prefix NLRIs"""
+        output = rr.vtysh_cmd("show bgp link-state link-state json")
+        data = json.loads(output)
+
+        # Extract all route objects from the routes dictionary
+        all_routes = []
+        if "routes" in data:
+            for nlri_key, route_list in data["routes"].items():
+                all_routes.extend(route_list)
+
+        # Count all ipv4Prefix NLRIs
+        ipv4_prefixes = [r for r in all_routes if r.get("nlri", {}).get("nlriType") == "ipv4Prefix"]
+        return len(ipv4_prefixes)
+
+    baseline_count = get_ipv4_prefix_count()
+    logger.info(f"Baseline ipv4Prefix count: {baseline_count}")
+
+    # Step 2: Remove static route
+    logger.info("Step 2: Removing static route 192.0.2.0/24 on r1")
+    r1.vtysh_cmd("""
+        configure terminal
+        no ip route 192.0.2.0/24 Null0
+    """)
+
+    # Step 3: Verify ipv4Prefix count drops by 2
+    logger.info("Step 3: Verifying ipv4Prefix count drops by 2")
+
+    def check_prefix_count_decreased():
+        """Verify ipv4Prefix count decreased by 2"""
+        current_count = get_ipv4_prefix_count()
+        expected_count = baseline_count - 2
+
+        # Store counts for error reporting
+        check_prefix_count_decreased.current = current_count
+        check_prefix_count_decreased.expected = expected_count
+
+        if current_count == expected_count:
+            return True
+        return False
+
+    test_func = functools.partial(check_prefix_count_decreased)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"ipv4Prefix count did not decrease by 2 after route removal. "
+        f"Baseline: {baseline_count}, Expected: {check_prefix_count_decreased.expected}, "
+        f"Found: {check_prefix_count_decreased.current}"
+    )
+
+    # Step 4: Restore static route
+    logger.info("Step 4: Restoring static route 192.0.2.0/24 on r1")
+    r1.vtysh_cmd("""
+        configure terminal
+        ip route 192.0.2.0/24 Null0
+    """)
+
+    # Step 5: Verify ipv4Prefix count is restored
+    logger.info("Step 5: Verifying ipv4Prefix count is restored")
+
+    def check_prefix_count_restored():
+        """Verify ipv4Prefix count is restored to baseline"""
+        current_count = get_ipv4_prefix_count()
+
+        # Store counts for error reporting
+        check_prefix_count_restored.current = current_count
+        check_prefix_count_restored.expected = baseline_count
+
+        if current_count == baseline_count:
+            return True
+        return False
+
+    test_func = functools.partial(check_prefix_count_restored)
+    success, _ = topotest.run_and_expect(test_func, True, count=30, wait=1)
+    assert success, (
+        f"ipv4Prefix count not restored after route re-addition. "
+        f"Expected: {check_prefix_count_restored.expected}, "
+        f"Found: {check_prefix_count_restored.current}"
+    )
+
+    # Final check: Verify output matches expected baseline
+    logger.info("Final verification: Comparing output with expected baseline")
+    expected_file = os.path.join(CWD, "rr/expected_bgp_ls.json")
+    expected = json.load(open(expected_file))
+
+    test_func = functools.partial(
+        bgp_ls_router_json_cmp,
+        rr,
+        expected,
+    )
+    _, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assertmsg = 'BGP-LS NLRIs do not match expected baseline output after router-id reset'
+    assert result is None, assertmsg
+
+    logger.info("Static route removal/restore test completed successfully")
+
+
+if __name__ == "__main__":
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
This PR extends BGP-LS (BGP Link State) to support BGP-only fabric topologies, as described in [draft-ietf-idr-bgp-ls-bgp-only-fabric-04](https://www.ietf.org/archive/id/draft-ietf-idr-bgp-ls-bgp-only-fabric-04.html).
 
BGP-LS provides a standardized way for external systems, such as controllers or network management platforms, to collect topology information from a network.
While BGP-LS was originally designed to advertise link-state and traffic engineering information learned via IGP protocols (like OSPF or IS-IS), many large-scale data center and fabric networks now deploy BGP as a hop-by-hop routing protocol between directly connected nodes, using EBGP sessions over individual links.
In these BGP-only topologies, detailed visibility into the network’s nodes, links, and prefixes is not available through traditional IGP-based mechanisms.

This update enables BGP-LS to collect and advertise topology information in BGP-only fabrics, where routing is provided exclusively by BGP with no IGP present.

