### PR TITLE
zebra: Add a new infra to have NHG to RE mapping

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -85,6 +85,9 @@ struct route_entry {
 	/* Link list. */
 	struct re_list_item next;
 
+	/* Back pointer to route node */
+	struct route_node *rn;
+
 	/* Nexthop group, shared/refcounted, based on the nexthop(s)
 	 * provided by the owner of the route
 	 */

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -172,7 +172,40 @@ struct route_entry {
 	time_t uptime;
 
 	struct re_opaque *opaque;
+
+	/* Selected re using an nhe are in its re RB tree */
+	struct nhe_re_tree_item re_item;
 };
+
+static int route_entry_cmp(const struct route_entry *re1, const struct route_entry *re2)
+{
+	/* Compare VRF first - most likely to be different */
+	if (re1->vrf_id < re2->vrf_id)
+		return -1;
+	if (re1->vrf_id > re2->vrf_id)
+		return 1;
+
+	/* Compare protocol type - next most likely differentiator */
+	if (re1->type < re2->type)
+		return -1;
+	if (re1->type > re2->type)
+		return 1;
+
+	/* Compare instance */
+	if (re1->instance < re2->instance)
+		return -1;
+	if (re1->instance > re2->instance)
+		return 1;
+
+	if (re1 > re2)
+		return 1;
+	else if (re1 < re2)
+		return -1;
+
+	return 0;
+}
+
+DECLARE_RBTREE_UNIQ(nhe_re_tree, struct route_entry, re_item, route_entry_cmp);
 
 #define RIB_SYSTEM_ROUTE(R) RSYSTEM_ROUTE((R)->type)
 
@@ -626,6 +659,9 @@ extern uint32_t zebra_rib_dplane_results_count(void);
 extern pid_t zebra_pid;
 
 extern uint32_t rt_table_main_id;
+
+extern void nhe_add_or_del_re_tree(struct nhg_hash_entry *nhe, struct route_entry *re_to_oper,
+				   const char *caller, bool is_del);
 
 void route_entry_dump_nh(const struct route_entry *re, const char *straddr,
 			 const struct vrf *re_vrf,

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -401,6 +401,10 @@ struct nhg_hash_entry *zebra_nhg_alloc(void)
 	struct nhg_hash_entry *nhe;
 
 	nhe = XCALLOC(MTYPE_NHG, sizeof(struct nhg_hash_entry));
+	if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+		zlog_debug("%s Creating the nhe %u (%p) re-tree", __func__, nhe->id, nhe);
+
+	nhe_re_tree_init(&nhe->re_head);
 
 	return nhe;
 }
@@ -1062,6 +1066,41 @@ static struct nhg_ctx *nhg_ctx_init(uint32_t id, struct nexthop *nh, struct nh_g
 	return ctx;
 }
 
+/* Unset all the re's INSTALLED flag which uses the nhe */
+static void zebra_nhg_unset_installed_for_routes(struct nhg_hash_entry *nhe, const char *caller)
+{
+	struct route_entry *re = NULL;
+	struct route_entry *re_dep = NULL;
+	struct nhg_connected *rb_node_dep = NULL;
+
+	frr_each (nhe_re_tree, &nhe->re_head, re) {
+		if (CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED)) {
+			if (IS_ZEBRA_DEBUG_NHG_DETAIL && re->rn)
+				zlog_debug("Caller %s: Unsetting INSTALLED flag for route %p (%pFX) using NHG %p (%pNG)",
+					   caller, re, &re->rn->p, nhe, nhe);
+
+			UNSET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
+		}
+	}
+
+	frr_each (nhg_connected_tree, &nhe->nhg_dependents, rb_node_dep) {
+		/* Only unset INSTALLED flag if the dependent NHG is invalid */
+		if (!CHECK_FLAG(rb_node_dep->nhe->flags, NEXTHOP_GROUP_VALID)) {
+			frr_each (nhe_re_tree, &rb_node_dep->nhe->re_head, re_dep) {
+				if (CHECK_FLAG(re_dep->status, ROUTE_ENTRY_INSTALLED)) {
+					if (IS_ZEBRA_DEBUG_NHG_DETAIL && re_dep->rn)
+						zlog_debug("Caller %s: Unsetting INSTALLED flag for route %p (%pFX) using Dependent NHG %p (%pNG) of %p (%pNG)",
+							   caller, re_dep, &re_dep->rn->p,
+							   rb_node_dep->nhe, rb_node_dep->nhe, nhe,
+							   nhe);
+
+					UNSET_FLAG(re_dep->status, ROUTE_ENTRY_INSTALLED);
+				}
+			}
+		}
+	}
+}
+
 static void zebra_nhg_set_valid(struct nhg_hash_entry *nhe, bool valid)
 {
 	struct nhg_connected *rb_node_dep;
@@ -1075,8 +1114,11 @@ static void zebra_nhg_set_valid(struct nhg_hash_entry *nhe, bool valid)
 		/* If we're in shutdown, this interface event needs to clean
 		 * up installed NHGs, so don't clear that flag directly.
 		 */
-		if (!zebra_router_in_shutdown())
+		if (!zebra_router_in_shutdown()) {
 			UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
+			/* Handles route re-install for quick interface flaps */
+			zebra_nhg_unset_installed_for_routes(nhe, __func__);
+		}
 	}
 
 	/* Update validity of nexthops depending on it */
@@ -1226,6 +1268,9 @@ static void zebra_nhg_handle_kernel_state_change(struct nhg_hash_entry *nhe,
 			EC_ZEBRA_NHG_SYNC,
 			"Kernel %s a nexthop group with ID (%pNG) that we are still using for a route, sending it back down",
 			(is_delete ? "deleted" : "updated"), nhe);
+
+		/* Handles route re-install for ip nexthop del <id>/flush */
+		zebra_nhg_unset_installed_for_routes(nhe, __func__);
 
 		UNSET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
 		zebra_nhg_install_kernel(nhe, ZEBRA_ROUTE_MAX);
@@ -1716,6 +1761,12 @@ void zebra_nhg_free(struct nhg_hash_entry *nhe)
 	if (nhe->id)
 		frrtrace(1, frr_zebra, zebra_nhg_free_nhe_refcount, nhe);
 
+	/*
+	 * Since the nhe->re_tree is in line with the refcount, all the re entries
+	 * should have been deleted at this point in time.
+	 */
+	assert(!nhe_re_tree_count(&nhe->re_head));
+	nhe_re_tree_fini(&nhe->re_head);
 	zebra_nhg_free_members(nhe);
 
 	XFREE(MTYPE_NHG, nhe);
@@ -3535,6 +3586,25 @@ void zebra_nhg_uninstall_kernel(struct nhg_hash_entry *nhe)
 	zebra_nhg_handle_uninstall(nhe);
 }
 
+/* Helper function to handle route installation for all routes in an NHE */
+static void zebra_nhg_install_route_entries(struct nhg_hash_entry *nhe)
+{
+	struct route_entry *re = NULL;
+
+	frr_each (nhe_re_tree, &nhe->re_head, re) {
+		if (CHECK_FLAG(re->flags, ZEBRA_FLAG_SELECTED) &&
+		    !CHECK_FLAG(re->status, ROUTE_ENTRY_QUEUED) &&
+		    !CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED)) {
+			if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+				zlog_debug("%s Route re-install for re %p (%pRN, %s) flags 0x%x on nhe %p (%pNG) flags 0x%x",
+					   __func__, re, re->rn, zebra_route_string(re->type),
+					   re->flags, nhe, nhe, nhe->flags);
+
+			rib_install_kernel(re->rn, re, NULL);
+		}
+	}
+}
+
 void zebra_nhg_dplane_result(struct zebra_dplane_ctx *ctx)
 {
 	enum dplane_op_e op;
@@ -3579,6 +3649,41 @@ void zebra_nhg_dplane_result(struct zebra_dplane_ctx *ctx)
 		case ZEBRA_DPLANE_REQUEST_SUCCESS:
 			SET_FLAG(nhe->flags, NEXTHOP_GROUP_INSTALLED);
 			zebra_nhg_handle_install(nhe, true);
+
+			/*
+			 * In cases such as quick Interface flaps/kernel nexthop related
+			 * triggers (ip nexthop flush/ip nexthop del id <>), reinstall all
+			 * the routes which the nhe has at this moment.
+			 * The remainder new routes will anyway be successful since the NHG
+			 * is now installed.
+			 */
+			zebra_nhg_install_route_entries(nhe);
+			/*
+			 * Also handle route entries for recursive NHE dependents as well
+			 * that are not installed. For Ex:
+			 *    Routing entry for 3.3.3.1/32
+			 *       Nexthop Group ID: 114
+			 *       Installed Nexthop Group ID: 115
+			 *
+			 * In the above case, all re's of interest point to 114 but 115 is
+			 * what gets installed in kernel. So upon NH flush, 115 gets
+			 * reinstalled which has no re's.
+			 * So we need to walk the re's of recursive NHE dependents as well.
+			 */
+			struct nhg_connected *rb_node_dep = NULL;
+
+			frr_each (nhg_connected_tree, &nhe->nhg_dependents, rb_node_dep) {
+				struct nhg_hash_entry *dep_nhe = rb_node_dep->nhe;
+
+				if (CHECK_FLAG(dep_nhe->flags, NEXTHOP_GROUP_RECURSIVE)) {
+					if (IS_ZEBRA_DEBUG_NHG_DETAIL)
+						zlog_debug("%s Route re-install for nhe's %p (%pNG) flags 0x%x recursive NHE dependent %p (%pNG) flags 0x%x",
+							   __func__, nhe, nhe, nhe->flags, dep_nhe,
+							   dep_nhe, dep_nhe->flags);
+
+					zebra_nhg_install_route_entries(dep_nhe);
+				}
+			}
 
 			/* If daemon nhg, send it an update */
 			if (PROTO_OWNED(nhe))

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -26,6 +26,7 @@ struct nh_grp {
 };
 
 PREDECL_RBTREE_UNIQ(nhg_connected_tree);
+PREDECL_RBTREE_UNIQ(nhe_re_tree);
 
 /*
  * Hashtables containing nhg entries is in `zebra_router`.
@@ -173,6 +174,8 @@ struct nhg_hash_entry {
 #define NEXTHOP_GROUP_INITIAL_DELAY_INSTALL (1 << 9)
 
 #define NEXTHOP_GROUP_RECEIVED_FROM_EXTERNAL (1 << 10)
+	/* Head of rb_tree of route_entries(re's)*/
+	struct nhe_re_tree_head re_head;
 };
 
 /* Upper 4 bits of the NHG are reserved for indicating the NHG type */

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3875,6 +3875,7 @@ static void rib_link(struct route_node *rn, struct route_entry *re)
 			rnode_debug(rn, re->vrf_id, "rn %p adding dest", rn);
 	}
 
+	re->rn = rn;
 	re_list_add_head(&dest->routes, re);
 
 	afi = (rn->p.family == AF_INET)
@@ -3929,6 +3930,7 @@ void rib_unlink(struct route_node *rn, struct route_entry *re)
 
 	dest = rib_dest_from_rnode(rn);
 
+	re->rn = NULL;
 	re_list_del(&dest->routes, re);
 
 	if (dest->selected_fib == re)
@@ -4239,6 +4241,7 @@ struct route_entry *zebra_rib_route_entry_new(vrf_id_t vrf_id, int type,
 	re->uptime = monotime(NULL);
 	re->tag = tag;
 	re->nhe_id = nhe_id;
+	re->rn = NULL;
 
 	return re;
 }

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -481,6 +481,10 @@ int route_entry_update_nhe(struct route_entry *re,
 
 	if (new_nhghe == NULL) {
 		old_nhg = re->nhe;
+		if (old_nhg) {
+			/* Delete the re from the old nhe->re_head first */
+			nhe_add_or_del_re_tree(old_nhg, re, __func__, true);
+		}
 
 		re->nhe_id = 0;
 		re->nhe_installed_id = 0;
@@ -491,11 +495,19 @@ int route_entry_update_nhe(struct route_entry *re,
 	if ((re->nhe_id != 0) && re->nhe && (re->nhe != new_nhghe)) {
 		/* Capture previous nhg, if any */
 		old_nhg = re->nhe;
+		if (old_nhg) {
+			/* Delete the re from the old nhe->re_head first */
+			nhe_add_or_del_re_tree(old_nhg, re, __func__, true);
+		}
 
 		route_entry_attach_ref(re, new_nhghe);
-	} else if (!re->nhe)
+		/* Add the re to the new nhe->re_head */
+		nhe_add_or_del_re_tree(new_nhghe, re, __func__, false);
+	} else if (!re->nhe) {
 		/* This is the first time it's being attached */
 		route_entry_attach_ref(re, new_nhghe);
+		nhe_add_or_del_re_tree(new_nhghe, re, __func__, false);
+	}
 
 done:
 	/* Detach / deref previous nhg */
@@ -1838,6 +1850,49 @@ done:
 	return rn;
 }
 
+
+/* Add or Deletes a re to the nhe->re_tree head */
+void nhe_add_or_del_re_tree(struct nhg_hash_entry *nhe, struct route_entry *re, const char *caller,
+			    bool is_del)
+{
+	uint32_t b_count = 0, a_count = 0;
+	struct route_entry *re_found = NULL;
+
+	b_count = nhe_re_tree_count(&nhe->re_head);
+	if (is_del) {
+		if (b_count && nhe->re_head.rr.rbt_root) {
+			re_found = nhe_re_tree_find(&nhe->re_head, re);
+			if (re_found) {
+				nhe_re_tree_del(&nhe->re_head, re);
+				a_count = nhe_re_tree_count(&nhe->re_head);
+				if (IS_ZEBRA_DEBUG_RIB_DETAILED)
+					zlog_debug("%s: Deleted re %p (%pRN %s) from nhe %p (%pNG) called from %s count %u->%u rbt_root %p",
+						   __func__, re, re->rn,
+						   zebra_route_string(re->type), nhe, nhe, caller,
+						   b_count, a_count, nhe->re_head.rr.rbt_root);
+
+				if (!nhe_re_tree_count(&nhe->re_head)) {
+					if (IS_ZEBRA_DEBUG_RIB_DETAILED)
+						zlog_debug("%s: Initializing the nhe %p re_tree head, rbt_root %p",
+							   __func__, nhe, nhe->re_head.rr.rbt_root);
+
+					nhe_re_tree_init(&nhe->re_head);
+				}
+			} else if (IS_ZEBRA_DEBUG_RIB_DETAILED) {
+				zlog_debug("%s: Skip delete for re %p (%pRN %s) from nhe %p (%pNG) called from %s - entry not found in tree",
+					   __func__, re, re->rn, zebra_route_string(re->type), nhe,
+					   nhe, caller);
+			}
+		}
+	} else {
+		nhe_re_tree_add(&nhe->re_head, re);
+		a_count = nhe_re_tree_count(&nhe->re_head);
+		if (IS_ZEBRA_DEBUG_RIB_DETAILED)
+			zlog_debug("%s Added re %p (%pRN %s) for nhe %p (%pNG) called from %s count %u->%u rbt_root %p",
+				   __func__, re, re->rn, zebra_route_string(re->type), nhe, nhe,
+				   caller, b_count, a_count, nhe->re_head.rr.rbt_root);
+	}
+}
 
 /*
  * Route-update results processing after async dataplane update.
@@ -3925,18 +3980,18 @@ void rib_unlink(struct route_node *rn, struct route_entry *re)
 	assert(rn && re);
 
 	if (IS_ZEBRA_DEBUG_RIB)
-		rnode_debug(rn, re->vrf_id, "rn %p, re %p", (void *)rn,
-			    (void *)re);
+		rnode_debug(rn, re->vrf_id, "%s: rn %p, re %p nhe %p", __func__, (void *)rn,
+			    (void *)re, re->nhe);
 
 	dest = rib_dest_from_rnode(rn);
 
-	re->rn = NULL;
 	re_list_del(&dest->routes, re);
 
 	if (dest->selected_fib == re)
 		dest->selected_fib = NULL;
 
 	rib_re_nhg_free(re);
+	re->rn = NULL;
 
 	zebra_rib_route_entry_free(re);
 }

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1557,11 +1557,12 @@ DEFPY (show_interface_nexthop_group,
 
 DEFPY(show_nexthop_group,
       show_nexthop_group_cmd,
-      "show nexthop-group rib <(0-4294967295)$id|[singleton <ip$v4|ipv6$v6>] [<kernel|zebra|bgp|sharp>$type_str] [vrf <NAME$vrf_name|all$vrf_all>]> [json]",
+      "show nexthop-group rib <(0-4294967295)$id [routes$routes]|[singleton <ip$v4|ipv6$v6>] [<kernel|zebra|bgp|sharp>$type_str] [vrf <NAME$vrf_name|all$vrf_all>]> [json]",
       SHOW_STR
       "Show Nexthop Groups\n"
       "RIB information\n"
       "Nexthop Group ID\n"
+      "Show routes using this nexthop group\n"
       "Show Singleton Nexthop-Groups\n"
       IP_STR
       IP6_STR
@@ -1572,18 +1573,97 @@ DEFPY(show_nexthop_group,
       VRF_FULL_CMD_HELP_STR
       JSON_STR)
 {
-
 	struct zebra_vrf *zvrf = NULL;
 	afi_t afi = AFI_UNSPEC;
 	uint8_t type = 0;
 	bool uj = use_json(argc, argv);
 	json_object *json = NULL;
+	struct route_entry *re = NULL;
 
 	if (uj)
 		json = json_object_new_object();
 
-	if (id)
-		return show_nexthop_group_id_cmd_helper(vty, id, json);
+	if (id) {
+		struct nhg_hash_entry *nhe = zebra_nhg_lookup_id(id);
+
+		if (!nhe) {
+			vty_out(vty, "%% Can't find nexthop group %" PRIu64 "\n", id);
+			return CMD_WARNING;
+		}
+
+		if (routes) {
+			if (uj) {
+				json_object *json_routes = json_object_new_array();
+
+				frr_each (nhe_re_tree, &nhe->re_head, re) {
+					json_object *json_route = json_object_new_object();
+					char buf[PREFIX_STRLEN];
+					const char *proto_name;
+					struct rib_table_info *info;
+
+					if (!re->rn)
+						continue;
+
+					info = route_table_get_info(re->rn->table);
+					prefix2str(&re->rn->p, buf, sizeof(buf));
+					proto_name = zebra_route_string(re->type);
+
+					json_object_string_add(json_route, "prefix", buf);
+					json_object_boolean_add(json_route, "installed",
+								CHECK_FLAG(re->status,
+									   ROUTE_ENTRY_INSTALLED));
+					json_object_string_add(json_route, "protocol", proto_name);
+					if (info) {
+						json_object_string_add(json_route, "afi",
+								       afi2str(info->afi));
+						json_object_string_add(json_route, "safi",
+								       safi2str(info->safi));
+					} else {
+						json_object_string_add(json_route, "afi",
+								       "unknown");
+						json_object_string_add(json_route, "safi",
+								       "unknown");
+					}
+					json_object_array_add(json_routes, json_route);
+				}
+
+				json_object_object_add(json, "routes", json_routes);
+				vty_json(vty, json);
+			} else {
+				vty_out(vty, "Routes using nexthop group %" PRIu64 ":\n", id);
+
+				vty_out(vty,
+					"Route Entry                    Status          Protocol    AFI      SAFI\n");
+				vty_out(vty,
+					"------------------------------ --------------- ----------  -------  -------\n");
+
+				frr_each (nhe_re_tree, &nhe->re_head, re) {
+					char buf[PREFIX_STRLEN];
+					const char *proto_name;
+					struct rib_table_info *info;
+
+					if (!re->rn)
+						continue;
+
+					info = route_table_get_info(re->rn->table);
+					prefix2str(&re->rn->p, buf, sizeof(buf));
+					proto_name = zebra_route_string(re->type);
+
+					vty_out(vty, "%-30s %-14s  %-12s  %-7s  %-7s\n", buf,
+						CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED)
+							? "installed"
+							: "not installed",
+						proto_name, info ? afi2str(info->afi) : "unknown",
+						info ? safi2str(info->safi) : "unknown");
+				}
+			}
+
+			return CMD_SUCCESS;
+		}
+
+		show_nexthop_group_id_cmd_helper(vty, id, uj ? json : NULL);
+		return CMD_SUCCESS;
+	}
 
 	if (v4)
 		afi = AFI_IP;


### PR DESCRIPTION
This PR adds a support to have the RE back pointer inside NHE, so that it can be used for below bug fix and the upcoming optimization planned to re-use NHG during local link events.

commit-1: add a back ptr from re to rn
commit-2: add RE back ptr in NHG and also handle re-installation of routes during kernel NHG action
commit-3: show command to display all the routes which use the given NHG
commit-4: topotest to verify the fix in commit-3 works as expected during NHG events from kernel.

Below is the summary about the issue that is fixed in commit-3 which required the new NHG->RE mapping.

When operations such as the below happens,
- ip nexthop flush
- ip nexthop del id <>
- quick flap of interface

there are cases where the routes are re-installed when the nexthop-group
isnt yet installed. This will lead to route install failures which isnt
re-tried there by out of sync issues between kernel and zebra.

Take ip nexthop flush for example:
Say we have 10 routes using NHG 100 [50,60]. Upon flush, kernel cleans
up all the route + nexthop entries but notifies zebra only about the
nexthop delete event. Sequence of events could be

- Kernel sends 100 NHG delete
- Kernel sends 50 NHG delete
- Kernel sends 60 NHG delete

When we receive NHG 100 delete, zebra immediately sees "Oh! routes still
point to it, let me reinstall NHG 100" but then kernel doesnt know about
the NHG 50 and 60 yet (so NHG 100 installation fails as expected)..
Only after the NHG's 50 and 60 are installed, the NHG 100 is installed
successfully. But in this timeframe, route installation(new/updated)
fails since NHG 100 was never installed and then it will never be
attempted to re-install.

Fix here is to maintain a rb tree of all the route-entries which uses
a nhe with the head of the tree in the struct nhg_hash_entry.
When the nhe is installed, we walk this tree and reinstall all the re's
which were SELECTED for install at that point in time. Post the NHG install,
the route installation will be successful as anyways.

It also takes care of unsetting the INSTALLED flag in re in case of
events where a NHG is to be reinstalled/going away.

Note: This PR introduces NHG→RE mapping and serves as the baseline for future work
aimed at reusing NHGs during local link flap events.

Also added a new show command

```
r1# sh nexthop-group rib 40 routes
Routes using nexthop group 40:
Route Entry                    Status          Protocol    AFI      SAFI
------------------------------ --------------- ----------  -------  -------
4.5.6.10/32                    installed       static        IPv4     unicast
4.5.6.11/32                    installed       static        IPv4     unicast
4.5.6.15/32                    not installed   static        IPv4     unicast
4.5.6.16/32                    installed       static        IPv4     unicast
4.5.6.17/32                    installed       static        IPv4     unicast
```