### PR TITLE
lib: Fix link state memory corruption on te lsa deletion

### DIFF
--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -969,7 +969,8 @@ void ls_subnet_del(struct ls_ted *ted, struct ls_subnet *subnet)
 		return;
 
 	/* First, disconnect Subnet from associated Vertex */
-	listnode_delete(subnet->vertex->prefixes, subnet);
+	if (subnet->vertex && subnet->vertex->prefixes)
+		listnode_delete(subnet->vertex->prefixes, subnet);
 	/* Then delete Subnet */
 	subnets_del(&ted->subnets, subnet);
 	XFREE(MTYPE_LS_DB, subnet);

--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -982,11 +982,7 @@ void ls_subnet_del_all(struct ls_ted *ted, struct ls_subnet *subnet)
 		return;
 
 	/* First, remove associated Link State Subnet */
-	if (subnet->ls_pref) {
-		ls_prefix_del(subnet->ls_pref);
-		/* Set to NULL after deletion to prevent double free */
-		subnet->ls_pref = NULL;
-	}
+	ls_prefix_del(subnet->ls_pref);
 	/* Then, delete Subnet itself */
 	ls_subnet_del(ted, subnet);
 }

--- a/lib/link_state.c
+++ b/lib/link_state.c
@@ -981,7 +981,11 @@ void ls_subnet_del_all(struct ls_ted *ted, struct ls_subnet *subnet)
 		return;
 
 	/* First, remove associated Link State Subnet */
-	ls_prefix_del(subnet->ls_pref);
+	if (subnet->ls_pref) {
+		ls_prefix_del(subnet->ls_pref);
+		/* Set to NULL after deletion to prevent double free */
+		subnet->ls_pref = NULL;
+	}
 	/* Then, delete Subnet itself */
 	ls_subnet_del(ted, subnet);
 }

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -1799,6 +1799,8 @@ static void ospf_te_update_subnet(struct ls_ted *ted, struct ls_vertex *vertex,
 	if (subnet) {
 		/* Re-attach the subnet to the vertex if necessary */
 		if (subnet->vertex != vertex) {
+			/* First, remove from old vertex's prefixes list */
+			listnode_delete(subnet->vertex->prefixes, subnet);
 			subnet->vertex = vertex;
 			listnode_add_sort_nodup(vertex->prefixes, subnet);
 		}


### PR DESCRIPTION
Fixes https://github.com/FRRouting/frr/issues/20722
When OSPF Traffic Engineering (TE) is enabled and TE Router LSAs are deleted, ospfd can crash with SIGSEGV or SIGABRT due to memory corruption or invalid pointer access in the Link State Database cleanup code. The crashes occur in lib/link_state.c when deleting Link State vertices, subnets, and prefixes during TE LSA deletion. This patch addresses the issue by adding NULL checks for related pointers.