### PR TITLE
lib: use MTYPEs for northbound in several places

### DIFF
--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -22,6 +22,8 @@
 #include "northbound_db.h"
 #include "lib/northbound_cli_clippy.c"
 
+DEFINE_MTYPE(LIB, NB_CMDS, "NB vty commands");
+
 struct debug nb_dbg_cbs_config = { 0, "debug northbound callbacks configuration",
 				   "Northbound callbacks: configuration" };
 struct debug nb_dbg_cbs_state = { 0, "debug northbound callbacks state",
@@ -84,7 +86,7 @@ static void nb_cli_pending_commit_clear(struct vty *vty)
 {
 	vty->pending_commit = 0;
 	vty->buffer_cmd_count = 0;
-	XFREE(MTYPE_TMP, vty->pending_cmds_buf);
+	XFREE(MTYPE_NB_CMDS, vty->pending_cmds_buf);
 	vty->pending_cmds_buflen = 0;
 	vty->pending_cmds_bufpos = 0;
 }
@@ -113,14 +115,14 @@ static int nb_cli_schedule_command(struct vty *vty)
 	if (!vty->pending_cmds_buf) {
 		vty->pending_cmds_buflen = 4096;
 		vty->pending_cmds_buf =
-			XCALLOC(MTYPE_TMP, vty->pending_cmds_buflen);
+			XCALLOC(MTYPE_NB_CMDS, vty->pending_cmds_buflen);
 	}
 
 	if ((strlen(vty->buf) + 3)
 	    > (vty->pending_cmds_buflen - vty->pending_cmds_bufpos)) {
 		vty->pending_cmds_buflen *= 2;
 		vty->pending_cmds_buf =
-			XREALLOC(MTYPE_TMP, vty->pending_cmds_buf,
+			XREALLOC(MTYPE_NB_CMDS, vty->pending_cmds_buf,
 				 vty->pending_cmds_buflen);
 	}
 	strlcat(vty->pending_cmds_buf, "- ", vty->pending_cmds_buflen);

--- a/lib/northbound_cli.h
+++ b/lib/northbound_cli.h
@@ -23,6 +23,9 @@ enum nb_cfg_format {
 /* Maximum config commands in a batch*/
 #define NB_CMD_BATCH_SIZE 5000
 
+/* Mem type for nb vty buffer */
+DECLARE_MTYPE(NB_CMDS);
+
 extern struct nb_config *vty_shared_candidate_config;
 
 /*

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2488,7 +2488,7 @@ void vty_close(struct vty *vty)
 	if (vty->fd == STDIN_FILENO)
 		was_stdio = true;
 
-	XFREE(MTYPE_TMP, vty->pending_cmds_buf);
+	XFREE(MTYPE_NB_CMDS, vty->pending_cmds_buf);
 	XFREE(MTYPE_VTY, vty->buf);
 
 	if (vty->error) {


### PR DESCRIPTION
Stop using MTYPE_TMP in several places; use NB-specific MTYPEs for visibility.
