### PR TITLE
babeld: fix NULL pointer dereference in babel_clean_routing_process

### DIFF
--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -303,12 +303,17 @@ void babel_clean_routing_process(void)
 	resend_delay = BABEL_DEFAULT_RESEND_DELAY;
 	change_smoothing_half_life(BABEL_DEFAULT_SMOOTHING_HALF_LIFE);
 
+	/* Check if babel_routing_process is initialized before accessing it */
+	if (!babel_routing_process)
+		return;
+
 	/* cancel events */
 	event_cancel(&babel_routing_process->t_read);
 	event_cancel(&babel_routing_process->t_update);
 
 	distribute_list_delete(&babel_routing_process->distribute_ctx);
 	XFREE(MTYPE_BABEL, babel_routing_process);
+	babel_routing_process = NULL;
 }
 
 /* Function used with timeout. */


### PR DESCRIPTION
When babeld receives an exit signal (SIGINT/SIGTERM) during shutdown or when `babel_routing_process` is NULL (never initialized or already freed), the program crashes with SIGSEGV due to a NULL pointer dereference in `babel_clean_routing_process()`. The function accesses `babel_routing_process->t_read` and `babel_routing_process->t_update` without checking if `babel_routing_process` is NULL first.

This can occur when:
1. The program receives an exit signal before `babel_routing_process` is fully initialized
2. `babel_routing_process` initialization fails but the cleanup function is still called
3. The cleanup function is called multiple times

```
#0  __pthread_kill_implementation (no_tid=0, signo=11, threadid=140251119745472)
    at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=11, threadid=140251119745472)
    at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140251119745472, signo=signo@entry=11)
    at ./nptl/pthread_kill.c:89
#3  0x00007f8ec27a0476 in __GI_raise (sig=sig@entry=11)
    at ../sysdeps/posix/raise.c:26
#4  0x00007f8ec2b23836 in core_handler (signo=11, siginfo=0x7ffd37d9db70,
    context=<optimized out>) at lib/sigevent.c:268
#5  <signal handler called>
#6  0x00007f8ec2b3ebdd in event_cancel (thread=0x8) at lib/event.c:1456
#7  0x000063ee3c9e7a3e in babel_clean_routing_process ()
    at babeld/babeld.c:320
#8  0x000063ee3c9e4636 in babel_exit_properly () at babeld/babel_main.c:306
#9  babel_sigexit () at babeld/babel_main.c:92
#10 0x00007f8ec2b23cca in frr_sigevent_process () at lib/sigevent.c:117
#11 0x00007f8ec2b3f93d in event_fetch (m=m@entry=0x63ee60c108a0,
    fetch=fetch@entry=0x7ffd37d9e9b0) at lib/event.c:1742
#12 0x00007f8ec2ab85d3 in frr_run (loop=0x63ee60c108a0) at lib/libfrr.c:1249
#13 0x000063ee3c9de8bb in main (argc=12, argv=0x7ffd37d9ec08)
    at babeld/babel_main.c:205
```