### PR TITLE
Fix ospf checksum #20706

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -173,6 +173,9 @@ uint16_t ospf_lsa_checksum(struct lsa_header *lsa)
 
 int ospf_lsa_checksum_valid(struct lsa_header *lsa)
 {
+	if (lsa->checksum == 0)
+		return 0; /* cannot be 0, discard */
+
 	uint8_t *buffer = &lsa->options;
 	int options_offset = buffer - (uint8_t *)&lsa->ls_age; /* should be 2 */
 


### PR DESCRIPTION
The Issue: Currently, ospf_lsa_checksum_valid does not explicitly reject LSAs where the checksum field is 0x0000. In OSPF, the checksum calculation is mandatory and the value zero is reserved to indicate a checksum failure. Because Fletcher-16 uses ones-complement arithmetic, 0x0000 and 0xFFFF are mathematically equivalent, which could allow corrupted LSAs to bypass validation if the checksum field is tampered with or corrupted to 0x0000.

The Fix: Added a guard clause in ospf_lsa_checksum_valid to immediately return 0 (invalid) if lsa->checksum == 0.

Fix  #20706 