### PR TITLE
bgpd: fix md5 password unset on dynamic nbr

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2879,10 +2879,8 @@ int peer_delete(struct peer *peer)
 	/* Password configuration */
 	if (CHECK_FLAG(peer->flags, PEER_FLAG_PASSWORD)) {
 		XFREE(MTYPE_PEER_PASSWORD, peer->password);
-		if (!accept_peer &&
-		    !BGP_CONNECTION_SU_UNSPEC(peer->connection) &&
-		    !CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP) &&
-		    !CHECK_FLAG(peer->flags, PEER_FLAG_DYNAMIC_NEIGHBOR))
+		if (!accept_peer && !BGP_CONNECTION_SU_UNSPEC(peer->connection) &&
+		    !CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
 			bgp_md5_unset(peer->connection);
 	}
 


### PR DESCRIPTION
When a password is applied on peer-group associated to dynamic neighbor listen range.

```
1) Per peer (/32)  MD5 entry is set on the listen socket for each group member
     /* Attempt to install password on socket. */
     if (!BGP_CONNECTION_SU_UNSPEC(member->connection) &&
         bgp_md5_set(member->connection) < 0)
         ret = BGP_ERR_TCPSIG_FAILED;
2) Per dynamic listen range prefix (/24) MD5 entry on the listen socket.

    for (ALL_LIST_ELEMENTS_RO(peer->group->listen_range[AFI_IP], ln, lr))
        bgp_md5_set_prefix(peer->bgp, lr, password);
    for (ALL_LIST_ELEMENTS_RO(peer->group->listen_range[AFI_IP6], ln, lr))
        bgp_md5_set_prefix(peer->bgp, lr, password);
```

When no neighbor <pg> password is applied to the peer‑group, the configuration correctly removes the prefix‑range (/24) MD5 entry, but the stale per‑peer (/32) entry remains. Because the kernel always prefers the more specific (/32) rule, the affected peer’s TCP SYN packets (sent without MD5) are silently dropped.

The fix is to ensure that the peer‑delete path also removes the dynamic neighbor’s per‑peer MD5 entry, allowing the cleanup to complete correctly.


Signed-off-by: Chirag Shah <chirag@nvidia.com>
