### PR TITLE
bgpd: EVPN MH fix unimport ES route on vtep change

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -84,6 +84,21 @@
 
 #include "bgpd/bgp_route_clippy.c"
 
+static bool bgp_attr_nexthop_same(const struct attr *attr1, const struct attr *attr2, afi_t afi)
+{
+	afi_t nh_afi1 = BGP_ATTR_NH_AFI(afi, attr1);
+	afi_t nh_afi2 = BGP_ATTR_NH_AFI(afi, attr2);
+
+	/* v4<->v6 transition: treat as different */
+	if (nh_afi1 != nh_afi2)
+		return false;
+
+	if (nh_afi1 == AFI_IP6)
+		return IPV6_ADDR_SAME(&attr1->mp_nexthop_global, &attr2->mp_nexthop_global);
+
+	return IPV4_ADDR_SAME(&attr1->nexthop, &attr2->nexthop);
+}
+
 DEFINE_MTYPE_STATIC(BGPD, BGP_EOIU_MARKER_INFO, "BGP EOIU Marker info");
 DEFINE_MTYPE_STATIC(BGPD, BGP_METAQ, "BGP MetaQ");
 /* Memory for batched clearing of peers from the RIB */
@@ -6149,8 +6164,8 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 		}
 
 		/* Special handling for EVPN update of an existing route. If the
-		 * extended community attribute has changed, we need to
-		 * un-import
+		 * extended community or nexthop attribute has changed, we need
+		 * to un-import
 		 * the route using its existing extended community. It will be
 		 * subsequently processed for import with the new extended
 		 * community.
@@ -6160,6 +6175,7 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 			if (bgp_attr_exists(pi->attr, BGP_ATTR_EXT_COMMUNITIES) &&
 			    bgp_attr_exists(attr_new, BGP_ATTR_EXT_COMMUNITIES)) {
 				int cmp;
+				struct prefix_evpn *evp = (struct prefix_evpn *)p;
 
 				cmp = ecommunity_cmp(
 					bgp_attr_get_ecommunity(pi->attr),
@@ -6184,6 +6200,12 @@ void bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 							bgp, afi, safi, p, pi);
 					else /* SAFI_MPLS_VPN */
 						vpn_leak_to_vrf_withdraw(pi);
+				}
+				/* evpn update with new nexthop: unimport route with old VTEP entry.*/
+				else if (safi == SAFI_EVPN &&
+					 evp->prefix.route_type == BGP_EVPN_AD_ROUTE &&
+					 !bgp_attr_nexthop_same(pi->attr, attr_new, afi)) {
+					bgp_evpn_unimport_route(bgp, afi, safi, p, pi);
 				}
 			}
 		}

--- a/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
+++ b/tests/topotests/bgp_evpn_mh/test_evpn_mh.py
@@ -777,6 +777,115 @@ def test_evpn_df():
     # tgen.mininet_cli()
 
 
+def check_remote_es_vtep_present(dut, esi, vtep_ip):
+    """
+    Return None if vtep_ip is found in the ES VTEP list, else error string.
+    """
+    bgp_es = dut.vtysh_cmd(f"show bgp l2vp evpn es {esi} json")
+    es = json.loads(bgp_es)
+
+    if not es:
+        return f"esi {esi} not found"
+
+    vtep_ips = []
+    for vtep in es.get("vteps", []):
+        vtep_ips.append(vtep["vtep_ip"])
+
+    if vtep_ip in vtep_ips:
+        return None
+
+    return f"vtep {vtep_ip} not in ES {esi} vteps {vtep_ips}"
+
+
+def check_remote_es_vtep_absent(dut, esi, vtep_ip):
+    """
+    Return None if vtep_ip is NOT in the ES VTEP list, else error string.
+    """
+    bgp_es = dut.vtysh_cmd(f"show bgp l2vp evpn es {esi} json")
+    es = json.loads(bgp_es)
+
+    if not es:
+        # ES gone entirely means vtep is absent
+        return None
+
+    vtep_ips = []
+    for vtep in es.get("vteps", []):
+        vtep_ips.append(vtep["vtep_ip"])
+
+    if vtep_ip not in vtep_ips:
+        return None
+
+    return f"stale vtep {vtep_ip} still in ES {esi} vteps {vtep_ips}"
+
+
+def test_evpn_vtep_change():
+    """
+    Test that changing the originator VTEP IP on a remote TOR removes the
+    stale VTEP from ES tables on the receiver.
+
+    torm21 has two loopback addresses: 192.168.100.17 (primary) and
+    192.168.100.117 (secondary). The VTEP is switched from primary to
+    secondary and back to verify stale VTEP cleanup.
+
+    1. Add secondary loopback on torm21.
+    2. Verify initial ES VTEP list is correct on torm11.
+    3. Switch VTEP from primary to secondary.
+    4. Verify new VTEP appears and old VTEP is removed.
+    5. Switch VTEP back to primary and verify convergence.
+    """
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    dut = tgen.gears["torm11"]
+    remote_tor = tgen.gears["torm21"]
+    esi = host_es_map.get("hostd21")
+    primary_vtep = "192.168.100.17"
+    secondary_vtep = "192.168.100.117"
+
+    # 1. Add secondary loopback address on torm21
+    remote_tor.run(f"ip addr add {secondary_vtep}/32 dev lo")
+
+    # 2. Verify primary VTEP is present initially
+    test_fn = partial(check_remote_es_vtep_present, dut, esi, primary_vtep)
+    _, result = topotest.run_and_expect(test_fn, None, count=20, wait=3)
+    assertmsg = f"torm11: primary VTEP {primary_vtep} not found in ES {esi} initially"
+    assert result is None, assertmsg
+
+    # 3. Switch VTEP from primary to secondary (vxlan local IP change
+    #    triggers zebra to update ES originator IP and BGP re-advertises)
+    remote_tor.run(f"ip link set dev vx-1000 type vxlan local {secondary_vtep}")
+
+    # 4. Verify new VTEP appears and old VTEP is removed
+    test_fn = partial(check_remote_es_vtep_present, dut, esi, secondary_vtep)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
+    assertmsg = f"torm11: secondary VTEP {secondary_vtep} not found in ES {esi} after switch"
+    assert result is None, assertmsg
+
+    test_fn = partial(check_remote_es_vtep_absent, dut, esi, primary_vtep)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
+    assertmsg = f"torm11: stale VTEP {primary_vtep} still in ES {esi} after switch"
+    assert result is None, assertmsg
+
+    # 5. Switch VTEP back to primary
+    remote_tor.run(f"ip link set dev vx-1000 type vxlan local {primary_vtep}")
+
+    # Verify restored
+    test_fn = partial(check_remote_es_vtep_present, dut, esi, primary_vtep)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
+    assertmsg = f"torm11: primary VTEP {primary_vtep} not restored in ES {esi}"
+    assert result is None, assertmsg
+
+    test_fn = partial(check_remote_es_vtep_absent, dut, esi, secondary_vtep)
+    _, result = topotest.run_and_expect(test_fn, None, count=30, wait=3)
+    assertmsg = f"torm11: stale VTEP {secondary_vtep} still in ES {esi} after restore"
+    assert result is None, assertmsg
+
+    # Cleanup: remove secondary loopback
+    remote_tor.run(f"ip addr del {secondary_vtep}/32 dev lo")
+
+
 def check_protodown_rc(dut, protodown_rc):
     """
     check if specified protodown reason code is set


### PR DESCRIPTION
In EVPN MH deployment, when a VTEP-IP address changed at the sender VTEP, the remote VTEP sees a stale VTEP-IP entry in ES to VTEP-IP mapping.

RCA:
Handling for nexthop change for evpn es (Type-1) route is missing on receiver side.

On changing the VTEP IP on local node, the EAD (Type-1) route's BGP update contains new originator VTEP-IP as nexthop. The new BGP update message treated as update to existing path and the ES route import simply goes with adding with the new VTEP-IP,
hence the stale ES EVI/VTEP (old VTEP) references are seen.

Fix:
At the receiving VTEP, detect the nexthop change during processing of EVPN ES (Type-1) BGP Update.
Unimport the prior Type-1 route entry before processing of the new nexthop pased bgp update. The unimport/import ensures the proper clean up of old VTEP-IP in ES to VTEP-IP list.

Test:
Before Fix:
----------
On local node vtep is changed from 27.0.0.103 to 27.0.0.3 Remote node shows 27.0.0.103 stale vtep

```
torm-21# show evpn es
Type: B bypass, L local, R remote, N non-DF
ESI                            Type ES-IF                 VTEPs
03:44:38:39:ff:ff:01:00:00:01  R    -                     27.0.0.3,27.0.0.4,27.0.0.5,27.0.0.103
```

Afer fix:
--------
The old VTEP IP is no longer present as stale entry  on remote VTEP

```
root@torm-21:mgmt:/var/home/cumulus# vtysh -c "show evpn es"
Type: B bypass, L local, R remote, N non-DF
ESI                            Type ES-IF                 VTEPs
03:44:38:39:ff:ff:01:00:00:01  R    -                     27.0.0.3,27.0.0.4,27.0.0.5
```