### PR TITLE
zebra: Updation of ifp->flags

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -2175,9 +2175,6 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 			frrtrace(8, frr_zebra, if_dplane_ifp_handling_new, name, ifindex, vrf_id,
 				 zif_type, zif_slave_type, master_ifindex, flags, 1);
 
-			/* Update flags - all paths need this */
-			ifp->flags = flags;
-
 			/*
 			 * Interface promiscuity changes trigger spurious routing updates on HBN
 			 * uplink interfaces, causing route flushes and traffic disruption.
@@ -2185,7 +2182,8 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 			 * Check if only promiscuity flag changed (from netlink change mask)
 			 */
 			if (change_flags == IFF_PROMISC) {
-				/* Flags already updated above, skip routing notifications */
+				ifp->flags = flags;
+				/* Flags updated above, skip routing notifications */
 				if (IS_ZEBRA_DEBUG_KERNEL)
 					zlog_debug("%s: PROMISC-only update for %s(%u), no routing notification",
 						   __func__, name, ifp->ifindex);
@@ -2222,6 +2220,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 						       rc_bitfield);
 
 			if (if_is_no_ptm_operative(ifp)) {
+				ifp->flags = flags;
 				bool is_up = if_is_operative(ifp);
 
 				if (!if_is_no_ptm_operative(ifp) ||
@@ -2279,6 +2278,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
 					}
 				}
 			} else {
+				ifp->flags = flags;
 				if (if_is_operative(ifp) &&
 				    !CHECK_FLAG(zif->flags,
 						ZIF_FLAG_PROTODOWN)) {


### PR DESCRIPTION
As a part of PR:20181 , ifp->flags updation is changed. Do not set ifp->flags before the if_is_no_ptm_operative(ifp) check. That check must run on the previous interface state so we take the correct branch; we then set ifp->flags in each branch. Updating flags before the check would branch on the new state and break if_down/if_up transition logic.