### PR TITLE
bgpd: unref routes when yielding during clearing iteration

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7417,7 +7417,7 @@ static int walk_batch_table_helper(struct bgp_clearing_info *cinfo,
 		cinfo->total_counter++;
 
 		/* Save dest's prefix */
-		memcpy(&pfx, &dest->rn->p, sizeof(struct prefix));
+		prefix_copy(&pfx, &dest->rn->p);
 
 		ain = dest->adj_in;
 		while (ain) {
@@ -7457,6 +7457,10 @@ static int walk_batch_table_helper(struct bgp_clearing_info *cinfo,
 			/* Reset the counter */
 			cinfo->curr_counter = 0;
 			set_clearing_resume_info(cinfo, table, &pfx, inner_p);
+
+			/* Unref, since we're breaking the iteration */
+			bgp_dest_unlock_node(dest);
+
 			ret = -1;
 			break;
 		}
@@ -7561,7 +7565,7 @@ static int clear_batch_rib_helper(struct bgp_clearing_info *cinfo)
 							   safi2str(outer_table->safi), pbuf);
 
 					/* Capture last prefix */
-					memcpy(&pfx, &dest->rn->p, sizeof(struct prefix));
+					prefix_copy(&pfx, &dest->rn->p);
 
 					/* This will resume the "inner" walk if necessary */
 					ret = walk_batch_table_helper(cinfo, table, true /*inner*/);
@@ -7572,6 +7576,9 @@ static int clear_batch_rib_helper(struct bgp_clearing_info *cinfo)
 						 */
 						set_clearing_resume_info(cinfo, outer_table, &pfx,
 									 false);
+
+						/* Unref, since we're breaking the iteration */
+						bgp_dest_unlock_node(dest);
 						break;
 					}
 				}


### PR DESCRIPTION
The route-table iteration adds a ref to routes as they're being examined. When the peer-clearing iteration breaks to yield, unref the current route-nodes/dests to match that, so we don't add a ref unnecessarily.
